### PR TITLE
Add a OGRLayer::WriteArrowBatch method

### DIFF
--- a/.github/workflows/alpine/Dockerfile.ci
+++ b/.github/workflows/alpine/Dockerfile.ci
@@ -21,6 +21,8 @@ RUN apk add \
     qhull-dev \
     unixodbc-dev \
     libpq-dev \
+    apache-arrow-dev \
+    py3-pyarrow py3-pyarrow-pyc \
     libxml2-dev \
     podofo-dev
 

--- a/.github/workflows/ubuntu_20.04/Dockerfile.ci
+++ b/.github/workflows/ubuntu_20.04/Dockerfile.ci
@@ -215,13 +215,14 @@ RUN mkdir odbc-cpp-wrapper \
 
 # Arrow
 # We should perhaps pin the pyarrow version to the one of libarrow...
+# Actually not: the libarrow embedded in pyarrow 13 doesn't work with libarrow 13 linked from GDAL...
 RUN wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb \
  && dpkg --install apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb \
  && apt-get update \
  && apt-get install -y -V libarrow-dev libparquet-dev libarrow-dataset-dev \
  && rm ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb \
  && rm -rf /var/lib/apt/lists/* \
- && python3 -m pip install pyarrow
+ && python3 -m pip install pyarrow==11.0.0
 
 # Build libQB3
 # Used by the MRF driver

--- a/.github/workflows/ubuntu_20.04/Dockerfile.ci
+++ b/.github/workflows/ubuntu_20.04/Dockerfile.ci
@@ -214,12 +214,14 @@ RUN mkdir odbc-cpp-wrapper \
   && rm -rf odbc-cpp-wrapper
 
 # Arrow
+# We should perhaps pin the pyarrow version to the one of libarrow...
 RUN wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb \
  && dpkg --install apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb \
  && apt-get update \
  && apt-get install -y -V libarrow-dev libparquet-dev libarrow-dataset-dev \
  && rm ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb \
- && rm -rf /var/lib/apt/lists/*
+ && rm -rf /var/lib/apt/lists/* \
+ && python3 -m pip install pyarrow
 
 # Build libQB3
 # Used by the MRF driver

--- a/autotest/cpp/CMakeLists.txt
+++ b/autotest/cpp/CMakeLists.txt
@@ -85,6 +85,7 @@ add_executable(
   test_ogr_geos.cpp
   test_ogr_shape.cpp
   test_ogr_swq.cpp
+  test_ogr_wkb.cpp
   test_osr.cpp
   test_osr_pci.cpp
   test_osr_ct.cpp

--- a/autotest/cpp/test_ogr.cpp
+++ b/autotest/cpp/test_ogr.cpp
@@ -2388,7 +2388,7 @@ TEST_F(test_ogr, GDALDatasetSetQueryLoggerFunc)
     ASSERT_TRUE(insertEntry != queryLog.end());
     ASSERT_EQ(
         insertEntry->sql.find(
-            R"sql(INSERT INTO "poly" ( "geom", "AREA", "EAS_ID", "PRFEDEA") VALUES (NULL, NULL, '123', NULL))sql",
+            R"sql(INSERT INTO "poly" ( "geom", "AREA", "EAS_ID", "PRFEDEA") VALUES (NULL, NULL, 123, NULL))sql",
             0),
         0);
 #endif

--- a/autotest/cpp/test_ogr_wkb.cpp
+++ b/autotest/cpp/test_ogr_wkb.cpp
@@ -1,0 +1,112 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+// Project:  C++ Test Suite for GDAL/OGR
+// Purpose:  Test ogr_wkb.h
+// Author:   Even Rouault <even.rouault at spatialys.com>
+//
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2023, Even Rouault <even.rouault at spatialys.com>
+/*
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "gdal_unit_test.h"
+
+#include "ogr_geometry.h"
+#include "ogr_wkb.h"
+
+#include "gtest_include.h"
+
+namespace
+{
+
+struct test_ogr_wkb : public ::testing::Test
+{
+};
+
+}  // namespace
+
+class OGRWKBFixupCounterClockWiseExternalRingFixture
+    : public test_ogr_wkb,
+      public ::testing::WithParamInterface<
+          std::tuple<const char *, const char *, const char *>>
+{
+  public:
+    static std::vector<std::tuple<const char *, const char *, const char *>>
+    GetTupleValues()
+    {
+        return {
+            std::make_tuple("MULTIPOLYGON (((0 1,0 0,1 1,0 1),(0.2 0.3,0.2 "
+                            "0.8,0.7 0.8,0.2 0.3)))",
+                            "MULTIPOLYGON (((0 1,0 0,1 1,0 1),(0.2 0.3,0.2 "
+                            "0.8,0.7 0.8,0.2 0.3)))",
+                            "MULTIPOLYGON_CCW"),
+            std::make_tuple("MULTIPOLYGON (((1 1,0 0,0 1,1 1),(0.2 0.3,0.7 "
+                            "0.8,0.2 0.8,0.2 0.3)))",
+                            "MULTIPOLYGON (((1 1,0 1,0 0,1 1),(0.2 0.3,0.2 "
+                            "0.8,0.7 0.8,0.2 0.3)))",
+                            "MULTIPOLYGON_CW"),
+            std::make_tuple(
+                "MULTIPOLYGON Z (((0 0 10,0 1 10,1 1 10,0 0 10),(0.2 0.3 "
+                "10,0.7 0.8 10,0.2 0.8 10,0.2 0.3 10)))",
+                "MULTIPOLYGON Z (((0 0 10,1 1 10,0 1 10,0 0 10),(0.2 0.3 "
+                "10,0.2 0.8 10,0.7 0.8 10,0.2 0.3 10)))",
+                "MULTIPOLYGON_CW_3D"),
+            std::make_tuple("MULTIPOLYGON (((0 0,0 0,1 1,1 1,0 1,0 1,0 0)))",
+                            "MULTIPOLYGON (((0 0,0 0,1 1,1 1,0 1,0 1,0 0)))",
+                            "MULTIPOLYGON_CCW_REPEATED_POINTS"),
+            std::make_tuple("MULTIPOLYGON (((0 0,0 0,0 1,0 1,1 1,1 1,0 0)))",
+                            "MULTIPOLYGON (((0 0,1 1,1 1,0 1,0 1,0 0,0 0)))",
+                            "MULTIPOLYGON_CW_REPEATED_POINTS"),
+            std::make_tuple("MULTIPOLYGON EMPTY", "MULTIPOLYGON EMPTY",
+                            "MULTIPOLYGON_EMPTY"),
+            std::make_tuple("POINT (1 2)", "POINT (1 2)", "POINT"),
+        };
+    }
+};
+
+TEST_P(OGRWKBFixupCounterClockWiseExternalRingFixture, test)
+{
+    const char *pszInput = std::get<0>(GetParam());
+    const char *pszExpected = std::get<1>(GetParam());
+
+    OGRGeometry *poGeom = nullptr;
+    OGRGeometryFactory::createFromWkt(pszInput, nullptr, &poGeom);
+    ASSERT_TRUE(poGeom != nullptr);
+    std::vector<GByte> abyWkb(poGeom->WkbSize());
+    poGeom->exportToWkb(wkbNDR, abyWkb.data());
+    OGRWKBFixupCounterClockWiseExternalRing(abyWkb.data(), abyWkb.size());
+    delete poGeom;
+    poGeom = nullptr;
+    OGRGeometryFactory::createFromWkb(abyWkb.data(), nullptr, &poGeom);
+    ASSERT_TRUE(poGeom != nullptr);
+    char *pszWKT = nullptr;
+    poGeom->exportToWkt(&pszWKT, wkbVariantIso);
+    EXPECT_STREQ(pszWKT, pszExpected);
+    CPLFree(pszWKT);
+    delete poGeom;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    test_ogr_wkb, OGRWKBFixupCounterClockWiseExternalRingFixture,
+    ::testing::ValuesIn(
+        OGRWKBFixupCounterClockWiseExternalRingFixture::GetTupleValues()),
+    [](const ::testing::TestParamInfo<
+        OGRWKBFixupCounterClockWiseExternalRingFixture::ParamType> &l_info)
+    { return std::get<2>(l_info.param); });

--- a/autotest/ogr/ogr_feature.py
+++ b/autotest/ogr/ogr_feature.py
@@ -975,3 +975,46 @@ def test_ogr_feature_repr():
     out = feat.__repr__()
 
     assert out.startswith("OGRFeature(src):")
+
+
+def test_ogr_feature_list_to_json():
+
+    src_feat_def = ogr.FeatureDefn("src")
+
+    field_def = ogr.FieldDefn("field_integerlist", ogr.OFTIntegerList)
+    src_feat_def.AddFieldDefn(field_def)
+
+    field_def = ogr.FieldDefn("field_booleanlist", ogr.OFTIntegerList)
+    field_def.SetSubType(ogr.OFSTBoolean)
+    src_feat_def.AddFieldDefn(field_def)
+
+    field_def = ogr.FieldDefn("field_integer64list", ogr.OFTInteger64List)
+    src_feat_def.AddFieldDefn(field_def)
+
+    field_def = ogr.FieldDefn("field_reallist", ogr.OFTRealList)
+    src_feat_def.AddFieldDefn(field_def)
+
+    field_def = ogr.FieldDefn("field_stringlist", ogr.OFTStringList)
+    src_feat_def.AddFieldDefn(field_def)
+
+    dst_feat_def = ogr.FeatureDefn("dst")
+    for i in range(src_feat_def.GetFieldCount()):
+        field_def = ogr.FieldDefn(src_feat_def.GetFieldDefn(i).GetName(), ogr.OFTString)
+        field_def.SetSubType(ogr.OFSTJSON)
+        dst_feat_def.AddFieldDefn(field_def)
+
+    src_f = ogr.Feature(src_feat_def)
+    src_f["field_integerlist"] = [1, 2]
+    src_f["field_booleanlist"] = [True, False]
+    src_f["field_integer64list"] = [123456789012345, 2]
+    src_f["field_reallist"] = [1.5, 2.5]
+    src_f["field_stringlist"] = ["a", "b"]
+
+    dst_f = ogr.Feature(dst_feat_def)
+    dst_f.SetFrom(src_f)
+
+    assert dst_f["field_integerlist"] == "[ 1, 2 ]"
+    assert dst_f["field_booleanlist"] == "[ true, false ]"
+    assert dst_f["field_integer64list"] == "[ 123456789012345, 2 ]"
+    assert dst_f["field_reallist"] == "[ 1.5, 2.5 ]"
+    assert dst_f["field_stringlist"] == '[ "a", "b" ]'

--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -9311,3 +9311,110 @@ def test_ogr_gpkg_write_flushcache(tmp_vsimem):
     assert ds2.GetLayer(0).GetFeatureCount() == 2
     assert ds2.GetLayer(1).GetFeatureCount() == 1
     ds2 = None
+
+
+###############################################################################
+# Test WriteArrowBatch() with USE_FALLBACK_TYPES=YES
+
+
+@gdaltest.enable_exceptions()
+def test_ogr_gpkg_write_arrow_fallback_types(tmp_vsimem):
+
+    src_ds = ogr.GetDriverByName("Memory").CreateDataSource("")
+    src_lyr = src_ds.CreateLayer("test")
+    src_lyr.CreateField(ogr.FieldDefn("string", ogr.OFTString))
+    src_lyr.CreateField(ogr.FieldDefn("int", ogr.OFTInteger))
+    src_lyr.CreateField(ogr.FieldDefn("int64", ogr.OFTInteger64))
+    src_lyr.CreateField(ogr.FieldDefn("real", ogr.OFTReal))
+    src_lyr.CreateField(ogr.FieldDefn("date", ogr.OFTDate))
+    src_lyr.CreateField(ogr.FieldDefn("time", ogr.OFTTime))
+    src_lyr.CreateField(ogr.FieldDefn("datetime", ogr.OFTDateTime))
+    src_lyr.CreateField(ogr.FieldDefn("binary", ogr.OFTBinary))
+    src_lyr.CreateField(ogr.FieldDefn("stringlist", ogr.OFTStringList))
+    src_lyr.CreateField(ogr.FieldDefn("intlist", ogr.OFTIntegerList))
+    src_lyr.CreateField(ogr.FieldDefn("int64list", ogr.OFTInteger64List))
+    src_lyr.CreateField(ogr.FieldDefn("reallist", ogr.OFTRealList))
+    f = ogr.Feature(src_lyr.GetLayerDefn())
+    f["string"] = "foo"
+    f["int"] = 123
+    f["int64"] = 12345678901234
+    f["real"] = 1.5
+    f["date"] = "2023/10/06"
+    f["time"] = "12:34:56"
+    f["datetime"] = "2023/10/06 19:43:00"
+    f.SetField("binary", b"\x01\x23\x46\x57\x89\xAB\xCD\xEF")
+    f["stringlist"] = ["foo", "bar"]
+    f["intlist"] = [1, 2]
+    f["int64list"] = [12345678901234, 2]
+    f["reallist"] = [1.5, 2.5]
+    f.SetFID(10)
+    f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (1 2)"))
+    src_lyr.CreateFeature(f)
+
+    filename = tmp_vsimem / "test_ogr_gpkg_write_arrow_fallback_types.gpkg"
+    ds = gdal.GetDriverByName("GPKG").Create(filename, 0, 0, 0, gdal.GDT_Unknown)
+    lyr = ds.CreateLayer("test")
+
+    stream = src_lyr.GetArrowStream()
+    schema = stream.GetSchema()
+
+    success, error_msg = lyr.IsArrowSchemaSupported(schema)
+    assert not success
+    assert (
+        "Field stringlist would require using OGR type StringList but the driver does not support it. You may set the USE_FALLBACK_TYPES=YES option to allow use of a fallback type"
+        in error_msg
+    )
+
+    success, error_msg = lyr.IsArrowSchemaSupported(schema, ["USE_FALLBACK_TYPES=YES"])
+    assert success
+
+    for i in range(schema.GetChildrenCount()):
+        if schema.GetChild(i).GetName() in (
+            "stringlist",
+            "intlist",
+            "int64list",
+            "reallist",
+        ):
+            with pytest.raises(Exception):
+                lyr.CreateFieldFromArrowSchema(schema.GetChild(i))
+
+    for i in range(schema.GetChildrenCount()):
+        if schema.GetChild(i).GetName() not in ("wkb_geometry", "OGC_FID"):
+            lyr.CreateFieldFromArrowSchema(
+                schema.GetChild(i), ["USE_FALLBACK_TYPES=YES"]
+            )
+
+    while True:
+        array = stream.GetNextRecordBatch()
+        if array is None:
+            break
+        with pytest.raises(
+            Exception,
+            match="For field time, OGR field type is String whereas Arrow type implies Time",
+        ):
+            lyr.WriteArrowBatch(schema, array, ["FID=OGC_FID"])
+
+    del stream
+    stream = src_lyr.GetArrowStream()
+    schema = stream.GetSchema()
+    while True:
+        array = stream.GetNextRecordBatch()
+        if array is None:
+            break
+        lyr.WriteArrowBatch(schema, array, ["FID=OGC_FID", "USE_FALLBACK_TYPES=YES"])
+
+    f = lyr.GetNextFeature()
+    assert f.GetFID() == 10
+    assert f["string"] == "foo"
+    assert f["int"] == 123
+    assert f["int64"] == 12345678901234
+    assert f["real"] == 1.5
+    assert f["date"] == "2023/10/06"
+    assert f["time"] == "12:34:56"
+    assert f["binary"] == "0123465789ABCDEF"
+    assert f["datetime"] == "2023/10/06 19:43:00"
+    assert f["stringlist"] == '[ "foo", "bar" ]'
+    assert f["intlist"] == "[ 1, 2 ]"
+    assert f["int64list"] == "[ 12345678901234, 2 ]"
+    assert f["reallist"] == "[ 1.5, 2.5 ]"
+    assert f.GetGeometryRef().ExportToIsoWkt() == "POINT (1 2)"

--- a/autotest/ogr/ogr_mem.py
+++ b/autotest/ogr/ogr_mem.py
@@ -1555,6 +1555,39 @@ def test_ogr_mem_write_pyarrow():
     decimal128 = pa.array([d, d, d, d, d], pa.decimal128(5, 2))
     decimal256 = pa.array([d, d, d, d, d], pa.decimal256(5, 2))
 
+    list_decimal128 = pa.array(
+        [
+            [],
+            [decimal.Decimal("123.45")],
+            [decimal.Decimal("123.45"), decimal.Decimal("-123.45")],
+            None,
+            [decimal.Decimal("123.45"), decimal.Decimal("234.56")],
+        ],
+        type=pa.list_(pa.decimal128(5, 2)),
+    )
+
+    large_list_decimal128 = pa.array(
+        [
+            [],
+            [decimal.Decimal("123.45")],
+            [decimal.Decimal("123.45"), decimal.Decimal("-123.45")],
+            None,
+            [decimal.Decimal("123.45"), decimal.Decimal("234.56")],
+        ],
+        type=pa.large_list(pa.decimal128(5, 2)),
+    )
+
+    fixed_size_list_decimal128 = pa.array(
+        [
+            [decimal.Decimal("123.45"), decimal.Decimal("-123.45")],
+            [decimal.Decimal("-123.45"), decimal.Decimal("123.45")],
+            None,
+            [decimal.Decimal("234.56"), decimal.Decimal("-234.56")],
+            [decimal.Decimal("345.67"), decimal.Decimal("-345.67")],
+        ],
+        type=pa.list_(pa.decimal128(5, 2), 2),
+    )
+
     import struct
 
     wkb_geometry = pa.array(
@@ -1636,6 +1669,9 @@ def test_ogr_mem_write_pyarrow():
         "dict_list_uint8",
         "decimal128",
         "decimal256",
+        "list_decimal128",
+        "large_list_decimal128",
+        "fixed_size_list_decimal128",
         "wkb_geometry",
         "fid",
     ]
@@ -1743,6 +1779,9 @@ def test_ogr_mem_write_pyarrow():
   dict_list_uint8 (IntegerList(Int16)) = (2:2,3)
   decimal128 (Real) = 123.45
   decimal256 (Real) = 123.45
+  list_decimal128 (RealList) = (2: 123.45, 234.56)
+  large_list_decimal128 (RealList) = (2: 123.45, 234.56)
+  fixed_size_list_decimal128 (RealList) = (2: 345.67,-345.67)
   POINT (4 2)
 
 """

--- a/autotest/ogr/ogr_mem.py
+++ b/autotest/ogr/ogr_mem.py
@@ -1175,6 +1175,7 @@ def test_ogr_mem_write_arrow():
 @gdaltest.enable_exceptions()
 def test_ogr_mem_write_pyarrow():
     pa = pytest.importorskip("pyarrow")
+    np = pytest.importorskip("numpy")  # for float16
 
     ds = ogr.GetDriverByName("Memory").CreateDataSource("")
     lyr = ds.CreateLayer("test")
@@ -1203,6 +1204,9 @@ def test_ogr_mem_write_pyarrow():
     int64 = pa.array(
         [None if i == 2 else -200000000000 + i * 100000000000 for i in range(5)],
         type=pa.int64(),
+    )
+    float16 = pa.array(
+        [None if i == 2 else np.float16(1.5 + i) for i in range(5)], type=pa.float16()
     )
     float32 = pa.array(
         [None if i == 2 else 1.5 + i for i in range(5)], type=pa.float32()
@@ -1311,6 +1315,18 @@ def test_ogr_mem_write_pyarrow():
             for i in range(5)
         ],
         type=pa.list_(pa.int64()),
+    )
+    list_float16 = pa.array(
+        [
+            None
+            if i == 2
+            else [
+                None if j == 0 else np.float16(0.5 + j + i * (i - 1) // 2)
+                for j in range(i)
+            ]
+            for i in range(5)
+        ],
+        type=pa.list_(pa.float16()),
     )
     list_float32 = pa.array(
         [
@@ -1433,6 +1449,18 @@ def test_ogr_mem_write_pyarrow():
         ],
         type=pa.large_list(pa.int64()),
     )
+    large_list_float16 = pa.array(
+        [
+            None
+            if i == 2
+            else [
+                None if j == 0 else np.float16(0.5 + j + i * (i - 1) // 2)
+                for j in range(i)
+            ]
+            for i in range(5)
+        ],
+        type=pa.large_list(pa.float16()),
+    )
     large_list_float32 = pa.array(
         [
             None
@@ -1501,6 +1529,16 @@ def test_ogr_mem_write_pyarrow():
     )
     fixed_size_list_int64 = pa.array(
         [[0, 1], [2, 3], [4, 5], [6, 7], [8, 9]], type=pa.list_(pa.int64(), 2)
+    )
+    fixed_size_list_float16 = pa.array(
+        [
+            [np.float16(0), None],
+            [np.float16(2), np.float16(3)],
+            [np.float16(4), np.float16(5)],
+            [np.float16(6), np.float16(7)],
+            [np.float16(8), np.float16(9)],
+        ],
+        type=pa.list_(pa.float16(), 2),
     )
     fixed_size_list_float32 = pa.array(
         [[0, None], [2, 3], [4, 5], [6, 7], [8, 9]], type=pa.list_(pa.float32(), 2)
@@ -1588,6 +1626,318 @@ def test_ogr_mem_write_pyarrow():
         type=pa.list_(pa.decimal128(5, 2), 2),
     )
 
+    map_boolean = pa.array(
+        [[("z", False)], None, [], [], [("x", None), ("yz", True)]],
+        type=pa.map_(pa.string(), pa.bool_()),
+    )
+
+    map_uint8 = pa.array(
+        [[("z", 2)], None, [], [], [("x", None), ("yz", 4)]],
+        type=pa.map_(pa.string(), pa.uint8()),
+    )
+
+    map_int8 = pa.array(
+        [[("z", -2)], None, [], [], [("x", None), ("yz", -4)]],
+        type=pa.map_(pa.string(), pa.int8()),
+    )
+
+    map_uint16 = pa.array(
+        [[("z", 2)], None, [], [], [("x", None), ("yz", 4)]],
+        type=pa.map_(pa.string(), pa.uint16()),
+    )
+
+    map_int16 = pa.array(
+        [[("z", -2)], None, [], [], [("x", None), ("yz", -4)]],
+        type=pa.map_(pa.string(), pa.int16()),
+    )
+
+    map_uint32 = pa.array(
+        [[("z", 2)], None, [], [], [("x", None), ("yz", 4)]],
+        type=pa.map_(pa.string(), pa.uint32()),
+    )
+
+    map_int32 = pa.array(
+        [[("z", -2)], None, [], [], [("x", None), ("yz", -4)]],
+        type=pa.map_(pa.string(), pa.int32()),
+    )
+
+    map_uint64 = pa.array(
+        [[("z", 2)], None, [], [], [("x", None), ("yz", 4)]],
+        type=pa.map_(pa.string(), pa.uint64()),
+    )
+
+    map_int64 = pa.array(
+        [[("z", -2)], None, [], [], [("x", None), ("yz", -4)]],
+        type=pa.map_(pa.string(), pa.int64()),
+    )
+
+    map_float16 = pa.array(
+        [[("z", np.float16(2))], None, [], [], [("x", None), ("yz", np.float16(4))]],
+        type=pa.map_(pa.string(), pa.float16()),
+    )
+
+    map_float32 = pa.array(
+        [[("z", 2)], None, [], [], [("x", None), ("yz", 4)]],
+        type=pa.map_(pa.string(), pa.float32()),
+    )
+
+    map_float64 = pa.array(
+        [[("z", 2)], None, [], [], [("x", None), ("yz", 4)]],
+        type=pa.map_(pa.string(), pa.float64()),
+    )
+
+    map_string = pa.array(
+        [[("z", "foo")], None, [], [], [("x", None), ("yz", "bar")]],
+        type=pa.map_(pa.string(), pa.string()),
+    )
+
+    map_large_string = pa.array(
+        [[("z", "foo")], None, [], [], [("x", None), ("yz", "bar")]],
+        type=pa.map_(pa.string(), pa.large_string()),
+    )
+
+    map_binary = pa.array(
+        [
+            [("z", b"\x01\x01\x00\x00\x00")],
+            None,
+            [],
+            [],
+            [("x", None), ("yz", b"\x00\x00\x01\x00\x00")],
+        ],
+        type=pa.map_(pa.string(), pa.binary()),
+    )
+
+    map_large_binary = pa.array(
+        [
+            [("z", b"\x01\x01\x00\x00\x00")],
+            None,
+            [],
+            [],
+            [("x", None), ("yz", b"\x00\x00\x01\x00\x00")],
+        ],
+        type=pa.map_(pa.string(), pa.large_binary()),
+    )
+
+    map_fixed_size_binary = pa.array(
+        [
+            [("z", b"\x01\x01\x00\x00\x00")],
+            None,
+            [],
+            [],
+            [("x", None), ("yz", b"\x00\x00\x01\x00\x00")],
+        ],
+        type=pa.map_(pa.string(), pa.binary(5)),
+    )
+
+    map_decimal = pa.array(
+        [[("z", d)], None, [], [], [("x", None), ("yz", d)]],
+        type=pa.map_(pa.string(), pa.decimal128(5, 2)),
+    )
+
+    map_structure = pa.array(
+        [None, None, [], [], [("x", None), ("y", {}), ("z", {"f1": "foo", "f2": 2})]],
+        type=pa.map_(pa.string(), pa.struct([("f1", pa.string()), ("f2", pa.int32())])),
+    )
+
+    map_map_string = pa.array(
+        [
+            None,
+            [("f", [("g", "h")])],
+            None,
+            None,
+            [("a", [("b", "c"), ("d", None)]), ("e", None)],
+        ],
+        type=pa.map_(pa.string(), pa.map_(pa.string(), pa.string())),
+    )
+
+    map_list_bool = pa.array(
+        [
+            [("x", [True]), ("y", [False, True])],
+            [("z", [])],
+            None,
+            [],
+            [("w", [True, False]), ("x", None), ("z", [False, None, True])],
+        ],
+        type=pa.map_(pa.string(), pa.list_(pa.bool_())),
+    )
+
+    map_list_uint8 = pa.array(
+        [
+            [("x", [2]), ("y", [3, 4])],
+            [("z", [])],
+            None,
+            [],
+            [("w", [5, 6]), ("x", None), ("z", [7, None, 8])],
+        ],
+        type=pa.map_(pa.string(), pa.list_(pa.uint8())),
+    )
+
+    map_list_int8 = pa.array(
+        [
+            [("x", [2]), ("y", [3, 4])],
+            [("z", [])],
+            None,
+            [],
+            [("w", [5, 6]), ("x", None), ("z", [7, None, -8])],
+        ],
+        type=pa.map_(pa.string(), pa.list_(pa.int8())),
+    )
+
+    map_list_uint16 = pa.array(
+        [
+            [("x", [2]), ("y", [3, 4])],
+            [("z", [])],
+            None,
+            [],
+            [("w", [5, 6]), ("x", None), ("z", [7, None, 8])],
+        ],
+        type=pa.map_(pa.string(), pa.list_(pa.uint16())),
+    )
+
+    map_list_int16 = pa.array(
+        [
+            [("x", [2]), ("y", [3, 4])],
+            [("z", [])],
+            None,
+            [],
+            [("w", [5, 6]), ("x", None), ("z", [7, None, -8])],
+        ],
+        type=pa.map_(pa.string(), pa.list_(pa.int16())),
+    )
+
+    map_list_uint32 = pa.array(
+        [
+            [("x", [2]), ("y", [3, 4])],
+            [("z", [])],
+            None,
+            [],
+            [("w", [5, 6]), ("x", None), ("z", [7, None, 8])],
+        ],
+        type=pa.map_(pa.string(), pa.list_(pa.uint32())),
+    )
+
+    map_list_int32 = pa.array(
+        [
+            [("x", [2]), ("y", [3, 4])],
+            [("z", [])],
+            None,
+            [],
+            [("w", [5, 6]), ("x", None), ("z", [7, None, -8])],
+        ],
+        type=pa.map_(pa.string(), pa.list_(pa.int32())),
+    )
+
+    map_list_uint64 = pa.array(
+        [
+            [("x", [2]), ("y", [3, 4])],
+            [("z", [])],
+            None,
+            [],
+            [("w", [5, 6]), ("x", None), ("z", [7, None, 8])],
+        ],
+        type=pa.map_(pa.string(), pa.list_(pa.uint64())),
+    )
+
+    map_list_int64 = pa.array(
+        [
+            [("x", [2]), ("y", [3, 4])],
+            [("z", [])],
+            None,
+            [],
+            [("w", [5, 6]), ("x", None), ("z", [7, None, -8])],
+        ],
+        type=pa.map_(pa.string(), pa.list_(pa.int64())),
+    )
+
+    map_list_float16 = pa.array(
+        [
+            [("x", [np.float16(2)]), ("y", [np.float16(3), np.float16(4)])],
+            [("z", [])],
+            None,
+            [],
+            [
+                ("w", [np.float16(5), np.float16(6)]),
+                ("x", None),
+                ("z", [np.float16(7), None, np.float16(8)]),
+            ],
+        ],
+        type=pa.map_(pa.string(), pa.list_(pa.float16())),
+    )
+
+    map_list_float32 = pa.array(
+        [
+            [("x", [2]), ("y", [3, 4])],
+            [("z", [])],
+            None,
+            [],
+            [("w", [5, 6]), ("x", None), ("z", [7, None, 8])],
+        ],
+        type=pa.map_(pa.string(), pa.list_(pa.float32())),
+    )
+
+    map_list_float64 = pa.array(
+        [
+            [("x", [2]), ("y", [3, 4])],
+            [("z", [])],
+            None,
+            [],
+            [("w", [5, 6]), ("x", None), ("z", [7, None, -8])],
+        ],
+        type=pa.map_(pa.string(), pa.list_(pa.float64())),
+    )
+
+    map_list_decimal = pa.array(
+        [
+            [("x", [d]), ("y", [d, d])],
+            [("z", [])],
+            None,
+            [],
+            [("w", [d, d]), ("x", None), ("z", [d, None, d])],
+        ],
+        type=pa.map_(pa.string(), pa.list_(pa.decimal128(5, 2))),
+    )
+
+    map_fixed_size_list_uint8 = pa.array(
+        [
+            [("z", [4, 5])],
+            None,
+            None,
+            None,
+            [("x", [2, 3]), ("y", None), ("z", [4, 5])],
+        ],
+        type=pa.map_(pa.string(), pa.list_(pa.uint8(), 2)),
+    )
+
+    list_list_string = pa.array(
+        [None, [["efg"]], [], [], [["a"], None, ["b", None, "cd"]]],
+        type=pa.list_(pa.list_(pa.string())),
+    )
+
+    list_large_list_large_string = pa.array(
+        [None, [["efg"]], [], [], [["a"], None, ["b", None, "cd"]]],
+        type=pa.list_(pa.large_list(pa.large_string())),
+    )
+
+    list_map_string = pa.array(
+        [None, [None], [], [], [[("a", "b"), ("c", "d")], [("e", "f")]]],
+        type=pa.list_(pa.map_(pa.string(), pa.string())),
+    )
+
+    list_binary = pa.array(
+        [None, [None], [], [], [b"\x01\x01\x00\x00\x00", b"\x00\x00\x01\x00\x00"]],
+        type=pa.list_(pa.binary()),
+    )
+
+    list_large_binary = pa.array(
+        [None, [None], [], [], [b"\x01\x01\x00\x00\x00", b"\x00\x00\x01\x00\x00"]],
+        type=pa.list_(pa.large_binary()),
+    )
+
+    list_fixed_size_binary = pa.array(
+        [None, [None], [], [], [b"\x01\x01\x00\x00\x00", b"\x00\x00\x01\x00\x00"]],
+        type=pa.list_(pa.binary(5)),
+    )
+
     import struct
 
     wkb_geometry = pa.array(
@@ -1608,6 +1958,7 @@ def test_ogr_mem_write_pyarrow():
         "uint32",
         "int64",
         "uint64",
+        "float16",
         "float32",
         "float64",
         "string",
@@ -1628,6 +1979,7 @@ def test_ogr_mem_write_pyarrow():
         "list_uint32",
         "list_int64",
         "list_uint64",
+        "list_float16",
         "list_float32",
         "list_float64",
         "list_string",
@@ -1641,6 +1993,7 @@ def test_ogr_mem_write_pyarrow():
         "large_list_uint32",
         "large_list_int64",
         "large_list_uint64",
+        "large_list_float16",
         "large_list_float32",
         "large_list_float64",
         "large_list_string",
@@ -1654,6 +2007,7 @@ def test_ogr_mem_write_pyarrow():
         "fixed_size_list_uint32",
         "fixed_size_list_int64",
         "fixed_size_list_uint64",
+        "fixed_size_list_float16",
         "fixed_size_list_float32",
         "fixed_size_list_float64",
         "fixed_size_list_string",
@@ -1672,6 +2026,46 @@ def test_ogr_mem_write_pyarrow():
         "list_decimal128",
         "large_list_decimal128",
         "fixed_size_list_decimal128",
+        "map_boolean",
+        "map_int8",
+        "map_uint8",
+        "map_int16",
+        "map_uint16",
+        "map_int32",
+        "map_uint32",
+        "map_int64",
+        "map_uint64",
+        "map_float16",
+        "map_float32",
+        "map_float64",
+        "map_string",
+        "map_large_string",
+        "map_binary",
+        "map_large_binary",
+        "map_fixed_size_binary",
+        "map_decimal",
+        "map_structure",
+        "map_map_string",
+        "map_list_bool",
+        "map_list_int8",
+        "map_list_uint8",
+        "map_list_int16",
+        "map_list_uint16",
+        "map_list_int32",
+        "map_list_uint32",
+        "map_list_int64",
+        "map_list_uint64",
+        "map_list_float16",
+        "map_list_float32",
+        "map_list_float64",
+        "map_list_decimal",
+        "map_fixed_size_list_uint8",
+        "list_list_string",
+        "list_large_list_large_string",
+        "list_map_string",
+        "list_binary",
+        "list_large_binary",
+        "list_fixed_size_binary",
         "wkb_geometry",
         "fid",
     ]
@@ -1704,6 +2098,18 @@ def test_ogr_mem_write_pyarrow():
     assert lyr.WritePyArrow(table, options=["FID=fid"]) == ogr.OGRERR_NONE
     assert fid.to_pylist() == [0, 1, 2, 3, 4]
 
+    f = lyr.GetFeature(0)
+    assert f["map_uint8"] == """{"z":2}"""
+
+    f = lyr.GetFeature(1)
+    assert f["map_uint8"] is None
+
+    f = lyr.GetFeature(2)
+    assert f["map_uint8"] == "{}"
+
+    f = lyr.GetFeature(3)
+    assert f["map_uint8"] == "{}"
+
     f = lyr.GetFeature(4)
     assert (
         str(f)
@@ -1717,6 +2123,7 @@ def test_ogr_mem_write_pyarrow():
   uint32 (Integer64) = 4000000001
   int64 (Integer64) = 200000000000
   uint64 (Real) = 400000000001
+  float16 (Real(Float32)) = 5.5
   float32 (Real(Float32)) = 5.5
   float64 (Real) = 5.5
   string (String) = def
@@ -1738,6 +2145,7 @@ def test_ogr_mem_write_pyarrow():
   list_uint32 (Integer64List) = (4:0,7,8,9)
   list_int64 (Integer64List) = (4:0,7,8,9)
   list_uint64 (RealList) = (4:0,7,8,9)
+  list_float16 (RealList(Float32)) = (4:0.0,7.5,8.5,9.5)
   list_float32 (RealList(Float32)) = (4:0.0,7.5,8.5,9.5)
   list_float64 (RealList) = (4:0,7.5,8.5,9.5)
   list_string (StringList) = (4:A,BC,CDE,DEFG)
@@ -1751,6 +2159,7 @@ def test_ogr_mem_write_pyarrow():
   large_list_uint32 (Integer64List) = (4:0,7,8,9)
   large_list_int64 (Integer64List) = (4:0,7,8,9)
   large_list_uint64 (RealList) = (4:0,7,8,9)
+  large_list_float16 (RealList(Float32)) = (4:0.0,7.5,8.5,9.5)
   large_list_float32 (RealList(Float32)) = (4:0.0,7.5,8.5,9.5)
   large_list_float64 (RealList) = (4:0,7.5,8.5,9.5)
   large_list_string (StringList) = (4:A,BC,CDE,DEFG)
@@ -1764,6 +2173,7 @@ def test_ogr_mem_write_pyarrow():
   fixed_size_list_uint32 (Integer64List) = (2:8,9)
   fixed_size_list_int64 (Integer64List) = (2:8,9)
   fixed_size_list_uint64 (RealList) = (2:8,9)
+  fixed_size_list_float16 (RealList(Float32)) = (2:8.0,9.0)
   fixed_size_list_float32 (RealList(Float32)) = (2:8.0,9.0)
   fixed_size_list_float64 (RealList) = (2:8,9)
   fixed_size_list_string (StringList) = (2:iw,j)
@@ -1782,6 +2192,46 @@ def test_ogr_mem_write_pyarrow():
   list_decimal128 (RealList) = (2: 123.45, 234.56)
   large_list_decimal128 (RealList) = (2: 123.45, 234.56)
   fixed_size_list_decimal128 (RealList) = (2: 345.67,-345.67)
+  map_boolean (String(JSON)) = {"x":null,"yz":true}
+  map_int8 (String(JSON)) = {"x":null,"yz":-4}
+  map_uint8 (String(JSON)) = {"x":null,"yz":4}
+  map_int16 (String(JSON)) = {"x":null,"yz":-4}
+  map_uint16 (String(JSON)) = {"x":null,"yz":4}
+  map_int32 (String(JSON)) = {"x":null,"yz":-4}
+  map_uint32 (String(JSON)) = {"x":null,"yz":4}
+  map_int64 (String(JSON)) = {"x":null,"yz":-4}
+  map_uint64 (String(JSON)) = {"x":null,"yz":4}
+  map_float16 (String(JSON)) = {"x":null,"yz":4.0}
+  map_float32 (String(JSON)) = {"x":null,"yz":4.0}
+  map_float64 (String(JSON)) = {"x":null,"yz":4.0}
+  map_string (String(JSON)) = {"x":null,"yz":"bar"}
+  map_large_string (String(JSON)) = {"x":null,"yz":"bar"}
+  map_binary (String(JSON)) = {"x":null,"yz":"AAABAAA="}
+  map_large_binary (String(JSON)) = {"x":null,"yz":"AAABAAA="}
+  map_fixed_size_binary (String(JSON)) = {"x":null,"yz":"AAABAAA="}
+  map_decimal (String(JSON)) = {"x":null,"yz":123.45}
+  map_structure (String(JSON)) = {"x":null,"y":{"f1":null,"f2":null},"z":{"f1":"foo","f2":2}}
+  map_map_string (String(JSON)) = {"a":{"b":"c","d":null},"e":null}
+  map_list_bool (String(JSON)) = {"w":[true,false],"x":null,"z":[false,null,true]}
+  map_list_int8 (String(JSON)) = {"w":[5,6],"x":null,"z":[7,null,-8]}
+  map_list_uint8 (String(JSON)) = {"w":[5,6],"x":null,"z":[7,null,8]}
+  map_list_int16 (String(JSON)) = {"w":[5,6],"x":null,"z":[7,null,-8]}
+  map_list_uint16 (String(JSON)) = {"w":[5,6],"x":null,"z":[7,null,8]}
+  map_list_int32 (String(JSON)) = {"w":[5,6],"x":null,"z":[7,null,-8]}
+  map_list_uint32 (String(JSON)) = {"w":[5,6],"x":null,"z":[7,null,8]}
+  map_list_int64 (String(JSON)) = {"w":[5,6],"x":null,"z":[7,null,-8]}
+  map_list_uint64 (String(JSON)) = {"w":[5,6],"x":null,"z":[7,null,8]}
+  map_list_float16 (String(JSON)) = {"w":[5.0,6.0],"x":null,"z":[7.0,null,8.0]}
+  map_list_float32 (String(JSON)) = {"w":[5.0,6.0],"x":null,"z":[7.0,null,8.0]}
+  map_list_float64 (String(JSON)) = {"w":[5.0,6.0],"x":null,"z":[7.0,null,-8.0]}
+  map_list_decimal (String(JSON)) = {"w":[123.45,123.45],"x":null,"z":[123.45,null,123.45]}
+  map_fixed_size_list_uint8 (String(JSON)) = {"x":[2,3],"y":null,"z":[4,5]}
+  list_list_string (String(JSON)) = [["a"],null,["b",null,"cd"]]
+  list_large_list_large_string (String(JSON)) = [["a"],null,["b",null,"cd"]]
+  list_map_string (String(JSON)) = [{"a":"b","c":"d"},{"e":"f"}]
+  list_binary (String(JSON)) = ["AQEAAAA=","AAABAAA="]
+  list_large_binary (String(JSON)) = ["AQEAAAA=","AAABAAA="]
+  list_fixed_size_binary (String(JSON)) = ["AQEAAAA=","AAABAAA="]
   POINT (4 2)
 
 """

--- a/autotest/ogr/ogr_parquet.py
+++ b/autotest/ogr/ogr_parquet.py
@@ -2281,15 +2281,16 @@ def test_ogr_parquet_arrow_stream_fast_attribute_filter_on_decimal128():
     ds = ogr.Open("data/parquet/test.parquet")
     lyr = ds.GetLayer(0)
     lyr.SetAttributeFilter("decimal128 = -1234.567")
-    # Fast filtering on decimal data type not implemented for now
-    assert lyr.TestCapability(ogr.OLCFastGetArrowStream) == 0
+    assert lyr.TestCapability(ogr.OLCFastGetArrowStream) == 1
     stream = lyr.GetArrowStreamAsPyArrow()
     batches = [batch for batch in stream]
-    assert len(batches[0].field("uint8")) == 2
+    assert len(batches) == 2
+    assert len(batches[0].field("uint8")) == 1
+    assert len(batches[1].field("uint8")) == 1
     assert batches[0].field("uint8")[0].as_py() == 2
-    assert batches[0].field("uint8")[1].as_py() == 5
-    assert batches[0].field("decimal128")[0].as_py() == -1234.567
-    assert batches[0].field("decimal128")[1].as_py() == -1234.567
+    assert batches[1].field("uint8")[0].as_py() == 5
+    assert float(batches[0].field("decimal128")[0].as_py()) == -1234.567
+    assert float(batches[1].field("decimal128")[0].as_py()) == -1234.567
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_parquet.py
+++ b/autotest/ogr/ogr_parquet.py
@@ -2939,3 +2939,75 @@ def test_ogr_parquet_bbox_minx_miny_maxx_maxy(tmp_vsimem):
         minx, maxx, miny, maxy = lyr.GetExtent()
         assert (minx, miny, maxx, maxy) == (-1.0, 0.0, 3.0, 10.0)
         ds = None
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_ogr_parquet_write_arrow(tmp_vsimem):
+
+    src_ds = ogr.Open("data/parquet/test.parquet")
+    src_lyr = src_ds.GetLayer(0)
+
+    outfilename = str(tmp_vsimem / "test_ogr_parquet_write_arrow.parquet")
+    with ogr.GetDriverByName("Parquet").CreateDataSource(outfilename) as dst_ds:
+        dst_lyr = dst_ds.CreateLayer(
+            "test", srs=src_lyr.GetSpatialRef(), geom_type=ogr.wkbPoint, options=[]
+        )
+
+        stream = src_lyr.GetArrowStream(["MAX_FEATURES_IN_BATCH=3"])
+        schema = stream.GetSchema()
+
+        success, error_msg = dst_lyr.IsArrowSchemaSupported(schema)
+        assert success
+
+        for i in range(schema.GetChildrenCount()):
+            if schema.GetChild(i).GetName() != src_lyr.GetGeometryColumn():
+                dst_lyr.CreateFieldFromArrowSchema(schema.GetChild(i))
+
+        while True:
+            array = stream.GetNextRecordBatch()
+            if array is None:
+                break
+            assert dst_lyr.WriteArrowBatch(schema, array) == ogr.OGRERR_NONE
+
+    _check_test_parquet(outfilename)
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_ogr_parquet_write_arrow_rewind_polygon(tmp_vsimem):
+
+    src_ds = ogr.GetDriverByName("Memory").CreateDataSource("")
+    src_lyr = src_ds.CreateLayer("test")
+    f = ogr.Feature(src_lyr.GetLayerDefn())
+    f.SetGeometryDirectly(ogr.CreateGeometryFromWkt("POLYGON ((0 0,0 1,1 1,0 0))"))
+    src_lyr.CreateFeature(f)
+
+    outfilename = str(tmp_vsimem / "test_ogr_parquet_write_arrow.parquet")
+    with ogr.GetDriverByName("Parquet").CreateDataSource(outfilename) as dst_ds:
+        dst_lyr = dst_ds.CreateLayer("test", geom_type=ogr.wkbPolygon, options=[])
+
+        stream = src_lyr.GetArrowStream()
+        schema = stream.GetSchema()
+
+        success, error_msg = dst_lyr.IsArrowSchemaSupported(schema)
+        assert success
+
+        for i in range(schema.GetChildrenCount()):
+            if schema.GetChild(i).GetName() not in ("OGC_FID", "wkb_geometry"):
+                dst_lyr.CreateFieldFromArrowSchema(schema.GetChild(i))
+
+        while True:
+            array = stream.GetNextRecordBatch()
+            if array is None:
+                break
+            assert dst_lyr.WriteArrowBatch(schema, array) == ogr.OGRERR_NONE
+
+    ds = ogr.Open(outfilename)
+    lyr = ds.GetLayer(0)
+    f = lyr.GetNextFeature()
+    assert f.GetGeometryRef().ExportToWkt() == "POLYGON ((0 0,1 1,0 1,0 0))"

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -5772,7 +5772,7 @@ def test_ogr_shape_write_arrow_fallback_types(tmp_vsimem):
     assert f["date"] == "2023/10/06"
     assert f["time"] == "12:34:56"
     assert f["binary"] == "0123465789ABCDEF"
-    assert f["datetime"] == "2023/10/06 19:43:00"
+    assert f["datetime"] == "2023-10-06T19:43:00"
     assert f["stringlist"] == '[ "foo", "bar" ]'
     assert f["intlist"] == "[ 1, 2 ]"
     assert f["int64list"] == "[ 12345678901234, 2 ]"

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -5704,3 +5704,111 @@ def test_ogr_shape_prj_with_wrong_axis_order(tmp_vsimem):
     assert lyr.GetSpatialRef().GetAxisName(None, 0) == "Latitude"
     assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4326"
     assert lyr.GetSpatialRef().GetDataAxisToSRSAxisMapping() == [2, 1]
+
+
+###############################################################################
+# Test WriteArrowBatch() with USE_FALLBACK_TYPES=YES
+
+
+@gdaltest.enable_exceptions()
+def test_ogr_shape_write_arrow_fallback_types(tmp_vsimem):
+
+    src_ds = ogr.GetDriverByName("Memory").CreateDataSource("")
+    src_lyr = src_ds.CreateLayer("test")
+    src_lyr.CreateField(ogr.FieldDefn("string", ogr.OFTString))
+    src_lyr.CreateField(ogr.FieldDefn("int", ogr.OFTInteger))
+    src_lyr.CreateField(ogr.FieldDefn("int64", ogr.OFTInteger64))
+    src_lyr.CreateField(ogr.FieldDefn("real", ogr.OFTReal))
+    src_lyr.CreateField(ogr.FieldDefn("date", ogr.OFTDate))
+    src_lyr.CreateField(ogr.FieldDefn("time", ogr.OFTTime))
+    src_lyr.CreateField(ogr.FieldDefn("datetime", ogr.OFTDateTime))
+    src_lyr.CreateField(ogr.FieldDefn("binary", ogr.OFTBinary))
+    src_lyr.CreateField(ogr.FieldDefn("stringlist", ogr.OFTStringList))
+    src_lyr.CreateField(ogr.FieldDefn("intlist", ogr.OFTIntegerList))
+    src_lyr.CreateField(ogr.FieldDefn("int64list", ogr.OFTInteger64List))
+    src_lyr.CreateField(ogr.FieldDefn("reallist", ogr.OFTRealList))
+    f = ogr.Feature(src_lyr.GetLayerDefn())
+    f["string"] = "foo"
+    f["int"] = 123
+    f["int64"] = 12345678901234
+    f["real"] = 1.5
+    f["date"] = "2023/10/06"
+    f["time"] = "12:34:56"
+    f["datetime"] = "2023/10/06 19:43:00"
+    f.SetField("binary", b"\x01\x23\x46\x57\x89\xAB\xCD\xEF")
+    f["stringlist"] = ["foo", "bar"]
+    f["intlist"] = [1, 2]
+    f["int64list"] = [12345678901234, 2]
+    f["reallist"] = [1.5, 2.5]
+    src_lyr.CreateFeature(f)
+
+    filename = tmp_vsimem / "test_ogr_gpkg_write_arrow_fallback_types.shp"
+    ds = gdal.GetDriverByName("ESRI Shapefile").Create(
+        filename, 0, 0, 0, gdal.GDT_Unknown
+    )
+    lyr = ds.CreateLayer("test")
+
+    stream = src_lyr.GetArrowStream()
+    schema = stream.GetSchema()
+
+    success, error_msg = lyr.IsArrowSchemaSupported(schema)
+    assert not success
+    assert (
+        "Field stringlist would require using OGR type StringList but the driver does not support it. You may set the USE_FALLBACK_TYPES=YES option to allow use of a fallback type"
+        in error_msg
+    )
+
+    success, error_msg = lyr.IsArrowSchemaSupported(schema, ["USE_FALLBACK_TYPES=YES"])
+    assert success
+
+    for i in range(schema.GetChildrenCount()):
+        if schema.GetChild(i).GetName() in (
+            "time",
+            "datetime",
+            "binary",
+            "stringlist",
+            "intlist",
+            "int64list",
+            "reallist",
+        ):
+            with pytest.raises(Exception):
+                lyr.CreateFieldFromArrowSchema(schema.GetChild(i))
+
+    for i in range(schema.GetChildrenCount()):
+        if schema.GetChild(i).GetName() not in ("wkb_geometry", "OGC_FID"):
+            lyr.CreateFieldFromArrowSchema(
+                schema.GetChild(i), ["USE_FALLBACK_TYPES=YES"]
+            )
+
+    while True:
+        array = stream.GetNextRecordBatch()
+        if array is None:
+            break
+        with pytest.raises(
+            Exception,
+            match="For field time, OGR field type is String whereas Arrow type implies Time",
+        ):
+            lyr.WriteArrowBatch(schema, array, ["FID=OGC_FID"])
+
+    del stream
+    stream = src_lyr.GetArrowStream()
+    schema = stream.GetSchema()
+    while True:
+        array = stream.GetNextRecordBatch()
+        if array is None:
+            break
+        lyr.WriteArrowBatch(schema, array, ["FID=OGC_FID", "USE_FALLBACK_TYPES=YES"])
+
+    f = lyr.GetNextFeature()
+    assert f["string"] == "foo"
+    assert f["int"] == 123
+    assert f["int64"] == 12345678901234
+    assert f["real"] == 1.5
+    assert f["date"] == "2023/10/06"
+    assert f["time"] == "12:34:56"
+    assert f["binary"] == "0123465789ABCDEF"
+    assert f["datetime"] == "2023/10/06 19:43:00"
+    assert f["stringlist"] == '[ "foo", "bar" ]'
+    assert f["intlist"] == "[ 1, 2 ]"
+    assert f["int64list"] == "[ 12345678901234, 2 ]"
+    assert f["reallist"] == "[ 1.5, 2.5 ]"

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -5707,7 +5707,7 @@ def test_ogr_shape_prj_with_wrong_axis_order(tmp_vsimem):
 
 
 ###############################################################################
-# Test WriteArrowBatch() with USE_FALLBACK_TYPES=YES
+# Test WriteArrowBatch() and fallback types
 
 
 @gdaltest.enable_exceptions()
@@ -5752,52 +5752,17 @@ def test_ogr_shape_write_arrow_fallback_types(tmp_vsimem):
     schema = stream.GetSchema()
 
     success, error_msg = lyr.IsArrowSchemaSupported(schema)
-    assert not success
-    assert (
-        "Field stringlist would require using OGR type StringList but the driver does not support it. You may set the USE_FALLBACK_TYPES=YES option to allow use of a fallback type"
-        in error_msg
-    )
-
-    success, error_msg = lyr.IsArrowSchemaSupported(schema, ["USE_FALLBACK_TYPES=YES"])
     assert success
 
     for i in range(schema.GetChildrenCount()):
-        if schema.GetChild(i).GetName() in (
-            "time",
-            "datetime",
-            "binary",
-            "stringlist",
-            "intlist",
-            "int64list",
-            "reallist",
-        ):
-            with pytest.raises(Exception):
-                lyr.CreateFieldFromArrowSchema(schema.GetChild(i))
-
-    for i in range(schema.GetChildrenCount()):
         if schema.GetChild(i).GetName() not in ("wkb_geometry", "OGC_FID"):
-            lyr.CreateFieldFromArrowSchema(
-                schema.GetChild(i), ["USE_FALLBACK_TYPES=YES"]
-            )
+            lyr.CreateFieldFromArrowSchema(schema.GetChild(i))
 
     while True:
         array = stream.GetNextRecordBatch()
         if array is None:
             break
-        with pytest.raises(
-            Exception,
-            match="For field time, OGR field type is String whereas Arrow type implies Time",
-        ):
-            lyr.WriteArrowBatch(schema, array, ["FID=OGC_FID"])
-
-    del stream
-    stream = src_lyr.GetArrowStream()
-    schema = stream.GetSchema()
-    while True:
-        array = stream.GetNextRecordBatch()
-        if array is None:
-            break
-        lyr.WriteArrowBatch(schema, array, ["FID=OGC_FID", "USE_FALLBACK_TYPES=YES"])
+        lyr.WriteArrowBatch(schema, array, ["FID=OGC_FID"])
 
     f = lyr.GetNextFeature()
     assert f["string"] == "foo"

--- a/doc/source/tutorials/vector_api_tut.rst
+++ b/doc/source/tutorials/vector_api_tut.rst
@@ -1747,13 +1747,6 @@ Supported options of the base implementation are:
   The corresponding ArrowArray must be of type binary (w) or large
   binary (W).
 
-- USE_FALLBACK_TYPES=YES. This may be set to allow GDAL to fallback to
-  another OGRFieldType data type (typically String) when the natural OGR type
-  is not supported in creation by the driver. This implies that the layer
-  implements GetDataset() to be able to retrieve supported data types from the
-  driver. This option must be used consistently among IsArrowSchemaSupported(),
-  CreateFieldFromArrowSchema() and WriteArrowBatch().
-
 Drivers that have a specialized implementation (such as :ref:`vector.parquet`
 and :ref:`vector.arrow`) advertise the OLCFastWriteArrowBatch layer capability.
 

--- a/doc/source/tutorials/vector_api_tut.rst
+++ b/doc/source/tutorials/vector_api_tut.rst
@@ -1025,6 +1025,8 @@ of a integer field and a geometry field:
     }
 
 
+To write features by batches using an ArrowArray, consult :ref:`vector_api_tut_arrow_write`.
+
 Writing To OGR
 --------------
 
@@ -1662,3 +1664,174 @@ In Python :
         if lyr.CreateFeature( feat ) != 0:
             print( "Failed to create feature.\n" );
             sys.exit( 1 );
+
+.. _vector_api_tut_arrow_write:
+
+Writing to OGR using the Arrow C Data interface
+-----------------------------------------------
+
+.. versionadded:: 3.8
+
+Instead of writing features one at a time, it is also possible to write
+them by batches, with a column-oriented memory layout, using the
+:cpp:func:`OGRLayer::WriteArrowBatch` method. Note that this method is more
+difficult to use than the traditional :cpp:func:`OGRLayer::CreateFeature` approach,
+and is only advised when compatibility with the
+`Apache Arrow C Data interface <https://arrow.apache.org/docs/format/CDataInterface.html>`_
+is needed, or when column-oriented writing of layers is required.
+
+Pending using an helper library, generation of the Arrow C Data interface
+requires reading of the following documents:
+
+- `Arrow C data interface <https://arrow.apache.org/docs/format/CDataInterface.html>`_
+- `Arrow Columnar Format <https://arrow.apache.org/docs/format/Columnar.html>`_.
+
+Consult :ref:`vector_api_tut_arrow_stream` for introduction to the ArrowSchema and ArrowArray
+basic types involved for batch writing.
+
+The WriteArrowBatch() method has the following signature:
+
+  .. code-block:: cpp
+
+        /** Writes a batch of rows from an ArrowArray.
+         *
+         * @param schema Schema of array
+         * @param array Array of type struct. It may be released (array->release==NULL)
+         *              after calling this method.
+         * @param papszOptions Options. Null terminated list, or nullptr.
+         * @return true in case of success
+         */
+        virtual bool OGRLayer::WriteArrowBatch(const struct ArrowSchema *schema,
+                                               struct ArrowArray *array,
+                                               CSLConstList papszOptions = nullptr);
+
+It is also available in the C API as :cpp:func:`OGR_L_WriteArrowBatch`.
+
+This is semantically close to calling :cpp:func:`OGRLayer::CreateFeature()`
+with multiple features at once.
+
+The ArrowArray must be of type struct (format=+s), and its children generally
+map to a OGR attribute or geometry field (unless they are struct themselves).
+
+Method :cpp:func:`OGRLayer::IsArrowSchemaSupported` can be called to determine
+if the schema will be supported by WriteArrowBatch().
+
+OGR fields for the corresponding children arrays must exist and be of a
+compatible type. For attribute fields, they should be created with
+:cpp:func:`OGRLayer::CreateFieldFromArrowSchema`.
+
+Arrays for geometry columns should be of binary or large binary type and
+contain WKB geometry.
+
+Note that the passed array may be set to a released state
+(array->release==NULL) after this call (not by the base implementation,
+but in specialized ones such as Parquet or Arrow for example)
+
+Supported options of the base implementation are:
+
+- FID=name. Name of the FID column in the array. If not provided,
+  GetFIDColumn() is used to determine it. The special name
+  OGRLayer::DEFAULT_ARROW_FID_NAME is also recognized if neither FID nor
+  GetFIDColumn() are set.
+  The corresponding ArrowArray must be of type int32 (i) or int64 (l).
+  On input, values of the FID column are used to create the feature.
+  On output, the values of the FID column may be set with the FID of the
+  created feature (if the array is not released).
+
+- GEOMETRY_NAME=name. Name of the geometry column. If not provided,
+  GetGeometryColumn() is used. The special name
+  OGRLayer::DEFAULT_ARROW_GEOMETRY_NAME is also recognized if neither
+  GEOMETRY_NAME nor GetGeometryColumn() are set.
+  Geometry columns are also identified if they have
+  ARROW:extension:name=ogc.wkb as a field metadata.
+  The corresponding ArrowArray must be of type binary (w) or large
+  binary (W).
+
+Drivers that have a specialized implementation (such as :ref:`vector.parquet`
+and :ref:`vector.arrow`) advertise the OLCFastWriteArrowBatch layer capability.
+
+The following example in Python demonstrates how to copy a layer from one format to
+another one (assuming it has at most a single geometry column):
+
+.. code-block:: python
+
+    def copy_layer(src_lyr, out_filename, out_format, lcos = {}):
+        stream = src_lyr.GetArrowStream()
+        schema = stream.GetSchema()
+
+        # If the source layer has a FID column and the output driver supports
+        # a FID layer creation option, set it to the source FID column name.
+        if src_lyr.GetFIDColumn():
+            creationOptions = gdal.GetDriverByName(out_format).GetMetadataItem(
+                "DS_LAYER_CREATIONOPTIONLIST"
+            )
+            if creationOptions and '"FID"' in creationOptions:
+                lcos["FID"] = src_lyr.GetFIDColumn()
+
+        with ogr.GetDriverByName(out_format).CreateDataSource(out_filename) as out_ds:
+            if src_lyr.GetLayerDefn().GetGeomFieldCount() > 1:
+                out_lyr = out_ds.CreateLayer(
+                    src_lyr.GetName(), geom_type=ogr.wkbNone, options=lcos
+                )
+                for i in range(src_lyr.GetLayerDefn().GetGeomFieldCount()):
+                    out_lyr.CreateGeomField(src_lyr.GetLayerDefn().GetGeomFieldDefn(i))
+            else:
+                out_lyr = out_ds.CreateLayer(
+                    src_lyr.GetName(),
+                    geom_type=src_lyr.GetGeomType(),
+                    srs=src_lyr.GetSpatialRef(),
+                    options=lcos,
+                )
+
+            success, error_msg = out_lyr.IsArrowSchemaSupported(schema)
+            assert success, error_msg
+
+            src_geom_field_names = [
+                src_lyr.GetLayerDefn().GetGeomFieldDefn(i).GetName()
+                for i in range(src_lyr.GetLayerDefn().GetGeomFieldCount())
+            ]
+            for i in range(schema.GetChildrenCount()):
+                # GetArrowStream() may return "OGC_FID" for a unnamed source FID
+                # column and "wkb_geometry" for a unnamed source geometry column.
+                # Also test GetFIDColumn() and src_geom_field_names if they are
+                # named.
+                if (
+                    schema.GetChild(i).GetName()
+                    not in ("OGC_FID", "wkb_geometry", src_lyr.GetFIDColumn())
+                    and schema.GetChild(i).GetName() not in src_geom_field_names
+                ):
+                    out_lyr.CreateFieldFromArrowSchema(schema.GetChild(i))
+
+            write_options = []
+            if src_lyr.GetFIDColumn():
+                write_options.append("FID=" + src_lyr.GetFIDColumn())
+            if (
+                src_lyr.GetLayerDefn().GetGeomFieldCount() == 1
+                and src_lyr.GetGeometryColumn()
+            ):
+                write_options.append("GEOMETRY_NAME=" + src_lyr.GetGeometryColumn())
+
+            while True:
+                array = stream.GetNextRecordBatch()
+                if array is None:
+                    break
+                out_lyr.WriteArrowBatch(schema, array, write_options)
+
+
+For the Python bindings, in addition to the above ogr.Layer.IsArrowSchemaSupported(),
+ogr.Layer.CreateFieldFromArrowSchema() and ogr.Layer.WriteArrowBatch() methods,
+3 similar methods exist using the `PyArrow <https://arrow.apache.org/docs/python/index.html>`__
+data types:
+
+.. code-block:: python
+
+    class Layer:
+
+        def IsPyArrowSchemaSupported(self, pa_schema):
+            """Returns whether the passed pyarrow Schema is supported by the layer, as a tuple (success: bool, errorMsg: str).
+
+        def CreateFieldFromPyArrowSchema(self, pa_schema, options=[]):
+            """Create a field from the passed pyarrow Schema."""
+
+        def WritePyArrow(self, pa_batch, options=[]):
+            """Write the content of the passed PyArrow batch (either a pyarrow.Table, a pyarrow.RecordBatch or a pyarrow.StructArray) into the layer."""

--- a/doc/source/tutorials/vector_api_tut.rst
+++ b/doc/source/tutorials/vector_api_tut.rst
@@ -1747,6 +1747,13 @@ Supported options of the base implementation are:
   The corresponding ArrowArray must be of type binary (w) or large
   binary (W).
 
+- USE_FALLBACK_TYPES=YES. This may be set to allow GDAL to fallback to
+  another OGRFieldType data type (typically String) when the natural OGR type
+  is not supported in creation by the driver. This implies that the layer
+  implements GetDataset() to be able to retrieve supported data types from the
+  driver. This option must be used consistently among IsArrowSchemaSupported(),
+  CreateFieldFromArrowSchema() and WriteArrowBatch().
+
 Drivers that have a specialized implementation (such as :ref:`vector.parquet`
 and :ref:`vector.arrow`) advertise the OLCFastWriteArrowBatch layer capability.
 
@@ -1827,7 +1834,7 @@ data types:
 
     class Layer:
 
-        def IsPyArrowSchemaSupported(self, pa_schema):
+        def IsPyArrowSchemaSupported(self, pa_schema, options=[]):
             """Returns whether the passed pyarrow Schema is supported by the layer, as a tuple (success: bool, errorMsg: str).
 
         def CreateFieldFromPyArrowSchema(self, pa_schema, options=[]):

