### PR TITLE
autotest: Use tmp_path fixture for utilities tests

### DIFF
--- a/autotest/utilities/test_gdal_create.py
+++ b/autotest/utilities/test_gdal_create.py
@@ -55,15 +55,17 @@ def gdal_create_path():
 ###############################################################################
 
 
-def test_gdal_create_pdf_tif(gdal_create_path):
+def test_gdal_create_pdf_tif(gdal_create_path, tmp_path):
+
+    output_tif = str(tmp_path / "tmp.tif")
 
     (_, err) = gdaltest.runexternal_out_and_err(
         gdal_create_path
-        + " tmp/tmp.tif -bands 3 -outsize 1 2 -a_srs EPSG:4326 -a_ullr 2 50 3 49 -a_nodata 5 -burn 1 2 -ot UInt16 -co COMPRESS=DEFLATE -mo FOO=BAR"
+        + f" {output_tif} -bands 3 -outsize 1 2 -a_srs EPSG:4326 -a_ullr 2 50 3 49 -a_nodata 5 -burn 1 2 -ot UInt16 -co COMPRESS=DEFLATE -mo FOO=BAR"
     )
     assert err is None or err == "", "got error/warning"
 
-    ds = gdal.Open("tmp/tmp.tif")
+    ds = gdal.Open(output_tif)
     assert ds.RasterCount == 3
     assert ds.RasterXSize == 1
     assert ds.RasterYSize == 2
@@ -78,21 +80,21 @@ def test_gdal_create_pdf_tif(gdal_create_path):
     assert ds.GetMetadataItem("FOO") == "BAR"
     ds = None
 
-    os.unlink("tmp/tmp.tif")
-
 
 ###############################################################################
 
 
 @pytest.mark.require_driver("PNG")
-def test_gdal_create_pdf_no_direct_write_capabilities(gdal_create_path):
+def test_gdal_create_pdf_no_direct_write_capabilities(gdal_create_path, tmp_path):
+
+    output_png = str(tmp_path / "tmp.png")
 
     (_, err) = gdaltest.runexternal_out_and_err(
-        gdal_create_path + " tmp/tmp.png -of PNG -outsize 1 2"
+        gdal_create_path + f" {output_png} -of PNG -outsize 1 2"
     )
     assert err is None or err == "", "got error/warning"
 
-    ds = gdal.Open("tmp/tmp.png")
+    ds = gdal.Open(output_png)
     assert ds.RasterCount == 1
     assert ds.RasterXSize == 1
     assert ds.RasterYSize == 2
@@ -103,8 +105,6 @@ def test_gdal_create_pdf_no_direct_write_capabilities(gdal_create_path):
     assert ds.GetRasterBand(1).Checksum() == 0
     ds = None
 
-    os.unlink("tmp/tmp.png")
-
 
 ###############################################################################
 
@@ -114,9 +114,12 @@ def test_gdal_create_pdf_no_direct_write_capabilities(gdal_create_path):
     or gdal.GetDriverByName("PDF").GetMetadataItem("HAVE_POPPLER") is None,
     reason="Poppler PDF support missing",
 )
-def test_gdal_create_pdf_composition(gdal_create_path):
+def test_gdal_create_pdf_composition(gdal_create_path, tmp_path):
 
-    open("tmp/tmp.xml", "wt").write(
+    tmp_xml = str(tmp_path / "tmp.xml")
+    tmp_pdf = str(tmp_path / "tmp.pdf")
+
+    open(tmp_xml, "wt").write(
         """<PDFComposition>
     <Page>
         <DPI>72</DPI>
@@ -132,14 +135,11 @@ def test_gdal_create_pdf_composition(gdal_create_path):
     )
 
     (_, err) = gdaltest.runexternal_out_and_err(
-        gdal_create_path + " tmp/tmp.pdf -co COMPOSITION_FILE=tmp/tmp.xml"
+        gdal_create_path + f" {tmp_pdf} -co COMPOSITION_FILE={tmp_xml}"
     )
-    os.unlink("tmp/tmp.xml")
     assert err is None or err == "", "got error/warning"
 
-    assert os.path.exists("tmp/tmp.pdf")
-
-    os.unlink("tmp/tmp.pdf")
+    assert os.path.exists(tmp_pdf)
 
 
 ###############################################################################
@@ -157,29 +157,31 @@ def test_gdal_create_not_write_driver(gdal_create_path):
 ###############################################################################
 
 
-def test_gdal_create_input_file_invalid(gdal_create_path):
+def test_gdal_create_input_file_invalid(gdal_create_path, tmp_path):
 
     (_, err) = gdaltest.runexternal_out_and_err(
-        gdal_create_path + " tmp/tmp.tif -if ../gdrivers/data/i_do_not_exist"
+        f"{gdal_create_path} {tmp_path}/tmp.tif -if ../gdrivers/data/i_do_not_exist"
     )
     assert err != ""
 
-    assert not os.path.exists("tmp/tmp.tif")
+    assert not os.path.exists(f"{tmp_path}/tmp.tif")
 
 
 ###############################################################################
 
 
-def test_gdal_create_input_file(gdal_create_path):
+def test_gdal_create_input_file(gdal_create_path, tmp_path):
+
+    output_tif = str(tmp_path / "tmp.tif")
 
     (_, err) = gdaltest.runexternal_out_and_err(
-        gdal_create_path + " tmp/tmp.tif -if ../gdrivers/data/small_world.tif"
+        gdal_create_path + f" {output_tif} -if ../gdrivers/data/small_world.tif"
     )
     assert err is None or err == "", "got error/warning"
 
-    assert os.path.exists("tmp/tmp.tif")
+    assert os.path.exists(output_tif)
 
-    ds = gdal.Open("tmp/tmp.tif")
+    ds = gdal.Open(output_tif)
     ref_ds = gdal.Open("../gdrivers/data/small_world.tif")
     assert ds.RasterCount == ref_ds.RasterCount
     assert ds.RasterXSize == ref_ds.RasterXSize
@@ -189,23 +191,23 @@ def test_gdal_create_input_file(gdal_create_path):
     assert ds.GetProjectionRef() == ref_ds.GetProjectionRef()
     ds = None
 
-    os.unlink("tmp/tmp.tif")
-
 
 ###############################################################################
 
 
-def test_gdal_create_input_file_overrrides(gdal_create_path):
+def test_gdal_create_input_file_overrrides(gdal_create_path, tmp_path):
+
+    output_tif = str(tmp_path / "tmp.tif")
 
     (_, err) = gdaltest.runexternal_out_and_err(
         gdal_create_path
-        + " tmp/tmp.tif -if ../gdrivers/data/small_world.tif -bands 2 -outsize 1 3 -a_nodata 1"
+        + f" {output_tif} -if ../gdrivers/data/small_world.tif -bands 2 -outsize 1 3 -a_nodata 1"
     )
     assert err is None or err == "", "got error/warning"
 
-    assert os.path.exists("tmp/tmp.tif")
+    assert os.path.exists(output_tif)
 
-    ds = gdal.Open("tmp/tmp.tif")
+    ds = gdal.Open(output_tif)
     ref_ds = gdal.Open("../gdrivers/data/small_world.tif")
     assert ds.RasterCount == 2
     assert ds.RasterXSize == 1
@@ -214,5 +216,3 @@ def test_gdal_create_input_file_overrrides(gdal_create_path):
     assert ds.GetGeoTransform() == ref_ds.GetGeoTransform()
     assert ds.GetProjectionRef() == ref_ds.GetProjectionRef()
     ds = None
-
-    os.unlink("tmp/tmp.tif")

--- a/autotest/utilities/test_gdal_footprint.py
+++ b/autotest/utilities/test_gdal_footprint.py
@@ -34,7 +34,7 @@ import ogrtest
 import pytest
 import test_cli_utilities
 
-from osgeo import gdal, ogr
+from osgeo import ogr
 
 pytestmark = [
     pytest.mark.require_geos,
@@ -53,18 +53,16 @@ def gdal_footprint_path():
 ###############################################################################
 
 
-def test_gdal_footprint_basic(gdal_footprint_path):
+def test_gdal_footprint_basic(gdal_footprint_path, tmp_path):
 
-    if gdal.VSIStatL("tmp/out_footprint.json"):
-        gdal.Unlink("tmp/out_footprint.json")
+    footprint_json = str(tmp_path / "out_footprint.json")
 
     (_, err) = gdaltest.runexternal_out_and_err(
-        gdal_footprint_path
-        + " -f GeoJSON ../gcore/data/byte.tif tmp/out_footprint.json"
+        gdal_footprint_path + f" -f GeoJSON ../gcore/data/byte.tif {footprint_json}"
     )
     assert err is None or err == "", "got error/warning"
 
-    ds = ogr.Open("tmp/out_footprint.json")
+    ds = ogr.Open(footprint_json)
     assert ds is not None
     lyr = ds.GetLayer(0)
     assert lyr.GetFeatureCount() == 1
@@ -76,28 +74,25 @@ def test_gdal_footprint_basic(gdal_footprint_path):
 
     ds = None
 
-    gdal.Unlink("tmp/out_footprint.json")
-
 
 ###############################################################################
 
 
-def test_gdal_footprint_appending(gdal_footprint_path):
+def test_gdal_footprint_appending(gdal_footprint_path, tmp_path):
 
-    if gdal.VSIStatL("tmp/out_footprint.shp"):
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/out_footprint.shp")
+    footprint_shp = str(tmp_path / "out_footprint.shp")
 
     (_, err) = gdaltest.runexternal_out_and_err(
-        gdal_footprint_path + " ../gcore/data/byte.tif tmp/out_footprint.shp"
+        gdal_footprint_path + f" ../gcore/data/byte.tif {footprint_shp}"
     )
     assert err is None or err == "", "got error/warning"
 
     (_, err) = gdaltest.runexternal_out_and_err(
-        gdal_footprint_path + " ../gcore/data/byte.tif tmp/out_footprint.shp"
+        gdal_footprint_path + f" ../gcore/data/byte.tif {footprint_shp}"
     )
     assert err is None or err == "", "got error/warning"
 
-    ds = ogr.Open("tmp/out_footprint.shp")
+    ds = ogr.Open(footprint_shp)
     assert ds is not None
     lyr = ds.GetLayer(0)
     assert lyr.GetFeatureCount() == 2
@@ -114,28 +109,25 @@ def test_gdal_footprint_appending(gdal_footprint_path):
 
     ds = None
 
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/out_footprint.shp")
-
 
 ###############################################################################
 
 
-def test_gdal_footprint_overwrite(gdal_footprint_path):
+def test_gdal_footprint_overwrite(gdal_footprint_path, tmp_path):
 
-    if gdal.VSIStatL("tmp/out_footprint.shp"):
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/out_footprint.shp")
+    footprint_shp = str(tmp_path / "out_footprint.shp")
 
     (_, err) = gdaltest.runexternal_out_and_err(
-        gdal_footprint_path + " ../gcore/data/byte.tif tmp/out_footprint.shp"
+        gdal_footprint_path + f" ../gcore/data/byte.tif {footprint_shp}"
     )
     assert err is None or err == "", "got error/warning"
 
     (_, err) = gdaltest.runexternal_out_and_err(
-        gdal_footprint_path + " -overwrite ../gcore/data/byte.tif tmp/out_footprint.shp"
+        gdal_footprint_path + f" -overwrite ../gcore/data/byte.tif {footprint_shp}"
     )
     assert err is None or err == "", "got error/warning"
 
-    ds = ogr.Open("tmp/out_footprint.shp")
+    ds = ogr.Open(footprint_shp)
     assert ds is not None
     lyr = ds.GetLayer(0)
     assert lyr.GetFeatureCount() == 1
@@ -146,8 +138,6 @@ def test_gdal_footprint_overwrite(gdal_footprint_path):
     )
 
     ds = None
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/out_footprint.shp")
 
 
 ###############################################################################

--- a/autotest/utilities/test_gdal_rasterize.py
+++ b/autotest/utilities/test_gdal_rasterize.py
@@ -30,7 +30,6 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
-import os
 import sys
 
 import pytest
@@ -57,7 +56,10 @@ def gdal_rasterize_path():
 # Simple polygon rasterization (adapted from alg/rasterize.py).
 
 
-def test_gdal_rasterize_1(gdal_rasterize_path):
+def test_gdal_rasterize_1(gdal_rasterize_path, tmp_path):
+
+    output_tif = str(tmp_path / "rast1.tif")
+    input_tab = str(tmp_path / "rast1.tab")
 
     # Setup working spatial reference
     # sr_wkt = 'LOCAL_CS["arbitrary"]'
@@ -69,7 +71,7 @@ def test_gdal_rasterize_1(gdal_rasterize_path):
     # Create a raster to rasterize into.
 
     target_ds = gdal.GetDriverByName("GTiff").Create(
-        "tmp/rast1.tif", 100, 100, 3, gdal.GDT_Byte
+        output_tif, 100, 100, 3, gdal.GDT_Byte
     )
     target_ds.SetGeoTransform((1000, 1, 0, 1100, 0, -1))
     target_ds.SetProjection(sr_wkt)
@@ -79,7 +81,7 @@ def test_gdal_rasterize_1(gdal_rasterize_path):
 
     # Create a layer to rasterize from.
 
-    rast_ogr_ds = ogr.GetDriverByName("MapInfo File").CreateDataSource("tmp/rast1.tab")
+    rast_ogr_ds = ogr.GetDriverByName("MapInfo File").CreateDataSource(input_tab)
     rast_lyr = rast_ogr_ds.CreateLayer("rast1", srs=sr)
 
     rast_lyr.GetLayerDefn()
@@ -113,22 +115,18 @@ def test_gdal_rasterize_1(gdal_rasterize_path):
 
     # Run the algorithm.
     (_, err) = gdaltest.runexternal_out_and_err(
-        gdal_rasterize_path
-        + " -b 3 -b 2 -b 1 -burn 200 -burn 220 -burn 240 -l rast1 tmp/rast1.tab tmp/rast1.tif"
+        f"{gdal_rasterize_path} -b 3 -b 2 -b 1 -burn 200 -burn 220 -burn 240 -l rast1 {input_tab} {output_tif}"
     )
     assert err is None or err == "", "got error/warning"
 
     # Check results.
 
-    target_ds = gdal.Open("tmp/rast1.tif")
+    target_ds = gdal.Open(output_tif)
     expected = 6452
     checksum = target_ds.GetRasterBand(2).Checksum()
     assert checksum == expected, "Did not get expected image checksum"
 
     target_ds = None
-
-    gdal.GetDriverByName("GTiff").Delete("tmp/rast1.tif")
-    ogr.GetDriverByName("MapInfo File").DeleteDataSource("tmp/rast1.tab")
 
 
 ###############################################################################
@@ -136,12 +134,14 @@ def test_gdal_rasterize_1(gdal_rasterize_path):
 
 
 @pytest.mark.require_driver("CSV")
-def test_gdal_rasterize_2(gdal_rasterize_path):
+def test_gdal_rasterize_2(gdal_rasterize_path, tmp_path):
+
+    output_tif = str(tmp_path / "rast2.tif")
 
     # Create a raster to rasterize into.
 
     target_ds = gdal.GetDriverByName("GTiff").Create(
-        "tmp/rast2.tif", 12, 12, 3, gdal.GDT_Byte
+        output_tif, 12, 12, 3, gdal.GDT_Byte
     )
     target_ds.SetGeoTransform((0, 1, 0, 12, 0, -1))
 
@@ -150,43 +150,43 @@ def test_gdal_rasterize_2(gdal_rasterize_path):
 
     # Run the algorithm.
     gdaltest.runexternal(
-        gdal_rasterize_path
-        + " -at -b 3 -b 2 -b 1 -burn 200 -burn 220 -burn 240 -l cutline ../alg/data/cutline.csv tmp/rast2.tif"
+        f"{gdal_rasterize_path} -at -b 3 -b 2 -b 1 -burn 200 -burn 220 -burn 240 -l cutline ../alg/data/cutline.csv {output_tif}"
     )
 
     # Check results.
 
-    target_ds = gdal.Open("tmp/rast2.tif")
+    target_ds = gdal.Open(output_tif)
     expected = 121
     checksum = target_ds.GetRasterBand(2).Checksum()
     assert checksum == expected, "Did not get expected image checksum"
 
     target_ds = None
 
-    gdal.GetDriverByName("GTiff").Delete("tmp/rast2.tif")
-
 
 ###############################################################################
 # Test creating an output file
 
 
-def test_gdal_rasterize_3(gdal_rasterize_path):
+def test_gdal_rasterize_3(gdal_rasterize_path, tmp_path):
+
+    contour_shp = str(tmp_path / "n43dt0.shp")
+    output_tif = str(tmp_path / "n43dt0.tif")
 
     if test_cli_utilities.get_gdal_contour_path() is None:
         pytest.skip("gdal_contour missing")
 
     gdaltest.runexternal(
         test_cli_utilities.get_gdal_contour_path()
-        + " ../gdrivers/data/n43.tif tmp/n43dt0.shp -i 10 -3d"
+        + f" ../gdrivers/data/n43.tif {contour_shp} -i 10 -3d"
     )
 
     gdaltest.runexternal(
         gdal_rasterize_path
-        + " -3d tmp/n43dt0.shp tmp/n43dt0.tif -l n43dt0 -ts 121 121 -a_nodata 0 -q"
+        + f" -3d {contour_shp} {output_tif} -l n43dt0 -ts 121 121 -a_nodata 0 -q"
     )
 
     ds_ref = gdal.Open("../gdrivers/data/n43.tif")
-    ds = gdal.Open("tmp/n43dt0.tif")
+    ds = gdal.Open(output_tif)
 
     assert (
         ds.GetRasterBand(1).GetNoDataValue() == 0.0
@@ -207,34 +207,31 @@ def test_gdal_rasterize_3(gdal_rasterize_path):
     assert wkt.find("WGS_1984") != -1, "did not get expected SRS"
     ds = None
 
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/n43dt0.shp")
-    gdal.GetDriverByName("GTiff").Delete("tmp/n43dt0.tif")
-
 
 ###############################################################################
 # Same but with -tr argument
 
 
-def test_gdal_rasterize_4(gdal_rasterize_path):
+def test_gdal_rasterize_4(gdal_rasterize_path, tmp_path):
+
+    contour_shp = str(tmp_path / "n43dt0.shp")
+    output_tif = str(tmp_path / "n43dt0.tif")
 
     if test_cli_utilities.get_gdal_contour_path() is None:
         pytest.skip("gdal_contour missing")
 
-    with gdaltest.disable_exceptions():
-        gdal.GetDriverByName("GTiff").Delete("tmp/n43dt0.tif")
-
     gdaltest.runexternal(
         test_cli_utilities.get_gdal_contour_path()
-        + " ../gdrivers/data/n43.tif tmp/n43dt0.shp -i 10 -3d"
+        + f" ../gdrivers/data/n43.tif {contour_shp} -i 10 -3d"
     )
 
     gdaltest.runexternal(
         gdal_rasterize_path
-        + " -3d tmp/n43dt0.shp tmp/n43dt0.tif -l n43dt0 -tr 0.008333333333333  0.008333333333333 -a_nodata 0 -a_srs EPSG:4326"
+        + f" -3d {contour_shp} {output_tif} -l n43dt0 -tr 0.008333333333333  0.008333333333333 -a_nodata 0 -a_srs EPSG:4326"
     )
 
     ds_ref = gdal.Open("../gdrivers/data/n43.tif")
-    ds = gdal.Open("tmp/n43dt0.tif")
+    ds = gdal.Open(output_tif)
 
     assert (
         ds.GetRasterBand(1).GetNoDataValue() == 0.0
@@ -261,18 +258,18 @@ def test_gdal_rasterize_4(gdal_rasterize_path):
     assert wkt.find("WGS_1984") != -1, "did not get expected SRS"
     ds = None
 
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/n43dt0.shp")
-    gdal.GetDriverByName("GTiff").Delete("tmp/n43dt0.tif")
-
 
 ###############################################################################
 # Test point rasterization (#3774)
 
 
 @pytest.mark.require_driver("CSV")
-def test_gdal_rasterize_5(gdal_rasterize_path):
+def test_gdal_rasterize_5(gdal_rasterize_path, tmp_path):
 
-    f = open("tmp/test_gdal_rasterize_5.csv", "wb")
+    input_csv = str(tmp_path / "test_gdal_rasterize_5.csv")
+    output_tif = str(tmp_path / "test_gdal_rasterize_5.tif")
+
+    f = open(input_csv, "wb")
     f.write(
         """x,y,Value
 0.5,0.5,1
@@ -288,11 +285,11 @@ def test_gdal_rasterize_5(gdal_rasterize_path):
     gdaltest.runexternal(
         gdal_rasterize_path
         + " -l test_gdal_rasterize_5 -oo X_POSSIBLE_NAMES=x -oo Y_POSSIBLE_NAMES=y "
-        + " tmp/test_gdal_rasterize_5.csv tmp/test_gdal_rasterize_5.tif "
+        + f" {input_csv} {output_tif} "
         + " -a Value -tr 1 1 -ot Byte"
     )
 
-    ds = gdal.Open("tmp/test_gdal_rasterize_5.tif")
+    ds = gdal.Open(output_tif)
     assert (
         ds.RasterXSize == 3 and ds.RasterYSize == 3
     ), "did not get expected dimensions"
@@ -311,18 +308,19 @@ def test_gdal_rasterize_5(gdal_rasterize_path):
 
     ds = None
 
-    gdal.GetDriverByName("GTiff").Delete("tmp/test_gdal_rasterize_5.tif")
-    os.unlink("tmp/test_gdal_rasterize_5.csv")
-
 
 ###############################################################################
 # Test on the fly reprojection of input data
 
 
 @pytest.mark.require_driver("CSV")
-def test_gdal_rasterize_6(gdal_rasterize_path):
+def test_gdal_rasterize_6(gdal_rasterize_path, tmp_path):
 
-    f = open("tmp/test_gdal_rasterize_6.csv", "wb")
+    input_csv = str(tmp_path / "test_gdal_rasterize_6.csv")
+    input_prj = str(tmp_path / "test_gdal_rasterize_6.prj")
+    output_tif = str(tmp_path / "test_gdal_rasterize_6.tif")
+
+    f = open(input_csv, "wb")
     f.write(
         """WKT,Value
 "POLYGON((2 49,2 50,3 50,3 49,2 49))",255
@@ -332,11 +330,11 @@ def test_gdal_rasterize_6(gdal_rasterize_path):
     )
     f.close()
 
-    f = open("tmp/test_gdal_rasterize_6.prj", "wb")
+    f = open(input_prj, "wb")
     f.write("""EPSG:4326""".encode("ascii"))
     f.close()
 
-    ds = gdal.GetDriverByName("GTiff").Create("tmp/test_gdal_rasterize_6.tif", 100, 100)
+    ds = gdal.GetDriverByName("GTiff").Create(output_tif, 100, 100)
     ds.SetGeoTransform(
         [200000, (400000 - 200000) / 100, 0, 6500000, 0, -(6500000 - 6200000) / 100]
     )
@@ -347,17 +345,13 @@ def test_gdal_rasterize_6(gdal_rasterize_path):
 
     gdaltest.runexternal(
         gdal_rasterize_path
-        + " -l test_gdal_rasterize_6 tmp/test_gdal_rasterize_6.csv tmp/test_gdal_rasterize_6.tif -a Value"
+        + f" -l test_gdal_rasterize_6 {input_csv} {output_tif} -a Value"
     )
 
-    ds = gdal.Open("tmp/test_gdal_rasterize_6.tif")
+    ds = gdal.Open(output_tif)
     assert ds.GetRasterBand(1).Checksum() == 39190, "did not get expected checksum"
 
     ds = None
-
-    gdal.GetDriverByName("GTiff").Delete("tmp/test_gdal_rasterize_6.tif")
-    os.unlink("tmp/test_gdal_rasterize_6.csv")
-    os.unlink("tmp/test_gdal_rasterize_6.prj")
 
 
 ###############################################################################
@@ -367,9 +361,13 @@ def test_gdal_rasterize_6(gdal_rasterize_path):
 @pytest.mark.require_driver("SQLite")
 @pytest.mark.require_driver("CSV")
 @pytest.mark.parametrize("sql_in_file", [False, True])
-def test_gdal_rasterize_7(gdal_rasterize_path, sql_in_file):
+def test_gdal_rasterize_7(gdal_rasterize_path, sql_in_file, tmp_path):
 
     pytest.importorskip("numpy")
+
+    input_csv = str(tmp_path / "test_gdal_rasterize_7.csv")
+    output_tif = str(tmp_path / "test_gdal_rasterize_7.tif")
+    sql_txt = str(tmp_path / "sql.txt")
 
     try:
         drv = ogr.GetDriverByName("SQLITE")
@@ -378,7 +376,7 @@ def test_gdal_rasterize_7(gdal_rasterize_path, sql_in_file):
     except Exception:
         pytest.skip("Spatialite not available")
 
-    f = open("tmp/test_gdal_rasterize_7.csv", "wb")
+    f = open(input_csv, "wb")
     x = (0, 0, 50, 50, 25)
     y = (0, 50, 0, 50, 25)
     f.write("WKT,Value\n".encode("ascii"))
@@ -390,13 +388,13 @@ def test_gdal_rasterize_7(gdal_rasterize_path, sql_in_file):
 
     sql = "SELECT ST_Buffer(GEOMETRY, 2) FROM test_gdal_rasterize_7"
     if sql_in_file:
-        open("tmp/sql.txt", "wt").write(sql)
-        sql = "@tmp/sql.txt"
+        open(sql_txt, "wt").write(sql)
+        sql = f"@{sql_txt}"
     else:
         sql = '"' + sql + '"'
     cmds = (
-        "tmp/test_gdal_rasterize_7.csv "
-        + "tmp/test_gdal_rasterize_7.tif "
+        f"{input_csv} "
+        + f"{output_tif} "
         + "-init 0 -burn 1 "
         + f"-sql {sql} "
         + "-dialect sqlite -tr 1 1 -te -1 -1 51 51"
@@ -404,19 +402,11 @@ def test_gdal_rasterize_7(gdal_rasterize_path, sql_in_file):
 
     gdaltest.runexternal(gdal_rasterize_path + " " + cmds)
 
-    if sql_in_file:
-        os.unlink("tmp/sql.txt")
-
-    ds = gdal.Open("tmp/test_gdal_rasterize_7.tif")
+    ds = gdal.Open(output_tif)
     data = ds.GetRasterBand(1).ReadAsArray()
     assert data.sum() > 5, "Only rasterized 5 pixels or less."
 
     ds = None
-
-    if os.path.exists("tmp/test_gdal_rasterize_7.tif"):
-        gdal.GetDriverByName("GTiff").Delete("tmp/test_gdal_rasterize_7.tif")
-    if os.path.exists("tmp/test_gdal_rasterize_7.csv"):
-        os.unlink("tmp/test_gdal_rasterize_7.csv")
 
 
 ###############################################################################
@@ -425,22 +415,22 @@ def test_gdal_rasterize_7(gdal_rasterize_path, sql_in_file):
 
 
 @pytest.mark.require_driver("CSV")
-def test_gdal_rasterize_8(gdal_rasterize_path):
+def test_gdal_rasterize_8(gdal_rasterize_path, tmp_path):
 
-    f = open("tmp/test_gdal_rasterize_8.csv", "wb")
+    input_csv = str(tmp_path / "test_gdal_rasterize_8.csv")
+    output_tif = str(tmp_path / "test_gdal_rasterize_8.tif")
+
+    f = open(input_csv, "wb")
     f.write("WKT,Value\n".encode("ascii"))
     f.write('"LINESTRING (0 0, 5 5, 10 0, 10 10)",1'.encode("ascii"))
     f.close()
 
-    cmds = """tmp/test_gdal_rasterize_8.csv tmp/test_gdal_rasterize_8.tif -init 0 -burn 1 -tr 1 1"""
+    cmds = f"""{input_csv} {output_tif} -init 0 -burn 1 -tr 1 1"""
 
     gdaltest.runexternal(gdal_rasterize_path + " " + cmds)
 
-    ds = gdal.Open("tmp/test_gdal_rasterize_8.tif")
+    ds = gdal.Open(output_tif)
     cs = ds.GetRasterBand(1).Checksum()
     assert cs == 21, "Did not rasterize line data properly"
 
     ds = None
-
-    gdal.GetDriverByName("GTiff").Delete("tmp/test_gdal_rasterize_8.tif")
-    os.unlink("tmp/test_gdal_rasterize_8.csv")

--- a/autotest/utilities/test_gdal_rasterize_lib.py
+++ b/autotest/utilities/test_gdal_rasterize_lib.py
@@ -108,24 +108,26 @@ def test_gdal_rasterize_lib_1():
 # Test creating an output file
 
 
-def test_gdal_rasterize_lib_3():
+def test_gdal_rasterize_lib_3(tmp_path):
 
     import test_cli_utilities
 
     if test_cli_utilities.get_gdal_contour_path() is None:
         pytest.skip()
 
+    dst_shp = str(tmp_path / "n43dt0.shp")
+
     gdaltest.runexternal(
         test_cli_utilities.get_gdal_contour_path()
-        + " ../gdrivers/data/n43.tif tmp/n43dt0.shp -i 10 -3d"
+        + f" ../gdrivers/data/n43.tif {dst_shp} -i 10 -3d"
     )
 
     with pytest.raises(Exception):
-        gdal.Rasterize("/vsimem/bogus.tif", "tmp/n43dt0.shp")
+        gdal.Rasterize("/vsimem/bogus.tif", dst_shp)
 
     ds = gdal.Rasterize(
         "",
-        "tmp/n43dt0.shp",
+        dst_shp,
         format="MEM",
         outputType=gdal.GDT_Byte,
         useZ=True,
@@ -134,8 +136,6 @@ def test_gdal_rasterize_lib_3():
         height=121,
         noData=0,
     )
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/n43dt0.shp")
 
     ds_ref = gdal.Open("../gdrivers/data/n43.tif")
 

--- a/autotest/utilities/test_gdal_translate.py
+++ b/autotest/utilities/test_gdal_translate.py
@@ -30,6 +30,7 @@
 ###############################################################################
 
 import os
+import shutil
 import sys
 
 import gdaltest
@@ -53,14 +54,16 @@ def gdal_translate_path():
 # Simple test
 
 
-def test_gdal_translate_1(gdal_translate_path):
+def test_gdal_translate_1(gdal_translate_path, tmp_path):
+
+    dst_tif = str(tmp_path / "test1.tif")
 
     (_, err) = gdaltest.runexternal_out_and_err(
-        gdal_translate_path + " ../gcore/data/byte.tif tmp/test1.tif"
+        f"{gdal_translate_path} ../gcore/data/byte.tif {dst_tif}"
     )
     assert err is None or err == "", "got error/warning"
 
-    ds = gdal.Open("tmp/test1.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
@@ -72,13 +75,15 @@ def test_gdal_translate_1(gdal_translate_path):
 # Test -of option
 
 
-def test_gdal_translate_2(gdal_translate_path):
+def test_gdal_translate_2(gdal_translate_path, tmp_path):
+
+    dst_tif = str(tmp_path / "test2.tif")
 
     gdaltest.runexternal(
-        gdal_translate_path + " -of GTiff ../gcore/data/byte.tif tmp/test2.tif"
+        f"{gdal_translate_path} -of GTiff ../gcore/data/byte.tif {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/test2.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
@@ -90,13 +95,15 @@ def test_gdal_translate_2(gdal_translate_path):
 # Test -ot option
 
 
-def test_gdal_translate_3(gdal_translate_path):
+def test_gdal_translate_3(gdal_translate_path, tmp_path):
+
+    dst_tif = str(tmp_path / "test3.tif")
 
     gdaltest.runexternal(
-        gdal_translate_path + " -ot Int16 ../gcore/data/byte.tif tmp/test3.tif"
+        f"{gdal_translate_path} -ot Int16 ../gcore/data/byte.tif {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/test3.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).DataType == gdal.GDT_Int16, "Bad data type"
@@ -110,13 +117,15 @@ def test_gdal_translate_3(gdal_translate_path):
 # Test -b option
 
 
-def test_gdal_translate_4(gdal_translate_path):
+def test_gdal_translate_4(gdal_translate_path, tmp_path):
+
+    dst_tif = str(tmp_path / "test4.tif")
 
     gdaltest.runexternal(
-        gdal_translate_path + " -b 3 -b 2 -b 1 ../gcore/data/rgbsmall.tif tmp/test4.tif"
+        f"{gdal_translate_path}  -b 3 -b 2 -b 1 ../gcore/data/rgbsmall.tif {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/test4.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 21349, "Bad checksum"
@@ -133,14 +142,15 @@ def test_gdal_translate_4(gdal_translate_path):
 
 
 @pytest.mark.require_driver("GIF")
-def test_gdal_translate_5(gdal_translate_path):
+def test_gdal_translate_5(gdal_translate_path, tmp_path):
+
+    dst_tif = str(tmp_path / "test5.tif")
 
     gdaltest.runexternal(
-        gdal_translate_path
-        + " -expand rgb ../gdrivers/data/gif/bug407.gif tmp/test5.tif"
+        f"{gdal_translate_path} -expand rgb ../gdrivers/data/gif/bug407.gif {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/test5.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert (
@@ -168,13 +178,15 @@ def test_gdal_translate_5(gdal_translate_path):
 # Test -outsize option in absolute mode
 
 
-def test_gdal_translate_6(gdal_translate_path):
+def test_gdal_translate_6(gdal_translate_path, tmp_path):
+
+    dst_tif = str(tmp_path / "test6.tif")
 
     gdaltest.runexternal(
-        gdal_translate_path + " -outsize 40 40 ../gcore/data/byte.tif tmp/test6.tif"
+        f"{gdal_translate_path} -outsize 40 40 ../gcore/data/byte.tif {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/test6.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 18784, "Bad checksum"
@@ -186,13 +198,15 @@ def test_gdal_translate_6(gdal_translate_path):
 # Test -outsize option in percentage mode
 
 
-def test_gdal_translate_7(gdal_translate_path):
+def test_gdal_translate_7(gdal_translate_path, tmp_path):
+
+    dst_tif = str(tmp_path / "test7.tif")
 
     gdaltest.runexternal(
-        gdal_translate_path + " -outsize 200% 200% ../gcore/data/byte.tif tmp/test7.tif"
+        f"{gdal_translate_path} -outsize 200% 200% ../gcore/data/byte.tif {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/test7.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 18784, "Bad checksum"
@@ -204,14 +218,15 @@ def test_gdal_translate_7(gdal_translate_path):
 # Test -a_srs and -gcp options
 
 
-def test_gdal_translate_8(gdal_translate_path):
+def test_gdal_translate_8(gdal_translate_path, tmp_path):
+
+    dst_tif = str(tmp_path / "test8.tif")
 
     gdaltest.runexternal(
-        gdal_translate_path
-        + " -a_srs EPSG:26711 -gcp 0 0  440720.000 3751320.000 -gcp 20 0 441920.000 3751320.000 -gcp 20 20 441920.000 3750120.000 0 -gcp 0 20 440720.000 3750120.000 ../gcore/data/byte.tif tmp/test8.tif"
+        f"{gdal_translate_path} -a_srs EPSG:26711 -gcp 0 0  440720.000 3751320.000 -gcp 20 0 441920.000 3751320.000 -gcp 20 20 441920.000 3750120.000 0 -gcp 0 20 440720.000 3750120.000 ../gcore/data/byte.tif {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/test8.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
@@ -228,13 +243,15 @@ def test_gdal_translate_8(gdal_translate_path):
 # Test -a_nodata option
 
 
-def test_gdal_translate_9(gdal_translate_path):
+def test_gdal_translate_9(gdal_translate_path, tmp_path):
+
+    dst_tif = str(tmp_path / "test9.tif")
 
     gdaltest.runexternal(
-        gdal_translate_path + " -a_nodata 1 ../gcore/data/byte.tif tmp/test9.tif"
+        f"{gdal_translate_path} -a_nodata 1 ../gcore/data/byte.tif {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/test9.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).GetNoDataValue() == 1, "Bad nodata value"
@@ -246,13 +263,15 @@ def test_gdal_translate_9(gdal_translate_path):
 # Test -srcwin option
 
 
-def test_gdal_translate_10(gdal_translate_path):
+def test_gdal_translate_10(gdal_translate_path, tmp_path):
+
+    dst_tif = str(tmp_path / "test10.tif")
 
     gdaltest.runexternal(
-        gdal_translate_path + " -srcwin 0 0 1 1 ../gcore/data/byte.tif tmp/test10.tif"
+        f"{gdal_translate_path} -srcwin 0 0 1 1 ../gcore/data/byte.tif {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/test10.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 2, "Bad checksum"
@@ -264,14 +283,15 @@ def test_gdal_translate_10(gdal_translate_path):
 # Test -projwin option
 
 
-def test_gdal_translate_11(gdal_translate_path):
+def test_gdal_translate_11(gdal_translate_path, tmp_path):
+
+    dst_tif = str(tmp_path / "test11.tif")
 
     gdaltest.runexternal(
-        gdal_translate_path
-        + " -projwin 440720.000 3751320.000 441920.000 3750120.000 ../gcore/data/byte.tif tmp/test11.tif"
+        f"{gdal_translate_path} -projwin 440720.000 3751320.000 441920.000 3750120.000 ../gcore/data/byte.tif {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/test11.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
@@ -289,14 +309,15 @@ def test_gdal_translate_11(gdal_translate_path):
 # Test -a_ullr option
 
 
-def test_gdal_translate_12(gdal_translate_path):
+def test_gdal_translate_12(gdal_translate_path, tmp_path):
+
+    dst_tif = str(tmp_path / "test12.tif")
 
     gdaltest.runexternal(
-        gdal_translate_path
-        + " -a_ullr 440720.000 3751320.000 441920.000 3750120.000 ../gcore/data/byte.tif tmp/test12.tif"
+        f"{gdal_translate_path} -a_ullr 440720.000 3751320.000 441920.000 3750120.000 ../gcore/data/byte.tif {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/test12.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
@@ -314,14 +335,15 @@ def test_gdal_translate_12(gdal_translate_path):
 # Test -mo option
 
 
-def test_gdal_translate_13(gdal_translate_path):
+def test_gdal_translate_13(gdal_translate_path, tmp_path):
+
+    dst_tif = str(tmp_path / "test13.tif")
 
     gdaltest.runexternal(
-        gdal_translate_path
-        + " -mo TIFFTAG_DOCUMENTNAME=test13 ../gcore/data/byte.tif tmp/test13.tif"
+        f"{gdal_translate_path} -mo TIFFTAG_DOCUMENTNAME=test13 ../gcore/data/byte.tif {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/test13.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     md = ds.GetMetadata()
@@ -334,13 +356,15 @@ def test_gdal_translate_13(gdal_translate_path):
 # Test -co option
 
 
-def test_gdal_translate_14(gdal_translate_path):
+def test_gdal_translate_14(gdal_translate_path, tmp_path):
+
+    dst_tif = str(tmp_path / "test14.tif")
 
     gdaltest.runexternal(
-        gdal_translate_path + " -co COMPRESS=LZW ../gcore/data/byte.tif tmp/test14.tif"
+        f"{gdal_translate_path} -co COMPRESS=LZW ../gcore/data/byte.tif {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/test14.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     md = ds.GetMetadata("IMAGE_STRUCTURE")
@@ -354,13 +378,13 @@ def test_gdal_translate_14(gdal_translate_path):
 
 
 @pytest.mark.require_driver("RPFTOC")
-def test_gdal_translate_15(gdal_translate_path):
+def test_gdal_translate_15(gdal_translate_path, tmp_path):
 
     gdaltest.runexternal(
-        gdal_translate_path + " -sds ../gdrivers/data/nitf/A.TOC tmp/test15.tif"
+        f"{gdal_translate_path} -sds ../gdrivers/data/nitf/A.TOC {tmp_path}/test15.tif"
     )
 
-    ds = gdal.Open("tmp/test15_1.tif")
+    ds = gdal.Open(f"{tmp_path}/test15_1.tif")
     assert ds is not None
 
     ds = None
@@ -370,13 +394,15 @@ def test_gdal_translate_15(gdal_translate_path):
 # Test -of VRT which is a special case
 
 
-def test_gdal_translate_16(gdal_translate_path):
+def test_gdal_translate_16(gdal_translate_path, tmp_path):
+
+    dst_vrt = str(tmp_path / "test16.vrt")
 
     gdaltest.runexternal(
-        gdal_translate_path + " -of VRT ../gcore/data/byte.tif tmp/test16.vrt"
+        f"{gdal_translate_path} -of VRT ../gcore/data/byte.tif {dst_vrt}"
     )
 
-    ds = gdal.Open("tmp/test16.vrt")
+    ds = gdal.Open(dst_vrt)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
@@ -389,14 +415,15 @@ def test_gdal_translate_16(gdal_translate_path):
 
 
 @pytest.mark.require_driver("GIF")
-def test_gdal_translate_17(gdal_translate_path):
+def test_gdal_translate_17(gdal_translate_path, tmp_path):
+
+    dst_vrt = str(tmp_path / "test17.vrt")
 
     gdaltest.runexternal(
-        gdal_translate_path
-        + " -of VRT -expand rgba ../gdrivers/data/gif/bug407.gif tmp/test17.vrt"
+        f"{gdal_translate_path} -of VRT -expand rgba ../gdrivers/data/gif/bug407.gif {dst_vrt}"
     )
 
-    ds = gdal.Open("tmp/test17.vrt")
+    ds = gdal.Open(dst_vrt)
     assert ds is not None
 
     assert (
@@ -431,22 +458,26 @@ def test_gdal_translate_17(gdal_translate_path):
 
 
 @pytest.mark.require_driver("BMP")
-def test_gdal_translate_18(gdal_translate_path):
+def test_gdal_translate_18(gdal_translate_path, tmp_path):
+
+    dst1_vrt = str(tmp_path / "test18_1.vrt")
+    dst2_vrt = str(tmp_path / "test18_2.vrt")
+    dst2_tif = str(tmp_path / "test18_2.tif")
 
     gdaltest.runexternal(
-        gdal_translate_path + " ../gcore/data/8bit_pal.bmp -of VRT tmp/test18_1.vrt"
+        f"{gdal_translate_path} ../gcore/data/8bit_pal.bmp -of VRT {dst1_vrt}"
     )
     gdaltest.runexternal(
-        gdal_translate_path + " tmp/test18_1.vrt -expand rgb -of VRT tmp/test18_2.vrt"
+        f"{gdal_translate_path} {dst1_vrt} -expand rgb -of VRT {dst2_vrt}"
     )
     (_, ret_stderr) = gdaltest.runexternal_out_and_err(
-        gdal_translate_path + " tmp/test18_2.vrt tmp/test18_2.tif"
+        f"{gdal_translate_path} {dst2_vrt} {dst2_tif}"
     )
 
     # Check that all datasets are closed
     assert ret_stderr.find("Open GDAL Datasets") == -1
 
-    ds = gdal.Open("tmp/test18_2.tif")
+    ds = gdal.Open(dst2_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
@@ -458,11 +489,12 @@ def test_gdal_translate_18(gdal_translate_path):
 # Test -expand rgba on a color indexed dataset with an alpha band
 
 
-def test_gdal_translate_19(gdal_translate_path):
+def test_gdal_translate_19(gdal_translate_path, tmp_path):
 
-    ds = gdal.GetDriverByName("GTiff").Create(
-        "tmp/test_gdal_translate_19_src.tif", 1, 1, 2
-    )
+    src_tif = str(tmp_path / "test_gdal_translate_19_src.tif")
+    dst_tif = str(tmp_path / "test_gdal_translate_19_dst.tif")
+
+    ds = gdal.GetDriverByName("GTiff").Create(src_tif, 1, 1, 2)
     ct = gdal.ColorTable()
     ct.SetColorEntry(127, (1, 2, 3, 255))
     ds.GetRasterBand(1).SetRasterColorTable(ct)
@@ -470,12 +502,9 @@ def test_gdal_translate_19(gdal_translate_path):
     ds.GetRasterBand(2).Fill(250)
     ds = None
 
-    gdaltest.runexternal(
-        gdal_translate_path
-        + " -expand rgba tmp/test_gdal_translate_19_src.tif tmp/test_gdal_translate_19_dst.tif"
-    )
+    gdaltest.runexternal(f"{gdal_translate_path} -expand rgba {src_tif} {dst_tif}")
 
-    ds = gdal.Open("tmp/test_gdal_translate_19_dst.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 1, "Bad checksum for band 1"
@@ -490,18 +519,17 @@ def test_gdal_translate_19(gdal_translate_path):
 # Test -a_nodata None
 
 
-def test_gdal_translate_20(gdal_translate_path):
+def test_gdal_translate_20(gdal_translate_path, tmp_path):
+
+    src_tif = str(tmp_path / "test_gdal_translate_20_src.tif")
+    dst_tif = str(tmp_path / "test_gdal_translate_20_dst.tif")
 
     gdaltest.runexternal(
-        gdal_translate_path
-        + " -a_nodata 255 ../gcore/data/byte.tif tmp/test_gdal_translate_20_src.tif"
+        f"{gdal_translate_path} -a_nodata 255 ../gcore/data/byte.tif {src_tif}"
     )
-    gdaltest.runexternal(
-        gdal_translate_path
-        + " -a_nodata None tmp/test_gdal_translate_20_src.tif tmp/test_gdal_translate_20_dst.tif"
-    )
+    gdaltest.runexternal(f"{gdal_translate_path} -a_nodata None {src_tif} {dst_tif}")
 
-    ds = gdal.Open("tmp/test_gdal_translate_20_dst.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     nodata = ds.GetRasterBand(1).GetNoDataValue()
@@ -515,14 +543,15 @@ def test_gdal_translate_20(gdal_translate_path):
 # in that case, they must be copied
 
 
-def test_gdal_translate_21(gdal_translate_path):
+def test_gdal_translate_21(gdal_translate_path, tmp_path):
+
+    dst_img = str(tmp_path / "test_gdal_translate_21.img")
 
     gdaltest.runexternal(
-        gdal_translate_path
-        + " -of HFA ../gcore/data/utmsmall.img tmp/test_gdal_translate_21.img"
+        f"{gdal_translate_path} -of HFA ../gcore/data/utmsmall.img {dst_img}"
     )
 
-    ds = gdal.Open("tmp/test_gdal_translate_21.img")
+    ds = gdal.Open(dst_img)
     md = ds.GetRasterBand(1).GetMetadata()
     ds = None
 
@@ -539,14 +568,15 @@ def test_gdal_translate_21(gdal_translate_path):
 # in that case, they must *NOT* be copied
 
 
-def test_gdal_translate_22(gdal_translate_path):
+def test_gdal_translate_22(gdal_translate_path, tmp_path):
+
+    dst_img = str(tmp_path / "test_gdal_translate_22.img")
 
     gdaltest.runexternal(
-        gdal_translate_path
-        + " -of HFA -scale 0 255 0 128 ../gcore/data/utmsmall.img tmp/test_gdal_translate_22.img"
+        f"{gdal_translate_path} -of HFA -scale 0 255 0 128 ../gcore/data/utmsmall.img {dst_img}"
     )
 
-    ds = gdal.Open("tmp/test_gdal_translate_22.img")
+    ds = gdal.Open(dst_img)
     md = ds.GetRasterBand(1).GetMetadata()
     ds = None
 
@@ -563,36 +593,39 @@ def test_gdal_translate_22(gdal_translate_path):
 # Test -stats option (#3889)
 
 
-def test_gdal_translate_23(gdal_translate_path):
+def test_gdal_translate_23(gdal_translate_path, tmp_path):
+
+    src_tif = str(tmp_path / "byte.tif")
+    dst_tif = str(tmp_path / "test_gdal_translate_23.tif")
+
+    shutil.copy("../gcore/data/byte.tif", src_tif)
 
     gdaltest.runexternal(
-        gdal_translate_path
-        + " -stats ../gcore/data/byte.tif tmp/test_gdal_translate_23.tif"
+        f"{gdal_translate_path} -stats ../gcore/data/byte.tif {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/test_gdal_translate_23.tif")
+    ds = gdal.Open(dst_tif)
     md = ds.GetRasterBand(1).GetMetadata()
     ds = None
 
     assert md["STATISTICS_MINIMUM"] == "74", "STATISTICS_MINIMUM is wrong."
 
-    assert not os.path.exists("tmp/test_gdal_translate_23.tif.aux.xml")
-
-    gdal.Unlink("../gcore/data/byte.tif.aux.xml")
+    assert not os.path.exists(dst_tif + ".aux.xml")
 
 
 ###############################################################################
 # Test -srcwin option when partially outside
 
 
-def test_gdal_translate_24(gdal_translate_path):
+def test_gdal_translate_24(gdal_translate_path, tmp_path):
+
+    dst_tif = str(tmp_path / "test_gdal_translate_24.tif")
 
     gdaltest.runexternal(
-        gdal_translate_path
-        + " -q -srcwin -10 -10 40 40 ../gcore/data/byte.tif tmp/test_gdal_translate_24.tif"
+        f"{gdal_translate_path} -q -srcwin -10 -10 40 40 ../gcore/data/byte.tif {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/test_gdal_translate_24.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     cs = ds.GetRasterBand(1).Checksum()
@@ -605,14 +638,15 @@ def test_gdal_translate_24(gdal_translate_path):
 # Test -norat
 
 
-def test_gdal_translate_25(gdal_translate_path):
+def test_gdal_translate_25(gdal_translate_path, tmp_path):
+
+    dst_tif = str(tmp_path / "test_gdal_translate_25.tif")
 
     gdaltest.runexternal(
-        gdal_translate_path
-        + " -q ../gdrivers/data/hfa/int.img tmp/test_gdal_translate_25.tif -norat"
+        f"{gdal_translate_path} -q ../gdrivers/data/hfa/int.img {dst_tif} -norat"
     )
 
-    ds = gdal.Open("tmp/test_gdal_translate_25.tif")
+    ds = gdal.Open(dst_tif)
     assert ds.GetRasterBand(1).GetDefaultRAT() is None, "RAT unexpected"
 
     ds = None
@@ -623,9 +657,12 @@ def test_gdal_translate_25(gdal_translate_path):
 
 
 @pytest.mark.require_driver("XYZ")
-def test_gdal_translate_26(gdal_translate_path):
+def test_gdal_translate_26(gdal_translate_path, tmp_path):
 
-    f = open("tmp/test_gdal_translate_26.xyz", "wb")
+    src_xyz = str(tmp_path / "test_gdal_translate_26.xyz")
+    dst_tif = str(tmp_path / "test_gdal_translate_26.tif")
+
+    f = open(src_xyz, "wb")
     f.write(
         """X Y Z
 0 0 -999
@@ -637,11 +674,10 @@ def test_gdal_translate_26(gdal_translate_path):
     )
     f.close()
     gdaltest.runexternal(
-        gdal_translate_path
-        + " -a_nodata -999 -stats tmp/test_gdal_translate_26.xyz tmp/test_gdal_translate_26.tif"
+        f"{gdal_translate_path} -a_nodata -999 -stats {src_xyz} {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/test_gdal_translate_26.tif")
+    ds = gdal.Open(dst_tif)
     assert ds.GetRasterBand(1).GetMinimum() == 10
     assert ds.GetRasterBand(1).GetNoDataValue() == -999
 
@@ -653,12 +689,15 @@ def test_gdal_translate_26(gdal_translate_path):
 
 
 @pytest.mark.require_driver("AAIGRID")
-def test_gdal_translate_27(gdal_translate_path):
+def test_gdal_translate_27(gdal_translate_path, tmp_path):
 
     if test_cli_utilities.get_gdalinfo_path() is None:
         pytest.skip("gdalinfo missing")
 
-    f = open("tmp/test_gdal_translate_27.asc", "wb")
+    src_asc = str(tmp_path / "test_gdal_translate_27.asc")
+    dst_tif = str(tmp_path / "test_gdal_translate_27.tif")
+
+    f = open(src_asc, "wb")
     f.write(
         """ncols        2
 nrows        2
@@ -672,38 +711,26 @@ cellsize     60.000000000000
     )
     f.close()
 
-    gdaltest.runexternal(
-        test_cli_utilities.get_gdalinfo_path()
-        + " -stats tmp/test_gdal_translate_27.asc"
-    )
+    gdaltest.runexternal(f"{test_cli_utilities.get_gdalinfo_path()} -stats {src_asc}")
 
     # Translate to an output type that accepts 256 as maximum
-    gdaltest.runexternal(
-        gdal_translate_path
-        + " tmp/test_gdal_translate_27.asc tmp/test_gdal_translate_27.tif -ot UInt16"
-    )
+    gdaltest.runexternal(f"{gdal_translate_path} {src_asc} {dst_tif} -ot UInt16")
 
-    ds = gdal.Open("tmp/test_gdal_translate_27.tif")
+    ds = gdal.Open(dst_tif)
     assert ds.GetRasterBand(1).GetMetadataItem("STATISTICS_MINIMUM") is not None
     ds = None
 
     # Translate to an output type that accepts 256 as maximum
-    gdaltest.runexternal(
-        gdal_translate_path
-        + " tmp/test_gdal_translate_27.asc tmp/test_gdal_translate_27.tif -ot Float64"
-    )
+    gdaltest.runexternal(f"{gdal_translate_path} {src_asc} {dst_tif} -ot Float64")
 
-    ds = gdal.Open("tmp/test_gdal_translate_27.tif")
+    ds = gdal.Open(dst_tif)
     assert ds.GetRasterBand(1).GetMetadataItem("STATISTICS_MINIMUM") is not None
     ds = None
 
     # Translate to an output type that doesn't accept 256 as maximum
-    gdaltest.runexternal(
-        gdal_translate_path
-        + " tmp/test_gdal_translate_27.asc tmp/test_gdal_translate_27.tif -ot Byte"
-    )
+    gdaltest.runexternal(f"{gdal_translate_path} {src_asc} {dst_tif} -ot Byte")
 
-    ds = gdal.Open("tmp/test_gdal_translate_27.tif")
+    ds = gdal.Open(dst_tif)
     assert ds.GetRasterBand(1).GetMetadataItem("STATISTICS_MINIMUM") is None
     ds = None
 
@@ -713,14 +740,15 @@ cellsize     60.000000000000
 
 
 @pytest.mark.require_driver("AAIGRID")
-def test_gdal_translate_28(gdal_translate_path):
+def test_gdal_translate_28(gdal_translate_path, tmp_path):
+
+    dst_tif = str(tmp_path / "test_gdal_translate_28.tif")
 
     gdaltest.runexternal(
-        gdal_translate_path
-        + " ../gdrivers/data/aaigrid/float64.asc tmp/test_gdal_translate_28.tif -oo datatype=float64"
+        f"{gdal_translate_path} ../gdrivers/data/aaigrid/float64.asc {dst_tif} -oo datatype=float64"
     )
 
-    ds = gdal.Open("tmp/test_gdal_translate_28.tif")
+    ds = gdal.Open(dst_tif)
     assert ds.GetRasterBand(1).DataType == gdal.GDT_Float64
     ds = None
 
@@ -729,15 +757,17 @@ def test_gdal_translate_28(gdal_translate_path):
 # Test -r
 
 
-def test_gdal_translate_29(gdal_translate_path):
+def test_gdal_translate_29(gdal_translate_path, tmp_path):
+
+    dst_tif = str(tmp_path / "test_gdal_translate_29.tif")
+    dst_vrt = str(tmp_path / "test_gdal_translate_29.vrt")
 
     (_, err) = gdaltest.runexternal_out_and_err(
-        gdal_translate_path
-        + " ../gcore/data/byte.tif tmp/test_gdal_translate_29.tif -outsize 50% 50% -r cubic"
+        f"{gdal_translate_path} ../gcore/data/byte.tif {dst_tif} -outsize 50% 50% -r cubic"
     )
     assert err is None or err == "", "got error/warning"
 
-    ds = gdal.Open("tmp/test_gdal_translate_29.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     cs = ds.GetRasterBand(1).Checksum()
@@ -746,17 +776,15 @@ def test_gdal_translate_29(gdal_translate_path):
     ds = None
 
     (_, err) = gdaltest.runexternal_out_and_err(
-        gdal_translate_path
-        + " ../gcore/data/byte.tif tmp/test_gdal_translate_29.vrt -outsize 50% 50% -r cubic -of VRT"
+        f"{gdal_translate_path} ../gcore/data/byte.tif {dst_vrt} -outsize 50% 50% -r cubic -of VRT"
     )
     assert err is None or err == "", "got error/warning"
     (_, err) = gdaltest.runexternal_out_and_err(
-        gdal_translate_path
-        + " tmp/test_gdal_translate_29.vrt tmp/test_gdal_translate_29.tif"
+        f"{gdal_translate_path} {dst_vrt} {dst_tif}"
     )
     assert err is None or err == "", "got error/warning"
 
-    ds = gdal.Open("tmp/test_gdal_translate_29.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     cs = ds.GetRasterBand(1).Checksum()
@@ -769,14 +797,15 @@ def test_gdal_translate_29(gdal_translate_path):
 # Test -tr option
 
 
-def test_gdal_translate_30(gdal_translate_path):
+def test_gdal_translate_30(gdal_translate_path, tmp_path):
+
+    dst_tif = str(tmp_path / "test_gdal_translate_30.tif")
 
     gdaltest.runexternal(
-        gdal_translate_path
-        + " -tr 30 30 ../gcore/data/byte.tif tmp/test_gdal_translate_30.tif"
+        f"{gdal_translate_path} -tr 30 30 ../gcore/data/byte.tif {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/test_gdal_translate_30.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     cs = ds.GetRasterBand(1).Checksum()
@@ -789,14 +818,15 @@ def test_gdal_translate_30(gdal_translate_path):
 # Test -projwin_srs option
 
 
-def test_gdal_translate_31(gdal_translate_path):
+def test_gdal_translate_31(gdal_translate_path, tmp_path):
+
+    dst_tif = str(tmp_path / "test_gdal_translate_30.tif")
 
     gdaltest.runexternal(
-        gdal_translate_path
-        + " -projwin_srs EPSG:4267 -projwin -117.641168620797 33.9023526904262 -117.628110837847 33.8915970129613 ../gcore/data/byte.tif tmp/test_gdal_translate_31.tif"
+        f"{gdal_translate_path} -projwin_srs EPSG:4267 -projwin -117.641168620797 33.9023526904262 -117.628110837847 33.8915970129613 ../gcore/data/byte.tif {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/test_gdal_translate_31.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
@@ -814,13 +844,14 @@ def test_gdal_translate_31(gdal_translate_path):
 # Test subsetting a file with a RPC
 
 
-def test_gdal_translate_32(gdal_translate_path):
+def test_gdal_translate_32(gdal_translate_path, tmp_path):
+
+    dst_tif = str(tmp_path / "out.tif")
 
     gdaltest.runexternal(
-        gdal_translate_path
-        + " ../gcore/data/byte_rpc.tif tmp/test_gdal_translate_32.tif -srcwin 1 2 13 14 -outsize 150% 300%"
+        f"{gdal_translate_path} ../gcore/data/byte_rpc.tif {dst_tif} -srcwin 1 2 13 14 -outsize 150% 300%"
     )
-    ds = gdal.Open("tmp/test_gdal_translate_32.tif")
+    ds = gdal.Open(dst_tif)
     md = ds.GetMetadata("RPC")
     assert (
         float(md["LINE_OFF"]) == pytest.approx(47496, abs=1e-5)
@@ -829,11 +860,15 @@ def test_gdal_translate_32(gdal_translate_path):
         and float(md["SAMP_SCALE"]) == pytest.approx(19678.1538461538, abs=1e-5)
     )
 
+
+def test_gdal_translate_32bis(gdal_translate_path, tmp_path):
+
+    dst_tif = str(tmp_path / "out.tif")
+
     gdaltest.runexternal_out_and_err(
-        gdal_translate_path
-        + " ../gcore/data/byte_rpc.tif tmp/test_gdal_translate_32.tif -srcwin -10 -5 20 20"
+        f"{gdal_translate_path}  ../gcore/data/byte_rpc.tif {dst_tif} -srcwin -10 -5 20 20"
     )
-    ds = gdal.Open("tmp/test_gdal_translate_32.tif")
+    ds = gdal.Open(dst_tif)
     md = ds.GetMetadata("RPC")
     assert (
         float(md["LINE_OFF"]) == pytest.approx((15834 - -5), abs=1e-5)
@@ -847,31 +882,38 @@ def test_gdal_translate_32(gdal_translate_path):
 # Test -outsize option in auto mode
 
 
-def test_gdal_translate_33(gdal_translate_path):
+def test_gdal_translate_33(gdal_translate_path, tmp_path):
+
+    dst_tif = str(tmp_path / "out.tif")
 
     gdaltest.runexternal(
-        gdal_translate_path
-        + " -outsize 100 0 ../gdrivers/data/small_world.tif tmp/test_gdal_translate_33.tif"
+        f"{gdal_translate_path} -outsize 100 0 ../gdrivers/data/small_world.tif {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/test_gdal_translate_33.tif")
+    ds = gdal.Open(dst_tif)
     assert ds.RasterYSize == 50
     ds = None
 
+
+def test_gdal_translate_33bis(gdal_translate_path, tmp_path):
+
+    dst_tif = str(tmp_path / "out.tif")
+
     gdaltest.runexternal(
-        gdal_translate_path
-        + " -outsize 0 100 ../gdrivers/data/small_world.tif tmp/test_gdal_translate_33.tif"
+        f"{gdal_translate_path} -outsize 0 100 ../gdrivers/data/small_world.tif {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/test_gdal_translate_33.tif")
+    ds = gdal.Open(dst_tif)
     assert ds.RasterXSize == 200, ds.RasterYSize
     ds = None
 
-    os.unlink("tmp/test_gdal_translate_33.tif")
+
+def test_gdal_translate_33ter(gdal_translate_path, tmp_path):
+
+    dst_tif = str(tmp_path / "out.tif")
 
     (_, err) = gdaltest.runexternal_out_and_err(
-        gdal_translate_path
-        + " -outsize 0 0 ../gdrivers/data/small_world.tif tmp/test_gdal_translate_33.tif"
+        f"{gdal_translate_path} -outsize 0 0 ../gdrivers/data/small_world.tif {dst_tif}"
     )
     assert "-outsize 0 0 invalid" in err
 
@@ -880,18 +922,17 @@ def test_gdal_translate_33(gdal_translate_path):
 # Test NBITS is preserved
 
 
-def test_gdal_translate_34(gdal_translate_path):
+def test_gdal_translate_34(gdal_translate_path, tmp_path):
+
+    dst_vrt = str(tmp_path / "test_gdal_translate_34.vrt")
 
     gdaltest.runexternal(
-        gdal_translate_path
-        + " ../gcore/data/oddsize1bit.tif tmp/test_gdal_translate_34.vrt -of VRT -mo FOO=BAR"
+        f"{gdal_translate_path} ../gcore/data/oddsize1bit.tif {dst_vrt} -of VRT -mo FOO=BAR"
     )
 
-    ds = gdal.Open("tmp/test_gdal_translate_34.vrt")
+    ds = gdal.Open(dst_vrt)
     assert ds.GetRasterBand(1).GetMetadataItem("NBITS", "IMAGE_STRUCTURE") == "1"
     ds = None
-
-    os.unlink("tmp/test_gdal_translate_34.vrt")
 
 
 ###############################################################################
@@ -926,14 +967,15 @@ def test_gdal_translate_35(gdal_translate_path):
 # Test RAT is copied from hfa to gtiff - continuous/athematic
 
 
-def test_gdal_translate_36(gdal_translate_path):
+def test_gdal_translate_36(gdal_translate_path, tmp_path):
+
+    dst_tif = str(tmp_path / "test_gdal_translate_36.tif")
 
     gdaltest.runexternal(
-        gdal_translate_path
-        + " -of gtiff data/onepixelcontinuous.img tmp/test_gdal_translate_36.tif"
+        f"{gdal_translate_path} -of gtiff data/onepixelcontinuous.img {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/test_gdal_translate_36.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     rat = ds.GetRasterBand(1).GetDefaultRAT()
@@ -950,14 +992,16 @@ def test_gdal_translate_36(gdal_translate_path):
 # Test RAT is copied from hfa to gtiff - thematic
 
 
-def test_gdal_translate_37(gdal_translate_path):
+def test_gdal_translate_37(gdal_translate_path, tmp_path):
+
+    dst1_tif = str(tmp_path / "test_gdal_translate_37.tif")
+    dst2_tif = str(tmp_path / "test_gdal_translate_38.tif")
 
     gdaltest.runexternal(
-        gdal_translate_path
-        + " -q -of gtiff data/onepixelthematic.img tmp/test_gdal_translate_37.tif"
+        f"{gdal_translate_path} -q -of gtiff data/onepixelthematic.img {dst1_tif}"
     )
 
-    ds = gdal.Open("tmp/test_gdal_translate_37.tif")
+    ds = gdal.Open(dst1_tif)
     assert ds is not None
 
     rat = ds.GetRasterBand(1).GetDefaultRAT()
@@ -971,12 +1015,9 @@ def test_gdal_translate_37(gdal_translate_path):
 
     # Test RAT is copied round trip back to hfa
 
-    gdaltest.runexternal(
-        gdal_translate_path
-        + " -q -of hfa tmp/test_gdal_translate_37.tif tmp/test_gdal_translate_38.img"
-    )
+    gdaltest.runexternal(f"{gdal_translate_path} -q -of hfa {dst1_tif} {dst2_tif}")
 
-    ds = gdal.Open("tmp/test_gdal_translate_38.img")
+    ds = gdal.Open(dst2_tif)
     assert ds is not None
 
     rat = ds.GetRasterBand(1).GetDefaultRAT()
@@ -993,13 +1034,15 @@ def test_gdal_translate_37(gdal_translate_path):
 # Test -nogcp options
 
 
-def test_gdal_translate_39(gdal_translate_path):
+def test_gdal_translate_39(gdal_translate_path, tmp_path):
+
+    dst_tif = str(tmp_path / "test39.tif")
 
     gdaltest.runexternal(
-        gdal_translate_path + " -nogcp ../gcore/data/byte_gcp.tif tmp/test39.tif"
+        f"{gdal_translate_path} -nogcp ../gcore/data/byte_gcp.tif {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/test39.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
@@ -1046,133 +1089,3 @@ def test_gdal_translate_scale_and_unscale_incompatible(gdal_translate_path):
         + " -a_scale 0.0001 -a_offset 0.1 -unscale ../gcore/data/byte.tif /vsimem/out.tif"
     )
     assert "-a_scale/-a_offset are not applied by -unscale" in err
-
-
-###############################################################################
-# Cleanup
-
-
-def test_gdal_translate_cleanup():
-    for i in range(14):
-        try:
-            os.remove("tmp/test" + str(i + 1) + ".tif")
-        except OSError:
-            pass
-        try:
-            os.remove("tmp/test" + str(i + 1) + ".tif.aux.xml")
-        except OSError:
-            pass
-    try:
-        os.remove("tmp/test15_1.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/test16.vrt")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/test17.vrt")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/test18_1.vrt")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/test18_2.vrt")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/test18_2.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/test_gdal_translate_19_src.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/test_gdal_translate_19_dst.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/test_gdal_translate_20_src.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/test_gdal_translate_20_dst.tif")
-    except OSError:
-        pass
-    try:
-        gdal.GetDriverByName("HFA").Delete("tmp/test_gdal_translate_21.img")
-    except (AttributeError, RuntimeError):
-        pass
-    try:
-        gdal.GetDriverByName("HFA").Delete("tmp/test_gdal_translate_22.img")
-    except (AttributeError, RuntimeError):
-        pass
-    try:
-        gdal.GetDriverByName("GTiff").Delete("tmp/test_gdal_translate_23.tif")
-    except (AttributeError, RuntimeError):
-        pass
-    try:
-        os.remove("tmp/test_gdal_translate_24.tif")
-    except OSError:
-        pass
-    try:
-        gdal.GetDriverByName("GTiff").Delete("tmp/test_gdal_translate_25.tif")
-    except (AttributeError, RuntimeError):
-        pass
-    try:
-        gdal.GetDriverByName("XYZ").Delete("tmp/test_gdal_translate_26.xyz")
-        gdal.GetDriverByName("GTiff").Delete("tmp/test_gdal_translate_26.tif")
-    except (AttributeError, RuntimeError):
-        pass
-    try:
-        gdal.GetDriverByName("AAIGRID").Delete("tmp/test_gdal_translate_27.asc")
-        gdal.GetDriverByName("GTiff").Delete("tmp/test_gdal_translate_27.tif")
-    except (AttributeError, RuntimeError):
-        pass
-    try:
-        gdal.GetDriverByName("GTiff").Delete("tmp/test_gdal_translate_28.tif")
-    except (AttributeError, RuntimeError):
-        pass
-    try:
-        os.remove("tmp/test_gdal_translate_29.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/test_gdal_translate_29.vrt")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/test_gdal_translate_30.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/test_gdal_translate_31.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/test_gdal_translate_32.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/test_gdal_translate_36.tif")
-    except Exception:
-        pass
-    try:
-        os.remove("tmp/test_gdal_translate_36.tif.aux.xml")
-    except Exception:
-        pass
-    try:
-        os.remove("tmp/test_gdal_translate_37.tif")
-    except Exception:
-        pass
-    try:
-        os.remove("tmp/test_gdal_translate_37.tif.aux.xml")
-    except Exception:
-        pass
-    try:
-        gdal.GetDriverByName("HFA").Delete("tmp/test_gdal_translate_38.img")
-    except Exception:
-        pass

--- a/autotest/utilities/test_gdal_translate_lib.py
+++ b/autotest/utilities/test_gdal_translate_lib.py
@@ -42,18 +42,20 @@ from osgeo import gdal, osr
 # Simple test
 
 
-def test_gdal_translate_lib_1():
+def test_gdal_translate_lib_1(tmp_path):
+
+    dst_tif = str(tmp_path / "test1.tif")
 
     ds = gdal.Open("../gcore/data/byte.tif")
 
-    ds = gdal.Translate("tmp/test1.tif", ds)
+    ds = gdal.Translate(dst_tif, ds)
     assert ds is not None, "got error/warning"
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
 
     ds = None
 
-    ds = gdal.Open("tmp/test1.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
@@ -71,12 +73,14 @@ def mycallback(pct, msg, user_data):
     return 1
 
 
-def test_gdal_translate_lib_2():
+def test_gdal_translate_lib_2(tmp_path):
+
+    dst_tif = str(tmp_path / "test2.tif")
 
     src_ds = gdal.Open("../gcore/data/byte.tif")
     tab = [0]
     ds = gdal.Translate(
-        "tmp/test2.tif", src_ds, format="GTiff", callback=mycallback, callback_data=tab
+        dst_tif, src_ds, format="GTiff", callback=mycallback, callback_data=tab
     )
     assert ds is not None
 
@@ -91,10 +95,12 @@ def test_gdal_translate_lib_2():
 # Test outputType option
 
 
-def test_gdal_translate_lib_3():
+def test_gdal_translate_lib_3(tmp_path):
+
+    dst_tif = str(tmp_path / "test3.tif")
 
     ds = gdal.Open("../gcore/data/byte.tif")
-    ds = gdal.Translate("tmp/test3.tif", ds, outputType=gdal.GDT_Int16)
+    ds = gdal.Translate(dst_tif, ds, outputType=gdal.GDT_Int16)
     assert ds is not None
 
     assert ds.GetRasterBand(1).DataType == gdal.GDT_Int16, "Bad data type"
@@ -108,11 +114,13 @@ def test_gdal_translate_lib_3():
 # Test bandList option
 
 
-def test_gdal_translate_lib_4():
+def test_gdal_translate_lib_4(tmp_path):
+
+    dst_tif = str(tmp_path / "test4.tif")
 
     ds = gdal.Open("../gcore/data/rgbsmall.tif")
 
-    ds = gdal.Translate("tmp/test4.tif", ds, bandList=[3, 2, 1])
+    ds = gdal.Translate(dst_tif, ds, bandList=[3, 2, 1])
     assert ds is not None, "got error/warning"
 
     assert ds.GetRasterBand(1).Checksum() == 21349, "Bad checksum"
@@ -129,10 +137,12 @@ def test_gdal_translate_lib_4():
 
 
 @pytest.mark.require_driver("GIF")
-def test_gdal_translate_lib_5():
+def test_gdal_translate_lib_5(tmp_path):
+
+    dst_tif = str(tmp_path / "test5.tif")
 
     ds = gdal.Open("../gdrivers/data/gif/bug407.gif")
-    ds = gdal.Translate("tmp/test5.tif", ds, rgbExpand="rgb")
+    ds = gdal.Translate(dst_tif, ds, rgbExpand="rgb")
     assert ds is not None
 
     assert (
@@ -160,10 +170,12 @@ def test_gdal_translate_lib_5():
 # Test oXSizePixel and oYSizePixel option
 
 
-def test_gdal_translate_lib_6():
+def test_gdal_translate_lib_6(tmp_path):
+
+    dst_tif = str(tmp_path / "test6.tif")
 
     ds = gdal.Open("../gcore/data/byte.tif")
-    ds = gdal.Translate("tmp/test6.tif", ds, width=40, height=40)
+    ds = gdal.Translate(dst_tif, ds, width=40, height=40)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 18784, "Bad checksum"
@@ -175,10 +187,12 @@ def test_gdal_translate_lib_6():
 # Test oXSizePct and oYSizePct option
 
 
-def test_gdal_translate_lib_7():
+def test_gdal_translate_lib_7(tmp_path):
+
+    dst_tif = str(tmp_path / "test7.tif")
 
     ds = gdal.Open("../gcore/data/byte.tif")
-    ds = gdal.Translate("tmp/test7.tif", ds, widthPct=200.0, heightPct=200.0)
+    ds = gdal.Translate(dst_tif, ds, widthPct=200.0, heightPct=200.0)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 18784, "Bad checksum"
@@ -190,7 +204,9 @@ def test_gdal_translate_lib_7():
 # Test outputSRS and GCPs options
 
 
-def test_gdal_translate_lib_8():
+def test_gdal_translate_lib_8(tmp_path):
+
+    dst_tif = str(tmp_path / "test8.tif")
 
     gcpList = [
         gdal.GCP(440720.000, 3751320.000, 0, 0, 0),
@@ -199,7 +215,7 @@ def test_gdal_translate_lib_8():
         gdal.GCP(440720.000, 3750120.000, 0, 0, 20),
     ]
     ds = gdal.Open("../gcore/data/byte.tif")
-    ds = gdal.Translate("tmp/test8.tif", ds, outputSRS="EPSG:26711", GCPs=gcpList)
+    ds = gdal.Translate(dst_tif, ds, outputSRS="EPSG:26711", GCPs=gcpList)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
@@ -216,10 +232,12 @@ def test_gdal_translate_lib_8():
 # Test nodata option
 
 
-def test_gdal_translate_lib_9():
+def test_gdal_translate_lib_9(tmp_path):
+
+    dst_tif = str(tmp_path / "test9.tif")
 
     ds = gdal.Open("../gcore/data/byte.tif")
-    ds = gdal.Translate("tmp/test9.tif", ds, noData=1)
+    ds = gdal.Translate(dst_tif, ds, noData=1)
     assert ds is not None
 
     assert ds.GetRasterBand(1).GetNoDataValue() == 1, "Bad nodata value"
@@ -263,10 +281,12 @@ def test_gdal_translate_lib_nodata_int64():
 # Test srcWin option
 
 
-def test_gdal_translate_lib_10():
+def test_gdal_translate_lib_10(tmp_path):
+
+    dst_tif = str(tmp_path / "test10.tif")
 
     ds = gdal.Open("../gcore/data/byte.tif")
-    ds = gdal.Translate("tmp/test10.tif", ds, srcWin=[0, 0, 1, 1])
+    ds = gdal.Translate(dst_tif, ds, srcWin=[0, 0, 1, 1])
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 2, "Bad checksum"
@@ -278,11 +298,13 @@ def test_gdal_translate_lib_10():
 # Test projWin option
 
 
-def test_gdal_translate_lib_11():
+def test_gdal_translate_lib_11(tmp_path):
+
+    dst_tif = str(tmp_path / "test11.tif")
 
     ds = gdal.Open("../gcore/data/byte.tif")
     ds = gdal.Translate(
-        "tmp/test11.tif", ds, projWin=[440720.000, 3751320.000, 441920.000, 3750120.000]
+        dst_tif, ds, projWin=[440720.000, 3751320.000, 441920.000, 3750120.000]
     )
     assert ds is not None
 
@@ -301,11 +323,13 @@ def test_gdal_translate_lib_11():
 # Test outputBounds option
 
 
-def test_gdal_translate_lib_12():
+def test_gdal_translate_lib_12(tmp_path):
+
+    dst_tif = str(tmp_path / "test12.tif")
 
     ds = gdal.Open("../gcore/data/byte.tif")
     ds = gdal.Translate(
-        "tmp/test12.tif",
+        dst_tif,
         ds,
         outputBounds=[440720.000, 3751320.000, 441920.000, 3750120.000],
     )
@@ -326,7 +350,7 @@ def test_gdal_translate_lib_12():
 # Test metadataOptions
 
 
-def test_gdal_translate_lib_13():
+def test_gdal_translate_lib_13(tmp_path):
 
     src_ds = gdal.Open("../gcore/data/byte.tif")
 
@@ -355,10 +379,12 @@ def test_gdal_translate_lib_13():
 # Test creationOptions
 
 
-def test_gdal_translate_lib_14():
+def test_gdal_translate_lib_14(tmp_path):
+
+    dst_tif = str(tmp_path / "test14.tif")
 
     ds = gdal.Open("../gcore/data/byte.tif")
-    ds = gdal.Translate("tmp/test14.tif", ds, creationOptions=["COMPRESS=LZW"])
+    ds = gdal.Translate(dst_tif, ds, creationOptions=["COMPRESS=LZW"])
     assert ds is not None
 
     md = ds.GetMetadata("IMAGE_STRUCTURE")
@@ -578,10 +604,12 @@ def test_gdal_translate_lib_colorinterp():
 # Test nogcp options
 
 
-def test_gdal_translate_lib_110():
+def test_gdal_translate_lib_110(tmp_path):
+
+    dst_tif = str(tmp_path / "test110.tif")
 
     ds = gdal.Open("../gcore/data/byte_gcp.tif")
-    ds = gdal.Translate("tmp/test110.tif", ds, nogcp="True")
+    ds = gdal.Translate(dst_tif, ds, nogcp="True")
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
@@ -596,29 +624,33 @@ def test_gdal_translate_lib_110():
 # Test noxmp options
 
 
-def test_gdal_translate_lib_111():
+def test_gdal_translate_lib_111(tmp_path):
+
+    dst_tif = str(tmp_path / "test111noxmp.tif")
+    dst2_tif = str(tmp_path / "test111notcopied.tif")
+    dst3_tif = str(tmp_path / "test111.tif")
 
     ds = gdal.Open("../gdrivers/data/gtiff/byte_with_xmp.tif")
-    new_ds = gdal.Translate("tmp/test111noxmp.tif", ds, options="-noxmp")
+    new_ds = gdal.Translate(dst_tif, ds, options="-noxmp")
     assert new_ds is not None
     xmp = new_ds.GetMetadata("xml:XMP")
     new_ds = None
     assert xmp is None
 
     # codepath if some other options are set is different, creating a VRTdataset
-    new_ds = gdal.Translate("tmp/test111notcopied.tif", ds, nogcp="True")
+    new_ds = gdal.Translate(dst2_tif, ds, nogcp="True")
     assert new_ds is not None
     new_ds = None
-    new_ds = gdal.Open("tmp/test111notcopied.tif")
+    new_ds = gdal.Open(dst2_tif)
     xmp = new_ds.GetMetadata("xml:XMP")
     new_ds = None
     assert "W5M0MpCehiHzreSzNTczkc9d" in xmp[0], "Wrong output file without XMP"
 
     # normal codepath calling CreateCopy directly
-    new_ds = gdal.Translate("tmp/test111.tif", ds)
+    new_ds = gdal.Translate(dst3_tif, ds)
     assert new_ds is not None
     new_ds = None
-    new_ds = gdal.Open("tmp/test111.tif")
+    new_ds = gdal.Open(dst3_tif)
     xmp = new_ds.GetMetadata("xml:XMP")
     new_ds = None
     assert "W5M0MpCehiHzreSzNTczkc9d" in xmp[0], "Wrong output file without XMP"
@@ -626,19 +658,22 @@ def test_gdal_translate_lib_111():
     ds = None
 
 
-def test_gdal_translate_lib_112():
+def test_gdal_translate_lib_112(tmp_path):
+
+    dst_tif = str(tmp_path / "test112noxmp.tif")
+    dst2_tif = str(tmp_path / "test112.tif")
 
     ds = gdal.Open("../gdrivers/data/gtiff/byte_with_xmp.tif")
-    new_ds = gdal.Translate("tmp/test112noxmp.tif", ds, options="-of COG -noxmp")
+    new_ds = gdal.Translate(dst_tif, ds, options="-of COG -noxmp")
     assert new_ds is not None
     xmp = new_ds.GetMetadata("xml:XMP")
     new_ds = None
     assert xmp is None
 
-    new_ds = gdal.Translate("tmp/test112.tif", ds, format="COG")
+    new_ds = gdal.Translate(dst2_tif, ds, format="COG")
     assert new_ds is not None
     new_ds = None
-    new_ds = gdal.Open("tmp/test112.tif")
+    new_ds = gdal.Open(dst2_tif)
     xmp = new_ds.GetMetadata("xml:XMP")
     new_ds = None
     assert "W5M0MpCehiHzreSzNTczkc9d" in xmp[0], "Wrong output file without XMP"
@@ -830,26 +865,23 @@ def test_gdal_translate_lib_resampling_methods(resampleAlg, resampleAlgStr):
 # overwritten (https://github.com/OSGeo/gdal/issues/5633)
 
 
-def test_gdal_translate_lib_not_delete_shared_auxiliary_files():
+def test_gdal_translate_lib_not_delete_shared_auxiliary_files(tmp_path):
+
+    img_foo_r1c1_jp2 = str(tmp_path / "IMG_foo_R1C1.JP2")
+    img_foo_r1c1_tif = str(tmp_path / "IMG_foo_R1C1.tif")
+    dim_foo_xml = str(tmp_path / "DIM_foo.XML")
 
     # Yes, we do intend to copy a .TIF as a fake .JP2
-    shutil.copy(
-        "../gdrivers/data/dimap2/bundle/IMG_foo_R1C1.TIF", "tmp/IMG_foo_R1C1.JP2"
-    )
-    shutil.copy("../gdrivers/data/dimap2/bundle/DIM_foo.XML", "tmp/DIM_foo.XML")
+    shutil.copy("../gdrivers/data/dimap2/bundle/IMG_foo_R1C1.TIF", img_foo_r1c1_jp2)
+    shutil.copy("../gdrivers/data/dimap2/bundle/DIM_foo.XML", dim_foo_xml)
 
-    gdal.Translate("tmp/IMG_foo_R1C1.tif", "tmp/IMG_foo_R1C1.JP2")
+    gdal.Translate(img_foo_r1c1_tif, img_foo_r1c1_jp2)
 
-    os.unlink("tmp/IMG_foo_R1C1.IMD")
+    os.unlink(f"{tmp_path}/IMG_foo_R1C1.IMD")
 
-    gdal.Translate("tmp/IMG_foo_R1C1.tif", "tmp/IMG_foo_R1C1.JP2")
+    gdal.Translate(img_foo_r1c1_tif, img_foo_r1c1_jp2)
 
-    assert os.path.exists("tmp/DIM_foo.XML")
-
-    os.unlink("tmp/IMG_foo_R1C1.JP2")
-    os.unlink("tmp/IMG_foo_R1C1.tif")
-    os.unlink("tmp/IMG_foo_R1C1.IMD")
-    os.unlink("tmp/DIM_foo.XML")
+    assert os.path.exists(f"{tmp_path}/DIM_foo.XML")
 
 
 ###############################################################################
@@ -1057,19 +1089,3 @@ def test_gdal_translate_lib_scale_and_unscale_incompatible():
             unscale=True,
             outputType=gdal.GDT_UInt16,
         )
-
-
-###############################################################################
-# Cleanup
-
-
-def test_gdal_translate_lib_cleanup():
-    for i in range(14):
-        try:
-            os.remove("tmp/test" + str(i + 1) + ".tif")
-        except OSError:
-            pass
-        try:
-            os.remove("tmp/test" + str(i + 1) + ".tif.aux.xml")
-        except OSError:
-            pass

--- a/autotest/utilities/test_gdaladdo.py
+++ b/autotest/utilities/test_gdaladdo.py
@@ -54,36 +54,32 @@ def gdaladdo_path():
 # Similar to tiff_ovr_1
 
 
-def test_gdaladdo_1(gdaladdo_path):
+def test_gdaladdo_1(gdaladdo_path, tmp_path):
 
-    shutil.copy("../gcore/data/mfloat32.vrt", "tmp/mfloat32.vrt")
-    shutil.copy("../gcore/data/float32.tif", "tmp/float32.tif")
+    shutil.copy("../gcore/data/mfloat32.vrt", f"{tmp_path}/mfloat32.vrt")
+    shutil.copy("../gcore/data/float32.tif", f"{tmp_path}/float32.tif")
 
-    (_, err) = gdaltest.runexternal_out_and_err(gdaladdo_path + " tmp/mfloat32.vrt 2 4")
+    (_, err) = gdaltest.runexternal_out_and_err(
+        f"{gdaladdo_path} {tmp_path}/mfloat32.vrt 2 4"
+    )
     assert err is None or err == "", "got error/warning"
 
-    ds = gdal.Open("tmp/mfloat32.vrt")
-    ret = tiff_ovr.tiff_ovr_check(ds)
+    ds = gdal.Open(f"{tmp_path}/mfloat32.vrt")
+    tiff_ovr.tiff_ovr_check(ds)
     ds = None
-
-    os.remove("tmp/mfloat32.vrt")
-    os.remove("tmp/mfloat32.vrt.ovr")
-    os.remove("tmp/float32.tif")
-
-    return ret
 
 
 ###############################################################################
 # Test -r average. Similar to tiff_ovr_5
 
 
-def test_gdaladdo_2(gdaladdo_path):
+def test_gdaladdo_2(gdaladdo_path, tmp_path):
 
-    shutil.copyfile("../gcore/data/nodata_byte.tif", "tmp/ovr5.tif")
+    shutil.copyfile("../gcore/data/nodata_byte.tif", f"{tmp_path}/ovr5.tif")
 
-    gdaltest.runexternal(gdaladdo_path + " -r average tmp/ovr5.tif 2")
+    gdaltest.runexternal(f"{gdaladdo_path} -r average {tmp_path}/ovr5.tif 2")
 
-    ds = gdal.Open("tmp/ovr5.tif")
+    ds = gdal.Open(f"{tmp_path}/ovr5.tif")
     cs = ds.GetRasterBand(1).GetOverview(0).Checksum()
     exp_cs = 1130
 
@@ -91,24 +87,22 @@ def test_gdaladdo_2(gdaladdo_path):
 
     ds = None
 
-    os.remove("tmp/ovr5.tif")
-
 
 ###############################################################################
 # Test -ro
 
 
-def test_gdaladdo_3(gdaladdo_path):
+def test_gdaladdo_3(gdaladdo_path, tmp_path):
 
     gdal.Translate(
-        "tmp/test_gdaladdo_3.tif",
+        f"{tmp_path}/test_gdaladdo_3.tif",
         "../gcore/data/nodata_byte.tif",
         options="-outsize 1024 1024",
     )
 
-    gdaltest.runexternal(gdaladdo_path + " -ro tmp/test_gdaladdo_3.tif 2")
+    gdaltest.runexternal(f"{gdaladdo_path} -ro {tmp_path}/test_gdaladdo_3.tif 2")
 
-    ds = gdal.Open("tmp/test_gdaladdo_3.tif")
+    ds = gdal.Open(f"{tmp_path}/test_gdaladdo_3.tif")
     cs = ds.GetRasterBand(1).GetOverview(0).Checksum()
     exp_cs = 20683
 
@@ -117,81 +111,88 @@ def test_gdaladdo_3(gdaladdo_path):
     ds = None
 
     try:
-        os.stat("tmp/test_gdaladdo_3.tif.ovr")
+        os.stat(f"{tmp_path}/test_gdaladdo_3.tif.ovr")
     except OSError:
         pytest.fail("no external overview.")
 
     # Test -clean
 
-    gdaltest.runexternal(gdaladdo_path + " -clean tmp/test_gdaladdo_3.tif")
+    gdaltest.runexternal(f"{gdaladdo_path} -clean {tmp_path}/test_gdaladdo_3.tif")
 
-    ds = gdal.Open("tmp/test_gdaladdo_3.tif")
+    ds = gdal.Open(f"{tmp_path}/test_gdaladdo_3.tif")
     cnt = ds.GetRasterBand(1).GetOverviewCount()
     ds = None
 
     assert cnt == 0, "did not clean overviews."
 
-    assert not os.path.exists("tmp/test_gdaladdo_3.tif.ovr")
-
-    os.remove("tmp/test_gdaladdo_3.tif")
+    assert not os.path.exists(f"{tmp_path}/test_gdaladdo_3.tif.ovr")
 
 
 ###############################################################################
 # Test implicit levels
 
 
-def test_gdaladdo_5(gdaladdo_path):
+def test_gdaladdo_5(gdaladdo_path, tmp_path):
 
-    shutil.copyfile("../gcore/data/nodata_byte.tif", "tmp/test_gdaladdo_5.tif")
+    input_tif = str(tmp_path / "test_gdaladdo_5.tif")
+
+    shutil.copyfile("../gcore/data/nodata_byte.tif", input_tif)
 
     # Will not do anything given than the file is smaller than 256x256 already
-    gdaltest.runexternal(gdaladdo_path + " tmp/test_gdaladdo_5.tif")
+    gdaltest.runexternal(f"{gdaladdo_path} {input_tif}")
 
-    ds = gdal.Open("tmp/test_gdaladdo_5.tif")
+    ds = gdal.Open(input_tif)
     cnt = ds.GetRasterBand(1).GetOverviewCount()
     ds = None
 
     assert cnt == 0
 
     # Will generate overviews of size 10 5 3 2 1
-    gdaltest.runexternal(gdaladdo_path + " -minsize 1 tmp/test_gdaladdo_5.tif")
+    gdaltest.runexternal(f"{gdaladdo_path} -minsize 1 {input_tif}")
 
-    ds = gdal.Open("tmp/test_gdaladdo_5.tif")
+    ds = gdal.Open(input_tif)
     cnt = ds.GetRasterBand(1).GetOverviewCount()
     ds = None
 
     assert cnt == 5
 
+
+def test_gdaladdo_5bis(gdaladdo_path, tmp_path):
+
+    input_tif = str(tmp_path / "test_gdaladdo_5.tif")
+
+    shutil.copyfile("../gcore/data/nodata_byte.tif", input_tif)
+
     gdal.Translate(
-        "tmp/test_gdaladdo_5.tif",
+        input_tif,
         "../gcore/data/nodata_byte.tif",
         options="-outsize 257 257",
     )
 
     # Will generate overviews of size 129x129
-    gdaltest.runexternal(gdaladdo_path + " tmp/test_gdaladdo_5.tif")
+    gdaltest.runexternal(f"{gdaladdo_path} {input_tif}")
 
-    ds = gdal.Open("tmp/test_gdaladdo_5.tif")
+    ds = gdal.Open(input_tif)
     cnt = ds.GetRasterBand(1).GetOverviewCount()
     ds = None
 
     assert cnt == 1
-
-    os.remove("tmp/test_gdaladdo_5.tif")
 
 
 ###############################################################################
 # Test --partial-refresh-from-projwin
 
 
-def test_gdaladdo_partial_refresh_from_projwin(gdaladdo_path):
+def test_gdaladdo_partial_refresh_from_projwin(gdaladdo_path, tmp_path):
+
+    input_tif = str(tmp_path / "tmp.tif")
 
     gdal.Translate(
-        "tmp/tmp.tif", "../gcore/data/byte.tif", options="-outsize 512 512 -r cubic"
+        input_tif, "../gcore/data/byte.tif", options="-outsize 512 512 -r cubic"
     )
-    gdaltest.runexternal(gdaladdo_path + " -r bilinear tmp/tmp.tif 2 4")
+    gdaltest.runexternal(f"{gdaladdo_path} -r bilinear {input_tif} 2 4")
 
-    ds = gdal.Open("tmp/tmp.tif", gdal.GA_Update)
+    ds = gdal.Open(input_tif, gdal.GA_Update)
     ovr_data_ori = array.array("B", ds.GetRasterBand(1).GetOverview(0).ReadRaster())
     ds.GetRasterBand(1).Fill(0)
     gt = ds.GetGeoTransform()
@@ -207,11 +208,11 @@ def test_gdaladdo_partial_refresh_from_projwin(gdaladdo_path):
     lry = gt[3] + gt[5] * (y + height)
     out, err = gdaltest.runexternal_out_and_err(
         gdaladdo_path
-        + f" -r bilinear --partial-refresh-from-projwin {ulx} {uly} {lrx} {lry} tmp/tmp.tif 2"
+        + f" -r bilinear --partial-refresh-from-projwin {ulx} {uly} {lrx} {lry} {input_tif} 2"
     )
     assert "ERROR" not in err, (out, err)
 
-    ds = gdal.Open("tmp/tmp.tif")
+    ds = gdal.Open(input_tif)
     ovr_band = ds.GetRasterBand(1).GetOverview(0)
     ovr_data_refreshed = array.array("B", ovr_band.ReadRaster())
     # Test that data is zero only in the refreshed area, and unchanged
@@ -224,51 +225,48 @@ def test_gdaladdo_partial_refresh_from_projwin(gdaladdo_path):
     assert ovr_data_refreshed == ovr_data_ori
     ds = None
 
-    gdal.GetDriverByName("GTiff").Delete("tmp/tmp.tif")
-
 
 ###############################################################################
 # Test --partial-refresh-from-source-timestamp
 
 
-def test_gdaladdo_partial_refresh_from_source_timestamp(gdaladdo_path):
+def test_gdaladdo_partial_refresh_from_source_timestamp(gdaladdo_path, tmp_path):
 
-    gdal.Translate(
-        "tmp/left.tif", "../gcore/data/byte.tif", options="-srcwin 0 0 10 20"
-    )
-    gdal.Translate(
-        "tmp/right.tif", "../gcore/data/byte.tif", options="-srcwin 10 0 10 20"
-    )
-    gdal.BuildVRT("tmp/tmp.vrt", ["tmp/left.tif", "tmp/right.tif"])
-    gdaltest.runexternal(gdaladdo_path + " -r bilinear tmp/tmp.vrt 2")
+    left_tif = str(tmp_path / "left.tif")
+    right_tif = str(tmp_path / "right.tif")
+    tmp_vrt = str(tmp_path / "tmp.vrt")
 
-    ds = gdal.Open("tmp/tmp.vrt", gdal.GA_Update)
+    gdal.Translate(left_tif, "../gcore/data/byte.tif", options="-srcwin 0 0 10 20")
+    gdal.Translate(right_tif, "../gcore/data/byte.tif", options="-srcwin 10 0 10 20")
+    gdal.BuildVRT(tmp_vrt, [left_tif, right_tif])
+    gdaltest.runexternal(f"{gdaladdo_path} -r bilinear {tmp_vrt} 2")
+
+    ds = gdal.Open(tmp_vrt, gdal.GA_Update)
     ovr_data_ori = array.array("B", ds.GetRasterBand(1).GetOverview(0).ReadRaster())
     ds = None
 
-    ds = gdal.Open("tmp/left.tif", gdal.GA_Update)
+    ds = gdal.Open(left_tif, gdal.GA_Update)
     ds.GetRasterBand(1).Fill(0)
     ds = None
 
     # Make sure timestamp of left.tif is before tmp.vrt.ovr
-    timestamp = int(os.stat("tmp/tmp.vrt.ovr").st_mtime) - 10
-    os.utime("tmp/left.tif", times=(timestamp, timestamp))
+    timestamp = int(os.stat(tmp_vrt + ".ovr").st_mtime) - 10
+    os.utime(left_tif, times=(timestamp, timestamp))
 
-    ds = gdal.Open("tmp/right.tif", gdal.GA_Update)
+    ds = gdal.Open(right_tif, gdal.GA_Update)
     ds.GetRasterBand(1).Fill(0)
     ds = None
 
     # Make sure timestamp of right.tif is after tmp.vrt.ovr
-    timestamp = int(os.stat("tmp/tmp.vrt.ovr").st_mtime) + 10
-    os.utime("tmp/right.tif", times=(timestamp, timestamp))
+    timestamp = int(os.stat(tmp_vrt + ".ovr").st_mtime) + 10
+    os.utime(right_tif, times=(timestamp, timestamp))
 
     out, err = gdaltest.runexternal_out_and_err(
-        gdaladdo_path
-        + " -r bilinear --partial-refresh-from-source-timestamp tmp/tmp.vrt"
+        f"{gdaladdo_path} -r bilinear --partial-refresh-from-source-timestamp {tmp_vrt}"
     )
     assert "ERROR" not in err, (out, err)
 
-    ds = gdal.Open("tmp/tmp.vrt")
+    ds = gdal.Open(tmp_vrt)
     ovr_band = ds.GetRasterBand(1).GetOverview(0)
     ovr_data_refreshed = array.array("B", ovr_band.ReadRaster())
     # Test that data is zero only in the refreshed area, and unchanged
@@ -280,47 +278,41 @@ def test_gdaladdo_partial_refresh_from_source_timestamp(gdaladdo_path):
             ovr_data_refreshed[idx] = ovr_data_ori[idx]
     assert ovr_data_refreshed == ovr_data_ori
     ds = None
-
-    gdal.GetDriverByName("VRT").Delete("tmp/tmp.vrt")
-    gdal.GetDriverByName("GTiff").Delete("tmp/tmp.vrt.ovr")
-    gdal.GetDriverByName("GTiff").Delete("tmp/left.tif")
-    gdal.GetDriverByName("GTiff").Delete("tmp/right.tif")
 
 
 ###############################################################################
 # Test --partial-refresh-from-source-extent
 
 
-def test_gdaladdo_partial_refresh_from_source_extent(gdaladdo_path):
+def test_gdaladdo_partial_refresh_from_source_extent(gdaladdo_path, tmp_path):
 
-    gdal.Translate(
-        "tmp/left.tif", "../gcore/data/byte.tif", options="-srcwin 0 0 10 20"
-    )
-    gdal.Translate(
-        "tmp/right.tif", "../gcore/data/byte.tif", options="-srcwin 10 0 10 20"
-    )
-    gdal.BuildVRT("tmp/tmp.vrt", ["tmp/left.tif", "tmp/right.tif"])
-    gdaltest.runexternal(gdaladdo_path + " -r bilinear tmp/tmp.vrt 2")
+    left_tif = str(tmp_path / "left.tif")
+    right_tif = str(tmp_path / "right.tif")
+    tmp_vrt = str(tmp_path / "tmp.vrt")
 
-    ds = gdal.Open("tmp/tmp.vrt", gdal.GA_Update)
+    gdal.Translate(left_tif, "../gcore/data/byte.tif", options="-srcwin 0 0 10 20")
+    gdal.Translate(right_tif, "../gcore/data/byte.tif", options="-srcwin 10 0 10 20")
+    gdal.BuildVRT(tmp_vrt, [left_tif, right_tif])
+    gdaltest.runexternal(f"{gdaladdo_path} -r bilinear {tmp_vrt} 2")
+
+    ds = gdal.Open(tmp_vrt, gdal.GA_Update)
     ovr_data_ori = array.array("B", ds.GetRasterBand(1).GetOverview(0).ReadRaster())
     ds = None
 
-    ds = gdal.Open("tmp/left.tif", gdal.GA_Update)
+    ds = gdal.Open(left_tif, gdal.GA_Update)
     ds.GetRasterBand(1).Fill(0)
     ds = None
 
-    ds = gdal.Open("tmp/right.tif", gdal.GA_Update)
+    ds = gdal.Open(right_tif, gdal.GA_Update)
     ds.GetRasterBand(1).Fill(0)
     ds = None
 
     out, err = gdaltest.runexternal_out_and_err(
-        gdaladdo_path
-        + " -r bilinear --partial-refresh-from-source-extent tmp/right.tif tmp/tmp.vrt"
+        f"{gdaladdo_path} -r bilinear --partial-refresh-from-source-extent {right_tif} {tmp_vrt}"
     )
     assert "ERROR" not in err, (out, err)
 
-    ds = gdal.Open("tmp/tmp.vrt")
+    ds = gdal.Open(tmp_vrt)
     ovr_band = ds.GetRasterBand(1).GetOverview(0)
     ovr_data_refreshed = array.array("B", ovr_band.ReadRaster())
     # Test that data is zero only in the refreshed area, and unchanged
@@ -332,8 +324,3 @@ def test_gdaladdo_partial_refresh_from_source_extent(gdaladdo_path):
             ovr_data_refreshed[idx] = ovr_data_ori[idx]
     assert ovr_data_refreshed == ovr_data_ori
     ds = None
-
-    gdal.GetDriverByName("VRT").Delete("tmp/tmp.vrt")
-    gdal.GetDriverByName("GTiff").Delete("tmp/tmp.vrt.ovr")
-    gdal.GetDriverByName("GTiff").Delete("tmp/left.tif")
-    gdal.GetDriverByName("GTiff").Delete("tmp/right.tif")

--- a/autotest/utilities/test_gdaldem.py
+++ b/autotest/utilities/test_gdaldem.py
@@ -51,16 +51,17 @@ def gdaldem_path():
 # Test gdaldem hillshade
 
 
-def test_gdaldem_hillshade(gdaldem_path):
+def test_gdaldem_hillshade(gdaldem_path, tmp_path):
+
+    output_tif = str(tmp_path / "n43_hillshade.tif")
 
     (_, err) = gdaltest.runexternal_out_and_err(
-        gdaldem_path
-        + " hillshade -s 111120 -z 30 ../gdrivers/data/n43.tif tmp/n43_hillshade.tif"
+        f"{gdaldem_path} hillshade -s 111120 -z 30 ../gdrivers/data/n43.tif {output_tif}"
     )
     assert err is None or err == "", "got error/warning"
 
     src_ds = gdal.Open("../gdrivers/data/n43.tif")
-    ds = gdal.Open("tmp/n43_hillshade.tif")
+    ds = gdal.Open(output_tif)
     assert ds is not None
 
     cs = ds.GetRasterBand(1).Checksum()
@@ -84,15 +85,16 @@ def test_gdaldem_hillshade(gdaldem_path):
 # Test gdaldem hillshade
 
 
-def test_gdaldem_hillshade_compressed_tiled_output(gdaldem_path):
+def test_gdaldem_hillshade_compressed_tiled_output(gdaldem_path, tmp_path):
+
+    output_tif = str(tmp_path / "n43_hillshade_compressed_tiled.tif")
 
     (_, err) = gdaltest.runexternal_out_and_err(
-        gdaldem_path
-        + " hillshade -s 111120 -z 30 ../gdrivers/data/n43.tif tmp/n43_hillshade_compressed_tiled.tif -co TILED=YES -co COMPRESS=DEFLATE --config GDAL_CACHEMAX 0"
+        f"{gdaldem_path} hillshade -s 111120 -z 30 ../gdrivers/data/n43.tif {output_tif} -co TILED=YES -co COMPRESS=DEFLATE --config GDAL_CACHEMAX 0"
     )
     assert err is None or err == "", "got error/warning"
 
-    ds = gdal.Open("tmp/n43_hillshade_compressed_tiled.tif")
+    ds = gdal.Open(output_tif)
     assert ds is not None
 
     cs = ds.GetRasterBand(1).Checksum()
@@ -100,7 +102,7 @@ def test_gdaldem_hillshade_compressed_tiled_output(gdaldem_path):
 
     ds = None
 
-    stat_compressed = os.stat("tmp/n43_hillshade_compressed_tiled.tif")
+    stat_compressed = os.stat(output_tif)
 
     assert (
         stat_compressed.st_size <= 15027
@@ -111,15 +113,16 @@ def test_gdaldem_hillshade_compressed_tiled_output(gdaldem_path):
 # Test gdaldem hillshade -combined
 
 
-def test_gdaldem_hillshade_combined(gdaldem_path):
+def test_gdaldem_hillshade_combined(gdaldem_path, tmp_path):
+
+    output_tif = str(tmp_path / "n43_hillshade_combined.tif")
 
     gdaltest.runexternal(
-        gdaldem_path
-        + " hillshade -s 111120 -z 30 -combined ../gdrivers/data/n43.tif tmp/n43_hillshade_combined.tif"
+        f"{gdaldem_path} hillshade -s 111120 -z 30 -combined ../gdrivers/data/n43.tif {output_tif}"
     )
 
     src_ds = gdal.Open("../gdrivers/data/n43.tif")
-    ds = gdal.Open("tmp/n43_hillshade_combined.tif")
+    ds = gdal.Open(output_tif)
     assert ds is not None
 
     cs = ds.GetRasterBand(1).Checksum()
@@ -143,14 +146,15 @@ def test_gdaldem_hillshade_combined(gdaldem_path):
 # Test gdaldem hillshade with -compute_edges
 
 
-def test_gdaldem_hillshade_compute_edges(gdaldem_path):
+def test_gdaldem_hillshade_compute_edges(gdaldem_path, tmp_path):
+
+    output_tif = str(tmp_path / "n43_hillshade_compute_edges.tif")
 
     gdaltest.runexternal(
-        gdaldem_path
-        + " hillshade -compute_edges -s 111120 -z 30 ../gdrivers/data/n43.tif tmp/n43_hillshade_compute_edges.tif"
+        f"{gdaldem_path} hillshade -compute_edges -s 111120 -z 30 ../gdrivers/data/n43.tif {output_tif}"
     )
 
-    ds = gdal.Open("tmp/n43_hillshade_compute_edges.tif")
+    ds = gdal.Open(output_tif)
     assert ds is not None
 
     cs = ds.GetRasterBand(1).Checksum()
@@ -163,9 +167,12 @@ def test_gdaldem_hillshade_compute_edges(gdaldem_path):
 # Test gdaldem hillshade with -az parameter
 
 
-def test_gdaldem_hillshade_azimuth(gdaldem_path):
+def test_gdaldem_hillshade_azimuth(gdaldem_path, tmp_path):
 
-    ds = gdal.GetDriverByName("GTiff").Create("tmp/pyramid.tif", 100, 100, 1)
+    input_tif = str(tmp_path / "pyramid.tif")
+    output_tif = str(tmp_path / "pyramid_shaded.tif")
+
+    ds = gdal.GetDriverByName("GTiff").Create(input_tif, 100, 100, 1)
     ds.SetGeoTransform([2, 0.01, 0, 49, 0, -0.01])
     sr = osr.SpatialReference()
     sr.ImportFromEPSG(4326)
@@ -182,12 +189,11 @@ def test_gdaldem_hillshade_azimuth(gdaldem_path):
 
     # Light from the east
     gdaltest.runexternal(
-        gdaldem_path
-        + " hillshade -s 111120 -z 100 -az 90 -co COMPRESS=LZW tmp/pyramid.tif tmp/pyramid_shaded.tif"
+        f"{gdaldem_path} hillshade -s 111120 -z 100 -az 90 -co COMPRESS=LZW {input_tif} {output_tif}"
     )
 
     ds_ref = gdal.Open("data/pyramid_shaded_ref.tif")
-    ds = gdal.Open("tmp/pyramid_shaded.tif")
+    ds = gdal.Open(output_tif)
     assert gdaltest.compare_ds(ds, ds_ref, verbose=1) <= 1, "Bad checksum"
     ds = None
     ds_ref = None
@@ -198,14 +204,15 @@ def test_gdaldem_hillshade_azimuth(gdaldem_path):
 
 
 @pytest.mark.require_driver("PNG")
-def test_gdaldem_hillshade_png(gdaldem_path):
+def test_gdaldem_hillshade_png(gdaldem_path, tmp_path):
+
+    output_png = str(tmp_path / "n43_hillshade.png")
 
     gdaltest.runexternal(
-        gdaldem_path
-        + " hillshade -of PNG  -s 111120 -z 30 ../gdrivers/data/n43.tif tmp/n43_hillshade.png"
+        f"{gdaldem_path} hillshade -of PNG  -s 111120 -z 30 ../gdrivers/data/n43.tif {output_png}"
     )
 
-    ds = gdal.Open("tmp/n43_hillshade.png")
+    ds = gdal.Open(output_png)
     assert ds is not None
 
     cs = ds.GetRasterBand(1).Checksum()
@@ -219,14 +226,15 @@ def test_gdaldem_hillshade_png(gdaldem_path):
 
 
 @pytest.mark.require_driver("PNG")
-def test_gdaldem_hillshade_png_compute_edges(gdaldem_path):
+def test_gdaldem_hillshade_png_compute_edges(gdaldem_path, tmp_path):
+
+    output_png = str(tmp_path / "n43_hillshade_compute_edges.png")
 
     gdaltest.runexternal(
-        gdaldem_path
-        + " hillshade -compute_edges -of PNG  -s 111120 -z 30 ../gdrivers/data/n43.tif tmp/n43_hillshade_compute_edges.png"
+        f"{gdaldem_path} hillshade -compute_edges -of PNG  -s 111120 -z 30 ../gdrivers/data/n43.tif {output_png}"
     )
 
-    ds = gdal.Open("tmp/n43_hillshade_compute_edges.png")
+    ds = gdal.Open(output_png)
     assert ds is not None
 
     cs = ds.GetRasterBand(1).Checksum()
@@ -239,14 +247,16 @@ def test_gdaldem_hillshade_png_compute_edges(gdaldem_path):
 # Test gdaldem slope
 
 
-def test_gdaldem_slope(gdaldem_path):
+def test_gdaldem_slope(gdaldem_path, tmp_path):
+
+    output_tif = str(tmp_path / "n43_slope.tif")
 
     gdaltest.runexternal(
-        gdaldem_path + " slope -s 111120 ../gdrivers/data/n43.tif tmp/n43_slope.tif"
+        f"{gdaldem_path} slope -s 111120 ../gdrivers/data/n43.tif {output_tif}"
     )
 
     src_ds = gdal.Open("../gdrivers/data/n43.tif")
-    ds = gdal.Open("tmp/n43_slope.tif")
+    ds = gdal.Open(output_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 63748, "Bad checksum"
@@ -269,14 +279,14 @@ def test_gdaldem_slope(gdaldem_path):
 # Test gdaldem aspect
 
 
-def test_gdaldem_aspect(gdaldem_path):
+def test_gdaldem_aspect(gdaldem_path, tmp_path):
 
-    gdaltest.runexternal(
-        gdaldem_path + " aspect ../gdrivers/data/n43.tif tmp/n43_aspect.tif"
-    )
+    output_tif = str(tmp_path / "n43_aspect.tif")
+
+    gdaltest.runexternal(f"{gdaldem_path} aspect ../gdrivers/data/n43.tif {output_tif}")
 
     src_ds = gdal.Open("../gdrivers/data/n43.tif")
-    ds = gdal.Open("tmp/n43_aspect.tif")
+    ds = gdal.Open(output_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 54885, "Bad checksum"
@@ -304,8 +314,7 @@ def n43_colorrelief_tif(gdaldem_path, tmp_path):
     n43_colorrelief_tif = str(tmp_path / "n43_colorrelief.tif")
 
     gdaltest.runexternal(
-        gdaldem_path
-        + f" color-relief ../gdrivers/data/n43.tif data/color_file.txt {n43_colorrelief_tif}"
+        f"{gdaldem_path} color-relief ../gdrivers/data/n43.tif data/color_file.txt {n43_colorrelief_tif}"
     )
 
     yield n43_colorrelief_tif
@@ -339,14 +348,15 @@ def test_gdaldem_color_relief(gdaldem_path, n43_colorrelief_tif):
 # Test gdaldem color relief on a GMT .cpt file
 
 
-def test_gdaldem_color_relief_cpt(gdaldem_path):
+def test_gdaldem_color_relief_cpt(gdaldem_path, tmp_path):
+
+    output_tif = str(tmp_path / "n43_colorrelief_cpt.tif")
 
     gdaltest.runexternal(
-        gdaldem_path
-        + " color-relief ../gdrivers/data/n43.tif data/color_file.cpt tmp/n43_colorrelief_cpt.tif"
+        f"{gdaldem_path} color-relief ../gdrivers/data/n43.tif data/color_file.cpt {output_tif}"
     )
     src_ds = gdal.Open("../gdrivers/data/n43.tif")
-    ds = gdal.Open("tmp/n43_colorrelief_cpt.tif")
+    ds = gdal.Open(output_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 55009, "Bad checksum"
@@ -371,14 +381,15 @@ def test_gdaldem_color_relief_cpt(gdaldem_path):
 # Test gdaldem color relief to VRT
 
 
-def test_gdaldem_color_relief_vrt(gdaldem_path, n43_colorrelief_tif):
+def test_gdaldem_color_relief_vrt(gdaldem_path, n43_colorrelief_tif, tmp_path):
+
+    output_vrt = str(tmp_path / "n43_colorrelief.vrt")
 
     gdaltest.runexternal(
-        gdaldem_path
-        + " color-relief -of VRT ../gdrivers/data/n43.tif data/color_file.txt tmp/n43_colorrelief.vrt"
+        f"{gdaldem_path} color-relief -of VRT ../gdrivers/data/n43.tif data/color_file.txt {output_vrt}"
     )
     src_ds = gdal.Open("../gdrivers/data/n43.tif")
-    ds = gdal.Open("tmp/n43_colorrelief.vrt")
+    ds = gdal.Open(output_vrt)
     assert ds is not None
 
     ds_ref = gdal.Open(n43_colorrelief_tif)
@@ -411,13 +422,14 @@ def n43_float32_tif(tmp_path):
     yield n43_float32_path
 
 
-def test_gdaldem_color_relief_from_float32(gdaldem_path, n43_float32_tif):
+def test_gdaldem_color_relief_from_float32(gdaldem_path, n43_float32_tif, tmp_path):
+
+    output_tif = str(tmp_path / "n43_colorrelief_from_float32.tif")
 
     gdaltest.runexternal(
-        gdaldem_path
-        + f" color-relief {n43_float32_tif} data/color_file.txt tmp/n43_colorrelief_from_float32.tif"
+        f"{gdaldem_path} color-relief {n43_float32_tif} data/color_file.txt {output_tif}"
     )
-    ds = gdal.Open("tmp/n43_colorrelief_from_float32.tif")
+    ds = gdal.Open(output_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 55009, "Bad checksum"
@@ -434,13 +446,14 @@ def test_gdaldem_color_relief_from_float32(gdaldem_path, n43_float32_tif):
 
 
 @pytest.mark.require_driver("PNG")
-def test_gdaldem_color_relief_png(gdaldem_path):
+def test_gdaldem_color_relief_png(gdaldem_path, tmp_path):
+
+    output_png = str(tmp_path / "n43_colorrelief.png")
 
     gdaltest.runexternal(
-        gdaldem_path
-        + " color-relief -of PNG ../gdrivers/data/n43.tif data/color_file.txt tmp/n43_colorrelief.png"
+        f"{gdaldem_path} color-relief -of PNG ../gdrivers/data/n43.tif data/color_file.txt {output_png}"
     )
-    ds = gdal.Open("tmp/n43_colorrelief.png")
+    ds = gdal.Open(output_png)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 55009, "Bad checksum"
@@ -457,13 +470,16 @@ def test_gdaldem_color_relief_png(gdaldem_path):
 
 
 @pytest.mark.require_driver("PNG")
-def test_gdaldem_color_relief_from_float32_to_png(gdaldem_path, n43_float32_tif):
+def test_gdaldem_color_relief_from_float32_to_png(
+    gdaldem_path, n43_float32_tif, tmp_path
+):
+
+    output_png = str(tmp_path / "n43_colorrelief_from_float32.png")
 
     gdaltest.runexternal(
-        gdaldem_path
-        + f" color-relief -of PNG {n43_float32_tif} data/color_file.txt tmp/n43_colorrelief_from_float32.png"
+        f"{gdaldem_path} color-relief -of PNG {n43_float32_tif} data/color_file.txt {output_png}"
     )
-    ds = gdal.Open("tmp/n43_colorrelief_from_float32.png")
+    ds = gdal.Open(output_png)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 55009, "Bad checksum"
@@ -479,13 +495,14 @@ def test_gdaldem_color_relief_from_float32_to_png(gdaldem_path, n43_float32_tif)
 # Test gdaldem color relief with -nearest_color_entry
 
 
-def test_gdaldem_color_relief_nearest_color_entry(gdaldem_path):
+def test_gdaldem_color_relief_nearest_color_entry(gdaldem_path, tmp_path):
+
+    output_tif = str(tmp_path / "n43_colorrelief_nearest.tif")
 
     gdaltest.runexternal(
-        gdaldem_path
-        + " color-relief -nearest_color_entry ../gdrivers/data/n43.tif data/color_file.txt tmp/n43_colorrelief_nearest.tif"
+        f"{gdaldem_path} color-relief -nearest_color_entry ../gdrivers/data/n43.tif data/color_file.txt {output_tif}"
     )
-    ds = gdal.Open("tmp/n43_colorrelief_nearest.tif")
+    ds = gdal.Open(output_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 57296, "Bad checksum"
@@ -501,13 +518,14 @@ def test_gdaldem_color_relief_nearest_color_entry(gdaldem_path):
 # Test gdaldem color relief with -nearest_color_entry and -of VRT
 
 
-def test_gdaldem_color_relief_nearest_color_entry_vrt(gdaldem_path):
+def test_gdaldem_color_relief_nearest_color_entry_vrt(gdaldem_path, tmp_path):
+
+    output_vrt = str(tmp_path / "n43_colorrelief_nearest.vrt")
 
     gdaltest.runexternal(
-        gdaldem_path
-        + " color-relief -of VRT -nearest_color_entry ../gdrivers/data/n43.tif data/color_file.txt tmp/n43_colorrelief_nearest.vrt"
+        f"{gdaldem_path} color-relief -of VRT -nearest_color_entry ../gdrivers/data/n43.tif data/color_file.txt {output_vrt}"
     )
-    ds = gdal.Open("tmp/n43_colorrelief_nearest.vrt")
+    ds = gdal.Open(output_vrt)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 57296, "Bad checksum"
@@ -524,9 +542,13 @@ def test_gdaldem_color_relief_nearest_color_entry_vrt(gdaldem_path):
 
 
 @pytest.mark.require_driver("AAIGRID")
-def test_gdaldem_color_relief_nodata_nan(gdaldem_path):
+def test_gdaldem_color_relief_nodata_nan(gdaldem_path, tmp_path):
 
-    f = open("tmp/nodata_nan_src.asc", "wt")
+    input_asc = str(tmp_path / "nodata_nan_src.asc")
+    colors_txt = str(tmp_path / "nodata_nan_plt.txt")
+    output_tif = str(tmp_path / "nodata_nan_out.tif")
+
+    f = open(input_asc, "wt")
     f.write(
         """ncols        2
 nrows        2
@@ -539,17 +561,16 @@ NODATA_value nan
     )
     f.close()
 
-    f = open("tmp/nodata_nan_plt.txt", "wt")
+    f = open(colors_txt, "wt")
     f.write("0 0 0 0\n")
     f.write("nv 1 1 1\n")
     f.close()
 
     gdaltest.runexternal(
-        gdaldem_path
-        + " color-relief tmp/nodata_nan_src.asc tmp/nodata_nan_plt.txt tmp/nodata_nan_out.tif"
+        f"{gdaldem_path} color-relief {input_asc} {colors_txt} {output_tif}"
     )
 
-    ds = gdal.Open("tmp/nodata_nan_out.tif")
+    ds = gdal.Open(output_tif)
     val = ds.GetRasterBand(1).ReadRaster()
     ds = None
 
@@ -558,19 +579,20 @@ NODATA_value nan
     val = struct.unpack("B" * 4, val)
     assert val == (0, 0, 0, 1)
 
-    os.unlink("tmp/nodata_nan_src.asc")
-    os.unlink("tmp/nodata_nan_plt.txt")
-    os.unlink("tmp/nodata_nan_out.tif")
-
 
 ###############################################################################
 # Test gdaldem color relief with entries with repeated DEM values in the color table (#6422)
 
 
 @pytest.mark.require_driver("AAIGRID")
-def test_gdaldem_color_relief_repeated_entry(gdaldem_path):
+def test_gdaldem_color_relief_repeated_entry(gdaldem_path, tmp_path):
 
-    f = open("tmp/test_gdaldem_color_relief_repeated_entry.asc", "wt")
+    input_asc = str(tmp_path / "test_gdaldem_color_relief_repeated_entry.asc")
+    colors_txt = str(tmp_path / "test_gdaldem_color_relief_repeated_entry.txt")
+    output_tif = str(tmp_path / "test_gdaldem_color_relief_repeated_entry_out.tif")
+    output_vrt = str(tmp_path / "test_gdaldem_color_relief_repeated_entry_out.vrt")
+
+    f = open(input_asc, "wt")
     f.write(
         """ncols        2
 nrows        3
@@ -584,7 +606,7 @@ NODATA_value 5
     )
     f.close()
 
-    f = open("tmp/test_gdaldem_color_relief_repeated_entry.txt", "wt")
+    f = open(colors_txt, "wt")
     f.write("1 1 1 1\n")
     f.write("6 10 10 10\n")
     f.write("6 20 20 20\n")
@@ -593,12 +615,11 @@ NODATA_value 5
     f.close()
 
     gdaltest.runexternal(
-        gdaldem_path
-        + " color-relief tmp/test_gdaldem_color_relief_repeated_entry.asc tmp/test_gdaldem_color_relief_repeated_entry.txt tmp/test_gdaldem_color_relief_repeated_entry_out.tif",
+        f"{gdaldem_path} color-relief {input_asc} {colors_txt} {output_tif}",
         display_live_on_parent_stdout=True,
     )
 
-    ds = gdal.Open("tmp/test_gdaldem_color_relief_repeated_entry_out.tif")
+    ds = gdal.Open(output_tif)
     val = ds.GetRasterBand(1).ReadRaster()
     ds = None
 
@@ -608,100 +629,13 @@ NODATA_value 5
     assert val == (1, 1, 5, 10, 10, 25)
 
     gdaltest.runexternal(
-        gdaldem_path
-        + " color-relief tmp/test_gdaldem_color_relief_repeated_entry.asc tmp/test_gdaldem_color_relief_repeated_entry.txt tmp/test_gdaldem_color_relief_repeated_entry_out.vrt -of VRT",
+        f"{gdaldem_path} color-relief {input_asc} {colors_txt} {output_vrt} -of VRT",
         display_live_on_parent_stdout=True,
     )
 
-    ds = gdal.Open("tmp/test_gdaldem_color_relief_repeated_entry_out.vrt")
+    ds = gdal.Open(output_vrt)
     val = ds.GetRasterBand(1).ReadRaster()
     ds = None
 
     val = struct.unpack("B" * 6, val)
     assert val == (1, 1, 5, 10, 10, 25)
-
-    os.unlink("tmp/test_gdaldem_color_relief_repeated_entry.asc")
-    os.unlink("tmp/test_gdaldem_color_relief_repeated_entry.txt")
-    os.unlink("tmp/test_gdaldem_color_relief_repeated_entry_out.tif")
-    os.unlink("tmp/test_gdaldem_color_relief_repeated_entry_out.vrt")
-
-
-###############################################################################
-# Cleanup
-
-
-def test_gdaldem_cleanup():
-    try:
-        os.remove("tmp/n43_hillshade.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/n43_hillshade_compressed_tiled.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/n43_hillshade_combined.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/n43_hillshade_compute_edges.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/pyramid.tif")
-        os.remove("tmp/pyramid_shaded.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/n43_hillshade.png")
-        os.remove("tmp/n43_hillshade.png.aux.xml")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/n43_hillshade_compute_edges.png")
-        os.remove("tmp/n43_hillshade_compute_edges.png.aux.xml")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/n43_slope.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/n43_aspect.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/n43_colorrelief.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/n43_colorrelief_cpt.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/n43_colorrelief.vrt")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/n43_float32.tif")
-        os.remove("tmp/n43_colorrelief_from_float32.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/n43_colorrelief.png")
-        os.remove("tmp/n43_colorrelief.png.aux.xml")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/n43_colorrelief_from_float32.png")
-        os.remove("tmp/n43_colorrelief_from_float32.png.aux.xml")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/n43_colorrelief_nearest.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/n43_colorrelief_nearest.vrt")
-    except OSError:
-        pass

--- a/autotest/utilities/test_gdallocationinfo.py
+++ b/autotest/utilities/test_gdallocationinfo.py
@@ -136,21 +136,18 @@ def test_gdallocationinfo_5(gdallocationinfo_path):
 # Test -overview
 
 
-def test_gdallocationinfo_6(gdallocationinfo_path):
+def test_gdallocationinfo_6(gdallocationinfo_path, tmp_path):
+
+    tmp_tif = str(tmp_path / "test_gdallocationinfo_6.tif")
 
     src_ds = gdal.Open("../gcore/data/byte.tif")
-    ds = gdal.GetDriverByName("GTiff").CreateCopy(
-        "tmp/test_gdallocationinfo_6.tif", src_ds
-    )
+    ds = gdal.GetDriverByName("GTiff").CreateCopy(tmp_tif, src_ds)
     ds.BuildOverviews("AVERAGE", overviewlist=[2])
     ds = None
     src_ds = None
 
-    ret = gdaltest.runexternal(
-        gdallocationinfo_path + " tmp/test_gdallocationinfo_6.tif 10 10 -overview 1"
-    )
+    ret = gdaltest.runexternal(f"{gdallocationinfo_path} {tmp_tif} 10 10 -overview 1")
 
-    gdal.GetDriverByName("GTiff").Delete("tmp/test_gdallocationinfo_6.tif")
     expected_ret = """Value: 130"""
     assert expected_ret in ret
 

--- a/autotest/utilities/test_gdalmdimtranslate.py
+++ b/autotest/utilities/test_gdalmdimtranslate.py
@@ -35,8 +35,6 @@ import gdaltest
 import pytest
 import test_cli_utilities
 
-from osgeo import gdal
-
 pytestmark = pytest.mark.skipif(
     test_cli_utilities.get_gdalmdimtranslate_path() is None,
     reason="gdalmdimtranslate not available",
@@ -52,31 +50,38 @@ def gdalmdimtranslate_path():
 # Simple test
 
 
-def test_gdalmdimtranslate_1(gdalmdimtranslate_path):
+def test_gdalmdimtranslate_1(gdalmdimtranslate_path, tmp_path):
+
+    dst_vrt = str(tmp_path / "out.vrt")
 
     (ret, err) = gdaltest.runexternal_out_and_err(
-        gdalmdimtranslate_path + " data/mdim.vrt tmp/out.vrt"
+        f"{gdalmdimtranslate_path} data/mdim.vrt {dst_vrt}"
     )
     assert err is None or err == "", "got error/warning"
-    assert os.path.exists("tmp/out.vrt")
-    gdal.Unlink("tmp/out.vrt")
+    assert os.path.exists(dst_vrt)
 
 
 ###############################################################################
 # Test -if option
 
 
-def test_gdalmdimtranslate_if(gdalmdimtranslate_path):
+def test_gdalmdimtranslate_if(gdalmdimtranslate_path, tmp_path):
+
+    dst_vrt = str(tmp_path / "out.vrt")
 
     (ret, err) = gdaltest.runexternal_out_and_err(
-        gdalmdimtranslate_path + " -if VRT data/mdim.vrt tmp/out.vrt"
+        f"{gdalmdimtranslate_path} -if VRT data/mdim.vrt {dst_vrt}"
     )
     assert err is None or err == "", "got error/warning"
-    assert os.path.exists("tmp/out.vrt")
-    gdal.Unlink("tmp/out.vrt")
+    assert os.path.exists(dst_vrt)
+
+
+def test_gdalmdimtranslate_if_error(gdalmdimtranslate_path, tmp_path):
+
+    dst_vrt = str(tmp_path / "out.vrt")
 
     (ret, err) = gdaltest.runexternal_out_and_err(
-        gdalmdimtranslate_path + " -if i_do_not_exist data/mdim.vrt tmp/out.vrt"
+        f"{gdalmdimtranslate_path} -if i_do_not_exist data/mdim.vrt {dst_vrt}"
     )
     assert "i_do_not_exist is not a recognized driver" in err
-    assert not os.path.exists("tmp/out.vrt")
+    assert not os.path.exists(dst_vrt)

--- a/autotest/utilities/test_gdalsrsinfo.py
+++ b/autotest/utilities/test_gdalsrsinfo.py
@@ -294,7 +294,7 @@ def test_gdalsrsinfo_16(gdalsrsinfo_path):
 # Test -e
 
 
-def test_gdalsrsinfo_17(gdalsrsinfo_path):
+def test_gdalsrsinfo_17(gdalsrsinfo_path, tmp_path):
 
     # Zero match
     ret = gdaltest.runexternal(gdalsrsinfo_path + ' -e "LOCAL_CS[foo]"')
@@ -307,10 +307,12 @@ def test_gdalsrsinfo_17(gdalsrsinfo_path):
     assert "EPSG:32119" in ret
 
     # Two matches
-    open("tmp/test_gdalsrsinfo_17.wkt", "wt").write(
+    open(f"{tmp_path}/test_gdalsrsinfo_17.wkt", "wt").write(
         'GEOGCS["myLKS94",DATUM["Lithuania_1994_ETRS89",SPHEROID["GRS_1980",6378137,298.257222101],TOWGS84[0,0,0,0,0,0,0]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433]]'
     )
-    ret = gdaltest.runexternal(gdalsrsinfo_path + """ -e tmp/test_gdalsrsinfo_17.wkt""")
+    ret = gdaltest.runexternal(
+        f"{gdalsrsinfo_path} -e {tmp_path}/test_gdalsrsinfo_17.wkt"
+    )
     assert "EPSG:4669" in ret
 
 

--- a/autotest/utilities/test_gdaltindex.py
+++ b/autotest/utilities/test_gdaltindex.py
@@ -29,8 +29,6 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
-import os
-
 import gdaltest
 import pytest
 import test_cli_utilities
@@ -55,65 +53,60 @@ def gdaltindex_path():
 # Simple test
 
 
-def test_gdaltindex_1(gdaltindex_path):
-
-    try:
-        os.remove("tmp/tileindex.shp")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/tileindex.dbf")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/tileindex.shx")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/tileindex.prj")
-    except OSError:
-        pass
+@pytest.fixture(scope="module")
+def four_tiles(tmp_path_factory):
 
     drv = gdal.GetDriverByName("GTiff")
     wkt = 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],TOWGS84[0,0,0,0,0,0,0],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9108"]],AUTHORITY["EPSG","4326"]]'
 
-    ds = drv.Create("tmp/gdaltindex1.tif", 10, 10, 1)
+    dirname = tmp_path_factory.mktemp("test_gdaltindex")
+    fnames = [f"{dirname}/gdaltindex{i}.tif" for i in (1, 2, 3, 4)]
+
+    ds = drv.Create(fnames[0], 10, 10, 1)
     ds.SetProjection(wkt)
     ds.SetGeoTransform([49, 0.1, 0, 2, 0, -0.1])
     ds = None
 
-    ds = drv.Create("tmp/gdaltindex2.tif", 10, 10, 1)
+    ds = drv.Create(fnames[1], 10, 10, 1)
     ds.SetProjection(wkt)
     ds.SetGeoTransform([49, 0.1, 0, 3, 0, -0.1])
     ds = None
 
-    ds = drv.Create("tmp/gdaltindex3.tif", 10, 10, 1)
+    ds = drv.Create(fnames[2], 10, 10, 1)
     ds.SetProjection(wkt)
     ds.SetGeoTransform([48, 0.1, 0, 2, 0, -0.1])
     ds = None
 
-    ds = drv.Create("tmp/gdaltindex4.tif", 10, 10, 1)
+    ds = drv.Create(fnames[3], 10, 10, 1)
     ds.SetProjection(wkt)
     ds.SetGeoTransform([48, 0.1, 0, 3, 0, -0.1])
     ds = None
 
+    return fnames
+
+
+@pytest.fixture()
+def four_tile_index(gdaltindex_path, four_tiles, tmp_path):
+
     (_, err) = gdaltest.runexternal_out_and_err(
-        gdaltindex_path + " tmp/tileindex.shp tmp/gdaltindex1.tif tmp/gdaltindex2.tif"
+        f"{gdaltindex_path} {tmp_path}/tileindex.shp {four_tiles[0]} {four_tiles[1]}"
     )
     assert err is None or err == "", "got error/warning"
 
     (ret_stdout, ret_stderr) = gdaltest.runexternal_out_and_err(
-        gdaltindex_path + " tmp/tileindex.shp tmp/gdaltindex3.tif tmp/gdaltindex4.tif"
+        f"{gdaltindex_path} {tmp_path}/tileindex.shp {four_tiles[2]} {four_tiles[3]}"
     )
 
-    ds = ogr.Open("tmp/tileindex.shp")
-    if ds.GetLayer(0).GetFeatureCount() != 4:
-        print(ret_stdout)
-        pytest.fail(ret_stderr)
+    return f"{tmp_path}/tileindex.shp"
+
+
+def test_gdaltindex_1(gdaltindex_path, four_tile_index):
+
+    ds = ogr.Open(four_tile_index)
+    assert ds.GetLayer(0).GetFeatureCount() == 4
+
     tileindex_wkt = ds.GetLayer(0).GetSpatialRef().ExportToWkt()
-    if tileindex_wkt.find("WGS_1984") == -1:
-        print(ret_stdout)
-        pytest.fail(ret_stderr)
+    assert "WGS_1984" in tileindex_wkt
 
     expected_wkts = [
         "POLYGON ((49 2,50 2,50 1,49 1,49 2))",
@@ -121,50 +114,30 @@ def test_gdaltindex_1(gdaltindex_path):
         "POLYGON ((48 2,49 2,49 1,48 1,48 2))",
         "POLYGON ((48 3,49 3,49 2,48 2,48 3))",
     ]
-    i = 0
-    feat = ds.GetLayer(0).GetNextFeature()
-    while feat is not None:
+
+    for i, feat in enumerate(ds.GetLayer(0)):
         assert (
             feat.GetGeometryRef().ExportToWkt() == expected_wkts[i]
         ), "i=%d, wkt=%s" % (i, feat.GetGeometryRef().ExportToWkt())
-        i = i + 1
-        feat = ds.GetLayer(0).GetNextFeature()
-    ds.Destroy()
 
 
 ###############################################################################
 # Try adding the same rasters again
 
 
-def test_gdaltindex_2(gdaltindex_path):
+def test_gdaltindex_2(gdaltindex_path, four_tiles, four_tile_index, tmp_path):
 
     (_, ret_stderr) = gdaltest.runexternal_out_and_err(
-        gdaltindex_path
-        + " tmp/tileindex.shp tmp/gdaltindex1.tif tmp/gdaltindex2.tif tmp/gdaltindex3.tif tmp/gdaltindex4.tif"
+        f"{gdaltindex_path} {four_tile_index} {four_tiles[0]} {four_tiles[1]} {four_tiles[2]} {four_tiles[3]}"
     )
 
-    assert not (
-        ret_stderr.find(
-            "File tmp/gdaltindex1.tif is already in tileindex. Skipping it."
-        )
-        == -1
-        or ret_stderr.find(
-            "File tmp/gdaltindex2.tif is already in tileindex. Skipping it."
-        )
-        == -1
-        or ret_stderr.find(
-            "File tmp/gdaltindex3.tif is already in tileindex. Skipping it."
-        )
-        == -1
-        or ret_stderr.find(
-            "File tmp/gdaltindex4.tif is already in tileindex. Skipping it."
-        )
-        == -1
-    ), "got unexpected error messages."
+    assert "gdaltindex1.tif is already in tileindex. Skipping it." in ret_stderr
+    assert "gdaltindex2.tif is already in tileindex. Skipping it." in ret_stderr
+    assert "gdaltindex3.tif is already in tileindex. Skipping it." in ret_stderr
+    assert "gdaltindex4.tif is already in tileindex. Skipping it." in ret_stderr
 
-    ds = ogr.Open("tmp/tileindex.shp")
+    ds = ogr.Open(four_tile_index)
     assert ds.GetLayer(0).GetFeatureCount() == 4
-    ds.Destroy()
 
 
 ###############################################################################
@@ -172,7 +145,7 @@ def test_gdaltindex_2(gdaltindex_path):
 # 5th tile should NOT be inserted
 
 
-def test_gdaltindex_3(gdaltindex_path):
+def test_gdaltindex_3(gdaltindex_path, tmp_path, four_tile_index):
 
     drv = gdal.GetDriverByName("GTiff")
     wkt = """GEOGCS["WGS 72",
@@ -182,30 +155,26 @@ def test_gdaltindex_3(gdaltindex_path):
     PRIMEM["Greenwich",0],
     UNIT["degree",0.0174532925199433]]"""
 
-    ds = drv.Create("tmp/gdaltindex5.tif", 10, 10, 1)
+    ds = drv.Create(f"{tmp_path}/gdaltindex5.tif", 10, 10, 1)
     ds.SetProjection(wkt)
     ds.SetGeoTransform([47, 0.1, 0, 2, 0, -0.1])
     ds = None
 
     (_, ret_stderr) = gdaltest.runexternal_out_and_err(
-        gdaltindex_path
-        + " -skip_different_projection tmp/tileindex.shp tmp/gdaltindex5.tif"
+        f"{gdaltindex_path} -skip_different_projection {four_tile_index} {tmp_path}/gdaltindex5.tif"
     )
 
-    assert not (
-        ret_stderr.find(
-            "Warning : tmp/gdaltindex5.tif is not using the same projection system as other files in the tileindex."
-        )
-        == -1
-        or ret_stderr.find(
-            "Use -t_srs option to set target projection system (not supported by MapServer)."
-        )
-        == -1
-    ), "got unexpected error message \n[%s]" % (ret_stderr)
+    assert (
+        "gdaltindex5.tif is not using the same projection system as other files in the tileindex."
+        in ret_stderr
+    )
+    assert (
+        "Use -t_srs option to set target projection system (not supported by MapServer)."
+        in ret_stderr
+    )
 
-    ds = ogr.Open("tmp/tileindex.shp")
+    ds = ogr.Open(four_tile_index)
     assert ds.GetLayer(0).GetFeatureCount() == 4
-    ds.Destroy()
 
 
 ###############################################################################
@@ -213,7 +182,7 @@ def test_gdaltindex_3(gdaltindex_path):
 # 5th tile should be inserted, will not be if there is a srs transformation error
 
 
-def test_gdaltindex_4(gdaltindex_path):
+def test_gdaltindex_4(gdaltindex_path, tmp_path, four_tile_index):
 
     drv = gdal.GetDriverByName("GTiff")
     wkt = """GEOGCS["WGS 72",
@@ -223,117 +192,88 @@ def test_gdaltindex_4(gdaltindex_path):
     PRIMEM["Greenwich",0],
     UNIT["degree",0.0174532925199433]]"""
 
-    ds = drv.Create("tmp/gdaltindex5.tif", 10, 10, 1)
+    ds = drv.Create(f"{tmp_path}/gdaltindex5.tif", 10, 10, 1)
     ds.SetProjection(wkt)
     ds.SetGeoTransform([47, 0.1, 0, 2, 0, -0.1])
     ds = None
 
     gdaltest.runexternal_out_and_err(
-        gdaltindex_path + " -t_srs EPSG:4326 tmp/tileindex.shp tmp/gdaltindex5.tif"
+        f"{gdaltindex_path} -t_srs EPSG:4326 {four_tile_index} {tmp_path}/gdaltindex5.tif"
     )
 
-    ds = ogr.Open("tmp/tileindex.shp")
+    ds = ogr.Open(four_tile_index)
     assert ds.GetLayer(0).GetFeatureCount() == 5, (
         "got %d features, expecting 5" % ds.GetLayer(0).GetFeatureCount()
     )
-    ds.Destroy()
 
 
 ###############################################################################
 # Test -src_srs_name, -src_srs_format options
 
 
-def test_gdaltindex_5(gdaltindex_path):
+@pytest.mark.parametrize(
+    "src_srs_format",
+    [
+        "",
+        "-src_srs_format AUTO",
+        "-src_srs_format EPSG",
+        "-src_srs_format PROJ",
+        "-src_srs_format WKT",
+    ],
+)
+def test_gdaltindex_5(gdaltindex_path, tmp_path, four_tiles, src_srs_format):
+
+    index_shp = str(tmp_path / "test_gdaltindex_5.shp")
+    tile1_tif = four_tiles[0]
+    tile2_tif = str(tmp_path / "gdaltindex6.tif")
 
     drv = gdal.GetDriverByName("GTiff")
 
-    ds = drv.Create("tmp/gdaltindex6.tif", 10, 10, 1)
+    ds = drv.Create(tile2_tif, 10, 10, 1)
     sr = osr.SpatialReference()
     sr.ImportFromEPSG(4322)
     ds.SetProjection(sr.ExportToWkt())
     ds.SetGeoTransform([47, 0.1, 0, 2, 0, -0.1])
     ds = None
 
-    for src_srs_format in [
-        "",
-        "-src_srs_format AUTO",
-        "-src_srs_format EPSG",
-        "-src_srs_format PROJ",
-        "-src_srs_format WKT",
-    ]:
-        if os.path.exists("tmp/test_gdaltindex_5.shp"):
-            ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-                "tmp/test_gdaltindex_5.shp"
-            )
-        gdaltest.runexternal_out_and_err(
-            gdaltindex_path
-            + " -src_srs_name src_srs %s -t_srs EPSG:4326 tmp/test_gdaltindex_5.shp tmp/gdaltindex1.tif tmp/gdaltindex6.tif"
-            % src_srs_format
-        )
+    gdaltest.runexternal_out_and_err(
+        f"{gdaltindex_path} -src_srs_name src_srs {src_srs_format} -t_srs EPSG:4326 {index_shp} {tile1_tif} {tile2_tif}"
+    )
 
-        ds = ogr.Open("tmp/test_gdaltindex_5.shp")
-        lyr = ds.GetLayer(0)
-        assert lyr.GetFeatureCount() == 2, (
-            "got %d features, expecting 2" % ds.GetLayer(0).GetFeatureCount()
-        )
-        feat = lyr.GetNextFeature()
-        feat = lyr.GetNextFeature()
-        if src_srs_format == "-src_srs_format PROJ":
-            if feat.GetField("src_srs").find("+proj=longlat +ellps=WGS72") != 0:
-                feat.DumpReadable()
-                pytest.fail()
-        elif src_srs_format == "-src_srs_format WKT":
-            # if feat.GetField('src_srs').find('GEOGCS["WGS 72"') != 0:
-            # Full definition too long...
-            if feat.GetField("src_srs") is not None:
-                feat.DumpReadable()
-                pytest.fail()
-        else:
-            if feat.GetField("src_srs") != "EPSG:4322":
-                feat.DumpReadable()
-                pytest.fail()
-        ds = None
+    ds = ogr.Open(index_shp)
+    lyr = ds.GetLayer(0)
+    assert lyr.GetFeatureCount() == 2, (
+        "got %d features, expecting 2" % ds.GetLayer(0).GetFeatureCount()
+    )
+    feat = lyr.GetNextFeature()
+    feat = lyr.GetNextFeature()
+    if src_srs_format == "-src_srs_format PROJ":
+        assert "+proj=longlat +ellps=WGS72" in feat.GetField("src_srs")
+    elif src_srs_format == "-src_srs_format WKT":
+        # if feat.GetField('src_srs').find('GEOGCS["WGS 72"') != 0:
+        # Full definition too long...
+        if feat.GetField("src_srs") is not None:
+            feat.DumpReadable()
+            pytest.fail()
+    else:
+        assert feat.GetField("src_srs") == "EPSG:4322"
 
 
 ###############################################################################
 # Test -f, -lyr_name
 
 
-def test_gdaltindex_6(gdaltindex_path):
+@pytest.mark.parametrize("option", ["", "-lyr_name tileindex"])
+def test_gdaltindex_6(gdaltindex_path, tmp_path, four_tiles, option):
 
-    for option in ["", "-lyr_name tileindex"]:
-        if os.path.exists("tmp/test_gdaltindex_6.mif"):
-            ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-                "tmp/test_gdaltindex_6.mif"
-            )
-        gdaltest.runexternal_out_and_err(
-            gdaltindex_path
-            + ' -f "MapInfo File" %s tmp/test_gdaltindex_6.mif tmp/gdaltindex1.tif'
-            % option
-        )
-        ds = ogr.Open("tmp/test_gdaltindex_6.mif")
-        lyr = ds.GetLayer(0)
-        assert lyr.GetFeatureCount() == 1, (
-            "got %d features, expecting 1" % lyr.GetFeatureCount()
-        )
-        ds = None
+    index_mif = str(tmp_path / "test_gdaltindex6.mif")
 
-
-###############################################################################
-# Cleanup
-
-
-def test_gdaltindex_cleanup():
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/tileindex.shp")
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/test_gdaltindex_5.shp")
-    ogr.GetDriverByName("MapInfo File").DeleteDataSource("tmp/test_gdaltindex_6.mif")
-
-    drv = gdal.GetDriverByName("GTiff")
-
-    drv.Delete("tmp/gdaltindex1.tif")
-    drv.Delete("tmp/gdaltindex2.tif")
-    drv.Delete("tmp/gdaltindex3.tif")
-    drv.Delete("tmp/gdaltindex4.tif")
-    drv.Delete("tmp/gdaltindex5.tif")
-    drv.Delete("tmp/gdaltindex6.tif")
+    gdaltest.runexternal_out_and_err(
+        f'{gdaltindex_path} -f "MapInfo File" {option} {index_mif} {four_tiles[0]}'
+    )
+    ds = ogr.Open(index_mif)
+    lyr = ds.GetLayer(0)
+    assert lyr.GetFeatureCount() == 1, (
+        "got %d features, expecting 1" % lyr.GetFeatureCount()
+    )
+    ds = None

--- a/autotest/utilities/test_gdalwarp.py
+++ b/autotest/utilities/test_gdalwarp.py
@@ -48,119 +48,20 @@ def gdalwarp_path():
     return test_cli_utilities.get_gdalwarp_path()
 
 
-@pytest.fixture(scope="module", autouse=True)
-def setup_and_cleanup():
-
-    yield
-
-    # We don't clean up when run in debug mode.
-    if gdal.GetConfigOption("CPL_DEBUG", "OFF") == "ON":
-        return
-
-    for i in range(37):
-        try:
-            os.remove("tmp/testgdalwarp" + str(i + 1) + ".tif")
-        except OSError:
-            pass
-        try:
-            os.remove("tmp/testgdalwarp" + str(i + 1) + ".vrt")
-        except OSError:
-            pass
-        try:
-            os.remove("tmp/testgdalwarp" + str(i + 1) + ".tif.aux.xml")
-        except OSError:
-            pass
-    try:
-        os.remove("tmp/testgdalwarp24src.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/testgdalwarp24dst.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/testgdalwarp30_1.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/testgdalwarp30_2.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/testgdalwarp30_3.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/testgdalwarp33_mask.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/testgdalwarp37.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/testgdalwarp38.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/test_gdalwarp_39.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/test_gdalwarp_40_src.tif")
-        os.remove("tmp/test_gdalwarp_40.tif")
-        os.remove("tmp/test_gdalwarp_40.vrt")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/test_gdalwarp_41_src.tif")
-        os.remove("tmp/test_gdalwarp_41.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/small_world_left.tif")
-        os.remove("tmp/small_world_right.tif")
-        os.remove("tmp/test_gdalwarp_42.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/small_world.tif")
-        os.remove("tmp/test_gdalwarp_43.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/test_gdalwarp_44.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/test_gdalwarp_45.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/test_gdalwarp_46.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/cutline_4326.shp")
-        os.remove("tmp/cutline_4326.shx")
-        os.remove("tmp/cutline_4326.dbf")
-        os.remove("tmp/cutline_4326.prj")
-    except OSError:
-        pass
-
-
 ###############################################################################
 # Simple test
 
 
-def test_gdalwarp_1(gdalwarp_path):
+def test_gdalwarp_1(gdalwarp_path, tmp_path):
+
+    dst_tif = str(tmp_path / "testgdalwarp1.tif")
 
     (_, err) = gdaltest.runexternal_out_and_err(
-        gdalwarp_path + " ../gcore/data/byte.tif tmp/testgdalwarp1.tif"
+        f"{gdalwarp_path} ../gcore/data/byte.tif {dst_tif}"
     )
     assert err is None or err == "", "got error/warning"
 
-    ds = gdal.Open("tmp/testgdalwarp1.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
@@ -172,13 +73,13 @@ def test_gdalwarp_1(gdalwarp_path):
 # Test -of option
 
 
-def test_gdalwarp_2(gdalwarp_path):
+def test_gdalwarp_2(gdalwarp_path, tmp_path):
 
-    gdaltest.runexternal(
-        gdalwarp_path + " -of GTiff ../gcore/data/byte.tif tmp/testgdalwarp2.tif"
-    )
+    dst_tif = str(tmp_path / "testgdalwarp2.tif")
 
-    ds = gdal.Open("tmp/testgdalwarp2.tif")
+    gdaltest.runexternal(f"{gdalwarp_path} -of GTiff ../gcore/data/byte.tif {dst_tif}")
+
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
@@ -190,13 +91,13 @@ def test_gdalwarp_2(gdalwarp_path):
 # Test -ot option
 
 
-def test_gdalwarp_3(gdalwarp_path):
+def test_gdalwarp_3(gdalwarp_path, tmp_path):
 
-    gdaltest.runexternal(
-        gdalwarp_path + " -ot Int16 ../gcore/data/byte.tif tmp/testgdalwarp3.tif"
-    )
+    dst_tif = str(tmp_path / "testgdalwarp3.tif")
 
-    ds = gdal.Open("tmp/testgdalwarp3.tif")
+    gdaltest.runexternal(f"{gdalwarp_path} -ot Int16 ../gcore/data/byte.tif {dst_tif}")
+
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).DataType == gdal.GDT_Int16, "Bad data type"
@@ -210,14 +111,15 @@ def test_gdalwarp_3(gdalwarp_path):
 # Test -t_srs option
 
 
-def test_gdalwarp_4(gdalwarp_path):
+def test_gdalwarp_4(gdalwarp_path, tmp_path):
+
+    dst_tif = str(tmp_path / "testgdalwarp4.tif")
 
     gdaltest.runexternal(
-        gdalwarp_path
-        + " -t_srs EPSG:32611 ../gcore/data/byte.tif tmp/testgdalwarp4.tif"
+        f"{gdalwarp_path} -t_srs EPSG:32611 ../gcore/data/byte.tif {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/testgdalwarp4.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
@@ -247,13 +149,13 @@ def testgdalwarp_gcp_tif(tmp_path_factory):
     yield testgdalwarp_gcp_tif_fname
 
 
-def test_gdalwarp_5(gdalwarp_path, testgdalwarp_gcp_tif):
+def test_gdalwarp_5(gdalwarp_path, testgdalwarp_gcp_tif, tmp_path):
 
-    gdaltest.runexternal(
-        gdalwarp_path + f" {testgdalwarp_gcp_tif} tmp/testgdalwarp5.tif"
-    )
+    dst_tif = str(tmp_path / "testgdalwarp5.tif")
 
-    ds = gdal.Open("tmp/testgdalwarp5.tif")
+    gdaltest.runexternal(f"{gdalwarp_path} {testgdalwarp_gcp_tif} {dst_tif}")
+
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
@@ -271,13 +173,13 @@ def test_gdalwarp_5(gdalwarp_path, testgdalwarp_gcp_tif):
 # Test warping from GCPs with -tps
 
 
-def test_gdalwarp_6(gdalwarp_path, testgdalwarp_gcp_tif):
+def test_gdalwarp_6(gdalwarp_path, testgdalwarp_gcp_tif, tmp_path):
 
-    gdaltest.runexternal(
-        gdalwarp_path + f" -tps {testgdalwarp_gcp_tif} tmp/testgdalwarp6.tif"
-    )
+    dst_tif = str(tmp_path / "testgdalwarp6.tif")
 
-    ds = gdal.Open("tmp/testgdalwarp6.tif")
+    gdaltest.runexternal(f"{gdalwarp_path} -tps {testgdalwarp_gcp_tif} {dst_tif}")
+
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
@@ -295,13 +197,15 @@ def test_gdalwarp_6(gdalwarp_path, testgdalwarp_gcp_tif):
 # Test -tr
 
 
-def test_gdalwarp_7(gdalwarp_path, testgdalwarp_gcp_tif):
+def test_gdalwarp_7(gdalwarp_path, testgdalwarp_gcp_tif, tmp_path):
+
+    dst_tif = str(tmp_path / "testgdalwarp7.tif")
 
     gdaltest.runexternal(
-        gdalwarp_path + f" -tr 120 120 {testgdalwarp_gcp_tif} tmp/testgdalwarp7.tif"
+        f"{gdalwarp_path} -tr 120 120 {testgdalwarp_gcp_tif} {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/testgdalwarp7.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     expected_gt = (440720.0, 120.0, 0.0, 3751320.0, 0.0, -120.0)
@@ -314,13 +218,13 @@ def test_gdalwarp_7(gdalwarp_path, testgdalwarp_gcp_tif):
 # Test -ts
 
 
-def test_gdalwarp_8(gdalwarp_path, testgdalwarp_gcp_tif):
+def test_gdalwarp_8(gdalwarp_path, testgdalwarp_gcp_tif, tmp_path):
 
-    gdaltest.runexternal(
-        gdalwarp_path + f" -ts 10 10 {testgdalwarp_gcp_tif} tmp/testgdalwarp8.tif"
-    )
+    dst_tif = str(tmp_path / "testgdalwarp8.tif")
 
-    ds = gdal.Open("tmp/testgdalwarp8.tif")
+    gdaltest.runexternal(f"{gdalwarp_path} -ts 10 10 {testgdalwarp_gcp_tif} {dst_tif}")
+
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     expected_gt = (440720.0, 120.0, 0.0, 3751320.0, 0.0, -120.0)
@@ -333,14 +237,15 @@ def test_gdalwarp_8(gdalwarp_path, testgdalwarp_gcp_tif):
 # Test -te
 
 
-def test_gdalwarp_9(gdalwarp_path, testgdalwarp_gcp_tif):
+def test_gdalwarp_9(gdalwarp_path, testgdalwarp_gcp_tif, tmp_path):
+
+    dst_tif = str(tmp_path / "testgdalwarp9.tif")
 
     gdaltest.runexternal(
-        gdalwarp_path
-        + f" -te 440720.000 3750120.000 441920.000 3751320.000 {testgdalwarp_gcp_tif} tmp/testgdalwarp9.tif"
+        f"{gdalwarp_path} -te 440720.000 3750120.000 441920.000 3751320.000 {testgdalwarp_gcp_tif} {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/testgdalwarp9.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     gdaltest.check_geotransform(
@@ -356,13 +261,15 @@ def test_gdalwarp_9(gdalwarp_path, testgdalwarp_gcp_tif):
 # Test -rn
 
 
-def test_gdalwarp_10(gdalwarp_path, testgdalwarp_gcp_tif):
+def test_gdalwarp_10(gdalwarp_path, testgdalwarp_gcp_tif, tmp_path):
+
+    dst_tif = str(tmp_path / "testgdalwarp10.tif")
 
     gdaltest.runexternal(
-        gdalwarp_path + f" -ts 40 40 -rn {testgdalwarp_gcp_tif} tmp/testgdalwarp10.tif"
+        f"{gdalwarp_path} -ts 40 40 -rn {testgdalwarp_gcp_tif} {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/testgdalwarp10.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 18784, "Bad checksum"
@@ -374,13 +281,15 @@ def test_gdalwarp_10(gdalwarp_path, testgdalwarp_gcp_tif):
 # Test -rb
 
 
-def test_gdalwarp_11(gdalwarp_path, testgdalwarp_gcp_tif):
+def test_gdalwarp_11(gdalwarp_path, testgdalwarp_gcp_tif, tmp_path):
+
+    dst_tif = str(tmp_path / "testgdalwarp11.tif")
 
     gdaltest.runexternal(
-        gdalwarp_path + f" -ts 40 40 -rb {testgdalwarp_gcp_tif} tmp/testgdalwarp11.tif"
+        f"{gdalwarp_path} -ts 40 40 -rb {testgdalwarp_gcp_tif} {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/testgdalwarp11.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     ref_ds = gdal.Open("ref_data/testgdalwarp11.tif")
@@ -398,13 +307,15 @@ def test_gdalwarp_11(gdalwarp_path, testgdalwarp_gcp_tif):
 # Test -rc
 
 
-def test_gdalwarp_12(gdalwarp_path, testgdalwarp_gcp_tif):
+def test_gdalwarp_12(gdalwarp_path, testgdalwarp_gcp_tif, tmp_path):
+
+    dst_tif = str(tmp_path / "testgdalwarp12.tif")
 
     gdaltest.runexternal(
-        gdalwarp_path + f" -ts 40 40 -rc {testgdalwarp_gcp_tif} tmp/testgdalwarp12.tif"
+        f"{gdalwarp_path} -ts 40 40 -rc {testgdalwarp_gcp_tif} {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/testgdalwarp12.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     ref_ds = gdal.Open("ref_data/testgdalwarp12.tif")
@@ -423,13 +334,15 @@ def test_gdalwarp_12(gdalwarp_path, testgdalwarp_gcp_tif):
 # Test -rcs
 
 
-def test_gdalwarp_13(gdalwarp_path, testgdalwarp_gcp_tif):
+def test_gdalwarp_13(gdalwarp_path, testgdalwarp_gcp_tif, tmp_path):
+
+    dst_tif = str(tmp_path / "testgdalwarp13.tif")
 
     gdaltest.runexternal(
-        gdalwarp_path + f" -ts 40 40 -rcs {testgdalwarp_gcp_tif} tmp/testgdalwarp13.tif"
+        f"{gdalwarp_path} -ts 40 40 -rcs {testgdalwarp_gcp_tif} {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/testgdalwarp13.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     ref_ds = gdal.Open("ref_data/testgdalwarp13.tif")
@@ -445,14 +358,15 @@ def test_gdalwarp_13(gdalwarp_path, testgdalwarp_gcp_tif):
 # Test -r lanczos
 
 
-def test_gdalwarp_14(gdalwarp_path, testgdalwarp_gcp_tif):
+def test_gdalwarp_14(gdalwarp_path, testgdalwarp_gcp_tif, tmp_path):
+
+    dst_tif = str(tmp_path / "testgdalwarp14.tif")
 
     gdaltest.runexternal(
-        gdalwarp_path
-        + f" -ts 40 40 -r lanczos {testgdalwarp_gcp_tif} tmp/testgdalwarp14.tif"
+        f"{gdalwarp_path} -ts 40 40 -r lanczos {testgdalwarp_gcp_tif} {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/testgdalwarp14.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     ref_ds = gdal.Open("ref_data/testgdalwarp14.tif")
@@ -468,13 +382,13 @@ def test_gdalwarp_14(gdalwarp_path, testgdalwarp_gcp_tif):
 # Test -of VRT which is a special case
 
 
-def test_gdalwarp_16(gdalwarp_path, testgdalwarp_gcp_tif):
+def test_gdalwarp_16(gdalwarp_path, testgdalwarp_gcp_tif, tmp_path):
 
-    gdaltest.runexternal(
-        gdalwarp_path + f" -of VRT {testgdalwarp_gcp_tif} tmp/testgdalwarp16.vrt"
-    )
+    dst_vrt = str(tmp_path / "testgdalwarp16.vrt")
 
-    ds = gdal.Open("tmp/testgdalwarp16.vrt")
+    gdaltest.runexternal(f"{gdalwarp_path} -of VRT {testgdalwarp_gcp_tif} {dst_vrt}")
+
+    ds = gdal.Open(dst_vrt)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
@@ -486,13 +400,15 @@ def test_gdalwarp_16(gdalwarp_path, testgdalwarp_gcp_tif):
 # Test -dstalpha
 
 
-def test_gdalwarp_17(gdalwarp_path):
+def test_gdalwarp_17(gdalwarp_path, tmp_path):
+
+    dst_tif = str(tmp_path / "testgdalwarp17.tif")
 
     gdaltest.runexternal(
-        gdalwarp_path + " -dstalpha ../gcore/data/rgbsmall.tif tmp/testgdalwarp17.tif"
+        f"{gdalwarp_path} -dstalpha ../gcore/data/rgbsmall.tif {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/testgdalwarp17.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(4) is not None, "No alpha band generated"
@@ -504,17 +420,19 @@ def test_gdalwarp_17(gdalwarp_path):
 # Test -wm -multi
 
 
-def test_gdalwarp_18(gdalwarp_path):
+def test_gdalwarp_18(gdalwarp_path, tmp_path):
+
+    dst_tif = str(tmp_path / "testgdalwarp18.tif")
 
     (_, ret_stderr) = gdaltest.runexternal_out_and_err(
-        gdalwarp_path + " -wm 20 -multi ../gcore/data/byte.tif tmp/testgdalwarp18.tif"
+        f"{gdalwarp_path} -wm 20 -multi ../gcore/data/byte.tif {dst_tif}"
     )
 
     # This error will be returned if GDAL is not compiled with thread support
     if ret_stderr.find("CPLCreateThread() failed in ChunkAndWarpMulti()") != -1:
         pytest.skip("GDAL not compiled with thread support")
 
-    ds = gdal.Open("tmp/testgdalwarp18.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
@@ -526,13 +444,13 @@ def test_gdalwarp_18(gdalwarp_path):
 # Test -et 0 which is a special case
 
 
-def test_gdalwarp_19(gdalwarp_path, testgdalwarp_gcp_tif):
+def test_gdalwarp_19(gdalwarp_path, testgdalwarp_gcp_tif, tmp_path):
 
-    gdaltest.runexternal(
-        gdalwarp_path + f" -et 0 {testgdalwarp_gcp_tif} tmp/testgdalwarp19.tif"
-    )
+    dst_tif = str(tmp_path / "testgdalwarp19.tif")
 
-    ds = gdal.Open("tmp/testgdalwarp19.tif")
+    gdaltest.runexternal(f"{gdalwarp_path} -et 0 {testgdalwarp_gcp_tif} {dst_tif}")
+
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
@@ -544,13 +462,15 @@ def test_gdalwarp_19(gdalwarp_path, testgdalwarp_gcp_tif):
 # Test -of VRT -et 0 which is a special case
 
 
-def test_gdalwarp_20(gdalwarp_path, testgdalwarp_gcp_tif):
+def test_gdalwarp_20(gdalwarp_path, testgdalwarp_gcp_tif, tmp_path):
+
+    dst_vrt = str(tmp_path / "testgdalwarp20.vrt")
 
     gdaltest.runexternal(
-        gdalwarp_path + f" -of VRT -et 0 {testgdalwarp_gcp_tif} tmp/testgdalwarp20.vrt"
+        f"{gdalwarp_path} -of VRT -et 0 {testgdalwarp_gcp_tif} {dst_vrt}"
     )
 
-    ds = gdal.Open("tmp/testgdalwarp20.vrt")
+    ds = gdal.Open(dst_vrt)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
@@ -563,14 +483,15 @@ def test_gdalwarp_20(gdalwarp_path, testgdalwarp_gcp_tif):
 
 
 @pytest.mark.require_driver("CSV")
-def test_gdalwarp_21(gdalwarp_path):
+def test_gdalwarp_21(gdalwarp_path, tmp_path):
+
+    dst_tif = str(tmp_path / "testgdalwarp21.tif")
 
     gdaltest.runexternal(
-        gdalwarp_path
-        + " ../gcore/data/utmsmall.tif tmp/testgdalwarp21.tif -cutline data/cutline.vrt -cl cutline"
+        f"{gdalwarp_path} ../gcore/data/utmsmall.tif {dst_tif} -cutline data/cutline.vrt -cl cutline"
     )
 
-    ds = gdal.Open("tmp/testgdalwarp21.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 19139, "Bad checksum"
@@ -583,14 +504,15 @@ def test_gdalwarp_21(gdalwarp_path):
 
 
 @pytest.mark.require_driver("CSV")
-def test_gdalwarp_22(gdalwarp_path):
+def test_gdalwarp_22(gdalwarp_path, tmp_path):
+
+    dst_tif = str(tmp_path / "testgdalwarp22.tif")
 
     gdaltest.runexternal(
-        gdalwarp_path
-        + " ../gcore/data/utmsmall.tif tmp/testgdalwarp22.tif -cutline data/cutline.vrt -cl cutline -tr 30 30"
+        f"{gdalwarp_path} ../gcore/data/utmsmall.tif {dst_tif} -cutline data/cutline.vrt -cl cutline -tr 30 30"
     )
 
-    ds = gdal.Open("tmp/testgdalwarp22.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 14047, "Bad checksum"
@@ -603,14 +525,15 @@ def test_gdalwarp_22(gdalwarp_path):
 
 
 @pytest.mark.require_driver("CSV")
-def test_gdalwarp_23(gdalwarp_path):
+def test_gdalwarp_23(gdalwarp_path, tmp_path):
+
+    dst_tif = str(tmp_path / "testgdalwarp23.tif")
 
     gdaltest.runexternal(
-        gdalwarp_path
-        + " -wo CUTLINE_ALL_TOUCHED=TRUE ../gcore/data/utmsmall.tif tmp/testgdalwarp23.tif -cutline data/cutline.vrt -cl cutline"
+        f"{gdalwarp_path} -wo CUTLINE_ALL_TOUCHED=TRUE ../gcore/data/utmsmall.tif {dst_tif} -cutline data/cutline.vrt -cl cutline"
     )
 
-    ds = gdal.Open("tmp/testgdalwarp23.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 20123, "Bad checksum"
@@ -622,9 +545,12 @@ def test_gdalwarp_23(gdalwarp_path):
 # Test warping an image crossing the 180E/180W longitude (#3206)
 
 
-def test_gdalwarp_24(gdalwarp_path):
+def test_gdalwarp_24(gdalwarp_path, tmp_path):
 
-    ds = gdal.GetDriverByName("GTiff").Create("tmp/testgdalwarp24src.tif", 100, 100)
+    src_tif = str(tmp_path / "testgdalwarp24src.tif")
+    dst_tif = str(tmp_path / "testgdalwarp24dst.tif")
+
+    ds = gdal.GetDriverByName("GTiff").Create(src_tif, 100, 100)
     ds.SetGeoTransform([179.5, 0.01, 0, 45, 0, -0.01])
     ds.SetProjection(
         'GEOGCS["GCS_WGS_1984",DATUM["D_WGS_1984",SPHEROID["WGS_1984",6378137.0,298.257223563]],PRIMEM["Greenwich",0.0],UNIT["Degree",0.0174532925199433]]'
@@ -632,12 +558,9 @@ def test_gdalwarp_24(gdalwarp_path):
     ds.GetRasterBand(1).Fill(255)
     ds = None
 
-    gdaltest.runexternal(
-        gdalwarp_path
-        + " -t_srs EPSG:32660 tmp/testgdalwarp24src.tif tmp/testgdalwarp24dst.tif"
-    )
+    gdaltest.runexternal(f"{gdalwarp_path} -t_srs EPSG:32660 {src_tif} {dst_tif}")
 
-    ds = gdal.Open("tmp/testgdalwarp24dst.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 50683, "Bad checksum"
@@ -650,13 +573,15 @@ def test_gdalwarp_24(gdalwarp_path):
 
 
 @pytest.mark.require_creation_option("GTiff", "JPEG")
-def test_gdalwarp_25(gdalwarp_path):
+def test_gdalwarp_25(gdalwarp_path, tmp_path):
+
+    dst_tif = str(tmp_path / "testgdalwarp25.tif")
 
     gdaltest.runexternal(
-        gdalwarp_path + ' -t_srs "+proj=sinu" data/w_jpeg.tiff tmp/testgdalwarp25.tif'
+        f'{gdalwarp_path} -t_srs "+proj=sinu" data/w_jpeg.tiff {dst_tif}'
     )
 
-    ds = gdal.Open("tmp/testgdalwarp25.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     cs = ds.GetRasterBand(1).Checksum()
@@ -682,13 +607,15 @@ def test_gdalwarp_25(gdalwarp_path):
 
 
 @pytest.mark.require_creation_option("GTiff", "JPEG")
-def test_gdalwarp_26(gdalwarp_path):
+def test_gdalwarp_26(gdalwarp_path, tmp_path):
+
+    dst_tif = str(tmp_path / "testgdalwarp26.tif")
 
     gdaltest.runexternal(
-        gdalwarp_path + ' -t_srs "+proj=eck4" data/w_jpeg.tiff tmp/testgdalwarp26.tif'
+        f'{gdalwarp_path} -t_srs "+proj=eck4" data/w_jpeg.tiff {dst_tif}'
     )
 
-    ds = gdal.Open("tmp/testgdalwarp26.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     cs = ds.GetRasterBand(1).Checksum()
@@ -714,14 +641,15 @@ def test_gdalwarp_26(gdalwarp_path):
 
 
 @pytest.mark.require_creation_option("GTiff", "JPEG")
-def test_gdalwarp_27(gdalwarp_path):
+def test_gdalwarp_27(gdalwarp_path, tmp_path):
+
+    dst_tif = str(tmp_path / "testgdalwarp27.tif")
 
     gdaltest.runexternal(
-        gdalwarp_path
-        + ' -t_srs "+proj=vandg" data/w_jpeg.tiff tmp/testgdalwarp27.tif -overwrite'
+        f'{gdalwarp_path} -t_srs "+proj=vandg" data/w_jpeg.tiff {dst_tif} -overwrite'
     )
 
-    ds = gdal.Open("tmp/testgdalwarp27.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     cs = ds.GetRasterBand(1).Checksum()
@@ -748,14 +676,15 @@ def test_gdalwarp_27(gdalwarp_path):
 
 
 @pytest.mark.require_creation_option("GTiff", "JPEG")
-def test_gdalwarp_28(gdalwarp_path):
+def test_gdalwarp_28(gdalwarp_path, tmp_path):
+
+    dst_tif = str(tmp_path / "testgdalwarp28.tif")
 
     gdaltest.runexternal(
-        gdalwarp_path
-        + ' -t_srs "+proj=aeqd +lat_0=45 +lon_0=90" data/w_jpeg.tiff tmp/testgdalwarp28.tif'
+        f'{gdalwarp_path} -t_srs "+proj=aeqd +lat_0=45 +lon_0=90" data/w_jpeg.tiff {dst_tif}'
     )
 
-    ds = gdal.Open("tmp/testgdalwarp28.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     # Check that there is no hole at the south pole location
@@ -783,17 +712,18 @@ def test_gdalwarp_28(gdalwarp_path):
 
 
 @pytest.mark.require_creation_option("GTiff", "JPEG")
-def DISABLED_test_gdalwarp_29(gdalwarp_path):
+@pytest.mark.xfail()
+def test_gdalwarp_29(gdalwarp_path, tmp_path):
 
     # This test has been disabled since PROJ 8 will reproject a coordinates at
     # lat=90 to a finite value, due to 90deg being < PI/2 due to numerical
     # accuracy
 
-    gdaltest.runexternal(
-        gdalwarp_path + " -t_srs EPSG:3785 data/w_jpeg.tiff tmp/testgdalwarp29.tif"
-    )
+    dst_tif = str(tmp_path / "testgdalwarp29.tif")
 
-    ds = gdal.Open("tmp/testgdalwarp29.tif")
+    gdaltest.runexternal(f"{gdalwarp_path} -t_srs EPSG:3785 data/w_jpeg.tiff {dst_tif}")
+
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     cs = ds.GetRasterBand(1).Checksum()
@@ -819,36 +749,40 @@ def DISABLED_test_gdalwarp_29(gdalwarp_path):
 
 
 @pytest.mark.require_creation_option("GTiff", "JPEG")
-def test_gdalwarp_30(gdalwarp_path):
+def test_gdalwarp_30(gdalwarp_path, tmp_path):
+
+    dst1_tif = str(tmp_path / "testgdalwarp30_1.tif")
+    dst2_tif = str(tmp_path / "testgdalwarp30_2.tif")
+    dst3_tif = str(tmp_path / "testgdalwarp30_3.tif")
 
     te = " -te -20037508.343 -16206629.152 20036845.112 16213801.068"
 
     # First run : no parameter
     gdaltest.runexternal(
         gdalwarp_path
-        + " data/w_jpeg.tiff tmp/testgdalwarp30_1.tif  -t_srs EPSG:3785 -co COMPRESS=LZW -wm 500000  --config GDAL_CACHEMAX 1 -ts 1000 500 -co TILED=YES"
+        + f" data/w_jpeg.tiff {dst1_tif}  -t_srs EPSG:3785 -co COMPRESS=LZW -wm 500000  --config GDAL_CACHEMAX 1 -ts 1000 500 -co TILED=YES"
         + te
     )
 
     # Second run : with  -wo OPTIMIZE_SIZE=TRUE
     gdaltest.runexternal(
         gdalwarp_path
-        + " data/w_jpeg.tiff tmp/testgdalwarp30_2.tif  -t_srs EPSG:3785 -co COMPRESS=LZW -wm 500000 -wo OPTIMIZE_SIZE=TRUE  --config GDAL_CACHEMAX 1 -ts 1000 500 -co TILED=YES"
+        + f" data/w_jpeg.tiff {dst2_tif}  -t_srs EPSG:3785 -co COMPRESS=LZW -wm 500000 -wo OPTIMIZE_SIZE=TRUE  --config GDAL_CACHEMAX 1 -ts 1000 500 -co TILED=YES"
         + te
     )
 
     # Third run : with  -wo STREAMABLE_OUTPUT=TRUE
     gdaltest.runexternal(
         gdalwarp_path
-        + " data/w_jpeg.tiff tmp/testgdalwarp30_3.tif  -t_srs EPSG:3785 -co COMPRESS=LZW -wm 500000 -wo STREAMABLE_OUTPUT=TRUE  --config GDAL_CACHEMAX 1 -ts 1000 500 -co TILED=YES"
+        + f" data/w_jpeg.tiff {dst3_tif}  -t_srs EPSG:3785 -co COMPRESS=LZW -wm 500000 -wo STREAMABLE_OUTPUT=TRUE  --config GDAL_CACHEMAX 1 -ts 1000 500 -co TILED=YES"
         + te
     )
 
-    file_size1 = os.stat("tmp/testgdalwarp30_1.tif")[stat.ST_SIZE]
-    file_size2 = os.stat("tmp/testgdalwarp30_2.tif")[stat.ST_SIZE]
-    file_size3 = os.stat("tmp/testgdalwarp30_3.tif")[stat.ST_SIZE]
+    file_size1 = os.stat(dst1_tif)[stat.ST_SIZE]
+    file_size2 = os.stat(dst2_tif)[stat.ST_SIZE]
+    file_size3 = os.stat(dst3_tif)[stat.ST_SIZE]
 
-    ds = gdal.Open("tmp/testgdalwarp30_1.tif")
+    ds = gdal.Open(dst1_tif)
     assert ds is not None
 
     cs = ds.GetRasterBand(1).Checksum()
@@ -856,7 +790,7 @@ def test_gdalwarp_30(gdalwarp_path):
 
     ds = None
 
-    ds = gdal.Open("tmp/testgdalwarp30_2.tif")
+    ds = gdal.Open(dst2_tif)
     assert ds is not None
 
     cs = ds.GetRasterBand(1).Checksum()
@@ -864,7 +798,7 @@ def test_gdalwarp_30(gdalwarp_path):
 
     ds = None
 
-    ds = gdal.Open("tmp/testgdalwarp30_3.tif")
+    ds = gdal.Open(dst3_tif)
     assert ds is not None
 
     cs = ds.GetRasterBand(1).Checksum()
@@ -885,31 +819,29 @@ def test_gdalwarp_30(gdalwarp_path):
 # Test -overwrite (#3759)
 
 
-def test_gdalwarp_31(gdalwarp_path):
+def test_gdalwarp_31(gdalwarp_path, tmp_path):
 
-    gdaltest.runexternal(
-        gdalwarp_path + " ../gcore/data/byte.tif tmp/testgdalwarp31.tif"
-    )
+    dst_tif = str(tmp_path / "testgdalwarp31.tif")
 
-    ds = gdal.Open("tmp/testgdalwarp31.tif")
+    gdaltest.runexternal(f"{gdalwarp_path} ../gcore/data/byte.tif {dst_tif}")
+
+    ds = gdal.Open(dst_tif)
     cs1 = ds.GetRasterBand(1).Checksum()
     ds = None
 
     (_, err) = gdaltest.runexternal_out_and_err(
-        gdalwarp_path
-        + " ../gcore/data/byte.tif tmp/testgdalwarp31.tif -t_srs EPSG:4326"
+        f"{gdalwarp_path} ../gcore/data/byte.tif {dst_tif} -t_srs EPSG:4326"
     )
 
-    ds = gdal.Open("tmp/testgdalwarp31.tif")
+    ds = gdal.Open(dst_tif)
     cs2 = ds.GetRasterBand(1).Checksum()
     ds = None
 
     (_, err2) = gdaltest.runexternal_out_and_err(
-        gdalwarp_path
-        + " ../gcore/data/byte.tif tmp/testgdalwarp31.tif -t_srs EPSG:4326 -overwrite"
+        f"{gdalwarp_path} ../gcore/data/byte.tif {dst_tif} -t_srs EPSG:4326 -overwrite"
     )
 
-    ds = gdal.Open("tmp/testgdalwarp31.tif")
+    ds = gdal.Open(dst_tif)
     cs3 = ds.GetRasterBand(1).Checksum()
     ds = None
 
@@ -921,18 +853,20 @@ def test_gdalwarp_31(gdalwarp_path):
 
 
 @pytest.mark.require_creation_option("GTiff", "JPEG")
-def test_gdalwarp_33(gdalwarp_path):
+def test_gdalwarp_33(gdalwarp_path, tmp_path):
 
     if test_cli_utilities.get_gdal_translate_path() is None:
         pytest.skip("gdal_translate missing")
 
+    dst_tif = str(tmp_path / "testgdalwarp33.tif")
+    mask_tif = str(tmp_path / "testgdalwarp33_mask.tif")
+
     gdaltest.runexternal(
-        gdalwarp_path
-        + " -dstalpha ../gcore/data/ycbcr_with_mask.tif tmp/testgdalwarp33.tif"
+        f"{gdalwarp_path} -dstalpha ../gcore/data/ycbcr_with_mask.tif {dst_tif}"
     )
 
     src_ds = gdal.Open("../gcore/data/ycbcr_with_mask.tif")
-    ds = gdal.Open("tmp/testgdalwarp33.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     # There are expected diffs because of the artifacts due to JPEG compression in 8x8 blocks
@@ -944,10 +878,10 @@ def test_gdalwarp_33(gdalwarp_path):
 
     gdaltest.runexternal(
         test_cli_utilities.get_gdal_translate_path()
-        + " -expand gray GTIFF_DIR:2:../gcore/data/ycbcr_with_mask.tif tmp/testgdalwarp33_mask.tif"
+        + f" -expand gray GTIFF_DIR:2:../gcore/data/ycbcr_with_mask.tif {mask_tif}"
     )
 
-    mask_ds = gdal.Open("tmp/testgdalwarp33_mask.tif")
+    mask_ds = gdal.Open(mask_tif)
     expected_cs = mask_ds.GetRasterBand(1).Checksum()
     mask_ds = None
 
@@ -962,39 +896,31 @@ def test_gdalwarp_33(gdalwarp_path):
 # Test warping multiple sources
 
 
-def test_gdalwarp_34(gdalwarp_path):
+def test_gdalwarp_34(gdalwarp_path, tmp_path):
 
     if test_cli_utilities.get_gdal_translate_path() is None:
         pytest.skip("gdal_translate missing")
 
-    try:
-        os.remove("tmp/testgdalwarp34.tif")
-    except OSError:
-        pass
+    src1_tif = str(tmp_path / "testgdalwarp34src_1.tif")
+    src2_tif = str(tmp_path / "testgdalwarp34src_2.tif")
+    dst_tif = str(tmp_path / "testgdalwarp34.tif")
 
     gdaltest.runexternal(
         test_cli_utilities.get_gdal_translate_path()
-        + " ../gcore/data/byte.tif tmp/testgdalwarp34src_1.tif -srcwin 0 0 10 20"
+        + f" ../gcore/data/byte.tif {src1_tif} -srcwin 0 0 10 20"
     )
     gdaltest.runexternal(
         test_cli_utilities.get_gdal_translate_path()
-        + " ../gcore/data/byte.tif tmp/testgdalwarp34src_2.tif -srcwin 10 0 10 20"
+        + f" ../gcore/data/byte.tif {src2_tif} -srcwin 10 0 10 20"
     )
-    gdaltest.runexternal(
-        gdalwarp_path
-        + " tmp/testgdalwarp34src_1.tif tmp/testgdalwarp34src_2.tif tmp/testgdalwarp34.tif"
-    )
-    os.remove("tmp/testgdalwarp34src_1.tif")
-    os.remove("tmp/testgdalwarp34src_2.tif")
+    gdaltest.runexternal(f"{gdalwarp_path} {src1_tif} {src2_tif} {dst_tif}")
 
-    ds = gdal.Open("tmp/testgdalwarp34.tif")
+    ds = gdal.Open(dst_tif)
     cs = ds.GetRasterBand(1).Checksum()
     gt = ds.GetGeoTransform()
     xsize = ds.RasterXSize
     ysize = ds.RasterYSize
     ds = None
-
-    os.remove("tmp/testgdalwarp34.tif")
 
     assert xsize == 20 and ysize == 20, "bad dimensions"
 
@@ -1009,14 +935,15 @@ def test_gdalwarp_34(gdalwarp_path):
 # Test -ts and -te optimization (doesn't need calling GDALSuggestedWarpOutput2, #4804)
 
 
-def test_gdalwarp_35(gdalwarp_path):
+def test_gdalwarp_35(gdalwarp_path, tmp_path):
+
+    dst_tif = str(tmp_path / "testgdalwarp35.tif")
 
     gdaltest.runexternal(
-        gdalwarp_path
-        + " -ts 20 20 -te 440720.000 3750120.000 441920.000 3751320.000 ../gcore/data/byte.tif tmp/testgdalwarp35.tif"
+        f"{gdalwarp_path} -ts 20 20 -te 440720.000 3750120.000 441920.000 3751320.000 ../gcore/data/byte.tif {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/testgdalwarp35.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     gdaltest.check_geotransform(
@@ -1032,14 +959,15 @@ def test_gdalwarp_35(gdalwarp_path):
 # Test -tr and -te optimization (doesn't need calling GDALSuggestedWarpOutput2, #4804)
 
 
-def test_gdalwarp_36(gdalwarp_path):
+def test_gdalwarp_36(gdalwarp_path, tmp_path):
+
+    dst_tif = str(tmp_path / "testgdalwarp36.tif")
 
     gdaltest.runexternal(
-        gdalwarp_path
-        + " -tr 60 60 -te 440720.000 3750120.000 441920.000 3751320.000 ../gcore/data/byte.tif tmp/testgdalwarp36.tif"
+        f"{gdalwarp_path} -tr 60 60 -te 440720.000 3750120.000 441920.000 3751320.000 ../gcore/data/byte.tif {dst_tif}"
     )
 
-    ds = gdal.Open("tmp/testgdalwarp36.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     gdaltest.check_geotransform(
@@ -1055,13 +983,13 @@ def test_gdalwarp_36(gdalwarp_path):
 # Test metadata copying - stats should not be copied (#5319)
 
 
-def test_gdalwarp_37(gdalwarp_path):
+def test_gdalwarp_37(gdalwarp_path, tmp_path):
 
-    gdaltest.runexternal(
-        gdalwarp_path + " -tr 60 60 ./data/utmsmall.tif tmp/testgdalwarp37.tif"
-    )
+    dst_tif = str(tmp_path / "testgdalwarp37.tif")
 
-    ds = gdal.Open("tmp/testgdalwarp37.tif")
+    gdaltest.runexternal(f"{gdalwarp_path} -tr 60 60 ./data/utmsmall.tif {dst_tif}")
+
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     md = ds.GetRasterBand(1).GetMetadata()
@@ -1084,11 +1012,13 @@ def test_gdalwarp_37(gdalwarp_path):
 
 
 @pytest.mark.require_driver("AAIGRID")
-def test_gdalwarp_38(gdalwarp_path):
+def test_gdalwarp_38(gdalwarp_path, tmp_path):
 
-    gdaltest.runexternal(gdalwarp_path + " data/withnodata.asc tmp/testgdalwarp38.tif")
+    dst_tif = str(tmp_path / "testgdalwarp38.tif")
 
-    ds = gdal.Open("tmp/testgdalwarp38.tif")
+    gdaltest.runexternal(f"{gdalwarp_path} data/withnodata.asc {dst_tif}")
+
+    ds = gdal.Open(dst_tif)
     assert ds.GetRasterBand(1).Checksum() == 65531
     assert ds.GetRasterBand(1).GetNoDataValue() == -999
     ds = None
@@ -1099,14 +1029,15 @@ def test_gdalwarp_38(gdalwarp_path):
 
 
 @pytest.mark.require_driver("AAIGRID")
-def test_gdalwarp_39(gdalwarp_path):
+def test_gdalwarp_39(gdalwarp_path, tmp_path):
+
+    dst_tif = str(tmp_path / "testgdalwarp39.tif")
 
     gdaltest.runexternal(
-        gdalwarp_path
-        + " ../gdrivers/data/aaigrid/float64.asc tmp/test_gdalwarp_39.tif -oo DATATYPE=Float64 -overwrite"
+        f"{gdalwarp_path} ../gdrivers/data/aaigrid/float64.asc {dst_tif} -oo DATATYPE=Float64 -overwrite"
     )
 
-    ds = gdal.Open("tmp/test_gdalwarp_39.tif")
+    ds = gdal.Open(dst_tif)
     assert ds.GetRasterBand(1).DataType == gdal.GDT_Float64
     ds = None
 
@@ -1115,12 +1046,14 @@ def test_gdalwarp_39(gdalwarp_path):
 # Test -ovr
 
 
-def test_gdalwarp_40(gdalwarp_path):
+def test_gdalwarp_40(gdalwarp_path, tmp_path):
+
+    src_tif = str(tmp_path / "test_gdalwarp_40_src.tif")
+    dst_tif = str(tmp_path / "test_gdalwarp_40.tif")
+    dst_vrt = str(tmp_path / "test_gdalwarp_40.vrt")
 
     src_ds = gdal.Open("../gcore/data/byte.tif")
-    out_ds = gdal.GetDriverByName("GTiff").CreateCopy(
-        "tmp/test_gdalwarp_40_src.tif", src_ds
-    )
+    out_ds = gdal.GetDriverByName("GTiff").CreateCopy(src_tif, src_ds)
     cs_main = out_ds.GetRasterBand(1).Checksum()
     out_ds.BuildOverviews("NONE", overviewlist=[2, 4])
     out_ds.GetRasterBand(1).GetOverview(0).Fill(127)
@@ -1130,170 +1063,136 @@ def test_gdalwarp_40(gdalwarp_path):
     out_ds = None
 
     # Should select main resolution
-    gdaltest.runexternal(
-        gdalwarp_path
-        + " tmp/test_gdalwarp_40_src.tif tmp/test_gdalwarp_40.tif -overwrite"
-    )
+    gdaltest.runexternal(f"{gdalwarp_path} {src_tif} {dst_tif} -overwrite")
 
-    ds = gdal.Open("tmp/test_gdalwarp_40.tif")
+    ds = gdal.Open(dst_tif)
     assert ds.GetRasterBand(1).Checksum() == cs_main
     ds = None
 
     # Test -ovr AUTO. Should select main resolution
-    gdaltest.runexternal(
-        gdalwarp_path
-        + " tmp/test_gdalwarp_40_src.tif tmp/test_gdalwarp_40.tif -overwrite -ovr AUTO"
-    )
+    gdaltest.runexternal(f"{gdalwarp_path} {src_tif} {dst_tif} -overwrite -ovr AUTO")
 
-    ds = gdal.Open("tmp/test_gdalwarp_40.tif")
+    ds = gdal.Open(dst_tif)
     assert ds.GetRasterBand(1).Checksum() == cs_main
     ds = None
 
     gdaltest.runexternal(
-        gdalwarp_path
-        + " ../gcore/data/byte.tif tmp/test_gdalwarp_40.tif -overwrite -ts 5 5"
+        f"{gdalwarp_path} ../gcore/data/byte.tif {dst_tif} -overwrite -ts 5 5"
     )
-    ds = gdal.Open("tmp/test_gdalwarp_40.tif")
+    ds = gdal.Open(dst_tif)
     expected_cs = ds.GetRasterBand(1).Checksum()
     ds = None
 
     # Test -ovr NONE. Should select main resolution too
     gdaltest.runexternal(
-        gdalwarp_path
-        + " tmp/test_gdalwarp_40_src.tif tmp/test_gdalwarp_40.tif -overwrite -ovr NONE -ts 5 5"
+        f"{gdalwarp_path} {src_tif} {dst_tif} -overwrite -ovr NONE -ts 5 5"
     )
 
-    ds = gdal.Open("tmp/test_gdalwarp_40.tif")
+    ds = gdal.Open(dst_tif)
     assert ds.GetRasterBand(1).Checksum() == expected_cs
     ds = None
 
     gdaltest.runexternal(
-        gdalwarp_path
-        + " ../gcore/data/byte.tif tmp/test_gdalwarp_40.tif -overwrite -ts 15 15"
+        f"{gdalwarp_path} ../gcore/data/byte.tif {dst_tif} -overwrite -ts 15 15"
     )
-    ds = gdal.Open("tmp/test_gdalwarp_40.tif")
+    ds = gdal.Open(dst_tif)
     expected_cs = ds.GetRasterBand(1).Checksum()
     ds = None
 
     # Should select main resolution too
-    gdaltest.runexternal(
-        gdalwarp_path
-        + " tmp/test_gdalwarp_40_src.tif tmp/test_gdalwarp_40.tif -overwrite -ts 15 15"
-    )
+    gdaltest.runexternal(f"{gdalwarp_path} {src_tif} {dst_tif} -overwrite -ts 15 15")
 
-    ds = gdal.Open("tmp/test_gdalwarp_40.tif")
+    ds = gdal.Open(dst_tif)
     assert ds.GetRasterBand(1).Checksum() == expected_cs
     ds = None
 
     # Should select overview 0
-    gdaltest.runexternal(
-        gdalwarp_path
-        + " tmp/test_gdalwarp_40_src.tif tmp/test_gdalwarp_40.tif -overwrite -ts 10 10"
-    )
+    gdaltest.runexternal(f"{gdalwarp_path} {src_tif} {dst_tif} -overwrite -ts 10 10")
 
-    ds = gdal.Open("tmp/test_gdalwarp_40.tif")
+    ds = gdal.Open(dst_tif)
     assert ds.GetRasterBand(1).Checksum() == cs_ov0
     ds = None
 
     # Should select overview 0 through VRT
     gdaltest.runexternal(
-        gdalwarp_path
-        + " tmp/test_gdalwarp_40_src.tif tmp/test_gdalwarp_40.vrt -overwrite -ts 10 10 -of VRT"
+        f"{gdalwarp_path} {src_tif} {dst_vrt} -overwrite -ts 10 10 -of VRT"
     )
 
-    ds = gdal.Open("tmp/test_gdalwarp_40.vrt")
+    ds = gdal.Open(dst_vrt)
     assert ds.GetRasterBand(1).Checksum() == cs_ov0
     ds = None
 
     # Should select overview 0 through VRT
     gdaltest.runexternal(
-        gdalwarp_path
-        + " tmp/test_gdalwarp_40_src.tif tmp/test_gdalwarp_40.vrt -overwrite -ts 10 10 -te 440720 3750120 441920 3751320 -of VRT"
+        f"{gdalwarp_path} {src_tif} {dst_vrt} -overwrite -ts 10 10 -te 440720 3750120 441920 3751320 -of VRT"
     )
 
-    ds = gdal.Open("tmp/test_gdalwarp_40.vrt")
+    ds = gdal.Open(dst_vrt)
     assert ds.GetRasterBand(1).Checksum() == cs_ov0
     ds = None
 
     gdaltest.runexternal(
-        gdalwarp_path
-        + " tmp/test_gdalwarp_40_src.tif -oo OVERVIEW_LEVEL=0 tmp/test_gdalwarp_40.tif -overwrite -ts 7 7"
+        f"{gdalwarp_path} {src_tif} -oo OVERVIEW_LEVEL=0 {dst_tif} -overwrite -ts 7 7"
     )
-    ds = gdal.Open("tmp/test_gdalwarp_40.tif")
+    ds = gdal.Open(dst_tif)
     expected_cs = ds.GetRasterBand(1).Checksum()
     ds = None
 
     # Should select overview 0 too
-    gdaltest.runexternal(
-        gdalwarp_path
-        + " tmp/test_gdalwarp_40_src.tif tmp/test_gdalwarp_40.tif -overwrite -ts 7 7"
-    )
+    gdaltest.runexternal(f"{gdalwarp_path} {src_tif} {dst_tif} -overwrite -ts 7 7")
 
-    ds = gdal.Open("tmp/test_gdalwarp_40.tif")
+    ds = gdal.Open(dst_tif)
     assert ds.GetRasterBand(1).Checksum() == expected_cs
     ds = None
 
     gdaltest.runexternal(
-        gdalwarp_path
-        + " tmp/test_gdalwarp_40_src.tif -ovr NONE -oo OVERVIEW_LEVEL=0 tmp/test_gdalwarp_40.tif -overwrite -ts 5 5"
+        f"{gdalwarp_path} {src_tif} -ovr NONE -oo OVERVIEW_LEVEL=0 {dst_tif} -overwrite -ts 5 5"
     )
-    ds = gdal.Open("tmp/test_gdalwarp_40.tif")
+    ds = gdal.Open(dst_tif)
     expected_cs = ds.GetRasterBand(1).Checksum()
     ds = None
 
     # Test AUTO-n. Should select overview 0 too
     gdaltest.runexternal(
-        gdalwarp_path
-        + " tmp/test_gdalwarp_40_src.tif tmp/test_gdalwarp_40.tif -overwrite -ts 5 5 -ovr AUTO-1"
+        f"{gdalwarp_path} {src_tif} {dst_tif} -overwrite -ts 5 5 -ovr AUTO-1"
     )
 
-    ds = gdal.Open("tmp/test_gdalwarp_40.tif")
+    ds = gdal.Open(dst_tif)
     assert ds.GetRasterBand(1).Checksum() == expected_cs
     ds = None
 
     # Should select overview 1
-    gdaltest.runexternal(
-        gdalwarp_path
-        + " tmp/test_gdalwarp_40_src.tif tmp/test_gdalwarp_40.tif -overwrite -ts 5 5"
-    )
+    gdaltest.runexternal(f"{gdalwarp_path} {src_tif} {dst_tif} -overwrite -ts 5 5")
 
-    ds = gdal.Open("tmp/test_gdalwarp_40.tif")
+    ds = gdal.Open(dst_tif)
     assert ds.GetRasterBand(1).Checksum() == cs_ov1
     ds = None
 
     gdaltest.runexternal(
-        gdalwarp_path
-        + " tmp/test_gdalwarp_40_src.tif -oo OVERVIEW_LEVEL=1 tmp/test_gdalwarp_40.tif -overwrite -ts 3 3"
+        f"{gdalwarp_path} {src_tif} -oo OVERVIEW_LEVEL=1 {dst_tif} -overwrite -ts 3 3"
     )
-    ds = gdal.Open("tmp/test_gdalwarp_40.tif")
+    ds = gdal.Open(dst_tif)
     expected_cs = ds.GetRasterBand(1).Checksum()
     ds = None
 
     # Should select overview 1 too
-    gdaltest.runexternal(
-        gdalwarp_path
-        + " tmp/test_gdalwarp_40_src.tif tmp/test_gdalwarp_40.tif -overwrite -ts 3 3"
-    )
+    gdaltest.runexternal(f"{gdalwarp_path} {src_tif} {dst_tif} -overwrite -ts 3 3")
 
-    ds = gdal.Open("tmp/test_gdalwarp_40.tif")
+    ds = gdal.Open(dst_tif)
     assert ds.GetRasterBand(1).Checksum() == expected_cs
     ds = None
 
     gdaltest.runexternal(
-        gdalwarp_path
-        + " tmp/test_gdalwarp_40_src.tif -oo OVERVIEW_LEVEL=1 tmp/test_gdalwarp_40.tif -overwrite -ts 20 20"
+        f"{gdalwarp_path} {src_tif} -oo OVERVIEW_LEVEL=1 {dst_tif} -overwrite -ts 20 20"
     )
-    ds = gdal.Open("tmp/test_gdalwarp_40.tif")
+    ds = gdal.Open(dst_tif)
     expected_cs = ds.GetRasterBand(1).Checksum()
     ds = None
 
     # Specify a level >= number of overviews. Should select overview 1 too
-    gdaltest.runexternal(
-        gdalwarp_path
-        + " tmp/test_gdalwarp_40_src.tif tmp/test_gdalwarp_40.tif -overwrite -ovr 5"
-    )
+    gdaltest.runexternal(f"{gdalwarp_path} {src_tif} {dst_tif} -overwrite -ovr 5")
 
-    ds = gdal.Open("tmp/test_gdalwarp_40.tif")
+    ds = gdal.Open(dst_tif)
     assert ds.GetRasterBand(1).Checksum() == expected_cs
     ds = None
 
@@ -1304,11 +1203,12 @@ def test_gdalwarp_40(gdalwarp_path):
 # dataset and target extent
 
 
-def test_gdalwarp_41(gdalwarp_path):
+def test_gdalwarp_41(gdalwarp_path, tmp_path):
 
-    src_ds = gdal.GetDriverByName("GTiff").Create(
-        "tmp/test_gdalwarp_41_src.tif", 666, 666
-    )
+    src_tif = str(tmp_path / "test_gdalwarp_41_src.tif")
+    dst_tif = str(tmp_path / "test_gdalwarp_41.tif")
+
+    src_ds = gdal.GetDriverByName("GTiff").Create(src_tif, 666, 666)
     src_ds.SetGeoTransform(
         [
             -3333500,
@@ -1343,11 +1243,10 @@ def test_gdalwarp_41(gdalwarp_path):
 
     # Check when source fill ratio heuristics is ON
     gdaltest.runexternal(
-        gdalwarp_path
-        + " tmp/test_gdalwarp_41_src.tif tmp/test_gdalwarp_41.tif -overwrite  -t_srs EPSG:4326 -te -180 -90 180 90  -wo INIT_DEST=127 -wo SKIP_NOSOURCE=YES"
+        f"{gdalwarp_path} {src_tif} {dst_tif} -overwrite  -t_srs EPSG:4326 -te -180 -90 180 90  -wo INIT_DEST=127 -wo SKIP_NOSOURCE=YES"
     )
 
-    ds = gdal.Open("tmp/test_gdalwarp_41.tif")
+    ds = gdal.Open(dst_tif)
     assert ds.RasterXSize == 2052
     assert ds.RasterYSize == 1026
     assert ds.GetRasterBand(1).Checksum() == 57091
@@ -1355,11 +1254,10 @@ def test_gdalwarp_41(gdalwarp_path):
 
     # Check when source fill ratio heuristics is OFF
     gdaltest.runexternal(
-        gdalwarp_path
-        + " tmp/test_gdalwarp_41_src.tif tmp/test_gdalwarp_41.tif -overwrite  -t_srs EPSG:4326 -te -180 -90 180 90  -wo INIT_DEST=127 -wo SKIP_NOSOURCE=YES -wo SRC_FILL_RATIO_HEURISTICS=NO"
+        f"{gdalwarp_path} {src_tif} {dst_tif} -overwrite  -t_srs EPSG:4326 -te -180 -90 180 90  -wo INIT_DEST=127 -wo SKIP_NOSOURCE=YES -wo SRC_FILL_RATIO_HEURISTICS=NO"
     )
 
-    ds = gdal.Open("tmp/test_gdalwarp_41.tif")
+    ds = gdal.Open(dst_tif)
     assert ds.GetRasterBand(1).Checksum() == 31890
     ds = None
 
@@ -1368,29 +1266,32 @@ def test_gdalwarp_41(gdalwarp_path):
 # Test warping multiple source images, in one step or several, with INIT_DEST/nodata (#5909, #5387)
 
 
-def test_gdalwarp_42(gdalwarp_path):
+def test_gdalwarp_42(gdalwarp_path, tmp_path):
+
     if test_cli_utilities.get_gdal_translate_path() is None:
         pytest.skip("gdal_translate missing")
 
+    left_tif = str(tmp_path / "small_world_left.tif")
+    right_tif = str(tmp_path / "small_world_right.tif")
+    dst_tif = str(tmp_path / "test_gdalwarp_42.tif")
+
     gdaltest.runexternal(
         test_cli_utilities.get_gdal_translate_path()
-        + " ../gdrivers/data/small_world.tif tmp/small_world_left.tif -srcwin 0 0 200 200 -a_nodata 255"
+        + f" ../gdrivers/data/small_world.tif {left_tif} -srcwin 0 0 200 200 -a_nodata 255"
     )
     gdaltest.runexternal(
         test_cli_utilities.get_gdal_translate_path()
-        + " ../gdrivers/data/small_world.tif tmp/small_world_right.tif -srcwin 200 0 200 200  -a_nodata 255"
+        + f" ../gdrivers/data/small_world.tif {right_tif} -srcwin 200 0 200 200  -a_nodata 255"
     )
 
     gdaltest.runexternal(
-        gdalwarp_path
-        + " tmp/small_world_left.tif tmp/test_gdalwarp_42.tif -overwrite -te -180 -90 180 90 -dstalpha -wo UNIFIED_SRC_NODATA=YES"
+        f"{gdalwarp_path} {left_tif} {dst_tif} -overwrite -te -180 -90 180 90 -dstalpha -wo UNIFIED_SRC_NODATA=YES"
     )
     gdaltest.runexternal(
-        gdalwarp_path
-        + " tmp/small_world_right.tif tmp/test_gdalwarp_42.tif -wo UNIFIED_SRC_NODATA=YES"
+        f"{gdalwarp_path} {right_tif} {dst_tif} -wo UNIFIED_SRC_NODATA=YES"
     )
 
-    ds = gdal.Open("tmp/test_gdalwarp_42.tif")
+    ds = gdal.Open(dst_tif)
     got_cs = [ds.GetRasterBand(i + 1).Checksum() for i in range(4)]
     expected_cs = [25382, 27573, 35297, 59540]
     assert got_cs == expected_cs
@@ -1398,11 +1299,10 @@ def test_gdalwarp_42(gdalwarp_path):
 
     # In one step
     gdaltest.runexternal(
-        gdalwarp_path
-        + " tmp/small_world_left.tif tmp/small_world_right.tif tmp/test_gdalwarp_42.tif -overwrite -te -180 -90 180 90 -dstalpha -wo UNIFIED_SRC_NODATA=YES"
+        f"{gdalwarp_path} {left_tif} {right_tif} {dst_tif} -overwrite -te -180 -90 180 90 -dstalpha -wo UNIFIED_SRC_NODATA=YES"
     )
 
-    ds = gdal.Open("tmp/test_gdalwarp_42.tif")
+    ds = gdal.Open(dst_tif)
     got_cs = [ds.GetRasterBand(i + 1).Checksum() for i in range(4)]
     expected_cs = [25382, 27573, 35297, 59540]
     assert got_cs == expected_cs
@@ -1410,11 +1310,10 @@ def test_gdalwarp_42(gdalwarp_path):
 
     # In one step with -wo INIT_DEST=255,255,255,0
     gdaltest.runexternal(
-        gdalwarp_path
-        + " tmp/small_world_left.tif tmp/small_world_right.tif tmp/test_gdalwarp_42.tif -wo INIT_DEST=255,255,255,0 -overwrite -te -180 -90 180 90 -dstalpha -wo UNIFIED_SRC_NODATA=YES"
+        f"{gdalwarp_path} {left_tif} {right_tif} {dst_tif} -wo INIT_DEST=255,255,255,0 -overwrite -te -180 -90 180 90 -dstalpha -wo UNIFIED_SRC_NODATA=YES"
     )
 
-    ds = gdal.Open("tmp/test_gdalwarp_42.tif")
+    ds = gdal.Open(dst_tif)
     got_cs = [ds.GetRasterBand(i + 1).Checksum() for i in range(4)]
     expected_cs = [30111, 32302, 40026, 59540]
     assert got_cs == expected_cs
@@ -1423,11 +1322,10 @@ def test_gdalwarp_42(gdalwarp_path):
     # In one step with -wo INIT_DEST=0,0,0,0
     # Different checksum since there are source pixels at 255, so they get remap to 0
     gdaltest.runexternal(
-        gdalwarp_path
-        + " tmp/small_world_left.tif tmp/small_world_right.tif tmp/test_gdalwarp_42.tif -wo INIT_DEST=0,0,0,0 -overwrite -te -180 -90 180 90 -dstalpha -wo UNIFIED_SRC_NODATA=YES"
+        f"{gdalwarp_path} {left_tif} {right_tif} {dst_tif} -wo INIT_DEST=0,0,0,0 -overwrite -te -180 -90 180 90 -dstalpha -wo UNIFIED_SRC_NODATA=YES"
     )
 
-    ds = gdal.Open("tmp/test_gdalwarp_42.tif")
+    ds = gdal.Open(dst_tif)
     got_cs = [ds.GetRasterBand(i + 1).Checksum() for i in range(4)]
     expected_cs = [25382, 27573, 35297, 59540]
     assert got_cs == expected_cs
@@ -1438,21 +1336,21 @@ def test_gdalwarp_42(gdalwarp_path):
 # Test that NODATA_VALUES is honoured, but not transferred when adding an alpha channel.
 
 
-def test_gdalwarp_43(gdalwarp_path):
+def test_gdalwarp_43(gdalwarp_path, tmp_path):
     if test_cli_utilities.get_gdal_translate_path() is None:
         pytest.skip("gdal_translate missing")
 
+    src_tif = str(tmp_path / "small_world.tif")
+    dst_tif = str(tmp_path / "test_gdalwarp_43.tif")
+
     gdaltest.runexternal(
         test_cli_utilities.get_gdal_translate_path()
-        + ' ../gdrivers/data/small_world.tif tmp/small_world.tif -mo "FOO=BAR" -mo "NODATA_VALUES=62 93 23"'
+        + f' ../gdrivers/data/small_world.tif {src_tif} -mo "FOO=BAR" -mo "NODATA_VALUES=62 93 23"'
     )
 
-    gdaltest.runexternal(
-        gdalwarp_path
-        + " tmp/small_world.tif tmp/test_gdalwarp_43.tif -overwrite -dstalpha"
-    )
+    gdaltest.runexternal(f"{gdalwarp_path} {src_tif} {dst_tif} -overwrite -dstalpha")
 
-    ds = gdal.Open("tmp/test_gdalwarp_43.tif")
+    ds = gdal.Open(dst_tif)
     assert ds.GetMetadataItem("NODATA_VALUES") is None
     assert ds.GetMetadataItem("FOO") == "BAR"
     got_cs = [ds.GetRasterBand(i + 1).Checksum() for i in range(4)]
@@ -1464,22 +1362,22 @@ def test_gdalwarp_43(gdalwarp_path):
 # Test effect of -wo SRC_COORD_PRECISION
 
 
-def test_gdalwarp_44(gdalwarp_path):
+def test_gdalwarp_44(gdalwarp_path, tmp_path):
+
+    dst_tif = str(tmp_path / "out.tif")
 
     # Without  -wo SRC_COORD_PRECISION
     gdaltest.runexternal(
-        gdalwarp_path
-        + " -q ../gcore/data/byte.tif tmp/test_gdalwarp_44.tif -wm 10 -overwrite -ts 500 500 -r cubic -ot float32 -t_srs EPSG:4326"
+        f"{gdalwarp_path} -q ../gcore/data/byte.tif {dst_tif} -wm 10 -overwrite -ts 500 500 -r cubic -ot float32 -t_srs EPSG:4326"
     )
-    ds = gdal.Open("tmp/test_gdalwarp_44.tif")
+    ds = gdal.Open(dst_tif)
     cs1 = ds.GetRasterBand(1).Checksum()
     ds = None
 
     gdaltest.runexternal(
-        gdalwarp_path
-        + " -q ../gcore/data/byte.tif tmp/test_gdalwarp_44.tif -wm 0.1 -overwrite -ts 500 500 -r cubic -ot float32 -t_srs EPSG:4326"
+        f"{gdalwarp_path} -q ../gcore/data/byte.tif {dst_tif} -wm 0.1 -overwrite -ts 500 500 -r cubic -ot float32 -t_srs EPSG:4326"
     )
-    ds = gdal.Open("tmp/test_gdalwarp_44.tif")
+    ds = gdal.Open(dst_tif)
     cs2 = ds.GetRasterBand(1).Checksum()
     ds = None
 
@@ -1488,18 +1386,16 @@ def test_gdalwarp_44(gdalwarp_path):
 
     # With  -wo SRC_COORD_PRECISION
     gdaltest.runexternal(
-        gdalwarp_path
-        + " -q ../gcore/data/byte.tif tmp/test_gdalwarp_44.tif -wm 10 -et 0.01 -wo SRC_COORD_PRECISION=0.1 -overwrite -ts 500 500 -r cubic -ot float32 -t_srs EPSG:4326"
+        f"{gdalwarp_path} -q ../gcore/data/byte.tif {dst_tif} -wm 10 -et 0.01 -wo SRC_COORD_PRECISION=0.1 -overwrite -ts 500 500 -r cubic -ot float32 -t_srs EPSG:4326"
     )
-    ds = gdal.Open("tmp/test_gdalwarp_44.tif")
+    ds = gdal.Open(dst_tif)
     cs3 = ds.GetRasterBand(1).Checksum()
     ds = None
 
     gdaltest.runexternal(
-        gdalwarp_path
-        + " -q ../gcore/data/byte.tif tmp/test_gdalwarp_44.tif -wm 0.1 -et 0.01 -wo SRC_COORD_PRECISION=0.1 -overwrite -ts 500 500 -r cubic -ot float32 -t_srs EPSG:4326"
+        f"{gdalwarp_path} -q ../gcore/data/byte.tif {dst_tif} -wm 0.1 -et 0.01 -wo SRC_COORD_PRECISION=0.1 -overwrite -ts 500 500 -r cubic -ot float32 -t_srs EPSG:4326"
     )
-    ds = gdal.Open("tmp/test_gdalwarp_44.tif")
+    ds = gdal.Open(dst_tif)
     cs4 = ds.GetRasterBand(1).Checksum()
     ds = None
 
@@ -1510,24 +1406,29 @@ def test_gdalwarp_44(gdalwarp_path):
 # Test -te_srs
 
 
-def test_gdalwarp_45(gdalwarp_path):
+def test_gdalwarp_45(gdalwarp_path, tmp_path):
+
+    dst_tif = str(tmp_path / "test_gdalwarp_45.tif")
 
     gdaltest.runexternal(
-        gdalwarp_path
-        + " -te_srs EPSG:4267 -te -117.641087629972 33.8915301685897 -117.628190189534 33.9024195619201 ../gcore/data/byte.tif tmp/test_gdalwarp_45.tif -overwrite"
+        f"{gdalwarp_path} -te_srs EPSG:4267 -te -117.641087629972 33.8915301685897 -117.628190189534 33.9024195619201 ../gcore/data/byte.tif {dst_tif} -overwrite"
     )
 
-    ds = gdal.Open("tmp/test_gdalwarp_45.tif")
+    ds = gdal.Open(dst_tif)
     assert ds.GetRasterBand(1).Checksum() == 4672
 
     ds = None
 
+
+def test_gdalwarp_45bis(gdalwarp_path, tmp_path):
+
+    dst_tif = str(tmp_path / "test_gdalwarp_45bis.tif")
+
     gdaltest.runexternal(
-        gdalwarp_path
-        + " -te_srs EPSG:4267 -te -117.641087629972 33.8915301685897 -117.628190189534 33.9024195619201 -t_srs EPSG:32611 ../gcore/data/byte.tif tmp/test_gdalwarp_45.tif -overwrite"
+        f"{gdalwarp_path} -te_srs EPSG:4267 -te -117.641087629972 33.8915301685897 -117.628190189534 33.9024195619201 -t_srs EPSG:32611 ../gcore/data/byte.tif {dst_tif} -overwrite"
     )
 
-    ds = gdal.Open("tmp/test_gdalwarp_45.tif")
+    ds = gdal.Open(dst_tif)
     assert ds.GetRasterBand(1).Checksum() == 4672
 
     ds = None
@@ -1538,46 +1439,64 @@ def test_gdalwarp_45(gdalwarp_path):
 
 
 @pytest.mark.require_driver("CSV")
-def test_gdalwarp_46(gdalwarp_path):
+def test_gdalwarp_46(gdalwarp_path, tmp_path):
     if test_cli_utilities.get_ogr2ogr_path() is None:
         pytest.skip("ogr2ogr missing")
 
+    dst_tif = str(tmp_path / "testgdalwarp46.tif")
+
     gdaltest.runexternal(
-        gdalwarp_path
-        + " ../gcore/data/utmsmall.tif tmp/test_gdalwarp_46.tif -cutline data/cutline.vrt -crop_to_cutline -overwrite"
+        f"{gdalwarp_path} ../gcore/data/utmsmall.tif {dst_tif} -cutline data/cutline.vrt -crop_to_cutline -overwrite"
     )
 
-    ds = gdal.Open("tmp/test_gdalwarp_46.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 18837, "Bad checksum"
 
     ds = None
+
+
+@pytest.mark.require_driver("CSV")
+def test_gdalwarp_46bis(gdalwarp_path, tmp_path):
+
+    if test_cli_utilities.get_ogr2ogr_path() is None:
+        pytest.skip("ogr2ogr missing")
+
+    dst_tif = str(tmp_path / "testgdalwarp46bis.tif")
 
     # With explicit -s_srs and -t_srs
     gdaltest.runexternal(
-        gdalwarp_path
-        + " ../gcore/data/utmsmall.tif tmp/test_gdalwarp_46.tif -cutline data/cutline.vrt -crop_to_cutline -overwrite -s_srs EPSG:26711 -t_srs EPSG:26711"
+        f"{gdalwarp_path} ../gcore/data/utmsmall.tif {dst_tif} -cutline data/cutline.vrt -crop_to_cutline -overwrite -s_srs EPSG:26711 -t_srs EPSG:26711"
     )
 
-    ds = gdal.Open("tmp/test_gdalwarp_46.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 18837, "Bad checksum"
 
     ds = None
+
+
+@pytest.mark.require_driver("CSV")
+def test_gdalwarp_46ter(gdalwarp_path, tmp_path):
+
+    if test_cli_utilities.get_ogr2ogr_path() is None:
+        pytest.skip("ogr2ogr missing")
+
+    dst_tif = str(tmp_path / "testgdalwarp46ter.tif")
+    cutline_shp = str(tmp_path / "cutline_4326.shp")
 
     # With cutline in another SRS
     gdaltest.runexternal(
         test_cli_utilities.get_ogr2ogr_path()
-        + " tmp/cutline_4326.shp data/cutline.vrt -s_srs EPSG:26711 -t_srs EPSG:4326"
+        + f" {cutline_shp} data/cutline.vrt -s_srs EPSG:26711 -t_srs EPSG:4326"
     )
     gdaltest.runexternal(
-        gdalwarp_path
-        + " ../gcore/data/utmsmall.tif tmp/test_gdalwarp_46.tif -cutline tmp/cutline_4326.shp -crop_to_cutline -overwrite -t_srs EPSG:32711"
+        f"{gdalwarp_path} ../gcore/data/utmsmall.tif {dst_tif} -cutline {cutline_shp} -crop_to_cutline -overwrite -t_srs EPSG:32711"
     )
 
-    ds = gdal.Open("tmp/test_gdalwarp_46.tif")
+    ds = gdal.Open(dst_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 19582, "Bad checksum"
@@ -1589,9 +1508,9 @@ def test_gdalwarp_46(gdalwarp_path):
 # Test gdalwarp -co APPEND_SUBDATASET=YES
 
 
-def test_gdalwarp_47_append_subdataset(gdalwarp_path):
+def test_gdalwarp_47_append_subdataset(gdalwarp_path, tmp_path):
 
-    tmpfilename = "tmp/test_gdalwarp_47_append_subdataset.tif"
+    tmpfilename = str(tmp_path / "test_gdalwarp_47_append_subdataset.tif")
     gdal.Translate(tmpfilename, "../gcore/data/byte.tif")
     gdaltest.runexternal(
         gdalwarp_path

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -30,7 +30,6 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
-import os
 import shutil
 import struct
 
@@ -40,31 +39,14 @@ import pytest
 
 from osgeo import gdal, ogr, osr
 
-
-@pytest.fixture(scope="module", autouse=True)
-def setup_and_cleanup():
-
-    yield
-
-    # We don't clean up when run in debug mode.
-    if gdal.GetConfigOption("CPL_DEBUG", "OFF") == "ON":
-        return
-
-    for i in range(2):
-        try:
-            os.remove("tmp/testgdalwarp" + str(i + 1) + ".tif")
-        except OSError:
-            pass
-
-
 ###############################################################################
 # Simple test
 
 
-def test_gdalwarp_lib_1():
+def test_gdalwarp_lib_1(tmp_path):
 
     ds1 = gdal.Open("../gcore/data/byte.tif")
-    dstDS = gdal.Warp("tmp/testgdalwarp1.tif", ds1)
+    dstDS = gdal.Warp(f"{tmp_path}/testgdalwarp1.tif", ds1)
 
     assert dstDS.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
 
@@ -75,11 +57,13 @@ def test_gdalwarp_lib_1():
 # Test -of option
 
 
-def test_gdalwarp_lib_2():
+def test_gdalwarp_lib_2(tmp_path):
 
     ds1 = gdal.Open("../gcore/data/byte.tif")
     dstDS = gdal.Warp(
-        "tmp/testgdalwarp2.tif".encode("ascii").decode("ascii"), [ds1], format="GTiff"
+        f"{tmp_path}/testgdalwarp2.tif".encode("ascii").decode("ascii"),
+        [ds1],
+        format="GTiff",
     )
 
     assert dstDS.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
@@ -1735,12 +1719,54 @@ def test_gdalwarp_lib_134():
 # Test vertical datum shift
 
 
+@pytest.fixture()
 @pytest.mark.require_driver("GTX")
-def test_gdalwarp_lib_135():
+def gdalwarp_135_grid_gtx(tmp_path):
+
+    grid_gtx = str(tmp_path / "grid.gtx")
+
+    sr = osr.SpatialReference()
+    sr.SetFromUserInput("WGS84")
+
+    grid_ds = gdal.GetDriverByName("GTX").Create(grid_gtx, 3, 3, 1, gdal.GDT_Float32)
+    grid_ds.SetProjection(sr.ExportToWkt())
+    grid_ds.SetGeoTransform([-180 - 90, 180, 0, 90 + 45, 0, -90])
+    grid_ds.GetRasterBand(1).Fill(20)
+    grid_ds = None
+
+    return grid_gtx
+
+
+@pytest.fixture()
+@pytest.mark.require_driver("GTX")
+def gdalwarp_135_grid2_gtx(tmp_path):
+
+    grid2_gtx = str(tmp_path / "grid2.gtx")
+
+    sr = osr.SpatialReference()
+    sr.SetFromUserInput("WGS84")
+
+    grid_ds = gdal.GetDriverByName("GTX").Create(grid2_gtx, 3, 3, 1, gdal.GDT_Float32)
+    grid_ds.SetProjection(sr.ExportToWkt())
+    grid_ds.SetGeoTransform([-180 - 90, 180, 0, 90 + 45, 0, -90])
+    grid_ds.GetRasterBand(1).Fill(5)
+    grid_ds = None
+
+    return grid2_gtx
+
+
+@pytest.fixture()
+def gdalwarp_135_src_ds(tmp_path):
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
     src_ds.SetGeoTransform([500000, 1, 0, 4000000, 0, -1])
     src_ds.GetRasterBand(1).Fill(100)
+
+    return src_ds
+
+
+@pytest.fixture()
+def gdalwarp_135_src_ds_longlat(tmp_path):
 
     sr = osr.SpatialReference()
     sr.SetFromUserInput("WGS84")
@@ -1750,144 +1776,181 @@ def test_gdalwarp_lib_135():
     src_ds_longlat.SetGeoTransform([-180, 180, 0, 90, 0, -180])
     src_ds_longlat.GetRasterBand(1).Fill(100)
 
-    grid_ds = gdal.GetDriverByName("GTX").Create(
-        "tmp/grid.gtx", 3, 3, 1, gdal.GDT_Float32
-    )
-    grid_ds.SetProjection(sr.ExportToWkt())
-    grid_ds.SetGeoTransform([-180 - 90, 180, 0, 90 + 45, 0, -90])
-    grid_ds.GetRasterBand(1).Fill(20)
-    grid_ds = None
+    return src_ds_longlat
 
-    grid_ds = gdal.GetDriverByName("GTX").Create(
-        "tmp/grid2.gtx", 3, 3, 1, gdal.GDT_Float32
-    )
-    grid_ds.SetProjection(sr.ExportToWkt())
-    grid_ds.SetGeoTransform([-180 - 90, 180, 0, 90 + 45, 0, -90])
-    grid_ds.GetRasterBand(1).Fill(5)
-    grid_ds = None
+
+@pytest.mark.require_driver("GTX")
+def test_gdalwarp_lib_135(gdalwarp_135_src_ds, gdalwarp_135_grid_gtx):
 
     # Forward transform
     ds = gdal.Warp(
         "",
-        src_ds,
+        gdalwarp_135_src_ds,
         format="MEM",
-        srcSRS="+proj=utm +zone=31 +datum=WGS84 +units=m +geoidgrids=./tmp/grid.gtx +vunits=m +no_defs",
+        srcSRS=f"+proj=utm +zone=31 +datum=WGS84 +units=m +geoidgrids={gdalwarp_135_grid_gtx} +vunits=m +no_defs",
         dstSRS="EPSG:4979",
     )
     data = struct.unpack("B" * 1, ds.GetRasterBand(1).ReadRaster())[0]
     assert data == 120, "Bad value"
 
+
+@pytest.mark.require_driver("GTX")
+def test_gdalwarp_lib_135a(gdalwarp_135_src_ds_longlat, gdalwarp_135_grid_gtx):
+
+    # Forward transform, longlat
+
     ds = gdal.Warp(
         "",
-        src_ds_longlat,
+        gdalwarp_135_src_ds_longlat,
         format="MEM",
-        srcSRS="+proj=longlat +datum=WGS84 +geoidgrids=./tmp/grid.gtx +vunits=m +no_defs",
+        srcSRS=f"+proj=longlat +datum=WGS84 +geoidgrids={gdalwarp_135_grid_gtx} +vunits=m +no_defs",
         dstSRS="EPSG:4979",
     )
     assert ds.GetGeoTransform() == (-180, 180, 0, 90, 0, -180)
     data = struct.unpack("B" * 2, ds.GetRasterBand(1).ReadRaster())[0]
     assert data == 120, "Bad value"
+
+
+@pytest.mark.require_driver("GTX")
+def test_gdalwarp_lib_135b(gdalwarp_135_src_ds, gdalwarp_135_grid_gtx):
 
     # Inverse transform
     ds = gdal.Warp(
         "",
-        src_ds,
+        gdalwarp_135_src_ds,
         format="MEM",
         srcSRS="+proj=utm +zone=31 +datum=WGS84 +units=m +no_defs",
-        dstSRS="+proj=longlat +datum=WGS84 +geoidgrids=./tmp/grid.gtx +vunits=m +no_defs",
+        dstSRS=f"+proj=longlat +datum=WGS84 +geoidgrids={gdalwarp_135_grid_gtx} +vunits=m +no_defs",
     )
     data = struct.unpack("B" * 1, ds.GetRasterBand(1).ReadRaster())[0]
     assert data == 80, "Bad value"
 
+
+@pytest.mark.require_driver("GTX")
+def test_gdalwarp_lib_135c(gdalwarp_135_src_ds_longlat, gdalwarp_135_grid_gtx):
+
+    # Inverse transform, longlat
     ds = gdal.Warp(
         "",
-        src_ds_longlat,
+        gdalwarp_135_src_ds_longlat,
         format="MEM",
         srcSRS="EPSG:4979",
-        dstSRS="+proj=longlat +datum=WGS84 +geoidgrids=./tmp/grid.gtx +vunits=m +no_defs",
+        dstSRS=f"+proj=longlat +datum=WGS84 +geoidgrids={gdalwarp_135_grid_gtx} +vunits=m +no_defs",
     )
     assert ds.GetGeoTransform() == (-180, 180, 0, 90, 0, -180)
     data = struct.unpack("B" * 2, ds.GetRasterBand(1).ReadRaster())[0]
     assert data == 80, "Bad value"
 
+
+@pytest.mark.require_driver("GTX")
+def test_gdalwarp_lib_135d(
+    gdalwarp_135_src_ds, gdalwarp_135_grid_gtx, gdalwarp_135_grid2_gtx
+):
+
     # Both transforms
     ds = gdal.Warp(
         "",
-        src_ds,
+        gdalwarp_135_src_ds,
         format="MEM",
-        srcSRS="+proj=utm +zone=31 +datum=WGS84 +units=m +geoidgrids=./tmp/grid.gtx +vunits=m +no_defs",
-        dstSRS="+proj=longlat +datum=WGS84 +geoidgrids=./tmp/grid2.gtx +vunits=m +no_defs",
+        srcSRS=f"+proj=utm +zone=31 +datum=WGS84 +units=m +geoidgrids={gdalwarp_135_grid_gtx} +vunits=m +no_defs",
+        dstSRS=f"+proj=longlat +datum=WGS84 +geoidgrids={gdalwarp_135_grid2_gtx} +vunits=m +no_defs",
     )
     data = struct.unpack("B" * 1, ds.GetRasterBand(1).ReadRaster())[0]
     assert data == 115, "Bad value"
 
+
+def test_gdalwarp_lib_135e(gdalwarp_135_src_ds):
+
     # Both transforms, but none of them have geoidgrids
     ds = gdal.Warp(
-        "", src_ds, format="MEM", srcSRS="EPSG:32631+5730", dstSRS="EPSG:4326+5621"
+        "",
+        gdalwarp_135_src_ds,
+        format="MEM",
+        srcSRS="EPSG:32631+5730",
+        dstSRS="EPSG:4326+5621",
     )
     data = struct.unpack("B" * 1, ds.GetRasterBand(1).ReadRaster())[0]
     assert data == 100, "Bad value"
+
+
+@pytest.mark.require_driver("GTX")
+def test_gdalwarp_lib_135f(gdalwarp_135_src_ds, gdalwarp_135_grid_gtx):
 
     # Both transforms being a no-op
     ds = gdal.Warp(
         "",
-        src_ds,
+        gdalwarp_135_src_ds,
         format="MEM",
-        srcSRS="+proj=utm +zone=31 +datum=WGS84 +units=m +geoidgrids=./tmp/grid.gtx +vunits=m +no_defs",
-        dstSRS="+proj=longlat +datum=WGS84 +geoidgrids=./tmp/grid.gtx +vunits=m +no_defs",
+        srcSRS=f"+proj=utm +zone=31 +datum=WGS84 +units=m +geoidgrids={gdalwarp_135_grid_gtx} +vunits=m +no_defs",
+        dstSRS=f"+proj=longlat +datum=WGS84 +geoidgrids={gdalwarp_135_grid_gtx} +vunits=m +no_defs",
     )
     data = struct.unpack("B" * 1, ds.GetRasterBand(1).ReadRaster())[0]
     assert data == 100, "Bad value"
 
-    if (osr.GetPROJVersionMajor(), osr.GetPROJVersionMinor()) >= (6, 3):
-        # Both transforms to anonymous VRT
-        ds = gdal.Warp(
-            "",
-            src_ds,
-            format="VRT",
-            srcSRS="+proj=utm +zone=31 +datum=WGS84 +units=m +geoidgrids=./tmp/grid.gtx +vunits=m +no_defs",
-            dstSRS="+proj=longlat +datum=WGS84 +geoidgrids=./tmp/grid2.gtx +vunits=m +no_defs",
-        )
-        src_ds = None  # drop the ref to src_ds before for fun
-        data = struct.unpack("B" * 1, ds.GetRasterBand(1).ReadRaster())[0]
-        assert data == 115, "Bad value"
 
-        src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
-        src_ds.SetGeoTransform([500000, 1, 0, 4000000, 0, -1])
-        src_ds.GetRasterBand(1).Fill(100)
+@pytest.mark.require_proj(6, 3)
+@pytest.mark.require_driver("GTX")
+def test_gdalwarp_lib_135g(
+    gdalwarp_135_src_ds, gdalwarp_135_grid_gtx, gdalwarp_135_grid2_gtx
+):
+    # Both transforms to anonymous VRT
+    ds = gdal.Warp(
+        "",
+        gdalwarp_135_src_ds,
+        format="VRT",
+        srcSRS=f"+proj=utm +zone=31 +datum=WGS84 +units=m +geoidgrids={gdalwarp_135_grid_gtx} +vunits=m +no_defs",
+        dstSRS=f"+proj=longlat +datum=WGS84 +geoidgrids={gdalwarp_135_grid2_gtx} +vunits=m +no_defs",
+    )
+    gdalwarp_135_src_ds = None  # drop the ref to src_ds before for fun
+    data = struct.unpack("B" * 1, ds.GetRasterBand(1).ReadRaster())[0]
+    assert data == 115, "Bad value"
 
-        # Target CRS in us-ft
-        ds = gdal.Warp(
-            "",
-            src_ds,
-            format="VRT",
-            outputType=gdal.GDT_Float32,
-            srcSRS="+proj=utm +zone=31 +datum=WGS84 +units=m +geoidgrids=./tmp/grid.gtx +vunits=m +no_defs",
-            dstSRS="+proj=longlat +datum=WGS84 +geoidgrids=./tmp/grid2.gtx +vunits=us-ft +no_defs",
-        )
-        data = struct.unpack("f" * 1, ds.GetRasterBand(1).ReadRaster())[0]
-        assert data == pytest.approx(115 / (1200.0 / 3937)), "Bad value"
 
-        # Both transforms to regular VRT
-        gdal.GetDriverByName("GTiff").CreateCopy("tmp/dem.tif", src_ds)
-        gdal.Warp(
-            "tmp/tmp.vrt",
-            "tmp/dem.tif",
-            format="VRT",
-            srcSRS="+proj=utm +zone=31 +datum=WGS84 +units=m +geoidgrids=./tmp/grid.gtx +vunits=m +no_defs",
-            dstSRS="+proj=longlat +datum=WGS84 +geoidgrids=./tmp/grid2.gtx +vunits=m +no_defs",
-        )
-        ds = gdal.Open("tmp/tmp.vrt")
-        data = struct.unpack("B" * 1, ds.GetRasterBand(1).ReadRaster())[0]
-        ds = None
-        gdal.Unlink("tmp/dem.tif")
-        gdal.Unlink("tmp/tmp.vrt")
-        assert data == 115, "Bad value"
+@pytest.mark.require_proj(6, 3)
+@pytest.mark.require_driver("GTX")
+def test_gdalwarp_lib_135h(gdalwarp_135_grid_gtx, gdalwarp_135_grid2_gtx):
+    src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    src_ds.SetGeoTransform([500000, 1, 0, 4000000, 0, -1])
+    src_ds.GetRasterBand(1).Fill(100)
 
-    # Missing grid in forward path, but this is OK
+    # Target CRS in us-ft
     ds = gdal.Warp(
         "",
         src_ds,
+        format="VRT",
+        outputType=gdal.GDT_Float32,
+        srcSRS=f"+proj=utm +zone=31 +datum=WGS84 +units=m +geoidgrids={gdalwarp_135_grid_gtx} +vunits=m +no_defs",
+        dstSRS=f"+proj=longlat +datum=WGS84 +geoidgrids={gdalwarp_135_grid2_gtx} +vunits=us-ft +no_defs",
+    )
+    data = struct.unpack("f" * 1, ds.GetRasterBand(1).ReadRaster())[0]
+    assert data == pytest.approx(115 / (1200.0 / 3937)), "Bad value"
+
+
+@pytest.mark.require_proj(6, 3)
+@pytest.mark.require_driver("GTX")
+def test_gdalwarp_lib_135i(
+    gdalwarp_135_src_ds, gdalwarp_135_grid_gtx, gdalwarp_135_grid2_gtx, tmp_path
+):
+    # Both transforms to regular VRT
+    gdal.GetDriverByName("GTiff").CreateCopy(f"{tmp_path}/dem.tif", gdalwarp_135_src_ds)
+    gdal.Warp(
+        f"{tmp_path}/tmp.vrt",
+        f"{tmp_path}/dem.tif",
+        format="VRT",
+        srcSRS=f"+proj=utm +zone=31 +datum=WGS84 +units=m +geoidgrids={gdalwarp_135_grid_gtx} +vunits=m +no_defs",
+        dstSRS=f"+proj=longlat +datum=WGS84 +geoidgrids={gdalwarp_135_grid2_gtx} +vunits=m +no_defs",
+    )
+    ds = gdal.Open(f"{tmp_path}/tmp.vrt")
+    data = struct.unpack("B" * 1, ds.GetRasterBand(1).ReadRaster())[0]
+    ds = None
+    assert data == 115, "Bad value"
+
+
+def test_gdalwarp_lib_135j(gdalwarp_135_src_ds):
+    # Missing grid in forward path, but this is OK
+    ds = gdal.Warp(
+        "",
+        gdalwarp_135_src_ds,
         format="MEM",
         srcSRS="+proj=utm +zone=31 +datum=WGS84 +units=m +geoidgrids=@i_dont_exist.tif +vunits=m +no_defs",
         dstSRS="EPSG:4979",
@@ -1895,10 +1958,12 @@ def test_gdalwarp_lib_135():
     data = struct.unpack("B" * 1, ds.GetRasterBand(1).ReadRaster())[0]
     assert data == 100, "Bad value"
 
+
+def test_gdalwarp_lib_135k(gdalwarp_135_src_ds):
     # Missing grid in inverse path but this is OK
     ds = gdal.Warp(
         "",
-        src_ds,
+        gdalwarp_135_src_ds,
         format="MEM",
         srcSRS="+proj=utm +zone=31 +datum=WGS84 +units=m +no_defs",
         dstSRS="+proj=longlat +datum=WGS84 +geoidgrids=@i_dont_exist.tif +vunits=m +no_defs",
@@ -1906,12 +1971,15 @@ def test_gdalwarp_lib_135():
     data = struct.unpack("B" * 1, ds.GetRasterBand(1).ReadRaster())[0]
     assert data == 100, "Bad value"
 
+
+@pytest.mark.require_driver("GTX")
+def test_gdalwarp_lib_135m(gdalwarp_135_grid_gtx):
     # Forward transform with explicit m unit
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
     src_ds.SetGeoTransform([500000, 1, 0, 4000000, 0, -1])
     sr = osr.SpatialReference()
     sr.ImportFromProj4(
-        "+proj=utm +zone=31 +datum=WGS84 +units=m +geoidgrids=./tmp/grid.gtx +vunits=m +no_defs"
+        f"+proj=utm +zone=31 +datum=WGS84 +units=m +geoidgrids={gdalwarp_135_grid_gtx} +vunits=m +no_defs"
     )
     src_ds.SetProjection(sr.ExportToWkt())
     src_ds.GetRasterBand(1).Fill(100)
@@ -1921,12 +1989,15 @@ def test_gdalwarp_lib_135():
     data = struct.unpack("B" * 1, ds.GetRasterBand(1).ReadRaster())[0]
     assert data == 120, "Bad value"
 
+
+@pytest.mark.require_driver("GTX")
+def test_gdalwarp_lib_135n(gdalwarp_135_grid_gtx):
     # Forward transform with explicit ft unit
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1, 1, gdal.GDT_Float32)
     src_ds.SetGeoTransform([500000, 1, 0, 4000000, 0, -1])
     sr = osr.SpatialReference()
     sr.ImportFromProj4(
-        "+proj=utm +zone=31 +datum=WGS84 +units=m +geoidgrids=./tmp/grid.gtx +vunits=m +no_defs"
+        f"+proj=utm +zone=31 +datum=WGS84 +units=m +geoidgrids={gdalwarp_135_grid_gtx} +vunits=m +no_defs"
     )
     src_ds.SetProjection(sr.ExportToWkt())
     src_ds.GetRasterBand(1).Fill(100 / 0.3048)
@@ -1938,12 +2009,15 @@ def test_gdalwarp_lib_135():
     data = struct.unpack("B" * 1, ds.GetRasterBand(1).ReadRaster())[0]
     assert data == 120, "Bad value"
 
+
+@pytest.mark.require_driver("GTX")
+def test_gdalwarp_lib_135o(gdalwarp_135_grid_gtx):
     # Forward transform with explicit US survey foot unit
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1, 1, gdal.GDT_Float32)
     src_ds.SetGeoTransform([500000, 1, 0, 4000000, 0, -1])
     sr = osr.SpatialReference()
     sr.ImportFromProj4(
-        "+proj=utm +zone=31 +datum=WGS84 +units=m +geoidgrids=./tmp/grid.gtx +vunits=m +no_defs"
+        f"+proj=utm +zone=31 +datum=WGS84 +units=m +geoidgrids={gdalwarp_135_grid_gtx} +vunits=m +no_defs"
     )
     src_ds.SetProjection(sr.ExportToWkt())
     src_ds.GetRasterBand(1).Fill(100 / 0.3048006096012192)
@@ -1955,12 +2029,15 @@ def test_gdalwarp_lib_135():
     data = struct.unpack("B" * 1, ds.GetRasterBand(1).ReadRaster())[0]
     assert data == 120, "Bad value"
 
+
+@pytest.mark.require_driver("GTX")
+def test_gdalwarp_lib_135p(gdalwarp_135_grid_gtx):
     # Forward transform with explicit unhandled unit
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
     src_ds.SetGeoTransform([500000, 1, 0, 4000000, 0, -1])
     sr = osr.SpatialReference()
     sr.ImportFromProj4(
-        "+proj=utm +zone=31 +datum=WGS84 +units=m +geoidgrids=./tmp/grid.gtx +vunits=m +no_defs"
+        f"+proj=utm +zone=31 +datum=WGS84 +units=m +geoidgrids={gdalwarp_135_grid_gtx} +vunits=m +no_defs"
     )
     src_ds.SetProjection(sr.ExportToWkt())
     src_ds.GetRasterBand(1).Fill(100)
@@ -1971,6 +2048,8 @@ def test_gdalwarp_lib_135():
     data = struct.unpack("B" * 1, ds.GetRasterBand(1).ReadRaster())[0]
     assert data == 120, "Bad value"
 
+
+def test_gdalwarp_lib_135q():
     # Transform to same CRS (implicit)
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
     src_ds.SetGeoTransform([500000, 1, 0, 4000000, 0, -1])
@@ -1983,6 +2062,8 @@ def test_gdalwarp_lib_135():
     data = struct.unpack("B" * 1, ds.GetRasterBand(1).ReadRaster())[0]
     assert data == 100, "Bad value"
 
+
+def test_gdalwarp_lib_135r():
     # Transform to same CRS (explicit)
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
     src_ds.SetGeoTransform([500000, 1, 0, 4000000, 0, -1])
@@ -1995,8 +2076,13 @@ def test_gdalwarp_lib_135():
     data = struct.unpack("B" * 1, ds.GetRasterBand(1).ReadRaster())[0]
     assert data == 100, "Bad value"
 
+
+@pytest.mark.require_driver("GTX")
+def test_gdalwarp_lib_135s(tmp_path):
+    empty_grid_gtx = str(tmp_path / "empty_grid.gtx")
+
     grid_ds = gdal.GetDriverByName("GTX").Create(
-        "tmp/empty_grid.gtx", 3, 3, 1, gdal.GDT_Float32
+        empty_grid_gtx, 3, 3, 1, gdal.GDT_Float32
     )
     sr = osr.SpatialReference()
     sr.SetFromUserInput("WGS84")
@@ -2016,34 +2102,23 @@ def test_gdalwarp_lib_135():
                 "",
                 src_ds,
                 format="MEM",
-                srcSRS="+proj=utm +zone=31 +datum=WGS84 +units=m +geoidgrids=./tmp/empty_grid.gtx +vunits=m +no_defs",
+                srcSRS="+proj=utm +zone=31 +datum=WGS84 +units=m +geoidgrids={empty_grid_gtx} +vunits=m +no_defs",
                 dstSRS="EPSG:4979",
             )
-
-    gdal.GetDriverByName("GTiff").Delete("tmp/grid.gtx")
-    gdal.GetDriverByName("GTiff").Delete("tmp/grid2.gtx")
-    gdal.GetDriverByName("GTiff").Delete("tmp/empty_grid.gtx")
 
 
 ###############################################################################
 # Test error code path linked with failed warper initialization
 
 
-def test_gdalwarp_lib_136():
+@pytest.mark.parametrize("fmt", ("MEM", "VRT"))
+def test_gdalwarp_lib_136(fmt):
 
     with pytest.raises(Exception):
         gdal.Warp(
             "",
             "../gcore/data/utmsmall.tif",
-            format="MEM",
-            warpOptions=["CUTLINE=invalid"],
-        )
-
-    with pytest.raises(Exception):
-        gdal.Warp(
-            "",
-            "../gcore/data/utmsmall.tif",
-            format="VRT",
+            format=fmt,
             warpOptions=["CUTLINE=invalid"],
         )
 
@@ -2089,32 +2164,29 @@ def test_gdalwarp_lib_touching_dateline():
 # Test fix for https://trac.osgeo.org/gdal/ticket/7245
 
 
-def test_gdalwarp_lib_override_default_output_nodata():
+@pytest.mark.require_driver("netCDF")
+@pytest.mark.parametrize("frmt", ("NC", "NC2", "NC4"))
+def test_gdalwarp_lib_override_default_output_nodata(frmt, tmp_path):
 
     drv = gdal.GetDriverByName("netCDF")
-    if drv is None:
-        pytest.skip()
-
     creationoptionlist = drv.GetMetadataItem("DMD_CREATIONOPTIONLIST")
-    formats = ["NC"]
-    if "<Value>NC2</Value>" in creationoptionlist:
-        formats += ["NC2"]
-    if "<Value>NC4</Value>" in creationoptionlist:
-        formats += ["NC4", "NC4C"]
 
-    for frmt in formats:
-        gdal.Warp(
-            "tmp/out.nc",
-            "../gcore/data/byte.tif",
-            srcNodata=255,
-            format="netCDF",
-            creationOptions=["FORMAT=" + frmt],
-        )
-        ds = gdal.Open("tmp/out.nc")
-        assert ds.GetRasterBand(1).GetNoDataValue() == 255, frmt
-        assert ds.GetProjection() != "", frmt
-        ds = None
-        os.unlink("tmp/out.nc")
+    if f"<Value>{frmt}</Value>" not in creationoptionlist:
+        pytest.skip(f"netCDF format {frmt} not available")
+
+    result_nc = str(tmp_path / "out.nc")
+
+    gdal.Warp(
+        result_nc,
+        "../gcore/data/byte.tif",
+        srcNodata=255,
+        format="netCDF",
+        creationOptions=["FORMAT=" + frmt],
+    )
+    ds = gdal.Open(result_nc)
+    assert ds.GetRasterBand(1).GetNoDataValue() == 255, frmt
+    assert ds.GetProjection() != "", frmt
+    ds = None
 
 
 ###############################################################################
@@ -2238,10 +2310,12 @@ def test_gdalwarp_lib_auto_skip_nosource():
 # (https://github.com/OSGeo/gdal/issues/862)
 
 
-def test_gdalwarp_lib_to_ortho():
+def test_gdalwarp_lib_to_ortho(tmp_path):
+
+    result_tif = str(tmp_path / "out.tif")
 
     out_ds = gdal.Warp(
-        "/tmp/out.tif",
+        result_tif,
         "../gdrivers/data/small_world.tif",
         options='-of MEM -t_srs "+proj=ortho +datum=WGS84" -ts 1024 1024',
     )
@@ -3035,29 +3109,27 @@ def test_gdalwarp_lib_generate_ovr():
 # overwritten (https://github.com/OSGeo/gdal/issues/5633)
 
 
-def test_gdalwarp_lib_not_delete_shared_auxiliary_files():
+def test_gdalwarp_lib_not_delete_shared_auxiliary_files(tmp_path):
+
+    img_foo_r1c1_jp2 = str(tmp_path / "IMG_foo_R1C1.JP2")
+    img_foo_r1c1_tif = str(tmp_path / "IMG_foo_R1C1.tif")
+    dim_foo_xml = str(tmp_path / "DIM_foo.XML")
 
     # Yes, we do intend to copy a .TIF as a fake .JP2
-    shutil.copy(
-        "../gdrivers/data/dimap2/bundle/IMG_foo_R1C1.TIF", "tmp/IMG_foo_R1C1.JP2"
-    )
-    shutil.copy("../gdrivers/data/dimap2/bundle/DIM_foo.XML", "tmp/DIM_foo.XML")
+    shutil.copy("../gdrivers/data/dimap2/bundle/IMG_foo_R1C1.TIF", img_foo_r1c1_jp2)
+    shutil.copy("../gdrivers/data/dimap2/bundle/DIM_foo.XML", dim_foo_xml)
 
-    gdal.Warp("tmp/IMG_foo_R1C1.tif", "tmp/IMG_foo_R1C1.JP2")
+    gdal.Warp(img_foo_r1c1_tif, img_foo_r1c1_jp2)
 
-    ds = gdal.Open("tmp/IMG_foo_R1C1.tif")
+    ds = gdal.Open(img_foo_r1c1_tif)
     assert len(ds.GetFileList()) == 2
     ds = None
 
-    gdal.Warp("tmp/IMG_foo_R1C1.tif", "tmp/IMG_foo_R1C1.JP2", format="GTiff")
+    gdal.Warp(img_foo_r1c1_tif, img_foo_r1c1_jp2, format="GTiff")
 
-    ds = gdal.Open("tmp/IMG_foo_R1C1.tif")
+    ds = gdal.Open(img_foo_r1c1_tif)
     assert len(ds.GetFileList()) == 2
     ds = None
-
-    os.unlink("tmp/IMG_foo_R1C1.JP2")
-    os.unlink("tmp/IMG_foo_R1C1.tif")
-    os.unlink("tmp/DIM_foo.XML")
 
 
 ###############################################################################

--- a/autotest/utilities/test_gnmutils.py
+++ b/autotest/utilities/test_gnmutils.py
@@ -60,23 +60,25 @@ def gnmanalyse_path():
     return test_cli_utilities.get_gnmanalyse_path()
 
 
+@pytest.fixture(scope="module")
+def test_gnm_dir(tmp_path_factory):
+    return tmp_path_factory.mktemp("test_gnmutiles") / "test_gnm"
+
+
 ###############################################################################
 # Test create
 # gnmmanage create -f GNMFile -t_srs EPSG:4326 -dsco net_name=test_gnm -dsco net_description="Test file based GNM" /home/bishop/tmp/ --config CPL_DEBUG ON
 
 
-def test_gnmmanage_1(gnmmanage_path):
+def test_gnmmanage_1(gnmmanage_path, test_gnm_dir):
 
     (_, err) = gdaltest.runexternal_out_and_err(
         gnmmanage_path
-        + ' create -f GNMFile -t_srs EPSG:4326 -dsco net_name=test_gnm -dsco net_description="Test file based GNM" tmp'
+        + f' create -f GNMFile -t_srs EPSG:4326 -dsco net_name=test_gnm -dsco net_description="Test file based GNM" {test_gnm_dir.parent}'
     )
     assert err is None or err == "", "got error/warning"
 
-    try:
-        os.stat("tmp/test_gnm")
-    except OSError:
-        pytest.fail("Expected create tmp/test_gnm")
+    assert os.path.exists(test_gnm_dir)
 
 
 ###############################################################################
@@ -85,15 +87,15 @@ def test_gnmmanage_1(gnmmanage_path):
 # gnmmanage import /home/bishop/tmp/data/wells.shp /home/bishop/tmp/test_gnm --config CPL_DEBUG ON
 
 
-def test_gnmmanage_2(gnmmanage_path):
+def test_gnmmanage_2(gnmmanage_path, test_gnm_dir):
 
     (_, err) = gdaltest.runexternal_out_and_err(
-        gnmmanage_path + " import ../gnm/data/pipes.shp tmp/test_gnm"
+        f"{gnmmanage_path} import ../gnm/data/pipes.shp {test_gnm_dir}"
     )
     assert err is None or err == "", "got error/warning"
 
     (_, err) = gdaltest.runexternal_out_and_err(
-        gnmmanage_path + " import ../gnm/data/wells.shp tmp/test_gnm"
+        f"{gnmmanage_path} import ../gnm/data/wells.shp {test_gnm_dir}"
     )
     assert err is None or err == "", "got error/warning"
 
@@ -103,9 +105,9 @@ def test_gnmmanage_2(gnmmanage_path):
 # gnmmanage info /home/bishop/tmp/test_gnm
 
 
-def test_gnmmanage_3(gnmmanage_path):
+def test_gnmmanage_3(gnmmanage_path, test_gnm_dir):
 
-    ret = gdaltest.runexternal(gnmmanage_path + " info tmp/test_gnm")
+    ret = gdaltest.runexternal(f"{gnmmanage_path} info {test_gnm_dir}")
 
     assert ret.find("Network version: 1.0.") != -1
     assert ret.find("Network name: test_gnm.") != -1
@@ -117,9 +119,9 @@ def test_gnmmanage_3(gnmmanage_path):
 # gnmmanage autoconnect 0.000001 /home/bishop/tmp/test_gnm --config CPL_DEBUG ON
 
 
-def test_gnmmanage_4(gnmmanage_path):
+def test_gnmmanage_4(gnmmanage_path, test_gnm_dir):
 
-    ret = gdaltest.runexternal(gnmmanage_path + " autoconnect 0.000001 tmp/test_gnm")
+    ret = gdaltest.runexternal(f"{gnmmanage_path} autoconnect 0.000001 {test_gnm_dir}")
     assert ret.find("success") != -1
 
 
@@ -128,9 +130,9 @@ def test_gnmmanage_4(gnmmanage_path):
 # gnmanalyse dijkstra 61 50 -alo "fetch_vertex=OFF" -ds /home/bishop/tmp/di.shp -lco "SHPT=ARC" /home/bishop/tmp/test_gnm --config CPL_DEBUG ON
 
 
-def test_gnmanalyse_1(gnmanalyse_path):
+def test_gnmanalyse_1(gnmanalyse_path, test_gnm_dir):
 
-    ret = gdaltest.runexternal(gnmanalyse_path + " dijkstra 61 50 tmp/test_gnm")
+    ret = gdaltest.runexternal(f"{gnmanalyse_path} dijkstra 61 50 {test_gnm_dir}")
     assert ret.find("Feature Count: 19") != -1
 
 
@@ -139,9 +141,9 @@ def test_gnmanalyse_1(gnmanalyse_path):
 # gnmanalyse kpaths 61 50 3 -alo "fetch_vertex=OFF" -ds /home/bishop/tmp/kp.shp -lco "SHPT=ARC" /home/bishop/tmp/test_gnm --config CPL_DEBUG ON
 
 
-def test_gnmanalyse_2(gnmanalyse_path):
+def test_gnmanalyse_2(gnmanalyse_path, test_gnm_dir):
 
-    ret = gdaltest.runexternal(gnmanalyse_path + " kpaths 61 50 3 tmp/test_gnm")
+    ret = gdaltest.runexternal(f"{gnmanalyse_path} kpaths 61 50 3 {test_gnm_dir}")
     assert ret.find("Feature Count: 61") != -1
 
 
@@ -149,9 +151,11 @@ def test_gnmanalyse_2(gnmanalyse_path):
 # Test cleanup
 
 
-def test_gnm_cleanup(gnmmanage_path):
+def test_gnm_cleanup(gnmmanage_path, test_gnm_dir):
 
-    (_, err) = gdaltest.runexternal_out_and_err(gnmmanage_path + " delete tmp/test_gnm")
+    (_, err) = gdaltest.runexternal_out_and_err(
+        f"{gnmmanage_path} delete {test_gnm_dir}"
+    )
     assert err is None or err == "", "got error/warning"
 
-    assert not os.path.exists("tmp/test_gnm")
+    assert not os.path.exists(test_gnm_dir)

--- a/autotest/utilities/test_nearblack.py
+++ b/autotest/utilities/test_nearblack.py
@@ -29,7 +29,6 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
-import os
 import shutil
 
 import gdaltest
@@ -52,16 +51,17 @@ def nearblack_path():
 # Basic test
 
 
-def test_nearblack_1(nearblack_path):
+def test_nearblack_1(nearblack_path, tmp_path):
+
+    output_tif = str(tmp_path / "nearblack1.tif")
 
     (_, err) = gdaltest.runexternal_out_and_err(
-        nearblack_path
-        + " ../gdrivers/data/rgbsmall.tif -nb 0 -of GTiff -o tmp/nearblack1.tif"
+        f"{nearblack_path} ../gdrivers/data/rgbsmall.tif -nb 0 -of GTiff -o {output_tif}"
     )
     assert err is None or err == "", "got error/warning"
 
     src_ds = gdal.Open("../gdrivers/data/rgbsmall.tif")
-    ds = gdal.Open("tmp/nearblack1.tif")
+    ds = gdal.Open(output_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 21106, "Bad checksum band 1"
@@ -86,14 +86,16 @@ def test_nearblack_1(nearblack_path):
 # Add alpha band
 
 
-def test_nearblack_2(nearblack_path):
+def test_nearblack_2(nearblack_path, tmp_path):
+
+    output_tif = str(tmp_path / "nearblack2.tif")
+    output2_tif = str(tmp_path / "nearblack3.tif")
 
     gdaltest.runexternal(
-        nearblack_path
-        + " ../gdrivers/data/rgbsmall.tif -setalpha -nb 0 -of GTiff -o tmp/nearblack2.tif -co TILED=YES"
+        f"{nearblack_path} ../gdrivers/data/rgbsmall.tif -setalpha -nb 0 -of GTiff -o {output_tif} -co TILED=YES"
     )
 
-    ds = gdal.Open("tmp/nearblack2.tif")
+    ds = gdal.Open(output_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(4).Checksum() == 22002, "Bad checksum band 0"
@@ -102,12 +104,10 @@ def test_nearblack_2(nearblack_path):
 
     # Set existing alpha band
 
-    shutil.copy("tmp/nearblack2.tif", "tmp/nearblack3.tif")
-    gdaltest.runexternal(
-        nearblack_path + " -setalpha -nb 0 -of GTiff tmp/nearblack3.tif"
-    )
+    shutil.copy(output_tif, output2_tif)
+    gdaltest.runexternal(f"{nearblack_path} -setalpha -nb 0 -of GTiff {output2_tif}")
 
-    ds = gdal.Open("tmp/nearblack3.tif")
+    ds = gdal.Open(output2_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(4).Checksum() == 22002, "Bad checksum band 0"
@@ -119,20 +119,23 @@ def test_nearblack_2(nearblack_path):
 # Test -white
 
 
-def test_nearblack_4(nearblack_path):
+def test_nearblack_4(nearblack_path, tmp_path):
     if test_cli_utilities.get_gdalwarp_path() is None:
         pytest.skip()
 
+    src_tif = str(tmp_path / "nearblack4_src.tif")
+    output_tif = str(tmp_path / "nearblack4.tif")
+
     gdaltest.runexternal(
         test_cli_utilities.get_gdalwarp_path()
-        + ' -wo "INIT_DEST=255" ../gdrivers/data/rgbsmall.tif  tmp/nearblack4_src.tif -srcnodata 0'
+        + f' -wo "INIT_DEST=255" ../gdrivers/data/rgbsmall.tif  {src_tif} -srcnodata 0'
     )
     gdaltest.runexternal(
         nearblack_path
-        + " -q -setalpha -white -nb 0 -of GTiff tmp/nearblack4_src.tif -o tmp/nearblack4.tif"
+        + f" -q -setalpha -white -nb 0 -of GTiff {src_tif} -o {output_tif}"
     )
 
-    ds = gdal.Open("tmp/nearblack4.tif")
+    ds = gdal.Open(output_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(4).Checksum() == 24151, "Bad checksum band 0"
@@ -144,14 +147,16 @@ def test_nearblack_4(nearblack_path):
 # Add mask band
 
 
-def test_nearblack_5(nearblack_path):
+def test_nearblack_5(nearblack_path, tmp_path):
+
+    output_tif = str(tmp_path / "nearblack5.tif")
+    output2_tif = str(tmp_path / "nearblack6.tif")
 
     gdaltest.runexternal(
-        nearblack_path
-        + " ../gdrivers/data/rgbsmall.tif --config GDAL_TIFF_INTERNAL_MASK NO -setmask -nb 0 -of GTiff -o tmp/nearblack5.tif -co TILED=YES"
+        f"{nearblack_path} ../gdrivers/data/rgbsmall.tif --config GDAL_TIFF_INTERNAL_MASK NO -setmask -nb 0 -of GTiff -o {output_tif} -co TILED=YES"
     )
 
-    ds = gdal.Open("tmp/nearblack5.tif")
+    ds = gdal.Open(output_tif)
     assert ds is not None
 
     assert (
@@ -162,14 +167,12 @@ def test_nearblack_5(nearblack_path):
 
     # Set existing mask band
 
-    shutil.copy("tmp/nearblack5.tif", "tmp/nearblack6.tif")
-    shutil.copy("tmp/nearblack5.tif.msk", "tmp/nearblack6.tif.msk")
+    shutil.copy(output_tif, output2_tif)
+    shutil.copy(output_tif + ".msk", output2_tif + ".msk")
 
-    gdaltest.runexternal(
-        nearblack_path + " -setmask -nb 0 -of GTiff tmp/nearblack6.tif"
-    )
+    gdaltest.runexternal(f"{nearblack_path} -setmask -nb 0 -of GTiff {output2_tif}")
 
-    ds = gdal.Open("tmp/nearblack6.tif")
+    ds = gdal.Open(output2_tif)
     assert ds is not None
 
     assert (
@@ -183,14 +186,15 @@ def test_nearblack_5(nearblack_path):
 # Test -color
 
 
-def test_nearblack_7(nearblack_path):
+def test_nearblack_7(nearblack_path, tmp_path):
+
+    output_tif = str(tmp_path / "nearblack7.tif")
 
     gdaltest.runexternal(
-        nearblack_path
-        + " data/whiteblackred.tif -o tmp/nearblack7.tif -color 0,0,0 -color 255,255,255 -of GTiff"
+        f"{nearblack_path} data/whiteblackred.tif -o {output_tif} -color 0,0,0 -color 255,255,255 -of GTiff"
     )
 
-    ds = gdal.Open("tmp/nearblack7.tif")
+    ds = gdal.Open(output_tif)
     assert ds is not None
 
     assert (
@@ -206,18 +210,18 @@ def test_nearblack_7(nearblack_path):
 # Test in-place update
 
 
-def test_nearblack_8(nearblack_path):
+def test_nearblack_8(nearblack_path, tmp_path):
+
+    output_tif = str(tmp_path / "nearblack8.tif")
 
     src_ds = gdal.Open("../gdrivers/data/rgbsmall.tif")
-    gdal.GetDriverByName("GTiff").CreateCopy("tmp/nearblack8.tif", src_ds)
+    gdal.GetDriverByName("GTiff").CreateCopy(output_tif, src_ds)
     src_ds = None
 
-    (_, err) = gdaltest.runexternal_out_and_err(
-        nearblack_path + " tmp/nearblack8.tif -nb 0"
-    )
+    (_, err) = gdaltest.runexternal_out_and_err(f"{nearblack_path} {output_tif} -nb 0")
     assert err is None or err == "", "got error/warning"
 
-    ds = gdal.Open("tmp/nearblack8.tif")
+    ds = gdal.Open(output_tif)
     assert ds is not None
 
     assert ds.GetRasterBand(1).Checksum() == 21106, "Bad checksum band 1"
@@ -225,54 +229,3 @@ def test_nearblack_8(nearblack_path):
     assert ds.GetRasterBand(2).Checksum() == 20736, "Bad checksum band 2"
 
     assert ds.GetRasterBand(3).Checksum() == 21309, "Bad checksum band 3"
-
-
-###############################################################################
-# Cleanup
-
-
-def test_nearblack_cleanup():
-    try:
-        os.remove("tmp/nearblack1.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/nearblack2.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/nearblack3.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/nearblack4_src.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/nearblack4.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/nearblack5.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/nearblack5.tif.msk")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/nearblack6.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/nearblack6.tif.msk")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/nearblack7.tif")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/nearblack8.tif")
-    except OSError:
-        pass

--- a/autotest/utilities/test_ogr2ogr.py
+++ b/autotest/utilities/test_ogr2ogr.py
@@ -54,20 +54,16 @@ def ogr2ogr_path():
 # Simple test
 
 
-def test_ogr2ogr_1(ogr2ogr_path):
+def test_ogr2ogr_1(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/poly.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
-    except (OSError, AttributeError):
-        pass
+    output_shp = str(tmp_path / "poly.shp")
 
     (_, err) = gdaltest.runexternal_out_and_err(
-        ogr2ogr_path + " tmp/poly.shp ../ogr/data/poly.shp"
+        ogr2ogr_path + f" {output_shp} ../ogr/data/poly.shp"
     )
     assert err is None or err == "", "got error/warning"
 
-    ds = ogr.Open("tmp/poly.shp")
+    ds = ogr.Open(output_shp)
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 10
 
     feat0 = ds.GetLayer(0).GetFeature(0)
@@ -78,107 +74,78 @@ def test_ogr2ogr_1(ogr2ogr_path):
         feat0.GetFieldAsString("PRFEDEA") == "35043411"
     ), "Did not get expected value for field PRFEDEA"
 
-    ds.Destroy()
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
-
 
 ###############################################################################
 # Test -sql
 
 
-def test_ogr2ogr_2(ogr2ogr_path):
+def test_ogr2ogr_2(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/poly.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
-    except (OSError, AttributeError):
-        pass
+    output_shp = str(tmp_path / "poly.shp")
 
     gdaltest.runexternal(
-        ogr2ogr_path + ' tmp/poly.shp ../ogr/data/poly.shp -sql "select * from poly"'
+        ogr2ogr_path + f' {output_shp} ../ogr/data/poly.shp -sql "select * from poly"'
     )
 
-    ds = ogr.Open("tmp/poly.shp")
+    ds = ogr.Open(output_shp)
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 10
-    ds.Destroy()
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
 
 
 ###############################################################################
 # Test -spat
 
 
-def test_ogr2ogr_3(ogr2ogr_path):
+def test_ogr2ogr_3(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/poly.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
-    except (OSError, AttributeError):
-        pass
+    output_shp = str(tmp_path / "poly.shp")
 
     gdaltest.runexternal(
         ogr2ogr_path
-        + " tmp/poly.shp ../ogr/data/poly.shp -spat 479609 4764629 479764 4764817"
+        + f" {output_shp} ../ogr/data/poly.shp -spat 479609 4764629 479764 4764817"
     )
 
-    ds = ogr.Open("tmp/poly.shp")
+    ds = ogr.Open(output_shp)
     if ogrtest.have_geos():
         assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 4
     else:
         assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 5
-    ds.Destroy()
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
 
 
 ###############################################################################
 # Test -where
 
 
-def test_ogr2ogr_4(ogr2ogr_path):
+def test_ogr2ogr_4(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/poly.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
-    except (OSError, AttributeError):
-        pass
+    output_shp = str(tmp_path / "poly.shp")
 
     gdaltest.runexternal(
-        ogr2ogr_path + ' tmp/poly.shp ../ogr/data/poly.shp -where "EAS_ID=171"'
+        ogr2ogr_path + f' {output_shp} ../ogr/data/poly.shp -where "EAS_ID=171"'
     )
 
-    ds = ogr.Open("tmp/poly.shp")
+    ds = ogr.Open(output_shp)
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 1
-    ds.Destroy()
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
 
 
 ###############################################################################
 # Test -append
 
 
-def test_ogr2ogr_5(ogr2ogr_path):
+def test_ogr2ogr_5(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/poly.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
-    except (OSError, AttributeError):
-        pass
+    output_shp = str(tmp_path / "poly.shp")
 
-    gdaltest.runexternal(ogr2ogr_path + " tmp/poly.shp ../ogr/data/poly.shp")
+    gdaltest.runexternal(ogr2ogr_path + f" {output_shp} ../ogr/data/poly.shp")
     # All 3 variants below should be equivalent
     gdaltest.runexternal(
-        ogr2ogr_path + " -update -append tmp/poly.shp ../ogr/data/poly.shp"
+        ogr2ogr_path + f" -update -append {output_shp} ../ogr/data/poly.shp"
     )
-    gdaltest.runexternal(ogr2ogr_path + " -append tmp/poly.shp ../ogr/data/poly.shp")
+    gdaltest.runexternal(ogr2ogr_path + f" -append {output_shp} ../ogr/data/poly.shp")
     gdaltest.runexternal(
-        ogr2ogr_path + " -append -update tmp/poly.shp ../ogr/data/poly.shp"
+        ogr2ogr_path + f" -append -update {output_shp} ../ogr/data/poly.shp"
     )
 
-    ds = ogr.Open("tmp/poly.shp")
+    ds = ogr.Open(output_shp)
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 40
 
     feat10 = ds.GetLayer(0).GetFeature(10)
@@ -188,10 +155,6 @@ def test_ogr2ogr_5(ogr2ogr_path):
     assert (
         feat10.GetFieldAsString("PRFEDEA") == "35043411"
     ), "Did not get expected value for field PRFEDEA"
-
-    ds.Destroy()
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
 
 
 def check_if_has_ogr_pg():
@@ -292,66 +255,48 @@ def test_ogr2ogr_7(ogr2ogr_path):
 # Test -t_srs
 
 
-def test_ogr2ogr_8(ogr2ogr_path):
+def test_ogr2ogr_8(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/poly.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
-    except (OSError, AttributeError):
-        pass
+    output_shp = str(tmp_path / "poly.shp")
 
     gdaltest.runexternal(
-        ogr2ogr_path + " -t_srs EPSG:4326 tmp/poly.shp ../ogr/data/poly.shp"
+        ogr2ogr_path + f" -t_srs EPSG:4326 {output_shp} ../ogr/data/poly.shp"
     )
 
-    ds = ogr.Open("tmp/poly.shp")
+    ds = ogr.Open(output_shp)
     assert str(ds.GetLayer(0).GetSpatialRef()).find("1984") != -1
-    ds.Destroy()
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
 
 
 ###############################################################################
 # Test -a_srs
 
 
-def test_ogr2ogr_9(ogr2ogr_path):
+def test_ogr2ogr_9(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/poly.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
-    except (OSError, AttributeError):
-        pass
+    output_shp = str(tmp_path / "poly.shp")
 
     gdaltest.runexternal(
-        ogr2ogr_path + " -a_srs EPSG:4326 tmp/poly.shp ../ogr/data/poly.shp"
+        ogr2ogr_path + f" -a_srs EPSG:4326 {output_shp} ../ogr/data/poly.shp"
     )
 
-    ds = ogr.Open("tmp/poly.shp")
+    ds = ogr.Open(output_shp)
     assert str(ds.GetLayer(0).GetSpatialRef()).find("1984") != -1
-    ds.Destroy()
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
 
 
 ###############################################################################
 # Test -select
 
 
-def test_ogr2ogr_10(ogr2ogr_path):
+def test_ogr2ogr_10(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/poly.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
-    except (OSError, AttributeError):
-        pass
+    output_shp = str(tmp_path / "poly.shp")
 
     # Voluntary don't use the exact case of the source field names (#4502)
     gdaltest.runexternal(
-        ogr2ogr_path + " -select eas_id,prfedea tmp/poly.shp ../ogr/data/poly.shp"
+        ogr2ogr_path + f" -select eas_id,prfedea {output_shp} ../ogr/data/poly.shp"
     )
 
-    ds = ogr.Open("tmp/poly.shp")
+    ds = ogr.Open(output_shp)
     lyr = ds.GetLayer(0)
     assert lyr.GetLayerDefn().GetFieldCount() == 2
     feat = lyr.GetNextFeature()
@@ -360,179 +305,127 @@ def test_ogr2ogr_10(ogr2ogr_path):
     feat = None
     ds = None
 
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
-
 
 ###############################################################################
 # Test -lco
 
 
-def test_ogr2ogr_11(ogr2ogr_path):
+def test_ogr2ogr_11(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/poly.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
-    except (OSError, AttributeError):
-        pass
+    output_shp = str(tmp_path / "poly.shp")
 
     gdaltest.runexternal(
-        ogr2ogr_path + " -lco SHPT=POLYGONZ tmp/poly.shp ../ogr/data/poly.shp"
+        ogr2ogr_path + f" -lco SHPT=POLYGONZ {output_shp} ../ogr/data/poly.shp"
     )
 
-    ds = ogr.Open("tmp/poly.shp")
+    ds = ogr.Open(output_shp)
     assert ds.GetLayer(0).GetLayerDefn().GetGeomType() == ogr.wkbPolygon25D
-    ds.Destroy()
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
 
 
 ###############################################################################
 # Test -nlt
 
 
-def test_ogr2ogr_12(ogr2ogr_path):
+def test_ogr2ogr_12(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/poly.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
-    except (OSError, AttributeError):
-        pass
+    output_shp = str(tmp_path / "poly.shp")
 
     gdaltest.runexternal(
-        ogr2ogr_path + " -nlt POLYGON25D tmp/poly.shp ../ogr/data/poly.shp"
+        ogr2ogr_path + f" -nlt POLYGON25D {output_shp} ../ogr/data/poly.shp"
     )
 
-    ds = ogr.Open("tmp/poly.shp")
+    ds = ogr.Open(output_shp)
     assert ds.GetLayer(0).GetLayerDefn().GetGeomType() == ogr.wkbPolygon25D
-    ds.Destroy()
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
 
 
 ###############################################################################
 # Add explicit source layer name
 
 
-def test_ogr2ogr_13(ogr2ogr_path):
+def test_ogr2ogr_13(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/poly.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
-    except (OSError, AttributeError):
-        pass
+    output_shp = str(tmp_path / "poly.shp")
 
-    gdaltest.runexternal(ogr2ogr_path + " tmp/poly.shp ../ogr/data/poly.shp poly")
+    gdaltest.runexternal(ogr2ogr_path + f" {output_shp} ../ogr/data/poly.shp poly")
 
-    ds = ogr.Open("tmp/poly.shp")
+    ds = ogr.Open(output_shp)
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 10
-    ds.Destroy()
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
 
 
 ###############################################################################
 # Test -segmentize
 
 
-def test_ogr2ogr_14(ogr2ogr_path):
+def test_ogr2ogr_14(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/poly.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
-    except (OSError, AttributeError):
-        pass
+    output_shp = str(tmp_path / "poly.shp")
 
     gdaltest.runexternal(
-        ogr2ogr_path + " -segmentize 100 tmp/poly.shp ../ogr/data/poly.shp poly"
+        ogr2ogr_path + f" -segmentize 100 {output_shp} ../ogr/data/poly.shp poly"
     )
 
-    ds = ogr.Open("tmp/poly.shp")
+    ds = ogr.Open(output_shp)
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 10
     feat = ds.GetLayer(0).GetNextFeature()
     assert feat.GetGeometryRef().GetGeometryRef(0).GetPointCount() == 36
-    ds.Destroy()
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
 
 
 ###############################################################################
 # Test -overwrite with a shapefile
 
 
-def test_ogr2ogr_15(ogr2ogr_path):
+def test_ogr2ogr_15(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/poly.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
-    except (OSError, AttributeError):
-        pass
+    output_shp = str(tmp_path / "poly.shp")
 
-    gdaltest.runexternal(ogr2ogr_path + " tmp/poly.shp ../ogr/data/poly.shp")
+    gdaltest.runexternal(ogr2ogr_path + f" {output_shp} ../ogr/data/poly.shp")
 
-    ds = ogr.Open("tmp/poly.shp")
+    ds = ogr.Open(output_shp)
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 10
-    ds.Destroy()
+    ds = None
 
     # Overwrite
-    gdaltest.runexternal(ogr2ogr_path + " -overwrite tmp ../ogr/data/poly.shp")
+    gdaltest.runexternal(ogr2ogr_path + f" -overwrite {tmp_path} ../ogr/data/poly.shp")
 
-    ds = ogr.Open("tmp/poly.shp")
+    ds = ogr.Open(output_shp)
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 10
-    ds.Destroy()
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
 
 
 ###############################################################################
 # Test -fid
 
 
-def test_ogr2ogr_16(ogr2ogr_path):
+def test_ogr2ogr_16(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/poly.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
-    except (OSError, AttributeError):
-        pass
+    output_shp = str(tmp_path / "poly.shp")
 
-    gdaltest.runexternal(ogr2ogr_path + " -fid 8 tmp/poly.shp ../ogr/data/poly.shp")
+    gdaltest.runexternal(ogr2ogr_path + f" -fid 8 {output_shp} ../ogr/data/poly.shp")
 
     src_ds = ogr.Open("../ogr/data/poly.shp")
-    ds = ogr.Open("tmp/poly.shp")
+    ds = ogr.Open(output_shp)
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 1
     src_feat = src_ds.GetLayer(0).GetFeature(8)
     feat = ds.GetLayer(0).GetNextFeature()
     assert feat.GetField("EAS_ID") == src_feat.GetField("EAS_ID")
-    ds.Destroy()
-    src_ds.Destroy()
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
 
 
 ###############################################################################
 # Test -progress
 
 
-def test_ogr2ogr_17(ogr2ogr_path):
+def test_ogr2ogr_17(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/poly.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
-    except (OSError, AttributeError):
-        pass
+    output_shp = str(tmp_path / "poly.shp")
 
     ret = gdaltest.runexternal(
-        ogr2ogr_path + " -progress tmp/poly.shp ../ogr/data/poly.shp"
+        ogr2ogr_path + f" -progress {output_shp} ../ogr/data/poly.shp"
     )
     assert (
         ret.find("0...10...20...30...40...50...60...70...80...90...100 - done.") != -1
     )
 
-    ds = ogr.Open("tmp/poly.shp")
+    ds = ogr.Open(output_shp)
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 10
-    ds.Destroy()
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
 
 
 ###############################################################################
@@ -540,49 +433,31 @@ def test_ogr2ogr_17(ogr2ogr_path):
 
 
 @pytest.mark.require_geos
-def test_ogr2ogr_18(ogr2ogr_path):
+def test_ogr2ogr_18(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/wrapdateline_src.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-            "tmp/wrapdateline_src.shp"
+    src_shp = str(tmp_path / "wrapdateline_src.shp")
+    dst_shp = str(tmp_path / "wrapdateline_dst.shp")
+
+    with ogr.GetDriverByName("ESRI Shapefile").CreateDataSource(src_shp) as ds:
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(32660)
+        lyr = ds.CreateLayer("wrapdateline_src", srs=srs)
+        feat = ogr.Feature(lyr.GetLayerDefn())
+        geom = ogr.CreateGeometryFromWkt(
+            "POLYGON((700000 4000000,800000 4000000,800000 3000000,700000 3000000,700000 4000000))"
         )
-    except (OSError, AttributeError):
-        pass
-
-    try:
-        os.stat("tmp/wrapdateline_dst.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-            "tmp/wrapdateline_dst.shp"
-        )
-    except (OSError, AttributeError):
-        pass
-
-    ds = ogr.GetDriverByName("ESRI Shapefile").CreateDataSource(
-        "tmp/wrapdateline_src.shp"
-    )
-    srs = osr.SpatialReference()
-    srs.ImportFromEPSG(32660)
-    lyr = ds.CreateLayer("wrapdateline_src", srs=srs)
-    feat = ogr.Feature(lyr.GetLayerDefn())
-    geom = ogr.CreateGeometryFromWkt(
-        "POLYGON((700000 4000000,800000 4000000,800000 3000000,700000 3000000,700000 4000000))"
-    )
-    feat.SetGeometryDirectly(geom)
-    lyr.CreateFeature(feat)
-    feat.Destroy()
-    ds.Destroy()
+        feat.SetGeometryDirectly(geom)
+        lyr.CreateFeature(feat)
 
     gdaltest.runexternal(
-        ogr2ogr_path
-        + " -wrapdateline -t_srs EPSG:4326 tmp/wrapdateline_dst.shp tmp/wrapdateline_src.shp"
+        ogr2ogr_path + f" -wrapdateline -t_srs EPSG:4326 {dst_shp} {src_shp}"
     )
 
     expected_wkt = "MULTIPOLYGON (((179.222391385437 36.124095832137,180.0 36.1071354434926,180.0 36.107135443432,180.0 27.0904291237556,179.017505655194 27.1079795236266,179.222391385437 36.124095832137)),((-180 36.1071354434425,-179.667822828784 36.0983491954849,-179.974688335432 27.0898861430914,-180 27.0904291237129,-180 27.090429123727,-180 36.107135443432,-180 36.1071354434425)))"
     expected_wkt2 = "MULTIPOLYGON (((179.017505655194 27.1079795236266,179.222391385437 36.124095832137,180.0 36.1071354434926,180.0 36.107135443432,180.0 27.0904291237556,179.017505655194 27.1079795236266)),((-180 27.090429123727,-180 36.107135443432,-180 36.1071354434425,-179.667822828784 36.0983491954849,-179.974688335432 27.0898861430914,-180 27.0904291237129,-180 27.090429123727)))"  # with geos OverlayNG
     expected_wkt3 = "MULTIPOLYGON (((180.0 36.1071354434926,180.0 36.107135443432,180.0 27.0904291237556,179.017505655194 27.1079795236266,179.222391385437 36.124095832137,180.0 36.1071354434926)),((-179.667822828784 36.0983491954849,-179.974688335432 27.0898861430914,-180 27.0904291237129,-180 27.090429123727,-180 36.107135443432,-180 36.1071354434425,-179.667822828784 36.0983491954849)))"
 
-    ds = ogr.Open("tmp/wrapdateline_dst.shp")
+    ds = ogr.Open(dst_shp)
     lyr = ds.GetLayer(0)
     feat = lyr.GetNextFeature()
 
@@ -594,12 +469,6 @@ def test_ogr2ogr_18(ogr2ogr_path):
         except AssertionError:
             ogrtest.check_feature_geometry(feat, expected_wkt3)
 
-    feat.Destroy()
-    ds.Destroy()
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/wrapdateline_src.shp")
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/wrapdateline_dst.shp")
-
 
 ###############################################################################
 # Test automatic polygon splitting, and also antimeridian being intersected
@@ -607,54 +476,30 @@ def test_ogr2ogr_18(ogr2ogr_path):
 
 
 @pytest.mark.require_geos
-def test_ogr2ogr_polygon_splitting(ogr2ogr_path):
+def test_ogr2ogr_polygon_splitting(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/wrapdateline_src.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-            "tmp/wrapdateline_src.shp"
+    src_shp = str(tmp_path / "wrapdateline_src.shp")
+    dst_shp = str(tmp_path / "wrapdateline_dst.shp")
+
+    with ogr.GetDriverByName("ESRI Shapefile").CreateDataSource(src_shp) as ds:
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(32601)
+        lyr = ds.CreateLayer("wrapdateline_src", srs=srs)
+        feat = ogr.Feature(lyr.GetLayerDefn())
+        geom = ogr.CreateGeometryFromWkt(
+            "POLYGON((377120 7577600,418080 7577600,418080 7618560,377120 7618560,377120 7577600))"
         )
-    except (OSError, AttributeError):
-        pass
+        feat.SetGeometryDirectly(geom)
+        lyr.CreateFeature(feat)
 
-    try:
-        os.stat("tmp/wrapdateline_dst.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-            "tmp/wrapdateline_dst.shp"
-        )
-    except (OSError, AttributeError):
-        pass
+    gdaltest.runexternal(f"{ogr2ogr_path} -t_srs EPSG:4326 {dst_shp} {src_shp}")
 
-    ds = ogr.GetDriverByName("ESRI Shapefile").CreateDataSource(
-        "tmp/wrapdateline_src.shp"
-    )
-    srs = osr.SpatialReference()
-    srs.ImportFromEPSG(32601)
-    lyr = ds.CreateLayer("wrapdateline_src", srs=srs)
-    feat = ogr.Feature(lyr.GetLayerDefn())
-    geom = ogr.CreateGeometryFromWkt(
-        "POLYGON((377120 7577600,418080 7577600,418080 7618560,377120 7618560,377120 7577600))"
-    )
-    feat.SetGeometryDirectly(geom)
-    lyr.CreateFeature(feat)
-    feat.Destroy()
-    ds.Destroy()
-
-    gdaltest.runexternal(
-        ogr2ogr_path
-        + " -t_srs EPSG:4326 tmp/wrapdateline_dst.shp tmp/wrapdateline_src.shp"
-    )
-
-    ds = ogr.Open("tmp/wrapdateline_dst.shp")
+    ds = ogr.Open(dst_shp)
     lyr = ds.GetLayer(0)
     feat = lyr.GetNextFeature()
     geom = feat.GetGeometryRef()
     assert geom.GetGeometryType() == ogr.wkbMultiPolygon
     assert geom.GetGeometryCount() == 2
-    ds = None
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/wrapdateline_src.shp")
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/wrapdateline_dst.shp")
 
 
 ###############################################################################
@@ -662,20 +507,15 @@ def test_ogr2ogr_polygon_splitting(ogr2ogr_path):
 
 
 @pytest.mark.require_geos
-def test_ogr2ogr_19(ogr2ogr_path):
+def test_ogr2ogr_19(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/poly.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
-    except (OSError, AttributeError):
-        pass
+    output_shp = str(tmp_path / "poly.shp")
 
     gdaltest.runexternal(
-        ogr2ogr_path
-        + " tmp/poly.shp ../ogr/data/poly.shp -clipsrc spat_extent -spat 479609 4764629 479764 4764817"
+        f"{ogr2ogr_path} {output_shp} ../ogr/data/poly.shp -clipsrc spat_extent -spat 479609 4764629 479764 4764817"
     )
 
-    ds = ogr.Open("tmp/poly.shp")
+    ds = ogr.Open(output_shp)
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 4
 
     assert ds.GetLayer(0).GetExtent() == (
@@ -685,10 +525,6 @@ def test_ogr2ogr_19(ogr2ogr_path):
         4764817,
     ), "unexpected extent"
 
-    ds.Destroy()
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
-
 
 ###############################################################################
 # Test correct remap of fields when laundering to Shapefile format
@@ -697,7 +533,7 @@ def test_ogr2ogr_19(ogr2ogr_path):
 
 
 @pytest.mark.require_driver("CSV")
-def test_ogr2ogr_20(ogr2ogr_path):
+def test_ogr2ogr_20(ogr2ogr_path, tmp_path):
 
     expected_fields = [
         "a",
@@ -734,44 +570,18 @@ def test_ogr2ogr_20(ogr2ogr_path):
         "15",
     ]
 
-    gdaltest.runexternal(ogr2ogr_path + " tmp data/Fields.csv")
+    gdaltest.runexternal(ogr2ogr_path + f" {tmp_path} data/Fields.csv")
 
-    ds = ogr.Open("tmp/Fields.dbf")
+    ds = ogr.Open(f"{tmp_path}/Fields.dbf")
 
     assert ds is not None
     layer_defn = ds.GetLayer(0).GetLayerDefn()
-    if layer_defn.GetFieldCount() != 15:
-        ds.Destroy()
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/Fields.dbf")
-        pytest.fail(
-            "Unexpected field count: "
-            + str(ds.GetLayer(0).GetLayerDefn().GetFieldCount())
-        )
+    assert layer_defn.GetFieldCount() == 15, "Unexpected field count"
 
-    error_occurred = False
     feat = ds.GetLayer(0).GetNextFeature()
     for i in range(layer_defn.GetFieldCount()):
-        if layer_defn.GetFieldDefn(i).GetNameRef() != expected_fields[i]:
-            print(
-                "Expected ",
-                expected_fields[i],
-                ",but got",
-                layer_defn.GetFieldDefn(i).GetNameRef(),
-            )
-            error_occurred = True
-        if feat.GetFieldAsString(i) != expected_data[i]:
-            print(
-                "Expected the value ",
-                expected_data[i],
-                ",but got",
-                feat.GetFieldAsString(i),
-            )
-            error_occurred = True
-
-    ds.Destroy()
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/Fields.dbf")
-
-    assert not error_occurred
+        assert layer_defn.GetFieldDefn(i).GetNameRef() == expected_fields[i]
+        assert feat.GetFieldAsString(i) == expected_data[i]
 
 
 ###############################################################################
@@ -781,20 +591,16 @@ def test_ogr2ogr_20(ogr2ogr_path):
 
 @pytest.mark.require_driver("GPX")
 @pytest.mark.require_driver("CSV")
-def test_ogr2ogr_21(ogr2ogr_path):
+def test_ogr2ogr_21(ogr2ogr_path, tmp_path):
 
-    try:
-        os.remove("tmp/testogr2ogr21.gpx")
-    except OSError:
-        pass
+    output_gpx = str(tmp_path / "testogr2ogr21.gpx")
 
     gdaltest.runexternal(
         ogr2ogr_path
-        + " -f GPX tmp/testogr2ogr21.gpx data/dataforogr2ogr21.csv "
+        + f" -f GPX {output_gpx} data/dataforogr2ogr21.csv "
         + '-sql "SELECT name AS route_name, 0 as route_fid FROM dataforogr2ogr21" -nlt POINT -nln route_points'
     )
-    assert "<name>NAME</name>" in open("tmp/testogr2ogr21.gpx", "rt").read()
-    os.remove("tmp/testogr2ogr21.gpx")
+    assert "<name>NAME</name>" in open(output_gpx, "rt").read()
 
 
 ###############################################################################
@@ -803,30 +609,23 @@ def test_ogr2ogr_21(ogr2ogr_path):
 
 @pytest.mark.require_driver("MapInfo File")
 @pytest.mark.require_driver("CSV")
-def test_ogr2ogr_22(ogr2ogr_path):
+def test_ogr2ogr_22(ogr2ogr_path, tmp_path):
+
+    output_mif = str(tmp_path / "testogr2ogr22.mif")
 
     gdaltest.runexternal(
         ogr2ogr_path
-        + ' -f "MapInfo File" tmp/testogr2ogr22.mif data/dataforogr2ogr21.csv '
+        + f' -f "MapInfo File" {output_mif} data/dataforogr2ogr21.csv '
         + '-sql "SELECT comment, name FROM dataforogr2ogr21" -nlt POINT'
     )
-    ds = ogr.Open("tmp/testogr2ogr22.mif")
+    ds = ogr.Open(output_mif)
 
     assert ds is not None
     ds.GetLayer(0).GetLayerDefn()
     lyr = ds.GetLayer(0)
     feat = lyr.GetNextFeature()
-    if (
-        feat.GetFieldAsString("name") != "NAME"
-        or feat.GetFieldAsString("comment") != "COMMENT"
-    ):
-        print(feat.GetFieldAsString("comment"))
-        ds.Destroy()
-        ogr.GetDriverByName("MapInfo File").DeleteDataSource("tmp/testogr2ogr22.mif")
-        pytest.fail(feat.GetFieldAsString("name"))
-
-    ds.Destroy()
-    ogr.GetDriverByName("MapInfo File").DeleteDataSource("tmp/testogr2ogr22.mif")
+    assert feat.GetFieldAsString("name") == "NAME"
+    assert feat.GetFieldAsString("comment") == "COMMENT"
 
 
 ###############################################################################
@@ -835,30 +634,23 @@ def test_ogr2ogr_22(ogr2ogr_path):
 
 @pytest.mark.require_driver("MapInfo File")
 @pytest.mark.require_driver("CSV")
-def test_ogr2ogr_23(ogr2ogr_path):
+def test_ogr2ogr_23(ogr2ogr_path, tmp_path):
+
+    output_mif = str(tmp_path / "testogr2ogr23.mif")
 
     gdaltest.runexternal(
         ogr2ogr_path
-        + ' -f "MapInfo File" tmp/testogr2ogr23.mif data/dataforogr2ogr21.csv '
+        + f' -f "MapInfo File" {output_mif} data/dataforogr2ogr21.csv '
         + '-sql "SELECT comment, name FROM dataforogr2ogr21" -select comment,name -nlt POINT'
     )
-    ds = ogr.Open("tmp/testogr2ogr23.mif")
+    ds = ogr.Open(output_mif)
 
     assert ds is not None
     ds.GetLayer(0).GetLayerDefn()
     lyr = ds.GetLayer(0)
     feat = lyr.GetNextFeature()
-    if (
-        feat.GetFieldAsString("name") != "NAME"
-        or feat.GetFieldAsString("comment") != "COMMENT"
-    ):
-        print(feat.GetFieldAsString("comment"))
-        ds.Destroy()
-        ogr.GetDriverByName("MapInfo File").DeleteDataSource("tmp/testogr2ogr23.mif")
-        pytest.fail(feat.GetFieldAsString("name"))
-
-    ds.Destroy()
-    ogr.GetDriverByName("MapInfo File").DeleteDataSource("tmp/testogr2ogr23.mif")
+    assert feat.GetFieldAsString("name") == "NAME"
+    assert feat.GetFieldAsString("comment") == "COMMENT"
 
 
 ###############################################################################
@@ -866,20 +658,16 @@ def test_ogr2ogr_23(ogr2ogr_path):
 
 
 @pytest.mark.require_geos
-def test_ogr2ogr_24(ogr2ogr_path):
+def test_ogr2ogr_24(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/poly.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
-    except (OSError, AttributeError):
-        pass
+    output_shp = str(tmp_path / "poly.shp")
 
     gdaltest.runexternal(
         ogr2ogr_path
-        + ' tmp/poly.shp ../ogr/data/poly.shp -clipsrc "POLYGON((479609 4764629,479609 4764817,479764 4764817,479764 4764629,479609 4764629))"'
+        + f' {output_shp} ../ogr/data/poly.shp -clipsrc "POLYGON((479609 4764629,479609 4764817,479764 4764817,479764 4764629,479609 4764629))"'
     )
 
-    ds = ogr.Open("tmp/poly.shp")
+    ds = ogr.Open(output_shp)
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 4
 
     assert ds.GetLayer(0).GetExtent() == (
@@ -888,10 +676,6 @@ def test_ogr2ogr_24(ogr2ogr_path):
         4764629,
         4764817,
     ), "unexpected extent"
-
-    ds.Destroy()
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
 
 
 ###############################################################################
@@ -900,15 +684,12 @@ def test_ogr2ogr_24(ogr2ogr_path):
 
 @pytest.mark.require_driver("CSV")
 @pytest.mark.require_geos
-def test_ogr2ogr_25(ogr2ogr_path):
+def test_ogr2ogr_25(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/poly.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
-    except (OSError, AttributeError):
-        pass
+    output_shp = str(tmp_path / "poly.shp")
+    clip_csv = str(tmp_path / "clip.csv")
 
-    f = open("tmp/clip.csv", "wt")
+    f = open(clip_csv, "wt")
     f.write("foo,WKT\n")
     f.write(
         'foo,"POLYGON((479609 4764629,479609 4764817,479764 4764817,479764 4764629,479609 4764629))"\n'
@@ -916,11 +697,10 @@ def test_ogr2ogr_25(ogr2ogr_path):
     f.close()
 
     gdaltest.runexternal(
-        ogr2ogr_path
-        + " tmp/poly.shp ../ogr/data/poly.shp -clipsrc tmp/clip.csv -clipsrcwhere foo='foo'"
+        f"{ogr2ogr_path} {output_shp} ../ogr/data/poly.shp -clipsrc {clip_csv} -clipsrcwhere foo='foo'"
     )
 
-    ds = ogr.Open("tmp/poly.shp")
+    ds = ogr.Open(output_shp)
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 4
 
     assert ds.GetLayer(0).GetExtent() == (
@@ -929,11 +709,6 @@ def test_ogr2ogr_25(ogr2ogr_path):
         4764629,
         4764817,
     ), "unexpected extent"
-
-    ds.Destroy()
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
-    os.remove("tmp/clip.csv")
 
 
 ###############################################################################
@@ -941,20 +716,15 @@ def test_ogr2ogr_25(ogr2ogr_path):
 
 
 @pytest.mark.require_geos
-def test_ogr2ogr_26(ogr2ogr_path):
+def test_ogr2ogr_26(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/poly.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
-    except (OSError, AttributeError):
-        pass
+    output_shp = str(tmp_path / "poly.shp")
 
     gdaltest.runexternal(
-        ogr2ogr_path
-        + ' tmp/poly.shp ../ogr/data/poly.shp -clipdst "POLYGON((479609 4764629,479609 4764817,479764 4764817,479764 4764629,479609 4764629))"'
+        f'{ogr2ogr_path} {output_shp} ../ogr/data/poly.shp -clipdst "POLYGON((479609 4764629,479609 4764817,479764 4764817,479764 4764629,479609 4764629))"'
     )
 
-    ds = ogr.Open("tmp/poly.shp")
+    ds = ogr.Open(output_shp)
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 4
 
     assert ds.GetLayer(0).GetExtent() == (
@@ -963,10 +733,6 @@ def test_ogr2ogr_26(ogr2ogr_path):
         4764629,
         4764817,
     ), "unexpected extent"
-
-    ds.Destroy()
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
 
 
 ###############################################################################
@@ -975,15 +741,12 @@ def test_ogr2ogr_26(ogr2ogr_path):
 
 @pytest.mark.require_driver("CSV")
 @pytest.mark.require_geos
-def test_ogr2ogr_27(ogr2ogr_path):
+def test_ogr2ogr_27(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/poly.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
-    except (OSError, AttributeError):
-        pass
+    output_shp = str(tmp_path / "poly.shp")
+    clip_csv = str(tmp_path / "clip.csv")
 
-    f = open("tmp/clip.csv", "wt")
+    f = open(clip_csv, "wt")
     f.write("foo,WKT\n")
     f.write(
         'foo,"POLYGON((479609 4764629,479609 4764817,479764 4764817,479764 4764629,479609 4764629))"\n'
@@ -991,11 +754,10 @@ def test_ogr2ogr_27(ogr2ogr_path):
     f.close()
 
     gdaltest.runexternal(
-        ogr2ogr_path
-        + ' -nlt MULTIPOLYGON tmp/poly.shp ../ogr/data/poly.shp -clipdst tmp/clip.csv -clipdstsql "SELECT * from clip"'
+        f'{ogr2ogr_path} -nlt MULTIPOLYGON {output_shp} ../ogr/data/poly.shp -clipdst {clip_csv} -clipdstsql "SELECT * from clip"'
     )
 
-    ds = ogr.Open("tmp/poly.shp")
+    ds = ogr.Open(output_shp)
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 4
 
     assert ds.GetLayer(0).GetExtent() == (
@@ -1005,73 +767,36 @@ def test_ogr2ogr_27(ogr2ogr_path):
         4764817,
     ), "unexpected extent"
 
-    ds.Destroy()
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
-    os.remove("tmp/clip.csv")
-
 
 ###############################################################################
 # Test -wrapdateline on linestrings
 
 
-def test_ogr2ogr_28(ogr2ogr_path):
+def test_ogr2ogr_28(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/wrapdateline_src.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-            "tmp/wrapdateline_src.shp"
+    src_shp = str(tmp_path / "wrapdateline_src.shp")
+    dst_shp = str(tmp_path / "wrapdateline_dst.shp")
+
+    with ogr.GetDriverByName("ESRI Shapefile").CreateDataSource(src_shp) as ds:
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(4326)
+        lyr = ds.CreateLayer("wrapdateline_src", srs=srs)
+        feat = ogr.Feature(lyr.GetLayerDefn())
+        geom = ogr.CreateGeometryFromWkt(
+            "LINESTRING(160 0,165 1,170 2,175 3,177 4,-177 5,-175 6,-170 7,-177 8,177 9,170 10)"
         )
-    except (OSError, AttributeError):
-        pass
+        feat.SetGeometryDirectly(geom)
+        lyr.CreateFeature(feat)
 
-    try:
-        os.stat("tmp/wrapdateline_dst.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-            "tmp/wrapdateline_dst.shp"
-        )
-    except (OSError, AttributeError):
-        pass
-
-    ds = ogr.GetDriverByName("ESRI Shapefile").CreateDataSource(
-        "tmp/wrapdateline_src.shp"
-    )
-    srs = osr.SpatialReference()
-    srs.ImportFromEPSG(4326)
-    lyr = ds.CreateLayer("wrapdateline_src", srs=srs)
-    feat = ogr.Feature(lyr.GetLayerDefn())
-    geom = ogr.CreateGeometryFromWkt(
-        "LINESTRING(160 0,165 1,170 2,175 3,177 4,-177 5,-175 6,-170 7,-177 8,177 9,170 10)"
-    )
-    feat.SetGeometryDirectly(geom)
-    lyr.CreateFeature(feat)
-    feat.Destroy()
-    ds.Destroy()
-
-    gdaltest.runexternal(
-        ogr2ogr_path
-        + " -wrapdateline tmp/wrapdateline_dst.shp tmp/wrapdateline_src.shp"
-    )
+    gdaltest.runexternal(f"{ogr2ogr_path} -wrapdateline {dst_shp} {src_shp}")
 
     expected_wkt = "MULTILINESTRING ((160 0,165 1,170 2,175 3,177 4,180 4.5),(-180 4.5,-177 5,-175 6,-170 7,-177 8,-180 8.5),(180 8.5,177 9,170 10))"
     expected_geom = ogr.CreateGeometryFromWkt(expected_wkt)
-    ds = ogr.Open("tmp/wrapdateline_dst.shp")
+    ds = ogr.Open(dst_shp)
     lyr = ds.GetLayer(0)
     feat = lyr.GetNextFeature()
 
-    try:
-        ogrtest.check_feature_geometry(feat, expected_geom)
-    finally:
-        feat.Destroy()
-        expected_geom.Destroy()
-        ds.Destroy()
-
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-            "tmp/wrapdateline_src.shp"
-        )
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-            "tmp/wrapdateline_dst.shp"
-        )
+    ogrtest.check_feature_geometry(feat, expected_geom)
 
 
 ###############################################################################
@@ -1079,28 +804,13 @@ def test_ogr2ogr_28(ogr2ogr_path):
 
 
 @pytest.mark.require_geos
-def test_ogr2ogr_29(ogr2ogr_path):
+@pytest.mark.parametrize("i", (0, 1))
+def test_ogr2ogr_29(ogr2ogr_path, tmp_path, i):
 
-    for i in range(2):
-        try:
-            os.stat("tmp/wrapdateline_src.shp")
-            ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-                "tmp/wrapdateline_src.shp"
-            )
-        except (OSError, AttributeError):
-            pass
+    src_shp = str(tmp_path / "wrapdateline_src.shp")
+    dst_shp = str(tmp_path / "wrapdateline_dst.shp")
 
-        try:
-            os.stat("tmp/wrapdateline_dst.shp")
-            ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-                "tmp/wrapdateline_dst.shp"
-            )
-        except (OSError, AttributeError):
-            pass
-
-        ds = ogr.GetDriverByName("ESRI Shapefile").CreateDataSource(
-            "tmp/wrapdateline_src.shp"
-        )
+    with ogr.GetDriverByName("ESRI Shapefile").CreateDataSource(src_shp) as ds:
         srs = osr.SpatialReference()
         srs.ImportFromEPSG(4326)
         lyr = ds.CreateLayer("wrapdateline_src", srs=srs)
@@ -1116,54 +826,33 @@ def test_ogr2ogr_29(ogr2ogr_path):
             )
         feat.SetGeometry(geom)
         lyr.CreateFeature(feat)
-        feat.Destroy()
-        ds.Destroy()
 
-        gdaltest.runexternal(
-            ogr2ogr_path
-            + " -wrapdateline tmp/wrapdateline_dst.shp tmp/wrapdateline_src.shp"
-        )
+    gdaltest.runexternal(f"{ogr2ogr_path} -wrapdateline {dst_shp} {src_shp}")
 
-        expected_wkt = "MULTIPOLYGON (((180 30,179.5 30.0,179 30,179 40,179.5 40.0,180 40,180 30)),((-180 40,-179.5 40.0,-179 40,-170 40,-165 40,-165 30,-170 30,-179 30,-179.5 30.0,-180 30,-180 40)))"
-        expected_geom = ogr.CreateGeometryFromWkt(expected_wkt)
-        ds = ogr.Open("tmp/wrapdateline_dst.shp")
-        lyr = ds.GetLayer(0)
-        feat = lyr.GetNextFeature()
+    expected_wkt = "MULTIPOLYGON (((180 30,179.5 30.0,179 30,179 40,179.5 40.0,180 40,180 30)),((-180 40,-179.5 40.0,-179 40,-170 40,-165 40,-165 30,-170 30,-179 30,-179.5 30.0,-180 30,-180 40)))"
+    expected_geom = ogr.CreateGeometryFromWkt(expected_wkt)
+    ds = ogr.Open(dst_shp)
+    lyr = ds.GetLayer(0)
+    feat = lyr.GetNextFeature()
 
-        try:
-            ogrtest.check_feature_geometry(feat, expected_geom)
-        finally:
-            feat.Destroy()
-            expected_geom.Destroy()
-            ds.Destroy()
-
-            ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-                "tmp/wrapdateline_src.shp"
-            )
-            ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-                "tmp/wrapdateline_dst.shp"
-            )
+    ogrtest.check_feature_geometry(feat, expected_geom)
 
 
 ###############################################################################
 # Test -splitlistfields option
 
 
-def test_ogr2ogr_30(ogr2ogr_path):
+@pytest.mark.require_driver("GML")
+def test_ogr2ogr_30(ogr2ogr_path, tmp_path):
 
-    with gdaltest.disable_exceptions():
-        ds = ogr.Open("../ogr/data/gml/testlistfields.gml")
-    if ds is None:
-        pytest.skip("GML reader not available")
-    ds = None
+    src_gml = str(tmp_path / "testlistfields.gml")
+    dst_dbf = str(tmp_path / "test_ogr2ogr_30.dbf")
 
-    gdaltest.runexternal(
-        ogr2ogr_path
-        + " -splitlistfields tmp/test_ogr2ogr_30.dbf ../ogr/data/gml/testlistfields.gml"
-    )
-    gdal.Unlink("../ogr/data/gml/testlistfields.gfs")
+    shutil.copy("../ogr/data/gml/testlistfields.gml", src_gml)
 
-    ds = ogr.Open("tmp/test_ogr2ogr_30.dbf")
+    gdaltest.runexternal(f"{ogr2ogr_path} -splitlistfields {dst_dbf} {src_gml}")
+
+    ds = ogr.Open(dst_dbf)
     assert ds is not None
     lyr = ds.GetLayer(0)
     feat = lyr.GetNextFeature()
@@ -1181,64 +870,48 @@ def test_ogr2ogr_30(ogr2ogr_path):
         pytest.fail("did not get expected attribs")
 
     ds = None
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/test_ogr2ogr_30.dbf")
 
 
 ###############################################################################
-# Test that -overwrite work if the output file doesn't yet exist (#3825)
+# Test that -overwrite works if the output file doesn't yet exist (#3825)
 
 
-def test_ogr2ogr_31(ogr2ogr_path):
+def test_ogr2ogr_31(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/poly.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
-    except (OSError, AttributeError):
-        pass
+    output_shp = str(tmp_path / "poly.shp")
 
-    gdaltest.runexternal(ogr2ogr_path + " -overwrite tmp/poly.shp ../ogr/data/poly.shp")
+    gdaltest.runexternal(
+        ogr2ogr_path + f" -overwrite {output_shp} ../ogr/data/poly.shp"
+    )
 
-    ds = ogr.Open("tmp/poly.shp")
+    ds = ogr.Open(output_shp)
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 10
-    ds.Destroy()
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
 
 
 ###############################################################################
 # Test that -append/-overwrite to a single-file shapefile work without specifying -nln
 
 
-def test_ogr2ogr_32(ogr2ogr_path):
+def test_ogr2ogr_32(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/test_ogr2ogr_32.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-            "tmp/test_ogr2ogr_32.shp"
-        )
-    except (OSError, AttributeError):
-        pass
+    output_shp = str(tmp_path / "test_ogr2ogr_32.shp")
 
-    gdaltest.runexternal(ogr2ogr_path + " tmp/test_ogr2ogr_32.shp ../ogr/data/poly.shp")
-    gdaltest.runexternal(
-        ogr2ogr_path + " -append tmp/test_ogr2ogr_32.shp ../ogr/data/poly.shp"
-    )
+    gdaltest.runexternal(ogr2ogr_path + f" {output_shp} ../ogr/data/poly.shp")
+    gdaltest.runexternal(ogr2ogr_path + f" -append {output_shp} ../ogr/data/poly.shp")
 
-    ds = ogr.Open("tmp/test_ogr2ogr_32.shp")
+    ds = ogr.Open(output_shp)
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 20, "-append failed"
     ds = None
 
     gdaltest.runexternal(
-        ogr2ogr_path + " -overwrite tmp/test_ogr2ogr_32.shp ../ogr/data/poly.shp"
+        ogr2ogr_path + f" -overwrite {output_shp} ../ogr/data/poly.shp"
     )
 
-    ds = ogr.Open("tmp/test_ogr2ogr_32.shp")
+    ds = ogr.Open(output_shp)
     assert (
         ds is not None and ds.GetLayer(0).GetFeatureCount() == 10
     ), "-overwrite failed"
     ds = None
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/test_ogr2ogr_32.shp")
 
 
 ###############################################################################
@@ -1246,23 +919,12 @@ def test_ogr2ogr_32(ogr2ogr_path):
 
 
 @pytest.mark.require_driver("CSV")
-def test_ogr2ogr_33(ogr2ogr_path):
+def test_ogr2ogr_33(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/test_ogr2ogr_33_src.csv")
-        ogr.GetDriverByName("CSV").DeleteDataSource("tmp/test_ogr2ogr_33_src.csv")
-    except (OSError, AttributeError):
-        pass
+    src_csv = str(tmp_path / "test_ogr2ogr_33_src.csv")
+    dst_shp = str(tmp_path / "test_ogr2ogr_33_dst.shp")
 
-    try:
-        os.stat("tmp/test_ogr2ogr_33_dst.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-            "tmp/test_ogr2ogr_33_dst.shp"
-        )
-    except (OSError, AttributeError):
-        pass
-
-    f = open("tmp/test_ogr2ogr_33_src.csv", "wt")
+    f = open(src_csv, "wt")
     f.write("foo,WKT\n")
     f.write(
         'bar,"MULTIPOLYGON (((10 10,10 11,11 11,11 10,10 10)),((100 100,100 200,200 200,200 100,100 100),(125 125,175 125,175 175,125 175,125 125)))"\n'
@@ -1271,50 +933,32 @@ def test_ogr2ogr_33(ogr2ogr_path):
     f.close()
 
     gdaltest.runexternal(
-        ogr2ogr_path
-        + " -explodecollections tmp/test_ogr2ogr_33_dst.shp tmp/test_ogr2ogr_33_src.csv -select foo"
+        ogr2ogr_path + f" -explodecollections {dst_shp} {src_csv} -select foo"
     )
 
-    ds = ogr.Open("tmp/test_ogr2ogr_33_dst.shp")
+    ds = ogr.Open(dst_shp)
     lyr = ds.GetLayer(0)
     assert lyr.GetFeatureCount() == 3, "-explodecollections failed"
 
     feat = lyr.GetFeature(0)
-    if feat.GetField("foo") != "bar":
-        feat.DumpReadable()
-        pytest.fail()
-    if (
+    assert feat.GetField("foo") == "bar"
+    assert (
         feat.GetGeometryRef().ExportToWkt()
-        != "POLYGON ((10 10,10 11,11 11,11 10,10 10))"
-    ):
-        feat.DumpReadable()
-        pytest.fail()
+        == "POLYGON ((10 10,10 11,11 11,11 10,10 10))"
+    )
 
     feat = lyr.GetFeature(1)
-    if feat.GetField("foo") != "bar":
-        feat.DumpReadable()
-        pytest.fail()
-    if (
+    assert feat.GetField("foo") == "bar"
+    assert (
         feat.GetGeometryRef().ExportToWkt()
-        != "POLYGON ((100 100,100 200,200 200,200 100,100 100),(125 125,175 125,175 175,125 175,125 125))"
-    ):
-        feat.DumpReadable()
-        pytest.fail()
+        == "POLYGON ((100 100,100 200,200 200,200 100,100 100),(125 125,175 125,175 175,125 175,125 125))"
+    )
 
     feat = lyr.GetFeature(2)
-    if feat.GetField("foo") != "baz":
-        feat.DumpReadable()
-        pytest.fail()
-    if feat.GetGeometryRef().ExportToWkt() != "POLYGON ((0 0,0 1,1 1,1 0,0 0))":
-        feat.DumpReadable()
-        pytest.fail()
+    assert feat.GetField("foo") == "baz"
+    assert feat.GetGeometryRef().ExportToWkt() == "POLYGON ((0 0,0 1,1 1,1 0,0 0))"
 
     ds = None
-
-    ogr.GetDriverByName("CSV").DeleteDataSource("tmp/test_ogr2ogr_33_src.csv")
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-        "tmp/test_ogr2ogr_33_dst.shp"
-    )
 
 
 ###############################################################################
@@ -1323,22 +967,15 @@ def test_ogr2ogr_33(ogr2ogr_path):
 # someDirThatDoesNotExist.shp/dbf/shx inside this directory
 
 
-def test_ogr2ogr_34(ogr2ogr_path):
+def test_ogr2ogr_34(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/test_ogr2ogr_34_dir")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-            "tmp/test_ogr2ogr_34_dir"
-        )
-    except (OSError, AttributeError):
-        pass
+    output_dir = str(tmp_path / "test_ogr2ogr_34_dir")
 
     gdaltest.runexternal(
-        ogr2ogr_path
-        + " tmp/test_ogr2ogr_34_dir ../ogr/data/poly.shp -nln test_ogr2ogr_34_dir"
+        ogr2ogr_path + f" {output_dir} ../ogr/data/poly.shp -nln test_ogr2ogr_34_dir"
     )
 
-    ds = ogr.Open("tmp/test_ogr2ogr_34_dir/test_ogr2ogr_34_dir.shp")
+    ds = ogr.Open(f"{output_dir}/test_ogr2ogr_34_dir.shp")
     assert (
         ds is not None and ds.GetLayer(0).GetFeatureCount() == 10
     ), "initial shapefile creation failed"
@@ -1346,96 +983,74 @@ def test_ogr2ogr_34(ogr2ogr_path):
 
     gdaltest.runexternal(
         ogr2ogr_path
-        + " -append tmp/test_ogr2ogr_34_dir ../ogr/data/poly.shp -nln test_ogr2ogr_34_dir"
+        + f" -append {output_dir} ../ogr/data/poly.shp -nln test_ogr2ogr_34_dir"
     )
 
-    ds = ogr.Open("tmp/test_ogr2ogr_34_dir/test_ogr2ogr_34_dir.shp")
+    ds = ogr.Open(f"{output_dir}/test_ogr2ogr_34_dir.shp")
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 20, "-append failed"
     ds = None
 
     gdaltest.runexternal(
         ogr2ogr_path
-        + " -overwrite tmp/test_ogr2ogr_34_dir ../ogr/data/poly.shp -nln test_ogr2ogr_34_dir"
+        + f" -overwrite {output_dir} ../ogr/data/poly.shp -nln test_ogr2ogr_34_dir"
     )
 
-    ds = ogr.Open("tmp/test_ogr2ogr_34_dir/test_ogr2ogr_34_dir.shp")
+    ds = ogr.Open(f"{output_dir}/test_ogr2ogr_34_dir.shp")
     assert (
         ds is not None and ds.GetLayer(0).GetFeatureCount() == 10
     ), "-overwrite failed"
     ds = None
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/test_ogr2ogr_34_dir")
 
 
 ###############################################################################
 # Test 'ogr2ogr someDirThatDoesNotExist src.shp'
 
 
-def test_ogr2ogr_35(ogr2ogr_path):
+def test_ogr2ogr_35(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/test_ogr2ogr_35_dir")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-            "tmp/test_ogr2ogr_35_dir"
-        )
-    except (OSError, AttributeError):
-        pass
+    output_dir = str(tmp_path / "test_ogr2ogr_35_dir")
 
-    gdaltest.runexternal(
-        ogr2ogr_path + " tmp/test_ogr2ogr_35_dir ../ogr/data/poly.shp "
-    )
+    gdaltest.runexternal(ogr2ogr_path + f" {output_dir} ../ogr/data/poly.shp ")
 
-    ds = ogr.Open("tmp/test_ogr2ogr_35_dir/poly.shp")
+    ds = ogr.Open(f"{output_dir}/poly.shp")
     assert (
         ds is not None and ds.GetLayer(0).GetFeatureCount() == 10
     ), "initial shapefile creation failed"
     ds = None
 
-    gdaltest.runexternal(
-        ogr2ogr_path + " -append tmp/test_ogr2ogr_35_dir ../ogr/data/poly.shp"
-    )
+    gdaltest.runexternal(ogr2ogr_path + f" -append {output_dir} ../ogr/data/poly.shp")
 
-    ds = ogr.Open("tmp/test_ogr2ogr_35_dir/poly.shp")
+    ds = ogr.Open(f"{output_dir}/poly.shp")
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 20, "-append failed"
     ds = None
 
     gdaltest.runexternal(
-        ogr2ogr_path + " -overwrite tmp/test_ogr2ogr_35_dir ../ogr/data/poly.shp"
+        ogr2ogr_path + f" -overwrite {output_dir} ../ogr/data/poly.shp"
     )
 
-    ds = ogr.Open("tmp/test_ogr2ogr_35_dir/poly.shp")
+    ds = ogr.Open(f"{output_dir}/poly.shp")
     assert (
         ds is not None and ds.GetLayer(0).GetFeatureCount() == 10
     ), "-overwrite failed"
     ds = None
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/test_ogr2ogr_35_dir")
 
 
 ###############################################################################
 # Test ogr2ogr -zfield
 
 
-def test_ogr2ogr_36(ogr2ogr_path):
+def test_ogr2ogr_36(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/test_ogr2ogr_36.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-            "tmp/test_ogr2ogr_36.shp"
-        )
-    except (OSError, AttributeError):
-        pass
+    output_shp = str(tmp_path / "test_ogr2ogr_36.shp")
 
     gdaltest.runexternal(
-        ogr2ogr_path + " tmp/test_ogr2ogr_36.shp ../ogr/data/poly.shp -zfield EAS_ID"
+        ogr2ogr_path + f" {output_shp} ../ogr/data/poly.shp -zfield EAS_ID"
     )
 
-    ds = ogr.Open("tmp/test_ogr2ogr_36.shp")
+    ds = ogr.Open(output_shp)
     feat = ds.GetLayer(0).GetNextFeature()
     wkt = feat.GetGeometryRef().ExportToWkt()
     ds = None
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/test_ogr2ogr_36.shp")
 
     assert wkt.find(" 168,") != -1
 
@@ -1444,39 +1059,24 @@ def test_ogr2ogr_36(ogr2ogr_path):
 # Test 'ogr2ogr someDirThatDoesNotExist.shp dataSourceWithMultipleLayer'
 
 
-def test_ogr2ogr_37(ogr2ogr_path):
+def test_ogr2ogr_37(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/test_ogr2ogr_37_dir.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-            "tmp/test_ogr2ogr_37_dir.shp"
-        )
-    except (OSError, AttributeError):
-        pass
+    src_dir = tmp_path / "test_ogr2ogr_37_src"
+    output_shp = str(tmp_path / "test_ogr2ogr_37_dir.shp")
 
-    try:
-        os.mkdir("tmp/test_ogr2ogr_37_src")
-    except OSError:
-        pass
-    shutil.copy("../ogr/data/poly.shp", "tmp/test_ogr2ogr_37_src")
-    shutil.copy("../ogr/data/poly.shx", "tmp/test_ogr2ogr_37_src")
-    shutil.copy("../ogr/data/poly.dbf", "tmp/test_ogr2ogr_37_src")
-    shutil.copy("../ogr/data/shp/testpoly.shp", "tmp/test_ogr2ogr_37_src")
-    shutil.copy("../ogr/data/shp/testpoly.shx", "tmp/test_ogr2ogr_37_src")
-    shutil.copy("../ogr/data/shp/testpoly.dbf", "tmp/test_ogr2ogr_37_src")
+    src_dir.mkdir()
+    shutil.copy("../ogr/data/poly.shp", src_dir)
+    shutil.copy("../ogr/data/poly.shx", src_dir)
+    shutil.copy("../ogr/data/poly.dbf", src_dir)
+    shutil.copy("../ogr/data/shp/testpoly.shp", src_dir)
+    shutil.copy("../ogr/data/shp/testpoly.shx", src_dir)
+    shutil.copy("../ogr/data/shp/testpoly.dbf", src_dir)
 
-    gdaltest.runexternal(
-        ogr2ogr_path + " tmp/test_ogr2ogr_37_dir.shp tmp/test_ogr2ogr_37_src"
-    )
+    gdaltest.runexternal(f"{ogr2ogr_path} {output_shp} {src_dir}")
 
-    ds = ogr.Open("tmp/test_ogr2ogr_37_dir.shp")
+    ds = ogr.Open(output_shp)
     assert ds is not None and ds.GetLayerCount() == 2
     ds = None
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/test_ogr2ogr_37_src")
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-        "tmp/test_ogr2ogr_37_dir.shp"
-    )
 
 
 ###############################################################################
@@ -1484,66 +1084,46 @@ def test_ogr2ogr_37(ogr2ogr_path):
 # -select and -where (#4015)
 
 
-def test_ogr2ogr_38(ogr2ogr_path):
+def test_ogr2ogr_38(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/test_ogr2ogr_38.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-            "tmp/test_ogr2ogr_38.shp"
-        )
-    except (OSError, AttributeError):
-        pass
+    output_shp = str(tmp_path / "test_ogr2ogr_38.shp")
 
     gdaltest.runexternal(
         ogr2ogr_path
-        + ' tmp/test_ogr2ogr_38.shp ../ogr/data/poly.shp -select AREA -where "EAS_ID = 170"'
+        + f' {output_shp} ../ogr/data/poly.shp -select AREA -where "EAS_ID = 170"'
     )
 
-    ds = ogr.Open("tmp/test_ogr2ogr_38.shp")
+    ds = ogr.Open(output_shp)
     lyr = ds.GetLayer(0)
     feat = lyr.GetNextFeature()
     assert feat is not None
     ds = None
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/test_ogr2ogr_38.shp")
 
 
 ###############################################################################
 # Test 'ogr2ogr someDirThatDoesNotExist.shp dataSourceWithMultipleLayer -sql "select * from alayer"' (#4268)
 
 
-def test_ogr2ogr_39(ogr2ogr_path):
+def test_ogr2ogr_39(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/test_ogr2ogr_39_dir.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-            "tmp/test_ogr2ogr_39.shp"
-        )
-    except (OSError, AttributeError):
-        pass
+    src_dir = tmp_path / "test_ogr2ogr_39_src"
+    output_shp = str(tmp_path / "test_ogr2ogr_39_dir.shp")
 
-    try:
-        os.mkdir("tmp/test_ogr2ogr_39_src")
-    except OSError:
-        pass
-    shutil.copy("../ogr/data/poly.shp", "tmp/test_ogr2ogr_39_src")
-    shutil.copy("../ogr/data/poly.shx", "tmp/test_ogr2ogr_39_src")
-    shutil.copy("../ogr/data/poly.dbf", "tmp/test_ogr2ogr_39_src")
-    shutil.copy("../ogr/data/shp/testpoly.shp", "tmp/test_ogr2ogr_39_src")
-    shutil.copy("../ogr/data/shp/testpoly.shx", "tmp/test_ogr2ogr_39_src")
-    shutil.copy("../ogr/data/shp/testpoly.dbf", "tmp/test_ogr2ogr_39_src")
+    src_dir.mkdir()
+    shutil.copy("../ogr/data/poly.shp", src_dir)
+    shutil.copy("../ogr/data/poly.shx", src_dir)
+    shutil.copy("../ogr/data/poly.dbf", src_dir)
+    shutil.copy("../ogr/data/shp/testpoly.shp", src_dir)
+    shutil.copy("../ogr/data/shp/testpoly.shx", src_dir)
+    shutil.copy("../ogr/data/shp/testpoly.dbf", src_dir)
 
     gdaltest.runexternal(
-        ogr2ogr_path
-        + ' tmp/test_ogr2ogr_39.shp tmp/test_ogr2ogr_39_src -sql "select * from poly"'
+        f'{ogr2ogr_path} {output_shp} {src_dir} -sql "select * from poly"'
     )
 
-    ds = ogr.Open("tmp/test_ogr2ogr_39.shp")
+    ds = ogr.Open(output_shp)
     assert ds is not None and ds.GetLayerCount() == 1
     ds = None
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/test_ogr2ogr_39_src")
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/test_ogr2ogr_39.shp")
 
 
 ###############################################################################
@@ -1551,27 +1131,19 @@ def test_ogr2ogr_39(ogr2ogr_path):
 
 
 @pytest.mark.require_driver("SQLite")
-def test_ogr2ogr_40(ogr2ogr_path):
+def test_ogr2ogr_40(ogr2ogr_path, tmp_path):
 
-    try:
-        ogr.GetDriverByName("SQLite").DeleteDataSource("tmp/test_ogr2ogr_40.db")
-    except AttributeError:
-        pass
+    output_db = str(tmp_path / "test_ogr2ogr_40.db")
 
+    gdaltest.runexternal(f"{ogr2ogr_path} -f SQlite {output_db} ../ogr/data/poly.shp")
     gdaltest.runexternal(
-        ogr2ogr_path + " -f SQlite tmp/test_ogr2ogr_40.db ../ogr/data/poly.shp"
-    )
-    gdaltest.runexternal(
-        ogr2ogr_path
-        + " -update tmp/test_ogr2ogr_40.db tmp/test_ogr2ogr_40.db poly -nln poly2"
+        f"{ogr2ogr_path} -update {output_db} {output_db} poly -nln poly2"
     )
 
-    ds = ogr.Open("tmp/test_ogr2ogr_40.db")
+    ds = ogr.Open(output_db)
     lyr = ds.GetLayerByName("poly2")
     assert lyr.GetFeatureCount() == 10
     ds = None
-
-    ogr.GetDriverByName("SQLite").DeleteDataSource("tmp/test_ogr2ogr_40.db")
 
 
 ###############################################################################
@@ -1618,71 +1190,37 @@ def test_ogr2ogr_41(ogr2ogr_path):
 # Test combination of -select and -where FID=xx (#4500)
 
 
-def test_ogr2ogr_42(ogr2ogr_path):
+def test_ogr2ogr_42(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/test_ogr2ogr_42.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-            "tmp/test_ogr2ogr_42.shp"
-        )
-    except (OSError, AttributeError):
-        pass
+    output_shp = str(tmp_path / "test_ogr2ogr_42.shp")
 
     gdaltest.runexternal(
-        ogr2ogr_path
-        + ' tmp/test_ogr2ogr_42.shp ../ogr/data/poly.shp -select AREA -where "FID = 0"'
+        f'{ogr2ogr_path} {output_shp} ../ogr/data/poly.shp -select AREA -where "FID = 0"'
     )
 
-    ds = ogr.Open("tmp/test_ogr2ogr_42.shp")
+    ds = ogr.Open(output_shp)
     lyr = ds.GetLayerByIndex(0)
     assert lyr.GetFeatureCount() == 1
     ds = None
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/test_ogr2ogr_42.shp")
 
 
 ###############################################################################
 # Test -dim 3 and -dim 2
 
 
-def test_ogr2ogr_43(ogr2ogr_path):
+@pytest.mark.parametrize("dim", (2, 3))
+def test_ogr2ogr_43(ogr2ogr_path, tmp_path, dim):
 
-    try:
-        os.stat("tmp/test_ogr2ogr_43_3d.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-            "tmp/test_ogr2ogr_43_3d.shp"
-        )
-    except (OSError, AttributeError):
-        pass
+    output_shp = str(tmp_path / "test_ogr2ogr_43_{dim}d.shp")
 
-    gdaltest.runexternal(
-        ogr2ogr_path + " tmp/test_ogr2ogr_43_3d.shp ../ogr/data/poly.shp -dim 3"
-    )
+    gdaltest.runexternal(f"{ogr2ogr_path} {output_shp} ../ogr/data/poly.shp -dim {dim}")
 
-    ds = ogr.Open("tmp/test_ogr2ogr_43_3d.shp")
+    ds = ogr.Open(output_shp)
     lyr = ds.GetLayerByIndex(0)
-    assert lyr.GetGeomType() == ogr.wkbPolygon25D
-    ds = None
-
-    try:
-        os.stat("tmp/test_ogr2ogr_43_2d.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-            "tmp/test_ogr2ogr_43_2d.shp"
-        )
-    except (OSError, AttributeError):
-        pass
-
-    gdaltest.runexternal(
-        ogr2ogr_path + " tmp/test_ogr2ogr_43_2d.shp tmp/test_ogr2ogr_43_3d.shp -dim 2"
-    )
-
-    ds = ogr.Open("tmp/test_ogr2ogr_43_2d.shp")
-    lyr = ds.GetLayerByIndex(0)
-    assert lyr.GetGeomType() == ogr.wkbPolygon
-    ds = None
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/test_ogr2ogr_43_2d.shp")
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/test_ogr2ogr_43_3d.shp")
+    if dim == 3:
+        assert lyr.GetGeomType() == ogr.wkbPolygon25D
+    elif dim == 2:
+        assert lyr.GetGeomType() == ogr.wkbPolygon
 
 
 ###############################################################################
@@ -1690,25 +1228,12 @@ def test_ogr2ogr_43(ogr2ogr_path):
 
 
 @pytest.mark.require_driver("GML")
-def test_ogr2ogr_44(ogr2ogr_path):
+def test_ogr2ogr_44(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/test_ogr2ogr_44_src.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-            "tmp/test_ogr2ogr_44_src.shp"
-        )
-    except (OSError, AttributeError):
-        pass
+    src_shp = str(tmp_path / "test_ogr2ogr_44_src.shp")
+    dst_gml = str(tmp_path / "test_ogr2ogr_44.xml")
 
-    if os.path.exists("tmp/test_ogr2ogr_44.gml"):
-        gdal.Unlink("tmp/test_ogr2ogr_44.gml")
-
-    if os.path.exists("tmp/test_ogr2ogr_44.xsd"):
-        gdal.Unlink("tmp/test_ogr2ogr_44.xsd")
-
-    ds = ogr.GetDriverByName("ESRI Shapefile").CreateDataSource(
-        "tmp/test_ogr2ogr_44_src.shp"
-    )
+    ds = ogr.GetDriverByName("ESRI Shapefile").CreateDataSource(src_shp)
     lyr = ds.CreateLayer("test_ogr2ogr_44_src", geom_type=ogr.wkbPolygon)
     feat = ogr.Feature(lyr.GetLayerDefn())
     feat.SetGeometry(ogr.CreateGeometryFromWkt("POLYGON((0 0,0 1,1 1,0 0))"))
@@ -1723,17 +1248,16 @@ def test_ogr2ogr_44(ogr2ogr_path):
     ds = None
 
     gdaltest.runexternal(
-        ogr2ogr_path
-        + " -f GML tmp/test_ogr2ogr_44.gml tmp/test_ogr2ogr_44_src.shp -nlt PROMOTE_TO_MULTI"
+        f"{ogr2ogr_path} -f GML {dst_gml} {src_shp} -nlt PROMOTE_TO_MULTI"
     )
 
-    f = open("tmp/test_ogr2ogr_44.xsd")
+    f = open(dst_gml[:-4] + ".xsd")
     data = f.read()
     f.close()
 
     assert 'type="gml:MultiSurfacePropertyType"' in data
 
-    f = open("tmp/test_ogr2ogr_44.gml")
+    f = open(dst_gml)
     data = f.read()
     f.close()
 
@@ -1742,37 +1266,18 @@ def test_ogr2ogr_44(ogr2ogr_path):
         in data
     )
 
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-        "tmp/test_ogr2ogr_44_src.shp"
-    )
-    os.unlink("tmp/test_ogr2ogr_44.gml")
-    os.unlink("tmp/test_ogr2ogr_44.xsd")
-
 
 ###############################################################################
 # Test -nlt PROMOTE_TO_MULTI for linestring/multilinestring
 
 
 @pytest.mark.require_driver("GML")
-def test_ogr2ogr_45(ogr2ogr_path):
+def test_ogr2ogr_45(ogr2ogr_path, tmp_path):
 
-    try:
-        os.stat("tmp/test_ogr2ogr_45_src.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-            "tmp/test_ogr2ogr_45_src.shp"
-        )
-    except (OSError, AttributeError):
-        pass
+    src_shp = str(tmp_path / "test_ogr2ogr_45_src.shp")
+    dst_gml = str(tmp_path / "test_ogr2ogr_45.gml")
 
-    if os.path.exists("tmp/test_ogr2ogr_45.gml"):
-        gdal.Unlink("tmp/test_ogr2ogr_45.gml")
-
-    if os.path.exists("tmp/test_ogr2ogr_45.xsd"):
-        gdal.Unlink("tmp/test_ogr2ogr_45.xsd")
-
-    ds = ogr.GetDriverByName("ESRI Shapefile").CreateDataSource(
-        "tmp/test_ogr2ogr_45_src.shp"
-    )
+    ds = ogr.GetDriverByName("ESRI Shapefile").CreateDataSource(src_shp)
     lyr = ds.CreateLayer("test_ogr2ogr_45_src", geom_type=ogr.wkbLineString)
     feat = ogr.Feature(lyr.GetLayerDefn())
     feat.SetGeometry(ogr.CreateGeometryFromWkt("LINESTRING(0 0,0 1,1 1,0 0)"))
@@ -1787,17 +1292,16 @@ def test_ogr2ogr_45(ogr2ogr_path):
     ds = None
 
     gdaltest.runexternal(
-        ogr2ogr_path
-        + " -f GML tmp/test_ogr2ogr_45.gml tmp/test_ogr2ogr_45_src.shp -nlt PROMOTE_TO_MULTI"
+        f"{ogr2ogr_path} -f GML {dst_gml} {src_shp} -nlt PROMOTE_TO_MULTI"
     )
 
-    f = open("tmp/test_ogr2ogr_45.xsd")
+    f = open(dst_gml[:-4] + ".xsd")
     data = f.read()
     f.close()
 
     assert 'type="gml:MultiCurvePropertyType"' in data
 
-    f = open("tmp/test_ogr2ogr_45.gml")
+    f = open(dst_gml)
     data = f.read()
     f.close()
 
@@ -1806,37 +1310,28 @@ def test_ogr2ogr_45(ogr2ogr_path):
         in data
     )
 
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-        "tmp/test_ogr2ogr_45_src.shp"
-    )
-    os.unlink("tmp/test_ogr2ogr_45.gml")
-    os.unlink("tmp/test_ogr2ogr_45.xsd")
-
 
 ###############################################################################
 # Test -gcp (#4604)
 
 
 @pytest.mark.require_driver("GML")
-def test_ogr2ogr_46(ogr2ogr_path):
+@pytest.mark.parametrize(
+    "option",
+    [
+        "",
+        "-tps",
+        "-order 1",
+        "-a_srs EPSG:4326",
+        "-s_srs EPSG:4326 -t_srs EPSG:3857",
+    ],
+)
+def test_ogr2ogr_46(ogr2ogr_path, tmp_path, option):
 
-    try:
-        os.stat("tmp/test_ogr2ogr_46_src.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-            "tmp/test_ogr2ogr_46_src.shp"
-        )
-    except (OSError, AttributeError):
-        pass
+    src_shp = str(tmp_path / "test_ogr2ogr_46_src.shp")
+    dst_gml = str(tmp_path / "test_ogr2ogr_46.gml")
 
-    if os.path.exists("tmp/test_ogr2ogr_46.gml"):
-        gdal.Unlink("tmp/test_ogr2ogr_46.gml")
-
-    if os.path.exists("tmp/test_ogr2ogr_46.xsd"):
-        gdal.Unlink("tmp/test_ogr2ogr_46.xsd")
-
-    ds = ogr.GetDriverByName("ESRI Shapefile").CreateDataSource(
-        "tmp/test_ogr2ogr_46_src.shp"
-    )
+    ds = ogr.GetDriverByName("ESRI Shapefile").CreateDataSource(src_shp)
     lyr = ds.CreateLayer("test_ogr2ogr_46_src", geom_type=ogr.wkbPoint)
     feat = ogr.Feature(lyr.GetLayerDefn())
     feat.SetGeometry(ogr.CreateGeometryFromWkt("POINT(0 0)"))
@@ -1846,37 +1341,21 @@ def test_ogr2ogr_46(ogr2ogr_path):
     lyr.CreateFeature(feat)
     ds = None
 
-    for option in [
-        "",
-        " -tps",
-        " -order 1",
-        " -a_srs EPSG:4326",
-        " -s_srs EPSG:4326 -t_srs EPSG:3857",
-    ]:
-        gdaltest.runexternal(
-            ogr2ogr_path
-            + " -f GML -dsco FORMAT=GML2 tmp/test_ogr2ogr_46.gml tmp/test_ogr2ogr_46_src.shp -gcp 0 0 2 49 -gcp 0 1 2 50 -gcp 1 0 3 49%s"
-            % option
-        )
-
-        f = open("tmp/test_ogr2ogr_46.gml")
-        data = f.read()
-        f.close()
-
-        assert not (
-            "2,49" not in data and "2.0,49.0" not in data and "222638." not in data
-        ), option
-
-        assert not (
-            "3,50" not in data and "3.0,50.0" not in data and "333958." not in data
-        ), option
-
-        os.unlink("tmp/test_ogr2ogr_46.gml")
-        os.unlink("tmp/test_ogr2ogr_46.xsd")
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-        "tmp/test_ogr2ogr_46_src.shp"
+    gdaltest.runexternal(
+        f"{ogr2ogr_path} -f GML -dsco FORMAT=GML2 {dst_gml} {src_shp} -gcp 0 0 2 49 -gcp 0 1 2 50 -gcp 1 0 3 49 {option}"
     )
+
+    f = open(dst_gml)
+    data = f.read()
+    f.close()
+
+    assert not (
+        "2,49" not in data and "2.0,49.0" not in data and "222638." not in data
+    ), option
+
+    assert not (
+        "3,50" not in data and "3.0,50.0" not in data and "333958." not in data
+    ), option
 
 
 ###############################################################################
@@ -1884,9 +1363,12 @@ def test_ogr2ogr_46(ogr2ogr_path):
 
 
 @pytest.mark.require_driver("GML")
-def test_ogr2ogr_47(ogr2ogr_path):
+def test_ogr2ogr_47(ogr2ogr_path, tmp_path):
 
-    f = open("tmp/test_ogr2ogr_47_src.gml", "wt")
+    src_gml = str(tmp_path / "test_ogr2ogr_47_src.gml")
+    dst_gml = str(tmp_path / "test_ogr2ogr_47_dst.gml")
+
+    f = open(src_gml, "wt")
     f.write(
         """<foo xmlns:gml="http://www.opengis.net/gml">
    <gml:featureMember>
@@ -1911,21 +1393,11 @@ def test_ogr2ogr_47(ogr2ogr_path):
     )
     f.close()
 
-    if os.path.exists("tmp/test_ogr2ogr_47_src.gfs"):
-        gdal.Unlink("tmp/test_ogr2ogr_47_src.gfs")
-
-    try:
-        ogr.Open("tmp/test_ogr2ogr_47_src.gml")
-    except Exception:
-        os.unlink("tmp/test_ogr2ogr_47_src.gml")
-        pytest.skip("GML reader not available")
-
     gdaltest.runexternal(
-        ogr2ogr_path
-        + " -f GML -dsco FORMAT=GML2 -t_srs EPSG:4326 tmp/test_ogr2ogr_47_dst.gml tmp/test_ogr2ogr_47_src.gml"
+        f"{ogr2ogr_path} -f GML -dsco FORMAT=GML2 -t_srs EPSG:4326 {dst_gml} {src_gml}"
     )
 
-    f = open("tmp/test_ogr2ogr_47_dst.gml")
+    f = open(dst_gml)
     data = f.read()
     f.close()
 
@@ -1935,66 +1407,37 @@ def test_ogr2ogr_47(ogr2ogr_path):
         or (">-2.99999999999999,40.65" in data and ">2.99999999999999,40.65" in data)
     ), data
 
-    os.unlink("tmp/test_ogr2ogr_47_dst.gml")
-    os.unlink("tmp/test_ogr2ogr_47_dst.xsd")
-
-    os.unlink("tmp/test_ogr2ogr_47_src.gml")
-    os.unlink("tmp/test_ogr2ogr_47_src.gfs")
-
 
 ###############################################################################
 # Test fieldmap option
 
 
 @pytest.mark.require_driver("CSV")
-def test_ogr2ogr_48(ogr2ogr_path):
+def test_ogr2ogr_48(ogr2ogr_path, tmp_path):
 
-    gdaltest.runexternal(ogr2ogr_path + " tmp data/Fields.csv")
+    gdaltest.runexternal(f"{ogr2ogr_path} {tmp_path} data/Fields.csv")
     gdaltest.runexternal(
-        ogr2ogr_path + " -append -fieldmap identity tmp data/Fields.csv"
+        f"{ogr2ogr_path} -append -fieldmap identity {tmp_path} data/Fields.csv"
     )
     gdaltest.runexternal(
-        ogr2ogr_path
-        + " -append -fieldmap 14,13,12,11,10,9,8,7,6,5,4,3,2,1,0 tmp data/Fields.csv"
+        f"{ogr2ogr_path} -append -fieldmap 14,13,12,11,10,9,8,7,6,5,4,3,2,1,0 {tmp_path} data/Fields.csv"
     )
 
-    ds = ogr.Open("tmp/Fields.dbf")
+    ds = ogr.Open(f"{tmp_path}/Fields.dbf")
 
     assert ds is not None
     layer_defn = ds.GetLayer(0).GetLayerDefn()
-    if layer_defn.GetFieldCount() != 15:
-        ds.Destroy()
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/Fields.dbf")
-        pytest.fail(
-            "Unexpected field count: "
-            + str(ds.GetLayer(0).GetLayerDefn().GetFieldCount())
-        )
+    assert layer_defn.GetFieldCount() == 15, "Unexpected field count"
 
-    error_occurred = False
     lyr = ds.GetLayer(0)
     lyr.GetNextFeature()
     feat = lyr.GetNextFeature()
     for i in range(layer_defn.GetFieldCount()):
-        if feat.GetFieldAsString(i) != str(i + 1):
-            print(
-                "Expected the value ", str(i + 1), ",but got", feat.GetFieldAsString(i)
-            )
-            error_occurred = True
+        assert feat.GetFieldAsString(i) == str(i + 1)
+
     feat = lyr.GetNextFeature()
     for i in range(layer_defn.GetFieldCount()):
-        if feat.GetFieldAsString(i) != str(layer_defn.GetFieldCount() - i):
-            print(
-                "Expected the value ",
-                str(layer_defn.GetFieldCount() - i),
-                ",but got",
-                feat.GetFieldAsString(i),
-            )
-            error_occurred = True
-
-    ds.Destroy()
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/Fields.dbf")
-
-    assert not error_occurred
+        assert feat.GetFieldAsString(i) == str(layer_defn.GetFieldCount() - i)
 
 
 ###############################################################################
@@ -2003,16 +1446,16 @@ def test_ogr2ogr_48(ogr2ogr_path):
 
 
 @pytest.mark.require_driver("CSV")
-def test_ogr2ogr_49(ogr2ogr_path):
+def test_ogr2ogr_49(ogr2ogr_path, tmp_path):
+
+    output_csv = str(tmp_path / "tset_ogr2ogr_49.csv")
 
     gdaltest.runexternal(
-        ogr2ogr_path + " -f CSV tmp/test_ogr2ogr_49.csv data/duplicatedfields.csv"
+        f"{ogr2ogr_path} -f CSV {output_csv} data/duplicatedfields.csv"
     )
-    f = open("tmp/test_ogr2ogr_49.csv")
+    f = open(output_csv)
     lines = f.readlines()
     f.close()
-
-    os.unlink("tmp/test_ogr2ogr_49.csv")
 
     assert (
         lines[0].find("foo,bar,foo3,foo2,baz,foo4") == 0
@@ -2026,17 +1469,16 @@ def test_ogr2ogr_49(ogr2ogr_path):
 
 @pytest.mark.require_driver("CSV")
 @pytest.mark.require_driver("KML")
-def test_ogr2ogr_49_bis(ogr2ogr_path):
+def test_ogr2ogr_49_bis(ogr2ogr_path, tmp_path):
+
+    output_kml = str(tmp_path / "test_ogr2ogr_49_bis.kml")
 
     gdaltest.runexternal(
-        ogr2ogr_path
-        + ' -f KML tmp/test_ogr2ogr_49_bis.kml data/grid.csv -sql "SELECT field_1 AS name FROM grid WHERE fid = 1"'
+        f'{ogr2ogr_path} -f KML {output_kml} data/grid.csv -sql "SELECT field_1 AS name FROM grid WHERE fid = 1"'
     )
-    f = open("tmp/test_ogr2ogr_49_bis.kml")
+    f = open(output_kml)
     lines = f.readlines()
     f.close()
-
-    os.unlink("tmp/test_ogr2ogr_49_bis.kml")
 
     expected_lines = [
         """<?xml version="1.0" encoding="utf-8" ?>""",
@@ -2060,28 +1502,28 @@ def test_ogr2ogr_49_bis(ogr2ogr_path):
 
 
 @pytest.mark.require_driver("CSV")
-def test_ogr2ogr_50(ogr2ogr_path):
+def test_ogr2ogr_50(ogr2ogr_path, tmp_path):
 
-    f = open("tmp/test_ogr2ogr_50_1.csv", "wt")
+    src1_csv = str(tmp_path / "test_ogr2ogr_50_1.csv")
+    src2_csv = str(tmp_path / "test_ogr2ogr_50_2.csv")
+    dst_dbf = str(tmp_path / "test_ogr2ogr_50.dbf")
+
+    f = open(src1_csv, "wt")
     f.write("id,field1\n")
     f.write("1,foo\n")
     f.close()
 
-    f = open("tmp/test_ogr2ogr_50_2.csv", "wt")
+    f = open(src2_csv, "wt")
     f.write("id,field1,field2\n")
     f.write("2,bar,baz\n")
     f.close()
 
+    gdaltest.runexternal(f"{ogr2ogr_path} {dst_dbf} {src1_csv} -nln test_ogr2ogr_50")
     gdaltest.runexternal(
-        ogr2ogr_path
-        + " tmp/test_ogr2ogr_50.dbf tmp/test_ogr2ogr_50_1.csv -nln test_ogr2ogr_50"
-    )
-    gdaltest.runexternal(
-        ogr2ogr_path
-        + " -addfields tmp/test_ogr2ogr_50.dbf tmp/test_ogr2ogr_50_2.csv -nln test_ogr2ogr_50"
+        f"{ogr2ogr_path} -addfields {dst_dbf} {src2_csv} -nln test_ogr2ogr_50"
     )
 
-    ds = ogr.Open("tmp/test_ogr2ogr_50.dbf")
+    ds = ogr.Open(dst_dbf)
     lyr = ds.GetLayer(0)
     feat = lyr.GetNextFeature()
     if feat.GetField("field1") != "foo" or not feat.IsFieldNull("field2"):
@@ -2094,30 +1536,35 @@ def test_ogr2ogr_50(ogr2ogr_path):
         pytest.fail()
     ds = None
 
-    os.unlink("tmp/test_ogr2ogr_50.dbf")
-    os.unlink("tmp/test_ogr2ogr_50_1.csv")
-    os.unlink("tmp/test_ogr2ogr_50_2.csv")
-
 
 ###############################################################################
 # Test RFC 41 support
 
 
-@pytest.mark.require_driver("CSV")
-def test_ogr2ogr_51(ogr2ogr_path):
+@pytest.fixture()
+def ogr2ogr_51_multigeom_csv(tmp_path):
 
-    f = open("tmp/test_ogr2ogr_51_src.csv", "wt")
-    f.write("id,_WKTgeom1_EPSG_4326,foo,_WKTgeom2_EPSG_32631\n")
-    f.write('1,"POINT(1 2)","bar","POINT(3 4)"\n')
-    f.close()
+    src_csv = str(tmp_path / "test_ogr2ogr_51_src.csv")
+
+    with open(src_csv, "wt") as f:
+        f.write("id,_WKTgeom1_EPSG_4326,foo,_WKTgeom2_EPSG_32631\n")
+        f.write('1,"POINT(1 2)","bar","POINT(3 4)"\n')
+
+    return src_csv
+
+
+@pytest.mark.require_driver("CSV")
+def test_ogr2ogr_51(ogr2ogr_path, ogr2ogr_51_multigeom_csv, tmp_path):
+
+    src_csv = ogr2ogr_51_multigeom_csv
+    dst_csv = str(tmp_path / "test_ogr2ogr_51_dst.csv")
 
     # Test conversion from a multi-geometry format into a multi-geometry format
     gdaltest.runexternal(
-        ogr2ogr_path
-        + " -f CSV tmp/test_ogr2ogr_51_dst.csv tmp/test_ogr2ogr_51_src.csv -nln test_ogr2ogr_51_dst -dsco GEOMETRY=AS_WKT -lco STRING_QUOTING=ALWAYS"
+        f"{ogr2ogr_path} -f CSV {dst_csv} {src_csv} -nln test_ogr2ogr_51_dst -dsco GEOMETRY=AS_WKT -lco STRING_QUOTING=ALWAYS"
     )
 
-    f = open("tmp/test_ogr2ogr_51_dst.csv", "rt")
+    f = open(dst_csv, "rt")
     lines = f.readlines()
     f.close()
 
@@ -2128,30 +1575,12 @@ def test_ogr2ogr_51(ogr2ogr_path):
     for i in range(2):
         assert lines[i].strip() == expected_lines[i]
 
-    # Test conversion from a multi-geometry format into a single-geometry format
-    gdaltest.runexternal(
-        ogr2ogr_path
-        + " tmp/test_ogr2ogr_51_dst.shp tmp/test_ogr2ogr_51_src.csv -nln test_ogr2ogr_51_dst"
-    )
-
-    ds = ogr.Open("tmp/test_ogr2ogr_51_dst.shp")
-    lyr = ds.GetLayer(0)
-    sr = lyr.GetSpatialRef()
-    assert sr is not None and sr.ExportToWkt().find('GEOGCS["WGS 84"') == 0
-    feat = lyr.GetNextFeature()
-    assert feat.GetGeometryRef().ExportToWkt() == "POINT (1 2)"
-    ds = None
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(
-        "tmp/test_ogr2ogr_51_dst.shp"
-    )
-
     # Test -append into a multi-geometry format
     gdaltest.runexternal(
-        ogr2ogr_path
-        + " -append tmp/test_ogr2ogr_51_dst.csv tmp/test_ogr2ogr_51_src.csv -nln test_ogr2ogr_51_dst"
+        f"{ogr2ogr_path} -append {dst_csv} {src_csv} -nln test_ogr2ogr_51_dst"
     )
 
-    f = open("tmp/test_ogr2ogr_51_dst.csv", "rt")
+    f = open(dst_csv, "rt")
     lines = f.readlines()
     f.close()
 
@@ -2163,15 +1592,37 @@ def test_ogr2ogr_51(ogr2ogr_path):
     for i in range(3):
         assert lines[i].strip() == expected_lines[i]
 
-    os.unlink("tmp/test_ogr2ogr_51_dst.csv")
+
+@pytest.mark.require_driver("CSV")
+def test_ogr2ogr_51bis(ogr2ogr_path, ogr2ogr_51_multigeom_csv, tmp_path):
+
+    src_csv = ogr2ogr_51_multigeom_csv
+    dst_shp = str(tmp_path / "test_ogr2ogr_51_dst.shp")
+
+    # Test conversion from a multi-geometry format into a single-geometry format
+    gdaltest.runexternal(f"{ogr2ogr_path} {dst_shp} {src_csv} -nln test_ogr2ogr_51_dst")
+
+    ds = ogr.Open(dst_shp)
+    lyr = ds.GetLayer(0)
+    sr = lyr.GetSpatialRef()
+    assert sr is not None and sr.ExportToWkt().find('GEOGCS["WGS 84"') == 0
+    feat = lyr.GetNextFeature()
+    assert feat.GetGeometryRef().ExportToWkt() == "POINT (1 2)"
+    ds = None
+
+
+@pytest.mark.require_driver("CSV")
+def test_ogr2ogr_51ter(ogr2ogr_path, ogr2ogr_51_multigeom_csv, tmp_path):
+
+    src_csv = ogr2ogr_51_multigeom_csv
+    dst_csv = str(tmp_path / "test_ogr2ogr_51_dst.csv")
 
     # Test -select with geometry field names
     gdaltest.runexternal(
-        ogr2ogr_path
-        + " -select foo,geom__WKTgeom2_EPSG_32631,id,geom__WKTgeom1_EPSG_4326 -f CSV tmp/test_ogr2ogr_51_dst.csv tmp/test_ogr2ogr_51_src.csv -nln test_ogr2ogr_51_dst -dsco GEOMETRY=AS_WKT -lco STRING_QUOTING=ALWAYS"
+        f"{ogr2ogr_path} -select foo,geom__WKTgeom2_EPSG_32631,id,geom__WKTgeom1_EPSG_4326 -f CSV {dst_csv} {src_csv} -nln test_ogr2ogr_51_dst -dsco GEOMETRY=AS_WKT -lco STRING_QUOTING=ALWAYS"
     )
 
-    f = open("tmp/test_ogr2ogr_51_dst.csv", "rt")
+    f = open(dst_csv, "rt")
     lines = f.readlines()
     f.close()
 
@@ -2184,11 +1635,10 @@ def test_ogr2ogr_51(ogr2ogr_path):
 
     # Test -geomfield option
     gdaltest.runexternal(
-        ogr2ogr_path
-        + " -append tmp/test_ogr2ogr_51_dst.csv tmp/test_ogr2ogr_51_src.csv -nln test_ogr2ogr_51_dst -spat 1 2 1 2 -geomfield geom__WKTgeom1_EPSG_4326"
+        f"{ogr2ogr_path} -append {dst_csv} {src_csv} -nln test_ogr2ogr_51_dst -spat 1 2 1 2 -geomfield geom__WKTgeom1_EPSG_4326"
     )
 
-    f = open("tmp/test_ogr2ogr_51_dst.csv", "rt")
+    f = open(dst_csv, "rt")
     lines = f.readlines()
     f.close()
 
@@ -2200,47 +1650,42 @@ def test_ogr2ogr_51(ogr2ogr_path):
     for i in range(2):
         assert lines[i].strip() == expected_lines[i]
 
-    os.unlink("tmp/test_ogr2ogr_51_src.csv")
-    os.unlink("tmp/test_ogr2ogr_51_dst.csv")
-
 
 ###############################################################################
 # Test -nlt CONVERT_TO_LINEAR and -nlt CONVERT_TO_CURVE
 
 
 @pytest.mark.require_driver("CSV")
-def test_ogr2ogr_52(ogr2ogr_path):
+def test_ogr2ogr_52(ogr2ogr_path, tmp_path):
 
-    f = open("tmp/test_ogr2ogr_52_src.csv", "wt")
+    src_csv = str(tmp_path / "test_ogr2ogr_52_src.csv")
+    dst1_csv = str(tmp_path / "test_ogr2ogr_52_dst.csv")
+    dst2_csv = str(tmp_path / "test_ogr2ogr_52_dst2.csv")
+
+    f = open(src_csv, "wt")
     f.write("id,WKT\n")
     f.write('1,"CIRCULARSTRING(0 0,1 0,0 0)"\n')
     f.close()
 
     gdaltest.runexternal(
-        ogr2ogr_path
-        + " -f CSV tmp/test_ogr2ogr_52_dst.csv tmp/test_ogr2ogr_52_src.csv -select id -nln test_ogr2ogr_52_dst -dsco GEOMETRY=AS_WKT -nlt CONVERT_TO_LINEAR"
+        f"{ogr2ogr_path}  -f CSV {dst1_csv} {src_csv} -select id -nln test_ogr2ogr_52_dst -dsco GEOMETRY=AS_WKT -nlt CONVERT_TO_LINEAR"
     )
 
-    f = open("tmp/test_ogr2ogr_52_dst.csv", "rt")
+    f = open(dst1_csv, "rt")
     content = f.read()
     f.close()
 
     assert "LINESTRING (0 0," in content
 
     gdaltest.runexternal(
-        ogr2ogr_path
-        + " -f CSV tmp/test_ogr2ogr_52_dst2.csv tmp/test_ogr2ogr_52_dst.csv -select id -nln test_ogr2ogr_52_dst2 -dsco GEOMETRY=AS_WKT -nlt CONVERT_TO_CURVE"
+        f"{ogr2ogr_path} -f CSV {dst2_csv} {dst1_csv} -select id -nln test_ogr2ogr_52_dst2 -dsco GEOMETRY=AS_WKT -nlt CONVERT_TO_CURVE"
     )
 
-    f = open("tmp/test_ogr2ogr_52_dst2.csv", "rt")
+    f = open(dst2_csv, "rt")
     content = f.read()
     f.close()
 
     assert "COMPOUNDCURVE ((0 0," in content
-
-    os.unlink("tmp/test_ogr2ogr_52_src.csv")
-    os.unlink("tmp/test_ogr2ogr_52_dst.csv")
-    os.unlink("tmp/test_ogr2ogr_52_dst2.csv")
 
 
 ###############################################################################
@@ -2249,23 +1694,27 @@ def test_ogr2ogr_52(ogr2ogr_path):
 
 @pytest.mark.require_driver("CSV")
 @pytest.mark.require_driver("KML")
-def test_ogr2ogr_53(ogr2ogr_path):
+def test_ogr2ogr_53(ogr2ogr_path, tmp_path):
 
-    f = open("tmp/test_ogr2ogr_53.csv", "wt")
+    src_csv = str(tmp_path / "test_ogr2ogr_53.csv")
+    src_csvt = str(tmp_path / "test_ogr2ogr_53.csvt")
+    dst_kml = str(tmp_path / "test_ogr2ogr_53.kml")
+    dst2_kml = str(tmp_path / "test_ogr2ogr_53b.kml")
+
+    f = open(src_csv, "wt")
     f.write("id,i64,b,WKT\n")
     f.write('1,123456789012,true,"POINT(0 0)"\n')
     f.close()
-    f = open("tmp/test_ogr2ogr_53.csvt", "wt")
+    f = open(src_csvt, "wt")
     f.write("Integer,Integer64,Integer(Boolean),String\n")
     f.close()
 
     # Default behaviour with a driver that declares GDAL_DMD_CREATIONFIELDDATATYPES
     gdaltest.runexternal(
-        ogr2ogr_path
-        + ' -f KML tmp/test_ogr2ogr_53.kml tmp/test_ogr2ogr_53.csv -mapFieldType "Integer(Boolean)=String"'
+        f'{ogr2ogr_path} -f KML {dst_kml} {src_csv} -mapFieldType "Integer(Boolean)=String"'
     )
 
-    f = open("tmp/test_ogr2ogr_53.kml", "rt")
+    f = open(dst_kml, "rt")
     content = f.read()
     f.close()
 
@@ -2277,8 +1726,6 @@ def test_ogr2ogr_53(ogr2ogr_path):
         and '<SimpleField name="b" type="string"></SimpleField>' in content
         and '<SimpleData name="b">1</SimpleData>' in content
     )
-
-    os.unlink("tmp/test_ogr2ogr_53.kml")
 
     # Default behaviour with a driver that does not GDAL_DMD_CREATIONFIELDDATATYPES
     # gdaltest.runexternal(ogr2ogr_path + ' -f BNA tmp/test_ogr2ogr_53.bna tmp/test_ogr2ogr_53.csv -nlt POINT')
@@ -2293,11 +1740,10 @@ def test_ogr2ogr_53(ogr2ogr_path):
 
     # with -mapFieldType
     gdaltest.runexternal(
-        ogr2ogr_path
-        + " -f KML tmp/test_ogr2ogr_53.kml tmp/test_ogr2ogr_53.csv -mapFieldType Integer64=String"
+        f"{ogr2ogr_path} -f KML {dst2_kml} {src_csv} -mapFieldType Integer64=String"
     )
 
-    f = open("tmp/test_ogr2ogr_53.kml", "rt")
+    f = open(dst2_kml, "rt")
     content = f.read()
     f.close()
 
@@ -2306,26 +1752,22 @@ def test_ogr2ogr_53(ogr2ogr_path):
         and '<SimpleData name="i64">123456789012</SimpleData>' in content
     )
 
-    os.unlink("tmp/test_ogr2ogr_53.kml")
-
-    os.unlink("tmp/test_ogr2ogr_53.csv")
-    os.unlink("tmp/test_ogr2ogr_53.csvt")
-
 
 ###############################################################################
 # Test behaviour with nullable fields
 
 
-@pytest.mark.require_driver("CSV")
-@pytest.mark.require_driver("GML")
-def test_ogr2ogr_54(ogr2ogr_path):
+@pytest.fixture()
+def ogr2ogr_54_vrt(tmp_path):
+    src_csv = str(tmp_path / "test_ogr2ogr_54.csv")
+    src_vrt = str(tmp_path / "test_ogr2ogr_54.vrt")
 
-    f = open("tmp/test_ogr2ogr_54.csv", "wt")
+    f = open(src_csv, "wt")
     f.write("fld1,fld2,WKT\n")
     f.write('1,2,"POINT(0 0)"\n')
     f.close()
 
-    f = open("tmp/test_ogr2ogr_54.vrt", "wt")
+    f = open(src_vrt, "wt")
     f.write(
         """<OGRVRTDataSource>
   <OGRVRTLayer name="test_ogr2ogr_54">
@@ -2341,11 +1783,18 @@ def test_ogr2ogr_54(ogr2ogr_path):
     )
     f.close()
 
+    return src_vrt
+
+
+@pytest.mark.require_driver("CSV")
+@pytest.mark.require_driver("GML")
+def test_ogr2ogr_54(ogr2ogr_path, ogr2ogr_54_vrt, tmp_path):
+
     gdaltest.runexternal(
-        ogr2ogr_path + " -f GML tmp/test_ogr2ogr_54.gml tmp/test_ogr2ogr_54.vrt"
+        f"{ogr2ogr_path} -f GML {tmp_path}/test_ogr2ogr_54.gml {ogr2ogr_54_vrt}"
     )
 
-    f = open("tmp/test_ogr2ogr_54.xsd", "rt")
+    f = open(f"{tmp_path}/test_ogr2ogr_54.xsd", "rt")
     content = f.read()
     f.close()
 
@@ -2358,16 +1807,17 @@ def test_ogr2ogr_54(ogr2ogr_path):
         in content
     )
 
-    os.unlink("tmp/test_ogr2ogr_54.gml")
-    os.unlink("tmp/test_ogr2ogr_54.xsd")
+
+@pytest.mark.require_driver("CSV")
+@pytest.mark.require_driver("GML")
+def test_ogr2ogr_54bis(ogr2ogr_path, ogr2ogr_54_vrt, tmp_path):
 
     # Test -forceNullable
     gdaltest.runexternal(
-        ogr2ogr_path
-        + " -forceNullable -f GML tmp/test_ogr2ogr_54.gml tmp/test_ogr2ogr_54.vrt"
+        f"{ogr2ogr_path} -forceNullable -f GML {tmp_path}/test_ogr2ogr_54.gml {ogr2ogr_54_vrt}"
     )
 
-    f = open("tmp/test_ogr2ogr_54.xsd", "rt")
+    f = open(f"{tmp_path}/test_ogr2ogr_54.xsd", "rt")
     content = f.read()
     f.close()
 
@@ -2380,77 +1830,68 @@ def test_ogr2ogr_54(ogr2ogr_path):
         in content
     )
 
-    os.unlink("tmp/test_ogr2ogr_54.gml")
-    os.unlink("tmp/test_ogr2ogr_54.xsd")
-
-    os.unlink("tmp/test_ogr2ogr_54.csv")
-    os.unlink("tmp/test_ogr2ogr_54.vrt")
-
 
 ###############################################################################
 # Test behaviour with default values
 
 
+@pytest.fixture()
+def ogr2ogr_55_vrt(tmp_path):
+
+    with open(f"{tmp_path}/test_ogr2ogr_55.csv", "wt") as f:
+        f.write("fld1,fld2,WKT\n")
+        f.write('1,,"POINT(0 0)"\n')
+
+    with open(f"{tmp_path}/test_ogr2ogr_55.csvt", "wt") as f:
+        f.write("Integer,Integer,String\n")
+
+    with open(f"{tmp_path}/test_ogr2ogr_55.vrt", "wt") as f:
+        f.write(
+            """<OGRVRTDataSource>
+      <OGRVRTLayer name="test_ogr2ogr_55">
+        <SrcDataSource relativeToVRT="1" shared="1">test_ogr2ogr_55.csv</SrcDataSource>
+        <SrcLayer>test_ogr2ogr_55</SrcLayer>
+        <GeometryType>wkbUnknown</GeometryType>
+        <GeometryField name="WKT"/>
+        <Field name="fld1" type="Integer" src="fld1"/>
+        <Field name="fld2" type="Integer" src="fld2" nullable="false" default="2"/>
+      </OGRVRTLayer>
+    </OGRVRTDataSource>
+    """
+        )
+
+    return f"{tmp_path}/test_ogr2ogr_55.vrt"
+
+
 @pytest.mark.require_driver("CSV")
 @pytest.mark.require_driver("GML")
-def test_ogr2ogr_55(ogr2ogr_path):
-
-    f = open("tmp/test_ogr2ogr_55.csv", "wt")
-    f.write("fld1,fld2,WKT\n")
-    f.write('1,,"POINT(0 0)"\n')
-    f.close()
-
-    f = open("tmp/test_ogr2ogr_55.csvt", "wt")
-    f.write("Integer,Integer,String\n")
-    f.close()
-
-    f = open("tmp/test_ogr2ogr_55.vrt", "wt")
-    f.write(
-        """<OGRVRTDataSource>
-  <OGRVRTLayer name="test_ogr2ogr_55">
-    <SrcDataSource relativeToVRT="1" shared="1">test_ogr2ogr_55.csv</SrcDataSource>
-    <SrcLayer>test_ogr2ogr_55</SrcLayer>
-    <GeometryType>wkbUnknown</GeometryType>
-    <GeometryField name="WKT"/>
-    <Field name="fld1" type="Integer" src="fld1"/>
-    <Field name="fld2" type="Integer" src="fld2" nullable="false" default="2"/>
-  </OGRVRTLayer>
-</OGRVRTDataSource>
-"""
-    )
-    f.close()
+def test_ogr2ogr_55(ogr2ogr_path, ogr2ogr_55_vrt, tmp_path):
 
     gdaltest.runexternal(
-        ogr2ogr_path + " -f GML tmp/test_ogr2ogr_55.gml tmp/test_ogr2ogr_55.vrt"
+        f"{ogr2ogr_path} -f GML {tmp_path}/test_ogr2ogr_55.gml {ogr2ogr_55_vrt}"
     )
 
-    f = open("tmp/test_ogr2ogr_55.gml", "rt")
+    f = open(f"{tmp_path}/test_ogr2ogr_55.gml", "rt")
     content = f.read()
     f.close()
 
     assert "<ogr:fld2>2</ogr:fld2>" in content
 
-    os.unlink("tmp/test_ogr2ogr_55.gml")
-    os.unlink("tmp/test_ogr2ogr_55.xsd")
+
+@pytest.mark.require_driver("CSV")
+@pytest.mark.require_driver("GML")
+def test_ogr2ogr_55bis(ogr2ogr_path, ogr2ogr_55_vrt, tmp_path):
 
     # Test -unsetDefault
     gdaltest.runexternal(
-        ogr2ogr_path
-        + " -forceNullable -unsetDefault -f GML tmp/test_ogr2ogr_55.gml tmp/test_ogr2ogr_55.vrt"
+        f"{ogr2ogr_path} -forceNullable -unsetDefault -f GML {tmp_path}/test_ogr2ogr_55.gml {ogr2ogr_55_vrt}"
     )
 
-    f = open("tmp/test_ogr2ogr_55.gml", "rt")
+    f = open(f"{tmp_path}/test_ogr2ogr_55.gml", "rt")
     content = f.read()
     f.close()
 
     assert "<ogr:fld2>" not in content
-
-    os.unlink("tmp/test_ogr2ogr_55.gml")
-    os.unlink("tmp/test_ogr2ogr_55.xsd")
-
-    os.unlink("tmp/test_ogr2ogr_55.csv")
-    os.unlink("tmp/test_ogr2ogr_55.csvt")
-    os.unlink("tmp/test_ogr2ogr_55.vrt")
 
 
 ###############################################################################
@@ -2459,23 +1900,26 @@ def test_ogr2ogr_55(ogr2ogr_path):
 
 @pytest.mark.require_driver("CSV")
 @pytest.mark.require_driver("PGDump")
-def test_ogr2ogr_56(ogr2ogr_path):
+def test_ogr2ogr_56(ogr2ogr_path, tmp_path):
 
-    f = open("tmp/test_ogr2ogr_56.csv", "wt")
+    src_csv = str(tmp_path / "test_ogr2ogr_56.csv")
+    src_csvt = str(tmp_path / "test_ogr2ogr_56.csvt")
+    dst_sql = str(tmp_path / "test_ogr2ogr_56.sql")
+
+    f = open(src_csv, "wt")
     f.write("str,myid,WKT\n")
     f.write('aaa,10,"POINT(0 0)"\n')
     f.close()
 
-    f = open("tmp/test_ogr2ogr_56.csvt", "wt")
+    f = open(src_csvt, "wt")
     f.write("String,Integer,String\n")
     f.close()
 
     gdaltest.runexternal(
-        ogr2ogr_path
-        + " -f PGDump tmp/test_ogr2ogr_56.sql tmp/test_ogr2ogr_56.csv -lco FID=myid --config PGDUMP_DEBUG_ALLOW_CREATION_FIELD_WITH_FID_NAME NO"
+        f"{ogr2ogr_path} -f PGDump {dst_sql} {src_csv} -lco FID=myid --config PGDUMP_DEBUG_ALLOW_CREATION_FIELD_WITH_FID_NAME NO"
     )
 
-    f = open("tmp/test_ogr2ogr_56.sql", "rt")
+    f = open(dst_sql, "rt")
     content = f.read()
     f.close()
 
@@ -2488,49 +1932,47 @@ def test_ogr2ogr_56(ogr2ogr_path):
         in content
     )
 
-    os.unlink("tmp/test_ogr2ogr_56.sql")
-    os.unlink("tmp/test_ogr2ogr_56.csv")
-    os.unlink("tmp/test_ogr2ogr_56.csvt")
-
 
 ###############################################################################
 # Test default propagation of FID column name and values, and -unsetFid
 
 
+@pytest.fixture()
+def ogr2ogr_57_vrt(tmp_path):
+    with open(f"{tmp_path}/test_ogr2ogr_57.csv", "wt") as f:
+        f.write("id,str,WKT\n")
+        f.write('10,a,"POINT(0 0)"\n')
+
+    with open(f"{tmp_path}/test_ogr2ogr_57.csvt", "wt") as f:
+        f.write("Integer,String,String\n")
+
+    with open(f"{tmp_path}/test_ogr2ogr_57.vrt", "wt") as f:
+        f.write(
+            """<OGRVRTDataSource>
+      <OGRVRTLayer name="test_ogr2ogr_57">
+        <SrcDataSource relativeToVRT="1" shared="1">test_ogr2ogr_57.csv</SrcDataSource>
+        <SrcLayer>test_ogr2ogr_57</SrcLayer>
+        <GeometryType>wkbUnknown</GeometryType>
+        <GeometryField name="WKT"/>
+        <FID name="id">id</FID>
+        <Field name="str"/>
+      </OGRVRTLayer>
+    </OGRVRTDataSource>
+    """
+        )
+
+    return f"{tmp_path}/test_ogr2ogr_57.vrt"
+
+
 @pytest.mark.require_driver("CSV")
 @pytest.mark.require_driver("PGDump")
-def test_ogr2ogr_57(ogr2ogr_path):
+def test_ogr2ogr_57(ogr2ogr_path, ogr2ogr_57_vrt, tmp_path):
 
-    f = open("tmp/test_ogr2ogr_57.csv", "wt")
-    f.write("id,str,WKT\n")
-    f.write('10,a,"POINT(0 0)"\n')
-    f.close()
+    dst_sql = str(tmp_path / "test_ogr2ogr_57.sql")
 
-    f = open("tmp/test_ogr2ogr_57.csvt", "wt")
-    f.write("Integer,String,String\n")
-    f.close()
+    gdaltest.runexternal(f"{ogr2ogr_path} -f PGDump {dst_sql} {ogr2ogr_57_vrt}")
 
-    f = open("tmp/test_ogr2ogr_57.vrt", "wt")
-    f.write(
-        """<OGRVRTDataSource>
-  <OGRVRTLayer name="test_ogr2ogr_57">
-    <SrcDataSource relativeToVRT="1" shared="1">test_ogr2ogr_57.csv</SrcDataSource>
-    <SrcLayer>test_ogr2ogr_57</SrcLayer>
-    <GeometryType>wkbUnknown</GeometryType>
-    <GeometryField name="WKT"/>
-    <FID name="id">id</FID>
-    <Field name="str"/>
-  </OGRVRTLayer>
-</OGRVRTDataSource>
-"""
-    )
-    f.close()
-
-    gdaltest.runexternal(
-        ogr2ogr_path + " -f PGDump tmp/test_ogr2ogr_57.sql tmp/test_ogr2ogr_57.vrt"
-    )
-
-    f = open("tmp/test_ogr2ogr_57.sql", "rt")
+    f = open(dst_sql, "rt")
     content = f.read()
     f.close()
 
@@ -2543,15 +1985,19 @@ def test_ogr2ogr_57(ogr2ogr_path):
         in content
     )
 
-    os.unlink("tmp/test_ogr2ogr_57.sql")
+
+@pytest.mark.require_driver("CSV")
+@pytest.mark.require_driver("PGDump")
+def test_ogr2ogr_57bis(ogr2ogr_path, ogr2ogr_57_vrt, tmp_path):
+
+    dst_sql = str(tmp_path / "test_ogr2ogr_57bis.sql")
 
     # Test -unsetFid
     gdaltest.runexternal(
-        ogr2ogr_path
-        + " -f PGDump tmp/test_ogr2ogr_57.sql tmp/test_ogr2ogr_57.vrt -unsetFid"
+        f"{ogr2ogr_path} -f PGDump {dst_sql} {ogr2ogr_57_vrt} -unsetFid"
     )
 
-    f = open("tmp/test_ogr2ogr_57.sql", "rt")
+    f = open(dst_sql, "rt")
     content = f.read()
     f.close()
 
@@ -2564,41 +2010,36 @@ def test_ogr2ogr_57(ogr2ogr_path):
         in content
     )
 
-    os.unlink("tmp/test_ogr2ogr_57.sql")
-
-    os.unlink("tmp/test_ogr2ogr_57.csv")
-    os.unlink("tmp/test_ogr2ogr_57.csvt")
-    os.unlink("tmp/test_ogr2ogr_57.vrt")
-
 
 ###############################################################################
 # Test datasource transactions
 
 
 @pytest.mark.require_driver("SQLite")
-def test_ogr2ogr_58(ogr2ogr_path):
+def test_ogr2ogr_58(ogr2ogr_path, tmp_path):
+
+    dst_sqlite = str(tmp_path / "test_ogr2ogr_58.sqlite")
 
     gdaltest.runexternal(
-        ogr2ogr_path
-        + " -gt 3 -f SQLite tmp/test_ogr2ogr_58.sqlite ../ogr/data/poly.shp"
+        f"{ogr2ogr_path} -gt 3 -f SQLite {dst_sqlite} ../ogr/data/poly.shp"
     )
 
-    ds = ogr.Open("tmp/test_ogr2ogr_58.sqlite")
+    ds = ogr.Open(dst_sqlite)
     lyr = ds.GetLayer(0)
     assert lyr.GetFeatureCount() == 10
     ds = None
-
-    ogr.GetDriverByName("SQLite").DeleteDataSource("tmp/test_ogr2ogr_58.sqlite")
 
 
 ###############################################################################
 # Test metadata support
 
 
-@pytest.mark.require_driver("GPKG")
-def test_ogr2ogr_59(ogr2ogr_path):
+@pytest.fixture()
+def ogr2ogr_59_gpkg(tmp_path):
 
-    ds = ogr.GetDriverByName("GPKG").CreateDataSource("tmp/test_ogr2ogr_59_src.gpkg")
+    src_gpkg = str(tmp_path / "test_ogr2ogr_59_src.gpkg")
+
+    ds = ogr.GetDriverByName("GPKG").CreateDataSource(src_gpkg)
     ds.SetMetadataItem("FOO", "BAR")
     ds.SetMetadataItem("BAR", "BAZ", "another_domain")
     lyr = ds.CreateLayer("mylayer")
@@ -2606,12 +2047,19 @@ def test_ogr2ogr_59(ogr2ogr_path):
     lyr.SetMetadataItem("lyr_BAR", "lyr_BAZ", "lyr_another_domain")
     ds = None
 
+    return src_gpkg
+
+
+@pytest.mark.require_driver("GPKG")
+def test_ogr2ogr_59(ogr2ogr_path, ogr2ogr_59_gpkg, tmp_path):
+
+    dst_gpkg = str(tmp_path / "test_ogr2ogr_59_dest.gpkg")
+
     gdaltest.runexternal(
-        ogr2ogr_path
-        + " -f GPKG tmp/test_ogr2ogr_59_dest.gpkg tmp/test_ogr2ogr_59_src.gpkg -mo BAZ=BAW"
+        f"{ogr2ogr_path} -f GPKG {dst_gpkg} {ogr2ogr_59_gpkg} -mo BAZ=BAW"
     )
 
-    ds = ogr.Open("tmp/test_ogr2ogr_59_dest.gpkg")
+    ds = ogr.Open(dst_gpkg)
     assert ds.GetMetadata() == {"FOO": "BAR", "BAZ": "BAW"}
     assert ds.GetMetadata("another_domain") == {"BAR": "BAZ"}
     lyr = ds.GetLayer(0)
@@ -2619,21 +2067,18 @@ def test_ogr2ogr_59(ogr2ogr_path):
     assert lyr.GetMetadata("lyr_another_domain") == {"lyr_BAR": "lyr_BAZ"}
     ds = None
 
-    ogr.GetDriverByName("GPKG").DeleteDataSource("tmp/test_ogr2ogr_59_dest.gpkg")
 
-    gdaltest.runexternal(
-        ogr2ogr_path
-        + " -f GPKG tmp/test_ogr2ogr_59_dest.gpkg tmp/test_ogr2ogr_59_src.gpkg -nomd"
-    )
-    ds = ogr.Open("tmp/test_ogr2ogr_59_dest.gpkg")
+@pytest.mark.require_driver("GPKG")
+def test_ogr2ogr_59bis(ogr2ogr_path, ogr2ogr_59_gpkg, tmp_path):
+
+    dst_gpkg = str(tmp_path / "test_ogr2ogr_59bis_dest.gpkg")
+
+    gdaltest.runexternal(f"{ogr2ogr_path} -f GPKG {dst_gpkg} {ogr2ogr_59_gpkg} -nomd")
+    ds = ogr.Open(dst_gpkg)
     assert ds.GetMetadata() == {}
     lyr = ds.GetLayer(0)
     assert lyr.GetMetadata() == {}
     ds = None
-
-    ogr.GetDriverByName("GPKG").DeleteDataSource("tmp/test_ogr2ogr_59_dest.gpkg")
-
-    ogr.GetDriverByName("GPKG").DeleteDataSource("tmp/test_ogr2ogr_59_src.gpkg")
 
 
 ###############################################################################
@@ -2641,19 +2086,18 @@ def test_ogr2ogr_59(ogr2ogr_path):
 
 
 @pytest.mark.require_driver("OpenFileGDB")
-def test_ogr2ogr_60(ogr2ogr_path):
+def test_ogr2ogr_60(ogr2ogr_path, tmp_path):
+
+    dst_gdb = str(tmp_path / "test_ogr2ogr_60.gdb")
 
     gdaltest.runexternal(
-        ogr2ogr_path
-        + " -ds_transaction -f OpenFileGDB tmp/test_ogr2ogr_60.gdb ../ogr/data/poly.shp -mapFieldType Integer64=Integer"
+        f"{ogr2ogr_path} -ds_transaction -f OpenFileGDB {dst_gdb} ../ogr/data/poly.shp -mapFieldType Integer64=Integer"
     )
 
-    ds = ogr.Open("tmp/test_ogr2ogr_60.gdb")
+    ds = ogr.Open(dst_gdb)
     lyr = ds.GetLayer(0)
     assert lyr.GetFeatureCount() == 10
     ds = None
-
-    ogr.GetDriverByName("OpenFileGDB").DeleteDataSource("tmp/test_ogr2ogr_60.gdb")
 
 
 ###############################################################################
@@ -2661,73 +2105,78 @@ def test_ogr2ogr_60(ogr2ogr_path):
 
 
 @pytest.mark.require_driver("CSV")
-def test_ogr2ogr_61(ogr2ogr_path):
+def test_ogr2ogr_61(ogr2ogr_path, tmp_path):
 
-    f = open("tmp/test_ogr2ogr_61.csv", "wt")
+    src_csv = str(tmp_path / "test_ogr2ogr_61.csv")
+    dst_shp = str(tmp_path / "test_ogr2ogr_61.shp")
+    dst2_shp = str(tmp_path / "test_ogr2ogr_61b.shp")
+
+    f = open(src_csv, "wt")
     f.write("foo,WKT\n")
     f.write('1,"POINT(2 49)"\n')
     f.close()
 
     gdaltest.runexternal(
-        ogr2ogr_path
-        + " tmp/test_ogr2ogr_61.shp tmp/test_ogr2ogr_61.csv -spat 426857 5427937 426858 5427938 -spat_srs EPSG:32631 -s_srs EPSG:4326 -a_srs EPSG:4326"
+        f"{ogr2ogr_path} {dst_shp} {src_csv} -spat 426857 5427937 426858 5427938 -spat_srs EPSG:32631 -s_srs EPSG:4326 -a_srs EPSG:4326"
     )
 
-    ds = ogr.Open("tmp/test_ogr2ogr_61.shp")
+    ds = ogr.Open(dst_shp)
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 1
     ds.Destroy()
 
     gdaltest.runexternal(
-        ogr2ogr_path
-        + " tmp/test_ogr2ogr_61_2.shp tmp/test_ogr2ogr_61.shp -spat 426857 5427937 426858 5427938 -spat_srs EPSG:32631"
+        f"{ogr2ogr_path} {dst2_shp} {dst_shp} -spat 426857 5427937 426858 5427938 -spat_srs EPSG:32631"
     )
 
-    ds = ogr.Open("tmp/test_ogr2ogr_61_2.shp")
+    ds = ogr.Open(dst2_shp)
     assert ds is not None and ds.GetLayer(0).GetFeatureCount() == 1
     ds.Destroy()
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/test_ogr2ogr_61.shp")
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/test_ogr2ogr_61_2.shp")
-    os.unlink("tmp/test_ogr2ogr_61.csv")
 
 
 ###############################################################################
 # Test -noNativeData
 
 
-def test_ogr2ogr_62(ogr2ogr_path):
+@pytest.fixture()
+def ogr2ogr_62_json(tmp_path):
+
+    fname = str(tmp_path / "test_ogr2ogr_62_in.json")
+
+    with open(fname, "wt") as fp:
+        fp.write(
+            '{"type": "FeatureCollection", "foo": "bar", "features":[ { "type": "Feature", "bar": "baz", "properties": { "myprop": "myvalue" }, "geometry": null } ]}'
+        )
+
+    return fname
+
+
+def test_ogr2ogr_62(ogr2ogr_path, ogr2ogr_62_json, tmp_path):
+
+    dst_json = str(tmp_path / "test_ogr2ogr_62.json")
 
     # Default behaviour
 
-    fp = open("tmp/test_ogr2ogr_62_in.json", "wt")
-    fp.write(
-        '{"type": "FeatureCollection", "foo": "bar", "features":[ { "type": "Feature", "bar": "baz", "properties": { "myprop": "myvalue" }, "geometry": null } ]}'
-    )
-    fp = None
-
-    gdaltest.runexternal(
-        ogr2ogr_path
-        + """ -f GeoJSON tmp/test_ogr2ogr_62.json tmp/test_ogr2ogr_62_in.json"""
-    )
-    fp = gdal.VSIFOpenL("tmp/test_ogr2ogr_62.json", "rb")
+    gdaltest.runexternal(f"{ogr2ogr_path} -f GeoJSON {dst_json} {ogr2ogr_62_json}")
+    fp = gdal.VSIFOpenL(dst_json, "rb")
     assert fp is not None
     data = gdal.VSIFReadL(1, 10000, fp).decode("ascii")
     gdal.VSIFCloseL(fp)
-    os.unlink("tmp/test_ogr2ogr_62.json")
 
     assert "bar" in data and "baz" in data
 
+
+def test_ogr2ogr_62bis(ogr2ogr_path, ogr2ogr_62_json, tmp_path):
+
+    dst_json = str(tmp_path / "test_ogr2ogr_62bis.json")
+
     # Test -noNativeData
     gdaltest.runexternal(
-        ogr2ogr_path
-        + """ -f GeoJSON tmp/test_ogr2ogr_62.json tmp/test_ogr2ogr_62_in.json -noNativeData"""
+        f"{ogr2ogr_path} -f GeoJSON {dst_json} {ogr2ogr_62_json} -noNativeData"
     )
-    fp = gdal.VSIFOpenL("tmp/test_ogr2ogr_62.json", "rb")
+    fp = gdal.VSIFOpenL(dst_json, "rb")
     assert fp is not None
     data = gdal.VSIFReadL(1, 10000, fp).decode("ascii")
     gdal.VSIFCloseL(fp)
-    os.unlink("tmp/test_ogr2ogr_62.json")
-    os.unlink("tmp/test_ogr2ogr_62_in.json")
 
     assert "bar" not in data and "baz" not in data
 
@@ -2737,12 +2186,6 @@ def test_ogr2ogr_62(ogr2ogr_path):
 
 
 def test_ogr2ogr_63(ogr2ogr_path):
-
-    try:
-        os.stat("tmp/poly.shp")
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/poly.shp")
-    except (OSError, AttributeError):
-        pass
 
     (ret, err) = gdaltest.runexternal_out_and_err(ogr2ogr_path + " --formats")
     assert "Supported Formats" in ret, err
@@ -2754,38 +2197,27 @@ def test_ogr2ogr_63(ogr2ogr_path):
 
 
 @pytest.mark.require_driver("CSV")
-def test_ogr2ogr_64(ogr2ogr_path):
+def test_ogr2ogr_64(ogr2ogr_path, tmp_path):
 
-    try:
-        shutil.rmtree("tmp/in_csv")
-    except OSError:
-        pass
-    try:
-        shutil.rmtree("tmp/out_csv")
-    except OSError:
-        pass
+    in_csv = str(tmp_path / "in_csv")
+    out_csv = str(tmp_path / "out_csv")
 
-    os.mkdir("tmp/in_csv")
-    open("tmp/in_csv/lyr1.csv", "wt").write("id,col\n1,1\n")
-    open("tmp/in_csv/lyr2.csv", "wt").write("id,col\n1,1\n")
+    os.mkdir(in_csv)
+    open(f"{in_csv}/lyr1.csv", "wt").write("id,col\n1,1\n")
+    open(f"{in_csv}/lyr2.csv", "wt").write("id,col\n1,1\n")
 
-    ds = ogr.Open("tmp/in_csv")
+    ds = ogr.Open(in_csv)
     first_layer = ds.GetLayer(0).GetName()
     second_layer = ds.GetLayer(1).GetName()
     ds = None
 
-    gdaltest.runexternal(
-        ogr2ogr_path + " -f CSV tmp/out_csv tmp/in_csv " + second_layer
-    )
-    gdaltest.runexternal(ogr2ogr_path + " -append tmp/out_csv tmp/in_csv")
+    gdaltest.runexternal(f"{ogr2ogr_path} -f CSV {out_csv} {in_csv} {second_layer}")
+    gdaltest.runexternal(f"{ogr2ogr_path} -append {out_csv} {in_csv}")
 
-    ds = ogr.Open("tmp/out_csv")
+    ds = ogr.Open(out_csv)
     assert ds.GetLayerByName(first_layer).GetFeatureCount() == 1
     assert ds.GetLayerByName(second_layer).GetFeatureCount() == 2
     ds = None
-
-    shutil.rmtree("tmp/in_csv")
-    shutil.rmtree("tmp/out_csv")
 
 
 ###############################################################################
@@ -2793,13 +2225,14 @@ def test_ogr2ogr_64(ogr2ogr_path):
 
 
 @pytest.mark.require_driver("CSV")
-def test_ogr2ogr_65(ogr2ogr_path):
+def test_ogr2ogr_65(ogr2ogr_path, tmp_path):
 
-    gdaltest.runexternal(ogr2ogr_path + " tmp/out.csv ../ogr/data/poly.shp")
-    ds = gdal.OpenEx("tmp/out.csv")
+    dst_csv = str(tmp_path / "out.csv")
+
+    gdaltest.runexternal(f"{ogr2ogr_path} {dst_csv} ../ogr/data/poly.shp")
+    ds = gdal.OpenEx(dst_csv)
     assert ds.GetDriver().ShortName == "CSV"
     ds = None
-    gdal.Unlink("tmp/out.csv")
 
     (ret, err) = gdaltest.runexternal_out_and_err(
         ogr2ogr_path + " /vsimem/out.xxx ../ogr/data/poly.shp"
@@ -2836,22 +2269,18 @@ def hexify_double(val):
 # If the coordinates are converted to radians and back to degrees the value of x will be altered
 @pytest.mark.parametrize("x,y,srid", [(float.fromhex("0x1.5EB3ED959A307p6"), 0, 4326)])
 @pytest.mark.require_driver("CSV")
-def test_ogr2ogr_check_identity_transformation(ogr2ogr_path, x, y, srid):
+def test_ogr2ogr_check_identity_transformation(ogr2ogr_path, tmp_path, x, y, srid):
     import struct
 
-    shape_drv = ogr.GetDriverByName("ESRI Shapefile")
-    for output_shp in ["tmp/output_point.shp", "tmp/output_point2.shp"]:
-        try:
-            os.stat(output_shp)
-            shape_drv.DeleteDataSource(output_shp)
-        except OSError:
-            pass
+    src_csv = str(tmp_path / "input_point.csv")
+    dst1_shp = str(tmp_path / "output_point.shp")
+    dst2_shp = str(tmp_path / "output_point2.shp")
 
     # Generate CSV file with test point
     xy_wkb = "0101000000" + "".join(
         hexify_double(q) for q in struct.unpack(">QQ", struct.pack("<dd", x, y))
     )
-    f = open("tmp/input_point.csv", "wt")
+    f = open(src_csv, "wt")
     f.write("id,wkb_geom\n")
     f.write("1," + xy_wkb + "\n")
     f.close()
@@ -2863,33 +2292,18 @@ def test_ogr2ogr_check_identity_transformation(ogr2ogr_path, x, y, srid):
     # Note that when transforming CSV to SHP the same internal definition of EPSG:srid is being used for source and target,
     # so that this transformation will have identically defined input and output units
     gdaltest.runexternal(
-        ogr2ogr_path
-        + " tmp/output_point.shp tmp/input_point.csv -oo GEOM_POSSIBLE_NAMES=wkb_geom -s_srs EPSG:%(srid)d  -t_srs EPSG:%(srid)d"
-        % locals()
+        f"{ogr2ogr_path} {dst1_shp} {src_csv} -oo GEOM_POSSIBLE_NAMES=wkb_geom -s_srs EPSG:{srid} -t_srs EPSG:{srid}"
     )
 
-    ds = ogr.Open("tmp/output_point.shp")
-    feat = ds.GetLayer(0).GetNextFeature()
-    try:
+    with ogr.Open(dst1_shp) as ds:
+        feat = ds.GetLayer(0).GetNextFeature()
         assert feat.GetGeometryRef().GetX() == x and feat.GetGeometryRef().GetY() == y
-    finally:
-        feat.Destroy()
-        ds.Destroy()
-        os.remove("tmp/input_point.csv")
 
     # Now, transforming SHP to SHP will have a different definition of the SRS (EPSG:srid) which comes from the previously saved .prj file
     # For angular units in degrees the .prj is saved with greater precision than the internally used value.
     # We perform this additional transformation to exercise the case of units defined with different precision
-    gdaltest.runexternal(
-        ogr2ogr_path
-        + " tmp/output_point2.shp tmp/output_point.shp -t_srs EPSG:%(srid)d" % locals()
-    )
-    ds = ogr.Open("tmp/output_point2.shp")
+    gdaltest.runexternal(f"{ogr2ogr_path} {dst2_shp} {dst1_shp} -t_srs EPSG:{srid}")
+    ds = ogr.Open(dst2_shp)
     feat = ds.GetLayer(0).GetNextFeature()
-    try:
-        assert feat.GetGeometryRef().GetX() == x and feat.GetGeometryRef().GetY() == y
-    finally:
-        feat.Destroy()
-        ds.Destroy()
-        shape_drv.DeleteDataSource("tmp/output_point.shp")
-        shape_drv.DeleteDataSource("tmp/output_point2.shp")
+
+    assert feat.GetGeometryRef().GetX() == x and feat.GetGeometryRef().GetY() == y

--- a/autotest/utilities/test_ogr2ogr_lib.py
+++ b/autotest/utilities/test_ogr2ogr_lib.py
@@ -1912,9 +1912,9 @@ def test_ogr2ogr_lib_valid_nlt_combinations(nlt_value):
 @pytest.mark.skipif(
     test_cli_utilities.get_ogrinfo_path() is None, reason="ogrinfo not available"
 )
-def test_ogr2ogr_lib_geojson_output():
+def test_ogr2ogr_lib_geojson_output(tmp_path):
 
-    tmpfilename = "tmp/out.geojson"
+    tmpfilename = str(tmp_path / "out.geojson")
     out_ds = gdal.VectorTranslate(tmpfilename, "../ogr/data/poly.shp")
 
     # Check that the file can be read at that point. Use an external process
@@ -1933,5 +1933,3 @@ def test_ogr2ogr_lib_geojson_output():
     with ogr.Open(tmpfilename) as ds:
         lyr = ds.GetLayer(0)
         assert lyr.GetFeatureCount() == 11
-
-    gdal.Unlink(tmpfilename)

--- a/autotest/utilities/test_ogrinfo.py
+++ b/autotest/utilities/test_ogrinfo.py
@@ -29,7 +29,7 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
-import os
+import pathlib
 
 import gdaltest
 import ogrtest
@@ -246,7 +246,9 @@ def test_ogrinfo_16(ogrinfo_path):
 # Test erroneous use of --optfile.
 
 
-def test_ogrinfo_17(ogrinfo_path):
+def test_ogrinfo_17(ogrinfo_path, tmp_path):
+
+    optfile_txt = str(tmp_path / "optfile.txt")
 
     (_, err) = gdaltest.runexternal_out_and_err(
         ogrinfo_path + " --optfile", check_memleak=False
@@ -259,14 +261,13 @@ def test_ogrinfo_17(ogrinfo_path):
     )
     assert "Unable to open optfile" in err
 
-    f = open("tmp/optfile.txt", "wt")
+    f = open(optfile_txt, "wt")
     f.write("--config foo\n")
     f.close()
     (_, err) = gdaltest.runexternal_out_and_err(
-        ogrinfo_path + " --optfile tmp/optfile.txt",
+        ogrinfo_path + f" --optfile {optfile_txt}",
         check_memleak=False,
     )
-    os.unlink("tmp/optfile.txt")
     assert "--config option given without a key and value argument" in err
 
 
@@ -274,17 +275,18 @@ def test_ogrinfo_17(ogrinfo_path):
 # Test --optfile
 
 
-def test_ogrinfo_18(ogrinfo_path):
+def test_ogrinfo_18(ogrinfo_path, tmp_path):
 
-    f = open("tmp/optfile.txt", "wt")
+    optfile_txt = str(tmp_path / "optfile.txt")
+
+    f = open(optfile_txt, "wt")
     f.write("# comment\n")
     f.write("../ogr/data/poly.shp\n")
     f.close()
     ret = gdaltest.runexternal(
-        ogrinfo_path + " --optfile tmp/optfile.txt",
+        ogrinfo_path + f" --optfile {optfile_txt}",
         check_memleak=False,
     )
-    os.unlink("tmp/optfile.txt")
     assert "ESRI Shapefile" in ret
 
 
@@ -326,24 +328,26 @@ def test_ogrinfo_21(ogrinfo_path):
 
 
 @pytest.mark.require_driver("CSV")
-def test_ogrinfo_22(ogrinfo_path):
+def test_ogrinfo_22(ogrinfo_path, tmp_path):
 
-    f = open("tmp/test_ogrinfo_22.csv", "wt")
+    csv_fname = str(tmp_path / "test_ogrinfo_22.csv")
+
+    f = open(csv_fname, "wt")
     f.write("_WKTgeom1_EPSG_4326,_WKTgeom2_EPSG_32631\n")
     f.write('"POINT(1 2)","POINT(3 4)"\n')
     f.close()
 
     ret = gdaltest.runexternal(
-        ogrinfo_path + " tmp/test_ogrinfo_22.csv",
+        ogrinfo_path + f" {csv_fname}",
         check_memleak=False,
     )
     assert "1: test_ogrinfo_22 (Unknown (any), Unknown (any))" in ret
 
     ret = gdaltest.runexternal(
-        ogrinfo_path + " -al -wkt_format wkt1 tmp/test_ogrinfo_22.csv",
+        ogrinfo_path + f" -al -wkt_format wkt1 {csv_fname}",
         check_memleak=False,
     )
-    expected_ret = """INFO: Open of `tmp/test_ogrinfo_22.csv'
+    expected_ret = f"""INFO: Open of `{csv_fname}'
       using driver `CSV' successful.
 
 Layer name: test_ogrinfo_22
@@ -405,17 +409,17 @@ OGRFeature(test_ogrinfo_22):1
     for i, exp_line in enumerate(expected_lines):
         assert exp_line == lines[i], ret
 
-    os.unlink("tmp/test_ogrinfo_22.csv")
-
 
 ###############################################################################
 # Test -geomfield (RFC 41) support
 
 
 @pytest.mark.require_driver("CSV")
-def test_ogrinfo_23(ogrinfo_path):
+def test_ogrinfo_23(ogrinfo_path, tmp_path):
 
-    f = open("tmp/test_ogrinfo_23.csv", "wt")
+    csv_fname = str(tmp_path / "test_ogrinfo_23.csv")
+
+    f = open(csv_fname, "wt")
     f.write("_WKTgeom1_EPSG_4326,_WKTgeom2_EPSG_32631\n")
     f.write('"POINT(1 2)","POINT(3 4)"\n')
     f.write('"POINT(3 4)","POINT(1 2)"\n')
@@ -423,10 +427,10 @@ def test_ogrinfo_23(ogrinfo_path):
 
     ret = gdaltest.runexternal(
         ogrinfo_path
-        + " -al tmp/test_ogrinfo_23.csv -wkt_format wkt1 -spat 1 2 1 2 -geomfield geom__WKTgeom2_EPSG_32631",
+        + f" -al {csv_fname} -wkt_format wkt1 -spat 1 2 1 2 -geomfield geom__WKTgeom2_EPSG_32631",
         check_memleak=False,
     )
-    expected_ret = """INFO: Open of `tmp/test_ogrinfo_23.csv'
+    expected_ret = f"""INFO: Open of `{csv_fname}'
       using driver `CSV' successful.
 
 Layer name: test_ogrinfo_23
@@ -488,18 +492,19 @@ OGRFeature(test_ogrinfo_23):2
     for i, exp_line in enumerate(expected_lines):
         assert exp_line == lines[i], ret
 
-    os.unlink("tmp/test_ogrinfo_23.csv")
-
 
 ###############################################################################
 # Test metadata
 
 
-def test_ogrinfo_24(ogrinfo_path):
+def test_ogrinfo_24(ogrinfo_path, tmp_path):
 
-    f = open("tmp/test_ogrinfo_24.vrt", "wt")
+    vrt_fname = str(tmp_path / "test_ogrinfo_24.vrt")
+    poly_shp = str(pathlib.Path(__file__).parent.parent / "ogr" / "data" / "poly.shp")
+
+    f = open(vrt_fname, "wt")
     f.write(
-        """<OGRVRTDataSource>
+        f"""<OGRVRTDataSource>
     <Metadata>
         <MDI key="foo">bar</MDI>
     </Metadata>
@@ -510,7 +515,7 @@ def test_ogrinfo_24(ogrinfo_path):
         <Metadata>
             <MDI key="bar">baz</MDI>
         </Metadata>
-        <SrcDataSource relativeToVRT="1" shared="1">../../ogr/data/poly.shp</SrcDataSource>
+        <SrcDataSource relativeToVRT="0" shared="1">{poly_shp}</SrcDataSource>
         <SrcLayer>poly</SrcLayer>
   </OGRVRTLayer>
 </OGRVRTDataSource>"""
@@ -518,14 +523,14 @@ def test_ogrinfo_24(ogrinfo_path):
     f.close()
 
     ret = gdaltest.runexternal(
-        ogrinfo_path + " -ro -al tmp/test_ogrinfo_24.vrt -so",
+        ogrinfo_path + f" -ro -al {vrt_fname} -so",
         check_memleak=False,
     )
     assert "foo=bar" in ret
     assert "bar=baz" in ret
 
     ret = gdaltest.runexternal(
-        ogrinfo_path + " -ro -al tmp/test_ogrinfo_24.vrt -so -mdd all",
+        ogrinfo_path + f" -ro -al {vrt_fname} -so -mdd all",
         check_memleak=False,
     )
     assert "foo=bar" in ret
@@ -533,12 +538,10 @@ def test_ogrinfo_24(ogrinfo_path):
     assert "bar=baz" in ret
 
     ret = gdaltest.runexternal(
-        ogrinfo_path + " -ro -al tmp/test_ogrinfo_24.vrt -so -nomd",
+        ogrinfo_path + f" -ro -al {vrt_fname} -so -nomd",
         check_memleak=False,
     )
     assert "Metadata" not in ret
-
-    os.unlink("tmp/test_ogrinfo_24.vrt")
 
 
 ###############################################################################
@@ -558,15 +561,16 @@ def test_ogrinfo_25(ogrinfo_path):
 # Test SQLStatement with -sql @filename syntax
 
 
-def test_ogrinfo_sql_filename(ogrinfo_path):
+def test_ogrinfo_sql_filename(ogrinfo_path, tmp_path):
 
-    open("tmp/my.sql", "wt").write(
+    sql_fname = str(tmp_path / "my.sql")
+
+    open(sql_fname, "wt").write(
         """-- initial comment\nselect\n'--''--',* from --comment\npoly\n-- trailing comment"""
     )
     (ret, err) = gdaltest.runexternal_out_and_err(
-        ogrinfo_path + " -q ../ogr/data/poly.shp -sql @tmp/my.sql"
+        ogrinfo_path + f" -q ../ogr/data/poly.shp -sql @{sql_fname}"
     )
-    os.unlink("tmp/my.sql")
     assert err is None or err == "", "got error/warning"
     assert "OGRFeature(poly):0" in ret and "OGRFeature(poly):9" in ret, "wrong output"
 

--- a/autotest/utilities/test_ogrlineref.py
+++ b/autotest/utilities/test_ogrlineref.py
@@ -103,24 +103,20 @@ def test_ogrlineref_3(ogrlineref_path, parts_shp):
 # get_subline test
 
 
-def test_ogrlineref_4(ogrlineref_path, parts_shp):
+def test_ogrlineref_4(ogrlineref_path, parts_shp, tmp_path):
 
-    if os.path.exists("tmp/subline.shp"):
-        ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/subline.shp")
+    output_shp = str(tmp_path / "subline.shp")
 
     gdaltest.runexternal(
-        ogrlineref_path
-        + f" -get_subline -r {parts_shp} -mb 13300 -me 17400 -o tmp/subline.shp"
+        f"{ogrlineref_path} -get_subline -r {parts_shp} -mb 13300 -me 17400 -o {output_shp}"
     )
 
-    ds = ogr.Open("tmp/subline.shp")
+    ds = ogr.Open(output_shp)
     assert ds is not None, "ds is None"
 
     feature_count = ds.GetLayer(0).GetFeatureCount()
     assert feature_count == 1, "feature count %d != 1" % feature_count
     ds = None
-
-    ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/subline.shp")
 
 
 ###############################################################################
@@ -131,12 +127,8 @@ def test_ogrlineref_5(ogrlineref_path, tmp_path):
 
     parts_kml = str(tmp_path / "parts.kml")
 
-    if os.path.exists("tmp/parts.kml"):
-        ogr.GetDriverByName("KML").DeleteDataSource("tmp/parts.kml")
-
     gdaltest.runexternal_out_and_err(
-        ogrlineref_path
-        + f' -create -f "KML" -l data/path.shp -p data/mstones.shp -pm pos -o {parts_kml} -s 222'
+        f'{ogrlineref_path} -create -f "KML" -l data/path.shp -p data/mstones.shp -pm pos -o {parts_kml} -s 222'
     )
 
     assert os.path.exists(parts_kml)

--- a/autotest/utilities/test_ogrtindex.py
+++ b/autotest/utilities/test_ogrtindex.py
@@ -29,8 +29,6 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
-import os
-
 import gdaltest
 import ogrtest
 import pytest
@@ -48,72 +46,46 @@ def ogrtindex_path():
     return test_cli_utilities.get_ogrtindex_path()
 
 
-@pytest.fixture(scope="module", autouse=True)
-def setup_and_cleanup():
-
-    yield
-
-    shape_drv = ogr.GetDriverByName("ESRI Shapefile")
-    if os.path.exists("tmp/tileindex.shp"):
-        shape_drv.DeleteDataSource("tmp/tileindex.shp")
-    shape_drv.DeleteDataSource("tmp/point1.shp")
-    shape_drv.DeleteDataSource("tmp/point2.shp")
-    if os.path.exists("tmp/point3.shp"):
-        shape_drv.DeleteDataSource("tmp/point3.shp")
-    if os.path.exists("tmp/point4.shp"):
-        shape_drv.DeleteDataSource("tmp/point4.shp")
-
-
 ###############################################################################
 # Simple test
 
 
-def test_ogrtindex_1(ogrtindex_path, srs=None):
+@pytest.mark.parametrize("srs", (None, 4326))
+def test_ogrtindex_1(ogrtindex_path, tmp_path, srs):
+
+    if srs:
+        srs_obj = osr.SpatialReference()
+        srs_obj.ImportFromEPSG(srs)
+        srs = srs_obj
 
     shape_drv = ogr.GetDriverByName("ESRI Shapefile")
+    with shape_drv.CreateDataSource(str(tmp_path)) as shape_ds:
+        shape_lyr = shape_ds.CreateLayer("point1", srs=srs)
+        dst_feat = ogr.Feature(feature_def=shape_lyr.GetLayerDefn())
+        dst_feat.SetGeometry(ogr.CreateGeometryFromWkt("POINT(49 2)"))
+        shape_lyr.CreateFeature(dst_feat)
 
-    for basename in ["tileindex", "point1", "point2", "point3", "point4"]:
-        for extension in ["shp", "dbf", "shx", "prj"]:
-            try:
-                os.remove("tmp/%s.%s" % (basename, extension))
-            except OSError:
-                pass
+        shape_lyr = shape_ds.CreateLayer("point2", srs=srs)
+        dst_feat = ogr.Feature(feature_def=shape_lyr.GetLayerDefn())
+        dst_feat.SetGeometry(ogr.CreateGeometryFromWkt("POINT(49 3)"))
+        shape_lyr.CreateFeature(dst_feat)
 
-    shape_ds = shape_drv.CreateDataSource("tmp")
+        shape_lyr = shape_ds.CreateLayer("point3", srs=srs)
+        dst_feat = ogr.Feature(feature_def=shape_lyr.GetLayerDefn())
+        dst_feat.SetGeometry(ogr.CreateGeometryFromWkt("POINT(48 2)"))
+        shape_lyr.CreateFeature(dst_feat)
 
-    shape_lyr = shape_ds.CreateLayer("point1", srs=srs)
-    dst_feat = ogr.Feature(feature_def=shape_lyr.GetLayerDefn())
-    dst_feat.SetGeometry(ogr.CreateGeometryFromWkt("POINT(49 2)"))
-    shape_lyr.CreateFeature(dst_feat)
-    dst_feat.Destroy()
-
-    shape_lyr = shape_ds.CreateLayer("point2", srs=srs)
-    dst_feat = ogr.Feature(feature_def=shape_lyr.GetLayerDefn())
-    dst_feat.SetGeometry(ogr.CreateGeometryFromWkt("POINT(49 3)"))
-    shape_lyr.CreateFeature(dst_feat)
-    dst_feat.Destroy()
-
-    shape_lyr = shape_ds.CreateLayer("point3", srs=srs)
-    dst_feat = ogr.Feature(feature_def=shape_lyr.GetLayerDefn())
-    dst_feat.SetGeometry(ogr.CreateGeometryFromWkt("POINT(48 2)"))
-    shape_lyr.CreateFeature(dst_feat)
-    dst_feat.Destroy()
-
-    shape_lyr = shape_ds.CreateLayer("point4", srs=srs)
-    dst_feat = ogr.Feature(feature_def=shape_lyr.GetLayerDefn())
-    dst_feat.SetGeometry(ogr.CreateGeometryFromWkt("POINT(48 3)"))
-    shape_lyr.CreateFeature(dst_feat)
-    dst_feat.Destroy()
-
-    shape_ds.Destroy()
+        shape_lyr = shape_ds.CreateLayer("point4", srs=srs)
+        dst_feat = ogr.Feature(feature_def=shape_lyr.GetLayerDefn())
+        dst_feat.SetGeometry(ogr.CreateGeometryFromWkt("POINT(48 3)"))
+        shape_lyr.CreateFeature(dst_feat)
 
     (_, err) = gdaltest.runexternal_out_and_err(
-        ogrtindex_path
-        + " -skip_different_projection tmp/tileindex.shp tmp/point1.shp tmp/point2.shp tmp/point3.shp tmp/point4.shp"
+        f"{ogrtindex_path} -skip_different_projection {tmp_path}/tileindex.shp {tmp_path}/point1.shp {tmp_path}/point2.shp {tmp_path}/point3.shp {tmp_path}/point4.shp"
     )
     assert err is None or err == "", "got error/warning"
 
-    ds = ogr.Open("tmp/tileindex.shp")
+    ds = ogr.Open(f"{tmp_path}/tileindex.shp")
     assert ds.GetLayer(0).GetFeatureCount() == 4, "did not get expected feature count"
 
     if srs is not None:
@@ -133,53 +105,49 @@ def test_ogrtindex_1(ogrtindex_path, srs=None):
         "POLYGON ((48 2,48 2,48 2,48 2,48 2))",
         "POLYGON ((48 3,48 3,48 3,48 3,48 3))",
     ]
-    i = 0
-    feat = ds.GetLayer(0).GetNextFeature()
-    while feat is not None:
+
+    for i, feat in enumerate(ds.GetLayer(0)):
         assert (
             feat.GetGeometryRef().ExportToWkt() == expected_wkts[i]
         ), "i=%d, wkt=%s" % (i, feat.GetGeometryRef().ExportToWkt())
-        i = i + 1
-        feat = ds.GetLayer(0).GetNextFeature()
-    ds.Destroy()
-
-
-###############################################################################
-# Same test but with a SRS set on the different tiles to index
-
-
-def test_ogrtindex_2(ogrtindex_path):
-
-    srs = osr.SpatialReference()
-    srs.ImportFromEPSG(4326)
-
-    return test_ogrtindex_1(ogrtindex_path, srs)
 
 
 ###############################################################################
 # Test -src_srs_name, -src_srs_format and -t_srs
 
 
-def test_ogrtindex_3(ogrtindex_path):
+def epsg_to_wkt(srid):
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(srid)
+    return srs.ExportToWkt()
+
+
+@pytest.mark.parametrize(
+    "src_srs_format,expected_srss",
+    [
+        ("", ["EPSG:4326", "EPSG:32631"]),
+        ("-src_srs_format AUTO", ["EPSG:4326", "EPSG:32631"]),
+        ("-src_srs_format EPSG", ["EPSG:4326", "EPSG:32631"]),
+        (
+            "-src_srs_format PROJ",
+            [
+                "+proj=longlat +datum=WGS84 +no_defs",
+                "+proj=utm +zone=31 +datum=WGS84 +units=m +no_defs",
+            ],
+        ),
+        ("-src_srs_format WKT", [epsg_to_wkt(4326), epsg_to_wkt(32631)]),
+    ],
+)
+def test_ogrtindex_3(ogrtindex_path, tmp_path, src_srs_format, expected_srss):
 
     shape_drv = ogr.GetDriverByName("ESRI Shapefile")
-
-    for basename in ["tileindex", "point1", "point2", "point3", "point4"]:
-        for extension in ["shp", "dbf", "shx", "prj"]:
-            try:
-                os.remove("tmp/%s.%s" % (basename, extension))
-            except OSError:
-                pass
-
-    shape_ds = shape_drv.CreateDataSource("tmp")
+    shape_ds = shape_drv.CreateDataSource(str(tmp_path))
 
     srs_4326 = osr.SpatialReference()
     srs_4326.ImportFromEPSG(4326)
-    wkt_epsg_4326 = srs_4326.ExportToWkt()
 
     srs_32631 = osr.SpatialReference()
     srs_32631.ImportFromEPSG(32631)
-    wkt_epsg_32631 = srs_32631.ExportToWkt()
 
     shape_lyr = shape_ds.CreateLayer("point1", srs=srs_4326)
     dst_feat = ogr.Feature(feature_def=shape_lyr.GetLayerDefn())
@@ -192,73 +160,41 @@ def test_ogrtindex_3(ogrtindex_path):
     shape_lyr.CreateFeature(dst_feat)
     shape_ds = None
 
-    for (src_srs_format, expected_srss) in [
-        ("", ["EPSG:4326", "EPSG:32631"]),
-        ("-src_srs_format AUTO", ["EPSG:4326", "EPSG:32631"]),
-        ("-src_srs_format EPSG", ["EPSG:4326", "EPSG:32631"]),
-        (
-            "-src_srs_format PROJ",
-            [
-                "+proj=longlat +datum=WGS84 +no_defs",
-                "+proj=utm +zone=31 +datum=WGS84 +units=m +no_defs",
-            ],
-        ),
-        ("-src_srs_format WKT", [wkt_epsg_4326, wkt_epsg_32631]),
-    ]:
+    output_filename = str(tmp_path / "tileindex.shp")
+    output_format = ""
+    if src_srs_format == "-src_srs_format WKT":
+        if ogr.GetDriverByName("SQLite") is None:
+            pytest.skip("SQLite driver not available")
+        output_filename = str(tmp_path / "tileindex.shp")
+        output_format = " -f SQLite"
 
-        if os.path.exists("tmp/tileindex.shp"):
-            shape_drv.DeleteDataSource("tmp/tileindex.shp")
-        if os.path.exists("tmp/tileindex.db"):
-            os.unlink("tmp/tileindex.db")
+    (_, err) = gdaltest.runexternal_out_and_err(
+        ogrtindex_path
+        + " -src_srs_name src_srs -t_srs EPSG:4326 "
+        + output_filename
+        + f" {tmp_path}/point1.shp {tmp_path}/point2.shp "
+        + src_srs_format
+        + output_format
+    )
 
-        output_filename = "tmp/tileindex.shp"
-        output_format = ""
-        if src_srs_format == "-src_srs_format WKT":
-            if ogr.GetDriverByName("SQLite") is None:
-                continue
-            output_filename = "tmp/tileindex.db"
-            output_format = " -f SQLite"
+    assert src_srs_format == "-src_srs_format WKT" or (
+        err is None or err == ""
+    ), "got error/warning"
 
-        (_, err) = gdaltest.runexternal_out_and_err(
-            ogrtindex_path
-            + " -src_srs_name src_srs -t_srs EPSG:4326 "
-            + output_filename
-            + " tmp/point1.shp tmp/point2.shp "
-            + src_srs_format
-            + output_format
-        )
+    ds = ogr.Open(output_filename)
+    assert ds.GetLayer(0).GetFeatureCount() == 2, "did not get expected feature count"
 
-        assert src_srs_format == "-src_srs_format WKT" or (
-            err is None or err == ""
-        ), "got error/warning"
+    assert (
+        ds.GetLayer(0).GetSpatialRef().GetAuthorityCode(None) == "4326"
+    ), "did not get expected spatial ref"
 
-        ds = ogr.Open(output_filename)
-        assert (
-            ds.GetLayer(0).GetFeatureCount() == 2
-        ), "did not get expected feature count"
+    expected_wkts = [
+        "POLYGON ((2 49,2 49,2 49,2 49,2 49))",
+        "POLYGON ((3 50,3 50,3 50,3 50,3 50))",
+    ]
 
-        assert (
-            ds.GetLayer(0).GetSpatialRef().GetAuthorityCode(None) == "4326"
-        ), "did not get expected spatial ref"
+    for i, feat in enumerate(ds.GetLayer(0)):
+        assert feat.GetField("src_srs") == expected_srss[i]
+        ogrtest.check_feature_geometry(feat, expected_wkts[i], context=f"i={i}")
 
-        expected_wkts = [
-            "POLYGON ((2 49,2 49,2 49,2 49,2 49))",
-            "POLYGON ((3 50,3 50,3 50,3 50,3 50))",
-        ]
-        i = 0
-        feat = ds.GetLayer(0).GetNextFeature()
-        while feat is not None:
-            if feat.GetField("src_srs") != expected_srss[i]:
-                feat.DumpReadable()
-                pytest.fail(i, src_srs_format)
-
-                ogrtest.check_feature_geometry(feat, expected_wkts[i], context=f"i={i}")
-
-            i = i + 1
-            feat = ds.GetLayer(0).GetNextFeature()
-        ds = None
-
-    if os.path.exists("tmp/tileindex.shp"):
-        shape_drv.DeleteDataSource("tmp/tileindex.shp")
-    if os.path.exists("tmp/tileindex.db"):
-        os.unlink("tmp/tileindex.db")
+    ds = None


### PR DESCRIPTION
## What does this PR do?

Updates tests in `autotest/utilities` to use `tmp_path` for temporary files.

Also splits some tests where I noticed this could be done trivially (e.g,, `gdalwarp_46`, `gdalwarp_lib_135` and parametrizes other (e.g., `test_gdalwarp_lib_override_default_output_nodata`)

## What are related issues/pull requests?

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed