### PR TITLE
STACIT: apply vsis3 protocol to  s3:// items

### DIFF
--- a/frmts/stacit/stacitdataset.cpp
+++ b/frmts/stacit/stacitdataset.cpp
@@ -516,6 +516,12 @@ bool STACITDataset::SetupDataset(
         {
             osRet = osFilename.substr(strlen("file://"));
         }
+        else if (STARTS_WITH(osFilename.c_str(), "s3://"))
+        {
+            osRet = "/vsis3/";
+            osRet += osFilename.substr(strlen("s3://"));
+        }
+
         else
         {
             osRet = osFilename;


### PR DESCRIPTION
Apply the `/vsis3/` prefix to data sources found within STACIT that are prefixed `s3://`. 

Addresses this mailing list item: https://lists.osgeo.org/pipermail/gdal-dev/2023-August/057524.html


I've had good results with this

```
gdalinfo --config AWS_NO_SIGN_REQUEST "YES"  "STACIT:\"https://explorer.sandbox.dea.ga.gov.au/stac/search?collections=ga_ls_landcover_class_cyear_2&bbox=122.1,-18.28,122.48,-17.91&datetime=2020-01-01/2020-02-29\":asset=level3"
```

EDIT: (putting 'collections' in the search args rather than the dsn args is *much* faster)

## Tasklist

 - [x] no test cases (too flaky for ephemeral sources, needs local simulation)
 - [x] Review
 - [x] Adjust for comments
 - [x] All CI builds and checks have passed

