### PR TITLE
[Backport 3.8]  CI: Linux: test install target, and fix installation of Python bindings on debian:unstable with py3.12

### DIFF
--- a/.github/workflows/alpine/build.sh
+++ b/.github/workflows/alpine/build.sh
@@ -10,3 +10,4 @@ cmake ${GDAL_SOURCE_DIR:=..} \
   -DIconv_LIBRARY=/usr/lib/libiconv.so \
   -DCMAKE_C_FLAGS=-Werror -DCMAKE_CXX_FLAGS=-Werror -DWERROR_DEV_FLAG="-Werror=dev"
 make -j$(nproc)
+make -j$(nproc) install DESTDIR=/tmp/install-gdal

--- a/.github/workflows/fedora_rawhide/build.sh
+++ b/.github/workflows/fedora_rawhide/build.sh
@@ -13,3 +13,4 @@ cmake ${GDAL_SOURCE_DIR:=..} \
   -DCMAKE_INSTALL_PREFIX=/usr \
   -DWERROR_DEV_FLAG="-Werror=dev"
 make -j$(nproc)
+make -j$(nproc) install DESTDIR=/tmp/install-gdal

--- a/.github/workflows/ubuntu_20.04/build.sh
+++ b/.github/workflows/ubuntu_20.04/build.sh
@@ -21,3 +21,4 @@ unset CXXFLAGS
 unset CFLAGS
 
 make -j$(nproc)
+make -j$(nproc) install DESTDIR=/tmp/install-gdal

--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -403,7 +403,12 @@ if (Python_Interpreter_FOUND)
     set(SETUPTOOLS_USE_DISTUTILS stdlib)
   elseif ("${SITE_PACKAGE_DIR}" MATCHES "dist-packages")
     set(INSTALL_ARGS "${INSTALL_ARGS} --install-layout=deb")
-    set(SETUPTOOLS_USE_DISTUTILS stdlib)
+    if(Python_VERSION VERSION_LESS 3.12)
+        # It no longer seems needed to mess with SETUPTOOLS_USE_DISTUTILS
+        # with Debian Python 3.12 (or maybe its setuptools 68.1.2 version...),
+        # so only do that with older versions
+        set(SETUPTOOLS_USE_DISTUTILS stdlib)
+    endif()
   endif ()
 
   if (ONLY_GENERATE_FOR_NON_DEBUG)

--- a/swig/python/install_python.cmake.in
+++ b/swig/python/install_python.cmake.in
@@ -19,8 +19,11 @@ if(NOT "@SETUPTOOLS_USE_DISTUTILS@x" STREQUAL "x")
 endif()
 if(DEFINED INSTALL_PREFIX)
    execute_process(COMMAND "@Python_EXECUTABLE_CMAKE@" "@SETUP_PY_FILENAME@" install ${ROOT_DIR_ARG} @INSTALL_ARGS@ "${INSTALL_PREFIX}"
-                   WORKING_DIRECTORY "@CMAKE_CURRENT_BINARY_DIR@")
+                   WORKING_DIRECTORY "@CMAKE_CURRENT_BINARY_DIR@" RESULT_VARIABLE res)
 else()
    execute_process(COMMAND "@Python_EXECUTABLE_CMAKE@" "@SETUP_PY_FILENAME@" install ${ROOT_DIR_ARG} @INSTALL_ARGS@
-                   WORKING_DIRECTORY "@CMAKE_CURRENT_BINARY_DIR@")
+                   WORKING_DIRECTORY "@CMAKE_CURRENT_BINARY_DIR@" RESULT_VARIABLE res)
+endif()
+if(NOT res EQUAL 0)
+   message( FATAL_ERROR "Installation of python bindings failed")
 endif()


### PR DESCRIPTION
Backport of https://github.com/OSGeo/gdal/pull/8812