### PR TITLE
ENVI: warn if assigning different nodata value to different bands

### DIFF
--- a/autotest/gdrivers/envi.py
+++ b/autotest/gdrivers/envi.py
@@ -1003,3 +1003,28 @@ def test_envi_read_direct_access_update_scenario():
     ds = None
 
     gdal.GetDriverByName("ENVI").Delete(filename)
+
+
+###############################################################################
+# Test setting different nodata values
+
+
+@pytest.mark.parametrize(
+    "nd1,nd2,expected_warning",
+    [
+        (1, 1, False),
+        (float("nan"), float("nan"), False),
+        (float("nan"), 1, True),
+        (1, float("nan"), True),
+    ],
+)
+def test_envi_write_warn_different_nodata(tmp_vsimem, nd1, nd2, expected_warning):
+    filename = str(tmp_vsimem / "test_envi_write_warn_different_nodata.img")
+    ds = gdal.GetDriverByName("ENVI").Create(filename, 1, 1, 2)
+    assert ds.GetRasterBand(1).SetNoDataValue(nd1) == gdal.CE_None
+    gdal.ErrorReset()
+    with gdal.quiet_errors():
+        assert ds.GetRasterBand(2).SetNoDataValue(nd2) == gdal.CE_None
+        assert gdal.GetLastErrorType() == (
+            gdal.CE_Warning if expected_warning else gdal.CE_None
+        )

--- a/autotest/gdrivers/plmosaic.py
+++ b/autotest/gdrivers/plmosaic.py
@@ -530,6 +530,8 @@ def test_plmosaic_16(tmp_vsimem, valid_mosaic):
 # Open with explicit MOSAIC dataset open option
 
 
+@pytest.mark.require_driver("PNG")
+@pytest.mark.require_driver("WMS")
 def test_plmosaic_17(tmp_path, valid_mosaic):
 
     cache_path = str(tmp_path / "plmosaic_cache")
@@ -809,6 +811,8 @@ def test_plmosaic_20(valid_mosaic):
 # Try use_tiles
 
 
+@pytest.mark.require_driver("PNG")
+@pytest.mark.require_driver("WMS")
 def test_plmosaic_21(valid_mosaic):
 
     with gdal.config_option("PL_URL", valid_mosaic):

--- a/gcore/gdaldriver.cpp
+++ b/gcore/gdaldriver.cpp
@@ -659,7 +659,7 @@ GDALDataset *GDALDriver::DefaultCreateCopy(const char *pszFilename,
     double adfGeoTransform[6] = {};
 
     if (nDstBands == 0 && !bStrict)
-        CPLPushErrorHandler(CPLQuietErrorHandler);
+        CPLTurnFailureIntoWarning(true);
 
     if (eErr == CE_None &&
         poSrcDS->GetGeoTransform(adfGeoTransform) == CE_None
@@ -696,7 +696,7 @@ GDALDataset *GDALDriver::DefaultCreateCopy(const char *pszFilename,
     }
 
     if (nDstBands == 0 && !bStrict)
-        CPLPopErrorHandler();
+        CPLTurnFailureIntoWarning(false);
 
     /* -------------------------------------------------------------------- */
     /*      Copy metadata.                                                  */
@@ -728,7 +728,7 @@ GDALDataset *GDALDriver::DefaultCreateCopy(const char *pszFilename,
         /* --------------------------------------------------------------------
          */
         if (!bStrict)
-            CPLPushErrorHandler(CPLQuietErrorHandler);
+            CPLTurnFailureIntoWarning(true);
 
         if (strlen(poSrcBand->GetDescription()) > 0)
             poDstBand->SetDescription(poSrcBand->GetDescription());
@@ -768,8 +768,7 @@ GDALDataset *GDALDriver::DefaultCreateCopy(const char *pszFilename,
 
         if (!bStrict)
         {
-            CPLPopErrorHandler();
-            CPLErrorReset();
+            CPLTurnFailureIntoWarning(false);
         }
         else
         {


### PR DESCRIPTION
and GDALDriver::DefaultCreateCopy(): in non-strict mode, turn (ignored) errors as warnings and do not silence them

Refs #8148