### PR TITLE
CI: add a coverage job

### DIFF
--- a/.github/workflows/coverage/build.sh
+++ b/.github/workflows/coverage/build.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -eu
+
+export CXXFLAGS="--coverage"
+export CFLAGS="--coverage"
+export LDFLAGS="-lgcov"
+
+cmake ${GDAL_SOURCE_DIR:=..} \
+    -DUSE_CCACHE=ON \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+    -DGDAL_USE_TIFF_INTERNAL=ON \
+    -DGDAL_USE_GEOTIFF_INTERNAL=ON \
+    -DECW_ROOT=/opt/libecwj2-3.3 \
+    -DMRSID_ROOT=/usr/local \
+    -DFileGDB_ROOT=/usr/local/FileGDB_API
+
+make -j$(nproc)

--- a/.github/workflows/coverage/test.sh
+++ b/.github/workflows/coverage/test.sh
@@ -14,10 +14,3 @@ lcov --remove gdal_filtered.info '*jpeg/libjpeg*' --output-file gdal_filtered.in
 lcov --remove gdal_filtered.info '*pcraster/libcsf*' --output-file gdal_filtered.info
 lcov --remove gdal_filtered.info '*googletest-src*' --output-file gdal_filtered.info
 genhtml -o ./coverage_html --ignore-errors source --num-spaces 2 gdal_filtered.info >/dev/null
-
-if test "${COVERALLS_REPO_TOKEN:-}" != ""; then
-  pip install cpp-coveralls
-  echo "Running git config --global --add safe.directory ${GDAL_SOURCE_DIR}"
-  git config --global --add safe.directory ${GDAL_SOURCE_DIR}
-  coveralls -n -l gdal_filtered.info
-fi

--- a/.github/workflows/coverage/test.sh
+++ b/.github/workflows/coverage/test.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+set -eu
+
+export OGR_HANA_CONNECTION_STRING='DRIVER=/usr/sap/hdbclient/libodbcHDB.so;HOST=917df316-4e01-4a10-be54-eac1b6ab15fb.hana.prod-us10.hanacloud.ondemand.com;PORT=443;USER=GDALCI;PASSWORD=u7t!Ukeugzq7'
+
+ctest -V -j $(nproc)
+
+lcov --directory . --capture --output-file gdal.info 2>/dev/null
+cp gdal.info gdal_filtered.info
+lcov --remove gdal_filtered.info '/usr/*' --output-file gdal_filtered.info
+lcov --remove gdal_filtered.info '/opt/*' --output-file gdal_filtered.info
+lcov --remove gdal_filtered.info '*jpeg/libjpeg*' --output-file gdal_filtered.info
+lcov --remove gdal_filtered.info '*pcraster/libcsf*' --output-file gdal_filtered.info
+lcov --remove gdal_filtered.info '*googletest-src*' --output-file gdal_filtered.info
+genhtml -o ./coverage_html --ignore-errors source --num-spaces 2 gdal_filtered.info >/dev/null
+
+if test "${COVERALLS_REPO_TOKEN:-}" != ""; then
+  pip install cpp-coveralls
+  echo "Running git config --global --add safe.directory ${GDAL_SOURCE_DIR}"
+  git config --global --add safe.directory ${GDAL_SOURCE_DIR}
+  coveralls -n -l gdal_filtered.info
+fi

--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -35,7 +35,7 @@ jobs:
       GDAL_SOURCE_DIR: /gdal # Directory to which workspace (source root) will be mounted inside container
 
     permissions:
-      contents: read
+      contents: write  # for Git to git push
       packages: write
 
     strategy:
@@ -81,6 +81,13 @@ jobs:
             travis_branch: ubuntu_2004
             container: ubuntu_20.04
             use_avx2: true
+            build_script: build.sh
+            test_script: test.sh
+
+          - name: Ubuntu 20.04, coverage
+            id: coverage
+            travis_branch: ubuntu_2004
+            container: ubuntu_20.04
             build_script: build.sh
             test_script: test.sh
 
@@ -248,6 +255,8 @@ jobs:
             -e GITHUB_WORKFLOW \
             -e TRAVIS \
             -e TRAVIS_BRANCH \
+            -e GDAL_SOURCE_DIR \
+            -e "COVERALLS_REPO_TOKEN=${{ secrets.COVERALLS_REPO_TOKEN }}" \
             --security-opt seccomp=unconfined \
             --add-host=host.docker.internal:host-gateway \
             --rm \
