### PR TITLE
VRT 'projwin_srs' for vrt:// connection

### DIFF
--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1527,6 +1527,19 @@ def test_vrt_protocol():
     assert ds.GetRasterBand(1).XSize == 18
     assert ds.GetRasterBand(1).YSize == 16
 
+    ## no op, simply ignored as with gdal_translate
+    ds = gdal.Open("vrt://data/float32.tif?projwin_srs=OGC:CRS84")
+    assert ds
+
+    ds = gdal.Open(
+        "vrt://data/float32.tif?projwin_srs=OGC:CRS84&projwin=-117.6407,33.90027,-117.6292,33.89181"
+    )
+
+    assert ds.GetGeoTransform()[0] == 440840.0
+    assert ds.GetGeoTransform()[3] == 3751140.0
+    assert ds.GetRasterBand(1).XSize == 18
+    assert ds.GetRasterBand(1).YSize == 16
+
 
 @pytest.mark.require_driver("BMP")
 def test_vrt_protocol_expand_option():

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1743,7 +1743,10 @@ The effect of the ``outsize`` option (added in GDAL 3.7) is to set the size of t
 
 The effect of the ``projwin`` option (added in GDAL 3.8) is to select a subwindow from the source image in georeferenced
 coordinates in the same way as (:ref:`gdal_translate`). The value consists of four numeric values separated by commas, in
-the order 'xmin,ymax,xmax,ymin'.
+the order 'xmin,ymax,xmax,ymin', these are in the native georeferenced coordinates of the source unless ``projwin_srs`` is also
+provided.
+
+The effect of the ``projwin_srs`` option (added in GDAL 3.8) is to specify the SRS in which to interpret the coordinates given with ``projwin`` in the same way as (:ref:`gdal_translate`). This option only applies if ``projwin`` is also supplied.
 
 
 The options may be chained together separated by '&'. (Beware the need for quoting to protect

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -1223,6 +1223,12 @@ GDALDataset *VRTDataset::OpenVRTProtocol(const char *pszSpec)
                 argv.AddString(aosProjWin[2]);
                 argv.AddString(aosProjWin[3]);
             }
+            else if (EQUAL(pszKey, "projwin_srs"))
+            {
+                argv.AddString("-projwin_srs");
+                argv.AddString(pszValue);
+            }
+
             else
             {
                 CPLError(CE_Failure, CPLE_NotSupported, "Unknown option: %s",


### PR DESCRIPTION
Add 'projwin_srs' to allowed options for a "vrt://" connection.

## What are related issues/pull requests?

Discussion and summary of related PRs: https://github.com/OSGeo/gdal/issues/7477

## Tasklist

 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
