### PR TITLE
[Backport 3.8] STACTA: use STAC Raster extension to get number of bands, their data type, nodata value, scale/offset, units, and avoid fetching a metatile

### DIFF
--- a/autotest/gdrivers/data/stacta/test_stac_1_1.json
+++ b/autotest/gdrivers/data/stacta/test_stac_1_1.json
@@ -1,0 +1,177 @@
+{
+    "stac_version": "1.1.0",
+    "stac_extensions": [
+        "https://stac-extensions.github.io/tiled-assets/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/eo/v2.0.0/schema.json"
+    ],
+    "id": "test",
+    "type": "Feature",
+    "bbox": [
+        -180,
+        90,
+        180,
+        90
+    ],
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    180,
+                    90
+                ],
+                [
+                    -180,
+                    90
+                ],
+                [
+                    -180,
+                    -90
+                ],
+                [
+                    180,
+                    -90
+                ],
+                [
+                    180,
+                    90
+                ]
+            ]
+        ]
+    },
+    "properties": {
+        "collection": "collection",
+        "datetime": "2019-01-01T00:00:00Z",
+        "start_datetime": "2019-01-01T00:00:00Z",
+        "end_datetime": "2019-12-31T23:59:59Z",
+        "tiles:tile_matrix_links": {
+            "WorldCRS84Quad": {
+                "url": "http://schemas.opengis.net/tms/1.0/json/examples/WorldCRS84Quad.json",
+                "limits": {
+                    "0": {
+                        "min_tile_col": 0,
+                        "max_tile_col": 0,
+                        "min_tile_row": 0,
+                        "max_tile_row": 0
+                    },
+                    "1": {
+                        "min_tile_col": 0,
+                        "max_tile_col": 0,
+                        "min_tile_row": 0,
+                        "max_tile_row": 0
+                    },
+                    "2": {
+                        "min_tile_col": 0,
+                        "max_tile_col": 1,
+                        "min_tile_row": 0,
+                        "max_tile_row": 0
+                    }
+                }
+            }
+        },
+        "tiles:tile_matrix_sets": {
+            "WorldCRS84Quad": {
+                "type": "TileMatrixSetType",
+                "title": "WGS84 World",
+                "identifier": "WorldCRS84Quad",
+                "boundingBox": {
+                    "type": "BoundingBoxType",
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+                    "lowerCorner": [
+                        -180,
+                        -90
+                    ],
+                    "upperCorner": [
+                        180,
+                        90
+                    ]
+                },
+                "supportedCRS": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+                "wellKnownScaleSet": "http://www.opengis.net/def/wkss/OGC/1.0/GoogleCRS84Quad",
+                "tileMatrix": [
+                    {
+                        "type": "TileMatrixType",
+                        "identifier": "0",
+                        "scaleDenominator": 279541132.014358,
+                        "topLeftCorner": [
+                            -180,
+                            90
+                        ],
+                        "tileWidth": 512,
+                        "tileHeight": 256,
+                        "matrixWidth": 1,
+                        "matrixHeight": 1
+                    },
+                    {
+                        "type": "TileMatrixType",
+                        "identifier": "1",
+                        "scaleDenominator": 139770566.007179,
+                        "topLeftCorner": [
+                            -180,
+                            90
+                        ],
+                        "tileWidth": 1024,
+                        "tileHeight": 512,
+                        "matrixWidth": 1,
+                        "matrixHeight": 1
+                    },
+                    {
+                        "type": "TileMatrixType",
+                        "identifier": "2",
+                        "scaleDenominator": 69885283.0035897,
+                        "topLeftCorner": [
+                            -180,
+                            90
+                        ],
+                        "tileWidth": 1024,
+                        "tileHeight": 1024,
+                        "matrixWidth": 2,
+                        "matrixHeight": 1
+                    }
+                ]
+            }
+        }
+    },
+    "asset_templates": {
+        "bands": {
+            "href": "./non_existing/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.tif",
+            "type": "image/tiff; application=geotiff",
+            "bands": [
+                {
+                    "name": "B1",
+                    "eo:common_name": "nir",
+                    "data_type": "uint8",
+                    "unit": "dn",
+                    "nodata": 1,
+                    "raster:scale": 10,
+                    "raster:offset": 1.2,
+                    "raster:bits_per_sample": 7
+                },
+                {
+                    "name": "B2",
+                    "data_type": "float32",
+                    "nodata": 1.5
+                },
+                {
+                    "name": "B3",
+                    "data_type": "float32",
+                    "nodata": "inf"
+                },
+                {
+                    "name": "B4",
+                    "data_type": "float32",
+                    "nodata": "-inf"
+                },
+                {
+                    "name": "B5",
+                    "data_type": "float32",
+                    "nodata": "nan"
+                },
+                {
+                    "name": "B6",
+                    "data_type": "float32"
+                }
+            ]
+        }
+    }
+}

