### PR TITLE
autotest: remove global setting of ECW_DO_NOT_RESOLVE_DATUM_PROJECTION

### DIFF
--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -29,9 +29,6 @@ collect_ignore = [
 ]
 collect_ignore_glob = ["pymod/*.py"]
 
-# we set ECW to not resolve projection and datum strings to get 3.x behavior.
-gdal.SetConfigOption("ECW_DO_NOT_RESOLVE_DATUM_PROJECTION", "YES")
-
 if "APPLY_LOCALE" in os.environ:
     import locale
 


### PR DESCRIPTION
## What does this PR do?

Removes a global configuration option setting from `conftest.py`. It is already set where needed at https://github.com/OSGeo/gdal/blob/6e9103bd5acb1ff8da305c4e77fa30335ffa3b70/autotest/gdrivers/ecw.py#L116