### PR TITLE
OGRLayer: Have CreateField take const OGRFieldDefn* argument

### DIFF
--- a/MIGRATION_GUIDE.TXT
+++ b/MIGRATION_GUIDE.TXT
@@ -1,3 +1,13 @@
+MIGRATION GUIDE FROM GDAL 3.8 to GDAL 3.9
+-----------------------------------------
+
+- Out-of-tree vector drivers:
+  * OGRLayer::CreateField() now takes a const OGRFieldDefn* instead of a
+    OGRFieldDefn*.
+  * OGRLayer::CreateGeomField() now takes a const OGRGeomFieldDefn* instead of
+    a OGRGeomFieldDefn*.
+
+
 MIGRATION GUIDE FROM GDAL 3.7 to GDAL 3.8
 -----------------------------------------
 

--- a/frmts/fits/fitsdataset.cpp
+++ b/frmts/fits/fitsdataset.cpp
@@ -219,7 +219,7 @@ class FITSLayer final : public OGRLayer,
     int TestCapability(const char *) override;
     OGRFeature *GetFeature(GIntBig) override;
     GIntBig GetFeatureCount(int bForce) override;
-    OGRErr CreateField(OGRFieldDefn *poField, int bApproxOK) override;
+    OGRErr CreateField(const OGRFieldDefn *poField, int bApproxOK) override;
     OGRErr ICreateFeature(OGRFeature *poFeature) override;
     OGRErr ISetFeature(OGRFeature *poFeature) override;
     OGRErr DeleteFeature(GIntBig nFID) override;
@@ -1261,7 +1261,7 @@ void FITSLayer::RunDeferredFieldCreation(const OGRFeature *poFeature)
 /*                           CreateField()                              */
 /************************************************************************/
 
-OGRErr FITSLayer::CreateField(OGRFieldDefn *poField, int /* bApproxOK */)
+OGRErr FITSLayer::CreateField(const OGRFieldDefn *poField, int /* bApproxOK */)
 {
     if (!TestCapability(OLCCreateField))
         return OGRERR_FAILURE;

--- a/frmts/netcdf/netcdfdataset.h
+++ b/frmts/netcdf/netcdfdataset.h
@@ -1174,7 +1174,7 @@ class netCDFLayer final : public OGRLayer
     virtual OGRFeatureDefn *GetLayerDefn() override;
 
     virtual OGRErr ICreateFeature(OGRFeature *poFeature) override;
-    virtual OGRErr CreateField(OGRFieldDefn *poFieldDefn,
+    virtual OGRErr CreateField(const OGRFieldDefn *poFieldDefn,
                                int bApproxOK) override;
 };
 

--- a/frmts/netcdf/netcdflayer.cpp
+++ b/frmts/netcdf/netcdflayer.cpp
@@ -2433,7 +2433,8 @@ bool netCDFLayer::AddField(int nVarID)
 /*                             CreateField()                            */
 /************************************************************************/
 
-OGRErr netCDFLayer::CreateField(OGRFieldDefn *poFieldDefn, int /* bApproxOK */)
+OGRErr netCDFLayer::CreateField(const OGRFieldDefn *poFieldDefn,
+                                int /* bApproxOK */)
 {
     int nSecDimId = -1;
     int nVarID = -1;

--- a/frmts/null/nulldataset.cpp
+++ b/frmts/null/nulldataset.cpp
@@ -124,7 +124,7 @@ class GDALNullLayer final : public OGRLayer
         return OGRERR_NONE;
     }
 
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
 };
 
@@ -371,7 +371,7 @@ int GDALNullLayer::TestCapability(const char *pszCap)
 /*                             CreateField()                            */
 /************************************************************************/
 
