### PR TITLE
SWIG: Add GetConfigOptions

### DIFF
--- a/autotest/gcore/misc.py
+++ b/autotest/gcore/misc.py
@@ -942,6 +942,31 @@ def test_misc_config_context_mgrs_3():
 
 
 ###############################################################################
+# Test GetConfigOptions
+
+
+def test_misc_get_config_options():
+
+    assert gdal.GetConfigOptions() == {}
+
+    try:
+        gdal.SetConfigOption("A", "1")
+
+        assert gdal.GetConfigOptions() == {"A": "1"}
+
+        gdal.SetConfigOption("B", "2")
+
+        with gdal.config_options({"A": "9", "C": "8"}):
+            assert gdal.GetConfigOptions() == {"A": "9", "B": "2", "C": "8"}
+
+        assert gdal.GetConfigOptions() == {"A": "1", "B": "2"}
+
+    finally:
+        gdal.SetConfigOption("A", None)
+        gdal.SetConfigOption("B", None)
+
+
+###############################################################################
 
 
 def test_misc_cleanup():

--- a/frmts/rasterlite/rasterlitedataset.cpp
+++ b/frmts/rasterlite/rasterlitedataset.cpp
@@ -1296,12 +1296,9 @@ GDALDataset *RasterliteDataset::Open(GDALOpenInfo *poOpenInfo)
         }
         else
         {
-            CPLString osOldVal =
-                CPLGetConfigOption("OGR_SQLITE_EXACT_EXTENT", "NO");
-            CPLSetThreadLocalConfigOption("OGR_SQLITE_EXACT_EXTENT", "YES");
+            CPLConfigOptionSetter oSetter("OGR_SQLITE_EXACT_EXTENT", "YES",
+                                          false);
             OGR_L_GetExtent(hMetadataLyr, &oEnvelope, TRUE);
-            CPLSetThreadLocalConfigOption("OGR_SQLITE_EXACT_EXTENT",
-                                          osOldVal.c_str());
             // printf("minx=%.15f miny=%.15f maxx=%.15f maxy=%.15f\n",
             //        oEnvelope.MinX, oEnvelope.MinY, oEnvelope.MaxX,
             //        oEnvelope.MaxY);

--- a/swig/include/cpl.i
+++ b/swig/include/cpl.i
@@ -505,6 +505,27 @@ const char *wrapper_CPLGetThreadLocalConfigOption( const char * pszKey, const ch
 }
 }
 
+
+%rename(GetConfigOptions) wrapper_GetConfigOptions;
+#if defined(SWIGPYTHON)
+%apply (char **dictAndCSLDestroy) { char ** };
+#else
+%apply (char **) { char ** };
+#endif
+%inline {
+char** wrapper_GetConfigOptions() {
+    char ** papszOpts = CPLGetConfigOptions();
+    char ** papszTLOpts = CPLGetThreadLocalConfigOptions();
+
+    papszOpts = CSLMerge(papszOpts, papszTLOpts);
+
+    CPLFree(papszTLOpts);
+
+    return papszOpts;
+};
+}
+%clear char **;
+
 %apply Pointer NONNULL {const char * pszPathPrefix};
 void VSISetPathSpecificOption( const char* pszPathPrefix, const char * pszKey, const char * pszValue );
 


### PR DESCRIPTION
## What does this PR do?

Exposes a `GetConfigOptions` function that returns the set of options obtainable with `GetConfigOption`, with the exception of environment variables. This is done by blending the results of `CPLGetConfigOptions` and `CPLGetThreadLocalConfigOptions`.

I had conflicting opinions about this. On the one hand, the `GetConfigOptions` name is similar to `GetConfigOption`, so the functions should behave similarly and return thread-local config options that shadow global config options. On the other hand, the SWIG bindings should behave similarly to the underling C API, but this would introduce an unintuitive behavior difference between `GetConfigOption` and `GetConfigOptions`. This conflict could also be resolved by changing the behavior of `CPLGetConfigOptions`. I'm not seeing real usage in the wild: https://github.com/search?q=CPLGetConfigOptions+NOT+path%3Acpl_conv.*+NOT+path%3Agdal_*.rs+NOT+path%3Atest_cpl.cpp&type=code 

## What are related issues/pull requests?

https://trac.osgeo.org/gdal/ticket/7163

## Tasklist

 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
