### PR TITLE
GPKG: disable by default multi-threaded ArrowArray interface. Make it…

### DIFF
--- a/doc/source/drivers/vector/gpkg.rst
+++ b/doc/source/drivers/vector/gpkg.rst
@@ -456,6 +456,19 @@ available:
 
 - :copy-config:`SQLITE_USE_OGR_VFS`
 
+- .. config:: OGR_GPKG_NUM_THREADS
+     :since: 3.8.3
+
+     Can be set to an integer or ``ALL_CPUS``.
+     This is the number of threads used when reading tables through the
+     ArrowArray interface, when no filter is applied and when features have
+     consecutive feature ID numbering.
+     Note that setting this value too high is not recommended: a value of 4 is
+     close to the optimal.
+     Although note that at time of writing, this option might not be fully
+     reliable (cf  https://lists.osgeo.org/pipermail/gdal-dev/2024-January/058177.html)
+
+
 Metadata
 --------
 

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -8416,9 +8416,9 @@ int OGRGeoPackageTableLayer::GetNextArrowArray(struct ArrowArrayStream *stream,
     const auto GetThreadsAvailable = []()
     {
         const char *pszMaxThreads =
-            CPLGetConfigOption("GDAL_NUM_THREADS", nullptr);
+            CPLGetConfigOption("OGR_GPKG_NUM_THREADS", nullptr);
         if (pszMaxThreads == nullptr)
-            return std::min(4, CPLGetNumCPUs());
+            return 0;
         else if (EQUAL(pszMaxThreads, "ALL_CPUS"))
             return CPLGetNumCPUs();
         else


### PR DESCRIPTION
… opt-in with the OGR_GPKG_NUM_THREADS config option

Cf https://lists.osgeo.org/pipermail/gdal-dev/2024-January/058177.html