--- a/ogr/ogr_api.h
+++ b/ogr/ogr_api.h
@@ -710,13 +710,33 @@ OGRFeatureH CPL_DLL OGR_L_GetNextFeature(OGRLayerH) CPL_WARN_UNUSED_RESULT;
     OGR_F_Destroy(hFeat);                                                      \
     }
 
-/** Data type for a Arrow C stream Include ogr_recordbatch.h to get the
+/** Data type for a Arrow C stream. Include ogr_recordbatch.h to get the
  * definition. */
 struct ArrowArrayStream;
 
 bool CPL_DLL OGR_L_GetArrowStream(OGRLayerH hLayer,
                                   struct ArrowArrayStream *out_stream,
                                   char **papszOptions);
+
+/** Data type for a Arrow C schema. Include ogr_recordbatch.h to get the
+ * definition. */
+struct ArrowSchema;
+
+bool CPL_DLL OGR_L_IsArrowSchemaSupported(OGRLayerH hLayer,
+                                          const struct ArrowSchema *schema,
+                                          char **ppszErrorMsg);
+bool CPL_DLL OGR_L_CreateFieldFromArrowSchema(OGRLayerH hLayer,
+                                              const struct ArrowSchema *schema,
+                                              char **papszOptions);
+
+/** Data type for a Arrow C array. Include ogr_recordbatch.h to get the
+ * definition. */
+struct ArrowArray;
+
+bool CPL_DLL OGR_L_WriteArrowBatch(OGRLayerH hLayer,
+                                   const struct ArrowSchema *schema,
+                                   struct ArrowArray *array,
+                                   char **papszOptions);
 
 OGRErr CPL_DLL OGR_L_SetNextByIndex(OGRLayerH, GIntBig);
 OGRFeatureH CPL_DLL OGR_L_GetFeature(OGRLayerH, GIntBig) CPL_WARN_UNUSED_RESULT;

