### PR TITLE
Added tiledb metadata fields to easily tag array type

### DIFF
--- a/autotest/gdrivers/tiledb_write.py
+++ b/autotest/gdrivers/tiledb_write.py
@@ -50,6 +50,7 @@ def test_tiledb_write_complex(mode):
     )
     meta = new_ds.GetMetadata("IMAGE_STRUCTURE")
     assert meta["INTERLEAVE"] == mode, "Did not get expected mode"
+    assert meta["DATASET_TYPE"] == "raster", "Did not get expected dataset type"
 
     bnd = new_ds.GetRasterBand(1)
     assert bnd.Checksum() == 5028, "Did not get expected checksum on still-open file"
@@ -72,6 +73,7 @@ def test_tiledb_write_custom_blocksize(mode):
     )
     meta = new_ds.GetMetadata("IMAGE_STRUCTURE")
     assert meta["INTERLEAVE"] == mode, "Did not get expected mode"
+    assert meta["DATASET_TYPE"] == "raster", "Did not get expected dataset type"
 
     bnd = new_ds.GetRasterBand(1)
     assert bnd.Checksum() == 50054, "Did not get expected checksum on still-open file"
@@ -97,6 +99,7 @@ def test_tiledb_write_update(mode):
     new_ds.GetRasterBand(1).WriteArray(np.zeros((20, 20)))
     meta = new_ds.GetMetadata("IMAGE_STRUCTURE")
     assert meta["INTERLEAVE"] == mode, "Did not get expected mode"
+    assert meta["DATASET_TYPE"] == "raster", "Did not get expected dataset type"
     del new_ds
 
     update_ds = gdal.Open("tmp/tiledb_update", gdal.GA_Update)
@@ -125,6 +128,7 @@ def test_tiledb_write_rgb(mode):
     new_ds = gdaltest.tiledb_drv.CreateCopy("tmp/tiledb_rgb", src_ds, options=options)
     meta = new_ds.GetMetadata("IMAGE_STRUCTURE")
     assert meta["INTERLEAVE"] == mode, "Did not get expected mode"
+    assert meta["DATASET_TYPE"] == "raster", "Did not get expected dataset type"
     assert new_ds.RasterCount == 3, "Did not get expected band count"
     bnd = new_ds.GetRasterBand(2)
     assert bnd.Checksum() == 21053, "Did not get expected checksum on still-open file"
@@ -164,6 +168,7 @@ def test_tiledb_write_attributes(mode):
     assert new_ds.RasterCount == src_ds.RasterCount
     meta = new_ds.GetMetadata("IMAGE_STRUCTURE")
     assert meta["INTERLEAVE"] == mode, "Did not get expected mode"
+    assert meta["DATASET_TYPE"] == "raster", "Did not get expected dataset type"
 
     with gdaltest.disable_exceptions():
         new_ds = None
@@ -242,6 +247,7 @@ def test_tiledb_write_band_meta(mode):
 
     meta = new_ds.GetMetadata("IMAGE_STRUCTURE")
     assert meta["INTERLEAVE"] == mode, "Did not get expected mode"
+    assert meta["DATASET_TYPE"] == "raster", "Did not get expected dataset type"
 
     bnd = new_ds.GetRasterBand(1)
     bnd.SetMetadataItem("Item", "Value")
@@ -273,6 +279,8 @@ def test_tiledb_write_history(mode):
 
     meta = new_ds.GetMetadata("IMAGE_STRUCTURE")
     assert meta["INTERLEAVE"] == mode, "Did not get expected mode"
+    assert meta["DATASET_TYPE"] == "raster", "Did not get expected dataset type"
+
     del new_ds
 
     ts = [2, 3, 4, 5]

--- a/autotest/ogr/ogr_tiledb.py
+++ b/autotest/ogr/ogr_tiledb.py
@@ -748,6 +748,7 @@ def test_ogr_tiledb_basic(nullable, batch_size):
     md = tiledb_md["array"]["metadata"]
     del md["CRS"]
     assert md == {
+        "dataset_type": {"type": "STRING_UTF8", "value": "geometry"},
         "FEATURE_COUNT": {"type": "INT64", "value": 3},
         "FID_ATTRIBUTE_NAME": {"type": "STRING_UTF8", "value": "FID"},
         "GEOMETRY_ATTRIBUTE_NAME": {"type": "STRING_UTF8", "value": "wkb_geometry"},

--- a/frmts/tiledb/tiledbdense.cpp
+++ b/frmts/tiledb/tiledbdense.cpp
@@ -37,6 +37,8 @@
 #pragma warning(disable : 4996) /* XXXX was deprecated */
 #endif
 
+constexpr const char *RASTER_DATASET_TYPE = "raster";
+
 /************************************************************************/
 /* ==================================================================== */
 /*                            TileDBRasterBand                          */
@@ -795,6 +797,9 @@ CPLErr TileDBRasterDataset::TrySaveXML()
         }
         else
         {
+            m_array->put_metadata("dataset_type", TILEDB_STRING_UTF8,
+                                  static_cast<int>(strlen(RASTER_DATASET_TYPE)),
+                                  RASTER_DATASET_TYPE);
             m_array->put_metadata(GDAL_ATTRIBUTE_NAME, TILEDB_UINT8,
                                   static_cast<int>(strlen(pszTree)), pszTree);
         }
@@ -2230,6 +2235,8 @@ GDALDataset *TileDBRasterDataset::Create(const char *pszFilename, int nXSize,
                             CPLString().Printf("%d", poDS->nRasterYSize));
         papszImageStruct = CSLAddNameValue(papszImageStruct, "INTERLEAVE",
                                            index_type_name(poDS->eIndexMode));
+        papszImageStruct = CSLAddNameValue(papszImageStruct, "DATASET_TYPE",
+                                           RASTER_DATASET_TYPE);
 
         if (poDS->lpoAttributeDS.size() > 0)
         {

--- a/frmts/tiledb/tiledbsparse.cpp
+++ b/frmts/tiledb/tiledbsparse.cpp
@@ -38,6 +38,7 @@
 #include <limits>
 
 constexpr int SECONDS_PER_DAY = 3600 * 24;
+constexpr const char *GEOMETRY_DATASET_TYPE = "geometry";
 
 /************************************************************************/
 /* ==================================================================== */
@@ -3745,6 +3746,10 @@ void OGRTileDBLayer::InitializeSchemaAndArray()
                                   static_cast<int>(strlen(pszGeomColName)),
                                   pszGeomColName);
         }
+
+        m_array->put_metadata("dataset_type", TILEDB_STRING_UTF8,
+                              static_cast<int>(strlen(GEOMETRY_DATASET_TYPE)),
+                              GEOMETRY_DATASET_TYPE);
 
         auto poSRS = GetSpatialRef();
         if (poSRS)


### PR DESCRIPTION
## What does this PR do?

TileDB is a multi-modal array database with applications outside of geospatial, this PR adds tagging to the array so that the array can be easily recognized by other TileDB client libraries. Currently `raster`, `geometry` and `pointcloud` are used for geospatial array tags.

## What are related issues/pull requests?

None within GDAL.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed