### PR TITLE
WCS: remove non-standard 'FORMAT' parameter from 'DescribeCoverage' requests (fixes #8381)

### DIFF
--- a/frmts/wcs/wcsdataset110.cpp
+++ b/frmts/wcs/wcsdataset110.cpp
@@ -269,7 +269,6 @@ std::string WCSDataset110::DescribeCoverageRequest()
                            CPLGetXMLValue(psService, "Version", "1.1.0"));
     request = CPLURLAddKVP(request, "IDENTIFIERS",
                            CPLGetXMLValue(psService, "CoverageName", ""));
-    request = CPLURLAddKVP(request, "FORMAT", "text/xml");
     CPLString extra = CPLGetXMLValue(psService, "Parameters", "");
     if (extra != "")
     {

--- a/frmts/wcs/wcsdataset201.cpp
+++ b/frmts/wcs/wcsdataset201.cpp
@@ -376,7 +376,6 @@ std::string WCSDataset201::DescribeCoverageRequest()
                            CPLGetXMLValue(psService, "Version", "2.0.1"));
     request = CPLURLAddKVP(request.c_str(), "COVERAGEID",
                            CPLGetXMLValue(psService, "CoverageName", ""));
-    request = CPLURLAddKVP(request.c_str(), "FORMAT", "text/xml");
     std::string extra = CPLGetXMLValue(psService, "Parameters", "");
     if (extra != "")
     {


### PR DESCRIPTION
removes non-standard 'FORMAT' parameter from WCS 1.1.0 and WCS 2.0.1 'DescribeCoverage' requests. The additional parameter cause errors with some strict server implementation. See #8381.

As researched by @jratike80 '&format=' is never needed and must not be accepted by DescribeCoverage:
https://github.com/OSGeo/gdal/issues/8381#issuecomment-1715643356
Thanks for your fast help on this! 👍 

If additional parameters (like 'format') are needed in special use cases they can be added with 'DescribeCoverageExtra' option.