### PR TITLE
[Backport release/3.8] Python bindings: add missing reference increment on Py_None in error case of Geometry.GetPoints() (fixes #8945)

### DIFF
--- a/swig/include/python/typemaps_python.i
+++ b/swig/include/python/typemaps_python.i
@@ -2331,6 +2331,7 @@ DecomposeSequenceOf4DCoordinates( PyObject *seq, int nCount, double *x, double *
   int nPointCount = *($1);
   if (nPointCount == 0)
   {
+    Py_INCREF(Py_None);
     $result = Py_None;
   }
   else


### PR DESCRIPTION
Backport #8946
 **Authored by:** @rouault