### PR TITLE
Doc: substitute remotesensing.org/geotiff/proj_list with gdal.org/proj_list/

### DIFF
--- a/doc/source/tutorials/wktproblems.rst
+++ b/doc/source/tutorials/wktproblems.rst
@@ -44,7 +44,7 @@ associated with them. This leads to various selection of parameter names
 (and sometimes projection names) from different vendors. I have
 attempted to maintain a list of WKT bindings for different projections
 as part of my `GeoTIFF Projections
-List <https://web.archive.org/web/20130728081442/http://www.remotesensing.org/geotiff/proj_list/>`__
+List <https://gdal.org/proj_list>`__
 registry. Please try to adhere to the projection names and parameters
 listed there. That list also tries to relate the projections to the
 GeoTIFF, EPSG and PROJ.4 formulations where possible.

--- a/swig/java/javadoc.java
+++ b/swig/java/javadoc.java
@@ -11614,7 +11614,7 @@ public class SpatialReference:public int SetProjection(String name)
  * <p>
  * Adds a new PARAMETER under the PROJCS with the indicated name and value.
  * <p>
- * Please check <a href="https://gdal.org/proj_list/">https://gdal.org/proj_list/</a> pages for
+ * Please check <a href="https://gdal.org/proj_list">https://gdal.org/proj_list</a> pages for
  * legal parameter names for specific projections.
  *
  * @param name the parameter name, which should be selected from

--- a/swig/java/javadoc.java
+++ b/swig/java/javadoc.java
@@ -11614,7 +11614,7 @@ public class SpatialReference:public int SetProjection(String name)
  * <p>
  * Adds a new PARAMETER under the PROJCS with the indicated name and value.
  * <p>
- * Please check <a href="http://www.remotesensing.org/geotiff/proj_list">http://www.remotesensing.org/geotiff/proj_list</a> pages for
+ * Please check <a href="https://gdal.org/proj_list/">https://gdal.org/proj_list/</a> pages for
  * legal parameter names for specific projections.
  *
  * @param name the parameter name, which should be selected from


### PR DESCRIPTION


<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

It substitutes remotesensing.org/geotiff/proj_list with gdal.org/proj_list/ in https://gdal.org/tutorials/wktproblems.html and https://gdal.org/java/org/gdal/osr/SpatialReference.html#SetProjParm(java.lang.String,double)

Other no longer available resources previously hosted at remotesensing.org are also linked in other files... e.g.:
https://github.com/OSGeo/gdal/blob/af5b75ecc6b8d3cef36f2b6fecf085319d39a546/doc/source/drivers/raster/hdf4.rst?plain=1#L200-L203
https://github.com/OSGeo/gdal/blob/af5b75ecc6b8d3cef36f2b6fecf085319d39a546/frmts/hdf4/hdf4imagedataset.cpp#L62-L64
or in some libgeotiff and libtiff files, ...

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/pull/8256