### PR TITLE
gdal_footprint: write source dataset path in a 'location' field (fixes #8795)     

### DIFF
--- a/apps/gdal_footprint_bin.cpp
+++ b/apps/gdal_footprint_bin.cpp
@@ -49,6 +49,8 @@ static void Usage(bool bIsError, const char *pszErrorMsg = nullptr)
             "       [-convex_hull] [-densify <value>] [-simplify <value>]\n"
             "       [-min_ring_area <value>] [-max_points <value>|unlimited]\n"
             "       [-of <ogr_format>] [-lyr_name <dst_layername>]\n"
+            "       [-location_field_name <field_name>] [-no_location]\n"
+            "       [-write_absolute_path]\n"
             "       [-dsco <name>=<value>]... [-lco <name>=<value>]... "
             "[-overwrite] [-q]\n"
             "       <src_filename> <dst_filename>\n");

--- a/apps/gdal_footprint_lib.cpp
+++ b/apps/gdal_footprint_lib.cpp
@@ -44,6 +44,7 @@
 #include "cpl_error.h"
 #include "cpl_progress.h"
 #include "cpl_string.h"
+#include "cpl_vsi.h"
 #include "gdal.h"
 #include "gdal_alg.h"
 #include "gdal_priv.h"
@@ -111,6 +112,12 @@ struct GDALFootprintOptions
 
     /*! Whether to combine bands unioning (true) or intersecting (false) */
     bool bCombineBandsUnion = true;
+
+    /*! Field name where to write the path of the raster. Empty if not desired */
+    std::string osLocationFieldName = "location";
+
+    /*! Whether to force writing absolute paths in location field. */
+    bool bAbsolutePath = false;
 
     std::string osSrcNoData;
 };
@@ -501,6 +508,14 @@ GetOutputLayerAndUpdateDstDS(const char *pszDest, GDALDatasetH &hDstDS,
             osDestLayerName.c_str(), poSRS.get(),
             psOptions->bSplitPolys ? wkbPolygon : wkbMultiPolygon,
             const_cast<char **>(psOptions->aosLCO.List()));
+
+        if (!psOptions->osLocationFieldName.empty())
+        {
+            OGRFieldDefn oFieldDefn(psOptions->osLocationFieldName.c_str(),
+                                    OFTString);
+            if (poLayer->CreateField(&oFieldDefn) != OGRERR_NONE)
+                return nullptr;
+        }
     }
 
     return poLayer;
@@ -1009,6 +1024,25 @@ static bool GDALFootprintProcess(GDALDataset *poSrcDS, OGRLayer *poDstLayer,
 
         poDstFeature->SetGeometryDirectly(poGeom.release());
 
+        if (!psOptions->osLocationFieldName.empty())
+        {
+
+            std::string osFilename = poSrcDS->GetDescription();
+            // Make sure it is a file before building absolute path name.
+            VSIStatBufL sStatBuf;
+            if (psOptions->bAbsolutePath &&
+                CPLIsFilenameRelative(osFilename.c_str()) &&
+                VSIStatL(osFilename.c_str(), &sStatBuf) == 0)
+            {
+                const char *pszCurDir = CPLGetCurrentDir();
+                if (pszCurDir)
+                    osFilename = CPLProjectRelativeFilename(pszCurDir,
+                                                            osFilename.c_str());
+            }
+            poDstFeature->SetField(psOptions->osLocationFieldName.c_str(),
+                                   osFilename.c_str());
+        }
+
         if (poDstLayer->CreateFeature(poDstFeature.get()) != OGRERR_NONE)
         {
             return false;
@@ -1340,6 +1374,22 @@ GDALFootprintOptionsNew(char **papszArgv,
                          "binary.");
                 return nullptr;
             }
+        }
+
+        else if (i < argc - 1 && EQUAL(papszArgv[i], "-location_field_name"))
+        {
+            i++;
+            psOptions->osLocationFieldName = papszArgv[i];
+        }
+
+        else if (EQUAL(papszArgv[i], "-no_location"))
+        {
+            psOptions->osLocationFieldName.clear();
+        }
+
+        else if (EQUAL(papszArgv[i], "-write_absolute_path"))
+        {
+            psOptions->bAbsolutePath = true;
         }
 
         else if (i < argc - 1 && EQUAL(papszArgv[i], "-ovr"))

--- a/apps/gdal_footprint_lib.cpp
+++ b/apps/gdal_footprint_lib.cpp
@@ -1282,13 +1282,11 @@ GDALFootprintOptionsNew(char **papszArgv,
 
         else if (EQUAL(papszArgv[i], "-split_polys"))
         {
-            i++;
             psOptions->bSplitPolys = true;
         }
 
         else if (EQUAL(papszArgv[i], "-convex_hull"))
         {
-            i++;
             psOptions->bConvexHull = true;
         }
 

--- a/autotest/utilities/test_gdal_footprint_lib.py
+++ b/autotest/utilities/test_gdal_footprint_lib.py
@@ -30,6 +30,7 @@
 ###############################################################################
 
 import collections
+import os
 import pathlib
 
 import ogrtest
@@ -52,6 +53,7 @@ def test_gdal_footprint_lib_basic():
     assert lyr.GetSpatialRef().GetAuthorityCode(None) == "26711"
     assert lyr.GetFeatureCount() == 1
     f = lyr.GetNextFeature()
+    assert f["location"] == "../gcore/data/byte.tif"
     ogrtest.check_feature_geometry(
         f,
         "MULTIPOLYGON (((440720 3751320,440720 3750120,441920 3750120,441920 3751320,440720 3751320)))",
@@ -722,3 +724,32 @@ def test_gdal_footprint_lib_srcNodata_and_ovr_mutually_exclusive():
         gdal.Footprint(
             "", "../gcore/data/byte.tif", format="Memory", srcNodata=0, ovr=0
         )
+
+
+###############################################################################
+# Test locationFieldName=None
+
+
+def test_gdal_footprint_lib_no_location():
+
+    out_ds = gdal.Footprint(
+        "", "../gcore/data/byte.tif", format="Memory", locationFieldName=None
+    )
+    assert out_ds is not None
+    lyr = out_ds.GetLayer(0)
+    assert lyr.GetLayerDefn().GetFieldCount() == 0
+
+
+###############################################################################
+# Test writeAbsolutePath=True
+
+
+def test_gdal_footprint_lib_writeAbsolutePath():
+
+    out_ds = gdal.Footprint(
+        "", "../gcore/data/byte.tif", format="Memory", writeAbsolutePath=True
+    )
+    assert out_ds is not None
+    lyr = out_ds.GetLayer(0)
+    f = lyr.GetNextFeature()
+    assert os.path.isabs(f["location"])

--- a/doc/source/programs/gdal_footprint.rst
+++ b/doc/source/programs/gdal_footprint.rst
@@ -26,6 +26,8 @@ Synopsis
        [-convex_hull] [-densify <value>] [-simplify <value>]
        [-min_ring_area <value>] [-max_points <value>|unlimited]
        [-of <ogr_format>] [-lyr_name <dst_layername>]
+       [-location_field_name <field_name>] [-no_location]
+       [-write_absolute_path]
        [-dsco <name>=<value>]... [-lco <name>=<value>]... [-overwrite] [-q]
        <src_filename> <dst_filename>
 
@@ -147,6 +149,30 @@ proper mask bands.
 
     Select the output format. Use the short format name. Guessed from the
     file extension if not specified
+
+.. option:: -location_field_name <field_name>
+
+    .. versionadded:: 3.9.0
+
+    Specifies the name of the field in the resulting vector dataset where the
+    path of the input dataset will be stored. The default field name is
+    "location". To prevent writing the path of the input dataset, use
+    :option:`-no_location`
+
+.. option:: -no_location
+
+    .. versionadded:: 3.9.0
+
+    Turns off the writing of the path of the input dataset as a field in the
+    output vector dataset.
+
+.. option:: -write_absolute_path
+
+    .. versionadded:: 3.9.0
+
+    Enables writing the absolute path of the input dataset. By default, the
+    filename is written in the location field exactly as specified on the
+    command line.
 
 .. option:: -lco <NAME>=<VALUE>
 

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -3420,6 +3420,8 @@ def FootprintOptions(options=None,
                      maxPoints=None,
                      minRingArea=None,
                      layerName=None,
+                     locationFieldName="location",
+                     writeAbsolutePath=False,
                      layerCreationOptions=None,
                      datasetCreationOptions=None,
                      callback=None, callback_data=None):
@@ -3459,6 +3461,10 @@ def FootprintOptions(options=None,
         maximum number of points (100 by default, "unlimited" for unlimited)
     minRingArea:
         Minimum value for the area of a ring The unit of the area is in square pixels if targetCoordinateSystem equals "pixel", or otherwise in georeferenced units of the target vector dataset. This option is applied after the reprojection implied by dstSRS
+    locationFieldName:
+        Specifies the name of the field in the resulting vector dataset where the path of the input dataset will be stored. The default field name is "location". Can be set to None to disable creation of such field.
+    writeAbsolutePath:
+        Enables writing the absolute path of the input dataset. By default, the filename is written in the location field exactly as the dataset name.
     layerName:
         output layer name
     callback:
@@ -3522,6 +3528,12 @@ def FootprintOptions(options=None,
             else:
                 for opt in layerCreationOptions:
                     new_options += ['-lco', opt]
+        if locationFieldName is not None:
+            new_options += ['-location_field_name', locationFieldName]
+        else:
+            new_options += ['-no_location']
+        if writeAbsolutePath:
+            new_options += ['-write_absolute_path']
 
     if return_option_list:
         return new_options


### PR DESCRIPTION
New options:
```
.. option:: -location_field_name <field_name>

    .. versionadded:: 3.9.0

    Specifies the name of the field in the resulting vector dataset where the
    path of the input dataset will be stored. The default field name is
    "location". To prevent writing the path of the input dataset, use
    :option:`-no_location`

.. option:: -no_location

    .. versionadded:: 3.9.0

    Turns off the writing of the path of the input dataset as a field in the
    output vector dataset.

.. option:: -write_absolute_path

    .. versionadded:: 3.9.0

    Enables writing the absolute path of the input dataset. By default, the
    filename is written in the location field exactly as specified on the
    command line.
```
First commit is a bugfix that must be backported