### PR TITLE
Add gdal_footprint utility

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(
   gdaldem_lib.cpp
   nearblack_lib.cpp
   nearblack_lib_floodfill.cpp
+  gdal_footprint_lib.cpp
   gdalmdiminfo_lib.cpp
   gdalmdimtranslate_lib.cpp)
 add_dependencies(appslib generate_gdal_version_h)
@@ -64,6 +65,7 @@ if (BUILD_APPS)
   add_executable(gdaltransform gdaltransform.cpp)
   add_executable(gdal_create gdal_create.cpp)
   add_executable(gdal_viewshed gdal_viewshed.cpp)
+  add_executable(gdal_footprint commonutils.h gdal_footprint_bin.cpp)
   add_executable(ogrinfo commonutils.h ogrinfo_bin.cpp)
   add_executable(ogr2ogr ogr2ogr_bin.cpp)
 
@@ -100,6 +102,7 @@ if (BUILD_APPS)
       gdalwarp
       gdal_contour
       gdallocationinfo
+      gdal_footprint
       ogrinfo
       ogr2ogr
       gdalmdiminfo

--- a/apps/gdal_footprint_bin.cpp
+++ b/apps/gdal_footprint_bin.cpp
@@ -1,0 +1,233 @@
+/******************************************************************************
+ *
+ * Project:  GDAL Utilities
+ * Purpose:  Computes the footprint of a GDAL raster
+ * Authors:  Even Rouault, <even dot rouault at spatialys dot com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Even Rouault <even dot rouault at spatialys dot com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "cpl_string.h"
+#include "gdal_version.h"
+#include "commonutils.h"
+#include "gdal_utils_priv.h"
+#include "gdal_priv.h"
+#include "ogrsf_frmts.h"
+
+/************************************************************************/
+/*                               Usage()                                */
+/************************************************************************/
+
+static void Usage(const char *pszErrorMsg = nullptr)
+
+{
+    printf("Usage: gdal_footprint [--help-general]\n"
+           "       [-b band]* [-combine_bands union|intersection]\n"
+           "       [-oo NAME=VALUE]* [-ovr <index>]\n"
+           "       [-srcnodata \"value [value...]\"]\n"
+           "       [-t_cs pixel|georef] [-t_srs <srs_def>] [-split_polys]\n"
+           "       [-convex_hull] [-densify <value>] [-simplify <value>]\n"
+           "       [-min_ring_area <value>] [-max_points <value>|unlimited]\n"
+           "       [-of ogr_format] [-lyr_name dst_layername]\n"
+           "       [-dsco name=value]* [-lco name=value]* [-overwrite] [-q]\n"
+           "       <src_filename> <dst_filename>\n");
+
+    if (pszErrorMsg != nullptr)
+        fprintf(stderr, "\nFAILURE: %s\n", pszErrorMsg);
+    exit(1);
+}
+
+/************************************************************************/
+/*                                main()                                */
+/************************************************************************/
+
+MAIN_START(argc, argv)
+{
+    /* Check strict compilation and runtime library version as we use C++ API */
+    if (!GDAL_CHECK_VERSION(argv[0]))
+        exit(1);
+
+    EarlySetConfigOptions(argc, argv);
+
+    /* -------------------------------------------------------------------- */
+    /*      Generic arg processing.                                         */
+    /* -------------------------------------------------------------------- */
+    GDALAllRegister();
+    argc = GDALGeneralCmdLineProcessor(argc, &argv, 0);
+    if (argc < 1)
+        exit(-argc);
+
+    for (int i = 0; i < argc; i++)
+    {
+        if (EQUAL(argv[i], "--utility_version"))
+        {
+            printf("%s was compiled against GDAL %s and "
+                   "is running against GDAL %s\n",
+                   argv[0], GDAL_RELEASE_NAME, GDALVersionInfo("RELEASE_NAME"));
+            CSLDestroy(argv);
+            return 0;
+        }
+        else if (EQUAL(argv[i], "--help"))
+        {
+            Usage();
+        }
+    }
+
+    GDALFootprintOptionsForBinary sOptionsForBinary;
+    // coverity[tainted_data]
+    GDALFootprintOptions *psOptions =
+        GDALFootprintOptionsNew(argv + 1, &sOptionsForBinary);
+    CSLDestroy(argv);
+
+    if (psOptions == nullptr)
+    {
+        Usage();
+    }
+
+    if (!(sOptionsForBinary.bQuiet))
+    {
+        GDALFootprintOptionsSetProgress(psOptions, GDALTermProgress, nullptr);
+    }
+
+    if (sOptionsForBinary.osSource.empty())
+        Usage("No input file specified.");
+
+    if (!sOptionsForBinary.bDestSpecified)
+        Usage("No output file specified.");
+
+    /* -------------------------------------------------------------------- */
+    /*      Open input file.                                                */
+    /* -------------------------------------------------------------------- */
+    GDALDatasetH hInDS = GDALOpenEx(sOptionsForBinary.osSource.c_str(),
+                                    GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR,
+                                    /*papszAllowedDrivers=*/nullptr,
+                                    sOptionsForBinary.aosOpenOptions.List(),
+                                    /*papszSiblingFiles=*/nullptr);
+
+    if (hInDS == nullptr)
+        exit(1);
+
+    /* -------------------------------------------------------------------- */
+    /*      Open output file if it exists.                                  */
+    /* -------------------------------------------------------------------- */
+    GDALDatasetH hDstDS = nullptr;
+    if (!(sOptionsForBinary.bCreateOutput))
+    {
+        CPLPushErrorHandler(CPLQuietErrorHandler);
+        hDstDS =
+            GDALOpenEx(sOptionsForBinary.osDest.c_str(),
+                       GDAL_OF_VECTOR | GDAL_OF_VERBOSE_ERROR | GDAL_OF_UPDATE,
+                       nullptr, nullptr, nullptr);
+        CPLPopErrorHandler();
+    }
+
+    if (!sOptionsForBinary.osFormat.empty() &&
+        (sOptionsForBinary.bCreateOutput || hDstDS == nullptr))
+    {
+        GDALDriverManager *poDM = GetGDALDriverManager();
+        GDALDriver *poDriver =
+            poDM->GetDriverByName(sOptionsForBinary.osFormat.c_str());
+        char **papszDriverMD = (poDriver) ? poDriver->GetMetadata() : nullptr;
+        if (poDriver == nullptr ||
+            !CPLTestBool(CSLFetchNameValueDef(papszDriverMD, GDAL_DCAP_VECTOR,
+                                              "FALSE")) ||
+            !CPLTestBool(
+                CSLFetchNameValueDef(papszDriverMD, GDAL_DCAP_CREATE, "FALSE")))
+        {
+            fprintf(stderr,
+                    "Output driver `%s' not recognised or does not support "
+                    "direct output file creation.\n",
+                    sOptionsForBinary.osFormat.c_str());
+            fprintf(stderr, "The following format drivers are configured and "
+                            "support direct output:\n");
+
+            for (int iDriver = 0; iDriver < poDM->GetDriverCount(); iDriver++)
+            {
+                GDALDriver *poIter = poDM->GetDriver(iDriver);
+                papszDriverMD = poIter->GetMetadata();
+                if (CPLTestBool(CSLFetchNameValueDef(
+                        papszDriverMD, GDAL_DCAP_VECTOR, "FALSE")) &&
+                    CPLTestBool(CSLFetchNameValueDef(
+                        papszDriverMD, GDAL_DCAP_CREATE, "FALSE")))
+                {
+                    fprintf(stderr, "  -> `%s'\n", poIter->GetDescription());
+                }
+            }
+            exit(1);
+        }
+    }
+
+    if (hDstDS && sOptionsForBinary.bOverwrite)
+    {
+        auto poDstDS = GDALDataset::FromHandle(hDstDS);
+        int nLayerCount = poDstDS->GetLayerCount();
+        int iLayerToDelete = -1;
+        for (int i = 0; i < nLayerCount; ++i)
+        {
+            auto poLayer = poDstDS->GetLayer(i);
+            if (poLayer &&
+                poLayer->GetName() == sOptionsForBinary.osDestLayerName)
+            {
+                iLayerToDelete = i;
+                break;
+            }
+        }
+        bool bDeleteOK = false;
+        if (iLayerToDelete >= 0 && poDstDS->TestCapability(ODsCDeleteLayer))
+        {
+            bDeleteOK = poDstDS->DeleteLayer(iLayerToDelete) == OGRERR_NONE;
+        }
+        if (!bDeleteOK && nLayerCount == 1)
+        {
+            GDALClose(hDstDS);
+            hDstDS = nullptr;
+            CPLPushErrorHandler(CPLQuietErrorHandler);
+            GDALDeleteDataset(nullptr, sOptionsForBinary.osDest.c_str());
+            CPLPopErrorHandler();
+            VSIUnlink(sOptionsForBinary.osDest.c_str());
+        }
+    }
+    else if (sOptionsForBinary.bOverwrite)
+    {
+        CPLPushErrorHandler(CPLQuietErrorHandler);
+        GDALDeleteDataset(nullptr, sOptionsForBinary.osDest.c_str());
+        CPLPopErrorHandler();
+        VSIUnlink(sOptionsForBinary.osDest.c_str());
+    }
+
+    int bUsageError = FALSE;
+    GDALDatasetH hRetDS = GDALFootprint(sOptionsForBinary.osDest.c_str(),
+                                        hDstDS, hInDS, psOptions, &bUsageError);
+    if (bUsageError == TRUE)
+        Usage();
+    int nRetCode = hRetDS ? 0 : 1;
+
+    GDALClose(hInDS);
+    if (GDALClose(hRetDS) != CE_None)
+        nRetCode = 1;
+    GDALFootprintOptionsFree(psOptions);
+
+    GDALDestroyDriverManager();
+
+    return nRetCode;
+}
+MAIN_END

