### PR TITLE
[Backport release/3.8] GDALTranslate(): avoid useless extra GDALOpen() call on a target GeoRaster (again)

### DIFF
--- a/frmts/kmlsuperoverlay/kmlsuperoverlaydataset.cpp
+++ b/frmts/kmlsuperoverlay/kmlsuperoverlaydataset.cpp
@@ -167,7 +167,7 @@ static void GenerateTiles(const std::string &filename, CPL_UNUSED int zoom,
     CPLSetThreadLocalConfigOption("GDAL_OPEN_AFTER_COPY", "NO");
     /* to prevent CreateCopy() from calling QuietDelete() */
     char **papszOptions =
-        CSLAddNameValue(nullptr, "QUIET_DELETE_ON_CREATE_COPY", "NO");
+        CSLAddNameValue(nullptr, "@QUIET_DELETE_ON_CREATE_COPY", "NO");
     GDALDataset *outDs = poOutputTileDriver->CreateCopy(
         filename.c_str(), poTmpDataset, FALSE, papszOptions, nullptr, nullptr);
     CSLDestroy(papszOptions);

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -1844,6 +1844,10 @@ class CPL_DLL GDALDriver : public GDALMajorObject
                                    int bStrict, CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
+
+    CPLErr QuietDeleteForCreateCopy(const char *pszFilename,
+                                    GDALDataset *poSrcDS);
+
     //! @endcond
     static CPLErr QuietDelete(const char *pszName,
                               CSLConstList papszAllowedDrivers = nullptr);

--- a/gcore/gdaldriver.cpp
+++ b/gcore/gdaldriver.cpp
@@ -980,6 +980,112 @@ void GDALDriver::DefaultCopyMetadata(GDALDataset *poSrcDS, GDALDataset *poDstDS,
     }
     CSLDestroy(papszSrcMDD);
 }
+
+/************************************************************************/
+/*                      QuietDeleteForCreateCopy()                      */
+/************************************************************************/
+
+CPLErr GDALDriver::QuietDeleteForCreateCopy(const char *pszFilename,
+                                            GDALDataset *poSrcDS)
+{
+    // Someone issuing CreateCopy("foo.tif") on a
+    // memory driver doesn't expect files with those names to be deleted
+    // on a file system...
+    // This is somewhat messy. Ideally there should be a way for the
+    // driver to overload the default behavior
+    if (!EQUAL(GetDescription(), "MEM") && !EQUAL(GetDescription(), "Memory") &&
+        // Also exclude database formats for which there's no file list
+        // and whose opening might be slow (GeoRaster in particular)
+        !EQUAL(GetDescription(), "GeoRaster") &&
+        !EQUAL(GetDescription(), "PostGISRaster"))
+    {
+        /* --------------------------------------------------------------------
+         */
+        /*      Establish list of files of output dataset if it already
+         * exists. */
+        /* --------------------------------------------------------------------
+         */
+        std::set<std::string> oSetExistingDestFiles;
+        {
+            CPLPushErrorHandler(CPLQuietErrorHandler);
+            const char *const apszAllowedDrivers[] = {GetDescription(),
+                                                      nullptr};
+            auto poExistingOutputDS =
+                std::unique_ptr<GDALDataset>(GDALDataset::Open(
+                    pszFilename, GDAL_OF_RASTER, apszAllowedDrivers));
+            if (poExistingOutputDS)
+            {
+                char **papszFileList = poExistingOutputDS->GetFileList();
+                for (char **papszIter = papszFileList; papszIter && *papszIter;
+                     ++papszIter)
+                {
+                    oSetExistingDestFiles.insert(
+                        CPLString(*papszIter).replaceAll('\\', '/'));
+                }
+                CSLDestroy(papszFileList);
+            }
+            CPLPopErrorHandler();
+        }
+
+        /* --------------------------------------------------------------------
+         */
+        /*      Check if the source dataset shares some files with the dest
+         * one.*/
+        /* --------------------------------------------------------------------
+         */
+        std::set<std::string> oSetExistingDestFilesFoundInSource;
+        if (!oSetExistingDestFiles.empty())
+        {
+            CPLPushErrorHandler(CPLQuietErrorHandler);
+            // We need to reopen in a temporary dataset for the particular
+            // case of overwritten a .tif.ovr file from a .tif
+            // If we probe the file list of the .tif, it will then open the
+            // .tif.ovr !
+            const char *const apszAllowedDrivers[] = {
+                poSrcDS->GetDriver() ? poSrcDS->GetDriver()->GetDescription()
+                                     : nullptr,
+                nullptr};
+            auto poSrcDSTmp = std::unique_ptr<GDALDataset>(GDALDataset::Open(
+                poSrcDS->GetDescription(), GDAL_OF_RASTER, apszAllowedDrivers));
+            if (poSrcDSTmp)
+            {
+                char **papszFileList = poSrcDSTmp->GetFileList();
+                for (char **papszIter = papszFileList; papszIter && *papszIter;
+                     ++papszIter)
+                {
+                    CPLString osFilename(*papszIter);
+                    osFilename.replaceAll('\\', '/');
+                    if (oSetExistingDestFiles.find(osFilename) !=
+                        oSetExistingDestFiles.end())
+                    {
+                        oSetExistingDestFilesFoundInSource.insert(osFilename);
+                    }
+                }
+                CSLDestroy(papszFileList);
+            }
+            CPLPopErrorHandler();
+        }
+
+        // If the source file(s) and the dest one share some files in
+        // common, only remove the files that are *not* in common
+        if (!oSetExistingDestFilesFoundInSource.empty())
+        {
+            for (const std::string &osFilename : oSetExistingDestFiles)
+            {
+                if (oSetExistingDestFilesFoundInSource.find(osFilename) ==
+                    oSetExistingDestFilesFoundInSource.end())
+                {
+                    VSIUnlink(osFilename.c_str());
+                }
+            }
+        }
+
+        QuietDelete(pszFilename);
+    }
+
+    return CE_None;
+}
+
 //! @endcond
 
 /************************************************************************/