--- a/ogr/ogr_api.h
+++ b/ogr/ogr_api.h
@@ -724,6 +724,7 @@ struct ArrowSchema;
 
 bool CPL_DLL OGR_L_IsArrowSchemaSupported(OGRLayerH hLayer,
                                           const struct ArrowSchema *schema,
+                                          char **papszOptions,
                                           char **ppszErrorMsg);
 bool CPL_DLL OGR_L_CreateFieldFromArrowSchema(OGRLayerH hLayer,
                                               const struct ArrowSchema *schema,

--- a/ogr/ogr_core.h
+++ b/ogr/ogr_core.h
@@ -1013,6 +1013,9 @@ int CPL_DLL OGRParseDate(const char *pszInput, OGRField *psOutput,
 #define OLCFastGetArrowStream                                                  \
     "FastGetArrowStream" /**< Layer capability for fast GetArrowStream()       \
                             implementation */
+#define OLCFastWriteArrowBatch                                                 \
+    "FastWriteArrowBatch" /**< Layer capability for fast WriteArrowBatch()     \
+                            implementation */
 
 #define ODsCCreateLayer                                                        \
     "CreateLayer" /**< Dataset capability for layer creation */

--- a/ogr/ogr_feature.h
+++ b/ogr/ogr_feature.h
@@ -1211,9 +1211,12 @@ class CPL_DLL OGRFeature
     void DumpReadable(FILE *, CSLConstList papszOptions = nullptr) const;
     std::string DumpReadableAsString(CSLConstList papszOptions = nullptr) const;
 
-    OGRErr SetFrom(const OGRFeature *, int = TRUE);
-    OGRErr SetFrom(const OGRFeature *, const int *, int = TRUE);
-    OGRErr SetFieldsFrom(const OGRFeature *, const int *, int = TRUE);
+    OGRErr SetFrom(const OGRFeature *, int bForgiving = TRUE);
+    OGRErr SetFrom(const OGRFeature *, const int *panMap, int bForgiving = TRUE,
+                   bool bUseISO8601ForDateTimeAsString = false);
+    OGRErr SetFieldsFrom(const OGRFeature *, const int *panMap,
+                         int bForgiving = TRUE,
+                         bool bUseISO8601ForDateTimeAsString = false);
 
     //! @cond Doxygen_Suppress
     OGRErr RemapFields(OGRFeatureDefn *poNewDefn, const int *panRemapSource);

--- a/ogr/ogr_wkb.cpp
+++ b/ogr/ogr_wkb.cpp
@@ -778,6 +778,254 @@ bool OGRWKBIsWithinPessimistic(const GByte *pabyWkb, size_t nWKBSize,
 }
 
 /************************************************************************/
+/*                            epsilonEqual()                            */
+/************************************************************************/
+
+constexpr double EPSILON = 1.0E-5;
+
+static inline bool epsilonEqual(double a, double b, double eps)
+{
+    return ::fabs(a - b) < eps;
+}
+
+/************************************************************************/
+/*                     OGRWKBIsClockwiseRing()                          */
+/************************************************************************/
+
+static inline double GetX(const GByte *data, uint32_t i, int nDim,
+                          bool bNeedSwap)
+{
+    double dfX;
+    memcpy(&dfX, data + static_cast<size_t>(i) * nDim * sizeof(double),
+           sizeof(double));
+    if (bNeedSwap)
+        CPL_SWAP64PTR(&dfX);
+    return dfX;
+}
+
+static inline double GetY(const GByte *data, uint32_t i, int nDim,
+                          bool bNeedSwap)
+{
+    double dfY;
+    memcpy(&dfY, data + (static_cast<size_t>(i) * nDim + 1) * sizeof(double),
+           sizeof(double));
+    if (bNeedSwap)
+        CPL_SWAP64PTR(&dfY);
+    return dfY;
+}
+
+static bool OGRWKBIsClockwiseRing(const GByte *data, const uint32_t nPoints,
+                                  const int nDim, const bool bNeedSwap)
+{
+    // WARNING: keep in sync OGRLineString::isClockwise(),
+    // OGRCurve::isClockwise() and OGRWKBIsClockwiseRing()
+
+    bool bUseFallback = false;
+
+    // Find the lowest rightmost vertex.
+    uint32_t v = 0;  // Used after for.
+    double vX = GetX(data, v, nDim, bNeedSwap);
+    double vY = GetY(data, v, nDim, bNeedSwap);
+    for (uint32_t i = 1; i < nPoints - 1; i++)
+    {
+        // => v < end.
+        const double y = GetY(data, i, nDim, bNeedSwap);
+        if (y < vY)
+        {
+            v = i;
+            vX = GetX(data, i, nDim, bNeedSwap);
+            vY = y;
+            bUseFallback = false;
+        }
+        else if (y == vY)
+        {
+            const double x = GetX(data, i, nDim, bNeedSwap);
+            if (x > vX)
+            {
+                v = i;
+                vX = x;
+                vY = y;
+                bUseFallback = false;
+            }
+            else if (x == vX)
+            {
+                // Two vertex with same coordinates are the lowest rightmost
+                // vertex.  Cannot use that point as the pivot (#5342).
+                bUseFallback = true;
+            }
+        }
+    }
+
+    // Previous.
+    uint32_t next = (v == 0) ? nPoints - 2 : v - 1;
+    if (epsilonEqual(GetX(data, next, nDim, bNeedSwap), vX, EPSILON) &&
+        epsilonEqual(GetY(data, next, nDim, bNeedSwap), vY, EPSILON))
+    {
+        // Don't try to be too clever by retrying with a next point.
+        // This can lead to false results as in the case of #3356.
+        bUseFallback = true;
+    }
+
+    const double dx0 = GetX(data, next, nDim, bNeedSwap) - vX;
+    const double dy0 = GetY(data, next, nDim, bNeedSwap) - vY;
+
+    // Following.
+    next = v + 1;
+    if (next >= nPoints - 1)
+    {
+        next = 0;
+    }
+
+    if (epsilonEqual(GetX(data, next, nDim, bNeedSwap), vX, EPSILON) &&
+        epsilonEqual(GetY(data, next, nDim, bNeedSwap), vY, EPSILON))
+    {
+        // Don't try to be too clever by retrying with a next point.
+        // This can lead to false results as in the case of #3356.
+        bUseFallback = true;
+    }
+
+    const double dx1 = GetX(data, next, nDim, bNeedSwap) - vX;
+    const double dy1 = GetY(data, next, nDim, bNeedSwap) - vY;
+
+    const double crossproduct = dx1 * dy0 - dx0 * dy1;
+
+    if (!bUseFallback)
+    {
+        if (crossproduct > 0)  // CCW
+            return false;
+        else if (crossproduct < 0)  // CW
+            return true;
+    }
+
+    // This is a degenerate case: the extent of the polygon is less than EPSILON
+    // or 2 nearly identical points were found.
+    // Try with Green Formula as a fallback, but this is not a guarantee
+    // as we'll probably be affected by numerical instabilities.
+
+    double dfSum = GetX(data, 0, nDim, bNeedSwap) *
+                   (GetY(data, 1, nDim, bNeedSwap) -
+                    GetY(data, nPoints - 1, nDim, bNeedSwap));
+
+    for (uint32_t i = 1; i < nPoints - 1; i++)
+    {
+        dfSum += GetX(data, i, nDim, bNeedSwap) *
+                 (GetY(data, i + 1, nDim, bNeedSwap) -
+                  GetY(data, i - 1, nDim, bNeedSwap));
+    }
+
+    dfSum += GetX(data, nPoints - 1, nDim, bNeedSwap) *
+             (GetY(data, 0, nDim, bNeedSwap) -
+              GetX(data, nPoints - 2, nDim, bNeedSwap));
+
+    return dfSum < 0;
+}
+
+/************************************************************************/
+/*                OGRWKBFixupCounterClockWiseExternalRing()             */
+/************************************************************************/
+
+static bool OGRWKBFixupCounterClockWiseExternalRingInternal(
+    GByte *data, size_t size, size_t &iOffsetInOut, const int nRec)
+{
+    if (size - iOffsetInOut < MIN_WKB_SIZE)
+    {
+        return false;
+    }
+    const int nByteOrder = DB2_V72_FIX_BYTE_ORDER(data[iOffsetInOut]);
+    if (!(nByteOrder == wkbXDR || nByteOrder == wkbNDR))
+    {
+        return false;
+    }
+    const OGRwkbByteOrder eByteOrder = static_cast<OGRwkbByteOrder>(nByteOrder);
+
+    OGRwkbGeometryType eGeometryType = wkbUnknown;
+    OGRReadWKBGeometryType(data + iOffsetInOut, wkbVariantIso, &eGeometryType);
+    iOffsetInOut += 5;
+    const auto eFlatType = wkbFlatten(eGeometryType);
+    const int nDim = 2 + (OGR_GT_HasZ(eGeometryType) ? 1 : 0) +
+                     (OGR_GT_HasM(eGeometryType) ? 1 : 0);
+
+    if (eFlatType == wkbPolygon)
+    {
+        const uint32_t nRings =
+            OGRWKBReadUInt32AtOffset(data, eByteOrder, iOffsetInOut);
+        if (nRings > (size - iOffsetInOut) / sizeof(uint32_t))
+        {
+            return false;
+        }
+        for (uint32_t iRing = 0; iRing < nRings; ++iRing)
+        {
+            if (iOffsetInOut + sizeof(uint32_t) > size)
+                return false;
+            const uint32_t nPoints =
+                OGRWKBReadUInt32AtOffset(data, eByteOrder, iOffsetInOut);
+            const size_t sizeOfPoint = nDim * sizeof(double);
+            if (nPoints > (size - iOffsetInOut) / sizeOfPoint)
+            {
+                return false;
+            }
+
+            if (nPoints >= 4)
+            {
+                const bool bIsClockwiseRing = OGRWKBIsClockwiseRing(
+                    data + iOffsetInOut, nPoints, nDim, OGR_SWAP(eByteOrder));
+                if ((bIsClockwiseRing && iRing == 0) ||
+                    (!bIsClockwiseRing && iRing > 0))
+                {
+                    GByte abyTmp[4 * sizeof(double)];
+                    for (uint32_t i = 0; i < nPoints / 2; ++i)
+                    {
+                        GByte *pBegin = data + iOffsetInOut + i * sizeOfPoint;
+                        GByte *pEnd = data + iOffsetInOut +
+                                      (nPoints - 1 - i) * sizeOfPoint;
+                        memcpy(abyTmp, pBegin, sizeOfPoint);
+                        memcpy(pBegin, pEnd, sizeOfPoint);
+                        memcpy(pEnd, abyTmp, sizeOfPoint);
+                    }
+                }
+            }
+
+            iOffsetInOut += nPoints * sizeOfPoint;
+        }
+    }
+
+    if (eFlatType == wkbGeometryCollection || eFlatType == wkbMultiPolygon ||
+        eFlatType == wkbMultiSurface)
+    {
+        if (nRec == 128)
+        {
+            return false;
+        }
+        const uint32_t nParts =
+            OGRWKBReadUInt32AtOffset(data, eByteOrder, iOffsetInOut);
+        if (nParts > (size - iOffsetInOut) / MIN_WKB_SIZE)
+        {
+            return false;
+        }
+        for (uint32_t k = 0; k < nParts; k++)
+        {
+            if (!OGRWKBFixupCounterClockWiseExternalRingInternal(
+                    data, size, iOffsetInOut, nRec))
+            {
+                return false;
+            }
+        }
+    }
+
+    return true;
+}
+
+/** Modifies the geometry such that exterior rings of polygons are
+ * counter-clockwise oriented and inner rings clockwise oriented.
+ */
+void OGRWKBFixupCounterClockWiseExternalRing(GByte *pabyWkb, size_t nWKBSize)
+{
+    size_t iOffsetInOut = 0;
+    OGRWKBFixupCounterClockWiseExternalRingInternal(
+        pabyWkb, nWKBSize, iOffsetInOut, /* nRec = */ 0);
+}
+
+/************************************************************************/
 /*                         OGRAppendBuffer()                            */
 /************************************************************************/
 

--- a/ogr/ogr_wkb.h
+++ b/ogr/ogr_wkb.h
@@ -32,8 +32,8 @@
 #include "cpl_port.h"
 #include "ogr_core.h"
 
-bool OGRWKBGetGeomType(const GByte *pabyWkb, size_t nWKBSize, bool &bNeedSwap,
-                       uint32_t &nType);
+bool CPL_DLL OGRWKBGetGeomType(const GByte *pabyWkb, size_t nWKBSize,
+                               bool &bNeedSwap, uint32_t &nType);
 bool OGRWKBPolygonGetArea(const GByte *&pabyWkb, size_t &nWKBSize,
                           double &dfArea);
 bool OGRWKBMultiPolygonGetArea(const GByte *&pabyWkb, size_t &nWKBSize,

--- a/ogr/ogr_wkb.h
+++ b/ogr/ogr_wkb.h
@@ -45,6 +45,9 @@ bool CPL_DLL OGRWKBGetBoundingBox(const GByte *pabyWkb, size_t nWKBSize,
 bool CPL_DLL OGRWKBIsWithinPessimistic(const GByte *pabyWkb, size_t nWKBSize,
                                        const OGREnvelope &sEnvelope);
 
+void CPL_DLL OGRWKBFixupCounterClockWiseExternalRing(GByte *pabyWkb,
+                                                     size_t nWKBSize);
+
 /** Modifies a PostGIS-style Extended WKB geometry to a regular WKB one.
  * pabyEWKB will be modified in place.
  * The return value will be either at the beginning of pabyEWKB or 4 bytes

--- a/ogr/ogrcurve.cpp
+++ b/ogr/ogrcurve.cpp
@@ -711,6 +711,9 @@ static inline bool epsilonEqual(double a, double b, double eps)
 int OGRCurve::isClockwise() const
 
 {
+    // WARNING: keep in sync OGRLineString::isClockwise(),
+    // OGRCurve::isClockwise() and OGRWKBIsClockwiseRing()
+
     const int nPointCount = getNumPoints();
     if (nPointCount < 3)
         return TRUE;

--- a/ogr/ogrfeature.cpp
+++ b/ogr/ogrfeature.cpp
@@ -6853,7 +6853,7 @@ void OGRFeature::FillUnsetWithDefault(int bNotNullableOnly,
     const int nFieldCount = poDefn->GetFieldCount();
     for (int i = 0; i < nFieldCount; i++)
     {
-        if (IsFieldSet(i))
+        if (IsFieldSetUnsafe(i))
             continue;
         const auto poFieldDefn = poDefn->GetFieldDefn(i);
         if (bNotNullableOnly && poFieldDefn->IsNullable())

--- a/ogr/ogrfeature.cpp
+++ b/ogr/ogrfeature.cpp
@@ -3569,9 +3569,20 @@ char *OGRFeature::GetFieldAsSerializedJSon(int iField) const
         json_object *poObj = json_object_new_array();
         int nCount = 0;
         const int *panValues = GetFieldAsIntegerList(iField, &nCount);
-        for (int i = 0; i < nCount; i++)
+        if (poFDefn->GetSubType() == OFSTBoolean)
         {
-            json_object_array_add(poObj, json_object_new_int(panValues[i]));
+            for (int i = 0; i < nCount; i++)
+            {
+                json_object_array_add(
+                    poObj, json_object_new_boolean(panValues[i] != 0));
+            }
+        }
+        else
+        {
+            for (int i = 0; i < nCount; i++)
+            {
+                json_object_array_add(poObj, json_object_new_int(panValues[i]));
+            }
         }
         pszRet = CPLStrdup(json_object_to_json_string(poObj));
         json_object_put(poObj);

--- a/ogr/ogrlinestring.cpp
+++ b/ogr/ogrlinestring.cpp
@@ -2972,6 +2972,9 @@ static inline bool epsilonEqual(double a, double b, double eps)
 int OGRLineString::isClockwise() const
 
 {
+    // WARNING: keep in sync OGRLineString::isClockwise(),
+    // OGRCurve::isClockwise() and OGRWKBIsClockwiseRing()
+
     if (nPointCount < 2)
         return TRUE;
 

--- a/ogr/ogrsf_frmts/arrow/ogr_feather.h
+++ b/ogr/ogrsf_frmts/arrow/ogr_feather.h
@@ -195,6 +195,10 @@ class OGRFeatherWriterLayer final : public OGRArrowWriterLayer
     bool SetOptions(const std::string &osFilename, CSLConstList papszOptions,
                     OGRSpatialReference *poSpatialRef,
                     OGRwkbGeometryType eGType);
+
+    bool WriteArrowBatch(const struct ArrowSchema *schema,
+                         struct ArrowArray *array,
+                         CSLConstList papszOptions = nullptr) override;
 };
 
 /************************************************************************/

--- a/ogr/ogrsf_frmts/arrow/ogrfeatherwriterlayer.cpp
+++ b/ogr/ogrsf_frmts/arrow/ogrfeatherwriterlayer.cpp
@@ -460,3 +460,29 @@ bool OGRFeatherWriterLayer::FlushGroup()
     m_apoBuilders.clear();
     return ret;
 }
+
+/************************************************************************/
+/*                          WriteArrowBatch()                           */
+/************************************************************************/
+
+inline bool
+OGRFeatherWriterLayer::WriteArrowBatch(const struct ArrowSchema *schema,
+                                       struct ArrowArray *array,
+                                       CSLConstList papszOptions)
+{
+    return WriteArrowBatchInternal(
+        schema, array, papszOptions,
+        [this](const std::shared_ptr<arrow::RecordBatch> &poBatch)
+        {
+            auto status = m_poFileWriter->WriteRecordBatch(*poBatch);
+            if (!status.ok())
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "WriteRecordBatch() failed: %s",
+                         status.message().c_str());
+                return false;
+            }
+
+            return true;
+        });
+}

--- a/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
+++ b/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
@@ -408,6 +408,7 @@ class OGRArrowWriterLayer CPL_NON_FINAL : public OGRLayer
     GIntBig GetFeatureCount(int bForce) override;
 
     bool IsArrowSchemaSupported(const struct ArrowSchema * /*schema*/,
+                                CSLConstList /* papszOptions */,
                                 std::string & /*osErrorMsg */) const override
     {
         return true;

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowwriterlayer.hpp
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowwriterlayer.hpp
@@ -31,6 +31,9 @@
 #include "cpl_json.h"
 #include "cpl_time.h"
 
+#include "ogrlayerarrow.h"
+#include "ogr_wkb.h"
+
 #include <cinttypes>
 #include <limits>
 
@@ -98,7 +101,7 @@ inline void OGRArrowWriterLayer::FinalizeWriting()
     {
         PerformStepsBeforeFinalFlushGroup();
 
-        if (!m_apoBuilders.empty())
+        if (!m_apoBuilders.empty() && m_apoFieldsFromArrowSchema.empty())
             FlushGroup();
 
         CloseFileWriter();
@@ -123,6 +126,12 @@ inline void OGRArrowWriterLayer::CreateSchemaCommon()
     {
         bNeedGDALSchema = true;
         fields.emplace_back(arrow::field(m_osFIDColumn, arrow::int64(), false));
+    }
+
+    if (!m_apoFieldsFromArrowSchema.empty())
+    {
+        fields.insert(fields.end(), m_apoFieldsFromArrowSchema.begin(),
+                      m_apoFieldsFromArrowSchema.end());
     }
 
     for (int i = 0; i < m_poFeatureDefn->GetFieldCount(); ++i)
@@ -515,8 +524,83 @@ inline OGRErr OGRArrowWriterLayer::CreateField(OGRFieldDefn *poField,
                  "Cannot add field after a first feature has been written");
         return OGRERR_FAILURE;
     }
+    if (!m_apoFieldsFromArrowSchema.empty())
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "Cannot mix calls to CreateField() and "
+                 "CreateFieldFromArrowSchema()");
+        return OGRERR_FAILURE;
+    }
     m_poFeatureDefn->AddFieldDefn(poField);
     return OGRERR_NONE;
