### PR TITLE
cpl_vsil_win32: check return value of FlushFileBuffers(), and open file with GENERIC_WRITE only if access=w or wb

### DIFF
--- a/autotest/gcore/vsifile.py
+++ b/autotest/gcore/vsifile.py
@@ -51,11 +51,11 @@ def module_disable_exceptions():
 # Generic test
 
 
-def vsifile_generic(filename):
+def vsifile_generic(filename, options=[]):
 
     start_time = time.time()
 
-    fp = gdal.VSIFOpenL(filename, "wb+")
+    fp = gdal.VSIFOpenExL(filename, "wb+", False, options)
     assert fp is not None
 
     assert gdal.VSIFWriteL("0123456789", 1, 10, fp) == 10
@@ -84,7 +84,7 @@ def vsifile_generic(filename):
     assert statBuf.size == 7
     assert start_time == pytest.approx(statBuf.mtime, abs=2)
 
-    fp = gdal.VSIFOpenL(filename, "rb")
+    fp = gdal.VSIFOpenExL(filename, "rb", False, options)
     assert gdal.VSIFReadL(1, 0, fp) is None
     assert gdal.VSIFReadL(0, 1, fp) is None
     buf = gdal.VSIFReadL(1, 7, fp)
@@ -95,7 +95,7 @@ def vsifile_generic(filename):
     assert buf.decode("ascii") == "01234XX"
 
     # Test append mode on existing file
-    fp = gdal.VSIFOpenL(filename, "ab")
+    fp = gdal.VSIFOpenExL(filename, "ab", False, options)
     gdal.VSIFWriteL("XX", 1, 2, fp)
     gdal.VSIFCloseL(fp)
 
@@ -111,7 +111,7 @@ def vsifile_generic(filename):
     assert statBuf is None
 
     # Test append mode on non existing file
-    fp = gdal.VSIFOpenL(filename, "ab")
+    fp = gdal.VSIFOpenExL(filename, "ab", False, options)
     gdal.VSIFWriteL("XX", 1, 2, fp)
     gdal.VSIFCloseL(fp)
 
@@ -138,6 +138,15 @@ def test_vsifile_1():
 
 def test_vsifile_2():
     vsifile_generic("tmp/vsifile_2.bin")
+
+
+###############################################################################
+# Test Windows specific WRITE_THROUGH=YES
+
+
+@pytest.mark.skipif(sys.platform != "win32", reason="Windows specific test")
+def test_vsifile_WRITE_THROUGH():
+    vsifile_generic("tmp/vsifile_WRITE_THROUGH.bin", ["WRITE_THROUGH=YES"])
 
 
 ###############################################################################

--- a/port/cpl_vsil.cpp
+++ b/port/cpl_vsil.cpp
@@ -1921,6 +1921,19 @@ VSILFILE *VSIFOpenExL(const char *pszFilename, const char *pszAccess,
  * This method goes through the VSIFileHandler virtualization and may
  * work on unusual filesystems such as in memory.
  *
+ * The following options are supported:
+ * <ul>
+ * <li>MIME headers such as Content-Type and Content-Encoding
+ * are supported for the /vsis3/, /vsigs/, /vsiaz/, /vsiadls/ file systems.</li>
+ * <li>DISABLE_READDIR_ON_OPEN=YES/NO (GDAL >= 3.6) for /vsicurl/ and other
+ * network-based file systems. By default, directory file listing is done,
+ * unless YES is specified.</li>
+ * <li>WRITE_THROUGH=YES (GDAL >= 3.8) for the Windows regular files to
+ * set the FILE_FLAG_WRITE_THROUGH flag to the CreateFile() function. In that
+ * mode, the data is written to the system cache but is flushed to disk without
+ * delay.</li>
+ * </ul>
+ *
  * Analog of the POSIX fopen() function.
  *
  * @param pszFilename the file to open.  UTF-8 encoded.
@@ -1929,12 +1942,7 @@ VSILFILE *VSIFOpenExL(const char *pszFilename, const char *pszAccess,
  * should set VSIErrors on failure.
  * @param papszOptions NULL or NULL-terminated list of strings. The content is
  *                     highly file system dependent.
- *                     MIME headers such as Content-Type and Content-Encoding
- * are supported for the /vsis3/, /vsigs/, /vsiaz/, /vsiadls/ file systems.
- *                     Starting with GDAL 3.6, the
- * DISABLE_READDIR_ON_OPEN=YES/NO option is supported for /vsicurl/ and other
- * network-based file systems. By default, directory file listing is done,
- *                     unless YES is specified.
+ *
  *
  * @return NULL on failure, or the file handle.
  *
@@ -2137,6 +2145,10 @@ void VSIRewindL(VSILFILE *fp)
  *
  * Analog of the POSIX fflush() call.
  *
+ * On Windows regular files, this method does nothing, unless the
+ * VSI_FLUSH configuration option is set to YES (and only when the file has
+ * *not* been opened with the WRITE_THROUGH option).
+ *
  * @return 0 on success or -1 on error.
  */
 
@@ -2150,6 +2162,10 @@ void VSIRewindL(VSILFILE *fp)
  * work on unusual filesystems such as in memory.
  *
  * Analog of the POSIX fflush() call.
+ *
+ * On Windows regular files, this method does nothing, unless the
+ * VSI_FLUSH configuration option is set to YES (and only when the file has
+ * *not* been opened with the WRITE_THROUGH option).
  *
  * @param fp file handle opened with VSIFOpenL().
  *


### PR DESCRIPTION
Also: cpl_vsil_win32: implement a WRITE_THROUGH=YEs option to pass to VSIFOpenEx2L()