### PR TITLE
KEA: fix segfault in CreateCopy with truncated input (fixes #8743)

### DIFF
--- a/frmts/kea/keadataset.cpp
+++ b/frmts/kea/keadataset.cpp
@@ -279,7 +279,8 @@ H5::H5File *KEADataset::CreateLL(const char *pszFilename, int nXSize,
     catch (...)
     {
         CPLError(CE_Failure, CPLE_OpenFailed,
-                 "Attempt to create file `%s' failed. Error: Unknown\n", pszFilename);
+                 "Attempt to create file `%s' failed. Error: Unknown\n",
+                 pszFilename);
         return nullptr;
     }
 }

--- a/frmts/kea/keadataset.cpp
+++ b/frmts/kea/keadataset.cpp
@@ -276,6 +276,12 @@ H5::H5File *KEADataset::CreateLL(const char *pszFilename, int nXSize,
                  e.what());
         return nullptr;
     }
+    catch (...)
+    {
+        CPLError(CE_Failure, CPLE_OpenFailed,
+                 "Attempt to create file `%s' failed. Error: Unknown\n", pszFilename);
+        return nullptr;
+    }
 }
 
 // static function- pointer set in driver


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

GOOD: "GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

BAD: "Fix crash", "fix #1234"

In case you need several iterations to make continuous integration happy,
please squash your commits in a single one at the end. See
[Contributing](https://github.com/OSGeo/gdal/blob/master/CONTRIBUTING.md)
-->

## What does this PR do?

Ensures that all exceptions are handled within `KEADataset::CreateLL`. Previously only `KEAIOException` was handled and letting other exceptions bubble up from that function appeared to cause issues.

## What are related issues/pull requests?

#8743

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
