### PR TITLE
dev_environment.rst: fix docker  label

### DIFF
--- a/doc/source/development/dev_environment.rst
+++ b/doc/source/development/dev_environment.rst
@@ -75,7 +75,7 @@ that is used in GitHub Actions:
 
     docker run -it \
         -v $(pwd):/gdal:rw \
-        ghcr.io/osgeo/gdal-deps:ubuntu_20.04-master
+        ghcr.io/osgeo/gdal-deps:ubuntu20.04-master
     cd /gdal
     mkdir build-asan
     cd build-asan


### PR DESCRIPTION
remove stray "_" from docker  label in "Setting up a development environment" 

https://gdal.org/development/dev_environment.html


