### PR TITLE
Python bindings: Accept os.PathLike arguments where applicable

### DIFF
--- a/autotest/gcore/basic_test.py
+++ b/autotest/gcore/basic_test.py
@@ -123,6 +123,11 @@ def test_basic_test_5():
     pytest.fail()
 
 
+def test_basic_test_5bis():
+    with pytest.raises(RuntimeError, match="not a string"):
+        gdal.Open(12345)
+
+
 ###############################################################################
 # Issue several AllRegister() to check that GDAL drivers are good citizens
 
@@ -800,7 +805,7 @@ def test_basic_test_DontUseExceptions():
 
 
 def test_create_context_manager(tmp_path):
-    fname = str(tmp_path / "out.tif")
+    fname = tmp_path / "out.tif"
 
     drv = gdal.GetDriverByName("GTiff")
     with drv.Create(fname, xsize=10, ysize=10, bands=1, eType=gdal.GDT_Float32) as ds:
@@ -873,4 +878,6 @@ def test_checksum_more_than_2billion_pixels():
 
 
 def test_tmp_vsimem(tmp_vsimem):
-    assert gdal.VSIStatL(str(tmp_vsimem)) is not None
+    assert isinstance(tmp_vsimem, os.PathLike)
+
+    assert gdal.VSIStatL(tmp_vsimem) is not None

--- a/swig/include/python/python_strings.i
+++ b/swig/include/python/python_strings.i
@@ -103,6 +103,44 @@ static char* GDALPythonObjectToCStr(PyObject* pyObject, int* pbToFree)
   }
 }
 
+static char * GDALPythonPathToCStr(PyObject* pyObject, int* pbToFree) CPL_UNUSED;
+static char * GDALPythonPathToCStr(PyObject* pyObject, int* pbToFree)
+{
+    PyObject* os = PyImport_ImportModule("os");
+    if (os == NULL)
+    {
+        return NULL;
+    }
+
+    PyObject* pathLike = PyObject_GetAttrString(os, "PathLike");
+    if (pathLike == NULL)
+    {
+        Py_DECREF(os);
+        return NULL;
+    }
+
+    if (!PyObject_IsInstance(pyObject, pathLike))
+    {
+        Py_DECREF(pathLike);
+        Py_DECREF(os);
+        return NULL;
+    }
+
+    PyObject* str = PyObject_Str(pyObject);
+    char* ret = NULL;
+    if (str != NULL)
+    {
+        ret = GDALPythonObjectToCStr(str, pbToFree);
+        Py_DECREF(str);
+    }
+
+    Py_DECREF(pathLike);
+    Py_DECREF(os);
+
+    return ret;
+}
+
+
 static void GDALPythonFreeCStr(void* ptr, int bToFree) CPL_UNUSED;
 static void GDALPythonFreeCStr(void* ptr, int bToFree)
 {

--- a/swig/include/python/typemaps_python.i
+++ b/swig/include/python/typemaps_python.i
@@ -2146,10 +2146,18 @@ DecomposeSequenceOf4DCoordinates( PyObject *seq, int nCount, double *x, double *
 %typemap(in) (const char *utf8_path) (int bToFree = 0)
 {
     /* %typemap(in) (const char *utf8_path) */
-    $1 = GDALPythonObjectToCStr( $input, &bToFree );
+    if (PyUnicode_Check($input) || PyBytes_Check($input))
+    {
+        $1 = GDALPythonObjectToCStr( $input, &bToFree );
+    }
+    else
+    {
+        $1 = GDALPythonPathToCStr($input, &bToFree);
+
+    }
     if ($1 == NULL)
     {
-        PyErr_SetString( PyExc_RuntimeError, "not a string" );
+        PyErr_SetString( PyExc_RuntimeError, "not a string or os.PathLike" );
         SWIG_fail;
     }
 }


### PR DESCRIPTION
## What does this PR do?

Coerces path-like data types to a string when calling functions such as `gdal.Open` that have a `const char *utf8_path` argument.

## What are related issues/pull requests?

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed