### PR TITLE
autotest: make more tests run independently

### DIFF
--- a/autotest/conftest.py
+++ b/autotest/conftest.py
@@ -136,7 +136,9 @@ def pytest_collection_modifyitems(config, items):
         for mark in item.iter_markers("require_driver"):
             driver_name = mark.args[0]
             if driver_name not in drivers_checked:
-                driver = gdal.GetDriverByName(driver_name)
+                driver = gdal.GetDriverByName(driver_name) or ogr.GetDriverByName(
+                    driver_name
+                )
                 drivers_checked[driver_name] = bool(driver)
                 if driver:
                     # Store the driver on gdaltest module so test functions can assume it's there.

--- a/autotest/gcore/vsicurl.py
+++ b/autotest/gcore/vsicurl.py
@@ -44,6 +44,7 @@ pytestmark = pytest.mark.require_curl()
 
 
 @pytest.mark.slow()
+@pytest.mark.skip("File is no longer available")
 def test_vsicurl_1():
 
     ds = ogr.Open(
@@ -57,7 +58,8 @@ def test_vsicurl_1():
 
 
 @pytest.mark.slow()
-def vsicurl_2():
+@pytest.mark.skip("File is no longer available")
+def test_vsicurl_2():
 
     ds = gdal.Open(
         "/vsizip//vsicurl/http://eros.usgs.gov/archive/nslrsda/GeoTowns/HongKong/srtm/n22e113.zip/n22e113.bil"
@@ -70,7 +72,8 @@ def vsicurl_2():
 
 
 @pytest.mark.slow()
-def vsicurl_3():
+@pytest.mark.skip("File is no longer available")
+def test_vsicurl_3():
 
     ds = ogr.Open(
         "/vsizip/vsicurl/http://www.iucnredlist.org/spatial-data/MAMMALS_TERRESTRIAL.zip"
@@ -83,6 +86,7 @@ def vsicurl_3():
 
 
 @pytest.mark.slow()
+@gdaltest.disable_exceptions()
 def test_vsicurl_4():
 
     ds = ogr.Open(
@@ -96,6 +100,7 @@ def test_vsicurl_4():
 
 
 @pytest.mark.slow()
+@pytest.mark.skip("File is no longer available")
 def test_vsicurl_5():
 
     ds = gdal.Open(
@@ -109,7 +114,8 @@ def test_vsicurl_5():
 
 
 @pytest.mark.slow()
-def vsicurl_6_disabled():
+@pytest.mark.skip("Server is no longer available")
+def test_vsicurl_6():
 
     fl = gdal.ReadDir("/vsicurl/ftp://ftp2.cits.rncan.gc.ca/pub/cantopo/250k_tif")
     assert fl
@@ -120,6 +126,7 @@ def vsicurl_6_disabled():
 
 
 @pytest.mark.slow()
+@pytest.mark.skip("Server is no longer available")
 def test_vsicurl_7():
 
     fl = gdal.ReadDir("/vsicurl/http://ortho.linz.govt.nz/tifs/2005_06")
@@ -131,7 +138,8 @@ def test_vsicurl_7():
 
 
 @pytest.mark.slow()
-def vsicurl_8():
+@pytest.mark.skip("File is no longer available")
+def test_vsicurl_8():
 
     ds1 = gdal.Open(
         "/vsigzip//vsicurl/http://dds.cr.usgs.gov/pub/data/DEM/250/notavail/C/chipicoten-w.gz"
@@ -194,26 +202,31 @@ def test_vsicurl_11():
 ###############################################################################
 
 
-def test_vsicurl_start_webserver():
+@pytest.fixture(scope="module")
+def server():
 
-    gdaltest.webserver_process = None
-    gdaltest.webserver_port = 0
-
-    (gdaltest.webserver_process, gdaltest.webserver_port) = webserver.launch(
-        handler=webserver.DispatcherHttpHandler
-    )
-    if gdaltest.webserver_port == 0:
+    process, port = webserver.launch(handler=webserver.DispatcherHttpHandler)
+    if port == 0:
         pytest.skip()
+
+    import collections
+
+    WebServer = collections.namedtuple("WebServer", "process port")
+
+    yield WebServer(process, port)
+
+    # Clearcache needed to close all connections, since the Python server
+    # can only handle one connection at a time
+    gdal.VSICurlClearCache()
+
+    webserver.server_stop(process, port)
 
 
 ###############################################################################
 # Test redirection with Expires= type of signed URLs
 
 
-def test_vsicurl_test_redirect():
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
+def test_vsicurl_test_redirect(server):
 
     gdal.VSICurlClearCache()
 
@@ -232,7 +245,7 @@ def test_vsicurl_test_redirect():
         )
         response += "Location: %s\r\n" % (
             "http://localhost:%d/foo.s3.amazonaws.com/test_redirected/test.bin?Signature=foo&Expires=%d"
-            % (gdaltest.webserver_port, current_time + 30)
+            % (server.port, current_time + 30)
         )
         response += "\r\n"
         request.wfile.write(response.encode("ascii"))
@@ -292,8 +305,7 @@ def test_vsicurl_test_redirect():
 
     with webserver.install_http_handler(handler):
         f = gdal.VSIFOpenL(
-            "/vsicurl/http://localhost:%d/test_redirect/test.bin"
-            % gdaltest.webserver_port,
+            "/vsicurl/http://localhost:%d/test_redirect/test.bin" % server.port,
             "rb",
         )
     assert f is not None
@@ -378,10 +390,7 @@ def test_vsicurl_test_redirect():
 # Test redirection with X-Amz-Expires= + X-Amz-Date= type of signed URLs
 
 
-def test_vsicurl_test_redirect_x_amz():
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
+def test_vsicurl_test_redirect_x_amz(server):
 
     gdal.VSICurlClearCache()
 
@@ -401,7 +410,7 @@ def test_vsicurl_test_redirect_x_amz():
         response += "Location: %s\r\n" % (
             "http://localhost:%d/foo.s3.amazonaws.com/test_redirected/test.bin?X-Amz-Signature=foo&X-Amz-Expires=30&X-Amz-Date=%s"
             % (
-                gdaltest.webserver_port,
+                server.port,
                 time.strftime("%Y%m%dT%H%M%SZ", time.gmtime(current_time)),
             )
         )
@@ -463,8 +472,7 @@ def test_vsicurl_test_redirect_x_amz():
 
     with webserver.install_http_handler(handler):
         f = gdal.VSIFOpenL(
-            "/vsicurl/http://localhost:%d/test_redirect/test.bin"
-            % gdaltest.webserver_port,
+            "/vsicurl/http://localhost:%d/test_redirect/test.bin" % server.port,
             "rb",
         )
     assert f is not None
@@ -561,10 +569,7 @@ def test_vsicurl_test_clear_cache():
 ###############################################################################
 
 
-def test_vsicurl_test_retry():
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
+def test_vsicurl_test_retry(server):
 
     handler = webserver.SequentialHandler()
     handler.add("GET", "/test_retry/", 404)
@@ -572,8 +577,7 @@ def test_vsicurl_test_retry():
     handler.add("GET", "/test_retry/test.txt", 502)
     with webserver.install_http_handler(handler):
         f = gdal.VSIFOpenL(
-            "/vsicurl/http://localhost:%d/test_retry/test.txt"
-            % gdaltest.webserver_port,
+            "/vsicurl/http://localhost:%d/test_retry/test.txt" % server.port,
             "rb",
         )
         data_len = 0
@@ -593,7 +597,7 @@ def test_vsicurl_test_retry():
     with webserver.install_http_handler(handler):
         f = gdal.VSIFOpenL(
             "/vsicurl?max_retry=2&retry_delay=0.01&url=http://localhost:%d/test_retry/test.txt"
-            % gdaltest.webserver_port,
+            % server.port,
             "rb",
         )
         assert f is not None
@@ -609,10 +613,7 @@ def test_vsicurl_test_retry():
 ###############################################################################
 
 
-def test_vsicurl_test_fallback_from_head_to_get():
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
+def test_vsicurl_test_fallback_from_head_to_get(server):
 
     gdal.VSICurlClearCache()
 
@@ -621,8 +622,7 @@ def test_vsicurl_test_fallback_from_head_to_get():
     handler.add("GET", "/test_fallback_from_head_to_get", 200, {}, "foo")
     with webserver.install_http_handler(handler):
         statres = gdal.VSIStatL(
-            "/vsicurl/http://localhost:%d/test_fallback_from_head_to_get"
-            % gdaltest.webserver_port
+            "/vsicurl/http://localhost:%d/test_fallback_from_head_to_get" % server.port
         )
     assert statres.size == 3
 
@@ -632,10 +632,7 @@ def test_vsicurl_test_fallback_from_head_to_get():
 ###############################################################################
 
 
-def test_vsicurl_test_parse_html_filelist_apache():
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
+def test_vsicurl_test_parse_html_filelist_apache(server):
 
     handler = webserver.SequentialHandler()
     handler.add(
@@ -659,15 +656,12 @@ def test_vsicurl_test_parse_html_filelist_apache():
 </body></html>""",
     )
     with webserver.install_http_handler(handler):
-        fl = gdal.ReadDir(
-            "/vsicurl/http://localhost:%d/mydir" % gdaltest.webserver_port
-        )
+        fl = gdal.ReadDir("/vsicurl/http://localhost:%d/mydir" % server.port)
     assert fl == ["foo.tif", "foo%20with%20space.tif"]
 
     assert (
         gdal.VSIStatL(
-            "/vsicurl/http://localhost:%d/mydir/foo%%20with%%20space.tif"
-            % gdaltest.webserver_port,
+            "/vsicurl/http://localhost:%d/mydir/foo%%20with%%20space.tif" % server.port,
             gdal.VSI_STAT_EXISTS_FLAG,
         )
         is not None
@@ -678,8 +672,7 @@ def test_vsicurl_test_parse_html_filelist_apache():
     with webserver.install_http_handler(handler):
         assert (
             gdal.VSIStatL(
-                "/vsicurl/http://localhost:%d/mydir/i_dont_exist"
-                % gdaltest.webserver_port,
+                "/vsicurl/http://localhost:%d/mydir/i_dont_exist" % server.port,
                 gdal.VSI_STAT_EXISTS_FLAG,
             )
             is None
@@ -689,10 +682,7 @@ def test_vsicurl_test_parse_html_filelist_apache():
 ###############################################################################
 
 
-def test_vsicurl_no_size_in_HEAD():
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
+def test_vsicurl_no_size_in_HEAD(server):
 
     handler = webserver.SequentialHandler()
     handler.add(
@@ -706,7 +696,7 @@ def test_vsicurl_no_size_in_HEAD():
     with webserver.install_http_handler(handler):
         statres = gdal.VSIStatL(
             "/vsicurl/http://localhost:%d/test_vsicurl_no_size_in_HEAD.bin"
-            % gdaltest.webserver_port
+            % server.port
         )
     assert statres.size == 10
 
@@ -714,10 +704,7 @@ def test_vsicurl_no_size_in_HEAD():
 ###############################################################################
 
 
-def test_vsicurl_test_CPL_CURL_VERBOSE():
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
+def test_vsicurl_test_CPL_CURL_VERBOSE(server):
 
     gdal.VSICurlClearCache()
 
@@ -745,7 +732,7 @@ def test_vsicurl_test_CPL_CURL_VERBOSE():
             with webserver.install_http_handler(handler):
                 statres = gdal.VSIStatL(
                     "/vsicurl/http://localhost:%d/test_vsicurl_test_CPL_CURL_VERBOSE"
-                    % gdaltest.webserver_port
+                    % server.port
                 )
     assert statres.size == 3
 
@@ -759,10 +746,7 @@ def test_vsicurl_test_CPL_CURL_VERBOSE():
 ###############################################################################
 
 
-def test_vsicurl_planetary_computer_url_signing():
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
+def test_vsicurl_planetary_computer_url_signing(server):
 
     gdal.VSICurlClearCache()
 
@@ -770,11 +754,11 @@ def test_vsicurl_planetary_computer_url_signing():
     handler.add(
         "GET",
         "/pc_sas_sign_href?href=http://localhost:%d/test_vsicurl_planetary_computer_url_signing.bin"
-        % gdaltest.webserver_port,
+        % server.port,
         200,
         {},
         '{"msft:expiry":"1970-01-01T00:00:00","href":"http://localhost:%d/test_vsicurl_planetary_computer_url_signing.bin?my_token"}'
-        % gdaltest.webserver_port,
+        % server.port,
     )
     handler.add(
         "HEAD",
@@ -786,11 +770,11 @@ def test_vsicurl_planetary_computer_url_signing():
     with webserver.install_http_handler(handler):
         with gdaltest.config_option(
             "VSICURL_PC_SAS_SIGN_HREF_URL",
-            "http://localhost:%d/pc_sas_sign_href?href=" % gdaltest.webserver_port,
+            "http://localhost:%d/pc_sas_sign_href?href=" % server.port,
         ):
             statres = gdal.VSIStatL(
                 "/vsicurl?pc_url_signing=yes&url=http://localhost:%d/test_vsicurl_planetary_computer_url_signing.bin"
-                % gdaltest.webserver_port
+                % server.port
             )
             assert statres.size == 3
 
@@ -801,11 +785,11 @@ def test_vsicurl_planetary_computer_url_signing():
     handler.add(
         "GET",
         "/pc_sas_sign_href?href=http://localhost:%d/test_vsicurl_planetary_computer_url_signing.bin"
-        % gdaltest.webserver_port,
+        % server.port,
         200,
         {},
         '{"msft:expiry":"9999-01-01T00:00:00","href":"http://localhost:%d/test_vsicurl_planetary_computer_url_signing.bin?my_token"}'
-        % gdaltest.webserver_port,
+        % server.port,
     )
     handler.add(
         "HEAD",
@@ -817,11 +801,11 @@ def test_vsicurl_planetary_computer_url_signing():
     with webserver.install_http_handler(handler):
         with gdaltest.config_option(
             "VSICURL_PC_SAS_SIGN_HREF_URL",
-            "http://localhost:%d/pc_sas_sign_href?href=" % gdaltest.webserver_port,
+            "http://localhost:%d/pc_sas_sign_href?href=" % server.port,
         ):
             statres = gdal.VSIStatL(
                 "/vsicurl?pc_url_signing=yes&url=http://localhost:%d/test_vsicurl_planetary_computer_url_signing.bin"
-                % gdaltest.webserver_port
+                % server.port
             )
             assert statres.size == 3
 
@@ -839,11 +823,11 @@ def test_vsicurl_planetary_computer_url_signing():
     with webserver.install_http_handler(handler):
         with gdaltest.config_option(
             "VSICURL_PC_SAS_SIGN_HREF_URL",
-            "http://localhost:%d/pc_sas_sign_href?href=" % gdaltest.webserver_port,
+            "http://localhost:%d/pc_sas_sign_href?href=" % server.port,
         ):
             statres = gdal.VSIStatL(
                 "/vsicurl?pc_url_signing=yes&url=http://localhost:%d/test_vsicurl_planetary_computer_url_signing.bin"
-                % gdaltest.webserver_port
+                % server.port
             )
             assert statres.size == 3
 
@@ -851,11 +835,11 @@ def test_vsicurl_planetary_computer_url_signing():
     handler.add(
         "GET",
         "/pc_sas_sign_href?href=http://localhost:%d/test_vsicurl_planetary_computer_url_signing2.bin"
-        % gdaltest.webserver_port,
+        % server.port,
         200,
         {},
         '{"msft:expiry":"9999-01-01T00:00:00","href":"http://localhost:%d/test_vsicurl_planetary_computer_url_signing2.bin?my_token2"}'
-        % gdaltest.webserver_port,
+        % server.port,
     )
     handler.add(
         "HEAD",
@@ -867,11 +851,11 @@ def test_vsicurl_planetary_computer_url_signing():
     with webserver.install_http_handler(handler):
         with gdaltest.config_option(
             "VSICURL_PC_SAS_SIGN_HREF_URL",
-            "http://localhost:%d/pc_sas_sign_href?href=" % gdaltest.webserver_port,
+            "http://localhost:%d/pc_sas_sign_href?href=" % server.port,
         ):
             statres = gdal.VSIStatL(
                 "/vsicurl?pc_url_signing=yes&url=http://localhost:%d/test_vsicurl_planetary_computer_url_signing2.bin"
-                % gdaltest.webserver_port
+                % server.port
             )
             assert statres.size == 4
 
@@ -897,17 +881,17 @@ def test_vsicurl_planetary_computer_url_signing():
     with webserver.install_http_handler(handler):
         with gdaltest.config_option(
             "VSICURL_PC_SAS_SIGN_HREF_URL",
-            "http://localhost:%d/pc_sas_sign_href?href=" % gdaltest.webserver_port,
+            "http://localhost:%d/pc_sas_sign_href?href=" % server.port,
         ):
             statres = gdal.VSIStatL(
                 "/vsicurl?pc_url_signing=yes&url=http://localhost:%d/test_vsicurl_planetary_computer_url_signing.bin"
-                % gdaltest.webserver_port
+                % server.port
             )
             assert statres.size == 3
 
             statres = gdal.VSIStatL(
                 "/vsicurl?pc_url_signing=yes&url=http://localhost:%d/test_vsicurl_planetary_computer_url_signing2.bin"
-                % gdaltest.webserver_port
+                % server.port
             )
             assert statres.size == 4
 
@@ -915,10 +899,7 @@ def test_vsicurl_planetary_computer_url_signing():
 ###############################################################################
 
 
-def test_vsicurl_planetary_computer_url_signing_collection():
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
+def test_vsicurl_planetary_computer_url_signing_collection(server):
 
     gdal.VSICurlClearCache()
 
@@ -978,31 +959,31 @@ def test_vsicurl_planetary_computer_url_signing_collection():
     with webserver.install_http_handler(handler):
         with gdaltest.config_option(
             "VSICURL_PC_SAS_TOKEN_URL",
-            "http://localhost:%d/pc_sas_token/" % gdaltest.webserver_port,
+            "http://localhost:%d/pc_sas_token/" % server.port,
         ):
             statres = gdal.VSIStatL(
                 "/vsicurl?pc_url_signing=yes&pc_collection=my_collection&url=http://localhost:%d/test_vsicurl_planetary_computer_url_signing.bin"
-                % gdaltest.webserver_port
+                % server.port
             )
             assert statres.size == 3
             statres = gdal.VSIStatL(
                 "/vsicurl?pc_url_signing=yes&pc_collection=my_collection&url=http://localhost:%d/test_vsicurl_planetary_computer_url_signing2.bin"
-                % gdaltest.webserver_port
+                % server.port
             )
             assert statres.size == 4
             statres = gdal.VSIStatL(
                 "/vsicurl?pc_url_signing=yes&pc_collection=my_collection&url=http://localhost:%d/test_vsicurl_planetary_computer_url_signing3.bin"
-                % gdaltest.webserver_port
+                % server.port
             )
             assert statres.size == 5
             statres = gdal.VSIStatL(
                 "/vsicurl?pc_url_signing=yes&pc_collection=my_collection2&url=http://localhost:%d/test_vsicurl_planetary_computer_url_signing4.bin"
-                % gdaltest.webserver_port
+                % server.port
             )
             assert statres.size == 6
             statres = gdal.VSIStatL(
                 "/vsicurl?pc_url_signing=yes&pc_collection=my_collection&url=http://localhost:%d/test_vsicurl_planetary_computer_url_signing5.bin"
-                % gdaltest.webserver_port
+                % server.port
             )
             assert statres.size == 7
 
@@ -1010,10 +991,7 @@ def test_vsicurl_planetary_computer_url_signing_collection():
 ###############################################################################
 
 
-def test_vsicurl_GDAL_HTTP_HEADERS():
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
+def test_vsicurl_GDAL_HTTP_HEADERS(server):
 
     gdal.VSICurlClearCache()
 
@@ -1031,8 +1009,7 @@ def test_vsicurl_GDAL_HTTP_HEADERS():
     )
 
     filename = (
-        "/vsicurl/http://localhost:%d/test_vsicurl_GDAL_HTTP_HEADERS.bin"
-        % gdaltest.webserver_port
+        "/vsicurl/http://localhost:%d/test_vsicurl_GDAL_HTTP_HEADERS.bin" % server.port
     )
     gdal.SetPathSpecificOption(
         filename,
@@ -1049,10 +1026,7 @@ def test_vsicurl_GDAL_HTTP_HEADERS():
 # Test CPL_VSIL_CURL_USE_HEAD=NO
 
 
-def test_vsicurl_test_CPL_VSIL_CURL_USE_HEAD_NO():
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
+def test_vsicurl_test_CPL_VSIL_CURL_USE_HEAD_NO(server):
 
     gdal.VSICurlClearCache()
 
@@ -1082,7 +1056,7 @@ def test_vsicurl_test_CPL_VSIL_CURL_USE_HEAD_NO():
         with gdaltest.config_option("CPL_VSIL_CURL_USE_HEAD", "NO"):
             f = gdal.VSIFOpenL(
                 "/vsicurl/http://localhost:%d/test_CPL_VSIL_CURL_USE_HEAD_NO/test.bin"
-                % gdaltest.webserver_port,
+                % server.port,
                 "rb",
             )
     assert f is not None
@@ -1090,21 +1064,6 @@ def test_vsicurl_test_CPL_VSIL_CURL_USE_HEAD_NO():
     assert gdal.VSIFTellL(f) == 1000000
 
     gdal.VSIFCloseL(f)
-
-
-###############################################################################
-
-
-def test_vsicurl_stop_webserver():
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
-
-    # Clearcache needed to close all connections, since the Python server
-    # can only handle one connection at a time
-    gdal.VSICurlClearCache()
-
-    webserver.server_stop(gdaltest.webserver_process, gdaltest.webserver_port)
 
 
 ###############################################################################

--- a/autotest/gcore/vsiswift.py
+++ b/autotest/gcore/vsiswift.py
@@ -51,26 +51,54 @@ def open_for_read(uri):
 ###############################################################################
 
 
-def test_vsiswift_init():
+@pytest.fixture(scope="module", autouse=True)
+def setup_and_cleanup():
 
-    gdaltest.swift_vars = {}
-    for var in (
-        "SWIFT_STORAGE_URL",
-        "SWIFT_AUTH_TOKEN",
-        "SWIFT_AUTH_V1_URL",
-        "SWIFT_USER",
-        "SWIFT_KEY",
+    with gdal.config_options(
+        {
+            "SWIFT_STORAGE_URL": "",
+            "SWIFT_AUTH_TOKEN": "",
+            "SWIFT_AUTH_V1_URL": "",
+            "SWIFT_USER": "",
+            "SWIFT_KEY": "",
+        },
+        thread_local=False,
     ):
-        gdaltest.swift_vars[var] = gdal.GetConfigOption(var)
-        if gdaltest.swift_vars[var] is not None:
-            gdal.SetConfigOption(var, "")
+
+        yield
+
+
+@pytest.fixture(scope="function", autouse=True)
+def clear_cache():
+    gdal.VSICurlClearCache()
+    yield
+
+
+@pytest.fixture(scope="module")
+def server():
+
+    process, port = webserver.launch(handler=webserver.DispatcherHttpHandler)
+    if port == 0:
+        pytest.skip()
+
+    import collections
+
+    WebServer = collections.namedtuple("WebServer", "process port")
+
+    yield WebServer(process, port)
+
+    # Clearcache needed to close all connections, since the Python server
+    # can only handle one connection at a time
+    gdal.VSICurlClearCache()
+
+    webserver.server_stop(process, port)
 
 
 ###############################################################################
 # Error cases
 
 
-def test_vsiswift_real_server_errors():
+def test_vsiswift_real_server_errors_a():
 
     # Nothing set
     gdal.ErrorReset()
@@ -78,253 +106,246 @@ def test_vsiswift_real_server_errors():
         f = open_for_read("/vsiswift/foo/bar")
     assert f is None and gdal.VSIGetLastErrorMsg().find("SWIFT_STORAGE_URL") >= 0
 
+
+def test_vsiswift_real_server_errors_b():
+
     gdal.ErrorReset()
     with gdal.quiet_errors():
         f = open_for_read("/vsiswift_streaming/foo/bar")
     assert f is None and gdal.VSIGetLastErrorMsg().find("SWIFT_STORAGE_URL") >= 0
 
-    gdal.SetConfigOption("SWIFT_STORAGE_URL", "http://0.0.0.0")
 
-    # Missing SWIFT_AUTH_TOKEN
-    gdal.ErrorReset()
-    with gdal.quiet_errors():
-        f = open_for_read("/vsiswift/foo/bar")
-    assert f is None and gdal.VSIGetLastErrorMsg().find("SWIFT_AUTH_TOKEN") >= 0
+def test_vsiswift_real_server_errors_c():
 
-    gdal.SetConfigOption("SWIFT_AUTH_TOKEN", "SWIFT_AUTH_TOKEN")
+    with gdal.config_option("SWIFT_STORAGE_URL", "http://0.0.0.0"):
 
-    gdal.ErrorReset()
-    with gdal.quiet_errors():
-        f = open_for_read("/vsiswift/foo/bar.baz")
-    if f is not None:
+        # Missing SWIFT_AUTH_TOKEN
+        gdal.ErrorReset()
+        with gdal.quiet_errors():
+            f = open_for_read("/vsiswift/foo/bar")
+        assert f is None and gdal.VSIGetLastErrorMsg().find("SWIFT_AUTH_TOKEN") >= 0
+
+
+def test_vsiswift_real_server_errors_d():
+
+    with gdal.config_options(
+        {"SWIFT_STORAGE_URL": "http://0.0.0.0", "SWIFT_AUTH_TOKEN": "SWIFT_AUTH_TOKEN"}
+    ):
+
+        gdal.ErrorReset()
+        with gdal.quiet_errors():
+            f = open_for_read("/vsiswift/foo/bar.baz")
         if f is not None:
-            gdal.VSIFCloseL(f)
-        pytest.fail(gdal.VSIGetLastErrorMsg())
+            if f is not None:
+                gdal.VSIFCloseL(f)
+            pytest.fail(gdal.VSIGetLastErrorMsg())
 
-    gdal.ErrorReset()
-    with gdal.quiet_errors():
-        f = open_for_read("/vsiswift_streaming/foo/bar.baz")
-    assert f is None, gdal.VSIGetLastErrorMsg()
-
-
-###############################################################################
-
-
-def test_vsiswift_start_webserver():
-
-    gdaltest.webserver_process = None
-    gdaltest.webserver_port = 0
-
-    (gdaltest.webserver_process, gdaltest.webserver_port) = webserver.launch(
-        handler=webserver.DispatcherHttpHandler
-    )
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
+        gdal.ErrorReset()
+        with gdal.quiet_errors():
+            f = open_for_read("/vsiswift_streaming/foo/bar.baz")
+        assert f is None, gdal.VSIGetLastErrorMsg()
 
 
 ###############################################################################
 # Test authentication with SWIFT_AUTH_V1_URL + SWIFT_USER + SWIFT_KEY
 
 
-def test_vsiswift_fake_auth_v1_url():
+def test_vsiswift_fake_auth_v1_url(server):
 
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
+    with gdal.config_options(
+        {
+            "SWIFT_AUTH_V1_URL": "http://127.0.0.1:%d/auth/1.0" % server.port,
+            "SWIFT_USER": "my_user",
+            "SWIFT_KEY": "my_key",
+            "SWIFT_STORAGE_URL": "",
+            "SWIFT_AUTH_TOKEN": "",
+        },
+        thread_local=False,
+    ):
 
-    gdal.VSICurlClearCache()
-    gdal.SetConfigOption(
-        "SWIFT_AUTH_V1_URL", "http://127.0.0.1:%d/auth/1.0" % gdaltest.webserver_port
-    )
-    gdal.SetConfigOption("SWIFT_USER", "my_user")
-    gdal.SetConfigOption("SWIFT_KEY", "my_key")
-    gdal.SetConfigOption("SWIFT_STORAGE_URL", "")
-    gdal.SetConfigOption("SWIFT_AUTH_TOKEN", "")
+        handler = webserver.SequentialHandler()
 
-    handler = webserver.SequentialHandler()
+        def method(request):
 
-    def method(request):
+            request.protocol_version = "HTTP/1.1"
+            h = request.headers
+            if (
+                "X-Auth-User" not in h
+                or h["X-Auth-User"] != "my_user"
+                or "X-Auth-Key" not in h
+                or h["X-Auth-Key"] != "my_key"
+            ):
+                sys.stderr.write("Bad headers: %s\n" % str(h))
+                request.send_response(403)
+                return
+            request.send_response(200)
+            request.send_header("Content-Length", 0)
+            request.send_header(
+                "X-Storage-Url",
+                "http://127.0.0.1:%d/v1/AUTH_something" % server.port,
+            )
+            request.send_header("X-Auth-Token", "my_auth_token")
+            request.send_header("Connection", "close")
+            request.end_headers()
+            request.wfile.write("""foo""".encode("ascii"))
 
-        request.protocol_version = "HTTP/1.1"
-        h = request.headers
-        if (
-            "X-Auth-User" not in h
-            or h["X-Auth-User"] != "my_user"
-            or "X-Auth-Key" not in h
-            or h["X-Auth-Key"] != "my_key"
-        ):
-            sys.stderr.write("Bad headers: %s\n" % str(h))
-            request.send_response(403)
-            return
-        request.send_response(200)
-        request.send_header("Content-Length", 0)
-        request.send_header(
-            "X-Storage-Url",
-            "http://127.0.0.1:%d/v1/AUTH_something" % gdaltest.webserver_port,
-        )
-        request.send_header("X-Auth-Token", "my_auth_token")
-        request.send_header("Connection", "close")
-        request.end_headers()
-        request.wfile.write("""foo""".encode("ascii"))
+        handler.add("GET", "/auth/1.0", custom_method=method)
 
-    handler.add("GET", "/auth/1.0", custom_method=method)
+        def method(request):
 
-    def method(request):
+            request.protocol_version = "HTTP/1.1"
+            h = request.headers
+            if "x-auth-token" not in h or h["x-auth-token"] != "my_auth_token":
+                sys.stderr.write("Bad headers: %s\n" % str(h))
+                request.send_response(403)
+                return
+            request.send_response(200)
+            request.send_header("Content-type", "text/plain")
+            request.send_header("Content-Length", 3)
+            request.send_header("Connection", "close")
+            request.end_headers()
+            request.wfile.write("""foo""".encode("ascii"))
 
-        request.protocol_version = "HTTP/1.1"
-        h = request.headers
-        if "x-auth-token" not in h or h["x-auth-token"] != "my_auth_token":
-            sys.stderr.write("Bad headers: %s\n" % str(h))
-            request.send_response(403)
-            return
-        request.send_response(200)
-        request.send_header("Content-type", "text/plain")
-        request.send_header("Content-Length", 3)
-        request.send_header("Connection", "close")
-        request.end_headers()
-        request.wfile.write("""foo""".encode("ascii"))
+        handler.add("GET", "/v1/AUTH_something/foo/bar", custom_method=method)
+        with webserver.install_http_handler(handler):
+            f = open_for_read("/vsiswift/foo/bar")
+            assert f is not None
+            data = gdal.VSIFReadL(1, 4, f).decode("ascii")
+            gdal.VSIFCloseL(f)
 
-    handler.add("GET", "/v1/AUTH_something/foo/bar", custom_method=method)
-    with webserver.install_http_handler(handler):
-        f = open_for_read("/vsiswift/foo/bar")
-        assert f is not None
-        data = gdal.VSIFReadL(1, 4, f).decode("ascii")
-        gdal.VSIFCloseL(f)
+        assert data == "foo"
 
-    assert data == "foo"
+        # authentication is reused
 
-    # authentication is reused
+        def method(request):
 
-    def method(request):
+            request.protocol_version = "HTTP/1.1"
+            h = request.headers
+            if "x-auth-token" not in h or h["x-auth-token"] != "my_auth_token":
+                sys.stderr.write("Bad headers: %s\n" % str(h))
+                request.send_response(403)
+                return
+            request.send_response(200)
+            request.send_header("Content-type", "text/plain")
+            request.send_header("Content-Length", 3)
+            request.send_header("Connection", "close")
+            request.end_headers()
+            request.wfile.write("""bar""".encode("ascii"))
 
-        request.protocol_version = "HTTP/1.1"
-        h = request.headers
-        if "x-auth-token" not in h or h["x-auth-token"] != "my_auth_token":
-            sys.stderr.write("Bad headers: %s\n" % str(h))
-            request.send_response(403)
-            return
-        request.send_response(200)
-        request.send_header("Content-type", "text/plain")
-        request.send_header("Content-Length", 3)
-        request.send_header("Connection", "close")
-        request.end_headers()
-        request.wfile.write("""bar""".encode("ascii"))
+        handler.add("GET", "/v1/AUTH_something/foo/baz", custom_method=method)
 
-    handler.add("GET", "/v1/AUTH_something/foo/baz", custom_method=method)
+        with webserver.install_http_handler(handler):
+            f = open_for_read("/vsiswift/foo/baz")
+            assert f is not None
+            data = gdal.VSIFReadL(1, 4, f).decode("ascii")
+            gdal.VSIFCloseL(f)
 
-    with webserver.install_http_handler(handler):
-        f = open_for_read("/vsiswift/foo/baz")
-        assert f is not None
-        data = gdal.VSIFReadL(1, 4, f).decode("ascii")
-        gdal.VSIFCloseL(f)
-
-    assert data == "bar"
+        assert data == "bar"
 
 
 ###############################################################################
 # Test authentication with OS_IDENTITY_API_VERSION=3 OS_AUTH_URL + OS_USERNAME + OS_PASSWORD
 
 
-def test_vsiswift_fake_auth_v3_url():
+def test_vsiswift_fake_auth_v3_url(server):
 
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
+    with gdal.config_options(
+        {
+            "OS_IDENTITY_API_VERSION": "3",
+            "OS_AUTH_URL": "http://127.0.0.1:%d/v3" % server.port,
+            "OS_USERNAME": "my_user",
+            "OS_USER_DOMAIN_NAME": "test_user_domain",
+            "OS_PROJECT_NAME": "test_proj",
+            "OS_PROJECT_DOMAIN_NAME": "test_project_domain",
+            "OS_REGION_NAME": "Test",
+            "OS_PASSWORD": "pwd",
+            "SWIFT_STORAGE_URL": "",
+            "SWIFT_AUTH_TOKEN": "",
+        }
+    ):
 
-    gdal.VSICurlClearCache()
-    gdal.SetConfigOption("OS_IDENTITY_API_VERSION", "3")
-    gdal.SetConfigOption(
-        "OS_AUTH_URL", "http://127.0.0.1:%d/v3" % gdaltest.webserver_port
-    )
-    gdal.SetConfigOption("OS_USERNAME", "my_user")
-    gdal.SetConfigOption("OS_USER_DOMAIN_NAME", "test_user_domain")
-    gdal.SetConfigOption("OS_PROJECT_NAME", "test_proj")
-    gdal.SetConfigOption("OS_PROJECT_DOMAIN_NAME", "test_project_domain")
-    gdal.SetConfigOption("OS_REGION_NAME", "Test")
-    gdal.SetConfigOption("OS_PASSWORD", "pwd")
-    gdal.SetConfigOption("SWIFT_STORAGE_URL", "")
-    gdal.SetConfigOption("SWIFT_AUTH_TOKEN", "")
+        handler = webserver.SequentialHandler()
 
-    handler = webserver.SequentialHandler()
+        def method(request):
 
-    def method(request):
+            request.protocol_version = "HTTP/1.1"
+            h = request.headers
 
-        request.protocol_version = "HTTP/1.1"
-        h = request.headers
+            if "Content-Type" not in h or h["Content-Type"] != "application/json":
+                sys.stderr.write("Bad headers: %s\n" % str(h))
+                request.send_response(403)
+                return
 
-        if "Content-Type" not in h or h["Content-Type"] != "application/json":
-            sys.stderr.write("Bad headers: %s\n" % str(h))
-            request.send_response(403)
-            return
+            request_len = int(h["Content-Length"])
+            request_body = request.rfile.read(request_len).decode()
+            request_json = json.loads(request_body)
+            methods = request_json["auth"]["identity"]["methods"]
+            assert "password" in methods
+            password = request_json["auth"]["identity"]["password"]["user"]["password"]
+            assert password == "pwd"
 
-        request_len = int(h["Content-Length"])
-        request_body = request.rfile.read(request_len).decode()
-        request_json = json.loads(request_body)
-        methods = request_json["auth"]["identity"]["methods"]
-        assert "password" in methods
-        password = request_json["auth"]["identity"]["password"]["user"]["password"]
-        assert password == "pwd"
-
-        content = (
-            """{
-             "token" : {
-               "catalog" : [
-                 {
-                  "endpoints" : [
+            content = (
+                """{
+                 "token" : {
+                   "catalog" : [
                      {
-                        "region" : "Test",
-                        "interface" : "admin",
-                        "url" : "http://127.0.0.1:8080/v1/admin/AUTH_something"
-                     },
-                     {
-                        "region" : "Test",
-                        "interface" : "internal",
-                        "url" : "http://127.0.0.1:8081/v1/internal/AUTH_something"
-                     },
-                     {
-                        "region" : "Test",
-                        "interface" : "public",
-                        "url" : "http://127.0.0.1:%d/v1/AUTH_something"
+                      "endpoints" : [
+                         {
+                            "region" : "Test",
+                            "interface" : "admin",
+                            "url" : "http://127.0.0.1:8080/v1/admin/AUTH_something"
+                         },
+                         {
+                            "region" : "Test",
+                            "interface" : "internal",
+                            "url" : "http://127.0.0.1:8081/v1/internal/AUTH_something"
+                         },
+                         {
+                            "region" : "Test",
+                            "interface" : "public",
+                            "url" : "http://127.0.0.1:%d/v1/AUTH_something"
+                         }
+                      ],
+                      "type": "object-store",
+                      "name" : "swift"
                      }
-                  ],
-                  "type": "object-store",
-                  "name" : "swift"
+                   ]
                  }
-               ]
-             }
-          }"""
-            % gdaltest.webserver_port
-        )
-        content = content.encode("ascii")
-        request.send_response(200)
-        request.send_header("Content-Length", len(content))
-        request.send_header("Content-Type", "application/json")
-        request.send_header("X-Subject-Token", "my_auth_token")
-        request.end_headers()
-        request.wfile.write(content)
+              }"""
+                % server.port
+            )
+            content = content.encode("ascii")
+            request.send_response(200)
+            request.send_header("Content-Length", len(content))
+            request.send_header("Content-Type", "application/json")
+            request.send_header("X-Subject-Token", "my_auth_token")
+            request.end_headers()
+            request.wfile.write(content)
 
-    handler.add("POST", "/v3/auth/tokens", custom_method=method)
+        handler.add("POST", "/v3/auth/tokens", custom_method=method)
 
-    def method(request):
+        def method(request):
 
-        request.protocol_version = "HTTP/1.1"
-        h = request.headers
-        if "x-auth-token" not in h or h["x-auth-token"] != "my_auth_token":
-            sys.stderr.write("Bad headers: %s\n" % str(h))
-            request.send_response(403)
-            return
-        request.send_response(200)
-        request.send_header("Content-type", "text/plain")
-        request.send_header("Content-Length", 3)
-        request.send_header("Connection", "close")
-        request.end_headers()
-        request.wfile.write("foo".encode("ascii"))
+            request.protocol_version = "HTTP/1.1"
+            h = request.headers
+            if "x-auth-token" not in h or h["x-auth-token"] != "my_auth_token":
+                sys.stderr.write("Bad headers: %s\n" % str(h))
+                request.send_response(403)
+                return
+            request.send_response(200)
+            request.send_header("Content-type", "text/plain")
+            request.send_header("Content-Length", 3)
+            request.send_header("Connection", "close")
+            request.end_headers()
+            request.wfile.write("foo".encode("ascii"))
 
-    handler.add("GET", "/v1/AUTH_something/foo/bar", custom_method=method)
-    with webserver.install_http_handler(handler):
-        f = open_for_read("/vsiswift/foo/bar")
-        assert f is not None
-        data = gdal.VSIFReadL(1, 4, f).decode("ascii")
-        assert data == "foo"
-        gdal.VSIFCloseL(f)
+        handler.add("GET", "/v1/AUTH_something/foo/bar", custom_method=method)
+        with webserver.install_http_handler(handler):
+            f = open_for_read("/vsiswift/foo/bar")
+            assert f is not None
+            data = gdal.VSIFReadL(1, 4, f).decode("ascii")
+            assert data == "foo"
+            gdal.VSIFCloseL(f)
 
 
 ###############################################################################
@@ -332,18 +353,14 @@ def test_vsiswift_fake_auth_v3_url():
 # + OS_APPLICATION_CREDENTIAL_ID + OS_APPLICATION_CREDENTIAL_SECRET
 
 
-def test_vsiswift_fake_auth_v3_application_credential_url():
+def test_vsiswift_fake_auth_v3_application_credential_url(server):
 
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
-
-    gdal.VSICurlClearCache()
-    gdal.SetConfigOption("SWIFT_STORAGE_URL", "")
-    gdal.SetConfigOption("SWIFT_AUTH_TOKEN", "")
     with gdaltest.config_options(
         {
+            "SWIFT_STORAGE_URL": "",
+            "SWIFT_AUTH_TOKEN": "",
             "OS_IDENTITY_API_VERSION": "3",
-            "OS_AUTH_URL": "http://127.0.0.1:%d/v3" % gdaltest.webserver_port,
+            "OS_AUTH_URL": "http://127.0.0.1:%d/v3" % server.port,
             "OS_AUTH_TYPE": "v3applicationcredential",
             "OS_APPLICATION_CREDENTIAL_ID": "xxxyyycredential-idyyyxxx==",
             "OS_APPLICATION_CREDENTIAL_SECRET": "xxxyyycredential-secretyyyxxx==",
@@ -405,7 +422,7 @@ def test_vsiswift_fake_auth_v3_application_credential_url():
                    ]
                  }
               }"""
-                % gdaltest.webserver_port
+                % server.port
             )
             content = content.encode("ascii")
             request.send_response(200)
@@ -445,327 +462,341 @@ def test_vsiswift_fake_auth_v3_application_credential_url():
 # Test authentication with SWIFT_STORAGE_URL + SWIFT_AUTH_TOKEN
 
 
-def test_vsiswift_fake_auth_storage_url_and_auth_token():
+def test_vsiswift_fake_auth_storage_url_and_auth_token(server):
 
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
+    with gdal.config_options(
+        {
+            "SWIFT_AUTH_V1_URL": "",
+            "SWIFT_USER": "",
+            "SWIFT_KEY": "",
+            "SWIFT_STORAGE_URL": "http://127.0.0.1:%d/v1/AUTH_something" % server.port,
+            "SWIFT_AUTH_TOKEN": "my_auth_token",
+        }
+    ):
 
-    gdal.VSICurlClearCache()
-    gdal.SetConfigOption("SWIFT_AUTH_V1_URL", "")
-    gdal.SetConfigOption("SWIFT_USER", "")
-    gdal.SetConfigOption("SWIFT_KEY", "")
-    gdal.SetConfigOption(
-        "SWIFT_STORAGE_URL",
-        "http://127.0.0.1:%d/v1/AUTH_something" % gdaltest.webserver_port,
-    )
-    gdal.SetConfigOption("SWIFT_AUTH_TOKEN", "my_auth_token")
+        # Failure
+        handler = webserver.SequentialHandler()
+        handler.add("GET", "/v1/AUTH_something/foo/bar", 501)
+        with webserver.install_http_handler(handler):
+            f = open_for_read("/vsiswift/foo/bar")
+            assert f is not None
+            gdal.VSIFReadL(1, 4, f).decode("ascii")
+            gdal.VSIFCloseL(f)
 
-    # Failure
-    handler = webserver.SequentialHandler()
-    handler.add("GET", "/v1/AUTH_something/foo/bar", 501)
-    with webserver.install_http_handler(handler):
-        f = open_for_read("/vsiswift/foo/bar")
-        assert f is not None
-        gdal.VSIFReadL(1, 4, f).decode("ascii")
-        gdal.VSIFCloseL(f)
+        gdal.VSICurlClearCache()
 
-    gdal.VSICurlClearCache()
+        # Success
+        def method(request):
 
-    # Success
-    def method(request):
+            request.protocol_version = "HTTP/1.1"
+            h = request.headers
+            if "x-auth-token" not in h or h["x-auth-token"] != "my_auth_token":
+                sys.stderr.write("Bad headers: %s\n" % str(h))
+                request.send_response(403)
+                return
+            request.send_response(200)
+            request.send_header("Content-type", "text/plain")
+            request.send_header("Content-Length", 3)
+            request.send_header("Connection", "close")
+            request.end_headers()
+            request.wfile.write("""foo""".encode("ascii"))
 
-        request.protocol_version = "HTTP/1.1"
-        h = request.headers
-        if "x-auth-token" not in h or h["x-auth-token"] != "my_auth_token":
-            sys.stderr.write("Bad headers: %s\n" % str(h))
-            request.send_response(403)
-            return
-        request.send_response(200)
-        request.send_header("Content-type", "text/plain")
-        request.send_header("Content-Length", 3)
-        request.send_header("Connection", "close")
-        request.end_headers()
-        request.wfile.write("""foo""".encode("ascii"))
+        handler = webserver.SequentialHandler()
+        handler.add("GET", "/v1/AUTH_something/foo/bar", custom_method=method)
+        with webserver.install_http_handler(handler):
+            f = open_for_read("/vsiswift/foo/bar")
+            assert f is not None
+            data = gdal.VSIFReadL(1, 4, f).decode("ascii")
+            gdal.VSIFCloseL(f)
 
-    handler = webserver.SequentialHandler()
-    handler.add("GET", "/v1/AUTH_something/foo/bar", custom_method=method)
-    with webserver.install_http_handler(handler):
-        f = open_for_read("/vsiswift/foo/bar")
-        assert f is not None
-        data = gdal.VSIFReadL(1, 4, f).decode("ascii")
-        gdal.VSIFCloseL(f)
-
-    assert data == "foo"
+        assert data == "foo"
 
 
 ###############################################################################
 # Test VSIStatL()
 
 
-def test_vsiswift_stat():
+def test_vsiswift_stat(server):
 
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
+    with gdal.config_options(
+        {
+            "SWIFT_AUTH_TOKEN": "my_auth_token",
+            "SWIFT_AUTH_V1_URL": "",
+            "SWIFT_KEY": "",
+            "SWIFT_STORAGE_URL": f"http://127.0.0.1:{server.port}/v1/AUTH_something",
+            "SWIFT_USER": "",
+        }
+    ):
 
-    gdal.VSICurlClearCache()
+        handler = webserver.SequentialHandler()
+        handler.add(
+            "GET",
+            "/v1/AUTH_something/foo/bar",
+            206,
+            {"Content-Range": "bytes 0-0/1000000"},
+            "x",
+        )
+        with webserver.install_http_handler(handler):
+            stat_res = gdal.VSIStatL("/vsiswift/foo/bar")
+            if stat_res is None or stat_res.size != 1000000:
+                if stat_res is not None:
+                    print(stat_res.size)
+                else:
+                    print(stat_res)
+                pytest.fail()
 
-    handler = webserver.SequentialHandler()
-    handler.add(
-        "GET",
-        "/v1/AUTH_something/foo/bar",
-        206,
-        {"Content-Range": "bytes 0-0/1000000"},
-        "x",
-    )
-    with webserver.install_http_handler(handler):
-        stat_res = gdal.VSIStatL("/vsiswift/foo/bar")
-        if stat_res is None or stat_res.size != 1000000:
-            if stat_res is not None:
-                print(stat_res.size)
-            else:
-                print(stat_res)
-            pytest.fail()
+        handler = webserver.SequentialHandler()
+        handler.add(
+            "HEAD", "/v1/AUTH_something/foo/bar", 200, {"Content-Length": "1000000"}
+        )
+        with webserver.install_http_handler(handler):
+            stat_res = gdal.VSIStatL("/vsiswift_streaming/foo/bar")
+            if stat_res is None or stat_res.size != 1000000:
+                if stat_res is not None:
+                    print(stat_res.size)
+                else:
+                    print(stat_res)
+                pytest.fail()
 
-    handler = webserver.SequentialHandler()
-    handler.add(
-        "HEAD", "/v1/AUTH_something/foo/bar", 200, {"Content-Length": "1000000"}
-    )
-    with webserver.install_http_handler(handler):
-        stat_res = gdal.VSIStatL("/vsiswift_streaming/foo/bar")
-        if stat_res is None or stat_res.size != 1000000:
-            if stat_res is not None:
-                print(stat_res.size)
-            else:
-                print(stat_res)
-            pytest.fail()
+        # Test stat on container
+        handler = webserver.SequentialHandler()
+        # GET on the container URL returns something, but we must hack this back
+        # to a directory
+        handler.add("GET", "/v1/AUTH_something/foo", 200, {}, "blabla")
+        with webserver.install_http_handler(handler):
+            stat_res = gdal.VSIStatL("/vsiswift/foo")
+            assert stat_res is not None and stat.S_ISDIR(stat_res.mode)
 
-    # Test stat on container
-    handler = webserver.SequentialHandler()
-    # GET on the container URL returns something, but we must hack this back
-    # to a directory
-    handler.add("GET", "/v1/AUTH_something/foo", 200, {}, "blabla")
-    with webserver.install_http_handler(handler):
-        stat_res = gdal.VSIStatL("/vsiswift/foo")
-        assert stat_res is not None and stat.S_ISDIR(stat_res.mode)
-
-    # No network access done
-    s = gdal.VSIStatL(
-        "/vsiswift/foo",
-        gdal.VSI_STAT_EXISTS_FLAG
-        | gdal.VSI_STAT_NATURE_FLAG
-        | gdal.VSI_STAT_SIZE_FLAG
-        | gdal.VSI_STAT_CACHE_ONLY,
-    )
-    assert s
-    assert stat.S_ISDIR(s.mode)
-
-    # No network access done
-    assert (
-        gdal.VSIStatL(
-            "/vsiswift/i_do_not_exist",
+        # No network access done
+        s = gdal.VSIStatL(
+            "/vsiswift/foo",
             gdal.VSI_STAT_EXISTS_FLAG
             | gdal.VSI_STAT_NATURE_FLAG
             | gdal.VSI_STAT_SIZE_FLAG
             | gdal.VSI_STAT_CACHE_ONLY,
         )
-        is None
-    )
+        assert s
+        assert stat.S_ISDIR(s.mode)
+
+        # No network access done
+        assert (
+            gdal.VSIStatL(
+                "/vsiswift/i_do_not_exist",
+                gdal.VSI_STAT_EXISTS_FLAG
+                | gdal.VSI_STAT_NATURE_FLAG
+                | gdal.VSI_STAT_SIZE_FLAG
+                | gdal.VSI_STAT_CACHE_ONLY,
+            )
+            is None
+        )
 
 
 ###############################################################################
 # Test ReadDir()
 
 
-def test_vsiswift_fake_readdir():
+def test_vsiswift_fake_readdir(server):
 
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
+    with gdal.config_options(
+        {
+            "SWIFT_AUTH_TOKEN": "my_auth_token",
+            "SWIFT_AUTH_V1_URL": "",
+            "SWIFT_KEY": "",
+            "SWIFT_STORAGE_URL": f"http://127.0.0.1:{server.port}/v1/AUTH_something",
+            "SWIFT_USER": "",
+        }
+    ):
 
-    gdal.VSICurlClearCache()
+        handler = webserver.SequentialHandler()
+        handler.add(
+            "GET",
+            "/v1/AUTH_something/foo?delimiter=%2F&limit=1",
+            200,
+            {"Content-type": "application/json"},
+            """[
+      {
+        "last_modified": "1970-01-01T00:00:01",
+        "bytes": 123456,
+        "name": "bar.baz"
+      }
+    ]""",
+        )
 
-    handler = webserver.SequentialHandler()
-    handler.add(
-        "GET",
-        "/v1/AUTH_something/foo?delimiter=%2F&limit=1",
-        200,
-        {"Content-type": "application/json"},
-        """[
-  {
-    "last_modified": "1970-01-01T00:00:01",
-    "bytes": 123456,
-    "name": "bar.baz"
-  }
-]""",
-    )
+        handler.add(
+            "GET",
+            "/v1/AUTH_something/foo?delimiter=%2F&limit=1&marker=bar.baz",
+            200,
+            {"Content-type": "application/json"},
+            """[
+      {
+        "subdir": "mysubdir/"
+      }
+    ]""",
+        )
 
-    handler.add(
-        "GET",
-        "/v1/AUTH_something/foo?delimiter=%2F&limit=1&marker=bar.baz",
-        200,
-        {"Content-type": "application/json"},
-        """[
-  {
-    "subdir": "mysubdir/"
-  }
-]""",
-    )
+        handler.add(
+            "GET",
+            "/v1/AUTH_something/foo?delimiter=%2F&limit=1&marker=mysubdir%2F",
+            200,
+            {"Content-type": "application/json"},
+            """[
+    ]""",
+        )
 
-    handler.add(
-        "GET",
-        "/v1/AUTH_something/foo?delimiter=%2F&limit=1&marker=mysubdir%2F",
-        200,
-        {"Content-type": "application/json"},
-        """[
-]""",
-    )
+        with gdaltest.config_option("SWIFT_MAX_KEYS", "1"):
+            with webserver.install_http_handler(handler):
+                f = open_for_read("/vsiswift/foo/bar.baz")
+            assert f is not None
+            gdal.VSIFCloseL(f)
 
-    with gdaltest.config_option("SWIFT_MAX_KEYS", "1"):
+        dir_contents = gdal.ReadDir("/vsiswift/foo")
+        assert dir_contents == ["bar.baz", "mysubdir"]
+        stat_res = gdal.VSIStatL("/vsiswift/foo/bar.baz")
+        assert stat_res.size == 123456
+        assert stat_res.mtime == 1
+
+        # ReadDir on something known to be a file shouldn't cause network access
+        dir_contents = gdal.ReadDir("/vsiswift/foo/bar.baz")
+        assert dir_contents is None
+
+        # Test error on ReadDir()
+        handler = webserver.SequentialHandler()
+        handler.add(
+            "GET",
+            "/v1/AUTH_something/foo?delimiter=%2F&limit=10000&prefix=error_test%2F",
+            500,
+        )
         with webserver.install_http_handler(handler):
-            f = open_for_read("/vsiswift/foo/bar.baz")
-        assert f is not None
-        gdal.VSIFCloseL(f)
+            dir_contents = gdal.ReadDir("/vsiswift/foo/error_test/")
+        assert dir_contents is None
 
-    dir_contents = gdal.ReadDir("/vsiswift/foo")
-    assert dir_contents == ["bar.baz", "mysubdir"]
-    stat_res = gdal.VSIStatL("/vsiswift/foo/bar.baz")
-    assert stat_res.size == 123456
-    assert stat_res.mtime == 1
+        # List containers (empty result)
+        handler = webserver.SequentialHandler()
+        handler.add(
+            "GET",
+            "/v1/AUTH_something",
+            200,
+            {"Content-type": "application/json"},
+            """[]
+            """,
+        )
+        with webserver.install_http_handler(handler):
+            dir_contents = gdal.ReadDir("/vsiswift/")
+        assert dir_contents == ["."]
 
-    # ReadDir on something known to be a file shouldn't cause network access
-    dir_contents = gdal.ReadDir("/vsiswift/foo/bar.baz")
-    assert dir_contents is None
+        # List containers
+        gdal.VSICurlClearCache()
 
-    # Test error on ReadDir()
-    handler = webserver.SequentialHandler()
-    handler.add(
-        "GET",
-        "/v1/AUTH_something/foo?delimiter=%2F&limit=10000&prefix=error_test%2F",
-        500,
-    )
-    with webserver.install_http_handler(handler):
-        dir_contents = gdal.ReadDir("/vsiswift/foo/error_test/")
-    assert dir_contents is None
+        handler = webserver.SequentialHandler()
+        handler.add(
+            "GET",
+            "/v1/AUTH_something",
+            200,
+            {"Content-type": "application/json"},
+            """[ { "name": "mycontainer1", "count": 0, "bytes": 0 },
+                 { "name": "mycontainer2", "count": 0, "bytes": 0}
+               ] """,
+        )
+        with webserver.install_http_handler(handler):
+            dir_contents = gdal.ReadDir("/vsiswift/")
+        assert dir_contents == ["mycontainer1", "mycontainer2"]
 
-    # List containers (empty result)
-    handler = webserver.SequentialHandler()
-    handler.add(
-        "GET",
-        "/v1/AUTH_something",
-        200,
-        {"Content-type": "application/json"},
-        """[]
-        """,
-    )
-    with webserver.install_http_handler(handler):
-        dir_contents = gdal.ReadDir("/vsiswift/")
-    assert dir_contents == ["."]
+        # ReadDir() with a file and directory of same names
+        gdal.VSICurlClearCache()
 
-    # List containers
-    gdal.VSICurlClearCache()
+        handler = webserver.SequentialHandler()
+        handler.add(
+            "GET",
+            "/v1/AUTH_something",
+            200,
+            {"Content-type": "application/json"},
+            """[ {
+                    "last_modified": "1970-01-01T00:00:01",
+                    "bytes": 123456,
+                    "name": "foo"
+                 },
+                 { "subdir": "foo/"} ] """,
+        )
+        with webserver.install_http_handler(handler):
+            dir_contents = gdal.ReadDir("/vsiswift/")
+        assert dir_contents == ["foo", "foo/"]
 
-    handler = webserver.SequentialHandler()
-    handler.add(
-        "GET",
-        "/v1/AUTH_something",
-        200,
-        {"Content-type": "application/json"},
-        """[ { "name": "mycontainer1", "count": 0, "bytes": 0 },
-             { "name": "mycontainer2", "count": 0, "bytes": 0}
-           ] """,
-    )
-    with webserver.install_http_handler(handler):
-        dir_contents = gdal.ReadDir("/vsiswift/")
-    assert dir_contents == ["mycontainer1", "mycontainer2"]
-
-    # ReadDir() with a file and directory of same names
-    gdal.VSICurlClearCache()
-
-    handler = webserver.SequentialHandler()
-    handler.add(
-        "GET",
-        "/v1/AUTH_something",
-        200,
-        {"Content-type": "application/json"},
-        """[ {
-                "last_modified": "1970-01-01T00:00:01",
-                "bytes": 123456,
-                "name": "foo"
-             },
-             { "subdir": "foo/"} ] """,
-    )
-    with webserver.install_http_handler(handler):
-        dir_contents = gdal.ReadDir("/vsiswift/")
-    assert dir_contents == ["foo", "foo/"]
-
-    handler = webserver.SequentialHandler()
-    handler.add(
-        "GET",
-        "/v1/AUTH_something/foo?delimiter=%2F&limit=10000",
-        200,
-        {"Content-type": "application/json"},
-        "[]",
-    )
-    with webserver.install_http_handler(handler):
-        dir_contents = gdal.ReadDir("/vsiswift/foo/")
-    assert dir_contents == ["."]
+        handler = webserver.SequentialHandler()
+        handler.add(
+            "GET",
+            "/v1/AUTH_something/foo?delimiter=%2F&limit=10000",
+            200,
+            {"Content-type": "application/json"},
+            "[]",
+        )
+        with webserver.install_http_handler(handler):
+            dir_contents = gdal.ReadDir("/vsiswift/foo/")
+        assert dir_contents == ["."]
 
 
 ###############################################################################
 # Test write
 
 
-def test_vsiswift_fake_write():
+def test_vsiswift_fake_write(server):
 
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
+    with gdal.config_options(
+        {
+            "SWIFT_AUTH_TOKEN": "my_auth_token",
+            "SWIFT_AUTH_V1_URL": "",
+            "SWIFT_KEY": "",
+            "SWIFT_STORAGE_URL": f"http://127.0.0.1:{server.port}/v1/AUTH_something",
+            "SWIFT_USER": "",
+        }
+    ):
 
-    gdal.VSICurlClearCache()
+        # Test creation of BlockBob
+        f = gdal.VSIFOpenL("/vsiswift/test_copy/file.bin", "wb")
+        assert f is not None
 
-    # Test creation of BlockBob
-    f = gdal.VSIFOpenL("/vsiswift/test_copy/file.bin", "wb")
-    assert f is not None
+        handler = webserver.SequentialHandler()
 
-    handler = webserver.SequentialHandler()
+        def method(request):
+            h = request.headers
+            if (
+                "x-auth-token" not in h
+                or h["x-auth-token"] != "my_auth_token"
+                or "Transfer-Encoding" not in h
+                or h["Transfer-Encoding"] != "chunked"
+            ):
+                sys.stderr.write("Bad headers: %s\n" % str(h))
+                request.send_response(403)
+                return
 
-    def method(request):
-        h = request.headers
-        if (
-            "x-auth-token" not in h
-            or h["x-auth-token"] != "my_auth_token"
-            or "Transfer-Encoding" not in h
-            or h["Transfer-Encoding"] != "chunked"
-        ):
-            sys.stderr.write("Bad headers: %s\n" % str(h))
-            request.send_response(403)
-            return
-
-        request.protocol_version = "HTTP/1.1"
-        request.wfile.write("HTTP/1.1 100 Continue\r\n\r\n".encode("ascii"))
-        content = ""
-        while True:
-            numchars = int(request.rfile.readline().strip(), 16)
-            content += request.rfile.read(numchars).decode("ascii")
-            request.rfile.read(2)
-            if numchars == 0:
-                break
-        if len(content) != 40000:
-            sys.stderr.write("Bad headers: %s\n" % str(request.headers))
-            request.send_response(403)
+            request.protocol_version = "HTTP/1.1"
+            request.wfile.write("HTTP/1.1 100 Continue\r\n\r\n".encode("ascii"))
+            content = ""
+            while True:
+                numchars = int(request.rfile.readline().strip(), 16)
+                content += request.rfile.read(numchars).decode("ascii")
+                request.rfile.read(2)
+                if numchars == 0:
+                    break
+            if len(content) != 40000:
+                sys.stderr.write("Bad headers: %s\n" % str(request.headers))
+                request.send_response(403)
+                request.send_header("Content-Length", 0)
+                request.end_headers()
+                return
+            request.send_response(200)
             request.send_header("Content-Length", 0)
             request.end_headers()
-            return
-        request.send_response(200)
-        request.send_header("Content-Length", 0)
-        request.end_headers()
 
-    handler.add("PUT", "/v1/AUTH_something/test_copy/file.bin", custom_method=method)
-    with webserver.install_http_handler(handler):
-        ret = gdal.VSIFWriteL("x" * 35000, 1, 35000, f)
-        ret += gdal.VSIFWriteL("x" * 5000, 1, 5000, f)
-        if ret != 40000:
+        handler.add(
+            "PUT", "/v1/AUTH_something/test_copy/file.bin", custom_method=method
+        )
+        with webserver.install_http_handler(handler):
+            ret = gdal.VSIFWriteL("x" * 35000, 1, 35000, f)
+            ret += gdal.VSIFWriteL("x" * 5000, 1, 5000, f)
+            if ret != 40000:
+                gdal.VSIFCloseL(f)
+                pytest.fail(ret)
             gdal.VSIFCloseL(f)
-            pytest.fail(ret)
-        gdal.VSIFCloseL(f)
 
 
 ###############################################################################
@@ -773,33 +804,50 @@ def test_vsiswift_fake_write():
 
 
 @gdaltest.disable_exceptions()
-def test_vsiswift_fake_unlink():
+def test_vsiswift_fake_unlink(server):
 
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
+    with gdal.config_options(
+        {
+            "SWIFT_AUTH_TOKEN": "my_auth_token",
+            "SWIFT_AUTH_V1_URL": "",
+            "SWIFT_KEY": "",
+            "SWIFT_STORAGE_URL": f"http://127.0.0.1:{server.port}/v1/AUTH_something",
+            "SWIFT_USER": "",
+        }
+    ):
 
-    gdal.VSICurlClearCache()
-
-    # Success
-    handler = webserver.SequentialHandler()
-    handler.add(
-        "GET", "/v1/AUTH_something/foo/bar", 206, {"Content-Range": "bytes 0-0/1"}, "x"
-    )
-    handler.add("DELETE", "/v1/AUTH_something/foo/bar", 202, {"Connection": "close"})
-    with webserver.install_http_handler(handler):
-        ret = gdal.Unlink("/vsiswift/foo/bar")
-    assert ret == 0
-
-    # Failure
-    handler = webserver.SequentialHandler()
-    handler.add(
-        "GET", "/v1/AUTH_something/foo/bar", 206, {"Content-Range": "bytes 0-0/1"}, "x"
-    )
-    handler.add("DELETE", "/v1/AUTH_something/foo/bar", 400, {"Connection": "close"})
-    with webserver.install_http_handler(handler):
-        with gdal.quiet_errors():
+        # Success
+        handler = webserver.SequentialHandler()
+        handler.add(
+            "GET",
+            "/v1/AUTH_something/foo/bar",
+            206,
+            {"Content-Range": "bytes 0-0/1"},
+            "x",
+        )
+        handler.add(
+            "DELETE", "/v1/AUTH_something/foo/bar", 202, {"Connection": "close"}
+        )
+        with webserver.install_http_handler(handler):
             ret = gdal.Unlink("/vsiswift/foo/bar")
-    assert ret == -1
+        assert ret == 0
+
+        # Failure
+        handler = webserver.SequentialHandler()
+        handler.add(
+            "GET",
+            "/v1/AUTH_something/foo/bar",
+            206,
+            {"Content-Range": "bytes 0-0/1"},
+            "x",
+        )
+        handler.add(
+            "DELETE", "/v1/AUTH_something/foo/bar", 400, {"Connection": "close"}
+        )
+        with webserver.install_http_handler(handler):
+            with gdal.quiet_errors():
+                ret = gdal.Unlink("/vsiswift/foo/bar")
+        assert ret == -1
 
 
 ###############################################################################
@@ -807,126 +855,116 @@ def test_vsiswift_fake_unlink():
 
 
 @gdaltest.disable_exceptions()
-def test_vsiswift_fake_mkdir_rmdir():
+def test_vsiswift_fake_mkdir_rmdir(server):
 
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
+    with gdal.config_options(
+        {
+            "SWIFT_AUTH_TOKEN": "my_auth_token",
+            "SWIFT_AUTH_V1_URL": "",
+            "SWIFT_KEY": "",
+            "SWIFT_STORAGE_URL": f"http://127.0.0.1:{server.port}/v1/AUTH_something",
+            "SWIFT_USER": "",
+        }
+    ):
 
-    gdal.VSICurlClearCache()
+        # Invalid name
+        ret = gdal.Mkdir("/vsiswift", 0)
+        assert ret != 0
 
-    # Invalid name
-    ret = gdal.Mkdir("/vsiswift", 0)
-    assert ret != 0
+        handler = webserver.SequentialHandler()
+        handler.add("GET", "/v1/AUTH_something/foo/dir/", 404, {"Connection": "close"})
+        handler.add(
+            "GET",
+            "/v1/AUTH_something/foo?delimiter=%2F&limit=10000",
+            200,
+            {"Connection": "close"},
+            "[]",
+        )
+        handler.add("PUT", "/v1/AUTH_something/foo/dir/", 201)
+        with webserver.install_http_handler(handler):
+            ret = gdal.Mkdir("/vsiswift/foo/dir", 0)
+        assert ret == 0
 
-    handler = webserver.SequentialHandler()
-    handler.add("GET", "/v1/AUTH_something/foo/dir/", 404, {"Connection": "close"})
-    handler.add(
-        "GET",
-        "/v1/AUTH_something/foo?delimiter=%2F&limit=10000",
-        200,
-        {"Connection": "close"},
-        "[]",
-    )
-    handler.add("PUT", "/v1/AUTH_something/foo/dir/", 201)
-    with webserver.install_http_handler(handler):
-        ret = gdal.Mkdir("/vsiswift/foo/dir", 0)
-    assert ret == 0
+        # Try creating already existing directory
+        handler = webserver.SequentialHandler()
+        handler.add("GET", "/v1/AUTH_something/foo/dir/", 404, {"Connection": "close"})
+        handler.add(
+            "GET",
+            "/v1/AUTH_something/foo?delimiter=%2F&limit=10000",
+            200,
+            {"Connection": "close", "Content-type": "application/json"},
+            """[ { "subdir": "dir/" } ]""",
+        )
+        with webserver.install_http_handler(handler):
+            ret = gdal.Mkdir("/vsiswift/foo/dir", 0)
+        assert ret != 0
 
-    # Try creating already existing directory
-    handler = webserver.SequentialHandler()
-    handler.add("GET", "/v1/AUTH_something/foo/dir/", 404, {"Connection": "close"})
-    handler.add(
-        "GET",
-        "/v1/AUTH_something/foo?delimiter=%2F&limit=10000",
-        200,
-        {"Connection": "close", "Content-type": "application/json"},
-        """[ { "subdir": "dir/" } ]""",
-    )
-    with webserver.install_http_handler(handler):
-        ret = gdal.Mkdir("/vsiswift/foo/dir", 0)
-    assert ret != 0
+        # Invalid name
+        ret = gdal.Rmdir("/vsiswift")
+        assert ret != 0
 
-    # Invalid name
-    ret = gdal.Rmdir("/vsiswift")
-    assert ret != 0
+        gdal.VSICurlClearCache()
 
-    gdal.VSICurlClearCache()
+        # Not a directory
+        handler = webserver.SequentialHandler()
+        handler.add("GET", "/v1/AUTH_something/foo/it_is_a_file/", 404)
+        handler.add(
+            "GET",
+            "/v1/AUTH_something/foo?delimiter=%2F&limit=10000",
+            200,
+            {"Connection": "close", "Content-type": "application/json"},
+            """[ { "name": "it_is_a_file/", "bytes": 0, "last_modified": "1970-01-01T00:00:01" } ]""",
+        )
+        with webserver.install_http_handler(handler):
+            ret = gdal.Rmdir("/vsiswift/foo/it_is_a_file")
+        assert ret != 0
 
-    # Not a directory
-    handler = webserver.SequentialHandler()
-    handler.add("GET", "/v1/AUTH_something/foo/it_is_a_file/", 404)
-    handler.add(
-        "GET",
-        "/v1/AUTH_something/foo?delimiter=%2F&limit=10000",
-        200,
-        {"Connection": "close", "Content-type": "application/json"},
-        """[ { "name": "it_is_a_file/", "bytes": 0, "last_modified": "1970-01-01T00:00:01" } ]""",
-    )
-    with webserver.install_http_handler(handler):
-        ret = gdal.Rmdir("/vsiswift/foo/it_is_a_file")
-    assert ret != 0
+        # Valid
+        handler = webserver.SequentialHandler()
+        handler.add("GET", "/v1/AUTH_something/foo/dir/", 200)
+        handler.add(
+            "GET",
+            "/v1/AUTH_something/foo?delimiter=%2F&limit=101&prefix=dir%2F",
+            200,
+            {"Connection": "close", "Content-type": "application/json"},
+            """[]
+                    """,
+        )
+        handler.add("DELETE", "/v1/AUTH_something/foo/dir/", 204)
+        with webserver.install_http_handler(handler):
+            ret = gdal.Rmdir("/vsiswift/foo/dir")
+        assert ret == 0
 
-    # Valid
-    handler = webserver.SequentialHandler()
-    handler.add("GET", "/v1/AUTH_something/foo/dir/", 200)
-    handler.add(
-        "GET",
-        "/v1/AUTH_something/foo?delimiter=%2F&limit=101&prefix=dir%2F",
-        200,
-        {"Connection": "close", "Content-type": "application/json"},
-        """[]
-                """,
-    )
-    handler.add("DELETE", "/v1/AUTH_something/foo/dir/", 204)
-    with webserver.install_http_handler(handler):
-        ret = gdal.Rmdir("/vsiswift/foo/dir")
-    assert ret == 0
+        # Try deleting already deleted directory
+        handler = webserver.SequentialHandler()
+        handler.add("GET", "/v1/AUTH_something/foo/dir/", 404)
+        handler.add("GET", "/v1/AUTH_something/foo?delimiter=%2F&limit=10000", 200)
+        with webserver.install_http_handler(handler):
+            ret = gdal.Rmdir("/vsiswift/foo/dir")
+        assert ret != 0
 
-    # Try deleting already deleted directory
-    handler = webserver.SequentialHandler()
-    handler.add("GET", "/v1/AUTH_something/foo/dir/", 404)
-    handler.add("GET", "/v1/AUTH_something/foo?delimiter=%2F&limit=10000", 200)
-    with webserver.install_http_handler(handler):
-        ret = gdal.Rmdir("/vsiswift/foo/dir")
-    assert ret != 0
+        gdal.VSICurlClearCache()
 
-    gdal.VSICurlClearCache()
-
-    # Try deleting non-empty directory
-    handler = webserver.SequentialHandler()
-    handler.add("GET", "/v1/AUTH_something/foo/dir_nonempty/", 404)
-    handler.add(
-        "GET",
-        "/v1/AUTH_something/foo?delimiter=%2F&limit=10000",
-        200,
-        {"Connection": "close", "Content-type": "application/json"},
-        """[ { "subdir": "dir_nonempty/" } ]""",
-    )
-    handler.add(
-        "GET",
-        "/v1/AUTH_something/foo?delimiter=%2F&limit=101&prefix=dir_nonempty%2F",
-        200,
-        {"Connection": "close", "Content-type": "application/json"},
-        """[ { "name": "dir_nonempty/some_file", "bytes": 0, "last_modified": "1970-01-01T00:00:01" } ]""",
-    )
-    with webserver.install_http_handler(handler):
-        ret = gdal.Rmdir("/vsiswift/foo/dir_nonempty")
-    assert ret != 0
-
-
-###############################################################################
-
-
-def test_vsiswift_stop_webserver():
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
-
-    # Clearcache needed to close all connections, since the Python server
-    # can only handle one connection at a time
-    gdal.VSICurlClearCache()
-
-    webserver.server_stop(gdaltest.webserver_process, gdaltest.webserver_port)
+        # Try deleting non-empty directory
+        handler = webserver.SequentialHandler()
+        handler.add("GET", "/v1/AUTH_something/foo/dir_nonempty/", 404)
+        handler.add(
+            "GET",
+            "/v1/AUTH_something/foo?delimiter=%2F&limit=10000",
+            200,
+            {"Connection": "close", "Content-type": "application/json"},
+            """[ { "subdir": "dir_nonempty/" } ]""",
+        )
+        handler.add(
+            "GET",
+            "/v1/AUTH_something/foo?delimiter=%2F&limit=101&prefix=dir_nonempty%2F",
+            200,
+            {"Connection": "close", "Content-type": "application/json"},
+            """[ { "name": "dir_nonempty/some_file", "bytes": 0, "last_modified": "1970-01-01T00:00:01" } ]""",
+        )
+        with webserver.install_http_handler(handler):
+            ret = gdal.Rmdir("/vsiswift/foo/dir_nonempty")
+        assert ret != 0
 
 
 ###############################################################################
@@ -1026,12 +1064,3 @@ def test_vsiswift_extra_1():
     gdal.ErrorReset()
     f = open_for_read("/vsiswift_streaming/" + swift_resource + "/invalid_resource.baz")
     assert f is None, gdal.VSIGetLastErrorMsg()
-
-
-###############################################################################
-
-
-def test_vsiswift_cleanup():
-
-    for var in gdaltest.swift_vars:
-        gdal.SetConfigOption(var, gdaltest.swift_vars[var])

--- a/autotest/gdrivers/arg.py
+++ b/autotest/gdrivers/arg.py
@@ -37,6 +37,11 @@ import pytest
 
 from osgeo import gdal
 
+pytestmark = [
+    pytest.mark.require_driver("ARG"),
+    pytest.mark.random_order(disabled=True),
+]
+
 # given fmt and nodata, encodes a value as bytes
 
 ###############################################################################

--- a/autotest/gdrivers/ecw.py
+++ b/autotest/gdrivers/ecw.py
@@ -573,10 +573,12 @@ def test_ecw_17():
 # Open byte.jp2.gz (test use of the VSIL API)
 
 
-def test_ecw_18():
+def test_ecw_18(tmp_path):
 
     if gdaltest.jp2ecw_drv is None:
         pytest.skip()
+
+    shutil.copy("data/jpeg2000/byte.jp2.gz", tmp_path)
 
     srs = """PROJCS["NAD27 / UTM zone 11N",
     GEOGCS["NAD27",
@@ -600,10 +602,9 @@ def test_ecw_18():
     gt = (440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0)
 
     tst = gdaltest.GDALTest(
-        "JP2ECW", "/vsigzip/data/jpeg2000/byte.jp2.gz", 1, 50054, filename_absolute=1
+        "JP2ECW", f"/vsigzip/{tmp_path}/byte.jp2.gz", 1, 50054, filename_absolute=True
     )
     tst.testOpen(check_prj=srs, check_gt=gt)
-    gdal.Unlink("data/jpeg2000/byte.jp2.gz.properties")
 
 
 ###############################################################################

--- a/autotest/gdrivers/ecw.py
+++ b/autotest/gdrivers/ecw.py
@@ -118,86 +118,6 @@ def startup_and_cleanup():
 
     gdaltest.reregister_all_jpeg2000_drivers()
 
-    try:
-        os.remove("tmp/jrc_out.ecw")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/jrc_out.ecw.aux.xml")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/ecw_5.jp2")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/ecw_5.jp2.aux.xml")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/ecw_7.ntf")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/ecw9.jp2")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/test_11.ntf")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/rgb_gcp.jp2")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/spif83.ecw")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/spif83.ecw.aux.xml")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/UInt16_big_out.ecw")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/UInt16_big_out.jp2")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/UInt16_big_out.jp2.aux.xml")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/UInt16_big_out.ecw.aux.xml")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/jrc312.ecw")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/jrc123.ecw")
-    except OSError:
-        pass
-    try:
-        os.remove("tmp/jrcstats.ecw")
-    except OSError:
-        pass
-
-    if hasattr(gdaltest, "ecw_38_fname"):
-        if gdal.VSIStatL(gdaltest.ecw_38_fname) is not None:
-            gdal.Unlink(gdaltest.ecw_38_fname)
-        if gdal.VSIStatL(gdaltest.ecw_38_fname + ".aux.xml") is not None:
-            gdal.Unlink(gdaltest.ecw_38_fname + ".aux.xml")
-
-    try:
-        os.remove("tmp/stefan_full_rgba_ecwv3_meta.ecw")
-    except OSError:
-        pass
-
 
 ###############################################################################
 # Verify various information about our test image.
@@ -241,17 +161,17 @@ def test_ecw_2():
 # Verify various information about our generated image.
 
 
-def test_ecw_4():
+def test_ecw_4(tmp_path):
 
     if not has_write_support():
-        pytest.skip()
+        pytest.skip("ECW write support not available")
 
     src_ds = gdal.Open("data/ecw/jrc.ecw")
-    gdaltest.ecw_drv.CreateCopy("tmp/jrc_out.ecw", src_ds, options=["TARGET=75"])
-    if os.path.exists("tmp/jrc_out.ecw.aux.xml"):
-        gdal.Unlink("tmp/jrc_out.ecw.aux.xml")
+    gdaltest.ecw_drv.CreateCopy(tmp_path / "jrc_out.ecw", src_ds, options=["TARGET=75"])
+    if os.path.exists(tmp_path / "jrc_out.ecw.aux.xml"):
+        gdal.Unlink(tmp_path / "jrc_out.ecw.aux.xml")
 
-    ds = gdal.Open("tmp/jrc_out.ecw")
+    ds = gdal.Open(tmp_path / "jrc_out.ecw")
     version = ds.GetMetadataItem("VERSION")
     assert version == "2", "bad VERSION"
 
@@ -291,28 +211,24 @@ def test_ecw_4():
 # Now try writing a JPEG2000 compressed version of the same with the ECW driver
 
 
-def test_ecw_5():
+def test_ecw_5(tmp_path):
     if gdaltest.jp2ecw_drv is None or not has_write_support():
-        pytest.skip()
+        pytest.skip("ECW write support not available")
 
     ds = gdal.Open("data/small.vrt")
-    ds_out = gdaltest.jp2ecw_drv.CreateCopy("tmp/ecw_5.jp2", ds, options=["TARGET=75"])
+    ds_out = gdaltest.jp2ecw_drv.CreateCopy(
+        tmp_path / "ecw_5.jp2", ds, options=["TARGET=75"]
+    )
     assert ds_out.GetDriver().ShortName == "JP2ECW"
     version = ds_out.GetMetadataItem("VERSION")
     assert version == "1", "bad VERSION"
     ds = None
+    ds_out = None
 
+    ###############################################################################
+    # Verify various information about our generated image.
 
-###############################################################################
-# Verify various information about our generated image.
-
-
-def test_ecw_6():
-
-    if gdaltest.jp2ecw_drv is None or not has_write_support():
-        pytest.skip()
-
-    ds = gdal.Open("tmp/ecw_5.jp2")
+    ds = gdal.Open(tmp_path / "ecw_5.jp2")
 
     if gdaltest.ecw_drv.major_version == 3:
         (exp_mean, exp_stddev) = (144.422, 44.9075)
@@ -366,26 +282,19 @@ def test_ecw_6():
 # Write the same image to NITF.
 
 
-def test_ecw_7():
+def test_ecw_7(tmp_path):
     if gdaltest.jp2ecw_drv is None or not has_write_support():
-        pytest.skip()
+        pytest.skip("ECW write support not available")
 
     ds = gdal.Open("data/small.vrt")
     drv = gdal.GetDriverByName("NITF")
-    drv.CreateCopy("tmp/ecw_7.ntf", ds, options=["IC=C8", "TARGET=75"], strict=0)
+    drv.CreateCopy(tmp_path / "ecw_7.ntf", ds, options=["IC=C8", "TARGET=75"], strict=0)
     ds = None
 
+    ###############################################################################
+    # Verify various information about our generated image.
 
-###############################################################################
-# Verify various information about our generated image.
-
-
-def test_ecw_8():
-
-    if gdaltest.jp2ecw_drv is None or not has_write_support():
-        pytest.skip()
-
-    ds = gdal.Open("tmp/ecw_7.ntf")
+    ds = gdal.Open(tmp_path / "ecw_7.ntf")
 
     (exp_mean, exp_stddev) = (145.57, 43.1712)
     (mean, stddev) = ds.GetRasterBand(1).ComputeBandStats()
@@ -425,16 +334,16 @@ def test_ecw_8():
 # Try writing 16bit JP2 file directly using Create().
 
 
-def test_ecw_9():
+def test_ecw_9(tmp_path):
     if gdaltest.jp2ecw_drv is None or not has_write_support():
-        pytest.skip()
+        pytest.skip("ECW write support not available")
 
     # This always crashes on Frank's machine - some bug in old sdk.
     if os.getenv("USER") == "warmerda" and gdaltest.ecw_drv.major_version == 3:
         pytest.skip()
 
     ds = gdaltest.jp2ecw_drv.Create(
-        "tmp/ecw9.jp2", 200, 100, 1, gdal.GDT_Int16, options=["TARGET=75"]
+        tmp_path / "ecw9.jp2", 200, 100, 1, gdal.GDT_Int16, options=["TARGET=75"]
     )
     ds.SetGeoTransform((100, 0.1, 0.0, 30.0, 0.0, -0.1))
 
@@ -448,20 +357,10 @@ def test_ecw_9():
         ds.WriteRaster(0, line, 200, 1, raw_data, buf_type=gdal.GDT_Int16)
     ds = None
 
+    ###############################################################################
+    # Verify previous 16bit file.
 
-###############################################################################
-# Verify previous 16bit file.
-
-
-def test_ecw_10():
-    if gdaltest.jp2ecw_drv is None or not has_write_support():
-        pytest.skip()
-
-    # This always crashes on Frank's machine - some bug in old sdk.
-    if os.getenv("USER") == "warmerda" and gdaltest.ecw_drv.major_version == 3:
-        pytest.skip()
-
-    ds = gdal.Open("tmp/ecw9.jp2")
+    ds = gdal.Open(tmp_path / "ecw9.jp2")
 
     (exp_mean, exp_stddev) = (98.49, 57.7129)
     (mean, stddev) = ds.GetRasterBand(1).ComputeBandStats()
@@ -490,12 +389,12 @@ def test_ecw_10():
 # Test direct creation of an NITF/JPEG2000 file.
 
 
-def test_ecw_11():
+def test_ecw_11(tmp_path):
     if gdaltest.jp2ecw_drv is None or not has_write_support():
-        pytest.skip()
+        pytest.skip("ECW write support not available")
 
     drv = gdal.GetDriverByName("NITF")
-    ds = drv.Create("tmp/test_11.ntf", 200, 100, 3, gdal.GDT_Byte, ["ICORDS=G"])
+    ds = drv.Create(tmp_path / "test_11.ntf", 200, 100, 3, gdal.GDT_Byte, ["ICORDS=G"])
     ds.SetGeoTransform((100, 0.1, 0.0, 30.0, 0.0, -0.1))
 
     my_list = list(range(200)) + list(range(20, 220)) + list(range(30, 230))
@@ -512,16 +411,10 @@ def test_ecw_11():
 
     ds = None
 
+    ###############################################################################
+    # Verify previous file
 
-###############################################################################
-# Verify previous file
-
-
-def test_ecw_12():
-    if gdaltest.jp2ecw_drv is None or not has_write_support():
-        pytest.skip()
-
-    ds = gdal.Open("tmp/test_11.ntf")
+    ds = gdal.Open(tmp_path / "test_11.ntf")
 
     geotransform = ds.GetGeoTransform()
     assert (
@@ -587,25 +480,18 @@ def test_ecw_13():
 # Write out image with GCPs.
 
 
-def test_ecw_14():
+def test_ecw_14(tmp_path):
     if gdaltest.jp2ecw_drv is None or not has_write_support():
-        pytest.skip()
+        pytest.skip("ECW write support not available")
 
     ds = gdal.Open("data/rgb_gcp.vrt")
-    gdaltest.jp2ecw_drv.CreateCopy("tmp/rgb_gcp.jp2", ds)
+    gdaltest.jp2ecw_drv.CreateCopy(tmp_path / "rgb_gcp.jp2", ds)
     ds = None
 
+    ###############################################################################
+    # Verify various information about our generated image.
 
-###############################################################################
-# Verify various information about our generated image.
-
-
-def test_ecw_15():
-
-    if gdaltest.jp2ecw_drv is None or not has_write_support():
-        pytest.skip()
-
-    ds = gdal.Open("tmp/rgb_gcp.jp2")
+    ds = gdal.Open(tmp_path / "rgb_gcp.jp2")
 
     gcp_srs = ds.GetGCPProjection()
     assert not (
@@ -832,12 +718,14 @@ def test_ecw_22():
 # preserving the ecw derived georeferencing.
 
 
-def test_ecw_23():
+def test_ecw_23(tmp_path):
 
-    shutil.copyfile("data/ecw/spif83.ecw", "tmp/spif83.ecw")
-    shutil.copyfile("data/ecw/spif83_hidden.ecw.aux.xml", "tmp/spif83.ecw.aux.xml")
+    shutil.copyfile("data/ecw/spif83.ecw", tmp_path / "spif83.ecw")
+    shutil.copyfile(
+        "data/ecw/spif83_hidden.ecw.aux.xml", tmp_path / "spif83.ecw.aux.xml"
+    )
 
-    ds = gdal.Open("tmp/spif83.ecw")
+    ds = gdal.Open(tmp_path / "spif83.ecw")
 
     wkt = ds.GetProjectionRef()
 
@@ -856,82 +744,54 @@ def test_ecw_23():
     )
     assert gt == expected_gt, "did not get expected geotransform."
 
-    try:
-        os.remove("tmp/spif83.ecw")
-        os.remove("tmp/spif83.ecw.aux.xml")
-    except OSError:
-        pass
-
 
 ###############################################################################
 # Test that we can alter geotransform on existing ECW
 
 
-def test_ecw_24():
+def test_ecw_24(tmp_path):
 
-    shutil.copyfile("data/ecw/spif83.ecw", "tmp/spif83.ecw")
-    try:
-        os.remove("tmp/spif83.ecw.aux.xml")
-    except OSError:
-        pass
+    shutil.copyfile("data/ecw/spif83.ecw", tmp_path / "spif83.ecw")
 
-    ds = gdal.Open("tmp/spif83.ecw", gdal.GA_Update)
+    ds = gdal.Open(tmp_path / "spif83.ecw", gdal.GA_Update)
     if (
         ds is None
         and gdaltest.ecw_drv.major_version == 3
         and gdal.GetConfigOption("APPVEYOR") is not None
     ):
-        try:
-            os.remove("tmp/spif83.ecw")
-        except OSError:
-            pass
         pytest.skip()
     gt = [1, 2, 0, 3, 0, -4]
     ds.SetGeoTransform(gt)
     ds = None
 
-    with pytest.raises(OSError):
-        os.stat("tmp/spif83.ecw.aux.xml")
+    assert not os.path.exists(tmp_path / "spif83.ecw.aux.xml")
 
-    ds = gdal.Open("tmp/spif83.ecw")
+    ds = gdal.Open(tmp_path / "spif83.ecw")
     got_gt = ds.GetGeoTransform()
     ds = None
 
     for i in range(6):
         assert gt[i] == pytest.approx(got_gt[i], abs=1e-5)
 
-    try:
-        os.remove("tmp/spif83.ecw")
-    except OSError:
-        pass
-
 
 ###############################################################################
 # Test that we can alter projection info on existing ECW (through SetProjection())
 
 
-def test_ecw_25():
+def test_ecw_25(tmp_path):
 
-    shutil.copyfile("data/ecw/spif83.ecw", "tmp/spif83.ecw")
-    try:
-        os.remove("tmp/spif83.ecw.aux.xml")
-    except OSError:
-        pass
+    shutil.copyfile("data/ecw/spif83.ecw", tmp_path / "spif83.ecw")
 
     proj = "NUTM31"
     datum = "WGS84"
     units = "FEET"
 
-    ds = gdal.Open("tmp/spif83.ecw", gdal.GA_Update)
+    ds = gdal.Open(tmp_path / "spif83.ecw", gdal.GA_Update)
     if (
         ds is None
         and gdaltest.ecw_drv.major_version == 3
         and gdal.GetConfigOption("APPVEYOR") is not None
     ):
-        try:
-            os.remove("tmp/spif83.ecw")
-        except OSError:
-            pass
         pytest.skip()
     sr = osr.SpatialReference()
     sr.ImportFromERM(proj, datum, units)
@@ -939,10 +799,9 @@ def test_ecw_25():
     ds.SetProjection(wkt)
     ds = None
 
-    with pytest.raises(OSError):
-        os.stat("tmp/spif83.ecw.aux.xml")
+    assert not os.path.exists(tmp_path / "spif83.ecw.aux.xml")
 
-    ds = gdal.Open("tmp/spif83.ecw")
+    ds = gdal.Open(tmp_path / "spif83.ecw")
     got_proj = ds.GetMetadataItem("PROJ", "ECW")
     got_datum = ds.GetMetadataItem("DATUM", "ECW")
     got_units = ds.GetMetadataItem("UNITS", "ECW")
@@ -955,48 +814,34 @@ def test_ecw_25():
 
     assert wkt == got_wkt
 
-    try:
-        os.remove("tmp/spif83.ecw")
-    except OSError:
-        pass
-
 
 ###############################################################################
 # Test that we can alter projection info on existing ECW (through SetMetadataItem())
 
 
-def test_ecw_26():
+def test_ecw_26(tmp_path):
 
-    shutil.copyfile("data/ecw/spif83.ecw", "tmp/spif83.ecw")
-    try:
-        os.remove("tmp/spif83.ecw.aux.xml")
-    except OSError:
-        pass
+    shutil.copyfile("data/ecw/spif83.ecw", tmp_path / "spif83.ecw")
 
     proj = "NUTM31"
     datum = "WGS84"
     units = "FEET"
 
-    ds = gdal.Open("tmp/spif83.ecw", gdal.GA_Update)
+    ds = gdal.Open(tmp_path / "spif83.ecw", gdal.GA_Update)
     if (
         ds is None
         and gdaltest.ecw_drv.major_version == 3
         and gdal.GetConfigOption("APPVEYOR") is not None
     ):
-        try:
-            os.remove("tmp/spif83.ecw")
-        except OSError:
-            pass
         pytest.skip()
     ds.SetMetadataItem("PROJ", proj, "ECW")
     ds.SetMetadataItem("DATUM", datum, "ECW")
     ds.SetMetadataItem("UNITS", units, "ECW")
     ds = None
 
-    with pytest.raises(OSError):
-        os.stat("tmp/spif83.ecw.aux.xml")
+    assert not os.path.exists(tmp_path / "spif83.ecw.aux.xml")
 
-    ds = gdal.Open("tmp/spif83.ecw")
+    ds = gdal.Open(tmp_path / "spif83.ecw")
     got_proj = ds.GetMetadataItem("PROJ", "ECW")
     got_datum = ds.GetMetadataItem("DATUM", "ECW")
     got_units = ds.GetMetadataItem("UNITS", "ECW")
@@ -1012,11 +857,6 @@ def test_ecw_26():
     wkt = sr.ExportToWkt()
 
     assert wkt == got_wkt
-
-    try:
-        os.remove("tmp/spif83.ecw")
-    except OSError:
-        pass
 
 
 ###############################################################################
@@ -1026,7 +866,7 @@ def test_ecw_26():
 def test_ecw_27():
 
     if gdaltest.jp2ecw_drv is None or not has_write_support():
-        pytest.skip()
+        pytest.skip("ECW write support not available")
 
     ds = gdal.Open("data/jpeg2000/byte_without_geotransform.jp2")
 
@@ -1158,7 +998,7 @@ def test_ecw_30():
 def test_ecw_31():
 
     if gdaltest.ecw_drv.major_version < 4:
-        pytest.skip()
+        pytest.skip("Requires ECW SDK >= 4.0")
 
     ds = gdal.Open("data/ecw/jrc.ecw")
     ref_buf = ds.ReadRaster(0, 0, ds.RasterXSize, ds.RasterYSize)
@@ -1319,23 +1159,25 @@ def test_ecw_33_bis():
 # Verify that an write the imagery out to a new ecw file. Source file is 16 bit.
 
 
-def test_ecw_34():
+def test_ecw_34(tmp_path):
 
     if not has_write_support():
-        pytest.skip()
+        pytest.skip("ECW write support not available")
     if gdaltest.ecw_drv.major_version < 5:
-        pytest.skip()
+        pytest.skip("Requires ECW SDK >= 5.0")
 
     ds = gdal.GetDriverByName("MEM").Create("MEM:::", 128, 128, 1, gdal.GDT_UInt16)
     ds.GetRasterBand(1).Fill(65535)
     ref_data = ds.GetRasterBand(1).ReadRaster(0, 0, 128, 128, buf_type=gdal.GDT_UInt16)
     out_ds = gdaltest.ecw_drv.CreateCopy(
-        "tmp/UInt16_big_out.ecw", ds, options=["ECW_FORMAT_VERSION=3", "TARGET=1"]
+        tmp_path / "UInt16_big_out.ecw",
+        ds,
+        options=["ECW_FORMAT_VERSION=3", "TARGET=1"],
     )
     del out_ds
     ds = None
 
-    ds = gdal.Open("tmp/UInt16_big_out.ecw")
+    ds = gdal.Open(tmp_path / "UInt16_big_out.ecw")
     got_data = ds.GetRasterBand(1).ReadRaster(0, 0, 128, 128, buf_type=gdal.GDT_UInt16)
     version = ds.GetMetadataItem("VERSION")
     ds = None
@@ -1348,20 +1190,20 @@ def test_ecw_34():
 # Verify that an write the imagery out to a new JP2 file. Source file is 16 bit.
 
 
-def test_ecw_35():
+def test_ecw_35(tmp_path):
     if gdaltest.jp2ecw_drv is None or not has_write_support():
-        pytest.skip()
+        pytest.skip("ECW write support not available")
 
     ds = gdal.GetDriverByName("MEM").Create("MEM:::", 128, 128, 1, gdal.GDT_UInt16)
     ds.GetRasterBand(1).Fill(65535)
     ref_data = ds.GetRasterBand(1).ReadRaster(0, 0, 128, 128, buf_type=gdal.GDT_UInt16)
     out_ds = gdaltest.jp2ecw_drv.CreateCopy(
-        "tmp/UInt16_big_out.jp2", ds, options=["TARGET=1"]
+        tmp_path / "UInt16_big_out.jp2", ds, options=["TARGET=1"]
     )
     del out_ds
     ds = None
 
-    ds = gdal.Open("tmp/UInt16_big_out.jp2")
+    ds = gdal.Open(tmp_path / "UInt16_big_out.jp2")
     got_data = ds.GetRasterBand(1).ReadRaster(0, 0, 128, 128, buf_type=gdal.GDT_UInt16)
     ds = None
 
@@ -1372,12 +1214,12 @@ def test_ecw_35():
 # Make sure that band descriptions are preserved for version 3 ECW files.
 
 
-def test_ecw_36():
+def test_ecw_36(tmp_path):
 
     if not has_write_support():
-        pytest.skip()
+        pytest.skip("ECW write support not available")
     if gdaltest.ecw_drv.major_version < 5:
-        pytest.skip()
+        pytest.skip("Requires ECW SDK >= 5.0")
 
     vrt_ds = gdal.Open(
         """<VRTDataset rasterXSize="400" rasterYSize="400">
@@ -1406,7 +1248,7 @@ def test_ecw_36():
     )
 
     dswr = gdaltest.ecw_drv.CreateCopy(
-        "tmp/jrc312.ecw", vrt_ds, options=["ECW_FORMAT_VERSION=3", "TARGET=75"]
+        tmp_path / "jrc312.ecw", vrt_ds, options=["ECW_FORMAT_VERSION=3", "TARGET=75"]
     )
 
     assert dswr.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_BlueBand, (
@@ -1430,7 +1272,7 @@ def test_ecw_36():
 
     dswr = None
 
-    dsr = gdal.Open("tmp/jrc312.ecw")
+    dsr = gdal.Open(tmp_path / "jrc312.ecw")
 
     assert dsr.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_BlueBand, (
         "Band 1 color interpretation should be Blue  but is : "
@@ -1453,17 +1295,17 @@ def test_ecw_36():
 # color space set implicitly to sRGB.
 
 
-def test_ecw_37():
+def test_ecw_37(tmp_path):
 
     if not has_write_support():
-        pytest.skip()
+        pytest.skip("ECW write support not available")
     if gdaltest.ecw_drv.major_version < 5:
-        pytest.skip()
+        pytest.skip("Requires ECW SDK >= 5.0")
 
     ds = gdal.Open("data/ecw/jrc.ecw")
 
     dswr = gdaltest.ecw_drv.CreateCopy(
-        "tmp/jrc123.ecw", ds, options=["ECW_FORMAT_VERSION=3", "TARGET=75"]
+        tmp_path / "jrc123.ecw", ds, options=["ECW_FORMAT_VERSION=3", "TARGET=75"]
     )
 
     assert dswr.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_RedBand, (
@@ -1487,7 +1329,7 @@ def test_ecw_37():
 
     dswr = None
 
-    dsr = gdal.Open("tmp/jrc123.ecw")
+    dsr = gdal.Open(tmp_path / "jrc123.ecw")
 
     assert dsr.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_RedBand, (
         "Band 1 color interpretation should be Red  but is : "
@@ -1509,14 +1351,14 @@ def test_ecw_37():
 # Check opening unicode files.
 
 
-def test_ecw_38():
+def test_ecw_38(tmp_path):
 
-    gdaltest.ecw_38_fname = (
-        fname
-    ) = "tmp/za\u017C\u00F3\u0142\u0107g\u0119\u015Bl\u0105ja\u017A\u0144.ecw"
+    fname = (
+        tmp_path / "za\u017C\u00F3\u0142\u0107g\u0119\u015Bl\u0105ja\u017A\u0144.ecw"
+    )
 
     if gdaltest.ecw_drv.major_version < 4:
-        pytest.skip()
+        pytest.skip("Requires ECW SDK >= 4.0")
 
     shutil.copyfile("data/ecw/jrc.ecw", fname)
 
@@ -1537,17 +1379,17 @@ def test_ecw_38():
 # Check writing histograms.
 
 
-def test_ecw_39():
+def test_ecw_39(tmp_path):
 
     if not has_write_support():
-        pytest.skip()
+        pytest.skip("ECW write support not available")
     if gdaltest.ecw_drv.major_version < 5:
-        pytest.skip()
+        pytest.skip("Requires ECW SDK >= 5.0")
 
     ds = gdal.Open("data/ecw/jrc.ecw")
 
     dswr = gdaltest.ecw_drv.CreateCopy(
-        "tmp/jrcstats.ecw", ds, options=["ECW_FORMAT_VERSION=3", "TARGET=75"]
+        tmp_path / "jrcstats.ecw", ds, options=["ECW_FORMAT_VERSION=3", "TARGET=75"]
     )
     ds = None
     hist = (0, 255, 2, [3, 4])
@@ -1555,7 +1397,7 @@ def test_ecw_39():
     dswr.GetRasterBand(1).SetDefaultHistogram(0, 255, [3, 4])
     dswr = None
 
-    ds = gdal.Open("tmp/jrcstats.ecw")
+    ds = gdal.Open(tmp_path / "jrcstats.ecw")
 
     result = hist == ds.GetRasterBand(1).GetDefaultHistogram(force=0)
 
@@ -1621,21 +1463,17 @@ def test_ecw_40():
 # Check generating statistics & histogram for a ECW v3 file
 
 
-def test_ecw_41():
+def test_ecw_41(tmp_path):
 
     if gdaltest.ecw_drv.major_version < 5:
-        pytest.skip()
+        pytest.skip("Requires ECW SDK >= 5.0")
 
     shutil.copy(
         "data/ecw/stefan_full_rgba_ecwv3_meta.ecw",
-        "tmp/stefan_full_rgba_ecwv3_meta.ecw",
+        tmp_path / "stefan_full_rgba_ecwv3_meta.ecw",
     )
-    try:
-        os.remove("tmp/stefan_full_rgba_ecwv3_meta.ecw.aux.xml")
-    except OSError:
-        pass
 
-    ds = gdal.Open("tmp/stefan_full_rgba_ecwv3_meta.ecw")
+    ds = gdal.Open(tmp_path / "stefan_full_rgba_ecwv3_meta.ecw")
 
     # Check that no statistics is already included in the file
     assert ds.GetRasterBand(1).GetMinimum() is None
@@ -1652,9 +1490,9 @@ def test_ecw_41():
     ds = None
 
     # Check that there's no .aux.xml file
-    assert not os.path.exists("tmp/stefan_full_rgba_ecwv3_meta.ecw.aux.xml")
+    assert not os.path.exists(tmp_path / "stefan_full_rgba_ecwv3_meta.ecw.aux.xml")
 
-    ds = gdal.Open("tmp/stefan_full_rgba_ecwv3_meta.ecw")
+    ds = gdal.Open(tmp_path / "stefan_full_rgba_ecwv3_meta.ecw")
     assert ds.GetRasterBand(1).GetMinimum() == 0
     assert ds.GetRasterBand(1).GetMaximum() == 255
     stats = ds.GetRasterBand(1).GetStatistics(0, 0)
@@ -1663,7 +1501,7 @@ def test_ecw_41():
         assert stats[i] == pytest.approx(expected_stats[i], abs=1)
     ds = None
 
-    ds = gdal.Open("tmp/stefan_full_rgba_ecwv3_meta.ecw")
+    ds = gdal.Open(tmp_path / "stefan_full_rgba_ecwv3_meta.ecw")
     # And compute the histogram
     got_hist = ds.GetRasterBand(1).GetDefaultHistogram()
     expected_hist = (
@@ -1934,11 +1772,11 @@ def test_ecw_41():
 
     # Remove the .aux.xml file
     try:
-        os.remove("tmp/stefan_full_rgba_ecwv3_meta.ecw.aux.xml")
+        os.remove(tmp_path / "stefan_full_rgba_ecwv3_meta.ecw.aux.xml")
     except OSError:
         pass
 
-    ds = gdal.Open("tmp/stefan_full_rgba_ecwv3_meta.ecw")
+    ds = gdal.Open(tmp_path / "stefan_full_rgba_ecwv3_meta.ecw")
     assert ds.GetRasterBand(1).GetMinimum() == 0
     assert ds.GetRasterBand(1).GetMaximum() == 255
     got_hist = ds.GetRasterBand(1).GetDefaultHistogram(force=0)
@@ -1946,29 +1784,24 @@ def test_ecw_41():
     ds = None
 
     # Check that there's no .aux.xml file
-    with pytest.raises(OSError):
-        os.stat("tmp/stefan_full_rgba_ecwv3_meta.ecw.aux.xml")
+    assert not os.path.exists(tmp_path / "stefan_full_rgba_ecwv3_meta.ecw.aux.xml")
 
 
 ###############################################################################
 # Test setting/unsetting file metadata of a ECW v3 file
 
 
-def test_ecw_42():
+def test_ecw_42(tmp_path):
 
     if gdaltest.ecw_drv.major_version < 5:
-        pytest.skip()
+        pytest.skip("Requires ECW SDK >= 5.0")
 
     shutil.copy(
         "data/ecw/stefan_full_rgba_ecwv3_meta.ecw",
-        "tmp/stefan_full_rgba_ecwv3_meta.ecw",
+        tmp_path / "stefan_full_rgba_ecwv3_meta.ecw",
     )
-    try:
-        os.remove("tmp/stefan_full_rgba_ecwv3_meta.ecw.aux.xml")
-    except OSError:
-        pass
 
-    ds = gdal.Open("tmp/stefan_full_rgba_ecwv3_meta.ecw", gdal.GA_Update)
+    ds = gdal.Open(tmp_path / "stefan_full_rgba_ecwv3_meta.ecw", gdal.GA_Update)
     md = {}
     md["FILE_METADATA_CLASSIFICATION"] = "FILE_METADATA_CLASSIFICATION"
     md["FILE_METADATA_ACQUISITION_DATE"] = "2013-04-04"
@@ -1986,18 +1819,17 @@ def test_ecw_42():
     ds = None
 
     # Check that there's no .aux.xml file
-    with pytest.raises(OSError):
-        os.stat("tmp/stefan_full_rgba_ecwv3_meta.ecw.aux.xml")
+    assert not os.path.exists(tmp_path / "stefan_full_rgba_ecwv3_meta.ecw.aux.xml")
 
     # Check item values
-    ds = gdal.Open("tmp/stefan_full_rgba_ecwv3_meta.ecw")
+    ds = gdal.Open(tmp_path / "stefan_full_rgba_ecwv3_meta.ecw")
     got_md = ds.GetMetadata()
     for item in md:
         assert got_md[item] == md[item]
     ds = None
 
     # Test unsetting all the stuff
-    ds = gdal.Open("tmp/stefan_full_rgba_ecwv3_meta.ecw", gdal.GA_Update)
+    ds = gdal.Open(tmp_path / "stefan_full_rgba_ecwv3_meta.ecw", gdal.GA_Update)
     md = {}
     md["FILE_METADATA_CLASSIFICATION"] = ""
     md["FILE_METADATA_ACQUISITION_DATE"] = "1970-01-01"
@@ -2013,11 +1845,10 @@ def test_ecw_42():
     ds = None
 
     # Check that there's no .aux.xml file
-    with pytest.raises(OSError):
-        os.stat("tmp/stefan_full_rgba_ecwv3_meta.ecw.aux.xml")
+    assert not os.path.exists(tmp_path / "stefan_full_rgba_ecwv3_meta.ecw.aux.xml")
 
     # Check item values
-    ds = gdal.Open("tmp/stefan_full_rgba_ecwv3_meta.ecw")
+    ds = gdal.Open(tmp_path / "stefan_full_rgba_ecwv3_meta.ecw")
     got_md = ds.GetMetadata()
     for item in md:
         assert item not in got_md or item == "FILE_METADATA_ACQUISITION_DATE", md[item]
@@ -2085,7 +1916,7 @@ def test_ecw_44():
     if gdaltest.ecw_drv.major_version < 5 or (
         gdaltest.ecw_drv.major_version == 5 and gdaltest.ecw_drv.minor_version < 1
     ):
-        pytest.skip()
+        pytest.skip("Requires ECW SDK >= 5.1")
 
     ds = gdal.Open("data/jpeg2000/stefan_full_rgba_alpha_1bit.jp2")
 
@@ -2131,7 +1962,7 @@ def RemoveDriverMetadata(md):
 
 def test_ecw_45():
     if gdaltest.jp2ecw_drv is None or not has_write_support():
-        pytest.skip()
+        pytest.skip("ECW write support not available")
 
     # No metadata
     src_ds = gdal.GetDriverByName("MEM").Create("", 2, 2)
@@ -2218,7 +2049,7 @@ def test_ecw_45():
 def test_ecw_46():
 
     if gdaltest.jp2ecw_drv is None or not has_write_support():
-        pytest.skip()
+        pytest.skip("ECW write support not available")
 
     tmp_ds = gdaltest.jp2ecw_drv.CreateCopy(
         "/vsimem/ecw_46.jp2", gdal.Open("data/int16.tif")

--- a/autotest/gdrivers/eedai.py
+++ b/autotest/gdrivers/eedai.py
@@ -39,7 +39,10 @@ import webserver
 
 from osgeo import gdal
 
-pytestmark = pytest.mark.require_driver("EEDAI")
+pytestmark = [
+    pytest.mark.require_driver("EEDAI"),
+    pytest.mark.random_order(disabled=True),
+]
 
 ###############################################################################
 # Find EEDAI driver

--- a/autotest/gdrivers/idrisi.py
+++ b/autotest/gdrivers/idrisi.py
@@ -29,7 +29,7 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
-import os
+import shutil
 
 import gdaltest
 
@@ -37,9 +37,14 @@ import gdaltest
 # Read test of byte file.
 
 
-def test_idrisi_1():
+def test_idrisi_1(tmp_path):
 
-    tst = gdaltest.GDALTest("RST", "rst/byte.rst", 1, 5044)
+    shutil.copy("data/rst/byte.rst", tmp_path)
+    shutil.copy("data/rst/byte.rdc", tmp_path)
+
+    tst = gdaltest.GDALTest(
+        "RST", tmp_path / "byte.rst", 1, 5044, filename_absolute=True
+    )
     tst.testOpen()
 
 
@@ -47,9 +52,14 @@ def test_idrisi_1():
 # Read test of byte file.
 
 
-def test_idrisi_2():
+def test_idrisi_2(tmp_path):
 
-    tst = gdaltest.GDALTest("RST", "rst/real.rst", 1, 5275)
+    shutil.copy("data/rst/real.rst", tmp_path)
+    shutil.copy("data/rst/real.rdc", tmp_path)
+
+    tst = gdaltest.GDALTest(
+        "RST", tmp_path / "real.rst", 1, 5275, filename_absolute=True
+    )
     tst.testOpen()
 
 
@@ -57,37 +67,31 @@ def test_idrisi_2():
 #
 
 
-def test_idrisi_3():
+def test_idrisi_3(tmp_path):
 
-    tst = gdaltest.GDALTest("RST", "ehdr/float32.bil", 1, 27)
+    shutil.copy("data/ehdr/float32.bil", tmp_path)
+    shutil.copy("data/ehdr/float32.hdr", tmp_path)
+    shutil.copy("data/ehdr/float32.prj", tmp_path)
 
-    tst.testCreate(new_filename="tmp/float32.rst", out_bands=1, vsimem=1)
+    tst = gdaltest.GDALTest(
+        "RST", tmp_path / "float32.bil", 1, 27, filename_absolute=True
+    )
+
+    tst.testCreate(new_filename=tmp_path / "float32.rst", out_bands=1, vsimem=1)
 
 
 ###############################################################################
 #
 
 
-def test_idrisi_4():
+def test_idrisi_4(tmp_path):
 
-    tst = gdaltest.GDALTest("RST", "rgbsmall.tif", 2, 21053)
+    shutil.copy("data/rgbsmall.tif", tmp_path)
 
-    tst.testCreateCopy(
-        check_gt=1, check_srs=1, new_filename="tmp/rgbsmall_cc.rst", vsimem=1
+    tst = gdaltest.GDALTest(
+        "RST", tmp_path / "rgbsmall.tif", 2, 21053, filename_absolute=True
     )
 
-
-###############################################################################
-# Cleanup.
-
-
-def test_idrisi_cleanup():
-    gdaltest.clean_tmp()
-    try:
-        os.unlink("data/rgbsmall.tif.aux.xml")
-        os.unlink("data/rst/real.rst.aux.xml")
-        os.unlink("data/frmt09.cot.aux.xml")
-        os.unlink("data/rst/byte.rst.aux.xml")
-        print("FIXME?: data/rgbsmall.tif.aux.xml is produced by those tests")
-    except OSError:
-        pass
+    tst.testCreateCopy(
+        check_gt=1, check_srs=1, new_filename=tmp_path / "rgbsmall_cc.rst", vsimem=1
+    )

--- a/autotest/ogr/ogr_fgdb.py
+++ b/autotest/ogr/ogr_fgdb.py
@@ -53,10 +53,6 @@ def module_disable_exceptions():
 
 @pytest.fixture(autouse=True, scope="module")
 def startup_and_cleanup():
-    try:
-        shutil.rmtree("tmp/test.gdb")
-    except OSError:
-        pass
 
     yield
 
@@ -66,28 +62,6 @@ def startup_and_cleanup():
     import locale
 
     locale.setlocale(locale.LC_ALL, "C")
-
-    try:
-        shutil.rmtree("tmp/test.gdb")
-    except OSError:
-        pass
-
-    try:
-        shutil.rmtree("tmp/test2.gdb")
-    except OSError:
-        pass
-    try:
-        shutil.rmtree("tmp/poly.gdb")
-    except OSError:
-        pass
-    try:
-        shutil.rmtree("tmp/test3005.gdb")
-    except OSError:
-        pass
-    try:
-        shutil.rmtree("tmp/roads_clip Drawing.gdb")
-    except OSError:
-        pass
 
 
 ###############################################################################
@@ -163,14 +137,9 @@ def ogrsf_path():
 # Write and read back various geometry types
 
 
-def test_ogr_fgdb_1(fgdb_drv):
-
-    srs = osr.SpatialReference()
-    srs.SetFromUserInput("WGS84")
-
-    ds = fgdb_drv.CreateDataSource("tmp/test.gdb")
-
-    datalist = [
+@pytest.fixture()
+def test_gdb_datalist():
+    return [
         ["none", ogr.wkbNone, None],
         ["point", ogr.wkbPoint, "POINT (1 2)"],
         ["multipoint", ogr.wkbMultiPoint, "MULTIPOINT (1 2,3 4)"],
@@ -234,11 +203,19 @@ def test_ogr_fgdb_1(fgdb_drv):
         ["empty_polygon", ogr.wkbPolygon, "POLYGON EMPTY", None],
     ]
 
+
+@pytest.fixture()
+def test_gdb(fgdb_drv, tmp_path, test_gdb_datalist):
+    srs = osr.SpatialReference()
+    srs.SetFromUserInput("WGS84")
+
+    ds = fgdb_drv.CreateDataSource(tmp_path / "test.gdb")
+
     options = [
         "COLUMN_TYPES=smallint=esriFieldTypeSmallInteger,float=esriFieldTypeSingle,guid=esriFieldTypeGUID,xml=esriFieldTypeXML"
     ]
 
-    for data in datalist:
+    for data in test_gdb_datalist:
         if data[1] == ogr.wkbNone:
             lyr = ds.CreateLayer(data[0], geom_type=data[1], options=options)
         elif data[0] == "multipatch":
@@ -288,7 +265,17 @@ def test_ogr_fgdb_1(fgdb_drv):
             feat.SetField("float2", 1.5)
             lyr.CreateFeature(feat)
 
-    for data in datalist:
+    yield tmp_path / "test.gdb"
+
+
+def test_ogr_fgdb_1(test_gdb, test_gdb_datalist):
+
+    srs = osr.SpatialReference()
+    srs.SetFromUserInput("WGS84")
+
+    ds = ogr.Open(test_gdb)
+
+    for data in test_gdb_datalist:
         lyr = ds.GetLayerByName(data[0])
         if data[1] != ogr.wkbNone:
             assert (
@@ -350,9 +337,9 @@ def test_ogr_fgdb_1(fgdb_drv):
 # Test DeleteField()
 
 
-def test_ogr_fgdb_DeleteField():
+def test_ogr_fgdb_DeleteField(test_gdb):
 
-    ds = ogr.Open("tmp/test.gdb", update=1)
+    ds = ogr.Open(test_gdb, update=1)
     lyr = ds.GetLayerByIndex(0)
 
     assert (
@@ -396,7 +383,7 @@ def test_ogr_fgdb_DeleteField():
 
     # Needed since FileGDB v1.4, otherwise crash/error ...
     if True:  # pylint: disable=using-constant-test
-        ds = ogr.Open("tmp/test.gdb", update=1)
+        ds = ogr.Open(test_gdb, update=1)
         lyr = ds.GetLayerByIndex(0)
 
     fld_defn = ogr.FieldDefn("str2", ogr.OFTString)
@@ -427,7 +414,7 @@ def test_ogr_fgdb_DeleteField():
     feat = None
     ds = None
 
-    ds = ogr.Open("tmp/test.gdb")
+    ds = ogr.Open(test_gdb)
     lyr = ds.GetLayerByIndex(0)
     assert (
         lyr.GetLayerDefn()
@@ -445,9 +432,9 @@ def test_ogr_fgdb_DeleteField():
 # Run test_ogrsf
 
 
-def test_ogr_fgdb_2(ogrsf_path):
+def test_ogr_fgdb_2(ogrsf_path, test_gdb):
     ret = gdaltest.runexternal(
-        ogrsf_path + " -ro tmp/test.gdb --config OGR_SKIP OpenFileGDB"
+        ogrsf_path + f" -ro {test_gdb} --config OGR_SKIP OpenFileGDB"
     )
 
     assert ret.find("INFO") != -1 and ret.find("ERROR") == -1
@@ -457,24 +444,27 @@ def test_ogr_fgdb_2(ogrsf_path):
 # Run ogr2ogr
 
 
-def test_ogr_fgdb_3(openfilegdb_drv):
+@pytest.fixture()
+def poly_gdb(tmp_path):
 
     import test_cli_utilities
 
     if test_cli_utilities.get_ogr2ogr_path() is None:
         pytest.skip()
 
-    try:
-        shutil.rmtree("tmp/poly.gdb")
-    except OSError:
-        pass
-
     gdaltest.runexternal(
         test_cli_utilities.get_ogr2ogr_path()
-        + " -f filegdb tmp/poly.gdb data/poly.shp -nlt MULTIPOLYGON -a_srs None"
+        + f" -f filegdb {tmp_path}/poly.gdb data/poly.shp -nlt MULTIPOLYGON -a_srs None"
     )
 
-    ds = ogr.Open("tmp/poly.gdb")
+    return tmp_path / "poly.gdb"
+
+
+def test_ogr_fgdb_3(openfilegdb_drv, poly_gdb):
+
+    import test_cli_utilities
+
+    ds = ogr.Open(poly_gdb)
     assert not (ds is None or ds.GetLayerCount() == 0), "ogr2ogr failed"
     ds = None
 
@@ -487,9 +477,8 @@ def test_ogr_fgdb_3(openfilegdb_drv):
 
     ret = gdaltest.runexternal(
         test_cli_utilities.get_test_ogrsf_path()
-        + " tmp/poly.gdb --config DRIVER_WISHED FileGDB"
+        + f" {poly_gdb} --config DRIVER_WISHED FileGDB"
     )
-    # print ret
 
     assert ret.find("INFO") != -1 and ret.find("ERROR") == -1
 
@@ -498,14 +487,14 @@ def test_ogr_fgdb_3(openfilegdb_drv):
 # Test SQL support
 
 
-def test_ogr_fgdb_sql():
+def test_ogr_fgdb_sql(poly_gdb):
 
     import test_cli_utilities
 
     if test_cli_utilities.get_ogr2ogr_path() is None:
         pytest.skip()
 
-    ds = ogr.Open("tmp/poly.gdb")
+    ds = ogr.Open(poly_gdb)
 
     ds.ExecuteSQL("CREATE INDEX idx_poly_eas_id ON poly(EAS_ID)")
 
@@ -523,12 +512,12 @@ def test_ogr_fgdb_sql():
 # Test delete layer
 
 
-def test_ogr_fgdb_4():
+def test_ogr_fgdb_4(test_gdb):
 
     for j in range(2):
 
         # Create a layer
-        ds = ogr.Open("tmp/test.gdb", update=1)
+        ds = ogr.Open(test_gdb, update=1)
         srs = osr.SpatialReference()
         srs.SetFromUserInput("WGS84")
         lyr = ds.CreateLayer("layer_to_remove", geom_type=ogr.wkbPoint, srs=srs)
@@ -541,7 +530,7 @@ def test_ogr_fgdb_4():
 
         if j == 1:
             ds = None
-            ds = ogr.Open("tmp/test.gdb", update=1)
+            ds = ogr.Open(test_gdb, update=1)
 
         # Delete it
         for i in range(ds.GetLayerCount()):
@@ -560,89 +549,76 @@ def test_ogr_fgdb_4():
 # Test DeleteDataSource()
 
 
-def test_ogr_fgdb_5(fgdb_drv):
+def test_ogr_fgdb_5(fgdb_drv, poly_gdb):
 
-    assert fgdb_drv.DeleteDataSource("tmp/test.gdb") == 0, "DeleteDataSource() failed"
+    assert fgdb_drv.DeleteDataSource(poly_gdb) == 0, "DeleteDataSource() failed"
 
-    assert not os.path.exists("tmp/test.gdb")
+    assert not os.path.exists(poly_gdb)
 
 
 ###############################################################################
 # Test adding a layer to an existing feature dataset
 
 
-def test_ogr_fgdb_6(fgdb_drv):
+def test_ogr_fgdb_6(fgdb_drv, tmp_path):
 
     srs = osr.SpatialReference()
     srs.SetFromUserInput("WGS84")
 
-    ds = fgdb_drv.CreateDataSource("tmp/test.gdb")
-    ds.CreateLayer(
-        "layer1",
-        srs=srs,
-        geom_type=ogr.wkbPoint,
-        options=["FEATURE_DATASET=featuredataset"],
-    )
-    ds.CreateLayer(
-        "layer2",
-        srs=srs,
-        geom_type=ogr.wkbPoint,
-        options=["FEATURE_DATASET=featuredataset"],
-    )
-    ds = None
+    with fgdb_drv.CreateDataSource(tmp_path / "test.gdb") as ds:
+        ds.CreateLayer(
+            "layer1",
+            srs=srs,
+            geom_type=ogr.wkbPoint,
+            options=["FEATURE_DATASET=featuredataset"],
+        )
+        ds.CreateLayer(
+            "layer2",
+            srs=srs,
+            geom_type=ogr.wkbPoint,
+            options=["FEATURE_DATASET=featuredataset"],
+        )
 
-    ds = ogr.Open("tmp/test.gdb")
-    assert ds.GetLayerCount() == 2
-    ds = None
+    with ogr.Open(tmp_path / "test.gdb") as ds:
+        assert ds.GetLayerCount() == 2
 
 
 ###############################################################################
 # Test bulk loading (#4420)
 
 
-def test_ogr_fgdb_7(fgdb_drv):
-
-    try:
-        shutil.rmtree("tmp/test.gdb")
-    except OSError:
-        pass
+def test_ogr_fgdb_7(fgdb_drv, tmp_path):
 
     srs = osr.SpatialReference()
     srs.SetFromUserInput("WGS84")
 
-    ds = fgdb_drv.CreateDataSource("tmp/test.gdb")
-    lyr = ds.CreateLayer("test", srs=srs, geom_type=ogr.wkbPoint)
-    lyr.CreateField(ogr.FieldDefn("id", ogr.OFTInteger))
-    with gdal.config_option("FGDB_BULK_LOAD", "YES"):
-        for i in range(1000):
-            feat = ogr.Feature(lyr.GetLayerDefn())
-            feat.SetField(0, i)
-            geom = ogr.CreateGeometryFromWkt("POINT(0 1)")
-            feat.SetGeometry(geom)
-            lyr.CreateFeature(feat)
-            feat = None
+    with fgdb_drv.CreateDataSource(tmp_path / "test.gdb") as ds:
+        lyr = ds.CreateLayer("test", srs=srs, geom_type=ogr.wkbPoint)
+        lyr.CreateField(ogr.FieldDefn("id", ogr.OFTInteger))
+        with gdal.config_option("FGDB_BULK_LOAD", "YES"):
+            for i in range(1000):
+                feat = ogr.Feature(lyr.GetLayerDefn())
+                feat.SetField(0, i)
+                geom = ogr.CreateGeometryFromWkt("POINT(0 1)")
+                feat.SetGeometry(geom)
+                lyr.CreateFeature(feat)
+                feat = None
 
-        lyr.ResetReading()
-        feat = lyr.GetNextFeature()
-        assert feat.GetField(0) == 0
-        ds = None
+            lyr.ResetReading()
+            feat = lyr.GetNextFeature()
+            assert feat.GetField(0) == 0
 
 
 ###############################################################################
 # Test field name laundering (#4458)
 
 
-def test_ogr_fgdb_8(fgdb_drv):
-
-    try:
-        shutil.rmtree("tmp/test.gdb")
-    except OSError:
-        pass
+def test_ogr_fgdb_8(fgdb_drv, tmp_path):
 
     srs = osr.SpatialReference()
     srs.SetFromUserInput("WGS84")
 
-    ds = fgdb_drv.CreateDataSource("tmp/test.gdb")
+    ds = fgdb_drv.CreateDataSource(tmp_path / "test.gdb")
     lyr = ds.CreateLayer("test", srs=srs, geom_type=ogr.wkbPoint)
     with gdal.quiet_errors():
         lyr.CreateField(ogr.FieldDefn("FROM", ogr.OFTInteger))  # reserved keyword
@@ -692,12 +668,7 @@ def test_ogr_fgdb_8(fgdb_drv):
 # Test layer name laundering (#4466)
 
 
-def test_ogr_fgdb_9(fgdb_drv):
-
-    try:
-        shutil.rmtree("tmp/test.gdb")
-    except OSError:
-        pass
+def test_ogr_fgdb_9(fgdb_drv, tmp_path):
 
     srs = osr.SpatialReference()
     srs.SetFromUserInput("WGS84")
@@ -714,7 +685,7 @@ def test_ogr_fgdb_9(fgdb_drv):
         _160char + "B",  # still too long
     ]
 
-    ds = fgdb_drv.CreateDataSource("tmp/test.gdb")
+    ds = fgdb_drv.CreateDataSource(tmp_path / "test.gdb")
     with gdal.quiet_errors():
         for in_name in in_names:
             lyr = ds.CreateLayer(in_name, srs=srs, geom_type=ogr.wkbPoint)
@@ -737,12 +708,7 @@ def test_ogr_fgdb_9(fgdb_drv):
 # Test SRS support
 
 
-def test_ogr_fgdb_10(fgdb_drv):
-
-    try:
-        shutil.rmtree("tmp/test.gdb")
-    except OSError:
-        pass
+def test_ogr_fgdb_10(fgdb_drv, tmp_path):
 
     srs_exact_4326 = osr.SpatialReference()
     srs_exact_4326.ImportFromEPSG(4326)
@@ -786,7 +752,7 @@ def test_ogr_fgdb_10(fgdb_drv):
     srs_exact_4233 = osr.SpatialReference()
     srs_exact_4233.ImportFromEPSG(4233)
 
-    ds = fgdb_drv.CreateDataSource("tmp/test.gdb")
+    ds = fgdb_drv.CreateDataSource(tmp_path / "test.gdb")
     lyr = ds.CreateLayer("srs_exact_4326", srs=srs_exact_4326, geom_type=ogr.wkbPoint)
     lyr = ds.CreateLayer("srs_approx_4326", srs=srs_approx_4326, geom_type=ogr.wkbPoint)
     lyr = ds.CreateLayer("srs_exact_2193", srs=srs_exact_2193, geom_type=ogr.wkbPoint)
@@ -812,7 +778,7 @@ def test_ogr_fgdb_10(fgdb_drv):
 
     ds = None
 
-    ds = ogr.Open("tmp/test.gdb")
+    ds = ogr.Open(tmp_path / "test.gdb")
     lyr = ds.GetLayerByName("srs_exact_4326")
     assert lyr.GetSpatialRef().ExportToWkt().find("4326") != -1
     lyr = ds.GetLayerByName("srs_approx_4326")
@@ -830,18 +796,13 @@ def test_ogr_fgdb_10(fgdb_drv):
 # Test all data types
 
 
-def test_ogr_fgdb_11(fgdb_drv):
-
-    try:
-        shutil.rmtree("tmp/test.gdb")
-    except OSError:
-        pass
+def test_ogr_fgdb_11(fgdb_drv, tmp_path):
 
     f = open("data/filegdb/test_filegdb_field_types.xml", "rt")
     xml_def = f.read()
     f.close()
 
-    ds = fgdb_drv.CreateDataSource("tmp/test.gdb")
+    ds = fgdb_drv.CreateDataSource(tmp_path / "test.gdb")
     lyr = ds.CreateLayer(
         "test", geom_type=ogr.wkbNone, options=["XML_DEFINITION=%s" % xml_def]
     )
@@ -876,7 +837,7 @@ def test_ogr_fgdb_11(fgdb_drv):
 
     ds = None
 
-    ds = ogr.Open("tmp/test.gdb")
+    ds = ogr.Open(tmp_path / "test.gdb")
     lyr = ds.GetLayerByName("test")
     feat = lyr.GetNextFeature()
     if (
@@ -912,57 +873,54 @@ def test_ogr_fgdb_11(fgdb_drv):
 
 
 @gdaltest.disable_exceptions()
-def test_ogr_fgdb_12():
+def test_ogr_fgdb_12(tmp_path):
 
-    ds = ogr.Open("tmp/non_existing.gdb")
+    ds = ogr.Open(tmp_path / "non_existing.gdb")
     assert ds is None
 
-    gdal.Unlink("tmp/dummy.gdb")
-    try:
-        shutil.rmtree("tmp/dummy.gdb")
-    except OSError:
-        pass
 
-    f = open("tmp/dummy.gdb", "wb")
+@gdaltest.disable_exceptions()
+def test_ogr_fgdb_12_bis(tmp_path):
+
+    f = open(tmp_path / "dummy.gdb", "wb")
     f.close()
 
-    ds = ogr.Open("tmp/dummy.gdb")
+    ds = ogr.Open(tmp_path / "dummy.gdb")
     assert ds is None
 
-    os.unlink("tmp/dummy.gdb")
 
-    os.mkdir("tmp/dummy.gdb")
+@gdaltest.disable_exceptions()
+def test_ogr_fgdb_12_ter(tmp_path):
+
+    os.mkdir(tmp_path / "dummy.gdb")
 
     with gdal.quiet_errors():
-        ds = ogr.Open("tmp/dummy.gdb")
+        ds = ogr.Open(tmp_path / "dummy.gdb")
     assert ds is None
-
-    shutil.rmtree("tmp/dummy.gdb")
 
 
 ###############################################################################
 # Test failed CreateDataSource() and DeleteDataSource()
 
 
-def test_ogr_fgdb_13(fgdb_drv):
+def test_ogr_fgdb_13(fgdb_drv, tmp_path):
 
     with gdal.quiet_errors():
-        ds = fgdb_drv.CreateDataSource("tmp/foo")
+        ds = fgdb_drv.CreateDataSource(tmp_path / "foo")
     assert ds is None
 
-    f = open("tmp/dummy.gdb", "wb")
+
+def test_ogr_fgdb_13_bis(fgdb_drv, tmp_path):
+
+    f = open(tmp_path / "dummy.gdb", "wb")
     f.close()
 
     with gdal.quiet_errors():
-        ds = fgdb_drv.CreateDataSource("tmp/dummy.gdb")
+        ds = fgdb_drv.CreateDataSource(tmp_path / "dummy.gdb")
     assert ds is None
 
-    os.unlink("tmp/dummy.gdb")
 
-    try:
-        shutil.rmtree("/nonexistingdir")
-    except OSError:
-        pass
+def test_ogr_fgdb_13_ter(fgdb_drv, tmp_path):
 
     if sys.platform == "win32":
         name = "/nonexistingdrive:/nonexistingdir/dummy.gdb"
@@ -982,12 +940,12 @@ def test_ogr_fgdb_13(fgdb_drv):
 # Test interleaved opening and closing of databases (#4270)
 
 
-def test_ogr_fgdb_14():
+def test_ogr_fgdb_14(poly_gdb):
 
     for _ in range(3):
-        ds1 = ogr.Open("tmp/test.gdb")
+        ds1 = ogr.Open(poly_gdb)
         assert ds1 is not None
-        ds2 = ogr.Open("tmp/test.gdb")
+        ds2 = ogr.Open(poly_gdb)
         assert ds2 is not None
         ds2 = None
         ds1 = None
@@ -997,14 +955,10 @@ def test_ogr_fgdb_14():
 # Test opening a FGDB with both SRID and LatestSRID set (#5638)
 
 
-def test_ogr_fgdb_15():
+def test_ogr_fgdb_15(tmp_path):
 
-    try:
-        shutil.rmtree("tmp/test3005.gdb")
-    except OSError:
-        pass
-    gdaltest.unzip("tmp", "data/filegdb/test3005.gdb.zip")
-    ds = ogr.Open("tmp/test3005.gdb")
+    gdaltest.unzip(tmp_path, "data/filegdb/test3005.gdb.zip")
+    ds = ogr.Open(tmp_path / "test3005.gdb")
     lyr = ds.GetLayer(0)
     got_wkt = lyr.GetSpatialRef().ExportToWkt()
     sr = osr.SpatialReference()
@@ -1051,14 +1005,9 @@ def test_ogr_fgdb_16(openfilegdb_drv, fgdb_drv):
 # Test not nullable fields
 
 
-def test_ogr_fgdb_17(fgdb_drv):
+def test_ogr_fgdb_17(fgdb_drv, tmp_path):
 
-    try:
-        shutil.rmtree("tmp/test.gdb")
-    except OSError:
-        pass
-
-    ds = fgdb_drv.CreateDataSource("tmp/test.gdb")
+    ds = fgdb_drv.CreateDataSource(tmp_path / "test.gdb")
     sr = osr.SpatialReference()
     sr.ImportFromEPSG(4326)
     lyr = ds.CreateLayer(
@@ -1096,7 +1045,7 @@ def test_ogr_fgdb_17(fgdb_drv):
 
     ds = None
 
-    ds = ogr.Open("tmp/test.gdb", update=1)
+    ds = ogr.Open(tmp_path / "test.gdb", update=1)
     lyr = ds.GetLayerByName("test")
     assert (
         lyr.GetLayerDefn()
@@ -1119,14 +1068,9 @@ def test_ogr_fgdb_17(fgdb_drv):
 # Test default values
 
 
-def test_ogr_fgdb_18(openfilegdb_drv, fgdb_drv):
+def test_ogr_fgdb_18(openfilegdb_drv, fgdb_drv, tmp_path):
 
-    try:
-        shutil.rmtree("tmp/test.gdb")
-    except OSError:
-        pass
-
-    ds = fgdb_drv.CreateDataSource("tmp/test.gdb")
+    ds = fgdb_drv.CreateDataSource(tmp_path / "test.gdb")
     lyr = ds.CreateLayer("test", geom_type=ogr.wkbNone)
 
     field_defn = ogr.FieldDefn("field_string", ogr.OFTString)
@@ -1160,14 +1104,14 @@ def test_ogr_fgdb_18(openfilegdb_drv, fgdb_drv):
 
     if openfilegdb_drv is not None:
         openfilegdb_drv.Register()
-    ogr_fgdb_18_test_results(openfilegdb_drv)
+    ogr_fgdb_18_test_results(openfilegdb_drv, tmp_path / "test.gdb")
     if openfilegdb_drv is not None:
         openfilegdb_drv.Deregister()
 
 
-def ogr_fgdb_18_test_results(openfilegdb_drv):
+def ogr_fgdb_18_test_results(openfilegdb_drv, fname):
 
-    ds = ogr.Open("tmp/test.gdb", update=1)
+    ds = ogr.Open(fname, update=1)
     lyr = ds.GetLayerByName("test")
     assert (
         lyr.GetLayerDefn()
@@ -1242,7 +1186,7 @@ def ogr_fgdb_19_open_update(openfilegdb_drv, fgdb_drv, filename):
     return (bPerLayerCopyingForTransaction, ds)
 
 
-def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
+def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv, test_gdb):
 
     # FIXME likely due to too old FileGDB SDK on those targets
     # fails with ERROR 1: Failed to open Geodatabase (The system cannot find the file specified.)
@@ -1258,24 +1202,15 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
     ):
         pytest.skip()
 
-    try:
-        shutil.rmtree("tmp/test.gdb.ogrtmp")
-    except OSError:
-        pass
-    try:
-        shutil.rmtree("tmp/test.gdb.ogredited")
-    except OSError:
-        pass
-
     # Error case: try in read-only
-    ds = fgdb_drv.Open("tmp/test.gdb")
+    ds = fgdb_drv.Open(test_gdb)
     with gdal.quiet_errors():
         ret = ds.StartTransaction(force=True)
     assert ret != 0
     ds = None
 
     (bPerLayerCopyingForTransaction, ds) = ogr_fgdb_19_open_update(
-        openfilegdb_drv, fgdb_drv, "tmp/test.gdb"
+        openfilegdb_drv, fgdb_drv, test_gdb
     )
 
     assert ds.TestCapability(ogr.ODsCEmulatedTransactions) == 1
@@ -1303,7 +1238,7 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
     assert ret != 0
 
     # Error case: try StartTransaction() with another active connection
-    ds2 = fgdb_drv.Open("tmp/test.gdb", update=1)
+    ds2 = fgdb_drv.Open(test_gdb, update=1)
     with gdal.quiet_errors():
         ret = ds2.StartTransaction(force=True)
     assert ret != 0
@@ -1323,8 +1258,8 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
 
     assert ds.StartTransaction(force=True) == 0
 
-    assert os.path.exists("tmp/test.gdb.ogredited")
-    assert not os.path.exists("tmp/test.gdb.ogrtmp")
+    assert os.path.exists(f"{test_gdb}.ogredited")
+    assert not os.path.exists(f"{test_gdb}.ogrtmp")
 
     ret = lyr.CreateField(ogr.FieldDefn("foobar", ogr.OFTString))
     assert ret == 0
@@ -1382,10 +1317,10 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
     # Test that CommitTransaction() works
     assert ds.CommitTransaction() == 0
 
-    assert not os.path.exists("tmp/test.gdb.ogredited")
-    assert not os.path.exists("tmp/test.gdb.ogrtmp")
+    assert not os.path.exists(f"{test_gdb}.ogredited")
+    assert not os.path.exists(f"{test_gdb}.ogrtmp")
 
-    lst = gdal.ReadDir("tmp/test.gdb")
+    lst = gdal.ReadDir(test_gdb)
     for filename in lst:
         assert ".tmp" not in filename, lst
 
@@ -1428,8 +1363,8 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
 
     assert ds.RollbackTransaction() == 0
 
-    assert not os.path.exists("tmp/test.gdb.ogredited")
-    assert not os.path.exists("tmp/test.gdb.ogrtmp")
+    assert not os.path.exists(f"{test_gdb}.ogredited")
+    assert not os.path.exists(f"{test_gdb}.ogrtmp")
 
     assert lyr.GetFeatureCount() == old_count
 
@@ -1452,7 +1387,7 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
     assert ret != 0
 
     assert ds.GetLayerCount() == 0
-    shutil.rmtree("tmp/test.gdb.ogredited")
+    shutil.rmtree(f"{test_gdb}.ogredited")
 
     # Test method on ghost datasource and layer
     ds.GetName()
@@ -1519,7 +1454,7 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
         # Test an error case where we simulate a failure of destroying a
         # layer destroyed during transaction
         (bPerLayerCopyingForTransaction, ds) = ogr_fgdb_19_open_update(
-            openfilegdb_drv, fgdb_drv, "tmp/test.gdb"
+            openfilegdb_drv, fgdb_drv, test_gdb
         )
 
         layer_tmp = ds.CreateLayer("layer_tmp", geom_type=ogr.wkbNone)
@@ -1535,16 +1470,16 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
 
         ds = None
 
-        shutil.rmtree("tmp/test.gdb.ogredited")
+        shutil.rmtree(f"{test_gdb}.ogredited")
 
-        lst = gdal.ReadDir("tmp/test.gdb")
+        lst = gdal.ReadDir(test_gdb)
         for filename in lst:
             assert ".tmp" not in filename, lst
 
         # Test an error case where we simulate a failure in renaming
         # a file in original directory
         (bPerLayerCopyingForTransaction, ds) = ogr_fgdb_19_open_update(
-            openfilegdb_drv, fgdb_drv, "tmp/test.gdb"
+            openfilegdb_drv, fgdb_drv, test_gdb
         )
 
         for i in range(ds.GetLayerCount()):
@@ -1565,16 +1500,16 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
 
         ds = None
 
-        shutil.rmtree("tmp/test.gdb.ogredited")
+        shutil.rmtree(f"{test_gdb}.ogredited")
 
-        lst = gdal.ReadDir("tmp/test.gdb")
+        lst = gdal.ReadDir(test_gdb)
         for filename in lst:
             assert ".tmp" not in filename, lst
 
         # Test an error case where we simulate a failure in moving
         # a file into original directory
         (bPerLayerCopyingForTransaction, ds) = ogr_fgdb_19_open_update(
-            openfilegdb_drv, fgdb_drv, "tmp/test.gdb"
+            openfilegdb_drv, fgdb_drv, test_gdb
         )
 
         assert ds.StartTransaction(force=True) == 0
@@ -1590,18 +1525,18 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
 
         ds = None
 
-        shutil.rmtree("tmp/test.gdb.ogredited")
+        shutil.rmtree(f"{test_gdb}.ogredited")
 
         # Remove left over .tmp files
-        lst = gdal.ReadDir("tmp/test.gdb")
+        lst = gdal.ReadDir(test_gdb)
         for filename in lst:
             if ".tmp" in filename:
-                os.remove("tmp/test.gdb/" + filename)
+                os.remove(f"{test_gdb}/{filename}")
 
         # Test not critical error in removing a temporary file
         for case in ("CASE4", "CASE5"):
             (bPerLayerCopyingForTransaction, ds) = ogr_fgdb_19_open_update(
-                openfilegdb_drv, fgdb_drv, "tmp/test.gdb"
+                openfilegdb_drv, fgdb_drv, test_gdb
             )
 
             assert ds.StartTransaction(force=True) == 0
@@ -1618,20 +1553,20 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
             ds = None
 
             if case == "CASE4":
-                assert not os.path.exists("tmp/test.gdb.ogredited"), case
+                assert not os.path.exists(f"{test_gdb}.ogredited"), case
             else:
-                shutil.rmtree("tmp/test.gdb.ogredited")
+                shutil.rmtree(f"{test_gdb}.ogredited")
 
             # Remove left over .tmp files
-            lst = gdal.ReadDir("tmp/test.gdb")
+            lst = gdal.ReadDir(test_gdb)
             for filename in lst:
                 if ".tmp" in filename:
-                    os.remove("tmp/test.gdb/" + filename)
+                    os.remove(f"{test_gdb}/{filename}")
 
     else:
         # Test an error case where we simulate a failure of rename from .gdb to .gdb.ogrtmp during commit
         (bPerLayerCopyingForTransaction, ds) = ogr_fgdb_19_open_update(
-            openfilegdb_drv, fgdb_drv, "tmp/test.gdb"
+            openfilegdb_drv, fgdb_drv, test_gdb
         )
         lyr = ds.GetLayer(0)
         lyr_defn = lyr.GetLayerDefn()
@@ -1646,7 +1581,7 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
 
         # Test an error case where we simulate a failure of rename from .gdb.ogredited to .gdb during commit
         (bPerLayerCopyingForTransaction, ds) = ogr_fgdb_19_open_update(
-            openfilegdb_drv, fgdb_drv, "tmp/test.gdb"
+            openfilegdb_drv, fgdb_drv, test_gdb
         )
         lyr = ds.GetLayer(0)
         lyr_defn = lyr.GetLayerDefn()
@@ -1658,11 +1593,11 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
         assert ret != 0
 
         ds = None
-        os.rename("tmp/test.gdb.ogrtmp", "tmp/test.gdb")
+        os.rename(f"{test_gdb}.ogrtmp", test_gdb)
 
         # Test an error case where we simulate a failure of removing from .gdb.ogrtmp during commit
         (bPerLayerCopyingForTransaction, ds) = ogr_fgdb_19_open_update(
-            openfilegdb_drv, fgdb_drv, "tmp/test.gdb"
+            openfilegdb_drv, fgdb_drv, test_gdb
         )
         lyr = ds.GetLayer(0)
         lyr_defn = lyr.GetLayerDefn()
@@ -1674,11 +1609,11 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
         assert ret == 0
 
         ds = None
-        shutil.rmtree("tmp/test.gdb.ogrtmp")
+        shutil.rmtree(f"{test_gdb}.ogrtmp")
 
     # Test an error case where we simulate a failure of reopening the committed DB
     (bPerLayerCopyingForTransaction, ds) = ogr_fgdb_19_open_update(
-        openfilegdb_drv, fgdb_drv, "tmp/test.gdb"
+        openfilegdb_drv, fgdb_drv, test_gdb
     )
     lyr = ds.GetLayer(0)
     lyr_defn = lyr.GetLayerDefn()
@@ -1695,7 +1630,7 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
 
     # Test an error case where we simulate a failure of removing from .gdb.ogredited during rollback
     (bPerLayerCopyingForTransaction, ds) = ogr_fgdb_19_open_update(
-        openfilegdb_drv, fgdb_drv, "tmp/test.gdb"
+        openfilegdb_drv, fgdb_drv, test_gdb
     )
     lyr = ds.GetLayer(0)
     lyr_defn = lyr.GetLayerDefn()
@@ -1707,11 +1642,11 @@ def test_ogr_fgdb_19(openfilegdb_drv, fgdb_drv):
     assert ret != 0
 
     ds = None
-    shutil.rmtree("tmp/test.gdb.ogredited")
+    shutil.rmtree(f"{test_gdb}.ogredited")
 
     # Test an error case where we simulate a failure of reopening the rollbacked DB
     (bPerLayerCopyingForTransaction, ds) = ogr_fgdb_19_open_update(
-        openfilegdb_drv, fgdb_drv, "tmp/test.gdb"
+        openfilegdb_drv, fgdb_drv, test_gdb
     )
     lyr = ds.GetLayer(0)
     lyr_defn = lyr.GetLayerDefn()
@@ -1747,7 +1682,7 @@ def test_ogr_fgdb_19bis(openfilegdb_drv, fgdb_drv):
         pytest.skip()
 
     (bPerLayerCopyingForTransaction, ds) = ogr_fgdb_19_open_update(
-        openfilegdb_drv, fgdb_drv, "tmp/test.gdb"
+        openfilegdb_drv, fgdb_drv, test_gdb
     )
     del ds
     if not bPerLayerCopyingForTransaction:
@@ -1761,7 +1696,7 @@ def test_ogr_fgdb_19bis(openfilegdb_drv, fgdb_drv):
 # Test CreateFeature() with user defined FID
 
 
-def test_ogr_fgdb_20(openfilegdb_drv, fgdb_drv):
+def test_ogr_fgdb_20(openfilegdb_drv, fgdb_drv, tmp_path):
 
     if openfilegdb_drv is None:
         pytest.skip("No OpenFileGDB driver available")
@@ -1776,13 +1711,12 @@ def test_ogr_fgdb_20(openfilegdb_drv, fgdb_drv):
     ):
         pytest.skip()
 
-    if not os.path.exists("tmp/test.gdb"):
-        ds = fgdb_drv.CreateDataSource("tmp/test.gdb")
-        ds = None
+    ds = fgdb_drv.CreateDataSource(tmp_path / "test.gdb")
+    ds = None
 
     # We need the OpenFileGDB driver for CreateFeature() with user defined FID
     openfilegdb_drv.Register()
-    ds = fgdb_drv.Open("tmp/test.gdb", update=1)
+    ds = fgdb_drv.Open(tmp_path / "test.gdb", update=1)
     openfilegdb_drv.Deregister()
     fgdb_drv.Deregister()
     # Force OpenFileGDB first
@@ -1798,14 +1732,14 @@ def test_ogr_fgdb_20(openfilegdb_drv, fgdb_drv):
     lyr.CreateFeature(f)
     ds = None
 
-    ds = openfilegdb_drv.Open("tmp/test.gdb")
+    ds = openfilegdb_drv.Open(tmp_path / "test.gdb")
     lyr = ds.GetLayerByName("test_2147483647")
     f = lyr.GetNextFeature()
     assert f
     assert f.GetFID() == 2147483647
     ds = None
 
-    ds = fgdb_drv.Open("tmp/test.gdb", update=1)
+    ds = fgdb_drv.Open(tmp_path / "test.gdb", update=1)
     lyr = ds.GetLayerByName("test_2147483647")
     # GetNextFeature() is excruciatingly slow on such huge FID with the SDK driver
     f = lyr.GetFeature(2147483647)
@@ -1856,7 +1790,7 @@ def test_ogr_fgdb_20(openfilegdb_drv, fgdb_drv):
     f.SetField("id", 4)
 
     # Cannot call CreateFeature() with a set FID when a dataset is opened more than once
-    ds2 = fgdb_drv.Open("tmp/test.gdb", update=1)
+    ds2 = fgdb_drv.Open(tmp_path / "test.gdb", update=1)
     with gdal.quiet_errors():
         ret = lyr.CreateFeature(f)
     assert ret != 0
@@ -1873,7 +1807,7 @@ def test_ogr_fgdb_20(openfilegdb_drv, fgdb_drv):
 
     #  Cannot open geodatabase at the moment since it is in 'FID hack mode'
     with gdal.quiet_errors():
-        ds2 = fgdb_drv.Open("tmp/test.gdb", update=1)
+        ds2 = fgdb_drv.Open(tmp_path / "test.gdb", update=1)
     assert ds2 is None
     ds2 = None
 
@@ -2081,7 +2015,7 @@ def test_ogr_fgdb_20(openfilegdb_drv, fgdb_drv):
     # Check consistency after re-opening
     gdal.ErrorReset()
     for update in [0, 1]:
-        ds = fgdb_drv.Open("tmp/test.gdb", update=update)
+        ds = fgdb_drv.Open(tmp_path / "test.gdb", update=update)
         lyr = ds.GetLayerByName("ogr_fgdb_20")
         assert lyr.GetFeatureCount() == 10
         lyr.ResetReading()
@@ -2128,7 +2062,7 @@ def test_ogr_fgdb_20(openfilegdb_drv, fgdb_drv):
                 assert f.GetFID() == fid
 
     # Insert new features
-    ds = fgdb_drv.Open("tmp/test.gdb", update=1)
+    ds = fgdb_drv.Open(tmp_path / "test.gdb", update=1)
     lyr = ds.GetLayerByName("ogr_fgdb_20")
     for (fid, fgdb_fid) in [
         (10000000, 2050),
@@ -2154,7 +2088,7 @@ def test_ogr_fgdb_20(openfilegdb_drv, fgdb_drv):
     # Insert a new intermediate FIDs
     for (fid, fgdb_fid) in [(1000000, 10000002), (1000001, 10000002)]:
 
-        ds = fgdb_drv.Open("tmp/test.gdb", update=1)
+        ds = fgdb_drv.Open(tmp_path / "test.gdb", update=1)
         lyr = ds.GetLayerByName("ogr_fgdb_20")
         f = ogr.Feature(lyr.GetLayerDefn())
         f.SetFID(fid)
@@ -2172,7 +2106,7 @@ def test_ogr_fgdb_20(openfilegdb_drv, fgdb_drv):
     # Check consistency after re-opening
     gdal.ErrorReset()
     for update in [0, 1]:
-        ds = fgdb_drv.Open("tmp/test.gdb", update=update)
+        ds = fgdb_drv.Open(tmp_path / "test.gdb", update=update)
         lyr = ds.GetLayerByName("ogr_fgdb_20")
         assert lyr.GetFeatureCount() == 16
         lyr.ResetReading()
@@ -2210,7 +2144,7 @@ def test_ogr_fgdb_20(openfilegdb_drv, fgdb_drv):
         except OSError:
             pass
 
-        ds = fgdb_drv.CreateDataSource("tmp/test2.gdb")
+        ds = fgdb_drv.CreateDataSource(tmp_path / "test2.gdb")
 
         lyr = ds.CreateLayer("foo", geom_type=ogr.wkbNone)
         lyr.CreateField(ogr.FieldDefn("id", ogr.OFTInteger))
@@ -2252,7 +2186,7 @@ def test_ogr_fgdb_20(openfilegdb_drv, fgdb_drv):
 # Test M support
 
 
-def test_ogr_fgdb_21(fgdb_drv, fgdb_sdk_1_4_or_later):
+def test_ogr_fgdb_21(fgdb_drv, fgdb_sdk_1_4_or_later, tmp_path):
     # Fails on MULTIPOINT ZM
     if (
         gdaltest.is_travis_branch("ubuntu_2004")
@@ -2263,12 +2197,7 @@ def test_ogr_fgdb_21(fgdb_drv, fgdb_sdk_1_4_or_later):
     ):
         pytest.skip()
 
-    try:
-        shutil.rmtree("tmp/test.gdb")
-    except OSError:
-        pass
-
-    ds = fgdb_drv.CreateDataSource("tmp/test.gdb")
+    ds = fgdb_drv.CreateDataSource(tmp_path / "test.gdb")
 
     datalist = [
         ["pointm", ogr.wkbPointM, "POINT M (1 2 3)"],
@@ -2334,7 +2263,7 @@ def test_ogr_fgdb_21(fgdb_drv, fgdb_sdk_1_4_or_later):
         lyr.CreateFeature(feat)
 
     ds = None
-    ds = ogr.Open("tmp/test.gdb")
+    ds = ogr.Open(tmp_path / "test.gdb")
 
     for data in datalist:
         lyr = ds.GetLayerByName(data[0])
@@ -2459,15 +2388,11 @@ def test_ogr_fgdb_25():
 
 
 @pytest.mark.require_geos
-def test_ogr_fgdb_weird_winding_order(fgdb_sdk_1_4_or_later):
+def test_ogr_fgdb_weird_winding_order(fgdb_sdk_1_4_or_later, tmp_path):
 
-    try:
-        shutil.rmtree("tmp/roads_clip Drawing.gdb")
-    except OSError:
-        pass
-    gdaltest.unzip("tmp", "data/filegdb/weird_winding_order_fgdb.zip")
+    gdaltest.unzip(tmp_path, "data/filegdb/weird_winding_order_fgdb.zip")
 
-    ds = ogr.Open("tmp/roads_clip Drawing.gdb")
+    ds = ogr.Open(tmp_path / "roads_clip Drawing.gdb")
     lyr = ds.GetLayer(0)
     f = lyr.GetNextFeature()
     g = f.GetGeometryRef()
@@ -2493,17 +2418,12 @@ def test_ogr_fgdb_utc_datetime():
 # Test field alias
 
 
-def test_ogr_fgdb_alias(fgdb_drv):
-
-    try:
-        shutil.rmtree("tmp/alias.gdb")
-    except OSError:
-        pass
+def test_ogr_fgdb_alias(fgdb_drv, tmp_path):
 
     srs = osr.SpatialReference()
     srs.SetFromUserInput("WGS84")
 
-    ds = fgdb_drv.CreateDataSource("tmp/alias.gdb")
+    ds = fgdb_drv.CreateDataSource(tmp_path / "alias.gdb")
     lyr = ds.CreateLayer("test", srs=srs, geom_type=ogr.wkbPoint)
     fld_defn = ogr.FieldDefn("short_name", ogr.OFTInteger)
     fld_defn.SetAlternativeName("longer name")
@@ -2512,16 +2432,11 @@ def test_ogr_fgdb_alias(fgdb_drv):
     lyr.CreateField(fld_defn)
     ds = None
 
-    ds = ogr.Open("tmp/alias.gdb")
+    ds = ogr.Open(tmp_path / "alias.gdb")
     lyr = ds.GetLayer(0)
     lyr_defn = lyr.GetLayerDefn()
     assert lyr_defn.GetFieldDefn(0).GetAlternativeName() == "longer name"
     assert lyr_defn.GetFieldDefn(1).GetAlternativeName() == ""
-
-    try:
-        shutil.rmtree("tmp/alias.gdb")
-    except OSError:
-        pass
 
 
 ###############################################################################
@@ -2529,17 +2444,12 @@ def test_ogr_fgdb_alias(fgdb_drv):
 
 
 @pytest.mark.require_driver("OpenFileGDB")
-def test_ogr_fgdb_alias_with_ampersand(fgdb_drv, openfilegdb_drv):
-
-    try:
-        shutil.rmtree("tmp/alias.gdb")
-    except OSError:
-        pass
+def test_ogr_fgdb_alias_with_ampersand(fgdb_drv, openfilegdb_drv, tmp_path):
 
     srs = osr.SpatialReference()
     srs.SetFromUserInput("WGS84")
 
-    ds = fgdb_drv.CreateDataSource("tmp/alias.gdb")
+    ds = fgdb_drv.CreateDataSource(tmp_path / "alias.gdb")
     lyr = ds.CreateLayer("test", srs=srs, geom_type=ogr.wkbPoint)
     fld_defn = ogr.FieldDefn("short_name", ogr.OFTInteger)
     fld_defn.SetAlternativeName("longer & name")
@@ -2549,17 +2459,12 @@ def test_ogr_fgdb_alias_with_ampersand(fgdb_drv, openfilegdb_drv):
     ds = None
 
     openfilegdb_drv.Register()
-    ds = fgdb_drv.Open("tmp/alias.gdb")
+    ds = fgdb_drv.Open(tmp_path / "alias.gdb")
     openfilegdb_drv.Deregister()
     lyr = ds.GetLayer(0)
     lyr_defn = lyr.GetLayerDefn()
     assert lyr_defn.GetFieldDefn(0).GetAlternativeName() == "longer & name"
     assert lyr_defn.GetFieldDefn(1).GetAlternativeName() == ""
-
-    try:
-        shutil.rmtree("tmp/alias.gdb")
-    except OSError:
-        pass
 
 
 ###############################################################################
@@ -2615,13 +2520,9 @@ def test_ogr_fgdb_read_domains():
 # Test writing field domains
 
 
-def test_ogr_fgdb_write_domains(fgdb_drv):
+def test_ogr_fgdb_write_domains(fgdb_drv, tmp_path):
 
-    out_dir = "tmp/test_ogr_fgdb_write_domains.gdb"
-    try:
-        shutil.rmtree(out_dir)
-    except OSError:
-        pass
+    out_dir = tmp_path / "test_ogr_fgdb_write_domains.gdb"
 
     ds = gdal.VectorTranslate(out_dir, "data/filegdb/Domains.gdb", options="-f FileGDB")
     _check_domains(ds)
@@ -2653,11 +2554,6 @@ def test_ogr_fgdb_write_domains(fgdb_drv):
     domain = ds.GetFieldDomain("SpeedLimit")
     assert domain.GetDescription() == "desc"
     ds = None
-
-    try:
-        shutil.rmtree(out_dir)
-    except OSError:
-        pass
 
 
 ###############################################################################
@@ -2725,17 +2621,12 @@ def test_ogr_fgdb_read_layer_hierarchy():
 
 
 @pytest.mark.parametrize("options", [[], ["FEATURE_DATASET=fd1"]])
-def test_ogr_fgdb_rename_layer(fgdb_drv, options):
-
-    try:
-        shutil.rmtree("tmp/rename.gdb")
-    except OSError:
-        pass
+def test_ogr_fgdb_rename_layer(fgdb_drv, options, tmp_path):
 
     srs4326 = osr.SpatialReference()
     srs4326.ImportFromEPSG(4326)
 
-    ds = fgdb_drv.CreateDataSource("tmp/rename.gdb")
+    ds = fgdb_drv.CreateDataSource(tmp_path / "rename.gdb")
     ds.CreateLayer("other_layer", geom_type=ogr.wkbNone)
     lyr = ds.CreateLayer("foo", geom_type=ogr.wkbPoint, srs=srs4326, options=options)
     assert lyr.TestCapability(ogr.OLCRename) == 1
@@ -2764,7 +2655,7 @@ def test_ogr_fgdb_rename_layer(fgdb_drv, options):
 
     ds = None
 
-    ds = ogr.Open("tmp/rename.gdb")
+    ds = ogr.Open(tmp_path / "rename.gdb")
     lyr = ds.GetLayerByName("baz")
     assert lyr is not None, [
         ds.GetLayer(i).GetName() for i in range(ds.GetLayerCount())
@@ -2775,11 +2666,6 @@ def test_ogr_fgdb_rename_layer(fgdb_drv, options):
     assert f.GetGeometryRef() is not None
 
     ds = None
-
-    try:
-        shutil.rmtree("tmp/rename.gdb")
-    except OSError:
-        pass
 
 
 ###############################################################################
@@ -2841,9 +2727,11 @@ def test_ogr_filegdb_shape_length_shape_area_as_default_in_field_defn(fgdb_drv):
 # Test explicit CREATE_SHAPE_AREA_AND_LENGTH_FIELDS=YES option
 
 
-def test_ogr_filegdb_CREATE_SHAPE_AREA_AND_LENGTH_FIELDS_explicit(fgdb_drv):
+def test_ogr_filegdb_CREATE_SHAPE_AREA_AND_LENGTH_FIELDS_explicit(fgdb_drv, tmp_path):
 
-    dirname = "tmp/test_ogr_filegdb_CREATE_SHAPE_AREA_AND_LENGTH_FIELDS_explicit.gdb"
+    dirname = (
+        tmp_path / "test_ogr_filegdb_CREATE_SHAPE_AREA_AND_LENGTH_FIELDS_explicit.gdb"
+    )
     ds = fgdb_drv.CreateDataSource(dirname)
 
     srs = osr.SpatialReference()
@@ -2906,19 +2794,16 @@ def test_ogr_filegdb_CREATE_SHAPE_AREA_AND_LENGTH_FIELDS_explicit(fgdb_drv):
 
     ds = None
 
-    try:
-        shutil.rmtree(dirname)
-    except OSError:
-        pass
-
 
 ###############################################################################
 # Test explicit CREATE_SHAPE_AREA_AND_LENGTH_FIELDS=YES option
 
 
-def test_ogr_filegdb_CREATE_SHAPE_AREA_AND_LENGTH_FIELDS_implicit(fgdb_drv):
+def test_ogr_filegdb_CREATE_SHAPE_AREA_AND_LENGTH_FIELDS_implicit(fgdb_drv, tmp_path):
 
-    dirname = "tmp/test_ogr_filegdb_CREATE_SHAPE_AREA_AND_LENGTH_FIELDS_implicit.gdb"
+    dirname = (
+        tmp_path / "test_ogr_filegdb_CREATE_SHAPE_AREA_AND_LENGTH_FIELDS_implicit.gdb"
+    )
     gdal.VectorTranslate(
         dirname,
         "data/filegdb/filegdb_polygonzm_m_not_closing_with_curves.gdb",
@@ -2938,11 +2823,6 @@ def test_ogr_filegdb_CREATE_SHAPE_AREA_AND_LENGTH_FIELDS_implicit(fgdb_drv):
     )
 
     ds = None
-
-    try:
-        shutil.rmtree(dirname)
-    except OSError:
-        pass
 
 
 @pytest.mark.require_driver("OpenFileGDB")
@@ -3085,14 +2965,11 @@ def test_ogr_filegdb_read_relationships(openfilegdb_drv, fgdb_drv):
         (ogr.wkbMultiPoint, "POINT(0 0)"),
     ],
 )
-def test_ogr_filegdb_incompatible_geometry_types(fgdb_drv, layer_geom_type, wkt):
+def test_ogr_filegdb_incompatible_geometry_types(
+    fgdb_drv, tmp_path, layer_geom_type, wkt
+):
 
-    dirname = "tmp/test_ogr_filegdb_incompatible_geometry_types.gdb"
-
-    try:
-        shutil.rmtree(dirname)
-    except OSError:
-        pass
+    dirname = tmp_path / "test_ogr_filegdb_incompatible_geometry_types.gdb"
 
     ds = fgdb_drv.CreateDataSource(dirname)
 
@@ -3105,11 +2982,6 @@ def test_ogr_filegdb_incompatible_geometry_types(fgdb_drv, layer_geom_type, wkt)
     with gdal.quiet_errors():
         assert lyr.CreateFeature(f) == ogr.OGRERR_FAILURE
     ds = None
-
-    try:
-        shutil.rmtree(dirname)
-    except OSError:
-        pass
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_mongodbv3.py
+++ b/autotest/ogr/ogr_mongodbv3.py
@@ -38,6 +38,7 @@ import pytest
 
 from osgeo import gdal, ogr, osr
 
+pytestmark = pytest.mark.require_driver("MongoDBv3")
 
 ###############################################################################
 @pytest.fixture(autouse=True, scope="module")

--- a/autotest/ogr/ogr_mssqlspatial.py
+++ b/autotest/ogr/ogr_mssqlspatial.py
@@ -49,63 +49,74 @@ def module_disable_exceptions():
 # Open Database.
 
 
-def test_ogr_mssqlspatial_1():
+@pytest.fixture(scope="module")
+def mssql_ds():
 
-    gdaltest.mssqlspatial_ds = None
-
-    gdaltest.mssqlspatial_dsname = gdal.GetConfigOption(
-        "OGR_MSSQL_CONNECTION_STRING",
+    val = gdal.GetConfigOption("OGR_MSSQL_CONNECTION_STRING", None)
+    if val is None:
         # localhost doesn't work under chroot
-        "MSSQL:server=127.0.0.1;database=TestDB;driver=ODBC Driver 17 for SQL Server;UID=SA;PWD=DummyPassw0rd",
-    )
-    gdaltest.mssqlspatial_ds = ogr.Open(gdaltest.mssqlspatial_dsname, update=1)
-    if gdaltest.mssqlspatial_ds is None:
-        pytest.skip()
+        dsname = "MSSQL:server=127.0.0.1;database=TestDB;driver=ODBC Driver 17 for SQL Server;UID=SA;PWD=DummyPassw0rd"
+    else:
+        dsname = val
 
+    ds = ogr.Open(dsname, update=1)
+
+    if ds is None:
+        if val is None:
+            pytest.skip(
+                f"OGR_MSSSQL_CONNECTION_STRING not specified; MS SQL is not available using default connection string {dsname}"
+            )
+        else:
+            pytest.skip(
+                f"MS SQL is not available using supplied OGR_MSSQL_CONNECTION_STRING {dsname}"
+            )
+
+    return ds
+
+
+@pytest.fixture(scope="module")
+def mssql_version(mssql_ds):
     # Fetch and store the major-version number of the SQL Server engine in use
-    sql_lyr = gdaltest.mssqlspatial_ds.ExecuteSQL(
-        "SELECT SERVERPROPERTY('ProductVersion')"
-    )
-    feat = sql_lyr.GetNextFeature()
-    gdaltest.mssqlspatial_version = feat.GetFieldAsString(0)
-    gdaltest.mssqlspatial_ds.ReleaseResultSet(sql_lyr)
+    with mssql_ds.ExecuteSQL("SELECT SERVERPROPERTY('ProductVersion')") as sql_lyr:
+        feat = sql_lyr.GetNextFeature()
 
-    gdaltest.mssqlspatial_version_major = -1
-    if "." in gdaltest.mssqlspatial_version:
-        version_major_str = gdaltest.mssqlspatial_version[
-            0 : gdaltest.mssqlspatial_version.find(".")
-        ]
+    version_str = feat.GetFieldAsString(0)
+
+    version_major = -1
+    if "." in version_str:
+        version_major_str = version_str[0 : version_str.find(".")]
         if version_major_str.isdigit():
-            gdaltest.mssqlspatial_version_major = int(version_major_str)
+            version_major = int(version_major_str)
 
+    return version_major
+
+
+@pytest.fixture(scope="module")
+def mssql_has_z_m(mssql_version):
     # Check whether the database server provides support for Z and M values,
     # available since SQL Server 2012
-    gdaltest.mssqlspatial_has_z_m = gdaltest.mssqlspatial_version_major >= 11
+
+    return mssql_version >= 11
 
 
 ###############################################################################
 # Create table from data/poly.shp
 
 
-def test_ogr_mssqlspatial_2():
-
-    if gdaltest.mssqlspatial_ds is None:
-        pytest.skip()
+@pytest.fixture()
+def tpoly(mssql_ds):
 
     shp_ds = ogr.Open("data/poly.shp")
-    gdaltest.shp_ds = shp_ds
     shp_lyr = shp_ds.GetLayer(0)
 
     ######################################################
     # Create Layer
-    gdaltest.mssqlspatial_lyr = gdaltest.mssqlspatial_ds.CreateLayer(
-        "tpoly", srs=shp_lyr.GetSpatialRef()
-    )
+    sql_lyr = mssql_ds.CreateLayer("tpoly", srs=shp_lyr.GetSpatialRef())
 
     ######################################################
     # Setup Schema
     ogrtest.quick_create_layer_def(
-        gdaltest.mssqlspatial_lyr,
+        sql_lyr,
         [
             ("AREA", ogr.OFTReal),
             ("EAS_ID", ogr.OFTInteger),
@@ -118,58 +129,60 @@ def test_ogr_mssqlspatial_2():
     ######################################################
     # Copy in poly.shp
 
-    dst_feat = ogr.Feature(feature_def=gdaltest.mssqlspatial_lyr.GetLayerDefn())
+    dst_feat = ogr.Feature(feature_def=sql_lyr.GetLayerDefn())
 
     feat = shp_lyr.GetNextFeature()
-    gdaltest.poly_feat = []
 
     while feat is not None:
 
-        gdaltest.poly_feat.append(feat)
-
         dst_feat.SetFrom(feat)
         dst_feat.SetField("INT64", 1234567890123)
-        gdaltest.mssqlspatial_lyr.CreateFeature(dst_feat)
+        sql_lyr.CreateFeature(dst_feat)
 
         feat = shp_lyr.GetNextFeature()
 
     dst_feat = None
 
     assert (
-        gdaltest.mssqlspatial_lyr.GetFeatureCount() == shp_lyr.GetFeatureCount()
+        sql_lyr.GetFeatureCount() == shp_lyr.GetFeatureCount()
     ), "not matching feature count"
 
-    got_srs = gdaltest.mssqlspatial_lyr.GetSpatialRef()
+    got_srs = sql_lyr.GetSpatialRef()
     expected_srs = shp_lyr.GetSpatialRef()
     assert got_srs.GetAuthorityCode(None) == expected_srs.GetAuthorityCode(
         None
     ), "not matching spatial ref"
+
+    yield
+
+    mssql_ds.ExecuteSQL("DELLAYER:tpoly")
 
 
 ###############################################################################
 # Verify that stuff we just wrote is still OK.
 
 
-def test_ogr_mssqlspatial_3():
-    if gdaltest.mssqlspatial_ds is None:
-        pytest.skip()
+@pytest.mark.usefixtures("tpoly")
+def test_ogr_mssqlspatial_3(mssql_ds, poly_feat):
 
-    assert gdaltest.mssqlspatial_lyr.GetGeometryColumn() == "ogr_geometry"
+    mssqlspatial_lyr = mssql_ds.GetLayerByName("tpoly")
 
-    assert gdaltest.mssqlspatial_lyr.GetFeatureCount() == 10
+    assert mssqlspatial_lyr.GetGeometryColumn() == "ogr_geometry"
+
+    assert mssqlspatial_lyr.GetFeatureCount() == 10
 
     expect = [168, 169, 166, 158, 165]
 
-    with ogrtest.attribute_filter(gdaltest.mssqlspatial_lyr, "eas_id < 170"):
-        ogrtest.check_features_against_list(gdaltest.mssqlspatial_lyr, "eas_id", expect)
+    with ogrtest.attribute_filter(mssqlspatial_lyr, "eas_id < 170"):
+        ogrtest.check_features_against_list(mssqlspatial_lyr, "eas_id", expect)
 
-        assert gdaltest.mssqlspatial_lyr.GetFeatureCount() == 5
+        assert mssqlspatial_lyr.GetFeatureCount() == 5
 
-    gdaltest.mssqlspatial_lyr.ResetReading()
+    mssqlspatial_lyr.ResetReading()
 
-    for i in range(len(gdaltest.poly_feat)):
-        orig_feat = gdaltest.poly_feat[i]
-        read_feat = gdaltest.mssqlspatial_lyr.GetNextFeature()
+    for i in range(len(poly_feat)):
+        orig_feat = poly_feat[i]
+        read_feat = mssqlspatial_lyr.GetNextFeature()
 
         ogrtest.check_feature_geometry(
             read_feat, orig_feat.GetGeometryRef(), max_error=0.001
@@ -185,24 +198,22 @@ def test_ogr_mssqlspatial_3():
         read_feat = None
         orig_feat = None
 
-    gdaltest.poly_feat = None
-    gdaltest.shp_ds = None
-
 
 ###############################################################################
 # Write more features with a bunch of different geometries, and verify the
 # geometries are still OK.
 
 
-def test_ogr_mssqlspatial_4():
-    if gdaltest.mssqlspatial_ds is None:
-        pytest.skip()
+@pytest.mark.usefixtures("tpoly")
+def test_ogr_mssqlspatial_4(mssql_ds, mssql_has_z_m):
 
-    dst_feat = ogr.Feature(feature_def=gdaltest.mssqlspatial_lyr.GetLayerDefn())
+    mssqlspatial_lyr = mssql_ds.GetLayer("tpoly")
+
+    dst_feat = ogr.Feature(feature_def=mssqlspatial_lyr.GetLayerDefn())
     wkt_list = ["10", "2", "1", "4", "5", "6"]
 
     # If the database engine supports 3D features, include one in the tests
-    if gdaltest.mssqlspatial_has_z_m:
+    if mssql_has_z_m:
         wkt_list.append("3d_1")
 
     use_bcp = "BCP" in gdal.GetDriverByName("MSSQLSpatial").GetMetadataItem(
@@ -224,7 +235,7 @@ def test_ogr_mssqlspatial_4():
         dst_feat.SetGeometryDirectly(geom)
         dst_feat.SetField("PRFEDEA", item)
         dst_feat.SetFID(-1)
-        assert gdaltest.mssqlspatial_lyr.CreateFeature(dst_feat) == ogr.OGRERR_NONE, (
+        assert mssqlspatial_lyr.CreateFeature(dst_feat) == ogr.OGRERR_NONE, (
             "CreateFeature failed creating feature "
             + 'from file "'
             + wkt_filename
@@ -243,25 +254,23 @@ def test_ogr_mssqlspatial_4():
         ######################################################################
         # Read back the feature and get the geometry.
 
-        gdaltest.mssqlspatial_lyr.SetAttributeFilter("PRFEDEA = '%s'" % item)
-        feat_read = gdaltest.mssqlspatial_lyr.GetNextFeature()
+        mssqlspatial_lyr.SetAttributeFilter("PRFEDEA = '%s'" % item)
+        feat_read = mssqlspatial_lyr.GetNextFeature()
 
         ogrtest.check_feature_geometry(feat_read, geom)
 
         feat_read.Destroy()
 
     dst_feat.Destroy()
-    gdaltest.mssqlspatial_lyr.ResetReading()  # to close implicit transaction
+    mssqlspatial_lyr.ResetReading()  # to close implicit transaction
 
 
 ###############################################################################
 # Run test_ogrsf
 
 
-def test_ogr_mssqlspatial_test_ogrsf():
-
-    if gdaltest.mssqlspatial_ds is None:
-        pytest.skip()
+@pytest.mark.usefixtures("tpoly")
+def test_ogr_mssqlspatial_test_ogrsf(mssql_ds):
 
     import test_cli_utilities
 
@@ -271,7 +280,7 @@ def test_ogr_mssqlspatial_test_ogrsf():
     ret = gdaltest.runexternal(
         test_cli_utilities.get_test_ogrsf_path()
         + " -ro '"
-        + gdaltest.mssqlspatial_dsname
+        + mssql_ds.GetDescription()
         + "' tpoly"
     )
 
@@ -283,9 +292,7 @@ def test_ogr_mssqlspatial_test_ogrsf():
 # column but is not registered in the "geometry_columns" table.
 
 
-def test_ogr_mssqlspatial_create_feature_in_unregistered_table():
-    if gdaltest.mssqlspatial_ds is None:
-        pytest.skip()
+def test_ogr_mssqlspatial_create_feature_in_unregistered_table(mssql_ds):
 
     # Create a feature that specifies a spatial-reference system
     spatial_reference = osr.SpatialReference()
@@ -298,7 +305,7 @@ def test_ogr_mssqlspatial_create_feature_in_unregistered_table():
 
     # Create a table that includes a geometry column but is not registered in
     # the "geometry_columns" table
-    gdaltest.mssqlspatial_ds.ExecuteSQL(
+    mssql_ds.ExecuteSQL(
         "CREATE TABLE Unregistered"
         + "("
         + "ObjectID int IDENTITY(1,1) NOT NULL PRIMARY KEY,"
@@ -309,7 +316,7 @@ def test_ogr_mssqlspatial_create_feature_in_unregistered_table():
     # Create a new MSSQLSpatial data source, one that will find the table just
     # created and make it available via GetLayerByName()
     with gdaltest.config_option("MSSQLSPATIAL_USE_GEOMETRY_COLUMNS", "NO"):
-        test_ds = ogr.Open(gdaltest.mssqlspatial_dsname, update=1)
+        test_ds = ogr.Open(mssql_ds.GetDescription(), update=1)
 
     assert test_ds is not None, "cannot open data source"
 
@@ -344,214 +351,207 @@ def test_ogr_mssqlspatial_create_feature_in_unregistered_table():
         )
     ), "created-feature SRS does not match original"
 
-    # Clean up
-    test_ds.Destroy()
-    feature.Destroy()
-
 
 ###############################################################################
 # Test all datatype support
 
 
-def test_ogr_mssqlspatial_datatypes():
-    if gdaltest.mssqlspatial_ds is None:
-        pytest.skip()
+def test_ogr_mssqlspatial_datatypes(mssql_ds):
 
-    lyr = gdaltest.mssqlspatial_ds.CreateLayer("test_ogr_mssql_datatypes")
+    try:
+        lyr = mssql_ds.CreateLayer("test_ogr_mssql_datatypes")
 
-    fd = ogr.FieldDefn("int32", ogr.OFTInteger)
-    assert lyr.CreateField(fd) == 0
+        fd = ogr.FieldDefn("int32", ogr.OFTInteger)
+        assert lyr.CreateField(fd) == 0
 
-    fd = ogr.FieldDefn("int16", ogr.OFTInteger)
-    fd.SetSubType(ogr.OFSTInt16)
-    assert lyr.CreateField(fd) == 0
+        fd = ogr.FieldDefn("int16", ogr.OFTInteger)
+        fd.SetSubType(ogr.OFSTInt16)
+        assert lyr.CreateField(fd) == 0
 
-    fd = ogr.FieldDefn("int64", ogr.OFTInteger64)
-    assert lyr.CreateField(fd) == 0
+        fd = ogr.FieldDefn("int64", ogr.OFTInteger64)
+        assert lyr.CreateField(fd) == 0
 
-    fd = ogr.FieldDefn("float32", ogr.OFTReal)
-    fd.SetSubType(ogr.OFSTFloat32)
-    assert lyr.CreateField(fd) == 0
+        fd = ogr.FieldDefn("float32", ogr.OFTReal)
+        fd.SetSubType(ogr.OFSTFloat32)
+        assert lyr.CreateField(fd) == 0
 
-    fd = ogr.FieldDefn("float64", ogr.OFTReal)
-    assert lyr.CreateField(fd) == 0
+        fd = ogr.FieldDefn("float64", ogr.OFTReal)
+        assert lyr.CreateField(fd) == 0
 
-    fd = ogr.FieldDefn("numeric", ogr.OFTReal)
-    fd.SetWidth(12)
-    fd.SetPrecision(6)
-    assert lyr.CreateField(fd) == 0
+        fd = ogr.FieldDefn("numeric", ogr.OFTReal)
+        fd.SetWidth(12)
+        fd.SetPrecision(6)
+        assert lyr.CreateField(fd) == 0
 
-    fd = ogr.FieldDefn("numeric_width_9_prec_0_from_int", ogr.OFTInteger)
-    fd.SetWidth(9)
-    fd.SetPrecision(0)
-    assert lyr.CreateField(fd) == 0
+        fd = ogr.FieldDefn("numeric_width_9_prec_0_from_int", ogr.OFTInteger)
+        fd.SetWidth(9)
+        fd.SetPrecision(0)
+        assert lyr.CreateField(fd) == 0
 
-    fd = ogr.FieldDefn("numeric_width_9_prec_0_from_real", ogr.OFTReal)
-    fd.SetWidth(9)
-    fd.SetPrecision(0)
-    assert lyr.CreateField(fd) == 0
+        fd = ogr.FieldDefn("numeric_width_9_prec_0_from_real", ogr.OFTReal)
+        fd.SetWidth(9)
+        fd.SetPrecision(0)
+        assert lyr.CreateField(fd) == 0
 
-    fd = ogr.FieldDefn("numeric_width_18_prec_0", ogr.OFTInteger64)
-    fd.SetWidth(18)
-    fd.SetPrecision(0)
-    assert lyr.CreateField(fd) == 0
+        fd = ogr.FieldDefn("numeric_width_18_prec_0", ogr.OFTInteger64)
+        fd.SetWidth(18)
+        fd.SetPrecision(0)
+        assert lyr.CreateField(fd) == 0
 
-    fd = ogr.FieldDefn("string", ogr.OFTString)
-    assert lyr.CreateField(fd) == 0
+        fd = ogr.FieldDefn("string", ogr.OFTString)
+        assert lyr.CreateField(fd) == 0
 
-    fd = ogr.FieldDefn("string_limited", ogr.OFTString)
-    fd.SetWidth(5)
-    assert lyr.CreateField(fd) == 0
+        fd = ogr.FieldDefn("string_limited", ogr.OFTString)
+        fd.SetWidth(5)
+        assert lyr.CreateField(fd) == 0
 
-    fd = ogr.FieldDefn("date", ogr.OFTDate)
-    assert lyr.CreateField(fd) == 0
+        fd = ogr.FieldDefn("date", ogr.OFTDate)
+        assert lyr.CreateField(fd) == 0
 
-    fd = ogr.FieldDefn("time", ogr.OFTTime)
-    assert lyr.CreateField(fd) == 0
+        fd = ogr.FieldDefn("time", ogr.OFTTime)
+        assert lyr.CreateField(fd) == 0
 
-    fd = ogr.FieldDefn("datetime", ogr.OFTDateTime)
-    assert lyr.CreateField(fd) == 0
+        fd = ogr.FieldDefn("datetime", ogr.OFTDateTime)
+        assert lyr.CreateField(fd) == 0
 
-    fd = ogr.FieldDefn("uid", ogr.OFTString)
-    fd.SetSubType(ogr.OFSTUUID)
-    assert lyr.CreateField(fd) == 0
+        fd = ogr.FieldDefn("uid", ogr.OFTString)
+        fd.SetSubType(ogr.OFSTUUID)
+        assert lyr.CreateField(fd) == 0
 
-    fd = ogr.FieldDefn("binary", ogr.OFTBinary)
-    assert lyr.CreateField(fd) == 0
+        fd = ogr.FieldDefn("binary", ogr.OFTBinary)
+        assert lyr.CreateField(fd) == 0
 
-    lyr.StartTransaction()
-    f = ogr.Feature(lyr.GetLayerDefn())
-    f["int32"] = (1 << 31) - 1
-    f["int16"] = (1 << 15) - 1
-    f["int64"] = (1 << 63) - 1
-    f["float32"] = 1.25
-    f["float64"] = 1.25123456789
-    f["numeric"] = 123456.789012
-    f["numeric_width_9_prec_0_from_int"] = 123456789
-    f["numeric_width_9_prec_0_from_real"] = 123456789
-    f["numeric_width_18_prec_0"] = 12345678912345678
-    f["string"] = "unlimited string"
-    f["string_limited"] = "abcd\u00e9"
-    f["date"] = "2021/12/11"
-    f["time"] = "12:34:56"
-    f["datetime"] = "2021/12/11 12:34:56"
-    f["uid"] = "6F9619FF-8B86-D011-B42D-00C04FC964FF"
-    f["binary"] = b"\x01\x23\x46\x57\x89\xAB\xCD\xEF"
-    lyr.CreateFeature(f)
-    lyr.CommitTransaction()
+        lyr.StartTransaction()
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f["int32"] = (1 << 31) - 1
+        f["int16"] = (1 << 15) - 1
+        f["int64"] = (1 << 63) - 1
+        f["float32"] = 1.25
+        f["float64"] = 1.25123456789
+        f["numeric"] = 123456.789012
+        f["numeric_width_9_prec_0_from_int"] = 123456789
+        f["numeric_width_9_prec_0_from_real"] = 123456789
+        f["numeric_width_18_prec_0"] = 12345678912345678
+        f["string"] = "unlimited string"
+        f["string_limited"] = "abcd\u00e9"
+        f["date"] = "2021/12/11"
+        f["time"] = "12:34:56"
+        f["datetime"] = "2021/12/11 12:34:56"
+        f["uid"] = "6F9619FF-8B86-D011-B42D-00C04FC964FF"
+        f["binary"] = b"\x01\x23\x46\x57\x89\xAB\xCD\xEF"
+        lyr.CreateFeature(f)
+        lyr.CommitTransaction()
 
-    test_ds = ogr.Open(gdaltest.mssqlspatial_dsname, update=0)
-    lyr = test_ds.GetLayer("test_ogr_mssql_datatypes")
-    lyr_defn = lyr.GetLayerDefn()
+        test_ds = ogr.Open(mssql_ds.GetDescription(), update=0)
+        lyr = test_ds.GetLayer("test_ogr_mssql_datatypes")
+        lyr_defn = lyr.GetLayerDefn()
 
-    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("int32"))
-    assert fd.GetType() == ogr.OFTInteger
-    assert fd.GetSubType() == ogr.OFSTNone
-    assert fd.GetWidth() == 0
+        fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("int32"))
+        assert fd.GetType() == ogr.OFTInteger
+        assert fd.GetSubType() == ogr.OFSTNone
+        assert fd.GetWidth() == 0
 
-    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("int16"))
-    assert fd.GetType() == ogr.OFTInteger
-    assert fd.GetSubType() == ogr.OFSTInt16
-    assert fd.GetWidth() == 0
+        fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("int16"))
+        assert fd.GetType() == ogr.OFTInteger
+        assert fd.GetSubType() == ogr.OFSTInt16
+        assert fd.GetWidth() == 0
 
-    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("int64"))
-    assert fd.GetType() == ogr.OFTInteger64
-    assert fd.GetSubType() == ogr.OFSTNone
-    assert fd.GetWidth() == 0
+        fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("int64"))
+        assert fd.GetType() == ogr.OFTInteger64
+        assert fd.GetSubType() == ogr.OFSTNone
+        assert fd.GetWidth() == 0
 
-    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("float32"))
-    assert fd.GetType() == ogr.OFTReal
-    assert fd.GetSubType() == ogr.OFSTFloat32
-    assert fd.GetWidth() == 0
+        fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("float32"))
+        assert fd.GetType() == ogr.OFTReal
+        assert fd.GetSubType() == ogr.OFSTFloat32
+        assert fd.GetWidth() == 0
 
-    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("float64"))
-    assert fd.GetType() == ogr.OFTReal
-    assert fd.GetSubType() == ogr.OFSTNone
-    assert fd.GetWidth() == 0
+        fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("float64"))
+        assert fd.GetType() == ogr.OFTReal
+        assert fd.GetSubType() == ogr.OFSTNone
+        assert fd.GetWidth() == 0
 
-    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("numeric"))
-    assert fd.GetType() == ogr.OFTReal
-    assert fd.GetSubType() == ogr.OFSTNone
-    assert fd.GetWidth() == 12
-    assert fd.GetPrecision() == 6
+        fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("numeric"))
+        assert fd.GetType() == ogr.OFTReal
+        assert fd.GetSubType() == ogr.OFSTNone
+        assert fd.GetWidth() == 12
+        assert fd.GetPrecision() == 6
 
-    fd = lyr_defn.GetFieldDefn(
-        lyr_defn.GetFieldIndex("numeric_width_9_prec_0_from_int")
-    )
-    assert fd.GetType() == ogr.OFTInteger
-    assert fd.GetSubType() == ogr.OFSTNone
-    assert fd.GetWidth() == 9
-    assert fd.GetPrecision() == 0
+        fd = lyr_defn.GetFieldDefn(
+            lyr_defn.GetFieldIndex("numeric_width_9_prec_0_from_int")
+        )
+        assert fd.GetType() == ogr.OFTInteger
+        assert fd.GetSubType() == ogr.OFSTNone
+        assert fd.GetWidth() == 9
+        assert fd.GetPrecision() == 0
 
-    fd = lyr_defn.GetFieldDefn(
-        lyr_defn.GetFieldIndex("numeric_width_9_prec_0_from_real")
-    )
-    assert fd.GetType() == ogr.OFTInteger
-    assert fd.GetSubType() == ogr.OFSTNone
-    assert fd.GetWidth() == 9
-    assert fd.GetPrecision() == 0
+        fd = lyr_defn.GetFieldDefn(
+            lyr_defn.GetFieldIndex("numeric_width_9_prec_0_from_real")
+        )
+        assert fd.GetType() == ogr.OFTInteger
+        assert fd.GetSubType() == ogr.OFSTNone
+        assert fd.GetWidth() == 9
+        assert fd.GetPrecision() == 0
 
-    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("numeric_width_18_prec_0"))
-    assert fd.GetType() == ogr.OFTInteger64
-    assert fd.GetSubType() == ogr.OFSTNone
-    assert fd.GetWidth() == 18
-    assert fd.GetPrecision() == 0
+        fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("numeric_width_18_prec_0"))
+        assert fd.GetType() == ogr.OFTInteger64
+        assert fd.GetSubType() == ogr.OFSTNone
+        assert fd.GetWidth() == 18
+        assert fd.GetPrecision() == 0
 
-    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("string"))
-    assert fd.GetType() == ogr.OFTString
-    assert fd.GetWidth() == 0
+        fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("string"))
+        assert fd.GetType() == ogr.OFTString
+        assert fd.GetWidth() == 0
 
-    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("string_limited"))
-    assert fd.GetType() == ogr.OFTString
-    assert fd.GetWidth() == 5
+        fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("string_limited"))
+        assert fd.GetType() == ogr.OFTString
+        assert fd.GetWidth() == 5
 
-    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("date"))
-    assert fd.GetType() == ogr.OFTDate
+        fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("date"))
+        assert fd.GetType() == ogr.OFTDate
 
-    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("time"))
-    # We get a string currently
-    # assert fd.GetType() == ogr.OFTTime
+        fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("time"))
+        # We get a string currently
+        # assert fd.GetType() == ogr.OFTTime
 
-    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("datetime"))
-    assert fd.GetType() == ogr.OFTDateTime
+        fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("datetime"))
+        assert fd.GetType() == ogr.OFTDateTime
 
-    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("uid"))
-    assert fd.GetType() == ogr.OFTString
-    assert fd.GetSubType() == ogr.OFSTUUID
+        fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("uid"))
+        assert fd.GetType() == ogr.OFTString
+        assert fd.GetSubType() == ogr.OFSTUUID
 
-    fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("binary"))
-    assert fd.GetType() == ogr.OFTBinary
+        fd = lyr_defn.GetFieldDefn(lyr_defn.GetFieldIndex("binary"))
+        assert fd.GetType() == ogr.OFTBinary
 
