### PR TITLE
[Backport release/3.8] PMTiles: avoid undefined-shift when zoom level is too big (fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=64234)

### DIFF
--- a/ogr/ogrsf_frmts/pmtiles/ogrpmtilesdataset.cpp
+++ b/ogr/ogrsf_frmts/pmtiles/ogrpmtilesdataset.cpp
@@ -287,6 +287,20 @@ bool OGRPMTilesDataset::Open(GDALOpenInfo *poOpenInfo)
 
     m_nMinZoomLevel = m_sHeader.min_zoom;
     m_nMaxZoomLevel = m_sHeader.max_zoom;
+    if (m_nMinZoomLevel > m_nMaxZoomLevel)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "min_zoom(=%d) > max_zoom(=%d)",
+                 m_nMinZoomLevel, m_nMaxZoomLevel);
+        return false;
+    }
+    if (m_nMinZoomLevel > 30)
+    {
+        CPLError(CE_Warning, CPLE_AppDefined,
+                 "Clamping min_zoom (and max_zoom) from %d to %d",
+                 m_nMinZoomLevel, 30);
+        m_nMinZoomLevel = 30;
+        m_nMaxZoomLevel = 30;
+    }
 
     if (bAcceptAnyTileType)
         return true;


### PR DESCRIPTION
Backport #8738
 **Authored by:** @rouault