### PR TITLE
[Backport release/3.7] gdalwarp: make -cutline to work again with PostGIS datasources (fixes 3.7.0 regression, fixes #8023)

### DIFF
--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -3212,7 +3212,7 @@ static CPLErr LoadCutline(const std::string &osCutlineDSName,
     /*      Open source vector dataset.                                     */
     /* -------------------------------------------------------------------- */
     auto poDS = std::unique_ptr<GDALDataset>(
-        GDALDataset::Open(osCutlineDSName.c_str()));
+        GDALDataset::Open(osCutlineDSName.c_str(), GDAL_OF_VECTOR));
     if (poDS == nullptr)
     {
         CPLError(CE_Failure, CPLE_AppDefined, "Cannot open %s.",


### PR DESCRIPTION
Backport #8049
 **Authored by:** @rouault