### PR TITLE
GTiff JXL codec: fix wrong use of memcpy() in decoding, and add memcpy() optimizations

### DIFF
--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -10375,6 +10375,7 @@ def test_tiff_write_jpegxl_band_combinations():
     types = [
         gdal.GDT_Byte,
         gdal.GDT_UInt16,
+        gdal.GDT_Float32,
     ]
 
     creationOptions = [


### PR DESCRIPTION
Fixes
```
2023-10-28T20:34:37.3586623Z gcore/tiff_write.py::test_tiff_write_jpegxl_band_combinations =================================================================
2023-10-28T20:34:37.3589811Z ==9962==ERROR: AddressSanitizer: memcpy-param-overlap: memory ranges [0x7f42ae19580f,0x7f42ae195813) and [0x7f42ae19580c, 0x7f42ae195810) overlap
2023-10-28T20:34:37.9301668Z     #0 0x7f42ceadd135 in memcpy (/usr/lib/llvm-10/lib/clang/10.0.0/lib/linux/libclang_rt.asan-x86_64.so+0x58135)
2023-10-28T20:34:38.3855796Z     #1 0x7f42c7865574 in JXLPreDecode /home/runner/work/gdal/gdal/frmts/gtiff/tif_jxl.c:525:13
2023-10-28T20:34:38.3865654Z     #2 0x7f42c736f8b3 in gdal_TIFFStartTile /home/runner/work/gdal/gdal/frmts/gtiff/libtiff/tif_read.c:1481:9
2023-10-28T20:34:38.3867385Z     #3 0x7f42c736ed71 in gdal_TIFFFillTile /home/runner/work/gdal/gdal/frmts/gtiff/libtiff/tif_read.c:1333:13
2023-10-28T20:34:38.3869135Z     #4 0x7f42c736e428 in gdal_TIFFReadEncodedTile /home/runner/work/gdal/gdal/frmts/gtiff/libtiff/tif_read.c:965:9
2023-10-28T20:34:38.3920735Z     #5 0x7f42c77e2f5c in GTiffDataset::ReadStrile(int, void*, long long) /home/runner/work/gdal/gdal/frmts/gtiff/gtiffdataset_read.cpp:3172:13
2023-10-28T20:34:38.3926914Z     #6 0x7f42c77e3499 in GTiffDataset::LoadBlockBuf(int, bool) /home/runner/work/gdal/gdal/frmts/gtiff/gtiffdataset_read.cpp:3314:10
2023-10-28T20:34:38.3957108Z     #7 0x7f42c7834cd1 in GTiffRasterBand::IReadBlock(int, int, void*) /home/runner/work/gdal/gdal/frmts/gtiff/gtiffrasterband_read.cpp:1277:25
2023-10-28T20:34:38.3998932Z     #8 0x7f42c8c680ca in GDALRasterBand::GetLockedBlockRef(int, int, int) /home/runner/work/gdal/gdal/gcore/gdalrasterband.cpp:1417:20
2023-10-28T20:34:38.4043184Z     #9 0x7f42c8d46056 in GDALRasterBand::IRasterIO(GDALRWFlag, int, int, int, int, void*, int, int, GDALDataType, long long, long long, GDALRasterIOExtraArg*) /home/runner/work/gdal/gdal/gcore/rasterio.cpp:473:21
2023-10-28T20:34:38.4053538Z     #10 0x7f42c782e4df in GTiffRasterBand::IRasterIO(GDALRWFlag, int, int, int, int, void*, int, int, GDALDataType, long long, long long, GDALRasterIOExtraArg*) /home/runner/work/gdal/gdal/frmts/gtiff/gtiffrasterband.cpp:462:44
2023-10-28T20:34:38.4059381Z     #11 0x7f42c8c665f7 in GDALRasterBand::RasterIO(GDALRWFlag, int, int, int, int, void*, int, int, GDALDataType, long long, long long, GDALRasterIOExtraArg*) /home/runner/work/gdal/gdal/gcore/gdalrasterband.cpp:413:13
2023-10-28T20:34:38.4063556Z     #12 0x7f42c8c66bec in GDALRasterIO /home/runner/work/gdal/gdal/gcore/gdalrasterband.cpp:446:21
2023-10-28T20:34:38.4065133Z     #13 0x7f42c74969e7 in GDALChecksumImage /home/runner/work/gdal/gdal/alg/gdalchecksum.cpp:198:21
2023-10-28T20:34:38.4538129Z     #14 0x7f42c9e5af12 in GDALRasterBandShadow_Checksum /home/runner/work/gdal/gdal/build-asan/swig/python/extensions/gdal_wrap.cpp:6906:29
2023-10-28T20:34:38.4541346Z     #15 0x7f42c9e5af12 in _wrap_Band_Checksum /home/runner/work/gdal/gdal/build-asan/swig/python/extensions/gdal_wrap.cpp:35715:50
```