### PR TITLE
[Backport release/3.7] XLSX: do not write empty <cols> element on empty layers, and change heuristics to detect 'default' empty layers from intended empty ones (fixes qgis/qgis#42945)

### DIFF
--- a/autotest/ogr/ogr_xlsx.py
+++ b/autotest/ogr/ogr_xlsx.py
@@ -569,3 +569,33 @@ def test_ogr_xlsx_read_xlsx_prefix():
         tmpfilename, open("data/xlsx/cells_with_inline_formatting.xlsx", "rb").read()
     ):
         assert ogr.Open("XLSX:" + tmpfilename) is not None
+
+
+###############################################################################
+# Test writing sheets without rows
+
+
+def test_ogr_xlsx_write_sheet_without_row():
+
+    tmpfilename = "/vsimem/temp.xlsx"
+    ds = ogr.GetDriverByName("XLSX").CreateDataSource(tmpfilename)
+    lyr = ds.CreateLayer("L1")
+    lyr.CreateField(ogr.FieldDefn("foo"))
+    lyr = ds.CreateLayer("L2")
+    lyr.CreateField(ogr.FieldDefn("bar"))
+    ds = None
+    ds = ogr.Open(tmpfilename, update=1)
+    assert ds.GetLayerCount() == 2
+    lyr = ds.CreateLayer("L3")
+    lyr.CreateField(ogr.FieldDefn("baz", ogr.OFTInteger))
+    f = ogr.Feature(lyr.GetLayerDefn())
+    f["baz"] = 123
+    lyr.CreateFeature(f)
+    ds = None
+    ds = ogr.Open(tmpfilename)
+    assert ds.GetLayerCount() == 3
+    assert ds.GetLayer(0).GetFeatureCount() == 0
+    assert ds.GetLayer(1).GetFeatureCount() == 0
+    assert ds.GetLayer(2).GetFeatureCount() == 1
+    ds = None
+    gdal.Unlink(tmpfilename)

--- a/ogr/ogrsf_frmts/xlsx/ogr_xlsx.h
+++ b/ogr/ogrsf_frmts/xlsx/ogr_xlsx.h
@@ -59,6 +59,7 @@ class OGRXLSXLayer final : public OGRMemLayer
     void Init();
     bool bUpdated;
     bool bHasHeaderLine;
+    std::string m_osCols{};
     std::set<int> oSetFieldsOfUnknownType{};
 
   public:
@@ -161,6 +162,11 @@ class OGRXLSXLayer final : public OGRMemLayer
         return OGRMemLayer::TestCapability(pszCap);
     }
 
+    const std::string &GetCols() const
+    {
+        return m_osCols;
+    }
+
     virtual OGRErr SyncToDisk() override;
 };
 
@@ -178,6 +184,7 @@ typedef enum
     STATE_T,
 
     /* for sheet?.xml */
+    STATE_COLS,
     STATE_SHEETDATA,
     STATE_ROW,
     STATE_CELL,
@@ -213,7 +220,7 @@ class OGRXLSXDataSource final : public GDALDataset
     bool bUpdated;
 
     int nLayers;
-    OGRLayer **papoLayers;
+    OGRXLSXLayer **papoLayers;
     std::map<CPLString, CPLString> oMapRelsIdToTarget;
     std::set<std::string> m_oSetSheetId;
 
@@ -236,6 +243,7 @@ class OGRXLSXDataSource final : public GDALDataset
     int nCurCol;
 
     OGRXLSXLayer *poCurLayer;
+    std::string m_osCols{};
 
     int nStackDepth;
     int nDepth;
@@ -257,6 +265,8 @@ class OGRXLSXDataSource final : public GDALDataset
     void startElementDefault(const char *pszName, const char **ppszAttr);
     void startElementTable(const char *pszName, const char **ppszAttr);
     void endElementTable(const char *pszName);
+    void startElementCols(const char *pszName, const char **ppszAttr);
+    void endElementCols(const char *pszName);
     void startElementRow(const char *pszName, const char **ppszAttr);
     void endElementRow(const char *pszName);
     void startElementCell(const char *pszName, const char **ppszAttr);