--- a/apps/gdal_footprint_lib.cpp
+++ b/apps/gdal_footprint_lib.cpp
@@ -1,0 +1,1453 @@
+/******************************************************************************
+ *
+ * Project:  GDAL Utilities
+ * Purpose:  Footprint OGR shapes into a GDAL raster.
+ * Authors:  Even Rouault, <even dot rouault at spatialys dot com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Even Rouault <even dot rouault at spatialys dot com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "cpl_port.h"
+#include "gdal_utils.h"
+#include "gdal_utils_priv.h"
+
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <algorithm>
+#include <limits>
+#include <vector>
+
+#include "commonutils.h"
+#include "cpl_conv.h"
+#include "cpl_error.h"
+#include "cpl_progress.h"
+#include "cpl_string.h"
+#include "gdal.h"
+#include "gdal_alg.h"
+#include "gdal_priv.h"
+#include "ogr_api.h"
+#include "ogr_core.h"
+#include "ogr_mem.h"
+#include "ogrsf_frmts.h"
+#include "ogr_spatialref.h"
+
+constexpr const char *DEFAULT_LAYER_NAME = "footprint";
+
+/************************************************************************/
+/*                          GDALFootprintOptions                        */
+/************************************************************************/
+
+struct GDALFootprintOptions
+{
+    /*! output format. Use the short format name. */
+    std::string osFormat{};
+
+    /*! the progress function to use */
+    GDALProgressFunc pfnProgress = GDALDummyProgress;
+
+    /*! pointer to the progress data variable */
+    void *pProgressData = nullptr;
+
+    bool bCreateOutput = false;
+
+    std::string osDestLayerName{};
+
+    /*! Layer creation options */
+    CPLStringList aosLCO{};
+
+    /*! Dataset creation options */
+    CPLStringList aosDSCO{};
+
+    /*! Overview index: 0 = first overview level */
+    int nOvrIndex = -1;
+
+    /** Whether output geometry should be in georeferenced coordinates, if
+     * possible (if explicitly requested, bOutCSGeorefRequested is also set)
+     * false = in pixel coordinates
+     */
+    bool bOutCSGeoref = true;
+
+    /** Whether -t_cs georef has been explicitly set */
+    bool bOutCSGeorefRequested = false;
+
+    OGRSpatialReference oOutputSRS{};
+
+    bool bSplitPolys = false;
+
+    double dfDensifyDistance = 0;
+
+    double dfSimplifyTolerance = 0;
+
+    bool bConvexHull = false;
+
+    double dfMinRingArea = 0;
+
+    int nMaxPoints = 100;
+
+    /*! Source bands to take into account */
+    std::vector<int> anBands{};
+
+    /*! Whether to combine bands unioning (true) or intersecting (false) */
+    bool bCombineBandsUnion = true;
+
+    std::string osSrcNoData;
+};
+
+/************************************************************************/
+/*                       GDALFootprintMaskBand                          */
+/************************************************************************/
+
+class GDALFootprintMaskBand final : public GDALRasterBand
+{
+    GDALRasterBand *m_poSrcBand = nullptr;
+
+  public:
+    explicit GDALFootprintMaskBand(GDALRasterBand *poSrcBand)
+        : m_poSrcBand(poSrcBand)
+    {
+        nRasterXSize = m_poSrcBand->GetXSize();
+        nRasterYSize = m_poSrcBand->GetYSize();
+        eDataType = GDT_Byte;
+        m_poSrcBand->GetBlockSize(&nBlockXSize, &nBlockYSize);
+    }
+
+  protected:
+    CPLErr IReadBlock(int nBlockXOff, int nBlockYOff, void *pData) override
+    {
+        int nWindowXSize;
+        int nWindowYSize;
+        m_poSrcBand->GetActualBlockSize(nBlockXOff, nBlockYOff, &nWindowXSize,
+                                        &nWindowYSize);
+        GDALRasterIOExtraArg sExtraArg;
+        INIT_RASTERIO_EXTRA_ARG(sExtraArg);
+        return IRasterIO(GF_Read, nBlockXOff * nBlockXSize,
+                         nBlockYOff * nBlockYSize, nWindowXSize, nWindowYSize,
+                         pData, nWindowXSize, nWindowYSize, GDT_Byte, 1,
+                         nBlockXSize, &sExtraArg);
+    }
+
+    CPLErr IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff, int nXSize,
+                     int nYSize, void *pData, int nBufXSize, int nBufYSize,
+                     GDALDataType eBufType, GSpacing nPixelSpace,
+                     GSpacing nLineSpace,
+                     GDALRasterIOExtraArg *psExtraArg) override
+    {
+        if (eRWFlag == GF_Read && nXSize == nBufXSize && nYSize == nBufYSize &&
+            eBufType == GDT_Byte && nPixelSpace == 1)
+        {
+            // Request when band seen as the mask band for GDALPolygonize()
+
+            if (m_poSrcBand->RasterIO(GF_Read, nXOff, nYOff, nXSize, nYSize,
+                                      pData, nBufXSize, nBufYSize, eBufType,
+                                      nPixelSpace, nLineSpace,
+                                      psExtraArg) != CE_None)
+            {
+                return CE_Failure;
+            }
+            GByte *pabyData = static_cast<GByte *>(pData);
+            for (int iY = 0; iY < nYSize; ++iY)
+            {
+                for (int iX = 0; iX < nXSize; ++iX)
+                {
+                    if (pabyData[iX])
+                        pabyData[iX] = 1;
+                }
+                pabyData += nLineSpace;
+            }
+
+            return CE_None;
+        }
+
+        if (eRWFlag == GF_Read && nXSize == nBufXSize && nYSize == nBufYSize &&
+            eBufType == GDT_Int64 &&
+            nPixelSpace == static_cast<int>(sizeof(int64_t)) &&
+            (nLineSpace % nPixelSpace) == 0)
+        {
+            // Request when band seen as the value band for GDALPolygonize()
+
+            if (m_poSrcBand->RasterIO(GF_Read, nXOff, nYOff, nXSize, nYSize,
+                                      pData, nBufXSize, nBufYSize, eBufType,
+                                      nPixelSpace, nLineSpace,
+                                      psExtraArg) != CE_None)
+            {
+                return CE_Failure;
+            }
+            int64_t *panData = static_cast<int64_t *>(pData);
+            for (int iY = 0; iY < nYSize; ++iY)
+            {
+                for (int iX = 0; iX < nXSize; ++iX)
+                {
+                    if (panData[iX])
+                        panData[iX] = 1;
+                }
+                panData += (nLineSpace / nPixelSpace);
+            }
+
+            return CE_None;
+        }
+
+        return GDALRasterBand::IRasterIO(eRWFlag, nXOff, nYOff, nXSize, nYSize,
+                                         pData, nBufXSize, nBufYSize, eBufType,
+                                         nPixelSpace, nLineSpace, psExtraArg);
+    }
+};
+
+/************************************************************************/
+/*                   GDALFootprintCombinedMaskBand                      */
+/************************************************************************/
+
+class GDALFootprintCombinedMaskBand final : public GDALRasterBand
+{
+    std::vector<GDALRasterBand *> m_apoSrcBands{};
+
+    /** Whether to combine bands unioning (true) or intersecting (false) */
+    bool m_bUnion = false;
+
+  public:
+    explicit GDALFootprintCombinedMaskBand(
+        const std::vector<GDALRasterBand *> &apoSrcBands, bool bUnion)
+        : m_apoSrcBands(apoSrcBands), m_bUnion(bUnion)
+    {
+        nRasterXSize = m_apoSrcBands[0]->GetXSize();
+        nRasterYSize = m_apoSrcBands[0]->GetYSize();
+        eDataType = GDT_Byte;
+        m_apoSrcBands[0]->GetBlockSize(&nBlockXSize, &nBlockYSize);
+    }
+
+  protected:
+    CPLErr IReadBlock(int nBlockXOff, int nBlockYOff, void *pData) override
+    {
+        int nWindowXSize;
+        int nWindowYSize;
+        m_apoSrcBands[0]->GetActualBlockSize(nBlockXOff, nBlockYOff,
+                                             &nWindowXSize, &nWindowYSize);
+        GDALRasterIOExtraArg sExtraArg;
+        INIT_RASTERIO_EXTRA_ARG(sExtraArg);
+        return IRasterIO(GF_Read, nBlockXOff * nBlockXSize,
+                         nBlockYOff * nBlockYSize, nWindowXSize, nWindowYSize,
+                         pData, nWindowXSize, nWindowYSize, GDT_Byte, 1,
+                         nBlockXSize, &sExtraArg);
+    }
+
+    CPLErr IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff, int nXSize,
+                     int nYSize, void *pData, int nBufXSize, int nBufYSize,
+                     GDALDataType eBufType, GSpacing nPixelSpace,
+                     GSpacing nLineSpace,
+                     GDALRasterIOExtraArg *psExtraArg) override
+    {
+        if (eRWFlag == GF_Read && nXSize == nBufXSize && nYSize == nBufYSize &&
+            eBufType == GDT_Byte && nPixelSpace == 1)
+        {
+            // Request when band seen as the mask band for GDALPolygonize()
+            {
+                GByte *pabyData = static_cast<GByte *>(pData);
+                for (int iY = 0; iY < nYSize; ++iY)
+                {
+                    memset(pabyData, m_bUnion ? 0 : 1, nXSize);
+                    pabyData += nLineSpace;
+                }
+            }
+
+            std::vector<GByte> abyTmp(static_cast<size_t>(nXSize) * nYSize);
+            for (auto poBand : m_apoSrcBands)
+            {
+                if (poBand->RasterIO(GF_Read, nXOff, nYOff, nXSize, nYSize,
+                                     abyTmp.data(), nBufXSize, nBufYSize,
+                                     GDT_Byte, 1, nXSize,
+                                     psExtraArg) != CE_None)
+                {
+                    return CE_Failure;
+                }
+                GByte *pabyData = static_cast<GByte *>(pData);
+                size_t iTmp = 0;
+                for (int iY = 0; iY < nYSize; ++iY)
+                {
+                    if (m_bUnion)
+                    {
+                        for (int iX = 0; iX < nXSize; ++iX, ++iTmp)
+                        {
+                            if (abyTmp[iTmp])
+                                pabyData[iX] = 1;
+                        }
+                    }
+                    else
+                    {
+                        for (int iX = 0; iX < nXSize; ++iX, ++iTmp)
+                        {
+                            if (abyTmp[iTmp] == 0)
+                                pabyData[iX] = 0;
+                        }
+                    }
+                    pabyData += nLineSpace;
+                }
+            }
+
+            return CE_None;
+        }
+
+        if (eRWFlag == GF_Read && nXSize == nBufXSize && nYSize == nBufYSize &&
+            eBufType == GDT_Int64 &&
+            nPixelSpace == static_cast<int>(sizeof(int64_t)) &&
+            (nLineSpace % nPixelSpace) == 0)
+        {
+            // Request when band seen as the value band for GDALPolygonize()
+            {
+                int64_t *panData = static_cast<int64_t *>(pData);
+                for (int iY = 0; iY < nYSize; ++iY)
+                {
+                    if (m_bUnion)
+                    {
+                        memset(panData, 0, nXSize * sizeof(int64_t));
+                    }
+                    else
+                    {
+                        int64_t nOne = 1;
+                        GDALCopyWords(&nOne, GDT_Int64, 0, panData, GDT_Int64,
+                                      sizeof(int64_t), nXSize);
+                    }
+                    panData += (nLineSpace / nPixelSpace);
+                }
+            }
+
+            std::vector<GByte> abyTmp(static_cast<size_t>(nXSize) * nYSize);
+            for (auto poBand : m_apoSrcBands)
+            {
+                if (poBand->RasterIO(GF_Read, nXOff, nYOff, nXSize, nYSize,
+                                     abyTmp.data(), nBufXSize, nBufYSize,
+                                     GDT_Byte, 1, nXSize,
+                                     psExtraArg) != CE_None)
+                {
+                    return CE_Failure;
+                }
+                size_t iTmp = 0;
+                int64_t *panData = static_cast<int64_t *>(pData);
+                for (int iY = 0; iY < nYSize; ++iY)
+                {
+                    if (m_bUnion)
+                    {
+                        for (int iX = 0; iX < nXSize; ++iX, ++iTmp)
+                        {
+                            if (abyTmp[iTmp])
+                                panData[iX] = 1;
+                        }
+                    }
+                    else
+                    {
+                        for (int iX = 0; iX < nXSize; ++iX, ++iTmp)
+                        {
+                            if (abyTmp[iTmp] == 0)
+                                panData[iX] = 0;
+                        }
+                    }
+                    panData += (nLineSpace / nPixelSpace);
+                }
+            }
+            return CE_None;
+        }
+
+        return GDALRasterBand::IRasterIO(eRWFlag, nXOff, nYOff, nXSize, nYSize,
+                                         pData, nBufXSize, nBufYSize, eBufType,
+                                         nPixelSpace, nLineSpace, psExtraArg);
+    }
+};
+
+/************************************************************************/
+/*                    GetOutputLayerAndUpdateDstDS()                    */
+/************************************************************************/
+
+static OGRLayer *
+GetOutputLayerAndUpdateDstDS(const char *pszDest, GDALDatasetH &hDstDS,
+                             GDALDataset *poSrcDS,
+                             const GDALFootprintOptions *psOptions)
+{
+
+    if (pszDest == nullptr)
+        pszDest = GDALGetDescription(hDstDS);
+
+    /* -------------------------------------------------------------------- */
+    /*      Create output dataset if needed                                 */
+    /* -------------------------------------------------------------------- */
+    const bool bCreateOutput = psOptions->bCreateOutput || hDstDS == nullptr;
+
+    GDALDriverH hDriver = nullptr;
+    if (bCreateOutput)
+    {
+        std::string osFormat(psOptions->osFormat);
+        if (osFormat.empty())
+        {
+            std::vector<CPLString> aoDrivers =
+                GetOutputDriversFor(pszDest, GDAL_OF_VECTOR);
+            if (aoDrivers.empty())
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Cannot guess driver for %s", pszDest);
+                return nullptr;
+            }
+            else
+            {
+                if (aoDrivers.size() > 1)
+                {
+                    CPLError(CE_Warning, CPLE_AppDefined,
+                             "Several drivers matching %s extension. Using %s",
+                             CPLGetExtension(pszDest), aoDrivers[0].c_str());
+                }
+                osFormat = aoDrivers[0];
+            }
+        }
+
+        /* ----------------------------------------------------------------- */
+        /*      Find the output driver. */
+        /* ----------------------------------------------------------------- */
+        hDriver = GDALGetDriverByName(osFormat.c_str());
+        char **papszDriverMD =
+            hDriver ? GDALGetMetadata(hDriver, nullptr) : nullptr;
+        if (hDriver == nullptr ||
+            !CPLTestBool(CSLFetchNameValueDef(papszDriverMD, GDAL_DCAP_VECTOR,
+                                              "FALSE")) ||
+            !CPLTestBool(
+                CSLFetchNameValueDef(papszDriverMD, GDAL_DCAP_CREATE, "FALSE")))
+        {
+            CPLError(CE_Failure, CPLE_NotSupported,
+                     "Output driver `%s' not recognised or does not support "
+                     "direct output file creation.",
+                     osFormat.c_str());
+            return nullptr;
+        }
+
+        hDstDS = GDALCreate(hDriver, pszDest, 0, 0, 0, GDT_Unknown,
+                            psOptions->aosDSCO.List());
+        if (!hDstDS)
+        {
+            return nullptr;
+        }
+    }
+
+    /* -------------------------------------------------------------------- */
+    /*      Open or create target layer.                                    */
+    /* -------------------------------------------------------------------- */
+    auto poDstDS = GDALDataset::FromHandle(hDstDS);
+    OGRLayer *poLayer = nullptr;
+    if (!psOptions->osDestLayerName.empty())
+    {
+        poLayer = poDstDS->GetLayerByName(psOptions->osDestLayerName.c_str());
+    }
+    else if (poDstDS->GetLayerCount() == 1 && poDstDS->GetDriver() &&
+             EQUAL(poDstDS->GetDriver()->GetDescription(), "ESRI Shapefile"))
+    {
+        poLayer = poDstDS->GetLayer(0);
+    }
+    else
+    {
+        poLayer = poDstDS->GetLayerByName(DEFAULT_LAYER_NAME);
+    }
+    if (!poLayer)
+    {
+        std::string osDestLayerName = psOptions->osDestLayerName;
+        if (osDestLayerName.empty())
+        {
+            if (poDstDS->GetDriver() &&
+                EQUAL(poDstDS->GetDriver()->GetDescription(), "ESRI Shapefile"))
+            {
+                osDestLayerName = CPLGetBasename(pszDest);
+            }
+            else
+            {
+                osDestLayerName = DEFAULT_LAYER_NAME;
+            }
+        }
+
+        std::unique_ptr<OGRSpatialReference, OGRSpatialReferenceReleaser> poSRS;
+        if (psOptions->bOutCSGeoref)
+        {
+            if (!psOptions->oOutputSRS.IsEmpty())
+            {
+                poSRS.reset(psOptions->oOutputSRS.Clone());
+            }
+            else if (auto poSrcSRS = poSrcDS->GetSpatialRef())
+            {
+                poSRS.reset(poSrcSRS->Clone());
+            }
+        }
+
+        poLayer = poDstDS->CreateLayer(
+            osDestLayerName.c_str(), poSRS.get(),
+            psOptions->bSplitPolys ? wkbPolygon : wkbMultiPolygon,
+            const_cast<char **>(psOptions->aosLCO.List()));
+    }
+
+    return poLayer;
+}
+
+/************************************************************************/
+/*                 GeoTransformCoordinateTransformation                 */
+/************************************************************************/
+
+class GeoTransformCoordinateTransformation final
+    : public OGRCoordinateTransformation
+{
+    const std::array<double, 6> m_gt;
+
+  public:
+    explicit GeoTransformCoordinateTransformation(
+        const std::array<double, 6> &gt)
+        : m_gt(gt)
+    {
+    }
+
+    const OGRSpatialReference *GetSourceCS() const override
+    {
+        return nullptr;
+    }
+
+    const OGRSpatialReference *GetTargetCS() const override
+    {
+        return nullptr;
+    }
+
+    OGRCoordinateTransformation *Clone() const override
+    {
+        return new GeoTransformCoordinateTransformation(m_gt);
+    }
+
+    OGRCoordinateTransformation *GetInverse() const override
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "GeoTransformCoordinateTransformation::GetInverse() not "
+                 "implemented");
+        return nullptr;
+    }
+
+    int Transform(int nCount, double *x, double *y, double * /* z */,
+                  double * /* t */, int *pabSuccess) override
+    {
+        for (int i = 0; i < nCount; ++i)
+        {
+            const double X = m_gt[0] + x[i] * m_gt[1] + y[i] * m_gt[2];
+            const double Y = m_gt[3] + x[i] * m_gt[4] + y[i] * m_gt[5];
+            x[i] = X;
+            y[i] = Y;
+            if (pabSuccess)
+                pabSuccess[i] = TRUE;
+        }
+        return TRUE;
+    }
+};
+
+/************************************************************************/
+/*                             CountPoints()                            */
+/************************************************************************/
+
+static size_t CountPoints(const OGRGeometry *poGeom)
+{
+    if (poGeom->getGeometryType() == wkbMultiPolygon)
+    {
+        size_t n = 0;
+        for (auto *poPoly : poGeom->toMultiPolygon())
+        {
+            n += CountPoints(poPoly);
+        }
+        return n;
+    }
+    else if (poGeom->getGeometryType() == wkbPolygon)
+    {
+        size_t n = 0;
+        for (auto *poRing : poGeom->toPolygon())
+        {
+            n += poRing->getNumPoints() - 1;
+        }
+        return n;
+    }
+    return 0;
+}
+
+/************************************************************************/
+/*                   GetMinDistanceBetweenTwoPoints()                   */
+/************************************************************************/
+
+static double GetMinDistanceBetweenTwoPoints(const OGRGeometry *poGeom)
+{
+    if (poGeom->getGeometryType() == wkbMultiPolygon)
+    {
+        double v = std::numeric_limits<double>::max();
+        for (auto *poPoly : poGeom->toMultiPolygon())
+        {
+            v = std::min(v, GetMinDistanceBetweenTwoPoints(poPoly));
+        }
+        return v;
+    }
+    else if (poGeom->getGeometryType() == wkbPolygon)
+    {
+        double v = std::numeric_limits<double>::max();
+        for (auto *poRing : poGeom->toPolygon())
+        {
+            v = std::min(v, GetMinDistanceBetweenTwoPoints(poRing));
+        }
+        return v;
+    }
+    else if (poGeom->getGeometryType() == wkbLineString)
+    {
+        double v = std::numeric_limits<double>::max();
+        const auto poLS = poGeom->toLineString();
+        const int nNumPoints = poLS->getNumPoints();
+        for (int i = 0; i < nNumPoints - 1; ++i)
+        {
+            const double x1 = poLS->getX(i);
+            const double y1 = poLS->getY(i);
+            const double x2 = poLS->getX(i + 1);
+            const double y2 = poLS->getY(i + 1);
+            const double d = (x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1);
+            if (d > 0)
+                v = std::min(v, d);
+        }
+        return sqrt(v);
+    }
+    return 0;
+}
+
+/************************************************************************/
+/*                       GDALFootprintProcess()                         */
+/************************************************************************/
+
+static bool GDALFootprintProcess(GDALDataset *poSrcDS, OGRLayer *poDstLayer,
+                                 const GDALFootprintOptions *psOptions)
+{
+    std::unique_ptr<OGRCoordinateTransformation> poCT_SRS;
+    const OGRSpatialReference *poDstSRS = poDstLayer->GetSpatialRef();
+    if (!psOptions->oOutputSRS.IsEmpty())
+        poDstSRS = &(psOptions->oOutputSRS);
+    if (poDstSRS)
+    {
+        auto poSrcSRS = poSrcDS->GetSpatialRef();
+        if (!poSrcSRS)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Output layer has CRS, but input is not georeferenced");
+            return false;
+        }
+        poCT_SRS.reset(OGRCreateCoordinateTransformation(poSrcSRS, poDstSRS));
+        if (!poCT_SRS)
+            return false;
+    }
+
+    std::vector<int> anBands = psOptions->anBands;
+    const int nBandCount = poSrcDS->GetRasterCount();
+    if (anBands.empty())
+    {
+        for (int i = 1; i <= nBandCount; ++i)
+            anBands.push_back(i);
+    }
+
+    std::vector<GDALRasterBand *> apoSrcMaskBands;
+    const CPLStringList aosSrcNoData(
+        CSLTokenizeString2(psOptions->osSrcNoData.c_str(), " ", 0));
+    std::vector<double> adfSrcNoData;
+    if (!psOptions->osSrcNoData.empty())
+    {
+        if (aosSrcNoData.size() != 1 &&
+            static_cast<size_t>(aosSrcNoData.size()) != anBands.size())
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Number of values in -srcnodata should be 1 or the number "
+                     "of bands");
+            return false;
+        }
+        for (int i = 0; i < aosSrcNoData.size(); ++i)
+        {
+            adfSrcNoData.emplace_back(CPLAtof(aosSrcNoData[i]));
+        }
+    }
+    bool bGlobalMask = true;
+    std::vector<std::unique_ptr<GDALRasterBand>> apoTmpNoDataMaskBands;
+    for (size_t i = 0; i < anBands.size(); ++i)
+    {
+        const int nBand = anBands[i];
+        if (nBand <= 0 || nBand > nBandCount)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined, "Invalid band number: %d",
+                     nBand);
+            return false;
+        }
+        auto poBand = poSrcDS->GetRasterBand(nBand);
+        if (!adfSrcNoData.empty())
+        {
+            bGlobalMask = false;
+            apoTmpNoDataMaskBands.emplace_back(
+                cpl::make_unique<GDALNoDataMaskBand>(
+                    poBand, adfSrcNoData.size() == 1 ? adfSrcNoData[0]
+                                                     : adfSrcNoData[i]));
+            apoSrcMaskBands.push_back(apoTmpNoDataMaskBands.back().get());
+        }
+        else
+        {
+            GDALRasterBand *poMaskBand;
+            const int nMaskFlags = poBand->GetMaskFlags();
+            if ((nMaskFlags & GMF_ALPHA) != 0)
+            {
+                poMaskBand = poBand;
+            }
+            else
+            {
+                if ((nMaskFlags & GMF_PER_DATASET) != 0)
+                {
+                    bGlobalMask = false;
+                }
+                poMaskBand = poBand->GetMaskBand();
+            }
+            if (psOptions->nOvrIndex >= 0)
+            {
+                if (nMaskFlags == GMF_NODATA)
+                {
+                    // If the mask band is based on nodata, we don't need
+                    // to check the overviews of the mask band, but we
+                    // can take the mask band of the overviews
+                    auto poOvrBand = poBand->GetOverview(psOptions->nOvrIndex);
+                    if (!poOvrBand)
+                    {
+                        if (poBand->GetOverviewCount() == 0)
+                        {
+                            CPLError(
+                                CE_Failure, CPLE_AppDefined,
+                                "Overview index %d invalid for this dataset. "
+                                "Bands of this dataset have no "
+                                "precomputed overviews",
+                                psOptions->nOvrIndex);
+                        }
+                        else
+                        {
+                            CPLError(
+                                CE_Failure, CPLE_AppDefined,
+                                "Overview index %d invalid for this dataset. "
+                                "Value should be in [0,%d] range",
+                                psOptions->nOvrIndex,
+                                poBand->GetOverviewCount() - 1);
+                        }
+                        return false;
+                    }
+                    if (poOvrBand->GetMaskFlags() != GMF_NODATA)
+                    {
+                        CPLError(CE_Failure, CPLE_AppDefined,
+                                 "poOvrBand->GetMaskFlags() != GMF_NODATA");
+                        return false;
+                    }
+                    poMaskBand = poOvrBand->GetMaskBand();
+                }
+                else
+                {
+                    poMaskBand = poMaskBand->GetOverview(psOptions->nOvrIndex);
+                    if (!poMaskBand)
+                    {
+                        if (poBand->GetMaskBand()->GetOverviewCount() == 0)
+                        {
+                            CPLError(
+                                CE_Failure, CPLE_AppDefined,
+                                "Overview index %d invalid for this dataset. "
+                                "Mask bands of this dataset have no "
+                                "precomputed overviews",
+                                psOptions->nOvrIndex);
+                        }
+                        else
+                        {
+                            CPLError(
+                                CE_Failure, CPLE_AppDefined,
+                                "Overview index %d invalid for this dataset. "
+                                "Value should be in [0,%d] range",
+                                psOptions->nOvrIndex,
+                                poBand->GetMaskBand()->GetOverviewCount() - 1);
+                        }
+                        return false;
+                    }
+                }
+            }
+            apoSrcMaskBands.push_back(poMaskBand);
+        }
+    }
+
+    std::unique_ptr<OGRCoordinateTransformation> poCT_GT;
+    std::array<double, 6> adfGeoTransform{{0.0, 1.0, 0.0, 0.0, 0.0, 1.0}};
+    if (psOptions->bOutCSGeoref &&
+        poSrcDS->GetGeoTransform(adfGeoTransform.data()) == CE_None)
+    {
+        auto poMaskBand = apoSrcMaskBands[0];
+        adfGeoTransform[1] *=
+            double(poSrcDS->GetRasterXSize()) / poMaskBand->GetXSize();
+        adfGeoTransform[2] *=
+            double(poSrcDS->GetRasterYSize()) / poMaskBand->GetYSize();
+        adfGeoTransform[4] *=
+            double(poSrcDS->GetRasterXSize()) / poMaskBand->GetXSize();
+        adfGeoTransform[5] *=
+            double(poSrcDS->GetRasterYSize()) / poMaskBand->GetYSize();
+        poCT_GT = cpl::make_unique<GeoTransformCoordinateTransformation>(
+            adfGeoTransform);
+    }
+    else if (psOptions->bOutCSGeorefRequested)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Georeferenced coordinates requested, but "
+                 "input dataset has no geotransform.");
+        return false;
+    }
+    else if (psOptions->nOvrIndex >= 0)
+    {
+        // Transform from overview pixel coordinates to full resolution
+        // pixel coordinates
+        auto poMaskBand = apoSrcMaskBands[0];
+        adfGeoTransform[1] =
+            double(poSrcDS->GetRasterXSize()) / poMaskBand->GetXSize();
+        adfGeoTransform[2] = 0;
+        adfGeoTransform[4] = 0;
+        adfGeoTransform[5] =
+            double(poSrcDS->GetRasterYSize()) / poMaskBand->GetYSize();
+        poCT_GT = cpl::make_unique<GeoTransformCoordinateTransformation>(
+            adfGeoTransform);
+    }
+
+    std::unique_ptr<GDALRasterBand> poMaskForRasterize;
+    if (bGlobalMask || anBands.size() == 1)
+    {
+        poMaskForRasterize =
+            cpl::make_unique<GDALFootprintMaskBand>(apoSrcMaskBands[0]);
+    }
+    else
+    {
+        poMaskForRasterize = cpl::make_unique<GDALFootprintCombinedMaskBand>(
+            apoSrcMaskBands, psOptions->bCombineBandsUnion);
+    }
+
+    auto hBand = GDALRasterBand::ToHandle(poMaskForRasterize.get());
+    auto poMemLayer = cpl::make_unique<OGRMemLayer>("", nullptr, wkbUnknown);
+    const CPLErr eErr =
+        GDALPolygonize(hBand, hBand, OGRLayer::ToHandle(poMemLayer.get()),
+                       /* iPixValField = */ -1,
+                       /* papszOptions = */ nullptr, psOptions->pfnProgress,
+                       psOptions->pProgressData);
+    if (eErr != CE_None)
+    {
+        return false;
+    }
+
+    if (!psOptions->bSplitPolys)
+    {
+        auto poMP = cpl::make_unique<OGRMultiPolygon>();
+        for (auto &&poFeature : poMemLayer.get())
+        {
+            auto poGeom =
+                std::unique_ptr<OGRGeometry>(poFeature->StealGeometry());
+            CPLAssert(poGeom);
+            if (poGeom->getGeometryType() == wkbPolygon)
+            {
+                poMP->addGeometryDirectly(poGeom.release());
+            }
+        }
+        poMemLayer = cpl::make_unique<OGRMemLayer>("", nullptr, wkbUnknown);
+        auto poFeature =
+            cpl::make_unique<OGRFeature>(poMemLayer->GetLayerDefn());
+        poFeature->SetGeometryDirectly(poMP.release());
+        CPL_IGNORE_RET_VAL(poMemLayer->CreateFeature(poFeature.get()));
+    }
+
+    for (auto &&poFeature : poMemLayer.get())
+    {
+        auto poGeom = std::unique_ptr<OGRGeometry>(poFeature->StealGeometry());
+        CPLAssert(poGeom);
+        if (poGeom->IsEmpty())
+            continue;
+
+        auto poDstFeature =
+            cpl::make_unique<OGRFeature>(poDstLayer->GetLayerDefn());
+        poDstFeature->SetFrom(poFeature.get());
+
+        if (poCT_GT)
+        {
+            if (poGeom->transform(poCT_GT.get()) != OGRERR_NONE)
+                return false;
+        }
+
+        if (psOptions->dfDensifyDistance > 0)
+        {
+            OGREnvelope sEnvelope;
+            poGeom->getEnvelope(&sEnvelope);
+            // Some sanity check to avoid insane memory allocations
+            if (sEnvelope.MaxX - sEnvelope.MinX >
+                    1e6 * psOptions->dfDensifyDistance ||
+                sEnvelope.MaxY - sEnvelope.MinY >
+                    1e6 * psOptions->dfDensifyDistance)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Densification distance too small compared to "
+                         "geometry extent");
+                return false;
+            }
+            poGeom->segmentize(psOptions->dfDensifyDistance);
+        }
+
+        if (poCT_SRS)
+        {
+            if (poGeom->transform(poCT_SRS.get()) != OGRERR_NONE)
+                return false;
+        }
+
+        if (psOptions->dfMinRingArea != 0)
+        {
+            if (poGeom->getGeometryType() == wkbMultiPolygon)
+            {
+                auto poMP = cpl::make_unique<OGRMultiPolygon>();
+                for (auto *poPoly : poGeom->toMultiPolygon())
+                {
+                    auto poNewPoly = cpl::make_unique<OGRPolygon>();
+                    for (auto *poRing : poPoly)
+                    {
+                        if (poRing->get_Area() >= psOptions->dfMinRingArea)
+                        {
+                            poNewPoly->addRing(poRing);
+                        }
+                    }
+                    if (!poNewPoly->IsEmpty())
+                        poMP->addGeometryDirectly(poNewPoly.release());
+                }
+                poGeom = std::move(poMP);
+            }
+            else if (poGeom->getGeometryType() == wkbPolygon)
+            {
+                auto poNewPoly = cpl::make_unique<OGRPolygon>();
+                for (auto *poRing : poGeom->toPolygon())
+                {
+                    if (poRing->get_Area() >= psOptions->dfMinRingArea)
+                    {
+                        poNewPoly->addRing(poRing);
+                    }
+                }
+                poGeom = std::move(poNewPoly);
+            }
+            if (poGeom->IsEmpty())
+                continue;
+        }
+
+        if (psOptions->bConvexHull)
+        {
+            poGeom.reset(poGeom->ConvexHull());
+            if (!poGeom || poGeom->IsEmpty())
+                continue;
+        }
+
+        if (psOptions->dfSimplifyTolerance != 0)
+        {
+            poGeom.reset(poGeom->Simplify(psOptions->dfSimplifyTolerance));
+            if (!poGeom || poGeom->IsEmpty())
+                continue;
+        }
+
+        if (psOptions->nMaxPoints > 0 &&
+            CountPoints(poGeom.get()) >
+                static_cast<size_t>(psOptions->nMaxPoints))
+        {
+            OGREnvelope sEnvelope;
+            poGeom->getEnvelope(&sEnvelope);
+            double tolMin = GetMinDistanceBetweenTwoPoints(poGeom.get());
+            double tolMax = std::max(sEnvelope.MaxY - sEnvelope.MinY,
+                                     sEnvelope.MaxX - sEnvelope.MinX);
+            for (int i = 0; i < 20; ++i)
+            {
+                const double tol = (tolMin + tolMax) / 2;
+                std::unique_ptr<OGRGeometry> poSimplifiedGeom(
+                    poGeom->Simplify(tol));
+                if (!poSimplifiedGeom || poSimplifiedGeom->IsEmpty())
+                {
+                    tolMax = tol;
+                    continue;
+                }
+                const auto nPoints = CountPoints(poSimplifiedGeom.get());
+                if (nPoints == static_cast<size_t>(psOptions->nMaxPoints))
+                {
+                    tolMax = tol;
+                    break;
+                }
+                else if (nPoints < static_cast<size_t>(psOptions->nMaxPoints))
+                {
+                    tolMax = tol;
+                }
+                else
+                {
+                    tolMin = tol;
+                }
+            }
+            poGeom.reset(poGeom->Simplify(tolMax));
+            if (!poGeom || poGeom->IsEmpty())
+                continue;
+        }
+
+        if (!psOptions->bSplitPolys && poGeom->getGeometryType() == wkbPolygon)
+            poGeom.reset(
+                OGRGeometryFactory::forceToMultiPolygon(poGeom.release()));
+
+        poDstFeature->SetGeometryDirectly(poGeom.release());
+
+        if (poDstLayer->CreateFeature(poDstFeature.get()) != OGRERR_NONE)
+        {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/************************************************************************/
+/*                             GDALFootprint()                          */
+/************************************************************************/
+
+/* clang-format off */
+/**
+ * Computes the footprint of a raster.
+ *
+ * This is the equivalent of the
+ * <a href="/programs/gdal_footprint.html">gdal_footprint</a> utility.
+ *
+ * GDALFootprintOptions* must be allocated and freed with
+ * GDALFootprintOptionsNew() and GDALFootprintOptionsFree() respectively.
+ * pszDest and hDstDS cannot be used at the same time.
+ *
+ * @param pszDest the vector destination dataset path or NULL.
+ * @param hDstDS the vector destination dataset or NULL.
+ * @param hSrcDataset the raster source dataset handle.
+ * @param psOptionsIn the options struct returned by GDALFootprintOptionsNew()
+ * or NULL.
+ * @param pbUsageError pointer to a integer output variable to store if any
+ * usage error has occurred or NULL.
+ * @return the output dataset (new dataset that must be closed using
+ * GDALClose(), or hDstDS is not NULL) or NULL in case of error.
+ *
+ * @since GDAL 3.8
+ */
+/* clang-format on */
+
+GDALDatasetH GDALFootprint(const char *pszDest, GDALDatasetH hDstDS,
+                           GDALDatasetH hSrcDataset,
+                           const GDALFootprintOptions *psOptionsIn,
+                           int *pbUsageError)
+{
+    if (pszDest == nullptr && hDstDS == nullptr)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "pszDest == NULL && hDstDS == NULL");
+
+        if (pbUsageError)
+            *pbUsageError = TRUE;
+        return nullptr;
+    }
+    if (hSrcDataset == nullptr)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "hSrcDataset== NULL");
+
+        if (pbUsageError)
+            *pbUsageError = TRUE;
+        return nullptr;
+    }
+    if (hDstDS != nullptr && psOptionsIn && psOptionsIn->bCreateOutput)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "hDstDS != NULL but options that imply creating a new dataset "
+                 "have been set.");
+
+        if (pbUsageError)
+            *pbUsageError = TRUE;
+        return nullptr;
+    }
+
+    GDALFootprintOptions *psOptionsToFree = nullptr;
+    const GDALFootprintOptions *psOptions = psOptionsIn;
+    if (psOptions == nullptr)
+    {
+        psOptionsToFree = GDALFootprintOptionsNew(nullptr, nullptr);
+        psOptions = psOptionsToFree;
+    }
+
+    const bool bCloseOutDSOnError = hDstDS == nullptr;
+
+    auto poSrcDS = GDALDataset::FromHandle(hSrcDataset);
+    if (poSrcDS->GetRasterCount() == 0)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Input dataset has no raster band.%s",
+                 poSrcDS->GetMetadata("SUBDATASETS")
+                     ? " You need to specify one subdataset."
+                     : "");
+        GDALFootprintOptionsFree(psOptionsToFree);
+        if (bCloseOutDSOnError)
+            GDALClose(hDstDS);
+        return nullptr;
+    }
+
+    auto poLayer =
+        GetOutputLayerAndUpdateDstDS(pszDest, hDstDS, poSrcDS, psOptions);
+    if (!poLayer)
+    {
+        GDALFootprintOptionsFree(psOptionsToFree);
+        if (hDstDS && bCloseOutDSOnError)
+            GDALClose(hDstDS);
+        return nullptr;
+    }
+
+    if (!GDALFootprintProcess(poSrcDS, poLayer, psOptions))
+    {
+        GDALFootprintOptionsFree(psOptionsToFree);
+        if (bCloseOutDSOnError)
+            GDALClose(hDstDS);
+        return nullptr;
+    }
+
+    GDALFootprintOptionsFree(psOptionsToFree);
+
+    return hDstDS;
+}
+
+/************************************************************************/
+/*                           GDALFootprintOptionsNew()                  */
+/************************************************************************/
+
+/**
+ * Allocates a GDALFootprintOptions struct.
+ *
+ * @param papszArgv NULL terminated list of options (potentially including
+ * filename and open options too), or NULL. The accepted options are the ones of
+ * the <a href="/programs/gdal_rasterize.html">gdal_rasterize</a> utility.
+ * @param psOptionsForBinary (output) may be NULL (and should generally be
+ * NULL), otherwise (gdal_translate_bin.cpp use case) must be allocated with
+ * GDALFootprintOptionsForBinaryNew() prior to this function. Will be filled
+ * with potentially present filename, open options,...
+ * @return pointer to the allocated GDALFootprintOptions struct. Must be freed
+ * with GDALFootprintOptionsFree().
+ *
+ * @since GDAL 3.8
+ */
+
+GDALFootprintOptions *
+GDALFootprintOptionsNew(char **papszArgv,
+                        GDALFootprintOptionsForBinary *psOptionsForBinary)
+{
+    auto psOptions = cpl::make_unique<GDALFootprintOptions>();
+
+    bool bGotSourceFilename = false;
+    bool bGotDestFilename = false;
+    /* -------------------------------------------------------------------- */
+    /*      Handle command line arguments.                                  */
+    /* -------------------------------------------------------------------- */
+    const int argc = CSLCount(papszArgv);
+    for (int i = 0; papszArgv != nullptr && i < argc; i++)
+    {
+        if (i < argc - 1 &&
+            (EQUAL(papszArgv[i], "-of") || EQUAL(papszArgv[i], "-f")))
+        {
+            ++i;
+            psOptions->osFormat = papszArgv[i];
+            psOptions->bCreateOutput = true;
+        }
+
+        else if (EQUAL(papszArgv[i], "-q") || EQUAL(papszArgv[i], "-quiet"))
+        {
+            if (psOptionsForBinary)
+            {
+                psOptionsForBinary->bQuiet = true;
+            }
+            else
+            {
+                CPLError(CE_Failure, CPLE_NotSupported,
+                         "%s switch only supported from gdal_footprint binary.",
+                         papszArgv[i]);
+                return nullptr;
+            }
+        }
+
+        else if (i < argc - 1 && EQUAL(papszArgv[i], "-oo"))
+        {
+            i++;
+            if (psOptionsForBinary)
+            {
+                psOptionsForBinary->aosOpenOptions.AddString(papszArgv[i]);
+            }
+            else
+            {
+                CPLError(
+                    CE_Failure, CPLE_NotSupported,
+                    "-oo switch only supported from gdal_footprint binary.");
+            }
+        }
+
+        else if (i < argc - 1 && EQUAL(papszArgv[i], "-t_cs"))
+        {
+            i++;
+            const std::string osVal(papszArgv[i]);
+            if (osVal == "georef")
+            {
+                psOptions->bOutCSGeoref = true;
+                psOptions->bOutCSGeorefRequested = true;
+            }
+            else if (osVal == "pixel")
+            {
+                psOptions->bOutCSGeoref = false;
+            }
+            else
+            {
+                CPLError(CE_Failure, CPLE_NotSupported,
+                         "Invalid value for -t_cs");
+                return nullptr;
+            }
+        }
+
+        else if (i < argc - 1 && EQUAL(papszArgv[i], "-t_srs"))
+        {
+            i++;
+            const std::string osVal(papszArgv[i]);
+            if (psOptions->oOutputSRS.SetFromUserInput(osVal.c_str()) !=
+                OGRERR_NONE)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Failed to process SRS definition: %s", osVal.c_str());
+                return nullptr;
+            }
+            psOptions->oOutputSRS.SetAxisMappingStrategy(
+                OAMS_TRADITIONAL_GIS_ORDER);
+        }
+
+        else if (i < argc - 1 && EQUAL(papszArgv[i], "-b"))
+        {
+            i++;
+            psOptions->anBands.push_back(atoi(papszArgv[i]));
+        }
+
+        else if (i < argc - 1 && EQUAL(papszArgv[i], "-combine_bands"))
+        {
+            i++;
+            if (EQUAL(papszArgv[i], "union"))
+                psOptions->bCombineBandsUnion = true;
+            else if (EQUAL(papszArgv[i], "intersection"))
+                psOptions->bCombineBandsUnion = false;
+            else
+            {
+                CPLError(CE_Failure, CPLE_NotSupported,
+                         "Invalid value for -combine_bands");
+                return nullptr;
+            }
+        }
+
+        else if (i < argc - 1 && EQUAL(papszArgv[i], "-srcnodata"))
+        {
+            i++;
+            psOptions->osSrcNoData = papszArgv[i];
+        }
+
+        else if (i < argc - 1 && EQUAL(papszArgv[i], "-lco"))
+        {
+            i++;
+            psOptions->aosLCO.AddString(papszArgv[i]);
+        }
+
+        else if (i < argc - 1 && EQUAL(papszArgv[i], "-dsco"))
+        {
+            i++;
+            psOptions->aosDSCO.AddString(papszArgv[i]);
+        }
+
+        else if (i < argc - 1 && EQUAL(papszArgv[i], "-lyr_name"))
+        {
+            i++;
+            psOptions->osDestLayerName = papszArgv[i];
+        }
+
+        else if (EQUAL(papszArgv[i], "-split_polys"))
+        {
+            i++;
+            psOptions->bSplitPolys = true;
+        }
+
+        else if (EQUAL(papszArgv[i], "-convex_hull"))
+        {
+            i++;
+            psOptions->bConvexHull = true;
+        }
+
+        else if (i < argc - 1 && EQUAL(papszArgv[i], "-densify"))
+        {
+            i++;
+            psOptions->dfDensifyDistance = CPLAtof(papszArgv[i]);
+        }
+
+        else if (i < argc - 1 && EQUAL(papszArgv[i], "-simplify"))
+        {
+            i++;
+            psOptions->dfSimplifyTolerance = CPLAtof(papszArgv[i]);
+        }
+
+        else if (i < argc - 1 && EQUAL(papszArgv[i], "-max_points"))
+        {
+            i++;
+            if (EQUAL(papszArgv[i], "unlimited"))
+            {
+                psOptions->nMaxPoints = 0;
+            }
+            else
+            {
+                psOptions->nMaxPoints = atoi(papszArgv[i]);
+                if (psOptions->nMaxPoints > 0 && psOptions->nMaxPoints < 3)
+                {
+                    CPLError(CE_Failure, CPLE_NotSupported,
+                             "Invalid value for -max_points");
+                    return nullptr;
+                }
+            }
+        }
+
+        else if (i < argc - 1 && EQUAL(papszArgv[i], "-min_ring_area"))
+        {
+            i++;
+            psOptions->dfMinRingArea = CPLAtof(papszArgv[i]);
+        }
+
+        else if (EQUAL(papszArgv[i], "-overwrite"))
+        {
+            if (psOptionsForBinary)
+            {
+                psOptionsForBinary->bOverwrite = true;
+            }
+            else
+            {
+                CPLError(CE_Failure, CPLE_NotSupported,
+                         "-overwrite switch only supported from gdal_footprint "
+                         "binary.");
+                return nullptr;
+            }
+        }
+
+        else if (i < argc - 1 && EQUAL(papszArgv[i], "-ovr"))
+        {
+            i++;
+            psOptions->nOvrIndex = atoi(papszArgv[i]);
+        }
+
+        else if (papszArgv[i][0] == '-')
+        {
+            CPLError(CE_Failure, CPLE_NotSupported, "Unknown option name '%s'",
+                     papszArgv[i]);
+            return nullptr;
+        }
+        else if (!bGotSourceFilename)
+        {
+            bGotSourceFilename = true;
+            if (psOptionsForBinary)
+            {
+                psOptionsForBinary->osSource = papszArgv[i];
+            }
+            else
+            {
+                CPLError(CE_Failure, CPLE_NotSupported,
+                         "{source_filename} only supported from gdal_footprint "
+                         "binary.");
+                return nullptr;
+            }
+        }
+        else if (!bGotDestFilename)
+        {
+            bGotDestFilename = true;
+            if (psOptionsForBinary)
+            {
+                psOptionsForBinary->bDestSpecified = true;
+                psOptionsForBinary->osDest = papszArgv[i];
+            }
+            else
+            {
+                CPLError(CE_Failure, CPLE_NotSupported,
+                         "{dest_filename} only supported from gdal_footprint "
+                         "binary.");
+                return nullptr;
+            }
+        }
+        else
+        {
+            CPLError(CE_Failure, CPLE_NotSupported,
+                     "Too many command options '%s'", papszArgv[i]);
+            return nullptr;
+        }
+    }
+
+    if (!psOptions->bOutCSGeoref && !psOptions->oOutputSRS.IsEmpty())
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "-t_cs pixel and -t_srs are mutually exclusive.");
+        return nullptr;
+    }
+
+    if (!psOptions->osSrcNoData.empty() && psOptions->nOvrIndex >= 0)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "-srcnodata and -ovr are mutually exclusive.");
+        return nullptr;
+    }
+
+    if (psOptionsForBinary)
+    {
+        psOptionsForBinary->bCreateOutput = psOptions->bCreateOutput;
+        psOptionsForBinary->osFormat = psOptions->osFormat;
+        psOptionsForBinary->osDestLayerName = psOptions->osDestLayerName;
+    }
+
+    return psOptions.release();
+}
+
+/************************************************************************/
+/*                       GDALFootprintOptionsFree()                     */
+/************************************************************************/
+
+/**
+ * Frees the GDALFootprintOptions struct.
+ *
+ * @param psOptions the options struct for GDALFootprint().
+ *
+ * @since GDAL 3.8
+ */
+
+void GDALFootprintOptionsFree(GDALFootprintOptions *psOptions)
+{
+    delete psOptions;
+}
+
+/************************************************************************/
+/*                  GDALFootprintOptionsSetProgress()                   */
+/************************************************************************/
+
+/**
+ * Set a progress function.
+ *
+ * @param psOptions the options struct for GDALFootprint().
+ * @param pfnProgress the progress callback.
+ * @param pProgressData the user data for the progress callback.
+ *
+ * @since GDAL 3.8
+ */
+
+void GDALFootprintOptionsSetProgress(GDALFootprintOptions *psOptions,
+                                     GDALProgressFunc pfnProgress,
+                                     void *pProgressData)
+{
+    psOptions->pfnProgress = pfnProgress ? pfnProgress : GDALDummyProgress;
+    psOptions->pProgressData = pProgressData;
+}

