### PR TITLE
autotest: add tmp_vsimem fixture

### DIFF
--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -245,3 +245,20 @@ def pytest_report_header(config):
         gdal_header_info += ' (tests marked as "slow" will be skipped)'
 
     return gdal_header_info
+
+
+@pytest.fixture()
+def tmp_vsimem(request):
+    import pathlib
+    import re
+
+    # sanitize test name using same method as pytest's tmp_path
+    subdir = re.sub(r"[\W]", "_", request.node.name)
+
+    # return a pathlib object so that behavior matches tmp_path
+    # and we can easily switch between the two
+    path = pathlib.PurePosixPath("/vsimem") / subdir
+
+    yield path
+
+    gdal.RmdirRecursive(str(path))

--- a/autotest/gdrivers/plmosaic.py
+++ b/autotest/gdrivers/plmosaic.py
@@ -29,6 +29,7 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
+import json
 import os
 import shutil
 import struct
@@ -52,9 +53,6 @@ def setup_and_cleanup(tmp_path):
 
     with gdal.config_option("PL_CACHE_PATH", str(tmp_path)):
         yield
-
-    for path in gdal.ReadDirRecursive("/vsimem/") or []:
-        gdal.Unlink(path)
 
 
 ###############################################################################
@@ -85,11 +83,13 @@ def test_plmosaic_3():
 # Error case: invalid JSON
 
 
-def test_plmosaic_4():
+def test_plmosaic_4(tmp_vsimem):
 
-    gdal.FileFromMemBuffer("/vsimem/root", """{""")
+    root = str(tmp_vsimem / "root")
 
-    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
+    gdal.FileFromMemBuffer(root, """{""")
+
+    with gdal.config_option("PL_URL", root), gdaltest.error_handler():
         ds = gdal.OpenEx("PLMosaic:", gdal.OF_RASTER, open_options=["API_KEY=foo"])
     assert ds is None
 
@@ -98,11 +98,13 @@ def test_plmosaic_4():
 # Error case: not a JSON dictionary
 
 
-def test_plmosaic_5():
+def test_plmosaic_5(tmp_vsimem):
 
-    gdal.FileFromMemBuffer("/vsimem/root", """null""")
+    root = str(tmp_vsimem / "root")
 
-    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
+    gdal.FileFromMemBuffer(root, """null""")
+
+    with gdal.config_option("PL_URL", root), gdaltest.error_handler():
         ds = gdal.OpenEx("PLMosaic:", gdal.OF_RASTER, open_options=["API_KEY=foo"])
     assert ds is None
 
@@ -111,11 +113,13 @@ def test_plmosaic_5():
 # Error case: missing "mosaics" element
 
 
-def test_plmosaic_6():
+def test_plmosaic_6(tmp_vsimem):
 
-    gdal.FileFromMemBuffer("/vsimem/root", """{}""")
+    root = str(tmp_vsimem / "root")
 
-    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
+    gdal.FileFromMemBuffer(root, """{}""")
+
+    with gdal.config_option("PL_URL", root), gdaltest.error_handler():
         ds = gdal.OpenEx("PLMosaic:", gdal.OF_RASTER, open_options=["API_KEY=foo"])
     assert ds is None
 
@@ -124,18 +128,21 @@ def test_plmosaic_6():
 # Valid root but no mosaics
 
 
-def test_plmosaic_7():
+def test_plmosaic_7(tmp_vsimem):
+
+    root = str(tmp_vsimem / "root")
 
     gdal.FileFromMemBuffer(
-        "/vsimem/root",
+        root,
         """{
     "mosaics": [],
 }""",
     )
 
-    with gdal.config_option("PL_URL", "/vsimem/root"):
+    with gdal.config_option("PL_URL", root):
         ds = gdal.OpenEx("PLMosaic:", gdal.OF_RASTER, open_options=["API_KEY=foo"])
     assert ds is None
+
     ds = None
 
 
@@ -144,59 +151,60 @@ def test_plmosaic_7():
 
 
 @pytest.fixture()
