### PR TITLE
OGR SQL: fix min/max on string fields (master only)

### DIFF
--- a/ogr/ogrsf_frmts/generic/ogr_gensql.cpp
+++ b/ogr/ogrsf_frmts/generic/ogr_gensql.cpp
@@ -1038,7 +1038,8 @@ int OGRGenSQLResultsLayer::PrepareSummary()
                 {
                     if (psColDef->field_type == SWQ_DATE ||
                         psColDef->field_type == SWQ_TIME ||
-                        psColDef->field_type == SWQ_TIMESTAMP)
+                        psColDef->field_type == SWQ_TIMESTAMP ||
+                        psColDef->field_type == SWQ_STRING)
                         poSummaryFeature->SetField(iField,
                                                    oSummary.osMin.c_str());
                     else
@@ -1048,7 +1049,8 @@ int OGRGenSQLResultsLayer::PrepareSummary()
                 {
                     if (psColDef->field_type == SWQ_DATE ||
                         psColDef->field_type == SWQ_TIME ||
-                        psColDef->field_type == SWQ_TIMESTAMP)
+                        psColDef->field_type == SWQ_TIMESTAMP ||
+                        psColDef->field_type == SWQ_STRING)
                         poSummaryFeature->SetField(iField,
                                                    oSummary.osMax.c_str());
                     else

--- a/ogr/swq.cpp
+++ b/ogr/swq.cpp
@@ -429,9 +429,10 @@ const char *swq_select_summarize(swq_select *select_info, int dest_column,
             {
                 if (def->field_type == SWQ_DATE ||
                     def->field_type == SWQ_TIME ||
-                    def->field_type == SWQ_TIMESTAMP)
+                    def->field_type == SWQ_TIMESTAMP ||
+                    def->field_type == SWQ_STRING)
                 {
-                    if (strcmp(value, summary.osMin) < 0)
+                    if (summary.count == 0 || strcmp(value, summary.osMin) < 0)
                     {
                         summary.osMin = value;
                     }
@@ -450,9 +451,10 @@ const char *swq_select_summarize(swq_select *select_info, int dest_column,
             {
                 if (def->field_type == SWQ_DATE ||
                     def->field_type == SWQ_TIME ||
-                    def->field_type == SWQ_TIMESTAMP)
+                    def->field_type == SWQ_TIMESTAMP ||
+                    def->field_type == SWQ_STRING)
                 {
-                    if (strcmp(value, summary.osMax) > 0)
+                    if (summary.count == 0 || strcmp(value, summary.osMax) > 0)
                     {
                         summary.osMax = value;
                     }


### PR DESCRIPTION
actually fix ef90e9fce2555836ff32f2b482d519913d5c78aa which only worked on string fields having numeric values...

Thanks to QGIS test suite to catch that...
