### PR TITLE
GPKG: add a CRS_WKT_EXTENSION and METADATA_TABLES creation option

### DIFF
--- a/autotest/gdrivers/gpkg.py
+++ b/autotest/gdrivers/gpkg.py
@@ -2874,6 +2874,8 @@ def test_gpkg_39():
     ds = None
 
     # Test GRID_CELL_ENCODING=grid-value-is-corner
+    if os.path.exists("data/byte.tif.aux.xml"):
+        os.unlink("data/byte.tif.aux.xml")
     gdal.Translate(
         "/vsimem/gpkg_39.gpkg",
         "data/byte.tif",
@@ -2883,10 +2885,9 @@ def test_gpkg_39():
     )
     ds = gdal.Open("/vsimem/gpkg_39.gpkg")
     assert ds.GetMetadataItem("AREA_OR_POINT") == "Point", ds.GetMetadata()
-    assert (
-        ds.GetRasterBand(1).GetMetadataItem("GRID_CELL_ENCODING")
-        == "grid-value-is-corner"
-    )
+    assert ds.GetRasterBand(1).GetMetadata() == {
+        "GRID_CELL_ENCODING": "grid-value-is-corner"
+    }
 
     # No metadata for now
     sql_lyr = ds.ExecuteSQL("SELECT 1 FROM sqlite_master WHERE name = 'gpkg_metadata'")
@@ -2894,8 +2895,27 @@ def test_gpkg_39():
     ds.ReleaseResultSet(sql_lyr)
     feat_is_none = feat is None
     assert feat_is_none
-
     ds = None
+
+    # Test GRID_CELL_ENCODING=grid-value-is-corner
+    src_with_stats = gdal.Translate("", "data/byte.tif", format="MEM")
+    src_with_stats.GetRasterBand(1).ComputeStatistics(approx_ok=False)
+    gdal.Translate(
+        "/vsimem/gpkg_39.gpkg",
+        src_with_stats,
+        format="GPKG",
+        outputType=gdal.GDT_UInt16,
+        creationOptions=["GRID_CELL_ENCODING=grid-value-is-corner"],
+    )
+    assert gdal.VSIStatL("/vsimem/gpkg_39.gpkg.aux.xml") is None
+    ds = gdal.Open("/vsimem/gpkg_39.gpkg")
+    assert ds.GetMetadataItem("AREA_OR_POINT") == "Point", ds.GetMetadata()
+    expected_md = src_with_stats.GetRasterBand(1).GetMetadata()
+    expected_md.update({"GRID_CELL_ENCODING": "grid-value-is-corner"})
+    assert ds.GetRasterBand(1).GetMetadata() == expected_md
+    ds = None
+
+    gdal.Unlink("/vsimem/gpkg_39.gpkg")
 
     # With nodata: statistics available
     gdal.Translate("/vsimem/gpkg_39.gpkg", src_ds, format="GPKG", noData=0)

--- a/autotest/gdrivers/gpkg.py
+++ b/autotest/gdrivers/gpkg.py
@@ -248,8 +248,9 @@ def test_gpkg_1():
     )[0]
     expected_gt = ds.GetGeoTransform()
     expected_wkt = ds.GetProjectionRef()
-    with gdaltest.config_option("CREATE_METADATA_TABLES", "NO"):
-        gdaltest.gpkg_dr.CreateCopy("/vsimem/tmp.gpkg", ds, options=["TILE_FORMAT=PNG"])
+    gdaltest.gpkg_dr.CreateCopy(
+        "/vsimem/tmp.gpkg", ds, options=["TILE_FORMAT=PNG", "METADATA_TABLES=NO"]
+    )
     ds = None
 
     assert validate("/vsimem/tmp.gpkg"), "validation failed"
@@ -349,10 +350,9 @@ def test_gpkg_2():
     )
     clamped_expected_cs.append(17849)
 