+}
+
+/************************************************************************/
+/*                OGRLayer::CreateFieldFromArrowSchema()                */
+/************************************************************************/
+
+inline bool OGRArrowWriterLayer::CreateFieldFromArrowSchema(
+    const struct ArrowSchema *schema, CSLConstList /*papszOptions*/)
+{
+    if (m_poSchema)
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "Cannot add field after a first feature has been written");
+        return false;
+    }
+
+    if (m_poFeatureDefn->GetFieldCount())
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "Cannot mix calls to CreateField() and "
+                 "CreateFieldFromArrowSchema()");
+        return false;
+    }
+
+    if (m_osFIDColumn == schema->name)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "FID column has the same name as this field: %s",
+                 schema->name);
+        return false;
+    }
+
+    for (auto &apoField : m_apoFieldsFromArrowSchema)
+    {
+        if (apoField->name() == schema->name)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Field of name %s already exists", schema->name);
+            return false;
+        }
+    }
+
+    if (m_poFeatureDefn->GetGeomFieldIndex(schema->name) >= 0)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Geometry field of name %s already exists", schema->name);
+        return false;
+    }
+
+    // ImportField() would release the schema, but we don't want that
+    // So copy the structure content into a local variable, and override its
+    // release callback to a no-op. This may be a bit fragile, but it doesn't
+    // look like ImportField implementation tries to access the C ArrowSchema
+    // after it has been called.
+    struct ArrowSchema lSchema = *schema;
+    const auto DummyFreeSchema = [](struct ArrowSchema *ptrSchema)
+    { ptrSchema->release = nullptr; };
+    lSchema.release = DummyFreeSchema;
+    auto result = arrow::ImportField(&lSchema);
+    CPLAssert(lSchema.release == nullptr);
+    if (!result.ok())
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "CreateFieldFromArrowSchema() failed");
+        return false;
+    }
+    m_apoFieldsFromArrowSchema.emplace_back(std::move(*result));
+    return true;
 }
 
 /************************************************************************/
