### PR TITLE
[Backport release/3.7] Python bindings: works around issue with SWIG 4.1 related to module unloading

### DIFF
--- a/swig/include/python/osr_python.i
+++ b/swig/include/python/osr_python.i
@@ -55,10 +55,15 @@ def _WarnIfUserHasNotSpecifiedIfUsingExceptions():
                 this = _osr.new_SpatialReference(*args, **kwargs)
         finally:
             pass
-        try:
-            self.this.append(this)
-        except __builtin__.Exception:
-            self.this = this
+        if hasattr(_osr, "SpatialReference_swiginit"):
+            # SWIG 4 way
+            _osr.SpatialReference_swiginit(self, this)
+        else:
+            # SWIG < 4 way
+            try:
+                self.this.append(this)
+            except __builtin__.Exception:
+                self.this = this
 
   %}
 }

--- a/swig/python/modify_cpp_files.cmake
+++ b/swig/python/modify_cpp_files.cmake
@@ -33,9 +33,6 @@ string(REPLACE "obj = PyUnicode_AsUTF8String(obj);"
                "obj = PyUnicode_AsUTF8String(obj); if (!obj) return SWIG_TypeError;"
        _CONTENTS "${_CONTENTS}")
 
-# TODO: To remove once swig/python/GNUmakefile has gone
-string(APPEND _CONTENTS "#define POST_PROCESSING_APPLIED\n")
-
 if("${FILE}" MATCHES "gdal_wrap.cpp")
     string(REGEX REPLACE "result = \\(CPLErr\\)([^;]+)(\\;)"
                          [[CPL_IGNORE_RET_VAL(result = (CPLErr)\1)\2]]
@@ -55,5 +52,20 @@ if(NOT "${FILE}" MATCHES "gdal_array_wrap.cpp")
                    "if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }\n  return resultobj;"
            _CONTENTS "${_CONTENTS}")
 endif()
+
+# Below works around https://github.com/swig/swig/issues/2638 and https://github.com/swig/swig/issues/2037#issuecomment-874372082
+# to avoid the ""swig/python detected a memory leak of type 'OSRSpatialReferenceShadow *', no destructor found."
+# error message of https://github.com/OSGeo/gdal/issues/4907
+# The issue is that starting with SWIG 4.1, the SWIG_Python_DestroyModule(), which
+# is run in the gdal module (since __init__.py loads gdal in first),
+# removes the destructor on the OGRSpatialReferenceShadow type (among others),
+# which prevents full free of object of those type.
+# The following hack just makes SWIG_Python_DestroyModule() a no-op, which
+# will leak a bit of memory, but anyway SWIG currently can only free one single
+# SWIG module, so we had already memleaks
+# To be revisted if above mentionned SWIG issues are resolved
+string(REPLACE "if (--interpreter_counter != 0) // another sub-interpreter may still be using the swig_module's types"
+               "/* Even Rouault / GDAL hack for SWIG >= 4.1 related to objects not beeing freed. See swig/python/modify_cpp_files.cmake for more details */\nif( 1 )"
+       _CONTENTS "${_CONTENTS}")
 
 file(WRITE ${FILE} "${_CONTENTS}")


### PR DESCRIPTION
Backport #7951
 **Authored by:** @rouault