--- a/autotest/gdrivers/data/stacta/test_with_raster_extension.json
+++ b/autotest/gdrivers/data/stacta/test_with_raster_extension.json
@@ -1,0 +1,191 @@
+{
+    "stac_version": "1.0.0",
+    "stac_extensions": [
+        "https://stac-extensions.github.io/tiled-assets/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/eo/v1.1.0/schema.json",
+        "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+    ],
+    "id": "test",
+    "type": "Feature",
+    "bbox": [
+        -180,
+        90,
+        180,
+        90
+    ],
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    180,
+                    90
+                ],
+                [
+                    -180,
+                    90
+                ],
+                [
+                    -180,
+                    -90
+                ],
+                [
+                    180,
+                    -90
+                ],
+                [
+                    180,
+                    90
+                ]
+            ]
+        ]
+    },
+    "properties": {
+        "collection": "collection",
+        "datetime": "2019-01-01T00:00:00Z",
+        "start_datetime": "2019-01-01T00:00:00Z",
+        "end_datetime": "2019-12-31T23:59:59Z",
+        "tiles:tile_matrix_links": {
+            "WorldCRS84Quad": {
+                "url": "http://schemas.opengis.net/tms/1.0/json/examples/WorldCRS84Quad.json",
+                "limits": {
+                    "0": {
+                        "min_tile_col": 0,
+                        "max_tile_col": 0,
+                        "min_tile_row": 0,
+                        "max_tile_row": 0
+                    },
+                    "1": {
+                        "min_tile_col": 0,
+                        "max_tile_col": 0,
+                        "min_tile_row": 0,
+                        "max_tile_row": 0
+                    },
+                    "2": {
+                        "min_tile_col": 0,
+                        "max_tile_col": 1,
+                        "min_tile_row": 0,
+                        "max_tile_row": 0
+                    }
+                }
+            }
+        },
+        "tiles:tile_matrix_sets": {
+            "WorldCRS84Quad": {
+                "type": "TileMatrixSetType",
+                "title": "WGS84 World",
+                "identifier": "WorldCRS84Quad",
+                "boundingBox": {
+                    "type": "BoundingBoxType",
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+                    "lowerCorner": [
+                        -180,
+                        -90
+                    ],
+                    "upperCorner": [
+                        180,
+                        90
+                    ]
+                },
+                "supportedCRS": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+                "wellKnownScaleSet": "http://www.opengis.net/def/wkss/OGC/1.0/GoogleCRS84Quad",
+                "tileMatrix": [
+                    {
+                        "type": "TileMatrixType",
+                        "identifier": "0",
+                        "scaleDenominator": 279541132.014358,
+                        "topLeftCorner": [
+                            -180,
+                            90
+                        ],
+                        "tileWidth": 512,
+                        "tileHeight": 256,
+                        "matrixWidth": 1,
+                        "matrixHeight": 1
+                    },
+                    {
+                        "type": "TileMatrixType",
+                        "identifier": "1",
+                        "scaleDenominator": 139770566.007179,
+                        "topLeftCorner": [
+                            -180,
+                            90
+                        ],
+                        "tileWidth": 1024,
+                        "tileHeight": 512,
+                        "matrixWidth": 1,
+                        "matrixHeight": 1
+                    },
+                    {
+                        "type": "TileMatrixType",
+                        "identifier": "2",
+                        "scaleDenominator": 69885283.0035897,
+                        "topLeftCorner": [
+                            -180,
+                            90
+                        ],
+                        "tileWidth": 1024,
+                        "tileHeight": 1024,
+                        "matrixWidth": 2,
+                        "matrixHeight": 1
+                    }
+                ]
+            }
+        }
+    },
+    "asset_templates": {
+        "bands": {
+            "href": "./non_existing/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.tif",
+            "type": "image/tiff; application=geotiff",
+            "eo:bands": [
+                {
+                    "name": "B1"
+                },
+                {
+                    "name": "B2"
+                },
+                {
+                    "name": "B3"
+                },
+                {
+                    "name": "B4"
+                },
+                {
+                    "name": "B5"
+                },
+                {
+                    "name": "B6"
+                }
+            ],
+            "raster:bands": [
+                {
+                  "data_type": "uint8",
+                  "unit": "dn",
+                  "nodata": 1,
+                  "scale": 10,
+                  "offset": 1.2,
+                  "bits_per_sample": 7
+                },
+                {
+                  "data_type": "float32",
+                  "nodata": 1.5
+                },
+                {
+                  "data_type": "float32",
+                  "nodata": "inf"
+                },
+                {
+                  "data_type": "float32",
+                  "nodata": "-inf"
+                },
+                {
+                  "data_type": "float32",
+                  "nodata": "nan"
+                },
+                {
+                  "data_type": "float32"
+                }
+            ]
+        }
+    }
+}