-def valid_root_with_two_mosaics(tmp_path):
+def valid_root_with_two_mosaics(tmp_vsimem):
+
+    root = str(tmp_vsimem / "root")
 
     gdal.FileFromMemBuffer(
-        "/vsimem/root",
-        """{
-    "_links" : { "_next": "/vsimem/root/?page=2" },
-    "mosaics": [
-        {
-            "id": "my_mosaic_id",
-            "name": "my_mosaic_name",
-            "coordinate_system": "EPSG:3857",
-            "_links" : {
-                "_self": "/vsimem/root/my_mosaic"
-            },
-            "quad_download": true
-        }
-    ],
-}""",
+        root,
+        json.dumps(
+            {
+                "_links": {"_next": f"{root}/?page=2"},
+                "mosaics": [
+                    {
+                        "id": "my_mosaic_id",
+                        "name": "my_mosaic_name",
+                        "coordinate_system": "EPSG:3857",
+                        "_links": {"_self": f"{root}/my_mosaic"},
+                        "quad_download": "true",
+                    }
+                ],
+            }
+        ),
     )
+
     gdal.FileFromMemBuffer(
-        "/vsimem/root/?page=2",
-        """{
-    "_links" : { "_next": null },
-    "mosaics": [
-        {
-            "id": "another_mosaic_id",
-            "name": "another_mosaic_name",
-            "coordinate_system": "EPSG:3857",
-            "_links" : {
-                "_self": "/vsimem/root/another_mosaic"
-            },
-            "quad_download": true
-        },
-        {
-            "id": "this_one_will_be_ignored",
-            "name": "this_one_will_be_ignored",
-            "coordinate_system": "EPSG:1234",
-            "_links" : {
-                "_self": "/vsimem/root/this_one_will_be_ignored"
-            },
-            "quad_download": true
-        }
-    ],
-}""",
+        f"{root}/?page=2",
+        json.dumps(
+            {
+                "_links": {"_next": None},
+                "mosaics": [
+                    {
+                        "id": "another_mosaic_id",
+                        "name": "another_mosaic_name",
+                        "coordinate_system": "EPSG:3857",
+                        "_links": {"_self": f"{root}/another_mosaic"},
+                        "quad_download": True,
+                    },
+                    {
+                        "id": "this_one_will_be_ignored",
+                        "name": "this_one_will_be_ignored",
+                        "coordinate_system": "EPSG:1234",
+                        "_links": {"_self": f"{root}/this_one_will_be_ignored"},
+                        "quad_download": True,
+                    },
+                ],
+            }
+        ),
     )
 
     yield
 
 
 @pytest.mark.usefixtures("valid_root_with_two_mosaics")
-def test_plmosaic_8():
+def test_plmosaic_8(tmp_vsimem):
 
-    with gdal.config_option("PL_URL", "/vsimem/root"):
+    with gdal.config_option("PL_URL", f"{tmp_vsimem}/root"):
         ds = gdal.OpenEx("PLMosaic:", gdal.OF_RASTER, open_options=["API_KEY=foo"])
     assert ds.GetMetadata("SUBDATASETS") == {
         "SUBDATASET_2_NAME": "PLMOSAIC:mosaic=another_mosaic_name",
@@ -212,9 +220,9 @@ def test_plmosaic_8():
 
 
 @pytest.mark.usefixtures("valid_root_with_two_mosaics")
-def test_plmosaic_9():
+def test_plmosaic_9(tmp_vsimem):
 
-    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
+    with gdal.config_option("PL_URL", f"{tmp_vsimem}/root"), gdaltest.error_handler():
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
@@ -222,7 +230,7 @@ def test_plmosaic_9():
         )
 
     assert ds is None
-    assert "/vsimem/root/?name__is=does_not_exist" in gdal.GetLastErrorMsg()
+    assert f"{tmp_vsimem}/root/?name__is=does_not_exist" in gdal.GetLastErrorMsg()
 
 
 ###############################################################################
@@ -230,10 +238,10 @@ def test_plmosaic_9():
 
 
 @pytest.mark.usefixtures("valid_root_with_two_mosaics")
-def test_plmosaic_9bis():
+def test_plmosaic_9bis(tmp_vsimem):
 
-    gdal.FileFromMemBuffer("/vsimem/root/?name__is=my_mosaic", """{""")
-    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
+    gdal.FileFromMemBuffer(f"{tmp_vsimem}/root/?name__is=my_mosaic", """{""")
+    with gdal.config_option("PL_URL", f"{tmp_vsimem}/root"), gdaltest.error_handler():
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
@@ -247,10 +255,10 @@ def test_plmosaic_9bis():
 
 
 @pytest.mark.usefixtures("valid_root_with_two_mosaics")
-def test_plmosaic_9ter():
+def test_plmosaic_9ter(tmp_vsimem):
 
