### PR TITLE
Python bindings: Use OGRFeature::DumpReadableAsString for __repr__

### DIFF
--- a/autotest/ogr/ogr_feature.py
+++ b/autotest/ogr/ogr_feature.py
@@ -965,3 +965,12 @@ def test_ogr_feature_dump_readable():
 
     assert feat_wkt not in out_geometry_summary
     assert "POINT" in out_geometry_summary
+
+
+def test_ogr_feature_repr():
+
+    feat = mk_src_feature()
+
+    out = feat.__repr__()
+
+    assert out.startswith("OGRFeature(src):")

--- a/autotest/ogr/ogr_feature.py
+++ b/autotest/ogr/ogr_feature.py
@@ -920,3 +920,48 @@ def test_ogr_feature_GetFieldAsISO8601DateTime():
 
     feature.SetFieldNull("field_datetime")
     assert feature.GetFieldAsISO8601DateTime("field_datetime") == ""
+
+
+def test_ogr_feature_dump_readable():
+
+    ds = ogr.Open("data/mitab/single_point_mapinfo.tab")
+    lyr = ds.GetLayer(0)
+
+    feature = lyr.GetNextFeature()
+    feat_wkt = feature.GetGeometryRef().ExportToWkt()
+
+    # default output
+
+    out_full = feature.DumpReadableAsString()
+
+    defn = feature.GetDefnRef()
+    for i in range(defn.GetFieldCount()):
+        field_name = defn.GetFieldDefn(i).GetName()
+
+        assert field_name in out_full
+
+    assert "Style = " in out_full
+
+    assert feat_wkt in out_full
+
+    # no fields
+
+    out_no_fields = feature.DumpReadableAsString({"DISPLAY_FIELDS": "NO"})
+
+    for i in range(defn.GetFieldCount()):
+        field_name = defn.GetFieldDefn(i).GetName()
+
+        assert field_name not in out_no_fields
+
+    # no geometry
+
+    out_no_geometry = feature.DumpReadableAsString({"DISPLAY_GEOMETRY": "NO"})
+
+    assert feat_wkt not in out_no_geometry
+
+    # geometry summary only
+
+    out_geometry_summary = feature.DumpReadableAsString({"DISPLAY_GEOMETRY": "SUMMARY"})
+
+    assert feat_wkt not in out_geometry_summary
+    assert "POINT" in out_geometry_summary

--- a/ogr/ogr_api.h
+++ b/ogr/ogr_api.h
@@ -548,6 +548,8 @@ OGRErr CPL_DLL OGR_F_SetGeomField(OGRFeatureH hFeat, int iField,
 GIntBig CPL_DLL OGR_F_GetFID(OGRFeatureH);
 OGRErr CPL_DLL OGR_F_SetFID(OGRFeatureH, GIntBig);
 void CPL_DLL OGR_F_DumpReadable(OGRFeatureH, FILE *);
+char CPL_DLL *OGR_F_DumpReadableAsString(OGRFeatureH,
+                                         CSLConstList) CPL_WARN_UNUSED_RESULT;
 OGRErr CPL_DLL OGR_F_SetFrom(OGRFeatureH, OGRFeatureH, int);
 OGRErr CPL_DLL OGR_F_SetFromWithMap(OGRFeatureH, OGRFeatureH, int, const int *);
 

--- a/ogr/ogrfeature.cpp
+++ b/ogr/ogrfeature.cpp
@@ -5676,6 +5676,40 @@ void OGR_F_DumpReadable(OGRFeatureH hFeat, FILE *fpOut)
 }
 
 /************************************************************************/
+/*                         OGR_F_DumpReadableAsString()                 */
+/************************************************************************/
+
+/**
+ * \brief Dump this feature in a human readable form.
+ *
+ * This dumps the attributes, and geometry; however, it doesn't include
+ * definition information (other than field types and names), nor does
+ * it report the geometry spatial reference system.
+ *
+ * A few options can be defined to change the default dump :
+ * <ul>
+ * <li>DISPLAY_FIELDS=NO : to hide the dump of the attributes</li>
+ * <li>DISPLAY_STYLE=NO : to hide the dump of the style string</li>
+ * <li>DISPLAY_GEOMETRY=NO : to hide the dump of the geometry</li>
+ * <li>DISPLAY_GEOMETRY=SUMMARY : to get only a summary of the geometry</li>
+ * </ul>
+ *
+ * @param hFeat handle to the feature to dump.
+ * @param papszOptions NULL terminated list of options (may be NULL)
+ * @return a string with the feature representation (to be freed with CPLFree())
+ * @since GDAL 3.8
+ */
+
+char *OGR_F_DumpReadableAsString(OGRFeatureH hFeat, CSLConstList papszOptions)
+{
+    VALIDATE_POINTER1(hFeat, "OGR_F_DumpReadableAsString", nullptr);
+
+    return CPLStrdup(OGRFeature::FromHandle(hFeat)
+                         ->DumpReadableAsString(papszOptions)
+                         .c_str());
+}
+
+/************************************************************************/
 /*                               GetFID()                               */
 /************************************************************************/
 

--- a/swig/include/ogr.i
+++ b/swig/include/ogr.i
@@ -1983,6 +1983,10 @@ public:
     OGR_F_DumpReadable(self, NULL);
   }
 
+  retStringAndCPLFree* DumpReadableAsString(char** options=NULL) {
+    return OGR_F_DumpReadableAsString(self, options);
+  }
+
   void UnsetField(int id) {
     OGR_F_UnsetField(self, id);
   }

--- a/swig/include/python/ogr_python.i
+++ b/swig/include/python/ogr_python.i
@@ -743,6 +743,11 @@ def ReleaseResultSet(self, sql_lyr):
 
         return self.GetGeometryRef()
 
+
+    def __repr__(self):
+        return self.DumpReadableAsString()
+
+
     def ExportToJson(self, as_object=False, options=None):
         """Exports a GeoJSON object which represents the Feature. The
            as_object parameter determines whether the returned value


### PR DESCRIPTION
## What does this PR do?

Make the Python `Feature.__repr__` use `DumpReadableAsString`. This is convenient for interactive use and also lets pytest generate assertion failure messages, like

```
>       assert feat1 == feat2
E       assert OGRFeature(rfc35_test):1\n  intfield (Integer) = (null)\n  foo5 (String) = foo0\n  bar10 (String) = (null)\n  baz15 (String) = (null)\n  baw20 (String) = (null)\n\n == OGRFeature(rfc35_test):2\n  intfield (Integer) = (null)\n  foo5 (String) = foo1\n  bar10 (String) = bar1\n  baz15 (String) = (null)\n  baw20 (String) = (null)\n\n
E         Full diff:
E         - OGRFeature(rfc35_test):2
E         ?                        ^
E         + OGRFeature(rfc35_test):1
E         ?                        ^
E             intfield (Integer) = (null)
E         -   foo5 (String) = foo1
E         ?                      ^
E         +   foo5 (String) = foo0
E         ?                      ^
E         -   bar10 (String) = bar1
E         ?                    ^^^^
E         +   bar10 (String) = (null)
E         ?                    ^^^^^^
E             baz15 (String) = (null)
E             baw20 (String) = (null)

/home/dan/dev/build-gdal-Desktop-Debug/autotest/ogr/ogr_rfc35.py:363: AssertionError
```

## What are related issues/pull requests?

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
