### PR TITLE
GTiff and COG: add a MAX_Z_ERROR_OVERVIEW creation option …

### DIFF
--- a/autotest/gcore/cog.py
+++ b/autotest/gcore/cog.py
@@ -388,6 +388,43 @@ def test_cog_creation_of_overviews_with_mask():
 
 
 ###############################################################################
+# Test MAX_Z_ERROR_OVERVIEW creation option
+
+
+@pytest.mark.require_creation_option("COG", "LERC")
+def test_cog_lerc_max_z_error_overview(tmp_vsimem):
+
+    fname = str(tmp_vsimem / "test_cog_lerc_max_z_error_overview.tif")
+
+    gdal.Translate(
+        fname,
+        "../gdrivers/data/utm.tif",
+        options="-of COG -co COMPRESS=LERC -outsize 256 256 -co BLOCKSIZE=128",
+    )
+    ds = gdal.Open(fname)
+    assert float(ds.GetMetadataItem("MAX_Z_ERROR", "_DEBUG_")) == 0
+    assert float(ds.GetMetadataItem("MAX_Z_ERROR_OVERVIEW", "_DEBUG_")) == 0.0
+    ref_cs_main = ds.GetRasterBand(1).Checksum()
+    ref_cs_ovr = ds.GetRasterBand(1).GetOverview(0).Checksum()
+    ds = None
+
+    gdal.Translate(
+        fname,
+        "../gdrivers/data/utm.tif",
+        options="-of COG -co COMPRESS=LERC -co MAX_Z_ERROR_OVERVIEW=1.5 -outsize 256 256 -co BLOCKSIZE=128",
+    )
+    ds = gdal.Open(fname)
+    assert float(ds.GetMetadataItem("MAX_Z_ERROR", "_DEBUG_")) == 0
+    assert float(ds.GetMetadataItem("MAX_Z_ERROR_OVERVIEW", "_DEBUG_")) == 1.5
+    got_cs_main = ds.GetRasterBand(1).Checksum()
+    got_cs_ovr = ds.GetRasterBand(1).GetOverview(0).Checksum()
+    ds = None
+
+    assert got_cs_main == ref_cs_main
+    assert got_cs_ovr != ref_cs_ovr
+
+
+###############################################################################
 # Test full world reprojection to WebMercator
 
 

--- a/doc/source/drivers/raster/cog.rst
+++ b/doc/source/drivers/raster/cog.rst
@@ -84,11 +84,20 @@ General creation options
       * For ZSTD, 22 is the slowest/higher compression rate. The default is 9.
 
 -  .. co:: MAX_Z_ERROR
+      :choices: <threshold>
       :default: 0
 
       Set the maximum error threshold on values
       for LERC/LERC_DEFLATE/LERC_ZSTD compression. The default is 0
       (lossless).
+
+-  .. co:: MAX_Z_ERROR_OVERVIEW
+      :choices: <threshold>
+      :since: 3.8
+
+      Set the maximum error threshold on values
+      for LERC/LERC_DEFLATE/LERC_ZSTD compression, on overviews.
+      The default is the value of :co:`MAX_Z_ERROR`
 
 -  .. co:: QUALITY
       :choices: <integer>

--- a/doc/source/drivers/raster/gtiff.rst
+++ b/doc/source/drivers/raster/gtiff.rst
@@ -569,6 +569,14 @@ Creation Options
       for LERC/LERC_DEFLATE/LERC_ZSTD compression. The default is 0
       (lossless).
 
+-  .. co:: MAX_Z_ERROR_OVERVIEW
+      :choices: <threshold>
+      :since: 3.8
+
+      Set the maximum error threshold on values
+      for LERC/LERC_DEFLATE/LERC_ZSTD compression, on overviews.
+      The default is the value of :co:`MAX_Z_ERROR`
+
 -  .. co:: WEBP_LEVEL
       :choices: [1-100]
       :default: 75

--- a/frmts/gtiff/cogdriver.cpp
+++ b/frmts/gtiff/cogdriver.cpp
@@ -1115,6 +1115,9 @@ GDALDataset *GDALCOGCreator::Create(const char *pszFilename,
     {
         aosOptions.SetNameValue("MAX_Z_ERROR",
                                 CSLFetchNameValue(papszOptions, "MAX_Z_ERROR"));
+        aosOptions.SetNameValue(
+            "MAX_Z_ERROR_OVERVIEW",
+            CSLFetchNameValue(papszOptions, "MAX_Z_ERROR_OVERVIEW"));
     }
 
     if (STARTS_WITH_CI(osCompress, "JXL"))
@@ -1376,7 +1379,10 @@ void GDALCOGDriver::InitializeCreationOptionList()
         osOptions +=
             ""
             "   <Option name='MAX_Z_ERROR' type='float' description='Maximum "
-            "error for LERC compression' default='0'/>";
+            "error for LERC compression' default='0'/>"
+            "   <Option name='MAX_Z_ERROR_OVERVIEW' type='float' "
+            "description='Maximum error for LERC compression in overviews' "
+            "default='0'/>";
     }
 #ifdef HAVE_JXL
     osOptions +=

