### PR TITLE
[Backport release/3.8] gdalwarp -of COG: use target SRS from -co TILING_SCHEME when specified (fixes #8684)

### DIFF
--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -2696,6 +2696,55 @@ def test_gdalwarp_lib_to_cog_reprojection_options(tmp_vsimem):
 
 
 ###############################################################################
+# Test warping of single source to COG with reprojection options and -te
+
+
+def test_gdalwarp_lib_to_cog_reprojection_options_and_te(tmp_vsimem):
+
+    tmpfilename = tmp_vsimem / "cog.tif"
+    ds = gdal.Warp(
+        tmpfilename,
+        "../gcore/data/byte.tif",
+        options="-f COG -co TILING_SCHEME=GoogleMapsCompatible -te -13110479.091 4011415.244 -13090911.212 4030983.124",
+    )
+    assert ds.GetRasterBand(1).Checksum() != 0
+    ds = None
+    gdal.Unlink(tmpfilename)
+
+
+###############################################################################
+# Test warping of single source to COG with reprojection options and conflicting
+# -t_srs
+
+
+def test_gdalwarp_lib_to_cog_reprojection_options_and_conflicting_t_srs(tmp_vsimem):
+
+    tmpfilename = tmp_vsimem / "cog.tif"
+    with pytest.raises(Exception):
+        gdal.Warp(
+            tmpfilename,
+            "../gcore/data/byte.tif",
+            options="-f COG -co TILING_SCHEME=GoogleMapsCompatible -t_srs EPSG:4326",
+        )
+
+
+###############################################################################
+# Test warping of single source to COG with reprojection options and conflicting
+# -t_srs
+
+
+def test_gdalwarp_lib_to_cog_reprojection_options_te_and_conflicting_t_srs(tmp_vsimem):
+
+    tmpfilename = tmp_vsimem / "cog.tif"
+    with pytest.raises(Exception):
+        gdal.Warp(
+            tmpfilename,
+            "../gcore/data/byte.tif",
+            options="-f COG -co TILING_SCHEME=GoogleMapsCompatible -te -13110479.091 4011415.244 -13090911.212 4030983.124 -t_srs EPSG:4326",
+        )
+
+
+###############################################################################
 # Test warping of multiple source, compatible of BuildVRT mosaicing, to COG
 
 

--- a/frmts/gtiff/cogdriver.h
+++ b/frmts/gtiff/cogdriver.h
@@ -34,6 +34,11 @@
 
 bool COGHasWarpingOptions(CSLConstList papszOptions);
 
+bool COGGetTargetSRS(const char *const *papszOptions, CPLString &osTargetSRS);
+
+std::string COGGetResampling(GDALDataset *poSrcDS,
+                             const char *const *papszOptions);
+
 bool COGGetWarpingCharacteristics(GDALDataset *poSrcDS,
                                   const char *const *papszOptions,
                                   CPLString &osResampling,


### PR DESCRIPTION
Backport #8686
 **Authored by:** @rouault