### PR TITLE
[Backport release/3.7] /vsiaz/: fix cached URL names when listing /vsiaz/

### DIFF
--- a/autotest/gcore/vsiaz.py
+++ b/autotest/gcore/vsiaz.py
@@ -389,6 +389,8 @@ def test_vsiaz_fake_readdir():
         dir_contents = gdal.ReadDir("/vsiaz/")
     assert dir_contents == ["mycontainer1", "mycontainer2"]
 
+    assert gdal.VSIStatL("/vsiaz/mycontainer1", gdal.VSI_STAT_CACHE_ONLY) is not None
+
 
 ###############################################################################
 # Test AZURE_STORAGE_SAS_TOKEN option with fake server

--- a/port/cpl_vsil_az.cpp
+++ b/port/cpl_vsil_az.cpp
@@ -379,7 +379,9 @@ bool VSIDIRAz::IssueListDir()
     }
 
     poHandleHelper->ResetQueryParameters();
-    const CPLString osBaseURL(poHandleHelper->GetURLNoKVP());
+    std::string osBaseURL(poHandleHelper->GetURLNoKVP());
+    if (osBaseURL.back() == '/')
+        osBaseURL.pop_back();
 
     CURL *hCurlHandle = curl_easy_init();
 


### PR DESCRIPTION
Backport #8181
 **Authored by:** @rouault