### PR TITLE
autotest: Remove some inter-test dependencies

### DIFF
--- a/autotest/gcore/colortable.py
+++ b/autotest/gcore/colortable.py
@@ -31,33 +31,25 @@
 ###############################################################################
 
 
-import gdaltest
 import pytest
 
 from osgeo import gdal
 
 ###############################################################################
-# Create a color table.
+# Create a color table and verify its contents
 
 
 def test_colortable_1():
 
-    gdaltest.test_ct_data = [(255, 0, 0), (0, 255, 0), (0, 0, 255), (255, 255, 255, 0)]
+    test_ct_data = [(255, 0, 0), (0, 255, 0), (0, 0, 255), (255, 255, 255, 0)]
 
-    gdaltest.test_ct = gdal.ColorTable()
-    for i in range(len(gdaltest.test_ct_data)):
-        gdaltest.test_ct.SetColorEntry(i, gdaltest.test_ct_data[i])
+    test_ct = gdal.ColorTable()
+    for i, color in enumerate(test_ct_data):
+        test_ct.SetColorEntry(i, color)
 
-
-###############################################################################
-# verify contents.
-
-
-def test_colortable_2():
-
-    for i in range(len(gdaltest.test_ct_data)):
-        g_data = gdaltest.test_ct.GetColorEntry(i)
-        o_data = gdaltest.test_ct_data[i]
+    for i in range(len(test_ct_data)):
+        g_data = test_ct.GetColorEntry(i)
+        o_data = test_ct_data[i]
 
         for j in range(4):
             if len(o_data) <= j:
@@ -85,11 +77,3 @@ def test_colortable_3():
     assert ct.GetColorEntry(0) == (255, 0, 0, 255)
 
     assert ct.GetColorEntry(255) == (0, 0, 255, 255)
-
-
-###############################################################################
-# Cleanup.
-
-
-def test_colortable_cleanup():
-    gdaltest.test_ct = None

--- a/autotest/gcore/gdal_stats.py
+++ b/autotest/gcore/gdal_stats.py
@@ -43,20 +43,14 @@ from osgeo import gdal
 
 def test_stats_nan_1():
 
-    gdaltest.gtiff_drv = gdal.GetDriverByName("GTiff")
-    if gdaltest.gtiff_drv is None:
-        pytest.skip()
-
     stats = (50.0, 58.0, 54.0, 2.5819888974716)
 
     shutil.copyfile("data/nan32.tif", "tmp/nan32.tif")
 
     t = gdaltest.GDALTest("GTiff", "tmp/nan32.tif", 1, 874, filename_absolute=1)
-    ret = t.testOpen(check_approx_stat=stats, check_stat=stats)
+    t.testOpen(check_approx_stat=stats, check_stat=stats)
 
     gdal.GetDriverByName("GTiff").Delete("tmp/nan32.tif")
-
-    return ret
 
 
 ###############################################################################
@@ -65,29 +59,22 @@ def test_stats_nan_1():
 
 def test_stats_nan_2():
 
-    if gdaltest.gtiff_drv is None:
-        pytest.skip()
-
     stats = (50.0, 58.0, 54.0, 2.5819888974716)
 
     shutil.copyfile("data/nan64.tif", "tmp/nan64.tif")
 
     t = gdaltest.GDALTest("GTiff", "tmp/nan64.tif", 1, 4414, filename_absolute=1)
-    ret = t.testOpen(check_approx_stat=stats, check_stat=stats)
+    t.testOpen(check_approx_stat=stats, check_stat=stats)
 
     gdal.GetDriverByName("GTiff").Delete("tmp/nan64.tif")
-
-    return ret
 
 
 ###############################################################################
 # Test stats on signed byte (#3151)
 
 
+@pytest.mark.require_driver("HFA")
 def test_stats_signedbyte():
-
-    if gdaltest.gtiff_drv is None:
-        pytest.skip()
 
     stats = (-128.0, 127.0, -0.2, 80.64)
 
@@ -96,11 +83,9 @@ def test_stats_signedbyte():
     t = gdaltest.GDALTest(
         "HFA", "tmp/stats_signed_byte.img", 1, 11, filename_absolute=1
     )
