### PR TITLE
CSV: do not quote numeric fields even if STRING_QUOTING=ALWAYS (3.8.1 regression) 

### DIFF
--- a/autotest/ogr/ogr_csv.py
+++ b/autotest/ogr/ogr_csv.py
@@ -2633,7 +2633,7 @@ def test_ogr_csv_string_quoting_always(tmp_vsimem):
     data = gdal.VSIFReadL(1, 10000, f).decode("ascii")
     gdal.VSIFCloseL(f)
 
-    assert data.startswith('"AREA","EAS_ID","PRFEDEA"\n"215229.266","168","35043411"')
+    assert data.startswith('"AREA","EAS_ID","PRFEDEA"\n215229.266,168,"35043411"')
 
     ds = gdal.OpenEx(
         tmp_vsimem / "ogr_csv_string_quoting_always.csv",
@@ -2653,7 +2653,7 @@ def test_ogr_csv_string_quoting_always(tmp_vsimem):
     gdal.VSIFCloseL(f)
 
     assert data.startswith(
-        '"AREA","EAS_ID","PRFEDEA"\n"215229.266","168","35043411"\n"247328.172","179","35043423"'
+        '"AREA","EAS_ID","PRFEDEA"\n215229.266,168,"35043411"\n247328.172,179,"35043423"'
     )
 
 

--- a/ogr/ogrsf_frmts/csv/ogrcsvlayer.cpp
+++ b/ogr/ogrsf_frmts/csv/ogrcsvlayer.cpp
@@ -2309,9 +2309,8 @@ OGRErr OGRCSVLayer::ICreateFeature(OGRFeature *poNewFeature)
         {
             const OGRFieldType eType(
                 poFeatureDefn->GetFieldDefn(iField)->GetType());
-            if ((eType == OFTReal || eType == OFTInteger ||
-                 eType == OFTInteger64) &&
-                m_eStringQuoting != StringQuoting::ALWAYS)
+            if (eType == OFTReal || eType == OFTInteger ||
+                eType == OFTInteger64)
             {
                 if (poFeatureDefn->GetFieldDefn(iField)->GetSubType() ==
                         OFSTFloat32 &&


### PR DESCRIPTION
(fixes https://github.com/qgis/QGIS/issues/55808)
