### PR TITLE
[Backport release/3.7] STACIT: correctly process asset 'href' starting with 'file://' (fixes #8135)

### DIFF
--- a/autotest/gdrivers/data/stacit/test_page2.json
+++ b/autotest/gdrivers/data/stacit/test_page2.json
@@ -31,7 +31,7 @@
               "full_width_half_max": 0.027
             }
           ],
-          "href": "data/int16.tif",
+          "href": "file://data/int16.tif",
           "proj:epsg": 26711,
           "proj:shape": [
             20,

--- a/frmts/stacit/stacitdataset.cpp
+++ b/frmts/stacit/stacitdataset.cpp
@@ -519,6 +519,10 @@ bool STACITDataset::SetupDataset(
                 osRet += osFilename;
             }
         }
+        else if (STARTS_WITH(osFilename.c_str(), "file://"))
+        {
+            osRet = osFilename.substr(strlen("file://"));
+        }
         else
         {
             osRet = osFilename;


### PR DESCRIPTION
Backport #8136
 **Authored by:** @rouault