--- a/frmts/gtiff/geotiff.cpp
+++ b/frmts/gtiff/geotiff.cpp
@@ -252,11 +252,16 @@ void GTIFFSetMaxZError(GDALDatasetH hGTIFFDS, double dfMaxZError)
 
     GTiffDataset *const poDS = static_cast<GTiffDataset *>(hGTIFFDS);
     poDS->m_dfMaxZError = dfMaxZError;
+    poDS->m_dfMaxZErrorOverview = dfMaxZError;
 
     poDS->ScanDirectories();
 
     for (int i = 0; i < poDS->m_nOverviewCount; ++i)
+    {
         poDS->m_papoOverviewDS[i]->m_dfMaxZError = poDS->m_dfMaxZError;
+        poDS->m_papoOverviewDS[i]->m_dfMaxZErrorOverview =
+            poDS->m_dfMaxZErrorOverview;
+    }
 }
 
 /************************************************************************/
@@ -1214,10 +1219,15 @@ void GDALRegister_GTiff()
             "   <Option name='ZSTD_LEVEL' type='int' description='ZSTD "
             "compression level 1(fast)-22(slow)' default='9'/>";
     if (bHasLERC)
+    {
         osOptions +=
             ""
             "   <Option name='MAX_Z_ERROR' type='float' description='Maximum "
-            "error for LERC compression' default='0'/>";
+            "error for LERC compression' default='0'/>"
+            "   <Option name='MAX_Z_ERROR_OVERVIEW' type='float' "
+            "description='Maximum error for LERC compression in overviews' "
+            "default='0'/>";
+    }
     if (bHasWebP)
     {
 #ifndef DEFAULT_WEBP_LEVEL

--- a/frmts/gtiff/gtiffdataset.cpp
+++ b/frmts/gtiff/gtiffdataset.cpp
@@ -1157,6 +1157,29 @@ void GTiffDataset::ScanDirectories()
                     m_papoOverviewDS[m_nOverviewCount - 1] = poODS;
                     poODS->m_poBaseDS = this;
                     poODS->m_bIsOverview = true;
+
+                    // Propagate a few compression related settings that are
+                    // no preserved at the TIFF tag level, but may be set in
+                    // the GDAL_METADATA tag in the IMAGE_STRUCTURE domain
+                    // Note: this might not be totally reflecting the reality
+                    // if users have created overviews with different settings
+                    // but this is probably better than the default ones
+                    poODS->m_nWebPLevel = m_nWebPLevel;
+                    // below is not a copy & paste error: we transfer the
+                    // m_dfMaxZErrorOverview overview of the parent to
+                    // m_dfMaxZError of the overview
+                    poODS->m_dfMaxZError = m_dfMaxZErrorOverview;
+                    poODS->m_dfMaxZErrorOverview = m_dfMaxZErrorOverview;
+#if HAVE_JXL
+                    poODS->m_bJXLLossless = m_bJXLLossless;
+                    poODS->m_fJXLDistance = m_fJXLDistance;
+                    poODS->m_fJXLAlphaDistance = m_fJXLAlphaDistance;
+                    poODS->m_nJXLEffort = m_nJXLEffort;
+#endif
+                    // Those ones are not serialized currently..
+                    // poODS->m_nZLevel = m_nZLevel;
+                    // poODS->m_nLZMAPreset = m_nLZMAPreset;
+                    // poODS->m_nZSTDLevel = m_nZSTDLevel;
                 }
             }
             // Embedded mask of the main image.

--- a/frmts/gtiff/gtiffdataset.h
+++ b/frmts/gtiff/gtiffdataset.h
@@ -173,6 +173,7 @@ class GTiffDataset final : public GDALPamDataset
 
     double m_adfGeoTransform[6]{0, 1, 0, 0, 0, 1};
     double m_dfMaxZError = 0.0;
+    double m_dfMaxZErrorOverview = 0.0;
     uint32_t m_anLercAddCompressionAndVersion[2]{0, 0};
 #if HAVE_JXL
     bool m_bJXLLossless = true;

--- a/frmts/gtiff/gtiffdataset_write.cpp
+++ b/frmts/gtiff/gtiffdataset_write.cpp
@@ -97,6 +97,18 @@ static bool GTiffGetWebPLossless(CSLConstList papszOptions)
     return CPLFetchBool(papszOptions, "WEBP_LOSSLESS", false);
 }
 
