### PR TITLE
OGRCoordinateTransformation::Transform(): change nCount parameter to size_t, and optimize performance of axis swapping

### DIFF
--- a/apps/gdal_footprint_lib.cpp
+++ b/apps/gdal_footprint_lib.cpp
@@ -560,10 +560,10 @@ class GeoTransformCoordinateTransformation final
         return nullptr;
     }
 
-    int Transform(int nCount, double *x, double *y, double * /* z */,
+    int Transform(size_t nCount, double *x, double *y, double * /* z */,
                   double * /* t */, int *pabSuccess) override
     {
-        for (int i = 0; i < nCount; ++i)
+        for (size_t i = 0; i < nCount; ++i)
         {
             const double X = m_gt[0] + x[i] * m_gt[1] + y[i] * m_gt[2];
             const double Y = m_gt[3] + x[i] * m_gt[4] + y[i] * m_gt[5];

--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -4700,11 +4700,14 @@ class CutlineTransformer : public OGRCoordinateTransformation
         GDALDestroyTransformer(hSrcImageTransformer);
     }
 
-    virtual int Transform(int nCount, double *x, double *y, double *z,
+    virtual int Transform(size_t nCount, double *x, double *y, double *z,
                           double * /* t */, int *pabSuccess) override
     {
-        return GDALGenImgProjTransform(hSrcImageTransformer, TRUE, nCount, x, y,
-                                       z, pabSuccess);
+        CPLAssert(nCount <=
+                  static_cast<size_t>(std::numeric_limits<int>::max()));
+        return GDALGenImgProjTransform(hSrcImageTransformer, TRUE,
+                                       static_cast<int>(nCount), x, y, z,
+                                       pabSuccess);
     }
 
     virtual OGRCoordinateTransformation *Clone() const override

--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -39,6 +39,7 @@
 #include <cstring>
 
 #include <algorithm>
+#include <limits>
 #include <map>
 #include <memory>
 #include <set>
@@ -1127,14 +1128,18 @@ class GCPCoordTransformation : public OGRCoordinateTransformation
         return poSRS;
     }
 
-    virtual int Transform(int nCount, double *x, double *y, double *z,
+    virtual int Transform(size_t nCount, double *x, double *y, double *z,
                           double * /* t */, int *pabSuccess) override
     {
+        CPLAssert(nCount <=
+                  static_cast<size_t>(std::numeric_limits<int>::max()));
         if (bUseTPS)
-            return GDALTPSTransform(hTransformArg, FALSE, nCount, x, y, z,
+            return GDALTPSTransform(hTransformArg, FALSE,
+                                    static_cast<int>(nCount), x, y, z,
                                     pabSuccess);
         else
-            return GDALGCPTransform(hTransformArg, FALSE, nCount, x, y, z,
+            return GDALGCPTransform(hTransformArg, FALSE,
+                                    static_cast<int>(nCount), x, y, z,
                                     pabSuccess);
     }
 
@@ -1214,7 +1219,7 @@ class CompositeCT : public OGRCoordinateTransformation
             poCT2->SetEmitErrors(bEmitErrors);
     }
 
-    virtual int Transform(int nCount, double *x, double *y, double *z,
+    virtual int Transform(size_t nCount, double *x, double *y, double *z,
                           double *t, int *pabSuccess) override
     {
         int nResult = TRUE;
@@ -1280,10 +1285,10 @@ class AxisMappingCoordinateTransformation : public OGRCoordinateTransformation
         return nullptr;
     }
 
-    virtual int Transform(int nCount, double *x, double *y, double * /*z*/,
+    virtual int Transform(size_t nCount, double *x, double *y, double * /*z*/,
                           double * /*t*/, int *pabSuccess) override
     {
-        for (int i = 0; i < nCount; i++)
+        for (size_t i = 0; i < nCount; i++)
         {
             if (pabSuccess)
                 pabSuccess[i] = true;

--- a/autotest/gcore/multidim.py
+++ b/autotest/gcore/multidim.py
@@ -286,7 +286,7 @@ def test_multidim_getresampled_3d():
     assert attr.Write(1) == gdal.CE_None
 
     srs = ds.GetSpatialRef().Clone()
-    srs.SetDataAxisToSRSAxisMapping([1, 2])
+    srs.SetDataAxisToSRSAxisMapping([2, 3])
     ar.SetSpatialRef(srs)
     for i in range(ds.RasterCount):
         ar[i].Write(ds.GetRasterBand(i + 1).ReadRaster())

--- a/autotest/osr/osr_ct.py
+++ b/autotest/osr/osr_ct.py
@@ -840,3 +840,61 @@ def test_osr_ct_target_z_axis_reversal():
     assert x == pytest.approx(1)
     assert y == pytest.approx(2)
     assert z == pytest.approx(3)
+
+
+###############################################################################
+# Test effect of SetDataAxisToSRSAxisMapping([-2,1])
+
+
+def test_osr_ct_source_mapping_minus_two_one():
+
+    s = osr.SpatialReference()
+    s.ImportFromEPSG(4326)
+    s.SetDataAxisToSRSAxisMapping([-2, 1])
+
+    t = osr.SpatialReference()
+    t.ImportFromEPSG(4326)
+
+    ct = osr.CoordinateTransformation(s, t)
+    x, y, _ = ct.TransformPoint(10, 20, 0)
+    assert x == pytest.approx(-20)
+    assert y == pytest.approx(10)
+
+
+###############################################################################
+# Test effect of SetDataAxisToSRSAxisMapping([-2,1])
+
+
+def test_osr_ct_target_mapping_minus_two_one():
+
+    s = osr.SpatialReference()
+    s.ImportFromEPSG(4326)
+
+    t = osr.SpatialReference()
+    t.ImportFromEPSG(4326)
+    t.SetDataAxisToSRSAxisMapping([-2, 1])
+
+    ct = osr.CoordinateTransformation(s, t)
+    x, y, _ = ct.TransformPoint(-20, 10, 0)
+    assert x == pytest.approx(10)
+    assert y == pytest.approx(20)
+
+
+###############################################################################
+# Test effect of SetDataAxisToSRSAxisMapping([-2,1])
+
+
+def test_osr_ct_source_and_target_mapping_minus_two_one():
+
+    s = osr.SpatialReference()
+    s.ImportFromEPSG(4326)
+    s.SetDataAxisToSRSAxisMapping([-2, 1])
+
+    t = osr.SpatialReference()
+    t.ImportFromEPSG(4326)
+    t.SetDataAxisToSRSAxisMapping([-2, 1])
+
+    ct = osr.CoordinateTransformation(s, t)
+    x, y, _ = ct.TransformPoint(10, 20, 0)
+    assert x == pytest.approx(10)
+    assert y == pytest.approx(20)

--- a/autotest/osr/osr_ct.py
+++ b/autotest/osr/osr_ct.py
@@ -800,3 +800,43 @@ def test_osr_ct_point_motion_operation():
     assert abs(x - 582395.993) < 1e-3, x
     assert abs(y - 6708035.973) < 1e-3, y
     assert abs(z - 0.060) < 1e-3, z
+
+
+###############################################################################
+# Test effect of SetDataAxisToSRSAxisMapping([1,2,-3])
+
+
+def test_osr_ct_source_z_axis_reversal():
+
+    s = osr.SpatialReference()
+    s.ImportFromEPSG(4979)
+    s.SetDataAxisToSRSAxisMapping([1, 2, -3])
+
+    t = osr.SpatialReference()
+    t.ImportFromEPSG(4979)
+
+    ct = osr.CoordinateTransformation(s, t)
+    x, y, z = ct.TransformPoint(1, 2, -3)
+    assert x == pytest.approx(1)
+    assert y == pytest.approx(2)
+    assert z == pytest.approx(3)
+
+
+###############################################################################
+# Test effect of SetDataAxisToSRSAxisMapping([1,2,-3])
+
+
+def test_osr_ct_target_z_axis_reversal():
+
+    s = osr.SpatialReference()
+    s.ImportFromEPSG(4979)
+
+    t = osr.SpatialReference()
+    t.ImportFromEPSG(4979)
+    t.SetDataAxisToSRSAxisMapping([1, 2, -3])
+
+    ct = osr.CoordinateTransformation(s, t)
+    x, y, z = ct.TransformPoint(1, 2, -3)
+    assert x == pytest.approx(1)
+    assert y == pytest.approx(2)
+    assert z == pytest.approx(3)

--- a/frmts/vrt/vrtwarped.cpp
+++ b/frmts/vrt/vrtwarped.cpp
@@ -651,10 +651,10 @@ class GDALWarpCoordRescaler : public OGRCoordinateTransformation
         return nullptr;
     }
 
-    virtual int Transform(int nCount, double *x, double *y, double * /*z*/,
+    virtual int Transform(size_t nCount, double *x, double *y, double * /*z*/,
                           double * /*t*/, int *pabSuccess) override
     {
-        for (int i = 0; i < nCount; i++)
+        for (size_t i = 0; i < nCount; i++)
         {
             x[i] *= m_dfRatioX;
             y[i] *= m_dfRatioY;

--- a/gcore/gdalmultidim.cpp
+++ b/gcore/gdalmultidim.cpp
@@ -7492,8 +7492,6 @@ class GDALMDArrayResampledDataset final : public GDALPamDataset
                     m = 1;
                 else if (m == static_cast<int>(m_iYDim) + 1)
                     m = 2;
-                else
-                    m = 0;
             }
             m_poSRS->SetDataAxisToSRSAxisMapping(axisMapping);
         }
@@ -8464,8 +8462,6 @@ class GDALDatasetFromArray final : public GDALPamDataset
                     m = 1;
                 else if (m == static_cast<int>(m_iYDim) + 1)
                     m = 2;
-                else
-                    m = 0;
             }
             m_poSRS->SetDataAxisToSRSAxisMapping(axisMapping);
         }

--- a/gcore/gdalmultidim_gltorthorectification.cpp
+++ b/gcore/gdalmultidim_gltorthorectification.cpp
@@ -123,7 +123,7 @@ class GLTOrthoRectifiedArray final : public GDALPamMDArray
         oSRS.importFromEPSG(4326);
         newAr->m_poSRS.reset(oSRS.Clone());
         newAr->m_poSRS->SetDataAxisToSRSAxisMapping(
-            {/*latIdx = */ 0, /* lonIdx = */ 1});
+            {/*latIdx = */ 1, /* lonIdx = */ 2});
         return newAr;
     }
 

--- a/ogr/ogr_spatialref.h
+++ b/ogr/ogr_spatialref.h
@@ -802,7 +802,8 @@ class CPL_DLL OGRCoordinateTransformation
      *
      * This method is the same as the C function OCTTransformEx().
      *
-     * @param nCount number of points to transform.
+     * @param nCount number of points to transform (`size_t` type since 3.9,
+     *               `int` in previous versions).
      * @param x array of nCount X vertices, modified in place. Should not be
      * NULL.
      * @param y array of nCount Y vertices, modified in place. Should not be
@@ -814,7 +815,7 @@ class CPL_DLL OGRCoordinateTransformation
      * @return TRUE if some or all points transform successfully, or FALSE if
      * if none transform.
      */
-    int Transform(int nCount, double *x, double *y, double *z = nullptr,
+    int Transform(size_t nCount, double *x, double *y, double *z = nullptr,
                   int *pabSuccess = nullptr);
 
     /**
@@ -822,7 +823,8 @@ class CPL_DLL OGRCoordinateTransformation
      *
      * This method is the same as the C function OCTTransform4D().
      *
-     * @param nCount number of points to transform.
+     * @param nCount number of points to transform (`size_t` type since 3.9,
+     *               `int` in previous versions).
      * @param x array of nCount X vertices, modified in place. Should not be
      * NULL.
      * @param y array of nCount Y vertices, modified in place. Should not be
@@ -835,7 +837,7 @@ class CPL_DLL OGRCoordinateTransformation
      * @return TRUE if some or all points transform successfully, or FALSE if
      * if none transform.
      */
-    virtual int Transform(int nCount, double *x, double *y, double *z,
+    virtual int Transform(size_t nCount, double *x, double *y, double *z,
                           double *t, int *pabSuccess) = 0;
 
     /**
@@ -843,7 +845,8 @@ class CPL_DLL OGRCoordinateTransformation
      *
      * This method is the same as the C function OCTTransform4DWithErrorCodes().
      *
-     * @param nCount number of points to transform.
+     * @param nCount number of points to transform (`size_t` type since 3.9,
+     *               `int` in previous versions).
      * @param x array of nCount X vertices, modified in place. Should not be
      * NULL.
      * @param y array of nCount Y vertices, modified in place. Should not be
@@ -857,7 +860,7 @@ class CPL_DLL OGRCoordinateTransformation
      * if none transform.
      * @since GDAL 3.3, and PROJ 8 to be able to use PROJ public error codes
      */
-    virtual int TransformWithErrorCodes(int nCount, double *x, double *y,
+    virtual int TransformWithErrorCodes(size_t nCount, double *x, double *y,
                                         double *z, double *t,
                                         int *panErrorCodes);
 

--- a/ogr/ogrct.cpp
+++ b/ogr/ogrct.cpp
@@ -2844,10 +2844,6 @@ int OGRProjCT::TransformWithErrorCodes(size_t nCount, double *x, double *y,
         const auto &mapping = poSRSTarget->GetDataAxisToSRSAxisMapping();
         if (mapping.size() >= 2)
         {
-            if (std::abs(mapping[0]) == 2 && std::abs(mapping[1]) == 1)
-            {
-                std::swap(x, y);
-            }
             const bool bNegateX = mapping[0] < 0;
             if (bNegateX)
             {
@@ -2870,6 +2866,11 @@ int OGRProjCT::TransformWithErrorCodes(size_t nCount, double *x, double *y,
                 {
                     z[i] = -z[i];
                 }
+            }
+
+            if (std::abs(mapping[0]) == 2 && std::abs(mapping[1]) == 1)
+            {
+                std::swap(x, y);
             }
         }
     }

--- a/ogr/ogrsf_frmts/dwg/ogrdwglayer.cpp
+++ b/ogr/ogrsf_frmts/dwg/ogrdwglayer.cpp
@@ -1104,11 +1104,10 @@ class GeometryInsertTransformer : public OGRCoordinateTransformation
         return nullptr;
     }
 
-    int Transform(int nCount, double *x, double *y, double *z = nullptr,
+    int Transform(size_t nCount, double *x, double *y, double *z = nullptr,
                   double * /*t*/ = nullptr, int *pabSuccess = nullptr) override
     {
-        int i;
-        for (i = 0; i < nCount; i++)
+        for (size_t i = 0; i < nCount; i++)
         {
             double dfXNew, dfYNew;
 

--- a/ogr/ogrsf_frmts/dxf/ogr_dxf.h
+++ b/ogr/ogrsf_frmts/dxf/ogr_dxf.h
@@ -179,10 +179,10 @@ class OGRDXFInsertTransformer final : public OGRCoordinateTransformation
         return nullptr;
     }
 
-    int Transform(int nCount, double *x, double *y, double *z, double * /* t */,
-                  int *pabSuccess) override
+    int Transform(size_t nCount, double *x, double *y, double *z,
+                  double * /* t */, int *pabSuccess) override
     {
-        for (int i = 0; i < nCount; i++)
+        for (size_t i = 0; i < nCount; i++)
         {
             x[i] *= dfXScale;
             y[i] *= dfYScale;
@@ -296,10 +296,11 @@ class OGRDXFOCSTransformer final : public OGRCoordinateTransformation
         return nullptr;
     }
 
-    int Transform(int nCount, double *adfX, double *adfY, double *adfZ,
+    int Transform(size_t nCount, double *adfX, double *adfY, double *adfZ,
                   double *adfT, int *pabSuccess) override;
 
-    int InverseTransform(int nCount, double *adfX, double *adfY, double *adfZ);
+    int InverseTransform(size_t nCount, double *adfX, double *adfY,
+                         double *adfZ);
 
     void ComposeOnto(OGRDXFAffineTransform &poCT) const;
 

--- a/ogr/ogrsf_frmts/dxf/ogrdxf_ocstransformer.cpp
+++ b/ogr/ogrsf_frmts/dxf/ogrdxf_ocstransformer.cpp
@@ -125,11 +125,11 @@ OGRDXFOCSTransformer::OGRDXFOCSTransformer(double adfNIn[3],
 /*                            Transform()                               */
 /************************************************************************/
 
-int OGRDXFOCSTransformer::Transform(int nCount, double *adfX, double *adfY,
+int OGRDXFOCSTransformer::Transform(size_t nCount, double *adfX, double *adfY,
                                     double *adfZ, double * /* adfT */,
                                     int *pabSuccess /* = nullptr */)
 {
-    for (int i = 0; i < nCount; i++)
+    for (size_t i = 0; i < nCount; i++)
     {
         const double x = adfX[i];
         const double y = adfY[i];
@@ -149,13 +149,13 @@ int OGRDXFOCSTransformer::Transform(int nCount, double *adfX, double *adfY,
 /*                          InverseTransform()                          */
 /************************************************************************/
 
-int OGRDXFOCSTransformer::InverseTransform(int nCount, double *adfX,
+int OGRDXFOCSTransformer::InverseTransform(size_t nCount, double *adfX,
                                            double *adfY, double *adfZ)
 {
     if (dfDeterminant == 0.0)
         return FALSE;
 
-    for (int i = 0; i < nCount; i++)
+    for (size_t i = 0; i < nCount; i++)
     {
         const double x = adfX[i];
         const double y = adfY[i];


### PR DESCRIPTION
- OGRCoordinateTransformation::Transform(): change nCount parameter to size_t (C++ API only for now) (fixes #9074)
- OGRProjCT::TransformWithErrorCodes(): Improve performance of axis swapping (inspired by @SunBlack proposal) (fixes #9073)
