### PR TITLE
FlatGeoBuf: ArrowStream: return a released array when there are no rows

### DIFF
--- a/autotest/ogr/ogr_flatgeobuf.py
+++ b/autotest/ogr/ogr_flatgeobuf.py
@@ -1109,6 +1109,23 @@ def test_ogr_flatgeobuf_arrow_stream_numpy():
     ogr.GetDriverByName("FlatGeobuf").DeleteDataSource("/vsimem/test.fgb")
 
 
+###############################################################################
+# Test reading an empty file with GetArrowStream()
+
+
+def test_ogr_flatgeobuf_arrow_stream_empty_file():
+
+    ds = ogr.GetDriverByName("FlatGeoBuf").CreateDataSource("/vsimem/test.fgb")
+    lyr = ds.CreateLayer("test", geom_type=ogr.wkbPoint)
+    assert lyr.TestCapability(ogr.OLCFastGetArrowStream) == 1
+    stream = lyr.GetArrowStream()
+    assert stream.GetNextRecordBatch() is None
+    del stream
+    ds = None
+
+    ogr.GetDriverByName("FlatGeobuf").DeleteDataSource("/vsimem/test.fgb")
+
+
 def test_ogr_flatgeobuf_issue_7401():
     # Verify null geom handling without spatial index
     ds = ogr.GetDriverByName("FlatGeobuf").CreateDataSource("/vsimem/test.fgb")

--- a/autotest/ogr/ogr_parquet.py
+++ b/autotest/ogr/ogr_parquet.py
@@ -1783,6 +1783,26 @@ def test_ogr_parquet_arrow_stream_numpy():
 
 
 ###############################################################################
+# Test reading an empty file with GetArrowStream()
+
+
+def test_ogr_parquet_arrow_stream_empty_file():
+
+    ds = ogr.GetDriverByName("Parquet").CreateDataSource("/vsimem/test.parquet")
+    ds.CreateLayer("test", geom_type=ogr.wkbPoint)
+    ds = None
+    ds = ogr.Open("/vsimem/test.parquet")
+    lyr = ds.GetLayer(0)
+    assert lyr.TestCapability(ogr.OLCFastGetArrowStream) == 1
+    stream = lyr.GetArrowStream()
+    assert stream.GetNextRecordBatch() is None
+    del stream
+    ds = None
+
+    ogr.GetDriverByName("Parquet").DeleteDataSource("/vsimem/test.parquet")
+
+
+###############################################################################
 
 
 def test_ogr_parquet_arrow_stream_numpy_with_fid_column():

--- a/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
+++ b/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
@@ -1879,10 +1879,17 @@ int OGRFlatGeobufLayer::GetNextArrowArray(struct ArrowArrayStream *stream,
         bEOFOrError = false;
     }
 
-    if (bEOFOrError && m_featuresCount > 0)
+    if (bEOFOrError)
         m_bEOF = true;
 
     sHelper.Shrink(iFeat);
+
+    if (iFeat == 0)
+    {
+        out_array->release(out_array);
+        memset(out_array, 0, sizeof(*out_array));
+    }
+
     return 0;
 
 error:

--- a/ogr/ogrsf_frmts/generic/ograrrowarrayhelper.h
+++ b/ogr/ogrsf_frmts/generic/ograrrowarrayhelper.h
@@ -255,7 +255,8 @@ class CPL_DLL OGRArrowArrayHelper
 
     void ClearArray()
     {
-        m_out_array->release(m_out_array);
+        if (m_out_array->release)
+            m_out_array->release(m_out_array);
         memset(m_out_array, 0, sizeof(*m_out_array));
     }
 

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagelayer.cpp
@@ -842,6 +842,8 @@ int OGRGeoPackageLayer::GetNextArrowArray(struct ArrowArrayStream *stream,
     }
 
     sHelper.Shrink(iFeat);
+    if (iFeat == 0)
+        sHelper.ClearArray();
 
     return 0;
 


### PR DESCRIPTION
Fixes #8509

@jorisvandenbossche 
I've decided to uniformize the behavior of all drivers to immediately return a released array when there are no rows. The GeoPackage one was for example returning a non-released empty batch at the first iteration and then a released batch.