### PR TITLE
VSI7Z: Accept ArcGIS Pro Project Packages

### DIFF
--- a/doc/source/user/virtual_file_systems.rst
+++ b/doc/source/user/virtual_file_systems.rst
@@ -223,7 +223,8 @@ To point to a file inside a 7z file, the filename must be of the form
 is the relative path to the file inside the archive.`
 
 Default extensions recognized by this virtual file system are:
-``7z``, ``lpk`` (Esri ArcGIS Layer Package), ``lpkx``, ``mpk`` (Esri ArcGIS Map Package) and ``mpkx``.
+``7z``, ``lpk`` (Esri ArcGIS Layer Package), ``lpkx``, ``mpk`` (Esri ArcGIS Map Package),
+``mpkx`` and ``ppkx`` (Esri ArcGIS Pro Project Package).
 
 An alternate syntax is available so as to enable chaining and not being
 dependent on those extensions, e.g.: :file:`/vsi7z/{/path/to/the/archive}/path/inside/the/archive`.

--- a/port/cpl_vsil_libarchive.cpp
+++ b/port/cpl_vsil_libarchive.cpp
@@ -483,7 +483,7 @@ class VSILibArchiveFilesystemHandler final : public VSIArchiveFilesystemHandler
     {
         if (m_osPrefix == "/vsi7z")
         {
-            return {".7z", ".lpk", ".lpkx", ".mpk", ".mpkx"};
+            return {".7z", ".lpk", ".lpkx", ".mpk", ".mpkx", ".ppkx"};
         }
         else
         {


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

ArcGIS Pro Project Package (`.ppkx`) files are another 7-zipped Esri archive format, very similar to Esri Layer Packages (`.lpkx`) and Esri Map Packages (`.mpkx`). We seem to be treating those extensions simply as synonyms to `.7z`. This PR simply adds `.ppkx` to that list in the code and documentation.

## What are related issues/pull requests?

Depends on the work done in #7035 to add the `/vsi7z/` virtual file system.

## Tasklist

 - [ ] Add test case(s)
 - [x] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
