### PR TITLE
OpenFileGDB: make Open() to fail if requested to open in update mode …

### DIFF
--- a/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdbdatasource.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdbdatasource.cpp
@@ -279,7 +279,8 @@ bool OGROpenFileGDBDataSource::Open(const GDALOpenInfo *poOpenInfo)
     m_osGDBSystemCatalogFilename =
         CPLFormFilename(m_osDirName, "a00000001", "gdbtable");
     if (!FileExists(m_osGDBSystemCatalogFilename.c_str()) ||
-        !oTable.Open(m_osGDBSystemCatalogFilename.c_str(), false))
+        !oTable.Open(m_osGDBSystemCatalogFilename.c_str(),
+                     poOpenInfo->eAccess == GA_Update))
     {
         if (nInterestTable > 0 && FileExists(poOpenInfo->pszFilename))
         {

--- a/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer.cpp
@@ -363,8 +363,31 @@ int OGROpenFileGDBLayer::BuildLayerDefinition()
         if (!(m_poLyrTable->Open(m_osGDBFilename, m_bEditable,
                                  GetDescription())))
         {
-            Close();
-            return FALSE;
+            if (m_bEditable)
+            {
+                // Retry in read-only mode
+                m_bEditable = false;
+                delete m_poLyrTable;
+                m_poLyrTable = new FileGDBTable();
+                if (!(m_poLyrTable->Open(m_osGDBFilename, m_bEditable,
+                                         GetDescription())))
+                {
+                    Close();
+                    return FALSE;
+                }
+                else
+                {
+                    CPLError(
+                        CE_Failure, CPLE_FileIO,
+                        "Cannot open %s in update mode, but only in read-only",
+                        GetDescription());
+                }
+            }
+            else
+            {
+                Close();
+                return FALSE;
+            }
         }
     }
 


### PR DESCRIPTION
…and that files are in read-only (fixes qgis/QGIS#53715)
