### PR TITLE
Python bindings: Invalidate more band, layer refs

### DIFF
--- a/autotest/gcore/basic_test.py
+++ b/autotest/gcore/basic_test.py
@@ -790,3 +790,26 @@ def test_band_use_after_dataset_close_2():
     # Make sure ds.__exit__() has invalidated "band" so we don't crash here
     with pytest.raises(Exception):
         band.Checksum()
+
+
+def test_mask_band_use_after_dataset_close():
+    with gdal.Open("data/byte.tif") as ds:
+        m1 = ds.GetRasterBand(1).GetMaskBand()
+        m2 = m1.GetMaskBand()
+
+    # Make sure ds.__exit__() invalidation has propagated to mask bands
+    with pytest.raises(Exception):
+        m1.Checksum()
+
+    with pytest.raises(Exception):
+        m2.Checksum()
+
+
+def test_ovr_band_use_after_dataset_close():
+    with gdal.Open("data/byte_with_ovr.tif") as ds:
+        ovr = ds.GetRasterBand(1).GetOverview(1)
+
+    # Make sure ds.__exit__() invalidation has propagated to overviews
+
+    with pytest.raises(Exception):
+        ovr.Checksum()

--- a/autotest/ogr/ogr_basic_test.py
+++ b/autotest/ogr/ogr_basic_test.py
@@ -969,10 +969,15 @@ def test_layer_use_after_datasource_close_3(tmp_path):
 
     with drv.CreateDataSource(fname) as ds:
         lyr = ds.CreateLayer("test")
+        lyr2 = ds.CopyLayer(lyr, "test2")
 
     # Make sure ds.__exit__() has invalidated "lyr" so we don't crash here
     with pytest.raises(Exception):
         lyr.GetFeatureCount()
+
+    # Make sure ds.__exit__() has invalidated "lyr2" so we don't crash here
+    with pytest.raises(Exception):
+        lyr2.GetFeatureCount()
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_basic_test.py
+++ b/autotest/ogr/ogr_basic_test.py
@@ -962,6 +962,19 @@ def test_layer_use_after_datasource_close_2():
         lyr.GetFeatureCount()
 
 
+def test_layer_use_after_datasource_close_3(tmp_path):
+    fname = str(tmp_path / "test.shp")
+
+    drv = ogr.GetDriverByName("ESRI Shapefile")
+
+    with drv.CreateDataSource(fname) as ds:
+        lyr = ds.CreateLayer("test")
+
+    # Make sure ds.__exit__() has invalidated "lyr" so we don't crash here
+    with pytest.raises(Exception):
+        lyr.GetFeatureCount()
+
+
 ###############################################################################
 # cleanup
 

--- a/swig/include/python/ogr_python.i
+++ b/swig/include/python/ogr_python.i
@@ -150,36 +150,29 @@ def _WarnIfUserHasNotSpecifiedIfUsingExceptions():
             for lyr in self._layer_references:
                 lyr.this = None
 
+
+    def _add_layer_ref(self, lyr):
+        if not lyr:
+            return
+
+        if not hasattr(self, '_layer_references'):
+            import weakref
+
+            self._layer_references = weakref.WeakSet()
+
+        self._layer_references.add(lyr)
   }
 
-%feature("shadow") GetLayerByName %{
-    def GetLayerByName(self, name):
-        lyr = $action(self, name)
-
-        if not hasattr(self, '_layer_references'):
-            import weakref
-
-            self._layer_references = weakref.WeakSet()
-
-        if lyr is not None:
-            self._layer_references.add(lyr)
-
-        return lyr
+%feature("pythonappend") GetLayerByName %{
+    self._add_layer_ref(val)
 %}
 
-%feature("shadow") GetLayerByIndex %{
-    def GetLayerByIndex(self, idx):
-        lyr = $action(self, idx)
+%feature("pythonappend") GetLayerByIndex %{
+    self._add_layer_ref(val)
+%}
 
-        if not hasattr(self, '_layer_references'):
-            import weakref
-
-            self._layer_references = weakref.WeakSet()
-
-        if lyr is not None:
-            self._layer_references.add(lyr)
-
-        return lyr
+%feature("pythonappend") CreateLayer %{
+    self._add_layer_ref(val)
 %}
 
 %feature("shadow") DeleteLayer %{

--- a/swig/include/python/ogr_python.i
+++ b/swig/include/python/ogr_python.i
@@ -175,6 +175,10 @@ def _WarnIfUserHasNotSpecifiedIfUsingExceptions():
     self._add_layer_ref(val)
 %}
 
+%feature("pythonappend") CopyLayer %{
+    self._add_layer_ref(val)
+%}
+
 %feature("shadow") DeleteLayer %{
     def DeleteLayer(self, value) -> "OGRErr":
         """


### PR DESCRIPTION
## What does this PR do?

Continues the pattern set in #7965 where closing a `Dataset` or `DataSource` invalidates associated `Band` and `Layer` objects, covering mask bands and overview bands, as well as layers created with `CreateLayer` and `CopyLayer`.

## What are related issues/pull requests?

#7965

## Tasklist

 - [x] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
