### PR TITLE
ogrinfo: speed-up on GPKG with large number of layers

### DIFF
--- a/apps/ogrinfo_lib.cpp
+++ b/apps/ogrinfo_lib.cpp
@@ -129,6 +129,14 @@ static void Concat(CPLString &osRet, bool bStdoutOutput, const char *pszFormat,
     va_end(args);
 }
 
+static void ConcatStr(CPLString &osRet, bool bStdoutOutput, const char *pszStr)
+{
+    if (bStdoutOutput)
+        fwrite(pszStr, 1, strlen(pszStr), stdout);
+    else
+        osRet += pszStr;
+}
+
 /************************************************************************/
 /*                        ReportFieldDomain()                           */
 /************************************************************************/
@@ -515,10 +523,9 @@ static void ReportRelationships(CPLString &osRet, CPLJSONObject &oRoot,
                 for (const auto &osName : aosList)
                 {
                     if (!bFirstName)
-                        Concat(osRet, psOptions->bStdoutOutput, ", ");
+                        ConcatStr(osRet, psOptions->bStdoutOutput, ", ");
                     bFirstName = false;
-                    Concat(osRet, psOptions->bStdoutOutput, "%s",
-                           osName.c_str());
+                    ConcatStr(osRet, psOptions->bStdoutOutput, osName.c_str());
                 }
                 Concat(osRet, psOptions->bStdoutOutput, "\n");
             };
@@ -1051,8 +1058,8 @@ static void ReportOnLayer(CPLString &osRet, CPLJSONObject oLayer,
                     }
                     else
                     {
-                        Concat(osRet, psOptions->bStdoutOutput, "%s",
-                               poSupportedSRS->GetName());
+                        ConcatStr(osRet, psOptions->bStdoutOutput,
+                                  poSupportedSRS->GetName());
                     }
                 }
                 Concat(osRet, psOptions->bStdoutOutput, "\n");
