### PR TITLE
[Backport release/3.7] gdalmdimtranslate: fix wrong output dimension size when using syntax …

### DIFF
--- a/autotest/utilities/test_gdalmdimtranslate_lib.py
+++ b/autotest/utilities/test_gdalmdimtranslate_lib.py
@@ -852,6 +852,21 @@ def test_gdalmdimtranslate_dims_with_same_name_different_size():
     gdal.Unlink(srcfile)
 
 
+@pytest.mark.require_driver("netCDF")
+def test_gdalmdimtranslate_array_with_view():
+    ds = gdal.MultiDimTranslate(
+        "",
+        "../gdrivers/data/netcdf/byte_no_cf.nc",
+        arraySpecs=["name=Band1,view=[::2,::4]"],
+        format="MEM",
+    )
+    rg = ds.GetRootGroup()
+    ar = rg.OpenMDArray("Band1")
+    dims = ar.GetDimensions()
+    assert dims[0].GetSize() == 10
+    assert dims[1].GetSize() == 5
+
+
 def XXXX_test_all():
     while True:
         test_gdalmdimtranslate_no_arg()


### PR DESCRIPTION
Backport #8297
 **Authored by:** @rouault