### PR TITLE
gdal_translate: add  -dmo option for domain-specific md

### DIFF
--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -59,6 +59,8 @@
 
 static int ArgIsNumeric(const char *);
 static void AttachMetadata(GDALDatasetH, const CPLStringList &);
+static void AttachDomainMetadata(GDALDatasetH, const CPLStringList &);
+
 static void CopyBandInfo(GDALRasterBand *poSrcBand, GDALRasterBand *poDstBand,
                          int bCanCopyStatsMetadata, int bCopyScale,
                          int bCopyNoData, bool bCopyRAT,
@@ -196,10 +198,11 @@ struct GDALTranslateOptions
 
     bool bHasUsedExplicitExponentBand = false;
 
-    /*! list of metadata key and value to set on the output dataset if possible.
-     *  GDALTranslateOptionsSetMetadataOptions() and
-     * GDALTranslateOptionsAddMetadataOptions() should be used */
+    /*! list of metadata key and value to set on the output dataset if possible. */
     CPLStringList aosMetadataOptions{};
+
+    /*! list of metadata key and value in a domain to set on the output dataset if possible. */
+    CPLStringList aosDomainMetadataOptions{};
 
     /*! override the projection for the output file. The SRS may be any of the
        usual GDAL/OGR forms, complete WKT, PROJ.4, EPSG:n or a file containing
@@ -1258,10 +1261,10 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
         psOptions->asScaleParams.empty() && psOptions->adfExponent.empty() &&
         !psOptions->bUnscale && !psOptions->bSetScale &&
         !psOptions->bSetOffset && psOptions->aosMetadataOptions.empty() &&
-        bAllBandsInOrder && psOptions->eMaskMode == MASK_AUTO &&
-        bSpatialArrangementPreserved && !psOptions->bNoGCP &&
-        psOptions->nGCPCount == 0 && !bGotBounds && !bGotGeoTransform &&
-        psOptions->osOutputSRS.empty() &&
+        psOptions->aosDomainMetadataOptions.empty() && bAllBandsInOrder &&
+        psOptions->eMaskMode == MASK_AUTO && bSpatialArrangementPreserved &&
+        !psOptions->bNoGCP && psOptions->nGCPCount == 0 && !bGotBounds &&
+        !bGotGeoTransform && psOptions->osOutputSRS.empty() &&
         psOptions->dfOutputCoordinateEpoch == 0 && !psOptions->bSetNoData &&
         !psOptions->bUnsetNoData && psOptions->nRGBExpand == 0 &&
         !psOptions->bNoRAT && psOptions->anColorInterp.empty() &&
@@ -1803,7 +1806,11 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
 
     poVDS->SetMetadata(papszMetadata);
     CSLDestroy(papszMetadata);
+
     AttachMetadata(GDALDataset::ToHandle(poVDS), psOptions->aosMetadataOptions);
+
+    AttachDomainMetadata(GDALDataset::ToHandle(poVDS),
+                         psOptions->aosDomainMetadataOptions);
 
     const char *pszInterleave =
         poSrcDS->GetMetadataItem("INTERLEAVE", "IMAGE_STRUCTURE");
@@ -2642,6 +2649,31 @@ static void AttachMetadata(GDALDatasetH hDS,
 }
 
 /************************************************************************/
+/*                           AttachDomainMetadata()                           */
+/************************************************************************/
+
+static void AttachDomainMetadata(GDALDatasetH hDS,
+                                 const CPLStringList &aosDomainMetadataOptions)
+
+{
+    const int nCount = aosDomainMetadataOptions.size();
+
+    for (int i = 0; i < nCount; i++)
+    {
+        // FIXME: catch invalid cases syntax is DOMAIN:META-TAG=value
+        CPLStringList aosTokens(
+            CSLTokenizeString2(aosDomainMetadataOptions[i], ":", 0));
+        char *pszKey = nullptr;
+        const char *pszValue = CPLParseNameValue(aosTokens[1], &pszKey);
+        if (pszKey && pszValue)
+        {
+            GDALSetMetadataItem(hDS, pszKey, pszValue, aosTokens[0]);
+        }
+        CPLFree(pszKey);
+    }
+}
+
+/************************************************************************/
 /*                           CopyBandInfo()                            */
 /************************************************************************/
 
@@ -3137,6 +3169,11 @@ GDALTranslateOptionsNew(char **papszArgv,
         else if (EQUAL(papszArgv[i], "-mo") && papszArgv[i + 1])
         {
             psOptions->aosMetadataOptions.AddString(papszArgv[++i]);
+        }
+
+        else if (EQUAL(papszArgv[i], "-dmo") && papszArgv[i + 1])
+        {
+            psOptions->aosDomainMetadataOptions.AddString(papszArgv[++i]);
         }
 
         else if (i + 2 < argc && EQUAL(papszArgv[i], "-outsize") &&

--- a/autotest/utilities/test_gdal_translate.py
+++ b/autotest/utilities/test_gdal_translate.py
@@ -1115,3 +1115,24 @@ def test_gdal_translate_scale_and_unscale_incompatible(gdal_translate_path):
         + " -a_scale 0.0001 -a_offset 0.1 -unscale ../gcore/data/byte.tif /vsimem/out.tif"
     )
     assert "-a_scale/-a_offset are not applied by -unscale" in err
+
+
+###############################################################################
+# Test -dmo option
+
+
+def test_gdal_translate_dmo_option(gdal_translate_path, tmp_path):
+
+    dst_vrt = str(tmp_path / "test_dmo.vrt")
+
+    gdaltest.runexternal(
+        f"{gdal_translate_path} -dmo NEW_DOMAIN:META-TAG=value ../gcore/data/byte.tif {dst_vrt}"
+    )
+
+    ds = gdal.Open(dst_vrt)
+    assert ds is not None
+
+    md = ds.GetMetadata("NEW_DOMAIN")
+    assert "META-TAG" in md, "Did not get META-TAG"
+
+    ds = None

--- a/doc/source/development/building_from_source.rst
+++ b/doc/source/development/building_from_source.rst
@@ -99,17 +99,11 @@ Building on MacOS
 
 On MacOS, there are a couple of libraries that do not function properly when the GDAL build requirements are installed using Homebrew.
 
-The `Apache Arrow <https://arrow.apache.org/docs/index.html>`_ library included in the current distribution of CMake is broken, and causes a detection issue. In order to build GDAL successfuly, you must first remove it:
+The `Apache Arrow <https://arrow.apache.org/docs/index.html>`_ library included in the current distribution of CMake is broken, and causes a detection issue. In order to build GDAL successfuly, configure CMake to not find the Arrow package:
 
 .. code-block:: bash
 
-    rm -rf /usr/local/lib/cmake/Arrow
-
-And then set the appropriate options to exclude Arrow from the build:
-
-.. code-block:: bash
-
-    cmake -DGDAL_USE_ARROW=OFF -DGDAL_USE_PARQUET=OFF ..
+    cmake -DCMAKE_DISABLE_FIND_PACKAGE_Arrow=ON ..
 
 
 Similarly, recent versions of Homebrew no longer bundle `Boost <https://www.boost.org/>`_ with libkml, causing a failure to find Boost headers. You should either install Boost manually or disable libkml when building on MacOS:

--- a/doc/source/development/building_from_source.rst
+++ b/doc/source/development/building_from_source.rst
@@ -47,12 +47,6 @@ From the build directory you can now configure CMake, build and install the bina
     and is thus not recommended. It is also not supported on Windows multi-configuration
     generator (such as VisualStudio).
 
-`
-On Windows, one may need to specify generator:
-
-.. code-block:: bash
-
-    cmake -G "Visual Studio 15 2017" ..
 
 If a dependency is installed in a custom location, specify the
 paths to the include directory and the library:
@@ -89,6 +83,41 @@ for the shared lib, *e.g.* ``set (GDAL_LIB_OUTPUT_NAME gdal_x64 CACHE STRING "" 
     you may try removing CMakeCache.txt to start from a clean state.
 
 Refer to :ref:`using_gdal_in_cmake` for how to use GDAL in a CMake project.
+
+Building on Windows
++++++++++++++++++++
+
+On Windows, one may need to specify generator:
+
+.. code-block:: bash
+
+    cmake -G "Visual Studio 15 2017" ..
+
+
+Building on MacOS
++++++++++++++++++
+
+On MacOS, there are a couple of libraries that do not function properly when the GDAL build requirements are installed using Homebrew.
+
+The `Apache Arrow <https://arrow.apache.org/docs/index.html>`_ library included in the current distribution of CMake is broken, and causes a detection issue. In order to build GDAL successfuly, you must first remove it:
+
+.. code-block:: bash
+
+    rm -rf /usr/local/lib/cmake/Arrow
+
+And then set the appropriate options to exclude Arrow from the build:
+
+.. code-block:: bash
+
+    cmake -DGDAL_USE_ARROW=OFF -DGDAL_USE_PARQUET=OFF ..
+
+
+Similarly, recent versions of Homebrew no longer bundle `Boost <https://www.boost.org/>`_ with libkml, causing a failure to find Boost headers. You should either install Boost manually or disable libkml when building on MacOS:
+
+.. code-block:: bash
+
+    cmake -DGDAL_USE_LIBKML=OFF ..
+
 
 CMake general configure options
 +++++++++++++++++++++++++++++++

--- a/doc/source/programs/gdal_translate.rst
+++ b/doc/source/programs/gdal_translate.rst
@@ -34,7 +34,7 @@ Synopsis
         [-nogcp] [-gcp pixel line easting northing [elevation]]*
         |-colorinterp{_bn} {red|green|blue|alpha|gray|undefined}]
         |-colorinterp {red|green|blue|alpha|gray|undefined},...]
