### PR TITLE
Don't use jpeg if disabled

### DIFF
--- a/cmake/helpers/CheckDependentLibraries.cmake
+++ b/cmake/helpers/CheckDependentLibraries.cmake
@@ -416,7 +416,7 @@ if (GDAL_USE_JPEG AND (JPEG_LIBRARY MATCHES ".*turbojpeg\.(so|lib)"))
       "JPEG_LIBRARY should point to a library with libjpeg ABI, not TurboJPEG. See https://libjpeg-turbo.org/About/TurboJPEG for the difference"
     )
 endif ()
-if (TARGET JPEG::JPEG)
+if (GDAL_USE_JPEG AND TARGET JPEG::JPEG)
   set(EXPECTED_JPEG_LIB_VERSION "" CACHE STRING "Expected libjpeg version number")
   mark_as_advanced(GDAL_CHECK_PACKAGE_${name}_NAMES)
   if (EXPECTED_JPEG_LIB_VERSION)


### PR DESCRIPTION
Fixes https://github.com/microsoft/vcpkg/issues/33565

When `-DGDAL_USE_JPEG=OFF` is used and gdal is found, the target `JPEG::JPEG` exists. Based on this some checks are executed and HAVE_JPEGTURBO_DUAL_MODE_8_12 is set to `ON`.  
Then the following if gets true and gdal tries to use jpeg: 
https://github.com/OSGeo/gdal/blob/d12af24fa7496d7bf2aa850453230278dd9070e4/frmts/mrf/CMakeLists.txt#L35-L38

Since we don't want to use jpeg anyway, we can simply skip the checks (`check_c_source_compiles`).