### PR TITLE
.github/workflows/benchmarks/test.sh: attempt to avoid random error '…

### DIFF
--- a/.github/workflows/benchmarks/test.sh
+++ b/.github/workflows/benchmarks/test.sh
@@ -2,7 +2,7 @@
 
 set -eu
 
-BENCHMARK_STORAGE="file:///tmp"
+BENCHMARK_STORAGE="file://${PWD}/benchmark_results"
 
 # Use time.process_time for more reliability on VMs
 BENCHMARK_OPTIONS=(


### PR DESCRIPTION
…/tmp' does not start with '/home/runner/work/gdal/gdal/build-benchmarks'
