### PR TITLE
Eliminate some deprecations / compiler warnings

### DIFF
--- a/swig/java/apps/GDALtest.java
+++ b/swig/java/apps/GDALtest.java
@@ -86,7 +86,7 @@ public class GDALtest extends JFrame implements ActionListener{
 		this.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
 
 		this.setSize(1024, 768);
-		this.show();
+		this.setVisible(true);
 	}
 
 	public void setImage(BufferedImage image) {

--- a/swig/java/apps/ogr2ogr.java
+++ b/swig/java/apps/ogr2ogr.java
@@ -267,10 +267,10 @@ public class ogr2ogr
             else if (args[iArg].equalsIgnoreCase("-spat") && iArg + 4 < args.length)
             {
                 Geometry oRing = new Geometry(ogrConstants.wkbLinearRing);
-                double xmin = new Double(args[++iArg]).doubleValue();
-                double ymin = new Double(args[++iArg]).doubleValue();
-                double xmax = new Double(args[++iArg]).doubleValue();
-                double ymax = new Double(args[++iArg]).doubleValue();
+                double xmin = Double.parseDouble(args[++iArg]);
+                double ymin = Double.parseDouble(args[++iArg]);
+                double xmax = Double.parseDouble(args[++iArg]);
+                double ymax = Double.parseDouble(args[++iArg]);
                 oRing.AddPoint(xmin, ymin);
                 oRing.AddPoint(xmin, ymax);
                 oRing.AddPoint(xmax, ymax);
@@ -295,12 +295,12 @@ public class ogr2ogr
             else if( args[iArg].equalsIgnoreCase("-simplify") && iArg < args.length-1 )
             {
                 eGeomOp = GeomOperation.SIMPLIFY_PRESERVE_TOPOLOGY;
-                dfGeomOpParam = new Double(args[++iArg]).doubleValue();
+                dfGeomOpParam = Double.parseDouble(args[++iArg]);
             }
             else if( args[iArg].equalsIgnoreCase("-segmentize") && iArg < args.length-1 )
             {
                 eGeomOp = GeomOperation.SEGMENTIZE;
-                dfGeomOpParam = new Double(args[++iArg]).doubleValue();
+                dfGeomOpParam = Double.parseDouble(args[++iArg]);
             }
             else if( args[iArg].equalsIgnoreCase("-fieldTypeToString") && iArg < args.length-1 )
             {
@@ -349,10 +349,10 @@ public class ogr2ogr
                 if ( IsNumber(args[iArg+1]) && iArg < args.length - 4 )
                 {
                     Geometry oRing = new Geometry(ogrConstants.wkbLinearRing);
-                    double xmin = new Double(args[++iArg]).doubleValue();
-                    double ymin = new Double(args[++iArg]).doubleValue();
-                    double xmax = new Double(args[++iArg]).doubleValue();
-                    double ymax = new Double(args[++iArg]).doubleValue();
+                    double xmin = Double.parseDouble(args[++iArg]);
+                    double ymin = Double.parseDouble(args[++iArg]);
+                    double xmax = Double.parseDouble(args[++iArg]);
+                    double ymax = Double.parseDouble(args[++iArg]);
                     oRing.AddPoint(xmin, ymin);
                     oRing.AddPoint(xmin, ymax);
                     oRing.AddPoint(xmax, ymax);
@@ -403,10 +403,10 @@ public class ogr2ogr
                 if ( IsNumber(args[iArg+1]) && iArg < args.length - 4 )
                 {
                     Geometry oRing = new Geometry(ogrConstants.wkbLinearRing);
-                    double xmin = new Double(args[++iArg]).doubleValue();
-                    double ymin = new Double(args[++iArg]).doubleValue();
-                    double xmax = new Double(args[++iArg]).doubleValue();
-                    double ymax = new Double(args[++iArg]).doubleValue();
+                    double xmin = Double.parseDouble(args[++iArg]);
+                    double ymin = Double.parseDouble(args[++iArg]);
+                    double xmax = Double.parseDouble(args[++iArg]);
+                    double ymax = Double.parseDouble(args[++iArg]);
                     oRing.AddPoint(xmin, ymin);
                     oRing.AddPoint(xmin, ymax);
                     oRing.AddPoint(xmax, ymax);

--- a/swig/java/apps/ogrinfo.java
+++ b/swig/java/apps/ogrinfo.java
@@ -81,15 +81,15 @@ public class ogrinfo
                 bVerbose = false;
             else if (args[i].equals("-fid") && i + 1 < args.length)
             {
-                nFetchFID = new Integer(args[++i]).intValue();
+                nFetchFID = Integer.parseInt(args[++i]);
             }
             else if (args[i].equals("-spat") && i + 4 < args.length)
             {
                 Geometry oRing = new Geometry(ogrConstants.wkbLinearRing);
-                double xmin = new Double(args[++i]).doubleValue();
-                double ymin = new Double(args[++i]).doubleValue();
-                double xmax = new Double(args[++i]).doubleValue();
-                double ymax = new Double(args[++i]).doubleValue();
+                double xmin = Double.parseDouble(args[++i]);
+                double ymin = Double.parseDouble(args[++i]);
+                double xmax = Double.parseDouble(args[++i]);
+                double ymax = Double.parseDouble(args[++i]);
                 oRing.AddPoint(xmin, ymin);
                 oRing.AddPoint(xmin, ymax);
                 oRing.AddPoint(xmax, ymax);
@@ -113,7 +113,7 @@ public class ogrinfo
             }
             else if( args[i].equals("-rc") && i + 1 < args.length)
             {
-                nRepeatCount = new Integer(args[++i]).intValue();
+                nRepeatCount = Integer.parseInt(args[++i]);
             }
             else if( args[i].equals("-al") )
             {


### PR DESCRIPTION
Some java deprecation warnings were getting in the way of easily seeing real compile errors during the build process. Bring that code up to date to eliminate the warnings.
