### PR TITLE
Python bindings: accept options as dicts in CLI wrapper functions

### DIFF
--- a/autotest/utilities/test_gdal_footprint_lib.py
+++ b/autotest/utilities/test_gdal_footprint_lib.py
@@ -29,6 +29,7 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
+import collections
 import pathlib
 
 import ogrtest
@@ -391,3 +392,38 @@ def test_gdal_footprint_lib_dsco_lco(tmp_vsimem):
     ) as sql_lyr:
         assert sql_lyr.GetFeatureCount() == 0
     gdal.Unlink(out_filename)
+
+
+###############################################################################
+# Test option argument handling
+
+
+def test_gdaldem_footprint_dict_arguments():
+
+    opt = gdal.FootprintOptions(
+        "__RETURN_OPTION_LIST__",
+        datasetCreationOptions=collections.OrderedDict(
+            (("GEOMETRY_ENCODING", "WKT"), ("FORMAT", "NC4"))
+        ),
+        layerCreationOptions=collections.OrderedDict(
+            (("RECORD_DIM_NAME", "record"), ("STRING_DEFAULT_WIDTH", 10))
+        ),
+    )
+
+    dsco_idx = opt.index("-dsco")
+
+    assert opt[dsco_idx : dsco_idx + 4] == [
+        "-dsco",
+        "GEOMETRY_ENCODING=WKT",
+        "-dsco",
+        "FORMAT=NC4",
+    ]
+
+    lco_idx = opt.index("-lco")
+
+    assert opt[lco_idx : lco_idx + 4] == [
+        "-lco",
+        "RECORD_DIM_NAME=record",
+        "-lco",
+        "STRING_DEFAULT_WIDTH=10",
+    ]

--- a/autotest/utilities/test_gdal_grid_lib.py
+++ b/autotest/utilities/test_gdal_grid_lib.py
@@ -30,6 +30,7 @@
 ###############################################################################
 
 import array
+import collections
 import struct
 
 import gdaltest
@@ -1028,3 +1029,21 @@ def test_gdal_grid_lib_skip_nan_zvalue():
             10,
         )
     )
+
+
+###############################################################################
+# Test option argument handling
+
+
+def test_gdal_grid_lib_dict_arguments():
+
+    opt = gdal.GridOptions(
+        "__RETURN_OPTION_LIST__",
+        creationOptions=collections.OrderedDict(
+            (("COMPRESS", "DEFLATE"), ("LEVEL", 4))
+        ),
+    )
+
+    ind = opt.index("-co")
+
+    assert opt[ind : ind + 4] == ["-co", "COMPRESS=DEFLATE", "-co", "LEVEL=4"]

--- a/autotest/utilities/test_gdal_rasterize_lib.py
+++ b/autotest/utilities/test_gdal_rasterize_lib.py
@@ -30,6 +30,7 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
+import collections
 import struct
 
 import gdaltest
@@ -641,3 +642,21 @@ def test_gdal_rasterize_lib_too_small_resolution():
 
     with pytest.raises(Exception, match="Invalid computed output raster size"):
         gdal.Rasterize("", vector_ds, format="MEM", xRes=1, yRes=1e-20)
+
+
+###############################################################################
+# Test option argument handling
+
+
+def test_gdal_rasterize_lib_dict_arguments():
+
+    opt = gdal.RasterizeOptions(
+        "__RETURN_OPTION_LIST__",
+        creationOptions=collections.OrderedDict(
+            (("COMPRESS", "DEFLATE"), ("LEVEL", 4))
+        ),
+    )
+
+    ind = opt.index("-co")
+
+    assert opt[ind : ind + 4] == ["-co", "COMPRESS=DEFLATE", "-co", "LEVEL=4"]

--- a/autotest/utilities/test_gdal_translate_lib.py
+++ b/autotest/utilities/test_gdal_translate_lib.py
@@ -29,6 +29,7 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
+import collections
 import os
 import shutil
 import struct
@@ -1125,3 +1126,33 @@ def test_gdal_translate_lib_scale_and_unscale_incompatible():
             unscale=True,
             outputType=gdal.GDT_UInt16,
         )
+
+
+###############################################################################
+# Test option argument handling
+
+
+def test_gdal_translate_lib_dict_arguments():
+
+    opt = gdal.TranslateOptions(
+        "__RETURN_OPTION_LIST__",
+        creationOptions=collections.OrderedDict(
+            (("COMPRESS", "DEFLATE"), ("LEVEL", 4))
+        ),
+        metadataOptions=collections.OrderedDict(
+            (("AREA_OR_POINT", "Area"), ("TIFFTAG_XRESOLUTION", 123))
+        ),
+    )
+
+    co_idx = opt.index("-co")
+
+    assert opt[co_idx : co_idx + 4] == ["-co", "COMPRESS=DEFLATE", "-co", "LEVEL=4"]
+
+    mo_idx = opt.index("-mo")
+
+    assert opt[mo_idx : mo_idx + 4] == [
+        "-mo",
+        "AREA_OR_POINT=Area",
+        "-mo",
+        "TIFFTAG_XRESOLUTION=123",
+    ]

--- a/autotest/utilities/test_gdaldem_lib.py
+++ b/autotest/utilities/test_gdaldem_lib.py
@@ -29,6 +29,7 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
+import collections
 import struct
 
 import gdaltest
@@ -696,3 +697,21 @@ def test_gdaldem_lib_nodata():
     if cs != 10:
         print(ds.ReadAsArray())  # Should be 0 0 0 0 181 0 0 0 0
         pytest.fail("Bad checksum")
+
+
+###############################################################################
+# Test option argument handling
+
+
+def test_gdaldem_lib_dict_arguments():
+
+    opt = gdal.DEMProcessingOptions(
+        "__RETURN_OPTION_LIST__",
+        creationOptions=collections.OrderedDict(
+            (("COMPRESS", "DEFLATE"), ("LEVEL", 4))
+        ),
+    )
+
+    ind = opt.index("-co")
+
+    assert opt[ind : ind + 4] == ["-co", "COMPRESS=DEFLATE", "-co", "LEVEL=4"]

--- a/autotest/utilities/test_gdalmdimtranslate_lib.py
+++ b/autotest/utilities/test_gdalmdimtranslate_lib.py
@@ -29,6 +29,7 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
+import collections
 import pathlib
 import struct
 
@@ -882,3 +883,21 @@ def XXXX_test_all():
         test_gdalmdimtranslate_two_groups()
         test_gdalmdimtranslate_subset()
         test_gdalmdimtranslate_scaleaxes()
+
+
+###############################################################################
+# Test option argument handling
+
+
+def test_gdalmdimtranslate_dict_arguments():
+
+    opt = gdal.MultiDimTranslateOptions(
+        "__RETURN_OPTION_LIST__",
+        creationOptions=collections.OrderedDict(
+            (("COMPRESS", "DEFLATE"), ("LEVEL", 4))
+        ),
+    )
+
+    co_idx = opt.index("-co")
+
+    assert opt[co_idx : co_idx + 4] == ["-co", "COMPRESS=DEFLATE", "-co", "LEVEL=4"]

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -30,6 +30,7 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
+import collections
 import shutil
 import struct
 
@@ -3659,3 +3660,28 @@ def test_gdalwarp_lib_cutline_crossing_antimeridian_in_EPSG_32601_and_raster_in_
         ]
         == 9
     )
+
+
+###############################################################################
+# Test option argument handling
+
+
+def test_gdalwarp_lib_dict_arguments():
+
+    opt = gdal.WarpOptions(
+        "__RETURN_OPTION_LIST__",
+        creationOptions=collections.OrderedDict(
+            (("COMPRESS", "DEFLATE"), ("LEVEL", 4))
+        ),
+    )
+
+    assert opt == ["-co", "COMPRESS=DEFLATE", "-co", "LEVEL=4"]
+
+    opt = gdal.WarpOptions(
+        "__RETURN_OPTION_LIST__",
+        warpOptions=collections.OrderedDict(
+            (("SKIP_NOSOURCE", "YES"), ("NUM_THREADS", 2))
+        ),
+    )
+
+    assert opt == ["-wo", "SKIP_NOSOURCE=YES", "-wo", "NUM_THREADS=2"]

--- a/autotest/utilities/test_nearblack_lib.py
+++ b/autotest/utilities/test_nearblack_lib.py
@@ -31,6 +31,7 @@
 
 
 import array
+import collections
 import pathlib
 
 import pytest
@@ -557,3 +558,17 @@ def test_nearblack_lib_floodfill_concave_from_bottom_non_black():
         maxNonBlack=1,
         alg="floodfill",
     )
+
+
+def test_nearblack_lib_dict_arguments():
+
+    opt = gdal.NearblackOptions(
+        "__RETURN_OPTION_LIST__",
+        creationOptions=collections.OrderedDict(
+            (("COMPRESS", "DEFLATE"), ("LEVEL", 4))
+        ),
+    )
+
+    ind = opt.index("-co")
+
+    assert opt[ind : ind + 4] == ["-co", "COMPRESS=DEFLATE", "-co", "LEVEL=4"]

--- a/autotest/utilities/test_ogr2ogr_lib.py
+++ b/autotest/utilities/test_ogr2ogr_lib.py
@@ -29,6 +29,7 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
+import collections
 import json
 import pathlib
 import tempfile
@@ -1934,3 +1935,38 @@ def test_ogr2ogr_lib_geojson_output(tmp_path):
     with ogr.Open(tmpfilename) as ds:
         lyr = ds.GetLayer(0)
         assert lyr.GetFeatureCount() == 11
+
+
+###############################################################################
+# Test option argument handling
+
+
+def test_ogr2ogr_lib_dict_arguments():
+
+    opt = gdal.VectorTranslateOptions(
+        "__RETURN_OPTION_LIST__",
+        datasetCreationOptions=collections.OrderedDict(
+            (("GEOMETRY_ENCODING", "WKT"), ("FORMAT", "NC4"))
+        ),
+        layerCreationOptions=collections.OrderedDict(
+            (("RECORD_DIM_NAME", "record"), ("STRING_DEFAULT_WIDTH", 10))
+        ),
+    )
+
+    dsco_idx = opt.index("-dsco")
+
+    assert opt[dsco_idx : dsco_idx + 4] == [
+        "-dsco",
+        "GEOMETRY_ENCODING=WKT",
+        "-dsco",
+        "FORMAT=NC4",
+    ]
+
+    lco_idx = opt.index("-lco")
+
+    assert opt[lco_idx : lco_idx + 4] == [
+        "-lco",
+        "RECORD_DIM_NAME=record",
+        "-lco",
+        "STRING_DEFAULT_WIDTH=10",
+    ]

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -1917,7 +1917,7 @@ def TranslateOptions(options=None, format=None,
     yRes:
         output vertical resolution
     creationOptions:
-        list of creation options
+        list or dict of creation options
     srcWin:
         subwindow in pixels to extract: [left_x, top_y, width, height]
     projWin:
@@ -1937,7 +1937,7 @@ def TranslateOptions(options=None, format=None,
     outputGeotransform:
         assigned geotransform matrix (array of 6 values) (mutually exclusive with outputBounds)
     metadataOptions:
-        list of metadata options
+        list or dict of metadata options
     outputSRS:
         assigned output SRS
     nogcp:
@@ -1966,6 +1966,7 @@ def TranslateOptions(options=None, format=None,
 
     # Only used for tests
     return_option_list = options == '__RETURN_OPTION_LIST__'
+
     if return_option_list:
         options = []
     else:
@@ -1991,6 +1992,9 @@ def TranslateOptions(options=None, format=None,
         if creationOptions is not None:
             if isinstance(creationOptions, str):
                 new_options += ['-co', creationOptions]
+            elif isinstance(creationOptions, dict):
+                for k, v in creationOptions.items():
+                    new_options += ['-co', f'{k}={v}']
             else:
                 for opt in creationOptions:
                     new_options += ['-co', opt]
@@ -2020,6 +2024,9 @@ def TranslateOptions(options=None, format=None,
         if metadataOptions is not None:
             if isinstance(metadataOptions, str):
                 new_options += ['-mo', metadataOptions]
+            elif isinstance(metadataOptions, dict):
+                for k, v in metadataOptions.items():
+                    new_options += ['-mo', f'{k}={v}']
             else:
                 for opt in metadataOptions:
                     new_options += ['-mo', opt]
@@ -2159,7 +2166,7 @@ def WarpOptions(options=None, format=None,
     workingType:
         working type (gdalconst.GDT_Byte, etc...)
     warpOptions:
-        list of warping options
+        list or dict of warping options
     errorThreshold:
         error threshold for approximation transformer (in pixels)
     warpMemoryLimit:
@@ -2167,7 +2174,7 @@ def WarpOptions(options=None, format=None,
     resampleAlg:
         resampling mode
     creationOptions:
-        list of creation options
+        list or dict of creation options
     srcNodata:
         source nodata value(s)
     dstNodata:
@@ -2183,7 +2190,7 @@ def WarpOptions(options=None, format=None,
     polynomialOrder:
         order of polynomial GCP interpolation
     transformerOptions:
-        list of transformer options
+        list or dict of transformer options
     cutlineDSName:
         cutline dataset name
     cutlineLayer:
@@ -2256,8 +2263,12 @@ def WarpOptions(options=None, format=None,
         if dstAlpha:
             new_options += ['-dstalpha']
         if warpOptions is not None:
-            for opt in warpOptions:
-                new_options += ['-wo', str(opt)]
+            if isinstance(warpOptions, dict):
+                for k, v in warpOptions.items():
+                    new_options += ['-wo', f'{k}={v}']
+            else:
+                for opt in warpOptions:
+                    new_options += ['-wo', str(opt)]
         if errorThreshold is not None:
             new_options += ['-et', _strHighPrec(errorThreshold)]
         if resampleAlg is not None:
@@ -2286,8 +2297,12 @@ def WarpOptions(options=None, format=None,
         if warpMemoryLimit is not None:
             new_options += ['-wm', str(warpMemoryLimit)]
         if creationOptions is not None:
-            for opt in creationOptions:
-                new_options += ['-co', opt]
+            if isinstance(creationOptions, dict):
+                for k, v in creationOptions.items():
+                    new_options += ['-co', f'{k}={v}']
+            else:
+                for opt in creationOptions:
+                    new_options += ['-co', opt]
         if srcNodata is not None:
             new_options += ['-srcnodata', str(srcNodata)]
         if dstNodata is not None:
@@ -2303,8 +2318,12 @@ def WarpOptions(options=None, format=None,
         if polynomialOrder is not None:
             new_options += ['-order', str(polynomialOrder)]
         if transformerOptions is not None:
-            for opt in transformerOptions:
-                new_options += ['-to', opt]
+            if isinstance(transformerOptions, dict):
+                for k, v in transformerOptions.items():
+                    new_options += ['-to', opt]
+            else:
+                for opt in transformerOptions:
+                    new_options += ['-to', opt]
         if cutlineDSName is not None:
             new_options += ['-cutline', str(cutlineDSName)]
         if cutlineLayer is not None:
@@ -2460,9 +2479,9 @@ def VectorTranslateOptions(options=None, format=None,
         SRS in which the spatFilter is expressed. If not specified, it is assumed to be
         the one of the layer(s)
     datasetCreationOptions:
-        list of dataset creation options
+        list or dict of dataset creation options
     layerCreationOptions:
-        list of layer creation options
+        list or dict of layer creation options
     layers:
         list of layers to convert
     layerName:
@@ -2533,7 +2552,13 @@ def VectorTranslateOptions(options=None, format=None,
     callback_data:
         user data for callback
     """
-    options = [] if options is None else options
+
+    # Only used for tests
+    return_option_list = options == '__RETURN_OPTION_LIST__'
+    if return_option_list:
+        options = []
+    else:
+        options = [] if options is None else options
 
     if isinstance(options, str):
         new_options = ParseCommandLine(options)
@@ -2582,11 +2607,20 @@ def VectorTranslateOptions(options=None, format=None,
             new_options += ['-select', val]
 
         if datasetCreationOptions is not None:
-            for opt in datasetCreationOptions:
-                new_options += ['-dsco', opt]
+            if isinstance(datasetCreationOptions, dict):
+                for k, v in datasetCreationOptions.items():
+                    new_options += ['-dsco', f'{k}={v}']
+            else:
+                for opt in datasetCreationOptions:
+                    new_options += ['-dsco', opt]
+
         if layerCreationOptions is not None:
-            for opt in layerCreationOptions:
-                new_options += ['-lco', opt]
+            if isinstance(layerCreationOptions, dict):
+                for k, v in layerCreationOptions.items():
+                    new_options += ['-lco', f'{k}={v}']
+            else:
+                for opt in layerCreationOptions:
+                    new_options += ['-lco', opt]
 
         if layers is not None:
             if isinstance(layers, str):
@@ -2685,6 +2719,9 @@ def VectorTranslateOptions(options=None, format=None,
     if callback is not None:
         new_options += ['-progress']
 
+    if return_option_list:
+        return new_options
+
     return (GDALVectorTranslateOptions(new_options), callback, callback_data)
 
 
@@ -2739,7 +2776,7 @@ def DEMProcessingOptions(options=None, colorFilename=None, format=None,
     format:
         output format ("GTiff", etc...)
     creationOptions:
-        list of creation options
+        list or dict of creation options
     computeEdges:
         whether to compute values at raster edges.
     alg:
@@ -2775,7 +2812,12 @@ def DEMProcessingOptions(options=None, colorFilename=None, format=None,
     callback_data:
         user data for callback
     """
-    options = [] if options is None else options
+    # Only used for tests
+    return_option_list = options == '__RETURN_OPTION_LIST__'
+    if return_option_list:
+        options = []
+    else:
+        options = [] if options is None else options
 
     if isinstance(options, str):
         new_options = ParseCommandLine(options)
@@ -2784,8 +2826,12 @@ def DEMProcessingOptions(options=None, colorFilename=None, format=None,
         if format is not None:
             new_options += ['-of', format]
         if creationOptions is not None:
-            for opt in creationOptions:
-                new_options += ['-co', opt]
+            if isinstance(creationOptions, dict):
+                for k, v in creationOptions.items():
+                    new_options += ['-co', f'{k}={v}']
+            else:
+                for opt in creationOptions:
+                    new_options += ['-co', opt]
         if computeEdges:
             new_options += ['-compute_edges']
         if alg:
@@ -2822,6 +2868,9 @@ def DEMProcessingOptions(options=None, colorFilename=None, format=None,
                 raise ValueError("Unsupported value for colorSelection")
         if addAlpha:
             new_options += ['-alpha']
+
+    if return_option_list:
+        return new_options
 
     return (GDALDEMProcessingOptions(new_options), colorFilename, callback, callback_data)
 
@@ -2869,7 +2918,7 @@ def NearblackOptions(options=None, format=None,
     format:
         output format ("GTiff", etc...)
     creationOptions:
-        list of creation options
+        list or dict of creation options
     white:
         whether to search for nearly white (255) pixels instead of nearly black pixels.
     colors:
@@ -2889,7 +2938,12 @@ def NearblackOptions(options=None, format=None,
     callback_data:
         user data for callback
     """
-    options = [] if options is None else options
+    # Only used for tests
+    return_option_list = options == '__RETURN_OPTION_LIST__'
+    if return_option_list:
+        options = []
+    else:
+        options = [] if options is None else options
 
     if isinstance(options, str):
         new_options = ParseCommandLine(options)
@@ -2898,8 +2952,12 @@ def NearblackOptions(options=None, format=None,
         if format is not None:
             new_options += ['-of', format]
         if creationOptions is not None:
-            for opt in creationOptions:
-                new_options += ['-co', opt]
+            if isinstance(creationOptions, dict):
+                for k, v in creationOptions.items():
+                    new_options += ['-co', f'{k}={v}']
+            else:
+                for opt in creationOptions:
+                    new_options += ['-co', opt]
         if white:
             new_options += ['-white']
         if colors is not None:
@@ -2920,6 +2978,9 @@ def NearblackOptions(options=None, format=None,
             new_options += ['-setmask']
         if alg:
             new_options += ['-alg', alg]
+
+    if return_option_list:
+        return new_options
 
     return (GDALNearblackOptions(new_options), callback, callback_data)
 
@@ -2987,7 +3048,7 @@ def GridOptions(options=None, format=None,
     height:
         height of the output raster in pixel
     creationOptions:
-        list of creation options
+        list or dict of creation options
     outputBounds:
         assigned output bounds:
         [ulx, uly, lrx, lry]
@@ -3021,7 +3082,13 @@ def GridOptions(options=None, format=None,
     callback_data:
         user data for callback
     """
-    options = [] if options is None else options
+    # Only used for tests
+    return_option_list = options == '__RETURN_OPTION_LIST__'
+
+    if return_option_list:
+        options = []
+    else:
+        options = [] if options is None else options
 
     if isinstance(options, str):
         new_options = ParseCommandLine(options)
@@ -3034,8 +3101,12 @@ def GridOptions(options=None, format=None,
         if width != 0 or height != 0:
             new_options += ['-outsize', str(width), str(height)]
         if creationOptions is not None:
-            for opt in creationOptions:
-                new_options += ['-co', opt]
+            if isinstance(creationOptions, dict):
+                for k, v in creationOptions.items():
+                    new_options += ['-co', f'{k}={v}']
+            else:
+                for opt in creationOptions:
+                    new_options += ['-co', opt]
         if outputBounds is not None:
             new_options += ['-txe', _strHighPrec(outputBounds[0]), _strHighPrec(outputBounds[2]), '-tye', _strHighPrec(outputBounds[1]), _strHighPrec(outputBounds[3])]
         if outputSRS is not None:
@@ -3060,6 +3131,9 @@ def GridOptions(options=None, format=None,
             new_options += ['-z_multiply', str(z_multiply)]
         if spatFilter is not None:
             new_options += ['-spat', str(spatFilter[0]), str(spatFilter[1]), str(spatFilter[2]), str(spatFilter[3])]
+
+    if return_option_list:
+        return new_options
 
     return (GDALGridOptions(new_options), callback, callback_data)
 
@@ -3112,14 +3186,14 @@ def RasterizeOptions(options=None, format=None,
     outputType:
         output type (gdalconst.GDT_Byte, etc...)
     creationOptions:
-        list of creation options
+        list or dict of creation options
     outputBounds:
         assigned output bounds:
         [minx, miny, maxx, maxy]
     outputSRS:
         assigned output SRS
     transformerOptions:
-        list of transformer options
+        list or dict of transformer options
     width:
         width of the output raster in pixel
     height:
@@ -3171,7 +3245,14 @@ def RasterizeOptions(options=None, format=None,
     callback_data:
         user data for callback
     """
-    options = [] if options is None else options
+
+    # Only used for tests
+    return_option_list = options == '__RETURN_OPTION_LIST__'
+
+    if return_option_list:
+        options = []
+    else:
+        options = [] if options is None else options
 
     if isinstance(options, str):
         new_options = ParseCommandLine(options)
@@ -3182,8 +3263,12 @@ def RasterizeOptions(options=None, format=None,
         if outputType != gdalconst.GDT_Unknown:
             new_options += ['-ot', GetDataTypeName(outputType)]
         if creationOptions is not None:
-            for opt in creationOptions:
-                new_options += ['-co', opt]
+            if isinstance(creationOptions, dict):
+                for k, v in creationOptions.items():
+                    new_options += ['-co', f'{k}={v}']
+            else:
+                for opt in creationOptions:
+                    new_options += ['-co', opt]
         if bands is not None:
             for b in bands:
                 new_options += ['-b', str(b)]
@@ -3200,8 +3285,12 @@ def RasterizeOptions(options=None, format=None,
         if outputSRS is not None:
             new_options += ['-a_srs', str(outputSRS)]
         if transformerOptions is not None:
-            for opt in transformerOptions:
-                new_options += ['-to', opt]
+            if isinstance(transformerOptions, dict):
+                for k, v in transformerOptions.items():
+                    new_options += ['-to', f'{k}={v}']
+            else:
+                for opt in transformerOptions:
+                    new_options += ['-to', opt]
         if width is not None and height is not None:
             new_options += ['-ts', str(width), str(height)]
         if xRes is not None and yRes is not None:
@@ -3240,6 +3329,9 @@ def RasterizeOptions(options=None, format=None,
             new_options += ['-optim', str(optim)]
         if add:
             new_options += ['-add']
+
+    if return_option_list:
+        return new_options
 
     return (GDALRasterizeOptions(new_options), callback, callback_data)
 
@@ -3310,9 +3402,9 @@ def FootprintOptions(options=None,
     dstSRS:
         output SRS
     datasetCreationOptions:
-        list of dataset creation options
+        list or dict of dataset creation options
     layerCreationOptions:
-        list of layer creation options
+        list or dict of layer creation options
     splitPolys:
         whether to split multipolygons as several polygons
     convexHull:
@@ -3330,7 +3422,14 @@ def FootprintOptions(options=None,
     callback_data:
         user data for callback
     """
-    options = [] if options is None else options
+
+    # Only used for tests
+    return_option_list = options == '__RETURN_OPTION_LIST__'
+
+    if return_option_list:
+        options = []
+    else:
+        options = [] if options is None else options
 
     if isinstance(options, str):
         new_options = ParseCommandLine(options)
@@ -3362,11 +3461,22 @@ def FootprintOptions(options=None,
         if layerName is not None:
             new_options += ['-lyr_name', layerName]
         if datasetCreationOptions is not None:
-            for opt in datasetCreationOptions:
-                new_options += ['-dsco', opt]
+            if isinstance(datasetCreationOptions, dict):
+                for k, v in datasetCreationOptions.items():
+                    new_options += ['-dsco', f'{k}={v}']
+            else:
+                for opt in datasetCreationOptions:
+                    new_options += ['-dsco', opt]
         if layerCreationOptions is not None:
-            for opt in layerCreationOptions:
-                new_options += ['-lco', opt]
+            if isinstance(layerCreationOptions, dict):
+                for k, v in layerCreationOptions.items():
+                    new_options += ['-lco', f'{k}={v}']
+            else:
+                for opt in layerCreationOptions:
+                    new_options += ['-lco', opt]
+
+    if return_option_list:
+        return new_options
 
     return (GDALFootprintOptions(new_options), callback, callback_data)
 
@@ -3634,7 +3744,7 @@ def MultiDimTranslateOptions(options=None, format=None, creationOptions=None,
     format:
         output format ("GTiff", etc...)
     creationOptions:
-        list of creation options
+        list or dict of creation options
     arraySpecs:
         list of array specifications, each of them being an array name or
         "name={src_array_name},dstname={dst_name},transpose=[1,0],view=[:,::-1]"
@@ -3652,7 +3762,14 @@ def MultiDimTranslateOptions(options=None, format=None, creationOptions=None,
     callback_data:
         user data for callback
     """
-    options = [] if options is None else options
+
+    # Only used for tests
+    return_option_list = options == '__RETURN_OPTION_LIST__'
+
+    if return_option_list:
+        options = []
+    else:
+        options = [] if options is None else options
 
     if isinstance(options, str):
         new_options = ParseCommandLine(options)
@@ -3661,8 +3778,12 @@ def MultiDimTranslateOptions(options=None, format=None, creationOptions=None,
         if format is not None:
             new_options += ['-of', format]
         if creationOptions is not None:
-            for opt in creationOptions:
-                new_options += ['-co', opt]
+            if isinstance(creationOptions, dict):
+                for k, v in creationOptions.items():
+                    new_options += ['-co', f'{k}={v}']
+            else:
+                for opt in creationOptions:
+                    new_options += ['-co', opt]
         if arraySpecs is not None:
             for s in arraySpecs:
                 new_options += ['-array', s]
@@ -3675,6 +3796,9 @@ def MultiDimTranslateOptions(options=None, format=None, creationOptions=None,
         if scaleAxesSpecs is not None:
             for s in scaleAxesSpecs:
                 new_options += ['-scaleaxes', s]
+
+    if return_option_list:
+        return new_options
 
     return (GDALMultiDimTranslateOptions(new_options), callback, callback_data)
 


### PR DESCRIPTION
## What does this PR do?

Allows dictionaries to be used for `creationOptions`, `datasetCreationOptions`, `layerCreationOptions`, etc. in high-level functions like `gdal.VectorTranslate`.

## What are related issues/pull requests?

#8073

## Tasklist

 - [x] Add test case(s)
 - [x] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
