### PR TITLE
Autotest: remove unused code, usage of return values

### DIFF
--- a/autotest/alg/cutline.py
+++ b/autotest/alg/cutline.py
@@ -42,7 +42,7 @@ from osgeo import gdal
 def test_cutline_1():
 
     tst = gdaltest.GDALTest("VRT", "cutline_noblend.vrt", 1, 11409)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -52,7 +52,7 @@ def test_cutline_1():
 def test_cutline_2():
 
     tst = gdaltest.GDALTest("VRT", "cutline_blend.vrt", 1, 21395)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -62,7 +62,7 @@ def test_cutline_2():
 def test_cutline_3():
 
     tst = gdaltest.GDALTest("VRT", "cutline_multipolygon.vrt", 1, 20827)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################

--- a/autotest/alg/warp.py
+++ b/autotest/alg/warp.py
@@ -287,21 +287,21 @@ def test_warp_6():
 
     tst = gdaltest.GDALTest("VRT", "utmsmall_ds_near.vrt", 1, 4770)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 def test_warp_7():
 
     tst = gdaltest.GDALTest("VRT", "utmsmall_ds_blinear.vrt", 1, 4755)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 def test_warp_8():
 
     tst = gdaltest.GDALTest("VRT", "utmsmall_ds_cubic.vrt", 1, 4833)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 def test_warp_9():
@@ -330,7 +330,7 @@ def test_warp_11():
 
     tst = gdaltest.GDALTest("VRT", "rgbsmall_dstalpha.vrt", 4, 30658)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 # Test warping an empty RGBA with bilinear resampling
@@ -349,11 +349,9 @@ def test_warp_12():
     # The alpha channel must be empty
     tst = gdaltest.GDALTest("VRT", "empty_rb.vrt", 4, 0)
 
-    ret = tst.testOpen()
+    tst.testOpen()
 
     tiff_drv.Delete("tmp/empty.tif")
-
-    return ret
 
 
 # Test warping an empty RGBA with cubic resampling
@@ -372,11 +370,9 @@ def test_warp_13():
     # The alpha channel must be empty
     tst = gdaltest.GDALTest("VRT", "empty_rc.vrt", 4, 0)
 
-    ret = tst.testOpen()
+    tst.testOpen()
 
     tiff_drv.Delete("tmp/empty.tif")
-
-    return ret
 
 
 # Test warping an empty RGBA with cubic spline resampling
@@ -395,11 +391,9 @@ def test_warp_14():
     # The alpha channel must be empty
     tst = gdaltest.GDALTest("VRT", "empty_rcs.vrt", 4, 0)
 
-    ret = tst.testOpen()
+    tst.testOpen()
 
     tiff_drv.Delete("tmp/empty.tif")
-
-    return ret
 
 
 # Test GWKNearestFloat with transparent source alpha band
@@ -418,11 +412,9 @@ def test_warp_15():
     # The alpha channel must be empty
     tst = gdaltest.GDALTest("VRT", "test_nearest_float.vrt", 4, 0)
 
-    ret = tst.testOpen()
+    tst.testOpen()
 
     tiff_drv.Delete("tmp/test.tif")
-
-    return ret
 
 
 # Test GWKNearestFloat with opaque source alpha band
@@ -441,11 +433,9 @@ def test_warp_16():
     # The alpha channel must be empty
     tst = gdaltest.GDALTest("VRT", "test_nearest_float.vrt", 4, 4921)
 
-    ret = tst.testOpen()
+    tst.testOpen()
 
     tiff_drv.Delete("tmp/test.tif")
-
-    return ret
 
 
 # Test GWKNearestShort with transparent source alpha band
@@ -464,11 +454,9 @@ def test_warp_17():
     # The alpha channel must be empty
     tst = gdaltest.GDALTest("VRT", "test_nearest_short.vrt", 4, 0)
 
-    ret = tst.testOpen()
+    tst.testOpen()
 
     tiff_drv.Delete("tmp/test.tif")
-
-    return ret
 
 
 # Test GWKNearestShort with opaque source alpha band
@@ -487,11 +475,9 @@ def test_warp_18():
     # The alpha channel must be empty
     tst = gdaltest.GDALTest("VRT", "test_nearest_short.vrt", 4, 4921)
 
-    ret = tst.testOpen()
+    tst.testOpen()
 
     tiff_drv.Delete("tmp/test.tif")
-
-    return ret
 
 
 # Test all data types and resampling methods for very small images
@@ -553,7 +539,7 @@ def test_warp_20():
 
     tst = gdaltest.GDALTest("VRT", "white_nodata.vrt", 1, 1705)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -1614,14 +1600,14 @@ def test_warp_ds_rms():
 
     tst = gdaltest.GDALTest("VRT", "utmsmall_ds_rms.vrt", 1, 4926)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 def test_warp_rms_1():
 
     tst = gdaltest.GDALTest("VRT", "utmsmall_rms_float.vrt", 1, 29819)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 def test_warp_rms_2():

--- a/autotest/gcore/bmp_read.py
+++ b/autotest/gcore/bmp_read.py
@@ -59,7 +59,7 @@ def test_bmp_online_1():
         "BMP", "tmp/cache/8bit_pal_rle.bmp", 1, 17270, filename_absolute=1
     )
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 def test_bmp_online_2():
@@ -69,9 +69,8 @@ def test_bmp_online_2():
     )
 
     tst = gdaltest.GDALTest("BMP", "tmp/cache/24bit.bmp", 1, 7158, filename_absolute=1)
-    if tst == "success":
-        tst = gdaltest.GDALTest(
-            "BMP", "tmp/cache/24bit.bmp", 3, 27670, filename_absolute=1
-        )
+    tst.testOpen()
 
-    return tst.testOpen()
+    tst = gdaltest.GDALTest("BMP", "tmp/cache/24bit.bmp", 3, 27670, filename_absolute=1)
+
+    tst.testOpen()

--- a/autotest/gcore/bmp_write.py
+++ b/autotest/gcore/bmp_write.py
@@ -40,7 +40,7 @@ def test_bmp_vsimem():
 
     tst = gdaltest.GDALTest("BMP", "byte.tif", 1, 4672)
 
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 ###############################################################################

--- a/autotest/gcore/geoloc.py
+++ b/autotest/gcore/geoloc.py
@@ -44,7 +44,7 @@ from osgeo import gdal, osr
 def test_geoloc_1():
 
     tst = gdaltest.GDALTest("VRT", "warpsst.vrt", 1, 63034)
-    return tst.testOpen(check_filelist=False)
+    tst.testOpen(check_filelist=False)
 
 
 ###############################################################################

--- a/autotest/gcore/hdf4_read.py
+++ b/autotest/gcore/hdf4_read.py
@@ -143,7 +143,7 @@ def test_hdf4_read_online_1():
         filename_absolute=1,
     )
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################

--- a/autotest/gcore/misc.py
+++ b/autotest/gcore/misc.py
@@ -481,10 +481,7 @@ def test_misc_6():
             datatype = gdal.GDT_Byte
             setDriversDone = set()
             for nBands in range(6):
-                ret = misc_6_internal(datatype, nBands, setDriversDone)
-                if ret != "success":
-                    gdal.PopErrorHandler()
-                    return ret
+                misc_6_internal(datatype, nBands, setDriversDone)
 
             nBands = 1
             for datatype in (
@@ -499,10 +496,7 @@ def test_misc_6():
                 gdal.GDT_CFloat32,
                 gdal.GDT_CFloat64,
             ):
-                ret = misc_6_internal(datatype, nBands, setDriversDone)
-                if ret != "success":
-                    gdal.PopErrorHandler()
-                    return ret
+                misc_6_internal(datatype, nBands, setDriversDone)
 
 
 ###############################################################################

--- a/autotest/gcore/tiff_ovr.py
+++ b/autotest/gcore/tiff_ovr.py
@@ -128,11 +128,9 @@ def test_tiff_ovr_1(both_endian):
 
     assert err == 0, "BuildOverviews reports an error"
 
-    ret = tiff_ovr_check(ds)
+    tiff_ovr_check(ds)
 
     ds = None
-
-    return ret
 
 
 ###############################################################################
@@ -145,11 +143,9 @@ def test_tiff_ovr_2(both_endian):
 
     assert src_ds is not None, "Failed to open test dataset."
 
-    ret = tiff_ovr_check(src_ds)
+    tiff_ovr_check(src_ds)
 
     src_ds = None
-
-    return ret
 
 
 ###############################################################################
@@ -170,11 +166,9 @@ def test_tiff_ovr_3(both_endian):
     err = src_ds.BuildOverviews(overviewlist=[2, 4])
     assert err == 0, "BuildOverviews reports an error"
 
-    ret = tiff_ovr_check(src_ds)
+    tiff_ovr_check(src_ds)
 
     src_ds = None
-
-    return ret
 
 
 ###############################################################################
@@ -1366,8 +1360,7 @@ def test_tiff_ovr_35(both_endian):
 def test_tiff_ovr_36(both_endian):
 
     with gdaltest.config_option("GDAL_FORCE_CACHING", "YES"):
-        ret = test_tiff_ovr_35(both_endian)
-    return ret
+        test_tiff_ovr_35(both_endian)
 
 
 ###############################################################################

--- a/autotest/gcore/tiff_read.py
+++ b/autotest/gcore/tiff_read.py
@@ -3965,7 +3965,7 @@ def test_tiff_read_negative_scaley():
 def test_tiff_read_zstd():
 
     ut = gdaltest.GDALTest("GTiff", "byte_zstd.tif", 1, 4672)
-    return ut.testOpen()
+    ut.testOpen()
 
 
 ###############################################################################
@@ -3977,7 +3977,7 @@ def test_tiff_read_zstd_corrupted():
 
     ut = gdaltest.GDALTest("GTiff", "byte_zstd_corrupted.tif", 1, -1)
     with pytest.raises(Exception):
-        return ut.testOpen()
+        ut.testOpen()
 
 
 ###############################################################################
@@ -3989,7 +3989,7 @@ def test_tiff_read_zstd_corrupted2():
 
     ut = gdaltest.GDALTest("GTiff", "byte_zstd_corrupted2.tif", 1, -1)
     with pytest.raises(Exception):
-        return ut.testOpen()
+        ut.testOpen()
 
 
 ###############################################################################
@@ -4001,9 +4001,8 @@ def test_tiff_read_webp():
 
     stats = (0, 215, 66.38, 47.186)
     ut = gdaltest.GDALTest("GTiff", "tif_webp.tif", 1, None)
-    success = ut.testOpen(check_approx_stat=stats, stat_epsilon=1)
+    ut.testOpen(check_approx_stat=stats, stat_epsilon=1)
     gdal.Unlink("data/tif_webp.tif.aux.xml")
-    return success
 
 
 ###############################################################################
@@ -4034,7 +4033,7 @@ def test_tiff_read_1bit_2bands():
 def test_tiff_read_lerc():
 
     ut = gdaltest.GDALTest("GTiff", "byte_lerc.tif", 1, 4672)
-    return ut.testOpen()
+    ut.testOpen()
 
 
 ###############################################################################

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -614,8 +614,7 @@ def test_tiff_write_17():
 
 def test_tiff_write_17_disable_readdir():
     with gdal.config_option("GDAL_DISABLE_READDIR_ON_OPEN", "TRUE"):
-        ret = test_tiff_write_17()
-    return ret
+        test_tiff_write_17()
 
 
 ###############################################################################
@@ -720,8 +719,7 @@ def test_tiff_write_imd_with_space_in_values():
 
 def test_tiff_write_18_disable_readdir():
     with gdal.config_option("GDAL_DISABLE_READDIR_ON_OPEN", "TRUE"):
-        ret = test_tiff_write_18()
-    return ret
+        test_tiff_write_18()
 
 
 ###############################################################################
@@ -1651,8 +1649,7 @@ def test_tiff_write_46():
 def test_tiff_write_47():
 
     with gdaltest.SetCacheMax(0):
-        ret = test_tiff_write_3()
-    return ret
+        test_tiff_write_3()
 
 
 ###############################################################################

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -354,7 +354,7 @@ def test_tiff_write_10():
     ut = gdaltest.GDALTest(
         "GTiff", "oddsize_1bit2b.tif", 2, 5918, options=["NBITS=1", "INTERLEAVE=BAND"]
     )
-    return ut.testCreate(out_bands=2)
+    ut.testCreate(out_bands=2)
 
 
 ###############################################################################
@@ -366,7 +366,7 @@ def test_tiff_write_11():
     ut = gdaltest.GDALTest(
         "GTiff", "oddsize1bit.tif", 1, 5918, options=["NBITS=1", "COMPRESS=CCITTFAX4"]
     )
-    return ut.testCreateCopy()
+    ut.testCreateCopy()
 
 
 ###############################################################################
@@ -430,7 +430,7 @@ def test_tiff_write_14():
 
     tst = gdaltest.GDALTest("GTiff", "byte.tif", 1, 4672)
 
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 ###############################################################################
@@ -4634,7 +4634,7 @@ def test_tiff_write_114():
 
     tst = gdaltest.GDALTest("GTiff", "byte.tif", 1, 4672)
 
-    return tst.testCreateCopy(vsimem=1, interrupt_during_copy=True)
+    tst.testCreateCopy(vsimem=1, interrupt_during_copy=True)
 
 
 ###############################################################################
@@ -8173,7 +8173,7 @@ def test_tiff_write_168_ccitfax3():
     ut = gdaltest.GDALTest(
         "GTiff", "oddsize1bit.tif", 1, 5918, options=["NBITS=1", "COMPRESS=CCITTFAX3"]
     )
-    return ut.testCreateCopy()
+    ut.testCreateCopy()
 
 
 ###############################################################################
@@ -8185,7 +8185,7 @@ def test_tiff_write_169_ccitrle():
     ut = gdaltest.GDALTest(
         "GTiff", "oddsize1bit.tif", 1, 5918, options=["NBITS=1", "COMPRESS=CCITTRLE"]
     )
-    return ut.testCreateCopy()
+    ut.testCreateCopy()
 
 
 ###############################################################################
@@ -8213,7 +8213,7 @@ def test_tiff_write_171_zstd():
     ut = gdaltest.GDALTest(
         "GTiff", "byte.tif", 1, 4672, options=["COMPRESS=ZSTD", "ZSTD_LEVEL=1"]
     )
-    return ut.testCreateCopy()
+    ut.testCreateCopy()
 
 
 ###############################################################################
@@ -8230,7 +8230,7 @@ def test_tiff_write_171_zstd_predictor():
         4672,
         options=["COMPRESS=ZSTD", "ZSTD_LEVEL=1", "PREDICTOR=2"],
     )
-    return ut.testCreateCopy()
+    ut.testCreateCopy()
 
 
 ###############################################################################
@@ -8380,7 +8380,7 @@ def test_tiff_write_172_geometadata_tiff_rsid():
 def test_tiff_write_173_lerc():
 
     ut = gdaltest.GDALTest("GTiff", "byte.tif", 1, 4672, options=["COMPRESS=LERC"])
-    return ut.testCreateCopy()
+    ut.testCreateCopy()
 
 
 ###############################################################################
@@ -8393,7 +8393,7 @@ def test_tiff_write_174_lerc_deflate():
     ut = gdaltest.GDALTest(
         "GTiff", "byte.tif", 1, 4672, options=["COMPRESS=LERC_DEFLATE"]
     )
-    return ut.testCreateCopy()
+    ut.testCreateCopy()
 
 
 ###############################################################################
@@ -8406,7 +8406,7 @@ def test_tiff_write_174_lerc_deflate_with_level():
     ut = gdaltest.GDALTest(
         "GTiff", "byte.tif", 1, 4672, options=["COMPRESS=LERC_DEFLATE", "ZLEVEL=1"]
     )
-    return ut.testCreateCopy()
+    ut.testCreateCopy()
 
 
 ###############################################################################
@@ -8417,7 +8417,7 @@ def test_tiff_write_174_lerc_deflate_with_level():
 def test_tiff_write_175_lerc_zstd():
 
     ut = gdaltest.GDALTest("GTiff", "byte.tif", 1, 4672, options=["COMPRESS=LERC_ZSTD"])
-    return ut.testCreateCopy()
+    ut.testCreateCopy()
 
 
 ###############################################################################
@@ -8430,7 +8430,7 @@ def test_tiff_write_175_lerc_zstd_with_level():
     ut = gdaltest.GDALTest(
         "GTiff", "byte.tif", 1, 4672, options=["COMPRESS=LERC_ZSTD", "ZSTD_LEVEL=1"]
     )
-    return ut.testCreateCopy()
+    ut.testCreateCopy()
 
 
 ###############################################################################
@@ -8443,7 +8443,7 @@ def test_tiff_write_176_lerc_max_z_error():
     ut = gdaltest.GDALTest(
         "GTiff", "byte.tif", 1, 4529, options=["COMPRESS=LERC", "MAX_Z_ERROR=1"]
     )
-    return ut.testCreateCopy(skip_preclose_test=1)
+    ut.testCreateCopy(skip_preclose_test=1)
 
 
 ###############################################################################
@@ -9419,7 +9419,7 @@ def test_tiff_write_jpegxl_byte_single_band(lossless, writeImageStructureMetadat
 def test_tiff_write_jpegxl_byte_three_band():
 
     ut = gdaltest.GDALTest("GTiff", "rgbsmall.tif", 1, 21212, options=["COMPRESS=JXL"])
-    return ut.testCreateCopy()
+    ut.testCreateCopy()
 
 
 ###############################################################################
@@ -9430,7 +9430,7 @@ def test_tiff_write_jpegxl_byte_three_band():
 def test_tiff_write_jpegxl_uint16_single_band():
 
     ut = gdaltest.GDALTest("GTiff", "uint16.tif", 1, 4672, options=["COMPRESS=JXL"])
-    return ut.testCreateCopy()
+    ut.testCreateCopy()
 
 
 ###############################################################################
@@ -10029,7 +10029,7 @@ def test_tiff_write_predictor_2_float64():
 def test_tiff_write_uint64():
 
     ut = gdaltest.GDALTest("GTiff", "gtiff/uint64_full_range.tif", 1, 1)
-    return ut.testCreateCopy()
+    ut.testCreateCopy()
 
 
 ###############################################################################
@@ -10063,7 +10063,7 @@ def test_tiff_write_uint64_nodata():
 def test_tiff_write_int64():
 
     ut = gdaltest.GDALTest("GTiff", "gtiff/int64_full_range.tif", 1, 65535)
-    return ut.testCreateCopy()
+    ut.testCreateCopy()
 
 
 ###############################################################################

--- a/autotest/gdrivers/aaigrid.py
+++ b/autotest/gdrivers/aaigrid.py
@@ -48,7 +48,7 @@ pytestmark = pytest.mark.require_driver("AAIGRID")
 def test_aaigrid_1():
 
     tst = gdaltest.GDALTest("aaigrid", "aaigrid/pixel_per_line.asc", 1, 1123)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -119,7 +119,7 @@ def test_aaigrid_3():
 
     prj = 'PROJCS["NAD27 / UTM zone 11N",GEOGCS["NAD27",DATUM["North_American_Datum_1927",SPHEROID["Clarke_1866",6378206.4,294.9786982138982]],PRIMEM["Greenwich",0],UNIT["Degree",0.017453292519943295]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",-117],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],UNIT["Meter",1]]'
 
-    return tst.testCreateCopy(check_gt=1, check_srs=prj)
+    tst.testCreateCopy(check_gt=1, check_srs=prj)
 
 
 ###############################################################################
@@ -129,7 +129,7 @@ def test_aaigrid_3():
 def test_aaigrid_4():
 
     tst = gdaltest.GDALTest("aaigrid", "aaigrid/pixel_per_line.asc", 1, 187, 5, 5, 5, 5)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -166,7 +166,7 @@ def test_aaigrid_5():
     UNIT["METERS",1]]
     """
 
-    return tst.testOpen(check_prj=prj)
+    tst.testOpen(check_prj=prj)
 
 
 ###############################################################################
@@ -205,7 +205,7 @@ def test_aaigrid_7():
 
     tst = gdaltest.GDALTest("AAIGRID", "aaigrid/nonsquare.vrt", 1, 12481)
 
-    return tst.testCreateCopy(check_gt=1)
+    tst.testCreateCopy(check_gt=1)
 
 
 ###############################################################################
@@ -216,7 +216,7 @@ def test_aaigrid_8():
 
     tst = gdaltest.GDALTest("AAIGRID", "byte.tif", 1, 4672)
 
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 ###############################################################################

--- a/autotest/gdrivers/ace2.py
+++ b/autotest/gdrivers/ace2.py
@@ -58,8 +58,6 @@ def test_ace2_1():
     UNIT["degree",0.0174532925199433,
         AUTHORITY["EPSG","9108"]],
     AUTHORITY["EPSG","4326"]]"""