-    f = lyr.GetNextFeature()
-    assert f["int32"] == (1 << 31) - 1
-    assert f["int16"] == (1 << 15) - 1
-    assert f["int64"] == (1 << 63) - 1
-    assert f["float32"] == 1.25
-    assert f["float64"] == 1.25123456789
-    assert f["numeric"] == 123456.789012
-    assert f["numeric_width_9_prec_0_from_int"] == 123456789
-    assert f["numeric_width_9_prec_0_from_real"] == 123456789
-    assert f["numeric_width_18_prec_0"] == 12345678912345678
-    assert f["string"] == "unlimited string"
-    assert f["string_limited"] == "abcd\u00e9"
-    assert f["date"] == "2021/12/11"
-    assert f["time"] == "12:34:56" or f["time"].startswith("12:34:56.0")
-    assert f["datetime"] == "2021/12/11 12:34:56"
-    assert f["uid"] == "6F9619FF-8B86-D011-B42D-00C04FC964FF"
-    assert f["binary"] == "0123465789ABCDEF"
+        f = lyr.GetNextFeature()
+        assert f["int32"] == (1 << 31) - 1
+        assert f["int16"] == (1 << 15) - 1
+        assert f["int64"] == (1 << 63) - 1
+        assert f["float32"] == 1.25
+        assert f["float64"] == 1.25123456789
+        assert f["numeric"] == 123456.789012
+        assert f["numeric_width_9_prec_0_from_int"] == 123456789
+        assert f["numeric_width_9_prec_0_from_real"] == 123456789
+        assert f["numeric_width_18_prec_0"] == 12345678912345678
+        assert f["string"] == "unlimited string"
+        assert f["string_limited"] == "abcd\u00e9"
+        assert f["date"] == "2021/12/11"
+        assert f["time"] == "12:34:56" or f["time"].startswith("12:34:56.0")
+        assert f["datetime"] == "2021/12/11 12:34:56"
+        assert f["uid"] == "6F9619FF-8B86-D011-B42D-00C04FC964FF"
+        assert f["binary"] == "0123465789ABCDEF"
 
