### PR TITLE
[Backport release/3.8] OSRPJContextHolder: call pthread_atfork() once for the process

### DIFF
--- a/ogr/ogr_proj_p.cpp
+++ b/ogr/ogr_proj_p.cpp
@@ -121,7 +121,17 @@ struct OSRPJContextHolder
 #endif
     {
 #if HAVE_PTHREAD_ATFORK
-        pthread_atfork(nullptr, nullptr, ForkOccurred);
+        static std::once_flag flag;
+        std::call_once(
+            flag,
+            []()
+            {
+                if (pthread_atfork(nullptr, nullptr, ForkOccurred) != 0)
+                {
+                    CPLError(CE_Failure, CPLE_OutOfMemory,
+                             "pthread_atfork() in ogr_proj_p failed");
+                }
+            });
 #endif
         init();
     }

--- a/ogr/ogr_proj_p.cpp
+++ b/ogr/ogr_proj_p.cpp
@@ -35,14 +35,6 @@
 
 #include "proj.h"
 
-#if defined(__MACH__) && defined(__APPLE__) && defined(HAVE_PTHREAD_ATFORK)
-// Works around a weird issue with GDAL, numpy and python threading on
-// Mac. There is definitely something not understood, but as using pthread_atfork()
-// is just an optimization, just disable it.
-// Cf https://github.com/OSGeo/gdal/issues/8497 for details
-#undef HAVE_PTHREAD_ATFORK
-#endif
-
 #ifndef _WIN32
 #include <sys/types.h>
 #include <unistd.h>


### PR DESCRIPTION
Backport #8909
 **Authored by:** @rouault