### PR TITLE
autotest: Add a VSIFile wrapper class

### DIFF
--- a/autotest/gcore/vsifile.py
+++ b/autotest/gcore/vsifile.py
@@ -37,7 +37,7 @@ import gdaltest
 import pytest
 from lxml import etree
 
-from osgeo import gdal
+from osgeo import gdal, ogr
 
 
 ###############################################################################
@@ -1364,3 +1364,217 @@ def test_vsifile_CopyFileRestartable(tmp_vsimem):
     assert retcode == 0
     assert output_payload is None
     assert gdal.VSIStatL(dstfilename).size == 3
+
+
+###############################################################################
+# Test VSIFile helper class
+
+
+def test_vsifile_class_write_ascii(tmp_path):
+
+    fname = tmp_path / "test.txt"
+
+    lines = ["permission is hereby granted", "free of charge", "to any person"]
+
+    with gdaltest.vsi_open(fname, "w") as f:
+        assert f.tell() == 0
+
+        for line in lines:
+            f.write(line)
+            f.write("\n")
+
+    with open(fname, "r") as f:
+        assert [line.strip() for line in f.readlines()] == lines
+
+
+def test_vsifile_class_read_ascii(tmp_path):
+
+    fname = str(tmp_path / "test.txt")
+
+    lines = ["permission is hereby granted", "free of charge", "to any person"]
+
+    with open(fname, "w", newline="\n") as f:
+        for line in lines:
+            f.write(line)
+            f.write("\n")
+
+        with pytest.raises(Exception):
+            f.write(b"some bytes")
+
+    # read entire file
+    with gdaltest.vsi_open(fname, "r") as f:
+        contents = f.read()
+
+        assert type(contents) is str
+
+        lines_in = [line.strip() for line in contents.strip().split("\n")]
+        assert lines_in == lines
+
+    # read some characters
+    f = gdaltest.vsi_open(fname)
+    assert f.read(10) == "permission"
+
+    # skip a character
+    f.seek(1, os.SEEK_CUR)
+    assert f.read(9) == "is hereby"
+
+    f.seek(0, os.SEEK_SET)
+    assert f.read(10) == "permission"
+
+    # jump to end
+    f.seek(0, os.SEEK_END)
+    assert f.read(10) == ""
+
+    f.seek(-7, os.SEEK_END)
+    assert f.read() == "person\n"
+
+    f.close()
+    f.close()  # no harm in closing an already-closed file
+
+
+def test_vsifile_class_read_binary(tmp_path):
+
+    fname = tmp_path / "test.wkb"
+
+    g = ogr.CreateGeometryFromWkt("POINT (15 17)")
+    wkb = g.ExportToWkb()
+
+    with open(fname, "wb") as f:
+        f.write(wkb)
+
+    # read entire file
+    with gdaltest.vsi_open(fname, "rb") as f:
+        contents = f.read()
+
+        assert type(contents) is bytes
+
+        assert contents == wkb
+
+    # read some bytes
+    f = gdaltest.vsi_open(fname, "rb")
+    assert f.read(5) == wkb[:5]
+
+    f.seek(10, os.SEEK_SET)
+    assert f.read(5) == wkb[10:15]
+
+
+def test_vsifile_class_write_binary(tmp_path):
+
+    fname = tmp_path / "test.wkb"
+
+    g = ogr.CreateGeometryFromWkt("POINT (15 17)")
+    wkb = g.ExportToWkb()
+
+    with gdaltest.vsi_open(fname, "wb") as f:
+        f.write(wkb[:8])
+        f.write(wkb[8:])
+
+    with open(fname, "rb") as f:
+        assert f.read() == wkb
+
+
+def random_lines():
+    import random
+    import string
+
+    lines = []
+    for i in range(50):
+        lines.append(
+            "".join([random.choice(string.ascii_letters) for j in range(20 + 3 * i)])
+        )
+    lines.append(" ")
+    lines.append("")
+    lines.append("theend")
+    lines.append("")
+
+    return lines
+
+
+@pytest.mark.parametrize("terminating_newline", (True, False))
+def test_vsifile_class_line_iteration(tmp_path, terminating_newline):
+
+    fname = str(tmp_path / "test.txt")
+
+    lines_out = random_lines()
+
+    with open(fname, "w") as f:
+        for line in lines_out:
+            f.write(line)
+            f.write("\n")
+
+        if not terminating_newline:
+            f.write("lastline")
+            lines_out.append("lastline")
+
+    with gdaltest.vsi_open(fname) as f:
+        lines_in = [line for line in f]
+
+    assert lines_in == lines_out
+
+
+def test_vsifile_class_binary_line_iteration(tmp_path):
+
+    fname = str(tmp_path / "test.txt")
+
+    lines_out = [x.encode() for x in random_lines()]
+
+    with open(fname, "wb") as f:
+        for line in lines_out:
+            f.write(line)
+            f.write(b"\n")
+
+    with gdaltest.vsi_open(fname, "rb") as f:
+        lines_in = [line for line in f]
+
+    assert lines_in == lines_out
+
+
+def test_vsifile_class_zipped_csv_reader(tmp_path):
+
+    test_csv = str(tmp_path / "input.csv")
+    test_zip = str(tmp_path / "input.zip")
+
+    import csv
+    import shutil
+    import zipfile
+
+    shutil.copy("../ogr/data/prime_meridian.csv", test_csv)
+
+    with zipfile.ZipFile(test_zip, "w") as zf:
+        zf.write(test_csv, arcname="input.csv")
+
+    with gdaltest.vsi_open(f"/vsizip/{test_zip}/input.csv") as f:
+        records = [x for x in csv.DictReader(f)]
+
+    assert len(records) == 4
+    assert (
+        records[2]["INFORMATION_SOURCE"]
+        == "Institut Geographique National (IGN), Paris"
+    )
+
+
+def test_vsifile_class_file_does_not_exist(tmp_path):
+
+    with pytest.raises(OSError, match="No such file or directory"):
+        gdaltest.vsi_open(tmp_path / "does_not_exist.txt")
+
+
+def test_vsifile_class_read_from_closed_file(tmp_path):
+
+    with gdaltest.vsi_open(tmp_path / "out.txt", "w") as f:
+        f.write("abc")
+
+    with pytest.raises(ValueError, match="closed file"):
+        f.seek(0)
+
+
+def test_vsifile_class_append(tmp_vsimem):
+
+    fname = tmp_vsimem / "out.txt"
+
+    with gdaltest.vsi_open(fname, "w") as f:
+        f.write("abc")
+    with gdaltest.vsi_open(fname, "a") as f:
+        f.write("def")
+    with gdaltest.vsi_open(fname) as f:
+        assert f.read() == "abcdef"