-    ret = tst.testOpen(check_gt=expected_gt, check_prj=expected_srs)
+    tst.testOpen(check_gt=expected_gt, check_prj=expected_srs)
 
     gdal.Unlink("/vsimem/45N015E_5M.ACE2")
-
-    return ret

--- a/autotest/gdrivers/adrg.py
+++ b/autotest/gdrivers/adrg.py
@@ -46,7 +46,7 @@ pytestmark = pytest.mark.require_driver("ADRG")
 def test_adrg_read_gen():
 
     tst = gdaltest.GDALTest("ADRG", "adrg/SMALL_ADRG/ABCDEF01.GEN", 1, 62833)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -56,7 +56,7 @@ def test_adrg_read_gen():
 def test_adrg_read_transh():
 
     tst = gdaltest.GDALTest("ADRG", "adrg/SMALL_ADRG/TRANSH01.THF", 1, 62833)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -72,7 +72,7 @@ def test_adrg_read_subdataset_img():
         62833,
         filename_absolute=1,
     )
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################

--- a/autotest/gdrivers/aigrid.py
+++ b/autotest/gdrivers/aigrid.py
@@ -46,7 +46,7 @@ pytestmark = pytest.mark.require_driver("AIG")
 def test_aigrid_1():
 
     tst = gdaltest.GDALTest("AIG", "aigrid/abc3x1", 1, 3)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -108,7 +108,7 @@ def test_aigrid_3():
 def test_aigrid_4():
 
     tst = gdaltest.GDALTest("AIG", "aigrid/ABC3X1UC", 1, 3)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -270,7 +270,7 @@ def test_aigrid_online_2():
     tst = gdaltest.GDALTest(
         "AIG", "tmp/cache/ai_bug/ai_bug/hdr.adf", 1, 16018, filename_absolute=1
     )
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################

--- a/autotest/gdrivers/bag.py
+++ b/autotest/gdrivers/bag.py
@@ -714,8 +714,7 @@ def test_bag_vr_resampled_mask():
 def test_bag_write_single_band():
 
     tst = gdaltest.GDALTest("BAG", "byte.tif", 1, 4672)
-    ret = tst.testCreateCopy(quiet_error_handler=False, new_filename="/vsimem/out.bag")
-    return ret
+    tst.testCreateCopy(quiet_error_handler=False, new_filename="/vsimem/out.bag")
 
 
 ###############################################################################

--- a/autotest/gdrivers/blx.py
+++ b/autotest/gdrivers/blx.py
@@ -44,7 +44,7 @@ def test_blx_1():
     prj = "WGS84"
     gt = [20.0004166, 0.0008333, 0.0, 50.0004166, 0.0, -0.0008333]
     tst = gdaltest.GDALTest("BLX", "blx/s4103.blx", 1, 47024)
-    return tst.testOpen(check_prj=prj, check_gt=gt)
+    tst.testOpen(check_prj=prj, check_gt=gt)
 
 
 ###############################################################################
@@ -56,7 +56,7 @@ def test_blx_2():
     prj = "WGS84"
     gt = [20.0004166, 0.0008333, 0.0, 50.0004166, 0.0, -0.0008333]
     tst = gdaltest.GDALTest("BLX", "blx/s4103.xlb", 1, 47024)
-    return tst.testOpen(check_prj=prj, check_gt=gt)
+    tst.testOpen(check_prj=prj, check_gt=gt)
 
 
 ###############################################################################
@@ -66,7 +66,7 @@ def test_blx_2():
 def test_blx_3():
 
     tst = gdaltest.GDALTest("BLX", "blx/s4103.xlb", 1, 47024)
-    return tst.testCreateCopy(check_gt=1, check_srs=1)
+    tst.testCreateCopy(check_gt=1, check_srs=1)
 
 
 ###############################################################################
@@ -76,7 +76,7 @@ def test_blx_3():
 def test_blx_4():
 
     tst = gdaltest.GDALTest("BLX", "blx/s4103.blx", 1, 47024, options=["BIGENDIAN=YES"])
-    return tst.testCreateCopy(check_gt=1, check_srs=1)
+    tst.testCreateCopy(check_gt=1, check_srs=1)
 
 
 ###############################################################################

--- a/autotest/gdrivers/bsb.py
+++ b/autotest/gdrivers/bsb.py
@@ -53,7 +53,7 @@ def test_bsb_1():
 
     tst = gdaltest.GDALTest("BSB", "bsb/rgbsmall.kap", 1, 30321)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -70,7 +70,7 @@ def test_bsb_2():
 
     tst = gdaltest.GDALTest("BSB", "bsb/rgbsmall.kap", 1, 30321)
 
-    return tst.testCreateCopy()
+    tst.testCreateCopy()
 
 
 ###############################################################################
@@ -86,7 +86,7 @@ def test_bsb_3():
 
     tst = gdaltest.GDALTest("BSB", "bsb/rgbsmall_index.kap", 1, 30321)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -101,7 +101,7 @@ def test_bsb_4():
 
     tst = gdaltest.GDALTest("BSB", "bsb/rgbsmall_with_line_break.kap", 1, 30321)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################

--- a/autotest/gdrivers/bt.py
+++ b/autotest/gdrivers/bt.py
@@ -44,7 +44,7 @@ def test_bt_1():
     tst = gdaltest.GDALTest("BT", "int16.tif", 1, 4672)
     srs = osr.SpatialReference()
     srs.SetWellKnownGeogCS("NAD27")
-    return tst.testCreateCopy(
+    tst.testCreateCopy(
         vsimem=1,
         check_srs=srs.ExportToWkt(),
         check_gt=(-67.00041667, 0.00083333, 0.0, 50.000416667, 0.0, -0.00083333),
@@ -60,7 +60,7 @@ def test_bt_2():
     tst = gdaltest.GDALTest("BT", "int32.tif", 1, 4672)
     srs = osr.SpatialReference()
     srs.SetWellKnownGeogCS("NAD27")
-    return tst.testCreateCopy(
+    tst.testCreateCopy(
         check_srs=srs.ExportToWkt(),
         check_gt=(-67.00041667, 0.00083333, 0.0, 50.000416667, 0.0, -0.00083333),
     )
@@ -75,7 +75,7 @@ def test_bt_3():
     tst = gdaltest.GDALTest("BT", "float32.tif", 1, 4672)
     srs = osr.SpatialReference()
     srs.SetWellKnownGeogCS("NAD27")
-    return tst.testCreateCopy(
+    tst.testCreateCopy(
         check_srs=srs.ExportToWkt(),
         check_gt=(-67.00041667, 0.00083333, 0.0, 50.000416667, 0.0, -0.00083333),
     )
@@ -88,7 +88,7 @@ def test_bt_3():
 def test_bt_4():
 
     tst = gdaltest.GDALTest("BT", "float32.tif", 1, 4672)
-    return tst.testCreate(out_bands=1)
+    tst.testCreate(out_bands=1)
 
 
 ###############################################################################
@@ -98,7 +98,7 @@ def test_bt_4():
 def test_bt_5():
 
     tst = gdaltest.GDALTest("BT", "float32.tif", 1, 4672)
-    return tst.testSetProjection()
+    tst.testSetProjection()
 
 
 ###############################################################################
@@ -108,7 +108,7 @@ def test_bt_5():
 def test_bt_6():
 
     tst = gdaltest.GDALTest("BT", "float32.tif", 1, 4672)
-    return tst.testSetGeoTransform()
+    tst.testSetGeoTransform()
 
 
 ###############################################################################

--- a/autotest/gdrivers/byn.py
+++ b/autotest/gdrivers/byn.py
@@ -50,7 +50,7 @@ def test_byn_1():
 def test_byn_2():
 
     tst = gdaltest.GDALTest("BYN", "byn/cgg2013ai08_reduced.byn", 1, 64764)
-    return tst.testCreateCopy(new_filename="tmp/byn_test_2.byn")
+    tst.testCreateCopy(new_filename="tmp/byn_test_2.byn")
 
 
 ###############################################################################

--- a/autotest/gdrivers/cals.py
+++ b/autotest/gdrivers/cals.py
@@ -44,7 +44,7 @@ def test_cals_1():
 
     tst = gdaltest.GDALTest("CALS", "hfa/small1bit.img", 1, 9907)
 
-    return tst.testCreateCopy()
+    tst.testCreateCopy()
 
 
 ###############################################################################
@@ -56,7 +56,7 @@ def test_cals_2():
     # Has no color table
     tst = gdaltest.GDALTest("CALS", "../../gcore/data/oddsize1bit.tif", 1, 3883)
 
-    return tst.testCreateCopy()
+    tst.testCreateCopy()
 
 
 ###############################################################################

--- a/autotest/gdrivers/ctg.py
+++ b/autotest/gdrivers/ctg.py
@@ -62,16 +62,13 @@ def test_ctg_1():
     AUTHORITY["EPSG","32614"],
     AXIS["Easting",EAST],
     AXIS["Northing",NORTH]]"""
-    ret = tst.testOpen(check_gt=expected_gt, check_prj=expected_srs)
+    tst.testOpen(check_gt=expected_gt, check_prj=expected_srs)
 
-    if ret == "success":
-        ds = gdal.Open("data/ctg/fake_grid_cell")
-        lst = ds.GetRasterBand(1).GetCategoryNames()
-        assert lst is not None and lst, "expected non empty category names for band 1"
-        lst = ds.GetRasterBand(2).GetCategoryNames()
-        assert lst is None, "expected empty category names for band 2"
-        assert (
-            ds.GetRasterBand(1).GetNoDataValue() == 0
-        ), "did not get expected nodata value"
-
-    return ret
+    ds = gdal.Open("data/ctg/fake_grid_cell")
+    lst = ds.GetRasterBand(1).GetCategoryNames()
+    assert lst is not None and lst, "expected non empty category names for band 1"
+    lst = ds.GetRasterBand(2).GetCategoryNames()
+    assert lst is None, "expected empty category names for band 2"
+    assert (
+        ds.GetRasterBand(1).GetNoDataValue() == 0
+    ), "did not get expected nodata value"

--- a/autotest/gdrivers/dipex.py
+++ b/autotest/gdrivers/dipex.py
@@ -38,4 +38,4 @@ import gdaltest
 def test_dipex_1():
 
     tst = gdaltest.GDALTest("DIPEx", "dipex/fakedipex.dat", 1, 1)
-    return tst.testOpen()
+    tst.testOpen()

--- a/autotest/gdrivers/dted.py
+++ b/autotest/gdrivers/dted.py
@@ -46,7 +46,7 @@ pytestmark = pytest.mark.require_driver("DTED")
 def test_dted_1():
 
     tst = gdaltest.GDALTest("dted", "n43.dt0", 1, 49187)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -92,7 +92,7 @@ def test_dted_3():
 
     prj = 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Latitude",NORTH],AXIS["Longitude",EAST],AUTHORITY["EPSG","4326"]]'
 
-    return tst.testCreateCopy(check_gt=1, check_srs=prj)
+    tst.testCreateCopy(check_gt=1, check_srs=prj)
 
 
 ###############################################################################
@@ -102,7 +102,7 @@ def test_dted_3():
 def test_dted_4():
 
     tst = gdaltest.GDALTest("dted", "n43.dt0", 1, 305, 5, 5, 5, 5)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -254,7 +254,7 @@ def test_dted_9():
 def test_dted_10():
 
     tst = gdaltest.GDALTest("dted", "n43.dt0", 1, 49187)
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 ###############################################################################
@@ -311,7 +311,7 @@ def test_dted_12():
 def test_dted_13():
 
     tst = gdaltest.GDALTest("dted", "dted/n43_partial_cols.dt0", 1, 56006)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -322,7 +322,7 @@ def test_dted_13():
 def test_dted_14():
 
     tst = gdaltest.GDALTest("dted", "dted/n43_sparse_cols.dt0", 1, 56369)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -333,8 +333,7 @@ def test_dted_15():
 
     with gdal.config_option("GDAL_DTED_SINGLE_BLOCK", "YES"):
         tst = gdaltest.GDALTest("dted", "n43.dt0", 1, 49187)
-        ret = tst.testOpen()
-    return ret
+        tst.testOpen()
 
 
 def test_dted_16():

--- a/autotest/gdrivers/ecw.py
+++ b/autotest/gdrivers/ecw.py
@@ -656,7 +656,7 @@ def test_ecw_16():
     gt = (440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0)
 
     tst = gdaltest.GDALTest("JP2ECW", "jpeg2000/byte.jp2", 1, 50054)
-    return tst.testOpen(check_prj=srs, check_gt=gt)
+    tst.testOpen(check_prj=srs, check_gt=gt)
 
 
 ###############################################################################
@@ -716,9 +716,8 @@ def test_ecw_18():
     tst = gdaltest.GDALTest(
         "JP2ECW", "/vsigzip/data/jpeg2000/byte.jp2.gz", 1, 50054, filename_absolute=1
     )
-    ret = tst.testOpen(check_prj=srs, check_gt=gt)
+    tst.testOpen(check_prj=srs, check_gt=gt)
     gdal.Unlink("data/jpeg2000/byte.jp2.gz.properties")
-    return ret
 
 
 ###############################################################################

--- a/autotest/gdrivers/ehdr.py
+++ b/autotest/gdrivers/ehdr.py
@@ -48,7 +48,7 @@ def test_ehdr_1():
 
     tst = gdaltest.GDALTest("EHDR", "png/rgba16.png", 2, 2042)
 
-    return tst.testCreate()
+    tst.testCreate()
 
 
 ###############################################################################
@@ -59,7 +59,7 @@ def test_ehdr_2():
 
     tst = gdaltest.GDALTest("EHDR", "byte.tif", 1, 4672)
 
-    return tst.testCreateCopy(check_gt=1, check_srs=1)
+    tst.testCreateCopy(check_gt=1, check_srs=1)
 
 
 ###############################################################################
@@ -70,7 +70,7 @@ def test_ehdr_3():
 
     tst = gdaltest.GDALTest("EHDR", "ehdr/float32.bil", 1, 27)
 
-    return tst.testCreateCopy()
+    tst.testCreateCopy()
 
 
 ###############################################################################
@@ -138,7 +138,7 @@ def test_ehdr_6():
 
     tst = gdaltest.GDALTest("EHDR", "ehdr/float32.bil", 1, 27)
 
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 ###############################################################################
@@ -149,7 +149,7 @@ def test_ehdr_7():
 
     tst = gdaltest.GDALTest("EHDR", "int32.tif", 1, 4672)
 
-    return tst.testCreateCopy()
+    tst.testCreateCopy()
 
 
 ###############################################################################
@@ -200,7 +200,7 @@ def test_ehdr_9():
 
 def test_ehdr_10():
     tst = gdaltest.GDALTest("EHDR", "ehdr/ehdr10.bil", 1, 8202)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -209,7 +209,7 @@ def test_ehdr_10():
 
 def test_ehdr_11():
     tst = gdaltest.GDALTest("EHDR", "ehdr/ehdr11.flt", 1, 8202)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################

--- a/autotest/gdrivers/eir.py
+++ b/autotest/gdrivers/eir.py
@@ -38,4 +38,4 @@ import gdaltest
 def test_eir_1():
 
     tst = gdaltest.GDALTest("EIR", "eir/fakeeir.hdr", 1, 1)
-    return tst.testOpen()
+    tst.testOpen()

--- a/autotest/gdrivers/elas.py
+++ b/autotest/gdrivers/elas.py
@@ -38,7 +38,7 @@ import gdaltest
 def test_elas_1():
 
     tst = gdaltest.GDALTest("ELAS", "elas/byte_elas.bin", 1, 4672)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -48,4 +48,4 @@ def test_elas_1():
 def test_elas_2():
 
     tst = gdaltest.GDALTest("ELAS", "elas/byte_elas.bin", 1, 4672)
-    return tst.testCreate()
+    tst.testCreate()

--- a/autotest/gdrivers/envi.py
+++ b/autotest/gdrivers/envi.py
@@ -65,7 +65,7 @@ def test_envi_1():
     PARAMETER["false_northing",0],
     UNIT["Meter",1]]"""
 
-    return tst.testOpen(
+    tst.testOpen(
         check_prj=prj, check_gt=(-936408.178, 28.5, 0.0, 2423902.344, 0.0, -28.5)
     )
 
@@ -77,7 +77,7 @@ def test_envi_1():
 def test_envi_2():
 
     tst = gdaltest.GDALTest("envi", "envi/aea.dat", 1, 14823)
-    return tst.testCreateCopy(check_gt=1)
+    tst.testCreateCopy(check_gt=1)
 
 
 ###############################################################################
@@ -87,7 +87,7 @@ def test_envi_2():
 def test_envi_3():
 
     tst = gdaltest.GDALTest("envi", "rgbsmall.tif", 2, 21053)
-    return tst.testCreate()
+    tst.testCreate()
 
 
 ###############################################################################
@@ -114,7 +114,7 @@ def test_envi_4():
     PARAMETER["false_northing",30000],
     UNIT["Meter",1]]"""
 
-    return tst.testSetProjection(prj=prj)
+    tst.testSetProjection(prj=prj)
 
 
 ###############################################################################
@@ -142,7 +142,7 @@ def test_envi_5():
     AXIS["Easting",EAST],
     AXIS["Northing",NORTH]]"""
 
-    return tst.testSetProjection(prj=prj)
+    tst.testSetProjection(prj=prj)
 
 
 ###############################################################################
@@ -169,7 +169,7 @@ def test_envi_6():
     AXIS["Easting",EAST],
     AXIS["Northing",NORTH]]"""
 
-    return gdaltest.envi_tst.testSetProjection(prj=prj)
+    gdaltest.envi_tst.testSetProjection(prj=prj)
 
 
 ###############################################################################
@@ -179,7 +179,7 @@ def test_envi_6():
 def test_envi_7():
 
     tst = gdaltest.GDALTest("envi", "envi/aea.dat", 1, 14823)
-    return tst.testCreateCopy(check_gt=1, vsimem=1)
+    tst.testCreateCopy(check_gt=1, vsimem=1)
 
 
 ###############################################################################
@@ -205,7 +205,7 @@ def test_envi_8():
 def test_envi_9():
 
     tst = gdaltest.GDALTest("envi", "envi/aea_compressed.dat", 1, 14823)
-    return tst.testCreateCopy(check_gt=1)
+    tst.testCreateCopy(check_gt=1)
 
 
 ###############################################################################

--- a/autotest/gdrivers/ers.py
+++ b/autotest/gdrivers/ers.py
@@ -63,7 +63,7 @@ def test_ers_1():
 def test_ers_2():
 
     tst = gdaltest.GDALTest("ERS", "ehdr/float32.bil", 1, 27)
-    return tst.testCreateCopy(new_filename="tmp/float32.ers", check_gt=1, vsimem=1)
+    tst.testCreateCopy(new_filename="tmp/float32.ers", check_gt=1, vsimem=1)
 
 
 ###############################################################################
@@ -73,7 +73,7 @@ def test_ers_2():
 def test_ers_3():
 
     tst = gdaltest.GDALTest("ERS", "rgbsmall.tif", 2, 21053)
-    return tst.testCreate(new_filename="tmp/rgbsmall.ers")
+    tst.testCreate(new_filename="tmp/rgbsmall.ers")
 
 
 ###############################################################################
@@ -90,7 +90,7 @@ def test_ers_4():
     UNIT["degree",0.0174532925199433]]"""
 
     tst = gdaltest.GDALTest("ERS", "ers/ers_dem.ers", 1, 56588)
-    return tst.testOpen(check_prj=srs, check_gt=gt)
+    tst.testOpen(check_prj=srs, check_gt=gt)
 
 
 ###############################################################################

--- a/autotest/gdrivers/exr.py
+++ b/autotest/gdrivers/exr.py
@@ -38,67 +38,67 @@ pytestmark = pytest.mark.require_driver("EXR")
 
 def test_exr_byte_createcopy():
     tst = gdaltest.GDALTest("EXR", "byte.tif", 1, 4672)
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 def test_exr_byte_createcopy_pixel_type_half():
     tst = gdaltest.GDALTest("EXR", "byte.tif", 1, 4672, options=["PIXEL_TYPE=HALF"])
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 def test_exr_byte_createcopy_pixel_type_float():
     tst = gdaltest.GDALTest("EXR", "byte.tif", 1, 4672, options=["PIXEL_TYPE=FLOAT"])
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 def test_exr_byte_createcopy_pixel_type_uint():
     tst = gdaltest.GDALTest("EXR", "byte.tif", 1, 4672, options=["PIXEL_TYPE=UINT"])
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 def test_exr_byte_create():
     tst = gdaltest.GDALTest("EXR", "byte.tif", 1, 4672)
-    return tst.testCreate(vsimem=1)
+    tst.testCreate(vsimem=1)
 
 
 def test_exr_uint16_createcopy():
     tst = gdaltest.GDALTest("EXR", "../../gcore/data/uint16.tif", 1, 4672)
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 def test_exr_uint16_create():
     tst = gdaltest.GDALTest("EXR", "../../gcore/data/uint16.tif", 1, 4672)
-    return tst.testCreate(vsimem=1)
+    tst.testCreate(vsimem=1)
 
 
 def test_exr_uint32_createcopy():
     tst = gdaltest.GDALTest("EXR", "../../gcore/data/uint32.tif", 1, 4672)
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 def test_exr_uint32_create():
     tst = gdaltest.GDALTest("EXR", "../../gcore/data/uint32.tif", 1, 4672)
-    return tst.testCreate(vsimem=1)
+    tst.testCreate(vsimem=1)
 
 
 def test_exr_float32_createcopy():
     tst = gdaltest.GDALTest("EXR", "../../gcore/data/float32.tif", 1, 4672)
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 def test_exr_float32_create():
     tst = gdaltest.GDALTest("EXR", "../../gcore/data/float32.tif", 1, 4672)
-    return tst.testCreate(vsimem=1)
+    tst.testCreate(vsimem=1)
 
 
 def test_exr_float64_createcopy():
     tst = gdaltest.GDALTest("EXR", "../../gcore/data/float64.tif", 1, 4672)
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 def test_exr_float64_create():
     tst = gdaltest.GDALTest("EXR", "../../gcore/data/float64.tif", 1, 4672)
-    return tst.testCreate(vsimem=1)
+    tst.testCreate(vsimem=1)
 
 
 def test_exr_compression_createcopy():

--- a/autotest/gdrivers/fast.py
+++ b/autotest/gdrivers/fast.py
@@ -48,7 +48,7 @@ def test_fast_2():
     tst = gdaltest.GDALTest(
         "fast", "fast/L71118038_03820020111_HPN.FST", 1, 60323, 0, 0, 5000, 1
     )
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -144,7 +144,7 @@ def test_fast_5():
         PARAMETER["false_northing",10002288.3],
         UNIT["Meter",1]]"""
 
-    return tst.testOpen(check_gt=gt, check_prj=proj)
+    tst.testOpen(check_gt=gt, check_prj=proj)
 
 
 ###############################################################################
@@ -169,7 +169,7 @@ def test_fast_6():
     proj = """LOCAL_CS["GCTP projection number 22",
     UNIT["Meter",1]]"""
 
-    return tst.testOpen(check_gt=gt, check_prj=proj)
+    tst.testOpen(check_gt=gt, check_prj=proj)
 
 
 ###############################################################################
@@ -199,7 +199,7 @@ def test_fast_7():
     PARAMETER["false_northing",0],
     UNIT["Meter",1]]"""
 
-    return tst.testOpen(check_gt=gt, check_prj=proj)
+    tst.testOpen(check_gt=gt, check_prj=proj)
 
 
 ###############################################################################
@@ -237,7 +237,7 @@ def test_fast_8():
     PARAMETER["false_northing",0],
     UNIT["Meter",1]]"""
 
-    return tst.testOpen(check_gt=gt, check_prj=proj)
+    tst.testOpen(check_gt=gt, check_prj=proj)
 
 
 ###############################################################################

--- a/autotest/gdrivers/gdalhttp.py
+++ b/autotest/gdrivers/gdalhttp.py
@@ -101,8 +101,10 @@ def test_http_1():
 def test_http_2():
     url = "https://raw.githubusercontent.com/OSGeo/gdal/release/3.1/autotest/gcore/data/byte.tif"
     tst = gdaltest.GDALTest("GTiff", "/vsicurl/" + url, 1, 4672, filename_absolute=1)
-    ret = tst.testOpen()
-    if ret == "fail":
+
+    try:
+        tst.testOpen()
+    except Exception:
         skip_if_unreachable(url)
         pytest.fail()
 

--- a/autotest/gdrivers/genbin.py
+++ b/autotest/gdrivers/genbin.py
@@ -54,4 +54,4 @@ def test_genbin_1():
             -82.021003723045894,
         )
 
-        return tst.testOpen(check_prj=sr.ExportToWkt(), check_gt=gt)
+        tst.testOpen(check_prj=sr.ExportToWkt(), check_gt=gt)

--- a/autotest/gdrivers/georaster.py
+++ b/autotest/gdrivers/georaster.py
@@ -114,7 +114,7 @@ def test_georaster_byte():
 
     tst = gdaltest.GDALTest("GeoRaster", ds_name, 1, 4672, filename_absolute=1)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -145,7 +145,7 @@ def test_georaster_int16():
 
     tst = gdaltest.GDALTest("GeoRaster", ds_name, 1, 4672, filename_absolute=1)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -176,7 +176,7 @@ def test_georaster_int32():
 
     tst = gdaltest.GDALTest("GeoRaster", ds_name, 1, 4672, filename_absolute=1)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -206,7 +206,7 @@ def test_georaster_rgb_b1():
 
     tst = gdaltest.GDALTest("GeoRaster", ds_name, 1, 21212, filename_absolute=1)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -236,7 +236,7 @@ def test_georaster_rgb_b2():
 
     tst = gdaltest.GDALTest("GeoRaster", ds_name, 1, 21212, filename_absolute=1)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -267,7 +267,7 @@ def test_georaster_rgb_b3_bsq():
 
     tst = gdaltest.GDALTest("GeoRaster", ds_name, 1, 21212, filename_absolute=1)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -298,7 +298,7 @@ def test_georaster_rgb_b3_bip():
 
     tst = gdaltest.GDALTest("GeoRaster", ds_name, 1, 21212, filename_absolute=1)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -329,7 +329,7 @@ def test_georaster_rgb_b3_bil():
 
     tst = gdaltest.GDALTest("GeoRaster", ds_name, 1, 21212, filename_absolute=1)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -359,7 +359,7 @@ def test_georaster_byte_deflate():
 
     tst = gdaltest.GDALTest("GeoRaster", ds_name, 1, 4672, filename_absolute=1)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -391,7 +391,7 @@ def test_georaster_rgb_deflate_b3():
 
     tst = gdaltest.GDALTest("GeoRaster", ds_name, 1, 21212, filename_absolute=1)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -421,7 +421,7 @@ def test_georaster_1bit():
 
     tst = gdaltest.GDALTest("GeoRaster", ds_name, 1, 252, filename_absolute=1)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -451,7 +451,7 @@ def test_georaster_2bit():
 
     tst = gdaltest.GDALTest("GeoRaster", ds_name, 1, 718, filename_absolute=1)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -481,7 +481,7 @@ def test_georaster_4bit():
 
     tst = gdaltest.GDALTest("GeoRaster", ds_name, 1, 2578, filename_absolute=1)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################

--- a/autotest/gdrivers/gif.py
+++ b/autotest/gdrivers/gif.py
@@ -54,7 +54,7 @@ def test_gif_1():
 def test_gif_2():
 
     tst = gdaltest.GDALTest("GIF", "gif/bug407.gif", 1, 57921)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -67,7 +67,7 @@ def test_gif_3():
         "GIF", "gif/bug407.gif", 1, 57921, options=["INTERLACING=NO"]
     )
 
-    return tst.testCreateCopy()
+    tst.testCreateCopy()
 
 
 ###############################################################################
@@ -102,7 +102,7 @@ def test_gif_5():
 
     tst = gdaltest.GDALTest("GIF", "byte.tif", 1, 4672)
 
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 ###############################################################################
@@ -205,7 +205,7 @@ def test_gif_10():
 
     tst = gdaltest.GDALTest("GIF", "byte.tif", 1, 4672, options=["INTERLACING=YES"])
 
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 ###############################################################################

--- a/autotest/gdrivers/gmt.py
+++ b/autotest/gdrivers/gmt.py
@@ -55,7 +55,7 @@ def test_gmt_1():
         -0.083333333333333,
     )
 
-    return tst.testOpen(check_gt=gt)
+    tst.testOpen(check_gt=gt)
 
 
 ###############################################################################
@@ -68,7 +68,7 @@ def test_gmt_2():
         pytest.skip()
 
     tst = gdaltest.GDALTest("GMT", "int16.tif", 1, 4672)
-    return tst.testCreateCopy(check_gt=1)
+    tst.testCreateCopy(check_gt=1)
 
 
 ###############################################################################

--- a/autotest/gdrivers/grassasciigrid.py
+++ b/autotest/gdrivers/grassasciigrid.py
@@ -39,7 +39,7 @@ def test_grassasciigrid_1():
 
     tst = gdaltest.GDALTest("GRASSASCIIGrid", "grassasciigrid/grassascii.txt", 1, 212)
     expected_gt = [-100.0, 62.5, 0.0, 250.0, 0.0, -41.666666666666664]
-    return tst.testOpen(check_gt=expected_gt)
+    tst.testOpen(check_gt=expected_gt)
 
 
 ###############################################################################

--- a/autotest/gdrivers/grib.py
+++ b/autotest/gdrivers/grib.py
@@ -63,7 +63,7 @@ def has_jp2kdrv():
 def test_grib_1():
 
     tst = gdaltest.GDALTest("GRIB", "grib/ds.mint.bin", 2, 46927)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -91,13 +91,11 @@ def test_grib_read_different_sizes_messages():
 
     tst = gdaltest.GDALTest("GRIB", "grib/bug3246.grb", 4, 4081)
     with gdaltest.error_handler():
-        result = tst.testOpen()
+        tst.testOpen()
 
     msg = gdal.GetLastErrorMsg()
     assert "data access may be incomplete" in msg, "did not get expected warning."
     assert gdal.GetLastErrorType() == 2, "did not get expected warning."
-
-    return result
 
 
 ###############################################################################

--- a/autotest/gdrivers/gsc.py
+++ b/autotest/gdrivers/gsc.py
@@ -38,4 +38,4 @@ import gdaltest
 def test_gsc_1():
 
     tst = gdaltest.GDALTest("GSC", "gsc/fakegsc.gsc", 1, 0)
-    return tst.testOpen()
+    tst.testOpen()

--- a/autotest/gdrivers/gsg.py
+++ b/autotest/gdrivers/gsg.py
@@ -38,19 +38,19 @@ import gdaltest
 def test_gsg_1():
 
     tst = gdaltest.GDALTest("gsbg", "gsg/gsg_binary.grd", 1, 4672)
-    return tst.testOpen(check_gt=(440720, 60, 0, 3751320, 0, -60))
+    tst.testOpen(check_gt=(440720, 60, 0, 3751320, 0, -60))
 
 
 def test_gsg_2():
 
     tst = gdaltest.GDALTest("gsag", "gsg/gsg_ascii.grd", 1, 4672)
-    return tst.testOpen(check_gt=(440720, 60, 0, 3751320, 0, -60))
+    tst.testOpen(check_gt=(440720, 60, 0, 3751320, 0, -60))
 
 
 def test_gsg_3():
 
     tst = gdaltest.GDALTest("gs7bg", "gsg/gsg_7binary.grd", 1, 4672)
-    return tst.testOpen(check_gt=(440720, 60, 0, 3751320, 0, -60))
+    tst.testOpen(check_gt=(440720, 60, 0, 3751320, 0, -60))
 
 
 ###############################################################################
@@ -61,35 +61,35 @@ def test_gsg_4():
 
     tst = gdaltest.GDALTest("gsbg", "gsg/gsg_binary.grd", 1, 4672)
 
-    return tst.testCreateCopy(check_gt=1)
+    tst.testCreateCopy(check_gt=1)
 
 
 def test_gsg_5():
 
     tst = gdaltest.GDALTest("gsag", "gsg/gsg_ascii.grd", 1, 4672)
 
-    return tst.testCreateCopy(check_gt=1)
+    tst.testCreateCopy(check_gt=1)
 
 
 def test_gsg_6():
 
     tst = gdaltest.GDALTest("gsbg", "gsg/gsg_binary.grd", 1, 4672)
 
-    return tst.testCreate(out_bands=1)
+    tst.testCreate(out_bands=1)
 
 
 def test_gsg_7():
 
     tst = gdaltest.GDALTest("gs7bg", "gsg/gsg_7binary.grd", 1, 4672)
 
-    return tst.testCreate(out_bands=1)
+    tst.testCreate(out_bands=1)
 
 
 def test_gsg_8():
 
     tst = gdaltest.GDALTest("gs7bg", "gsg/gsg_7binary.grd", 1, 4672)
 
-    return tst.testCreateCopy(check_gt=1)
+    tst.testCreateCopy(check_gt=1)
 
 
 ###############################################################################

--- a/autotest/gdrivers/gtx.py
+++ b/autotest/gdrivers/gtx.py
@@ -39,4 +39,4 @@ def test_gtx_1():
 
     tst = gdaltest.GDALTest("GTX", "gtx/hydroc1.gtx", 1, 64183)
     gt = (276.725, 0.05, 0.0, 42.775, 0.0, -0.05)
-    return tst.testOpen(check_gt=gt, check_prj="WGS84")
+    tst.testOpen(check_gt=gt, check_prj="WGS84")

--- a/autotest/gdrivers/gxf.py
+++ b/autotest/gdrivers/gxf.py
@@ -45,7 +45,7 @@ def test_gxf_1():
 
     tst = gdaltest.GDALTest("GXF", "gxf/small.gxf", 1, 90)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -69,7 +69,7 @@ def test_gxf_2():
     PARAMETER["false_easting",609601.22],
     UNIT["ftUS",0.3048006096012]]"""
 