-    gdal.FileFromMemBuffer("/vsimem/root/?name__is=my_mosaic", """{}""")
-    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
+    gdal.FileFromMemBuffer(f"{tmp_vsimem}/root/?name__is=my_mosaic", """{}""")
+    with gdal.config_option("PL_URL", f"{tmp_vsimem}/root"), gdaltest.error_handler():
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
@@ -263,10 +271,10 @@ def test_plmosaic_9ter():
 # Invalid mosaic definition: missing parameters
 
 
-def test_plmosaic_10():
+def test_plmosaic_10(tmp_vsimem):
 
     gdal.FileFromMemBuffer(
-        "/vsimem/root/?name__is=my_mosaic",
+        f"{tmp_vsimem}/root/?name__is=my_mosaic",
         """{
 "mosaics": [{
     "id": "my_mosaic_id",
@@ -274,7 +282,7 @@ def test_plmosaic_10():
 }]
 }""",
     )
-    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
+    with gdal.config_option("PL_URL", f"{tmp_vsimem}/root"), gdaltest.error_handler():
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
@@ -287,10 +295,10 @@ def test_plmosaic_10():
 # Invalid mosaic definition: unsupported projection
 
 
-def test_plmosaic_11():
+def test_plmosaic_11(tmp_vsimem):
 
     gdal.FileFromMemBuffer(
-        "/vsimem/root/?name__is=my_mosaic",
+        f"{tmp_vsimem}/root/?name__is=my_mosaic",
         """{
 "mosaics": [{
     "id": "my_mosaic_id",
@@ -304,7 +312,7 @@ def test_plmosaic_11():
 }]
 }""",
     )
-    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
+    with gdal.config_option("PL_URL", f"{tmp_vsimem}/root"), gdaltest.error_handler():
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
@@ -319,10 +327,10 @@ def test_plmosaic_11():
 # Invalid mosaic definition: unsupported datatype
 
 
-def test_plmosaic_12():
+def test_plmosaic_12(tmp_vsimem):
 
     gdal.FileFromMemBuffer(
-        "/vsimem/root/?name__is=my_mosaic",
+        f"{tmp_vsimem}/root/?name__is=my_mosaic",
         """{
 "mosaics": [{
     "id": "my_mosaic_id",
@@ -336,7 +344,7 @@ def test_plmosaic_12():
 }]
 }""",
     )
-    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
+    with gdal.config_option("PL_URL", f"{tmp_vsimem}/root"), gdaltest.error_handler():
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
@@ -349,10 +357,10 @@ def test_plmosaic_12():
 # Invalid mosaic definition: unsupported resolution
 
 
-def test_plmosaic_13():
+def test_plmosaic_13(tmp_vsimem):
 
     gdal.FileFromMemBuffer(
-        "/vsimem/root/?name__is=my_mosaic",
+        f"{tmp_vsimem}/root/?name__is=my_mosaic",
         """{
 "mosaics": [{
     "id": "my_mosaic_id",
@@ -366,7 +374,7 @@ def test_plmosaic_13():
 }]
 }""",
     )
-    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
+    with gdal.config_option("PL_URL", f"{tmp_vsimem}/root"), gdaltest.error_handler():
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
@@ -379,10 +387,10 @@ def test_plmosaic_13():
 # Invalid mosaic definition: unsupported quad_size
 
 
-def test_plmosaic_14():
+def test_plmosaic_14(tmp_vsimem):
 
     gdal.FileFromMemBuffer(
-        "/vsimem/root/?name__is=my_mosaic",
+        f"{tmp_vsimem}/root/?name__is=my_mosaic",
         """{
 "mosaics": [{
     "id": "my_mosaic_id",
@@ -396,7 +404,7 @@ def test_plmosaic_14():
 }]
 }""",
     )
-    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
+    with gdal.config_option("PL_URL", f"{tmp_vsimem}/root"), gdaltest.error_handler():
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
@@ -409,30 +417,31 @@ def test_plmosaic_14():
 # Nearly valid mosaic definition. Warning about invalid links.tiles
 
 
