### PR TITLE
gdal_translate: add -dmo option, for domain-metadata items

### DIFF
--- a/apps/gdal_translate_bin.cpp
+++ b/apps/gdal_translate_bin.cpp
@@ -69,7 +69,8 @@ static void Usage(bool bIsError, const char *pszErrorMsg, bool bShort)
         "[<elevation>]]...\n"
         "       |-colorinterp{_bn} {red|green|blue|alpha|gray|undefined}]\n"
         "       |-colorinterp {red|green|blue|alpha|gray|undefined},...]\n"
-        "       [-mo <META-TAG>=<VALUE>]... [-q] [-sds]\n"
+        "       [-mo <META-TAG>=<VALUE>]... [-dmo "
+        "<DOMAIN:META-TAG>=<VALUE>]... [-q] [-sds]\n"
         "       [-co <NAME>=<VALUE>]... [-stats] [-norat] [-noxmp]\n"
         "       [-oo <NAME>=<VALUE>]...\n"
         "       <src_dataset> <dst_dataset>\n");

--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -2573,24 +2573,25 @@ static void AttachDomainMetadata(GDALDatasetH hDS,
     {
 
         char *pszKey = nullptr;
-        char *pszKey2 = nullptr;
-        // parse twice because the first time picks the colon ":", second picks the "="
-        //    (so we can't have domain names with colons but we can have values like "OGC:CRS84")
-        // first key is E1 from E1:E2=E3
-        // value is E2=E3
-        // then second key is E2, second value is E3
-        const char *pszValue =
-            CPLParseNameValue(aosDomainMetadataOptions[i], &pszKey);
-        const char *pszValue2 = CPLParseNameValue(pszValue, &pszKey2);
+        char *pszDomain = nullptr;
 
-        if (pszKey && pszValue && pszKey2 && pszValue2)
+        // parse the DOMAIN:KEY=value, Remainder is KEY=value
+        const char *pszRemainder =
+            CPLParseNameValueSep(aosDomainMetadataOptions[i], &pszDomain, ':');
+
+        if (pszDomain && pszRemainder)
         {
-            CPLDebug("translate", "pszValue2: %s, pszKey2: %s, pszKey: %s",
-                     pszValue2, pszKey2, pszKey);
-            GDALSetMetadataItem(hDS, pszKey2, pszValue2, pszKey);
+
+            const char *pszValue =
+                CPLParseNameValueSep(pszRemainder, &pszKey, '=');
+            if (pszKey && pszValue)
+            {
+                GDALSetMetadataItem(hDS, pszKey, pszValue, pszDomain);
+            }
         }
         CPLFree(pszKey);
-        CPLFree(pszKey2);
+
+        CPLFree(pszDomain);
     }
 }
 

--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -58,6 +58,8 @@
 #include "vrtdataset.h"
 
 static void AttachMetadata(GDALDatasetH, const CPLStringList &);
