### PR TITLE
Fix missing /usr/local/lib/libproj.so.25.9.3.0 file

### DIFF
--- a/docker/ubuntu-full/bh-proj.sh
+++ b/docker/ubuntu-full/bh-proj.sh
@@ -71,6 +71,7 @@ ln -s "libinternalproj.so.${PROJ_SO}" "${DESTDIR}${PROJ_INSTALL_PREFIX}/lib/libi
 ln -s "libinternalproj.so.${PROJ_SO}" "${DESTDIR}${PROJ_INSTALL_PREFIX}/lib/libinternalproj.so"
 
 rm "${DESTDIR}${PROJ_INSTALL_PREFIX}/lib"/libproj.*
+ln -s "libinternalproj.so.${PROJ_SO}" "${DESTDIR}${PROJ_INSTALL_PREFIX}/lib/libproj.so.${PROJ_SO}"
 ln -s "libinternalproj.so.${PROJ_SO}" "${DESTDIR}${PROJ_INSTALL_PREFIX}/lib/libproj.so.${PROJ_SO_FIRST}"
 
 if [ "${WITH_DEBUG_SYMBOLS}" = "yes" ]; then

--- a/docker/ubuntu-small/Dockerfile
+++ b/docker/ubuntu-small/Dockerfile
@@ -134,6 +134,7 @@ RUN . /buildscripts/bh-set-envvars.sh \
     && ln -s libinternalproj.so.${PROJ_SO} /build${PROJ_INSTALL_PREFIX}/lib/libinternalproj.so.${PROJ_SO_FIRST} \
     && ln -s libinternalproj.so.${PROJ_SO} /build${PROJ_INSTALL_PREFIX}/lib/libinternalproj.so \
     && rm /build${PROJ_INSTALL_PREFIX}/lib/libproj.*  \
+    && ln -s libinternalproj.so.${PROJ_SO} /build${PROJ_INSTALL_PREFIX}/lib/libproj.so.${PROJ_SO} \
     && ln -s libinternalproj.so.${PROJ_SO} /build${PROJ_INSTALL_PREFIX}/lib/libproj.so.${PROJ_SO_FIRST} \
     && ${GCC_ARCH}-linux-gnu-strip -s /build${PROJ_INSTALL_PREFIX}/lib/libinternalproj.so.${PROJ_SO} \
     && for i in /build${PROJ_INSTALL_PREFIX}/bin/*; do ${GCC_ARCH}-linux-gnu-strip -s $i 2>/dev/null || /bin/true; done


### PR DESCRIPTION
This file is referenced in `/usr/local/lib/cmake/proj/proj-targets-release.cmake`

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

He add the symbolic link /usr/local/lib/libproj.so.25.9.3.0to make the find package working

## What are related issues/pull requests?

Currently, I get the error 
```

#31 1.753 CMake Error at /usr/local/lib/cmake/proj/proj-targets.cmake:74 (message):
#31 1.753   The imported target "PROJ::proj" references the file
#31 1.753 
#31 1.753      "/usr/local/lib/libproj.so.25.9.3.0"
#31 1.753 
#31 1.753   but this file does not exist.  Possible reasons include:
#31 1.753 
#31 1.753   * The file was deleted, renamed, or moved to another location.
#31 1.753 
#31 1.753   * An install or uninstall procedure did not complete successfully.
#31 1.753 
#31 1.753   * The installation package was faulty and contained
#31 1.753 
#31 1.753      "/usr/local/lib/cmake/proj/proj-targets.cmake"
#31 1.753 
#31 1.753   but not all the files it references.
#31 1.753 
#31 1.753 Call Stack (most recent call first):
#31 1.753   /usr/local/lib/cmake/proj/proj-config.cmake:65 (include)
#31 1.753   cmake/FindProj.cmake:21 (find_package)
#31 1.753   CMakeLists.txt:361 (find_package)
#31 1.753 
#31 1.753 
#31 1.753 -- Configuring incomplete, errors occurred!
#31 1.753 See also "/src/build/CMakeFiles/CMakeOutput.log".
#31 ERROR: process "/bin/bash -o pipefail -cux cmake ..     -GNinja     -DCMAKE_C_FLAGS=\"-O2 -DPROJ_RENAME_SYMBOLS\"     -DCMAKE_CXX_FLAGS=\"-O2 -DPROJ_RENAME_SYMBOLS\"     -DCMAKE_BUILD_TYPE=Release     -DCMAKE_INSTALL_PREFIX=/usr/local     -DWITH_DESKTOP=OFF     -DWITH_SERVER=ON     -DWITH_SERVER_LANDINGPAGE_WEBAPP=ON     -DBUILD_TESTING=OFF     -DENABLE_TESTS=OFF     -DCMAKE_PREFIX_PATH=/src/external/qt3dextra-headers/cmake" did not complete successfully: exit code: 1
------
 > [builder 13/14] RUN cmake ..     -GNinja     -DCMAKE_C_FLAGS="-O2 -DPROJ_RENAME_SYMBOLS"     -DCMAKE_CXX_FLAGS="-O2 -DPROJ_RENAME_SYMBOLS"     -DCMAKE_BUILD_TYPE=Release     -DCMAKE_INSTALL_PREFIX=/usr/local     -DWITH_DESKTOP=OFF     -DWITH_SERVER=ON     -DWITH_SERVER_LANDINGPAGE_WEBAPP=ON     -DBUILD_TESTING=OFF     -DENABLE_TESTS=OFF     -DCMAKE_PREFIX_PATH=/src/external/qt3dextra-headers/cmake:
1.753   but not all the files it references.
1.753 
1.753 Call Stack (most recent call first):
1.753   /usr/local/lib/cmake/proj/proj-config.cmake:65 (include)
1.753   cmake/FindProj.cmake:21 (find_package)
1.753   CMakeLists.txt:361 (find_package)
1.753 
1.753 
1.753 -- Configuring incomplete, errors occurred!
1.753 See also "/src/build/CMakeFiles/CMakeOutput.log".
```


## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
