### PR TITLE
VRT: 'sd_name' and 'sd' for vrt:// connection

### DIFF
--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1659,6 +1659,27 @@ def test_vrt_protocol():
         assert not gdal.Open("vrt://data/byte.tif?srcwin=0,0,20,21&epo=true")
         assert not gdal.Open("vrt://data/byte.tif?srcwin=20,20,1,1&epo=false&eco=true")
 
+    ds = gdal.Open("vrt://data/tiff_with_subifds.tif?subdataset_n=2")
+    assert ds.GetRasterBand(1).Checksum() == 0
+
+    ## the component name is "1"
+    ds = gdal.Open("vrt://data/tiff_with_subifds.tif?subdataset=1")
+    assert ds.GetRasterBand(1).Checksum() == 35731
+    with pytest.raises(Exception):
+        assert not gdal.Open(
+            "vrt://data/tiff_with_subifds.tif?subdataset_n=2&subdataset=1"
+        )
+        assert not gdal.Open("vrt://data/tiff_with_subifds.tif?subdataset_n=3")
+        assert not gdal.Open("vrt://data/tiff_with_subifds.tif?subdataset=sds")
+
+
+@pytest.mark.require_driver("NetCDF")
+def test_vrt_protocol_netcdf_component_name():
+    ds = gdal.Open(
+        "vrt://../gdrivers/data/netcdf/alldatatypes.nc?subdataset=ubyte_y2_x2_var"
+    )
+    assert ds.GetRasterBand(1).Checksum() == 71
+
 
 @pytest.mark.require_proj(7, 2)
 def test_vrt_protocol_a_coord_epoch_option():

--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1659,24 +1659,22 @@ def test_vrt_protocol():
         assert not gdal.Open("vrt://data/byte.tif?srcwin=0,0,20,21&epo=true")
         assert not gdal.Open("vrt://data/byte.tif?srcwin=20,20,1,1&epo=false&eco=true")
 
-    ds = gdal.Open("vrt://data/tiff_with_subifds.tif?subdataset_n=2")
+    ds = gdal.Open("vrt://data/tiff_with_subifds.tif?sd=2")
     assert ds.GetRasterBand(1).Checksum() == 0
 
     ## the component name is "1"
-    ds = gdal.Open("vrt://data/tiff_with_subifds.tif?subdataset=1")
+    ds = gdal.Open("vrt://data/tiff_with_subifds.tif?sd_name=1")
     assert ds.GetRasterBand(1).Checksum() == 35731
     with pytest.raises(Exception):
-        assert not gdal.Open(
-            "vrt://data/tiff_with_subifds.tif?subdataset_n=2&subdataset=1"
-        )
-        assert not gdal.Open("vrt://data/tiff_with_subifds.tif?subdataset_n=3")
-        assert not gdal.Open("vrt://data/tiff_with_subifds.tif?subdataset=sds")
+        assert not gdal.Open("vrt://data/tiff_with_subifds.tif?sd=2&sd_name=1")
+        assert not gdal.Open("vrt://data/tiff_with_subifds.tif?sd=3")
+        assert not gdal.Open("vrt://data/tiff_with_subifds.tif?sd_name=sds")
 
 
 @pytest.mark.require_driver("NetCDF")
 def test_vrt_protocol_netcdf_component_name():
     ds = gdal.Open(
-        "vrt://../gdrivers/data/netcdf/alldatatypes.nc?subdataset=ubyte_y2_x2_var"
+        "vrt://../gdrivers/data/netcdf/alldatatypes.nc?sd_name=ubyte_y2_x2_var"
     )
     assert ds.GetRasterBand(1).Checksum() == 71
 

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1904,12 +1904,12 @@ For example:
 
 ::
 
-    vrt://my.nc?subdataset=sds
+    vrt://my.nc?sd_name=sds
 
 
 The supported options currently are ``bands``, ``a_nodata``, ``a_srs``, ``a_ullr``, ``ovr``, ``expand``,
 ``a_scale``, ``a_offset``, ``ot``, ``gcp``, ``if``, ``scale``, ``exponent``, ``outsize``, ``projwin``,