+static void AttachDomainMetadata(GDALDatasetH, const CPLStringList &);
+
 static void CopyBandInfo(GDALRasterBand *poSrcBand, GDALRasterBand *poDstBand,
                          int bCanCopyStatsMetadata, int bCopyScale,
                          int bCopyNoData, bool bCopyRAT,
@@ -189,10 +191,11 @@ struct GDALTranslateOptions
 
     bool bHasUsedExplicitExponentBand = false;
 
-    /*! list of metadata key and value to set on the output dataset if possible.
-     *  GDALTranslateOptionsSetMetadataOptions() and
-     * GDALTranslateOptionsAddMetadataOptions() should be used */
+    /*! list of metadata key and value to set on the output dataset if possible. */
     CPLStringList aosMetadataOptions{};
+
+    /*! list of metadata key and value in a domain to set on the output dataset if possible. */
+    CPLStringList aosDomainMetadataOptions{};
 
     /*! override the projection for the output file. The SRS may be any of the
        usual GDAL/OGR forms, complete WKT, PROJ.4, EPSG:n or a file containing
@@ -1168,10 +1171,10 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
         psOptions->asScaleParams.empty() && psOptions->adfExponent.empty() &&
         !psOptions->bUnscale && !psOptions->bSetScale &&
         !psOptions->bSetOffset && psOptions->aosMetadataOptions.empty() &&
-        bAllBandsInOrder && psOptions->eMaskMode == MASK_AUTO &&
-        bSpatialArrangementPreserved && !psOptions->bNoGCP &&
-        psOptions->nGCPCount == 0 && !bGotBounds && !bGotGeoTransform &&
-        psOptions->osOutputSRS.empty() &&
+        psOptions->aosDomainMetadataOptions.empty() && bAllBandsInOrder &&
+        psOptions->eMaskMode == MASK_AUTO && bSpatialArrangementPreserved &&
+        !psOptions->bNoGCP && psOptions->nGCPCount == 0 && !bGotBounds &&
+        !bGotGeoTransform && psOptions->osOutputSRS.empty() &&
         psOptions->dfOutputCoordinateEpoch == 0 && !psOptions->bSetNoData &&
         !psOptions->bUnsetNoData && psOptions->nRGBExpand == 0 &&
         !psOptions->bNoRAT && psOptions->anColorInterp.empty() &&
@@ -1714,6 +1717,9 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
     poVDS->SetMetadata(papszMetadata);
     CSLDestroy(papszMetadata);
     AttachMetadata(GDALDataset::ToHandle(poVDS), psOptions->aosMetadataOptions);
+
+    AttachDomainMetadata(GDALDataset::ToHandle(poVDS),
+                         psOptions->aosDomainMetadataOptions);
 
     const char *pszInterleave =
         poSrcDS->GetMetadataItem("INTERLEAVE", "IMAGE_STRUCTURE");
@@ -2554,6 +2560,41 @@ static void AttachMetadata(GDALDatasetH hDS,
 }
 
 /************************************************************************/
+/*                           AttachDomainMetadata()                     */
+/************************************************************************/
+
+static void AttachDomainMetadata(GDALDatasetH hDS,
+                                 const CPLStringList &aosDomainMetadataOptions)
+
+{
+    const int nCount = aosDomainMetadataOptions.size();
+
+    for (int i = 0; i < nCount; i++)
+    {
+
+        char *pszKey = nullptr;
+        char *pszKey2 = nullptr;
+        // parse twice because the first time picks the colon ":", second picks the "="
+        //    (so we can't have domain names with colons but we can have values like "OGC:CRS84")
+        // first key is E1 from E1:E2=E3
+        // value is E2=E3
+        // then second key is E2, second value is E3
+        const char *pszValue =
+            CPLParseNameValue(aosDomainMetadataOptions[i], &pszKey);
+        const char *pszValue2 = CPLParseNameValue(pszValue, &pszKey2);
+
+        if (pszKey && pszValue && pszKey2 && pszValue2)
+        {
+            CPLDebug("translate", "pszValue2: %s, pszKey2: %s, pszKey: %s",
+                     pszValue2, pszKey2, pszKey);
+            GDALSetMetadataItem(hDS, pszKey2, pszValue2, pszKey);
+        }
+        CPLFree(pszKey);
+        CPLFree(pszKey2);
+    }
+}
+
+/************************************************************************/
 /*                           CopyBandInfo()                            */
 /************************************************************************/
 
@@ -3041,6 +3082,10 @@ GDALTranslateOptionsNew(char **papszArgv,
             psOptions->aosMetadataOptions.AddString(papszArgv[++i]);
         }
 
+        else if (EQUAL(papszArgv[i], "-dmo") && papszArgv[i + 1])
+        {
+            psOptions->aosDomainMetadataOptions.AddString(papszArgv[++i]);
+        }
         else if (i + 2 < argc && EQUAL(papszArgv[i], "-outsize") &&
                  papszArgv[i + 1] != nullptr)
         {

--- a/autotest/utilities/test_gdal_translate_lib.py
+++ b/autotest/utilities/test_gdal_translate_lib.py
@@ -1159,6 +1159,61 @@ def test_gdal_translate_lib_dict_arguments():
 
 
 ###############################################################################
+# Test -dmo option
+
+
+def test_gdal_translate_dmo_option():
+
+    dst_vrt = "/vsimem/test_dmo.vrt"
+
+    ## string dmo input
+    ds = gdal.Translate(
+        dst_vrt,
+        "../gcore/data/byte.tif",
+        domainMetadataOptions="NEW_DOMAIN:META-TAG=value",
+    )
+
+    md = ds.GetMetadata("NEW_DOMAIN")
+    assert "META-TAG" in md, "Did not get META-TAG"
+    assert md["META-TAG"] == "value"
+    ds = None
+
+    ## list dmo input
+    ds = gdal.Translate(
+        dst_vrt,
+        "../gcore/data/byte.tif",
+        domainMetadataOptions=[
+            "NEW_DOMAIN:META-TAG=value",
+            "ANOTHER_NEW_DOMAIN:META2-TAG=value",
+        ],
+    )
+
+    md = ds.GetMetadata("NEW_DOMAIN")
+    assert "META-TAG" in md, "Did not get META-TAG"
+    assert md["META-TAG"] == "value"
+    md = ds.GetMetadata("ANOTHER_NEW_DOMAIN")
+    assert "META2-TAG" in md, "Did not get META2-TAG"
+    assert md["META2-TAG"] == "value"
+
+    ds = None
+
+    ## pythonic dict dmo input
+    items = {
+        "domain_name": {"key": "value", "key1": "value1"},
+        "domain_2": {"key2": "value2"},
+    }
+    ds = gdal.Translate(
+        "/vsimem/dmo.vrt",
+        gdal.Open("../gcore/data/byte.tif"),
+        domainMetadataOptions=items,
+    )
+    md = ds.GetMetadata("domain_2")
+    assert "key2" in md, "Did not get key2"
+    assert md["key2"] == "value2"
+    ds = None
+
+
+###############################################################################
 # Test -ovr and RPC (https://github.com/OSGeo/gdal/issues/8386)
 
 

--- a/autotest/utilities/test_gdal_translate_lib.py
+++ b/autotest/utilities/test_gdal_translate_lib.py
@@ -1203,13 +1203,29 @@ def test_gdal_translate_dmo_option():
         "domain_2": {"key2": "value2"},
     }
     ds = gdal.Translate(
-        "/vsimem/dmo.vrt",
+        dst_vrt,
         gdal.Open("../gcore/data/byte.tif"),
         domainMetadataOptions=items,
     )
     md = ds.GetMetadata("domain_2")
     assert "key2" in md, "Did not get key2"
     assert md["key2"] == "value2"
+    ds = None
+
+    ds = gdal.Translate(
+        dst_vrt,
+        gdal.Open("../gcore/data/byte.tif"),
+        options=["-dmo", "FOO", "-dmo", "BOO:FAR", "-dmo", "dom=ain:SOO=VAR:1"],
+    )
+    mdl = ds.GetMetadataDomainList()
+    assert "FOO" not in mdl, "Found key 'FOO' from invalid input"
+    assert "BOO" not in mdl, "Found key 'BOO' from invalid input"
+    assert "dom=ain" in mdl, "Did not get dom=ain"
+
+    md = ds.GetMetadata("dom=ain")
+    assert "SOO" in md, "Did not get SOO"
+    assert md["SOO"] == "VAR:1", "Did not get value VAR:1"
+
     ds = None
 
 

--- a/doc/source/programs/gdal_translate.rst
+++ b/doc/source/programs/gdal_translate.rst
@@ -34,7 +34,7 @@ Synopsis
        [-nogcp] [-gcp <pixel> <line> <easting> <northing> [<elevation>]]...
        |-colorinterp{_bn} {red|green|blue|alpha|gray|undefined}]
        |-colorinterp {red|green|blue|alpha|gray|undefined},...]