--- a/autotest/gdrivers/data/stacta/test_with_raster_extension_no_eo_bands.json
+++ b/autotest/gdrivers/data/stacta/test_with_raster_extension_no_eo_bands.json
@@ -1,0 +1,170 @@
+{
+    "stac_version": "1.0.0",
+    "stac_extensions": [
+        "https://stac-extensions.github.io/tiled-assets/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/raster/v1.1.0/schema.json"
+    ],
+    "id": "test",
+    "type": "Feature",
+    "bbox": [
+        -180,
+        90,
+        180,
+        90
+    ],
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    180,
+                    90
+                ],
+                [
+                    -180,
+                    90
+                ],
+                [
+                    -180,
+                    -90
+                ],
+                [
+                    180,
+                    -90
+                ],
+                [
+                    180,
+                    90
+                ]
+            ]
+        ]
+    },
+    "properties": {
+        "collection": "collection",
+        "datetime": "2019-01-01T00:00:00Z",
+        "start_datetime": "2019-01-01T00:00:00Z",
+        "end_datetime": "2019-12-31T23:59:59Z",
+        "tiles:tile_matrix_links": {
+            "WorldCRS84Quad": {
+                "url": "http://schemas.opengis.net/tms/1.0/json/examples/WorldCRS84Quad.json",
+                "limits": {
+                    "0": {
+                        "min_tile_col": 0,
+                        "max_tile_col": 0,
+                        "min_tile_row": 0,
+                        "max_tile_row": 0
+                    },
+                    "1": {
+                        "min_tile_col": 0,
+                        "max_tile_col": 0,
+                        "min_tile_row": 0,
+                        "max_tile_row": 0
+                    },
+                    "2": {
+                        "min_tile_col": 0,
+                        "max_tile_col": 1,
+                        "min_tile_row": 0,
+                        "max_tile_row": 0
+                    }
+                }
+            }
+        },
+        "tiles:tile_matrix_sets": {
+            "WorldCRS84Quad": {
+                "type": "TileMatrixSetType",
+                "title": "WGS84 World",
+                "identifier": "WorldCRS84Quad",
+                "boundingBox": {
+                    "type": "BoundingBoxType",
+                    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+                    "lowerCorner": [
+                        -180,
+                        -90
+                    ],
+                    "upperCorner": [
+                        180,
+                        90
+                    ]
+                },
+                "supportedCRS": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+                "wellKnownScaleSet": "http://www.opengis.net/def/wkss/OGC/1.0/GoogleCRS84Quad",
+                "tileMatrix": [
+                    {
+                        "type": "TileMatrixType",
+                        "identifier": "0",
+                        "scaleDenominator": 279541132.014358,
+                        "topLeftCorner": [
+                            -180,
+                            90
+                        ],
+                        "tileWidth": 512,
+                        "tileHeight": 256,
+                        "matrixWidth": 1,
+                        "matrixHeight": 1
+                    },
+                    {
+                        "type": "TileMatrixType",
+                        "identifier": "1",
+                        "scaleDenominator": 139770566.007179,
+                        "topLeftCorner": [
+                            -180,
+                            90
+                        ],
+                        "tileWidth": 1024,
+                        "tileHeight": 512,
+                        "matrixWidth": 1,
+                        "matrixHeight": 1
+                    },
+                    {
+                        "type": "TileMatrixType",
+                        "identifier": "2",
+                        "scaleDenominator": 69885283.0035897,
+                        "topLeftCorner": [
+                            -180,
+                            90
+                        ],
+                        "tileWidth": 1024,
+                        "tileHeight": 1024,
+                        "matrixWidth": 2,
+                        "matrixHeight": 1
+                    }
+                ]
+            }
+        }
+    },
+    "asset_templates": {
+        "bands": {
+            "href": "./non_existing/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.tif",
+            "type": "image/tiff; application=geotiff",
+            "raster:bands": [
+                {
+                  "data_type": "uint8",
+                  "unit": "dn",
+                  "nodata": 1,
+                  "scale": 10,
+                  "offset": 1.2,
+                  "bits_per_sample": 7
+                },
+                {
+                  "data_type": "float32",
+                  "nodata": 1.5
+                },
+                {
+                  "data_type": "float32",
+                  "nodata": "inf"
+                },
+                {
+                  "data_type": "float32",
+                  "nodata": "-inf"
+                },
+                {
+                  "data_type": "float32",
+                  "nodata": "nan"
+                },
+                {
+                  "data_type": "float32"
+                }
+            ]
+        }
+    }
+}

--- a/autotest/gdrivers/stacta.py
+++ b/autotest/gdrivers/stacta.py
@@ -28,7 +28,9 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
+import copy
 import json
+import math
 import struct
 from http.server import BaseHTTPRequestHandler
 
@@ -290,3 +292,94 @@ def test_stacta_network():
 
     finally:
         webserver.server_stop(process, port)
