### PR TITLE
CI: Add `ubuntugis` PPA by URL

### DIFF
--- a/.github/workflows/cmake_builds.yml
+++ b/.github/workflows/cmake_builds.yml
@@ -52,7 +52,10 @@ jobs:
         cmake --version
     - name: Install dependency
       run: |
-        sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
+        # This currently fails as of https://lists.osgeo.org/pipermail/ubuntu/2023-October/002046.html
+        # sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B827C12C2D425E227EDCA75089EBE08314DF160
+        sudo add-apt-repository -y http://ppa.launchpad.net/ubuntugis/ubuntugis-unstable/ubuntu/
         sudo apt-get update
         sudo apt-get install -y -q bison libaec-dev libjpeg-dev libgif-dev liblzma-dev libzstd-dev libgeos-dev git \
            libcurl4-gnutls-dev libproj-dev libxml2-dev  libxerces-c-dev libnetcdf-dev netcdf-bin \

--- a/ci/travis/csa_common/before_install.sh
+++ b/ci/travis/csa_common/before_install.sh
@@ -6,7 +6,10 @@ sudo apt-get purge -y libgeos*
 (sudo mv /etc/apt/sources.list.d/pgdg* /tmp || /bin/true)
 #sudo apt-get remove postgresql-9.2
 #sudo apt-get remove postgis libpq5 libpq-dev postgresql-9.1-postgis postgresql-9.1-postgis-2.2-scripts postgresql-9.2-postgis postgresql-9.3-postgis postgresql-9.1 postgresql-9.2 postgresql-9.3 libgdal1
-sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
+# This currently fails as of https://lists.osgeo.org/pipermail/ubuntu/2023-October/002046.html
+# sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B827C12C2D425E227EDCA75089EBE08314DF160
+sudo add-apt-repository -y http://ppa.launchpad.net/ubuntugis/ubuntugis-unstable/ubuntu/
 #sudo add-apt-repository -y ppa:marlam/gta
 sudo apt-get update -qq
 sudo apt-get install -y automake python-numpy postgis libpq-dev libpng12-dev libjpeg-dev libgif-dev liblzma-dev libgeos-dev libcurl4-gnutls-dev libproj-dev libxml2-dev libexpat-dev libxerces-c-dev libnetcdf-dev netcdf-bin libpoppler-dev libpoppler-private-dev libspatialite-dev gpsbabel swig libhdf4-alt-dev libhdf5-serial-dev libhdf5-dev libpodofo-dev poppler-utils libfreexl-dev unixodbc-dev libwebp-dev openjdk-8-jdk libepsilon-dev liblcms2-2 libpcre3-dev mercurial cmake libkml-dev libopenjp2-7-dev libzstd1-dev sqlite3 wget unzip curl


### PR DESCRIPTION
## What does this PR do?

I can reproduce the PPA issue easily on Ubuntu 20.04 (22.04 works file), but adding by URL instead seems to fix it.

The signing key is taken from the PPA page.

## What are related issues/pull requests?

https://lists.osgeo.org/pipermail/ubuntu/2023-October/002046.html

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
