### PR TITLE
add GDALRegisterPlugins function to register all/only plugins

### DIFF
--- a/autotest/cpp/test_gdal.cpp
+++ b/autotest/cpp/test_gdal.cpp
@@ -58,6 +58,12 @@ TEST_F(test_gdal, driver_manager)
     ASSERT_TRUE(nullptr != drv_mgr);
 }
 
+// Test that GDALRegisterPlugins can be called
+TEST_F(test_gdal, register_plugins)
+{
+    GDALRegisterPlugins();
+}
+
 // Test number of registered GDAL drivers
 TEST_F(test_gdal, number_of_registered_drivers)
 {

--- a/frmts/gdalallregister.cpp
+++ b/frmts/gdalallregister.cpp
@@ -58,8 +58,9 @@ static char *szConfiguredFormats = "GDAL_FORMATS";
  * fine tuning which drivers are needed at runtime.
  * 
  * @see GDALDriverManager::AutoLoadDrivers()
+ * @since GDAL 3.8
 */
-void CPL_DLL CPL_STDCALL GDALRegisterPlugins(void)
+void CPL_DLL GDALRegisterPlugins(void)
 {
     auto poDriverManager = GetGDALDriverManager();
     // AutoLoadDrivers is a no-op if compiled with GDAL_NO_AUTOLOAD defined.

--- a/frmts/gdalallregister.cpp
+++ b/frmts/gdalallregister.cpp
@@ -41,6 +41,41 @@ static char *szConfiguredFormats = "GDAL_FORMATS";
 #endif
 
 /************************************************************************/
+/*                          GDALRegisterPlugins()                       */
+/*                                                                      */
+/*      Register drivers and support code available as a plugin.        */
+/************************************************************************/
+
+/**
+ * \brief Register drivers and support code available as a plugin.
+ * 
+ * This function will call GDALDriverManager::AutoLoadDrivers() to
+ * register all drivers or supporting code (for example VRT pixelfunctions
+ * or VSI adapters) that have not been compiled into the GDAL core but instead
+ * are made available through GDAL's plugin mechanism.
+ * 
+ * This method is intended to be called instead of GDALAllRegister() when
+ * fine tuning which drivers are needed at runtime.
+ * 
+ * @see GDALDriverManager::AutoLoadDrivers()
+*/
+void CPL_DLL CPL_STDCALL GDALRegisterPlugins(void)
+{
+    auto poDriverManager = GetGDALDriverManager();
+    // AutoLoadDrivers is a no-op if compiled with GDAL_NO_AUTOLOAD defined.
+    poDriverManager->AutoLoadDrivers();
+    poDriverManager->AutoLoadPythonDrivers();
+
+    /* -------------------------------------------------------------------- */
+    /*      Deregister any drivers explicitly marked as suppressed by the   */
+    /*      GDAL_SKIP environment variable.                                 */
+    /* -------------------------------------------------------------------- */
+    poDriverManager->AutoSkipDrivers();
+
+    poDriverManager->ReorderDrivers();
+}
+
+/************************************************************************/
 /*                          GDALAllRegister()                           */
 /*                                                                      */
 /*      Register all identifiably supported formats.                    */

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -877,6 +877,7 @@ typedef struct GDALDimensionHS *GDALDimensionH;
                             UpdateRelationship()*/
 
 void CPL_DLL CPL_STDCALL GDALAllRegister(void);
+void CPL_DLL CPL_STDCALL GDALRegisterPlugins(void);
 
 GDALDatasetH CPL_DLL CPL_STDCALL
 GDALCreate(GDALDriverH hDriver, const char *, int, int, int, GDALDataType,

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -877,7 +877,7 @@ typedef struct GDALDimensionHS *GDALDimensionH;
                             UpdateRelationship()*/
 
 void CPL_DLL CPL_STDCALL GDALAllRegister(void);
-void CPL_DLL CPL_STDCALL GDALRegisterPlugins(void);
+void CPL_DLL GDALRegisterPlugins(void);
 
 GDALDatasetH CPL_DLL CPL_STDCALL
 GDALCreate(GDALDriverH hDriver, const char *, int, int, int, GDALDataType,


### PR DESCRIPTION
implements #8422

for the naming I went with RegisterPlugins instead of AutoloadDrivers, as the
plugin mechanism can be used for registering more than just drivers (e.g. vrt
pixel functions, VSI handlers, ...)