--- a/autotest/gcore/vsifile.py
+++ b/autotest/gcore/vsifile.py
@@ -1415,27 +1415,28 @@ def test_vsifile_class_read_ascii(tmp_path):
     assert f.read(10) == "permission"
 
     # skip a character
-    assert f.seek(1, os.SEEK_CUR) == 0
+    f.seek(1, os.SEEK_CUR)
     assert f.read(9) == "is hereby"
 
     # seek backwards
-    assert f.seek(-2, os.SEEK_CUR) == 0
+    f.seek(-2, os.SEEK_CUR)
     assert f.read(2) == "by"
 
     # jump to beginning
-    assert f.seek(0, os.SEEK_SET) == 0
+    f.seek(0, os.SEEK_SET)
     assert f.read(10) == "permission"
 
     # can't jump before the beginning
     pos = f.tell()
-    assert f.seek(-2, os.SEEK_SET) == -1
+    with pytest.raises(OSError, match="negative offset"):
+        f.seek(-2, os.SEEK_SET) == -1
     assert pos == f.tell()
 
     # jump to end
-    assert f.seek(0, os.SEEK_END) == 0
+    f.seek(0, os.SEEK_END)
     assert f.read(10) == ""
 
-    assert f.seek(-7, os.SEEK_END) == 0
+    f.seek(-7, os.SEEK_END)
     assert f.read() == "person\n"
 
     f.close()
