### PR TITLE
[Backport release/3.8] Shapefile: recogize '      0' as a null date

### DIFF
--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -5819,3 +5819,28 @@ def test_ogr_shape_write_arrow_IF_FID_NOT_PRESERVED_ERROR(tmp_vsimem):
             lyr.WriteArrowBatch(
                 schema, array, ["FID=OGC_FID", "IF_FID_NOT_PRESERVED=ERROR"]
             )
+
+
+###############################################################################
+# Test writing an invalid "0000/00/00" date
+
+
+@gdaltest.enable_exceptions()
+def test_ogr_shape_write_date_0000_00_00(tmp_vsimem):
+
+    filename = tmp_vsimem / "test_ogr_shape_write_date_0000_00_00.shp"
+    ds = gdal.GetDriverByName("ESRI Shapefile").Create(
+        filename, 0, 0, 0, gdal.GDT_Unknown
+    )
+    lyr = ds.CreateLayer("test")
+    lyr.CreateField(ogr.FieldDefn("date", ogr.OFTDate))
+    f = ogr.Feature(lyr.GetLayerDefn())
+    f["date"] = "0000/00/00"
+    lyr.CreateFeature(f)
+    f = None
+    ds.Close()
+
+    ds = ogr.Open(filename)
+    lyr = ds.GetLayer(0)
+    f = lyr.GetNextFeature()
+    assert f.IsFieldNull("date")

--- a/ogr/ogrsf_frmts/shape/dbfopen.c
+++ b/ogr/ogrsf_frmts/shape/dbfopen.c
@@ -1165,7 +1165,12 @@ static bool DBFIsValueNULL(char chType, const char *pszValue)
 
         case 'D':
             /* NULL date fields have value "00000000" */
-            return strncmp(pszValue, "00000000", 8) == 0;
+            /* Some DBF files have fields filled with spaces */
+            /* (trimmed by DBFReadStringAttribute) to indicate null */
+            /* values for dates (#4265). */
+            /* And others have '       0': https://lists.osgeo.org/pipermail/gdal-dev/2023-November/058010.html */
+            return strncmp(pszValue, "00000000", 8) == 0 ||
+                   strcmp(pszValue, " ") == 0 || strcmp(pszValue, "0") == 0;
 
         case 'L':
             /* NULL boolean fields have value "?" */

--- a/ogr/ogrsf_frmts/shape/shape2ogr.cpp
+++ b/ogr/ogrsf_frmts/shape/shape2ogr.cpp
@@ -1447,12 +1447,6 @@ OGRFeature *SHPReadOGRFeature(SHPHandle hSHP, DBFHandle hDBF,
                 const char *const pszDateValue =
                     DBFReadStringAttribute(hDBF, iShape, iField);
 
-                // Some DBF files have fields filled with spaces
-                // (trimmed by DBFReadStringAttribute) to indicate null
-                // values for dates (#4265).
-                if (pszDateValue[0] == '\0')
-                    continue;
-
                 OGRField sFld;
                 memset(&sFld, 0, sizeof(sFld));
 

--- a/ogr/ogrsf_frmts/shape/shape2ogr.cpp
+++ b/ogr/ogrsf_frmts/shape/shape2ogr.cpp
@@ -1757,6 +1757,12 @@ OGRErr SHPWriteOGRFeature(SHPHandle hSHP, DBFHandle hDBF,
                         CE_Warning, CPLE_NotSupported,
                         "Year < 0 or > 9999 is not a valid date for shapefile");
                 }
+                else if (psField->Date.Year == 0 && psField->Date.Month == 0 &&
+                         psField->Date.Day == 0)
+                {
+                    DBFWriteNULLAttribute(
+                        hDBF, static_cast<int>(poFeature->GetFID()), iField);
+                }
                 else
                 {
                     DBFWriteIntegerAttribute(


### PR DESCRIPTION
Backport #8840
 **Authored by:** @rouault