-    return tst.testOpen(check_prj=wkt)
+    tst.testOpen(check_prj=wkt)
 
 
 gxf_list = [

--- a/autotest/gdrivers/hf2.py
+++ b/autotest/gdrivers/hf2.py
@@ -39,7 +39,7 @@ import gdaltest
 def test_hf2_1():
 
     tst = gdaltest.GDALTest("HF2", "byte.tif", 1, 4672)
-    return tst.testCreateCopy(
+    tst.testCreateCopy(
         vsimem=1,
         check_gt=(-67.00041667, 0.00083333, 0.0, 50.000416667, 0.0, -0.00083333),
     )
@@ -54,12 +54,11 @@ def test_hf2_2():
     tst = gdaltest.GDALTest(
         "HF2", "byte.tif", 1, 4672, options=["COMPRESS=YES", "BLOCKSIZE=10"]
     )
-    ret = tst.testCreateCopy(new_filename="tmp/hf2_2.hfz")
+    tst.testCreateCopy(new_filename="tmp/hf2_2.hfz")
     try:
         os.remove("tmp/hf2_2.hfz.properties")
     except OSError:
         pass
-    return ret
 
 
 ###############################################################################
@@ -69,7 +68,7 @@ def test_hf2_2():
 def test_hf2_3():
 
     tst = gdaltest.GDALTest("HF2", "hfa/float.img", 1, 23529)
-    return tst.testCreateCopy(check_minmax=0)
+    tst.testCreateCopy(check_minmax=0)
 
 
 ###############################################################################
@@ -79,7 +78,7 @@ def test_hf2_3():
 def test_hf2_4():
 
     tst = gdaltest.GDALTest("HF2", "n43.dt0", 1, 49187)
-    return tst.testCreateCopy()
+    tst.testCreateCopy()
 
 
 ###############################################################################

--- a/autotest/gdrivers/hfa.py
+++ b/autotest/gdrivers/hfa.py
@@ -1074,9 +1074,8 @@ def test_hfa_write_tmso_projection():
     )
     out_ds = None
     exp_wkt = 'PROJCS["Hartebeesthoek94 / Lo15",GEOGCS["Hartebeesthoek94",DATUM["Hartebeesthoek94",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY["EPSG","6148"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.01745329251994328,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4148"]],UNIT["metre",1,AUTHORITY["EPSG","9001"]],PROJECTION["Transverse_Mercator_South_Orientated"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",15],PARAMETER["scale_factor",1],PARAMETER["false_easting",0],PARAMETER["false_northing",0],AUTHORITY["EPSG","2046"],AXIS["Y",WEST],AXIS["X",SOUTH]]'
-    ret = hfa_verify_dataset_projection(dataset_path, exp_wkt)
+    hfa_verify_dataset_projection(dataset_path, exp_wkt)
     gdal.GetDriverByName("HFA").Delete(dataset_path)
-    return ret
 
 
 ###############################################################################
@@ -1110,9 +1109,8 @@ def test_hfa_write_homva_projection():
     )
     out_ds = None
     exp_wkt = 'PROJCS["Hotine Oblique Mercator (Variant A)",GEOGCS["GDM_2000",DATUM["GDM_2000",SPHEROID["GRS 1980",6378137,298.257222096042],TOWGS84[0,0,0,0,0,0,0]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]]],PROJECTION["Hotine_Oblique_Mercator"],PARAMETER["latitude_of_center",4],PARAMETER["longitude_of_center",115],PARAMETER["azimuth",53.31580995],PARAMETER["rectified_grid_angle",53.1301023611111],PARAMETER["scale_factor",0.99984],PARAMETER["false_easting",0],PARAMETER["false_northing",0],UNIT["meters",1],AXIS["Easting",EAST],AXIS["Northing",NORTH]]'
-    ret = hfa_verify_dataset_projection(dataset_path, exp_wkt)
+    hfa_verify_dataset_projection(dataset_path, exp_wkt)
     gdal.GetDriverByName("HFA").Delete(dataset_path)
-    return ret
 
 
 ###############################################################################

--- a/autotest/gdrivers/idrisi.py
+++ b/autotest/gdrivers/idrisi.py
@@ -40,7 +40,7 @@ import gdaltest
 def test_idrisi_1():
 
     tst = gdaltest.GDALTest("RST", "rst/byte.rst", 1, 5044)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -50,7 +50,7 @@ def test_idrisi_1():
 def test_idrisi_2():
 
     tst = gdaltest.GDALTest("RST", "rst/real.rst", 1, 5275)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -61,7 +61,7 @@ def test_idrisi_3():
 
     tst = gdaltest.GDALTest("RST", "ehdr/float32.bil", 1, 27)
 
-    return tst.testCreate(new_filename="tmp/float32.rst", out_bands=1, vsimem=1)
+    tst.testCreate(new_filename="tmp/float32.rst", out_bands=1, vsimem=1)
 
 
 ###############################################################################
@@ -72,7 +72,7 @@ def test_idrisi_4():
 
     tst = gdaltest.GDALTest("RST", "rgbsmall.tif", 2, 21053)
 
