### PR TITLE
VRT: ignore <OverviewList> when external .vrt.ovr is present, as documented and intended

### DIFF
--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -201,6 +201,7 @@ class CPL_DLL VRTDataset CPL_NON_FINAL : public GDALDataset
     // when it is cheap to do it, or explicitly.
     std::vector<GDALDataset *> m_apoOverviews{};
     std::vector<GDALDataset *> m_apoOverviewsBak{};
+    CPLStringList m_aosOverviewList{};  // only temporarily set during Open()
     CPLString m_osOverviewResampling{};
     std::vector<int> m_anOverviewFactors{};
 


### PR DESCRIPTION
(not appropriate for 3.7 backport due to VRTDataset ABI change)