### PR TITLE
Add AUTODETECT_JSON_STRINGS option

### DIFF
--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -3558,7 +3558,11 @@ def test_ogr_geojson_json_string_autodetect():
     gdal.Unlink(tmpfilename)
 
     with gdal.quiet_errors():
-        gdal.VectorTranslate(tmpfilename, json_content, options="-f GeoJSON -lco AUTODETECT_JSON_STRINGS=FALSE")
+        gdal.VectorTranslate(
+            tmpfilename,
+            json_content,
+            options="-f GeoJSON -lco AUTODETECT_JSON_STRINGS=FALSE",
+        )
     ds = ogr.Open(tmpfilename)
     lyr = ds.GetLayer(0)
     assert lyr.GetLayerDefn().GetFieldCount() == 1

--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -3543,9 +3543,7 @@ def test_ogr_geojson_json_string_autodetect():
     f = lyr.GetNextFeature()
     for i in range(1):
         assert lyr.GetLayerDefn().GetFieldDefn(i).GetType() == ogr.OFTString
-    if f["jsonish"] != "[5]":
-        f.DumpReadable()
-        pytest.fail()
+    assert f["jsonish"] == "[5]"
     ds = None
 
     tmpfilename = "/vsimem/out.json"
@@ -3566,9 +3564,7 @@ def test_ogr_geojson_json_string_autodetect():
     assert lyr.GetLayerDefn().GetFieldCount() == 1
     assert lyr.GetLayerDefn().GetFieldDefn(i).GetType() == ogr.OFTString
     f = lyr.GetNextFeature()
-    if f["jsonish"] != "[5]":
-        f.DumpReadable()
-        pytest.fail()
+    assert f["jsonish"] == "[5]"
     ds = None
     gdal.Unlink(tmpfilename)
 

--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -3534,20 +3534,16 @@ def test_ogr_geojson_json_string_autodetect():
     json_content = """{
   "type": "FeatureCollection",
   "features": [
-      { "type": "Feature", "properties": { "jsonish": "[nan]" }, "geometry": null }
+      { "type": "Feature", "properties": { "jsonish": "[5]" }, "geometry": null }
   ]
 }"""
     with gdal.quiet_errors():
         ds = ogr.Open(json_content)
-    if ds is None:
-        # Might fail with older libjson-c versions
-        pytest.skip()
     lyr = ds.GetLayer(0)
     f = lyr.GetNextFeature()
     for i in range(1):
         assert lyr.GetLayerDefn().GetFieldDefn(i).GetType() == ogr.OFTString
-
-    if f["jsonish"] != "[nan]":
+    if f["jsonish"] != "[5]":
         f.DumpReadable()
         pytest.fail()
     ds = None
@@ -3559,7 +3555,7 @@ def test_ogr_geojson_json_string_autodetect():
     ds = ogr.Open(tmpfilename)
     lyr = ds.GetLayer(0)
     assert lyr.GetLayerDefn().GetFieldCount() == 1
-    assert lyr.GetLayerDefn().GetFieldDefn(i).GetType() == ogr.OFTRealList
+    assert lyr.GetLayerDefn().GetFieldDefn(i).GetType() == ogr.OFTIntegerList
     ds = None
     gdal.Unlink(tmpfilename)
 
@@ -3570,7 +3566,7 @@ def test_ogr_geojson_json_string_autodetect():
     assert lyr.GetLayerDefn().GetFieldCount() == 1
     assert lyr.GetLayerDefn().GetFieldDefn(i).GetType() == ogr.OFTString
     f = lyr.GetNextFeature()
-    if f["jsonish"] != "[nan]":
+    if f["jsonish"] != "[5]":
         f.DumpReadable()
         pytest.fail()
     ds = None

--- a/doc/source/drivers/vector/geojson.rst
+++ b/doc/source/drivers/vector/geojson.rst
@@ -373,6 +373,15 @@ Layer creation options
       mode, but some JSon parsers (libjson-c >= 0.12 for example) can
       understand them as they are allowed by ECMAScript.
 
+-  .. lco:: AUTODETECT_JSON_STRINGS
+      :choices: YES, NO
+      :default: YES
+      :since: 3.8
+
+      Whether to try to interpret string fields as JSON arrays or objects
+      if they start and end with brackets and braces, even if they do
+      not have their subtype set to JSON.
+
 VSI Virtual File System API support
 -----------------------------------
 

--- a/doc/source/drivers/vector/geojsonseq.rst
+++ b/doc/source/drivers/vector/geojsonseq.rst
@@ -94,6 +94,25 @@ Layer creation options
 
       Type of the 'id' member of Feature objects.
 
