### PR TITLE
Add Javier as PSC member [skip ci]

### DIFF
--- a/doc/source/community/index.rst
+++ b/doc/source/community/index.rst
@@ -120,6 +120,7 @@ decisions related to the GDAL/OGR project. The current members are (@github user
 - Kurt Schwehr         (@schwehr)
 - Norman Barker        (@normanb)
 - Sean Gillies         (@sgillies)
+- Javier Jimenez Shaw  (@jjimenezshaw)
 
 Past members:
 


### PR DESCRIPTION
## What does this PR do?
Adds Javier Jimenez Shaw as member of PSC

## What are related issues/pull requests?
https://lists.osgeo.org/pipermail/gdal-dev/2023-September/057667.html

## Tasklist

 - [ ] ~Add test case(s)~
 - [x] Add documentation
 - [ ] ~Updated Python API documentation (swig/include/python/docs/)~
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment
N/A