### PR TITLE
heif: add CreateCopy support (WIP)

### DIFF
--- a/autotest/gdrivers/heif.py
+++ b/autotest/gdrivers/heif.py
@@ -29,6 +29,9 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
+import array
+import os
+
 import pytest
 
 from osgeo import gdal
@@ -158,3 +161,51 @@ def test_heif_subdatasets():
         assert gdal.Open("HEIF:1") is None
     with pytest.raises(Exception):
         assert gdal.Open("HEIF:1:") is None
+
+
+def test_heif_create():
+    drv = gdal.GetDriverByName("HEIF")
+
+    try:
+        os.remove("tmp/test_create.hif")
+    except OSError:
+        pass
+
+    ds = gdal.GetDriverByName("MEM").Create("", 300, 200, 3, gdal.GDT_Byte)
+
+    ds.GetRasterBand(1).SetRasterColorInterpretation(gdal.GCI_RedBand)
+    ds.GetRasterBand(2).SetRasterColorInterpretation(gdal.GCI_GreenBand)
+    ds.GetRasterBand(3).SetRasterColorInterpretation(gdal.GCI_BlueBand)
+
+    red_green_blue = (
+        ([0xFF] * 100 + [0x00] * 200)
+        + ([0x00] * 100 + [0xFF] * 100 + [0x00] * 100)
+        + ([0x00] * 200 + [0xFF] * 100)
+    )
+    rgb_bytes = array.array("B", red_green_blue).tobytes()
+    for line in range(100):
+        ds.WriteRaster(
+            0, line, 300, 1, rgb_bytes, buf_type=gdal.GDT_Byte, band_list=[1, 2, 3]
+        )
+    black_white = ([0xFF] * 150 + [0x00] * 150) * 3
+    black_white_bytes = array.array("B", black_white).tobytes()
+    for line in range(100):
+        ds.WriteRaster(
+            0,
+            100 + line,
+            300,
+            1,
+            black_white_bytes,
+            buf_type=gdal.GDT_Byte,
+            band_list=[1, 2, 3],
+        )
+
+    assert ds.FlushCache() == gdal.CE_None
+
+    ds = drv.CreateCopy("tmp/test_create.hif", ds, options=[])
+
+    ds = None
+
+    ds = gdal.Open("tmp/test_create.hif")
+
+    assert ds

--- a/frmts/heif/CMakeLists.txt
+++ b/frmts/heif/CMakeLists.txt
@@ -1,5 +1,17 @@
 add_gdal_driver(TARGET gdal_HEIF
-                SOURCES heifdataset.cpp
+                SOURCES heifdataset.cpp heifdataset.h 
+                        heifdatasetcreatecopy.cpp
+                        boxes/box.cpp boxes/box.h
+                        boxes/fullbox.cpp boxes/fullbox.h
+                        boxes/cmpd.cpp boxes/cmpd.h
+                        boxes/hdlr.cpp boxes/hdlr.h
+                        boxes/iloc.cpp boxes/iloc.h
+                        boxes/iprp.cpp boxes/iprp.h 
+                        boxes/ispe.cpp boxes/ispe.h
+                        boxes/mdat.cpp boxes/mdat.h
+                        boxes/meta.cpp boxes/meta.h
+                        boxes/pitm.cpp boxes/pitm.h
+                        boxes/uncc.cpp boxes/uncc.h
                 CORE_SOURCES heifdrivercore.cpp
                 PLUGIN_CAPABLE)
 

