### PR TITLE
Python bindings: error handling/exception related fixes make sure that CPL_DEBUG=ON and gdal.UseExceptions() work fine during gdal.VectorTranslate() (and similar) (fixes #8552); accumulate CE_Failure messages during a GDAL call when gdal.UseExceptions() (fixes #8551)

### DIFF
--- a/autotest/gdrivers/usgsdem.py
+++ b/autotest/gdrivers/usgsdem.py
@@ -112,6 +112,7 @@ def test_usgsdem_4():
 # Test CreateCopy() without any creation options
 
 
+@pytest.mark.require_driver("DTED")
 def test_usgsdem_5():
 
     ds = gdal.Open("data/n43.dt0")
@@ -147,6 +148,7 @@ def test_usgsdem_5():
 # creation option and check that both files are binary identical.
 
 
+@pytest.mark.require_driver("DTED")
 def test_usgsdem_6():
 
     ds = gdal.Open("data/n43.dt0")
@@ -188,6 +190,7 @@ def test_usgsdem_6():
 # Test CreateCopy() with CDED50K profile
 
 
+@pytest.mark.require_driver("DTED")
 def test_usgsdem_7():
 
     ds = gdal.Open("data/n43.dt0")

--- a/autotest/utilities/test_ogr2ogr_lib.py
+++ b/autotest/utilities/test_ogr2ogr_lib.py
@@ -2176,3 +2176,41 @@ def test_ogr2ogr_lib_OGR2OGR_USE_ARROW_API_YES(limit):
     assert (
         out_lyr.GetFeatureCount() == (limit if limit else src_lyr.GetFeatureCount()) + 2
     )
+
+
+###############################################################################
+@pytest.mark.parametrize("enable_exceptions", [True, False])
+@pytest.mark.parametrize("enable_debug", [True, False])
+@pytest.mark.require_driver("GPKG")
+def test_ogr2ogr_lib_accumulerated_errors(tmp_vsimem, enable_exceptions, enable_debug):
+
+    src_ds = gdal.GetDriverByName("Memory").Create("", 0, 0, 0, gdal.GDT_Unknown)
+    src_lyr = src_ds.CreateLayer("test")
+    f = ogr.Feature(src_lyr.GetLayerDefn())
+    f.SetFID(1)
+    src_lyr.CreateFeature(f)
+
+    out_filename = str(tmp_vsimem / "test_ogr2ogr_lib_accumulerated_errors.gpkg")
+    gdal.VectorTranslate(out_filename, src_ds)
+
+    def my_handler(errorClass, errno, msg):
+        pass
+
+    with gdaltest.error_handler(my_handler if enable_debug else None):
+        with gdaltest.config_option("CPL_DEBUG", "ON" if enable_debug else "OFF"):
+            with gdal.ExceptionMgr(useExceptions=enable_exceptions):
+                if enable_exceptions:
+                    with pytest.raises(
+                        Exception,
+                        match=r"Unable to write feature 1 from layer test\.\nMay be caused by: failed to execute insert : UNIQUE constraint failed: test\.fid",
+                    ):
+                        gdal.VectorTranslate(
+                            out_filename, src_ds, options="-preserve_fid -append"
+                        )
+                else:
+                    assert (
+                        gdal.VectorTranslate(
+                            out_filename, src_ds, options="-preserve_fid -append"
+                        )
+                        is None
+                    )

--- a/ogr/ogrsf_frmts/generic/ogrlayerarrow.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrlayerarrow.cpp
@@ -4838,7 +4838,6 @@ static bool IsArrowSchemaSupportedInternal(const struct ArrowSchema *schema,
         return false;
     }
 }
