### PR TITLE
[Backport release/3.8] KEA: Create(): error out if passing a /vsi file. avoids crashes (fixes #8743)

### DIFF
--- a/autotest/gdrivers/kea.py
+++ b/autotest/gdrivers/kea.py
@@ -649,3 +649,14 @@ def test_kea_15(tmp_path, tmp_vsimem):
     ds = gdal.Open(tmp_vsimem / "foo.kea")
     assert ds.GetDriver().ShortName == "KEA"
     ds = None
+
+
+###############################################################################
+# Test /vsi functionality on writing (does not work)
+
+
+@gdaltest.enable_exceptions()
+def test_kea_create_vsimem(tmp_vsimem):
+
+    with pytest.raises(Exception):
+        gdaltest.kea_driver.Create(tmp_vsimem / "vsitest.kea", 1, 1)

--- a/frmts/kea/keadataset.cpp
+++ b/frmts/kea/keadataset.cpp
@@ -31,6 +31,7 @@
 #include "keaband.h"
 #include "keacopy.h"
 #include "../frmts/hdf5/hdf5vfl.h"
+#include "cpl_vsi_virtual.h"
 
 /************************************************************************/
 /*                     KEADatasetDriverUnload()                        */
@@ -179,6 +180,14 @@ GDALDataset *KEADataset::Open(GDALOpenInfo *poOpenInfo)
                      poOpenInfo->pszFilename, e.what());
             return nullptr;
         }
+        catch (...)
+        {
+            // was a problem - can't be a valid file
+            CPLError(CE_Failure, CPLE_OpenFailed,
+                     "Attempt to open file `%s' failed. Error: unknown\n",
+                     poOpenInfo->pszFilename);
+            return nullptr;
+        }
     }
     else
     {
@@ -230,6 +239,20 @@ H5::H5File *KEADataset::CreateLL(const char *pszFilename, int nXSize,
             pszFilename);
         return nullptr;
     }
+
+    // This helps avoiding issues with H5File handles in a bad state, that
+    // may cause crashes at process termination
+    // Cf https://github.com/OSGeo/gdal/issues/8743
+    if (VSIFileManager::GetHandler(pszFilename) !=
+        VSIFileManager::GetHandler(""))
+    {
+        CPLError(CE_Failure, CPLE_OpenFailed,
+                 "Attempt to create file `%s' failed. /vsi file systems not "
+                 "supported\n",
+                 pszFilename);
+        return nullptr;
+    }
+
     // process any creation options in papszParamList
     // default value
     unsigned int nimageblockSize = kealib::KEA_IMAGE_CHUNK_SIZE;
@@ -301,6 +324,13 @@ H5::H5File *KEADataset::CreateLL(const char *pszFilename, int nXSize,
         CPLError(CE_Failure, CPLE_OpenFailed,
                  "Attempt to create file `%s' failed. Error: %s\n", pszFilename,
                  e.what());
+        return nullptr;
+    }
+    catch (...)
+    {
+        CPLError(CE_Failure, CPLE_OpenFailed,
+                 "Attempt to create file `%s' failed. Error: unknown\n",
+                 pszFilename);
         return nullptr;
     }
 }


### PR DESCRIPTION
Backport #8788
 **Authored by:** @rouault