### PR TITLE
autotest: make utilities, pyscript tests run independently

### DIFF
--- a/.github/workflows/cmake_builds.yml
+++ b/.github/workflows/cmake_builds.yml
@@ -430,8 +430,9 @@ jobs:
       shell: bash -l {0}
       run: |
         conda install --yes --quiet curl libiconv icu python=3.10 swig numpy pytest pytest-env filelock zlib lxml jsonschema
+        # FIXME: remove libnetcdf=4.9.2=nompi_h5902ca5_107 pinning as soon as https://github.com/conda-forge/libnetcdf-feedstock/issues/182 is resolved
         conda install --yes --quiet proj geos hdf4 hdf5 kealib \
-            libnetcdf openjpeg poppler libtiff libpng xerces-c expat libxml2 kealib json-c \
+            libnetcdf=4.9.2=nompi_h5902ca5_107 openjpeg poppler libtiff libpng xerces-c expat libxml2 kealib json-c \
             cfitsio freexl geotiff libjpeg-turbo libpq libspatialite libwebp-base pcre pcre2 postgresql \
             sqlite tiledb zstd cryptopp cgal doxygen librttopo libkml openssl xz \
             openjdk ant qhull armadillo blas blas-devel libblas libcblas liblapack liblapacke blosc libarchive \

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -1912,7 +1912,10 @@ def runexternal(
     encoding="latin1",
 ):
     # pylint: disable=unused-argument
-    command = shlex.split(cmd)
+    if sys.platform == "win32":
+        command = cmd
+    else:
+        command = shlex.split(cmd)
     if strin is None:
         p = subprocess.Popen(command, stdout=subprocess.PIPE)
     else:
@@ -1949,7 +1952,10 @@ def _read_in_thread(f, q):
 
 def runexternal_out_and_err(cmd, check_memleak=True, encoding="ascii"):
     # pylint: disable=unused-argument
-    command = shlex.split(cmd)
+    if sys.platform == "win32":
+        command = cmd
+    else:
+        command = shlex.split(cmd)
     p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
     if p.stdout is not None:

--- a/autotest/pyscripts/test_gdal_edit.py
+++ b/autotest/pyscripts/test_gdal_edit.py
@@ -173,7 +173,9 @@ def test_gdal_edit_py_3(script_path):
     shutil.copy(test_py_scripts.get_data_path("gcore") + "byte.tif", filename)
 
     try:
-        test_py_scripts.run_py_script(script_path, "gdal_edit", filename + " -a_srs ''")
+        test_py_scripts.run_py_script(
+            script_path, "gdal_edit", filename + " -a_srs None"
+        )
 
         ds = gdal.Open(filename)
         wkt = ds.GetProjectionRef()

--- a/autotest/utilities/test_gdal_contour.py
+++ b/autotest/utilities/test_gdal_contour.py
@@ -29,7 +29,6 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
-import os
 import struct
 
 import gdaltest
@@ -50,24 +49,9 @@ def gdal_contour_path():
     return test_cli_utilities.get_gdal_contour_path()
 
 
-###############################################################################
-# Test with -a and -i options
-
-
-def test_gdal_contour_1(gdal_contour_path):
-
-    try:
-        os.remove("tmp/contour.shp")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/contour.dbf")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/contour.shx")
-    except OSError:
-        pass
+@pytest.fixture()
+def testdata_tif(tmp_path):
+    tif_fname = str(tmp_path / "gdal_contour.tif")
 
     drv = gdal.GetDriverByName("GTiff")
     sr = osr.SpatialReference()
@@ -77,7 +61,7 @@ def test_gdal_contour_1(gdal_contour_path):
     size = 160
     precision = 1.0 / size
 
-    ds = drv.Create("tmp/gdal_contour.tif", size, size, 1)
+    ds = drv.Create(tif_fname, size, size, 1)
     ds.SetProjection(wkt)
     ds.SetGeoTransform([1, precision, 0, 50, 0, -precision])
 
@@ -119,12 +103,23 @@ def test_gdal_contour_1(gdal_contour_path):
 
     ds = None
 
+    yield tif_fname
+
+
+###############################################################################
+# Test with -a and -i options
+
+
+def test_gdal_contour_1(gdal_contour_path, testdata_tif, tmp_path):
+
+    contour_shp = str(tmp_path / "contour.shp")
+
     (_, err) = gdaltest.runexternal_out_and_err(
-        gdal_contour_path + " -a elev -i 10 tmp/gdal_contour.tif tmp/contour.shp"
+        gdal_contour_path + f" -a elev -i 10 {testdata_tif} {contour_shp}"
     )
     assert err is None or err == "", "got error/warning"
 
-    ds = ogr.Open("tmp/contour.shp")
+    ds = ogr.Open(contour_shp)
 
     expected_envelopes = [
         [1.25, 1.75, 49.25, 49.75],
@@ -134,9 +129,16 @@ def test_gdal_contour_1(gdal_contour_path):
 
     lyr = ds.ExecuteSQL("select * from contour order by elev asc")
 
-    assert lyr.GetSpatialRef().ExportToWkt() == wkt, "Did not get expected spatial ref"
+    raster_srs_wkt = gdal.Open(testdata_tif).GetSpatialRef().ExportToWkt()
+
+    assert (
+        lyr.GetSpatialRef().ExportToWkt() == raster_srs_wkt
+    ), "Did not get expected spatial ref"
 
     assert lyr.GetFeatureCount() == len(expected_envelopes)
+
+    size = 160
+    precision = 1.0 / size
 
     i = 0
     feat = lyr.GetNextFeature()
@@ -163,31 +165,20 @@ def test_gdal_contour_1(gdal_contour_path):
 # Test with -fl option and -3d option
 
 
-def test_gdal_contour_2(gdal_contour_path):
+def test_gdal_contour_2(gdal_contour_path, testdata_tif, tmp_path):
 
-    try:
-        os.remove("tmp/contour.shp")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/contour.dbf")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/contour.shx")
-    except OSError:
-        pass
+    contour_shp = str(tmp_path / "contour.shp")
 
     # put -3d just after -fl to test #2793
-    gdaltest.runexternal(
-        gdal_contour_path
-        + " -a elev -fl 10 20 25 -3d tmp/gdal_contour.tif tmp/contour.shp"
+    _, err = gdaltest.runexternal_out_and_err(
+        gdal_contour_path + f" -a elev -fl 10 20 25 -3d {testdata_tif} {contour_shp}"
     )
+    assert not err
 
     size = 160
     precision = 1.0 / size
 
-    ds = ogr.Open("tmp/contour.shp")
+    ds = ogr.Open(contour_shp)
 
     expected_envelopes = [
         [1.25, 1.75, 49.25, 49.75],
@@ -231,27 +222,16 @@ def test_gdal_contour_2(gdal_contour_path):
 # Test on a real DEM
 
 
-def test_gdal_contour_3(gdal_contour_path):
+def test_gdal_contour_3(gdal_contour_path, tmp_path):
 
-    try:
-        os.remove("tmp/contour.shp")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/contour.dbf")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/contour.shx")
-    except OSError:
-        pass
+    contour_shp = str(tmp_path / "contour.shp")
 
     # put -3d just after -fl to test #2793
     gdaltest.runexternal(
-        gdal_contour_path + " -a elev -i 50 ../gdrivers/data/n43.tif tmp/contour.shp"
+        gdal_contour_path + f" -a elev -i 50 ../gdrivers/data/n43.tif {contour_shp}"
     )
 
-    ds = ogr.Open("tmp/contour.shp")
+    ds = ogr.Open(contour_shp)
 
     lyr = ds.ExecuteSQL("select distinct elev from contour order by elev asc")
 
@@ -273,20 +253,10 @@ def test_gdal_contour_3(gdal_contour_path):
 # Test contour orientation
 
 
-def test_gdal_contour_4(gdal_contour_path):
+def test_gdal_contour_4(gdal_contour_path, tmp_path):
 
-    try:
-        os.remove("tmp/contour_orientation.shp")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/contour_orientation.dbf")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/contour_orientation.shx")
-    except OSError:
-        pass
+    contour_orientation1_shp = str(tmp_path / "contour_orientation1.shp")
+    contour_orientation_tif = str(tmp_path / "contour_orientation.tif")
 
     drv = gdal.GetDriverByName("GTiff")
     wkt = 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9108"]],AUTHORITY["EPSG","4326"]]'
@@ -294,7 +264,7 @@ def test_gdal_contour_4(gdal_contour_path):
     size = 160
     precision = 1.0 / size
 
-    ds = drv.Create("tmp/gdal_contour_orientation.tif", size, size, 1)
+    ds = drv.Create(contour_orientation_tif, size, size, 1)
     ds.SetProjection(wkt)
     ds.SetGeoTransform([1, precision, 0, 50, 0, -precision])
 
@@ -335,10 +305,10 @@ def test_gdal_contour_4(gdal_contour_path):
 
     gdaltest.runexternal(
         gdal_contour_path
-        + " -a elev -i 10 tmp/gdal_contour_orientation.tif tmp/contour_orientation1.shp"
+        + f" -a elev -i 10 {contour_orientation_tif} {contour_orientation1_shp}"
     )
 
-    ds = ogr.Open("tmp/contour_orientation1.shp")
+    ds = ogr.Open(contour_orientation1_shp)
 
     expected_contours = [
         "LINESTRING ("
@@ -385,16 +355,18 @@ def test_gdal_contour_4(gdal_contour_path):
 # Test contour orientation
 
 
-def test_gdal_contour_5(gdal_contour_path):
+def test_gdal_contour_5(gdal_contour_path, tmp_path):
 
     ds = None
 
+    contour_orientation2_shp = str(tmp_path / "contour_orientation2.shp")
+
     gdaltest.runexternal(
         gdal_contour_path
-        + " -a elev -i 10 data/contour_orientation.tif tmp/contour_orientation2.shp"
+        + f" -a elev -i 10 data/contour_orientation.tif {contour_orientation2_shp}"
     )
 
-    ds = ogr.Open("tmp/contour_orientation2.shp")
+    ds = ogr.Open(contour_orientation2_shp)
 
     expected_contours = [
         "LINESTRING (0.0 1.999999,"
@@ -423,23 +395,3 @@ def test_gdal_contour_5(gdal_contour_path):
             feat = lyr.GetNextFeature()
 
     ds.Destroy()
-
-
-###############################################################################
-# Cleanup
-
-
-def test_gdal_contour_cleanup():
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/contour.shp")
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-        "tmp/contour_orientation1.shp"
-    )
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-        "tmp/contour_orientation2.shp"
-    )
-    try:
-        os.remove("tmp/gdal_contour.tif")
-        os.remove("tmp/gdal_contour_orientation.tif")
-    except OSError:
-        pass

--- a/autotest/utilities/test_gdal_grid.py
+++ b/autotest/utilities/test_gdal_grid.py
@@ -29,7 +29,6 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
-import os
 import struct
 import sys
 
@@ -82,24 +81,6 @@ def n43_shp(tmp_path):
     yield n43_shp_fname
 
 
-# List of output TIFF files that will be created by tests and later deleted
-# in test_gdal_grid_cleanup()
-outfiles = []
-
-###############################################################################
-@pytest.fixture(autouse=True, scope="module")
-def auto_cleanup():
-
-    yield
-
-    if os.path.exists("tmp/n43.shp"):
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/n43.shp")
-    drv = gdal.GetDriverByName("GTiff")
-    for outfile in outfiles:
-        if os.path.exists(outfile):
-            drv.Delete(outfile)
-
-
 ###############################################################################
 #
 
@@ -135,30 +116,24 @@ def test_gdal_grid_1(gdal_grid_path, n43_shp, tmp_path):
 
 
 @pytest.mark.require_driver("CSV")
-def test_gdal_grid_2(gdal_grid_path):
+def test_gdal_grid_2(gdal_grid_path, tmp_path):
 
     # Open reference dataset
     ds_ref = gdal.Open("../gcore/data/byte.tif")
     checksum_ref = ds_ref.GetRasterBand(1).Checksum()
     ds_ref = None
 
