### PR TITLE
Overview: save resampling method, and reuse it in gdaladdo

### DIFF
--- a/autotest/gcore/tiff_ovr.py
+++ b/autotest/gcore/tiff_ovr.py
@@ -1388,9 +1388,13 @@ def test_tiff_ovr_37(tmp_path, both_endian):
     shutil.copy("../gdrivers/data/n43.dt0", ovr37_dt0)
 
     ds = gdal.Open(ovr37_dt0)
+    with gdaltest.config_option("COMPRESS_OVERVIEW", "LZW"):
+        ds.BuildOverviews("NEAR", overviewlist=[2])
+    ds = None
+    no_predictor_size = os.stat(f"{ovr37_dt0}.ovr")[stat.ST_SIZE]
+    os.unlink(f"{ovr37_dt0}.ovr")
 
-    assert ds is not None, "Failed to open test dataset."
-
+    ds = gdal.Open(ovr37_dt0)
     with gdaltest.config_option("PREDICTOR_OVERVIEW", "2"):
         with gdaltest.config_option("COMPRESS_OVERVIEW", "LZW"):
             ds.BuildOverviews("NEAR", overviewlist=[2])
@@ -1403,9 +1407,7 @@ def test_tiff_ovr_37(tmp_path, both_endian):
     ds = None
 
     predictor2_size = os.stat(f"{ovr37_dt0}.ovr")[stat.ST_SIZE]
-    # 3789 : on little-endian host
-    # 3738 : on big-endian host
-    assert predictor2_size in (3789, 3738), "did not get expected file size."
+    assert predictor2_size < no_predictor_size
 
 
 ###############################################################################

--- a/autotest/pyscripts/test_gdalcompare.py
+++ b/autotest/pyscripts/test_gdalcompare.py
@@ -321,5 +321,8 @@ def test_gdalcompare_different_overview(tmp_vsimem, captured_print, source_filen
     ds.BuildOverviews("AVERAGE", [2])
     ds = None
     assert (
-        gdalcompare.find_diff(golden_filename, filename, options=["SKIP_BINARY"]) == 1
+        gdalcompare.find_diff(
+            golden_filename, filename, options=["SKIP_METADATA", "SKIP_BINARY"]
+        )
+        == 1
     )

--- a/doc/source/programs/gdaladdo.rst
+++ b/doc/source/programs/gdaladdo.rst
@@ -35,9 +35,16 @@ most supported file formats with one of several downsampling algorithms.
 
 .. option:: -r {nearest|average|rms|gauss|cubic|cubicspline|lanczos|average_magphase|mode}
 
-    Select a resampling algorithm.
+    Select a resampling algorithm. The default is ``nearest``, which is generally not
+    appropriate if sub-pixel accuracy is desired.
 
-    ``nearest`` applies a nearest neighbour (simple sampling) resampler (default)
+    Starting with GDAL 3.9, when refreshing existing TIFF overviews, the previously
+    used method, as noted in the RESAMPLING metadata item of the overview, will
+    be used if :option:`-r` is not specified.
+
+    The available methods are:
+
+    ``nearest`` applies a nearest neighbour (simple sampling) resampler.
 
     ``average`` computes the average of all non-NODATA contributing pixels. Starting with GDAL 3.1, this is a weighted average taking into account properly the weight of source pixels not contributing fully to the target pixel.
 
@@ -131,9 +138,14 @@ most supported file formats with one of several downsampling algorithms.
 
     .. versionadded:: 2.3
 
-        levels are no longer required to build overviews.
+        Levels are no longer required to build overviews.
         In which case, appropriate overview power-of-two factors will be selected
         until the smallest overview is smaller than the value of the -minsize switch.
+
+        Starting with GDAL 3.9, if there are already existing overviews, the
+        corresponding levels will be used to refresh them if no explicit levels
+        are specified.
+
 
 gdaladdo will honour properly NODATA_VALUES tuples (special dataset metadata) so
 that only a given RGB triplet (in case of a RGB image) will be considered as the

--- a/frmts/gtiff/gt_overview.cpp
+++ b/frmts/gtiff/gt_overview.cpp
@@ -207,9 +207,13 @@ void GTIFFBuildOverviewMetadata(const char *pszResampling,
 {
     osMetadata = "<GDALMetadata>";
 
-    if (pszResampling && STARTS_WITH_CI(pszResampling, "AVERAGE_BIT2"))
-        osMetadata += "<Item name=\"RESAMPLING\" sample=\"0\">"
-                      "AVERAGE_BIT2GRAYSCALE</Item>";
+    auto osNormalizedResampling = GDALGetNormalizedOvrResampling(pszResampling);
+    if (!osNormalizedResampling.empty())
+    {
+        osMetadata += "<Item name=\"RESAMPLING\" sample=\"0\">";
+        osMetadata += osNormalizedResampling;
+        osMetadata += "</Item>";
+    }
 
     if (poBaseDS->GetMetadataItem("INTERNAL_MASK_FLAGS_1"))
     {

--- a/frmts/gtiff/gtiffdataset_write.cpp
+++ b/frmts/gtiff/gtiffdataset_write.cpp
@@ -3232,6 +3232,20 @@ CPLErr GTiffDataset::IBuildOverviews(const char *pszResampling, int nOverviews,
                                                         poBand->GetXSize(),
                                                         poBand->GetYSize()))
                     {
+                        if (iBand == 0)
+                        {
+                            const auto osNewResampling =
+                                GDALGetNormalizedOvrResampling(pszResampling);
+                            const char *pszExistingResampling =
+                                poOverview->GetMetadataItem("RESAMPLING");
+                            if (pszExistingResampling &&
+                                pszExistingResampling != osNewResampling)
+                            {
+                                poOverview->SetMetadataItem(
+                                    "RESAMPLING", osNewResampling.c_str());
+                            }
+                        }
+
                         abAlreadyUsedOverviewBand[j] = true;
                         CPLAssert(iCurOverview < poBand->GetOverviewCount());
                         papapoOverviewBands[iBand][iCurOverview] = poOverview;
@@ -3301,6 +3315,20 @@ CPLErr GTiffDataset::IBuildOverviews(const char *pszResampling, int nOverviews,
                                                         poBand->GetXSize(),
                                                         poBand->GetYSize()))
                     {
+                        if (iBand == 0)
+                        {
+                            const auto osNewResampling =
+                                GDALGetNormalizedOvrResampling(pszResampling);
+                            const char *pszExistingResampling =
+                                poOverview->GetMetadataItem("RESAMPLING");
+                            if (pszExistingResampling &&
+                                pszExistingResampling != osNewResampling)
+                            {
+                                poOverview->SetMetadataItem(
+                                    "RESAMPLING", osNewResampling.c_str());
+                            }
+                        }
+
                         abAlreadyUsedOverviewBand[j] = true;
                         CPLAssert(nNewOverviews < poBand->GetOverviewCount());
                         papoOverviewBands[nNewOverviews++] = poOverview;

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -3871,6 +3871,8 @@ typedef CPLErr (*GDALResampleFunction)(
 GDALResampleFunction GDALGetResampleFunction(const char *pszResampling,
                                              int *pnRadius);
 
+std::string GDALGetNormalizedOvrResampling(const char *pszResampling);
+
 GDALDataType GDALGetOvrWorkDataType(const char *pszResampling,
                                     GDALDataType eSrcDataType);
 


### PR DESCRIPTION
- GTiff overviews: generalize saving resampling method in a RESAMPLING metadata item
- gdaladdo: reuse previous resampling method (from GTiff RESAMPLING metadata item) if not specifying -r and overview levels if not specifying them