-    with gdaltest.config_option("CREATE_METADATA_TABLES", "NO"):
-        gdaltest.gpkg_dr.CreateCopy(
-            "/vsimem/tmp.gpkg", ds, options=["TILE_FORMAT=JPEG"]
-        )
+    gdaltest.gpkg_dr.CreateCopy(
+        "/vsimem/tmp.gpkg", ds, options=["TILE_FORMAT=JPEG", "METADATA_TABLES=NO"]
+    )
 
     out_ds = gdal.Open("/vsimem/tmp.gpkg")
     expected_cs = [expected_cs, expected_cs, expected_cs, 4873]
@@ -1525,8 +1525,9 @@ def test_gpkg_17():
 
     # Without padding, after reopening
     ds = gdal.Open("data/byte.tif")
-    with gdaltest.config_option("CREATE_METADATA_TABLES", "NO"):
-        gdaltest.gpkg_dr.CreateCopy("/vsimem/tmp.gpkg", ds, options=["BLOCKSIZE=10"])
+    gdaltest.gpkg_dr.CreateCopy(
+        "/vsimem/tmp.gpkg", ds, options=["BLOCKSIZE=10", "METADATA_TABLES=NO"]
+    )
     out_ds = gdal.OpenEx(
         "/vsimem/tmp.gpkg",
         gdal.OF_RASTER | gdal.OF_UPDATE,
@@ -1697,16 +1698,20 @@ def test_gpkg_18():
 
     # Without padding, immediately after create copy
     ds = gdal.Open("data/small_world.tif")
-    with gdaltest.config_option("CREATE_METADATA_TABLES", "NO"):
-        out_ds = gdaltest.gpkg_dr.CreateCopy(
-            "/vsimem/tmp.gpkg",
-            ds,
-            options=["TILE_FORMAT=PNG", "BLOCKXSIZE=100", "BLOCKYSIZE=100"],
-        )
-        # Should not result in gpkg_zoom_other
-        ret = out_ds.BuildOverviews("NEAR", [8])
-        assert ret == 0
-        out_ds = None
+    out_ds = gdaltest.gpkg_dr.CreateCopy(
+        "/vsimem/tmp.gpkg",
+        ds,
+        options=[
+            "TILE_FORMAT=PNG",
+            "BLOCKXSIZE=100",
+            "BLOCKYSIZE=100",
+            "METADATA_TABLES=NO",
+        ],
+    )
+    # Should not result in gpkg_zoom_other
+    ret = out_ds.BuildOverviews("NEAR", [8])
+    assert ret == 0
+    out_ds = None
 
     # Check that there's no extensions
     out_ds = gdal.Open("/vsimem/tmp.gpkg")

--- a/autotest/gdrivers/gpkg.py
+++ b/autotest/gdrivers/gpkg.py
@@ -2915,8 +2915,6 @@ def test_gpkg_39():
     assert ds.GetRasterBand(1).GetMetadata() == expected_md
     ds = None
 
-    gdal.Unlink("/vsimem/gpkg_39.gpkg")
-
     # With nodata: statistics available
     gdal.Translate("/vsimem/gpkg_39.gpkg", src_ds, format="GPKG", noData=0)
 

--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -4096,36 +4096,117 @@ def test_ogr_gpkg_43():
 # Test GeoPackage without metadata table
 
 
-def test_ogr_gpkg_44():
+def test_ogr_gpkg_METADATA_TABLES_NO(tmp_vsimem):
 
-    with gdal.config_option("CREATE_METADATA_TABLES", "NO"):
-        ds = gdaltest.gpkg_dr.CreateDataSource("/vsimem/ogr_gpkg_44.gpkg")
-        ds.CreateLayer("foo")
-        ds = None
+    filename = str(tmp_vsimem / "test_ogr_gpkg_METADATA_TABLES_NO.gpkg")
 
-    assert validate("/vsimem/ogr_gpkg_44.gpkg"), "validation failed"
+    ds = gdaltest.gpkg_dr.CreateDataSource(filename, options=["METADATA_TABLES=NO"])
+    ds.CreateLayer("foo")
+    ds.SetMetadataItem("FOO", "BAR")  # will not be written
+    ds = None
 
-    ds = ogr.Open("/vsimem/ogr_gpkg_44.gpkg")
+    assert validate(filename), "validation failed"
+
+    ds = ogr.Open(filename)
     md = ds.GetMetadata()
     assert md == {}
     md = ds.GetLayer(0).GetMetadata()
     assert md == {}
-    sql_lyr = ds.ExecuteSQL("SELECT * FROM sqlite_master WHERE name = 'gpkg_metadata'")
-    fc = sql_lyr.GetFeatureCount()
-    ds.ReleaseResultSet(sql_lyr)
+    with ds.ExecuteSQL(
+        "SELECT * FROM sqlite_master WHERE name = 'gpkg_metadata'"
+    ) as sql_lyr:
+        fc = sql_lyr.GetFeatureCount()
     assert fc == 0
     ds = None
 
-    ds = ogr.Open("/vsimem/ogr_gpkg_44.gpkg", update=1)
+    ds = ogr.Open(filename, update=1)
     ds.SetMetadataItem("FOO", "BAR")
     ds = None
 
-    ds = ogr.Open("/vsimem/ogr_gpkg_44.gpkg")
+    ds = ogr.Open(filename)
     md = ds.GetMetadata()
     assert md == {"FOO": "BAR"}
     ds = None
 
-    gdaltest.gpkg_dr.DeleteDataSource("/vsimem/ogr_gpkg_44.gpkg")
+    gdaltest.gpkg_dr.DeleteDataSource(filename)
+
+
+###############################################################################
+# Test GeoPackage with forced metadata table
+
+
+def test_ogr_gpkg_METADATA_TABLES_YES(tmp_vsimem):
+
+    filename = str(tmp_vsimem / "test_ogr_gpkg_METADATA_TABLES_YES.gpkg")
+
+    ds = gdaltest.gpkg_dr.CreateDataSource(filename, options=["METADATA_TABLES=YES"])
+    ds.CreateLayer("foo")
+    ds = None
+
+    assert validate(filename), "validation failed"
+
+    ds = ogr.Open(filename)
+    with ds.ExecuteSQL(
+        "SELECT * FROM sqlite_master WHERE name = 'gpkg_metadata'"
+    ) as sql_lyr:
+        fc = sql_lyr.GetFeatureCount()
+    assert fc == 1
+    ds = None
+
+    gdaltest.gpkg_dr.DeleteDataSource(filename)
+
+
+###############################################################################
+# Test GeoPackage with automatic metadata table creation
+
+
+def test_ogr_gpkg_METADATA_TABLES_AUTO(tmp_vsimem):
+
+    filename = str(tmp_vsimem / "test_ogr_gpkg_METADATA_TABLES_AUTO.gpkg")
+
+    ds = gdaltest.gpkg_dr.CreateDataSource(filename)
+    lyr = ds.CreateLayer("foo")
+    lyr.SetMetadataItem("foo", "bar")
+    ds = None
+
+    assert validate(filename), "validation failed"
+
+    ds = ogr.Open(filename)
+    with ds.ExecuteSQL(
+        "SELECT * FROM sqlite_master WHERE name = 'gpkg_metadata'"
+    ) as sql_lyr:
+        fc = sql_lyr.GetFeatureCount()
+    assert fc == 1
+    md = ds.GetLayer(0).GetMetadata()
+    assert md == {"foo": "bar"}
+    ds = None
+
+    gdaltest.gpkg_dr.DeleteDataSource(filename)
+
+
+###############################################################################
+# Test GeoPackage with automatic metadata table creation
+
+
+def test_ogr_gpkg_METADATA_TABLES_AUTO_not_needed(tmp_vsimem):
+
+    filename = str(tmp_vsimem / "test_ogr_gpkg_METADATA_TABLES_AUTO_not_needed.gpkg")
+
+    ds = gdaltest.gpkg_dr.CreateDataSource(filename)
+    ds.CreateLayer("foo")
+    ds = None
+
+    assert validate(filename), "validation failed"
+
+    ds = ogr.Open(filename)
+    with ds.ExecuteSQL(
+        "SELECT * FROM sqlite_master WHERE name = 'gpkg_metadata'"
+    ) as sql_lyr:
+        fc = sql_lyr.GetFeatureCount()
+    assert fc == 0
+    ds = None
+
+    gdaltest.gpkg_dr.DeleteDataSource(filename)
 
 
 ###############################################################################

--- a/doc/source/drivers/raster/gpkg.rst
+++ b/doc/source/drivers/raster/gpkg.rst
@@ -597,6 +597,15 @@ The following creation options are available:
       it may be useful to create GeoPackage datasets matching the expections of
       other software or profiles (such as the DGIWG-GPKG profile).
 
+-  .. co:: METADATA_TABLES
+      :choices: YES, NO
+      :since: 3.8
+
+      Defines whether to add the metadata system tables.
+      By default, they are created on demand.
+      If NO is specified, they are not created, even if metadata is set.
+      If YES is specified, they are always created.
+
 Overviews
 ---------
 

--- a/doc/source/drivers/raster/gpkg.rst
+++ b/doc/source/drivers/raster/gpkg.rst
@@ -577,6 +577,26 @@ The following creation options are available:
       add a gpkg_ogr_contents table to keep feature count for vector
       layers, and associated triggers.
 
+-  .. co:: CRS_WKT_EXTENSION
+      :choices: YES, NO
+      :default: NO
+      :since: 3.8
+
+      Defines whether to add the ``definition_12_063`` column to the
+      ``gpkg_spatial_ref_sys`` system table, according to
+      http://www.geopackage.org/spec/#extension_crs_wkt . The default is NO,
+      unless the tile gridded coverage extension is used.
+      With VERSION >= 1.4, a ``epoch`` column is also added.
+      WKT strings in ``definition_12_063`` will follow the
+      `WKT2:2015 standard <https://docs.ogc.org/is/12-063r5/12-063r5.html>`__
+      when possible, but may use the
+      `WKT2:2019 standard <https://docs.ogc.org/is/18-010r7/18-010r7.html>`__
+      for specific cases (dynamic CRS with coordinate epoch).
+      This option generally does not need to be specified, as the driver will
+      automatically update the ``gpkg_spatial_ref_sys`` table when needed, but
+      it may be useful to create GeoPackage datasets matching the expections of
+      other software or profiles (such as the DGIWG-GPKG profile).
+
 Overviews
 ---------
 

--- a/doc/source/drivers/vector/gpkg.rst
+++ b/doc/source/drivers/vector/gpkg.rst
@@ -303,6 +303,15 @@ raster) are available:
       it may be useful to create GeoPackage datasets matching the expections of
       other software or profiles (such as the DGIWG-GPKG profile).
 
