### PR TITLE
GeoPackage: deal with DateTime fields without milliseconds or seconds

### DIFF
--- a/autotest/cpp/test_ogr.cpp
+++ b/autotest/cpp/test_ogr.cpp
@@ -2364,4 +2364,52 @@ TEST_F(test_ogr, GDALDatasetSetQueryLoggerFunc)
 #endif
 }
 
+TEST_F(test_ogr, OGRGetISO8601DateTime)
+{
+    OGRField sField;
+    sField.Date.Year = 2023;
+    sField.Date.Month = 7;
+    sField.Date.Day = 11;
+    sField.Date.Hour = 17;
+    sField.Date.Minute = 27;
+    sField.Date.Second = 34.567f;
+    sField.Date.TZFlag = 100;
+    {
+        char szResult[OGR_SIZEOF_ISO8601_DATETIME_BUFFER];
+        OGRISO8601Format sFormat;
+        sFormat.ePrecision = OGRISO8601Precision::AUTO;
+        OGRGetISO8601DateTime(&sField, sFormat, szResult);
+        EXPECT_STREQ(szResult, "2023-07-11T17:27:34.567Z");
+    }
+    {
+        char szResult[OGR_SIZEOF_ISO8601_DATETIME_BUFFER];
+        OGRISO8601Format sFormat;
+        sFormat.ePrecision = OGRISO8601Precision::MILLISECOND;
+        OGRGetISO8601DateTime(&sField, sFormat, szResult);
+        EXPECT_STREQ(szResult, "2023-07-11T17:27:34.567Z");
+    }
+    {
+        char szResult[OGR_SIZEOF_ISO8601_DATETIME_BUFFER];
+        OGRISO8601Format sFormat;
+        sFormat.ePrecision = OGRISO8601Precision::SECOND;
+        OGRGetISO8601DateTime(&sField, sFormat, szResult);
+        EXPECT_STREQ(szResult, "2023-07-11T17:27:35Z");
+    }
+    {
+        char szResult[OGR_SIZEOF_ISO8601_DATETIME_BUFFER];
+        OGRISO8601Format sFormat;
+        sFormat.ePrecision = OGRISO8601Precision::MINUTE;
+        OGRGetISO8601DateTime(&sField, sFormat, szResult);
+        EXPECT_STREQ(szResult, "2023-07-11T17:27Z");
+    }
+    sField.Date.Second = 34.0f;
+    {
+        char szResult[OGR_SIZEOF_ISO8601_DATETIME_BUFFER];
+        OGRISO8601Format sFormat;
+        sFormat.ePrecision = OGRISO8601Precision::AUTO;
+        OGRGetISO8601DateTime(&sField, sFormat, szResult);
+        EXPECT_STREQ(szResult, "2023-07-11T17:27:34Z");
+    }
+}
+
 }  // namespace

--- a/autotest/cpp/test_ogr.cpp
+++ b/autotest/cpp/test_ogr.cpp
@@ -2364,6 +2364,150 @@ TEST_F(test_ogr, GDALDatasetSetQueryLoggerFunc)
 #endif
 }
 
