### PR TITLE
SWIG bindings: fix warning related to redefinition of CPLErr

### DIFF
--- a/swig/include/gnm.i
+++ b/swig/include/gnm.i
@@ -109,7 +109,6 @@ typedef struct OGRGeomFieldDefnHS OGRGeomFieldDefnShadow;
 
 
 typedef int GNMDirection;
-typedef int CPLErr;
 
 //************************************************************************
 //

--- a/swig/include/ogr.i
+++ b/swig/include/ogr.i
@@ -619,6 +619,7 @@ typedef int OGRErr;
 %{
 #include "gdal.h"
 %}
+typedef int CPLErr;
 #define FROM_PYTHON_OGR_I
 %include MajorObject.i
 #undef FROM_PYTHON_OGR_I


### PR DESCRIPTION
This actually ammends be9f8da7b466cb78ecafc4edf66c1838c81e4425 which caused warnings about missing destructor for "CPLErr*" when running Python OGR scripts
