### PR TITLE
Fix arrow repo URLs to reference main branch instead of master

### DIFF
--- a/doc/source/development/rfc/rfc86_column_oriented_api.rst
+++ b/doc/source/development/rfc/rfc86_column_oriented_api.rst
@@ -96,7 +96,7 @@ over individual features, one iterates over a batch of several features at
 once.
 
 The ArrowArrayStream, ArrowSchema, ArrowArray structures are defined in a ogr_recordbatch.h
-public header file, directly derived from https://github.com/apache/arrow/blob/master/cpp/src/arrow/c/abi.h
+public header file, directly derived from https://github.com/apache/arrow/blob/main/cpp/src/arrow/c/abi.h
 to get API/ABI compatibility with Apache Arrow C++. This header file must be
 explicitly included when the related array batch API is used.
 

--- a/doc/source/tutorials/vector_api_tut.rst
+++ b/doc/source/tutorials/vector_api_tut.rst
@@ -793,7 +793,7 @@ once.
 
 The ArrowArrayStream, ArrowSchema, ArrowArray structures are defined in a
 ogr_recordbatch.h public header file, directly derived from
-https://github.com/apache/arrow/blob/master/cpp/src/arrow/c/abi.h
+https://github.com/apache/arrow/blob/main/cpp/src/arrow/c/abi.h
 to get API/ABI compatibility with Apache Arrow C++. This header file must be
 explicitly included when the related array batch API is used.
 

--- a/ogr/ogr_recordbatch.h
+++ b/ogr/ogr_recordbatch.h
@@ -16,7 +16,7 @@
 // under the License.
 
 // This file is an extract
-// https://github.com/apache/arrow/blob/master/cpp/src/arrow/c/abi.h WARNING: DO
+// https://github.com/apache/arrow/blob/main/cpp/src/arrow/c/abi.h WARNING: DO
 // NOT MODIFY the content as it would break interoperability !
 
 #pragma once


### PR DESCRIPTION
## What does this PR do?

Fixes URLs in the docs to the Apache Arrow GitHub repository that reference the master branch instead of the current main branch. The master branch was renamed to main in 2022 and, while GitHub helpfully redirects outdated links, I think it would be good for these docs to reference the new branch.

## What are related issues/pull requests?

None.