### PR TITLE
OpenFileGDB raster: add a RASTER_DATASET metadata item with the name of the RasterDataset (fixes #8427)

### DIFF
--- a/ogr/ogrsf_frmts/openfilegdb/gdalopenfilegdbrasterband.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/gdalopenfilegdbrasterband.cpp
@@ -834,6 +834,8 @@ bool OGROpenFileGDBDataSource::OpenRaster(const GDALOpenInfo *poOpenInfo,
 
     ReadAuxTable(osLayerName);
 
+    SetMetadataItem("RASTER_DATASET", m_osRasterLayerName.c_str());
+
     if (!osDefinition.empty())
     {
         const char *const apszMD[] = {osDefinition.c_str(), nullptr};


### PR DESCRIPTION
```
$ gdalinfo  Raster_class.gdb
[...]
Metadata:
  RASTER_DATASET=Tacoma_landcover_t2
```