### PR TITLE
[Backport release/3.8] Add a OGRPARSEDATE_OPTION_LAX option to OGRParseDate() and use it when reading GPKG files (fixes #8759)

### DIFF
--- a/autotest/cpp/test_ogr.cpp
+++ b/autotest/cpp/test_ogr.cpp
@@ -452,133 +452,199 @@ TEST_F(test_ogr, style_manager)
 TEST_F(test_ogr, OGRParseDate)
 {
     OGRField sField;
-    ASSERT_EQ(OGRParseDate("2017/11/31 12:34:56", &sField, 0), TRUE);
-    ASSERT_EQ(sField.Date.Year, 2017);
-    ASSERT_EQ(sField.Date.Month, 11);
-    ASSERT_EQ(sField.Date.Day, 31);
-    ASSERT_EQ(sField.Date.Hour, 12);
-    ASSERT_EQ(sField.Date.Minute, 34);
-    ASSERT_EQ(sField.Date.Second, 56.0f);
-    ASSERT_EQ(sField.Date.TZFlag, 0);
+    EXPECT_EQ(OGRParseDate("2017/11/31 12:34:56", &sField, 0), TRUE);
+    EXPECT_EQ(sField.Date.Year, 2017);
+    EXPECT_EQ(sField.Date.Month, 11);
+    EXPECT_EQ(sField.Date.Day, 31);
+    EXPECT_EQ(sField.Date.Hour, 12);
+    EXPECT_EQ(sField.Date.Minute, 34);
+    EXPECT_EQ(sField.Date.Second, 56.0f);
+    EXPECT_EQ(sField.Date.TZFlag, 0);
 
-    ASSERT_EQ(OGRParseDate("2017/11/31 12:34:56+00", &sField, 0), TRUE);
-    ASSERT_EQ(sField.Date.TZFlag, 100);
+    EXPECT_EQ(OGRParseDate("2017/11/31 12:34:56+00", &sField, 0), TRUE);
+    EXPECT_EQ(sField.Date.TZFlag, 100);
 
-    ASSERT_EQ(OGRParseDate("2017/11/31 12:34:56+12:00", &sField, 0), TRUE);
-    ASSERT_EQ(sField.Date.TZFlag, 100 + 12 * 4);
+    EXPECT_EQ(OGRParseDate("2017/11/31 12:34:56+12:00", &sField, 0), TRUE);
+    EXPECT_EQ(sField.Date.TZFlag, 100 + 12 * 4);
 
-    ASSERT_EQ(OGRParseDate("2017/11/31 12:34:56+1200", &sField, 0), TRUE);
-    ASSERT_EQ(sField.Date.TZFlag, 100 + 12 * 4);
+    EXPECT_EQ(OGRParseDate("2017/11/31 12:34:56+1200", &sField, 0), TRUE);
+    EXPECT_EQ(sField.Date.TZFlag, 100 + 12 * 4);
 
-    ASSERT_EQ(OGRParseDate("2017/11/31 12:34:56+815", &sField, 0), TRUE);
-    ASSERT_EQ(sField.Date.TZFlag, 100 + 8 * 4 + 1);
+    EXPECT_EQ(OGRParseDate("2017/11/31 12:34:56+815", &sField, 0), TRUE);
+    EXPECT_EQ(sField.Date.TZFlag, 100 + 8 * 4 + 1);
 
-    ASSERT_EQ(OGRParseDate("2017/11/31 12:34:56-12:00", &sField, 0), TRUE);
-    ASSERT_EQ(sField.Date.TZFlag, 100 - 12 * 4);
+    EXPECT_EQ(OGRParseDate("2017/11/31 12:34:56-12:00", &sField, 0), TRUE);
+    EXPECT_EQ(sField.Date.TZFlag, 100 - 12 * 4);
 
-    ASSERT_EQ(OGRParseDate(" 2017/11/31 12:34:56", &sField, 0), TRUE);
-    ASSERT_EQ(sField.Date.Year, 2017);
+    EXPECT_EQ(OGRParseDate(" 2017/11/31 12:34:56", &sField, 0), TRUE);
+    EXPECT_EQ(sField.Date.Year, 2017);
 
-    ASSERT_EQ(OGRParseDate("2017/11/31 12:34:56.789", &sField, 0), TRUE);
-    ASSERT_EQ(sField.Date.Second, 56.789f);
+    EXPECT_EQ(OGRParseDate("2017/11/31 12:34:56.789", &sField, 0), TRUE);
+    EXPECT_EQ(sField.Date.Second, 56.789f);
 
     // Leap second
-    ASSERT_EQ(OGRParseDate("2017/11/31 12:34:60", &sField, 0), TRUE);
-    ASSERT_EQ(sField.Date.Second, 60.0f);
+    EXPECT_EQ(OGRParseDate("2017/11/31 12:34:60", &sField, 0), TRUE);
+    EXPECT_EQ(sField.Date.Second, 60.0f);
 
-    ASSERT_EQ(OGRParseDate("2017-11-31T12:34:56", &sField, 0), TRUE);
-    ASSERT_EQ(sField.Date.Year, 2017);
-    ASSERT_EQ(sField.Date.Month, 11);
-    ASSERT_EQ(sField.Date.Day, 31);
-    ASSERT_EQ(sField.Date.Hour, 12);
-    ASSERT_EQ(sField.Date.Minute, 34);
-    ASSERT_EQ(sField.Date.Second, 56.0f);
-    ASSERT_EQ(sField.Date.TZFlag, 0);
+    EXPECT_EQ(OGRParseDate("2017-11-31T12:34:56", &sField, 0), TRUE);
+    EXPECT_EQ(sField.Date.Year, 2017);
+    EXPECT_EQ(sField.Date.Month, 11);
+    EXPECT_EQ(sField.Date.Day, 31);
+    EXPECT_EQ(sField.Date.Hour, 12);
+    EXPECT_EQ(sField.Date.Minute, 34);
+    EXPECT_EQ(sField.Date.Second, 56.0f);
+    EXPECT_EQ(sField.Date.TZFlag, 0);
 
-    ASSERT_EQ(OGRParseDate("2017-11-31T12:34:56Z", &sField, 0), TRUE);
-    ASSERT_EQ(sField.Date.Second, 56.0f);
-    ASSERT_EQ(sField.Date.TZFlag, 100);
+    EXPECT_EQ(OGRParseDate("2017-11-31T12:34:56Z", &sField, 0), TRUE);
+    EXPECT_EQ(sField.Date.Second, 56.0f);
+    EXPECT_EQ(sField.Date.TZFlag, 100);
 
-    ASSERT_EQ(OGRParseDate("2017-11-31T12:34:56.789Z", &sField, 0), TRUE);
-    ASSERT_EQ(sField.Date.Second, 56.789f);
-    ASSERT_EQ(sField.Date.TZFlag, 100);
+    EXPECT_EQ(OGRParseDate("2017-11-31T12:34:56.789Z", &sField, 0), TRUE);
+    EXPECT_EQ(sField.Date.Second, 56.789f);
+    EXPECT_EQ(sField.Date.TZFlag, 100);
 
-    ASSERT_EQ(OGRParseDate("2017-11-31", &sField, 0), TRUE);
-    ASSERT_EQ(sField.Date.Year, 2017);
-    ASSERT_EQ(sField.Date.Month, 11);
-    ASSERT_EQ(sField.Date.Day, 31);
-    ASSERT_EQ(sField.Date.Hour, 0);
-    ASSERT_EQ(sField.Date.Minute, 0);
-    ASSERT_EQ(sField.Date.Second, 0.0f);
-    ASSERT_EQ(sField.Date.TZFlag, 0);
+    EXPECT_EQ(OGRParseDate("2017-11-31", &sField, 0), TRUE);
+    EXPECT_EQ(sField.Date.Year, 2017);
+    EXPECT_EQ(sField.Date.Month, 11);
+    EXPECT_EQ(sField.Date.Day, 31);
+    EXPECT_EQ(sField.Date.Hour, 0);
+    EXPECT_EQ(sField.Date.Minute, 0);
+    EXPECT_EQ(sField.Date.Second, 0.0f);
+    EXPECT_EQ(sField.Date.TZFlag, 0);
 
-    ASSERT_EQ(OGRParseDate("2017-11-31Z", &sField, 0), TRUE);
-    ASSERT_EQ(sField.Date.Year, 2017);
-    ASSERT_EQ(sField.Date.Month, 11);
-    ASSERT_EQ(sField.Date.Day, 31);
-    ASSERT_EQ(sField.Date.Hour, 0);
-    ASSERT_EQ(sField.Date.Minute, 0);
-    ASSERT_EQ(sField.Date.Second, 0.0f);
-    ASSERT_EQ(sField.Date.TZFlag, 0);
+    EXPECT_EQ(OGRParseDate("2017-11-31Z", &sField, 0), TRUE);
+    EXPECT_EQ(sField.Date.Year, 2017);
+    EXPECT_EQ(sField.Date.Month, 11);
+    EXPECT_EQ(sField.Date.Day, 31);
+    EXPECT_EQ(sField.Date.Hour, 0);
+    EXPECT_EQ(sField.Date.Minute, 0);
+    EXPECT_EQ(sField.Date.Second, 0.0f);
+    EXPECT_EQ(sField.Date.TZFlag, 0);
 
-    ASSERT_EQ(OGRParseDate("12:34", &sField, 0), TRUE);
-    ASSERT_EQ(sField.Date.Year, 0);
-    ASSERT_EQ(sField.Date.Month, 0);
-    ASSERT_EQ(sField.Date.Day, 0);
-    ASSERT_EQ(sField.Date.Hour, 12);
-    ASSERT_EQ(sField.Date.Minute, 34);
-    ASSERT_EQ(sField.Date.Second, 0.0f);
-    ASSERT_EQ(sField.Date.TZFlag, 0);
+    EXPECT_EQ(OGRParseDate("12:34", &sField, 0), TRUE);
+    EXPECT_EQ(sField.Date.Year, 0);
+    EXPECT_EQ(sField.Date.Month, 0);
+    EXPECT_EQ(sField.Date.Day, 0);
+    EXPECT_EQ(sField.Date.Hour, 12);
+    EXPECT_EQ(sField.Date.Minute, 34);
+    EXPECT_EQ(sField.Date.Second, 0.0f);
+    EXPECT_EQ(sField.Date.TZFlag, 0);
 
-    ASSERT_EQ(OGRParseDate("12:34:56", &sField, 0), TRUE);
-    ASSERT_EQ(OGRParseDate("12:34:56.789", &sField, 0), TRUE);
+    EXPECT_EQ(OGRParseDate("12:34:56", &sField, 0), TRUE);
+    EXPECT_EQ(OGRParseDate("12:34:56.789", &sField, 0), TRUE);
 
-    ASSERT_EQ(OGRParseDate("T12:34:56", &sField, 0), TRUE);
-    ASSERT_EQ(sField.Date.Year, 0);
-    ASSERT_EQ(sField.Date.Month, 0);
-    ASSERT_EQ(sField.Date.Day, 0);
-    ASSERT_EQ(sField.Date.Hour, 12);
-    ASSERT_EQ(sField.Date.Minute, 34);
-    ASSERT_EQ(sField.Date.Second, 56.0f);
-    ASSERT_EQ(sField.Date.TZFlag, 0);
+    EXPECT_EQ(OGRParseDate("T12:34:56", &sField, 0), TRUE);
+    EXPECT_EQ(sField.Date.Year, 0);
+    EXPECT_EQ(sField.Date.Month, 0);
+    EXPECT_EQ(sField.Date.Day, 0);
+    EXPECT_EQ(sField.Date.Hour, 12);
+    EXPECT_EQ(sField.Date.Minute, 34);
+    EXPECT_EQ(sField.Date.Second, 56.0f);
+    EXPECT_EQ(sField.Date.TZFlag, 0);
 
-    ASSERT_EQ(OGRParseDate("T123456", &sField, 0), TRUE);
-    ASSERT_EQ(sField.Date.Year, 0);
-    ASSERT_EQ(sField.Date.Month, 0);
-    ASSERT_EQ(sField.Date.Day, 0);
-    ASSERT_EQ(sField.Date.Hour, 12);
-    ASSERT_EQ(sField.Date.Minute, 34);
-    ASSERT_EQ(sField.Date.Second, 56.0f);
-    ASSERT_EQ(sField.Date.TZFlag, 0);
+    EXPECT_EQ(OGRParseDate("T123456", &sField, 0), TRUE);
+    EXPECT_EQ(sField.Date.Year, 0);
+    EXPECT_EQ(sField.Date.Month, 0);
+    EXPECT_EQ(sField.Date.Day, 0);
+    EXPECT_EQ(sField.Date.Hour, 12);
+    EXPECT_EQ(sField.Date.Minute, 34);
+    EXPECT_EQ(sField.Date.Second, 56.0f);
+    EXPECT_EQ(sField.Date.TZFlag, 0);
 
-    ASSERT_EQ(OGRParseDate("T123456.789", &sField, 0), TRUE);
-    ASSERT_EQ(sField.Date.Year, 0);
-    ASSERT_EQ(sField.Date.Month, 0);
-    ASSERT_EQ(sField.Date.Day, 0);
-    ASSERT_EQ(sField.Date.Hour, 12);
-    ASSERT_EQ(sField.Date.Minute, 34);
-    ASSERT_EQ(sField.Date.Second, 56.789f);
-    ASSERT_EQ(sField.Date.TZFlag, 0);
+    EXPECT_EQ(OGRParseDate("T123456.789", &sField, 0), TRUE);
+    EXPECT_EQ(sField.Date.Year, 0);
+    EXPECT_EQ(sField.Date.Month, 0);
+    EXPECT_EQ(sField.Date.Day, 0);
+    EXPECT_EQ(sField.Date.Hour, 12);
+    EXPECT_EQ(sField.Date.Minute, 34);
+    EXPECT_EQ(sField.Date.Second, 56.789f);
+    EXPECT_EQ(sField.Date.TZFlag, 0);
 
-    ASSERT_TRUE(!OGRParseDate("2017", &sField, 0));
-    ASSERT_TRUE(!OGRParseDate("12:", &sField, 0));
-    ASSERT_TRUE(!OGRParseDate("12:3", &sField, 0));
-    ASSERT_TRUE(!OGRParseDate("1:23", &sField, 0));
-    ASSERT_TRUE(!OGRParseDate("12:34:5", &sField, 0));
-    ASSERT_TRUE(!OGRParseDate("2017-a-31T12:34:56", &sField, 0));
-    ASSERT_TRUE(!OGRParseDate("2017-00-31T12:34:56", &sField, 0));
-    ASSERT_TRUE(!OGRParseDate("2017-13-31T12:34:56", &sField, 0));
-    ASSERT_TRUE(!OGRParseDate("2017-01-00T12:34:56", &sField, 0));
-    ASSERT_TRUE(!OGRParseDate("2017-01-aT12:34:56", &sField, 0));
-    ASSERT_TRUE(!OGRParseDate("2017-01-32T12:34:56", &sField, 0));
-    ASSERT_TRUE(!OGRParseDate("a:34:56", &sField, 0));
-    ASSERT_TRUE(!OGRParseDate("2017-01-01Ta:34:56", &sField, 0));
-    ASSERT_TRUE(!OGRParseDate("2017-01-01T25:34:56", &sField, 0));
-    ASSERT_TRUE(!OGRParseDate("2017-01-01T00:a:00", &sField, 0));
-    ASSERT_TRUE(!OGRParseDate("2017-01-01T00: 34:56", &sField, 0));
-    ASSERT_TRUE(!OGRParseDate("2017-01-01T00:61:00", &sField, 0));
-    ASSERT_TRUE(!OGRParseDate("2017-01-01T00:00:61", &sField, 0));
-    ASSERT_TRUE(!OGRParseDate("2017-01-01T00:00:a", &sField, 0));
+    CPLPushErrorHandler(CPLQuietErrorHandler);
+    EXPECT_TRUE(!OGRParseDate("123456-01-01", &sField, 0));
+    CPLPopErrorHandler();
+    EXPECT_TRUE(!OGRParseDate("2017", &sField, 0));
+    EXPECT_TRUE(!OGRParseDate("2017x-01-01", &sField, 0));
+    EXPECT_TRUE(!OGRParseDate("2017-1-01", &sField, 0));
+    EXPECT_TRUE(!OGRParseDate("2017-01-1", &sField, 0));
+    EXPECT_TRUE(!OGRParseDate("2017-01-01x", &sField, 0));
+    EXPECT_TRUE(!OGRParseDate("12:", &sField, 0));
+    EXPECT_TRUE(!OGRParseDate("12:3", &sField, 0));
+    EXPECT_TRUE(!OGRParseDate("1:23", &sField, 0));
+    EXPECT_TRUE(!OGRParseDate("12:34:5", &sField, 0));
+    EXPECT_TRUE(!OGRParseDate("1a:34", &sField, 0));
+    EXPECT_TRUE(!OGRParseDate("2017-a-31T12:34:56", &sField, 0));
+    EXPECT_TRUE(!OGRParseDate("2017-00-31T12:34:56", &sField, 0));
+    EXPECT_TRUE(!OGRParseDate("2017-13-31T12:34:56", &sField, 0));
+    EXPECT_TRUE(!OGRParseDate("2017-01-00T12:34:56", &sField, 0));
+    EXPECT_TRUE(!OGRParseDate("2017-01-aT12:34:56", &sField, 0));
+    EXPECT_TRUE(!OGRParseDate("2017-01-32T12:34:56", &sField, 0));
+    EXPECT_TRUE(!OGRParseDate("a:34:56", &sField, 0));
+    EXPECT_TRUE(!OGRParseDate("2017-01-01Ta:34:56", &sField, 0));
+    EXPECT_TRUE(!OGRParseDate("2017-01-01T25:34:56", &sField, 0));
+    EXPECT_TRUE(!OGRParseDate("2017-01-01T00:a:00", &sField, 0));
+    EXPECT_TRUE(!OGRParseDate("2017-01-01T00: 34:56", &sField, 0));
+    EXPECT_TRUE(!OGRParseDate("2017-01-01T00:61:00", &sField, 0));
+    EXPECT_TRUE(!OGRParseDate("2017-01-01T00:00:61", &sField, 0));
+    EXPECT_TRUE(!OGRParseDate("2017-01-01T00:00:a", &sField, 0));
+
+    // Test OGRPARSEDATE_OPTION_LAX
+    EXPECT_EQ(OGRParseDate("2017-1-9", &sField, OGRPARSEDATE_OPTION_LAX), TRUE);
+    EXPECT_EQ(sField.Date.Year, 2017);
+    EXPECT_EQ(sField.Date.Month, 1);
+    EXPECT_EQ(sField.Date.Day, 9);
+
+    EXPECT_EQ(OGRParseDate("2017-1-31", &sField, OGRPARSEDATE_OPTION_LAX),
+              TRUE);
+    EXPECT_EQ(sField.Date.Year, 2017);
+    EXPECT_EQ(sField.Date.Month, 1);
+    EXPECT_EQ(sField.Date.Day, 31);
+
+    EXPECT_EQ(OGRParseDate("2017-1-31T1:2:3", &sField, OGRPARSEDATE_OPTION_LAX),
+              TRUE);
+    EXPECT_EQ(sField.Date.Year, 2017);
+    EXPECT_EQ(sField.Date.Month, 1);
+    EXPECT_EQ(sField.Date.Day, 31);
+    EXPECT_EQ(sField.Date.Hour, 1);
+    EXPECT_EQ(sField.Date.Minute, 2);
+    EXPECT_EQ(sField.Date.Second, 3.0f);
+    EXPECT_EQ(sField.Date.TZFlag, 0);
+
+    EXPECT_EQ(OGRParseDate("2017-1-31T1:3", &sField, OGRPARSEDATE_OPTION_LAX),
+              TRUE);
+    EXPECT_EQ(sField.Date.Year, 2017);
+    EXPECT_EQ(sField.Date.Month, 1);
+    EXPECT_EQ(sField.Date.Day, 31);
+    EXPECT_EQ(sField.Date.Hour, 1);
+    EXPECT_EQ(sField.Date.Minute, 3);
+    EXPECT_EQ(sField.Date.Second, 0.0f);
+    EXPECT_EQ(sField.Date.TZFlag, 0);
+
+    EXPECT_EQ(OGRParseDate("1:3", &sField, OGRPARSEDATE_OPTION_LAX), TRUE);
+    EXPECT_EQ(sField.Date.Year, 0);
+    EXPECT_EQ(sField.Date.Month, 0);
+    EXPECT_EQ(sField.Date.Day, 0);
+    EXPECT_EQ(sField.Date.Hour, 1);
+    EXPECT_EQ(sField.Date.Minute, 3);
+    EXPECT_EQ(sField.Date.Second, 0.0f);
+    EXPECT_EQ(sField.Date.TZFlag, 0);
+
+    EXPECT_TRUE(!OGRParseDate("2017-a-01", &sField, OGRPARSEDATE_OPTION_LAX));
+    EXPECT_TRUE(!OGRParseDate("2017-0-01", &sField, OGRPARSEDATE_OPTION_LAX));
+    EXPECT_TRUE(!OGRParseDate("2017-1", &sField, OGRPARSEDATE_OPTION_LAX));
+    EXPECT_TRUE(!OGRParseDate("2017-1-", &sField, OGRPARSEDATE_OPTION_LAX));
+    EXPECT_TRUE(!OGRParseDate("2017-1-a", &sField, OGRPARSEDATE_OPTION_LAX));
+    EXPECT_TRUE(!OGRParseDate("2017-1-0", &sField, OGRPARSEDATE_OPTION_LAX));
+    EXPECT_TRUE(!OGRParseDate("2017-1-32", &sField, OGRPARSEDATE_OPTION_LAX));
+    EXPECT_TRUE(
+        !OGRParseDate("2017-1-1Ta:00:00", &sField, OGRPARSEDATE_OPTION_LAX));
+    EXPECT_TRUE(!OGRParseDate("2017-1-1T1", &sField, OGRPARSEDATE_OPTION_LAX));
+    EXPECT_TRUE(
+        !OGRParseDate("2017-1-1T00:a:00", &sField, OGRPARSEDATE_OPTION_LAX));
+    EXPECT_TRUE(!OGRParseDate("2017-1-1T1:", &sField, OGRPARSEDATE_OPTION_LAX));
+    EXPECT_TRUE(
+        !OGRParseDate("2017-1-1T00:00:a", &sField, OGRPARSEDATE_OPTION_LAX));
+    EXPECT_TRUE(!OGRParseDate("1a:3", &sField, OGRPARSEDATE_OPTION_LAX));
 }
 
 // Test OGRPolygon::IsPointOnSurface()

--- a/ogr/ogr_core.h
+++ b/ogr/ogr_core.h
@@ -973,6 +973,9 @@ inline int OGR_GET_MS(float fSec)
 }
 #endif  // __cplusplus
 
+/** Option for OGRParseDate() to ask for lax checks on the input format */
+#define OGRPARSEDATE_OPTION_LAX 1
+
 int CPL_DLL OGRParseDate(const char *pszInput, OGRField *psOutput,
                          int nOptions);
 

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagelayer.cpp
@@ -220,7 +220,7 @@ bool OGRGeoPackageLayer::ParseDateField(const char *pszTxt, OGRField *psField,
             bError = true;
         }
     }
-    else if (OGRParseDate(pszTxt, psField, 0))
+    else if (OGRParseDate(pszTxt, psField, OGRPARSEDATE_OPTION_LAX))
     {
         constexpr int line = __LINE__;
         if (!m_poDS->m_oSetGPKGLayerWarnings[line])
@@ -308,7 +308,7 @@ bool OGRGeoPackageLayer::ParseDateTimeField(const char *pszTxt,
         // nominal format is YYYYMMDDTHHMMSSsssZ before GeoPackage 1.4
         // GeoPackage 1.4 also accepts omission of seconds and milliseconds
     }
-    else if (OGRParseDate(pszTxt, psField, 0))
+    else if (OGRParseDate(pszTxt, psField, OGRPARSEDATE_OPTION_LAX))
     {
         constexpr int line = __LINE__;
         if (!m_poDS->m_oSetGPKGLayerWarnings[line])


### PR DESCRIPTION
Backport #8762
 **Authored by:** @rouault