### PR TITLE
swig/python/setup.py.in: workaround easy_install behavior on Windows to keep .py scripts (fixes #8811)

### DIFF
--- a/.github/workflows/cmake_builds.yml
+++ b/.github/workflows/cmake_builds.yml
@@ -496,6 +496,11 @@ jobs:
     - name: Show gdal.pc
       shell: bash -l {0}
       run: cat $GITHUB_WORKSPACE/build/gdal.pc
+    - name: Test python setup.py install
+      shell: bash -l {0}
+      run: |
+        cd $GITHUB_WORKSPACE/build/swig/python
+        python setup.py install
 
   build-windows-minimum:
     runs-on: windows-2022

--- a/swig/python/setup.py.in
+++ b/swig/python/setup.py.in
@@ -147,6 +147,39 @@ def has_flag(compiler, flagname):
     return True
 
 # ---------------------------------------------------------------------------
+# BEGIN monkey patching of setuptools.command.easy_install.easy_install class
+# ---------------------------------------------------------------------------
+
+# "python setup.py install" uses setuptools.command.easy_install internally
+# When installing the .exe wrapper executable for our command line utilities,
+# that class removes the installed .py scripts themselves. Which we do not want,
+# since they may be directly used by users. So we do a monkey patching of
+# easy_install.install_wrapper_scripts to install a modified
+# easy_install.delete_blockers method that does NOT remove .py files
+if sys.platform == 'win32':
+    from setuptools.command.easy_install import easy_install
+
+    original_install_wrapper_scripts = easy_install.install_wrapper_scripts
+
+    def monkey_patched_install_wrapper_scripts(self, dist):
+        original_delete_blockers = easy_install.delete_blockers
+        def monkey_patched_delete_blockers(self, blockers):
+            blockers = filter(lambda x: not x.endswith('.py'), blockers)
+            return original_delete_blockers(self, blockers)
+
+        easy_install.delete_blockers = monkey_patched_delete_blockers
+        try:
+            return original_install_wrapper_scripts(self, dist)
+        finally:
+             easy_install.delete_blockers = original_delete_blockers
+
+    easy_install.install_wrapper_scripts = monkey_patched_install_wrapper_scripts
+
+# ---------------------------------------------------------------------------
+# END monkey patching of setuptools.command.easy_install.easy_install class
+# ---------------------------------------------------------------------------
+
+# ---------------------------------------------------------------------------
 # Imports
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
This is a follow-up of #8815 for Windows, and particularly to unbreak conda-forge builds that test the presence of the .py scripts.

Before this PR, "python setup.py install" would cause the following logs:
```
Installing gdal2tiles.py script to C:\Miniconda3\envs\test\conda-bld\gdal-split_1700841951001\_h_env\Scripts
[...]
Deleting C:\Miniconda3\envs\test\conda-bld\gdal-split_1700841951001\_h_env\Scripts\gdal2tiles.py
Installing gdal2tiles-script.py script to C:\Miniconda3\envs\test\conda-bld\gdal-split_1700841951001\_h_env\Scripts
Installing gdal2tiles.exe script to C:\Miniconda3\envs\test\conda-bld\gdal-split_1700841951001\_h_env\Scripts
```

This PR hacks around easy_install to avoid the deletiong of the .py script