-//! @endcond
 
 /** Returns whether the provided ArrowSchema is supported for writing.
  *

--- a/port/cpl_error.cpp
+++ b/port/cpl_error.cpp
@@ -159,19 +159,6 @@ static CPLErrorContext *CPLGetErrorContext()
 
 void *CPL_STDCALL CPLGetErrorHandlerUserData(void)
 {
-    int bError = FALSE;
-
-    // check if there is an active error being propagated through the handlers
-    void **pActiveUserData = reinterpret_cast<void **>(
-        CPLGetTLSEx(CTLS_ERRORHANDLERACTIVEDATA, &bError));
-    if (bError)
-        return nullptr;
-
-    if (pActiveUserData != nullptr)
-    {
-        return *pActiveUserData;
-    }
-
     // get the current threadlocal or global error context user data
     CPLErrorContext *psCtx = CPLGetErrorContext();
     if (psCtx == nullptr || IS_PREFEFINED_ERROR_CTX(psCtx))
@@ -230,10 +217,7 @@ CPLErrorHandler CPLGetErrorHandler(void **ppUserData)
 static void ApplyErrorHandler(CPLErrorContext *psCtx, CPLErr eErrClass,
                               CPLErrorNum err_no, const char *pszMessage)
 {
-    void **pActiveUserData;
     bool bProcessed = false;
-
-    // CTLS_ERRORHANDLERACTIVEDATA holds the active error handler userData
 
     if (psCtx->psHandlerStack != nullptr)
     {
@@ -241,9 +225,14 @@ static void ApplyErrorHandler(CPLErrorContext *psCtx, CPLErr eErrClass,
         if ((eErrClass != CE_Debug) || psCtx->psHandlerStack->bCatchDebug)
         {
             // call the error handler
-            pActiveUserData = &(psCtx->psHandlerStack->pUserData);
-            CPLSetTLS(CTLS_ERRORHANDLERACTIVEDATA, pActiveUserData, false);
+            CPLErrorHandlerNode *psNewCurNode = psCtx->psHandlerStack;
             psCtx->psHandlerStack->pfnHandler(eErrClass, err_no, pszMessage);
+            if (psNewCurNode != psCtx->psHandlerStack)
+            {
+                fprintf(stderr, "ApplyErrorHandler() has detected that a "
+                                "previous error handler messed up with the "
+                                "error stack. Chaos guaranteed!\n");
+            }
             bProcessed = true;
         }
         else
@@ -254,10 +243,19 @@ static void ApplyErrorHandler(CPLErrorContext *psCtx, CPLErr eErrClass,
             {
                 if (psNode->bCatchDebug)
                 {
-                    pActiveUserData = &(psNode->pUserData);
-                    CPLSetTLS(CTLS_ERRORHANDLERACTIVEDATA, pActiveUserData,
-                              false);
+                    CPLErrorHandlerNode *psBackupCurNode =
+                        psCtx->psHandlerStack;
+                    psCtx->psHandlerStack = psNode;
+                    CPLErrorHandlerNode *psNewCurNode = psCtx->psHandlerStack;
                     psNode->pfnHandler(eErrClass, err_no, pszMessage);
+                    if (psNewCurNode != psCtx->psHandlerStack)
+                    {
+                        fprintf(stderr,
+                                "ApplyErrorHandler() has detected that a "
+                                "previous error handler messed up with the "
+                                "error stack. Chaos guaranteed!\n");
+                    }
+                    psCtx->psHandlerStack = psBackupCurNode;
                     bProcessed = true;
                     break;
                 }
@@ -274,20 +272,15 @@ static void ApplyErrorHandler(CPLErrorContext *psCtx, CPLErr eErrClass,
         {
             if (pfnErrorHandler != nullptr)
             {
-                pActiveUserData = &pErrorHandlerUserData;
-                CPLSetTLS(CTLS_ERRORHANDLERACTIVEDATA, pActiveUserData, false);
                 pfnErrorHandler(eErrClass, err_no, pszMessage);
             }
         }
         else /* if( eErrClass == CE_Debug ) */
         {
             // for CPLDebug messages we propagate to the default error handler
-            pActiveUserData = nullptr;
-            CPLSetTLS(CTLS_ERRORHANDLERACTIVEDATA, pActiveUserData, false);
             CPLDefaultErrorHandler(eErrClass, err_no, pszMessage);
         }
     }
-    CPLSetTLS(CTLS_ERRORHANDLERACTIVEDATA, nullptr, false);
 }
 
 /**********************************************************************

--- a/port/cpl_error.h
+++ b/port/cpl_error.h
@@ -152,6 +152,8 @@ GUInt32 CPL_DLL CPL_STDCALL CPLGetErrorCounter(void);
 void CPL_DLL *CPL_STDCALL CPLGetErrorHandlerUserData(void);
 void CPL_DLL CPLErrorSetState(CPLErr eErrClass, CPLErrorNum err_no,
                               const char *pszMsg);
+void CPL_DLL CPLCallPreviousHandler(CPLErr eErrClass, CPLErrorNum err_no,
+                                    const char *pszMsg);
 /*! @cond Doxygen_Suppress */
 void CPL_DLL CPLCleanupErrorMutex(void);
 /*! @endcond */

--- a/port/cpl_multiproc.h
+++ b/port/cpl_multiproc.h
@@ -234,10 +234,10 @@ class CPL_DLL CPLLockHolder
 #define CTLS_CONFIGOPTIONS 14           /* cpl_conv.cpp */
 #define CTLS_FINDFILE 15                /* cpl_findfile.cpp */
 #define CTLS_VSIERRORCONTEXT 16         /* cpl_vsi_error.cpp */
-#define CTLS_ERRORHANDLERACTIVEDATA 17  /* cpl_error.cpp */
-#define CTLS_PROJCONTEXTHOLDER 18       /* ogr_proj_p.cpp */
-#define CTLS_GDALDEFAULTOVR_ANTIREC 19  /* gdaldefaultoverviews.cpp */
-#define CTLS_HTTPFETCHCALLBACK 20       /* cpl_http.cpp */
+/* 17: unused */
+#define CTLS_PROJCONTEXTHOLDER 18      /* ogr_proj_p.cpp */
+#define CTLS_GDALDEFAULTOVR_ANTIREC 19 /* gdaldefaultoverviews.cpp */
+#define CTLS_HTTPFETCHCALLBACK 20      /* cpl_http.cpp */
 
 #define CTLS_MAX 32
 

--- a/swig/include/cpl.i
+++ b/swig/include/cpl.i
@@ -77,7 +77,9 @@ void CPLSetCurrentErrorHandlerCatchDebug( int bCatchDebug );
 %{
 extern "C" int CPL_DLL GDALIsInGlobalDestructor();
 
-void CPL_STDCALL PyCPLErrorHandler(CPLErr eErrClass, int err_no, const char* pszErrorMsg)
+extern "C" void CPL_STDCALL PyCPLErrorHandler(CPLErr eErrClass, CPLErrorNum err_no, const char* pszErrorMsg);
+
+void PyCPLErrorHandler(CPLErr eErrClass, CPLErrorNum err_no, const char* pszErrorMsg)
 {
     if( GDALIsInGlobalDestructor() )
     {

--- a/swig/include/gdal.i
+++ b/swig/include/gdal.i
@@ -1081,6 +1081,7 @@ static void CPL_STDCALL StackingErrorHandler( CPLErr eErr, CPLErrorNum no,
 static void PushStackingErrorHandler(std::vector<ErrorStruct>* paoErrors)
 {
     CPLPushErrorHandlerEx(StackingErrorHandler, paoErrors);
+    CPLSetCurrentErrorHandlerCatchDebug(false);
 }
 
 static void PopStackingErrorHandler(std::vector<ErrorStruct>* paoErrors, bool bSuccess)
@@ -1097,7 +1098,7 @@ static void PopStackingErrorHandler(std::vector<ErrorStruct>* paoErrors, bool bS
         CPLErr eErrClass = (*paoErrors)[iError].type;
         if( bSuccess && eErrClass == CE_Failure )
         {
-            pfnPreviousHandler( eErrClass,
+            CPLCallPreviousHandler( eErrClass,
                                 (*paoErrors)[iError].no,
                                 (*paoErrors)[iError].msg );
         }

--- a/swig/include/gdal_array.i
+++ b/swig/include/gdal_array.i
@@ -681,7 +681,6 @@ int GDALTermProgress( double, const char *, void * );
     }
 %#endif
     if( result != NULL && bLocalUseExceptions ) {
-        StoreLastException();
 %#ifdef SED_HACKS
         bLocalUseExceptionsCode = FALSE;
 %#endif
@@ -714,7 +713,6 @@ GDALDatasetShadow* OpenNumPyArray(PyArrayObject *psArray, bool binterleave)
     }
 %#endif
     if( result != NULL && bLocalUseExceptions ) {
-        StoreLastException();
 %#ifdef SED_HACKS
         bLocalUseExceptionsCode = FALSE;
 %#endif


### PR DESCRIPTION
- make sure that CPL_DEBUG=ON and gdal.UseExceptions() work fine during gdal.VectorTranslate() (and similar) (fixes #8552)
- accumulate CE_Failure messages during a GDAL call when gdal.UseExceptions() (fixes #8551)