### PR TITLE
-rl vs. -sql: warn now on the man page before the user attempts mixing the two

### DIFF
--- a/doc/source/programs/ogrinfo.rst
+++ b/doc/source/programs/ogrinfo.rst
@@ -65,6 +65,8 @@ edit data.
     Enable random layer reading mode, i.e. iterate over features in the order
     they are found in the dataset, and not layer per layer. This can be
     significantly faster for some formats (for example OSM, GMLAS).
+    -rl cannot be used with -sql.
+
 
     .. versionadded:: 2.2
 


### PR DESCRIPTION
Not heeding the warning that I am putting on this man page will cause an "-rl is incompatible with -sql" error message.

I bet there are other man pages that need this warning too...