-def test_plmosaic_15():
+def test_plmosaic_15(tmp_vsimem):
+
+    root = str(tmp_vsimem / "root")
 
     gdal.FileFromMemBuffer(
-        "/vsimem/root/?name__is=my_mosaic",
-        """{
-"mosaics": [{
-    "id": "my_mosaic_id",
-    "name": "my_mosaic",
-    "coordinate_system": "EPSG:3857",
-    "datatype": "byte",
-    "grid": {
-        "quad_size": 4096,
-        "resolution": 4.77731426716
-    },
-    "first_acquired": "first_date",
-    "last_acquired": "last_date",
-    "_links" : {
-        "tiles" : "/vsimem/root/my_mosaic/tiles/foo"
-    },
-    "quad_download": true
-}]
-}""",
+        f"{root}/?name__is=my_mosaic",
+        json.dumps(
+            {
+                "mosaics": [
+                    {
+                        "id": "my_mosaic_id",
+                        "name": "my_mosaic",
+                        "coordinate_system": "EPSG:3857",
+                        "datatype": "byte",
+                        "grid": {"quad_size": 4096, "resolution": 4.77731426716},
+                        "first_acquired": "first_date",
+                        "last_acquired": "last_date",
+                        "_links": {"tiles": f"{root}/my_mosaic/tiles/foo"},
+                        "quad_download": True,
+                    }
+                ]
+            }
+        ),
     )
-    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
+    with gdal.config_option("PL_URL", root), gdaltest.error_handler():
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
@@ -449,62 +458,64 @@ def test_plmosaic_15():
 
 
 @pytest.fixture()
-def valid_mosaic():
+def valid_mosaic(tmp_vsimem):
+
+    root = str(tmp_vsimem / "root")
 
     gdal.FileFromMemBuffer(
-        "/vsimem/root/?name__is=my_mosaic",
-        """{
-"mosaics": [{
-    "id": "my_mosaic_id",
-    "name": "my_mosaic",
-    "coordinate_system": "EPSG:3857",
-    "datatype": "byte",
-    "grid": {
-        "quad_size": 4096,
-        "resolution": 4.77731426716
-    },
-    "first_acquired": "first_date",
-    "last_acquired": "last_date",
-    "_links" : {
-        "tiles" : "/vsimem/root/my_mosaic/tiles{0-3}/{z}/{x}/{y}.png"
-    },
-    "quad_download": true
-}]
-}""",
+        f"{root}/?name__is=my_mosaic",
+        json.dumps(
+            {
+                "mosaics": [
+                    {
+                        "id": "my_mosaic_id",
+                        "name": "my_mosaic",
+                        "coordinate_system": "EPSG:3857",
+                        "datatype": "byte",
+                        "grid": {"quad_size": 4096, "resolution": 4.77731426716},
+                        "first_acquired": "first_date",
+                        "last_acquired": "last_date",
+                        "_links": {
+                            "tiles": root + "/my_mosaic/tiles{0-3}/{z}/{x}/{y}.png"
+                        },
+                        "quad_download": True,
+                    }
+                ]
+            }
+        ),
     )
 
     # Valid root: one single mosaic, should open the dataset directly
     gdal.FileFromMemBuffer(
-        "/vsimem/root",
-        """{
-    "mosaics": [
-        {
-            "id": "my_mosaic_id",
-            "name": "my_mosaic",
-            "coordinate_system": "EPSG:3857",
-            "_links" : {
-                "_self": "/vsimem/root/my_mosaic"
-            },
-            "quad_download": true
-        }
-    ],
-}""",
+        root,
+        json.dumps(
+            {
+                "mosaics": [
+                    {
+                        "id": "my_mosaic_id",
+                        "name": "my_mosaic",
+                        "coordinate_system": "EPSG:3857",
+                        "_links": {"_self": f"{root}/my_mosaic"},
+                        "quad_download": True,
+                    }
+                ],
+            }
+        ),
     )
 
-    yield
+    yield root
 
 
-@pytest.mark.usefixtures("valid_mosaic")
-def test_plmosaic_16():
+def test_plmosaic_16(tmp_vsimem, valid_mosaic):
 
-    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
+    with gdal.config_option("PL_URL", valid_mosaic), gdaltest.error_handler():
         ds = gdal.OpenEx("PLMosaic:api_key=foo,unsupported_option=val", gdal.OF_RASTER)
     assert (
         ds is None
         and gdal.GetLastErrorMsg().find("Unsupported option unsupported_option") >= 0
     )
 