-``projwin_srs``, ``tr``, ``r``, ``srcwin``, ``a_gt``, ``oo``, ``unscale``, ``a_coord_epoch``, ``nogcp``, ``epo``, ``eco``, ``subdataset``, and ``subdataset_n``.
+``projwin_srs``, ``tr``, ``r``, ``srcwin``, ``a_gt``, ``oo``, ``unscale``, ``a_coord_epoch``, ``nogcp``, ``epo``, ``eco``, ``sd_name``, and ``sd``.
 
 Other options may be added in the future.
 
@@ -1996,18 +1996,18 @@ The effect of the ``epo`` option (added in GDAL 3.8) is that ``srcwin`` or ``pro
 
 The effect of the ``eco`` option (added in GDAL 3.8) is that ``srcwin`` or ``projwin`` values that fall completely outside the source raster extent will be considered as an error as per (:ref:`gdal_translate`). To apply this use syntax ``eco=true``, or ``eco=false`` (which is the default if not specified).
 
-The effect of the ``subdataset`` option (added in GDAL 3.9) is to choose an individual subdataset by
+The effect of the ``sd_name`` option (added in GDAL 3.9) is to choose an individual subdataset by
 name for sources that have multiple subdatasets. This means that rather than a fully-qualified description
-such as "NETCDF:myfile.nc:somearray" we may use "vrt://myfile.nc?subdataset=somearray". This option
-is mutually exclusive with ``subdataset_n``.
+such as "NETCDF:myfile.nc:somearray" we may use "vrt://myfile.nc?sd_name=somearray". This option
+is mutually exclusive with ``sd``.
 
-The effect of the ``subdataset_n`` option (added in GDAL 3.9) is to choose an individual subdataset by
-index for sources that have multiple subdatasets. This means that rather than a fully-qualified
-description such as "NETCDF:myfile.nc:somearray" we may use "vrt://myfile.nc?subdataset_n=<n>" where "<n>"
+The effect of the ``sd`` option (added in GDAL 3.9) is to choose an individual subdataset by
+number for sources that have multiple subdatasets. This means that rather than a fully-qualified
+description such as "NETCDF:myfile.nc:somearray" we may use "vrt://myfile.nc?sd=<n>" where "<n>"
 is between 1 and the number of subdatasets. Note that there is no guarantee of the order of the
 subdatasets within a source between GDAL versions (or in some cases between file series in datasets). This
