### PR TITLE
Doc: Document common MacOS CMake build issues

### DIFF
--- a/doc/source/development/building_from_source.rst
+++ b/doc/source/development/building_from_source.rst
@@ -47,12 +47,6 @@ From the build directory you can now configure CMake, build and install the bina
     and is thus not recommended. It is also not supported on Windows multi-configuration
     generator (such as VisualStudio).
 
-`
-On Windows, one may need to specify generator:
-
-.. code-block:: bash
-
-    cmake -G "Visual Studio 15 2017" ..
 
 If a dependency is installed in a custom location, specify the
 paths to the include directory and the library:
@@ -89,6 +83,41 @@ for the shared lib, *e.g.* ``set (GDAL_LIB_OUTPUT_NAME gdal_x64 CACHE STRING "" 
     you may try removing CMakeCache.txt to start from a clean state.
 
 Refer to :ref:`using_gdal_in_cmake` for how to use GDAL in a CMake project.
+
+Building on Windows
++++++++++++++++++++
+
+On Windows, one may need to specify generator:
+
+.. code-block:: bash
+
+    cmake -G "Visual Studio 15 2017" ..
+
+
+Building on MacOS
++++++++++++++++++
+
+On MacOS, there are a couple of libraries that do not function properly when the GDAL build requirements are installed using Homebrew.
+
+The `Apache Arrow <https://arrow.apache.org/docs/index.html>`_ library included in the current distribution of CMake is broken, and causes a detection issue. In order to build GDAL successfuly, you must first remove it:
+
+.. code-block:: bash
+
+    rm -rf /usr/local/lib/cmake/Arrow
+
+And then set the appropriate options to exclude Arrow from the build:
+
+.. code-block:: bash
+
+    cmake -DGDAL_USE_ARROW=OFF -DGDAL_USE_PARQUET=OFF ..
+
+
+Similarly, recent versions of Homebrew no longer bundle `Boost <https://www.boost.org/>`_ with libkml, causing a failure to find Boost headers. You should either install Boost manually or disable libkml when building on MacOS:
+
+.. code-block:: bash
+
+    cmake -DGDAL_USE_LIBKML=OFF ..
+
 
 CMake general configure options
 +++++++++++++++++++++++++++++++


### PR DESCRIPTION
## Preamble

Long-time GDAL user, first-time (potential) contributor.

I recently updated my local GDAL build from 3.3.2 to 3.7.0, and encountered a number of issues building with CMake on MacOS. I discovered basically all of these issues had fixes or workarounds in the [cmake_builds.yml](https://github.com/OSGeo/gdal/blob/master/.github/workflows/cmake_builds.yml#L552) CI config, but these workarounds didn't seem to be documented anywhere. After applying these, I was able to get a successful build.

## What does this PR do?

This PR aims to add a section with information about common CMake build failures on MacOS, and their workarounds, to the documentation. For consistency, I've also moved the preexisting Windows guideline to a similar section. 

## What are related issues/pull requests?

 - https://github.com/OSGeo/gdal/pull/7588
 - [**8891395**: CI: fix build-mac](https://github.com/OSGeo/gdal/commit/889139563a4869cbfea212621f25a81c33cc3a92)
 - [**369f0c3**: CI: cmake_builds.yml: build-mac: disable Arrow/Parquet](https://github.com/OSGeo/gdal/commit/369f0c3da15e0a72efd66496e161684c0063dca2)

## Tasklist

 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: MacOS 13.5
* Compiler: AppleClang 14.0.3.14030022
