### PR TITLE
CSV: avoid extra comma at end of header line with GEOMETRY=AS_XYZ and…

### DIFF
--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -1963,7 +1963,7 @@ def test_netcdf_49():
     expected_content = """WKT,int32
 "POINT Z (1 2 3)",1
 "POINT (1 2)",
-,,
+,
 """
     assert content == expected_content
 

--- a/autotest/ogr/ogr_csv.py
+++ b/autotest/ogr/ogr_csv.py
@@ -959,7 +959,7 @@ def test_ogr_csv_25(csvwrk):
     lyr = None
     ds = None
 
-    EXPECTED = 'foo,\n"windows newline:\r\nlinux newline:\nend of string:"\n'
+    EXPECTED = 'foo\n"windows newline:\r\nlinux newline:\nend of string:"\n'
 
     data = open(csvwrk / "newlines.csv", "rb").read().decode("ascii")
     assert data == EXPECTED, "Newlines changed:\n\texpected=%s\n\tgot=     %s" % (
@@ -994,7 +994,7 @@ def test_ogr_csv_26(csvwrk):
     lyr = None
     ds = None
 
-    EXPECTED = "foo,\n10.5000000000000000000000000\n"
+    EXPECTED = "foo\n10.5000000000000000000000000\n"
 
     data = open(csvwrk / "num_padding.csv", "rb").read().decode("ascii")
     assert data == EXPECTED, "expected=%s got= %s" % (repr(EXPECTED), repr(data))


### PR DESCRIPTION
… a single attribute (fixes #8410)
