### PR TITLE
Python bindings: Prevent migration of config options between env vars, global and thread-local storage

### DIFF
--- a/autotest/gcore/misc.py
+++ b/autotest/gcore/misc.py
@@ -869,6 +869,85 @@ def test_misc_15():
 
 
 ###############################################################################
+# Test config option context managers
+
+
+def test_misc_config_context_mgrs_1():
+    # Make sure that config_options context manager does not convert a
+    # global config option to a thread-local config option
+
+    try:
+        gdal.SetConfigOption("A", "1")
+
+        assert gdal.GetConfigOption("A") == "1"
+        assert gdal.GetThreadLocalConfigOption("A") is None
+
+        # temporarily set new thread-local value for A
+        with gdal.config_option("A", "2", thread_local=True):
+            assert gdal.GetConfigOption("A") == "2"
+            assert gdal.GetThreadLocalConfigOption("A") == "2"
+
+        # value of A is restored, and thread-local value is unset
+        assert gdal.GetConfigOption("A") == "1"
+        assert gdal.GetThreadLocalConfigOption("A") is None
+
+    finally:
+        gdal.SetConfigOption("A", None)
+
+
+def test_misc_config_context_mgrs_2():
+    # Make sure that config_options context manager does not convert a
+    # thread-local config option to a global config option
+
+    try:
+        gdal.SetThreadLocalConfigOption("B", "5")
+        assert gdal.GetConfigOption("B") == "5"
+        assert gdal.GetThreadLocalConfigOption("B") == "5"
+
+        # temporarily set new global value for B
+        # this has no effect, because the thread-local value overrides it
+        with gdal.config_option("B", "6", thread_local=False):
+            assert gdal.GetConfigOption("B") == "5"
+            assert gdal.GetThreadLocalConfigOption("B") == "5"
+
+        # value of B is restored
+        assert gdal.GetThreadLocalConfigOption("B") == "5"
+
+        gdal.SetThreadLocalConfigOption("B", None)
+        assert gdal.GetConfigOption("B") is None
+
+    finally:
+        gdal.SetThreadLocalConfigOption("B", None)
+
+
+def test_misc_config_context_mgrs_3():
+    # Make sure that config_options correctly restores state when
+    # a configuration option is set in both thread-local and global
+    # contexts.
+
+    try:
+        gdal.SetConfigOption("C", "GLOBAL")
+        gdal.SetThreadLocalConfigOption("C", "TL")
+
+        # temporarily set new global value for C
+        # this has no effect, because the thread-local value overrides it
+        with gdal.config_option("C", "XX", thread_local=False):
+            assert gdal.GetConfigOption("C") == "TL"
+            assert gdal.GetThreadLocalConfigOption("C") == "TL"
+
+        # value of C is restored
+        assert gdal.GetThreadLocalConfigOption("C") == "TL"
+
+        # clear thread-local value of C, exposing global value
+        gdal.SetThreadLocalConfigOption("C", None)
+        assert gdal.GetConfigOption("C") == "GLOBAL"
+
+    finally:
+        gdal.SetConfigOption("C", None)
+        gdal.SetThreadLocalConfigOption("C", None)
+
+
+###############################################################################
 
 
 def test_misc_cleanup():

--- a/port/cpl_conv.h
+++ b/port/cpl_conv.h
@@ -56,6 +56,8 @@ const char CPL_DLL *CPL_STDCALL CPLGetConfigOption(const char *, const char *)
     CPL_WARN_UNUSED_RESULT;
 const char CPL_DLL *CPL_STDCALL CPLGetThreadLocalConfigOption(
     const char *, const char *) CPL_WARN_UNUSED_RESULT;
+const char CPL_DLL *CPL_STDCALL
+CPLGetGlobalConfigOption(const char *, const char *) CPL_WARN_UNUSED_RESULT;
 void CPL_DLL CPL_STDCALL CPLSetConfigOption(const char *, const char *);
 void CPL_DLL CPL_STDCALL CPLSetThreadLocalConfigOption(const char *pszKey,
                                                        const char *pszValue);

--- a/swig/include/cpl.i
+++ b/swig/include/cpl.i
@@ -198,6 +198,7 @@ void CPL_STDCALL PyCPLErrorHandler(CPLErr eErrClass, int err_no, const char* psz
 %rename (GetFileSystemOptions) VSIGetFileSystemOptions;
 %rename (SetConfigOption) CPLSetConfigOption;
 %rename (GetConfigOption) wrapper_CPLGetConfigOption;
+%rename (GetGlobalConfigOption) wrapper_CPLGetGlobalConfigOption;
 %rename (SetThreadLocalConfigOption) CPLSetThreadLocalConfigOption;
 %rename (GetThreadLocalConfigOption) wrapper_CPLGetThreadLocalConfigOption;
 %rename (SetCredential) wrapper_VSISetCredential;
@@ -493,6 +494,10 @@ void CPLSetThreadLocalConfigOption( const char * pszKey, const char * pszValue )
 const char *wrapper_CPLGetConfigOption( const char * pszKey, const char * pszDefault = NULL )
 {
     return CPLGetConfigOption( pszKey, pszDefault );
+}
+const char *wrapper_CPLGetGlobalConfigOption( const char * pszKey, const char * pszDefault = NULL )
+{
+    return CPLGetGlobalConfigOption( pszKey, pszDefault );
 }
 const char *wrapper_CPLGetThreadLocalConfigOption( const char * pszKey, const char * pszDefault = NULL )
 {

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -3565,8 +3565,11 @@ def config_options(options, thread_local=True):
            with gdal.config_options({"GDAL_NUM_THREADS": "ALL_CPUS"}):
                gdal.Warp("out.tif", "in.tif", dstSRS="EPSG:4326")
     """
-    oldvals = {key: GetConfigOption(key) for key in options}
+    get_config_option = GetThreadLocalConfigOption if thread_local else GetGlobalConfigOption
     set_config_option = SetThreadLocalConfigOption if thread_local else SetConfigOption
+
+    oldvals = {key: get_config_option(key) for key in options}
+
     for key in options:
         set_config_option(key, options[key])
     try:


### PR DESCRIPTION
## What does this PR do?

Fix for https://github.com/OSGeo/gdal/issues/8018

Maybe there is a better name than `CPLGetGlobalConfigOption`. I couldn't think of a word that exactly means the opposite of "thread-local".

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed