### PR TITLE
Python bindings: Avoid crashes when using orphaned Geometry refs

### DIFF
--- a/doc/source/api/python_gotchas.rst
+++ b/doc/source/api/python_gotchas.rst
@@ -125,30 +125,6 @@ references to objects that no longer exist so that an exception is thrown
 instead of a crash, but the work is not complete.
 
 Unfortunately there is no complete list of such relationships, so you have to watch for it yourself.
-One other known place involves the OGR ``GetGeometryRef()`` function:
-
-.. code-block::
-
-   >>> feat = lyr.GetNextFeature()
-   >>> geom = feat.GetGeometryRef()     # geom contains a reference into the C++ geometry object maintained by the C++ feature object
-   >>> del feat                         # This deallocates the C++ feature object, and its C++ geometry
-   >>> print(geom.ExportToWkt())        # Crash here. The C++ geometry no longer exists
-   < Python crashes >
-
-If you read the GDAL and OGR API documentation carefully, you will see that the functions that end in "Ref" obtain references to internal objects, rather than making new copies.
-This is a clue that the problem could occur. Be careful when using the "Ref" functions. Also watch out for functions that end in "Directly", such as ``SetGeometryDirectly()``, which transfer ownership of internal objects:
-
-.. code-block::
-
-   >>> point = ogr.Geometry(ogr.wkbPoint)
-   >>> feature = ogr.Feature(layer_defn)
-   >>> feature.SetGeometryDirectly(point)    # Transfers ownership of the C++ geometry from point to feature
-   >>> del feature                           # point becomes implicitly invalid, because feature owns the C++ geometry
-   >>> print(point.ExportToWkt())            # Crash here
-   < Python crashes >
-
-The advantage of the "Ref" and "Directly" functions is they provide faster performance because a duplicate object does not need to be created. The disadvantage is that you have to watch out for this problem.
-
 
 Python crashes if you add a new field to an OGR layer when features deriving from this layer definition are still active
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/swig/include/python/ogr_python.i
+++ b/swig/include/python/ogr_python.i
@@ -559,7 +559,9 @@ def ReleaseResultSet(self, sql_lyr):
     def Destroy(self):
       "Once called, self has effectively been destroyed.  Do not access. For backwards compatibility only"
       _ogr.delete_Feature(self)
+      self._invalidate_geom_refs()
       self.thisown = 0
+      self.this = None
 
     def __cmp__(self, other):
         """Compares a feature to another for equality"""
@@ -583,8 +585,8 @@ def ReleaseResultSet(self, sql_lyr):
     # This has some risk of name collisions.
     def __getattr__(self, key):
         """Returns the values of fields by the given name"""
-        if key == 'this':
-            return self.__dict__[key]
+        if key in ('this', 'thisown', '_geom_references'):
+            return self.__getattribute__(key)
 
         idx = self._getfieldindex(key)
         if idx < 0:
@@ -600,8 +602,8 @@ def ReleaseResultSet(self, sql_lyr):
     # This has some risk of name collisions.
     def __setattr__(self, key, value):
         """Set the values of fields by the given name"""
-        if key == 'this' or key == 'thisown':
-            self.__dict__[key] = value
+        if key in ('this', 'thisown', '_geom_references'):
+            super().__setattr__(key, value)
         else:
             idx = self._getfieldindex(key)
             if idx != -1:
@@ -779,6 +781,8 @@ def ReleaseResultSet(self, sql_lyr):
 
         return self.GetGeometryRef()
 
+    def __del__(self):
+        self._invalidate_geom_refs()
 
     def __repr__(self):
         return self.DumpReadableAsString()
@@ -829,6 +833,47 @@ def ReleaseResultSet(self, sql_lyr):
         return output
 
 
+    def _add_geom_ref(self, geom):
+        if geom is None:
+            return
+
+        if not hasattr(self, '_geom_references'):
+            import weakref
+
+            self._geom_references = weakref.WeakSet()
+
+        self._geom_references.add(geom)
+
+
+    def _invalidate_geom_refs(self):
+        if hasattr(self, '_geom_references'):
+            for geom in self._geom_references:
+                geom.this = None
+
+%}
+
+%feature("shadow") SetGeometryDirectly %{
+    def SetGeometryDirectly(self, geom):
+        ret = $action(self, geom)
+        if ret == OGRERR_NONE:
+            self._add_geom_ref(geom)
+        return ret
+%}
+
+%feature("shadow") SetGeomFieldDirectly %{
+    def SetGeomFieldDirectly(self, field, geom):
+        ret = $action(self, field, geom)
+        if ret == OGRERR_NONE:
+            self._add_geom_ref(geom)
+        return ret
+%}
+
+%feature("pythonappend") GetGeometryRef %{
+    self._add_geom_ref(val)
+%}
+
+%feature("pythonappend") GetGeomFieldRef %{
+    self._add_geom_ref(val)
 %}
 
 %feature("shadow") SetField %{


### PR DESCRIPTION
## What does this PR do?

Avoids some scenarios that can produce a segfault.

## What are related issues/pull requests?

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
