### PR TITLE
Update the list of released PgSQL versions to the present

### DIFF
--- a/cmake/modules/3.20/FindPostgreSQL.cmake
+++ b/cmake/modules/3.20/FindPostgreSQL.cmake
@@ -102,7 +102,7 @@ set(PostgreSQL_ROOT_DIR_MESSAGE "Set the PostgreSQL_ROOT system variable to wher
 
 
 set(PostgreSQL_KNOWN_VERSIONS ${PostgreSQL_ADDITIONAL_VERSIONS}
-    "13" "12" "11" "10" "9.6" "9.5" "9.4" "9.3" "9.2" "9.1" "9.0" "8.4" "8.3" "8.2" "8.1" "8.0")
+    "16" "15" "14" "13" "12" "11" "10" "9.6" "9.5" "9.4" "9.3" "9.2" "9.1" "9.0" "8.4" "8.3" "8.2" "8.1" "8.0")
 
 # Define additional search paths for root directories.
 set( PostgreSQL_ROOT_DIRECTORIES


### PR DESCRIPTION
I'm not sure what the balance between this list of versions and the `PostgreSQL_ADDITIONAL_VERSIONS` configuration parameter is supposed to be, but superficially it makes sense to me that all the officially released versions should be in this list?

If there any argument against pulling this back into stable branches? 