### PR TITLE
CMakeLists.txt: update maximum range to 3.27

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # CMake4GDAL project is distributed under MIT license. See accompanying file LICENSE.txt.
-cmake_minimum_required(VERSION 3.9...3.23)
+cmake_minimum_required(VERSION 3.9...3.27)
 
 project(gdal LANGUAGES C CXX)
 include(CTest)


### PR DESCRIPTION
should fix
```
CMake Error (dev) at cmake/modules/thirdparty/FindCSharp.cmake:40 (find_package):
  Policy CMP0144 is not set: find_package uses upper-case <PACKAGENAME>_ROOT
  variables.  Run "cmake --help-policy CMP0144" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.

  Environment variable DOTNET_ROOT is set to:

    /Users/runner/.dotnet

  For compatibility, find_package is ignoring the variable, but code in a
  .cmake module might still use it.
Call Stack (most recent call first):
  cmake/helpers/CheckDependentLibraries.cmake:793 (find_package)
  gdal.cmake:265 (include)
  CMakeLists.txt:246 (include)
```
of https://github.com/OSGeo/gdal/actions/runs/5798527630/job/15716491404
