### PR TITLE
Documentation: Update mamba installation instructions in download.rst

### DIFF
--- a/doc/source/download.rst
+++ b/doc/source/download.rst
@@ -315,8 +315,8 @@ GDAL master Conda builds
 GDAL master builds are available in the `gdal-master <https://anaconda.org/gdal-master/gdal>`__
 channel. They are based on dependencies from the ``conda-forge`` channel.
 
-First, install mamba into the ``base`` environment, then create a dedicated ``gdal_master_env`` 
-environment, activate the dedicated ``gdal_master_env`` environment.
+First, install mamba into the ``base`` environment, create a dedicated ``gdal_master_env`` 
+environment, and then activate the dedicated ``gdal_master_env`` environment.
 
 ::
 

--- a/doc/source/download.rst
+++ b/doc/source/download.rst
@@ -321,9 +321,9 @@ the ``mamba`` package manager.
 ::
 
     conda update -n base -c conda-forge conda
+    conda install -n base --override-channels -c conda-forge mamba 'python_abi=*=*cp*'
     conda create --name gdal_master_env
     conda activate gdal_master_env
-    conda install -c conda-forge mamba
 
 Then install GDAL from the ``gdal-master`` channel:
 

--- a/doc/source/download.rst
+++ b/doc/source/download.rst
@@ -315,8 +315,8 @@ GDAL master Conda builds
 GDAL master builds are available in the `gdal-master <https://anaconda.org/gdal-master/gdal>`__
 channel. They are based on dependencies from the ``conda-forge`` channel.
 
-First create a dedicated ``gdal_master_env`` environment, activate it and install
-the ``mamba`` package manager.
+First, install mamba into the ``base`` environment, then create a dedicated ``gdal_master_env`` 
+environment, activate the dedicated ``gdal_master_env`` environment.
 
 ::
 


### PR DESCRIPTION
## What does this PR do?

- Makes sure mamba is installed in base conda environment
- Uses installation instructions based on their current stable version

Updates the mamba installation instructions according to [mamba's documentation for their stable release](https://mamba.readthedocs.io/en/stable/mamba-installation.html#existing-conda-install-not-recommended). I understand the caveat to the download instructions is that they are assuming that a user already has conda installed instead of starting from a fresh environment.

## What are related issues/pull requests?

No issues have been opened for this. Would you like for me to include/add a section for if a user is wanting to install using `mamba` from an environment where conda isn't already installed? If so, I'd probably write up instructions for their [Miniforge3](https://github.com/conda-forge/miniforge#miniforge3) installer.
