### PR TITLE
[Backport release/3.8] Include <cstdint> for uint64_t.

### DIFF
--- a/port/cpl_json.h
+++ b/port/cpl_json.h
@@ -31,6 +31,7 @@
 #include "cpl_progress.h"
 #include "cpl_string.h"
 
+#include <cstdint>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
Backport #8682
 **Authored by:** @sebastic