-        [-mo "META-TAG=VALUE"]* [-q] [-sds]
+        [-mo "META-TAG=VALUE"]* [-dmo "DOMAIN:META-TAG=VALUE"]* [-q] [-sds]
         [-co "NAME=VALUE"]* [-stats] [-norat] [-noxmp]
         [-oo NAME=VALUE]*
         src_dataset dst_dataset
@@ -306,6 +306,10 @@ resampling, and rescaling pixels in the process.
 .. option:: -mo META-TAG=VALUE
 
     Passes a metadata key and value to set on the output dataset if possible.
+
+.. option:: -dmo DOMAIN:META-TAG=VALUE
+
+    Passes a metadata key and value in specified domain to set on the output dataset if possible.
 
 .. option:: -co <NAME=VALUE>
 


### PR DESCRIPTION
Adds `-dmo` to availalable options for gdal_translate. 

Usage is like that for `mo` but with a domain prefix and colon before the key,value pair: 

```
gdal_translate [in] [out] -dmo DOMAIN:key=value
```

Was discussed on gdal-dev: https://lists.osgeo.org/pipermail/gdal-dev/2023-September/057663.html

Ugh - this includes a PR to building_from_source.rst .... I'll have to restart this. 

 I will add 'dmo' to vrt:// in a future PR. 

I think a bit more doc is needed for what domains are allowed and being driver-specific, but I need a bit more experience to write anything meaningful there. 

## Tasklist

 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed


