### PR TITLE
[Backport release/3.7] gdal_calc.py: make --hideNoData imply --NoDataValue=none as documented (fixes #8009)

### DIFF
--- a/autotest/pyscripts/test_gdal_calc.py
+++ b/autotest/pyscripts/test_gdal_calc.py
@@ -436,6 +436,7 @@ def test_gdal_calc_py_9(script_path):
         kwargs = copy(common_kwargs)
         kwargs.update(inputs0)
         ds = gdal_calc.Calc(calc="a", outfile=outfile, **kwargs)
+        assert ds.GetRasterBand(1).GetNoDataValue() is None
         if return_ds:
             input_file = ds
         else:

--- a/swig/python/gdal-utils/osgeo_utils/gdal_calc.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_calc.py
@@ -443,7 +443,7 @@ def Calc(
         if ProjectionCheck:
             myOut.SetProjection(ProjectionCheck)
 
-        if NoDataValue is None:
+        if NoDataValue is None and not hideNoData:
             myOutNDV = DefaultNDVLookup[
                 myOutType
             ]  # use the default noDataValue for this datatype
@@ -464,9 +464,6 @@ def Calc(
                 myOutB.SetRasterColorInterpretation(gdal.GCI_PaletteIndex)
 
             myOutB = None  # write to band
-
-        if hideNoData:
-            myOutNDV = None
 
     myOutTypeName = gdal.GetDataTypeName(myOutType)
     if debug:


### PR DESCRIPTION
Backport #8010
 **Authored by:** @rouault