+static double GTiffGetLERCMaxZError(CSLConstList papszOptions)
+{
+    return CPLAtof(CSLFetchNameValueDef(papszOptions, "MAX_Z_ERROR", "0.0"));
+}
+
+static double GTiffGetLERCMaxZErrorOverview(CSLConstList papszOptions)
+{
+    return CPLAtof(CSLFetchNameValueDef(
+        papszOptions, "MAX_Z_ERROR_OVERVIEW",
+        CSLFetchNameValueDef(papszOptions, "MAX_Z_ERROR", "0.0")));
+}
+
 #if HAVE_JXL
 static bool GTiffGetJXLLossless(CSLConstList papszOptions)
 {
@@ -2451,7 +2463,7 @@ CPLErr GTiffDataset::RegisterNewOverviewDataset(toff_t nOverviewOffset,
         nWebpLevel = atoi(opt);
     }
 
-    double dfMaxZError = m_dfMaxZError;
+    double dfMaxZError = m_dfMaxZErrorOverview;
     if (const char *opt = GetOptionValue("MAX_Z_ERROR", "MAX_Z_ERROR_OVERVIEW"))
     {
         dfMaxZError = CPLAtof(opt);
@@ -2479,6 +2491,7 @@ CPLErr GTiffDataset::RegisterNewOverviewDataset(toff_t nOverviewOffset,
     poODS->m_bWebPLossless = bWebpLossless;
     poODS->m_nJpegTablesMode = m_nJpegTablesMode;
     poODS->m_dfMaxZError = dfMaxZError;
+    poODS->m_dfMaxZErrorOverview = dfMaxZError;
     memcpy(poODS->m_anLercAddCompressionAndVersion,
            m_anLercAddCompressionAndVersion,
            sizeof(m_anLercAddCompressionAndVersion));
@@ -4136,6 +4149,34 @@ bool GTiffDataset::WriteMetadata(GDALDataset *poSrcDS, TIFF *l_hTIFF,
                     0, nullptr, "IMAGE_STRUCTURE");
             }
         }
+        else if (pszCompress && STARTS_WITH_CI(pszCompress, "LERC"))
+        {
+            const double dfMaxZError =
+                GTiffGetLERCMaxZError(papszCreationOptions);
+            const double dfMaxZErrorOverview =
+                GTiffGetLERCMaxZErrorOverview(papszCreationOptions);
+            if (dfMaxZError == 0.0 && dfMaxZErrorOverview == 0.0)
+            {
+                AppendMetadataItem(&psRoot, &psTail,
+                                   "COMPRESSION_REVERSIBILITY", "LOSSLESS", 0,
+                                   nullptr, "IMAGE_STRUCTURE");
+            }
+            else
+            {
+                AppendMetadataItem(&psRoot, &psTail, "MAX_Z_ERROR",
+                                   CSLFetchNameValueDef(papszCreationOptions,
+                                                        "MAX_Z_ERROR", ""),
+                                   0, nullptr, "IMAGE_STRUCTURE");
+                if (dfMaxZError != dfMaxZErrorOverview)
+                {
+                    AppendMetadataItem(
+                        &psRoot, &psTail, "MAX_Z_ERROR_OVERVIEW",
+                        CSLFetchNameValueDef(papszCreationOptions,
+                                             "MAX_Z_ERROR_OVERVIEW", ""),
+                        0, nullptr, "IMAGE_STRUCTURE");
+                }
+            }
+        }
 #if HAVE_JXL
         else if (pszCompress && EQUAL(pszCompress, "JXL"))
         {
@@ -4661,11 +4702,6 @@ static signed char GTiffGetZSTDPreset(char **papszOptions)
         }
     }
     return static_cast<signed char>(nZSTDLevel);
-}
-
-static double GTiffGetLERCMaxZError(char **papszOptions)
-{
-    return CPLAtof(CSLFetchNameValueDef(papszOptions, "MAX_Z_ERROR", "0.0"));
 }
 
 static signed char GTiffGetZLevel(char **papszOptions)
@@ -6199,6 +6235,7 @@ GDALDataset *GTiffDataset::Create(const char *pszFilename, int nXSize,
     poDS->m_nJpegQuality = GTiffGetJpegQuality(papszParamList);
     poDS->m_nJpegTablesMode = GTiffGetJpegTablesMode(papszParamList);
     poDS->m_dfMaxZError = GTiffGetLERCMaxZError(papszParamList);
+    poDS->m_dfMaxZErrorOverview = GTiffGetLERCMaxZErrorOverview(papszParamList);
 #if HAVE_JXL
     poDS->m_bJXLLossless = GTiffGetJXLLossless(papszParamList);
     poDS->m_nJXLEffort = GTiffGetJXLEffort(papszParamList);
@@ -7492,6 +7529,7 @@ GDALDataset *GTiffDataset::CreateCopy(const char *pszFilename,
     poDS->m_nJpegTablesMode = GTiffGetJpegTablesMode(papszOptions);
     poDS->GetDiscardLsbOption(papszOptions);
     poDS->m_dfMaxZError = GTiffGetLERCMaxZError(papszOptions);
+    poDS->m_dfMaxZErrorOverview = GTiffGetLERCMaxZErrorOverview(papszOptions);
 #if HAVE_JXL
     poDS->m_bJXLLossless = GTiffGetJXLLossless(papszOptions);
     poDS->m_nJXLEffort = GTiffGetJXLEffort(papszOptions);


### PR DESCRIPTION
…to separately control the error threshold of overviews w.r.t the one of the full resolution image
