### PR TITLE
Python bindings: Allow ExecuteSQL context manager to work on empty datasources

### DIFF
--- a/autotest/ogr/ogr_sql_test.py
+++ b/autotest/ogr/ogr_sql_test.py
@@ -122,6 +122,16 @@ def test_ogr_sql_execute_sql(use_gdal):
         os.unlink("tmp/test_ogr_sql_execute_sql.shx")
 
 
+@pytest.mark.require_driver("SQLite")
+def test_ogr_sql_execute_sql_empty_database(tmp_vsimem):
+
+    ds = ogr.GetDriverByName("SQLite").CreateDataSource(tmp_vsimem / "test.sqlite")
+
+    with ds.ExecuteSQL("SELECT sqlite_version() AS version") as sql_lyr:
+        f = sql_lyr.GetNextFeature()
+        assert type(f["version"]) is str
+
+
 ###############################################################################
 # Test invalid use of ReleaseResultSet()
 

--- a/swig/include/python/ogr_python.i
+++ b/swig/include/python/ogr_python.i
@@ -373,7 +373,7 @@ def ReleaseResultSet(self, sql_lyr):
         """Method called when using Dataset.ExecuteSQL() as a context manager"""
         if hasattr(self, "_dataset_weak_ref"):
             self._dataset_strong_ref = self._dataset_weak_ref()
-            assert self._dataset_strong_ref
+            assert self._dataset_strong_ref is not None
             del self._dataset_weak_ref
             return self
         raise Exception("__enter__() called in unexpected situation")


### PR DESCRIPTION
The statement `assert self._dataset_strong_ref` is equivalent to `assert bool(self._dataset_strong_ref)`, whose default implementation is `len(self._dataset_strong_ref) > 0`. Since dataset defines `__len__` as `GetLayerCount()`, this is false for an empty datasource.