### PR TITLE
ogr2ogr: fix -gt 0 to disable transactions

### DIFF
--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -4820,7 +4820,7 @@ SetupTargetLayer::Setup(OGRLayer *poSrcLayer, const char *pszNewLayerName,
 
     if (bOverwriteActuallyDone && !bAddOverwriteLCO &&
         EQUAL(m_poDstDS->GetDriver()->GetDescription(), "PostgreSQL") &&
-        !psOptions->nLayerTransaction && psOptions->nGroupTransactions >= 0 &&
+        !psOptions->nLayerTransaction && psOptions->nGroupTransactions > 0 &&
         CPLTestBool(CPLGetConfigOption("PG_COMMIT_WHEN_OVERWRITING", "YES")))
     {
         CPLDebug("GDALVectorTranslate",
@@ -5380,7 +5380,7 @@ int LayerTranslator::Translate(OGRFeature *poFeatureIn, TargetLayerInfo *psInfo,
                 nFeaturesInTransaction = 0;
             }
             else if (!psOptions->nLayerTransaction &&
-                     psOptions->nGroupTransactions >= 0 &&
+                     psOptions->nGroupTransactions > 0 &&
                      ++nTotalEventsDone >= psOptions->nGroupTransactions)
             {
                 if (m_poODS->CommitTransaction() == OGRERR_FAILURE ||

--- a/autotest/utilities/test_ogr2ogr_lib.py
+++ b/autotest/utilities/test_ogr2ogr_lib.py
@@ -1521,11 +1521,6 @@ def test_ogr2ogr_lib_transaction_size(transaction_size):
     )
 
     try:
-        # A transaction size of 0 is invalid
-        if transaction_size == 0:
-            assert ds is None
-            return
-
         assert ds is not None
         lyr = ds.GetLayer(0)
         assert lyr.GetFeatureCount() == 10, "wrong feature count"


### PR DESCRIPTION
This helps workarounding an error in a scenario like: ogr2ogr "MSSQL:xxx" "MSSQL:xxx" -sql "SELECT * FROM foo" -nln bar -update Without -gt 0, this fails with
ERROR 1: Column ogr_geometry requested for geometry, but it does not exist. (and other subsequent errors)
This is obviously a workaround, not a proper fix
