### PR TITLE
GDALDataset::ICreateLayer(): now takes a const OGRSpatialReference* instead of a OGRSpatialReference*

### DIFF
--- a/MIGRATION_GUIDE.TXT
+++ b/MIGRATION_GUIDE.TXT
@@ -1,3 +1,11 @@
+MIGRATION GUIDE FROM GDAL 3.7 to GDAL 3.8
+-----------------------------------------
+
+- Out-of-tree vector drivers:
+  * GDALDataset::ICreateLayer() now takes a const OGRSpatialReference* instead
+    of a OGRSpatialReference*. Drivers should clone the passed SRS if they need
+    to keep it.
+
 MIGRATION GUIDE FROM GDAL 3.6 to GDAL 3.7
 -----------------------------------------
 

--- a/frmts/fits/fitsdataset.cpp
+++ b/frmts/fits/fitsdataset.cpp
@@ -117,7 +117,8 @@ class FITSDataset final : public GDALPamDataset
     }
     OGRLayer *GetLayer(int) override;
 
-    OGRLayer *ICreateLayer(const char *pszName, OGRSpatialReference *poSRS,
+    OGRLayer *ICreateLayer(const char *pszName,
+                           const OGRSpatialReference *poSRS,
                            OGRwkbGeometryType eGType,
                            char **papszOptions) override;
     int TestCapability(const char *pszCap) override;
@@ -2315,7 +2316,7 @@ OGRLayer *FITSDataset::GetLayer(int idx)
 /************************************************************************/
 
 OGRLayer *FITSDataset::ICreateLayer(const char *pszName,
-                                    OGRSpatialReference * /* poSRS */,
+                                    const OGRSpatialReference * /* poSRS */,
                                     OGRwkbGeometryType eGType,
                                     char **papszOptions)
 {

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -7651,7 +7651,7 @@ OGRLayer *netCDFDataset::GetLayer(int nIdx)
 /************************************************************************/
 
 OGRLayer *netCDFDataset::ICreateLayer(const char *pszName,
-                                      OGRSpatialReference *poSpatialRef,
+                                      const OGRSpatialReference *poSpatialRef,
                                       OGRwkbGeometryType eGType,
                                       char **papszOptions)
 {
@@ -7719,10 +7719,10 @@ OGRLayer *netCDFDataset::ICreateLayer(const char *pszName,
 
     // Make a clone to workaround a bug in released MapServer versions
     // that destroys the passed SRS instead of releasing it .
-    OGRSpatialReference *poSRS = poSpatialRef;
-    if (poSRS != nullptr)
+    OGRSpatialReference *poSRS = nullptr;
+    if (poSpatialRef)
     {
-        poSRS = poSRS->Clone();
+        poSRS = poSpatialRef->Clone();
         poSRS->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     }
     std::shared_ptr<netCDFLayer> poLayer(

--- a/frmts/netcdf/netcdfdataset.h
+++ b/frmts/netcdf/netcdfdataset.h
@@ -959,7 +959,7 @@ class netCDFDataset final : public GDALPamDataset
     CPLXMLNode *SerializeToXML(const char *pszVRTPath) override;
 
     virtual OGRLayer *ICreateLayer(const char *pszName,
-                                   OGRSpatialReference *poSpatialRef,
+                                   const OGRSpatialReference *poSpatialRef,
                                    OGRwkbGeometryType eGType,
                                    char **papszOptions) override;
 

--- a/frmts/null/nulldataset.cpp
+++ b/frmts/null/nulldataset.cpp
@@ -52,7 +52,7 @@ class GDALNullDataset final : public GDALDataset
     virtual OGRLayer *GetLayer(int) override;
 
     virtual OGRLayer *ICreateLayer(const char *pszLayerName,
-                                   OGRSpatialReference *poSRS,
+                                   const OGRSpatialReference *poSRS,
                                    OGRwkbGeometryType eType,
                                    char **papszOptions) override;
 
@@ -93,10 +93,10 @@ class GDALNullRasterBand final : public GDALRasterBand
 class GDALNullLayer final : public OGRLayer
 {
     OGRFeatureDefn *poFeatureDefn;
-    OGRSpatialReference *poSRS;
+    OGRSpatialReference *poSRS = nullptr;
 
   public:
-    GDALNullLayer(const char *pszLayerName, OGRSpatialReference *poSRS,
+    GDALNullLayer(const char *pszLayerName, const OGRSpatialReference *poSRS,
                   OGRwkbGeometryType eType);
     virtual ~GDALNullLayer();
 
@@ -222,7 +222,7 @@ GDALNullDataset::~GDALNullDataset()
 /************************************************************************/
 
 OGRLayer *GDALNullDataset::ICreateLayer(const char *pszLayerName,
-                                        OGRSpatialReference *poSRS,
+                                        const OGRSpatialReference *poSRS,
                                         OGRwkbGeometryType eType, char **)
 {
     m_papoLayers = static_cast<OGRLayer **>(
@@ -329,16 +329,16 @@ GDALDataset *GDALNullDataset::Create(const char *, int nXSize, int nYSize,
 /************************************************************************/
 
 GDALNullLayer::GDALNullLayer(const char *pszLayerName,
-                             OGRSpatialReference *poSRSIn,
+                             const OGRSpatialReference *poSRSIn,
                              OGRwkbGeometryType eType)
-    : poFeatureDefn(new OGRFeatureDefn(pszLayerName)), poSRS(poSRSIn)
+    : poFeatureDefn(new OGRFeatureDefn(pszLayerName))
 {
     SetDescription(poFeatureDefn->GetName());
     poFeatureDefn->SetGeomType(eType);
     poFeatureDefn->Reference();
 
-    if (poSRS)
-        poSRS->Reference();
+    if (poSRSIn)
+        poSRS = poSRSIn->Clone();
 }
 
 /************************************************************************/

--- a/frmts/pcidsk/pcidskdataset2.cpp
+++ b/frmts/pcidsk/pcidskdataset2.cpp
@@ -2106,7 +2106,7 @@ OGRLayer *PCIDSK2Dataset::GetLayer(int iLayer)
 /************************************************************************/
 
 OGRLayer *PCIDSK2Dataset::ICreateLayer(const char *pszLayerName,
-                                       OGRSpatialReference *poSRS,
+                                       const OGRSpatialReference *poSRS,
                                        OGRwkbGeometryType eType,
                                        CPL_UNUSED char **papszOptions)
 {

--- a/frmts/pcidsk/pcidskdataset2.h
+++ b/frmts/pcidsk/pcidskdataset2.h
@@ -108,7 +108,7 @@ class PCIDSK2Dataset final : public GDALPamDataset
 
     virtual int TestCapability(const char *) override;
 
-    virtual OGRLayer *ICreateLayer(const char *, OGRSpatialReference *,
+    virtual OGRLayer *ICreateLayer(const char *, const OGRSpatialReference *,
                                    OGRwkbGeometryType, char **) override;
 };
 

--- a/frmts/pdf/gdal_pdf.h
+++ b/frmts/pdf/gdal_pdf.h
@@ -503,7 +503,7 @@ class PDFWritableVectorDataset final : public GDALDataset
     virtual ~PDFWritableVectorDataset();
 
     virtual OGRLayer *ICreateLayer(const char *pszLayerName,
-                                   OGRSpatialReference *poSRS,
+                                   const OGRSpatialReference *poSRS,
                                    OGRwkbGeometryType eType,
                                    char **papszOptions) override;
 

--- a/frmts/pdf/pdfwritabledataset.cpp
+++ b/frmts/pdf/pdfwritabledataset.cpp
@@ -98,18 +98,18 @@ GDALDataset *PDFWritableVectorDataset::Create(const char *pszName, int nXSize,
 /*                           ICreateLayer()                             */
 /************************************************************************/
 
-OGRLayer *PDFWritableVectorDataset::ICreateLayer(const char *pszLayerName,
-                                                 OGRSpatialReference *poSRS,
-                                                 OGRwkbGeometryType eType,
-                                                 char **)
+OGRLayer *
+PDFWritableVectorDataset::ICreateLayer(const char *pszLayerName,
+                                       const OGRSpatialReference *poSRS,
+                                       OGRwkbGeometryType eType, char **)
 {
     /* -------------------------------------------------------------------- */
     /*      Create the layer object.                                        */
     /* -------------------------------------------------------------------- */
-    auto poSRSClone = poSRS;
-    if (poSRSClone)
+    OGRSpatialReference *poSRSClone = nullptr;
+    if (poSRS)
     {
-        poSRSClone = poSRSClone->Clone();
+        poSRSClone = poSRS->Clone();
         poSRSClone->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     }
     OGRLayer *poLayer =

--- a/frmts/pds/pds4dataset.cpp
+++ b/frmts/pds/pds4dataset.cpp
@@ -4160,7 +4160,7 @@ void PDS4Dataset::WriteHeader()
 /************************************************************************/
 
 OGRLayer *PDS4Dataset::ICreateLayer(const char *pszName,
-                                    OGRSpatialReference *poSpatialRef,
+                                    const OGRSpatialReference *poSpatialRef,
                                     OGRwkbGeometryType eGType,
                                     char **papszOptions)
 {

--- a/frmts/pds/pds4dataset.h
+++ b/frmts/pds/pds4dataset.h
@@ -168,8 +168,8 @@ class PDS4FixedWidthTable CPL_NON_FINAL : public PDS4TableBaseLayer
 
     bool ReadTableDef(const CPLXMLNode *psTable);
 
-    bool InitializeNewLayer(OGRSpatialReference *poSRS, bool bForceGeographic,
-                            OGRwkbGeometryType eGType,
+    bool InitializeNewLayer(const OGRSpatialReference *poSRS,
+                            bool bForceGeographic, OGRwkbGeometryType eGType,
                             const char *const *papszOptions);
 
     virtual PDS4FixedWidthTable *NewLayer(PDS4Dataset *poDS,
@@ -276,8 +276,8 @@ class PDS4DelimitedTable CPL_NON_FINAL : public PDS4TableBaseLayer
 
     bool ReadTableDef(const CPLXMLNode *psTable);
 
-    bool InitializeNewLayer(OGRSpatialReference *poSRS, bool bForceGeographic,
-                            OGRwkbGeometryType eGType,
+    bool InitializeNewLayer(const OGRSpatialReference *poSRS,
+                            bool bForceGeographic, OGRwkbGeometryType eGType,
                             const char *const *papszOptions);
 
     void RefreshFileAreaObservational(CPLXMLNode *psFAO) override;
@@ -409,7 +409,7 @@ class PDS4Dataset final : public RawDataset
     OGRLayer *GetLayer(int) override;
 
     OGRLayer *ICreateLayer(const char *pszName,
-                           OGRSpatialReference *poSpatialRef,
+                           const OGRSpatialReference *poSpatialRef,
                            OGRwkbGeometryType eGType,
                            char **papszOptions) override;
     int TestCapability(const char *pszCap) override;

--- a/frmts/pds/pds4vector.cpp
+++ b/frmts/pds/pds4vector.cpp
@@ -1502,7 +1502,7 @@ OGRErr PDS4FixedWidthTable::CreateField(OGRFieldDefn *poFieldIn, int)
 /*                          InitializeNewLayer()                        */
 /************************************************************************/
 
-bool PDS4FixedWidthTable::InitializeNewLayer(OGRSpatialReference *poSRS,
+bool PDS4FixedWidthTable::InitializeNewLayer(const OGRSpatialReference *poSRS,
                                              bool bForceGeographic,
                                              OGRwkbGeometryType eGType,
                                              const char *const *papszOptions)
@@ -2485,7 +2485,7 @@ char **PDS4DelimitedTable::GetFileList() const
 /*                          InitializeNewLayer()                        */
 /************************************************************************/
 
-bool PDS4DelimitedTable::InitializeNewLayer(OGRSpatialReference *poSRS,
+bool PDS4DelimitedTable::InitializeNewLayer(const OGRSpatialReference *poSRS,
                                             bool bForceGeographic,
                                             OGRwkbGeometryType eGType,
                                             const char *const *papszOptions)

--- a/frmts/tiledb/tiledbheaders.h
+++ b/frmts/tiledb/tiledbheaders.h
@@ -538,7 +538,7 @@ class OGRTileDBDataset final : public TileDBDataset
     }
     int TestCapability(const char *) override;
     OGRLayer *ICreateLayer(const char *pszName,
-                           OGRSpatialReference *poSpatialRef = nullptr,
+                           const OGRSpatialReference *poSpatialRef = nullptr,
                            OGRwkbGeometryType eGType = wkbUnknown,
                            char **papszOptions = nullptr) override;
     static GDALDataset *Open(GDALOpenInfo *, tiledb::Object::Type objectType);

--- a/frmts/tiledb/tiledbsparse.cpp
+++ b/frmts/tiledb/tiledbsparse.cpp
@@ -334,10 +334,10 @@ OGRLayer *OGRTileDBDataset::ExecuteSQL(const char *pszSQLCommand,
 /***********************************************************************/
 /*                           ICreateLayer()                            */
 /***********************************************************************/
-OGRLayer *OGRTileDBDataset::ICreateLayer(const char *pszName,
-                                         OGRSpatialReference *poSpatialRef,
-                                         OGRwkbGeometryType eGType,
-                                         char **papszOptions)
+OGRLayer *
+OGRTileDBDataset::ICreateLayer(const char *pszName,
+                               const OGRSpatialReference *poSpatialRef,
+                               OGRwkbGeometryType eGType, char **papszOptions)
 {
     if (eAccess != GA_Update)
     {

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -880,10 +880,9 @@ class CPL_DLL GDALDataset : public GDALMajorObject
     UpdateRelationship(std::unique_ptr<GDALRelationship> &&relationship,
                        std::string &failureReason);
 
-    virtual OGRLayer *CreateLayer(const char *pszName,
-                                  OGRSpatialReference *poSpatialRef = nullptr,
-                                  OGRwkbGeometryType eGType = wkbUnknown,
-                                  char **papszOptions = nullptr);
+    virtual OGRLayer *CreateLayer(
+        const char *pszName, const OGRSpatialReference *poSpatialRef = nullptr,
+        OGRwkbGeometryType eGType = wkbUnknown, char **papszOptions = nullptr);
     virtual OGRLayer *CopyLayer(OGRLayer *poSrcLayer, const char *pszNewName,
                                 char **papszOptions = nullptr);
 
@@ -922,10 +921,9 @@ class CPL_DLL GDALDataset : public GDALMajorObject
     //! @endcond
 
   protected:
-    virtual OGRLayer *ICreateLayer(const char *pszName,
-                                   OGRSpatialReference *poSpatialRef = nullptr,
-                                   OGRwkbGeometryType eGType = wkbUnknown,
-                                   char **papszOptions = nullptr);
+    virtual OGRLayer *ICreateLayer(
+        const char *pszName, const OGRSpatialReference *poSpatialRef = nullptr,
+        OGRwkbGeometryType eGType = wkbUnknown, char **papszOptions = nullptr);
 
     //! @cond Doxygen_Suppress
     OGRErr ProcessSQLCreateIndex(const char *);

--- a/gcore/gdaldataset.cpp
+++ b/gcore/gdaldataset.cpp
@@ -4726,10 +4726,7 @@ Example:
 @param pszName the name for the new layer.  This should ideally not
 match any existing layer on the datasource.
 @param poSpatialRef the coordinate system to use for the new layer, or NULL if
-no coordinate system is available.  The driver might only increase
-the reference counter of the object to take ownership, and not make a full copy,
-so do not use OSRDestroySpatialReference(), but OSRRelease() instead when you
-are done with the object.
+no coordinate system is available.
 @param eGType the geometry type for the layer.  Use wkbUnknown if there
 are no constraints on the types geometry to be written.
 @param papszOptions a StringList of name=value options.  Options are driver
@@ -4740,7 +4737,7 @@ specific.
 */
 
 OGRLayer *GDALDataset::CreateLayer(const char *pszName,
-                                   OGRSpatialReference *poSpatialRef,
+                                   const OGRSpatialReference *poSpatialRef,
                                    OGRwkbGeometryType eGType,
                                    char **papszOptions)
 
@@ -4818,10 +4815,7 @@ Example:
 @param pszName the name for the new layer.  This should ideally not
 match any existing layer on the datasource.
 @param hSpatialRef the coordinate system to use for the new layer, or NULL if
-no coordinate system is available.  The driver might only increase
-the reference counter of the object to take ownership, and not make a full copy,
-so do not use OSRDestroySpatialReference(), but OSRRelease() instead when you
-are done with the object.
+no coordinate system is available.
 @param eGType the geometry type for the layer.  Use wkbUnknown if there
 are no constraints on the types geometry to be written.
 @param papszOptions a StringList of name=value options.  Options are driver
@@ -5198,7 +5192,7 @@ int GDALDataset::GetSummaryRefCount() const
 
 OGRLayer *
 GDALDataset::ICreateLayer(CPL_UNUSED const char *pszName,
-                          CPL_UNUSED OGRSpatialReference *poSpatialRef,
+                          CPL_UNUSED const OGRSpatialReference *poSpatialRef,
                           CPL_UNUSED OGRwkbGeometryType eGType,
                           CPL_UNUSED char **papszOptions)
 

--- a/gnm/gnm_frmts/db/gnmdb.h
+++ b/gnm/gnm_frmts/db/gnmdb.h
@@ -42,10 +42,11 @@ class GNMDatabaseNetwork : public GNMGenericNetwork
                           char **papszOptions) override;
 
   protected:
-    virtual OGRLayer *ICreateLayer(const char *pszName,
-                                   OGRSpatialReference *poSpatialRef = nullptr,
-                                   OGRwkbGeometryType eGType = wkbUnknown,
-                                   char **papszOptions = nullptr) override;
+    virtual OGRLayer *
+    ICreateLayer(const char *pszName,
+                 const OGRSpatialReference *poSpatialRef = nullptr,
+                 OGRwkbGeometryType eGType = wkbUnknown,
+                 char **papszOptions = nullptr) override;
     virtual int CheckNetworkExist(const char *pszFilename,
                                   char **papszOptions) override;
 

--- a/gnm/gnm_frmts/db/gnmdbnetwork.cpp
+++ b/gnm/gnm_frmts/db/gnmdbnetwork.cpp
@@ -414,7 +414,7 @@ OGRErr GNMDatabaseNetwork::DeleteLayer(int nIndex)
 
 OGRLayer *
 GNMDatabaseNetwork::ICreateLayer(const char *pszName,
-                                 OGRSpatialReference * /*poSpatialRef*/,
+                                 const OGRSpatialReference * /*poSpatialRef*/,
                                  OGRwkbGeometryType eGType, char **papszOptions)
 {
     // check if layer with such name exist

--- a/gnm/gnm_frmts/file/gnmfile.h
+++ b/gnm/gnm_frmts/file/gnmfile.h
@@ -46,10 +46,11 @@ class GNMFileNetwork : public GNMGenericNetwork
                           char **papszOptions) override;
 
   protected:
-    virtual OGRLayer *ICreateLayer(const char *pszName,
-                                   OGRSpatialReference *poSpatialRef = nullptr,
-                                   OGRwkbGeometryType eGType = wkbUnknown,
-                                   char **papszOptions = nullptr) override;
+    virtual OGRLayer *
+    ICreateLayer(const char *pszName,
+                 const OGRSpatialReference *poSpatialRef = nullptr,
+                 OGRwkbGeometryType eGType = wkbUnknown,
+                 char **papszOptions = nullptr) override;
     virtual int CheckNetworkExist(const char *pszFilename,
                                   char **papszOptions) override;
 

--- a/gnm/gnm_frmts/file/gnmfilenetwork.cpp
+++ b/gnm/gnm_frmts/file/gnmfilenetwork.cpp
@@ -521,10 +521,10 @@ OGRErr GNMFileNetwork::DeleteLayer(int nIndex)
     return GNMGenericNetwork::DeleteLayer(nIndex);
 }
 
-OGRLayer *GNMFileNetwork::ICreateLayer(const char *pszName,
-                                       OGRSpatialReference * /* poSpatialRef */,
-                                       OGRwkbGeometryType eGType,
-                                       char **papszOptions)
+OGRLayer *
+GNMFileNetwork::ICreateLayer(const char *pszName,
+                             const OGRSpatialReference * /* poSpatialRef */,
+                             OGRwkbGeometryType eGType, char **papszOptions)
 {
     if (nullptr == m_poLayerDriver)
     {

--- a/ogr/ogrsf_frmts/amigocloud/ogr_amigocloud.h
+++ b/ogr/ogrsf_frmts/amigocloud/ogr_amigocloud.h
@@ -290,10 +290,11 @@ class OGRAmigoCloudDataSource final : public OGRDataSource
 
     virtual int TestCapability(const char *) override;
 
-    virtual OGRLayer *ICreateLayer(const char *pszName,
-                                   OGRSpatialReference *poSpatialRef = nullptr,
-                                   OGRwkbGeometryType eGType = wkbUnknown,
-                                   char **papszOptions = nullptr) override;
+    virtual OGRLayer *
+    ICreateLayer(const char *pszName,
+                 const OGRSpatialReference *poSpatialRef = nullptr,
+                 OGRwkbGeometryType eGType = wkbUnknown,
+                 char **papszOptions = nullptr) override;
     virtual OGRErr DeleteLayer(int) override;
 
     virtual OGRLayer *ExecuteSQL(const char *pszSQLCommand,

--- a/ogr/ogrsf_frmts/amigocloud/ogramigoclouddatasource.cpp
+++ b/ogr/ogrsf_frmts/amigocloud/ogramigoclouddatasource.cpp
@@ -371,7 +371,7 @@ int OGRAmigoCloudDataSource::FetchSRSId(OGRSpatialReference *poSRS)
 /************************************************************************/
 
 OGRLayer *OGRAmigoCloudDataSource::ICreateLayer(
-    const char *pszNameIn, OGRSpatialReference *poSpatialRef,
+    const char *pszNameIn, const OGRSpatialReference *poSpatialRef,
     OGRwkbGeometryType eGType, char **papszOptions)
 {
     if (!bReadWrite)
@@ -386,10 +386,10 @@ OGRLayer *OGRAmigoCloudDataSource::ICreateLayer(
         new OGRAmigoCloudTableLayer(this, osName);
     const bool bGeomNullable =
         CPLFetchBool(papszOptions, "GEOMETRY_NULLABLE", true);
-    OGRSpatialReference *poSRSClone = poSpatialRef;
-    if (poSRSClone)
+    OGRSpatialReference *poSRSClone = nullptr;
+    if (poSpatialRef)
     {
-        poSRSClone = poSRSClone->Clone();
+        poSRSClone = poSpatialRef->Clone();
         poSRSClone->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     }
     poLayer->SetDeferredCreation(eGType, poSRSClone, bGeomNullable);

--- a/ogr/ogrsf_frmts/arrow/ogr_feather.h
+++ b/ogr/ogrsf_frmts/arrow/ogr_feather.h
@@ -193,7 +193,7 @@ class OGRFeatherWriterLayer final : public OGRArrowWriterLayer
     ~OGRFeatherWriterLayer() override;
 
     bool SetOptions(const std::string &osFilename, CSLConstList papszOptions,
-                    OGRSpatialReference *poSpatialRef,
+                    const OGRSpatialReference *poSpatialRef,
                     OGRwkbGeometryType eGType);
 };
 
@@ -230,7 +230,7 @@ class OGRFeatherWriterDataset final : public GDALPamDataset
 
   protected:
     OGRLayer *ICreateLayer(const char *pszName,
-                           OGRSpatialReference *poSpatialRef = nullptr,
+                           const OGRSpatialReference *poSpatialRef = nullptr,
                            OGRwkbGeometryType eGType = wkbUnknown,
                            char **papszOptions = nullptr) override;
 };

--- a/ogr/ogrsf_frmts/arrow/ogrfeatherwriterdataset.cpp
+++ b/ogr/ogrsf_frmts/arrow/ogrfeatherwriterdataset.cpp
@@ -79,7 +79,7 @@ int OGRFeatherWriterDataset::TestCapability(const char *pszCap)
 /************************************************************************/
 
 OGRLayer *OGRFeatherWriterDataset::ICreateLayer(
-    const char *pszName, OGRSpatialReference *poSpatialRef,
+    const char *pszName, const OGRSpatialReference *poSpatialRef,
     OGRwkbGeometryType eGType, char **papszOptions)
 {
     if (m_poLayer)

--- a/ogr/ogrsf_frmts/arrow/ogrfeatherwriterlayer.cpp
+++ b/ogr/ogrsf_frmts/arrow/ogrfeatherwriterlayer.cpp
@@ -82,7 +82,7 @@ bool OGRFeatherWriterLayer::IsSupportedGeometryType(
 
 bool OGRFeatherWriterLayer::SetOptions(const std::string &osFilename,
                                        CSLConstList papszOptions,
-                                       OGRSpatialReference *poSpatialRef,
+                                       const OGRSpatialReference *poSpatialRef,
                                        OGRwkbGeometryType eGType)
 {
     const char *pszDefaultFormat =

--- a/ogr/ogrsf_frmts/carto/ogr_carto.h
+++ b/ogr/ogrsf_frmts/carto/ogr_carto.h
@@ -302,10 +302,11 @@ class OGRCARTODataSource final : public OGRDataSource
 
     virtual int TestCapability(const char *) override;
 
-    virtual OGRLayer *ICreateLayer(const char *pszName,
-                                   OGRSpatialReference *poSpatialRef = nullptr,
-                                   OGRwkbGeometryType eGType = wkbUnknown,
-                                   char **papszOptions = nullptr) override;
+    virtual OGRLayer *
+    ICreateLayer(const char *pszName,
+                 const OGRSpatialReference *poSpatialRef = nullptr,
+                 OGRwkbGeometryType eGType = wkbUnknown,
+                 char **papszOptions = nullptr) override;
     virtual OGRErr DeleteLayer(int) override;
 
     virtual OGRLayer *ExecuteSQL(const char *pszSQLCommand,

--- a/ogr/ogrsf_frmts/carto/ogrcartodatasource.cpp
+++ b/ogr/ogrsf_frmts/carto/ogrcartodatasource.cpp
@@ -408,10 +408,10 @@ int OGRCARTODataSource::FetchSRSId(const OGRSpatialReference *poSRS)
 /*                          ICreateLayer()                              */
 /************************************************************************/
 
-OGRLayer *OGRCARTODataSource::ICreateLayer(const char *pszNameIn,
-                                           OGRSpatialReference *poSpatialRef,
-                                           OGRwkbGeometryType eGType,
-                                           char **papszOptions)
+OGRLayer *
+OGRCARTODataSource::ICreateLayer(const char *pszNameIn,
+                                 const OGRSpatialReference *poSpatialRef,
+                                 OGRwkbGeometryType eGType, char **papszOptions)
 {
     if (!bReadWrite)
     {
@@ -492,10 +492,10 @@ OGRLayer *OGRCARTODataSource::ICreateLayer(const char *pszNameIn,
 
     poLayer->SetLaunderFlag(CPLFetchBool(papszOptions, "LAUNDER", true));
 
-    OGRSpatialReference *poSRSClone = poSpatialRef;
-    if (poSRSClone)
+    OGRSpatialReference *poSRSClone = nullptr;
+    if (poSpatialRef)
     {
-        poSRSClone = poSRSClone->Clone();
+        poSRSClone = poSpatialRef->Clone();
         poSRSClone->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     }
     poLayer->SetDeferredCreation(eGType, poSRSClone, bGeomNullable, bCartoify);

--- a/ogr/ogrsf_frmts/csv/ogr_csv.h
+++ b/ogr/ogrsf_frmts/csv/ogr_csv.h
@@ -298,10 +298,11 @@ class OGRCSVDataSource final : public OGRDataSource
 
     char **GetFileList() override;
 
-    virtual OGRLayer *ICreateLayer(const char *pszName,
-                                   OGRSpatialReference *poSpatialRef = nullptr,
-                                   OGRwkbGeometryType eGType = wkbUnknown,
-                                   char **papszOptions = nullptr) override;
+    virtual OGRLayer *
+    ICreateLayer(const char *pszName,
+                 const OGRSpatialReference *poSpatialRef = nullptr,
+                 OGRwkbGeometryType eGType = wkbUnknown,
+                 char **papszOptions = nullptr) override;
 
     virtual OGRErr DeleteLayer(int) override;
 

--- a/ogr/ogrsf_frmts/csv/ogrcsvdatasource.cpp
+++ b/ogr/ogrsf_frmts/csv/ogrcsvdatasource.cpp
@@ -916,10 +916,10 @@ bool OGRCSVDataSource::OpenTable(const char *pszFilename,
 /*                           ICreateLayer()                             */
 /************************************************************************/
 
-OGRLayer *OGRCSVDataSource::ICreateLayer(const char *pszLayerName,
-                                         OGRSpatialReference *poSpatialRef,
-                                         OGRwkbGeometryType eGType,
-                                         char **papszOptions)
+OGRLayer *
+OGRCSVDataSource::ICreateLayer(const char *pszLayerName,
+                               const OGRSpatialReference *poSpatialRef,
+                               OGRwkbGeometryType eGType, char **papszOptions)
 {
     // Verify we are in update mode.
     if (!bUpdate)

--- a/ogr/ogrsf_frmts/dgn/ogr_dgn.h
+++ b/ogr/ogrsf_frmts/dgn/ogr_dgn.h
@@ -115,7 +115,7 @@ class OGRDGNDataSource final : public OGRDataSource
     int Open(const char *, int bTestOpen, int bUpdate);
     bool PreCreate(const char *, char **);
 
-    OGRLayer *ICreateLayer(const char *, OGRSpatialReference * = nullptr,
+    OGRLayer *ICreateLayer(const char *, const OGRSpatialReference * = nullptr,
                            OGRwkbGeometryType = wkbUnknown,
                            char ** = nullptr) override;
 

--- a/ogr/ogrsf_frmts/dgn/ogrdgndatasource.cpp
+++ b/ogr/ogrsf_frmts/dgn/ogrdgndatasource.cpp
@@ -171,7 +171,7 @@ bool OGRDGNDataSource::PreCreate(const char *pszFilename, char **papszOptionsIn)
 /************************************************************************/
 
 OGRLayer *OGRDGNDataSource::ICreateLayer(const char *pszLayerName,
-                                         OGRSpatialReference *poSRS,
+                                         const OGRSpatialReference *poSRS,
                                          OGRwkbGeometryType eGeomType,
                                          char **papszExtraOptions)
 

--- a/ogr/ogrsf_frmts/dwg/ogr_dgnv8.h
+++ b/ogr/ogrsf_frmts/dwg/ogr_dgnv8.h
@@ -144,7 +144,7 @@ class OGRDGNV8DataSource final : public GDALDataset
     int Open(const char *, bool bUpdate);
     bool PreCreate(const char *, char **);
 
-    OGRLayer *ICreateLayer(const char *, OGRSpatialReference * = nullptr,
+    OGRLayer *ICreateLayer(const char *, const OGRSpatialReference * = nullptr,
                            OGRwkbGeometryType = wkbUnknown,
                            char ** = nullptr) override;
 

--- a/ogr/ogrsf_frmts/dwg/ogrdgnv8datasource.cpp
+++ b/ogr/ogrsf_frmts/dwg/ogrdgnv8datasource.cpp
@@ -521,10 +521,9 @@ OdString OGRDGNV8DataSource::FromUTF8(const CPLString &str)
 /*                           ICreateLayer()                             */
 /************************************************************************/
 
-OGRLayer *OGRDGNV8DataSource::ICreateLayer(const char *pszLayerName,
-                                           OGRSpatialReference * /*poSRS*/,
-                                           OGRwkbGeometryType /*eGeomType*/,
-                                           char **papszOptions)
+OGRLayer *OGRDGNV8DataSource::ICreateLayer(
+    const char *pszLayerName, const OGRSpatialReference * /*poSRS*/,
+    OGRwkbGeometryType /*eGeomType*/, char **papszOptions)
 
 {
     if (!m_bUpdate)

--- a/ogr/ogrsf_frmts/dxf/ogr_dxf.h
+++ b/ogr/ogrsf_frmts/dxf/ogr_dxf.h
@@ -943,7 +943,7 @@ class OGRDXFWriterDS final : public OGRDataSource
     int TestCapability(const char *) override;
 
     OGRLayer *ICreateLayer(const char *pszName,
-                           OGRSpatialReference *poSpatialRef = nullptr,
+                           const OGRSpatialReference *poSpatialRef = nullptr,
                            OGRwkbGeometryType eGType = wkbUnknown,
                            char **papszOptions = nullptr) override;
 

--- a/ogr/ogrsf_frmts/dxf/ogrdxfwriterds.cpp
+++ b/ogr/ogrsf_frmts/dxf/ogrdxfwriterds.cpp
@@ -275,7 +275,7 @@ int OGRDXFWriterDS::Open(const char *pszFilename, char **papszOptions)
 /************************************************************************/
 
 OGRLayer *OGRDXFWriterDS::ICreateLayer(const char *pszName,
-                                       OGRSpatialReference *,
+                                       const OGRSpatialReference *,
                                        OGRwkbGeometryType, char **)
 
 {

--- a/ogr/ogrsf_frmts/elastic/ogr_elastic.h
+++ b/ogr/ogrsf_frmts/elastic/ogr_elastic.h
@@ -376,7 +376,7 @@ class OGRElasticDataSource final : public GDALDataset
     virtual OGRLayer *GetLayerByName(const char *pszName) override;
 
     virtual OGRLayer *ICreateLayer(const char *pszLayerName,
-                                   OGRSpatialReference *poSRS,
+                                   const OGRSpatialReference *poSRS,
                                    OGRwkbGeometryType eType,
                                    char **papszOptions) override;
     virtual OGRErr DeleteLayer(int iLayer) override;

--- a/ogr/ogrsf_frmts/elastic/ogrelasticdatasource.cpp
+++ b/ogr/ogrsf_frmts/elastic/ogrelasticdatasource.cpp
@@ -413,7 +413,7 @@ OGRErr OGRElasticDataSource::DeleteLayer(int iLayer)
 /************************************************************************/
 
 OGRLayer *OGRElasticDataSource::ICreateLayer(const char *pszLayerName,
-                                             OGRSpatialReference *poSRS,
+                                             const OGRSpatialReference *poSRS,
                                              OGRwkbGeometryType eGType,
                                              char **papszOptions)
 {

--- a/ogr/ogrsf_frmts/filegdb/FGdbDatasource.cpp
+++ b/ogr/ogrsf_frmts/filegdb/FGdbDatasource.cpp
@@ -691,7 +691,7 @@ OGRLayer *FGdbDataSource::GetLayer(int iLayer)
 /************************************************************************/
 
 OGRLayer *FGdbDataSource::ICreateLayer(const char *pszLayerName,
-                                       OGRSpatialReference *poSRS,
+                                       const OGRSpatialReference *poSRS,
                                        OGRwkbGeometryType eType,
                                        char **papszOptions)
 {

--- a/ogr/ogrsf_frmts/filegdb/FGdbLayer.cpp
+++ b/ogr/ogrsf_frmts/filegdb/FGdbLayer.cpp
@@ -2073,7 +2073,7 @@ OGRErr FGdbLayer::AlterFieldDefn(int iFieldToAlter,
 /*                                                                      */
 /************************************************************************/
 
-static CPLXMLNode *XMLSpatialReference(OGRSpatialReference *poSRS,
+static CPLXMLNode *XMLSpatialReference(const OGRSpatialReference *poSRS,
                                        char **papszOptions)
 {
     /* We always need a SpatialReference */
@@ -2343,7 +2343,7 @@ static CPLXMLNode *XMLSpatialReference(OGRSpatialReference *poSRS,
 
 bool FGdbLayer::CreateFeatureDataset(FGdbDataSource *pParentDataSource,
                                      const std::string &feature_dataset_name,
-                                     OGRSpatialReference *poSRS,
+                                     const OGRSpatialReference *poSRS,
                                      char **papszOptions)
 {
     /* XML node */
@@ -2430,7 +2430,8 @@ bool FGdbLayer::CreateFeatureDataset(FGdbDataSource *pParentDataSource,
 /************************************************************************/
 
 bool FGdbLayer::Create(FGdbDataSource *pParentDataSource,
-                       const char *pszLayerNameIn, OGRSpatialReference *poSRS,
+                       const char *pszLayerNameIn,
+                       const OGRSpatialReference *poSRS,
                        OGRwkbGeometryType eType, char **papszOptions)
 {
     std::string parent_path = "";

--- a/ogr/ogrsf_frmts/filegdb/ogr_fgdb.h
+++ b/ogr/ogrsf_frmts/filegdb/ogr_fgdb.h
@@ -165,11 +165,11 @@ class FGdbLayer final : public FGdbBaseLayer
                     const std::wstring &wstrTablePath,
                     const std::wstring &wstrType);
     bool Create(FGdbDataSource *pParentDataSource, const char *pszLayerName,
-                OGRSpatialReference *poSRS, OGRwkbGeometryType eType,
+                const OGRSpatialReference *poSRS, OGRwkbGeometryType eType,
                 char **papszOptions);
     static bool CreateFeatureDataset(FGdbDataSource *pParentDataSource,
                                      const std::string &feature_dataset_name,
-                                     OGRSpatialReference *poSRS,
+                                     const OGRSpatialReference *poSRS,
                                      char **papszOptions);
 
     // virtual const char *GetName();
@@ -346,7 +346,7 @@ class FGdbDataSource final : public OGRDataSource
     OGRLayer *GetLayer(int) override;
 
     virtual OGRLayer *ICreateLayer(const char *,
-                                   OGRSpatialReference * = nullptr,
+                                   const OGRSpatialReference * = nullptr,
                                    OGRwkbGeometryType = wkbUnknown,
                                    char ** = nullptr) override;
 

--- a/ogr/ogrsf_frmts/flatgeobuf/ogr_flatgeobuf.h
+++ b/ogr/ogrsf_frmts/flatgeobuf/ogr_flatgeobuf.h
@@ -142,7 +142,7 @@ class OGRFlatGeobufLayer final : public OGRLayer,
                        const char *pszFilename, VSILFILE *poFp,
                        uint64_t offset);
     OGRFlatGeobufLayer(const char *pszLayerName, const char *pszFilename,
-                       OGRSpatialReference *poSpatialRef,
+                       const OGRSpatialReference *poSpatialRef,
                        OGRwkbGeometryType eGType,
                        bool bCreateSpatialIndexAtClose, VSILFILE *poFpWrite,
                        std::string &osTempFile);
@@ -163,7 +163,7 @@ class OGRFlatGeobufLayer final : public OGRLayer,
                                     bool bVerifyBuffers);
     static OGRFlatGeobufLayer *
     Create(const char *pszLayerName, const char *pszFilename,
-           OGRSpatialReference *poSpatialRef, OGRwkbGeometryType eGType,
+           const OGRSpatialReference *poSpatialRef, OGRwkbGeometryType eGType,
            bool bCreateSpatialIndexAtClose, char **papszOptions);
 
     virtual OGRFeature *GetFeature(GIntBig nFeatureId) override;
@@ -262,10 +262,11 @@ class OGRFlatGeobufDataset final : public GDALDataset
                                char **papszOptions);
     virtual OGRLayer *GetLayer(int) override;
     int TestCapability(const char *pszCap) override;
-    virtual OGRLayer *ICreateLayer(const char *pszName,
-                                   OGRSpatialReference *poSpatialRef = nullptr,
-                                   OGRwkbGeometryType eGType = wkbUnknown,
-                                   char **papszOptions = nullptr) override;
+    virtual OGRLayer *
+    ICreateLayer(const char *pszName,
+                 const OGRSpatialReference *poSpatialRef = nullptr,
+                 OGRwkbGeometryType eGType = wkbUnknown,
+                 char **papszOptions = nullptr) override;
 
     virtual int GetLayerCount() override
     {

--- a/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobufdataset.cpp
+++ b/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobufdataset.cpp
@@ -396,10 +396,9 @@ static CPLString LaunderLayerName(const char *pszLayerName)
     return osRet;
 }
 
-OGRLayer *OGRFlatGeobufDataset::ICreateLayer(const char *pszLayerName,
-                                             OGRSpatialReference *poSpatialRef,
-                                             OGRwkbGeometryType eGType,
-                                             char **papszOptions)
+OGRLayer *OGRFlatGeobufDataset::ICreateLayer(
+    const char *pszLayerName, const OGRSpatialReference *poSpatialRef,
+    OGRwkbGeometryType eGType, char **papszOptions)
 {
     // Verify we are in update mode.
     if (!m_bCreate)

--- a/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
+++ b/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
@@ -170,7 +170,7 @@ OGRFlatGeobufLayer::OGRFlatGeobufLayer(const Header *poHeader, GByte *headerBuf,
 
 OGRFlatGeobufLayer::OGRFlatGeobufLayer(const char *pszLayerName,
                                        const char *pszFilename,
-                                       OGRSpatialReference *poSpatialRef,
+                                       const OGRSpatialReference *poSpatialRef,
                                        OGRwkbGeometryType eGType,
                                        bool bCreateSpatialIndexAtClose,
                                        VSILFILE *poFpWrite,
@@ -2345,7 +2345,7 @@ VSILFILE *OGRFlatGeobufLayer::CreateOutputFile(const CPLString &osFilename,
 
 OGRFlatGeobufLayer *
 OGRFlatGeobufLayer::Create(const char *pszLayerName, const char *pszFilename,
-                           OGRSpatialReference *poSpatialRef,
+                           const OGRSpatialReference *poSpatialRef,
                            OGRwkbGeometryType eGType,
                            bool bCreateSpatialIndexAtClose, char **papszOptions)
 {

--- a/ogr/ogrsf_frmts/generic/ogremulatedtransaction.cpp
+++ b/ogr/ogrsf_frmts/generic/ogremulatedtransaction.cpp
@@ -117,10 +117,11 @@ class OGRDataSourceWithTransaction final : public OGRDataSource
 
     virtual int TestCapability(const char *) override;
 
-    virtual OGRLayer *ICreateLayer(const char *pszName,
-                                   OGRSpatialReference *poSpatialRef = nullptr,
-                                   OGRwkbGeometryType eGType = wkbUnknown,
-                                   char **papszOptions = nullptr) override;
+    virtual OGRLayer *
+    ICreateLayer(const char *pszName,
+                 const OGRSpatialReference *poSpatialRef = nullptr,
+                 OGRwkbGeometryType eGType = wkbUnknown,
+                 char **papszOptions = nullptr) override;
     virtual OGRLayer *CopyLayer(OGRLayer *poSrcLayer, const char *pszNewName,
                                 char **papszOptions = nullptr) override;
 
@@ -324,7 +325,7 @@ int OGRDataSourceWithTransaction::TestCapability(const char *pszCap)
 }
 
 OGRLayer *OGRDataSourceWithTransaction::ICreateLayer(
-    const char *pszName, OGRSpatialReference *poSpatialRef,
+    const char *pszName, const OGRSpatialReference *poSpatialRef,
     OGRwkbGeometryType eGType, char **papszOptions)
 {
     if (!m_poBaseDataSource)

--- a/ogr/ogrsf_frmts/generic/ogrmutexeddatasource.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrmutexeddatasource.cpp
@@ -127,10 +127,9 @@ int OGRMutexedDataSource::TestCapability(const char *pszCap)
     return m_poBaseDataSource->TestCapability(pszCap);
 }
 
-OGRLayer *OGRMutexedDataSource::ICreateLayer(const char *pszName,
-                                             OGRSpatialReference *poSpatialRef,
-                                             OGRwkbGeometryType eGType,
-                                             char **papszOptions)
+OGRLayer *OGRMutexedDataSource::ICreateLayer(
+    const char *pszName, const OGRSpatialReference *poSpatialRef,
+    OGRwkbGeometryType eGType, char **papszOptions)
 {
     CPLMutexHolderOptionalLockD(m_hGlobalMutex);
     return WrapLayerIfNecessary(m_poBaseDataSource->CreateLayer(

--- a/ogr/ogrsf_frmts/generic/ogrmutexeddatasource.h
+++ b/ogr/ogrsf_frmts/generic/ogrmutexeddatasource.h
@@ -81,10 +81,11 @@ class CPL_DLL OGRMutexedDataSource : public OGRDataSource
 
     virtual int TestCapability(const char *) override;
 
-    virtual OGRLayer *ICreateLayer(const char *pszName,
-                                   OGRSpatialReference *poSpatialRef = nullptr,
-                                   OGRwkbGeometryType eGType = wkbUnknown,
-                                   char **papszOptions = nullptr) override;
+    virtual OGRLayer *
+    ICreateLayer(const char *pszName,
+                 const OGRSpatialReference *poSpatialRef = nullptr,
+                 OGRwkbGeometryType eGType = wkbUnknown,
+                 char **papszOptions = nullptr) override;
     virtual OGRLayer *CopyLayer(OGRLayer *poSrcLayer, const char *pszNewName,
                                 char **papszOptions = nullptr) override;
 

--- a/ogr/ogrsf_frmts/geoconcept/ogrgeoconceptdatasource.cpp
+++ b/ogr/ogrsf_frmts/geoconcept/ogrgeoconceptdatasource.cpp
@@ -293,7 +293,7 @@ int OGRGeoconceptDataSource::Create(const char *pszName, char **papszOptions)
 /************************************************************************/
 
 OGRLayer *OGRGeoconceptDataSource::ICreateLayer(
-    const char *pszLayerName, OGRSpatialReference *poSRS /* = NULL */,
+    const char *pszLayerName, const OGRSpatialReference *poSRS /* = NULL */,
     OGRwkbGeometryType eType /* = wkbUnknown */,
     char **papszOptions /* = NULL */)
 
@@ -517,7 +517,11 @@ OGRLayer *OGRGeoconceptDataSource::ICreateLayer(
     /*      Assign the coordinate system (if provided)                      */
     /* -------------------------------------------------------------------- */
     if (poSRS != nullptr)
-        poFile->SetSpatialRef(poSRS);
+    {
+        auto poSRSClone = poSRS->Clone();
+        poFile->SetSpatialRef(poSRSClone);
+        poSRSClone->Release();
+    }
 
     return poFile;
 }

--- a/ogr/ogrsf_frmts/geoconcept/ogrgeoconceptdatasource.h
+++ b/ogr/ogrsf_frmts/geoconcept/ogrgeoconceptdatasource.h
@@ -72,7 +72,7 @@ class OGRGeoconceptDataSource : public OGRDataSource
     int TestCapability(const char *pszCap) override;
 
     OGRLayer *ICreateLayer(const char *pszName,
-                           OGRSpatialReference *poSpatialRef = nullptr,
+                           const OGRSpatialReference *poSpatialRef = nullptr,
                            OGRwkbGeometryType eGType = wkbUnknown,
                            char **papszOptions = nullptr) override;
 

--- a/ogr/ogrsf_frmts/geojson/ogr_geojson.h
+++ b/ogr/ogrsf_frmts/geojson/ogr_geojson.h
@@ -220,7 +220,7 @@ class OGRGeoJSONDataSource final : public OGRDataSource
     int GetLayerCount() override;
     OGRLayer *GetLayer(int nLayer) override;
     OGRLayer *ICreateLayer(const char *pszName,
-                           OGRSpatialReference *poSRS = nullptr,
+                           const OGRSpatialReference *poSRS = nullptr,
                            OGRwkbGeometryType eGType = wkbUnknown,
                            char **papszOptions = nullptr) override;
     int TestCapability(const char *pszCap) override;

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsondatasource.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsondatasource.cpp
@@ -255,7 +255,7 @@ OGRLayer *OGRGeoJSONDataSource::GetLayer(int nLayer)
 /************************************************************************/
 
 OGRLayer *OGRGeoJSONDataSource::ICreateLayer(const char *pszNameIn,
-                                             OGRSpatialReference *poSRS,
+                                             const OGRSpatialReference *poSRS,
                                              OGRwkbGeometryType eGType,
                                              char **papszOptions)
 {

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonseqdriver.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonseqdriver.cpp
@@ -65,7 +65,7 @@ class OGRGeoJSONSeqDataSource final : public GDALDataset
     }
     OGRLayer *GetLayer(int) override;
     OGRLayer *ICreateLayer(const char *pszName,
-                           OGRSpatialReference *poSRS = nullptr,
+                           const OGRSpatialReference *poSRS = nullptr,
                            OGRwkbGeometryType eGType = wkbUnknown,
                            char **papszOptions = nullptr) override;
     int TestCapability(const char *pszCap) override;
@@ -174,10 +174,9 @@ OGRLayer *OGRGeoJSONSeqDataSource::GetLayer(int nIndex)
 /*                           ICreateLayer()                             */
 /************************************************************************/
 
-OGRLayer *OGRGeoJSONSeqDataSource::ICreateLayer(const char *pszNameIn,
-                                                OGRSpatialReference *poSRS,
-                                                OGRwkbGeometryType /*eGType*/,
-                                                char **papszOptions)
+OGRLayer *OGRGeoJSONSeqDataSource::ICreateLayer(
+    const char *pszNameIn, const OGRSpatialReference *poSRS,
+    OGRwkbGeometryType /*eGType*/, char **papszOptions)
 {
     if (!TestCapability(ODsCCreateLayer))
         return nullptr;

--- a/ogr/ogrsf_frmts/georss/ogr_georss.h
+++ b/ogr/ogrsf_frmts/georss/ogr_georss.h
@@ -208,7 +208,8 @@ class OGRGeoRSSDataSource final : public OGRDataSource
     }
     OGRLayer *GetLayer(int) override;
 
-    OGRLayer *ICreateLayer(const char *pszLayerName, OGRSpatialReference *poSRS,
+    OGRLayer *ICreateLayer(const char *pszLayerName,
+                           const OGRSpatialReference *poSRS,
                            OGRwkbGeometryType eType,
                            char **papszOptions) override;
 

--- a/ogr/ogrsf_frmts/georss/ogrgeorssdatasource.cpp
+++ b/ogr/ogrsf_frmts/georss/ogrgeorssdatasource.cpp
@@ -128,7 +128,7 @@ OGRLayer *OGRGeoRSSDataSource::GetLayer(int iLayer)
 /************************************************************************/
 
 OGRLayer *OGRGeoRSSDataSource::ICreateLayer(const char *pszLayerName,
-                                            OGRSpatialReference *poSRS,
+                                            const OGRSpatialReference *poSRS,
                                             OGRwkbGeometryType /* eType */,
                                             char ** /* papszOptions */)
 {
@@ -153,10 +153,10 @@ OGRLayer *OGRGeoRSSDataSource::ICreateLayer(const char *pszLayerName,
     nLayers++;
     papoLayers = static_cast<OGRGeoRSSLayer **>(
         CPLRealloc(papoLayers, nLayers * sizeof(OGRGeoRSSLayer *)));
-    auto poSRSClone = poSRS;
-    if (poSRSClone)
+    OGRSpatialReference *poSRSClone = nullptr;
+    if (poSRS)
     {
-        poSRSClone = poSRSClone->Clone();
+        poSRSClone = poSRS->Clone();
         poSRSClone->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     }
     papoLayers[nLayers - 1] =

--- a/ogr/ogrsf_frmts/gml/ogr_gml.h
+++ b/ogr/ogrsf_frmts/gml/ogr_gml.h
@@ -194,7 +194,7 @@ class OGRGMLDataSource final : public OGRDataSource
     OGRLayer *GetLayer(int) override;
 
     virtual OGRLayer *ICreateLayer(const char *,
-                                   OGRSpatialReference * = nullptr,
+                                   const OGRSpatialReference * = nullptr,
                                    OGRwkbGeometryType = wkbUnknown,
                                    char ** = nullptr) override;
 

--- a/ogr/ogrsf_frmts/gml/ogrgmldatasource.cpp
+++ b/ogr/ogrsf_frmts/gml/ogrgmldatasource.cpp
@@ -1972,7 +1972,7 @@ void OGRGMLDataSource::WriteTopElements()
 /************************************************************************/
 
 OGRLayer *OGRGMLDataSource::ICreateLayer(const char *pszLayerName,
-                                         OGRSpatialReference *poSRS,
+                                         const OGRSpatialReference *poSRS,
                                          OGRwkbGeometryType eType,
                                          CPL_UNUSED char **papszOptions)
 {
@@ -2040,12 +2040,11 @@ OGRLayer *OGRGMLDataSource::ICreateLayer(const char *pszLayerName,
             "geometryProperty");
         if (poSRS != nullptr)
         {
-            // Clone it since mapogroutput assumes that it can destroys
-            // the SRS it has passed to use, instead of dereferencing it.
-            poSRS = poSRS->Clone();
-            poSRS->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
-            poLayer->GetLayerDefn()->GetGeomFieldDefn(0)->SetSpatialRef(poSRS);
-            poSRS->Dereference();
+            auto poSRSClone = poSRS->Clone();
+            poSRSClone->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+            poLayer->GetLayerDefn()->GetGeomFieldDefn(0)->SetSpatialRef(
+                poSRSClone);
+            poSRSClone->Dereference();
         }
     }
 

--- a/ogr/ogrsf_frmts/gmt/ogr_gmt.h
+++ b/ogr/ogrsf_frmts/gmt/ogr_gmt.h
@@ -129,7 +129,7 @@ class OGRGmtDataSource final : public OGRDataSource
     OGRLayer *GetLayer(int) override;
 
     virtual OGRLayer *ICreateLayer(const char *,
-                                   OGRSpatialReference * = nullptr,
+                                   const OGRSpatialReference * = nullptr,
                                    OGRwkbGeometryType = wkbUnknown,
                                    char ** = nullptr) override;
     int TestCapability(const char *) override;

--- a/ogr/ogrsf_frmts/gmt/ogrgmtdatasource.cpp
+++ b/ogr/ogrsf_frmts/gmt/ogrgmtdatasource.cpp
@@ -100,7 +100,7 @@ int OGRGmtDataSource::Create(const char *pszDSName, char ** /* papszOptions */)
 /************************************************************************/
 
 OGRLayer *OGRGmtDataSource::ICreateLayer(const char *pszLayerName,
-                                         OGRSpatialReference *poSRS,
+                                         const OGRSpatialReference *poSRS,
                                          OGRwkbGeometryType eType,
                                          CPL_UNUSED char **papszOptions)
 {

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -325,7 +325,7 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource,
     OGRLayer *GetLayer(int iLayer) override;
     OGRErr DeleteLayer(int iLayer) override;
     OGRLayer *ICreateLayer(const char *pszLayerName,
-                           OGRSpatialReference *poSpatialRef,
+                           const OGRSpatialReference *poSpatialRef,
                            OGRwkbGeometryType eGType,
                            char **papszOptions) override;
     int TestCapability(const char *) override;

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -6497,10 +6497,9 @@ OGRLayer *GDALGeoPackageDataset::GetLayer(int iLayer)
 /*                          ICreateLayer()                              */
 /************************************************************************/
 
-OGRLayer *GDALGeoPackageDataset::ICreateLayer(const char *pszLayerName,
-                                              OGRSpatialReference *poSpatialRef,
-                                              OGRwkbGeometryType eGType,
-                                              char **papszOptions)
+OGRLayer *GDALGeoPackageDataset::ICreateLayer(
+    const char *pszLayerName, const OGRSpatialReference *poSpatialRef,
+    OGRwkbGeometryType eGType, char **papszOptions)
 {
     /* -------------------------------------------------------------------- */
     /*      Verify we are in update mode.                                   */

--- a/ogr/ogrsf_frmts/gpsbabel/ogr_gpsbabel.h
+++ b/ogr/ogrsf_frmts/gpsbabel/ogr_gpsbabel.h
@@ -102,7 +102,7 @@ class OGRGPSBabelWriteDataSource final : public OGRDataSource
     virtual int TestCapability(const char *) override;
 
     virtual OGRLayer *ICreateLayer(const char *pszLayerName,
-                                   OGRSpatialReference *poSRS,
+                                   const OGRSpatialReference *poSRS,
                                    OGRwkbGeometryType eType,
                                    char **papszOptions) override;
 

--- a/ogr/ogrsf_frmts/gpsbabel/ogrgpsbabelwritedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpsbabel/ogrgpsbabelwritedatasource.cpp
@@ -209,10 +209,9 @@ int OGRGPSBabelWriteDataSource::Create(const char *pszNameIn,
 /*                           ICreateLayer()                             */
 /************************************************************************/
 
-OGRLayer *OGRGPSBabelWriteDataSource::ICreateLayer(const char *pszLayerName,
-                                                   OGRSpatialReference *poSRS,
-                                                   OGRwkbGeometryType eType,
-                                                   char **papszOptions)
+OGRLayer *OGRGPSBabelWriteDataSource::ICreateLayer(
+    const char *pszLayerName, const OGRSpatialReference *poSRS,
+    OGRwkbGeometryType eType, char **papszOptions)
 {
     if (poGPXDS)
         return poGPXDS->CreateLayer(pszLayerName, poSRS, eType, papszOptions);

--- a/ogr/ogrsf_frmts/gpx/ogr_gpx.h
+++ b/ogr/ogrsf_frmts/gpx/ogr_gpx.h
@@ -236,7 +236,8 @@ class OGRGPXDataSource final : public OGRDataSource
     }
     OGRLayer *GetLayer(int) override;
 
-    OGRLayer *ICreateLayer(const char *pszLayerName, OGRSpatialReference *poSRS,
+    OGRLayer *ICreateLayer(const char *pszLayerName,
+                           const OGRSpatialReference *poSRS,
                            OGRwkbGeometryType eType,
                            char **papszOptions) override;
 

--- a/ogr/ogrsf_frmts/gpx/ogrgpxdatasource.cpp
+++ b/ogr/ogrsf_frmts/gpx/ogrgpxdatasource.cpp
@@ -149,10 +149,10 @@ OGRLayer *OGRGPXDataSource::GetLayer(int iLayer)
 /*                           ICreateLayer()                             */
 /************************************************************************/
 
-OGRLayer *OGRGPXDataSource::ICreateLayer(const char *pszLayerName,
-                                         OGRSpatialReference * /* poSRS */,
-                                         OGRwkbGeometryType eType,
-                                         char **papszOptions)
+OGRLayer *
+OGRGPXDataSource::ICreateLayer(const char *pszLayerName,
+                               const OGRSpatialReference * /* poSRS */,
+                               OGRwkbGeometryType eType, char **papszOptions)
 {
     GPXGeometryType gpxGeomType;
     if (eType == wkbPoint || eType == wkbPoint25D)

--- a/ogr/ogrsf_frmts/hana/ogr_hana.h
+++ b/ogr/ogrsf_frmts/hana/ogr_hana.h
@@ -406,7 +406,7 @@ class OGRHanaDataSource final : public GDALDataset
     OGRLayer *GetLayer(int index) override;
     OGRLayer *GetLayerByName(const char *) override;
     OGRLayer *ICreateLayer(const char *layerName,
-                           OGRSpatialReference *srs = nullptr,
+                           const OGRSpatialReference *srs = nullptr,
                            OGRwkbGeometryType geomType = wkbUnknown,
                            char **options = nullptr) override;
     int TestCapability(const char *capabilities) override;

--- a/ogr/ogrsf_frmts/hana/ogrhanadatasource.cpp
+++ b/ogr/ogrsf_frmts/hana/ogrhanadatasource.cpp
@@ -1662,7 +1662,7 @@ OGRLayer *OGRHanaDataSource::GetLayerByName(const char *name)
 /************************************************************************/
 
 OGRLayer *OGRHanaDataSource::ICreateLayer(const char *layerNameIn,
-                                          OGRSpatialReference *srs,
+                                          const OGRSpatialReference *srs,
                                           OGRwkbGeometryType geomType,
                                           char **options)
 {

--- a/ogr/ogrsf_frmts/ili/ogr_ili1.h
+++ b/ogr/ogrsf_frmts/ili/ogr_ili1.h
@@ -140,7 +140,7 @@ class OGRILI1DataSource final : public OGRDataSource
     }
 
     virtual OGRLayer *ICreateLayer(const char *,
-                                   OGRSpatialReference * = nullptr,
+                                   const OGRSpatialReference * = nullptr,
                                    OGRwkbGeometryType = wkbUnknown,
                                    char ** = nullptr) override;
 

--- a/ogr/ogrsf_frmts/ili/ogr_ili2.h
+++ b/ogr/ogrsf_frmts/ili/ogr_ili2.h
@@ -121,7 +121,7 @@ class OGRILI2DataSource final : public OGRDataSource
     OGRLayer *GetLayer(int) override;
 
     virtual OGRLayer *ICreateLayer(const char *,
-                                   OGRSpatialReference * = nullptr,
+                                   const OGRSpatialReference * = nullptr,
                                    OGRwkbGeometryType = wkbUnknown,
                                    char ** = nullptr) override;
 

--- a/ogr/ogrsf_frmts/ili/ogrili1datasource.cpp
+++ b/ogr/ogrsf_frmts/ili/ogrili1datasource.cpp
@@ -258,7 +258,7 @@ static char *ExtractTopic(const char *pszLayerName)
 /************************************************************************/
 
 OGRLayer *OGRILI1DataSource::ICreateLayer(const char *pszLayerName,
-                                          OGRSpatialReference * /*poSRS*/,
+                                          const OGRSpatialReference * /*poSRS*/,
                                           OGRwkbGeometryType eType,
                                           char ** /* papszOptions */)
 {

--- a/ogr/ogrsf_frmts/ili/ogrili2datasource.cpp
+++ b/ogr/ogrsf_frmts/ili/ogrili2datasource.cpp
@@ -264,10 +264,9 @@ int OGRILI2DataSource::Create(const char *pszFilename,
 /*                           ICreateLayer()                             */
 /************************************************************************/
 
-OGRLayer *OGRILI2DataSource::ICreateLayer(const char *pszLayerName,
-                                          OGRSpatialReference * /* poSRS */,
-                                          OGRwkbGeometryType eType,
-                                          char ** /* papszOptions */)
+OGRLayer *OGRILI2DataSource::ICreateLayer(
+    const char *pszLayerName, const OGRSpatialReference * /* poSRS */,
+    OGRwkbGeometryType eType, char ** /* papszOptions */)
 {
     if (fpOutput == nullptr)
         return nullptr;

--- a/ogr/ogrsf_frmts/jml/ogr_jml.h
+++ b/ogr/ogrsf_frmts/jml/ogr_jml.h
@@ -207,7 +207,8 @@ class OGRJMLDataset final : public GDALDataset
     }
     OGRLayer *GetLayer(int) override;
 
-    OGRLayer *ICreateLayer(const char *pszLayerName, OGRSpatialReference *poSRS,
+    OGRLayer *ICreateLayer(const char *pszLayerName,
+                           const OGRSpatialReference *poSRS,
                            OGRwkbGeometryType eType,
                            char **papszOptions) override;
 

--- a/ogr/ogrsf_frmts/jml/ogrjmldataset.cpp
+++ b/ogr/ogrsf_frmts/jml/ogrjmldataset.cpp
@@ -177,7 +177,7 @@ GDALDataset *OGRJMLDataset::Create(const char *pszFilename, int /* nXSize */,
 /************************************************************************/
 
 OGRLayer *OGRJMLDataset::ICreateLayer(const char *pszLayerName,
-                                      OGRSpatialReference *poSRS,
+                                      const OGRSpatialReference *poSRS,
                                       OGRwkbGeometryType /* eType */,
                                       char **papszOptions)
 {
@@ -190,10 +190,10 @@ OGRLayer *OGRJMLDataset::ICreateLayer(const char *pszLayerName,
         CSLFetchNameValueDef(papszOptions, "CREATE_OGR_STYLE_FIELD", "NO"));
     bool bClassicGML =
         CPLTestBool(CSLFetchNameValueDef(papszOptions, "CLASSIC_GML", "NO"));
-    auto poSRSClone = poSRS;
-    if (poSRSClone)
+    OGRSpatialReference *poSRSClone = nullptr;
+    if (poSRS)
     {
-        poSRSClone = poSRSClone->Clone();
+        poSRSClone = poSRS->Clone();
         poSRSClone->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     }
     poLayer =

--- a/ogr/ogrsf_frmts/jsonfg/ogr_jsonfg.h
+++ b/ogr/ogrsf_frmts/jsonfg/ogr_jsonfg.h
@@ -270,7 +270,7 @@ class OGRJSONFGDataset final : public GDALDataset
     void BeforeCreateFeature();
 
     OGRLayer *ICreateLayer(const char *pszName,
-                           OGRSpatialReference *poSRS = nullptr,
+                           const OGRSpatialReference *poSRS = nullptr,
                            OGRwkbGeometryType eGType = wkbUnknown,
                            char **papszOptions = nullptr) override;
     int TestCapability(const char *pszCap) override;

--- a/ogr/ogrsf_frmts/jsonfg/ogrjsonfgdataset.cpp
+++ b/ogr/ogrsf_frmts/jsonfg/ogrjsonfgdataset.cpp
@@ -509,7 +509,7 @@ bool OGRJSONFGDataset::EmitStartFeaturesIfNeededAndReturnIfFirstFeature()
 /************************************************************************/
 
 OGRLayer *OGRJSONFGDataset::ICreateLayer(const char *pszNameIn,
-                                         OGRSpatialReference *poSRS,
+                                         const OGRSpatialReference *poSRS,
                                          OGRwkbGeometryType eGType,
                                          char **papszOptions)
 {

--- a/ogr/ogrsf_frmts/kml/ogr_kml.h
+++ b/ogr/ogrsf_frmts/kml/ogr_kml.h
@@ -48,8 +48,8 @@ class OGRKMLDataSource;
 class OGRKMLLayer final : public OGRLayer
 {
   public:
-    OGRKMLLayer(const char *pszName_, OGRSpatialReference *poSRS, bool bWriter,
-                OGRwkbGeometryType eType, OGRKMLDataSource *poDS);
+    OGRKMLLayer(const char *pszName_, const OGRSpatialReference *poSRS,
+                bool bWriter, OGRwkbGeometryType eType, OGRKMLDataSource *poDS);
     ~OGRKMLLayer();
 
     //
@@ -121,7 +121,7 @@ class OGRKMLDataSource final : public OGRDataSource
     }
     OGRLayer *GetLayer(int nLayer) override;
     OGRLayer *ICreateLayer(const char *pszName,
-                           OGRSpatialReference *poSRS = nullptr,
+                           const OGRSpatialReference *poSRS = nullptr,
                            OGRwkbGeometryType eGType = wkbUnknown,
                            char **papszOptions = nullptr) override;
     int TestCapability(const char *pszCap) override;

--- a/ogr/ogrsf_frmts/kml/ogrkmldatasource.cpp
+++ b/ogr/ogrsf_frmts/kml/ogrkmldatasource.cpp
@@ -364,7 +364,7 @@ int OGRKMLDataSource::Create(const char *pszName, char **papszOptions)
 /************************************************************************/
 
 OGRLayer *OGRKMLDataSource::ICreateLayer(const char *pszLayerName,
-                                         OGRSpatialReference *poSRS,
+                                         const OGRSpatialReference *poSRS,
                                          OGRwkbGeometryType eType,
                                          char ** /* papszOptions */)
 {

--- a/ogr/ogrsf_frmts/kml/ogrkmllayer.cpp
+++ b/ogr/ogrsf_frmts/kml/ogrkmllayer.cpp
@@ -55,9 +55,9 @@ char *OGR_G_ExportToKML(OGRGeometryH hGeometry, const char *pszAltitudeMode);
 /*                           OGRKMLLayer()                              */
 /************************************************************************/
 
-OGRKMLLayer::OGRKMLLayer(const char *pszName, OGRSpatialReference *poSRSIn,
-                         bool bWriterIn, OGRwkbGeometryType eReqType,
-                         OGRKMLDataSource *poDSIn)
+OGRKMLLayer::OGRKMLLayer(const char *pszName,
+                         const OGRSpatialReference *poSRSIn, bool bWriterIn,
+                         OGRwkbGeometryType eReqType, OGRKMLDataSource *poDSIn)
     : poDS_(poDSIn),
       poSRS_(poSRSIn ? new OGRSpatialReference(nullptr) : nullptr),
       poCT_(nullptr), poFeatureDefn_(new OGRFeatureDefn(pszName)),

--- a/ogr/ogrsf_frmts/libkml/ogr_libkml.h
+++ b/ogr/ogrsf_frmts/libkml/ogr_libkml.h
@@ -253,7 +253,7 @@ class OGRLIBKMLDataSource final : public OGRDataSource
     OGRErr DeleteLayer(int) override;
 
     OGRLayer *ICreateLayer(const char *pszName,
-                           OGRSpatialReference *poSpatialRef = nullptr,
+                           const OGRSpatialReference *poSpatialRef = nullptr,
                            OGRwkbGeometryType eGType = wkbUnknown,
                            char **papszOptions = nullptr) override;
 
@@ -329,11 +329,11 @@ class OGRLIBKMLDataSource final : public OGRDataSource
 
     /***** methods to create layers on various datasource types *****/
     OGRLIBKMLLayer *CreateLayerKml(const char *pszLayerName,
-                                   OGRSpatialReference *poOgrSRS,
+                                   const OGRSpatialReference *poOgrSRS,
                                    OGRwkbGeometryType eGType,
                                    char **papszOptions);
     OGRLIBKMLLayer *CreateLayerKmz(const char *pszLayerName,
-                                   OGRSpatialReference *poOgrSRS,
+                                   const OGRSpatialReference *poOgrSRS,
                                    OGRwkbGeometryType eGType,
                                    char **papszOptions);
 

--- a/ogr/ogrsf_frmts/libkml/ogrlibkmldatasource.cpp
+++ b/ogr/ogrsf_frmts/libkml/ogrlibkmldatasource.cpp
@@ -2120,10 +2120,9 @@ OGRErr OGRLIBKMLDataSource::DeleteLayer(int iLayer)
 
 ******************************************************************************/
 
-OGRLIBKMLLayer *OGRLIBKMLDataSource::CreateLayerKml(const char *pszLayerName,
-                                                    OGRSpatialReference *poSRS,
-                                                    OGRwkbGeometryType eGType,
-                                                    char **papszOptions)
+OGRLIBKMLLayer *OGRLIBKMLDataSource::CreateLayerKml(
+    const char *pszLayerName, const OGRSpatialReference *poSRS,
+    OGRwkbGeometryType eGType, char **papszOptions)
 {
     ContainerPtr poKmlLayerContainer = nullptr;
 
@@ -2167,10 +2166,9 @@ OGRLIBKMLLayer *OGRLIBKMLDataSource::CreateLayerKml(const char *pszLayerName,
 
 ******************************************************************************/
 
-OGRLIBKMLLayer *OGRLIBKMLDataSource::CreateLayerKmz(const char *pszLayerName,
-                                                    OGRSpatialReference *poSRS,
-                                                    OGRwkbGeometryType eGType,
-                                                    char ** /* papszOptions */)
+OGRLIBKMLLayer *OGRLIBKMLDataSource::CreateLayerKmz(
+    const char *pszLayerName, const OGRSpatialReference *poSRS,
+    OGRwkbGeometryType eGType, char ** /* papszOptions */)
 {
     DocumentPtr poKmlDocument = nullptr;
 
@@ -2231,7 +2229,7 @@ OGRLIBKMLLayer *OGRLIBKMLDataSource::CreateLayerKmz(const char *pszLayerName,
 ******************************************************************************/
 
 OGRLayer *OGRLIBKMLDataSource::ICreateLayer(const char *pszLayerName,
-                                            OGRSpatialReference *poOgrSRS,
+                                            const OGRSpatialReference *poOgrSRS,
                                             OGRwkbGeometryType eGType,
                                             char **papszOptions)
 {

--- a/ogr/ogrsf_frmts/mapml/ogrmapmldataset.cpp
+++ b/ogr/ogrsf_frmts/mapml/ogrmapmldataset.cpp
@@ -141,7 +141,7 @@ class OGRMapMLWriterDataset final : public GDALPamDataset
     }
     OGRLayer *GetLayer(int idx) override;
 
-    OGRLayer *ICreateLayer(const char *, OGRSpatialReference * = nullptr,
+    OGRLayer *ICreateLayer(const char *, const OGRSpatialReference * = nullptr,
                            OGRwkbGeometryType = wkbUnknown,
                            char ** = nullptr) override;
 
@@ -977,12 +977,12 @@ int OGRMapMLWriterDataset::TestCapability(const char *pszCap)
 /*                           ICreateLayer()                             */
 /************************************************************************/
 
-OGRLayer *OGRMapMLWriterDataset::ICreateLayer(const char *pszLayerName,
-                                              OGRSpatialReference *poSRS,
-                                              OGRwkbGeometryType,
-                                              char ** /* papszOptions */)
+OGRLayer *OGRMapMLWriterDataset::ICreateLayer(
+    const char *pszLayerName, const OGRSpatialReference *poSRSIn,
+    OGRwkbGeometryType, char ** /* papszOptions */)
 {
     OGRSpatialReference oSRS_WGS84;
+    const OGRSpatialReference *poSRS = poSRSIn;
     if (poSRS == nullptr)
     {
         oSRS_WGS84.SetFromUserInput(SRS_WKT_WGS84_LAT_LONG);

--- a/ogr/ogrsf_frmts/mem/ogr_mem.h
+++ b/ogr/ogrsf_frmts/mem/ogr_mem.h
@@ -185,7 +185,7 @@ class OGRMemDataSource CPL_NON_FINAL : public OGRDataSource
     OGRLayer *GetLayer(int) override;
 
     virtual OGRLayer *ICreateLayer(const char *,
-                                   OGRSpatialReference * = nullptr,
+                                   const OGRSpatialReference * = nullptr,
                                    OGRwkbGeometryType = wkbUnknown,
                                    char ** = nullptr) override;
     OGRErr DeleteLayer(int iLayer) override;

--- a/ogr/ogrsf_frmts/mem/ogrmemdatasource.cpp
+++ b/ogr/ogrsf_frmts/mem/ogrmemdatasource.cpp
@@ -65,15 +65,15 @@ OGRMemDataSource::~OGRMemDataSource()
 /************************************************************************/
 
 OGRLayer *OGRMemDataSource::ICreateLayer(const char *pszLayerName,
-                                         OGRSpatialReference *poSRSIn,
+                                         const OGRSpatialReference *poSRSIn,
                                          OGRwkbGeometryType eType,
                                          char **papszOptions)
 {
     // Create the layer object.
-    OGRSpatialReference *poSRS = poSRSIn;
-    if (poSRS)
+    OGRSpatialReference *poSRS = nullptr;
+    if (poSRSIn)
     {
-        poSRS = poSRS->Clone();
+        poSRS = poSRSIn->Clone();
         poSRS->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     }
     OGRMemLayer *poLayer = new OGRMemLayer(pszLayerName, poSRS, eType);

--- a/ogr/ogrsf_frmts/mitab/mitab_ogr_datasource.cpp
+++ b/ogr/ogrsf_frmts/mitab/mitab_ogr_datasource.cpp
@@ -288,7 +288,7 @@ OGRLayer *OGRTABDataSource::GetLayer(int iLayer)
 /************************************************************************/
 
 OGRLayer *OGRTABDataSource::ICreateLayer(const char *pszLayerName,
-                                         OGRSpatialReference *poSRSIn,
+                                         const OGRSpatialReference *poSRSIn,
                                          OGRwkbGeometryType /* eGeomTypeIn */,
                                          char **papszOptions)
 

--- a/ogr/ogrsf_frmts/mitab/mitab_ogr_driver.h
+++ b/ogr/ogrsf_frmts/mitab/mitab_ogr_driver.h
@@ -81,7 +81,7 @@ class OGRTABDataSource : public OGRDataSource
     OGRLayer *GetLayer(int) override;
     int TestCapability(const char *) override;
 
-    OGRLayer *ICreateLayer(const char *, OGRSpatialReference * = nullptr,
+    OGRLayer *ICreateLayer(const char *, const OGRSpatialReference * = nullptr,
                            OGRwkbGeometryType = wkbUnknown,
                            char ** = nullptr) override;
 

--- a/ogr/ogrsf_frmts/mssqlspatial/ogr_mssqlspatial.h
+++ b/ogr/ogrsf_frmts/mssqlspatial/ogr_mssqlspatial.h
@@ -652,7 +652,7 @@ class OGRMSSQLSpatialDataSource final : public OGRDataSource
 
     virtual OGRErr DeleteLayer(int iLayer) override;
     virtual OGRLayer *ICreateLayer(const char *,
-                                   OGRSpatialReference * = nullptr,
+                                   const OGRSpatialReference * = nullptr,
                                    OGRwkbGeometryType = wkbUnknown,
                                    char ** = nullptr) override;
 

--- a/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdatasource.cpp
+++ b/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdatasource.cpp
@@ -325,10 +325,9 @@ OGRErr OGRMSSQLSpatialDataSource::DeleteLayer(int iLayer)
 /*                            CreateLayer()                             */
 /************************************************************************/
 
-OGRLayer *OGRMSSQLSpatialDataSource::ICreateLayer(const char *pszLayerName,
-                                                  OGRSpatialReference *poSRS,
-                                                  OGRwkbGeometryType eType,
-                                                  char **papszOptions)
+OGRLayer *OGRMSSQLSpatialDataSource::ICreateLayer(
+    const char *pszLayerName, const OGRSpatialReference *poSRS,
+    OGRwkbGeometryType eType, char **papszOptions)
 
 {
     char *pszTableName = nullptr;

--- a/ogr/ogrsf_frmts/mvt/ogrmvtdataset.cpp
+++ b/ogr/ogrsf_frmts/mvt/ogrmvtdataset.cpp
@@ -3372,7 +3372,7 @@ class OGRMVTWriterDataset final : public GDALDataset
 
     CPLErr Close() override;
 
-    OGRLayer *ICreateLayer(const char *, OGRSpatialReference * = nullptr,
+    OGRLayer *ICreateLayer(const char *, const OGRSpatialReference * = nullptr,
                            OGRwkbGeometryType = wkbUnknown,
                            char ** = nullptr) override;
 
@@ -5966,12 +5966,12 @@ static bool ValidateMinMaxZoom(int nMinZoom, int nMaxZoom)
 /************************************************************************/
 
 OGRLayer *OGRMVTWriterDataset::ICreateLayer(const char *pszLayerName,
-                                            OGRSpatialReference *poSRS,
+                                            const OGRSpatialReference *poSRS,
                                             OGRwkbGeometryType,
                                             char **papszOptions)
 {
-    OGRSpatialReference *poSRSClone = poSRS;
-    if (poSRSClone)
+    OGRSpatialReference *poSRSClone = nullptr;
+    if (poSRS)
     {
         poSRSClone = poSRS->Clone();
         poSRSClone->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);

--- a/ogr/ogrsf_frmts/mysql/ogr_mysql.h
+++ b/ogr/ogrsf_frmts/mysql/ogr_mysql.h
@@ -278,7 +278,7 @@ class OGRMySQLDataSource final : public OGRDataSource
         return hConn;
     }
 
-    int FetchSRSId(OGRSpatialReference *poSRS);
+    int FetchSRSId(const OGRSpatialReference *poSRS);
 
     OGRSpatialReference *FetchSRS(int nSRSId);
 
@@ -302,7 +302,7 @@ class OGRMySQLDataSource final : public OGRDataSource
     OGRLayer *GetLayer(int) override;
 
     virtual OGRLayer *ICreateLayer(const char *,
-                                   OGRSpatialReference * = nullptr,
+                                   const OGRSpatialReference * = nullptr,
                                    OGRwkbGeometryType = wkbUnknown,
                                    char ** = nullptr) override;
 

--- a/ogr/ogrsf_frmts/mysql/ogrmysqldatasource.cpp
+++ b/ogr/ogrsf_frmts/mysql/ogrmysqldatasource.cpp
@@ -652,7 +652,7 @@ OGRSpatialReference *OGRMySQLDataSource::FetchSRS(int nId)
 /*      it to the table.                                                */
 /************************************************************************/
 
-int OGRMySQLDataSource::FetchSRSId(OGRSpatialReference *poSRSIn)
+int OGRMySQLDataSource::FetchSRSId(const OGRSpatialReference *poSRSIn)
 
 {
     if (poSRSIn == nullptr)
@@ -1173,7 +1173,7 @@ OGRErr OGRMySQLDataSource::DeleteLayer(int iLayer)
 /************************************************************************/
 
 OGRLayer *OGRMySQLDataSource::ICreateLayer(const char *pszLayerNameIn,
-                                           OGRSpatialReference *poSRS,
+                                           const OGRSpatialReference *poSRS,
                                            OGRwkbGeometryType eType,
                                            char **papszOptions)
 

--- a/ogr/ogrsf_frmts/ngw/ogr_ngw.h
+++ b/ogr/ogrsf_frmts/ngw/ogr_ngw.h
@@ -270,10 +270,11 @@ class OGRNGWDataset final : public GDALDataset
     }
     virtual OGRLayer *GetLayer(int) override;
     virtual int TestCapability(const char *) override;
-    virtual OGRLayer *ICreateLayer(const char *pszName,
-                                   OGRSpatialReference *poSpatialRef = nullptr,
-                                   OGRwkbGeometryType eGType = wkbUnknown,
-                                   char **papszOptions = nullptr) override;
+    virtual OGRLayer *
+    ICreateLayer(const char *pszName,
+                 const OGRSpatialReference *poSpatialRef = nullptr,
+                 OGRwkbGeometryType eGType = wkbUnknown,
+                 char **papszOptions = nullptr) override;
     virtual OGRErr DeleteLayer(int) override;
     virtual CPLErr SetMetadata(char **papszMetadata,
                                const char *pszDomain = "") override;

--- a/ogr/ogrsf_frmts/oci/ogr_oci.h
+++ b/ogr/ogrsf_frmts/oci/ogr_oci.h
@@ -595,7 +595,7 @@ class OGROCIDataSource final : public OGRDataSource
 
     virtual OGRErr DeleteLayer(int) override;
     virtual OGRLayer *ICreateLayer(const char *,
-                                   OGRSpatialReference * = nullptr,
+                                   const OGRSpatialReference * = nullptr,
                                    OGRwkbGeometryType = wkbUnknown,
                                    char ** = nullptr) override;
 
@@ -611,7 +611,7 @@ class OGROCIDataSource final : public OGRDataSource
                                  const char *pszDialect) override;
     virtual void ReleaseResultSet(OGRLayer *poLayer) override;
 
-    int FetchSRSId(OGRSpatialReference *poSRS);
+    int FetchSRSId(const OGRSpatialReference *poSRS);
     OGRSpatialReference *FetchSRS(int nSRID);
 };
 

--- a/ogr/ogrsf_frmts/oci/ogrocidatasource.cpp
+++ b/ogr/ogrsf_frmts/oci/ogrocidatasource.cpp
@@ -485,7 +485,7 @@ void OGROCIDataSource::TruncateLayer(const char *pszLayerName)
 /************************************************************************/
 
 OGRLayer *OGROCIDataSource::ICreateLayer(const char *pszLayerName,
-                                         OGRSpatialReference *poSRS,
+                                         const OGRSpatialReference *poSRS,
                                          OGRwkbGeometryType eType,
                                          char **papszOptions)
 
@@ -908,7 +908,7 @@ OGRSpatialReference *OGROCIDataSource::FetchSRS(int nId)
 /*      it to the table.                                                */
 /************************************************************************/
 
-int OGROCIDataSource::FetchSRSId(OGRSpatialReference *poSRS)
+int OGROCIDataSource::FetchSRSId(const OGRSpatialReference *poSRS)
 
 {
     char *pszWKT = nullptr;

--- a/ogr/ogrsf_frmts/ods/ogr_ods.h
+++ b/ogr/ogrsf_frmts/ods/ogr_ods.h
@@ -248,7 +248,7 @@ class OGRODSDataSource final : public GDALDataset
     virtual int TestCapability(const char *) override;
 
     virtual OGRLayer *ICreateLayer(const char *pszLayerName,
-                                   OGRSpatialReference *poSRS,
+                                   const OGRSpatialReference *poSRS,
                                    OGRwkbGeometryType eType,
                                    char **papszOptions) override;
     virtual OGRErr DeleteLayer(int iLayer) override;

--- a/ogr/ogrsf_frmts/ods/ogrodsdatasource.cpp
+++ b/ogr/ogrsf_frmts/ods/ogrodsdatasource.cpp
@@ -1522,10 +1522,9 @@ void OGRODSDataSource::AnalyseSettings()
 /*                           ICreateLayer()                             */
 /************************************************************************/
 
-OGRLayer *OGRODSDataSource::ICreateLayer(const char *pszLayerName,
-                                         OGRSpatialReference * /* poSRS */,
-                                         OGRwkbGeometryType /* eType */,
-                                         char **papszOptions)
+OGRLayer *OGRODSDataSource::ICreateLayer(
+    const char *pszLayerName, const OGRSpatialReference * /* poSRS */,
+    OGRwkbGeometryType /* eType */, char **papszOptions)
 {
     /* -------------------------------------------------------------------- */
     /*      Verify we are in update mode.                                   */

--- a/ogr/ogrsf_frmts/openfilegdb/ogr_openfilegdb.h
+++ b/ogr/ogrsf_frmts/openfilegdb/ogr_openfilegdb.h
@@ -536,7 +536,7 @@ class OGROpenFileGDBDataSource final : public OGRDataSource
     virtual int TestCapability(const char *) override;
 
     virtual OGRLayer *ICreateLayer(const char *,
-                                   OGRSpatialReference * = nullptr,
+                                   const OGRSpatialReference * = nullptr,
                                    OGRwkbGeometryType = wkbUnknown,
                                    char ** = nullptr) override;
     virtual OGRErr DeleteLayer(int) override;

--- a/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdbdatasource_write.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdbdatasource_write.cpp
@@ -1345,10 +1345,9 @@ bool OGROpenFileGDBDataSource::Create(const char *pszName)
 /*                             ICreateLayer()                           */
 /************************************************************************/
 
-OGRLayer *OGROpenFileGDBDataSource::ICreateLayer(const char *pszLayerName,
-                                                 OGRSpatialReference *poSRS,
-                                                 OGRwkbGeometryType eType,
-                                                 char **papszOptions)
+OGRLayer *OGROpenFileGDBDataSource::ICreateLayer(
+    const char *pszLayerName, const OGRSpatialReference *poSRS,
+    OGRwkbGeometryType eType, char **papszOptions)
 {
     if (eAccess != GA_Update)
         return nullptr;

--- a/ogr/ogrsf_frmts/parquet/ogr_parquet.h
+++ b/ogr/ogrsf_frmts/parquet/ogr_parquet.h
@@ -286,7 +286,7 @@ class OGRParquetWriterLayer final : public OGRArrowWriterLayer
     ~OGRParquetWriterLayer() override;
 
     bool SetOptions(CSLConstList papszOptions,
-                    OGRSpatialReference *poSpatialRef,
+                    const OGRSpatialReference *poSpatialRef,
                     OGRwkbGeometryType eGType);
 
     OGRErr CreateGeomField(OGRGeomFieldDefn *poField,
@@ -324,7 +324,7 @@ class OGRParquetWriterDataset final : public GDALPamDataset
 
   protected:
     OGRLayer *ICreateLayer(const char *pszName,
-                           OGRSpatialReference *poSpatialRef = nullptr,
+                           const OGRSpatialReference *poSpatialRef = nullptr,
                            OGRwkbGeometryType eGType = wkbUnknown,
                            char **papszOptions = nullptr) override;
 };

--- a/ogr/ogrsf_frmts/parquet/ogrparquetwriterdataset.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetwriterdataset.cpp
@@ -77,7 +77,7 @@ int OGRParquetWriterDataset::TestCapability(const char *pszCap)
 /************************************************************************/
 
 OGRLayer *OGRParquetWriterDataset::ICreateLayer(
-    const char *pszName, OGRSpatialReference *poSpatialRef,
+    const char *pszName, const OGRSpatialReference *poSpatialRef,
     OGRwkbGeometryType eGType, char **papszOptions)
 {
     if (m_poLayer)

--- a/ogr/ogrsf_frmts/parquet/ogrparquetwriterlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetwriterlayer.cpp
@@ -89,7 +89,7 @@ bool OGRParquetWriterLayer::IsSupportedGeometryType(
 /************************************************************************/
 
 bool OGRParquetWriterLayer::SetOptions(CSLConstList papszOptions,
-                                       OGRSpatialReference *poSpatialRef,
+                                       const OGRSpatialReference *poSpatialRef,
                                        OGRwkbGeometryType eGType)
 {
     const char *pszGeomEncoding =

--- a/ogr/ogrsf_frmts/pg/ogr_pg.h
+++ b/ogr/ogrsf_frmts/pg/ogr_pg.h
@@ -662,7 +662,7 @@ class OGRPGDataSource final : public OGRDataSource
     virtual CPLErr FlushCache(bool bAtClosing) override;
 
     virtual OGRLayer *ICreateLayer(const char *,
-                                   OGRSpatialReference * = nullptr,
+                                   const OGRSpatialReference * = nullptr,
                                    OGRwkbGeometryType = wkbUnknown,
                                    char ** = nullptr) override;
 

--- a/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
@@ -1676,7 +1676,7 @@ OGRErr OGRPGDataSource::DeleteLayer(int iLayer)
 /************************************************************************/
 
 OGRLayer *OGRPGDataSource::ICreateLayer(const char *pszLayerName,
-                                        OGRSpatialReference *poSRS,
+                                        const OGRSpatialReference *poSRS,
                                         OGRwkbGeometryType eType,
                                         char **papszOptions)
 

--- a/ogr/ogrsf_frmts/pgdump/ogr_pgdump.h
+++ b/ogr/ogrsf_frmts/pgdump/ogr_pgdump.h
@@ -264,7 +264,7 @@ class OGRPGDumpDataSource final : public GDALDataset
     virtual OGRLayer *GetLayer(int) override;
 
     virtual OGRLayer *ICreateLayer(const char *,
-                                   OGRSpatialReference * = nullptr,
+                                   const OGRSpatialReference * = nullptr,
                                    OGRwkbGeometryType = wkbUnknown,
                                    char ** = nullptr) override;
 

--- a/ogr/ogrsf_frmts/pgdump/ogrpgdumpdatasource.cpp
+++ b/ogr/ogrsf_frmts/pgdump/ogrpgdumpdatasource.cpp
@@ -166,7 +166,7 @@ char *OGRPGCommonLaunderName(const char *pszSrcName, const char *pszDebugPrefix)
 /************************************************************************/
 
 OGRLayer *OGRPGDumpDataSource::ICreateLayer(const char *pszLayerName,
-                                            OGRSpatialReference *poSRS,
+                                            const OGRSpatialReference *poSRS,
                                             OGRwkbGeometryType eType,
                                             char **papszOptions)
 

--- a/ogr/ogrsf_frmts/pmtiles/ogr_pmtiles.h
+++ b/ogr/ogrsf_frmts/pmtiles/ogr_pmtiles.h
@@ -364,7 +364,7 @@ class OGRPMTilesWriterDataset final : public GDALDataset
 
     CPLErr Close() override;
 
-    OGRLayer *ICreateLayer(const char *, OGRSpatialReference *,
+    OGRLayer *ICreateLayer(const char *, const OGRSpatialReference *,
                            OGRwkbGeometryType, char **) override;
 
     int TestCapability(const char *) override;

--- a/ogr/ogrsf_frmts/pmtiles/ogrpmtileswriterdataset.cpp
+++ b/ogr/ogrsf_frmts/pmtiles/ogrpmtileswriterdataset.cpp
@@ -111,10 +111,9 @@ bool OGRPMTilesWriterDataset::Create(const char *pszFilename,
 /*                           ICreateLayer()                             */
 /************************************************************************/
 
-OGRLayer *OGRPMTilesWriterDataset::ICreateLayer(const char *pszLayerName,
-                                                OGRSpatialReference *poSRS,
-                                                OGRwkbGeometryType eGeomType,
-                                                char **papszOptions)
+OGRLayer *OGRPMTilesWriterDataset::ICreateLayer(
+    const char *pszLayerName, const OGRSpatialReference *poSRS,
+    OGRwkbGeometryType eGeomType, char **papszOptions)
 {
     return m_poMBTilesWriterDataset->CreateLayer(pszLayerName, poSRS, eGeomType,
                                                  papszOptions);

--- a/ogr/ogrsf_frmts/selafin/ogr_selafin.h
+++ b/ogr/ogrsf_frmts/selafin/ogr_selafin.h
@@ -92,7 +92,7 @@ class OGRSelafinLayer final : public OGRLayer
 
   public:
     OGRSelafinLayer(const char *pszLayerNameP, int bUpdateP,
-                    OGRSpatialReference *poSpatialRefP,
+                    const OGRSpatialReference *poSpatialRefP,
                     Selafin::Header *poHeaderP, int nStepNumberP,
                     SelafinTypeDef eTypeP);
     ~OGRSelafinLayer();
@@ -160,10 +160,11 @@ class OGRSelafinDataSource final : public OGRDataSource
         return nLayers;
     }
     OGRLayer *GetLayer(int) override;
-    virtual OGRLayer *ICreateLayer(const char *pszName,
-                                   OGRSpatialReference *poSpatialRefP = nullptr,
-                                   OGRwkbGeometryType eGType = wkbUnknown,
-                                   char **papszOptions = nullptr) override;
+    virtual OGRLayer *
+    ICreateLayer(const char *pszName,
+                 const OGRSpatialReference *poSpatialRefP = nullptr,
+                 OGRwkbGeometryType eGType = wkbUnknown,
+                 char **papszOptions = nullptr) override;
     virtual OGRErr DeleteLayer(int) override;
     int TestCapability(const char *) override;
     void SetDefaultSelafinName(const char *pszNameIn)

--- a/ogr/ogrsf_frmts/selafin/ogrselafindatasource.cpp
+++ b/ogr/ogrsf_frmts/selafin/ogrselafindatasource.cpp
@@ -587,10 +587,9 @@ int OGRSelafinDataSource::OpenTable(const char *pszFilename)
 /*                           ICreateLayer()                             */
 /************************************************************************/
 
-OGRLayer *OGRSelafinDataSource::ICreateLayer(const char *pszLayerName,
-                                             OGRSpatialReference *poSpatialRefP,
-                                             OGRwkbGeometryType eGType,
-                                             char **papszOptions)
+OGRLayer *OGRSelafinDataSource::ICreateLayer(
+    const char *pszLayerName, const OGRSpatialReference *poSpatialRefP,
+    OGRwkbGeometryType eGType, char **papszOptions)
 {
     CPLDebug("Selafin", "CreateLayer(%s,%s)", pszLayerName,
              (eGType == wkbPoint) ? "wkbPoint" : "wkbPolygon");
@@ -618,8 +617,7 @@ OGRLayer *OGRSelafinDataSource::ICreateLayer(const char *pszLayerName,
     // Set the SRS of the datasource if this is the first layer
     if (nLayers == 0 && poSpatialRefP != nullptr)
     {
-        poSpatialRef = poSpatialRefP;
-        poSpatialRef->Reference();
+        poSpatialRef = poSpatialRefP->Clone();
         const char *szEpsg = poSpatialRef->GetAttrValue("GEOGCS|AUTHORITY", 1);
         int nEpsg = 0;
         if (szEpsg != nullptr)

--- a/ogr/ogrsf_frmts/selafin/ogrselafinlayer.cpp
+++ b/ogr/ogrsf_frmts/selafin/ogrselafinlayer.cpp
@@ -60,7 +60,7 @@ static void MoveOverwrite(VSILFILE *fpDest, VSILFILE *fpSource)
 /************************************************************************/
 
 OGRSelafinLayer::OGRSelafinLayer(const char *pszLayerNameP, int bUpdateP,
-                                 OGRSpatialReference *poSpatialRefP,
+                                 const OGRSpatialReference *poSpatialRefP,
                                  Selafin::Header *poHeaderP, int nStepNumberP,
                                  SelafinTypeDef eTypeP)
     : eType(eTypeP), bUpdate(CPL_TO_BOOL(bUpdateP)), nStepNumber(nStepNumberP),

--- a/ogr/ogrsf_frmts/shape/ogrshape.h
+++ b/ogr/ogrsf_frmts/shape/ogrshape.h
@@ -345,7 +345,7 @@ class OGRShapeDataSource final : public OGRDataSource
     OGRLayer *GetLayer(int) override;
     OGRLayer *GetLayerByName(const char *) override;
 
-    OGRLayer *ICreateLayer(const char *, OGRSpatialReference * = nullptr,
+    OGRLayer *ICreateLayer(const char *, const OGRSpatialReference * = nullptr,
                            OGRwkbGeometryType = wkbUnknown,
                            char ** = nullptr) override;
 

--- a/ogr/ogrsf_frmts/sosi/ogr_sosi.h
+++ b/ogr/ogrsf_frmts/sosi/ogr_sosi.h
@@ -77,8 +77,8 @@ class OGRSOSILayer final : public OGRLayer
     OGRFeature *GetNextFeature() override;
     OGRFeatureDefn *GetLayerDefn() override;
 #ifdef WRITE_SUPPORT
-    OGRErr CreateField(OGRFieldDefn *poField, int bApproxOK = TRUE);
-    OGRErr ICreateFeature(OGRFeature *poFeature);
+    OGRErr CreateField(OGRFieldDefn *poField, int bApproxOK = TRUE) override;
+    OGRErr ICreateFeature(OGRFeature *poFeature) override;
 #endif
     int TestCapability(const char *) override;
 };
@@ -138,9 +138,9 @@ class OGRSOSIDataSource final : public OGRDataSource
     OGRLayer *GetLayer(int) override;
 #ifdef WRITE_SUPPORT
     OGRLayer *ICreateLayer(const char *pszName,
-                           OGRSpatialReference *poSpatialRef = NULL,
+                           const OGRSpatialReference *poSpatialRef = NULL,
                            OGRwkbGeometryType eGType = wkbUnknown,
-                           char **papszOptions = NULL);
+                           char **papszOptions = NULL) override;
 #endif
     int TestCapability(const char *) override;
 };

--- a/ogr/ogrsf_frmts/sosi/ogrsosidatasource.cpp
+++ b/ogr/ogrsf_frmts/sosi/ogrsosidatasource.cpp
@@ -660,10 +660,9 @@ int OGRSOSIDataSource::Create(const char *pszFilename)
 /*                             ICreateLayer()                           */
 /************************************************************************/
 
-OGRLayer *OGRSOSIDataSource::ICreateLayer(const char *pszNameIn,
-                                          OGRSpatialReference *poSpatialRef,
-                                          OGRwkbGeometryType eGType,
-                                          CPL_UNUSED char **papszOptions)
+OGRLayer *OGRSOSIDataSource::ICreateLayer(
+    const char *pszNameIn, const OGRSpatialReference *poSpatialRef,
+    OGRwkbGeometryType eGType, CPL_UNUSED char **papszOptions)
 {
     /* SOSI does not really support layers - so let's first see that the global
      * settings are consistent */
@@ -671,8 +670,7 @@ OGRLayer *OGRSOSIDataSource::ICreateLayer(const char *pszNameIn,
     {
         if (poSpatialRef != NULL)
         {
-            poSRS = poSpatialRef;
-            poSRS->Reference();
+            poSRS = poSpatialRef->Clone();
 
             const char *pszKoosys = poSRS->GetAuthorityCode("PROJCS");
             if (pszKoosys == NULL)

--- a/ogr/ogrsf_frmts/sqlite/ogr_sqlite.h
+++ b/ogr/ogrsf_frmts/sqlite/ogr_sqlite.h
@@ -722,7 +722,7 @@ class OGRSQLiteDataSource final : public OGRSQLiteBaseDataSource
     GetLayerWithGetSpatialWhereByName(const char *pszName) override;
 
     virtual OGRLayer *ICreateLayer(const char *pszLayerName,
-                                   OGRSpatialReference *poSRS,
+                                   const OGRSpatialReference *poSRS,
                                    OGRwkbGeometryType eType,
                                    char **papszOptions) override;
     virtual OGRErr DeleteLayer(int) override;

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
@@ -3352,7 +3352,7 @@ void OGRSQLiteDataSource::ReleaseResultSet(OGRLayer *poLayer)
 /************************************************************************/
 
 OGRLayer *OGRSQLiteDataSource::ICreateLayer(const char *pszLayerNameIn,
-                                            OGRSpatialReference *poSRS,
+                                            const OGRSpatialReference *poSRS,
                                             OGRwkbGeometryType eType,
                                             char **papszOptions)
 
@@ -3571,10 +3571,10 @@ OGRLayer *OGRSQLiteDataSource::ICreateLayer(const char *pszLayerNameIn,
 
     poLayer->Initialize(pszLayerName, true, false, true,
                         /* bMayEmitError = */ false);
-    OGRSpatialReference *poSRSClone = poSRS;
-    if (poSRSClone)
+    OGRSpatialReference *poSRSClone = nullptr;
+    if (poSRS)
     {
-        poSRSClone = poSRSClone->Clone();
+        poSRSClone = poSRS->Clone();
         poSRSClone->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     }
     poLayer->SetCreationParameters(osFIDColumnName, eType, pszGeomFormat,

--- a/ogr/ogrsf_frmts/vdv/ogr_vdv.h
+++ b/ogr/ogrsf_frmts/vdv/ogr_vdv.h
@@ -207,7 +207,7 @@ class OGRVDVDataSource final : public GDALDataset
     virtual int GetLayerCount() override;
     virtual OGRLayer *GetLayer(int) override;
     virtual OGRLayer *ICreateLayer(const char *pszLayerName,
-                                   OGRSpatialReference * /*poSpatialRef*/,
+                                   const OGRSpatialReference * /*poSpatialRef*/,
                                    OGRwkbGeometryType /*eGType*/,
                                    char **papszOptions) override;
     virtual int TestCapability(const char *pszCap) override;

--- a/ogr/ogrsf_frmts/vdv/ogrvdvdatasource.cpp
+++ b/ogr/ogrsf_frmts/vdv/ogrvdvdatasource.cpp
@@ -1756,10 +1756,10 @@ static bool OGRVDVLoadVDV452Tables(OGRVDV452Tables &oTables)
 /*                           ICreateLayer()                             */
 /************************************************************************/
 
-OGRLayer *OGRVDVDataSource::ICreateLayer(const char *pszLayerName,
-                                         OGRSpatialReference * /*poSpatialRef*/,
-                                         OGRwkbGeometryType eGType,
-                                         char **papszOptions)
+OGRLayer *
+OGRVDVDataSource::ICreateLayer(const char *pszLayerName,
+                               const OGRSpatialReference * /*poSpatialRef*/,
+                               OGRwkbGeometryType eGType, char **papszOptions)
 {
     if (!m_bUpdate)
         return nullptr;

--- a/ogr/ogrsf_frmts/wasp/ogrwasp.h
+++ b/ogr/ogrsf_frmts/wasp/ogrwasp.h
@@ -200,10 +200,11 @@ class OGRWAsPDataSource final : public OGRDataSource
     virtual OGRLayer *GetLayer(int) override;
     virtual OGRLayer *GetLayerByName(const char *) override;
 
-    virtual OGRLayer *ICreateLayer(const char *pszName,
-                                   OGRSpatialReference *poSpatialRef = nullptr,
-                                   OGRwkbGeometryType eGType = wkbUnknown,
-                                   char **papszOptions = nullptr) override;
+    virtual OGRLayer *
+    ICreateLayer(const char *pszName,
+                 const OGRSpatialReference *poSpatialRef = nullptr,
+                 OGRwkbGeometryType eGType = wkbUnknown,
+                 char **papszOptions = nullptr) override;
 
     virtual int TestCapability(const char *) override;
     OGRErr Load(bool bSilent = false);

--- a/ogr/ogrsf_frmts/wasp/ogrwaspdatasource.cpp
+++ b/ogr/ogrsf_frmts/wasp/ogrwaspdatasource.cpp
@@ -185,10 +185,10 @@ OGRLayer *OGRWAsPDataSource::GetLayer(int iLayer)
 /*                             ICreateLayer()                           */
 /************************************************************************/
 
-OGRLayer *OGRWAsPDataSource::ICreateLayer(const char *pszName,
-                                          OGRSpatialReference *poSpatialRef,
-                                          OGRwkbGeometryType eGType,
-                                          char **papszOptions)
+OGRLayer *
+OGRWAsPDataSource::ICreateLayer(const char *pszName,
+                                const OGRSpatialReference *poSpatialRef,
+                                OGRwkbGeometryType eGType, char **papszOptions)
 
 {
 
@@ -305,10 +305,10 @@ OGRLayer *OGRWAsPDataSource::ICreateLayer(const char *pszName,
         }
     }
 
-    auto poSRSClone = poSpatialRef;
-    if (poSRSClone)
+    OGRSpatialReference *poSRSClone = nullptr;
+    if (poSpatialRef)
     {
-        poSRSClone = poSRSClone->Clone();
+        poSRSClone = poSpatialRef->Clone();
         poSRSClone->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     }
     oLayer.reset(new OGRWAsPLayer(

--- a/ogr/ogrsf_frmts/xlsx/ogr_xlsx.h
+++ b/ogr/ogrsf_frmts/xlsx/ogr_xlsx.h
@@ -286,7 +286,7 @@ class OGRXLSXDataSource final : public GDALDataset
     virtual int TestCapability(const char *) override;
 
     virtual OGRLayer *ICreateLayer(const char *pszLayerName,
-                                   OGRSpatialReference *poSRS,
+                                   const OGRSpatialReference *poSRS,
                                    OGRwkbGeometryType eType,
                                    char **papszOptions) override;
     virtual OGRErr DeleteLayer(int iLayer) override;

--- a/ogr/ogrsf_frmts/xlsx/ogrxlsxdatasource.cpp
+++ b/ogr/ogrsf_frmts/xlsx/ogrxlsxdatasource.cpp
@@ -1747,7 +1747,7 @@ void OGRXLSXDataSource::AnalyseStyles(VSILFILE *fpStyles)
 /************************************************************************/
 
 OGRLayer *OGRXLSXDataSource::ICreateLayer(const char *pszLayerName,
-                                          OGRSpatialReference * /*poSRS*/,
+                                          const OGRSpatialReference * /*poSRS*/,
                                           OGRwkbGeometryType /*eType*/,
                                           char **papszOptions)
 


### PR DESCRIPTION
Affects out-of-tree drivers (fixes #8493)