-    return tst.testCreateCopy(
+    tst.testCreateCopy(
         check_gt=1, check_srs=1, new_filename="tmp/rgbsmall_cc.rst", vsimem=1
     )
 

--- a/autotest/gdrivers/ilwis.py
+++ b/autotest/gdrivers/ilwis.py
@@ -62,7 +62,7 @@ def test_ilwis_1():
 
     gt = (795480, 20, 0, 8090520, 0, -20)
 
-    return tst.testOpen(check_gt=gt, check_prj=srs)
+    tst.testOpen(check_gt=gt, check_prj=srs)
 
 
 ###############################################################################
@@ -73,7 +73,7 @@ def test_ilwis_2():
 
     tst = gdaltest.GDALTest("ilwis", "byte.tif", 1, 4672)
 
-    return tst.testCreateCopy(check_srs=1, check_gt=1, new_filename="tmp/byte.mpr")
+    tst.testCreateCopy(check_srs=1, check_gt=1, new_filename="tmp/byte.mpr")
 
 
 ###############################################################################
@@ -84,7 +84,7 @@ def test_ilwis_3():
 
     tst = gdaltest.GDALTest("ilwis", "hfa/float.img", 1, 23529)
 
-    return tst.testCreate(new_filename="tmp/float.mpr", out_bands=1)
+    tst.testCreate(new_filename="tmp/float.mpr", out_bands=1)
 
 
 ###############################################################################
@@ -95,7 +95,7 @@ def test_ilwis_4():
 
     tst = gdaltest.GDALTest("ilwis", "rgbsmall.tif", 2, 21053)
 
-    return tst.testCreate(new_filename="tmp/rgb.mpl", check_minmax=0, out_bands=3)
+    tst.testCreate(new_filename="tmp/rgb.mpl", check_minmax=0, out_bands=3)
 
 
 ###############################################################################
@@ -106,7 +106,7 @@ def test_ilwis_5():
 
     tst = gdaltest.GDALTest("ilwis", "byte.tif", 1, 4672)
 
-    return tst.testCreateCopy(
+    tst.testCreateCopy(
         check_srs=1, check_gt=1, vsimem=1, new_filename="/vsimem/ilwis/byte.mpr"
     )
 

--- a/autotest/gdrivers/iris.py
+++ b/autotest/gdrivers/iris.py
@@ -43,7 +43,7 @@ pytestmark = pytest.mark.require_driver("IRIS")
 def test_iris_1():
 
     tst = gdaltest.GDALTest("IRIS", "iris/fakeiris.dat", 1, 65532)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################

--- a/autotest/gdrivers/isce.py
+++ b/autotest/gdrivers/isce.py
@@ -56,7 +56,7 @@ def test_isce_1():
         AUTHORITY["EPSG","9108"]],
     AUTHORITY["EPSG","4326"]]"""
 
-    return tst.testOpen(
+    tst.testOpen(
         check_prj=prj,
         check_gt=(
             14.259166666666667,
@@ -87,7 +87,7 @@ def test_isce_2():
 def test_isce_3():
 
     tst = gdaltest.GDALTest("isce", "isce/isce.slc", 1, 350)
-    return tst.testCreateCopy(check_gt=0, new_filename="isce.tst.slc")
+    tst.testCreateCopy(check_gt=0, new_filename="isce.tst.slc")
 
 
 ###############################################################################
@@ -97,4 +97,4 @@ def test_isce_3():
 def test_isce_4():
 
     tst = gdaltest.GDALTest("isce", "isce/isce.slc", 1, 350)
-    return tst.testCreateCopy(check_gt=0, new_filename="isce.tst.slc", vsimem=1)
+    tst.testCreateCopy(check_gt=0, new_filename="isce.tst.slc", vsimem=1)

--- a/autotest/gdrivers/isg.py
+++ b/autotest/gdrivers/isg.py
@@ -43,7 +43,7 @@ def test_isg_1():
 
     tst = gdaltest.GDALTest("ISG", "isg/test.isg", 1, 159)
     expected_gt = [120.0, 0.25, 0.0, 41.0, 0.0, -0.25]
-    return tst.testOpen(check_gt=expected_gt)
+    tst.testOpen(check_gt=expected_gt)
 
 
 ###############################################################################

--- a/autotest/gdrivers/isis.py
+++ b/autotest/gdrivers/isis.py
@@ -68,7 +68,7 @@ def test_isis_1():
     )
 
     tst = gdaltest.GDALTest("ISIS3", "isis3/isis3_detached.lbl", 1, 9978)
-    return tst.testOpen(check_prj=srs, check_gt=gt)
+    tst.testOpen(check_prj=srs, check_gt=gt)
 
 
 ###############################################################################
@@ -93,7 +93,7 @@ def test_isis_2():
     gt = (653.132641495800044, 0.38, 0, -2298409.710162799805403, 0, -0.38)
 
     tst = gdaltest.GDALTest("ISIS3", "isis3/isis3_unit_test.cub", 1, 42403)
-    return tst.testOpen(check_prj=srs, check_gt=gt)
+    tst.testOpen(check_prj=srs, check_gt=gt)
 
 
 ###############################################################################
@@ -125,7 +125,7 @@ def test_isis_3():
     )
 
     tst = gdaltest.GDALTest("ISIS3", "isis3/isis3_geotiff.lbl", 1, 9978)
-    return tst.testOpen(check_prj=srs, check_gt=gt)
+    tst.testOpen(check_prj=srs, check_gt=gt)
 
 
 # ISIS3 -> ISIS3 conversion
@@ -558,7 +558,7 @@ def test_isis_16():
 def test_isis_17():
 
     tst = gdaltest.GDALTest("ISIS3", "isis3/isis3_detached.lbl", 1, 9978)
-    return tst.testCreate(vsimem=1)
+    tst.testCreate(vsimem=1)
 
 
 # Test SRS serialization and deserialization

--- a/autotest/gdrivers/isis2.py
+++ b/autotest/gdrivers/isis2.py
@@ -63,7 +63,7 @@ def test_isis2_1():
         0.0,
         -1200.0000476837158,
     )
-    return tst.testOpen(check_prj=expected_prj, check_gt=expected_gt)
+    tst.testOpen(check_prj=expected_prj, check_gt=expected_gt)
 
 
 ###############################################################################
@@ -74,7 +74,7 @@ def test_isis2_2():
 
     tst = gdaltest.GDALTest("ISIS2", "byte.tif", 1, 4672)
 
-    return tst.testCreate()
+    tst.testCreate()
 
 
 ###############################################################################
@@ -91,4 +91,4 @@ def test_isis2_3():
         options=["LABELING_METHOD=DETACHED", "IMAGE_EXTENSION=qub"],
     )
 
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)

--- a/autotest/gdrivers/jdem.py
+++ b/autotest/gdrivers/jdem.py
@@ -38,4 +38,4 @@ import gdaltest
 def test_jdem_1():
 
     tst = gdaltest.GDALTest("JDEM", "jdem/fakejdem.mem", 1, 15)
-    return tst.testOpen()
+    tst.testOpen()

--- a/autotest/gdrivers/jp2kak.py
+++ b/autotest/gdrivers/jp2kak.py
@@ -58,7 +58,7 @@ def startup_and_cleanup():
 def test_jp2kak_1():
 
     tst = gdaltest.GDALTest("JP2KAK", "jpeg2000/byte.jp2", 1, 50054)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -68,7 +68,7 @@ def test_jp2kak_1():
 def test_jp2kak_2():
 
     tst = gdaltest.GDALTest("JP2KAK", "jpeg2000/int16.jp2", 1, 4587)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -81,7 +81,7 @@ def test_jp2kak_3():
         "JP2KAK", "jpeg2000/byte.jp2", 1, 50054, options=["QUALITY=100"]
     )
 
-    return tst.testCreateCopy()
+    tst.testCreateCopy()
 
 
 ###############################################################################
@@ -92,7 +92,7 @@ def test_jp2kak_4():
 
     tst = gdaltest.GDALTest("JP2KAK", "rgbsmall.tif", 0, 0, options=["GMLJP2=OFF"])
 
-    return tst.testCreateCopy(check_srs=1, check_gt=1)
+    tst.testCreateCopy(check_srs=1, check_gt=1)
 
 
 ###############################################################################
@@ -103,7 +103,7 @@ def test_jp2kak_5():
 
     tst = gdaltest.GDALTest("JP2KAK", "rgbsmall.tif", 0, 0, options=["GEOJP2=OFF"])
 
-    return tst.testCreateCopy(check_srs=1, check_gt=1)
+    tst.testCreateCopy(check_srs=1, check_gt=1)
 
 
 ###############################################################################
@@ -117,7 +117,7 @@ def test_jp2kak_8():
         "JP2KAK", "jpeg2000/byte.jp2", 1, 50054, options=["QUALITY=100"]
     )
 
-    return tst.testCreateCopy(vsimem=1, new_filename="/vsimem/jp2kak_8.jpc")
+    tst.testCreateCopy(vsimem=1, new_filename="/vsimem/jp2kak_8.jpc")
 
 
 ###############################################################################
@@ -128,7 +128,7 @@ def test_jp2kak_8():
 def test_jp2kak_9():
 
     tst = gdaltest.GDALTest("JP2KAK", "jpeg2000/rgbwcmyk01_YeGeo_kakadu.jp2", 2, 32141)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -363,7 +363,7 @@ def test_jp2kak_lossless_int16(use_stripe_compressor):
     tst = gdaltest.GDALTest("JP2KAK", "int16.tif", 1, 4672, options=["QUALITY=100"])
 
     with gdaltest.config_option("JP2KAK_USE_STRIPE_COMPRESSOR", use_stripe_compressor):
-        return tst.testCreateCopy()
+        tst.testCreateCopy()
 
 
 ###############################################################################
@@ -383,7 +383,7 @@ def test_jp2kak_lossless_uint16(use_stripe_compressor):
     )
 
     with gdaltest.config_option("JP2KAK_USE_STRIPE_COMPRESSOR", use_stripe_compressor):
-        return tst.testCreateCopy(vsimem=1)
+        tst.testCreateCopy(vsimem=1)
 
 
 ###############################################################################
@@ -403,7 +403,7 @@ def test_jp2kak_lossless_int32(use_stripe_compressor):
     )
 
     with gdaltest.config_option("JP2KAK_USE_STRIPE_COMPRESSOR", use_stripe_compressor):
-        return tst.testCreateCopy()
+        tst.testCreateCopy()
 
 
 ###############################################################################
@@ -423,7 +423,7 @@ def test_jp2kak_lossless_uint32(use_stripe_compressor):
     )
 
     with gdaltest.config_option("JP2KAK_USE_STRIPE_COMPRESSOR", use_stripe_compressor):
-        return tst.testCreateCopy(vsimem=1)
+        tst.testCreateCopy(vsimem=1)
 
 
 ###############################################################################

--- a/autotest/gdrivers/jp2lura.py
+++ b/autotest/gdrivers/jp2lura.py
@@ -182,7 +182,7 @@ def test_jp2lura_2():
     gt = (440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0)
 
     tst = gdaltest.GDALTest("JP2Lura", "jpeg2000/byte.jp2", 1, 50054)
-    return tst.testOpen(check_prj=srs, check_gt=gt)
+    tst.testOpen(check_prj=srs, check_gt=gt)
 
 
 ###############################################################################
@@ -285,7 +285,7 @@ def test_jp2lura_5():
         None,
         options=["REVERSIBLE=YES", "CODEC=J2K"],
     )
-    return tst.testCreateCopy()
+    tst.testCreateCopy()
 
 
 ###############################################################################
@@ -312,9 +312,8 @@ def test_jp2lura_7():
     tst = gdaltest.GDALTest(
         "JP2Lura", "/vsigzip/data/jpeg2000/byte.jp2.gz", 1, 50054, filename_absolute=1
     )
-    ret = tst.testOpen()
+    tst.testOpen()
     gdal.Unlink("data/jpeg2000/byte.jp2.gz.properties")
-    return ret
 
 
 ###############################################################################
@@ -2135,7 +2134,7 @@ def test_jp2lura_50():
     tst = gdaltest.GDALTest(
         "JP2Lura", "jpeg2000/float32_ieee754_split_reversible.jp2", 1, 4672
     )
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################

--- a/autotest/gdrivers/jp2openjpeg.py
+++ b/autotest/gdrivers/jp2openjpeg.py
@@ -91,7 +91,7 @@ def test_jp2openjpeg_2():
     gt = (440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0)
 
     tst = gdaltest.GDALTest("JP2OpenJPEG", "jpeg2000/byte.jp2", 1, 50054)
-    return tst.testOpen(check_prj=srs, check_gt=gt)
+    tst.testOpen(check_prj=srs, check_gt=gt)
 
 
 ###############################################################################
@@ -205,7 +205,7 @@ def test_jp2openjpeg_5():
         None,
         options=["REVERSIBLE=YES", "QUALITY=100", "CODEC=J2K"],
     )
-    return tst.testCreateCopy()
+    tst.testCreateCopy()
 
 
 ###############################################################################
@@ -235,9 +235,8 @@ def test_jp2openjpeg_7():
         50054,
         filename_absolute=1,
     )
-    ret = tst.testOpen()
+    tst.testOpen()
     gdal.Unlink("data/jpeg2000/byte.jp2.gz.properties")
-    return ret
 
 
 ###############################################################################

--- a/autotest/gdrivers/jpeg.py
+++ b/autotest/gdrivers/jpeg.py
@@ -72,7 +72,7 @@ def test_jpeg_1():
         tst = gdaltest.GDALTest("JPEG", "jpeg/albania.jpg", 2, 34298)
     else:
         tst = gdaltest.GDALTest("JPEG", "jpeg/albania.jpg", 2, 17016)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################

--- a/autotest/gdrivers/jpegxl.py
+++ b/autotest/gdrivers/jpegxl.py
@@ -48,41 +48,41 @@ def module_disable_exceptions():
 
 def test_jpegxl_read():
     tst = gdaltest.GDALTest("JPEGXL", "jpegxl/byte.jxl", 1, 4672)
-    return tst.testOpen(check_gt=(440720, 60, 0, 3751320, 0, -60))
+    tst.testOpen(check_gt=(440720, 60, 0, 3751320, 0, -60))
 
 
 def test_jpegxl_byte():
     tst = gdaltest.GDALTest(
         "JPEGXL", "byte.tif", 1, 4672, options=["LOSSLESS_COPY=YES"]
     )
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 def test_jpegxl_uint16():
     tst = gdaltest.GDALTest("JPEGXL", "../../gcore/data/uint16.tif", 1, 4672)
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 def test_jpegxl_float32():
     tst = gdaltest.GDALTest("JPEGXL", "float32.tif", 1, 4672)
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 def test_jpegxl_grey_alpha():
     tst = gdaltest.GDALTest(
         "JPEGXL", "../../gcore/data/stefan_full_greyalpha.tif", 1, 1970
     )
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 def test_jpegxl_rgb():
     tst = gdaltest.GDALTest("JPEGXL", "rgbsmall.tif", 1, 21212)
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 def test_jpegxl_rgba():
     tst = gdaltest.GDALTest("JPEGXL", "../../gcore/data/stefan_full_rgba.tif", 1, 12603)
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 @pytest.mark.parametrize("lossless", ["YES", "NO", None])

--- a/autotest/gdrivers/kea.py
+++ b/autotest/gdrivers/kea.py
@@ -54,7 +54,7 @@ def test_kea_1():
     tst = gdaltest.GDALTest(
         "KEA", "byte.tif", 1, 4672, options=["IMAGEBLOCKSIZE=15", "THEMATIC=YES"]
     )
-    return tst.testCreateCopy(check_srs=True, check_gt=1, new_filename="tmp/byte.kea")
+    tst.testCreateCopy(check_srs=True, check_gt=1, new_filename="tmp/byte.kea")
 
 
 ###############################################################################

--- a/autotest/gdrivers/kmlsuperoverlay.py
+++ b/autotest/gdrivers/kmlsuperoverlay.py
@@ -49,7 +49,7 @@ def test_kmlsuperoverlay_1():
         "KMLSUPEROVERLAY", "small_world.tif", 1, 30111, options=["FORMAT=PNG"]
     )
 
-    return tst.testCreateCopy(new_filename="/vsimem/kmlout.kmz")
+    tst.testCreateCopy(new_filename="/vsimem/kmlout.kmz")
 
 
 ###############################################################################
@@ -62,7 +62,7 @@ def test_kmlsuperoverlay_2():
         "KMLSUPEROVERLAY", "small_world.tif", 1, 30111, options=["FORMAT=PNG"]
     )
 
-    return tst.testCreateCopy(new_filename="/vsimem/kmlout.kml")
+    tst.testCreateCopy(new_filename="/vsimem/kmlout.kml")
 
 
 ###############################################################################

--- a/autotest/gdrivers/kro.py
+++ b/autotest/gdrivers/kro.py
@@ -44,7 +44,7 @@ def test_kro_1():
 
     tst = gdaltest.GDALTest("KRO", "rgbsmall.tif", 2, 21053)
 
-    return tst.testCreate()
+    tst.testCreate()
 
 
 ###############################################################################
@@ -55,7 +55,7 @@ def test_kro_2():
 
     tst = gdaltest.GDALTest("KRO", "../../gcore/data/uint16.tif", 1, 4672)
 
-    return tst.testCreate()
+    tst.testCreate()
 
 
 ###############################################################################
@@ -66,7 +66,7 @@ def test_kro_3():
 
     tst = gdaltest.GDALTest("KRO", "../../gcore/data/float32.tif", 1, 4672)
 
-    return tst.testCreate()
+    tst.testCreate()
 
 
 ###############################################################################
@@ -77,7 +77,7 @@ def test_kro_4():
 
     tst = gdaltest.GDALTest("KRO", "png/rgba16.png", 1, 1886)
 
-    return tst.testCreate()
+    tst.testCreate()
 
 
 ###############################################################################

--- a/autotest/gdrivers/lan.py
+++ b/autotest/gdrivers/lan.py
@@ -38,7 +38,7 @@ import gdaltest
 def test_lan_1():
 
     tst = gdaltest.GDALTest("LAN", "lan/fakelan.lan", 1, 10)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -48,4 +48,4 @@ def test_lan_1():
 def test_lan_2():
 
     tst = gdaltest.GDALTest("LAN", "lan/fakelan4bit.lan", 1, 10)
-    return tst.testOpen()
+    tst.testOpen()

--- a/autotest/gdrivers/leveller.py
+++ b/autotest/gdrivers/leveller.py
@@ -38,4 +38,4 @@ import gdaltest
 def test_leveller_1():
 
     tst = gdaltest.GDALTest("Leveller", "leveller/ter6test.ter", 1, 33441)
-    return tst.testOpen()
+    tst.testOpen()

--- a/autotest/gdrivers/loslas.py
+++ b/autotest/gdrivers/loslas.py
@@ -47,6 +47,5 @@ def test_loslas_1():
         0.009716129862575248,
         0.008260044951413324,
     )
-    ret = tst.testOpen(check_gt=gt, check_stat=stats, check_prj="WGS84")
+    tst.testOpen(check_gt=gt, check_stat=stats, check_prj="WGS84")
     os.unlink("data/loslas/wyhpgn.los.aux.xml")
-    return ret

--- a/autotest/gdrivers/mff.py
+++ b/autotest/gdrivers/mff.py
@@ -38,7 +38,7 @@ import gdaltest
 def test_mff_1():
 
     tst = gdaltest.GDALTest("MFF", "mff/fakemff.hdr", 1, 1)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -48,7 +48,7 @@ def test_mff_1():
 def test_mff_2():
 
     tst = gdaltest.GDALTest("MFF", "mff/fakemfftiled.hdr", 1, 1)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -58,4 +58,4 @@ def test_mff_2():
 def test_mff_3():
 
     tst = gdaltest.GDALTest("MFF", "mff/bytemff.hdr", 1, 4672)
-    return tst.testOpen()
+    tst.testOpen()

--- a/autotest/gdrivers/mff2.py
+++ b/autotest/gdrivers/mff2.py
@@ -38,7 +38,7 @@ import gdaltest
 def test_mff2_1():
 
     tst = gdaltest.GDALTest("MFF2", "mff2/bytemff2", 1, 4672)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -49,4 +49,4 @@ def test_mff2_write():
 
     with gdaltest.config_option("GDAL_PAM_ENABLED", "NO"):
         tst = gdaltest.GDALTest("MFF2", "mff2/bytemff2", 1, 4672)
-        return tst.testCreateCopy(check_srs=True)
+        tst.testCreateCopy(check_srs=True)

--- a/autotest/gdrivers/mrf.py
+++ b/autotest/gdrivers/mrf.py
@@ -183,7 +183,7 @@ def test_mrf(src_filename, chksum, chksum_after_reopening, options):
     for x in ut.options:
         if "OPTIONS:LERC_PREC=" in x:
             check_minmax = False
-    return ut.testCreateCopy(check_minmax=check_minmax)
+    ut.testCreateCopy(check_minmax=check_minmax)
 
 
 def cleanup(base="/vsimem/out."):

--- a/autotest/gdrivers/mrsid.py
+++ b/autotest/gdrivers/mrsid.py
@@ -226,7 +226,7 @@ def test_mrsid_4():
     UNIT["metre",1,
         AUTHORITY["EPSG","9001"]]]"""
 
-    ret = tst.testOpen(
+    tst.testOpen(
         check_gt=gt,
         check_prj=prj,
         check_stat=(0.0, 255.0, 103.112, 52.477),
@@ -237,8 +237,6 @@ def test_mrsid_4():
         os.remove("data/sid/mercator_new.sid.aux.xml")
     except OSError:
         pass
-
-    return ret
 
 
 ###############################################################################
@@ -272,7 +270,7 @@ def test_mrsid_6():
     gt = (440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0)
 
     tst = gdaltest.GDALTest("JP2MrSID", "jpeg2000/byte.jp2", 1, 50054)
-    return tst.testOpen(check_prj=srs, check_gt=gt)
+    tst.testOpen(check_prj=srs, check_gt=gt)
 
 
 ###############################################################################

--- a/autotest/gdrivers/ndf.py
+++ b/autotest/gdrivers/ndf.py
@@ -72,4 +72,4 @@ def test_ndf_1():
     PARAMETER["false_northing",0],
     UNIT["Meter",1]]"""
 
-    return tst.testOpen(check_gt=gt, gt_epsilon=0.0001, check_prj=wkt)
+    tst.testOpen(check_gt=gt, gt_epsilon=0.0001, check_prj=wkt)

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -131,7 +131,7 @@ def netcdf_test_copy(ifile, band, checksum, ofile, opts=None, driver="NETCDF"):
     # pylint: disable=unused-argument
     opts = [] if opts is None else opts
     test = gdaltest.GDALTest("NETCDF", "../" + ifile, band, checksum, options=opts)
-    return test.testCreateCopy(
+    test.testCreateCopy(
         check_gt=0, check_srs=0, new_filename=ofile, delete_copy=0, check_minmax=0
     )
 
@@ -388,9 +388,7 @@ def test_netcdf_4():
     # 'Warning 1: No UNIDATA NC_GLOBAL:Conventions attribute' message.
     with gdaltest.error_handler():
         # don't test for checksum (see bug #4284)
-        result = tst.testOpen(skip_checksum=True)
-
-    return result
+        tst.testOpen(skip_checksum=True)
 
 
 ###############################################################################
@@ -412,9 +410,7 @@ def test_netcdf_5():
     # 'Warning 1: No UNIDATA NC_GLOBAL:Conventions attribute' message.
     with gdaltest.error_handler():
         # don't test for checksum (see bug #4284)
-        result = tst.testOpen(skip_checksum=True)
-
-    return result
+        tst.testOpen(skip_checksum=True)
 
 
 ###############################################################################
@@ -831,9 +827,7 @@ def test_netcdf_19():
         "NetCDF", "data/netcdf/trmm-nc4z.nc", 1, 50235, filename_absolute=1
     )
 
-    result = tst.testOpen(skip_checksum=True)
-
-    return result
+    tst.testOpen(skip_checksum=True)
 
 
 ###############################################################################
@@ -1269,9 +1263,7 @@ def test_netcdf_30():
     # We don't want to gum up the test stream output with the
     # 'Warning 1: No UNIDATA NC_GLOBAL:Conventions attribute' message.
     with gdaltest.error_handler():
-        result = tst.testOpen()
-
-    return result
+        tst.testOpen()
 
 
 ###############################################################################
@@ -2590,7 +2582,7 @@ def test_netcdf_59():
     # set
     tst = gdaltest.GDALTest("NetCDF", "netcdf/unittype.nc", 1, 4672)
 
-    return tst.testSetUnitType()
+    tst.testSetUnitType()
 
 
 ###############################################################################
@@ -3186,7 +3178,7 @@ def test_netcdf_75():
         AUTHORITY["EPSG","9001"]],
     AUTHORITY["EPSG","26711"]]"""
 
-    return tst.testOpen(check_prj=wkt)
+    tst.testOpen(check_prj=wkt)
 
 
 ###############################################################################
@@ -3255,7 +3247,7 @@ def test_netcdf_79():
 def test_netcdf_80():
 
     test = gdaltest.GDALTest("NETCDF", "../data/byte.tif", 1, 4672)
-    return test.testCreateCopy(
+    test.testCreateCopy(
         new_filename="test\xc3\xa9.nc", check_gt=0, check_srs=0, check_minmax=0
     )
 

--- a/autotest/gdrivers/ngsgeoid.py
+++ b/autotest/gdrivers/ngsgeoid.py
@@ -38,7 +38,7 @@ import gdaltest
 def test_ngsgeoid_1():
 
     tst = gdaltest.GDALTest("NGSGEOID", "ngsgeoid/g2009u01_le_truncated.bin", 1, 65534)
-    return tst.testOpen(
+    tst.testOpen(
         check_gt=(
             229.99166666666667,
             0.016666666666670001,
@@ -58,7 +58,7 @@ def test_ngsgeoid_1():
 def test_ngsgeoid_2():
 
     tst = gdaltest.GDALTest("NGSGEOID", "ngsgeoid/g2009u01_be_truncated.bin", 1, 65534)
-    return tst.testOpen(
+    tst.testOpen(
         check_gt=(
             229.99166666666667,
             0.016666666666670001,

--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -744,7 +744,7 @@ def test_nitf_28_jp2mrsid():
     # Deregister other potential conflicting JPEG2000 drivers
     gdaltest.deregister_all_jpeg2000_drivers_but("JP2MrSID")
 
-    ret = nitf_check_created_file(
+    nitf_check_created_file(
         32398,
         42502,
         38882,
@@ -753,8 +753,6 @@ def test_nitf_28_jp2mrsid():
     )
 
     gdaltest.reregister_all_jpeg2000_drivers()
-
-    return ret
 
 
 ###############################################################################
@@ -767,7 +765,7 @@ def test_nitf_28_jp2kak():
     # Deregister other potential conflicting JPEG2000 drivers
     gdaltest.deregister_all_jpeg2000_drivers_but("JP2KAK")
 
-    ret = nitf_check_created_file(
+    nitf_check_created_file(
         32398,
         42502,
         38882,
@@ -776,8 +774,6 @@ def test_nitf_28_jp2kak():
     )
 
     gdaltest.reregister_all_jpeg2000_drivers()
-
-    return ret
 
 
 ###############################################################################

--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -72,7 +72,7 @@ def hex_string(s):
 def test_nitf_1():
 
     tst = gdaltest.GDALTest("NITF", "byte.tif", 1, 4672)
-    return tst.testCreateCopy()
+    tst.testCreateCopy()
 
 
 ###############################################################################
@@ -82,7 +82,7 @@ def test_nitf_1():
 def test_nitf_2():
 
     tst = gdaltest.GDALTest("NITF", "int16.tif", 1, 4672)
-    return tst.testCreateCopy()
+    tst.testCreateCopy()
 
 
 ###############################################################################
@@ -92,7 +92,7 @@ def test_nitf_2():
 def test_nitf_3():
 
     tst = gdaltest.GDALTest("NITF", "rgbsmall.tif", 3, 21349)
-    return tst.testCreateCopy()
+    tst.testCreateCopy()
 
 
 ###############################################################################
@@ -221,7 +221,7 @@ def test_nitf_5():
 def test_nitf_6():
 
     tst = gdaltest.GDALTest("NITF", "nitf/rgb.ntf", 3, 21349)
-    return tst.testOpen(
+    tst.testOpen(
         check_prj="WGS84",
         check_gt=(
             -44.842029478458,
@@ -241,7 +241,7 @@ def test_nitf_6():
 def test_nitf_7():
 
     tst = gdaltest.GDALTest("NITF", "rgbsmall.tif", 3, 21349)
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 ###############################################################################
@@ -316,7 +316,7 @@ def test_nitf_10():
     )
 
     tst = gdaltest.GDALTest("NITF", "../tmp/nitf9.ntf", 2, expected_cs)
-    return tst.testCreateCopy()
+    tst.testCreateCopy()
 
 
 ###############################################################################
@@ -327,7 +327,7 @@ def test_nitf_11():
 
     # From http://www.gwg.nga.mil/ntb/baseline/software/testfile/Nitfv2_1/i_3034c.ntf
     tst = gdaltest.GDALTest("NITF", "nitf/i_3034c.ntf", 1, 170)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -547,7 +547,7 @@ def test_nitf_15():
 
     tst = gdaltest.GDALTest("NITF", "byte.tif", 1, 4672)
 
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 ###############################################################################
@@ -558,7 +558,7 @@ def test_nitf_16():
 
     # From http://www.gwg.nga.mil/ntb/baseline/software/testfile/Nitfv2_1/ns3034d.nsf
     tst = gdaltest.GDALTest("NITF", "nitf/ns3034d.nsf", 1, 170)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -570,7 +570,7 @@ def test_nitf_17():
 
     # From http://www.gwg.nga.mil/ntb/baseline/software/testfile/Nitfv2_1/i_3034f.ntf
     tst = gdaltest.GDALTest("NITF", "nitf/i_3034f.ntf", 1, 170)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -596,7 +596,7 @@ def test_nitf_19():
     # From http://www.gwg.nga.mil/ntb/baseline/software/testfile/Nitfv2_0/U_1050A.NTF
     tst = gdaltest.GDALTest("NITF", "nitf/U_1050A.NTF", 1, 65024)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -646,7 +646,7 @@ def test_nitf_21():
 def test_nitf_22():
 
     tst = gdaltest.GDALTest("NITF", "../../gcore/data/int32.tif", 1, 4672)
-    return tst.testCreateCopy()
+    tst.testCreateCopy()
 
 
 ###############################################################################
@@ -656,7 +656,7 @@ def test_nitf_22():
 def test_nitf_23():
 
     tst = gdaltest.GDALTest("NITF", "../../gcore/data/float32.tif", 1, 4672)
-    return tst.testCreateCopy()
+    tst.testCreateCopy()
 
 
 ###############################################################################
@@ -666,7 +666,7 @@ def test_nitf_23():
 def test_nitf_24():
 
     tst = gdaltest.GDALTest("NITF", "../../gcore/data/float64.tif", 1, 4672)
-    return tst.testCreateCopy()
+    tst.testCreateCopy()
 
 
 ###############################################################################
@@ -676,7 +676,7 @@ def test_nitf_24():
 def test_nitf_25():
 
     tst = gdaltest.GDALTest("NITF", "../../gcore/data/uint16.tif", 1, 4672)
-    return tst.testCreateCopy()
+    tst.testCreateCopy()
 
 
 ###############################################################################
@@ -686,7 +686,7 @@ def test_nitf_25():
 def test_nitf_26():
 
     tst = gdaltest.GDALTest("NITF", "../../gcore/data/uint32.tif", 1, 4672)
-    return tst.testCreateCopy()
+    tst.testCreateCopy()
 
 
 ###############################################################################
@@ -1306,7 +1306,7 @@ def test_nitf_33():
 def test_nitf_34():
 
     tst = gdaltest.GDALTest("NITF", "n43.dt0", 1, 49187, options=["BLOCKSIZE=64"])
-    return tst.testCreateCopy()
+    tst.testCreateCopy()
 
 
 ###############################################################################
@@ -5511,9 +5511,7 @@ def test_nitf_online_1():
 
     # Shut up the warning about missing image segment
     with gdaltest.error_handler():
-        ret = tst.testOpen()
-
-    return ret
+        tst.testOpen()
 
 
 ###############################################################################
@@ -5547,7 +5545,7 @@ def test_nitf_online_3():
         "NITF", "NITF_IM:3:tmp/cache/U_0001a.ntf", 1, 23463, filename_absolute=1
     )
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -5575,7 +5573,7 @@ def test_nitf_online_4():
         "NITF", "tmp/cache/001zc013.on1", 1, 53960, filename_absolute=1
     )
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -5592,7 +5590,7 @@ def test_nitf_online_5():
         "NITF", "tmp/cache/overview.ovr", 1, 60699, filename_absolute=1
     )
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -5609,7 +5607,7 @@ def test_nitf_online_6():
         "NITF", "tmp/cache/U_4001b.ntf", 1, 60030, filename_absolute=1
     )
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -5664,7 +5662,7 @@ def test_nitf_online_8():
         "NITF", "tmp/cache/ns3301j.nsf", 1, 56861, filename_absolute=1
     )
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -5682,7 +5680,7 @@ def test_nitf_online_9():
         "NITF", "tmp/cache/ns3304a.nsf", 1, 32419, filename_absolute=1
     )
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -5784,7 +5782,7 @@ def test_nitf_online_12():
         "NITF", "tmp/cache/i_3430a.ntf", 1, 38647, filename_absolute=1
     )
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -6036,7 +6034,7 @@ def test_nitf_online_19():
         "NITF", "tmp/cache/0000M033.GN3", 1, 38928, filename_absolute=1
     )
 
-    return tst.testOpen(
+    tst.testOpen(
         check_gt=(
             174.375000000000000,
             0.010986328125000,
@@ -6207,7 +6205,7 @@ def test_nitf_online_23():
         "NITF", "tmp/cache/U_3058b.ntf", 1, 44748, filename_absolute=1
     )
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################

--- a/autotest/gdrivers/noaa_b.py
+++ b/autotest/gdrivers/noaa_b.py
@@ -41,7 +41,7 @@ pytestmark = pytest.mark.require_driver("NOAA_B")
 def test_noaa_b():
 
     tst = gdaltest.GDALTest("NOAA_B", "noaa_b/test.b", 1, 3)
-    return tst.testOpen(check_gt=(1.75, 0.5, 0.0, 49.25, 0.0, -0.5))
+    tst.testOpen(check_gt=(1.75, 0.5, 0.0, 49.25, 0.0, -0.5))
 
 
 ###############################################################################
@@ -51,4 +51,4 @@ def test_noaa_b():
 def test_noaa_b_little_endian():
 
     tst = gdaltest.GDALTest("NOAA_B", "noaa_b/test_little_endian.b", 1, 3)
-    return tst.testOpen(check_gt=(1.75, 0.5, 0.0, 49.25, 0.0, -0.5))
+    tst.testOpen(check_gt=(1.75, 0.5, 0.0, 49.25, 0.0, -0.5))

--- a/autotest/gdrivers/ntv2.py
+++ b/autotest/gdrivers/ntv2.py
@@ -45,7 +45,7 @@ def test_ntv2_1():
 
     tst = gdaltest.GDALTest("NTV2", "ntv2/test_ntv2_le.gsb", 2, 10)
     gt = (-5.52, 7.8, 0.0, 52.05, 0.0, -5.55)
-    return tst.testOpen(check_gt=gt, check_prj="WGS84")
+    tst.testOpen(check_gt=gt, check_prj="WGS84")
 
 
 ###############################################################################
@@ -56,7 +56,7 @@ def test_ntv2_2():
 
     tst = gdaltest.GDALTest("NTV2", "ntv2/test_ntv2_be.gsb", 2, 10)
     gt = (-5.52, 7.8, 0.0, 52.05, 0.0, -5.55)
-    return tst.testOpen(check_gt=gt, check_prj="WGS84")
+    tst.testOpen(check_gt=gt, check_prj="WGS84")
 
 
 ###############################################################################
@@ -68,7 +68,7 @@ def test_ntv2_3():
     tst = gdaltest.GDALTest(
         "NTV2", "ntv2/test_ntv2_le.gsb", 2, 10, options=["ENDIANNESS=LE"]
     )
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 ###############################################################################
@@ -80,7 +80,7 @@ def test_ntv2_4():
     tst = gdaltest.GDALTest(
         "NTV2", "ntv2/test_ntv2_le.gsb", 2, 10, options=["ENDIANNESS=BE"]
     )
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 ###############################################################################
@@ -166,7 +166,7 @@ def test_ntv2_online_1():
         "NTV2", "tmp/cache/nzgd2kgrid0005.gsb", 1, 54971, filename_absolute=1
     )
     gt = (165.95, 0.1, 0.0, -33.95, 0.0, -0.1)
-    return tst.testOpen(check_gt=gt, check_prj="WGS84")
+    tst.testOpen(check_gt=gt, check_prj="WGS84")
 
 
 ###############################################################################
@@ -182,7 +182,7 @@ def test_ntv2_online_2():
     tst = gdaltest.GDALTest(
         "NTV2", "tmp/cache/nzgd2kgrid0005.gsb", 1, 54971, filename_absolute=1
     )
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 ###############################################################################
@@ -198,4 +198,4 @@ def test_ntv2_online_3():
     tst = gdaltest.GDALTest(
         "NTV2", "tmp/cache/nzgd2kgrid0005.gsb", 1, 54971, filename_absolute=1
     )
-    return tst.testCreate(vsimem=1, out_bands=4)
+    tst.testCreate(vsimem=1, out_bands=4)

--- a/autotest/gdrivers/nwt_grc.py
+++ b/autotest/gdrivers/nwt_grc.py
@@ -38,4 +38,4 @@ import gdaltest
 def test_nwt_grc_1():
 
     tst = gdaltest.GDALTest("NWT_GRC", "nwt_grc/nwt_grc.grc", 1, 46760)
-    return tst.testOpen()
+    tst.testOpen()

--- a/autotest/gdrivers/paux.py
+++ b/autotest/gdrivers/paux.py
@@ -40,7 +40,7 @@ from osgeo import gdal
 def test_paux_1():
 
     tst = gdaltest.GDALTest("PAux", "paux/small16.raw", 2, 12816)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -51,7 +51,7 @@ def test_paux_2():
 
     tst = gdaltest.GDALTest("PAux", "byte.tif", 1, 4672)
 
-    return tst.testCreateCopy(check_gt=1)
+    tst.testCreateCopy(check_gt=1)
 
 
 ###############################################################################
@@ -62,7 +62,7 @@ def test_paux_3():
 
     tst = gdaltest.GDALTest("PAux", "byte.tif", 1, 4672)
 
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 ###############################################################################

--- a/autotest/gdrivers/pcidsk.py
+++ b/autotest/gdrivers/pcidsk.py
@@ -53,7 +53,7 @@ def module_disable_exceptions():
 def test_pcidsk_1():
 
     tst = gdaltest.GDALTest("PCIDSK", "pcidsk/utm.pix", 1, 39576)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -64,7 +64,7 @@ def test_pcidsk_2():
 
     tst = gdaltest.GDALTest("PCIDSK", "png/rgba16.png", 2, 2042)
 
-    return tst.testCreate()
+    tst.testCreate()
 
 
 ###############################################################################
@@ -75,7 +75,7 @@ def test_pcidsk_3():
 
     tst = gdaltest.GDALTest("PCIDSK", "pcidsk/utm.pix", 1, 39576)
 
-    return tst.testCreateCopy(check_gt=1, check_srs=1)
+    tst.testCreateCopy(check_gt=1, check_srs=1)
 
 
 ###############################################################################
@@ -234,7 +234,7 @@ def test_pcidsk_8():
         "PCIDSK", "png/rgba16.png", 2, 2042, options=["INTERLEAVING=FILE"]
     )
 
-    return tst.testCreate()
+    tst.testCreate()
 
 
 ###############################################################################
@@ -300,7 +300,7 @@ def test_pcidsk_11():
         options=["INTERLEAVING=TILED", "TILESIZE=32"],
     )
 
-    return tst.testCreate()
+    tst.testCreate()
 
 
 def test_pcidsk_11_v1():
@@ -313,7 +313,7 @@ def test_pcidsk_11_v1():
         options=["INTERLEAVING=TILED", "TILESIZE=32", "TILEVERSION=1"],
     )
 
-    return tst.testCreate()
+    tst.testCreate()
 
 
 def test_pcidsk_11_v2():
@@ -326,7 +326,7 @@ def test_pcidsk_11_v2():
         options=["INTERLEAVING=TILED", "TILESIZE=32", "TILEVERSION=2"],
     )
 
-    return tst.testCreate()
+    tst.testCreate()
 
 
 ###############################################################################
@@ -343,7 +343,7 @@ def test_pcidsk_12():
         options=["INTERLEAVING=TILED", "TILESIZE=32", "COMPRESSION=RLE"],
     )
 
-    return tst.testCreate()
+    tst.testCreate()
 
 
 def test_pcidsk_12_v1():
@@ -361,7 +361,7 @@ def test_pcidsk_12_v1():
         ],
     )
 
-    return tst.testCreate()
+    tst.testCreate()
 
 
 def test_pcidsk_12_v2():
@@ -379,7 +379,7 @@ def test_pcidsk_12_v2():
         ],
     )
 
-    return tst.testCreate()
+    tst.testCreate()
 
 
 ###############################################################################
@@ -668,7 +668,7 @@ def test_pcidsk_tile_v1():
 
     tst = gdaltest.GDALTest("PCIDSK", "pcidsk/tile_v1.1.pix", 1, 49526)
 
-    return tst.testCreateCopy(check_gt=1, check_srs=1)
+    tst.testCreateCopy(check_gt=1, check_srs=1)
 
 
 def test_pcidsk_tile_v1_overview():

--- a/autotest/gdrivers/pcraster.py
+++ b/autotest/gdrivers/pcraster.py
@@ -42,7 +42,7 @@ pytestmark = pytest.mark.require_driver("PCRaster")
 def test_pcraster_1():
 
     tst = gdaltest.GDALTest("PCRaster", "pcraster/ldd.map", 1, 4528)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -74,7 +74,7 @@ def test_pcraster_2():
 def test_pcraster_createcopy():
 
     tst = gdaltest.GDALTest("PCRaster", "pcraster/ldd.map", 1, 4528)
-    return tst.testCreateCopy(new_filename="tmp/ldd.map")
+    tst.testCreateCopy(new_filename="tmp/ldd.map")
 
 
 ###############################################################################
@@ -85,4 +85,4 @@ def test_pcraster_create():
     tst = gdaltest.GDALTest(
         "PCRaster", "float32.tif", 1, 4672, options=["PCRASTER_VALUESCALE=VS_SCALAR"]
     )
-    return tst.testCreate(new_filename="tmp/float32.map")
+    tst.testCreate(new_filename="tmp/float32.map")

--- a/autotest/gdrivers/pdf.py
+++ b/autotest/gdrivers/pdf.py
@@ -342,14 +342,12 @@ def test_pdf_1(poppler_or_pdfium):
 
 def test_pdf_iso32000(poppler_or_pdfium_or_podofo):
     tst = gdaltest.GDALTest("PDF", "byte.tif", 1, None)
