### PR TITLE
[Backport release/3.7] GTiff JXL codec: fix wrong use of memcpy() in decoding, and add memcpy() optimizations

### DIFF
--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -10293,6 +10293,7 @@ def test_tiff_write_jpegxl_band_combinations():
     types = [
         gdal.GDT_Byte,
         gdal.GDT_UInt16,
+        gdal.GDT_Float32,
     ]
 
     creationOptions = [


### PR DESCRIPTION
Backport #8628
 **Authored by:** @rouault