--- a/apps/gdal_utils.h
+++ b/apps/gdal_utils.h
@@ -211,6 +211,27 @@ GDALDatasetH CPL_DLL GDALRasterize(const char *pszDest, GDALDatasetH hDstDS,
                                    const GDALRasterizeOptions *psOptions,
                                    int *pbUsageError);
 
+/*! Options for GDALFootprint(). Opaque type */
+typedef struct GDALFootprintOptions GDALFootprintOptions;
+
+/** Opaque type */
+typedef struct GDALFootprintOptionsForBinary GDALFootprintOptionsForBinary;
+
+GDALFootprintOptions CPL_DLL *
+GDALFootprintOptionsNew(char **papszArgv,
+                        GDALFootprintOptionsForBinary *psOptionsForBinary);
+
+void CPL_DLL GDALFootprintOptionsFree(GDALFootprintOptions *psOptions);
+
+void CPL_DLL GDALFootprintOptionsSetProgress(GDALFootprintOptions *psOptions,
+                                             GDALProgressFunc pfnProgress,
+                                             void *pProgressData);
+
+GDALDatasetH CPL_DLL GDALFootprint(const char *pszDest, GDALDatasetH hDstDS,
+                                   GDALDatasetH hSrcDS,
+                                   const GDALFootprintOptions *psOptions,
+                                   int *pbUsageError);
+
 /*! Options for GDALBuildVRT(). Opaque type */
 typedef struct GDALBuildVRTOptions GDALBuildVRTOptions;
 