-    ret = t.testOpen(check_approx_stat=stats, check_stat=stats, skip_checksum=1)
+    t.testOpen(check_approx_stat=stats, check_stat=stats, skip_checksum=1)
 
     gdal.GetDriverByName("HFA").Delete("tmp/stats_signed_byte.img")
-
-    return ret
 
 
 ###############################################################################
@@ -165,13 +150,14 @@ def test_stats_approx_nodata():
 # Test read and copy of dataset with nan as nodata value (#3576)
 
 
+@pytest.mark.require_driver("GTiff")
 def test_stats_nan_3():
 
     src_ds = gdal.Open("data/nan32_nodata.tif")
     nodata = src_ds.GetRasterBand(1).GetNoDataValue()
     assert gdaltest.isnan(nodata), "expected nan, got %f" % nodata
 
-    out_ds = gdaltest.gtiff_drv.CreateCopy("tmp/nan32_nodata.tif", src_ds)
+    out_ds = gdal.GetDriverByName("GTiff").CreateCopy("tmp/nan32_nodata.tif", src_ds)
     del out_ds
 
     src_ds = None
@@ -185,7 +171,7 @@ def test_stats_nan_3():
     nodata = ds.GetRasterBand(1).GetNoDataValue()
     ds = None
 
-    gdaltest.gtiff_drv.Delete("tmp/nan32_nodata.tif")
+    gdal.GetDriverByName("GTiff").Delete("tmp/nan32_nodata.tif")
     assert gdaltest.isnan(nodata), "expected nan, got %f" % nodata
 
 

--- a/autotest/gcore/hfa_write.py
+++ b/autotest/gcore/hfa_write.py
@@ -134,12 +134,15 @@ def test_hfa_write_nd_invalid():
 # Test updating .rrd overviews in place (#2524).
 
 
-def test_hfa_update_overviews():
+def test_hfa_update_overviews(tmp_path):
 
-    shutil.copyfile("data/small_ov.img", "tmp/small.img")
-    shutil.copyfile("data/small_ov.rrd", "tmp/small.rrd")
+    img_path = str(tmp_path / "small.img")
+    rrd_path = str(tmp_path / "small.rrd")
 
-    ds = gdal.Open("tmp/small.img", gdal.GA_Update)
+    shutil.copyfile("data/small_ov.img", img_path)
+    shutil.copyfile("data/small_ov.rrd", rrd_path)
+
+    ds = gdal.Open(img_path, gdal.GA_Update)
     result = ds.BuildOverviews(overviewlist=[2])
 
     assert result == 0, "BuildOverviews() failed."
@@ -150,9 +153,15 @@ def test_hfa_update_overviews():
 # Test cleaning external overviews.
 
 
-def test_hfa_clean_external_overviews():
+def test_hfa_clean_external_overviews(tmp_path):
 
-    ds = gdal.Open("tmp/small.img", gdal.GA_Update)
+    img_path = str(tmp_path / "small.img")
+    rrd_path = str(tmp_path / "small.rrd")
+
+    shutil.copyfile("data/small_ov.img", img_path)
+    shutil.copyfile("data/small_ov.rrd", rrd_path)
+
+    ds = gdal.Open(img_path, gdal.GA_Update)
     result = ds.BuildOverviews(overviewlist=[])
 
     assert result == 0, "BuildOverviews() failed."
@@ -160,13 +169,13 @@ def test_hfa_clean_external_overviews():
     assert ds.GetRasterBand(1).GetOverviewCount() == 0, "Overviews still exist."
 
     ds = None
-    ds = gdal.Open("tmp/small.img")
+    ds = gdal.Open(img_path)
     assert ds.GetRasterBand(1).GetOverviewCount() == 0, "Overviews still exist."
     ds = None
 
-    assert not os.path.exists("tmp/small.rrd")
+    assert not os.path.exists(rrd_path)
 
-    gdal.GetDriverByName("HFA").Delete("tmp/small.img")
+    gdal.GetDriverByName("HFA").Delete(img_path)
 
 
 ###############################################################################

--- a/autotest/gcore/vsizip.py
+++ b/autotest/gcore/vsizip.py
@@ -683,6 +683,7 @@ def test_vsizip_create_zip64():
 
 
 @pytest.mark.slow()
+@gdaltest.disable_exceptions()
 def test_vsizip_create_zip64_stream_larger_than_4G():
 
     zip_name = "tmp/vsizip_create_zip64_stream_larger_than_4G.zip"

