### PR TITLE
autotest: ogr_mitab.py: fix format parametrization of mapinfo_ds fixture

### DIFF
--- a/autotest/ogr/ogr_mitab.py
+++ b/autotest/ogr/ogr_mitab.py
@@ -60,7 +60,7 @@ def mapinfo_ds(request, tmp_path, poly_feat):
 
     if hasattr(request, "param"):
         if request.param == "MIF":
-            ds_loc = tmp_path
+            ds_loc = tmp_path / "wrk.mif"
         else:
             assert request.param == "TAB"
 


### PR DESCRIPTION
## What does this PR do?

Fixes bug wherein `mapinfo_ds` incorrectly produced a `.tab` when a `.mif` was requested. This lead to a loss of test coverage for `.mif` files.

## What are related issues/pull requests?

Introduced in #8333

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed