### PR TITLE
SWIG: Expose GDALClose

### DIFF
--- a/autotest/gcore/basic_test.py
+++ b/autotest/gcore/basic_test.py
@@ -834,6 +834,31 @@ def test_create_context_manager(tmp_path):
     assert ds_in.GetRasterBand(1).Checksum() != 0
 
 
+def test_dataset_use_after_close_1():
+    ds = gdal.Open("data/byte.tif")
+    assert ds is not None
+
+    ds.Close()
+
+    with pytest.raises(Exception):
+        ds.GetRasterBand(1)
+
+
+def test_dataset_use_after_close_2():
+    ds = gdal.Open("data/byte.tif")
+    assert ds is not None
+
+    ds2 = ds
+
+    ds2.Close()
+
+    with pytest.raises(Exception):
+        ds.GetRasterBand(1)
+
+    with pytest.raises(Exception):
+        ds2.GetRasterBand(1)
+
+
 def test_band_use_after_dataset_close_1():
     ds = gdal.Open("data/byte.tif")
     band = ds.GetRasterBand(1)

--- a/autotest/ogr/ogr_basic_test.py
+++ b/autotest/ogr/ogr_basic_test.py
@@ -975,6 +975,34 @@ def test_datasource_use_after_close_2():
         ds2.GetLayer(0)
 
 
+def test_datasource_use_after_destroy():
+    ds = ogr.Open("data/poly.shp")
+
+    ds2 = ds
+
+    ds.Destroy()
+
+    with pytest.raises(Exception):
+        ds.GetLayer(0)
+
+    with pytest.raises(Exception):
+        ds2.GetLayer(0)
+
+
+def test_datasource_use_after_release():
+    ds = ogr.Open("data/poly.shp")
+
+    ds2 = ds
+
+    ds.Release()
+
+    with pytest.raises(Exception):
+        ds.GetLayer(0)
+
+    with pytest.raises(Exception):
+        ds2.GetLayer(0)
+
+
 def test_layer_use_after_datasource_close_1():
     with ogr.Open("data/poly.shp") as ds:
         lyr = ds.GetLayer(0)
@@ -1010,3 +1038,25 @@ def test_layer_use_after_datasource_close_3(tmp_path):
     # Make sure ds.__exit__() has invalidated "lyr2" so we don't crash here
     with pytest.raises(Exception):
         lyr2.GetFeatureCount()
+
+
+def test_layer_use_after_datasource_destroy():
+    ds = ogr.Open("data/poly.shp")
+    lyr = ds.GetLayerByName("poly")
+
+    ds.Destroy()
+
+    # Make sure ds.Destroy() has invalidated "lyr" so we don't crash here
+    with pytest.raises(Exception):
+        lyr.GetFeatureCount()
+
+
+def test_layer_use_after_datasource_release():
+    ds = ogr.Open("data/poly.shp")
+    lyr = ds.GetLayerByName("poly")
+
+    ds.Release()
+
+    # Make sure ds.Release() has invalidated "lyr" so we don't crash here
+    with pytest.raises(Exception):
+        lyr.GetFeatureCount()

--- a/autotest/ogr/ogr_basic_test.py
+++ b/autotest/ogr/ogr_basic_test.py
@@ -947,7 +947,32 @@ def test_ogr_basic_create_data_source_context_manager(tmp_path):
 
 
 ###############################################################################
-# check layer access after datasource has closed
+# check access after datasource has closed
+
+
+def test_datasource_use_after_close_1():
+    ds = ogr.Open("data/poly.shp")
+
+    assert ds is not None
+
+    ds.Close()
+
+    with pytest.raises(Exception):
+        ds.GetLayer(0)
+
+
+def test_datasource_use_after_close_2():
+    ds = ogr.Open("data/poly.shp")
+
+    ds2 = ds
+
+    ds.Close()
+
+    with pytest.raises(Exception):
+        ds.GetLayer(0)
+
+    with pytest.raises(Exception):
+        ds2.GetLayer(0)
 
 
 def test_layer_use_after_datasource_close_1():

--- a/swig/include/Dataset.i
+++ b/swig/include/Dataset.i
@@ -288,6 +288,10 @@ public:
     }
   }
 
+  CPLErr Close() {
+     return GDALClose(self);
+  }
+
   GDALDriverShadow* GetDriver() {
     return (GDALDriverShadow*) GDALGetDatasetDriver( self );
   }

--- a/swig/include/ogr.i
+++ b/swig/include/ogr.i
@@ -871,8 +871,13 @@ public:
   char const *name;
 %mutable;
 