@@ -1481,6 +1482,10 @@ def test_vsifile_class_write_binary(tmp_path):
 
     with open(fname, "rb") as f:
         assert f.read() == wkb
+
+    with gdaltest.vsi_open(fname, "rb") as f:
+        with pytest.raises(OSError, match="Expected to write"):
+            f.write(wkb)
 
 
 def random_lines():

--- a/autotest/gcore/vsifile.py
+++ b/autotest/gcore/vsifile.py
@@ -1415,17 +1415,27 @@ def test_vsifile_class_read_ascii(tmp_path):
     assert f.read(10) == "permission"
 
     # skip a character
-    f.seek(1, os.SEEK_CUR)
+    assert f.seek(1, os.SEEK_CUR) == 0
     assert f.read(9) == "is hereby"
 
-    f.seek(0, os.SEEK_SET)
+    # seek backwards
+    assert f.seek(-2, os.SEEK_CUR) == 0
+    assert f.read(2) == "by"
+
+    # jump to beginning
+    assert f.seek(0, os.SEEK_SET) == 0
     assert f.read(10) == "permission"
 
+    # can't jump before the beginning
+    pos = f.tell()
+    assert f.seek(-2, os.SEEK_SET) == -1
+    assert pos == f.tell()
+
     # jump to end
-    f.seek(0, os.SEEK_END)
+    assert f.seek(0, os.SEEK_END) == 0
     assert f.read(10) == ""
 
-    f.seek(-7, os.SEEK_END)
+    assert f.seek(-7, os.SEEK_END) == 0
     assert f.read() == "person\n"
 
     f.close()

--- a/autotest/ogr/ogr_libkml.py
+++ b/autotest/ogr/ogr_libkml.py
@@ -707,10 +707,8 @@ def test_ogr_libkml_camera(tmp_vsimem):
 
     ds = None
 
-    f = gdal.VSIFOpenL(tmp_vsimem / "ogr_libkml_camera.kml", "rb")
-    data = gdal.VSIFReadL(1, 2048, f)
-    data = data.decode("ascii")
-    gdal.VSIFCloseL(f)
+    with gdaltest.vsi_open(tmp_vsimem / "ogr_libkml_camera.kml", "rb") as f:
+        data = f.read().decode("ascii")
 
     assert not (
         data.find("<Camera>") == -1
@@ -771,10 +769,8 @@ def test_ogr_libkml_write_layer_lookat(tmp_vsimem):
     ds.CreateLayer("test2", options=options)
     ds = None
 
-    f = gdal.VSIFOpenL(tmp_vsimem / "ogr_libkml_write_layer_lookat.kml", "rb")
-    data = gdal.VSIFReadL(1, 2048, f)
-    data = data.decode("ascii")
-    gdal.VSIFCloseL(f)
+    with gdaltest.vsi_open(tmp_vsimem / "ogr_libkml_write_layer_lookat.kml", "rb") as f:
+        data = f.read().decode("ascii")
 
     assert not (
         data.find("<LookAt>") == -1
@@ -816,10 +812,8 @@ def test_ogr_libkml_write_layer_camera(tmp_vsimem):
     ds.CreateLayer("test", options=options)
     ds = None
 
-    f = gdal.VSIFOpenL(tmp_vsimem / "ogr_libkml_write_layer_camera.kml", "rb")
-    data = gdal.VSIFReadL(1, 2048, f)
-    data = data.decode("ascii")
-    gdal.VSIFCloseL(f)
+    with gdaltest.vsi_open(tmp_vsimem / "ogr_libkml_write_layer_camera.kml", "rb") as f:
+        data = f.read().decode("ascii")
 
     assert not (
         data.find("<Camera>") == -1
@@ -884,10 +878,8 @@ def test_ogr_libkml_write_snippet(tmp_vsimem):
     lyr.CreateFeature(feat)
     ds = None
 
-    f = gdal.VSIFOpenL(tmp_vsimem / "ogr_libkml_write_snippet.kml", "rb")
-    data = gdal.VSIFReadL(1, 2048, f)
-    data = data.decode("ascii")
-    gdal.VSIFCloseL(f)
+    with gdaltest.vsi_open(tmp_vsimem / "ogr_libkml_write_snippet.kml", "rb") as f:
+        data = f.read().decode("ascii")
 
     assert data.find("<snippet>test_snippet</snippet>") != -1
 
@@ -920,10 +912,8 @@ def test_ogr_libkml_write_atom_author(tmp_vsimem):
     assert ds is not None, "Unable to create %s." % filepath
     ds = None
 
-    f = gdal.VSIFOpenL(filepath, "rb")
-    data = gdal.VSIFReadL(1, 2048, f)
-    data = data.decode("ascii")
-    gdal.VSIFCloseL(f)
+    with gdaltest.vsi_open(filepath, "rb") as f:
+        data = f.read().decode("ascii")
 
     assert not (
         data.find(
@@ -949,10 +939,8 @@ def test_ogr_libkml_write_atom_link(tmp_vsimem):
     assert ds is not None, "Unable to create %s." % filepath
     ds = None
 
-    f = gdal.VSIFOpenL(filepath, "rb")
-    data = gdal.VSIFReadL(1, 2048, f)
-    data = data.decode("ascii")
-    gdal.VSIFCloseL(f)
+    with gdaltest.vsi_open(filepath, "rb") as f:
+        data = f.read().decode("ascii")
 
     assert not (
         data.find(
@@ -976,10 +964,8 @@ def test_ogr_libkml_write_phonenumber(tmp_vsimem):
     assert ds is not None, "Unable to create %s." % filepath
     ds = None
 
-    f = gdal.VSIFOpenL(filepath, "rb")
-    data = gdal.VSIFReadL(1, 2048, f)
-    data = data.decode("ascii")
-    gdal.VSIFCloseL(f)
+    with gdaltest.vsi_open(filepath, "rb") as f:
+        data = f.read().decode("ascii")
 
     assert data.find("<phoneNumber>tel:911</phoneNumber>") != -1
 
@@ -1013,10 +999,8 @@ def test_ogr_libkml_write_region(tmp_vsimem):
     )
     ds = None
 
-    f = gdal.VSIFOpenL(tmp_vsimem / "ogr_libkml_write_region.kml", "rb")
-    data = gdal.VSIFReadL(1, 2048, f)
-    data = data.decode("ascii")
-    gdal.VSIFCloseL(f)
+    with gdaltest.vsi_open(tmp_vsimem / "ogr_libkml_write_region.kml", "rb") as f:
+        data = f.read().decode("ascii")
 
     assert not (
         data.find("<north>49</north>") == -1
@@ -1071,10 +1055,10 @@ def test_ogr_libkml_write_screenoverlay(tmp_vsimem):
     )
     ds = None
 
-    f = gdal.VSIFOpenL(tmp_vsimem / "ogr_libkml_write_screenoverlay.kml", "rb")
-    data = gdal.VSIFReadL(1, 2048, f)
-    data = data.decode("ascii")
-    gdal.VSIFCloseL(f)
+    with gdaltest.vsi_open(
+        tmp_vsimem / "ogr_libkml_write_screenoverlay.kml", "rb"
+    ) as f:
+        data = f.read().decode("ascii")
 
     assert not (
         data.find("<href>http://foo</href>") == -1
@@ -1135,10 +1119,8 @@ def test_ogr_libkml_write_model(tmp_vsimem):
 
     ds = None
 
-    f = gdal.VSIFOpenL(tmp_vsimem / "ogr_libkml_write_model.kml", "rb")
-    data = gdal.VSIFReadL(1, 2048, f)
-    data = data.decode("ascii")
-    gdal.VSIFCloseL(f)
+    with gdaltest.vsi_open(tmp_vsimem / "ogr_libkml_write_model.kml", "rb") as f:
+        data = f.read().decode("ascii")
 
     assert not (
         data.find("<longitude>2</longitude>") == -1
@@ -1274,10 +1256,10 @@ def test_ogr_libkml_read_write_style(tmp_vsimem):
     ds = None
     src_ds = None
 
-    f = gdal.VSIFOpenL(tmp_vsimem / "ogr_libkml_read_write_style_write.kml", "rb")
-    data = gdal.VSIFReadL(1, 2048, f)
-    data = data.decode("ascii")
-    gdal.VSIFCloseL(f)
+    with gdaltest.vsi_open(
+        tmp_vsimem / "ogr_libkml_read_write_style_write.kml", "rb"
+    ) as f:
+        data = f.read().decode("ascii")
     lines = [l.strip() for l in data.split("\n")]
 
     lines_got = lines[
@@ -1308,10 +1290,10 @@ def test_ogr_libkml_read_write_style(tmp_vsimem):
     ds = None
     src_ds = None
 
-    f = gdal.VSIFOpenL(tmp_vsimem / "ogr_libkml_read_write_style_write.kml", "rb")
-    data = gdal.VSIFReadL(1, 2048, f)
-    data = data.decode("ascii")
-    gdal.VSIFCloseL(f)
+    with gdaltest.vsi_open(
+        tmp_vsimem / "ogr_libkml_read_write_style_write.kml", "rb"
+    ) as f:
+        data = f.read().decode("ascii")
     lines = [l.strip() for l in data.split("\n")]
 
     lines_got = lines[
@@ -1346,10 +1328,10 @@ def test_ogr_libkml_read_write_style(tmp_vsimem):
     assert feat.GetStyleString() == style_string
     ds = None
 
-    f = gdal.VSIFOpenL(tmp_vsimem / "ogr_libkml_read_write_style_write.kml", "rb")
-    data = gdal.VSIFReadL(1, 2048, f)
-    data = data.decode("ascii")
-    gdal.VSIFCloseL(f)
+    with gdaltest.vsi_open(
+        tmp_vsimem / "ogr_libkml_read_write_style_write.kml", "rb"
+    ) as f:
+        data = f.read().decode("ascii")
 
     expected_style = """<Style>
           <IconStyle>
@@ -1394,11 +1376,10 @@ def test_ogr_libkml_read_write_style(tmp_vsimem):
     ds.SetStyleTable(style_table)
     ds = None
 
-    f = gdal.VSIFOpenL(tmp_vsimem / "ogr_libkml_read_write_style_write.kml", "rb")
-    data = gdal.VSIFReadL(1, 2048, f)
-    data = data.decode("ascii")
-    gdal.VSIFCloseL(f)
-    lines = [l.strip() for l in data.split("\n")]
+    with gdaltest.vsi_open(
+        tmp_vsimem / "ogr_libkml_read_write_style_write.kml", "r"
+    ) as f:
+        lines = [l.strip() for l in f]
 
     expected_styles = """<Style id="style1_normal">
       <IconStyle>
@@ -1470,11 +1451,8 @@ def test_ogr_libkml_write_update(tmp_vsimem, fmt):
     else:
         open_name = name
 
-    f = gdal.VSIFOpenL(open_name, "rb")
-    assert f is not None, "Unable to open the write_update file."
-    data = gdal.VSIFReadL(1, 2048, f)
-    data = data.decode("ascii")
-    gdal.VSIFCloseL(f)
+    with gdaltest.vsi_open(open_name, "rb") as f:
+        data = f.read().decode("ascii")
 
     assert not (
         data.find("<NetworkLinkControl>") == -1
@@ -1525,11 +1503,8 @@ def test_ogr_libkml_write_networklinkcontrol(tmp_vsimem, fmt):
     else:
         open_name = name
 
-    f = gdal.VSIFOpenL(open_name, "rb")
-    assert f is not None
-    data = gdal.VSIFReadL(1, 2048, f)
-    data = data.decode("ascii")
-    gdal.VSIFCloseL(f)
+    with gdaltest.vsi_open(open_name, "rb") as f:
+        data = f.read().decode("ascii")
 
     assert not (
         data.find("<minRefreshPeriod>3600</minRefreshPeriod>") == -1
@@ -1564,10 +1539,8 @@ def test_ogr_libkml_write_liststyle(tmp_vsimem):
         ds.CreateLayer("test_error", options=["LISTSTYLE_TYPE=error"])
         ds = None
 
-    f = gdal.VSIFOpenL(tmp_vsimem / "ogr_libkml_write_liststyle.kml", "rb")
-    data = gdal.VSIFReadL(1, 2048, f)
-    data = data.decode("ascii")
-    gdal.VSIFCloseL(f)
+    with gdaltest.vsi_open(tmp_vsimem / "ogr_libkml_write_liststyle.kml", "rb") as f:
+        data = f.read().decode("ascii")
 
     assert not (
         data.find("<styleUrl>#root_doc_liststyle</styleUrl>") == -1
@@ -1637,10 +1610,8 @@ def test_ogr_libkml_write_networklink(tmp_vsimem):
 
     ds = None
 
-    f = gdal.VSIFOpenL(tmp_vsimem / "ogr_libkml_write_networklink.kml", "rb")
-    data = gdal.VSIFReadL(1, 2048, f)
-    data = data.decode("ascii")
-    gdal.VSIFCloseL(f)
+    with gdaltest.vsi_open(tmp_vsimem / "ogr_libkml_write_networklink.kml", "rb") as f:
+        data = f.read().decode("ascii")
 
     assert not (
         data.find("<name>a network link</name>") == -1
@@ -1723,10 +1694,8 @@ def test_ogr_libkml_write_photooverlay(tmp_vsimem):
 
     ds = None
 
-    f = gdal.VSIFOpenL(tmp_vsimem / "ogr_libkml_write_photooverlay.kml", "rb")
-    data = gdal.VSIFReadL(1, 2048, f)
-    data = data.decode("ascii")
-    gdal.VSIFCloseL(f)
+    with gdaltest.vsi_open(tmp_vsimem / "ogr_libkml_write_photooverlay.kml", "rb") as f:
+        data = f.read().decode("ascii")
 
     assert not (
         data.find("<Camera>") == -1
@@ -1774,10 +1743,8 @@ def test_ogr_libkml_read_write_data(tmp_vsimem):
     lyr.CreateFeature(feat)
     ds = None
 
-    f = gdal.VSIFOpenL(tmp_vsimem / "ogr_libkml_read_write_data.kml", "rb")
-    data = gdal.VSIFReadL(1, 2048, f)
-    data = data.decode("ascii")
-    gdal.VSIFCloseL(f)
+    with gdaltest.vsi_open(tmp_vsimem / "ogr_libkml_read_write_data.kml", "rb") as f:
+        data = f.read().decode("ascii")
 
     assert not (
         data.find('<Data name="foo">') == -1 or data.find("<value>bar</value>") == -1
@@ -1802,10 +1769,8 @@ def test_ogr_libkml_write_folder(tmp_vsimem):
     ds.CreateLayer("test2", options=["FOLDER=YES"])
     ds = None
 
-    f = gdal.VSIFOpenL(tmp_vsimem / "ogr_libkml_write_folder.kml", "rb")
-    data = gdal.VSIFReadL(1, 2048, f)
-    data = data.decode("ascii")
-    gdal.VSIFCloseL(f)
+    with gdaltest.vsi_open(tmp_vsimem / "ogr_libkml_write_folder.kml", "rb") as f:
+        data = f.read().decode("ascii")
 
     assert not (
         data.find('<Style id="test_liststyle">') == -1
@@ -1844,10 +1809,10 @@ def test_ogr_libkml_write_container_properties(tmp_vsimem):
     )
     ds = None
 
-    f = gdal.VSIFOpenL(tmp_vsimem / "ogr_libkml_write_container_properties.kml", "rb")
-    data = gdal.VSIFReadL(1, 2048, f)
-    data = data.decode("ascii")
-    gdal.VSIFCloseL(f)
+    with gdaltest.vsi_open(
+        tmp_vsimem / "ogr_libkml_write_container_properties.kml", "rb"
+    ) as f:
+        data = f.read().decode("ascii")
 
     assert not (
         data.find("<name>ds_name</name>") == -1
@@ -2082,14 +2047,10 @@ def test_ogr_libkml_write_layer_name_underscore(tmp_vsimem):
     ds.CreateLayer("_45+6")
     ds = None
 
-    f = gdal.VSIFOpenL(dirname + "/123.kml", "rb")
-    assert f
-    content = gdal.VSIFReadL(1, 10000, f)
-    gdal.VSIFCloseL(f)
+    with gdaltest.vsi_open(dirname + "/123.kml", "rb") as f:
+        content = f.read()
     assert b'<Document id="_123">' in content
 
-    f = gdal.VSIFOpenL(dirname + "/_45+6.kml", "rb")
-    assert f
-    content = gdal.VSIFReadL(1, 10000, f)
-    gdal.VSIFCloseL(f)
+    with gdaltest.vsi_open(dirname + "/_45+6.kml", "rb") as f:
+        content = f.read()
     assert b'<Document id="_45_6">' in content

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -2134,7 +2134,6 @@ class VSIFile:
             raise OSError(gdal.VSIGetLastErrorMsg())
 
         self._closed = False
-        self._buffer = None
 
     def __enter__(self):
         return self

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -2116,3 +2116,80 @@ def reopen(ds, update=False, open_options=None):
         allowed_drivers=[ds_drv.GetDescription()],
         open_options=open_options,
     )
+
+
+# VSIFile helper class
+
+
+class VSIFile:
+    def __init__(self, path, mode, encoding="utf-8"):
+        self._path = path
+        self._mode = mode
+
+        self._binary = "b" in mode
+        self._encoding = encoding
+
+        self._fp = gdal.VSIFOpenExL(self._path, self._mode, True)
+        if self._fp is None:
+            raise OSError(gdal.VSIGetLastErrorMsg())
+
+        self._closed = False
+        self._buffer = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        line = gdal.CPLReadLineL(self._fp)
+        if line is None:
+            raise StopIteration
+        if self._binary:
+            return line.encode()
+        return line
+
+    def close(self):
+        if self._closed:
+            return
+
+        self._closed = True
+        gdal.VSIFCloseL(self._fp)
+
+    def read(self, size=-1):
+        if size == -1:
+            pos = self.tell()
+            self.seek(0, 2)
+            size = self.tell()
+            self.seek(pos)
+
+        raw = gdal.VSIFReadL(1, size, self._fp)
+
+        if self._binary:
+            return bytes(raw)
+        else:
+            return raw.decode(self._encoding)
+
+    def write(self, x):
+
+        if self._binary:
+            assert type(x) in (bytes, bytearray, memoryview)
+        else:
+            assert type(x) is str
+            x = x.encode(self._encoding)
+
+        gdal.VSIFWriteL(x, 1, len(x), self._fp)
+
+    def seek(self, offset, whence=0):
+        gdal.VSIFSeekL(self._fp, offset, whence)
+
+    def tell(self):
+        return gdal.VSIFTellL(self._fp)
+
+
+def vsi_open(path, mode="r"):
+    return VSIFile(path, mode)

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -2182,10 +2182,17 @@ class VSIFile:
             assert type(x) is str
             x = x.encode(self._encoding)
 
-        gdal.VSIFWriteL(x, 1, len(x), self._fp)
+        planned_write = len(x)
+        actual_write = gdal.VSIFWriteL(x, 1, planned_write, self._fp)
+
+        if planned_write != actual_write:
+            raise OSError(
+                f"Expected to write {planned_write} bytes but {actual_write} were written"
+            )
 
     def seek(self, offset, whence=0):
-        return gdal.VSIFSeekL(self._fp, offset, whence)
+        if gdal.VSIFSeekL(self._fp, offset, whence) != 0:
+            raise OSError(gdal.VSIGetLastErrorMsg())
 
     def tell(self):
         return gdal.VSIFTellL(self._fp)

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -2185,7 +2185,7 @@ class VSIFile:
         gdal.VSIFWriteL(x, 1, len(x), self._fp)
 
     def seek(self, offset, whence=0):
-        gdal.VSIFSeekL(self._fp, offset, whence)
+        return gdal.VSIFSeekL(self._fp, offset, whence)
 
     def tell(self):
         return gdal.VSIFTellL(self._fp)

--- a/swig/include/cpl.i
+++ b/swig/include/cpl.i
@@ -906,8 +906,33 @@ int VSIFFlushL( VSILFILE* fp );
 
 VSI_RETVAL VSIFCloseL( VSILFILE* fp );
 
+// Wrap VSIFSeekL to allow negative offsets
+%rename (VSIFSeekL) wrapper_VSIFSeekL;
+%inline {
 #if defined(SWIGPYTHON)
-int     VSIFSeekL( VSILFILE* fp, GIntBig offset, int whence);
+int wrapper_VSIFSeekL( VSILFILE* fp, GIntBig offset, int whence) {
+#else
+VSI_RETVAL wrapper_VSIFSeekL( VSILFILE* fp, long offset, int whence) {
+#endif
+if (offset < 0) {
+    switch (whence) {
+        case SEEK_END: VSIFSeekL(fp, 0, SEEK_END);
+        case SEEK_CUR:
+            offset = VSIFTellL(fp) + offset;
+            whence = SEEK_SET;
+            break;
+        default:
+            VSIError(VSIE_FileError, "Cannot use negative offset with SEEK_SET");
+            return -1;
+    }
+}
+
+return VSIFSeekL(fp, offset, whence);
+}
+}
+
+
+#if defined(SWIGPYTHON)
 GIntBig    VSIFTellL( VSILFILE* fp );
 int     VSIFTruncateL( VSILFILE* fp, GIntBig length );
 
@@ -919,7 +944,6 @@ int     VSISupportsSparseFiles( const char* utf8_path );
 
 int     VSIFGetRangeStatusL( VSILFILE* fp, GIntBig offset, GIntBig length );
 #else
-VSI_RETVAL VSIFSeekL( VSILFILE* fp, long offset, int whence);
 long    VSIFTellL( VSILFILE* fp );
 VSI_RETVAL VSIFTruncateL( VSILFILE* fp, long length );
 #endif

--- a/swig/include/cpl.i
+++ b/swig/include/cpl.i
@@ -943,6 +943,8 @@ int     VSIFWriteL( const char *, int, int, VSILFILE *fp );
 
 /* VSIFReadL() handled specially in python/gdal_python.i */
 
+const char* CPLReadLineL(VSILFILE* fp);
+
 void VSICurlClearCache();
 void VSICurlPartialClearCache( const char* utf8_path );
 

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -371,7 +371,7 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
         raise ValueError("I/O operation on closed file.")
 %}
 
-%pythonprepend VSIFSeekL %{
+%pythonprepend wrapper_VSIFSeekL %{
     if args[0].this is None:
         raise ValueError("I/O operation on closed file.")
 %}


### PR DESCRIPTION
## What does this PR do?

This PR adds a `gdal.vsi_open()` function that returns a file-like object, allowing virtual files to be used as "regular" Python files in some cases.  For example, a zipped CSV can be read using the Python `csv` module:

```
with gdal.vsi_open(f'/vsizip/prime_meridian.csv') as f:
    records = [x for x in csv.DictReader(f)]

assert records[2]['INFORMATION_SOURCE'] == "Institut Geographique National (IGN), Paris"
```

Still need to correctly handle different linebreak/OS combinations, ensure errors are raised when accessing a closed file, handle append mode (or raise error), and probably other things.

## What are related issues/pull requests?

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
