### PR TITLE
Scaling related fixes

### DIFF
--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -3070,7 +3070,7 @@ GDALTranslateOptionsNew(char **papszArgv,
             else
             {
                 psOptions->asScaleParams[nIndex].dfScaleDstMin = 0.0;
-                psOptions->asScaleParams[nIndex].dfScaleDstMax = 255.999;
+                psOptions->asScaleParams[nIndex].dfScaleDstMax = 255.0;
             }
         }
 

--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1498,13 +1498,13 @@ def test_vrt_protocol():
     assert ds.GetRasterBand(2).Checksum() == 5047
 
     ds = gdal.Open("vrt://data/float32.tif?scale_1=0,10")
-    assert ds.GetRasterBand(1).Checksum() == 4867
+    assert ds.GetRasterBand(1).Checksum() == 4155
 
     ds = gdal.Open("vrt://data/float32.tif?exponent=2.2")
     assert ds is None
 
     ds = gdal.Open("vrt://data/float32.tif?exponent=2.2&scale=0,100")
-    assert ds.GetRasterBand(1).Checksum() == 5294
+    assert ds.GetRasterBand(1).Checksum() == 4901
 
     ds = gdal.Open("vrt://data/uint16_3band.vrt?exponent_2=2.2&scale_2=0,10,0,100")
     assert ds.GetRasterBand(2).Checksum() == 4455

--- a/autotest/utilities/test_gdal_translate_lib.py
+++ b/autotest/utilities/test_gdal_translate_lib.py
@@ -514,6 +514,19 @@ def test_gdal_translate_lib_102():
 
 
 ###############################################################################
+# Test -scale preserves [0,255] input range
+
+
+def test_gdal_translate_lib_scale_0_255_input_range():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 3, 1)
+    expected_data = struct.pack("B" * 3, 0, 254, 255)
+    src_ds.WriteRaster(0, 0, 3, 1, expected_data)
+    ds = gdal.Translate("", src_ds, options="-of MEM -scale")
+    assert ds.ReadRaster() == expected_data
+
+
+###############################################################################
 # Test that -projwin with nearest neighbor resampling uses integer source
 # pixel boundaries (#6610)
 

--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -1186,12 +1186,12 @@ class CPL_DLL VRTComplexSource CPL_NON_FINAL : public VRTSimpleSource
     double GetAdjustedNoDataValue() const;
 
     template <class WorkingDT>
-    CPLErr RasterIOInternal(int nReqXOff, int nReqYOff, int nReqXSize,
-                            int nReqYSize, void *pData, int nOutXSize,
-                            int nOutYSize, GDALDataType eBufType,
-                            GSpacing nPixelSpace, GSpacing nLineSpace,
-                            GDALRasterIOExtraArg *psExtraArg,
-                            GDALDataType eWrkDataType);
+    CPLErr
+    RasterIOInternal(GDALDataType eBandDataType, int nReqXOff, int nReqYOff,
+                     int nReqXSize, int nReqYSize, void *pData, int nOutXSize,
+                     int nOutYSize, GDALDataType eBufType, GSpacing nPixelSpace,
+                     GSpacing nLineSpace, GDALRasterIOExtraArg *psExtraArg,
+                     GDALDataType eWrkDataType);
 
   public:
     VRTComplexSource();

--- a/frmts/vrt/vrtfilters.cpp
+++ b/frmts/vrt/vrtfilters.cpp
@@ -317,7 +317,7 @@ CPLErr VRTFilteredSource::RasterIO(GDALDataType eBandDataType, int nXOff,
         const bool bIsComplex =
             CPL_TO_BOOL(GDALDataTypeIsComplex(eOperDataType));
         const CPLErr eErr = VRTComplexSource::RasterIOInternal<float>(
-            nFileXOff, nFileYOff, nFileXSize, nFileYSize,
+            eBandDataType, nFileXOff, nFileYOff, nFileXSize, nFileYSize,
             pabyWorkData + nLineOffset * nTopFill + nPixelOffset * nLeftFill,
             nFileXSize, nFileYSize, eOperDataType, nPixelOffset, nLineOffset,
             &sExtraArgs, bIsComplex ? GDT_CFloat32 : GDT_Float32);


### PR DESCRIPTION
- gdal_translate -scale: change dstMax value from 255.999 to 255
- VRTComplexSource (scaling typically): make sure to take into account constraints from VRTRasterBand data type in RasterIO() (rather than just taking into account output buffer data type)