+-  .. lco:: WRITE_NON_FINITE_VALUES
+      :choices: YES, NO
+      :default: NO
+      :since: 2.4
+
+      Whether to write
+      NaN / Infinity values. Such values are not allowed in strict JSon
+      mode, but some JSon parsers (libjson-c >= 0.12 for example) can
+      understand them as they are allowed by ECMAScript.
+
+-  .. lco:: AUTODETECT_JSON_STRINGS
+      :choices: YES, NO
+      :default: YES
+      :since: 3.8
+
+      Whether to try to interpret string fields as JSON arrays or objects
+      if they start and end with brackets and braces, even if they do
+      not have their subtype set to JSON.
+
 See Also
 --------
 

--- a/doc/source/drivers/vector/geojsonseq.rst
+++ b/doc/source/drivers/vector/geojsonseq.rst
@@ -97,7 +97,7 @@ Layer creation options
 -  .. lco:: WRITE_NON_FINITE_VALUES
       :choices: YES, NO
       :default: NO
-      :since: 2.4
+      :since: 3.8
 
       Whether to write
       NaN / Infinity values. Such values are not allowed in strict JSon

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsondriver.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsondriver.cpp
@@ -724,6 +724,9 @@ void RegisterOGRGeoJSON()
         "description='Auto-generate feature ids' />"
         "  <Option name='WRITE_NON_FINITE_VALUES' type='boolean' "
         "description='Whether to write NaN / Infinity values' default='NO'/>"
+        "  <Option name='AUTODETECT_JSON_STRINGS' type='boolean' "
+        "description='Whether to try to interpret string fields as JSON "
+        "arrays or objects' default='YES'/>"
         "</LayerCreationOptionList>");
 
     poDriver->SetMetadataItem(GDAL_DCAP_VIRTUALIO, "YES");

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonseqdriver.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonseqdriver.cpp
@@ -283,6 +283,10 @@ OGRGeoJSONSeqLayer::OGRGeoJSONSeqLayer(
         atoi(CSLFetchNameValueDef(papszOptions, "COORDINATE_PRECISION", "7"));
     m_oWriteOptions.nSignificantFigures =
         atoi(CSLFetchNameValueDef(papszOptions, "SIGNIFICANT_FIGURES", "-1"));
+    m_oWriteOptions.bAllowNonFiniteValues = CPLTestBool(
+        CSLFetchNameValueDef(papszOptions, "WRITE_NON_FINITE_VALUES", "FALSE"));
+    m_oWriteOptions.bAutodetectJsonStrings = CPLTestBool(
+        CSLFetchNameValueDef(papszOptions, "AUTODETECT_JSON_STRINGS", "TRUE"));
 }
 
 /************************************************************************/

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonwritelayer.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonwritelayer.cpp
@@ -73,6 +73,8 @@ OGRGeoJSONWriteLayer::OGRGeoJSONWriteLayer(const char *pszName,
     oWriteOptions_.SetIDOptions(papszOptions);
     oWriteOptions_.bAllowNonFiniteValues = CPLTestBool(
         CSLFetchNameValueDef(papszOptions, "WRITE_NON_FINITE_VALUES", "FALSE"));
+    oWriteOptions_.bAutodetectJsonStrings = CPLTestBool(
+        CSLFetchNameValueDef(papszOptions, "AUTODETECT_JSON_STRINGS", "TRUE"));
 }
 
 /************************************************************************/

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.cpp
@@ -911,8 +911,9 @@ json_object *OGRGeoJSONWriteAttributes(OGRFeature *poFeature,
             const size_t nLen = strlen(pszStr);
 
             if (eSubType == OFSTJSON ||
-                ((pszStr[0] == '{' && pszStr[nLen - 1] == '}') ||
-                 (pszStr[0] == '[' && pszStr[nLen - 1] == ']')))
+                (oOptions.bAutodetectJsonStrings &&
+                 ((pszStr[0] == '{' && pszStr[nLen - 1] == '}') ||
+                  (pszStr[0] == '[' && pszStr[nLen - 1] == ']'))))
             {
                 if (bUseNativeMedia)
                 {

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.h
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.h
@@ -85,6 +85,7 @@ class OGRGeoJSONWriteOptions
     bool bGenerateID = false;
     OGRFieldType eForcedIDFieldType = OFTString;
     bool bAllowNonFiniteValues = false;
+    bool bAutodetectJsonStrings = true;
 
     void SetRFC7946Settings();
     void SetIDOptions(CSLConstList papszOptions);


### PR DESCRIPTION
This optionally prevents conversion of JSON-like string fields into JSON objects or arrays when they are written with the GeoJSON or GeoJSONSeq driver.

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Optionally prevents conversion of JSON-like string fields into JSON objects or arrays when they are written with the GeoJSON or GeoJSONSeq driver.

## What are related issues/pull requests?

None known

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: (.venv) Erica-Felt% uname -a
Darwin Erica-Felt.local 22.5.0 Darwin Kernel Version 22.5.0: Thu Jun  8 22:22:19 PDT 2023; root:xnu-8796.121.3~7/RELEASE_ARM64_T8103 arm64
* Compiler: Apple clang version 14.0.3 (clang-1403.0.22.14.1)