-index mode is for convenience only, please use ``subdataset`` to choose a subdataset by name explicitly.
-This option is mutually exclusive with ``subdataset``.
+mode is for convenience only, please use ``sd_name`` to choose a subdataset by name explicitly.
+This option is mutually exclusive with ``sd_name``.
 
 
 The options may be chained together separated by '&'. (Beware the need for quoting to protect

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1902,10 +1902,14 @@ For example:
 
     vrt://my.tif?bands=2&ovr=4
 
+::
+
+    vrt://my.nc?subdataset=sds
+
 
 The supported options currently are ``bands``, ``a_nodata``, ``a_srs``, ``a_ullr``, ``ovr``, ``expand``,
 ``a_scale``, ``a_offset``, ``ot``, ``gcp``, ``if``, ``scale``, ``exponent``, ``outsize``, ``projwin``,
-``projwin_srs``, ``tr``, ``r``, ``srcwin``, ``a_gt``, ``oo``, ``unscale``, ``a_coord_epoch``, ``nogcp``, ``epo``, and ``eco``.
+``projwin_srs``, ``tr``, ``r``, ``srcwin``, ``a_gt``, ``oo``, ``unscale``, ``a_coord_epoch``, ``nogcp``, ``epo``, ``eco``, ``subdataset``, and ``subdataset_n``.
 
 Other options may be added in the future.
 
@@ -1991,6 +1995,20 @@ use syntax ``nogcp=true``, or ``nogcp=false`` (which is the default if not speci
 The effect of the ``epo`` option (added in GDAL 3.8) is that ``srcwin`` or ``projwin`` values that fall partially outside the source raster extent will be considered as an error as per (:ref:`gdal_translate`). To apply this use syntax ``epo=true``, or ``epo=false`` (which is the default if not specified).
 
 The effect of the ``eco`` option (added in GDAL 3.8) is that ``srcwin`` or ``projwin`` values that fall completely outside the source raster extent will be considered as an error as per (:ref:`gdal_translate`). To apply this use syntax ``eco=true``, or ``eco=false`` (which is the default if not specified).
+
+The effect of the ``subdataset`` option (added in GDAL 3.9) is to choose an individual subdataset by
+name for sources that have multiple subdatasets. This means that rather than a fully-qualified description
+such as "NETCDF:myfile.nc:somearray" we may use "vrt://myfile.nc?subdataset=somearray". This option
+is mutually exclusive with ``subdataset_n``.
+
+The effect of the ``subdataset_n`` option (added in GDAL 3.9) is to choose an individual subdataset by
+index for sources that have multiple subdatasets. This means that rather than a fully-qualified
+description such as "NETCDF:myfile.nc:somearray" we may use "vrt://myfile.nc?subdataset_n=<n>" where "<n>"
+is between 1 and the number of subdatasets. Note that there is no guarantee of the order of the
+subdatasets within a source between GDAL versions (or in some cases between file series in datasets). This
+index mode is for convenience only, please use ``subdataset`` to choose a subdataset by name explicitly.
+This option is mutually exclusive with ``subdataset``.
+
 
 The options may be chained together separated by '&'. (Beware the need for quoting to protect
 the ampersand).

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -1044,6 +1044,121 @@ GDALDataset *VRTDataset::OpenVRTProtocol(const char *pszSpec)
         return nullptr;
     }
 
+    // scan for subdataset/subdataset_n in tokens, close the source dataset and reopen with subdataset if found/valid
+    // make subdataset and subdataset_n mutually exclusive
+    bool bFound_subdataset = false;
+    for (int i = 0; i < aosTokens.size(); i++)
+    {
+        char *pszKey = nullptr;
+        const char *pszValue = CPLParseNameValue(aosTokens[i], &pszKey);
+
+        if (pszKey && pszValue)
+        {
+            char **papszSubdatasets = GDALGetMetadata(poSrcDS, "SUBDATASETS");
+
+            int nSubdatasets = CSLCount(papszSubdatasets);
+
+            if (EQUAL(pszKey, "subdataset"))
+            {
+                if (bFound_subdataset)
+                {
+                    CPLError(CE_Failure, CPLE_IllegalArg,
+                             "'subdataset' is mutually exclusive with option "
+                             "'subdataset_n'");
+                    poSrcDS->ReleaseRef();
+
+                    CPLFree(pszKey);
+                    return nullptr;
+                }
+                if (nSubdatasets > 0)
+                {
+                    bool bFound = false;
+                    for (int j = 0; j < nSubdatasets; j += 2)
+                    {
+                        char *pszSubdatasetSource =
+                            CPLStrdup(strstr(papszSubdatasets[j], "=") + 1);
+                        GDALSubdatasetInfoH info =
+                            GDALGetSubdatasetInfo(pszSubdatasetSource);
+                        char *component =
+                            info
+                                ? GDALSubdatasetInfoGetSubdatasetComponent(info)
+                                : nullptr;
+
+                        bFound = component && EQUAL(pszValue, component);
+                        bFound_subdataset = true;
+                        CPLFree(component);
+                        GDALDestroySubdatasetInfo(info);
+                        if (bFound)
+                        {
+                            poSrcDS->ReleaseRef();
+                            poSrcDS = GDALDataset::Open(
+                                pszSubdatasetSource, GDAL_OF_RASTER,
+                                aosAllowedDrivers.List(), aosOpenOptions.List(),
+                                nullptr);
+                            CPLFree(pszSubdatasetSource);
+                            break;
+                        }
+                        else
+                        {
+                            CPLFree(pszSubdatasetSource);
+                        }
+                    }
+
+                    if (!bFound)
+                    {
+                        CPLError(CE_Failure, CPLE_IllegalArg,
+                                 "'subdataset' option should be be a valid "
+                                 "subdataset component name");
+                        poSrcDS->ReleaseRef();
+
+                        CPLFree(pszKey);
+                        return nullptr;
+                    }
+                }
+            }
+
+            if (EQUAL(pszKey, "subdataset_n"))
+            {
+                if (bFound_subdataset)
+                {
+                    CPLError(CE_Failure, CPLE_IllegalArg,
+                             "'subdataset_n' is mutually exclusive with option "
+                             "'subdataset'");
+                    poSrcDS->ReleaseRef();
+
+                    CPLFree(pszKey);
+                    return nullptr;
+                }
+                if (nSubdatasets > 0)
+                {
+                    int iSubdataset = atoi(pszValue);
+                    if (iSubdataset < 1 || iSubdataset > (nSubdatasets) / 2)
+                    {
+                        CPLError(
+                            CE_Failure, CPLE_IllegalArg,
+                            "'subdataset_n' option should indicate a valid "
+                            "subdataset component index (starting with 1)");
+                        CPLFree(pszKey);
+                        poSrcDS->ReleaseRef();
+                        return nullptr;
+                    }
+                    char *pszSubdatasetSource = CPLStrdup(
+                        strstr(papszSubdatasets[(iSubdataset - 1) * 2], "=") +
+                        1);
+                    poSrcDS->ReleaseRef();
+                    poSrcDS =
+                        GDALDataset::Open(pszSubdatasetSource, GDAL_OF_RASTER,
+                                          aosAllowedDrivers.List(),
+                                          aosOpenOptions.List(), nullptr);
+                    bFound_subdataset = true;
+                    CPLFree(pszSubdatasetSource);
+                }
+            }
+        }
+
+        CPLFree(pszKey);
+    }
+
     std::vector<int> anBands;
 
     CPLStringList argv;
@@ -1336,6 +1451,14 @@ GDALDataset *VRTDataset::OpenVRTProtocol(const char *pszSpec)
             {
                 // do nothing, we passed this in earlier
             }
+            else if (EQUAL(pszKey, "subdataset"))
+            {
+                // do nothing, we passed this in earlier
+            }
+            else if (EQUAL(pszKey, "subdataset_n"))
+            {
+                // do nothing, we passed this in earlier
+            }
             else if (EQUAL(pszKey, "unscale"))
             {
                 if (CPLTestBool(pszValue))
@@ -1519,10 +1642,10 @@ CPLErr VRTDataset::AddBand(GDALDataType eType, char **papszOptions)
         const int nWordDataSize = GDALGetDataTypeSizeBytes(eType);
 
         /* --------------------------------------------------------------------
-         */
+     */
         /*      Collect required information. */
         /* --------------------------------------------------------------------
-         */
+     */
         const char *pszImageOffset =
             CSLFetchNameValueDef(papszOptions, "ImageOffset", "0");
         vsi_l_offset nImageOffset = CPLScanUIntBig(
@@ -1566,10 +1689,10 @@ CPLErr VRTDataset::AddBand(GDALDataType eType, char **papszOptions)
             CPLFetchBool(papszOptions, "relativeToVRT", false);
 
         /* --------------------------------------------------------------------
-         */
+     */
         /*      Create and initialize the band. */
         /* --------------------------------------------------------------------
-         */
+     */
 
         VRTRawRasterBand *poBand =
             new VRTRawRasterBand(this, GetRasterCount() + 1, eType);


### PR DESCRIPTION
Add `sd_name` and `sd` to allowed options for a "vrt://" connection.

Discussion and summary of related PRs: https://github.com/OSGeo/gdal/issues/7477

## Tasklist

 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed


## Example

online netcdf subdataset by name or number

```bash
gdalinfo "vrt:///vsicurl/https://www.ncei.noaa.gov/data/sea-surface-temperature-optimum-interpolation/v2.1/access/avhrr/202202/oisst-avhrr-v02r01.20220218.nc?sd_name=ice"

gdalinfo "vrt:///vsicurl/https://www.ncei.noaa.gov/data/sea-surface-temperature-optimum-interpolation/v2.1/access/avhrr/202202/oisst-avhrr-v02r01.20220218.nc?sd=4"

```

