### PR TITLE
autotest: test that Python bool can be used in options dict

### DIFF
--- a/autotest/gcore/basic_test.py
+++ b/autotest/gcore/basic_test.py
@@ -548,36 +548,51 @@ def test_basic_dict_open_options():
     assert ds1.GetGeoTransform() != ds2.GetGeoTransform()
 
 
-def test_basic_dict_create_options():
+@pytest.mark.parametrize(
+    "create_tfw", (True, False, "TRUE", "FALSE", "YES", "NO", "ON", "OFF")
+)
+def test_basic_dict_create_options(tmp_vsimem, create_tfw):
 
     with gdal.GetDriverByName("GTiff").Create(
-        "/vsimem/test_basic_dict_create_options.tif", 1, 1, options={"TFW": "YES"}
+        tmp_vsimem / "test_basic_dict_create_options.tif",
+        1,
+        1,
+        options={"TFW": create_tfw},
     ) as ds:
         gt = (0.0, 5.0, 0.0, 5.0, 0.0, -5.0)
         ds.SetGeoTransform(gt)
 
-    assert gdal.VSIStatL("/vsimem/test_basic_dict_create_options.tfw") is not None
+    if create_tfw in (True, "TRUE", "YES", "ON"):
+        assert (
+            gdal.VSIStatL(tmp_vsimem / "test_basic_dict_create_options.tfw") is not None
+        )
+    else:
+        assert gdal.VSIStatL(tmp_vsimem / "test_basic_dict_create_options.tfw") is None
 
-    gdal.Unlink("/vsimem/test_basic_dict_create_options.tif")
-    gdal.Unlink("/vsimem/test_basic_dict_create_options.tfw")
 
-
-def test_basic_dict_create_copy_options():
+@pytest.mark.parametrize("create_tfw", (True, False))
+def test_basic_dict_create_copy_options(tmp_vsimem, create_tfw):
 
     src_ds = gdal.Open("data/byte.tif")
 
     with gdal.GetDriverByName("GTiff").CreateCopy(
-        "/vsimem/test_basic_dict_create_copy_options.tif",
+        tmp_vsimem / "test_basic_dict_create_copy_options.tif",
         src_ds,
-        options={"TFW": "YES"},
+        options={"TFW": create_tfw},
     ) as ds:
         gt = (0.0, 5.0, 0.0, 5.0, 0.0, -5.0)
         ds.SetGeoTransform(gt)
 
-    assert gdal.VSIStatL("/vsimem/test_basic_dict_create_copy_options.tfw") is not None
-
-    gdal.Unlink("/vsimem/test_basic_dict_create_copy_options.tif")
-    gdal.Unlink("/vsimem/test_basic_dict_create_copy_options.tfw")
+    if create_tfw:
+        assert (
+            gdal.VSIStatL(tmp_vsimem / "test_basic_dict_create_copy_options.tfw")
+            is not None
+        )
+    else:
+        assert (
+            gdal.VSIStatL(tmp_vsimem / "test_basic_dict_create_copy_options.tfw")
+            is None
+        )
 
 
 def test_gdal_getspatialref():


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Adds a test case using Python bools for options (instead of "TRUE", "FALSE", etc.) I was going to add this behavior but discovered that it already exists.

## What are related issues/pull requests?

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