+-  .. co:: METADATA_TABLES
+      :choices: YES, NO
+      :since: 3.8
+
+      Defines whether to add the metadata system tables.
+      By default, they are created on demand.
+      If NO is specified, they are not created, even if metadata is set.
+      If YES is specified, they are always created.
+
 
 Other options are available for raster. See the :ref:`GeoPackage raster <raster.gpkg>`
 documentation page.

--- a/doc/source/drivers/vector/gpkg.rst
+++ b/doc/source/drivers/vector/gpkg.rst
@@ -283,6 +283,27 @@ raster) are available:
       by GeoPackage v1.3 (see https://github.com/opengeospatial/geopackage/issues/530).
       When using UTC format, with a unspecified timezone, UTC will be assumed.
 
+-  .. dsco:: CRS_WKT_EXTENSION
+      :choices: YES, NO
+      :default: NO
+      :since: 3.8
+
+      Defines whether to add the ``definition_12_063`` column to the
+      ``gpkg_spatial_ref_sys`` system table, according to
+      http://www.geopackage.org/spec/#extension_crs_wkt . The default is NO,
+      unless the tile gridded coverage extension is used.
+      With VERSION >= 1.4, a ``epoch`` column is also added.
+      WKT strings in ``definition_12_063`` will follow the
+      `WKT2:2015 standard <https://docs.ogc.org/is/12-063r5/12-063r5.html>`__
+      when possible, but may use the
+      `WKT2:2019 standard <https://docs.ogc.org/is/18-010r7/18-010r7.html>`__
+      for specific cases (dynamic CRS with coordinate epoch).
+      This option generally does not need to be specified, as the driver will
+      automatically update the ``gpkg_spatial_ref_sys`` table when needed, but
+      it may be useful to create GeoPackage datasets matching the expections of
+      other software or profiles (such as the DGIWG-GPKG profile).
+
+
 Other options are available for raster. See the :ref:`GeoPackage raster <raster.gpkg>`
 documentation page.
 

--- a/ogr/ogrsf_frmts/gpkg/gdalgeopackagerasterband.cpp
+++ b/ogr/ogrsf_frmts/gpkg/gdalgeopackagerasterband.cpp
@@ -3683,8 +3683,14 @@ void GDALGeoPackageRasterBand::LoadBandMetadata()
                                 cpl::down_cast<GDALGeoPackageRasterBand *>(
                                     poGDS->GetRasterBand(l_nBand));
                             l_poBand->m_bHasReadMetadataFromStorage = true;
-                            l_poBand->GDALPamRasterBand::SetMetadata(
+
+                            char **papszMD = CSLDuplicate(
                                 oLocalMDMD.GetMetadata(*papszIter));
+                            papszMD = CSLMerge(
+                                papszMD,
+                                GDALGPKGMBTilesLikeRasterBand::GetMetadata(""));
+                            l_poBand->GDALPamRasterBand::SetMetadata(papszMD);
+                            CSLDestroy(papszMD);
                         }
                     }
                 }