+
   ~OGRDataSourceShadow() {
     OGRReleaseDataSource(self);
+  }
+
+  CPLErr Close() {
+    return GDALClose(self);
   }
 
   int GetRefCount() {

--- a/swig/include/python/docs/gdal_dataset_docs.i
+++ b/swig/include/python/docs/gdal_dataset_docs.i
@@ -7,5 +7,15 @@ data will be written to disk.
 "
 
 %extend GDALDatasetShadow {
+
+%feature("docstring")  Close "
+Closes opened dataset and releases allocated resources.
+
+This method can be used to force the dataset to close
+when one more references to the dataset are still
+reachable. If Close is never called, the dataset will
+be closed automatically during garbage collection.
+"
+
 }
 

--- a/swig/include/python/docs/ogr_datasource_docs.i
+++ b/swig/include/python/docs/ogr_datasource_docs.i
@@ -8,6 +8,16 @@ features will be written to disk.
 
 %extend OGRDataSourceShadow {
 // File: ogrdatasource_8cpp.xml
+
+%feature("docstring")  Close "
+Closes opened dataset and releases allocated resources.
+
+This method can be used to force the dataset to close
+when one more references to the dataset are still
+reachable. If Close is never called, the dataset will
+be closed automatically during garbage collection.
+"
+
 %feature("docstring")  Destroy "void OGR_DS_Destroy(OGRDataSourceH
 hDS)
 

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -1088,10 +1088,14 @@ CPLErr ReadRaster1( double xoff, double yoff, double xsize, double ysize,
         return self
 
     def __exit__(self, *args):
-        self._invalidate_bands()
+        self.Close()
+%}
 
-        _gdal.delete_Dataset(self)
-        self.this = None
+%feature("pythonappend") Close %{
+    self.thisown = 0
+    self.this = None
+    self._invalidate_bands()
+    return val
 %}
 
 %feature("shadow") ExecuteSQL %{

--- a/swig/include/python/ogr_python.i
+++ b/swig/include/python/ogr_python.i
@@ -82,11 +82,15 @@ def _WarnIfUserHasNotSpecifiedIfUsingExceptions():
       "Once called, self has effectively been destroyed.  Do not access. For backwards compatibility only"
       _ogr.delete_DataSource(self)
       self.thisown = 0
+      self.this = None
+      self._invalidate_layers()
 
     def Release(self):
       "Once called, self has effectively been destroyed.  Do not access. For backwards compatibility only"
       _ogr.delete_DataSource(self)
       self.thisown = 0
+      self.this = None
+      self._invalidate_layers()
 
     def Reference(self):
       "For backwards compatibility only."

--- a/swig/include/python/ogr_python.i
+++ b/swig/include/python/ogr_python.i
@@ -77,6 +77,7 @@ def _WarnIfUserHasNotSpecifiedIfUsingExceptions():
 
 %extend OGRDataSourceShadow {
   %pythoncode {
+
     def Destroy(self):
       "Once called, self has effectively been destroyed.  Do not access. For backwards compatibility only"
       _ogr.delete_DataSource(self)
@@ -103,9 +104,7 @@ def _WarnIfUserHasNotSpecifiedIfUsingExceptions():
         return self
 
     def __exit__(self, *args):
-        self._invalidate_layers()
-        self.Destroy()
-        self.this = None
+        self.Close()
 
     def __del__(self):
         self._invalidate_layers()
@@ -177,6 +176,13 @@ def _WarnIfUserHasNotSpecifiedIfUsingExceptions():
 
 %feature("pythonappend") CopyLayer %{
     self._add_layer_ref(val)
+%}
+
+%feature("pythonappend") Close %{
+    self.thisown = 0
+    self.this = None
+    self._invalidate_layers()
+    return val
 %}
 
 %feature("shadow") DeleteLayer %{


### PR DESCRIPTION
## What does this PR do?

Exposes `GDALClose` through SWIG so that `DataSource` and `Dataset` objects can be explicitly closed. I named the method `Close` rather than `close` for consistency with the rest of the library. I do not expect this method to be used often. For most cases, a `with` block would be a better choice.

For `DataSource`, this is essentially a synonym of `Destroy`, except that it does not leave the object in a state where further use will cause a crash. Instead, further use will cause an unintuitive `TypeError`:

```
>>> ds.Close()
0
>>> ds.GetLayerCount()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/dan/dev/build-gdal-Desktop-Debug/swig/python/osgeo/ogr.py", line 830, in GetLayerCount
    return _ogr.DataSource_GetLayerCount(self, *args)
TypeError: in method 'DataSource_GetLayerCount', argument 1 of type 'OGRDataSourceShadow *'
```

We can get a better error message by annotating _every single method_ with an explicit check, e.g.:

```
%feature("pythonprepend") GetLayerCount %{
    if self.this is None:
        raise ValueError("Operation on closed Dataset")
%}
```

but it appears for now (https://github.com/swig/swig/issues/2657) that there is no automated way to ask SWIG to apply this to all methods. 

## What are related issues/pull requests?

## Tasklist

 - [x] Add test case(s)
 - [ ] Add documentation
 - [x] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