-OGRErr GDALNullLayer::CreateField(OGRFieldDefn *poField, int)
+OGRErr GDALNullLayer::CreateField(const OGRFieldDefn *poField, int)
 {
     poFeatureDefn->AddFieldDefn(poField);
     return OGRERR_NONE;

--- a/frmts/pcidsk/ogrpcidsklayer.cpp
+++ b/frmts/pcidsk/ogrpcidsklayer.cpp
@@ -765,7 +765,8 @@ OGRErr OGRPCIDSKLayer::ISetFeature(OGRFeature *poFeature)
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGRPCIDSKLayer::CreateField(OGRFieldDefn *poFieldDefn, int bApproxOK)
+OGRErr OGRPCIDSKLayer::CreateField(const OGRFieldDefn *poFieldDefn,
+                                   int bApproxOK)
 
 {
     try

--- a/frmts/pcidsk/pcidskdataset2.h
+++ b/frmts/pcidsk/pcidskdataset2.h
@@ -209,7 +209,7 @@ class OGRPCIDSKLayer final : public OGRLayer,
 
     OGRErr DeleteFeature(GIntBig nFID) override;
     virtual OGRErr ICreateFeature(OGRFeature *poFeature) override;
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
 
     GIntBig GetFeatureCount(int) override;

--- a/frmts/pds/pds4dataset.h
+++ b/frmts/pds/pds4dataset.h
@@ -164,7 +164,7 @@ class PDS4FixedWidthTable CPL_NON_FINAL : public PDS4TableBaseLayer
     int TestCapability(const char *) override;
     OGRErr ISetFeature(OGRFeature *poFeature) override;
     OGRErr ICreateFeature(OGRFeature *poFeature) override;
-    OGRErr CreateField(OGRFieldDefn *poFieldIn, int) override;
+    OGRErr CreateField(const OGRFieldDefn *poFieldIn, int) override;
 
     bool ReadTableDef(const CPLXMLNode *psTable);
 
@@ -272,7 +272,7 @@ class PDS4DelimitedTable CPL_NON_FINAL : public PDS4TableBaseLayer
     OGRFeature *GetNextFeature() override;
     int TestCapability(const char *) override;
     OGRErr ICreateFeature(OGRFeature *poFeature) override;
-    OGRErr CreateField(OGRFieldDefn *poFieldIn, int) override;
+    OGRErr CreateField(const OGRFieldDefn *poFieldIn, int) override;
 
     bool ReadTableDef(const CPLXMLNode *psTable);
 

--- a/frmts/pds/pds4vector.cpp
+++ b/frmts/pds/pds4vector.cpp
@@ -1462,7 +1462,7 @@ void PDS4FixedWidthTable::RefreshFileAreaObservational(CPLXMLNode *psFAO)
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr PDS4FixedWidthTable::CreateField(OGRFieldDefn *poFieldIn, int)
+OGRErr PDS4FixedWidthTable::CreateField(const OGRFieldDefn *poFieldIn, int)
 
 {
     if (m_poDS->GetAccess() != GA_Update)
@@ -2104,7 +2104,7 @@ OGRErr PDS4DelimitedTable::ICreateFeature(OGRFeature *poFeature)
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr PDS4DelimitedTable::CreateField(OGRFieldDefn *poFieldIn, int)
+OGRErr PDS4DelimitedTable::CreateField(const OGRFieldDefn *poFieldIn, int)
 
 {
     if (m_poDS->GetAccess() != GA_Update)

--- a/frmts/tiledb/tiledbheaders.h
+++ b/frmts/tiledb/tiledbheaders.h
@@ -487,7 +487,7 @@ class OGRTileDBLayer final : public OGRLayer,
     DEFINE_GET_NEXT_FEATURE_THROUGH_RAW(OGRTileDBLayer);
     OGRFeature *GetFeature(GIntBig nFID) override;
     OGRErr ICreateFeature(OGRFeature *poFeature) override;
-    OGRErr CreateField(OGRFieldDefn *poField, int bApproxOK) override;
+    OGRErr CreateField(const OGRFieldDefn *poField, int bApproxOK) override;
     int TestCapability(const char *) override;
     GIntBig GetFeatureCount(int bForce) override;
     OGRErr GetExtent(OGREnvelope *psExtent, int bForce = TRUE) override;

--- a/frmts/tiledb/tiledbsparse.cpp
+++ b/frmts/tiledb/tiledbsparse.cpp
@@ -3418,7 +3418,8 @@ void OGRTileDBLayer::ResetReading()
 /*                         CreateField()                                */
 /************************************************************************/
 
-OGRErr OGRTileDBLayer::CreateField(OGRFieldDefn *poField, int /* bApproxOK*/)
+OGRErr OGRTileDBLayer::CreateField(const OGRFieldDefn *poField,
+                                   int /* bApproxOK*/)
 {
     if (!m_bUpdatable)
         return OGRERR_FAILURE;

--- a/gnm/gnm.h
+++ b/gnm/gnm.h
@@ -528,7 +528,7 @@ class GNMGenericLayer : public OGRLayer
 
     virtual int TestCapability(const char *) override;
 
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
     virtual OGRErr DeleteField(int iField) override;
     virtual OGRErr ReorderFields(int *panMap) override;
@@ -721,7 +721,7 @@ class OGRGNMWrappedResultLayer : public OGRLayer
     virtual OGRFeatureDefn *GetLayerDefn() override;
     virtual GIntBig GetFeatureCount(int bForce = TRUE) override;
     virtual int TestCapability(const char *pszCap) override;
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
     virtual OGRErr CreateGeomField(OGRGeomFieldDefn *poField,
                                    int bApproxOK = TRUE) override;

--- a/gnm/gnm.h
+++ b/gnm/gnm.h
@@ -535,7 +535,7 @@ class GNMGenericLayer : public OGRLayer
     virtual OGRErr AlterFieldDefn(int iField, OGRFieldDefn *poNewFieldDefn,
                                   int nFlagsIn) override;
 
-    virtual OGRErr CreateGeomField(OGRGeomFieldDefn *poField,
+    virtual OGRErr CreateGeomField(const OGRGeomFieldDefn *poField,
                                    int bApproxOK = TRUE) override;
 
     virtual OGRErr SyncToDisk() override;
@@ -723,7 +723,7 @@ class OGRGNMWrappedResultLayer : public OGRLayer
     virtual int TestCapability(const char *pszCap) override;
     virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
-    virtual OGRErr CreateGeomField(OGRGeomFieldDefn *poField,
+    virtual OGRErr CreateGeomField(const OGRGeomFieldDefn *poField,
                                    int bApproxOK = TRUE) override;
     virtual const char *GetFIDColumn() override;
     virtual const char *GetGeometryColumn() override;

--- a/gnm/gnmlayer.cpp
+++ b/gnm/gnmlayer.cpp
@@ -294,7 +294,7 @@ int GNMGenericLayer::TestCapability(const char *pszCapability)
     return m_poLayer->TestCapability(pszCapability);
 }
 
-OGRErr GNMGenericLayer::CreateField(OGRFieldDefn *poField, int bApproxOK)
+OGRErr GNMGenericLayer::CreateField(const OGRFieldDefn *poField, int bApproxOK)
 {
     return m_poLayer->CreateField(poField, bApproxOK);
 }

--- a/gnm/gnmlayer.cpp
+++ b/gnm/gnmlayer.cpp
@@ -323,7 +323,7 @@ OGRErr GNMGenericLayer::AlterFieldDefn(int iField, OGRFieldDefn *poNewFieldDefn,
     return m_poLayer->AlterFieldDefn(iField, poNewFieldDefn, nFlagsIn);
 }
 
-OGRErr GNMGenericLayer::CreateGeomField(OGRGeomFieldDefn *poField,
+OGRErr GNMGenericLayer::CreateGeomField(const OGRGeomFieldDefn *poField,
                                         int bApproxOK)
 {
     return m_poLayer->CreateGeomField(poField, bApproxOK);

--- a/gnm/gnmresultlayer.cpp
+++ b/gnm/gnmresultlayer.cpp
@@ -99,8 +99,9 @@ OGRErr OGRGNMWrappedResultLayer::CreateField(const OGRFieldDefn *poField,
     return poLayer->CreateField(poField, bApproxOK);
 }
 
-OGRErr OGRGNMWrappedResultLayer::CreateGeomField(OGRGeomFieldDefn *poField,
-                                                 int bApproxOK)
+OGRErr
+OGRGNMWrappedResultLayer::CreateGeomField(const OGRGeomFieldDefn *poField,
+                                          int bApproxOK)
 {
     return poLayer->CreateGeomField(poField, bApproxOK);
 }

--- a/gnm/gnmresultlayer.cpp
+++ b/gnm/gnmresultlayer.cpp
@@ -93,7 +93,7 @@ int OGRGNMWrappedResultLayer::TestCapability(const char *pszCap)
     return poLayer->TestCapability(pszCap);
 }
 
-OGRErr OGRGNMWrappedResultLayer::CreateField(OGRFieldDefn *poField,
+OGRErr OGRGNMWrappedResultLayer::CreateField(const OGRFieldDefn *poField,
                                              int bApproxOK)
 {
     return poLayer->CreateField(poField, bApproxOK);

--- a/ogr/ogrsf_frmts/amigocloud/ogr_amigocloud.h
+++ b/ogr/ogrsf_frmts/amigocloud/ogr_amigocloud.h
@@ -184,7 +184,7 @@ class OGRAmigoCloudTableLayer final : public OGRAmigoCloudLayer
 
     virtual int TestCapability(const char *) override;
 
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
 
     virtual OGRFeature *GetNextRawFeature() override;

--- a/ogr/ogrsf_frmts/amigocloud/ogramigocloudtablelayer.cpp
+++ b/ogr/ogrsf_frmts/amigocloud/ogramigocloudtablelayer.cpp
@@ -369,7 +369,7 @@ void OGRAmigoCloudTableLayer::FlushDeferredInsert()
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGRAmigoCloudTableLayer::CreateField(OGRFieldDefn *poFieldIn,
+OGRErr OGRAmigoCloudTableLayer::CreateField(const OGRFieldDefn *poFieldIn,
                                             CPL_UNUSED int bApproxOK)
 {
     GetLayerDefn();

--- a/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
+++ b/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
@@ -406,7 +406,7 @@ class OGRArrowWriterLayer CPL_NON_FINAL : public OGRLayer
     int TestCapability(const char *pszCap) override;
     OGRErr CreateField(const OGRFieldDefn *poField,
                        int bApproxOK = TRUE) override;
-    OGRErr CreateGeomField(OGRGeomFieldDefn *poField,
+    OGRErr CreateGeomField(const OGRGeomFieldDefn *poField,
                            int bApproxOK = TRUE) override;
     GIntBig GetFeatureCount(int bForce) override;
 

--- a/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
+++ b/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
@@ -404,7 +404,8 @@ class OGRArrowWriterLayer CPL_NON_FINAL : public OGRLayer
         return nullptr;
     }
     int TestCapability(const char *pszCap) override;
-    OGRErr CreateField(OGRFieldDefn *poField, int bApproxOK = TRUE) override;
+    OGRErr CreateField(const OGRFieldDefn *poField,
+                       int bApproxOK = TRUE) override;
     OGRErr CreateGeomField(OGRGeomFieldDefn *poField,
                            int bApproxOK = TRUE) override;
     GIntBig GetFeatureCount(int bForce) override;

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowwriterlayer.hpp
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowwriterlayer.hpp
@@ -689,8 +689,9 @@ OGRArrowWriterLayer::GetGeomEncodingAsString(OGRArrowGeomEncoding eGeomEncoding,
 /*                          CreateGeomField()                           */
 /************************************************************************/
 
-inline OGRErr OGRArrowWriterLayer::CreateGeomField(OGRGeomFieldDefn *poField,
-                                                   int /* bApproxOK */)
+inline OGRErr
+OGRArrowWriterLayer::CreateGeomField(const OGRGeomFieldDefn *poField,
+                                     int /* bApproxOK */)
 {
     if (m_poSchema)
     {

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowwriterlayer.hpp
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowwriterlayer.hpp
@@ -523,7 +523,7 @@ OGRArrowWriterLayer::GetFieldDomain(const std::string &name) const
 /*                          CreateField()                               */
 /************************************************************************/
 
-inline OGRErr OGRArrowWriterLayer::CreateField(OGRFieldDefn *poField,
+inline OGRErr OGRArrowWriterLayer::CreateField(const OGRFieldDefn *poField,
                                                int /* bApproxOK */)
 {
     if (m_poSchema)

--- a/ogr/ogrsf_frmts/carto/ogr_carto.h
+++ b/ogr/ogrsf_frmts/carto/ogr_carto.h
@@ -167,7 +167,7 @@ class OGRCARTOTableLayer final : public OGRCARTOLayer
     virtual OGRErr CreateGeomField(OGRGeomFieldDefn *poGeomFieldIn,
                                    int bApproxOK = TRUE) override;
 
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
 
     virtual OGRErr DeleteField(int iField) override;

--- a/ogr/ogrsf_frmts/carto/ogr_carto.h
+++ b/ogr/ogrsf_frmts/carto/ogr_carto.h
@@ -164,7 +164,7 @@ class OGRCARTOTableLayer final : public OGRCARTOLayer
 
     virtual int TestCapability(const char *) override;
 
-    virtual OGRErr CreateGeomField(OGRGeomFieldDefn *poGeomFieldIn,
+    virtual OGRErr CreateGeomField(const OGRGeomFieldDefn *poGeomFieldIn,
                                    int bApproxOK = TRUE) override;
 
     virtual OGRErr CreateField(const OGRFieldDefn *poField,

--- a/ogr/ogrsf_frmts/carto/ogrcartotablelayer.cpp
+++ b/ogr/ogrsf_frmts/carto/ogrcartotablelayer.cpp
@@ -713,7 +713,7 @@ OGRErr OGRCARTOTableLayer::CreateGeomField(OGRGeomFieldDefn *poGeomFieldIn,
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGRCARTOTableLayer::CreateField(OGRFieldDefn *poFieldIn,
+OGRErr OGRCARTOTableLayer::CreateField(const OGRFieldDefn *poFieldIn,
                                        CPL_UNUSED int bApproxOK)
 {
     GetLayerDefn();

--- a/ogr/ogrsf_frmts/carto/ogrcartotablelayer.cpp
+++ b/ogr/ogrsf_frmts/carto/ogrcartotablelayer.cpp
@@ -618,8 +618,9 @@ OGRErr OGRCARTOTableLayer::FlushDeferredCopy(bool bReset)
 /*                          CreateGeomField()                           */
 /************************************************************************/
 
-OGRErr OGRCARTOTableLayer::CreateGeomField(OGRGeomFieldDefn *poGeomFieldIn,
-                                           CPL_UNUSED int bApproxOK)
+OGRErr
+OGRCARTOTableLayer::CreateGeomField(const OGRGeomFieldDefn *poGeomFieldIn,
+                                    CPL_UNUSED int bApproxOK)
 {
     if (!poDS->IsReadWrite())
     {

--- a/ogr/ogrsf_frmts/csv/ogr_csv.h
+++ b/ogr/ogrsf_frmts/csv/ogr_csv.h
@@ -232,7 +232,7 @@ class OGRCSVLayer final : public IOGRCSVLayer, public OGRLayer
     PreCreateField(OGRFeatureDefn *poFeatureDefn,
                    const std::set<CPLString> &oSetFields,
                    const OGRFieldDefn *poNewField, int bApproxOK);
-    virtual OGRErr CreateGeomField(OGRGeomFieldDefn *poGeomField,
+    virtual OGRErr CreateGeomField(const OGRGeomFieldDefn *poGeomField,
                                    int bApproxOK = TRUE) override;
 
     virtual OGRErr ICreateFeature(OGRFeature *poFeature) override;

--- a/ogr/ogrsf_frmts/csv/ogr_csv.h
+++ b/ogr/ogrsf_frmts/csv/ogr_csv.h
@@ -225,13 +225,13 @@ class OGRCSVLayer final : public IOGRCSVLayer, public OGRLayer
 
     int TestCapability(const char *) override;
 
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
 
     static OGRCSVCreateFieldAction
     PreCreateField(OGRFeatureDefn *poFeatureDefn,
                    const std::set<CPLString> &oSetFields,
-                   OGRFieldDefn *poNewField, int bApproxOK);
+                   const OGRFieldDefn *poNewField, int bApproxOK);
     virtual OGRErr CreateGeomField(OGRGeomFieldDefn *poGeomField,
                                    int bApproxOK = TRUE) override;
 

--- a/ogr/ogrsf_frmts/csv/ogrcsvdatasource.cpp
+++ b/ogr/ogrsf_frmts/csv/ogrcsvdatasource.cpp
@@ -329,7 +329,7 @@ class OGRCSVEditableLayer final : public IOGRCSVLayer, public OGREditableLayer
             ->GetFileList();
     }
 
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
     virtual OGRErr DeleteField(int iField) override;
     virtual OGRErr AlterFieldDefn(int iField, OGRFieldDefn *poNewFieldDefn,
@@ -356,7 +356,8 @@ OGRCSVEditableLayer::OGRCSVEditableLayer(OGRCSVLayer *poCSVLayer,
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGRCSVEditableLayer::CreateField(OGRFieldDefn *poNewField, int bApproxOK)
+OGRErr OGRCSVEditableLayer::CreateField(const OGRFieldDefn *poNewField,
+                                        int bApproxOK)
 
 {
     if (m_poEditableFeatureDefn->GetFieldCount() >= 10000)

--- a/ogr/ogrsf_frmts/csv/ogrcsvlayer.cpp
+++ b/ogr/ogrsf_frmts/csv/ogrcsvlayer.cpp
@@ -1864,7 +1864,7 @@ OGRErr OGRCSVLayer::CreateField(const OGRFieldDefn *poNewField, int bApproxOK)
 /*                          CreateGeomField()                           */
 /************************************************************************/
 
-OGRErr OGRCSVLayer::CreateGeomField(OGRGeomFieldDefn *poGeomField,
+OGRErr OGRCSVLayer::CreateGeomField(const OGRGeomFieldDefn *poGeomField,
                                     int /* bApproxOK */)
 {
     if (!TestCapability(OLCCreateGeomField))

--- a/ogr/ogrsf_frmts/csv/ogrcsvlayer.cpp
+++ b/ogr/ogrsf_frmts/csv/ogrcsvlayer.cpp
@@ -1750,7 +1750,7 @@ int OGRCSVLayer::TestCapability(const char *pszCap)
 OGRCSVCreateFieldAction
 OGRCSVLayer::PreCreateField(OGRFeatureDefn *poFeatureDefn,
                             const std::set<CPLString> &oSetFields,
-                            OGRFieldDefn *poNewField, int bApproxOK)
+                            const OGRFieldDefn *poNewField, int bApproxOK)
 {
     // Does this duplicate an existing field?
     if (oSetFields.find(CPLString(poNewField->GetNameRef()).toupper()) !=
@@ -1813,7 +1813,7 @@ OGRCSVLayer::PreCreateField(OGRFeatureDefn *poFeatureDefn,
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGRCSVLayer::CreateField(OGRFieldDefn *poNewField, int bApproxOK)
+OGRErr OGRCSVLayer::CreateField(const OGRFieldDefn *poNewField, int bApproxOK)
 
 {
     // If we have already written our field names, then we are not

--- a/ogr/ogrsf_frmts/dxf/ogr_dxf.h
+++ b/ogr/ogrsf_frmts/dxf/ogr_dxf.h
@@ -837,7 +837,8 @@ class OGRDXFWriterLayer final : public OGRLayer
 
     int TestCapability(const char *) override;
     OGRErr ICreateFeature(OGRFeature *poFeature) override;
-    OGRErr CreateField(OGRFieldDefn *poField, int bApproxOK = TRUE) override;
+    OGRErr CreateField(const OGRFieldDefn *poField,
+                       int bApproxOK = TRUE) override;
 
     void ResetFP(VSILFILE *);
 
@@ -878,7 +879,8 @@ class OGRDXFBlocksWriterLayer final : public OGRLayer
 
     int TestCapability(const char *) override;
     OGRErr ICreateFeature(OGRFeature *poFeature) override;
-    OGRErr CreateField(OGRFieldDefn *poField, int bApproxOK = TRUE) override;
+    OGRErr CreateField(const OGRFieldDefn *poField,
+                       int bApproxOK = TRUE) override;
 
     std::vector<OGRFeature *> apoBlocks;
     OGRFeature *FindBlock(const char *);

--- a/ogr/ogrsf_frmts/dxf/ogrdxfblockswriterlayer.cpp
+++ b/ogr/ogrsf_frmts/dxf/ogrdxfblockswriterlayer.cpp
@@ -74,7 +74,7 @@ int OGRDXFBlocksWriterLayer::TestCapability(const char *pszCap)
 /*      This is really a dummy as our fields are precreated.            */
 /************************************************************************/
 
-OGRErr OGRDXFBlocksWriterLayer::CreateField(OGRFieldDefn *poField,
+OGRErr OGRDXFBlocksWriterLayer::CreateField(const OGRFieldDefn *poField,
                                             int bApproxOK)
 
 {

--- a/ogr/ogrsf_frmts/dxf/ogrdxfwriterlayer.cpp
+++ b/ogr/ogrsf_frmts/dxf/ogrdxfwriterlayer.cpp
@@ -97,7 +97,8 @@ int OGRDXFWriterLayer::TestCapability(const char *pszCap)
 /*      This is really a dummy as our fields are precreated.            */
 /************************************************************************/
 
-OGRErr OGRDXFWriterLayer::CreateField(OGRFieldDefn *poField, int bApproxOK)
+OGRErr OGRDXFWriterLayer::CreateField(const OGRFieldDefn *poField,
+                                      int bApproxOK)
 
 {
     if (poFeatureDefn->GetFieldIndex(poField->GetNameRef()) >= 0 && bApproxOK)

--- a/ogr/ogrsf_frmts/elastic/ogr_elastic.h
+++ b/ogr/ogrsf_frmts/elastic/ogr_elastic.h
@@ -187,7 +187,8 @@ class OGRElasticLayer final : public OGRLayer
     virtual OGRErr ICreateFeature(OGRFeature *poFeature) override;
     virtual OGRErr ISetFeature(OGRFeature *poFeature) override;
     OGRErr IUpsertFeature(OGRFeature *poFeature) override;
-    virtual OGRErr CreateField(OGRFieldDefn *poField, int bApproxOK) override;
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
+                               int bApproxOK) override;
     virtual OGRErr CreateGeomField(OGRGeomFieldDefn *poField,
                                    int bApproxOK) override;
 

--- a/ogr/ogrsf_frmts/elastic/ogr_elastic.h
+++ b/ogr/ogrsf_frmts/elastic/ogr_elastic.h
@@ -189,7 +189,7 @@ class OGRElasticLayer final : public OGRLayer
     OGRErr IUpsertFeature(OGRFeature *poFeature) override;
     virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK) override;
-    virtual OGRErr CreateGeomField(OGRGeomFieldDefn *poField,
+    virtual OGRErr CreateGeomField(const OGRGeomFieldDefn *poField,
                                    int bApproxOK) override;
 
     virtual const char *GetName() override

--- a/ogr/ogrsf_frmts/elastic/ogrelasticlayer.cpp
+++ b/ogr/ogrsf_frmts/elastic/ogrelasticlayer.cpp
@@ -2898,7 +2898,7 @@ bool OGRElasticLayer::PushIndex()
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGRElasticLayer::CreateField(OGRFieldDefn *poFieldDefn,
+OGRErr OGRElasticLayer::CreateField(const OGRFieldDefn *poFieldDefn,
                                     int /*bApproxOK*/)
 {
     if (m_poDS->GetAccess() != GA_Update)

--- a/ogr/ogrsf_frmts/elastic/ogrelasticlayer.cpp
+++ b/ogr/ogrsf_frmts/elastic/ogrelasticlayer.cpp
@@ -2951,7 +2951,7 @@ OGRErr OGRElasticLayer::CreateField(const OGRFieldDefn *poFieldDefn,
 /*                           CreateGeomField()                          */
 /************************************************************************/
 
-OGRErr OGRElasticLayer::CreateGeomField(OGRGeomFieldDefn *poFieldIn,
+OGRErr OGRElasticLayer::CreateGeomField(const OGRGeomFieldDefn *poFieldIn,
                                         int /*bApproxOK*/)
 
 {

--- a/ogr/ogrsf_frmts/filegdb/FGdbLayer.cpp
+++ b/ogr/ogrsf_frmts/filegdb/FGdbLayer.cpp
@@ -1911,7 +1911,7 @@ char *FGdbLayer::CreateFieldDefn(OGRFieldDefn &oField, int bApproxOK,
 /*                                                                      */
 /************************************************************************/
 
-OGRErr FGdbLayer::CreateField(OGRFieldDefn *poField, int bApproxOK)
+OGRErr FGdbLayer::CreateField(const OGRFieldDefn *poField, int bApproxOK)
 {
     OGRFieldDefn oField(poField);
     std::string fieldname_clean;

--- a/ogr/ogrsf_frmts/filegdb/ogr_fgdb.h
+++ b/ogr/ogrsf_frmts/filegdb/ogr_fgdb.h
@@ -196,7 +196,8 @@ class FGdbLayer final : public FGdbBaseLayer
         return m_wstrType;
     }
 
-    virtual OGRErr CreateField(OGRFieldDefn *poField, int bApproxOK) override;
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
+                               int bApproxOK) override;
     virtual OGRErr DeleteField(int iFieldToDelete) override;
 #ifdef AlterFieldDefn_implemented_but_not_working
     virtual OGRErr AlterFieldDefn(int iFieldToAlter,

--- a/ogr/ogrsf_frmts/flatgeobuf/ogr_flatgeobuf.h
+++ b/ogr/ogrsf_frmts/flatgeobuf/ogr_flatgeobuf.h
@@ -169,7 +169,7 @@ class OGRFlatGeobufLayer final : public OGRLayer,
 
     virtual OGRFeature *GetFeature(GIntBig nFeatureId) override;
     virtual OGRFeature *GetNextFeature() override;
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = true) override;
     virtual OGRErr ICreateFeature(OGRFeature *poFeature) override;
     virtual int TestCapability(const char *) override;

--- a/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
+++ b/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
@@ -1955,7 +1955,7 @@ error:
     return errorErrno;
 }
 
-OGRErr OGRFlatGeobufLayer::CreateField(OGRFieldDefn *poField,
+OGRErr OGRFlatGeobufLayer::CreateField(const OGRFieldDefn *poField,
                                        int /* bApproxOK */)
 {
     // CPLDebugOnly("FlatGeobuf", "CreateField %s %s", poField->GetNameRef(),

--- a/ogr/ogrsf_frmts/generic/ogreditablelayer.cpp
+++ b/ogr/ogrsf_frmts/generic/ogreditablelayer.cpp
@@ -707,7 +707,7 @@ int OGREditableLayer::TestCapability(const char *pszCap)
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGREditableLayer::CreateField(OGRFieldDefn *poField, int bApproxOK)
+OGRErr OGREditableLayer::CreateField(const OGRFieldDefn *poField, int bApproxOK)
 {
     if (!m_poDecoratedLayer)
         return OGRERR_FAILURE;

--- a/ogr/ogrsf_frmts/generic/ogreditablelayer.cpp
+++ b/ogr/ogrsf_frmts/generic/ogreditablelayer.cpp
@@ -852,7 +852,7 @@ OGRErr OGREditableLayer::AlterGeomFieldDefn(
 /*                          CreateGeomField()                          */
 /************************************************************************/
 
-OGRErr OGREditableLayer::CreateGeomField(OGRGeomFieldDefn *poField,
+OGRErr OGREditableLayer::CreateGeomField(const OGRGeomFieldDefn *poField,
                                          int bApproxOK)
 {
     if (!m_poDecoratedLayer || !m_bSupportsCreateGeomField)

--- a/ogr/ogrsf_frmts/generic/ogreditablelayer.h
+++ b/ogr/ogrsf_frmts/generic/ogreditablelayer.h
@@ -131,7 +131,7 @@ class CPL_DLL OGREditableLayer : public OGRLayerDecorator
                        const OGRGeomFieldDefn *poNewGeomFieldDefn,
                        int nFlags) override;
 
-    virtual OGRErr CreateGeomField(OGRGeomFieldDefn *poField,
+    virtual OGRErr CreateGeomField(const OGRGeomFieldDefn *poField,
                                    int bApproxOK = TRUE) override;
 
     virtual OGRErr SyncToDisk() override;

--- a/ogr/ogrsf_frmts/generic/ogreditablelayer.h
+++ b/ogr/ogrsf_frmts/generic/ogreditablelayer.h
@@ -120,7 +120,7 @@ class CPL_DLL OGREditableLayer : public OGRLayerDecorator
 
     virtual int TestCapability(const char *) override;
 
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
     virtual OGRErr DeleteField(int iField) override;
     virtual OGRErr ReorderFields(int *panMap) override;

--- a/ogr/ogrsf_frmts/generic/ogremulatedtransaction.cpp
+++ b/ogr/ogrsf_frmts/generic/ogremulatedtransaction.cpp
@@ -54,7 +54,7 @@ class OGRLayerWithTransaction final : public OGRLayerDecorator
     }
     virtual OGRFeatureDefn *GetLayerDefn() override;
 
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
     virtual OGRErr DeleteField(int iField) override;
     virtual OGRErr ReorderFields(int *panMap) override;
@@ -610,7 +610,7 @@ OGRFeatureDefn *OGRLayerWithTransaction::GetLayerDefn()
     return m_poFeatureDefn;
 }
 
-OGRErr OGRLayerWithTransaction::CreateField(OGRFieldDefn *poField,
+OGRErr OGRLayerWithTransaction::CreateField(const OGRFieldDefn *poField,
                                             int bApproxOK)
 {
     if (!m_poDecoratedLayer)

--- a/ogr/ogrsf_frmts/generic/ogremulatedtransaction.cpp
+++ b/ogr/ogrsf_frmts/generic/ogremulatedtransaction.cpp
@@ -64,7 +64,7 @@ class OGRLayerWithTransaction final : public OGRLayerDecorator
     AlterGeomFieldDefn(int iField, const OGRGeomFieldDefn *poNewGeomFieldDefn,
                        int nFlags) override;
 
-    virtual OGRErr CreateGeomField(OGRGeomFieldDefn *poField,
+    virtual OGRErr CreateGeomField(const OGRGeomFieldDefn *poField,
                                    int bApproxOK = TRUE) override;
 
     virtual OGRFeature *GetNextFeature() override;
@@ -626,7 +626,7 @@ OGRErr OGRLayerWithTransaction::CreateField(const OGRFieldDefn *poField,
     return eErr;
 }
 
-OGRErr OGRLayerWithTransaction::CreateGeomField(OGRGeomFieldDefn *poField,
+OGRErr OGRLayerWithTransaction::CreateGeomField(const OGRGeomFieldDefn *poField,
                                                 int bApproxOK)
 {
     if (!m_poDecoratedLayer)

--- a/ogr/ogrsf_frmts/generic/ogrlayer.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrlayer.cpp
@@ -810,7 +810,7 @@ OGRErr OGR_L_UpdateFeature(OGRLayerH hLayer, OGRFeatureH hFeat,
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGRLayer::CreateField(OGRFieldDefn *poField, int bApproxOK)
+OGRErr OGRLayer::CreateField(const OGRFieldDefn *poField, int bApproxOK)
 
 {
     (void)poField;

--- a/ogr/ogrsf_frmts/generic/ogrlayer.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrlayer.cpp
@@ -1056,7 +1056,7 @@ OGRErr OGR_L_AlterGeomFieldDefn(OGRLayerH hLayer, int iGeomField,
 /*                         CreateGeomField()                            */
 /************************************************************************/
 
-OGRErr OGRLayer::CreateGeomField(OGRGeomFieldDefn *poField, int bApproxOK)
+OGRErr OGRLayer::CreateGeomField(const OGRGeomFieldDefn *poField, int bApproxOK)
 
 {
     (void)poField;

--- a/ogr/ogrsf_frmts/generic/ogrlayerdecorator.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrlayerdecorator.cpp
@@ -236,7 +236,8 @@ int OGRLayerDecorator::TestCapability(const char *pszCapability)
     return m_poDecoratedLayer->TestCapability(pszCapability);
 }
 
-OGRErr OGRLayerDecorator::CreateField(OGRFieldDefn *poField, int bApproxOK)
+OGRErr OGRLayerDecorator::CreateField(const OGRFieldDefn *poField,
+                                      int bApproxOK)
 {
     if (!m_poDecoratedLayer)
         return OGRERR_FAILURE;

--- a/ogr/ogrsf_frmts/generic/ogrlayerdecorator.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrlayerdecorator.cpp
@@ -276,7 +276,7 @@ OGRErr OGRLayerDecorator::AlterGeomFieldDefn(
                                                   poNewGeomFieldDefn, nFlagsIn);
 }
 
-OGRErr OGRLayerDecorator::CreateGeomField(OGRGeomFieldDefn *poField,
+OGRErr OGRLayerDecorator::CreateGeomField(const OGRGeomFieldDefn *poField,
                                           int bApproxOK)
 {
     if (!m_poDecoratedLayer)

--- a/ogr/ogrsf_frmts/generic/ogrlayerdecorator.h
+++ b/ogr/ogrsf_frmts/generic/ogrlayerdecorator.h
@@ -88,7 +88,7 @@ class CPL_DLL OGRLayerDecorator : public OGRLayer
 
     virtual int TestCapability(const char *) override;
 
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
     virtual OGRErr DeleteField(int iField) override;
     virtual OGRErr ReorderFields(int *panMap) override;

--- a/ogr/ogrsf_frmts/generic/ogrlayerdecorator.h
+++ b/ogr/ogrsf_frmts/generic/ogrlayerdecorator.h
@@ -99,7 +99,7 @@ class CPL_DLL OGRLayerDecorator : public OGRLayer
                        const OGRGeomFieldDefn *poNewGeomFieldDefn,
                        int nFlags) override;
 
-    virtual OGRErr CreateGeomField(OGRGeomFieldDefn *poField,
+    virtual OGRErr CreateGeomField(const OGRGeomFieldDefn *poField,
                                    int bApproxOK = TRUE) override;
 
     virtual OGRErr SyncToDisk() override;

--- a/ogr/ogrsf_frmts/generic/ogrlayerpool.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrlayerpool.cpp
@@ -508,7 +508,7 @@ int OGRProxiedLayer::TestCapability(const char *pszCapability)
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGRProxiedLayer::CreateField(OGRFieldDefn *poField, int bApproxOK)
+OGRErr OGRProxiedLayer::CreateField(const OGRFieldDefn *poField, int bApproxOK)
 {
     if (poUnderlyingLayer == nullptr && !OpenUnderlyingLayer())
         return OGRERR_FAILURE;

--- a/ogr/ogrsf_frmts/generic/ogrlayerpool.h
+++ b/ogr/ogrsf_frmts/generic/ogrlayerpool.h
@@ -160,7 +160,7 @@ class OGRProxiedLayer : public OGRAbstractProxiedLayer
 
     virtual int TestCapability(const char *) override;
 
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
     virtual OGRErr DeleteField(int iField) override;
     virtual OGRErr ReorderFields(int *panMap) override;

--- a/ogr/ogrsf_frmts/generic/ogrmutexedlayer.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrmutexedlayer.cpp
@@ -205,7 +205,7 @@ int OGRMutexedLayer::TestCapability(const char *pszCapability)
     return OGRLayerDecorator::TestCapability(pszCapability);
 }
 
-OGRErr OGRMutexedLayer::CreateField(OGRFieldDefn *poField, int bApproxOK)
+OGRErr OGRMutexedLayer::CreateField(const OGRFieldDefn *poField, int bApproxOK)
 {
     CPLMutexHolderOptionalLockD(m_hMutex);
     return OGRLayerDecorator::CreateField(poField, bApproxOK);

--- a/ogr/ogrsf_frmts/generic/ogrmutexedlayer.h
+++ b/ogr/ogrsf_frmts/generic/ogrmutexedlayer.h
@@ -99,7 +99,7 @@ class CPL_DLL OGRMutexedLayer : public OGRLayerDecorator
 
     virtual int TestCapability(const char *) override;
 
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
     virtual OGRErr DeleteField(int iField) override;
     virtual OGRErr ReorderFields(int *panMap) override;

--- a/ogr/ogrsf_frmts/geoconcept/ogrgeoconceptlayer.cpp
+++ b/ogr/ogrsf_frmts/geoconcept/ogrgeoconceptlayer.cpp
@@ -499,7 +499,7 @@ int OGRGeoconceptLayer::TestCapability(const char *pszCap)
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGRGeoconceptLayer::CreateField(OGRFieldDefn *poField,
+OGRErr OGRGeoconceptLayer::CreateField(const OGRFieldDefn *poField,
                                        CPL_UNUSED int bApproxOK)
 {
     if (GetGCMode_GCIO(GetSubTypeGCHandle_GCIO(_gcFeature)) == vReadAccess_GCIO)

--- a/ogr/ogrsf_frmts/geoconcept/ogrgeoconceptlayer.h
+++ b/ogr/ogrsf_frmts/geoconcept/ogrgeoconceptlayer.h
@@ -77,7 +77,8 @@ class OGRGeoconceptLayer final : public OGRLayer
     }
     int TestCapability(const char *pszCap) override;
     //    const char*          GetInfo( const char* pszTag );
-    OGRErr CreateField(OGRFieldDefn *poField, int bApproxOK = TRUE) override;
+    OGRErr CreateField(const OGRFieldDefn *poField,
+                       int bApproxOK = TRUE) override;
     OGRErr SyncToDisk() override;
     //    OGRStyleTable*       GetStyleTable( );
     //    void                 SetStyleTableDirectly( OGRStyleTable*

--- a/ogr/ogrsf_frmts/geojson/ogr_geojson.h
+++ b/ogr/ogrsf_frmts/geojson/ogr_geojson.h
@@ -83,7 +83,7 @@ class OGRGeoJSONLayer final : public OGRMemLayer
     OGRErr ISetFeature(OGRFeature *poFeature) override;
     OGRErr ICreateFeature(OGRFeature *poFeature) override;
     virtual OGRErr DeleteFeature(GIntBig nFID) override;
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
     virtual OGRErr DeleteField(int iField) override;
     virtual OGRErr ReorderFields(int *panMap) override;
@@ -160,7 +160,7 @@ class OGRGeoJSONWriteLayer final : public OGRLayer
         return nullptr;
     }
     OGRErr ICreateFeature(OGRFeature *poFeature) override;
-    OGRErr CreateField(OGRFieldDefn *poField, int bApproxOK) override;
+    OGRErr CreateField(const OGRFieldDefn *poField, int bApproxOK) override;
     int TestCapability(const char *pszCap) override;
     OGRErr GetExtent(OGREnvelope *psExtent, int bForce) override;
     OGRErr GetExtent(int iGeomField, OGREnvelope *psExtent, int bForce) override

--- a/ogr/ogrsf_frmts/geojson/ogr_geojson.h
+++ b/ogr/ogrsf_frmts/geojson/ogr_geojson.h
@@ -89,7 +89,7 @@ class OGRGeoJSONLayer final : public OGRMemLayer
     virtual OGRErr ReorderFields(int *panMap) override;
     virtual OGRErr AlterFieldDefn(int iField, OGRFieldDefn *poNewFieldDefn,
                                   int nFlags) override;
-    virtual OGRErr CreateGeomField(OGRGeomFieldDefn *poGeomField,
+    virtual OGRErr CreateGeomField(const OGRGeomFieldDefn *poGeomField,
                                    int bApproxOK = TRUE) override;
 
     //

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonlayer.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonlayer.cpp
@@ -378,7 +378,7 @@ OGRErr OGRGeoJSONLayer::DeleteFeature(GIntBig nFID)
 /*                           CreateField()                              */
 /************************************************************************/
 
-OGRErr OGRGeoJSONLayer::CreateField(OGRFieldDefn *poField, int bApproxOK)
+OGRErr OGRGeoJSONLayer::CreateField(const OGRFieldDefn *poField, int bApproxOK)
 {
     if (!IsUpdatable() || !IngestAll())
         return OGRERR_FAILURE;

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonlayer.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonlayer.cpp
@@ -423,7 +423,7 @@ OGRErr OGRGeoJSONLayer::AlterFieldDefn(int iField, OGRFieldDefn *poNewFieldDefn,
 /*                         CreateGeomField()                            */
 /************************************************************************/
 
-OGRErr OGRGeoJSONLayer::CreateGeomField(OGRGeomFieldDefn *poGeomField,
+OGRErr OGRGeoJSONLayer::CreateGeomField(const OGRGeomFieldDefn *poGeomField,
                                         int bApproxOK)
 {
     if (!IsUpdatable() || !IngestAll())

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonseqdriver.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonseqdriver.cpp
@@ -132,7 +132,7 @@ class OGRGeoJSONSeqLayer final : public OGRLayer
     GIntBig GetFeatureCount(int) override;
     int TestCapability(const char *) override;
     OGRErr ICreateFeature(OGRFeature *poFeature) override;
-    OGRErr CreateField(OGRFieldDefn *, int) override;
+    OGRErr CreateField(const OGRFieldDefn *, int) override;
 };
 
 /************************************************************************/
@@ -683,7 +683,7 @@ OGRErr OGRGeoJSONSeqLayer::ICreateFeature(OGRFeature *poFeature)
 /*                           CreateField()                              */
 /************************************************************************/
 
-OGRErr OGRGeoJSONSeqLayer::CreateField(OGRFieldDefn *poField,
+OGRErr OGRGeoJSONSeqLayer::CreateField(const OGRFieldDefn *poField,
                                        int /* bApproxOK */)
 {
     if (m_poDS->GetAccess() != GA_Update)

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonwritelayer.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonwritelayer.cpp
@@ -436,7 +436,7 @@ OGRErr OGRGeoJSONWriteLayer::ICreateFeature(OGRFeature *poFeature)
 /*                           CreateField()                              */
 /************************************************************************/
 
-OGRErr OGRGeoJSONWriteLayer::CreateField(OGRFieldDefn *poField,
+OGRErr OGRGeoJSONWriteLayer::CreateField(const OGRFieldDefn *poField,
                                          int /* bApproxOK */)
 {
     if (poFeatureDefn_->GetFieldIndexCaseSensitive(poField->GetNameRef()) >= 0)

--- a/ogr/ogrsf_frmts/georss/ogr_georss.h
+++ b/ogr/ogrsf_frmts/georss/ogr_georss.h
@@ -135,7 +135,7 @@ class OGRGeoRSSLayer final : public OGRLayer
     OGRFeature *GetNextFeature() override;
 
     OGRErr ICreateFeature(OGRFeature *poFeature) override;
-    OGRErr CreateField(OGRFieldDefn *poField, int bApproxOK) override;
+    OGRErr CreateField(const OGRFieldDefn *poField, int bApproxOK) override;
 
     OGRFeatureDefn *GetLayerDefn() override;
 

--- a/ogr/ogrsf_frmts/georss/ogrgeorsslayer.cpp
+++ b/ogr/ogrsf_frmts/georss/ogrgeorsslayer.cpp
@@ -1677,7 +1677,7 @@ OGRErr OGRGeoRSSLayer::ICreateFeature(OGRFeature *poFeatureIn)
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGRGeoRSSLayer::CreateField(OGRFieldDefn *poFieldDefn,
+OGRErr OGRGeoRSSLayer::CreateField(const OGRFieldDefn *poFieldDefn,
                                    CPL_UNUSED int bApproxOK)
 {
     const char *pszName = poFieldDefn->GetNameRef();

--- a/ogr/ogrsf_frmts/gml/ogr_gml.h
+++ b/ogr/ogrsf_frmts/gml/ogr_gml.h
@@ -96,7 +96,7 @@ class OGRGMLLayer final : public OGRLayer
         return poFeatureDefn;
     }
 
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
     virtual OGRErr CreateGeomField(OGRGeomFieldDefn *poField,
                                    int bApproxOK = TRUE) override;

--- a/ogr/ogrsf_frmts/gml/ogr_gml.h
+++ b/ogr/ogrsf_frmts/gml/ogr_gml.h
@@ -98,7 +98,7 @@ class OGRGMLLayer final : public OGRLayer
 
     virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
-    virtual OGRErr CreateGeomField(OGRGeomFieldDefn *poField,
+    virtual OGRErr CreateGeomField(const OGRGeomFieldDefn *poField,
                                    int bApproxOK = TRUE) override;
 
     int TestCapability(const char *) override;

--- a/ogr/ogrsf_frmts/gml/ogrgmllayer.cpp
+++ b/ogr/ogrsf_frmts/gml/ogrgmllayer.cpp
@@ -1192,7 +1192,8 @@ OGRErr OGRGMLLayer::CreateField(const OGRFieldDefn *poField, int bApproxOK)
 /*                          CreateGeomField()                           */
 /************************************************************************/
 
-OGRErr OGRGMLLayer::CreateGeomField(OGRGeomFieldDefn *poField, int bApproxOK)
+OGRErr OGRGMLLayer::CreateGeomField(const OGRGeomFieldDefn *poField,
+                                    int bApproxOK)
 
 {
     if (!bWriter || iNextGMLId != 0)

--- a/ogr/ogrsf_frmts/gml/ogrgmllayer.cpp
+++ b/ogr/ogrsf_frmts/gml/ogrgmllayer.cpp
@@ -1149,7 +1149,7 @@ int OGRGMLLayer::TestCapability(const char *pszCap)
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGRGMLLayer::CreateField(OGRFieldDefn *poField, int bApproxOK)
+OGRErr OGRGMLLayer::CreateField(const OGRFieldDefn *poField, int bApproxOK)
 
 {
     if (!bWriter || iNextGMLId != 0)

--- a/ogr/ogrsf_frmts/gmt/ogr_gmt.h
+++ b/ogr/ogrsf_frmts/gmt/ogr_gmt.h
@@ -91,7 +91,7 @@ class OGRGmtLayer final : public OGRLayer,
 
     OGRErr ICreateFeature(OGRFeature *poFeature) override;
 
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
 
     int TestCapability(const char *) override;

--- a/ogr/ogrsf_frmts/gmt/ogrgmtlayer.cpp
+++ b/ogr/ogrsf_frmts/gmt/ogrgmtlayer.cpp
@@ -1025,7 +1025,7 @@ int OGRGmtLayer::TestCapability(const char *pszCap)
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGRGmtLayer::CreateField(OGRFieldDefn *poField, int bApproxOK)
+OGRErr OGRGmtLayer::CreateField(const OGRFieldDefn *poField, int bApproxOK)
 
 {
     if (!bUpdate)

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -722,7 +722,7 @@ class OGRGeoPackageTableLayer final : public OGRGeoPackageLayer
     OGRErr ReadTableDefinition();
     void InitView();
 
-    bool DoSpecialProcessingForColumnCreation(OGRFieldDefn *poField);
+    bool DoSpecialProcessingForColumnCreation(const OGRFieldDefn *poField);
 
     bool StartDeferredSpatialIndexUpdate();
     bool FlushPendingSpatialIndexUpdate();
@@ -793,7 +793,8 @@ class OGRGeoPackageTableLayer final : public OGRGeoPackageLayer
     const char *GetGeometryColumn() override;
     OGRFeatureDefn *GetLayerDefn() override;
     int TestCapability(const char *) override;
-    OGRErr CreateField(OGRFieldDefn *poField, int bApproxOK = TRUE) override;
+    OGRErr CreateField(const OGRFieldDefn *poField,
+                       int bApproxOK = TRUE) override;
     OGRErr CreateGeomField(OGRGeomFieldDefn *poGeomFieldIn,
                            int bApproxOK = TRUE) override;
     virtual OGRErr DeleteField(int iFieldToDelete) override;

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -795,7 +795,7 @@ class OGRGeoPackageTableLayer final : public OGRGeoPackageLayer
     int TestCapability(const char *) override;
     OGRErr CreateField(const OGRFieldDefn *poField,
                        int bApproxOK = TRUE) override;
-    OGRErr CreateGeomField(OGRGeomFieldDefn *poGeomFieldIn,
+    OGRErr CreateGeomField(const OGRGeomFieldDefn *poGeomFieldIn,
                            int bApproxOK = TRUE) override;
     virtual OGRErr DeleteField(int iFieldToDelete) override;
     virtual OGRErr AlterFieldDefn(int iFieldToAlter,

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -1665,7 +1665,7 @@ bool OGRGeoPackageTableLayer::CheckUpdatableTable(const char *pszOperation)
 /*                      CreateField()                                   */
 /************************************************************************/
 
-OGRErr OGRGeoPackageTableLayer::CreateField(OGRFieldDefn *poField,
+OGRErr OGRGeoPackageTableLayer::CreateField(const OGRFieldDefn *poField,
                                             int /* bApproxOK */)
 {
     if (!m_bFeatureDefnCompleted)
@@ -1785,7 +1785,7 @@ OGRErr OGRGeoPackageTableLayer::CreateField(OGRFieldDefn *poField,
 /************************************************************************/
 
 bool OGRGeoPackageTableLayer::DoSpecialProcessingForColumnCreation(
-    OGRFieldDefn *poField)
+    const OGRFieldDefn *poField)
 {
     const std::string &osConstraintName(poField->GetDomainName());
     const std::string osName(poField->GetAlternativeNameRef());

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -1874,8 +1874,9 @@ bool OGRGeoPackageTableLayer::DoSpecialProcessingForColumnCreation(
 /*                           CreateGeomField()                          */
 /************************************************************************/
 
-OGRErr OGRGeoPackageTableLayer::CreateGeomField(OGRGeomFieldDefn *poGeomFieldIn,
-                                                int /* bApproxOK */)
+OGRErr
+OGRGeoPackageTableLayer::CreateGeomField(const OGRGeomFieldDefn *poGeomFieldIn,
+                                         int /* bApproxOK */)
 {
     if (!m_bFeatureDefnCompleted)
         GetLayerDefn();

--- a/ogr/ogrsf_frmts/gpx/ogr_gpx.h
+++ b/ogr/ogrsf_frmts/gpx/ogr_gpx.h
@@ -140,7 +140,7 @@ class OGRGPXLayer final : public OGRLayer
     OGRFeature *GetNextFeature() override;
 
     OGRErr ICreateFeature(OGRFeature *poFeature) override;
-    OGRErr CreateField(OGRFieldDefn *poField, int bApproxOK) override;
+    OGRErr CreateField(const OGRFieldDefn *poField, int bApproxOK) override;
 
     OGRFeatureDefn *GetLayerDefn() override
     {

--- a/ogr/ogrsf_frmts/gpx/ogrgpxlayer.cpp
+++ b/ogr/ogrsf_frmts/gpx/ogrgpxlayer.cpp
@@ -1867,7 +1867,8 @@ OGRErr OGRGPXLayer::ICreateFeature(OGRFeature *poFeatureIn)
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGRGPXLayer::CreateField(OGRFieldDefn *poField, CPL_UNUSED int bApproxOK)
+OGRErr OGRGPXLayer::CreateField(const OGRFieldDefn *poField,
+                                CPL_UNUSED int bApproxOK)
 {
     for (int iField = 0; iField < poFeatureDefn->GetFieldCount(); iField++)
     {

--- a/ogr/ogrsf_frmts/hana/ogr_hana.h
+++ b/ogr/ogrsf_frmts/hana/ogr_hana.h
@@ -269,7 +269,7 @@ class OGRHanaTableLayer final : public OGRHanaLayer
     OGRErr ISetFeature(OGRFeature *feature) override;
 
     OGRErr CreateField(const OGRFieldDefn *field, int approxOK = TRUE) override;
-    OGRErr CreateGeomField(OGRGeomFieldDefn *geomField,
+    OGRErr CreateGeomField(const OGRGeomFieldDefn *geomField,
                            int approxOK = TRUE) override;
     OGRErr DeleteField(int field) override;
     OGRErr AlterFieldDefn(int field, OGRFieldDefn *newFieldDefn,

--- a/ogr/ogrsf_frmts/hana/ogr_hana.h
+++ b/ogr/ogrsf_frmts/hana/ogr_hana.h
@@ -268,7 +268,7 @@ class OGRHanaTableLayer final : public OGRHanaLayer
     OGRErr DeleteFeature(GIntBig nFID) override;
     OGRErr ISetFeature(OGRFeature *feature) override;
 
-    OGRErr CreateField(OGRFieldDefn *field, int approxOK = TRUE) override;
+    OGRErr CreateField(const OGRFieldDefn *field, int approxOK = TRUE) override;
     OGRErr CreateGeomField(OGRGeomFieldDefn *geomField,
                            int approxOK = TRUE) override;
     OGRErr DeleteField(int field) override;

--- a/ogr/ogrsf_frmts/hana/ogrhanatablelayer.cpp
+++ b/ogr/ogrsf_frmts/hana/ogrhanatablelayer.cpp
@@ -1406,7 +1406,8 @@ OGRErr OGRHanaTableLayer::ISetFeature(OGRFeature *feature)
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGRHanaTableLayer::CreateField(OGRFieldDefn *srsField, int approxOK)
+OGRErr OGRHanaTableLayer::CreateField(const OGRFieldDefn *srsField,
+                                      int approxOK)
 {
     if (!updateMode_)
     {

--- a/ogr/ogrsf_frmts/hana/ogrhanatablelayer.cpp
+++ b/ogr/ogrsf_frmts/hana/ogrhanatablelayer.cpp
@@ -1544,7 +1544,8 @@ OGRErr OGRHanaTableLayer::CreateField(const OGRFieldDefn *srsField,
 /*                          CreateGeomField()                           */
 /************************************************************************/
 
-OGRErr OGRHanaTableLayer::CreateGeomField(OGRGeomFieldDefn *geomField, int)
+OGRErr OGRHanaTableLayer::CreateGeomField(const OGRGeomFieldDefn *geomField,
+                                          int)
 {
     if (!updateMode_)
     {

--- a/ogr/ogrsf_frmts/ili/ogr_ili1.h
+++ b/ogr/ogrsf_frmts/ili/ogr_ili1.h
@@ -85,7 +85,8 @@ class OGRILI1Layer final : public OGRLayer
         return oGeomFieldInfos;
     }
 
-    OGRErr CreateField(OGRFieldDefn *poField, int bApproxOK = TRUE) override;
+    OGRErr CreateField(const OGRFieldDefn *poField,
+                       int bApproxOK = TRUE) override;
 
     int TestCapability(const char *) override;
 

--- a/ogr/ogrsf_frmts/ili/ogr_ili2.h
+++ b/ogr/ogrsf_frmts/ili/ogr_ili2.h
@@ -79,7 +79,8 @@ class OGRILI2Layer final : public OGRLayer
         return oGeomFieldInfos[cFieldName].iliGeomType;
     }
 
-    OGRErr CreateField(OGRFieldDefn *poField, int bApproxOK = TRUE) override;
+    OGRErr CreateField(const OGRFieldDefn *poField,
+                       int bApproxOK = TRUE) override;
 
     int TestCapability(const char *) override;
 };

--- a/ogr/ogrsf_frmts/ili/ogrili1layer.cpp
+++ b/ogr/ogrsf_frmts/ili/ogrili1layer.cpp
@@ -441,7 +441,8 @@ int OGRILI1Layer::TestCapability(CPL_UNUSED const char *pszCap)
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGRILI1Layer::CreateField(OGRFieldDefn *poField, int /* bApproxOK */)
+OGRErr OGRILI1Layer::CreateField(const OGRFieldDefn *poField,
+                                 int /* bApproxOK */)
 {
     poFeatureDefn->AddFieldDefn(poField);
 

--- a/ogr/ogrsf_frmts/ili/ogrili2layer.cpp
+++ b/ogr/ogrsf_frmts/ili/ogrili2layer.cpp
@@ -339,7 +339,8 @@ int OGRILI2Layer::TestCapability(CPL_UNUSED const char *pszCap)
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGRILI2Layer::CreateField(OGRFieldDefn *poField, int /* bApproxOK */)
+OGRErr OGRILI2Layer::CreateField(const OGRFieldDefn *poField,
+                                 int /* bApproxOK */)
 {
     poFeatureDefn->AddFieldDefn(poField);
     return OGRERR_NONE;

--- a/ogr/ogrsf_frmts/jml/ogr_jml.h
+++ b/ogr/ogrsf_frmts/jml/ogr_jml.h
@@ -176,7 +176,7 @@ class OGRJMLWriterLayer final : public OGRLayer
     }
 
     OGRErr ICreateFeature(OGRFeature *poFeature) override;
-    OGRErr CreateField(OGRFieldDefn *poField, int bApproxOK) override;
+    OGRErr CreateField(const OGRFieldDefn *poField, int bApproxOK) override;
 
     OGRFeatureDefn *GetLayerDefn() override
     {

--- a/ogr/ogrsf_frmts/jml/ogrjmlwriterlayer.cpp
+++ b/ogr/ogrsf_frmts/jml/ogrjmlwriterlayer.cpp
@@ -370,7 +370,8 @@ OGRErr OGRJMLWriterLayer::ICreateFeature(OGRFeature *poFeature)
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGRJMLWriterLayer::CreateField(OGRFieldDefn *poFieldDefn, int bApproxOK)
+OGRErr OGRJMLWriterLayer::CreateField(const OGRFieldDefn *poFieldDefn,
+                                      int bApproxOK)
 {
     if (bFeaturesWritten)
         return OGRERR_FAILURE;

--- a/ogr/ogrsf_frmts/jsonfg/ogr_jsonfg.h
+++ b/ogr/ogrsf_frmts/jsonfg/ogr_jsonfg.h
@@ -205,7 +205,7 @@ class OGRJSONFGWriteLayer final : public OGRLayer
         return nullptr;
     }
     OGRErr ICreateFeature(OGRFeature *poFeature) override;
-    OGRErr CreateField(OGRFieldDefn *poField, int bApproxOK) override;
+    OGRErr CreateField(const OGRFieldDefn *poField, int bApproxOK) override;
     int TestCapability(const char *pszCap) override;
 
     OGRErr SyncToDisk() override;

--- a/ogr/ogrsf_frmts/jsonfg/ogrjsonfgwritelayer.cpp
+++ b/ogr/ogrsf_frmts/jsonfg/ogrjsonfgwritelayer.cpp
@@ -410,7 +410,7 @@ OGRErr OGRJSONFGWriteLayer::ICreateFeature(OGRFeature *poFeature)
 /*                           CreateField()                              */
 /************************************************************************/
 
-OGRErr OGRJSONFGWriteLayer::CreateField(OGRFieldDefn *poField,
+OGRErr OGRJSONFGWriteLayer::CreateField(const OGRFieldDefn *poField,
                                         int /* bApproxOK */)
 {
     if (poFeatureDefn_->GetFieldIndexCaseSensitive(poField->GetNameRef()) >= 0)

--- a/ogr/ogrsf_frmts/kml/ogr_kml.h
+++ b/ogr/ogrsf_frmts/kml/ogr_kml.h
@@ -57,7 +57,8 @@ class OGRKMLLayer final : public OGRLayer
     //
     OGRFeatureDefn *GetLayerDefn() override;
     OGRErr ICreateFeature(OGRFeature *poFeature) override;
-    OGRErr CreateField(OGRFieldDefn *poField, int bApproxOK = TRUE) override;
+    OGRErr CreateField(const OGRFieldDefn *poField,
+                       int bApproxOK = TRUE) override;
     void ResetReading() override;
     OGRFeature *GetNextFeature() override;
     GIntBig GetFeatureCount(int bForce = TRUE) override;

--- a/ogr/ogrsf_frmts/kml/ogrkmllayer.cpp
+++ b/ogr/ogrsf_frmts/kml/ogrkmllayer.cpp
@@ -617,7 +617,8 @@ int OGRKMLLayer::TestCapability(const char *pszCap)
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGRKMLLayer::CreateField(OGRFieldDefn *poField, CPL_UNUSED int bApproxOK)
+OGRErr OGRKMLLayer::CreateField(const OGRFieldDefn *poField,
+                                CPL_UNUSED int bApproxOK)
 {
     if (!bWriter_ || iNextKMLId_ != 0)
         return OGRERR_FAILURE;

--- a/ogr/ogrsf_frmts/libkml/ogr_libkml.h
+++ b/ogr/ogrsf_frmts/libkml/ogr_libkml.h
@@ -120,7 +120,8 @@ class OGRLIBKMLLayer final : public OGRLayer,
 
     // const char               *GetInfo( const char * );
 
-    OGRErr CreateField(OGRFieldDefn *poField, int bApproxOK = TRUE) override;
+    OGRErr CreateField(const OGRFieldDefn *poField,
+                       int bApproxOK = TRUE) override;
 
     OGRErr SyncToDisk() override;
 

--- a/ogr/ogrsf_frmts/libkml/ogrlibkmlfield.cpp
+++ b/ogr/ogrsf_frmts/libkml/ogrlibkmlfield.cpp
@@ -1533,7 +1533,7 @@ void kml2field(OGRFeature *poOgrFeat, FeaturePtr poKmlFeature)
  function create a simplefield from a FieldDefn
 ******************************************************************************/
 
-SimpleFieldPtr FieldDef2kml(OGRFieldDefn *poOgrFieldDef,
+SimpleFieldPtr FieldDef2kml(const OGRFieldDefn *poOgrFieldDef,
                             KmlFactory *poKmlFactory)
 {
     /***** Get the field config. *****/

--- a/ogr/ogrsf_frmts/libkml/ogrlibkmlfield.h
+++ b/ogr/ogrsf_frmts/libkml/ogrlibkmlfield.h
@@ -64,7 +64,7 @@ void kml2field(OGRFeature *poOgrFeat, kmldom::FeaturePtr poKmlFeature);
  Function create a simplefield from a FieldDefn.
 ******************************************************************************/
 
-kmldom::SimpleFieldPtr FieldDef2kml(OGRFieldDefn *poOgrFieldDef,
+kmldom::SimpleFieldPtr FieldDef2kml(const OGRFieldDefn *poOgrFieldDef,
                                     kmldom::KmlFactory *poKmlFactory);
 
 /******************************************************************************

--- a/ogr/ogrsf_frmts/libkml/ogrlibkmllayer.cpp
+++ b/ogr/ogrsf_frmts/libkml/ogrlibkmllayer.cpp
@@ -729,7 +729,8 @@ OGRErr OGRLIBKMLLayer::GetExtent(OGREnvelope *psExtent, int bForce)
 
 ******************************************************************************/
 
-OGRErr OGRLIBKMLLayer::CreateField(OGRFieldDefn *poField, int /* bApproxOK */)
+OGRErr OGRLIBKMLLayer::CreateField(const OGRFieldDefn *poField,
+                                   int /* bApproxOK */)
 {
     if (!bUpdate)
         return OGRERR_UNSUPPORTED_OPERATION;

--- a/ogr/ogrsf_frmts/mapml/ogrmapmldataset.cpp
+++ b/ogr/ogrsf_frmts/mapml/ogrmapmldataset.cpp
@@ -187,7 +187,7 @@ class OGRMapMLWriterLayer final : public OGRLayer
     {
         return nullptr;
     }
-    OGRErr CreateField(OGRFieldDefn *poFieldDefn, int) override;
+    OGRErr CreateField(const OGRFieldDefn *poFieldDefn, int) override;
     OGRErr ICreateFeature(OGRFeature *poFeature) override;
     int TestCapability(const char *) override;
 };
@@ -1076,7 +1076,7 @@ int OGRMapMLWriterLayer::TestCapability(const char *pszCap)
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGRMapMLWriterLayer::CreateField(OGRFieldDefn *poFieldDefn, int)
+OGRErr OGRMapMLWriterLayer::CreateField(const OGRFieldDefn *poFieldDefn, int)
 {
     m_poFeatureDefn->AddFieldDefn(poFieldDefn);
     return OGRERR_NONE;

--- a/ogr/ogrsf_frmts/mem/ogr_mem.h
+++ b/ogr/ogrsf_frmts/mem/ogr_mem.h
@@ -116,7 +116,7 @@ class CPL_DLL OGRMemLayer CPL_NON_FINAL : public OGRLayer
     AlterGeomFieldDefn(int iGeomField,
                        const OGRGeomFieldDefn *poNewGeomFieldDefn,
                        int nFlagsIn) override;
-    virtual OGRErr CreateGeomField(OGRGeomFieldDefn *poGeomField,
+    virtual OGRErr CreateGeomField(const OGRGeomFieldDefn *poGeomField,
                                    int bApproxOK = TRUE) override;
 
     int TestCapability(const char *) override;

--- a/ogr/ogrsf_frmts/mem/ogr_mem.h
+++ b/ogr/ogrsf_frmts/mem/ogr_mem.h
@@ -106,7 +106,7 @@ class CPL_DLL OGRMemLayer CPL_NON_FINAL : public OGRLayer
 
     GIntBig GetFeatureCount(int) override;
 
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
     virtual OGRErr DeleteField(int iField) override;
     virtual OGRErr ReorderFields(int *panMap) override;

--- a/ogr/ogrsf_frmts/mem/ogrmemlayer.cpp
+++ b/ogr/ogrsf_frmts/mem/ogrmemlayer.cpp
@@ -613,7 +613,8 @@ int OGRMemLayer::TestCapability(const char *pszCap)
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGRMemLayer::CreateField(OGRFieldDefn *poField, int /* bApproxOK */)
+OGRErr OGRMemLayer::CreateField(const OGRFieldDefn *poField,
+                                int /* bApproxOK */)
 {
     if (!m_bUpdatable)
         return OGRERR_FAILURE;

--- a/ogr/ogrsf_frmts/mem/ogrmemlayer.cpp
+++ b/ogr/ogrsf_frmts/mem/ogrmemlayer.cpp
@@ -932,7 +932,7 @@ OGRErr OGRMemLayer::AlterGeomFieldDefn(
 /*                          CreateGeomField()                           */
 /************************************************************************/
 
-OGRErr OGRMemLayer::CreateGeomField(OGRGeomFieldDefn *poGeomField,
+OGRErr OGRMemLayer::CreateGeomField(const OGRGeomFieldDefn *poGeomField,
                                     int /* bApproxOK */)
 {
     if (!m_bUpdatable)

--- a/ogr/ogrsf_frmts/mitab/mitab.h
+++ b/ogr/ogrsf_frmts/mitab/mitab.h
@@ -173,7 +173,7 @@ class IMapInfoFile CPL_NON_FINAL : public OGRLayer
                                int nWidth = 0, int nPrecision = 0,
                                GBool bIndexed = FALSE, GBool bUnique = FALSE,
                                int bApproxOK = TRUE) = 0;
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
 
     virtual int SetSpatialRef(OGRSpatialReference *poSpatialRef) = 0;
@@ -199,7 +199,7 @@ class IMapInfoFile CPL_NON_FINAL : public OGRLayer
     virtual int SetProjInfo(TABProjInfo *poPI) = 0;
     virtual int SetMIFCoordSys(const char *pszMIFCoordSys) = 0;
 
-    static int GetTABType(OGRFieldDefn *poField, TABFieldType *peTABType,
+    static int GetTABType(const OGRFieldDefn *poField, TABFieldType *peTABType,
                           int *pnWidth, int *pnPrecision);
 
 #ifdef DEBUG

--- a/ogr/ogrsf_frmts/mitab/mitab_imapinfofile.cpp
+++ b/ogr/ogrsf_frmts/mitab/mitab_imapinfofile.cpp
@@ -434,8 +434,9 @@ OGRFeature *IMapInfoFile::GetFeature(GIntBig nFeatureId)
 /*      Create a native field based on a generic OGR definition.        */
 /************************************************************************/
 
-int IMapInfoFile::GetTABType(OGRFieldDefn *poField, TABFieldType *peTABType,
-                             int *pnWidth, int *pnPrecision)
+int IMapInfoFile::GetTABType(const OGRFieldDefn *poField,
+                             TABFieldType *peTABType, int *pnWidth,
+                             int *pnPrecision)
 {
     TABFieldType eTABType;
     int nWidth = poField->GetWidth();
@@ -530,7 +531,7 @@ int IMapInfoFile::GetTABType(OGRFieldDefn *poField, TABFieldType *peTABType,
 /*      Create a native field based on a generic OGR definition.        */
 /************************************************************************/
 
-OGRErr IMapInfoFile::CreateField(OGRFieldDefn *poField, int bApproxOK)
+OGRErr IMapInfoFile::CreateField(const OGRFieldDefn *poField, int bApproxOK)
 
 {
     TABFieldType eTABType;

--- a/ogr/ogrsf_frmts/mongodbv3/ogrmongodbv3driver.cpp
+++ b/ogr/ogrsf_frmts/mongodbv3/ogrmongodbv3driver.cpp
@@ -202,7 +202,7 @@ class OGRMongoDBv3Layer final : public OGRLayer
     int TestCapability(const char *pszCap) override;
     OGRFeatureDefn *GetLayerDefn() override;
     OGRErr CreateField(const OGRFieldDefn *poFieldIn, int) override;
-    OGRErr CreateGeomField(OGRGeomFieldDefn *poFieldIn, int) override;
+    OGRErr CreateGeomField(const OGRGeomFieldDefn *poFieldIn, int) override;
     OGRErr ICreateFeature(OGRFeature *poFeature) override;
     OGRErr ISetFeature(OGRFeature *poFeature) override;
     OGRErr IUpsertFeature(OGRFeature *poFeature) override;
@@ -1474,7 +1474,8 @@ OGRErr OGRMongoDBv3Layer::CreateField(const OGRFieldDefn *poFieldIn, int)
 /*                           CreateGeomField()                          */
 /************************************************************************/
 
-OGRErr OGRMongoDBv3Layer::CreateGeomField(OGRGeomFieldDefn *poFieldIn, int)
+OGRErr OGRMongoDBv3Layer::CreateGeomField(const OGRGeomFieldDefn *poFieldIn,
+                                          int)
 
 {
     if (m_poDS->GetAccess() != GA_Update)

--- a/ogr/ogrsf_frmts/mongodbv3/ogrmongodbv3driver.cpp
+++ b/ogr/ogrsf_frmts/mongodbv3/ogrmongodbv3driver.cpp
@@ -201,7 +201,7 @@ class OGRMongoDBv3Layer final : public OGRLayer
     void SetSpatialFilter(int iGeomField, OGRGeometry *poGeom) override;
     int TestCapability(const char *pszCap) override;
     OGRFeatureDefn *GetLayerDefn() override;
-    OGRErr CreateField(OGRFieldDefn *poFieldIn, int) override;
+    OGRErr CreateField(const OGRFieldDefn *poFieldIn, int) override;
     OGRErr CreateGeomField(OGRGeomFieldDefn *poFieldIn, int) override;
     OGRErr ICreateFeature(OGRFeature *poFeature) override;
     OGRErr ISetFeature(OGRFeature *poFeature) override;
@@ -1428,7 +1428,7 @@ OGRErr OGRMongoDBv3Layer::DeleteFeature(GIntBig nFID)
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGRMongoDBv3Layer::CreateField(OGRFieldDefn *poFieldIn, int)
+OGRErr OGRMongoDBv3Layer::CreateField(const OGRFieldDefn *poFieldIn, int)
 
 {
     if (m_poDS->GetAccess() != GA_Update)

--- a/ogr/ogrsf_frmts/mssqlspatial/ogr_mssqlspatial.h
+++ b/ogr/ogrsf_frmts/mssqlspatial/ogr_mssqlspatial.h
@@ -482,7 +482,7 @@ class OGRMSSQLSpatialTableLayer final : public OGRMSSQLSpatialLayer
         return pszSchemaName;
     }
 
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
 
     virtual OGRFeature *GetFeature(GIntBig nFeatureId) override;

--- a/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
+++ b/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialtablelayer.cpp
@@ -933,7 +933,7 @@ OGRErr OGRMSSQLSpatialTableLayer::EndCopy()
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGRMSSQLSpatialTableLayer::CreateField(OGRFieldDefn *poFieldIn,
+OGRErr OGRMSSQLSpatialTableLayer::CreateField(const OGRFieldDefn *poFieldIn,
                                               int bApproxOK)
 
 {

--- a/ogr/ogrsf_frmts/mvt/ogrmvtdataset.cpp
+++ b/ogr/ogrsf_frmts/mvt/ogrmvtdataset.cpp
@@ -3425,7 +3425,7 @@ class OGRMVTWriterLayer final : public OGRLayer
     }
     int TestCapability(const char *) override;
     OGRErr ICreateFeature(OGRFeature *) override;
-    OGRErr CreateField(OGRFieldDefn *, int) override;
+    OGRErr CreateField(const OGRFieldDefn *, int) override;
 };
 
 /************************************************************************/
@@ -3483,7 +3483,7 @@ int OGRMVTWriterLayer::TestCapability(const char *pszCap)
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGRMVTWriterLayer::CreateField(OGRFieldDefn *poFieldDefn, int)
+OGRErr OGRMVTWriterLayer::CreateField(const OGRFieldDefn *poFieldDefn, int)
 {
     m_poFeatureDefn->AddFieldDefn(poFieldDefn);
     return OGRERR_NONE;

--- a/ogr/ogrsf_frmts/mysql/ogr_mysql.h
+++ b/ogr/ogrsf_frmts/mysql/ogr_mysql.h
@@ -196,7 +196,7 @@ class OGRMySQLTableLayer final : public OGRMySQLLayer
     virtual OGRErr DeleteFeature(GIntBig nFID) override;
     virtual OGRErr ISetFeature(OGRFeature *poFeature) override;
 
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
 
     void SetLaunderFlag(int bFlag)

--- a/ogr/ogrsf_frmts/mysql/ogrmysqltablelayer.cpp
+++ b/ogr/ogrsf_frmts/mysql/ogrmysqltablelayer.cpp
@@ -970,7 +970,8 @@ OGRErr OGRMySQLTableLayer::ICreateFeature(OGRFeature *poFeature)
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGRMySQLTableLayer::CreateField(OGRFieldDefn *poFieldIn, int bApproxOK)
+OGRErr OGRMySQLTableLayer::CreateField(const OGRFieldDefn *poFieldIn,
+                                       int bApproxOK)
 
 {
 

--- a/ogr/ogrsf_frmts/ngw/ogr_ngw.h
+++ b/ogr/ogrsf_frmts/ngw/ogr_ngw.h
@@ -180,7 +180,7 @@ class OGRNGWLayer final : public OGRLayer
     virtual OGRFeatureDefn *GetLayerDefn() override;
     virtual int TestCapability(const char *) override;
 
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
     virtual OGRErr DeleteField(int iField) override;
     virtual OGRErr ReorderFields(int *panMap) override;

--- a/ogr/ogrsf_frmts/ngw/ogrngwlayer.cpp
+++ b/ogr/ogrsf_frmts/ngw/ogrngwlayer.cpp
@@ -1153,7 +1153,8 @@ void OGRNGWLayer::FetchPermissions()
 /*
  * CreateField()
  */
-OGRErr OGRNGWLayer::CreateField(OGRFieldDefn *poField, CPL_UNUSED int bApproxOK)
+OGRErr OGRNGWLayer::CreateField(const OGRFieldDefn *poField,
+                                CPL_UNUSED int bApproxOK)
 {
     CPLAssert(nullptr != poField);
 

--- a/ogr/ogrsf_frmts/oci/ogr_oci.h
+++ b/ogr/ogrsf_frmts/oci/ogr_oci.h
@@ -339,7 +339,7 @@ class OGROCIWritableLayer CPL_NON_FINAL : public OGROCILayer
     {
         return poSRS;
     }
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
     virtual int FindFieldIndex(const char *pszFieldName,
                                int bExactMatch) override;

--- a/ogr/ogrsf_frmts/oci/ogrociwritablelayer.cpp
+++ b/ogr/ogrsf_frmts/oci/ogrociwritablelayer.cpp
@@ -242,7 +242,8 @@ void OGROCIWritableLayer::SetOptions(char **papszOptionsIn)
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGROCIWritableLayer::CreateField(OGRFieldDefn *poFieldIn, int bApproxOK)
+OGRErr OGROCIWritableLayer::CreateField(const OGRFieldDefn *poFieldIn,
+                                        int bApproxOK)
 
 {
     OGROCISession *poSession = poDS->GetSession();

--- a/ogr/ogrsf_frmts/ods/ogr_ods.h
+++ b/ogr/ogrsf_frmts/ods/ogr_ods.h
@@ -113,7 +113,7 @@ class OGRODSLayer final : public OGRMemLayer
         return OGRMemLayer::ICreateFeature(poFeature);
     }
 
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override
     {
         SetUpdated();

--- a/ogr/ogrsf_frmts/ogrsf_frmts.h
+++ b/ogr/ogrsf_frmts/ogrsf_frmts.h
@@ -273,7 +273,7 @@ class CPL_DLL OGRLayer : public GDALMajorObject
                        const OGRGeomFieldDefn *poNewGeomFieldDefn,
                        int nFlagsIn);
 
-    virtual OGRErr CreateGeomField(OGRGeomFieldDefn *poField,
+    virtual OGRErr CreateGeomField(const OGRGeomFieldDefn *poField,
                                    int bApproxOK = TRUE);
 
     virtual OGRErr SyncToDisk();

--- a/ogr/ogrsf_frmts/ogrsf_frmts.h
+++ b/ogr/ogrsf_frmts/ogrsf_frmts.h
@@ -262,7 +262,8 @@ class CPL_DLL OGRLayer : public GDALMajorObject
 
     virtual OGRErr Rename(const char *pszNewName) CPL_WARN_UNUSED_RESULT;
 
-    virtual OGRErr CreateField(OGRFieldDefn *poField, int bApproxOK = TRUE);
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
+                               int bApproxOK = TRUE);
     virtual OGRErr DeleteField(int iField);
     virtual OGRErr ReorderFields(int *panMap);
     virtual OGRErr AlterFieldDefn(int iField, OGRFieldDefn *poNewFieldDefn,

--- a/ogr/ogrsf_frmts/openfilegdb/ogr_openfilegdb.h
+++ b/ogr/ogrsf_frmts/openfilegdb/ogr_openfilegdb.h
@@ -280,7 +280,8 @@ class OGROpenFileGDBLayer final : public OGRLayer
 
     virtual OGRErr Rename(const char *pszNewName) override;
 
-    virtual OGRErr CreateField(OGRFieldDefn *poField, int bApproxOK) override;
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
+                               int bApproxOK) override;
     virtual OGRErr DeleteField(int iFieldToDelete) override;
     virtual OGRErr AlterFieldDefn(int iFieldToAlter,
                                   OGRFieldDefn *poNewFieldDefn,

--- a/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer_write.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer_write.cpp
@@ -1088,7 +1088,8 @@ OGROpenFileGDBLayer::GetLaunderedFieldName(const std::string &osNameOri) const
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGROpenFileGDBLayer::CreateField(OGRFieldDefn *poField, int bApproxOK)
+OGRErr OGROpenFileGDBLayer::CreateField(const OGRFieldDefn *poFieldIn,
+                                        int bApproxOK)
 {
     if (!m_bEditable)
         return OGRERR_FAILURE;
@@ -1104,8 +1105,8 @@ OGRErr OGROpenFileGDBLayer::CreateField(OGRFieldDefn *poField, int bApproxOK)
     }
 
     /* Clean field names */
-    OGRFieldDefn oField(poField);
-    poField = &oField;
+    OGRFieldDefn oField(poFieldIn);
+    OGRFieldDefn *poField = &oField;
 
     const std::string osFidColumn = GetFIDColumn();
     if (!osFidColumn.empty() &&

--- a/ogr/ogrsf_frmts/parquet/ogr_parquet.h
+++ b/ogr/ogrsf_frmts/parquet/ogr_parquet.h
@@ -292,7 +292,7 @@ class OGRParquetWriterLayer final : public OGRArrowWriterLayer
                     const OGRSpatialReference *poSpatialRef,
                     OGRwkbGeometryType eGType);
 
-    OGRErr CreateGeomField(OGRGeomFieldDefn *poField,
+    OGRErr CreateGeomField(const OGRGeomFieldDefn *poField,
                            int bApproxOK = TRUE) override;
 
     int TestCapability(const char *pszCap) override;

--- a/ogr/ogrsf_frmts/parquet/ogrparquetwriterlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetwriterlayer.cpp
@@ -620,7 +620,7 @@ void OGRParquetWriterLayer::CreateSchema()
 /*                          CreateGeomField()                           */
 /************************************************************************/
 
-OGRErr OGRParquetWriterLayer::CreateGeomField(OGRGeomFieldDefn *poField,
+OGRErr OGRParquetWriterLayer::CreateGeomField(const OGRGeomFieldDefn *poField,
                                               int bApproxOK)
 {
     OGRErr eErr = OGRArrowWriterLayer::CreateGeomField(poField, bApproxOK);

--- a/ogr/ogrsf_frmts/pg/ogr_pg.h
+++ b/ogr/ogrsf_frmts/pg/ogr_pg.h
@@ -392,7 +392,7 @@ class OGRPGTableLayer final : public OGRPGLayer
     virtual OGRErr DeleteFeature(GIntBig nFID) override;
     virtual OGRErr ICreateFeature(OGRFeature *poFeature) override;
 
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
     virtual OGRErr CreateGeomField(OGRGeomFieldDefn *poGeomField,
                                    int bApproxOK = TRUE) override;

--- a/ogr/ogrsf_frmts/pg/ogr_pg.h
+++ b/ogr/ogrsf_frmts/pg/ogr_pg.h
@@ -394,7 +394,7 @@ class OGRPGTableLayer final : public OGRPGLayer
 
     virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
-    virtual OGRErr CreateGeomField(OGRGeomFieldDefn *poGeomField,
+    virtual OGRErr CreateGeomField(const OGRGeomFieldDefn *poGeomField,
                                    int bApproxOK = TRUE) override;
     virtual OGRErr DeleteField(int iField) override;
     virtual OGRErr AlterFieldDefn(int iField, OGRFieldDefn *poNewFieldDefn,

--- a/ogr/ogrsf_frmts/pg/ogrpgtablelayer.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgtablelayer.cpp
@@ -2161,7 +2161,8 @@ int OGRPGTableLayer::TestCapability(const char *pszCap)
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGRPGTableLayer::CreateField(OGRFieldDefn *poFieldIn, int bApproxOK)
+OGRErr OGRPGTableLayer::CreateField(const OGRFieldDefn *poFieldIn,
+                                    int bApproxOK)
 
 {
     PGconn *hPGConn = poDS->GetPGConn();

--- a/ogr/ogrsf_frmts/pg/ogrpgtablelayer.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgtablelayer.cpp
@@ -2413,7 +2413,7 @@ OGRPGTableLayer::RunCreateSpatialIndex(const OGRPGGeomFieldDefn *poGeomField,
 /*                           CreateGeomField()                          */
 /************************************************************************/
 
-OGRErr OGRPGTableLayer::CreateGeomField(OGRGeomFieldDefn *poGeomFieldIn,
+OGRErr OGRPGTableLayer::CreateGeomField(const OGRGeomFieldDefn *poGeomFieldIn,
                                         CPL_UNUSED int bApproxOK)
 {
     OGRwkbGeometryType eType = poGeomFieldIn->GetType();

--- a/ogr/ogrsf_frmts/pgdump/ogr_pgdump.h
+++ b/ogr/ogrsf_frmts/pgdump/ogr_pgdump.h
@@ -171,7 +171,7 @@ class OGRPGDumpLayer final : public OGRLayer
 
     virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
-    virtual OGRErr CreateGeomField(OGRGeomFieldDefn *poGeomField,
+    virtual OGRErr CreateGeomField(const OGRGeomFieldDefn *poGeomField,
                                    int bApproxOK = TRUE) override;
 
     virtual OGRFeature *GetNextFeature() override;

--- a/ogr/ogrsf_frmts/pgdump/ogr_pgdump.h
+++ b/ogr/ogrsf_frmts/pgdump/ogr_pgdump.h
@@ -169,7 +169,7 @@ class OGRPGDumpLayer final : public OGRLayer
     virtual OGRErr CreateFeatureViaInsert(OGRFeature *poFeature);
     virtual OGRErr CreateFeatureViaCopy(OGRFeature *poFeature);
 
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
     virtual OGRErr CreateGeomField(OGRGeomFieldDefn *poGeomField,
                                    int bApproxOK = TRUE) override;

--- a/ogr/ogrsf_frmts/pgdump/ogrpgdumplayer.cpp
+++ b/ogr/ogrsf_frmts/pgdump/ogrpgdumplayer.cpp
@@ -1558,7 +1558,7 @@ CPLString OGRPGCommonLayerGetPGDefault(OGRFieldDefn *poFieldDefn)
 /*                           GetNextFeature()                           */
 /************************************************************************/
 
-OGRErr OGRPGDumpLayer::CreateField(OGRFieldDefn *poFieldIn, int bApproxOK)
+OGRErr OGRPGDumpLayer::CreateField(const OGRFieldDefn *poFieldIn, int bApproxOK)
 {
     if (m_poFeatureDefn->GetFieldCount() +
             m_poFeatureDefn->GetGeomFieldCount() ==

--- a/ogr/ogrsf_frmts/pgdump/ogrpgdumplayer.cpp
+++ b/ogr/ogrsf_frmts/pgdump/ogrpgdumplayer.cpp
@@ -1677,7 +1677,7 @@ OGRErr OGRPGDumpLayer::CreateField(const OGRFieldDefn *poFieldIn, int bApproxOK)
 /*                           CreateGeomField()                          */
 /************************************************************************/
 
-OGRErr OGRPGDumpLayer::CreateGeomField(OGRGeomFieldDefn *poGeomFieldIn,
+OGRErr OGRPGDumpLayer::CreateGeomField(const OGRGeomFieldDefn *poGeomFieldIn,
                                        int /* bApproxOK */)
 {
     if (m_poFeatureDefn->GetFieldCount() +

--- a/ogr/ogrsf_frmts/selafin/ogr_selafin.h
+++ b/ogr/ogrsf_frmts/selafin/ogr_selafin.h
@@ -122,7 +122,8 @@ class OGRSelafinLayer final : public OGRLayer
     }
     OGRErr ISetFeature(OGRFeature *poFeature) override;
     OGRErr ICreateFeature(OGRFeature *poFeature) override;
-    OGRErr CreateField(OGRFieldDefn *poField, int bApproxOK = TRUE) override;
+    OGRErr CreateField(const OGRFieldDefn *poField,
+                       int bApproxOK = TRUE) override;
     OGRErr DeleteField(int iField) override;
     OGRErr ReorderFields(int *panMap) override;
     OGRErr AlterFieldDefn(int iField, OGRFieldDefn *poNewFieldDefn,

--- a/ogr/ogrsf_frmts/selafin/ogrselafinlayer.cpp
+++ b/ogr/ogrsf_frmts/selafin/ogrselafinlayer.cpp
@@ -679,7 +679,7 @@ OGRErr OGRSelafinLayer::ICreateFeature(OGRFeature *poFeature)
 /************************************************************************/
 /*                           CreateField()                              */
 /************************************************************************/
-OGRErr OGRSelafinLayer::CreateField(OGRFieldDefn *poField,
+OGRErr OGRSelafinLayer::CreateField(const OGRFieldDefn *poField,
                                     CPL_UNUSED int bApproxOK)
 {
     CPLDebug("Selafin", "CreateField(%s,%s)", poField->GetNameRef(),

--- a/ogr/ogrsf_frmts/shape/ogrshape.h
+++ b/ogr/ogrsf_frmts/shape/ogrshape.h
@@ -260,7 +260,8 @@ class OGRShapeLayer final : public OGRAbstractProxiedLayer
         return OGRLayer::GetExtent(iGeomField, psExtent, bForce);
     }
 
-    OGRErr CreateField(OGRFieldDefn *poField, int bApproxOK = TRUE) override;
+    OGRErr CreateField(const OGRFieldDefn *poField,
+                       int bApproxOK = TRUE) override;
     OGRErr DeleteField(int iField) override;
     OGRErr ReorderFields(int *panMap) override;
     OGRErr AlterFieldDefn(int iField, OGRFieldDefn *poNewFieldDefn,

--- a/ogr/ogrsf_frmts/shape/ogrshapelayer.cpp
+++ b/ogr/ogrsf_frmts/shape/ogrshapelayer.cpp
@@ -1814,7 +1814,8 @@ int OGRShapeLayer::TestCapability(const char *pszCap)
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGRShapeLayer::CreateField(OGRFieldDefn *poFieldDefn, int bApproxOK)
+OGRErr OGRShapeLayer::CreateField(const OGRFieldDefn *poFieldDefn,
+                                  int bApproxOK)
 
 {
     if (!StartUpdate("CreateField"))

--- a/ogr/ogrsf_frmts/sqlite/ogr_sqlite.h
+++ b/ogr/ogrsf_frmts/sqlite/ogr_sqlite.h
@@ -384,7 +384,7 @@ class OGRSQLiteTableLayer final : public OGRSQLiteLayer
     virtual OGRErr DeleteFeature(GIntBig nFID) override;
     virtual OGRErr ICreateFeature(OGRFeature *poFeature) override;
 
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
     virtual OGRErr CreateGeomField(OGRGeomFieldDefn *poGeomFieldIn,
                                    int bApproxOK = TRUE) override;

--- a/ogr/ogrsf_frmts/sqlite/ogr_sqlite.h
+++ b/ogr/ogrsf_frmts/sqlite/ogr_sqlite.h
@@ -386,7 +386,7 @@ class OGRSQLiteTableLayer final : public OGRSQLiteLayer
 
     virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
-    virtual OGRErr CreateGeomField(OGRGeomFieldDefn *poGeomFieldIn,
+    virtual OGRErr CreateGeomField(const OGRGeomFieldDefn *poGeomFieldIn,
                                    int bApproxOK = TRUE) override;
     virtual OGRErr DeleteField(int iField) override;
     virtual OGRErr ReorderFields(int *panMap) override;

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitetablelayer.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitetablelayer.cpp
@@ -1632,8 +1632,9 @@ OGRErr OGRSQLiteTableLayer::CreateField(const OGRFieldDefn *poFieldIn,
 /*                           CreateGeomField()                          */
 /************************************************************************/
 
-OGRErr OGRSQLiteTableLayer::CreateGeomField(OGRGeomFieldDefn *poGeomFieldIn,
-                                            CPL_UNUSED int bApproxOK)
+OGRErr
+OGRSQLiteTableLayer::CreateGeomField(const OGRGeomFieldDefn *poGeomFieldIn,
+                                     CPL_UNUSED int bApproxOK)
 {
     OGRwkbGeometryType eType = poGeomFieldIn->GetType();
     if (eType == wkbNone)

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitetablelayer.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitetablelayer.cpp
@@ -1517,7 +1517,7 @@ OGRSQLiteTableLayer::FieldDefnToSQliteFieldDefn(OGRFieldDefn *poFieldDefn)
 /*                            CreateField()                             */
 /************************************************************************/
 
-OGRErr OGRSQLiteTableLayer::CreateField(OGRFieldDefn *poFieldIn,
+OGRErr OGRSQLiteTableLayer::CreateField(const OGRFieldDefn *poFieldIn,
                                         CPL_UNUSED int bApproxOK)
 {
     OGRFieldDefn oField(poFieldIn);

--- a/ogr/ogrsf_frmts/vdv/ogr_vdv.h
+++ b/ogr/ogrsf_frmts/vdv/ogr_vdv.h
@@ -170,7 +170,7 @@ class OGRVDVWriterLayer final : public OGRLayer
         return m_poFeatureDefn;
     }
     virtual int TestCapability(const char *pszCap) override;
-    virtual OGRErr CreateField(OGRFieldDefn *poFieldDefn,
+    virtual OGRErr CreateField(const OGRFieldDefn *poFieldDefn,
                                int bApproxOK = TRUE) override;
     virtual OGRErr ICreateFeature(OGRFeature *poFeature) override;
     virtual GIntBig GetFeatureCount(int bForce = TRUE) override;

--- a/ogr/ogrsf_frmts/vdv/ogrvdvdatasource.cpp
+++ b/ogr/ogrsf_frmts/vdv/ogrvdvdatasource.cpp
@@ -1527,7 +1527,7 @@ GIntBig OGRVDVWriterLayer::GetFeatureCount(int)
 /*                          CreateField()                               */
 /************************************************************************/
 
-OGRErr OGRVDVWriterLayer::CreateField(OGRFieldDefn *poFieldDefn,
+OGRErr OGRVDVWriterLayer::CreateField(const OGRFieldDefn *poFieldDefn,
                                       int /* bApprox */)
 {
     if (m_nFeatureCount >= 0)

--- a/ogr/ogrsf_frmts/wasp/ogrwasp.h
+++ b/ogr/ogrsf_frmts/wasp/ogrwasp.h
@@ -159,7 +159,7 @@ class OGRWAsPLayer final : public OGRLayer,
 
     virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
-    virtual OGRErr CreateGeomField(OGRGeomFieldDefn *poGeomField,
+    virtual OGRErr CreateGeomField(const OGRGeomFieldDefn *poGeomField,
                                    int bApproxOK = TRUE) override;
 
     virtual OGRErr ICreateFeature(OGRFeature *poFeature) override;

--- a/ogr/ogrsf_frmts/wasp/ogrwasp.h
+++ b/ogr/ogrsf_frmts/wasp/ogrwasp.h
@@ -157,7 +157,7 @@ class OGRWAsPLayer final : public OGRLayer,
     virtual void ResetReading() override;
     virtual int TestCapability(const char *) override;
 
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
     virtual OGRErr CreateGeomField(OGRGeomFieldDefn *poGeomField,
                                    int bApproxOK = TRUE) override;

--- a/ogr/ogrsf_frmts/wasp/ogrwasplayer.cpp
+++ b/ogr/ogrsf_frmts/wasp/ogrwasplayer.cpp
@@ -698,7 +698,7 @@ OGRErr OGRWAsPLayer::ICreateFeature(OGRFeature *poFeature)
 /*                            CreateField()                            */
 /************************************************************************/
 
-OGRErr OGRWAsPLayer::CreateField(OGRFieldDefn *poField,
+OGRErr OGRWAsPLayer::CreateField(const OGRFieldDefn *poField,
                                  CPL_UNUSED int bApproxOK)
 {
     poLayerDefn->AddFieldDefn(poField);

--- a/ogr/ogrsf_frmts/wasp/ogrwasplayer.cpp
+++ b/ogr/ogrsf_frmts/wasp/ogrwasplayer.cpp
@@ -716,7 +716,7 @@ OGRErr OGRWAsPLayer::CreateField(const OGRFieldDefn *poField,
 /*                           CreateGeomField()                          */
 /************************************************************************/
 
-OGRErr OGRWAsPLayer::CreateGeomField(OGRGeomFieldDefn *poGeomFieldIn,
+OGRErr OGRWAsPLayer::CreateGeomField(const OGRGeomFieldDefn *poGeomFieldIn,
                                      CPL_UNUSED int bApproxOK)
 {
     OGRGeomFieldDefn oFieldDefn(poGeomFieldIn);

--- a/ogr/ogrsf_frmts/xlsx/ogr_xlsx.h
+++ b/ogr/ogrsf_frmts/xlsx/ogr_xlsx.h
@@ -131,7 +131,7 @@ class OGRXLSXLayer final : public OGRMemLayer
         return OGRMemLayer::GetFeatureCount(bForce);
     }
 
-    virtual OGRErr CreateField(OGRFieldDefn *poField,
+    virtual OGRErr CreateField(const OGRFieldDefn *poField,
                                int bApproxOK = TRUE) override;
 
     virtual OGRErr DeleteField(int iField) override

--- a/ogr/ogrsf_frmts/xlsx/ogrxlsxdatasource.cpp
+++ b/ogr/ogrsf_frmts/xlsx/ogrxlsxdatasource.cpp
@@ -107,7 +107,7 @@ OGRFeature *OGRXLSXLayer::GetNextFeature()
     return poFeature;
 }
 
-OGRErr OGRXLSXLayer::CreateField(OGRFieldDefn *poField, int bApproxOK)
+OGRErr OGRXLSXLayer::CreateField(const OGRFieldDefn *poField, int bApproxOK)
 {
     Init();
     if (GetLayerDefn()->GetFieldCount() >= 2000)


### PR DESCRIPTION
## What does this PR do?

Change `OGRLayer::CreateField` interface to accept a `const OGRField*`, reflecting the semantics of current implementations.

Avoids the need to call the non-const `OGRFeatureDefn::GetFieldDefn` only to pass the return value along to `OGRLayer::CreateField`.

Does not touch drivers not included in my local build (can address these if the overall approach is sound).

## What are related issues/pull requests?

## Tasklist

 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