-       [-mo <META-TAG>=<VALUE>]... [-q] [-sds]
+       [-mo <META-TAG>=<VALUE>]... [-dmo "DOMAIN:META-TAG=VALUE"]... [-q] [-sds]
        [-co <NAME>=<VALUE>]... [-stats] [-norat] [-noxmp]
        [-oo <NAME>=<VALUE>]...
        <src_dataset> <dst_dataset>
@@ -306,6 +306,12 @@ resampling, and rescaling pixels in the process.
 .. option:: -mo <META-TAG>=<VALUE>
 
     Passes a metadata key and value to set on the output dataset if possible.
+
+.. option:: -dmo DOMAIN:META-TAG=VALUE
+
+    Passes a metadata key and value in specified domain to set on the output dataset if possible.
+
+    .. versionadded:: 3.9
 
 .. option:: -co <NAME>=<VALUE>
 

--- a/port/cpl_string.cpp
+++ b/port/cpl_string.cpp
@@ -1805,6 +1805,54 @@ const char *CPLParseNameValue(const char *pszNameValue, char **ppszKey)
 }
 
 /**********************************************************************
+ *                       CPLParseNameValueSep()
+ **********************************************************************/
+/**
+ * Parse NAME<Sep>VALUE string into name and value components.
+ *
+ * This is derived directly from CPLParseNameValue() which will separate
+ * on '=' OR ':', here chSep is required for specifying the separator
+ * explicitly.
+ *
+ * @param pszNameValue string in "NAME=VALUE" format.
+ * @param ppszKey optional pointer though which to return the name
+ * portion.
+ * @pararm chSep required single char separator
+ * @return the value portion (pointing into original string).
+ */
+
+const char *CPLParseNameValueSep(const char *pszNameValue, char **ppszKey,
+                                 char chSep)
+{
+    for (int i = 0; pszNameValue[i] != '\0'; ++i)
+    {
+        if (pszNameValue[i] == chSep)
+        {
+            const char *pszValue = pszNameValue + i + 1;
+            while (*pszValue == ' ' || *pszValue == '\t')
+                ++pszValue;
+
+            if (ppszKey != nullptr)
+            {
+                *ppszKey = static_cast<char *>(CPLMalloc(i + 1));
+                memcpy(*ppszKey, pszNameValue, i);
+                (*ppszKey)[i] = '\0';
+                while (i > 0 &&
+                       ((*ppszKey)[i - 1] == ' ' || (*ppszKey)[i - 1] == '\t'))
+                {
+                    (*ppszKey)[i - 1] = '\0';
+                    i--;
+                }
+            }
+
+            return pszValue;
+        }
+    }
+
+    return nullptr;
+}
+
+/**********************************************************************
  *                       CSLFetchNameValueMultiple()
  **********************************************************************/
 