+
+
+###############################################################################
+
+
+def test_stacta_with_raster_extension_nominal():
+
+    ds = gdal.Open("data/stacta/test_with_raster_extension.json")
+    assert ds.RasterCount == 6
+    band = ds.GetRasterBand(1)
+    assert band.DataType == gdal.GDT_Byte
+    assert band.GetNoDataValue() == 1
+    assert band.GetOffset() == 1.2
+    assert band.GetScale() == 10
+    assert band.GetUnitType() == "dn"
+    assert band.GetMetadataItem("NBITS", "IMAGE_STRUCTURE") == "7"
+
+    band = ds.GetRasterBand(2)
+    assert band.DataType == gdal.GDT_Float32
+    assert band.GetNoDataValue() == 1.5
+    assert band.GetOffset() is None
+    assert band.GetScale() is None
+    assert band.GetUnitType() == ""
+
+    band = ds.GetRasterBand(3)
+    assert band.GetNoDataValue() == float("inf")
+
+    band = ds.GetRasterBand(4)
+    assert band.GetNoDataValue() == float("-inf")
+
+    band = ds.GetRasterBand(5)
+    assert math.isnan(band.GetNoDataValue())
+
+    band = ds.GetRasterBand(6)
+    assert band.GetNoDataValue() is None
+
+
+###############################################################################
+
+
+def test_stacta_with_raster_extension_errors():
+
+    j_ori = json.loads(open("data/stacta/test_with_raster_extension.json", "rb").read())
+
+    j = copy.deepcopy(j_ori)
+    del j["asset_templates"]["bands"]["raster:bands"]
+    with gdaltest.tempfile("/vsimem/test.json", json.dumps(j)):
+        with pytest.raises(
+            Exception, match="Cannot open /vsimem/non_existing/WorldCRS84Quad/0/0/0.tif"
+        ):
+            gdal.Open("/vsimem/test.json")
+
+    j = copy.deepcopy(j_ori)
+    del j["asset_templates"]["bands"]["raster:bands"][4]
+    with gdaltest.tempfile("/vsimem/test.json", json.dumps(j)):
+        with pytest.raises(
+            Exception, match="Cannot open /vsimem/non_existing/WorldCRS84Quad/0/0/0.tif"
+        ):
+            with gdal.quiet_errors():
+                gdal.Open("/vsimem/test.json")
+
+    j = copy.deepcopy(j_ori)
+    j["asset_templates"]["bands"]["raster:bands"][0] = "invalid"
+    with gdaltest.tempfile("/vsimem/test.json", json.dumps(j)):
+        with pytest.raises(Exception, match=r"Wrong raster:bands\[0\]"):
+            with gdal.quiet_errors():
+                gdal.Open("/vsimem/test.json")
+
+    j = copy.deepcopy(j_ori)
+    del j["asset_templates"]["bands"]["raster:bands"][0]["data_type"]
+    with gdaltest.tempfile("/vsimem/test.json", json.dumps(j)):
+        with pytest.raises(Exception, match=r"Wrong raster:bands\[0\].data_type"):
+            gdal.Open("/vsimem/test.json")
+
+    j = copy.deepcopy(j_ori)
+    j["asset_templates"]["bands"]["raster:bands"][0]["data_type"] = "invalid"
+    with gdaltest.tempfile("/vsimem/test.json", json.dumps(j)):
+        with pytest.raises(Exception, match=r"Wrong raster:bands\[0\].data_type"):
+            gdal.Open("/vsimem/test.json")
+
+    j = copy.deepcopy(j_ori)
+    j["asset_templates"]["bands"]["raster:bands"][0]["nodata"] = "invalid"
+    with gdaltest.tempfile("/vsimem/test.json", json.dumps(j)):
+        with gdal.quiet_errors():
+            assert gdal.Open("/vsimem/test.json") is not None
+
+    j = copy.deepcopy(j_ori)
+    j["asset_templates"]["bands"]["raster:bands"][0]["nodata"] = ["invalid json object"]
+    with gdaltest.tempfile("/vsimem/test.json", json.dumps(j)):
+        with gdal.quiet_errors():
+            assert gdal.Open("/vsimem/test.json") is not None

--- a/autotest/gdrivers/stacta.py
+++ b/autotest/gdrivers/stacta.py
@@ -297,11 +297,20 @@ def test_stacta_network():
 ###############################################################################
 
 
-def test_stacta_with_raster_extension_nominal():
+@pytest.mark.parametrize(
+    "filename",
+    [
+        "data/stacta/test_with_raster_extension.json",
+        "data/stacta/test_with_raster_extension_no_eo_bands.json",
+    ],
+)
+def test_stacta_with_raster_extension_nominal(filename):
 
-    ds = gdal.Open("data/stacta/test_with_raster_extension.json")
+    ds = gdal.Open(filename)
     assert ds.RasterCount == 6
     band = ds.GetRasterBand(1)
+    if filename == "data/stacta/test_with_raster_extension.json":
+        assert band.GetMetadataItem("name") == "B1"
     assert band.DataType == gdal.GDT_Byte
     assert band.GetNoDataValue() == 1
     assert band.GetOffset() == 1.2