-    #################
-    outfiles.append("tmp/grid_near.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
+    grid_near_tif = str(tmp_path / "grid_near.tif")
 
     # Create a GDAL dataset from the values of "grid.csv".
     # Grid nodes are located exactly in raster nodes.
     gdaltest.runexternal(
         gdal_grid_path
-        + " -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a nearest:radius1=0.0:radius2=0.0:angle=0.0:nodata=0.0 data/grid.vrt "
-        + outfiles[-1]
+        + f" -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a nearest:radius1=0.0:radius2=0.0:angle=0.0:nodata=0.0 data/grid.vrt {grid_near_tif}"
     )
 
     # We should get the same values as in "gcore/data/byte.tif"
-    ds = gdal.Open(outfiles[-1])
+    ds = gdal.Open(grid_near_tif)
     if ds.GetRasterBand(1).Checksum() != checksum_ref:
         print(
             "bad checksum : got %d, expected %d"
@@ -168,23 +143,26 @@ def test_gdal_grid_2(gdal_grid_path):
     assert ds.GetRasterBand(1).GetNoDataValue() == 0.0, "expected a nodata value"
     ds = None
 
-    #################
-    outfiles.append("tmp/grid_near_shift.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
+
+@pytest.mark.require_driver("CSV")
+def test_gdal_grid_2bis(gdal_grid_path, tmp_path):
+
+    # Open reference dataset
+    ds_ref = gdal.Open("../gcore/data/byte.tif")
+    checksum_ref = ds_ref.GetRasterBand(1).Checksum()
+    ds_ref = None
+
+    grid_near_shift_tif = str(tmp_path / "grid_near_shift.tif")
 
     # Now the same, but shift grid nodes a bit in both horizontal and vertical
     # directions.
     gdaltest.runexternal(
         gdal_grid_path
-        + " -txe 440721.0 441920.0 -tye 3751321.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a nearest:radius1=0.0:radius2=0.0:angle=0.0:nodata=0.0 data/grid.vrt "
-        + outfiles[-1]
+        + f" -txe 440721.0 441920.0 -tye 3751321.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a nearest:radius1=0.0:radius2=0.0:angle=0.0:nodata=0.0 data/grid.vrt {grid_near_shift_tif}"
     )
 
     # We should get the same values as in "gcore/data/byte.tif"
-    ds = gdal.Open(outfiles[-1])
+    ds = gdal.Open(grid_near_shift_tif)
     if ds.GetRasterBand(1).Checksum() != checksum_ref:
         print(
             "bad checksum : got %d, expected %d"
@@ -196,19 +174,14 @@ def test_gdal_grid_2(gdal_grid_path):
 
 @pytest.mark.require_driver("CSV")
 @pytest.mark.parametrize("use_quadtree", [True, False])
-def test_gdal_grid_3(gdal_grid_path, use_quadtree):
+def test_gdal_grid_3(gdal_grid_path, tmp_path, use_quadtree):
 
     # Open reference dataset
     ds_ref = gdal.Open("../gcore/data/byte.tif")
     checksum_ref = ds_ref.GetRasterBand(1).Checksum()
     ds_ref = None
 
-    #################
-    outfiles.append("tmp/grid_near_search3.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
+    grid_near_search3_tif = str(tmp_path / "grid_near_search3.tif")
 
     # Create a GDAL dataset from the values of "grid.csv".
     # Try the search ellipse larger than the raster cell.
@@ -217,12 +190,11 @@ def test_gdal_grid_3(gdal_grid_path, use_quadtree):
     ):
         gdaltest.runexternal(
             gdal_grid_path
-            + " -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a nearest:radius1=180.0:radius2=180.0:angle=0.0:nodata=0.0 data/grid.vrt "
-            + outfiles[-1]
+            + f" -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a nearest:radius1=180.0:radius2=180.0:angle=0.0:nodata=0.0 data/grid.vrt {grid_near_search3_tif}"
         )
 
         # We should get the same values as in "gcore/data/byte.tif"
-        ds = gdal.Open(outfiles[-1])
+        ds = gdal.Open(grid_near_search3_tif)
         if ds.GetRasterBand(1).Checksum() != checksum_ref:
             print(
                 "bad checksum : got %d, expected %d"
@@ -232,21 +204,16 @@ def test_gdal_grid_3(gdal_grid_path, use_quadtree):
         ds = None
 
         #################
-        outfiles.append("tmp/grid_near_search1.tif")
-        try:
-            os.remove(outfiles[-1])
-        except OSError:
-            pass
+        grid_near_search1_tif = str(tmp_path / "grid_near_search1.tif")
 
         # Search ellipse smaller than the raster cell.
         gdaltest.runexternal(
             gdal_grid_path
-            + " -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a nearest:radius1=20.0:radius2=20.0:angle=0.0:nodata=0.0 data/grid.vrt "
-            + outfiles[-1]
+            + f" -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a nearest:radius1=20.0:radius2=20.0:angle=0.0:nodata=0.0 data/grid.vrt {grid_near_search1_tif}"
         )
 
         # We should get the same values as in "gcore/data/byte.tif"
-        ds = gdal.Open(outfiles[-1])
+        ds = gdal.Open(grid_near_search1_tif)
         if ds.GetRasterBand(1).Checksum() != checksum_ref:
             print(
                 "bad checksum : got %d, expected %d"
@@ -256,21 +223,16 @@ def test_gdal_grid_3(gdal_grid_path, use_quadtree):
         ds = None
 
         #################
-        outfiles.append("tmp/grid_near_shift_search3.tif")
-        try:
-            os.remove(outfiles[-1])
-        except OSError:
-            pass
+        grid_near_shift_search3_tif = str(tmp_path / "grid_near_shift_search3.tif")
 
         # Large search ellipse and the grid shift.
         gdaltest.runexternal(
             gdal_grid_path
-            + " -txe 440721.0 441920.0 -tye 3751321.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a nearest:radius1=180.0:radius2=180.0:angle=0.0:nodata=0.0 data/grid.vrt "
-            + outfiles[-1]
+            + f" -txe 440721.0 441920.0 -tye 3751321.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a nearest:radius1=180.0:radius2=180.0:angle=0.0:nodata=0.0 data/grid.vrt {grid_near_shift_search3_tif}"
         )
 
         # We should get the same values as in "gcore/data/byte.tif"
-        ds = gdal.Open(outfiles[-1])
+        ds = gdal.Open(grid_near_shift_search3_tif)
         if ds.GetRasterBand(1).Checksum() != checksum_ref:
             print(
                 "bad checksum : got %d, expected %d"
@@ -280,21 +242,16 @@ def test_gdal_grid_3(gdal_grid_path, use_quadtree):
         ds = None
 
         #################
-        outfiles.append("tmp/grid_near_shift_search1.tif")
-        try:
-            os.remove(outfiles[-1])
-        except OSError:
-            pass
+        grid_near_shift_search1_tif = str(tmp_path / "grid_near_shift_search1.tif")
 
         # Small search ellipse and the grid shift.
         gdaltest.runexternal(
             gdal_grid_path
-            + " -txe 440721.0 441920.0 -tye 3751321.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a nearest:radius1=20.0:radius2=20.0:angle=0.0:nodata=0.0 data/grid.vrt "
-            + outfiles[-1]
+            + f" -txe 440721.0 441920.0 -tye 3751321.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a nearest:radius1=20.0:radius2=20.0:angle=0.0:nodata=0.0 data/grid.vrt {grid_near_shift_search1_tif}"
         )
 
         # We should get the same values as in "gcore/data/byte.tif"
-        ds = gdal.Open(outfiles[-1])
+        ds = gdal.Open(grid_near_shift_search1_tif)
         if ds.GetRasterBand(1).Checksum() != checksum_ref:
             print(
                 "bad checksum : got %d, expected %d"
@@ -309,170 +266,55 @@ def test_gdal_grid_3(gdal_grid_path, use_quadtree):
 
 
 @pytest.mark.require_driver("CSV")
-def test_gdal_grid_4(gdal_grid_path):
+@pytest.mark.parametrize(
+    "algorithm,threads",
+    [("Generic", None), ("SSE", None), ("AVX", None), ("AVX", 1), ("AVX", 2)],
+)
+def test_gdal_grid_4(gdal_grid_path, algorithm, threads, tmp_path):
 
-    #################
-    # Test generic implementation (no AVX, no SSE)
-    outfiles.append("tmp/grid_invdist_generic.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
+    alg_flags = {
+        "Generic": "--config GDAL_USE_AVX NO --config GDAL_USE_SSE NO",
+        "SSE": "--config GDAL_USE_AVX NO",
+        "AVX": "",
+    }
+
+    output_tif = str(tmp_path / "output.tif")
+
+    flags = alg_flags[algorithm]
+
+    if threads:
+        flags += " --config GDAL_NUM_THREADS {threads}"
 
     # Create a GDAL dataset from the values of "grid.csv".
-    print("Step 1: Disabling AVX/SSE optimized versions...")
     (_, err) = gdaltest.runexternal_out_and_err(
         gdal_grid_path
-        + " --debug on --config GDAL_USE_AVX NO --config GDAL_USE_SSE NO -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a invdist:power=2.0:smoothing=0.0:radius1=0.0:radius2=0.0:angle=0.0:max_points=0:min_points=0:nodata=0.0 data/grid.vrt "
-        + outfiles[-1]
+        + f" --debug on {flags} -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a invdist:power=2.0:smoothing=0.0:radius1=0.0:radius2=0.0:angle=0.0:max_points=0:min_points=0:nodata=0.0 data/grid.vrt {output_tif}"
     )
+
     pos = err.find(" threads")
     if pos >= 0:
         pos_blank = err[0 : pos - 1].rfind(" ")
         if pos_blank >= 0:
             print("Step 1: %s threads used" % err[pos_blank + 1 : pos])
 
-    # We should get the same values as in "ref_data/gdal_invdist.tif"
-    ds = gdal.Open(outfiles[-1])
-    ds_ref = gdal.Open("ref_data/grid_invdist.tif")
-    maxdiff = gdaltest.compare_ds(ds, ds_ref, verbose=0)
-    if maxdiff > 1:
-        gdaltest.compare_ds(ds, ds_ref, verbose=1)
-        pytest.fail("Image too different from the reference")
-    ds_ref = None
-    ds = None
+    if algorithm == "SSE" and "SSE" not in err:
+        pytest.skip(f"{algorithm} not used")
 
-    #################
-    # Potentially test optimized SSE implementation
 
-    outfiles.append("tmp/grid_invdist_sse.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
+@pytest.mark.require_driver("CSV")
+def test_gdal_grid_4bis(gdal_grid_path, tmp_path):
 
-    # Create a GDAL dataset from the values of "grid.csv".
-    print("Step 2: Trying SSE optimized version...")
-    (_, err) = gdaltest.runexternal_out_and_err(
-        gdal_grid_path
-        + " --debug on --config GDAL_USE_AVX NO -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a invdist:power=2.0:smoothing=0.0:radius1=0.0:radius2=0.0:angle=0.0:max_points=0:min_points=0:nodata=0.0 data/grid.vrt "
-        + outfiles[-1]
-    )
-    if "SSE" in err:
-        print("...SSE optimized version used")
-    else:
-        print("...SSE optimized version NOT used")
-
-    # We should get the same values as in "ref_data/gdal_invdist.tif"
-    ds = gdal.Open(outfiles[-1])
-    ds_ref = gdal.Open("ref_data/grid_invdist.tif")
-    maxdiff = gdaltest.compare_ds(ds, ds_ref, verbose=0)
-    if maxdiff > 1:
-        gdaltest.compare_ds(ds, ds_ref, verbose=1)
-        pytest.fail("Image too different from the reference")
-    ds_ref = None
-    ds = None
-
-    #################
-    # Potentially test optimized AVX implementation
-
-    outfiles.append("tmp/grid_invdist_avx.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
-
-    # Create a GDAL dataset from the values of "grid.csv".
-    print("Step 3: Trying AVX optimized version...")
-    (_, err) = gdaltest.runexternal_out_and_err(
-        gdal_grid_path
-        + " --debug on -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a invdist:power=2.0:smoothing=0.0:radius1=0.0:radius2=0.0:angle=0.0:max_points=0:min_points=0:nodata=0.0 data/grid.vrt "
-        + outfiles[-1]
-    )
-    if "AVX" in err:
-        print("...AVX optimized version used")
-    else:
-        print("...AVX optimized version NOT used")
-
-    # We should get the same values as in "ref_data/gdal_invdist.tif"
-    ds = gdal.Open(outfiles[-1])
-    ds_ref = gdal.Open("ref_data/grid_invdist.tif")
-    maxdiff = gdaltest.compare_ds(ds, ds_ref, verbose=0)
-    if maxdiff > 1:
-        gdaltest.compare_ds(ds, ds_ref, verbose=1)
-        pytest.fail("Image too different from the reference")
-    ds_ref = None
-    ds = None
-
-    #################
-    # Test GDAL_NUM_THREADS config option to 1
-
-    outfiles.append("tmp/grid_invdist_1thread.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
-
-    # Create a GDAL dataset from the values of "grid.csv".
-    gdaltest.runexternal(
-        gdal_grid_path
-        + " --config GDAL_NUM_THREADS 1 -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a invdist:power=2.0:smoothing=0.0:radius1=0.0:radius2=0.0:angle=0.0:max_points=0:min_points=0:nodata=0.0 data/grid.vrt "
-        + outfiles[-1]
-    )
-
-    # We should get the same values as in "ref_data/gdal_invdist.tif"
-    ds = gdal.Open(outfiles[-1])
-    ds_ref = gdal.Open("ref_data/grid_invdist.tif")
-    maxdiff = gdaltest.compare_ds(ds, ds_ref, verbose=0)
-    if maxdiff > 1:
-        gdaltest.compare_ds(ds, ds_ref, verbose=1)
-        pytest.fail("Image too different from the reference")
-    ds_ref = None
-    ds = None
-
-    #################
-    # Test GDAL_NUM_THREADS config option to 2
-
-    outfiles.append("tmp/grid_invdist_2threads.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
-
-    # Create a GDAL dataset from the values of "grid.csv".
-    gdaltest.runexternal(
-        gdal_grid_path
-        + " --config GDAL_NUM_THREADS 2 -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a invdist:power=2.0:smoothing=0.0:radius1=0.0:radius2=0.0:angle=0.0:max_points=0:min_points=0:nodata=0.0 data/grid.vrt "
-        + outfiles[-1]
-    )
-
-    # We should get the same values as in "ref_data/gdal_invdist.tif"
-    ds = gdal.Open(outfiles[-1])
-    ds_ref = gdal.Open("ref_data/grid_invdist.tif")
-    maxdiff = gdaltest.compare_ds(ds, ds_ref, verbose=0)
-    if maxdiff > 1:
-        gdaltest.compare_ds(ds, ds_ref, verbose=1)
-        pytest.fail("Image too different from the reference")
-    ds_ref = None
-    ds = None
-
-    #################
-    outfiles.append("tmp/grid_invdist_90_90_8p.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
+    output_tif = str(tmp_path / "grid_invdist_90_90_8p.tif")
 
     # Create a GDAL dataset from the values of "grid.csv".
     # Circular window, shifted, test min points and NODATA setting.
     gdaltest.runexternal(
         gdal_grid_path
-        + " -txe 440721.0 441920.0 -tye 3751321.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a invdist:power=2.0:radius1=90.0:radius2=90.0:angle=0.0:max_points=0:min_points=8:nodata=0.0 data/grid.vrt "
-        + outfiles[-1]
+        + f" -txe 440721.0 441920.0 -tye 3751321.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a invdist:power=2.0:radius1=90.0:radius2=90.0:angle=0.0:max_points=0:min_points=8:nodata=0.0 data/grid.vrt {output_tif}"
     )
 
     # We should get the same values as in "ref_data/grid_invdist_90_90_8p.tif"
-    ds = gdal.Open(outfiles[-1])
+    ds = gdal.Open(output_tif)
     ds_ref = gdal.Open("ref_data/grid_invdist_90_90_8p.tif")
     maxdiff = gdaltest.compare_ds(ds, ds_ref, verbose=0)
     if maxdiff > 1:
@@ -487,26 +329,20 @@ def test_gdal_grid_4(gdal_grid_path):
 
 
 @pytest.mark.require_driver("CSV")
-def test_gdal_grid_5(gdal_grid_path):
+def test_gdal_grid_5(gdal_grid_path, tmp_path):
 
-    #################
-    outfiles.append("tmp/grid_average.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
+    output_tif = str(tmp_path / "grid_average.tif")
 
     # Create a GDAL dataset from the values of "grid.csv".
     # We are using all the points from input dataset to average, so
     # the result is a raster filled with the same value in each node.
     gdaltest.runexternal(
         gdal_grid_path
-        + " -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a average:radius1=0.0:radius2=0.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt "
-        + outfiles[-1]
+        + f" -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a average:radius1=0.0:radius2=0.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt {output_tif}"
     )
 
     # We should get the same values as in "ref_data/grid_average.tif"
-    ds = gdal.Open(outfiles[-1])
+    ds = gdal.Open(output_tif)
     ds_ref = gdal.Open("ref_data/grid_average.tif")
     maxdiff = gdaltest.compare_ds(ds, ds_ref, verbose=0)
     ds_ref = None
@@ -515,23 +351,21 @@ def test_gdal_grid_5(gdal_grid_path):
         pytest.fail("Image too different from the reference")
     ds = None
 
-    #################
-    outfiles.append("tmp/grid_average_300_100_40.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
+
+@pytest.mark.require_driver("CSV")
+def test_gdal_grid_5bis(gdal_grid_path, tmp_path):
+
+    output_tif = str(tmp_path / "grid_average_300_100_40.tif")
 
     # Create a GDAL dataset from the values of "grid.csv".
     # Elliptical window, rotated.
     gdaltest.runexternal(
         gdal_grid_path
-        + " -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a average:radius1=300.0:radius2=100.0:angle=40.0:min_points=0:nodata=0.0 data/grid.vrt "
-        + outfiles[-1]
+        + f" -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a average:radius1=300.0:radius2=100.0:angle=40.0:min_points=0:nodata=0.0 data/grid.vrt {output_tif}"
     )
 
     # We should get the same values as in "ref_data/grid_average_300_100_40.tif"
-    ds = gdal.Open(outfiles[-1])
+    ds = gdal.Open(output_tif)
     ds_ref = gdal.Open("ref_data/grid_average_300_100_40.tif")
     maxdiff = gdaltest.compare_ds(ds, ds_ref, verbose=0)
     ds_ref = None
@@ -543,14 +377,9 @@ def test_gdal_grid_5(gdal_grid_path):
 
 @pytest.mark.require_driver("CSV")
 @pytest.mark.parametrize("use_quadtree", [True, False])
-def test_gdal_grid_6(gdal_grid_path, use_quadtree):
+def test_gdal_grid_6(gdal_grid_path, tmp_path, use_quadtree):
 
-    #################
-    outfiles.append("tmp/grid_average_190_190.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
+    output_tif = str(tmp_path / "grid_average_190_190.tif")
 
     with gdaltest.config_option(
         "GDAL_GRID_POINT_COUNT_THRESHOLD", "0" if use_quadtree else "1000000000"
@@ -559,12 +388,11 @@ def test_gdal_grid_6(gdal_grid_path, use_quadtree):
         # This time using a circular window.
         gdaltest.runexternal(
             gdal_grid_path
-            + " -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a average:radius1=190.0:radius2=190.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt "
-            + outfiles[-1]
+            + f" -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a average:radius1=190.0:radius2=190.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt {output_tif}"
         )
 
         # We should get the same values as in "ref_data/grid_average_190_190.tif"
-        ds = gdal.Open(outfiles[-1])
+        ds = gdal.Open(output_tif)
         ds_ref = gdal.Open("ref_data/grid_average_190_190.tif")
         maxdiff = gdaltest.compare_ds(ds, ds_ref, verbose=0)
         ds_ref = None
@@ -573,23 +401,26 @@ def test_gdal_grid_6(gdal_grid_path, use_quadtree):
             pytest.fail("Image too different from the reference")
         ds = None
 
-        #################
-        outfiles.append("tmp/grid_average_90_90_8p.tif")
-        try:
-            os.remove(outfiles[-1])
-        except OSError:
-            pass
+
+@pytest.mark.require_driver("CSV")
+@pytest.mark.parametrize("use_quadtree", [True, False])
+def test_gdal_grid_6bis(gdal_grid_path, tmp_path, use_quadtree):
+
+    output_tif = str(tmp_path / "grid_average_90_90_8p.tif")
+
+    with gdaltest.config_option(
+        "GDAL_GRID_POINT_COUNT_THRESHOLD", "0" if use_quadtree else "1000000000"
+    ):
 
         # Create a GDAL dataset from the values of "grid.csv".
         # Circular window, shifted, test min points and NODATA setting.
         gdaltest.runexternal(
             gdal_grid_path
-            + " -txe 440721.0 441920.0 -tye 3751321.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a average:radius1=90.0:radius2=90.0:angle=0.0:min_points=8:nodata=0.0 data/grid.vrt "
-            + outfiles[-1]
+            + f" -txe 440721.0 441920.0 -tye 3751321.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a average:radius1=90.0:radius2=90.0:angle=0.0:min_points=8:nodata=0.0 data/grid.vrt {output_tif}"
         )
 
         # We should get the same values as in "ref_data/grid_average_90_90_8p.tif"
-        ds = gdal.Open(outfiles[-1])
+        ds = gdal.Open(output_tif)
         ds_ref = gdal.Open("ref_data/grid_average_90_90_8p.tif")
         maxdiff = gdaltest.compare_ds(ds, ds_ref, verbose=0)
         ds_ref = None
@@ -604,25 +435,19 @@ def test_gdal_grid_6(gdal_grid_path, use_quadtree):
 
 
 @pytest.mark.require_driver("CSV")
-def test_gdal_grid_7(gdal_grid_path):
+def test_gdal_grid_7(gdal_grid_path, tmp_path):
 
-    #################
-    outfiles.append("tmp/grid_minimum.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
+    output_tif = str(tmp_path / "grid_minimum.tif")
 
     # Create a GDAL dataset from the values of "grid.csv".
     # Search the whole dataset for minimum.
     gdaltest.runexternal(
         gdal_grid_path
-        + " -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a minimum:radius1=0.0:radius2=0.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt "
-        + outfiles[-1]
+        + f" -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a minimum:radius1=0.0:radius2=0.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt {output_tif}"
     )
 
     # We should get the same values as in "ref_data/grid_minimum.tif"
-    ds = gdal.Open(outfiles[-1])
+    ds = gdal.Open(output_tif)
     ds_ref = gdal.Open("ref_data/grid_minimum.tif")
     assert (
         ds.GetRasterBand(1).Checksum() == ds_ref.GetRasterBand(1).Checksum()
@@ -633,23 +458,21 @@ def test_gdal_grid_7(gdal_grid_path):
     ds_ref = None
     ds = None
 
-    #################
-    outfiles.append("tmp/grid_minimum_400_100_120.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
+
+@pytest.mark.require_driver("CSV")
+def test_gdal_grid_7bis(gdal_grid_path, tmp_path):
+
+    output_tif = str(tmp_path / "grid_minimum_400_100_120.tif")
 
     # Create a GDAL dataset from the values of "grid.csv".
     # Elliptical window, rotated.
     gdaltest.runexternal(
         gdal_grid_path
-        + " -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a minimum:radius1=400.0:radius2=100.0:angle=120.0:min_points=0:nodata=0.0 data/grid.vrt "
-        + outfiles[-1]
+        + f" -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a minimum:radius1=400.0:radius2=100.0:angle=120.0:min_points=0:nodata=0.0 data/grid.vrt {output_tif}"
     )
 
     # We should get the same values as in "ref_data/grid_minimum_400_100_120.tif"
-    ds = gdal.Open(outfiles[-1])
+    ds = gdal.Open(output_tif)
     ds_ref = gdal.Open("ref_data/grid_minimum_400_100_120.tif")
     assert (
         ds.GetRasterBand(1).Checksum() == ds_ref.GetRasterBand(1).Checksum()
@@ -663,14 +486,9 @@ def test_gdal_grid_7(gdal_grid_path):
 
 @pytest.mark.require_driver("CSV")
 @pytest.mark.parametrize("use_quadtree", [True, False])
-def test_gdal_grid_8(gdal_grid_path, use_quadtree):
+def test_gdal_grid_8(gdal_grid_path, tmp_path, use_quadtree):
 
-    #################
-    outfiles.append("tmp/grid_minimum_180_180.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
+    output_tif = str(tmp_path / "grid_minimum_180_180.tif")
 
     with gdaltest.config_option(
         "GDAL_GRID_POINT_COUNT_THRESHOLD", "0" if use_quadtree else "1000000000"
@@ -679,12 +497,11 @@ def test_gdal_grid_8(gdal_grid_path, use_quadtree):
         # Search ellipse larger than the raster cell.
         gdaltest.runexternal(
             gdal_grid_path
-            + " -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a minimum:radius1=180.0:radius2=180.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt "
-            + outfiles[-1]
+            + f" -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a minimum:radius1=180.0:radius2=180.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt {output_tif}"
         )
 
         # We should get the same values as in "ref_data/grid_minimum_180_180.tif"
-        ds = gdal.Open(outfiles[-1])
+        ds = gdal.Open(output_tif)
         ds_ref = gdal.Open("ref_data/grid_minimum_180_180.tif")
         assert (
             ds.GetRasterBand(1).Checksum() == ds_ref.GetRasterBand(1).Checksum()
@@ -695,23 +512,26 @@ def test_gdal_grid_8(gdal_grid_path, use_quadtree):
         ds_ref = None
         ds = None
 
-        #################
-        outfiles.append("tmp/grid_minimum_20_20.tif")
-        try:
-            os.remove(outfiles[-1])
-        except OSError:
-            pass
+
+@pytest.mark.require_driver("CSV")
+@pytest.mark.parametrize("use_quadtree", [True, False])
+def test_gdal_grid_8bis(gdal_grid_path, tmp_path, use_quadtree):
+
+    output_tif = str(tmp_path / "grid_minimum_20_20.tif")
+
+    with gdaltest.config_option(
+        "GDAL_GRID_POINT_COUNT_THRESHOLD", "0" if use_quadtree else "1000000000"
+    ):
 
         # Create a GDAL dataset from the values of "grid.csv".
         # Search ellipse smaller than the raster cell.
         gdaltest.runexternal(
             gdal_grid_path
-            + " -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a minimum:radius1=20.0:radius2=20.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt "
-            + outfiles[-1]
+            + f" -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a minimum:radius1=20.0:radius2=20.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt {output_tif}"
         )
 
         # We should get the same values as in "ref_data/grid_minimum_20_20.tif"
-        ds = gdal.Open(outfiles[-1])
+        ds = gdal.Open(output_tif)
         ds_ref = gdal.Open("ref_data/grid_minimum_20_20.tif")
         assert (
             ds.GetRasterBand(1).Checksum() == ds_ref.GetRasterBand(1).Checksum()
@@ -728,25 +548,19 @@ def test_gdal_grid_8(gdal_grid_path, use_quadtree):
 
 
 @pytest.mark.require_driver("CSV")
-def test_gdal_grid_9(gdal_grid_path):
+def test_gdal_grid_9(gdal_grid_path, tmp_path):
 
-    #################
-    outfiles.append("tmp/grid_maximum.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
+    output_tif = str(tmp_path / "grid_maximum.tif")
 
     # Create a GDAL dataset from the values of "grid.csv".
     # Search the whole dataset for maximum.
     gdaltest.runexternal(
         gdal_grid_path
-        + " -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a maximum:radius1=0.0:radius2=0.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt "
-        + outfiles[-1]
+        + f" -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a maximum:radius1=0.0:radius2=0.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt {output_tif}"
     )
 
     # We should get the same values as in "ref_data/grid_maximum.tif"
-    ds = gdal.Open(outfiles[-1])
+    ds = gdal.Open(output_tif)
     ds_ref = gdal.Open("ref_data/grid_maximum.tif")
     assert (
         ds.GetRasterBand(1).Checksum() == ds_ref.GetRasterBand(1).Checksum()
@@ -757,23 +571,21 @@ def test_gdal_grid_9(gdal_grid_path):
     ds_ref = None
     ds = None
 
-    #################
-    outfiles.append("tmp/grid_maximum_100_100.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
+
+@pytest.mark.require_driver("CSV")
+def test_gdal_grid_9bis(gdal_grid_path, tmp_path):
+
+    output_tif = str(tmp_path / "grid_maximum_100_100.tif")
 
     # Create a GDAL dataset from the values of "grid.csv".
     # Circular window.
     gdaltest.runexternal(
         gdal_grid_path
-        + " -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a maximum:radius1=100.0:radius2=100.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt "
-        + outfiles[-1]
+        + f" -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a maximum:radius1=100.0:radius2=100.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt {output_tif}"
     )
 
     # We should get the same values as in "ref_data/grid_maximum_100_100.tif"
-    ds = gdal.Open(outfiles[-1])
+    ds = gdal.Open(output_tif)
     ds_ref = gdal.Open("ref_data/grid_maximum_100_100.tif")
     assert (
         ds.GetRasterBand(1).Checksum() == ds_ref.GetRasterBand(1).Checksum()
@@ -787,14 +599,9 @@ def test_gdal_grid_9(gdal_grid_path):
 
 @pytest.mark.require_driver("CSV")
 @pytest.mark.parametrize("use_quadtree", [True, False])
-def test_gdal_grid_10(gdal_grid_path, use_quadtree):
+def test_gdal_grid_10bis(gdal_grid_path, tmp_path, use_quadtree):
 
-    #################
-    outfiles.append("tmp/grid_maximum_180_180.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
+    output_tif = str(tmp_path / "grid_maximum_180_180.tif")
 
     with gdaltest.config_option(
         "GDAL_GRID_POINT_COUNT_THRESHOLD", "0" if use_quadtree else "1000000000"
@@ -803,12 +610,11 @@ def test_gdal_grid_10(gdal_grid_path, use_quadtree):
         # Search ellipse larger than the raster cell.
         gdaltest.runexternal(
             gdal_grid_path
-            + " -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a maximum:radius1=180.0:radius2=180.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt "
-            + outfiles[-1]
+            + f" -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a maximum:radius1=180.0:radius2=180.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt {output_tif}"
         )
 
         # We should get the same values as in "ref_data/grid_maximum_180_180.tif"
-        ds = gdal.Open(outfiles[-1])
+        ds = gdal.Open(output_tif)
         ds_ref = gdal.Open("ref_data/grid_maximum_180_180.tif")
         assert (
             ds.GetRasterBand(1).Checksum() == ds_ref.GetRasterBand(1).Checksum()
@@ -819,23 +625,26 @@ def test_gdal_grid_10(gdal_grid_path, use_quadtree):
         ds_ref = None
         ds = None
 
-        #################
-        outfiles.append("tmp/grid_maximum_20_20.tif")
-        try:
-            os.remove(outfiles[-1])
-        except OSError:
-            pass
+
+@pytest.mark.require_driver("CSV")
+@pytest.mark.parametrize("use_quadtree", [True, False])
+def test_gdal_grid_10(gdal_grid_path, tmp_path, use_quadtree):
+
+    output_tif = str(tmp_path / "grid_maximum_20_20.tif")
+
+    with gdaltest.config_option(
+        "GDAL_GRID_POINT_COUNT_THRESHOLD", "0" if use_quadtree else "1000000000"
+    ):
 
         # Create a GDAL dataset from the values of "grid.csv".
         # Search ellipse smaller than the raster cell.
         gdaltest.runexternal(
             gdal_grid_path
-            + " -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a maximum:radius1=20.0:radius2=20.0:angle=120.0:min_points=0:nodata=0.0 data/grid.vrt "
-            + outfiles[-1]
+            + f" -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a maximum:radius1=20.0:radius2=20.0:angle=120.0:min_points=0:nodata=0.0 data/grid.vrt {output_tif}"
         )
 
         # We should get the same values as in "ref_data/grid_maximum_20_20.tif"
-        ds = gdal.Open(outfiles[-1])
+        ds = gdal.Open(output_tif)
         ds_ref = gdal.Open("ref_data/grid_maximum_20_20.tif")
         assert (
             ds.GetRasterBand(1).Checksum() == ds_ref.GetRasterBand(1).Checksum()
@@ -852,25 +661,19 @@ def test_gdal_grid_10(gdal_grid_path, use_quadtree):
 
 
 @pytest.mark.require_driver("CSV")
-def test_gdal_grid_11(gdal_grid_path):
+def test_gdal_grid_11(gdal_grid_path, tmp_path):
 
-    #################
-    outfiles.append("tmp/grid_range.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
+    output_tif = str(tmp_path / "grid_range.tif")
 
     # Create a GDAL dataset from the values of "grid.csv".
     # Search the whole dataset.
     gdaltest.runexternal(
         gdal_grid_path
-        + " -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a range:radius1=0.0:radius2=0.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt "
-        + outfiles[-1]
+        + f" -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a range:radius1=0.0:radius2=0.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt {output_tif}"
     )
 
     # We should get the same values as in "ref_data/grid_range.tif"
-    ds = gdal.Open(outfiles[-1])
+    ds = gdal.Open(output_tif)
     ds_ref = gdal.Open("ref_data/grid_range.tif")
     assert (
         ds.GetRasterBand(1).Checksum() == ds_ref.GetRasterBand(1).Checksum()
@@ -884,14 +687,9 @@ def test_gdal_grid_11(gdal_grid_path):
 
 @pytest.mark.require_driver("CSV")
 @pytest.mark.parametrize("use_quadtree", [True, False])
-def test_gdal_grid_12(gdal_grid_path, use_quadtree):
+def test_gdal_grid_12(gdal_grid_path, tmp_path, use_quadtree):
 
-    #################
-    outfiles.append("tmp/grid_range_90_90_8p.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
+    output_tif = str(tmp_path / "grid_range_90_90_8p.tif")
 
     with gdaltest.config_option(
         "GDAL_GRID_POINT_COUNT_THRESHOLD", "0" if use_quadtree else "1000000000"
@@ -901,12 +699,11 @@ def test_gdal_grid_12(gdal_grid_path, use_quadtree):
         # points found.
         gdaltest.runexternal(
             gdal_grid_path
-            + " -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a range:radius1=90.0:radius2=90.0:angle=0.0:min_points=8:nodata=0.0 data/grid.vrt "
-            + outfiles[-1]
+            + f" -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a range:radius1=90.0:radius2=90.0:angle=0.0:min_points=8:nodata=0.0 data/grid.vrt {output_tif}"
         )
 
         # We should get the same values as in "ref_data/grid_range_90_90_8p.tif"
-        ds = gdal.Open(outfiles[-1])
+        ds = gdal.Open(output_tif)
         ds_ref = gdal.Open("ref_data/grid_range_90_90_8p.tif")
         assert (
             ds.GetRasterBand(1).Checksum() == ds_ref.GetRasterBand(1).Checksum()
@@ -924,14 +721,9 @@ def test_gdal_grid_12(gdal_grid_path, use_quadtree):
 
 @pytest.mark.require_driver("CSV")
 @pytest.mark.parametrize("use_quadtree", [True, False])
-def test_gdal_grid_13(gdal_grid_path, use_quadtree):
+def test_gdal_grid_13bis(gdal_grid_path, tmp_path, use_quadtree):
 
-    #################
-    outfiles.append("tmp/grid_count_70_70.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
+    output_tif = str(tmp_path / "grid_count_70_70.tif")
 
     with gdaltest.config_option(
         "GDAL_GRID_POINT_COUNT_THRESHOLD", "0" if use_quadtree else "1000000000"
@@ -939,12 +731,11 @@ def test_gdal_grid_13(gdal_grid_path, use_quadtree):
         # Create a GDAL dataset from the values of "grid.csv".
         gdaltest.runexternal(
             gdal_grid_path
-            + " -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a count:radius1=70.0:radius2=70.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt "
-            + outfiles[-1]
+            + f" -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a count:radius1=70.0:radius2=70.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt {output_tif}"
         )
 
         # We should get the same values as in "ref_data/grid_count_70_70.tif"
-        ds = gdal.Open(outfiles[-1])
+        ds = gdal.Open(output_tif)
         ds_ref = gdal.Open("ref_data/grid_count_70_70.tif")
         assert (
             ds.GetRasterBand(1).Checksum() == ds_ref.GetRasterBand(1).Checksum()
@@ -955,22 +746,24 @@ def test_gdal_grid_13(gdal_grid_path, use_quadtree):
         ds_ref = None
         ds = None
 
-        #################
-        outfiles.append("tmp/grid_count_300_300.tif")
-        try:
-            os.remove(outfiles[-1])
-        except OSError:
-            pass
 
+@pytest.mark.require_driver("CSV")
+@pytest.mark.parametrize("use_quadtree", [True, False])
+def test_gdal_grid_13(gdal_grid_path, tmp_path, use_quadtree):
+
+    output_tif = str(tmp_path / "grid_count_300_300.tif")
+
+    with gdaltest.config_option(
+        "GDAL_GRID_POINT_COUNT_THRESHOLD", "0" if use_quadtree else "1000000000"
+    ):
         # Create a GDAL dataset from the values of "grid.csv".
         gdaltest.runexternal(
             gdal_grid_path
-            + " -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a count:radius1=300.0:radius2=300.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt "
-            + outfiles[-1]
+            + f" -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a count:radius1=300.0:radius2=300.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt {output_tif}"
         )
 
         # We should get the same values as in "ref_data/grid_count_300_300.tif"
-        ds = gdal.Open(outfiles[-1])
+        ds = gdal.Open(output_tif)
         ds_ref = gdal.Open("ref_data/grid_count_300_300.tif")
         assert (
             ds.GetRasterBand(1).Checksum() == ds_ref.GetRasterBand(1).Checksum()
@@ -987,26 +780,20 @@ def test_gdal_grid_13(gdal_grid_path, use_quadtree):
 
 
 @pytest.mark.require_driver("CSV")
-def test_gdal_grid_14(gdal_grid_path):
+def test_gdal_grid_14(gdal_grid_path, tmp_path):
 
-    #################
-    outfiles.append("tmp/grid_avdist.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
+    output_tif = str(tmp_path / "grid_avdist.tif")
 
     # Create a GDAL dataset from the values of "grid.csv".
     # We are using all the points from input dataset to average, so
     # the result is a raster filled with the same value in each node.
     gdaltest.runexternal(
         gdal_grid_path
-        + " -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a average_distance:radius1=0.0:radius2=0.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt "
-        + outfiles[-1]
+        + f" -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a average_distance:radius1=0.0:radius2=0.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt {output_tif}"
     )
 
     # We should get the same values as in "ref_data/grid_avdist.tif"
-    ds = gdal.Open(outfiles[-1])
+    ds = gdal.Open(output_tif)
     ds_ref = gdal.Open("ref_data/grid_avdist.tif")
     maxdiff = gdaltest.compare_ds(ds, ds_ref, verbose=0)
     if maxdiff > 1:
@@ -1018,14 +805,9 @@ def test_gdal_grid_14(gdal_grid_path):
 
 @pytest.mark.require_driver("CSV")
 @pytest.mark.parametrize("use_quadtree", [True, False])
-def test_gdal_grid_15(gdal_grid_path, use_quadtree):
+def test_gdal_grid_15(gdal_grid_path, tmp_path, use_quadtree):
 
-    #################
-    outfiles.append("tmp/grid_avdist_150_150.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
+    output_tif = str(tmp_path / "grid_avdist_150_150.tif")
 
     with gdaltest.config_option(
         "GDAL_GRID_POINT_COUNT_THRESHOLD", "0" if use_quadtree else "1000000000"
@@ -1035,12 +817,11 @@ def test_gdal_grid_15(gdal_grid_path, use_quadtree):
         # the result is a raster filled with the same value in each node.
         gdaltest.runexternal(
             gdal_grid_path
-            + " -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a average_distance:radius1=150.0:radius2=150.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt "
-            + outfiles[-1]
+            + f" -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a average_distance:radius1=150.0:radius2=150.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt {output_tif}"
         )
 
         # We should get the same values as in "ref_data/grid_avdist_150_150.tif"
-        ds = gdal.Open(outfiles[-1])
+        ds = gdal.Open(output_tif)
         ds_ref = gdal.Open("ref_data/grid_avdist_150_150.tif")
         maxdiff = gdaltest.compare_ds(ds, ds_ref, verbose=0)
         if maxdiff > 1:
@@ -1055,26 +836,20 @@ def test_gdal_grid_15(gdal_grid_path, use_quadtree):
 
 
 @pytest.mark.require_driver("CSV")
-def test_gdal_grid_16(gdal_grid_path):
+def test_gdal_grid_16(gdal_grid_path, tmp_path):
 
-    #################
-    outfiles.append("tmp/grid_avdistpts_150_50_-15.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
+    output_tif = str(tmp_path / "grid_avdistpts_150_50_-15.tif")
 
     # Create a GDAL dataset from the values of "grid.csv".
     # We are using all the points from input dataset to average, so
     # the result is a raster filled with the same value in each node.
     gdaltest.runexternal(
         gdal_grid_path
-        + " -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a average_distance_pts:radius1=150.0:radius2=50.0:angle=-15.0:min_points=0:nodata=0.0 data/grid.vrt "
-        + outfiles[-1]
+        + f" -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a average_distance_pts:radius1=150.0:radius2=50.0:angle=-15.0:min_points=0:nodata=0.0 data/grid.vrt {output_tif}"
     )
 
     # We should get the same values as in "ref_data/grid_avdistpts_150_50_-15.tif"
-    ds = gdal.Open(outfiles[-1])
+    ds = gdal.Open(output_tif)
     ds_ref = gdal.Open("ref_data/grid_avdistpts_150_50_-15.tif")
     maxdiff = gdaltest.compare_ds(ds, ds_ref, verbose=0)
     if maxdiff > 1:
@@ -1086,14 +861,9 @@ def test_gdal_grid_16(gdal_grid_path):
 
 @pytest.mark.require_driver("CSV")
 @pytest.mark.parametrize("use_quadtree", [True, False])
-def test_gdal_grid_17(gdal_grid_path, use_quadtree):
+def test_gdal_grid_17(gdal_grid_path, tmp_path, use_quadtree):
 
-    #################
-    outfiles.append("tmp/grid_avdistpts_150_150.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
+    output_tif = str(tmp_path / "grid_avdistpts_150_150.tif")
 
     with gdaltest.config_option(
         "GDAL_GRID_POINT_COUNT_THRESHOLD", "0" if use_quadtree else "1000000000"
@@ -1103,12 +873,11 @@ def test_gdal_grid_17(gdal_grid_path, use_quadtree):
         # the result is a raster filled with the same value in each node.
         gdaltest.runexternal(
             gdal_grid_path
-            + " -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a average_distance_pts:radius1=150.0:radius2=150.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt "
-            + outfiles[-1]
+            + f" -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a average_distance_pts:radius1=150.0:radius2=150.0:angle=0.0:min_points=0:nodata=0.0 data/grid.vrt {output_tif}"
         )
 
         # We should get the same values as in "ref_data/grid_avdistpts_150_150.tif"
-        ds = gdal.Open(outfiles[-1])
+        ds = gdal.Open(output_tif)
         ds_ref = gdal.Open("ref_data/grid_avdistpts_150_150.tif")
         maxdiff = gdaltest.compare_ds(ds, ds_ref, verbose=0)
         if maxdiff > 1:
@@ -1123,21 +892,20 @@ def test_gdal_grid_17(gdal_grid_path, use_quadtree):
 
 
 @pytest.mark.skipif(not gdal.HasTriangulation(), reason="qhull missing")
-def test_gdal_grid_18(gdal_grid_path, n43_shp):
+def test_gdal_grid_18(gdal_grid_path, tmp_path, n43_shp):
 
-    outfiles.append("tmp/n43_linear.tif")
+    output_tif = str(tmp_path / "n43_linear.tif")
 
     # Create a GDAL dataset from the previous generated OGR grid
     (_, err) = gdaltest.runexternal_out_and_err(
         gdal_grid_path
-        + f" -txe -80.0041667 -78.9958333 -tye 42.9958333 44.0041667 -outsize 121 121 -ot Int16 -l n43 -a linear -co TILED=YES -co BLOCKXSIZE=256 -co BLOCKYSIZE=256 {n43_shp} "
-        + outfiles[-1]
+        + f" -txe -80.0041667 -78.9958333 -tye 42.9958333 44.0041667 -outsize 121 121 -ot Int16 -l n43 -a linear -co TILED=YES -co BLOCKXSIZE=256 -co BLOCKYSIZE=256 {n43_shp} {output_tif}"
     )
     assert err is None or err == "", "got error/warning"
 
     # We should get the same values as in n43.tif
     ds = gdal.Open("../gdrivers/data/n43.tif")
-    ds2 = gdal.Open(outfiles[-1])
+    ds2 = gdal.Open(output_tif)
     assert (
         ds.GetRasterBand(1).Checksum() == ds2.GetRasterBand(1).Checksum()
     ), "bad checksum : got %d, expected %d" % (
@@ -1154,25 +922,20 @@ def test_gdal_grid_18(gdal_grid_path, n43_shp):
 
 
 @pytest.mark.require_driver("CSV")
-def test_gdal_grid_19(gdal_grid_path):
+def test_gdal_grid_19(gdal_grid_path, tmp_path):
 
+    output_tif = str(tmp_path / "grid_invdistnn_generic.tif")
     #################
     # Test generic implementation (no AVX, no SSE)
-    outfiles.append("tmp/grid_invdistnn_generic.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
 
     # Create a GDAL dataset from the values of "grid.csv".
     (_, _) = gdaltest.runexternal_out_and_err(
         gdal_grid_path
-        + " -txe 440721.0 441920.0 -tye 3751321.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a invdistnn:power=2.0:radius=1.0:max_points=12:min_points=0:nodata=0.0 data/grid.vrt "
-        + outfiles[-1]
+        + f" -txe 440721.0 441920.0 -tye 3751321.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a invdistnn:power=2.0:radius=1.0:max_points=12:min_points=0:nodata=0.0 data/grid.vrt {output_tif}"
     )
 
     # We should get the same values as in "ref_data/gdal_invdistnn.tif"
-    ds = gdal.Open(outfiles[-1])
+    ds = gdal.Open(output_tif)
     ds_ref = gdal.Open("ref_data/grid_invdistnn.tif")
     maxdiff = gdaltest.compare_ds(ds, ds_ref, verbose=0)
     if maxdiff > 0.00001:
@@ -1181,23 +944,21 @@ def test_gdal_grid_19(gdal_grid_path):
     ds_ref = None
     ds = None
 
-    #################
-    outfiles.append("tmp/grid_invdistnn_250_8minp.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
+
+@pytest.mark.require_driver("CSV")
+def test_gdal_grid_19_250_8minp(gdal_grid_path, tmp_path):
+
+    output_tif = str(tmp_path / "grid_invdistnn_250_8minp.tif")
 
     # Create a GDAL dataset from the values of "grid.csv".
     # Circular window, shifted, test min points and NODATA setting.
     gdaltest.runexternal(
         gdal_grid_path
-        + " -txe 440721.0 441920.0 -tye 3751321.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a invdistnn:power=2.0:radius=250.0:max_points=12:min_points=8:nodata=0.0 data/grid.vrt "
-        + outfiles[-1]
+        + f" -txe 440721.0 441920.0 -tye 3751321.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a invdistnn:power=2.0:radius=250.0:max_points=12:min_points=8:nodata=0.0 data/grid.vrt {output_tif}"
     )
 
     # We should get the same values as in "ref_data/grid_invdistnn_250_8minp.tif"
-    ds = gdal.Open(outfiles[-1])
+    ds = gdal.Open(output_tif)
     ds_ref = gdal.Open("ref_data/grid_invdistnn_250_8minp.tif")
     maxdiff = gdaltest.compare_ds(ds, ds_ref, verbose=0)
     if maxdiff > 0.00001:
@@ -1206,23 +967,23 @@ def test_gdal_grid_19(gdal_grid_path):
     ds_ref = None
     ds = None
 
+
+@pytest.mark.require_driver("CSV")
+def test_gdal_grid_19_250_10maxp_3pow(gdal_grid_path, tmp_path):
+
+    output_tif = str(tmp_path / "grid_invdistnn_250_10maxp_3pow.tif")
+
     #################
     # Test generic implementation with max_points and radius specified
-    outfiles.append("tmp/grid_invdistnn_250_10maxp_3pow.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
 
     # Create a GDAL dataset from the values of "grid.csv".
     gdaltest.runexternal(
         gdal_grid_path
-        + " -txe 440721.0 441920.0 -tye 3751321.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a invdistnn:power=3.0:radius=250.0:max_points=10:min_points=0:nodata=0.0 data/grid.vrt "
-        + outfiles[-1]
+        + f" -txe 440721.0 441920.0 -tye 3751321.0 3750120.0 -outsize 20 20 -ot Float64 -l grid -a invdistnn:power=3.0:radius=250.0:max_points=10:min_points=0:nodata=0.0 data/grid.vrt {output_tif}"
     )
 
     # We should get the same values as in "ref_data/gdal_invdistnn_250_10maxp_3pow.tif"
-    ds = gdal.Open(outfiles[-1])
+    ds = gdal.Open(output_tif)
     ds_ref = gdal.Open("ref_data/grid_invdistnn_250_10maxp_3pow.tif")
     maxdiff = gdaltest.compare_ds(ds, ds_ref, verbose=0)
     if maxdiff > 0.00001:
@@ -1238,16 +999,12 @@ def test_gdal_grid_19(gdal_grid_path):
 
 @pytest.mark.require_driver("CSV")
 @pytest.mark.require_geos
-def test_gdal_grid_clipsrc(gdal_grid_path):
+def test_gdal_grid_clipsrc(gdal_grid_path, tmp_path):
 
-    #################
-    outfiles.append("tmp/grid_clipsrc.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
+    output_tif = str(tmp_path / "grid_clipsrc.tif")
+    clip_csv = str(tmp_path / "clip.csv")
 
-    open("tmp/clip.csv", "wt").write(
+    open(clip_csv, "wt").write(
         'id,WKT\n1,"POLYGON((440750 3751340,440750 3750100,441900 3750100,441900 3751340,440750 3751340))"\n'
     )
 
@@ -1255,14 +1012,11 @@ def test_gdal_grid_clipsrc(gdal_grid_path):
     # Grid nodes are located exactly in raster nodes.
     gdaltest.runexternal_out_and_err(
         gdal_grid_path
-        + " -clipsrc tmp/clip.csv -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a nearest:radius1=0.0:radius2=0.0:angle=0.0:nodata=0.0 data/grid.vrt "
-        + outfiles[-1]
+        + f" -clipsrc {clip_csv} -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -outsize 20 20 -ot Byte -l grid -a nearest:radius1=0.0:radius2=0.0:angle=0.0:nodata=0.0 data/grid.vrt {output_tif}"
     )
 
-    os.unlink("tmp/clip.csv")
-
     # We should get the same values as in "gcore/data/byte.tif"
-    ds = gdal.Open(outfiles[-1])
+    ds = gdal.Open(output_tif)
     cs = ds.GetRasterBand(1).Checksum()
     assert not (cs == 0 or cs == 4672), "bad checksum"
     ds = None
@@ -1273,14 +1027,9 @@ def test_gdal_grid_clipsrc(gdal_grid_path):
 
 
 @pytest.mark.require_driver("CSV")
-def test_gdal_grid_tr(gdal_grid_path):
+def test_gdal_grid_tr(gdal_grid_path, tmp_path):
 
-    #################
-    outfiles.append("tmp/grid_count_70_70.tif")
-    try:
-        os.remove(outfiles[-1])
-    except OSError:
-        pass
+    output_tif = str(tmp_path / "grid_count_70_70.tif")
 
     # Create a GDAL dataset from the values of "grid.csv".
     gdaltest.runexternal(
@@ -1288,11 +1037,11 @@ def test_gdal_grid_tr(gdal_grid_path):
         + " -txe 440720.0 441920.0 -tye 3751320.0 3750120.0 -tr 60 60 -ot Byte -l grid -a count:radius1=70.0:radius2=70.0:angle=0.0:min_points=0:nodata=0.0 "
         + " -oo X_POSSIBLE_NAMES=field_1 -oo Y_POSSIBLE_NAMES=field_2 -oo Z_POSSIBLE_NAMES=field_3"
         + " data/grid.csv "
-        + outfiles[-1]
+        + output_tif
     )
 
     # We should get the same values as in "ref_data/grid_count_70_70.tif"
-    ds = gdal.Open(outfiles[-1])
+    ds = gdal.Open(output_tif)
     ds_ref = gdal.Open("ref_data/grid_count_70_70.tif")
     assert (
         ds.GetRasterBand(1).Checksum() == ds_ref.GetRasterBand(1).Checksum()

--- a/autotest/utilities/test_gdal_rasterize.py
+++ b/autotest/utilities/test_gdal_rasterize.py
@@ -395,12 +395,11 @@ def test_gdal_rasterize_7(gdal_rasterize_path, sql_in_file):
     else:
         sql = '"' + sql + '"'
     cmds = (
-        """tmp/test_gdal_rasterize_7.csv
-              tmp/test_gdal_rasterize_7.tif
-              -init 0 -burn 1
-              -sql %s
-              -dialect sqlite -tr 1 1 -te -1 -1 51 51"""
-        % sql
+        "tmp/test_gdal_rasterize_7.csv "
+        + "tmp/test_gdal_rasterize_7.tif "
+        + "-init 0 -burn 1 "
+        + f"-sql {sql} "
+        + "-dialect sqlite -tr 1 1 -te -1 -1 51 51"
     )
 
     gdaltest.runexternal(gdal_rasterize_path + " " + cmds)

--- a/autotest/utilities/test_gdal_translate.py
+++ b/autotest/utilities/test_gdal_translate.py
@@ -969,11 +969,7 @@ def test_gdal_translate_37(gdal_translate_path):
     rat = None
     ds = None
 
-
-# Test RAT is copied round trip back to hfa
-
-
-def test_gdal_translate_38(gdal_translate_path):
+    # Test RAT is copied round trip back to hfa
 
     gdaltest.runexternal(
         gdal_translate_path

--- a/autotest/utilities/test_gdaladdo.py
+++ b/autotest/utilities/test_gdaladdo.py
@@ -120,12 +120,7 @@ def test_gdaladdo_3(gdaladdo_path):
     except OSError:
         pytest.fail("no external overview.")
 
-
-###############################################################################
-# Test -clean
-
-
-def test_gdaladdo_4(gdaladdo_path):
+    # Test -clean
 
     gdaltest.runexternal(gdaladdo_path + " -clean tmp/test_gdaladdo_3.tif")
 

--- a/autotest/utilities/test_gdalbuildvrt.py
+++ b/autotest/utilities/test_gdalbuildvrt.py
@@ -29,13 +29,11 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
-import os
-
 import gdaltest
 import pytest
 import test_cli_utilities
 
-from osgeo import gdal, ogr, osr
+from osgeo import gdal, osr
 
 pytestmark = pytest.mark.skipif(
     test_cli_utilities.get_gdalbuildvrt_path() is None,
@@ -43,16 +41,53 @@ pytestmark = pytest.mark.skipif(
 )
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def gdalbuildvrt_path():
     return test_cli_utilities.get_gdalbuildvrt_path()
 
 
-###############################################################################
-def gdalbuildvrt_check():
+@pytest.fixture(scope="module")
+def sample_tifs(tmp_path_factory):
 
-    ds = gdal.Open("tmp/mosaic.vrt")
-    try:
+    tmpdir = tmp_path_factory.mktemp("tmp")
+
+    drv = gdal.GetDriverByName("GTiff")
+    srs = osr.SpatialReference()
+    srs.SetWellKnownGeogCS("WGS84")
+    wkt = srs.ExportToWkt()
+
+    sample1_tif = str(tmpdir / "gdalbuildvrt1.tif")
+    with drv.Create(sample1_tif, 10, 10, 1) as ds:
+        ds.SetProjection(wkt)
+        ds.SetGeoTransform([2, 0.1, 0, 49, 0, -0.1])
+        ds.GetRasterBand(1).Fill(0)
+
+    sample2_tif = str(tmpdir / "gdalbuildvrt2.tif")
+    with drv.Create(sample2_tif, 10, 10, 1) as ds:
+        ds.SetProjection(wkt)
+        ds.SetGeoTransform([3, 0.1, 0, 49, 0, -0.1])
+        ds.GetRasterBand(1).Fill(63)
+
+    sample3_tif = str(tmpdir / "gdalbuildvrt3.tif")
+    with drv.Create(sample3_tif, 10, 10, 1) as ds:
+        ds.SetProjection(wkt)
+        ds.SetGeoTransform([2, 0.1, 0, 48, 0, -0.1])
+        ds.GetRasterBand(1).Fill(127)
+
+    sample4_tif = str(tmpdir / "gdalbuildvrt4.tif")
+    with drv.Create(sample4_tif, 10, 10, 1) as ds:
+        ds.SetProjection(wkt)
+        ds.SetGeoTransform([3, 0.1, 0, 48, 0, -0.1])
+        ds.GetRasterBand(1).Fill(255)
+
+    yield (sample1_tif, sample2_tif, sample3_tif, sample4_tif)
+
+
+###############################################################################
+def gdalbuildvrt_check(mosaic_vrt):
+
+    with gdal.Open(mosaic_vrt) as ds:
+
         assert (
             ds.GetProjectionRef().find("WGS 84") != -1
         ), "Expected WGS 84\nGot : %s" % (ds.GetProjectionRef())
@@ -72,112 +107,72 @@ def gdalbuildvrt_check():
         assert ds.RasterCount == 1, "Wrong raster count : %d " % (ds.RasterCount)
 
         assert ds.GetRasterBand(1).Checksum() == 3508, "Wrong checksum"
-    finally:
-        del ds
 
 
 ###############################################################################
 # Simple test
 
 
-def test_gdalbuildvrt_1(gdalbuildvrt_path):
+def test_gdalbuildvrt_1(gdalbuildvrt_path, tmp_path, sample_tifs):
 
-    drv = gdal.GetDriverByName("GTiff")
-    srs = osr.SpatialReference()
-    srs.SetWellKnownGeogCS("WGS84")
-    wkt = srs.ExportToWkt()
-
-    ds = drv.Create("tmp/gdalbuildvrt1.tif", 10, 10, 1)
-    ds.SetProjection(wkt)
-    ds.SetGeoTransform([2, 0.1, 0, 49, 0, -0.1])
-    ds.GetRasterBand(1).Fill(0)
-    ds = None
-
-    ds = drv.Create("tmp/gdalbuildvrt2.tif", 10, 10, 1)
-    ds.SetProjection(wkt)
-    ds.SetGeoTransform([3, 0.1, 0, 49, 0, -0.1])
-    ds.GetRasterBand(1).Fill(63)
-    ds = None
-
-    ds = drv.Create("tmp/gdalbuildvrt3.tif", 10, 10, 1)
-    ds.SetProjection(wkt)
-    ds.SetGeoTransform([2, 0.1, 0, 48, 0, -0.1])
-    ds.GetRasterBand(1).Fill(127)
-    ds = None
-
-    ds = drv.Create("tmp/gdalbuildvrt4.tif", 10, 10, 1)
-    ds.SetProjection(wkt)
-    ds.SetGeoTransform([3, 0.1, 0, 48, 0, -0.1])
-    ds.GetRasterBand(1).Fill(255)
-    ds = None
+    mosaic_vrt = str(tmp_path / "mosaic.vrt")
 
     (_, err) = gdaltest.runexternal_out_and_err(
-        gdalbuildvrt_path
-        + " tmp/mosaic.vrt tmp/gdalbuildvrt1.tif tmp/gdalbuildvrt2.tif tmp/gdalbuildvrt3.tif tmp/gdalbuildvrt4.tif"
+        gdalbuildvrt_path + f" {mosaic_vrt} {' '.join(sample_tifs)}"
     )
     assert err is None or err == "", "got error/warning"
 
-    return gdalbuildvrt_check()
+    return gdalbuildvrt_check(mosaic_vrt)
 
 
 ###############################################################################
 # Test with tile index
 
 
-def test_gdalbuildvrt_2(gdalbuildvrt_path):
+def test_gdalbuildvrt_2(gdalbuildvrt_path, tmp_path, sample_tifs):
 
     if test_cli_utilities.get_gdaltindex_path() is None:
         pytest.skip()
 
-    try:
-        os.remove("tmp/tileindex.shp")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/tileindex.dbf")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/tileindex.shx")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/mosaic.vrt")
-    except OSError:
-        pass
+    tileindex_shp = str(tmp_path / "tileindex.shp")
+    mosaic_vrt = str(tmp_path / "mosaic.vrt")
 
     gdaltest.runexternal(
         test_cli_utilities.get_gdaltindex_path()
-        + " tmp/tileindex.shp tmp/gdalbuildvrt1.tif tmp/gdalbuildvrt2.tif tmp/gdalbuildvrt3.tif tmp/gdalbuildvrt4.tif"
+        + f" {tileindex_shp} {' '.join(sample_tifs)}"
     )
 
-    gdaltest.runexternal(gdalbuildvrt_path + " tmp/mosaic.vrt tmp/tileindex.shp")
+    gdaltest.runexternal(gdalbuildvrt_path + f" {mosaic_vrt} {tileindex_shp}")
 
-    return gdalbuildvrt_check()
+    return gdalbuildvrt_check(mosaic_vrt)
 
 
 ###############################################################################
 # Test with file list
 
 
-def test_gdalbuildvrt_3(gdalbuildvrt_path):
+def test_gdalbuildvrt_3(gdalbuildvrt_path, tmp_path, sample_tifs):
 
-    open("tmp/filelist.txt", "wt").write(
-        "tmp/gdalbuildvrt1.tif\ntmp/gdalbuildvrt2.tif\ntmp/gdalbuildvrt3.tif\ntmp/gdalbuildvrt4.tif"
-    )
+    mosaic_vrt = str(tmp_path / "mosaic.vrt")
+    filelist_txt = str(tmp_path / "filelist.txt")
+
+    with open(filelist_txt, "wt") as filelist:
+        filelist.write("\n".join(sample_tifs))
 
     gdaltest.runexternal(
-        gdalbuildvrt_path + " -input_file_list tmp/filelist.txt tmp/mosaic.vrt"
+        gdalbuildvrt_path + f" -input_file_list {filelist_txt} {mosaic_vrt}"
     )
 
-    return gdalbuildvrt_check()
+    return gdalbuildvrt_check(mosaic_vrt)
 
 
 ###############################################################################
 # Try adding a raster in another projection
 
 
-def test_gdalbuildvrt_4(gdalbuildvrt_path):
+def test_gdalbuildvrt_4(gdalbuildvrt_path, tmp_path, sample_tifs):
+
+    mosaic_vrt = str(tmp_path / "mosaic.vrt")
 
     drv = gdal.GetDriverByName("GTiff")
     wkt = """GEOGCS["WGS 72",
@@ -187,57 +182,59 @@ def test_gdalbuildvrt_4(gdalbuildvrt_path):
     PRIMEM["Greenwich",0],
     UNIT["degree",0.0174532925199433]]"""
 
-    ds = drv.Create("tmp/gdalbuildvrt5.tif", 10, 10, 1)
-    ds.SetProjection(wkt)
-    ds.SetGeoTransform([47, 0.1, 0, 2, 0, -0.1])
-    ds = None
+    input5_tif = str(tmp_path / "gdalbuildvrt5.tif")
+
+    with drv.Create(input5_tif, 10, 10, 1) as ds:
+        ds.SetProjection(wkt)
+        ds.SetGeoTransform([47, 0.1, 0, 2, 0, -0.1])
 
     gdaltest.runexternal(
-        gdalbuildvrt_path
-        + " tmp/mosaic.vrt tmp/gdalbuildvrt1.tif tmp/gdalbuildvrt2.tif tmp/gdalbuildvrt3.tif tmp/gdalbuildvrt4.tif tmp/gdalbuildvrt5.tif"
+        gdalbuildvrt_path + f" {mosaic_vrt} {' '.join(sample_tifs)} {input5_tif}"
     )
 
-    return gdalbuildvrt_check()
+    return gdalbuildvrt_check(mosaic_vrt)
 
 
 ###############################################################################
 # Try adding a raster with different band count
 
 
-# NOTE: fails. commented out originally in 4ef886421c99a4451f8873cb6e094d45ecc86d3f, not sure why
-@pytest.mark.skip()
-def test_gdalbuildvrt_5(gdalbuildvrt_path):
+# commented out originally in 4ef886421c99a4451f8873cb6e094d45ecc86d3f, not sure why
+def test_gdalbuildvrt_5(gdalbuildvrt_path, tmp_path, sample_tifs):
+
+    mosaic_vrt = str(tmp_path / "mosaic.vrt")
 
     drv = gdal.GetDriverByName("GTiff")
     srs = osr.SpatialReference()
     srs.SetWellKnownGeogCS("WGS84")
     wkt = srs.ExportToWkt()
 
-    ds = drv.Create("tmp/gdalbuildvrt5.tif", 10, 10, 2)
-    ds.SetProjection(wkt)
-    ds.SetGeoTransform([47, 0.1, 0, 2, 0, -0.1])
-    ds = None
+    input5_tif = str(tmp_path / "gdalbuildvrt5.tif")
+
+    with drv.Create(input5_tif, 10, 10, 2) as ds:
+        ds.SetProjection(wkt)
+        ds.SetGeoTransform([47, 0.1, 0, 2, 0, -0.1])
 
     gdaltest.runexternal(
-        gdalbuildvrt_path
-        + " tmp/mosaic.vrt tmp/gdalbuildvrt1.tif tmp/gdalbuildvrt2.tif tmp/gdalbuildvrt3.tif tmp/gdalbuildvrt4.tif tmp/gdalbuildvrt5.tif"
+        gdalbuildvrt_path + f" {mosaic_vrt} {' '.join(sample_tifs)} {input5_tif}"
     )
 
-    return gdalbuildvrt_check()
+    return gdalbuildvrt_check(mosaic_vrt)
 
 
 ###############################################################################
 # Test -separate option
 
 
-def test_gdalbuildvrt_6(gdalbuildvrt_path):
+def test_gdalbuildvrt_6(gdalbuildvrt_path, tmp_path, sample_tifs):
+
+    output_vrt = str(tmp_path / "stacked.vrt")
 
     gdaltest.runexternal(
-        gdalbuildvrt_path
-        + " -separate tmp/stacked.vrt tmp/gdalbuildvrt1.tif tmp/gdalbuildvrt2.tif tmp/gdalbuildvrt3.tif tmp/gdalbuildvrt4.tif"
+        gdalbuildvrt_path + f" -separate {output_vrt} {' '.join(sample_tifs)}"
     )
 
-    ds = gdal.Open("tmp/stacked.vrt")
+    ds = gdal.Open(output_vrt)
     assert ds.GetProjectionRef().find("WGS 84") != -1, "Expected WGS 84\nGot : %s" % (
         ds.GetProjectionRef()
     )
@@ -263,86 +260,86 @@ def test_gdalbuildvrt_6(gdalbuildvrt_path):
 # Test source rasters with nodata
 
 
-def test_gdalbuildvrt_7(gdalbuildvrt_path):
+def test_gdalbuildvrt_7(gdalbuildvrt_path, tmp_path):
 
-    out_ds = gdal.GetDriverByName("GTiff").Create(
-        "tmp/vrtnull1.tif", 20, 10, 3, gdal.GDT_UInt16
-    )
-    out_ds.SetGeoTransform([2, 0.1, 0, 49, 0, -0.1])
-    srs = osr.SpatialReference()
-    srs.SetFromUserInput("EPSG:4326")
-    out_ds.SetProjection(srs.ExportToWkt())
-    out_ds.GetRasterBand(1).SetRasterColorInterpretation(gdal.GCI_RedBand)
-    out_ds.GetRasterBand(2).SetRasterColorInterpretation(gdal.GCI_GreenBand)
-    out_ds.GetRasterBand(3).SetRasterColorInterpretation(gdal.GCI_BlueBand)
-    out_ds.GetRasterBand(1).SetNoDataValue(256)
+    input1_tif = str(tmp_path / "vrtnull1.tif")
+    input2_tif = str(tmp_path / "vrtnull2.tif")
+    output_vrt = str(tmp_path / "gdalbuildvrt7.vrt")
 
-    try:
-        ff = "\xff".encode("latin1")
-    except UnicodeDecodeError:
-        ff = "\xff"
+    with gdal.GetDriverByName("GTiff").Create(
+        input1_tif, 20, 10, 3, gdal.GDT_UInt16
+    ) as out_ds:
+        out_ds.SetGeoTransform([2, 0.1, 0, 49, 0, -0.1])
+        srs = osr.SpatialReference()
+        srs.SetFromUserInput("EPSG:4326")
+        out_ds.SetProjection(srs.ExportToWkt())
+        out_ds.GetRasterBand(1).SetRasterColorInterpretation(gdal.GCI_RedBand)
+        out_ds.GetRasterBand(2).SetRasterColorInterpretation(gdal.GCI_GreenBand)
+        out_ds.GetRasterBand(3).SetRasterColorInterpretation(gdal.GCI_BlueBand)
+        out_ds.GetRasterBand(1).SetNoDataValue(256)
 
-    out_ds.GetRasterBand(1).WriteRaster(
-        0, 0, 10, 10, ff, buf_type=gdal.GDT_Byte, buf_xsize=1, buf_ysize=1
-    )
-    out_ds.GetRasterBand(2).WriteRaster(
-        0, 0, 10, 10, "\x00", buf_type=gdal.GDT_Byte, buf_xsize=1, buf_ysize=1
-    )
-    out_ds.GetRasterBand(3).WriteRaster(
-        0, 0, 10, 10, "\x00", buf_type=gdal.GDT_Byte, buf_xsize=1, buf_ysize=1
-    )
-    out_ds = None
+        try:
+            ff = "\xff".encode("latin1")
+        except UnicodeDecodeError:
+            ff = "\xff"
 
-    out_ds = gdal.GetDriverByName("GTiff").Create(
-        "tmp/vrtnull2.tif", 20, 10, 3, gdal.GDT_UInt16
-    )
-    out_ds.SetGeoTransform([2, 0.1, 0, 49, 0, -0.1])
-    srs = osr.SpatialReference()
-    srs.SetFromUserInput("EPSG:4326")
-    out_ds.SetProjection(srs.ExportToWkt())
-    out_ds.GetRasterBand(1).SetRasterColorInterpretation(gdal.GCI_RedBand)
-    out_ds.GetRasterBand(2).SetRasterColorInterpretation(gdal.GCI_GreenBand)
-    out_ds.GetRasterBand(3).SetRasterColorInterpretation(gdal.GCI_BlueBand)
-    out_ds.GetRasterBand(1).SetNoDataValue(256)
+        out_ds.GetRasterBand(1).WriteRaster(
+            0, 0, 10, 10, ff, buf_type=gdal.GDT_Byte, buf_xsize=1, buf_ysize=1
+        )
+        out_ds.GetRasterBand(2).WriteRaster(
+            0, 0, 10, 10, "\x00", buf_type=gdal.GDT_Byte, buf_xsize=1, buf_ysize=1
+        )
+        out_ds.GetRasterBand(3).WriteRaster(
+            0, 0, 10, 10, "\x00", buf_type=gdal.GDT_Byte, buf_xsize=1, buf_ysize=1
+        )
 
-    out_ds.GetRasterBand(1).WriteRaster(
-        10, 0, 10, 10, "\x00", buf_type=gdal.GDT_Byte, buf_xsize=1, buf_ysize=1
-    )
-    out_ds.GetRasterBand(2).WriteRaster(
-        10, 0, 10, 10, ff, buf_type=gdal.GDT_Byte, buf_xsize=1, buf_ysize=1
-    )
-    out_ds.GetRasterBand(3).WriteRaster(
-        10, 0, 10, 10, "\x00", buf_type=gdal.GDT_Byte, buf_xsize=1, buf_ysize=1
-    )
-    out_ds = None
+    with gdal.GetDriverByName("GTiff").Create(
+        input2_tif, 20, 10, 3, gdal.GDT_UInt16
+    ) as out_ds:
+        out_ds.SetGeoTransform([2, 0.1, 0, 49, 0, -0.1])
+        srs = osr.SpatialReference()
+        srs.SetFromUserInput("EPSG:4326")
+        out_ds.SetProjection(srs.ExportToWkt())
+        out_ds.GetRasterBand(1).SetRasterColorInterpretation(gdal.GCI_RedBand)
+        out_ds.GetRasterBand(2).SetRasterColorInterpretation(gdal.GCI_GreenBand)
+        out_ds.GetRasterBand(3).SetRasterColorInterpretation(gdal.GCI_BlueBand)
+        out_ds.GetRasterBand(1).SetNoDataValue(256)
 
-    gdaltest.runexternal(
-        gdalbuildvrt_path + " tmp/gdalbuildvrt7.vrt tmp/vrtnull1.tif tmp/vrtnull2.tif"
-    )
+        out_ds.GetRasterBand(1).WriteRaster(
+            10, 0, 10, 10, "\x00", buf_type=gdal.GDT_Byte, buf_xsize=1, buf_ysize=1
+        )
+        out_ds.GetRasterBand(2).WriteRaster(
+            10, 0, 10, 10, ff, buf_type=gdal.GDT_Byte, buf_xsize=1, buf_ysize=1
+        )
+        out_ds.GetRasterBand(3).WriteRaster(
+            10, 0, 10, 10, "\x00", buf_type=gdal.GDT_Byte, buf_xsize=1, buf_ysize=1
+        )
 
-    ds = gdal.Open("tmp/gdalbuildvrt7.vrt")
+    gdaltest.runexternal(gdalbuildvrt_path + f" {output_vrt} {input1_tif} {input2_tif}")
 
-    assert ds.GetRasterBand(1).Checksum() == 1217, "Wrong checksum"
+    with gdal.Open(output_vrt) as ds:
 
-    assert ds.GetRasterBand(2).Checksum() == 1218, "Wrong checksum"
+        assert ds.GetRasterBand(1).Checksum() == 1217, "Wrong checksum"
 
-    assert ds.GetRasterBand(3).Checksum() == 0, "Wrong checksum"
+        assert ds.GetRasterBand(2).Checksum() == 1218, "Wrong checksum"
 
-    ds = None
+        assert ds.GetRasterBand(3).Checksum() == 0, "Wrong checksum"
 
 
 ###############################################################################
 # Test -tr option
 
 
-def test_gdalbuildvrt_8(gdalbuildvrt_path):
+def test_gdalbuildvrt_8(gdalbuildvrt_path, tmp_path, sample_tifs):
+
+    mosaic_vrt = str(tmp_path / "mosiac.vrt")
+    mosaic2_vrt = str(tmp_path / "mosaic2.vrt")
 
     gdaltest.runexternal(
-        gdalbuildvrt_path
-        + " -tr 0.05 0.05 tmp/mosaic2.vrt tmp/gdalbuildvrt1.tif tmp/gdalbuildvrt2.tif tmp/gdalbuildvrt3.tif tmp/gdalbuildvrt4.tif"
+        gdalbuildvrt_path + f" -tr 0.05 0.05 {mosaic2_vrt} {' '.join(sample_tifs)}"
     )
 
-    ds = gdal.Open("tmp/mosaic2.vrt")
+    ds = gdal.Open(mosaic2_vrt)
 
     gt = ds.GetGeoTransform()
     expected_gt = [2, 0.05, 0, 49, 0, -0.05]
@@ -356,25 +353,25 @@ def test_gdalbuildvrt_8(gdalbuildvrt_path):
         ds.RasterXSize == 40 and ds.RasterYSize == 40
     ), "Wrong raster dimensions : %d x %d" % (ds.RasterXSize, ds.RasterYSize)
 
-    gdaltest.runexternal(
-        gdalbuildvrt_path + " -tr 0.1 0.1 tmp/mosaic.vrt tmp/mosaic2.vrt"
-    )
+    gdaltest.runexternal(gdalbuildvrt_path + f" -tr 0.1 0.1 {mosaic_vrt} {mosaic2_vrt}")
 
-    return gdalbuildvrt_check()
+    return gdalbuildvrt_check(mosaic_vrt)
 
 
 ###############################################################################
 # Test -te option
 
 
-def test_gdalbuildvrt_9(gdalbuildvrt_path):
+def test_gdalbuildvrt_9(gdalbuildvrt_path, tmp_path, sample_tifs):
+
+    mosaic_vrt = str(tmp_path / "mosiac.vrt")
+    mosaic2_vrt = str(tmp_path / "mosaic2.vrt")
 
     gdaltest.runexternal(
-        gdalbuildvrt_path
-        + " -te 1 46 5 50 tmp/mosaic2.vrt tmp/gdalbuildvrt1.tif tmp/gdalbuildvrt2.tif tmp/gdalbuildvrt3.tif tmp/gdalbuildvrt4.tif"
+        gdalbuildvrt_path + f" -te 1 46 5 50 {mosaic2_vrt} {' '.join(sample_tifs)}"
     )
 
-    ds = gdal.Open("tmp/mosaic2.vrt")
+    ds = gdal.Open(mosaic2_vrt)
 
     gt = ds.GetGeoTransform()
     expected_gt = [1, 0.1, 0, 50, 0, -0.1]
@@ -389,60 +386,61 @@ def test_gdalbuildvrt_9(gdalbuildvrt_path):
     ), "Wrong raster dimensions : %d x %d" % (ds.RasterXSize, ds.RasterYSize)
 
     gdaltest.runexternal(
-        gdalbuildvrt_path + " -te 2 47 4 49 tmp/mosaic.vrt tmp/mosaic2.vrt"
+        gdalbuildvrt_path + f" -te 2 47 4 49 {mosaic_vrt} {mosaic2_vrt}"
     )
 
-    return gdalbuildvrt_check()
+    return gdalbuildvrt_check(mosaic_vrt)
 
 
 ###############################################################################
 # Test explicit nodata setting (#3254)
 
 
-def test_gdalbuildvrt_10(gdalbuildvrt_path):
+def test_gdalbuildvrt_10(gdalbuildvrt_path, tmp_path):
 
-    out_ds = gdal.GetDriverByName("GTiff").Create(
-        "tmp/test_gdalbuildvrt_10_1.tif",
+    input1_tif = str(tmp_path / "test_gdalbuildvrt_10_1.tif")
+    input2_tif = str(tmp_path / "test_gdalbuildvrt_10_2.tif")
+    output_vrt = str(tmp_path / "gdalbuildvrt10.vrt")
+
+    with gdal.GetDriverByName("GTiff").Create(
+        input1_tif,
         10,
         10,
         1,
         gdal.GDT_Byte,
         options=["NBITS=1", "PHOTOMETRIC=MINISWHITE"],
-    )
-    out_ds.SetGeoTransform([2, 0.1, 0, 49, 0, -0.1])
-    srs = osr.SpatialReference()
-    srs.SetFromUserInput("EPSG:4326")
-    out_ds.SetProjection(srs.ExportToWkt())
+    ) as out_ds:
+        out_ds.SetGeoTransform([2, 0.1, 0, 49, 0, -0.1])
+        srs = osr.SpatialReference()
+        srs.SetFromUserInput("EPSG:4326")
+        out_ds.SetProjection(srs.ExportToWkt())
 
-    out_ds.GetRasterBand(1).WriteRaster(
-        1, 1, 3, 3, "\x01", buf_type=gdal.GDT_Byte, buf_xsize=1, buf_ysize=1
-    )
-    out_ds = None
+        out_ds.GetRasterBand(1).WriteRaster(
+            1, 1, 3, 3, "\x01", buf_type=gdal.GDT_Byte, buf_xsize=1, buf_ysize=1
+        )
 
-    out_ds = gdal.GetDriverByName("GTiff").Create(
-        "tmp/test_gdalbuildvrt_10_2.tif",
+    with gdal.GetDriverByName("GTiff").Create(
+        input2_tif,
         10,
         10,
         1,
         gdal.GDT_Byte,
         options=["NBITS=1", "PHOTOMETRIC=MINISWHITE"],
-    )
-    out_ds.SetGeoTransform([2, 0.1, 0, 49, 0, -0.1])
-    srs = osr.SpatialReference()
-    srs.SetFromUserInput("EPSG:4326")
-    out_ds.SetProjection(srs.ExportToWkt())
+    ) as out_ds:
+        out_ds.SetGeoTransform([2, 0.1, 0, 49, 0, -0.1])
+        srs = osr.SpatialReference()
+        srs.SetFromUserInput("EPSG:4326")
+        out_ds.SetProjection(srs.ExportToWkt())
 
-    out_ds.GetRasterBand(1).WriteRaster(
-        6, 6, 3, 3, "\x01", buf_type=gdal.GDT_Byte, buf_xsize=1, buf_ysize=1
-    )
-    out_ds = None
+        out_ds.GetRasterBand(1).WriteRaster(
+            6, 6, 3, 3, "\x01", buf_type=gdal.GDT_Byte, buf_xsize=1, buf_ysize=1
+        )
 
     gdaltest.runexternal(
-        gdalbuildvrt_path
-        + " -srcnodata 0 tmp/gdalbuildvrt10.vrt tmp/test_gdalbuildvrt_10_1.tif tmp/test_gdalbuildvrt_10_2.tif"
+        gdalbuildvrt_path + f" -srcnodata 0 {output_vrt} {input1_tif} {input2_tif}"
     )
 
-    ds = gdal.Open("tmp/gdalbuildvrt10.vrt")
+    ds = gdal.Open(output_vrt)
 
     assert ds.GetRasterBand(1).Checksum() == 18, "Wrong checksum"
 
@@ -453,56 +451,52 @@ def test_gdalbuildvrt_10(gdalbuildvrt_path):
 # Test that we can stack ungeoreference single band images with -separate (#3432)
 
 
-def test_gdalbuildvrt_11(gdalbuildvrt_path):
+def test_gdalbuildvrt_11(gdalbuildvrt_path, tmp_path):
 
-    out_ds = gdal.GetDriverByName("GTiff").Create(
-        "tmp/test_gdalbuildvrt_11_1.tif", 10, 10, 1
-    )
-    out_ds.GetRasterBand(1).Fill(255)
-    cs1 = out_ds.GetRasterBand(1).Checksum()
-    out_ds = None
+    output_vrt = str(tmp_path / "gdalbuildvrt11.vrt")
 
-    out_ds = gdal.GetDriverByName("GTiff").Create(
-        "tmp/test_gdalbuildvrt_11_2.tif", 10, 10, 1
-    )
-    out_ds.GetRasterBand(1).Fill(127)
-    cs2 = out_ds.GetRasterBand(1).Checksum()
-    out_ds = None
+    input_tif1 = str(tmp_path / "test_gdalbuildvrt_11_1.tif")
+    input_tif2 = str(tmp_path / "test_gdalbuildvrt_11_2.tif")
+
+    with gdal.GetDriverByName("GTiff").Create(input_tif1, 10, 10, 1) as out_ds:
+        out_ds.GetRasterBand(1).Fill(255)
+        cs1 = out_ds.GetRasterBand(1).Checksum()
+
+    with gdal.GetDriverByName("GTiff").Create(input_tif2, 10, 10, 1) as out_ds:
+        out_ds.GetRasterBand(1).Fill(127)
+        cs2 = out_ds.GetRasterBand(1).Checksum()
 
     gdaltest.runexternal(
-        gdalbuildvrt_path
-        + " -separate tmp/gdalbuildvrt11.vrt tmp/test_gdalbuildvrt_11_1.tif tmp/test_gdalbuildvrt_11_2.tif"
+        gdalbuildvrt_path + f" -separate {output_vrt} {input_tif1} {input_tif2}"
     )
 
-    ds = gdal.Open("tmp/gdalbuildvrt11.vrt")
+    with gdal.Open(output_vrt) as ds:
 
-    assert ds.GetRasterBand(1).Checksum() == cs1, "Wrong checksum"
+        assert ds.GetRasterBand(1).Checksum() == cs1, "Wrong checksum"
 
-    assert ds.GetRasterBand(2).Checksum() == cs2, "Wrong checksum"
-
-    ds = None
+        assert ds.GetRasterBand(2).Checksum() == cs2, "Wrong checksum"
 
 
 ###############################################################################
 # Test -tap option
 
 
-def test_gdalbuildvrt_12(gdalbuildvrt_path):
+def test_gdalbuildvrt_12(gdalbuildvrt_path, tmp_path):
+
+    output_vrt = str(tmp_path / "gdalbuildvrt12.vrt")
 
     (_, err) = gdaltest.runexternal_out_and_err(
-        gdalbuildvrt_path + " -tap tmp/gdalbuildvrt12.vrt ../gcore/data/byte.tif",
+        gdalbuildvrt_path + f" -tap {output_vrt} ../gcore/data/byte.tif",
         check_memleak=False,
     )
-    assert (
-        err.find("-tap option cannot be used without using -tr") != -1
-    ), "expected error"
+
+    assert "-tap option cannot be used without using -tr" in err, "expected error"
 
     gdaltest.runexternal(
-        gdalbuildvrt_path
-        + " -tr 100 50 -tap tmp/gdalbuildvrt12.vrt ../gcore/data/byte.tif"
+        gdalbuildvrt_path + f" -tr 100 50 -tap {output_vrt} ../gcore/data/byte.tif"
     )
 
-    ds = gdal.Open("tmp/gdalbuildvrt12.vrt")
+    ds = gdal.Open(output_vrt)
 
     gt = ds.GetGeoTransform()
     expected_gt = [440700.0, 100.0, 0.0, 3751350.0, 0.0, -50.0]
@@ -521,42 +515,45 @@ def test_gdalbuildvrt_12(gdalbuildvrt_path):
 # Test -a_srs
 
 
-def test_gdalbuildvrt_13(gdalbuildvrt_path):
+def test_gdalbuildvrt_13(gdalbuildvrt_path, tmp_path):
+
+    output_vrt = str(tmp_path / "gdalbuildvrt13.vrt")
 
     gdaltest.runexternal(
-        gdalbuildvrt_path
-        + " tmp/gdalbuildvrt13.vrt ../gcore/data/byte.tif -a_srs EPSG:4326"
+        gdalbuildvrt_path + f" {output_vrt} ../gcore/data/byte.tif -a_srs EPSG:4326"
     )
 
-    ds = gdal.Open("tmp/gdalbuildvrt13.vrt")
-    assert ds.GetProjectionRef().find("4326") != -1
-    ds = None
+    with gdal.Open(output_vrt) as ds:
+        assert "4326" in ds.GetProjectionRef()
 
 
 ###############################################################################
 # Test -r
 
 
-def test_gdalbuildvrt_14(gdalbuildvrt_path):
+def test_gdalbuildvrt_14(gdalbuildvrt_path, tmp_path):
     if test_cli_utilities.get_gdal_translate_path() is None:
         pytest.skip()
 
+    buildvrt_output_vrt = str(tmp_path / "test_gdalbuildvrt_14.vrt")
+
     gdaltest.runexternal(
         gdalbuildvrt_path
-        + " tmp/test_gdalbuildvrt_14.vrt ../gcore/data/byte.tif -r cubic -tr 30 30"
+        + f" {buildvrt_output_vrt} ../gcore/data/byte.tif -r cubic -tr 30 30"
     )
+
+    translate_output_vrt = str(tmp_path / "test_gdalbuildvrt_14_ref.vrt")
 
     gdaltest.runexternal(
         test_cli_utilities.get_gdal_translate_path()
-        + " -of VRT ../gcore/data/byte.tif tmp/test_gdalbuildvrt_14_ref.vrt -r cubic -outsize 40 40"
+        + f" -of VRT ../gcore/data/byte.tif {translate_output_vrt} -r cubic -outsize 40 40"
     )
 
-    ds = gdal.Open("tmp/test_gdalbuildvrt_14.vrt")
-    ds_ref = gdal.Open("tmp/test_gdalbuildvrt_14_ref.vrt")
-    cs = ds.GetRasterBand(1).Checksum()
-    cs_ref = ds_ref.GetRasterBand(1).Checksum()
-    ds = None
-    ds_ref = None
+    with gdal.Open(buildvrt_output_vrt) as ds:
+        cs = ds.GetRasterBand(1).Checksum()
+
+    with gdal.Open(translate_output_vrt) as ds_ref:
+        cs_ref = ds_ref.GetRasterBand(1).Checksum()
 
     assert cs == cs_ref
 
@@ -565,17 +562,16 @@ def test_gdalbuildvrt_14(gdalbuildvrt_path):
 # Test -b
 
 
-def test_gdalbuildvrt_15(gdalbuildvrt_path):
+def test_gdalbuildvrt_15(gdalbuildvrt_path, tmp_path):
+
+    output_vrt = str(tmp_path / "test_gdalbuildvrt_15.vrt")
 
     gdaltest.runexternal(
-        gdalbuildvrt_path + " tmp/test_gdalbuildvrt_15.vrt ../gcore/data/byte.tif -b 1"
+        gdalbuildvrt_path + f" {output_vrt}  ../gcore/data/byte.tif -b 1"
     )
 
-    ds = gdal.Open("tmp/test_gdalbuildvrt_15.vrt")
-    cs = ds.GetRasterBand(1).Checksum()
-    ds = None
-
-    assert cs == 4672
+    with gdal.Open(output_vrt) as ds:
+        assert ds.GetRasterBand(1).Checksum() == 4672
 
 
 ###############################################################################
@@ -594,45 +590,3 @@ def test_gdalbuildvrt_16(gdalbuildvrt_path):
     else:
         # We don't get the error code on Travis mingw
         assert "ERROR" in err, out
-
-
-###############################################################################
-# Cleanup
-
-
-def test_gdalbuildvrt_cleanup():
-
-    if gdalbuildvrt_path is None:
-        pytest.skip()
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/tileindex.shp")
-
-    gdal.GetDriverByName("VRT").Delete("tmp/mosaic.vrt")
-    gdal.GetDriverByName("VRT").Delete("tmp/mosaic2.vrt")
-    gdal.GetDriverByName("VRT").Delete("tmp/stacked.vrt")
-    gdal.GetDriverByName("VRT").Delete("tmp/gdalbuildvrt7.vrt")
-    gdal.GetDriverByName("VRT").Delete("tmp/gdalbuildvrt10.vrt")
-    gdal.GetDriverByName("VRT").Delete("tmp/gdalbuildvrt11.vrt")
-    gdal.GetDriverByName("VRT").Delete("tmp/gdalbuildvrt12.vrt")
-    gdal.GetDriverByName("VRT").Delete("tmp/gdalbuildvrt13.vrt")
-    gdal.GetDriverByName("VRT").Delete("tmp/test_gdalbuildvrt_14.vrt")
-    gdal.GetDriverByName("VRT").Delete("tmp/test_gdalbuildvrt_14_ref.vrt")
-    gdal.GetDriverByName("VRT").Delete("tmp/test_gdalbuildvrt_15.vrt")
-
-    drv = gdal.GetDriverByName("GTiff")
-
-    drv.Delete("tmp/gdalbuildvrt1.tif")
-    drv.Delete("tmp/gdalbuildvrt2.tif")
-    drv.Delete("tmp/gdalbuildvrt3.tif")
-    drv.Delete("tmp/gdalbuildvrt4.tif")
-    drv.Delete("tmp/gdalbuildvrt5.tif")
-    drv.Delete("tmp/vrtnull1.tif")
-    drv.Delete("tmp/vrtnull2.tif")
-    drv.Delete("tmp/test_gdalbuildvrt_10_1.tif")
-    drv.Delete("tmp/test_gdalbuildvrt_10_2.tif")
-    drv.Delete("tmp/test_gdalbuildvrt_11_1.tif")
-    drv.Delete("tmp/test_gdalbuildvrt_11_2.tif")
-    try:
-        os.remove("tmp/filelist.txt")
-    except OSError:
-        pass

--- a/autotest/utilities/test_gdaltindex.py
+++ b/autotest/utilities/test_gdaltindex.py
@@ -37,9 +37,13 @@ import test_cli_utilities
 
 from osgeo import gdal, ogr, osr
 
-pytestmark = pytest.mark.skipif(
-    test_cli_utilities.get_gdaltindex_path() is None, reason="gdaltindex not available"
-)
+pytestmark = [
+    pytest.mark.skipif(
+        test_cli_utilities.get_gdaltindex_path() is None,
+        reason="gdaltindex not available",
+    ),
+    pytest.mark.random_order(disabled=True),
+]
 
 
 @pytest.fixture()

--- a/autotest/utilities/test_gnmutils.py
+++ b/autotest/utilities/test_gnmutils.py
@@ -46,6 +46,7 @@ pytestmark = [
         test_cli_utilities.get_gnmanalyse_path() is None,
         reason="gnmanalyse not available",
     ),
+    pytest.mark.random_order(disabled=True),
 ]
 
 

--- a/autotest/utilities/test_nearblack.py
+++ b/autotest/utilities/test_nearblack.py
@@ -100,12 +100,7 @@ def test_nearblack_2(nearblack_path):
 
     ds = None
 
-
-###############################################################################
-# Set existing alpha band
-
-
-def test_nearblack_3(nearblack_path):
+    # Set existing alpha band
 
     shutil.copy("tmp/nearblack2.tif", "tmp/nearblack3.tif")
     gdaltest.runexternal(
@@ -165,12 +160,7 @@ def test_nearblack_5(nearblack_path):
 
     ds = None
 
-
-###############################################################################
-# Set existing mask band
-
-
-def test_nearblack_6(nearblack_path):
+    # Set existing mask band
 
     shutil.copy("tmp/nearblack5.tif", "tmp/nearblack6.tif")
     shutil.copy("tmp/nearblack5.tif.msk", "tmp/nearblack6.tif.msk")

--- a/autotest/utilities/test_ogrlineref.py
+++ b/autotest/utilities/test_ogrlineref.py
@@ -49,38 +49,36 @@ pytestmark = [
 ]
 
 
-@pytest.fixture()
+@pytest.fixture(scope="module")
 def ogrlineref_path():
     return test_cli_utilities.get_ogrlineref_path()
 
 
-###############################################################################
-# create test
+@pytest.fixture(scope="module")
+def parts_shp(ogrlineref_path, tmp_path_factory):
 
-
-def test_ogrlineref_1(ogrlineref_path):
-
-    if os.path.exists("tmp/parts.shp"):
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/parts.shp")
+    parts_shp_fname = str(tmp_path_factory.mktemp("tmp") / "parts.shp")
 
     _, err = gdaltest.runexternal_out_and_err(
         ogrlineref_path
-        + " -create -l data/path.shp -p data/mstones.shp -pm pos -o tmp/parts.shp -s 1000"
+        + f" -create -l data/path.shp -p data/mstones.shp -pm pos -o {parts_shp_fname} -s 1000"
     )
     assert err is None or err == "", 'got error/warning: "%s"' % err
 
-    ds = ogr.Open("tmp/parts.shp")
-    assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 9
+    with ogr.Open(parts_shp_fname) as ds:
+        assert ds.GetLayer(0).GetFeatureCount() == 9
+
+    yield parts_shp_fname
 
 
 ###############################################################################
 # get_pos test
 
 
-def test_ogrlineref_2(ogrlineref_path):
+def test_ogrlineref_2(ogrlineref_path, parts_shp):
 
     ret = gdaltest.runexternal(
-        ogrlineref_path + " -get_pos -r tmp/parts.shp -x -1.4345 -y 51.9497 -quiet"
+        ogrlineref_path + f" -get_pos -r {parts_shp} -x -1.4345 -y 51.9497 -quiet"
     ).strip()
 
     expected = "15977.724709"
@@ -91,10 +89,10 @@ def test_ogrlineref_2(ogrlineref_path):
 # get_coord test
 
 
-def test_ogrlineref_3(ogrlineref_path):
+def test_ogrlineref_3(ogrlineref_path, parts_shp):
 
     ret = gdaltest.runexternal(
-        ogrlineref_path + " -get_coord -r tmp/parts.shp -m 15977.724709 -quiet"
+        ogrlineref_path + f" -get_coord -r {parts_shp} -m 15977.724709 -quiet"
     ).strip()
 
     expected = "-1.435097,51.950080,0.000000"
@@ -105,14 +103,14 @@ def test_ogrlineref_3(ogrlineref_path):
 # get_subline test
 
 
-def test_ogrlineref_4(ogrlineref_path):
+def test_ogrlineref_4(ogrlineref_path, parts_shp):
 
     if os.path.exists("tmp/subline.shp"):
         ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/subline.shp")
 
     gdaltest.runexternal(
         ogrlineref_path
-        + " -get_subline -r tmp/parts.shp -mb 13300 -me 17400 -o tmp/subline.shp"
+        + f" -get_subline -r {parts_shp} -mb 13300 -me 17400 -o tmp/subline.shp"
     )
 
     ds = ogr.Open("tmp/subline.shp")
@@ -129,24 +127,16 @@ def test_ogrlineref_4(ogrlineref_path):
 # test kml
 
 
-def test_ogrlineref_5(ogrlineref_path):
+def test_ogrlineref_5(ogrlineref_path, tmp_path):
+
+    parts_kml = str(tmp_path / "parts.kml")
 
     if os.path.exists("tmp/parts.kml"):
         ogr.GetDriverByName("KML").DeleteDataSource("tmp/parts.kml")
 
     gdaltest.runexternal_out_and_err(
         ogrlineref_path
-        + ' -create -f "KML" -l data/path.shp -p data/mstones.shp -pm pos -o tmp/parts.kml -s 222'
+        + f' -create -f "KML" -l data/path.shp -p data/mstones.shp -pm pos -o {parts_kml} -s 222'
     )
-    if os.path.exists("tmp/parts.kml"):
-        return
 
-    pytest.fail()
-
-
-def test_ogrlineref_cleanup():
-
-    if os.path.exists("tmp/parts.shp"):
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/parts.shp")
-    if os.path.exists("tmp/parts.kml"):
-        ogr.GetDriverByName("KML").DeleteDataSource("tmp/parts.kml")
+    assert os.path.exists(parts_kml)

--- a/autotest/utilities/test_ogrtindex.py
+++ b/autotest/utilities/test_ogrtindex.py
@@ -48,6 +48,22 @@ def ogrtindex_path():
     return test_cli_utilities.get_ogrtindex_path()
 
 
+@pytest.fixture(scope="module", autouse=True)
+def setup_and_cleanup():
+
+    yield
+
+    shape_drv = ogr.GetDriverByName("ESRI Shapefile")
+    if os.path.exists("tmp/tileindex.shp"):
+        shape_drv.DeleteDataSource("tmp/tileindex.shp")
+    shape_drv.DeleteDataSource("tmp/point1.shp")
+    shape_drv.DeleteDataSource("tmp/point2.shp")
+    if os.path.exists("tmp/point3.shp"):
+        shape_drv.DeleteDataSource("tmp/point3.shp")
+    if os.path.exists("tmp/point4.shp"):
+        shape_drv.DeleteDataSource("tmp/point4.shp")
+
+
 ###############################################################################
 # Simple test
 
@@ -246,20 +262,3 @@ def test_ogrtindex_3(ogrtindex_path):
         shape_drv.DeleteDataSource("tmp/tileindex.shp")
     if os.path.exists("tmp/tileindex.db"):
         os.unlink("tmp/tileindex.db")
-
-
-###############################################################################
-# Cleanup
-
-
-def test_ogrtindex_cleanup():
-
-    shape_drv = ogr.GetDriverByName("ESRI Shapefile")
-    if os.path.exists("tmp/tileindex.shp"):
-        shape_drv.DeleteDataSource("tmp/tileindex.shp")
-    shape_drv.DeleteDataSource("tmp/point1.shp")
-    shape_drv.DeleteDataSource("tmp/point2.shp")
-    if os.path.exists("tmp/point3.shp"):
-        shape_drv.DeleteDataSource("tmp/point3.shp")
-    if os.path.exists("tmp/point4.shp"):
-        shape_drv.DeleteDataSource("tmp/point4.shp")

--- a/cmake/template/pytest.ini.in
+++ b/cmake/template/pytest.ini.in
@@ -19,6 +19,7 @@ env =
 gdal_version = @GDAL_VERSION_NO_DEV_SUFFIX@
 
 markers =
+    random_order: Indicates whether tests can be run non-sequentially
     require_curl: Skip test(s) if curl support is absent
     require_creation_option: Skip test(s) if required creation option is not available
     require_driver: Skip test(s) if driver isn't present

--- a/swig/python/gdal-utils/osgeo_utils/gdal_pansharpen.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_pansharpen.py
@@ -277,8 +277,13 @@ def gdal_pansharpen(
         ms_name = spectral_ds[i].GetDescription()
         if driver_name.upper() == "VRT":
             if not os.path.isabs(ms_name):
-                ms_relative = "1"
-                ms_name = os.path.relpath(ms_name, os.path.dirname(dst_filename))
+                try:
+                    ms_name = os.path.relpath(ms_name, os.path.dirname(dst_filename))
+                    ms_relative = "1"
+                except ValueError:
+                    # Thrown if generating a relative path is not possible, e.g. if
+                    # ms_name is on a different Windows drive from dst_filename
+                    pass
 
         vrt_xml += """    <SpectralBand%s>
       <SourceFilename relativeToVRT="%s">%s</SourceFilename>


### PR DESCRIPTION
## What does this PR do?

This PR makes tests under the `utilities` and `pyscripts` folders run independently, using the following types of changes:

- Pulling out generated data that is used by multiple tests into module-scoped fixtures.

- Moving cleanup steps from a dummy test into a fixture, or in some cases writing generated files to a location provided by `tmp_path` to avoid the need for a cleanup fixture. The `tmp_path` method is more invasive but probably easier for understand, so it might be worth doing this in all cases.

- Merging tests, occasionally, such as a test that writes a file followed by a test that reads the file.

-  Flagging tests as non-independent using the `random_order(disabled=True)` marker (44b24c8c656d23112bb9ff0ea3852be3ae7fdcb5).
   These will need to be addressed eventually if we want to run the tests in parallel.

While I was in there, I also split and parameterized some tests (2062341495720874bda7624fd3904ba9d237c359)

## What are related issues/pull requests?

#4407

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