-    with gdal.config_option("PL_URL", "/vsimem/root"):
+    with gdal.config_option("PL_URL", valid_mosaic):
         ds = gdal.OpenEx("PLMosaic:", gdal.OF_RASTER, open_options=["API_KEY=foo"])
     assert ds.GetMetadata("SUBDATASETS") == {}
     assert ds.GetMetadata() == {
@@ -519,12 +530,11 @@ def test_plmosaic_16():
 # Open with explicit MOSAIC dataset open option
 
 
-@pytest.mark.usefixtures("valid_mosaic")
-def test_plmosaic_17(tmp_path):
+def test_plmosaic_17(tmp_path, valid_mosaic):
 
     cache_path = str(tmp_path / "plmosaic_cache")
 
-    with gdal.config_option("PL_URL", "/vsimem/root"):
+    with gdal.config_option("PL_URL", valid_mosaic):
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
@@ -583,7 +593,7 @@ def test_plmosaic_17(tmp_path):
     ds.FlushCache()
 
     # Invalid tile content
-    gdal.FileFromMemBuffer("/vsimem/root/my_mosaic_id/quads/0-2047/full", "garbage")
+    gdal.FileFromMemBuffer(f"{valid_mosaic}/my_mosaic_id/quads/0-2047/full", "garbage")
     with gdaltest.error_handler():
         ds.GetRasterBand(1).ReadRaster(0, 0, 1, 1)
 
@@ -594,7 +604,7 @@ def test_plmosaic_17(tmp_path):
 
     # GeoTIFF but with wrong dimensions
     gdal.GetDriverByName("GTiff").Create(
-        "/vsimem/root/my_mosaic_id/quads/0-2047/full", 1, 1, 1
+        f"{valid_mosaic}/my_mosaic_id/quads/0-2047/full", 1, 1, 1
     )
     with gdaltest.error_handler():
         ds.GetRasterBand(1).ReadRaster(0, 0, 1, 1)
@@ -606,7 +616,7 @@ def test_plmosaic_17(tmp_path):
 
     # Good GeoTIFF
     tmp_ds = gdal.GetDriverByName("GTiff").Create(
-        "/vsimem/root/my_mosaic_id/quads/0-2047/full",
+        f"{valid_mosaic}/my_mosaic_id/quads/0-2047/full",
         4096,
         4096,
         4,
@@ -627,7 +637,7 @@ def test_plmosaic_17(tmp_path):
     # We change the file behind the scene (but not changing its size)
     # to demonstrate that the cached tile is still use
     tmp_ds = gdal.GetDriverByName("GTiff").Create(
-        "/vsimem/root/my_mosaic_id/quads/0-2047/full",
+        f"{valid_mosaic}/my_mosaic_id/quads/0-2047/full",
         4096,
         4096,
         4,
@@ -643,8 +653,8 @@ def test_plmosaic_17(tmp_path):
 
     # Read again from file cache, but with TRUST_CACHE=YES
     # delete the full GeoTIFF before
-    gdal.Unlink("/vsimem/root/my_mosaic_id/quads/0-2047/full")
-    with gdal.config_option("PL_URL", "/vsimem/root"):
+    gdal.Unlink(f"{valid_mosaic}/my_mosaic_id/quads/0-2047/full")
+    with gdal.config_option("PL_URL", valid_mosaic):
         ds = gdal.OpenEx(
             f"PLMosaic:API_KEY=foo,MOSAIC=my_mosaic,CACHE_PATH={tmp_path},TRUST_CACHE=YES",
             gdal.OF_RASTER,
@@ -656,7 +666,7 @@ def test_plmosaic_17(tmp_path):
     ds = None
 
     # Read again from file cache but the metatile has changed in between
-    with gdal.config_option("PL_URL", "/vsimem/root"):
+    with gdal.config_option("PL_URL", valid_mosaic):
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
@@ -664,7 +674,7 @@ def test_plmosaic_17(tmp_path):
         )
 
     tmp_ds = gdal.GetDriverByName("GTiff").Create(
-        "/vsimem/root/my_mosaic_id/quads/0-2047/full",
+        f"{valid_mosaic}/my_mosaic_id/quads/0-2047/full",
         4096,
         4096,
         4,
@@ -683,10 +693,9 @@ def test_plmosaic_17(tmp_path):
 # Test location info
 
 
-@pytest.mark.usefixtures("valid_mosaic")
-def test_plmosaic_18():
+def test_plmosaic_18(valid_mosaic):
 
-    with gdal.config_option("PL_URL", "/vsimem/root"):
+    with gdal.config_option("PL_URL", valid_mosaic):
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
@@ -704,7 +713,7 @@ def test_plmosaic_18():
     assert ret == old_ret
 
     gdal.FileFromMemBuffer(
-        "/vsimem/root/my_mosaic_id/quads/0-2047/items",
+        f"{valid_mosaic}/my_mosaic_id/quads/0-2047/items",
         """{
     "items": [
         { "link": "foo" }
@@ -733,11 +742,10 @@ def test_plmosaic_18():
 # Try error in saving in cache
 
 
-@pytest.mark.usefixtures("valid_mosaic")
-def test_plmosaic_19():
+def test_plmosaic_19(valid_mosaic):
 
     with gdal.GetDriverByName("GTiff").Create(
-        "/vsimem/root/my_mosaic_id/quads/0-2047/full",
+        f"{valid_mosaic}/my_mosaic_id/quads/0-2047/full",
         4096,
         4096,
         4,
@@ -745,7 +753,7 @@ def test_plmosaic_19():
     ) as tmp_ds:
         tmp_ds.GetRasterBand(1).Fill(254)
 
-    with gdal.config_option("PL_URL", "/vsimem/root"):
+    with gdal.config_option("PL_URL", valid_mosaic):
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
@@ -770,11 +778,10 @@ def test_plmosaic_19():
 # Try disabling cache
 
 
-@pytest.mark.usefixtures("valid_mosaic")
-def test_plmosaic_20():
+def test_plmosaic_20(valid_mosaic):
 
     with gdal.GetDriverByName("GTiff").Create(
-        "/vsimem/root/my_mosaic_id/quads/0-2047/full",
+        f"{valid_mosaic}/my_mosaic_id/quads/0-2047/full",
         4096,
         4096,
         4,
@@ -782,7 +789,7 @@ def test_plmosaic_20():
     ) as tmp_ds:
         tmp_ds.GetRasterBand(1).Fill(254)
 
-    with gdal.config_option("PL_URL", "/vsimem/root"):
+    with gdal.config_option("PL_URL", valid_mosaic):
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
@@ -802,10 +809,9 @@ def test_plmosaic_20():
 # Try use_tiles
 
 
-@pytest.mark.usefixtures("valid_mosaic")
-def test_plmosaic_21():
+def test_plmosaic_21(valid_mosaic):
 
-    with gdal.config_option("PL_URL", "/vsimem/root"):
+    with gdal.config_option("PL_URL", valid_mosaic):
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
@@ -833,30 +839,32 @@ def test_plmosaic_21():
     assert gdal.GetLastErrorMsg() != ""
 
     gdal.FileFromMemBuffer(
-        "/vsimem/root/?name__is=mosaic_uint16",
-        """{
-"mosaics": [{
-    "id": "mosaic_uint16",
-    "name": "mosaic_uint16",
-    "coordinate_system": "EPSG:3857",
-    "datatype": "uint16",
-    "grid": {
-        "quad_size": 4096,
-        "resolution": 4.77731426716
-    },
-    "first_acquired": "first_date",
-    "last_acquired": "last_date",
-    "_links" : {
-        "tiles" : "/vsimem/root/mosaic_uint16/tiles{0-3}/{z}/{x}/{y}.png"
-    },
-    "quad_download": true
-}]
-}""",
+        f"{valid_mosaic}/?name__is=mosaic_uint16",
+        json.dumps(
+            {
+                "mosaics": [
+                    {
+                        "id": "mosaic_uint16",
+                        "name": "mosaic_uint16",
+                        "coordinate_system": "EPSG:3857",
+                        "datatype": "uint16",
+                        "grid": {"quad_size": 4096, "resolution": 4.77731426716},
+                        "first_acquired": "first_date",
+                        "last_acquired": "last_date",
+                        "_links": {
+                            "tiles": valid_mosaic
+                            + "/mosaic_uint16/tiles{0-3}/{z}/{x}/{y}.png"
+                        },
+                        "quad_download": True,
+                    }
+                ]
+            }
+        ),
     )
 
     # Should emit a warning
     gdal.ErrorReset()
-    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
+    with gdal.config_option("PL_URL", valid_mosaic), gdaltest.error_handler():
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
@@ -875,7 +883,7 @@ def test_plmosaic_21():
     )
 
     gdal.FileFromMemBuffer(
-        "/vsimem/root/?name__is=mosaic_without_tiles",
+        f"{valid_mosaic}/?name__is=mosaic_without_tiles",
         """{
 "mosaics": [{
     "id": "mosaic_without_tiles",
@@ -895,7 +903,7 @@ def test_plmosaic_21():
 
     # Should emit a warning
     gdal.ErrorReset()
-    with gdal.config_option("PL_URL", "/vsimem/root"), gdaltest.error_handler():
+    with gdal.config_option("PL_URL", valid_mosaic), gdaltest.error_handler():
         ds = gdal.OpenEx(
             "PLMosaic:",
             gdal.OF_RASTER,
@@ -918,55 +926,53 @@ def test_plmosaic_21():
 # Valid mosaic definition with bbox
 
 
-def test_plmosaic_with_bbox():
+def test_plmosaic_with_bbox(tmp_vsimem):
+
+    root = str(tmp_vsimem / "root")
 
     gdal.FileFromMemBuffer(
-        "/vsimem/root/?name__is=my_mosaic",
-        """{
-"mosaics": [{
-    "id": "my_mosaic_id",
-    "name": "my_mosaic",
-    "coordinate_system": "EPSG:3857",
-    "datatype": "byte",
-    "grid": {
-        "quad_size": 4096,
-        "resolution": 4.77731426716
-    },
-    "bbox" : [
-        -100,
-        30,
-        -90,
-        40
-    ],
-    "first_acquired": "first_date",
-    "last_acquired": "last_date",
-    "_links" : {
-        "tiles" : "/vsimem/root/my_mosaic/tiles{0-3}/{z}/{x}/{y}.png"
-    },
-    "quad_download": true
-}]
-}""",
+        f"{root}/?name__is=my_mosaic",
+        json.dumps(
+            {
+                "mosaics": [
+                    {
+                        "id": "my_mosaic_id",
+                        "name": "my_mosaic",
+                        "coordinate_system": "EPSG:3857",
+                        "datatype": "byte",
+                        "grid": {"quad_size": 4096, "resolution": 4.77731426716},
+                        "bbox": [-100, 30, -90, 40],
+                        "first_acquired": "first_date",
+                        "last_acquired": "last_date",
+                        "_links": {
+                            "tiles": root + "/my_mosaic/tiles{0-3}/{z}/{x}/{y}.png"
+                        },
+                        "quad_download": True,
+                    }
+                ]
+            }
+        ),
     )
 
     # Valid root: one single mosaic, should open the dataset directly
     gdal.FileFromMemBuffer(
-        "/vsimem/root",
-        """{
-    "mosaics": [
-        {
-            "id": "my_mosaic_id",
-            "name": "my_mosaic",
-            "coordinate_system": "EPSG:3857",
-            "_links" : {
-                "_self": "/vsimem/root/my_mosaic"
-            },
-            "quad_download": true
-        }
-    ],
-}""",
+        root,
+        json.dumps(
+            {
+                "mosaics": [
+                    {
+                        "id": "my_mosaic_id",
+                        "name": "my_mosaic",
+                        "coordinate_system": "EPSG:3857",
+                        "_links": {"_self": root + "/my_mosaic"},
+                        "quad_download": True,
+                    }
+                ],
+            }
+        ),
     )
 
-    with gdal.config_option("PL_URL", "/vsimem/root"):
+    with gdal.config_option("PL_URL", root):
         ds = gdal.OpenEx("PLMosaic:", gdal.OF_RASTER, open_options=["API_KEY=foo"])
     assert ds.RasterXSize == 233472
     assert ds.RasterYSize == 286720
@@ -984,7 +990,7 @@ def test_plmosaic_with_bbox():
 
     # Good GeoTIFF
     tmp_ds = gdal.GetDriverByName("GTiff").Create(
-        "/vsimem/root/my_mosaic_id/quads/455-1272/full",
+        f"{root}/my_mosaic_id/quads/455-1272/full",
         4096,
         4096,
         4,
@@ -998,7 +1004,7 @@ def test_plmosaic_with_bbox():
     assert val == 125
 
     gdal.FileFromMemBuffer(
-        "/vsimem/root/my_mosaic_id/quads/455-1272/items",
+        f"{root}/my_mosaic_id/quads/455-1272/items",
         """{
     "items": [
         { "link": "bar" }


### PR DESCRIPTION
## What does this PR do?

Adds a `tmp_vsimem` fixture that behaves like `tmp_path` but returns a location under `vsimem` instead of the local file system.

This removes the need for tests to include cleanup code and prevents collisions between tests running in parallel.

## What are related issues/pull requests?

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
