### PR TITLE
GDALMDArray::AsClassicDataset(): allow to map band indexing arrays as band metadata items

### DIFF
--- a/autotest/gcore/multidim.py
+++ b/autotest/gcore/multidim.py
@@ -29,6 +29,7 @@
 ###############################################################################
 
 import array
+import json
 import math
 
 import gdaltest
@@ -616,3 +617,197 @@ def test_multidim_getgridded():
             5,
         ],
     )
+
+
+@gdaltest.enable_exceptions()
+def test_multidim_asclassicsubdataset_band_metadata():
+
+    drv = gdal.GetDriverByName("MEM")
+    mem_ds = drv.CreateMultiDimensional("myds")
+    rg = mem_ds.GetRootGroup()
+
+    dimOther = rg.CreateDimension("other", None, None, 2)
+    other = rg.CreateMDArray(
+        "other", [dimOther], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    other.Write(array.array("d", [10.5, 20]))
+    dimOther.SetIndexingVariable(other)
+    numeric_attr = other.CreateAttribute(
+        "numeric_attr", [], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    assert numeric_attr.Write(1) == gdal.CE_None
+    string_attr = other.CreateAttribute(
+        "string_attr", [], gdal.ExtendedDataType.CreateString()
+    )
+    assert string_attr.Write("string_attr_value") == gdal.CE_None
+
+    dimX = rg.CreateDimension("X", None, None, 2)
+    X = rg.CreateMDArray("X", [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Float64))
+    X.Write(array.array("d", [10, 20]))
+    dimX.SetIndexingVariable(X)
+    dimY = rg.CreateDimension("Y", None, None, 2)
+
+    ar = rg.CreateMDArray(
+        "ar", [dimOther, dimY, dimX], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+
+    aux_var = rg.CreateMDArray(
+        "aux_var", [dimOther], gdal.ExtendedDataType.CreateString()
+    )
+    aux_var.Write(["foo", "bar"])
+
+    with pytest.raises(
+        Exception, match="Root group should be provided when BAND_METADATA is set"
+    ):
+        ar.AsClassicDataset(2, 1, None, ["BAND_METADATA=[]"])
+
+    with pytest.raises(Exception, match="Invalid JSON content for BAND_METADATA"):
+        ar.AsClassicDataset(2, 1, rg, ["BAND_METADATA=invalid"])
+
+    with pytest.raises(Exception, match="Value of BAND_METADATA should be an array"):
+        ar.AsClassicDataset(2, 1, rg, ["BAND_METADATA=false"])
+
+    band_metadata = [{"item_name": "name"}]
+    with pytest.raises(Exception, match=r"BAND_METADATA\[0\]\[\"array\"\] is missing"):
+        ds = ar.AsClassicDataset(
+            2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)]
+        )
+
+    band_metadata = [{"array": "/i/do/not/exist", "item_name": "name"}]
+    with pytest.raises(Exception, match="Array /i/do/not/exist cannot be found"):
+        ds = ar.AsClassicDataset(
+            2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)]
+        )
+
+    band_metadata = [{"array": "/ar", "item_name": "name"}]
+    with pytest.raises(Exception, match="Array /ar is not a 1D array"):
+        ds = ar.AsClassicDataset(
+            2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)]
+        )
+
+    band_metadata = [{"array": "/X", "item_name": "name"}]
+    with pytest.raises(
+        Exception,
+        match="Dimension X of array /X is not a non-X/Y dimension of array ar",
+    ):
+        ds = ar.AsClassicDataset(
+            2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)]
+        )
+
+    band_metadata = [{"array": "/other"}]
+    with pytest.raises(
+        Exception, match=r"BAND_METADATA\[0\]\[\"item_name\"\] is missing"
+    ):
+        ds = ar.AsClassicDataset(
+            2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)]
+        )
+
+    band_metadata = [{"array": "/other", "item_name": "other", "item_value": "%f %f"}]
+    with pytest.raises(Exception, match="formatters should be specified at most once"):
+        ds = ar.AsClassicDataset(
+            2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)]
+        )
+
+    band_metadata = [{"array": "/other", "item_name": "other", "item_value": "%d"}]
+    with pytest.raises(
+        Exception, match=r"only %\[x\]\[\.y\]f\|g or \%s formatters are accepted"
+    ):
+        ds = ar.AsClassicDataset(
+            2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)]
+        )
+
+    band_metadata = [{"array": "/other", "item_name": "other", "item_value": "%"}]
+    with pytest.raises(Exception, match="is invalid at offset 0"):
+        ds = ar.AsClassicDataset(
+            2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)]
+        )
+
+    band_metadata = [
+        {"array": "/other", "item_name": "other", "item_value": "${numeric_attr"}
+    ]
+    with pytest.raises(Exception, match="is invalid at offset 0"):
+        ds = ar.AsClassicDataset(
+            2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)]
+        )
+
+    band_metadata = [
+        {"array": "/other", "item_name": "other", "item_value": "${i_do_not_exist}"}
+    ]
+    with pytest.raises(Exception, match="i_do_not_exist is not an attribute of other"):
+        ds = ar.AsClassicDataset(
+            2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)]
+        )
+
+    band_metadata = [{"array": "/aux_var", "item_name": "AUX_VAR", "item_value": "%f"}]
+    with pytest.raises(Exception, match="Data type of other array is not numeric"):
+        ds = ar.AsClassicDataset(
+            2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)]
+        )
+
+    band_metadata = []
+    ds = ar.AsClassicDataset(2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)])
+    assert ds.GetRasterBand(1).GetMetadata() == {
+        "DIM_other_INDEX": "0",
+        "DIM_other_VALUE": "10.5",
+    }
+
+    band_metadata = [{"array": "/other", "item_name": "OTHER"}]
+    ds = ar.AsClassicDataset(2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)])
+    assert ds.GetRasterBand(1).GetMetadata() == {
+        "DIM_other_INDEX": "0",
+        "OTHER": "10.5",
+    }
+
+    band_metadata = [
+        {
+            "array": "/other",
+            "item_name": "OTHER",
+            "item_value": "%s in pct(%%) with numeric_attr=${numeric_attr} and string_attr=${string_attr}",
+        }
+    ]
+    ds = ar.AsClassicDataset(2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)])
+    assert ds.GetRasterBand(1).GetMetadata() == {
+        "DIM_other_INDEX": "0",
+        "OTHER": "10.5 in pct(%) with numeric_attr=1 and string_attr=string_attr_value",
+    }
+
+    band_metadata = [{"array": "/other", "item_name": "OTHER", "item_value": "%f"}]
+    ds = ar.AsClassicDataset(2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)])
+    assert ds.GetRasterBand(1).GetMetadata() == {
+        "DIM_other_INDEX": "0",
+        "OTHER": "10.500000",
+    }
+
+    band_metadata = [{"array": "/other", "item_name": "OTHER", "item_value": "%2.3f"}]
+    ds = ar.AsClassicDataset(2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)])
+    assert ds.GetRasterBand(1).GetMetadata() == {
+        "DIM_other_INDEX": "0",
+        "OTHER": "10.500",
+    }
+
+    band_metadata = [{"array": "/other", "item_name": "OTHER", "item_value": "%g"}]
+    ds = ar.AsClassicDataset(2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)])
+    assert float(ds.GetRasterBand(1).GetMetadataItem("OTHER")) == 10.5
+
+    band_metadata = [
+        {"array": "/other", "item_name": "OTHER"},
+        {
+            "array": "/other",
+            "item_name": "OTHER_STRING_ATTR",
+            "item_value": "${string_attr}",
+        },
+        {"array": "/aux_var", "item_name": "AUX_VAR"},
+    ]
+    ds = ar.AsClassicDataset(2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)])
+    assert ds.GetRasterBand(1).GetMetadata() == {
+        "DIM_other_INDEX": "0",
+        "OTHER": "10.5",
+        "OTHER_STRING_ATTR": "string_attr_value",
+        "AUX_VAR": "foo",
+    }
+    assert ds.GetRasterBand(2).GetMetadata() == {
+        "DIM_other_INDEX": "1",
+        "OTHER": "20",
+        "OTHER_STRING_ATTR": "string_attr_value",
+        "AUX_VAR": "bar",
+    }

