### PR TITLE
Check availability of std::shared_mutex with configure build test

### DIFF
--- a/cmake/helpers/configure.cmake
+++ b/cmake/helpers/configure.cmake
@@ -361,38 +361,11 @@ else ()
 
   check_cxx_source_compiles(
     "
-    #include <mutex>
     #include <shared_mutex>
     int main(int argc, const char * argv[]) {
         std::shared_mutex smtx;
-        int product = 0;
-        auto writer = [&smtx, &product](int start, int end)
-        {
-            for (int i = start; i < end; ++i)
-            {
-                auto data = i;
-                {
-                    std::unique_lock<std::shared_mutex> lock(smtx);
-                    product = data;
-                }
-            }
-            smtx.lock();
-            smtx.unlock();
-        };
-        auto reader = [&smtx, &product]()
-        {
-            int data = 0;
-            std::vector<int> seen;
-            do
-            {
-                {
-                    smtx.lock_shared();
-                    data = product;
-                    smtx.unlock_shared();
-                }
-            }
-            while (1);
-        };
+        smtx.lock_shared();
+        smtx.unlock_shared();
         return 0;
     }
     "

--- a/cmake/template/cpl_config.h.in
+++ b/cmake/template/cpl_config.h.in
@@ -175,6 +175,9 @@
 /* Define to 1 if you have the `sched_getaffinity' function. */
 #cmakedefine HAVE_SCHED_GETAFFINITY 1
 
+/* Define to 1 if you have the `std::shared_mutex' function. */
+#cmakedefine HAVE_SHARED_MUTEX 1
+
 /* Define to 1 if you have the `uselocale' function. */
 #cmakedefine HAVE_USELOCALE 1
 

--- a/port/cpl_vsi_mem.cpp
+++ b/port/cpl_vsi_mem.cpp
@@ -50,7 +50,7 @@
 
 #include <mutex>
 // c++17 or VS2017
-#if __cplusplus >= 201703L || _MSC_VER >= 1910
+#if defined(HAVE_SHARED_MUTEX) || _MSC_VER >= 1910
 #include <shared_mutex>
 #define CPL_SHARED_MUTEX_TYPE std::shared_mutex
 #define CPL_SHARED_LOCK std::shared_lock<std::shared_mutex>


### PR DESCRIPTION
Older systems/compilers (or combinations thereof) may not have all C++17 features implemented and checking for `__cplusplus >= 201703L` is apparently not enough.

That is the case on Mac with failing builds of MacOSX 10.7–10.11 as reported with https://trac.macports.org/ticket/68716 (resulting in `Undefined symbols for architecture x86_64:   "std::__1::__shared_mutex_base::lock_shared()" ...` build error).

The patch submitted here, where the presence and usability of `std::shared_mutex` is tested during configuration, is tested with and works for macOS 13 as well as MacOSX 10.7.

(The `check_cxx_source_compiles` code is shamelessly taken and modified from cppreference.com).