--- a/ogr/ogrsf_frmts/gpkg/gdalgeopackagerasterband.cpp
+++ b/ogr/ogrsf_frmts/gpkg/gdalgeopackagerasterband.cpp
@@ -3793,7 +3793,8 @@ char **GDALGeoPackageRasterBand::GetMetadata(const char *pszDomain)
         !GDALGPKGMBTilesLikeRasterBand::GetMetadataItem("STATISTICS_MINIMUM") &&
         !GDALGPKGMBTilesLikeRasterBand::GetMetadataItem("STATISTICS_MAXIMUM"))
     {
-        m_aosMD = GDALGPKGMBTilesLikeRasterBand::GetMetadata(pszDomain);
+        m_aosMD.Assign(CSLDuplicate(
+            GDALGPKGMBTilesLikeRasterBand::GetMetadata(pszDomain)));
         if (!std::isnan(m_dfStatsMinFromTileAncillary))
         {
             m_aosMD.SetNameValue(

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -258,7 +258,7 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource,
     OGRErr DeleteRasterLayer(const char *pszLayerName);
     bool DeleteVectorOrRasterLayer(const char *pszLayerName);
 
-    bool ConvertGpkgSpatialRefSysToExtensionWkt2();
+    bool ConvertGpkgSpatialRefSysToExtensionWkt2(bool bForceEpoch);
     void DetectSpatialRefSysColumns();
 
     std::map<int, bool> m_oSetGPKGLayerWarnings{};

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -144,6 +144,7 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource,
         false;  // whether gpkg_spatial_ref_sys has a epoch column
     bool m_bNonSpatialTablesNonRegisteredInGpkgContentsFound = false;
     mutable int m_nHasMetadataTables = -1;  // -1 = unknown, 0 = false, 1 = true
+    int m_nCreateMetadataTables = -1;  // -1 = on demand, 0 = false, 1 = true
 
     CPLString m_osIdentifier{};
     bool m_bIdentifierAsCO = false;

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -408,8 +408,10 @@ const char *GDALGeoPackageDataset::GetSrsName(const OGRSpatialReference &oSRS)
 }
 
 /* Add the definition_12_063 column to an existing gpkg_spatial_ref_sys table */
-bool GDALGeoPackageDataset::ConvertGpkgSpatialRefSysToExtensionWkt2()
+bool GDALGeoPackageDataset::ConvertGpkgSpatialRefSysToExtensionWkt2(
+    bool bForceEpoch)
 {
+    const bool bAddEpoch = (m_nUserVersion >= GPKG_1_4_VERSION || bForceEpoch);
     auto oResultTable = SQLQuery(
         hDB, "SELECT srs_name, srs_id, organization, organization_coordsys_id, "
              "definition, description FROM gpkg_spatial_ref_sys LIMIT 100000");
@@ -420,15 +422,18 @@ bool GDALGeoPackageDataset::ConvertGpkgSpatialRefSysToExtensionWkt2()
 
     if (bRet)
     {
-        bRet =
-            SQLCommand(hDB, "CREATE TABLE gpkg_spatial_ref_sys_temp ("
-                            "srs_name TEXT NOT NULL,"
-                            "srs_id INTEGER NOT NULL PRIMARY KEY,"
-                            "organization TEXT NOT NULL,"
-                            "organization_coordsys_id INTEGER NOT NULL,"
-                            "definition TEXT NOT NULL,"
-                            "description TEXT, "
-                            "definition_12_063 TEXT NOT NULL)") == OGRERR_NONE;
+        std::string osSQL("CREATE TABLE gpkg_spatial_ref_sys_temp ("
+                          "srs_name TEXT NOT NULL,"
+                          "srs_id INTEGER NOT NULL PRIMARY KEY,"
+                          "organization TEXT NOT NULL,"
+                          "organization_coordsys_id INTEGER NOT NULL,"
+                          "definition TEXT NOT NULL,"
+                          "description TEXT, "
+                          "definition_12_063 TEXT NOT NULL");
+        if (bAddEpoch)
+            osSQL += ", epoch DOUBLE";
+        osSQL += ")";
+        bRet = SQLCommand(hDB, osSQL.c_str()) == OGRERR_NONE;
     }
 
     if (bRet)
@@ -531,10 +536,30 @@ bool GDALGeoPackageDataset::ConvertGpkgSpatialRefSysToExtensionWkt2()
                                          "'http://www.geopackage.org/spec120/"
                                          "#extension_crs_wkt', 'read-write')");
     }
+    if (bRet && bAddEpoch)
+    {
+        bRet =
+            OGRERR_NONE ==
+                SQLCommand(hDB, "UPDATE gpkg_extensions SET extension_name = "
+                                "'gpkg_crs_wkt_1_1' "
+                                "WHERE extension_name = 'gpkg_crs_wkt'") &&
+            OGRERR_NONE ==
+                SQLCommand(
+                    hDB,
+                    "INSERT INTO gpkg_extensions "
+                    "(table_name, column_name, extension_name, definition, "
+                    "scope) "
+                    "VALUES "
+                    "('gpkg_spatial_ref_sys', 'epoch', 'gpkg_crs_wkt_1_1', "
+                    "'http://www.geopackage.org/spec/#extension_crs_wkt', "
+                    "'read-write')");
+    }
     if (bRet)
     {
         SoftCommitTransaction();
         m_bHasDefinition12_063 = true;
+        if (bAddEpoch)
+            m_bHasEpochColumn = true;
     }
     else
     {
@@ -794,46 +819,57 @@ int GDALGeoPackageDataset::GetSrsId(const OGRSpatialReference &oSRS)
         }
     }
 