--- a/frmts/heif/boxes/box.cpp
+++ b/frmts/heif/boxes/box.cpp
@@ -1,0 +1,129 @@
+/******************************************************************************
+ *
+ * Project:  HEIF driver
+ * Author:   Brad Hards <bradh@frogmouth.net>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Brad Hards <bradh@frogmouth.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "box.h"
+#include <cstddef>
+#include <cstdint>
+
+uint64_t Box::getFullSize()
+{
+    uint64_t size = getSize();
+    if (size > 1)
+    {
+        return size;
+    }
+    return getHeaderSize() + sizeof(uint64_t) + getBodySize();
+}
+
+void Box::writeHeader(VSILFILE *fp)
+{
+    // TODO: rework this to handle uuid as well
+    uint32_t size = getSize();
+    writeUint32Value(fp, size);
+    writeBoxType(fp);
+    if (size == 1)
+    {
+        uint64_t largesize = getFullSize();
+        writeUint64Value(fp, largesize);
+    }
+}
+
+void Box::writeBoxType(VSILFILE *fp)
+{
+    writeFourCC(fp, boxtype);
+}
+
+uint64_t Box::getSize()
+{
+    if (getHeaderSize() + getBodySize() > UINT32_MAX)
+    {
+        return 1;
+    }
+    else
+    {
+        uint32_t size = getHeaderSize() + getBodySize();
+        return size;
+    }
+}
+
+int Box::ReadBoxHeader(VSILFILE *fp, size_t *bytesRead, uint64_t *size)
+{
+    uint32_t sizeBigEndian = 0;
+    uint32_t fourCC = 0;
+
+    if (VSIFReadL(&sizeBigEndian, sizeof(uint32_t), 1, fp) != 1)
+    {
+        return FALSE;
+    }
+    *size = CPL_MSBWORD32(sizeBigEndian);
+    *bytesRead += sizeof(uint32_t);
+
+    if (VSIFReadL(&fourCC, sizeof(uint32_t), 1, fp) != 1)
+    {
+        return FALSE;
+    }
+    *bytesRead += sizeof(uint32_t);
+
+    if (*size == 1)
+    {
+        if (VSIFReadL(size, sizeof(uint64_t), 1, fp) != 1)
+        {
+            return FALSE;
+        }
+        *bytesRead += sizeof(uint64_t);
+    }
+
+    // TODO: add support for 0 size
+
+    // TODO: add support for uuid box
+    return TRUE;
+}
+
+uint32_t AbstractContainerBox::addChildBox(std::shared_ptr<Box> box)
+{
+    boxes.push_back(box);
+    // Return 1 based index.
+    return boxes.size();
+}
+
+uint64_t AbstractContainerBox::getBodySize()
+{
+    uint64_t size = 0;
+    for (size_t i = 0; i < boxes.size(); i++)
+    {
+        size += boxes[i]->getFullSize();
+    }
+    return size;
+}
+
+void AbstractContainerBox::writeBodyTo(VSILFILE *fp)
+{
+    for (size_t i = 0; i < boxes.size(); i++)
+    {
+        boxes[i]->writeTo(fp);
+    }
+}

--- a/frmts/heif/boxes/box.cpp
+++ b/frmts/heif/boxes/box.cpp
@@ -42,7 +42,7 @@ uint64_t Box::getFullSize()
 void Box::writeHeader(VSILFILE *fp)
 {
     // TODO: rework this to handle uuid as well
-    uint32_t size = getSize();
+    uint32_t size = (uint32_t)getSize();
     writeUint32Value(fp, size);
     writeBoxType(fp);
     if (size == 1)
@@ -65,7 +65,7 @@ uint64_t Box::getSize()
     }
     else
     {
-        uint32_t size = getHeaderSize() + getBodySize();
+        uint32_t size = (uint32_t)(getHeaderSize() + getBodySize());
         return size;
     }
 }
@@ -73,7 +73,6 @@ uint64_t Box::getSize()
 int Box::ReadBoxHeader(VSILFILE *fp, size_t *bytesRead, uint64_t *size)
 {
     uint32_t sizeBigEndian = 0;
-    uint32_t fourCC = 0;
 
     if (VSIFReadL(&sizeBigEndian, sizeof(uint32_t), 1, fp) != 1)
     {
@@ -82,7 +81,7 @@ int Box::ReadBoxHeader(VSILFILE *fp, size_t *bytesRead, uint64_t *size)
     *size = CPL_MSBWORD32(sizeBigEndian);
     *bytesRead += sizeof(uint32_t);
 
-    if (VSIFReadL(&fourCC, sizeof(uint32_t), 1, fp) != 1)
+    if (VSIFReadL(&boxtype, sizeof(uint32_t), 1, fp) != 1)
     {
         return FALSE;
     }
@@ -107,7 +106,7 @@ uint32_t AbstractContainerBox::addChildBox(std::shared_ptr<Box> box)
 {
     boxes.push_back(box);
     // Return 1 based index.
-    return boxes.size();
+    return (uint32_t)boxes.size();
 }
 
 uint64_t AbstractContainerBox::getBodySize()

--- a/frmts/heif/boxes/box.h
+++ b/frmts/heif/boxes/box.h
@@ -129,7 +129,7 @@ class AbstractContainerBox : public Box
     uint32_t addChildBox(std::shared_ptr<Box> box);
 
   protected:
-    AbstractContainerBox(const char *fourCC) : Box(fourCC)
+    explicit AbstractContainerBox(const char *fourCC) : Box(fourCC)
     {
     }
 

--- a/frmts/heif/boxes/box.h
+++ b/frmts/heif/boxes/box.h
@@ -1,0 +1,144 @@
+/******************************************************************************
+ *
+ * Project:  HEIF driver
+ * Author:   Brad Hards <bradh@frogmouth.net>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Brad Hards <bradh@frogmouth.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#ifndef INCLUDE_HEIF_BOX_DEFINED
+#define INCLUDE_HEIF_BOX_DEFINED
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gdal_priv.h"
+
+static uint32_t fourcc(const char *pszType)
+{
+    uint32_t fourCC;
+    CPLAssert(strlen(pszType) == 4);
+    memcpy(&fourCC, pszType, 4);
+    return fourCC;
+}
+
+class Box
+{
+  public:
+    virtual void writeTo(VSILFILE *fp)
+    {
+        writeHeader(fp);
+        writeBodyTo(fp);
+    }
+
+    virtual ~Box() = default;
+
+    virtual uint64_t getFullSize();
+
+    virtual uint32_t getHeaderSize()
+    {
+        return 8;
+    }
+
+  protected:
+    Box(const char *fourCC) : boxtype(fourcc(fourCC))
+    {
+    }
+
+    int ReadBoxHeader(VSILFILE *fp, size_t *bytesRead, uint64_t *size);
+
+    virtual void writeBodyTo(VSILFILE *fp) = 0;
+
+    virtual uint64_t getBodySize() = 0;
+
+    virtual void writeHeader(VSILFILE *fp);
+
+    void writeBoxType(VSILFILE *fp);
+
+    static void writeFourCC(VSILFILE *fp, uint32_t fourCC)
+    {
+        VSIFWriteL(&fourCC, sizeof(uint32_t), 1, fp);
+    }
+
+    static void writeUint8Value(VSILFILE *fp, uint8_t value)
+    {
+        VSIFWriteL(&value, sizeof(uint8_t), 1, fp);
+    }
+
+    static void writeUint16Value(VSILFILE *fp, uint16_t value)
+    {
+        CPL_MSBPTR16(&value);
+        VSIFWriteL(&value, sizeof(uint16_t), 1, fp);
+    }
+
+    static void writeUint32Value(VSILFILE *fp, uint32_t value)
+    {
+        CPL_MSBPTR32(&value);
+        VSIFWriteL(&value, sizeof(uint32_t), 1, fp);
+    }
+
+    static void writeUint64Value(VSILFILE *fp, uint64_t value)
+    {
+        CPL_MSBPTR64(&value);
+        VSIFWriteL(&value, sizeof(uint64_t), 1, fp);
+    }
+
+    static void writeStringValue(VSILFILE *fp, const char *value)
+    {
+        VSIFWriteL(value, sizeof(uint8_t), strlen(value) + 1, fp);
+    }
+
+    static void writeBytes(VSILFILE *fp,
+                           std::shared_ptr<std::vector<uint8_t>> values)
+    {
+        VSIFWriteL(values->data(), sizeof(uint8_t), values->size(), fp);
+    }
+
+  private:
+    uint32_t boxtype;
+    uint64_t getSize();
+};
+
+class AbstractContainerBox : public Box
+{
+  public:
+    uint32_t addChildBox(std::shared_ptr<Box> box);
+
+  protected:
+    AbstractContainerBox(const char *fourCC) : Box(fourCC)
+    {
+    }
+
+    virtual void writeBodyTo(VSILFILE *fp) override;
+
+    virtual uint64_t getBodySize() override;
+
+  private:
+    std::vector<std::shared_ptr<Box>> boxes;
+};
+
+#endif

--- a/frmts/heif/boxes/cmpd.cpp
+++ b/frmts/heif/boxes/cmpd.cpp
@@ -1,0 +1,65 @@
+/******************************************************************************
+ *
+ * Project:  HEIF driver
+ * Author:   Brad Hards <bradh@frogmouth.net>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Brad Hards <bradh@frogmouth.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "cmpd.h"
+#include <cstdint>
+
+uint64_t ComponentDefinitionBox::getBodySize()
+{
+    uint64_t size = 0;
+    size += sizeof(uint32_t);
+    for (size_t i = 0; i < components.size(); i++)
+    {
+        size += sizeof(uint16_t);
+        if (components[i].component_type >= 0x8000)
+        {
+            size += components[i].component_type_uri.size();
+            size += 1;
+        }
+    }
+    return size;
+}
+
+void ComponentDefinitionBox::writeBodyTo(VSILFILE *fp)
+{
+    writeUint32Value(fp, components.size());
+    for (size_t i = 0; i < components.size(); i++)
+    {
+        writeUint16Value(fp, components[i].component_type);
+        if (components[i].component_type >= 0x8000)
+        {
+            writeStringValue(fp, components[i].component_type_uri.c_str());
+        }
+    }
+}
+
+void ComponentDefinitionBox::addComponent(uint16_t component_type)
+{
+    ComponentDefinitionBox::Component component;
+    component.component_type = component_type;
+    components.push_back(component);
+}

--- a/frmts/heif/boxes/cmpd.h
+++ b/frmts/heif/boxes/cmpd.h
@@ -1,0 +1,62 @@
+/******************************************************************************
+ *
+ * Project:  HEIF driver
+ * Author:   Brad Hards <bradh@frogmouth.net>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Brad Hards <bradh@frogmouth.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "fullbox.h"
+#include <cstdint>
+
+/**
+ * Component definition box.
+ *
+ * From ISO/IEC 23001-17 (FDIS)
+ */
+class ComponentDefinitionBox : public Box
+{
+  public:
+    ComponentDefinitionBox() : Box("cmpd")
+    {
+    }
+
+    ~ComponentDefinitionBox()
+    {
+    }
+
+    struct Component
+    {
+        uint16_t component_type;
+        std::string component_type_uri;
+    };
+
+    void addComponent(uint16_t component);
+
+  protected:
+    uint64_t getBodySize() override;
+
+    void writeBodyTo(VSILFILE *fp) override;
+
+  private:
+    std::vector<Component> components;
+};

