### PR TITLE
Python bindings: Allow passing options as dict

### DIFF
--- a/autotest/gcore/basic_test.py
+++ b/autotest/gcore/basic_test.py
@@ -534,6 +534,47 @@ def test_basic_test_16():
     assert "Invalid value for NUM_THREADS: INVALID" in gdal.GetLastErrorMsg()
 
 
+def test_basic_dict_open_options():
+
+    ds1 = gdal.Open("data/byte.tif")
+
+    ds2 = gdal.OpenEx("data/byte.tif", open_options={"GEOREF_SOURCES": "TABFILE"})
+
+    assert ds1.GetGeoTransform() != ds2.GetGeoTransform()
+
+
+def test_basic_dict_create_options():
+
+    with gdal.GetDriverByName("GTiff").Create(
+        "/vsimem/test_basic_dict_create_options.tif", 1, 1, options={"TFW": "YES"}
+    ) as ds:
+        gt = (0.0, 5.0, 0.0, 5.0, 0.0, -5.0)
+        ds.SetGeoTransform(gt)
+
+    assert gdal.VSIStatL("/vsimem/test_basic_dict_create_options.tfw") is not None
+
+    gdal.Unlink("/vsimem/test_basic_dict_create_options.tif")
+    gdal.Unlink("/vsimem/test_basic_dict_create_options.tfw")
+
+
+def test_basic_dict_create_copy_options():
+
+    src_ds = gdal.Open("data/byte.tif")
+
+    with gdal.GetDriverByName("GTiff").CreateCopy(
+        "/vsimem/test_basic_dict_create_copy_options.tif",
+        src_ds,
+        options={"TFW": "YES"},
+    ) as ds:
+        gt = (0.0, 5.0, 0.0, 5.0, 0.0, -5.0)
+        ds.SetGeoTransform(gt)
+
+    assert gdal.VSIStatL("/vsimem/test_basic_dict_create_copy_options.tfw") is not None
+
+    gdal.Unlink("/vsimem/test_basic_dict_create_copy_options.tif")
+    gdal.Unlink("/vsimem/test_basic_dict_create_copy_options.tfw")
+
+
 def test_gdal_getspatialref():
 
     ds = gdal.Open("data/byte.tif")

--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -4254,7 +4254,7 @@ def test_ogr_gpkg_47():
     assert gdal.GetLastErrorMsg() == ""
 
     gdaltest.gpkg_dr.CreateDataSource(
-        "/vsimem/ogr_gpkg_47.gpkg", options=["VERSION=1.2"]
+        "/vsimem/ogr_gpkg_47.gpkg", options={"VERSION": "1.2"}
     )
     # Set wrong user_version
     fp = gdal.VSIFOpenL("/vsimem/ogr_gpkg_47.gpkg", "rb+")
@@ -4299,7 +4299,7 @@ def test_ogr_gpkg_47():
 
     # Set GPKG 1.3.0
     gdaltest.gpkg_dr.CreateDataSource(
-        "/vsimem/ogr_gpkg_47.gpkg", options=["VERSION=1.3"]
+        "/vsimem/ogr_gpkg_47.gpkg", options={"VERSION": "1.3"}
     )
     # Check user_version
     fp = gdal.VSIFOpenL("/vsimem/ogr_gpkg_47.gpkg", "rb")

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -3651,7 +3651,7 @@ def test_ogr_shape_85():
 
     # Test open option ADJUST_TYPE
     ds = gdal.OpenEx(
-        "/vsimem/ogr_shape_85.shp", gdal.OF_VECTOR, open_options=["ADJUST_TYPE=YES"]
+        "/vsimem/ogr_shape_85.shp", gdal.OF_VECTOR, open_options={"ADJUST_TYPE": "YES"}
     )
     lyr = ds.GetLayer(0)
     assert lyr.GetLayerDefn().GetFieldDefn(0).GetType() == ogr.OFTInteger
@@ -3948,7 +3948,7 @@ def test_ogr_shape_94(shpt, geom_type, wkt):
             "/vsimem/ogr_shape_94.shp"
         )
         if i == 0:
-            lyr = ds.CreateLayer("ogr_shape_94", options=["SHPT=" + shpt])
+            lyr = ds.CreateLayer("ogr_shape_94", options={"SHPT": shpt})
         else:
             lyr = ds.CreateLayer("ogr_shape_94", geom_type=geom_type)
         test_lyr_geom_type = (
@@ -4581,7 +4581,7 @@ def test_ogr_shape_103(options, expected):
     lyr = ds.CreateLayer(
         "ogr_shape_103",
         geom_type=ogr.wkbNone,
-        options=["DBF_EOF_CHAR=NO"] + ["DBF_DATE_LAST_UPDATE=1970-01-01"],
+        options={"DBF_EOF_CHAR": "NO", "DBF_DATE_LAST_UPDATE": "1970-01-01"},
     )
     lyr.CreateField(ogr.FieldDefn("foo", ogr.OFTString))
     lyr.CreateFeature(ogr.Feature(lyr.GetLayerDefn()))


### PR DESCRIPTION
## What does this PR do?

Allows functions/methods in the Python bindings to accept options via a dictionaries.

A typemap (`char **dict`) already existed to accept a dictionary or sequence and convert it into a CSL, but it was only applied to `SetMetadata`. I updated the `char **dict` typemap to use the `CSLFromPySequence` helper, and set the `char **options` typemap to alias this.

I noticed that `CSLFromPySequence` has some special handling for UTF8 strings that was not present in the sequence-to-CSL code I replaced in `char **dict`. The dict-to-CSL pathway in `char **dict` does not have any special handling, but it appears that UTF8 option names and values are successfully transmitted to GDAL.

## What are related issues/pull requests?

## Tasklist

 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