--- a/apps/gdal_utils_priv.h
+++ b/apps/gdal_utils_priv.h
@@ -202,6 +202,22 @@ struct GDALRasterizeOptionsForBinary
     std::string osFormat{};
 };
 
+struct GDALFootprintOptionsForBinary
+{
+    std::string osSource{};
+    bool bDestSpecified = false;
+    std::string osDest{};
+    bool bQuiet = false;
+    CPLStringList aosOpenOptions{};
+    bool bCreateOutput = false;
+    std::string osFormat{};
+
+    /*! whether to overwrite destination layer */
+    bool bOverwrite = false;
+
+    std::string osDestLayerName{};
+};
+
 #endif /* #ifndef DOXYGEN_SKIP */
 
 #endif /* GDAL_UTILS_PRIV_H_INCLUDED */

--- a/autotest/pymod/test_cli_utilities.py
+++ b/autotest/pymod/test_cli_utilities.py
@@ -274,3 +274,11 @@ def get_gnmanalyse_path():
 
 def get_gdal_viewshed_path():
     return get_cli_utility_path("gdal_viewshed")
+
+
+###############################################################################
+#
+
+
+def get_gdal_footprint_path():
+    return get_cli_utility_path("gdal_footprint")

--- a/autotest/utilities/test_gdal_footprint.py
+++ b/autotest/utilities/test_gdal_footprint.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env pytest
+# -*- coding: utf-8 -*-
+###############################################################################
+# $Id$
+#
+# Project:  GDAL/OGR Test Suite
+# Purpose:  gdal_footprint testing
+# Author:   Even Rouault <even dot rouault @ spatialys.com>
+#
+###############################################################################
+# Copyright (c) 2023, Even Rouault <even dot rouault at spatialys.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+###############################################################################
+
+import gdaltest
+import ogrtest
+import pytest
+import test_cli_utilities
+
+from osgeo import gdal, ogr
+
+pytestmark = [
+    pytest.mark.require_geos,
+    pytest.mark.skipif(
+        test_cli_utilities.get_gdal_footprint_path() is None,
+        reason="gdal_footprint not available",
+    ),
+]
+
+
+@pytest.fixture()
+def gdal_footprint_path():
+    return test_cli_utilities.get_gdal_footprint_path()
+
+
+###############################################################################
+
+
+def test_gdal_footprint_basic(gdal_footprint_path):
+
+    if gdal.VSIStatL("tmp/out_footprint.json"):
+        gdal.Unlink("tmp/out_footprint.json")
+
+    (_, err) = gdaltest.runexternal_out_and_err(
+        gdal_footprint_path + " ../gcore/data/byte.tif tmp/out_footprint.json"
+    )
+    assert err is None or err == "", "got error/warning"
+
+    ds = ogr.Open("tmp/out_footprint.json")
+    assert ds is not None
+    lyr = ds.GetLayer(0)
+    assert lyr.GetFeatureCount() == 1
+    f = lyr.GetNextFeature()
+    ogrtest.check_feature_geometry(
+        f,
+        "MULTIPOLYGON (((440720 3751320,440720 3750120,441920 3750120,441920 3751320,440720 3751320)))",
+    )
+
+    ds = None
+
+    gdal.Unlink("tmp/out_footprint.json")
+
+
+###############################################################################
+
+
+def test_gdal_footprint_appending(gdal_footprint_path):
+
+    if gdal.VSIStatL("tmp/out_footprint.shp"):
+        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/out_footprint.shp")
+
+    (_, err) = gdaltest.runexternal_out_and_err(
+        gdal_footprint_path + " ../gcore/data/byte.tif tmp/out_footprint.shp"
+    )
+    assert err is None or err == "", "got error/warning"
+
+    (_, err) = gdaltest.runexternal_out_and_err(
+        gdal_footprint_path + " ../gcore/data/byte.tif tmp/out_footprint.shp"
+    )
+    assert err is None or err == "", "got error/warning"
+
+    ds = ogr.Open("tmp/out_footprint.shp")
+    assert ds is not None
+    lyr = ds.GetLayer(0)
+    assert lyr.GetFeatureCount() == 2
+    f = lyr.GetNextFeature()
+    ogrtest.check_feature_geometry(
+        f,
+        "POLYGON ((440720 3751320,440720 3750120,441920 3750120,441920 3751320,440720 3751320))",
+    )
+    f = lyr.GetNextFeature()
+    ogrtest.check_feature_geometry(
+        f,
+        "POLYGON ((440720 3751320,440720 3750120,441920 3750120,441920 3751320,440720 3751320))",
+    )
+
+    ds = None
+
+    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/out_footprint.shp")
+
+
+###############################################################################
+
+
+def test_gdal_footprint_overwrite(gdal_footprint_path):
+
+    if gdal.VSIStatL("tmp/out_footprint.shp"):
+        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/out_footprint.shp")
+
+    (_, err) = gdaltest.runexternal_out_and_err(
+        gdal_footprint_path + " ../gcore/data/byte.tif tmp/out_footprint.shp"
+    )
+    assert err is None or err == "", "got error/warning"
+
+    (_, err) = gdaltest.runexternal_out_and_err(
+        gdal_footprint_path + " -overwrite ../gcore/data/byte.tif tmp/out_footprint.shp"
+    )
+    assert err is None or err == "", "got error/warning"
+
+    ds = ogr.Open("tmp/out_footprint.shp")
+    assert ds is not None
+    lyr = ds.GetLayer(0)
+    assert lyr.GetFeatureCount() == 1
+    f = lyr.GetNextFeature()
+    ogrtest.check_feature_geometry(
+        f,
+        "POLYGON ((440720 3751320,440720 3750120,441920 3750120,441920 3751320,440720 3751320))",
+    )
+
+    ds = None
+
+    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/out_footprint.shp")
+
+
+###############################################################################
+
+
+def test_gdal_footprint_wrong_input_dataset(gdal_footprint_path):
+
+    (_, err) = gdaltest.runexternal_out_and_err(
+        gdal_footprint_path + " /vsimem/in.tif /vsimem/out.json"
+    )
+    assert "ret code = 1" in err
+
+
+###############################################################################
+
+
+def test_gdal_footprint_wrong_output_dataset(gdal_footprint_path):
+
+    (_, err) = gdaltest.runexternal_out_and_err(
+        gdal_footprint_path + " ../gcore/data/byte.tif /invalid/output/file.json"
+    )
+    assert "ret code = 1" in err