--- a/ogr/ogrsf_frmts/xlsx/ogrxlsxdatasource.cpp
+++ b/ogr/ogrsf_frmts/xlsx/ogrxlsxdatasource.cpp
@@ -308,7 +308,11 @@ int OGRXLSXDataSource::Open(const char *pszFilename,
     /* Remove empty layers at the end, which tend to be there */
     while (nLayers > 1)
     {
-        if (papoLayers[nLayers - 1]->GetFeatureCount() == 0)
+        papoLayers[nLayers - 1]->Init();
+        if ((papoLayers[nLayers - 1]->m_osCols.empty() ||
+             papoLayers[nLayers - 1]->m_osCols.find("max=\"1025\" min=\"1\"") !=
+                 std::string::npos) &&
+            papoLayers[nLayers - 1]->GetFeatureCount(false) == 0)
         {
             delete papoLayers[nLayers - 1];
             nLayers--;
@@ -357,6 +361,9 @@ void OGRXLSXDataSource::startElementCbk(const char *pszNameIn,
         case STATE_DEFAULT:
             startElementDefault(pszNameIn, ppszAttr);
             break;
+        case STATE_COLS:
+            startElementCols(pszNameIn, ppszAttr);
+            break;
         case STATE_SHEETDATA:
             startElementTable(pszNameIn, ppszAttr);
             break;
@@ -397,6 +404,9 @@ void OGRXLSXDataSource::endElementCbk(const char *pszNameIn)
             break;
         case STATE_SHEETDATA:
             endElementTable(pszNameIn);
+            break;
+        case STATE_COLS:
+            endElementCols(pszNameIn);
             break;
         case STATE_ROW:
             endElementRow(pszNameIn);
@@ -663,13 +673,51 @@ void OGRXLSXDataSource::DetectHeaderLine()
 void OGRXLSXDataSource::startElementDefault(const char *pszNameIn,
                                             CPL_UNUSED const char **ppszAttr)
 {
-    if (strcmp(pszNameIn, "sheetData") == 0)
+    if (strcmp(pszNameIn, "cols") == 0)
+    {
+        PushState(STATE_COLS);
+        m_osCols = "<cols>";
+    }
+    else if (strcmp(pszNameIn, "sheetData") == 0)
     {
         apoFirstLineValues.resize(0);
         apoFirstLineTypes.resize(0);
         nCurLine = 0;
         PushState(STATE_SHEETDATA);
     }
+}
+
+/************************************************************************/
+/*                          startElementCols()                          */
+/************************************************************************/
+
+void OGRXLSXDataSource::startElementCols(const char *pszNameIn,
+                                         const char **ppszAttr)
+{
+    m_osCols.append("<");
+    m_osCols.append(pszNameIn);
+    for (const char **iter = ppszAttr; iter && iter[0] && iter[1]; iter += 2)
+    {
+        m_osCols.append(" ");
+        m_osCols.append(iter[0]);
+        m_osCols.append("=\"");
+        char *pszXML = OGRGetXML_UTF8_EscapedString(iter[1]);
+        m_osCols.append(pszXML);
+        CPLFree(pszXML);
+        m_osCols.append("\"");
+    }
+    m_osCols.append(">");
+}
+
+/************************************************************************/
+/*                            endElementCell()                          */
+/************************************************************************/
+
+void OGRXLSXDataSource::endElementCols(const char *pszNameIn)
+{
+    m_osCols.append("</");
+    m_osCols.append(pszNameIn);
+    m_osCols.append(">");
 }
 
 /************************************************************************/
@@ -734,7 +782,7 @@ void OGRXLSXDataSource::endElementTable(CPL_UNUSED const char *pszNameIn)
 
         if (nCurLine == 0 || (nCurLine == 1 && apoFirstLineValues.empty()))
         {
-            /* We could remove empty sheet, but too late now */
+            // no rows
         }
         else if (nCurLine == 1)
         {
@@ -1147,6 +1195,7 @@ void OGRXLSXDataSource::BuildLayer(OGRXLSXLayer *poLayer)
     const bool bUpdatedBackup = bUpdated;
 
     oParser = OGRCreateExpatXMLParser();
+    m_osCols.clear();
     XML_SetElementHandler(oParser, OGRXLSX::startElementCbk,
                           OGRXLSX::endElementCbk);
     XML_SetCharacterDataHandler(oParser, OGRXLSX::dataHandlerCbk);
@@ -1195,6 +1244,7 @@ void OGRXLSXDataSource::BuildLayer(OGRXLSXLayer *poLayer)
     VSIFCloseL(fp);
 
     bUpdated = bUpdatedBackup;
+    poLayer->m_osCols = m_osCols;
 }
 
 /************************************************************************/
@@ -1517,8 +1567,8 @@ void OGRXLSXDataSource::startElementWBCbk(const char *pszNameIn,
                 // or relative to the /xl subdirectory
                 osFilename = osPrefixedFilename + CPLString("/xl/") + osTarget;
             }
-            papoLayers = (OGRLayer **)CPLRealloc(
-                papoLayers, (nLayers + 1) * sizeof(OGRLayer *));
+            papoLayers = (OGRXLSXLayer **)CPLRealloc(
+                papoLayers, (nLayers + 1) * sizeof(OGRXLSXLayer *));
             papoLayers[nLayers++] =
                 new OGRXLSXLayer(this, osFilename, pszSheetName);
         }
@@ -1789,14 +1839,14 @@ OGRLayer *OGRXLSXDataSource::ICreateLayer(const char *pszLayerName,
     /* -------------------------------------------------------------------- */
     /*      Create the layer object.                                        */
     /* -------------------------------------------------------------------- */
-    OGRLayer *poLayer =
+    OGRXLSXLayer *poLayer =
         new OGRXLSXLayer(this,
                          CPLSPrintf("/vsizip/%s/xl/worksheets/sheet%d.xml",
                                     pszName, nLayers + 1),
                          pszLayerName, TRUE);
 
-    papoLayers =
-        (OGRLayer **)CPLRealloc(papoLayers, (nLayers + 1) * sizeof(OGRLayer *));
+    papoLayers = (OGRXLSXLayer **)CPLRealloc(
+        papoLayers, (nLayers + 1) * sizeof(OGRXLSXLayer *));
     papoLayers[nLayers] = poLayer;
     nLayers++;
 
@@ -2069,7 +2119,7 @@ static CPLString BuildColString(int nCol)
 /*                             WriteLayer()                             */
 /************************************************************************/
 
-static bool WriteLayer(const char *pszName, OGRLayer *poLayer, int iLayer,
+static bool WriteLayer(const char *pszName, OGRXLSXLayer *poLayer, int iLayer,
                        std::map<std::string, int> &oStringMap,
                        std::vector<std::string> &oStringList)
 {
@@ -2100,27 +2150,33 @@ static bool WriteLayer(const char *pszName, OGRLayer *poLayer, int iLayer,
     bool bHasHeaders = false;
     int iRow = 1;
 
-    VSIFPrintfL(fp, "<cols>\n");
-    for (int j = 0; j < poFDefn->GetFieldCount(); j++)
+    const int nFields = poFDefn->GetFieldCount();
+    if (nFields > 0)
     {
-        int nWidth = 15;
-        if (poFDefn->GetFieldDefn(j)->GetType() == OFTDateTime)
-            nWidth = 29;
-        VSIFPrintfL(fp, "<col min=\"%d\" max=\"%d\" width=\"%d\"/>\n", j + 1,
-                    1024, nWidth);
+        VSIFPrintfL(fp, "<cols>\n");
+        for (int j = 0; j < nFields; j++)
+        {
+            int nWidth = 15;
+            if (poFDefn->GetFieldDefn(j)->GetType() == OFTDateTime)
+                nWidth = 29;
+            VSIFPrintfL(fp, "<col min=\"%d\" max=\"%d\" width=\"%d\"/>\n",
+                        j + 1, 1024, nWidth);
 
-        if (strcmp(poFDefn->GetFieldDefn(j)->GetNameRef(),
-                   CPLSPrintf("Field%d", j + 1)) != 0)
-            bHasHeaders = true;
+            if (strcmp(poFDefn->GetFieldDefn(j)->GetNameRef(),
+                       CPLSPrintf("Field%d", j + 1)) != 0)
+                bHasHeaders = true;
+        }
+        VSIFPrintfL(fp, "</cols>\n");
     }
-    VSIFPrintfL(fp, "</cols>\n");
+    else if (!poLayer->GetCols().empty())
+        VSIFPrintfL(fp, "%s\n", poLayer->GetCols().c_str());
 
     VSIFPrintfL(fp, "<sheetData>\n");
 
     if (bHasHeaders && poFeature != nullptr)
     {
         VSIFPrintfL(fp, "<row r=\"%d\">\n", iRow);
-        for (int j = 0; j < poFDefn->GetFieldCount(); j++)
+        for (int j = 0; j < nFields; j++)
         {
             const char *pszVal = poFDefn->GetFieldDefn(j)->GetNameRef();
             std::map<std::string, int>::iterator oIter =
@@ -2149,7 +2205,7 @@ static bool WriteLayer(const char *pszName, OGRLayer *poLayer, int iLayer,
     while (poFeature != nullptr)
     {
         VSIFPrintfL(fp, "<row r=\"%d\">\n", iRow);
-        for (int j = 0; j < poFeature->GetFieldCount(); j++)
+        for (int j = 0; j < nFields; j++)
         {
             if (poFeature->IsFieldSetAndNotNull(j))
             {
@@ -2475,7 +2531,7 @@ CPLErr OGRXLSXDataSource::FlushCache(bool /* bAtClosing */)
     // VSIMkdir(CPLSPrintf("/vsizip/%s/xl/worksheets", pszName),0755);
     for (int i = 0; i < nLayers; i++)
     {
-        bOK &= WriteLayer(pszName, GetLayer(i), i, oStringMap, oStringList);
+        bOK &= WriteLayer(pszName, papoLayers[i], i, oStringMap, oStringList);
     }
 
     bOK &= WriteSharedStrings(pszName, oStringMap, oStringList);


### PR DESCRIPTION
Backport #8484
 **Authored by:** @rouault