### PR TITLE
Update gdalsrsinfo.rst

### DIFF
--- a/doc/source/programs/gdalsrsinfo.rst
+++ b/doc/source/programs/gdalsrsinfo.rst
@@ -90,7 +90,6 @@ Example
 
     $ gdalsrsinfo -o proj4 osr/data/lcc_esri.prj
     '+proj=lcc +lat_1=34.33333333333334 +lat_2=36.16666666666666 +lat_0=33.75 +lon_0=-79 +x_0=609601.22 +y_0=0 +datum=NAD83 +units=m +no_defs '
-    \endverbatim
 
 ::
 


### PR DESCRIPTION
remove parasitic `\endverbatim`

## What does this PR do?
Remove parasitic word `\endverbatim` from documentation