### PR TITLE
[Backport release/3.7] CSV: avoid extra comma at end of header line with GEOMETRY=AS_XYZ and…

### DIFF
--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -1941,7 +1941,7 @@ def test_netcdf_49():
     expected_content = """WKT,int32
 "POINT Z (1 2 3)",1
 "POINT (1 2)",
-,,
+,
 """
     assert content == expected_content
 

--- a/autotest/ogr/ogr_csv.py
+++ b/autotest/ogr/ogr_csv.py
@@ -989,7 +989,7 @@ def test_ogr_csv_25():
     lyr = None
     ds = None
 
-    EXPECTED = 'foo,\n"windows newline:\r\nlinux newline:\nend of string:"\n'
+    EXPECTED = 'foo\n"windows newline:\r\nlinux newline:\nend of string:"\n'
 
     data = open("tmp/csvwrk/newlines.csv", "rb").read().decode("ascii")
     assert data == EXPECTED, "Newlines changed:\n\texpected=%s\n\tgot=     %s" % (
@@ -1024,7 +1024,7 @@ def test_ogr_csv_26():
     lyr = None
     ds = None
 
-    EXPECTED = "foo,\n10.5000000000000000000000000\n"
+    EXPECTED = "foo\n10.5000000000000000000000000\n"
 
     data = open("tmp/csvwrk/num_padding.csv", "rb").read().decode("ascii")
     assert data == EXPECTED, "expected=%s got= %s" % (repr(EXPECTED), repr(data))

--- a/ogr/ogrsf_frmts/csv/ogrcsvlayer.cpp
+++ b/ogr/ogrsf_frmts/csv/ogrcsvlayer.cpp
@@ -1965,6 +1965,7 @@ OGRErr OGRCSVLayer::WriteHeader()
             bOK &= VSIFWriteL("\xEF\xBB\xBF", 1, 3, fpCSV) > 0;
         }
 
+        bool bNeedDelimiter = false;
         if (eGeometryFormat == OGR_CSV_GEOM_AS_XYZ)
         {
             if (fpCSV)
@@ -1972,13 +1973,7 @@ OGRErr OGRCSVLayer::WriteHeader()
                     VSIFPrintfL(fpCSV, "X%sY%sZ", szDelimiter, szDelimiter) > 0;
             if (fpCSVT)
                 bOK &= VSIFPrintfL(fpCSVT, "%s", "CoordX,CoordY,Real") > 0;
-            if (poFeatureDefn->GetFieldCount() > 0)
-            {
-                if (fpCSV)
-                    bOK &= VSIFPrintfL(fpCSV, "%s", szDelimiter) > 0;
-                if (fpCSVT)
-                    bOK &= VSIFPrintfL(fpCSVT, "%s", ",") > 0;
-            }
+            bNeedDelimiter = true;
         }
         else if (eGeometryFormat == OGR_CSV_GEOM_AS_XY)
         {
@@ -1986,13 +1981,7 @@ OGRErr OGRCSVLayer::WriteHeader()
                 bOK &= VSIFPrintfL(fpCSV, "X%sY", szDelimiter) > 0;
             if (fpCSVT)
                 bOK &= VSIFPrintfL(fpCSVT, "%s", "CoordX,CoordY") > 0;
-            if (poFeatureDefn->GetFieldCount() > 0)
-            {
-                if (fpCSV)
-                    bOK &= VSIFPrintfL(fpCSV, "%s", szDelimiter) > 0;
-                if (fpCSVT)
-                    bOK &= VSIFPrintfL(fpCSVT, "%s", ",") > 0;
-            }
+            bNeedDelimiter = true;
         }
         else if (eGeometryFormat == OGR_CSV_GEOM_AS_YX)
         {
@@ -2000,16 +1989,9 @@ OGRErr OGRCSVLayer::WriteHeader()
                 bOK &= VSIFPrintfL(fpCSV, "Y%sX", szDelimiter) > 0;
             if (fpCSVT)
                 bOK &= VSIFPrintfL(fpCSVT, "%s", "CoordY,CoordX") > 0;
-            if (poFeatureDefn->GetFieldCount() > 0)
-            {
-                if (fpCSV)
-                    bOK &= VSIFPrintfL(fpCSV, "%s", szDelimiter) > 0;
-                if (fpCSVT)
-                    bOK &= VSIFPrintfL(fpCSVT, "%s", ",") > 0;
-            }
+            bNeedDelimiter = true;
         }
-
-        if (bHiddenWKTColumn)
+        else if (bHiddenWKTColumn)
         {
             if (fpCSV)
             {
@@ -2019,17 +2001,19 @@ OGRErr OGRCSVLayer::WriteHeader()
             }
             if (fpCSVT)
                 bOK &= VSIFPrintfL(fpCSVT, "%s", "WKT") > 0;
+            bNeedDelimiter = true;
         }
 
         for (int iField = 0; iField < poFeatureDefn->GetFieldCount(); iField++)
         {
-            if (iField > 0 || bHiddenWKTColumn)
+            if (bNeedDelimiter)
             {
                 if (fpCSV)
                     bOK &= VSIFPrintfL(fpCSV, "%s", szDelimiter) > 0;
                 if (fpCSVT)
                     bOK &= VSIFPrintfL(fpCSVT, "%s", ",") > 0;
             }
+            bNeedDelimiter = true;
 
             char *pszEscaped = CPLEscapeString(
                 poFeatureDefn->GetFieldDefn(iField)->GetNameRef(), -1,
@@ -2139,15 +2123,6 @@ OGRErr OGRCSVLayer::WriteHeader()
             }
         }
 
