### PR TITLE
Fix missing quotes in RFC45 SWIG bindings

### DIFF
--- a/doc/source/development/rfc/rfc45_virtualmem.rst
+++ b/doc/source/development/rfc/rfc45_virtualmem.rst
@@ -1227,6 +1227,7 @@ And the Band object has the following 3 methods :
      def GetVirtualMemAutoArray(self, eAccess = gdalconst.GF_Read, options = None):
            """Return a NumPy array for the band, seen as a virtual memory mapping.
               An element is accessed with array[y][x].
+           """
 
      def GetTiledVirtualMemArray(self, eAccess = gdalconst.GF_Read, xoff=0, yoff=0,
                               xsize=None, ysize=None, tilexsize=256, tileysize=256,


### PR DESCRIPTION
## What does this PR do?
Third code section under SWIG bindings for RFC45 is missing a closing docstring quote, making it render wrong and harder to read.

https://gdal.org/development/rfc/rfc45_virtualmem.html#swig-bindings

## What are related issues/pull requests?
None

## Tasklist
None?