### PR TITLE
[Backport release/3.7] gdal2tiles: fix exception with dataset in EPSG:4326 with longitudes > 180 in WebMercator profile (fixes #8100)

### DIFF
--- a/autotest/pyscripts/gdal2tiles/test_reproject_dataset.py
+++ b/autotest/pyscripts/gdal2tiles/test_reproject_dataset.py
@@ -31,6 +31,8 @@
 
 from unittest import TestCase, mock
 
+import pytest
+
 from osgeo import gdal, osr
 from osgeo_utils import gdal2tiles
 
@@ -53,6 +55,7 @@ class ReprojectDatasetTest(TestCase):
         self.mercator_srs = osr.SpatialReference()
         self.mercator_srs.ImportFromEPSG(3857)
         self.geodetic_srs = osr.SpatialReference()
+        self.geodetic_srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
         self.geodetic_srs.ImportFromEPSG(4326)
 
     def test_raises_if_no_from_or_to_srs(self):
@@ -83,4 +86,23 @@ class ReprojectDatasetTest(TestCase):
 
         mock_gdal.AutoCreateWarpedVRT.assert_called_with(
             from_ds, self.mercator_srs.ExportToWkt(), self.geodetic_srs.ExportToWkt()
+        )
+
+    def test_4326_to_3857_longitude_beyond_180(self):
+        from_ds = gdal.GetDriverByName("MEM").Create("", 10, 10)
+        from_ds.SetGeoTransform([-180, 36.01, 0, 90, 0, -18])
+        to_ds = gdal2tiles.reproject_dataset(
+            from_ds, self.geodetic_srs, self.mercator_srs
+        )
+        assert to_ds.RasterXSize == 13
+        assert to_ds.RasterYSize == 13
+        assert to_ds.GetGeoTransform() == pytest.approx(
+            (
+                -20037508.342789244,
+                3082693.591198345,
+                0.0,
+                20037508.342789248,
+                0.0,
+                -3082693.5911983456,
+            )
         )

--- a/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
@@ -1086,10 +1086,18 @@ def reproject_dataset(
         ):
             from_gt = from_dataset.GetGeoTransform(can_return_null=True)
             if from_gt and from_gt[2] == 0 and from_gt[4] == 0 and from_gt[5] < 0:
+                minlon = from_gt[0]
+                maxlon = from_gt[0] + from_dataset.RasterXSize * from_gt[1]
                 maxlat = from_gt[3]
                 minlat = from_gt[3] + from_dataset.RasterYSize * from_gt[5]
                 MAX_LAT = 85.0511287798066
                 adjustBounds = False
+                if minlon < -180.0:
+                    minlon = -180.0
+                    adjustBounds = True
+                if maxlon > 180.0:
+                    maxlon = 180.0
+                    adjustBounds = True
                 if maxlat > MAX_LAT:
                     maxlat = MAX_LAT
                     adjustBounds = True
@@ -1098,15 +1106,14 @@ def reproject_dataset(
                     adjustBounds = True
                 if adjustBounds:
                     ct = osr.CoordinateTransformation(from_srs, to_srs)
-                    west, south = ct.TransformPoint(from_gt[0], minlat)[:2]
-                    east, north = ct.TransformPoint(
-                        from_gt[0] + from_dataset.RasterXSize * from_gt[1], maxlat
-                    )[:2]
+                    west, south = ct.TransformPoint(minlon, minlat)[:2]
+                    east, north = ct.TransformPoint(maxlon, maxlat)[:2]
                     return gdal.Warp(
                         "",
                         from_dataset,
                         format="VRT",
                         outputBounds=[west, south, east, north],
+                        srcSRS=from_srs.ExportToWkt(),
                         dstSRS="EPSG:3857",
                     )
 


### PR DESCRIPTION
Backport #8104
 **Authored by:** @rouault