### PR TITLE
WIP: Run mypy on CI to check python type hints

### DIFF
--- a/.github/workflows/cmake_builds.yml
+++ b/.github/workflows/cmake_builds.yml
@@ -254,6 +254,12 @@ jobs:
         LD_LIBRARY_PATH=$GITHUB_WORKSPACE/install-gdal/lib ldd myvenv/lib/python3.8/site-packages/osgeo/_gdal.cpython-38-x86_64-linux-gnu.so
         LD_LIBRARY_PATH=$GITHUB_WORKSPACE/install-gdal/lib gdal_edit.py byte.tif -mo FOO=BAR
         rm -f myvenv/bin/gdal_edit.py
+    - name: Python type hints check
+      run: |
+        cd $GITHUB_WORKSPACE/superbuild/build/gdal/swig/python
+        pip install typing-extensions==4.8.0 mypy==1.5.1
+        # TODO: Remove || true once type hints are correct
+        mypy osgeo || true
     - name: Standalone gdal-utils package from wheel
       run: |
         mv gdal-swig-python $GITHUB_WORKSPACE/superbuild/build/gdal/swig/python

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -8,6 +8,7 @@
 %feature("autodoc");
 
 %include "gdal_dataset_docs.i"
+%include "python_type_hints.i"
 
 %init %{
   /* gdal_python.i %init code */

--- a/swig/include/python/ogr_python.i
+++ b/swig/include/python/ogr_python.i
@@ -49,6 +49,7 @@
 
 %include "python_exceptions.i"
 %include "python_strings.i"
+%include "python_type_hints.i"
 
 // Start: to be removed in GDAL 4.0
 

--- a/swig/include/python/osr_python.i
+++ b/swig/include/python/osr_python.i
@@ -18,6 +18,8 @@
 
 %include "python_exceptions.i"
 %include "python_strings.i"
+%include "python_type_hints.i"
+
 #endif
 
 %include typemaps_python.i

--- a/swig/include/python/python_type_hints.i
+++ b/swig/include/python/python_type_hints.i
@@ -1,0 +1,27 @@
+/*
+ * SWIG generates Python type annotations containing C/C++ types:
+ *
+ * https://www.swig.org/Doc4.1/SWIGDocumentation.html#Python_annotations_c
+ *
+ * Since mypy won't recognize those by default, we define type aliases here
+ * to map them back to well-known python types
+ */
+%pythoncode %{
+# Type aliases
+from enum import IntEnum
+from typing_extensions import TypeAlias
+void: TypeAlias = None
+double: TypeAlias = float
+OGRErr: TypeAlias = int
+CPLErr: TypeAlias =int
+# See cpl_error.h
+# TODO: Typemap to convert return sto CPLErr(ret)
+# TODO: Would this break python API ?
+#class CPLErr(IntEnum):
+#    CE_None = 0
+#    CE_Debug = 1
+#    CE_Warning = 2
+#    CE_Failure = 3
+#    CE_Fatal = 4
+%}
+

--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -21,6 +21,7 @@ set(GDAL_PYTHON_CSOURCES
        ${PROJECT_SOURCE_DIR}/swig/include/python/osr_python.i
        ${PROJECT_SOURCE_DIR}/swig/include/python/python_exceptions.i
        ${PROJECT_SOURCE_DIR}/swig/include/python/python_strings.i
+       ${PROJECT_SOURCE_DIR}/swig/include/python/python_type_hints.i
        ${PROJECT_SOURCE_DIR}/swig/include/python/typemaps_python.i
        ${PROJECT_SOURCE_DIR}/swig/include/python/docs/gdal_dataset_docs.i
        ${PROJECT_SOURCE_DIR}/swig/include/python/docs/ogr_datasource_docs.i


### PR DESCRIPTION
This is exploring adding mypy to the CI so we can check generated python type hints (see #3538).

## What does this PR do?

Running mypy on the generated `osgeo` directory of the python bindings currently yields ~900 warnings. A lot of them seem to be because swig generates [annotations containing C/C++ types](https://www.swig.org/Doc4.1/SWIGDocumentation.html#Python_annotations_c) like:

```
def DecToPackedDMS(*args) -> "double":
```

Mypy won't be happy about that annotation though and will generate an error like:

```
osgeo/gdal.py:5940: error: Name "double" is not defined
```

The strategy explored in this PR is to add a bunch of Python `TypeAlias` to the bindings so that mypy is aware that a `double` is just a python `float`:

```
%pythoncode %{
from typing import TypeAlias
void: TypeAlias = None
double: TypeAlias = float
%}
```

## What are related issues/pull requests?

#3538

On SWIG side, there is ongoing discussion on how to allow custom type hints (rather than C types one), but as far as I can tell, this isn't implemented yet: https://github.com/swig/swig/issues/735

## Open question

Once we have mypy running on CI, is it better to land this already and then do multiple PR to get rid of some of the errors one by one ? Or would you prefer one big PR directly fixing all the type hints ? I guess the "big PR" approach could be hairy if some of the type hints require a bit more work than just mere aliases.

## Tasklist

 - [ ] Get initial mypy setup & running on CI
 - [ ] Get maintainer decision on whether this is better done in a single PR or multiple small ones
