### PR TITLE
autotest: allow utilities tests to run in parallel

### DIFF
--- a/autotest/utilities/test_gdal_footprint.py
+++ b/autotest/utilities/test_gdal_footprint.py
@@ -143,10 +143,10 @@ def test_gdal_footprint_overwrite(gdal_footprint_path, tmp_path):
 ###############################################################################
 
 
-def test_gdal_footprint_wrong_input_dataset(gdal_footprint_path):
+def test_gdal_footprint_wrong_input_dataset(gdal_footprint_path, tmp_vsimem):
 
     (_, err) = gdaltest.runexternal_out_and_err(
-        gdal_footprint_path + " /vsimem/in.tif /vsimem/out.json"
+        f"{gdal_footprint_path} {tmp_vsimem}/in.tif {tmp_vsimem}/out.json"
     )
     assert "ret code = 1" in err
 

--- a/autotest/utilities/test_gdal_translate.py
+++ b/autotest/utilities/test_gdal_translate.py
@@ -965,7 +965,7 @@ def test_gdal_translate_34(gdal_translate_path, tmp_path):
 # Test various errors (missing source or dest...)
 
 
-def test_gdal_translate_35(gdal_translate_path):
+def test_gdal_translate_35(gdal_translate_path, tmp_vsimem):
 
     (_, err) = gdaltest.runexternal_out_and_err(gdal_translate_path)
     assert "No source dataset specified" in err
