### PR TITLE
[Backport release/3.7] gdal_translate: when specifying -srcwin, preserve source block size in the temporary VRT if srcwin top,left is a multiple of the block size

### DIFF
--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -1208,13 +1208,14 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
     /*      virtual input source to copy from.                              */
     /* -------------------------------------------------------------------- */
 
-    const bool bSpatialArrangementPreserved =
-        psOptions->adfSrcWin[0] == 0 && psOptions->adfSrcWin[1] == 0 &&
-        psOptions->adfSrcWin[2] == poSrcDS->GetRasterXSize() &&
-        psOptions->adfSrcWin[3] == poSrcDS->GetRasterYSize() &&
+    const bool bKeepResolution =
         psOptions->nOXSizePixel == 0 && psOptions->dfOXSizePct == 0.0 &&
         psOptions->nOYSizePixel == 0 && psOptions->dfOYSizePct == 0.0 &&
         psOptions->dfXRes == 0.0;
+    const bool bSpatialArrangementPreserved =
+        psOptions->adfSrcWin[0] == 0 && psOptions->adfSrcWin[1] == 0 &&
+        psOptions->adfSrcWin[2] == poSrcDS->GetRasterXSize() &&
+        psOptions->adfSrcWin[3] == poSrcDS->GetRasterYSize() && bKeepResolution;
 
     if (psOptions->eOutputType == GDT_Unknown &&
         psOptions->asScaleParams.empty() && psOptions->adfExponent.empty() &&
@@ -2069,10 +2070,12 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
         /* --------------------------------------------------------------------
          */
         CPLStringList aosAddBandOptions;
-        if (bSpatialArrangementPreserved)
+        int nSrcBlockXSize, nSrcBlockYSize;
+        poSrcBand->GetBlockSize(&nSrcBlockXSize, &nSrcBlockYSize);
+        if (bKeepResolution &&
+            (fmod(psOptions->adfSrcWin[0], nSrcBlockXSize)) == 0 &&
+            (fmod(psOptions->adfSrcWin[1], nSrcBlockYSize)) == 0)
         {
-            int nSrcBlockXSize, nSrcBlockYSize;
-            poSrcBand->GetBlockSize(&nSrcBlockXSize, &nSrcBlockYSize);
             aosAddBandOptions.SetNameValue("BLOCKXSIZE",
                                            CPLSPrintf("%d", nSrcBlockXSize));
             aosAddBandOptions.SetNameValue("BLOCKYSIZE",

--- a/autotest/gcore/vrtmisc.py
+++ b/autotest/gcore/vrtmisc.py
@@ -707,6 +707,31 @@ def test_vrtmisc_blocksize_gdal_translate_indirect():
 
 
 ###############################################################################
+# Test replicating source block size if we subset with an offset multiple
+# of the source block size
+
+
+def test_vrtmisc_blocksize_gdal_translate_implicit():
+
+    src_filename = "/vsimem/src.tif"
+    gdal.GetDriverByName("GTiff").Create(
+        src_filename, 128, 512, options=["TILED=YES", "BLOCKXSIZE=48", "BLOCKYSIZE=256"]
+    )
+    filename = "/vsimem/test_vrtmisc_blocksize_gdal_translate_implicit.vrt"
+    vrt_ds = gdal.Translate(filename, src_filename, srcWin=[48 * 2, 256, 100, 256])
+    vrt_ds = None
+
+    vrt_ds = gdal.Open(filename)
+    blockxsize, blockysize = vrt_ds.GetRasterBand(1).GetBlockSize()
+    assert blockxsize == 48
+    assert blockysize == 256
+    vrt_ds = None
+
+    gdal.Unlink(filename)
+    gdal.Unlink(src_filename)
+
+
+###############################################################################
 # Test support for coordinate epoch
 
 

--- a/frmts/vrt/vrtrasterband.cpp
+++ b/frmts/vrt/vrtrasterband.cpp
@@ -649,11 +649,13 @@ CPLXMLNode *VRTRasterBand::SerializeToXML(const char *pszVRTPath)
     // serialized at the dataset level.
     if (dynamic_cast<VRTWarpedRasterBand *>(this) == nullptr)
     {
-        if (nBlockXSize != 128 && nBlockXSize != nRasterXSize)
+        if (nBlockXSize != 128 &&
+            !(nBlockXSize < 128 && nBlockXSize == nRasterXSize))
             CPLSetXMLValue(psTree, "#blockXSize",
                            CPLSPrintf("%d", nBlockXSize));
 
-        if (nBlockYSize != 128 && nBlockYSize != nRasterYSize)
+        if (nBlockYSize != 128 &&
+            !(nBlockYSize < 128 && nBlockYSize == nRasterYSize))
             CPLSetXMLValue(psTree, "#blockYSize",
                            CPLSPrintf("%d", nBlockYSize));
     }


### PR DESCRIPTION
Backport #8531
 **Authored by:** @rouault