### PR TITLE
Add workflow that signals rasterio

### DIFF
--- a/.github/workflows/rasterio_dispatch.yml
+++ b/.github/workflows/rasterio_dispatch.yml
@@ -1,0 +1,21 @@
+name: Rasterio dispatch 
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  dispatch:
+    name: Rasterio Dispatch
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: POST
+        run: |
+          curl -L \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.RASTERIO_REPO_DISPATCH_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/rasterio/rasterio/dispatches \
+            -d '{"event_type":"upstream_tag","client_payload":{"tag":"${{ github.ref }}"}}'


### PR DESCRIPTION
So that rasterio will immediately build against GDAL release candidates and provide some feedback. Work on the rasterio side is here https://github.com/rasterio/rasterio/pull/2967.

I'm not sure how this can be generalized to other projects. I suspect QGIS is doing something smarter and better, but I felt like it was good to learn about using these GitHub ways.

cc @rouault @dbaston @nyalldawson 

Resolves #8688.