--- a/autotest/utilities/test_gdal_footprint_lib.py
+++ b/autotest/utilities/test_gdal_footprint_lib.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env pytest
+# -*- coding: utf-8 -*-
+###############################################################################
+# $Id$
+#
+# Project:  GDAL/OGR Test Suite
+# Purpose:  gdal_footprint testing
+# Author:   Even Rouault <even dot rouault @ spatialys.com>
+#
+###############################################################################
+# Copyright (c) 2023, Even Rouault <even dot rouault at spatialys.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+###############################################################################
+
+import ogrtest
+import pytest
+
+from osgeo import gdal
+
+pytestmark = pytest.mark.require_geos
+
+
+###############################################################################
+# Simple test
+
+
+def test_gdal_footprint_lib_basic():
+
+    out_ds = gdal.Footprint("", "../gcore/data/byte.tif", format="Memory")
+    assert out_ds is not None
+    lyr = out_ds.GetLayer(0)
+    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "26711"
+    assert lyr.GetFeatureCount() == 1
+    f = lyr.GetNextFeature()
+    ogrtest.check_feature_geometry(
+        f,
+        "MULTIPOLYGON (((440720 3751320,440720 3750120,441920 3750120,441920 3751320,440720 3751320)))",
+    )
+
+
+###############################################################################
+#
+
+
+def test_gdal_footprint_lib_targetCoordinateSystem_pixel():
+
+    out_ds = gdal.Footprint(
+        "", "../gcore/data/byte.tif", format="Memory", targetCoordinateSystem="pixel"
+    )
+    assert out_ds is not None
+    lyr = out_ds.GetLayer(0)
+    assert lyr.GetSpatialRef() is None
+    assert lyr.GetFeatureCount() == 1
+    f = lyr.GetNextFeature()
+    ogrtest.check_feature_geometry(
+        f,
+        "MULTIPOLYGON (((0 0,0 20,20 20,20 0,0 0)))",
+    )
+
+
+###############################################################################
+#
+
+
+def test_gdal_footprint_lib_targetCoordinateSystem_georef():
+
+    out_ds = gdal.Footprint(
+        "", "../gcore/data/byte.tif", format="Memory", targetCoordinateSystem="georef"
+    )
+    assert out_ds is not None
+    lyr = out_ds.GetLayer(0)
+    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "26711"
+    assert lyr.GetFeatureCount() == 1
+    f = lyr.GetNextFeature()
+    ogrtest.check_feature_geometry(
+        f,
+        "MULTIPOLYGON (((440720 3751320,440720 3750120,441920 3750120,441920 3751320,440720 3751320)))",
+    )
+
+
+###############################################################################
+#
+
+
+def test_gdal_footprint_lib_destSRS():
+
+    out_ds = gdal.Footprint(
+        "", "../gcore/data/byte.tif", format="Memory", dstSRS="EPSG:4267"
+    )
+    assert out_ds is not None
+    lyr = out_ds.GetLayer(0)
+    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4267"
+    f = lyr.GetNextFeature()
+    ogrtest.check_feature_geometry(
+        f,
+        "MULTIPOLYGON (((-117.641168620797 33.9023526904272,-117.641087629972 33.8915301685907,-117.628110837847 33.8915970129623,-117.628190189534 33.9024195619211,-117.641168620797 33.9023526904272)))",
+    )
+
+
+###############################################################################
+#
+
+
+def test_gdal_footprint_lib_inline_geojson():
+
+    ret = gdal.Footprint("", "../gcore/data/byte.tif", format="GeoJSON")
+    assert type(ret) == dict
+    assert ret["crs"]["properties"]["name"] == "urn:ogc:def:crs:OGC:1.3:CRS84"
+
+
+###############################################################################
+#
+
+
+def test_gdal_footprint_lib_inline_wkt():
+
+    ret = gdal.Footprint("", "../gcore/data/byte.tif", format="WKT")
+    assert ret.startswith(
+        "MULTIPOLYGON (((440720 3751320,440720 3750120,441920 3750120,441920 3751320,440720 3751320)))"
+    )
+
+
+###############################################################################
+#
+
+
+def test_gdal_footprint_lib_srcNodata():
+
+    out_ds = gdal.Footprint(
+        "",
+        "../gcore/data/byte.tif",
+        format="Memory",
+        targetCoordinateSystem="pixel",
+        srcNodata=74,
+    )
+    assert out_ds is not None
+    lyr = out_ds.GetLayer(0)
+    f = lyr.GetNextFeature()
+    ogrtest.check_feature_geometry(
+        f, "MULTIPOLYGON (((0 0,0 20,20 20,20 0,0 0),(9 17,10 17,10 18,9 18,9 17)))"
+    )
+
+
+###############################################################################
+#
+
+
+def test_gdal_footprint_lib_alpha_band():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 3, 3, 4)
+    src_ds.GetRasterBand(4).SetColorInterpretation(gdal.GCI_AlphaBand)
+    for i in range(4):
+        src_ds.GetRasterBand(i + 1).WriteRaster(1, 1, 1, 1, b"\xFF")
+    out_ds = gdal.Footprint(
+        "",
+        src_ds,
+        format="Memory",
+        targetCoordinateSystem="pixel",
+    )
+    assert out_ds is not None
+    lyr = out_ds.GetLayer(0)
+    f = lyr.GetNextFeature()
+    ogrtest.check_feature_geometry(
+        f,
+        "MULTIPOLYGON (((1 1,1 2,2 2,2 1,1 1)))",
+    )
+
+
+###############################################################################
+#
+
+
+def test_gdal_footprint_lib_splitPolys():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 3, 1, 1)
+    src_ds.GetRasterBand(1).SetNoDataValue(0)
+    src_ds.GetRasterBand(1).WriteRaster(0, 0, 1, 1, b"\xFF")
+    src_ds.GetRasterBand(1).WriteRaster(2, 0, 1, 1, b"\xFF")
+    out_ds = gdal.Footprint(
+        "",
+        src_ds,
+        format="Memory",
+        targetCoordinateSystem="pixel",
+        splitPolys=True,
+    )
+    assert out_ds is not None
+    lyr = out_ds.GetLayer(0)
+    f1 = lyr.GetNextFeature()
+    f2 = lyr.GetNextFeature()
+    try:
+        ogrtest.check_feature_geometry(f1, "POLYGON ((0 0,0 1,1 1,1 0,0 0))")
+        ogrtest.check_feature_geometry(f2, "POLYGON ((2 0,2 1,3 1,3 0,2 0))")
+    except AssertionError:
+        ogrtest.check_feature_geometry(f2, "POLYGON ((0 0,0 1,1 1,1 0,0 0))")
+        ogrtest.check_feature_geometry(f1, "POLYGON ((2 0,2 1,3 1,3 0,2 0))")
+
+
+###############################################################################
+#
+
+
+def test_gdal_footprint_lib_convexHull():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 3, 1, 1)
+    src_ds.GetRasterBand(1).SetNoDataValue(0)
+    src_ds.GetRasterBand(1).WriteRaster(0, 0, 1, 1, b"\xFF")
+    src_ds.GetRasterBand(1).WriteRaster(2, 0, 1, 1, b"\xFF")
+    out_ds = gdal.Footprint(
+        "",
+        src_ds,
+        format="Memory",
+        targetCoordinateSystem="pixel",
+        convexHull=True,
+    )
+    assert out_ds is not None
+    lyr = out_ds.GetLayer(0)
+    f = lyr.GetNextFeature()
+    ogrtest.check_feature_geometry(f, "MULTIPOLYGON (((0 0,0 1,3 1,3 0,0 0)))")
+
+
+###############################################################################
+#
+
+
+def test_gdal_footprint_lib_densify():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 3, 1, 1)
+    src_ds.GetRasterBand(1).SetNoDataValue(0)
+    src_ds.GetRasterBand(1).WriteRaster(1, 0, 1, 1, b"\xFF")
+    out_ds = gdal.Footprint(
+        "",
+        src_ds,
+        format="Memory",
+        targetCoordinateSystem="pixel",
+        densify=0.5,
+    )
+    assert out_ds is not None
+    lyr = out_ds.GetLayer(0)
+    f = lyr.GetNextFeature()
+    ogrtest.check_feature_geometry(
+        f, "MULTIPOLYGON (((1 0,1.0 0.5,1 1,1.5 1.0,2 1,2.0 0.5,2 0,1.5 0.0,1 0)))"
+    )
+
+
+###############################################################################
+#
+
+
+def test_gdal_footprint_lib_simplify():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 3, 2, 1)
+    src_ds.GetRasterBand(1).SetNoDataValue(0)
+    src_ds.GetRasterBand(1).WriteRaster(1, 0, 1, 1, b"\xFF")
+    src_ds.GetRasterBand(1).WriteRaster(1, 1, 1, 1, b"\xFF")
+    src_ds.GetRasterBand(1).WriteRaster(2, 1, 1, 1, b"\xFF")
+    out_ds = gdal.Footprint(
+        "",
+        src_ds,
+        format="Memory",
+        targetCoordinateSystem="pixel",
+        simplify=1,
+    )
+    assert out_ds is not None
+    lyr = out_ds.GetLayer(0)
+    f = lyr.GetNextFeature()
+    ogrtest.check_feature_geometry(f, "MULTIPOLYGON (((1 0,1 2,3 2,1 0)))")
+
+
+###############################################################################
+#
+
+
+def test_gdal_footprint_lib_maxPoints():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 3, 2, 1)
+    src_ds.GetRasterBand(1).SetNoDataValue(0)
+    src_ds.GetRasterBand(1).WriteRaster(1, 0, 1, 1, b"\xFF")
+    src_ds.GetRasterBand(1).WriteRaster(1, 1, 1, 1, b"\xFF")
+    src_ds.GetRasterBand(1).WriteRaster(2, 1, 1, 1, b"\xFF")
+    out_ds = gdal.Footprint(
+        "",
+        src_ds,
+        format="Memory",
+        targetCoordinateSystem="pixel",
+        maxPoints=4,
+    )
+    assert out_ds is not None
+    lyr = out_ds.GetLayer(0)
+    f = lyr.GetNextFeature()
+    ogrtest.check_feature_geometry(f, "MULTIPOLYGON (((1 0,1 2,3 2,1 0)))")
+
+
+###############################################################################
+#
+
+
+def test_gdal_footprint_lib_ovr():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 3, 2, 1)
+    src_ds.GetRasterBand(1).SetNoDataValue(0)
+    src_ds.GetRasterBand(1).WriteRaster(1, 0, 1, 1, b"\xFF")
+    src_ds.GetRasterBand(1).WriteRaster(1, 1, 1, 1, b"\xFF")
+    src_ds.GetRasterBand(1).WriteRaster(2, 1, 1, 1, b"\xFF")
+    src_ds.BuildOverviews("NONE", [2])
+    src_ds.GetRasterBand(1).GetOverview(0).WriteRaster(0, 0, 1, 1, b"\xFF")
+    out_ds = gdal.Footprint(
+        "",
+        src_ds,
+        format="Memory",
+        targetCoordinateSystem="pixel",
+        ovr=0,
+    )
+    assert out_ds is not None
+    lyr = out_ds.GetLayer(0)
+    f = lyr.GetNextFeature()
+    ogrtest.check_feature_geometry(f, "MULTIPOLYGON (((0 0,0 2,1.5 2.0,1.5 0.0,0 0)))")
+
+
+###############################################################################
+#
+
+
+def test_gdal_footprint_lib_ovr_georef():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 3, 2, 1)
+    src_ds.SetGeoTransform([2, 1, 0, 49, 0, -1])
+    src_ds.GetRasterBand(1).SetNoDataValue(0)
+    src_ds.GetRasterBand(1).WriteRaster(1, 0, 1, 1, b"\xFF")
+    src_ds.GetRasterBand(1).WriteRaster(1, 1, 1, 1, b"\xFF")
+    src_ds.GetRasterBand(1).WriteRaster(2, 1, 1, 1, b"\xFF")
+    src_ds.BuildOverviews("NONE", [2])
+    src_ds.GetRasterBand(1).GetOverview(0).WriteRaster(0, 0, 1, 1, b"\xFF")
+    out_ds = gdal.Footprint(
+        "",
+        src_ds,
+        format="Memory",
+        ovr=0,
+    )
+    assert out_ds is not None
+    lyr = out_ds.GetLayer(0)
+    f = lyr.GetNextFeature()
+    ogrtest.check_feature_geometry(
+        f, "MULTIPOLYGON (((2 49,2 47,3.5 47.0,3.5 49.0,2 49)))"
+    )
+
+
+###############################################################################
+#
+
+
+@pytest.mark.require_driver("GPKG")
+def test_gdal_footprint_lib_dsco_lco():
+
+    out_filename = "/vsimem/out.gpkg"
+    out_ds = gdal.Footprint(
+        out_filename,
+        "../gcore/data/byte.tif",
+        format="GPKG",
+        datasetCreationOptions=["ADD_GPKG_OGR_CONTENTS=NO"],
+        layerCreationOptions=["GEOMETRY_NAME=my_geom"],
+    )
+    assert out_ds is not None
+    lyr = out_ds.GetLayer(0)
+    assert lyr.GetGeometryColumn() == "my_geom"
+    f = lyr.GetNextFeature()
+    ogrtest.check_feature_geometry(
+        f,
+        "MULTIPOLYGON (((440720 3751320,440720 3750120,441920 3750120,441920 3751320,440720 3751320)))",
+    )
+    with out_ds.ExecuteSQL(
+        "SELECT * FROM sqlite_master WHERE name = 'gpkg_ogr_contents'"
+    ) as sql_lyr:
+        assert sql_lyr.GetFeatureCount() == 0
+    gdal.Unlink(out_filename)

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -411,6 +411,13 @@ man_pages = [
         [author_evenr],
         1,
     ),
