### PR TITLE
Add a compatablity method to swig bindings that is Java Only

### DIFF
--- a/swig/include/ogr.i
+++ b/swig/include/ogr.i
@@ -2496,6 +2496,13 @@ public:
         OGR_Fld_SetType(self, type);
   }
 
+#ifdef SWIGJAVA
+  // Alias for backward compatibity
+  OGRFieldType GetFieldType() {
+    return OGR_Fld_GetType(self);
+  }
+#endif
+
   OGRFieldSubType GetSubType() {
     return OGR_Fld_GetSubType(self);
   }


### PR DESCRIPTION
It will simplify some future development in regards to FieldDefn and upcoming changes to java typemaps file.

Note that the java typemaps file has not yet removed the %rename GetType GetFieldType code from swig/include/java/ogr_java.i