### PR TITLE
[Backport release/3.8] Rasterization: avoid burning pixel that we only touch (with an empty intersection) (fixes #8918)

### DIFF
--- a/alg/llrasterize.cpp
+++ b/alg/llrasterize.cpp
@@ -477,7 +477,8 @@ void GDALdllImageLineAllTouched(int nRasterXSize, int nRasterYSize,
 
                 const int iX = static_cast<int>(floor(dfXEnd));
                 int iY = static_cast<int>(floor(dfY));
-                int iYEnd = static_cast<int>(floor(dfYEnd));
+                int iYEnd =
+                    static_cast<int>(floor(dfYEnd - EPSILON_INTERSECT_ONLY));
 
                 if (iX < 0 || iX >= nRasterXSize)
                     continue;
@@ -556,7 +557,8 @@ void GDALdllImageLineAllTouched(int nRasterXSize, int nRasterYSize,
 
                 int iX = static_cast<int>(floor(dfX));
                 const int iY = static_cast<int>(floor(dfY));
-                int iXEnd = static_cast<int>(floor(dfXEnd));
+                int iXEnd =
+                    static_cast<int>(floor(dfXEnd - EPSILON_INTERSECT_ONLY));
 
                 if (iY < 0 || iY >= nRasterYSize)
                     continue;


### PR DESCRIPTION
Backport #8920
 **Authored by:** @rouault