### PR TITLE
Add time zone flag property to OGRFieldDefn, and use it in ArrowStream interface

### DIFF
--- a/apps/ogrinfo_lib.cpp
+++ b/apps/ogrinfo_lib.cpp
@@ -1195,13 +1195,51 @@ static void ReportOnLayer(CPLString &osRet, CPLJSONObject oLayer,
             const char *pszAlias = poField->GetAlternativeNameRef();
             const std::string &osDomain = poField->GetDomainName();
             const std::string &osComment = poField->GetComment();
+            const auto eType = poField->GetType();
+            std::string osTimeZone;
+            if (eType == OFTTime || eType == OFTDate || eType == OFTDateTime)
+            {
+                const int nTZFlag = poField->GetTZFlag();
+                if (nTZFlag == OGR_TZFLAG_LOCALTIME)
+                {
+                    osTimeZone = "localtime";
+                }
+                else if (nTZFlag == OGR_TZFLAG_MIXED_TZ)
+                {
+                    osTimeZone = "mixed timezones";
+                }
+                else if (nTZFlag == OGR_TZFLAG_UTC)
+                {
+                    osTimeZone = "UTC";
+                }
+                else if (nTZFlag > 0)
+                {
+                    char chSign;
+                    const int nOffset = (nTZFlag - OGR_TZFLAG_UTC) * 15;
+                    int nHours =
+                        static_cast<int>(nOffset / 60);  // Round towards zero.
+                    const int nMinutes = std::abs(nOffset - nHours * 60);
+
+                    if (nOffset < 0)
+                    {
+                        chSign = '-';
+                        nHours = std::abs(nHours);
+                    }
+                    else
+                    {
+                        chSign = '+';
+                    }
+                    osTimeZone =
+                        CPLSPrintf("%c%02d:%02d", chSign, nHours, nMinutes);
+                }
+            }
+
             if (bJson)
             {
                 CPLJSONObject oField;
                 oFields.Add(oField);
                 oField.Set("name", poField->GetNameRef());
-                oField.Set("type",
-                           OGRFieldDefn::GetFieldTypeName(poField->GetType()));
+                oField.Set("type", OGRFieldDefn::GetFieldTypeName(eType));
                 if (poField->GetSubType() != OFSTNone)
                     oField.Set("subType", OGRFieldDefn::GetFieldSubTypeName(
                                               poField->GetSubType()));
@@ -1220,6 +1258,8 @@ static void ReportOnLayer(CPLString &osRet, CPLJSONObject oLayer,
                     oField.Set("domainName", osDomain);
                 if (!osComment.empty())
                     oField.Set("comment", osComment);
+                if (!osTimeZone.empty())
+                    oField.Set("timezone", osTimeZone);
             }
             else
             {
@@ -1231,9 +1271,20 @@ static void ReportOnLayer(CPLString &osRet, CPLJSONObject oLayer,
                                      OGRFieldDefn::GetFieldSubTypeName(
                                          poField->GetSubType()))
                         : OGRFieldDefn::GetFieldTypeName(poField->GetType());
-                Concat(osRet, psOptions->bStdoutOutput, "%s: %s (%d.%d)",
-                       poField->GetNameRef(), pszType, poField->GetWidth(),
-                       poField->GetPrecision());
+                Concat(osRet, psOptions->bStdoutOutput, "%s: %s",
+                       poField->GetNameRef(), pszType);
+                if (eType == OFTTime || eType == OFTDate ||
+                    eType == OFTDateTime)
+                {
+                    if (!osTimeZone.empty())
+                        Concat(osRet, psOptions->bStdoutOutput, " (%s)",
+                               osTimeZone.c_str());
+                }
+                else
+                {
+                    Concat(osRet, psOptions->bStdoutOutput, " (%d.%d)",
+                           poField->GetWidth(), poField->GetPrecision());
+                }
                 if (poField->IsUnique())
                     Concat(osRet, psOptions->bStdoutOutput, " UNIQUE");
                 if (!poField->IsNullable())

--- a/autotest/ogr/data/gmlas/gmlas_test1.txt
+++ b/autotest/ogr/data/gmlas/gmlas_test1.txt
@@ -59,9 +59,9 @@ decimal: Real (0.0) NOT NULL
 byte: Integer (0.0) NOT NULL
 short: Integer(Int16) (0.0) NOT NULL
 positiveinteger: Integer (0.0) NOT NULL
-dt: DateTime (0.0) NOT NULL
-date: Date (0.0) NOT NULL
-time: Time (0.0) NOT NULL
+dt: DateTime NOT NULL
+date: Date NOT NULL
+time: Time NOT NULL
 boolean: Integer(Boolean) (0.0) NOT NULL
 boolean_array: IntegerList(Boolean) (0.0) NOT NULL
 base64binary: Binary (0.0) NOT NULL
@@ -179,7 +179,7 @@ Layer SRS WKT:
 (unknown)
 ogr_pkid: String (0.0) NOT NULL
 parent_otherns_id: String (0.0) NOT NULL
-value: DateTime (0.0)
+value: DateTime
 OGRFeature(main_elt_dt_array):1
   ogr_pkid (String) = otherns_id_dt_array_1
   parent_otherns_id (String) = otherns_id
@@ -219,7 +219,7 @@ Layer SRS WKT:
 (unknown)
 ogr_pkid: String (0.0) NOT NULL
 parent_otherns_id: String (0.0) NOT NULL
-subelement: DateTime (0.0) NOT NULL
+subelement: DateTime NOT NULL
 OGRFeature(main_elt_unbounded_sequence_1_dt):1
   ogr_pkid (String) = otherns_id_unbounded_sequence_1_dt_1
   parent_otherns_id (String) = otherns_id
@@ -238,7 +238,7 @@ Layer SRS WKT:
 (unknown)
 ogr_pkid: String (0.0) NOT NULL
 parent_otherns_id: String (0.0) NOT NULL
-value: DateTime (0.0)
+value: DateTime
 OGRFeature(main_elt_sequence_1_dt_unbounded_subelement):1
   ogr_pkid (String) = otherns_id_subelement_1
   parent_otherns_id (String) = otherns_id
@@ -257,7 +257,7 @@ Layer SRS WKT:
 (unknown)
 ogr_pkid: String (0.0) NOT NULL
 parent_otherns_id: String (0.0) NOT NULL
-subelement: DateTime (0.0) NOT NULL
+subelement: DateTime NOT NULL
 OGRFeature(main_elt_sequence_unbounded_dt_1):1
   ogr_pkid (String) = otherns_id_sequence_unbounded_dt_1_1
   parent_otherns_id (String) = otherns_id
@@ -292,7 +292,7 @@ Layer SRS WKT:
 (unknown)
 ogr_pkid: String (0.0) NOT NULL
 parent_ogr_pkid: String (0.0) NOT NULL
-value: DateTime (0.0)
+value: DateTime
 OGRFeature(main_elt_sequence_sequence_subsequence_subelement):1
   ogr_pkid (String) = otherns_id_subsequence_1_subelement_1
   parent_ogr_pkid (String) = otherns_id_subsequence_1
@@ -515,7 +515,7 @@ Layer SRS WKT:
 (unknown)
 ogr_pkid: String (0.0) NOT NULL
 parent_ogr_pkid: String (0.0) NOT NULL
-value: DateTime (0.0)
+value: DateTime
 OGRFeature(main_elt_group3_group3_elt3_b2):1
   ogr_pkid (String) = otherns_id_group3_elt1_1_b2_1
   parent_ogr_pkid (String) = otherns_id_group3_elt1_1

--- a/autotest/ogr/data/gmlas/real_world/output/EUReg.example.txt
+++ b/autotest/ogr/data/gmlas/real_world/output/EUReg.example.txt
@@ -45,15 +45,15 @@ act_core_name_nilreason: String (0.0)
 act_core_name_nil: Integer(Boolean) (0.0)
 act_core_name: String (0.0)
 validfrom_nilreason: String (0.0)
-validfrom: DateTime (0.0)
+validfrom: DateTime
 validto_nilreason: String (0.0)
 validto_nil: Integer(Boolean) (0.0)
-validto: DateTime (0.0)
+validto: DateTime
 beginlifespanversion_nilreason: String (0.0)
-beginlifespanversion: DateTime (0.0)
+beginlifespanversion: DateTime
 endlifespanversion_nilreason: String (0.0)
 endlifespanversion_nil: Integer(Boolean) (0.0)
-endlifespanversion: DateTime (0.0)
+endlifespanversion: DateTime
 riverbasindistrict_anyattributes: String (0.0)
 riverbasindistrict: String (0.0)
 hostingsite_href: String (0.0)
@@ -1087,7 +1087,7 @@ OGRFeature(_ogr_fields_metadata):17
   field_max_occurs (Integer) = 1
   field_category (String) = REGULAR
   field_documentation (String) = -- Definition --
-The identifier of the particular version of the spatial object, with a maximum length of 25 characters. If the specification of a spatial object type with an external object identifier includes life-cycle information, the version identifier is used to distinguish between the different versions of a spatial object. Within the set of all versions of a spatial object, the version identifier is unique. 
+The identifier of the particular version of the spatial object, with a maximum length of 25 characters. If the specification of a spatial object type with an external object identifier includes life-cycle information, the version identifier is used to distinguish between the different versions of a spatial object. Within the set of all versions of a spatial object, the version identifier is unique.
 
 -- Description --
 NOTE The maximum length has been selected to allow for time stamps based on ISO 8601, for example, "2007-02-12T12:12:12+05:30" as the version identifier.
@@ -1346,8 +1346,8 @@ OGRFeature(_ogr_fields_metadata):36
   field_min_occurs (Integer) = 0
   field_max_occurs (Integer) = 1
   field_category (String) = REGULAR
-  field_documentation (String) = -- Definition -- 
-Code identifier and/or name assigned to the basin district of a watercourse. 
+  field_documentation (String) = -- Definition --
+Code identifier and/or name assigned to the basin district of a watercourse.
 
 -- Description --
 NOTE  Information required (not registered in the Hydrography Theme) according to Article 3(1) of Directive 2000/60/EC of the European Parliament and of the Council of 23 October 2000 establishing
@@ -3048,7 +3048,7 @@ OGRFeature(_ogr_fields_metadata):357
   field_max_occurs (Integer) = 1
   field_category (String) = REGULAR
   field_documentation (String) = -- Definition --
-The identifier of the particular version of the spatial object, with a maximum length of 25 characters. If the specification of a spatial object type with an external object identifier includes life-cycle information, the version identifier is used to distinguish between the different versions of a spatial object. Within the set of all versions of a spatial object, the version identifier is unique. 
+The identifier of the particular version of the spatial object, with a maximum length of 25 characters. If the specification of a spatial object type with an external object identifier includes life-cycle information, the version identifier is used to distinguish between the different versions of a spatial object. Within the set of all versions of a spatial object, the version identifier is unique.
 
 -- Description --
 NOTE The maximum length has been selected to allow for time stamps based on ISO 8601, for example, "2007-02-12T12:12:12+05:30" as the version identifier.
@@ -3088,7 +3088,7 @@ identifier scheme
 Identifier defining the scheme used to assign the identifier.
 
 -- Description --
-NOTE 1: Reporting requirements for different environmental legislation mandate that each spatial object is assigned an identifier conforming to specific lexical rules. 
+NOTE 1: Reporting requirements for different environmental legislation mandate that each spatial object is assigned an identifier conforming to specific lexical rules.
 
 NOTE 2: These rules are often inconsistent so a spatial object may be assigned multiple identifiers which are used for object referencing to link information to the spatial object.
 
@@ -3723,7 +3723,7 @@ OGRFeature(_ogr_fields_metadata):438
   field_max_occurs (Integer) = 1
   field_category (String) = REGULAR
   field_documentation (String) = -- Definition --
-The identifier of the particular version of the spatial object, with a maximum length of 25 characters. If the specification of a spatial object type with an external object identifier includes life-cycle information, the version identifier is used to distinguish between the different versions of a spatial object. Within the set of all versions of a spatial object, the version identifier is unique. 
+The identifier of the particular version of the spatial object, with a maximum length of 25 characters. If the specification of a spatial object type with an external object identifier includes life-cycle information, the version identifier is used to distinguish between the different versions of a spatial object. Within the set of all versions of a spatial object, the version identifier is unique.
 
 -- Description --
 NOTE The maximum length has been selected to allow for time stamps based on ISO 8601, for example, "2007-02-12T12:12:12+05:30" as the version identifier.
@@ -3763,7 +3763,7 @@ identifier scheme
 Identifier defining the scheme used to assign the identifier.
 
 -- Description --
-NOTE 1: Reporting requirements for different environmental legislation mandate that each spatial object is assigned an identifier conforming to specific lexical rules. 
+NOTE 1: Reporting requirements for different environmental legislation mandate that each spatial object is assigned an identifier conforming to specific lexical rules.
 
 NOTE 2: These rules are often inconsistent so a spatial object may be assigned multiple identifiers which are used for object referencing to link information to the spatial object.
 
@@ -4324,7 +4324,7 @@ OGRFeature(_ogr_fields_metadata):1014
   field_max_occurs (Integer) = 1
   field_category (String) = REGULAR
   field_documentation (String) = -- Definition --
-The identifier of the particular version of the spatial object, with a maximum length of 25 characters. If the specification of a spatial object type with an external object identifier includes life-cycle information, the version identifier is used to distinguish between the different versions of a spatial object. Within the set of all versions of a spatial object, the version identifier is unique. 
+The identifier of the particular version of the spatial object, with a maximum length of 25 characters. If the specification of a spatial object type with an external object identifier includes life-cycle information, the version identifier is used to distinguish between the different versions of a spatial object. Within the set of all versions of a spatial object, the version identifier is unique.
 
 -- Description --
 NOTE The maximum length has been selected to allow for time stamps based on ISO 8601, for example, "2007-02-12T12:12:12+05:30" as the version identifier.
@@ -4685,8 +4685,8 @@ OGRFeature(_ogr_layers_metadata):0
   layer_category (String) = TOP_LEVEL_ELEMENT
   layer_pkid_name (String) = id
   layer_documentation (String) = The basic feature model is given by the gml:AbstractFeatureType.
-The content model for gml:AbstractFeatureType adds two specific properties suitable for geographic features to the content model defined in gml:AbstractGMLType. 
-The value of the gml:boundedBy property describes an envelope that encloses the entire feature instance, and is primarily useful for supporting rapid searching for features that occur in a particular location. 
+The content model for gml:AbstractFeatureType adds two specific properties suitable for geographic features to the content model defined in gml:AbstractGMLType.
+The value of the gml:boundedBy property describes an envelope that encloses the entire feature instance, and is primarily useful for supporting rapid searching for features that occur in a particular location.
 The value of the gml:location property describes the extent, position or relative location of the feature.
 
 OGRFeature(_ogr_layers_metadata):4
@@ -4702,7 +4702,7 @@ function
 
 Activities performed by the activity complex. Function is described by the activity and potentially complemented with information about inputs and outputs as result of it.
 
--- Description -- 
+-- Description --
 NOTE  The Activity described as part of the Function &ldquo;Activity Complex&rdquo; should be recorded using a controlled vocabulary where a particular controlled vocabulary is in use within a given context, such as SIC codes in the UK, it is acceptable to use these, however, the preferred choice for European interoperability is whenever possible NACE [NACE].
 
 OGRFeature(_ogr_layers_metadata):5
@@ -4763,8 +4763,8 @@ OGRFeature(_ogr_layers_metadata):25
   layer_category (String) = TOP_LEVEL_ELEMENT
   layer_pkid_name (String) = id
   layer_documentation (String) = The basic feature model is given by the gml:AbstractFeatureType.
-The content model for gml:AbstractFeatureType adds two specific properties suitable for geographic features to the content model defined in gml:AbstractGMLType. 
-The value of the gml:boundedBy property describes an envelope that encloses the entire feature instance, and is primarily useful for supporting rapid searching for features that occur in a particular location. 
+The content model for gml:AbstractFeatureType adds two specific properties suitable for geographic features to the content model defined in gml:AbstractGMLType.
+The value of the gml:boundedBy property describes an envelope that encloses the entire feature instance, and is primarily useful for supporting rapid searching for features that occur in a particular location.
 The value of the gml:location property describes the extent, position or relative location of the feature.
 
 OGRFeature(_ogr_layers_metadata):30
@@ -4807,8 +4807,8 @@ OGRFeature(_ogr_layers_metadata):35
   layer_category (String) = TOP_LEVEL_ELEMENT
   layer_pkid_name (String) = id
   layer_documentation (String) = The basic feature model is given by the gml:AbstractFeatureType.
-The content model for gml:AbstractFeatureType adds two specific properties suitable for geographic features to the content model defined in gml:AbstractGMLType. 
-The value of the gml:boundedBy property describes an envelope that encloses the entire feature instance, and is primarily useful for supporting rapid searching for features that occur in a particular location. 
+The content model for gml:AbstractFeatureType adds two specific properties suitable for geographic features to the content model defined in gml:AbstractGMLType.
+The value of the gml:boundedBy property describes an envelope that encloses the entire feature instance, and is primarily useful for supporting rapid searching for features that occur in a particular location.
 The value of the gml:location property describes the extent, position or relative location of the feature.
 
 OGRFeature(_ogr_layers_metadata):40
@@ -4826,8 +4826,8 @@ OGRFeature(_ogr_layers_metadata):43
   layer_category (String) = TOP_LEVEL_ELEMENT
   layer_pkid_name (String) = id
   layer_documentation (String) = The basic feature model is given by the gml:AbstractFeatureType.
-The content model for gml:AbstractFeatureType adds two specific properties suitable for geographic features to the content model defined in gml:AbstractGMLType. 
-The value of the gml:boundedBy property describes an envelope that encloses the entire feature instance, and is primarily useful for supporting rapid searching for features that occur in a particular location. 
+The content model for gml:AbstractFeatureType adds two specific properties suitable for geographic features to the content model defined in gml:AbstractGMLType.
+The value of the gml:boundedBy property describes an envelope that encloses the entire feature instance, and is primarily useful for supporting rapid searching for features that occur in a particular location.
 The value of the gml:location property describes the extent, position or relative location of the feature.
 
 OGRFeature(_ogr_layers_metadata):49
@@ -4845,8 +4845,8 @@ OGRFeature(_ogr_layers_metadata):50
   layer_category (String) = TOP_LEVEL_ELEMENT
   layer_pkid_name (String) = id
   layer_documentation (String) = The basic feature model is given by the gml:AbstractFeatureType.
-The content model for gml:AbstractFeatureType adds two specific properties suitable for geographic features to the content model defined in gml:AbstractGMLType. 
-The value of the gml:boundedBy property describes an envelope that encloses the entire feature instance, and is primarily useful for supporting rapid searching for features that occur in a particular location. 
+The content model for gml:AbstractFeatureType adds two specific properties suitable for geographic features to the content model defined in gml:AbstractGMLType.
+The value of the gml:boundedBy property describes an envelope that encloses the entire feature instance, and is primarily useful for supporting rapid searching for features that occur in a particular location.
 The value of the gml:location property describes the extent, position or relative location of the feature.
 
 OGRFeature(_ogr_layers_metadata):106

--- a/autotest/ogr/data/gmlas/real_world/output/Piezometre.06512X0037.STREMY.2.txt
+++ b/autotest/ogr/data/gmlas/real_world/output/Piezometre.06512X0037.STREMY.2.txt
@@ -534,7 +534,7 @@ reporttolegalact_legalact_nilreason: String (0.0)
 reporttolegalact_legalact_owns: Integer(Boolean) (0.0) DEFAULT 'false'
 reporttolegalact_legalact_legislationcitation_pkid: String (0.0)
 reporttolegalact_reportdate_nilreason: String (0.0)
-reporttolegalact_reportdate: DateTime (0.0)
+reporttolegalact_reportdate: DateTime
 reporttolegalact_reportedenvelope_nilreason: String (0.0)
 reporttolegalact_reportedenvelope_nil: Integer(Boolean) (0.0)
 reporttolegalact_reportedenvelope: String (0.0)
@@ -2280,11 +2280,11 @@ OGRFeature(_ogr_fields_metadata):508
   field_max_occurs (Integer) = 1
   field_category (String) = REGULAR
   field_documentation (String) = The method for identifying a temporal position is specific to each temporal reference system.  gml:TimePositionType supports the description of temporal position according to the subtypes described in ISO 19108.
-Values based on calendars and clocks use lexical formats that are based on ISO 8601, as described in XML Schema Part 2:2001. A decimal value may be used with coordinate systems such as GPS time or UNIX time. A URI may be used to provide a reference to some era in an ordinal reference system . 
+Values based on calendars and clocks use lexical formats that are based on ISO 8601, as described in XML Schema Part 2:2001. A decimal value may be used with coordinate systems such as GPS time or UNIX time. A URI may be used to provide a reference to some era in an ordinal reference system .
 In common with many of the components modelled as data types in the ISO 19100 series of International Standards, the corresponding GML component has simple content. However, the content model gml:TimePositionType is defined in several steps.
 Three XML attributes appear on gml:TimePositionType:
-A time value shall be associated with a temporal reference system through the frame attribute that provides a URI reference that identifies a description of the reference system. Following ISO 19108, the Gregorian calendar with UTC is the default reference system, but others may also be used. Components for describing temporal reference systems are described in 14.4, but it is not required that the reference system be described in this, as the reference may refer to anything that may be indentified with a URI.  
-For time values using a calendar containing more than one era, the (optional) calendarEraName attribute provides the name of the calendar era.  
+A time value shall be associated with a temporal reference system through the frame attribute that provides a URI reference that identifies a description of the reference system. Following ISO 19108, the Gregorian calendar with UTC is the default reference system, but others may also be used. Components for describing temporal reference systems are described in 14.4, but it is not required that the reference system be described in this, as the reference may refer to anything that may be indentified with a URI.
+For time values using a calendar containing more than one era, the (optional) calendarEraName attribute provides the name of the calendar era.
 Inexact temporal positions may be expressed using the optional indeterminatePosition attribute.  This takes a value from an enumeration.
 
 OGRFeature(_ogr_fields_metadata):509
@@ -2377,11 +2377,11 @@ OGRFeature(_ogr_fields_metadata):517
   field_max_occurs (Integer) = 1
   field_category (String) = REGULAR
   field_documentation (String) = The method for identifying a temporal position is specific to each temporal reference system.  gml:TimePositionType supports the description of temporal position according to the subtypes described in ISO 19108.
-Values based on calendars and clocks use lexical formats that are based on ISO 8601, as described in XML Schema Part 2:2001. A decimal value may be used with coordinate systems such as GPS time or UNIX time. A URI may be used to provide a reference to some era in an ordinal reference system . 
+Values based on calendars and clocks use lexical formats that are based on ISO 8601, as described in XML Schema Part 2:2001. A decimal value may be used with coordinate systems such as GPS time or UNIX time. A URI may be used to provide a reference to some era in an ordinal reference system .
 In common with many of the components modelled as data types in the ISO 19100 series of International Standards, the corresponding GML component has simple content. However, the content model gml:TimePositionType is defined in several steps.
 Three XML attributes appear on gml:TimePositionType:
-A time value shall be associated with a temporal reference system through the frame attribute that provides a URI reference that identifies a description of the reference system. Following ISO 19108, the Gregorian calendar with UTC is the default reference system, but others may also be used. Components for describing temporal reference systems are described in 14.4, but it is not required that the reference system be described in this, as the reference may refer to anything that may be indentified with a URI.  
-For time values using a calendar containing more than one era, the (optional) calendarEraName attribute provides the name of the calendar era.  
+A time value shall be associated with a temporal reference system through the frame attribute that provides a URI reference that identifies a description of the reference system. Following ISO 19108, the Gregorian calendar with UTC is the default reference system, but others may also be used. Components for describing temporal reference systems are described in 14.4, but it is not required that the reference system be described in this, as the reference may refer to anything that may be indentified with a URI.
+For time values using a calendar containing more than one era, the (optional) calendarEraName attribute provides the name of the calendar era.
 Inexact temporal positions may be expressed using the optional indeterminatePosition attribute.  This takes a value from an enumeration.
 
 OGRFeature(_ogr_fields_metadata):518
@@ -2553,7 +2553,7 @@ OGRFeature(_ogr_fields_metadata):5558
   field_max_occurs (Integer) = 1
   field_category (String) = REGULAR
   field_documentation (String) = -- Definition --
-The identifier of the particular version of the spatial object, with a maximum length of 25 characters. If the specification of a spatial object type with an external object identifier includes life-cycle information, the version identifier is used to distinguish between the different versions of a spatial object. Within the set of all versions of a spatial object, the version identifier is unique. 
+The identifier of the particular version of the spatial object, with a maximum length of 25 characters. If the specification of a spatial object type with an external object identifier includes life-cycle information, the version identifier is used to distinguish between the different versions of a spatial object. Within the set of all versions of a spatial object, the version identifier is unique.
 
 -- Description --
 NOTE The maximum length has been selected to allow for time stamps based on ISO 8601, for example, "2007-02-12T12:12:12+05:30" as the version identifier.
@@ -3273,11 +3273,11 @@ A georeferenced object directly collecting or processing data about objects whos
 -- Description --
 NOTE 1: An EnvironmentalMonitoringFacility is not a facility in the common INSPIRE sense realised by the Generic Conceptual Model class ActivtiyComplex.
 
-NOTE 2: Laboratories are not EnvironmentalMonitoringFacilities from an INSPIRE perspective as the exact location of the laboratory does not add further information to the measurement. 
+NOTE 2: Laboratories are not EnvironmentalMonitoringFacilities from an INSPIRE perspective as the exact location of the laboratory does not add further information to the measurement.
 The methodology used in the laboratory should be provided with observational data.
 The basic feature model is given by the gml:AbstractFeatureType.
-The content model for gml:AbstractFeatureType adds two specific properties suitable for geographic features to the content model defined in gml:AbstractGMLType. 
-The value of the gml:boundedBy property describes an envelope that encloses the entire feature instance, and is primarily useful for supporting rapid searching for features that occur in a particular location. 
+The content model for gml:AbstractFeatureType adds two specific properties suitable for geographic features to the content model defined in gml:AbstractGMLType.
+The value of the gml:boundedBy property describes an envelope that encloses the entire feature instance, and is primarily useful for supporting rapid searching for features that occur in a particular location.
 The value of the gml:location property describes the extent, position or relative location of the feature.
 
 OGRFeature(_ogr_layers_metadata):22
@@ -3389,8 +3389,8 @@ operational activity period
 -- Definition --
 Corresponds to a period during which the EnvironmentalMonitoringFacility has been up and running.
 The basic feature model is given by the gml:AbstractFeatureType.
-The content model for gml:AbstractFeatureType adds two specific properties suitable for geographic features to the content model defined in gml:AbstractGMLType. 
-The value of the gml:boundedBy property describes an envelope that encloses the entire feature instance, and is primarily useful for supporting rapid searching for features that occur in a particular location. 
+The content model for gml:AbstractFeatureType adds two specific properties suitable for geographic features to the content model defined in gml:AbstractGMLType.
+The value of the gml:boundedBy property describes an envelope that encloses the entire feature instance, and is primarily useful for supporting rapid searching for features that occur in a particular location.
 The value of the gml:location property describes the extent, position or relative location of the feature.
 
 OGRFeature(_ogr_layers_metadata):52
@@ -3399,7 +3399,7 @@ OGRFeature(_ogr_layers_metadata):52
   layer_category (String) = TOP_LEVEL_ELEMENT
   layer_pkid_name (String) = id
   layer_documentation (String) = gml:TimePeriod acts as a one-dimensional geometric primitive that represents an identifiable extent in time.
-The location in of a gml:TimePeriod is described by the temporal positions of the instants at which it begins and ends. The length of the period is equal to the temporal distance between the two bounding temporal positions. 
+The location in of a gml:TimePeriod is described by the temporal positions of the instants at which it begins and ends. The length of the period is equal to the temporal distance between the two bounding temporal positions.
 Both beginning and end may be described in terms of their direct position using gml:TimePositionType which is an XML Schema simple content type, or by reference to an indentifiable time instant using gml:TimeInstantPropertyType.
 Alternatively a limit of a gml:TimePeriod may use the conventional GML property model to make a reference to a time instant described elsewhere, or a limit may be indicated as a direct position.
 

--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -4378,3 +4378,134 @@ def test_ogr_geojson_write_geometry_validity_fixing(tmp_vsimem):
     lyr = ds.GetLayer(0)
     f = lyr.GetNextFeature()
     assert f.GetGeometryRef().IsValid()
+
+
+###############################################################################
+
+
+def test_ogr_geojson_arrow_stream_pyarrow_mixed_timezone(tmp_vsimem):
+    pytest.importorskip("pyarrow")
+
+    filename = str(
+        tmp_vsimem / "test_ogr_geojson_arrow_stream_pyarrow_mixed_timezone.geojson"
+    )
+    ds = gdal.GetDriverByName("GeoJSON").Create(filename, 0, 0, 0, gdal.GDT_Unknown)
+    lyr = ds.CreateLayer("test", geom_type=ogr.wkbPoint)
+    lyr.CreateField(ogr.FieldDefn("datetime", ogr.OFTDateTime))
+    f = ogr.Feature(lyr.GetLayerDefn())
+    lyr.CreateFeature(f)
+    f = ogr.Feature(lyr.GetLayerDefn())
+    f.SetField("datetime", "2022-05-31T12:34:56.789Z")
+    lyr.CreateFeature(f)
+    f = ogr.Feature(lyr.GetLayerDefn())
+    lyr.CreateFeature(f)
+    f = ogr.Feature(lyr.GetLayerDefn())
+    f.SetField("datetime", "2022-05-31T12:34:56.789+01:00")
+    lyr.CreateFeature(f)
+    f = ogr.Feature(lyr.GetLayerDefn())
+    f.SetField("datetime", "2022-05-31T12:34:56.789-01:00")
+    lyr.CreateFeature(f)
+    ds = None
+
+    ds = ogr.Open(filename)
+    lyr = ds.GetLayer(0)
+    stream = lyr.GetArrowStreamAsPyArrow()
+    assert stream.schema.field("datetime").type.tz == "UTC"
+    values = []
+    for batch in stream:
+        for x in batch.field("datetime"):
+            values.append(x.value)
+    assert values == [None, 1654000496789, None, 1653996896789, 1654004096789]
+
+
+###############################################################################
+
+
+def test_ogr_geojson_arrow_stream_pyarrow_utc_plus_five(tmp_vsimem):
+    pytest.importorskip("pyarrow")
+
+    filename = str(
+        tmp_vsimem / "test_ogr_geojson_arrow_stream_pyarrow_utc_plus_five.geojson"
+    )
+    ds = gdal.GetDriverByName("GeoJSON").Create(filename, 0, 0, 0, gdal.GDT_Unknown)
+    lyr = ds.CreateLayer("test", geom_type=ogr.wkbPoint)
+    lyr.CreateField(ogr.FieldDefn("datetime", ogr.OFTDateTime))
+    f = ogr.Feature(lyr.GetLayerDefn())
+    f.SetField("datetime", "2022-05-31T12:34:56.789+05:00")
+    lyr.CreateFeature(f)
+    f = ogr.Feature(lyr.GetLayerDefn())
+    f.SetField("datetime", "2022-05-31T13:34:56.789+05:00")
+    lyr.CreateFeature(f)
+    ds = None
+
+    ds = ogr.Open(filename)
+    lyr = ds.GetLayer(0)
+    stream = lyr.GetArrowStreamAsPyArrow()
+    assert stream.schema.field("datetime").type.tz == "+05:00"
+    values = []
+    for batch in stream:
+        for x in batch.field("datetime"):
+            values.append(x.value)
+    assert values == [1654000496789, 1654004096789]
+
+
+###############################################################################
+
+
+def test_ogr_geojson_arrow_stream_pyarrow_utc_minus_five(tmp_vsimem):
+    pytest.importorskip("pyarrow")
+
+    filename = str(
+        tmp_vsimem / "test_ogr_geojson_arrow_stream_pyarrow_utc_minus_five.geojson"
+    )
+    ds = gdal.GetDriverByName("GeoJSON").Create(filename, 0, 0, 0, gdal.GDT_Unknown)
+    lyr = ds.CreateLayer("test", geom_type=ogr.wkbPoint)
+    lyr.CreateField(ogr.FieldDefn("datetime", ogr.OFTDateTime))
+    f = ogr.Feature(lyr.GetLayerDefn())
+    f.SetField("datetime", "2022-05-31T12:34:56.789-05:00")
+    lyr.CreateFeature(f)
+    f = ogr.Feature(lyr.GetLayerDefn())
+    f.SetField("datetime", "2022-05-31T13:34:56.789-05:00")
+    lyr.CreateFeature(f)
+    ds = None
+
+    ds = ogr.Open(filename)
+    lyr = ds.GetLayer(0)
+    stream = lyr.GetArrowStreamAsPyArrow()
+    assert stream.schema.field("datetime").type.tz == "-05:00"
+    values = []
+    for batch in stream:
+        for x in batch.field("datetime"):
+            values.append(x.value)
+    assert values == [1654000496789, 1654004096789]
+
+
+###############################################################################
+
+
+def test_ogr_geojson_arrow_stream_pyarrow_unknown_timezone(tmp_vsimem):
+    pytest.importorskip("pyarrow")
+
+    filename = str(
+        tmp_vsimem / "test_ogr_geojson_arrow_stream_pyarrow_unknown_timezone.geojson"
+    )
+    ds = gdal.GetDriverByName("GeoJSON").Create(filename, 0, 0, 0, gdal.GDT_Unknown)
+    lyr = ds.CreateLayer("test", geom_type=ogr.wkbPoint)
+    lyr.CreateField(ogr.FieldDefn("datetime", ogr.OFTDateTime))
+    f = ogr.Feature(lyr.GetLayerDefn())
+    f.SetField("datetime", "2022-05-31T12:34:56.789Z")
+    lyr.CreateFeature(f)
+    f = ogr.Feature(lyr.GetLayerDefn())
+    f.SetField("datetime", "2022-05-31T13:34:56.789")
+    lyr.CreateFeature(f)
+    ds = None
+
+    ds = ogr.Open(filename)
+    lyr = ds.GetLayer(0)
+    stream = lyr.GetArrowStreamAsPyArrow()
+    assert stream.schema.field("datetime").type.tz is None
+    values = []
+    for batch in stream:
+        for x in batch.field("datetime"):
+            values.append(x.value)
+    assert values == [1654000496789, 1654004096789]

--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -7645,6 +7645,14 @@ def test_ogr_gpkg_arrow_stream_pyarrow_timezone(tmp_vsimem):
             values.append(x.value)
     assert values == [1654000496789, 1653996896789]
 
+    stream = lyr.GetArrowStreamAsPyArrow(["TIMEZONE=+01:00"])
+    assert stream.schema.field("datetime").type.tz == "+01:00"
+    values = []
+    for batch in stream:
+        for x in batch.field("datetime"):
+            values.append(x.value)
+    assert values == [1654000496789, 1653996896789]
+
 
 ###############################################################################
 # Test GetArrowStreamAsNumPy()

--- a/data/ogrinfo_output.schema.json
+++ b/data/ogrinfo_output.schema.json
@@ -149,6 +149,10 @@
         },
         "comment": {
           "type": "string"
+        },
+        "timezone": {
+          "type": "string",
+          "pattern": "^(localtime|(mixed timezones)|UTC|((\\+|-)[0-9][0-9]:[0-9][0-9]))$"
         }
       },
       "required": [
@@ -209,7 +213,14 @@
           }
         },
         "coordinateSystem": {
-          "$ref": "#/definitions/coordinateSystem"
+          "oneOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/definitions/coordinateSystem"
+            }
+          ]
         },
         "supportedSRSList": {
           "type": "array",

--- a/ogr/ogr_api.h
+++ b/ogr/ogr_api.h
@@ -390,6 +390,8 @@ int CPL_DLL OGR_Fld_GetWidth(OGRFieldDefnH);
 void CPL_DLL OGR_Fld_SetWidth(OGRFieldDefnH, int);
 int CPL_DLL OGR_Fld_GetPrecision(OGRFieldDefnH);
 void CPL_DLL OGR_Fld_SetPrecision(OGRFieldDefnH, int);
+int CPL_DLL OGR_Fld_GetTZFlag(OGRFieldDefnH);
+void CPL_DLL OGR_Fld_SetTZFlag(OGRFieldDefnH, int);
 void CPL_DLL OGR_Fld_Set(OGRFieldDefnH, const char *, OGRFieldType, int, int,
                          OGRJustification);
 int CPL_DLL OGR_Fld_IsIgnored(OGRFieldDefnH hDefn);

--- a/ogr/ogr_core.h
+++ b/ogr/ogr_core.h
@@ -866,6 +866,29 @@ typedef enum
  */
 #define OGRNullMarker -21122
 
+/** Time zone flag indicating unknown timezone. For the
+ *  OGRFieldDefn::GetTZFlag() property, this may also indicate a mix of
+ *  unknown, localtime or known time zones in the same field.
+ */
+#define OGR_TZFLAG_UNKNOWN 0
+
+/** Time zone flag indicating local time */
+#define OGR_TZFLAG_LOCALTIME 1
+
+/** Time zone flag only returned by OGRFieldDefn::GetTZFlag() to indicate
+ * that all values in the field have a known time zone (ie different from
+ * OGR_TZFLAG_UNKNOWN and OGR_TZFLAG_LOCALTIME), but it may be different among
+ * features. */
+#define OGR_TZFLAG_MIXED_TZ 2
+
+/** Time zone flag indicating UTC.
+ * Used to derived other time zone flags with the following logic:
+ * - values above 100 indicate a 15 minute increment per unit.
+ * - values under 100 indicate a 15 minute decrement per unit.
+ * For example: a value of 101 indicates UTC+00:15, a value of 102 UTC+00:30,
+ * a value of 99 UTC-00:15 ,etc. */
+#define OGR_TZFLAG_UTC 100
+
 /************************************************************************/
 /*                               OGRField                               */
 /************************************************************************/

--- a/ogr/ogr_feature.h
+++ b/ogr/ogr_feature.h
@@ -121,6 +121,8 @@ class CPL_DLL OGRFieldDefn
 
     std::string m_osComment{};  // field comment. Might be empty
 
+    int m_nTZFlag = OGR_TZFLAG_UNKNOWN;
+
   public:
     OGRFieldDefn(const char *, OGRFieldType);
     explicit OGRFieldDefn(const OGRFieldDefn *);
@@ -177,6 +179,15 @@ class CPL_DLL OGRFieldDefn
     void SetPrecision(int nPrecisionIn)
     {
         nPrecision = nPrecisionIn;
+    }
+
+    int GetTZFlag() const
+    {
+        return m_nTZFlag;
+    }
+    void SetTZFlag(int nTZFlag)
+    {
+        m_nTZFlag = nTZFlag;
     }
 
     void Set(const char *, OGRFieldType, int = 0, int = 0,

--- a/ogr/ogr_p.h
+++ b/ogr/ogr_p.h
@@ -112,6 +112,12 @@ int OGRFormatFloat(char *pszBuffer, int nBufferLen, float fVal, int nPrecision,
 
 /* Internal use by OGR drivers only, CPL_DLL is just there in case */
 /* they are compiled as plugins  */
+
+int CPL_DLL OGRTimezoneToTZFlag(const char *pszTZ,
+                                bool bEmitErrorIfUnhandledFormat);
+std::string CPL_DLL OGRTZFlagToTimezone(int nTZFlag,
+                                        const char *pszUTCRepresentation);
+
 int CPL_DLL OGRGetDayOfWeek(int day, int month, int year);
 int CPL_DLL OGRParseXMLDateTime(const char *pszXMLDateTime, OGRField *psField);
 int CPL_DLL OGRParseRFC822DateTime(const char *pszRFC822DateTime,

--- a/ogr/ogrfielddefn.cpp
+++ b/ogr/ogrfielddefn.cpp
@@ -85,7 +85,8 @@ OGRFieldDefn::OGRFieldDefn(const OGRFieldDefn *poPrototype)
       eSubType(poPrototype->GetSubType()), bNullable(poPrototype->IsNullable()),
       bUnique(poPrototype->IsUnique()),
       m_osDomainName(poPrototype->m_osDomainName),
-      m_osComment(poPrototype->GetComment())
+      m_osComment(poPrototype->GetComment()),
+      m_nTZFlag(poPrototype->GetTZFlag())
 {
     SetDefault(poPrototype->GetDefault());
 }
@@ -1107,6 +1108,92 @@ void OGR_Fld_SetPrecision(OGRFieldDefnH hDefn, int nPrecision)
 }
 
 /************************************************************************/
+/*                            GetTZFlag()                               */
+/************************************************************************/
+
+/**
+ * \fn int OGRFieldDefn::GetTZFlag() const;
+ *
+ * \brief Get the time zone flag.
+ *
+ * Only applies to OFTTime, OFTDate and OFTDateTime fields.
+ *
+ * Cf OGR_TZFLAG_UNKNOWN, OGR_TZFLAG_LOCALTIME, OGR_TZFLAG_MIXED_TZ and
+ * OGR_TZFLAG_UTC
+ *
+ * This method is the same as the C function OGR_Fld_GetTZFlag().
+ *
+ * @return the time zone flag.
+ * @since GDAL 3.8
+ */
+
+/************************************************************************/
+/*                        OGR_Fld_GetTZFlag()                           */
+/************************************************************************/
+/**
+ * \brief Get the time zone flag.
+ *
+ * Only applies to OFTTime, OFTDate and OFTDateTime fields.
+ *
+ * Cf OGR_TZFLAG_UNKNOWN, OGR_TZFLAG_LOCALTIME, OGR_TZFLAG_MIXED_TZ and
+ * OGR_TZFLAG_UTC
+ *
+ * @param hDefn handle to the field definition .
+ * @return the time zone flag.
+ * @since GDAL 3.8
+ */
+
+int OGR_Fld_GetTZFlag(OGRFieldDefnH hDefn)
+
+{
+    return OGRFieldDefn::FromHandle(hDefn)->GetTZFlag();
+}
+
+/************************************************************************/
+/*                             SetTZFlag()                              */
+/************************************************************************/
+
+/**
+ * \fn void OGRFieldDefn::SetTZFlag( int nTZFlag );
+ *
+ * \brief Set the time zone flag.
+ *
+ * Only applies to OFTTime, OFTDate and OFTDateTime fields.
+ *
+ * Cf OGR_TZFLAG_UNKNOWN, OGR_TZFLAG_LOCALTIME, OGR_TZFLAG_MIXED_TZ and
+ * OGR_TZFLAG_UTC
+ *
+ * This method is the same as the C function OGR_Fld_SetTZFlag().
+ *
+ * @param nTZFlag the new time zone flag.
+ * @since GDAL 3.8
+ */
+
+/************************************************************************/
+/*                         OGR_Fld_SetTZFlag()                          */
+/************************************************************************/
+/**
+ * \brief Set the formatting precision for this field in characters.
+ *
+ * Set the time zone flag.
+ *
+ * Only applies to OFTTime, OFTDate and OFTDateTime fields.
+ *
+ * Cf OGR_TZFLAG_UNKNOWN, OGR_TZFLAG_LOCALTIME, OGR_TZFLAG_MIXED_TZ and
+ * OGR_TZFLAG_UTC
+ *
+ * @param hDefn handle to the field definition to set precision to.
+ * @param nTZFlag the new time zone flag.
+ * @since GDAL 3.8
+ */
+
+void OGR_Fld_SetTZFlag(OGRFieldDefnH hDefn, int nTZFlag)
+
+{
+    OGRFieldDefn::FromHandle(hDefn)->SetTZFlag(nTZFlag);
+}
+
+/************************************************************************/
 /*                                Set()                                 */
 /************************************************************************/
 
@@ -1249,7 +1336,8 @@ int OGRFieldDefn::IsSame(const OGRFieldDefn *poOtherFieldDefn) const
            nWidth == poOtherFieldDefn->nWidth &&
            nPrecision == poOtherFieldDefn->nPrecision &&
            bNullable == poOtherFieldDefn->bNullable &&
-           m_osComment == poOtherFieldDefn->m_osComment;
+           m_osComment == poOtherFieldDefn->m_osComment &&
+           m_nTZFlag == poOtherFieldDefn->m_nTZFlag;
 }
 
 /************************************************************************/

--- a/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
+++ b/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
@@ -248,7 +248,7 @@ class OGRArrowLayer CPL_NON_FINAL
 
     static void TimestampToOGR(int64_t timestamp,
                                const arrow::TimestampType *timestampType,
-                               OGRField *psField);
+                               int nTZFlag, OGRField *psField);
 };
 
 /************************************************************************/

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
@@ -213,6 +213,39 @@ OGRArrowLayer::IsHandledMapType(const std::shared_ptr<arrow::MapType> &mapType)
 }
 
 /************************************************************************/