@@ -976,7 +976,7 @@ def test_gdal_translate_35(gdal_translate_path):
     assert "No target dataset specified" in err
 
     (_, err) = gdaltest.runexternal_out_and_err(
-        gdal_translate_path + " /non_existing_path/non_existing.tif /vsimem/out.tif"
+        f"{gdal_translate_path} /non_existing_path/non_existing.tif {tmp_vsimem}/out.tif"
     )
     assert (
         "does not exist in the file system" in err or "No such file or directory" in err
@@ -1083,22 +1083,21 @@ def test_gdal_translate_39(gdal_translate_path, tmp_path):
 # Test -if option
 
 
-def test_gdal_translate_if_option(gdal_translate_path):
+def test_gdal_translate_if_option(gdal_translate_path, tmp_vsimem):
 
     ret, err = gdaltest.runexternal_out_and_err(
-        gdal_translate_path + " -if GTiff ../gcore/data/byte.tif /vsimem/out.tif"
+        f"{gdal_translate_path} -if GTiff ../gcore/data/byte.tif {tmp_vsimem}/out.tif"
     )
     assert err is None or err == ""
 
     _, err = gdaltest.runexternal_out_and_err(
-        gdal_translate_path
-        + " -if invalid_driver_name ../gcore/data/byte.tif /vsimem/out.tif"
+        f"{gdal_translate_path}  -if invalid_driver_name ../gcore/data/byte.tif {tmp_vsimem}/out.tif"
     )
     assert err is not None
     assert "invalid_driver_name" in err
 
     _, err = gdaltest.runexternal_out_and_err(
-        gdal_translate_path + " -if HFA ../gcore/data/byte.tif /vsimem/out.tif"
+        f"{gdal_translate_path} -if HFA ../gcore/data/byte.tif {tmp_vsimem}/out.tif"
     )
     assert err is not None
 
@@ -1108,10 +1107,10 @@ def test_gdal_translate_if_option(gdal_translate_path):
 
 
 @pytest.mark.skipif(sys.platform == "win32", reason="not working on Windows")
-def test_gdal_translate_scale_and_unscale_incompatible(gdal_translate_path):
+def test_gdal_translate_scale_and_unscale_incompatible(gdal_translate_path, tmp_vsimem):
 
     _, err = gdaltest.runexternal_out_and_err(
         gdal_translate_path
-        + " -a_scale 0.0001 -a_offset 0.1 -unscale ../gcore/data/byte.tif /vsimem/out.tif"
+        + f" -a_scale 0.0001 -a_offset 0.1 -unscale ../gcore/data/byte.tif {tmp_vsimem}/out.tif"
     )
     assert "-a_scale/-a_offset are not applied by -unscale" in err

--- a/autotest/utilities/test_gdalbuildvrt_lib.py
+++ b/autotest/utilities/test_gdalbuildvrt_lib.py
@@ -106,7 +106,6 @@ def test_gdalbuildvrt_lib_ovr(tmp_vsimem):
     ds = gdal.Open(tmpfilename)
     assert ds.GetRasterBand(1).GetOverviewCount() == 1
     ds = None
-    gdal.GetDriverByName("VRT").Delete(tmpfilename)
 
 
 def test_gdalbuildvrt_lib_te_partial_overlap():
@@ -247,7 +246,7 @@ def test_gdalbuildvrt_lib_virtual_overviews_not_same_res():
 
 
 ###############################################################################
-def test_gdalbuildvrt_lib_separate_nodata():
+def test_gdalbuildvrt_lib_separate_nodata(tmp_vsimem):
 
     src1_ds = gdal.GetDriverByName("MEM").Create("", 1000, 1000)
     src1_ds.SetGeoTransform([2, 0.001, 0, 49, 0, -0.001])
@@ -257,12 +256,11 @@ def test_gdalbuildvrt_lib_separate_nodata():
     src2_ds.SetGeoTransform([2, 0.001, 0, 49, 0, -0.001])
     src2_ds.GetRasterBand(1).SetNoDataValue(2)
 
-    gdal.BuildVRT("/vsimem/out.vrt", [src1_ds, src2_ds], separate=True)
+    gdal.BuildVRT(tmp_vsimem / "out.vrt", [src1_ds, src2_ds], separate=True)
 
-    f = gdal.VSIFOpenL("/vsimem/out.vrt", "rb")
+    f = gdal.VSIFOpenL(tmp_vsimem / "out.vrt", "rb")
     data = gdal.VSIFReadL(1, 10000, f)
     gdal.VSIFCloseL(f)
-    gdal.Unlink("/vsimem/out.vrt")
 
     assert b"<NoDataValue>1</NoDataValue>" in data
     assert b"<NODATA>1</NODATA>" in data
@@ -271,7 +269,7 @@ def test_gdalbuildvrt_lib_separate_nodata():
 
 
 ###############################################################################
-def test_gdalbuildvrt_lib_separate_nodata_2():
+def test_gdalbuildvrt_lib_separate_nodata_2(tmp_vsimem):
 
     src1_ds = gdal.GetDriverByName("MEM").Create("", 1000, 1000)
     src1_ds.SetGeoTransform([2, 0.001, 0, 49, 0, -0.001])
@@ -281,12 +279,13 @@ def test_gdalbuildvrt_lib_separate_nodata_2():
     src2_ds.SetGeoTransform([2, 0.001, 0, 49, 0, -0.001])
     src2_ds.GetRasterBand(1).SetNoDataValue(2)
 
-    gdal.BuildVRT("/vsimem/out.vrt", [src1_ds, src2_ds], separate=True, srcNodata="3 4")
+    gdal.BuildVRT(
+        tmp_vsimem / "out.vrt", [src1_ds, src2_ds], separate=True, srcNodata="3 4"
+    )
 
-    f = gdal.VSIFOpenL("/vsimem/out.vrt", "rb")
+    f = gdal.VSIFOpenL(tmp_vsimem / "out.vrt", "rb")
     data = gdal.VSIFReadL(1, 10000, f)
     gdal.VSIFCloseL(f)
-    gdal.Unlink("/vsimem/out.vrt")
 
     assert b"<NoDataValue>3</NoDataValue>" in data
     assert b"<NODATA>3</NODATA>" in data
@@ -295,7 +294,7 @@ def test_gdalbuildvrt_lib_separate_nodata_2():
 
 
 ###############################################################################
-def test_gdalbuildvrt_lib_separate_nodata_3():
+def test_gdalbuildvrt_lib_separate_nodata_3(tmp_vsimem):
 
     src1_ds = gdal.GetDriverByName("MEM").Create("", 1000, 1000)
     src1_ds.SetGeoTransform([2, 0.001, 0, 49, 0, -0.001])
@@ -306,17 +305,16 @@ def test_gdalbuildvrt_lib_separate_nodata_3():
     src2_ds.GetRasterBand(1).SetNoDataValue(2)
 
     gdal.BuildVRT(
-        "/vsimem/out.vrt",
+        tmp_vsimem / "out.vrt",
         [src1_ds, src2_ds],
         separate=True,
         srcNodata="3 4",
         VRTNodata="5 6",
     )
 
-    f = gdal.VSIFOpenL("/vsimem/out.vrt", "rb")
+    f = gdal.VSIFOpenL(tmp_vsimem / "out.vrt", "rb")
     data = gdal.VSIFReadL(1, 10000, f)
     gdal.VSIFCloseL(f)
-    gdal.Unlink("/vsimem/out.vrt")
 
     assert b"<NoDataValue>5</NoDataValue>" in data
     assert b"<NODATA>3</NODATA>" in data
@@ -325,7 +323,7 @@ def test_gdalbuildvrt_lib_separate_nodata_3():
 
 
 ###############################################################################
-def test_gdalbuildvrt_lib_separate_nodata_4():
+def test_gdalbuildvrt_lib_separate_nodata_4(tmp_vsimem):
 
     src1_ds = gdal.GetDriverByName("MEM").Create("", 1000, 1000)
     src1_ds.SetGeoTransform([2, 0.001, 0, 49, 0, -0.001])
@@ -336,17 +334,16 @@ def test_gdalbuildvrt_lib_separate_nodata_4():
     src2_ds.GetRasterBand(1).SetNoDataValue(2)
 
     gdal.BuildVRT(
-        "/vsimem/out.vrt",
+        tmp_vsimem / "out.vrt",
         [src1_ds, src2_ds],
         separate=True,
         srcNodata="None",
         VRTNodata="None",
     )
 
-    f = gdal.VSIFOpenL("/vsimem/out.vrt", "rb")
+    f = gdal.VSIFOpenL(tmp_vsimem / "out.vrt", "rb")
     data = gdal.VSIFReadL(1, 10000, f)
     gdal.VSIFCloseL(f)
-    gdal.Unlink("/vsimem/out.vrt")
 
     assert b"<NoDataValue>" not in data
     assert b"<NODATA>" not in data
@@ -574,9 +571,9 @@ def test_gdalbuildvrt_lib_strict_mode():
 
 
 ###############################################################################
-def test_gdalbuildvrt_lib_te_touching_on_edge():
+def test_gdalbuildvrt_lib_te_touching_on_edge(tmp_vsimem):
 
-    tmp_filename = "/vsimem/test_gdalbuildvrt_lib_te_touching_on_edge.vrt"
+    tmp_filename = tmp_vsimem / "test_gdalbuildvrt_lib_te_touching_on_edge.vrt"
     ds = gdal.BuildVRT(
         tmp_filename,
         "../gcore/data/byte.tif",
@@ -591,54 +588,46 @@ def test_gdalbuildvrt_lib_te_touching_on_edge():
     assert ds.GetRasterBand(1).Checksum() == 0
     ds = None
 
-    gdal.Unlink(tmp_filename)
-
 
 ###############################################################################
 @pytest.mark.parametrize("num_bands_1,num_bands_2", [(3, 3), (3, 4), (4, 3), (4, 4)])
 @pytest.mark.parametrize("drv_name", ["MEM", "GTiff"])
-def test_gdalbuildvrt_lib_addAlpha(num_bands_1, num_bands_2, drv_name):
-    fname1 = "/vsimem/test_gdalbuildvrt_lib_addAlpha_1.tif"
-    fname2 = "/vsimem/test_gdalbuildvrt_lib_addAlpha_2.tif"
+def test_gdalbuildvrt_lib_addAlpha(tmp_vsimem, num_bands_1, num_bands_2, drv_name):
+    fname1 = tmp_vsimem / "test_gdalbuildvrt_lib_addAlpha_1.tif"
+    fname2 = tmp_vsimem / "test_gdalbuildvrt_lib_addAlpha_2.tif"
 
-    try:
-        src_ds1 = gdal.GetDriverByName(drv_name).Create(fname1, 1, 1, num_bands_1)
-        if num_bands_1 == 4:
-            src_ds1.GetRasterBand(src_ds1.RasterCount).SetColorInterpretation(
-                gdal.GCI_AlphaBand
-            )
-        for i in range(src_ds1.RasterCount):
-            src_ds1.GetRasterBand(i + 1).Fill(i + 1)
-        src_ds1.SetGeoTransform([2, 1, 0, 49, 0, -1])
+    src_ds1 = gdal.GetDriverByName(drv_name).Create(fname1, 1, 1, num_bands_1)
+    if num_bands_1 == 4:
+        src_ds1.GetRasterBand(src_ds1.RasterCount).SetColorInterpretation(
+            gdal.GCI_AlphaBand
+        )
+    for i in range(src_ds1.RasterCount):
+        src_ds1.GetRasterBand(i + 1).Fill(i + 1)
+    src_ds1.SetGeoTransform([2, 1, 0, 49, 0, -1])
 
-        src_ds2 = gdal.GetDriverByName(drv_name).Create(fname2, 1, 1, num_bands_2)
-        if num_bands_2 == 4:
-            src_ds2.GetRasterBand(src_ds2.RasterCount).SetColorInterpretation(
-                gdal.GCI_AlphaBand
-            )
-        for i in range(src_ds2.RasterCount):
-            src_ds2.GetRasterBand(i + 1).Fill(i + 1)
-        src_ds2.SetGeoTransform([3, 1, 0, 49, 0, -1])
+    src_ds2 = gdal.GetDriverByName(drv_name).Create(fname2, 1, 1, num_bands_2)
+    if num_bands_2 == 4:
+        src_ds2.GetRasterBand(src_ds2.RasterCount).SetColorInterpretation(
+            gdal.GCI_AlphaBand
+        )
+    for i in range(src_ds2.RasterCount):
+        src_ds2.GetRasterBand(i + 1).Fill(i + 1)
+    src_ds2.SetGeoTransform([3, 1, 0, 49, 0, -1])
 
-        if drv_name == "MEM":
-            ds = gdal.BuildVRT("", [src_ds1, src_ds2], addAlpha=True)
-        else:
-            src_ds1 = None
-            src_ds2 = None
-            ds = gdal.BuildVRT("", [fname1, fname2], addAlpha=True)
-        assert ds.RasterCount == 4
-        assert ds.GetRasterBand(4).GetColorInterpretation() == gdal.GCI_AlphaBand
-        assert ds.GetRasterBand(1).ReadRaster() == b"\x01\x01"
-        assert ds.GetRasterBand(2).ReadRaster() == b"\x02\x02"
-        assert ds.GetRasterBand(3).ReadRaster() == b"\x03\x03"
-        assert ds.GetRasterBand(4).ReadRaster() == (
-            b"\xff" if num_bands_1 == 3 else b"\x04"
-        ) + (b"\xff" if num_bands_2 == 3 else b"\x04")
-    finally:
-        if gdal.VSIStatL(fname1) is not None:
-            gdal.Unlink(fname1)
-        if gdal.VSIStatL(fname2) is not None:
-            gdal.Unlink(fname2)
+    if drv_name == "MEM":
+        ds = gdal.BuildVRT("", [src_ds1, src_ds2], addAlpha=True)
+    else:
+        src_ds1 = None
+        src_ds2 = None
+        ds = gdal.BuildVRT("", [fname1, fname2], addAlpha=True)
+    assert ds.RasterCount == 4
+    assert ds.GetRasterBand(4).GetColorInterpretation() == gdal.GCI_AlphaBand
+    assert ds.GetRasterBand(1).ReadRaster() == b"\x01\x01"
+    assert ds.GetRasterBand(2).ReadRaster() == b"\x02\x02"
+    assert ds.GetRasterBand(3).ReadRaster() == b"\x03\x03"
+    assert ds.GetRasterBand(4).ReadRaster() == (
+        b"\xff" if num_bands_1 == 3 else b"\x04"
+    ) + (b"\xff" if num_bands_2 == 3 else b"\x04")
 
 
 ###############################################################################

--- a/autotest/utilities/test_gdaldem_lib.py
+++ b/autotest/utilities/test_gdaldem_lib.py
@@ -505,10 +505,10 @@ def test_gdaldem_lib_color_relief():
     ds = None
 
 
-def test_gdaldem_lib_color_relief_nodata_value():
+def test_gdaldem_lib_color_relief_nodata_value(tmp_vsimem):
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
-    colorFilename = "/vsimem/color_file.txt"
+    colorFilename = tmp_vsimem / "color_file.txt"
     gdal.FileFromMemBuffer(colorFilename, """nv 255 255 255""")
 
     with gdal.quiet_errors():

--- a/autotest/utilities/test_gdalmdimtranslate_lib.py
+++ b/autotest/utilities/test_gdalmdimtranslate_lib.py
@@ -41,13 +41,12 @@ from osgeo import gdal
 ###############################################################################
 
 
-def test_gdalmdimtranslate_no_arg():
+def test_gdalmdimtranslate_no_arg(tmp_vsimem):
 
-    tmpfile = "/vsimem/out.vrt"
+    tmpfile = tmp_vsimem / "out.vrt"
     assert gdal.MultiDimTranslate(tmpfile, "data/mdim.vrt")
 
     assert gdal.MultiDimInfo(tmpfile) == gdal.MultiDimInfo("data/mdim.vrt")
-    gdal.Unlink(tmpfile)
 
 
 ###############################################################################
@@ -80,15 +79,13 @@ def test_gdalmdimtranslate_multidim_to_classic(tmp_vsimem):
         arraySpecs=["/my_subgroup/array_in_subgroup"],
     )
 
-    gdal.Unlink(tmpfile)
-
 
 ###############################################################################
 
 
-def test_gdalmdimtranslate_multidim_1d_to_classic():
+def test_gdalmdimtranslate_multidim_1d_to_classic(tmp_vsimem):
 
-    tmpfile = "/vsimem/out.tif"
+    tmpfile = tmp_vsimem / "out.tif"
 
     assert gdal.MultiDimTranslate(tmpfile, "data/mdim.vrt", arraySpecs=["latitude"])
     ds = gdal.Open(tmpfile)
@@ -98,30 +95,26 @@ def test_gdalmdimtranslate_multidim_1d_to_classic():
     assert struct.unpack("f" * 10, data)[0] == 90.0
     ds = None
 
-    gdal.Unlink(tmpfile)
-
 
 ###############################################################################
 
 
-def test_gdalmdimtranslate_classic_to_classic():
+def test_gdalmdimtranslate_classic_to_classic(tmp_vsimem):
 
-    tmpfile = "/vsimem/out.tif"
+    tmpfile = tmp_vsimem / "out.tif"
 
     ds = gdal.MultiDimTranslate(tmpfile, "../gcore/data/byte.tif")
     assert ds.GetRasterBand(1).Checksum() == 4672
     ds = None
 
-    gdal.Unlink(tmpfile)
-
 
 ###############################################################################
 
 
-def test_gdalmdimtranslate_classic_to_multidim():
+def test_gdalmdimtranslate_classic_to_multidim(tmp_vsimem):
 
-    tmpfile = "/vsimem/out.vrt"
-    tmpgtifffile = "/vsimem/tmp.tif"
+    tmpfile = tmp_vsimem / "out.vrt"
+    tmpgtifffile = tmp_vsimem / "tmp.tif"
     ds = gdal.Translate(tmpgtifffile, "../gcore/data/byte.tif")
     ds.SetSpatialRef(None)
     ds = None
@@ -175,9 +168,9 @@ def test_gdalmdimtranslate_classic_to_multidim():
 ###############################################################################
 
 
-def test_gdalmdimtranslate_array():
+def test_gdalmdimtranslate_array(tmp_vsimem):
 
-    tmpfile = "/vsimem/out.vrt"
+    tmpfile = tmp_vsimem / "out.vrt"
     with pytest.raises(Exception):
         gdal.MultiDimTranslate(tmpfile, "data/mdim.vrt", arraySpecs=["not_existing"])
     with pytest.raises(Exception):
@@ -256,9 +249,9 @@ def test_gdalmdimtranslate_array():
 ###############################################################################
 
 
-def test_gdalmdimtranslate_array_with_transpose_and_view():
+def test_gdalmdimtranslate_array_with_transpose_and_view(tmp_vsimem):
 
-    tmpfile = "/vsimem/out.vrt"
+    tmpfile = tmp_vsimem / "out.vrt"
     assert gdal.MultiDimTranslate(
         tmpfile,
         "data/mdim.vrt",
@@ -331,9 +324,9 @@ def test_gdalmdimtranslate_array_with_transpose_and_view():
 ###############################################################################
 
 
-def test_gdalmdimtranslate_group():
+def test_gdalmdimtranslate_group(tmp_vsimem):
 
-    tmpfile = "/vsimem/out.vrt"
+    tmpfile = tmp_vsimem / "out.vrt"
     with pytest.raises(Exception):
         gdal.MultiDimTranslate(tmpfile, "data/mdim.vrt", groupSpecs=["not_existing"])
     with pytest.raises(Exception):
@@ -396,9 +389,9 @@ def test_gdalmdimtranslate_group():
 ###############################################################################
 
 
-def test_gdalmdimtranslate_two_groups():
+def test_gdalmdimtranslate_two_groups(tmp_vsimem):
 
-    tmpfile = "/vsimem/out.vrt"
+    tmpfile = tmp_vsimem / "out.vrt"
     assert gdal.MultiDimTranslate(
         tmpfile,
         "data/mdim.vrt",
@@ -466,9 +459,9 @@ def test_gdalmdimtranslate_two_groups():
 ###############################################################################
 
 
-def test_gdalmdimtranslate_subset():
+def test_gdalmdimtranslate_subset(tmp_vsimem):
 
-    tmpfile = "/vsimem/out.vrt"
+    tmpfile = tmp_vsimem / "out.vrt"
     with pytest.raises(Exception):
         gdal.MultiDimTranslate(tmpfile, "data/mdim.vrt", subsetSpecs=["latitude("])
     with pytest.raises(Exception):
@@ -721,9 +714,9 @@ def test_gdalmdimtranslate_subset():
 ###############################################################################
 
 
-def test_gdalmdimtranslate_scaleaxes():
+def test_gdalmdimtranslate_scaleaxes(tmp_vsimem):
 
-    tmpfile = "/vsimem/out.vrt"
+    tmpfile = tmp_vsimem / "out.vrt"
     assert gdal.MultiDimTranslate(
         tmpfile,
         "data/mdim.vrt",
@@ -795,9 +788,9 @@ def test_gdalmdimtranslate_scaleaxes():
     )
 
 
-def test_gdalmdimtranslate_dims_with_same_name_different_size():
+def test_gdalmdimtranslate_dims_with_same_name_different_size(tmp_vsimem):
 
-    srcfile = "/vsimem/in.vrt"
+    srcfile = tmp_vsimem / "in.vrt"
     gdal.FileFromMemBuffer(
         srcfile,
         """<VRTDataset>
@@ -814,7 +807,7 @@ def test_gdalmdimtranslate_dims_with_same_name_different_size():
 </VRTDataset>""",
     )
 
-    tmpfile = "/vsimem/test.vrt"
+    tmpfile = tmp_vsimem / "test.vrt"
     gdal.MultiDimTranslate(tmpfile, srcfile, groupSpecs=["/"], format="VRT")
 
     f = gdal.VSIFOpenL(tmpfile, "rb")

--- a/autotest/utilities/test_gdalwarp.py
+++ b/autotest/utilities/test_gdalwarp.py
@@ -1529,21 +1529,20 @@ def test_gdalwarp_47_append_subdataset(gdalwarp_path, tmp_path):
 # Test -if option
 
 
-def test_gdalwarp_if_option(gdalwarp_path):
+def test_gdalwarp_if_option(gdalwarp_path, tmp_vsimem):
 
     ret, err = gdaltest.runexternal_out_and_err(
-        gdalwarp_path + " -if GTiff ../gcore/data/byte.tif /vsimem/out.tif"
+        f"{gdalwarp_path} -if GTiff ../gcore/data/byte.tif {tmp_vsimem}/out.tif"
     )
     assert err is None or err == ""
 
     _, err = gdaltest.runexternal_out_and_err(
-        gdalwarp_path
-        + " -if invalid_driver_name ../gcore/data/byte.tif /vsimem/out.tif"
+        f"{gdalwarp_path} -if invalid_driver_name ../gcore/data/byte.tif {tmp_vsimem}/out.tif"
     )
     assert err is not None
     assert "invalid_driver_name" in err
 
     _, err = gdaltest.runexternal_out_and_err(
-        gdalwarp_path + " -if HFA ../gcore/data/byte.tif /vsimem/out.tif"
+        f"{gdalwarp_path} -if HFA ../gcore/data/byte.tif {tmp_vsimem}/out.tif"
     )
     assert err is not None

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -2102,7 +2102,10 @@ def Translate(destName, srcDS, **kwargs):
         (opts, callback, callback_data) = TranslateOptions(**kwargs)
     else:
         (opts, callback, callback_data) = kwargs['options']
-    if isinstance(srcDS, str):
+
+    import os
+
+    if isinstance(srcDS, (str, os.PathLike)):
         srcDS = Open(srcDS)
 
     return TranslateInternal(destName, srcDS, opts, callback, callback_data)
@@ -2637,9 +2640,13 @@ def VectorTranslateOptions(options=None, format=None,
             new_options += ['-gt', str(transactionSize)]
 
         if clipSrc is not None:
+            import os
+
             new_options += ['-clipsrc']
             if isinstance(clipSrc, str):
                 new_options += [clipSrc]
+            elif isinstance(clipSrc, os.PathLike):
+                new_options += [str(clipSrc)]
             else:
                 try:
                     new_options += [
@@ -2658,9 +2665,13 @@ def VectorTranslateOptions(options=None, format=None,
             new_options += ['-clipsrcwhere', str(clipSrcWhere)]
 
         if clipDst is not None:
+            import os
+
             new_options += ['-clipdst']
             if isinstance(clipDst, str):
                 new_options += [clipDst]
+            elif isinstance(clipDst, os.PathLike):
+                new_options += [str(clipDst)]
             else:
                 try:
                     new_options += [
@@ -2902,8 +2913,14 @@ def DEMProcessing(destName, srcDS, processing, **kwargs):
         (opts, colorFilename, callback, callback_data) = DEMProcessingOptions(**kwargs)
     else:
         (opts, colorFilename, callback, callback_data) = kwargs['options']
-    if isinstance(srcDS, str):
+
+    import os
+
+    if isinstance(srcDS, (str, os.PathLike)):
         srcDS = Open(srcDS)
+
+    if isinstance(colorFilename, os.PathLike):
+        colorFilename = str(colorFilename)
 
     return DEMProcessingInternal(destName, srcDS, processing, colorFilename, opts, callback, callback_data)
 
@@ -3162,7 +3179,10 @@ def Grid(destName, srcDS, **kwargs):
         (opts, callback, callback_data) = GridOptions(**kwargs)
     else:
         (opts, callback, callback_data) = kwargs['options']
-    if isinstance(srcDS, str):
+
+    import os
+
+    if isinstance(srcDS, (str, os.PathLike)):
         srcDS = OpenEx(srcDS, gdalconst.OF_VECTOR)
 
     return GridInternal(destName, srcDS, opts, callback, callback_data)


### PR DESCRIPTION
## What does this PR do?

* Applies `tmp_vsimem` fixture to tests in `utilities` to avoid collisions when running tests in parallel (`pytest -n`)
* Adds `os.PathLike` handling to some arguments that were lacking it

## What are related issues/pull requests?

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
