### PR TITLE
[Backport release/3.8] sqlite_rtree_bulk_load.c: define __STDC_FORMAT_MACROS

### DIFF
--- a/ogr/ogrsf_frmts/sqlite/sqlite_rtree_bulk_load/sqlite_rtree_bulk_load.c
+++ b/ogr/ogrsf_frmts/sqlite/sqlite_rtree_bulk_load/sqlite_rtree_bulk_load.c
@@ -26,6 +26,10 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+
 #include "sqlite_rtree_bulk_load.h"
 
 #include <assert.h>


### PR DESCRIPTION
Backport #8748
 **Authored by:** @barracuda156