### PR TITLE
Include <cstdint> for uint64_t.

### DIFF
--- a/port/cpl_json.h
+++ b/port/cpl_json.h
@@ -31,6 +31,7 @@
 #include "cpl_progress.h"
 #include "cpl_string.h"
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
## What does this PR do?

Fix build failure of reverse dependencies with GCC 13.

Per: http://gcc.gnu.org/gcc-13/porting_to.html

## What are related issues/pull requests?

 * gdal-grass:
   https://github.com/OSGeo/gdal-grass/issues/32
 * osmcoastline:
   https://github.com/osmcode/osmcoastline/issues/46
 * pktools:
   https://savannah.nongnu.org/bugs/index.php?64873
 * r-cran-sf:
   https://github.com/r-spatial/sf/issues/2252

## Environment

Provide environment details, if relevant:

* OS: Debian unstable
* Compiler: GCC 13
