### PR TITLE
autotest: use gdal.quiet_errors()

### DIFF
--- a/autotest/alg/applyverticalshiftgrid.py
+++ b/autotest/alg/applyverticalshiftgrid.py
@@ -102,7 +102,7 @@ def test_applyverticalshiftgrid_2():
             grid_ds.SetProjection(sr.ExportToWkt())
         if i == 5:
             grid_ds.AddBand(gdal.GDT_Byte)
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             out_ds = gdal.ApplyVerticalShiftGrid(src_ds, grid_ds)
         assert out_ds is None, i
 
@@ -113,7 +113,7 @@ def test_applyverticalshiftgrid_2():
     grid_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
     grid_ds.SetGeoTransform([0, 1, 0, 0, 0, -1])
     grid_ds.SetProjection(sr.ExportToWkt())
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdal.ApplyVerticalShiftGrid(src_ds, grid_ds)
     assert out_ds is None
 
@@ -124,7 +124,7 @@ def test_applyverticalshiftgrid_2():
     grid_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
     grid_ds.SetGeoTransform([0, 0, 0, 0, 0, 0])
     grid_ds.SetProjection(sr.ExportToWkt())
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdal.ApplyVerticalShiftGrid(src_ds, grid_ds)
     assert out_ds is None
 
@@ -136,7 +136,7 @@ def test_applyverticalshiftgrid_2():
     grid_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
     grid_ds.SetGeoTransform([0, 1, 0, 0, 0, -1])
     grid_ds.SetProjection('LOCAL_CS["foo"]')
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdal.ApplyVerticalShiftGrid(src_ds, grid_ds)
     assert out_ds is None
 
@@ -148,7 +148,7 @@ def test_applyverticalshiftgrid_2():
         grid_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
         grid_ds.SetGeoTransform([0, 1, 0, 0, 0, -1])
         grid_ds.SetProjection(sr.ExportToWkt())
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             out_ds = gdal.ApplyVerticalShiftGrid(
                 src_ds, grid_ds, options=["BLOCKSIZE=2000000000"]
             )
@@ -161,7 +161,7 @@ def test_applyverticalshiftgrid_2():
     grid_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
     grid_ds.SetGeoTransform([0, 1, 0, 0, 0, -1])
     grid_ds.SetProjection(sr.ExportToWkt())
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdal.ApplyVerticalShiftGrid(src_ds, grid_ds, options=["DATATYPE=x"])
     assert out_ds is None
 

--- a/autotest/alg/rasterize.py
+++ b/autotest/alg/rasterize.py
@@ -30,7 +30,6 @@
 
 import struct
 
-import gdaltest
 import ogrtest
 import pytest
 
@@ -121,7 +120,7 @@ def test_rasterize_2():
 
     # Run the algorithm.
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         err = gdal.RasterizeLayer(
             target_ds,
             [3, 2, 1],
@@ -467,7 +466,7 @@ def test_rasterize_7():
 
     # Run the algorithm.
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         err = gdal.RasterizeLayer(
             target_ds,
             [1],

--- a/autotest/gcore/basic_test.py
+++ b/autotest/gcore/basic_test.py
@@ -61,7 +61,7 @@ def matches_non_existing_error_msg(msg):
 
 
 def test_basic_test_1():
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("non_existing_ds", gdal.GA_ReadOnly)
     if ds is None and matches_non_existing_error_msg(gdal.GetLastErrorMsg()):
         return
@@ -90,7 +90,7 @@ def test_basic_test_strace_non_existing_file():
 
 
 def test_basic_test_2():
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("non_existing_ds", gdal.GA_Update)
     if ds is None and matches_non_existing_error_msg(gdal.GetLastErrorMsg()):
         return
@@ -98,7 +98,7 @@ def test_basic_test_2():
 
 
 def test_basic_test_3():
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("", gdal.GA_ReadOnly)
     if ds is None and matches_non_existing_error_msg(gdal.GetLastErrorMsg()):
         return
@@ -106,7 +106,7 @@ def test_basic_test_3():
 
 
 def test_basic_test_4():
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("", gdal.GA_Update)
     if ds is None and matches_non_existing_error_msg(gdal.GetLastErrorMsg()):
         return
@@ -114,7 +114,7 @@ def test_basic_test_4():
 
 
 def test_basic_test_5():
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/doctype.xml", gdal.GA_ReadOnly)
     last_error = gdal.GetLastErrorMsg()
     expected = "`data/doctype.xml' not recognized as a supported file format"
@@ -298,7 +298,7 @@ def test_basic_test_11():
     ds = gdal.OpenEx("data/byte.tif", allowed_drivers=["PNG"])
     assert ds is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx("data/byte.tif", open_options=["FOO"])
     assert ds is not None
 
@@ -324,7 +324,7 @@ def test_basic_test_11():
     ds = gdal.OpenEx("non existing")
     assert ds is None and gdal.GetLastErrorMsg() == ""
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx("non existing", gdal.OF_VERBOSE_ERROR)
     assert ds is None and gdal.GetLastErrorMsg() != ""
 
@@ -419,7 +419,7 @@ def test_basic_test_14():
     ds.SetMetadata(["foo=bar"])
     assert ds.GetMetadata_List() == ["foo=bar"]
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         with pytest.raises(Exception):
             ds.SetMetadata([5])
 
@@ -429,7 +429,7 @@ def test_basic_test_14():
     ds.SetMetadata({"foo": b"baz"})
     assert ds.GetMetadata_List() == ["foo=baz"]
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         with pytest.raises(Exception):
             ds.SetMetadata({"foo": b"zero_byte_in_string\0"})
 
@@ -495,24 +495,24 @@ def test_basic_test_15():
     mem_driver = gdal.GetDriverByName("MEM")
 
     with pytest.raises(Exception):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             gdal.GetDriverByName("MEM").CreateCopy(
                 "", gdal.GetDriverByName("MEM").Create("", 1, 1), callback="foo"
             )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = mem_driver.CreateCopy(
             "", mem_driver.Create("", 1, 1), callback=basic_test_15_cbk_no_argument
         )
     assert ds is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = mem_driver.CreateCopy(
             "", mem_driver.Create("", 1, 1), callback=basic_test_15_cbk_no_ret
         )
     assert ds is not None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = mem_driver.CreateCopy(
             "", mem_driver.Create("", 1, 1), callback=basic_test_15_cbk_bad_ret
         )
@@ -531,7 +531,7 @@ def test_basic_test_16():
 
     gdal.ErrorReset()
     gdal.Translate("/vsimem/temp.tif", "data/byte.tif", options="-co BLOCKYSIZE=10")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.OpenEx(
             "/vsimem/temp.tif", gdal.OF_UPDATE, open_options=["@NUM_THREADS=INVALID"]
         )

--- a/autotest/gcore/cog.py
+++ b/autotest/gcore/cog.py
@@ -197,7 +197,7 @@ def test_cog_creation_options():
 
     if "<Value>WEBP" in colist:
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert not gdal.GetDriverByName("COG").CreateCopy(
                 filename, src_ds, options=["COMPRESS=WEBP"]
             )
@@ -242,7 +242,7 @@ def test_cog_creation_options():
             assert filesize_lerc_zstd_level_1 > filesize_lerc_zstd
 
     src_ds = None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("GTiff").Delete(filename)
 
 
@@ -772,11 +772,11 @@ def test_cog_invalidation_by_data_change():
     src_ds = gdal.Open("data/byte.tif")
     data = src_ds.ReadRaster()
     ds.GetRasterBand(1).WriteRaster(0, 0, 20, 20, data)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.FlushCache() == gdal.CE_None
     ds = None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(filename)
     assert ds.GetMetadataItem("LAYOUT", "IMAGE_STRUCTURE") is None
     ds = None
@@ -786,7 +786,7 @@ def test_cog_invalidation_by_data_change():
     ):
         _check_cog(filename)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("GTiff").Delete(filename)
 
 
@@ -809,12 +809,12 @@ def test_cog_invalidation_by_metadata_change():
     ds.GetRasterBand(1).ComputeStatistics(False)
     ds = None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(filename)
     assert ds.GetMetadataItem("LAYOUT", "IMAGE_STRUCTURE") is None
     ds = None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("GTiff").Delete(filename)
 
 
@@ -1319,7 +1319,7 @@ def test_cog_zoom_level():
     filename = "/vsimem/test_cog_zoom_level.tif"
     src_ds = gdal.Open("data/byte.tif")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             gdal.GetDriverByName("COG").CreateCopy(
                 filename,
@@ -1425,7 +1425,7 @@ def test_cog_invalid_warp_resampling():
     filename = "/vsimem/test_cog_invalid_warp_resampling.tif"
     src_ds = gdal.Open("data/byte.tif")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             gdal.GetDriverByName("COG").CreateCopy(
                 filename,
@@ -1481,7 +1481,7 @@ def test_cog_float32_color_table():
     src_ds.GetRasterBand(1).SetColorTable(ct)
     filename = "/vsimem/test_cog_float32_color_table.tif"
     # Silence warning about color table not being copied
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.GetDriverByName("COG").CreateCopy(filename, src_ds)  # segfault
     assert ds
     assert ds.GetRasterBand(1).GetColorTable() is None
@@ -1617,7 +1617,7 @@ def test_cog_overview_count(options, expected_count):
 
     tmpfilename = "/vsimem/test_cog_overview_count.tif"
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.Translate(
             tmpfilename,
             "../gdrivers/data/small_world.tif",

--- a/autotest/gcore/geoloc.py
+++ b/autotest/gcore/geoloc.py
@@ -610,7 +610,7 @@ def test_geoloc_warnings_inconsistent_size(
     }
     ds.SetMetadata(md, "GEOLOCATION")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.ErrorReset()
         tr = gdal.Transformer(ds, None, [])
         if warning_expected:

--- a/autotest/gcore/hfa_srs.py
+++ b/autotest/gcore/hfa_srs.py
@@ -259,7 +259,7 @@ def test_hfa_srs_NAD83_CORS96_UTM():
 
 def test_hfa_srs_esri_54049_pe_string_only_broken():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("../gdrivers/data/hfa/esri_54049_pe_string_only_broken.img")
     assert gdal.GetLastErrorType() == gdal.CE_Warning
     srs_got = ds.GetSpatialRef()

--- a/autotest/gcore/histogram.py
+++ b/autotest/gcore/histogram.py
@@ -747,7 +747,7 @@ def test_histogram_errors():
 def test_histogram_invalid_min_max(min, max):
 
     ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.ErrorReset()
         ret = ds.GetRasterBand(1).GetHistogram(
             buckets=2, min=min, max=max, include_out_of_range=1, approx_ok=0

--- a/autotest/gcore/mask.py
+++ b/autotest/gcore/mask.py
@@ -481,7 +481,7 @@ def test_mask_14():
     src_ds = None
 
     # The only flag value supported for internal mask is GMF_PER_DATASET
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         with gdaltest.config_option("GDAL_TIFF_INTERNAL_MASK", "YES"):
             ret = ds.CreateMaskBand(0)
     assert ret != 0, "Error expected"
@@ -500,13 +500,13 @@ def test_mask_14():
     assert cs == 400, "Got wrong checksum for the mask (2)"
 
     # This TIFF dataset has already an internal mask band
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         with gdaltest.config_option("GDAL_TIFF_INTERNAL_MASK", "YES"):
             ret = ds.CreateMaskBand(gdal.GMF_PER_DATASET)
     assert ret != 0, "Error expected"
 
     # This TIFF dataset has already an internal mask band
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         with gdaltest.config_option("GDAL_TIFF_INTERNAL_MASK", "YES"):
             ret = ds.GetRasterBand(1).CreateMaskBand(gdal.GMF_PER_DATASET)
     assert ret != 0, "Error expected"
@@ -916,7 +916,7 @@ def test_mask_25():
     ds.SetMetadataItem("INTERNAL_MASK_FLAGS_2", "0")
     ds = None
     ds = gdal.Open("/vsimem/mask_25.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.GetRasterBand(2).GetMaskFlags() == gdal.GMF_ALL_VALID
     ds = None
     gdal.Unlink("/vsimem/mask_25.tif")
@@ -925,14 +925,14 @@ def test_mask_25():
     # Invalid sequences of CreateMaskBand() calls
     ds = gdal.GetDriverByName("GTiff").Create("/vsimem/mask_25.tif", 1, 1, 2)
     ds.GetRasterBand(1).CreateMaskBand(gdal.GMF_PER_DATASET)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.GetRasterBand(2).CreateMaskBand(0) != 0
     ds = None
     gdal.Unlink("/vsimem/mask_25.tif")
     gdal.Unlink("/vsimem/mask_25.tif.msk")
 
     # CreateMaskBand not supported by this dataset
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
         ds.CreateMaskBand(0)
 

--- a/autotest/gcore/minixml.py
+++ b/autotest/gcore/minixml.py
@@ -30,7 +30,6 @@
 ###############################################################################
 
 
-import gdaltest
 import pytest
 
 from osgeo import gdal
@@ -164,7 +163,7 @@ def test_minixml_5():
     )
 
     for xml_str, expect in test_pairs:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             tree = gdal.ParseXMLString(xml_str)
 
         found = gdal.GetLastErrorMsg()

--- a/autotest/gcore/misc.py
+++ b/autotest/gcore/misc.py
@@ -81,12 +81,12 @@ def test_misc_2():
 @pytest.mark.require_driver("PAUX")
 def test_misc_3():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenShared("../gdrivers/data/paux/small16.aux")
     ds.GetRasterBand(1).Checksum()
     cache_size = gdal.GetCacheUsed()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds2 = gdal.OpenShared("../gdrivers/data/paux/small16.aux")
     ds2.GetRasterBand(1).Checksum()
     cache_size2 = gdal.GetCacheUsed()
@@ -104,7 +104,7 @@ def test_misc_3():
 
 def test_misc_4():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
 
         # Test a few invalid argument
         drv = gdal.GetDriverByName("GTiff")
@@ -205,7 +205,7 @@ def _misc_5_internal(drv, datatype, nBands):
 
 def test_misc_5():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
 
         try:
             shutil.rmtree("tmp/tmp")
@@ -457,7 +457,7 @@ def misc_6_internal(datatype, nBands, setDriversDone):
 
 def test_misc_6():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
 
         try:
             shutil.rmtree("tmp/tmp")
@@ -669,7 +669,7 @@ def test_misc_12():
             )
 
             # Test to detect crashes
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ds = drv.CreateCopy("/nonexistingpath" + get_filename(drv, ""), src_ds)
             if ds is None and gdal.GetLastErrorMsg() == "":
                 gdal.Unlink("/vsimem/misc_12_src.tif")
@@ -720,7 +720,7 @@ def test_misc_13():
 
     # Raster-only -> vector-only
     ds = gdal.Open("data/byte.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdal.GetDriverByName("ESRI Shapefile").CreateCopy(
             "/vsimem/out.shp", ds
         )
@@ -728,7 +728,7 @@ def test_misc_13():
 
     # Raster-only -> vector-only
     ds = gdal.OpenEx("../ogr/data/poly.shp", gdal.OF_VECTOR)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdal.GetDriverByName("GTiff").CreateCopy("/vsimem/out.tif", ds)
     assert out_ds is None
 

--- a/autotest/gcore/multidim.py
+++ b/autotest/gcore/multidim.py
@@ -127,7 +127,7 @@ def test_multidim_getresampled(resampling):
     assert ar
 
     if resampling == gdal.GRIORA_Gauss:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             resampled_ar = ar.GetResampled(
                 [None] * ar.GetDimensionCount(), resampling, None
             )
@@ -323,7 +323,7 @@ def test_multidim_getresampled_error_single_dim():
     rg = mem_ds.GetRootGroup()
     dimX = rg.CreateDimension("X", None, None, 3)
     ar = rg.CreateMDArray("ar", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         resampled_ar = ar.GetResampled([None], gdal.GRIORA_NearestNeighbour, None)
         assert resampled_ar is None
 
@@ -339,7 +339,7 @@ def test_multidim_getresampled_error_too_large_y():
         "ar", [dimY, dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
     )
     new_dimY = rg.CreateDimension("Y", None, None, 4 * 1000 * 1000 * 1000)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         resampled_ar = ar.GetResampled(
             [new_dimY, None], gdal.GRIORA_NearestNeighbour, None
         )
@@ -357,7 +357,7 @@ def test_multidim_getresampled_error_too_large_x():
         "ar", [dimY, dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
     )
     new_dimX = rg.CreateDimension("Y", None, None, 4 * 1000 * 1000 * 1000)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         resampled_ar = ar.GetResampled(
             [None, new_dimX], gdal.GRIORA_NearestNeighbour, None
         )
@@ -374,7 +374,7 @@ def test_multidim_getresampled_error_no_geotransform():
     ar = rg.CreateMDArray(
         "ar", [dimY, dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         resampled_ar = ar.GetResampled([None, None], gdal.GRIORA_NearestNeighbour, None)
         assert resampled_ar is None
 
@@ -395,7 +395,7 @@ def test_multidim_getresampled_error_extra_dim_not_same():
     )
 
     dimOtherNew = rg.CreateDimension("otherNew", None, None, 1)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         resampled_ar = ar.GetResampled(
             [dimOtherNew, None, None], gdal.GRIORA_NearestNeighbour, None
         )
@@ -409,11 +409,11 @@ def test_multidim_getresampled_bad_input_dim_count():
     ar = band.AsMDArray()
     assert ar
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         resampled_ar = ar.GetResampled([None], gdal.GRIORA_NearestNeighbour, None)
         assert resampled_ar is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         resampled_ar = ar.GetResampled(
             [None, None, None], gdal.GRIORA_NearestNeighbour, None
         )
@@ -452,7 +452,7 @@ def test_multidim_getgridded():
         == gdal.CE_None
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ar.GetGridded("invdist") is None
         assert ar.GetGridded("invdist", varX) is None
         assert ar.GetGridded("invdist", None, varY) is None
@@ -524,17 +524,17 @@ def test_multidim_getgridded():
 
     # Not enough coordinate variables
     assert coordinates.WriteString("other varY") == 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ar.GetGridded("invdist:nodata=nan") is None
 
     # Too many coordinate variables
     assert coordinates.WriteString("other unrelated varY varX") == 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ar.GetGridded("invdist:nodata=nan") is None
 
     # poYArray->GetDimensions()[0]->GetFullName() != poXArray->GetDimensions()[0]->GetFullName()
     assert coordinates.WriteString("other unrelated varX") == 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ar.GetGridded("invdist:nodata=nan") is None
 
     assert coordinates.WriteString("other varY varX") == 0
@@ -575,7 +575,7 @@ def test_multidim_getgridded():
         "d", [20, 20, 20, 30, 30, 30]
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # Cannot read more than one sample in the non X/Y dimensions
         assert gridded.Read() is None
 

--- a/autotest/gcore/numpy_rw.py
+++ b/autotest/gcore/numpy_rw.py
@@ -659,19 +659,19 @@ def test_numpy_rw_16():
 
     # 1D
     array = numpy.empty([1], numpy.uint8)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal_array.OpenArray(array)
     assert ds is None
 
     # 4D
     array = numpy.empty([1, 1, 1, 1], numpy.uint8)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal_array.OpenArray(array)
     assert ds is None
 
     # Unsupported data type
     array = numpy.empty([1, 1], numpy.float16)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal_array.OpenArray(array)
     assert ds is None
 
@@ -684,7 +684,7 @@ def test_numpy_rw_17():
 
     # Disabled by default
     array = numpy.empty([1, 1], numpy.uint8)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(gdal_array.GetArrayFilename(array))
     assert ds is None
 
@@ -693,7 +693,7 @@ def test_numpy_rw_17():
     assert ds is not None
 
     # Invalid value
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("NUMPY:::invalid")
     assert ds is None
 
@@ -765,12 +765,12 @@ def test_numpy_rw_gdal_array_openarray_permissions():
     ar = numpy.zeros([1, 1], dtype=numpy.uint8)
     ar.setflags(write=False)
     ds = gdal_array.OpenArray(ar)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.GetRasterBand(1).Fill(1) != 0
     assert ds.GetRasterBand(1).Checksum() == 0
 
     # Cannot read in non-writeable array
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.ReadAsArray(buf_obj=ar) is None
         assert ds.GetRasterBand(1).ReadAsArray(buf_obj=ar) is None
 
@@ -975,6 +975,6 @@ def test_numpy_rw_band_read_as_array_getlasterrormsg():
 </VRTDataset>"""
     )
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.GetRasterBand(1).ReadAsArray() is None
     assert gdal.GetLastErrorMsg() != ""

--- a/autotest/gcore/pam.py
+++ b/autotest/gcore/pam.py
@@ -372,7 +372,7 @@ def test_pam_11():
     stats = ds.GetRasterBand(1).ComputeStatistics(False)
     assert stats[0] == 74, "did not get expected minimum"
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = None
     error_msg = gdal.GetLastErrorMsg()
     assert error_msg.startswith(

--- a/autotest/gcore/rasterio.py
+++ b/autotest/gcore/rasterio.py
@@ -243,7 +243,7 @@ def test_rasterio_5():
 
     for band_number in [-1, 0, 2]:
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             res = ds.ReadRaster(0, 0, 1, 1, band_list=[band_number])
         error_msg = gdal.GetLastErrorMsg()
         assert res is None, "expected None"
@@ -256,7 +256,7 @@ def test_rasterio_5():
 
     for obj in [ds, ds.GetRasterBand(1)]:
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             res = obj.ReadRaster(0, 0, 21, 21)
         error_msg = gdal.GetLastErrorMsg()
         assert res is None, "expected None"
@@ -276,7 +276,7 @@ def test_rasterio_5():
         # to detect win64 better.
         if maxsize == 2147483647 and sys.platform != "win32":
             gdal.ErrorReset()
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 res = obj.ReadRaster(0, 0, 1, 1, 1000000, 1000000)
             error_msg = gdal.GetLastErrorMsg()
             assert res is None, "expected None"
@@ -285,7 +285,7 @@ def test_rasterio_5():
             ), "did not get expected error msg (2)"
 
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             res = obj.ReadRaster(0, 0, 0, 1)
         error_msg = gdal.GetLastErrorMsg()
         assert res is None, "expected None"
@@ -309,7 +309,7 @@ def test_rasterio_6():
             obj.WriteRaster(0, 0, 2, 2, None)
 
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             obj.WriteRaster(0, 0, 2, 2, " ")
         error_msg = gdal.GetLastErrorMsg()
         assert (
@@ -317,7 +317,7 @@ def test_rasterio_6():
         ), "did not get expected error msg (1)"
 
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             obj.WriteRaster(-1, 0, 1, 1, " ")
         error_msg = gdal.GetLastErrorMsg()
         assert (
@@ -325,7 +325,7 @@ def test_rasterio_6():
         ), "did not get expected error msg (2)"
 
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             obj.WriteRaster(0, 0, 0, 1, " ")
         error_msg = gdal.GetLastErrorMsg()
         assert (
@@ -603,7 +603,7 @@ def test_rasterio_9():
 
     # Test interruption
     tab = [0, 0.5]
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         data = ds.GetRasterBand(1).ReadRaster(
             buf_xsize=10,
             buf_ysize=10,
@@ -733,17 +733,17 @@ def test_rasterio_9():
 def test_rasterio_10():
     ds = gdal.Open("data/byte_truncated.tif")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         data = ds.GetRasterBand(1).ReadRaster()
     assert data is None
 
     # Change buffer type
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         data = ds.GetRasterBand(1).ReadRaster(buf_type=gdal.GDT_Int16)
     assert data is None
 
     # Resampling case
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         data = ds.GetRasterBand(1).ReadRaster(buf_xsize=10, buf_ysize=10)
     assert data is None
 
@@ -1284,7 +1284,7 @@ def test_rasterio_rasterband_write_on_readonly():
 
     ds = gdal.Open("data/byte.tif")
     band = ds.GetRasterBand(1)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         err = band.WriteRaster(0, 0, 20, 20, band.ReadRaster())
     assert err != 0
 
@@ -1292,7 +1292,7 @@ def test_rasterio_rasterband_write_on_readonly():
 def test_rasterio_dataset_write_on_readonly():
 
     ds = gdal.Open("data/byte.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         err = ds.WriteRaster(0, 0, 20, 20, ds.ReadRaster())
     assert err != 0
 
@@ -1301,7 +1301,7 @@ def test_rasterio_dataset_write_on_readonly():
 def test_rasterio_dataset_invalid_resample_alg(resample_alg):
 
     mem_ds = gdal.GetDriverByName("MEM").Create("", 2, 2)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         with pytest.raises(Exception):
             assert (
                 mem_ds.ReadRaster(buf_xsize=1, buf_ysize=1, resample_alg=resample_alg)
@@ -2884,7 +2884,7 @@ def test_rasterio_readraster_in_existing_buffer():
     assert ds.ReadRaster(buf_obj=bytearray([0, 0])) == ar
     # buf_obj is larger than expected
     assert ds.ReadRaster(buf_obj=bytearray([0, 0, 10])) == bytearray([1, 2, 10])
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # buf_obj is a wrong object type
         assert ds.ReadRaster(buf_obj=123) is None
         # buf_obj is not large enough
@@ -2896,7 +2896,7 @@ def test_rasterio_readraster_in_existing_buffer():
     assert band.ReadRaster(buf_obj=bytearray([0, 0])) == ar
     # buf_obj is larger than expected
     assert band.ReadRaster(buf_obj=bytearray([0, 0, 10])) == bytearray([1, 2, 10])
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # buf_obj is a wrong object type
         assert band.ReadRaster(buf_obj=123) is None
         # buf_obj is not large enough
@@ -2922,7 +2922,7 @@ def test_rasterio_readblock_in_existing_buffer():
     assert band.ReadBlock(0, 0, buf_obj=bytearray([0, 0])) == ar
     # buf_obj is larger than expected
     assert band.ReadBlock(0, 0, buf_obj=bytearray([0, 0, 10])) == bytearray([1, 2, 10])
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # buf_obj is a wrong object type
         assert band.ReadBlock(0, 0, buf_obj=123) is None
         # buf_obj is not large enough
@@ -2962,7 +2962,7 @@ def test_rasterio_readraster_in_existing_buffer_alignment_issues(datatype):
     # buf_obj has appropriate alignment
     assert ds.ReadRaster(buf_obj=bytearray([0] * buffer_size)) == ar
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # buf_obj has not appropriate alignment
         assert (
             ds.ReadRaster(buf_obj=memoryview(bytearray([0] * (buffer_size + 1)))[1:])
@@ -2972,7 +2972,7 @@ def test_rasterio_readraster_in_existing_buffer_alignment_issues(datatype):
     # buf_obj has appropriate alignment
     assert band.ReadRaster(buf_obj=bytearray([0] * buffer_size)) == ar
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # buf_obj has not appropriate alignment
         assert (
             band.ReadRaster(buf_obj=memoryview(bytearray([0] * (buffer_size + 1)))[1:])
@@ -2982,7 +2982,7 @@ def test_rasterio_readraster_in_existing_buffer_alignment_issues(datatype):
     # buf_obj has appropriate alignment
     assert band.ReadBlock(0, 0, buf_obj=bytearray([0] * buffer_size)) == ar
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # buf_obj has not appropriate alignment
         assert (
             band.ReadBlock(0, 0, buf_obj=memoryview(bytearray([0] * (2 * 8 + 1)))[1:])

--- a/autotest/gcore/tiff_ovr.py
+++ b/autotest/gcore/tiff_ovr.py
@@ -837,7 +837,7 @@ def test_tiff_ovr_22(tmp_path, both_endian):
     # 170 k * 100 k = 17 GB. 17 GB / (2^2) = 4.25 GB > 4.2 GB
     # so BigTIFF is needed
     with gdaltest.config_option("BIGTIFF_OVERVIEW", "NO"):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             err = ds.BuildOverviews("NONE", overviewlist=[2])
 
     ds = None
@@ -1615,7 +1615,7 @@ def test_tiff_ovr_43(tmp_path, both_endian):
 
     with gdaltest.config_option("CPL_ACCUM_ERROR_MSG", "ON"):
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             try:
                 ds = gdal.Open("data/mandrilmini_12bitjpeg.tif")
                 ds.GetRasterBand(1).ReadRaster(0, 0, 1, 1)

--- a/autotest/gcore/tiff_read.py
+++ b/autotest/gcore/tiff_read.py
@@ -148,7 +148,7 @@ def test_tiff_read_off_errors(filename):
 def test_tiff_read_off_error_update():
     # Opening a specific TIFF directory is not supported in update mode.
     # Switching to read-only
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("GTIFF_DIR:1:data/byte.tif", gdal.GA_Update)
     assert ds is not None
 
@@ -264,7 +264,7 @@ def test_tiff_read_cmyk_raw():
 @pytest.mark.require_creation_option("GTiff", "JPEG")
 def test_tiff_read_ojpeg():
     with gdal.ExceptionMgr(useExceptions=False):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.Open("data/zackthecat.tif")
             if ds is None:
                 assert (
@@ -273,7 +273,7 @@ def test_tiff_read_ojpeg():
                 )
                 pytest.skip("OJPEG codec missing")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         got_cs = ds.GetRasterBand(1).Checksum()
     expected_cs = 61570
     assert got_cs == expected_cs, "Expected checksum = %d. Got = %d" % (
@@ -282,14 +282,14 @@ def test_tiff_read_ojpeg():
     )
 
     # should fail with internal libtiff
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/zackthecat_corrupted.tif")
     if gdal.GetDriverByName("GTiff").GetMetadataItem("LIBTIFF") == "INTERNAL":
         with pytest.raises(Exception):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ds.GetRasterBand(1).Checksum()
     else:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             with gdal.ExceptionMgr(useExceptions=False):
                 ds.GetRasterBand(1).Checksum()
 
@@ -931,7 +931,7 @@ def test_tiff_read_tiepoints_pixelispoint():
 
 def test_tiff_read_corrupted_gtiff():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.Open("data/corrupted_gtiff_tags.tif")
 
 
@@ -959,13 +959,13 @@ def test_tiff_read_buggy_packbits():
     with gdal.config_option("GTIFF_IGNORE_READ_ERRORS", None):
         ds = gdal.Open("data/byte_buggy_packbits.tif")
     with pytest.raises(Exception):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds.ReadRaster(0, 0, 20, 20)
     ds = None
 
     with gdal.config_option("GTIFF_IGNORE_READ_ERRORS", "YES"):
         ds = gdal.Open("data/byte_buggy_packbits.tif")
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             with gdal.ExceptionMgr(useExceptions=False):
                 ret = ds.ReadRaster(0, 0, 20, 20)
         assert ret is not None, "expected a valid result"
@@ -1047,7 +1047,7 @@ def test_tiff_small():
 
 def test_tiff_dos_strip_chop():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/tiff_dos_strip_chop.tif")
     del ds
 
@@ -2794,7 +2794,7 @@ def test_tiff_read_scanline_more_than_2GB():
 def test_tiff_read_wrong_number_extrasamples():
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/6band_wrong_number_extrasamples.tif")
         assert "Wrong number of ExtraSamples" in gdal.GetLastErrorMsg()
     assert ds.GetRasterBand(6).GetRasterColorInterpretation() == gdal.GCI_AlphaBand
@@ -2806,7 +2806,7 @@ def test_tiff_read_wrong_number_extrasamples():
 
 def test_tiff_read_one_strip_no_bytecount():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/one_strip_nobytecount.tif")
     assert ds.GetRasterBand(1).Checksum() == 1
 
@@ -3315,7 +3315,7 @@ def test_tiff_read_corrupted_jpeg_cloud_optimized():
     cs0 = ds.GetRasterBand(1).Checksum()
     assert cs0 == 4743
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         cs1 = ds.GetRasterBand(1).GetOverview(0).Checksum()
     if cs1 == -1:
         print("Expected error while writing overview with libjpeg-6b")
@@ -3490,7 +3490,7 @@ def test_tiff_read_minimum_tiff_tags_no_warning():
 def test_tiff_read_minimum_tiff_tags_with_warning():
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/minimum_tiff_tags_with_warning.tif")
     assert gdal.GetLastErrorMsg() != ""
     gdal.ErrorReset()
@@ -3542,7 +3542,7 @@ def test_tiff_read_leak_ZIPSetupDecode():
     if not check_libtiff_internal_or_at_least(4, 0, 8):
         pytest.skip()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/leak-ZIPSetupDecode.tif")
         for i in range(ds.RasterCount):
             with pytest.raises(Exception):
@@ -3557,7 +3557,7 @@ def test_tiff_read_excessive_memory_TIFFFillStrip():
     if not check_libtiff_internal_or_at_least(4, 0, 8):
         pytest.skip()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/excessive-memory-TIFFFillStrip.tif")
         for i in range(ds.RasterCount):
             with pytest.raises(Exception):
@@ -3572,7 +3572,7 @@ def test_tiff_read_excessive_memory_TIFFFillStrip2():
     if not check_libtiff_internal_or_at_least(4, 0, 8):
         pytest.skip()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/excessive-memory-TIFFFillStrip2.tif")
         with pytest.raises(Exception):
             ds.GetRasterBand(1).Checksum()
@@ -3586,7 +3586,7 @@ def test_tiff_read_excessive_memory_TIFFFillTile():
     if not check_libtiff_internal_or_at_least(4, 0, 8):
         pytest.skip()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/excessive-memory-TIFFFillTile.tif")
         with pytest.raises(Exception):
             ds.GetRasterBand(1).Checksum()
@@ -3670,7 +3670,7 @@ def test_tiff_read_huge_number_strips():
     if md["LIBTIFF"] != "INTERNAL":
         pytest.skip("Test for internal libtiff")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/huge-number-strips.tif")
         with pytest.raises(Exception):
             ds.GetRasterBand(1).Checksum()
@@ -3684,7 +3684,7 @@ def test_tiff_read_huge_implied_number_strips():
     if not check_libtiff_internal_or_at_least(4, 0, 10):
         pytest.skip("Test for internal libtiff or external libtiff >= 4.0.10")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         with gdal.ExceptionMgr(useExceptions=False):
             gdal.Open("data/huge-implied-number-strips.tif")
 
@@ -3742,7 +3742,7 @@ def test_tiff_read_corrupted_deflate_singlestrip():
     if not check_libtiff_internal_or_at_least(4, 0, 8):
         pytest.skip()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/corrupted_deflate_singlestrip.tif")
         with pytest.raises(Exception):
             ds.GetRasterBand(1).Checksum()
@@ -3757,7 +3757,7 @@ def test_tiff_read_packbits_not_enough_data():
     if not check_libtiff_internal_or_at_least(4, 0, 8):
         pytest.skip()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/packbits-not-enough-data.tif")
         with pytest.raises(Exception):
             ds.GetRasterBand(1).Checksum()
@@ -3844,7 +3844,7 @@ def test_tiff_read_stripoffset_types():
         ds = gdal.Open(filename)
         offsets = []
         for row in range(4):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 mdi = ds.GetRasterBand(1).GetMetadataItem(
                     "BLOCK_OFFSET_0_%d" % row, "TIFF"
                 )
@@ -3870,7 +3870,7 @@ def test_tiff_read_progressive_jpeg_denial_of_service():
     # Should error out with 'JPEGPreDecode:Reading this strip would require
     # libjpeg to allocate at least...'
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         os.environ["JPEGMEM"] = "10M"
         os.environ["LIBTIFF_JPEG_MAX_ALLOWED_SCAN_NUMBER"] = "1000"
         ds = gdal.Open("/vsizip/data/eofloop_valid_huff.tif.zip")
@@ -3882,7 +3882,7 @@ def test_tiff_read_progressive_jpeg_denial_of_service():
     # Should error out with 'TIFFjpeg_progress_monitor:Scan number...
     gdal.ErrorReset()
     ds = gdal.Open("/vsizip/data/eofloop_valid_huff.tif.zip")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         os.environ["LIBTIFF_ALLOW_LARGE_LIBJPEG_MEM_ALLOC"] = "YES"
         os.environ["LIBTIFF_JPEG_MAX_ALLOWED_SCAN_NUMBER"] = "10"
         with pytest.raises(Exception):
@@ -3902,7 +3902,7 @@ def test_tiff_read_old_style_lzw():
 
     ds = gdal.Open("data/quad-lzw-old-style.tif")
     # Shut down warning about old style LZW
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         cs = ds.GetRasterBand(1).Checksum()
     assert cs == 34282
 
@@ -3949,12 +3949,12 @@ def test_tiff_read_jpeg_too_big_last_stripe():
         pytest.skip()
 
     ds = gdal.Open("data/tif_jpeg_too_big_last_stripe.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         cs = ds.GetRasterBand(1).Checksum()
     assert cs == 4557
 
     ds = gdal.Open("data/tif_jpeg_ycbcr_too_big_last_stripe.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         cs = ds.GetRasterBand(1).Checksum()
     assert cs == 4557
 
@@ -3966,7 +3966,7 @@ def test_tiff_read_jpeg_too_big_last_stripe():
 def test_tiff_read_negative_scaley():
 
     ds = gdal.Open("data/negative_scaley.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.GetGeoTransform()[5] == -60
 
     ds = gdal.Open("data/negative_scaley.tif")
@@ -4573,7 +4573,7 @@ def test_tiff_read_unhandled_codec_unknown_name():
 @pytest.mark.require_creation_option("GTiff", "JXL")
 def test_tiff_jxl_read_for_files_created_before_6393():
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/gtiff/jxl-rgbi.tif")
         dsorig = gdal.Open("data/rgba.tif")
 
@@ -5005,7 +5005,7 @@ def test_tiff_read_multi_threaded_vsicurl_window_not_aligned_on_blocks():
 def test_tiff_warning_get_metadata_item_PIXELTYPE():
 
     ds = gdal.Open("data/byte.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.GetRasterBand(1).GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE")
     assert (
         gdal.GetLastErrorMsg()

--- a/autotest/gcore/tiff_srs.py
+++ b/autotest/gcore/tiff_srs.py
@@ -135,7 +135,7 @@ def test_srs_read_compd_cs():
 def test_tiff_srs_weird_mercator_2sp():
 
     ds = gdal.Open("data/weird_mercator_2sp.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         wkt = ds.GetProjectionRef()
     assert gdal.GetLastErrorMsg() != "", "warning expected"
     sr2 = osr.SpatialReference()
@@ -936,7 +936,7 @@ def test_tiff_srs_read_getspatialref_getgcpspatialref():
 
 def test_tiff_srs_read_VerticalUnitsGeoKey_private_range():
     ds = gdal.Open("data/gtiff/VerticalUnitsGeoKey_private_range.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sr = ds.GetSpatialRef()
     assert sr.GetName() == "NAD83 / UTM zone 16N"
     assert gdal.GetLastErrorMsg() != ""
@@ -946,7 +946,7 @@ def test_tiff_srs_read_invalid_semimajoraxis_compound():
     ds = gdal.Open("data/gtiff/invalid_semimajoraxis_compound.tif")
     # Check that it doesn't crash. PROJ >= 8.2.0 will return a NULL CRS
     # whereas previous versions will return a non-NULL one
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.GetSpatialRef()
 
 
@@ -978,7 +978,7 @@ def test_tiff_srs_try_write_derived_geographic():
 
 def test_tiff_srs_read_GeogGeodeticDatumGeoKey_reserved_range():
     ds = gdal.Open("data/gtiff/GeogGeodeticDatumGeoKey_reserved.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sr = ds.GetSpatialRef()
     assert sr.GetName() == "WGS 84 / Pseudo-Mercator"
     assert gdal.GetLastErrorMsg() != ""
@@ -997,7 +997,7 @@ def test_tiff_srs_read_invalid_GeogAngularUnitSizeGeoKey():
     # That file has GeogAngularUnitSizeGeoKey = 0
     ds = gdal.Open("data/gtiff/invalid_GeogAngularUnitSizeGeoKey.tif")
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.GetSpatialRef()
     assert gdal.GetLastErrorMsg() != ""
 
@@ -1007,7 +1007,7 @@ def test_tiff_srs_read_inconsistent_invflattening():
     # which are inconsistent with the ones from the ellipsoid of the datum
     ds = gdal.Open("data/gtiff/inconsistent_invflattening.tif")
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         srs = ds.GetSpatialRef()
     assert gdal.GetLastErrorMsg() != ""
     assert srs.GetAuthorityCode(None) == "28992"

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -340,7 +340,7 @@ def test_tiff_write_9():
 
     src_ds = gdal.Open("data/byte.tif")
     new_ds = gdaltest.tiff_drv.CreateCopy("tmp/test_9.tif", src_ds, options=["NBITS=5"])
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         new_ds = None
 
     new_ds = gdal.Open("tmp/test_9.tif")
@@ -2112,7 +2112,7 @@ def test_tiff_write_60():
 
     for options_tuple in tuples:
         # Create case
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdaltest.tiff_drv.Create(
                 "tmp/tiff_write_60.tif",
                 10,
@@ -2123,7 +2123,7 @@ def test_tiff_write_60():
         ds.SetGeoTransform(gt)
         ds = None
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.Open("tmp/tiff_write_60.tif")
         assert ds.GetGeoTransform() == gt, "case1: %s != %s" % (
             ds.GetGeoTransform(),
@@ -2137,7 +2137,7 @@ def test_tiff_write_60():
 
         # CreateCopy case
         src_ds = gdal.Open("data/byte.tif")
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdaltest.tiff_drv.CreateCopy(
                 "tmp/tiff_write_60.tif",
                 src_ds,
@@ -2230,7 +2230,7 @@ def test_tiff_write_62():
 
 def test_tiff_write_63():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdaltest.tiff_drv.Create(
             "tmp/bigtiff.tif", 150000, 150000, 1, options=["BIGTIFF=NO"]
         )
@@ -2572,7 +2572,7 @@ def test_tiff_write_74():
 
     with gdal.config_option("CPL_ACCUM_ERROR_MSG", "ON"):
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
 
             try:
                 ds = gdal.Open("data/mandrilmini_12bitjpeg.tif")
@@ -3026,7 +3026,7 @@ def test_tiff_write_81():
 def test_tiff_write_82():
 
     src_ds = gdal.Open("data/byte.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdaltest.tiff_drv.CreateCopy(
             "tmp/tiff_write_82.tif", src_ds, options=["PIXELTYPE=SIGNEDBYTE"]
         )
@@ -4929,7 +4929,7 @@ def test_tiff_write_121():
   </VRTRasterBand>
 </VRTDataset>"""
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdaltest.tiff_drv.CreateCopy(
             "/vsimem/tiff_write_121.tif", src_ds, options=["COPY_SRC_OVERVIEWS=YES"]
         )
@@ -4957,7 +4957,7 @@ def test_tiff_write_121():
   </VRTRasterBand>
 </VRTDataset>"""
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdaltest.tiff_drv.CreateCopy(
             "/vsimem/tiff_write_121.tif", src_ds, options=["COPY_SRC_OVERVIEWS=YES"]
         )
@@ -4989,7 +4989,7 @@ def test_tiff_write_121():
   </VRTRasterBand>
 </VRTDataset>"""
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdaltest.tiff_drv.CreateCopy(
             "/vsimem/tiff_write_121.tif", src_ds, options=["COPY_SRC_OVERVIEWS=YES"]
         )
@@ -5258,12 +5258,12 @@ def test_tiff_write_124():
 
     ds = gdaltest.tiff_drv.Create("/vsimem/tiff_write_124.tif", 1, 1, 3, gdal.GDT_Byte)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # Test "SetColorTable() can only be called on band 1"
         ret = ds.GetRasterBand(2).SetColorTable(gdal.ColorTable())
     assert ret != 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # Test "SetColorTable() not supported for multi-sample TIFF files"
         ret = ds.GetRasterBand(1).SetColorTable(gdal.ColorTable())
     assert ret != 0
@@ -5273,13 +5273,13 @@ def test_tiff_write_124():
     ds = gdaltest.tiff_drv.Create(
         "/vsimem/tiff_write_124.tif", 1, 1, 1, gdal.GDT_UInt32
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # Test "SetColorTable() only supported for Byte or UInt16 bands in TIFF format."
         ret = ds.GetRasterBand(1).SetColorTable(gdal.ColorTable())
     assert ret != 0
     ds = None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # Test "SetColorTable() only supported for Byte or UInt16 bands in TIFF format."
         ds = gdaltest.tiff_drv.Create(
             "/vsimem/tiff_write_124.tif",
@@ -5315,7 +5315,7 @@ def test_tiff_write_125():
     ds = gdal.Open("/vsimem/tiff_write_125.tif")
     # Will not open on 32-bit due to overflow
     if ds is not None:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds.GetRasterBand(1).ReadBlock(0, 0)
 
     ds = gdal.GetDriverByName("GTiff").Create(
@@ -5336,7 +5336,7 @@ def test_tiff_write_125():
     ds = gdal.Open("/vsimem/tiff_write_125.tif")
     # Will not open on 32-bit due to overflow
     if ds is not None:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds.GetRasterBand(1).ReadBlock(0, 0)
 
     gdal.Unlink("/vsimem/tiff_write_125.tif")
@@ -5894,25 +5894,25 @@ def test_tiff_write_133():
     src_ds.GetRasterBand(3).Fill(184)
 
     src_ds.FlushCache()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = src_ds.SetProjection(srs.ExportToWkt())
     assert ret != 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = src_ds.SetGeoTransform([1, 2, 0, 3, 0, -4])
     assert ret != 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = src_ds.SetMetadataItem("FOO", "BAZ")
     assert ret != 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = src_ds.SetMetadata({})
     assert ret != 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = src_ds.GetRasterBand(1).SetMetadataItem("FOO", "BAZ")
     assert ret != 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = src_ds.GetRasterBand(1).SetMetadata({})
     assert ret != 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = src_ds.GetRasterBand(1).SetNoDataValue(0)
     assert ret != 0
 
@@ -5938,7 +5938,7 @@ def test_tiff_write_133():
 
     ds.FlushCache()
     for y in range(1000):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             got_data = ds.ReadRaster(0, y, 1024, 1)
         assert got_data is None
     ds = None
@@ -6019,7 +6019,7 @@ def test_tiff_write_133():
         gdaltest.tiff_drv.Delete("/vsimem/tiff_write_133_dst.tif")
 
     # Compression not supported
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.tiff_drv.CreateCopy(
             "/vsimem/tiff_write_133_dst.tif",
             src_ds,
@@ -6033,7 +6033,7 @@ def test_tiff_write_133():
     )
     assert ds is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.tiff_drv.CreateCopy(
             "/foo/bar", src_ds, options=["STREAMABLE_OUTPUT=YES"]
         )
@@ -6087,7 +6087,7 @@ def test_tiff_write_133():
         options=["STREAMABLE_OUTPUT=YES", "BLOCKYSIZE=1"],
     )
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.WriteRaster(0, 999, 1024, 1, "a" * (3 * 1024))
         ds.FlushCache()
     assert gdal.GetLastErrorMsg() != ""
@@ -6102,7 +6102,7 @@ def test_tiff_write_133():
         options=["STREAMABLE_OUTPUT=YES", "TILED=YES"],
     )
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.WriteRaster(256, 256, 256, 256, "a" * (3 * 256 * 256))
         ds.FlushCache()
     assert gdal.GetLastErrorMsg() != ""
@@ -6434,7 +6434,7 @@ def test_tiff_write_134():
 
     # Error cases
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdaltest.tiff_drv.Create(
             "/vsimem/tiff_write_134.tif",
             1,
@@ -6444,7 +6444,7 @@ def test_tiff_write_134():
     assert gdal.GetLastErrorMsg() != ""
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # Too many elements
         gdaltest.tiff_drv.Create(
             "/vsimem/tiff_write_134.tif", 1, 1, options=["DISCARD_LSB=1,2"]
@@ -6452,7 +6452,7 @@ def test_tiff_write_134():
     assert gdal.GetLastErrorMsg() != ""
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # Too many elements
         gdaltest.tiff_drv.Create(
             "/vsimem/tiff_write_134.tif", 1, 1, options=["DISCARD_LSB=1", "NBITS=7"]
@@ -6835,7 +6835,7 @@ def test_tiff_write_140():
     ds.GetRasterBand(2).SetColorInterpretation(gdal.GCI_AlphaBand)
     # Should emit a warning
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.GetRasterBand(5).SetColorInterpretation(gdal.GCI_AlphaBand)
     assert gdal.GetLastErrorMsg() != ""
     assert ret == 0
@@ -6856,7 +6856,7 @@ def test_tiff_write_140():
     )
     # Should emit a warning mentioning ALPHA creation option.
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.GetRasterBand(5).SetColorInterpretation(gdal.GCI_AlphaBand)
     assert gdal.GetLastErrorMsg().find("ALPHA") >= 0
     assert ret == 0
@@ -6934,7 +6934,7 @@ def test_tiff_write_142():
 
 def test_tiff_write_143():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdaltest.tiff_drv.Create(
             "/vsimem/tiff_write_143.tif", 1000000000, 1000000000
         )
@@ -7070,7 +7070,7 @@ def test_tiff_write_145():
         creation_options = options.get("creation_options", [])
         gdal.Unlink(filename)
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdaltest.tiff_drv.Create(
                 filename, xsize, ysize, bands, datatype, options=creation_options
             )
@@ -7282,7 +7282,7 @@ def test_tiff_write_150():
     ds = gdal.Open("tmp/tiled_bad_offset.tif", gdal.GA_Update)
     ds.GetRasterBand(1).Fill(0)
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.FlushCache()
     assert gdal.GetLastErrorMsg() != ""
     ds = None
@@ -7698,7 +7698,7 @@ def test_tiff_write_157():
         0x47800000,  # 65536 --> converted to infinity
     )
     ds.GetRasterBand(1).WriteRaster(0, 0, 18, 1, vals, buf_type=gdal.GDT_Float32)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.FlushCache()
     ds = None
 
@@ -7904,7 +7904,7 @@ def test_tiff_write_161():
 
     ds = gdal.Open("/vsimem/tiff_write_161.tif", gdal.GA_Update)
     src_ds = gdal.Open("data/gcps.vrt")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.SetGCPs(src_ds.GetGCPs(), "") == 0
     assert ds.GetGeoTransform(can_return_null=True) is None
     ds = None
@@ -7912,7 +7912,7 @@ def test_tiff_write_161():
     ds = gdal.Open("/vsimem/tiff_write_161.tif", gdal.GA_Update)
     assert ds.GetGCPs()
     assert ds.GetGeoTransform(can_return_null=True) is None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.SetGeoTransform([0, 1, 2, 3, 4, 5]) == 0
     assert ds.GetGeoTransform() == (0.0, 1.0, 2.0, 3.0, 4.0, 5.0)
     assert not ds.GetGCPs()
@@ -8010,7 +8010,7 @@ def test_tiff_write_165():
     ret = ds.GetRasterBand(1).SetNoDataValue(100)
     assert ret == 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.GetRasterBand(2).SetNoDataValue(200)
     assert gdal.GetLastErrorMsg() != "", "warning expected, but not emitted"
     assert ret == 0
@@ -8200,7 +8200,7 @@ def test_tiff_write_169_ccitrle():
 def test_tiff_write_170_invalid_compresion():
 
     src_ds = gdal.Open("data/byte.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("GTiff").CreateCopy(
             "/vsimem/out.tif", src_ds, options=["COMPRESS=INVALID"]
         )
@@ -8535,7 +8535,7 @@ def test_tiff_write_179_lerc_data_types():
         assert cs == 4672
 
     filename_tmp = filename + ".tmp.tif"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.Translate(
             filename_tmp, "data/byte.tif", creationOptions=["PIXELTYPE=SIGNEDBYTE"]
         )
@@ -8548,7 +8548,7 @@ def test_tiff_write_179_lerc_data_types():
     assert cs == 1046
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.Translate(filename, "data/cfloat32.tif", creationOptions=["COMPRESS=LERC"])
     assert gdal.GetLastErrorMsg() != ""
     gdal.Unlink(filename)
@@ -8973,7 +8973,7 @@ def test_tiff_write_overviews_mask_no_ovr_on_mask():
 
     ds = gdal.Open(tmpfile)
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.BuildOverviews("NEAR", overviewlist=[2])
     assert (
         "Building external overviews whereas there is an internal mask is not fully supported. The overviews of the non-mask bands will be created, but not the overviews of the mask band."
@@ -8986,7 +8986,7 @@ def test_tiff_write_overviews_mask_no_ovr_on_mask():
     tmpfile2 = "/vsimem/test_tiff_write_overviews_mask_no_ovr_on_mask_copy.tif"
     src_ds = gdal.Open(tmpfile)
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdaltest.tiff_drv.CreateCopy(
             tmpfile2, src_ds, options=["COPY_SRC_OVERVIEWS=YES"]
         )
@@ -9186,7 +9186,7 @@ def test_tiff_write_too_many_tiles():
     src_ds = gdal.Open(
         '<VRTDataset rasterXSize="40000000" rasterYSize="40000000"><VRTRasterBand dataType="Byte" band="1"/></VRTDataset>'
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not gdaltest.tiff_drv.CreateCopy(
             "/vsimem/tmp.tif", src_ds, options=["TILED=YES"]
         )
@@ -9199,7 +9199,7 @@ def test_tiff_write_too_many_tiles():
         src_ds = gdal.Open("/vsimem/test_tiff_write_too_many_tiles.vrt")
         gdal.ErrorReset()
         with gdaltest.config_option("GDAL_TIFF_OVR_BLOCKSIZE", "128"):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 src_ds.BuildOverviews("NEAR", [2])
         assert "File too large regarding tile size" in gdal.GetLastErrorMsg()
 
@@ -9212,7 +9212,7 @@ def test_tiff_write_too_many_tiles():
 def test_tiff_write_jpeg_incompatible_of_paletted():
 
     src_ds = gdal.Open("data/test_average_palette.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not gdaltest.tiff_drv.CreateCopy(
             "/vsimem/tmp.tif", src_ds, options=["COMPRESS=JPEG"]
         )
@@ -9995,7 +9995,7 @@ def test_tiff_write_setcolortable_read_only_overriding_tifftags():
 def test_tiff_write_incompatible_predictor(dt, options):
 
     filename = "/vsimem/out.tif"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             gdal.GetDriverByName("GTiff").Create(
                 filename, 1, 1, 1, dt, options + ["COMPRESS=LZW"]

--- a/autotest/gcore/transformer.py
+++ b/autotest/gcore/transformer.py
@@ -992,7 +992,7 @@ def test_transformer_no_reverse_method():
     assert pnt[0] == pytest.approx(141270.54731856665, abs=1e-3), pnt
     assert pnt[1] == pytest.approx(4656605.104980032, abs=1e-3), pnt
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         (success, pnt) = tr.TransformPoint(1, 2, 49)
     assert not success
 

--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -94,7 +94,7 @@ def test_vrt_open(filename, checksum):
 def test_vrt_read_non_existing_source(filename):
 
     ds = gdal.Open(filename)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         cs = ds.GetRasterBand(1).Checksum()
     if ds is None:
         return
@@ -286,7 +286,7 @@ def test_vrt_read_7():
 
     gdal.FileFromMemBuffer(filename, content)
     ds = gdal.Open(filename)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.GetRasterBand(1).Checksum() == -1
     gdal.Unlink(filename)
 
@@ -1096,7 +1096,7 @@ def test_vrt_read_27():
 
 def test_vrt_read_28():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(
             '<VRTDataset rasterXSize="1 "rasterYSize="1"><VRTRasterBand band="-2147483648"><SimpleSource></SimpleSource></VRTRasterBand></VRTDataset>'
         )
@@ -1415,13 +1415,13 @@ def test_vrt_invalid_source_band():
   </VRTRasterBand>
 </VRTDataset>"""
     ds = gdal.Open(vrt_text)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.GetRasterBand(1).Checksum() == -1
 
 
 def test_vrt_protocol():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not gdal.Open("vrt://")
         assert not gdal.Open("vrt://i_do_not_exist")
         assert not gdal.Open("vrt://i_do_not_exist?")
@@ -1430,7 +1430,7 @@ def test_vrt_protocol():
     assert ds.RasterCount == 1
     assert ds.GetRasterBand(1).Checksum() == 4672
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not gdal.Open("vrt://data/byte.tif?foo=bar")
         assert not gdal.Open("vrt://data/byte.tif?bands=foo")
         assert not gdal.Open("vrt://data/byte.tif?bands=0")
@@ -1505,7 +1505,7 @@ def test_vrt_protocol():
     ds = gdal.Open("vrt://data/uint16_3band.vrt?exponent_2=2.2&scale_2=0,10,0,100")
     assert ds.GetRasterBand(2).Checksum() == 4455
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("vrt://data/float32.tif?outsize=10")
         assert ds is None
 
@@ -1563,7 +1563,7 @@ def test_vrt_dataset_rasterio_recursion_detection():
     )
 
     ds = gdal.Open("/vsimem/test.vrt")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.ReadRaster(0, 0, 20, 20, 10, 10)
     gdal.Unlink("/vsimem/test.vrt")
 
@@ -1857,7 +1857,7 @@ def test_vrt_check_dont_open_unneeded_source():
         ds = gdal.Translate("", tmpfilename, options="-of MEM -srcwin 0 0 10 10")
         assert ds is not None
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.Translate(
                 "", tmpfilename, options="-of MEM -srcwin 0 0 10.1 10.1"
             )
@@ -1894,7 +1894,7 @@ def test_vrt_check_dont_open_unneeded_source_with_complex_source_nodata():
         ds = gdal.Translate("", tmpfilename, options="-of MEM -srcwin 0 0 10 10")
         assert ds is not None
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.Translate(
                 "", tmpfilename, options="-of MEM -srcwin 0 0 10.1 10.1"
             )
@@ -2147,12 +2147,12 @@ def test_vrt_read_compute_statistics_mosaic_optimization_src_with_nodata_all():
     src_ds1.GetRasterBand(1).SetNoDataValue(10)
     src_ds2.GetRasterBand(1).SetNoDataValue(10)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         minmax = vrt_ds.GetRasterBand(1).ComputeRasterMinMax(False)
     assert math.isnan(minmax[0])
     assert math.isnan(minmax[1])
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         vrt_stats = vrt_ds.GetRasterBand(1).ComputeStatistics(False)
         assert vrt_stats == [0, 0, 0, 0]
         assert vrt_ds.GetRasterBand(1).GetMetadataItem("STATISTICS_MINIMUM") is None

--- a/autotest/gcore/vsiadls.py
+++ b/autotest/gcore/vsiadls.py
@@ -643,7 +643,7 @@ def test_vsiadls_fake_unlink():
         {"Connection": "close"},
     )
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = gdal.Unlink("/vsiadls/az_bucket_test_unlink/myfile")
     assert ret == -1
 
@@ -825,7 +825,7 @@ def test_vsiadls_fake_sync_copyobject():
     handler.add("HEAD", "/azure/blob/myaccount/test_bucket/dst.txt", 404)
     handler.add("PUT", "/azure/blob/myaccount/test_bucket/dst.txt", 400)
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert not gdal.Sync(
                 "/vsiadls/test_bucket/src.txt", "/vsiadls/test_bucket/dst.txt"
             )

--- a/autotest/gcore/vsiaz.py
+++ b/autotest/gcore/vsiaz.py
@@ -517,7 +517,7 @@ def test_vsiaz_fake_write():
     # Simulate illegal read
     f = gdal.VSIFOpenL("/vsiaz/test_copy/file.tif", "wb")
     assert f is not None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = gdal.VSIFReadL(1, 1, f)
     assert not ret
     gdal.VSIFCloseL(f)
@@ -525,7 +525,7 @@ def test_vsiaz_fake_write():
     # Simulate illegal seek
     f = gdal.VSIFOpenL("/vsiaz/test_copy/file.tif", "wb")
     assert f is not None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = gdal.VSIFSeekL(f, 1, 0)
     assert ret != 0
     gdal.VSIFCloseL(f)
@@ -570,7 +570,7 @@ def test_vsiaz_fake_write():
         pytest.fail()
 
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = gdal.VSIFCloseL(f)
         if ret == 0:
             gdal.VSIFCloseL(f)
@@ -713,7 +713,7 @@ def test_vsiaz_fake_write():
     handler.add("PUT", "/azure/blob/myaccount/test_copy/file.tif", custom_method=method)
 
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = gdal.VSIFWriteL("0123456789abcdef", 1, 16, f)
         if ret != 0:
             gdal.VSIFCloseL(f)
@@ -729,7 +729,7 @@ def test_vsiaz_fake_write():
     handler.add("PUT", "/azure/blob/myaccount/test_copy/file.tif", 201)
     handler.add("PUT", "/azure/blob/myaccount/test_copy/file.tif?comp=appendblock", 403)
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = gdal.VSIFWriteL("0123456789abcdef", 1, 16, f)
         if ret != 0:
             gdal.VSIFCloseL(f)
@@ -777,7 +777,7 @@ def test_vsiaz_write_blockblob_retry():
         handler.add(
             "PUT", "/azure/blob/myaccount/test_copy/file.bin", custom_method=method
         )
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             with webserver.install_http_handler(handler):
                 assert gdal.VSIFWriteL("foo", 1, 3, f) == 3
                 gdal.VSIFCloseL(f)
@@ -822,7 +822,7 @@ def test_vsiaz_write_appendblob_retry():
             "PUT", "/azure/blob/myaccount/test_copy/file.bin?comp=appendblock", 201
         )
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             with webserver.install_http_handler(handler):
                 assert gdal.VSIFWriteL("0123456789abcdef", 1, 16, f) == 16
                 gdal.VSIFCloseL(f)
@@ -870,7 +870,7 @@ def test_vsiaz_fake_unlink():
         {"Connection": "close"},
     )
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = gdal.Unlink("/vsiaz/az_bucket_test_unlink/myfile")
     assert ret == -1
 

--- a/autotest/gcore/vsiaz_real_instance_auto.py
+++ b/autotest/gcore/vsiaz_real_instance_auto.py
@@ -80,19 +80,19 @@ def test_vsiaz_real_server_errors():
 
     # Missing AZURE_STORAGE_ACCOUNT
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = open_for_read("/vsiaz/foo/bar")
     assert f is None and gdal.VSIGetLastErrorMsg().find("AZURE_STORAGE_ACCOUNT") >= 0
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = open_for_read("/vsiaz_streaming/foo/bar")
     assert f is None and gdal.VSIGetLastErrorMsg().find("AZURE_STORAGE_ACCOUNT") >= 0
 
     # Invalid AZURE_STORAGE_CONNECTION_STRING
     with gdaltest.config_option("AZURE_STORAGE_CONNECTION_STRING", "invalid"):
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = open_for_read("/vsiaz/foo/bar")
         assert f is None
 
@@ -104,7 +104,7 @@ def test_vsiaz_real_server_errors():
             "CPL_AZURE_VM_API_ROOT_URL": "disabled",
         }
     ):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = open_for_read("/vsiaz/foo/bar")
         assert (
             f is None
@@ -119,7 +119,7 @@ def test_vsiaz_real_server_errors():
             "AZURE_STORAGE_ACCESS_KEY": "AZURE_STORAGE_ACCESS_KEY",
         }
     ):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = open_for_read("/vsiaz/foo/bar.baz")
         if f is not None:
             if f is not None:
@@ -129,7 +129,7 @@ def test_vsiaz_real_server_errors():
             pytest.fail(gdal.VSIGetLastErrorMsg())
 
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = open_for_read("/vsiaz_streaming/foo/bar.baz")
         assert f is None, gdal.VSIGetLastErrorMsg()
 

--- a/autotest/gcore/vsiaz_real_instance_manual.py
+++ b/autotest/gcore/vsiaz_real_instance_manual.py
@@ -188,7 +188,7 @@ def test_vsiaz_extra_1():
         # Invalid bucket : "The specified bucket does not exist"
         gdal.ErrorReset()
         f = open_for_read("/vsiaz/not_existing_bucket/foo")
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             gdal.VSIFReadL(1, 1, f)
         gdal.VSIFCloseL(f)
         assert gdal.VSIGetLastErrorMsg() != ""

--- a/autotest/gcore/vsicrypt.py
+++ b/autotest/gcore/vsicrypt.py
@@ -77,46 +77,46 @@ def test_vsicrypt_1():
 def test_vsicrypt_2():
 
     # Missing key
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fp = gdal.VSIFOpenL("/vsicrypt//vsimem/file.bin", "wb+")
     assert fp is None
 
     # Invalid file
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fp = gdal.VSIFOpenL(
             "/vsicrypt/key=DONT_USE_IN_PROD,file=/not_existing/not_existing", "wb"
         )
     assert fp is None
 
     # Invalid file
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fp = gdal.VSIFOpenL(
             "/vsicrypt/key=DONT_USE_IN_PROD,file=/not_existing/not_existing", "rb"
         )
     assert fp is None
 
     # Invalid file
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fp = gdal.VSIFOpenL(
             "/vsicrypt/key=DONT_USE_IN_PROD,file=/not_existing/not_existing", "ab"
         )
     assert fp is None
 
     # Invalid access
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fp = gdal.VSIFOpenL(
             "/vsicrypt/key=DONT_USE_IN_PROD,file=/not_existing/not_existing", "foo"
         )
     assert fp is None
 
     # Key to short
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fp = gdal.VSIFOpenL("/vsicrypt/key=a,file=/vsimem/file.bin", "wb+")
     assert fp is None
 
     # Invalid signature
     gdal.FileFromMemBuffer("/vsimem/file.bin", "foo")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fp = gdal.VSIFOpenL(
             "/vsicrypt/key=DONT_USE_IN_PROD,file=/vsimem/file.bin", "rb"
         )
@@ -142,7 +142,7 @@ def test_vsicrypt_2():
         gdal.VSIFWriteL(header, 1, 46 - 1 - i, fp)
         gdal.VSIFCloseL(fp)
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             fp = gdal.VSIFOpenL(
                 "/vsicrypt/key=DONT_USE_IN_PROD,file=/vsimem/file.bin", "rb"
             )
@@ -160,7 +160,7 @@ def test_vsicrypt_2():
             gdal.VSIFWriteL(header_new, 1, 46, fp)
             gdal.VSIFCloseL(fp)
 
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 fp = gdal.VSIFOpenL(
                     "/vsicrypt/key=DONT_USE_IN_PROD,file=" "/vsimem/file.bin", "rb"
                 )
@@ -220,7 +220,7 @@ def test_vsicrypt_2():
     gdal.VSIFWriteL(header, 1, len(header), fp)
     gdal.VSIFCloseL(fp)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fp = gdal.VSIFOpenL(
             "/vsicrypt/key=DONT_USE_IN_PROD,file=/vsimem/file.bin", "rb"
         )
@@ -273,7 +273,7 @@ def test_vsicrypt_2():
     gdal.VSIFWriteL(header, 1, len(header), fp)
     gdal.VSIFCloseL(fp)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fp = gdal.VSIFOpenL(
             "/vsicrypt/key=DONT_USE_IN_PROD,file=/vsimem/file.bin", "rb"
         )
@@ -290,7 +290,7 @@ def test_vsicrypt_2():
 
     assert content != "hello"
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fp = gdal.VSIFOpenL("/vsicrypt/key=short_key,file=/vsimem/file.bin", "ab")
     assert fp is None
 
@@ -301,24 +301,24 @@ def test_vsicrypt_2():
     gdal.VSIFWriteL("hello", 1, 5, fp)
     gdal.VSIFCloseL(fp)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fp = gdal.VSIFOpenL(
             "/vsicrypt/key=dont_use_in_prod,file=/vsimem/file.bin", "rb"
         )
     assert fp is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fp = gdal.VSIFOpenL("/vsicrypt/key=short_key,file=/vsimem/file.bin", "ab")
     assert fp is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fp = gdal.VSIFOpenL(
             "/vsicrypt/key=dont_use_in_prod,file=/vsimem/file.bin", "ab"
         )
     assert fp is None
 
     # Test creating with potentially not built-in alg:
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fp = gdal.VSIFOpenL(
             "/vsicrypt/alg=blowfish,key=DONT_USE_IN_PROD,file=/vsimem/file.bin", "wb"
         )
@@ -326,14 +326,14 @@ def test_vsicrypt_2():
         gdal.VSIFCloseL(fp)
 
     # Invalid sector_size
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fp = gdal.VSIFOpenL(
             "/vsicrypt/key=DONT_USE_IN_PROD,sector_size=1,file=/vsimem/file.bin", "wb"
         )
     assert fp is None
 
     # Sector size (16) should be at least twice larger than the block size (16) in CBC_CTS
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fp = gdal.VSIFOpenL(
             "/vsicrypt/key=DONT_USE_IN_PROD,sector_size=16,mode=CBC_CTS,file=/vsimem/file.bin",
             "wb",
@@ -373,7 +373,7 @@ def test_vsicrypt_3():
         gdal.Unlink("/vsimem/file.bin")
 
         if options == "alg=invalid" or options == "mode=invalid":
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 fp = gdal.VSIFOpenL(
                     "/vsicrypt/key=DONT_USE_IN_PRODDONT_USE_IN_PROD,%s,file=/vsimem/file.bin"
                     % options,
@@ -414,7 +414,7 @@ def test_vsicrypt_3():
 
         gdal.Unlink("/vsimem/file.bin")
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             fp = gdal.VSIFOpenL(
                 "/vsicrypt/key=DONT_USE_IN_PROD,%s,file=/vsimem/file.bin" % options,
                 "wb",
@@ -460,7 +460,7 @@ def test_vsicrypt_3():
 
     assert content == "hello", options
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         statRes = gdal.VSIStatL("/vsicrypt//vsimem/file.bin")
     assert statRes is None
 
@@ -635,17 +635,17 @@ def test_vsicrypt_6(testnonboundtoswig_setup):  # noqa
 
     # Set a too short key
     testnonboundtoswig_setup.VSISetCryptKey("bbc".encode("ASCII"), 3)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fp = gdal.VSIFOpenL("/vsicrypt//vsimem/file.bin", "rb")
     assert fp is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fp = gdal.VSIFOpenL("/vsicrypt//vsimem/file.bin", "wb+")
     assert fp is None
 
     # Erase key
     testnonboundtoswig_setup.VSISetCryptKey(None, 0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fp = gdal.VSIFOpenL("/vsicrypt//vsimem/file.bin", "wb+")
     assert fp is None
 

--- a/autotest/gcore/vsicurl.py
+++ b/autotest/gcore/vsicurl.py
@@ -598,7 +598,7 @@ def test_vsicurl_test_retry():
         )
         assert f is not None
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             data = gdal.VSIFReadL(1, 3, f).decode("ascii")
         error_msg = gdal.GetLastErrorMsg()
         gdal.VSIFCloseL(f)

--- a/autotest/gcore/vsifile.py
+++ b/autotest/gcore/vsifile.py
@@ -343,7 +343,7 @@ def test_vsifile_7():
     fp = gdal.VSIFOpenL("/vsimem/vsifile_7.bin", "wb")
     assert gdal.VSIFSeekL(fp, 0x7FFFFFFFFFFFFFFF, 0) == 0
     assert gdal.VSIStatL("/vsimem/vsifile_7.bin").size == 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = gdal.VSIFWriteL("a", 1, 1, fp)
     assert ret == 0
     assert gdal.VSIStatL("/vsimem/vsifile_7.bin").size == 0
@@ -600,7 +600,7 @@ def test_vsifile_13():
 
 def test_vsifile_14():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.VSIFOpenL(
             "/vsitar//vsitar//vsitar//vsitar//vsitar//vsitar//vsitar//vsitar/a.tgzb.tgzc.tgzd.tgze.tgzf.tgz.h.tgz.i.tgz",
             "rb",
@@ -617,15 +617,15 @@ def test_vsifile_15():
     assert fp is not None
     file_len = 0
     while not gdal.VSIFEofL(fp):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             file_len += len(gdal.VSIFReadL(1, 4, fp))
     assert file_len == 6469
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         file_len += len(gdal.VSIFReadL(1, 4, fp))
     assert file_len == 6469
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert gdal.VSIFSeekL(fp, 0, 2) != 0
 
     assert gdal.VSIFSeekL(fp, 0, 0) == 0
@@ -725,7 +725,7 @@ def test_vsifile_21():
     gdal.VSIFCloseL(vsifile_write)
     gdal.Unlink(filename)
     gdal.Unlink(filename_write)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         data3 = gdal.VSIGetMemFileBuffer_unsafe(filename)
         assert data3 == None
 
@@ -801,10 +801,10 @@ def test_vsigzip_multi_thread():
 
 def test_vsisync():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not gdal.Sync("/i_do/not/exist", "/vsimem/")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not gdal.Sync("vsifile.py", "/i_do/not/exist")
 
     # Test copying a file
@@ -822,7 +822,7 @@ def test_vsisync():
     gdal.FileFromMemBuffer("/vsimem/test_sync/subdir/bar.txt", "baz")
 
     if sys.platform == "linux":
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             # even root cannot write into /proc
             assert not gdal.Sync("/vsimem/test_sync/", "/proc/i_do_not/exist")
 
@@ -1050,7 +1050,7 @@ def test_unlink_batch():
 
     gdal.FileFromMemBuffer("/vsimem/foo", "foo")
     open("tmp/bar", "wt").write("bar")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not gdal.UnlinkBatch(["/vsimem/foo", "tmp/bar"])
     gdal.Unlink("/vsimem/foo")
     gdal.Unlink("tmp/bar")
@@ -1077,7 +1077,7 @@ def test_vsifile_vsizip_error():
 
     for i in range(128):
         filename = "/vsimem/tmp||maxlength=%d.zip" % i
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = gdal.VSIFOpenL("/vsizip/%s/out.bin" % filename, "wb")
             if f is not None:
                 assert gdal.VSIFCloseL(f) < 0

--- a/autotest/gcore/vsigs.py
+++ b/autotest/gcore/vsigs.py
@@ -118,7 +118,7 @@ def test_vsigs_1(gs_test_config):
         with gdaltest.config_option(
             "GDAL_HTTP_HEADER_FILE", "/i_dont/exist.py", thread_local=False
         ):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 f = open_for_read("/vsigs/foo/bar")
         if f is not None:
             gdal.VSIFCloseL(f)
@@ -137,12 +137,12 @@ def test_vsigs_1(gs_test_config):
 
         # Missing GS_SECRET_ACCESS_KEY
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = open_for_read("/vsigs/foo/bar")
         assert f is None and gdal.VSIGetLastErrorMsg().find("GS_SECRET_ACCESS_KEY") >= 0
 
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = open_for_read("/vsigs_streaming/foo/bar")
         assert f is None and gdal.VSIGetLastErrorMsg().find("GS_SECRET_ACCESS_KEY") >= 0
 
@@ -152,7 +152,7 @@ def test_vsigs_1(gs_test_config):
 
             # Missing GS_ACCESS_KEY_ID
             gdal.ErrorReset()
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 f = open_for_read("/vsigs/foo/bar")
             assert f is None and gdal.VSIGetLastErrorMsg().find("GS_ACCESS_KEY_ID") >= 0
 
@@ -162,7 +162,7 @@ def test_vsigs_1(gs_test_config):
 
                 # ERROR 1: The User Id you provided does not exist in our records.
                 gdal.ErrorReset()
-                with gdaltest.error_handler():
+                with gdal.quiet_errors():
                     f = open_for_read("/vsigs/foo/bar.baz")
                 if f is not None or gdal.VSIGetLastErrorMsg() == "":
                     if f is not None:
@@ -172,7 +172,7 @@ def test_vsigs_1(gs_test_config):
                     pytest.fail(gdal.VSIGetLastErrorMsg())
 
                 gdal.ErrorReset()
-                with gdaltest.error_handler():
+                with gdal.quiet_errors():
                     f = open_for_read("/vsigs_streaming/foo/bar.baz")
                 assert f is None and gdal.VSIGetLastErrorMsg() != ""
 
@@ -632,7 +632,7 @@ def test_vsigs_acl(gs_test_config, webserver_port):
         assert "XML" in md and md["XML"] == "<foo/>"
 
         # Error cases
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert (
                 gdal.GetFileMetadata("/vsigs/test_metadata/foo.txt", "UNSUPPORTED")
                 == {}
@@ -641,7 +641,7 @@ def test_vsigs_acl(gs_test_config, webserver_port):
         handler = webserver.SequentialHandler()
         handler.add("GET", "/test_metadata/foo.txt?acl", 400)
         with webserver.install_http_handler(handler):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 assert not gdal.GetFileMetadata("/vsigs/test_metadata/foo.txt", "ACL")
 
         handler = webserver.SequentialHandler()
@@ -652,7 +652,7 @@ def test_vsigs_acl(gs_test_config, webserver_port):
             )
 
         # Error cases
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert not gdal.SetFileMetadata(
                 "/vsigs/test_metadata/foo.txt", {}, "UNSUPPORTED"
             )
@@ -661,7 +661,7 @@ def test_vsigs_acl(gs_test_config, webserver_port):
         handler = webserver.SequentialHandler()
         handler.add("PUT", "/test_metadata/foo.txt?acl", 400)
         with webserver.install_http_handler(handler):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 assert not gdal.SetFileMetadata(
                     "/vsigs/test_metadata/foo.txt", {"XML": "<foo/>"}, "ACL"
                 )
@@ -725,7 +725,7 @@ def test_vsigs_read_credentials_refresh_token_default_gdal_app(
         thread_local=False,
     ):
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert gdal.GetSignedURL("/vsigs/foo/bar") is None
 
         gdal.VSICurlClearCache()
@@ -1473,7 +1473,7 @@ def test_vsigs_read_credentials_gce(gs_test_config, webserver_port):
 
             assert data == "bar"
 
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 assert gdal.GetSignedURL("/vsigs/foo/bar") is None
 
 
@@ -1668,7 +1668,7 @@ def test_vsigs_extra_1():
         # Invalid bucket : "The specified bucket does not exist"
         gdal.ErrorReset()
         f = open_for_read("/vsigs/not_existing_bucket/foo")
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             gdal.VSIFReadL(1, 1, f)
         gdal.VSIFCloseL(f)
         assert gdal.VSIGetLastErrorMsg() != ""

--- a/autotest/gcore/vsioss.py
+++ b/autotest/gcore/vsioss.py
@@ -76,12 +76,12 @@ def test_vsioss_1():
 
     # Missing OSS_SECRET_ACCESS_KEY
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = open_for_read("/vsioss/foo/bar")
     assert f is None and gdal.VSIGetLastErrorMsg().find("OSS_SECRET_ACCESS_KEY") >= 0
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = open_for_read("/vsioss_streaming/foo/bar")
     assert f is None and gdal.VSIGetLastErrorMsg().find("OSS_SECRET_ACCESS_KEY") >= 0
 
@@ -89,7 +89,7 @@ def test_vsioss_1():
 
     # Missing OSS_ACCESS_KEY_ID
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = open_for_read("/vsioss/foo/bar")
     assert f is None and gdal.VSIGetLastErrorMsg().find("OSS_ACCESS_KEY_ID") >= 0
 
@@ -102,7 +102,7 @@ def test_vsioss_real_test():
 
     # ERROR 1: The OSS Access Key Id you provided does not exist in our records.
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = open_for_read("/vsioss/foo/bar.baz")
     if f is not None or gdal.VSIGetLastErrorMsg() == "":
         if f is not None:
@@ -112,7 +112,7 @@ def test_vsioss_real_test():
         pytest.fail(gdal.VSIGetLastErrorMsg())
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = open_for_read("/vsioss_streaming/foo/bar.baz")
     assert f is None and gdal.VSIGetLastErrorMsg() != ""
 
@@ -298,7 +298,7 @@ def test_vsioss_2():
 
     gdal.ErrorReset()
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = open_for_read("/vsioss_streaming/oss_fake_bucket/non_xml_error")
     assert f is None and gdal.VSIGetLastErrorMsg().find("bla") >= 0
 
@@ -318,7 +318,7 @@ def test_vsioss_2():
     )
     gdal.ErrorReset()
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = open_for_read("/vsioss_streaming/oss_fake_bucket/invalid_xml_error")
     assert f is None and gdal.VSIGetLastErrorMsg().find("<oops>") >= 0
 
@@ -338,7 +338,7 @@ def test_vsioss_2():
     )
     gdal.ErrorReset()
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = open_for_read("/vsioss_streaming/oss_fake_bucket/no_code_in_error")
     assert f is None and gdal.VSIGetLastErrorMsg().find("<Error/>") >= 0
 
@@ -358,7 +358,7 @@ def test_vsioss_2():
     )
     gdal.ErrorReset()
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = open_for_read(
                 "/vsioss_streaming/oss_fake_bucket/no_region_in_AuthorizationHeaderMalformed_error"
             )
@@ -380,7 +380,7 @@ def test_vsioss_2():
     )
     gdal.ErrorReset()
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = open_for_read(
                 "/vsioss_streaming/oss_fake_bucket/no_endpoint_in_PermanentRedirect_error"
             )
@@ -402,7 +402,7 @@ def test_vsioss_2():
     )
     gdal.ErrorReset()
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = open_for_read("/vsioss_streaming/oss_fake_bucket/no_message_in_error")
     assert f is None and gdal.VSIGetLastErrorMsg().find("<Error>") >= 0
 
@@ -634,7 +634,7 @@ def test_vsioss_4():
         pytest.skip()
 
     with webserver.install_http_handler(webserver.SequentialHandler()):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = gdal.VSIFOpenL("/vsioss/oss_fake_bucket3", "wb")
     assert f is None
 
@@ -681,7 +681,7 @@ def test_vsioss_4():
     with webserver.install_http_handler(handler):
         f = gdal.VSIFOpenL("/vsioss/oss_fake_bucket3/empty_file.bin", "wb")
         assert f is not None
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = gdal.VSIFSeekL(f, 1, 0)
         assert ret != 0
         gdal.VSIFCloseL(f)
@@ -691,7 +691,7 @@ def test_vsioss_4():
     with webserver.install_http_handler(handler):
         f = gdal.VSIFOpenL("/vsioss/oss_fake_bucket3/empty_file.bin", "wb")
         assert f is not None
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = gdal.VSIFReadL(1, 1, f)
         assert not ret
         gdal.VSIFCloseL(f)
@@ -703,7 +703,7 @@ def test_vsioss_4():
         f = gdal.VSIFOpenL("/vsioss/oss_fake_bucket3/empty_file_error.bin", "wb")
         assert f is not None
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             gdal.VSIFCloseL(f)
     assert gdal.GetLastErrorMsg() != ""
 
@@ -763,7 +763,7 @@ def test_vsioss_5():
         pytest.skip()
 
     with webserver.install_http_handler(webserver.SequentialHandler()):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = gdal.Unlink("/vsioss/foo")
     assert ret != 0
 
@@ -801,7 +801,7 @@ def test_vsioss_5():
     handler.add("GET", "/oss_delete_bucket/delete_file_error", 200)
     handler.add("DELETE", "/oss_delete_bucket/delete_file_error", 403)
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = gdal.Unlink("/vsioss/oss_delete_bucket/delete_file_error")
     assert ret != 0
 
@@ -956,7 +956,7 @@ def test_vsioss_6():
             with gdaltest.config_option("VSIOSS_CHUNK_SIZE", "1"):  # 1 MB
                 f = gdal.VSIFOpenL(filename, "wb")
             assert f is not None
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ret = gdal.VSIFWriteL(big_buffer, 1, size, f)
             assert ret == 0
             gdal.ErrorReset()
@@ -1008,7 +1008,7 @@ def test_vsioss_6():
             with gdaltest.config_option("VSIOSS_CHUNK_SIZE", "1"):  # 1 MB
                 f = gdal.VSIFOpenL(filename, "wb")
             assert f is not None, filename
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ret = gdal.VSIFWriteL(big_buffer, 1, size, f)
             assert ret == 0, filename
             gdal.ErrorReset()
@@ -1040,11 +1040,11 @@ def test_vsioss_6():
         with gdaltest.config_option("VSIOSS_CHUNK_SIZE", "1"):  # 1 MB
             f = gdal.VSIFOpenL(filename, "wb")
         assert f is not None, filename
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = gdal.VSIFWriteL(big_buffer, 1, size, f)
         assert ret == 0, filename
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             gdal.VSIFCloseL(f)
         assert gdal.GetLastErrorMsg() != "", filename
 
@@ -1086,7 +1086,7 @@ def test_vsioss_6():
             ret = gdal.VSIFWriteL(big_buffer, 1, size, f)
             assert ret == size, filename
             gdal.ErrorReset()
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 gdal.VSIFCloseL(f)
             assert gdal.GetLastErrorMsg() != "", filename
 
@@ -1326,7 +1326,7 @@ def test_vsioss_extra_1():
         # Invalid bucket : "The specified bucket does not exist"
         gdal.ErrorReset()
         f = open_for_read("/vsioss/not_existing_bucket/foo")
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             gdal.VSIFReadL(1, 1, f)
         gdal.VSIFCloseL(f)
         assert gdal.VSIGetLastErrorMsg() != ""

--- a/autotest/gcore/vsis3.py
+++ b/autotest/gcore/vsis3.py
@@ -255,13 +255,13 @@ def test_vsis3_1(aws_test_config):
     with gdaltest.config_options({"AWS_SECRET_ACCESS_KEY": ""}, thread_local=False):
         gdal.ErrorReset()
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = open_for_read("/vsis3/foo/bar")
         assert f is None
         assert gdal.VSIGetLastErrorMsg().find("AWS_SECRET_ACCESS_KEY") >= 0
 
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = open_for_read("/vsis3_streaming/foo/bar")
         assert f is None
         assert gdal.VSIGetLastErrorMsg().find("AWS_SECRET_ACCESS_KEY") >= 0
@@ -272,7 +272,7 @@ def test_vsis3_1(aws_test_config):
     ):
         # Missing AWS_ACCESS_KEY_ID
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = open_for_read("/vsis3/foo/bar")
         assert f is None
         assert gdal.VSIGetLastErrorMsg().find("AWS_ACCESS_KEY_ID") >= 0
@@ -287,7 +287,7 @@ def test_vsis3_1(aws_test_config):
         # ERROR 1: The AWS Access Key Id you provided does not exist in our
         # records.
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = open_for_read("/vsis3/foo/bar.baz")
         if f is not None or gdal.VSIGetLastErrorMsg() == "":
             if f is not None:
@@ -297,7 +297,7 @@ def test_vsis3_1(aws_test_config):
             pytest.fail(gdal.VSIGetLastErrorMsg())
 
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = open_for_read("/vsis3_streaming/foo/bar.baz")
         assert f is None and gdal.VSIGetLastErrorMsg() != ""
 
@@ -659,7 +659,7 @@ def test_vsis3_2(aws_test_config_as_config_options_or_credentials, webserver_por
 
     gdal.ErrorReset()
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = open_for_read("/vsis3_streaming/s3_fake_bucket/non_xml_error")
     assert f is None and gdal.VSIGetLastErrorMsg().find("bla") >= 0
 
@@ -679,7 +679,7 @@ def test_vsis3_2(aws_test_config_as_config_options_or_credentials, webserver_por
     )
     gdal.ErrorReset()
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = open_for_read("/vsis3_streaming/s3_fake_bucket/invalid_xml_error")
     assert f is None and gdal.VSIGetLastErrorMsg().find("<oops>") >= 0
 
@@ -699,7 +699,7 @@ def test_vsis3_2(aws_test_config_as_config_options_or_credentials, webserver_por
     )
     gdal.ErrorReset()
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = open_for_read("/vsis3_streaming/s3_fake_bucket/no_code_in_error")
     assert f is None and gdal.VSIGetLastErrorMsg().find("<Error/>") >= 0
 
@@ -722,7 +722,7 @@ def test_vsis3_2(aws_test_config_as_config_options_or_credentials, webserver_por
     )
     gdal.ErrorReset()
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = open_for_read(
                 "/vsis3_streaming/s3_fake_bucket"
                 "/no_region_in_AuthorizationHeaderMalformed_error"
@@ -748,7 +748,7 @@ def test_vsis3_2(aws_test_config_as_config_options_or_credentials, webserver_por
     )
     gdal.ErrorReset()
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = open_for_read(
                 "/vsis3_streaming/s3_fake_bucket"
                 "/no_endpoint_in_PermanentRedirect_error"
@@ -774,7 +774,7 @@ def test_vsis3_2(aws_test_config_as_config_options_or_credentials, webserver_por
     )
     gdal.ErrorReset()
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = open_for_read("/vsis3_streaming/s3_fake_bucket/no_message_in_error")
     assert f is None and gdal.VSIGetLastErrorMsg().find("<Error>") >= 0
 
@@ -833,7 +833,7 @@ def test_vsis3_2(aws_test_config_as_config_options_or_credentials, webserver_por
         "/vsis3/s3_fake_bucket_with_requester_pays", {"AWS_REQUEST_PAYER": "requester"}
     ):
         with webserver.install_http_handler(handler):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 f = open_for_read("/vsis3/s3_fake_bucket_with_requester_pays/resource")
                 assert f is not None
                 data = gdal.VSIFReadL(1, 3, f).decode("ascii")
@@ -943,7 +943,7 @@ def test_vsis3_open_after_config_option_change(aws_test_config, webserver_port):
     handler.add("GET", "/test_vsis3_change_config_options/?delimiter=%2F", 403)
     handler.add("GET", "/test_vsis3_change_config_options/test.bin", 403)
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = open_for_read("/vsis3/test_vsis3_change_config_options/test.bin")
         assert f is None
 
@@ -1909,7 +1909,7 @@ def test_vsis3_opendir_synthetize_missing_directory(aws_test_config, webserver_p
 
 def test_vsis3_4(aws_test_config, webserver_port):
     with webserver.install_http_handler(webserver.SequentialHandler()):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = gdal.VSIFOpenL("/vsis3/s3_fake_bucket3", "wb")
     assert f is None
 
@@ -1976,7 +1976,7 @@ def test_vsis3_4(aws_test_config, webserver_port):
     with webserver.install_http_handler(handler):
         f = gdal.VSIFOpenL("/vsis3/s3_fake_bucket3/empty_file.bin", "wb")
         assert f is not None
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = gdal.VSIFSeekL(f, 1, 0)
         assert ret != 0
         gdal.VSIFCloseL(f)
@@ -1986,7 +1986,7 @@ def test_vsis3_4(aws_test_config, webserver_port):
     with webserver.install_http_handler(handler):
         f = gdal.VSIFOpenL("/vsis3/s3_fake_bucket3/empty_file.bin", "wb")
         assert f is not None
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = gdal.VSIFReadL(1, 1, f)
         assert not ret
         gdal.VSIFCloseL(f)
@@ -1998,7 +1998,7 @@ def test_vsis3_4(aws_test_config, webserver_port):
         f = gdal.VSIFOpenL("/vsis3/s3_fake_bucket3/empty_file_error.bin", "wb")
         assert f is not None
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             gdal.VSIFCloseL(f)
     assert gdal.GetLastErrorMsg() != ""
 
@@ -2178,7 +2178,7 @@ def test_vsis3_write_single_put_retry(aws_test_config, webserver_port):
         handler.add("PUT", "/s3_fake_bucket3/put_with_retry.bin", 502)
         handler.add("PUT", "/s3_fake_bucket3/put_with_retry.bin", custom_method=method)
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             with webserver.install_http_handler(handler):
                 gdal.VSIFCloseL(f)
 
@@ -2189,7 +2189,7 @@ def test_vsis3_write_single_put_retry(aws_test_config, webserver_port):
 
 def test_vsis3_5(aws_test_config, webserver_port):
     with webserver.install_http_handler(webserver.SequentialHandler()):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = gdal.Unlink("/vsis3/foo")
     assert ret != 0
 
@@ -2225,7 +2225,7 @@ def test_vsis3_5(aws_test_config, webserver_port):
     handler.add("GET", "/s3_delete_bucket/delete_file_error", 200)
     handler.add("DELETE", "/s3_delete_bucket/delete_file_error", 403)
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = gdal.Unlink("/vsis3/s3_delete_bucket/delete_file_error")
     assert ret != 0
 
@@ -2726,7 +2726,7 @@ def test_vsis3_6(aws_test_config, webserver_port):
             ):  # 1 MB
                 f = gdal.VSIFOpenL(filename, "wb")
             assert f is not None
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ret = gdal.VSIFWriteL(big_buffer, 1, size, f)
             assert ret == 0
             gdal.ErrorReset()
@@ -2793,7 +2793,7 @@ def test_vsis3_6(aws_test_config, webserver_port):
             ):  # 1 MB
                 f = gdal.VSIFOpenL(filename, "wb")
             assert f is not None, filename
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ret = gdal.VSIFWriteL(big_buffer, 1, size, f)
             assert ret == 0, filename
             gdal.ErrorReset()
@@ -2833,11 +2833,11 @@ def test_vsis3_6(aws_test_config, webserver_port):
         ):  # 1 MB
             f = gdal.VSIFOpenL(filename, "wb")
         assert f is not None, filename
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = gdal.VSIFWriteL(big_buffer, 1, size, f)
         assert ret == 0, filename
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             gdal.VSIFCloseL(f)
         assert gdal.GetLastErrorMsg() != "", filename
 
@@ -2892,7 +2892,7 @@ def test_vsis3_6(aws_test_config, webserver_port):
             ret = gdal.VSIFWriteL(big_buffer, 1, size, f)
             assert ret == size, filename
             gdal.ErrorReset()
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 gdal.VSIFCloseL(f)
             assert gdal.GetLastErrorMsg() != "", filename
 
@@ -2950,7 +2950,7 @@ def test_vsis3_write_multipart_retry(aws_test_config, webserver_port):
             {},
         )
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             with webserver.install_http_handler(handler):
                 ret = gdal.VSIFWriteL(big_buffer, 1, size, f)
         assert ret == size
@@ -2973,7 +2973,7 @@ def test_vsis3_write_multipart_retry(aws_test_config, webserver_port):
             {},
         )
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             with webserver.install_http_handler(handler):
                 gdal.VSIFCloseL(f)
 
@@ -3249,12 +3249,12 @@ def test_vsis3_sync_etag(aws_test_config, webserver_port):
 
     options = ["SYNC_STRATEGY=ETAG"]
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         handler = webserver.SequentialHandler()
         with webserver.install_http_handler(handler):
             assert not gdal.Sync("/i_do/not/exist", "/vsis3/", options=options)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         handler = webserver.SequentialHandler()
         handler.add("GET", "/do_not/exist", 404)
         handler.add("GET", "/do_not/?delimiter=%2F&max-keys=100&prefix=exist%2F", 404)
@@ -3960,7 +3960,7 @@ def test_vsis3_fake_sync_multithreaded_upload_chunk_size_failure(
         thread_local=False,
     ):
         with webserver.install_http_handler(handler):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 assert not gdal.Sync(
                     "/vsimem/test",
                     "/vsis3/test_bucket",
@@ -4052,11 +4052,11 @@ def test_vsis3_metadata(aws_test_config, webserver_port):
         assert gdal.SetFileMetadata("/vsis3/test_metadata/foo.txt", {}, "TAGS")
 
     # Error case
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert gdal.GetFileMetadata("/vsis3/test_metadata/foo.txt", "UNSUPPORTED") == {}
 
     # Error case
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not gdal.SetFileMetadata(
             "/vsis3/test_metadata/foo.txt", {}, "UNSUPPORTED"
         )
@@ -4099,7 +4099,7 @@ def test_vsis3_random_write(aws_test_config, webserver_port):
 
     gdal.VSICurlClearCache()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert gdal.VSIFOpenL("/vsis3/random_write/test.bin", "w+b") is None
 
     with gdaltest.config_option(
@@ -4136,7 +4136,7 @@ def test_vsis3_random_write_failure_1(aws_test_config, webserver_port):
     handler = webserver.SequentialHandler()
     handler.add("PUT", "/random_write/test.bin", 400, {})
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert gdal.VSIFCloseL(f) != 0
 
 
@@ -4159,7 +4159,7 @@ def test_vsis3_random_write_failure_2(aws_test_config, webserver_port):
     handler = webserver.SequentialHandler()
     handler.add("POST", "/random_write/test.bin?uploads", 400, {})
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert gdal.VSIFCloseL(f) != 0
 
 
@@ -4477,7 +4477,7 @@ aws_secret_access_key = bar
     )
     with webserver.install_http_handler(handler):
         with gdaltest.config_options(options, thread_local=False):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 f = open_for_read("/vsis3/s3_fake_bucket/resource")
         assert f is not None
         assert gdal.GetLastErrorMsg() != ""
@@ -4888,7 +4888,7 @@ def test_vsis3_read_credentials_ec2_expiration(aws_test_config, webserver_port):
             with gdaltest.config_option(
                 "CPL_AWS_EC2_API_ROOT_URL", invalid_url, thread_local=False
             ):
-                with gdaltest.error_handler():
+                with gdal.quiet_errors():
                     f = open_for_read("/vsis3/s3_fake_bucket/bar")
         assert f is None
 
@@ -5284,7 +5284,7 @@ def test_vsis3_non_existing_file_GDAL_DISABLE_READDIR_ON_OPEN(
         "GDAL_DISABLE_READDIR_ON_OPEN", "YES", thread_local=False
     ):
         with webserver.install_http_handler(handler):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 gdal.Open("/vsis3/test_bucket/non_existing.tif")
     assert gdal.GetLastErrorMsg() == "HTTP response code: 404"
 
@@ -5478,7 +5478,7 @@ def test_vsis3_extra_1():
         # Invalid bucket : "The specified bucket does not exist"
         gdal.ErrorReset()
         f = open_for_read("/vsis3/not_existing_bucket/foo")
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             gdal.VSIFReadL(1, 1, f)
         gdal.VSIFCloseL(f)
         assert gdal.VSIGetLastErrorMsg() != ""

--- a/autotest/gcore/vsistdin.py
+++ b/autotest/gcore/vsistdin.py
@@ -99,7 +99,7 @@ def test_vsistdin_2():
 @gdaltest.disable_exceptions()
 def test_vsistdin_3():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = gdal.VSIFOpenL("/vsistdin/", "wb")
     assert f is None
 
@@ -230,7 +230,7 @@ def test_vsistdin_5():
         assert gdal.VSIFSeekL(f, 0, 0) == 0
         assert gdal.VSIFReadL(5, 1, f) == b"01234"
         assert gdal.VSIFReadL(3, 1, f) == b"567"
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert gdal.VSIFReadL(3, 1, f) == b""
         gdal.VSIFCloseL(f)
 

--- a/autotest/gcore/vsiswift.py
+++ b/autotest/gcore/vsiswift.py
@@ -74,12 +74,12 @@ def test_vsiswift_real_server_errors():
 
     # Nothing set
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = open_for_read("/vsiswift/foo/bar")
     assert f is None and gdal.VSIGetLastErrorMsg().find("SWIFT_STORAGE_URL") >= 0
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = open_for_read("/vsiswift_streaming/foo/bar")
     assert f is None and gdal.VSIGetLastErrorMsg().find("SWIFT_STORAGE_URL") >= 0
 
@@ -87,14 +87,14 @@ def test_vsiswift_real_server_errors():
 
     # Missing SWIFT_AUTH_TOKEN
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = open_for_read("/vsiswift/foo/bar")
     assert f is None and gdal.VSIGetLastErrorMsg().find("SWIFT_AUTH_TOKEN") >= 0
 
     gdal.SetConfigOption("SWIFT_AUTH_TOKEN", "SWIFT_AUTH_TOKEN")
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = open_for_read("/vsiswift/foo/bar.baz")
     if f is not None:
         if f is not None:
@@ -102,7 +102,7 @@ def test_vsiswift_real_server_errors():
         pytest.fail(gdal.VSIGetLastErrorMsg())
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = open_for_read("/vsiswift_streaming/foo/bar.baz")
     assert f is None, gdal.VSIGetLastErrorMsg()
 
@@ -797,7 +797,7 @@ def test_vsiswift_fake_unlink():
     )
     handler.add("DELETE", "/v1/AUTH_something/foo/bar", 400, {"Connection": "close"})
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = gdal.Unlink("/vsiswift/foo/bar")
     assert ret == -1
 

--- a/autotest/gcore/vsiwebhdfs.py
+++ b/autotest/gcore/vsiwebhdfs.py
@@ -262,7 +262,7 @@ def test_vsiwebhdfs_write():
     handler = webserver.SequentialHandler()
     with webserver.install_http_handler(handler):
         # Missing required config options
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = gdal.VSIFOpenL(gdaltest.webhdfs_base_connection + "/foo/bar", "wb")
         assert f is None
 
@@ -366,7 +366,7 @@ def test_vsiwebhdfs_write():
         {"WEBHDFS_USERNAME": "root", "WEBHDFS_DATANODE_HOST": "localhost"}
     ):
         with webserver.install_http_handler(handler):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 f = gdal.VSIFOpenL(gdaltest.webhdfs_base_connection + "/foo/bar", "wb")
                 assert f is None
 
@@ -382,7 +382,7 @@ def test_vsiwebhdfs_write():
     )
     with gdaltest.config_options({"WEBHDFS_USERNAME": "root"}):
         with webserver.install_http_handler(handler):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 f = gdal.VSIFOpenL(gdaltest.webhdfs_base_connection + "/foo/bar", "wb")
                 assert f is None
 
@@ -427,7 +427,7 @@ def test_vsiwebhdfs_write():
     )
     handler.add("POST", "/redirected/webhdfs/v1/foo/bar?op=APPEND&user.name=root", 400)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         with webserver.install_http_handler(handler):
             assert gdal.VSIFCloseL(f) != 0
 
@@ -476,7 +476,7 @@ def test_vsiwebhdfs_unlink():
     handler = webserver.SequentialHandler()
     handler.add("DELETE", "/webhdfs/v1/foo/bar?op=DELETE", 200, {}, '{"boolean":false}')
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = gdal.Unlink(gdaltest.webhdfs_base_connection + "/foo/bar")
     assert ret == -1
 
@@ -486,7 +486,7 @@ def test_vsiwebhdfs_unlink():
     handler = webserver.SequentialHandler()
     handler.add("DELETE", "/webhdfs/v1/foo/bar?op=DELETE", 404, {})
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = gdal.Unlink(gdaltest.webhdfs_base_connection + "/foo/bar")
     assert ret == -1
 

--- a/autotest/gcore/vsizip.py
+++ b/autotest/gcore/vsizip.py
@@ -63,7 +63,7 @@ def test_vsizip_1():
 
     # Test that we cannot read a zip file being written
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = gdal.VSIFOpenL("/vsizip/vsimem/test.zip/subdir3/abcd", "rb")
     assert (
         gdal.GetLastErrorMsg() == "Cannot read a zip file being written"
@@ -77,7 +77,7 @@ def test_vsizip_1():
 
     # Try creating a 3d file
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f4 = gdal.VSIFOpenL("/vsizip/vsimem/test.zip/that_wont_work", "wb")
     assert (
         gdal.GetLastErrorMsg()
@@ -92,7 +92,7 @@ def test_vsizip_1():
 
     # ERROR 6: Support only 1 file in archive file /vsimem/test.zip when no explicit in-archive filename is specified
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = gdal.VSIFOpenL("/vsizip/vsimem/test.zip", "rb")
     if f is not None:
         gdal.VSIFCloseL(f)
@@ -191,7 +191,7 @@ def test_vsizip_2():
     gdal.VSIFWriteL("67890", 1, 5, fmain)
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         content = gdal.ReadDir("/vsizip/" + zip_name)
     assert (
         gdal.GetLastErrorMsg() == "Cannot read a zip file being written"
@@ -310,7 +310,7 @@ def test_vsizip_6():
     gdal.VSIFCloseL(f)
     f = None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = gdal.VSIFOpenL("/vsizip/vsimem/test6.zip/foo.bar", "wb")
     if f is not None:
         gdal.VSIFCloseL(f)
@@ -327,7 +327,7 @@ def test_vsizip_6():
     gdal.VSIFCloseL(f)
     f = None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = gdal.VSIFOpenL("/vsizip/vsimem/test6.zip/foo.bar", "wb")
     if f is not None:
         gdal.VSIFCloseL(f)
@@ -550,7 +550,7 @@ def test_vsizip_14():
     except Exception:
         cp866_filename = "\u0430\u0431\u0432\u0433\u0434\u0435"
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = gdal.VSIFOpenL("/vsizip//vsimem/vsizip_14.zip/" + cp866_filename, "wb")
     if f is None:
         gdal.VSIFCloseL(fmain)
@@ -605,7 +605,7 @@ def test_vsizip_multi_thread():
 @gdaltest.disable_exceptions()
 def test_vsizip_multi_thread_error():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         with gdaltest.config_options(
             {"GDAL_NUM_THREADS": "ALL_CPUS", "CPL_VSIL_DEFLATE_CHUNK_SIZE": "16K"}
         ):
@@ -782,7 +782,7 @@ def test_vsizip_byte_copyfile_regular():
         assert int(md["COMPRESSED_SIZE"]) < int(md["UNCOMPRESSED_SIZE"])
 
         # The file already exists:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert gdal.CopyFile("data/byte.tif", dstfilename) == -1
     finally:
         gdal.Unlink(zipfilename)

--- a/autotest/gdrivers/bag.py
+++ b/autotest/gdrivers/bag.py
@@ -233,7 +233,7 @@ def test_bag_vr_normal():
             pp.pprint(got_md)
             pytest.fail(key)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             "data/bag/test_vr.bag", open_options=["MODE=LOW_RES_GRID", "MINX=0"]
         )
@@ -256,7 +256,7 @@ def test_bag_vr_list_supergrids():
 
     assert sub_ds[0][0] == 'BAG:"data/bag/test_vr.bag":supergrid:0:0'
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # Bounding box filter ignored since only part of MINX, MINY, MAXX and
         # MAXY has been specified
         ds = gdal.OpenEx(
@@ -304,7 +304,7 @@ def test_bag_vr_list_supergrids():
 
     # Test invalid values for SUPERGRIDS_INDICES
     for invalid_val in ["", "x", "(", "(1", "(1,", "(1,)", "(1,2),", "(x,2)", "(2,x)"]:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.OpenEx(
                 "data/bag/test_vr.bag",
                 open_options=["SUPERGRIDS_INDICES=" + invalid_val],
@@ -378,19 +378,19 @@ def test_bag_vr_open_supergrids():
             pp.pprint(got_md)
             pytest.fail(key)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open('BAG:"/vsimem/unexisting.bag":supergrid:0:0')
     assert ds is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open('BAG:"data/bag/test_vr.bag":supergrid:4:0')
     assert ds is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open('BAG:"data/bag/test_vr.bag":supergrid:0:6')
     assert ds is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             'BAG:"data/bag/test_vr.bag":supergrid:0:0', open_options=["MINX=0"]
         )
@@ -596,7 +596,7 @@ def test_bag_vr_resampled():
     assert got == (165, 205)
 
     # Too big RES_FILTER_MIN
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             "data/bag/test_vr.bag",
             open_options=["MODE=RESAMPLED_GRID", "RES_FILTER_MIN=32"],
@@ -604,7 +604,7 @@ def test_bag_vr_resampled():
     assert ds is None
 
     # Too small RES_FILTER_MAX
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             "data/bag/test_vr.bag",
             open_options=["MODE=RESAMPLED_GRID", "RES_FILTER_MAX=4"],
@@ -612,7 +612,7 @@ def test_bag_vr_resampled():
     assert ds is None
 
     # RES_FILTER_MIN >= RES_FILTER_MAX
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             "data/bag/test_vr.bag",
             open_options=[
@@ -836,7 +836,7 @@ def test_bag_read_georef_metadata():
         == 'BAG:"data/bag/test_georef_metadata.bag":georef_metadata:layer_with_keys_values:0:0'
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             gdal.Open(
                 'BAG:"data/bag/test_georef_metadata.bag":georef_metadata:not_existing'

--- a/autotest/gdrivers/basisu.py
+++ b/autotest/gdrivers/basisu.py
@@ -105,7 +105,7 @@ def test_basisu_read_two_images():
     ],
 )
 def test_basisu_read_wrong_subds(filename):
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert gdal.Open(filename) is None
 
 
@@ -283,7 +283,7 @@ def test_basisu_write_etc1s_clusters_options():
     gdal.Unlink(out_filename)
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             gdal.GetDriverByName("BASISU").CreateCopy(
                 out_filename,
@@ -341,7 +341,7 @@ def test_basisu_write_etc1s_incompatible_or_missing_options():
     out_filename = "/vsimem/out.basis"
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             gdal.GetDriverByName("BASISU").CreateCopy(
                 out_filename, src_ds, options=["ETC1S_MAX_ENDPOINTS_CLUSTERS=16128"]
@@ -351,7 +351,7 @@ def test_basisu_write_etc1s_incompatible_or_missing_options():
         assert gdal.GetLastErrorMsg() != ""
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             gdal.GetDriverByName("BASISU").CreateCopy(
                 out_filename, src_ds, options=["ETC1S_MAX_SELECTOR_CLUSTERS=16128"]
@@ -361,7 +361,7 @@ def test_basisu_write_etc1s_incompatible_or_missing_options():
         assert gdal.GetLastErrorMsg() != ""
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             gdal.GetDriverByName("BASISU").CreateCopy(
                 out_filename,
@@ -374,7 +374,7 @@ def test_basisu_write_etc1s_incompatible_or_missing_options():
     gdal.Unlink(out_filename)
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             gdal.GetDriverByName("BASISU").CreateCopy(
                 out_filename,
@@ -392,13 +392,13 @@ def test_basisu_write_incompatible_source():
     out_filename = "/vsimem/out.basis"
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1, 0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert gdal.GetDriverByName("BASISU").CreateCopy(out_filename, src_ds) is None
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1, 5)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert gdal.GetDriverByName("BASISU").CreateCopy(out_filename, src_ds) is None
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1, 1, gdal.GDT_UInt16)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert gdal.GetDriverByName("BASISU").CreateCopy(out_filename, src_ds) is None

--- a/autotest/gdrivers/daas.py
+++ b/autotest/gdrivers/daas.py
@@ -83,7 +83,7 @@ def startup_and_cleanup():
 
 def test_daas_missing_parameters():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("DAAS:")
         assert not ds
 
@@ -100,7 +100,7 @@ def test_daas_authentication_failure():
             "missing_GDAL_DAAS_API_KEY": "api_key",
         }
     ):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.Open("DAAS:https://127.0.0.1:99999")
             assert not ds
 
@@ -111,7 +111,7 @@ def test_daas_authentication_failure():
             "GDAL_DAAS_API_KEY": "api_key",
         }
     ):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.Open("DAAS:https://127.0.0.1:99999")
             assert not ds
 
@@ -132,7 +132,7 @@ def test_daas_authentication_failure():
                 "GDAL_DAAS_API_KEY": "api_key",
             }
         ):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ds = gdal.Open("DAAS:https://127.0.0.1:99999")
                 assert not ds
 
@@ -147,7 +147,7 @@ def test_daas_authentication_failure():
                 "GDAL_DAAS_API_KEY": "api_key",
             }
         ):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ds = gdal.Open("DAAS:https://127.0.0.1:99999")
                 assert not ds
 
@@ -162,7 +162,7 @@ def test_daas_authentication_failure():
                 "GDAL_DAAS_API_KEY": "api_key",
             }
         ):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ds = gdal.Open("DAAS:https://127.0.0.1:99999")
                 assert not ds
 
@@ -202,7 +202,7 @@ def test_daas_authentication():
                 "GDAL_DAAS_API_KEY": "api_key",
             }
         ):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 gdal.Open(
                     "DAAS:http://127.0.0.1:%d/daas/sensors/products/foo/images/bar"
                     % gdaltest.webserver_port
@@ -231,7 +231,7 @@ def test_daas_authentication():
                 "GDAL_DAAS_API_KEY": "api_key",
             }
         ):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 gdal.OpenEx(
                     "DAAS:http://127.0.0.1:%d/daas/sensors/products/foo/images/bar"
                     % gdaltest.webserver_port,
@@ -258,7 +258,7 @@ def test_daas_authentication():
                 "GDAL_DAAS_API_KEY": "api_key",
             }
         ):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 gdal.Open(
                     "DAAS:http://127.0.0.1:%d/daas/sensors/products/foo/images/bar"
                     % gdaltest.webserver_port
@@ -280,7 +280,7 @@ def test_daas_authentication():
                 % gdaltest.webserver_port,
             }
         ):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 gdal.OpenEx(
                     "DAAS:http://127.0.0.1:%d/daas/sensors/products/foo/images/bar"
                     % gdaltest.webserver_port
@@ -304,7 +304,7 @@ def test_daas_getimagemetadata_failure():
                     % gdaltest.webserver_port,
                 }
             ):
-                with gdaltest.error_handler():
+                with gdal.quiet_errors():
                     ds = gdal.Open(
                         "DAAS:http://127.0.0.1:%d/daas/sensors/products/foo/images/bar"
                         % gdaltest.webserver_port
@@ -322,7 +322,7 @@ def test_daas_getimagemetadata_failure():
                 % gdaltest.webserver_port,
             }
         ):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ds = gdal.Open(
                     "DAAS:http://127.0.0.1:%d/daas/sensors/products/foo/images/bar"
                     % gdaltest.webserver_port
@@ -342,7 +342,7 @@ def test_daas_getimagemetadata_failure():
                 % gdaltest.webserver_port,
             }
         ):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ds = gdal.Open(
                     "DAAS:http://127.0.0.1:%d/daas/sensors/products/foo/images/bar"
                     % gdaltest.webserver_port
@@ -360,7 +360,7 @@ def test_daas_getimagemetadata_failure():
                 % gdaltest.webserver_port,
             }
         ):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ds = gdal.Open(
                     "DAAS:http://127.0.0.1:%d/daas/sensors/products/foo/images/bar"
                     % gdaltest.webserver_port
@@ -378,7 +378,7 @@ def test_daas_getimagemetadata_failure():
                 % gdaltest.webserver_port,
             }
         ):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ds = gdal.Open(
                     "DAAS:http://127.0.0.1:%d/daas/sensors/products/foo/images/bar"
                     % gdaltest.webserver_port
@@ -905,7 +905,7 @@ def test_daas_getimagemetadata_http_retry():
                 % gdaltest.webserver_port,
             }
         ):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ds = gdal.Open(
                     "DAAS:http://127.0.0.1:%d/daas/sensors/products/foo/images/bar"
                     % gdaltest.webserver_port
@@ -928,7 +928,7 @@ def test_daas_getimagemetadata_http_retry():
                 % gdaltest.webserver_port,
             }
         ):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ds = gdal.Open(
                     "DAAS:http://127.0.0.1:%d/daas/sensors/products/foo/images/bar"
                     % gdaltest.webserver_port
@@ -947,7 +947,7 @@ def test_daas_getimagemetadata_http_retry():
                 % gdaltest.webserver_port,
             }
         ):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ds = gdal.Open(
                     "DAAS:http://127.0.0.1:%d/daas/sensors/products/foo/images/bar"
                     % gdaltest.webserver_port
@@ -1012,7 +1012,7 @@ def test_daas_getbuffer_failure():
     handler.add("POST", "/getbuffer", 404)
     handler.add("POST", "/getbuffer", 404)
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             data = ds.GetRasterBand(1).ReadRaster()
     assert not data
 
@@ -1022,7 +1022,7 @@ def test_daas_getbuffer_failure():
     handler.add("POST", "/getbuffer", 404, {}, "my error message")
     handler.add("POST", "/getbuffer", 404)
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             data = ds.GetRasterBand(1).ReadRaster()
     assert not data
 
@@ -1032,7 +1032,7 @@ def test_daas_getbuffer_failure():
     handler.add("POST", "/getbuffer", 200, {}, "not multipart")
     handler.add("POST", "/getbuffer", 404)
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             data = ds.GetRasterBand(1).ReadRaster()
     assert not data
 
@@ -1057,7 +1057,7 @@ Content-Type: application/json
     )
     handler.add("POST", "/getbuffer", 404)
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             data = ds.GetRasterBand(1).ReadRaster()
     assert not data
 
@@ -1082,7 +1082,7 @@ ABCDEF
     )
     handler.add("POST", "/getbuffer", 404)
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             data = ds.GetRasterBand(1).ReadRaster()
     assert not data
 
@@ -1112,7 +1112,7 @@ Content-Type: application/json
     )
     handler.add("POST", "/getbuffer", 404)
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             data = ds.GetRasterBand(1).ReadRaster()
     assert not data
 
@@ -1142,7 +1142,7 @@ Content-Type: application/json
     )
     handler.add("POST", "/getbuffer", 404)
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             data = ds.GetRasterBand(1).ReadRaster()
     assert not data
 
@@ -1200,7 +1200,7 @@ Content-Type: application/json
     handler.add("POST", "/getbuffer", 404)
 
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             data = ds.GetRasterBand(1).ReadRaster()
     assert not data
 
@@ -1240,7 +1240,7 @@ Content-Type: application/json
     handler.add("POST", "/getbuffer", 404)
 
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             data = ds.GetRasterBand(1).ReadRaster()
     assert not data
 
@@ -1293,7 +1293,7 @@ def test_daas_getbuffer_pixel_encoding_failures():
                 % gdaltest.webserver_port,
             }
         ):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ds = gdal.OpenEx(
                     "DAAS:http://127.0.0.1:%d/daas/sensors/products/foo/images/bar"
                     % gdaltest.webserver_port,
@@ -1313,7 +1313,7 @@ def test_daas_getbuffer_pixel_encoding_failures():
                 % gdaltest.webserver_port,
             }
         ):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ds = gdal.OpenEx(
                     "DAAS:http://127.0.0.1:%d/daas/sensors/products/foo/images/bar"
                     % gdaltest.webserver_port,
@@ -1333,7 +1333,7 @@ def test_daas_getbuffer_pixel_encoding_failures():
                 % gdaltest.webserver_port,
             }
         ):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ds = gdal.OpenEx(
                     "DAAS:http://127.0.0.1:%d/daas/sensors/products/foo/images/bar"
                     % gdaltest.webserver_port,
@@ -1387,7 +1387,7 @@ def test_daas_getbuffer_pixel_encoding_failures():
                 % gdaltest.webserver_port,
             }
         ):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ds = gdal.OpenEx(
                     "DAAS:http://127.0.0.1:%d/daas/sensors/products/foo/images/bar"
                     % gdaltest.webserver_port,
@@ -1624,7 +1624,7 @@ Content-Type: application/json
     )
 
     with webserver.install_http_handler(handler):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             data = ds.GetRasterBand(1).ReadRaster(0, 0, 1, 1)
     assert data == "A".encode("ascii")
     data = ds.GetRasterBand(2).ReadRaster(0, 0, 1, 1)

--- a/autotest/gdrivers/dted.py
+++ b/autotest/gdrivers/dted.py
@@ -175,7 +175,7 @@ def test_dted_7():
     ds = gdal.Open("data/dted/n43_wgs72.dt0")
 
     # a warning is issued
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         prj = ds.GetProjection()
 
     assert gdal.GetLastErrorMsg() is not None, "An expected warning was not emitted"

--- a/autotest/gdrivers/ehdr.py
+++ b/autotest/gdrivers/ehdr.py
@@ -356,7 +356,7 @@ def test_ehdr_rat():
     assert not (
         ds.GetRasterBand(1).GetDefaultRAT() or ds.GetRasterBand(1).GetColorTable()
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.GetRasterBand(1).SetDefaultRAT(gdal.RasterAttributeTable())
     assert ret != 0
     ds = None

--- a/autotest/gdrivers/fits.py
+++ b/autotest/gdrivers/fits.py
@@ -161,7 +161,7 @@ def test_fits_read_empty_primary_hdu():
 
     filename = "data/fits/empty_primary_hdu.fits"
     assert os.path.exists(filename)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert gdal.Open(filename) is None
 
 
@@ -195,7 +195,7 @@ def test_fits_read_image_in_first_and_second_hdu():
     assert sub_ds[1][0] == 'FITS:"data/fits/image_in_first_and_second_hdu.fits":2'
     assert sub_ds[1][1] == "HDU 2 (1x3, 1 band)"
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert gdal.Open("FITS:") is None
         assert gdal.Open('FITS:"data/fits/image_in_first_and_second_hdu.fits"') is None
         assert (
@@ -248,18 +248,18 @@ def test_fits_open_raster_only_in_vector_mode():
 
     filename = "data/fits/empty_primary_hdu.fits"
     assert os.path.exists(filename)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ogr.Open(filename) is None
 
     filename = "data/fits/byte_merc.fits"
     assert os.path.exists(filename)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ogr.Open(filename) is None
     assert "but contains image" in gdal.GetLastErrorMsg()
 
     filename = "data/fits/image_in_first_and_second_hdu.fits"
     assert os.path.exists(filename)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ogr.Open(filename) is None
 
     ds = gdal.OpenEx(
@@ -273,7 +273,7 @@ def test_fits_open_vector_only_in_raster_mode():
 
     filename = "data/fits/binary_table.fits"
     assert os.path.exists(filename)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert gdal.Open(filename) is None
     assert "but contains binary table" in gdal.GetLastErrorMsg()
 
@@ -720,7 +720,7 @@ def _check_lyr_defn_after_write(lyr_defn):
 def test_fits_vector_write_with_source_fits_metadata():
 
     filename = "tmp/out.fits"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.VectorTranslate(filename, "data/fits/binary_table.fits", options="-f FITS")
     try:
         ds = ogr.Open(filename)
@@ -835,7 +835,7 @@ def test_fits_vector_write_with_source_fits_metadata():
 def test_fits_vector_write_without_source_fits_metadata():
 
     filename = "tmp/out.fits"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.VectorTranslate(
             filename, "data/fits/binary_table.fits", options="-f FITS -nomd"
         )
@@ -953,7 +953,7 @@ def test_fits_vector_write_without_source_fits_metadata():
 def test_fits_vector_write_without_source_fits_metadata_compute_repeat():
 
     filename = "tmp/out.fits"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.VectorTranslate(
             filename,
             "data/fits/binary_table.fits",
@@ -1074,7 +1074,7 @@ def test_fits_vector_write_without_source_fits_metadata_compute_repeat():
 def test_fits_vector_editing():
 
     filename = "tmp/out.fits"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.VectorTranslate(
             filename, "data/fits/binary_table.fits", options="-f FITS -nomd"
         )

--- a/autotest/gdrivers/gdalhttp.py
+++ b/autotest/gdrivers/gdalhttp.py
@@ -162,7 +162,7 @@ def test_http_6():
 
 def test_http_ssl_verifystatus():
     with gdaltest.config_option("GDAL_HTTP_SSL_VERIFYSTATUS", "YES"):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             # For now this URL doesn't support OCSP stapling...
             gdal.OpenEx("https://google.com", allowed_drivers=["HTTP"])
     last_err = gdal.GetLastErrorMsg()
@@ -192,7 +192,7 @@ def test_http_ssl_verifystatus():
 
 def test_http_use_capi_store():
     if sys.platform != "win32":
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             return test_http_use_capi_store_sub()
 
     # Prints this to stderr in many cases (but doesn't error)

--- a/autotest/gdrivers/georaster.py
+++ b/autotest/gdrivers/georaster.py
@@ -72,7 +72,7 @@ def test_georaster_init():
     if gdaltest.oci_ds is None:
         pytest.skip()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         rs = gdaltest.oci_ds.ExecuteSQL("select owner from all_sdo_geor_sysdata")
 
     err_msg = gdal.GetLastErrorMsg()

--- a/autotest/gdrivers/gpkg.py
+++ b/autotest/gdrivers/gpkg.py
@@ -397,7 +397,7 @@ def test_gpkg_2():
     out_ds = gdal.Open("/vsimem/tmp.gpkg")
     # Should give warning at pixel reading time
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds.GetRasterBand(1).Checksum()
     assert gdal.GetLastErrorMsg() != ""
     out_ds = None
@@ -409,7 +409,7 @@ def test_gpkg_2():
         "/vsimem/tmp.gpkg", ds, options=["TILE_FORMAT=JPEG"]
     )
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds.FlushCache()
     assert gdal.GetLastErrorMsg() != ""
     out_ds = None
@@ -493,7 +493,7 @@ def test_gpkg_3():
 
     # Should give warning at open time since the webp extension is declared
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdal.Open("/vsimem/tmp.gpkg")
     if gdal.GetLastErrorMsg() == "":
         gdaltest.webp_dr.Register()
@@ -501,7 +501,7 @@ def test_gpkg_3():
 
     # And at pixel reading time as well
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds.GetRasterBand(1).Checksum()
     if gdal.GetLastErrorMsg() == "":
         gdaltest.webp_dr.Register()
@@ -789,7 +789,7 @@ def test_gpkg_10():
 
     # SetColorTable() on a non single-band dataset
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds.GetRasterBand(1).SetColorTable(None)
     assert gdal.GetLastErrorMsg() != ""
 
@@ -805,7 +805,7 @@ def test_gpkg_10():
 
     # SetColorTable() on a re-opened dataset
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds.GetRasterBand(1).SetColorTable(None)
     assert gdal.GetLastErrorMsg() != ""
 
@@ -818,11 +818,11 @@ def test_gpkg_10():
     out_ds.GetRasterBand(1).SetColorTable(None)
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds.GetRasterBand(1).SetColorTable(None)
     assert gdal.GetLastErrorMsg() != ""
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = None
 
     gdal.Unlink("/vsimem/tmp.gpkg")
@@ -987,7 +987,7 @@ def test_gpkg_14():
     )
     ds = None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx("/vsimem/tmp.gpkg", open_options=["TABLE=non_existing"])
     assert ds is None
 
@@ -1035,7 +1035,7 @@ def test_gpkg_14():
     ds = gdal.OpenEx("/vsimem/tmp2.gpkg", gdal.OF_UPDATE)
     ds.ExecuteSQL("UPDATE gpkg_contents SET min_x = NULL")
     ds = None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx("/vsimem/tmp2.gpkg", open_options=["ZOOM_LEVEL=-1"])
     assert ds is None
     gdal.Unlink("/vsimem/tmp2.gpkg")
@@ -1305,14 +1305,14 @@ def test_gpkg_14():
     ds = None
 
     # Overflow occurred in ComputeTileAndPixelShifts()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             "/vsimem/tmp.gpkg", open_options=["MINX=-1e12", "MAXX=-0.9999e12"]
         )
     assert ds is None
 
     # Overflow occurred in ComputeTileAndPixelShifts()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             "/vsimem/tmp.gpkg", open_options=["MINY=-1e12", "MAXY=-0.9999e12"]
         )
@@ -1323,7 +1323,7 @@ def test_gpkg_14():
     ds = gdal.OpenEx("/vsimem/tmp.gpkg", gdal.OF_UPDATE)
     ds.ExecuteSQL("UPDATE gpkg_contents SET min_x=-1000000002000, max_x=-1000000000000")
     ds = None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/tmp.gpkg")
     assert ds is None
 
@@ -1342,13 +1342,13 @@ def test_gpkg_15():
     out_ds = gdaltest.gpkg_dr.Create("/vsimem/tmp.gpkg", 0, 0, 0)
     assert out_ds.GetGeoTransform(can_return_null=True) is None
     assert out_ds.GetProjectionRef() == ""
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = out_ds.SetGeoTransform([0, 1, 0, 0, 0, -1])
     assert ret != 0
 
     srs = osr.SpatialReference()
     srs.ImportFromEPSG(4326)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = out_ds.SetProjection(srs.ExportToWkt())
     assert ret != 0
     out_ds = None
@@ -1359,7 +1359,7 @@ def test_gpkg_15():
     out_ds = gdaltest.gpkg_dr.Create("/vsimem/tmp.gpkg", 1, 1)
     ret = out_ds.SetGeoTransform([0, 1, 0, 0, 0, -1])
     assert ret == 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = out_ds.SetGeoTransform([0, 1, 0, 0, 0, -1])
     assert ret != 0
     out_ds = None
@@ -1384,10 +1384,10 @@ def test_gpkg_15():
     assert out_ds.GetSpatialRef().IsLocal()
     assert out_ds.GetProjectionRef().find("Undefined Cartesian SRS") >= 0
     # Test setting on read-only dataset
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = out_ds.SetProjection("")
     assert ret != 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = out_ds.SetGeoTransform([0, 1, 0, 0, 0, -1])
     assert ret != 0
     out_ds = None
@@ -1403,7 +1403,7 @@ def test_gpkg_15():
     assert ret == 0
     ret = out_ds.GetRasterBand(1).SetColorInterpretation(gdal.GCI_PaletteIndex)
     assert ret == 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = out_ds.GetRasterBand(1).SetColorInterpretation(gdal.GCI_RedBand)
     assert ret != 0
     out_ds = None
@@ -1414,7 +1414,7 @@ def test_gpkg_15():
     out_ds.SetGeoTransform([0, 1, 0, 0, 0, -1])
     ret = out_ds.GetRasterBand(1).SetColorInterpretation(gdal.GCI_RedBand)
     assert ret == 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = out_ds.GetRasterBand(2).SetColorInterpretation(gdal.GCI_RedBand)
     assert ret != 0
     out_ds = None
@@ -1425,12 +1425,12 @@ def test_gpkg_15():
     out_ds.SetGeoTransform([0, 1, 0, 0, 0, -1])
     ret = out_ds.GetRasterBand(1).SetColorInterpretation(gdal.GCI_GrayIndex)
     assert ret == 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = out_ds.GetRasterBand(1).SetColorInterpretation(gdal.GCI_RedBand)
     assert ret != 0
     ret = out_ds.GetRasterBand(2).SetColorInterpretation(gdal.GCI_AlphaBand)
     assert ret == 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = out_ds.GetRasterBand(2).SetColorInterpretation(gdal.GCI_RedBand)
     assert ret != 0
     out_ds = None
@@ -1561,7 +1561,7 @@ def test_gpkg_17():
 
     # Test building on an overview dataset --> error
     out_ds = gdal.OpenEx("/vsimem/tmp.gpkg", gdal.OF_RASTER | gdal.OF_UPDATE)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = (
             out_ds.GetRasterBand(1)
             .GetOverview(0)
@@ -1573,7 +1573,7 @@ def test_gpkg_17():
 
     # Test building overview factor 1 --> error
     out_ds = gdal.OpenEx("/vsimem/tmp.gpkg", gdal.OF_RASTER | gdal.OF_UPDATE)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = out_ds.BuildOverviews("NEAR", [1])
     assert ret != 0
     out_ds = None
@@ -1598,7 +1598,7 @@ def test_gpkg_17():
 
     # Test building overviews on read-only dataset
     out_ds = gdal.OpenEx("/vsimem/tmp.gpkg", gdal.OF_RASTER)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = out_ds.BuildOverviews("NEAR", [2])
     assert ret != 0
     out_ds = None
@@ -1652,7 +1652,7 @@ def test_gpkg_18():
     # Test gpkg_zoom_other extension
     out_ds = gdal.OpenEx("/vsimem/tmp.gpkg", gdal.OF_RASTER | gdal.OF_UPDATE)
     # We expect a warning
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = out_ds.BuildOverviews("NEAR", [3])
     assert ret == 0
     assert out_ds.GetRasterBand(1).GetOverviewCount() == 3
@@ -2356,7 +2356,7 @@ def test_gpkg_26():
         gdal.Unlink("/vsimem/tmp.gpkg")
 
     # Test a few error cases
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdaltest.gpkg_dr.Create(
             "/vsimem/tmp.gpkg",
             1,
@@ -2372,15 +2372,15 @@ def test_gpkg_26():
     )
     # Test that implicit SRS registration works.
     assert ds.GetProjectionRef().find("4326") >= 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.SetGeoTransform([0, 10, 0, 0, 0, -10])
     assert ret != 0
     srs = osr.SpatialReference()
     srs.ImportFromEPSG(32630)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.SetProjection(srs.ExportToWkt())
     assert ret != 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = None
 
     gdal.Unlink("/vsimem/tmp.gpkg")
@@ -2400,7 +2400,7 @@ def test_gpkg_26():
 
     # Unsupported TILING_SCHEME
     src_ds = gdal.Open("data/byte.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             gdaltest.gpkg_dr.CreateCopy(
                 "/vsimem/tmp.gpkg", src_ds, options=["TILING_SCHEME=NZTM2000"]
@@ -2411,7 +2411,7 @@ def test_gpkg_26():
 
     # Invalid TILING_SCHEME
     src_ds = gdal.Open("data/byte.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             gdaltest.gpkg_dr.CreateCopy(
                 "/vsimem/tmp.gpkg", src_ds, options=["TILING_SCHEME=invalid"]
@@ -2422,7 +2422,7 @@ def test_gpkg_26():
 
     # Invalid target filename
     src_ds = gdal.Open("data/byte.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdaltest.gpkg_dr.CreateCopy(
             "/foo/tmp.gpkg", src_ds, options=["TILING_SCHEME=GoogleCRS84Quad"]
         )
@@ -2430,7 +2430,7 @@ def test_gpkg_26():
 
     # Source is not georeferenced
     src_ds = gdal.Open("../gcore/data/stefan_full_rgba.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdaltest.gpkg_dr.CreateCopy(
             "/vsimem/tmp.gpkg", src_ds, options=["TILING_SCHEME=GoogleCRS84Quad"]
         )
@@ -2782,7 +2782,7 @@ def test_gpkg_38():
     gdal.Unlink("/vsimem/gpkg_38.gpkg")
 
     filename = "/vsimem/||maxlength=%d||gpkg_38.gpkg" % (filesize - 100000)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdaltest.gpkg_dr.CreateCopy(
             filename, src_ds, options=["TILE_FORMAT=PNG", "BLOCKSIZE=8"]
         )
@@ -2792,7 +2792,7 @@ def test_gpkg_38():
     assert ds_is_none or gdal.GetLastErrorMsg() != ""
 
     filename = "/vsimem/||maxlength=%d||gpkg_38.gpkg" % (filesize - 1)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdaltest.gpkg_dr.CreateCopy(
             filename, src_ds, options=["TILE_FORMAT=PNG", "BLOCKSIZE=8"]
         )
@@ -3593,7 +3593,7 @@ def test_gpkg_47():
     ds = gdaltest.gpkg_dr.CreateCopy(tmpfile, gdal.Open("data/byte.tif"))
     ds.ExecuteSQL("UPDATE gpkg_contents SET min_x = 1, max_x = 0")
     ds = None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(tmpfile)
     assert ds.RasterXSize == 256
     ds = None
@@ -4070,11 +4070,11 @@ def test_gpkg_byte_nodata_value(band_count):
         filename, 1, 1, band_count, gdal.GDT_Byte, options=["TILE_FORMAT=PNG"]
     )
     ds.SetGeoTransform([0, 1, 0, 0, 0, -1])
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.GetRasterBand(1).SetNoDataValue(-32768) == gdal.CE_Failure
     assert ds.GetRasterBand(1).SetNoDataValue(255) == gdal.CE_None
     if band_count == 2:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert ds.GetRasterBand(2).SetNoDataValue(254) == gdal.CE_Failure
     ds = None
     ds = gdal.Open(filename)
@@ -4133,7 +4133,7 @@ def test_gpkg_sql_gdal_get_layer_pixel_value():
     assert f[0] is None
 
     # NULL as 1st arg
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = ds.ExecuteSQL(
             "select gdal_get_layer_pixel_value(NULL, 1, 'pixel', 0, 0)"
         )
@@ -4142,7 +4142,7 @@ def test_gpkg_sql_gdal_get_layer_pixel_value():
         assert f[0] is None
 
     # NULL as 2nd arg
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = ds.ExecuteSQL(
             "select gdal_get_layer_pixel_value('byte', NULL, 'pixel', 0, 0)"
         )
@@ -4151,7 +4151,7 @@ def test_gpkg_sql_gdal_get_layer_pixel_value():
         assert f[0] is None
 
     # NULL as 3rd arg
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = ds.ExecuteSQL(
             "select gdal_get_layer_pixel_value('byte', 1, NULL, 0, 0)"
         )
@@ -4160,7 +4160,7 @@ def test_gpkg_sql_gdal_get_layer_pixel_value():
         assert f[0] is None
 
     # NULL as 4th arg
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = ds.ExecuteSQL(
             "select gdal_get_layer_pixel_value('byte', 1, 'pixel', NULL, 0)"
         )
@@ -4169,7 +4169,7 @@ def test_gpkg_sql_gdal_get_layer_pixel_value():
         assert f[0] is None
 
     # NULL as 5th arg
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = ds.ExecuteSQL(
             "select gdal_get_layer_pixel_value('byte', 1, 'pixel', 0, NULL)"
         )
@@ -4178,7 +4178,7 @@ def test_gpkg_sql_gdal_get_layer_pixel_value():
         assert f[0] is None
 
     # Invalid band number
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = ds.ExecuteSQL(
             "select gdal_get_layer_pixel_value('byte', 0, 'pixel', 0, 0)"
         )
@@ -4187,7 +4187,7 @@ def test_gpkg_sql_gdal_get_layer_pixel_value():
         assert f[0] is None
 
     # Invalid value for 3rd argument
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = ds.ExecuteSQL(
             "select gdal_get_layer_pixel_value('byte', 1, 'invalid', 0, 0)"
         )

--- a/autotest/gdrivers/grib.py
+++ b/autotest/gdrivers/grib.py
@@ -90,7 +90,7 @@ def test_grib_2():
 def test_grib_read_different_sizes_messages():
 
     tst = gdaltest.GDALTest("GRIB", "grib/bug3246.grb", 4, 4081)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         tst.testOpen()
 
     msg = gdal.GetLastErrorMsg()
@@ -435,7 +435,7 @@ def test_grib_grib2_read_template_4_40():
 
 def test_grib_grib2_read_template_4_unhandled():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/grib/template_4_65535.grb2")
     md = ds.GetRasterBand(1).GetMetadata()
     expected_md = {"GRIB_PDS_TEMPLATE_NUMBERS": "0 1 2 3 4 5", "GRIB_PDS_PDTN": "65535"}
@@ -657,7 +657,7 @@ def test_grib_grib2_write_creation_options():
     gdal.Unlink(tmpfilename)
 
     # Test with PDS_TEMPLATE_NUMBERS and more elements than needed (warning)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdal.Translate(
             tmpfilename,
             "data/byte.tif",
@@ -681,7 +681,7 @@ def test_grib_grib2_write_creation_options():
     gdal.Unlink(tmpfilename)
 
     # Test with PDS_TEMPLATE_ASSEMBLED_VALUES and insufficient number of elements
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdal.Translate(
             tmpfilename,
             "data/byte.tif",
@@ -716,7 +716,7 @@ def test_grib_grib2_write_creation_options():
     gdal.Unlink(tmpfilename)
 
     # Test with PDS_TEMPLATE_ASSEMBLED_VALUES and more elements than needed (warning)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdal.Translate(
             tmpfilename,
             "data/byte.tif",
@@ -740,7 +740,7 @@ def test_grib_grib2_write_creation_options():
     gdal.Unlink(tmpfilename)
 
     # Test with PDS_TEMPLATE_ASSEMBLED_VALUES and insufficient number of elements
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdal.Translate(
             tmpfilename,
             "data/byte.tif",
@@ -775,7 +775,7 @@ def test_grib_grib2_write_creation_options():
     gdal.Unlink(tmpfilename)
 
     # Test with PDS_TEMPLATE_ASSEMBLED_VALUES with variable number of elements, and insufficient number of elements in the variable section
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdal.Translate(
             tmpfilename,
             "data/byte.tif",
@@ -789,7 +789,7 @@ def test_grib_grib2_write_creation_options():
     gdal.Unlink(tmpfilename)
 
     # Test with PDS_TEMPLATE_ASSEMBLED_VALUES with variable number of elements, and extra elements
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.Translate(
             tmpfilename,
             "data/byte.tif",
@@ -832,7 +832,7 @@ def test_grib_grib2_write_creation_options():
     gdal.Unlink(tmpfilename)
 
     # Test with unknown PDS_PDTN with PDS_TEMPLATE_NUMBERS
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdal.Translate(
             tmpfilename,
             "data/byte.tif",
@@ -841,7 +841,7 @@ def test_grib_grib2_write_creation_options():
         )
     assert out_ds is not None
     out_ds = None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(tmpfilename)
     md = ds.GetRasterBand(1).GetMetadata()
     expected_md = {"GRIB_PDS_PDTN": "65535", "GRIB_PDS_TEMPLATE_NUMBERS": "1 2 3 4 5"}
@@ -851,7 +851,7 @@ def test_grib_grib2_write_creation_options():
     gdal.Unlink(tmpfilename)
 
     # Test with unknown PDS_PDTN with PDS_TEMPLATE_ASSEMBLED_VALUES
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdal.Translate(
             tmpfilename,
             "data/byte.tif",
@@ -865,7 +865,7 @@ def test_grib_grib2_write_creation_options():
     gdal.Unlink(tmpfilename)
 
     # Test with PDS_PDTN != 0 without template numbers
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdal.Translate(
             tmpfilename, "data/byte.tif", format="GRIB", creationOptions=["PDS_PDTN=32"]
         )
@@ -873,7 +873,7 @@ def test_grib_grib2_write_creation_options():
     gdal.Unlink(tmpfilename)
 
     # Test with invalid values in PDS_TEMPLATE_NUMBERS
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdal.Translate(
             tmpfilename,
             "data/byte.tif",
@@ -885,7 +885,7 @@ def test_grib_grib2_write_creation_options():
     gdal.Unlink(tmpfilename)
 
     # Test with invalid values in PDS_TEMPLATE_ASSEMBLED_VALUES
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdal.Translate(
             tmpfilename,
             "data/byte.tif",
@@ -901,7 +901,7 @@ def test_grib_grib2_write_creation_options():
     gdal.Unlink(tmpfilename)
 
     # Test with both PDS_TEMPLATE_NUMBERS and PDS_TEMPLATE_ASSEMBLED_VALUES
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdal.Translate(
             tmpfilename,
             "data/byte.tif",
@@ -1410,7 +1410,7 @@ def test_grib_grib2_write_data_encodings():
         gdal.ErrorReset()
         options = ["DATA_ENCODING=" + encoding]
         if encoding == "COMPLEX_PACKING":
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 success = gdal.Translate(
                     tmpfilename, test_ds, format="GRIB", creationOptions=options
                 )
@@ -1560,7 +1560,7 @@ def test_grib_grib2_write_data_encodings_warnings_and_errors():
         tmpfilename = "/vsimem/out.grb2"
         src_ds = gdal.Open(filename)
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             out_ds = gdaltest.grib_drv.CreateCopy(tmpfilename, src_ds, options=options)
 
         error_msg = gdal.GetLastErrorMsg()
@@ -1611,7 +1611,7 @@ def test_grib_grib2_write_data_encodings_warnings_and_errors():
         tmpfilename = "/vsimem/out.grb2"
         src_ds = gdal.Open(filename)
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             out_ds = gdaltest.grib_drv.CreateCopy(tmpfilename, src_ds, options=options)
 
         error_msg = gdal.GetLastErrorMsg()
@@ -1628,7 +1628,7 @@ def test_grib_grib2_write_data_encodings_warnings_and_errors():
 
     gdal.Unlink("/vsimem/huge.tif")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdal.Translate("/i/do_not/exist.grb2", "data/byte.tif", format="GRIB")
     assert out_ds is None, "expected null return"
 
@@ -2218,7 +2218,7 @@ def test_grib_grib2_wrong_earth_shape():
     # Byte=1 (spherical sphere)
     # Byte=255 (invalid scale)
     # UInt32=-1 (invalid scaled radius)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/grib/byte_wrong_earth_shape.grib2")
         assert (
             "The GRIB file contains invalid values for the spheroid"

--- a/autotest/gdrivers/hdf5multidim.py
+++ b/autotest/gdrivers/hdf5multidim.py
@@ -548,7 +548,7 @@ def test_hdf5_multidim_read_missing_value_of_different_type_not_in_range():
         gdal.OF_MULTIDIM_RASTER,
     )
     rg = ds.GetRootGroup()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.ErrorReset()
         var = rg.OpenMDArray("test")
         assert gdal.GetLastErrorMsg() != ""

--- a/autotest/gdrivers/hfa.py
+++ b/autotest/gdrivers/hfa.py
@@ -484,7 +484,7 @@ def test_hfa_mapinformation_units():
     # NOTE: we depend on being able to open .aux files as a weak sort of
     # dataset.
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/hfa/fg118-91.aux")
 
     wkt = ds.GetProjectionRef()
@@ -932,7 +932,7 @@ def test_hfa_ov_nodata():
     assert ovb.GetMaskFlags() == gdal.GMF_NODATA, "mask flag not as expected."
 
     # Confirm that a .ovr file was *not* produced.
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         try:
             wrk3_ds = gdal.Open("/vsimem/ov_nodata.img.ovr")
         except Exception:

--- a/autotest/gdrivers/isg.py
+++ b/autotest/gdrivers/isg.py
@@ -69,7 +69,7 @@ def test_isg_approx_georeferencing_with_warning():
     gdal.ErrorReset()
     # Header of https://www.isgeoid.polimi.it/Geoid/America/Argentina/public/GEOIDEAR16_20160419.isg
     # with delta_lon modified
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/isg/approx_georeferencing_warning.isg")
         assert gdal.GetLastErrorMsg() != ""
     expected_gt = [

--- a/autotest/gdrivers/isis.py
+++ b/autotest/gdrivers/isis.py
@@ -586,7 +586,7 @@ def test_isis_18():
     sr.SetGeogCS("GEOG_NAME", "D_DATUM_NAME", "", 123456, 200)
     ds = gdal.GetDriverByName("ISIS3").Create("/vsimem/isis_tmp.lbl", 1, 1)
     ds.SetProjection(sr.ExportToWkt())
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # Will warn that latitude_of_origin, false_easting and false_northing are ignored
         ds = None
     ds = gdal.Open("/vsimem/isis_tmp.lbl")
@@ -772,7 +772,7 @@ def test_isis_19():
 
 def test_isis_20():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.Translate(
             "/vsimem/isis_tmp.lbl",
             "data/isis3/isis3_detached.lbl",
@@ -791,7 +791,7 @@ def test_isis_20():
 
 def test_isis_21():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.Warp(
             "/vsimem/isis_tmp.lbl", "data/isis3/isis3_detached.lbl", format="ISIS3"
         )
@@ -955,14 +955,14 @@ def cancel_cbk(pct, msg, user_data):
 def test_isis_24():
 
     # For DATA_LOCATION=EXTERNAL, the main filename should have a .lbl extension
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.GetDriverByName("ISIS3").Create(
             "/vsimem/error.txt", 1, 1, options=["DATA_LOCATION=EXTERNAL"]
         )
     assert ds is None
 
     # cannot create external filename
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.GetDriverByName("ISIS3").Create(
             "/vsimem/error.lbl",
             1,
@@ -975,7 +975,7 @@ def test_isis_24():
     assert ds is None
 
     # no GTiff driver
-    # with gdaltest.error_handler():
+    # with gdal.quiet_errors():
     #    gtiff_drv = gdal.GetDriverByName('GTiff')
     #    gtiff_drv.Deregister()
     #    ds = gdal.GetDriverByName('ISIS3').Create('/vsimem/error.lbl', 1, 1,
@@ -986,7 +986,7 @@ def test_isis_24():
     #    return 'fail'
 
     # cannot create GeoTIFF
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.GetDriverByName("ISIS3").Create(
             "/vsimem/error.lbl",
             1,
@@ -1001,7 +1001,7 @@ def test_isis_24():
 
     # Output file has same name as input file
     src_ds = gdal.Translate("/vsimem/out.tif", "data/byte.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.GetDriverByName("ISIS3").CreateCopy(
             "/vsimem/out.lbl", src_ds, options=["DATA_LOCATION=GEOTIFF"]
         )
@@ -1010,15 +1010,15 @@ def test_isis_24():
 
     # Missing /vsimem/out.cub
     src_ds = gdal.Open("data/byte.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("ISIS3").CreateCopy(
             "/vsimem/out.lbl", src_ds, options=["DATA_LOCATION=EXTERNAL"]
         )
     gdal.Unlink("/vsimem/out.cub")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/out.lbl")
     assert ds is None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/out.lbl", gdal.GA_Update)
     assert ds is None
     # Delete would fail since ds is None
@@ -1026,14 +1026,14 @@ def test_isis_24():
 
     # Missing /vsimem/out.tif
     src_ds = gdal.Open("data/byte.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("ISIS3").CreateCopy(
             "/vsimem/out.lbl",
             src_ds,
             options=["DATA_LOCATION=GEOTIFF", "GEOTIFF_OPTIONS=COMPRESS=LZW"],
         )
     gdal.Unlink("/vsimem/out.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/out.lbl")
     assert ds is None
     # Delete would fail since ds is None
@@ -1068,15 +1068,15 @@ def test_isis_24():
 End_Object
 End""",
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.Open("/vsimem/out.lbl")
     gdal.Unlink("/vsimem/out.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("ISIS3").Delete("/vsimem/out.lbl")
 
     gdal.FileFromMemBuffer("/vsimem/out.lbl", "IsisCube")
     assert gdal.IdentifyDriver("/vsimem/out.lbl") is not None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/out.lbl")
     assert ds is None
     # Delete would fail since ds is None
@@ -1103,7 +1103,7 @@ End_Object
 End""",
     )
     # Wrong tile dimensions : 0 x 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/out.lbl")
     assert ds is None
     # Delete would fail since ds is None
@@ -1130,7 +1130,7 @@ End_Object
 End""",
     )
     # Invalid dataset dimensions : 0 x 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/out.lbl")
     assert ds is None
     # Delete would fail since ds is None
@@ -1157,7 +1157,7 @@ End_Object
 End""",
     )
     # Invalid band count : 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/out.lbl")
     assert ds is None
     # Delete would fail since ds is None
@@ -1185,7 +1185,7 @@ End""",
     )
 
     # unhandled format
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/out.lbl")
     assert ds is None
     # Delete would fail since ds is None
@@ -1213,7 +1213,7 @@ End""",
     )
 
     # bad PDL formatting
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/out.lbl")
     assert ds is None
     # Delete would fail since ds is None
@@ -1248,19 +1248,19 @@ End""",
     )
     # /vsimem/out.tif has incompatible characteristics with the ones declared in the label
     gdal.GetDriverByName("GTiff").Create("/vsimem/out.tif", 1, 2)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/out.lbl")
     assert ds is None
     gdal.GetDriverByName("GTiff").Create("/vsimem/out.tif", 2, 1)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/out.lbl")
     assert ds is None
     gdal.GetDriverByName("GTiff").Create("/vsimem/out.tif", 1, 1, 2)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/out.lbl")
     assert ds is None
     gdal.GetDriverByName("GTiff").Create("/vsimem/out.tif", 1, 1, 1, gdal.GDT_Int16)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/out.lbl")
     assert ds is None
     # Delete would fail since ds is None
@@ -1273,34 +1273,34 @@ End""",
     # /vsimem/out.tif has incompatible characteristics with the ones declared in the label
     gdal.GetDriverByName("GTiff").Create("/vsimem/out.tif", 1, 2)
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/out.lbl")
     assert gdal.GetLastErrorMsg() != ""
     gdal.GetDriverByName("GTiff").Create("/vsimem/out.tif", 2, 1)
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/out.lbl")
     assert gdal.GetLastErrorMsg() != ""
     gdal.GetDriverByName("GTiff").Create("/vsimem/out.tif", 1, 1, 2)
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/out.lbl")
     assert gdal.GetLastErrorMsg() != ""
     gdal.GetDriverByName("GTiff").Create("/vsimem/out.tif", 1, 1, 1, gdal.GDT_Int16)
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/out.lbl")
     assert gdal.GetLastErrorMsg() != ""
     gdal.GetDriverByName("GTiff").Create(
         "/vsimem/out.tif", 1, 1, options=["COMPRESS=LZW"]
     )
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/out.lbl")
     assert gdal.GetLastErrorMsg() != ""
     gdal.GetDriverByName("GTiff").Create("/vsimem/out.tif", 1, 1, options=["TILED=YES"])
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/out.lbl")
     assert gdal.GetLastErrorMsg() != ""
     ds = gdal.GetDriverByName("GTiff").Create("/vsimem/out.tif", 1, 1)
@@ -1308,15 +1308,15 @@ End""",
     ds.SetMetadataItem("foo", "bar")
     ds = None
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/out.lbl")
     assert gdal.GetLastErrorMsg() != ""
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("ISIS3").Delete("/vsimem/out.lbl")
     gdal.Unlink("/vsimem/out.tif")
 
     mem_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.GetDriverByName("ISIS3").CreateCopy(
             "/vsimem/out.lbl", mem_ds, callback=cancel_cbk
         )
@@ -1610,7 +1610,7 @@ End""",
 
 def test_isis_29():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.Translate("/vsimem/in.lbl", "data/byte.tif", format="ISIS3")
 
     gdal.Translate(
@@ -1687,7 +1687,7 @@ def test_isis_31():
 def test_isis3_write_utm():
 
     src_ds = gdal.Open("data/byte.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("ISIS3").CreateCopy(
             "/vsimem/temp.lbl", src_ds, options=["DATA_LOCATION=EXTERNAL"]
         )
@@ -1904,7 +1904,7 @@ End""",
     gdal.GetDriverByName("ISIS3").Delete("/vsimem/out.cub")
 
     # Copy ISIS3 to PDS4
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("PDS4").CreateCopy("/vsimem/out.xml", src_ds)
     ds = gdal.Open("/vsimem/out.xml")
     lbl = ds.GetMetadata_List("json:ISIS3")[0]

--- a/autotest/gdrivers/jp2lura.py
+++ b/autotest/gdrivers/jp2lura.py
@@ -1052,7 +1052,7 @@ def test_jp2lura_28():
 
     for (options, expected_cbkw, expected_cbkh, warning_expected) in tests:
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             out_ds = gdaltest.jp2lura_drv.CreateCopy(
                 "/vsimem/jp2lura_28.jp2", src_ds, options=options
             )
@@ -1084,7 +1084,7 @@ def test_jp2lura_30():
     src_ds.GetRasterBand(1).SetRasterColorTable(ct)
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2lura_drv.CreateCopy("/vsimem/jp2lura_30.jp2", src_ds)
     assert out_ds is None
 
@@ -1139,7 +1139,7 @@ def DISABLED_jp2lura_33():
   </VRTRasterBand>
 </VRTDataset>"""
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2lura_drv.CreateCopy(
             "/vsimem/jp2lura_33.jp2",
             src_ds,
@@ -1156,7 +1156,7 @@ def DISABLED_jp2lura_33():
 
 def test_jp2lura_34():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/jpeg2000/dimensions_above_31bit.jp2")
     assert ds is None
 
@@ -1167,7 +1167,7 @@ def test_jp2lura_34():
 
 def test_jp2lura_35():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/jpeg2000/truncated.jp2")
     assert ds is None
 
@@ -1179,7 +1179,7 @@ def test_jp2lura_35():
 def test_jp2lura_36():
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 2, 2, 16385)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2lura_drv.CreateCopy("/vsimem/jp2lura_36.jp2", src_ds)
     assert out_ds is None and gdal.VSIStatL("/vsimem/jp2lura_36.jp2") is None
 
@@ -1501,7 +1501,7 @@ def test_jp2lura_41():
 
     # Warning if ignored option
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2lura_drv.CreateCopy(
             "/vsimem/jp2lura_41.jp2",
             src_ds,
@@ -1517,7 +1517,7 @@ def test_jp2lura_41():
     # Warning if source is not JPEG2000
     src_ds = gdal.Open("data/byte.tif")
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2lura_drv.CreateCopy(
             "/vsimem/jp2lura_41.jp2", src_ds, options=["USE_SRC_CODESTREAM=YES"]
         )
@@ -2117,7 +2117,7 @@ def test_jp2lura_49():
     ), "Did not get expected filelist"
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.OpenEx(
             "data/jpeg2000/inconsitant_geojp2_gmljp2.jp2",
             open_options=["GEOREF_SOURCES=unhandled"],
@@ -2145,7 +2145,7 @@ def test_jp2lura_51():
 
     # Don't allow it by default
     src_ds = gdal.Open("data/float32.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdaltest.jp2lura_drv.CreateCopy("/vsimem/jp2lura_51.jp2", src_ds)
     assert ds is None
 
@@ -2162,7 +2162,7 @@ def test_jp2lura_51():
     assert maxdiff <= 0.01
 
     # QUALITY
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdaltest.jp2lura_drv.CreateCopy(
             "/vsimem/jp2lura_51.jp2",
             src_ds,
@@ -2175,7 +2175,7 @@ def test_jp2lura_51():
 
         assert validate("/vsimem/jp2lura_51.jp2", inspire_tg=False) != "fail"
     ds = None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdaltest.jp2lura_drv.Delete("/vsimem/jp2lura_51.jp2")
     gdal.Unlink("/vsimem/jp2lura_51.jp2")
 

--- a/autotest/gdrivers/jp2openjpeg.py
+++ b/autotest/gdrivers/jp2openjpeg.py
@@ -998,7 +998,7 @@ def test_jp2openjpeg_26():
 
     # Warning case: disabling JPX
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
             "/vsimem/jp2openjpeg_26.jp2", src_ds, options=["INSPIRE_TG=YES", "JPX=NO"]
         )
@@ -1036,7 +1036,7 @@ def test_jp2openjpeg_26():
     src_ds = gdal.GetDriverByName("MEM").Create("", 2048, 2048, 1)
 
     # Error case: too big tile
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
             "/vsimem/jp2openjpeg_26.jp2",
             src_ds,
@@ -1045,7 +1045,7 @@ def test_jp2openjpeg_26():
     assert out_ds is None
 
     # Error case: non square tile
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
             "/vsimem/jp2openjpeg_26.jp2",
             src_ds,
@@ -1054,7 +1054,7 @@ def test_jp2openjpeg_26():
     assert out_ds is None
 
     # Error case: incompatible PROFILE
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
             "/vsimem/jp2openjpeg_26.jp2",
             src_ds,
@@ -1063,7 +1063,7 @@ def test_jp2openjpeg_26():
     assert out_ds is None
 
     # Error case: valid, but too small number of resolutions regarding PROFILE_1
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
             "/vsimem/jp2openjpeg_26.jp2",
             src_ds,
@@ -1072,7 +1072,7 @@ def test_jp2openjpeg_26():
     assert out_ds is None
 
     # Too big resolution number. Will fallback to default one
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
             "/vsimem/jp2openjpeg_26.jp2",
             src_ds,
@@ -1083,28 +1083,28 @@ def test_jp2openjpeg_26():
     gdal.Unlink("/vsimem/jp2openjpeg_26.jp2")
 
     # Error case: unsupported NBITS
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
             "/vsimem/jp2openjpeg_26.jp2", src_ds, options=["INSPIRE_TG=YES", "NBITS=2"]
         )
     assert out_ds is None
 
     # Error case: unsupported CODEC (J2K)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
             "/vsimem/jp2openjpeg_26.j2k", src_ds, options=["INSPIRE_TG=YES"]
         )
     assert out_ds is None
 
     # Error case: invalid CODEBLOCK_WIDTH/HEIGHT
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
             "/vsimem/jp2openjpeg_26.jp2",
             src_ds,
             options=["INSPIRE_TG=YES", "CODEBLOCK_WIDTH=128", "CODEBLOCK_HEIGHT=32"],
         )
     assert out_ds is None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
             "/vsimem/jp2openjpeg_26.jp2",
             src_ds,
@@ -1237,7 +1237,7 @@ def test_jp2openjpeg_28():
 
     for (options, expected_cbkw, expected_cbkh, warning_expected) in tests:
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
                 "/vsimem/jp2openjpeg_28.jp2", src_ds, options=options
             )
@@ -1273,7 +1273,7 @@ def test_jp2openjpeg_29():
 
     for (options, warning_expected) in tests:
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             options.append("BLOCKXSIZE=64")
             options.append("BLOCKYSIZE=64")
             out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
@@ -1312,7 +1312,7 @@ def test_jp2openjpeg_30():
 
     for (options, warning_expected) in tests:
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
                 "/vsimem/jp2openjpeg_30.jp2", src_ds, options=options
             )
@@ -1380,7 +1380,7 @@ def test_jp2openjpeg_30():
     ct = gdal.ColorTable()
     src_ds.GetRasterBand(1).SetRasterColorTable(ct)
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
             "/vsimem/jp2openjpeg_30.jp2", src_ds
         )
@@ -1432,7 +1432,7 @@ def test_jp2openjpeg_31():
 def test_jp2openjpeg_32():
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 10, 10, 1)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
             "/vsimem/jp2openjpeg_32.jp2", src_ds, options=["JP2C_XLBOX=YES"]
         )
@@ -1453,7 +1453,7 @@ def test_jp2openjpeg_33():
   </VRTRasterBand>
 </VRTDataset>"""
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # Limit number of resolutions, because of
         # https://github.com/uclouvain/openjpeg/issues/493
         out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
@@ -1472,7 +1472,7 @@ def test_jp2openjpeg_33():
 
 def test_jp2openjpeg_34():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/jpeg2000/dimensions_above_31bit.jp2")
     assert ds is None
 
@@ -1483,7 +1483,7 @@ def test_jp2openjpeg_34():
 
 def test_jp2openjpeg_35():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/jpeg2000/truncated.jp2")
     assert ds is None
 
@@ -1495,7 +1495,7 @@ def test_jp2openjpeg_35():
 def test_jp2openjpeg_36():
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 2, 2, 16385)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
             "/vsimem/jp2openjpeg_36.jp2", src_ds
         )
@@ -1827,7 +1827,7 @@ def test_jp2openjpeg_41():
 
     # Warning if ignored option
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
             "/vsimem/jp2openjpeg_41.jp2",
             src_ds,
@@ -1841,7 +1841,7 @@ def test_jp2openjpeg_41():
     # Warning if source is not JPEG2000
     src_ds = gdal.Open("data/byte.tif")
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
             "/vsimem/jp2openjpeg_41.jp2", src_ds, options=["USE_SRC_CODESTREAM=YES"]
         )
@@ -1857,7 +1857,7 @@ def test_jp2openjpeg_41():
 def test_jp2openjpeg_42():
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 20, 20)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
             "/vsimem/jp2openjpeg_42.jp2", src_ds, options=["JP2C_LENGTH_ZERO=YES"]
         )
@@ -2020,11 +2020,11 @@ def test_jp2openjpeg_44():
 
 def test_jp2openjpeg_45():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         if ogr.Open("../ogr/data/gml/ionic_wfs.gml") is None:
             pytest.skip("GML read support missing")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         if ogr.Open("../ogr/data/kml/empty.kml") is None:
             pytest.skip("KML support missing")
 
@@ -2117,7 +2117,7 @@ def test_jp2openjpeg_45():
 
     # Invalid JSon
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
             "/vsimem/jp2openjpeg_45.jp2", src_ds, options=["GMLJP2V2_DEF={"]
         )
@@ -2125,7 +2125,7 @@ def test_jp2openjpeg_45():
 
     # Non existing file
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
             "/vsimem/jp2openjpeg_45.jp2",
             src_ds,
@@ -2179,7 +2179,7 @@ def test_jp2openjpeg_45():
         "/vsimem/conf.json",
         '{ "root_instance": { "grid_coverage_range_type_field_predefined_name": "invalid" } }',
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
             "/vsimem/jp2openjpeg_45.jp2",
             src_ds,
@@ -2230,7 +2230,7 @@ def test_jp2openjpeg_45():
     }
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
             "/vsimem/jp2openjpeg_45.jp2",
             src_ds,
@@ -2280,7 +2280,7 @@ def test_jp2openjpeg_45():
             {"file": "/vsimem/i_dont_exist_too.xsd", "label": "i_dont_exist.xsd"},
         ],
     }
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
             "/vsimem/jp2openjpeg_45.jp2",
             src_ds,
@@ -2895,7 +2895,7 @@ yeah: """
         gdal.FileFromMemBuffer("/vsimem/source.xml", """<A/>""")
 
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
                 "/vsimem/jp2openjpeg_46.jp2",
                 src_ds,
@@ -2929,7 +2929,7 @@ yeah: """
         }
     }
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
             "/vsimem/jp2openjpeg_46.jp2",
             src_ds,
@@ -2956,7 +2956,7 @@ yeah: """
         }
     }
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
             "/vsimem/jp2openjpeg_46.jp2",
             src_ds,
@@ -2984,7 +2984,7 @@ yeah: """
         }
     }
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
             "/vsimem/jp2openjpeg_46.jp2",
             src_ds,
@@ -3524,7 +3524,7 @@ def test_jp2openjpeg_49():
     ), "Did not get expected filelist"
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.OpenEx(
             "data/jpeg2000/inconsitant_geojp2_gmljp2.jp2",
             open_options=["GEOREF_SOURCES=unhandled"],
@@ -3573,13 +3573,13 @@ def test_jp2openjpeg_codeblock_style():
         ds = None
         assert cs == 4672
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdaltest.jp2openjpeg_drv.CreateCopy(
             filename, gdal.Open("data/byte.tif"), options=["CODEBLOCK_STYLE=64"]
         )
     assert gdal.GetLastErrorMsg() != ""
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdaltest.jp2openjpeg_drv.CreateCopy(
             filename,
             gdal.Open("data/byte.tif"),
@@ -3756,12 +3756,12 @@ def test_jp2openjpeg_STRICT_NO():
     filename = "data/jpeg2000/small_world_truncated.jp2"
 
     ds = gdal.Open(filename)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.GetRasterBand(1).Checksum() == -1
     ds = None
 
     ds = gdal.OpenEx(filename, open_options=["STRICT=NO"])
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.GetRasterBand(1).Checksum() == 5058
     ds = None
 

--- a/autotest/gdrivers/jpeg.py
+++ b/autotest/gdrivers/jpeg.py
@@ -993,7 +993,7 @@ def test_jpeg_25():
 def test_jpeg_26():
 
     src_ds = gdal.GetDriverByName("Mem").Create("", 70000, 1)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.GetDriverByName("JPEG").CreateCopy("/vsimem/jpeg_26.jpg", src_ds)
     assert ds is None
     gdal.Unlink("/vsimem/jpeg_26.jpg")
@@ -1011,7 +1011,7 @@ def test_jpeg_27_max_memory():
     # Should error out with 'Reading this image would require
     # libjpeg to allocate at least...'
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         os.environ["JPEGMEM"] = "10M"
         with gdal.config_option("GDAL_JPEG_MAX_ALLOWED_SCAN_NUMBER", "1000"):
             ds = gdal.Open(
@@ -1090,7 +1090,7 @@ def test_jpeg_28():
     src_ds.SetMetadataItem("EXIF_CompressedBitsPerPixel", "nan")  # invalid RATIONAL
     src_ds.SetMetadataItem("EXIF_ApertureValue", "-1")  # invalid RATIONAL
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("JPEG").CreateCopy(tmpfilename, src_ds)
     src_ds = None
     assert gdal.VSIStatL(tmpfilename + ".aux.xml") is None
@@ -1173,7 +1173,7 @@ def test_jpeg_28():
     src_ds.SetMetadataItem("EXIF_ExifVersion", "0231")
     src_ds.SetMetadataItem("EXIF_invalid", "foo")
     src_ds.SetMetadataItem("FOO", "BAR")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("JPEG").CreateCopy(tmpfilename, src_ds)
     src_ds = None
     assert gdal.VSIStatL(tmpfilename + ".aux.xml") is not None
@@ -1185,7 +1185,7 @@ def test_jpeg_28():
     # Too much content for EXIF
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
     src_ds.SetMetadataItem("EXIF_UserComment", "x" * 65535)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("JPEG").CreateCopy(tmpfilename, src_ds)
     src_ds = None
     ds = None
@@ -1350,15 +1350,15 @@ def test_jpeg_flir_raw():
 
 def test_jpeg_flir_error_flir_subds():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("JPEG:foo.jpg")
         assert ds is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("JPEG:foo.jpg:BAR")
         assert ds is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("JPEG:data/jpeg/masked.jpg:FLIR_RAW_THERMAL_IMAGE")
         assert ds is None
 
@@ -1392,7 +1392,7 @@ def test_jpeg_write_cmyk():
 def test_jpeg_write_4band_not_cmyk():
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 8, 8, 4)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("JPEG").CreateCopy("/vsimem/out.jpg", src_ds)
     assert gdal.GetLastErrorMsg() != ""
     gdal.GetDriverByName("JPEG").Delete("/vsimem/out.jpg")
@@ -1527,7 +1527,7 @@ def test_jpeg_read_lossless_16bit():
         is None
     ):
         pytest.skip("lossless jpeg not supported")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/jpeg/uint16_lossless.jpg")
         assert ds is None
 

--- a/autotest/gdrivers/jpegxl.py
+++ b/autotest/gdrivers/jpegxl.py
@@ -115,7 +115,7 @@ def test_jpegxl_rgba_lossless_no_but_lossless_copy_yes():
 
     src_ds = gdal.Open("../gcore/data/stefan_full_rgba.tif")
     outfilename = "/vsimem/out.jxl"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             gdal.GetDriverByName("JPEGXL").CreateCopy(
                 outfilename, src_ds, options=["LOSSLESS=NO", "LOSSLESS_COPY=YES"]
@@ -157,7 +157,7 @@ def test_jpegxl_rgba_quality(quality, equivalent_distance):
     cs = ds.GetRasterBand(1).Checksum()
     assert cs != 0 and cs != src_ds.GetRasterBand(1).Checksum()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("JPEGXL").CreateCopy(
             outfilename, src_ds, options=["DISTANCE=" + str(equivalent_distance)]
         )
@@ -205,7 +205,7 @@ def test_jpegxl_exif():
 @pytest.mark.require_creation_option("JPEGXL", "COMPRESS_BOX")
 def test_jpegxl_read_huge_xmp_compressed_box():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.ErrorReset()
         ds = gdal.Open("data/jpegxl/huge_xmp_compressed_box.jxl")
         assert ds is not None
@@ -358,7 +358,7 @@ def test_jpegxl_lossless_copy_of_jpeg():
     data = data[0 : len(data) // 2]
     with gdaltest.tempfile("/vsimem/truncated.jpg", data):
         src_ds = gdal.Open("/vsimem/truncated.jpg")
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert (
                 gdal.GetDriverByName("JPEGXL").CreateCopy(outfilename, src_ds) is None
             )
@@ -504,7 +504,7 @@ def test_jpegxl_write_extra_channels():
         )  # 'Band 2' encoded in .jxl file, but hidden when reading back
         assert ds.GetRasterBand(3).GetDescription() == "third channel"
     else:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert drv.CreateCopy(outfilename, mem_ds) is None
             assert (
                 gdal.GetLastErrorMsg()
@@ -573,21 +573,21 @@ def test_jpegxl_createcopy_errors():
 
     # band count = 0
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1, 0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.ErrorReset()
         assert gdal.GetDriverByName("JPEGXL").CreateCopy(outfilename, src_ds) is None
         assert gdal.GetLastErrorMsg() != ""
 
     # unsupported data type
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1, 1, gdal.GDT_Int16)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.ErrorReset()
         assert gdal.GetDriverByName("JPEGXL").CreateCopy(outfilename, src_ds) is None
         assert gdal.GetLastErrorMsg() != ""
 
     # wrong out file name
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.ErrorReset()
         assert (
             gdal.GetDriverByName("JPEGXL").CreateCopy("/i_do/not/exist.jxl", src_ds)
@@ -597,7 +597,7 @@ def test_jpegxl_createcopy_errors():
 
     # mutually exclusive options
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.ErrorReset()
         assert (
             gdal.GetDriverByName("JPEGXL").CreateCopy(
@@ -609,7 +609,7 @@ def test_jpegxl_createcopy_errors():
 
     # mutually exclusive options
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.ErrorReset()
         assert (
             gdal.GetDriverByName("JPEGXL").CreateCopy(
@@ -621,7 +621,7 @@ def test_jpegxl_createcopy_errors():
 
     # mutually exclusive options
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.ErrorReset()
         assert (
             gdal.GetDriverByName("JPEGXL").CreateCopy(
@@ -633,7 +633,7 @@ def test_jpegxl_createcopy_errors():
 
     # mutually exclusive options
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.ErrorReset()
         assert (
             gdal.GetDriverByName("JPEGXL").CreateCopy(
@@ -645,7 +645,7 @@ def test_jpegxl_createcopy_errors():
 
     # wrong value for DISTANCE
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.ErrorReset()
         assert (
             gdal.GetDriverByName("JPEGXL").CreateCopy(
@@ -657,7 +657,7 @@ def test_jpegxl_createcopy_errors():
 
     # wrong value for EFFORT
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.ErrorReset()
         assert (
             gdal.GetDriverByName("JPEGXL").CreateCopy(

--- a/autotest/gdrivers/kea.py
+++ b/autotest/gdrivers/kea.py
@@ -124,7 +124,7 @@ def test_kea_4():
     if gdaltest.kea_driver is None:
         pytest.skip()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdaltest.kea_driver.Create("/non_existing_path/non_existing_path", 1, 1)
     assert ds is None
 
@@ -142,42 +142,42 @@ def test_kea_4():
     ds = None
     ds = gdal.Open("tmp/out.kea")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.SetProjection("a")
     assert ret != 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.SetGeoTransform([1, 2, 3, 4, 5, 6])
     assert ret != 0
 
     # Disabled for now since some of them cause memory leaks or
     # crash in the HDF5 library finalizer
     if False:  # pylint: disable=using-constant-test
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = ds.SetMetadataItem("foo", "bar")
         assert ret != 0
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = ds.SetMetadata({"foo": "bar"})
         assert ret != 0
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = ds.GetRasterBand(1).SetMetadataItem("foo", "bar")
         assert ret != 0
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = ds.GetRasterBand(1).SetMetadata({"foo": "bar"})
         assert ret != 0
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = ds.SetGCPs([], "")
         assert ret != 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.AddBand(gdal.GDT_Byte)
     assert ret != 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.GetRasterBand(1).WriteRaster(0, 0, 1, 1, "\0")
     assert ret != 0
     assert ds.GetRasterBand(1).Checksum() == 3
@@ -555,7 +555,7 @@ def test_kea_12():
         assert rat.GetTypeOfCol(i) == cloned_rat.GetTypeOfCol(i)
         assert rat.GetUsageOfCol(i) == cloned_rat.GetUsageOfCol(i)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
 
         rat.GetNameOfCol(-1)
         rat.GetTypeOfCol(-1)

--- a/autotest/gdrivers/ktx2.py
+++ b/autotest/gdrivers/ktx2.py
@@ -106,7 +106,7 @@ def test_ktx2_read_two_layers():
     ],
 )
 def test_ktx2_read_wrong_subds(filename):
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert gdal.Open(filename) is None
 
 
@@ -312,7 +312,7 @@ def test_ktx2_write_etc1s_clusters_options():
     gdal.Unlink(out_filename)
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             gdal.GetDriverByName("KTX2").CreateCopy(
                 out_filename,
@@ -370,7 +370,7 @@ def test_ktx2_write_etc1s_incompatible_or_missing_options():
     out_filename = "/vsimem/out.ktx2"
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             gdal.GetDriverByName("KTX2").CreateCopy(
                 out_filename, src_ds, options=["ETC1S_MAX_ENDPOINTS_CLUSTERS=16128"]
@@ -380,7 +380,7 @@ def test_ktx2_write_etc1s_incompatible_or_missing_options():
         assert gdal.GetLastErrorMsg() != ""
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             gdal.GetDriverByName("KTX2").CreateCopy(
                 out_filename, src_ds, options=["ETC1S_MAX_SELECTOR_CLUSTERS=16128"]
@@ -390,7 +390,7 @@ def test_ktx2_write_etc1s_incompatible_or_missing_options():
         assert gdal.GetLastErrorMsg() != ""
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             gdal.GetDriverByName("KTX2").CreateCopy(
                 out_filename,
@@ -403,7 +403,7 @@ def test_ktx2_write_etc1s_incompatible_or_missing_options():
     gdal.Unlink(out_filename)
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             gdal.GetDriverByName("KTX2").CreateCopy(
                 out_filename,
@@ -421,13 +421,13 @@ def test_ktx2_write_incompatible_source():
     out_filename = "/vsimem/out.ktx2"
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1, 0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert gdal.GetDriverByName("KTX2").CreateCopy(out_filename, src_ds) is None
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1, 5)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert gdal.GetDriverByName("KTX2").CreateCopy(out_filename, src_ds) is None
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1, 1, gdal.GDT_UInt16)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert gdal.GetDriverByName("KTX2").CreateCopy(out_filename, src_ds) is None

--- a/autotest/gdrivers/lcp.py
+++ b/autotest/gdrivers/lcp.py
@@ -461,7 +461,7 @@ def test_lcp_8():
     assert mem_drv is not None
     lcp_drv = gdal.GetDriverByName("LCP")
     assert lcp_drv is not None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         co = ["LATITUDE=0", "LINEAR_UNIT=METER"]
         for i in [0, 1, 2, 3, 4, 6, 9, 11]:
             src_ds = mem_drv.Create("", 10, 10, i, gdal.GDT_Int16)
@@ -910,7 +910,7 @@ def test_lcp_23():
     assert src_ds is not None
 
     bad = "NOT_A_REAL_OPTION"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         for option in [
             "ELEVATION_UNIT",
             "SLOPE_UNIT",

--- a/autotest/gdrivers/mbtiles.py
+++ b/autotest/gdrivers/mbtiles.py
@@ -148,7 +148,7 @@ def test_mbtiles_2():
 def test_mbtiles_3():
 
     # Check that we have SQLite VFS support
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.GetDriverByName("SQLite").CreateDataSource("/vsimem/mbtiles_3.db")
     if ds is None:
         pytest.skip()
@@ -480,7 +480,7 @@ def test_mbtiles_9():
     ds.ExecuteSQL("UPDATE metadata SET value='invalid' WHERE name='bounds'")
     ds = None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/mbtiles_9.mbtiles")
     assert ds.RasterXSize == 256 and ds.RasterYSize == 256
     assert ds.GetGeoTransform()[0] == pytest.approx(-13110479.091473430395126, abs=1e-6)
@@ -544,7 +544,7 @@ def test_mbtiles_create():
 
     filename = "/vsimem/mbtiles_create.mbtiles"
     gdaltest.mbtiles_drv.Create(filename, 1, 1, 1)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert gdal.Open(filename) is None
 
     # Nominal case
@@ -557,18 +557,18 @@ def test_mbtiles_create():
     ds.SetProjection(src_ds.GetProjectionRef())
 
     # Cannot modify geotransform once set"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.SetGeoTransform(src_ds.GetGeoTransform())
     assert ret != 0
     ds = None
 
     ds = gdal.Open("data/mbtiles/byte.mbtiles")
     # SetGeoTransform() not supported on read-only dataset"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.SetGeoTransform(src_ds.GetGeoTransform())
     assert ret != 0
     # SetProjection() not supported on read-only dataset
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.SetProjection(src_ds.GetProjectionRef())
     assert ret != 0
     ds = None
@@ -576,7 +576,7 @@ def test_mbtiles_create():
     gdal.Unlink(filename)
     ds = gdaltest.mbtiles_drv.Create(filename, src_ds.RasterXSize, src_ds.RasterYSize)
     # Only EPSG:3857 supported on MBTiles dataset
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.SetProjection('LOCAL_CS["foo"]')
     assert ret != 0
     ds = None
@@ -584,7 +584,7 @@ def test_mbtiles_create():
     gdal.Unlink(filename)
     ds = gdaltest.mbtiles_drv.Create(filename, src_ds.RasterXSize, src_ds.RasterYSize)
     # Only north-up non rotated geotransform supported
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.SetGeoTransform([0, 1, 0, 0, 0, 1])
     assert ret != 0
     ds = None
@@ -592,7 +592,7 @@ def test_mbtiles_create():
     gdal.Unlink(filename)
     ds = gdaltest.mbtiles_drv.Create(filename, src_ds.RasterXSize, src_ds.RasterYSize)
     # Could not find an appropriate zoom level that matches raster pixel size
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.SetGeoTransform([0, 1, 0, 0, 0, -1])
     assert ret != 0
     ds = None

--- a/autotest/gdrivers/mem.py
+++ b/autotest/gdrivers/mem.py
@@ -42,7 +42,7 @@ from osgeo import gdal
 @gdaltest.disable_exceptions()
 def mem_native_memory():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("MEM:::")
     assert ds is None, "opening MEM dataset should have failed."
     for libname in ["msvcrt", "libc.so.6"]:
@@ -306,43 +306,43 @@ def test_mem_6():
     drv = gdal.GetDriverByName("MEM")
 
     # Multiplication overflow
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = drv.Create("", 1, 1, 0x7FFFFFFF, gdal.GDT_Float64)
     assert ds is None
     ds = None
 
     # Multiplication overflow
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = drv.Create("", 0x7FFFFFFF, 0x7FFFFFFF, 16)
     assert ds is None
     ds = None
 
     # Multiplication overflow
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = drv.Create("", 0x7FFFFFFF, 0x7FFFFFFF, 1, gdal.GDT_Float64)
     assert ds is None
     ds = None
 
     # Out of memory error
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = drv.Create("", 0x7FFFFFFF, 0x7FFFFFFF, 1, options=["INTERLEAVE=PIXEL"])
     assert ds is None
     ds = None
 
     # Out of memory error
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = drv.Create("", 0x7FFFFFFF, 0x7FFFFFFF, 1)
     assert ds is None
     ds = None
 
     # 32 bit overflow on 32-bit builds, or possible out of memory error
     ds = drv.Create("", 0x7FFFFFFF, 1, 0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.AddBand(gdal.GDT_Float64)
 
     # Will raise out of memory error in all cases
     ds = drv.Create("", 0x7FFFFFFF, 0x7FFFFFFF, 0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.AddBand(gdal.GDT_Float64)
     assert ret != 0
 
@@ -522,7 +522,7 @@ def test_mem_10():
 
     # Error case: building overview on a 0 band dataset
     ds = gdal.GetDriverByName("MEM").Create("", 1, 1, 0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.BuildOverviews("NEAR", [2])
 
     # Requesting overviews when they are not

--- a/autotest/gdrivers/memmultidim.py
+++ b/autotest/gdrivers/memmultidim.py
@@ -88,7 +88,7 @@ def test_mem_md_subgroup():
     ds = drv.CreateMultiDimensional("myds")
     rg = ds.GetRootGroup()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not rg.CreateGroup("")  # unnamed group not supported
     with pytest.raises(ValueError):
         assert not rg.CreateGroup(None)
@@ -127,7 +127,7 @@ def test_mem_md_array_unnamed_array():
     ds = drv.CreateMultiDimensional("myds")
     rg = ds.GetRootGroup()
     edt = gdal.ExtendedDataType.Create(gdal.GDT_Byte)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not rg.CreateMDArray("", [], edt)
 
 
@@ -139,7 +139,7 @@ def test_mem_md_array_duplicated_array_name():
     assert rg.CreateMDArray(
         "same_name", [], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not rg.CreateMDArray(
             "same_name", [], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
         )
@@ -263,7 +263,7 @@ def test_mem_md_array_single_dim():
     assert myarray.SetNoDataValue(1) == gdal.CE_None
     assert myarray.GetNoDataValue() == 1
     assert myarray.SetNoDataValueRaw(struct.pack("B", 127)) == gdal.CE_None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert myarray.SetNoDataValueRaw(struct.pack("h", 127)) != gdal.CE_None
     assert struct.unpack("B", myarray.GetNoDataValueAsRaw()) == (127,)
 
@@ -304,7 +304,7 @@ def test_mem_md_array_single_dim():
 
     assert myarray.DeleteNoDataValue() == gdal.CE_None
     assert myarray.GetNoDataValueAsDouble() is None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert myarray.GetNoDataValueAsString() is None
 
     assert myarray.SetUnit("foo") == gdal.CE_None
@@ -381,7 +381,7 @@ def test_mem_md_datatypes():
         "y", 4, gdal.ExtendedDataType.Create(gdal.GDT_Int32)
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert gdal.ExtendedDataType.CreateCompound("mytype", 8, []) is None
         assert (
             gdal.ExtendedDataType.CreateCompound("mytype", 2000 * 1000 * 1000, [comp0])
@@ -406,7 +406,7 @@ def test_mem_md_datatypes():
     assert not compound_dt.Equals(dt_byte)
     assert not dt_byte.Equals(compound_dt)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # Too short size
         assert not gdal.ExtendedDataType.CreateCompound("mytype", 7, [comp0, comp1])
 
@@ -475,7 +475,7 @@ def test_mem_md_array_compoundtype():
     assert len(got_data) == 8
     assert struct.unpack("i" * 2, got_data) == (1000000, -1000000)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not myarray.GetView('["z')
         assert not myarray.GetView('["z"')
         assert not myarray.GetView('["z"]')
@@ -510,7 +510,7 @@ def test_mem_md_array_compoundtype():
     assert len(got_data) == 8
     assert struct.unpack("i" * 2, got_data) == (1000000, -1000000)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not y_ar.GetView('["y"]')
 
     assert y_ar.AdviseRead() == gdal.CE_None
@@ -680,7 +680,7 @@ def test_mem_md_array_read_write_errors():
     assert myarray
 
     assert myarray.Read([0, 0, 0], [1, 1, 1], [1, 1, 1], [0, 0, 0])
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
 
         # Invalid number of values in array_idx array
         assert not myarray.Read([0, 0], [1, 1, 1], [1, 1, 1], [0, 0, 0])
@@ -728,7 +728,7 @@ def test_mem_md_array_read_write_errors():
 
     data = struct.pack("d" * 1, 25.0)
     float64dt = gdal.ExtendedDataType.Create(gdal.GDT_Float64)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert myarray.Write("", [1, 2, 3], [1, 1, 1]) == gdal.CE_Failure
         assert (
             myarray.Write(data[0:7], [1, 2, 3], [1, 1, 1], buffer_datatype=float64dt)
@@ -742,7 +742,7 @@ def test_mem_md_invalid_dims():
     ds = drv.CreateMultiDimensional("myds")
     rg = ds.GetRootGroup()
     assert rg.CreateDimension("dim1", None, None, 1)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # empty name
         assert not rg.CreateDimension("", None, None, 1)
         # existing dim
@@ -774,7 +774,7 @@ def test_mem_md_array_too_large():
     ds = drv.CreateMultiDimensional("myds")
     rg = ds.GetRootGroup()
     dim = rg.CreateDimension("dim0", None, None, (1 << 64) - 1)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not rg.CreateMDArray(
             "myarray", [dim], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
         )
@@ -788,7 +788,7 @@ def test_mem_md_array_too_large_overflow_dim():
     dim0 = rg.CreateDimension("dim0", None, None, 1 << 25)
     dim1 = rg.CreateDimension("dim1", None, None, 1 << 25)
     dim2 = rg.CreateDimension("dim2", None, None, 1 << 25)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not rg.CreateMDArray(
             "myarray", [dim0, dim1, dim2], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
         )
@@ -835,7 +835,7 @@ def test_mem_md_group_attribute_single_numeric():
     rg = ds.GetRootGroup()
 
     float64dt = gdal.ExtendedDataType.Create(gdal.GDT_Float64)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not rg.CreateAttribute("", [1], float64dt)  # unnamed attr not supported
     with pytest.raises(ValueError):
         assert not rg.CreateAttribute(None, [1], float64dt)
@@ -863,7 +863,7 @@ def test_mem_md_group_attribute_single_numeric():
     assert attr.Read() == 2
     assert attr.Write([2.25]) == gdal.CE_None
     assert attr.Read() == 2.25
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert attr.Write([]) != gdal.CE_None
         assert attr.Write([1, 2]) != gdal.CE_None
 
@@ -951,7 +951,7 @@ def test_mem_md_array_attribute():
     )
 
     float64dt = gdal.ExtendedDataType.Create(gdal.GDT_Float64)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not myarray.CreateAttribute(
             "", [1], float64dt
         )  # unnamed attr not supported
@@ -977,7 +977,7 @@ def test_mem_md_array_slice():
 
     ar = rg.CreateMDArray("nodim", [], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
     assert ar.Write(struct.pack("B", 1)) == gdal.CE_None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not ar[:]
 
     ar = rg.CreateMDArray(
@@ -994,7 +994,7 @@ def test_mem_md_array_slice():
     )
     assert attr.Write(1) == gdal.CE_None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not ar.GetView("")
         assert not ar.GetView("x")
         assert not ar.GetView("[")
@@ -1284,11 +1284,11 @@ def test_mem_md_array_as_classic_dataset():
     dim_y.SetIndexingVariable(dim_y_var)
 
     ar = rg.CreateMDArray("nodim", [], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not ar.AsClassicDataset(0, 0)
 
     ar = rg.CreateMDArray("1d", [dim_x], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not ar.AsClassicDataset(1, 0)
     ds = ar.AsClassicDataset(0, 0)
     assert ds.RasterXSize == 3
@@ -1311,7 +1311,7 @@ def test_mem_md_array_as_classic_dataset():
     ar = rg.CreateMDArray(
         "2d_string", [dim_y, dim_x], gdal.ExtendedDataType.CreateString()
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not ar.AsClassicDataset(0, 1)
 
     # 2D
@@ -1324,7 +1324,7 @@ def test_mem_md_array_as_classic_dataset():
     attr.Write(1.25)
     attr = ar.CreateAttribute("attr_strings", [2], gdal.ExtendedDataType.CreateString())
     attr.Write(["foo", "bar"])
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not ar.AsClassicDataset(0, 0)
         assert not ar.AsClassicDataset(0, 2)
         assert not ar.AsClassicDataset(2, 0)
@@ -1471,7 +1471,7 @@ def test_mem_md_array_transpose():
     data = array.array("H", list(range(24))).tobytes()
     assert ar.Write(data) == gdal.CE_None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not ar.Transpose([])  # 0 axis
         assert not ar.Transpose([0, 1])  # missing axis
         assert not ar.Transpose([0, 1, 2, 3])  # too many axis
@@ -1931,7 +1931,7 @@ def test_mem_md_array_get_mask():
         "myarray_string", [dim0], gdal.ExtendedDataType.CreateString()
     )
     # Non-numeric array unsupported
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not myarray.GetMask()
 
     myarray = rg.CreateMDArray(
@@ -1943,7 +1943,7 @@ def test_mem_md_array_get_mask():
     mask = myarray.GetMask()
     assert mask.GetOffset() is None
     assert mask.GetScale() is None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert mask.Write(mask.Read()) == gdal.CE_Failure
     assert mask.GetNoDataValueAsRaw() is None
     assert mask.GetSpatialRef() is None
@@ -2502,7 +2502,7 @@ def test_mem_md_getcoordinatevariables():
     assert len(coordVars) == 3
 
     assert coordinates.WriteString("other non_existing") == 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         coordVars = ar.GetCoordinateVariables()
         assert len(coordVars) == 1
 
@@ -2516,7 +2516,7 @@ def test_mem_md_resize_dim_wrong_new_size(new_size):
     xDim = rg.CreateDimension("x", None, None, 4)
     v = rg.CreateMDArray("v", [xDim], gdal.ExtendedDataType.Create(gdal.GDT_Float64))
     v.Write(struct.pack("d" * 4, 1, 2, 3, 4))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert v.Resize(new_size) == gdal.CE_Failure
 
 
@@ -2528,7 +2528,7 @@ def test_mem_md_resize_dim_wrong_too_big_allocation_before_malloc():
     xDim = rg.CreateDimension("x", None, None, 4)
     v = rg.CreateMDArray("v", [xDim], gdal.ExtendedDataType.Create(gdal.GDT_Float64))
     v.Write(struct.pack("d" * 4, 1, 2, 3, 4))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert v.Resize([1 << 63]) == gdal.CE_Failure
 
 
@@ -2542,7 +2542,7 @@ def test_mem_md_resize_dim_wrong_too_big_allocation_at_malloc():
     v = rg.CreateMDArray("v", [xDim], gdal.ExtendedDataType.Create(gdal.GDT_Float64))
     v.Write(struct.pack("d" * 4, 1, 2, 3, 4))
     sizeof_double = 8
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert v.Resize([sys.maxsize // sizeof_double]) == gdal.CE_Failure
 
 
@@ -2639,7 +2639,7 @@ def test_mem_md_resize_arbitrary_dim(new_size, new_values):
     v.Write(struct.pack("d" * 8, 1, 2, 3, 4, 5, 6, 7, 8))
     v2.Write(struct.pack("d" * 8, 1, 2, 3, 4, 5, 6, 7, 8))
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert v.Resize([1, 1 << 63, xDim.GetSize()]) == gdal.CE_Failure
 
     assert v.Resize([1, new_size, xDim.GetSize()]) == gdal.CE_None
@@ -2711,7 +2711,7 @@ def test_mem_md_resize_dim_referenced_twice_error():
     v = rg.CreateMDArray(
         "v", [xDim, xDim], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert v.Resize([2, 3]) == gdal.CE_Failure
         assert v.Resize([3, 2]) == gdal.CE_Failure
 

--- a/autotest/gdrivers/mrf.py
+++ b/autotest/gdrivers/mrf.py
@@ -161,7 +161,7 @@ def test_mrf(src_filename, chksum, chksum_after_reopening, options, jpeg_version
         if jpeg_version == "9b":
             pytest.skip()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/" + src_filename)
     if ds is None:
         pytest.skip()
@@ -399,7 +399,7 @@ def test_mrf_overview_nnb_implicit_level():
     assert cs == expected_cs
     ds = None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/out.mrf:MRF:L3")
     assert ds is None
 
@@ -476,7 +476,7 @@ def test_raw_lerc():
             "/vsimem/out.mrf", "data/byte.tif", format="MRF", creationOptions=co
         )
         ds = gdal.Open("/vsimem/out.lrc")
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             cs = ds.GetRasterBand(1).Checksum()
         expected_cs = 4819
         assert cs == expected_cs
@@ -486,7 +486,7 @@ def test_raw_lerc():
             ds = gdal.OpenEx(
                 "/vsimem/out.lrc", open_options=["@NDV=100, @datatype=UInt32"]
             )
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 cs = ds.GetRasterBand(1).Checksum()
             print(cs, opt)
             assert cs == 60065
@@ -504,7 +504,7 @@ def test_mrf_cached_source():
         creationOptions=["CACHEDSOURCE=invalid_source", "NOCOPY=TRUE"],
     )
     ds = gdal.Open("/vsimem/out.mrf")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         cs = ds.GetRasterBand(1).Checksum()
     expected_cs = -1
     assert cs == expected_cs
@@ -623,7 +623,7 @@ def test_mrf_versioned():
     assert cs == expected_cs
     ds = None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/out.mrf:MRF:V2")
     assert ds is None
 

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -302,7 +302,7 @@ def test_netcdf_1():
 
     # We don't want to gum up the test stream output with the
     # 'Warning 1: No UNIDATA NC_GLOBAL:Conventions attribute' message.
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         tst.testOpen()
 
 
@@ -386,7 +386,7 @@ def test_netcdf_4():
 
     # We don't want to gum up the test stream output with the
     # 'Warning 1: No UNIDATA NC_GLOBAL:Conventions attribute' message.
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # don't test for checksum (see bug #4284)
         tst.testOpen(skip_checksum=True)
 
@@ -408,7 +408,7 @@ def test_netcdf_5():
 
     # We don't want to gum up the test stream output with the
     # 'Warning 1: No UNIDATA NC_GLOBAL:Conventions attribute' message.
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # don't test for checksum (see bug #4284)
         tst.testOpen(skip_checksum=True)
 
@@ -898,7 +898,7 @@ def test_netcdf_22():
     ifile = "data/hdf4/hdifftst2.hdf"
 
     # suppress warning
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("NETCDF:" + ifile)
 
     if ds is None:
@@ -1094,7 +1094,7 @@ def test_netcdf_26():
 
     # test default config
     test = gdaltest.GDALTest("NETCDF", "netcdf/int16-nogeo.nc", 1, 4672)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         test.testCreateCopy(check_gt=0, check_srs=0, check_minmax=0)
 
     # test WRITE_BOTTOMUP=NO
@@ -1262,7 +1262,7 @@ def test_netcdf_30():
 
     # We don't want to gum up the test stream output with the
     # 'Warning 1: No UNIDATA NC_GLOBAL:Conventions attribute' message.
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         tst.testOpen()
 
 
@@ -1347,7 +1347,7 @@ def test_netcdf_34():
     tst = gdaltest.GDALTest("NetCDF", "../tmp/cache/" + filename, 1, 31621)
     # tst.testOpen()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         proc = Process(target=tst.testOpen)
         proc.start()
         proc.join(timeout)
@@ -1444,7 +1444,7 @@ def test_netcdf_37():
 
     ifile = "data/netcdf/reduce-cgcms.nc"
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(ifile)
     assert ds is not None, "open failed"
 
@@ -1474,7 +1474,7 @@ def test_netcdf_38():
 
     ifile = "data/netcdf/bug5118.nc"
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(ifile)
     assert ds is not None, "open failed"
 
@@ -1588,7 +1588,7 @@ def test_netcdf_40():
 
 def test_netcdf_41():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/netcdf/byte_no_cf.nc")
     assert ds.GetGeoTransform() == (440720, 60, 0, 3751320, 0, -60)
     assert ds.GetProjectionRef().find("26711") >= 0, ds.GetGeoTransform()
@@ -1817,7 +1817,7 @@ def test_netcdf_45():
     assert lyr.GetLayerDefn().GetFieldDefn(0).GetAlternativeName() == ""
     assert lyr.GetLayerDefn().GetFieldDefn(0).GetComment() == ""
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.VectorTranslate(
             "/vsimem/netcdf_45.csv",
             ds,
@@ -1880,13 +1880,13 @@ def test_netcdf_47():
         pytest.skip()
 
     # Test that a vector cannot be opened in raster-only mode
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx("data/netcdf/test_ogr_nc4.nc", gdal.OF_RASTER)
     assert ds is None
 
     ds = gdal.OpenEx("data/netcdf/test_ogr_nc4.nc", gdal.OF_VECTOR)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.VectorTranslate(
             "/vsimem/netcdf_47.csv",
             ds,
@@ -1928,7 +1928,7 @@ def test_netcdf_47():
 
 def test_netcdf_48():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx("data/netcdf/test_ogr_no_xyz_var.nc", gdal.OF_VECTOR)
     lyr = ds.GetLayer(0)
     assert lyr.GetGeomType() == ogr.wkbNone
@@ -1943,7 +1943,7 @@ def test_netcdf_48():
 @pytest.mark.require_driver("CSV")
 def test_netcdf_49():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx("data/netcdf/test_ogr_xyz_float.nc", gdal.OF_VECTOR)
         gdal.VectorTranslate(
             "/vsimem/netcdf_49.csv",
@@ -2044,7 +2044,7 @@ def test_netcdf_51():
         datasetCreationOptions=["GEOMETRY_ENCODING=WKT"],
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx("tmp/netcdf_51.nc", gdal.OF_VECTOR)
         gdal.VectorTranslate(
             "/vsimem/netcdf_51.csv",
@@ -2125,7 +2125,7 @@ def test_netcdf_51_no_gdal_tags():
         datasetCreationOptions=["WRITE_GDAL_TAGS=NO", "GEOMETRY_ENCODING=WKT"],
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx("tmp/netcdf_51_no_gdal_tags.nc", gdal.OF_VECTOR)
         gdal.VectorTranslate(
             "/vsimem/netcdf_51_no_gdal_tags.csv",
@@ -2190,7 +2190,7 @@ def test_netcdf_52():
         datasetCreationOptions=["FORMAT=NC4", "GEOMETRY_ENCODING=WKT"],
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx("tmp/netcdf_52.nc", gdal.OF_VECTOR)
         gdal.VectorTranslate(
             "/vsimem/netcdf_52.csv",
@@ -2392,7 +2392,7 @@ def test_netcdf_56():
     f = ogr.Feature(lyr.GetLayerDefn())
     f["txt"] = "0123456789"
     f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (1 2)"))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(f)
     assert ret == 0
     ds = None
@@ -2482,7 +2482,7 @@ def test_netcdf_57():
     except OSError:
         pass
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.GetDriverByName("netCDF").CreateDataSource(
             "/not_existing_dir/invalid_subdir",
             options=["MULTIPLE_LAYERS=SEPARATE_FILES", "GEOMETRY_ENCODING=WKT"],
@@ -2491,7 +2491,7 @@ def test_netcdf_57():
 
     open("tmp/netcdf_57", "wb").close()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.GetDriverByName("netCDF").CreateDataSource(
             "/not_existing_dir/invalid_subdir",
             options=["MULTIPLE_LAYERS=SEPARATE_FILES", "GEOMETRY_ENCODING=WKT"],
@@ -2598,7 +2598,7 @@ def test_netcdf_60():
     ds = gdal.OpenEx("data/netcdf/profile.nc", gdal.OF_VECTOR)
     assert ds is not None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.VectorTranslate(
             "/vsimem/netcdf_60.csv",
             ds,
@@ -2880,7 +2880,7 @@ def test_netcdf_66():
 
     # First trying with no so good configs
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.VectorTranslate(
             "tmp/netcdf_66.nc",
             "data/netcdf/profile.nc",
@@ -2888,7 +2888,7 @@ def test_netcdf_66():
             datasetCreationOptions=["CONFIG_FILE=not_existing"],
         )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.VectorTranslate(
             "tmp/netcdf_66.nc",
             "data/netcdf/profile.nc",
@@ -2931,7 +2931,7 @@ def test_netcdf_66():
 </Configuration>
 """
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.VectorTranslate(
             "tmp/netcdf_66.nc",
             "data/netcdf/profile.nc",
@@ -3377,7 +3377,7 @@ def test_netcdf_write_rotated_pole_from_method_grib():
 @pytest.mark.require_driver("CSV")
 def test_netcdf_82():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/netcdf/oddly_indexed_extra_dims.nc")
     md = ds.GetMetadata()
     expected_md = {
@@ -5166,7 +5166,7 @@ def test_netcdf_dimension_labels_with_null():
     ) or gdaltest.netcdf_drv_version.startswith("4.1."):
         pytest.skip("Test crashes with this libnetcdf version")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert gdal.Open("data/netcdf/dimension_labels_with_null.nc")
 
 
@@ -5882,7 +5882,7 @@ def test_netcdf_open_userfaultfd():
             is not None
         )
     else:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert (
                 gdal.Open("/vsizip/tmp/test_netcdf_open_userfaultfd.zip/test.nc")
                 is None
@@ -6276,7 +6276,7 @@ def test_netcdf_read_cf_xy_latlon_crs_wkt():
 def test_netcdf_warning_get_metadata_item_PIXELTYPE():
 
     ds = gdal.Open("data/netcdf/byte_no_cf.nc")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.GetRasterBand(1).GetMetadataItem("PIXELTYPE", "IMAGE_STRUCTURE")
     assert (
         gdal.GetLastErrorMsg()
@@ -6344,7 +6344,7 @@ def test_netcdf_read_lon_lat_indexed_irregularly_spaced():
 def test_netcdf_read_invalid_valid_min_valid_max():
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/netcdf/invalid_valid_min_valid_max.nc")
     assert gdal.GetLastErrorType() == gdal.CE_Warning
     assert struct.unpack("i" * 4, ds.ReadRaster()) == (-9999, 0, 1, 2)

--- a/autotest/gdrivers/netcdf_multidim.py
+++ b/autotest/gdrivers/netcdf_multidim.py
@@ -116,7 +116,7 @@ def test_netcdf_multidim_single_group():
     got_data = struct.unpack("B" * 400, var.Read())
     assert got_data == ref_data
 
-    with gdaltest.error_handler():  # Write to read only
+    with gdal.quiet_errors():  # Write to read only
         assert not rg.CreateDimension("X", None, None, 2)
         assert not rg.CreateAttribute(
             "att_text", [], gdal.ExtendedDataType.CreateString()
@@ -552,7 +552,7 @@ def test_netcdf_multidim_attr_alldatatypes():
     assert map_attrs["attr_char"].GetDimensionCount() == 0
     assert map_attrs["attr_char"].Read() == "x"
     assert map_attrs["attr_char"].ReadAsStringArray() == ["x"]
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not map_attrs["attr_char"].ReadAsRaw()
 
     assert (
@@ -617,7 +617,7 @@ def test_netcdf_multidim_attr_alldatatypes():
     assert len(map_attrs["attr_custom_type_2_elts"].ReadAsRaw()) == 8
 
     # Compound type contains a string
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not map_attrs["attr_custom_with_string"].ReadAsRaw()
 
 
@@ -684,7 +684,7 @@ def test_netcdf_multidim_read_netcdf_4d():
 def test_netcdf_multidim_create_nc3():
 
     drv = gdal.GetDriverByName("netCDF")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not drv.CreateMultiDimensional("/i_do/not_exist.nc")
 
     def f():
@@ -696,7 +696,7 @@ def test_netcdf_multidim_create_nc3():
         assert not rg.GetDimensions()
 
         # not support on NC3
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert not rg.CreateGroup("subgroup")
 
         dim_x = rg.CreateDimension("X", None, None, 2)
@@ -708,12 +708,12 @@ def test_netcdf_multidim_create_nc3():
         assert dim_y_unlimited
         assert dim_y_unlimited.GetSize() == 123
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert not rg.CreateDimension(
                 "unlimited2", None, None, 123, ["UNLIMITED=YES"]
             )
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert not rg.CreateDimension("too_big", None, None, (1 << 31) - 1)
 
         var = rg.CreateMDArray(
@@ -768,7 +768,7 @@ def test_netcdf_multidim_create_nc3():
 
         att = rg.CreateAttribute("att_text", [], gdal.ExtendedDataType.CreateString())
         assert att
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert not att.Read()
         assert att.Write("f") == gdal.CE_None
         assert att.Write("foo") == gdal.CE_None
@@ -779,7 +779,7 @@ def test_netcdf_multidim_create_nc3():
         assert att.Read() == "foo"
 
         # netCDF 3 cannot support NC_STRING. Needs fixed size strings
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             var = rg.CreateMDArray(
                 "my_var_string_array", [dim_x], gdal.ExtendedDataType.CreateString()
             )
@@ -864,10 +864,10 @@ def test_netcdf_multidim_create_nc4():
         assert subgroup
         assert subgroup.GetName() == "subgroup"
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert not rg.CreateGroup("")
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert not rg.CreateGroup("subgroup")
 
         subgroup = rg.OpenGroup("subgroup")
@@ -930,7 +930,7 @@ def test_netcdf_multidim_create_nc4():
 
         # Try with random filter id. Just to test that FILTER is taken
         # into account
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             var = rg.CreateMDArray(
                 "my_var_x",
                 [dim_x],
@@ -959,7 +959,7 @@ def test_netcdf_multidim_create_nc4():
             dim_z_from_mem = mem_rg.CreateDimension(
                 "Z", None, None, dim_z.GetSize() + 1
             )
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 var = rg.CreateMDArray(
                     "my_var_x_y",
                     [dim_x_from_mem, dim_y_from_mem, dim_z_from_mem],
@@ -1090,7 +1090,7 @@ def test_netcdf_multidim_create_nc4():
         )
         assert att.Read() == "foo_of_var"
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert not rg.CreateAttribute(
                 "attr_too_many_dimensions", [2, 3], gdal.ExtendedDataType.CreateString()
             )
@@ -1131,7 +1131,7 @@ def test_netcdf_multidim_create_nc4():
                 "att_two_strings", [2], gdal.ExtendedDataType.CreateString()
             )
             assert att
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 assert att.Write(["not_enough_elements"]) != gdal.CE_None
             assert att.Write([1, 2]) == gdal.CE_None
             assert att.Read() == ["1", "2"]
@@ -1337,7 +1337,7 @@ def test_netcdf_multidim_create_nc4():
         assert var.GetDimensions()[1].GetType() == gdal.DIM_TYPE_HORIZONTAL_X
 
     create_georeferenced_projected("georeferenced_projected_with_dim_type", True)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         create_georeferenced_projected(
             "georeferenced_projected_without_dim_type", False
         )
@@ -1389,7 +1389,7 @@ def test_netcdf_multidim_create_nc4():
         assert var.GetDimensions()[1].GetType() == gdal.DIM_TYPE_HORIZONTAL_X
 
     create_georeferenced_geographic("georeferenced_geographic_with_dim_type", True)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         create_georeferenced_geographic(
             "georeferenced_geographic_without_dim_type", False
         )
@@ -1973,7 +1973,7 @@ def test_netcdf_multidim_advise_read():
     got_data = struct.unpack("B" * 20 * 20, transposed.Read())
     assert got_data == ref_data_transposed
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert var.AdviseRead(array_start_idx=[2, 3], count=[20, 5]) == gdal.CE_Failure
 
 
@@ -2017,7 +2017,7 @@ def test_netcdf_multidim_createcopy_array_options():
 
     src_ds = gdal.OpenEx("data/netcdf/byte_no_cf.nc", gdal.OF_MULTIDIM_RASTER)
     tmpfilename = "tmp/test_netcdf_multidim_createcopy_array_options.nc"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("netCDF").CreateCopy(
             tmpfilename,
             src_ds,
@@ -2046,7 +2046,7 @@ def test_netcdf_multidim_createcopy_array_options_if_name_fullname():
     tmpfilename = (
         "tmp/test_netcdf_multidim_createcopy_array_options_if_name_fullname.nc"
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("netCDF").CreateCopy(
             tmpfilename, src_ds, options=["ARRAY:IF(NAME=/Band1):COMPRESS=DEFLATE"]
         )
@@ -2135,7 +2135,7 @@ def test_netcdf_multidim_cache():
         assert ar
         transpose = ar.Transpose([1, 0])
         assert transpose.Cache(["BLOCKSIZE=2,1"])
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             # Cannot cache twice the same array
             assert transpose.Cache() is False
 
@@ -2290,7 +2290,7 @@ def test_netcdf_multidim_open_userfaultfd():
             is not None
         )
     else:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert (
                 gdal.OpenEx(
                     "/vsizip/tmp/test_netcdf_open_userfaultfd.zip/test.nc",
@@ -2670,7 +2670,7 @@ def test_netcdf_read_missing_value_text_non_numeric():
     )
     rg = ds.GetRootGroup()
     var = rg.OpenMDArray("Band1")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.ErrorReset()
         assert var.GetNoDataValue() is None
         assert gdal.GetLastErrorMsg() != ""
@@ -2687,7 +2687,7 @@ def test_netcdf_read_missing_value_text_numeric_not_in_range():
     )
     rg = ds.GetRootGroup()
     var = rg.OpenMDArray("Band1")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.ErrorReset()
         assert var.GetNoDataValue() is None
         assert gdal.GetLastErrorMsg() != ""
@@ -2760,7 +2760,7 @@ def test_netcdf_read_missing_value_of_different_type_not_in_range():
             var.GetAttribute("missing_value").GetDataType().GetNumericDataType()
             == gdal.GDT_Float64
         )
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             gdal.ErrorReset()
             assert var.GetNoDataValue() is None
             assert gdal.GetLastErrorMsg() != ""
@@ -2841,7 +2841,7 @@ def test_netcdf_multidim_update_missing_value_and_FillValue():
         rg = ds.GetRootGroup()
         var = rg.OpenMDArray("var")
         assert var.GetNoDataValue() == 1
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert var.SetNoDataValueDouble(2) != gdal.CE_None
 
     update()
@@ -2924,7 +2924,7 @@ def test_netcdf_multidim_resize_fill():
         rg = ds.GetRootGroup()
         var = rg.OpenMDArray("var")
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert var.Resize([4, 3]) == gdal.CE_Failure
 
     update_read_only()
@@ -2934,7 +2934,7 @@ def test_netcdf_multidim_resize_fill():
         rg = ds.GetRootGroup()
         var = rg.OpenMDArray("var")
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             # 0 size
             assert var.Resize([0, 3]) == gdal.CE_Failure
 
@@ -3056,7 +3056,7 @@ def test_netcdf_multidim_resize_dim_referenced_twice():
         )
         assert var.Write(struct.pack("h" * 4, 1, 2, 3, 4)) == gdal.CE_None
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert var.Resize([3, 4]) == gdal.CE_Failure
             assert var.Resize([4, 3]) == gdal.CE_Failure
 

--- a/autotest/gdrivers/ngw.py
+++ b/autotest/gdrivers/ngw.py
@@ -125,7 +125,7 @@ def get_new_name():
 def test_ngw_2():
 
     create_url = "NGW:" + gdaltest.ngw_test_server + "/resource/0/" + get_new_name()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         description = "GDAL Raster test group"
         gdaltest.ngw_ds = gdal.GetDriverByName("NGW").Create(
             create_url,

--- a/autotest/gdrivers/nitf.py
+++ b/autotest/gdrivers/nitf.py
@@ -606,7 +606,7 @@ def test_nitf_create_copy_user_provided_IGEOLO_without_ICORDS():
         "/vsimem/test_nitf_create_copy_user_provided_IGEOLO_without_ICORDS.ntf"
     )
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             gdal.GetDriverByName("NITF").CreateCopy(
                 outfilename, src_ds, options=["IGEOLO=" + ("0" * 60)]
@@ -714,7 +714,7 @@ def test_nitf_17():
 def test_nitf_18():
 
     # Shut up the warning about missing image segment
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # From http://www.gwg.nga.mil/ntb/baseline/software/testfile/Nitfv1_1/U_0006A.NTF
         ds = gdal.Open("data/nitf/U_0006A.NTF")
 
@@ -740,7 +740,7 @@ def test_nitf_19():
 def test_nitf_20():
 
     # Shut up the warning about file either corrupt or empty
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # From http://www.gwg.nga.mil/ntb/baseline/software/testfile/Nitfv1_1/U_0002A.NTF
         ds = gdal.Open("data/nitf/U_0002A.NTF")
 
@@ -756,7 +756,7 @@ def test_nitf_20():
 def test_nitf_21():
 
     # Shut up the warning about missing image segment
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/nitf/ns3114a.nsf")
 
     mdTEXT = ds.GetMetadata("TEXT")
@@ -973,7 +973,7 @@ def test_nitf_jp2openjpeg_npje_numerically_lossless():
 
     src_ds = gdal.Open("../gcore/data/uint16.tif")
     # May throw a warning with openjpeg < 2.5
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("NITF").CreateCopy(
             "/vsimem/tmp.ntf",
             src_ds,
@@ -1065,7 +1065,7 @@ def test_nitf_jp2openjpeg_npje_visually_lossless():
 
     src_ds = gdal.Open("data/byte.tif")
     # May throw a warning with openjpeg < 2.5
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("NITF").CreateCopy(
             "/vsimem/tmp.ntf",
             src_ds,
@@ -1153,7 +1153,7 @@ def test_nitf_jp2openjpeg_npje_visually_lossless_with_quality():
 
     src_ds = gdal.Open("data/byte.tif")
     # May throw a warning with openjpeg < 2.5
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("NITF").CreateCopy(
             "/vsimem/tmp.ntf",
             src_ds,
@@ -1762,7 +1762,7 @@ def nitf_43(driver_to_test, options):
     gdaltest.deregister_all_jpeg2000_drivers_but(driver_to_test)
     try:
         ds = gdal.Open("data/byte.tif")
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             out_ds = gdal.GetDriverByName("NITF").CreateCopy(
                 "tmp/nitf_43.ntf", ds, options=options, strict=0
             )
@@ -2314,7 +2314,7 @@ def test_nitf_read_IMRFCA_IMASDA():
     assert md == {}
 
     # Too short IMRFCA
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("NITF").Create(
             tmpfile,
             1,
@@ -2328,7 +2328,7 @@ def test_nitf_read_IMRFCA_IMASDA():
     assert md == {}
 
     # Too short IMASDA
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("NITF").Create(
             tmpfile,
             1,
@@ -2382,7 +2382,7 @@ def test_nitf_59():
 def test_nitf_60():
 
     # Shut down errors because the file is truncated
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/nitf/testtest.on9")
     wkt = ds.GetProjectionRef()
     gt = ds.GetGeoTransform()
@@ -2632,7 +2632,7 @@ def test_nitf_66():
 def test_nitf_67():
 
     src_ds = gdal.Open("data/byte.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.GetDriverByName("NITF").CreateCopy(
             "/vsimem/nitf_67.ntf",
             src_ds,
@@ -3046,7 +3046,7 @@ def test_nitf_72():
 
         src_ds.SetMetadata(src_md, "RPC")
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.GetDriverByName("NITF").CreateCopy("/vsimem/nitf_72.ntf", src_ds)
         assert ds is not None, "fail: expected a dataset"
         ds = None
@@ -3077,7 +3077,7 @@ def test_nitf_72():
     ] = "0 9.876543e-10 9.876543e-9 -9.876543e+9 -9.876543e-9 0 9.876543e+9 9.876543e-9 -9.876543e+9 -9.876543e-9 0 9.876543e+9 9.876543e-9 -9.876543e+9 -9.876543e-9 0 9.876543e+9 9.876543e-9 -9.876543e+9 -9.876543e-9"
     src_ds.SetMetadata(src_md, "RPC")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.GetDriverByName("NITF").CreateCopy("/vsimem/nitf_72.ntf", src_ds)
     assert ds is not None, "fail: expected a dataset"
     ds = None
@@ -3100,7 +3100,7 @@ def test_nitf_72():
     assert RPC00B == expected_RPC00B, "fail: did not get expected RPC00B"
 
     # Test RPCTXT creation option
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("NITF").CreateCopy(
             "/vsimem/nitf_72.ntf", src_ds, options=["RPCTXT=YES"]
         )
@@ -3146,7 +3146,7 @@ def test_nitf_72():
 
         src_ds.SetMetadata(src_md, "RPC")
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.GetDriverByName("NITF").CreateCopy("/vsimem/nitf_72.ntf", src_ds)
         assert ds is None, "fail: expected failure for %s" % key
 
@@ -3158,7 +3158,7 @@ def test_nitf_72():
     ] = "0 9.876543e10 9.876543e-9 -9.876543e+9 -9.876543e-9 0 9.876543e+9 9.876543e-9 -9.876543e+9 -9.876543e-9 0 9.876543e+9 9.876543e-9 -9.876543e+9 -9.876543e-9 0 9.876543e+9 9.876543e-9 -9.876543e+9 -9.876543e-9"
     src_ds.SetMetadata(src_md, "RPC")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.GetDriverByName("NITF").CreateCopy("/vsimem/nitf_72.ntf", src_ds)
     assert ds is None, "fail: expected failure"
 
@@ -3169,7 +3169,7 @@ def test_nitf_72():
 
 def test_nitf_73():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.Open("data/nitf/oss_fuzz_1525.ntf")
 
 
@@ -4864,7 +4864,7 @@ def test_nitf_tre_overflow_des_error_missing_RESERVE_SPACE_FOR_TRE_OVERFLOW():
     des_data = "CSEPHA" + ("%05d" % len(CSEPHA_DATA)) + CSEPHA_DATA
     des = des_header + des_data
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.ErrorReset()
         gdal.GetDriverByName("NITF").Create(
             "/vsimem/nitf_DES.ntf", 1, 1, options=["DES=TRE_OVERFLOW=" + des]
@@ -4897,7 +4897,7 @@ def test_nitf_tre_overflow_des_errorinvalid_DESITEM():
     des_data = "CSEPHA" + ("%05d" % len(CSEPHA_DATA)) + CSEPHA_DATA
     des = des_header + des_data
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.ErrorReset()
         gdal.GetDriverByName("NITF").Create(
             "/vsimem/nitf_DES.ntf",
@@ -5145,13 +5145,13 @@ def test_nitf_create_too_large_file():
 
     # Test 1e10 byte limit for a single image
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("NITF").Create("/vsimem/out.ntf", int(1e5), int(1e5))
     assert gdal.GetLastErrorMsg() != ""
 
     # Test 1e12 byte limit for while file
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("NITF").Create(
             "/vsimem/out.ntf",
             int(1e5),
@@ -5488,7 +5488,7 @@ def test_nitf_no_image_segment():
 
     src_ds = gdal.Open("data/byte.tif")
     out_filename = "/vsimem/test_nitf_no_image_segment.ntf"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             gdal.GetDriverByName("NITF").CreateCopy(
                 out_filename, src_ds, strict=False, options=["NUMI=0"]
@@ -5496,14 +5496,14 @@ def test_nitf_no_image_segment():
             is not None
         )
     gdal.Unlink(out_filename + ".aux.xml")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(out_filename)
     assert ds is not None
     for domain in ds.GetMetadataDomainList():
         ds.GetMetadata(domain)
     ds = None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("NITF").Delete(out_filename)
 
 
@@ -5514,7 +5514,7 @@ def test_nitf_no_image_segment():
 def test_nitf_metadata_validation_tre():
 
     filename = "/vsimem/test_nitf_metadata_validation_tre.ntf"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("NITF").Create(
             filename,
             1,
@@ -5524,7 +5524,7 @@ def test_nitf_metadata_validation_tre():
             ],
         )
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(filename, open_options=["VALIDATE=YES"])
     assert gdal.GetLastErrorMsg() != ""
     md = ds.GetMetadata("xml:TRE")[0]
@@ -5551,7 +5551,7 @@ def test_nitf_metadata_validation_tre():
 """
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             filename, open_options=["VALIDATE=YES", "FAIL_IF_VALIDATION_ERROR=YES"]
         )
@@ -5569,12 +5569,12 @@ def test_nitf_metadata_validation_des():
     filename = "/vsimem/test_nitf_metadata_validation_des.ntf"
     des_data = b"02U" + b" " * 166 + b"0004ABCD"
     escaped_data = gdal.EscapeString(des_data, gdal.CPLES_BackslashQuotable)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("NITF").Create(
             filename, 1, 1, options=[b"DES=CSATTA DES=" + escaped_data]
         )
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(filename, open_options=["VALIDATE=YES"])
     assert gdal.GetLastErrorMsg() != ""
     md = ds.GetMetadata("xml:DES")[0]
@@ -5611,7 +5611,7 @@ def test_nitf_metadata_validation_des():
 """
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             filename, open_options=["VALIDATE=YES", "FAIL_IF_VALIDATION_ERROR=YES"]
         )
@@ -5640,7 +5640,7 @@ def test_nitf_online_1():
     )
 
     # Shut up the warning about missing image segment
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         tst.testOpen()
 
 
@@ -5825,7 +5825,7 @@ def test_nitf_online_10():
     )
 
     # Shut up the warning about missing image segment
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("tmp/cache/ns3119b.nsf")
 
     mdCGM = ds.GetMetadata("CGM")

--- a/autotest/gdrivers/openfilegdb.py
+++ b/autotest/gdrivers/openfilegdb.py
@@ -29,7 +29,6 @@
 
 import struct
 
-import gdaltest
 import pytest
 
 from osgeo import gdal
@@ -186,7 +185,7 @@ def test_openfilegb_raster_jpeg():
 def test_openfilegb_raster_jpeg_driver_not_available():
 
     ds = gdal.Open("OpenFileGDB:data/filegdb/gdal_test_data.gdb.zip:small_world_jpeg")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.GetRasterBand(1).Checksum() == -1
 
 

--- a/autotest/gdrivers/pcidsk.py
+++ b/autotest/gdrivers/pcidsk.py
@@ -246,7 +246,7 @@ def pcidsk_9():
     ds.CreateLayer("foo")
     ds = None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/pcidsk_9.pix")
     assert ds is None
     ds = None
@@ -729,7 +729,7 @@ def test_pcidsk_online_rpc():
 )
 def test_pcidsk_invalid_files(filename):
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert gdal.VSIStatL(filename) is not None
         assert gdal.Open(filename) is None
 

--- a/autotest/gdrivers/pdf.py
+++ b/autotest/gdrivers/pdf.py
@@ -1764,7 +1764,7 @@ def test_pdf_write_huge(poppler_or_pdfium):
         ds = None
 
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdaltest.pdf_drv.CreateCopy(tmp_filename, src_ds, options=["DPI=72"])
         msg = gdal.GetLastErrorMsg()
         assert msg != ""
@@ -1778,7 +1778,7 @@ def test_pdf_write_huge(poppler_or_pdfium):
     for option in ["LEFT_MARGIN=14400", "TOP_MARGIN=14400"]:
         src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1, 1)
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdaltest.pdf_drv.CreateCopy(tmp_filename, src_ds, options=[option])
         msg = gdal.GetLastErrorMsg()
         assert msg != ""
@@ -1836,12 +1836,12 @@ def test_pdf_password(poppler_or_pdfium_or_podofo):
     # owner_password
 
     # No password
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("data/pdf/byte_enc.pdf")
     assert ds is None
 
     # Wrong password
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             "data/pdf/byte_enc.pdf", open_options=["USER_PWD=wrong_password"]
         )
@@ -1907,15 +1907,15 @@ def test_pdf_multipage(poppler_or_pdfium_or_podofo):
     ds2 = gdal.Open("PDF:2:data/pdf/byte_and_rgbsmall_2pages.pdf")
     assert ds2.RasterXSize == 50, "wrong width"
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds3 = gdal.Open("PDF:0:data/pdf/byte_and_rgbsmall_2pages.pdf")
     assert ds3 is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds3 = gdal.Open("PDF:3:data/pdf/byte_and_rgbsmall_2pages.pdf")
     assert ds3 is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("PDF:1:/does/not/exist.pdf")
     assert ds is None
 
@@ -2205,7 +2205,7 @@ def test_pdf_composition_error_pdf_content_missing_filename(
 </PDFComposition>"""
 
     out_filename = "/vsimem/tmp.pdf"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.pdf_drv.Create(
             out_filename,
             0,
@@ -2232,7 +2232,7 @@ def test_pdf_composition_error_pdf_content_non_existing(poppler_or_pdfium_or_pod
 </PDFComposition>"""
 
     out_filename = "/vsimem/tmp.pdf"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.pdf_drv.Create(
             out_filename,
             0,
@@ -2261,7 +2261,7 @@ def test_pdf_composition_error_pdf_content_missing_contents(
 </PDFComposition>"""
 
     out_filename = "/vsimem/tmp.pdf"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.pdf_drv.Create(
             out_filename,
             0,
@@ -2290,7 +2290,7 @@ def test_pdf_composition_error_pdf_content_missing_contents_stream(
 </PDFComposition>"""
 
     out_filename = "/vsimem/tmp.pdf"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.pdf_drv.Create(
             out_filename,
             0,
@@ -2322,7 +2322,7 @@ def test_pdf_composition_error_pdf_content_missing_resources(
 </PDFComposition>"""
 
     out_filename = "/vsimem/tmp.pdf"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.pdf_drv.Create(
             out_filename,
             0,
@@ -2677,7 +2677,7 @@ def test_pdf_composition_outline():
 def test_pdf_composition_error_missing_file():
 
     out_filename = "/vsimem/tmp.pdf"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.pdf_drv.Create(
             out_filename,
             0,
@@ -2696,7 +2696,7 @@ def test_pdf_composition_error_missing_page():
     xml_content = """<PDFComposition></PDFComposition>"""
 
     out_filename = "/vsimem/tmp.pdf"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.pdf_drv.Create(
             out_filename,
             0,
@@ -2715,7 +2715,7 @@ def test_pdf_composition_error_missing_page_width():
     xml_content = """<PDFComposition><Page/></PDFComposition>"""
 
     out_filename = "/vsimem/tmp.pdf"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.pdf_drv.Create(
             out_filename,
             0,
@@ -2734,7 +2734,7 @@ def test_pdf_composition_error_missing_page_content():
     xml_content = """<PDFComposition><Page><Width>1</Width><Height>1</Height></Page></PDFComposition>"""
 
     out_filename = "/vsimem/tmp.pdf"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.pdf_drv.Create(
             out_filename,
             0,
@@ -2758,7 +2758,7 @@ def test_pdf_composition_error_invalid_layer_missing_id():
 </PDFComposition>"""
 
     out_filename = "/vsimem/tmp.pdf"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.pdf_drv.Create(
             out_filename,
             0,
@@ -2782,7 +2782,7 @@ def test_pdf_composition_error_invalid_layer_missing_name():
 </PDFComposition>"""
 
     out_filename = "/vsimem/tmp.pdf"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.pdf_drv.Create(
             out_filename,
             0,
@@ -2807,7 +2807,7 @@ def test_pdf_composition_error_duplicate_layer_id():
 </PDFComposition>"""
 
     out_filename = "/vsimem/tmp.pdf"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.pdf_drv.Create(
             out_filename,
             0,
@@ -2836,7 +2836,7 @@ def test_pdf_composition_error_referencing_invalid_layer_id():
 </PDFComposition>"""
 
     out_filename = "/vsimem/tmp.pdf"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.pdf_drv.Create(
             out_filename,
             0,
@@ -2872,7 +2872,7 @@ def test_pdf_composition_error_missing_srs():
 </PDFComposition>"""
 
     out_filename = "/vsimem/tmp.pdf"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.pdf_drv.Create(
             out_filename,
             0,
@@ -2906,7 +2906,7 @@ def test_pdf_composition_error_missing_control_point():
 </PDFComposition>"""
 
     out_filename = "/vsimem/tmp.pdf"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.pdf_drv.Create(
             out_filename,
             0,
@@ -2942,7 +2942,7 @@ def test_pdf_composition_error_missing_attribute_in_control_point():
 </PDFComposition>"""
 
     out_filename = "/vsimem/tmp.pdf"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.pdf_drv.Create(
             out_filename,
             0,
@@ -2981,7 +2981,7 @@ def test_pdf_composition_error_invalid_bbox():
 </PDFComposition>"""
 
     out_filename = "/vsimem/tmp.pdf"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.pdf_drv.Create(
             out_filename,
             0,
@@ -3007,7 +3007,7 @@ def test_pdf_composition_error_missing_dataset_attribute():
 </PDFComposition>"""
 
     out_filename = "/vsimem/tmp.pdf"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.pdf_drv.Create(
             out_filename,
             0,
@@ -3033,7 +3033,7 @@ def test_pdf_composition_error_invalid_dataset():
 </PDFComposition>"""
 
     out_filename = "/vsimem/tmp.pdf"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.pdf_drv.Create(
             out_filename,
             0,
@@ -3064,7 +3064,7 @@ def test_pdf_composition_duplicate_page_id():
 </PDFComposition>"""
 
     out_filename = "/vsimem/tmp.pdf"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.pdf_drv.Create(
             out_filename,
             0,
@@ -3098,7 +3098,7 @@ def test_pdf_composition_outline_item_gotopage_action_missing_page_id():
 </PDFComposition>"""
 
     out_filename = "/vsimem/tmp.pdf"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.pdf_drv.Create(
             out_filename,
             0,
@@ -3132,7 +3132,7 @@ def test_pdf_composition_outline_item_gotopage_action_pointing_to_invalid_page_i
 </PDFComposition>"""
 
     out_filename = "/vsimem/tmp.pdf"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.pdf_drv.Create(
             out_filename,
             0,
@@ -3169,7 +3169,7 @@ def test_pdf_composition_outline_item_setlayerstate_missing_layer_id():
 </PDFComposition>"""
 
     out_filename = "/vsimem/tmp.pdf"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.pdf_drv.Create(
             out_filename,
             0,
@@ -3203,7 +3203,7 @@ def test_pdf_composition_outline_item_setlayerstate_pointing_to_invalid_layer_id
 </PDFComposition>"""
 
     out_filename = "/vsimem/tmp.pdf"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdaltest.pdf_drv.Create(
             out_filename,
             0,

--- a/autotest/gdrivers/pds.py
+++ b/autotest/gdrivers/pds.py
@@ -108,7 +108,7 @@ def test_pds_2():
 def test_pds_3():
 
     # Shut down warning about missing projection
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
 
         tst = gdaltest.GDALTest("PDS", "pds/EN0001426030M_truncated.IMG", 1, 1367)
 

--- a/autotest/gdrivers/pds4.py
+++ b/autotest/gdrivers/pds4.py
@@ -219,7 +219,7 @@ def test_pds4_2():
 def test_pds4_write_utm():
 
     src_ds = gdal.Open("data/byte.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("PDS4").CreateCopy("/vsimem/temp.xml", src_ds)
     ds = gdal.Open("/vsimem/temp.xml")
     assert ds.GetRasterBand(1).Checksum() == 4672
@@ -358,7 +358,7 @@ def test_pds4_projected_srs(proj4str):
     sr.ImportFromProj4(proj4str)
     ds.SetProjection(sr.ExportToWkt())
     ds.SetGeoTransform([0, 1, 0, 0, 0, -1])
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = None
 
     validate_xml(filename)
@@ -389,7 +389,7 @@ def test_pds4_longlat_srs():
     sr.ImportFromProj4("+proj=longlat +R=2439400 +no_defs")
     ds.SetProjection(sr.ExportToWkt())
     ds.SetGeoTransform([2, 1, 0, 49, 0, -2])
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = None
 
     validate_xml(filename)
@@ -848,23 +848,23 @@ def test_pds4_13():
     ds = gdal.Open(subds_name)
     assert ds is not None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(r"PDS4:c:\do_not\exist.xml:1:1")
     assert ds is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("PDS4:i_do_not_exist.xml")
     assert ds is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("PDS4:i_do_not_exist.xml:1:1")
     assert ds is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("PDS4:data/pds4/byte_pds4_cart_1700_multi_sds.xml:3:1")
     assert ds is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("PDS4:data/pds4/byte_pds4_cart_1700_multi_sds.xml:1:3")
     assert ds is None
 
@@ -880,7 +880,7 @@ def test_pds4_14():
     gdal.FileFromMemBuffer(
         filename, "Product_Observational http://pds.nasa.gov/pds4/pds/v1"
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(filename)
     assert ds is None
 
@@ -955,7 +955,7 @@ def test_pds4_14():
     </File_Area_Observational>
 </Product_Observational>""",
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(filename)
     assert ds is None
 
@@ -992,7 +992,7 @@ def test_pds4_14():
     </File_Area_Observational>
 </Product_Observational>""",
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(filename)
     assert ds is None
 
@@ -1024,7 +1024,7 @@ def test_pds4_14():
     </File_Area_Observational>
 </Product_Observational>""",
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(filename)
     assert ds is None
 
@@ -1056,7 +1056,7 @@ def test_pds4_14():
     </File_Area_Observational>
 </Product_Observational>""",
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(filename)
     assert ds is None
 
@@ -1088,28 +1088,28 @@ def test_pds4_14():
     </File_Area_Observational>
 </Product_Observational>""",
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(filename)
     assert ds is None
 
     gdal.Unlink(filename)
 
     # Invalid value for INTERLEAVE
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.GetDriverByName("PDS4").Create(
             "/vsimem/out.xml", 1, 1, options=["INTERLEAVE=INVALID"]
         )
     assert ds is None
 
     # INTERLEAVE=BIL not supported for GeoTIFF in PDS4
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.GetDriverByName("PDS4").Create(
             "/vsimem/out.xml", 1, 1, options=["INTERLEAVE=BIL", "IMAGE_FORMAT=GEOTIFF"]
         )
     assert ds is None
 
     # Cannot create GeoTIFF file
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.GetDriverByName("PDS4").Create(
             "/i/do_not/exist.xml", 1, 1, options=["IMAGE_FORMAT=GEOTIFF"]
         )
@@ -1117,7 +1117,7 @@ def test_pds4_14():
 
     gdal.Translate("/vsimem/test.tif", "data/byte.tif")
     # Output file has same name as input file
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Translate(
             "/vsimem/test.xml",
             "/vsimem/test.tif",
@@ -1135,7 +1135,7 @@ def test_pds4_14():
         filename, 1, 1, options=["TEMPLATE=" + template]
     )
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = None
     assert (
         gdal.GetLastErrorMsg()
@@ -1159,7 +1159,7 @@ def test_pds4_14():
     ds.SetProjection(sr.ExportToWkt())
     ds.SetGeoTransform([2, 1, 0, 49, 0, -2])
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = None
     assert (
         gdal.GetLastErrorMsg()
@@ -1179,7 +1179,7 @@ def test_pds4_14():
         filename, 1, 1, options=["TEMPLATE=" + template]
     )
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = None
     assert gdal.GetLastErrorMsg() == "Cannot find Observation_Area in template"
 
@@ -1199,7 +1199,7 @@ def test_pds4_14():
         filename, 1, 1, options=["TEMPLATE=" + template]
     )
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = None
     assert (
         gdal.GetLastErrorMsg()
@@ -1331,7 +1331,7 @@ def test_pds4_17():
 
     filename = "/vsimem/out.xml"
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("PDS4").Create(
             filename, 1, 1, 1, options=["ARRAY_TYPE=Array_2D"] + options
         )
@@ -1352,14 +1352,14 @@ def test_pds4_17():
     gdal.GetDriverByName("PDS4").Delete(filename)
 
     # Test multi-band creation with Array_2D
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.GetDriverByName("PDS4").Create(
             filename, 1, 1, 2, options=["ARRAY_TYPE=Array_2D"] + options
         )
     assert ds is None, "expected failure"
 
     # Test multi-band creation with Array_3D_Spectrum
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("PDS4").Create(
             filename, 1, 1, 2, options=["ARRAY_TYPE=Array_3D_Spectrum"] + options
         )
@@ -1388,7 +1388,7 @@ def test_pds4_18():
     sr.ImportFromProj4("+proj=longlat +R=2439400 +no_defs")
     ds.SetProjection(sr.ExportToWkt())
     ds.SetGeoTransform([2, 1, 0, 49, 0, -2])
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = None
 
     f = gdal.VSIFOpenL(filename, "rb")
@@ -1523,11 +1523,11 @@ def _test_createlabelonly(
     src_ds_name = src_ds.GetDescription()
     src_driver_name = src_ds.GetDriver().GetDescription()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert gdal.GetDriverByName("PDS4").CreateCopy(
             filename, src_ds, options=["CREATE_LABEL_ONLY=YES"] + creation_options
         )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(filename)
     assert ds
     found_src_ds_name = False
@@ -1538,7 +1538,7 @@ def _test_createlabelonly(
     assert ds.RasterCount == src_ds.RasterCount
     assert ds.RasterXSize == src_ds.RasterXSize
     assert ds.RasterYSize == src_ds.RasterYSize
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         for i in range(ds.RasterCount):
             assert (
                 ds.GetRasterBand(i + 1).Checksum()
@@ -1620,7 +1620,7 @@ def test_pds4_createlabelonly_gtiff_error():
         "/vsimem/byte.tif", gdal.Open("data/byte.tif"), options=["TILED=YES"]
     )
     src_ds = gdal.Open("/vsimem/byte.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not gdal.GetDriverByName("PDS4").CreateCopy(
             "/vsimem/out.xml", src_ds, options=["CREATE_LABEL_ONLY=YES"]
         )

--- a/autotest/gdrivers/plmosaic.py
+++ b/autotest/gdrivers/plmosaic.py
@@ -594,7 +594,7 @@ def test_plmosaic_17(tmp_path, valid_mosaic):
 
     # Invalid tile content
     gdal.FileFromMemBuffer(f"{valid_mosaic}/my_mosaic_id/quads/0-2047/full", "garbage")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.GetRasterBand(1).ReadRaster(0, 0, 1, 1)
 
     os.stat(f"{cache_path}/my_mosaic/my_mosaic_0-2047.tif")
@@ -606,7 +606,7 @@ def test_plmosaic_17(tmp_path, valid_mosaic):
     gdal.GetDriverByName("GTiff").Create(
         f"{valid_mosaic}/my_mosaic_id/quads/0-2047/full", 1, 1, 1
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.GetRasterBand(1).ReadRaster(0, 0, 1, 1)
 
     os.stat(f"{cache_path}/my_mosaic/my_mosaic_0-2047.tif")
@@ -763,7 +763,7 @@ def test_plmosaic_19(valid_mosaic):
                 "CACHE_PATH=/does_not_exist",
             ],
         )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         val = ds.ReadRaster(0, 0, 1, 1)
     val = struct.unpack("B" * 4, val)
     assert val == (254, 0, 0, 0)
@@ -824,17 +824,17 @@ def test_plmosaic_21(valid_mosaic):
         )
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.ReadRaster(256, 512, 1, 1)
     assert gdal.GetLastErrorMsg() != ""
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.GetRasterBand(1).ReadRaster(256, 512, 1, 1)
     assert gdal.GetLastErrorMsg() != ""
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.GetRasterBand(1).ReadBlock(1, 2)
     assert gdal.GetLastErrorMsg() != ""
 

--- a/autotest/gdrivers/png.py
+++ b/autotest/gdrivers/png.py
@@ -176,13 +176,13 @@ def test_png_8():
     assert b is not None, "band 1 is missing"
 
     # We're not interested in returned value but internal state of GDAL.
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         b.ComputeBandStats()
         err = gdal.GetLastErrorNo()
 
     assert err != 0, "error condition expected"
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds_dst = drv.CreateCopy("tmp/idat_broken.png", ds_src)
         err = gdal.GetLastErrorNo()
     ds_src = None
@@ -352,7 +352,7 @@ def test_png_14():
     assert nbits == "2"
 
     # Test (wrong) explicit NBITS
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("PNG").CreateCopy(
             "/vsimem/tmp.png", src_ds, options=["NBITS=7"]
         )

--- a/autotest/gdrivers/pnm.py
+++ b/autotest/gdrivers/pnm.py
@@ -83,7 +83,7 @@ def test_pnm_4():
 @gdaltest.disable_exceptions()
 def test_pnm_write_non_standard_extension(nbands):
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("PNM").Create("foo.foo", 1, 1, nbands)
     assert gdal.GetLastErrorType() != 0
     gdal.Unlink("foo.foo")

--- a/autotest/gdrivers/postgisraster.py
+++ b/autotest/gdrivers/postgisraster.py
@@ -74,7 +74,7 @@ def setup_and_cleanup():
     )
 
     # Make sure we have SRID=26711 in spatial_ref_sys
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open(gdaltest.postgisraster_connection_string, update=1)
     if ds is None:
         if val:
@@ -104,14 +104,14 @@ def setup_and_cleanup():
 
     gdaltest.postgisraster_connection_string += " schema='gis_schema' "
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(gdaltest.postgisraster_connection_string + "table='utm'")
 
     # If we cannot open the table, try force loading the data
     if ds is None:
         gdaltest.runexternal("bash data/load_postgisraster_test_data.sh")
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.Open(gdaltest.postgisraster_connection_string + "table='utm'")
 
     if ds is None:
@@ -129,7 +129,7 @@ def setup_and_cleanup():
 
 def test_postgisraster_test_open_error1():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(gdaltest.postgisraster_connection_string + "table='nonexistent'")
     if ds is None:
         return
@@ -143,7 +143,7 @@ def test_postgisraster_test_open_error1():
 def test_postgisraster_test_open_error2():
 
     # removed mode, as it defaults to one raster per row
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(gdaltest.postgisraster_connection_string + "table='utm'")
     assert ds is not None
 
@@ -155,7 +155,7 @@ def test_postgisraster_test_open_error2():
 def test_postgisraster_compare_utm():
 
     src_ds = gdal.Open("data/utm.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         dst_ds = gdal.Open(gdaltest.postgisraster_connection_string + "table='utm'")
 
     # dataset actually contains many sub-datasets. test the first one
@@ -172,7 +172,7 @@ def test_postgisraster_compare_utm():
 def test_postgisraster_compare_small_world():
 
     src_ds = gdal.Open("data/small_world.tif")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         dst_ds = gdal.Open(
             gdaltest.postgisraster_connection_string + "table='small_world'"
         )
@@ -200,7 +200,7 @@ def test_postgisraster_test_utm_open():
     rb.GetStatistics(0, 1)
     cs = rb.Checksum()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         main_ds = gdal.Open(gdaltest.postgisraster_connection_string + "table='utm'")
 
         # Try to open PostGISRaster with the same data than original tif file
@@ -230,7 +230,7 @@ def test_postgisraster_test_small_world_open_b1():
     rb.GetStatistics(0, 1)
     cs = rb.Checksum()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         main_ds = gdal.Open(
             gdaltest.postgisraster_connection_string + "table='small_world'"
         )
@@ -262,7 +262,7 @@ def test_postgisraster_test_small_world_open_b2():
     rb.GetStatistics(0, 1)
     cs = rb.Checksum()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         main_ds = gdal.Open(
             gdaltest.postgisraster_connection_string + "table='small_world'"
         )
@@ -294,7 +294,7 @@ def test_postgisraster_test_small_world_open_b3():
     rb.GetStatistics(0, 1)
     cs = rb.Checksum()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         main_ds = gdal.Open(
             gdaltest.postgisraster_connection_string + "table='small_world'"
         )
@@ -313,7 +313,7 @@ def test_postgisraster_test_small_world_open_b3():
 
 def test_postgisraster_test_create_copy_bad_conn_string():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         src_ds = gdal.Open(
             gdaltest.postgisraster_connection_string + "table='small_world'"
         )
@@ -327,7 +327,7 @@ def test_postgisraster_test_create_copy_bad_conn_string():
 
 def test_postgisraster_test_create_copy_no_dbname():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         src_ds = gdal.Open(
             gdaltest.postgisraster_connection_string + "table='small_world'"
         )
@@ -345,7 +345,7 @@ def test_postgisraster_test_create_copy_no_dbname():
 
 def test_postgisraster_test_create_copy_no_tablename():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         src_ds = gdal.Open(
             gdaltest.postgisraster_connection_string + "table='small_world'"
         )
@@ -370,7 +370,7 @@ def test_postgisraster_test_create_copy_and_delete():
     Why, test "Delete", of course!
     """
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         src_ds = gdal.Open(
             gdaltest.postgisraster_connection_string + "table='small_world'"
         )
@@ -395,7 +395,7 @@ def test_postgisraster_test_create_copy_and_delete_phases():
     Create a copy of the dataset, then delete it in phases.
     """
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         src_ds = gdal.Open(
             gdaltest.postgisraster_connection_string + "table='small_world'"
         )
@@ -486,7 +486,7 @@ def test_postgisraster_test_norid():
     Test the ability to connect to a data source if it has no 'rid' column.
     """
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         src_ds = gdal.Open(
             gdaltest.postgisraster_connection_string + "table='small_world_noid'"
         )
@@ -503,7 +503,7 @@ def test_postgisraster_test_norid():
                 and src_md[k].find("ST_UpperLeftY") >= 0
             )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(
             gdaltest.postgisraster_connection_string + "table='small_world_noid' mode=2"
         )
@@ -517,7 +517,7 @@ def test_postgisraster_test_serial():
     but uses a sequence instead.
     """
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         src_ds = gdal.Open(
             gdaltest.postgisraster_connection_string + "table='small_world_serial'"
         )
@@ -537,7 +537,7 @@ def test_postgisraster_test_serial():
                 src_md[k],
             )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(
             gdaltest.postgisraster_connection_string
             + "table='small_world_serial' mode=2"
@@ -552,7 +552,7 @@ def test_postgisraster_test_unique():
     but uses a unique constraint instead.
     """
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         src_ds = gdal.Open(
             gdaltest.postgisraster_connection_string + "table='small_world_unique'"
         )
@@ -572,7 +572,7 @@ def test_postgisraster_test_unique():
                 src_md[k],
             )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(
             gdaltest.postgisraster_connection_string
             + "table='small_world_unique' mode=2"

--- a/autotest/gdrivers/rl2.py
+++ b/autotest/gdrivers/rl2.py
@@ -403,7 +403,7 @@ def test_rl2_20():
         if nbits is not None:
             src_ds.GetRasterBand(1).SetMetadataItem("NBITS", nbits, "IMAGE_STRUCTURE")
         options = ["PIXEL_TYPE=" + pixel_type, "COMPRESS=" + compress]
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             out_ds = gdaltest.rl2_drv.CreateCopy(
                 "/vsimem/rl2_20.rl2", src_ds, options=options
             )
@@ -558,5 +558,5 @@ def test_rl2_24():
 
 def test_rl2_error_create():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert gdaltest.rl2_drv.Create("/vsimem/out.db", 1, 1) is None

--- a/autotest/gdrivers/rmf.py
+++ b/autotest/gdrivers/rmf.py
@@ -51,14 +51,14 @@ def test_rmf_1():
 def test_rmf_2():
 
     tst = gdaltest.GDALTest("rmf", "rmf/byte-lzw.rsw", 1, 40503)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         tst.testOpen()
 
 
 def test_rmf_3():
 
     tst = gdaltest.GDALTest("rmf", "rmf/float64.mtw", 1, 4672)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         tst.testOpen(check_gt=(440720, 60, 0, 3751320, 0, -60))
 
 
@@ -77,30 +77,30 @@ def test_rmf_4():
 def test_rmf_5():
 
     tst = gdaltest.GDALTest("rmf", "rmf/rgbsmall-lzw.rsw", 1, 40503)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         tst.testOpen()
 
     tst = gdaltest.GDALTest("rmf", "rmf/rgbsmall-lzw.rsw", 2, 41429)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         tst.testOpen()
 
     tst = gdaltest.GDALTest("rmf", "rmf/rgbsmall-lzw.rsw", 3, 40238)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         tst.testOpen()
 
 
 def test_rmf_6():
 
     tst = gdaltest.GDALTest("rmf", "rmf/big-endian.rsw", 1, 7782)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         tst.testOpen()
 
     tst = gdaltest.GDALTest("rmf", "rmf/big-endian.rsw", 2, 8480)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         tst.testOpen()
 
     tst = gdaltest.GDALTest("rmf", "rmf/big-endian.rsw", 3, 4195)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         tst.testOpen()
 
 
@@ -141,7 +141,7 @@ def test_rmf_10():
 
     tst = gdaltest.GDALTest("rmf", "rmf/t100.mtw", 1, 6388)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         tst.testOpen()
 
 
@@ -189,7 +189,7 @@ def test_rmf_11():
 def test_rmf_12a():
 
     tst = gdaltest.GDALTest("rmf", "rmf/cucled-1.rsw", 1, 4672)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         tst.testOpen(check_gt=(440720, 60, 0, 3751320, 0, -60))
 
 
@@ -200,7 +200,7 @@ def test_rmf_12a():
 def test_rmf_12b():
 
     tst = gdaltest.GDALTest("rmf", "rmf/cucled-2.rsw", 1, 4672)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         tst.testOpen(check_gt=(440720, 60, 0, 3751320, 0, -60))
 
 
@@ -211,7 +211,7 @@ def test_rmf_12b():
 def test_rmf_12c():
 
     tst = gdaltest.GDALTest("rmf", "rmf/invalid-subheader.rsw", 1, 4672)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         tst.testOpen(check_gt=(440720, 60, 0, 3751320, 0, -60))
 
 

--- a/autotest/gdrivers/roipac.py
+++ b/autotest/gdrivers/roipac.py
@@ -114,5 +114,5 @@ def test_roipac_5():
 def test_roipac_6():
 
     tst = gdaltest.GDALTest("roi_pac", "byte.tif", 1, 4672)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         tst.testCreateCopy(check_gt=1, new_filename="byte.flg", vsimem=1)

--- a/autotest/gdrivers/sentinel2.py
+++ b/autotest/gdrivers/sentinel2.py
@@ -147,7 +147,7 @@ def test_sentinel2_l1c_1():
         "SENTINEL2_L1C:%s:50m:EPSG_32632" % filename_xml,
         "SENTINEL2_L1C:%s:10m:EPSG_32633" % filename_xml,
     ]:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.Open(name)
         assert ds is None, name
 
@@ -339,11 +339,11 @@ def test_sentinel2_l1c_5():
 """,
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/test.xml")
     assert ds is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("SENTINEL2_L1C:/vsimem/test.xml:10m:EPSG_32632")
     assert ds is None
 
@@ -418,12 +418,12 @@ def test_sentinel2_l1c_5():
     )
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.Open("/vsimem/test.xml")
     assert gdal.GetLastErrorMsg() != ""
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("SENTINEL2_L1C:/vsimem/test.xml:10m:EPSG_32632")
     assert ds is None
 
@@ -437,12 +437,12 @@ def test_sentinel2_l1c_5():
     )
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/test.xml")
     assert ds is None
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("SENTINEL2_L1C:/vsimem/test.xml:10m:EPSG_32632")
     assert ds is None
 
@@ -457,12 +457,12 @@ def test_sentinel2_l1c_5():
     )
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/test.xml")
     assert ds is None
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("SENTINEL2_L1C:/vsimem/test.xml:10m:EPSG_32632")
     assert ds is None
 
@@ -480,7 +480,7 @@ def test_sentinel2_l1c_5():
     )
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/test.xml")
     assert ds is None
 
@@ -503,7 +503,7 @@ def test_sentinel2_l1c_5():
     )
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/test.xml")
     assert ds is None
 
@@ -588,7 +588,7 @@ def test_sentinel2_l1c_7():
     )
 
     # Open with missing tile
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("SENTINEL2_L1C:/vsimem/test.xml:60m:EPSG_32753")
     ds = None
 
@@ -695,7 +695,7 @@ def test_sentinel2_l1c_tile_1():
         "SENTINEL2_L1C_TILE:%s" % filename_xml,
         "SENTINEL2_L1C_TILE:%s:" % filename_xml,
     ]:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.Open(name)
         assert ds is None, name
 
@@ -982,11 +982,11 @@ def test_sentinel2_l1c_tile_6():
 """,
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/test.xml")
     assert ds is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("SENTINEL2_L1C_TILE:/vsimem/test.xml:10m")
     assert ds is None
 
@@ -1020,7 +1020,7 @@ def test_sentinel2_l1c_tile_6():
     # Just tell it doesn't crash without any tile
     gdal.Open("/vsimem/GRANULE/S2A_OPER_MSI_L1C_bla_N01.03/S2A_OPER_MTD_L1C_bla.xml")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(
             "SENTINEL2_L1C_TILE:/vsimem/GRANULE/S2A_OPER_MSI_L1C_bla_N01.03/S2A_OPER_MTD_L1C_bla.xml:10m"
         )
@@ -1108,7 +1108,7 @@ def test_sentinel2_l1b_1():
         "SENTINEL2_L1B:%s:" % filename_xml,
         "SENTINEL2_L1B:%s:30m" % filename_xml,
     ]:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.Open(name)
         assert ds is None, name
 
@@ -1378,7 +1378,7 @@ def test_sentinel2_l1b_4():
     )
 
     # Open with missing tile
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(
             "SENTINEL2_L1B:/vsimem/foo/GRANULE/S2B_OPER_MTD_L1B_N01.03/S2B_OPER_MTD_L1B.xml:60m"
         )
@@ -1475,7 +1475,7 @@ def test_sentinel2_l1b_5():
 """,
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/test.xml")
     assert ds is None
 
@@ -1489,7 +1489,7 @@ def test_sentinel2_l1b_5():
     )
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/test.xml")
     assert ds is None
 
@@ -1504,12 +1504,12 @@ def test_sentinel2_l1b_5():
     )
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/test.xml")
     assert ds is None
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("SENTINEL2_L1B:/vsimem/test.xml:10m")
     assert ds is None
 
@@ -1527,7 +1527,7 @@ def test_sentinel2_l1b_5():
     )
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/test.xml")
     assert ds is None
 
@@ -1550,7 +1550,7 @@ def test_sentinel2_l1b_5():
     )
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/test.xml")
     assert ds is None
 
@@ -1561,12 +1561,12 @@ def test_sentinel2_l1b_5():
 """,
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/test.xml")
     assert ds is None
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("SENTINEL2_L1B:/vsimem/test.xml:10m")
     assert ds is None
 
@@ -1582,7 +1582,7 @@ def test_sentinel2_l1b_5():
     )
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("SENTINEL2_L1B:/vsimem/test.xml:10m")
     assert ds is None
 
@@ -1604,7 +1604,7 @@ def test_sentinel2_l1b_5():
     )
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("SENTINEL2_L1B:/vsimem/test.xml:10m")
     assert ds is None
 
@@ -1626,7 +1626,7 @@ def test_sentinel2_l1b_5():
     )
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("SENTINEL2_L1B:/vsimem/test.xml:10m")
     assert ds is None
 
@@ -1644,7 +1644,7 @@ def test_sentinel2_l1b_5():
     )
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("SENTINEL2_L1B:/vsimem/test.xml:10m")
     assert ds is None
     gdal.Unlink("/vsimem/test.xml")
@@ -1757,7 +1757,7 @@ def test_sentinel2_l2a_1():
         "SENTINEL2_L2A:%s:50m:EPSG_32632" % filename_xml,
         "SENTINEL2_L2A:%s:10m:EPSG_32633" % filename_xml,
     ]:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.Open(name)
         assert ds is None, name
 
@@ -1925,11 +1925,11 @@ def test_sentinel2_l2a_3():
 """,
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("/vsimem/test.xml")
     assert ds is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("SENTINEL2_L2A:/vsimem/test.xml:10m:EPSG_32632")
     assert ds is None
 
@@ -1975,12 +1975,12 @@ def test_sentinel2_l2a_3():
     )
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.Open("/vsimem/test.xml")
     assert gdal.GetLastErrorMsg() != ""
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("SENTINEL2_L2A:/vsimem/test.xml:10m:EPSG_32632")
     assert ds is None
 
@@ -2092,7 +2092,7 @@ def test_sentinel2_l2a_4():
         "SENTINEL2_L2A:%s:50m:EPSG_32632" % filename_xml,
         "SENTINEL2_L2A:%s:10m:EPSG_32633" % filename_xml,
     ]:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.Open(name)
         assert ds is None, name
 
@@ -2314,7 +2314,7 @@ def test_sentinel2_l2a_6():
         "SENTINEL2_L2A:%s:50m:EPSG_32632" % filename_xml,
         "SENTINEL2_L2A:%s:10m:EPSG_32633" % filename_xml,
     ]:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.Open(name)
         assert ds is None, name
 
@@ -2518,7 +2518,7 @@ def test_sentinel2_l1c_safe_compact_1():
         "SENTINEL2_L1C:%s:50m:EPSG_32632" % filename_xml,
         "SENTINEL2_L1C:%s:10m:EPSG_32633" % filename_xml,
     ]:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.Open(name)
         assert ds is None, name
 

--- a/autotest/gdrivers/test_validate_jp2.py
+++ b/autotest/gdrivers/test_validate_jp2.py
@@ -191,7 +191,7 @@ def test_validate_jp2_3():
     build_jp2_from_xml.build_file(
         "data/test_validate_jp2/stefan_full_rgba_corrupted.xml", "/vsimem/out.jp2"
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         error_report = validate(
             "/vsimem/out.jp2", oidoc="data/test_validate_jp2/stefan_full_rgba_oi.xml"
         )
@@ -249,7 +249,7 @@ def test_validate_jp2_4():
     build_jp2_from_xml.build_file(
         "data/test_validate_jp2/almost_nojp2box.xml", "/vsimem/out.jp2"
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         error_report = validate("/vsimem/out.jp2", expected_gmljp2=False)
     gdal.Unlink("/vsimem/out.jp2")
 
@@ -291,7 +291,7 @@ def test_validate_jp2_5():
     build_jp2_from_xml.build_file(
         "data/test_validate_jp2/utmsmall_pct_corrupted.xml", "/vsimem/out.jp2"
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         error_report = validate(
             "/vsimem/out.jp2", oidoc="data/test_validate_jp2/utmsmall_pct_oi.xml"
         )

--- a/autotest/gdrivers/usgsdem.py
+++ b/autotest/gdrivers/usgsdem.py
@@ -193,7 +193,7 @@ def test_usgsdem_7():
     ds = gdal.Open("data/n43.dt0")
 
     # To avoid warning about 'Unable to find NTS mapsheet lookup file: NTS-50kindex.csv'
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds2 = gdal.GetDriverByName("USGSDEM").CreateCopy(
             "tmp/000a00DEMz",
             ds,

--- a/autotest/gdrivers/vicar.py
+++ b/autotest/gdrivers/vicar.py
@@ -318,7 +318,7 @@ def test_vicar_create_label_option_as_inline_value():
 def test_vicar_create_label_option_as_inline_value_error():
 
     filename = "/vsimem/test.vic"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not gdal.GetDriverByName("VICAR").Create(
             filename, 1, 1, 1, gdal.GDT_Byte, options=["LABEL={error"]
         )
@@ -348,7 +348,7 @@ def test_vicar_create_label_option_as_filename_error():
     filename = "/vsimem/test.vic"
     json_filename = "/vsimem/test.json"
     gdal.FileFromMemBuffer(json_filename, "error")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not gdal.GetDriverByName("VICAR").Create(
             filename, 1, 1, 1, gdal.GDT_Byte, options=["LABEL=" + json_filename]
         )
@@ -495,7 +495,7 @@ def test_vicar_write_basic2_all_ones():
 
 def test_vicar_write_compression_errors():
     filename = "/vsimem/test.vic"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # Only single-band supported
         assert not gdal.GetDriverByName("VICAR").Create(
             filename, 1, 1, 2, options=["COMPRESS=BASIC"]
@@ -522,7 +522,7 @@ def test_vicar_write_compression_errors():
     )
     # Non sequential writing of lines
     ds.WriteRaster(0, 1, 1, 1, "x")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.FlushCache()
     assert gdal.GetLastErrorMsg() != ""
     ds = None

--- a/autotest/gdrivers/vrtderived.py
+++ b/autotest/gdrivers/vrtderived.py
@@ -141,10 +141,10 @@ def test_vrtderived_2():
     md["source_0"] = simpleSourceXML
 
     vrt_ds.GetRasterBand(1).SetMetadata(md, "vrt_sources")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         cs = vrt_ds.GetRasterBand(1).Checksum()
     assert cs == -1
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = vrt_ds.GetRasterBand(1).WriteRaster(0, 0, 1, 1, " ")
     assert ret != 0
     vrt_ds = None
@@ -211,7 +211,7 @@ def test_vrtderived_4():
         "PixelFunctionType=dummy",
         "SourceTransferType=Invalid",
     ]
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = vrt_ds.AddBand(gdal.GDT_Byte, options)
     assert ret != 0, "invalid SourceTransferType value not detected"
 
@@ -341,12 +341,12 @@ def test_vrtderived_8():
 
     with gdal.config_option("GDAL_VRT_ENABLE_PYTHON", "NO"):
         ds = gdal.Open("data/vrt/n43_hillshade.vrt")
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             cs = ds.GetRasterBand(1).Checksum()
     assert cs == -1, "invalid checksum"
 
     ds = gdal.Open("data/vrt/n43_hillshade.vrt")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         cs = ds.GetRasterBand(1).Checksum()
     assert cs == -1, "invalid checksum"
 
@@ -365,7 +365,7 @@ def test_vrtderived_9():
         pytest.skip()
 
     # Missing PixelFunctionType
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(
             """<VRTDataset rasterXSize="10" rasterYSize="10">
   <VRTRasterBand dataType="Byte" band="1" subClass="VRTDerivedRasterBand">
@@ -377,7 +377,7 @@ def test_vrtderived_9():
     assert ds is None
 
     # Unsupported PixelFunctionLanguage
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(
             """<VRTDataset rasterXSize="10" rasterYSize="10">
   <VRTRasterBand dataType="Byte" band="1" subClass="VRTDerivedRasterBand">
@@ -390,7 +390,7 @@ def test_vrtderived_9():
     assert ds is None
 
     # PixelFunctionCode can only be used with Python
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(
             """<VRTDataset rasterXSize="10" rasterYSize="10">
   <VRTRasterBand dataType="Byte" band="1" subClass="VRTDerivedRasterBand">
@@ -407,7 +407,7 @@ def identity(in_ar, out_ar, xoff, yoff, xsize, ysize, raster_xsize, raster_ysize
     assert ds is None
 
     # BufferRadius can only be used with Python
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(
             """<VRTDataset rasterXSize="10" rasterYSize="10">
   <VRTRasterBand dataType="Byte" band="1" subClass="VRTDerivedRasterBand">
@@ -420,7 +420,7 @@ def identity(in_ar, out_ar, xoff, yoff, xsize, ysize, raster_xsize, raster_ysize
     assert ds is None
 
     # Invalid BufferRadius
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(
             """<VRTDataset rasterXSize="10" rasterYSize="10">
   <VRTRasterBand dataType="Byte" band="1" subClass="VRTDerivedRasterBand">
@@ -593,7 +593,7 @@ def my_func(in_ar, out_ar, xoff, yoff, xsize, ysize, raster_xsize, raster_ysize,
 </VRTDataset>
 """
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         cs = ds.GetRasterBand(1).Checksum()
     if cs != -1:
         print(gdal.GetLastErrorMsg())
@@ -614,7 +614,7 @@ def my_func(in_ar, out_ar, xoff, yoff, xsize, ysize, raster_xsize, raster_ysize,
 </VRTDataset>
 """
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         cs = ds.GetRasterBand(1).Checksum()
     if cs != -1:
         print(gdal.GetLastErrorMsg())
@@ -630,7 +630,7 @@ def my_func(in_ar, out_ar, xoff, yoff, xsize, ysize, raster_xsize, raster_ysize,
 </VRTDataset>
 """
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         cs = ds.GetRasterBand(1).Checksum()
     if cs != -1:
         print(gdal.GetLastErrorMsg())
@@ -675,7 +675,7 @@ def test_vrtderived_10():
 
     # GDAL_VRT_TRUSTED_MODULES not defined
     ds = gdal.Open(content)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         cs = ds.GetRasterBand(1).Checksum()
     if cs != -1:
         print(gdal.GetLastErrorMsg())

--- a/autotest/gdrivers/vrtmultidim.py
+++ b/autotest/gdrivers/vrtmultidim.py
@@ -66,7 +66,7 @@ def test_vrtmultidim_dimension():
     assert dim_0.GetSize() == 2
     assert dim_0.GetType() == "foo"
     assert dim_0.GetDirection() == "bar"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.ErrorReset()
         assert not dim_0.GetIndexingVariable()
         assert gdal.GetLastErrorMsg() == "Cannot find variable X"
@@ -74,7 +74,7 @@ def test_vrtmultidim_dimension():
     assert dim_1.GetName() == "Y"
     assert dim_1.GetSize() == 1234567890123
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             """<VRTDataset>
         <Group MISSING_name="/">
@@ -84,7 +84,7 @@ def test_vrtmultidim_dimension():
         )
         assert not ds
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             """<VRTDataset>
         <Group name="INVALID">
@@ -94,7 +94,7 @@ def test_vrtmultidim_dimension():
         )
         assert not ds
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
@@ -105,7 +105,7 @@ def test_vrtmultidim_dimension():
         )
         assert not ds
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
@@ -172,7 +172,7 @@ def test_vrtmultidim_attribute():
     attrs = ar.GetAttributes()
     assert len(attrs) == 1
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
@@ -186,7 +186,7 @@ def test_vrtmultidim_attribute():
         )
         assert not ds
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
@@ -200,7 +200,7 @@ def test_vrtmultidim_attribute():
         )
         assert not ds
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
@@ -286,7 +286,7 @@ def test_vrtmultidim_subgroup_and_cross_references():
     assert Y.GetDimensionCount() == 1
     assert Y.GetDimensions()[0].GetSize() == 30
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
@@ -297,7 +297,7 @@ def test_vrtmultidim_subgroup_and_cross_references():
         )
         assert not ds
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
@@ -310,7 +310,7 @@ def test_vrtmultidim_subgroup_and_cross_references():
         )
         assert not ds
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
@@ -323,7 +323,7 @@ def test_vrtmultidim_subgroup_and_cross_references():
         )
         assert not ds
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
@@ -336,7 +336,7 @@ def test_vrtmultidim_subgroup_and_cross_references():
         )
         assert not ds
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
@@ -350,7 +350,7 @@ def test_vrtmultidim_subgroup_and_cross_references():
         )
         assert not ds
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
@@ -364,7 +364,7 @@ def test_vrtmultidim_subgroup_and_cross_references():
         )
         assert not ds
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
@@ -378,7 +378,7 @@ def test_vrtmultidim_subgroup_and_cross_references():
         )
         assert not ds
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
@@ -490,7 +490,7 @@ def test_vrtmultidim_RegularlySpacedValues():
         "d" * 2, X.Read(array_start_idx=[1], count=[2], array_step=[2])
     ) == (11.0, 32.0)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
@@ -506,7 +506,7 @@ def test_vrtmultidim_RegularlySpacedValues():
         )
         assert not ds
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
@@ -561,7 +561,7 @@ def test_vrtmultidim_ConstantValue():
     ar = rg.OpenMDArray("no_dim")
     assert struct.unpack("d", ar.Read()) == (50,)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
@@ -580,7 +580,7 @@ def test_vrtmultidim_ConstantValue():
         )
         assert not ds
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
@@ -599,7 +599,7 @@ def test_vrtmultidim_ConstantValue():
         )
         assert not ds
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
@@ -618,7 +618,7 @@ def test_vrtmultidim_ConstantValue():
         )
         assert not ds
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
@@ -637,7 +637,7 @@ def test_vrtmultidim_ConstantValue():
         )
         assert not ds
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
@@ -707,7 +707,7 @@ def test_vrtmultidim_InlineValues():
     ar = rg.OpenMDArray("no_dim")
     assert struct.unpack("d", ar.Read()) == (50,)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             """<VRTDataset>
         <Group name="/">
@@ -927,32 +927,32 @@ def test_vrtmultidim_Source():
 
         ar = rg.OpenMDArray("ar_non_existing_source")
         assert ar
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert not ar.Read()
 
         ar = rg.OpenMDArray("ar_invalid_source_slab_offset")
         assert ar
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert not ar.Read()
 
         ar = rg.OpenMDArray("ar_invalid_number_of_dimensions")
         assert ar
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert not ar.Read()
 
         ar = rg.OpenMDArray("ar_non_existing_array_source")
         assert ar
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert not ar.Read()
 
         ar = rg.OpenMDArray("ar_view_invalid")
         assert ar
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert not ar.Read()
 
         ar = rg.OpenMDArray("ar_transposed_invalid")
         assert ar
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert not ar.Read()
 
         gdal.Unlink("/vsimem/src.vrt")
@@ -1010,7 +1010,7 @@ def test_vrtmultidim_Source():
     assert ds2
     rg2 = ds2.GetRootGroup()
     ar2 = rg2.OpenMDArray("ar")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not ar2.Read()
 
 
@@ -1057,7 +1057,7 @@ def test_vrtmultidim_Source_classic_dataset():
 
     ar_wrong_band = rg.OpenMDArray("ar_wrong_band")
     assert ar_wrong_band
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not ar_wrong_band.Read()
 
 
@@ -1262,7 +1262,7 @@ def test_vrtmultidim_createcopy():
     attr.Write("bar")
     attr = None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.GetDriverByName("VRT").CreateCopy("/i_do/not_exist", src_ds)
 
     tmpfile = "/vsimem/test.vrt"
@@ -1313,12 +1313,12 @@ def test_vrtmultidim_createmultidimensional():
 
     dim = rg.CreateDimension("dim", "", "", 3)
     assert dim
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not rg.CreateDimension("", "", "", 1)
         assert not rg.CreateDimension("dim", "", "", 1)
 
     assert rg.CreateAttribute("attr", [1], gdal.ExtendedDataType.CreateString())
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not rg.CreateAttribute("", [1], gdal.ExtendedDataType.CreateString())
         assert not rg.CreateAttribute(
             "attr_2dim", [1, 2], gdal.ExtendedDataType.CreateString()
@@ -1330,7 +1330,7 @@ def test_vrtmultidim_createmultidimensional():
 
     ar = rg.CreateMDArray("ar", [dim], gdal.ExtendedDataType.Create(gdal.GDT_Float32))
     assert ar[0]
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not rg.CreateMDArray(
             "", [dim], gdal.ExtendedDataType.Create(gdal.GDT_Float32)
         )
@@ -1342,13 +1342,13 @@ def test_vrtmultidim_createmultidimensional():
         )
 
     assert ar.CreateAttribute("attr", [1], gdal.ExtendedDataType.CreateString())
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not ar.CreateAttribute("", [1], gdal.ExtendedDataType.CreateString())
         assert not ar.CreateAttribute("attr", [1], gdal.ExtendedDataType.CreateString())
 
     subg = rg.CreateGroup("subgroup")
     assert subg
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not rg.CreateGroup("subgroup")
         assert not rg.CreateGroup("")
 

--- a/autotest/gdrivers/vrtpansharpen.py
+++ b/autotest/gdrivers/vrtpansharpen.py
@@ -73,7 +73,7 @@ def startup_and_cleanup():
 def test_vrtpansharpen_1():
 
     # Missing PansharpeningOptions
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         vrt_ds = gdal.Open(
             """<VRTDataset rasterXSize="800" rasterYSize="400" subClass="VRTPansharpenedDataset">
         <VRTRasterBand dataType="Byte" band="1" subClass="VRTPansharpenedRasterBand">
@@ -90,7 +90,7 @@ def test_vrtpansharpen_1():
     assert vrt_ds is None
 
     # PanchroBand missing
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         vrt_ds = gdal.Open(
             """<VRTDataset rasterXSize="800" rasterYSize="400" subClass="VRTPansharpenedDataset">
         <VRTRasterBand dataType="Byte" band="1" subClass="VRTPansharpenedRasterBand">
@@ -128,7 +128,7 @@ def test_vrtpansharpen_1():
     assert vrt_ds is None
 
     # PanchroBand.SourceFilename missing
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         vrt_ds = gdal.Open(
             """<VRTDataset rasterXSize="800" rasterYSize="400" subClass="VRTPansharpenedDataset">
         <VRTRasterBand dataType="Byte" band="1" subClass="VRTPansharpenedRasterBand">
@@ -168,7 +168,7 @@ def test_vrtpansharpen_1():
     assert vrt_ds is None
 
     # Invalid dataset name
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         vrt_ds = gdal.Open(
             """<VRTDataset rasterXSize="800" rasterYSize="400" subClass="VRTPansharpenedDataset">
         <VRTRasterBand dataType="Byte" band="1" subClass="VRTPansharpenedRasterBand">
@@ -210,7 +210,7 @@ def test_vrtpansharpen_1():
     assert vrt_ds is None
 
     # Inconsistent declared VRT dimensions with panchro dataset.
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         vrt_ds = gdal.Open(
             """<VRTDataset rasterXSize="1800" rasterYSize="400" subClass="VRTPansharpenedDataset">
         <VRTRasterBand dataType="Byte" band="1" subClass="VRTPansharpenedRasterBand">
@@ -252,7 +252,7 @@ def test_vrtpansharpen_1():
     assert vrt_ds is None
 
     # VRTRasterBand of unrecognized subclass 'blabla'
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         vrt_ds = gdal.Open(
             """<VRTDataset rasterXSize="800" rasterYSize="400" subClass="VRTPansharpenedDataset">
         <VRTRasterBand dataType="Byte" band="1" subClass="blabla">
@@ -294,7 +294,7 @@ def test_vrtpansharpen_1():
     assert vrt_ds is None
 
     # Algorithm unsupported_alg unsupported
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         vrt_ds = gdal.Open(
             """<VRTDataset rasterXSize="800" rasterYSize="400" subClass="VRTPansharpenedDataset">
         <VRTRasterBand dataType="Byte" band="1" subClass="VRTPansharpenedRasterBand">
@@ -336,7 +336,7 @@ def test_vrtpansharpen_1():
     assert vrt_ds is None
 
     # 10 invalid band of tmp/small_world_pan.tif
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         vrt_ds = gdal.Open(
             """<VRTDataset rasterXSize="800" rasterYSize="400" subClass="VRTPansharpenedDataset">
         <VRTRasterBand dataType="Byte" band="1" subClass="VRTPansharpenedRasterBand">
@@ -378,7 +378,7 @@ def test_vrtpansharpen_1():
     assert vrt_ds is None
 
     # SpectralBand.dstBand = '-1' invalid
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         vrt_ds = gdal.Open(
             """<VRTDataset rasterXSize="800" rasterYSize="400" subClass="VRTPansharpenedDataset">
         <VRTRasterBand dataType="Byte" band="1" subClass="VRTPansharpenedRasterBand">
@@ -420,7 +420,7 @@ def test_vrtpansharpen_1():
     assert vrt_ds is None
 
     # SpectralBand.SourceFilename missing
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         vrt_ds = gdal.Open(
             """<VRTDataset rasterXSize="800" rasterYSize="400" subClass="VRTPansharpenedDataset">
         <VRTRasterBand dataType="Byte" band="1" subClass="VRTPansharpenedRasterBand">
@@ -461,7 +461,7 @@ def test_vrtpansharpen_1():
     assert vrt_ds is None
 
     # Invalid dataset name
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         vrt_ds = gdal.Open(
             """<VRTDataset rasterXSize="800" rasterYSize="400" subClass="VRTPansharpenedDataset">
         <VRTRasterBand dataType="Byte" band="1" subClass="VRTPansharpenedRasterBand">
@@ -503,7 +503,7 @@ def test_vrtpansharpen_1():
     assert vrt_ds is None
 
     # 10 invalid band of data/small_world.tif
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         vrt_ds = gdal.Open(
             """<VRTDataset rasterXSize="800" rasterYSize="400" subClass="VRTPansharpenedDataset">
         <VRTRasterBand dataType="Byte" band="1" subClass="VRTPansharpenedRasterBand">
@@ -545,7 +545,7 @@ def test_vrtpansharpen_1():
     assert vrt_ds is None
 
     # Another spectral band is already mapped to output band 1
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         vrt_ds = gdal.Open(
             """<VRTDataset rasterXSize="800" rasterYSize="400" subClass="VRTPansharpenedDataset">
         <VRTRasterBand dataType="Byte" band="1" subClass="VRTPansharpenedRasterBand">
@@ -587,7 +587,7 @@ def test_vrtpansharpen_1():
     assert vrt_ds is None
 
     # No spectral band defined
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         vrt_ds = gdal.Open(
             """<VRTDataset rasterXSize="800" rasterYSize="400" subClass="VRTPansharpenedDataset">
         <VRTRasterBand dataType="Byte" band="1" subClass="VRTPansharpenedRasterBand">
@@ -617,7 +617,7 @@ def test_vrtpansharpen_1():
     assert vrt_ds is None
 
     # Hole in SpectralBand.dstBand numbering
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         vrt_ds = gdal.Open(
             """<VRTDataset subClass="VRTPansharpenedDataset">
         <PansharpeningOptions>
@@ -650,7 +650,7 @@ def test_vrtpansharpen_1():
     assert vrt_ds is None
 
     # Band 4 of type VRTPansharpenedRasterBand, but no corresponding SpectralBand
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         vrt_ds = gdal.Open(
             """<VRTDataset rasterXSize="800" rasterYSize="400" subClass="VRTPansharpenedDataset">
         <VRTRasterBand dataType="Byte" band="1" subClass="VRTPansharpenedRasterBand">
@@ -694,7 +694,7 @@ def test_vrtpansharpen_1():
     assert vrt_ds is None
 
     # SpectralBand.dstBand = '3' invalid
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         vrt_ds = gdal.Open(
             """<VRTDataset rasterXSize="800" rasterYSize="400" subClass="VRTPansharpenedDataset">
         <VRTRasterBand dataType="Byte" band="1" subClass="VRTPansharpenedRasterBand">
@@ -733,7 +733,7 @@ def test_vrtpansharpen_1():
     assert vrt_ds is None
 
     # 2 weights defined, but 3 input spectral bands
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         vrt_ds = gdal.Open(
             """<VRTDataset rasterXSize="800" rasterYSize="400" subClass="VRTPansharpenedDataset">
         <VRTRasterBand dataType="Byte" band="1" subClass="VRTPansharpenedRasterBand">
@@ -775,7 +775,7 @@ def test_vrtpansharpen_1():
     assert vrt_ds is None
 
     # Dimensions of input spectral band 1 different from first spectral band
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         vrt_ds = gdal.Open(
             """<VRTDataset subClass="VRTPansharpenedDataset">
         <PansharpeningOptions>
@@ -801,7 +801,7 @@ def test_vrtpansharpen_1():
     # Georeferencing of top-left corner of pan dataset and data/byte.tif do not match
     # Georeferencing of bottom-right corner of pan dataset and data/byte.tif do not match
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         vrt_ds = gdal.Open(
             """<VRTDataset subClass="VRTPansharpenedDataset">
         <PansharpeningOptions>
@@ -824,7 +824,7 @@ def test_vrtpansharpen_1():
     # No spectral band is mapped to an output band
     # No output pansharpened band defined
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         vrt_ds = gdal.Open(
             """<VRTDataset rasterXSize="800" rasterYSize="400" subClass="VRTPansharpenedDataset">
         <PansharpeningOptions>
@@ -858,7 +858,7 @@ def test_vrtpansharpen_1():
     assert gdal.GetLastErrorMsg() != ""
 
     # Unsupported
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = vrt_ds.AddBand(gdal.GDT_Byte)
     assert ret != 0
 
@@ -1466,7 +1466,7 @@ def test_vrtpansharpen_7():
     </PansharpeningOptions>
 </VRTDataset>"""
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(xml)
     assert (
         ds.GetGeoTransform() == (100.0, 1.0, 0.0, 100.0, 0.0, -1.0)
@@ -1507,7 +1507,7 @@ def test_vrtpansharpen_7():
     </PansharpeningOptions>
 </VRTDataset>"""
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(xml)
     assert (
         ds.GetGeoTransform() == (120.0, 1.0, 0.0, 80.0, 0.0, -1.0)
@@ -1554,7 +1554,7 @@ def test_vrtpansharpen_7():
         </SpectralBand>
     </PansharpeningOptions>
 </VRTDataset>"""
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open(xml)
     assert ds is None
     ds = None
@@ -2124,7 +2124,7 @@ def test_vrtpansharpen_11():
     vrt_ds = None
 
     # Test error cases as well
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         vrt_ds = gdal.CreatePansharpenedVRT(
             """<invalid_xml""",
             pan_mem_ds.GetRasterBand(1),
@@ -2133,7 +2133,7 @@ def test_vrtpansharpen_11():
     assert vrt_ds is None
 
     # Not enough bands
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         vrt_ds = gdal.CreatePansharpenedVRT(
             """<VRTDataset subClass="VRTPansharpenedDataset">
             <PansharpeningOptions>
@@ -2149,7 +2149,7 @@ def test_vrtpansharpen_11():
     assert vrt_ds is None
 
     # Too many bands
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         vrt_ds = gdal.CreatePansharpenedVRT(
             """<VRTDataset subClass="VRTPansharpenedDataset">
             <PansharpeningOptions>

--- a/autotest/gdrivers/wmts.py
+++ b/autotest/gdrivers/wmts.py
@@ -91,19 +91,19 @@ def wmts_CleanCache():
 
 def test_wmts_2():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("WMTS:")
     assert ds is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("<GDAL_WMTS>")
     assert ds is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("<GDAL_WMTSxxx/>")
     assert ds is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("<GDAL_WMTS></GDAL_WMTS>")
     assert ds is None
 
@@ -114,7 +114,7 @@ def test_wmts_2():
 
 def test_wmts_3():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("WMTS:https://non_existing")
     assert ds is None
 
@@ -125,7 +125,7 @@ def test_wmts_3():
 
 def test_wmts_4():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("WMTS:/vsimem/non_existing")
     assert ds is None
 
@@ -138,7 +138,7 @@ def test_wmts_5():
 
     gdal.FileFromMemBuffer("/vsimem/invalid_getcapabilities.xml", "<invalid_xml")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("WMTS:/vsimem/invalid_getcapabilities.xml")
     assert ds is None
 
@@ -151,7 +151,7 @@ def test_wmts_6():
 
     gdal.FileFromMemBuffer("/vsimem/invalid_getcapabilities.xml", "<Capabilities/>")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("WMTS:/vsimem/invalid_getcapabilities.xml")
     assert ds is None
 
@@ -166,7 +166,7 @@ def test_wmts_7():
         "/vsimem/empty_getcapabilities.xml", "<Capabilities><Contents/></Capabilities>"
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("WMTS:/vsimem/empty_getcapabilities.xml")
     assert ds is None
 
@@ -188,7 +188,7 @@ def test_wmts_8():
 </Capabilities>""",
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("WMTS:/vsimem/missing.xml")
     assert ds is None
 
@@ -217,7 +217,7 @@ def test_wmts_9():
 </Capabilities>""",
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("WMTS:/vsimem/missing_tms.xml")
     assert ds is None
 
@@ -249,7 +249,7 @@ def test_wmts_10():
 </Capabilities>""",
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("WMTS:/vsimem/missing_SupportedCRS.xml")
     assert ds is None
 
@@ -282,7 +282,7 @@ def test_wmts_11():
 </Capabilities>""",
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("WMTS:/vsimem/no_tilematrix.xml")
     assert ds is None
 
@@ -316,7 +316,7 @@ def test_wmts_12():
 </Capabilities>""",
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("WMTS:/vsimem/missing_required_element_in_tilematrix.xml")
     assert ds is None
 
@@ -357,7 +357,7 @@ def test_wmts_12bis():
 </Capabilities>""",
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Open("WMTS:/vsimem/wmts_12bis.xml")
     assert ds is None
 
@@ -458,7 +458,7 @@ def test_wmts_13():
         assert ds.GetRasterBand(i + 1).GetColorInterpretation() == gdal.GCI_RedBand + i
     assert ds.GetRasterBand(1).GetOverviewCount() == 0
     assert ds.GetRasterBand(1).GetOverview(0) is None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         cs = ds.GetRasterBand(1).Checksum()
     assert cs == 0
     assert ds.GetSubDatasets() == []
@@ -485,7 +485,7 @@ def test_wmts_13():
         "WMTS:/vsimem/minimal.xml,tilematrix=baw",
         "WMTS:/vsimem/minimal.xml,zoom_level=30",
     ]:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.Open(connection_str)
         assert ds is None, connection_str
         ds = None
@@ -628,12 +628,12 @@ def test_wmts_14():
         ),
     ]
     assert ds.RasterXSize == 67108864
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         res = ds.GetRasterBand(1).GetMetadataItem("Pixel_1_2", "LocationInfo")
     assert res == ""
     assert ds.GetMetadata() == {"ABSTRACT": "My abstract", "TITLE": "My layer1"}
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdaltest.wmts_drv.CreateCopy(
             "/vsimem/gdal_nominal.xml", gdal.GetDriverByName("MEM").Create("", 1, 1)
         )
@@ -694,7 +694,7 @@ def test_wmts_14():
         ["URL=/vsimem/nominal.xml", "STYLE=style=auto", "TILEMATRIX=30"],
         ["URL=/vsimem/nominal.xml", "STYLE=style=auto", "ZOOM_LEVEL=30"],
     ]:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.OpenEx("WMTS:", open_options=open_options)
         assert ds is None
 
@@ -885,7 +885,7 @@ def test_wmts_15():
     ds = gdal.Open("/vsimem/nominal_kvp.xml?service=WMTS&request=GetCapabilities")
     assert ds is not None
     assert ds.RasterXSize == 67108864
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         res = ds.GetRasterBand(1).GetMetadataItem("Pixel_1_2", "LocationInfo")
     assert res == ""
 

--- a/autotest/gdrivers/xyz.py
+++ b/autotest/gdrivers/xyz.py
@@ -270,7 +270,7 @@ def test_xyz_9():
 """
 
     with gdaltest.tempfile("/vsimem/grid.xyz", content):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.Open("/vsimem/grid.xyz")
         assert ds.RasterXSize == 2 and ds.RasterYSize == 2
         cs = ds.GetRasterBand(1).Checksum()

--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -432,7 +432,7 @@ def test_zarr_invalid_json_remove_member(member):
     try:
         gdal.Mkdir("/vsimem/test.zarr", 0)
         gdal.FileFromMemBuffer("/vsimem/test.zarr/.zarray", json.dumps(j))
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.OpenEx("/vsimem/test.zarr", gdal.OF_MULTIDIM_RASTER)
         if member == "fill_value":
             assert ds is not None
@@ -501,7 +501,7 @@ def test_zarr_invalid_json_wrong_values(dict_update):
     try:
         gdal.Mkdir("/vsimem/test.zarr", 0)
         gdal.FileFromMemBuffer("/vsimem/test.zarr/.zarray", json.dumps(j))
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.OpenEx("/vsimem/test.zarr", gdal.OF_MULTIDIM_RASTER)
         assert ds is None
     finally:
@@ -527,7 +527,7 @@ def test_zarr_read_compression_methods(datasetname, compressor):
     filename = "data/zarr/" + datasetname
 
     if compressor not in compressors:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
         assert ds is None
     else:
@@ -1034,13 +1034,13 @@ def test_zarr_read_half_float(endianness):
 
 def test_zarr_read_mdim_zarr_non_existing():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             gdal.OpenEx('ZARR:"data/zarr/not_existing.zarr"', gdal.OF_MULTIDIM_RASTER)
             is None
         )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             gdal.OpenEx(
                 'ZARR:"https://example.org/not_existing.zarr"', gdal.OF_MULTIDIM_RASTER
@@ -1052,7 +1052,7 @@ def test_zarr_read_mdim_zarr_non_existing():
         in gdal.GetLastErrorMsg()
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             gdal.OpenEx(
                 "ZARR:https://example.org/not_existing.zarr", gdal.OF_MULTIDIM_RASTER
@@ -1064,7 +1064,7 @@ def test_zarr_read_mdim_zarr_non_existing():
         in gdal.GetLastErrorMsg()
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             gdal.OpenEx(
                 "ZARR:/vsicurl/https://example.org/not_existing.zarr",
@@ -1090,7 +1090,7 @@ def test_zarr_read_classic():
     assert not ds.GetSubDatasets()
     assert ds.ReadRaster() == array.array("b", [1, 2])
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert gdal.Open('ZARR:"data/zarr/not_existing.zarr"') is None
         assert gdal.Open('ZARR:"data/zarr/zlib.zarr":/not_existing') is None
         assert gdal.Open('ZARR:"data/zarr/zlib.zarr":/zlib:0') is None
@@ -1111,7 +1111,7 @@ def test_zarr_read_classic():
     assert ds
     assert ds.ReadRaster() == array.array("b", [12 + i for i in range(12)])
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert gdal.Open("ZARR:data/zarr/order_f_u1_3d.zarr:/order_f_u1_3d") is None
         assert gdal.Open("ZARR:data/zarr/order_f_u1_3d.zarr:/order_f_u1_3d:2") is None
         assert gdal.Open(subds[0][0] + ":0") is None
@@ -1202,7 +1202,7 @@ def test_zarr_read_classic_too_many_samples_3d():
         gdal.Mkdir("/vsimem/test.zarr", 0)
         gdal.FileFromMemBuffer("/vsimem/test.zarr/.zarray", json.dumps(j))
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.Open("/vsimem/test.zarr")
         assert gdal.GetLastErrorMsg() != ""
         assert len(ds.GetSubDatasets()) == 0
@@ -1252,7 +1252,7 @@ def test_zarr_read_classic_too_many_samples_4d():
         gdal.Mkdir("/vsimem/test.zarr", 0)
         gdal.FileFromMemBuffer("/vsimem/test.zarr/.zarray", json.dumps(j))
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.Open("/vsimem/test.zarr")
         assert gdal.GetLastErrorMsg() != ""
         assert len(ds.GetSubDatasets()) == 0
@@ -1316,7 +1316,7 @@ def test_zarr_create_group(format, create_z_metadata):
             assert attr
             assert attr.Write(["first_string", "second_string"]) == gdal.CE_None
 
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 attr = rg.CreateAttribute(
                     "dim_2_not_supported", [2, 2], gdal.ExtendedDataType.CreateString()
                 )
@@ -1439,7 +1439,7 @@ def test_zarr_create_group(format, create_z_metadata):
         assert attr.Read() == (12345678.5, -12345678.5)
 
         assert set(rg.GetGroupNames()) == set(["foo", "bar"])
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert rg.CreateGroup("not_opened_in_update_mode") is None
             assert (
                 rg.CreateAttribute(
@@ -1488,7 +1488,7 @@ def test_zarr_create_group_errors(group_name, format):
             subgroup = rg.CreateGroup("foo")
             assert subgroup
             gdal.Mkdir("/vsimem/test.zarr/directory_with_that_name", 0)
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 assert rg.CreateGroup(group_name) is None
 
         at_creation()
@@ -1499,7 +1499,7 @@ def test_zarr_create_group_errors(group_name, format):
             )
             rg = ds.GetRootGroup()
             gdal.Mkdir("/vsimem/test.zarr/directory_with_that_name", 0)
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 assert rg.CreateGroup(group_name) is None
 
         after_reopen()
@@ -1570,7 +1570,7 @@ def test_zarr_create_array(datatype, nodata, format):
             dim1 = rg.CreateDimension("dim1", None, None, 3)
 
             if error_expected:
-                with gdaltest.error_handler():
+                with gdal.quiet_errors():
                     ar = rg.CreateMDArray("my_ar", [dim0, dim1], datatype)
                 assert ar is None
                 return False
@@ -1669,7 +1669,7 @@ def test_zarr_create_array_errors(array_name, format):
                 is not None
             )
             gdal.Mkdir("/vsimem/test.zarr/directory_with_that_name", 0)
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 assert (
                     rg.CreateMDArray(
                         array_name, [], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
@@ -1685,7 +1685,7 @@ def test_zarr_create_array_errors(array_name, format):
             )
             rg = ds.GetRootGroup()
             gdal.Mkdir("/vsimem/test.zarr/directory_with_that_name", 0)
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 assert (
                     rg.CreateMDArray(
                         array_name, [], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
@@ -2248,7 +2248,7 @@ def test_zarr_read_invalid_zarr_v3(j, error_msg):
         gdal.Mkdir("/vsimem/test.zarr", 0)
         gdal.FileFromMemBuffer("/vsimem/test.zarr/zarr.json", json.dumps(j))
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert gdal.Open("/vsimem/test.zarr") is None
         assert error_msg in gdal.GetLastErrorMsg()
     finally:
@@ -2408,7 +2408,7 @@ def test_zarr_create_array_bad_compressor(format):
         assert ds is not None
         rg = ds.GetRootGroup()
         assert rg
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert (
                 rg.CreateMDArray(
                     "test",
@@ -2447,7 +2447,7 @@ def test_zarr_create_array_attributes(format):
             assert attr.GetFullName() == "/test/str_attr"
             assert attr.Write("my_string") == gdal.CE_None
 
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 assert (
                     ar.CreateAttribute(
                         "invalid_2d", [2, 3], gdal.ExtendedDataType.CreateString()
@@ -2484,10 +2484,10 @@ def test_zarr_create_array_attributes(format):
         attr = ar.GetAttribute("str_attr")
         assert attr
         assert attr.Read() == "my_string_modified"
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert attr.Write("foo") == gdal.CE_Failure
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert (
                 ar.CreateAttribute(
                     "another_attr", [], gdal.ExtendedDataType.CreateString()
@@ -3092,7 +3092,7 @@ def test_zarr_create_array_invalid_blocksize(blocksize):
             dim1 = rg.CreateDimension("dim1", None, None, 2)
             dim2 = rg.CreateDimension("dim2", None, None, 2)
 
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ar = rg.CreateMDArray(
                     "test",
                     [dim0, dim1, dim2],
@@ -3317,7 +3317,7 @@ def test_zarr_read_too_large_tile_size():
         gdal.FileFromMemBuffer("/vsimem/test.zarr/.zarray", json.dumps(j))
         ds = gdal.OpenEx("/vsimem/test.zarr", gdal.OF_MULTIDIM_RASTER)
         assert ds is not None
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert ds.GetRootGroup().OpenMDArray("test").Read() is None
     finally:
         gdal.RmdirRecursive("/vsimem/test.zarr")
@@ -3352,7 +3352,7 @@ def test_zarr_read_recursive_array_loading():
 
         ds = gdal.OpenEx("/vsimem/test.zarr", gdal.OF_MULTIDIM_RASTER)
         assert ds is not None
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ar = ds.GetRootGroup().OpenMDArray("a")
             assert ar
             assert (
@@ -3392,7 +3392,7 @@ def test_zarr_read_too_deep_array_loading():
 
         ds = gdal.OpenEx("/vsimem/test.zarr", gdal.OF_MULTIDIM_RASTER)
         assert ds is not None
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ar = ds.GetRootGroup().OpenMDArray("0")
             assert ar
             assert gdal.GetLastErrorMsg() == "Too deep call stack in LoadArray()"
@@ -3411,7 +3411,7 @@ def test_zarr_read_too_deep_array_loading():
 )
 def test_zarr_read_nczarr_v2(filename, path):
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER | gdal.OF_UPDATE) is None
 
     ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
@@ -3633,7 +3633,7 @@ def test_zarr_advise_read(compression, format):
             rg = ds.GetRootGroup()
             ar = rg.OpenMDArray("test")
 
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 assert ar.AdviseRead(options=["CACHE_SIZE=1"]) == gdal.CE_Failure
 
             got_data_before_advise_read = ar.Read(
@@ -3716,7 +3716,7 @@ def test_zarr_read_invalid_nczarr_dim():
 
         gdal.FileFromMemBuffer("/vsimem/test.zarr/OtherGroup/.zgroup", json.dumps(j))
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.OpenEx("/vsimem/test.zarr", gdal.OF_MULTIDIM_RASTER)
             assert ds
             rg = ds.GetRootGroup()
@@ -3768,7 +3768,7 @@ def test_zarr_read_nczar_repeated_array_names():
 
         gdal.FileFromMemBuffer("/vsimem/test.zarr/lon/.zarray", json.dumps(j))
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.OpenEx("/vsimem/test.zarr", gdal.OF_MULTIDIM_RASTER)
             assert ds
             rg = ds.GetRootGroup()
@@ -3806,7 +3806,7 @@ def test_zarr_read_test_overflow_in_AllocateWorkingBuffers_due_to_fortran():
         assert ds
         rg = ds.GetRootGroup()
         ar = rg.OpenMDArray("test")
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert ar.Read(count=[1, 1]) is None
 
     finally:
@@ -3838,7 +3838,7 @@ def test_zarr_read_test_overflow_in_AllocateWorkingBuffers_due_to_type_change():
         assert ds
         rg = ds.GetRootGroup()
         ar = rg.OpenMDArray("test")
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert ar.Read(count=[1, 1]) is None
 
     finally:
@@ -3904,7 +3904,7 @@ def test_zarr_resize(format, create_z_metadata):
             rg = ds.GetRootGroup()
             var = rg.OpenMDArray("test")
 
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 assert var.Resize([5, 2]) == gdal.CE_Failure
 
         resize_read_only()
@@ -3913,7 +3913,7 @@ def test_zarr_resize(format, create_z_metadata):
             ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER | gdal.OF_UPDATE)
             rg = ds.GetRootGroup()
             var = rg.OpenMDArray("test")
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 assert var.Resize([1, 2]) == gdal.CE_Failure, "shrinking not allowed"
 
             assert var.Resize([5, 2]) == gdal.CE_None
@@ -4004,7 +4004,7 @@ def test_zarr_resize_XARRAY(create_z_metadata):
             ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER | gdal.OF_UPDATE)
             rg = ds.GetRootGroup()
             var = rg.OpenMDArray("test")
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 assert var.Resize([1, 2]) == gdal.CE_Failure, "shrinking not allowed"
 
             dim0 = rg.OpenMDArray("dim0")
@@ -4097,7 +4097,7 @@ def test_zarr_resize_dim_referenced_twice():
             rg = ds.GetRootGroup()
             var = rg.OpenMDArray("test")
 
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 assert var.Resize([3, 4]) == gdal.CE_Failure
                 assert var.Resize([4, 3]) == gdal.CE_Failure
 

--- a/autotest/ogr/ogr_basic_test.py
+++ b/autotest/ogr/ogr_basic_test.py
@@ -463,7 +463,7 @@ def test_ogr_basic_12():
     f.SetField("fld", 0)
     f.SetField("fld", 1)
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f.SetField("fld", 2)
     assert gdal.GetLastErrorMsg() != ""
     assert isinstance(f.GetField("fld"), bool)
@@ -472,13 +472,13 @@ def test_ogr_basic_12():
     f.SetField("fld", "0")
     f.SetField("fld", "1")
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f.SetField("fld", "2")
     assert gdal.GetLastErrorMsg() != ""
     assert f.GetField("fld") == True
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         field_def = ogr.FieldDefn("fld", ogr.OFTString)
         field_def.SetSubType(ogr.OFSTBoolean)
     assert gdal.GetLastErrorMsg() != ""
@@ -494,7 +494,7 @@ def test_ogr_basic_12():
     f = ogr.Feature(feat_def)
     f.SetFieldIntegerList(0, [False, True])
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f.SetFieldIntegerList(0, [0, 1, 2, 1])
     assert gdal.GetLastErrorMsg() != ""
     for x in f.GetField("fld"):
@@ -513,18 +513,18 @@ def test_ogr_basic_12():
     f.SetField("fld", -32768)
     f.SetField("fld", 32767)
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f.SetField("fld", -32769)
     assert gdal.GetLastErrorMsg() != ""
     assert f.GetField("fld") == -32768
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f.SetField("fld", 32768)
     assert gdal.GetLastErrorMsg() != ""
     assert f.GetField("fld") == 32767
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         field_def = ogr.FieldDefn("fld", ogr.OFTString)
         field_def.SetSubType(ogr.OFSTInt16)
     assert gdal.GetLastErrorMsg() != ""
@@ -544,7 +544,7 @@ def test_ogr_basic_12():
         f.SetField("fld", "1.23")
         assert gdal.GetLastErrorMsg() == ""
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f.SetField("fld", 1.230000000001)
         assert gdal.GetLastErrorMsg() != ""
         if f.GetField("fld") == pytest.approx(1.23, abs=1e-8):
@@ -552,7 +552,7 @@ def test_ogr_basic_12():
             pytest.fail()
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         field_def = ogr.FieldDefn("fld", ogr.OFSTFloat32)
         field_def.SetSubType(ogr.OFSTInt16)
     assert gdal.GetLastErrorMsg() != ""
@@ -857,11 +857,11 @@ def test_ogr_basic_get_geometry_types():
         ogr.wkbTINZ: 1,
     }
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         with pytest.raises(Exception):
             lyr.GetGeometryTypes(callback=lambda x, y, z: 0)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         with pytest.raises(Exception):
             lyr.GetGeometryTypes(geom_field=2)
 

--- a/autotest/ogr/ogr_carto.py
+++ b/autotest/ogr/ogr_carto.py
@@ -422,7 +422,7 @@ Error""",
     lyr.ResetReading()
     f = lyr.GetNextFeature()
     assert f.GetFID() == 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     assert f is None
 
@@ -995,12 +995,12 @@ def ogr_carto_rw_1():
     lyr_name = "LAYER_" + a_uuid
 
     # No-op
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.CreateLayer(lyr_name)
     ds.DeleteLayer(ds.GetLayerCount() - 1)
 
     # Deferred table creation
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.CreateLayer(lyr_name)
     lyr.CreateField(ogr.FieldDefn("STRFIELD", ogr.OFTString))
     lyr.CreateField(ogr.FieldDefn("intfield", ogr.OFTInteger))

--- a/autotest/ogr/ogr_csv.py
+++ b/autotest/ogr/ogr_csv.py
@@ -58,13 +58,13 @@ def startup_and_cleanup():
     yield
 
     try:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ogr.GetDriverByName("CSV").DeleteDataSource("tmp/csvwrk")
     except Exception:
         pass
 
     try:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ogr.GetDriverByName("CSV").DeleteDataSource("tmp/ogr_csv_29")
     except Exception:
         pass
@@ -105,14 +105,14 @@ def ogr_csv_check_layer(lyr, expect_code_as_numeric):
 def test_ogr_csv_2():
     csv_ds = ogr.Open("data/prime_meridian.csv")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert csv_ds.CreateLayer("foo") is None
         assert csv_ds.DeleteLayer(0) != 0
 
     lyr = csv_ds.GetLayerByName("prime_meridian")
 
     f = ogr.Feature(lyr.GetLayerDefn())
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.CreateField(ogr.FieldDefn("foo")) != 0
         assert lyr.CreateFeature(f) != 0
 
@@ -172,7 +172,7 @@ def test_ogr_csv_3():
     #######################################################
     # Ensure any old copy of our working datasource is cleaned up
     try:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ogr.GetDriverByName("CSV").DeleteDataSource("tmp/csvwrk")
     except Exception:
         pass
@@ -190,7 +190,7 @@ def test_ogr_csv_3():
         # Check that we cannot add a new field now
         assert csv_lyr1.TestCapability(ogr.OLCCreateField) == 0
         field_defn = ogr.FieldDefn("dummy", ogr.OFTString)
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = csv_lyr1.CreateField(field_defn)
         assert ret != 0
 
@@ -254,7 +254,7 @@ def test_ogr_csv_7():
         csv_tmpds.GetLayerCount() == 1 and csv_tmpds.GetLayer(0).GetName() == "pm2"
     ), "Layer not destroyed properly?"
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert csv_tmpds.DeleteLayer(-1) != 0
         assert csv_tmpds.DeleteLayer(csv_tmpds.GetLayerCount()) != 0
 
@@ -473,7 +473,7 @@ def test_ogr_csv_12():
     # Setup Schema
     for i in range(srclyr.GetLayerDefn().GetFieldCount()):
         field_defn = srclyr.GetLayerDefn().GetFieldDefn(i)
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             csv_lyr2.CreateField(field_defn)
 
     #######################################################
@@ -491,7 +491,7 @@ def test_ogr_csv_12():
 
         feat = srclyr.GetNextFeature()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert csv_tmpds.CreateLayer("testcsvt_copy") is None
 
     #######################################################
@@ -766,7 +766,7 @@ def test_ogr_csv_19():
     lyr = csv_ds.GetLayerByName("testnull")
 
     lyr.ResetReading()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ogrtest.check_features_against_list(lyr, "INTCOL", [12])
     lyr.ResetReading()
     ogrtest.check_features_against_list(lyr, "REALCOL", [5.7])
@@ -1100,7 +1100,7 @@ def test_ogr_csv_29():
         )
         == 0
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             lyr.CreateGeomField(
                 ogr.GeomFieldDefn("geom__WKT_lyr2_EPSG_32632", ogr.wkbPolygon)
@@ -1247,7 +1247,7 @@ def test_ogr_csv_32():
 
     check_size_limit_0()
     with gdaltest.config_option("OGR_CSV_SIMULATE_VSISTDIN", "YES"):
-        with gdaltest.error_handler():  # a warning will be emitted
+        with gdal.quiet_errors():  # a warning will be emitted
             check_size_limit_0()
 
     # We limit to the first "1.5" line
@@ -1529,7 +1529,7 @@ def test_ogr_csv_32():
         )
         lyr = ds.GetLayer(0)
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             lyr.GetFeature(fid)
         if gdal.GetLastErrorType() != gdal.CE_Warning:
             f.DumpReadable()
@@ -2187,7 +2187,7 @@ def test_ogr_csv_43():
 
     assert lyr.TestCapability(ogr.OLCCreateField) == 1
     assert lyr.CreateField(ogr.FieldDefn("foo", ogr.OFTString)) == 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.CreateField(ogr.FieldDefn("foo", ogr.OFTString)) != 0
     f = lyr.GetFeature(1)
     f.SetField("foo", "bar")
@@ -2226,7 +2226,7 @@ def test_ogr_csv_43():
     assert f.GetGeometryRef().ExportToWkt() == "POINT (2 49)"
 
     # Invalid index
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.UpdateFeature(f, [-1], [], False) == ogr.OGRERR_FAILURE
         assert (
             lyr.UpdateFeature(f, [lyr.GetLayerDefn().GetFieldCount()], [], False)
@@ -2296,7 +2296,7 @@ def test_ogr_csv_43():
         pytest.fail()
     f = None
     assert lyr.TestCapability(ogr.OLCDeleteField) == 1
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.DeleteField(-1) != 0
     assert lyr.DeleteField(lyr.GetLayerDefn().GetFieldIndex("foo")) == 0
     assert lyr.TestCapability(ogr.OLCDeleteFeature) == 1
@@ -2341,9 +2341,9 @@ def test_ogr_csv_43():
     assert lyr.DeleteFeature(f.GetFID()) == 0
     assert lyr.GetFeatureCount() == 2
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.SetSpatialFilter(-1, None)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.SetSpatialFilter(1, None)
     lyr.SetSpatialFilterRect(0, 0, 100, 100)
     lyr.SetSpatialFilterRect(0, 0, 0, 100, 100)
@@ -2352,7 +2352,7 @@ def test_ogr_csv_43():
     assert lyr.GetFeatureCount() == 1
     assert lyr.GetExtent() == (2.0, 2.0, 49.0, 49.0)
     assert lyr.GetExtent(geom_field=0) == (2.0, 2.0, 49.0, 49.0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.GetExtent(geom_field=-1)
     lyr.SetAttributeFilter(None)
 
@@ -2367,13 +2367,13 @@ def test_ogr_csv_43():
 
     assert lyr.TestCapability(ogr.OLCReorderFields) == 1
     assert lyr.ReorderFields([0, 1]) == 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.ReorderFields([0, -1]) != 0
 
     assert lyr.TestCapability(ogr.OLCAlterFieldDefn) == 1
     fld_defn = lyr.GetLayerDefn().GetFieldDefn(0)
     assert lyr.AlterFieldDefn(0, fld_defn, 0) == 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.AlterFieldDefn(-1, fld_defn, 0) != 0
 
     f = lyr.GetFeature(2)
@@ -2663,7 +2663,7 @@ def test_ogr_csv_49():
 
 def test_ogr_csv_more_than_100_geom_fields():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("data/csv/more_than_100_geom_fields.csv")
     lyr = ds.GetLayer(0)
     lyr.GetNextFeature()
@@ -2938,7 +2938,7 @@ def test_ogr_csv_separator_with_other_sep(sep, other_sep):
         "/vsimem/test.csv", f"foo{sep}bar{other_sep}rr{sep}baz\n1{sep}2{sep}3\n"
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("/vsimem/test.csv")
         assert "other candidate separator" in gdal.GetLastErrorMsg()
     lyr = ds.GetLayer(0)

--- a/autotest/ogr/ogr_csw.py
+++ b/autotest/ogr/ogr_csw.py
@@ -105,7 +105,7 @@ def test_ogr_csw_vsimem_fail_because_empty_response():
     gdal.FileFromMemBuffer(
         "/vsimem/csw_endpoint?SERVICE=CSW&REQUEST=GetCapabilities", ""
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("CSW:/vsimem/csw_endpoint")
     assert ds is None
     assert gdal.GetLastErrorMsg().find("Empty content returned by server") >= 0
@@ -118,7 +118,7 @@ def test_ogr_csw_vsimem_fail_because_no_CSW_Capabilities():
     gdal.FileFromMemBuffer(
         "/vsimem/csw_endpoint?SERVICE=CSW&REQUEST=GetCapabilities", "<foo/>"
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("CSW:/vsimem/csw_endpoint")
     assert ds is None
     assert gdal.GetLastErrorMsg().find("Cannot find Capabilities.version") >= 0
@@ -132,7 +132,7 @@ def test_ogr_csw_vsimem_fail_because_exception():
         "/vsimem/csw_endpoint?SERVICE=CSW&REQUEST=GetCapabilities",
         "<ServiceExceptionReport/>",
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("CSW:/vsimem/csw_endpoint")
     assert ds is None
     assert (
@@ -150,7 +150,7 @@ def test_ogr_csw_vsimem_fail_because_invalid_xml_capabilities():
     gdal.FileFromMemBuffer(
         "/vsimem/csw_endpoint?SERVICE=CSW&REQUEST=GetCapabilities", "<invalid_xml"
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("CSW:/vsimem/csw_endpoint")
     assert ds is None
     assert gdal.GetLastErrorMsg().find("Invalid XML content : <invalid_xml") >= 0
@@ -166,7 +166,7 @@ def test_ogr_csw_vsimem_fail_because_missing_version():
 </Capabilities>
 """,
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("CSW:/vsimem/csw_endpoint")
     assert ds is None
     assert gdal.GetLastErrorMsg().find("Cannot find Capabilities.version") >= 0
@@ -191,11 +191,11 @@ def test_ogr_csw_vsimem_csw_minimal_instance():
 
     lyr = ds.GetLayer(0)
     lyr.TestCapability("foo")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     assert f is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fc = lyr.GetFeatureCount()
     assert fc == 0
 
@@ -204,7 +204,7 @@ def test_ogr_csw_vsimem_csw_minimal_instance():
         """""",
     )
     lyr.ResetReading()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     assert (
         f is None
@@ -216,7 +216,7 @@ def test_ogr_csw_vsimem_csw_minimal_instance():
         """<invalid_xml""",
     )
     lyr.ResetReading()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     assert f is None and gdal.GetLastErrorMsg().find("Error: cannot parse") >= 0
 
@@ -225,7 +225,7 @@ def test_ogr_csw_vsimem_csw_minimal_instance():
         """<dummy_xml/>""",
     )
     lyr.ResetReading()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     assert f is None and gdal.GetLastErrorMsg().find("Error: cannot parse") >= 0
 
@@ -234,7 +234,7 @@ def test_ogr_csw_vsimem_csw_minimal_instance():
         """<ServiceExceptionReport/>""",
     )
     lyr.ResetReading()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     assert f is None and gdal.GetLastErrorMsg().find("Error returned by server") >= 0
 
@@ -296,11 +296,11 @@ def test_ogr_csw_vsimem_csw_minimal_instance():
         pytest.fail()
     f = lyr.GetNextFeature()
     assert f is not None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     assert f is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fc = lyr.GetFeatureCount()
     assert fc == 2
 
@@ -355,7 +355,7 @@ def test_ogr_csw_vsimem_csw_minimal_instance():
         """/vsimem/csw_endpoint&POSTFIELDS=<?xml version="1.0" encoding="UTF-8"?><csw:GetRecords resultType="hits" service="CSW" version="2.0.2" xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:gml="http://www.opengis.net/gml" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:ogc="http://www.opengis.net/ogc" xmlns:ows="http://www.opengis.net/ows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd"><csw:Query typeNames="csw:Record"><csw:ElementSetName>full</csw:ElementSetName></csw:Query></csw:GetRecords>""",
         """""",
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fc = lyr.GetFeatureCount()
     assert fc == 3, gdal.GetLastErrorMsg()
 
@@ -363,7 +363,7 @@ def test_ogr_csw_vsimem_csw_minimal_instance():
         """/vsimem/csw_endpoint&POSTFIELDS=<?xml version="1.0" encoding="UTF-8"?><csw:GetRecords resultType="hits" service="CSW" version="2.0.2" xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:gml="http://www.opengis.net/gml" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:ogc="http://www.opengis.net/ogc" xmlns:ows="http://www.opengis.net/ows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd"><csw:Query typeNames="csw:Record"><csw:ElementSetName>full</csw:ElementSetName></csw:Query></csw:GetRecords>""",
         """<dummy_xml/>""",
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fc = lyr.GetFeatureCount()
     assert fc == 3, gdal.GetLastErrorMsg()
 
@@ -371,7 +371,7 @@ def test_ogr_csw_vsimem_csw_minimal_instance():
         """/vsimem/csw_endpoint&POSTFIELDS=<?xml version="1.0" encoding="UTF-8"?><csw:GetRecords resultType="hits" service="CSW" version="2.0.2" xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:gml="http://www.opengis.net/gml" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:ogc="http://www.opengis.net/ogc" xmlns:ows="http://www.opengis.net/ows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd"><csw:Query typeNames="csw:Record"><csw:ElementSetName>full</csw:ElementSetName></csw:Query></csw:GetRecords>""",
         """<invalid_xml>""",
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fc = lyr.GetFeatureCount()
     assert fc == 3, gdal.GetLastErrorMsg()
 
@@ -379,7 +379,7 @@ def test_ogr_csw_vsimem_csw_minimal_instance():
         """/vsimem/csw_endpoint&POSTFIELDS=<?xml version="1.0" encoding="UTF-8"?><csw:GetRecords resultType="hits" service="CSW" version="2.0.2" xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:gml="http://www.opengis.net/gml" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/" xmlns:ogc="http://www.opengis.net/ogc" xmlns:ows="http://www.opengis.net/ows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/cat/csw/2.0.2 http://schemas.opengis.net/csw/2.0.2/CSW-discovery.xsd"><csw:Query typeNames="csw:Record"><csw:ElementSetName>full</csw:ElementSetName></csw:Query></csw:GetRecords>""",
         """<ServiceExceptionReport/>""",
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fc = lyr.GetFeatureCount()
     assert fc == 3, gdal.GetLastErrorMsg()
 
@@ -474,7 +474,7 @@ def test_ogr_csw_vsimem_csw_output_schema_csw():
 """,
     )
     lyr.ResetReading()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     assert f is None
 
@@ -483,7 +483,7 @@ def test_ogr_csw_vsimem_csw_output_schema_csw():
         """<csw:GetRecordsResponse/>""",
     )
     lyr.ResetReading()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     assert f is None
 

--- a/autotest/ogr/ogr_dxf.py
+++ b/autotest/ogr/ogr_dxf.py
@@ -3060,7 +3060,7 @@ def test_ogr_dxf_44():
     with gdaltest.config_option("DXF_MAX_BSPLINE_CONTROL_POINTS", "1"):
         ds = ogr.Open("data/dxf/leader-mleader.dxf")
         lyr = ds.GetLayer(0)
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             lyr.GetFeatureCount()
         assert gdal.GetLastErrorMsg().find("DXF_MAX_BSPLINE_CONTROL_POINTS") >= 0
 
@@ -3926,7 +3926,7 @@ def test_ogr_dxf_55():
 ###############################################################################
 def test_ogr_dxf_insert_too_many_errors():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ogr.Open("data/dxf/insert-too-many-errors.dxf")
 
 
@@ -3940,7 +3940,7 @@ def test_ogr_dxf_write_geometry_collection_of_unsupported_type():
     lyr = ds.CreateLayer("test")
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometryDirectly(ogr.CreateGeometryFromWkt("GEOMETRYCOLLECTION(TIN EMPTY)"))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(f)
     assert ret != 0
     ds = None
@@ -3993,7 +3993,7 @@ def test_ogr_dxf_polygon_3D():
 def test_ogr_dxf_read_broken_file_1():
     """Test that we don't crash"""
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open(
             "data/dxf/clusterfuzz-testcase-minimized-dxf_fuzzer-5400376672124928.dxf"
         )
@@ -4008,7 +4008,7 @@ def test_ogr_dxf_read_broken_file_1():
 def test_ogr_dxf_read_broken_file_2():
     """Test that we don't crash"""
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open(
             "data/dxf/clusterfuzz-testcase-minimized-shape_fuzzer-6126814756995072.dxf"
         )

--- a/autotest/ogr/ogr_elasticsearch.py
+++ b/autotest/ogr/ogr_elasticsearch.py
@@ -104,29 +104,29 @@ def startup_and_cleanup():
 
 def test_ogr_elasticsearch_nonexistent_server():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogrtest.elasticsearch_drv.CreateDataSource("/vsimem/nonexistent_host")
     assert ds is None, "managed to open nonexistent Elasticsearch datastore."
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogrtest.elasticsearch_drv.Open("ES:/vsimem/nonexistent_host")
     assert ds is None, "managed to open nonexistent Elasticsearch datastore."
 
     gdal.FileFromMemBuffer("/vsimem/fakeelasticsearch", """{}""")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogrtest.elasticsearch_drv.Open("ES:/vsimem/fakeelasticsearch")
     assert ds is None, "managed to open invalid Elasticsearch datastore."
 
     gdal.FileFromMemBuffer("/vsimem/fakeelasticsearch", """{"version":null}""")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogrtest.elasticsearch_drv.Open("ES:/vsimem/fakeelasticsearch")
     assert ds is None, "managed to open invalid Elasticsearch datastore."
 
     gdal.FileFromMemBuffer("/vsimem/fakeelasticsearch", """{"version":{}}""")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogrtest.elasticsearch_drv.Open("ES:/vsimem/fakeelasticsearch")
     assert ds is None, "managed to open invalid Elasticsearch datastore."
 
@@ -134,7 +134,7 @@ def test_ogr_elasticsearch_nonexistent_server():
         "/vsimem/fakeelasticsearch", """{"version":{"number":null}}"""
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogrtest.elasticsearch_drv.Open("ES:/vsimem/fakeelasticsearch")
     assert ds is None, "managed to open invalid Elasticsearch datastore."
 
@@ -157,7 +157,7 @@ def test_ogr_elasticsearch_1():
     assert ds.TestCapability(ogr.ODsCCreateGeomFieldAfterCreateLayer) != 0
 
     # Failed index creation
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.CreateLayer("foo", srs=ogrtest.srs_wgs84, options=["FID="])
     assert lyr is None
     assert gdal.GetLastErrorType() == gdal.CE_Failure
@@ -186,7 +186,7 @@ def test_ogr_elasticsearch_1():
     gdal.FileFromMemBuffer(
         "/vsimem/fakeelasticsearch/foo", '{"foo":{"mappings":{"FeatureCollection":{}}}}'
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.CreateLayer("foo", geom_type=ogr.wkbNone, options=["OVERWRITE=TRUE"])
     assert gdal.GetLastErrorType() == gdal.CE_Failure
     gdal.ErrorReset()
@@ -223,7 +223,7 @@ def test_ogr_elasticsearch_1():
         "/vsimem/fakeelasticsearch/foo&CUSTOMREQUEST=PUT",
         '{"error":"IndexAlreadyExistsException[[foo] already exists]","status":400}',
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.CreateLayer("foo", srs=ogrtest.srs_wgs84)
     assert gdal.GetLastErrorType() == gdal.CE_Failure
     assert lyr is None
@@ -294,7 +294,7 @@ def test_ogr_elasticsearch_1():
     feat.SetGeometry(ogr.CreateGeometryFromWkt("POINT(0 1)"))
 
     # Simulate server error
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(feat)
     assert ret != 0
 
@@ -329,13 +329,13 @@ def test_ogr_elasticsearch_1():
 
     # Failed SetFeature because of missing _id
     feat = ogr.Feature(lyr.GetLayerDefn())
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetFeature(feat)
     assert ret != 0
 
     # Simulate server error
     feat["_id"] = "my_id"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetFeature(feat)
     assert ret != 0
 
@@ -370,7 +370,7 @@ def test_ogr_elasticsearch_1():
 
     # Test explicit MAPPING first with error case
     gdal.FileFromMemBuffer("/vsimem/fakeelasticsearch/foo4&CUSTOMREQUEST=PUT", "{}")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.CreateLayer(
             "foo4",
             srs=ogrtest.srs_wgs84,
@@ -517,7 +517,7 @@ def test_ogr_elasticsearch_3():
     assert ret == 0
     feat = None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SyncToDisk()
     assert ret != 0
 
@@ -545,7 +545,7 @@ def test_ogr_elasticsearch_3():
 
 def test_ogr_elasticsearch_4():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("ES:/vsimem/fakeelasticsearch")
     assert ds is not None
 
@@ -630,7 +630,7 @@ def test_ogr_elasticsearch_4():
     assert lyr is not None
     lyr = ds.GetLayerByName("a_layer")
     assert lyr is not None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.GetLayerByName("not_a_layer")
     assert lyr is None
     ds = None
@@ -640,7 +640,7 @@ def test_ogr_elasticsearch_4():
     assert ds.GetLayerCount() == 1
     ds = None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             "ES:/vsimem/fakeelasticsearch", open_options=["LAYER=not_a_layer"]
         )
@@ -664,7 +664,7 @@ def test_ogr_elasticsearch_4():
     assert ds.GetLayerCount() == 1
     lyr = ds.GetLayer(0)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr_defn = lyr.GetLayerDefn()
     idx = lyr_defn.GetFieldIndex("strlist_field")
     assert lyr_defn.GetFieldDefn(idx).GetType() == ogr.OFTStringList
@@ -677,7 +677,7 @@ def test_ogr_elasticsearch_4():
         """{
 }""",
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.GetFeatureCount()
 
     gdal.FileFromMemBuffer(
@@ -686,7 +686,7 @@ def test_ogr_elasticsearch_4():
     "hits": null
 }""",
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.GetFeatureCount()
 
     gdal.FileFromMemBuffer(
@@ -695,7 +695,7 @@ def test_ogr_elasticsearch_4():
     "hits": { "count": null }
 }""",
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.GetFeatureCount()
 
     gdal.FileFromMemBuffer(
@@ -710,7 +710,7 @@ def test_ogr_elasticsearch_4():
     fc = lyr.GetFeatureCount()
     assert fc == 3
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     assert f is None
 
@@ -991,7 +991,7 @@ def test_ogr_elasticsearch_4():
 
     lyr.SetSpatialFilter(None)
     lyr.SetSpatialFilterRect(-180, -90, 180, 90)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.SetSpatialFilter(-1, None)
         lyr.SetSpatialFilter(2, None)
 
@@ -1081,18 +1081,18 @@ def test_ogr_elasticsearch_4():
     ds.ReleaseResultSet(sql_lyr)
 
     # Invalid index
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         bbox = lyr.GetExtent(geom_field=-1)
 
     # geo_shape
     bbox = lyr.GetExtent(geom_field=0)
 
     # Invalid index
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         bbox = lyr.GetExtent(geom_field=2)
 
     # No response
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         bbox = lyr.GetExtent(geom_field=1)
 
     # Invalid response
@@ -1114,7 +1114,7 @@ def test_ogr_elasticsearch_4():
 }""",
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         bbox = lyr.GetExtent(geom_field=1)
 
     # Valid response
@@ -1141,33 +1141,33 @@ def test_ogr_elasticsearch_4():
     assert bbox == (1.0, 2.0, 9.0, 10.0)
 
     # Operations not available in read-only mode
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateField(ogr.FieldDefn("foo", ogr.OFTString))
     assert ret != 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateGeomField(ogr.GeomFieldDefn("shape", ogr.wkbPoint))
     assert ret != 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(ogr.Feature(lyr.GetLayerDefn()))
     assert ret != 0
 
     lyr.ResetReading()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetFeature(lyr.GetNextFeature())
     assert ret != 0
 
     lyr.ResetReading()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.UpsertFeature(lyr.GetNextFeature())
     assert ret != 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.CreateLayer("will_not_work")
     assert lyr is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.DeleteLayer(0)
     assert ret != 0
 
@@ -1365,7 +1365,7 @@ def test_ogr_elasticsearch_5():
 
     f = None
     lyr.CreateField(ogr.FieldDefn("superobject.subfield2", ogr.OFTString))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.CreateGeomField(
             ogr.GeomFieldDefn("superobject.another_geoshape3", ogr.wkbPoint)
         )
@@ -1604,7 +1604,7 @@ def test_ogr_elasticsearch_8():
     gdal.FileFromMemBuffer("/vsimem/fakeelasticsearch/no_srs&CUSTOMREQUEST=PUT", "{}")
     # Will emit a warning
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.CreateLayer("no_srs")
     assert gdal.GetLastErrorType() == gdal.CE_Warning, "warning expected"
     f = ogr.Feature(lyr.GetLayerDefn())
@@ -1622,7 +1622,7 @@ def test_ogr_elasticsearch_8():
     )
     # Will emit a warning
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(f)
     assert gdal.GetLastErrorType() == gdal.CE_Warning, "warning expected"
     assert ret == 0

--- a/autotest/ogr/ogr_esrijson.py
+++ b/autotest/ogr/ogr_esrijson.py
@@ -494,7 +494,7 @@ def test_ogr_esrijson_featureservice_scrolling(prefix):
             gdal.FileFromMemBuffer(
                 "/vsimem/esrijson/test.json?resultRecordCount=10", resultOffset0
             )
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ds = ogr.Open("/vsimem/esrijson/test.json?resultRecordCount=10")
             lyr = ds.GetLayer(0)
             f = lyr.GetNextFeature()
@@ -544,7 +544,7 @@ def test_ogr_esrijson_featureservice_scrolling(prefix):
             f = lyr.GetNextFeature()
             assert f is None
 
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 fc = lyr.GetFeatureCount()
             assert fc == 2
 
@@ -555,7 +555,7 @@ def test_ogr_esrijson_featureservice_scrolling(prefix):
             fc = lyr.GetFeatureCount()
             assert fc == 123456
 
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 extent = lyr.GetExtent()
             assert extent == (2, 2, 49, 49)
 

--- a/autotest/ogr/ogr_factory.py
+++ b/autotest/ogr/ogr_factory.py
@@ -257,7 +257,7 @@ def test_ogr_factory_6():
         ogr.ForceToMultiLineString(src_geom)
         ogr.ForceToLineString(src_geom)
         for target_type in range(ogr.wkbMultiSurface):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ogr.ForceTo(src_geom, 1 + target_type)
         # print(src_geom.ExportToWkt(), dst_geom1.ExportToWkt(), dst_geom2.ExportToWkt(), dst_geom3.ExportToWkt(), dst_geom4.ExportToWkt())
 

--- a/autotest/ogr/ogr_feature.py
+++ b/autotest/ogr/ogr_feature.py
@@ -29,7 +29,6 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
-import gdaltest
 import pytest
 
 from osgeo import gdal, ogr
@@ -128,7 +127,7 @@ def test_ogr_feature_cp_integer():
     src_feature.field_reallist = [17.5]
 
     dst_feature = mk_dst_feature(src_feature, ogr.OFTInteger)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         dst_feature.SetFrom(src_feature)
 
     assert dst_feature.GetField("field_integer") == 17
@@ -178,7 +177,7 @@ def test_ogr_feature_cp_integer64():
     assert dst_feature.GetField("field_integer") == 17
     assert dst_feature.GetField("field_integer64") == 9876543210
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         int32_ovflw = dst_feature.GetFieldAsInteger("field_integer64")
     assert int32_ovflw == 2147483647
 
@@ -204,7 +203,7 @@ def test_ogr_feature_cp_real():
     src_feature.field_reallist = [17.5]
 
     dst_feature = mk_dst_feature(src_feature, ogr.OFTReal)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         dst_feature.SetFrom(src_feature)
 
     assert dst_feature.GetField("field_integer") == 17.0
@@ -357,7 +356,7 @@ def test_ogr_feature_cp_integerlist():
     src_feature = mk_src_feature()
 
     dst_feature = mk_dst_feature(src_feature, ogr.OFTIntegerList)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         dst_feature.SetFrom(src_feature)
 
     assert dst_feature.GetField("field_integer") == [17]
@@ -493,12 +492,12 @@ def test_ogr_feature_overflow_64bit_integer():
     feat_def = ogr.FeatureDefn("test")
     feat_def.AddFieldDefn(ogr.FieldDefn("test", ogr.OFTInteger64))
     f = ogr.Feature(feat_def)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f.SetField(0, "9999999999999999999")
     if f.GetField(0) != 9223372036854775807:
         f.DumpReadable()
         pytest.fail()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f.SetField(0, "-9999999999999999999")
     if f.GetField(0) != -9223372036854775808:
         f.DumpReadable()
@@ -812,13 +811,13 @@ def test_ogr_feature_int32_overflow():
     feat_def.AddFieldDefn(field_def)
     f = ogr.Feature(feat_def)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.ErrorReset()
         f.SetField("field", "123456789012345")
         assert gdal.GetLastErrorMsg() != ""
         assert f.GetField("field") == 2147483647
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.ErrorReset()
         f.SetField("field", "-123456789012345")
         assert gdal.GetLastErrorMsg() != ""
@@ -876,7 +875,7 @@ def test_ogr_feature_set_boolean_through_string_warning(input_val, output_val):
     f = ogr.Feature(feat_def)
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f.SetField("field", input_val)
     assert gdal.GetLastErrorMsg() != ""
     assert f.GetField("field") == output_val

--- a/autotest/ogr/ogr_fgdb.py
+++ b/autotest/ogr/ogr_fgdb.py
@@ -135,7 +135,7 @@ def fgdb_sdk_1_4_or_later(fgdb_drv):
     ds = fgdb_drv.CreateDataSource("tmp/ogr_fgdb_is_sdk_1_4_or_later.gdb")
     srs = osr.SpatialReference()
     srs.ImportFromProj4("+proj=tmerc +datum=WGS84 +no_defs")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.CreateLayer("test", srs=srs, geom_type=ogr.wkbPoint)
     if lyr is not None:
         fgdb_is_sdk_1_4 = True
@@ -644,7 +644,7 @@ def test_ogr_fgdb_8(fgdb_drv):
 
     ds = fgdb_drv.CreateDataSource("tmp/test.gdb")
     lyr = ds.CreateLayer("test", srs=srs, geom_type=ogr.wkbPoint)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.CreateField(ogr.FieldDefn("FROM", ogr.OFTInteger))  # reserved keyword
         lyr.CreateField(
             ogr.FieldDefn("1NUMBER", ogr.OFTInteger)
@@ -715,7 +715,7 @@ def test_ogr_fgdb_9(fgdb_drv):
     ]
 
     ds = fgdb_drv.CreateDataSource("tmp/test.gdb")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         for in_name in in_names:
             lyr = ds.CreateLayer(in_name, srs=srs, geom_type=ogr.wkbPoint)
 
@@ -795,19 +795,19 @@ def test_ogr_fgdb_10(fgdb_drv):
     lyr = ds.CreateLayer("srs_approx_4230", srs=srs_approx_4230, geom_type=ogr.wkbPoint)
 
     # will fail
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.CreateLayer(
             "srs_approx_intl", srs=srs_approx_intl, geom_type=ogr.wkbPoint
         )
 
     # will fail: 4233 doesn't exist in DB
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.CreateLayer(
             "srs_exact_4233", srs=srs_exact_4233, geom_type=ogr.wkbPoint
         )
 
     # will fail
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.CreateLayer("srs_not_in_db", srs=srs_not_in_db, geom_type=ogr.wkbPoint)
 
     ds = None
@@ -933,7 +933,7 @@ def test_ogr_fgdb_12():
 
     os.mkdir("tmp/dummy.gdb")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("tmp/dummy.gdb")
     assert ds is None
 
@@ -946,14 +946,14 @@ def test_ogr_fgdb_12():
 
 def test_ogr_fgdb_13(fgdb_drv):
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = fgdb_drv.CreateDataSource("tmp/foo")
     assert ds is None
 
     f = open("tmp/dummy.gdb", "wb")
     f.close()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = fgdb_drv.CreateDataSource("tmp/dummy.gdb")
     assert ds is None
 
@@ -969,11 +969,11 @@ def test_ogr_fgdb_13(fgdb_drv):
     else:
         name = "/proc/dummy.gdb"
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = fgdb_drv.CreateDataSource(name)
     assert ds is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = fgdb_drv.DeleteDataSource(name)
     assert ret != 0
 
@@ -1081,7 +1081,7 @@ def test_ogr_fgdb_17(fgdb_drv):
     # Error case: missing geometry
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetField("field_not_nullable", "not_null")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(f)
     assert ret != 0
     f = None
@@ -1089,7 +1089,7 @@ def test_ogr_fgdb_17(fgdb_drv):
     # Error case: missing non-nullable field
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometryDirectly(ogr.CreateGeometryFromWkt("POINT(0 0)"))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(f)
     assert ret != 0
     f = None
@@ -1269,7 +1269,7 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
 
     # Error case: try in read-only
     ds = fgdb_drv.Open("tmp/test.gdb")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.StartTransaction(force=True)
     assert ret != 0
     ds = None
@@ -1281,30 +1281,30 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
     assert ds.TestCapability(ogr.ODsCEmulatedTransactions) == 1
 
     # Error case: try in non-forced mode
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.StartTransaction(force=False)
     assert ret != 0
 
     # Error case: try StartTransaction() with a ExecuteSQL layer still active
     sql_lyr = ds.ExecuteSQL("SELECT * FROM test")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.StartTransaction(force=True)
     assert ret != 0
     ds.ReleaseResultSet(sql_lyr)
 
     # Error case: call CommitTransaction() while there is no transaction
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.CommitTransaction()
     assert ret != 0
 
     # Error case: call RollbackTransaction() while there is no transaction
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.RollbackTransaction()
     assert ret != 0
 
     # Error case: try StartTransaction() with another active connection
     ds2 = fgdb_drv.Open("tmp/test.gdb", update=1)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds2.StartTransaction(force=True)
     assert ret != 0
     ds2 = None
@@ -1332,15 +1332,15 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
     ret = lyr.DeleteField(lyr.GetLayerDefn().GetFieldIndex("foobar"))
     assert ret == 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateGeomField(ogr.GeomFieldDefn("foobar", ogr.wkbPoint))
     assert ret != 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.ReorderFields([i for i in range(lyr.GetLayerDefn().GetFieldCount())])
     assert ret != 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.AlterFieldDefn(0, ogr.FieldDefn("foo", ogr.OFTString), 0)
     assert ret != 0
 
@@ -1361,20 +1361,20 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
     layer_created_before_transaction.CreateFeature(f)
 
     # Error case: call StartTransaction() while there is an active transaction
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.StartTransaction(force=True)
     assert ret != 0
 
     # Error case: try CommitTransaction() with a ExecuteSQL layer still active
     sql_lyr = ds.ExecuteSQL("SELECT * FROM test")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.CommitTransaction()
     assert ret != 0
     ds.ReleaseResultSet(sql_lyr)
 
     # Error case: try RollbackTransaction() with a ExecuteSQL layer still active
     sql_lyr = ds.ExecuteSQL("SELECT * FROM test")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.RollbackTransaction()
     assert ret != 0
     ds.ReleaseResultSet(sql_lyr)
@@ -1827,14 +1827,14 @@ def test_ogr_fgdb_20(openfilegdb_drv, fgdb_drv):
     )
 
     # Existing FID
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(f)
     assert ret != 0
 
     for invalid_fid in [-2, 0, 9876543210]:
         f = ogr.Feature(lyr.GetLayerDefn())
         f.SetFID(invalid_fid)
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = lyr.CreateFeature(f)
         assert ret != 0, invalid_fid
 
@@ -1857,7 +1857,7 @@ def test_ogr_fgdb_20(openfilegdb_drv, fgdb_drv):
 
     # Cannot call CreateFeature() with a set FID when a dataset is opened more than once
     ds2 = fgdb_drv.Open("tmp/test.gdb", update=1)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(f)
     assert ret != 0
     ds2 = None
@@ -1872,13 +1872,13 @@ def test_ogr_fgdb_20(openfilegdb_drv, fgdb_drv):
         pytest.fail(lyr.GetMetadataItem("4", "MAP_OGR_FID_TO_FGDB_FID"))
 
     #  Cannot open geodatabase at the moment since it is in 'FID hack mode'
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds2 = fgdb_drv.Open("tmp/test.gdb", update=1)
     assert ds2 is None
     ds2 = None
 
     # Existing FID, but only in OGR space
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(f)
     assert ret != 0
 
@@ -2045,7 +2045,7 @@ def test_ogr_fgdb_20(openfilegdb_drv, fgdb_drv):
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetFID(3)
     f.SetField("id", 3)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(f)
     assert ret != 0
 
@@ -2219,7 +2219,7 @@ def test_ogr_fgdb_20(openfilegdb_drv, fgdb_drv):
         f.SetField("id", 2)
         lyr.CreateFeature(f)
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             with gdal.config_option("FGDB_SIMUL_FAIL_REOPEN", case):
                 sql_lyr = ds.ExecuteSQL("SELECT * FROM foo")
         if case == "CASE3":
@@ -2574,7 +2574,7 @@ def _check_domains(ds):
         "SpeedLimit",
     }
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.GetFieldDomain("i_dont_exist") is None
     lyr = ds.GetLayer(0)
     lyr_defn = lyr.GetLayerDefn()
@@ -2747,10 +2747,10 @@ def test_ogr_fgdb_rename_layer(fgdb_drv, options):
     assert lyr.GetDescription() == "bar"
     assert lyr.GetLayerDefn().GetName() == "bar"
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.Rename("bar") != ogr.OGRERR_NONE
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.Rename("other_layer") != ogr.OGRERR_NONE
 
     # Second renaming
@@ -3102,7 +3102,7 @@ def test_ogr_filegdb_incompatible_geometry_types(fgdb_drv, layer_geom_type, wkt)
     lyr = ds.CreateLayer("test", srs=srs, geom_type=layer_geom_type)
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometryDirectly(ogr.CreateGeometryFromWkt(wkt))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.CreateFeature(f) == ogr.OGRERR_FAILURE
     ds = None
 

--- a/autotest/ogr/ogr_fgdb_stress_test.py
+++ b/autotest/ogr/ogr_fgdb_stress_test.py
@@ -33,7 +33,6 @@
 import random
 import shutil
 
-import gdaltest
 import ogrtest
 import pytest
 
@@ -118,7 +117,7 @@ def test_ogr_fgdb_stress_1():
                 f.SetFID(fid)
                 f.SetField(0, "%d" % random.randrange(0, 1000))
                 f.SetGeometry(ogr.CreateGeometryFromWkt(wkt))
-                with gdaltest.error_handler():
+                with gdal.quiet_errors():
                     ret.append(lyr.CreateFeature(f))
                 # So to ensure lyr_ref will use the same FID as the tested layer
                 fid = f.GetFID()

--- a/autotest/ogr/ogr_fielddomain.py
+++ b/autotest/ogr/ogr_fielddomain.py
@@ -28,7 +28,6 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
-import gdaltest
 import pytest
 
 from osgeo import gdal, ogr
@@ -41,7 +40,7 @@ def test_ogr_fielddomain_range():
             None, "desc", ogr.OFTInteger, ogr.OFSTNone, 1, True, 2, True
         )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             ogr.CreateRangeFieldDomain(
                 "name", "desc", ogr.OFTString, ogr.OFSTNone, 1, True, 2, True
@@ -129,7 +128,7 @@ def test_ogr_fielddomain_range():
     assert "Maximum value: 2023-07-03T12:13:15" in ret
 
     with pytest.raises(Exception):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             domain.GetEnumeration()
 
     with pytest.raises(Exception):

--- a/autotest/ogr/ogr_flatgeobuf.py
+++ b/autotest/ogr/ogr_flatgeobuf.py
@@ -328,7 +328,7 @@ def test_ogr_flatgeobuf_9():
 def test_ogr_flatgeobuf_directory():
 
     ds = ogr.GetDriverByName("FlatGeobuf").CreateDataSource("/vsimem/multi_layer")
-    with gdaltest.error_handler():  # name will be laundered
+    with gdal.quiet_errors():  # name will be laundered
         ds.CreateLayer("foo<", geom_type=ogr.wkbPoint)
     ds.CreateLayer("bar", geom_type=ogr.wkbPoint)
     ds = None
@@ -648,7 +648,7 @@ def test_ogr_flatgeobuf_huge_number_of_columns():
             lyr.CreateField(ogr.FieldDefn("col%d" % i, ogr.OFTInteger))
             == ogr.OGRERR_NONE
         ), i
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             lyr.CreateField(ogr.FieldDefn("col65536", ogr.OFTInteger))
             == ogr.OGRERR_FAILURE
@@ -797,7 +797,7 @@ def test_ogr_flatgeobuf_editing():
 
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (1 1)"))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.CreateFeature(f) != ogr.OGRERR_NONE
 
     ogr.GetDriverByName("FlatGeobuf").DeleteDataSource("/vsimem/test.fgb")
@@ -868,7 +868,7 @@ def test_ogr_flatgeobuf_ossfuzz_bug_29462():
     ],
 )
 def test_ogr_flatgeobuf_read_invalid_geometries(filename):
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(filename)
         lyr = ds.GetLayer(0)
         for f in lyr:
@@ -959,7 +959,7 @@ def test_ogr_flatgeobuf_coordinate_epoch_custom_wkt():
 def test_ogr_flatgeobuf_invalid_output_filename():
 
     ds = ogr.GetDriverByName("FlatGeobuf").CreateDataSource("/i_do/not_exist/my.fgb")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.CreateLayer("foo") is None
 
 

--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -461,7 +461,7 @@ def test_ogr_geojson_13():
 @gdaltest.disable_exceptions()
 def test_ogr_geojson_14():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("data/geojson/ogr_geojson_14.geojson")
     lyr = ds.GetLayer(0)
 
@@ -471,7 +471,7 @@ def test_ogr_geojson_14():
         )
         out_lyr = out_ds.CreateLayer("lyr")
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             for feat in lyr:
                 geom = feat.GetGeometryRef()
                 if geom is not None:
@@ -550,7 +550,7 @@ def test_ogr_geojson_20():
         gdal.VSIFWriteL(data, 1, len(data), f)
         gdal.VSIFCloseL(f)
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = ogr.Open("/vsimem/testgj")
         if ds is None:
             print(gj)
@@ -803,7 +803,7 @@ def test_ogr_geojson_26():
 
 def test_ogr_geojson_27():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # Warning 1: Integer values probably ranging out of 64bit integer range
         # have been found. Will be clamped to INT64_MIN/INT64_MAX
         ds = ogr.Open(
@@ -849,7 +849,7 @@ def test_ogr_geojson_35():
     feat.SetGeometry(geom)
     lyr.CreateFeature(feat)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         feat = ogr.Feature(lyr.GetLayerDefn())
         feat.SetFID(2)
         geom = ogr.Geometry(ogr.wkbPoint)
@@ -1189,7 +1189,7 @@ def test_ogr_geojson_39():
 
     # Test handling of duplicated id
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open(
             """{"type": "FeatureCollection", "features": [
 { "type": "Feature", "id" : 1, "properties": { "foo": "bar" }, "geometry": null },
@@ -1604,7 +1604,7 @@ def test_ogr_geojson_46():
 def test_ogr_geojson_47():
 
     # ERROR 6: Update from inline definition not supported
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open('{"type": "FeatureCollection", "features":[]}', update=1)
     assert ds is None
 
@@ -2904,12 +2904,12 @@ def test_ogr_geojson_62():
         """{ "type": "FeatureCollection", "crs": { "type":"EPSG", "properties":{"code":null} }, "features":[] }"""
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.OpenEx(
             """{ "type": "FeatureCollection", "crs": { "type":"EPSG", "properties":{"code":1} }, "features":[] }"""
         )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.OpenEx(
             """{ "type": "FeatureCollection", "crs": { "type":"EPSG", "properties":{"code":"x"} }, "features":[] }"""
         )
@@ -2938,12 +2938,12 @@ def test_ogr_geojson_62():
         """{ "type": "FeatureCollection", "crs": { "type":"link", "properties":{"href":null} }, "features":[] }"""
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.OpenEx(
             """{ "type": "FeatureCollection", "crs": { "type":"link", "properties":{"href":1} }, "features":[] }"""
         )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.OpenEx(
             """{ "type": "FeatureCollection", "crs": { "type":"link", "properties":{"href": "1"} }, "features":[] }"""
         )
@@ -2965,12 +2965,12 @@ def test_ogr_geojson_62():
         """{ "type": "FeatureCollection", "crs": { "type":"OGC", "properties":{"urn":null} }, "features":[] }"""
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.OpenEx(
             """{ "type": "FeatureCollection", "crs": { "type":"OGC", "properties":{"urn":1} }, "features":[] }"""
         )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.OpenEx(
             """{ "type": "FeatureCollection", "crs": { "type":"OGC", "properties":{"urn":"x"} }, "features":[] }"""
         )
@@ -3305,7 +3305,7 @@ def test_ogr_geojson_geom_export_failure():
 
     g = ogr.Geometry(ogr.wkbLineString)
     g.AddPoint_2D(float("nan"), 0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         geojson = g.ExportToJson()
     assert geojson is None
 
@@ -3322,7 +3322,7 @@ def test_ogr_geojson_geom_export_failure():
     lr.AddPoint_2D(1, 1)
     lr.AddPoint_2D(0, 0)
     g.AddGeometry(lr)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         geojson = g.ExportToJson()
     assert geojson is None
 
@@ -3474,7 +3474,7 @@ def test_ogr_geojson_non_finite():
       { "type": "Feature", "properties": { "inf_prop": infinity, "minus_inf_prop": -infinity, "nan_prop": nan }, "geometry": null }
   ]
 }"""
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open(json_content)
     if ds is None:
         # Might fail with older libjson-c versions
@@ -3497,7 +3497,7 @@ def test_ogr_geojson_non_finite():
 
     tmpfilename = "/vsimem/out.json"
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.VectorTranslate(tmpfilename, json_content, options="-f GeoJSON")
     ds = ogr.Open(tmpfilename)
     lyr = ds.GetLayer(0)
@@ -3960,7 +3960,7 @@ def test_ogr_geojson_feature_large():
     with gdaltest.config_option("OGR_GEOJSON_MAX_OBJ_SIZE", "0"):
         assert ogr.Open(filename) is not None
     with gdaltest.config_option("OGR_GEOJSON_MAX_OBJ_SIZE", "0.1"):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert ogr.Open(filename) is None
     gdal.Unlink(filename)
 
@@ -4072,7 +4072,7 @@ def test_ogr_geojson_ids_0_1_null_1_null(read_from_file):
     connection_name = "data/geojson/ids_0_1_null_1_null.json"
     if not read_from_file:
         connection_name = open(connection_name, "rb").read().decode("ascii")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.ErrorReset()
         ds = ogr.Open(connection_name)
         assert ds

--- a/autotest/ogr/ogr_geojsonseq.py
+++ b/autotest/ogr/ogr_geojsonseq.py
@@ -218,7 +218,7 @@ def test_ogr_geojsonseq_seq_geometries():
 @gdaltest.disable_exceptions()
 def test_ogr_geojsonseq_seq_geometries_with_errors():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open(
             """{"type":"Point","coordinates":[2,49]}
     {"type":"Point","coordinates":[3,50]}
@@ -314,7 +314,7 @@ def test_ogr_geojsonseq_feature_large():
     with gdaltest.config_option("OGR_GEOJSON_MAX_OBJ_SIZE", "0"):
         assert ogr.Open(filename) is not None
     with gdaltest.config_option("OGR_GEOJSON_MAX_OBJ_SIZE", "0.1"):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert ogr.Open(filename) is None
     gdal.Unlink(filename)
 

--- a/autotest/ogr/ogr_geom.py
+++ b/autotest/ogr/ogr_geom.py
@@ -187,7 +187,7 @@ def test_ogr_geom_pickle():
     geom_wkt = "MULTIPOLYGON( ((0 0,1 1,1 0,0 0)),((0 0,10 0, 10 10, 0 10),(1 1,1 2,2 2,2 1)) )"
     geom = ogr.CreateGeometryFromWkt(geom_wkt)
     p = pickle.dumps(geom)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         g = pickle.loads(p)
 
     assert geom.Equal(g), "pickled geometries were not equal"
@@ -344,7 +344,7 @@ def test_ogr_geom_tin():
 
     wrong_polygon = ogr.CreateGeometryFromWkt("POLYGON ((0 0 0,0 1 0,1 1 0,0 0 1))")
     geom_count = tin.GetGeometryCount()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         x = tin.AddGeometry(wrong_polygon)
     assert (
         tin.GetGeometryCount() == geom_count
@@ -372,18 +372,18 @@ def test_ogr_geom_tin():
 
     # 4 points
     invalid_wkt = "TIN (((0 0,0 1,1 1,1 0,0 0)))"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         g = ogr.CreateGeometryFromWkt(invalid_wkt)
     assert g is None
 
     # hole
     invalid_wkt = "TIN(((0 0,0 1,1 1,0 0),(0.1 0.1,0.1 0.2,0.2 0.2,0.1 0.1)))"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         g = ogr.CreateGeometryFromWkt(invalid_wkt)
     assert g is None
 
     invalid_wkt = "TIN (POLYGON((0 0,0 1,1 1,0 0)))"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         g = ogr.CreateGeometryFromWkt(invalid_wkt)
     assert g is None
 
@@ -544,7 +544,7 @@ def test_ogr_geom_build_from_edges_3():
 
     src_geom = ogr.CreateGeometryFromWkt("POINT (0 1)")
     try:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             poly = ogr.BuildPolygonFromEdges(src_geom)
         assert poly is None
     except Exception:
@@ -554,7 +554,7 @@ def test_ogr_geom_build_from_edges_3():
         "GEOMETRYCOLLECTION (LINESTRING(0 1,2 3),POINT(0 1),LINESTRING(0 1,-2 3),LINESTRING(-2 3,2 3))"
     )
     try:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             poly = ogr.BuildPolygonFromEdges(src_geom)
         assert poly is None
     except Exception:
@@ -641,7 +641,7 @@ def test_ogr_geom_transform_to():
     # Geometry without SRS
     geom = ogr.CreateGeometryFromWkt("POINT(2 49)")
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = geom.TransformTo(sr2)
     assert not (ret == 0 or gdal.GetLastErrorMsg() == "")
 
@@ -852,7 +852,7 @@ def test_ogr_geom_segmentize():
 
     # Test extremely small threshold
     geom = ogr.CreateGeometryFromWkt("LINESTRING(0 0,0 1)")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         geom.Segmentize(1e-30)
     assert gdal.GetLastErrorMsg() != ""
 
@@ -956,42 +956,42 @@ def test_ogr_geom_linestring_limits():
     assert geom.Length() == 0
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         geom.GetPoint(-1)
     assert gdal.GetLastErrorType() != 0
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         geom.GetPoint(0)
     assert gdal.GetLastErrorType() != 0
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         geom.GetPoint_2D(-1)
     assert gdal.GetLastErrorType() != 0
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         geom.GetPoint_2D(0)
     assert gdal.GetLastErrorType() != 0
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         geom.SetPoint(-1, 5, 6, 7)
     assert gdal.GetLastErrorType() != 0
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         geom.SetPoint_2D(-1, 5, 6)
     assert gdal.GetLastErrorType() != 0
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         geom.SetPoint(2147000000, 5, 6, 7)
     assert gdal.GetLastErrorType() != 0
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         geom.SetPoint_2D(2147000000, 5, 6)
     assert gdal.GetLastErrorType() != 0
 
@@ -1030,7 +1030,7 @@ def test_ogr_geom_area_point():
     geom_wkt = "POINT(0 0)"
     geom = ogr.CreateGeometryFromWkt(geom_wkt)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         area = geom.Area()
     assert area == 0, "Area() result wrong, got %g." % area
 
@@ -1045,7 +1045,7 @@ def test_ogr_geom_length_point():
     geom_wkt = "POINT(0 0)"
     geom = ogr.CreateGeometryFromWkt(geom_wkt)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         length = geom.Length()
     assert length == 0, "Length() result wrong, got %g." % length
 
@@ -1357,27 +1357,27 @@ def test_ogr_geom_triangle():
 def test_ogr_geom_triangle_invalid_wkt():
 
     geom_wkt = "TRIANGLE (0 0)"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         geom = ogr.CreateGeometryFromWkt(geom_wkt)
     assert geom is None
 
     geom_wkt = "TRIANGLE ((0 0))"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         geom = ogr.CreateGeometryFromWkt(geom_wkt)
     assert geom is None
 
     geom_wkt = "TRIANGLE ((0 0,0 1,1 1,1 0))"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         geom = ogr.CreateGeometryFromWkt(geom_wkt)
     assert geom is None
 
     geom_wkt = "TRIANGLE ((0 0,0 1,1 1,1 0,0 0))"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         geom = ogr.CreateGeometryFromWkt(geom_wkt)
     assert geom is None
 
     geom_wkt = "TRIANGLE ((0 0,0 1,1 1,0 0),(0 0,0 1,1 1,0 0))"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         geom = ogr.CreateGeometryFromWkt(geom_wkt)
     assert geom is None
 
@@ -1800,7 +1800,7 @@ def test_ogr_geom_circularstring():
 
     # Error case : not enough points
     in_wkt = "CIRCULARSTRING (0 0)"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         g = ogr.CreateGeometryFromWkt(in_wkt)
     assert g is None
 
@@ -1982,31 +1982,31 @@ def test_ogr_geom_compoundcurve():
 
     # Error case : not enough points
     in_wkt = "COMPOUNDCURVE ((0 0))"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         g = ogr.CreateGeometryFromWkt(in_wkt)
     assert g is None
 
     # Error case : invalid curve
     in_wkt = "COMPOUNDCURVE (COMPOUNDCURVE EMPTY)"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         g = ogr.CreateGeometryFromWkt(in_wkt)
     assert g is None
 
     # Error case : non contiguous curves
     in_wkt = "COMPOUNDCURVE ((0 0,1 1),(2 2,3 3))"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         g = ogr.CreateGeometryFromWkt(in_wkt)
     assert g is None
 
     # Error case : non contiguous curves
     in_wkt = "COMPOUNDCURVE (EMPTY,(2 2,3 3))"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         g = ogr.CreateGeometryFromWkt(in_wkt)
     assert g is None
 
     # Error case : non contiguous curves
     in_wkt = "COMPOUNDCURVE ((2 2,3 3), EMPTY)"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         g = ogr.CreateGeometryFromWkt(in_wkt)
     assert g is None
 
@@ -2014,7 +2014,7 @@ def test_ogr_geom_compoundcurve():
     g.AddGeometry(ogr.CreateGeometryFromWkt("LINESTRING(0 0,1 1)"))
     assert g.ExportToWkt() == "COMPOUNDCURVE ((0 0,1 1))"
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         g.AddGeometry(ogr.CreateGeometryFromWkt("LINESTRING(0 0,1 1)"))
     assert g.ExportToWkt() == "COMPOUNDCURVE ((0 0,1 1),(1 1,0 0))"
 
@@ -2022,13 +2022,13 @@ def test_ogr_geom_compoundcurve():
     g.AddGeometryDirectly(ogr.CreateGeometryFromWkt("LINESTRING(0 0,1 1)"))
     assert g.ExportToWkt() == "COMPOUNDCURVE ((0 0,1 1))"
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         g.AddGeometryDirectly(ogr.CreateGeometryFromWkt("LINESTRING(0 0,1 1)"))
     assert g.ExportToWkt() == "COMPOUNDCURVE ((0 0,1 1),(1 1,0 0))"
 
     # Cannot add compoundcurve in compoundcurve
     g = ogr.Geometry(ogr.wkbCompoundCurve)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         g.AddGeometryDirectly(ogr.CreateGeometryFromWkt("COMPOUNDCURVE((1 1,2 2))"))
     assert g.ExportToWkt() == "COMPOUNDCURVE EMPTY"
 
@@ -2068,7 +2068,7 @@ def test_ogr_geom_compoundcurve():
         "\x01\x09\x00\x00\x00\x01\x00\x00\x00\x01\x09\x00\x00\x00\x00\x00\x00\x00",  # subgeometry invalid: compoundcurve
     ]
     for wkb in wkb_list:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             g = ogr.CreateGeometryFromWkb(wkb)
         assert g is None, wkb
 
@@ -2217,19 +2217,19 @@ def test_ogr_geom_curvepolygon():
 
     # Error case : not enough points
     in_wkt = "CURVEPOLYGON ((0 0,0 1,0 0))"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         g = ogr.CreateGeometryFromWkt(in_wkt)
     assert g is None
 
     # Error case : wrong sub-geometry type
     in_wkt = "CURVEPOLYGON (POINT EMPTY)"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         g = ogr.CreateGeometryFromWkt(in_wkt)
     assert g is None
 
     # Error case: non closed ring
     in_wkt = "CURVEPOLYGON ((0 0,0 1,1 1,1 0))"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         with gdaltest.config_option("OGR_GEOMETRY_ACCEPT_UNCLOSED_RING", "NO"):
             g = ogr.CreateGeometryFromWkt(in_wkt)
     assert g is None
@@ -2432,7 +2432,7 @@ def test_ogr_geom_multicurve():
 
     # Error case : wrong sub-geometry type
     in_wkt = "MULTILINESTRING (POINT EMPTY)"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         g = ogr.CreateGeometryFromWkt(in_wkt)
     assert g is None
 
@@ -2517,7 +2517,7 @@ def test_ogr_geom_multisurface():
 
     # Error case : wrong sub-geometry type
     in_wkt = "MULTIPOLYGON (POINT EMPTY)"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         g = ogr.CreateGeometryFromWkt(in_wkt)
     assert g is None
 
@@ -2834,7 +2834,7 @@ def test_ogr_geom_getcurvegeometry():
     ogrtest.check_feature_geometry(g3, g1_expected)
 
     # Test with unrecognized options
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         g2_new = g1.GetLinearGeometry(
             options=["bla", "ADD_INTERMEDIATE_POINT=FALSE", "foo=bar"]
         )
@@ -3225,7 +3225,7 @@ def test_ogr_geom_api_limit_tests():
     lyr = ogr.Geometry(ogr.wkbLineString)
     poly = ogr.Geometry(ogr.wkbPolygon)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         p.GetX(1)
         p.GetY(1)
         p.GetZ(1)
@@ -3525,7 +3525,7 @@ def test_ogr_geom_import_corrupted_wkb():
                     wkb[i] = 127 + 2 - (method - 8)
                 else:
                     wkb[i] = 255 - wkb[i]
-                with gdaltest.error_handler():
+                with gdal.quiet_errors():
                     g = ogr.CreateGeometryFromWkb(bytes(wkb))
                 if g:
                     g2 = ogr.CreateGeometryFromWkb(g.ExportToIsoWkb())
@@ -3534,7 +3534,7 @@ def test_ogr_geom_import_corrupted_wkb():
 
         # Test truncation of the WKB
         for i in range(len(wkb)):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 g = ogr.CreateGeometryFromWkb(bytes(wkb[0:i]))
             assert g is None, (wkt, i)
 
@@ -3876,7 +3876,7 @@ def test_ogr_geom_makevalid():
     assert g is None or g.ExportToWkt() == "POINT EMPTY"
 
     g = ogr.CreateGeometryFromWkt("LINESTRING (0 0)")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         g = g.MakeValid()
     assert not g
 

--- a/autotest/ogr/ogr_georss.py
+++ b/autotest/ogr/ogr_georss.py
@@ -430,7 +430,7 @@ def test_ogr_georss_10():
     srs.ImportFromEPSG(32631)
 
     ds = ogr.GetDriverByName("GeoRSS").CreateDataSource("tmp/test32631.rss")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         try:
             lyr = ds.CreateLayer("georss", srs=srs)
         except Exception:

--- a/autotest/ogr/ogr_geos.py
+++ b/autotest/ogr/ogr_geos.py
@@ -388,14 +388,14 @@ def test_ogr_geos_concavehull():
 
     g1 = ogr.CreateGeometryFromWkt("MULTIPOINT(0 0,0.4 0.5,0 1,1 1,0.6 0.5,1 0)")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         res = g1.ConcaveHull(0.5, False)
 
     if res is None:
         assert "GEOS 3.11" in gdal.GetLastErrorMsg()
         pytest.skip(gdal.GetLastErrorMsg())
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         res = g1.ConcaveHull(-1, False)
     assert res is None
 
@@ -506,7 +506,7 @@ def test_ogr_geos_isvalid_false():
 
     g1 = ogr.CreateGeometryFromWkt("POLYGON((0 0,1 1,1 2,1 1,0 0))")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         isring = g1.IsValid()
 
     assert isring == 0
@@ -521,7 +521,7 @@ def test_ogr_geos_isvalid_false_too_few_points():
     )
 
     with ogr.ExceptionMgr():  # fail test if exception is thrown
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             isvalid = g1.IsValid()
 
     assert isvalid == 0

--- a/autotest/ogr/ogr_gml_geom.py
+++ b/autotest/ogr/ogr_gml_geom.py
@@ -1558,7 +1558,7 @@ def test_gml_invalid_geoms():
     ]
 
     for (gml, expected_wkt) in gml_expected_wkt_list:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             # print gml
             geom = ogr.CreateGeometryFromGML(gml)
         if geom is None:

--- a/autotest/ogr/ogr_gml_read.py
+++ b/autotest/ogr/ogr_gml_read.py
@@ -416,7 +416,7 @@ def test_ogr_gml_9():
     dst_feat.SetFieldBinaryFromHexString("test", "80626164")  # \x80bad'
 
     # Avoid the warning
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(dst_feat)
 
     assert ret == 0, "CreateFeature failed."
@@ -681,7 +681,7 @@ def test_ogr_gml_14():
             "GML_SAVE_RESOLVED_TO": "tmp/cache/xlink1resolved.gml",
         }
     ):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             gml_ds = ogr.Open("tmp/cache/xlink1.gml")
     gml_ds = None
 
@@ -3560,7 +3560,7 @@ def test_ogr_gml_69():
     # Error case: missing geometry
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetField("field_not_nullable", "not_null")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(f)
     assert ret != 0
     f = None
@@ -3568,7 +3568,7 @@ def test_ogr_gml_69():
     # Error case: missing non-nullable field
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometryDirectly(ogr.CreateGeometryFromWkt("POINT(0 0)"))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(f)
     assert ret != 0
     f = None
@@ -3907,7 +3907,7 @@ def test_ogr_gml_76():
     if not gdaltest.have_gml_reader:
         pytest.skip()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("/vsisparse/data/gml/huge_attribute_gml_sparse.xml")
         if ds is not None:
             lyr = ds.GetLayer(0)
@@ -4176,7 +4176,7 @@ def test_ogr_gml_gml2_write_geometry_error():
     f.SetGeometry(
         ogr.CreateGeometryFromWkt("GEOMETRYCOLLECTION(POINT(0 0), TIN EMPTY)")
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.CreateFeature(f)
     ds = None
 
@@ -4316,7 +4316,7 @@ def test_ogr_gml_unique(gml_format, constraint_met):
             if constraint_met:
                 validate("/vsimem/test_ogr_gml_unique.gml")
             else:
-                with gdaltest.error_handler():
+                with gdal.quiet_errors():
                     with pytest.raises(Exception):
                         validate("/vsimem/test_ogr_gml_unique.gml")
 
@@ -4496,7 +4496,7 @@ def test_ogr_gml_too_nested():
 
     gdal.Unlink("data/gml/too_nested.gfs")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("data/gml/too_nested.gml")
         lyr = ds.GetLayer(0)
         assert lyr.GetNextFeature() is None
@@ -4718,7 +4718,7 @@ def test_ogr_gml_read_boundedby_invalid():
     if not gdaltest.have_gml_reader:
         pytest.skip()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             "data/gml/only_boundedby_invalid.gml", open_options=["USE_BBOX=YES"]
         )

--- a/autotest/ogr/ogr_gmlas.py
+++ b/autotest/ogr/ogr_gmlas.py
@@ -214,7 +214,7 @@ def test_ogr_gmlas_no_datafile_with_xsd_option():
 
 def test_ogr_gmlas_no_datafile_xsd_which_is_not_xsd():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx("GMLAS:", open_options=["XSD=data/gmlas/gmlas_test1.xml"])
     assert ds is None
     assert gdal.GetLastErrorMsg().find("invalid content in 'schema' element") >= 0
@@ -226,7 +226,7 @@ def test_ogr_gmlas_no_datafile_xsd_which_is_not_xsd():
 
 def test_ogr_gmlas_no_datafile_no_xsd():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx("GMLAS:")
     assert ds is None
     assert (
@@ -243,7 +243,7 @@ def test_ogr_gmlas_no_datafile_no_xsd():
 
 def test_ogr_gmlas_non_existing_gml():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx("GMLAS:/vsimem/i_do_not_exist.gml")
     assert ds is None
     assert gdal.GetLastErrorMsg().find("Cannot open /vsimem/i_do_not_exist.gml") >= 0
@@ -255,7 +255,7 @@ def test_ogr_gmlas_non_existing_gml():
 
 def test_ogr_gmlas_non_existing_xsd():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx("GMLAS:", open_options=["XSD=/vsimem/i_do_not_exist.xsd"])
     assert ds is None
     assert gdal.GetLastErrorMsg().find("Cannot resolve /vsimem/i_do_not_exist.xsd") >= 0
@@ -272,7 +272,7 @@ def test_ogr_gmlas_gml_without_schema_location():
         """<MYNS:main_elt xmlns:MYNS="http://myns"/>""",
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx("GMLAS:/vsimem/ogr_gmlas_gml_without_schema_location.xml")
     assert ds is None
     assert (
@@ -291,7 +291,7 @@ def test_ogr_gmlas_gml_without_schema_location():
 
 def test_ogr_gmlas_invalid_schema():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx("GMLAS:data/gmlas/gmlas_invalid_schema.xml")
     assert ds is None
     assert gdal.GetLastErrorMsg().find("invalid content") >= 0
@@ -305,7 +305,7 @@ def test_ogr_gmlas_invalid_xml():
 
     ds = gdal.OpenEx("GMLAS:data/gmlas/gmlas_invalid_xml.xml")
     lyr = ds.GetLayer(0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     assert f is None
     assert (
@@ -324,7 +324,7 @@ def test_ogr_gmlas_gml_Reference():
     assert ds.GetLayerCount() == 3
 
     lyr = ds.GetLayerByName("main_elt")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     if (
         f["reference_existing_target_elt_with_required_id_href"] != "#BAZ"
@@ -387,7 +387,7 @@ def test_ogr_gmlas_unexpected_repeated_element():
 
     ds = gdal.OpenEx("GMLAS:data/gmlas/gmlas_unexpected_repeated_element.xml")
     lyr = ds.GetLayer(0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     if (
         f is None or f["foo"] != "foo_again"
@@ -408,7 +408,7 @@ def test_ogr_gmlas_unexpected_repeated_element_variant():
 
     ds = gdal.OpenEx("GMLAS:data/gmlas/gmlas_unexpected_repeated_element_variant.xml")
     lyr = ds.GetLayer(0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     if (
         f is None or f["foo"] != "foo_again"
@@ -434,7 +434,7 @@ def test_ogr_gmlas_geometryproperty():
         ],
     )
     lyr = ds.GetLayer(0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         geom_field_count = lyr.GetLayerDefn().GetGeomFieldCount()
     assert geom_field_count == 15
     f = lyr.GetNextFeature()
@@ -506,7 +506,7 @@ def test_ogr_gmlas_geometryproperty():
     ogrtest.check_feature_geometry(geom, "POINT (3.0 0.0)")
 
     # Failed reprojection
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     geom_idx = lyr.GetLayerDefn().GetGeomFieldIndex("geometryProperty")
     if f.GetGeomFieldRef(geom_idx) is not None:
@@ -519,7 +519,7 @@ def test_ogr_gmlas_geometryproperty():
         open_options=["SWAP_COORDINATES=NO"],
     )
     lyr = ds.GetLayer(0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     geom_idx = lyr.GetLayerDefn().GetGeomFieldIndex("geometryProperty")
     wkt = f.GetGeomFieldRef(geom_idx).ExportToWkt()
@@ -540,7 +540,7 @@ def test_ogr_gmlas_geometryproperty():
         open_options=["SWAP_COORDINATES=YES"],
     )
     lyr = ds.GetLayer(0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     geom_idx = lyr.GetLayerDefn().GetGeomFieldIndex("geometryProperty")
     wkt = f.GetGeomFieldRef(geom_idx).ExportToWkt()
@@ -730,7 +730,7 @@ def test_ogr_gmlas_no_namespace():
 def test_ogr_gmlas_conf():
 
     # Non existing file
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             "GMLAS:data/gmlas/gmlas_test1.xml",
             open_options=["CONFIG_FILE=not_existing"],
@@ -739,7 +739,7 @@ def test_ogr_gmlas_conf():
 
     # Broken conf file
     gdal.FileFromMemBuffer("/vsimem/my_conf.xml", "<broken>")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             "GMLAS:data/gmlas/gmlas_test1.xml",
             open_options=["CONFIG_FILE=/vsimem/my_conf.xml"],
@@ -749,7 +749,7 @@ def test_ogr_gmlas_conf():
 
     # Valid XML, but not validating
     gdal.FileFromMemBuffer("/vsimem/my_conf.xml", "<not_validating/>")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.OpenEx(
             "GMLAS:data/gmlas/gmlas_test1.xml",
             open_options=["CONFIG_FILE=/vsimem/my_conf.xml"],
@@ -790,7 +790,7 @@ def test_ogr_gmlas_conf():
     )
     assert ds is not None
     lyr = ds.GetLayer(0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.GetLayerDefn().GetFieldIndex("geometryProperty_xml") < 0
     f = lyr.GetNextFeature()
     geom_idx = lyr.GetLayerDefn().GetGeomFieldIndex("geometryProperty")
@@ -820,7 +820,7 @@ def test_ogr_gmlas_conf():
     assert ds.GetLayerCount() == 1
 
     # Turn on validation and error on validation
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             "GMLAS:data/gmlas/gmlas_validate.xml",
             open_options=[
@@ -850,7 +850,7 @@ def test_ogr_gmlas_conf_ignored_xpath():
         "foo[1]",
         "foo[@bar='baz']",
     ]:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             gdal.OpenEx(
                 "GMLAS:",
                 open_options=[
@@ -867,7 +867,7 @@ def test_ogr_gmlas_conf_ignored_xpath():
         assert gdal.GetLastErrorMsg().find("XPath syntax") >= 0, xpath
 
     # Test duplicating mapping
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.OpenEx(
             "GMLAS:",
             open_options=[
@@ -899,7 +899,7 @@ def test_ogr_gmlas_conf_ignored_xpath():
     assert ds is not None
     lyr = ds.GetLayerByName("main_elt")
     assert lyr.GetLayerDefn().GetFieldIndex("otherns_id") < 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.GetNextFeature()
     assert (
         gdal.GetLastErrorMsg().find(
@@ -1054,7 +1054,7 @@ def test_ogr_gmlas_cache():
     )
 
     # First try with remote schema download disabled
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             "GMLAS:/vsimem/ogr_gmlas_cache.xml",
             open_options=[
@@ -1064,7 +1064,7 @@ def test_ogr_gmlas_cache():
     assert ds is None and gdal.GetLastErrorMsg().find("Cannot resolve") >= 0
 
     # Test invalid cache directory
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             "GMLAS:/vsimem/ogr_gmlas_cache.xml",
             open_options=[
@@ -1136,7 +1136,7 @@ def test_ogr_gmlas_cache():
     assert ds.GetLayerCount() == 1
 
     # Re try but ask for refresh
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             "GMLAS:/vsimem/ogr_gmlas_cache.xml",
             open_options=[
@@ -1151,7 +1151,7 @@ def test_ogr_gmlas_cache():
     # Re try with non existing cached schema
     gdal.Unlink("/vsimem/my/gmlas_cache/" + gdal.ReadDir("/vsimem/my/gmlas_cache")[0])
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             "GMLAS:/vsimem/ogr_gmlas_cache.xml",
             open_options=[
@@ -1654,7 +1654,7 @@ def test_ogr_gmlas_xlink_resolver():
     gdal.Unlink("/vsimem/resource2.xml")
     lyr.ResetReading()
     # /vsimem/resource.xml has been evicted from the cache
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     if f["my_link_rawcontent"] is not None:
         webserver.server_stop(webserver_process, webserver_port)
@@ -1744,7 +1744,7 @@ def test_ogr_gmlas_xlink_resolver():
         ],
     )
     lyr = ds.GetLayer(0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     if f.IsFieldSet("my_link_rawcontent"):
         f.DumpReadable()
@@ -1769,7 +1769,7 @@ def test_ogr_gmlas_xlink_resolver():
         ],
     )
     lyr = ds.GetLayer(0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     if gdal.GetLastErrorMsg() == "":
         webserver.server_stop(webserver_process, webserver_port)
@@ -2094,7 +2094,7 @@ def test_ogr_gmlas_truncated_xml():
 
     ds = gdal.OpenEx("GMLAS:data/gmlas/gmlas_truncated_xml.xml")
     lyr = ds.GetLayer(0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     if f is not None:
         f.DumpReadable()
@@ -2656,7 +2656,7 @@ def test_ogr_gmlas_writer_options():
 def test_ogr_gmlas_writer_errors():
 
     # Source dataset is empty
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret_ds = gdal.VectorTranslate(
             "/vsimem/valid.xml",
             gdal.GetDriverByName("Memory").Create("", 0, 0, 0, 0),
@@ -2671,7 +2671,7 @@ def test_ogr_gmlas_writer_errors():
     src_ds = gdal.OpenEx("GMLAS:data/gmlas/gmlas_geometryproperty_gml32_no_error.gml")
     tmp_ds = gdal.VectorTranslate("", src_ds, format="Memory")
     src_ds = None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret_ds = gdal.VectorTranslate("/vsimem/valid.xml", tmp_ds, format="GMLAS")
     assert (
         ret_ds is None
@@ -2682,7 +2682,7 @@ def test_ogr_gmlas_writer_errors():
     )
 
     # Invalid input schema
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret_ds = gdal.VectorTranslate(
             "/vsimem/valid.xml",
             tmp_ds,
@@ -2701,7 +2701,7 @@ def test_ogr_gmlas_writer_errors():
     )
     tmp_ds = gdal.VectorTranslate("", src_ds, format="Memory")
     src_ds = None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret_ds = gdal.VectorTranslate(
             "/i_am/not/valid.xml",
             tmp_ds,
@@ -2714,7 +2714,7 @@ def test_ogr_gmlas_writer_errors():
     )
 
     # .xsd extension not allowed
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret_ds = gdal.VectorTranslate(
             "/i_am/not/valid.xsd",
             tmp_ds,
@@ -2727,7 +2727,7 @@ def test_ogr_gmlas_writer_errors():
     )
 
     # Invalid output .xsd name
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret_ds = gdal.VectorTranslate(
             "/vsimem/valid.xml",
             tmp_ds,
@@ -2744,7 +2744,7 @@ def test_ogr_gmlas_writer_errors():
     gdal.Unlink("/vsimem/valid.xml")
 
     # Invalid CONFIG_FILE
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret_ds = gdal.VectorTranslate(
             "/vsimem/valid.xml",
             tmp_ds,
@@ -2757,7 +2757,7 @@ def test_ogr_gmlas_writer_errors():
     )
 
     # Invalid layer name
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret_ds = gdal.VectorTranslate(
             "/vsimem/valid.xml",
             tmp_ds,
@@ -2776,7 +2776,7 @@ def test_ogr_gmlas_writer_errors():
     # _ogr_layers_metadata not found
     src_ds = gdal.GetDriverByName("Memory").Create("", 0, 0, 0, 0)
     src_ds.CreateLayer("_ogr_other_metadata")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret_ds = gdal.VectorTranslate("/vsimem/valid.xml", src_ds, format="GMLAS")
     assert (
         ret_ds is None
@@ -2787,7 +2787,7 @@ def test_ogr_gmlas_writer_errors():
     src_ds = gdal.GetDriverByName("Memory").Create("", 0, 0, 0, 0)
     src_ds.CreateLayer("_ogr_other_metadata")
     src_ds.CreateLayer("_ogr_layers_metadata")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret_ds = gdal.VectorTranslate("/vsimem/valid.xml", src_ds, format="GMLAS")
     assert (
         ret_ds is None
@@ -2799,7 +2799,7 @@ def test_ogr_gmlas_writer_errors():
     src_ds.CreateLayer("_ogr_other_metadata")
     src_ds.CreateLayer("_ogr_layers_metadata")
     src_ds.CreateLayer("_ogr_fields_metadata")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret_ds = gdal.VectorTranslate("/vsimem/valid.xml", src_ds, format="GMLAS")
     assert (
         ret_ds is None
@@ -2812,7 +2812,7 @@ def test_ogr_gmlas_writer_errors():
     src_ds.CreateLayer("_ogr_layers_metadata")
     src_ds.CreateLayer("_ogr_fields_metadata")
     src_ds.CreateLayer("_ogr_layer_relationships")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret_ds = gdal.VectorTranslate("/vsimem/valid.xml", src_ds, format="GMLAS")
     assert (
         ret_ds is None
@@ -3079,7 +3079,7 @@ def test_ogr_gmlas_any_field_at_end_of_declaration():
     # Will warn about 'Unexpected element with xpath=main_elt/extra (subxpath=main_elt/extra) found'
     # This should be fixed at some point
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     assert gdal.GetLastErrorMsg() != ""
     if f.GetField("foo") != "bar":
@@ -3185,7 +3185,7 @@ def test_ogr_gmlas_no_element_in_first_choice_schema():
 
 def test_ogr_gmlas_internal_xlink_href():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx("GMLAS:data/gmlas/gmlas_internal_xlink_href.xml")
         lyr = ds.GetLayerByName("main_elt")
         f = lyr.GetNextFeature()
@@ -3359,7 +3359,7 @@ def test_ogr_gmlas_internal_xlink_href():
 
 def test_ogr_gmlas_invalid_version_xsd():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx("GMLAS:data/gmlas/gmlas_invalid_version_xsd.xml")
     assert ds is None
 
@@ -3372,7 +3372,7 @@ def test_ogr_gmlas_invalid_version_xsd():
 def test_ogr_gmlas_huge_memory_allocation():
 
     with gdaltest.config_option("OGR_GMLAS_XERCES_MAX_TIME", "0"):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.OpenEx("GMLAS:data/gmlas/test_max_mem_xerces.xml")
         assert ds is None
 
@@ -3389,7 +3389,7 @@ def test_ogr_gmlas_huge_memory_allocation():
 def test_ogr_gmlas_huge_processing_time():
 
     with gdaltest.config_option("OGR_GMLAS_XERCES_MAX_TIME", "0.5"):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.OpenEx("GMLAS:data/gmlas/test_max_time_xerces.xml")
         assert ds is None
 

--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -204,7 +204,7 @@ def test_ogr_gpkg_3():
     # Test creating a layer with an existing name
     lyr = gpkg_ds.CreateLayer("a_layer", options=["SPATIAL_INDEX=NO"])
     assert lyr is not None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = gpkg_ds.CreateLayer("a_layer", options=["SPATIAL_INDEX=NO"])
     assert lyr is None, "layer creation should have failed"
 
@@ -217,7 +217,7 @@ def test_ogr_gpkg_4():
 
     assert validate("tmp/gpkg_test.gpkg"), "validation failed"
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gpkg_ds = ogr.Open("tmp/gpkg_test.gpkg", update=1)
 
     assert gpkg_ds is not None
@@ -264,11 +264,11 @@ def test_ogr_gpkg_5():
 
     assert gpkg_ds.GetLayerCount() == 2, "unexpected number of layers"
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = gpkg_ds.DeleteLayer(-1)
     assert ret != 0, "expected error"
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = gpkg_ds.DeleteLayer(gpkg_ds.GetLayerCount())
     assert ret != 0, "expected error"
 
@@ -303,7 +303,7 @@ def test_ogr_gpkg_6():
 
     assert validate("tmp/gpkg_test.gpkg"), "validation failed"
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gpkg_ds = ogr.Open("tmp/gpkg_test.gpkg", update=1)
 
     assert gpkg_ds is not None
@@ -842,7 +842,7 @@ def test_ogr_gpkg_14():
 ###############################################################################
 def _has_spatialite_4_3_or_later(ds):
     has_spatialite_4_3_or_later = False
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = ds.ExecuteSQL("SELECT spatialite_version()")
         if sql_lyr:
             f = sql_lyr.GetNextFeature()
@@ -1014,7 +1014,7 @@ def test_ogr_gpkg_15():
     gpkg_ds.ReleaseResultSet(sql_lyr)
 
     # Invalid code
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = gpkg_ds.ExecuteSQL("SELECT ImportFromEPSG(0)")
     feat = sql_lyr.GetNextFeature()
     if feat.GetField(0) != -1:
@@ -1031,7 +1031,7 @@ def test_ogr_gpkg_15():
     gpkg_ds.ReleaseResultSet(sql_lyr)
 
     # Invalid geometry
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = gpkg_ds.ExecuteSQL("SELECT ST_Transform(x'00', 4326)")
     feat = sql_lyr.GetNextFeature()
     if feat.GetGeometryRef() is not None:
@@ -1051,7 +1051,7 @@ def test_ogr_gpkg_15():
 
     # Invalid target SRID=0
     # GeoPackage: The record with an srs_id of 0 SHALL be used for undefined geographic coordinate reference systems.
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = gpkg_ds.ExecuteSQL(
             "SELECT ST_Transform(geom, 0), ST_SRID(ST_Transform(geom, 0)) FROM tbl_linestring_renamed"
         )
@@ -1068,7 +1068,7 @@ def test_ogr_gpkg_15():
     # and the result is an identity transformation that leaves geometry unchanged.
     src_lyr = gpkg_ds.GetLayerByName("point-with-spi-and-dashes")
     assert src_lyr.GetSpatialRef().ExportToWkt().find("Undefined geographic SRS") >= 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = gpkg_ds.ExecuteSQL(
             'SELECT ST_Transform(geom, 4326), ST_SRID(ST_Transform(geom, 4326)) FROM "point-with-spi-and-dashes"'
         )
@@ -1080,7 +1080,7 @@ def test_ogr_gpkg_15():
     gpkg_ds.ReleaseResultSet(sql_lyr)
 
     # Invalid spatialite geometry: SRID=4326,MULTIPOINT EMPTY truncated
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = gpkg_ds.ExecuteSQL(
             "SELECT ST_Transform(x'0001E610000000000000000000000000000000000000000000000000000000000000000000007C04000000000000FE', 4326) FROM tbl_linestring_renamed"
         )
@@ -1188,7 +1188,7 @@ def test_ogr_gpkg_15():
     gpkg_ds.ReleaseResultSet(sql_lyr)
 
     # Error case: invalid geometry
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = gpkg_ds.ExecuteSQL(
             "SELECT ST_GeometryType(x'475000030000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000')"
         )
@@ -1412,7 +1412,7 @@ def test_ogr_gpkg_16():
     ds = ogr.Open("/vsimem/ogr_gpk_16.gpkg", update=1)
     lyr = ds.GetLayer(0)
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.GetLayerDefn()
     assert gdal.GetLastErrorMsg() != "", "fail : warning expected"
 
@@ -1425,7 +1425,7 @@ def test_ogr_gpkg_16():
     ds = ogr.Open("/vsimem/ogr_gpk_16.gpkg")
     lyr = ds.GetLayer(0)
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.GetLayerDefn()
     assert gdal.GetLastErrorMsg() != "", "fail : warning expected"
 
@@ -1433,7 +1433,7 @@ def test_ogr_gpkg_16():
     ds = ogr.Open("/vsimem/ogr_gpk_16.gpkg", update=1)
     lyr = ds.GetLayer(0)
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.GetLayerDefn()
     assert gdal.GetLastErrorMsg() != "", "fail : warning expected"
     ds = None
@@ -1452,7 +1452,7 @@ def test_ogr_gpkg_16():
     ds = ogr.Open("/vsimem/ogr_gpk_16.gpkg")
     lyr = ds.GetLayer(0)
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.GetLayerDefn()
     assert gdal.GetLastErrorMsg() != "", "fail : warning expected"
 
@@ -1476,7 +1476,7 @@ def test_ogr_gpkg_16():
 
     # Warning since we open as read-write
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("/vsimem/ogr_gpk_16.gpkg", update=1)
     assert gdal.GetLastErrorMsg() != "", "fail : warning expected"
 
@@ -1487,13 +1487,13 @@ def test_ogr_gpkg_16():
 
     # Warning since we open as read-only
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("/vsimem/ogr_gpk_16.gpkg")
     assert gdal.GetLastErrorMsg() != "", "fail : warning expected"
 
     # and also as read-write
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("/vsimem/ogr_gpk_16.gpkg", update=1)
     assert gdal.GetLastErrorMsg() != "", "fail : warning expected"
     ds = None
@@ -1591,7 +1591,7 @@ def test_ogr_gpkg_18():
 
     ds = gdaltest.gpkg_dr.CreateDataSource("/vsimem/ogr_gpkg_18.gpkg")
     lyr = ds.CreateLayer("test", geom_type=ogr.wkbTriangle)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # Warning 1: Registering non-standard gpkg_geom_TRIANGLE extension
         ds.FlushCache()
     sql_lyr = ds.ExecuteSQL(
@@ -1638,7 +1638,7 @@ def test_ogr_gpkg_19():
     ds.SetMetadataItem("foo", "bar")
 
     # GEOPACKAGE metadata domain is not allowed in a non-raster context
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.SetMetadata(ds.GetMetadata("GEOPACKAGE"), "GEOPACKAGE")
         ds.SetMetadataItem("foo", ds.GetMetadataItem("foo", "GEOPACKAGE"), "GEOPACKAGE")
 
@@ -1800,7 +1800,7 @@ def test_ogr_gpkg_20():
     ds = None
 
     # Unable to parse srs_id '4326' well-known text 'invalid'
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("/vsimem/ogr_gpkg_20.gpkg", update=1)
 
     ds.ExecuteSQL("DELETE FROM gpkg_spatial_ref_sys WHERE srs_id = 4326")
@@ -1927,7 +1927,7 @@ def test_ogr_gpkg_srs_non_consistent_with_official_definition():
     AUTHORITY["EPSG","4267"]]"""
     )
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.CreateLayer("test_fake_4267", srs=test_fake_4267)
     assert (
         gdal.GetLastErrorMsg()
@@ -1944,7 +1944,7 @@ def test_ogr_gpkg_srs_non_consistent_with_official_definition():
     AUTHORITY["EPSG","4326"]]"""
     )
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.CreateLayer("test_fake_4326", srs=test_fake_4326)
     assert (
         gdal.GetLastErrorMsg()
@@ -2113,14 +2113,14 @@ def test_ogr_gpkg_21():
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetFieldBinaryFromHexString(0, "41E9")
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.CreateFeature(f)
     assert gdal.GetLastErrorMsg() != ""
 
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetField(0, "abc")
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.CreateFeature(f)
     assert gdal.GetLastErrorMsg() != ""
 
@@ -2138,7 +2138,7 @@ def test_ogr_gpkg_21():
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetFieldBinaryFromHexString(0, "41E9")
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.CreateFeature(f)
     assert gdal.GetLastErrorMsg() != ""
 
@@ -2148,7 +2148,7 @@ def test_ogr_gpkg_21():
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetField(0, "abc")
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.CreateFeature(f)
     assert gdal.GetLastErrorMsg() != ""
 
@@ -2171,7 +2171,7 @@ def test_ogr_gpkg_table_in_gpkg_content_but_missing():
     )
     ds = None
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open(filename)
     assert "non_existent" in gdal.GetLastErrorMsg()
     assert ds.GetLayerCount() == 1
@@ -2236,7 +2236,7 @@ def test_ogr_gpkg_23():
     # Error case: missing geometry
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetField("field_not_nullable", "not_null")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(f)
     assert ret != 0
     f = None
@@ -2244,7 +2244,7 @@ def test_ogr_gpkg_23():
     # Error case: missing non-nullable field
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometryDirectly(ogr.CreateGeometryFromWkt("POINT(0 0)"))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(f)
     assert ret != 0
     f = None
@@ -2253,7 +2253,7 @@ def test_ogr_gpkg_23():
     lyr = ds.CreateLayer("test2", geom_type=ogr.wkbPoint, options=["SPATIAL_INDEX=NO"])
 
     # Cannot add more than one geometry field
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateGeomField(ogr.GeomFieldDefn("foo", ogr.wkbPoint))
     assert ret != 0
 
@@ -2335,7 +2335,7 @@ def test_ogr_gpkg_23():
 
     lyr = ds.GetLayerByName("test5")
     field_defn = ogr.GeomFieldDefn("", ogr.wkbPoint)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.CreateGeomField(field_defn) != 0
 
     lyr = ds.GetLayerByName("test")
@@ -2433,7 +2433,7 @@ def test_ogr_gpkg_unique():
     field_defn = ogr.FieldDefn("field_unique_failure", ogr.OFTString)
     field_defn.SetUnique(1)
     # Not allowed by sqlite3. Could potentially be improved
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.CreateField(field_defn) == ogr.OGRERR_FAILURE
 
     # Create another layer from SQL to test quoting of fields
@@ -2691,7 +2691,7 @@ def test_ogr_gpkg_25():
     lyr = ds.CreateLayer("test", geom_type=ogr.wkbNone, options=["FID=myfid"])
 
     lyr.CreateField(ogr.FieldDefn("str", ogr.OFTString))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateField(ogr.FieldDefn("myfid", ogr.OFTString))
     assert ret != 0
 
@@ -2725,16 +2725,16 @@ def test_ogr_gpkg_25():
     feat = ogr.Feature(lyr.GetLayerDefn())
     feat.SetFID(1)
     feat.SetField("myfid", 10)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(feat)
     assert ret != 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetFeature(feat)
     assert ret != 0
 
     feat.UnsetField("myfid")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetFeature(feat)
     assert ret != 0
 
@@ -2776,7 +2776,7 @@ def test_ogr_gpkg_26():
 
     ret = ds.StartTransaction()
     assert ret == 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.StartTransaction()
     assert ret != 0
 
@@ -2784,7 +2784,7 @@ def test_ogr_gpkg_26():
     lyr.CreateField(ogr.FieldDefn("foo", ogr.OFTString))
     ret = ds.RollbackTransaction()
     assert ret == 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.RollbackTransaction()
     assert ret != 0
     ds = None
@@ -2793,7 +2793,7 @@ def test_ogr_gpkg_26():
     assert ds.GetLayerCount() == 0
     ret = ds.StartTransaction()
     assert ret == 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.StartTransaction()
     assert ret != 0
 
@@ -2801,7 +2801,7 @@ def test_ogr_gpkg_26():
     lyr.CreateField(ogr.FieldDefn("foo", ogr.OFTString))
     ret = ds.CommitTransaction()
     assert ret == 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.CommitTransaction()
     assert ret != 0
     ds = None
@@ -2884,7 +2884,7 @@ def test_ogr_gpkg_26():
 def test_ogr_gpkg_27():
 
     ds = gdaltest.gpkg_dr.CreateDataSource("/vsimem/ogr_gpkg_27.gpkg")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = ds.ExecuteSQL("SELECT GeomFromGPB(null)")
     if sql_lyr is None:
         ds = None
@@ -2999,20 +2999,20 @@ def test_ogr_gpkg_29():
 def test_ogr_gpkg_30():
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdaltest.gpkg_dr.CreateDataSource("/vsimem/ogr_gpkg_30.geopkg")
     assert ds is not None
     assert gdal.GetLastErrorMsg() != ""
     ds = None
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("/vsimem/ogr_gpkg_30.geopkg", update=1)
     assert ds is not None
     assert gdal.GetLastErrorMsg() != ""
     ds = None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdaltest.gpkg_dr.DeleteDataSource("/vsimem/ogr_gpkg_30.geopkg")
 
 
@@ -3158,7 +3158,7 @@ def test_ogr_gpkg_34():
     ds = ogr.Open(dbname, update=1)
     new_layer_name = """weird2'layer"name"""
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.ExecuteSQL('ALTER TABLE "weird\'layer""name" RENAME TO gpkg_contents')
     assert gdal.GetLastErrorMsg() != ""
     gdal.ErrorReset()
@@ -3192,7 +3192,7 @@ def test_ogr_gpkg_34():
     # currently we don't suppress rows from layer_styles
     ds.ExecuteSQL("DELETE FROM layer_styles")
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.ExecuteSQL("DELLAYER:does_not_exist")
     assert gdal.GetLastErrorMsg() != ""
     gdal.ErrorReset()
@@ -3226,7 +3226,7 @@ def test_ogr_gpkg_34():
     assert gdal.GetLastErrorMsg() == ""
     ds.ExecuteSQL("DROP TABLE another_layer_name")
     assert gdal.GetLastErrorMsg() == ""
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.ExecuteSQL('DROP TABLE "foobar"')
     assert gdal.GetLastErrorMsg() != ""
     gdal.ErrorReset()
@@ -3324,11 +3324,11 @@ def test_ogr_gpkg_35():
 
     assert lyr.TestCapability(ogr.OLCDeleteField) == 1
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.DeleteField(-1)
     assert ret != 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.DeleteField(lyr.GetLayerDefn().GetFieldCount())
     assert ret != 0
 
@@ -3377,7 +3377,7 @@ def test_ogr_gpkg_35():
     assert lyr.GetMetadataItem("FOO") == "BAR"
 
     lyr = ds.GetLayer(0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.DeleteField(0)
     assert ret != 0
     ds = None
@@ -3452,27 +3452,27 @@ def test_ogr_gpkg_36():
 
     assert lyr.TestCapability(ogr.OLCAlterFieldDefn) == 1
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.AlterFieldDefn(-1, ogr.FieldDefn("foo"), ogr.ALTER_ALL_FLAG)
     assert ret != 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.AlterFieldDefn(1, ogr.FieldDefn("foo"), ogr.ALTER_ALL_FLAG)
     assert ret != 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.AlterFieldDefn(
             0, ogr.FieldDefn(lyr.GetGeometryColumn()), ogr.ALTER_ALL_FLAG
         )
     assert ret != 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.AlterFieldDefn(
             0, ogr.FieldDefn(lyr.GetFIDColumn()), ogr.ALTER_ALL_FLAG
         )
     assert ret != 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.AlterFieldDefn(0, ogr.FieldDefn("baz"), ogr.ALTER_ALL_FLAG)
     assert ret != 0
 
@@ -3495,7 +3495,7 @@ def test_ogr_gpkg_36():
     # Violation of not-null constraint
     new_field_defn = ogr.FieldDefn("baz", ogr.OFTString)
     new_field_defn.SetNullable(False)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.AlterFieldDefn(1, new_field_defn, ogr.ALTER_ALL_FLAG) != 0
 
     lyr.ResetReading()
@@ -3561,7 +3561,7 @@ def test_ogr_gpkg_36():
     ds.ReleaseResultSet(sql_lyr)
 
     lyr = ds.GetLayer(0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.AlterFieldDefn(0, ogr.FieldDefn("foo"), ogr.ALTER_ALL_FLAG)
     assert ret != 0
     ds = None
@@ -3582,12 +3582,12 @@ def test_ogr_gpkg_36():
     lyr.CreateFeature(ogr.Feature(lyr.GetLayerDefn()))
     # Unlink before AlterFieldDefn
     gdal.Unlink(dbname)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         new_field_defn = ogr.FieldDefn("bar")
         new_field_defn.SetNullable(False)
         ret = lyr.AlterFieldDefn(0, new_field_defn, ogr.ALTER_ALL_FLAG)
     assert ret != 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = None
 
     gdaltest.gpkg_dr.DeleteDataSource(dbname)
@@ -3635,7 +3635,7 @@ def test_ogr_gpkg_37():
 
     assert lyr.TestCapability(ogr.OLCReorderFields) == 1
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.ReorderFields([-1, -1])
     assert ret != 0
 
@@ -3668,7 +3668,7 @@ def test_ogr_gpkg_37():
     # Try on read-only dataset
     ds = ogr.Open(dbname)
     lyr = ds.GetLayer(0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.ReorderFields([1, 0])
     assert ret != 0
     ds = None
@@ -3780,18 +3780,18 @@ def test_ogr_gpkg_39():
     )
     assert lyr is not None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.CreateLayer("test2", options=["IDENTIFIER=test"])
     assert lyr is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.CreateLayer("test2", options=["IDENTIFIER=explicit_identifier"])
     assert lyr is None
 
     ds.ExecuteSQL(
         "INSERT INTO gpkg_contents ( table_name, identifier, data_type ) VALUES ( 'some_table', 'another_identifier', 'some_data_type' )"
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.CreateLayer("test2", options=["IDENTIFIER=another_identifier"])
     assert lyr is None
     ds = None
@@ -3846,7 +3846,7 @@ def test_ogr_gpkg_41():
 
     ds = ogr.Open("/vsimem/ogr_gpkg_41.gpkg")
     lyr = ds.GetLayer(0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     if f["mycol"] != "myval" or f.GetFID() != 1:
         f.DumpReadable()
@@ -3855,7 +3855,7 @@ def test_ogr_gpkg_41():
 
     ds = ogr.Open("/vsimem/ogr_gpkg_41.gpkg")
     lyr = ds.GetLayer(0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetFeature(1)
     if f["mycol"] != "myval" or f.GetFID() != 1:
         f.DumpReadable()
@@ -3981,9 +3981,9 @@ def test_ogr_gpkg_42():
     assert lyr.Rename("bar") == ogr.OGRERR_NONE
     assert lyr.GetDescription() == "bar"
     assert lyr.GetLayerDefn().GetName() == "bar"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.Rename("bar") != ogr.OGRERR_NONE
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.Rename("gpkg_ogr_contents") != ogr.OGRERR_NONE
     assert lyr.GetDescription() == "bar"
     assert lyr.GetLayerDefn().GetName() == "bar"
@@ -4083,7 +4083,7 @@ def test_ogr_gpkg_43():
     assert ds.GetLayerCount() == 1001
 
     with gdaltest.config_option("OGR_TABLE_LIMIT", "1000"):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.OpenEx("/vsimem/ogr_gpkg_43.gpkg")
             assert len(ds.GetMetadata_List("SUBDATASETS")) == 2 * 1000
             assert ds.GetLayerCount() == 1000
@@ -4205,7 +4205,7 @@ def test_ogr_gpkg_46():
     assert lyr.GetGeometryColumn() == "my_geom"
 
     # Operations not valid on a view
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.ReleaseResultSet(
             ds.ExecuteSQL("SELECT CreateSpatialIndex('my_view', 'my_geom')")
         )
@@ -4272,7 +4272,7 @@ def test_ogr_gpkg_47():
     gdal.VSIFCloseL(fp)
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("/vsimem/ogr_gpkg_47.gpkg", update=1)
     assert ds is not None
     assert gdal.GetLastErrorMsg() != ""
@@ -4292,7 +4292,7 @@ def test_ogr_gpkg_47():
     gdal.VSIFCloseL(fp)
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("/vsimem/ogr_gpkg_47.gpkg", update=1)
     assert ds is not None
     assert gdal.GetLastErrorMsg() != ""
@@ -4358,7 +4358,7 @@ def test_ogr_gpkg_47():
     gdal.VSIFCloseL(fp)
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("/vsimem/ogr_gpkg_47.gpkg", update=1)
     assert ds is not None
     assert gdal.GetLastErrorMsg() != ""
@@ -4369,7 +4369,7 @@ def test_ogr_gpkg_47():
     assert gdal.GetLastErrorMsg() == ""
 
     # Just for the sake of coverage testing in DEBUG mode
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdaltest.gpkg_dr.CreateDataSource("/vsimem/.cur_input")
     # Set wrong application_id
     fp = gdal.VSIFOpenL("/vsimem/.cur_input", "rb+")
@@ -4379,7 +4379,7 @@ def test_ogr_gpkg_47():
     ogr.Open("/vsimem/.cur_input")
     gdal.Unlink("/vsimem/.cur_input")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdaltest.gpkg_dr.CreateDataSource("/vsimem/.cur_input", options=["VERSION=1.2"])
     # Set wrong user_version
     fp = gdal.VSIFOpenL("/vsimem/.cur_input", "rb+")
@@ -4551,7 +4551,7 @@ def test_ogr_gpkg_52():
 
     ds = ogr.Open("data/gpkg/poly_non_conformant.gpkg")
     lyr = ds.GetLayer(0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     assert f is not None
 
@@ -4657,7 +4657,7 @@ def test_ogr_gpkg_55():
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometry(ogr.CreateGeometryFromWkt("POINT(0 0)"))
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.CreateFeature(f)
     assert gdal.GetLastErrorMsg() != "", "should have warned"
     f = None
@@ -4750,7 +4750,7 @@ def test_ogr_gpkg_creation_fid():
     f = ogr.Feature(lyr.GetLayerDefn())
     f["fid"] = 1234567890125
     f.SetFID(1)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.CreateFeature(f) == ogr.OGRERR_FAILURE
 
     # Simulates the situation of GeoPackage ---QGIS---> Shapefile --> GeoPackage
@@ -4782,13 +4782,13 @@ def test_ogr_gpkg_creation_fid():
 
     f = ogr.Feature(lyr.GetLayerDefn())
     f["fid"] = 1234567890123.5
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.CreateFeature(f) == ogr.OGRERR_FAILURE
 
     f = ogr.Feature(lyr.GetLayerDefn())
     f["fid"] = 1234567890125
     f.SetFID(1)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.CreateFeature(f) == ogr.OGRERR_FAILURE
 
     ds = None
@@ -4822,7 +4822,7 @@ def test_ogr_gpkg_57():
     ds = None
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open(out_filename)
     assert ds.GetLayerCount() == 1, "bad layer count"
     assert gdal.GetLastErrorMsg() != ""
@@ -4864,7 +4864,7 @@ def test_ogr_gpkg_multiple_geom_columns():
     ds = None
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open(out_filename)
     assert gdal.GetLastErrorMsg() != ""
     assert ds.GetLayerCount() == 2
@@ -5245,31 +5245,31 @@ def test_ogr_gpkg_invalid_values_in_records():
     lyr.ResetReading()
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     assert gdal.GetLastErrorMsg() == "Invalid content for record 1 in column dt: foo"
     assert not f.IsFieldSet("dt")
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     assert gdal.GetLastErrorMsg() == "Invalid content for record 2 in column d: bar"
     assert not f.IsFieldSet("d")
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     assert gdal.GetLastErrorMsg() == "Unexpected data type for record 3 in column dt"
     assert not f.IsFieldSet("dt")
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     assert gdal.GetLastErrorMsg() == "Unexpected data type for record 4 in column d"
     assert not f.IsFieldSet("d")
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     assert (
         gdal.GetLastErrorMsg()
@@ -5279,7 +5279,7 @@ def test_ogr_gpkg_invalid_values_in_records():
     assert f["dt"] == "2020/01/21 12:34:56+01"
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     assert (
         gdal.GetLastErrorMsg()
@@ -5342,7 +5342,7 @@ def test_ogr_gpkg_fixup_wrong_rtree_trigger():
     ds.CreateLayer("test-with-dash")
     ds.CreateLayer("test2")
     ds = None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open(filename, update=1)
         # inject wrong trigger on purpose with the wrong 'OF "geometry" ' part
         ds.ExecuteSQL('DROP TRIGGER "rtree_test-with-dash_geometry_update3"')
@@ -5480,7 +5480,7 @@ def test_abort_sql():
             )
         SELECT i FROM r WHERE i = 1;"""
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.ExecuteSQL(sql)
 
     end = time.time()
@@ -5499,7 +5499,7 @@ def test_abort_sql():
     start = time.time()
 
     # Long running query
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds2.ExecuteSQL(sql)
 
     end = time.time()
@@ -6224,22 +6224,22 @@ def test_ogr_gpkg_field_domains_errors():
 
     assert ds.GetFieldDomain("null_constraint_type") is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.ErrorReset()
         assert ds.GetFieldDomain("invalid_constraint_type") is None
         assert gdal.GetLastErrorMsg() != ""
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.ErrorReset()
         assert ds.GetFieldDomain("mix_glob_enum") is None
         assert gdal.GetLastErrorMsg() != ""
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.ErrorReset()
         assert ds.GetFieldDomain("null_in_enum_code") is None
         assert gdal.GetLastErrorMsg() != ""
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.ErrorReset()
         assert ds.GetFieldDomain("null_in_glob_value") is None
         assert gdal.GetLastErrorMsg() != ""
@@ -7764,7 +7764,7 @@ def test_ogr_gpkg_arrow_stream_numpy():
 
     # Check that OGR_GPKG_FillArrowArray_INTERNAL() function is no longer
     # registered
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = ds.ExecuteSQL(
             "SELECT 1 FROM pragma_function_list WHERE name=lower('OGR_GPKG_FillArrowArray_INTERNAL')"
         )
@@ -7801,7 +7801,7 @@ def test_ogr_gpkg_immutable():
         # Turn directory in read-only mode
         os.chmod("tmp/read_only_test_ogr_gpkg_immutable", 0o555)
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert (
                 gdal.OpenEx(
                     "tmp/read_only_test_ogr_gpkg_immutable/test.gpkg",
@@ -7830,7 +7830,7 @@ def test_ogr_gpkg_immutable():
         assert gdal.GetLastErrorMsg() == ""
 
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert (
                 ogr.Open("tmp/read_only_test_ogr_gpkg_immutable/test.gpkg") is not None
             )
@@ -8045,7 +8045,7 @@ def test_ogr_gpkg_get_geometry_types():
         ogr.wkbTINZ: 1,
     }
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         with pytest.raises(Exception):
             lyr.GetGeometryTypes(geom_field=1)
 
@@ -8057,7 +8057,7 @@ def test_ogr_gpkg_get_geometry_types():
         f.SetGeometry(ogr.CreateGeometryFromWkt("POINT EMPTY"))
         lyr.CreateFeature(f)
     lyr.CommitTransaction()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         with pytest.raises(Exception):
             lyr.GetGeometryTypes(callback=lambda x, y, z: 0)
 
@@ -8223,7 +8223,7 @@ def test_ogr_gpkg_detect_broken_rtree_gdal_3_6_0():
     with gdaltest.config_option("OGR_GPKG_THRESHOLD_DETECT_BROKEN_RTREE", "100"):
         ds = ogr.Open(filename)
         lyr = ds.GetLayer(0)
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             gdal.ErrorReset()
             lyr.SetSpatialFilterRect(8.5, 8.5, 9.5, 9.5)
             assert (
@@ -8415,7 +8415,7 @@ def test_ogr_gpkg_sql_gdal_get_pixel_value():
     assert f[0] is None
 
     # Missing OGR_SQLITE_ALLOW_EXTERNAL_ACCESS
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = ds.ExecuteSQL(
             "select gdal_get_pixel_value('../gcore/data/byte.tif', 1, 'georef', 440720, 3751320)"
         )
@@ -8424,7 +8424,7 @@ def test_ogr_gpkg_sql_gdal_get_pixel_value():
         assert f[0] is None
 
     # NULL as 1st arg
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         with gdaltest.config_option("OGR_SQLITE_ALLOW_EXTERNAL_ACCESS", "YES"):
             sql_lyr = ds.ExecuteSQL(
                 "select gdal_get_pixel_value(NULL, 1, 'pixel', 0, 0)"
@@ -8434,7 +8434,7 @@ def test_ogr_gpkg_sql_gdal_get_pixel_value():
         assert f[0] is None
 
     # NULL as 2nd arg
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         with gdaltest.config_option("OGR_SQLITE_ALLOW_EXTERNAL_ACCESS", "YES"):
             sql_lyr = ds.ExecuteSQL(
                 "select gdal_get_pixel_value('../gcore/data/byte.tif', NULL, 'pixel', 0, 0)"
@@ -8444,7 +8444,7 @@ def test_ogr_gpkg_sql_gdal_get_pixel_value():
         assert f[0] is None
 
     # NULL as 3rd arg
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         with gdaltest.config_option("OGR_SQLITE_ALLOW_EXTERNAL_ACCESS", "YES"):
             sql_lyr = ds.ExecuteSQL(
                 "select gdal_get_pixel_value('../gcore/data/byte.tif', 1, NULL, 0, 0)"
@@ -8454,7 +8454,7 @@ def test_ogr_gpkg_sql_gdal_get_pixel_value():
         assert f[0] is None
 
     # NULL as 4th arg
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         with gdaltest.config_option("OGR_SQLITE_ALLOW_EXTERNAL_ACCESS", "YES"):
             sql_lyr = ds.ExecuteSQL(
                 "select gdal_get_pixel_value('../gcore/data/byte.tif', 1, 'pixel', NULL, 0)"
@@ -8464,7 +8464,7 @@ def test_ogr_gpkg_sql_gdal_get_pixel_value():
         assert f[0] is None
 
     # NULL as 5th arg
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         with gdaltest.config_option("OGR_SQLITE_ALLOW_EXTERNAL_ACCESS", "YES"):
             sql_lyr = ds.ExecuteSQL(
                 "select gdal_get_pixel_value('../gcore/data/byte.tif', 1, 'pixel', 0, NULL)"
@@ -8474,7 +8474,7 @@ def test_ogr_gpkg_sql_gdal_get_pixel_value():
         assert f[0] is None
 
     # Invalid band number
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         with gdaltest.config_option("OGR_SQLITE_ALLOW_EXTERNAL_ACCESS", "YES"):
             sql_lyr = ds.ExecuteSQL(
                 "select gdal_get_pixel_value('../gcore/data/byte.tif', 0, 'pixel', 0, 0)"
@@ -8484,7 +8484,7 @@ def test_ogr_gpkg_sql_gdal_get_pixel_value():
         assert f[0] is None
 
     # Invalid value for 3rd argument
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         with gdaltest.config_option("OGR_SQLITE_ALLOW_EXTERNAL_ACCESS", "YES"):
             sql_lyr = ds.ExecuteSQL(
                 "select gdal_get_pixel_value('../gcore/data/byte.tif', 1, 'invalid', 0, 0)"
@@ -8646,7 +8646,7 @@ def test_ogr_gpkg_ogr_layer_Extent():
         feat = None
 
         # Test with invalid parameter
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             sql_lyr = ds.ExecuteSQL("SELECT ogr_layer_Extent(12)")
         feat = sql_lyr.GetNextFeature()
         geom = feat.GetGeometryRef()
@@ -8655,7 +8655,7 @@ def test_ogr_gpkg_ogr_layer_Extent():
         assert geom is None
 
         # Test on non existing layer
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             sql_lyr = ds.ExecuteSQL("SELECT ogr_layer_Extent('foo')")
         feat = sql_lyr.GetNextFeature()
         geom = feat.GetGeometryRef()

--- a/autotest/ogr/ogr_gpsbabel.py
+++ b/autotest/ogr/ogr_gpsbabel.py
@@ -56,7 +56,7 @@ pytestmark = [
 def startup_and_cleanup():
 
     # Check that the GPX driver has read support
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         if ogr.Open("data/gpx/test.gpx") is None:
             assert "Expat" in gdal.GetLastErrorMsg()
             pytest.skip("GDAL build without Expat support")

--- a/autotest/ogr/ogr_gpx.py
+++ b/autotest/ogr/ogr_gpx.py
@@ -30,7 +30,6 @@
 
 import os
 
-import gdaltest
 import ogrtest
 import pytest
 
@@ -43,7 +42,7 @@ pytestmark = pytest.mark.require_driver("GPX")
 def startup_and_cleanup():
 
     # Check that the GPX driver has read support
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         if ogr.Open("data/gpx/test.gpx") is None:
             assert "Expat" in gdal.GetLastErrorMsg()
             pytest.skip("GDAL build without Expat support")
@@ -69,7 +68,7 @@ def test_ogr_gpx_1():
 
     expect = [2, None]
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ogrtest.check_features_against_list(lyr, "ele", expect)
 
     lyr.ResetReading()
@@ -211,7 +210,7 @@ def test_ogr_gpx_5():
 def test_ogr_gpx_6():
     gpx_ds = ogr.Open("data/gpx/test.gpx")
     try:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ogr.GetDriverByName("CSV").DeleteDataSource("tmp/gpx.gpx")
     except Exception:
         pass

--- a/autotest/ogr/ogr_hana.py
+++ b/autotest/ogr/ogr_hana.py
@@ -683,7 +683,7 @@ def test_ogr_hana_21():
         get_test_name(), geom_type=ogr.wkbNone, options=["FID=fid", "LAUNDER=NO"]
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert layer.CreateField(ogr.FieldDefn("str", ogr.OFTString)) == 0
         assert layer.CreateField(ogr.FieldDefn("fid", ogr.OFTString)) != 0
         assert layer.CreateField(ogr.FieldDefn("fid", ogr.OFTInteger)) != 0
@@ -770,7 +770,7 @@ def test_ogr_hana_25(ogrsf_path):
 def test_ogr_hana_26():
     ds = open_datasource()
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         layer = ds.ExecuteSQL("SELECT FROM")
     assert gdal.GetLastErrorMsg() != ""
     assert layer is None
@@ -853,7 +853,7 @@ def test_ogr_hana_28():
 def test_ogr_hana_29():
     ds_ro = open_datasource(0)
     layer = ds_ro.GetLayerByName("TPOLY")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             layer.CreateGeomField(ogr.GeomFieldDefn("GEOM_FIELD", ogr.wkbPoint))
             == ogr.OGRERR_FAILURE
@@ -864,7 +864,7 @@ def test_ogr_hana_29():
     create_tpoly_table(ds_rw, layer_name)
 
     layer = ds_rw.GetLayerByName(layer_name)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # unsupported geometry type
         assert (
             layer.CreateGeomField(ogr.GeomFieldDefn("GEOM_FIELD", ogr.wkbCompoundCurve))
@@ -952,7 +952,7 @@ def test_ogr_hana_32():
     ds = open_datasource(1)
     layer_name = get_test_name() + "_TABLE_\U0001f608"
     sql = "CREATE COLUMN TABLE %s (A INT, B INT)" % layer_name
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.ExecuteSQL(sql)
 
     ds = open_datasource(0)
@@ -1000,7 +1000,7 @@ def test_ogr_hana_33():
 
 def test_ogr_hana_34():
     def test_connection(conn_str, expected_param):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = ogr.Open("HANA:" + conn_str, update=1)
         assert ds is None
         expected_msg = (
@@ -1096,7 +1096,7 @@ def test_ogr_hana_36():
     assert ds.TestCapability(ogr.ODsCTransactions) == 1
 
     # test data source
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.StartTransaction() == 0
         assert ds.CommitTransaction() == 0
 
@@ -1114,7 +1114,7 @@ def test_ogr_hana_36():
     layer_name = get_test_name()
     create_tpoly_table(ds, layer_name)
     layer = ds.GetLayerByName(layer_name)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert layer.StartTransaction() == 0
         assert layer.CommitTransaction() == 0
 
@@ -1172,7 +1172,7 @@ def test_ogr_hana_37():
 
 
 def create_tpoly_table(ds, layer_name="TPOLY"):
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.ExecuteSQL("DELLAYER:%s" % layer_name)
 
     shp_ds = ogr.Open("data/poly.shp")
@@ -1260,7 +1260,7 @@ def create_connection():
     except ValueError as e:
         raise ValueError(f"Failed to parse connection params {conn_str} ({e})")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         conn = dbapi.connect(
             address=conn_params["HOST"],
             port=conn_params["PORT"],

--- a/autotest/ogr/ogr_ili.py
+++ b/autotest/ogr/ogr_ili.py
@@ -166,7 +166,7 @@ def test_ogr_interlis1_5():
     driver = ogr.GetDriverByName("Interlis 1")
     outfile = "tmp/interlis1_5.itf"
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         dst_ds = driver.CreateDataSource(outfile)
 
     dst_lyr = dst_ds.CreateLayer("FormatTests__FormatTable")

--- a/autotest/ogr/ogr_jml.py
+++ b/autotest/ogr/ogr_jml.py
@@ -124,7 +124,7 @@ def test_ogr_jml_1():
 def test_ogr_jml_2():
 
     # Invalid filename
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.GetDriverByName("JML").CreateDataSource("/foo/ogr_jml.jml")
     ds = None
 
@@ -176,7 +176,7 @@ def test_ogr_jml_2():
     lyr.CreateField(ogr.FieldDefn("datetime", ogr.OFTDateTime))
     lyr.CreateField(ogr.FieldDefn("datetime2", ogr.OFTDateTime))
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.CreateField(ogr.FieldDefn("time_as_str", ogr.OFTTime))
 
     assert lyr.TestCapability(ogr.OLCCreateField) == 1
@@ -456,7 +456,7 @@ def test_ogr_jml_4():
 
     ds = ogr.Open("/vsimem/ogr_jml.jml")
     lyr = ds.GetLayer(0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.GetLayerDefn()
     assert gdal.GetLastErrorType() != 0
     ds = None
@@ -480,7 +480,7 @@ def test_ogr_jml_4():
 
     ds = ogr.Open("/vsimem/ogr_jml.jml")
     lyr = ds.GetLayer(0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.GetLayerDefn()
     assert gdal.GetLastErrorType() != 0
     ds = None
@@ -510,7 +510,7 @@ def test_ogr_jml_4():
 
     ds = ogr.Open("/vsimem/ogr_jml.jml")
     lyr = ds.GetLayer(0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.GetLayerDefn().GetFieldCount()
     assert gdal.GetLastErrorType() != 0
     ds = None
@@ -541,7 +541,7 @@ def test_ogr_jml_4():
 
     ds = ogr.Open("/vsimem/ogr_jml.jml")
     lyr = ds.GetLayer(0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.GetLayerDefn().GetFieldCount()
     assert gdal.GetLastErrorType() != 0
     del ds

--- a/autotest/ogr/ogr_libkml.py
+++ b/autotest/ogr/ogr_libkml.py
@@ -800,7 +800,7 @@ def test_ogr_libkml_camera():
     dst_feat.SetField("heading", 70)
     dst_feat.SetField("tilt", 75)
     dst_feat.SetField("roll", 10)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.CreateFeature(dst_feat)
 
     dst_feat = ogr.Feature(lyr.GetLayerDefn())
@@ -963,7 +963,7 @@ def test_ogr_libkml_write_multigeometry():
     feat = ogr.Feature(lyr.GetLayerDefn())
     # Warning emitted per ATC 66
     feat.SetGeometry(ogr.CreateGeometryFromWkt("MULTIPOINT EMPTY"))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.CreateFeature(feat)
 
     ds = None
@@ -1596,7 +1596,7 @@ def test_ogr_libkml_write_update():
         )
         lyr = ds.CreateLayer("layer_to_edit")
         feat = ogr.Feature(lyr.GetLayerDefn())
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             lyr.CreateFeature(feat)
         feat.SetFID(10)
         assert lyr.CreateFeature(feat) == 0
@@ -1712,7 +1712,7 @@ def test_ogr_libkml_write_liststyle():
     ds.CreateLayer(
         "test_checkHideChildren", options=["LISTSTYLE_TYPE=checkHideChildren"]
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.CreateLayer("test_error", options=["LISTSTYLE_TYPE=error"])
         ds = None
 

--- a/autotest/ogr/ogr_mem.py
+++ b/autotest/ogr/ogr_mem.py
@@ -242,7 +242,7 @@ def test_ogr_mem_8():
     # Test expected failed case of SetFeature()
     new_feat = ogr.Feature(gdaltest.mem_lyr.GetLayerDefn())
     new_feat.SetFID(-2)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = gdaltest.mem_lyr.SetFeature(new_feat)
     assert ret != 0
     new_feat = None
@@ -739,7 +739,7 @@ def test_ogr_mem_arrow_stream_numpy():
     stream = lyr.GetArrowStreamAsNumPy()
 
     with pytest.raises(Exception):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             lyr.GetArrowStreamAsNumPy()
 
     it = iter(stream)
@@ -933,7 +933,7 @@ def test_ogr_mem_arrow_stream_pyarrow():
     stream = lyr.GetArrowStreamAsPyArrow()
 
     with pytest.raises(Exception):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             lyr.GetArrowStreamAsPyArrow()
 
     it = iter(stream)

--- a/autotest/ogr/ogr_mitab.py
+++ b/autotest/ogr/ogr_mitab.py
@@ -756,7 +756,7 @@ def test_ogr_mitab_21():
     lyr = ds.CreateLayer("test")
     feat = ogr.Feature(lyr.GetLayerDefn())
     feat.SetGeometryDirectly(ogr.CreateGeometryFromWkt("POINT (0 0)"))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.CreateFeature(feat)
     ds = None
 
@@ -1054,14 +1054,14 @@ def test_ogr_mitab_27():
 
     # Invalid call : feature without FID
     f = ogr.Feature(lyr.GetLayerDefn())
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetFeature(f)
     assert ret != 0
 
     # Invalid call : feature with FID <= 0
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetFID(0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetFeature(f)
     assert ret != 0
 
@@ -1076,7 +1076,7 @@ def test_ogr_mitab_27():
     # Invalid call : feature with FID > feature_count
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetFID(2)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetFeature(f)
     assert ret != 0
 
@@ -1967,7 +1967,7 @@ def test_ogr_mitab_40():
 
     for i in range(len(content)):
         gdal.FileFromMemBuffer("/vsimem/ogr_mitab_40.mif", content[0:i])
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = ogr.Open("/vsimem/ogr_mitab_40.mif")
             if ds is not None:
                 lyr = ds.GetLayer(0)
@@ -2039,7 +2039,7 @@ def test_ogr_mitab_43():
         format="MapInfo File",
         datasetCreationOptions=["BLOCKSIZE=32256"],
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdal.VectorTranslate(
             "/vsimem/all_geoms_block_invalid.tab",
             src_ds,
@@ -2367,7 +2367,7 @@ def test_ogr_mitab_tab_field_index_creation():
     lyr = ds.CreateLayer(layername)
     lyr.CreateField(ogr.FieldDefn("id", ogr.OFTInteger))
     lyr.CreateField(ogr.FieldDefn("other_field", ogr.OFTInteger))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.ExecuteSQL("CREATE INDEX ON foo USING id")
         ds.ExecuteSQL("CREATE INDEX ON " + layername + " USING foo")
     ds.ExecuteSQL("CREATE INDEX ON " + layername + " USING id")
@@ -2383,7 +2383,7 @@ def test_ogr_mitab_tab_field_index_creation():
     assert gdal.VSIStatL("/vsimem/" + layername + ".ind") is not None, "no ind file"
 
     ds = ogr.Open(filename)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.ExecuteSQL("CREATE INDEX ON " + layername + " USING other_field")
     lyr = ds.GetLayer(0)
     lyr.SetAttributeFilter("id = 200")
@@ -2482,7 +2482,7 @@ def test_ogr_mitab_tab_write_field_name_with_dot():
     f["with.dot"] = 1
     f.SetGeometryDirectly(ogr.CreateGeometryFromWkt("POINT(2 3)"))
     lyr.CreateFeature(f)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = None
 
     ds = ogr.Open(tmpfile)
@@ -2578,7 +2578,7 @@ def test_ogr_mitab_too_large_value_for_decimal_field():
 
     f = ogr.Feature(lyr.GetLayerDefn())
     f["f"] = 123456789.012
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.CreateFeature(f) != ogr.OGRERR_NONE
     f = None
 

--- a/autotest/ogr/ogr_mongodbv3.py
+++ b/autotest/ogr/ogr_mongodbv3.py
@@ -128,21 +128,21 @@ def test_ogr_mongodbv3_1():
         pytest.skip()
 
     # Might work or not depending on how the db is set up
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("mongodbv3:")
 
     # Wrong URI
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("mongodbv3:mongodb://")
     assert ds is None
 
     # URI to non existent host.
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("mongodbv3:mongodb://non_existing")
     assert ds is None
 
     # Connect to non existent host.
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx("mongodbv3:", open_options=["HOST=non_existing"])
     assert ds is None
 
@@ -169,7 +169,7 @@ def test_ogr_mongodbv3_1():
         open_options += ["USER=" + ogrtest.mongodbv3_test_user]
         open_options += ["PASSWORD=" + ogrtest.mongodbv3_test_password]
     # Will succeed only against server in single mode
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx("mongodbv3:", open_options=open_options)
 
     # A few error cases with authentication
@@ -179,7 +179,7 @@ def test_ogr_mongodbv3_1():
         open_options += ["PORT=" + str(ogrtest.mongodbv3_test_port)]
         open_options += ["DBNAME=" + ogrtest.mongodbv3_test_dbname]
         # Missing user and password
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.OpenEx("mongodbv3:", open_options=open_options)
         assert ds is None
 
@@ -189,7 +189,7 @@ def test_ogr_mongodbv3_1():
         open_options += ["DBNAME=" + ogrtest.mongodbv3_test_dbname]
         open_options += ["USER=" + ogrtest.mongodbv3_test_user]
         # Missing password
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.OpenEx("mongodbv3:", open_options=open_options)
         assert ds is None
 
@@ -199,7 +199,7 @@ def test_ogr_mongodbv3_1():
         open_options += ["USER=" + ogrtest.mongodbv3_test_user]
         open_options += ["PASSWORD=" + ogrtest.mongodbv3_test_password]
         # Missing DBNAME
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.OpenEx("mongodbv3:", open_options=open_options)
         assert ds is None
 
@@ -210,7 +210,7 @@ def test_ogr_mongodbv3_1():
         open_options += ["USER=" + ogrtest.mongodbv3_test_user]
         open_options += ["PASSWORDv3=" + ogrtest.mongodbv3_test_password + "_wrong"]
         # Wrong password
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.OpenEx("mongodb:", open_options=open_options)
         assert ds is None
 
@@ -247,14 +247,14 @@ def test_ogr_mongodbv3_2():
         options=["GEOMETRY_NAME=location.mygeom", "FID="],
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateGeomField(ogr.GeomFieldDefn("location.mygeom", ogr.wkbPoint))
     assert ret != 0
 
     ret = lyr.CreateField(ogr.FieldDefn("str", ogr.OFTString))
     assert ret == 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateField(ogr.FieldDefn("str", ogr.OFTString))
     assert ret != 0
 
@@ -335,7 +335,7 @@ def test_ogr_mongodbv3_2():
         pytest.fail()
 
     # Test (not working) DeleteFeature()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.DeleteFeature(1)
     assert ret != 0
 
@@ -391,7 +391,7 @@ def test_ogr_mongodbv3_2():
     assert lyr.CreateFeature(f) == 0
 
     # Duplicate key
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SyncToDisk()
     assert ret != 0
 
@@ -402,16 +402,16 @@ def test_ogr_mongodbv3_2():
 
     # Missing _id
     f.UnsetField("_id")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetFeature(f)
     assert ret != 0
 
     # MongoDB dialect of ExecuteSQL() with invalid JSON
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = ogrtest.mongodbv3_ds.ExecuteSQL("{", dialect="MongoDB")
 
     # MongoDB dialect of ExecuteSQL() with nonexistent command.
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = ogrtest.mongodbv3_ds.ExecuteSQL('{ "foo": 1 }', dialect="MongoDB")
     assert sql_lyr is None
 
@@ -437,7 +437,7 @@ def test_ogr_mongodbv3_2():
     ogrtest.mongodbv3_ds.ReleaseResultSet(sql_lyr)
 
     # Test CreateLayer again with same name
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ogrtest.mongodbv3_ds.CreateLayer(ogrtest.mongodbv3_layer_name)
     assert lyr is None
 
@@ -799,47 +799,47 @@ def test_ogr_mongodbv3_2():
     f = lyr.GetNextFeature()
     assert f is not None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ogrtest.mongodbv3_ds.CreateLayer("foo")
     assert lyr is None
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ogrtest.mongodbv3_ds.ExecuteSQL(
             "WRITE_OGR_METADATA " + ogrtest.mongodbv3_layer_name
         )
     assert gdal.GetLastErrorMsg() != ""
 
     lyr_count_before = ogrtest.mongodbv3_ds.GetLayerCount()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ogrtest.mongodbv3_ds.ExecuteSQL("DELLAYER:" + ogrtest.mongodbv3_layer_name)
     assert ogrtest.mongodbv3_ds.GetLayerCount() == lyr_count_before
 
     lyr = ogrtest.mongodbv3_ds.GetLayerByName(ogrtest.mongodbv3_layer_name)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateField(ogr.FieldDefn("foo", ogr.OFTString))
     assert ret != 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateGeomField(ogr.GeomFieldDefn("foo", ogr.wkbPoint))
     assert ret != 0
 
     f = ogr.Feature(lyr.GetLayerDefn())
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(f)
     assert ret != 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetFeature(f)
     assert ret != 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.DeleteFeature(1)
     assert ret != 0
 
     # Upsert fails in read-only
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.UpsertFeature(f)
     assert ret != 0
 
@@ -989,7 +989,7 @@ def test_ogr_mongodbv3_update_feature():
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetFID(1)
     f.SetField("test", "updated")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             lyr.UpdateFeature(f, [lyr.GetLayerDefn().GetFieldIndex("test")], [], False)
             != ogr.OGRERR_NONE

--- a/autotest/ogr/ogr_mssqlspatial.py
+++ b/autotest/ogr/ogr_mssqlspatial.py
@@ -567,7 +567,7 @@ def test_ogr_mssqlspatial_bulk_insert():
         assert source_ds
 
         try:
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ds = gdal.VectorTranslate(
                     gdaltest.mssqlspatial_dsname,
                     "data/poly.shp",
@@ -599,7 +599,7 @@ def test_ogr_mssqlspatial_geography_polygon_vertex_order():
     assert source_ds
 
     try:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = gdal.VectorTranslate(
                 gdaltest.mssqlspatial_dsname,
                 "data/shp/testpoly.shp",

--- a/autotest/ogr/ogr_mvt.py
+++ b/autotest/ogr/ogr_mvt.py
@@ -165,7 +165,7 @@ def test_ogr_mvt_datatype_promotion():
 
 def test_ogr_mvt_limit_cases():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("data/mvt/limit_cases.pbf")
 
     lyr = ds.GetLayerByName("empty")
@@ -639,7 +639,7 @@ def test_ogr_mvt_errors():
     gdal.Rmdir("/vsimem/33")
 
     # Inexisting metadata
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             gdal.OpenEx(
                 "data/mvt/linestring/0/0/0.pbf",
@@ -649,7 +649,7 @@ def test_ogr_mvt_errors():
         )
 
     # Invalid metadata
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             gdal.OpenEx(
                 "data/mvt/linestring/0/0/0.pbf",
@@ -660,7 +660,7 @@ def test_ogr_mvt_errors():
 
     # Invalid metadata
     gdal.FileFromMemBuffer("/vsimem/my.json", "{}")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             gdal.OpenEx(
                 "data/mvt/linestring/0/0/0.pbf",
@@ -672,7 +672,7 @@ def test_ogr_mvt_errors():
 
     # Invalid metadata
     gdal.FileFromMemBuffer("/vsimem/my.json", '{ "json": "x y" }')
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             gdal.OpenEx(
                 "data/mvt/linestring/0/0/0.pbf",
@@ -867,7 +867,7 @@ def test_ogr_mvt_write_one_layer(has_make_valid):
     lyr.CreateField(boolfield)
 
     # Test empty layer: OK
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdal.VectorTranslate("/vsimem/outmvt", src_ds, format="MVT")
     assert out_ds is not None
 
@@ -956,7 +956,7 @@ def test_ogr_mvt_write_one_layer(has_make_valid):
     )
     lyr.CreateFeature(f)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = gdal.VectorTranslate(
             "/vsimem/outmvt", src_ds, options="-f MVT -preserve_fid"
         )
@@ -1606,13 +1606,13 @@ def test_ogr_mvt_write_errors():
     # Raster creation attempt
     if gdal.VSIStatL("/vsimem/foo") is not None:
         gdal.RmdirRecursive("/vsimem/foo")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.GetDriverByName("MVT").Create("/vsimem/foo", 1, 1)
     assert ds is None
 
     # should have mbtiles extension
     gdal.RmdirRecursive("/vsimem/foo.bar")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.GetDriverByName("MVT").CreateDataSource(
             "/vsimem/foo.bar", options=["FORMAT=MBTILES"]
         )
@@ -1620,14 +1620,14 @@ def test_ogr_mvt_write_errors():
 
     # Cannot create temporary database
     gdal.RmdirRecursive("/vsimem/foo")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.GetDriverByName("MVT").CreateDataSource(
             "/vsimem/foo", options=["TEMPORARY_DB=/i/do_not/exist.db"]
         )
     assert ds is None
 
     # cannot create mbtiles file
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.GetDriverByName("MVT").CreateDataSource(
             "/i/do_not/exist.mbtiles", options=["TEMPORARY_DB=/vsimem/temp.db"]
         )
@@ -1636,12 +1636,12 @@ def test_ogr_mvt_write_errors():
 
     # invalid MINZOOM
     gdal.RmdirRecursive("/vsimem/foo")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.GetDriverByName("MVT").CreateDataSource(
             "/vsimem/foo", options=["MINZOOM=-1"]
         )
     assert ds is None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.GetDriverByName("MVT").CreateDataSource(
             "/vsimem/foo", options=["MINZOOM=30"]
         )
@@ -1649,12 +1649,12 @@ def test_ogr_mvt_write_errors():
 
     # invalid MAXZOOM
     gdal.RmdirRecursive("/vsimem/foo")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.GetDriverByName("MVT").CreateDataSource(
             "/vsimem/foo", options=["MAXZOOM=-1"]
         )
     assert ds is None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.GetDriverByName("MVT").CreateDataSource(
             "/vsimem/foo", options=["MAXZOOM=30"]
         )
@@ -1662,7 +1662,7 @@ def test_ogr_mvt_write_errors():
 
     # invalid MINZOOM vs MAXZOOM
     gdal.RmdirRecursive("/vsimem/foo")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.GetDriverByName("MVT").CreateDataSource(
             "/vsimem/foo", options=["MINZOOM=1", "MAXZOOM=0"]
         )
@@ -1671,14 +1671,14 @@ def test_ogr_mvt_write_errors():
     # invalid MINZOOM for layer
     gdal.RmdirRecursive("/vsimem/foo")
     ds = ogr.GetDriverByName("MVT").CreateDataSource("/vsimem/foo")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.CreateLayer("foo", options=["MINZOOM=-1"])
     assert lyr is None
 
     # invalid CONF
     gdal.RmdirRecursive("/vsimem/foo")
     gdal.FileFromMemBuffer("/vsimem/invalid.json", "foo bar")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.GetDriverByName("MVT").CreateDataSource(
             "/vsimem/foo", options=["CONF=/vsimem/invalid.json"]
         )
@@ -1686,7 +1686,7 @@ def test_ogr_mvt_write_errors():
     assert ds is None
 
     # TILING_SCHEME not allowed with MBTILES
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.GetDriverByName("MVT").CreateDataSource(
             "/vsimem/foo.mbtiles", options=["TILING_SCHEME=EPSG:4326,-180,180,360"]
         )
@@ -1694,7 +1694,7 @@ def test_ogr_mvt_write_errors():
 
     # Invalid TILING_SCHEME
     gdal.RmdirRecursive("/vsimem/foo")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.GetDriverByName("MVT").CreateDataSource(
             "/vsimem/foo", options=["TILING_SCHEME=EPSG:4326"]
         )
@@ -1708,7 +1708,7 @@ def test_ogr_mvt_write_errors():
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometry(ogr.CreateGeometryFromWkt("POINT(0 0)"))
     lyr.CreateFeature(f)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = None
     assert gdal.GetLastErrorMsg() != ""
     gdal.RmdirRecursive("tmp/tmpmvt")
@@ -1724,7 +1724,7 @@ def test_ogr_mvt_write_errors():
     lyr = ds.CreateLayer("test")
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometry(ogr.CreateGeometryFromWkt("GEOMETRYCOLLECTION(POINT(0 0))"))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.CreateFeature(f)
         ds = None
     assert gdal.GetLastErrorMsg() != ""
@@ -1742,7 +1742,7 @@ def test_ogr_mvt_write_errors():
     lyr = ds.CreateLayer("test")
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometry(ogr.CreateGeometryFromWkt("GEOMETRYCOLLECTION(POINT(0 0))"))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.CreateFeature(f)
         ds = None
     assert gdal.GetLastErrorMsg() != ""
@@ -1751,7 +1751,7 @@ def test_ogr_mvt_write_errors():
     # Test reprojection failure
     gdal.RmdirRecursive("/vsimem/foo")
     ds = ogr.GetDriverByName("MVT").CreateDataSource("/vsimem/foo")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.CreateLayer("test", srs=osr.SpatialReference())
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometry(ogr.CreateGeometryFromWkt("POINT(0 0)"))

--- a/autotest/ogr/ogr_mysql.py
+++ b/autotest/ogr/ogr_mysql.py
@@ -601,7 +601,7 @@ def test_ogr_mysql_21():
     dst_feat.SetField("name", "name")
 
     # The insertion MUST fail
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         layer.CreateFeature(dst_feat)
 
     dst_feat.Destroy()
@@ -780,7 +780,7 @@ def test_ogr_mysql_25():
     # Error case: missing geometry
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetField("field_not_nullable", "not_null")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(f)
     assert ret != 0
     f = None
@@ -790,7 +790,7 @@ def test_ogr_mysql_25():
         # hum mysql seems OK with unset non-nullable fields ??
         f = ogr.Feature(lyr.GetLayerDefn())
         f.SetGeometryDirectly(ogr.CreateGeometryFromWkt("POINT(0 0)"))
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = lyr.CreateFeature(f)
         assert ret != 0
         f = None
@@ -1123,7 +1123,7 @@ def test_ogr_mysql_cleanup():
     gdaltest.mysql_ds.ExecuteSQL("DROP TABLE tpoly")
     gdaltest.mysql_ds.ExecuteSQL("DROP TABLE `select`")
     gdaltest.mysql_ds.ExecuteSQL("DROP TABLE tablewithspatialindex")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdaltest.mysql_ds.ExecuteSQL("DROP TABLE tablewithoutspatialindex")
     gdaltest.mysql_ds.ExecuteSQL("DROP TABLE geometry_columns")
     if not gdaltest.is_mysql_8_or_later:

--- a/autotest/ogr/ogr_ngw.py
+++ b/autotest/ogr/ogr_ngw.py
@@ -120,7 +120,7 @@ def startup_and_cleanup():
 def test_ogr_ngw_2():
 
     create_url = "NGW:" + gdaltest.ngw_test_server + "/resource/0/" + get_new_name()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdaltest.ngw_ds = gdal.GetDriverByName("NGW").Create(
             create_url,
             0,
@@ -286,7 +286,7 @@ def test_ogr_ngw_5():
 
     # Test forbidden field names.
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fld_defn = ogr.FieldDefn("id", ogr.OFTInteger)
         lyr.CreateField(fld_defn)
     assert gdal.GetLastErrorMsg() != "", "Expecting a warning"
@@ -474,7 +474,7 @@ def test_ogr_ngw_7():
     lyr.DeleteFeature(f.GetFID())
 
     # Expected fail to get feature
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetFeature(f.GetFID())
     assert f is None, "Failed to delete feature #{}.".format(f.GetFID())
 

--- a/autotest/ogr/ogr_oci.py
+++ b/autotest/ogr/ogr_oci.py
@@ -32,7 +32,7 @@ import gdaltest
 import ogrtest
 import pytest
 
-from osgeo import ogr, osr
+from osgeo import gdal, ogr, osr
 
 pytestmark = [
     pytest.mark.skipif(
@@ -81,7 +81,7 @@ def setup_tests():
 
 def test_ogr_oci_2():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdaltest.oci_ds.ExecuteSQL("DELLAYER:tpoly")
 
     ######################################################
@@ -290,7 +290,7 @@ def test_ogr_oci_8():
     #######################################################
     # Preclean.
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdaltest.oci_ds.ExecuteSQL("DELLAYER:testsrs")
 
     #######################################################
@@ -337,7 +337,7 @@ def test_ogr_oci_9():
     #######################################################
     # Preclean.
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdaltest.oci_ds.ExecuteSQL("DELLAYER:testsrs2")
 
     #######################################################
@@ -373,7 +373,7 @@ def test_ogr_oci_9():
 def test_ogr_oci_10():
 
     # Create a test table.
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdaltest.oci_ds.ExecuteSQL("drop table geom_test")
 
     gdaltest.oci_ds.ExecuteSQL(
@@ -797,7 +797,7 @@ def test_ogr_oci_20():
     # Error case: missing geometry
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetField("field_not_nullable", "not_null")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(f)
     assert ret != 0
     f = None
@@ -805,7 +805,7 @@ def test_ogr_oci_20():
     # Error case: missing non-nullable field
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometryDirectly(ogr.CreateGeometryFromWkt("POINT(0 0)"))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(f)
     assert ret != 0
     f = None

--- a/autotest/ogr/ogr_ods.py
+++ b/autotest/ogr/ogr_ods.py
@@ -286,7 +286,7 @@ def test_ogr_ods_6():
 
     src_ds = ogr.Open("ODS:data/ods/content_formulas.xml")
     filepath = "/vsimem/content_formulas.csv"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         out_ds = ogr.GetDriverByName("CSV").CopyDataSource(src_ds, filepath)
     assert out_ds is not None, "Unable to create %s." % filepath
     out_ds = None

--- a/autotest/ogr/ogr_openfilegdb.py
+++ b/autotest/ogr/ogr_openfilegdb.py
@@ -1208,7 +1208,7 @@ def test_ogr_openfilegdb_10():
         ]:
             for offset in offsets:
                 backup = fuzz(filename, offset)
-                with gdaltest.error_handler():
+                with gdal.quiet_errors():
                     gdal.ErrorReset()
                     ds = ogr.Open("tmp/testopenfilegdb_fuzzed.gdb")
                     error_msg = gdal.GetLastErrorMsg()
@@ -1267,7 +1267,7 @@ def test_ogr_openfilegdb_10():
             for offset in offsets:
                 # print(offset)
                 backup = fuzz(filename, offset)
-                with gdaltest.error_handler():
+                with gdal.quiet_errors():
                     gdal.ErrorReset()
                     ds = ogr.Open("tmp/testopenfilegdb_fuzzed.gdb")
                     error_msg = gdal.GetLastErrorMsg()
@@ -1569,7 +1569,7 @@ def test_ogr_openfilegdb_read_broken_spx_wrong_index_depth():
     ds = ogr.Open(dirname)
     lyr = ds.GetLayer(0)
     lyr.SetSpatialFilterRect(0.5, 0.5, 48.5, 48.5)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.GetFeatureCount() == 48 * 48
     assert (
         "Cannot use /vsimem/test_ogr_openfilegdb_read_broken_spx_wrong_index_depth.gdb/a00000009.spx"
@@ -1938,7 +1938,7 @@ def _check_domains(ds):
         "SpeedLimit",
     }
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.GetFieldDomain("i_dont_exist") is None
     lyr = ds.GetLayer(0)
     lyr_defn = lyr.GetLayerDefn()
@@ -2000,7 +2000,7 @@ def test_ogr_openfilegdb_write_domains_from_other_gdb():
     assert ds.TestCapability(ogr.ODsCDeleteFieldDomain) == 1
     assert ds.TestCapability(ogr.ODsCUpdateFieldDomain) == 1
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not ds.DeleteFieldDomain("not_existing")
 
     domain = ogr.CreateCodedFieldDomain(

--- a/autotest/ogr/ogr_openfilegdb_write.py
+++ b/autotest/ogr/ogr_openfilegdb_write.py
@@ -66,13 +66,13 @@ def setup_driver():
 
 def test_ogr_openfilegdb_invalid_filename():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.GetDriverByName("OpenFileGDB").CreateDataSource(
             "/vsimem/bad.extension"
         )
         assert ds is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.GetDriverByName("OpenFileGDB").CreateDataSource(
             "/parent/directory/does/not/exist.gdb"
         )
@@ -118,7 +118,7 @@ def test_ogr_openfilegdb_write_field_types(use_synctodisk):
         )
 
         # Cannot create field with same name as an existing field (here the geometry one)
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             fld_defn = ogr.FieldDefn("SHAPE", ogr.OFTString)
             assert lyr.CreateField(fld_defn) != ogr.OGRERR_NONE
 
@@ -206,7 +206,7 @@ def test_ogr_openfilegdb_write_field_types(use_synctodisk):
         assert lyr.CreateFeature(f) == ogr.OGRERR_NONE
 
         f = ogr.Feature(lyr.GetLayerDefn())
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             gdal.ErrorReset()
             assert lyr.CreateFeature(f) == ogr.OGRERR_FAILURE
             assert (
@@ -649,7 +649,7 @@ def test_ogr_openfilegdb_write_bad_geoms(geom_type, wkt):
         f = ogr.Feature(lyr.GetLayerDefn())
         ref_geom = ogr.CreateGeometryFromWkt(wkt)
         f.SetGeometry(ref_geom)
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert lyr.CreateFeature(f) != ogr.OGRERR_NONE
         ds = None
     finally:
@@ -763,7 +763,7 @@ def test_ogr_openfilegdb_write_create_feature_with_id_set(has_bitmap, ids, sync)
             if ok:
                 assert lyr.CreateFeature(f) == ogr.OGRERR_NONE
             else:
-                with gdaltest.error_handler():
+                with gdal.quiet_errors():
                     assert lyr.CreateFeature(f) != ogr.OGRERR_NONE
             if sync:
                 lyr.SyncToDisk()
@@ -926,7 +926,7 @@ def test_ogr_openfilegdb_write_add_field_to_non_empty_table():
             "cannot_add_non_nullable_field_without_default_val", ogr.OFTString
         )
         fld_defn.SetNullable(False)
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert lyr.CreateField(fld_defn) != ogr.OGRERR_NONE
 
         # No need to rewrite the file
@@ -1081,13 +1081,13 @@ def test_ogr_openfilegdb_write_add_field_to_non_empty_table_extra_non_nullable(
 
             fld_defn = ogr.FieldDefn("dt_invalid_default", ogr.OFTDateTime)
             fld_defn.SetDefault("'foo'")
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 assert lyr.CreateField(fld_defn, False) == ogr.OGRERR_FAILURE
                 assert gdal.GetLastErrorMsg() == "Cannot parse foo as a date time"
 
             fld_defn = ogr.FieldDefn("dt_CURRENT_TIMESTAMP", ogr.OFTDateTime)
             fld_defn.SetDefault("CURRENT_TIMESTAMP")
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 assert lyr.CreateField(fld_defn, False) == ogr.OGRERR_FAILURE
                 assert (
                     gdal.GetLastErrorMsg()
@@ -1096,7 +1096,7 @@ def test_ogr_openfilegdb_write_add_field_to_non_empty_table_extra_non_nullable(
 
             fld_defn = ogr.FieldDefn("dt_CURRENT_TIMESTAMP_2", ogr.OFTDateTime)
             fld_defn.SetDefault("CURRENT_TIMESTAMP")
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 assert lyr.CreateField(fld_defn, True) == ogr.OGRERR_NONE
                 assert (
                     gdal.GetLastErrorMsg()
@@ -1166,7 +1166,7 @@ def test_ogr_openfilegdb_write_add_field_to_non_empty_table_extra_non_nullable_s
             fld_defn = ogr.FieldDefn("str2", ogr.OFTString)
             fld_defn.SetNullable(False)
             fld_defn.SetDefault("'default val'")
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 with gdaltest.config_option(
                     "OPENFILEGDB_SIMUL_ERROR_IN_RewriteTableToAddLastAddedField", "TRUE"
                 ):
@@ -1475,7 +1475,7 @@ def test_ogr_openfilegdb_write_feature_dataset_crs():
         other_srs = osr.SpatialReference()
         other_srs.ImportFromEPSG(4269)
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             lyr = ds.CreateLayer(
                 "other_srs",
                 geom_type=ogr.wkbPoint,
@@ -1544,7 +1544,7 @@ def test_ogr_openfilegdb_write_spatial_index(numPoints, maxFeaturesPerSpxPage):
             str(maxFeaturesPerSpxPage) if maxFeaturesPerSpxPage else None,
         ):
             if maxFeaturesPerSpxPage == 2 and numPoints > 30:
-                with gdaltest.error_handler():
+                with gdal.quiet_errors():
                     gdal.ErrorReset()
                     lyr.SyncToDisk()
                     assert gdal.GetLastErrorMsg() != ""
@@ -1626,7 +1626,7 @@ def test_ogr_openfilegdb_write_attribute_index():
         f = None
 
         # Errors of index creation
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             gdal.ErrorReset()
             ds.ExecuteSQL("CREATE INDEX this_name_is_wayyyyy_tooo_long ON test(int16)")
             assert gdal.GetLastErrorMsg() != ""
@@ -1671,7 +1671,7 @@ def test_ogr_openfilegdb_write_attribute_index():
         fld_defn = ogr.FieldDefn("unindexed", ogr.OFTString)
         assert lyr.CreateField(fld_defn) == ogr.OGRERR_NONE
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             # Re-using an index name
             gdal.ErrorReset()
             ds.ExecuteSQL("CREATE INDEX idx_int16 ON test(unindexed)")
@@ -1840,11 +1840,11 @@ def test_ogr_openfilegdb_write_delete_layer():
         assert ds.DeleteLayer(1) != ogr.OGRERR_NONE
 
         # The following should not work
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             gdal.ErrorReset()
             ds.ExecuteSQL("DELLAYER:not_existing")
             assert gdal.GetLastErrorMsg() != ""
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             gdal.ErrorReset()
             ds.ExecuteSQL("DELLAYER:GDB_SystemCatalog")
             assert gdal.GetLastErrorMsg() != ""
@@ -2241,7 +2241,7 @@ def test_ogr_openfilegdb_write_repack():
         lyr.SyncToDisk()
         filesize = gdal.VSIStatL(table_filename).size
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert ds.ExecuteSQL("REPACK unexisting_table") is None
 
         # Repack: nothing to do
@@ -2335,7 +2335,7 @@ def test_ogr_openfilegdb_write_recompute_extent_on():
         assert ds.ExecuteSQL("RECOMPUTE EXTENT ON test") is None
         assert gdal.GetLastErrorMsg() == ""
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             gdal.ErrorReset()
             assert ds.ExecuteSQL("RECOMPUTE EXTENT ON non_existing_layer") is None
             assert gdal.GetLastErrorMsg() != ""
@@ -2383,7 +2383,7 @@ def test_ogr_openfilegdb_write_alter_field_defn():
         assert lyr.AlterFieldDefn(0, fld_defn, ogr.ALTER_ALL_FLAG) == ogr.OGRERR_NONE
 
         # Invalid index
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert (
                 lyr.AlterFieldDefn(-1, fld_defn, ogr.ALTER_ALL_FLAG) != ogr.OGRERR_NONE
             )
@@ -2401,7 +2401,7 @@ def test_ogr_openfilegdb_write_alter_field_defn():
 
         # Changing type not supported
         fld_defn = ogr.FieldDefn("str", ogr.OFTInteger)
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert (
                 lyr.AlterFieldDefn(0, fld_defn, ogr.ALTER_ALL_FLAG) != ogr.OGRERR_NONE
             )
@@ -2411,7 +2411,7 @@ def test_ogr_openfilegdb_write_alter_field_defn():
         # Changing subtype not supported
         fld_defn = ogr.FieldDefn("str", ogr.OFTString)
         fld_defn.SetSubType(ogr.OFSTUUID)
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert (
                 lyr.AlterFieldDefn(0, fld_defn, ogr.ALTER_ALL_FLAG) != ogr.OGRERR_NONE
             )
@@ -2422,7 +2422,7 @@ def test_ogr_openfilegdb_write_alter_field_defn():
         # Changing nullable state not supported
         fld_defn = ogr.FieldDefn("str", ogr.OFTString)
         fld_defn.SetNullable(False)
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert (
                 lyr.AlterFieldDefn(0, fld_defn, ogr.ALTER_ALL_FLAG) != ogr.OGRERR_NONE
             )
@@ -2431,7 +2431,7 @@ def test_ogr_openfilegdb_write_alter_field_defn():
 
         # Renaming to an other existing field not supported
         fld_defn = ogr.FieldDefn("other_field", ogr.OFTString)
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert (
                 lyr.AlterFieldDefn(0, fld_defn, ogr.ALTER_ALL_FLAG) != ogr.OGRERR_NONE
             )
@@ -2439,7 +2439,7 @@ def test_ogr_openfilegdb_write_alter_field_defn():
             assert fld_defn.GetName() == "str"
 
         fld_defn = ogr.FieldDefn("SHAPE", ogr.OFTString)
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert (
                 lyr.AlterFieldDefn(0, fld_defn, ogr.ALTER_ALL_FLAG) != ogr.OGRERR_NONE
             )
@@ -3287,7 +3287,7 @@ def test_ogr_openfilegdb_write_emulated_transactions():
         ds = ogr.GetDriverByName("OpenFileGDB").CreateDataSource(dirname)
 
         gdal.Mkdir(dirname + "/.ogrtransaction_backup", 0o755)
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert ds.StartTransaction(True) == ogr.OGRERR_FAILURE
         gdal.Rmdir(dirname + "/.ogrtransaction_backup")
 
@@ -3306,18 +3306,18 @@ def test_ogr_openfilegdb_write_emulated_transactions():
         assert gdal.VSIStatL(dirname + "/.ogrtransaction_backup") is None
 
         assert ds.StartTransaction(True) == ogr.OGRERR_NONE
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert ds.StartTransaction(True) != ogr.OGRERR_NONE
         assert ds.RollbackTransaction() == ogr.OGRERR_NONE
 
         assert gdal.VSIStatL(dirname + "/.ogrtransaction_backup") is None
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert ds.CommitTransaction() != ogr.OGRERR_NONE
 
         assert gdal.VSIStatL(dirname + "/.ogrtransaction_backup") is None
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert ds.RollbackTransaction() != ogr.OGRERR_NONE
 
         assert gdal.VSIStatL(dirname + "/.ogrtransaction_backup") is None
@@ -3343,7 +3343,7 @@ def test_ogr_openfilegdb_write_emulated_transactions():
         ds = ogr.Open(dirname, update=1)
         assert ds.StartTransaction(True) == ogr.OGRERR_NONE
         gdal.Rmdir(dirname + "/.ogrtransaction_backup")
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert ds.RollbackTransaction() == ogr.OGRERR_FAILURE
             ds = None
 
@@ -3375,7 +3375,7 @@ def test_ogr_openfilegdb_write_emulated_transactions():
         ds = None
 
         gdal.Mkdir(dirname + "/.ogrtransaction_backup", 0o755)
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             # Cannot open in update mode with an existing backup directory
             assert ogr.Open(dirname, update=1) is None
 
@@ -3388,7 +3388,7 @@ def test_ogr_openfilegdb_write_emulated_transactions():
         # Transaction not supported in read-only mode
         ds = ogr.Open(dirname)
         assert ds.TestCapability(ogr.ODsCEmulatedTransactions) == 0
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert ds.StartTransaction(True) == ogr.OGRERR_FAILURE
         ds = None
 
@@ -3493,13 +3493,13 @@ def test_ogr_openfilegdb_write_rename_layer(options):
         assert lyr.GetLayerDefn().GetName() == "bar"
 
         # Too long layer name
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert lyr.Rename("x" * 200) != ogr.OGRERR_NONE
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert lyr.Rename("bar") != ogr.OGRERR_NONE
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert lyr.Rename("other_layer") != ogr.OGRERR_NONE
 
         f = ogr.Feature(lyr.GetLayerDefn())
@@ -3583,7 +3583,7 @@ def test_ogr_openfilegdb_field_name_laundering():
     try:
         ds = ogr.GetDriverByName("OpenFileGDB").CreateDataSource(dirname)
         lyr = ds.CreateLayer("test", geom_type=ogr.wkbPoint)
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             lyr.CreateField(ogr.FieldDefn("FROM", ogr.OFTInteger))  # reserved keyword
             lyr.CreateField(
                 ogr.FieldDefn("1NUMBER", ogr.OFTInteger)
@@ -3654,7 +3654,7 @@ def test_ogr_openfilegdb_layer_name_laundering():
 
     try:
         ds = ogr.GetDriverByName("OpenFileGDB").CreateDataSource(dirname)
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             for in_name in in_names:
                 ds.CreateLayer(in_name, geom_type=ogr.wkbPoint)
 
@@ -4048,7 +4048,7 @@ def test_ogr_openfilegdb_write_alter_geom_field_defn():
 
         # Changing geometry type not supported
         fld_defn = ogr.GeomFieldDefn("shape_renamed", ogr.wkbPolygon)
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert (
                 lyr.AlterGeomFieldDefn(0, fld_defn, ogr.ALTER_GEOM_FIELD_DEFN_TYPE_FLAG)
                 != ogr.OGRERR_NONE
@@ -4057,7 +4057,7 @@ def test_ogr_openfilegdb_write_alter_geom_field_defn():
         # Changing nullable state not supported
         fld_defn = ogr.GeomFieldDefn("shape_renamed", ogr.wkbPolygon)
         fld_defn.SetNullable(False)
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert (
                 lyr.AlterGeomFieldDefn(
                     0, fld_defn, ogr.ALTER_GEOM_FIELD_DEFN_NULLABLE_FLAG
@@ -4130,7 +4130,7 @@ def test_ogr_openfilegdb_write_create_OBJECTID(field_type):
         f = ogr.Feature(lyr.GetLayerDefn())
         f.SetFID(12)
         f[lyr.GetFIDColumn()] = 13
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert lyr.CreateFeature(f) != ogr.OGRERR_NONE
 
         lyr.ResetReading()
@@ -4148,7 +4148,7 @@ def test_ogr_openfilegdb_write_create_OBJECTID(field_type):
 
         # Can't delete or alter OBJECTID field
         field_idx = lyr.GetLayerDefn().GetFieldIndex(lyr.GetFIDColumn())
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert lyr.DeleteField(field_idx) == ogr.OGRERR_FAILURE
             assert (
                 lyr.AlterFieldDefn(

--- a/autotest/ogr/ogr_osm.py
+++ b/autotest/ogr/ogr_osm.py
@@ -296,7 +296,7 @@ def test_ogr_osm_3(options=None, all_layers=False):
         layers = ""
     else:
         layers = "points lines multipolygons multilinestrings "
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.VectorTranslate(
             "tmp/ogr_osm_3", "data/osm/test.pbf", options=layers + options
         )
@@ -358,7 +358,7 @@ def test_ogr_osm_4():
     feat = lyr.GetNextFeature()
     assert feat is None, "Zero filter "
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.SetSpatialFilter(None)
 
         # Change layer
@@ -555,7 +555,7 @@ def test_ogr_osm_10():
         ds = ogr.Open("/vsimem/foo.osm")
         lyr = ds.GetLayer(0)
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             feat = lyr.GetNextFeature()
         assert gdal.GetLastErrorMsg() != ""
         ds = None
@@ -571,7 +571,7 @@ def test_ogr_osm_10():
     ds = ogr.Open("/vsimem/foo.pbf")
     lyr = ds.GetLayer(0)
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         feat = lyr.GetNextFeature()
     assert gdal.GetLastErrorMsg() != ""
     ds = None
@@ -583,7 +583,7 @@ def test_ogr_osm_10():
         ds = ogr.Open("data/osm/billionlaugh.osm")
         lyr = ds.GetLayer(0)
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             feat = lyr.GetNextFeature()
         assert feat is None and gdal.GetLastErrorMsg() != ""
 
@@ -666,7 +666,7 @@ def test_ogr_osm_13():
         """<osm><node id="123" lon="2" lat="49"><tag k="osm_id" v="0"/></node></osm>""",
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("/vsimem/ogr_osm_13.osm")
     if ds is None:
         gdal.Unlink("/vsimem/ogr_osm_13.osm")
@@ -711,7 +711,7 @@ def test_ogr_osm_14():
 </osm>""",
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("/vsimem/ogr_osm_14.osm")
     if ds is None:
         gdal.Unlink("/vsimem/ogr_osm_14.osm")
@@ -855,7 +855,7 @@ def test_ogr_osm_17():
     if not ogrtest.osm_drv_parse_osm:
         pytest.skip("Expat support missing")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.VectorTranslate(
             "/vsimem/ogr_osm_17", "data/osm/empty.osm", options="-skip"
         )

--- a/autotest/ogr/ogr_parquet.py
+++ b/autotest/ogr/ogr_parquet.py
@@ -1611,7 +1611,7 @@ def test_ogr_parquet_arrow_stream_numpy():
     stream = lyr.GetArrowStreamAsNumPy(
         options=["MAX_FEATURES_IN_BATCH=5", "USE_MASKED_ARRAYS=NO"]
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         batches = [batch for batch in stream]
     assert len(batches) == 2
     batch = batches[0]

--- a/autotest/ogr/ogr_pcidsk.py
+++ b/autotest/ogr/ogr_pcidsk.py
@@ -227,7 +227,7 @@ def test_ogr_pcidsk_add_field_to_non_empty_layer():
     f["foo"] = "bar"
     lyr.CreateFeature(f)
     f = None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.CreateField(ogr.FieldDefn("bar", ogr.OFTString)) != 0
     f = ogr.Feature(lyr.GetLayerDefn())
     f["foo"] = "bar2"
@@ -247,7 +247,7 @@ def test_ogr_pcidsk_too_many_layers():
     ds = ogr.GetDriverByName("PCIDSK").CreateDataSource(tmpfile)
     for i in range(1023):
         ds.CreateLayer("foo%d" % i)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.CreateLayer("foo") is None
     ds = None
 

--- a/autotest/ogr/ogr_pds.py
+++ b/autotest/ogr/ogr_pds.py
@@ -29,11 +29,10 @@
 ###############################################################################
 
 
-import gdaltest
 import ogrtest
 import pytest
 
-from osgeo import ogr
+from osgeo import gdal, ogr
 
 pytestmark = pytest.mark.require_driver("OGR_PDS")
 
@@ -51,7 +50,7 @@ def test_ogr_pds_1():
 
     assert lyr.GetFeatureCount() == 74786, "did not get expected feature count"
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         feat = lyr.GetNextFeature()
     if feat.GetField("NOISE_COUNTS_1") != 96:
         feat.DumpReadable()
@@ -61,7 +60,7 @@ def test_ogr_pds_1():
         feat, "POINT (146.1325 -55.648)", max_error=0.000000001
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         feat = lyr.GetFeature(1)
     if feat.GetField("MARS_RADIUS") != 3385310.2:
         feat.DumpReadable()

--- a/autotest/ogr/ogr_pds4.py
+++ b/autotest/ogr/ogr_pds4.py
@@ -355,7 +355,7 @@ def test_ogr_pds4_create_table_character(line_ending):
     if line_ending:
         layer_creation_options.append("LINE_ENDING=" + line_ending)
     if line_ending == "error":
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             lyr = ds.CreateLayer("0f:oo", options=layer_creation_options)
     else:
         lyr = ds.CreateLayer("0f:oo", options=layer_creation_options)
@@ -653,7 +653,7 @@ def test_ogr_pds4_create_table_delimited(line_ending):
     if line_ending:
         layer_creation_options.append("LINE_ENDING=" + line_ending)
     if line_ending == "error":
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             lyr = ds.CreateLayer("foo", options=layer_creation_options)
     else:
         lyr = ds.CreateLayer("foo", options=layer_creation_options)

--- a/autotest/ogr/ogr_pg.py
+++ b/autotest/ogr/ogr_pg.py
@@ -109,7 +109,7 @@ def test_ogr_pg_1():
     # gdaltest.pg_connection_string='dbname=autotest port=5436 user=postgres'
 
     try:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             gdaltest.pg_ds = ogr.Open("PG:" + gdaltest.pg_connection_string, update=1)
     except Exception:
         gdaltest.pg_ds = None
@@ -147,12 +147,12 @@ def test_ogr_pg_1():
         if gdaltest.pg_version >= (8, 2):
             gdaltest.pg_retrieve_fid = True
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = gdaltest.pg_ds.ExecuteSQL("SHOW standard_conforming_strings")
     gdaltest.pg_quote_with_E = sql_lyr is not None
     gdaltest.pg_ds.ReleaseResultSet(sql_lyr)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = gdaltest.pg_ds.ExecuteSQL("SELECT postgis_version()")
         gdaltest.pg_has_postgis = sql_lyr is not None
         gdaltest.pg_has_postgis_2 = False
@@ -186,7 +186,7 @@ def test_ogr_pg_2():
     if gdaltest.pg_ds is None:
         pytest.skip()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdaltest.pg_ds.ExecuteSQL("DELLAYER:tpoly")
 
     ######################################################
@@ -622,7 +622,7 @@ def test_ogr_pg_update_feature():
         assert feat.GetGeometryRef() is None
 
         feat = ogr.Feature(lyr.GetLayerDefn())
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert lyr.UpdateFeature(feat, [], [0], False) != ogr.OGRERR_NONE
 
         feat = ogr.Feature(lyr.GetLayerDefn())
@@ -677,7 +677,7 @@ def test_ogr_pg_11():
     if gdaltest.pg_ds is None:
         pytest.skip()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdaltest.pg_ds.ExecuteSQL("DELLAYER:tpolycopy")
 
     with gdal.config_option("PG_USE_COPY", "NO"):
@@ -762,7 +762,7 @@ def test_ogr_pg_13():
     if gdaltest.pg_ds is None:
         pytest.skip()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdaltest.pg_ds.ExecuteSQL("DELLAYER:datetest")
 
     ######################################################
@@ -1256,7 +1256,7 @@ def test_ogr_pg_23():
     if gdaltest.pg_ds is None:
         pytest.skip()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdaltest.pg_ds.ExecuteSQL("DELLAYER:datatypetest")
 
     ######################################################
@@ -1579,7 +1579,7 @@ def test_ogr_pg_28():
 
         ds = ogr.Open("PG:" + gdaltest.pg_connection_string, update=1)
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds.ExecuteSQL("DELLAYER:datatypetest2")
 
         ds.ExecuteSQL('set timezone to "UTC"')
@@ -1651,7 +1651,7 @@ def test_ogr_pg_30():
 
         ds = ogr.Open("PG:" + gdaltest.pg_connection_string, update=1)
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds.ExecuteSQL("DELLAYER:datatypetest2")
 
         ds.ExecuteSQL('set timezone to "UTC"')
@@ -1918,7 +1918,7 @@ def test_ogr_pg_35():
     if gdaltest.pg_ds is None:
         pytest.skip()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         try:
             gdaltest.pg_lyr = gdaltest.pg_ds.CreateLayer("testoverflows")
             ogrtest.quick_create_layer_def(
@@ -1929,7 +1929,7 @@ def test_ogr_pg_35():
         except Exception:
             pass
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         try:
             gdaltest.pg_lyr = gdaltest.pg_ds.CreateLayer(
                 "testoverflows",
@@ -2245,7 +2245,7 @@ def test_ogr_pg_41():
     layer = ds.GetLayerByName("public.tpoly")
     assert layer.GetFeatureCount() == 19, "wrong feature count"
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdaltest.pg_ds.ExecuteSQL("DELLAYER:test41")
 
     ds.CreateLayer("test41")
@@ -2355,7 +2355,7 @@ def test_ogr_pg_44():
     feat.Destroy()
 
     gdaltest.pg_ds.ExecuteSQL('ALTER TABLE "select" RENAME COLUMN "ogc_fid" to "AND"')
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdaltest.pg_ds.ExecuteSQL("DELLAYER:from")
 
     ds = ogr.Open("PG:" + gdaltest.pg_connection_string, update=1)
@@ -2387,7 +2387,7 @@ def test_ogr_pg_44():
     layer.ResetReading()
     feat = layer.GetNextFeature()
     assert feat.GetGeometryRef().ExportToWkt() == "POINT (0.5 0.5 1)"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert layer.Rename("from") != ogr.OGRERR_NONE
     assert layer.Rename("select") == ogr.OGRERR_NONE
 
@@ -2522,7 +2522,7 @@ def test_ogr_pg_47():
 
     # Only geographic SRS is supported
     srs.ImportFromEPSG(32631)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = gdaltest.pg_ds.CreateLayer(
             "test_geog",
             srs=srs,
@@ -2890,7 +2890,7 @@ def test_ogr_pg_53():
     feat = lyr.GetNextFeature()
     assert feat.GetField(0) == "bar"
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.CreateLayer("no_geometry_table", geom_type=ogr.wkbNone)
     assert lyr is None, "layer creation should have failed"
 
@@ -3997,7 +3997,7 @@ def test_ogr_pg_73():
         # Error case: missing geometry
         f = ogr.Feature(lyr.GetLayerDefn())
         f.SetField("field_not_nullable", "not_null")
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = lyr.CreateFeature(f)
         assert ret != 0
         f = None
@@ -4005,7 +4005,7 @@ def test_ogr_pg_73():
         # Error case: missing non-nullable field
         f = ogr.Feature(lyr.GetLayerDefn())
         f.SetGeometryDirectly(ogr.CreateGeometryFromWkt("POINT(0 0)"))
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = lyr.CreateFeature(f)
         assert ret != 0
         f = None
@@ -4342,7 +4342,7 @@ def test_ogr_pg_75():
     )
 
     lyr.CreateField(ogr.FieldDefn("str", ogr.OFTString))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateField(ogr.FieldDefn("myfid", ogr.OFTString))
     assert ret != 0
 
@@ -4376,16 +4376,16 @@ def test_ogr_pg_75():
     feat = ogr.Feature(lyr.GetLayerDefn())
     feat.SetFID(1)
     feat.SetField("myfid", 10)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(feat)
     assert ret != 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetFeature(feat)
     assert ret != 0
 
     feat.UnsetField("myfid")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetFeature(feat)
     assert ret != 0
 
@@ -4570,7 +4570,7 @@ def ogr_pg_76_scenario2(lyr1, lyr2):
 
     # Try to re-enter a transaction
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = gdaltest.pg_ds.StartTransaction()
     assert not (gdal.GetLastErrorMsg() == "" or ret == 0)
     (lastcmd, level, savepoint, usertransac) = ogr_pg_76_get_transaction_state(
@@ -4633,7 +4633,7 @@ def ogr_pg_76_scenario2(lyr1, lyr2):
 
     # Try to re-commit a transaction
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = gdaltest.pg_ds.CommitTransaction()
     assert not (gdal.GetLastErrorMsg() == "" or ret == 0)
     (lastcmd, level, savepoint, usertransac) = ogr_pg_76_get_transaction_state(
@@ -4643,7 +4643,7 @@ def ogr_pg_76_scenario2(lyr1, lyr2):
 
     # Try to rollback a non-transaction
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = gdaltest.pg_ds.RollbackTransaction()
     assert not (gdal.GetLastErrorMsg() == "" or ret == 0)
     (lastcmd, level, savepoint, usertransac) = ogr_pg_76_get_transaction_state(
@@ -4677,7 +4677,7 @@ def ogr_pg_76_scenario3(lyr1, lyr2):
     assert (lastcmd, level, savepoint, usertransac) == ("COMMIT", 0, 0, 0)
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr1.GetNextFeature()
     assert gdal.GetLastErrorMsg() != "" and f is None
 
@@ -5009,7 +5009,7 @@ def test_ogr_pg_79():
     assert gdal.GetLastErrorMsg() == ""
 
     # Test wrong PRELUDE_STATEMENTS
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.OpenEx(
             "PG:" + gdaltest.pg_connection_string,
             gdal.OF_VECTOR | gdal.OF_UPDATE,
@@ -5030,7 +5030,7 @@ def test_ogr_pg_79():
         ],
     )
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = None
     assert gdal.GetLastErrorMsg() != ""
 
@@ -5045,7 +5045,7 @@ def test_ogr_pg_80(with_and_without_postgis):
         pytest.skip()
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = gdaltest.pg_ds.ExecuteSQL("SELECT FROM")
     assert gdal.GetLastErrorMsg() != ""
     assert sql_lyr is None
@@ -5095,7 +5095,7 @@ def test_ogr_pg_81(with_and_without_postgis):
 2,2""",
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdal.VectorTranslate(
             "PG:" + gdaltest.pg_connection_string,
             "/vsimem/ogr_pg_81",
@@ -5589,7 +5589,7 @@ def test_ogr_pg_unique():
     fld_defn = ogr.FieldDefn("without_unique", ogr.OFTString)
     fld_defn.SetUnique(False)
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             lyr.AlterFieldDefn(
                 feat_defn.GetFieldIndex(fld_defn.GetName()),
@@ -5868,7 +5868,7 @@ def test_ogr_pg_alter_geom_field_defn():
     test_ds = None
 
     # Error cases
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # Invalid index
         assert (
             lyr.AlterGeomFieldDefn(
@@ -6000,12 +6000,12 @@ def test_ogr_pg_get_geometry_types():
         assert ogr.wkbNone in res
         assert len(res) == 3
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             with gdaltest.config_option("OGR_PG_DEBUG_GGT_CANCEL", "YES"):
                 with pytest.raises(Exception):
                     lyr.GetGeometryTypes(callback=lambda x, y, z: 0)
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             with pytest.raises(Exception):
                 lyr.GetGeometryTypes(geom_field=2)
 
@@ -6315,7 +6315,7 @@ def test_ogr_pg_long_identifiers():
     long_name = "test_" + ("X" * 64) + "_long_name"
     short_name = "test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
     try:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             lyr = gdaltest.pg_ds.CreateLayer(long_name)
         assert lyr.GetName() == short_name
         f = ogr.Feature(lyr.GetLayerDefn())
@@ -6340,7 +6340,7 @@ def _test_ogr_pg_table_cleanup():
     if gdaltest.pg_ds is None:
         pytest.skip()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdaltest.pg_ds.ExecuteSQL("DELLAYER:tpoly")
         gdaltest.pg_ds.ExecuteSQL("DELLAYER:tpolycopy")
         gdaltest.pg_ds.ExecuteSQL("DELLAYER:test_for_tables_equal_param")

--- a/autotest/ogr/ogr_pgdump.py
+++ b/autotest/ogr/ogr_pgdump.py
@@ -456,7 +456,7 @@ def test_ogr_pgdump_non_nullable_unique_comment():
     # Error case: missing geometry
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetField("field_not_nullable", "not_null")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(f)
     assert ret != 0
     f = None
@@ -464,7 +464,7 @@ def test_ogr_pgdump_non_nullable_unique_comment():
     # Error case: missing non-nullable field
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometryDirectly(ogr.CreateGeometryFromWkt("POINT(0 0)"))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(f)
     assert ret != 0
     f = None
@@ -633,7 +633,7 @@ def test_ogr_pgdump_7():
     lyr = ds.CreateLayer("test", geom_type=ogr.wkbNone, options=["FID=myfid"])
 
     lyr.CreateField(ogr.FieldDefn("str", ogr.OFTString))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateField(ogr.FieldDefn("myfid", ogr.OFTString))
     assert ret != 0
 
@@ -669,7 +669,7 @@ def test_ogr_pgdump_7():
     feat = ogr.Feature(lyr.GetLayerDefn())
     feat.SetFID(1)
     feat.SetField("myfid", 10)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(feat)
     assert ret != 0
 
@@ -742,7 +742,7 @@ def test_ogr_pgdump_8():
     lyr = ds.CreateLayer("test", geom_type=ogr.wkbNone, options=["FID=myfid"])
 
     lyr.CreateField(ogr.FieldDefn("str", ogr.OFTString))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateField(ogr.FieldDefn("myfid", ogr.OFTString))
     assert ret != 0
 
@@ -1548,7 +1548,7 @@ def test_ogr_pgdump_long_identifiers():
     long_name = "test_" + ("X" * 64) + "_long_name"
     short_name = "test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.CreateLayer(long_name, geom_type=ogr.wkbPoint)
     lyr.CreateField(ogr.FieldDefn("str", ogr.OFTString))
     f = ogr.Feature(lyr.GetLayerDefn())

--- a/autotest/ogr/ogr_pgeo.py
+++ b/autotest/ogr/ogr_pgeo.py
@@ -749,7 +749,7 @@ def test_ogr_pgeo_read_domains():
         "split_policy_duplicate",
     }
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.GetFieldDomain("i_dont_exist") is None
     lyr = ds.GetLayer(0)
     assert lyr.GetName() == "domains"

--- a/autotest/ogr/ogr_plscenes.py
+++ b/autotest/ogr/ogr_plscenes.py
@@ -73,11 +73,11 @@ def test_ogr_plscenes_data_v1_catalog_no_paging():
             "PLScenes:", gdal.OF_VECTOR, open_options=["VERSION=data_v1", "API_KEY=foo"]
         )
     assert ds is not None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.GetLayerByName("non_existing") is None
     assert ds.GetLayerByName("PSScene3Band") is not None
     assert ds.GetLayerCount() == 1
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.GetLayerByName("non_existing") is None
 
     gdal.Unlink("/vsimem/data_v1/item-types")
@@ -105,7 +105,7 @@ def test_ogr_plscenes_data_v1_catalog_paging():
             "PLScenes:", gdal.OF_VECTOR, open_options=["VERSION=data_v1", "API_KEY=foo"]
         )
     assert ds is not None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.GetLayerByName("non_existing") is None
     assert ds.GetLayerByName("PSScene3Band") is not None
     gdal.FileFromMemBuffer(
@@ -114,7 +114,7 @@ def test_ogr_plscenes_data_v1_catalog_paging():
     assert ds.GetLayerByName("PSScene4Band") is not None
     assert ds.GetLayerCount() == 2
     assert ds.GetLayerByName("PSScene4Band") is not None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.GetLayerByName("non_existing") is None
 
     gdal.Unlink("/vsimem/data_v1/item-types")
@@ -313,7 +313,7 @@ def test_ogr_plscenes_data_v1_nominal():
         pytest.fail()
 
     # Cannot find /vsimem/data_v1/stats&POSTFIELDS={"interval":"year","item_types":["PSOrthoTile"],"filter":{"type":"AndFilter","config":[{"type":"GeometryFilter","field_name":"geometry","config":{"type":"Point","coordinates":[2.0,49.0]}}]}}
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.GetFeatureCount() == 1
 
     # Reset spatial filter
@@ -428,7 +428,7 @@ def test_ogr_plscenes_data_v1_nominal():
 
     # Missing catalog
     with gdal.config_option("PL_URL", "/vsimem/data_v1/"):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds_raster = gdal.OpenEx(
                 "PLScenes:",
                 gdal.OF_RASTER,
@@ -782,7 +782,7 @@ def test_ogr_plscenes_data_v1_errors():
         ds = gdal.OpenEx(
             "PLScenes:", gdal.OF_VECTOR, open_options=["VERSION=data_v1", "API_KEY=foo"]
         )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr_count = ds.GetLayerCount()
     assert lyr_count == 1
 
@@ -799,11 +799,11 @@ def test_ogr_plscenes_data_v1_errors():
     ds.GetLayer(-1)
     ds.GetLayer(1)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.GetLayerByName("invalid_name")
 
     # Cannot find /vsimem/data_v1/quick-search?_page_size=250&POSTFIELDS={"item_types":["PSScene3Band"],"filter":{"type":"AndFilter","config":[]}}
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.GetNextFeature()
 
     # Empty object

--- a/autotest/ogr/ogr_pythondrivers.py
+++ b/autotest/ogr/ogr_pythondrivers.py
@@ -108,7 +108,7 @@ def test_pythondrivers_missing_metadata():
     with gdaltest.config_option(
         "GDAL_PYTHON_DRIVER_PATH", "data/pydrivers/missingmetadata"
     ):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             gdal.AllRegister()
     assert gdal.GetLastErrorMsg() != ""
     assert gdal.GetDriverCount() == count_before
@@ -130,7 +130,7 @@ def test_pythondrivers_no_driver_class():
         gdal.AllRegister()
     drv = ogr.GetDriverByName("NO_DRIVER_CLASS")
     assert drv
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ogr.Open("FOO:")
     assert gdal.GetLastErrorMsg() != ""
 
@@ -145,7 +145,7 @@ def test_pythondrivers_missing_identify():
         gdal.AllRegister()
     drv = ogr.GetDriverByName("MISSING_IDENTIFY")
     assert drv
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ogr.Open("FOO:")
     assert gdal.GetLastErrorMsg() != ""
 

--- a/autotest/ogr/ogr_refcount.py
+++ b/autotest/ogr/ogr_refcount.py
@@ -30,7 +30,7 @@
 import gdaltest
 import pytest
 
-from osgeo import ogr
+from osgeo import gdal, ogr
 
 
 ###############################################################################
@@ -96,7 +96,7 @@ def test_ogr_refcount_3():
 
 def test_ogr_refcount_4():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ogr.GetOpenDS(0)
 
 

--- a/autotest/ogr/ogr_rfc35.py
+++ b/autotest/ogr/ogr_rfc35.py
@@ -286,7 +286,7 @@ def test_ogr_rfc35_2(rfc35_test_input, driver_name):
     lyr.ReorderFields([3, 2, 1, 0])
     Check(ds, lyr, ["foo5", "bar10", "baz15", "baw20"])
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.ReorderFields([0, 0, 0, 0])
     assert ret != 0
 
@@ -321,11 +321,11 @@ def test_ogr_rfc35_3(rfc35_test_input, driver_name):
 
     lyr_defn = lyr.GetLayerDefn()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.AlterFieldDefn(-1, fd, ogr.ALTER_ALL_FLAG)
     assert ret != 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.AlterFieldDefn(lyr_defn.GetFieldCount(), fd, ogr.ALTER_ALL_FLAG)
     assert ret != 0
 
@@ -523,11 +523,11 @@ def test_ogr_rfc35_5(rfc35_test_input, driver_name, tmp_path):
 
     assert lyr.TestCapability(ogr.OLCDeleteField) == 1
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.DeleteField(-1)
     assert ret != 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.DeleteField(lyr.GetLayerDefn().GetFieldCount())
     assert ret != 0
 

--- a/autotest/ogr/ogr_rfc41.py
+++ b/autotest/ogr/ogr_rfc41.py
@@ -85,7 +85,7 @@ def test_ogr_rfc41_1():
 
     # Test setting invalid value
     old_val = gfld_defn.GetType()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gfld_defn.SetType(-3)
     assert gfld_defn.GetType() == old_val
 
@@ -137,7 +137,7 @@ def test_ogr_rfc41_2():
 
     # Test setting invalid value
     old_val = feature_defn.GetGeomType()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         feature_defn.SetGeomType(-3)
     assert feature_defn.GetGeomType() == old_val
 
@@ -150,7 +150,7 @@ def test_ogr_rfc41_2():
 
     # Test wrong index values for GetGeomFieldDefn()
     for idx in [-1, 1]:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = feature_defn.GetGeomFieldDefn(idx)
         assert ret is None
 
@@ -302,7 +302,7 @@ def test_ogr_rfc41_4():
     assert got_extent == (10.0, 11.0, 10.0, 11.0)
     # Test invalid geometry field index
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         got_extent = lyr.GetExtent(geom_field=2)
     assert gdal.GetLastErrorMsg() != ""
 
@@ -325,7 +325,7 @@ def test_ogr_rfc41_4():
     assert feat is not None
     # Test invalid spatial filter index
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.SetSpatialFilterRect(2, 0, 0, 0, 0)
     assert gdal.GetLastErrorMsg() != ""
 
@@ -587,7 +587,7 @@ def test_ogr_rfc41_6():
 
     for (sql, error_msg) in wrong_sql_list:
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             sql_lyr = ds.ExecuteSQL(sql)
         assert (
             gdal.GetLastErrorMsg().find(error_msg) == 0
@@ -612,7 +612,7 @@ def test_ogr_rfc41_6():
         "SELECT * FROM poly WHERE geomfield IN( 'a' )",
     ]:
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             sql_lyr = ds.ExecuteSQL(sql)
         assert (
             gdal.GetLastErrorMsg().find("Cannot use geometry field in this operation")
@@ -680,13 +680,13 @@ def test_ogr_rfc41_6():
 
     # Test invalid spatial filter index
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr.SetSpatialFilterRect(2, 0, 0, 0, 0)
     assert gdal.GetLastErrorMsg() != ""
 
     # Test invalid geometry field index
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr.GetExtent(geom_field=2)
     assert gdal.GetLastErrorMsg() != ""
 

--- a/autotest/ogr/ogr_sdts.py
+++ b/autotest/ogr/ogr_sdts.py
@@ -32,7 +32,7 @@
 import gdaltest
 import pytest
 
-from osgeo import ogr
+from osgeo import gdal, ogr
 
 pytestmark = pytest.mark.require_driver("OGR_SDTS")
 
@@ -77,7 +77,7 @@ def test_ogr_sdts_1():
     for layer in layers:
         lyr = ds.GetLayerByName(layer[0])
         assert lyr is not None, "could not get layer %s" % (layer[0])
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert (
                 lyr.GetFeatureCount() == layer[1]
             ), "wrong number of features for layer %s : %d. %d were expected " % (
@@ -95,7 +95,7 @@ def test_ogr_sdts_1():
 
     # Check that we get non-empty polygons
     lyr = ds.GetLayerByName("PC01")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     g = f.GetGeometryRef()
     assert g

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -631,7 +631,7 @@ def test_ogr_shape_21(f):
     ds = ogr.Open(f)
     lyr = ds.GetLayer(0)
     lyr.ResetReading()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         feat = lyr.GetNextFeature()
 
     assert feat.GetGeometryRef() is None
@@ -725,7 +725,7 @@ def ogr_shape_23_write_valid_and_invalid(
     # Write an invalid geometry for this layer type
     dst_feat = ogr.Feature(feature_def=gdaltest.shape_lyr.GetLayerDefn())
     dst_feat.SetGeometryDirectly(ogr.CreateGeometryFromWkt(invalid_wkt))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdaltest.shape_lyr.CreateFeature(dst_feat)
 
     #######################################################
@@ -902,7 +902,7 @@ def test_ogr_shape_23():
     geom = ogr.CreateGeometryFromWkt("GEOMETRYCOLLECTION(POINT (0 0))")
     dst_feat = ogr.Feature(feature_def=gdaltest.shape_lyr.GetLayerDefn())
     dst_feat.SetGeometry(geom)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdaltest.shape_lyr.CreateFeature(dst_feat)
 
     # This geometry will be dealt as a multipolygon
@@ -1138,7 +1138,7 @@ def test_ogr_shape_28():
     # Test creating a feature over 2 GB file limit -> should work
     gdal.ErrorReset()
     feat = ogr.Feature(lyr.GetLayerDefn())
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(feat)
     assert ret == 0
     feat = None
@@ -1159,7 +1159,7 @@ def test_ogr_shape_28():
     # Test creating a feature over 2 GB file limit -> should fail
     gdal.ErrorReset()
     feat = ogr.Feature(lyr.GetLayerDefn())
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(feat)
     assert ret != 0
     feat = None
@@ -1306,7 +1306,7 @@ def test_ogr_shape_31():
 
     #######################################################
     # Setup Schema with weird field names
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ogrtest.quick_create_layer_def(gdaltest.shape_lyr, fields)
 
     layer_defn = gdaltest.shape_lyr.GetLayerDefn()
@@ -1574,7 +1574,7 @@ def test_ogr_shape_37_bis():
 def test_ogr_shape_38():
 
     ds = ogr.Open("/vsimem/", update=1)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.CreateLayer("test35")
     ds = None
 
@@ -2106,7 +2106,7 @@ def test_ogr_shape_53():
 
     # Test REPACK when there are no features
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.ExecuteSQL("REPACK ogr_shape_53")
     # Should work without any error
     assert gdal.GetLastErrorMsg() == ""
@@ -2117,13 +2117,13 @@ def test_ogr_shape_53():
 
     # GetFeature() on a invalid FID
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         feat = lyr.GetFeature(-1)
     assert feat is None and gdal.GetLastErrorMsg() != ""
 
     # SetFeature() on a invalid FID
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         feat = ogr.Feature(lyr.GetLayerDefn())
         ret = lyr.SetFeature(feat)
         feat = None
@@ -2131,7 +2131,7 @@ def test_ogr_shape_53():
 
     # SetFeature() on a invalid FID
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         feat = ogr.Feature(lyr.GetLayerDefn())
         feat.SetFID(1000)
         ret = lyr.SetFeature(feat)
@@ -2140,7 +2140,7 @@ def test_ogr_shape_53():
 
     # DeleteFeature() on a invalid FID
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.DeleteFeature(-1)
     assert ret != 0
 
@@ -2153,39 +2153,39 @@ def test_ogr_shape_53():
 
     # Try deleting an already deleted feature
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.DeleteFeature(0)
     assert ret != 0
 
     # Test DeleteField() on a invalid index
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.DeleteField(-1)
     assert not (ret == 0 or gdal.GetLastErrorMsg() == "")
 
     # Test ReorderFields() with invalid permutation
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.ReorderFields([1])
     assert not (ret == 0 or gdal.GetLastErrorMsg() == "")
 
     # Test AlterFieldDefn() on a invalid index
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fd = ogr.FieldDefn("foo2", ogr.OFTString)
         ret = lyr.AlterFieldDefn(-1, fd, 0)
     assert not (ret == 0 or gdal.GetLastErrorMsg() == "")
 
     # Test AlterFieldDefn() when attempting to convert from OFTString to something else
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fd = ogr.FieldDefn("foo", ogr.OFTInteger)
         ret = lyr.AlterFieldDefn(0, fd, ogr.ALTER_TYPE_FLAG)
     assert not (ret == 0 or gdal.GetLastErrorMsg() == "")
 
     # Test DROP SPATIAL INDEX ON layer without index
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.ExecuteSQL("DROP SPATIAL INDEX ON ogr_shape_53")
     assert gdal.GetLastErrorMsg() != ""
 
@@ -2212,25 +2212,25 @@ def test_ogr_shape_53():
     fd = ogr.FieldDefn("bar", ogr.OFTString)
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateField(fd)
     assert not (ret == 0 or gdal.GetLastErrorMsg() == "")
 
     # Test ReorderFields()
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.ReorderFields([0])
     assert not (ret == 0 or gdal.GetLastErrorMsg() == "")
 
     # Test DeleteField()
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.DeleteField(0)
     assert not (ret == 0 or gdal.GetLastErrorMsg() == "")
 
     # Test AlterFieldDefn()
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         fd = ogr.FieldDefn("foo2", ogr.OFTString)
         ret = lyr.AlterFieldDefn(0, fd, 0)
     assert not (ret == 0 or gdal.GetLastErrorMsg() == "")
@@ -2239,13 +2239,13 @@ def test_ogr_shape_53():
     feat = ogr.Feature(lyr.GetLayerDefn())
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(feat)
     assert not (ret == 0 or gdal.GetLastErrorMsg() == "")
 
     # Test DeleteFeature()
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.DeleteFeature(0)
     assert not (ret == 0 or gdal.GetLastErrorMsg() == "")
 
@@ -2253,19 +2253,19 @@ def test_ogr_shape_53():
     feat = lyr.GetNextFeature()
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetFeature(feat)
     assert not (ret == 0 or gdal.GetLastErrorMsg() == "")
 
     # Test REPACK
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.ExecuteSQL("REPACK ogr_shape_53")
     assert gdal.GetLastErrorMsg() != ""
 
     # Test RECOMPUTE EXTENT ON
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.ExecuteSQL("RECOMPUTE EXTENT ON ogr_shape_53")
     assert gdal.GetLastErrorMsg() != ""
 
@@ -2279,7 +2279,7 @@ def test_ogr_shape_53():
     lyr = ds.GetLayer(0)
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.DeleteFeature(0)
     assert not (ret == 0 or gdal.GetLastErrorMsg() == "")
 
@@ -2299,7 +2299,7 @@ def test_ogr_shape_53():
 
     # Test RECOMPUTE EXTENT ON
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.ExecuteSQL("RECOMPUTE EXTENT ON ogr_shape_53")
     assert gdal.GetLastErrorMsg() != ""
 
@@ -2410,11 +2410,11 @@ def test_ogr_shape_54():
     # Test corner case where we cannot reopen a closed layer
     ideletedlayer = 0
     gdal.Unlink(ds_name + "/" + "layer%03d.shp" % ideletedlayer)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.GetLayerByName("layer%03d" % ideletedlayer)
     if lyr is not None:
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             lyr.ResetReading()
             lyr.GetNextFeature()
         assert gdal.GetLastErrorMsg() != ""
@@ -2424,7 +2424,7 @@ def test_ogr_shape_54():
     gdal.Unlink(ds_name + "/" + "layer%03d.dbf" % ideletedlayer)
     lyr = ds.GetLayerByName("layer%03d" % ideletedlayer)
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.ResetReading()
         lyr.GetNextFeature()
     # if gdal.GetLastErrorMsg() == '':
@@ -2460,7 +2460,7 @@ def test_ogr_shape_55():
         assert ret == 0, "failed creating field foo%d" % i
 
     i = max_field_count
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateField(ogr.FieldDefn("foo%d" % i, ogr.OFTInteger))
     assert ret != 0, "should have failed creating field foo%d" % i
 
@@ -2502,7 +2502,7 @@ def test_ogr_shape_56():
         assert ret == 0, "failed creating field foo%d" % i
 
     i = max_field_count
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateField(ogr.FieldDefn("foo%d" % i, ogr.OFTString))
     assert ret != 0, "should have failed creating field foo%d" % i
 
@@ -2533,7 +2533,7 @@ def test_ogr_shape_57():
     field_defn.SetWidth(1024)
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.CreateField(field_defn)
     # print(gdal.GetLastErrorMsg())
     assert gdal.GetLastErrorMsg() != "", "expecting a warning"
@@ -2542,7 +2542,7 @@ def test_ogr_shape_57():
     feat.SetField(0, "0123456789" * 27)
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.CreateFeature(feat)
     # print(gdal.GetLastErrorMsg())
     assert gdal.GetLastErrorMsg() != "", "expecting a warning"
@@ -2815,14 +2815,14 @@ def test_ogr_shape_63():
     chinese_str = struct.pack("B" * 6, 229, 144, 141, 231, 167, 176)
     chinese_str = chinese_str.decode("UTF-8")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.AlterFieldDefn(
             0, ogr.FieldDefn(chinese_str, ogr.OFTString), ogr.ALTER_NAME_FLAG
         )
 
     assert ret != 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateField(ogr.FieldDefn(chinese_str, ogr.OFTString))
 
     assert ret != 0
@@ -2868,7 +2868,7 @@ def test_ogr_shape_64():
     assert lyr.GetName() == "a.c"
 
     # Test that we cannot create a duplicate layer
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.CreateLayer("a.b")
     assert lyr is None
 
@@ -2912,24 +2912,24 @@ def test_ogr_shape_65():
 def test_ogr_shape_66():
 
     ds = ogr.GetDriverByName("ESRI Shapefile").CreateDataSource("/i_dont_exist/bar.dbf")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.CreateLayer("bar", geom_type=ogr.wkbNone)
     assert lyr is None
     ds = None
 
     ds = ogr.GetDriverByName("ESRI Shapefile").CreateDataSource("/i_dont_exist/bar.shp")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.CreateLayer("bar", geom_type=ogr.wkbPoint)
     assert lyr is None
     ds = None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.GetDriverByName("ESRI Shapefile").CreateDataSource("/i_dont_exist/bar")
     assert ds is None
 
     f = open("tmp/foo", "wb")
     f.close()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.GetDriverByName("ESRI Shapefile").CreateDataSource("tmp/foo")
     assert ds is None
     os.unlink("tmp/foo")
@@ -3001,7 +3001,7 @@ def test_ogr_shape_68():
             assert lyr.GetGeomType() == ogr.wkbNone
             lyr = ds.GetLayerByName("mixedcase")
             assert lyr.GetGeomType() == ogr.wkbPolygon
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ret = lyr.DeleteFeature(0)
             assert ret != 0, "expected failure on DeleteFeature()"
             # gdal.ErrorReset()
@@ -3112,7 +3112,7 @@ def test_ogr_shape_71():
     shutil.copy("data/poly.dbf", "tmp/ogr_shape_71.dbf")
     old_mode = os.stat("tmp/ogr_shape_71.dbf").st_mode
     os.chmod("tmp/ogr_shape_71.dbf", stat.S_IREAD)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("tmp/ogr_shape_71.shp", update=1)
     ok = ds is None
     ds = None
@@ -3151,7 +3151,7 @@ def test_ogr_shape_72():
     lyr = ds.GetLayer(0)
     feat = ogr.Feature(lyr.GetLayerDefn())
     feat.SetGeometry(ogr.CreateGeometryFromWkt("POINT (3 4)"))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(feat)
     assert ret != 0
     ds = None
@@ -3168,7 +3168,7 @@ def test_ogr_shape_72():
     feat = ogr.Feature(lyr.GetLayerDefn())
     feat.SetGeometry(ogr.CreateGeometryFromWkt("POINT (5 6)"))
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(feat)
     assert ret != 0
     ds = None
@@ -3179,7 +3179,7 @@ def test_ogr_shape_72():
     feat = ogr.Feature(lyr.GetLayerDefn())
     feat.SetGeometry(ogr.CreateGeometryFromWkt("POINT (7 8)"))
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(feat)
     assert ret == 0
     assert (
@@ -3415,7 +3415,7 @@ def test_ogr_shape_78():
     gdal.ErrorReset()
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetField("dblfield2", 1e21)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.CreateFeature(f)
     assert gdal.GetLastErrorMsg() != "", "did not get expected error/warning"
 
@@ -3423,7 +3423,7 @@ def test_ogr_shape_78():
     gdal.ErrorReset()
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetField("dblfield", (2**53) * 1.0 + 2)  # 2^53+1 == 2^53 !
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.CreateFeature(f)
     assert gdal.GetLastErrorMsg() != "", "did not get expected error/warning"
 
@@ -3590,7 +3590,7 @@ def test_ogr_shape_82():
         "ушив голен"
     )
     feat.SetField("cut_field", init_rus)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdaltest.shape_lyr.CreateFeature(feat)
 
     # Insert feature with long a string in Russian.  Shoe repair ad.
@@ -3827,7 +3827,7 @@ def test_ogr_shape_89():
 
     ds = ogr.Open("/vsimem/ogr_shape_89.shp")
     lyr = ds.GetLayer(0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     assert f is None or f.GetGeometryRef() is None
     ds = None
@@ -4325,7 +4325,7 @@ def test_ogr_shape_100(variant):
     assert f["foo"] == "2"
     assert f.GetGeometryRef().ExportToWkt() == "LINESTRING (1 1,2 2,3 3)"
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetFeature(1)
     assert f is None, variant
     lyr.ResetReading()
@@ -5074,12 +5074,12 @@ def test_ogr_shape_112_delete_layer():
     ds = None
 
     ds = ogr.Open(dirname)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.DeleteLayer(0) != 0
     ds = None
 
     ds = ogr.Open(dirname, update=1)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.DeleteLayer(-1) != 0
         assert ds.DeleteLayer(1) != 0
     gdal.FileFromMemBuffer(dirname + "/test.cpg", "foo")
@@ -5111,7 +5111,7 @@ def test_ogr_shape_113_restore_shx_empty_shp_shx():
     gdal.FileFromMemBuffer(dirname + "/foo.shx", "")
 
     with gdaltest.config_option("SHAPE_RESTORE_SHX", "YES"):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = ogr.Open(dbfname)
     assert ds
     lyr = ds.GetLayer(0)
@@ -5165,10 +5165,10 @@ def test_ogr_shape_114_shz():
     lyr = ds.GetLayer(0)
     assert lyr.GetFeatureCount() == 10
     assert ds.TestCapability(ogr.ODsCCreateLayer) == 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not ds.CreateLayer("foo")
     assert ds.TestCapability(ogr.ODsCDeleteLayer) == 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.DeleteLayer(0) == ogr.OGRERR_FAILURE
     assert lyr.DeleteFeature(1) == 0
     ds = None
@@ -5193,7 +5193,7 @@ def test_ogr_shape_114_shz():
     shape_drv.DeleteDataSource(shz_name)
     assert not gdal.VSIStatL(shz_name)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not shape_drv.CreateDataSource("/i_do/not_exist/my.shz")
 
 
@@ -5279,7 +5279,7 @@ def test_ogr_shape_115_shp_zip():
     # Check lock file
     ds2 = ogr.Open(filename, update=1)
     lyr2 = ds2.GetLayer(0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr2.DeleteFeature(2) != 0
     ds2 = None
     ds = None
@@ -5314,7 +5314,7 @@ def test_ogr_shape_115_shp_zip():
     assert set(gdal.ReadDir(dirname)) in (set([".", ".."]), set([]))
     gdal.RmdirRecursive(dirname)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert not shape_drv.CreateDataSource("/i_do/not_exist/my.shp.zip")
 
 
@@ -5327,7 +5327,7 @@ def test_ogr_shape_116_invalid_layer_name():
     gdal.RmdirRecursive(dirname)
     shape_drv = ogr.GetDriverByName("ESRI Shapefile")
     ds = shape_drv.CreateDataSource(dirname)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert ds.CreateLayer('test<>:"/\\?*', None, ogr.wkbNone)
     ds = None
     ds = ogr.Open(dirname)
@@ -5400,7 +5400,7 @@ def test_ogr_shape_write_point_z_non_finite():
     g.AddPoint(0, 0, float("inf"))
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometry(g)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.CreateFeature(f) != ogr.OGRERR_NONE
     ds = None
     ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("/vsimem/test.shp")
@@ -5419,7 +5419,7 @@ def test_ogr_shape_write_linestring_z_non_finite():
     g.AddPoint(0, 1, float("inf"))
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometry(g)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.CreateFeature(f) != ogr.OGRERR_NONE
     ds = None
     ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("/vsimem/test.shp")
@@ -5440,7 +5440,7 @@ def test_ogr_shape_write_multilinestring_z_non_finite():
     g.AddGeometry(ls)
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometry(g)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.CreateFeature(f) != ogr.OGRERR_NONE
     ds = None
     ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("/vsimem/test.shp")
@@ -5463,7 +5463,7 @@ def test_ogr_shape_write_polygon_z_non_finite():
     g.AddGeometry(ls)
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometry(g)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.CreateFeature(f) != ogr.OGRERR_NONE
     ds = None
     ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("/vsimem/test.shp")
@@ -5488,7 +5488,7 @@ def test_ogr_shape_write_multipolygon_z_non_finite():
     g.AddGeometry(p)
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometry(g)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.CreateFeature(f) != ogr.OGRERR_NONE
     ds = None
     ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("/vsimem/test.shp")
@@ -5558,14 +5558,14 @@ def test_ogr_shape_rename_layer():
     lyr = ds.GetLayer(0)
     assert lyr.TestCapability(ogr.OLCRename) == 1
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.Rename("test_rename") != ogr.OGRERR_NONE
 
     f = gdal.VSIFOpenL("tmp/test_rename_foo.dbf", "wb")
     assert f
     gdal.VSIFCloseL(f)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.Rename("test_rename_foo") != ogr.OGRERR_NONE
 
     gdal.Unlink("tmp/test_rename_foo.dbf")
@@ -5699,7 +5699,7 @@ def test_ogr_shape_alter_geom_field_defn():
 
     # Wrong index
     new_geom_field_defn = ogr.GeomFieldDefn("", ogr.wkbPoint)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             lyr.AlterGeomFieldDefn(
                 -1, new_geom_field_defn, ogr.ALTER_GEOM_FIELD_DEFN_ALL_FLAG
@@ -5709,7 +5709,7 @@ def test_ogr_shape_alter_geom_field_defn():
 
     # Changing geometry type ==> unsupported
     new_geom_field_defn = ogr.GeomFieldDefn("", ogr.wkbLineString)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             lyr.AlterGeomFieldDefn(
                 0, new_geom_field_defn, ogr.ALTER_GEOM_FIELD_DEFN_ALL_FLAG
@@ -5723,7 +5723,7 @@ def test_ogr_shape_alter_geom_field_defn():
     srs_with_epoch.ImportFromEPSG(4326)
     srs_with_epoch.SetCoordinateEpoch(2022)
     new_geom_field_defn.SetSpatialRef(srs_with_epoch)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             lyr.AlterGeomFieldDefn(
                 0, new_geom_field_defn, ogr.ALTER_GEOM_FIELD_DEFN_ALL_FLAG

--- a/autotest/ogr/ogr_sql_rfc28.py
+++ b/autotest/ogr/ogr_sql_rfc28.py
@@ -743,7 +743,7 @@ def test_ogr_rfc28_union_all_three_branch_and(data_ds):
 
 def test_ogr_rfc28_33(data_ds):
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = data_ds.ExecuteSQL("select * from idlink where name='foo")
 
     assert lyr is None
@@ -755,7 +755,7 @@ def test_ogr_rfc28_33(data_ds):
 
 def test_ogr_rfc28_34(data_ds):
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = data_ds.ExecuteSQL("select foo.* from idlink")
     assert gdal.GetLastErrorMsg().startswith(
         "Table foo not recognised from foo.* definition"
@@ -770,7 +770,7 @@ def test_ogr_rfc28_34(data_ds):
 
 def test_ogr_rfc28_35(data_ds):
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = data_ds.ExecuteSQL("select distinct eas_id, distinct name from idlink")
     assert gdal.GetLastErrorMsg().startswith("SQL Expression Parsing Error")
 
@@ -783,7 +783,7 @@ def test_ogr_rfc28_35(data_ds):
 
 def test_ogr_rfc28_35_bis(data_ds):
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = data_ds.ExecuteSQL("select distinct eas_id, name from idlink")
     assert gdal.GetLastErrorMsg().startswith(
         "SELECT DISTINCT not supported on multiple columns"
@@ -798,7 +798,7 @@ def test_ogr_rfc28_35_bis(data_ds):
 
 def test_ogr_rfc28_35_ter(data_ds):
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = data_ds.ExecuteSQL("select distinct * from idlink")
     assert gdal.GetLastErrorMsg().startswith(
         "SELECT DISTINCT not supported on multiple columns"
@@ -852,7 +852,7 @@ def test_ogr_rfc28_37(data_ds):
 def test_ogr_rfc28_38(data_ds):
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = data_ds.ExecuteSQL("SELECT SUBSTR(PRFEDEA) from poly")
         assert (
             gdal.GetLastErrorMsg().find(
@@ -863,7 +863,7 @@ def test_ogr_rfc28_38(data_ds):
         assert lyr is None
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = data_ds.ExecuteSQL("SELECT SUBSTR(1,2) from poly")
         assert gdal.GetLastErrorMsg().find("Wrong argument type for SUBSTR()") == 0
         assert lyr is None
@@ -1114,7 +1114,7 @@ def test_ogr_rfc28_44():
     lyr.CreateField(fld_defn)
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.ExecuteSQL(
             'SELECT * FROM "lyr.withpoint" JOIN field ON "lyr.withpoint".foo = field.id WHERE field.withpoint = 1'
         )
@@ -1296,19 +1296,19 @@ def test_ogr_rfc28_48():
     feat.SetField("dt", "2017/02/17 11:06:34")
     lyr.CreateFeature(feat)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.SetAttributeFilter("dt >= 2500000000") != 0
 
     lyr.SetAttributeFilter("dt >= 'a'")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.GetFeatureCount() == 0
 
     lyr.SetAttributeFilter("'a' <= dt")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.GetFeatureCount() == 0
 
     lyr.SetAttributeFilter("dt BETWEEN dt AND 'a'")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert lyr.GetFeatureCount() == 0
 
     lyr.SetAttributeFilter("dt >= '2017/02/17 11:06:34'")
@@ -1426,7 +1426,7 @@ def test_ogr_rfc28_int_overflows():
     for sql, res in tests:
         sql_lyr = ds.ExecuteSQL(sql)
         if res is None:
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 f = sql_lyr.GetNextFeature()
         else:
             f = sql_lyr.GetNextFeature()

--- a/autotest/ogr/ogr_sql_sqlite.py
+++ b/autotest/ogr/ogr_sql_sqlite.py
@@ -74,7 +74,7 @@ def require_ogr_sql_sqlite():
     ds.ReleaseResultSet(sql_lyr)
     assert sql_lyr is not None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.GetDriverByName("SQLite").CreateDataSource(
             "/vsimem/foo.db", options=["SPATIALITE=YES"]
         )
@@ -780,17 +780,17 @@ def test_ogr_sql_sqlite_12():
     ds = ogr.GetDriverByName("Memory").CreateDataSource("my_ds")
 
     # Invalid SQL
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = ds.ExecuteSQL("qdfdfdf", dialect="SQLite")
     ds.ReleaseResultSet(sql_lyr)
 
     # Non existing external datasource
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = ds.ExecuteSQL("SELECT * FROM 'foo'.'bar'", dialect="SQLite")
     ds.ReleaseResultSet(sql_lyr)
 
     # Non existing layer in existing external datasource
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = ds.ExecuteSQL("SELECT * FROM 'data'.'azertyuio'", dialect="SQLite")
     ds.ReleaseResultSet(sql_lyr)
 
@@ -820,7 +820,7 @@ def test_ogr_sql_sqlite_13():
     feat = None
 
     # Test with invalid parameter
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = ds.ExecuteSQL("SELECT ogr_layer_Extent(12)", dialect="SQLite")
     feat = sql_lyr.GetNextFeature()
     geom = feat.GetGeometryRef()
@@ -829,7 +829,7 @@ def test_ogr_sql_sqlite_13():
     assert geom is None
 
     # Test on non existing layer
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = ds.ExecuteSQL("SELECT ogr_layer_Extent('foo')", dialect="SQLite")
     feat = sql_lyr.GetNextFeature()
     geom = feat.GetGeometryRef()
@@ -1711,7 +1711,7 @@ def test_ogr_sql_sqlite_24():
     ds.ReleaseResultSet(sql_lyr)
 
     # Error case
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = ds.ExecuteSQL("SELECT ogr_deflate()", dialect="SQLite")
     if sql_lyr is not None:
         ds.ReleaseResultSet(sql_lyr)
@@ -1727,7 +1727,7 @@ def test_ogr_sql_sqlite_24():
     ds.ReleaseResultSet(sql_lyr)
 
     # Error case
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = ds.ExecuteSQL("SELECT ogr_inflate()", dialect="SQLite")
     if sql_lyr is not None:
         ds.ReleaseResultSet(sql_lyr)
@@ -2015,7 +2015,7 @@ def test_ogr_sql_sqlite_28():
 
     # Invalid parameters
     for sql in ["SELECT hstore_get_value('a')"]:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             sql_lyr = ds.ExecuteSQL(sql, dialect="SQLite")
         assert sql_lyr is None, sql
 
@@ -2173,12 +2173,12 @@ def test_ogr_sql_sqlite_st_makevalid():
 
     # Check if MakeValid() is available
     g = ogr.CreateGeometryFromWkt("POLYGON ((0 0,10 10,0 10,10 0,0 0))")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         make_valid_available = g.MakeValid() is not None
 
     ds = ogr.GetDriverByName("Memory").CreateDataSource("")
     sql = "SELECT ST_MakeValid(ST_GeomFromText('POLYGON ((0 0,1 1,1 0,0 1,0 0))'))"
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = ds.ExecuteSQL(sql, dialect="SQLite")
     if sql_lyr is None:
         assert not make_valid_available

--- a/autotest/ogr/ogr_sql_test.py
+++ b/autotest/ogr/ogr_sql_test.py
@@ -474,7 +474,7 @@ def test_ogr_sql_17():
 
 def test_ogr_sql_19(data_ds):
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert data_ds.ExecuteSQL("") is None
 
 
@@ -812,7 +812,7 @@ def test_ogr_sql_28():
     for query in queries:
         gdal.ErrorReset()
         # print query
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             sql_lyr = ds.ExecuteSQL(query)
         if sql_lyr is not None:
             ds.ReleaseResultSet(sql_lyr)
@@ -985,7 +985,7 @@ def test_ogr_sql_34(data_ds):
 
         assert val == 1
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert (
             data_ds.ExecuteSQL("select count(*) from poly where eas_id in ('a165')")
             is None
@@ -1204,7 +1204,7 @@ def test_ogr_sql_44(data_ds):
         "SELECT hstore_get_value('a') FROM poly",
         "SELECT hstore_get_value(1, 1) FROM poly",
     ]:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             sql_lyr = data_ds.ExecuteSQL(sql)
         assert sql_lyr is None, sql
 
@@ -1328,7 +1328,7 @@ def test_ogr_sql_46():
         "select max('id') from 'test'",
         "select id as 'id2' from 'test'",
     ]:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             sql_lyr = ds.ExecuteSQL("select * from 'test'")
         assert sql_lyr is None, sql
 

--- a/autotest/ogr/ogr_sqlite.py
+++ b/autotest/ogr/ogr_sqlite.py
@@ -57,7 +57,7 @@ def module_disable_exceptions():
 
 @pytest.fixture(autouse=True, scope="module")
 def setup():
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.GetDriverByName("SQLite").CreateDataSource(
             "/vsimem/foo.db", options=["SPATIALITE=YES"]
         )
@@ -123,17 +123,17 @@ def test_ogr_sqlite_2():
     if gdaltest.sl_ds is None:
         pytest.skip()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdaltest.sl_ds.ExecuteSQL("DELLAYER:tpoly")
 
     # Test invalid FORMAT
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = gdaltest.sl_ds.CreateLayer("will_fail", options=["FORMAT=FOO"])
     assert lyr is None, "layer creation should have failed"
 
     # Test creating a layer with an existing name
     lyr = gdaltest.sl_ds.CreateLayer("a_layer")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = gdaltest.sl_ds.CreateLayer("a_layer")
     assert lyr is None, "layer creation should have failed"
 
@@ -744,7 +744,7 @@ def test_ogr_sqlite_15():
 
     ######################################################
     # Create Layer with SPATIALITE geometry
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         gdaltest.sl_lyr = gdaltest.sl_ds.CreateLayer(
             "geomspatialite", options=["FORMAT=SPATIALITE"]
         )
@@ -786,7 +786,7 @@ def test_ogr_sqlite_15():
     gdaltest.sl_ds = ogr.Open("tmp/sqlite_test.db")
 
     # Test creating a layer on a read-only DB
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = gdaltest.sl_ds.CreateLayer("will_fail")
     assert lyr is None, "layer creation should have failed"
 
@@ -928,12 +928,12 @@ def test_ogr_sqlite_17(require_spatialite):
     ######################################################
     # Create dataset with SPATIALITE geometry
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.GetDriverByName("SQLite").CreateDataSource(
             "tmp/spatialite_test.db", options=["SPATIALITE=YES"]
         )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.CreateLayer("will_fail", options=["FORMAT=WKB"])
     assert lyr is None, "layer creation should have failed"
 
@@ -1210,7 +1210,7 @@ def test_ogr_sqlite_24():
 
     ds = ogr.Open("tmp/test24.sqlite")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.ExecuteSQL("select OGR_GEOMETRY from test")
     if lyr is not None:
         ds.ReleaseResultSet(lyr)
@@ -1224,7 +1224,7 @@ def test_ogr_sqlite_24():
 
     lyr = ds.GetLayerByName("test")
     lyr.SetAttributeFilter("OGR_GEOMETRY = 'POLYGON'")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         feat = lyr.GetNextFeature()
     assert feat is None, "a feature was not expected (3)"
 
@@ -1269,7 +1269,7 @@ def test_ogr_sqlite_25():
         pytest.skip()
 
     # Check that we have SQLite VFS support
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.GetDriverByName("SQLite").CreateDataSource("/vsimem/ogr_sqlite_25.db")
     if ds is None:
         pytest.skip()
@@ -2154,7 +2154,7 @@ def test_ogr_spatialite_8(require_spatialite):
     feat = None
     ds.ReleaseResultSet(sql_lyr)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.GetLayerByName("invalid_layer_name(geom1)")
     assert lyr is None
 
@@ -2337,7 +2337,7 @@ def test_ogr_sqlite_33(with_and_without_spatialite):
     lyr = ds.CreateLayer("test2", options=["SRID=4326"])
 
     # Test with non-existing entry
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr = ds.CreateLayer("test3", options=["SRID=123456"])
     ds = None
 
@@ -2375,7 +2375,7 @@ def test_ogr_sqlite_34():
     if gdaltest.sl_ds is None:
         pytest.skip()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = gdaltest.sl_ds.ExecuteSQL("SELECT 'a' REGEXP 'a'")
     if sql_lyr is None:
         pytest.skip()
@@ -2399,12 +2399,12 @@ def test_ogr_sqlite_34():
     assert val == 0
 
     # NULL regexp
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = gdaltest.sl_ds.ExecuteSQL("SELECT 'a' REGEXP NULL")
     assert sql_lyr is None
 
     # Invalid regexp
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = gdaltest.sl_ds.ExecuteSQL("SELECT 'a' REGEXP '['")
     assert sql_lyr is None
 
@@ -2597,7 +2597,7 @@ def test_ogr_sqlite_37():
     # Error case: missing geometry
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetField("field_not_nullable", "not_null")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(f)
     assert ret != 0
     f = None
@@ -2605,7 +2605,7 @@ def test_ogr_sqlite_37():
     # Error case: missing non-nullable field
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometryDirectly(ogr.CreateGeometryFromWkt("POINT(0 0)"))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(f)
     assert ret != 0
     f = None
@@ -2995,7 +2995,7 @@ def test_ogr_sqlite_39():
     lyr = ds.CreateLayer("test", geom_type=ogr.wkbNone, options=["FID=myfid"])
 
     lyr.CreateField(ogr.FieldDefn("str", ogr.OFTString))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateField(ogr.FieldDefn("myfid", ogr.OFTString))
     assert ret != 0
 
@@ -3029,16 +3029,16 @@ def test_ogr_sqlite_39():
     feat = ogr.Feature(lyr.GetLayerDefn())
     feat.SetFID(1)
     feat.SetField("myfid", 10)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(feat)
     assert ret != 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetFeature(feat)
     assert ret != 0
 
     feat.UnsetField("myfid")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetFeature(feat)
     assert ret != 0
 
@@ -3080,7 +3080,7 @@ def test_ogr_sqlite_40(with_and_without_spatialite):
 
     ret = ds.StartTransaction()
     assert ret == 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.StartTransaction()
     assert ret != 0
 
@@ -3088,7 +3088,7 @@ def test_ogr_sqlite_40(with_and_without_spatialite):
     lyr.CreateField(ogr.FieldDefn("foo", ogr.OFTString))
     ret = ds.RollbackTransaction()
     assert ret == 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.RollbackTransaction()
     assert ret != 0
     ds = None
@@ -3097,7 +3097,7 @@ def test_ogr_sqlite_40(with_and_without_spatialite):
     assert ds.GetLayerCount() == 0
     ret = ds.StartTransaction()
     assert ret == 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.StartTransaction()
     assert ret != 0
 
@@ -3105,7 +3105,7 @@ def test_ogr_sqlite_40(with_and_without_spatialite):
     lyr.CreateField(ogr.FieldDefn("foo", ogr.OFTString))
     ret = ds.CommitTransaction()
     assert ret == 0
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = ds.CommitTransaction()
     assert ret != 0
     ds = None
@@ -3390,7 +3390,7 @@ def test_ogr_spatialite_11(require_spatialite):
     f = None
 
     lyr = ds.CreateLayer("test2", geom_type=ogr.wkbNone)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         res = lyr.CreateGeomField(ogr.GeomFieldDefn("foo", ogr.wkbCurvePolygon))
     assert res != 0
 
@@ -4123,7 +4123,7 @@ def test_ogr_sqlite_ogr_layer_Extent():
         feat = None
 
         # Test with invalid parameter
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             sql_lyr = ds.ExecuteSQL("SELECT ogr_layer_Extent(12)")
         feat = sql_lyr.GetNextFeature()
         geom = feat.GetGeometryRef()
@@ -4132,7 +4132,7 @@ def test_ogr_sqlite_ogr_layer_Extent():
         assert geom is None
 
         # Test on non existing layer
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             sql_lyr = ds.ExecuteSQL("SELECT ogr_layer_Extent('foo')")
         feat = sql_lyr.GetNextFeature()
         geom = feat.GetGeometryRef()

--- a/autotest/ogr/ogr_style.py
+++ b/autotest/ogr/ogr_style.py
@@ -30,7 +30,6 @@
 ###############################################################################
 
 
-import gdaltest
 import pytest
 
 from osgeo import gdal, ogr
@@ -58,7 +57,7 @@ def test_ogr_style_styletable():
 
     gdal.Unlink("/vsimem/out.txt")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = style_table.Find("non_existing_style")
     assert ret is None
 

--- a/autotest/ogr/ogr_sxf.py
+++ b/autotest/ogr/ogr_sxf.py
@@ -42,7 +42,7 @@ pytestmark = pytest.mark.require_driver("SXF")
 def test_ogr_sxf_1():
 
     gdaltest.sxf_ds = None
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # Expect Warning 0 and Warning 6.
         gdaltest.sxf_ds = ogr.Open("data/sxf/100_test.sxf")
 

--- a/autotest/ogr/ogr_tiledb.py
+++ b/autotest/ogr/ogr_tiledb.py
@@ -173,7 +173,7 @@ def create_tiledb_dataset(nullable, batch_size, include_bool, extra_feature=Fals
     f["intfieldextra"] = 2
     f.SetGeometry(ogr.CreateGeometryFromWkt("POLYGON ((1 2,1 3,4 3,1 2))"))
     if not nullable:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert lyr.CreateFeature(f) == ogr.OGRERR_NONE
     else:
         assert lyr.CreateFeature(f) == ogr.OGRERR_NONE

--- a/autotest/ogr/ogr_vdv.py
+++ b/autotest/ogr/ogr_vdv.py
@@ -378,7 +378,7 @@ def test_ogr_vdv_7():
 
         ds = ogr.GetDriverByName("VDV").CreateDataSource(out_filename)
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             lyr = ds.CreateLayer(
                 "UNKNOWN",
                 options=["PROFILE=" + profile, "PROFILE_STRICT=" + str(strict)],
@@ -397,7 +397,7 @@ def test_ogr_vdv_7():
             lyr_name, options=["PROFILE=" + profile, "PROFILE_STRICT=" + str(strict)]
         )
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = lyr.CreateField(ogr.FieldDefn("UNKNOWN"))
         assert gdal.GetLastErrorMsg() != ""
         if strict and ret == 0:
@@ -416,11 +416,11 @@ def test_ogr_vdv_7():
 
 def test_ogr_vdv_8():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.GetDriverByName("VDV").CreateDataSource("/does/not_exist")
     assert ds is None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.GetDriverByName("VDV").CreateDataSource(
             "/does/not_exist", options=["SINGLE_FILE=FALSE"]
         )
@@ -442,7 +442,7 @@ def test_ogr_vdv_8():
             do_test = True
         if do_test:
             ds = ogr.Open("tmp/ogr_vdv_8", update=1)
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 lyr = ds.CreateLayer("another_layer")
             # 0755 = 493
             os.chmod("tmp/ogr_vdv_8", 493)
@@ -454,7 +454,7 @@ def test_ogr_vdv_8():
     ds = ogr.GetDriverByName("VDV").CreateDataSource(out_filename)
 
     # File already exists
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds2 = ogr.GetDriverByName("VDV").CreateDataSource(out_filename)
     assert ds2 is None
 
@@ -466,7 +466,7 @@ def test_ogr_vdv_8():
 
     lyr1.ResetReading()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr1.GetNextFeature()
 
     lyr1.CreateFeature(ogr.Feature(lyr1.GetLayerDefn()))
@@ -474,7 +474,7 @@ def test_ogr_vdv_8():
     # Layer structure is now frozen
     assert lyr1.TestCapability(ogr.OLCCreateField) == 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr1.CreateField(ogr.FieldDefn("not_allowed"))
     assert ret != 0
 
@@ -485,7 +485,7 @@ def test_ogr_vdv_8():
 
     assert lyr1.TestCapability(ogr.OLCSequentialWrite) == 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr1.CreateFeature(ogr.Feature(lyr1.GetLayerDefn()))
     assert ret != 0
 

--- a/autotest/ogr/ogr_virtualogr.py
+++ b/autotest/ogr/ogr_virtualogr.py
@@ -64,7 +64,7 @@ def require_auto_load_extension():
         pytest.skip("SQLite missing")
 
     ds = ogr.Open(":memory:")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = ds.ExecuteSQL("PRAGMA compile_options")
     if sql_lyr:
         for f in sql_lyr:
@@ -81,7 +81,7 @@ def ogr_virtualogr_run_sql(sql_statement):
 
     ds = ogr.GetDriverByName("SQLite").CreateDataSource(":memory:")
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = ds.ExecuteSQL(sql_statement)
     success = gdal.GetLastErrorMsg() == ""
     ds.ReleaseResultSet(sql_lyr)
@@ -92,7 +92,7 @@ def ogr_virtualogr_run_sql(sql_statement):
 
     ds = ogr.GetDriverByName("Memory").CreateDataSource("")
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = ds.ExecuteSQL(sql_statement, dialect="SQLITE")
     success = gdal.GetLastErrorMsg() == ""
     ds.ReleaseResultSet(sql_lyr)
@@ -209,7 +209,7 @@ def test_ogr_virtualogr_2(require_auto_load_extension):
     for i in range(ds.GetLayerCount()):
         assert ds.GetLayer(i).GetName() != "foo"
     # An error will be triggered at the time the trigger is used
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.ExecuteSQL("INSERT INTO regular_table (bar) VALUES ('bar')")
     did_not_get_error = gdal.GetLastErrorMsg() == ""
     ds = None
@@ -279,7 +279,7 @@ def test_ogr_virtualogr_4(require_auto_load_extension):
     ds = ogr.GetDriverByName("SQLite").CreateDataSource("/vsimem/ogr_virtualogr_4.db")
     sql_lyr = ds.ExecuteSQL("SELECT ogr_datasource_load_layers('data/poly.shp')")
     ds.ReleaseResultSet(sql_lyr)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = ds.ExecuteSQL("SELECT ogr_datasource_load_layers('data/poly.shp')")
     ds.ReleaseResultSet(sql_lyr)
     sql_lyr = ds.ExecuteSQL("SELECT * FROM poly")
@@ -316,7 +316,7 @@ def test_ogr_virtualogr_4(require_auto_load_extension):
 
     # Various error conditions
     ds = ogr.GetDriverByName("SQLite").CreateDataSource("/vsimem/ogr_virtualogr_4.db")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = ds.ExecuteSQL("SELECT ogr_datasource_load_layers(0)")
         ds.ReleaseResultSet(sql_lyr)
         sql_lyr = ds.ExecuteSQL("SELECT ogr_datasource_load_layers('foo')")
@@ -348,7 +348,7 @@ def test_ogr_virtualogr_5(require_auto_load_extension):
     gdal.VSIFCloseL(fp)
 
     ds = ogr.GetDriverByName("Memory").CreateDataSource("")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         sql_lyr = ds.ExecuteSQL(
             "CREATE VIRTUAL TABLE lyr2 USING VirtualOGR('/vsimem/ogr_virtualogr_5.csv')",
             dialect="SQLITE",
@@ -371,7 +371,7 @@ def test_ogr_sqlite_load_extensions_load_self(require_auto_load_extension):
 
     # Load ourselves ! not allowed
     with gdaltest.config_option("OGR_SQLITE_LOAD_EXTENSIONS", libgdal_name):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = ogr.Open(":memory:")
             assert ds is not None
         assert gdal.GetLastErrorMsg() != ""
@@ -382,7 +382,7 @@ def test_ogr_sqlite_load_extensions_load_self(require_auto_load_extension):
     ):
         ds = ogr.Open(":memory:")
         assert ds is not None
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds.ReleaseResultSet(
                 ds.ExecuteSQL("SELECT load_extension('" + libgdal_name + "')")
             )

--- a/autotest/ogr/ogr_vrt.py
+++ b/autotest/ogr/ogr_vrt.py
@@ -51,7 +51,7 @@ def module_disable_exceptions():
 
 def test_ogr_vrt_1():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         # Complains about dummySrcDataSource as expected.
         gdaltest.vrt_ds = ogr.Open("data/vrt/vrt_test.vrt")
 
@@ -358,7 +358,7 @@ def test_ogr_vrt_11():
 
     # The x and y fields are considered as string by default, so spatial
     # filter cannot be turned into attribute filter
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         vrt_lyr.SetSpatialFilterRect(0, 40, 10, 49.5)
         ret = vrt_lyr.GetFeatureCount()
     assert gdal.GetLastErrorMsg().find("not declared as numeric fields") != -1
@@ -480,7 +480,7 @@ def test_ogr_vrt_14():
     if gdaltest.vrt_ds is None:
         pytest.skip()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         try:
             ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/test.shp")
         except AttributeError:
@@ -821,7 +821,7 @@ def test_ogr_vrt_20():
     if gdaltest.vrt_ds is None:
         pytest.skip()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         try:
             ogr.GetDriverByName("ESRI Shapefile").DeleteDataSource("tmp/test.shp")
         except AttributeError:
@@ -1028,7 +1028,7 @@ def ogr_vrt_21_internal():
 
 
 def test_ogr_vrt_21():
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ogr_vrt_21_internal()
 
 
@@ -1147,7 +1147,7 @@ def ogr_vrt_22_internal():
 
 
 def test_ogr_vrt_22():
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ogr_vrt_22_internal()
 
 
@@ -1187,7 +1187,7 @@ def test_ogr_vrt_23(shared_ds_flag=""):
     assert ds is not None
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.GetLayer(0).GetLayerDefn()
         ds.GetLayer(0).GetFeatureCount()
     assert gdal.GetLastErrorMsg() != "", "error expected !"
@@ -1223,7 +1223,7 @@ def test_ogr_vrt_24():
     assert ds is not None
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.GetLayer(0).GetLayerDefn()
         ds.GetLayer(0).GetFeatureCount()
     assert gdal.GetLastErrorMsg() != "", "error expected !"
@@ -1238,7 +1238,7 @@ def test_ogr_vrt_24():
 
 def test_ogr_vrt_25():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("data/vrt/vrt_test.vrt")
 
     # test3 layer just declares fid, and implicit fields (so all source
@@ -1370,7 +1370,7 @@ def test_ogr_vrt_27():
 
 def test_ogr_vrt_28():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("<OGRVRTDataSource></foo>")
     assert ds is None
 
@@ -1378,18 +1378,18 @@ def test_ogr_vrt_28():
         "/vsimem/ogr_vrt_28_invalid.vrt",
         "<bla><OGRVRTDataSource></OGRVRTDataSource></bla>",
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("/vsimem/ogr_vrt_28_invalid.vrt")
     assert ds is None
     gdal.Unlink("/vsimem/ogr_vrt_28_invalid.vrt")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("data/vrt/invalid.vrt")
     assert ds is not None
 
     for i in range(ds.GetLayerCount()):
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             lyr = ds.GetLayer(i)
             lyr.GetNextFeature()
         assert (
@@ -1398,15 +1398,15 @@ def test_ogr_vrt_28():
 
     ds = None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ogr.Open("<OGRVRTDataSource><OGRVRTLayer/></OGRVRTDataSource>")
     assert gdal.GetLastErrorMsg() != "", "expected error message on datasource opening"
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("data/vrt/invalid2.vrt")
     assert gdal.GetLastErrorMsg() != "", "expected error message on datasource opening"
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("data/vrt/invalid3.vrt")
     assert gdal.GetLastErrorMsg() != "", "expected error message on datasource opening"
 
@@ -1441,7 +1441,7 @@ def test_ogr_vrt_29():
     ds = None
 
     # Invalid source layer
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ogr.Open(
             """<OGRVRTDataSource>
         <OGRVRTWarpedLayer>
@@ -1455,7 +1455,7 @@ def test_ogr_vrt_29():
     assert gdal.GetLastErrorMsg() != ""
 
     # Non-spatial layer
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ogr.Open(
             """<OGRVRTDataSource>
         <OGRVRTWarpedLayer>
@@ -1469,7 +1469,7 @@ def test_ogr_vrt_29():
     assert gdal.GetLastErrorMsg() != ""
 
     # Missing TargetSRS
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ogr.Open(
             """<OGRVRTDataSource>
         <OGRVRTWarpedLayer>
@@ -1482,7 +1482,7 @@ def test_ogr_vrt_29():
     assert gdal.GetLastErrorMsg() != ""
 
     # Invalid TargetSRS
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ogr.Open(
             """<OGRVRTDataSource>
         <OGRVRTWarpedLayer>
@@ -1496,7 +1496,7 @@ def test_ogr_vrt_29():
     assert gdal.GetLastErrorMsg() != ""
 
     # Invalid SrcSRS
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ogr.Open(
             """<OGRVRTDataSource>
         <OGRVRTWarpedLayer>
@@ -1616,20 +1616,20 @@ def test_ogr_vrt_29():
     ds = ogr.Open("tmp/ogr_vrt_29.vrt")
     lyr = ds.GetLayer(0)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.DeleteFeature(1)
     assert ret != 0
 
     feat = lyr.GetNextFeature()
     feat.SetGeometry(ogr.CreateGeometryFromWkt("POINT(500000 0)"))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetFeature(feat)
     assert ret != 0
     feat = None
 
     feat = ogr.Feature(lyr.GetLayerDefn())
     feat.SetGeometry(ogr.CreateGeometryFromWkt("POINT(500000 0)"))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(feat)
     assert ret != 0
     feat = None
@@ -1670,14 +1670,14 @@ def test_ogr_vrt_29():
     lyr.SetAttributeFilter("id = 1000")
 
     # Reprojection will fail
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         feat = lyr.GetNextFeature()
     fid = feat.GetFID()
     if feat.GetGeometryRef() is not None:
         feat.DumpReadable()
         pytest.fail()
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         feat = lyr.GetFeature(fid)
     if feat.GetGeometryRef() is not None:
         feat.DumpReadable()
@@ -1706,14 +1706,14 @@ def test_ogr_vrt_29():
 
     feat = lyr.GetNextFeature()
     feat.SetGeometry(ogr.CreateGeometryFromWkt("POINT(-180 91)"))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetFeature(feat)
     assert ret != 0
     feat = None
 
     feat = ogr.Feature(lyr.GetLayerDefn())
     feat.SetGeometry(ogr.CreateGeometryFromWkt("POINT(-180 91)"))
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(feat)
     assert ret != 0
     feat = None
@@ -1932,7 +1932,7 @@ def test_ogr_vrt_30():
             # CreateFeature() should fail
             feat = ogr.Feature(lyr.GetLayerDefn())
             feat.SetField("id2", 12345)
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ret = lyr.CreateFeature(feat)
             assert ret != 0, "should have failed"
             feat = None
@@ -1941,7 +1941,7 @@ def test_ogr_vrt_30():
             lyr.ResetReading()
             feat = lyr.GetNextFeature()
             feat.SetField("id2", 45321)
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ret = lyr.SetFeature(feat)
             assert ret != 0, "should have failed"
             feat = None
@@ -2091,7 +2091,7 @@ def test_ogr_vrt_30():
             feat = ogr.Feature(lyr.GetLayerDefn())
             feat.SetField("source_layer", "random_name")
             feat.SetField("id2", 12345)
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ret = lyr.CreateFeature(feat)
             assert ret != 0, "should have failed"
             feat = None
@@ -2099,7 +2099,7 @@ def test_ogr_vrt_30():
             # unset source_layer name with CreateFeature()
             feat = ogr.Feature(lyr.GetLayerDefn())
             feat.SetField("id2", 12345)
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ret = lyr.CreateFeature(feat)
             assert ret != 0, "should have failed"
             feat = None
@@ -2109,7 +2109,7 @@ def test_ogr_vrt_30():
             feat.SetFID(999999)
             feat.SetField("source_layer", "ogr_vrt_30_2")
             feat.SetField("id2", 12345)
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ret = lyr.CreateFeature(feat)
             assert ret != 0, "should have failed"
             feat = None
@@ -2126,13 +2126,13 @@ def test_ogr_vrt_30():
 
             # invalid source_layer name with SetFeature()
             feat.SetField("source_layer", "random_name")
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ret = lyr.SetFeature(feat)
             assert ret != 0, "should have failed"
 
             # unset source_layer name with SetFeature()
             feat.UnsetField("source_layer")
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ret = lyr.SetFeature(feat)
             assert ret != 0, "should have failed"
 
@@ -2140,7 +2140,7 @@ def test_ogr_vrt_30():
             feat = ogr.Feature(lyr.GetLayerDefn())
             feat.SetField("source_layer", "ogr_vrt_30_2")
             feat.SetField("id2", 12345)
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ret = lyr.SetFeature(feat)
             assert ret != 0, "should have failed"
             feat = None
@@ -2233,7 +2233,7 @@ def test_ogr_vrt_31(shared_ds_flag=""):
     assert ds is not None
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds.GetLayer(0).GetLayerDefn()
         ds.GetLayer(0).GetFeatureCount()
     assert gdal.GetLastErrorMsg() != "", "error expected !"
@@ -2581,7 +2581,7 @@ def test_ogr_vrt_33():
         <TargetSRS>EPSG:32631</TargetSRS>
     </OGRVRTWarpedLayer>
 </OGRVRTDataSource>"""
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ogr.Open(ds_str)
     assert gdal.GetLastErrorMsg() != ""
 
@@ -3211,13 +3211,13 @@ def test_ogr_vrt_36():
 
 def test_ogr_vrt_37():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("data/vrt/vrt_test.vrt")
 
     lyr = ds.GetLayerByName("test6")
     assert lyr.GetGeomType() == ogr.wkbNone
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("data/vrt/vrt_test.vrt")
 
     lyr = ds.GetLayerByName("test6")
@@ -3387,7 +3387,7 @@ def test_ogr_vrt_41():
 </OGRVRTDataSource>"""
     )
     lyr = ds.GetLayer(0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr.GetExtent()
 
 

--- a/autotest/ogr/ogr_wfs.py
+++ b/autotest/ogr/ogr_wfs.py
@@ -1041,7 +1041,7 @@ def test_ogr_wfs_mapinfo():
 
 def test_ogr_wfs_vsimem_fail_because_not_enabled():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("WFS:/vsimem/wfs_endpoint")
     assert ds is None
 
@@ -1049,7 +1049,7 @@ def test_ogr_wfs_vsimem_fail_because_not_enabled():
 ###############################################################################
 def test_ogr_wfs_vsimem_fail_because_no_get_capabilities():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = ogr.Open("WFS:/vsimem/wfs_endpoint")
     assert ds is None
 
@@ -1217,7 +1217,7 @@ def test_ogr_wfs_vsimem_wfs110_minimal_instance():
         assert ds.GetMetadata() == {"TITLE": "LDS Testing"}
         assert len(ds.GetMetadata_List("xml:capabilities")) == 1
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ds = ogr.Open("WFS:/vsimem/wfs_endpoint", update=1)
         assert ds is None
 
@@ -1259,7 +1259,7 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_missing_describefeaturetype(
 
     # Missing DescribeFeatureType
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         lyr_defn = lyr.GetLayerDefn()
     assert gdal.GetLastErrorMsg() != ""
     assert lyr_defn.GetFieldCount() == 0
@@ -1283,7 +1283,7 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_invalid_describefeaturetype(
 """,
     ):
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             lyr_defn = lyr.GetLayerDefn()
         assert gdal.GetLastErrorMsg() != ""
         assert lyr_defn.GetFieldCount() == 0
@@ -1305,7 +1305,7 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_describefeaturetype_missing_schema(
 """,
     ):
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             lyr_defn = lyr.GetLayerDefn()
         assert gdal.GetLastErrorMsg() != ""
         assert lyr_defn.GetFieldCount() == 0
@@ -1509,7 +1509,7 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_missing_getfeaturecount_no_hits(
     lyr = ds.GetLayer(0)
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         count = lyr.GetFeatureCount()
     assert gdal.GetLastErrorMsg() != ""
     assert count == 0
@@ -1558,7 +1558,7 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_missing_getfeaturecount_with_hits(
     lyr = ds.GetLayer(0)
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         count = lyr.GetFeatureCount()
     assert gdal.GetLastErrorMsg() != ""
     assert count == 0
@@ -1579,7 +1579,7 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_invalid_getfeaturecount_with_hits(
         """<invalid_xml""",
     ):
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             count = lyr.GetFeatureCount()
         assert gdal.GetLastErrorMsg() != ""
         assert count == 0
@@ -1600,7 +1600,7 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_getfeaturecount_with_hits_missing_Featu
         """<dummy_xml/>""",
     ):
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             count = lyr.GetFeatureCount()
         assert gdal.GetLastErrorMsg() != ""
         assert count == 0
@@ -1621,7 +1621,7 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_getfeaturecount_with_hits_invalid_xml(
         """<invalid_xml""",
     ):
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             count = lyr.GetFeatureCount()
         assert gdal.GetLastErrorMsg() != ""
         assert count == 0
@@ -1642,7 +1642,7 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_getfeaturecount_with_hits_ServiceExcept
         """<ServiceExceptionReport/>""",
     ):
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             count = lyr.GetFeatureCount()
         assert gdal.GetLastErrorMsg() != ""
         assert count == 0
@@ -1661,7 +1661,7 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_getfeaturecount_with_hits_missing_numbe
         """<FeatureCollection/>""",
     ):
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             count = lyr.GetFeatureCount()
         assert gdal.GetLastErrorMsg() != ""
         assert count == 0
@@ -1708,7 +1708,7 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_missing_getfeature(
     lyr = ds.GetLayer(0)
 
     gdal.ErrorReset()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         f = lyr.GetNextFeature()
     assert gdal.GetLastErrorMsg() != ""
     assert f is None
@@ -1732,7 +1732,7 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_invalid_getfeature(
 """,
     ):
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = lyr.GetNextFeature()
         assert gdal.GetLastErrorMsg() != ""
         assert f is None
@@ -1756,7 +1756,7 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_exception_getfeature(
 """,
     ):
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = lyr.GetNextFeature()
         assert gdal.GetLastErrorMsg().find("Error returned by server") >= 0
         assert f is None
@@ -1938,7 +1938,7 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_getextent_without_getfeature(
 
     ds = ogr.Open("WFS:/vsimem/wfs_endpoint")
     lyr = ds.GetLayer(0)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         extent = lyr.GetExtent()
     assert gdal.GetLastErrorMsg() != ""
     assert extent == (0, 0, 0, 0)
@@ -2009,7 +2009,7 @@ def test_ogr_wfs_vsimem_wfs110_one_layer_getextent_optimized(
         assert lyr.GetExtent() == (-180.0, 180.0, -90.0, 90.0)
 
         lyr = ds.GetLayer(1)
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             got_extent = lyr.GetExtent()
         assert got_extent == (0.0, 0.0, 0.0, 0.0)
 
@@ -2173,7 +2173,7 @@ xsi:schemaLocation="http://foo /vsimem/wfs_endpoint?SERVICE=WFS&amp;VERSION=1.1.
         lyr.SetAttributeFilter("gml_id = 'my_layer.1'")
 
         gdal.ErrorReset()
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             f = lyr.GetNextFeature()
         assert gdal.GetLastErrorMsg() != ""
         assert f is None
@@ -2327,7 +2327,7 @@ xsi:schemaLocation="http://foo /vsimem/wfs_endpoint?SERVICE=WFS&amp;VERSION=1.1.
 """
 
     # Invalid syntax
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetAttributeFilter("ST_Intersects(shape)")
     assert not (
         ret == 0
@@ -2335,7 +2335,7 @@ xsi:schemaLocation="http://foo /vsimem/wfs_endpoint?SERVICE=WFS&amp;VERSION=1.1.
         < 0
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetAttributeFilter("ST_Intersects(shape, 5)")
     assert not (
         ret == 0
@@ -2345,7 +2345,7 @@ xsi:schemaLocation="http://foo /vsimem/wfs_endpoint?SERVICE=WFS&amp;VERSION=1.1.
         < 0
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetAttributeFilter("ST_Intersects(shape, ST_MakeEnvelope(1))")
     assert not (
         ret == 0
@@ -2353,7 +2353,7 @@ xsi:schemaLocation="http://foo /vsimem/wfs_endpoint?SERVICE=WFS&amp;VERSION=1.1.
         < 0
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetAttributeFilter("ST_Intersects(shape, ST_MakeEnvelope(1,1,1,'a'))")
     assert not (
         ret == 0
@@ -2363,7 +2363,7 @@ xsi:schemaLocation="http://foo /vsimem/wfs_endpoint?SERVICE=WFS&amp;VERSION=1.1.
         < 0
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetAttributeFilter(
             "ST_Intersects(shape, ST_MakeEnvelope(1,1,1,1,3.5))"
         )
@@ -2375,7 +2375,7 @@ xsi:schemaLocation="http://foo /vsimem/wfs_endpoint?SERVICE=WFS&amp;VERSION=1.1.
         < 0
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetAttributeFilter(
             "ST_Intersects(shape, ST_MakeEnvelope(1,1,1,1,'not_a_srs'))"
         )
@@ -2385,7 +2385,7 @@ xsi:schemaLocation="http://foo /vsimem/wfs_endpoint?SERVICE=WFS&amp;VERSION=1.1.
         < 0
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetAttributeFilter(
             "ST_Intersects(shape, ST_MakeEnvelope(1,1,1,1,-5))"
         )
@@ -2395,7 +2395,7 @@ xsi:schemaLocation="http://foo /vsimem/wfs_endpoint?SERVICE=WFS&amp;VERSION=1.1.
         < 0
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetAttributeFilter("ST_Intersects(shape, ST_GeomFromText(1,2,3))")
     assert not (
         ret == 0
@@ -2403,7 +2403,7 @@ xsi:schemaLocation="http://foo /vsimem/wfs_endpoint?SERVICE=WFS&amp;VERSION=1.1.
         < 0
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetAttributeFilter("ST_Intersects(shape, ST_GeomFromText(1))")
     assert not (
         ret == 0
@@ -2413,7 +2413,7 @@ xsi:schemaLocation="http://foo /vsimem/wfs_endpoint?SERVICE=WFS&amp;VERSION=1.1.
         < 0
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetAttributeFilter(
             "ST_Intersects(shape, ST_GeomFromText('INVALID_GEOM'))"
         )
@@ -2423,7 +2423,7 @@ xsi:schemaLocation="http://foo /vsimem/wfs_endpoint?SERVICE=WFS&amp;VERSION=1.1.
         < 0
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetAttributeFilter(
             "ST_Intersects(shape, ST_GeomFromText('POINT(0 0)', 'invalid_srs'))"
         )
@@ -2433,14 +2433,14 @@ xsi:schemaLocation="http://foo /vsimem/wfs_endpoint?SERVICE=WFS&amp;VERSION=1.1.
         < 0
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetAttributeFilter("ST_DWithin(shape)")
     assert not (
         ret == 0
         or gdal.GetLastErrorMsg().find("Wrong number of arguments for ST_DWithin") < 0
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetAttributeFilter("ST_DWithin(shape,'a',5)")
     assert not (
         ret == 0
@@ -2448,7 +2448,7 @@ xsi:schemaLocation="http://foo /vsimem/wfs_endpoint?SERVICE=WFS&amp;VERSION=1.1.
         < 0
     )
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetAttributeFilter("ST_DWithin(shape,shape,'a')")
     assert not (
         ret == 0
@@ -2718,7 +2718,7 @@ def test_ogr_wfs_vsimem_wfs110_insertfeature(
     lyr = ds.GetLayer(0)
 
     f = ogr.Feature(lyr.GetLayerDefn())
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(f)
     assert ret != 0
 
@@ -2737,19 +2737,19 @@ def test_ogr_wfs_vsimem_wfs110_insertfeature(
 """
     with gdaltest.tempfile(wfs_insert_url, ""):
         f = ogr.Feature(lyr.GetLayerDefn())
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = lyr.CreateFeature(f)
         assert ret != 0
 
     with gdaltest.tempfile(wfs_insert_url, "<invalid_xml"):
         f = ogr.Feature(lyr.GetLayerDefn())
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = lyr.CreateFeature(f)
         assert ret != 0
 
     with gdaltest.tempfile(wfs_insert_url, "<ServiceExceptionReport/>"):
         f = ogr.Feature(lyr.GetLayerDefn())
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = lyr.CreateFeature(f)
         assert not (
             ret == 0 or gdal.GetLastErrorMsg().find("Error returned by server") < 0
@@ -2757,7 +2757,7 @@ def test_ogr_wfs_vsimem_wfs110_insertfeature(
 
     with gdaltest.tempfile(wfs_insert_url, "<dummy_xml/>"):
         f = ogr.Feature(lyr.GetLayerDefn())
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = lyr.CreateFeature(f)
         assert not (
             ret == 0
@@ -2771,7 +2771,7 @@ def test_ogr_wfs_vsimem_wfs110_insertfeature(
 """,
     ):
         f = ogr.Feature(lyr.GetLayerDefn())
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = lyr.CreateFeature(f)
         assert ret != 0
 
@@ -2787,7 +2787,7 @@ def test_ogr_wfs_vsimem_wfs110_insertfeature(
 """,
     ):
         f = ogr.Feature(lyr.GetLayerDefn())
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = lyr.CreateFeature(f)
         assert ret != 0
 
@@ -2802,7 +2802,7 @@ def test_ogr_wfs_vsimem_wfs110_insertfeature(
 </TransactionResponse>
 """,
     ):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             sql_lyr = ds.ExecuteSQL(
                 "SELECT _LAST_INSERTED_FIDS_ FROM not_existing_layer"
             )
@@ -2818,7 +2818,7 @@ def test_ogr_wfs_vsimem_wfs110_insertfeature(
         assert got_f is None
         ds.ReleaseResultSet(sql_lyr)
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = lyr.CreateFeature(f)
         assert not (
             ret == 0
@@ -2841,19 +2841,19 @@ def test_ogr_wfs_vsimem_wfs110_insertfeature(
         assert ret == 0
 
         # Isolated CommitTransaction
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = lyr.CommitTransaction()
         assert ret != 0
 
         # Isolated RollbackTransaction
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = lyr.RollbackTransaction()
         assert ret != 0
 
         # 2 StartTransaction in a row
         ret = lyr.StartTransaction()
         assert ret == 0
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = lyr.StartTransaction()
         assert ret != 0
         ret = lyr.RollbackTransaction()
@@ -2865,7 +2865,7 @@ def test_ogr_wfs_vsimem_wfs110_insertfeature(
         f = ogr.Feature(lyr.GetLayerDefn())
         ret = lyr.CreateFeature(f)
         assert ret == 0
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = lyr.CommitTransaction()
         assert not (
             ret == 0
@@ -2882,7 +2882,7 @@ def test_ogr_wfs_vsimem_wfs110_insertfeature(
         assert ret == 0
 
     with gdaltest.tempfile(wfs_insert_url, "<invalid_xml"):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = lyr.CommitTransaction()
         assert not (ret == 0 or gdal.GetLastErrorMsg().find("Invalid XML content") < 0)
 
@@ -2893,7 +2893,7 @@ def test_ogr_wfs_vsimem_wfs110_insertfeature(
         assert ret == 0
 
     with gdaltest.tempfile(wfs_insert_url, "<dummy_xml/>"):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = lyr.CommitTransaction()
         assert not (
             ret == 0
@@ -2907,7 +2907,7 @@ def test_ogr_wfs_vsimem_wfs110_insertfeature(
         assert ret == 0
 
     with gdaltest.tempfile(wfs_insert_url, "<ServiceExceptionReport/>"):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = lyr.CommitTransaction()
         assert not (
             ret == 0 or gdal.GetLastErrorMsg().find("Error returned by server") < 0
@@ -2926,7 +2926,7 @@ def test_ogr_wfs_vsimem_wfs110_insertfeature(
 </TransactionResponse>
 """,
     ):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = lyr.CommitTransaction()
         assert not (
             ret == 0
@@ -2947,7 +2947,7 @@ def test_ogr_wfs_vsimem_wfs110_insertfeature(
 </TransactionResponse>
 """,
     ):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = lyr.CommitTransaction()
         assert not (
             ret == 0
@@ -2974,7 +2974,7 @@ def test_ogr_wfs_vsimem_wfs110_insertfeature(
 </TransactionResponse>
 """,
     ):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = lyr.CommitTransaction()
         assert not (ret == 0 or gdal.GetLastErrorMsg().find("Cannot find fid") < 0)
 
@@ -3060,12 +3060,12 @@ def test_ogr_wfs_vsimem_wfs110_updatefeature(
     lyr = ds.GetLayer(0)
 
     f = ogr.Feature(lyr.GetLayerDefn())
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.CreateFeature(f)
     assert ret != 0
 
     f = ogr.Feature(lyr.GetLayerDefn())
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetFeature(f)
     assert not (
         ret == 0
@@ -3077,7 +3077,7 @@ def test_ogr_wfs_vsimem_wfs110_updatefeature(
 
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetField("gml_id", "my_layer.1")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.SetFeature(f)
     assert ret != 0, gdal.GetLastErrorMsg()
 
@@ -3123,7 +3123,7 @@ def test_ogr_wfs_vsimem_wfs110_updatefeature(
     with gdaltest.tempfile(wfs_update_url, ""):
         f = ogr.Feature(lyr.GetLayerDefn())
         f.SetField("gml_id", "my_layer.1")
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = lyr.SetFeature(f)
         assert not (
             ret == 0
@@ -3133,14 +3133,14 @@ def test_ogr_wfs_vsimem_wfs110_updatefeature(
     with gdaltest.tempfile(wfs_update_url, "<invalid_xmm"):
         f = ogr.Feature(lyr.GetLayerDefn())
         f.SetField("gml_id", "my_layer.1")
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = lyr.SetFeature(f)
         assert not (ret == 0 or gdal.GetLastErrorMsg().find("Invalid XML content") < 0)
 
     with gdaltest.tempfile(wfs_update_url, "<ServiceExceptionReport/>"):
         f = ogr.Feature(lyr.GetLayerDefn())
         f.SetField("gml_id", "my_layer.1")
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = lyr.SetFeature(f)
         assert not (
             ret == 0 or gdal.GetLastErrorMsg().find("Error returned by server") < 0
@@ -3149,7 +3149,7 @@ def test_ogr_wfs_vsimem_wfs110_updatefeature(
     with gdaltest.tempfile(wfs_update_url, "<foo/>"):
         f = ogr.Feature(lyr.GetLayerDefn())
         f.SetField("gml_id", "my_layer.1")
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = lyr.SetFeature(f)
         assert not (
             ret == 0
@@ -3229,7 +3229,7 @@ def test_ogr_wfs_vsimem_wfs110_deletefeature(
     ds = ogr.Open("WFS:/vsimem/wfs_endpoint", update=1)
     lyr = ds.GetLayer(0)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = lyr.DeleteFeature(200)
     assert ret != 0, gdal.GetLastErrorMsg()
 
@@ -3257,7 +3257,7 @@ xsi:schemaLocation="http://foo /vsimem/wfs_endpoint?SERVICE=WFS&amp;VERSION=1.1.
         ds = ogr.Open("WFS:/vsimem/wfs_endpoint", update=1)
         lyr = ds.GetLayer(0)
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = lyr.DeleteFeature(200)
         assert ret != 0, gdal.GetLastErrorMsg()
 
@@ -3280,7 +3280,7 @@ xsi:schemaLocation="http://foo /vsimem/wfs_endpoint?SERVICE=WFS&amp;VERSION=1.1.
 """
 
         with gdaltest.tempfile(wfs_delete_url, ""):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ret = lyr.DeleteFeature(200)
             assert (
                 ret != 0
@@ -3290,7 +3290,7 @@ xsi:schemaLocation="http://foo /vsimem/wfs_endpoint?SERVICE=WFS&amp;VERSION=1.1.
         ds = ogr.Open("WFS:/vsimem/wfs_endpoint", update=1)
         lyr = ds.GetLayer(0)
         with gdaltest.tempfile(wfs_delete_url, "<invalid_xml>"):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ret = lyr.DeleteFeature(200)
             gdal.PopErrorHandler()
             assert not (
@@ -3300,7 +3300,7 @@ xsi:schemaLocation="http://foo /vsimem/wfs_endpoint?SERVICE=WFS&amp;VERSION=1.1.
         ds = ogr.Open("WFS:/vsimem/wfs_endpoint", update=1)
         lyr = ds.GetLayer(0)
         with gdaltest.tempfile(wfs_delete_url, "<foo/>"):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 ret = lyr.DeleteFeature(200)
             assert not (
                 ret == 0
@@ -3335,27 +3335,27 @@ xsi:schemaLocation="http://foo /vsimem/wfs_endpoint?SERVICE=WFS&amp;VERSION=1.1.
             assert gdal.GetLastErrorMsg() == ""
 
             gdal.ErrorReset()
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 sql_lyr = ds.ExecuteSQL("DELETE FROM ")
             assert gdal.GetLastErrorMsg() != ""
 
             gdal.ErrorReset()
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 sql_lyr = ds.ExecuteSQL("DELETE FROM non_existing_layer WHERE truc")
             assert gdal.GetLastErrorMsg().find("Unknown layer") >= 0
 
             gdal.ErrorReset()
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 sql_lyr = ds.ExecuteSQL("DELETE FROM my_layer BLA")
             assert gdal.GetLastErrorMsg().find("WHERE clause missing") >= 0
 
             gdal.ErrorReset()
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 sql_lyr = ds.ExecuteSQL("DELETE FROM my_layer WHERE -")
             assert gdal.GetLastErrorMsg().find("SQL Expression Parsing Error") >= 0
 
             gdal.ErrorReset()
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 sql_lyr = ds.ExecuteSQL(
                     "DELETE FROM my_layer WHERE ogr_geometry = 'POINT'"
                 )
@@ -3406,7 +3406,7 @@ def test_ogr_wfs_vsimem_wfs110_schema_not_understood(with_and_without_streaming)
         ds = ogr.Open("WFS:/vsimem/wfs_endpoint_schema_not_understood")
         lyr = ds.GetLayer(0)
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             lyr_defn = lyr.GetLayerDefn()
         assert lyr_defn.GetFieldCount() == 0
 
@@ -3501,7 +3501,7 @@ def test_ogr_wfs_vsimem_wfs110_multiple_layers(with_and_without_streaming):
     ):
         ds = ogr.Open("WFS:/vsimem/wfs110_multiple_layers")
         lyr = ds.GetLayer(0)
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             lyr_defn = lyr.GetLayerDefn()
         assert lyr_defn.GetFieldCount() == 0
 
@@ -3512,7 +3512,7 @@ def test_ogr_wfs_vsimem_wfs110_multiple_layers(with_and_without_streaming):
             "<ServiceExceptionReport/>",
         ):
             lyr = ds.GetLayer(0)
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 lyr_defn = lyr.GetLayerDefn()
             assert lyr_defn.GetFieldCount() == 0
 
@@ -3523,7 +3523,7 @@ def test_ogr_wfs_vsimem_wfs110_multiple_layers(with_and_without_streaming):
             "<invalid_xml",
         ):
             lyr = ds.GetLayer(0)
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 lyr_defn = lyr.GetLayerDefn()
             assert lyr_defn.GetFieldCount() == 0
 
@@ -3534,7 +3534,7 @@ def test_ogr_wfs_vsimem_wfs110_multiple_layers(with_and_without_streaming):
             "<no_schema/>",
         ):
             lyr = ds.GetLayer(0)
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 lyr_defn = lyr.GetLayerDefn()
             assert lyr_defn.GetFieldCount() == 0
 
@@ -4357,7 +4357,7 @@ def test_ogr_wfs_vsimem_wfs200_join(with_and_without_streaming):
         with ds.ExecuteSQL(
             "SELECT * FROM lyr1 JOIN lyr2 ON lyr1.str = lyr2.str2"
         ) as sql_lyr:
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 f = sql_lyr.GetNextFeature()
             assert f is None
 
@@ -4368,7 +4368,7 @@ def test_ogr_wfs_vsimem_wfs200_join(with_and_without_streaming):
             "/vsimem/wfs200_endpoint_join?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=%28lyr1,lyr2%29&STARTINDEX=0&COUNT=1&FILTER=%3CFilter%20xmlns%3D%22http:%2F%2Fwww.opengis.net%2Ffes%2F2.0%22%20xmlns:gml%3D%22http:%2F%2Fwww.opengis.net%2Fgml%2F3.2%22%3E%3CPropertyIsEqualTo%3E%3CValueReference%3Elyr1%2Fstr%3C%2FValueReference%3E%3CValueReference%3Elyr2%2Fstr2%3C%2FValueReference%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E",
             """""",
         ):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 f = sql_lyr.GetNextFeature()
             assert (
                 f is None
@@ -4382,7 +4382,7 @@ def test_ogr_wfs_vsimem_wfs200_join(with_and_without_streaming):
             "/vsimem/wfs200_endpoint_join?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=%28lyr1,lyr2%29&STARTINDEX=0&COUNT=1&FILTER=%3CFilter%20xmlns%3D%22http:%2F%2Fwww.opengis.net%2Ffes%2F2.0%22%20xmlns:gml%3D%22http:%2F%2Fwww.opengis.net%2Fgml%2F3.2%22%3E%3CPropertyIsEqualTo%3E%3CValueReference%3Elyr1%2Fstr%3C%2FValueReference%3E%3CValueReference%3Elyr2%2Fstr2%3C%2FValueReference%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E",
             """<ServiceExceptionReport/>""",
         ):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 f = sql_lyr.GetNextFeature()
             assert (
                 f is None
@@ -4396,7 +4396,7 @@ def test_ogr_wfs_vsimem_wfs200_join(with_and_without_streaming):
             "/vsimem/wfs200_endpoint_join?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=%28lyr1,lyr2%29&STARTINDEX=0&COUNT=1&FILTER=%3CFilter%20xmlns%3D%22http:%2F%2Fwww.opengis.net%2Ffes%2F2.0%22%20xmlns:gml%3D%22http:%2F%2Fwww.opengis.net%2Fgml%2F3.2%22%3E%3CPropertyIsEqualTo%3E%3CValueReference%3Elyr1%2Fstr%3C%2FValueReference%3E%3CValueReference%3Elyr2%2Fstr2%3C%2FValueReference%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E",
             """<invalid_xml""",
         ):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 f = sql_lyr.GetNextFeature()
             assert f is None and gdal.GetLastErrorMsg().find("Error: cannot parse") >= 0
 
@@ -4407,7 +4407,7 @@ def test_ogr_wfs_vsimem_wfs200_join(with_and_without_streaming):
             "/vsimem/wfs200_endpoint_join?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=%28lyr1,lyr2%29&STARTINDEX=0&COUNT=1&FILTER=%3CFilter%20xmlns%3D%22http:%2F%2Fwww.opengis.net%2Ffes%2F2.0%22%20xmlns:gml%3D%22http:%2F%2Fwww.opengis.net%2Fgml%2F3.2%22%3E%3CPropertyIsEqualTo%3E%3CValueReference%3Elyr1%2Fstr%3C%2FValueReference%3E%3CValueReference%3Elyr2%2Fstr2%3C%2FValueReference%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E",
             """<dummy_xml/>""",
         ):
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 f = sql_lyr.GetNextFeature()
             assert f is None and gdal.GetLastErrorMsg().find("Error: cannot parse") >= 0
 
@@ -4525,7 +4525,7 @@ def test_ogr_wfs_vsimem_wfs200_join(with_and_without_streaming):
                     f.DumpReadable()
                     pytest.fail()
 
-                with gdaltest.error_handler():
+                with gdal.quiet_errors():
                     fc = sql_lyr.GetFeatureCount()
                 assert fc == 2, gdal.GetLastErrorMsg()
 
@@ -4534,7 +4534,7 @@ def test_ogr_wfs_vsimem_wfs200_join(with_and_without_streaming):
                     "/vsimem/wfs200_endpoint_join?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=%28lyr1,lyr2%29&FILTER=%3CFilter%20xmlns%3D%22http:%2F%2Fwww.opengis.net%2Ffes%2F2.0%22%20xmlns:gml%3D%22http:%2F%2Fwww.opengis.net%2Fgml%2F3.2%22%3E%3CPropertyIsEqualTo%3E%3CValueReference%3Elyr1%2Fstr%3C%2FValueReference%3E%3CValueReference%3Elyr2%2Fstr2%3C%2FValueReference%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E&RESULTTYPE=hits",
                     """""",
                 ):
-                    with gdaltest.error_handler():
+                    with gdal.quiet_errors():
                         fc = sql_lyr.GetFeatureCount()
                     assert fc == 2, gdal.GetLastErrorMsg()
 
@@ -4543,7 +4543,7 @@ def test_ogr_wfs_vsimem_wfs200_join(with_and_without_streaming):
                     "/vsimem/wfs200_endpoint_join?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=%28lyr1,lyr2%29&FILTER=%3CFilter%20xmlns%3D%22http:%2F%2Fwww.opengis.net%2Ffes%2F2.0%22%20xmlns:gml%3D%22http:%2F%2Fwww.opengis.net%2Fgml%2F3.2%22%3E%3CPropertyIsEqualTo%3E%3CValueReference%3Elyr1%2Fstr%3C%2FValueReference%3E%3CValueReference%3Elyr2%2Fstr2%3C%2FValueReference%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E&RESULTTYPE=hits",
                     """<invalid_xml""",
                 ):
-                    with gdaltest.error_handler():
+                    with gdal.quiet_errors():
                         fc = sql_lyr.GetFeatureCount()
                     assert fc == 2, gdal.GetLastErrorMsg()
 
@@ -4552,7 +4552,7 @@ def test_ogr_wfs_vsimem_wfs200_join(with_and_without_streaming):
                     "/vsimem/wfs200_endpoint_join?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=%28lyr1,lyr2%29&FILTER=%3CFilter%20xmlns%3D%22http:%2F%2Fwww.opengis.net%2Ffes%2F2.0%22%20xmlns:gml%3D%22http:%2F%2Fwww.opengis.net%2Fgml%2F3.2%22%3E%3CPropertyIsEqualTo%3E%3CValueReference%3Elyr1%2Fstr%3C%2FValueReference%3E%3CValueReference%3Elyr2%2Fstr2%3C%2FValueReference%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E&RESULTTYPE=hits",
                     """<ServiceExceptionReport/>""",
                 ):
-                    with gdaltest.error_handler():
+                    with gdal.quiet_errors():
                         fc = sql_lyr.GetFeatureCount()
                     assert fc == 2, gdal.GetLastErrorMsg()
 
@@ -4561,7 +4561,7 @@ def test_ogr_wfs_vsimem_wfs200_join(with_and_without_streaming):
                     "/vsimem/wfs200_endpoint_join?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=%28lyr1,lyr2%29&FILTER=%3CFilter%20xmlns%3D%22http:%2F%2Fwww.opengis.net%2Ffes%2F2.0%22%20xmlns:gml%3D%22http:%2F%2Fwww.opengis.net%2Fgml%2F3.2%22%3E%3CPropertyIsEqualTo%3E%3CValueReference%3Elyr1%2Fstr%3C%2FValueReference%3E%3CValueReference%3Elyr2%2Fstr2%3C%2FValueReference%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E&RESULTTYPE=hits",
                     """<dummy_xml/>""",
                 ):
-                    with gdaltest.error_handler():
+                    with gdal.quiet_errors():
                         fc = sql_lyr.GetFeatureCount()
                     assert fc == 2, gdal.GetLastErrorMsg()
 
@@ -4570,7 +4570,7 @@ def test_ogr_wfs_vsimem_wfs200_join(with_and_without_streaming):
                     "/vsimem/wfs200_endpoint_join?SERVICE=WFS&VERSION=2.0.0&REQUEST=GetFeature&TYPENAMES=%28lyr1,lyr2%29&FILTER=%3CFilter%20xmlns%3D%22http:%2F%2Fwww.opengis.net%2Ffes%2F2.0%22%20xmlns:gml%3D%22http:%2F%2Fwww.opengis.net%2Fgml%2F3.2%22%3E%3CPropertyIsEqualTo%3E%3CValueReference%3Elyr1%2Fstr%3C%2FValueReference%3E%3CValueReference%3Elyr2%2Fstr2%3C%2FValueReference%3E%3C%2FPropertyIsEqualTo%3E%3C%2FFilter%3E&RESULTTYPE=hits",
                     """<FeatureCollection/>""",
                 ):
-                    with gdaltest.error_handler():
+                    with gdal.quiet_errors():
                         fc = sql_lyr.GetFeatureCount()
                     assert fc == 2, gdal.GetLastErrorMsg()
 
@@ -4591,7 +4591,7 @@ def test_ogr_wfs_vsimem_wfs200_join(with_and_without_streaming):
                         http://www.opengis.net/wfs/2.0 http://schemas.opengis.net/wfs/2.0/wfs.xsd">
     </wfs:FeatureCollection>""",
                 ):
-                    with gdaltest.error_handler():
+                    with gdal.quiet_errors():
                         fc = sql_lyr.GetFeatureCount()
                     assert fc == 3, gdal.GetLastErrorMsg()
 
@@ -4600,11 +4600,11 @@ def test_ogr_wfs_vsimem_wfs200_join(with_and_without_streaming):
 
                     # Test filters (nt supported)
                     sql_lyr.SetAttributeFilter(None)
-                    with gdaltest.error_handler():
+                    with gdal.quiet_errors():
                         sql_lyr.SetAttributeFilter('"lyr1.gml_id" IS NOT NULL')
 
                     sql_lyr.SetSpatialFilter(None)
-                    with gdaltest.error_handler():
+                    with gdal.quiet_errors():
                         sql_lyr.SetSpatialFilterRect(0, 0, 0, 0)
 
             ds = ogr.Open("WFS:/vsimem/wfs200_endpoint_join")
@@ -4728,7 +4728,7 @@ def test_ogr_wfs_vsimem_wfs200_join(with_and_without_streaming):
                     f.DumpReadable()
                     pytest.fail()
 
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 sql_lyr = ds.ExecuteSQL(
                     "SELECT * FROM lyr1 JOIN lyr2 ON lyr1.str = lyr2.str2 WHERE lyr1.OGR_GEOMETRY IS NOT NULL"
                 )
@@ -4737,7 +4737,7 @@ def test_ogr_wfs_vsimem_wfs200_join(with_and_without_streaming):
                 and gdal.GetLastErrorMsg().find("Unsupported WHERE clause") >= 0
             )
 
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 sql_lyr = ds.ExecuteSQL(
                     "SELECT * FROM lyr1 JOIN lyr2 ON lyr1.OGR_GEOMETRY IS NOT NULL"
                 )
@@ -4746,7 +4746,7 @@ def test_ogr_wfs_vsimem_wfs200_join(with_and_without_streaming):
                 and gdal.GetLastErrorMsg().find("Unsupported JOIN clause") >= 0
             )
 
-            with gdaltest.error_handler():
+            with gdal.quiet_errors():
                 sql_lyr = ds.ExecuteSQL(
                     "SELECT 1 FROM lyr1 JOIN lyr2 ON lyr1.str = lyr2.str2"
                 )

--- a/autotest/ogr/ogr_wkbwkt_geom.py
+++ b/autotest/ogr/ogr_wkbwkt_geom.py
@@ -32,7 +32,7 @@ import os
 import gdaltest
 import pytest
 
-from osgeo import ogr
+from osgeo import gdal, ogr
 
 
 ###############################################################################
@@ -363,7 +363,7 @@ def test_ogr_wkbwkt_test_broken_geom():
         "CURVEPOLYGON Z((0 1,2 3)",
     ]
     for wkt in list_broken:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             geom = ogr.CreateGeometryFromWkt(wkt)
         assert geom is None, "geom %s instantiated but not expected" % wkt
 
@@ -610,7 +610,7 @@ def test_ogr_wkbwkt_test_import_bad_multipoint_wkb():
         0,
         0,
     )
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         geom = ogr.CreateGeometryFromWkb(wkb)
     assert geom is None
 
@@ -656,7 +656,7 @@ def test_ogr_wkbwkt_test_geometrycollection_wkt_recursion():
 
     wkt = "GEOMETRYCOLLECTION (" * 32 + "GEOMETRYCOLLECTION EMPTY" + ")" * 32
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         geom = ogr.CreateGeometryFromWkt(wkt)
     assert geom is None, "expected None"
 
@@ -679,7 +679,7 @@ def test_ogr_wkbwkt_test_geometrycollection_wkb_recursion():
 
     wkb = struct.pack("B" * 0) + wkb_repeat * 32 + wkb_end
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         geom = ogr.CreateGeometryFromWkb(wkb)
     assert geom is None, "expected None"
 
@@ -714,7 +714,7 @@ def test_ogr_wkt_inf_nan():
 
 def test_ogr_wkt_multicurve_compoundcurve_corrupted():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         g = ogr.CreateGeometryFromWkt("MULTICURVE(COMPOUNDCURVE")
     assert g is None
 
@@ -725,7 +725,7 @@ def test_ogr_wkt_multicurve_compoundcurve_corrupted():
 
 def test_ogr_wkt_multipolygon_corrupted():
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         g = ogr.CreateGeometryFromWkt("MULTIPOLYGON(POLYGON((N")
     assert g is None
 

--- a/autotest/osr/osr_ct.py
+++ b/autotest/osr/osr_ct.py
@@ -52,7 +52,7 @@ def test_osr_ct_1():
     ll_srs.SetWellKnownGeogCS("WGS84")
 
     try:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ct = osr.CoordinateTransformation(ll_srs, utm_srs)
         if gdal.GetLastErrorMsg().find("Unable to load PROJ.4") != -1:
             pytest.skip("PROJ.4 missing, transforms not available.")
@@ -559,7 +559,7 @@ def test_osr_ct_options_accuracy():
     t.SetFromUserInput("EPSG:4258")  # ETRS89
     options = osr.CoordinateTransformationOptions()
     options.SetDesiredAccuracy(0.05)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         with osr.ExceptionMgr(useExceptions=False):
             ct = osr.CoordinateTransformation(s, t, options)
     with pytest.raises(Exception):
@@ -578,7 +578,7 @@ def test_osr_ct_options_ballpark_disallowed():
     t.SetFromUserInput("EPSG:4258")  # ETRS89
     options = osr.CoordinateTransformationOptions()
     options.SetBallparkAllowed(False)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         with osr.ExceptionMgr(useExceptions=False):
             ct = osr.CoordinateTransformation(s, t, options)
     with pytest.raises(Exception):
@@ -669,7 +669,7 @@ def test_osr_ct_take_into_account_srs_coordinate_epoch():
     assert y == pytest.approx(150, abs=1e-10)
 
     # Not properly supported currently
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         osr.CoordinateTransformation(t_2020, t_2030)
 
 

--- a/autotest/osr/osr_epsg.py
+++ b/autotest/osr/osr_epsg.py
@@ -43,7 +43,7 @@ from osgeo import gdal, osr
 def test_osr_epsg_1():
 
     srs = osr.SpatialReference()
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         srs.ImportFromEPSG(26591)
         assert "OSR_USE_NON_DEPRECATED" in gdal.GetLastErrorMsg()
     assert srs.GetAuthorityCode(None) == "3003"

--- a/autotest/osr/osr_url.py
+++ b/autotest/osr/osr_url.py
@@ -49,7 +49,7 @@ def osr_url_test(url, expected_wkt):
     srs = osr.SpatialReference()
     from osgeo import gdal
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         try:
             srs.ImportFromUrl(url)
         except AttributeError:  # old-gen bindings don't have this method yet

--- a/autotest/pyscripts/test_validate_geoparquet.py
+++ b/autotest/pyscripts/test_validate_geoparquet.py
@@ -36,7 +36,7 @@ import gdaltest
 import pytest
 import test_py_scripts
 
-from osgeo import ogr
+from osgeo import gdal, ogr
 
 CURRENT_VERSION = "1.0.0-beta.1"
 PARQUET_JSON_SCHEMA = "../ogr/data/parquet/schema.json"
@@ -133,7 +133,7 @@ def test_validate_geoparquet_invalid_json():
         ds = None
 
     try:
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             ret = _validate("tmp/tmp.parquet")
         assert ret and """'geo' metadata item is not valid JSON""" in str(ret)
     finally:

--- a/autotest/utilities/test_gdal_rasterize_lib.py
+++ b/autotest/utilities/test_gdal_rasterize_lib.py
@@ -432,7 +432,7 @@ def test_gdal_rasterize_lib_inverse():
     target_ds.SetGeoTransform((-0.5, 1, 0, 10.5, 0, -1))
     target_ds.SetSpatialRef(sr)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ret = gdal.Rasterize(target_ds, vector_ds, burnValues=[9], inverse=True)
     assert ret == 1
 

--- a/autotest/utilities/test_gdal_translate_lib.py
+++ b/autotest/utilities/test_gdal_translate_lib.py
@@ -568,7 +568,7 @@ def test_gdal_translate_lib_colorinterp():
     assert ds.GetRasterBand(3).GetColorInterpretation() == gdal.GCI_BlueBand
 
     # More bands specified than available and a unknown color interpretation
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Translate(
             "", src_ds, options="-f MEM -colorinterp alpha,red,undefined,foo"
         )
@@ -584,7 +584,7 @@ def test_gdal_translate_lib_colorinterp():
 
     # Test invalid colorinterp_
     with pytest.raises(Exception):
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             gdal.Translate("", src_ds, options="-f MEM -colorinterp_0 alpha")
 
     # Test colorinterp on a source mask band
@@ -924,7 +924,7 @@ def test_gdal_translate_lib_overview_level():
         src_ds.BuildOverviews("AVERAGE", [2])
         src_ds.BuildOverviews("NONE", [4])
 
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             with pytest.raises(Exception):
                 assert gdal.Translate("", src_ds, format="MEM", overviewLevel="invalid")
 

--- a/autotest/utilities/test_gdalbuildvrt_lib.py
+++ b/autotest/utilities/test_gdalbuildvrt_lib.py
@@ -436,7 +436,7 @@ def test_gdalbuildvrt_lib_bandList():
     assert vrt_ds.GetRasterBand(2).Checksum() != 0
     assert vrt_ds.GetRasterBand(3).Checksum() == 0
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         assert gdal.BuildVRT("", [src_ds], bandList=[3]) is None
 
     src2_ds = gdal.GetDriverByName("MEM").Create("src2", 3, 1, 3)
@@ -557,7 +557,7 @@ def test_gdalbuildvrt_lib_warnings_and_custom_error_handler():
 def test_gdalbuildvrt_lib_strict_mode():
 
     with gdal.ExceptionMgr():
-        with gdaltest.error_handler():
+        with gdal.quiet_errors():
             assert (
                 gdal.BuildVRT(
                     "", ["../gcore/data/byte.tif", "i_dont_exist.tif"], strict=False

--- a/autotest/utilities/test_gdaldem_lib.py
+++ b/autotest/utilities/test_gdaldem_lib.py
@@ -514,7 +514,7 @@ def test_gdaldem_lib_color_relief_nodata_value():
     colorFilename = "/vsimem/color_file.txt"
     gdal.FileFromMemBuffer(colorFilename, """nv 255 255 255""")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.DEMProcessing(
             "", src_ds, "color-relief", format="MEM", colorFilename=colorFilename
         )

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -1217,7 +1217,7 @@ def test_gdalwarp_lib_121():
         gdal.wrapper_GDALWarpDestName("", [], None, gdal.TermProgress_nocb)
 
     # Null dest name
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         with pytest.raises(Exception):
             gdal.wrapper_GDALWarpDestName(None, [], None)
 
@@ -2043,7 +2043,7 @@ def test_gdalwarp_lib_135p(gdalwarp_135_grid_gtx):
     src_ds.GetRasterBand(1).Fill(100)
     src_ds.GetRasterBand(1).SetUnitType("unhandled")
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.Warp("", src_ds, format="MEM", dstSRS="EPSG:4979")
     data = struct.unpack("B" * 1, ds.GetRasterBand(1).ReadRaster())[0]
     assert data == 120, "Bad value"
@@ -3324,7 +3324,7 @@ def test_gdalwarp_lib_srcBands():
     assert ds.GetRasterBand(2).Checksum() == 4672
 
     # Error: len(dstBands) != len(srcBands)
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         with pytest.raises(Exception):
             assert (
                 gdal.Warp(

--- a/autotest/utilities/test_ogr2ogr_lib.py
+++ b/autotest/utilities/test_ogr2ogr_lib.py
@@ -318,7 +318,7 @@ def test_ogr2ogr_lib_14():
 def test_ogr2ogr_lib_15():
 
     srcDS = gdal.OpenEx("../ogr/data/poly.shp")
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.VectorTranslate("", srcDS, format="Memory", zField="foo")
     lyr = ds.GetLayer(0)
     assert lyr.GetGeomType() == ogr.wkbPolygon
@@ -1187,7 +1187,7 @@ def test_ogr2ogr_lib_clipsrc_invalid_polygon():
     clip_ds = None
 
     # Intersection of above geometry with clipSrc bounding box is a point
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.VectorTranslate("", srcDS, format="Memory", clipSrc=clip_path)
     lyr = ds.GetLayer(0)
     assert lyr.GetFeatureCount() == 1
@@ -1228,7 +1228,7 @@ def test_ogr2ogr_lib_clipsrc_3d_polygon():
     clip_layer.CreateFeature(f)
     clip_ds = None
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         ds = gdal.VectorTranslate("", srcDS, format="Memory", clipSrc=clip_path)
     lyr = ds.GetLayer(0)
     assert lyr.GetFeatureCount() == 2
@@ -1555,7 +1555,7 @@ def test_ogr2ogr_lib_dateTimeTo():
     f = ogr.Feature(src_lyr.GetLayerDefn())
     src_lyr.CreateFeature(f)
 
-    with gdaltest.error_handler():
+    with gdal.quiet_errors():
         with pytest.raises(Exception):
             gdal.VectorTranslate("", src_ds, options="-f Memory -dateTimeTo")
         with pytest.raises(Exception):


### PR DESCRIPTION
## What does this PR do?

Updates tests to use `gdal.quiet_errors()`, introduced in #7475 as a more readable alternative to `gdaltest.error_handler()`

## What are related issues/pull requests?

#7418

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
