### PR TITLE
[Backport release/3.8] gdalbuildvrt: in -separate mode, only use ComplexSource if needed

### DIFF
--- a/apps/gdalbuildvrt_lib.cpp
+++ b/apps/gdalbuildvrt_lib.cpp
@@ -1088,7 +1088,9 @@ void VRTBuilder::CreateVRTSeparate(VRTDatasetH hVRTDS)
             }
 
             VRTSimpleSource *poSimpleSource;
-            if (bAllowSrcNoData)
+            if (bAllowSrcNoData &&
+                (nSrcNoDataCount > 0 ||
+                 psDatasetProperties->abHasNoData[nSrcBandIdx]))
             {
                 auto poComplexSource = new VRTComplexSource();
                 poSimpleSource = poComplexSource;
@@ -1101,7 +1103,7 @@ void VRTBuilder::CreateVRTSeparate(VRTDatasetH hVRTDS)
                         poComplexSource->SetNoDataValue(
                             padfSrcNoData[nSrcNoDataCount - 1]);
                 }
-                else if (psDatasetProperties->abHasNoData[nSrcBandIdx])
+                else /* if (psDatasetProperties->abHasNoData[nSrcBandIdx]) */
                 {
                     poComplexSource->SetNoDataValue(
                         psDatasetProperties->adfNoDataValues[nSrcBandIdx]);


### PR DESCRIPTION
Backport #8986
 **Authored by:** @rouault