+TEST_F(test_ogr, OGRParseDateTimeYYYYMMDDTHHMMZ)
+{
+    {
+        char szInput[] = "2023-07-11T17:27Z";
+        OGRField sField;
+        EXPECT_EQ(
+            OGRParseDateTimeYYYYMMDDTHHMMZ(szInput, strlen(szInput), &sField),
+            true);
+        EXPECT_EQ(sField.Date.Year, 2023);
+        EXPECT_EQ(sField.Date.Month, 7);
+        EXPECT_EQ(sField.Date.Day, 11);
+        EXPECT_EQ(sField.Date.Hour, 17);
+        EXPECT_EQ(sField.Date.Minute, 27);
+        EXPECT_EQ(sField.Date.Second, 0.0f);
+        EXPECT_EQ(sField.Date.TZFlag, 100);
+    }
+    {
+        char szInput[] = "2023-07-11T17:27";
+        OGRField sField;
+        EXPECT_EQ(
+            OGRParseDateTimeYYYYMMDDTHHMMZ(szInput, strlen(szInput), &sField),
+            true);
+        EXPECT_EQ(sField.Date.Year, 2023);
+        EXPECT_EQ(sField.Date.Month, 7);
+        EXPECT_EQ(sField.Date.Day, 11);
+        EXPECT_EQ(sField.Date.Hour, 17);
+        EXPECT_EQ(sField.Date.Minute, 27);
+        EXPECT_EQ(sField.Date.Second, 0.0f);
+        EXPECT_EQ(sField.Date.TZFlag, 0);
+    }
+    {
+        // Invalid
+        char szInput[] = "2023-07-11T17:2";
+        OGRField sField;
+        EXPECT_EQ(
+            OGRParseDateTimeYYYYMMDDTHHMMZ(szInput, strlen(szInput), &sField),
+            false);
+    }
+    {
+        // Invalid
+        char szInput[] = "2023-07-11T17:99";
+        OGRField sField;
+        EXPECT_EQ(
+            OGRParseDateTimeYYYYMMDDTHHMMZ(szInput, strlen(szInput), &sField),
+            false);
+    }
+}
+
+TEST_F(test_ogr, OGRParseDateTimeYYYYMMDDTHHMMSSZ)
+{
+    {
+        char szInput[] = "2023-07-11T17:27:34Z";
+        OGRField sField;
+        EXPECT_EQ(
+            OGRParseDateTimeYYYYMMDDTHHMMSSZ(szInput, strlen(szInput), &sField),
+            true);
+        EXPECT_EQ(sField.Date.Year, 2023);
+        EXPECT_EQ(sField.Date.Month, 7);
+        EXPECT_EQ(sField.Date.Day, 11);
+        EXPECT_EQ(sField.Date.Hour, 17);
+        EXPECT_EQ(sField.Date.Minute, 27);
+        EXPECT_EQ(sField.Date.Second, 34.0f);
+        EXPECT_EQ(sField.Date.TZFlag, 100);
+    }
+    {
+        char szInput[] = "2023-07-11T17:27:34";
+        OGRField sField;
+        EXPECT_EQ(
+            OGRParseDateTimeYYYYMMDDTHHMMSSZ(szInput, strlen(szInput), &sField),
+            true);
+        EXPECT_EQ(sField.Date.Year, 2023);
+        EXPECT_EQ(sField.Date.Month, 7);
+        EXPECT_EQ(sField.Date.Day, 11);
+        EXPECT_EQ(sField.Date.Hour, 17);
+        EXPECT_EQ(sField.Date.Minute, 27);
+        EXPECT_EQ(sField.Date.Second, 34.0f);
+        EXPECT_EQ(sField.Date.TZFlag, 0);
+    }
+    {
+        // Invalid
+        char szInput[] = "2023-07-11T17:27:3";
+        OGRField sField;
+        EXPECT_EQ(
+            OGRParseDateTimeYYYYMMDDTHHMMSSZ(szInput, strlen(szInput), &sField),
+            false);
+    }
+    {
+        // Invalid
+        char szInput[] = "2023-07-11T17:27:99";
+        OGRField sField;
+        EXPECT_EQ(
+            OGRParseDateTimeYYYYMMDDTHHMMSSZ(szInput, strlen(szInput), &sField),
+            false);
+    }
+}
+
+TEST_F(test_ogr, OGRParseDateTimeYYYYMMDDTHHMMSSsssZ)
+{
+    {
+        char szInput[] = "2023-07-11T17:27:34.123Z";
+        OGRField sField;
+        EXPECT_EQ(OGRParseDateTimeYYYYMMDDTHHMMSSsssZ(szInput, strlen(szInput),
+                                                      &sField),
+                  true);
+        EXPECT_EQ(sField.Date.Year, 2023);
+        EXPECT_EQ(sField.Date.Month, 7);
+        EXPECT_EQ(sField.Date.Day, 11);
+        EXPECT_EQ(sField.Date.Hour, 17);
+        EXPECT_EQ(sField.Date.Minute, 27);
+        EXPECT_EQ(sField.Date.Second, 34.123f);
+        EXPECT_EQ(sField.Date.TZFlag, 100);
+    }
+    {
+        char szInput[] = "2023-07-11T17:27:34.123";
+        OGRField sField;
+        EXPECT_EQ(OGRParseDateTimeYYYYMMDDTHHMMSSsssZ(szInput, strlen(szInput),
+                                                      &sField),
+                  true);
+        EXPECT_EQ(sField.Date.Year, 2023);
+        EXPECT_EQ(sField.Date.Month, 7);
+        EXPECT_EQ(sField.Date.Day, 11);
+        EXPECT_EQ(sField.Date.Hour, 17);
+        EXPECT_EQ(sField.Date.Minute, 27);
+        EXPECT_EQ(sField.Date.Second, 34.123f);
+        EXPECT_EQ(sField.Date.TZFlag, 0);
+    }
+    {
+        // Invalid
+        char szInput[] = "2023-07-11T17:27:34.12";
+        OGRField sField;
+        EXPECT_EQ(OGRParseDateTimeYYYYMMDDTHHMMSSsssZ(szInput, strlen(szInput),
+                                                      &sField),
+                  false);
+    }
+    {
+        // Invalid
+        char szInput[] = "2023-07-11T17:27:99.123";
+        OGRField sField;
+        EXPECT_EQ(OGRParseDateTimeYYYYMMDDTHHMMSSsssZ(szInput, strlen(szInput),
+                                                      &sField),
+                  false);
+    }
+}
+
 TEST_F(test_ogr, OGRGetISO8601DateTime)
 {
     OGRField sField;

--- a/doc/source/drivers/vector/gpkg.rst
+++ b/doc/source/drivers/vector/gpkg.rst
@@ -375,6 +375,19 @@ The following layer creation options are available:
       gpkg_extensions table. Starting with GDAL 3.3, OGR_ASPATIAL is no longer
       available on creation.
 
+-  .. lco:: DATETIME_PRECISION
+      :choices: AUTO, MILLISECOND, SECOND, MINUTE
+      :default: AUTO
+      :since: 3.8
+
+      Determines the level of detail for datetime fields.
+      Starting with GeoPackage 1.4, three variants of datetime formats are supported:
+      truncated at minute (``MINUTE``), truncated at second (``SECOND``) or
+      including milliseconds (``MILLISECOND``).
+      In ``AUTO`` mode and GeoPackage 1.4, milliseconds are included only if non-zero.
+      Selecting modes ``MINUTE`` or ``SECOND`` will raise a warning with GeoPackage < 1.4.
+
+
 Configuration options
 ---------------------
 

--- a/ogr/ogr_p.h
+++ b/ogr/ogr_p.h
@@ -121,6 +121,30 @@ char CPL_DLL *OGRGetXMLDateTime(const OGRField *psField,
 int CPL_DLL
 OGRGetISO8601DateTime(const OGRField *psField, bool bAlwaysMillisecond,
                       char szBuffer[OGR_SIZEOF_ISO8601_DATETIME_BUFFER]);
+
+/** Precision of formatting */
+enum class OGRISO8601Precision
+{
+    /** Automated mode: millisecond included if non zero, otherwise truncated at second */
+    AUTO,
+    /** Always include millisecond */
+    MILLISECOND,
+    /** Always include second, but no millisecond */
+    SECOND,
+    /** Always include minute, but no second */
+    MINUTE
+};
+
+/** Configuration of the ISO8601 formatting output */
+struct OGRISO8601Format
+{
+    /** Precision of formatting */
+    OGRISO8601Precision ePrecision;
+};
+
+int CPL_DLL
+OGRGetISO8601DateTime(const OGRField *psField, const OGRISO8601Format &sFormat,
+                      char szBuffer[OGR_SIZEOF_ISO8601_DATETIME_BUFFER]);
 char CPL_DLL *OGRGetXML_UTF8_EscapedString(const char *pszString);
 bool CPL_DLL OGRParseDateTimeYYYYMMDDTHHMMZ(const char *pszInput, size_t nLen,
                                             OGRField *psField);

--- a/ogr/ogr_p.h
+++ b/ogr/ogr_p.h
@@ -122,6 +122,8 @@ int CPL_DLL
 OGRGetISO8601DateTime(const OGRField *psField, bool bAlwaysMillisecond,
                       char szBuffer[OGR_SIZEOF_ISO8601_DATETIME_BUFFER]);
 char CPL_DLL *OGRGetXML_UTF8_EscapedString(const char *pszString);
+bool CPL_DLL OGRParseDateTimeYYYYMMDDTHHMMZ(const char *pszInput, size_t nLen,
+                                            OGRField *psField);
 bool CPL_DLL OGRParseDateTimeYYYYMMDDTHHMMSSZ(const char *pszInput, size_t nLen,
                                               OGRField *psField);
 bool CPL_DLL OGRParseDateTimeYYYYMMDDTHHMMSSsssZ(const char *pszInput,

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -36,6 +36,7 @@
 #include "ogrsqliteutility.h"
 #include "cpl_threadsafe_queue.hpp"
 #include "ograrrowarrayhelper.h"
+#include "ogr_p.h"
 
 #include <condition_variable>
 #include <limits>
@@ -684,6 +685,8 @@ class OGRGeoPackageTableLayer final : public OGRGeoPackageLayer
              // thread
     std::thread m_oThreadRTree{};
 
+    OGRISO8601Format m_sDateTimeFormat = {OGRISO8601Precision::AUTO};
+
     void StartAsyncRTree();
     void CancelAsyncRTree();
     void RemoveAsyncRTreeTempDB();
@@ -838,6 +841,10 @@ class OGRGeoPackageTableLayer final : public OGRGeoPackageLayer
         m_eASpatialVariant = eASpatialVariant;
         if (eASpatialVariant == GPKG_ATTRIBUTES)
             m_bIsInGpkgContents = true;
+    }
+    void SetDateTimePrecision(OGRISO8601Precision ePrecision)
+    {
+        m_sDateTimeFormat.ePrecision = ePrecision;
     }
 
     void CreateSpatialIndexIfNecessary();

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -6606,6 +6606,41 @@ OGRLayer *GDALGeoPackageDataset::ICreateLayer(const char *pszLayerName,
         poLayer->SetASpatialVariant(eASpatialVariant);
     }
 
+    const char *pszDateTimePrecision =
+        CSLFetchNameValueDef(papszOptions, "DATETIME_PRECISION", "AUTO");
+    if (EQUAL(pszDateTimePrecision, "MILLISECOND"))
+    {
+        poLayer->SetDateTimePrecision(OGRISO8601Precision::MILLISECOND);
+    }
+    else if (EQUAL(pszDateTimePrecision, "SECOND"))
+    {
+        if (m_nUserVersion < GPKG_1_4_VERSION)
+            CPLError(
+                CE_Warning, CPLE_AppDefined,
+                "DATETIME_PRECISION=SECOND is only valid since GeoPackage 1.4");
+        poLayer->SetDateTimePrecision(OGRISO8601Precision::SECOND);
+    }
+    else if (EQUAL(pszDateTimePrecision, "MINUTE"))
+    {
+        if (m_nUserVersion < GPKG_1_4_VERSION)
+            CPLError(
+                CE_Warning, CPLE_AppDefined,
+                "DATETIME_PRECISION=MINUTE is only valid since GeoPackage 1.4");
+        poLayer->SetDateTimePrecision(OGRISO8601Precision::MINUTE);
+    }
+    else if (EQUAL(pszDateTimePrecision, "AUTO"))
+    {
+        if (m_nUserVersion < GPKG_1_4_VERSION)
+            poLayer->SetDateTimePrecision(OGRISO8601Precision::MILLISECOND);
+    }
+    else
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "Unsupported value for DATETIME_PRECISION: %s",
+                 pszDateTimePrecision);
+        return nullptr;
+    }
+
     // If there was an ogr_empty_table table, we can remove it
     // But do it at dataset closing, otherwise locking performance issues
     // can arise (probably when transactions are used).

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedriver.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedriver.cpp
@@ -590,6 +590,14 @@ void RegisterOGRGeoPackage()
         "     <Value>GPKG_ATTRIBUTES</Value>"
         "     <Value>NOT_REGISTERED</Value>"
         "  </Option>"
