### PR TITLE
Add GDALRegisterPlugin function to register a single plugin by name

### DIFF
--- a/autotest/cpp/test_gdal.cpp
+++ b/autotest/cpp/test_gdal.cpp
@@ -64,6 +64,13 @@ TEST_F(test_gdal, register_plugins)
     GDALRegisterPlugins();
 }
 
+// Test that GDALRegisterPlugin can be called and returns an error for a non
+// existing plugin name
+TEST_F(test_gdal, register_plugin)
+{
+    ASSERT_EQ(GDALRegisterPlugin("rtbreg_non_existing_plugin"), CE_Failure);
+}
+
 // Test number of registered GDAL drivers
 TEST_F(test_gdal, number_of_registered_drivers)
 {

--- a/frmts/gdalallregister.cpp
+++ b/frmts/gdalallregister.cpp
@@ -62,7 +62,7 @@ static char *szConfiguredFormats = "GDAL_FORMATS";
 CPLErr CPL_DLL GDALRegisterPlugin(const char *name)
 {
     auto poDriverManager = GetGDALDriverManager();
-    // AutoLoadDrivers is a no-op if compiled with GDAL_NO_AUTOLOAD defined.
+    // LoadPlugin is a no-op if compiled with GDAL_NO_AUTOLOAD defined.
     return poDriverManager->LoadPlugin(name);
 }
 

--- a/frmts/gdalallregister.cpp
+++ b/frmts/gdalallregister.cpp
@@ -59,7 +59,7 @@ static char *szConfiguredFormats = "GDAL_FORMATS";
  * @see GDALDriverManager::AutoLoadDrivers()
  * @since GDAL 3.8
 */
-CPLErr CPL_DLL GDALRegisterPlugin(const char *name)
+CPLErr GDALRegisterPlugin(const char *name)
 {
     auto poDriverManager = GetGDALDriverManager();
     // LoadPlugin is a no-op if compiled with GDAL_NO_AUTOLOAD defined.

--- a/frmts/gdalallregister.cpp
+++ b/frmts/gdalallregister.cpp
@@ -41,6 +41,32 @@ static char *szConfiguredFormats = "GDAL_FORMATS";
 #endif
 
 /************************************************************************/
+/*                          GDALRegisterPlugin()                        */
+/*                                                                      */
+/*      Register a plugin by name, returning an error if not found      */
+/************************************************************************/
+
+/**
+ * \brief Register a plugin by name, returning an error if not found      
+ * 
+ * This function will call GDALDriverManager::LoadPlugin() to register a
+ * specific plugin by name.
+ * 
+ * This method is intended to be called instead of GDALAllRegister() or
+ * GDALRegisterPlugins() when fine tuning which drivers are needed at runtime.
+ * 
+ * @see GDALDriverManager::LoadPlugin()
+ * @see GDALDriverManager::AutoLoadDrivers()
+ * @since GDAL 3.8
+*/
+CPLErr CPL_DLL GDALRegisterPlugin(const char *name)
+{
+    auto poDriverManager = GetGDALDriverManager();
+    // AutoLoadDrivers is a no-op if compiled with GDAL_NO_AUTOLOAD defined.
+    return poDriverManager->LoadPlugin(name);
+}
+
+/************************************************************************/
 /*                          GDALRegisterPlugins()                       */
 /*                                                                      */
 /*      Register drivers and support code available as a plugin.        */

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -878,6 +878,7 @@ typedef struct GDALDimensionHS *GDALDimensionH;
 
 void CPL_DLL CPL_STDCALL GDALAllRegister(void);
 void CPL_DLL GDALRegisterPlugins(void);
+CPLErr CPL_DLL CPL_STDCALL GDALRegisterPlugin(const char *name);
 
 GDALDatasetH CPL_DLL CPL_STDCALL
 GDALCreate(GDALDriverH hDriver, const char *, int, int, int, GDALDataType,

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -878,7 +878,7 @@ typedef struct GDALDimensionHS *GDALDimensionH;
 
 void CPL_DLL CPL_STDCALL GDALAllRegister(void);
 void CPL_DLL GDALRegisterPlugins(void);
-CPLErr CPL_DLL CPL_STDCALL GDALRegisterPlugin(const char *name);
+CPLErr CPL_DLL GDALRegisterPlugin(const char *name);
 
 GDALDatasetH CPL_DLL CPL_STDCALL
 GDALCreate(GDALDriverH hDriver, const char *, int, int, int, GDALDataType,

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -1918,7 +1918,7 @@ class CPL_DLL GDALDriverManager : public GDALMajorObject
     void AutoLoadDrivers();
     void AutoSkipDrivers();
     void ReorderDrivers();
-    CPLErr LoadPlugin(const char *name);
+    static CPLErr LoadPlugin(const char *name);
 
     static void AutoLoadPythonDrivers();
 };

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -1918,6 +1918,7 @@ class CPL_DLL GDALDriverManager : public GDALMajorObject
     void AutoLoadDrivers();
     void AutoSkipDrivers();
     void ReorderDrivers();
+    CPLErr LoadPlugin(const char *name);
 
     static void AutoLoadPythonDrivers();
 };

--- a/gcore/gdaldrivermanager.cpp
+++ b/gcore/gdaldrivermanager.cpp
@@ -837,11 +837,11 @@ CPLErr GDALDriverManager::LoadPlugin(const char *name)
                 CSLDestroy(papszSearchPaths);
 
                 CPLString osFuncName;
-                if (STARTS_WITH_CI(pszFilename, "gdal_"))
+                if (EQUAL(prefix, "gdal_"))
                 {
                     osFuncName.Printf("GDALRegister_%s", name);
                 }
-                else if (STARTS_WITH_CI(pszFilename, "ogr_"))
+                else
                 {
                     osFuncName.Printf("RegisterOGR%s", name);
                 }
@@ -879,6 +879,7 @@ CPLErr GDALDriverManager::LoadPlugin(const char *name)
     return CE_Failure;
 #endif  // GDAL_NO_AUTOLOAD
 }
+
 /************************************************************************/
 /*                          AutoLoadDrivers()                           */
 /************************************************************************/

--- a/gcore/gdaldrivermanager.cpp
+++ b/gcore/gdaldrivermanager.cpp
@@ -767,6 +767,119 @@ char **GDALDriverManager::GetSearchPaths(const char *pszGDAL_DRIVER_PATH)
 }
 
 /************************************************************************/
