### PR TITLE
Sentinel2: include 10m AOT and WVP bands in 10m subdataset

### DIFF
--- a/autotest/gdrivers/sentinel2.py
+++ b/autotest/gdrivers/sentinel2.py
@@ -1763,7 +1763,7 @@ def test_sentinel2_l2a_1():
 
 
 ###############################################################################
-# Test opening a L21 subdataset on the 60m bands
+# Test opening a L2A subdataset on the 60m bands
 
 
 def test_sentinel2_l2a_2():
@@ -2056,7 +2056,7 @@ def test_sentinel2_l2a_4():
         pytest.fail()
 
     expected_md = {
-        "SUBDATASET_1_DESC": "Bands B2, B3, B4, B8 with 10m resolution, UTM 34N",
+        "SUBDATASET_1_DESC": "Bands B2, B3, B4, B8, AOT, WVP with 10m resolution, UTM 34N",
         "SUBDATASET_1_NAME": "SENTINEL2_L2A:data/sentinel2/fake_l2a_MSIL2A/S2A_MSIL2A_20180818T094031_N0208_R036_T34VFJ_20180818T120345.SAFE/MTD_MSIL2A.xml:10m:EPSG_32634",
         "SUBDATASET_2_DESC": "Bands B5, B6, B7, B8A, B11, B12, AOT, CLD, SCL, SNW, WVP with 20m resolution, UTM 34N",
         "SUBDATASET_2_NAME": "SENTINEL2_L2A:data/sentinel2/fake_l2a_MSIL2A/S2A_MSIL2A_20180818T094031_N0208_R036_T34VFJ_20180818T120345.SAFE/MTD_MSIL2A.xml:20m:EPSG_32634",
@@ -2278,7 +2278,7 @@ def test_sentinel2_l2a_6():
         pytest.fail()
 
     expected_md = {
-        "SUBDATASET_1_DESC": "Bands B2, B3, B4, B8 with 10m resolution, UTM 34N",
+        "SUBDATASET_1_DESC": "Bands B2, B3, B4, B8, AOT, WVP with 10m resolution, UTM 34N",
         "SUBDATASET_1_NAME": "SENTINEL2_L2A:data/sentinel2/fake_l2a_MSIL2Ap/S2A_MSIL2A_20170823T094031_N0205_R036_T34VFJ_20170823T094252.SAFE/MTD_MSIL2A.xml:10m:EPSG_32634",
         "SUBDATASET_2_DESC": "Bands B5, B6, B7, B8A, B11, B12, AOT, CLD, SCL, SNW, WVP with 20m resolution, UTM 34N",
         "SUBDATASET_2_NAME": "SENTINEL2_L2A:data/sentinel2/fake_l2a_MSIL2Ap/S2A_MSIL2A_20170823T094031_N0205_R036_T34VFJ_20170823T094252.SAFE/MTD_MSIL2A.xml:20m:EPSG_32634",
@@ -3007,7 +3007,7 @@ def test_sentinel2_l2a_processing_baseline_5_09__1():
     got_gt = ds.GetGeoTransform()
     assert got_gt == (300000.0, 10.0, 0.0, 6100020.0, 0.0, -10.0)
 
-    assert ds.RasterCount == 4
+    assert ds.RasterCount == 6
 
     assert ds.GetMetadata("xml:SENTINEL2") is not None
 

--- a/doc/source/drivers/raster/sentinel2.rst
+++ b/doc/source/drivers/raster/sentinel2.rst
@@ -121,13 +121,15 @@ When opening the main metadata .xml file, the driver will typically
 expose 4 sub-datasets:
 
 -  one for the 4 native 10m bands, and L2A specific bands (AOT and WVP)
--  one for the 6 native 20m bands, plus the 10m bands, except B8,
-   resampled to 20m, and L2A specific bands (AOT, WVP, SCL, CLD and
+-  one for the 6 native 20m bands, and L2A specific bands (AOT, WVP, SCL, CLD and
    SNW),
--  one for the 3 native 60m bands, plus the 10m&20m bands, except B8,
-   resampled to 60m, and L2A specific bands (AOT, WVP, SCL, CLD and
+-  one for the B01 and B09 native 60m bands, and L2A specific bands (AOT, WVP, SCL, CLD and
    SNW),
--  one for a preview of the R,G,B bands at a 320m resolution
+-  one for a true-color image (TCI) of the R,G,B bands at a 10m resolution,
+   for the "compact" L2A product formulation (or a preview of the R,G,B bands
+   at a 320m resolution for the older L2A product formulation). The TCI
+   products at resolution 20m and 60m are not exposed, as they are just
+   subsampled versions of the 10m product.
 
 All tiles of same resolution and projection are mosaiced together. If a
 product spans over several UTM zones, they will be exposed as separate

--- a/frmts/sentinel2/sentinel2dataset.cpp
+++ b/frmts/sentinel2/sentinel2dataset.cpp
@@ -126,8 +126,10 @@ static const char *L2A_BandDescription_SNW =
     "for high confidence snow/ice";
 
 static const SENTINEL2_L2A_BandDescription asL2ABandDesc[] = {
+    {"AOT", L2A_BandDescription_AOT, 10, TL_IMG_DATA_Rxxm},
     {"AOT", L2A_BandDescription_AOT, 20, TL_IMG_DATA_Rxxm},
     {"AOT", L2A_BandDescription_AOT, 60, TL_IMG_DATA_Rxxm},
+    {"WVP", L2A_BandDescription_WVP, 10, TL_IMG_DATA_Rxxm},
     {"WVP", L2A_BandDescription_WVP, 20, TL_IMG_DATA_Rxxm},
     {"WVP", L2A_BandDescription_WVP, 60, TL_IMG_DATA_Rxxm},
     {"SCL", L2A_BandDescription_SCL, 20, TL_IMG_DATA_Rxxm},


### PR DESCRIPTION
also: doc: adjust description of content of L2A subdatasets (fixes #9066)

@an-ivanov you contributed in #2024 support for L2A for SAFE_COMPACT format. Is there any reason you didn't include AOT and WVP for the 10m subdataset? They were present in the test dataset of our autotest suite, as well as in the dataset of #9066, hence my attempt at adding them here