+/*                      GetTZFlagFromTimezone()                         */
+/************************************************************************/
+
+static int GetTZFlagFromTimezone(const std::string &osTZ)
+{
+    int nTZFlag = 0;
+    if (osTZ == "UTC" || osTZ == "Etc/UTC")
+    {
+        nTZFlag = OGR_TZFLAG_UTC;
+    }
+    else if (osTZ.size() == 6 && (osTZ[0] == '+' || osTZ[0] == '-') &&
+             osTZ[3] == ':')
+    {
+        int nTZHour = atoi(osTZ.c_str() + 1);
+        int nTZMin = atoi(osTZ.c_str() + 4);
+        if (nTZHour >= 0 && nTZHour <= 14 && nTZMin >= 0 && nTZMin < 60 &&
+            (nTZMin % 15) == 0)
+        {
+            nTZFlag = (nTZHour * 4) + (nTZMin / 15);
+            if (osTZ[0] == '+')
+            {
+                nTZFlag = OGR_TZFLAG_UTC + nTZFlag;
+            }
+            else
+            {
+                nTZFlag = OGR_TZFLAG_UTC - nTZFlag;
+            }
+        }
+    }
+    return nTZFlag;
+}
+
+/************************************************************************/
 /*                        MapArrowTypeToOGR()                           */
 /************************************************************************/
 