--- a/autotest/gdrivers/stacta.py
+++ b/autotest/gdrivers/stacta.py
@@ -302,6 +302,7 @@ def test_stacta_network():
     [
         "data/stacta/test_with_raster_extension.json",
         "data/stacta/test_with_raster_extension_no_eo_bands.json",
+        "data/stacta/test_stac_1_1.json",
     ],
 )
 def test_stacta_with_raster_extension_nominal(filename):
@@ -309,8 +310,13 @@ def test_stacta_with_raster_extension_nominal(filename):
     ds = gdal.Open(filename)
     assert ds.RasterCount == 6
     band = ds.GetRasterBand(1)
-    if filename == "data/stacta/test_with_raster_extension.json":
+    if (
+        filename == "data/stacta/test_with_raster_extension.json"
+        or filename == "data/stacta/test_stac_1_1.json"
+    ):
         assert band.GetMetadataItem("name") == "B1"
+    if filename == "data/stacta/test_stac_1_1.json":
+        assert band.GetMetadata_Dict() == {"common_name": "nir", "name": "B1"}
     assert band.DataType == gdal.GDT_Byte
     assert band.GetNoDataValue() == 1
     assert band.GetOffset() == 1.2

--- a/doc/source/drivers/raster/stacta.rst
+++ b/doc/source/drivers/raster/stacta.rst
@@ -17,6 +17,10 @@ from a potentially big dataset according to a tiling scheme, with several zoom
 levels. The driver provides a single raster view, with overviews, of the dataset
 described by the JSON file. The driver supports metatiles of arbitrary size.
 
+The driver may use the `Electro-Optical Extension <https://github.com/stac-extensions/eo>`__
+and, starting with GDAL 3.8.2, the `Raster Extension <https://github.com/stac-extensions/raster>`__
+attached to an asset template.
+
 Configuration options
 ---------------------
 

--- a/frmts/stacta/stactadataset.cpp
+++ b/frmts/stacta/stactadataset.cpp
@@ -912,7 +912,7 @@ bool STACTADataset::Open(GDALOpenInfo *poOpenInfo)
         }
         else
         {
-            nExpectedBandCount = oEoBands.Size();
+            nExpectedBandCount = oRasterBands.Size();
             const struct
             {
                 const char *pszStacDataType;

--- a/frmts/stacta/stactadataset.cpp
+++ b/frmts/stacta/stactadataset.cpp
@@ -37,6 +37,7 @@
 
 #include <algorithm>
 #include <array>
+#include <limits>
 #include <map>
 #include <memory>
 #include <vector>
@@ -192,6 +193,25 @@ STACTARawRasterBand::STACTARawRasterBand(STACTARawDataset *poDSIn, int nBandIn,
     nRasterXSize = poDSIn->GetRasterXSize();
     nRasterYSize = poDSIn->GetRasterYSize();
     m_dfNoData = poProtoBand->GetNoDataValue(&m_bHasNoDataValue);
+}
+
+/************************************************************************/
+/*                        STACTARawRasterBand()                         */
+/************************************************************************/
+
+STACTARawRasterBand::STACTARawRasterBand(STACTARawDataset *poDSIn, int nBandIn,
+                                         GDALDataType eDT, bool bSetNoData,
+                                         double dfNoData)
+{
+    poDS = poDSIn;
+    nBand = nBandIn;
+    eDataType = eDT;
+    nBlockXSize = 256;
+    nBlockYSize = 256;
+    nRasterXSize = poDSIn->GetRasterXSize();
+    nRasterYSize = poDSIn->GetRasterYSize();
+    m_bHasNoDataValue = bSetNoData;
+    m_dfNoData = dfNoData;
 }
 
 /************************************************************************/
@@ -644,7 +664,10 @@ int STACTADataset::Identify(GDALOpenInfo *poOpenInfo)
         const char *pszHeader =
             reinterpret_cast<const char *>(poOpenInfo->pabyHeader);
         if (strstr(pszHeader, "\"stac_extensions\"") != nullptr &&
-            strstr(pszHeader, "\"tiled-assets\"") != nullptr)
+            (strstr(pszHeader, "\"tiled-assets\"") != nullptr ||
+             strstr(pszHeader,
+                    "https://stac-extensions.github.io/tiled-assets/") !=
+                 nullptr))
         {
             return true;
         }
@@ -869,50 +892,185 @@ bool STACTADataset::Open(GDALOpenInfo *poOpenInfo)
         poOpenInfo->papszOpenOptions, "SKIP_MISSING_METATILE",
         CPLGetConfigOption("GDAL_STACTA_SKIP_MISSING_METATILE", "NO")));
 
