### PR TITLE
VRT 'a_coord_epoch' for vrt:// connection

### DIFF
--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1627,7 +1627,7 @@ def test_vrt_protocol():
 
 @pytest.mark.require_proj(7, 2)
 def test_vrt_protocol_a_coord_epoch_option():
-    ds = gdal.Open("vrt://data/byte.tif?a_coord_epoch=2021.3")
+    ds = gdal.Open("vrt://data/byte.tif?a_srs=EPSG:4326&a_coord_epoch=2021.3")
     srs = ds.GetSpatialRef()
     assert srs.IsDynamic()
     assert srs.GetCoordinateEpoch() == 2021.3

--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1625,6 +1625,14 @@ def test_vrt_protocol():
         assert not gdal.Open("vrt://data/minfloat.tif?a_ullr=0,1,1,0&unscale&")
 
 
+@pytest.mark.require_proj(7, 2)
+def test_vrt_protocol_a_coord_epoch_option():
+    ds = gdal.Open("vrt://data/byte.tif?a_coord_epoch=2021.3")
+    srs = ds.GetSpatialRef()
+    assert srs.IsDynamic()
+    assert srs.GetCoordinateEpoch() == 2021.3
+
+
 @pytest.mark.require_driver("BMP")
 def test_vrt_protocol_expand_option():
     ds = gdal.Open("vrt://data/8bit_pal.bmp?expand=rgb")

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1697,7 +1697,7 @@ For example:
 
 The supported options currently are ``bands``, ``a_srs``, ``a_ullr``, ``ovr``, ``expand``,
 ``a_scale``, ``a_offset``, ``ot``, ``gcp``, ``if``, ``scale``, ``exponent``, ``outsize``, ``projwin``,
-``tr``, ``r``, ``srcwin``, ``a_gt``, ``oo`` and ``unscale``.
+``projwin_srs``, ``tr``, ``r``, ``srcwin``, ``a_gt``, ``oo``, ``unscale``, and ``a_coord_epoch``.
 
 Other options may be added in the future.
 
@@ -1770,6 +1770,9 @@ The effect of the ``oo`` option (added in GDAL 3.8) is to set driver-specific da
 consists of string key value pairs with multiple pairs separated by commas e.g. ``oo=<key>=<val>`` or . ``oo=<key1>=<val1>,<key2>=<val2>,...``. This is applied in the same way as (:ref:`gdal_translate`).
 
 The effect of the ``unscale`` option (added in GDAL 3.8) is to apply the scale/offset metadata for the bands to convert scaled values to unscaled values. Do apply this use syntax ``unscale=true``, or ``unscale=false`` which is the default behaviour if not specified. Do consider the need for also using ``ot`` option in order to accomodate the intended output range, see more details for the same argument as with (:ref:`gdal_translate`).
+
+The effect of the ``a_coord_epoch`` option (added in GDAL 3.8) is to assign a coordinate epoch, linked with the output SRS as
+with (:ref:`gdal_translate`).
 
 The options may be chained together separated by '&'. (Beware the need for quoting to protect
 the ampersand).

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -1337,6 +1337,11 @@ GDALDataset *VRTDataset::OpenVRTProtocol(const char *pszSpec)
                     argv.AddString("-unscale");
                 }
             }
+            else if (EQUAL(pszKey, "a_coord_epoch"))
+            {
+                argv.AddString("-a_coord_epoch");
+                argv.AddString(pszValue);
+            }
 
             else
             {


### PR DESCRIPTION
Add `a_coord_epoch` to allowed options for a "vrt://" connection.

Does this need a pytest requirement for the proj data files? 

## What are related issues/pull requests?

Discussion and summary of related PRs: https://github.com/OSGeo/gdal/issues/7477

## Tasklist

 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

