### PR TITLE
[Backport release/3.8] CMake: add gdalinfo bash-completion file to list of installed files

### DIFF
--- a/scripts/install_bash_completions.cmake.in
+++ b/scripts/install_bash_completions.cmake.in
@@ -43,6 +43,7 @@ set(INSTALL_DIR "$ENV{DESTDIR}${CMAKE_INSTALL_PREFIX}/@BASH_COMPLETIONS_DIR@")
 file(MAKE_DIRECTORY "${INSTALL_DIR}")
 message(STATUS "Installing ${INSTALL_DIR}/gdalinfo")
 configure_file("@CMAKE_CURRENT_SOURCE_DIR@/gdal-bash-completion.sh" "${INSTALL_DIR}/gdalinfo" COPYONLY)
+file(APPEND @PROJECT_BINARY_DIR@/install_manifest_extra.txt "${INSTALL_DIR}/gdalinfo\n")
 
 foreach (program IN LISTS PROGRAMS)
   message(STATUS "Installing ${INSTALL_DIR}/${program}")


### PR DESCRIPTION
Backport #8699
 **Authored by:** @PPazderski