### PR TITLE
autotest: Make SQLite, MySQL, Postgres tests run independently

### DIFF
--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -18,6 +18,14 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), "pymod"))
 # put the autotest dir on the path too. This lets us import all test modules
 sys.path.insert(1, os.path.dirname(__file__))
 
+# import fixtures that need to be used outside the test module where they were defined
+from ogr.ogr_pg import (  # noqa
+    pg_autotest_ds,
+    pg_ds,
+    pg_has_postgis,
+    pg_postgis_version,
+    use_postgis,
+)
 
 # These files may be non-importable, and don't contain tests anyway.
 # So we skip searching them during test collection.

--- a/autotest/pyscripts/test_ogr2ogr_py.py
+++ b/autotest/pyscripts/test_ogr2ogr_py.py
@@ -217,99 +217,57 @@ def test_ogr2ogr_py_5(script_path):
 # Test -overwrite
 
 
-def test_ogr2ogr_py_6(script_path):
-
-    ogr_pg = pytest.importorskip("ogr_pg")
+def test_ogr2ogr_py_6(script_path, pg_ds):
 
     if test_cli_utilities.get_ogrinfo_path() is None:
         pytest.skip()
 
-    ogr_pg.test_ogr_pg_1()
-    if gdaltest.pg_ds is None:
-        pytest.skip()
-    gdaltest.pg_ds.Destroy()
-
-    gdaltest.runexternal(
-        test_cli_utilities.get_ogrinfo_path()
-        + ' PG:"'
-        + gdaltest.pg_connection_string
-        + '" -sql "DELLAYER:tpoly"'
-    )
+    assert pg_ds.GetLayerByName("tpoly") is None
 
     test_py_scripts.run_py_script(
         script_path,
         "ogr2ogr",
-        '-f PostgreSQL PG:"'
-        + gdaltest.pg_connection_string
-        + '" '
+        "-f PostgreSQL "
+        + f'"{pg_ds.GetDescription()}" '
         + test_py_scripts.get_data_path("ogr")
         + "poly.shp -nln tpoly",
     )
+
+    assert pg_ds.GetLayerByName("tpoly").GetFeatureCount() == 10
+
     test_py_scripts.run_py_script(
         script_path,
         "ogr2ogr",
-        '-update -overwrite -f PostgreSQL PG:"'
-        + gdaltest.pg_connection_string
-        + '" '
+        "-update -overwrite -f PostgreSQL "
+        + f'"{pg_ds.GetDescription()}" '
         + test_py_scripts.get_data_path("ogr")
         + "poly.shp -nln tpoly",
     )
 
-    ds = ogr.Open("PG:" + gdaltest.pg_connection_string)
-    assert ds is not None and ds.GetLayerByName("tpoly").GetFeatureCount() == 10
-    ds.Destroy()
-
-    gdaltest.runexternal(
-        test_cli_utilities.get_ogrinfo_path()
-        + ' PG:"'
-        + gdaltest.pg_connection_string
-        + '" -sql "DELLAYER:tpoly"'
-    )
+    assert pg_ds.GetLayerByName("tpoly").GetFeatureCount() == 10
 
 
 ###############################################################################
 # Test -gt
 
 
-def test_ogr2ogr_py_7(script_path):
-
-    ogr_pg = pytest.importorskip("ogr_pg")
+def test_ogr2ogr_py_7(script_path, pg_ds):
 
     if test_cli_utilities.get_ogrinfo_path() is None:
         pytest.skip()
 
-    ogr_pg.test_ogr_pg_1()
-    if gdaltest.pg_ds is None:
-        pytest.skip()
-    gdaltest.pg_ds.Destroy()
-
-    gdaltest.runexternal(
-        test_cli_utilities.get_ogrinfo_path()
-        + ' PG:"'
-        + gdaltest.pg_connection_string
-        + '" -sql "DELLAYER:tpoly"'
-    )
+    assert pg_ds.GetLayerByName("tpoly") is None
 
     test_py_scripts.run_py_script(
         script_path,
         "ogr2ogr",
-        '-f PostgreSQL PG:"'
-        + gdaltest.pg_connection_string
-        + '" '
+        "-f PostgreSQL "
+        + f'"{pg_ds.GetDescription()}" '
         + test_py_scripts.get_data_path("ogr")
         + "poly.shp -nln tpoly -gt 1",
     )
 
-    ds = ogr.Open("PG:" + gdaltest.pg_connection_string)
-    assert ds is not None and ds.GetLayerByName("tpoly").GetFeatureCount() == 10
-    ds.Destroy()
-
-    gdaltest.runexternal(
-        test_cli_utilities.get_ogrinfo_path()
-        + ' PG:"'
-        + gdaltest.pg_connection_string
-        + '" -sql "DELLAYER:tpoly"'
-    )
+    assert pg_ds.GetLayerByName("tpoly").GetFeatureCount() == 10
 
 
 ###############################################################################


### PR DESCRIPTION
## What does this PR do?

This PR updates the tests for PostgreSQL, SQLite, and MySQL to run independently.
Each test runs in a clean schema / database to avoid interactions between tests.
Test tables that are used by more than one dataset can be brought in with, e.g. `@pytest.usefixtures("tpoly")`.

The Postgres tests cannot run in parallel because some of them manipulate `spatial_ref_sys`. 

## What are related issues/pull requests?

#4407

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed