### PR TITLE
[Backport release/3.8] Internal libjson: resync random_seed.c with upstream, and use getrandom() implementation when available (fixes #9024)

### DIFF
--- a/cmake/helpers/configure.cmake
+++ b/cmake/helpers/configure.cmake
@@ -144,6 +144,12 @@ else ()
   check_function_exists(getrlimit HAVE_GETRLIMIT)
   check_symbol_exists(RLIMIT_AS "sys/resource.h" HAVE_RLIMIT_AS)
 
+  # For internal libjson-c
+  check_include_file(sys/random.h HAVE_SYS_RANDOM_H)
+  if (HAVE_SYS_RANDOM_H)
+    check_symbol_exists(getrandom "sys/random.h" HAVE_GETRANDOM)
+  endif()
+
   check_function_exists(ftell64 HAVE_FTELL64)
   if (HAVE_FTELL64)
     set(VSI_FTELL64 "ftell64")

--- a/cmake/template/cpl_config.h.in
+++ b/cmake/template/cpl_config.h.in
@@ -70,6 +70,12 @@
 /* Define to 1 if you have the 5 args `mremap' function. */
 #cmakedefine HAVE_5ARGS_MREMAP 1
 
+/* Define to 1 if you have the <sys/random.h> header file. */
+#cmakedefine HAVE_SYS_RANDOM_H 1
+
+/* Define to 1 if you have the `getrandom' function. */
+#cmakedefine HAVE_GETRANDOM 1
+
 /* Define to 1 if you have the `getrlimit' function. */
 #cmakedefine HAVE_GETRLIMIT 1
 

--- a/ogr/ogrsf_frmts/geojson/libjson/random_seed.c
+++ b/ogr/ogrsf_frmts/geojson/libjson/random_seed.c
@@ -13,8 +13,22 @@
 #include "config.h"
 #include "strerror_override.h"
 #include <stdio.h>
+#include <stdlib.h>
+#ifdef HAVE_BSD_STDLIB_H
+#include <bsd/stdlib.h>
+#endif
 
 #define DEBUG_SEED(s)
+
+#if defined(__APPLE__) || defined(__unix__) || defined(__linux__)
+#define HAVE_DEV_RANDOM 1
+#endif
+
+#ifdef HAVE_ARC4RANDOM
+#undef HAVE_GETRANDOM
+#undef HAVE_DEV_RANDOM
+#undef HAVE_CRYPTGENRANDOM
+#endif
 
 #if defined ENABLE_RDRAND
 
@@ -155,9 +169,45 @@ retry:
 
 #endif /* defined ENABLE_RDRAND */
 
-/* has_dev_urandom */
+#ifdef HAVE_GETRANDOM
 
-#if defined(__APPLE__) || defined(__unix__) || defined(__linux__)
+#include <stdlib.h>
+#ifdef HAVE_SYS_RANDOM_H
+#include <sys/random.h>
+#endif
+
+static int get_getrandom_seed(int *seed)
+{
+	DEBUG_SEED("get_getrandom_seed");
+
+	ssize_t ret;
+
+	do
+	{
+		ret = getrandom(seed, sizeof(*seed), GRND_NONBLOCK);
+	} while ((ret == -1) && (errno == EINTR));
+
+	if (ret == -1)
+	{
+		if (errno == ENOSYS) /* syscall not available in kernel */
+			return -1;
+		if (errno == EAGAIN) /* entropy not yet initialized */
+			return -1;
+
+		fprintf(stderr, "error from getrandom(): %s", strerror(errno));
+		return -1;
+	}
+
+	if (ret != sizeof(*seed))
+		return -1;
+
+	return 0;
+}
+#endif /* defined HAVE_GETRANDOM */
+
+/* get_dev_random_seed */
+
+#ifdef HAVE_DEV_RANDOM
 
 #include <fcntl.h>
 #include <string.h>
@@ -167,43 +217,36 @@ retry:
 #include <stdlib.h>
 #include <sys/stat.h>
 
-#define HAVE_DEV_RANDOM 1
-
 static const char *dev_random_file = "/dev/urandom";
 
-static int has_dev_urandom(void)
-{
-	struct stat buf;
-	if (stat(dev_random_file, &buf))
-	{
-		return 0;
-	}
-	return ((buf.st_mode & S_IFCHR) != 0);
-}
-
-/* get_dev_random_seed */
-
-static int get_dev_random_seed(void)
+static int get_dev_random_seed(int *seed)
 {
 	DEBUG_SEED("get_dev_random_seed");
+
+	struct stat buf;
+	if (stat(dev_random_file, &buf))
+		return -1;
+	if ((buf.st_mode & S_IFCHR) == 0)
+		return -1;
 
 	int fd = open(dev_random_file, O_RDONLY);
 	if (fd < 0)
 	{
 		fprintf(stderr, "error opening %s: %s", dev_random_file, strerror(errno));
-		exit(1);
+		return -1;
 	}
 
-	int r;
-	ssize_t nread = read(fd, &r, sizeof(r));
-	if (nread != sizeof(r))
-	{
-		fprintf(stderr, "error short read %s: %s", dev_random_file, strerror(errno));
-		exit(1);
-	}
+	ssize_t nread = read(fd, seed, sizeof(*seed));
 
 	close(fd);
-	return r;
+
+	if (nread != sizeof(*seed))
+	{
+		fprintf(stderr, "error short read %s: %s", dev_random_file, strerror(errno));
+		return -1;
+	}
+
+	return 0;
 }
 
 #endif
@@ -226,43 +269,41 @@ static int get_dev_random_seed(void)
 #pragma comment(lib, "advapi32.lib")
 #endif
 
-static int get_time_seed(void);
-
-static int get_cryptgenrandom_seed(void)
+static int get_cryptgenrandom_seed(int *seed)
 {
 	HCRYPTPROV hProvider = 0;
 	DWORD dwFlags = CRYPT_VERIFYCONTEXT;
-	int r;
 
 	DEBUG_SEED("get_cryptgenrandom_seed");
 
 	/* WinNT 4 and Win98 do no support CRYPT_SILENT */
-	/* if (LOBYTE(LOWORD(GetVersion())) > 4) */
+	if (LOBYTE(LOWORD(GetVersion())) > 4)
 		dwFlags |= CRYPT_SILENT;
 
 	if (!CryptAcquireContextA(&hProvider, 0, 0, PROV_RSA_FULL, dwFlags))
 	{
 		fprintf(stderr, "error CryptAcquireContextA 0x%08lx", GetLastError());
-		r = get_time_seed();
+		return -1;
 	}
 	else
 	{
-		BOOL ret = CryptGenRandom(hProvider, sizeof(r), (BYTE*)&r);
+		BOOL ret = CryptGenRandom(hProvider, sizeof(*seed), (BYTE *)seed);
 		CryptReleaseContext(hProvider, 0);
 		if (!ret)
 		{
 			fprintf(stderr, "error CryptGenRandom 0x%08lx", GetLastError());
-			r = get_time_seed();
+			return -1;
 		}
 	}
 
-	return r;
+	return 0;
 }
 
 #endif
 
 /* get_time_seed */
 
+#ifndef HAVE_ARC4RANDOM
 #include <time.h>
 
 static int get_time_seed(void)
@@ -270,8 +311,9 @@ static int get_time_seed(void)
 	DEBUG_SEED("get_time_seed");
 
 	/* coverity[store_truncates_time_t] */
-	return (int)time(NULL) * 433494437;
+	return (unsigned)time(NULL) * 433494437;
 }