+    bool bConvertGpkgSpatialRefSysToExtensionWkt2 = false;
+    bool bForceEpoch = false;
     if (!m_bHasDefinition12_063 && pszWKT1 == nullptr &&
         (pszWKT2_2015 != nullptr || pszWKT2_2019 != nullptr))
     {
-        if (!ConvertGpkgSpatialRefSysToExtensionWkt2())
-        {
-            return DEFAULT_SRID;
-        }
+        bConvertGpkgSpatialRefSysToExtensionWkt2 = true;
     }
 
     // Add epoch column if needed
     if (oSRS.GetCoordinateEpoch() > 0 && !m_bHasEpochColumn)
     {
-        if (SoftStartTransaction() != OGRERR_NONE)
-            return DEFAULT_SRID;
-
-        if ((!m_bHasDefinition12_063 &&
-             !ConvertGpkgSpatialRefSysToExtensionWkt2()) ||
-            SQLCommand(hDB, "ALTER TABLE gpkg_spatial_ref_sys "
-                            "ADD COLUMN epoch DOUBLE") != OGRERR_NONE ||
-            SQLCommand(hDB, "UPDATE gpkg_extensions SET extension_name = "
-                            "'gpkg_crs_wkt_1_1' "
-                            "WHERE extension_name = 'gpkg_crs_wkt'") !=
-                OGRERR_NONE ||
-            SQLCommand(
-                hDB,
-                "INSERT INTO gpkg_extensions "
-                "(table_name, column_name, extension_name, definition, scope) "
-                "VALUES "
-                "('gpkg_spatial_ref_sys', 'epoch', 'gpkg_crs_wkt_1_1', "
-                "'http://www.geopackage.org/spec/#extension_crs_wkt', "
-                "'read-write')") != OGRERR_NONE)
+        if (m_bHasDefinition12_063)
         {
-            SoftRollbackTransaction();
-            return DEFAULT_SRID;
+            if (SoftStartTransaction() != OGRERR_NONE)
+                return DEFAULT_SRID;
+            if (SQLCommand(hDB, "ALTER TABLE gpkg_spatial_ref_sys "
+                                "ADD COLUMN epoch DOUBLE") != OGRERR_NONE ||
+                SQLCommand(hDB, "UPDATE gpkg_extensions SET extension_name = "
+                                "'gpkg_crs_wkt_1_1' "
+                                "WHERE extension_name = 'gpkg_crs_wkt'") !=
+                    OGRERR_NONE ||
+                SQLCommand(
+                    hDB,
+                    "INSERT INTO gpkg_extensions "
+                    "(table_name, column_name, extension_name, definition, "
+                    "scope) "
+                    "VALUES "
+                    "('gpkg_spatial_ref_sys', 'epoch', 'gpkg_crs_wkt_1_1', "
+                    "'http://www.geopackage.org/spec/#extension_crs_wkt', "
+                    "'read-write')") != OGRERR_NONE)
+            {
+                SoftRollbackTransaction();
+                return DEFAULT_SRID;
+            }
+
+            if (SoftCommitTransaction() != OGRERR_NONE)
+                return DEFAULT_SRID;
+
+            m_bHasEpochColumn = true;
         }
+        else
+        {
+            bConvertGpkgSpatialRefSysToExtensionWkt2 = true;
+            bForceEpoch = true;
+        }
+    }
 
