### PR TITLE
VRT 'projwin' for vrt:// connection

### DIFF
--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1517,6 +1517,16 @@ def test_vrt_protocol():
     assert ds.GetRasterBand(1).XSize == 10
     assert ds.GetRasterBand(1).YSize == 5
 
+    with gdal.quiet_errors():
+        ds = gdal.Open("vrt://data/float32.tif?projwin=440840,441920,3750120")
+        assert ds is None
+
+    ds = gdal.Open("vrt://data/float32.tif?projwin=440840,3751080,441920,3750120")
+    assert ds.GetGeoTransform()[0] == 440840.0
+    assert ds.GetGeoTransform()[3] == 3751080.0
+    assert ds.GetRasterBand(1).XSize == 18
+    assert ds.GetRasterBand(1).YSize == 16
+
 
 @pytest.mark.require_driver("BMP")
 def test_vrt_protocol_expand_option():

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1688,7 +1688,7 @@ For example:
 
 
 The supported options currently are ``bands``, ``a_srs``, ``a_ullr``, ``ovr``, ``expand``,
-``a_scale``, ``a_offset``, ``ot``, ``gcp``, ``if``, ``scale``, ``exponent``, and ``outsize``.
+``a_scale``, ``a_offset``, ``ot``, ``gcp``, ``if``, ``scale``, ``exponent``, ``outsize``, and ``projwin``.
 
 Other options may be added in the future.
 
@@ -1740,6 +1740,11 @@ a single value to be used with the ``scale`` option. The same ``exponent_bn`` sy
 target specific band/s as per (:ref:`gdal_translate`).
 
 The effect of the ``outsize`` option (added in GDAL 3.7) is to set the size of the output, in numbers `pixel,line` or in fraction `pixel%,line%` as per (:ref:`gdal_translate`).
+
+The effect of the ``projwin`` option (added in GDAL 3.8) is to select a subwindow from the source image in georeferenced
+coordinates in the same way as (:ref:`gdal_translate`). The value consists of four numeric values separated by commas, in
+the order 'xmin,ymax,xmax,ymin'.
+
 
 The options may be chained together separated by '&'. (Beware the need for quoting to protect
 the ampersand).

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -1202,6 +1202,27 @@ GDALDataset *VRTDataset::OpenVRTProtocol(const char *pszSpec)
                 argv.AddString(aosOutSize[0]);
                 argv.AddString(aosOutSize[1]);
             }
+            else if (EQUAL(pszKey, "projwin"))
+            {
+
+                // Parse the limits
+                CPLStringList aosProjWin(CSLTokenizeString2(pszValue, ",", 0));
+                // fail if not four values
+                if (aosProjWin.size() != 4)
+                {
+                    CPLError(CE_Failure, CPLE_IllegalArg,
+                             "Invalid projwin option: %s", pszValue);
+                    poSrcDS->ReleaseRef();
+                    CPLFree(pszKey);
+                    return nullptr;
+                }
+
+                argv.AddString("-projwin");
+                argv.AddString(aosProjWin[0]);
+                argv.AddString(aosProjWin[1]);
+                argv.AddString(aosProjWin[2]);
+                argv.AddString(aosProjWin[3]);
+            }
             else
             {
                 CPLError(CE_Failure, CPLE_NotSupported, "Unknown option: %s",


### PR DESCRIPTION
Add 'projwin' to allowed options for a "vrt://" connection.

## What are related issues/pull requests?

Discussion and summary of related PRs: https://github.com/OSGeo/gdal/issues/7477

## Tasklist

 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

