### PR TITLE
[Backport release/3.8] gdal_footprint: fix -ovr on RGBA datasets (fixes #8792)

### DIFF
--- a/apps/gdal_footprint_lib.cpp
+++ b/apps/gdal_footprint_lib.cpp
@@ -703,7 +703,8 @@ static bool GDALFootprintProcess(GDALDataset *poSrcDS, OGRLayer *poDstLayer,
         {
             GDALRasterBand *poMaskBand;
             const int nMaskFlags = poBand->GetMaskFlags();
-            if ((nMaskFlags & GMF_ALPHA) != 0)
+            if ((nMaskFlags & GMF_ALPHA) != 0 ||
+                poBand->GetColorInterpretation() == GCI_AlphaBand)
             {
                 poMaskBand = poBand;
             }


### PR DESCRIPTION
Backport #8798
 **Authored by:** @rouault