### PR TITLE
VSIFilesystemHandler::CopyFile(): detect wrong target file size w.r.t. source file size

### DIFF
--- a/port/cpl_conv.cpp
+++ b/port/cpl_conv.cpp
@@ -3022,7 +3022,8 @@ int CPLUnlinkTree(const char *pszPath)
 int CPLCopyFile(const char *pszNewPath, const char *pszOldPath)
 
 {
-    return VSICopyFile(pszOldPath, pszNewPath, nullptr, 0, nullptr, nullptr,
+    return VSICopyFile(pszOldPath, pszNewPath, nullptr,
+                       static_cast<vsi_l_offset>(-1), nullptr, nullptr,
                        nullptr);
 }
 


### PR DESCRIPTION
Note that nSourceSize==-1 must be passed if file size is unknown
