### PR TITLE
[Backport release/3.7] XLS: avoid compiler warning when building against freexl 2.0

### DIFF
--- a/ogr/ogrsf_frmts/xls/include_freexl.h
+++ b/ogr/ogrsf_frmts/xls/include_freexl.h
@@ -1,0 +1,44 @@
+/******************************************************************************
+ * $Id$
+ *
+ * Project:  XLS Translator
+ * Purpose:  Include freexl.h
+ * Author:   Even Rouault, even dot rouault at spatialys.com
+ *
+ ******************************************************************************
+ * Copyright (c) 2011-2012, Even Rouault <even dot rouault at spatialys.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#ifndef INCLUDE_FREEXL_H_INCLUDED
+#define INCLUDE_FREEXL_H_INCLUDED
+
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdocumentation"
+#endif
+
+#include <freexl.h>
+
+#ifdef __clang
+#pragma clang diagnostic pop
+#endif
+
+#endif  // INCLUDE_FREEXL_H_INCLUDED

--- a/ogr/ogrsf_frmts/xls/ogrxlsdatasource.cpp
+++ b/ogr/ogrsf_frmts/xls/ogrxlsdatasource.cpp
@@ -26,7 +26,7 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
-#include <freexl.h>
+#include "include_freexl.h"
 
 #ifdef _WIN32
 #include <windows.h>

--- a/ogr/ogrsf_frmts/xls/ogrxlslayer.cpp
+++ b/ogr/ogrsf_frmts/xls/ogrxlslayer.cpp
@@ -26,7 +26,7 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
-#include <freexl.h>
+#include "include_freexl.h"
 
 #include "ogr_xls.h"
 #include "cpl_conv.h"


### PR DESCRIPTION
Backport #8156
 **Authored by:** @rouault