### PR TITLE
WFS: Don't issue STARTINDEX if feature count is small

### DIFF
--- a/doc/source/drivers/vector/wfs.rst
+++ b/doc/source/drivers/vector/wfs.rst
@@ -108,6 +108,12 @@ If only the N first features must be downloaded and paging through the whole
 layer is not desirable, the :config:`OGR_WFS_PAGING_ALLOWED`
 configuration option should be set to OFF.
 
+Starting with GDAL 3.8, if the feature count is already known before
+fetching the first feature, and the feature count is less than the page
+size, then the WFS driver will not use paging (no ``STARTINDEX`` parameter
+will be used in the requests). (This behavior improves compatibility with
+Geoserver when datasources with no primary key.)
+
 Paging with WFS 1.0 or 1.1
 ++++++++++++++++++++++++++
 


### PR DESCRIPTION

## What does this PR do?

WFS datasources with no primary key cannot be naturally ordered by the server, and so using the STARTINDEX argument causes a 400 error with the response:

> Cannot do natural order without a primary key, please add it or
> specify a manual sort over existing attributes

An example is here: https://geo.irceline.be/wfs?request=GetFeature&version=2.0.0&service=WFS&TYPENAMES=bc_24hmean&COUNT=1000000&STARTINDEX=0

This change avoids issuing `STARTINDEX` if:
* the feature count is known by the time the first GetFeature request is issued
* the feature count is less than the page size.

In other words, this change allows us to use small datasets that have no primary key, while still allowing paging in larger datasets (as long as they have a primary key)

### What's not included

1. In the gdal-dev post, @rouault suggested adding a new value to the existing `OGR_WFS_PAGING_ALLOWED` (`COUNT_WITH_HITS`) in addition to the existing boolean values. I attempted to implement that but quickly came up against infinite recursion, since this makes `MakeGetFeatureURL` call `GetFeatureCount` which in turn eventually calls `MakeGetFeatureURL`. I decided to skip that complication for this PR, which is still useful in most circumstances without it. The WIP change is [here](https://github.com/OSGeo/gdal/compare/master...koordinates:gdal:wfs-disable-paging-check-with-hits) if you want to see it.
2. ~Tests.~ I've now included a test

## What are related issues/pull requests?

As discussed in [gdal-dev](https://lists.osgeo.org/pipermail/gdal-dev/2023-May/057174.html) a month ago

## Tasklist

 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