--- a/frmts/heif/boxes/ftyp.h
+++ b/frmts/heif/boxes/ftyp.h
@@ -32,7 +32,7 @@
 class FileTypeBox : public Box
 {
   public:
-    FileTypeBox() : Box("ftyp"), minorVersion(0)
+    FileTypeBox() : Box("ftyp"), majorBrand(0), minorVersion(0)
     {
     }
 

--- a/frmts/heif/boxes/ftyp.h
+++ b/frmts/heif/boxes/ftyp.h
@@ -1,0 +1,122 @@
+/******************************************************************************
+ *
+ * Project:  HEIF driver
+ * Author:   Brad Hards <bradh@frogmouth.net>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Brad Hards <bradh@frogmouth.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "box.h"
+#include <cstddef>
+#include <cstdint>
+
+class FileTypeBox : public Box
+{
+  public:
+    FileTypeBox() : Box("ftyp"), minorVersion(0)
+    {
+    }
+
+    uint32_t getMajorBrand() const
+    {
+        return majorBrand;
+    }
+
+    void setMajorBrand(uint32_t brand)
+    {
+        majorBrand = brand;
+    }
+
+    void addCompatibleBrand(uint32_t brand)
+    {
+        compatibleBrands.push_back(brand);
+    }
+
+    bool hasCompatibleBrand(uint32_t brand)
+    {
+        return (std::find(compatibleBrands.begin(), compatibleBrands.end(),
+                          brand) != compatibleBrands.end());
+    }
+
+    ~FileTypeBox()
+    {
+    }
+
+    int ReadBox(VSILFILE *fp)
+    {
+        size_t bytesRead = 0;
+        uint64_t size = 0;
+        int errCode = ReadBoxHeader(fp, &bytesRead, &size);
+        if (errCode != TRUE)
+        {
+            return errCode;
+        }
+        if (VSIFReadL(&majorBrand, sizeof(uint32_t), 1, fp) != 1)
+        {
+            return FALSE;
+        }
+        bytesRead += sizeof(uint32_t);
+
+        if (VSIFReadL(&minorVersion, sizeof(uint32_t), 1, fp) != 1)
+        {
+            return FALSE;
+        }
+        minorVersion = CPL_MSBWORD32(minorVersion);
+        bytesRead += sizeof(uint32_t);
+        size_t bytesRemaining = size - bytesRead;
+        for (size_t i = 0; i < bytesRemaining / sizeof(uint32_t); i++)
+        {
+            uint32_t brand;
+            if (VSIFReadL(&brand, sizeof(uint32_t), 1, fp) != 1)
+            {
+                return FALSE;
+            }
+            compatibleBrands.push_back(brand);
+        }
+
+        return TRUE;
+    }
+
+  protected:
+    uint64_t getBodySize() override
+    {
+        return 8 + sizeof(uint32_t) * compatibleBrands.size();
+        //  + sizeof(uint32_t);
+    }
+
+    void writeBodyTo(VSILFILE *fp) override
+    {
+        writeFourCC(fp, majorBrand);
+        writeUint32Value(fp, minorVersion);
+        for (size_t i = 0; i < compatibleBrands.size(); i++)
+        {
+            writeFourCC(fp, compatibleBrands[i]);
+        }
+        // Not clear if this is required or not, include to be safe
+        // writeFourCC(fp, majorBrand);
+    }
+
+  private:
+    uint32_t majorBrand;
+    uint32_t minorVersion;
+    std::vector<uint32_t> compatibleBrands;
+};

--- a/frmts/heif/boxes/fullbox.cpp
+++ b/frmts/heif/boxes/fullbox.cpp
@@ -1,0 +1,47 @@
+/******************************************************************************
+ *
+ * Project:  HEIF driver
+ * Author:   Brad Hards <bradh@frogmouth.net>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Brad Hards <bradh@frogmouth.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "fullbox.h"
+
+uint32_t FullBox::getHeaderSize()
+{
+    return 12;
+}
+
+void FullBox::writeHeader(VSILFILE *fp)
+{
+    Box::writeHeader(fp);
+    writeFlagsTo(fp);
+}
+
+void FullBox::writeFlagsTo(VSILFILE *fp)
+{
+    writeUint8Value(fp, version);
+    writeUint8Value(fp, flags[2]);
+    writeUint8Value(fp, flags[1]);
+    writeUint8Value(fp, flags[0]);
+}

--- a/frmts/heif/boxes/fullbox.h
+++ b/frmts/heif/boxes/fullbox.h
@@ -34,7 +34,7 @@
 class FullBox : public Box
 {
   protected:
-    FullBox(const char *fourCC) : Box(fourCC), version(0)
+    explicit FullBox(const char *fourCC) : Box(fourCC), version(0)
     {
         memset(flags, 0, 3);
     }

--- a/frmts/heif/boxes/fullbox.h
+++ b/frmts/heif/boxes/fullbox.h
@@ -1,0 +1,64 @@
+/******************************************************************************
+ *
+ * Project:  HEIF driver
+ * Author:   Brad Hards <bradh@frogmouth.net>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Brad Hards <bradh@frogmouth.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#ifndef INCLUDE_HEIF_FULLBOX_DEFINED
+#define INCLUDE_HEIF_FULLBOX_DEFINED
+
+#include "box.h"
+#include <cstdint>
+
+class FullBox : public Box
+{
+  protected:
+    FullBox(const char *fourCC) : Box(fourCC), version(0)
+    {
+        memset(flags, 0, 3);
+    }
+
+    virtual uint32_t getHeaderSize() override;
+    virtual void writeHeader(VSILFILE *fp) override;
+
+    void writeFlagsTo(VSILFILE *fp);
+
+    uint8_t version;
+
+    /**
+     * Full box flags value.
+     *
+     * ISO IEC 14496-12 requires this to be unsigned int(24).
+     *
+     * The convention is that flags[2] is the high byte which is written first, and flags[0] is the low byte which is written last.
+    */
+    uint8_t flags[3];
+
+    uint8_t getFlags(uint8_t index)
+    {
+        return flags[index];
+    }
+};
+
+#endif

--- a/frmts/heif/boxes/hdlr.cpp
+++ b/frmts/heif/boxes/hdlr.cpp
@@ -32,7 +32,7 @@ void HandlerBox::setHandlerType(uint32_t fourCC)
     handler_type = fourCC;
 }
 
-void HandlerBox::setName(std::string s)
+void HandlerBox::setName(const std::string &s)
 {
     name = s;
 }

--- a/frmts/heif/boxes/hdlr.cpp
+++ b/frmts/heif/boxes/hdlr.cpp
@@ -1,0 +1,55 @@
+/******************************************************************************
+ *
+ * Project:  HEIF driver
+ * Author:   Brad Hards <bradh@frogmouth.net>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Brad Hards <bradh@frogmouth.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "hdlr.h"
+
+void HandlerBox::setHandlerType(uint32_t fourCC)
+{
+    handler_type = fourCC;
+}
+
+void HandlerBox::setName(std::string s)
+{
+    name = s;
+}
+
+uint64_t HandlerBox::getBodySize()
+{
+    uint64_t bodySize = 5 * sizeof(uint32_t) + name.size() + 1;
+    return bodySize;
+}
+
+void HandlerBox::writeBodyTo(VSILFILE *fp)
+{
+    writeUint32Value(fp, 0);  // pre_defined
+    writeFourCC(fp, handler_type);
+    for (int i = 0; i < 3; i++)
+    {
+        writeUint32Value(fp, 0);  // reserved
+    }
+    writeStringValue(fp, name.c_str());
+}

--- a/frmts/heif/boxes/hdlr.h
+++ b/frmts/heif/boxes/hdlr.h
@@ -35,7 +35,7 @@ class HandlerBox : public FullBox
     {
     }
 
-    HandlerBox(uint32_t fourCC)
+    explicit HandlerBox(uint32_t fourCC)
         : FullBox("hdlr"), handler_type(fourCC), name("")
     {
     }

--- a/frmts/heif/boxes/hdlr.h
+++ b/frmts/heif/boxes/hdlr.h
@@ -26,20 +26,27 @@
  ****************************************************************************/
 
 #include "fullbox.h"
