### PR TITLE
OpenFileGDB: add support for DateTime field domains

### DIFF
--- a/apps/ogrinfo_lib.cpp
+++ b/apps/ogrinfo_lib.cpp
@@ -384,6 +384,47 @@ static void ReportFieldDomain(CPLString &osRet, CPLJSONObject &oDomains,
                     }
                 }
             }
+            else if (poDomain->GetFieldType() == OFTDateTime)
+            {
+                if (!OGR_RawField_IsUnset(&sMin))
+                {
+                    const char *pszVal = CPLSPrintf(
+                        "%04d-%02d-%02dT%02d:%02d:%02d", sMin.Date.Year,
+                        sMin.Date.Month, sMin.Date.Day, sMin.Date.Hour,
+                        sMin.Date.Minute,
+                        static_cast<int>(sMin.Date.Second + 0.5));
+                    if (bJson)
+                    {
+                        oDomain.Set("minValue", pszVal);
+                        oDomain.Set("minValueIncluded", bMinIsIncluded);
+                    }
+                    else
+                    {
+                        Concat(osRet, psOptions->bStdoutOutput,
+                               "  Minimum value: %s%s\n", pszVal,
+                               bMinIsIncluded ? "" : " (excluded)");
+                    }
+                }
+                if (!OGR_RawField_IsUnset(&sMax))
+                {
+                    const char *pszVal = CPLSPrintf(
+                        "%04d-%02d-%02dT%02d:%02d:%02d", sMax.Date.Year,
+                        sMax.Date.Month, sMax.Date.Day, sMax.Date.Hour,
+                        sMax.Date.Minute,
+                        static_cast<int>(sMax.Date.Second + 0.5));
+                    if (bJson)
+                    {
+                        oDomain.Set("maxValue", pszVal);
+                        oDomain.Set("maxValueIncluded", bMaxIsIncluded);
+                    }
+                    else
+                    {
+                        Concat(osRet, psOptions->bStdoutOutput,
+                               "  Maximum value: %s%s\n", pszVal,
+                               bMaxIsIncluded ? "" : " (excluded)");
+                    }
+                }
+            }
             break;
         }
 

--- a/autotest/ogr/ogr_fielddomain.py
+++ b/autotest/ogr/ogr_fielddomain.py
@@ -88,6 +88,22 @@ def test_ogr_fielddomain_range():
     assert domain.GetMaxAsDouble() == -1234567890123.0
     assert not domain.IsMaxInclusive()
 
+    domain = ogr.CreateRangeFieldDomainDateTime(
+        "datetime_range",
+        "datetime_range_desc",
+        "2023-07-03T12:13:14",
+        True,
+        "2023-07-03T12:13:15",
+        True,
+    )
+    assert domain.GetName() == "datetime_range"
+    assert domain.GetDescription() == "datetime_range_desc"
+    assert domain.GetDomainType() == ogr.OFDT_RANGE
+    assert domain.GetFieldType() == ogr.OFTDateTime
+    assert domain.GetFieldSubType() == ogr.OFSTNone
+    assert domain.GetMinAsString() == "2023-07-03T12:13:14"
+    assert domain.GetMaxAsString() == "2023-07-03T12:13:15"
+
     with pytest.raises(Exception):
         with gdaltest.error_handler():
             domain.GetEnumeration()

--- a/autotest/ogr/ogr_fielddomain.py
+++ b/autotest/ogr/ogr_fielddomain.py
@@ -103,6 +103,30 @@ def test_ogr_fielddomain_range():
     assert domain.GetFieldSubType() == ogr.OFSTNone
     assert domain.GetMinAsString() == "2023-07-03T12:13:14"
     assert domain.GetMaxAsString() == "2023-07-03T12:13:15"
+    ds = gdal.GetDriverByName("Memory").Create("", 0, 0, 0, gdal.GDT_Unknown)
+    ds.AddFieldDomain(domain)
+    ret = gdal.VectorInfo(ds, format="json")
+    assert ret["domains"] == {
+        "datetime_range": {
+            "description": "datetime_range_desc",
+            "fieldType": "DateTime",
+            "maxValue": "2023-07-03T12:13:15",
+            "maxValueIncluded": True,
+            "mergePolicy": "default value",
+            "minValue": "2023-07-03T12:13:14",
+            "minValueIncluded": True,
+            "splitPolicy": "default value",
+            "type": "range",
+        }
+    }
+    ret = gdal.VectorInfo(ds, options="-fielddomain datetime_range")
+    assert "Description: datetime_range_desc" in ret
+    assert "Type: range" in ret
+    assert "Field type: DateTime" in ret
+    assert "Split policy: default value" in ret
+    assert "Merge policy: default value" in ret
+    assert "Minimum value: 2023-07-03T12:13:14" in ret
+    assert "Maximum value: 2023-07-03T12:13:15" in ret
 
     with pytest.raises(Exception):
         with gdaltest.error_handler():