+    (
+        "programs/gdal_footprint",
+        "gdal_footprint",
+        "Compute footprint of a raster.",
+        [author_evenr],
+        1,
+    ),
 ]
 
 

--- a/doc/source/programs/gdal_footprint.rst
+++ b/doc/source/programs/gdal_footprint.rst
@@ -1,0 +1,199 @@
+.. _gdal_footprint:
+
+================================================================================
+gdal_footprint
+================================================================================
+
+.. only:: html
+
+    .. versionadded:: 3.8.0
+
+    Compute footprint of a raster.
+
+.. Index:: gdal_footprint
+
+Synopsis
+--------
+
+.. code-block::
+
+
+    gdal_footprint [--help-general]
+       [-b band]* [-combine_bands union|intersection]
+       [-oo NAME=VALUE]* [-ovr <index>]
+       [-srcnodata \"value [value...]\"]
+       [-t_cs pixel|georef] [-t_srs <srs_def>] [-split_polys]
+       [-convex_hull] [-densify <value>] [-simplify <value>]
+       [-min_ring_area <value>] [-max_points <value>|unlimited]
+       [-of ogr_format] [-lyr_name dst_layername]
+       [-dsco name=value]* [-lco name=value]* [-q] [-overwrite]
+       <src_filename> <dst_filename>
+
+
+Description
+-----------
+
+The :program:`gdal_footprint` utility can be used to compute the footprint of
+a raster file, taking into account nodata values (or more generally the mask
+band attached to the raster bands), and generating polygons/multipolygons
+corresponding to areas where pixels are valid, and write to an output vector file.
+
+The :program:`nearblack` utility may be run as a pre-processing step to generate
+proper mask bands.
+
+
+.. program:: gdal_footprint
+
+.. option:: -b <band>
+
+    Band(s) of interested. Between 1 and the number of bands of the raster.
+    May be specified multiple times. If not specified, all bands are taken
+    into account. The way multiple bands are combined is controlled by
+    :option:`-combine_bands`
+
+.. option:: -combine_bands union|intersection
+
+    Defines how the mask bands of the selected bands are combined to generate
+    a single mask band, before being vectorized.
+    The default value is ``union``: that is a pixel is valid if it is valid at least
+    for one of the selected bands.
+    ``intersection`` means that a pixel is valid only ifit is valid for all
+    selected bands.
+
+.. option:: -ovr <index>
+
+   To specify which overview level of source file must be used, when overviews
+   are available on the source raster. By default the full resolution level is
+   used. The index is 0-based, that is 0 means the first overview level.
+   This option is mutually exclusive with :option:`-srcnodata`.
+
+.. option:: -srcnodata "<value> [<value>...]"
+
+    Set nodata values for input bands (different values can be supplied for each band).
+    If a single value is specified, it applies to all selected bands.
+    If more than one value is supplied, there should be as many values as the number
+    of selected bands, and all values should be quoted to keep them
+    together as a single operating system argument.
+    If the option is not specified, the intrinsic mask band of each selected
+    bands will be used.
+
+.. option:: -t_cs pixel|georef
+
+    Target coordinate system. By default if the input dataset is georeferenced,
+    ``georef`` is implied, that is the footprint geometry will be expressed
+    as coordinates in the CRS of the raster (or the one specified with :option:`-t_srs`).
+    If specifying ``pixel``, the coordinates of the footprint geometry are
+    column and line indices.
+
+.. option:: -t_srs <srs_def>
+
+    Target CRS of the output file.  The <srs_def> may be any of
+    the usual GDAL/OGR forms, complete WKT, PROJ.4, EPSG:n or a file containing
+    the WKT.
+    Specifying this option implies -t_cs georef
+    The footprint is reprojected from the CRS of the source raster to the
+    specified CRS.
+
+.. option:: -split_polys
+
+    When specified, multipolygons are split as several features each with one
+    single polygon.
+
+.. option:: -convex_hull
+
+    When specified, the convex hull of (multi)polygons is computed.
+
+.. option:: -densify <value>
+
+    The specified value of this option is the maximum distance between 2
+    consecutive points of the output geometry.
+    The unit of the distance is in pixels if :option:`-t_cs` equals ``pixel``,
+    or otherwise in georeferenced units of the source raster.
+    This option is applied before the reprojection implied by :option:`-t_srs`
+
+.. option:: -simplify <value>
+
+    The specified value of this option is the tolerance used to merge
+    consecutive points of the output geometry using the
+    :cpp:func:`OGRGeometry::Simplify` method
+    The unit of the distance is in pixels if :option:`-t_cs` equals ``pixel``,
+    or otherwise in georeferenced units of the target vector dataset.
+    This option is applied after the reprojection implied by :option:`-t_srs`
+
+.. option:: -min_ring_area <value>
+
+    Minimum value for the area of a ring
+    The unit of the area is in square pixels if :option:`-t_cs` equals ``pixel``,
+    or otherwise in georeferenced units of the target vector dataset.
+    This option is applied after the reprojection implied by :option:`-t_srs`
+
+.. option:: -max_points <value>|unlimited
+
+    Maximum number of points of each output geometry (not counting the closing
+    point of each ring, which is always identical to the first point).
+    The default value is 100. ``unlimited`` can be used to remove that limitation.
+
+.. option:: -q
+
+    Suppress progress monitor and other non-error output.
+
+.. option:: -oo NAME=VALUE
+
+    Dataset open option (format specific)
+
+.. option:: -of <ogr_format>
+
+    Select the output format. Use the short format name. Guessed from the
+    file extension if not specified
+
+.. option:: -lco NAME=VALUE
+
+    Layer creation option (format specific)
+
+.. option:: -dsco NAME=VALUE
+
+    Dataset creation option (format specific)
+
+.. option:: -lyr_name <value>
+
+    Name of the target layer. ``footprint`` if not specified.
+
+.. option:: -overwrite
+
+    Overwrite the target layer if it exists.
+
+.. option:: <src_filename>
+
+    The source raster file name.
+
+.. option:: <dst_filename>
+
+    The destination vector file name. If the file and the output layer exist,
+    the new footprint is appended to them, unless :option:`-overwrite` is used.
+
+
+Post-vectorization geometric operations are applied in the following order:
+
+* optional splitting (:option:`-split_polys`)
+* optional densification (:option:`-densify`)
+* optional reprojection (:option:`-t_srs`)
+* optional filtering by minimum ring area (:option:`-min_ring_area`)
+* optional application of convex hull (:option:`-convex_hull`)
+* optional simplification (:option:`-simplify`)
+* limitation of number of points (:option:`-max_points`)
+
+C API
+-----
+
+This utility is also callable from C with :cpp:func:`GDALFootprint`.
+
+
+Examples
+--------
+
+- Compute the footprint of a GeoTIFF file as a GeoJSON file using WGS 84
+  longitude, latitude coordinates
+
+    ::
+
+        gdal_footprint -t_srs EPSG:4326 input.tif output.geojson

--- a/doc/source/programs/index.rst
+++ b/doc/source/programs/index.rst
@@ -46,6 +46,7 @@ Raster programs
    gdalcompare
    gdal_viewshed
    gdal_create
+   gdal_footprint
 
 .. only:: html
 
@@ -84,6 +85,7 @@ Raster programs
     - :ref:`gdalcompare`: Compare two images.
     - :ref:`gdal_viewshed`: Compute a visibility mask for a raster.
     - :ref:`gdal_create`: Create a raster file (without source dataset).
+    - :ref:`gdal_footprint`: Compute footprint of a raster.
 
 Multidimensional Raster programs
 --------------------------------

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -1578,10 +1578,10 @@ class CPL_DLL GDALAllValidMaskBand : public GDALRasterBand
 class CPL_DLL GDALNoDataMaskBand : public GDALRasterBand
 {
     friend class GDALRasterBand;
-    double dfNoDataValue = 0;
-    int64_t nNoDataValueInt64 = 0;
-    uint64_t nNoDataValueUInt64 = 0;
-    GDALRasterBand *poParent;
+    double m_dfNoDataValue = 0;
+    int64_t m_nNoDataValueInt64 = 0;
+    uint64_t m_nNoDataValueUInt64 = 0;
+    GDALRasterBand *m_poParent = nullptr;
 
     CPL_DISALLOW_COPY_ASSIGN(GDALNoDataMaskBand)
 
@@ -1593,6 +1593,7 @@ class CPL_DLL GDALNoDataMaskBand : public GDALRasterBand
 
   public:
     explicit GDALNoDataMaskBand(GDALRasterBand *);
+    explicit GDALNoDataMaskBand(GDALRasterBand *, double dfNoDataValue);
     ~GDALNoDataMaskBand() override;
 
     bool IsMaskBand() const override

--- a/gcore/gdalrasterband.cpp
+++ b/gcore/gdalrasterband.cpp
@@ -7065,11 +7065,11 @@ GDALRasterBand *GDALRasterBand::GetMaskBand()
                 int bHaveNoDataRaw = FALSE;
                 bool bIsSame = false;
                 if (eDataType == GDT_Int64)
-                    bIsSame = poNoDataMaskBand->nNoDataValueInt64 ==
+                    bIsSame = poNoDataMaskBand->m_nNoDataValueInt64 ==
                                   GetNoDataValueAsInt64(&bHaveNoDataRaw) &&
                               bHaveNoDataRaw;
                 else if (eDataType == GDT_UInt64)
-                    bIsSame = poNoDataMaskBand->nNoDataValueUInt64 ==
+                    bIsSame = poNoDataMaskBand->m_nNoDataValueUInt64 ==
                                   GetNoDataValueAsUInt64(&bHaveNoDataRaw) &&
                               bHaveNoDataRaw;
                 else
@@ -7080,8 +7080,8 @@ GDALRasterBand *GDALRasterBand::GetMaskBand()
                     {
                         bIsSame =
                             std::isnan(dfNoDataValue)
-                                ? std::isnan(poNoDataMaskBand->dfNoDataValue)
-                                : poNoDataMaskBand->dfNoDataValue ==
+                                ? std::isnan(poNoDataMaskBand->m_dfNoDataValue)
+                                : poNoDataMaskBand->m_dfNoDataValue ==
                                       dfNoDataValue;
                     }
                 }

--- a/scripts/completionFinder.py
+++ b/scripts/completionFinder.py
@@ -250,6 +250,7 @@ def main(argv):
         "gdal_viewshed",
         "gdal_create",
         "sozip",
+        "gdal_footprint",
     ]
 
     ogrtools = [

--- a/swig/include/gdal.i
+++ b/swig/include/gdal.i
@@ -1801,6 +1801,111 @@ GDALDatasetShadow* wrapper_GDALRasterizeDestName( const char* dest,
 %}
 
 //************************************************************************
+// gdal.Footprint()
+//************************************************************************
+
+#ifdef SWIGJAVA
+%rename (FootprintOptions) GDALFootprintOptions;
+#endif
+struct GDALFootprintOptions {
+%extend {
+    GDALFootprintOptions(char** options) {
+        return GDALFootprintOptionsNew(options, NULL);
+    }
+
+    ~GDALFootprintOptions() {
+        GDALFootprintOptionsFree( self );
+    }
+}
+};
+
+/* Note: we must use 2 distinct names due to different ownership of the result */
+
+#ifdef SWIGJAVA
+%rename (Footprint) wrapper_GDALFootprintDestDS;
+#endif
+%inline %{
+int wrapper_GDALFootprintDestDS( GDALDatasetShadow* dstDS,
+                            GDALDatasetShadow* srcDS,
+                            GDALFootprintOptions* options,
+                            GDALProgressFunc callback=NULL,
+                            void* callback_data=NULL)
+{
+    int usageError; /* ignored */
+    bool bFreeOptions = false;
+    if( callback )
+    {
+        if( options == NULL )
+        {
+            bFreeOptions = true;
+            options = GDALFootprintOptionsNew(NULL, NULL);
+        }
+        GDALFootprintOptionsSetProgress(options, callback, callback_data);
+    }
+#ifdef SWIGPYTHON
+    std::vector<ErrorStruct> aoErrors;
+    if( GetUseExceptions() )
+    {
+        PushStackingErrorHandler(&aoErrors);
+    }
+#endif
+    bool bRet = (GDALFootprint(NULL, dstDS, srcDS, options, &usageError) != NULL);
+    if( bFreeOptions )
+        GDALFootprintOptionsFree(options);
+#ifdef SWIGPYTHON
+    if( GetUseExceptions() )
+    {
+        PopStackingErrorHandler(&aoErrors, bRet);
+    }
+#endif
+    return bRet;
+}
+%}
+
+#ifdef SWIGJAVA
+%rename (Footprint) wrapper_GDALFootprintDestName;
+#endif
+%newobject wrapper_GDALFootprintDestName;
+
+%inline %{
+GDALDatasetShadow* wrapper_GDALFootprintDestName( const char* dest,
+                                             GDALDatasetShadow* srcDS,
+                                             GDALFootprintOptions* options,
+                                             GDALProgressFunc callback=NULL,
+                                             void* callback_data=NULL)
+{
+    int usageError; /* ignored */
+    bool bFreeOptions = false;
+    if( callback )
+    {
+        if( options == NULL )
+        {
+            bFreeOptions = true;
+            options = GDALFootprintOptionsNew(NULL, NULL);
+        }
+        GDALFootprintOptionsSetProgress(options, callback, callback_data);
+    }
+#ifdef SWIGPYTHON
+    std::vector<ErrorStruct> aoErrors;
+    if( GetUseExceptions() )
+    {
+        PushStackingErrorHandler(&aoErrors);
+    }
+#endif
+    GDALDatasetH hDSRet = GDALFootprint(dest, NULL, srcDS, options, &usageError);
+    if( bFreeOptions )
+        GDALFootprintOptionsFree(options);
+#ifdef SWIGPYTHON
+    if( GetUseExceptions() )
+    {
+        PopStackingErrorHandler(&aoErrors, hDSRet != NULL);
+    }
+#endif
+    return hDSRet;
+}
+%}
+
+//************************************************************************
 // gdal.BuildVRT()
 //************************************************************************
 

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -3232,6 +3232,192 @@ def Rasterize(destNameOrDestDS, srcDS, **kwargs):
         return wrapper_GDALRasterizeDestDS(destNameOrDestDS, srcDS, opts, callback, callback_data)
 
 
+def FootprintOptions(options=None,
+                     format=None,
+                     bands=None,
+                     srcNodata=None,
+                     ovr=None,
+                     targetCoordinateSystem=None,
+                     dstSRS=None,
+                     splitPolys=None,
+                     convexHull=None,
+                     densify=None,
+                     simplify=None,
+                     maxPoints=None,
+                     layerName=None,
+                     layerCreationOptions=None,
+                     datasetCreationOptions=None,
+                     callback=None, callback_data=None):
+    """Create a FootprintOptions() object that can be passed to gdal.Footprint()
+
+    Parameters
+    ----------
+    options:
+        can be be an array of strings, a string or let empty and filled from other keywords.
+    format:
+        output format ("GeoJSON", etc...)
+    bands:
+        list of output bands to burn values into
+    srcNodata:
+        source nodata value(s).
+    ovr:
+        overview index.
+    targetCoordinateSystem:
+        "pixel" or "georef"
+    dstSRS:
+        output SRS
+    datasetCreationOptions:
+        list of dataset creation options
+    layerCreationOptions:
+        list of layer creation options
+    splitPolys:
+        whether to split multipolygons as several polygons
+    convexHull:
+        whether to compute the convex hull of polygons/multipolygons
+    densify:
+        tolerance value for polygon densification
+    simplify:
+        tolerance value for polygon simplification
+    maxPoints:
+        maximum number of points (100 by default, "unlimited" for unlimited)
+    layerName:
+        output layer name
+    callback:
+        callback method
+    callback_data:
+        user data for callback
+    """
+    options = [] if options is None else options
+
+    if isinstance(options, str):
+        new_options = ParseCommandLine(options)
+    else:
+        new_options = options
+        if format is not None:
+            new_options += ['-of', format]
+        if bands is not None:
+            for b in bands:
+                new_options += ['-b', str(b)]
+        if targetCoordinateSystem:
+            new_options += ["-t_cs", targetCoordinateSystem]
+        if dstSRS:
+            new_options += ["-t_srs", dstSRS]
+        if srcNodata is not None:
+            new_options += ['-srcnodata', str(srcNodata)]
+        if ovr is not None:
+            new_options += ['-ovr', str(ovr)]
+        if splitPolys:
+            new_options += ["-split_polys"]
+        if convexHull:
+            new_options += ["-convex_hull"]
+        if densify is not None:
+            new_options += ['-densify', str(densify)]
+        if simplify is not None:
+            new_options += ['-simplify', str(simplify)]
+        if maxPoints is not None:
+            new_options += ['-max_points', str(maxPoints)]
+        if layerName is not None:
+            new_options += ['-lyr_name', layerName]
+        if datasetCreationOptions is not None:
+            for opt in datasetCreationOptions:
+                new_options += ['-dsco', opt]
+        if layerCreationOptions is not None:
+            for opt in layerCreationOptions:
+                new_options += ['-lco', opt]
+
+    return (GDALFootprintOptions(new_options), callback, callback_data)
+
+def Footprint(destNameOrDestDS, srcDS, **kwargs):
+    """Compute the footprint of a raster
+
+    Parameters
+    ----------
+    destNameOrDestDS:
+        Output dataset name or object
+    srcDS:
+        a Dataset object or a filename
+    kwargs:
+        options: return of gdal.FootprintOptions(), string or array of strings,
+        other keywords arguments of gdal.FootprintOptions()
+        If options is provided as a gdal.FootprintOptions() object, other keywords are ignored.
+
+    Examples
+    --------
+
+    1. Special mode to get deserialized GeoJSON (in EPSG:4326 if dstSRS not specified):
+
+    >>> deserialized_geojson = gdal.FootPrint(None, src_ds, format="GeoJSON")
+
+    2. Special mode to get WKT:
+
+    >>> wkt = gdal.FootPrint(None, src_ds, format="WKT")
+
+    3. Get result in a GeoPackage
+
+    >>> gdal.FootPrintf("out.gpkg", src_ds, format="GPKG")
+
+    """
+
+    _WarnIfUserHasNotSpecifiedIfUsingExceptions()
+
+    inline_geojson_requested = (destNameOrDestDS is None or destNameOrDestDS == "") and \
+        "format" in kwargs and kwargs["format"] == "GeoJSON"
+    if inline_geojson_requested and "dstSRS" not in kwargs:
+        import copy
+        kwargs = copy.copy(kwargs)
+        kwargs["dstSRS"] = "EPSG:4326"
+
+    wkt_requested = (destNameOrDestDS is None or destNameOrDestDS == "") and \
+        "format" in kwargs and kwargs["format"] == "WKT"
+    if wkt_requested:
+        import copy
+        kwargs = copy.copy(kwargs)
+        kwargs["format"] = "GeoJSON"
+
+    if 'options' not in kwargs or isinstance(kwargs['options'], (list, str)):
+        (opts, callback, callback_data) = FootprintOptions(**kwargs)
+    else:
+        (opts, callback, callback_data) = kwargs['options']
+    if isinstance(srcDS, str):
+        srcDS = OpenEx(srcDS, gdalconst.OF_RASTER)
+
+    if inline_geojson_requested or wkt_requested:
+        import uuid
+        temp_filename = "/vsimem/" + str(uuid.uuid4())
+        try:
+            if not wrapper_GDALFootprintDestName(temp_filename, srcDS, opts, callback, callback_data):
+                return None
+            if inline_geojson_requested:
+                f = VSIFOpenL(temp_filename, "rb")
+                assert f
+                VSIFSeekL(f, 0, 2) # SEEK_END
+                size = VSIFTellL(f)
+                VSIFSeekL(f, 0, 0) # SEEK_SET
+                data = VSIFReadL(1, size, f)
+                VSIFCloseL(f)
+                import json
+                return json.loads(data)
+            else:
+                assert wkt_requested
+                ds = OpenEx(temp_filename)
+                lyr = ds.GetLayer(0)
+                wkts = []
+                for f in lyr:
+                    wkts.append(f.GetGeometryRef().ExportToWkt())
+                if len(wkts) == 1:
+                    return wkts[0]
+                else:
+                    return wkts
+        finally:
+            if VSIStatL(temp_filename):
+                Unlink(temp_filename)
+
+    if isinstance(destNameOrDestDS, str):
+        return wrapper_GDALFootprintDestName(destNameOrDestDS, srcDS, opts, callback, callback_data)
+    else:
+        return wrapper_GDALFootprintDestDS(destNameOrDestDS, srcDS, opts, callback, callback_data)
+
+
 def BuildVRTOptions(options=None,
                     resolution=None,
                     outputBounds=None,


### PR DESCRIPTION
The gdal_footprint utility can be used to compute the footprint of
a raster file, taking into account nodata values (or more generally the mask
band attached to the raster bands), and generating polygons/multipolygons
corresponding to areas where pixels are valid, and write to an output vector file.

Documentation at https://github.com/rouault/gdal/blob/gdal_footprint/doc/source/programs/gdal_footprint.rst

Fixes #6264
