### PR TITLE
Enable removal of virtual filesystems

### DIFF
--- a/port/cpl_vsi.h
+++ b/port/cpl_vsi.h
@@ -719,6 +719,13 @@ void CPL_DLL VSIFreeFilesystemPluginCallbacksStruct(
 int CPL_DLL VSIInstallPluginHandler(
     const char *pszPrefix, const VSIFilesystemPluginCallbacksStruct *poCb);
 
+/**
+ * Unregister a handler previously installed with VSIInstallPluginHandler() on
+ * the given prefix.
+ * @since GDAL 3.9
+ */
+int CPL_DLL VSIRemovePluginHandler(const char *pszPrefix);
+
 /* ==================================================================== */
 /*      Time querying.                                                  */
 /* ==================================================================== */

--- a/port/cpl_vsi_virtual.h
+++ b/port/cpl_vsi_virtual.h
@@ -327,8 +327,7 @@ class CPL_DLL VSIFileManager
     static VSIFilesystemHandler *GetHandler(const char *);
     static void InstallHandler(const std::string &osPrefix,
                                VSIFilesystemHandler *);
-    /* RemoveHandler is never defined. */
-    /* static void RemoveHandler( const std::string& osPrefix ); */
+    static void RemoveHandler(const std::string& osPrefix);
 
     static char **GetPrefixes();
 };

--- a/port/cpl_vsil.cpp
+++ b/port/cpl_vsil.cpp
@@ -3254,6 +3254,18 @@ void VSIFileManager::InstallHandler(const std::string &osPrefix,
 }
 
 /************************************************************************/
+/*                          RemoveHandler()                             */
+/************************************************************************/
+
+void VSIFileManager::RemoveHandler(const std::string& osPrefix)
+{
+    if (osPrefix == "")
+        Get()->poDefaultHandler = nullptr;
+    else
+        Get()->oHandlers.erase(osPrefix);
+}
+
+/************************************************************************/
 /*                       VSICleanupFileManager()                        */
 /************************************************************************/
 

--- a/port/cpl_vsil_plugin.cpp
+++ b/port/cpl_vsil_plugin.cpp
@@ -470,6 +470,12 @@ int VSIInstallPluginHandler(const char *pszPrefix,
     return 0;
 }
 
+int VSIRemovePluginHandler(const char *pszPrefix)
+{
+    VSIFileManager::RemoveHandler(pszPrefix);
+    return 0;
+}
+
 VSIFilesystemPluginCallbacksStruct *
 VSIAllocFilesystemPluginCallbacksStruct(void)
 {


### PR DESCRIPTION
## What does this PR do?

This PR enables the removal of installed virtual filesystems. 

## What are related issues/pull requests?

Not in GDAL, but over in DuckDB Spatial I've ran into multiple problems as a result of trying to integrate DuckDB's own filesystem abstractions into GDAL since we don't assume that there is a "global" filesystem. New filesystems can be attached or removed at runtime and are tied to the lifetime of a connection (of which there can be multiple simultaneously in different threads). My solution is to give every new connection its own filesystem handler with a random and unique prefix, which keeps connections from interfering with each other, but ideally I'd like to be able to remove the attached filesystem as well once a connection is closed. Hence, this patch.

## Tasklist

 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: MacOS 13.4
* Compiler: Homebrew Clang 16.0.6