+#endif
 
 /* json_c_get_random_seed */
 
@@ -284,12 +326,31 @@ int json_c_get_random_seed(void)
 	if (has_rdrand())
 		return get_rdrand_seed();
 #endif
+#ifdef HAVE_ARC4RANDOM
+	/* arc4random never fails, so use it if it's available */
+	return arc4random();
+#else
+#ifdef HAVE_GETRANDOM
+	{
+		int seed = 0;
+		if (get_getrandom_seed(&seed) == 0)
+			return seed;
+	}
+#endif
 #if defined HAVE_DEV_RANDOM && HAVE_DEV_RANDOM
-	if (has_dev_urandom())
-		return get_dev_random_seed();
+	{
+		int seed = 0;
+		if (get_dev_random_seed(&seed) == 0)
+			return seed;
+	}
 #endif
 #if defined HAVE_CRYPTGENRANDOM && HAVE_CRYPTGENRANDOM
-	return get_cryptgenrandom_seed();
+	{
+		int seed = 0;
+		if (get_cryptgenrandom_seed(&seed) == 0)
+			return seed;
+	}
 #endif
 	return get_time_seed();
+#endif /* !HAVE_ARC4RANDOM */
 }


### PR DESCRIPTION
Backport #9027
 **Authored by:** @rouault