@@ -828,6 +912,325 @@ inline void OGRArrowWriterLayer::CreateArrayBuilders()
 }
 
 /************************************************************************/
+/*                          BuildGeometry()                             */
+/************************************************************************/
+
+inline OGRErr OGRArrowWriterLayer::BuildGeometry(OGRGeometry *poGeom,
+                                                 int iGeomField,
+                                                 arrow::ArrayBuilder *poBuilder)
+{
+    const auto eGType = poGeom ? poGeom->getGeometryType() : wkbNone;
+    const auto eColumnGType =
+        m_poFeatureDefn->GetGeomFieldDefn(iGeomField)->GetType();
+    const bool bIsEmpty = poGeom != nullptr && poGeom->IsEmpty();
+    if (poGeom != nullptr && !bIsEmpty)
+    {
+        if (poGeom->Is3D())
+        {
+            OGREnvelope3D oEnvelope;
+            poGeom->getEnvelope(&oEnvelope);
+            m_aoEnvelopes[iGeomField].Merge(oEnvelope);
+        }
+        else
+        {
+            OGREnvelope oEnvelope;
+            poGeom->getEnvelope(&oEnvelope);
+            m_aoEnvelopes[iGeomField].Merge(oEnvelope);
+        }
+        m_oSetWrittenGeometryTypes[iGeomField].insert(eGType);
+    }
+
+    if (poGeom == nullptr)
+    {
+        if (m_aeGeomEncoding[iGeomField] ==
+                OGRArrowGeomEncoding::GEOARROW_POINT &&
+            GetDriverUCName() == "PARQUET")
+        {
+            // For some reason, Parquet doesn't support a NULL FixedSizeList
+            // on reading
+            auto poPointBuilder =
+                static_cast<arrow::FixedSizeListBuilder *>(poBuilder);
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(poPointBuilder->Append());
+            auto poValueBuilder = static_cast<arrow::DoubleBuilder *>(
+                poPointBuilder->value_builder());
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(poValueBuilder->Append(
+                std::numeric_limits<double>::quiet_NaN()));
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(poValueBuilder->Append(
+                std::numeric_limits<double>::quiet_NaN()));
+            if (OGR_GT_HasZ(eGType))
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(poValueBuilder->Append(
+                    std::numeric_limits<double>::quiet_NaN()));
+            if (OGR_GT_HasM(eGType))
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(poValueBuilder->Append(
+                    std::numeric_limits<double>::quiet_NaN()));
+        }
+        else
+        {
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(poBuilder->AppendNull());
+        }
+    }
+    else if (m_aeGeomEncoding[iGeomField] == OGRArrowGeomEncoding::WKB)
+    {
+        std::unique_ptr<OGRGeometry> poGeomModified;
+        if (OGR_GT_HasM(eGType) && !OGR_GT_HasM(eColumnGType))
+        {
+            static bool bHasWarned = false;
+            if (!bHasWarned)
+            {
+                CPLError(CE_Warning, CPLE_AppDefined,
+                         "Removing M component from geometry");
+                bHasWarned = true;
+            }
+            poGeomModified.reset(poGeom->clone());
+            poGeomModified->setMeasured(false);
+            poGeom = poGeomModified.get();
+        }
+        FixupGeometryBeforeWriting(poGeom);
+        const auto nSize = poGeom->WkbSize();
+        if (nSize < INT_MAX)
+        {
+            m_abyBuffer.resize(nSize);
+            poGeom->exportToWkb(wkbNDR, &m_abyBuffer[0], wkbVariantIso);
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                static_cast<arrow::BinaryBuilder *>(poBuilder)->Append(
+                    m_abyBuffer.data(), static_cast<int>(m_abyBuffer.size())));
+        }
+        else
+        {
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "Too big geometry. "
+                     "Writing null geometry");
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(poBuilder->AppendNull());
+        }
+    }
+    else if (m_aeGeomEncoding[iGeomField] == OGRArrowGeomEncoding::WKT)
+    {
+        OGRWktOptions options;
+        options.variant = wkbVariantIso;
+        if (m_nWKTCoordinatePrecision >= 0)
+        {
+            options.format = OGRWktFormat::F;
+            options.precision = m_nWKTCoordinatePrecision;
+        }
+        OGR_ARROW_RETURN_OGRERR_NOT_OK(
+            static_cast<arrow::StringBuilder *>(poBuilder)->Append(
+                poGeom->exportToWkt(options)));
+    }
+    // The following checks are only valid for GeoArrow encoding
+    else if ((!bIsEmpty && eGType != eColumnGType) ||
+             (bIsEmpty && wkbFlatten(eGType) != wkbFlatten(eColumnGType)))
+    {
+        CPLError(CE_Warning, CPLE_AppDefined,
+                 "Geometry of type %s found, whereas %s is expected. "
+                 "Writing null geometry",
+                 OGRGeometryTypeToName(eGType),
+                 OGRGeometryTypeToName(eColumnGType));
+        OGR_ARROW_RETURN_OGRERR_NOT_OK(poBuilder->AppendNull());
+    }
+    else if (!bIsEmpty && poGeom->Is3D() != OGR_GT_HasZ(eColumnGType))
+    {
+        CPLError(CE_Warning, CPLE_AppDefined,
+                 "Geometry Z flag (%d) != column geometry type Z flag (%d)d. "
+                 "Writing null geometry",
+                 poGeom->Is3D(), OGR_GT_HasZ(eColumnGType));
+        OGR_ARROW_RETURN_OGRERR_NOT_OK(poBuilder->AppendNull());
+    }
+    else if (!bIsEmpty && poGeom->IsMeasured() != OGR_GT_HasM(eColumnGType))
+    {
+        CPLError(CE_Warning, CPLE_AppDefined,
+                 "Geometry M flag (%d) != column geometry type M flag (%d)d. "
+                 "Writing null geometry",
+                 poGeom->IsMeasured(), OGR_GT_HasM(eColumnGType));
+        OGR_ARROW_RETURN_OGRERR_NOT_OK(poBuilder->AppendNull());
+    }
+    else if (m_aeGeomEncoding[iGeomField] ==
+             OGRArrowGeomEncoding::GEOARROW_POINT)
+    {
+        const auto poPoint = poGeom->toPoint();
+        auto poPointBuilder =
+            static_cast<arrow::FixedSizeListBuilder *>(poBuilder);
+        OGR_ARROW_RETURN_OGRERR_NOT_OK(poPointBuilder->Append());
+        auto poValueBuilder = static_cast<arrow::DoubleBuilder *>(
+            poPointBuilder->value_builder());
+        if (bIsEmpty)
+        {
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(poValueBuilder->Append(
+                std::numeric_limits<double>::quiet_NaN()));
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(poValueBuilder->Append(
+                std::numeric_limits<double>::quiet_NaN()));
+        }
+        else
+        {
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                poValueBuilder->Append(poPoint->getX()));
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                poValueBuilder->Append(poPoint->getY()));
+        }
+        if (OGR_GT_HasZ(eColumnGType))
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                poValueBuilder->Append(poPoint->getZ()));
+        if (OGR_GT_HasM(eColumnGType))
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                poValueBuilder->Append(poPoint->getM()));
+    }
+    else if (m_aeGeomEncoding[iGeomField] ==
+             OGRArrowGeomEncoding::GEOARROW_LINESTRING)
+    {
+        const auto poLS = poGeom->toLineString();
+        auto poListBuilder = static_cast<arrow::ListBuilder *>(poBuilder);
+        auto poPointBuilder = static_cast<arrow::FixedSizeListBuilder *>(
+            poListBuilder->value_builder());
+        auto poValueBuilder = static_cast<arrow::DoubleBuilder *>(
+            poPointBuilder->value_builder());
+        OGR_ARROW_RETURN_OGRERR_NOT_OK(poListBuilder->Append());
+        for (int j = 0; j < poLS->getNumPoints(); ++j)
+        {
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(poPointBuilder->Append());
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                poValueBuilder->Append(poLS->getX(j)));
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                poValueBuilder->Append(poLS->getY(j)));
+            if (poGeom->Is3D())
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                    poValueBuilder->Append(poLS->getZ(j)));
+            if (poGeom->IsMeasured())
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                    poValueBuilder->Append(poLS->getM(j)));
+        }
+    }
+    else if (m_aeGeomEncoding[iGeomField] ==
+             OGRArrowGeomEncoding::GEOARROW_POLYGON)
+    {
+        const auto poPolygon = poGeom->toPolygon();
+        auto poPolygonBuilder = static_cast<arrow::ListBuilder *>(poBuilder);
+        auto poRingBuilder = static_cast<arrow::ListBuilder *>(
+            poPolygonBuilder->value_builder());
+        auto poPointBuilder = static_cast<arrow::FixedSizeListBuilder *>(
+            poRingBuilder->value_builder());
+        auto poValueBuilder = static_cast<arrow::DoubleBuilder *>(
+            poPointBuilder->value_builder());
+        OGR_ARROW_RETURN_OGRERR_NOT_OK(poPolygonBuilder->Append());
+        for (const auto *poRing : *poPolygon)
+        {
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(poRingBuilder->Append());
+            for (int j = 0; j < poRing->getNumPoints(); ++j)
+            {
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(poPointBuilder->Append());
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                    poValueBuilder->Append(poRing->getX(j)));
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                    poValueBuilder->Append(poRing->getY(j)));
+                if (poGeom->Is3D())
+                    OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                        poValueBuilder->Append(poRing->getZ(j)));
+                if (poGeom->IsMeasured())
+                    OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                        poValueBuilder->Append(poRing->getM(j)));
+            }
+        }
+    }
+    else if (m_aeGeomEncoding[iGeomField] ==
+             OGRArrowGeomEncoding::GEOARROW_MULTIPOINT)
+    {
+        const auto poMultiPoint = poGeom->toMultiPoint();
+        auto poListBuilder = static_cast<arrow::ListBuilder *>(poBuilder);
+        auto poPointBuilder = static_cast<arrow::FixedSizeListBuilder *>(
+            poListBuilder->value_builder());
+        auto poValueBuilder = static_cast<arrow::DoubleBuilder *>(
+            poPointBuilder->value_builder());
+        OGR_ARROW_RETURN_OGRERR_NOT_OK(poListBuilder->Append());
+        for (const auto *poPoint : *poMultiPoint)
+        {
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(poPointBuilder->Append());
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                poValueBuilder->Append(poPoint->getX()));
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                poValueBuilder->Append(poPoint->getY()));
+            if (poGeom->Is3D())
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                    poValueBuilder->Append(poPoint->getZ()));
+            if (poGeom->IsMeasured())
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                    poValueBuilder->Append(poPoint->getM()));
+        }
+    }
+    else if (m_aeGeomEncoding[iGeomField] ==
+             OGRArrowGeomEncoding::GEOARROW_MULTILINESTRING)
+    {
+        const auto poMLS = poGeom->toMultiLineString();
+        auto poMLSBuilder = static_cast<arrow::ListBuilder *>(poBuilder);
+        auto poLSBuilder =
+            static_cast<arrow::ListBuilder *>(poMLSBuilder->value_builder());
+        auto poPointBuilder = static_cast<arrow::FixedSizeListBuilder *>(
+            poLSBuilder->value_builder());
+        auto poValueBuilder = static_cast<arrow::DoubleBuilder *>(
+            poPointBuilder->value_builder());
+        OGR_ARROW_RETURN_OGRERR_NOT_OK(poMLSBuilder->Append());
+        for (const auto *poLS : *poMLS)
+        {
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(poLSBuilder->Append());
+            for (int j = 0; j < poLS->getNumPoints(); ++j)
+            {
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(poPointBuilder->Append());
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                    poValueBuilder->Append(poLS->getX(j)));
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                    poValueBuilder->Append(poLS->getY(j)));
+                if (poGeom->Is3D())
+                    OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                        poValueBuilder->Append(poLS->getZ(j)));
+                if (poGeom->IsMeasured())
+                    OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                        poValueBuilder->Append(poLS->getM(j)));
+            }
+        }
+    }
+    else if (m_aeGeomEncoding[iGeomField] ==
+             OGRArrowGeomEncoding::GEOARROW_MULTIPOLYGON)
+    {
+        const auto poMPoly = poGeom->toMultiPolygon();
+        auto poMPolyBuilder = static_cast<arrow::ListBuilder *>(poBuilder);
+        auto poPolyBuilder =
+            static_cast<arrow::ListBuilder *>(poMPolyBuilder->value_builder());
+        auto poRingBuilder =
+            static_cast<arrow::ListBuilder *>(poPolyBuilder->value_builder());
+        auto poPointBuilder = static_cast<arrow::FixedSizeListBuilder *>(
+            poRingBuilder->value_builder());
+        auto poValueBuilder = static_cast<arrow::DoubleBuilder *>(
+            poPointBuilder->value_builder());
+        OGR_ARROW_RETURN_OGRERR_NOT_OK(poMPolyBuilder->Append());
+        for (const auto *poPolygon : *poMPoly)
+        {
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(poPolyBuilder->Append());
+            for (const auto *poRing : *poPolygon)
+            {
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(poRingBuilder->Append());
+                for (int j = 0; j < poRing->getNumPoints(); ++j)
+                {
+                    OGR_ARROW_RETURN_OGRERR_NOT_OK(poPointBuilder->Append());
+                    OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                        poValueBuilder->Append(poRing->getX(j)));
+                    OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                        poValueBuilder->Append(poRing->getY(j)));
+                    if (poGeom->Is3D())
+                        OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                            poValueBuilder->Append(poRing->getZ(j)));
+                    if (poGeom->IsMeasured())
+                        OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                            poValueBuilder->Append(poRing->getM(j)));
+                }
+            }
+        }
+    }
+    else
+    {
+        CPLAssert(false);
+    }
+
+    return OGRERR_NONE;
+}
+
+/************************************************************************/
 /*                          ICreateFeature()                            */
 /************************************************************************/
 
@@ -840,6 +1243,13 @@ inline OGRErr OGRArrowWriterLayer::ICreateFeature(OGRFeature *poFeature)
 
     if (m_apoBuilders.empty())
     {
+        if (!m_apoFieldsFromArrowSchema.empty())
+        {
+            CPLError(CE_Failure, CPLE_NotSupported,
+                     "ICreateFeature() cannot be used after "
+                     "CreateFieldFromArrowSchema()");
+            return OGRERR_FAILURE;
+        }
         CreateArrayBuilders();
     }
 
