### PR TITLE
Internal libtiff: WebP codec: turn exact mode when creating lossless …

### DIFF
--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -11245,5 +11245,31 @@ def test_tiff_write_offset_in_GDAL_METADATA_tag_metadata_in_pam():
     gdal.GetDriverByName("GTiff").Delete(filename)
 
 
+@pytest.mark.skipif(
+    not check_libtiff_internal_or_at_least(4, 6, 0),
+    reason="libtiff internal or >=4.6.0 needed",
+)
+@pytest.mark.require_creation_option("GTiff", "WEBP")
+def test_tiff_write_webp_lossless_exact():
+
+    filename = "/vsimem/test_tiff_write_webp_lossless_exact.tif"
+    ds = gdal.GetDriverByName("GTiff").Create(
+        filename,
+        10,
+        10,
+        4,
+        options=["PHOTOMETRIC=RGB", "ALPHA=YES", "COMPRESS=WEBP", "WEBP_LOSSLESS=YES"],
+    )
+    ds.GetRasterBand(1).Fill(1)
+    ds.GetRasterBand(2).Fill(2)
+    ds.GetRasterBand(3).Fill(3)
+    ds.GetRasterBand(4).Fill(0)
+    ds = None
+    ds = gdal.Open(filename)
+    assert [ds.GetRasterBand(i + 1).Checksum() for i in range(4)] == [100, 200, 300, 0]
+    ds = None
+    gdal.GetDriverByName("GTiff").Delete(filename)
+
+
 def test_tiff_write_cleanup():
     gdaltest.tiff_drv = None

--- a/frmts/gtiff/libtiff/tiff.h
+++ b/frmts/gtiff/libtiff/tiff.h
@@ -646,7 +646,7 @@ typedef enum
 #define TIFFTAG_EP_EXPOSUREINDEX 37397            /* Exposure index */
 #define TIFFTAG_EP_STANDARDID 37398               /* TIFF/EP standard version, n.n.n.n */
 #define TIFFTAG_EP_SENSINGMETHOD 37399            /* Type of image sensor */
-/* 
+/*
  * TIFF/EP tags equivalent to EXIF tags
  *     Note that TIFF-EP and EXIF use nearly the same metadata tag set, but TIFF-EP stores the tags in IFD 0,
  *     while EXIF store the tags in a separate IFD. Either location is allowed by DNG, but the EXIF location is preferred.
@@ -761,6 +761,7 @@ typedef enum
 #define TIFFTAG_LERC_MAXZERROR 65567   /* LERC maximum error */
 #define TIFFTAG_WEBP_LEVEL 65568       /* WebP compression level */
 #define TIFFTAG_WEBP_LOSSLESS 65569    /* WebP lossless/lossy */
+#define TIFFTAG_WEBP_LOSSLESS_EXACT 65571  /* WebP lossless exact mode. Set-only mode. Default is 1. Can be set to 0 to increase compression rate, but R,G,B in areas where alpha = 0 will not be preserved */
 #define TIFFTAG_DEFLATE_SUBCODEC 65570 /* ZIP codec: to get/set the sub-codec to use. Will default to libdeflate when available */
 #define DEFLATE_SUBCODEC_ZLIB 0
 #define DEFLATE_SUBCODEC_LIBDEFLATE 1


### PR DESCRIPTION
…files to avoid altering R,G,B values in areas where alpha=0 (fixes #8038)

libtiff upstream change: https://gitlab.com/libtiff/libtiff/-/merge_requests/511
