### PR TITLE
jpeg.rst: Fix typo for bitmask: `valid date` → `valid data` [ci skip]

### DIFF
--- a/doc/source/drivers/raster/jpeg.rst
+++ b/doc/source/drivers/raster/jpeg.rst
@@ -100,7 +100,7 @@ The following configuration options are available :
       :choices: YES, NO
       :default: YES
 
-      Whether to read the bitmask identifying pixels with valid date.
+      Whether to read the bitmask identifying pixels with valid data.
 
 -  .. config:: JPEG_MASK_BIT_ORDER
       :choices: AUTO, LSB, MSB


### PR DESCRIPTION
Minor typo in the documentation.