@@ -1216,315 +1626,8 @@ inline OGRErr OGRArrowWriterLayer::ICreateFeature(OGRFeature *poFeature)
     {
         auto poBuilder = m_apoBuilders[nArrowIdx].get();
         OGRGeometry *poGeom = poFeature->GetGeomFieldRef(i);
-        const auto eGType = poGeom ? poGeom->getGeometryType() : wkbNone;
-        const auto eColumnGType =
-            m_poFeatureDefn->GetGeomFieldDefn(i)->GetType();
-        const bool bIsEmpty = poGeom != nullptr && poGeom->IsEmpty();
-        if (poGeom != nullptr && !bIsEmpty)
-        {
-            if (poGeom->Is3D())
-            {
-                OGREnvelope3D oEnvelope;
-                poGeom->getEnvelope(&oEnvelope);
-                m_aoEnvelopes[i].Merge(oEnvelope);
-            }
-            else
-            {
-                OGREnvelope oEnvelope;
-                poGeom->getEnvelope(&oEnvelope);
-                m_aoEnvelopes[i].Merge(oEnvelope);
-            }
-            m_oSetWrittenGeometryTypes[i].insert(eGType);
-        }
-
-        if (poGeom == nullptr)
-        {
-            if (m_aeGeomEncoding[i] == OGRArrowGeomEncoding::GEOARROW_POINT &&
-                GetDriverUCName() == "PARQUET")
-            {
-                // For some reason, Parquet doesn't support a NULL FixedSizeList
-                // on reading
-                auto poPointBuilder =
-                    static_cast<arrow::FixedSizeListBuilder *>(poBuilder);
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(poPointBuilder->Append());
-                auto poValueBuilder = static_cast<arrow::DoubleBuilder *>(
-                    poPointBuilder->value_builder());
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(poValueBuilder->Append(
-                    std::numeric_limits<double>::quiet_NaN()));
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(poValueBuilder->Append(
-                    std::numeric_limits<double>::quiet_NaN()));
-                if (OGR_GT_HasZ(eGType))
-                    OGR_ARROW_RETURN_OGRERR_NOT_OK(poValueBuilder->Append(
-                        std::numeric_limits<double>::quiet_NaN()));
-                if (OGR_GT_HasM(eGType))
-                    OGR_ARROW_RETURN_OGRERR_NOT_OK(poValueBuilder->Append(
-                        std::numeric_limits<double>::quiet_NaN()));
-            }
-            else
-            {
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(poBuilder->AppendNull());
-            }
-        }
-        else if (m_aeGeomEncoding[i] == OGRArrowGeomEncoding::WKB)
-        {
-            std::unique_ptr<OGRGeometry> poGeomModified;
-            if (OGR_GT_HasM(eGType) && !OGR_GT_HasM(eColumnGType))
-            {
-                static bool bHasWarned = false;
-                if (!bHasWarned)
-                {
-                    CPLError(CE_Warning, CPLE_AppDefined,
-                             "Removing M component from geometry");
-                    bHasWarned = true;
-                }
-                poGeomModified.reset(poGeom->clone());
-                poGeomModified->setMeasured(false);
-                poGeom = poGeomModified.get();
-            }
-            FixupGeometryBeforeWriting(poGeom);
-            const auto nSize = poGeom->WkbSize();
-            if (nSize < INT_MAX)
-            {
-                m_abyBuffer.resize(nSize);
-                poGeom->exportToWkb(wkbNDR, &m_abyBuffer[0], wkbVariantIso);
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                    static_cast<arrow::BinaryBuilder *>(poBuilder)->Append(
-                        m_abyBuffer.data(),
-                        static_cast<int>(m_abyBuffer.size())));
-            }
-            else
-            {
-                CPLError(CE_Warning, CPLE_AppDefined,
-                         "Too big geometry. "
-                         "Writing null geometry");
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(poBuilder->AppendNull());
-            }
-        }
-        else if (m_aeGeomEncoding[i] == OGRArrowGeomEncoding::WKT)
-        {
-            OGRWktOptions options;
-            options.variant = wkbVariantIso;
-            if (m_nWKTCoordinatePrecision >= 0)
-            {
-                options.format = OGRWktFormat::F;
-                options.precision = m_nWKTCoordinatePrecision;
-            }
-            OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                static_cast<arrow::StringBuilder *>(poBuilder)->Append(
-                    poGeom->exportToWkt(options)));
-        }
-        // The following checks are only valid for GeoArrow encoding
-        else if ((!bIsEmpty && eGType != eColumnGType) ||
-                 (bIsEmpty && wkbFlatten(eGType) != wkbFlatten(eColumnGType)))
-        {
-            CPLError(CE_Warning, CPLE_AppDefined,
-                     "Geometry of type %s found, whereas %s is expected. "
-                     "Writing null geometry",
-                     OGRGeometryTypeToName(eGType),
-                     OGRGeometryTypeToName(eColumnGType));
-            OGR_ARROW_RETURN_OGRERR_NOT_OK(poBuilder->AppendNull());
-        }
-        else if (!bIsEmpty && poGeom->Is3D() != OGR_GT_HasZ(eColumnGType))
-        {
-            CPLError(
-                CE_Warning, CPLE_AppDefined,
-                "Geometry Z flag (%d) != column geometry type Z flag (%d)d. "
-                "Writing null geometry",
-                poGeom->Is3D(), OGR_GT_HasZ(eColumnGType));
-            OGR_ARROW_RETURN_OGRERR_NOT_OK(poBuilder->AppendNull());
-        }
-        else if (!bIsEmpty && poGeom->IsMeasured() != OGR_GT_HasM(eColumnGType))
-        {
-            CPLError(
-                CE_Warning, CPLE_AppDefined,
-                "Geometry M flag (%d) != column geometry type M flag (%d)d. "
-                "Writing null geometry",
-                poGeom->IsMeasured(), OGR_GT_HasM(eColumnGType));
-            OGR_ARROW_RETURN_OGRERR_NOT_OK(poBuilder->AppendNull());
-        }
-        else if (m_aeGeomEncoding[i] == OGRArrowGeomEncoding::GEOARROW_POINT)
-        {
-            const auto poPoint = poGeom->toPoint();
-            auto poPointBuilder =
-                static_cast<arrow::FixedSizeListBuilder *>(poBuilder);
-            OGR_ARROW_RETURN_OGRERR_NOT_OK(poPointBuilder->Append());
-            auto poValueBuilder = static_cast<arrow::DoubleBuilder *>(
-                poPointBuilder->value_builder());
-            if (bIsEmpty)
-            {
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(poValueBuilder->Append(
-                    std::numeric_limits<double>::quiet_NaN()));
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(poValueBuilder->Append(
-                    std::numeric_limits<double>::quiet_NaN()));
-            }
-            else
-            {
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                    poValueBuilder->Append(poPoint->getX()));
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                    poValueBuilder->Append(poPoint->getY()));
-            }
-            if (OGR_GT_HasZ(eColumnGType))
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                    poValueBuilder->Append(poPoint->getZ()));
-            if (OGR_GT_HasM(eColumnGType))
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                    poValueBuilder->Append(poPoint->getM()));
-        }
-        else if (m_aeGeomEncoding[i] ==
-                 OGRArrowGeomEncoding::GEOARROW_LINESTRING)
-        {
-            const auto poLS = poGeom->toLineString();
-            auto poListBuilder = static_cast<arrow::ListBuilder *>(poBuilder);
-            auto poPointBuilder = static_cast<arrow::FixedSizeListBuilder *>(
-                poListBuilder->value_builder());
-            auto poValueBuilder = static_cast<arrow::DoubleBuilder *>(
-                poPointBuilder->value_builder());
-            OGR_ARROW_RETURN_OGRERR_NOT_OK(poListBuilder->Append());
-            for (int j = 0; j < poLS->getNumPoints(); ++j)
-            {
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(poPointBuilder->Append());
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                    poValueBuilder->Append(poLS->getX(j)));
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                    poValueBuilder->Append(poLS->getY(j)));
-                if (poGeom->Is3D())
-                    OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                        poValueBuilder->Append(poLS->getZ(j)));
-                if (poGeom->IsMeasured())
-                    OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                        poValueBuilder->Append(poLS->getM(j)));
-            }
-        }
-        else if (m_aeGeomEncoding[i] == OGRArrowGeomEncoding::GEOARROW_POLYGON)
-        {
-            const auto poPolygon = poGeom->toPolygon();
-            auto poPolygonBuilder =
-                static_cast<arrow::ListBuilder *>(poBuilder);
-            auto poRingBuilder = static_cast<arrow::ListBuilder *>(
-                poPolygonBuilder->value_builder());
-            auto poPointBuilder = static_cast<arrow::FixedSizeListBuilder *>(
-                poRingBuilder->value_builder());
-            auto poValueBuilder = static_cast<arrow::DoubleBuilder *>(
-                poPointBuilder->value_builder());
-            OGR_ARROW_RETURN_OGRERR_NOT_OK(poPolygonBuilder->Append());
-            for (const auto *poRing : *poPolygon)
-            {
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(poRingBuilder->Append());
-                for (int j = 0; j < poRing->getNumPoints(); ++j)
-                {
-                    OGR_ARROW_RETURN_OGRERR_NOT_OK(poPointBuilder->Append());
-                    OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                        poValueBuilder->Append(poRing->getX(j)));
-                    OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                        poValueBuilder->Append(poRing->getY(j)));
-                    if (poGeom->Is3D())
-                        OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                            poValueBuilder->Append(poRing->getZ(j)));
-                    if (poGeom->IsMeasured())
-                        OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                            poValueBuilder->Append(poRing->getM(j)));
-                }
-            }
-        }
-        else if (m_aeGeomEncoding[i] ==
-                 OGRArrowGeomEncoding::GEOARROW_MULTIPOINT)
-        {
-            const auto poMultiPoint = poGeom->toMultiPoint();
-            auto poListBuilder = static_cast<arrow::ListBuilder *>(poBuilder);
-            auto poPointBuilder = static_cast<arrow::FixedSizeListBuilder *>(
-                poListBuilder->value_builder());
-            auto poValueBuilder = static_cast<arrow::DoubleBuilder *>(
-                poPointBuilder->value_builder());
-            OGR_ARROW_RETURN_OGRERR_NOT_OK(poListBuilder->Append());
-            for (const auto *poPoint : *poMultiPoint)
-            {
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(poPointBuilder->Append());
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                    poValueBuilder->Append(poPoint->getX()));
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                    poValueBuilder->Append(poPoint->getY()));
-                if (poGeom->Is3D())
-                    OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                        poValueBuilder->Append(poPoint->getZ()));
-                if (poGeom->IsMeasured())
-                    OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                        poValueBuilder->Append(poPoint->getM()));
-            }
-        }
-        else if (m_aeGeomEncoding[i] ==
-                 OGRArrowGeomEncoding::GEOARROW_MULTILINESTRING)
-        {
-            const auto poMLS = poGeom->toMultiLineString();
-            auto poMLSBuilder = static_cast<arrow::ListBuilder *>(poBuilder);
-            auto poLSBuilder = static_cast<arrow::ListBuilder *>(
-                poMLSBuilder->value_builder());
-            auto poPointBuilder = static_cast<arrow::FixedSizeListBuilder *>(
-                poLSBuilder->value_builder());
-            auto poValueBuilder = static_cast<arrow::DoubleBuilder *>(
-                poPointBuilder->value_builder());
-            OGR_ARROW_RETURN_OGRERR_NOT_OK(poMLSBuilder->Append());
-            for (const auto *poLS : *poMLS)
-            {
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(poLSBuilder->Append());
-                for (int j = 0; j < poLS->getNumPoints(); ++j)
-                {
-                    OGR_ARROW_RETURN_OGRERR_NOT_OK(poPointBuilder->Append());
-                    OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                        poValueBuilder->Append(poLS->getX(j)));
-                    OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                        poValueBuilder->Append(poLS->getY(j)));
-                    if (poGeom->Is3D())
-                        OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                            poValueBuilder->Append(poLS->getZ(j)));
-                    if (poGeom->IsMeasured())
-                        OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                            poValueBuilder->Append(poLS->getM(j)));
-                }
-            }
-        }
-        else if (m_aeGeomEncoding[i] ==
-                 OGRArrowGeomEncoding::GEOARROW_MULTIPOLYGON)
-        {
-            const auto poMPoly = poGeom->toMultiPolygon();
-            auto poMPolyBuilder = static_cast<arrow::ListBuilder *>(poBuilder);
-            auto poPolyBuilder = static_cast<arrow::ListBuilder *>(
-                poMPolyBuilder->value_builder());
-            auto poRingBuilder = static_cast<arrow::ListBuilder *>(
-                poPolyBuilder->value_builder());
-            auto poPointBuilder = static_cast<arrow::FixedSizeListBuilder *>(
-                poRingBuilder->value_builder());
-            auto poValueBuilder = static_cast<arrow::DoubleBuilder *>(
-                poPointBuilder->value_builder());
-            OGR_ARROW_RETURN_OGRERR_NOT_OK(poMPolyBuilder->Append());
-            for (const auto *poPolygon : *poMPoly)
-            {
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(poPolyBuilder->Append());
-                for (const auto *poRing : *poPolygon)
-                {
-                    OGR_ARROW_RETURN_OGRERR_NOT_OK(poRingBuilder->Append());
-                    for (int j = 0; j < poRing->getNumPoints(); ++j)
-                    {
-                        OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                            poPointBuilder->Append());
-                        OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                            poValueBuilder->Append(poRing->getX(j)));
-                        OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                            poValueBuilder->Append(poRing->getY(j)));
-                        if (poGeom->Is3D())
-                            OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                                poValueBuilder->Append(poRing->getZ(j)));
-                        if (poGeom->IsMeasured())
-                            OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                                poValueBuilder->Append(poRing->getM(j)));
-                    }
-                }
-            }
-        }
-        else
-        {
-            CPLAssert(false);
-        }
+        if (BuildGeometry(poGeom, i, poBuilder) != OGRERR_NONE)
+            return OGRERR_FAILURE;
     }
 
     m_nFeatureCount++;
@@ -1569,6 +1672,9 @@ inline int OGRArrowWriterLayer::TestCapability(const char *pszCap)
         return m_poSchema == nullptr;
 
     if (EQUAL(pszCap, OLCSequentialWrite))
+        return true;
+
+    if (EQUAL(pszCap, OLCFastWriteArrowBatch))
         return true;
 
     if (EQUAL(pszCap, OLCStringsAsUTF8))
@@ -1643,4 +1749,420 @@ inline bool OGRArrowWriterLayer::WriteArrays(
         nArrowIdx++;
     }
     return true;