--- a/frmts/zarr/zarrdriver.cpp
+++ b/frmts/zarr/zarrdriver.cpp
@@ -558,7 +558,7 @@ GDALDataset *ZarrDataset::Open(GDALOpenInfo *poOpenInfo)
         // Pass papszOpenOptions for LOAD_EXTRA_DIM_METADATA_DELAY
         auto poNewDS =
             std::unique_ptr<GDALDataset>(poMainArray->AsClassicDataset(
-                iXDim, iYDim, poOpenInfo->papszOpenOptions));
+                iXDim, iYDim, poRG, poOpenInfo->papszOpenOptions));
         if (!poNewDS)
             return nullptr;
 

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -2244,6 +2244,10 @@ GDALMDArrayH CPL_DLL GDALMDArrayGetMask(GDALMDArrayH hArray,
                                         CSLConstList papszOptions);
 GDALDatasetH CPL_DLL GDALMDArrayAsClassicDataset(GDALMDArrayH hArray,
                                                  size_t iXDim, size_t iYDim);
+GDALDatasetH CPL_DLL GDALMDArrayAsClassicDatasetEx(GDALMDArrayH hArray,
+                                                   size_t iXDim, size_t iYDim,
+                                                   GDALGroupH hRootGroup,
+                                                   CSLConstList papszOptions);
 CPLErr CPL_DLL GDALMDArrayGetStatistics(
     GDALMDArrayH hArray, GDALDatasetH, int bApproxOK, int bForce,
     double *pdfMin, double *pdfMax, double *pdfMean, double *pdfStdDev,

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -2987,6 +2987,7 @@ class CPL_DLL GDALMDArray : virtual public GDALAbstractMDArray,
 
     virtual GDALDataset *
     AsClassicDataset(size_t iXDim, size_t iYDim,
+                     const std::shared_ptr<GDALGroup> &poRootGroup = nullptr,
                      CSLConstList papszOptions = nullptr) const;
 
     virtual CPLErr GetStatistics(bool bApproxOK, bool bForce, double *pdfMin,

--- a/swig/include/MultiDimensional.i
+++ b/swig/include/MultiDimensional.i
@@ -1080,9 +1080,11 @@ public:
   }
 
 %newobject AsClassicDataset;
-  GDALDatasetShadow* AsClassicDataset(size_t iXDim, size_t iYDim)
+  GDALDatasetShadow* AsClassicDataset(size_t iXDim, size_t iYDim,
+                                      GDALGroupHS* hRootGroup = NULL,
+                                      char** options = 0)
   {
-    return (GDALDatasetShadow*)GDALMDArrayAsClassicDataset(self, iXDim, iYDim);
+    return (GDALDatasetShadow*)GDALMDArrayAsClassicDatasetEx(self, iXDim, iYDim, hRootGroup, options);
   }
 
 #ifndef SWIGCSHARP


### PR DESCRIPTION
Add a BAND_METADATA options to papszOptions:

JSON serialized array defining which
arrays of the poRootGroup, indexed by non-X and Y
dimensions, should be mapped as band metadata items. Each array item should be an object with the
following members:
- "array": full name of a band parameter array. Such array must be a one dimensional array, and its dimension must be one of the dimensions of the array on which the method is called (excluding the X and Y dimensons).
- "item_name": band metadata item name
- "item_value": (optional) String, where "%[x][.y]f", "%[x][.y]g" or "%s" printf-like formatting can be used to format the corresponding value of the parameter array. The percentage character should be repeated: "%%" "${attribute_name}" can also be used to include the value of an attribute for the array. If "item_value" is not provided, a default formatting of the value will be applied.

Example:
```json
[
   {
     "array": "/sensor_band_parameters/wavelengths",
     "item_name": "WAVELENGTH",
     "item_value": "%.1f ${units}"
   },
   {
     "array": "/sensor_band_parameters/fwhm",
     "item_name": "FWHM"
   },
   {
     "array": "/sensor_band_parameters/fwhm",
     "item_name": "FWHM_UNIT",
     "item_value": "${units}"
   }
]
```
