### PR TITLE
[Backport release/3.8] GPKG: disable by default multi-threaded ArrowArray interface. Make it…

### DIFF
--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -8081,6 +8081,46 @@ def test_ogr_gpkg_arrow_stream_numpy(tmp_vsimem):
 
 
 ###############################################################################
+# Test GetArrowStreamAsNumPy() and multi-threading
+
+
+def test_ogr_gpkg_arrow_stream_numpy_multi_threading(tmp_vsimem):
+    pytest.importorskip("osgeo.gdal_array")
+    pytest.importorskip("numpy")
+
+    filename = tmp_vsimem / "test.gpkg"
+
+    ds = gdal.GetDriverByName("GPKG").Create(filename, 0, 0, 0, gdal.GDT_Unknown)
+    lyr = ds.CreateLayer("test", geom_type=ogr.wkbPoint)
+
+    for i in range(1000):
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f.SetGeometryDirectly(ogr.CreateGeometryFromWkt(f"POINT({i} {i})"))
+        lyr.CreateFeature(f)
+
+    ds = None
+
+    ds = ogr.Open(filename)
+    lyr = ds.GetLayer(0)
+    num_threads = max(2, min(gdal.GetNumCPUs(), 4))
+    with gdaltest.config_option("OGR_GPKG_NUM_THREADS", str(num_threads)):
+        stream = lyr.GetArrowStreamAsNumPy(
+            options=["USE_MASKED_ARRAYS=NO", "MAX_FEATURES_IN_BATCH=10"]
+        )
+        batches = [batch for batch in stream]
+        assert len(batches) == 100
+        i = 0
+        for batch in batches:
+            for wkb in batch["geom"]:
+                assert (
+                    ogr.CreateGeometryFromWkb(wkb).ExportToIsoWkt()
+                    == f"POINT ({i} {i})"
+                )
+                i += 1
+        assert i == 1000
+
+
+###############################################################################
 # Test Arrow interface with bool fields
 
 

--- a/doc/source/drivers/vector/gpkg.rst
+++ b/doc/source/drivers/vector/gpkg.rst
@@ -456,6 +456,19 @@ available:
 
 - :copy-config:`SQLITE_USE_OGR_VFS`
 
+- .. config:: OGR_GPKG_NUM_THREADS
+     :since: 3.8.3
+
+     Can be set to an integer or ``ALL_CPUS``.
+     This is the number of threads used when reading tables through the
+     ArrowArray interface, when no filter is applied and when features have
+     consecutive feature ID numbering.
+     Note that setting this value too high is not recommended: a value of 4 is
+     close to the optimal.
+     Although note that at time of writing, this option might not be fully
+     reliable (cf  https://lists.osgeo.org/pipermail/gdal-dev/2024-January/058177.html)
+
+
 Metadata
 --------
 

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -8438,9 +8438,9 @@ int OGRGeoPackageTableLayer::GetNextArrowArray(struct ArrowArrayStream *stream,
     const auto GetThreadsAvailable = []()
     {
         const char *pszMaxThreads =
-            CPLGetConfigOption("GDAL_NUM_THREADS", nullptr);
+            CPLGetConfigOption("OGR_GPKG_NUM_THREADS", nullptr);
         if (pszMaxThreads == nullptr)
-            return std::min(4, CPLGetNumCPUs());
+            return 0;
         else if (EQUAL(pszMaxThreads, "ALL_CPUS"))
             return CPLGetNumCPUs();
         else


### PR DESCRIPTION
Backport #9018
 **Authored by:** @rouault