### PR TITLE
Ccache.cmake: fix warning

### DIFF
--- a/cmake/modules/Ccache.cmake
+++ b/cmake/modules/Ccache.cmake
@@ -7,7 +7,7 @@
 # Add "include(Ccache)" to CMakeLists.txt and enable
 # using the option -D USE_CCACHE=ON
 
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.4...3.23)
 
 
 option(USE_CCACHE


### PR DESCRIPTION
should fix the following warning (as reported in
https://github.com/OSGeo/gdal/issues/8105)
```
CMake Deprecation Warning at cmake/modules/Ccache.cmake:10 (cmake_minimum_required):
Compatibility with CMake < 3.5 will be removed from a future version of
CMake.

Update the VERSION argument value or use a ... suffix to tell
CMake that the project does not need compatibility with older versions.
Call Stack (most recent call first):
CMakeLists.txt:58 (include)
```
