### PR TITLE
GTiff multithreaded reading/writing: fix a deadlock situation

### DIFF
--- a/frmts/gtiff/gtiffdataset_read.cpp
+++ b/frmts/gtiff/gtiffdataset_read.cpp
@@ -560,8 +560,16 @@ static void CPL_STDCALL ThreadDecompressionFuncErrorHandler(
                 psJob->nXBlock, psJob->nYBlock);
             if (apoBlocks[i] == nullptr)
             {
+                // Temporary disabling of dirty block fushing, otherwise
+                // we can be in a deadlock situation, where the
+                // GTiffDataset::SubmitCompressionJob() method waits for jobs
+                // to be finished, that can't finish (actually be started)
+                // because this task and its siblings are taking all the
+                // available workers allowed by the global thread pool.
+                GDALRasterBlock::EnterDisableDirtyBlockFlush();
                 apoBlocks[i] = poDS->GetRasterBand(iBand)->GetLockedBlockRef(
                     psJob->nXBlock, psJob->nYBlock, TRUE);
+                GDALRasterBlock::LeaveDisableDirtyBlockFlush();
                 if (apoBlocks[i] == nullptr)
                     return false;
             }


### PR DESCRIPTION
Fix a deadlock encountered with
gdalwarp test1.tif test2.tif -co  COMPRESS=LZW   -co TILED=YES  -co BLOCKXSIZE=256  -co  BLOCKYSIZE=256   -co   BIGTIFF=YES  -multi  -co  NUM_THREADS=ALL_CPUS out.tif -overwrite
on the test datasets provided in https://github.com/OSGeo/gdal/issues/8470#issuecomment-1760639682