-    std::unique_ptr<GDALDataset> poProtoDS;
-    for (int i = 0; i < static_cast<int>(tmsList.size()); i++)
+    // Check if there are both eo:bands and raster:bands extension
+    // If so, we don't need to fetch a prototype metatile to derive the
+    // information we need (number of bands, data type and nodata value)
+    const auto oEoBands = oAssetTemplate.GetArray("eo:bands");
+    const auto oRasterBands = oAssetTemplate.GetArray("raster:bands");
+
+    std::vector<GDALDataType> aeDT;
+    std::vector<double> adfNoData;
+    std::vector<bool> abSetNoData;
+    int nExpectedBandCount = 0;
+    if (oRasterBands.IsValid())
     {
-        // Open a metatile to get mostly its band data type
-        int nProtoTileCol = 0;
-        int nProtoTileRow = 0;
-        auto oIterLimit = oMapLimits.find(tmsList[i].mId);
-        if (oIterLimit != oMapLimits.end())
+        if (oEoBands.IsValid() && oEoBands.Size() != oRasterBands.Size())
         {
-            nProtoTileCol = oIterLimit->second.min_tile_col;
-            nProtoTileRow = oIterLimit->second.min_tile_row;
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "Number of bands in eo:bands and raster:bands is not "
+                     "identical. Ignoring the later");
         }
-        const CPLString osURL =
-            CPLString(osURLTemplate)
-                .replaceAll("{TileMatrix}", tmsList[i].mId)
-                .replaceAll("{TileRow}", CPLSPrintf("%d", nProtoTileRow))
-                .replaceAll("{TileCol}", CPLSPrintf("%d", nProtoTileCol));
-        CPLString osProtoDSName =
-            (STARTS_WITH(osURL, "http://") || STARTS_WITH(osURL, "https://"))
-                ? CPLString("/vsicurl/" + osURL)
-                : osURL;
-        CPLConfigOptionSetter oSetter("GDAL_DISABLE_READDIR_ON_OPEN",
-                                      "EMPTY_DIR",
-                                      /* bSetOnlyIfUndefined = */ true);
-        if (m_bSkipMissingMetaTile)
-            CPLPushErrorHandler(CPLQuietErrorHandler);
-        poProtoDS.reset(GDALDataset::Open(osProtoDSName.c_str()));
-        if (m_bSkipMissingMetaTile)
-            CPLPopErrorHandler();
-        if (poProtoDS != nullptr)
+        else
         {
-            break;
-        }
-        if (!m_bSkipMissingMetaTile)
-        {
-            CPLError(CE_Failure, CPLE_OpenFailed, "Cannot open %s",
-                     osURL.c_str());
-            return false;
+            nExpectedBandCount = oEoBands.Size();
+            const struct
+            {
+                const char *pszStacDataType;
+                GDALDataType eGDALDataType;
+            } aDataTypeMapping[] = {
+                {"int8", GDT_Int8},
+                {"int16", GDT_Int16},
+                {"int32", GDT_Int32},
+                {"int64", GDT_Int64},
+                {"uint8", GDT_Byte},
+                {"uint16", GDT_UInt16},
+                {"uint32", GDT_UInt32},
+                {"uint64", GDT_UInt64},
+                // float16: 16-bit float; unhandled
+                {"float32", GDT_Float32},
+                {"float64", GDT_Float64},
+                {"cint16", GDT_CInt16},
+                {"cint32", GDT_CInt32},
+                {"cfloat32", GDT_CFloat32},
+                {"cfloat64", GDT_CFloat64},
+            };
+            for (int i = 0; i < nExpectedBandCount; ++i)
+            {
+                if (oRasterBands[i].GetType() != CPLJSONObject::Type::Object)
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "Wrong raster:bands[%d]", i);
+                    return false;
+                }
+                const std::string osDataType =
+                    oRasterBands[i].GetString("data_type");
+                GDALDataType eDT = GDT_Unknown;
+                for (const auto &oTuple : aDataTypeMapping)
+                {
+                    if (osDataType == oTuple.pszStacDataType)
+                    {
+                        eDT = oTuple.eGDALDataType;
+                        break;
+                    }
+                }
+                if (eDT == GDT_Unknown)
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "Wrong raster:bands[%d].data_type = %s", i,
+                             osDataType.c_str());
+                    return false;
+                }
+                aeDT.push_back(eDT);
+
+                const auto oNoData = oRasterBands[i].GetObj("nodata");
+                if (oNoData.GetType() == CPLJSONObject::Type::String)
+                {
+                    const std::string osNoData = oNoData.ToString();
+                    if (osNoData == "inf")
+                    {
+                        abSetNoData.push_back(true);
+                        adfNoData.push_back(
+                            std::numeric_limits<double>::infinity());
+                    }
+                    else if (osNoData == "-inf")
+                    {
+                        abSetNoData.push_back(true);
+                        adfNoData.push_back(
+                            -std::numeric_limits<double>::infinity());
+                    }
+                    else if (osNoData == "nan")
+                    {
+                        abSetNoData.push_back(true);
+                        adfNoData.push_back(
+                            std::numeric_limits<double>::quiet_NaN());
+                    }
+                    else
+                    {
+                        CPLError(CE_Warning, CPLE_AppDefined,
+                                 "Invalid raster:bands[%d].nodata = %s", i,
+                                 osNoData.c_str());
+                        abSetNoData.push_back(false);
+                        adfNoData.push_back(
+                            std::numeric_limits<double>::quiet_NaN());
+                    }
+                }
+                else if (oNoData.GetType() == CPLJSONObject::Type::Integer ||
+                         oNoData.GetType() == CPLJSONObject::Type::Long ||
+                         oNoData.GetType() == CPLJSONObject::Type::Double)
+                {
+                    abSetNoData.push_back(true);
+                    adfNoData.push_back(oNoData.ToDouble());
+                }
+                else if (!oNoData.IsValid())
+                {
+                    abSetNoData.push_back(false);
+                    adfNoData.push_back(
+                        std::numeric_limits<double>::quiet_NaN());
+                }
+                else
+                {
+                    CPLError(CE_Warning, CPLE_AppDefined,
+                             "Invalid raster:bands[%d].nodata", i);
+                    abSetNoData.push_back(false);
+                    adfNoData.push_back(
+                        std::numeric_limits<double>::quiet_NaN());
+                }
+            }
+
+            CPLAssert(aeDT.size() == abSetNoData.size());
+            CPLAssert(adfNoData.size() == abSetNoData.size());
         }
     }