@@ -265,3 +274,45 @@ jobs:
         run: |
           docker push ${CONTAINER_NAME_FULL}
 
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@v3
+        if: ${{ matrix.id == 'coverage' }}
+        with:
+          name: coverage_index.html
+          path: build-${{ matrix.id }}/coverage_html/index.html
+
+      - name: Upload coverage artifacts
+        uses: actions/upload-artifact@v3
+        if: ${{ matrix.id == 'coverage' }}
+        with:
+          name: HTML
+          path: build-${{ matrix.id }}/coverage_html/*
+
+      - name: Deploy ssh key (for coverage)
+        if: ${{ matrix.id == 'coverage' && github.event_name == 'push' && github.ref_name == 'master' && github.repository == 'OSGeo/gdal' }}
+        shell: bash -l {0}
+        run: |
+          mkdir $HOME/.ssh && echo "${{ secrets.GDAL_TEST_COVERAGE_RESULTS_SSH_KEY }}" > $HOME/.ssh/id_rsa
+          chmod 700 $HOME/.ssh && chmod 600 $HOME/.ssh/id_rsa
+          ssh-keyscan -t rsa github.com >> $HOME/.ssh/known_hosts
+          eval `ssh-agent -s`
+          ssh-add $HOME/.ssh/id_rsa
+
+      - name: Deploy to https://github.com/OSGeo/gdal-test-coverage-results
+        if: ${{ matrix.id == 'coverage' && github.event_name == 'push' && github.ref_name == 'master' && github.repository == 'OSGeo/gdal' }}
+        shell: bash -l {0}
+        run: |
+          set -x
+          set -e
+          mkdir -p output_html/coverage_html
+          cp -r $GITHUB_WORKSPACE/build-${{ matrix.id }}/coverage_html/* output_html/coverage_html/
+          cd output_html
+          git init
+          git config user.email "gdal-test-coverage-results-bot@example.com"
+          git config user.name "GDAL test coverage results bot"
+          git remote add origin git@github.com:gdalautotest-coverage-results/gdalautotest-coverage-results.github.io
+          git remote -v
+          echo "Results of coverage of GDAL autotest See https://gdalautotest-coverage-results.github.io/coverage_html/index.html" > README.md
+          git add -A
+          git commit -m "Update with OSGeo/gdal commit $GITHUB_SHA"
+          git push -f origin master

--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -32,7 +32,6 @@ jobs:
       CONTAINER_NAME: gdal-deps
       CONTAINER_TAG: ${{ matrix.container }}-${{ github.base_ref || github.ref_name }}
       CACHE_CONTAINER_TAG: ${{ matrix.container }}-master
-      GDAL_SOURCE_DIR: /gdal # Directory to which workspace (source root) will be mounted inside container
 
     permissions:
       contents: write  # for Git to git push
@@ -206,7 +205,7 @@ jobs:
       - name: Build
         run: |
           if test -f ".github/workflows/${{ matrix.id }}/${{ matrix.build_script }}"; then
-            BUILD_CMD="${GDAL_SOURCE_DIR}/.github/workflows/${{ matrix.id }}/${{ matrix.build_script }}"
+            BUILD_CMD="$(pwd)/.github/workflows/${{ matrix.id }}/${{ matrix.build_script }}"
           else
             BUILD_CMD="sh -c 'cmake .. && make -j$(nproc)'"
           fi
@@ -214,9 +213,10 @@ jobs:
           mkdir -p build-${{ matrix.id }}
           docker run --name gdal-build \
             --rm \
-            -v $(pwd):/${GDAL_SOURCE_DIR}:rw \
+            -e "GDAL_SOURCE_DIR=$(pwd)" \
+            -v $(pwd):$(pwd):rw \
             -v ${{ github.workspace }}/.ccache:/root/.ccache:rw \
-            --workdir ${GDAL_SOURCE_DIR}/build-${{ matrix.id }} \
+            --workdir $(pwd)/build-${{ matrix.id }} \
             ${CONTAINER_NAME_FULL} \
             ${BUILD_CMD}
 
@@ -245,7 +245,7 @@ jobs:
           TRAVIS_BRANCH: ${{ matrix.travis_branch }}
         run: |
           if test -f ".github/workflows/${{ matrix.id }}/${{ matrix.test_script }}"; then
-            TEST_CMD="${GDAL_SOURCE_DIR}/.github/workflows/${{ matrix.id }}/${{ matrix.test_script }}"
+            TEST_CMD="$(pwd)/.github/workflows/${{ matrix.id }}/${{ matrix.test_script }}"
           else
             TEST_CMD="ctest -V -j $(nproc)"
           fi
@@ -255,16 +255,21 @@ jobs:
             -e GITHUB_WORKFLOW \
             -e TRAVIS \
             -e TRAVIS_BRANCH \
-            -e GDAL_SOURCE_DIR \
-            -e "COVERALLS_REPO_TOKEN=${{ secrets.COVERALLS_REPO_TOKEN }}" \
+            -e "GDAL_SOURCE_DIR=$(pwd)" \
             --security-opt seccomp=unconfined \
             --add-host=host.docker.internal:host-gateway \
             --rm \
-            -v $(pwd):${GDAL_SOURCE_DIR} \
-            --workdir ${GDAL_SOURCE_DIR}/build-${{ matrix.id }} \
+            -v $(pwd):$(pwd) \
+            --workdir $(pwd)/build-${{ matrix.id }} \
             ${CONTAINER_NAME_FULL} \
             ${TEST_CMD}
 
+      - name: Coveralls
+        uses: coverallsapp/github-action@v2
+        if: ${{ matrix.id == 'coverage' }}
+        with:
+          format: lcov
+          file: build-coverage/gdal_filtered.info
 
       - name: Push build environment
         if: github.event_name == 'push'

--- a/.github/workflows/ubuntu_20.04/Dockerfile.ci
+++ b/.github/workflows/ubuntu_20.04/Dockerfile.ci
@@ -20,6 +20,7 @@ RUN apt-get update -y \
     curl \
     git \
     gnupg \
+    lcov \
     libarmadillo-dev \
     libblosc-dev \
     libboost-dev \


### PR DESCRIPTION
For push operations on master, pushes to https://gdalautotest-coverage-results.github.io/coverage_html/index.html
(was tested on my fork : https://github.com/rouault/gdal/actions/runs/5379543312/jobs/9760905648 )

Pull requests and pushes should also appear at https://coveralls.io/github/OSGeo/gdal