-        // The CSV driver will not recognize single column tables, so add
-        // a fake second blank field.
-        if ((poFeatureDefn->GetFieldCount() == 1 && !bHiddenWKTColumn) ||
-            (poFeatureDefn->GetFieldCount() == 0 && bHiddenWKTColumn))
-        {
-            if (fpCSV)
-                bOK &= VSIFPrintfL(fpCSV, "%s", szDelimiter) > 0;
-        }
-
         if (bUseCRLF)
         {
             if (fpCSV)
@@ -2228,6 +2203,9 @@ OGRErr OGRCSVLayer::ICreateFeature(OGRFeature *poNewFeature)
         }
     }
 
+    bool bNeedDelimiter = false;
+    bool bEmptyLine = true;
+
     // Write out the geometry.
     if (eGeometryFormat == OGR_CSV_GEOM_AS_XYZ ||
         eGeometryFormat == OGR_CSV_GEOM_AS_XY ||
@@ -2262,26 +2240,23 @@ OGRErr OGRCSVLayer::ICreateFeature(OGRFeature *poNewFeature)
             if (eGeometryFormat == OGR_CSV_GEOM_AS_XYZ)
                 bRet &= VSIFPrintfL(fpCSV, "%s", szDelimiter) > 0;
         }
-        if (poFeatureDefn->GetFieldCount() > 0)
-            bRet &= VSIFPrintfL(fpCSV, "%s", szDelimiter) > 0;
+        bEmptyLine = false;
+        bNeedDelimiter = true;
     }
-
-    // Special case to deal with hidden "WKT" geometry column.
-    bool bNonEmptyLine = false;
-
-    if (bHiddenWKTColumn)
+    else if (bHiddenWKTColumn)
     {
         char *pszWKT = nullptr;
         OGRGeometry *poGeom = poNewFeature->GetGeomFieldRef(0);
         if (poGeom &&
             poGeom->exportToWkt(&pszWKT, wkbVariantIso) == OGRERR_NONE)
         {
-            bNonEmptyLine = true;
             bRet &= VSIFWriteL("\"", 1, 1, fpCSV) > 0;
             bRet &= VSIFWriteL(pszWKT, strlen(pszWKT), 1, fpCSV) > 0;
             bRet &= VSIFWriteL("\"", 1, 1, fpCSV) > 0;
+            bEmptyLine = false;
         }
         CPLFree(pszWKT);
+        bNeedDelimiter = true;
     }
 
     // Write out all the field values.
@@ -2289,8 +2264,12 @@ OGRErr OGRCSVLayer::ICreateFeature(OGRFeature *poNewFeature)
     {
         char *pszEscaped = nullptr;
 
-        if (iField > 0 || bHiddenWKTColumn)
+        if (bNeedDelimiter)
+        {
             bRet &= VSIFPrintfL(fpCSV, "%s", szDelimiter) > 0;
+            bEmptyLine = false;
+        }
+        bNeedDelimiter = true;
 
         if (eGeometryFormat == OGR_CSV_GEOM_AS_WKT &&
             panGeomFieldIndex[iField] >= 0)
@@ -2370,7 +2349,6 @@ OGRErr OGRCSVLayer::ICreateFeature(OGRFeature *poNewFeature)
             return OGRERR_FAILURE;
         }
         const size_t nLen = strlen(pszEscaped);
-        bNonEmptyLine |= nLen != 0;
         bool bAddDoubleQuote = false;
         if (szDelimiter[0] == ' ' && pszEscaped[0] != '"' &&
             strchr(pszEscaped, ' ') != nullptr)
@@ -2378,16 +2356,17 @@ OGRErr OGRCSVLayer::ICreateFeature(OGRFeature *poNewFeature)
         if (bAddDoubleQuote)
             bRet &= VSIFWriteL("\"", 1, 1, fpCSV) > 0;
         if (nLen)
+        {
             bRet &= VSIFWriteL(pszEscaped, nLen, 1, fpCSV) > 0;
+            bEmptyLine = false;
+        }
         if (bAddDoubleQuote)
             bRet &= VSIFWriteL("\"", 1, 1, fpCSV) > 0;
         CPLFree(pszEscaped);
     }
 
-    if ((poFeatureDefn->GetFieldCount() == 1 ||
-         (poFeatureDefn->GetFieldCount() == 0 && bHiddenWKTColumn)) &&
-        !bNonEmptyLine)
-        bRet &= VSIFPrintfL(fpCSV, "%s", szDelimiter) > 0;
+    if (bEmptyLine)
+        bRet &= VSIFPrintfL(fpCSV, "\"\"") > 0;
 
     if (bUseCRLF)
         bRet &= VSIFPutcL(13, fpCSV) != EOF;


### PR DESCRIPTION
Backport #8411
 **Authored by:** @rouault