-    if (poProtoDS == nullptr)
+
+    std::unique_ptr<GDALDataset> poProtoDS;
+    if (aeDT.empty())
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Cannot find prototype dataset");
-        return false;
+        for (int i = 0; i < static_cast<int>(tmsList.size()); i++)
+        {
+            // Open a metatile to get mostly its band data type
+            int nProtoTileCol = 0;
+            int nProtoTileRow = 0;
+            auto oIterLimit = oMapLimits.find(tmsList[i].mId);
+            if (oIterLimit != oMapLimits.end())
+            {
+                nProtoTileCol = oIterLimit->second.min_tile_col;
+                nProtoTileRow = oIterLimit->second.min_tile_row;
+            }
+            const CPLString osURL =
+                CPLString(osURLTemplate)
+                    .replaceAll("{TileMatrix}", tmsList[i].mId)
+                    .replaceAll("{TileRow}", CPLSPrintf("%d", nProtoTileRow))
+                    .replaceAll("{TileCol}", CPLSPrintf("%d", nProtoTileCol));
+            CPLString osProtoDSName = (STARTS_WITH(osURL, "http://") ||
+                                       STARTS_WITH(osURL, "https://"))
+                                          ? CPLString("/vsicurl/" + osURL)
+                                          : osURL;
+            CPLConfigOptionSetter oSetter("GDAL_DISABLE_READDIR_ON_OPEN",
+                                          "EMPTY_DIR",
+                                          /* bSetOnlyIfUndefined = */ true);
+            if (m_bSkipMissingMetaTile)
+                CPLPushErrorHandler(CPLQuietErrorHandler);
+            poProtoDS.reset(GDALDataset::Open(osProtoDSName.c_str()));
+            if (m_bSkipMissingMetaTile)
+                CPLPopErrorHandler();
+            if (poProtoDS != nullptr)
+            {
+                break;
+            }
+            if (!m_bSkipMissingMetaTile)
+            {
+                CPLError(CE_Failure, CPLE_OpenFailed, "Cannot open %s",
+                         osURL.c_str());
+                return false;
+            }
+        }
+        if (poProtoDS == nullptr)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Cannot find prototype dataset");
+            return false;
+        }
+        nExpectedBandCount = poProtoDS->GetRasterCount();
     }
 
     // Iterate over tile matrices to create corresponding STACTARawDataset
@@ -936,8 +1094,8 @@ bool STACTADataset::Open(GDALOpenInfo *poOpenInfo)
             continue;
         }
         auto poRawDS = cpl::make_unique<STACTARawDataset>();
-        if (!poRawDS->InitRaster(poProtoDS.get(), poTMS.get(), tmsList[i].mId,
-                                 oTM, oMapLimits))
+        if (!poRawDS->InitRaster(poProtoDS.get(), aeDT, abSetNoData, adfNoData,
+                                 poTMS.get(), tmsList[i].mId, oTM, oMapLimits))
         {
             return false;
         }
@@ -1011,13 +1169,11 @@ bool STACTADataset::Open(GDALOpenInfo *poOpenInfo)
     }
 
     // Create main bands