--- a/autotest/ogr/ogr_openfilegdb_write.py
+++ b/autotest/ogr/ogr_openfilegdb_write.py
@@ -2490,7 +2490,7 @@ def test_ogr_openfilegdb_write_alter_field_defn():
 # Test writing field domains
 
 
-def test_ogr_openfilegdb_write_domains_from_other_gdb():
+def test_ogr_openfilegdb_write_domains():
 
     dirname = "/vsimem/out.gdb"
     try:
@@ -2512,10 +2512,31 @@ def test_ogr_openfilegdb_write_domains_from_other_gdb():
         fld_defn = ogr.FieldDefn("foo2", ogr.OFTInteger)
         fld_defn.SetDomainName("domain")
         assert lyr.CreateField(fld_defn) == ogr.OGRERR_NONE
+
+        domain = ogr.CreateRangeFieldDomainDateTime(
+            "datetime_range",
+            "datetime_range_desc",
+            "2023-07-03T12:13:14",
+            True,
+            "2023-07-03T12:13:15",
+            True,
+        )
+        assert ds.AddFieldDomain(domain)
         ds = None
 
-        ds = ogr.Open(dirname, update=1)
+        ds = gdal.OpenEx(dirname)
         assert ds.GetLayerByName("GDB_ItemRelationships").GetFeatureCount() == 2
+
+        domain = ds.GetFieldDomain("datetime_range")
+        assert domain is not None
+        assert domain.GetName() == "datetime_range"
+        assert domain.GetDescription() == "datetime_range_desc"
+        assert domain.GetDomainType() == ogr.OFDT_RANGE
+        assert domain.GetFieldType() == ogr.OFTDateTime
+        assert domain.GetFieldSubType() == ogr.OFSTNone
+        assert domain.GetMinAsString() == "2023-07-03T12:13:14"
+        assert domain.GetMaxAsString() == "2023-07-03T12:13:15"
+
         ds = None
 
         ds = ogr.Open(dirname, update=1)

--- a/autotest/utilities/test_ogrinfo_lib.py
+++ b/autotest/utilities/test_ogrinfo_lib.py
@@ -764,3 +764,65 @@ def test_ogrinfo_lib_json_geom_NO():
     assert ret["layers"][0]["features"] == [
         {"type": "Feature", "fid": 0, "properties": {"prop0": 42}, "geometry": None}
     ]
+
+
+###############################################################################
+# Test field domains
+
+
+@pytest.mark.require_driver("GPKG")
+def test_ogrinfo_lib_fielddomains():
+
+    ret = gdal.VectorInfo("../ogr/data/gpkg/domains.gpkg", format="json")
+    assert ret["domains"] == {
+        "enum_domain": {
+            "type": "coded",
+            "fieldType": "Integer",
+            "splitPolicy": "default value",
+            "mergePolicy": "default value",
+            "codedValues": {"1": "one", "2": None},
+        },
+        "glob_domain": {
+            "type": "glob",
+            "fieldType": "String",
+            "splitPolicy": "default value",
+            "mergePolicy": "default value",
+            "glob": "*",
+        },
+        "range_domain_int": {
+            "type": "range",
+            "fieldType": "Integer",
+            "splitPolicy": "default value",
+            "mergePolicy": "default value",
+            "minValue": 1,
+            "minValueIncluded": True,
+            "maxValue": 2,
+            "maxValueIncluded": False,
+        },
+        "range_domain_int64": {
+            "type": "range",
+            "fieldType": "Integer64",
+            "splitPolicy": "default value",
+            "mergePolicy": "default value",
+            "minValue": -1234567890123,
+            "minValueIncluded": False,
+            "maxValue": 1234567890123,
+            "maxValueIncluded": True,
+        },
+        "range_domain_real": {
+            "type": "range",
+            "fieldType": "Real",
+            "splitPolicy": "default value",
+            "mergePolicy": "default value",
+            "minValue": 1.5,
+            "minValueIncluded": True,
+            "maxValue": 2.5,
+            "maxValueIncluded": True,
+        },
+        "range_domain_real_inf": {
+            "type": "range",
+            "fieldType": "Real",
+            "splitPolicy": "default value",
+            "mergePolicy": "default value",
+        },
+    }

