### PR TITLE
VRT 'scale' 'unscale' for vrt:// connection (2nd attempt)

### DIFF
--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1697,7 +1697,7 @@ For example:
 
 The supported options currently are ``bands``, ``a_srs``, ``a_ullr``, ``ovr``, ``expand``,
 ``a_scale``, ``a_offset``, ``ot``, ``gcp``, ``if``, ``scale``, ``exponent``, ``outsize``, ``projwin``,
-``tr``, ``r``, ``srcwin``, ``a_gt`` and ``oo``.
+  ``tr``, ``r``, ``srcwin``, ``a_gt``, ``oo`` and ``unscale``.
 
 Other options may be added in the future.
 
@@ -1741,8 +1741,7 @@ This can also be seen as an equivalent of running `gdal_translate -of VRT -if DR
 
 The effect of the ``scale`` option (added in GDAL 3.7) is to rescale the input pixel values from the
 range **src_min** to **src_max** to the range **dst_min** to **dst_max**  ``src_min,src_max[,dst_min,dst_max]``
-either 2 or 4 comma separated values. The same rules apply for the source and destination ranges, and ``scale_bn`` syntax may be used as it is
-with (:ref:`gdal_translate`).
+either 2 or 4 comma separated values. The same rules apply for the source and destination ranges, and ``scale_bn`` syntax may be used as it is with (:ref:`gdal_translate`).  The option ``scale=true`` (default if unspecified is ``scale=false``) may also be used without value arguments (added in GDAL 3.8), where it results in the output range 0,255 from whatever the source range is. Do consider the need for also using ``ot`` option in order to accomodate the intended output range.
 
 The effect of the ``exponent`` option (added in GDAL 3.7) is to apply non-linear scaling with a power function,
 a single value to be used with the ``scale`` option. The same ``exponent_bn`` syntax may be used in combination with ``scale_bn`` to
@@ -1769,6 +1768,8 @@ the order 'gt(0),gt(1),gt(2),gt(3),gt(4),gt(5)'.
 
 The effect of the ``oo`` option (added in GDAL 3.8) is to set driver-specific dataset open options, multiple values are allowed. The value
 consists of string key value pairs with multiple pairs separated by commas e.g. ``oo=<key>=<val>`` or . ``oo=<key1>=<val1>,<key2>=<val2>,...``. This is applied in the same way as (:ref:`gdal_translate`).
+
+The effect of the ``unscale`` option (added in GDAL 3.8) is to apply the scale/offset metadata for the bands to convert scaled values to unscaled values. Do apply this use syntax ``unscale=true``, or ``unscale=false`` which is the default behaviour if not specified. Do consider the need for also using ``ot`` option in order to accomodate the intended output range, see more details for the same argument as with (:ref:`gdal_translate`).
 
 The options may be chained together separated by '&'. (Beware the need for quoting to protect
 the ampersand).

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1697,7 +1697,7 @@ For example:
 
 The supported options currently are ``bands``, ``a_srs``, ``a_ullr``, ``ovr``, ``expand``,
 ``a_scale``, ``a_offset``, ``ot``, ``gcp``, ``if``, ``scale``, ``exponent``, ``outsize``, ``projwin``,
-  ``tr``, ``r``, ``srcwin``, ``a_gt``, ``oo`` and ``unscale``.
+``tr``, ``r``, ``srcwin``, ``a_gt``, ``oo`` and ``unscale``.
 
 Other options may be added in the future.
 

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -1020,7 +1020,6 @@ GDALDataset *VRTDataset::OpenVRTProtocol(const char *pszSpec)
                 }
                 aosOpenOptions = CSLTokenizeString2(pszValue, ",", 0);
             }
-            CPLFree(pszKey);
         }
         if (!pszKey)
         {
@@ -1031,6 +1030,7 @@ GDALDataset *VRTDataset::OpenVRTProtocol(const char *pszSpec)
                      aosTokens[i]);
             return nullptr;
         }
+        CPLFree(pszKey);
     }
 
     // We don't open in GDAL_OF_SHARED mode to avoid issues when we open a
@@ -1168,8 +1168,6 @@ GDALDataset *VRTDataset::OpenVRTProtocol(const char *pszSpec)
                 CPLStringList aosScaleParams(
                     CSLTokenizeString2(pszValue, ",", 0));
 
-                CPLDebug("VRT", "aosScaleParams.size(): %i",
-                         aosScaleParams.size());
                 if (!(aosScaleParams.size() == 2) &&
                     !(aosScaleParams.size() == 4) &&
                     !(aosScaleParams.size() == 1))

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -994,7 +994,7 @@ GDALDataset *VRTDataset::OpenVRTProtocol(const char *pszSpec)
     {
         char *pszKey = nullptr;
         const char *pszValue = CPLParseNameValue(aosTokens[i], &pszKey);
-        if (pszKey)
+        if (pszKey && pszValue)
         {
             if (EQUAL(pszKey, "if"))
             {
@@ -1021,6 +1021,15 @@ GDALDataset *VRTDataset::OpenVRTProtocol(const char *pszSpec)
                 aosOpenOptions = CSLTokenizeString2(pszValue, ",", 0);
             }
             CPLFree(pszKey);
+        }
+        if (!pszKey)
+        {
+
+            CPLError(CE_Failure, CPLE_NotSupported,
+                     "Invalid option specification: %s\n"
+                     "must be in the form 'key=value'",
+                     aosTokens[i]);
+            return nullptr;
         }
     }
 
@@ -1156,26 +1165,41 @@ GDALDataset *VRTDataset::OpenVRTProtocol(const char *pszSpec)
             }
             else if (EQUAL(pszKey, "scale") || STARTS_WITH_CI(pszKey, "scale_"))
             {
-                argv.AddString(CPLSPrintf("-%s", pszKey));
                 CPLStringList aosScaleParams(
                     CSLTokenizeString2(pszValue, ",", 0));
+
+                CPLDebug("VRT", "aosScaleParams.size(): %i",
+                         aosScaleParams.size());
                 if (!(aosScaleParams.size() == 2) &&
-                    !(aosScaleParams.size() == 4))
+                    !(aosScaleParams.size() == 4) &&
+                    !(aosScaleParams.size() == 1))
                 {
                     CPLError(CE_Failure, CPLE_IllegalArg,
-                             "Invalid value for explicit scale or scale_bn: "
-                             "%s\n  need 2, or 4 "
+                             "Invalid value for scale, (or scale_bn): "
+                             "%s\n  need 'scale=true', or 2 or 4 "
                              "numbers, comma separated: "
-                             "'scale=src_min,src_max[,dst_min,dst_max]'"
+                             "'scale=src_min,src_max[,dst_min,dst_max]' or "
                              "'scale_bn=src_min,src_max[,dst_min,dst_max]'",
                              pszValue);
                     poSrcDS->ReleaseRef();
                     CPLFree(pszKey);
                     return nullptr;
                 }
-                for (int j = 0; j < aosScaleParams.size(); j++)
+
+                // -scale because scale=true or scale=min,max or scale=min,max,dstmin,dstmax
+                if (aosScaleParams.size() == 1 &&
+                    CPLTestBool(aosScaleParams[0]))
                 {
-                    argv.AddString(aosScaleParams[j]);
+                    argv.AddString(CPLSPrintf("-%s", pszKey));
+                }
+                // add remaining params (length 2 or 4)
+                if (aosScaleParams.size() > 1)
+                {
+                    argv.AddString(CPLSPrintf("-%s", pszKey));
+                    for (int j = 0; j < aosScaleParams.size(); j++)
+                    {
+                        argv.AddString(aosScaleParams[j]);
+                    }
                 }
             }
             else if (EQUAL(pszKey, "exponent") ||
@@ -1308,6 +1332,14 @@ GDALDataset *VRTDataset::OpenVRTProtocol(const char *pszSpec)
             {
                 // do nothing, we passed this in earlier
             }
+            else if (EQUAL(pszKey, "unscale"))
+            {
+                if (CPLTestBool(pszValue))
+                {
+                    argv.AddString("-unscale");
+                }
+            }
+
             else
             {
                 CPLError(CE_Failure, CPLE_NotSupported, "Unknown option: %s",


### PR DESCRIPTION
Add 'scale' and 'unscale'  to allowed options for a "vrt://" connection.

These can be set to values `=true` or `=false`. 

Options without `key=value` form are now disallowed. 

## What are related issues/pull requests?

First attempt was #8343 see for some discussion. 

Discussion and summary of related PRs: https://github.com/OSGeo/gdal/issues/7477

## Tasklist

 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
