### PR TITLE
gdalwarp: progress bar tunings

### DIFF
--- a/apps/gdalwarp_bin.cpp
+++ b/apps/gdalwarp_bin.cpp
@@ -149,6 +149,8 @@ static int CPL_STDCALL WarpTermProgress(double dfProgress,
     }
     else if (pszMessage != osLastMsg)
     {
+        if (!osLastMsg.empty())
+            GDALTermProgress(1.0, nullptr, nullptr);
         printf("%s : ", pszMessage);
         osLastMsg = pszMessage;
         iSrc++;

--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -2582,7 +2582,6 @@ static GDALDatasetH GDALWarpDirect(const char *pszDest, GDALDatasetH hDstDS,
          */
         hSrcDS = pahSrcDS[iSrc];
         oProgress.iSrc = iSrc;
-        oProgress.Do(0);
 
         /* --------------------------------------------------------------------
          */
@@ -3027,6 +3026,8 @@ static GDALDatasetH GDALWarpDirect(const char *pszDest, GDALDatasetH hDstDS,
          */
         SetupNoData(pszDest, iSrc, hSrcDS, hWrkSrcDS, hDstDS, psWO, psOptions,
                     bEnableDstAlpha, bInitDestSetByUser);
+
+        oProgress.Do(0);
 
         /* --------------------------------------------------------------------
          */


### PR DESCRIPTION
- make sure that progress for each source file goes to 100%
- display first progress bar after message about copying nodata values