-    ret = tst.testCreateCopy(
+    tst.testCreateCopy(
         check_minmax=0,
         check_gt=1,
         check_srs=True,
         check_checksum_not_null=pdf_checksum_available(),
     )
-
-    return ret
 
 
 ###############################################################################
@@ -358,14 +356,12 @@ def test_pdf_iso32000(poppler_or_pdfium_or_podofo):
 
 def test_pdf_iso32000_dpi_300(poppler_or_pdfium):
     tst = gdaltest.GDALTest("PDF", "byte.tif", 1, None, options=["DPI=300"])
-    ret = tst.testCreateCopy(
+    tst.testCreateCopy(
         check_minmax=0,
         check_gt=1,
         check_srs=True,
         check_checksum_not_null=pdf_checksum_available(),
     )
-
-    return ret
 
 
 ###############################################################################
@@ -377,14 +373,12 @@ def test_pdf_ogcbp(poppler_or_pdfium_or_podofo):
         tst = gdaltest.GDALTest(
             "PDF", "byte.tif", 1, None, options=["GEO_ENCODING=OGC_BP"]
         )
-        ret = tst.testCreateCopy(
+        tst.testCreateCopy(
             check_minmax=0,
             check_gt=1,
             check_srs=True,
             check_checksum_not_null=pdf_checksum_available(),
         )
-
-    return ret
 
 
 ###############################################################################
@@ -396,14 +390,12 @@ def test_pdf_ogcbp_dpi_300(poppler_or_pdfium):
         tst = gdaltest.GDALTest(
             "PDF", "byte.tif", 1, None, options=["GEO_ENCODING=OGC_BP", "DPI=300"]
         )
-        ret = tst.testCreateCopy(
+        tst.testCreateCopy(
             check_minmax=0,
             check_gt=1,
             check_srs=True,
             check_checksum_not_null=pdf_checksum_available(),
         )
-
-    return ret
 
 
 def test_pdf_ogcbp_lcc(poppler_or_pdfium):
@@ -451,14 +443,12 @@ def test_pdf_ogcbp_lcc(poppler_or_pdfium):
 
 def test_pdf_no_compression(poppler_or_pdfium):
     tst = gdaltest.GDALTest("PDF", "byte.tif", 1, None, options=["COMPRESS=NONE"])
-    ret = tst.testCreateCopy(
+    tst.testCreateCopy(
         check_minmax=0,
         check_gt=0,
         check_srs=None,
         check_checksum_not_null=pdf_checksum_available(),
     )
-
-    return ret
 
 
 ###############################################################################
@@ -607,26 +597,22 @@ def test_pdf_jpeg_compression_rgba(poppler_or_pdfium):
 
 def test_pdf_predictor_2(poppler_or_pdfium):
     tst = gdaltest.GDALTest("PDF", "utm.tif", 1, None, options=["PREDICTOR=2"])
-    ret = tst.testCreateCopy(
+    tst.testCreateCopy(
         check_minmax=0,
         check_gt=0,
         check_srs=None,
         check_checksum_not_null=pdf_checksum_available(),
     )
-
-    return ret
 
 
 def test_pdf_predictor_2_rgb(poppler_or_pdfium):
     tst = gdaltest.GDALTest("PDF", "rgbsmall.tif", 1, None, options=["PREDICTOR=2"])
-    ret = tst.testCreateCopy(
+    tst.testCreateCopy(
         check_minmax=0,
         check_gt=0,
         check_srs=None,
         check_checksum_not_null=pdf_checksum_available(),
     )
-
-    return ret
 
 
 ###############################################################################
@@ -637,28 +623,24 @@ def test_pdf_tiled(poppler_or_pdfium):
     tst = gdaltest.GDALTest(
         "PDF", "utm.tif", 1, None, options=["COMPRESS=DEFLATE", "TILED=YES"]
     )
-    ret = tst.testCreateCopy(
+    tst.testCreateCopy(
         check_minmax=0,
         check_gt=0,
         check_srs=None,
         check_checksum_not_null=pdf_checksum_available(),
     )
-
-    return ret
 
 
 def test_pdf_tiled_128(poppler_or_pdfium):
     tst = gdaltest.GDALTest(
         "PDF", "utm.tif", 1, None, options=["BLOCKXSIZE=128", "BLOCKYSIZE=128"]
     )
-    ret = tst.testCreateCopy(
+    tst.testCreateCopy(
         check_minmax=0,
         check_gt=0,
         check_srs=None,
         check_checksum_not_null=pdf_checksum_available(),
     )
-
-    return ret
 
 
 ###############################################################################
@@ -669,14 +651,12 @@ def test_pdf_tiled_128(poppler_or_pdfium):
 def test_pdf_color_table(poppler_or_pdfium):
 
     tst = gdaltest.GDALTest("PDF", "small_world_pct.tif", 1, None)
-    ret = tst.testCreateCopy(
+    tst.testCreateCopy(
         check_minmax=0,
         check_gt=0,
         check_srs=None,
         check_checksum_not_null=pdf_checksum_available(),
     )
-
-    return ret
 
 
 ###############################################################################

--- a/autotest/gdrivers/pds.py
+++ b/autotest/gdrivers/pds.py
@@ -147,7 +147,7 @@ def test_pds_4():
 def test_pds_5():
 
     tst = gdaltest.GDALTest("PDS", "pds/pds_3355.lbl", 1, 2748)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -243,9 +243,7 @@ def test_pds_8():
             -926.11527442932129,
         )
 
-        result = tst.testOpen(check_gt=expected_gt)
-
-    return result
+        tst.testOpen(check_gt=expected_gt)
 
 
 ###############################################################################
@@ -341,7 +339,7 @@ END
 def test_pds_line_offset_not_multiple_of_record():
 
     tst = gdaltest.GDALTest("PDS", "pds/map_000_038_truncated.lbl", 1, 14019)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -355,7 +353,7 @@ def test_pds_band_storage_type_line_interleaved():
     tst = gdaltest.GDALTest(
         "PDS", "pds/hsp00017ba0_01_ra218s_trr3_truncated.lbl", 1, 64740
     )
-    return tst.testOpen()
+    tst.testOpen()
 
 
 def test_pds_oblique_cylindrical_read():

--- a/autotest/gdrivers/pds4.py
+++ b/autotest/gdrivers/pds4.py
@@ -182,7 +182,7 @@ def test_pds4_read_cart_versions(filename):
     gt = (-59280.0, 60.0, 0.0, 3751320.0, 0.0, -60.0)
 
     tst = gdaltest.GDALTest("PDS4", filename, 1, 4672)
-    return tst.testOpen(check_prj=srs, check_gt=gt)
+    tst.testOpen(check_prj=srs, check_gt=gt)
 
 
 ###############################################################################
@@ -212,8 +212,7 @@ def test_pds4_2():
 
     tst = gdaltest.GDALTest("PDS4", "rgbsmall.tif", 2, 21053)
     with hide_substitution_warnings_error_handler():
-        ret = tst.testCreateCopy(vsimem=1, strict_in=1, quiet_error_handler=False)
-    return ret
+        tst.testCreateCopy(vsimem=1, strict_in=1, quiet_error_handler=False)
 
 
 ###############################################################################
@@ -246,8 +245,7 @@ def test_pds4_3():
         "PDS4", "rgbsmall.tif", 2, 21053, options=["INTERLEAVE=BSQ"]
     )
     with hide_substitution_warnings_error_handler():
-        ret = tst.testCreateCopy(vsimem=1, strict_in=1, quiet_error_handler=False)
-    return ret
+        tst.testCreateCopy(vsimem=1, strict_in=1, quiet_error_handler=False)
 
 
 ###############################################################################
@@ -260,8 +258,7 @@ def test_pds4_4():
         "PDS4", "rgbsmall.tif", 2, 21053, options=["INTERLEAVE=BIP"]
     )
     with hide_substitution_warnings_error_handler():
-        ret = tst.testCreateCopy(vsimem=1, strict_in=1, quiet_error_handler=False)
-    return ret
+        tst.testCreateCopy(vsimem=1, strict_in=1, quiet_error_handler=False)
 
 
 ###############################################################################
@@ -274,8 +271,7 @@ def test_pds4_5():
         "PDS4", "rgbsmall.tif", 2, 21053, options=["INTERLEAVE=BIL"]
     )
     with hide_substitution_warnings_error_handler():
-        ret = tst.testCreateCopy(vsimem=1, strict_in=1, quiet_error_handler=False)
-    return ret
+        tst.testCreateCopy(vsimem=1, strict_in=1, quiet_error_handler=False)
 
 
 ###############################################################################
@@ -292,8 +288,7 @@ def test_pds4_6():
         options=["INTERLEAVE=BSQ", "IMAGE_FORMAT=GEOTIFF"],
     )
     with hide_substitution_warnings_error_handler():
-        ret = tst.testCreateCopy(vsimem=1, strict_in=1, quiet_error_handler=False)
-    return ret
+        tst.testCreateCopy(vsimem=1, strict_in=1, quiet_error_handler=False)
 
 
 ###############################################################################
@@ -310,8 +305,7 @@ def test_pds4_7():
         options=["INTERLEAVE=BIP", "IMAGE_FORMAT=GEOTIFF"],
     )
     with hide_substitution_warnings_error_handler():
-        ret = tst.testCreateCopy(vsimem=1, strict_in=1, quiet_error_handler=False)
-    return ret
+        tst.testCreateCopy(vsimem=1, strict_in=1, quiet_error_handler=False)
 
 
 ###############################################################################
@@ -324,8 +318,7 @@ def test_pds4_from_bil_to_geotiff():
         "PDS4", "envi/envi_rgbsmall_bil.img", 2, 20669, options=["IMAGE_FORMAT=GEOTIFF"]
     )
     with hide_substitution_warnings_error_handler():
-        ret = tst.testCreateCopy(vsimem=1, strict_in=1, quiet_error_handler=False)
-    return ret
+        tst.testCreateCopy(vsimem=1, strict_in=1, quiet_error_handler=False)
 
 
 ###############################################################################

--- a/autotest/gdrivers/png.py
+++ b/autotest/gdrivers/png.py
@@ -53,7 +53,7 @@ def module_disable_exceptions():
 def test_png_1():
 
     tst = gdaltest.GDALTest("PNG", "png/test.png", 1, 57921)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -64,7 +64,7 @@ def test_png_2():
 
     tst = gdaltest.GDALTest("PNG", "png/test.png", 1, 57921)
 
-    return tst.testCreateCopy()
+    tst.testCreateCopy()
 
 
 ###############################################################################
@@ -107,7 +107,7 @@ def test_png_4():
 
     tst = gdaltest.GDALTest("PNG", "rgbsmall.tif", 3, 21349)
 
-    return tst.testCreateCopy()
+    tst.testCreateCopy()
 
 
 ###############################################################################
@@ -117,7 +117,7 @@ def test_png_4():
 def test_png_5():
 
     tst = gdaltest.GDALTest("PNG", "png/rgba16.png", 3, 1815)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -128,7 +128,7 @@ def test_png_6():
 
     tst = gdaltest.GDALTest("PNG", "png/rgba16.png", 4, 4873)
 
-    return tst.testCreateCopy()
+    tst.testCreateCopy()
 
 
 ###############################################################################
@@ -202,7 +202,7 @@ def test_png_9():
 
     tst = gdaltest.GDALTest("PNG", "byte.tif", 1, 4672)
 
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 ###############################################################################
@@ -234,9 +234,8 @@ def test_png_11():
 
     tst = gdaltest.GDALTest("PNG", "byte.tif", 1, 4672)
 
-    ret = tst.testCreateCopy(vsimem=1, interrupt_during_copy=True)
+    tst.testCreateCopy(vsimem=1, interrupt_during_copy=True)
     gdal.Unlink("/vsimem/byte.tif.tst")
-    return ret
 
 
 ###############################################################################

--- a/autotest/gdrivers/pnm.py
+++ b/autotest/gdrivers/pnm.py
@@ -43,7 +43,7 @@ def test_pnm_1():
 
     tst = gdaltest.GDALTest("PNM", "pnm/byte.pgm", 1, 4672)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -54,7 +54,7 @@ def test_pnm_2():
 
     tst = gdaltest.GDALTest("PNM", "pnm/byte.pgm", 1, 4672)
 
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 ###############################################################################
@@ -65,7 +65,7 @@ def test_pnm_3():
 
     tst = gdaltest.GDALTest("PNM", "pnm/rgbsmall.ppm", 2, 21053)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -76,7 +76,7 @@ def test_pnm_4():
 
     tst = gdaltest.GDALTest("PNM", "pnm/rgbsmall.ppm", 2, 21053)
 
-    return tst.testCreateCopy()
+    tst.testCreateCopy()
 
 
 @pytest.mark.parametrize("nbands", [1, 3])

--- a/autotest/gdrivers/postgisraster.py
+++ b/autotest/gdrivers/postgisraster.py
@@ -213,7 +213,7 @@ def test_postgisraster_test_utm_open():
             cs,
             filename_absolute=1,
         )
-        return tst.testOpen(check_prj=prj, check_gt=gt, skip_checksum=True)
+        tst.testOpen(check_prj=prj, check_gt=gt, skip_checksum=True)
 
 
 ###############################################################################
@@ -247,7 +247,7 @@ def test_postgisraster_test_small_world_open_b1():
             cs,
             filename_absolute=1,
         )
-        return tst.testOpen(check_prj=prj, check_gt=gt, skip_checksum=True)
+        tst.testOpen(check_prj=prj, check_gt=gt, skip_checksum=True)
 
 
 ###############################################################################
@@ -281,7 +281,7 @@ def test_postgisraster_test_small_world_open_b2():
             cs,
             filename_absolute=1,
         )
-        return tst.testOpen(check_prj=prj, check_gt=gt, skip_checksum=True)
+        tst.testOpen(check_prj=prj, check_gt=gt, skip_checksum=True)
 
 
 ###############################################################################
@@ -316,7 +316,7 @@ def test_postgisraster_test_small_world_open_b3():
             filename_absolute=1,
         )
 
-        return tst.testOpen(check_prj=prj, check_gt=gt, skip_checksum=True)
+        tst.testOpen(check_prj=prj, check_gt=gt, skip_checksum=True)
 
 
 def test_postgisraster_test_create_copy_bad_conn_string():

--- a/autotest/gdrivers/prf.py
+++ b/autotest/gdrivers/prf.py
@@ -38,7 +38,7 @@ pytestmark = pytest.mark.require_driver("PRF")
 def test_prf_1():
 
     tst = gdaltest.GDALTest("prf", "./PRF/ph.prf", 1, 43190)
-    return tst.testOpen(check_gt=(1, 2, 3, -7, 5, 6))
+    tst.testOpen(check_gt=(1, 2, 3, -7, 5, 6))
 
 
 def test_prf_2():
@@ -88,7 +88,7 @@ def test_prf_3():
 def test_prf_4():
 
     tst = gdaltest.GDALTest("prf", "./PRF/dem.x-dem", 1, 0)
-    return tst.testOpen(check_gt=(1.5, 1.0, 0.0, 9329.0, 0.0, -2.0))
+    tst.testOpen(check_gt=(1.5, 1.0, 0.0, 9329.0, 0.0, -2.0))
 
 
 def test_prf_5():

--- a/autotest/gdrivers/r.py
+++ b/autotest/gdrivers/r.py
@@ -39,7 +39,7 @@ def test_r_1():
 
     tst = gdaltest.GDALTest("R", "r/r_test.asc", 2, 202)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -49,7 +49,7 @@ def test_r_1():
 def test_r_2():
 
     tst = gdaltest.GDALTest("R", "r/r_test.rdb", 1, 202)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -59,7 +59,7 @@ def test_r_2():
 def test_r_3():
 
     tst = gdaltest.GDALTest("R", "byte.tif", 1, 4672, options=["ASCII=YES"])
-    return tst.testCreateCopy()
+    tst.testCreateCopy()
 
 
 ###############################################################################

--- a/autotest/gdrivers/rik.py
+++ b/autotest/gdrivers/rik.py
@@ -64,7 +64,7 @@ def test_rik_online_1():
             pytest.skip()
 
     tst = gdaltest.GDALTest("RIK", file_to_test, 1, 17162, filename_absolute=1)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -80,4 +80,4 @@ def test_rik_online_2():
     tst = gdaltest.GDALTest(
         "RIK", "tmp/cache/ab-del.rik", 1, 44974, filename_absolute=1
     )
-    return tst.testOpen()
+    tst.testOpen()

--- a/autotest/gdrivers/rl2.py
+++ b/autotest/gdrivers/rl2.py
@@ -219,7 +219,7 @@ def test_rl2_5():
 def test_rl2_6():
 
     tst = gdaltest.GDALTest("SQLite", "byte.tif", 1, 4672)
-    return tst.testCreateCopy(vsimem=1, check_minmax=False)
+    tst.testCreateCopy(vsimem=1, check_minmax=False)
 
 
 ###############################################################################
@@ -231,7 +231,7 @@ def test_rl2_7():
     tst = gdaltest.GDALTest(
         "SQLite", "small_world.tif", 1, 30111, options=["COMPRESS=PNG"]
     )
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 ###############################################################################
@@ -243,7 +243,7 @@ def test_rl2_8():
     tst = gdaltest.GDALTest(
         "SQLite", "small_world_pct.tif", 1, 14890, options=["COMPRESS=PNG"]
     )
-    return tst.testCreateCopy(vsimem=1, check_minmax=False)
+    tst.testCreateCopy(vsimem=1, check_minmax=False)
 
 
 ###############################################################################
@@ -253,7 +253,7 @@ def test_rl2_8():
 def test_rl2_9():
 
     tst = gdaltest.GDALTest("SQLite", "../../gcore/data/uint16.tif", 1, 4672)
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 ###############################################################################
@@ -263,7 +263,7 @@ def test_rl2_9():
 def test_rl2_10():
 
     tst = gdaltest.GDALTest("SQLite", "../../gcore/data/int16.tif", 1, 4672)
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 ###############################################################################
@@ -283,7 +283,7 @@ def test_rl2_11():
 def test_rl2_12():
 
     tst = gdaltest.GDALTest("SQLite", "../../gcore/data/int32.tif", 1, 4672)
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 ###############################################################################
@@ -303,7 +303,7 @@ def test_rl2_13():
 def test_rl2_14():
 
     tst = gdaltest.GDALTest("SQLite", "../../gcore/data/float64.tif", 1, 4672)
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 ###############################################################################
@@ -314,7 +314,7 @@ def test_rl2_14():
 def test_rl2_15():
 
     tst = gdaltest.GDALTest("SQLite", "../../gcore/data/1bit.bmp", 1, 200)
-    return tst.testCreateCopy(vsimem=1, check_minmax=False)
+    tst.testCreateCopy(vsimem=1, check_minmax=False)
 
 
 ###############################################################################
@@ -326,7 +326,7 @@ def test_rl2_16():
     tst = gdaltest.GDALTest(
         "SQLite", "byte.tif", 1, 4873, options=["NBITS=1", "COMPRESS=CCITTFAX4"]
     )
-    return tst.testCreateCopy(vsimem=1, check_minmax=False)
+    tst.testCreateCopy(vsimem=1, check_minmax=False)
 
 
 ###############################################################################
@@ -338,7 +338,7 @@ def test_rl2_17():
     tst = gdaltest.GDALTest(
         "SQLite", "byte.tif", 1, 4873, options=["NBITS=2", "COMPRESS=DEFLATE"]
     )
-    return tst.testCreateCopy(vsimem=1, check_minmax=False)
+    tst.testCreateCopy(vsimem=1, check_minmax=False)
 
 
 ###############################################################################
@@ -348,7 +348,7 @@ def test_rl2_17():
 def test_rl2_18():
 
     tst = gdaltest.GDALTest("SQLite", "byte.tif", 1, 2541, options=["NBITS=4"])
-    return tst.testCreateCopy(vsimem=1, check_minmax=False)
+    tst.testCreateCopy(vsimem=1, check_minmax=False)
 
 
 ###############################################################################
@@ -360,7 +360,7 @@ def test_rl2_19():
     tst = gdaltest.GDALTest(
         "SQLite", "byte.tif", 1, 4873, options=["PIXEL_TYPE=MONOCHROME"]
     )
-    return tst.testCreateCopy(vsimem=1, check_minmax=False)
+    tst.testCreateCopy(vsimem=1, check_minmax=False)
 
 
 ###############################################################################

--- a/autotest/gdrivers/rmf.py
+++ b/autotest/gdrivers/rmf.py
@@ -45,21 +45,21 @@ pytestmark = pytest.mark.require_driver("RMF")
 def test_rmf_1():
 
     tst = gdaltest.GDALTest("rmf", "rmf/byte.rsw", 1, 4672)
-    return tst.testOpen(check_gt=(440720, 60, 0, 3751320, 0, -60))
+    tst.testOpen(check_gt=(440720, 60, 0, 3751320, 0, -60))
 
 
 def test_rmf_2():
 
     tst = gdaltest.GDALTest("rmf", "rmf/byte-lzw.rsw", 1, 40503)
     with gdaltest.error_handler():
-        return tst.testOpen()
+        tst.testOpen()
 
 
 def test_rmf_3():
 
     tst = gdaltest.GDALTest("rmf", "rmf/float64.mtw", 1, 4672)
     with gdaltest.error_handler():
-        return tst.testOpen(check_gt=(440720, 60, 0, 3751320, 0, -60))
+        tst.testOpen(check_gt=(440720, 60, 0, 3751320, 0, -60))
 
 
 def test_rmf_4():
@@ -86,7 +86,7 @@ def test_rmf_5():
 
     tst = gdaltest.GDALTest("rmf", "rmf/rgbsmall-lzw.rsw", 3, 40238)
     with gdaltest.error_handler():