@@ -1375,8 +1382,8 @@ static void ReportOnLayer(CPLString &osRet, CPLJSONObject oLayer,
                 }
                 else
                 {
-                    Concat(
-                        osRet, psOptions->bStdoutOutput, "%s",
+                    ConcatStr(
+                        osRet, psOptions->bStdoutOutput,
                         poFeature
                             ->DumpReadableAsString(psOptions->aosOptions.List())
                             .c_str());
@@ -1396,9 +1403,10 @@ static void ReportOnLayer(CPLString &osRet, CPLJSONObject oLayer,
         }
         else
         {
-            Concat(osRet, psOptions->bStdoutOutput, "%s",
-                   poFeature->DumpReadableAsString(psOptions->aosOptions.List())
-                       .c_str());
+            ConcatStr(
+                osRet, psOptions->bStdoutOutput,
+                poFeature->DumpReadableAsString(psOptions->aosOptions.List())
+                    .c_str());
             OGRFeature::DestroyFeature(poFeature);
         }
     }
@@ -1416,7 +1424,7 @@ static void PrintLayerSummary(CPLString &osRet, CPLJSONObject &oLayer,
     if (bJson)
         oLayer.Set("name", poLayer->GetName());
     else
-        Concat(osRet, psOptions->bStdoutOutput, "%s", poLayer->GetName());
+        ConcatStr(osRet, psOptions->bStdoutOutput, poLayer->GetName());
 
     const char *pszTitle = poLayer->GetMetadataItem("TITLE");
     if (pszTitle)
@@ -1448,8 +1456,8 @@ static void PrintLayerSummary(CPLString &osRet, CPLJSONObject &oLayer,
             {
                 if (iGeom > 0)
                     Concat(osRet, psOptions->bStdoutOutput, ", ");
-                Concat(osRet, psOptions->bStdoutOutput, "%s",
-                       OGRGeometryTypeToName(poGFldDefn->GetType()));
+                ConcatStr(osRet, psOptions->bStdoutOutput,
+                          OGRGeometryTypeToName(poGFldDefn->GetType()));
             }
         }
         if (!bJson)
@@ -1886,14 +1894,15 @@ char *GDALVectorInfo(GDALDatasetH hDataset,
     if (bJson)
     {
         osRet.clear();
-        Concat(osRet, psOptions->bStdoutOutput, "%s",
-               json_object_to_json_string_ext(
-                   static_cast<struct json_object *>(oRoot.GetInternalHandle()),
-                   JSON_C_TO_STRING_PRETTY
+        ConcatStr(
+            osRet, psOptions->bStdoutOutput,
+            json_object_to_json_string_ext(
+                static_cast<struct json_object *>(oRoot.GetInternalHandle()),
+                JSON_C_TO_STRING_PRETTY
 #ifdef JSON_C_TO_STRING_NOSLASHESCAPE
-                       | JSON_C_TO_STRING_NOSLASHESCAPE
+                    | JSON_C_TO_STRING_NOSLASHESCAPE
 #endif
-                   ));
+                ));
     }
 
     return VSI_STRDUP_VERBOSE(osRet);

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -181,6 +181,20 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource,
 
     CPLString m_osTilingScheme = "CUSTOM";
 
+    // To optimize reading table constraints
+    int m_nReadTableDefCount = 0;
+    std::vector<SQLSqliteMasterContent> m_aoSqliteMasterContent{};
+
+    void IncrementReadTableDefCounter()
+    {
+        m_nReadTableDefCount++;
+    }
+    int GetReadTableDefCounter() const
+    {
+        return m_nReadTableDefCount;
+    }
+    const std::vector<SQLSqliteMasterContent> &GetSqliteMasterContent();
+
     bool ComputeTileAndPixelShifts();
     bool AllocCachedTiles();
     bool InitRaster(GDALGeoPackageDataset *poParentDS, const char *pszTableName,

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -142,6 +142,7 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource,
     bool m_bHasEpochColumn =
         false;  // whether gpkg_spatial_ref_sys has a epoch column
     bool m_bNonSpatialTablesNonRegisteredInGpkgContentsFound = false;
+    mutable int m_nHasMetadataTables = -1;  // -1 = unknown, 0 = false, 1 = true
 
     CPLString m_osIdentifier{};
     bool m_bIdentifierAsCO = false;

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -3817,13 +3817,17 @@ const char *GDALGeoPackageDataset::CheckMetadataDomain(const char *pszDomain)
 
 bool GDALGeoPackageDataset::HasMetadataTables() const
 {
-    const int nCount =
-        SQLGetInteger(hDB,
-                      "SELECT COUNT(*) FROM sqlite_master WHERE name IN "
-                      "('gpkg_metadata', 'gpkg_metadata_reference') "
-                      "AND type IN ('table', 'view')",
-                      nullptr);
-    return nCount == 2;
+    if (m_nHasMetadataTables < 0)
+    {
+        const int nCount =
+            SQLGetInteger(hDB,
+                          "SELECT COUNT(*) FROM sqlite_master WHERE name IN "
+                          "('gpkg_metadata', 'gpkg_metadata_reference') "
+                          "AND type IN ('table', 'view')",
+                          nullptr);
+        m_nHasMetadataTables = nCount == 2;
+    }
+    return CPL_TO_BOOL(m_nHasMetadataTables);
 }
 
 /************************************************************************/
@@ -4574,7 +4578,9 @@ bool GDALGeoPackageDataset::CreateMetadataTables()
              "'http://www.geopackage.org/spec120/#extension_metadata', "
              "'read-write')";
 
-    return SQLCommand(hDB, osSQL) == OGRERR_NONE;
+    const bool bOK = SQLCommand(hDB, osSQL) == OGRERR_NONE;
+    m_nHasMetadataTables = bOK;
+    return bOK;
 }
 
 /************************************************************************/

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -10097,3 +10097,32 @@ bool GDALGeoPackageDataset::UpdateRelationship(
     LoadRelationships();
     return true;
 }
+
+/************************************************************************/
+/*                    GetSqliteMasterContent()                          */
+/************************************************************************/
+
+const std::vector<SQLSqliteMasterContent> &
+GDALGeoPackageDataset::GetSqliteMasterContent()
+{
+    if (m_aoSqliteMasterContent.empty())
+    {
+        auto oResultTable =
+            SQLQuery(hDB, "SELECT sql, type, tbl_name FROM sqlite_master");
+        if (oResultTable)
+        {
+            for (int rowCnt = 0; rowCnt < oResultTable->RowCount(); ++rowCnt)
+            {
+                SQLSqliteMasterContent row;
+                const char *pszSQL = oResultTable->GetValue(0, rowCnt);
+                row.osSQL = pszSQL ? pszSQL : "";
+                const char *pszType = oResultTable->GetValue(1, rowCnt);
+                row.osType = pszType ? pszType : "";
+                const char *pszTableName = oResultTable->GetValue(2, rowCnt);
+                row.osTableName = pszTableName ? pszTableName : "";
+                m_aoSqliteMasterContent.emplace_back(std::move(row));
+            }
+        }
+    }
+    return m_aoSqliteMasterContent;
+}

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -844,6 +844,8 @@ const char *OGRGeoPackageTableLayer::GetGeometryColumn()
 //
 OGRErr OGRGeoPackageTableLayer::ReadTableDefinition()
 {
+    m_poDS->IncrementReadTableDefCounter();
+
     bool bReadExtent = false;
     sqlite3 *poDb = m_poDS->GetDB();
     OGREnvelope oExtent;
@@ -1053,7 +1055,22 @@ OGRErr OGRGeoPackageTableLayer::ReadTableDefinition()
     std::set<std::string> uniqueFieldsUC;
     if (m_bIsTable)
     {
-        uniqueFieldsUC = SQLGetUniqueFieldUCConstraints(poDb, m_pszTableName);
+        // If resolving the layer definition of a substantial number of tables,
+        // fetch in a single time the content of the sqlite_master to increase
+        // performance
+        // Threshold somewhat arbitrary. If changing it, change
+        // ogr_gpkg.py::test_ogr_gpkg_unique_many_layers as well
+        constexpr int THRESHOLD_GET_SQLITE_MASTER = 10;
+        if (m_poDS->GetReadTableDefCounter() >= THRESHOLD_GET_SQLITE_MASTER)
+        {
+            uniqueFieldsUC = SQLGetUniqueFieldUCConstraints(
+                poDb, m_pszTableName, m_poDS->GetSqliteMasterContent());
+        }
+        else
+        {
+            uniqueFieldsUC =
+                SQLGetUniqueFieldUCConstraints(poDb, m_pszTableName);
+        }
     }
 
     /* Use the "PRAGMA TABLE_INFO()" call to get table definition */

--- a/ogr/ogrsf_frmts/sqlite/ogrsqliteutility.h
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqliteutility.h
@@ -37,6 +37,7 @@
 #include <set>
 #include <string>
 #include <memory>
+#include <vector>
 
 class SQLResult
 {
@@ -87,6 +88,16 @@ CPLString SQLUnescape(const char *pszVal);
 
 char **SQLTokenize(const char *pszSQL);
 
-std::set<std::string> SQLGetUniqueFieldUCConstraints(sqlite3 *poDb,
-                                                     const char *pszTableName);
+struct SQLSqliteMasterContent
+{
+    std::string osSQL{};
+    std::string osType{};
+    std::string osTableName{};
+};
+
+std::set<std::string> SQLGetUniqueFieldUCConstraints(
+    sqlite3 *poDb, const char *pszTableName,
+    const std::vector<SQLSqliteMasterContent> &sqliteMasterContent =
+        std::vector<SQLSqliteMasterContent>());
+
 #endif  // OGR_SQLITEUTILITY_H_INCLUDED


### PR DESCRIPTION
On the dataset of https://github.com/qgis/QGIS/issues/53525, this speeds up ogrinfo -json by a factor of 2.

Before:
```
$ time ogrinfo -json file_300_filled_layers.gpkg > out.json
real	0m0,565s
user	0m0,524s
sys	0m0,040s
```

After:
```
$ time ogrinfo -json file_300_filled_layers.gpkg > out.json
real	0m0,258s
user	0m0,217s
sys	0m0,041s
```