### PR TITLE
[Backport release/3.8] /vsis3/: takes into account AWS_CONTAINER_CREDENTIALS_FULL_URI environment variable (fixes #8858)

### DIFF
--- a/autotest/gcore/vsis3.py
+++ b/autotest/gcore/vsis3.py
@@ -73,6 +73,8 @@ general_s3_options = {
     "AWS_DEFAULT_REGION": "us-east-1",
     "AWS_DEFAULT_PROFILE": "",
     "AWS_PROFILE": "default",
+    "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI": "",
+    "AWS_CONTAINER_CREDENTIALS_FULL_URI": "",
 }
 
 
@@ -5022,6 +5024,55 @@ def test_vsis3_read_credentials_ec2_expiration(aws_test_config, webserver_port):
                 with gdal.quiet_errors():
                     f = open_for_read("/vsis3/s3_fake_bucket/bar")
         assert f is None
+
+
+###############################################################################
+# Read credentials from simulated instance with AWS_CONTAINER_CREDENTIALS_FULL_URI
+
+
+@pytest.mark.skipif(sys.platform not in ("linux", "win32"), reason="Incorrect platform")
+def test_vsis3_read_credentials_AWS_CONTAINER_CREDENTIALS_FULL_URI(
+    aws_test_config, webserver_port
+):
+    options = {
+        "CPL_AWS_CREDENTIALS_FILE": "",
+        "AWS_CONFIG_FILE": "",
+        "AWS_SECRET_ACCESS_KEY": "",
+        "AWS_ACCESS_KEY_ID": "",
+        # Disable hypervisor related check to test if we are really on EC2
+        "CPL_AWS_AUTODETECT_EC2": "NO",
+        "CPL_AWS_WEB_IDENTITY_ENABLE": "NO",
+        "AWS_CONTAINER_CREDENTIALS_FULL_URI": f"http://localhost:{webserver_port}/AWS_CONTAINER_CREDENTIALS_FULL_URI",
+    }
+
+    gdal.VSICurlClearCache()
+
+    handler = webserver.SequentialHandler()
+    handler.add(
+        "GET",
+        "/AWS_CONTAINER_CREDENTIALS_FULL_URI",
+        200,
+        {},
+        """{
+        "AccessKeyId": "AWS_ACCESS_KEY_ID",
+        "SecretAccessKey": "AWS_SECRET_ACCESS_KEY",
+        "Expiration": "3000-01-01T00:00:00Z"
+        }""",
+    )
+
+    handler.add(
+        "GET",
+        "/s3_fake_bucket/resource",
+        custom_method=get_s3_fake_bucket_resource_method,
+    )
+    with webserver.install_http_handler(handler):
+        with gdaltest.config_options(options, thread_local=False):
+            f = open_for_read("/vsis3/s3_fake_bucket/resource")
+        assert f is not None
+        data = gdal.VSIFReadL(1, 4, f).decode("ascii")
+        gdal.VSIFCloseL(f)
+
+    assert data == "foo"
 
 
 ###############################################################################


### PR DESCRIPTION
Backport #8859
 **Authored by:** @rouault