### PR TITLE
RasterIO: subpixel shift when reading from overviews

### DIFF
--- a/autotest/gcore/rasterio.py
+++ b/autotest/gcore/rasterio.py
@@ -726,6 +726,47 @@ def test_rasterio_9():
         assert tab[0] == pytest.approx(1.0, abs=1e-5)
 
 
+##############################################################################
+# Test resampled reading from an overview level (#8794)
+def test_rasterio_overview_subpixel_resampling():
+
+    numpy = pytest.importorskip("numpy")
+
+    temp_path = "/vsimem/rasterio_ovr.tif"
+    ds = gdal.GetDriverByName("GTiff").Create(temp_path, 8, 8, 1, gdal.GDT_Byte)
+    ds.GetRasterBand(1).WriteArray(
+        numpy.array(
+            [
+                [0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 255, 255, 255, 255, 0, 0],
+                [0, 0, 255, 255, 255, 255, 0, 0],
+                [0, 0, 255, 255, 255, 255, 0, 0],
+                [0, 0, 255, 255, 255, 255, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0],
+            ]
+        )
+    )
+    ds.BuildOverviews("NEAREST", overviewlist=[2])
+
+    pix = ds.GetRasterBand(1).ReadAsArray(
+        xoff=1,
+        yoff=1,
+        buf_xsize=3,
+        buf_ysize=3,
+        win_xsize=6,
+        win_ysize=6,
+        resample_alg=gdal.GRIORA_Bilinear,
+    )
+    assert numpy.all(
+        pix == numpy.array([[64, 128, 64], [128, 255, 128], [64, 128, 64]])
+    )
+
+    ds = None
+    gdal.Unlink("/vsimem/rasterio_ovr.tif")
+
+
 ###############################################################################
 # Test error when getting a block
 

--- a/gcore/rasterio.cpp
+++ b/gcore/rasterio.cpp
@@ -3775,6 +3775,18 @@ CPLErr GDALDataset::TryOverviewRasterIO(
     GDALRasterIOExtraArg sExtraArg;
     GDALCopyRasterIOExtraArg(&sExtraArg, psExtraArg);
 
+    // As we are going to use an overview, the window may/will become
+    // unaligned inside the overview, so we need to force the use of
+    // of a floating point window.
+    if (!sExtraArg.bFloatingPointWindowValidity)
+    {
+        sExtraArg.bFloatingPointWindowValidity = TRUE;
+        sExtraArg.dfXOff = nXOff;
+        sExtraArg.dfYOff = nYOff;
+        sExtraArg.dfXSize = nXSize;
+        sExtraArg.dfYSize = nYSize;
+    }
+
     int iOvrLevel = GDALBandGetBestOverviewLevel2(
         papoBands[0], nXOffMod, nYOffMod, nXSizeMod, nYSizeMod, nBufXSize,
         nBufYSize, &sExtraArg);

--- a/gcore/rasterio.cpp
+++ b/gcore/rasterio.cpp
@@ -3702,6 +3702,18 @@ CPLErr GDALRasterBand::OverviewRasterIO(
     GDALRasterIOExtraArg sExtraArg;
     GDALCopyRasterIOExtraArg(&sExtraArg, psExtraArg);
 
+    // As we are going to use an overview, the window may/will become
+    // unaligned inside the overview, so we need to force the use of
+    // of a floating point window.
+    if (!sExtraArg.bFloatingPointWindowValidity)
+    {
+        sExtraArg.bFloatingPointWindowValidity = TRUE;
+        sExtraArg.dfXOff = nXOff;
+        sExtraArg.dfYOff = nYOff;
+        sExtraArg.dfXSize = nXSize;
+        sExtraArg.dfYSize = nYSize;
+    }
+
     const int nOverview = GDALBandGetBestOverviewLevel2(
         this, nXOff, nYOff, nXSize, nYSize, nBufXSize, nBufYSize, &sExtraArg);
     if (nOverview < 0)
@@ -3736,6 +3748,18 @@ CPLErr GDALRasterBand::TryOverviewRasterIO(
     GDALRasterIOExtraArg sExtraArg;
 
     GDALCopyRasterIOExtraArg(&sExtraArg, psExtraArg);
+
+    // As we are going to use an overview, the window may/will become
+    // unaligned inside the overview, so we need to force the use of
+    // of a floating point window.
+    if (!sExtraArg.bFloatingPointWindowValidity)
+    {
+        sExtraArg.bFloatingPointWindowValidity = TRUE;
+        sExtraArg.dfXOff = nXOff;
+        sExtraArg.dfYOff = nYOff;
+        sExtraArg.dfXSize = nXSize;
+        sExtraArg.dfYSize = nYSize;
+    }
 
     int iOvrLevel = GDALBandGetBestOverviewLevel2(
         this, nXOffMod, nYOffMod, nXSizeMod, nYSizeMod, nBufXSize, nBufYSize,


### PR DESCRIPTION
There seems to be a subpixel shift when issuing a rasterio call when the buffer size and the source window size differ, and this difference leads to reading from an overview.
The issue can today be worked-around by artificially setting a floating point validity window, identical to the integer window, as this will ensure that `GDALBandGetBestOverviewLevel2` correctly selects a subpixel window inside the chosen overview.
This PR tries to correct `GDALDataset::TryOverviewRasterIO` so that a subpixel window can be used on overviews