-    const auto oEoBands = oAssetTemplate.GetArray("eo:bands");
     for (int i = 0; i < m_poDS->GetRasterCount(); i++)
     {
         auto poSrcBand = m_poDS->GetRasterBand(i + 1);
         auto poBand = new STACTARasterBand(this, i + 1, poSrcBand);
-        if (oEoBands.IsValid() &&
-            oEoBands.Size() == poProtoDS->GetRasterCount())
+        if (oEoBands.IsValid() && oEoBands.Size() == nExpectedBandCount)
         {
             // Set band metadata
             if (oEoBands[i].GetType() == CPLJSONObject::Type::Object)
@@ -1027,6 +1183,27 @@ bool STACTADataset::Open(GDALOpenInfo *poOpenInfo)
                     poBand->GDALRasterBand::SetMetadataItem(
                         oItem.GetName().c_str(), oItem.ToString().c_str());
                 }
+            }
+        }
+        if (oRasterBands.IsValid() &&
+            oRasterBands.Size() == nExpectedBandCount &&
+            oRasterBands[i].GetType() == CPLJSONObject::Type::Object)
+        {
+            poBand->m_osUnit = oRasterBands[i].GetString("unit");
+            const double dfScale = oRasterBands[i].GetDouble("scale");
+            if (dfScale != 0)
+                poBand->m_dfScale = dfScale;
+            poBand->m_dfOffset = oRasterBands[i].GetDouble("offset");
+            const int nBitsPerSample =
+                oRasterBands[i].GetInteger("bits_per_sample");
+            if (((nBitsPerSample >= 1 && nBitsPerSample <= 7) &&
+                 poBand->GetRasterDataType() == GDT_Byte) ||
+                ((nBitsPerSample >= 9 && nBitsPerSample <= 15) &&
+                 poBand->GetRasterDataType() == GDT_UInt16))
+            {
+                poBand->GDALRasterBand::SetMetadataItem(
+                    "NBITS", CPLSPrintf("%d", nBitsPerSample),
+                    "IMAGE_STRUCTURE");
             }
         }
         SetBand(i + 1, poBand);
@@ -1044,11 +1221,20 @@ bool STACTADataset::Open(GDALOpenInfo *poOpenInfo)
         }
     }
 
-    const char *pszInterleave =
-        poProtoDS->GetMetadataItem("INTERLEAVE", "IMAGE_STRUCTURE");
-    GDALDataset::SetMetadataItem("INTERLEAVE",
-                                 pszInterleave ? pszInterleave : "PIXEL",
-                                 "IMAGE_STRUCTURE");
+    if (poProtoDS)
+    {
+        const char *pszInterleave =
+            poProtoDS->GetMetadataItem("INTERLEAVE", "IMAGE_STRUCTURE");
+        GDALDataset::SetMetadataItem("INTERLEAVE",
+                                     pszInterleave ? pszInterleave : "PIXEL",
+                                     "IMAGE_STRUCTURE");
+    }
+    else
+    {
+        // A bit bold to assume that, but that should be a reasonable
+        // setting
+        GDALDataset::SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+    }
 
     m_bDownloadWholeMetaTile = CPLTestBool(CSLFetchNameValueDef(
         poOpenInfo->papszOpenOptions, "WHOLE_METATILE", "NO"));
@@ -1082,6 +1268,9 @@ CPLErr STACTADataset::FlushCache(bool bAtClosing)
 /************************************************************************/
 
 bool STACTARawDataset::InitRaster(GDALDataset *poProtoDS,
+                                  const std::vector<GDALDataType> &aeDT,
+                                  const std::vector<bool> &abSetNoData,
+                                  const std::vector<double> &adfNoData,
                                   const gdal::TileMatrixSet *poTMS,
                                   const std::string &osTMId,
                                   const gdal::TileMatrixSet::TileMatrix &oTM,
@@ -1102,11 +1291,23 @@ bool STACTARawDataset::InitRaster(GDALDataset *poProtoDS,
     nRasterXSize = nMatrixWidth * m_nMetaTileWidth;
     nRasterYSize = nMatrixHeight * m_nMetaTileHeight;
 
-    for (int i = 0; i < poProtoDS->GetRasterCount(); i++)
+    if (poProtoDS)
     {
-        auto poProtoBand = poProtoDS->GetRasterBand(i + 1);
-        auto poBand = new STACTARawRasterBand(this, i + 1, poProtoBand);
-        SetBand(i + 1, poBand);
+        for (int i = 0; i < poProtoDS->GetRasterCount(); i++)
+        {
+            auto poProtoBand = poProtoDS->GetRasterBand(i + 1);
+            auto poBand = new STACTARawRasterBand(this, i + 1, poProtoBand);
+            SetBand(i + 1, poBand);
+        }
+    }
+    else
+    {
+        for (int i = 0; i < static_cast<int>(aeDT.size()); i++)
+        {
+            auto poBand = new STACTARawRasterBand(this, i + 1, aeDT[i],
+                                                  abSetNoData[i], adfNoData[i]);
+            SetBand(i + 1, poBand);
+        }
     }
 
     CPLString osCRS = poTMS->crs().c_str();


### PR DESCRIPTION
Backport of https://github.com/OSGeo/gdal/pull/8931