### PR TITLE
[Backport release/3.7] GML: add a USE_BBOX=YES open option to allow using gml:boundedBy as feature geometry

### DIFF
--- a/autotest/ogr/ogr_gml_read.py
+++ b/autotest/ogr/ogr_gml_read.py
@@ -4622,8 +4622,17 @@ def test_ogr_gml_read_boundedby_only():
     if not gdaltest.have_gml_reader:
         pytest.skip()
 
-    def check():
+    def check_no_options():
         ds = gdal.OpenEx("data/gml/only_boundedby.gml")
+        lyr = ds.GetLayer(0)
+        assert lyr.GetGeomType() == ogr.wkbNone
+        ds = None
+
+    gdal.Unlink("data/gml/only_boundedby.gfs")
+    check_no_options()
+
+    def check():
+        ds = gdal.OpenEx("data/gml/only_boundedby.gml", open_options=["USE_BBOX=YES"])
         lyr = ds.GetLayer(0)
         assert lyr.GetLayerDefn().GetGeomFieldCount() == 1
         assert lyr.GetGeomType() == ogr.wkbPolygon
@@ -4657,7 +4666,9 @@ def test_ogr_gml_read_boundedby_only_gml_null_only():
         pytest.skip()
 
     def check():
-        ds = gdal.OpenEx("data/gml/only_boundedby_only_null.gml")
+        ds = gdal.OpenEx(
+            "data/gml/only_boundedby_only_null.gml", open_options=["USE_BBOX=YES"]
+        )
         lyr = ds.GetLayer(0)
         assert lyr.GetLayerDefn().GetGeomFieldCount() == 0
         f = lyr.GetNextFeature()
@@ -4686,7 +4697,9 @@ def test_ogr_gml_read_bbox_and_several_geom_elements():
         pytest.skip()
 
     def check():
-        ds = gdal.OpenEx("data/gml/bbox_and_several_geom_elements.gml")
+        ds = gdal.OpenEx(
+            "data/gml/bbox_and_several_geom_elements.gml", open_options=["USE_BBOX=YES"]
+        )
         lyr = ds.GetLayer(0)
         assert lyr.GetGeometryColumn() == "geom1"
         assert lyr.GetGeomType() == ogr.wkbMultiPolygon
@@ -4719,7 +4732,9 @@ def test_ogr_gml_read_boundedby_invalid():
         pytest.skip()
 
     with gdaltest.error_handler():
-        ds = gdal.OpenEx("data/gml/only_boundedby_invalid.gml")
+        ds = gdal.OpenEx(
+            "data/gml/only_boundedby_invalid.gml", open_options=["USE_BBOX=YES"]
+        )
         lyr = ds.GetLayer(0)
         assert lyr.GetFeatureCount() == 0
 
@@ -4734,7 +4749,9 @@ def test_ogr_gml_read_boundedby_repeated():
     if not gdaltest.have_gml_reader:
         pytest.skip()
 
-    ds = gdal.OpenEx("data/gml/only_boundedby_repeated.gml")
+    ds = gdal.OpenEx(
+        "data/gml/only_boundedby_repeated.gml", open_options=["USE_BBOX=YES"]
+    )
     lyr = ds.GetLayer(0)
     assert lyr.GetFeatureCount() == 1
 

--- a/ogr/ogrsf_frmts/gml/gmlhandler.cpp
+++ b/ogr/ogrsf_frmts/gml/gmlhandler.cpp
@@ -1275,7 +1275,13 @@ OGRErr GMLHandler::startElementFeatureAttribute(const char *pszName,
             return startElementGeometry(pszName, nLenName, attr);
         }
     }
-    else if (nLenName == 9 && strcmp(pszName, "boundedBy") == 0)
+    else if (nLenName == 9 && strcmp(pszName, "boundedBy") == 0 &&
+             // We ignore the UseBBOX() flag for CityGML, since CityGML
+             // has elements like bldg:boundedBy, which are not a simple
+             // rectangular bbox. This is needed to read properly
+             // autotest/ogr/data/gml/citygml_lod2_713_5322.xml
+             // (this is a workaround of not being namespace aware)
+             (eAppSchemaType == APPSCHEMA_CITYGML || m_poReader->UseBBOX()))
     {
         m_inBoundedByDepth = m_nDepth;
 

--- a/ogr/ogrsf_frmts/gml/gmlreaderp.h
+++ b/ogr/ogrsf_frmts/gml/gmlreaderp.h
@@ -429,6 +429,8 @@ class GMLReader final : public IGMLReader
 
     bool m_bEmptyAsNull;
 
+    bool m_bUseBBOX = false;
+
     bool ParseXMLHugeFile(const char *pszOutputFilename,
                           const bool bSqliteIsTempFile,
                           const int iSqliteCacheMB);
@@ -573,6 +575,15 @@ class GMLReader final : public IGMLReader
     bool IsEmptyAsNull() const
     {
         return m_bEmptyAsNull;
+    }
+
+    void SetUseBBOX(bool bFlag)
+    {
+        m_bUseBBOX = bFlag;
+    }
+    bool UseBBOX() const
+    {
+        return m_bUseBBOX;
     }
 
     static CPLMutex *hMutex;

--- a/ogr/ogrsf_frmts/gml/ogrgmldatasource.cpp
+++ b/ogr/ogrsf_frmts/gml/ogrgmldatasource.cpp
@@ -643,13 +643,16 @@ bool OGRGMLDataSource::Open(GDALOpenInfo *poOpenInfo)
     }
 
     poReader->SetSourceFile(pszFilename);
-    static_cast<GMLReader *>(poReader)->SetIsWFSJointLayer(bIsWFSJointLayer);
+    auto poGMLReader = cpl::down_cast<GMLReader *>(poReader);
+    poGMLReader->SetIsWFSJointLayer(bIsWFSJointLayer);
     bEmptyAsNull =
         CPLFetchBool(poOpenInfo->papszOpenOptions, "EMPTY_AS_NULL", true);
-    static_cast<GMLReader *>(poReader)->SetEmptyAsNull(bEmptyAsNull);
-    static_cast<GMLReader *>(poReader)->SetReportAllAttributes(CPLFetchBool(
+    poGMLReader->SetEmptyAsNull(bEmptyAsNull);
+    poGMLReader->SetReportAllAttributes(CPLFetchBool(
         poOpenInfo->papszOpenOptions, "GML_ATTRIBUTES_TO_OGR_FIELDS",
         CPLTestBool(CPLGetConfigOption("GML_ATTRIBUTES_TO_OGR_FIELDS", "NO"))));
+    poGMLReader->SetUseBBOX(
+        CPLFetchBool(poOpenInfo->papszOpenOptions, "USE_BBOX", false));
 
     // Find <gml:description>, <gml:name> and <gml:boundedBy> and if it is
     // a standalone geometry

--- a/ogr/ogrsf_frmts/gml/ogrgmldriver.cpp
+++ b/ogr/ogrsf_frmts/gml/ogrgmldriver.cpp
@@ -213,6 +213,9 @@ void RegisterOGRGML()
         "currently)' default='YES'/>"
         "  <Option name='REGISTRY' type='string' description='Filename of the "
         "registry with application schemas.'/>"
+        "  <Option name='USE_BBOX' type='boolean' description='Whether "
+        "to use gml:boundedBy at feature level as feature geometry, "
+        "if there are no other geometry' default='NO'/>"
         "</OpenOptionList>");
 
     poDriver->SetMetadataItem(


### PR DESCRIPTION
Backport #7954
 **Authored by:** @rouault