### PR TITLE
Speed improvements in WKB geometry import, and ogr2ogr

### DIFF
--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -5399,8 +5399,11 @@ bool LayerTranslator::TranslateArrow(
     if (!psInfo->m_bPreserveFID)
         aosOptions.SetNameValue("INCLUDE_FID", "NO");
     if (psOptions->nGroupTransactions > 0)
+    {
         aosOptions.SetNameValue(
-            "BATCH_SIZE", CPLSPrintf("%d", psOptions->nGroupTransactions));
+            "MAX_FEATURES_IN_BATCH",
+            CPLSPrintf("%d", psOptions->nGroupTransactions));
+    }
     if (psInfo->m_poSrcLayer->GetArrowStream(&stream, aosOptions.List()))
     {
         if (stream.get_schema(&stream, &schema) != 0)

--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -3841,15 +3841,14 @@ bool SetupTargetLayer::CanUseWriteArrowBatch(
     bError = false;
 
     // Check if we can use the Arrow interface to get and write features
-    // as it will be faster if the input (resp. output) driver has a fast
-    // implementation of GetArrowStream() (resp. WriteArrowBatch())
+    // as it will be faster if the input driver has a fast
+    // implementation of GetArrowStream().
     // We also can only do that only if using ogr2ogr without options that
     // alter features.
     // OGR2OGR_USE_ARROW_API config option is mostly for testing purposes
     // or as a safety belt if things turned bad...
     bool bUseWriteArrowBatch = false;
     if (((poSrcLayer->TestCapability(OLCFastGetArrowStream) &&
-          poDstLayer->TestCapability(OLCFastWriteArrowBatch) &&
           // As we don't control the input array size when the input or output
           // drivers are Arrow/Parquet (as they don't use the generic
           // implementation), we can't guarantee that ROW_GROUP_SIZE/BATCH_SIZE

--- a/autotest/cpp/test_ogr.cpp
+++ b/autotest/cpp/test_ogr.cpp
@@ -2589,4 +2589,361 @@ TEST_F(test_ogr, OGRGetISO8601DateTime)
     }
 }
 
+// Test calling importFromWkb() multiple times on the same geometry object
+TEST_F(test_ogr, importFromWkbReuse)
+{
+    {
+        OGRPoint oPoint;
+        {
+            size_t nBytesConsumed = 0;
+            EXPECT_EQ(oPoint.importFromWkb(
+                          reinterpret_cast<const GByte *>(
+                              "\x01\x01\x00\x00\x00"                // Point
+                              "\x00\x00\x00\x00\x00\x00\xf0\x3f"    // 1.0
+                              "\x00\x00\x00\x00\x00\x00\x00\x40"),  // 2.0
+                          21, wkbVariantIso, nBytesConsumed),
+                      OGRERR_NONE);
+            EXPECT_EQ(nBytesConsumed, 21);
+            EXPECT_EQ(oPoint.getX(), 1.0);
+            EXPECT_EQ(oPoint.getY(), 2.0);
+        }
+        {
+            size_t nBytesConsumed = 0;
+            EXPECT_EQ(oPoint.importFromWkb(
+                          reinterpret_cast<const GByte *>(
+                              "\x01\x01\x00\x00\x00"              // Point
+                              "\x00\x00\x00\x00\x00\x00\x00\x40"  // 2.0
+                              "\x00\x00\x00\x00\x00\x00\xf0\x3f"  // 1.0
+                              ),
+                          21, wkbVariantIso, nBytesConsumed),
+                      OGRERR_NONE);
+            EXPECT_EQ(nBytesConsumed, 21);
+            EXPECT_EQ(oPoint.getX(), 2.0);
+            EXPECT_EQ(oPoint.getY(), 1.0);
+        }
+    }
+
+    {
+        OGRLineString oLS;
+        {
+            size_t nBytesConsumed = 0;
+            EXPECT_EQ(oLS.importFromWkb(
+                          reinterpret_cast<const GByte *>(
+                              "\x01\x02\x00\x00\x00"              // LineString
+                              "\x01\x00\x00\x00"                  // 1 point
+                              "\x00\x00\x00\x00\x00\x00\xf0\x3f"  // 1.0
+                              "\x00\x00\x00\x00\x00\x00\x00\x40"),  // 2.0
+                          25, wkbVariantIso, nBytesConsumed),
+                      OGRERR_NONE);
+            EXPECT_EQ(nBytesConsumed, 25);
+            ASSERT_EQ(oLS.getNumPoints(), 1);
+            EXPECT_EQ(oLS.getX(0), 1.0);
+            EXPECT_EQ(oLS.getY(0), 2.0);
+        }
+        {
+            size_t nBytesConsumed = 0;
+            EXPECT_EQ(oLS.importFromWkb(
+                          reinterpret_cast<const GByte *>(
+                              "\x01\x02\x00\x00\x00"              // LineString
+                              "\x02\x00\x00\x00"                  // 2 points
+                              "\x00\x00\x00\x00\x00\x00\xf0\x3f"  // 1.0
+                              "\x00\x00\x00\x00\x00\x00\x00\x40"  // 2.0
+                              "\x00\x00\x00\x00\x00\x00\x00\x40"  // 2.0
+                              "\x00\x00\x00\x00\x00\x00\xf0\x3f"),  // 1.0
+                          41, wkbVariantIso, nBytesConsumed),
+                      OGRERR_NONE);
+            EXPECT_EQ(nBytesConsumed, 41);
+            ASSERT_EQ(oLS.getNumPoints(), 2);
+            EXPECT_EQ(oLS.getX(0), 1.0);
+            EXPECT_EQ(oLS.getY(0), 2.0);
+            EXPECT_EQ(oLS.getX(1), 2.0);
+            EXPECT_EQ(oLS.getY(1), 1.0);
+        }
+        {
+            size_t nBytesConsumed = 0;
+            EXPECT_EQ(oLS.importFromWkb(
+                          reinterpret_cast<const GByte *>(
+                              "\x01\x02\x00\x00\x00"              // LineString
+                              "\x01\x00\x00\x00"                  // 1 point
+                              "\x00\x00\x00\x00\x00\x00\x00\x40"  // 2.0
+                              "\x00\x00\x00\x00\x00\x00\xf0\x3f"),  // 1.0
+                          25, wkbVariantIso, nBytesConsumed),
+                      OGRERR_NONE);
+            EXPECT_EQ(nBytesConsumed, 25);
+            ASSERT_EQ(oLS.getNumPoints(), 1);
+            EXPECT_EQ(oLS.getX(0), 2.0);
+            EXPECT_EQ(oLS.getY(0), 1.0);
+        }
+    }
+
+    {
+        OGRPolygon oPoly;
+        {
+            size_t nBytesConsumed = 0;
+            EXPECT_EQ(oPoly.importFromWkb(
+                          reinterpret_cast<const GByte *>(
+                              "\x01\x03\x00\x00\x00"                // Polygon
+                              "\x01\x00\x00\x00"                    // 1 ring
+                              "\x01\x00\x00\x00"                    // 1 point
+                              "\x00\x00\x00\x00\x00\x00\xf0\x3f"    // 1.0
+                              "\x00\x00\x00\x00\x00\x00\x00\x40"),  // 2.0
+                          29, wkbVariantIso, nBytesConsumed),
+                      OGRERR_NONE);
+            EXPECT_EQ(nBytesConsumed, 29);
+            ASSERT_TRUE(oPoly.getExteriorRing() != nullptr);
+            ASSERT_EQ(oPoly.getNumInteriorRings(), 0);
+            auto poLS = oPoly.getExteriorRing();
+            ASSERT_EQ(poLS->getNumPoints(), 1);
+            EXPECT_EQ(poLS->getX(0), 1.0);
+            EXPECT_EQ(poLS->getY(0), 2.0);
+        }
+        {
+            size_t nBytesConsumed = 0;
+            EXPECT_EQ(oPoly.importFromWkb(
+                          reinterpret_cast<const GByte *>(
+                              "\x01\x03\x00\x00\x00"                // Polygon
+                              "\x01\x00\x00\x00"                    // 1 ring
+                              "\x01\x00\x00\x00"                    // 1 point
+                              "\x00\x00\x00\x00\x00\x00\x00\x40"    // 2.0
+                              "\x00\x00\x00\x00\x00\x00\xf0\x3f"),  // 1.0
+                          29, wkbVariantIso, nBytesConsumed),
+                      OGRERR_NONE);
+            EXPECT_EQ(nBytesConsumed, 29);
+            ASSERT_TRUE(oPoly.getExteriorRing() != nullptr);
+            ASSERT_EQ(oPoly.getNumInteriorRings(), 0);
+            auto poLS = oPoly.getExteriorRing();
+            ASSERT_EQ(poLS->getNumPoints(), 1);
+            EXPECT_EQ(poLS->getX(0), 2.0);
+            EXPECT_EQ(poLS->getY(0), 1.0);
+        }
+        {
+            size_t nBytesConsumed = 0;
+            EXPECT_EQ(oPoly.importFromWkb(reinterpret_cast<const GByte *>(
+                                              "\x01\x03\x00\x00\x00"  // Polygon
+                                              "\x00\x00\x00\x00"),    // 0 ring
+                                          9, wkbVariantIso, nBytesConsumed),
+                      OGRERR_NONE);
+            EXPECT_EQ(nBytesConsumed, 9);
+            ASSERT_TRUE(oPoly.getExteriorRing() == nullptr);
+            ASSERT_EQ(oPoly.getNumInteriorRings(), 0);
+        }
+        {
+            size_t nBytesConsumed = 0;
+            EXPECT_EQ(oPoly.importFromWkb(
+                          reinterpret_cast<const GByte *>(
+                              "\x01\x03\x00\x00\x00"                // Polygon
+                              "\x01\x00\x00\x00"                    // 1 ring
+                              "\x01\x00\x00\x00"                    // 1 point
+                              "\x00\x00\x00\x00\x00\x00\xf0\x3f"    // 1.0
+                              "\x00\x00\x00\x00\x00\x00\x00\x40"),  // 2.0
+                          29, wkbVariantIso, nBytesConsumed),
+                      OGRERR_NONE);
+            EXPECT_EQ(nBytesConsumed, 29);
+            ASSERT_TRUE(oPoly.getExteriorRing() != nullptr);
+            ASSERT_EQ(oPoly.getNumInteriorRings(), 0);
+            auto poLS = oPoly.getExteriorRing();
+            ASSERT_EQ(poLS->getNumPoints(), 1);
+            EXPECT_EQ(poLS->getX(0), 1.0);
+            EXPECT_EQ(poLS->getY(0), 2.0);
+        }
+        {
+            size_t nBytesConsumed = 0;
+            EXPECT_EQ(oPoly.importFromWkb(
+                          reinterpret_cast<const GByte *>(
+                              "\x01\x03\x00\x00\x00"                // Polygon
+                              "\x01\x00\x00\x00"                    // 1 ring
+                              "\x01\x00\x00\x00"                    // 1 point
+                              "\x00\x00\x00\x00\x00\x00\x00\x40"    // 2.0
+                              "\x00\x00\x00\x00\x00\x00\xf0\x3f"),  // 1.0
+                          static_cast<size_t>(-1), wkbVariantIso,
+                          nBytesConsumed),
+                      OGRERR_NONE);
+            EXPECT_EQ(nBytesConsumed, 29);
+            ASSERT_TRUE(oPoly.getExteriorRing() != nullptr);
+            ASSERT_EQ(oPoly.getNumInteriorRings(), 0);
+            auto poLS = oPoly.getExteriorRing();
+            ASSERT_EQ(poLS->getNumPoints(), 1);
+            EXPECT_EQ(poLS->getX(0), 2.0);
+            EXPECT_EQ(poLS->getY(0), 1.0);
+        }
+        {
+            size_t nBytesConsumed = 0;
+            // Truncated WKB
+            EXPECT_NE(oPoly.importFromWkb(reinterpret_cast<const GByte *>(
+                                              "\x01\x03\x00\x00\x00"  // Polygon
+                                              "\x01\x00\x00\x00"      // 1 ring
+                                              "\x01\x00\x00\x00"),    // 1 point
+                                          13, wkbVariantIso, nBytesConsumed),
+                      OGRERR_NONE);
+            ASSERT_TRUE(oPoly.getExteriorRing() == nullptr);
+            ASSERT_EQ(oPoly.getNumInteriorRings(), 0);
+        }
+    }
+
+    {
+        OGRMultiLineString oMLS;
+        {
+            size_t nBytesConsumed = 0;
+            EXPECT_EQ(oMLS.importFromWkb(
+                          reinterpret_cast<const GByte *>(
+                              "\x01\x05\x00\x00\x00"  // MultiLineString
+                              "\x01\x00\x00\x00"      // 1-part
+                              "\x01\x02\x00\x00\x00"  // LineString
+                              "\x01\x00\x00\x00"      // 1 point
+                              "\x00\x00\x00\x00\x00\x00\xf0\x3f"    // 1.0
+                              "\x00\x00\x00\x00\x00\x00\x00\x40"),  // 2.0
+                          34, wkbVariantIso, nBytesConsumed),
+                      OGRERR_NONE);
+            EXPECT_EQ(nBytesConsumed, 34);
+            ASSERT_EQ(oMLS.getNumGeometries(), 1);
+            auto poLS = oMLS.getGeometryRef(0);
+            ASSERT_EQ(poLS->getNumPoints(), 1);
+            EXPECT_EQ(poLS->getX(0), 1.0);
+            EXPECT_EQ(poLS->getY(0), 2.0);
+        }
+        {
+            size_t nBytesConsumed = 0;
+            EXPECT_EQ(oMLS.importFromWkb(
+                          reinterpret_cast<const GByte *>(
+                              "\x01\x05\x00\x00\x00"  // MultiLineString
+                              "\x01\x00\x00\x00"      // 1-part
+                              "\x01\x02\x00\x00\x00"  // LineString
+                              "\x01\x00\x00\x00"      // 1 point
+                              "\x00\x00\x00\x00\x00\x00\x00\x40"    // 2.0
+                              "\x00\x00\x00\x00\x00\x00\xf0\x3f"),  // 1.0
+                          34, wkbVariantIso, nBytesConsumed),
+                      OGRERR_NONE);
+            EXPECT_EQ(nBytesConsumed, 34);
+            ASSERT_EQ(oMLS.getNumGeometries(), 1);
+            auto poLS = oMLS.getGeometryRef(0);
+            ASSERT_EQ(poLS->getNumPoints(), 1);
+            EXPECT_EQ(poLS->getX(0), 2.0);
+            EXPECT_EQ(poLS->getY(0), 1.0);
+        }
+        {
+            size_t nBytesConsumed = 0;
+            EXPECT_EQ(oMLS.importFromWkb(
+                          reinterpret_cast<const GByte *>(
+                              "\x01\x05\x00\x00\x00"  // MultiLineString
+                              "\x01\x00\x00\x00"      // 1-part
+                              "\x01\x02\x00\x00\x00"  // LineString
+                              "\x01\x00\x00\x00"      // 1 point
+                              "\x00\x00\x00\x00\x00\x00\xf0\x3f"    // 1.0
+                              "\x00\x00\x00\x00\x00\x00\x00\x40"),  // 2.0
+                          static_cast<size_t>(-1), wkbVariantIso,
+                          nBytesConsumed),
+                      OGRERR_NONE);
+            EXPECT_EQ(nBytesConsumed, 34);
+            ASSERT_EQ(oMLS.getNumGeometries(), 1);
+            auto poLS = oMLS.getGeometryRef(0);
+            ASSERT_EQ(poLS->getNumPoints(), 1);
+            EXPECT_EQ(poLS->getX(0), 1.0);
+            EXPECT_EQ(poLS->getY(0), 2.0);
+        }
+        {
+            size_t nBytesConsumed = 0;
+            // Truncated WKB
+            EXPECT_NE(oMLS.importFromWkb(
+                          reinterpret_cast<const GByte *>(
+                              "\x01\x05\x00\x00\x00"  // MultiLineString
+                              "\x01\x00\x00\x00"      // 1-part
+                              "\x01\x02\x00\x00\x00"  // LineString
+                              "\x01\x00\x00\x00"      // 1 point
+                              ),
+                          18, wkbVariantIso, nBytesConsumed),
+                      OGRERR_NONE);
+            ASSERT_EQ(oMLS.getNumGeometries(), 0);
+        }
+    }
+
+    {
+        OGRMultiPolygon oMP;
+        {
+            size_t nBytesConsumed = 0;
+            EXPECT_EQ(oMP.importFromWkb(
+                          reinterpret_cast<const GByte *>(
+                              "\x01\x06\x00\x00\x00"  // MultiPolygon
+                              "\x01\x00\x00\x00"      // 1-part
+                              "\x01\x03\x00\x00\x00"  // Polygon
+                              "\x01\x00\x00\x00"      // 1 ring
+                              "\x01\x00\x00\x00"      // 1 point
+                              "\x00\x00\x00\x00\x00\x00\xf0\x3f"    // 1.0
+                              "\x00\x00\x00\x00\x00\x00\x00\x40"),  // 2.0
+                          38, wkbVariantIso, nBytesConsumed),
+                      OGRERR_NONE);
+            EXPECT_EQ(nBytesConsumed, 38);
+            ASSERT_EQ(oMP.getNumGeometries(), 1);
+            auto poPoly = oMP.getGeometryRef(0);
+            ASSERT_TRUE(poPoly->getExteriorRing() != nullptr);
+            ASSERT_EQ(poPoly->getNumInteriorRings(), 0);
+            auto poLS = poPoly->getExteriorRing();
+            ASSERT_EQ(poLS->getNumPoints(), 1);
+            EXPECT_EQ(poLS->getX(0), 1.0);
+            EXPECT_EQ(poLS->getY(0), 2.0);
+        }
+        {
+            size_t nBytesConsumed = 0;
+            EXPECT_EQ(oMP.importFromWkb(
+                          reinterpret_cast<const GByte *>(
+                              "\x01\x06\x00\x00\x00"  // MultiPolygon
+                              "\x01\x00\x00\x00"      // 1-part
+                              "\x01\x03\x00\x00\x00"  // Polygon
+                              "\x01\x00\x00\x00"      // 1 ring
+                              "\x01\x00\x00\x00"      // 1 point
+                              "\x00\x00\x00\x00\x00\x00\x00\x40"    // 2.0
+                              "\x00\x00\x00\x00\x00\x00\xf0\x3f"),  // 1.0
+                          38, wkbVariantIso, nBytesConsumed),
+                      OGRERR_NONE);
+            EXPECT_EQ(nBytesConsumed, 38);
+            ASSERT_EQ(oMP.getNumGeometries(), 1);
+            auto poPoly = oMP.getGeometryRef(0);
+            ASSERT_TRUE(poPoly->getExteriorRing() != nullptr);
+            ASSERT_EQ(poPoly->getNumInteriorRings(), 0);
+            auto poLS = poPoly->getExteriorRing();
+            ASSERT_EQ(poLS->getNumPoints(), 1);
+            EXPECT_EQ(poLS->getX(0), 2.0);
+            EXPECT_EQ(poLS->getY(0), 1.0);
+        }
+        {
+            size_t nBytesConsumed = 0;
+            EXPECT_EQ(oMP.importFromWkb(
+                          reinterpret_cast<const GByte *>(
+                              "\x01\x06\x00\x00\x00"  // MultiPolygon
+                              "\x01\x00\x00\x00"      // 1-part
+                              "\x01\x03\x00\x00\x00"  // Polygon
+                              "\x01\x00\x00\x00"      // 1 ring
+                              "\x01\x00\x00\x00"      // 1 point
+                              "\x00\x00\x00\x00\x00\x00\xf0\x3f"    // 1.0
+                              "\x00\x00\x00\x00\x00\x00\x00\x40"),  // 2.0
+                          static_cast<size_t>(-1), wkbVariantIso,
+                          nBytesConsumed),
+                      OGRERR_NONE);
+            EXPECT_EQ(nBytesConsumed, 38);
+            ASSERT_EQ(oMP.getNumGeometries(), 1);
+            auto poPoly = oMP.getGeometryRef(0);
+            ASSERT_TRUE(poPoly->getExteriorRing() != nullptr);
+            ASSERT_EQ(poPoly->getNumInteriorRings(), 0);
+            auto poLS = poPoly->getExteriorRing();
+            ASSERT_EQ(poLS->getNumPoints(), 1);
+            EXPECT_EQ(poLS->getX(0), 1.0);
+            EXPECT_EQ(poLS->getY(0), 2.0);
+        }
+        {
+            size_t nBytesConsumed = 0;
+            // Truncated WKB
+            EXPECT_NE(
+                oMP.importFromWkb(reinterpret_cast<const GByte *>(
+                                      "\x01\x06\x00\x00\x00"  // MultiPolygon
+                                      "\x01\x00\x00\x00"      // 1-part
+                                      "\x01\x03\x00\x00\x00"  // Polygon
+                                      "\x01\x00\x00\x00"      // 1 ring
+                                      "\x01\x00\x00\x00"      // 1 point
+                                      ),
+                                  22, wkbVariantIso, nBytesConsumed),
+                OGRERR_NONE);
+            ASSERT_EQ(oMP.getNumGeometries(), 0);
+        }
+    }
+}
+
 }  // namespace

--- a/ogr/ogr_geometry.h
+++ b/ogr/ogr_geometry.h
@@ -1445,6 +1445,7 @@ class CPL_DLL OGRSimpleCurve : public OGRCurve
     friend class OGRGeometry;
 
     int nPointCount;
+    int m_nPointCapacity = 0;
     OGRRawPoint *paoPoints;
     double *padfZ;
     double *padfM;
@@ -2741,9 +2742,6 @@ class CPL_DLL OGRTriangle : public OGRPolygon
 
 class CPL_DLL OGRGeometryCollection : public OGRGeometry
 {
-    OGRErr importFromWkbInternal(const unsigned char *pabyData, size_t nSize,
-                                 int nRecLevel, OGRwkbVariant,
-                                 size_t &nBytesConsumedOut);
     OGRErr importFromWktInternal(const char **ppszInput, int nRecLevel);
 
   protected:
@@ -2757,6 +2755,10 @@ class CPL_DLL OGRGeometryCollection : public OGRGeometry
     static OGRGeometryCollection *
     TransferMembersAndDestroy(OGRGeometryCollection *poSrc,
                               OGRGeometryCollection *poDst);
+
+    OGRErr importFromWkbInternal(const unsigned char *pabyData, size_t nSize,
+                                 int nRecLevel, OGRwkbVariant,
+                                 size_t &nBytesConsumedOut);
     //! @endcond
     virtual OGRBoolean isCompatibleSubType(OGRwkbGeometryType) const;
 
@@ -3141,6 +3143,9 @@ class CPL_DLL OGRMultiPolygon : public OGRMultiSurface
 #ifndef DOXYGEN_XML
     using OGRGeometry::exportToWkt;
 #endif
+
+    virtual OGRErr importFromWkb(const unsigned char *, size_t, OGRwkbVariant,
+                                 size_t &nBytesConsumedOut) override;
 
     /// Export a multipolygon to WKT
     /// \param opts  Output options.
@@ -3865,6 +3870,9 @@ class CPL_DLL OGRMultiLineString : public OGRMultiCurve
 #ifndef DOXYGEN_XML
     using OGRGeometry::exportToWkt;
 #endif
+
+    virtual OGRErr importFromWkb(const unsigned char *, size_t, OGRwkbVariant,
+                                 size_t &nBytesConsumedOut) override;
 
     /// Export a multilinestring to WKT
     /// \param opts  Output options.

--- a/ogr/ogrgeometrycollection.cpp
+++ b/ogr/ogrgeometrycollection.cpp
@@ -477,6 +477,7 @@ size_t OGRGeometryCollection::WkbSize() const
 /*                       importFromWkbInternal()                        */
 /************************************************************************/
 
+//! @cond Doxygen_Suppress
 OGRErr OGRGeometryCollection::importFromWkbInternal(
     const unsigned char *pabyData, size_t nSize, int nRecLevel,
     OGRwkbVariant eWkbVariant, size_t &nBytesConsumedOut)
@@ -581,6 +582,7 @@ OGRErr OGRGeometryCollection::importFromWkbInternal(
 
     return OGRERR_NONE;
 }
+//! @endcond
 
 /************************************************************************/
 /*                           importFromWkb()                            */

--- a/ogr/ogrlinestring.cpp
+++ b/ogr/ogrlinestring.cpp
@@ -214,12 +214,8 @@ void OGRSimpleCurve::Make3D()
 {
     if (padfZ == nullptr)
     {
-        if (nPointCount == 0)
-            padfZ =
-                static_cast<double *>(VSI_CALLOC_VERBOSE(sizeof(double), 1));
-        else
-            padfZ = static_cast<double *>(
-                VSI_CALLOC_VERBOSE(sizeof(double), nPointCount));
+        padfZ = static_cast<double *>(
+            VSI_CALLOC_VERBOSE(sizeof(double), std::max(1, m_nPointCapacity)));
         if (padfZ == nullptr)
         {
             flags &= ~OGR_G_3D;
@@ -255,12 +251,8 @@ void OGRSimpleCurve::AddM()
 {
     if (padfM == nullptr)
     {
-        if (nPointCount == 0)
-            padfM =
-                static_cast<double *>(VSI_CALLOC_VERBOSE(sizeof(double), 1));
-        else
-            padfM = static_cast<double *>(
-                VSI_CALLOC_VERBOSE(sizeof(double), nPointCount));
+        padfM = static_cast<double *>(
+            VSI_CALLOC_VERBOSE(sizeof(double), std::max(1, m_nPointCapacity)));
         if (padfM == nullptr)
         {
             flags &= ~OGR_G_MEASURED;
@@ -413,22 +405,7 @@ void OGRSimpleCurve::setNumPoints(int nNewPointCount, int bZeroizeNewContent)
 {
     CPLAssert(nNewPointCount >= 0);
 
-    if (nNewPointCount == 0)
-    {
-        CPLFree(paoPoints);
-        paoPoints = nullptr;
-
-        CPLFree(padfZ);
-        padfZ = nullptr;
-
-        CPLFree(padfM);
-        padfM = nullptr;
-
-        nPointCount = 0;
-        return;
-    }
-
-    if (nNewPointCount > nPointCount)
+    if (nNewPointCount > m_nPointCapacity)
     {
         // Overflow of sizeof(OGRRawPoint) * nNewPointCount can only occur on
         // 32 bit, but we don't really want to allocate 2 billion points even on
@@ -439,54 +416,82 @@ void OGRSimpleCurve::setNumPoints(int nNewPointCount, int bZeroizeNewContent)
             CPLError(CE_Failure, CPLE_IllegalArg, "Too big point count.");
             return;
         }
-        OGRRawPoint *paoNewPoints =
-            static_cast<OGRRawPoint *>(VSI_REALLOC_VERBOSE(
-                paoPoints, sizeof(OGRRawPoint) * nNewPointCount));
+
+        // If first allocation, just aim for nNewPointCount
+        // Otherwise aim for nNewPointCount + nNewPointCount / 3 to have
+        // exponential growth.
+        const int nNewCapacity =
+            (nPointCount == 0 ||
+             nNewPointCount > std::numeric_limits<int>::max() /
+                                      static_cast<int>(sizeof(OGRRawPoint)) -
+                                  nNewPointCount / 3)
+                ? nNewPointCount
+                : nNewPointCount + nNewPointCount / 3;
+
+        if (nPointCount == 0 && paoPoints)
+        {
+            // If there was an allocated array, but the old number of points is
+            // 0, then free the arrays before allocating them, to avoid
+            // potential costly recopy of useless data.
+            VSIFree(paoPoints);
+            paoPoints = nullptr;
+            VSIFree(padfZ);
+            padfZ = nullptr;
+            VSIFree(padfM);
+            padfM = nullptr;
+            m_nPointCapacity = 0;
+        }
+
+        OGRRawPoint *paoNewPoints = static_cast<OGRRawPoint *>(
+            VSI_REALLOC_VERBOSE(paoPoints, sizeof(OGRRawPoint) * nNewCapacity));
         if (paoNewPoints == nullptr)
         {
             return;
         }
         paoPoints = paoNewPoints;
 
-        if (bZeroizeNewContent)
-        {
-            // gcc 8.0 (dev) complains about -Wclass-memaccess since
-            // OGRRawPoint() has a constructor. So use a void* pointer.  Doing
-            // the memset() here is correct since the constructor sets to 0.  We
-            // could instead use a std::fill(), but at every other place, we
-            // treat this class as a regular POD (see above use of realloc())
-            void *dest = static_cast<void *>(paoPoints + nPointCount);
-            memset(dest, 0,
-                   sizeof(OGRRawPoint) * (nNewPointCount - nPointCount));
-        }
-
         if (flags & OGR_G_3D)
         {
             double *padfNewZ = static_cast<double *>(
-                VSI_REALLOC_VERBOSE(padfZ, sizeof(double) * nNewPointCount));
+                VSI_REALLOC_VERBOSE(padfZ, sizeof(double) * nNewCapacity));
             if (padfNewZ == nullptr)
             {
                 return;
             }
             padfZ = padfNewZ;
-            if (bZeroizeNewContent)
-                memset(padfZ + nPointCount, 0,
-                       sizeof(double) * (nNewPointCount - nPointCount));
         }
 
         if (flags & OGR_G_MEASURED)
         {
             double *padfNewM = static_cast<double *>(
-                VSI_REALLOC_VERBOSE(padfM, sizeof(double) * nNewPointCount));
+                VSI_REALLOC_VERBOSE(padfM, sizeof(double) * nNewCapacity));
             if (padfNewM == nullptr)
             {
                 return;
             }
             padfM = padfNewM;
-            if (bZeroizeNewContent)
-                memset(padfM + nPointCount, 0,
-                       sizeof(double) * (nNewPointCount - nPointCount));
         }
+
+        m_nPointCapacity = nNewCapacity;
+    }
+
+    if (nNewPointCount > nPointCount && bZeroizeNewContent)
+    {
+        // gcc 8.0 (dev) complains about -Wclass-memaccess since
+        // OGRRawPoint() has a constructor. So use a void* pointer.  Doing
+        // the memset() here is correct since the constructor sets to 0.  We
+        // could instead use a std::fill(), but at every other place, we
+        // treat this class as a regular POD (see above use of realloc())
+        void *dest = static_cast<void *>(paoPoints + nPointCount);
+        memset(dest, 0, sizeof(OGRRawPoint) * (nNewPointCount - nPointCount));
+
+        if ((flags & OGR_G_3D) && padfZ)
+            memset(padfZ + nPointCount, 0,
+                   sizeof(double) * (nNewPointCount - nPointCount));
+
+        if ((flags & OGR_G_MEASURED) && padfM)
+            memset(padfM + nPointCount, 0,
+                   sizeof(double) * (nNewPointCount - nPointCount));
     }
 
     nPointCount = nNewPointCount;
@@ -1757,9 +1762,9 @@ OGRErr OGRSimpleCurve::importFromWkt(const char **ppszInput)
     int flagsFromInput = flags;
     nPointCount = 0;
 
-    int nMaxPoints = 0;
-    pszInput = OGRWktReadPointsM(pszInput, &paoPoints, &padfZ, &padfM,
-                                 &flagsFromInput, &nMaxPoints, &nPointCount);
+    pszInput =
+        OGRWktReadPointsM(pszInput, &paoPoints, &padfZ, &padfM, &flagsFromInput,
+                          &m_nPointCapacity, &nPointCount);
     if (pszInput == nullptr)
         return OGRERR_CORRUPT_DATA;
 
@@ -2629,6 +2634,7 @@ void OGRSimpleCurve::segmentize(double dfMaxLength)
     CPLFree(paoPoints);
     paoPoints = paoNewPoints;
     nPointCount = nNewPointCount;
+    m_nPointCapacity = nNewPointCount;
 
     if (padfZ != nullptr)
     {
@@ -2850,10 +2856,12 @@ OGRLineString *OGRLineString::TransferMembersAndDestroy(OGRLineString *poSrc,
         poDst->flags |= OGR_G_MEASURED;
     poDst->assignSpatialReference(poSrc->getSpatialReference());
     poDst->nPointCount = poSrc->nPointCount;
+    poDst->m_nPointCapacity = poSrc->m_nPointCapacity;
     poDst->paoPoints = poSrc->paoPoints;
     poDst->padfZ = poSrc->padfZ;
     poDst->padfM = poSrc->padfM;
     poSrc->nPointCount = 0;
+    poSrc->m_nPointCapacity = 0;
     poSrc->paoPoints = nullptr;
     poSrc->padfZ = nullptr;
     poSrc->padfM = nullptr;


### PR DESCRIPTION
*   OGRLineString/Polygon/MultiPolygon/MultiLineString: make it possible to run importFromWkb() on the same object and limiting the number of dynamic memory (re)allocations
    
    - For lines, we keep track of the maximum capacity of the point array,
      with a new member variable.
      So doing setNumPoints(10), then setNumPoints(3), then setNumPoints(9)
      just allocates an array of size 10.
    - For polygons, if importing a WKB for a single ring polygon on top of
      an existing single ring polygon, reuse the existing ring (and benefit
      from the previous optimization)
    - For multipolygons, if importing a WKB for a single part multipolygon
      on top of an existing single part multipolygon, reuse the existing
      polygon (and benefit from the previous optimization)
    - Similar for multilinestring

* WriteArrowBatch() generic implementation: reuse existing geometry object to save memory allocations

* ogr2ogr: use Arrow interface as soon as the input driver declares OLCFastGetArrowStream, even if the output driver doesn't declare OLCFastWriteArrowBatch
    
    This helps in a notable way for Parquet -> GPKG or GPKG -> GPKG when
    disabling the creation of the spatial index which is now the major time
    consumer.
    
    Now (using Arrow API):
    
    ```
    $ time  ogr2ogr  out.gpkg nz-building-outlines.gpkg -lco spatial_index=no -progress
    0...10...20...30...40...50...60...70...80...90...100 - done.
    
    real    0m12,868s
    user    0m13,338s
    sys     0m1,843s
    ```
    
    Without use of Arrow API:
    
    ```
    $ time  ogr2ogr  out.gpkg nz-building-outlines.gpkg -lco spatial_index=no -progress --config OGR2OGR_USE_ARROW_API NO
    0...10...20...30...40...50...60...70...80...90...100 - done.
    
    real    0m17,625s
    user    0m15,917s
    sys     0m1,704s
    ```

