### PR TITLE
Escape docs for escaping

### DIFF
--- a/doc/source/user/configoptions.rst
+++ b/doc/source/user/configoptions.rst
@@ -708,8 +708,8 @@ Networking options
       or a double-quote character is needed in the value, then the key: value pair
       must be enclosed in double-quote characters. In that situation, backslash
       and double quote character must be backslash-escaped.  e.g
-      GDAL_HTTP_HEADERS=Foo: Bar,"Baz: escaped backslash \\, escaped double-quote
-      \", end of value",Another: Header
+      GDAL_HTTP_HEADERS=Foo: Bar,"Baz: escaped backslash \\\\, escaped double-quote
+      \\", end of value",Another: Header
 
 -  .. config:: GDAL_HTTP_MAX_RETRY
       :since: 2.3


### PR DESCRIPTION
Fix the rendering for escaping docs

https://gdal.org/user/configoptions.html
Current situation:
![image](https://github.com/OSGeo/gdal/assets/588407/e6df075b-637a-4314-92db-7194ab0787b3)