+}
+
+/************************************************************************/
+/*                            TestBit()                                 */
+/************************************************************************/
+
+static inline bool TestBit(const uint8_t *pabyData, size_t nIdx)
+{
+    return (pabyData[nIdx / 8] & (1 << (nIdx % 8))) != 0;
+}
+
+/************************************************************************/
+/*                       WriteArrowBatchInternal()                      */
+/************************************************************************/
+
+inline bool OGRArrowWriterLayer::WriteArrowBatchInternal(
+    const struct ArrowSchema *schema, struct ArrowArray *array,
+    CSLConstList papszOptions,
+    std::function<bool(const std::shared_ptr<arrow::RecordBatch> &)> writeBatch)
+{
+    if (m_poSchema == nullptr)
+    {
+        CreateSchema();
+    }
+
+    if (!IsFileWriterCreated())
+    {
+        CreateWriter();
+        if (!IsFileWriterCreated())
+            return false;
+    }
+
+    if (m_apoBuilders.empty())
+    {
+        CreateArrayBuilders();
+    }
+
+    const char *pszFIDName = CSLFetchNameValueDef(
+        papszOptions, "FID", OGRLayer::DEFAULT_ARROW_FID_NAME);
+    const char *pszSingleGeomFieldName =
+        CSLFetchNameValue(papszOptions, "GEOMETRY_NAME");
+
+    // Sort schema and array children in the same order as m_poSchema.
+    // This is needed for non-WKB geometry encoding
+    std::map<std::string, int> oMapSchemaChildrenNameToIdx;
+    for (int i = 0; i < static_cast<int>(schema->n_children); ++i)
+    {
+        if (oMapSchemaChildrenNameToIdx.find(schema->children[i]->name) !=
+            oMapSchemaChildrenNameToIdx.end())
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Several fields with same name '%s' found",
+                     schema->children[i]->name);
+            return false;
+        }
+        oMapSchemaChildrenNameToIdx[schema->children[i]->name] = i;
+
+        if (!pszSingleGeomFieldName && schema->children[i]->metadata)
+        {
+            const auto oMetadata =
+                OGRParseArrowMetadata(schema->children[i]->metadata);
+            auto oIter = oMetadata.find(ARROW_EXTENSION_NAME_KEY);
+            if (oIter != oMetadata.end() && oIter->second == EXTENSION_NAME_WKB)
+            {
+                pszSingleGeomFieldName = schema->children[i]->name;
+            }
+        }
+    }
+    if (!pszSingleGeomFieldName)
+        pszSingleGeomFieldName = OGRLayer::DEFAULT_ARROW_GEOMETRY_NAME;
+
+    std::vector<int> anMapLayerSchemaToArraySchema(m_poSchema->num_fields(),
+                                                   -1);
+    struct ArrowArray fidArray;
+    struct ArrowSchema fidSchema;
+    memset(&fidArray, 0, sizeof(fidArray));
+    memset(&fidSchema, 0, sizeof(fidSchema));
+    std::vector<void *> apBuffers;
+    std::vector<int64_t> fids;
+    std::set<int> oSetReferencedFieldsInArraySchema;
+    const auto DummyFreeArray = [](struct ArrowArray *ptrArray)
+    { ptrArray->release = nullptr; };
+    const auto DummyFreeSchema = [](struct ArrowSchema *ptrSchema)
+    { ptrSchema->release = nullptr; };
+    bool bRebuildBatch = false;
+    for (int i = 0; i < m_poSchema->num_fields(); ++i)
+    {
+        auto oIter =
+            oMapSchemaChildrenNameToIdx.find(m_poSchema->field(i)->name());
+        if (oIter == oMapSchemaChildrenNameToIdx.end())
+        {
+            if (m_poSchema->field(i)->name() == m_osFIDColumn)
+            {
+                oIter = oMapSchemaChildrenNameToIdx.find(pszFIDName);
+                if (oIter == oMapSchemaChildrenNameToIdx.end())
+                {
+                    // If the input data does not contain a FID column, but
+                    // the output file requires it, creates a default FID column
+                    fidArray.release = DummyFreeArray;
+                    fidArray.n_buffers = 2;
+                    apBuffers.resize(2);
+                    fidArray.buffers =
+                        const_cast<const void **>(apBuffers.data());
+                    fids.reserve(static_cast<size_t>(array->length));
+                    for (size_t iRow = 0;
+                         iRow < static_cast<size_t>(array->length); ++iRow)
+                        fids.push_back(m_nFeatureCount + iRow);
+                    fidArray.buffers[1] = fids.data();
+                    fidArray.length = array->length;
+                    fidSchema.release = DummyFreeSchema;
+                    fidSchema.name = m_osFIDColumn.c_str();
+                    fidSchema.format = "l";  // int64
+                    continue;
+                }
+            }
+            else if (m_poFeatureDefn->GetGeomFieldCount() == 1 &&
+                     m_poFeatureDefn->GetGeomFieldIndex(
+                         m_poSchema->field(i)->name().c_str()) == 0)
+            {
+                oIter =
+                    oMapSchemaChildrenNameToIdx.find(pszSingleGeomFieldName);
+                if (oIter != oMapSchemaChildrenNameToIdx.end())
+                    bRebuildBatch = true;
+            }
+
+            if (oIter == oMapSchemaChildrenNameToIdx.end())
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Cannot find field '%s' in schema",
+                         m_poSchema->field(i)->name().c_str());
+                return false;
+            }
+        }
+        anMapLayerSchemaToArraySchema[i] = oIter->second;
+        oSetReferencedFieldsInArraySchema.insert(oIter->second);
+    }
+
+    std::vector<struct ArrowSchema *> newSchemaChildren(
+        m_poSchema->num_fields());
+    std::vector<struct ArrowArray *> newArrayChildren(m_poSchema->num_fields());
+    for (int i = 0; i < m_poSchema->num_fields(); ++i)
+    {
+        if (anMapLayerSchemaToArraySchema[i] < 0)
+        {
+            CPLAssert(m_poSchema->field(i)->name() == m_osFIDColumn);
+            newSchemaChildren[i] = &fidSchema;
+            newArrayChildren[i] = &fidArray;
+        }
+        else
+        {
+            newSchemaChildren[i] =
+                schema->children[anMapLayerSchemaToArraySchema[i]];
+            newArrayChildren[i] =
+                array->children[anMapLayerSchemaToArraySchema[i]];
+        }
+    }
+
+    for (int i = 0; i < static_cast<int>(schema->n_children); ++i)
+    {
+        if (oSetReferencedFieldsInArraySchema.find(i) ==
+            oSetReferencedFieldsInArraySchema.end())
+        {
+            if (m_osFIDColumn.empty() &&
+                strcmp(schema->children[i]->name, pszFIDName) == 0)
+            {
+                // If the input data contains a FID column, but the output data
+                // does not, then ignore it.
+            }
+            else
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Found field '%s' in array schema that does not exist "
+                         "in layer schema",
+                         schema->children[i]->name);
+                return false;
+            }
+        }
+    }
+
+    // ImportSchema() would release the schema, but we don't want that
+    // So copy the structure content into a local variable, and override its
+    // release callback to a no-op. This may be a bit fragile, but it doesn't
+    // look like ImportSchema implementation tries to access the C ArrowSchema
+    // after it has been called.
+    struct ArrowSchema lSchema = *schema;
+    schema = &lSchema;
+    CPL_IGNORE_RET_VAL(schema);
+
+    lSchema.n_children = newSchemaChildren.size();
+    lSchema.children = newSchemaChildren.data();
+
+    lSchema.release = DummyFreeSchema;
+    auto poSchemaResult = arrow::ImportSchema(&lSchema);
+    CPLAssert(lSchema.release == nullptr);
+    if (!poSchemaResult.ok())
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "ImportSchema() failed with %s",
+                 poSchemaResult.status().message().c_str());
+        return false;
+    }
+    auto poSchema = *poSchemaResult;
+
+    // Hack the array to use the new children we've computed above
+    // but make sure the original release() callback sees the original children
+    struct ArrayReleaser
+    {
+        struct ArrowArray ori_array
+        {
+        };
+
+        explicit ArrayReleaser(struct ArrowArray *array)
+        {
+            memcpy(&ori_array, array, sizeof(*array));
+            array->release = ArrayReleaser::release;
+            array->private_data = this;
+        }
+
+        static void release(struct ArrowArray *array)
+        {
+            struct ArrayReleaser *releaser =
+                static_cast<struct ArrayReleaser *>(array->private_data);
+            memcpy(array, &(releaser->ori_array), sizeof(*array));
+            CPLAssert(array->release != nullptr);
+            array->release(array);
+            CPLAssert(array->release == nullptr);
+            delete releaser;
+        }
+    };
+
+    // Must be allocated on the heap, since ArrayReleaser::release() will be
+    // called after this method has ended.
+    ArrayReleaser *releaser = new ArrayReleaser(array);
+    array->private_data = releaser;
+    array->n_children = newArrayChildren.size();
+    array->children = newArrayChildren.data();
+
+    // Process geometry columns:
+    // - if the output encoding is WKB, then just note the geometry type and
+    //   envelope.
+    // - otherwise convert to the output encoding.
+    int nBuilderIdx = 0;
+    if (!m_osFIDColumn.empty())
+    {
+        nBuilderIdx++;
+    }
+    std::map<std::string, std::shared_ptr<arrow::Array>>
+        oMapGeomFieldNameToArray;
+    for (int i = 0; i < m_poFeatureDefn->GetGeomFieldCount();
+         ++i, ++nBuilderIdx)
+    {
+        const char *pszThisGeomFieldName =
+            m_poFeatureDefn->GetGeomFieldDefn(i)->GetNameRef();
+        int nIdx = poSchema->GetFieldIndex(pszThisGeomFieldName);
+        if (nIdx < 0)
+        {
+            if (m_poFeatureDefn->GetGeomFieldCount() == 1)
+                nIdx = poSchema->GetFieldIndex(pszSingleGeomFieldName);
+            if (nIdx < 0)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Cannot find geometry field '%s' in schema",
+                         pszThisGeomFieldName);
+                return false;
+            }
+        }
+
+        if (strcmp(lSchema.children[nIdx]->format, "z") != 0 &&
+            strcmp(lSchema.children[nIdx]->format, "Z") != 0)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Type of geometry field '%s' is not binary, but '%s'",
+                     pszThisGeomFieldName, lSchema.children[nIdx]->format);
+            return false;
+        }
+
+        const auto psGeomArray = array->children[nIdx];
+        const uint8_t *pabyValidity =
+            psGeomArray->null_count != 0
+                ? static_cast<const uint8_t *>(psGeomArray->buffers[0])
+                : nullptr;
+        const bool bUseOffsets32 =
+            (strcmp(lSchema.children[nIdx]->format, "z") == 0);
+        const uint32_t *panOffsets32 =
+            static_cast<const uint32_t *>(psGeomArray->buffers[1]) +
+            array->offset;
+        const uint64_t *panOffsets64 =
+            static_cast<const uint64_t *>(psGeomArray->buffers[1]) +
+            array->offset;
+        GByte *pabyData =
+            static_cast<GByte *>(const_cast<void *>(psGeomArray->buffers[2]));
+        OGREnvelope sEnvelope;
+        auto poBuilder = m_apoBuilders[nBuilderIdx].get();
+
+        for (size_t iRow = 0; iRow < static_cast<size_t>(psGeomArray->length);
+             ++iRow)
+        {
+            if (!pabyValidity ||
+                TestBit(pabyValidity, iRow + psGeomArray->offset))
+            {
+                const auto nLen =
+                    bUseOffsets32 ? static_cast<size_t>(panOffsets32[iRow + 1] -
+                                                        panOffsets32[iRow])
+                                  : static_cast<size_t>(panOffsets64[iRow + 1] -
+                                                        panOffsets64[iRow]);
+                GByte *pabyWkb =
+                    pabyData + (bUseOffsets32
+                                    ? panOffsets32[iRow]
+                                    : static_cast<size_t>(panOffsets64[iRow]));
+                if (m_aeGeomEncoding[i] == OGRArrowGeomEncoding::WKB)
+                {
+                    FixupWKBGeometryBeforeWriting(pabyWkb, nLen);
+
+                    uint32_t nType = 0;
+                    bool bNeedSwap = false;
+                    if (OGRWKBGetGeomType(pabyWkb, nLen, bNeedSwap, nType))
+                    {
+                        m_oSetWrittenGeometryTypes[i].insert(
+                            static_cast<OGRwkbGeometryType>(nType));
+                        if (OGRWKBGetBoundingBox(pabyWkb, nLen, sEnvelope))
+                        {
+                            m_aoEnvelopes[i].Merge(sEnvelope);
+                        }
+                    }
+                }
+                else
+                {
+                    size_t nBytesConsumedOut = 0;
+                    OGRGeometry *poGeometry = nullptr;
+                    OGRGeometryFactory::createFromWkb(
+                        pabyWkb, nullptr, &poGeometry, nLen, wkbVariantIso,
+                        nBytesConsumedOut);
+                    if (BuildGeometry(poGeometry, i, poBuilder) != OGRERR_NONE)
+                    {
+                        delete poGeometry;
+                        return false;
+                    }
+                    delete poGeometry;
+                }
+            }
+            else if (m_aeGeomEncoding[i] != OGRArrowGeomEncoding::WKB)
+            {
+                if (BuildGeometry(nullptr, i, poBuilder) != OGRERR_NONE)
+                    return false;
+            }
+        }
+
+        if (m_aeGeomEncoding[i] != OGRArrowGeomEncoding::WKB)
+        {
+            std::shared_ptr<arrow::Array> geomArray;
+            auto status = poBuilder->Finish(&geomArray);
+            if (!status.ok())
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "builder::Finish() for field %s failed with %s",
+                         pszThisGeomFieldName, status.message().c_str());
+                return false;
+            }
+            oMapGeomFieldNameToArray[pszThisGeomFieldName] =
+                std::move(geomArray);
+        }
+    }
+
+    auto poRecordBatchResult = arrow::ImportRecordBatch(array, poSchema);
+    if (!poRecordBatchResult.ok())
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "ImportRecordBatch() failed with %s",
+                 poRecordBatchResult.status().message().c_str());
+        return false;
+    }
+    auto poRecordBatch = *poRecordBatchResult;
+
+    // below assertion commented out since it is not strictly necessary, but
+    // reflects what ImportRecordBatch() does.
+    // CPLAssert(array->release == nullptr);
+
+    // We may need to reconstruct a final record batch that perfectly matches
+    // the expected schema.
+    if (bRebuildBatch || !oMapGeomFieldNameToArray.empty())
+    {
+        std::vector<std::shared_ptr<arrow::Array>> apoArrays;
+        for (int i = 0; i < m_poSchema->num_fields(); ++i)
+        {
+            auto oIter =
+                oMapGeomFieldNameToArray.find(m_poSchema->field(i)->name());
+            if (oIter != oMapGeomFieldNameToArray.end())
+                apoArrays.emplace_back(oIter->second);
+            else
+                apoArrays.emplace_back(poRecordBatch->column(i));
+            if (apoArrays.back()->type()->id() !=
+                m_poSchema->field(i)->type()->id())
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Field '%s' of unexpected type",
+                         m_poSchema->field(i)->name().c_str());
+                return false;
+            }
+        }
+        poRecordBatchResult = arrow::RecordBatch::Make(
+            m_poSchema, poRecordBatch->num_rows(), apoArrays);
+        if (!poRecordBatchResult.ok())
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "RecordBatch::Make() failed with %s",
+                     poRecordBatchResult.status().message().c_str());
+            return false;
+        }
+        poRecordBatch = *poRecordBatchResult;
+    }
+
+    if (writeBatch(poRecordBatch))
+    {
+        m_nFeatureCount += poRecordBatch->num_rows();
+        return true;
+    }
+    return false;
 }

--- a/ogr/ogrsf_frmts/generic/ogrlayerarrow.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrlayerarrow.cpp
@@ -6221,11 +6221,13 @@ bool OGRLayer::WriteArrowBatch(const struct ArrowSchema *schema,
     };
     LayerDefnTmpRefReleaser oLayerDefnTmpRefReleaser(oLayerDefnTmp);
 
+    std::vector<int> anIdentityFieldMap;
     if (bFallbackTypesUsed)
     {
         oLayerDefnTmp.SetGeomType(wkbNone);
         for (int i = 0; i < poLayerDefn->GetFieldCount(); ++i)
         {
+            anIdentityFieldMap.push_back(i);
             const auto poSrcFieldDefn = poLayerDefn->GetFieldDefn(i);
             const auto oIter = oMapOGRFieldIndexToFieldInfoIndex.find(i);
             OGRFieldDefn oFieldDefn(
@@ -6324,7 +6326,9 @@ bool OGRLayer::WriteArrowBatch(const struct ArrowSchema *schema,
 
         if (bFallbackTypesUsed)
         {
-            oFeatureTarget.SetFrom(&oFeature);
+            oFeatureTarget.SetFrom(&oFeature, anIdentityFieldMap.data(),
+                                   /*bForgiving=*/true,
+                                   /*bUseISO8601ForDateTimeAsString=*/true);
             oFeatureTarget.SetFID(oFeature.GetFID());
         }
 

--- a/ogr/ogrsf_frmts/generic/ogrlayerarrow.h
+++ b/ogr/ogrsf_frmts/generic/ogrlayerarrow.h
@@ -1,0 +1,43 @@
+/******************************************************************************
+ *
+ * Project:  OpenGIS Simple Features Reference Implementation
+ * Purpose:  Parts of OGRLayer dealing with Arrow C interface
+ * Author:   Even Rouault, <even dot rouault at spatialys.com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Even Rouault <even dot rouault at spatialys.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#ifndef OGRLAYERARROW_H_DEFINED
+#define OGRLAYERARROW_H_DEFINED
+
+#include "cpl_port.h"
+
+#include <map>
+#include <string>
+
+constexpr const char *ARROW_EXTENSION_NAME_KEY = "ARROW:extension:name";
+constexpr const char *EXTENSION_NAME_WKB = "ogc.wkb";
+
+std::map<std::string, std::string>
+    CPL_DLL OGRParseArrowMetadata(const char *pabyMetadata);
+
+#endif  // OGRLAYERARROW_H_DEFINED

--- a/ogr/ogrsf_frmts/ogrsf_frmts.h
+++ b/ogr/ogrsf_frmts/ogrsf_frmts.h
@@ -164,6 +164,15 @@ class CPL_DLL OGRLayer : public GDALMajorObject
                               struct ArrowArray *array,
                               CSLConstList papszOptions) const;
 
+    //! @cond Doxygen_Suppress
+    bool IsArrowSchemaSupportedInternal(const struct ArrowSchema *schema,
+                                        const std::string &osFieldPrefix,
+                                        std::string &osErrorMsg) const;
+    bool CreateFieldFromArrowSchemaInternal(const struct ArrowSchema *schema,
+                                            const std::string &osFieldPrefix,
+                                            CSLConstList papszOptions);
+    //! @endcond
+
   public:
     OGRLayer();
     virtual ~OGRLayer();
@@ -203,6 +212,14 @@ class CPL_DLL OGRLayer : public GDALMajorObject
     virtual GDALDataset *GetDataset();
     virtual bool GetArrowStream(struct ArrowArrayStream *out_stream,
                                 CSLConstList papszOptions = nullptr);
+    virtual bool IsArrowSchemaSupported(const struct ArrowSchema *schema,
+                                        std::string &osErrorMsg) const;
+    virtual bool
+    CreateFieldFromArrowSchema(const struct ArrowSchema *schema,
+                               CSLConstList papszOptions = nullptr);
+    virtual bool WriteArrowBatch(const struct ArrowSchema *schema,
+                                 struct ArrowArray *array,
+                                 CSLConstList papszOptions = nullptr);
 
     OGRErr SetFeature(OGRFeature *poFeature) CPL_WARN_UNUSED_RESULT;
     OGRErr CreateFeature(OGRFeature *poFeature) CPL_WARN_UNUSED_RESULT;
@@ -352,6 +369,16 @@ class CPL_DLL OGRLayer : public GDALMajorObject
                            bool bEnvelopeAlreadySet,
                            OGREnvelope &sEnvelope) const;
     //! @endcond
+
+    /** Field name used by GetArrowSchema() for a FID column when
+     * GetFIDColumn() is not set.
+     */
+    static constexpr const char *DEFAULT_ARROW_FID_NAME = "OGC_FID";
+
+    /** Field name used by GetArrowSchema() for the name of the (single)
+     * geometry column (returned by GetGeometryColumn()) is not set.
+     */
+    static constexpr const char *DEFAULT_ARROW_GEOMETRY_NAME = "wkb_geometry";
 
   protected:
     //! @cond Doxygen_Suppress

--- a/ogr/ogrsf_frmts/ogrsf_frmts.h
+++ b/ogr/ogrsf_frmts/ogrsf_frmts.h
@@ -165,9 +165,6 @@ class CPL_DLL OGRLayer : public GDALMajorObject
                               CSLConstList papszOptions) const;
 
     //! @cond Doxygen_Suppress
-    bool IsArrowSchemaSupportedInternal(const struct ArrowSchema *schema,
-                                        const std::string &osFieldPrefix,
-                                        std::string &osErrorMsg) const;
     bool CreateFieldFromArrowSchemaInternal(const struct ArrowSchema *schema,
                                             const std::string &osFieldPrefix,
                                             CSLConstList papszOptions);
@@ -213,6 +210,7 @@ class CPL_DLL OGRLayer : public GDALMajorObject
     virtual bool GetArrowStream(struct ArrowArrayStream *out_stream,
                                 CSLConstList papszOptions = nullptr);
     virtual bool IsArrowSchemaSupported(const struct ArrowSchema *schema,
+                                        CSLConstList papszOptions,
                                         std::string &osErrorMsg) const;
     virtual bool
     CreateFieldFromArrowSchema(const struct ArrowSchema *schema,

--- a/ogr/ogrsf_frmts/parquet/ogr_parquet.h
+++ b/ogr/ogrsf_frmts/parquet/ogr_parquet.h
@@ -270,6 +270,8 @@ class OGRParquetWriterLayer final : public OGRArrowWriterLayer
     virtual bool
     IsSupportedGeometryType(OGRwkbGeometryType eGType) const override;
 
+    virtual void FixupWKBGeometryBeforeWriting(GByte *pabyWKB,
+                                               size_t nLen) override;
     virtual void FixupGeometryBeforeWriting(OGRGeometry *poGeom) override;
     virtual bool IsSRSRequired() const override
     {
@@ -292,6 +294,10 @@ class OGRParquetWriterLayer final : public OGRArrowWriterLayer
 
     OGRErr CreateGeomField(OGRGeomFieldDefn *poField,
                            int bApproxOK = TRUE) override;
+
+    bool WriteArrowBatch(const struct ArrowSchema *schema,
+                         struct ArrowArray *array,
+                         CSLConstList papszOptions = nullptr) override;
 };
 
 /************************************************************************/

--- a/ogr/ogrsf_frmts/parquet/ogrparquetwriterlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetwriterlayer.cpp
@@ -33,6 +33,8 @@
 
 #include "../arrow_common/ograrrowwriterlayer.hpp"
 
+#include "ogr_wkb.h"
+
 /************************************************************************/
 /*                      OGRParquetWriterLayer()                         */
 /************************************************************************/
@@ -694,6 +696,19 @@ bool OGRParquetWriterLayer::FlushGroup()
 }
 
 /************************************************************************/
+/*                    FixupWKBGeometryBeforeWriting()                   */
+/************************************************************************/
+
+void OGRParquetWriterLayer::FixupWKBGeometryBeforeWriting(GByte *pabyWkb,
+                                                          size_t nLen)
+{
+    if (!m_bForceCounterClockwiseOrientation)
+        return;
+
+    OGRWKBFixupCounterClockWiseExternalRing(pabyWkb, nLen);
+}
+
+/************************************************************************/
 /*                     FixupGeometryBeforeWriting()                     */
 /************************************************************************/
 
@@ -726,4 +741,39 @@ void OGRParquetWriterLayer::FixupGeometryBeforeWriting(OGRGeometry *poGeom)
             FixupGeometryBeforeWriting(poSubGeom);
         }
     }
+}
+
+/************************************************************************/
+/*                          WriteArrowBatch()                           */
+/************************************************************************/
+
+inline bool
+OGRParquetWriterLayer::WriteArrowBatch(const struct ArrowSchema *schema,
+                                       struct ArrowArray *array,
+                                       CSLConstList papszOptions)
+{
+    return WriteArrowBatchInternal(
+        schema, array, papszOptions,
+        [this](const std::shared_ptr<arrow::RecordBatch> &poBatch)
+        {
+            auto status = m_poFileWriter->NewBufferedRowGroup();
+            if (!status.ok())
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "NewBufferedRowGroup() failed with %s",
+                         status.message().c_str());
+                return false;
+            }
+
+            status = m_poFileWriter->WriteRecordBatch(*poBatch);
+            if (!status.ok())
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "WriteRecordBatch() failed: %s",
+                         status.message().c_str());
+                return false;
+            }
+
+            return true;
+        });
 }

--- a/ogr/ogrsf_frmts/shape/ogrshape.h
+++ b/ogr/ogrsf_frmts/shape/ogrshape.h
@@ -236,6 +236,8 @@ class OGRShapeLayer final : public OGRAbstractProxiedLayer
                   char **papszCreateOptions = nullptr);
     virtual ~OGRShapeLayer();
 
+    GDALDataset *GetDataset() override;
+
     void ResetReading() override;
     OGRFeature *GetNextFeature() override;
     OGRErr SetNextByIndex(GIntBig nIndex) override;

--- a/ogr/ogrsf_frmts/shape/ogrshapelayer.cpp
+++ b/ogr/ogrsf_frmts/shape/ogrshapelayer.cpp
@@ -3778,3 +3778,12 @@ OGRErr OGRShapeLayer::Rename(const char *pszNewName)
 
     return OGRERR_NONE;
 }
+
+/************************************************************************/
+/*                          GetDataset()                                */
+/************************************************************************/
+
+GDALDataset *OGRShapeLayer::GetDataset()
+{
+    return poDS;
+}

--- a/ogr/ogrsf_frmts/sqlite/ogrsqliteutility.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqliteutility.cpp
@@ -173,27 +173,6 @@ int SQLGetInteger(sqlite3 *poDb, const char *pszSQL, OGRErr *err)
     return static_cast<int>(SQLGetInteger64(poDb, pszSQL, err));
 }
 
-int SQLiteFieldFromOGR(OGRFieldType eType)
-{
-    switch (eType)
-    {
-        case OFTInteger:
-            return SQLITE_INTEGER;
-        case OFTReal:
-            return SQLITE_FLOAT;
-        case OFTString:
-            return SQLITE_TEXT;
-        case OFTBinary:
-            return SQLITE_BLOB;
-        case OFTDate:
-            return SQLITE_TEXT;
-        case OFTDateTime:
-            return SQLITE_TEXT;
-        default:
-            return 0;
-    }
-}
-
 /************************************************************************/
 /*                             SQLUnescape()                            */
 /************************************************************************/

--- a/ogr/ogrsf_frmts/sqlite/ogrsqliteutility.h
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqliteutility.h
@@ -72,8 +72,6 @@ GIntBig SQLGetInteger64(sqlite3 *poDb, const char *pszSQL, OGRErr *err);
 
 std::unique_ptr<SQLResult> SQLQuery(sqlite3 *poDb, const char *pszSQL);
 
-int SQLiteFieldFromOGR(OGRFieldType eType);
-
 /* To escape literals. The returned string doesn't contain the surrounding
  * single quotes */
 CPLString SQLEscapeLiteral(const char *pszLiteral);

