### PR TITLE
Reprojection fixes

### DIFF
--- a/alg/gdaltransformer.cpp
+++ b/alg/gdaltransformer.cpp
@@ -3504,14 +3504,40 @@ static CPLXMLNode *GDALSerializeReprojectionTransformer(void *pTransformArg)
     /* -------------------------------------------------------------------- */
     /*      Handle SourceCS.                                                */
     /* -------------------------------------------------------------------- */
-    char *pszWKT = nullptr;
+    const auto ExportToWkt = [](const OGRSpatialReference *poSRS)
+    {
+        // Try first in WKT1 for backward compat
+        {
+            char *pszWKT = nullptr;
+            const char *const apszOptions[] = {"FORMAT=WKT1", nullptr};
+            CPLErrorHandlerPusher oHandler(CPLQuietErrorHandler);
+            CPLErrorStateBackuper oBackuper;
+            if (poSRS->exportToWkt(&pszWKT, apszOptions) == OGRERR_NONE)
+            {
+                std::string osRet(pszWKT);
+                CPLFree(pszWKT);
+                return osRet;
+            }
+            CPLFree(pszWKT);
+        }
+
+        char *pszWKT = nullptr;
+        const char *const apszOptions[] = {"FORMAT=WKT2_2019", nullptr};
+        if (poSRS->exportToWkt(&pszWKT, apszOptions) == OGRERR_NONE)
+        {
+            std::string osRet(pszWKT);
+            CPLFree(pszWKT);
+            return osRet;
+        }
+        CPLFree(pszWKT);
+        return std::string();
+    };
 
     auto poSRS = psInfo->poForwardTransform->GetSourceCS();
     if (poSRS)
     {
-        poSRS->exportToWkt(&pszWKT);
-        CPLCreateXMLElementAndValue(psTree, "SourceSRS", pszWKT);
-        CPLFree(pszWKT);
+        const auto osWKT = ExportToWkt(poSRS);
+        CPLCreateXMLElementAndValue(psTree, "SourceSRS", osWKT.c_str());
     }
 
     /* -------------------------------------------------------------------- */
@@ -3520,9 +3546,8 @@ static CPLXMLNode *GDALSerializeReprojectionTransformer(void *pTransformArg)
     poSRS = psInfo->poForwardTransform->GetTargetCS();
     if (poSRS)
     {
-        poSRS->exportToWkt(&pszWKT);
-        CPLCreateXMLElementAndValue(psTree, "TargetSRS", pszWKT);
-        CPLFree(pszWKT);
+        const auto osWKT = ExportToWkt(poSRS);
+        CPLCreateXMLElementAndValue(psTree, "TargetSRS", osWKT.c_str());
     }
 
     /* -------------------------------------------------------------------- */

--- a/ogr/ogrct.cpp
+++ b/ogr/ogrct.cpp
@@ -3211,6 +3211,7 @@ int OGRProjCT::TransformBounds(const double xmin, const double ymin,
     if (degree_output)
     {
         CPLErrorHandlerPusher oErrorHandlerPusher(CPLQuietErrorHandler);
+
         north_pole_in_bounds =
             ContainsNorthPole(xmin, ymin, xmax, ymax, output_lon_lat_order);
         if (CPLGetLastErrorType() != CE_None)
@@ -3302,6 +3303,9 @@ int OGRProjCT::TransformBounds(const double xmin, const double ymin,
         // and lat = +/- 90deg Helps for example for EPSG:4326 to ESRI:53037
         if (poSRSTarget->IsProjected())
         {
+            CPLErrorHandlerPusher oErrorHandlerPusher(CPLQuietErrorHandler);
+            CPLErrorStateBackuper oBackuper;
+
             const double dfLon0 =
                 poSRSTarget->GetNormProjParm(SRS_PP_CENTRAL_MERIDIAN, 0.0);
             if (dfLon0 != 0)


### PR DESCRIPTION
- GDALSerializeReprojectionTransformer(): fallback to WKT2 for SourceCRS/TargetCRS if WKT1 cannot be used
- OGRProjCT::TransformBounds(): do not emit errors when trying to reproject points at poles
