### PR TITLE
Parquet: use statistics to skip row groups that don't match attribute filter

### DIFF
--- a/autotest/ogr/ogr_parquet.py
+++ b/autotest/ogr/ogr_parquet.py
@@ -1341,6 +1341,7 @@ def test_ogr_parquet_multiple_geom_columns():
         "boolean = 0 OR boolean = 1",
         "1 = 1",
         "boolean = boolean",
+        "FID = 1",
     ],
 )
 def test_ogr_parquet_attribute_filter(filter):
@@ -2396,6 +2397,11 @@ def test_ogr_parquet_statistics_fid_column():
             f = sql_lyr.GetNextFeature()
             assert f["MIN_FID"] == 2
             assert f["MAX_FID"] == 9876543210
+
+        with ds.ExecuteSQL("SELECT * FROM out WHERE FID = 4") as sql_lyr:
+            f = sql_lyr.GetNextFeature()
+            assert f
+            assert f.GetFID() == 4
         ds = None
 
     finally:

--- a/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
+++ b/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
@@ -82,7 +82,6 @@ class OGRArrowLayer CPL_NON_FINAL
     OGRArrowLayer(const OGRArrowLayer &) = delete;
     OGRArrowLayer &operator=(const OGRArrowLayer &) = delete;
 
-    std::vector<Constraint> m_asAttributeFilterConstraints{};
     int m_nUseOptimizedAttributeFilter = -1;
     bool m_bSpatialFilterIntersectsLayerExtent = true;
     bool m_bUseRecordBatchBaseImplementation = false;
@@ -130,6 +129,8 @@ class OGRArrowLayer CPL_NON_FINAL
     std::vector<std::shared_ptr<arrow::Array>>
         m_poBatchColumns{};  // must always be == m_poBatch->columns()
     mutable std::shared_ptr<arrow::Array> m_poReadFeatureTmpArray{};
+
+    std::vector<Constraint> m_asAttributeFilterConstraints{};
 
     std::map<std::string, std::unique_ptr<OGRFieldDefn>>
     LoadGDALMetadata(const arrow::KeyValueMetadata *kv_metadata);

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
@@ -2168,21 +2168,46 @@ inline void OGRArrowLayer::ComputeConstraintsArrayIdx()
     {
         if (m_bIgnoredFields)
         {
-            constraint.iArrayIdx =
-                m_anMapFieldIndexToArrayIndex[constraint.iField];
+            if (constraint.iField == m_poFeatureDefn->GetFieldCount() + SPF_FID)
+            {
+                constraint.iArrayIdx = m_nRequestedFIDColumn;
+            }
+            else
+            {
+                constraint.iArrayIdx =
+                    m_anMapFieldIndexToArrayIndex[constraint.iField];
+            }
             if (constraint.iArrayIdx < 0)
             {
                 CPLError(CE_Failure, CPLE_AppDefined,
                          "Constraint on field %s cannot be applied due to "
                          "it being ignored",
-                         m_poFeatureDefn->GetFieldDefn(constraint.iField)
-                             ->GetNameRef());
+                         constraint.iField ==
+                                 m_poFeatureDefn->GetFieldCount() + SPF_FID
+                             ? (m_osFIDColumn.empty() ? "FID"
+                                                      : m_osFIDColumn.c_str())
+                             : m_poFeatureDefn->GetFieldDefn(constraint.iField)
+                                   ->GetNameRef());
             }
         }
         else
         {
-            constraint.iArrayIdx =
-                m_anMapFieldIndexToArrowColumn[constraint.iField][0];
+            if (constraint.iField == m_poFeatureDefn->GetFieldCount() + SPF_FID)
+            {
+                constraint.iArrayIdx = m_iFIDArrowColumn;
+                if (constraint.iArrayIdx < 0)
+                {
+                    CPLDebug(GetDriverUCName().c_str(),
+                             "Constraint on field %s cannot be applied",
+                             m_osFIDColumn.empty() ? "FID"
+                                                   : m_osFIDColumn.c_str());
+                }
+            }
+            else
+            {
+                constraint.iArrayIdx =
+                    m_anMapFieldIndexToArrowColumn[constraint.iField][0];
+            }
         }
     }
 }
@@ -2209,10 +2234,17 @@ inline void OGRArrowLayer::ExploreExprNode(const swq_expr_node *poNode)
         const swq_expr_node *poColumn = GetColumnSubNode(poNode);
         const swq_expr_node *poValue = GetConstantSubNode(poNode);
         if (poColumn != nullptr && poValue != nullptr &&
-            poColumn->field_index < m_poFeatureDefn->GetFieldCount())
+            (poColumn->field_index < m_poFeatureDefn->GetFieldCount() ||
+             poColumn->field_index ==
+                 m_poFeatureDefn->GetFieldCount() + SPF_FID))
         {
+            const OGRFieldDefn oDummyFIDFieldDefn(m_osFIDColumn.c_str(),
+                                                  OFTInteger64);
             const OGRFieldDefn *poFieldDefn =
-                m_poFeatureDefn->GetFieldDefn(poColumn->field_index);
+                (poColumn->field_index ==
+                 m_poFeatureDefn->GetFieldCount() + SPF_FID)
+                    ? &oDummyFIDFieldDefn
+                    : m_poFeatureDefn->GetFieldDefn(poColumn->field_index);
 
             Constraint constraint;
             constraint.iField = poColumn->field_index;

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
@@ -3541,9 +3541,13 @@ inline int OGRArrowLayer::GetNextArrowArray(struct ArrowArrayStream *stream,
 
         if (m_poBatch == nullptr || m_nIdxInBatch == m_poBatch->num_rows())
         {
-            m_bEOF = !ReadNextBatch();
-            if (m_bEOF)
+            if (!ReadNextBatch())
             {
+                if (m_poAttrQuery || m_poFilterGeom)
+                {
+                    InvalidateCachedBatches();
+                }
+                m_bEOF = true;
                 memset(out_array, 0, sizeof(*out_array));
                 return 0;
             }

--- a/ogr/ogrsf_frmts/parquet/ogr_parquet.h
+++ b/ogr/ogrsf_frmts/parquet/ogr_parquet.h
@@ -95,6 +95,7 @@ class OGRParquetLayer final : public OGRParquetLayerBase
 
     void EstablishFeatureDefn();
     bool CreateRecordBatchReader(int iStartingRowGroup);
+    bool CreateRecordBatchReader(const std::vector<int> &anRowGroups);
     bool ReadNextBatch() override;
 
     void InvalidateCachedBatches() override;

--- a/ogr/ogrsf_frmts/parquet/ogr_parquet.h
+++ b/ogr/ogrsf_frmts/parquet/ogr_parquet.h
@@ -150,6 +150,13 @@ class OGRParquetLayer final : public OGRParquetLayerBase
     {
         return m_apoArrowDataTypes;
     }
+
+    bool GetMinMaxForField(int iRowGroup,  // -1 for all
+                           int iOGRField, bool bComputeMin, OGRField &sMin,
+                           bool &bFoundMin, bool bComputeMax, OGRField &sMax,
+                           bool &bFoundMax, OGRFieldType &eType,
+                           OGRFieldSubType &eSubType, std::string &osMinTmp,
+                           std::string &osMaxTmp) const;
 };
 
 /************************************************************************/

--- a/ogr/ogrsf_frmts/parquet/ogr_parquet.h
+++ b/ogr/ogrsf_frmts/parquet/ogr_parquet.h
@@ -77,6 +77,7 @@ class OGRParquetLayer final : public OGRParquetLayerBase
     std::unique_ptr<parquet::arrow::FileReader> m_poArrowReader{};
     bool m_bSingleBatch = false;
     int m_iFIDParquetColumn = -1;
+    std::shared_ptr<arrow::DataType> m_poFIDType{};
     std::vector<std::shared_ptr<arrow::DataType>>
         m_apoArrowDataTypes{};  // .size() == field ocunt
     std::vector<int> m_anMapFieldIndexToParquetColumn{};
@@ -151,12 +152,18 @@ class OGRParquetLayer final : public OGRParquetLayerBase
         return m_apoArrowDataTypes;
     }
 
+    int GetFIDParquetColumn() const
+    {
+        return m_iFIDParquetColumn;
+    }
+
+    static constexpr int OGR_FID_INDEX = -2;
     bool GetMinMaxForField(int iRowGroup,  // -1 for all
-                           int iOGRField, bool bComputeMin, OGRField &sMin,
-                           bool &bFoundMin, bool bComputeMax, OGRField &sMax,
-                           bool &bFoundMax, OGRFieldType &eType,
-                           OGRFieldSubType &eSubType, std::string &osMinTmp,
-                           std::string &osMaxTmp) const;
+                           int iOGRField,  // or OGR_FID_INDEX
+                           bool bComputeMin, OGRField &sMin, bool &bFoundMin,
+                           bool bComputeMax, OGRField &sMax, bool &bFoundMax,
+                           OGRFieldType &eType, OGRFieldSubType &eSubType,
+                           std::string &osMinTmp, std::string &osMaxTmp) const;
 };
 
 /************************************************************************/

--- a/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
@@ -487,7 +487,9 @@ void OGRParquetLayer::EstablishFeatureDefn()
         if (!bParquetColValid)
             m_bHasMissingMappingToParquet = true;
 
-        if (!m_osFIDColumn.empty() && field->name() == m_osFIDColumn)
+        if (!m_osFIDColumn.empty() && field->name() == m_osFIDColumn &&
+            (field->type()->id() == arrow::Type::INT32 ||
+             field->type()->id() == arrow::Type::INT64))
         {
             m_poFIDType = field->type();
             m_iFIDArrowColumn = i;


### PR DESCRIPTION
Fixes #8225