--- a/autotest/ogr/ogr_sql_sqlite.py
+++ b/autotest/ogr/ogr_sql_sqlite.py
@@ -74,6 +74,19 @@ def require_ogr_sql_sqlite():
     ds.ReleaseResultSet(sql_lyr)
     assert sql_lyr is not None
 
+    with gdaltest.error_handler():
+        ds = ogr.GetDriverByName("SQLite").CreateDataSource(
+            "/vsimem/foo.db", options=["SPATIALITE=YES"]
+        )
+        ogrtest.has_spatialite = ds is not None
+        if ogrtest.has_spatialite:
+            sql_lyr = ds.ExecuteSQL("SELECT spatialite_version()")
+            feat = sql_lyr.GetNextFeature()
+            gdaltest.spatialite_version = feat.GetFieldAsString(0)
+            ds.ReleaseResultSet(sql_lyr)
+        ds = None
+        gdal.Unlink("/vsimem/foo.db")
+
 
 ###############################################################################
 # Tests that don't involve geometry
@@ -587,20 +600,6 @@ def test_ogr_sql_sqlite_4():
 
 
 def test_ogr_sql_sqlite_5():
-
-    with gdaltest.error_handler():
-        ds = ogr.GetDriverByName("SQLite").CreateDataSource(
-            "/vsimem/foo.db", options=["SPATIALITE=YES"]
-        )
-        ogrtest.has_spatialite = ds is not None
-        if ogrtest.has_spatialite:
-            sql_lyr = ds.ExecuteSQL("SELECT spatialite_version()")
-            feat = sql_lyr.GetNextFeature()
-            gdaltest.spatialite_version = feat.GetFieldAsString(0)
-            ds.ReleaseResultSet(sql_lyr)
-        ds = None
-        gdal.Unlink("/vsimem/foo.db")
-
     if ogrtest.has_spatialite is False:
         pytest.skip("Spatialite not available")
 
@@ -625,7 +624,7 @@ def test_ogr_sql_sqlite_5():
 def test_ogr_sql_sqlite_6():
 
     if ogrtest.has_spatialite is False:
-        pytest.skip()
+        pytest.skip("Spatialite not available")
 
     with gdal.config_option("OGR_SQLITE_DIALECT_USE_SPATIALITE", "NO"):
 
@@ -1011,7 +1010,7 @@ def ogr_sql_sqlite_14_and_15(sql):
 def test_ogr_sql_sqlite_14():
 
     if ogrtest.has_spatialite is False:
-        pytest.skip()
+        pytest.skip("Spatialite not available")
 
     sql = (
         "SELECT intfield, intfield2 FROM my_layer, my_layer2 WHERE "
@@ -1030,7 +1029,7 @@ def test_ogr_sql_sqlite_14():
 def test_ogr_sql_sqlite_15():
 
     if ogrtest.has_spatialite is False:
-        pytest.skip()
+        pytest.skip("Spatialite not available")
 
     if int(gdaltest.spatialite_version[0 : gdaltest.spatialite_version.find(".")]) < 3:
         pytest.skip()

--- a/autotest/ogr/ogr_sql_test.py
+++ b/autotest/ogr/ogr_sql_test.py
@@ -135,28 +135,33 @@ def test_ogr_sql_invalid_release_result_set(use_gdal):
         ds.ReleaseResultSet(lyr)
 
 
+@pytest.fixture
+def data_ds():
+    with ogr.Open("data") as ds:
+        yield ds
+
+
 ###############################################################################
 # Test a simple query with a where clause.
 
 
-def test_ogr_sql_1():
-    gdaltest.ds = ogr.Open("data")
-    gdaltest.lyr = gdaltest.ds.GetLayerByName("poly")
+def test_ogr_sql_1(data_ds):
+    lyr = data_ds.GetLayerByName("poly")
 
-    gdaltest.lyr.SetAttributeFilter("eas_id < 167")
+    lyr.SetAttributeFilter("eas_id < 167")
 
-    count = gdaltest.lyr.GetFeatureCount()
+    count = lyr.GetFeatureCount()
     assert count == 3, (
         "Got wrong count with GetFeatureCount() - %d, expecting 3" % count
     )
 
-    gdaltest.lyr.SetAttributeFilter("")
-    count = gdaltest.lyr.GetFeatureCount()
+    lyr.SetAttributeFilter("")
+    count = lyr.GetFeatureCount()
     assert count == 10, (
         "Got wrong count with GetFeatureCount() - %d, expecting 10" % count
     )
 
-    with gdaltest.ds.ExecuteSQL("SELECT * FROM poly WHERE eas_id < 167") as sql_lyr:
+    with data_ds.ExecuteSQL("SELECT * FROM poly WHERE eas_id < 167") as sql_lyr:
         assert sql_lyr.GetFeatureCount(force=0) < 0
         assert sql_lyr.GetFeatureCount(force=1) == 3
 
@@ -165,11 +170,11 @@ def test_ogr_sql_1():
 # Test DISTINCT handling
 
 
-def test_ogr_sql_2():
+def test_ogr_sql_2(data_ds):
 
     expect = [168, 169, 166, 158, 165]
 
-    with gdaltest.ds.ExecuteSQL(
+    with data_ds.ExecuteSQL(
         "select distinct eas_id from poly where eas_id < 170"
     ) as sql_lyr:
 
@@ -180,11 +185,11 @@ def test_ogr_sql_2():
 # Test ORDER BY handling
 
 
-def test_ogr_sql_3():
+def test_ogr_sql_3(data_ds):
 
     expect = [158, 165, 166, 168, 169]
 
-    with gdaltest.ds.ExecuteSQL(
+    with data_ds.ExecuteSQL(
         "select distinct eas_id from poly where eas_id < 170 order by eas_id"
     ) as sql_lyr:
 
@@ -195,11 +200,11 @@ def test_ogr_sql_3():
 # Test ORDER BY DESC handling
 
 
-def test_ogr_sql_3_desc():
+def test_ogr_sql_3_desc(data_ds):
 
     expect = [169, 168, 166, 165, 158]
 
-    with gdaltest.ds.ExecuteSQL(
+    with data_ds.ExecuteSQL(
         "select distinct eas_id from poly where eas_id < 170 order by eas_id desc"
     ) as sql_lyr:
 
@@ -210,11 +215,11 @@ def test_ogr_sql_3_desc():
 # Test DISTINCT and ORDER BY on strings.
 
 
-def test_ogr_sql_4():
+def test_ogr_sql_4(data_ds):
 
     expect = ["_158_", "_165_", "_166_", "_168_", "_170_", "_171_", "_179_"]
 
-    with gdaltest.ds.ExecuteSQL(
+    with data_ds.ExecuteSQL(
         "select distinct name from idlink order by name asc"
     ) as sql_lyr:
 
@@ -225,9 +230,9 @@ def test_ogr_sql_4():
 # Test column functions.
 
 
-def test_ogr_sql_5():
+def test_ogr_sql_5(data_ds):
 
-    with gdaltest.ds.ExecuteSQL(
+    with data_ds.ExecuteSQL(
         "select max(eas_id), min(eas_id), avg(eas_id), sum(eas_id), count(eas_id) from idlink"
     ) as sql_lyr:
         feat = sql_lyr.GetNextFeature()
@@ -242,11 +247,11 @@ def test_ogr_sql_5():
 # Test simple COUNT() function.
 
 
-def test_ogr_sql_6():
+def test_ogr_sql_6(data_ds):
 
     expect = [10]
 
-    with gdaltest.ds.ExecuteSQL("select count(*) from poly") as sql_lyr:
+    with data_ds.ExecuteSQL("select count(*) from poly") as sql_lyr:
         ogrtest.check_features_against_list(sql_lyr, "count_*", expect)
 
 
@@ -254,11 +259,11 @@ def test_ogr_sql_6():
 # Verify that selecting the FID works properly.
 
 
-def test_ogr_sql_7():
+def test_ogr_sql_7(data_ds):
 
     expect = [7, 8]
 
-    with gdaltest.ds.ExecuteSQL(
+    with data_ds.ExecuteSQL(
         "select eas_id, fid from poly where eas_id in (158,165)"
     ) as sql_lyr:
 
@@ -269,13 +274,11 @@ def test_ogr_sql_7():
 # Verify that wildcard expansion works properly.
 
 
-def test_ogr_sql_8():
+def test_ogr_sql_8(data_ds):
 
     expect = ["35043369", "35043408"]
 
-    with gdaltest.ds.ExecuteSQL(
-        "select * from poly where eas_id in (158,165)"
-    ) as sql_lyr:
+    with data_ds.ExecuteSQL("select * from poly where eas_id in (158,165)") as sql_lyr:
         ogrtest.check_features_against_list(sql_lyr, "PRFEDEA", expect)
 
 
@@ -283,11 +286,11 @@ def test_ogr_sql_8():
 # Verify that quoted table names work.
 
 
-def test_ogr_sql_9():
+def test_ogr_sql_9(data_ds):
 
     expect = ["35043369", "35043408"]
 
-    with gdaltest.ds.ExecuteSQL(
+    with data_ds.ExecuteSQL(
         'select * from "poly" where eas_id in (158,165)'
     ) as sql_lyr:
         ogrtest.check_features_against_list(sql_lyr, "PRFEDEA", expect)
@@ -377,22 +380,11 @@ def test_ogr_sql_12():
 # Verify selection of, and on ogr_geometry.
 
 
-def test_ogr_sql_13():
+def test_ogr_sql_13(data_ds):
 
-    expect = [
-        "POLYGON",
-        "POLYGON",
-        "POLYGON",
-        "POLYGON",
-        "POLYGON",
-        "POLYGON",
-        "POLYGON",
-        "POLYGON",
-        "POLYGON",
-        "POLYGON",
-    ]
+    expect = ["POLYGON"] * 10
 
-    with gdaltest.ds.ExecuteSQL(
+    with data_ds.ExecuteSQL(
         "select ogr_geometry from poly where ogr_geometry = 'POLYGON'"
     ) as sql_lyr:
 
@@ -422,11 +414,11 @@ def test_ogr_sql_14():
 # Verify that selecting with filtering by FID works properly.
 
 
-def test_ogr_sql_15():
+def test_ogr_sql_15(data_ds):
 
     expect = [7]
 
-    with gdaltest.ds.ExecuteSQL(
+    with data_ds.ExecuteSQL(
         "select fid,eas_id,prfedea from poly where fid = %d" % expect[0]
     ) as sql_lyr:
 
@@ -480,10 +472,10 @@ def test_ogr_sql_17():
 # Test empty request string
 
 
-def test_ogr_sql_19():
+def test_ogr_sql_19(data_ds):
 
     with gdaltest.error_handler():
-        assert gdaltest.ds.ExecuteSQL("") is None
+        assert data_ds.ExecuteSQL("") is None
 
 
 ###############################################################################
@@ -865,11 +857,11 @@ def test_ogr_sql_29():
 # Verify a select mixing a count(*) with something else works without errors
 
 
-def test_ogr_sql_30():
+def test_ogr_sql_30(data_ds):
 
     gdal.ErrorReset()
 
-    with gdaltest.ds.ExecuteSQL("select min(eas_id), count(*) from poly") as sql_lyr:
+    with data_ds.ExecuteSQL("select min(eas_id), count(*) from poly") as sql_lyr:
         feat = sql_lyr.GetNextFeature()
         val_count = feat.GetField(1)
 
@@ -882,13 +874,11 @@ def test_ogr_sql_30():
 # Regression test for #4022
 
 
-def test_ogr_sql_31():
+def test_ogr_sql_31(data_ds):
 
     gdal.ErrorReset()
 
-    with gdaltest.ds.ExecuteSQL(
-        "select min(eas_id) from poly where area = 0"
-    ) as sql_lyr:
+    with data_ds.ExecuteSQL("select min(eas_id) from poly where area = 0") as sql_lyr:
 
         feat = sql_lyr.GetNextFeature()
         val = feat.GetField(0)
@@ -902,11 +892,11 @@ def test_ogr_sql_31():
 # Regression test for #4022 (same as above, but with dialect = 'OGRSQL')
 
 
-def test_ogr_sql_32():
+def test_ogr_sql_32(data_ds):
 
     gdal.ErrorReset()
 
-    with gdaltest.ds.ExecuteSQL(
+    with data_ds.ExecuteSQL(
         "select min(eas_id) from poly where area = 0", dialect="OGRSQL"
     ) as sql_lyr:
 
@@ -985,9 +975,9 @@ def test_ogr_sql_33():
 # Test implicit conversion from string to numeric (#4259)
 
 
-def test_ogr_sql_34():
+def test_ogr_sql_34(data_ds):
 
-    with gdaltest.ds.ExecuteSQL(
+    with data_ds.ExecuteSQL(
         "select count(*) from poly where eas_id in ('165')"
     ) as sql_lyr:
         feat = sql_lyr.GetNextFeature()
@@ -997,7 +987,7 @@ def test_ogr_sql_34():
 
     with gdaltest.error_handler():
         assert (
-            gdaltest.ds.ExecuteSQL("select count(*) from poly where eas_id in ('a165')")
+            data_ds.ExecuteSQL("select count(*) from poly where eas_id in ('a165')")
             is None
         )
 
@@ -1006,12 +996,12 @@ def test_ogr_sql_34():
 # Test huge SQL queries (#4262)
 
 
-def test_ogr_sql_35():
+def test_ogr_sql_35(data_ds):
 
     cols = "area"
     for _ in range(10):
         cols = cols + "," + cols
-    with gdaltest.ds.ExecuteSQL("select %s from poly" % cols) as sql_lyr:
+    with data_ds.ExecuteSQL("select %s from poly" % cols) as sql_lyr:
         count_cols = sql_lyr.GetLayerDefn().GetFieldCount()
 
     assert count_cols == 1024
@@ -1131,9 +1121,9 @@ def test_ogr_sql_37():
 # Test "SELECT MAX(OGR_GEOM_AREA) FROM XXXX" (#4633)
 
 
-def test_ogr_sql_38():
+def test_ogr_sql_38(data_ds):
 
-    with gdaltest.ds.ExecuteSQL("SELECT MAX(OGR_GEOM_AREA) FROM poly") as sql_lyr:
+    with data_ds.ExecuteSQL("SELECT MAX(OGR_GEOM_AREA) FROM poly") as sql_lyr:
         feat = sql_lyr.GetNextFeature()
         val = feat.GetFieldAsDouble(0)
         assert val == pytest.approx(1634833.39062, abs=1e-5)
@@ -1143,9 +1133,9 @@ def test_ogr_sql_38():
 # Test ORDER BY on a float special field
 
 
-def test_ogr_sql_39():
+def test_ogr_sql_39(data_ds):
 
-    with gdaltest.ds.ExecuteSQL("SELECT * FROM poly ORDER BY OGR_GEOM_AREA") as sql_lyr:
+    with data_ds.ExecuteSQL("SELECT * FROM poly ORDER BY OGR_GEOM_AREA") as sql_lyr:
         feat = sql_lyr.GetNextFeature()
         val = feat.GetFieldAsDouble(0)
         assert val == pytest.approx(5268.813, abs=1e-5)
@@ -1155,9 +1145,9 @@ def test_ogr_sql_39():
 # Test ORDER BY on a int special field
 
 
-def test_ogr_sql_40():
+def test_ogr_sql_40(data_ds):
 
-    with gdaltest.ds.ExecuteSQL("SELECT * FROM poly ORDER BY FID DESC") as sql_lyr:
+    with data_ds.ExecuteSQL("SELECT * FROM poly ORDER BY FID DESC") as sql_lyr:
         feat = sql_lyr.GetNextFeature()
         assert feat.GetFID() == 9
 
@@ -1166,9 +1156,9 @@ def test_ogr_sql_40():
 # Test ORDER BY on a string special field
 
 
-def test_ogr_sql_41():
+def test_ogr_sql_41(data_ds):
 
-    with gdaltest.ds.ExecuteSQL("SELECT * FROM poly ORDER BY OGR_GEOMETRY") as sql_lyr:
+    with data_ds.ExecuteSQL("SELECT * FROM poly ORDER BY OGR_GEOMETRY") as sql_lyr:
         feat = sql_lyr.GetNextFeature()
         assert feat.GetFID() == 0
 
@@ -1177,15 +1167,15 @@ def test_ogr_sql_41():
 # Test comparing to empty string
 
 
-def test_ogr_sql_42():
+def test_ogr_sql_42(data_ds):
 
-    lyr = gdaltest.ds.GetLayerByName("poly")
+    lyr = data_ds.GetLayerByName("poly")
     lyr.SetAttributeFilter("prfedea <> ''")
     feat = lyr.GetNextFeature()
     lyr.SetAttributeFilter(None)
     assert feat is not None
 
-    with gdaltest.ds.ExecuteSQL("SELECT * FROM poly WHERE prfedea <> ''") as sql_lyr:
+    with data_ds.ExecuteSQL("SELECT * FROM poly WHERE prfedea <> ''") as sql_lyr:
         assert sql_lyr.GetNextFeature() is not None
 
 
@@ -1193,10 +1183,10 @@ def test_ogr_sql_42():
 # Test escape sequences
 
 
-def test_ogr_sql_43():
+def test_ogr_sql_43(data_ds):
 
     sql = "SELECT '\"' as a, '\\'' as b, '''' as c FROM poly"
-    with gdaltest.ds.ExecuteSQL(sql) as sql_lyr:
+    with data_ds.ExecuteSQL(sql) as sql_lyr:
         feat = sql_lyr.GetNextFeature()
         assert feat["a"] == '"'
         assert feat["b"] == "'"
@@ -1207,7 +1197,7 @@ def test_ogr_sql_43():
 # Test hstore_get_value()
 
 
-def test_ogr_sql_44():
+def test_ogr_sql_44(data_ds):
 
     # Invalid parameters
     for sql in [
@@ -1215,7 +1205,7 @@ def test_ogr_sql_44():
         "SELECT hstore_get_value(1, 1) FROM poly",
     ]:
         with gdaltest.error_handler():
-            sql_lyr = gdaltest.ds.ExecuteSQL(sql)
+            sql_lyr = data_ds.ExecuteSQL(sql)
         assert sql_lyr is None, sql
 
     # Invalid hstore syntax or empty result
@@ -1235,7 +1225,7 @@ def test_ogr_sql_44():
         "SELECT hstore_get_value('\"a\" => \"', 'a') FROM poly",
         "SELECT hstore_get_value('\"a\" => \"\" z', 'a') FROM poly",
     ]:
-        with gdaltest.ds.ExecuteSQL(sql) as sql_lyr:
+        with data_ds.ExecuteSQL(sql) as sql_lyr:
             f = sql_lyr.GetNextFeature()
             assert not f.IsFieldSetAndNotNull(0), sql
 
@@ -1251,7 +1241,7 @@ def test_ogr_sql_44():
         ("SELECT hstore_get_value(' \"a\" => \"b\" ', 'a') FROM poly", "b"),
         ('SELECT hstore_get_value(\' "a\\"b" => "b" \', \'a"b\') FROM poly', "b"),
     ]:
-        with gdaltest.ds.ExecuteSQL(sql) as sql_lyr:
+        with data_ds.ExecuteSQL(sql) as sql_lyr:
             f = sql_lyr.GetNextFeature()
             assert f.GetField(0) == expected, sql
 
@@ -1398,7 +1388,7 @@ def test_ogr_sql_48():
 # Test arithmetic expressions
 
 
-def test_ogr_sql_49():
+def test_ogr_sql_49(data_ds):
 
     # expressions and expected result
     expressions = [
@@ -1414,7 +1404,7 @@ def test_ogr_sql_49():
     ]
 
     for expression, expected in expressions:
-        with gdaltest.ds.ExecuteSQL(
+        with data_ds.ExecuteSQL(
             "select {} as result from poly limit 1".format(expression)
         ) as sql_lyr:
             ogrtest.check_features_against_list(sql_lyr, "result", [expected])
@@ -1523,11 +1513,3 @@ def test_ogr_sql_attribute_filter_on_top_of_non_forward_where_clause(dialect):
     ) as sql_lyr:
         sql_lyr.SetAttributeFilter("0")
         assert sql_lyr.GetFeatureCount() == 0
-
-
-###############################################################################
-
-
-def test_ogr_sql_cleanup():
-    gdaltest.lyr = None
-    gdaltest.ds = None


### PR DESCRIPTION
## What does this PR do?

Refactors some test files to remove dependencies between test functions.

I'm wondering if it would be a good idea to mark test files with no inter-test dependencies (`pytestmark = pytest.mark.independent` ?) and then use `pytest --random-order` for these tests in one of the CI configurations.

## What are related issues/pull requests?

#4407

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