--- a/ogr/ogr_p.h
+++ b/ogr/ogr_p.h
@@ -41,8 +41,9 @@
 #include "cpl_minixml.h"
 
 #include "ogr_core.h"
-#include "ogr_geometry.h"
-#include "ogr_feature.h"
+
+class OGRGeometry;
+class OGRFieldDefn;
 
 /* A default name for the default geometry column, instead of '' */
 #define OGR_GEOMETRY_DEFAULT_NON_EMPTY_NAME "_ogr_geometry_"
@@ -97,7 +98,10 @@ std::string CPL_DLL OGRMakeWktCoordinateM(double, double, double, double,
 void CPL_DLL OGRFormatDouble(char *pszBuffer, int nBufferLen, double dfVal,
                              char chDecimalSep, int nPrecision = 15,
                              char chConversionSpecifier = 'f');
+
+#ifdef OGR_GEOMETRY_H_INCLUDED
 std::string CPL_DLL OGRFormatDouble(double val, const OGRWktOptions &opts);
+#endif
 
 int OGRFormatFloat(char *pszBuffer, int nBufferLen, float fVal, int nPrecision,
                    char chConversionSpecifier);

--- a/ogr/ogr_wkb.cpp
+++ b/ogr/ogr_wkb.cpp
@@ -29,6 +29,7 @@
 #include "cpl_error.h"
 #include "ogr_wkb.h"
 #include "ogr_core.h"
+#include "ogr_geometry.h"
 #include "ogr_p.h"
 
 #include <algorithm>

--- a/ogr/ogrsf_frmts/openfilegdb/filegdb_fielddomain.h
+++ b/ogr/ogrsf_frmts/openfilegdb/filegdb_fielddomain.h
@@ -31,6 +31,7 @@
 
 #include "cpl_minixml.h"
 #include "filegdb_gdbtoogrfieldtype.h"
+#include "ogr_p.h"
 
 /************************************************************************/
 /*                      ParseXMLFieldDomainDef()                        */
@@ -139,7 +140,7 @@ ParseXMLFieldDomainDef(const std::string &domainDef)
     else if (bIsRangeDomain || strcmp(pszType, "esri:RangeDomain") == 0)
     {
         if (eFieldType != OFTInteger && eFieldType != OFTInteger64 &&
-            eFieldType != OFTReal)
+            eFieldType != OFTReal && eFieldType != OFTDateTime)
         {
             CPLError(CE_Failure, CPLE_NotSupported,
                      "Unsupported field type for range domain: %s",
@@ -166,6 +167,21 @@ ParseXMLFieldDomainDef(const std::string &domainDef)
         {
             sMin.Real = CPLAtof(pszMinValue);
             sMax.Real = CPLAtof(pszMaxValue);
+        }
+        else if (eFieldType == OFTDateTime)
+        {
+            if (!OGRParseXMLDateTime(pszMinValue, &sMin))
+            {
+                CPLError(CE_Failure, CPLE_AppDefined, "Invalid MinValue: %s",
+                         pszMinValue);
+                return nullptr;
+            }
+            if (!OGRParseXMLDateTime(pszMaxValue, &sMax))
+            {
+                CPLError(CE_Failure, CPLE_AppDefined, "Invalid MaxValue: %s",
+                         pszMaxValue);
+                return nullptr;
+            }
         }
         domain.reset(new OGRRangeFieldDomain(pszName, pszDescription,
                                              eFieldType, eSubType, sMin, true,
@@ -307,6 +323,10 @@ inline std::string BuildXMLFieldDomainDef(const OGRFieldDomain *poDomain,
     {
         CPLCreateXMLElementAndValue(psRoot, "FieldType", "esriFieldTypeString");
     }
+    else if (poDomain->GetFieldType() == OFTDateTime)
+    {
+        CPLCreateXMLElementAndValue(psRoot, "FieldType", "esriFieldTypeDate");
+    }
     else
     {
         failureReason = "Unsupported field type for FileGeoDatabase domain";
@@ -369,6 +389,10 @@ inline std::string BuildXMLFieldDomainDef(const OGRFieldDomain *poDomain,
         {
             CPLAddXMLAttributeAndValue(psParent, "xsi:type", "xs:string");
         }
+        else if (poDomain->GetFieldType() == OFTDateTime)
+        {
+            CPLAddXMLAttributeAndValue(psParent, "xsi:type", "xs:dateTime");
+        }
     };
 
     switch (poDomain->GetDomainType())
@@ -407,51 +431,50 @@ inline std::string BuildXMLFieldDomainDef(const OGRFieldDomain *poDomain,
             auto poRangeDomain =
                 cpl::down_cast<const OGRRangeFieldDomain *>(poDomain);
 
+            const auto SerializeMinOrMax =
+                [&AddFieldTypeAsXSIType, &poDomain,
+                 psRoot](const char *pszElementName, const OGRField &oValue)
+            {
+                if (!OGR_RawField_IsUnset(&oValue))
+                {
+                    auto psValue =
+                        CPLCreateXMLNode(psRoot, CXT_Element, pszElementName);
+                    AddFieldTypeAsXSIType(psValue);
+                    if (poDomain->GetFieldType() == OFTInteger)
+                    {
+                        CPLCreateXMLNode(psValue, CXT_Text,
+                                         CPLSPrintf("%d", oValue.Integer));
+                    }
+                    else if (poDomain->GetFieldType() == OFTReal)
+                    {
+                        CPLCreateXMLNode(psValue, CXT_Text,
+                                         CPLSPrintf("%.18g", oValue.Real));
+                    }
+                    else if (poDomain->GetFieldType() == OFTString)
+                    {
+                        CPLCreateXMLNode(psValue, CXT_Text, oValue.String);
+                    }
+                    else if (poDomain->GetFieldType() == OFTDateTime)
+                    {
+                        CPLCreateXMLNode(
+                            psValue, CXT_Text,
+                            CPLSPrintf(
+                                "%04d-%02d-%02dT%02d:%02d:%02d",
+                                oValue.Date.Year, oValue.Date.Month,
+                                oValue.Date.Day, oValue.Date.Hour,
+                                oValue.Date.Minute,
+                                static_cast<int>(oValue.Date.Second + 0.5)));
+                    }
+                }
+            };
+
             bool bIsInclusiveOut = false;
             const OGRField &oMax = poRangeDomain->GetMax(bIsInclusiveOut);
-            if (!OGR_RawField_IsUnset(&oMax))
-            {
-                auto psValue =
-                    CPLCreateXMLNode(psRoot, CXT_Element, "MaxValue");
-                AddFieldTypeAsXSIType(psValue);
-                if (poDomain->GetFieldType() == OFTInteger)
-                {
-                    CPLCreateXMLNode(psValue, CXT_Text,
-                                     CPLSPrintf("%d", oMax.Integer));
-                }
-                else if (poDomain->GetFieldType() == OFTReal)
-                {
-                    CPLCreateXMLNode(psValue, CXT_Text,
-                                     CPLSPrintf("%.18g", oMax.Real));
-                }
-                else if (poDomain->GetFieldType() == OFTString)
-                {
-                    CPLCreateXMLNode(psValue, CXT_Text, oMax.String);
-                }
-            }
+            SerializeMinOrMax("MaxValue", oMax);
 
             bIsInclusiveOut = false;
             const OGRField &oMin = poRangeDomain->GetMin(bIsInclusiveOut);
-            if (!OGR_RawField_IsUnset(&oMin))
-            {
-                auto psValue =
-                    CPLCreateXMLNode(psRoot, CXT_Element, "MinValue");
-                AddFieldTypeAsXSIType(psValue);
-                if (poDomain->GetFieldType() == OFTInteger)
-                {
-                    CPLCreateXMLNode(psValue, CXT_Text,
-                                     CPLSPrintf("%d", oMin.Integer));
-                }
-                else if (poDomain->GetFieldType() == OFTReal)
-                {
-                    CPLCreateXMLNode(psValue, CXT_Text,
-                                     CPLSPrintf("%.18g", oMin.Real));
-                }
-                else if (poDomain->GetFieldType() == OFTString)
-                {
-                    CPLCreateXMLNode(psValue, CXT_Text, oMin.String);
-                }
-            }
+            SerializeMinOrMax("MinValue", oMin);
 
             break;
         }

--- a/ogr/ogrspatialreference.cpp
+++ b/ogr/ogrspatialreference.cpp
@@ -47,6 +47,7 @@
 #include "cpl_error.h"
 #include "cpl_error_internal.h"
 #include "cpl_http.h"
+#include "cpl_json.h"
 #include "cpl_multiproc.h"
 #include "cpl_string.h"
 #include "cpl_vsi.h"

--- a/ogr/ogrutils.cpp
+++ b/ogr/ogrutils.cpp
@@ -29,6 +29,7 @@
  ****************************************************************************/
 
 #include "cpl_port.h"
+#include "ogr_geometry.h"
 #include "ogr_p.h"
 
 #include <cassert>


### PR DESCRIPTION
Fixes the warning "Unsupported field type for range domain: esriFieldTypeDate" of https://lists.osgeo.org/pipermail/gdal-dev/2023-June/057394.html