-    test_ds.Destroy()
+    finally:
+        mssql_ds.ExecuteSQL("DELLAYER:test_ogr_mssql_datatypes")
 
 
 ###############################################################################
 #
 
 
-def test_ogr_mssqlspatial_bulk_insert():
+def test_ogr_mssqlspatial_bulk_insert(mssql_ds):
     """Test issue GH https://github.com/OSGeo/gdal/issues/7787"""
-
-    if gdaltest.mssqlspatial_ds is None:
-        pytest.skip()
 
     use_bcp = "BCP" in gdal.GetDriverByName("MSSQLSpatial").GetMetadataItem(
         gdal.DMD_LONGNAME
@@ -560,7 +560,7 @@ def test_ogr_mssqlspatial_bulk_insert():
     if not use_bcp:
         pytest.skip("BCP not available")
 
-    with gdaltest.config_option("MSSQLSPATIAL_BCP_SIZE", "2"):
+    with gdal.config_option("MSSQLSPATIAL_BCP_SIZE", "2"):
 
         source_ds = gdal.OpenEx("data/poly.shp", gdal.OF_VECTOR)
 
@@ -569,7 +569,7 @@ def test_ogr_mssqlspatial_bulk_insert():
         try:
             with gdal.quiet_errors():
                 ds = gdal.VectorTranslate(
-                    gdaltest.mssqlspatial_dsname,
+                    mssql_ds.GetDescription(),
                     "data/poly.shp",
                     layerCreationOptions=[
                         "OVERWRITE=YES",
@@ -581,18 +581,15 @@ def test_ogr_mssqlspatial_bulk_insert():
                 assert lyr.GetFeatureCount() == 10
                 del lyr
         finally:
-            gdaltest.mssqlspatial_ds.ExecuteSQL("DROP TABLE poly")
+            mssql_ds.ExecuteSQL("DROP TABLE poly")
 
 
 ###############################################################################
 #
 
 
-def test_ogr_mssqlspatial_geography_polygon_vertex_order():
+def test_ogr_mssqlspatial_geography_polygon_vertex_order(mssql_ds):
     """Test issue GH https://github.com/OSGeo/gdal/issues/1128"""
-
-    if gdaltest.mssqlspatial_ds is None:
-        pytest.skip()
 
     source_ds = gdal.OpenEx("data/shp/testpoly.shp", gdal.OF_VECTOR)
 
@@ -601,7 +598,7 @@ def test_ogr_mssqlspatial_geography_polygon_vertex_order():
     try:
         with gdal.quiet_errors():
             ds = gdal.VectorTranslate(
-                gdaltest.mssqlspatial_dsname,
+                mssql_ds.GetDescription(),
                 "data/shp/testpoly.shp",
                 options="-nln poly_vertex_order -s_srs EPSG:32632 -t_srs EPSG:4326 -lco OVERWRITE=YES -lco GEOM_TYPE=GEOGRAPHY",
             )
@@ -628,7 +625,7 @@ def test_ogr_mssqlspatial_geography_polygon_vertex_order():
 
             del lyr
     finally:
-        gdaltest.mssqlspatial_ds.ExecuteSQL("DROP TABLE poly_vertex_order")
+        mssql_ds.ExecuteSQL("DROP TABLE poly_vertex_order")
 
 
 ###############################################################################
@@ -636,11 +633,8 @@ def test_ogr_mssqlspatial_geography_polygon_vertex_order():
 
 
 @pytest.mark.require_driver("GPKG")
-def test_binary_field_bcp():
+def test_binary_field_bcp(mssql_ds):
     """Test for issue GH #3040 MSSQLSpatial: Cannot write binary field with MSSQLSPATIAL_USE_BCP = TRUE"""
-
-    if gdaltest.mssqlspatial_ds is None:
-        pytest.skip()
 
     filename = "/vsimem/test_binary_field.gpkg"
     ds = ogr.GetDriverByName("GPKG").CreateDataSource(filename)
@@ -677,11 +671,11 @@ def test_binary_field_bcp():
     f["intfield"] = 4
     src_lyr.CreateFeature(f)
 
-    with gdaltest.config_option("MSSQLSPATIAL_USE_BCP", "TRUE"):
+    with gdal.config_option("MSSQLSPATIAL_USE_BCP", "TRUE"):
 
         try:
             res_ds = gdal.VectorTranslate(
-                gdaltest.mssqlspatial_dsname,
+                mssql_ds.GetDescription(),
                 filename,
                 options=["-nln", "test_binary_field", "-lco", "OVERWRITE=YES"],
             )
@@ -714,8 +708,8 @@ def test_binary_field_bcp():
             assert f.GetFieldAsInteger("intfield") == 4
 
         finally:
-            gdaltest.mssqlspatial_ds.ExecuteSQL("DROP TABLE test_binary_field")
-            gdaltest.mssqlspatial_ds.ExecuteSQL(
+            mssql_ds.ExecuteSQL("DROP TABLE test_binary_field")
+            mssql_ds.ExecuteSQL(
                 "DELETE from geometry_columns WHERE f_table_name = 'test_binary_field'"
             )
 
@@ -724,19 +718,17 @@ def test_binary_field_bcp():
 #
 
 
-def test_geometry_column_identification():
+@pytest.mark.usefixtures("tpoly")
+def test_geometry_column_identification(mssql_ds):
     """Test for issue GH #1190
     SQL Server data source: geometry column not identified by ogr2ogr"""
 
-    if gdaltest.mssqlspatial_ds is None:
-        pytest.skip("MSSQLSpatial driver not available")
-
-    gdaltest.mssqlspatial_ds.ExecuteSQL(
+    mssql_ds.ExecuteSQL(
         "SELECT *, ogr_geometry.STCentroid() AS shape INTO dbo.poly_shape FROM dbo.tpoly"
     )
 
     try:
-        ds = ogr.Open(gdaltest.mssqlspatial_dsname)
+        ds = ogr.Open(mssql_ds.GetDescription())
         with ds.ExecuteSQL("SELECT eas_id, shape FROM poly_shape") as lyr:
             f = lyr.GetFeature(1)
         geom = f.GetGeometryRef()
@@ -745,23 +737,4 @@ def test_geometry_column_identification():
         assert f.GetFieldCount() == 1
 
     finally:
-        gdaltest.mssqlspatial_ds.ExecuteSQL("DROP TABLE poly_shape")
-
-
-###############################################################################
-#
-
-
-def test_ogr_mssqlspatial_cleanup():
-
-    if gdaltest.mssqlspatial_ds is None:
-        pytest.skip()
-
-    gdaltest.mssqlspatial_ds = None
-
-    gdaltest.mssqlspatial_ds = ogr.Open(gdaltest.mssqlspatial_dsname, update=1)
-    gdaltest.mssqlspatial_ds.ExecuteSQL("DROP TABLE Unregistered")
-    gdaltest.mssqlspatial_ds.ExecuteSQL("DROP TABLE tpoly")
-    gdaltest.mssqlspatial_ds.ExecuteSQL("DROP TABLE test_ogr_mssql_datatypes")
-
-    gdaltest.mssqlspatial_ds = None
+        mssql_ds.ExecuteSQL("DROP TABLE poly_shape")

--- a/autotest/ogr/ogr_mvt.py
+++ b/autotest/ogr/ogr_mvt.py
@@ -700,26 +700,7 @@ def test_ogr_mvt_errors():
 
 
 @pytest.mark.require_curl()
-def test_ogr_mvt_http_start():
-
-    gdaltest.webserver_process = None
-    gdaltest.webserver_port = 0
-
-    (gdaltest.webserver_process, gdaltest.webserver_port) = webserver.launch(
-        handler=webserver.DispatcherHttpHandler
-    )
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
-
-
-###############################################################################
-
-
-@pytest.mark.require_curl()
-def test_ogr_mvt_http():
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
+def test_ogr_mvt_http(server):
 
     handler = webserver.SequentialHandler()
     handler.add(
@@ -744,7 +725,7 @@ def test_ogr_mvt_http():
         open("data/mvt/linestring/0/0/0.pbf", "rb").read(),
     )
     with webserver.install_http_handler(handler):
-        ds = ogr.Open("MVT:http://127.0.0.1:%d/linestring/0" % gdaltest.webserver_port)
+        ds = ogr.Open("MVT:http://127.0.0.1:%d/linestring/0" % server.port)
         lyr = ds.GetLayer(0)
         f = lyr.GetNextFeature()
         assert f is not None
@@ -756,7 +737,7 @@ def test_ogr_mvt_http():
     handler.add("GET", "/linestring/0/0/0.pbf", 404, {})
     with webserver.install_http_handler(handler):
         with pytest.raises(Exception):
-            ogr.Open("MVT:http://127.0.0.1:%d/linestring/0" % gdaltest.webserver_port)
+            ogr.Open("MVT:http://127.0.0.1:%d/linestring/0" % server.port)
 
     # No metadata file, but tiles
     handler = webserver.SequentialHandler()
@@ -777,7 +758,7 @@ def test_ogr_mvt_http():
         open("data/mvt/linestring/0/0/0.pbf", "rb").read(),
     )
     with webserver.install_http_handler(handler):
-        ds = ogr.Open("MVT:http://127.0.0.1:%d/linestring/0" % gdaltest.webserver_port)
+        ds = ogr.Open("MVT:http://127.0.0.1:%d/linestring/0" % server.port)
         lyr = ds.GetLayer(0)
         f = lyr.GetNextFeature()
         assert f is not None
@@ -794,7 +775,7 @@ def test_ogr_mvt_http():
     handler.add("GET", "/linestring/0/0/0.pbf", 404, {})
     handler.add("GET", "/linestring/0/0/0.pbf", 404, {})
     with webserver.install_http_handler(handler):
-        ds = ogr.Open("MVT:http://127.0.0.1:%d/linestring/0" % gdaltest.webserver_port)
+        ds = ogr.Open("MVT:http://127.0.0.1:%d/linestring/0" % server.port)
         lyr = ds.GetLayer(0)
         with pytest.raises(Exception):
             lyr.GetNextFeature()
@@ -812,7 +793,7 @@ def test_ogr_mvt_http():
     handler.add("GET", "/linestring/0/0/0.pbf", 404, {})
     handler.add("GET", "/linestring/0/0/0.pbf", 404, {})
     with webserver.install_http_handler(handler):
-        ds = ogr.Open("MVT:http://127.0.0.1:%d/linestring/0" % gdaltest.webserver_port)
+        ds = ogr.Open("MVT:http://127.0.0.1:%d/linestring/0" % server.port)
         lyr = ds.GetLayer(0)
         with pytest.raises(Exception):
             lyr.GetNextFeature()
@@ -827,24 +808,10 @@ def test_ogr_mvt_http():
         open("data/mvt/linestring/0/0/0.pbf", "rb").read(),
     )
     with webserver.install_http_handler(handler):
-        ds = ogr.Open(
-            "MVT:http://127.0.0.1:%d/linestring/0/0/0.pbf" % gdaltest.webserver_port
-        )
+        ds = ogr.Open("MVT:http://127.0.0.1:%d/linestring/0/0/0.pbf" % server.port)
         lyr = ds.GetLayer(0)
         f = lyr.GetNextFeature()
         assert f is not None
-
-
-###############################################################################
-
-
-@pytest.mark.require_curl()
-def test_ogr_mvt_http_stop():
-
-    if gdaltest.webserver_port == 0:
-        pytest.skip()
-
-    webserver.server_stop(gdaltest.webserver_process, gdaltest.webserver_port)
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_refcount.py
+++ b/autotest/ogr/ogr_refcount.py
@@ -49,15 +49,15 @@ def test_ogr_refcount_1():
     #    gdaltest.post_reason( 'Initial Open DS count is not zero!' )
     #    return 'failed'
 
-    gdaltest.ds_1 = ogr.OpenShared("data/idlink.dbf")
-    gdaltest.ds_2 = ogr.OpenShared("data/poly.shp")
+    ds_1 = ogr.OpenShared("data/idlink.dbf")
+    ds_2 = ogr.OpenShared("data/poly.shp")
 
     # if ogr.GetOpenDSCount() != 2:
     #    gdaltest.post_reason( 'Open DS count not 2 after shared opens.' )
     #    return 'failed'
 
-    assert gdaltest.ds_1.GetRefCount() == 1
-    assert gdaltest.ds_2.GetRefCount() == 1
+    assert ds_1.GetRefCount() == 1
+    assert ds_2.GetRefCount() == 1
 
 
 ###############################################################################
@@ -66,15 +66,17 @@ def test_ogr_refcount_1():
 
 def test_ogr_refcount_2():
 
+    ds_1 = ogr.OpenShared("data/idlink.dbf")
     ds_3 = ogr.OpenShared("data/idlink.dbf")
+
+    assert ds_1 is not None
+    assert ds_3 is not None
 
     # if ogr.GetOpenDSCount() != 2:
     #    gdaltest.post_reason( 'Open DS count not 2 after third open.' )
     #    return 'failed'
 
     assert ds_3.GetRefCount() == 2, "Refcount not 2 after reopened."
-
-    gdaltest.ds_3 = ds_3
 
 
 ###############################################################################
@@ -83,11 +85,15 @@ def test_ogr_refcount_2():
 
 def test_ogr_refcount_3():
 
-    gdaltest.ds_3.Release()
+    ds_1 = ogr.OpenShared("data/idlink.dbf")
+    ds_3 = ogr.OpenShared("data/idlink.dbf")
 
-    assert gdaltest.ds_1.GetRefCount() == 1
+    assert ds_1 is not None
+    assert ds_3 is not None
 
-    gdaltest.ds_1.Release()
+    ds_3.Release()
+
+    assert ds_1.GetRefCount() == 1
 
 
 ###############################################################################
@@ -96,12 +102,11 @@ def test_ogr_refcount_3():
 
 def test_ogr_refcount_4():
 
+    ds_1 = ogr.OpenShared("data/idlink.dbf")
+    ds_2 = ogr.OpenShared("data/poly.shp")
+
+    assert ds_1 is not None
+    assert ds_2 is not None
+
     with gdal.quiet_errors():
         ogr.GetOpenDS(0)
-
-
-###############################################################################
-
-
-def test_ogr_refcount_cleanup():
-    gdaltest.ds_2.Release()

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -109,6 +109,10 @@ class GDALTest(object):
         self.driver = None
         self.drivername = drivername
         self.filename = filename
+
+        if isinstance(self.filename, os.PathLike):
+            self.filename = str(self.filename)
+
         self.filename_absolute = filename_absolute
         self.band = band
         self.chksum = chksum


### PR DESCRIPTION
## What does this PR do?

Addresses remaining issues so that tests within individual test files exercised by the Ubuntu 20.04 CI configuration can run in random order, except for `gnm` and `utilities/gdal2tiles`.

This does _not_ mean that we can run `pytest --random-order autotest` because there are a handful of cases of inter-module interference -- where running `test_driver2.py` before `test_driver1.py` causes something in `test_driver1.py` to fail. (Examples in https://github.com/dbaston/gdal/actions/runs/6714087188/job/18246767524#step:16:3630)

## What are related issues/pull requests?

#4407

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
