### PR TITLE
GetExtent3D(): fix & enhancements

### DIFF
--- a/autotest/cpp/test_ogr.cpp
+++ b/autotest/cpp/test_ogr.cpp
@@ -1960,6 +1960,36 @@ TEST_F(test_ogr, OGREnvelope)
     }
 }
 
+// Test OGREnvelope3D
+TEST_F(test_ogr, OGREnvelope3D)
+{
+    OGREnvelope3D s1;
+    EXPECT_TRUE(!s1.IsInit());
+    {
+        OGREnvelope3D s2(s1);
+        EXPECT_TRUE(s1 == s2);
+        EXPECT_TRUE(!(s1 != s2));
+    }
+
+    s1.MinX = 0;
+    s1.MinY = 1;
+    s1.MaxX = 2;
+    s1.MaxY = 3;
+    EXPECT_TRUE(s1.IsInit());
+    EXPECT_FALSE(s1.Is3D());
+    s1.MinZ = 4;
+    s1.MaxZ = 5;
+    EXPECT_TRUE(s1.Is3D());
+    {
+        OGREnvelope3D s2(s1);
+        EXPECT_TRUE(s1 == s2);
+        EXPECT_TRUE(!(s1 != s2));
+        s2.MinX += 1;
+        EXPECT_TRUE(s1 != s2);
+        EXPECT_TRUE(!(s1 == s2));
+    }
+}
+
 // Test OGRStyleMgr::InitStyleString() with a style name
 // (https://github.com/OSGeo/gdal/issues/5555)
 TEST_F(test_ogr, InitStyleString_with_style_name)

--- a/autotest/cpp/test_ogr_wkb.cpp
+++ b/autotest/cpp/test_ogr_wkb.cpp
@@ -33,12 +33,199 @@
 
 #include "gtest_include.h"
 
+#include <limits>
+
 namespace
 {
 
 struct test_ogr_wkb : public ::testing::Test
 {
 };
+
+class OGRWKBGetEnvelopeFixture
+    : public test_ogr_wkb,
+      public ::testing::WithParamInterface<std::tuple<
+          const char *, double, double, double, double, const char *>>
+{
+    static constexpr double INF = std::numeric_limits<double>::infinity();
+
+  public:
+    static std::vector<
+        std::tuple<const char *, double, double, double, double, const char *>>
+    GetTupleValues()
+    {
+        return {
+            std::make_tuple("POINT(1 2)", 1, 2, 1, 2, "POINT"),
+            std::make_tuple("POINT EMPTY", INF, INF, -INF, -INF, "POINT_EMPTY"),
+            std::make_tuple("POINT Z (1 2 3)", 1, 2, 1, 2, "POINT_3D"),
+            std::make_tuple("LINESTRING(3 4,1 2)", 1, 2, 3, 4, "LINESTRING"),
+            std::make_tuple("LINESTRING EMPTY", INF, INF, -INF, -INF,
+                            "LINESTRING_EMPTY"),
+            std::make_tuple("LINESTRING Z (3 4 5,1 2 6)", 1, 2, 3, 4,
+                            "LINESTRING_3D"),
+            std::make_tuple("POLYGON((0 1,0 2,3 2,0 1))", 0, 1, 3, 2,
+                            "POLYGON"),
+            std::make_tuple("POLYGON EMPTY", INF, INF, -INF, -INF,
+                            "POLYGON_EMPTY"),
+            std::make_tuple("POLYGON Z ((0 1 10,0 2 20,3 2 20,0 1 10))", 0, 1,
+                            3, 2, "POLYGON_3D"),
+            std::make_tuple("MULTIPOINT((1 2),(3 4))", 1, 2, 3, 4,
+                            "MULTIPOINT"),
+            std::make_tuple("MULTIPOINT EMPTY", INF, INF, -INF, -INF,
+                            "MULTIPOINT_EMPTY"),
+            std::make_tuple("MULTIPOINT Z ((1 2 10),(3 4 20))", 1, 2, 3, 4,
+                            "MULTIPOINT_3D"),
+            std::make_tuple("MULTILINESTRING((3 4,1 2),(5 6,7 8))", 1, 2, 7, 8,
+                            "MULTILINESTRING"),
+            std::make_tuple("MULTILINESTRING EMPTY", INF, INF, -INF, -INF,
+                            "MULTILINESTRING_EMPTY"),
+            std::make_tuple(
+                "MULTILINESTRING Z ((3 4 10,1 2 20),(5 6 10,7 8 20))", 1, 2, 7,
+                8, "MULTILINESTRING_3D"),
+            std::make_tuple(
+                "MULTIPOLYGON(((0 1,0 2,3 2,0 1)),((0 -1,0 -2,-3 -2,0 -1)))",
+                -3, -2, 3, 2, "MULTIPOLYGON"),
+            std::make_tuple("MULTIPOLYGON EMPTY", INF, INF, -INF, -INF,
+                            "MULTIPOLYGON_EMPTY"),
+            std::make_tuple("MULTIPOLYGON Z (((0 1 10,0 2 20,3 2 20,0 1 "
+                            "10)),((0 -1 -10,0 -2 -20,-3 -2 -20,0 -1 -10)))",
+                            -3, -2, 3, 2, "MULTIPOLYGON_3D"),
+            std::make_tuple("GEOMETRYCOLLECTION(POINT(1 2),POINT(3 4))", 1, 2,
+                            3, 4, "GEOMETRYCOLLECTION"),
+            std::make_tuple("CIRCULARSTRING(0 10,1 11,2 10)", 0, 10, 2, 11,
+                            "CIRCULARSTRING"),
+            std::make_tuple("COMPOUNDCURVE((3 4,1 2))", 1, 2, 3, 4,
+                            "COMPOUNDCURVE"),
+            std::make_tuple("CURVEPOLYGON((0 1,0 2,3 2,0 1))", 0, 1, 3, 2,
+                            "CURVEPOLYGON"),
+            std::make_tuple("MULTICURVE((3 4,1 2),(5 6,7 8))", 1, 2, 7, 8,
+                            "MULTICURVE"),
+            std::make_tuple(
+                "MULTISURFACE(((0 1,0 2,3 2,0 1)),((0 -1,0 -2,-3 -2,0 -1)))",
+                -3, -2, 3, 2, "MULTISURFACE"),
+            std::make_tuple("TRIANGLE((0 1,0 2,3 2,0 1))", 0, 1, 3, 2,
+                            "TRIANGLE"),
+            std::make_tuple("POLYHEDRALSURFACE(((0 1,0 2,3 2,0 1)))", 0, 1, 3,
+                            2, "POLYHEDRALSURFACE"),
+            std::make_tuple("TIN(((0 1,0 2,3 2,0 1)))", 0, 1, 3, 2, "TIN"),
+        };
+    }
+};
+
+TEST_P(OGRWKBGetEnvelopeFixture, test)
+{
+    const char *pszInput = std::get<0>(GetParam());
+    const double dfExpectedMinX = std::get<1>(GetParam());
+    const double dfExpectedMinY = std::get<2>(GetParam());
+    const double dfExpectedMaxX = std::get<3>(GetParam());
+    const double dfExpectedMaxY = std::get<4>(GetParam());
+
+    OGRGeometry *poGeom = nullptr;
+    OGRGeometryFactory::createFromWkt(pszInput, nullptr, &poGeom);
+    ASSERT_TRUE(poGeom != nullptr);
+    std::vector<GByte> abyWkb(poGeom->WkbSize());
+    poGeom->exportToWkb(wkbNDR, abyWkb.data(), wkbVariantIso);
+    delete poGeom;
+    OGREnvelope sEnvelope;
+    OGRWKBGetBoundingBox(abyWkb.data(), abyWkb.size(), sEnvelope);
+    EXPECT_EQ(sEnvelope.MinX, dfExpectedMinX);
+    EXPECT_EQ(sEnvelope.MinY, dfExpectedMinY);
+    EXPECT_EQ(sEnvelope.MaxX, dfExpectedMaxX);
+    EXPECT_EQ(sEnvelope.MaxY, dfExpectedMaxY);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    test_ogr_wkb, OGRWKBGetEnvelopeFixture,
+    ::testing::ValuesIn(OGRWKBGetEnvelopeFixture::GetTupleValues()),
+    [](const ::testing::TestParamInfo<OGRWKBGetEnvelopeFixture::ParamType>
+           &l_info) { return std::get<5>(l_info.param); });
+
+class OGRWKBGetEnvelope3DFixture
+    : public test_ogr_wkb,
+      public ::testing::WithParamInterface<
+          std::tuple<const char *, double, double, double, double, double,
+                     double, const char *>>
+{
+    static constexpr double INF = std::numeric_limits<double>::infinity();
+
+  public:
+    static std::vector<std::tuple<const char *, double, double, double, double,
+                                  double, double, const char *>>
+    GetTupleValues()
+    {
+        return {
+            std::make_tuple("POINT(1 2)", 1, 2, INF, 1, 2, -INF, "POINT"),
+            std::make_tuple("POINT EMPTY", INF, INF, INF, -INF, -INF, -INF,
+                            "POINT_EMPTY"),
+            std::make_tuple("POINT Z (1 2 3)", 1, 2, 3, 1, 2, 3, "POINT_3D"),
+            std::make_tuple("LINESTRING(3 4,1 2)", 1, 2, INF, 3, 4, -INF,
+                            "LINESTRING"),
+            std::make_tuple("LINESTRING EMPTY", INF, INF, INF, -INF, -INF, -INF,
+                            "LINESTRING_EMPTY"),
+            std::make_tuple("LINESTRING Z (3 4 5,1 2 6)", 1, 2, 5, 3, 4, 6,
+                            "LINESTRING_3D"),
+            std::make_tuple("POLYGON((0 1,0 2,3 2,0 1))", 0, 1, INF, 3, 2, -INF,
+                            "POLYGON"),
+            std::make_tuple("POLYGON EMPTY", INF, INF, INF, -INF, -INF, -INF,
+                            "POLYGON_EMPTY"),
+            std::make_tuple("POLYGON Z ((0 1 10,0 2 20,3 2 20,0 1 10))", 0, 1,
+                            10, 3, 2, 20, "POLYGON_3D"),
+            std::make_tuple("MULTIPOINT((1 2),(3 4))", 1, 2, INF, 3, 4, -INF,
+                            "MULTIPOINT"),
+            std::make_tuple("MULTIPOINT EMPTY", INF, INF, INF, -INF, -INF, -INF,
+                            "MULTIPOINT_EMPTY"),
+            std::make_tuple("MULTIPOINT Z ((1 2 10),(3 4 20))", 1, 2, 10, 3, 4,
+                            20, "MULTIPOINT_3D"),
+            std::make_tuple("MULTILINESTRING((3 4,1 2),(5 6,7 8))", 1, 2, INF,
+                            7, 8, -INF, "MULTILINESTRING"),
+            std::make_tuple("MULTILINESTRING EMPTY", INF, INF, INF, -INF, -INF,
+                            -INF, "MULTILINESTRING_EMPTY"),
+            std::make_tuple(
+                "MULTILINESTRING Z ((3 4 10,1 2 20),(5 6 10,7 8 20))", 1, 2, 10,
+                7, 8, 20, "MULTILINESTRING_3D"),
+            std::make_tuple(
+                "MULTIPOLYGON(((0 1,0 2,3 2,0 1)),((0 -1,0 -2,-3 -2,0 -1)))",
+                -3, -2, INF, 3, 2, -INF, "MULTIPOLYGON"),
+            std::make_tuple("MULTIPOLYGON EMPTY", INF, INF, INF, -INF, -INF,
+                            -INF, "MULTIPOLYGON_EMPTY"),
+            std::make_tuple("MULTIPOLYGON Z (((0 1 10,0 2 20,3 2 20,0 1 "
+                            "10)),((0 -1 -10,0 -2 -20,-3 -2 -20,0 -1 -10)))",
+                            -3, -2, -20, 3, 2, 20, "MULTIPOLYGON_3D"),
+        };
+    }
+};
+
+TEST_P(OGRWKBGetEnvelope3DFixture, test)
+{
+    const char *pszInput = std::get<0>(GetParam());
+    const double dfExpectedMinX = std::get<1>(GetParam());
+    const double dfExpectedMinY = std::get<2>(GetParam());
+    const double dfExpectedMinZ = std::get<3>(GetParam());
+    const double dfExpectedMaxX = std::get<4>(GetParam());
+    const double dfExpectedMaxY = std::get<5>(GetParam());
+    const double dfExpectedMaxZ = std::get<6>(GetParam());
+
+    OGRGeometry *poGeom = nullptr;
+    OGRGeometryFactory::createFromWkt(pszInput, nullptr, &poGeom);
+    ASSERT_TRUE(poGeom != nullptr);
+    std::vector<GByte> abyWkb(poGeom->WkbSize());
+    poGeom->exportToWkb(wkbNDR, abyWkb.data(), wkbVariantIso);
+    delete poGeom;
+    OGREnvelope3D sEnvelope;
+    OGRWKBGetBoundingBox(abyWkb.data(), abyWkb.size(), sEnvelope);
+    EXPECT_EQ(sEnvelope.MinX, dfExpectedMinX);
+    EXPECT_EQ(sEnvelope.MinY, dfExpectedMinY);
+    EXPECT_EQ(sEnvelope.MinZ, dfExpectedMinZ);
+    EXPECT_EQ(sEnvelope.MaxX, dfExpectedMaxX);
+    EXPECT_EQ(sEnvelope.MaxY, dfExpectedMaxY);
+    EXPECT_EQ(sEnvelope.MaxZ, dfExpectedMaxZ);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    test_ogr_wkb, OGRWKBGetEnvelope3DFixture,
+    ::testing::ValuesIn(OGRWKBGetEnvelope3DFixture::GetTupleValues()),
+    [](const ::testing::TestParamInfo<OGRWKBGetEnvelope3DFixture::ParamType>
+           &l_info) { return std::get<7>(l_info.param); });
 
 class OGRWKBFixupCounterClockWiseExternalRingFixture
     : public test_ogr_wkb,

--- a/autotest/ogr/ogr_parquet.py
+++ b/autotest/ogr/ogr_parquet.py
@@ -238,6 +238,8 @@ def _check_test_parquet(
     assert lyr.GetFeatureCount() == 5
     assert lyr.GetExtent() == (0.0, 4.0, 2.0, 2.0)
     assert lyr.GetExtent(geom_field=0) == (0.0, 4.0, 2.0, 2.0)
+    assert lyr.TestCapability(ogr.OLCFastGetExtent3D) == 0
+    assert lyr.GetExtent3D() == (0.0, 4.0, 2.0, 2.0, float("inf"), float("-inf"))
     with pytest.raises(Exception):
         lyr.GetExtent(geom_field=-1)
     with pytest.raises(Exception):
@@ -3304,3 +3306,29 @@ def test_ogr_parquet_metadata(tmp_vsimem):
     assert lyr.GetMetadata_Dict() == {"foo": "bar"}
     assert lyr.GetMetadata_List("json:test")[0] == '{"foo":["bar","baz"]}'
     assert lyr.GetMetadata_List("xml:test")[0] == "<foo/>"
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_ogr_parquet_get_extent_3d(tmp_vsimem):
+
+    outfilename = str(tmp_vsimem / "test_ogr_parquet_get_extent_3d.parquet")
+    ds = ogr.GetDriverByName("Parquet").CreateDataSource(outfilename)
+    lyr = ds.CreateLayer("test", geom_type=ogr.wkbLineString25D)
+    f = ogr.Feature(lyr.GetLayerDefn())
+    f.SetGeometryDirectly(ogr.CreateGeometryFromWkt("LINESTRING Z (1 2 3,4 5 6)"))
+    lyr.CreateFeature(f)
+    ds = None
+
+    ds = ogr.Open(outfilename)
+    lyr = ds.GetLayer(0)
+    assert lyr.TestCapability(ogr.OLCFastGetExtent3D)
+    assert lyr.GetExtent3D() == (1.0, 4.0, 2.0, 5.0, 3.0, 6.0)
+
+    with gdaltest.config_option("OGR_PARQUET_USE_BBOX", "NO"):
+        ds = ogr.Open(outfilename)
+        lyr = ds.GetLayer(0)
+        assert lyr.TestCapability(ogr.OLCFastGetExtent3D) == 0
+        assert lyr.GetExtent3D() == (1.0, 4.0, 2.0, 5.0, 3.0, 6.0)

--- a/ogr/ogr_core.h
+++ b/ogr/ogr_core.h
@@ -234,7 +234,7 @@ extern "C++"
         /** Returns TRUE if MinZ and MaxZ are both valid numbers. */
         bool Is3D() const
         {
-            return !std::isnan(MinZ) && !std::isnan(MaxZ);
+            return std::isfinite(MinZ) && std::isfinite(MaxZ);
         }
 
         /** Minimum Z value */

--- a/ogr/ogr_wkb.h
+++ b/ogr/ogr_wkb.h
@@ -40,6 +40,9 @@ bool OGRWKBMultiPolygonGetArea(const GByte *&pabyWkb, size_t &nWKBSize,
                                double &dfArea);
 
 bool CPL_DLL OGRWKBGetBoundingBox(const GByte *pabyWkb, size_t nWKBSize,
+                                  OGREnvelope3D &sEnvelope);
+
+bool CPL_DLL OGRWKBGetBoundingBox(const GByte *pabyWkb, size_t nWKBSize,
                                   OGREnvelope &sEnvelope);
 
 bool CPL_DLL OGRWKBIntersectsPessimistic(const GByte *pabyWkb, size_t nWKBSize,

--- a/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
+++ b/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
@@ -210,8 +210,9 @@ class OGRArrowLayer CPL_NON_FINAL
     void ComputeConstraintsArrayIdx();
 
     virtual bool FastGetExtent(int iGeomField, OGREnvelope *psExtent) const;
+    bool FastGetExtent3D(int iGeomField, OGREnvelope3D *psExtent) const;
     static OGRErr GetExtentFromMetadata(const CPLJSONObject &oJSONDef,
-                                        OGREnvelope *psExtent);
+                                        OGREnvelope3D *psExtent);
 
     int GetArrowSchema(struct ArrowArrayStream *,
                        struct ArrowSchema *out) override;
@@ -234,6 +235,8 @@ class OGRArrowLayer CPL_NON_FINAL
     OGRErr GetExtent(OGREnvelope *psExtent, int bForce = TRUE) override;
     OGRErr GetExtent(int iGeomField, OGREnvelope *psExtent,
                      int bForce = TRUE) override;
+    OGRErr GetExtent3D(int iGeomField, OGREnvelope3D *psExtent,
+                       int bForce = TRUE) override;
     OGRErr SetAttributeFilter(const char *pszFilter) override;
 
     void SetSpatialFilter(OGRGeometry *poGeom) override

--- a/ogr/ogrsf_frmts/parquet/ogrparquetdatasetlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetdatasetlayer.cpp
@@ -257,20 +257,13 @@ OGRErr OGRParquetDatasetLayer::GetExtent(int iGeomField, OGREnvelope *psExtent,
                                 auto oRoot = oDoc.GetRoot();
                                 auto oColumns = oRoot.GetObj("columns");
                                 auto oCol = oColumns.GetObj(pszGeomFieldName);
-                                OGREnvelope sFragmentExtent;
+                                OGREnvelope3D sFragmentExtent;
                                 if (oCol.IsValid() &&
                                     GetExtentFromMetadata(
                                         oCol, &sFragmentExtent) == OGRERR_NONE)
                                 {
                                     nBBoxFragmentCount++;
-                                    psExtent->MinX = std::min(
-                                        psExtent->MinX, sFragmentExtent.MinX);
-                                    psExtent->MinY = std::min(
-                                        psExtent->MinY, sFragmentExtent.MinY);
-                                    psExtent->MaxX = std::max(
-                                        psExtent->MaxX, sFragmentExtent.MaxX);
-                                    psExtent->MaxY = std::max(
-                                        psExtent->MaxY, sFragmentExtent.MaxY);
+                                    psExtent->Merge(sFragmentExtent);
                                 }
                             }
                         }


### PR DESCRIPTION
- OGREnvelope3D::Is3D(): fix it to work with MinZ/MaxZ initialization values
- Add OGRWKBGetEnvelope() with a OGREnvelope3D; also fix 2D version with POINT EMPTY
- GPKG: make OGRGeoPackageGetHeader() return bounding box without instanciating a OGRGeometry
- Arrow/Parquet: implement GetExtent3D()

CC @elpaso 