@@ -284,8 +317,13 @@ inline bool OGRArrowLayer::MapArrowTypeToOGR(
             break;
 
         case arrow::Type::TIMESTAMP:
+        {
+            const auto timestampType =
+                static_cast<arrow::TimestampType *>(type.get());
             eType = OFTDateTime;
+            oField.SetTZFlag(GetTZFlagFromTimezone(timestampType->timezone()));
             break;
+        }
 
         case arrow::Type::TIME32:
             eType = OFTTime;
@@ -1413,7 +1451,7 @@ static SetPointsOfLineType GetSetPointsOfLine(bool bHasZ, bool bHasM)
 inline void
 OGRArrowLayer::TimestampToOGR(int64_t timestamp,
                               const arrow::TimestampType *timestampType,
-                              OGRField *psField)
+                              int nTZFlag, OGRField *psField)
 {
     const auto unit = timestampType->unit();
     double floatingPart = 0;
@@ -1432,32 +1470,10 @@ OGRArrowLayer::TimestampToOGR(int64_t timestamp,
         floatingPart = (timestamp % (1000 * 1000 * 1000)) / 1e9;
         timestamp /= 1000 * 1000 * 1000;
     }
-    int nTZFlag = 0;
-    const auto osTZ = timestampType->timezone();
-    if (osTZ == "UTC" || osTZ == "Etc/UTC")
+    if (nTZFlag > OGR_TZFLAG_MIXED_TZ)
     {
-        nTZFlag = 100;
-    }
-    else if (osTZ.size() == 6 && (osTZ[0] == '+' || osTZ[0] == '-') &&
-             osTZ[3] == ':')
-    {
-        int nTZHour = atoi(osTZ.c_str() + 1);
-        int nTZMin = atoi(osTZ.c_str() + 4);
-        if (nTZHour >= 0 && nTZHour <= 14 && nTZMin >= 0 && nTZMin < 60 &&
-            (nTZMin % 15) == 0)
-        {
-            nTZFlag = (nTZHour * 4) + (nTZMin / 15);
-            if (osTZ[0] == '+')
-            {
-                nTZFlag = 100 + nTZFlag;
-                timestamp += nTZHour * 3600 + nTZMin * 60;
-            }
-            else
-            {
-                nTZFlag = 100 - nTZFlag;
-                timestamp -= nTZHour * 3600 + nTZMin * 60;
-            }
-        }
+        const int TZOffset = (nTZFlag - OGR_TZFLAG_UTC) * 15;
+        timestamp += TZOffset * 60;
     }
     struct tm dt;
     CPLUnixTimeToYMDHMS(timestamp, &dt);
@@ -1733,7 +1749,9 @@ inline OGRFeature *OGRArrowLayer::ReadFeature(
                 sField.Set.nMarker1 = OGRUnsetMarker;
                 sField.Set.nMarker2 = OGRUnsetMarker;
                 sField.Set.nMarker3 = OGRUnsetMarker;
-                TimestampToOGR(timestamp, timestampType, &sField);
+                TimestampToOGR(timestamp, timestampType,
+                               m_poFeatureDefn->GetFieldDefn(i)->GetTZFlag(),
+                               &sField);
                 poFeature->SetField(i, &sField);
                 break;
             }

--- a/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
+++ b/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
@@ -1831,6 +1831,7 @@ int OGRFlatGeobufLayer::GetNextArrowArray(struct ArrowArrayStream *stream,
                                               len, &ogrField))
                             {
                                 sHelper.SetDateTime(psArray, iFeat, brokenDown,
+                                                    sHelper.anTZFlags[i],
                                                     ogrField);
                             }
                             else
