### PR TITLE
GDALOverviewDataset::IRasterIO(): use parent dataset when possible for more efficiency

### DIFF
--- a/autotest/utilities/test_gdal_translate_lib.py
+++ b/autotest/utilities/test_gdal_translate_lib.py
@@ -1096,6 +1096,28 @@ def test_gdal_translate_lib_overview_level(tmp_vsimem):
 
 
 ###############################################################################
+# Test overviewLevel option in a situation where overview bands have not a
+# dedicated owner dataset.
+# Test last part of GDALOverviewDataset::IRasterIO() implementation
+
+
+@pytest.mark.require_driver("JP2KAK")
+def test_gdal_translate_lib_overview_level_freestanding(tmp_vsimem):
+
+    tmp_filename = tmp_vsimem / "tmp.jp2"
+
+    src_ds = gdal.Translate(
+        tmp_filename,
+        "../gcore/data/byte.tif",
+        width=20 * 32,
+        creationOptions=["QUALITY=100"],
+        format="JP2KAK",
+    )
+    out_ds = gdal.Translate("", src_ds, format="MEM", overviewLevel=0, width=20)
+    assert out_ds.GetRasterBand(1).Checksum() == 4667
+
+
+###############################################################################
 # Test copying a raster with no input band
 
 

--- a/gcore/gdaloverviewdataset.cpp
+++ b/gcore/gdaloverviewdataset.cpp
@@ -200,6 +200,14 @@ GDALOverviewDataset::GDALOverviewDataset(GDALDataset *poMainDSIn,
     nBands = poMainDS->GetRasterCount();
     for (int i = 0; i < nBands; ++i)
     {
+        if (poOvrDS)
+        {
+            // Check that all overview bands belong to the same dataset
+            auto poOvrBand =
+                GetOverviewEx(poMainDS->GetRasterBand(i + 1), nOvrLevel);
+            if (poOvrBand->GetDataset() != poOvrDS)
+                poOvrDS = nullptr;
+        }
         SetBand(i + 1, new GDALOverviewBand(this, i + 1));
     }
 
@@ -328,7 +336,7 @@ CPLErr GDALOverviewDataset::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
 
     // In case the overview bands are really linked to a dataset, then issue
     // the request to that dataset.
-    if (nOvrLevel != -1 && poOvrDS != nullptr)
+    if (poOvrDS != nullptr)
     {
         return poOvrDS->RasterIO(eRWFlag, nXOff, nYOff, nXSize, nYSize, pData,
                                  nBufXSize, nBufYSize, eBufType, nBandCount,


### PR DESCRIPTION
Fixes https://lists.osgeo.org/pipermail/gdal-dev/2023-November/057996.html