--- a/perftests/ogr2ogr_arrow.py
+++ b/perftests/ogr2ogr_arrow.py
@@ -1,0 +1,136 @@
+# SPDX-License-Identifier: MIT
+# Copyright 2023 Even Rouault
+
+import sys
+
+from osgeo import gdal, ogr
+from osgeo_utils.auxiliary.util import GetOutputDriverFor
+
+ogr.UseExceptions()
+
+
+def copy_layer(src_lyr, out_filename, out_format, lcos={}):
+    stream = src_lyr.GetArrowStream()
+    schema = stream.GetSchema()
+
+    # If the source layer has a FID column and the output driver supports
+    # a FID layer creation option, set it to the source FID column name.
+    if src_lyr.GetFIDColumn():
+        creationOptions = gdal.GetDriverByName(out_format).GetMetadataItem(
+            "DS_LAYER_CREATIONOPTIONLIST"
+        )
+        if creationOptions and '"FID"' in creationOptions:
+            lcos["FID"] = src_lyr.GetFIDColumn()
+
+    with ogr.GetDriverByName(out_format).CreateDataSource(out_filename) as out_ds:
+        if src_lyr.GetLayerDefn().GetGeomFieldCount() > 1:
+            out_lyr = out_ds.CreateLayer(
+                src_lyr.GetName(), geom_type=ogr.wkbNone, options=lcos
+            )
+            for i in range(src_lyr.GetLayerDefn().GetGeomFieldCount()):
+                out_lyr.CreateGeomField(src_lyr.GetLayerDefn().GetGeomFieldDefn(i))
+        else:
+            out_lyr = out_ds.CreateLayer(
+                src_lyr.GetName(),
+                geom_type=src_lyr.GetGeomType(),
+                srs=src_lyr.GetSpatialRef(),
+                options=lcos,
+            )
+
+        success, error_msg = out_lyr.IsArrowSchemaSupported(schema)
+        assert success, error_msg
+
+        src_geom_field_names = [
+            src_lyr.GetLayerDefn().GetGeomFieldDefn(i).GetName()
+            for i in range(src_lyr.GetLayerDefn().GetGeomFieldCount())
+        ]
+        for i in range(schema.GetChildrenCount()):
+            # GetArrowStream() may return "OGC_FID" for a unnamed source FID
+            # column and "wkb_geometry" for a unnamed source geometry column.
+            # Also test GetFIDColumn() and src_geom_field_names if they are
+            # named.
+            if (
+                schema.GetChild(i).GetName()
+                not in ("OGC_FID", "wkb_geometry", src_lyr.GetFIDColumn())
+                and schema.GetChild(i).GetName() not in src_geom_field_names
+            ):
+                out_lyr.CreateFieldFromArrowSchema(schema.GetChild(i))
+
+        write_options = []
+        if src_lyr.GetFIDColumn():
+            write_options.append("FID=" + src_lyr.GetFIDColumn())
+        if (
+            src_lyr.GetLayerDefn().GetGeomFieldCount() == 1
+            and src_lyr.GetGeometryColumn()
+        ):
+            write_options.append("GEOMETRY_NAME=" + src_lyr.GetGeometryColumn())
+
+        while True:
+            array = stream.GetNextRecordBatch()
+            if array is None:
+                break
+            out_lyr.WriteArrowBatch(schema, array, write_options)
+
+
+def Usage():
+    print("ogr2ogr_arrow.py [-spat <xmin> <ymin> <xmax> <ymax>] [-where <cond>]")
+    print("                 [-f <format>] [-lco <NAME>=<VALUE>]...")
+    print("                 <out_filename> <src_filename> [<layer_name>]")
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+
+    i = 1
+    driver_name = None
+    out_filename = None
+    filename = None
+    where = None
+    minx = None
+    miny = None
+    maxx = None
+    maxy = None
+    layer_name = None
+    lcos = {}
+    while i < len(sys.argv):
+        if sys.argv[i] == "-spat":
+            minx = float(sys.argv[i + 1])
+            miny = float(sys.argv[i + 2])
+            maxx = float(sys.argv[i + 3])
+            maxy = float(sys.argv[i + 4])
+            i += 4
+        elif sys.argv[i] == "-where":
+            where = sys.argv[i + 1]
+            i += 1
+        elif sys.argv[i] == "-f":
+            driver_name = sys.argv[i + 1]
+            i += 1
+        elif sys.argv[i] == "-lco":
+            key, value = sys.argv[i + 1].split("=")
+            lcos[key] = value
+            i += 1
+        elif sys.argv[i][0] == "-":
+            Usage()
+        elif out_filename is None:
+            out_filename = sys.argv[i]
+        elif filename is None:
+            filename = sys.argv[i]
+        elif layer_name is None:
+            layer_name = sys.argv[i]
+        else:
+            Usage()
+        i += 1
+
+    if not filename:
+        Usage()
+    if not driver_name:
+        driver_name = GetOutputDriverFor(out_filename, is_raster=False)
+
+    ds = ogr.Open(filename)
+    lyr = ds.GetLayer(layer_name if layer_name else 0)
+    if minx:
+        lyr.SetSpatialFilterRect(minx, miny, maxx, maxy)
+    if where:
+        lyr.SetAttributeFilter(where)
+
+    copy_layer(lyr, out_filename, driver_name, lcos)

--- a/swig/include/ogr.i
+++ b/swig/include/ogr.i
@@ -1505,9 +1505,9 @@ public:
 #endif
 
 #ifdef SWIGPYTHON
-    void IsArrowSchemaSupported(const struct ArrowSchema *schema, bool* pbRet, char **errorMsg)
+    void IsArrowSchemaSupported(const struct ArrowSchema *schema, bool* pbRet, char **errorMsg, char** options = NULL)
     {
-        *pbRet = OGR_L_IsArrowSchemaSupported(self, schema, errorMsg);
+        *pbRet = OGR_L_IsArrowSchemaSupported(self, schema, options, errorMsg);
     }
 #endif
 

--- a/swig/include/ogr.i
+++ b/swig/include/ogr.i
@@ -1024,6 +1024,10 @@ class ArrowArray {
 public:
 %extend {
 
+  ArrowArray() {
+    return (struct ArrowArray* )calloc(1, sizeof(struct ArrowArray));
+  }
+
   ~ArrowArray() {
     if( self->release )
       self->release(self);
@@ -1051,6 +1055,10 @@ class ArrowSchema {
 public:
 %extend {
 
+  ArrowSchema() {
+    return (struct ArrowSchema* )calloc(1, sizeof(struct ArrowSchema));
+  }
+
   ~ArrowSchema() {
     if( self->release )
       self->release(self);
@@ -1061,8 +1069,21 @@ public:
     return self;
   }
 
+  const char* GetName() {
+    return self->name;
+  }
+
   GIntBig GetChildrenCount() {
     return self->n_children;
+  }
+
+  const ArrowSchema* GetChild(int iChild) {
+    if( iChild < 0 || iChild >= self->n_children )
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Wrong index");
+        return NULL;
+    }
+    return self->children[iChild];
   }
 
 } /* %extend */
@@ -1481,6 +1502,27 @@ public:
           return NULL;
       }
   }
+#endif
+
+#ifdef SWIGPYTHON
+    void IsArrowSchemaSupported(const struct ArrowSchema *schema, bool* pbRet, char **errorMsg)
+    {
+        *pbRet = OGR_L_IsArrowSchemaSupported(self, schema, errorMsg);
+    }
+#endif
+
+#ifdef SWIGPYTHON
+    OGRErr CreateFieldFromArrowSchema(const struct ArrowSchema *schema, char** options = NULL)
+    {
+        return OGR_L_CreateFieldFromArrowSchema(self, schema, options) ? OGRERR_NONE : OGRERR_FAILURE;
+    }
+#endif
+
+#ifdef SWIGPYTHON
+    OGRErr WriteArrowBatch(const struct ArrowSchema *schema, struct ArrowArray *array, char** options = NULL)
+    {
+        return OGR_L_WriteArrowBatch(self, schema, array, options) ? OGRERR_NONE : OGRERR_FAILURE;
+    }
 #endif
 
 #ifdef SWIGPYTHON

--- a/swig/include/python/ogr_python.i
+++ b/swig/include/python/ogr_python.i
@@ -538,7 +538,7 @@ def ReleaseResultSet(self, sql_lyr):
         return Stream(stream, use_masked_arrays)
 
 
-    def IsPyArrowSchemaSupported(self, pa_schema):
+    def IsPyArrowSchemaSupported(self, pa_schema, options=[]):
         """Returns whether the passed pyarrow Schema is supported by the layer, as a tuple (success: bool, errorMsg: str).
 
            This may be used as a preliminary check before calling WritePyArrowBatch()
@@ -547,7 +547,7 @@ def ReleaseResultSet(self, sql_lyr):
         import pyarrow as pa
         schema = ArrowSchema()
         pa_schema._export_to_c(schema._getPtr())
-        return self.IsArrowSchemaSupported(schema)
+        return self.IsArrowSchemaSupported(schema, options)
 
 
     def CreateFieldFromPyArrowSchema(self, pa_schema, options=[]):

--- a/swig/include/python/ogr_python.i
+++ b/swig/include/python/ogr_python.i
@@ -537,6 +537,51 @@ def ReleaseResultSet(self, sql_lyr):
 
         return Stream(stream, use_masked_arrays)
 
+
+    def IsPyArrowSchemaSupported(self, pa_schema):
+        """Returns whether the passed pyarrow Schema is supported by the layer, as a tuple (success: bool, errorMsg: str).
+
+           This may be used as a preliminary check before calling WritePyArrowBatch()
+        """
+
+        import pyarrow as pa
+        schema = ArrowSchema()
+        pa_schema._export_to_c(schema._getPtr())
+        return self.IsArrowSchemaSupported(schema)
+
+
+    def CreateFieldFromPyArrowSchema(self, pa_schema, options=[]):
+        """Create a field from the passed pyarrow Schema."""
+
+        import pyarrow as pa
+        schema = ArrowSchema()
+        pa_schema._export_to_c(schema._getPtr())
+        return self.CreateFieldFromArrowSchema(schema, options)
+
+
+    def WritePyArrow(self, pa_batch, options=[]):
+        """Write the content of the passed PyArrow batch (either a pyarrow.Table, a pyarrow.RecordBatch or a pyarrow.StructArray) into the layer."""
+
+        import pyarrow as pa
+
+        # Is it a pyarrow.Table ?
+        if hasattr(pa_batch, "to_batches"):
+            for batch in pa_batch.to_batches():
+                if self.WritePyArrow(batch, options=options) != OGRERR_NONE:
+                    return OGRERR_FAILURE
+            return OGRERR_NONE
+
+        # Is it a pyarrow.RecordBatch ?
+        if hasattr(pa_batch, "columns") and hasattr(pa_batch, "schema"):
+            array = pa.StructArray.from_arrays(pa_batch.columns, names=pa_batch.schema.names)
+            return self.WritePyArrow(array, options=options)
+
+        # Assume it is a pyarrow.StructArray
+        schema = ArrowSchema()
+        array = ArrowArray()
+        pa_batch._export_to_c(array._getPtr(), schema._getPtr())
+        return self.WriteArrowBatch(schema, array, options)
+
   %}
 
 }

--- a/swig/include/python/typemaps_python.i
+++ b/swig/include/python/typemaps_python.i
@@ -3220,3 +3220,31 @@ OBJECT_LIST_INPUT(GDALEDTComponentHS)
     /* %typemap(freearg)  (OGRSpatialReferenceH** ppRet, int* pnEntryCount) */
     OSRFreeSRSArray(*$1);
 }
+
+
+/***************************************************
+ * Typemap for Layer.IsArrowSchemaSupported()
+ ***************************************************/
+%typemap(in,numinputs=0) (bool* pbRet, char **errorMsg) (bool ret, char* errorMsg)
+{
+  /* %typemap(in,numinputs=0) (bool* pbRet, char **errorMsg) */
+  $1 = &ret;
+  $2 = &errorMsg;
+}
+%typemap(argout) (bool* pbRet, char **errorMsg)
+{
+  /* %typemap(argout) (bool* pbRet, char **errorMsg)*/
+  Py_DECREF($result);
+  $result = PyTuple_New(2);
+  PyTuple_SetItem($result, 0, PyBool_FromLong(*$1));
+  if( *$2 )
+  {
+      PyTuple_SetItem($result, 1, PyUnicode_FromString(*$2));
+      VSIFree(*$2);
+  }
+  else
+  {
+      PyTuple_SetItem($result, 1, Py_None);
+      Py_INCREF(Py_None);
+  }
+}


### PR DESCRIPTION
This is the continuation of [RFC 86 Column-oriented read API for vector layers](https://gdal.org/development/rfc/rfc86_column_oriented_api.html), but on the writing side.

Cf https://github.com/rouault/gdal/blob/write_arrow_batch/doc/source/tutorials/vector_api_tut.rst#writing-to-ogr-using-the-arrow-c-data-interface for an introduction

3 new methods to OGRLayer are added (and their corresponding C API and SWIG Python bindings):

* OGRLayer::IsArrowSchemaSupported():

```
/** Returns whether the provided ArrowSchema is supported for writing.
 *
 * This method exists since not all drivers may support all Arrow data types.
 *
 * The ArrowSchema must be of type struct (format=+s)
 *
 * It is recommended to call this method before calling WriteArrowBatch().
 *
 * This is the same as the C function OGR_L_IsArrowSchemaSupported().
 *
 * @param schema Schema of type struct (format = '+s')
 * @param[out] osErrorMsg Reason of the failure, when this method returns false.
 * @return true if the ArrowSchema is supported for writing.
 * @since 3.8
 */
bool OGRLayer::IsArrowSchemaSupported(const struct ArrowSchema *schema,
                                      std::string &osErrorMsg) const;
```

*  OGRLayer::CreateFieldFromArrowSchema()

```
/** Creates a field from an ArrowSchema.
 *
 * This should only be used for attribute fields. Geometry fields should
 * be created with CreateGeomField(). The FID field should also not be
 * passed with this method.
 *
 * Contrary to the IsArrowSchemaSupported() and WriteArrowBatch() methods, the
 * passed schema must be for an individual field, and thus, is *not* of type
 * struct (format=+s) (unless writing a set of fields grouped together in the
 * same structure).
 *
 * This method and CreateField() are mutually exclusive in the same session.
 *
 * This method is the same as the C function OGR_L_CreateFieldFromArrowSchema().
 *
 * @param schema Schema of the field to create.
 * @param papszOptions Options. Pass nullptr currently.
 * @return true in case of success
 * @since 3.8
 */
bool OGRLayer::CreateFieldFromArrowSchema(const struct ArrowSchema *schema,
                                          CSLConstList papszOptions);
```

* OGRLayer::WriteArrowBatch() 

```
/** Writes a batch of rows from an ArrowArray.
 *
 * This is semantically close to calling CreateFeature() with multiple features
 * at once.
 *
 * The ArrowArray must be of type struct (format=+s), and its children generally
 * map to a OGR attribute or geometry field (unless they are struct themselves).
 *
 * Method IsArrowSchemaSupported() can be called to determine if the schema
 * will be supported by WriteArrowBatch().
 *
 * OGR fields for the corresponding children arrays must exist and be of a
 * compatible type. For attribute fields, they should be created with
 * CreateFieldFromArrowSchema().
 *
 * Arrays for geometry columns should be of binary or large binary type and contain WKB geometry.
 *
 * Note that the passed array may be set to a released state
 * (array->release==NULL) after this call (not by the base implementation,
 * but in specialized ones such as Parquet or Arrow for example)
 *
 * Supported options of the base implementation are:
 * <ul>
 * <li>FID=name. Name of the FID column in the array. If not provided,
 *     GetFIDColumn() is used to determine it. The special name
 *     OGRLayer::DEFAULT_ARROW_FID_NAME is also recognized if neither FID nor
 *     GetFIDColumn() are set.
 *     The corresponding ArrowArray must be of type int32 (i) or int64 (l).
 *     On input, values of the FID column are used to create the feature.
 *     On output, the values of the FID column may be set with the FID of the
 *     created feature (if the array is not released).
 * </li>
 * <li>GEOMETRY_NAME=name. Name of the geometry column. If not provided,
 *     GetGeometryColumn() is used. The special name
 *     OGRLayer::DEFAULT_ARROW_GEOMETRY_NAME is also recognized if neither
 *     GEOMETRY_NAME nor GetGeometryColumn() are set.
 *     Geometry columns are also identified if they have
 *     ARROW:extension:name=ogc.wkb as a field metadata.
 *     The corresponding ArrowArray must be of type binary (w) or large
 *     binary (W).
 * </li>
 * </ul>
 *
 * The following example demonstrates how to copy a layer from one format to
 * another one (assuming it has at most a single geometry column):
\code{.py}
    def copy_layer(src_lyr, out_filename, out_format, lcos = {}):
        stream = src_lyr.GetArrowStream()
        schema = stream.GetSchema()

        # If the source layer has a FID column and the output driver supports
        # a FID layer creation option, set it to the source FID column name.
        if src_lyr.GetFIDColumn():
            creationOptions = gdal.GetDriverByName(out_format).GetMetadataItem(
                "DS_LAYER_CREATIONOPTIONLIST"
            )
            if creationOptions and '"FID"' in creationOptions:
                lcos["FID"] = src_lyr.GetFIDColumn()

        with ogr.GetDriverByName(out_format).CreateDataSource(out_filename) as out_ds:
            if src_lyr.GetLayerDefn().GetGeomFieldCount() > 1:
                out_lyr = out_ds.CreateLayer(
                    src_lyr.GetName(), geom_type=ogr.wkbNone, options=lcos
                )
                for i in range(src_lyr.GetLayerDefn().GetGeomFieldCount()):
                    out_lyr.CreateGeomField(src_lyr.GetLayerDefn().GetGeomFieldDefn(i))
            else:
                out_lyr = out_ds.CreateLayer(
                    src_lyr.GetName(),
                    geom_type=src_lyr.GetGeomType(),
                    srs=src_lyr.GetSpatialRef(),
                    options=lcos,
                )

            success, error_msg = out_lyr.IsArrowSchemaSupported(schema)
            assert success, error_msg

            src_geom_field_names = [
                src_lyr.GetLayerDefn().GetGeomFieldDefn(i).GetName()
                for i in range(src_lyr.GetLayerDefn().GetGeomFieldCount())
            ]
            for i in range(schema.GetChildrenCount()):
                # GetArrowStream() may return "OGC_FID" for a unnamed source FID
                # column and "wkb_geometry" for a unnamed source geometry column.
                # Also test GetFIDColumn() and src_geom_field_names if they are
                # named.
                if (
                    schema.GetChild(i).GetName()
                    not in ("OGC_FID", "wkb_geometry", src_lyr.GetFIDColumn())
                    and schema.GetChild(i).GetName() not in src_geom_field_names
                ):
                    out_lyr.CreateFieldFromArrowSchema(schema.GetChild(i))

            write_options = []
            if src_lyr.GetFIDColumn():
                write_options.append("FID=" + src_lyr.GetFIDColumn())
            if (
                src_lyr.GetLayerDefn().GetGeomFieldCount() == 1
                and src_lyr.GetGeometryColumn()
            ):
                write_options.append("GEOMETRY_NAME=" + src_lyr.GetGeometryColumn())

            while True:
                array = stream.GetNextRecordBatch()
                if array is None:
                    break
                out_lyr.WriteArrowBatch(schema, array, write_options)
\endcode
 *
 * This method and CreateFeature() are mutually exclusive in the same session.
 *
 * This method is the same as the C function OGR_L_WriteArrowBatch().
 *
 * @param schema Schema of array
 * @param array Array of type struct. It may be released (array->release==NULL)
 *              after calling this method.
 * @param papszOptions Options. Null terminated list, or nullptr.
 * @return true in case of success
 * @since 3.8
 */

bool OGRLayer::WriteArrowBatch(const struct ArrowSchema *schema,
                               struct ArrowArray *array,
                               CSLConstList papszOptions);
```

Some benchmarks comparing a ogr2ogr_arrow.py utility using the above copy_layer() method using GetNextRecordBatch() + WriteArrowBatch() to traditionnal ogr2ogr using GetNextFeature() + CreateFeature():

```
$ time python ogr2ogr_arrow.py out.parquet nz-building-outlines.parquet

real    0m4,268s
user    0m4,154s
sys	    0m1,777s

$ time ogr2ogr  out.parquet nz-building-outlines.parquet

real    0m11,300s
user    0m10,907s
sys     0m1,012s

$ time pythonogr2ogr_arrow.py out.gpkg nz-building-outlines.gpkg -lco SPATIAL_INDEX=NO

real    0m13,021s
user    0m13,893s
sys     0m2,200s

$ time ogr2ogr out.gpkg nz-building-outlines.gpkg -lco SPATIAL_INDEX=NO

real    0m16,977s
user    0m15,541s
sys     0m1,415s

```

CC @jorisvandenbossche, @paleolimbot, @kylebarron