-        if (SoftCommitTransaction() != OGRERR_NONE)
-            return DEFAULT_SRID;
-
-        m_bHasEpochColumn = true;
+    if (bConvertGpkgSpatialRefSysToExtensionWkt2 &&
+        !ConvertGpkgSpatialRefSysToExtensionWkt2(bForceEpoch))
+    {
+        return DEFAULT_SRID;
     }
 
     // Reuse the authority code number as SRS_ID if we can
@@ -5112,10 +5148,17 @@ int GDALGeoPackageDataset::Create(const char *pszFilename, int nXSize,
                 "organization_coordsys_id INTEGER NOT NULL,"
                 "definition  TEXT NOT NULL,"
                 "description TEXT";
-        if (CPLTestBool(CPLGetConfigOption("GPKG_ADD_DEFINITION_12_063", "NO")))
+        if (CPLTestBool(CSLFetchNameValueDef(papszOptions, "CRS_WKT_EXTENSION",
+                                             "NO")) ||
+            (nBandsIn != 0 && eDT != GDT_Byte))
         {
             m_bHasDefinition12_063 = true;
             osSQL += ", definition_12_063 TEXT NOT NULL";
+            if (m_nUserVersion >= GPKG_1_4_VERSION)
+            {
+                osSQL += ", epoch DOUBLE";
+                m_bHasEpochColumn = true;
+            }
         }
         osSQL += ")"
                  ";"
@@ -5384,6 +5427,27 @@ int GDALGeoPackageDataset::Create(const char *pszFilename, int nXSize,
                                     "#extension_crs_wkt', 'read-write')"))
             {
                 return FALSE;
+            }
+            if (m_bHasEpochColumn)
+            {
+                if (OGRERR_NONE !=
+                        SQLCommand(
+                            hDB, "UPDATE gpkg_extensions SET extension_name = "
+                                 "'gpkg_crs_wkt_1_1' "
+                                 "WHERE extension_name = 'gpkg_crs_wkt'") ||
+                    OGRERR_NONE !=
+                        SQLCommand(hDB, "INSERT INTO gpkg_extensions "
+                                        "(table_name, column_name, "
+                                        "extension_name, definition, scope) "
+                                        "VALUES "
+                                        "('gpkg_spatial_ref_sys', 'epoch', "
+                                        "'gpkg_crs_wkt_1_1', "
+                                        "'http://www.geopackage.org/spec/"
+                                        "#extension_crs_wkt', "
+                                        "'read-write')"))
+                {
+                    return FALSE;
+                }
             }
         }
     }
