### PR TITLE
[Backport release/3.7] Fix ExecuteSQL(dialect='SQLITE', spatialFilter=...) on a Memory datasource

### DIFF
--- a/autotest/ogr/ogr_sql_sqlite.py
+++ b/autotest/ogr/ogr_sql_sqlite.py
@@ -2323,3 +2323,42 @@ def test_ogr_sql_sqlite_json_each():
     fc = sql_lyr.GetFeatureCount()
     ds.ReleaseResultSet(sql_lyr)
     assert fc == 0
+
+
+###############################################################################
+@pytest.mark.parametrize("driver", ["memory", "shape"])
+def testogr_sql_sqlite_spatial_filter(driver):
+
+    filename = None
+    if driver == "memory":
+        ds = ogr.GetDriverByName("Memory").CreateDataSource("")
+    elif driver == "shape":
+        filename = "/vsimem/test.shp"
+        ds = ogr.GetDriverByName("ESRI Shapefile").CreateDataSource(filename)
+    else:
+        assert False
+    lyr = ds.CreateLayer("test")
+    f = ogr.Feature(lyr.GetLayerDefn())
+    f.SetGeometry(ogr.CreateGeometryFromWkt("POINT(1 2)"))
+    lyr.CreateFeature(f)
+    f = None
+
+    if driver == "shape":
+        ds = None
+        ds = ogr.Open(filename, update=1)
+
+    spatialFilter = ogr.CreateGeometryFromWkt("POLYGON((0 0,0 10,10 10,10 0,0 0))")
+    with ds.ExecuteSQL(
+        "SELECT * FROM test", spatialFilter=spatialFilter, dialect="SQLITE"
+    ) as sql_lyr:
+        assert [f.GetFID() for f in sql_lyr] == [0]
+
+    spatialFilter = ogr.CreateGeometryFromWkt("POLYGON((0 0,0 1,1 1,1 0,0 0))")
+    with ds.ExecuteSQL(
+        "SELECT * FROM test", spatialFilter=spatialFilter, dialect="SQLITE"
+    ) as sql_lyr:
+        assert [f.GetFID() for f in sql_lyr] == []
+
+    ds = None
+    if driver == "shape":
+        ds = ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource(filename)

--- a/ogr/ogrsf_frmts/sqlite/ogr_sqlite.h
+++ b/ogr/ogrsf_frmts/sqlite/ogr_sqlite.h
@@ -531,6 +531,7 @@ class OGRSQLiteSelectLayer CPL_NON_FINAL : public OGRSQLiteLayer,
                                            public IOGRSQLiteSelectLayer
 {
     OGRSQLiteSelectLayerCommonBehaviour *m_poBehavior = nullptr;
+    bool m_bCanReopenBaseDS = false;
 
     virtual OGRErr ResetStatement() override;
 
@@ -539,7 +540,8 @@ class OGRSQLiteSelectLayer CPL_NON_FINAL : public OGRSQLiteLayer,
   public:
     OGRSQLiteSelectLayer(OGRSQLiteDataSource *, const CPLString &osSQL,
                          sqlite3_stmt *, bool bUseStatementForGetNextFeature,
-                         bool bEmptyLayer, bool bAllowMultipleGeomFields);
+                         bool bEmptyLayer, bool bAllowMultipleGeomFields,
+                         bool bCanReopenBaseDS);
     virtual ~OGRSQLiteSelectLayer();
 
     virtual void ResetReading() override;

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
@@ -3328,7 +3328,7 @@ OGRLayer *OGRSQLiteDataSource::ExecuteSQL(const char *pszSQLCommand,
     CPLString osSQL = pszSQLCommand;
     OGRSQLiteSelectLayer *poLayer = new OGRSQLiteSelectLayer(
         this, osSQL, hSQLStmt, bUseStatementForGetNextFeature, bEmptyLayer,
-        true);
+        true, /*bCanReopenBaseDS=*/true);
 
     if (poSpatialFilter != nullptr &&
         poLayer->GetLayerDefn()->GetGeomFieldCount() > 0)


### PR DESCRIPTION
Backport #8247
 **Authored by:** @rouault