+/*                          LoadPlugin()                                */
+/************************************************************************/
+
+/**
+ * \brief Load a single GDAL driver/plugin from shared libraries.
+ *
+ * This function will load a single named driver/plugin from shared libraries.
+ * It searches the "driver path" for .so (or .dll) files named
+ * "gdal_{name}.[so|dll|dylib]" or "ogr_{name}.[so|dll|dylib]", then tries to
+ * call a function within them called GDALRegister_{name}(), or failing that
+ * called GDALRegisterMe().
+ * 
+ * \see GDALDriverManager::AutoLoadDrivers() for the rules used to determine
+ * which paths are searched for plugin library files.
+ */
+
+CPLErr GDALDriverManager::LoadPlugin(const char *name)
+{
+#ifdef GDAL_NO_AUTOLOAD
+    CPLDebug("GDAL", "GDALDriverManager::LoadPlugin() not compiled in.");
+    return CPLE_NotSupported;
+#else
+    const char *pszGDAL_DRIVER_PATH =
+        CPLGetConfigOption("GDAL_DRIVER_PATH", nullptr);
+    if (pszGDAL_DRIVER_PATH == nullptr)
+        pszGDAL_DRIVER_PATH = CPLGetConfigOption("OGR_DRIVER_PATH", nullptr);
+
+    /* -------------------------------------------------------------------- */
+    /*      Where should we look for stuff?                                 */
+    /* -------------------------------------------------------------------- */
+    char **papszSearchPaths = GetSearchPaths(pszGDAL_DRIVER_PATH);
+
+    /* -------------------------------------------------------------------- */
+    /*      Format the ABI version specific subdirectory to look in.        */
+    /* -------------------------------------------------------------------- */
+    CPLString osABIVersion;
+
+    osABIVersion.Printf("%d.%d", GDAL_VERSION_MAJOR, GDAL_VERSION_MINOR);
+
+    /* -------------------------------------------------------------------- */
+    /*      Scan each directory looking for files matching                  */
+    /*      gdal_{name}.[so|dll|dylib] or ogr_{name}.[so|dll|dylib]         */
+    /* -------------------------------------------------------------------- */
+    const int nSearchPaths = CSLCount(papszSearchPaths);
+    for (int iDir = 0; iDir < nSearchPaths; ++iDir)
+    {
+        CPLString osABISpecificDir =
+            CPLFormFilename(papszSearchPaths[iDir], osABIVersion, nullptr);
+
+        VSIStatBufL sStatBuf;
+        if (VSIStatL(osABISpecificDir, &sStatBuf) != 0)
+            osABISpecificDir = papszSearchPaths[iDir];
+
+        CPLString gdal_or_ogr[2] = {"gdal_", "ogr_"};
+        CPLString platformExtensions[3] = {"so", "dll", "dylib"};
+
+        for (CPLString &prefix : gdal_or_ogr)
+        {
+            for (CPLString &extension : platformExtensions)
+            {
+                const char *pszFilename = CPLFormFilename(
+                    osABISpecificDir, CPLSPrintf("%s%s", prefix.c_str(), name),
+                    extension);
+                if (VSIStatL(pszFilename, &sStatBuf) != 0)
+                    continue;
+
+                //cleanup now as the following codepath is garanteed to return
+                CSLDestroy(papszSearchPaths);
+
+                CPLString osFuncName;
+                if (STARTS_WITH_CI(pszFilename, "gdal_"))
+                {
+                    osFuncName.Printf("GDALRegister_%s", name);
+                }
+                else if (STARTS_WITH_CI(pszFilename, "ogr_"))
+                {
+                    osFuncName.Printf("RegisterOGR%s", name);
+                }
+                CPLErrorReset();
+                CPLPushErrorHandler(CPLQuietErrorHandler);
+                void *pRegister = CPLGetSymbol(pszFilename, osFuncName);
+                CPLPopErrorHandler();
+                if (pRegister == nullptr)
+                {
+                    CPLString osLastErrorMsg(CPLGetLastErrorMsg());
+                    osFuncName = "GDALRegisterMe";
+                    pRegister = CPLGetSymbol(pszFilename, osFuncName);
+                    if (pRegister == nullptr)
+                    {
+                        CPLError(CE_Failure, CPLE_AppDefined, "%s",
+                                 osLastErrorMsg.c_str());
+                        return CE_Failure;
+                    }
+                }
+                CPLDebug("GDAL", "Registering %s using %s in %s", name,
+                         osFuncName.c_str(), pszFilename);
+                CPLErrorReset();
+                reinterpret_cast<void (*)()>(pRegister)();
+                if (CPLGetErrorCounter() > 0)
+                {
+                    return CE_Failure;
+                }
+                return CE_None;
+            }
+        }
+    }
+    CSLDestroy(papszSearchPaths);
+    CPLError(CE_Failure, CPLE_AppDefined,
+             "Failed to find driver %s in configured driver paths.", name);
+    return CE_Failure;
+#endif  // GDAL_NO_AUTOLOAD
+}
+/************************************************************************/
 /*                          AutoLoadDrivers()                           */
 /************************************************************************/
 


### PR DESCRIPTION
This PR adds an exported `CPLErr GDALRegisterPlugin(const char *name)` function to
register a single plugin by name. Returns an error if either the plugin library
file was not found, or was found but did not contain a suitable plugin loading
function name, or if the plugin loading function CPLError'd.

Some of the plugin loading functionality has been copied over from 
`GDALDriverManager::AutoLoadDrivers()` instead of being refactored into
a single function as I deemed the return-on-error behavior was too messy to
unify.