+        "  <Option name='DATETIME_PRECISION' type='string-select' "
+        "description='Number of components of datetime fields' "
+        "default='AUTO'>"
+        "     <Value>AUTO</Value>"
+        "     <Value>MILLISECOND</Value>"
+        "     <Value>SECOND</Value>"
+        "     <Value>MINUTE</Value>"
+        "  </Option>"
         "</LayerCreationOptionList>");
 
     poDriver->SetMetadataItem(GDAL_DMD_CREATIONFIELDDATATYPES,

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagelayer.cpp
@@ -305,9 +305,12 @@ bool OGRGeoPackageLayer::ParseDateTimeField(const char *pszTxt,
 
     const size_t nLen = strlen(pszTxt);
 
-    if (OGRParseDateTimeYYYYMMDDTHHMMSSsssZ(pszTxt, nLen, psField))
+    if (OGRParseDateTimeYYYYMMDDTHHMMSSsssZ(pszTxt, nLen, psField) ||
+        OGRParseDateTimeYYYYMMDDTHHMMSSZ(pszTxt, nLen, psField) ||
+        OGRParseDateTimeYYYYMMDDTHHMMZ(pszTxt, nLen, psField))
     {
-        // nominal format
+        // nominal format is YYYYMMDDTHHMMSSsssZ before GeoPackage 1.4
+        // GeoPackage 1.4 also accepts omission of seconds and milliseconds
     }
     else if (OGRParseDate(pszTxt, psField, 0))
     {

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -388,8 +388,6 @@ OGRErr OGRGeoPackageTableLayer::FeatureBindParameters(
                     else if (poFieldDefn->GetType() == OFTDateTime)
                     {
                         destructorType = SQLITE_STATIC;
-                        const bool bAlwaysMillisecond =
-                            (m_poDS->m_nUserVersion < GPKG_1_4_VERSION);
                         const auto psFieldRaw =
                             poFeature->GetRawFieldRef(iField);
                         char *pszValEdit =
@@ -399,7 +397,7 @@ OGRErr OGRGeoPackageTableLayer::FeatureBindParameters(
                             psFieldRaw->Date.TZFlag == 100)
                         {
                             nValLengthBytes = OGRGetISO8601DateTime(
-                                psFieldRaw, bAlwaysMillisecond, pszValEdit);
+                                psFieldRaw, m_sDateTimeFormat, pszValEdit);
                         }
                         else
                         {
@@ -439,7 +437,7 @@ OGRErr OGRGeoPackageTableLayer::FeatureBindParameters(
                             }
 
                             nValLengthBytes = OGRGetISO8601DateTime(
-                                &sField, bAlwaysMillisecond, pszValEdit);
+                                &sField, m_sDateTimeFormat, pszValEdit);
                         }
                         nInsertionBufferPos += nValLengthBytes;
                     }

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -388,7 +388,8 @@ OGRErr OGRGeoPackageTableLayer::FeatureBindParameters(
                     else if (poFieldDefn->GetType() == OFTDateTime)
                     {
                         destructorType = SQLITE_STATIC;
-                        constexpr bool bAlwaysMillisecond = true;
+                        const bool bAlwaysMillisecond =
+                            (m_poDS->m_nUserVersion < GPKG_1_4_VERSION);
                         const auto psFieldRaw =
                             poFeature->GetRawFieldRef(iField);
                         char *pszValEdit =

--- a/ogr/ogrutils.cpp
+++ b/ogr/ogrutils.cpp
@@ -1177,6 +1177,57 @@ int OGRParseDate(const char *pszInput, OGRField *psField,
 }
 
 /************************************************************************/
+/*               OGRParseDateTimeYYYYMMDDTHHMMZ()                       */
+/************************************************************************/
+
+bool OGRParseDateTimeYYYYMMDDTHHMMZ(const char *pszInput, size_t nLen,
+                                    OGRField *psField)
+{
+    // Detect "YYYY-MM-DDTHH:MM[Z]" (16 or 17 characters)
+    if ((nLen == 16 || (nLen == 17 && pszInput[16] == 'Z')) &&
+        pszInput[4] == '-' && pszInput[7] == '-' && pszInput[10] == 'T' &&
+        pszInput[13] == ':' && static_cast<unsigned>(pszInput[0] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[1] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[2] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[3] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[5] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[6] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[8] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[9] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[11] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[12] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[14] - '0') <= 9 &&
+        static_cast<unsigned>(pszInput[15] - '0') <= 9)
+    {
+        psField->Date.Year = static_cast<GInt16>(
+            ((((pszInput[0] - '0') * 10 + (pszInput[1] - '0')) * 10) +
+             (pszInput[2] - '0')) *
+                10 +
+            (pszInput[3] - '0'));
+        psField->Date.Month =
+            static_cast<GByte>((pszInput[5] - '0') * 10 + (pszInput[6] - '0'));
+        psField->Date.Day =
+            static_cast<GByte>((pszInput[8] - '0') * 10 + (pszInput[9] - '0'));
+        psField->Date.Hour = static_cast<GByte>((pszInput[11] - '0') * 10 +
+                                                (pszInput[12] - '0'));
+        psField->Date.Minute = static_cast<GByte>((pszInput[14] - '0') * 10 +
+                                                  (pszInput[15] - '0'));
+        psField->Date.Second = 0.0f;
+        psField->Date.TZFlag = nLen == 16 ? 0 : 100;
+        psField->Date.Reserved = 0;
+        if (psField->Date.Month == 0 || psField->Date.Month > 12 ||
+            psField->Date.Day == 0 || psField->Date.Day > 31 ||
+            psField->Date.Hour > 23 || psField->Date.Minute > 59)
+        {
+            return false;
+        }
+        return true;
+    }
+
+    return false;
+}
+
+/************************************************************************/
 /*               OGRParseDateTimeYYYYMMDDTHHMMSSZ()                     */
 /************************************************************************/
 

--- a/swig/python/gdal-utils/osgeo_utils/samples/validate_gpkg.py
+++ b/swig/python/gdal-utils/osgeo_utils/samples/validate_gpkg.py
@@ -516,7 +516,13 @@ class GPKGChecker(object):
         geom_types = GPKGChecker.BASE_GEOM_TYPES + GPKGChecker.EXT_GEOM_TYPES
         date_pattern_str = "[0-9]{4}-[0-1][0-9]-[0-3][0-9]"
         date_pattern = re.compile(date_pattern_str)
-        datetime_pattern = re.compile(
+        datetime_pattern_no_seconds = re.compile(
+            date_pattern_str + "T[0-2][0-9]:[0-5][0-9]Z"
+        )
+        datetime_pattern_with_seconds_no_ms = re.compile(
+            date_pattern_str + "T[0-2][0-9]:[0-5][0-9]:[0-5][0-9]Z"
+        )
+        datetime_pattern_with_milliseconds = re.compile(
             date_pattern_str + "T[0-2][0-9]:[0-5][0-9]:[0-5][0-9].[0-9]{3}Z"
         )
         for row in c.fetchall():
@@ -633,7 +639,11 @@ class GPKGChecker(object):
                         continue
 
                 elif expected_col_type == "DATETIME" and got_col_type == "TEXT":
-                    if datetime_pattern.match(val) is None:
+                    if (
+                        datetime_pattern_with_milliseconds.match(val) is None
+                        and datetime_pattern_with_seconds_no_ms.match(val) is None
+                        and datetime_pattern_no_seconds.match(val) is None
+                    ):
                         warned_col[i] = True
                         self._warn(
                             "In column %s, text %s found which is not a valid DATETIME"


### PR DESCRIPTION
as allowed by GeoPackage 1.4 (fixes https://github.com/OSGeo/gdal/issues/8037)

and add a DATETIME_PRECISION layer creation option