### PR TITLE
[Backport release/3.7] VSIReadDirRecursive(): make it work properly with a trailing slash (especially on /vsizip/) (fixes #8474)

### DIFF
--- a/autotest/gcore/vsizip.py
+++ b/autotest/gcore/vsizip.py
@@ -269,6 +269,9 @@ def test_vsizip_4():
         "uint16.tif",
     ], "bad content"
 
+    # Test with trailing slash too
+    assert gdal.ReadDirRecursive("/vsizip/data/testzip.zip/") == res
+
 
 ###############################################################################
 # Test ReadRecursive on deep zip

--- a/port/cpl_vsil.cpp
+++ b/port/cpl_vsil.cpp
@@ -1591,6 +1591,9 @@ VSIDIR *VSIFilesystemHandler::OpenDir(const char *pszPath, int nRecurseDepth,
     }
     VSIDIRGeneric *dir = new VSIDIRGeneric(this);
     dir->osRootPath = pszPath;
+    if (!dir->osRootPath.empty() &&
+        (dir->osRootPath.back() == '/' || dir->osRootPath.back() == '\\'))
+        dir->osRootPath.pop_back();
     dir->nRecurseDepth = nRecurseDepth;
     dir->papszContent = papszContent;
     dir->m_osFilterPrefix = CSLFetchNameValueDef(papszOptions, "PREFIX", "");


### PR DESCRIPTION
Backport #8475
 **Authored by:** @rouault