@@ -5803,7 +5867,7 @@ bool GDALGeoPackageDataset::CreateTileGriddedTable(char **papszOptions)
     if (!bHasEPSG4979)
     {
         if (!m_bHasDefinition12_063 &&
-            !ConvertGpkgSpatialRefSysToExtensionWkt2())
+            !ConvertGpkgSpatialRefSysToExtensionWkt2(/*bForceEpoch=*/false))
         {
             return false;
         }

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -4631,7 +4631,7 @@ bool GDALGeoPackageDataset::CreateMetadataTables()
 void GDALGeoPackageDataset::FlushMetadata()
 {
     if (!m_bMetadataDirty || m_poParentDS != nullptr ||
-        !CPLTestBool(CPLGetConfigOption("CREATE_METADATA_TABLES", "YES")))
+        m_nCreateMetadataTables == FALSE)
         return;
     m_bMetadataDirty = false;
 
@@ -5409,8 +5409,12 @@ int GDALGeoPackageDataset::Create(const char *pszFilename, int nXSize,
 
     if (!bFileExists)
     {
-        if (CPLTestBool(CPLGetConfigOption("CREATE_METADATA_TABLES", "NO")) &&
-            !CreateMetadataTables())
+        const char *pszMetadataTables =
+            CSLFetchNameValue(papszOptions, "METADATA_TABLES");
+        if (pszMetadataTables)
+            m_nCreateMetadataTables = int(CPLTestBool(pszMetadataTables));
+
+        if (m_nCreateMetadataTables == TRUE && !CreateMetadataTables())
             return FALSE;
 
         if (m_bHasDefinition12_063)

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedriver.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedriver.cpp
@@ -320,6 +320,12 @@ static GDALDataset *OGRGeoPackageDriverCreate(const char *pszFilename,
 static CPLErr OGRGeoPackageDriverDelete(const char *pszFilename)
 
 {
+    std::string osAuxXml(pszFilename);
+    osAuxXml += ".aux.xml";
+    VSIStatBufL sStat;
+    if (VSIStatL(osAuxXml.c_str(), &sStat) == 0)
+        CPL_IGNORE_RET_VAL(VSIUnlink(osAuxXml.c_str()));
+
     if (VSIUnlink(pszFilename) == 0)
         return CE_None;
     else

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedriver.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedriver.cpp
@@ -474,6 +474,8 @@ void GDALGPKGDriver::InitializeCreationOptionList()
         "  <Option name='CRS_WKT_EXTENSION' type='boolean' "
         "description='Whether to create the database with the crs_wkt "
         "extension'/>"
+        "  <Option name='METADATA_TABLES' type='boolean' "
+        "description='Whether to create the metadata related system tables'/>"
         "</CreationOptionList>";
 
     std::string osOptions(pszCOBegin);

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedriver.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedriver.cpp
@@ -465,6 +465,9 @@ void GDALGPKGDriver::InitializeCreationOptionList()
         "description='Whether to add a gpkg_ogr_contents table to keep feature "
         "count' default='YES'/>"
 #endif
+        "  <Option name='CRS_WKT_EXTENSION' type='boolean' "
+        "description='Whether to create the database with the crs_wkt "
+        "extension'/>"
         "</CreationOptionList>";
 
     std::string osOptions(pszCOBegin);


### PR DESCRIPTION
New features:
- add a CRS_WKT_EXTENSION=YES/NO dataset creation option to force addition of definition_12_063 column
-  add a METADATA_TABLES creation option to control creation of system metadata tables

Bug fixes:
- GDALGeoPackageRasterBand::GetMetadata(): fix use after free
- GDALGeoPackageRasterBand: fix missing GRID_CELL_ENCODING metadata item when there is other metadata
- remove .aux.xml file in Delete()
