### PR TITLE
Python bindings: Support os.PathLike inputs in utilities

### DIFF
--- a/autotest/utilities/test_gdal_footprint_lib.py
+++ b/autotest/utilities/test_gdal_footprint_lib.py
@@ -29,6 +29,8 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
+import pathlib
+
 import ogrtest
 import pytest
 
@@ -366,12 +368,12 @@ def test_gdal_footprint_lib_ovr_georef():
 
 
 @pytest.mark.require_driver("GPKG")
-def test_gdal_footprint_lib_dsco_lco():
+def test_gdal_footprint_lib_dsco_lco(tmp_vsimem):
 
-    out_filename = "/vsimem/out.gpkg"
+    out_filename = tmp_vsimem / "out.gpkg"
     out_ds = gdal.Footprint(
         out_filename,
-        "../gcore/data/byte.tif",
+        pathlib.Path("../gcore/data/byte.tif"),
         format="GPKG",
         datasetCreationOptions=["ADD_GPKG_OGR_CONTENTS=NO"],
         layerCreationOptions=["GEOMETRY_NAME=my_geom"],

--- a/autotest/utilities/test_gdal_rasterize_lib.py
+++ b/autotest/utilities/test_gdal_rasterize_lib.py
@@ -108,14 +108,14 @@ def test_gdal_rasterize_lib_1():
 # Test creating an output file
 
 
-def test_gdal_rasterize_lib_3(tmp_path):
+def test_gdal_rasterize_lib_3(tmp_path, tmp_vsimem):
 
     import test_cli_utilities
 
     if test_cli_utilities.get_gdal_contour_path() is None:
         pytest.skip()
 
-    dst_shp = str(tmp_path / "n43dt0.shp")
+    dst_shp = tmp_path / "n43dt0.shp"
 
     gdaltest.runexternal(
         test_cli_utilities.get_gdal_contour_path()
@@ -123,7 +123,7 @@ def test_gdal_rasterize_lib_3(tmp_path):
     )
 
     with pytest.raises(Exception):
-        gdal.Rasterize("/vsimem/bogus.tif", dst_shp)
+        gdal.Rasterize(tmp_vsimem / "bogus.tif", dst_shp)
 
     ds = gdal.Rasterize(
         "",

--- a/autotest/utilities/test_gdal_translate_lib.py
+++ b/autotest/utilities/test_gdal_translate_lib.py
@@ -44,7 +44,7 @@ from osgeo import gdal, osr
 
 def test_gdal_translate_lib_1(tmp_path):
 
-    dst_tif = str(tmp_path / "test1.tif")
+    dst_tif = tmp_path / "test1.tif"
 
     ds = gdal.Open("../gcore/data/byte.tif")
 

--- a/autotest/utilities/test_gdalbuildvrt_lib.py
+++ b/autotest/utilities/test_gdalbuildvrt_lib.py
@@ -29,6 +29,7 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
+import pathlib
 import struct
 
 import gdaltest
@@ -96,10 +97,10 @@ def test_gdalbuildvrt_lib_2():
 # Test creating overviews
 
 
-def test_gdalbuildvrt_lib_ovr():
+def test_gdalbuildvrt_lib_ovr(tmp_vsimem):
 
-    tmpfilename = "/vsimem/my.vrt"
-    ds = gdal.BuildVRT(tmpfilename, "../gcore/data/byte.tif")
+    tmpfilename = tmp_vsimem / "my.vrt"
+    ds = gdal.BuildVRT(tmpfilename, pathlib.Path("../gcore/data/byte.tif"))
     ds.BuildOverviews("NEAR", [2])
     ds = None
     ds = gdal.Open(tmpfilename)

--- a/autotest/utilities/test_gdaldem_lib.py
+++ b/autotest/utilities/test_gdaldem_lib.py
@@ -104,7 +104,7 @@ def test_gdaldem_lib_hillshade_float():
 
 
 @pytest.mark.require_driver("PNG")
-def test_gdaldem_lib_hillshade_float_png():
+def test_gdaldem_lib_hillshade_float_png(tmp_vsimem):
 
     src_ds = gdal.Translate(
         "",
@@ -113,7 +113,7 @@ def test_gdaldem_lib_hillshade_float_png():
         outputType=gdal.GDT_Float32,
     )
     ds = gdal.DEMProcessing(
-        "/vsimem/test_gdaldem_lib_hillshade_float_png.png",
+        tmp_vsimem / "test_gdaldem_lib_hillshade_float_png.png",
         src_ds,
         "hillshade",
         format="PNG",
@@ -137,10 +137,6 @@ def test_gdaldem_lib_hillshade_float_png():
 
     src_ds = None
     ds = None
-
-    gdal.GetDriverByName("PNG").Delete(
-        "/vsimem/test_gdaldem_lib_hillshade_float_png.png"
-    )
 
 
 ###############################################################################

--- a/autotest/utilities/test_gdalinfo_lib.py
+++ b/autotest/utilities/test_gdalinfo_lib.py
@@ -30,6 +30,8 @@
 ###############################################################################
 
 
+import pathlib
+
 import gdaltest
 import pytest
 
@@ -44,6 +46,18 @@ def test_gdalinfo_lib_1():
     ds = gdal.Open("../gcore/data/byte.tif")
 
     ret = gdal.Info(ds)
+    assert ret.find("Driver: GTiff/GeoTIFF") != -1, "did not get expected string."
+
+
+def test_gdalinfo_lib_1_str():
+
+    ret = gdal.Info("../gcore/data/byte.tif")
+    assert ret.find("Driver: GTiff/GeoTIFF") != -1, "did not get expected string."
+
+
+def test_gdalinfo_lib_1_path():
+
+    ret = gdal.Info(pathlib.Path("../gcore/data/byte.tif"))
     assert ret.find("Driver: GTiff/GeoTIFF") != -1, "did not get expected string."
 
 

--- a/autotest/utilities/test_gdalmdiminfo_lib.py
+++ b/autotest/utilities/test_gdalmdiminfo_lib.py
@@ -29,6 +29,7 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
+import pathlib
 import struct
 
 import gdaltest
@@ -261,6 +262,17 @@ def test_gdalmdiminfo_lib_arrayoption():
         "../gdrivers/data/netcdf/with_bounds.nc", arrayoptions=["SHOW_BOUNDS=NO"]
     )
     assert len(ret["arrays"]) == 1
+
+
+###############################################################################
+# Test path argument
+
+
+@pytest.mark.require_driver("netCDF")
+def test_gdalmdiminfo_lib_path_input():
+
+    ret = gdal.MultiDimInfo(pathlib.Path("../gdrivers/data/netcdf/with_bounds.nc"))
+    assert ret is not None
 
 
 ###############################################################################

--- a/autotest/utilities/test_gdalmdimtranslate_lib.py
+++ b/autotest/utilities/test_gdalmdimtranslate_lib.py
@@ -29,6 +29,7 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
+import pathlib
 import struct
 
 import gdaltest
@@ -65,15 +66,17 @@ def test_gdalmdimtranslate_multidim_to_mem():
 ###############################################################################
 
 
-def test_gdalmdimtranslate_multidim_to_classic():
+def test_gdalmdimtranslate_multidim_to_classic(tmp_vsimem):
 
-    tmpfile = "/vsimem/out.tif"
+    tmpfile = tmp_vsimem / "out.tif"
 
     with pytest.raises(Exception):
         gdal.MultiDimTranslate(tmpfile, "data/mdim.vrt")
 
     assert gdal.MultiDimTranslate(
-        tmpfile, "data/mdim.vrt", arraySpecs=["/my_subgroup/array_in_subgroup"]
+        tmpfile,
+        pathlib.Path("data/mdim.vrt"),
+        arraySpecs=["/my_subgroup/array_in_subgroup"],
     )
 
     gdal.Unlink(tmpfile)

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -46,7 +46,7 @@ from osgeo import gdal, ogr, osr
 def test_gdalwarp_lib_1(tmp_path):
 
     ds1 = gdal.Open("../gcore/data/byte.tif")
-    dstDS = gdal.Warp(f"{tmp_path}/testgdalwarp1.tif", ds1)
+    dstDS = gdal.Warp(tmp_path / "testgdalwarp1.tif", ds1)
 
     assert dstDS.GetRasterBand(1).Checksum() == 4672, "Bad checksum"
 
@@ -61,7 +61,7 @@ def test_gdalwarp_lib_2(tmp_path):
 
     ds1 = gdal.Open("../gcore/data/byte.tif")
     dstDS = gdal.Warp(
-        f"{tmp_path}/testgdalwarp2.tif".encode("ascii").decode("ascii"),
+        tmp_path / "testgdalwarp2.tif".encode("ascii").decode("ascii"),
         [ds1],
         format="GTiff",
     )
@@ -108,9 +108,7 @@ def test_gdalwarp_lib_4():
 @pytest.fixture(scope="module")
 def testgdalwarp_gcp_tif(tmp_path_factory):
 
-    testgdalwarp_gcp_tif_fname = str(
-        tmp_path_factory.mktemp("tmp") / "testgdalwarp_gcp.tif"
-    )
+    testgdalwarp_gcp_tif_fname = tmp_path_factory.mktemp("tmp") / "testgdalwarp_gcp.tif"
 
     ds = gdal.Open("../gcore/data/byte.tif")
     gcpList = [
@@ -405,7 +403,7 @@ def test_gdalwarp_lib_15(testgdalwarp_gcp_tif):
 def test_gdalwarp_lib_16(testgdalwarp_gcp_tif):
 
     ds = gdal.Warp(
-        "/vsimem/test_gdalwarp_lib_16.vrt", testgdalwarp_gcp_tif, format="VRT"
+        "/vsimem/test_gdalwarp_lib_16.vrt", [testgdalwarp_gcp_tif], format="VRT"
     )
     assert ds is not None
 

--- a/autotest/utilities/test_nearblack_lib.py
+++ b/autotest/utilities/test_nearblack_lib.py
@@ -31,6 +31,7 @@
 
 
 import array
+import pathlib
 
 import pytest
 
@@ -135,11 +136,11 @@ def test_nearblack_lib_4(alg):
 
 
 @pytest.mark.parametrize("alg", ["twopasses", "floodfill"])
-def test_nearblack_lib_5(alg):
+def test_nearblack_lib_5(tmp_vsimem, alg):
 
     ds = gdal.Nearblack(
-        "/vsimem/test_nearblack_lib_5.tif",
-        "../gdrivers/data/rgbsmall.tif",
+        tmp_vsimem / "test_nearblack_lib_5.tif",
+        pathlib.Path("../gdrivers/data/rgbsmall.tif"),
         format="GTiff",
         maxNonBlack=0,
         setMask=True,
@@ -152,9 +153,6 @@ def test_nearblack_lib_5(alg):
     ), "Bad checksum mask band"
 
     ds = None
-
-    gdal.Unlink("/vsimem/test_nearblack_lib_5.tif")
-    gdal.Unlink("/vsimem/test_nearblack_lib_5.tif.msk")
 
 
 ###############################################################################

--- a/autotest/utilities/test_ogr2ogr_lib.py
+++ b/autotest/utilities/test_ogr2ogr_lib.py
@@ -30,6 +30,7 @@
 ###############################################################################
 
 import json
+import pathlib
 import tempfile
 
 import gdaltest
@@ -1914,8 +1915,8 @@ def test_ogr2ogr_lib_valid_nlt_combinations(nlt_value):
 )
 def test_ogr2ogr_lib_geojson_output(tmp_path):
 
-    tmpfilename = str(tmp_path / "out.geojson")
-    out_ds = gdal.VectorTranslate(tmpfilename, "../ogr/data/poly.shp")
+    tmpfilename = tmp_path / "out.geojson"
+    out_ds = gdal.VectorTranslate(tmpfilename, pathlib.Path("../ogr/data/poly.shp"))
 
     # Check that the file can be read at that point. Use an external process
     # to check flushes are done correctly

--- a/autotest/utilities/test_ogrinfo_lib.py
+++ b/autotest/utilities/test_ogrinfo_lib.py
@@ -27,6 +27,8 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
+import pathlib
+
 import gdaltest
 import pytest
 
@@ -41,6 +43,18 @@ def test_ogrinfo_lib_1():
     ds = gdal.OpenEx("../ogr/data/poly.shp")
 
     ret = gdal.VectorInfo(ds)
+    assert "ESRI Shapefile" in ret
+
+
+def test_ogrinfo_lib_1_str():
+
+    ret = gdal.VectorInfo("../ogr/data/poly.shp")
+    assert "ESRI Shapefile" in ret
+
+
+def test_ogrinfo_lib_1_path():
+
+    ret = gdal.VectorInfo(pathlib.Path("../ogr/data/poly.shp"))
     assert "ESRI Shapefile" in ret
 
 

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -1684,7 +1684,10 @@ def Info(ds, **kwargs):
         (opts, format, deserialize) = InfoOptions(**kwargs)
     else:
         (opts, format, deserialize) = kwargs['options']
-    if isinstance(ds, str):
+
+    import os
+
+    if isinstance(ds, (str, os.PathLike)):
         ds = Open(ds)
     ret = InfoInternal(ds, opts)
     if format == 'json' and deserialize:
@@ -1794,7 +1797,10 @@ def VectorInfo(ds, **kwargs):
         (opts, format, deserialize) = VectorInfoOptions(**kwargs)
     else:
         (opts, format, deserialize) = kwargs['options']
-    if isinstance(ds, str):
+
+    import os
+
+    if isinstance(ds, (str, os.PathLike)):
         ds = OpenEx(ds, OF_VERBOSE_ERROR | OF_VECTOR)
     ret = VectorInfoInternal(ds, opts)
     if format == 'json' and deserialize:
@@ -1845,7 +1851,10 @@ def MultiDimInfo(ds, **kwargs):
     else:
         opts = kwargs['options']
         as_text = True
-    if isinstance(ds, str):
+
+    import os
+
+    if isinstance(ds, (str, os.PathLike)):
         ds = OpenEx(ds, OF_VERBOSE_ERROR | OF_MULTIDIM_RASTER)
     ret = MultiDimInfoInternal(ds, opts)
     if not as_text:
@@ -2345,19 +2354,22 @@ def Warp(destNameOrDestDS, srcDSOrSrcDSTab, **kwargs):
         (opts, callback, callback_data) = WarpOptions(**kwargs)
     else:
         (opts, callback, callback_data) = kwargs['options']
-    if isinstance(srcDSOrSrcDSTab, str):
+
+    import os
+
+    if isinstance(srcDSOrSrcDSTab, (str, os.PathLike)):
         srcDSTab = [Open(srcDSOrSrcDSTab)]
     elif isinstance(srcDSOrSrcDSTab, list):
         srcDSTab = []
         for elt in srcDSOrSrcDSTab:
-            if isinstance(elt, str):
+            if isinstance(elt, (str, os.PathLike)):
                 srcDSTab.append(Open(elt))
             else:
                 srcDSTab.append(elt)
     else:
         srcDSTab = [srcDSOrSrcDSTab]
 
-    if isinstance(destNameOrDestDS, str):
+    if isinstance(destNameOrDestDS, (str, os.PathLike)):
         return wrapper_GDALWarpDestName(destNameOrDestDS, srcDSTab, opts, callback, callback_data)
     else:
         return wrapper_GDALWarpDestDS(destNameOrDestDS, srcDSTab, opts, callback, callback_data)
@@ -2689,10 +2701,13 @@ def VectorTranslate(destNameOrDestDS, srcDS, **kwargs):
         (opts, callback, callback_data) = VectorTranslateOptions(**kwargs)
     else:
         (opts, callback, callback_data) = kwargs['options']
-    if isinstance(srcDS, str):
+
+    import os
+
+    if isinstance(srcDS, (str, os.PathLike)):
         srcDS = OpenEx(srcDS, gdalconst.OF_VECTOR)
 
-    if isinstance(destNameOrDestDS, str):
+    if isinstance(destNameOrDestDS, (str, os.PathLike)):
         return wrapper_GDALVectorTranslateDestName(destNameOrDestDS, srcDS, opts, callback, callback_data)
     else:
         return wrapper_GDALVectorTranslateDestDS(destNameOrDestDS, srcDS, opts, callback, callback_data)
@@ -2920,10 +2935,13 @@ def Nearblack(destNameOrDestDS, srcDS, **kwargs):
         (opts, callback, callback_data) = NearblackOptions(**kwargs)
     else:
         (opts, callback, callback_data) = kwargs['options']
-    if isinstance(srcDS, str):
+
+    import os
+
+    if isinstance(srcDS, (str, os.PathLike)):
         srcDS = OpenEx(srcDS)
 
-    if isinstance(destNameOrDestDS, str):
+    if isinstance(destNameOrDestDS, (str, os.PathLike)):
         return wrapper_GDALNearblackDestName(destNameOrDestDS, srcDS, opts, callback, callback_data)
     else:
         return wrapper_GDALNearblackDestDS(destNameOrDestDS, srcDS, opts, callback, callback_data)
@@ -3233,14 +3251,16 @@ def Rasterize(destNameOrDestDS, srcDS, **kwargs):
 
     _WarnIfUserHasNotSpecifiedIfUsingExceptions()
 
+    import os
+
     if 'options' not in kwargs or isinstance(kwargs['options'], (list, str)):
         (opts, callback, callback_data) = RasterizeOptions(**kwargs)
     else:
         (opts, callback, callback_data) = kwargs['options']
-    if isinstance(srcDS, str):
+    if isinstance(srcDS, (str, os.PathLike)):
         srcDS = OpenEx(srcDS, gdalconst.OF_VECTOR)
 
-    if isinstance(destNameOrDestDS, str):
+    if isinstance(destNameOrDestDS, (str, os.PathLike)):
         return wrapper_GDALRasterizeDestName(destNameOrDestDS, srcDS, opts, callback, callback_data)
     else:
         return wrapper_GDALRasterizeDestDS(destNameOrDestDS, srcDS, opts, callback, callback_data)
@@ -3392,7 +3412,10 @@ def Footprint(destNameOrDestDS, srcDS, **kwargs):
         (opts, callback, callback_data) = FootprintOptions(**kwargs)
     else:
         (opts, callback, callback_data) = kwargs['options']
-    if isinstance(srcDS, str):
+
+    import os
+
+    if isinstance(srcDS, (str, os.PathLike)):
         srcDS = OpenEx(srcDS, gdalconst.OF_RASTER)
 
     if inline_geojson_requested or wkt_requested:
@@ -3426,7 +3449,9 @@ def Footprint(destNameOrDestDS, srcDS, **kwargs):
             if VSIStatL(temp_filename):
                 Unlink(temp_filename)
 
-    if isinstance(destNameOrDestDS, str):
+    import os
+
+    if isinstance(destNameOrDestDS, (str, os.PathLike)):
         return wrapper_GDALFootprintDestName(destNameOrDestDS, srcDS, opts, callback, callback_data)
     else:
         return wrapper_GDALFootprintDestDS(destNameOrDestDS, srcDS, opts, callback, callback_data)
@@ -3566,12 +3591,15 @@ def BuildVRT(destName, srcDSOrSrcDSTab, **kwargs):
 
     srcDSTab = []
     srcDSNamesTab = []
-    if isinstance(srcDSOrSrcDSTab, str):
-        srcDSNamesTab = [srcDSOrSrcDSTab]
+
+    import os
+
+    if isinstance(srcDSOrSrcDSTab, (str, os.PathLike)):
+        srcDSNamesTab = [str(srcDSOrSrcDSTab)]
     elif isinstance(srcDSOrSrcDSTab, list):
         for elt in srcDSOrSrcDSTab:
-            if isinstance(elt, str):
-                srcDSNamesTab.append(elt)
+            if isinstance(elt, (str, os.PathLike)):
+                srcDSNamesTab.append(str(elt))
             else:
                 srcDSTab.append(elt)
         if srcDSTab and srcDSNamesTab:
@@ -3663,7 +3691,10 @@ def MultiDimTranslate(destName, srcDSOrSrcDSTab, **kwargs):
         (opts, callback, callback_data) = MultiDimTranslateOptions(**kwargs)
     else:
         (opts, callback, callback_data) = kwargs['options']
-    if isinstance(srcDSOrSrcDSTab, str):
+
+    import os
+
+    if isinstance(srcDSOrSrcDSTab, (str, os.PathLike)):
         srcDSTab = [OpenEx(srcDSOrSrcDSTab, OF_VERBOSE_ERROR | OF_RASTER | OF_MULTIDIM_RASTER)]
     elif isinstance(srcDSOrSrcDSTab, list):
         srcDSTab = []


### PR DESCRIPTION
## What does this PR do?

Extends support for `os.PathLike` inputs to utility functions that did not pick it up automatically from the typemap.

## What are related issues/pull requests?

#8286 

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