-        return tst.testOpen()
+        tst.testOpen()
 
 
 def test_rmf_6():
@@ -101,7 +101,7 @@ def test_rmf_6():
 
     tst = gdaltest.GDALTest("rmf", "rmf/big-endian.rsw", 3, 4195)
     with gdaltest.error_handler():
-        return tst.testOpen()
+        tst.testOpen()
 
 
 ###############################################################################
@@ -112,14 +112,14 @@ def test_rmf_7():
 
     tst = gdaltest.GDALTest("rmf", "rmf/byte.rsw", 1, 4672)
 
-    return tst.testCreateCopy(check_srs=1, check_gt=1, vsimem=1)
+    tst.testCreateCopy(check_srs=1, check_gt=1, vsimem=1)
 
 
 def test_rmf_8():
 
     tst = gdaltest.GDALTest("rmf", "rmf/rgbsmall.rsw", 2, 21053)
 
-    return tst.testCreateCopy(check_srs=1, check_gt=1)
+    tst.testCreateCopy(check_srs=1, check_gt=1)
 
 
 ###############################################################################
@@ -130,7 +130,7 @@ def test_rmf_9():
 
     tst = gdaltest.GDALTest("rmf", "rmf/byte.rsw", 1, 4672, options=["RMFHUGE=YES"])
 
-    return tst.testCreateCopy(check_srs=1, check_gt=1, vsimem=1)
+    tst.testCreateCopy(check_srs=1, check_gt=1, vsimem=1)
 
 
 ###############################################################################
@@ -142,7 +142,7 @@ def test_rmf_10():
     tst = gdaltest.GDALTest("rmf", "rmf/t100.mtw", 1, 6388)
 
     with gdaltest.error_handler():
-        return tst.testOpen()
+        tst.testOpen()
 
 
 ###############################################################################
@@ -190,7 +190,7 @@ def test_rmf_12a():
 
     tst = gdaltest.GDALTest("rmf", "rmf/cucled-1.rsw", 1, 4672)
     with gdaltest.error_handler():
-        return tst.testOpen(check_gt=(440720, 60, 0, 3751320, 0, -60))
+        tst.testOpen(check_gt=(440720, 60, 0, 3751320, 0, -60))
 
 
 ###############################################################################
@@ -201,7 +201,7 @@ def test_rmf_12b():
 
     tst = gdaltest.GDALTest("rmf", "rmf/cucled-2.rsw", 1, 4672)
     with gdaltest.error_handler():
-        return tst.testOpen(check_gt=(440720, 60, 0, 3751320, 0, -60))
+        tst.testOpen(check_gt=(440720, 60, 0, 3751320, 0, -60))
 
 
 ###############################################################################
@@ -212,7 +212,7 @@ def test_rmf_12c():
 
     tst = gdaltest.GDALTest("rmf", "rmf/invalid-subheader.rsw", 1, 4672)
     with gdaltest.error_handler():
-        return tst.testOpen(check_gt=(440720, 60, 0, 3751320, 0, -60))
+        tst.testOpen(check_gt=(440720, 60, 0, 3751320, 0, -60))
 
 
 ###############################################################################
@@ -222,7 +222,7 @@ def test_rmf_12c():
 def test_rmf_12d():
 
     tst = gdaltest.GDALTest("rmf", "rmf/corrupted-subheader.rsw", 1, 4672)
-    return tst.testOpen(check_gt=(440720, 60, 0, 3751320, 0, -60))
+    tst.testOpen(check_gt=(440720, 60, 0, 3751320, 0, -60))
 
 
 ###############################################################################
@@ -668,7 +668,7 @@ def test_rmf_31a():
         "rmf", "small_world.tif", 1, 30111, options=["COMPRESS=NONE"]
     )
 
-    return tst.testCreateCopy(check_minmax=0, check_srs=1, check_gt=1)
+    tst.testCreateCopy(check_minmax=0, check_srs=1, check_gt=1)
 
 
 def test_rmf_31b():
@@ -677,7 +677,7 @@ def test_rmf_31b():
         "rmf", "small_world.tif", 1, 30111, options=["COMPRESS=LZW"]
     )
 
-    return tst.testCreateCopy(check_minmax=0, check_srs=1, check_gt=1)
+    tst.testCreateCopy(check_minmax=0, check_srs=1, check_gt=1)
 
 
 def test_rmf_31c():
@@ -707,7 +707,7 @@ def test_rmf_31d():
         "rmf", "rmf/t100.mtw", 1, 6388, options=["MTW=YES", "COMPRESS=RMF_DEM"]
     )
 
-    return tst.testCreateCopy(check_minmax=0, check_srs=1, check_gt=1)
+    tst.testCreateCopy(check_minmax=0, check_srs=1, check_gt=1)
 
 
 def rmf_31e_data_gen(min_val, max_val, stripeSize, sx):
@@ -775,7 +775,7 @@ def test_rmf_31e():
         "rmf", "../" + tst_name, 1, cs, options=["MTW=YES", "COMPRESS=RMF_DEM"]
     )
 
-    return tst.testCreateCopy(check_minmax=0, check_srs=1, check_gt=1)
+    tst.testCreateCopy(check_minmax=0, check_srs=1, check_gt=1)
 
 
 ###############################################################################
@@ -793,10 +793,8 @@ def test_rmf_32a():
     )
 
     tst = gdaltest.GDALTest("rmf", "../" + ds_name, 1, 5540)
-    res = tst.testOpen(check_gt=None)
+    tst.testOpen(check_gt=None)
     os.remove(ds_name)
-
-    return res
 
 
 def test_rmf_32b():
@@ -810,10 +808,8 @@ def test_rmf_32b():
     )
 
     tst = gdaltest.GDALTest("rmf", "../" + ds_name, 1, 5540)
-    res = tst.testOpen(check_gt=None)
+    tst.testOpen(check_gt=None)
     os.remove(ds_name)
-
-    return res
 
 
 ###############################################################################
@@ -849,19 +845,19 @@ def test_rmf_32c():
 def test_rmf_33a():
 
     tst = gdaltest.GDALTest("rmf", "rmf/1bit.rsw", 1, 34325)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 def test_rmf_33b():
 
     tst = gdaltest.GDALTest("rmf", "rmf/4bit.rsw", 1, 55221)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 def test_rmf_33c():
 
     tst = gdaltest.GDALTest("rmf", "rmf/4bit-lzw.rsw", 1, 55221)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################

--- a/autotest/gdrivers/rmf.py
+++ b/autotest/gdrivers/rmf.py
@@ -825,7 +825,7 @@ def test_rmf_32c():
         options="-outsize 400% 400% -co COMPRESS=LZW -co NUM_THREADS=4",
     )
 
-    res = rmf_build_ov(
+    rmf_build_ov(
         source=ds_name,
         testid="32c",
         options=["RMFHUGE=NO", "COMPRESS=LZW", "NUM_THREADS=4"],
@@ -834,8 +834,6 @@ def test_rmf_32c():
         reopen=False,
     )
     os.remove(ds_name)
-
-    return res
 
 
 ###############################################################################

--- a/autotest/gdrivers/roipac.py
+++ b/autotest/gdrivers/roipac.py
@@ -56,7 +56,7 @@ def test_roipac_1():
         AUTHORITY["EPSG","9108"]],
     AUTHORITY["EPSG","4326"]]"""
 
-    return tst.testOpen(
+    tst.testOpen(
         check_prj=prj,
         check_gt=(-180.0083333, 0.0083333333, 0.0, -59.9916667, 0.0, -0.0083333333),
     )
@@ -80,7 +80,7 @@ def test_roipac_2():
 def test_roipac_3():
 
     tst = gdaltest.GDALTest("roi_pac", "roipac/srtm.dem", 1, 64074)
-    return tst.testCreateCopy(check_gt=1, new_filename="strm.tst.dem")
+    tst.testCreateCopy(check_gt=1, new_filename="strm.tst.dem")
 
 
 ###############################################################################
@@ -90,7 +90,7 @@ def test_roipac_3():
 def test_roipac_4():
 
     tst = gdaltest.GDALTest("roi_pac", "roipac/srtm.dem", 1, 64074)
-    return tst.testCreateCopy(check_gt=1, new_filename="strm.tst.dem", vsimem=1)
+    tst.testCreateCopy(check_gt=1, new_filename="strm.tst.dem", vsimem=1)
 
 
 ###############################################################################
@@ -115,5 +115,4 @@ def test_roipac_6():
 
     tst = gdaltest.GDALTest("roi_pac", "byte.tif", 1, 4672)
     with gdaltest.error_handler():
-        ret = tst.testCreateCopy(check_gt=1, new_filename="byte.flg", vsimem=1)
-    return ret
+        tst.testCreateCopy(check_gt=1, new_filename="byte.flg", vsimem=1)

--- a/autotest/gdrivers/rpftoc.py
+++ b/autotest/gdrivers/rpftoc.py
@@ -59,7 +59,7 @@ def test_rpftoc_1():
         0.0,
         -0.0013461816406249993,
     )
-    return tst.testOpen(check_gt=gt)
+    tst.testOpen(check_gt=gt)
 
 
 ###############################################################################
@@ -75,8 +75,7 @@ def test_rpftoc_2():
             0,
             filename_absolute=1,
         )
-        res = tst.testOpen()
-    return res
+        tst.testOpen()
 
 
 ###############################################################################

--- a/autotest/gdrivers/rs2.py
+++ b/autotest/gdrivers/rs2.py
@@ -44,7 +44,7 @@ pytestmark = pytest.mark.require_driver("RS2")
 
 def test_rs2_1():
     tst = gdaltest.GDALTest("RS2", "rs2/product.xml", 1, 4672)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 def test_rs2_2():
@@ -55,7 +55,7 @@ def test_rs2_2():
         4848,
         filename_absolute=1,
     )
-    return tst.testOpen()
+    tst.testOpen()
 
 
 # Test reading our dummy RPC

--- a/autotest/gdrivers/safe.py
+++ b/autotest/gdrivers/safe.py
@@ -44,13 +44,13 @@ pytestmark = pytest.mark.require_driver("SAFE")
 def test_safe_1():
 
     tst = gdaltest.GDALTest("SAFE", "SAFE_FAKE/test.SAFE/manifest.safe", 1, 65372)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 def test_safe_2():
 
     tst = gdaltest.GDALTest("SAFE", "SAFE_FAKE/test.SAFE/manifest.safe", 2, 3732)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 def test_safe_3():
@@ -62,7 +62,7 @@ def test_safe_3():
         65372,
         filename_absolute=1,
     )
-    return tst.testOpen()
+    tst.testOpen()
 
 
 def test_safe_4():
@@ -74,7 +74,7 @@ def test_safe_4():
         3732,
         filename_absolute=1,
     )
-    return tst.testOpen()
+    tst.testOpen()
 
 
 def test_safe_5():
@@ -86,7 +86,7 @@ def test_safe_5():
         65372,
         filename_absolute=1,
     )
-    return tst.testOpen()
+    tst.testOpen()
 
 
 def test_safe_WV():

--- a/autotest/gdrivers/saga.py
+++ b/autotest/gdrivers/saga.py
@@ -45,7 +45,7 @@ pytestmark = pytest.mark.require_driver("SAGA")
 def test_saga_1():
 
     tst = gdaltest.GDALTest("SAGA", "saga/4byteFloat.sdat", 1, 108)
-    return tst.testOpen(
+    tst.testOpen(
         check_prj="""PROJCS["NAD_1927_UTM_Zone_11N",
     GEOGCS["GCS_North_American_1927",
         DATUM["North_American_Datum_1927",
@@ -69,7 +69,7 @@ def test_saga_1():
 def test_saga_2():
 
     tst = gdaltest.GDALTest("SAGA", "saga/4byteFloat.sdat", 1, 108)
-    return tst.testCreateCopy(new_filename="tmp/createcopy.sdat", check_srs=True)
+    tst.testCreateCopy(new_filename="tmp/createcopy.sdat", check_srs=True)
 
 
 ###############################################################################
@@ -79,7 +79,7 @@ def test_saga_2():
 def test_saga_3():
 
     tst = gdaltest.GDALTest("SAGA", "saga/4byteFloat.sdat", 1, 108)
-    return tst.testCreate(new_filename="tmp/copy.sdat", out_bands=1)
+    tst.testCreate(new_filename="tmp/copy.sdat", out_bands=1)
 
 
 ###############################################################################
@@ -186,7 +186,7 @@ def test_saga_6():
 def test_saga_7():
 
     tst = gdaltest.GDALTest("SAGA", "saga/4byteFloat.sdat", 1, 108)
-    return tst.testCreateCopy(new_filename="/vsimem/createcopy.sdat")
+    tst.testCreateCopy(new_filename="/vsimem/createcopy.sdat")
 
 
 ###############################################################################
@@ -195,7 +195,7 @@ def test_saga_7():
 
 def test_saga_8():
     tst = gdaltest.GDALTest("SAGA", "saga/4byteFloat.sg-grd-z", 1, 108)
-    return tst.testOpen(
+    tst.testOpen(
         check_prj="""PROJCS["NAD_1927_UTM_Zone_11N",
     GEOGCS["GCS_North_American_1927",
         DATUM["North_American_Datum_1927",

--- a/autotest/gdrivers/sar_ceos.py
+++ b/autotest/gdrivers/sar_ceos.py
@@ -38,7 +38,7 @@ def test_sar_ceos_app_1():
     tst = gdaltest.GDALTest(
         "SAR_CEOS", "data/sar_ceos/ottawa_patch.img", 1, -1, filename_absolute=1
     )
-    return tst.testOpen()
+    tst.testOpen()
 
 
 @gdaltest.disable_exceptions()
@@ -46,4 +46,4 @@ def test_sar_ceos_asf_2():
     tst = gdaltest.GDALTest(
         "SAR_CEOS", "data/sar_ceos/R1_26161_FN1_F164.D", 1, -1, filename_absolute=1
     )
-    return tst.testOpen()
+    tst.testOpen()

--- a/autotest/gdrivers/sgi.py
+++ b/autotest/gdrivers/sgi.py
@@ -39,7 +39,7 @@ def test_sgi_1():
 
     tst = gdaltest.GDALTest("SGI", "sgi/byte.sgi", 1, 4672)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -50,7 +50,7 @@ def test_sgi_2():
 
     tst = gdaltest.GDALTest("SGI", "byte.tif", 1, 4672)
 
-    return tst.testCreate()
+    tst.testCreate()
 
 
 ###############################################################################
@@ -61,4 +61,4 @@ def test_sgi_3():
 
     tst = gdaltest.GDALTest("SGI", "rgbsmall.tif", 2, 21053)
 
-    return tst.testCreate()
+    tst.testCreate()

--- a/autotest/gdrivers/sigdem.py
+++ b/autotest/gdrivers/sigdem.py
@@ -42,7 +42,7 @@ def test_sigdem_copy_check_prj():
 
     prj = 'PROJCS["NAD27 / UTM zone 11N",GEOGCS["NAD27",DATUM["North_American_Datum_1927",SPHEROID["Clarke_1866",6378206.4,294.9786982138982]],PRIMEM["Greenwich",0],UNIT["Degree",0.017453292519943295]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",-117],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],UNIT["Meter",1]]'
 
-    return tst.testCreateCopy(check_gt=1, check_srs=prj)
+    tst.testCreateCopy(check_gt=1, check_srs=prj)
 
 
 ###############################################################################
@@ -55,7 +55,7 @@ def test_sigdem_non_square():
 
     prj = 'PROJCS["NAD27 / UTM zone 11N",GEOGCS["NAD27",DATUM["North_American_Datum_1927",SPHEROID["Clarke_1866",6378206.4,294.9786982138982]],PRIMEM["Greenwich",0],UNIT["Degree",0.017453292519943295]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",-117],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],UNIT["Meter",1]]'
 
-    return tst.testCreateCopy(check_gt=1, check_srs=prj)
+    tst.testCreateCopy(check_gt=1, check_srs=prj)
 
 
 ###############################################################################
@@ -66,7 +66,7 @@ def test_sigdem_in_memory():
 
     tst = gdaltest.GDALTest("SIGDEM", "byte.tif", 1, 4672)
 
-    return tst.testCreateCopy(vsimem=1)
+    tst.testCreateCopy(vsimem=1)
 
 
 ###############################################################################

--- a/autotest/gdrivers/snodas.py
+++ b/autotest/gdrivers/snodas.py
@@ -58,13 +58,10 @@ def test_snodas_1():
     UNIT["degree",0.0174532925199433,
         AUTHORITY["EPSG","9108"]],
     AUTHORITY["EPSG","4326"]]"""
-    ret = tst.testOpen(check_gt=expected_gt, check_prj=expected_srs, skip_checksum=True)
+    tst.testOpen(check_gt=expected_gt, check_prj=expected_srs, skip_checksum=True)
 
-    if ret == "success":
-        ds = gdal.Open("data/snodas/fake_snodas.hdr")
-        ds.GetFileList()
-        assert ds.GetRasterBand(1).GetNoDataValue() == -9999
-        assert ds.GetRasterBand(1).GetMinimum() == 0
-        assert ds.GetRasterBand(1).GetMaximum() == 429
-
-    return ret
+    ds = gdal.Open("data/snodas/fake_snodas.hdr")
+    ds.GetFileList()
+    assert ds.GetRasterBand(1).GetNoDataValue() == -9999
+    assert ds.GetRasterBand(1).GetMinimum() == 0
+    assert ds.GetRasterBand(1).GetMaximum() == 429

--- a/autotest/gdrivers/srp.py
+++ b/autotest/gdrivers/srp.py
@@ -103,8 +103,7 @@ def test_srp_3():
 def test_srp_4():
 
     tst = gdaltest.GDALTest("SRP", "srp/USRP_PCB0/TRANSH01.THF", 1, 24576)
-    ret = tst.testOpen()
-    return ret
+    tst.testOpen()
 
 
 ###############################################################################

--- a/autotest/gdrivers/terragen.py
+++ b/autotest/gdrivers/terragen.py
@@ -42,7 +42,7 @@ def test_terragen_1():
 
     tst = gdaltest.GDALTest("terragen", "terragen/float32.ter", 1, 1128)
 
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################

--- a/autotest/gdrivers/til.py
+++ b/autotest/gdrivers/til.py
@@ -44,7 +44,7 @@ pytestmark = pytest.mark.require_driver("TIL")
 def test_til_1():
 
     tst = gdaltest.GDALTest("TIL", "til/testtil.til", 1, 4672)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################

--- a/autotest/gdrivers/usgsdem.py
+++ b/autotest/gdrivers/usgsdem.py
@@ -46,7 +46,7 @@ def test_usgsdem_1():
     tst = gdaltest.GDALTest("USGSDEM", "usgsdem/022gdeme_truncated", 1, 1583)
     srs = osr.SpatialReference()
     srs.SetWellKnownGeogCS("NAD27")
-    return tst.testOpen(
+    tst.testOpen(
         check_prj=srs.ExportToWkt(),
         check_gt=(-67.00041667, 0.00083333, 0.0, 50.000416667, 0.0, -0.00083333),
     )
@@ -63,7 +63,7 @@ def test_usgsdem_2():
     )
     srs = osr.SpatialReference()
     srs.SetWellKnownGeogCS("NAD27")
-    return tst.testOpen(
+    tst.testOpen(
         check_prj=srs.ExportToWkt(),
         check_gt=(
             -136.25010416667,
@@ -86,7 +86,7 @@ def test_usgsdem_3():
     srs = osr.SpatialReference()
     srs.SetWellKnownGeogCS("WGS72")
     srs.SetUTM(17)
-    return tst.testOpen(
+    tst.testOpen(
         check_prj=srs.ExportToWkt(),
         check_gt=(606855.0, 30.0, 0.0, 4414605.0, 0.0, -30.0),
     )
@@ -105,7 +105,7 @@ def test_usgsdem_4():
         61424,
         options=["RESAMPLE=Nearest"],
     )
-    return tst.testCreateCopy(check_gt=1, check_srs=1, vsimem=1)
+    tst.testCreateCopy(check_gt=1, check_srs=1, vsimem=1)
 
 
 ###############################################################################
@@ -242,7 +242,7 @@ def test_usgsdem_8():
     srs = osr.SpatialReference()
     srs.SetWellKnownGeogCS("NAD27")
     srs.SetUTM(12)
-    return tst.testOpen(
+    tst.testOpen(
         check_prj=srs.ExportToWkt(),
         check_gt=(660055.0, 10.0, 0.0, 4429465.0, 0.0, -10.0),
     )
@@ -258,7 +258,7 @@ def test_usgsdem_9():
     tst = gdaltest.GDALTest("USGSDEM", "usgsdem/4619old_truncated.dem", 1, 10659)
     srs = osr.SpatialReference()
     srs.SetWellKnownGeogCS("NAD27")
-    return tst.testOpen(
+    tst.testOpen(
         check_prj=srs.ExportToWkt(),
         check_gt=(18.99958333, 0.0008333, 0.0, 47.000416667, 0.0, -0.0008333),
     )
@@ -273,7 +273,7 @@ def test_usgsdem_with_extra_values_at_end_of_profile():
     tst = gdaltest.GDALTest(
         "USGSDEM", "usgsdem/usgsdem_with_extra_values_at_end_of_profile.dem", 1, 56679
     )
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -285,7 +285,7 @@ def test_usgsdem_with_spaces_after_byte_864():
     tst = gdaltest.GDALTest(
         "USGSDEM", "usgsdem/usgsdem_with_spaces_after_byte_864.dem", 1, 61078
     )
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -317,7 +317,7 @@ def test_usgsdem_record_1025_bytes_ending_with_linefeed():
     tst = gdaltest.GDALTest(
         "USGSDEM", "usgsdem/record_1025_ending_with_linefeed.dem", 1, 14172
     )
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################

--- a/autotest/gdrivers/vrtfilt.py
+++ b/autotest/gdrivers/vrtfilt.py
@@ -41,7 +41,7 @@ from osgeo import gdal
 def test_vrtfilt_1():
 
     tst = gdaltest.GDALTest("VRT", "vrt/avfilt.vrt", 1, 21890)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -57,7 +57,7 @@ def test_vrtfilt_2():
     # This is a black&white checkboard, where black = nodata
     # Thus averaging it and taking nodata into account will not change it
     tst = gdaltest.GDALTest("VRT", "vrt/avfilt_nodata.vrt", 1, checksum)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################
@@ -154,7 +154,7 @@ def test_vrtfilt_5():
 def test_vrtfilt_6():
 
     tst = gdaltest.GDALTest("VRT", "vrt/avfilt_1d.vrt", 1, 22377)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################

--- a/autotest/gdrivers/vrtlut.py
+++ b/autotest/gdrivers/vrtlut.py
@@ -38,4 +38,4 @@ import gdaltest
 def test_vrtlut_1():
 
     tst = gdaltest.GDALTest("VRT", "vrt/byte_lut.vrt", 1, 4655)
-    return tst.testOpen()
+    tst.testOpen()

--- a/autotest/gdrivers/vrtrawlink.py
+++ b/autotest/gdrivers/vrtrawlink.py
@@ -51,7 +51,7 @@ def _xmlsearch(root, nodetype, name):
 def test_vrtrawlink_1():
 
     tst = gdaltest.GDALTest("VRT", "small.vrt", 2, 12816)
-    return tst.testOpen()
+    tst.testOpen()
 
 
 ###############################################################################

--- a/autotest/gdrivers/vrtwarp.py
+++ b/autotest/gdrivers/vrtwarp.py
@@ -45,7 +45,7 @@ from osgeo import gdal
 def test_vrtwarp_1():
 
     tst = gdaltest.GDALTest("VRT", "vrt/rgb_warp.vrt", 2, 21504)
-    return tst.testOpen(check_filelist=False)
+    tst.testOpen(check_filelist=False)
 
 
 ###############################################################################

--- a/autotest/gdrivers/xpm.py
+++ b/autotest/gdrivers/xpm.py
@@ -56,4 +56,4 @@ def test_xpm(downloadURL, fileName, checksum, download_size):
 
 def test_xpm_1():
     tst = gdaltest.GDALTest("XPM", "byte.tif", 1, 4583)
-    return tst.testCreateCopy(vsimem=1, check_minmax=False)
+    tst.testCreateCopy(vsimem=1, check_minmax=False)

--- a/autotest/gdrivers/xyz.py
+++ b/autotest/gdrivers/xyz.py
@@ -45,7 +45,7 @@ pytestmark = pytest.mark.require_driver("XYZ")
 def test_xyz_1():
 
     tst = gdaltest.GDALTest("XYZ", "byte.tif", 1, 4672)
-    return tst.testCreateCopy(
+    tst.testCreateCopy(
         vsimem=1,
         check_gt=(-67.00041667, 0.00083333, 0.0, 50.000416667, 0.0, -0.00083333),
     )

--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -2975,7 +2975,7 @@ def test_zarr_create_copy():
     tst = gdaltest.GDALTest("Zarr", "../../gcore/data/uint16.tif", 1, 4672)
 
     try:
-        return tst.testCreate(vsimem=1, new_filename="/vsimem/test.zarr")
+        tst.testCreate(vsimem=1, new_filename="/vsimem/test.zarr")
     finally:
         gdal.RmdirRecursive("/vsimem/test.zarr")
 
@@ -3165,7 +3165,7 @@ def test_zarr_create_with_filter():
     )
 
     try:
-        ret = tst.testCreate(
+        tst.testCreate(
             vsimem=1, new_filename="/vsimem/test.zarr", delete_output_file=False
         )
 
@@ -3176,8 +3176,6 @@ def test_zarr_create_with_filter():
         j = json.loads(data)
         assert "filters" in j
         assert j["filters"] == [{"id": "delta", "dtype": "<u2"}]
-
-        return ret
     finally:
         gdal.RmdirRecursive("/vsimem/test.zarr")
 

--- a/autotest/gdrivers/zmap.py
+++ b/autotest/gdrivers/zmap.py
@@ -42,7 +42,7 @@ pytestmark = pytest.mark.require_driver("ZMap")
 def test_zmap_1():
 
     tst = gdaltest.GDALTest("ZMap", "byte.tif", 1, 4672)
-    return tst.testCreateCopy(
+    tst.testCreateCopy(
         vsimem=1,
         check_gt=(-67.00041667, 0.00083333, 0.0, 50.000416667, 0.0, -0.00083333),
     )

--- a/autotest/ogr/ogr_fgdb.py
+++ b/autotest/ogr/ogr_fgdb.py
@@ -1160,11 +1160,9 @@ def test_ogr_fgdb_18(openfilegdb_drv, fgdb_drv):
 
     if openfilegdb_drv is not None:
         openfilegdb_drv.Register()
-    ret = ogr_fgdb_18_test_results(openfilegdb_drv)
+    ogr_fgdb_18_test_results(openfilegdb_drv)
     if openfilegdb_drv is not None:
         openfilegdb_drv.Deregister()
-
-    return ret
 
 
 def ogr_fgdb_18_test_results(openfilegdb_drv):
@@ -1756,8 +1754,7 @@ def test_ogr_fgdb_19bis(openfilegdb_drv, fgdb_drv):
         pytest.skip()
 
     with gdal.config_option("FGDB_PER_LAYER_COPYING_TRANSACTION", "FALSE"):
-        ret = test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv)
-    return ret
+        test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv)
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_geos.py
+++ b/autotest/ogr/ogr_geos.py
@@ -291,7 +291,7 @@ def test_ogr_geos_centroid_multipolygon():
 
     centroid = g1.Centroid()
 
-    ogrtest.check_feature_geometry(centroid, "POINT (1.5 0.5)") == 0
+    ogrtest.check_feature_geometry(centroid, "POINT (1.5 0.5)")
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_libkml.py
+++ b/autotest/ogr/ogr_libkml.py
@@ -500,8 +500,7 @@ def test_ogr_libkml_check_write_kmz():
 
 def test_ogr_libkml_write_kmz_use_doc_off():
     with gdal.config_option("LIBKML_USE_DOC.KML", "NO"):
-        ret = ogr_libkml_write("/vsimem/libkml_use_doc_off.kmz")
-    return ret
+        ogr_libkml_write("/vsimem/libkml_use_doc_off.kmz")
 
 
 def test_ogr_libkml_check_write_kmz_use_doc_off():
@@ -516,12 +515,11 @@ def test_ogr_libkml_check_write_dir():
     if not ogrtest.have_read_libkml:
         pytest.skip()
 
-    ret = ogr_libkml_check_write("/vsimem/libkmldir")
+    ogr_libkml_check_write("/vsimem/libkmldir")
     files = gdal.ReadDir("/vsimem/libkmldir")
     for filename in files:
         gdal.Unlink("/vsimem/libkmldir/" + filename)
     gdal.Rmdir("/vsimem/libkmldir")
-    return ret
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_ods.py
+++ b/autotest/ogr/ogr_ods.py
@@ -245,12 +245,10 @@ def test_ogr_ods_5():
     )
 
     ds = ogr.Open("tmp/test.ods")
-    ret = ogr_ods_check(ds)
+    ogr_ods_check(ds)
     ds = None
 
     os.unlink("tmp/test.ods")
-
-    return ret
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_osm.py
+++ b/autotest/ogr/ogr_osm.py
@@ -301,11 +301,9 @@ def test_ogr_osm_3(options=None, all_layers=False):
             "tmp/ogr_osm_3", "data/osm/test.pbf", options=layers + options
         )
 
-    ret = test_ogr_osm_1(filepath)
+    test_ogr_osm_1(filepath)
 
     ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(filepath)
-
-    return ret
 
 
 ###############################################################################
@@ -314,8 +312,7 @@ def test_ogr_osm_3(options=None, all_layers=False):
 
 def test_ogr_osm_3_sqlite_nodes():
     with gdal.config_option("OSM_USE_CUSTOM_INDEXING", "NO"):
-        ret = test_ogr_osm_3(options="-skip")
-    return ret
+        test_ogr_osm_3(options="-skip")
 
 
 ###############################################################################
@@ -324,8 +321,7 @@ def test_ogr_osm_3_sqlite_nodes():
 
 def test_ogr_osm_3_custom_compress_nodes():
     with gdal.config_option("OSM_COMPRESS_NODES", "YES"):
-        ret = test_ogr_osm_3()
-    return ret
+        test_ogr_osm_3()
 
 
 ###############################################################################
@@ -514,9 +510,7 @@ def test_ogr_osm_8():
 def test_ogr_osm_9():
 
     with gdal.config_option("OSM_USE_CUSTOM_INDEXING", "NO"):
-        ret = test_ogr_osm_8()
-
-    return ret
+        test_ogr_osm_8()
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_pg.py
+++ b/autotest/ogr/ogr_pg.py
@@ -4487,12 +4487,10 @@ def test_ogr_pg_76():
     level = int(gdaltest.pg_ds.GetMetadataItem("nSoftTransactionLevel", "_DEBUG_"))
     assert level == 0
 
-    ret = ogr_pg_76_scenario1(lyr1, lyr2)
-    ret = ogr_pg_76_scenario2(lyr1, lyr2)
-    ret = ogr_pg_76_scenario3(lyr1, lyr2)
-    ret = ogr_pg_76_scenario4(lyr1, lyr2)
-
-    return ret
+    ogr_pg_76_scenario1(lyr1, lyr2)
+    ogr_pg_76_scenario2(lyr1, lyr2)
+    ogr_pg_76_scenario3(lyr1, lyr2)
+    ogr_pg_76_scenario4(lyr1, lyr2)
 
 
 # Scenario 1 : a CreateFeature done in the middle of GetNextFeature()

--- a/autotest/ogr/ogr_rfc35_mem.py
+++ b/autotest/ogr/ogr_rfc35_mem.py
@@ -175,28 +175,28 @@ def test_ogr_rfc35_mem_2():
     feat = None
 
     assert lyr.ReorderField(1, 3) == 0
-    ret = Check(lyr, ["foo5", "baz15", "baw20", "bar10"])
+    Check(lyr, ["foo5", "baz15", "baw20", "bar10"])
 
     lyr.ReorderField(3, 1)
-    ret = Check(lyr, ["foo5", "bar10", "baz15", "baw20"])
+    Check(lyr, ["foo5", "bar10", "baz15", "baw20"])
 
     lyr.ReorderField(0, 2)
-    ret = Check(lyr, ["bar10", "baz15", "foo5", "baw20"])
+    Check(lyr, ["bar10", "baz15", "foo5", "baw20"])
 
     lyr.ReorderField(2, 0)
-    ret = Check(lyr, ["foo5", "bar10", "baz15", "baw20"])
+    Check(lyr, ["foo5", "bar10", "baz15", "baw20"])
 
     lyr.ReorderField(0, 1)
-    ret = Check(lyr, ["bar10", "foo5", "baz15", "baw20"])
+    Check(lyr, ["bar10", "foo5", "baz15", "baw20"])
 
     lyr.ReorderField(1, 0)
-    ret = Check(lyr, ["foo5", "bar10", "baz15", "baw20"])
+    Check(lyr, ["foo5", "bar10", "baz15", "baw20"])
 
     lyr.ReorderFields([3, 2, 1, 0])
-    ret = Check(lyr, ["baw20", "baz15", "bar10", "foo5"])
+    Check(lyr, ["baw20", "baz15", "bar10", "foo5"])
 
     lyr.ReorderFields([3, 2, 1, 0])
-    ret = Check(lyr, ["foo5", "bar10", "baz15", "baw20"])
+    Check(lyr, ["foo5", "bar10", "baz15", "baw20"])
 
     with gdaltest.error_handler():
         ret = lyr.ReorderFields([0, 0, 0, 0])
@@ -226,7 +226,7 @@ def test_ogr_rfc35_mem_3():
 
     lyr.AlterFieldDefn(lyr_defn.GetFieldIndex("baz15"), fd, ogr.ALTER_ALL_FLAG)
 
-    ret = CheckFeatures(lyr, field3="baz25")
+    CheckFeatures(lyr, field3="baz25")
 
     fd = ogr.FieldDefn("baz5", ogr.OFTString)
     fd.SetWidth(5)
@@ -234,13 +234,13 @@ def test_ogr_rfc35_mem_3():
     lyr_defn = lyr.GetLayerDefn()
     lyr.AlterFieldDefn(lyr_defn.GetFieldIndex("baz25"), fd, ogr.ALTER_ALL_FLAG)
 
-    ret = CheckFeatures(lyr, field3="baz5")
+    CheckFeatures(lyr, field3="baz5")
 
     lyr_defn = lyr.GetLayerDefn()
     fld_defn = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("baz5"))
     assert fld_defn.GetWidth() == 5
 
-    ret = CheckFeatures(lyr, field3="baz5")
+    CheckFeatures(lyr, field3="baz5")
 
 
 ###############################################################################
@@ -355,21 +355,21 @@ def test_ogr_rfc35_mem_5():
 
     assert lyr.DeleteField(0) == 0
 
-    ret = CheckFeatures(lyr, field3="baz5")
+    CheckFeatures(lyr, field3="baz5")
 
     assert lyr.DeleteField(lyr_defn.GetFieldIndex("baw20")) == 0
 
-    ret = CheckFeatures(lyr, field3="baz5", field4=None)
+    CheckFeatures(lyr, field3="baz5", field4=None)
 
     assert lyr.DeleteField(lyr_defn.GetFieldIndex("baz5")) == 0
 
-    ret = CheckFeatures(lyr, field3=None, field4=None)
+    CheckFeatures(lyr, field3=None, field4=None)
 
     assert lyr.DeleteField(lyr_defn.GetFieldIndex("foo5")) == 0
 
     assert lyr.DeleteField(lyr_defn.GetFieldIndex("bar10")) == 0
 
-    ret = CheckFeatures(lyr, field1=None, field2=None, field3=None, field4=None)
+    CheckFeatures(lyr, field1=None, field2=None, field3=None, field4=None)
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_rfc35_mitab.py
+++ b/autotest/ogr/ogr_rfc35_mitab.py
@@ -482,7 +482,6 @@ def test_ogr_rfc35_mitab_5():
 
     # Check that the file size has decreased after column removing
     CheckFileSize("tmp/rfc35_test.tab")
-    assert ret != "fail"
 
     ds = ogr.Open("tmp/rfc35_test.tab", update=1)
     lyr = ds.GetLayer(0)

--- a/autotest/ogr/ogr_rfc35_shape.py
+++ b/autotest/ogr/ogr_rfc35_shape.py
@@ -455,8 +455,6 @@ def test_ogr_rfc35_shape_5():
 
     # Check that the file size has decreased after column removing
     CheckFileSize("tmp/rfc35_test.dbf")
-    if ret == "fail":
-        return ret
 
     ds = ogr.Open("tmp/rfc35_test.dbf", update=1)
     lyr = ds.GetLayer(0)

--- a/autotest/ogr/ogr_shape_qix.py
+++ b/autotest/ogr/ogr_shape_qix.py
@@ -117,11 +117,9 @@ def test_ogr_shape_qix_1():
 
     ds = ogr.Open("/vsimem/ogr_shape_qix.shp")
     lyr = ds.GetLayer(0)
-    ret = check_qix_non_overlapping_geoms(lyr)
+    check_qix_non_overlapping_geoms(lyr)
 
     shape_drv.DeleteDataSource("/vsimem/ogr_shape_qix.shp")
-
-    return ret
 
 
 ###############################################################################
@@ -147,11 +145,9 @@ def test_ogr_shape_qix_2():
 
     ds = ogr.Open("/vsimem/ogr_shape_qix.shp")
     lyr = ds.GetLayer(0)
-    ret = check_qix_non_overlapping_geoms(lyr)
+    check_qix_non_overlapping_geoms(lyr)
 
     shape_drv.DeleteDataSource("/vsimem/ogr_shape_qix.shp")
-
-    return ret
 
 
 ###############################################################################
@@ -184,11 +180,9 @@ def test_ogr_shape_qix_3():
 
     ds = ogr.Open("/vsimem/ogr_shape_qix.shp")
     lyr = ds.GetLayer(0)
-    ret = check_qix_non_overlapping_geoms(lyr)
+    check_qix_non_overlapping_geoms(lyr)
 
     shape_drv.DeleteDataSource("/vsimem/ogr_shape_qix.shp")
-
-    return ret
 
 
 ###############################################################################
@@ -279,8 +273,6 @@ def test_ogr_shape_qix_4():
 
     ds.ExecuteSQL("CREATE SPATIAL INDEX ON ogr_shape_qix")
 
-    ret = check_qix_random_geoms(lyr)
+    check_qix_random_geoms(lyr)
 
     shape_drv.DeleteDataSource("/vsimem/ogr_shape_qix.shp")
-
-    return ret

--- a/autotest/ogr/ogr_vrt.py
+++ b/autotest/ogr/ogr_vrt.py
@@ -1029,11 +1029,7 @@ def ogr_vrt_21_internal():
 
 def test_ogr_vrt_21():
     with gdaltest.error_handler():
-        try:
-            ret = ogr_vrt_21_internal()
-        except Exception:
-            ret = "fail"
-    return ret
+        ogr_vrt_21_internal()
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_xlsx.py
+++ b/autotest/ogr/ogr_xlsx.py
@@ -177,12 +177,10 @@ def test_ogr_xlsx_5():
     )
 
     ds = ogr.Open("tmp/test.xlsx")
-    ret = ogr_xlsx_check(ds)
+    ogr_xlsx_check(ds)
     ds = None
 
     os.unlink("tmp/test.xlsx")
-
-    return ret
 
 
 ###############################################################################

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -51,19 +51,6 @@ import pytest
 
 from osgeo import gdal, osr
 
-cur_name = "default"
-
-success_counter = 0
-failure_counter = 0
-expected_failure_counter = 0
-blow_counter = 0
-skip_counter = 0
-failure_summary = []
-
-reason = None
-start_time = None
-end_time = None
-
 jp2kak_drv = None
 jpeg2000_drv = None
 jp2ecw_drv = None
@@ -76,36 +63,6 @@ jp2ecw_drv_unregistered = False
 jp2mrsid_drv_unregistered = False
 jp2openjpeg_drv_unregistered = False
 jp2lura_drv_unregistered = False
-
-# Process commandline arguments for stuff like --debug, --locale, --config
-
-argv = gdal.GeneralCmdLineProcessor(sys.argv)
-
-###############################################################################
-
-
-def git_status():
-
-    out, _ = runexternal_out_and_err("git status --porcelain .")
-    return out
-
-
-###############################################################################
-
-
-def get_lineno_2framesback(frames):
-    try:
-        import inspect
-
-        frame = inspect.currentframe()
-        while frames > 0:
-            frame = frame.f_back
-            frames = frames - 1
-
-        return frame.f_lineno
-    except ImportError:
-        return -1
-
 
 ###############################################################################
 

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -881,7 +881,7 @@ class GDALTest(object):
             self.driver.Delete(new_filename)
 
     def testSetNoDataValueAndDelete(self):
-        return self.testSetNoDataValue(delete=True)
+        self.testSetNoDataValue(delete=True)
 
     def testSetDescription(self):
         self.testDriver()


### PR DESCRIPTION
## What does this PR do?

Minor test cleanups:

- Remove unused functions and global variables from `gdaltest`
- Avoid using the return values of several functions that no longer return a value (primarily methods of the GDALTest class). In most cases these usages have no effect but in a small number of cases (such gcore/misc.py, gdrivers/snodas.py) the return values were being checked against the "success" string, causing tests to be accidentally skipped.

## What are related issues/pull requests?

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