@@ -1840,8 +1841,9 @@ int OGRFlatGeobufLayer::GetNextArrowArray(struct ArrowArrayStream *stream,
                                 str[len] = '\0';
                                 if (OGRParseDate(str, &ogrField, 0))
                                 {
-                                    sHelper.SetDateTime(psArray, iFeat,
-                                                        brokenDown, ogrField);
+                                    sHelper.SetDateTime(
+                                        psArray, iFeat, brokenDown,
+                                        sHelper.anTZFlags[i], ogrField);
                                 }
                             }
                         }

--- a/ogr/ogrsf_frmts/generic/ograrrowarrayhelper.cpp
+++ b/ogr/ogrsf_frmts/generic/ograrrowarrayhelper.cpp
@@ -27,6 +27,7 @@
  ****************************************************************************/
 
 #include "ograrrowarrayhelper.h"
+#include "ogr_p.h"
 
 #include <limits>
 
@@ -70,8 +71,22 @@ OGRArrowArrayHelper::OGRArrowArrayHelper(
     mapOGRGeomFieldToArrowField.resize(nGeomFieldCount, -1);
     abNullableFields.resize(nFieldCount);
     anTZFlags.resize(nFieldCount);
+    int nTZFlagOverride = -1;
     const char *pszTZOverride =
-        aosArrowArrayStreamOptions.FetchNameValueDef("TIMEZONE", "");
+        aosArrowArrayStreamOptions.FetchNameValue("TIMEZONE");
+    if (pszTZOverride)
+    {
+        if (EQUAL(pszTZOverride, "unknown") || EQUAL(pszTZOverride, ""))
+        {
+            nTZFlagOverride = OGR_TZFLAG_UNKNOWN;
+        }
+        else
+        {
+            // we don't really care about the actual timezone, since we
+            // will convert OGRField::Date to UTC in all cases
+            nTZFlagOverride = OGR_TZFLAG_UTC;
+        }
+    }
 
     if (bIncludeFID)
     {
@@ -81,8 +96,8 @@ OGRArrowArrayHelper::OGRArrowArrayHelper(
     {
         const auto poFieldDefn = poFeatureDefn->GetFieldDefn(i);
         abNullableFields[i] = CPL_TO_BOOL(poFieldDefn->IsNullable());
-        anTZFlags[i] = EQUAL(pszTZOverride, "UTC") ? OGR_TZFLAG_UTC
-                                                   : poFieldDefn->GetTZFlag();
+        anTZFlags[i] =
+            nTZFlagOverride >= 0 ? nTZFlagOverride : poFieldDefn->GetTZFlag();
         if (!poFieldDefn->IsIgnored())
         {
             mapOGRFieldToArrowField[i] = nChildren;

--- a/ogr/ogrsf_frmts/generic/ograrrowarrayhelper.cpp
+++ b/ogr/ogrsf_frmts/generic/ograrrowarrayhelper.cpp
@@ -69,6 +69,9 @@ OGRArrowArrayHelper::OGRArrowArrayHelper(
     mapOGRFieldToArrowField.resize(nFieldCount, -1);
     mapOGRGeomFieldToArrowField.resize(nGeomFieldCount, -1);
     abNullableFields.resize(nFieldCount);
+    anTZFlags.resize(nFieldCount);
+    const char *pszTZOverride =
+        aosArrowArrayStreamOptions.FetchNameValueDef("TIMEZONE", "");
 
     if (bIncludeFID)
     {
@@ -78,6 +81,8 @@ OGRArrowArrayHelper::OGRArrowArrayHelper(
     {
         const auto poFieldDefn = poFeatureDefn->GetFieldDefn(i);
         abNullableFields[i] = CPL_TO_BOOL(poFieldDefn->IsNullable());
+        anTZFlags[i] = EQUAL(pszTZOverride, "UTC") ? OGR_TZFLAG_UTC
+                                                   : poFieldDefn->GetTZFlag();
         if (!poFieldDefn->IsIgnored())
         {
             mapOGRFieldToArrowField[i] = nChildren;

--- a/ogr/ogrsf_frmts/generic/ograrrowarrayhelper.h
+++ b/ogr/ogrsf_frmts/generic/ograrrowarrayhelper.h
@@ -53,6 +53,7 @@ class CPL_DLL OGRArrowArrayHelper
     std::vector<int> mapOGRGeomFieldToArrowField{};
     std::vector<bool> abNullableFields{};
     std::vector<uint32_t> anArrowFieldMaxAlloc{};
+    std::vector<int> anTZFlags{};
     int64_t *panFIDValues = nullptr;
     struct ArrowArray *m_out_array = nullptr;
 
@@ -182,7 +183,8 @@ class CPL_DLL OGRArrowArrayHelper
     }
 
     static void SetDateTime(struct ArrowArray *psArray, int iFeat,
-                            struct tm &brokenDown, const OGRField &ogrField)
+                            struct tm &brokenDown, int nFieldTZFlag,
+                            const OGRField &ogrField)
     {
         brokenDown.tm_year = ogrField.Date.Year - 1900;
         brokenDown.tm_mon = ogrField.Date.Month - 1;
@@ -190,9 +192,18 @@ class CPL_DLL OGRArrowArrayHelper
         brokenDown.tm_hour = ogrField.Date.Hour;
         brokenDown.tm_min = ogrField.Date.Minute;
         brokenDown.tm_sec = static_cast<int>(ogrField.Date.Second);
-        static_cast<int64_t *>(const_cast<void *>(psArray->buffers[1]))[iFeat] =
+        auto nVal =
             CPLYMDHMSToUnixTime(&brokenDown) * 1000 +
             (static_cast<int>(ogrField.Date.Second * 1000 + 0.5) % 1000);
+        if (nFieldTZFlag >= OGR_TZFLAG_MIXED_TZ &&
+            ogrField.Date.TZFlag > OGR_TZFLAG_MIXED_TZ)
+        {
+            // Convert for ogrField.Date.TZFlag to UTC
+            const int TZOffset = (ogrField.Date.TZFlag - OGR_TZFLAG_UTC) * 15;
+            nVal -= TZOffset * 60 * 1000;
+        }
+        static_cast<int64_t *>(const_cast<void *>(psArray->buffers[1]))[iFeat] =
+            nVal;
     }
 
     GByte *GetPtrForStringOrBinary(int iArrowField, int iFeat, size_t nLen)

--- a/ogr/ogrsf_frmts/generic/ogrlayerarrow.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrlayerarrow.cpp
@@ -75,8 +75,11 @@ inline void UnsetBit(uint8_t *pabyData, size_t nIdx)
 static void OGRLayerDefaultReleaseSchema(struct ArrowSchema *schema)
 {
     CPLAssert(schema->release != nullptr);
-    if (STARTS_WITH(schema->format, "w:"))
+    if (STARTS_WITH(schema->format, "w:") ||
+        STARTS_WITH(schema->format, "tsm:"))
+    {
         CPLFree(const_cast<char *>(schema->format));
+    }
     CPLFree(const_cast<char *>(schema->name));
     CPLFree(const_cast<char *>(schema->metadata));
     for (int i = 0; i < static_cast<int>(schema->n_children); ++i)
@@ -318,8 +321,44 @@ int OGRLayer::GetArrowSchema(struct ArrowArrayStream *,
                 break;
 
             case OFTDateTime:
-                psChild->format = "tsm:";
+            {
+                const char *pszPrefix = "tsm:";
+                const char *pszTZOverride =
+                    m_aosArrowArrayStreamOptions.FetchNameValueDef("TIMEZONE",
+                                                                   "");
+                const int nTZFlag = poFieldDefn->GetTZFlag();
+                if (nTZFlag == OGR_TZFLAG_MIXED_TZ ||
+                    nTZFlag == OGR_TZFLAG_UTC || EQUAL(pszTZOverride, "UTC"))
+                {
+                    psChild->format = CPLStrdup(CPLSPrintf("%sUTC", pszPrefix));
+                }
+                else if (nTZFlag == OGR_TZFLAG_UNKNOWN ||
+                         nTZFlag == OGR_TZFLAG_LOCALTIME)
+                {
+                    psChild->format = CPLStrdup(pszPrefix);
+                }
+                else
+                {
+                    char chSign;
+                    const int nOffset = (nTZFlag - OGR_TZFLAG_UTC) * 15;
+                    int nHours =
+                        static_cast<int>(nOffset / 60);  // Round towards zero.
+                    const int nMinutes = std::abs(nOffset - nHours * 60);
+
+                    if (nOffset < 0)
+                    {
+                        chSign = '-';
+                        nHours = std::abs(nHours);
+                    }
+                    else
+                    {
+                        chSign = '+';
+                    }
+                    psChild->format = CPLStrdup(CPLSPrintf(
+                        "%s%c%02d:%02d", pszPrefix, chSign, nHours, nMinutes));
+                }
                 break;
+            }
         }
 
         if (item_format)
@@ -1251,7 +1290,7 @@ static bool FillDateArray(struct ArrowArray *psChild,
 }
 
 /************************************************************************/
-/*                        FillDateArray()                               */
+/*                        FillTimeArray()                               */
 /************************************************************************/
 
 static bool FillTimeArray(struct ArrowArray *psChild,
@@ -1305,7 +1344,7 @@ static bool FillTimeArray(struct ArrowArray *psChild,
 static bool
 FillDateTimeArray(struct ArrowArray *psChild,
                   std::vector<std::unique_ptr<OGRFeature>> &apoFeatures,
-                  const bool bIsNullable, const int i)
+                  const bool bIsNullable, const int i, int nFieldTZFlag)
 {
     psChild->n_buffers = 2;
     psChild->buffers = static_cast<const void **>(CPLCalloc(2, sizeof(void *)));
@@ -1329,9 +1368,26 @@ FillDateTimeArray(struct ArrowArray *psChild,
             brokenDown.tm_hour = psRawField->Date.Hour;
             brokenDown.tm_min = psRawField->Date.Minute;
             brokenDown.tm_sec = static_cast<int>(psRawField->Date.Second);
-            panValues[iFeat] =
+            auto nVal =
                 CPLYMDHMSToUnixTime(&brokenDown) * 1000 +
                 (static_cast<int>(psRawField->Date.Second * 1000 + 0.5) % 1000);
+            if (nFieldTZFlag > OGR_TZFLAG_MIXED_TZ &&
+                psRawField->Date.TZFlag > OGR_TZFLAG_MIXED_TZ)
+            {
+                // Convert for psRawField->Date.TZFlag to nFieldTZFlag
+                const int TZOffset =
+                    (psRawField->Date.TZFlag - nFieldTZFlag) * 15;
+                nVal -= TZOffset * 60 * 1000;
+            }
+            else if (nFieldTZFlag == OGR_TZFLAG_MIXED_TZ &&
+                     psRawField->Date.TZFlag > OGR_TZFLAG_MIXED_TZ)
+            {
+                // Convert for psRawField->Date.TZFlag to UTC
+                const int TZOffset =
+                    (psRawField->Date.TZFlag - OGR_TZFLAG_UTC) * 15;
+                nVal -= TZOffset * 60 * 1000;
+            }
+            panValues[iFeat] = nVal;
         }
         else if (bIsNullable)
         {
@@ -1630,7 +1686,8 @@ int OGRLayer::GetNextArrowArray(struct ArrowArrayStream *,
 
             case OFTDateTime:
             {
-                if (!FillDateTimeArray(psChild, apoFeatures, bIsNullable, i))
+                if (!FillDateTimeArray(psChild, apoFeatures, bIsNullable, i,
+                                       poFieldDefn->GetTZFlag()))
                     goto error;
                 break;
             }

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonreader.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonreader.cpp
@@ -1299,7 +1299,10 @@ void OGRGeoJSONReaderAddOrUpdateField(
             poFieldDefn->SetWidth(1);
         if (poFieldDefn->GetType() == OFTString && !bDateAsString)
         {
-            poFieldDefn->SetType(GeoJSONStringPropertyToFieldType(poVal));
+            int nTZFlag = 0;
+            poFieldDefn->SetType(
+                GeoJSONStringPropertyToFieldType(poVal, nTZFlag));
+            poFieldDefn->SetTZFlag(nTZFlag);
         }
         apoFieldDefn.emplace_back(std::move(poFieldDefn));
         const int nIndex = static_cast<int>(apoFieldDefn.size()) - 1;
@@ -1328,7 +1331,10 @@ void OGRGeoJSONReaderAddOrUpdateField(
             poFDefn->SetType(eNewType);
             if (poFDefn->GetType() == OFTString && !bDateAsString)
             {
-                poFDefn->SetType(GeoJSONStringPropertyToFieldType(poVal));
+                int nTZFlag = 0;
+                poFDefn->SetType(
+                    GeoJSONStringPropertyToFieldType(poVal, nTZFlag));
+                poFDefn->SetTZFlag(nTZFlag);
             }
             poFDefn->SetSubType(eNewSubType);
             aoSetUndeterminedTypeFields.erase(nIndex);
@@ -1533,7 +1539,18 @@ void OGRGeoJSONReaderAddOrUpdateField(
         {
             if (eNewType == OFTString && !bDateAsString &&
                 eNewSubType == OFSTNone)
-                eNewType = GeoJSONStringPropertyToFieldType(poVal);
+            {
+                int nTZFlag = 0;
+                eNewType = GeoJSONStringPropertyToFieldType(poVal, nTZFlag);
+                if (poFDefn->GetTZFlag() > OGR_TZFLAG_UNKNOWN &&
+                    nTZFlag != poFDefn->GetTZFlag())
+                {
+                    if (nTZFlag == OGR_TZFLAG_UNKNOWN)
+                        poFDefn->SetTZFlag(OGR_TZFLAG_UNKNOWN);
+                    else
+                        poFDefn->SetTZFlag(OGR_TZFLAG_MIXED_TZ);
+                }
+            }
             if (eType != eNewType)
             {
                 poFDefn->SetSubType(OFSTNone);

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonutils.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonutils.cpp
@@ -991,7 +991,8 @@ OGRFieldType GeoJSONPropertyToFieldType(json_object *poObject,
 /*                        GeoJSONStringPropertyToFieldType()            */
 /************************************************************************/
 
-OGRFieldType GeoJSONStringPropertyToFieldType(json_object *poObject)
+OGRFieldType GeoJSONStringPropertyToFieldType(json_object *poObject,
+                                              int &nTZFlag)
 {
     if (poObject == nullptr)
     {
@@ -999,6 +1000,7 @@ OGRFieldType GeoJSONStringPropertyToFieldType(json_object *poObject)
     }
     const char *pszStr = json_object_get_string(poObject);
 
+    nTZFlag = 0;
     OGRField sWrkField;
     CPLPushErrorHandler(CPLQuietErrorHandler);
     const bool bSuccess = CPL_TO_BOOL(OGRParseDate(pszStr, &sWrkField, 0));
@@ -1009,6 +1011,7 @@ OGRFieldType GeoJSONStringPropertyToFieldType(json_object *poObject)
         const bool bHasDate =
             strchr(pszStr, '/') != nullptr || strchr(pszStr, '-') != nullptr;
         const bool bHasTime = strchr(pszStr, ':') != nullptr;
+        nTZFlag = sWrkField.Date.TZFlag;
         if (bHasDate && bHasTime)
             return OFTDateTime;
         else if (bHasDate)

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonutils.h
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonutils.h
@@ -77,7 +77,8 @@ OGRFieldType CPL_DLL GeoJSONPropertyToFieldType(json_object *poObject,
 /*                      GeoJSONStringPropertyToFieldType                */
 /************************************************************************/
 
-OGRFieldType GeoJSONStringPropertyToFieldType(json_object *poObject);
+OGRFieldType GeoJSONStringPropertyToFieldType(json_object *poObject,
+                                              int &nTZFlag);
 
 /************************************************************************/
 /*                           OGRGeoJSONGetGeometryName                  */

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -578,6 +578,8 @@ class OGRGeoPackageLayer CPL_NON_FINAL : public OGRLayer,
     {
         return m_poDS;
     }
+    virtual bool GetArrowStream(struct ArrowArrayStream *out_stream,
+                                CSLConstList papszOptions = nullptr) override;
     virtual int GetNextArrowArray(struct ArrowArrayStream *,
                                   struct ArrowArray *out_array) override;
 

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagelayer.cpp
@@ -504,6 +504,21 @@ OGRFeature *OGRGeoPackageLayer::TranslateFeature(sqlite3_stmt *hStmt)
 }
 
 /************************************************************************/
+/*                          GetArrowStream()                            */
+/************************************************************************/
+
+bool OGRGeoPackageLayer::GetArrowStream(struct ArrowArrayStream *out_stream,
+                                        CSLConstList papszOptions)
+{
+    CPLStringList aosOptions;
+    aosOptions.Assign(CSLDuplicate(papszOptions), true);
+    // GeoPackage are assumed to be in UTC. Even if another timezone is used,
+    // we'll do the conversion to UTC
+    aosOptions.SetNameValue("TIMEZONE", "UTC");
+    return OGRLayer::GetArrowStream(out_stream, aosOptions.List());
+}
+
+/************************************************************************/
 /*                      GetNextArrowArray()                             */
 /************************************************************************/
 
@@ -802,6 +817,7 @@ int OGRGeoPackageLayer::GetNextArrowArray(struct ArrowArrayStream *stream,
                                            &ogrField, poFieldDefn, nFID))
                     {
                         sHelper.SetDateTime(psArray, iFeat, brokenDown,
+                                            sHelper.anTZFlags[iField],
                                             ogrField);
                     }
                     break;

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagelayer.cpp
@@ -514,7 +514,10 @@ bool OGRGeoPackageLayer::GetArrowStream(struct ArrowArrayStream *out_stream,
     aosOptions.Assign(CSLDuplicate(papszOptions), true);
     // GeoPackage are assumed to be in UTC. Even if another timezone is used,
     // we'll do the conversion to UTC
-    aosOptions.SetNameValue("TIMEZONE", "UTC");
+    if (aosOptions.FetchNameValue("TIMEZONE") == nullptr)
+    {
+        aosOptions.SetNameValue("TIMEZONE", "UTC");
+    }
     return OGRLayer::GetArrowStream(out_stream, aosOptions.List());
 }
 

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -7586,7 +7586,8 @@ void OGR_GPKG_FillArrowArray_Step(sqlite3_context *pContext, int /*argc*/,
                         pszTxt, &ogrField, poFieldDefn, nFID))
                 {
                     psHelper->SetDateTime(
-                        psArray, iFeat, psFillArrowArray->brokenDown, ogrField);
+                        psArray, iFeat, psFillArrowArray->brokenDown,
+                        psHelper->anTZFlags[iField], ogrField);
                 }
                 break;
             }

--- a/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
@@ -2191,12 +2191,14 @@ bool OGRParquetLayer::GetMinMaxForField(int iRowGroup,  // -1 for all
         if (bFoundMin)
         {
             const int64_t timestamp = sMin.Integer64;
-            OGRArrowLayer::TimestampToOGR(timestamp, timestampType, &sMin);
+            OGRArrowLayer::TimestampToOGR(timestamp, timestampType,
+                                          poFieldDefn->GetTZFlag(), &sMin);
         }
         if (bFoundMax)
         {
             const int64_t timestamp = sMax.Integer64;
-            OGRArrowLayer::TimestampToOGR(timestamp, timestampType, &sMax);
+            OGRArrowLayer::TimestampToOGR(timestamp, timestampType,
+                                          poFieldDefn->GetTZFlag(), &sMax);
         }
         eType = OFTDateTime;
     }

--- a/swig/include/ogr.i
+++ b/swig/include/ogr.i
@@ -468,6 +468,11 @@ typedef void retGetPoints;
 %constant F_VAL_ALLOW_NULL_WHEN_DEFAULT = 0x00000008; /***<Allow fields that are null when there's an associated default value. */
 %constant F_VAL_ALL = 0xFFFFFFFF; /**< Enable all validation tests */
 
+%constant TZFLAG_UNKNOWN = 0;
+%constant TZFLAG_LOCALTIME = 1;
+%constant TZFLAG_MIXED_TZ = 2;
+%constant TZFLAG_UTC = 100;
+
 /** Flag for OGR_L_GetGeometryTypes() indicating that
  * OGRGeometryTypeCounter::nCount value is not needed */
 %constant GGT_COUNT_NOT_NEEDED = 0x1;
@@ -2549,6 +2554,14 @@ public:
 
   void SetPrecision(int precision) {
     OGR_Fld_SetPrecision(self, precision);
+  }
+
+  int GetTZFlag() {
+    return OGR_Fld_GetTZFlag(self);
+  }
+
+  void SetTZFlag(int tzflag) {
+    OGR_Fld_SetTZFlag(self, tzflag);
   }
 
   /* Interface method added for GDAL 1.7.0 */


### PR DESCRIPTION
- Add OGRFieldDefn::GetTZFlag()/SetTZFlag(), and OGR_TZFLAG_ constants
- ogrinfo: output timezone flag
- GeoJSON reading: set field TZFlag
- ArrowStream interface: set timezone on schema (when known), and do necessary conversions (fixes #8460)
- Arrow/Parquet reading: set field TZFlag

