### PR TITLE
sqlite_rtree_bulk_load.c: define __STDC_FORMAT_MACROS

### DIFF
--- a/ogr/ogrsf_frmts/sqlite/sqlite_rtree_bulk_load/sqlite_rtree_bulk_load.c
+++ b/ogr/ogrsf_frmts/sqlite/sqlite_rtree_bulk_load/sqlite_rtree_bulk_load.c
@@ -26,6 +26,10 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include "sqlite_rtree_bulk_load.h"
 
 #include <assert.h>


### PR DESCRIPTION
## What does this PR do?

The PR fixes the build of `gdal` for systems where `__STDC_FORMAT_MACROS` has to be defined in order to use `PRI*` macros.

## What are related issues/pull requests?

See also: https://trac.macports.org/ticket/68734

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: macOS 10.6
* Compiler: gcc13

P. S. Notice that while `gcc` advises to `#include <cinttypes>`, which indeed gonna work for it, some older macOS with clang will still be left broken. Defining instead `__STDC_FORMAT_MACROS` fixes all of them. Whether `<inttypes.h>` or `<cinttypes>` is used is then inconsequential.