### PR TITLE
Doc: Add ReadTheDocs configuration [WIP]

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,38 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "mambaforge-4.10"
+
+  jobs:
+    post_checkout:
+      - (git --no-pager log --pretty="tformat:%s -- %b" -1 | grep -viqP "skip ci|ci skip") || exit 183
+    pre_build:
+      - ./doc/rtd/pre_build.sh
+
+  apt_packages:
+    - cmake
+    - doxygen
+    - g++
+    - libproj-dev
+    - python3
+    - python3-pip
+    - swig
+
+
+formats:
+  - htmlzip
+  - pdf
+
+conda:
+  environment: doc/environment.yml
+
+sphinx:
+  configuration: doc/source/conf.py
+  fail_on_warning: false

--- a/doc/environment.yml
+++ b/doc/environment.yml
@@ -1,55 +1,15 @@
 name: gdal-docs
 channels:
   - conda-forge
-  - defaults
 dependencies:
-  - bzip2=1.0.6=h1de35cc_1002
-  - ca-certificates=2019.3.9=hecc5488_0
-  - certifi=2019.3.9=py37_0
-  - libcxx=8.0.0=2
-  - libcxxabi=8.0.0=2
-  - libffi=3.2.1=h6de7cb9_1006
-  - ncurses=6.1=h0a44026_1002
-  - openssl=1.1.1b=h01d97ff_2
-  - pip=19.1=py37_0
-  - python=3.7.3=h0d93f26_0
-  - readline=7.0=hcfe32e1_1001
-  - setuptools=41.0.1=py37_0
-  - sqlite=3.26.0=h1765d9f_1001
-  - tk=8.6.9=ha441bb4_1001
-  - wheel=0.33.4=py37_0
-  - xz=5.2.4=h1de35cc_1001
-  - zlib=1.2.11=h1de35cc_1004
+  - pip
   - pip:
-    - alabaster==0.7.12
-    - babel==2.6.0
-    - beautifulsoup4==4.7.1
-    - breathe==4.13.0.post0
-    - bs4==0.0.1
-    - chardet==3.0.4
-    - docutils==0.14
-    - exhale==0.2.2
-    - idna==2.8
-    - imagesize==1.1.0
-    - jinja2==2.10.1
-    - lxml==4.3.3
-    - markupsafe==1.1.1
-    - packaging==19.0
-    - pygments==2.4.0
-    - pyparsing==2.4.0
-    - pytz==2019.1
-    - requests==2.21.0
-    - six==1.12.0
-    - snowballstemmer==1.2.1
-    - soupsieve==1.9.1
-    - sphinx==2.0.1
-    - sphinx-rtd-theme==0.4.3
-    - sphinxcontrib-applehelp==1.0.1
-    - sphinxcontrib-devhelp==1.0.1
-    - sphinxcontrib-htmlhelp==1.0.2
-    - sphinxcontrib-jsmath==1.0.1
-    - sphinxcontrib-qthelp==1.0.2
-    - sphinxcontrib-serializinghtml==1.1.3
-    - urllib3==1.24.3
-prefix: /Users/hobu/miniconda3/envs/gdal-docs
-
+    - breathe
+    - recommonmark
+    - sphinx
+    - sphinx-bootstrap-theme
+    - sphinx-markdown-tables
+    - sphinx-rtd-theme
+    - sphinxcontrib-bibtex
+    - sphinxcontrib-jquery
+    - sphinxcontrib-spelling

--- a/doc/rtd/pre_build.sh
+++ b/doc/rtd/pre_build.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+set -e
+
+mkdir build
+cd build
+
+cmake \
+    -DCMAKE_BUILD_TYPE=Debug \
+    -DCMAKE_INSTALL_PREFIX=$HOME/.local \
+    -DGDAL_BUILD_OPTIONAL_DRIVERS=OFF \
+    -DOGR_BUILD_OPTIONAL_DRIVERS=OFF \
+    -DBUILD_PYTHON_BINDINGS=ON \
+    -DBUILD_TESTING=OFF ..
+
+make -j$(nproc)
+make install
+
+cd ../doc
+make doxygen


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Adds a ReadTheDocs configuration as a means of providing versioned documentation. Heavily copied from recent work in PROJ (https://github.com/OSGeo/PROJ/pull/3538).

Since this was configured in my fork I'm surprised that this became publicly available at https://gdal.readthedocs.io/en/latest/, but there it is. I can delete this and turn it over to OSGeo/gdal if the project wants to go that way.

## What are related issues/pull requests?

#2519

## Tasklist

 - [ ] Review
 - [ ] Remove GitHub Actions doc builder
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
