### PR TITLE
[Backport release/3.7] osgeo_utils: allign base.get_extension() and util.DoesDriverHandleExtension() on C++ versions, and add tests (fixes #8277)

### DIFF
--- a/autotest/pyscripts/test_gdal_utils.py
+++ b/autotest/pyscripts/test_gdal_utils.py
@@ -295,6 +295,36 @@ def test_read_write_color_table_from_raster():
     gdaltest.tiff_drv.Delete("tmp/ct8.tif")
 
 
+def test_utils_base_get_extension():
+    """test base.get_extension()"""
+
+    assert base.get_extension("foo.shp.zip") == "shp.zip"
+    assert base.get_extension("foo.gpkg.zip") == "gpkg.zip"
+    assert base.get_extension("foo.gpkg") == "gpkg"
+
+
+@pytest.mark.require_driver("GeoJSON")
+@pytest.mark.require_driver("GeoJSONSeq")
+def test_utils_util_DoesDriverHandleExtension():
+    """test util.DoesDriverHandleExtension()"""
+
+    assert util.DoesDriverHandleExtension(gdal.GetDriverByName("GeoJSON"), "geojson")
+    assert not util.DoesDriverHandleExtension(
+        gdal.GetDriverByName("GeoJSONSeq"), "geojson"
+    )
+
+
+@pytest.mark.require_driver("HFA")
+@pytest.mark.require_driver("netCDF")
+@pytest.mark.require_driver("GeoJSON")
+def test_utils_util_GetOutputDriverFor():
+    """test util.GetOutputDriverFor()"""
+
+    assert util.GetOutputDriverFor("foo.img") == "HFA"
+    assert util.GetOutputDriverFor("foo.nc") == "netCDF"
+    assert util.GetOutputDriverFor("foo.geojson", is_raster=False) == "GeoJSON"
+
+
 def test_utils_py_cleanup():
     for filename in temp_files:
         try:

--- a/swig/python/gdal-utils/osgeo_utils/auxiliary/base.py
+++ b/swig/python/gdal-utils/osgeo_utils/auxiliary/base.py
@@ -59,10 +59,13 @@ def get_suffix(filename: PathLikeOrStr) -> str:
 def get_extension(filename: PathLikeOrStr) -> str:
     """
     returns the suffix without the leading dot.
-    special case for shp.zip
+    special case for shp.zip and gpkg.zip
     """
-    if os.fspath(filename).lower().endswith(".shp.zip"):
+    lower_filename = os.fspath(filename).lower()
+    if lower_filename.endswith(".shp.zip"):
         return "shp.zip"
+    if lower_filename.endswith(".gpkg.zip"):
+        return "gpkg.zip"
     ext = get_suffix(filename)
     if ext.startswith("."):
         ext = ext[1:]

--- a/swig/python/gdal-utils/osgeo_utils/auxiliary/util.py
+++ b/swig/python/gdal-utils/osgeo_utils/auxiliary/util.py
@@ -56,7 +56,7 @@ gdal_version = tuple(int(s) for s in str(gdal_version_str).split(".") if s.isdig
 
 def DoesDriverHandleExtension(drv: gdal.Driver, ext: str) -> bool:
     exts = drv.GetMetadataItem(gdal.DMD_EXTENSIONS)
-    return exts is not None and exts.lower().find(ext.lower()) >= 0
+    return exts is not None and ext.lower() in exts.lower().split(" ")
 
 
 def GetOutputDriversFor(filename: PathLikeOrStr, is_raster=True) -> List[str]:


### PR DESCRIPTION
Backport #8307
 **Authored by:** @rouault