@@ -1165,109 +1271,17 @@ GDALDataset *GDALDriver::CreateCopy(const char *pszFilename,
     /* -------------------------------------------------------------------- */
     const bool bAppendSubdataset =
         CPLFetchBool(papszOptions, "APPEND_SUBDATASET", false);
-    // Note: QUIET_DELETE_ON_CREATE_COPY is set to NO by the KMLSuperOverlay
-    // driver when writing a .kmz file
+    // Note: @QUIET_DELETE_ON_CREATE_COPY is set to NO by the KMLSuperOverlay
+    // driver when writing a .kmz file. Also by GDALTranslate() if it has
+    // already done a similar job.
     if (!bAppendSubdataset &&
-        CPLFetchBool(papszOptions, "QUIET_DELETE_ON_CREATE_COPY", true))
+        CPLFetchBool(papszOptions, "@QUIET_DELETE_ON_CREATE_COPY", true))
     {
-        // Someone issuing CreateCopy("foo.tif") on a
-        // memory driver doesn't expect files with those names to be deleted
-        // on a file system...
-        // This is somewhat messy. Ideally there should be a way for the
-        // driver to overload the default behavior
-        if (!EQUAL(GetDescription(), "MEM") &&
-            !EQUAL(GetDescription(), "Memory"))
-        {
-            /* --------------------------------------------------------------------
-             */
-            /*      Establish list of files of output dataset if it already
-             * exists. */
-            /* --------------------------------------------------------------------
-             */
-            std::set<std::string> oSetExistingDestFiles;
-            {
-                CPLPushErrorHandler(CPLQuietErrorHandler);
-                const char *const apszAllowedDrivers[] = {GetDescription(),
-                                                          nullptr};
-                auto poExistingOutputDS =
-                    std::unique_ptr<GDALDataset>(GDALDataset::Open(
-                        pszFilename, GDAL_OF_RASTER, apszAllowedDrivers));
-                if (poExistingOutputDS)
-                {
-                    char **papszFileList = poExistingOutputDS->GetFileList();
-                    for (char **papszIter = papszFileList;
-                         papszIter && *papszIter; ++papszIter)
-                    {
-                        oSetExistingDestFiles.insert(
-                            CPLString(*papszIter).replaceAll('\\', '/'));
-                    }
-                    CSLDestroy(papszFileList);
-                }
-                CPLPopErrorHandler();
-            }
-
-            /* --------------------------------------------------------------------
-             */
-            /*      Check if the source dataset shares some files with the dest
-             * one.*/
-            /* --------------------------------------------------------------------
-             */
-            std::set<std::string> oSetExistingDestFilesFoundInSource;
-            if (!oSetExistingDestFiles.empty())
-            {
-                CPLPushErrorHandler(CPLQuietErrorHandler);
-                // We need to reopen in a temporary dataset for the particular
-                // case of overwritten a .tif.ovr file from a .tif
-                // If we probe the file list of the .tif, it will then open the
-                // .tif.ovr !
-                const char *const apszAllowedDrivers[] = {
-                    poSrcDS->GetDriver()
-                        ? poSrcDS->GetDriver()->GetDescription()
-                        : nullptr,
-                    nullptr};
-                auto poSrcDSTmp = std::unique_ptr<GDALDataset>(
-                    GDALDataset::Open(poSrcDS->GetDescription(), GDAL_OF_RASTER,
-                                      apszAllowedDrivers));
-                if (poSrcDSTmp)
-                {
-                    char **papszFileList = poSrcDSTmp->GetFileList();
-                    for (char **papszIter = papszFileList;
-                         papszIter && *papszIter; ++papszIter)
-                    {
-                        CPLString osFilename(*papszIter);
-                        osFilename.replaceAll('\\', '/');
-                        if (oSetExistingDestFiles.find(osFilename) !=
-                            oSetExistingDestFiles.end())
-                        {
-                            oSetExistingDestFilesFoundInSource.insert(
-                                osFilename);
-                        }
-                    }
-                    CSLDestroy(papszFileList);
-                }
-                CPLPopErrorHandler();
-            }
-
-            // If the source file(s) and the dest one share some files in
-            // common, only remove the files that are *not* in common
-            if (!oSetExistingDestFilesFoundInSource.empty())
-            {
-                for (const std::string &osFilename : oSetExistingDestFiles)
-                {
-                    if (oSetExistingDestFilesFoundInSource.find(osFilename) ==
-                        oSetExistingDestFilesFoundInSource.end())
-                    {
-                        VSIUnlink(osFilename.c_str());
-                    }
-                }
-            }
-
-            QuietDelete(pszFilename);
-        }
+        QuietDeleteForCreateCopy(pszFilename, poSrcDS);
     }
 
     int iIdxQuietDeleteOnCreateCopy =
-        CSLPartialFindString(papszOptions, "QUIET_DELETE_ON_CREATE_COPY=");
+        CSLPartialFindString(papszOptions, "@QUIET_DELETE_ON_CREATE_COPY=");
     if (iIdxQuietDeleteOnCreateCopy >= 0)
     {
         if (papszOptionsToDelete == nullptr)


### PR DESCRIPTION
Backport #8885
 **Authored by:** @rouault