--- a/port/cpl_string.cpp
+++ b/port/cpl_string.cpp
@@ -1817,7 +1817,7 @@ const char *CPLParseNameValue(const char *pszNameValue, char **ppszKey)
  * @param pszNameValue string in "NAME=VALUE" format.
  * @param ppszKey optional pointer though which to return the name
  * portion.
- * @pararm chSep required single char separator
+ * @param chSep required single char separator
  * @return the value portion (pointing into original string).
  */
 

--- a/port/cpl_string.h
+++ b/port/cpl_string.h
@@ -129,6 +129,8 @@ bool CPL_DLL CPLFetchBool(CSLConstList papszStrList, const char *pszKey,
                           bool bDefault);
 
 const char CPL_DLL *CPLParseNameValue(const char *pszNameValue, char **ppszKey);
+const char CPL_DLL *CPLParseNameValueSep(const char *pszNameValue,
+                                         char **ppszKey, char chSep);
 
 const char CPL_DLL *CSLFetchNameValue(CSLConstList papszStrList,
                                       const char *pszName);

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -1895,7 +1895,8 @@ def TranslateOptions(options=None, format=None,
               noData=None, rgbExpand=None,
               stats = False, rat = True, xmp = True, resampleAlg=None,
               overviewLevel = 'AUTO',
-              callback=None, callback_data=None):
+              callback=None, callback_data=None,
+              domainMetadataOptions = None):
     """Create a TranslateOptions() object that can be passed to gdal.Translate()
 
     Parameters
@@ -1968,6 +1969,8 @@ def TranslateOptions(options=None, format=None,
         callback method
     callback_data:
         user data for callback
+    domainMetadataOptions:
+        list or dict of domain-specific metadata options
     """
 
     # Only used for tests
@@ -2036,6 +2039,17 @@ def TranslateOptions(options=None, format=None,
             else:
                 for opt in metadataOptions:
                     new_options += ['-mo', opt]
+        if domainMetadataOptions is not None:
+            if isinstance(domainMetadataOptions, str):
+                new_options += ['-dmo', domainMetadataOptions]
+            elif isinstance(domainMetadataOptions, dict):
+                for d in domainMetadataOptions:
+                  things = domainMetadataOptions[d]
+                  for k, v in things.items():
+                    new_options += ['-dmo', f'{d}:{k}={v}']
+            else:
+                for opt in domainMetadataOptions:
+                    new_options += ['-dmo', opt]
         if outputSRS is not None:
             new_options += ['-a_srs', str(outputSRS)]
         if nogcp:


### PR DESCRIPTION
adds `-dmo` for adding one or more domain specific metadata items, as a complement to `-mo` which adds `metadata=value` items, we can specify `domain:metadata=value` with dmo, e.g. 

```bash
gdal_translate in.tif out.vrt -dmo DOMAIN:METATAG1=VALUE1 -dmo DOMAIN:METATAG1=VALUE
```

(note that random domains won't be reported by gdalinfo, so the effect may not be obvious without looking at the VRT file or querying the dataset). 

The motivating example is to add GEOLOCATION domain elements, e.g. 

```bash
gdal_translate in.tif out.vrt -dmo GEOLOCATION:X_DATASET=x.tif -dmo GEOLOCATION:Y_DATASET=y.tif ...
```

Discussed on the mailing list: https://lists.osgeo.org/pipermail/gdal-dev/2023-September/057665.html

Also removed outdated comments: 

https://lists.osgeo.org/pipermail/gdal-dev/2023-September/057677.html

## Tasklist


 - [x] need more test cases for the python API
 - [x] Add documentation
 - [x] Update Python API 
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed


I'm using key/valure parsing to get tokens from colon and = separators, I think this means it's not possible to have domain or key tags with colons in them .... I think that's ok, you can use the API for weirdo labels (and that needs tests added still). 

