### PR TITLE
VRT 'nogcp' for vrt:// connection

### DIFF
--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1626,6 +1626,9 @@ def test_vrt_protocol():
     with pytest.raises(Exception):
         assert not gdal.Open("vrt://data/minfloat.tif?a_ullr=0,1,1,0&unscale&")
 
+    ds = gdal.Open("vrt://data/gcps.vrt?nogcp=true")
+    assert ds.GetGCPCount() == 0
+
 
 @pytest.mark.require_proj(7, 2)
 def test_vrt_protocol_a_coord_epoch_option():

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1697,7 +1697,7 @@ For example:
 
 The supported options currently are ``bands``, ``a_srs``, ``a_ullr``, ``ovr``, ``expand``,
 ``a_scale``, ``a_offset``, ``ot``, ``gcp``, ``if``, ``scale``, ``exponent``, ``outsize``, ``projwin``,
-``projwin_srs``, ``tr``, ``r``, ``srcwin``, ``a_gt``, ``oo``, ``unscale``, and ``a_coord_epoch``.
+``projwin_srs``, ``tr``, ``r``, ``srcwin``, ``a_gt``, ``oo``, ``unscale``, ``a_coord_epoch``, and ``nogcp``.
 
 Other options may be added in the future.
 
@@ -1773,6 +1773,8 @@ The effect of the ``unscale`` option (added in GDAL 3.8) is to apply the scale/o
 
 The effect of the ``a_coord_epoch`` option (added in GDAL 3.8) is to assign a coordinate epoch, linked with the output SRS as
 with (:ref:`gdal_translate`).
+
+The effect of the ``nogcp`` option (added in GDAL 3.8) is to not copy the GCPs in the source dataset to the output dataset (:ref:`gdal_translate`).
 
 The options may be chained together separated by '&'. (Beware the need for quoting to protect
 the ampersand).

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -1342,6 +1342,13 @@ GDALDataset *VRTDataset::OpenVRTProtocol(const char *pszSpec)
                 argv.AddString("-a_coord_epoch");
                 argv.AddString(pszValue);
             }
+            else if (EQUAL(pszKey, "nogcp"))
+            {
+                if (CPLTestBool(pszValue))
+                {
+                    argv.AddString("-nogcp");
+                }
+            }
 
             else
             {


### PR DESCRIPTION
Add `nogcp` to allowed options for a "vrt://" connection.

Discussion and summary of related PRs: https://github.com/OSGeo/gdal/issues/7477

## Tasklist

- [x] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