+#include <cstdint>
 
 class HandlerBox : public FullBox
 {
   public:
-    HandlerBox() : FullBox("hdlr"), name("")
+    HandlerBox() : FullBox("hdlr"), handler_type(fourcc("pict")), name("")
     {
     }
+
+    HandlerBox(uint32_t fourCC)
+        : FullBox("hdlr"), handler_type(fourCC), name("")
+    {
+    }
+
     ~HandlerBox()
     {
     }
 
     void setHandlerType(uint32_t fourCC);
 
-    void setName(std::string s);
+    void setName(const std::string &s);
 
   protected:
     uint64_t getBodySize() override;

--- a/frmts/heif/boxes/hdlr.h
+++ b/frmts/heif/boxes/hdlr.h
@@ -1,0 +1,52 @@
+/******************************************************************************
+ *
+ * Project:  HEIF driver
+ * Author:   Brad Hards <bradh@frogmouth.net>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Brad Hards <bradh@frogmouth.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "fullbox.h"
+
+class HandlerBox : public FullBox
+{
+  public:
+    HandlerBox() : FullBox("hdlr"), name("")
+    {
+    }
+    ~HandlerBox()
+    {
+    }
+
+    void setHandlerType(uint32_t fourCC);
+
+    void setName(std::string s);
+
+  protected:
+    uint64_t getBodySize() override;
+
+    void writeBodyTo(VSILFILE *fp) override;
+
+  private:
+    uint32_t handler_type;
+    std::string name;
+};

--- a/frmts/heif/boxes/iinf.h
+++ b/frmts/heif/boxes/iinf.h
@@ -1,0 +1,148 @@
+/******************************************************************************
+ *
+ * Project:  HEIF driver
+ * Author:   Brad Hards <bradh@frogmouth.net>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Brad Hards <bradh@frogmouth.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "fullbox.h"
+
+class ItemInfoEntry : public FullBox
+{
+  public:
+    ItemInfoEntry(uint32_t id, const char *type)
+        : FullBox("infe"), item_ID(id), item_protection_index(0),
+          item_type(fourcc(type)), item_name("")
+    {
+        // TODO: be more sophisticated about this - probably alternative constructors
+        version = 2;
+    }
+
+    ItemInfoEntry(uint32_t id, const char *type, std::string name)
+        : FullBox("infe"), item_ID(id), item_protection_index(0),
+          item_type(fourcc(type)), item_name(name)
+    {
+        // TODO: be more sophisticated about this
+        version = 2;
+    }
+
+    ~ItemInfoEntry()
+    {
+    }
+
+  protected:
+    uint64_t getBodySize() override
+    {
+        // TODO: There are some more combinations we need for MIME and URI items
+        return sizeof(uint16_t) + sizeof(uint16_t) + sizeof(uint32_t) +
+               item_name.size() + 1;
+    }
+
+    void writeBodyTo(VSILFILE *fp) override
+    {
+        if (version >= 2)
+        {
+            if (version == 2)
+            {
+                writeUint16Value(fp, item_ID);
+            }
+            else if (version == 3)
+            {
+                writeUint32Value(fp, item_ID);
+            }
+            writeUint16Value(fp, item_protection_index);
+            writeFourCC(fp, item_type);
+            writeStringValue(fp, item_name.c_str());
+        }
+        // TODO: There are some more combinations we need for MIME and URI items
+    }
+
+  private:
+    uint32_t item_ID;
+    uint16_t item_protection_index;
+    uint32_t item_type;
+    std::string item_name;
+};
+
+class ItemInfoBox : public FullBox
+{
+
+  public:
+    ItemInfoBox() : FullBox("iinf")
+    {
+    }
+
+    ~ItemInfoBox()
+    {
+    }
+
+    void addEntry(const std::shared_ptr<ItemInfoEntry> entry)
+    {
+        item_infos.push_back(entry);
+    }
+
+  protected:
+    uint64_t getBodySize() override
+    {
+        uint64_t size = 0;
+        uint32_t entry_count = item_infos.size();
+        if (entry_count > UINT16_MAX)
+        {
+            version = 1;
+            size += sizeof(uint32_t);
+        }
+        else
+        {
+            {
+                size += sizeof(uint16_t);
+            }
+        }
+        for (size_t i = 0; i < entry_count; i++)
+        {
+            size += item_infos[i]->getFullSize();
+        }
+        return size;
+    }
+
+    void writeBodyTo(VSILFILE *fp) override
+    {
+        uint32_t entry_count = item_infos.size();
+        if (entry_count > UINT16_MAX)
+        {
+            writeUint32Value(fp, entry_count);
+        }
+        else
+        {
+            {
+                writeUint16Value(fp, entry_count);
+            }
+        }
+        for (size_t i = 0; i < entry_count; i++)
+        {
+            item_infos[i]->writeTo(fp);
+        }
+    }
+
+  private:
+    std::vector<std::shared_ptr<ItemInfoEntry>> item_infos;
+};

--- a/frmts/heif/boxes/iinf.h
+++ b/frmts/heif/boxes/iinf.h
@@ -26,6 +26,7 @@
  ****************************************************************************/
 
 #include "fullbox.h"
+#include <cstdint>
 
 class ItemInfoEntry : public FullBox
 {
@@ -38,7 +39,7 @@ class ItemInfoEntry : public FullBox
         version = 2;
     }
 
-    ItemInfoEntry(uint32_t id, const char *type, std::string name)
+    ItemInfoEntry(uint32_t id, const char *type, const std::string &name)
         : FullBox("infe"), item_ID(id), item_protection_index(0),
           item_type(fourcc(type)), item_name(name)
     {
@@ -105,7 +106,7 @@ class ItemInfoBox : public FullBox
     uint64_t getBodySize() override
     {
         uint64_t size = 0;
-        uint32_t entry_count = item_infos.size();
+        uint32_t entry_count = (uint32_t)item_infos.size();
         if (entry_count > UINT16_MAX)
         {
             version = 1;
@@ -126,7 +127,7 @@ class ItemInfoBox : public FullBox
 
     void writeBodyTo(VSILFILE *fp) override
     {
-        uint32_t entry_count = item_infos.size();
+        uint32_t entry_count = (uint32_t)item_infos.size();
         if (entry_count > UINT16_MAX)
         {
             writeUint32Value(fp, entry_count);

--- a/frmts/heif/boxes/iloc.cpp
+++ b/frmts/heif/boxes/iloc.cpp
@@ -26,6 +26,7 @@
  ****************************************************************************/
 
 #include "iloc.h"
+#include <algorithm>
 #include <cstddef>
 #include <cstdint>
 #include <memory>

--- a/frmts/heif/boxes/iloc.cpp
+++ b/frmts/heif/boxes/iloc.cpp
@@ -1,0 +1,178 @@
+/******************************************************************************
+ *
+ * Project:  HEIF driver
+ * Author:   Brad Hards <bradh@frogmouth.net>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Brad Hards <bradh@frogmouth.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "iloc.h"
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+uint64_t ItemLocationBox::getBodySize()
+{
+    uint64_t size = 0;
+    size += 2;
+    if (version < 2)
+    {
+        size += sizeof(uint16_t);
+    }
+    else
+    {
+        size += sizeof(uint32_t);
+    }
+    uint8_t offset_size = getOffsetSize();
+    uint8_t length_size = getLengthSize();
+    uint8_t base_offset_size = getBaseOffsetSize();
+    uint8_t index_size_or_reserved = getIndexSizeOrReserved();
+    for (size_t i = 0; i < items.size(); i++)
+    {
+        if (version < 2)
+        {
+            size += sizeof(uint16_t);
+        }
+        else
+        {
+            size += sizeof(uint32_t);
+        }
+        if ((version == 1) || (version == 2))
+        {
+            size += sizeof(uint16_t);
+        }
+        size += sizeof(uint16_t);
+        size += base_offset_size;
+        size += sizeof(uint16_t);  // extent_count size
+        uint8_t extent_count = items[i]->getExtentCount();
+        for (size_t j = 0; j < extent_count; j++)
+        {
+            if (((version == 1) || (version == 2)) &&
+                (index_size_or_reserved > 0))
+            {
+                size += index_size_or_reserved;
+            }
+            size += offset_size;
+            size += length_size;
+        }
+    }
+    return size;
+}
+
+void ItemLocationBox::writeBodyTo(VSILFILE *fp)
+{
+    uint8_t offset_size = getOffsetSize();
+    uint8_t length_size = getLengthSize();
+    writeUint8Value(fp, (offset_size << 4 | length_size));
+    uint8_t base_offset_size = getBaseOffsetSize();
+    uint8_t index_size_or_reserved = getIndexSizeOrReserved();
+    writeUint8Value(fp, (base_offset_size << 4 | index_size_or_reserved));
+    if (version < 2)
+    {
+        writeUint16Value(fp, items.size());
+    }
+    else
+    {
+        writeUint32Value(fp, items.size());
+    }
+    for (size_t i = 0; i < items.size(); i++)
+    {
+        std::shared_ptr<Item> item = items[i];
+        item->writeTo(fp, version, base_offset_size, index_size_or_reserved,
+                      offset_size, length_size);
+    }
+}
+
+uint64_t ItemLocationBox::Item::getBaseOffset() const
+{
+    // This is not optimal, but common.
+    return 0;
+}
+
+uint64_t ItemLocationBox::Item::getGreatestExtentOffset() const
+{
+    uint64_t maxExtentOffset = 0;
+    for (size_t i = 0; i < extents.size(); i++)
+    {
+        maxExtentOffset = std::max(maxExtentOffset, extents[i]->offset);
+    }
+    return maxExtentOffset;
+}
+
+uint64_t ItemLocationBox::Item::getGreatestExtentLength() const
+{
+    uint64_t maxExtentLength = 0;
+    for (size_t i = 0; i < extents.size(); i++)
+    {
+        maxExtentLength = std::max(maxExtentLength, extents[i]->length);
+    }
+    return maxExtentLength;
+}
+
+uint8_t ItemLocationBox::getOffsetSize() const
+{
+    uint64_t greatestOffset = 0;
+    for (size_t i = 0; i < items.size(); i++)
+    {
+        std::shared_ptr<Item> item = items[i];
+        uint64_t greatestExtentOffset = item->getGreatestExtentOffset();
+        greatestOffset = std::max(greatestOffset, greatestExtentOffset);
+    }
+    if (greatestOffset > UINT32_MAX)
+    {
+        return 8;
+    }
+    else
+    {
+        return 4;
+    }
+}
+
+uint8_t ItemLocationBox::getLengthSize() const
+{
+    uint64_t greatestLength = 0;
+    for (size_t i = 0; i < items.size(); i++)
+    {
+        std::shared_ptr<Item> item = items[i];
+        uint64_t greatestExtentLength = item->getGreatestExtentLength();
+        greatestLength = std::max(greatestLength, greatestExtentLength);
+    }
+    if (greatestLength > UINT32_MAX)
+    {
+        return 8;
+    }
+    else
+    {
+        return 4;
+    }
+}
+
+uint8_t ItemLocationBox::getBaseOffsetSize() const
+{
+    return 4;
+}
+
+uint8_t ItemLocationBox::getIndexSizeOrReserved() const
+{
+    // TODO: calculate based on version when needed
+    return 0;
+}

--- a/frmts/heif/boxes/iloc.cpp
+++ b/frmts/heif/boxes/iloc.cpp
@@ -103,7 +103,7 @@ void ItemLocationBox::writeBodyTo(VSILFILE *fp)
     }
 }
 
-uint64_t ItemLocationBox::Item::getBaseOffset() const
+uint64_t ItemLocationBox::Item::getBaseOffset()
 {
     // This is not optimal, but common.
     return 0;
@@ -167,12 +167,13 @@ uint8_t ItemLocationBox::getLengthSize() const
     }
 }
 
-uint8_t ItemLocationBox::getBaseOffsetSize() const
+uint8_t ItemLocationBox::getBaseOffsetSize()
 {
+    // TODO: real calculation
     return 4;
 }
 
-uint8_t ItemLocationBox::getIndexSizeOrReserved() const
+uint8_t ItemLocationBox::getIndexSizeOrReserved()
 {
     // TODO: calculate based on version when needed
     return 0;

--- a/frmts/heif/boxes/iloc.h
+++ b/frmts/heif/boxes/iloc.h
@@ -50,7 +50,7 @@ class ItemLocationBox : public FullBox
     class Item
     {
       public:
-        Item(uint32_t id)
+        explicit Item(uint32_t id)
             : item_ID(id), construction_method(0), data_reference_index(0)
         {
         }
@@ -99,7 +99,7 @@ class ItemLocationBox : public FullBox
             writeUint16Value(fp, data_reference_index);
             if (base_offset_size == 4)
             {
-                writeUint32Value(fp, getBaseOffset());
+                writeUint32Value(fp, (uint32_t)getBaseOffset());
             }
             else if (base_offset_size == 8)
             {
@@ -123,7 +123,8 @@ class ItemLocationBox : public FullBox
                 }
                 if (offset_size == 4)
                 {
-                    writeUint32Value(fp, extent->offset - getBaseOffset());
+                    writeUint32Value(
+                        fp, (uint32_t)(extent->offset - getBaseOffset()));
                 }
                 else if (offset_size == 8)
                 {
@@ -131,7 +132,7 @@ class ItemLocationBox : public FullBox
                 }
                 if (length_size == 4)
                 {
-                    writeUint32Value(fp, extent->length);
+                    writeUint32Value(fp, (uint32_t)extent->length);
                 }
                 else if (length_size == 8)
                 {
@@ -141,7 +142,7 @@ class ItemLocationBox : public FullBox
         }
 
       private:
-        uint64_t getBaseOffset() const;
+        static uint64_t getBaseOffset();
         uint32_t item_ID;
         uint8_t construction_method;
         uint16_t data_reference_index;
@@ -160,8 +161,8 @@ class ItemLocationBox : public FullBox
   private:
     uint8_t getOffsetSize() const;
     uint8_t getLengthSize() const;
-    uint8_t getBaseOffsetSize() const;
-    uint8_t getIndexSizeOrReserved() const;
+    static uint8_t getBaseOffsetSize();
+    static uint8_t getIndexSizeOrReserved();
 
     std::vector<std::shared_ptr<Item>> items;
 };

--- a/frmts/heif/boxes/iloc.h
+++ b/frmts/heif/boxes/iloc.h
@@ -1,0 +1,167 @@
+/******************************************************************************
+ *
+ * Project:  HEIF driver
+ * Author:   Brad Hards <bradh@frogmouth.net>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Brad Hards <bradh@frogmouth.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include <algorithm>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "gdal_priv.h"
+
+#include "fullbox.h"
+
+class ItemLocationBox : public FullBox
+{
+  public:
+    ItemLocationBox() : FullBox("iloc")
+    {
+    }
+
+    ~ItemLocationBox()
+    {
+    }
+
+    class Item
+    {
+      public:
+        Item(uint32_t id)
+            : item_ID(id), construction_method(0), data_reference_index(0)
+        {
+        }
+
+        ~Item()
+        {
+        }
+
+        struct Extent
+        {
+            uint64_t index;
+            uint64_t offset;
+            uint64_t length;
+        };
+
+        void addExtent(std::shared_ptr<Extent> extent)
+        {
+            extents.push_back(extent);
+        }
+
+        uint16_t getExtentCount() const
+        {
+            return extents.size();
+        }
+
+        uint64_t getGreatestExtentOffset() const;
+
+        uint64_t getGreatestExtentLength() const;
+
+        void writeTo(VSILFILE *fp, uint8_t version, uint8_t base_offset_size,
+                     uint8_t index_size, uint8_t offset_size,
+                     uint8_t length_size)
+        {
+            if (version < 2)
+            {
+                writeUint16Value(fp, item_ID);
+            }
+            else
+            {
+                writeUint32Value(fp, item_ID);
+            }
+            if ((version == 1) || (version == 2))
+            {
+                writeUint16Value(fp, (construction_method & 0x0F));
+            }
+            writeUint16Value(fp, data_reference_index);
+            if (base_offset_size == 4)
+            {
+                writeUint32Value(fp, getBaseOffset());
+            }
+            else if (base_offset_size == 8)
+            {
+                writeUint64Value(fp, getBaseOffset());
+            }
+            uint16_t extent_count = extents.size();
+            writeUint16Value(fp, extent_count);
+            for (int j = 0; j < extent_count; j++)
+            {
+                std::shared_ptr<Extent> extent = extents[j];
+                if (((version == 1) || (version == 2)) && (index_size > 0))
+                {
+                    if (index_size == 4)
+                    {
+                        writeUint32Value(fp, extent->index);
+                    }
+                    else if (index_size == 8)
+                    {
+                        writeUint64Value(fp, extent->index);
+                    }
+                }
+                if (offset_size == 4)
+                {
+                    writeUint32Value(fp, extent->offset - getBaseOffset());
+                }
+                else if (offset_size == 8)
+                {
+                    writeUint64Value(fp, extent->offset - getBaseOffset());
+                }
+                if (length_size == 4)
+                {
+                    writeUint32Value(fp, extent->length);
+                }
+                else if (length_size == 8)
+                {
+                    writeUint64Value(fp, extent->length);
+                }
+            }
+        }
+
+      private:
+        uint64_t getBaseOffset() const;
+        uint32_t item_ID;
+        uint8_t construction_method;
+        uint16_t data_reference_index;
+        std::vector<std::shared_ptr<Extent>> extents;
+    };
+
+    void addItem(std::shared_ptr<Item> item)
+    {
+        items.push_back(item);
+    }
+
+  protected:
+    uint64_t getBodySize() override;
+    void writeBodyTo(VSILFILE *fp) override;
+
+  private:
+    uint8_t getOffsetSize() const;
+    uint8_t getLengthSize() const;
+    uint8_t getBaseOffsetSize() const;
+    uint8_t getIndexSizeOrReserved() const;
+
+    std::vector<std::shared_ptr<Item>> items;
+};

--- a/frmts/heif/boxes/iprp.cpp
+++ b/frmts/heif/boxes/iprp.cpp
@@ -1,0 +1,117 @@
+/******************************************************************************
+ *
+ * Project:  HEIF driver
+ * Author:   Brad Hards <bradh@frogmouth.net>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Brad Hards <bradh@frogmouth.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "iprp.h"
+#include <cstddef>
+#include <cstdint>
+
+uint64_t ItemPropertyAssociationBox::getBodySize()
+{
+    uint64_t size = 0;
+    size += sizeof(uint32_t);
+    for (size_t i = 0; i < entries.size(); i++)
+    {
+        if (version < 1)
+        {
+            size += sizeof(uint16_t);
+        }
+        else
+        {
+            size += sizeof(uint32_t);
+        }
+        size += sizeof(uint8_t);
+        uint8_t associationCount = entries[i].getAssociationCount();
+        if (getFlags(0) & 0x01)
+        {
+            size += (associationCount * sizeof(uint16_t));
+        }
+        else
+        {
+            size += (associationCount * sizeof(uint8_t));
+        }
+    }
+    return size;
+}
+
+void ItemPropertyAssociationBox::writeBodyTo(VSILFILE *fp)
+{
+    writeUint32Value(fp, entries.size());
+    for (size_t i = 0; i < entries.size(); i++)
+    {
+        if (version < 1)
+        {
+            writeUint16Value(fp, entries[i].getItemID());
+        }
+        else
+        {
+            writeUint32Value(fp, entries[i].getItemID());
+        }
+        writeUint8Value(fp, entries[i].getAssociationCount());
+        for (size_t j = 0; j < entries[i].getAssociationCount(); j++)
+        {
+            if (getFlags(0) & 0x01)
+            {
+                uint16_t assoc = entries[i].getAssociationAsUint16(j);
+                writeUint16Value(fp, assoc);
+            }
+            else
+            {
+                uint8_t assoc = entries[i].getAssociationAsUint8(j);
+                writeUint8Value(fp, assoc);
+            }
+        }
+    }
+}
+
+uint32_t ItemPropertyAssociationBox::Entry::getItemID() const
+{
+    return item_ID;
+}
+
+uint16_t ItemPropertyAssociationBox::Entry::getAssociationAsUint16(
+    unsigned int index) const
+{
+    Association association = associations[index];
+    uint16_t v = association.property_index & 0x7fff;
+    if (association.essential)
+    {
+        v |= 0x8000;
+    }
+    return v;
+}
+
+uint8_t ItemPropertyAssociationBox::Entry::getAssociationAsUint8(
+    unsigned int index) const
+{
+    Association association = associations[index];
+    uint8_t v = association.property_index & 0x7f;
+    if (association.essential)
+    {
+        v |= 0x80;
+    }
+    return v;
+}

--- a/frmts/heif/boxes/iprp.h
+++ b/frmts/heif/boxes/iprp.h
@@ -1,0 +1,117 @@
+/******************************************************************************
+ *
+ * Project:  HEIF driver
+ * Author:   Brad Hards <bradh@frogmouth.net>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Brad Hards <bradh@frogmouth.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "box.h"
+#include "fullbox.h"
+#include <cstdint>
+#include <memory>
+
+class ItemPropertiesBox : public AbstractContainerBox
+{
+  public:
+    ItemPropertiesBox() : AbstractContainerBox("iprp")
+    {
+    }
+
+    ~ItemPropertiesBox()
+    {
+    }
+
+    // TODO: implement this
+    // void addAssociation(std::shared_ptr<Box> property, uint32_t itemId);
+};
+
+class ItemPropertyContainerBox : public AbstractContainerBox
+{
+  public:
+    ItemPropertyContainerBox() : AbstractContainerBox("ipco")
+    {
+    }
+
+    ~ItemPropertyContainerBox()
+    {
+    }
+};
+
+class ItemPropertyAssociationBox : public FullBox
+{
+  public:
+    ItemPropertyAssociationBox() : FullBox("ipma")
+    {
+    }
+
+    ~ItemPropertyAssociationBox()
+    {
+    }
+
+    class Entry
+    {
+      public:
+        Entry(uint32_t id) : item_ID(id)
+        {
+        }
+
+        struct Association
+        {
+            bool essential;
+            uint16_t property_index;
+        };
+
+        void addAssociation(Association association)
+        {
+            associations.push_back(association);
+        }
+
+        uint32_t getItemID() const;
+
+        uint8_t getAssociationCount() const
+        {
+            return associations.size();
+        }
+
+        uint8_t getAssociationAsUint8(unsigned int index) const;
+
+        uint16_t getAssociationAsUint16(unsigned int index) const;
+
+      private:
+        uint32_t item_ID;
+        std::vector<Association> associations;
+    };
+
+    void addEntry(Entry entry)
+    {
+        entries.push_back(entry);
+    }
+
+  protected:
+    uint64_t getBodySize() override;
+
+    void writeBodyTo(VSILFILE *fp) override;
+
+  private:
+    std::vector<Entry> entries;
+};

--- a/frmts/heif/boxes/iprp.h
+++ b/frmts/heif/boxes/iprp.h
@@ -71,7 +71,7 @@ class ItemPropertyAssociationBox : public FullBox
     class Entry
     {
       public:
-        Entry(uint32_t id) : item_ID(id)
+        explicit Entry(uint32_t id) : item_ID(id)
         {
         }
 

--- a/frmts/heif/boxes/ispe.cpp
+++ b/frmts/heif/boxes/ispe.cpp
@@ -1,0 +1,40 @@
+/******************************************************************************
+ *
+ * Project:  HEIF driver
+ * Author:   Brad Hards <bradh@frogmouth.net>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Brad Hards <bradh@frogmouth.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "ispe.h"
+#include <cstdint>
+
+uint64_t ImageSpatialExtentsProperty::getBodySize()
+{
+    return 2 * sizeof(uint32_t);
+}
+
+void ImageSpatialExtentsProperty::writeBodyTo(VSILFILE *fp)
+{
+    writeUint32Value(fp, image_width);
+    writeUint32Value(fp, image_height);
+}

--- a/frmts/heif/boxes/ispe.h
+++ b/frmts/heif/boxes/ispe.h
@@ -1,0 +1,51 @@
+/******************************************************************************
+ *
+ * Project:  HEIF driver
+ * Author:   Brad Hards <bradh@frogmouth.net>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Brad Hards <bradh@frogmouth.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "fullbox.h"
+#include <cstdint>
+
+class ImageSpatialExtentsProperty : public FullBox
+{
+  public:
+    ImageSpatialExtentsProperty(uint32_t width, uint32_t height)
+        : FullBox("ispe"), image_width(width), image_height(height)
+    {
+    }
+
+    ~ImageSpatialExtentsProperty()
+    {
+    }
+
+  protected:
+    uint64_t getBodySize() override;
+
+    void writeBodyTo(VSILFILE *fp) override;
+
+  private:
+    uint32_t image_width;
+    uint32_t image_height;
+};

--- a/frmts/heif/boxes/mdat.cpp
+++ b/frmts/heif/boxes/mdat.cpp
@@ -1,0 +1,40 @@
+/******************************************************************************
+ *
+ * Project:  HEIF driver
+ * Author:   Brad Hards <bradh@frogmouth.net>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Brad Hards <bradh@frogmouth.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "mdat.h"
+#include <cstdint>
+#include <memory>
+
+uint64_t MediaDataBox::getBodySize()
+{
+    return data->size();
+}
+
+void MediaDataBox::writeBodyTo(VSILFILE *fp)
+{
+    writeBytes(fp, data);
+}

--- a/frmts/heif/boxes/mdat.h
+++ b/frmts/heif/boxes/mdat.h
@@ -1,0 +1,57 @@
+/******************************************************************************
+ *
+ * Project:  HEIF driver
+ * Author:   Brad Hards <bradh@frogmouth.net>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Brad Hards <bradh@frogmouth.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "box.h"
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+class MediaDataBox : public Box
+{
+  public:
+    MediaDataBox() : Box("mdat")
+    {
+    }
+
+    ~MediaDataBox()
+    {
+    }
+
+    void setData(std::shared_ptr<std::vector<uint8_t>> d)
+    {
+        data = d;
+    }
+
+  protected:
+    uint64_t getBodySize() override;
+
+    void writeBodyTo(VSILFILE *fp) override;
+
+  private:
+    std::shared_ptr<std::vector<uint8_t>> data;
+};

--- a/frmts/heif/boxes/meta.cpp
+++ b/frmts/heif/boxes/meta.cpp
@@ -1,0 +1,51 @@
+/******************************************************************************
+ *
+ * Project:  HEIF driver
+ * Author:   Brad Hards <bradh@frogmouth.net>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Brad Hards <bradh@frogmouth.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "meta.h"
+
+void MetaBox::addBox(Box *box)
+{
+    childBoxes.push_back(box);
+}
+
+uint64_t MetaBox::getBodySize()
+{
+    uint64_t size = 0;
+    for (size_t i = 0; i < childBoxes.size(); i++)
+    {
+        size += childBoxes[i]->getFullSize();
+    }
+    return size;
+}
+
+void MetaBox::writeBodyTo(VSILFILE *fp)
+{
+    for (size_t i = 0; i < childBoxes.size(); i++)
+    {
+        childBoxes[i]->writeTo(fp);
+    }
+}

--- a/frmts/heif/boxes/meta.h
+++ b/frmts/heif/boxes/meta.h
@@ -1,0 +1,50 @@
+/******************************************************************************
+ *
+ * Project:  HEIF driver
+ * Author:   Brad Hards <bradh@frogmouth.net>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Brad Hards <bradh@frogmouth.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "fullbox.h"
+
+class MetaBox : public FullBox
+{
+  public:
+    MetaBox() : FullBox("meta")
+    {
+    }
+
+    ~MetaBox()
+    {
+    }
+
+    void addBox(Box *box);
+
+  protected:
+    uint64_t getBodySize() override;
+
+    void writeBodyTo(VSILFILE *fp) override;
+
+  private:
+    std::vector<Box *> childBoxes;
+};

--- a/frmts/heif/boxes/pitm.cpp
+++ b/frmts/heif/boxes/pitm.cpp
@@ -1,0 +1,58 @@
+/******************************************************************************
+ *
+ * Project:  HEIF driver
+ * Author:   Brad Hards <bradh@frogmouth.net>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Brad Hards <bradh@frogmouth.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "pitm.h"
+
+void PrimaryItemBox::setItemID(uint32_t id)
+{
+    item_ID = id;
+}
+
+uint64_t PrimaryItemBox::getBodySize()
+{
+    if (item_ID > UINT16_MAX)
+    {
+        return sizeof(uint32_t);
+    }
+    else
+    {
+        return sizeof(uint16_t);
+    }
+}
+
+void PrimaryItemBox::writeBodyTo(VSILFILE *fp)
+{
+
+    if (item_ID > UINT16_MAX)
+    {
+        writeUint32Value(fp, item_ID);
+    }
+    else
+    {
+        writeUint16Value(fp, (uint16_t)item_ID);
+    }
+}

--- a/frmts/heif/boxes/pitm.cpp
+++ b/frmts/heif/boxes/pitm.cpp
@@ -27,11 +27,6 @@
 
 #include "pitm.h"
 
-void PrimaryItemBox::setItemID(uint32_t id)
-{
-    item_ID = id;
-}
-
 uint64_t PrimaryItemBox::getBodySize()
 {
     if (item_ID > UINT16_MAX)

--- a/frmts/heif/boxes/pitm.h
+++ b/frmts/heif/boxes/pitm.h
@@ -1,0 +1,50 @@
+/******************************************************************************
+ *
+ * Project:  HEIF driver
+ * Author:   Brad Hards <bradh@frogmouth.net>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Brad Hards <bradh@frogmouth.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "fullbox.h"
+
+class PrimaryItemBox : public FullBox
+{
+  public:
+    PrimaryItemBox() : FullBox("pitm")
+    {
+    }
+
+    ~PrimaryItemBox()
+    {
+    }
+
+    void setItemID(uint32_t id);
+
+  protected:
+    uint64_t getBodySize() override;
+
+    void writeBodyTo(VSILFILE *fp) override;
+
+  private:
+    uint32_t item_ID;
+};

--- a/frmts/heif/boxes/pitm.h
+++ b/frmts/heif/boxes/pitm.h
@@ -26,19 +26,18 @@
  ****************************************************************************/
 
 #include "fullbox.h"
+#include <cstdint>
 
 class PrimaryItemBox : public FullBox
 {
   public:
-    PrimaryItemBox() : FullBox("pitm")
+    explicit PrimaryItemBox(uint32_t id) : FullBox("pitm"), item_ID(id)
     {
     }
 
     ~PrimaryItemBox()
     {
     }
-
-    void setItemID(uint32_t id);
 
   protected:
     uint64_t getBodySize() override;

--- a/frmts/heif/boxes/uncc.cpp
+++ b/frmts/heif/boxes/uncc.cpp
@@ -1,0 +1,81 @@
+/******************************************************************************
+ *
+ * Project:  HEIF driver
+ * Author:   Brad Hards <bradh@frogmouth.net>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Brad Hards <bradh@frogmouth.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "uncc.h"
+#include <cstdint>
+
+uint64_t UncompressedFrameConfigBox::getBodySize()
+{
+    uint64_t size = 0;
+    size += sizeof(uint32_t);  // profile
+    if (version == 1)
+    {
+    }
+    else if (version == 0)
+    {
+        size += sizeof(uint32_t);         // component_count
+        size += (5 * components.size());  // 5 bytes per component
+        size +=
+            (4 * sizeof(uint8_t));  // sampling, interleave, block + flag bits
+        size += (5 * sizeof(uint32_t));  // pixel_size onwards
+    }
+    return size;
+}
+
+void UncompressedFrameConfigBox::writeBodyTo(VSILFILE *fp)
+{
+    writeUint32Value(fp, profile);
+    if (version == 1)
+    {
+    }
+    else if (version == 0)
+    {
+        writeUint32Value(fp, components.size());
+        for (size_t i = 0; i < components.size(); i++)
+        {
+            writeUint16Value(fp, components[i].component_index);
+            writeUint8Value(fp, components[i].component_bit_depth_minus_one);
+            writeUint8Value(fp, components[i].component_format);
+            writeUint8Value(fp, components[i].component_align_size);
+        }
+        writeUint8Value(fp, sampling_type);
+        writeUint8Value(fp, interleave_type);
+        writeUint8Value(fp, block_size);
+        uint8_t flagBits = 0;
+        flagBits |= components_little_endian ? 0x80 : 0x00;
+        flagBits |= block_pad_lsb ? 0x40 : 0x00;
+        flagBits |= block_little_endian ? 0x20 : 0x00;
+        flagBits |= block_reversed ? 0x10 : 0x00;
+        flagBits |= pad_unknown ? 0x08 : 0x00;
+        writeUint8Value(fp, flagBits);
+        writeUint32Value(fp, pixel_size);
+        writeUint32Value(fp, row_align_size);
+        writeUint32Value(fp, tile_align_size);
+        writeUint32Value(fp, num_tile_cols_minus_one);
+        writeUint32Value(fp, num_tile_rows_minus_one);
+    }
+}

--- a/frmts/heif/boxes/uncc.h
+++ b/frmts/heif/boxes/uncc.h
@@ -1,0 +1,82 @@
+/******************************************************************************
+ *
+ * Project:  HEIF driver
+ * Author:   Brad Hards <bradh@frogmouth.net>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Brad Hards <bradh@frogmouth.net>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "fullbox.h"
+#include <cstdint>
+#include <vector>
+
+class UncompressedFrameConfigBox : public FullBox
+{
+  public:
+    UncompressedFrameConfigBox()
+        : FullBox("uncC"), profile(0), sampling_type(0), interleave_type(0),
+          block_size(0), components_little_endian(false), block_pad_lsb(false),
+          block_little_endian(false), block_reversed(false), pad_unknown(true),
+          pixel_size(0), row_align_size(0), tile_align_size(0),
+          num_tile_cols_minus_one(0), num_tile_rows_minus_one(0)
+    {
+    }
+
+    ~UncompressedFrameConfigBox()
+    {
+    }
+
+    struct Component
+    {
+        uint16_t component_index;
+        uint8_t component_bit_depth_minus_one;
+        uint8_t component_format;
+        uint8_t component_align_size;
+    };
+
+    void addComponent(Component component)
+    {
+        components.push_back(component);
+    }
+
+  protected:
+    uint64_t getBodySize() override;
+
+    void writeBodyTo(VSILFILE *fp) override;
+
+  private:
+    uint32_t profile;
+    std::vector<Component> components;
+    uint8_t sampling_type;
+    uint8_t interleave_type;
+    uint8_t block_size;
+    bool components_little_endian;
+    bool block_pad_lsb;
+    bool block_little_endian;
+    bool block_reversed;
+    bool pad_unknown;
+    uint32_t pixel_size;
+    uint32_t row_align_size;
+    uint32_t tile_align_size;
+    uint32_t num_tile_cols_minus_one;
+    uint32_t num_tile_rows_minus_one;
+};

--- a/frmts/heif/heifdataset.h
+++ b/frmts/heif/heifdataset.h
@@ -1,0 +1,79 @@
+/******************************************************************************
+ *
+ * Project:  HEIF read-only Driver
+ * Author:   Even Rouault <even.rouault at spatialys.com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2020, Even Rouault <even.rouault at spatialys.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "gdal_pam.h"
+#include "ogr_spatialref.h"
+
+#include "include_libheif.h"
+
+#include "heifdrivercore.h"
+
+#include <vector>
+
+/************************************************************************/
+/*                        GDALHEIFDataset                               */
+/************************************************************************/
+
+class GDALHEIFDataset final : public GDALPamDataset
+{
+    friend class GDALHEIFRasterBand;
+
+    heif_context *m_hCtxt = nullptr;
+    heif_image_handle *m_hImageHandle = nullptr;
+    heif_image *m_hImage = nullptr;
+    bool m_bFailureDecoding = false;
+    std::vector<std::unique_ptr<GDALHEIFDataset>> m_apoOvrDS{};
+    bool m_bIsThumbnail = false;
+
+#ifdef HAS_CUSTOM_FILE_READER
+    heif_reader m_oReader{};
+    VSILFILE *m_fpL = nullptr;
+    vsi_l_offset m_nSize = 0;
+
+    static int64_t GetPositionCbk(void *userdata);
+    static int ReadCbk(void *data, size_t size, void *userdata);
+    static int SeekCbk(int64_t position, void *userdata);
+    static enum heif_reader_grow_status WaitForFileSizeCbk(int64_t target_size,
+                                                           void *userdata);
+#endif
+
+    bool Init(GDALOpenInfo *poOpenInfo);
+    void ReadMetadata();
+    void OpenThumbnails();
+
+  public:
+    GDALHEIFDataset();
+    ~GDALHEIFDataset();
+
+    static GDALDataset *Open(GDALOpenInfo *poOpenInfo);
+
+    static GDALDataset *CreateCopy(const char *pszFilename,
+                                   GDALDataset *poSrcDS, int bStrict,
+                                   char **papszOptions,
+                                   GDALProgressFunc pfnProgress,
+                                   void *pProgressData);
+};

--- a/frmts/heif/heifdatasetcreatecopy.cpp
+++ b/frmts/heif/heifdatasetcreatecopy.cpp
@@ -51,7 +51,7 @@
 /************************************************************************/
 
 GDALDataset *GDALHEIFDataset::CreateCopy(const char *pszFilename,
-                                         GDALDataset *poSrcDS, int bStrict,
+                                         GDALDataset *poSrcDS, int,
                                          CPL_UNUSED char **papszOptions,
                                          GDALProgressFunc pfnProgress,
                                          void *pProgressData)

--- a/frmts/heif/heifdatasetcreatecopy.cpp
+++ b/frmts/heif/heifdatasetcreatecopy.cpp
@@ -1,0 +1,241 @@
+/******************************************************************************
+ *
+ * Project:  HEIF read-only Driver
+ * Author:   Even Rouault <even.rouault at spatialys.com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Even Rouault <even.rouault at spatialys.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "heifdataset.h"
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <vector>
+
+#include "boxes/cmpd.h"
+#include "boxes/ftyp.h"
+#include "boxes/hdlr.h"
+#include "boxes/iinf.h"
+#include "boxes/iloc.h"
+#include "boxes/iprp.h"
+#include "boxes/ispe.h"
+#include "boxes/mdat.h"
+#include "boxes/meta.h"
+#include "boxes/pitm.h"
+#include "boxes/uncc.h"
+#include "cpl_error.h"
+
+/************************************************************************/
+/*                             CreateCopy()                             */
+/************************************************************************/
+
+GDALDataset *GDALHEIFDataset::CreateCopy(const char *pszFilename,
+                                         GDALDataset *poSrcDS, int bStrict,
+                                         CPL_UNUSED char **papszOptions,
+                                         GDALProgressFunc pfnProgress,
+                                         void *pProgressData)
+{
+    if (pfnProgress == nullptr)
+        pfnProgress = GDALDummyProgress;
+
+    int nBands = poSrcDS->GetRasterCount();
+    if (nBands == 0)
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "Driver does not support source dataset with zero band.\n");
+        return nullptr;
+    }
+
+    // TODO: sanity checks
+
+    VSILFILE *fp = VSIFOpenL(pszFilename, "w+b");
+
+    if (fp == nullptr)
+    {
+        CPLError(CE_Failure, CPLE_OpenFailed,
+                 "Attempt to create file '%s' failed.\n", pszFilename);
+        return nullptr;
+    }
+
+    GInt32 nXSize = poSrcDS->GetRasterXSize();
+    GInt32 nYSize = poSrcDS->GetRasterYSize();
+
+    // TODO: maybe per-band extents
+    MediaDataBox mdat;
+    // TODO: don't hard code the per-pixel component data size.
+    size_t bandSize = nXSize * nYSize;
+    size_t size = bandSize * nBands;
+    std::shared_ptr<std::vector<uint8_t>> data =
+        std::make_shared<std::vector<uint8_t>>();
+
+    uint8_t *bandData =
+        (uint8_t *)VSI_MALLOC2_VERBOSE(bandSize, sizeof(uint8_t));
+    if (bandData == nullptr)
+    {
+        VSIFCloseL(fp);
+        return nullptr;
+    }
+
+    // TODO: iterator form
+    for (int bandIndex = 0; bandIndex < nBands; bandIndex++)
+    {
+        GDALRasterBand *band = poSrcDS->GetRasterBand(bandIndex + 1);
+        // TODO: we can probably handle line and pixel padding here.
+        auto eErr = band->RasterIO(GF_Read, 0, 0, nXSize, nYSize, bandData,
+                                   nXSize, nYSize, GDT_Byte, 0, 0, nullptr);
+
+        if (eErr != CE_None)
+        {
+            VSIFCloseL(fp);
+            VSIFree(bandData);
+            return nullptr;
+        }
+
+        data->insert(data->begin() + bandIndex * bandSize, bandData,
+                     bandData + bandSize);
+
+        if (!pfnProgress(static_cast<double>(bandIndex / nBands), nullptr,
+                         pProgressData))
+        {
+            VSIFCloseL(fp);
+            VSIFree(bandData);
+            CPLError(CE_Failure, CPLE_UserInterrupt, "User terminated");
+            return nullptr;
+        }
+    }
+
+    VSIFree(bandData);
+    mdat.setData(data);
+
+    std::shared_ptr<ItemLocationBox::Item::Extent> extent =
+        std::make_shared<ItemLocationBox::Item::Extent>();
+    extent->index = 0;
+    extent->offset = 0;
+    extent->length = size;
+
+    FileTypeBox ftyp;
+    ftyp.setMajorBrand(fourcc("mif1"));
+    ftyp.addCompatibleBrand(fourcc("mif1"));
+    ftyp.addCompatibleBrand(fourcc("heic"));
+    ftyp.addCompatibleBrand(fourcc("unif"));
+    ftyp.writeTo(fp);
+
+    MetaBox meta;
+    uint32_t primaryItemId = 1;
+
+    HandlerBox hdlr;
+    hdlr.setHandlerType(fourcc("pict"));
+    hdlr.setName("Picture handler");
+    meta.addBox(&hdlr);
+
+    PrimaryItemBox pitm;
+    pitm.setItemID(primaryItemId);
+    meta.addBox(&pitm);
+
+    ItemInfoBox iinf;
+    std::shared_ptr<ItemInfoEntry> infe =
+        std::make_shared<ItemInfoEntry>(primaryItemId, "unci", "Primary Image");
+    iinf.addEntry(infe);
+    meta.addBox(&iinf);
+
+    ItemLocationBox iloc;
+    std::shared_ptr<ItemLocationBox::Item> locationItem =
+        std::make_shared<ItemLocationBox::Item>(primaryItemId);
+    locationItem->addExtent(extent);
+    iloc.addItem(locationItem);
+    meta.addBox(&iloc);
+
+    ItemPropertiesBox iprp;
+    std::shared_ptr<ItemPropertyContainerBox> ipco =
+        std::make_shared<ItemPropertyContainerBox>();
+    iprp.addChildBox(ipco);
+    std::shared_ptr<ItemPropertyAssociationBox> ipma =
+        std::make_shared<ItemPropertyAssociationBox>();
+    iprp.addChildBox(ipma);
+
+    std::shared_ptr<ImageSpatialExtentsProperty> ispe =
+        std::make_shared<ImageSpatialExtentsProperty>(nXSize, nYSize);
+    // iprp.addEssentialAssociation(ispe, primaryItemId);
+    int ispeIndex = ipco->addChildBox(ispe);
+    ItemPropertyAssociationBox::Entry entry(primaryItemId);
+    ItemPropertyAssociationBox::Entry::Association ispeAssociation;
+    ispeAssociation.essential = true;
+    ispeAssociation.property_index = ispeIndex;
+    entry.addAssociation(ispeAssociation);
+
+    std::shared_ptr<ComponentDefinitionBox> cmpd =
+        std::make_shared<ComponentDefinitionBox>();
+    // TODO: add components based on GDAL band info.
+    cmpd->addComponent(4);
+    cmpd->addComponent(5);
+    cmpd->addComponent(6);
+    int cmpdIndex = ipco->addChildBox(cmpd);
+    ItemPropertyAssociationBox::Entry::Association cmpdAssociation;
+    cmpdAssociation.essential = true;
+    cmpdAssociation.property_index = cmpdIndex;
+    entry.addAssociation(cmpdAssociation);
+
+    std::shared_ptr<UncompressedFrameConfigBox> uncC =
+        std::make_shared<UncompressedFrameConfigBox>();
+    // TODO: build from GDAL band info
+    UncompressedFrameConfigBox::Component redComponent;
+    redComponent.component_index = 0;
+    redComponent.component_bit_depth_minus_one = 7;
+    redComponent.component_format = 0;
+    redComponent.component_align_size = 0;
+    uncC->addComponent(redComponent);
+    UncompressedFrameConfigBox::Component greenComponent;
+    greenComponent.component_index = 1;
+    greenComponent.component_bit_depth_minus_one = 7;
+    greenComponent.component_format = 0;
+    greenComponent.component_align_size = 0;
+    uncC->addComponent(greenComponent);
+    UncompressedFrameConfigBox::Component blueComponent;
+    blueComponent.component_index = 2;
+    blueComponent.component_bit_depth_minus_one = 7;
+    blueComponent.component_format = 0;
+    blueComponent.component_align_size = 0;
+    uncC->addComponent(blueComponent);
+
+    int uncCIndex = ipco->addChildBox(uncC);
+    ItemPropertyAssociationBox::Entry::Association uncCAssociation;
+    uncCAssociation.essential = true;
+    uncCAssociation.property_index = uncCIndex;
+    entry.addAssociation(uncCAssociation);
+
+    ipma->addEntry(entry);
+    meta.addBox(&iprp);
+
+    uint64_t mdatOffset = ftyp.getFullSize() + meta.getFullSize();
+    extent->offset = mdatOffset + mdat.getHeaderSize();
+
+    meta.writeTo(fp);
+
+    mdat.writeTo(fp);
+
+    VSIFCloseL(fp);
+
+    GDALPamDataset *poDS = (GDALPamDataset *)GDALOpen(pszFilename, GA_ReadOnly);
+    return poDS;
+}

--- a/frmts/heif/heifdatasetcreatecopy.cpp
+++ b/frmts/heif/heifdatasetcreatecopy.cpp
@@ -149,8 +149,7 @@ GDALDataset *GDALHEIFDataset::CreateCopy(const char *pszFilename,
     hdlr.setName("Picture handler");
     meta.addBox(&hdlr);
 
-    PrimaryItemBox pitm;
-    pitm.setItemID(primaryItemId);
+    PrimaryItemBox pitm(primaryItemId);
     meta.addBox(&pitm);
 
     ItemInfoBox iinf;


### PR DESCRIPTION
## What does this PR do?

Initial sketch of work to add write support to the HEIF driver.

This does not use libheif to do the writing, given the differences in what libheif can do and what GDAL can represent.

At this stage it can only do the uncompressed codec (which libheif can support, but is behind a cmake flag). A recent version of gpac is also an option

Perhaps it would be better to do a different driver. Possibly the box support could be generalised and used for other drivers (jpegxl, jpeg2000, etc).

Comments and feedback on the approach and way forward are sought.

## What are related issues/pull requests?

N/A.

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
