### PR TITLE
Fix calls to isspace(), isdigit(), isalnum(), isalpha(), islower(), isupper() to make sure argument is unsigned, otherwise unspecified behavior

### DIFF
--- a/apps/gdallocationinfo.cpp
+++ b/apps/gdallocationinfo.cpp
@@ -166,7 +166,8 @@ MAIN_START(argc, argv)
         {
             papszOpenOptions = CSLAddString(papszOpenOptions, argv[++i]);
         }
-        else if (argv[i][0] == '-' && !isdigit(argv[i][1]))
+        else if (argv[i][0] == '-' &&
+                 !isdigit(static_cast<unsigned char>(argv[i][1])))
             Usage(true);
 
         else if (pszSrcFilename == nullptr)

--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -5447,7 +5447,7 @@ GDALWarpAppOptionsNew(char **papszArgv,
                 return nullptr;
             }
             if (i < nArgc - 1 && atoi(papszArgv[i + 1]) >= 0 &&
-                isdigit(papszArgv[i + 1][0]))
+                isdigit(static_cast<unsigned char>(papszArgv[i + 1][0])))
             {
                 psOptions->aosTransformerOptions.SetNameValue(
                     "REFINE_MINIMUM_GCPS", papszArgv[++i]);

--- a/frmts/aaigrid/aaigriddataset.cpp
+++ b/frmts/aaigrid/aaigriddataset.cpp
@@ -1135,7 +1135,8 @@ GDALDataset *AAIGDataset::CommonOpen(GDALOpenInfo *poOpenInfo,
                 poOpenInfo->pabyHeader[i - 1] == '\r' ||
                 poOpenInfo->pabyHeader[i - 2] == '\r')
             {
-                if ((!isalpha(poOpenInfo->pabyHeader[i]) ||
+                if ((!isalpha(static_cast<unsigned char>(
+                         poOpenInfo->pabyHeader[i])) ||
                      // null seems to be specific of D12 software
                      // See https://github.com/OSGeo/gdal/issues/5095
                      (i + 5 < poOpenInfo->nHeaderBytes &&

--- a/frmts/aigrid/aigopen.c
+++ b/frmts/aigrid/aigopen.c
@@ -497,7 +497,7 @@ VSILFILE *AIGLLOpen(const char *pszFilename, const char *pszAccess)
         for (i = (int)strlen(pszUCFilename) - 1;
              pszUCFilename[i] != '/' && pszUCFilename[i] != '\\'; i--)
         {
-            pszUCFilename[i] = (char)toupper(pszUCFilename[i]);
+            pszUCFilename[i] = (char)toupper((unsigned char)(pszUCFilename[i]));
         }
 
         fp = VSIFOpenL(pszUCFilename, pszAccess);

--- a/frmts/eeda/eedadataset.cpp
+++ b/frmts/eeda/eedadataset.cpp
@@ -184,7 +184,7 @@ GDALEEDALayer::GDALEEDALayer(GDALEEDADataset *poDS,
     CPLString osLaundered(osCollection);
     for (size_t i = 0; i < osLaundered.size(); i++)
     {
-        if (!isalnum(static_cast<int>(osLaundered[i])))
+        if (!isalnum(static_cast<unsigned char>(osLaundered[i])))
         {
             osLaundered[i] = '_';
         }

--- a/frmts/georaster/oci_wrapper.cpp
+++ b/frmts/georaster/oci_wrapper.cpp
@@ -1433,7 +1433,8 @@ void OWUpperIfNoQuotes(char *pszText)
 
     for (size_t i = 0; i < nSize; i++)
     {
-        pszText[i] = static_cast<char>(toupper(pszText[i]));
+        pszText[i] =
+            static_cast<char>(toupper(static_cast<unsigned char>(pszText[i])));
     }
 }
 
@@ -1488,7 +1489,7 @@ CPLString OWParseSDO_GEOR_INIT(const char *pszInsert, int nField)
 
     for (pszIn = szUpcase; *pszIn != '\0'; pszIn++)
     {
-        *pszIn = (char)toupper(*pszIn);
+        *pszIn = (char)toupper(static_cast<unsigned char>(*pszIn));
     }
 
     char *pszStart = strstr(szUpcase, "SDO_GEOR.INIT");

--- a/frmts/grib/degrib/degrib/clock.c
+++ b/frmts/grib/degrib/degrib/clock.c
@@ -1962,12 +1962,12 @@ static int Clock_GetWord (char **Start, char **End, char word[30],
             f_integer = 0;
          }
       } else if (*ptr == '.') {
-         if (!isdigit (*(ptr + 1))) {
+         if (!isdigit ((unsigned char)*(ptr + 1))) {
             break;
          } else {
             f_integer = 0;
          }
-      } else if (!isdigit (*ptr)) {
+      } else if (!isdigit ((unsigned char)*ptr)) {
          f_integer = 0;
       }
       ptr++;

--- a/frmts/grib/degrib/degrib/clock.c
+++ b/frmts/grib/degrib/degrib/clock.c
@@ -1944,7 +1944,7 @@ static int Clock_GetWord (char **Start, char **End, char word[30],
    f_integer = 1;
    while ((*ptr != ' ') && (*ptr != ',') && (*ptr != '\0')) {
       if (cnt < 29) {
-         word[cnt] = (char) toupper (*ptr);
+         word[cnt] = (char) toupper ((unsigned char)*ptr);
          cnt++;
       }
       if (*ptr == ':') {

--- a/frmts/grib/degrib/degrib/metaname.cpp
+++ b/frmts/grib/degrib/degrib/metaname.cpp
@@ -867,8 +867,8 @@ static void ElemNamePerc (uChar mstrVersion, uShort2 center, uShort2 subcenter, 
  * the percentile (or exceedance value) so don't tack on percentile here.*/
             size_t len = strlen(pszShortName);
             if (len >= 2 &&
-                isdigit(pszShortName[len -1]) &&
-                isdigit(pszShortName[len -2])) {
+                isdigit(static_cast<unsigned char>(pszShortName[len -1])) &&
+                isdigit(static_cast<unsigned char>(pszShortName[len -2]))) {
                mallocSprintf (name, "%s", pszShortName);
             } else if ((strcmp (pszShortName, "Surge") == 0) ||
                        (strcmp (pszShortName, "SURGE") == 0)) {

--- a/frmts/grib/degrib/degrib/myutil.c
+++ b/frmts/grib/degrib/degrib/myutil.c
@@ -702,7 +702,7 @@ void strTrim (char *str)
    }
 
    /* Trim the string to the left first. */
-   for (ptr = str; isspace (*ptr); ptr++) {
+   for (ptr = str; isspace ((unsigned char)*ptr); ptr++) {
    }
    /* Did we hit the end of an all space string? */
    if (*ptr == '\0') {
@@ -711,7 +711,7 @@ void strTrim (char *str)
    }
 
    /* now work on the right side. */
-   for (ptr2 = ptr + (strlen (ptr) - 1); isspace (*ptr2); ptr2--) {
+   for (ptr2 = ptr + (strlen (ptr) - 1); isspace ((unsigned char)*ptr2); ptr2--) {
    }
 
    /* adjust the pointer to add the null byte. */

--- a/frmts/grib/degrib/degrib/myutil.c
+++ b/frmts/grib/degrib/degrib/myutil.c
@@ -212,7 +212,7 @@ int myAtoI (const char *ptr, sInt4 *value)
    myAssert (ptr != NULL);
    *value = 0;
    while (*ptr != '\0') {
-      if (isdigit (*ptr) || (*ptr == '+') || (*ptr == '-')) {
+      if (isdigit ((unsigned char)*ptr) || (*ptr == '+') || (*ptr == '-')) {
          *value = (int)strtol (ptr, &extra, 10);
          myAssert (extra != NULL);
          if (*extra == '\0') {
@@ -283,7 +283,7 @@ int myAtoF (const char *ptr, double *value)
    myAssert (ptr != NULL);
    *value = 0;
    while (*ptr != '\0') {
-      if (isdigit (*ptr) || (*ptr == '+') || (*ptr == '-') || (*ptr == '.')) {
+      if (isdigit ((unsigned char)*ptr) || (*ptr == '+') || (*ptr == '-') || (*ptr == '.')) {
          *value = strtod (ptr, &extra);
          myAssert (extra != NULL);
          if (*extra == '\0') {
@@ -327,15 +327,15 @@ int myIsReal_old (const char *ptr, double *value)
    size_t len, i;
 
    *value = 0;
-   if ((!isdigit (*ptr)) && (*ptr != '.'))
+   if ((!isdigit ((unsigned char)*ptr)) && (*ptr != '.'))
       if (*ptr != '-')
          return 0;
    len = strlen (ptr);
    for (i = 1; i < len - 1; i++) {
-      if ((!isdigit (ptr[i])) && (ptr[i] != '.'))
+      if ((!isdigit ((unsigned char)ptr[i])) && (ptr[i] != '.'))
          return 0;
    }
-   if ((!isdigit (ptr[len - 1])) && (ptr[len - 1] != '.')) {
+   if ((!isdigit ((unsigned char)ptr[len - 1])) && (ptr[len - 1] != '.')) {
       if (ptr[len - 1] != ',') {
          return 0;
       } else {

--- a/frmts/grib/degrib/degrib/myutil.c
+++ b/frmts/grib/degrib/degrib/myutil.c
@@ -873,7 +873,7 @@ void strToUpper (char *str)
       return;
    }
 
-   while ((*ptr++ = toupper (*str++)) != '\0') {
+   while ((*ptr++ = toupper ((unsigned char)(*str++))) != '\0') {
    }
 }
 #endif
@@ -908,7 +908,7 @@ void strToLower (char *str)
       return;
    }
 
-   while ((*ptr++ = tolower (*str++)) != '\0') {
+   while ((*ptr++ = tolower ((unsigned char)*str++)) != '\0') {
    }
 }
 #endif
@@ -920,7 +920,7 @@ void strToLower (char *str)
 int str2lw (char *s) {
   int i = 0, len = strlen (s);
   while (i < len) {
-    s[i] = (char) tolower(s[i]);
+    s[i] = (char) tolower((unsigned char)s[i]);
     i++;
   }
   return len;
@@ -968,18 +968,18 @@ int strcmpNoCase (const char *str1, const char *str2)
       return 1;
    }
 
-   for (; tolower (*str1) == tolower (*str2); str1++, str2++) {
+   for (; tolower ((unsigned char)*str1) == tolower ((unsigned char)*str2); str1++, str2++) {
       if (*str1 == '\0')
          return 0;
    }
-   return (tolower (*str1) - tolower (*str2) < 0) ? -1 : 1;
+   return (tolower ((unsigned char)*str1) - tolower ((unsigned char)*str2) < 0) ? -1 : 1;
 /*
    strlen1 = strlen (str1);
    strlen2 = strlen (str2);
    min = (strlen1 < strlen2) ? strlen1 : strlen2;
    for (i = 0; i < min; i++) {
-      c1 = tolower (str1[i]);
-      c2 = tolower (str2[i]);
+      c1 = tolower ((unsigned char)str1[i]);
+      c2 = tolower ((unsigned char)str2[i]);
       if (c1 < c2)
          return -1;
       if (c1 > c2)

--- a/frmts/gsg/gsagdataset.cpp
+++ b/frmts/gsg/gsagdataset.cpp
@@ -399,7 +399,8 @@ CPLErr GSAGRasterBand::IReadBlock(int nBlockXOff, int nBlockYOff, void *pImage)
                 *szEnd = cOldEnd;
 
                 szEnd = szStart;
-                while (!isdigit(*szEnd) && *szEnd != '.' && *szEnd != '\0')
+                while (!isdigit(static_cast<unsigned char>(*szEnd)) &&
+                       *szEnd != '.' && *szEnd != '\0')
                     szEnd++;
 
                 continue;

--- a/frmts/gtiff/geotiff.cpp
+++ b/frmts/gtiff/geotiff.cpp
@@ -1260,8 +1260,9 @@ struct GTiffDriverSubdatasetInfo : public GDALSubdatasetInfo
 
             m_driverPrefixComponent = aosParts[0];
 
-            const bool hasDriveLetter{strlen(aosParts[2]) == 1 &&
-                                      std::isalpha(aosParts[2][0])};
+            const bool hasDriveLetter{
+                strlen(aosParts[2]) == 1 &&
+                std::isalpha(static_cast<unsigned char>(aosParts[2][0]))};
 
             // Check for drive letter
             if (iPartsCount == 4)

--- a/frmts/hdf4/hdf4drivercore.cpp
+++ b/frmts/hdf4/hdf4drivercore.cpp
@@ -88,9 +88,11 @@ struct HDF4DriverSubdatasetInfo : public GDALSubdatasetInfo
                     (strlen(aosParts[3]) > 1 &&
                      (aosParts[3][0] == '\\' || aosParts[3][0] == '/')) &&
                     ((strlen(aosParts[2]) == 2 &&
-                      std::isalpha(aosParts[2][1])) ||
+                      std::isalpha(
+                          static_cast<unsigned char>(aosParts[2][1]))) ||
                      (strlen(aosParts[2]) == 1 &&
-                      std::isalpha(aosParts[2][0])))};
+                      std::isalpha(
+                          static_cast<unsigned char>(aosParts[2][0]))))};
                 m_pathComponent = aosParts[2];
 
                 const bool hasProtocol{m_pathComponent.find("/vsicurl/") !=

--- a/frmts/hdf5/hdf5drivercore.cpp
+++ b/frmts/hdf5/hdf5drivercore.cpp
@@ -193,7 +193,8 @@ struct HDF5DriverSubdatasetInfo : public GDALSubdatasetInfo
 
             int subdatasetIndex{2};
             const bool hasDriveLetter{
-                part1.length() == 1 && std::isalpha(part1.at(0)) &&
+                part1.length() == 1 &&
+                std::isalpha(static_cast<unsigned char>(part1.at(0))) &&
                 (strlen(aosParts[2]) > 1 &&
                  (aosParts[2][0] == '\\' ||
                   (aosParts[2][0] == '/' && aosParts[2][1] != '/')))};

--- a/frmts/iso8211/ddffielddefn.cpp
+++ b/frmts/iso8211/ddffielddefn.cpp
@@ -641,7 +641,7 @@ char *DDFFieldDefn::ExpandFormat(const char *pszSrc)
 
         // This is a repeated subclause.
         else if ((iSrc == 0 || pszSrc[iSrc - 1] == ',') &&
-                 isdigit(pszSrc[iSrc]))
+                 isdigit(static_cast<unsigned char>(pszSrc[iSrc])))
         {
             const int nRepeat = atoi(pszSrc + iSrc);
             // 100: arbitrary number. Higher values might cause performance
@@ -654,7 +654,7 @@ char *DDFFieldDefn::ExpandFormat(const char *pszSrc)
 
             // Skip over repeat count.
             const char *pszNext = pszSrc + iSrc;  // Used after for.
-            for (; isdigit(*pszNext); pszNext++)
+            for (; isdigit(static_cast<unsigned char>(*pszNext)); pszNext++)
                 iSrc++;
 
             char *pszContents = ExtractSubstring(pszNext);

--- a/frmts/mrf/marfa_dataset.cpp
+++ b/frmts/mrf/marfa_dataset.cpp
@@ -1594,8 +1594,9 @@ static inline bool is_absolute(const CPLString &name)
 {
     return (name.find_first_of("/\\") == 0)  // Starts with root
            || (name.size() > 1 && name[1] == ':' &&
-               isalpha(name[0]))  // Starts with drive letter
-           || (name[0] == '<');   // Maybe it is XML
+               isalpha(static_cast<unsigned char>(
+                   name[0])))    // Starts with drive letter
+           || (name[0] == '<');  // Maybe it is XML
 }
 
 // Add the dirname of path to the beginning of name, if it is relative

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -3431,14 +3431,14 @@ void netCDFDataset::SetProjectionFromVar(
         for (unsigned int i = 0;
              i < strlen(poDS->papszDimName[poDS->nXDimID]) && i < 3; i++)
         {
-            szDimNameX[i] =
-                (char)tolower((poDS->papszDimName[poDS->nXDimID])[i]);
+            szDimNameX[i] = (char)tolower(static_cast<unsigned char>(
+                (poDS->papszDimName[poDS->nXDimID])[i]));
         }
         szDimNameX[3] = '\0';
         // for( unsigned int i = 0;
         //      (i < strlen(poDS->papszDimName[poDS->nYDimID])
         //                        && i < 3 ); i++ ) {
-        //    szDimNameY[i]=(char)tolower((poDS->papszDimName[poDS->nYDimID])[i]);
+        //    szDimNameY[i]=(char)tolower(static_cast<unsigned char>((poDS->papszDimName[poDS->nYDimID])[i]));
         // }
         // szDimNameY[3] = '\0';
     }

--- a/frmts/netcdf/netcdfdrivercore.cpp
+++ b/frmts/netcdf/netcdfdrivercore.cpp
@@ -249,7 +249,8 @@ struct NCDFDriverSubdatasetInfo : public GDALSubdatasetInfo
             const bool hasDriveLetter{
                 (strlen(aosParts[2]) > 1 &&
                  (aosParts[2][0] == '\\' || aosParts[2][0] == '/')) &&
-                part1.length() == 1 && std::isalpha(part1.at(0))};
+                part1.length() == 1 &&
+                std::isalpha(static_cast<unsigned char>(part1.at(0)))};
 
             const bool hasProtocol{part1 == "/vsicurl/http" ||
                                    part1 == "/vsicurl/https" ||

--- a/frmts/nitf/mgrs.c
+++ b/frmts/nitf/mgrs.c
@@ -326,7 +326,7 @@ static long Check_Zone(char *MGRS, long *zone_exists)
     while (MGRS[i] == ' ')
         i++;
     j = i;
-    while (isdigit(MGRS[i]))
+    while (isdigit((unsigned char)MGRS[i]))
         i++;
     num_digits = i - j;
     if (num_digits <= 2)
@@ -428,7 +428,7 @@ static long Break_MGRS_String(char *MGRS, long *Zone,
     while (MGRS[i] == ' ')
         i++; /* skip any leading blanks */
     j = i;
-    while (isdigit(MGRS[i]))
+    while (isdigit((unsigned char)MGRS[i]))
         i++;
     num_digits = i - j;
     if (num_digits <= 2)
@@ -467,7 +467,7 @@ static long Break_MGRS_String(char *MGRS, long *Zone,
     else
         error_code |= MGRS_STRING_ERROR;
     j = i;
-    while (isdigit(MGRS[i]))
+    while (isdigit((unsigned char)MGRS[i]))
         i++;
     num_digits = i - j;
     if ((num_digits <= 10) && (num_digits % 2 == 0))

--- a/frmts/nitf/mgrs.c
+++ b/frmts/nitf/mgrs.c
@@ -454,13 +454,13 @@ static long Break_MGRS_String(char *MGRS, long *Zone,
     if (num_letters == 3)
     {
         /* get letters */
-        Letters[0] = (toupper(MGRS[j]) - (long)'A');
+        Letters[0] = (toupper((unsigned char)MGRS[j]) - (long)'A');
         if ((Letters[0] == LETTER_I) || (Letters[0] == LETTER_O))
             error_code |= MGRS_STRING_ERROR;
-        Letters[1] = (toupper(MGRS[j + 1]) - (long)'A');
+        Letters[1] = (toupper((unsigned char)MGRS[j + 1]) - (long)'A');
         if ((Letters[1] == LETTER_I) || (Letters[1] == LETTER_O))
             error_code |= MGRS_STRING_ERROR;
-        Letters[2] = (toupper(MGRS[j + 2]) - (long)'A');
+        Letters[2] = (toupper((unsigned char)MGRS[j + 2]) - (long)'A');
         if ((Letters[2] == LETTER_I) || (Letters[2] == LETTER_O))
             error_code |= MGRS_STRING_ERROR;
     }

--- a/frmts/nitf/mgrs.c
+++ b/frmts/nitf/mgrs.c
@@ -448,7 +448,7 @@ static long Break_MGRS_String(char *MGRS, long *Zone,
         error_code |= MGRS_STRING_ERROR;
     j = i;
 
-    while (isalpha(MGRS[i]))
+    while (isalpha((unsigned char)MGRS[i]))
         i++;
     num_letters = i - j;
     if (num_letters == 3)

--- a/frmts/nitf/nitfdataset.cpp
+++ b/frmts/nitf/nitfdataset.cpp
@@ -6224,9 +6224,9 @@ static bool NITFWriteDES(VSILFILE *&fp, const char *pszFilename,
         char szDESITEM[LEN_DESITEM + 1];
         memcpy(szDESITEM, pabyDESData + 169 + LEN_DESOFLW, LEN_DESITEM);
         szDESITEM[LEN_DESITEM] = '\0';
-        if (!isdigit(static_cast<int>(szDESITEM[0])) ||
-            !isdigit(static_cast<int>(szDESITEM[1])) ||
-            !isdigit(static_cast<int>(szDESITEM[2])))
+        if (!isdigit(static_cast<unsigned char>(szDESITEM[0])) ||
+            !isdigit(static_cast<unsigned char>(szDESITEM[1])) ||
+            !isdigit(static_cast<unsigned char>(szDESITEM[2])))
         {
             CPLError(CE_Failure, CPLE_AppDefined,
                      "Invalid value for DESITEM: '%s'", szDESITEM);
@@ -6328,10 +6328,10 @@ static bool NITFWriteDES(VSILFILE *&fp, const char *pszFilename,
         169 + (bIsTRE_OVERFLOW ? LEN_DESOFLW + LEN_DESITEM : 0);
     memcpy(szDESSHL, pabyDESData + OFFSET_DESSHL, LEN_DESSHL);
     szDESSHL[LEN_DESSHL] = '\0';
-    if (!isdigit(static_cast<int>(szDESSHL[0])) ||
-        !isdigit(static_cast<int>(szDESSHL[1])) ||
-        !isdigit(static_cast<int>(szDESSHL[2])) ||
-        !isdigit(static_cast<int>(szDESSHL[3])))
+    if (!isdigit(static_cast<unsigned char>(szDESSHL[0])) ||
+        !isdigit(static_cast<unsigned char>(szDESSHL[1])) ||
+        !isdigit(static_cast<unsigned char>(szDESSHL[2])) ||
+        !isdigit(static_cast<unsigned char>(szDESSHL[3])))
     {
         CPLError(CE_Failure, CPLE_AppDefined, "Invalid value for DESSHL: '%s'",
                  szDESSHL);

--- a/frmts/pcidsk/sdk/channel/ctiledchannel.cpp
+++ b/frmts/pcidsk/sdk/channel/ctiledchannel.cpp
@@ -717,7 +717,7 @@ void CTiledChannel::JPEGCompressBlock( PCIDSKBuffer &oDecompressedData,
 
     const char * compression = mpoTileLayer->GetCompressType();
 
-    if (strlen(compression) > 4 && isdigit(compression[4]))
+    if (strlen(compression) > 4 && isdigit(static_cast<unsigned char>(compression[4])))
         quality = atoi(compression + 4);
 
 /* -------------------------------------------------------------------- */

--- a/frmts/pcidsk/sdk/core/cpcidskblockfile.cpp
+++ b/frmts/pcidsk/sdk/core/cpcidskblockfile.cpp
@@ -64,7 +64,7 @@ SysTileDir * CPCIDSKBlockFile::CreateTileDir(void)
     std::string oFileOptions = GetFileOptions();
 
     for (char & chIter : oFileOptions)
-        chIter = (char) toupper((uchar) chIter);
+        chIter = (char) toupper(static_cast<unsigned char>(chIter));
 
     // Check if we should create a TILEV1 or TILEV2 block directory.
     bool bTileV1 = oFileOptions.find("TILEV1") != std::string::npos;

--- a/frmts/pcidsk/sdk/core/pcidsk_utils.cpp
+++ b/frmts/pcidsk/sdk/core/pcidsk_utils.cpp
@@ -98,7 +98,7 @@ std::string &PCIDSK::UCaseStr( std::string &target )
 {
     for( unsigned int i = 0; i < target.size(); i++ )
     {
-        if( islower(target[i]) )
+        if( islower(static_cast<unsigned char>(target[i])) )
             target[i] = (char) toupper(target[i]);
     }
 
@@ -402,9 +402,9 @@ int PCIDSK::pci_strcasecmp( const char *string1, const char *string2 )
         char c1 = string1[i];
         char c2 = string2[i];
 
-        if( islower(c1) )
+        if( islower(static_cast<unsigned char>(c1)) )
             c1 = (char) toupper(c1);
-        if( islower(c2) )
+        if( islower(static_cast<unsigned char>(c2)) )
             c2 = (char) toupper(c2);
 
         if( c1 < c2 )
@@ -440,9 +440,9 @@ int PCIDSK::pci_strncasecmp( const char *string1, const char *string2, size_t le
         char c1 = string1[i];
         char c2 = string2[i];
 
-        if( islower(c1) )
+        if( islower(static_cast<unsigned char>(c1)) )
             c1 = (char) toupper(c1);
-        if( islower(c2) )
+        if( islower(static_cast<unsigned char>(c2)) )
             c2 = (char) toupper(c2);
 
         if( c1 < c2 )

--- a/frmts/pcidsk/sdk/core/pcidsk_utils.cpp
+++ b/frmts/pcidsk/sdk/core/pcidsk_utils.cpp
@@ -99,7 +99,7 @@ std::string &PCIDSK::UCaseStr( std::string &target )
     for( unsigned int i = 0; i < target.size(); i++ )
     {
         if( islower(static_cast<unsigned char>(target[i])) )
-            target[i] = (char) toupper(target[i]);
+            target[i] = (char) toupper(static_cast<unsigned char>(target[i]));
     }
 
     return target;
@@ -403,9 +403,9 @@ int PCIDSK::pci_strcasecmp( const char *string1, const char *string2 )
         char c2 = string2[i];
 
         if( islower(static_cast<unsigned char>(c1)) )
-            c1 = (char) toupper(c1);
+            c1 = (char) toupper(static_cast<unsigned char>(c1));
         if( islower(static_cast<unsigned char>(c2)) )
-            c2 = (char) toupper(c2);
+            c2 = (char) toupper(static_cast<unsigned char>(c2));
 
         if( c1 < c2 )
             return -1;
@@ -441,9 +441,9 @@ int PCIDSK::pci_strncasecmp( const char *string1, const char *string2, size_t le
         char c2 = string2[i];
 
         if( islower(static_cast<unsigned char>(c1)) )
-            c1 = (char) toupper(c1);
+            c1 = (char) toupper(static_cast<unsigned char>(c1));
         if( islower(static_cast<unsigned char>(c2)) )
-            c2 = (char) toupper(c2);
+            c2 = (char) toupper(static_cast<unsigned char>(c2));
 
         if( c1 < c2 )
             return -1;

--- a/frmts/pcidsk/sdk/segment/cpcidskgcp2segment.cpp
+++ b/frmts/pcidsk/sdk/segment/cpcidskgcp2segment.cpp
@@ -133,11 +133,11 @@ void CPCIDSKGCP2Segment::Load()
         double x = pimpl_->seg_data.GetDouble(offset + 48, 22);
         double y = pimpl_->seg_data.GetDouble(offset + 70, 22);
 
-        char cElevDatum = (char)toupper(pimpl_->seg_data.buffer[offset + 47]);
+        char cElevDatum = (char)toupper(static_cast<unsigned char>(pimpl_->seg_data.buffer[offset + 47]));
         PCIDSK::GCP::EElevationDatum elev_datum = cElevDatum != 'M' ?
             GCP::EEllipsoidal : GCP::EMeanSeaLevel;
 
-        char elev_unit_c = (char)toupper(pimpl_->seg_data.buffer[offset + 46]);
+        char elev_unit_c = (char)toupper(static_cast<unsigned char>(pimpl_->seg_data.buffer[offset + 46]));
         PCIDSK::GCP::EElevationUnit elev_unit = elev_unit_c == 'M' ? GCP::EMetres :
             elev_unit_c == 'F' ? GCP::EInternationalFeet :
             elev_unit_c == 'A' ? GCP::EAmericanFeet : GCP::EUnknown;

--- a/frmts/pcidsk/sdk/segment/cpcidskgeoref.cpp
+++ b/frmts/pcidsk/sdk/segment/cpcidskgeoref.cpp
@@ -491,7 +491,7 @@ std::string CPCIDSKGeoref::ReformatGeosys( std::string const& geosysIn )
             zone = atoi(ptr);
             for( ; isdigit((unsigned char)*ptr) || *ptr == '-'; ptr++ ) {}
             for( ; isspace(static_cast<unsigned char>(*ptr)); ptr++ ) {}
-            if( isalpha(*ptr)
+            if( isalpha(static_cast<unsigned char>(*ptr))
                 && !isdigit((unsigned char)*(ptr+1))
                 && ptr[1] != '-' )
                 zone_code = *(ptr++);

--- a/frmts/pcidsk/sdk/segment/cpcidskgeoref.cpp
+++ b/frmts/pcidsk/sdk/segment/cpcidskgeoref.cpp
@@ -712,7 +712,7 @@ std::string CPCIDSKGeoref::ReformatGeosys( std::string const& geosysIn )
         if( *ptr == 'A' || *ptr == 'B' || *ptr == 'Y' || *ptr == 'Z' )
             ups_zone = *ptr;
         else if( *ptr == 'a' || *ptr == 'b' || *ptr == 'y' || *ptr == 'z' )
-            ups_zone = toupper( *ptr );
+            ups_zone = toupper( static_cast<unsigned char>(*ptr) );
         else
             ups_zone = ' ';
 

--- a/frmts/pcidsk/sdk/segment/cpcidskgeoref.cpp
+++ b/frmts/pcidsk/sdk/segment/cpcidskgeoref.cpp
@@ -433,7 +433,7 @@ std::string CPCIDSKGeoref::ReformatGeosys( std::string const& geosysIn )
     while( cp < local_buf + 16 && cp[1] != '\0' )
         cp++;
 
-    while( cp > local_buf && isspace(*cp) )
+    while( cp > local_buf && isspace(static_cast<unsigned char>(*cp)) )
         cp--;
 
     last = '\0';
@@ -452,7 +452,7 @@ std::string CPCIDSKGeoref::ReformatGeosys( std::string const& geosysIn )
         i = atoi( cp+1 );
         if(    i > -100 && i < 1000
                && (cp == local_buf
-                   || ( cp >  local_buf && isspace( *(cp-1) ) )
+                   || ( cp >  local_buf && isspace( static_cast<unsigned char>(*(cp-1)) ) )
                    )
                )
         {
@@ -485,12 +485,12 @@ std::string CPCIDSKGeoref::ReformatGeosys( std::string const& geosysIn )
     else if( STARTS_WITH_CI(local_buf, "UTM") )
     {
         /* Attempt to find a zone and ellipsoid */
-        for( ptr=local_buf+3; isspace(*ptr); ptr++ ) {}
+        for( ptr=local_buf+3; isspace(static_cast<unsigned char>(*ptr)); ptr++ ) {}
         if( isdigit( (unsigned char)*ptr ) || *ptr == '-' )
         {
             zone = atoi(ptr);
             for( ; isdigit((unsigned char)*ptr) || *ptr == '-'; ptr++ ) {}
-            for( ; isspace(*ptr); ptr++ ) {}
+            for( ; isspace(static_cast<unsigned char>(*ptr)); ptr++ ) {}
             if( isalpha(*ptr)
                 && !isdigit((unsigned char)*(ptr+1))
                 && ptr[1] != '-' )
@@ -545,7 +545,7 @@ std::string CPCIDSKGeoref::ReformatGeosys( std::string const& geosysIn )
     {
         int nSPZone = 0;
 
-        for( ptr=local_buf+4; isspace(*ptr); ptr++ ) {}
+        for( ptr=local_buf+4; isspace(static_cast<unsigned char>(*ptr)); ptr++ ) {}
         nSPZone = atoi(ptr);
 
         if      ( STARTS_WITH_CI(local_buf, "SPCS ") )
@@ -708,7 +708,7 @@ std::string CPCIDSKGeoref::ReformatGeosys( std::string const& geosysIn )
     else if( STARTS_WITH_CI(local_buf, "UPS ") )
     {
         /* Attempt to find UPS zone */
-        for( ptr=local_buf+3; isspace(*ptr); ptr++ ) {}
+        for( ptr=local_buf+3; isspace(static_cast<unsigned char>(*ptr)); ptr++ ) {}
         if( *ptr == 'A' || *ptr == 'B' || *ptr == 'Y' || *ptr == 'Z' )
             ups_zone = *ptr;
         else if( *ptr == 'a' || *ptr == 'b' || *ptr == 'y' || *ptr == 'z' )

--- a/frmts/pds/pds4dataset.cpp
+++ b/frmts/pds/pds4dataset.cpp
@@ -4140,7 +4140,8 @@ OGRLayer *PDS4Dataset::ICreateLayer(const char *pszName,
     std::string osBasename(pszName);
     for (char &ch : osBasename)
     {
-        if (!isalnum(ch) && static_cast<unsigned>(ch) <= 127)
+        if (!isalnum(static_cast<unsigned char>(ch)) &&
+            static_cast<unsigned>(ch) <= 127)
             ch = '_';
     }
 

--- a/frmts/pds/pds4dataset.cpp
+++ b/frmts/pds/pds4dataset.cpp
@@ -1423,7 +1423,7 @@ static CPLString FixupTableFilename(const CPLString &osFilename)
     if (!osExt.empty())
     {
         CPLString osTry(osFilename);
-        if (islower(osExt[0]))
+        if (islower(static_cast<unsigned char>(osExt[0])))
         {
             osTry = CPLResetExtension(osFilename, osExt.toupper());
         }

--- a/frmts/pds/pds4vector.cpp
+++ b/frmts/pds/pds4vector.cpp
@@ -436,7 +436,8 @@ CPLXMLNode *PDS4TableBaseLayer::RefreshFileAreaObservationalBeginningCommon(
         }
         for (char &ch : osLocalIdentifier)
         {
-            if (!isalnum(ch) && static_cast<unsigned>(ch) <= 127)
+            if (!isalnum(static_cast<unsigned char>(ch)) &&
+                static_cast<unsigned>(ch) <= 127)
                 ch = '_';
         }
     }

--- a/frmts/pds/pds4vector.cpp
+++ b/frmts/pds/pds4vector.cpp
@@ -430,7 +430,7 @@ CPLXMLNode *PDS4TableBaseLayer::RefreshFileAreaObservationalBeginningCommon(
     {
         // Make a valid NCName
         osLocalIdentifier = GetName();
-        if (isdigit(osLocalIdentifier[0]))
+        if (isdigit(static_cast<unsigned char>(osLocalIdentifier[0])))
         {
             osLocalIdentifier = '_' + osLocalIdentifier;
         }

--- a/frmts/raw/ehdrdataset.cpp
+++ b/frmts/raw/ehdrdataset.cpp
@@ -1094,11 +1094,13 @@ GDALDataset *EHdrDataset::Open(GDALOpenInfo *poOpenInfo, bool bFileSizeCheck)
         }
         else if (EQUAL(papszTokens[0], "PIXELTYPE"))
         {
-            chPixelType = static_cast<char>(toupper(papszTokens[1][0]));
+            chPixelType = static_cast<char>(
+                toupper(static_cast<unsigned char>(papszTokens[1][0])));
         }
         else if (EQUAL(papszTokens[0], "byteorder"))
         {
-            chByteOrder = static_cast<char>(toupper(papszTokens[1][0]));
+            chByteOrder = static_cast<char>(
+                toupper(static_cast<unsigned char>(papszTokens[1][0])));
         }
 
         // http://www.worldclim.org/futdown.htm have the projection extensions

--- a/frmts/raw/eirdataset.cpp
+++ b/frmts/raw/eirdataset.cpp
@@ -399,7 +399,8 @@ GDALDataset *EIRDataset::Open(GDALOpenInfo *poOpenInfo)
         else if (EQUAL(aosTokens[0], "BYTE_ORDER"))
         {
             // M for MSB, L for LSB
-            chByteOrder = static_cast<char>(toupper(aosTokens[1][0]));
+            chByteOrder = static_cast<char>(
+                toupper(static_cast<unsigned char>(aosTokens[1][0])));
         }
         else if (EQUAL(aosTokens[0], "DATA_OFFSET"))
         {

--- a/frmts/raw/mffdataset.cpp
+++ b/frmts/raw/mffdataset.cpp
@@ -821,7 +821,8 @@ GDALDataset *MFFDataset::Open(GDALOpenInfo *poOpenInfo)
                 continue;
 
             pszExtension = CPLGetExtension(papszDirFiles[i]);
-            if (strlen(pszExtension) >= 2 && isdigit(pszExtension[1]) &&
+            if (strlen(pszExtension) >= 2 &&
+                isdigit(static_cast<unsigned char>(pszExtension[1])) &&
                 atoi(pszExtension + 1) == nRawBand &&
                 strchr("bBcCiIjJrRxXzZ", pszExtension[0]) != nullptr)
                 break;

--- a/frmts/stacit/stacitdataset.cpp
+++ b/frmts/stacit/stacitdataset.cpp
@@ -148,7 +148,7 @@ static std::string SanitizeCRSValue(const std::string &v)
     bool lastWasAlphaNum = true;
     for (char ch : v)
     {
-        if (!isalnum(static_cast<int>(ch)))
+        if (!isalnum(static_cast<unsigned char>(ch)))
         {
             if (lastWasAlphaNum)
                 ret += '_';

--- a/frmts/usgsdem/usgsdem_create.cpp
+++ b/frmts/usgsdem/usgsdem_create.cpp
@@ -210,7 +210,8 @@ static void USGSDEMPrintDouble(char *pszBuffer, double dfValue)
             szTemp[i] = 'D';
 #ifdef MSVC_HACK
         if ((szTemp[i] == '+' || szTemp[i] == '-') && szTemp[i + 1] == '0' &&
-            isdigit(szTemp[i + 2]) && isdigit(szTemp[i + 3]) &&
+            isdigit(static_cast<unsigned char>(szTemp[i + 2])) &&
+            isdigit(static_cast<unsigned char>(szTemp[i + 3])) &&
             szTemp[i + 4] == '\0')
         {
             szTemp[i + 1] = szTemp[i + 2];
@@ -260,7 +261,8 @@ static void USGSDEMPrintSingle(char *pszBuffer, double dfValue)
             szTemp[i] = 'D';
 #ifdef MSVC_HACK
         if ((szTemp[i] == '+' || szTemp[i] == '-') && szTemp[i + 1] == '0' &&
-            isdigit(szTemp[i + 2]) && isdigit(szTemp[i + 3]) &&
+            isdigit(static_cast<unsigned char>(szTemp[i + 2])) &&
+            isdigit(static_cast<unsigned char>(szTemp[i + 3])) &&
             szTemp[i + 4] == '\0')
         {
             szTemp[i + 1] = szTemp[i + 2];

--- a/frmts/usgsdem/usgsdemdataset.cpp
+++ b/frmts/usgsdem/usgsdemdataset.cpp
@@ -67,7 +67,7 @@ static int ReadInt(VSILFILE *fp)
         }
         if (bInProlog)
         {
-            if (!isspace(static_cast<int>(c)))
+            if (!isspace(static_cast<unsigned char>(c)))
             {
                 bInProlog = false;
             }
@@ -166,7 +166,7 @@ static int USGSDEMReadIntFromBuffer(Buffer *psBuffer, int *pbSuccess = nullptr)
 
         c = psBuffer->buffer[psBuffer->cur_index];
         psBuffer->cur_index++;
-        if (!isspace(static_cast<int>(c)))
+        if (!isspace(static_cast<unsigned char>(c)))
             break;
     }
 

--- a/frmts/wms/minidriver_wms.cpp
+++ b/frmts/wms/minidriver_wms.cpp
@@ -174,7 +174,8 @@ CPLErr WMSMiniDriver_WMS::Initialize(CPLXMLNode *config,
         // according to the WMS spec so force upper case
         for (int i = 0; i < (int)m_transparent.size(); i++)
         {
-            m_transparent[i] = (char)toupper(m_transparent[i]);
+            m_transparent[i] =
+                (char)toupper(static_cast<unsigned char>(m_transparent[i]));
         }
     }
 

--- a/gcore/gdal_mdreader.cpp
+++ b/gcore/gdal_mdreader.cpp
@@ -1029,8 +1029,10 @@ static bool GDAL_IMD_AA2R(char ***ppapszIMD)
         {
             CPLString osValue = CSLFetchNameValue(papszIMD, osTarget);
             CPLString osLine;
-            osTarget.Printf("IMAGE_1.%c%s", tolower(keylist[iKey][0]),
-                            keylist[iKey] + 1);
+            osTarget.Printf(
+                "IMAGE_1.%c%s",
+                tolower(static_cast<unsigned char>(keylist[iKey][0])),
+                keylist[iKey] + 1);
 
             osLine = osTarget + "=" + osValue;
 

--- a/gcore/gdal_misc.cpp
+++ b/gcore/gdal_misc.cpp
@@ -2202,8 +2202,10 @@ int GDALReadWorldFile2(const char *pszBaseFilename, const char *pszExtension,
 
     for (int i = 0; szExtUpper[i] != '\0'; i++)
     {
-        szExtUpper[i] = static_cast<char>(toupper(szExtUpper[i]));
-        szExtLower[i] = static_cast<char>(tolower(szExtLower[i]));
+        szExtUpper[i] = static_cast<char>(
+            toupper(static_cast<unsigned char>(szExtUpper[i])));
+        szExtLower[i] = static_cast<char>(
+            tolower(static_cast<unsigned char>(szExtLower[i])));
     }
 
     const char *pszTFW = CPLResetExtension(pszBaseFilename, szExtLower);

--- a/gcore/gdal_misc.cpp
+++ b/gcore/gdal_misc.cpp
@@ -1488,7 +1488,7 @@ CPLString GDALFindAssociatedFile(const char *pszBaseFilename,
         {
             CPLString osAltExt = pszExt;
 
-            if (islower(pszExt[0]))
+            if (islower(static_cast<unsigned char>(pszExt[0])))
                 osAltExt.toupper();
             else
                 osAltExt.tolower();

--- a/gcore/gdaldrivermanager.cpp
+++ b/gcore/gdaldrivermanager.cpp
@@ -1137,7 +1137,8 @@ void GDALDriverManager::ReorderDrivers()
         if (pszLine[0] == '#')
             continue;
         int i = 0;
-        while (pszLine[i] != 0 && isspace(pszLine[i]))
+        while (pszLine[i] != 0 &&
+               isspace(static_cast<unsigned char>(pszLine[i])))
             i++;
         if (pszLine[i] == 0)
             continue;

--- a/gcore/gdalmultidim.cpp
+++ b/gcore/gdalmultidim.cpp
@@ -4048,7 +4048,7 @@ bool GDALMDArray::IAdviseRead(const GUInt64 *, const size_t *,
     std::string ret;
     for (const char ch : inputName)
     {
-        if (!isalnum(ch))
+        if (!isalnum(static_cast<unsigned char>(ch)))
             ret += '_';
         else
             ret += ch;

--- a/ogr/ogr_srs_pci.cpp
+++ b/ogr/ogr_srs_pci.cpp
@@ -236,7 +236,7 @@ OGRErr OGRSpatialReference::importFromPCI(const char *pszProj,
 
             if (nCode >= -99 && nCode <= 999)
                 snprintf(szEarthModel, sizeof(szEarthModel), "%c%03d",
-                         toupper(*pszEM), nCode);
+                         toupper(static_cast<unsigned char>(*pszEM)), nCode);
 
             break;
         }

--- a/ogr/ogr_srsnode.cpp
+++ b/ogr/ogr_srsnode.cpp
@@ -763,7 +763,7 @@ OGRErr OGR_SRSNode::importFromWkt(const char **ppszInput, int nRecLevel,
             AddChild(poNewChild);
 
             // Swallow whitespace.
-            while (isspace(*pszInput))
+            while (isspace(static_cast<unsigned char>(*pszInput)))
                 pszInput++;
         } while (*pszInput == ',');
 

--- a/ogr/ogrsf_frmts/avc/avc_binwr.cpp
+++ b/ogr/ogrsf_frmts/avc/avc_binwr.cpp
@@ -1793,7 +1793,7 @@ AVCBinFile *AVCBinWriteCreateTable(const char *pszInfoPath,
         for (i = 0; *pszPtr != '\0' && *pszPtr != '.' && *pszPtr != ' ';
              i++, pszPtr++)
         {
-            szCoverName[i] = (char)tolower(*pszPtr);
+            szCoverName[i] = (char)tolower(static_cast<unsigned char>(*pszPtr));
         }
         szCoverName[i] = '\0';
 
@@ -1802,13 +1802,13 @@ AVCBinFile *AVCBinWriteCreateTable(const char *pszInfoPath,
 
         for (i = 0; i < 3 && *pszPtr != '\0' && *pszPtr != ' '; i++, pszPtr++)
         {
-            szExt[i] = (char)tolower(*pszPtr);
+            szExt[i] = (char)tolower(static_cast<unsigned char>(*pszPtr));
         }
         szExt[i] = '\0';
 
         for (i = 0; *pszPtr != '\0' && *pszPtr != ' '; i++, pszPtr++)
         {
-            szSubclass[i] = (char)tolower(*pszPtr);
+            szSubclass[i] = (char)tolower(static_cast<unsigned char>(*pszPtr));
         }
         szSubclass[i] = '\0';
 
@@ -1979,7 +1979,8 @@ AVCBinFile *_AVCBinWriteCreateDBFTable(const char *pszPath,
     for (i = (int)strlen(psFile->pszFilename); *pszDBFBasename;
          i++, pszDBFBasename++)
     {
-        psFile->pszFilename[i] = (char)tolower(*pszDBFBasename);
+        psFile->pszFilename[i] =
+            (char)tolower(static_cast<unsigned char>(*pszDBFBasename));
     }
 
     strcat(psFile->pszFilename, ".dbf");

--- a/ogr/ogrsf_frmts/avc/avc_e00gen.cpp
+++ b/ogr/ogrsf_frmts/avc/avc_e00gen.cpp
@@ -168,7 +168,8 @@ const char *AVCE00GenStartSection(AVCE00GenInfo *psInfo, AVCFileType eType,
         int i;
         for (i = 0; pszClassName[i] != '\0'; i++)
         {
-            psInfo->pszBuf[i] = (char)toupper(pszClassName[i]);
+            psInfo->pszBuf[i] =
+                (char)toupper(static_cast<unsigned char>(pszClassName[i]));
         }
         psInfo->pszBuf[i] = '\0';
     }

--- a/ogr/ogrsf_frmts/avc/avc_e00read.cpp
+++ b/ogr/ogrsf_frmts/avc/avc_e00read.cpp
@@ -982,7 +982,8 @@ static int _AVCE00ReadBuildSqueleton(AVCE00ReadPtr psInfo, char **papszCoverDir)
      *----------------------------------------------------------------*/
 #ifdef _WIN32
     if (psInfo->pszCoverPath[0] != '\\' &&
-        !(isalpha(psInfo->pszCoverPath[0]) && psInfo->pszCoverPath[1] == ':'))
+        !(isalpha((unsigned char)psInfo->pszCoverPath[0]) &&
+          psInfo->pszCoverPath[1] == ':'))
 #else
     if (psInfo->pszCoverPath[0] != '/')
 #endif

--- a/ogr/ogrsf_frmts/avc/avc_e00read.cpp
+++ b/ogr/ogrsf_frmts/avc/avc_e00read.cpp
@@ -1008,7 +1008,7 @@ static int _AVCE00ReadBuildSqueleton(AVCE00ReadPtr psInfo, char **papszCoverDir)
         CPLSPrintf("EXP  0 %s%s.E00", szCWD, osCoverPathTruncated.c_str()));
     pcTmp = pszEXPPath;
     for (; *pcTmp != '\0'; pcTmp++)
-        *pcTmp = (char)toupper(*pcTmp);
+        *pcTmp = (char)toupper(static_cast<unsigned char>(*pcTmp));
 
     /*-----------------------------------------------------------------
      * EXP Header
@@ -1309,7 +1309,7 @@ static int _AVCE00ReadBuildSqueleton(AVCE00ReadPtr psInfo, char **papszCoverDir)
                                      papszCoverDir[iFile]);
                 pcTmp = (char *)szFname;
                 for (; *pcTmp != '\0'; pcTmp++)
-                    *pcTmp = (char)toupper(*pcTmp);
+                    *pcTmp = (char)toupper(static_cast<unsigned char>(*pcTmp));
                 papszCoverDir[iFile][nLen - 4] = '.';
 
                 papszTables = CSLAddString(papszTables, szFname);

--- a/ogr/ogrsf_frmts/avc/avc_e00write.cpp
+++ b/ogr/ogrsf_frmts/avc/avc_e00write.cpp
@@ -480,7 +480,7 @@ static void _AVCE00WriteRenameTable(AVCTableDef *psTableDef,
 
     snprintf(szNewName, sizeof(szNewName), "%s", pszNewCoverName);
     for (i = 0; szNewName[i] != '\0'; i++)
-        szNewName[i] = (char)toupper(szNewName[i]);
+        szNewName[i] = (char)toupper(static_cast<unsigned char>(szNewName[i]));
 
     /*-----------------------------------------------------------------
      * Extract components from the current table name.
@@ -662,7 +662,7 @@ static int _AVCE00WriteCreateCoverFile(AVCE00WritePtr psInfo, AVCFileType eType,
      * Make sure filename is all lowercase and attempt to create the file
      *----------------------------------------------------------------*/
     for (i = 0; szFname[i] != '\0'; i++)
-        szFname[i] = (char)tolower(szFname[i]);
+        szFname[i] = (char)tolower(static_cast<unsigned char>(szFname[i]));
 
     if (nStatus == 0)
     {
@@ -961,7 +961,8 @@ int AVCE00DeleteCoverage(const char *pszCoverToDelete)
         {
             /* Convert table filename to lowercases */
             for (j = 0; papszFiles[i] && papszFiles[i][j] != '\0'; j++)
-                papszFiles[i][j] = (char)tolower(papszFiles[i][j]);
+                papszFiles[i][j] =
+                    (char)tolower(static_cast<unsigned char>(papszFiles[i][j]));
 
             /* Delete the .DAT file */
             pszFname = CPLSPrintf("%s%s.dat", pszInfoPath, papszFiles[i]);

--- a/ogr/ogrsf_frmts/cad/libopencad/opencad.cpp
+++ b/ogr/ogrsf_frmts/cad/libopencad/opencad.cpp
@@ -55,18 +55,18 @@ static int CheckCADFile(CADFileIO * pCADFileIO)
     size_t nPathLen = strlen( pszFilePath );
 
     if( nPathLen > 3 &&
-        toupper( pszFilePath[nPathLen - 3] ) == 'D' &&
-        toupper( pszFilePath[nPathLen - 2] ) == 'X' &&
-        toupper( pszFilePath[nPathLen - 1] ) == 'F' )
+        toupper( static_cast<unsigned char>(pszFilePath[nPathLen - 3]) ) == 'D' &&
+        toupper( static_cast<unsigned char>(pszFilePath[nPathLen - 2]) ) == 'X' &&
+        toupper( static_cast<unsigned char>(pszFilePath[nPathLen - 1]) ) == 'F' )
     {
         //TODO: "AutoCAD Binary DXF"
         //std::cerr << "DXF ASCII and binary is not supported yet.";
         return 0;
     }
     if( ! ( nPathLen > 3 &&
-            toupper( pszFilePath[nPathLen - 3] ) == 'D' &&
-            toupper( pszFilePath[nPathLen - 2] ) == 'W' &&
-            toupper( pszFilePath[nPathLen - 1] ) == 'G' ) )
+            toupper( static_cast<unsigned char>(pszFilePath[nPathLen - 3]) ) == 'D' &&
+            toupper( static_cast<unsigned char>(pszFilePath[nPathLen - 2]) ) == 'W' &&
+            toupper( static_cast<unsigned char>(pszFilePath[nPathLen - 1]) ) == 'G' ) )
     {
         return 0;
     }

--- a/ogr/ogrsf_frmts/dxf/ogr_autocad_services.cpp
+++ b/ogr/ogrsf_frmts/dxf/ogr_autocad_services.cpp
@@ -67,7 +67,9 @@ CPLString ACTextUnescape(const char *pszRawInput, const char *pszEncoding,
             if (pszInput[1] == ' ')
                 osResult += '^';
             else
-                osResult += static_cast<char>(toupper(pszInput[1])) ^ 0x40;
+                osResult += static_cast<char>(toupper(
+                                static_cast<unsigned char>(pszInput[1]))) ^
+                            0x40;
             pszInput++;
         }
         else if (STARTS_WITH_CI(pszInput, "%%c") ||

--- a/ogr/ogrsf_frmts/edigeo/ogredigeodatasource.cpp
+++ b/ogr/ogrsf_frmts/edigeo/ogredigeodatasource.cpp
@@ -190,7 +190,7 @@ VSILFILE *OGREDIGEODataSource::OpenFile(const char *pszType,
     {
         CPLString osExtLower = osExt;
         for (int i = 0; i < (int)osExt.size(); i++)
-            osExtLower[i] = (char)tolower(osExt[i]);
+            osExtLower[i] = (char)tolower(static_cast<unsigned char>(osExt[i]));
         CPLString osFilename2 = CPLFormCIFilename(
             CPLGetPath(pszName), osTmp.c_str(), osExtLower.c_str());
         fp = VSIFOpenL(osFilename2, "rb");

--- a/ogr/ogrsf_frmts/elastic/ogrelasticlayer.cpp
+++ b/ogr/ogrsf_frmts/elastic/ogrelasticlayer.cpp
@@ -1414,7 +1414,7 @@ static void decode_geohash_bbox(const char *geohash, double lat[2],
     hashlen = static_cast<int>(strlen(geohash));
     for (i = 0; i < hashlen; i++)
     {
-        c = static_cast<char>(tolower(geohash[i]));
+        c = static_cast<char>(tolower(static_cast<unsigned char>(geohash[i])));
         cd = static_cast<char>(strchr(BASE32, c) - BASE32);
         for (j = 0; j < 5; j++)
         {

--- a/ogr/ogrsf_frmts/geoconcept/geoconcept.c
+++ b/ogr/ogrsf_frmts/geoconcept/geoconcept.c
@@ -1529,7 +1529,7 @@ static GCExportFileMetadata GCIOAPI_CALL1(*)
             e = p;
             if (*p == '-')
                 p++; /* allow -1 as SysCoord */
-            while (isdigit(*p))
+            while (isdigit((unsigned char)*p))
                 p++;
             *p = '\0';
             if (sscanf(e, "%d", &v) != 1)
@@ -1551,7 +1551,7 @@ static GCExportFileMetadata GCIOAPI_CALL1(*)
                     e = p;
                     if (*p == '-')
                         p++; /* allow -1 as TimeZone */
-                    while (isdigit(*p))
+                    while (isdigit((unsigned char)*p))
                         p++;
                     *p = '\0';
                     if (sscanf(e, "%d", &z) != 1)
@@ -1727,7 +1727,7 @@ static GCExportFileMetadata GCIOAPI_CALL1(*)
         }
         p = vl[1];
         e = p;
-        while (isdigit(*p))
+        while (isdigit((unsigned char)*p))
             p++;
         *p = '\0';
         if (sscanf(e, "%d", &v) != 1 || v < 1 || v > 4)

--- a/ogr/ogrsf_frmts/geoconcept/geoconcept.c
+++ b/ogr/ogrsf_frmts/geoconcept/geoconcept.c
@@ -1411,7 +1411,7 @@ static GCExportFileMetadata GCIOAPI_CALL1(*)
         while (isspace((unsigned char)*p))
             p++;
         e = p;
-        while (isalpha(*p))
+        while (isalpha((unsigned char)*p))
             p++;
         *p = '\0';
         SetMetaVersion_GCIO(Meta, CPLStrdup(e));
@@ -1468,7 +1468,7 @@ static GCExportFileMetadata GCIOAPI_CALL1(*)
         while (isspace((unsigned char)*p))
             p++;
         e = p;
-        while (isalpha(*p))
+        while (isalpha((unsigned char)*p))
             p++;
         *p = '\0';
         SetMetaCharset_GCIO(Meta, str2GCCharset_GCIO(e));
@@ -1483,7 +1483,7 @@ static GCExportFileMetadata GCIOAPI_CALL1(*)
             while (isspace((unsigned char)*p))
                 p++;
             e = p;
-            while (isalpha(*p) || *p == '.')
+            while (isalpha((unsigned char)*p) || *p == '.')
                 p++;
             *p = '\0';
             SetMetaUnit_GCIO(Meta, e); /* FIXME : check value ? */

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsondatasource.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsondatasource.cpp
@@ -945,12 +945,12 @@ void OGRGeoJSONDataSource::LoadLayers(GDALOpenInfo *poOpenInfo,
         if (pszStr)
         {
             pszStr += strlen("\"features\"");
-            while (*pszStr && isspace(*pszStr))
+            while (*pszStr && isspace(static_cast<unsigned char>(*pszStr)))
                 pszStr++;
             if (*pszStr == ':')
             {
                 pszStr++;
-                while (*pszStr && isspace(*pszStr))
+                while (*pszStr && isspace(static_cast<unsigned char>(*pszStr)))
                     pszStr++;
                 if (*pszStr == '[')
                 {

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonlayer.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonlayer.cpp
@@ -302,7 +302,8 @@ OGRErr OGRGeoJSONLayer::ICreateFeature(OGRFeature *poFeature)
                     szBuffer[10] = 0;
                     int i = 9;
                     // Locate final }
-                    while (isspace(szBuffer[i]) && i > 0)
+                    while (isspace(static_cast<unsigned char>(szBuffer[i])) &&
+                           i > 0)
                         i--;
                     if (szBuffer[i] != '}')
                     {
@@ -312,7 +313,8 @@ OGRErr OGRGeoJSONLayer::ICreateFeature(OGRFeature *poFeature)
                     if (i > 0)
                         i--;
                     // Locate ']' ending features array
-                    while (isspace(szBuffer[i]) && i > 0)
+                    while (isspace(static_cast<unsigned char>(szBuffer[i])) &&
+                           i > 0)
                         i--;
                     if (szBuffer[i] != ']')
                     {
@@ -321,7 +323,8 @@ OGRErr OGRGeoJSONLayer::ICreateFeature(OGRFeature *poFeature)
                     }
                     if (i > 0)
                         i--;
-                    while (isspace(szBuffer[i]) && i > 0)
+                    while (isspace(static_cast<unsigned char>(szBuffer[i])) &&
+                           i > 0)
                         i--;
                     // Locate '}' ending last feature, or '[' starting features
                     // array

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonutils.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonutils.cpp
@@ -57,7 +57,7 @@ static bool IsJSONObject(const char *pszText)
     /* -------------------------------------------------------------------- */
     /*      This is a primitive test, but we need to perform it fast.       */
     /* -------------------------------------------------------------------- */
-    while (*pszText != '\0' && isspace((unsigned char)*pszText))
+    while (*pszText != '\0' && isspace(static_cast<unsigned char>(*pszText)))
         pszText++;
 
     const char *const apszPrefix[] = {"loadGeoJSON(", "jsonp("};
@@ -89,12 +89,12 @@ static bool IsTypeSomething(const char *pszText, const char *pszTypeValue)
         if (pszIter == nullptr)
             return false;
         pszIter += strlen("\"type\"");
-        while (isspace(*pszIter))
+        while (isspace(static_cast<unsigned char>(*pszIter)))
             pszIter++;
         if (*pszIter != ':')
             return false;
         pszIter++;
-        while (isspace(*pszIter))
+        while (isspace(static_cast<unsigned char>(*pszIter)))
             pszIter++;
         CPLString osValue;
         osValue.Printf("\"%s\"", pszTypeValue);
@@ -143,7 +143,7 @@ static CPLString GetCompactJSon(const char *pszText, size_t nMaxSize)
             bInString = true;
             osWithoutSpace += '"';
         }
-        else if (!isspace(static_cast<int>(pszText[i])))
+        else if (!isspace(static_cast<unsigned char>(pszText[i])))
         {
             osWithoutSpace += pszText[i];
         }
@@ -336,7 +336,7 @@ static bool IsLikelyNewlineSequenceGeoJSON(VSILFILE *fpL,
                 {
                     bEOLFound = true;
                 }
-                else if (!isspace(static_cast<int>(abyBuffer[i])))
+                else if (!isspace(static_cast<unsigned char>(abyBuffer[i])))
                 {
                     bCompatibleOfSequence = false;
                     break;

--- a/ogr/ogrsf_frmts/gml/ogrgmldatasource.cpp
+++ b/ogr/ogrsf_frmts/gml/ogrgmldatasource.cpp
@@ -2991,7 +2991,8 @@ void OGRGMLDataSource::FindAndParseTopElements(VSILFILE *fp)
             const char *pszEndTag = nullptr;
             for (const char *pszIter = pszStartTag; *pszIter != '\0'; pszIter++)
             {
-                if (isspace(*pszIter) || *pszIter == '>')
+                if (isspace(static_cast<unsigned char>(*pszIter)) ||
+                    *pszIter == '>')
                 {
                     pszEndTag = pszIter;
                     break;

--- a/ogr/ogrsf_frmts/gmlas/ogrgmlasconf.cpp
+++ b/ogr/ogrsf_frmts/gmlas/ogrgmlasconf.cpp
@@ -176,13 +176,13 @@ static bool IsValidXPath(const CPLString &osXPath)
             // OK
         }
         else if (isdigit(static_cast<unsigned char>(chCur)) && i > 0 &&
-                 (isalnum(static_cast<int>(osXPath[i - 1])) ||
+                 (isalnum(static_cast<unsigned char>(osXPath[i - 1])) ||
                   osXPath[i - 1] == '_'))
         {
             // OK
         }
         else if (chCur == ':' && i > 0 &&
-                 (isalnum(static_cast<int>(osXPath[i - 1])) ||
+                 (isalnum(static_cast<unsigned char>(osXPath[i - 1])) ||
                   osXPath[i - 1] == '_') &&
                  i < osXPath.size() - 1 &&
                  isalpha(static_cast<int>(osXPath[i + 1])))

--- a/ogr/ogrsf_frmts/gmlas/ogrgmlasconf.cpp
+++ b/ogr/ogrsf_frmts/gmlas/ogrgmlasconf.cpp
@@ -167,11 +167,11 @@ static bool IsValidXPath(const CPLString &osXPath)
         }
         else if (chCur == '@' && (i == 0 || osXPath[i - 1] == '/') &&
                  i < osXPath.size() - 1 &&
-                 isalpha(static_cast<int>(osXPath[i + 1])))
+                 isalpha(static_cast<unsigned char>(osXPath[i + 1])))
         {
             // OK
         }
-        else if (chCur == '_' || isalpha(static_cast<int>(chCur)))
+        else if (chCur == '_' || isalpha(static_cast<unsigned char>(chCur)))
         {
             // OK
         }
@@ -185,7 +185,7 @@ static bool IsValidXPath(const CPLString &osXPath)
                  (isalnum(static_cast<unsigned char>(osXPath[i - 1])) ||
                   osXPath[i - 1] == '_') &&
                  i < osXPath.size() - 1 &&
-                 isalpha(static_cast<int>(osXPath[i + 1])))
+                 isalpha(static_cast<unsigned char>(osXPath[i + 1])))
         {
             // OK
         }

--- a/ogr/ogrsf_frmts/gmlas/ogrgmlasconf.cpp
+++ b/ogr/ogrsf_frmts/gmlas/ogrgmlasconf.cpp
@@ -175,7 +175,7 @@ static bool IsValidXPath(const CPLString &osXPath)
         {
             // OK
         }
-        else if (isdigit(static_cast<int>(chCur)) && i > 0 &&
+        else if (isdigit(static_cast<unsigned char>(chCur)) && i > 0 &&
                  (isalnum(static_cast<int>(osXPath[i - 1])) ||
                   osXPath[i - 1] == '_'))
         {

--- a/ogr/ogrsf_frmts/gmlas/ogrgmlasreader.cpp
+++ b/ogr/ogrsf_frmts/gmlas/ogrgmlasreader.cpp
@@ -2747,7 +2747,7 @@ static void SetSWEValue(OGRFeature *poFeature, int iField, CPLString &osValue)
 
 static size_t SkipSpace(const char *pszValues, size_t i)
 {
-    while (isspace(static_cast<int>(pszValues[i])))
+    while (isspace(static_cast<unsigned char>(pszValues[i])))
         i++;
     return i;
 }

--- a/ogr/ogrsf_frmts/gmlas/ogrgmlasschemaanalyzer.cpp
+++ b/ogr/ogrsf_frmts/gmlas/ogrgmlasschemaanalyzer.cpp
@@ -306,7 +306,7 @@ CPLString GMLASSchemaAnalyzer::GetPrefix(const CPLString &osNamespaceURI)
             osPrefix = osNamespaceURI;
         for (size_t i = 0; i < osPrefix.size(); i++)
         {
-            if (!isalnum(osPrefix[i]))
+            if (!isalnum(static_cast<unsigned char>(osPrefix[i])))
                 osPrefix[i] = '_';
         }
         m_oMapURIToPrefix[osNamespaceURI] = osPrefix;

--- a/ogr/ogrsf_frmts/gmlas/ogrgmlasutils.cpp
+++ b/ogr/ogrsf_frmts/gmlas/ogrgmlasutils.cpp
@@ -63,7 +63,7 @@ CPLString OGRGMLASTruncateIdentifier(const CPLString &osName,
             osCurrentPart += pszToken[1];
             for (int k = 2; pszToken[k]; ++k)
             {
-                if (isupper(pszToken[k]))
+                if (isupper(static_cast<unsigned char>(pszToken[k])))
                 {
                     if (!bLastIsLower)
                     {

--- a/ogr/ogrsf_frmts/gmlas/ogrgmlasutils.cpp
+++ b/ogr/ogrsf_frmts/gmlas/ogrgmlasutils.cpp
@@ -52,7 +52,8 @@ CPLString OGRGMLASTruncateIdentifier(const CPLString &osName,
         const char *pszToken = papszTokens[j];
         bool bIsCamelCase = false;
         // Split parts like camelCase or CamelCase into several tokens
-        if (pszToken[0] != '\0' && islower(pszToken[1]))
+        if (pszToken[0] != '\0' &&
+            islower(static_cast<unsigned char>(pszToken[1])))
         {
             bIsCamelCase = true;
             bool bLastIsLower = true;

--- a/ogr/ogrsf_frmts/gmlas/ogrgmlasxsdcache.cpp
+++ b/ogr/ogrsf_frmts/gmlas/ogrgmlasxsdcache.cpp
@@ -111,7 +111,8 @@ std::string GMLASResourceCache::GetCachedFilename(const std::string &osResource)
         osLaunderedName = osLaunderedName.substr(strlen("https://"));
     for (size_t i = 0; i < osLaunderedName.size(); i++)
     {
-        if (!isalnum(osLaunderedName[i]) && osLaunderedName[i] != '.')
+        if (!isalnum(static_cast<unsigned char>(osLaunderedName[i])) &&
+            osLaunderedName[i] != '.')
             osLaunderedName[i] = '_';
     }
 

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -7072,7 +7072,8 @@ OGRLayer *GDALGeoPackageDataset::ExecuteSQL(const char *pszSQLCommand,
 
     FlushMetadata();
 
-    while (*pszSQLCommand != '\0' && isspace(*pszSQLCommand))
+    while (*pszSQLCommand != '\0' &&
+           isspace(static_cast<unsigned char>(*pszSQLCommand)))
         pszSQLCommand++;
 
     CPLString osSQLCommand(pszSQLCommand);

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedriver.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedriver.cpp
@@ -278,8 +278,9 @@ struct OGRGeoPackageDriverSubdatasetInfo : public GDALSubdatasetInfo
             m_driverPrefixComponent = aosParts[0];
 
             int subdatasetIndex{2};
-            const bool hasDriveLetter{strlen(aosParts[1]) == 1 &&
-                                      std::isalpha(aosParts[1][0])};
+            const bool hasDriveLetter{
+                strlen(aosParts[1]) == 1 &&
+                std::isalpha(static_cast<unsigned char>(aosParts[1][0]))};
 
             // Check for drive letter
             if (iPartsCount == 4)

--- a/ogr/ogrsf_frmts/hana/ogrhanadatasource.cpp
+++ b/ogr/ogrsf_frmts/hana/ogrhanadatasource.cpp
@@ -362,11 +362,14 @@ GetGeometryColumnDescription(odbc::Connection &conn, const CPLString &query,
     CPLString clmName = columnName;
     if (needColumnName)
     {
-        auto it = std::search(preparedQuery.begin(), preparedQuery.end(),
-                              columnName.begin(), columnName.end(),
-                              [](char ch1, char ch2) {
-                                  return std::toupper(ch1) == std::toupper(ch2);
-                              });
+        auto it = std::search(
+            preparedQuery.begin(), preparedQuery.end(), columnName.begin(),
+            columnName.end(),
+            [](char ch1, char ch2)
+            {
+                return std::toupper(static_cast<unsigned char>(ch1)) ==
+                       std::toupper(static_cast<unsigned char>(ch2));
+            });
 
         if (it != preparedQuery.end())
         {
@@ -1282,7 +1285,8 @@ std::pair<OGRErr, CPLString> OGRHanaDataSource::LaunderName(const char *name)
             if (c == '-' || c == '#')
                 newName[i] = '_';
             else
-                newName[i] = static_cast<char>(toupper(c));
+                newName[i] =
+                    static_cast<char>(toupper(static_cast<unsigned char>(c)));
         }
         else
         {

--- a/ogr/ogrsf_frmts/ili/ili2reader.cpp
+++ b/ogr/ogrsf_frmts/ili/ili2reader.cpp
@@ -72,8 +72,12 @@ int cmpStr(const string &s1, const string &s2)
 
     while (p1 != s1.end() && p2 != s2.end())
     {
-        if (toupper(*p1) != toupper(*p2))
-            return (toupper(*p1) < toupper(*p2)) ? -1 : 1;
+        if (toupper(static_cast<unsigned char>(*p1)) !=
+            toupper(static_cast<unsigned char>(*p2)))
+            return (toupper(static_cast<unsigned char>(*p1)) <
+                    toupper(static_cast<unsigned char>(*p2)))
+                       ? -1
+                       : 1;
         ++p1;
         ++p2;
     }

--- a/ogr/ogrsf_frmts/jsonfg/ogrjsonfgdataset.cpp
+++ b/ogr/ogrsf_frmts/jsonfg/ogrjsonfgdataset.cpp
@@ -198,12 +198,12 @@ bool OGRJSONFGDataset::Open(GDALOpenInfo *poOpenInfo,
         if (pszStr)
         {
             pszStr += strlen("\"features\"");
-            while (*pszStr && isspace(*pszStr))
+            while (*pszStr && isspace(static_cast<unsigned char>(*pszStr)))
                 pszStr++;
             if (*pszStr == ':')
             {
                 pszStr++;
-                while (*pszStr && isspace(*pszStr))
+                while (*pszStr && isspace(static_cast<unsigned char>(*pszStr)))
                     pszStr++;
                 if (*pszStr == '[')
                 {

--- a/ogr/ogrsf_frmts/mitab/mitab_coordsys.cpp
+++ b/ogr/ogrsf_frmts/mitab/mitab_coordsys.cpp
@@ -364,7 +364,7 @@ int MITABCoordSys2TABProjInfo(const char *pszCoordSys, TABProjInfo *psProj)
     // Fetch the units string.
     if (CSLCount(papszNextField) > 0)
     {
-        if (isdigit(papszNextField[0][0]))
+        if (isdigit(static_cast<unsigned char>(papszNextField[0][0])))
         {
             psProj->nUnitsId = static_cast<GByte>(atoi(papszNextField[0]));
         }

--- a/ogr/ogrsf_frmts/mitab/mitab_feature.cpp
+++ b/ogr/ogrsf_frmts/mitab/mitab_feature.cpp
@@ -6311,7 +6311,7 @@ const char *TABText::GetLabelStyleString() const
 
     if (QueryFontStyle(TABFSAllCaps))
         for (int i = 0; pszTextString[i]; ++i)
-            if (isalpha(pszTextString[i]))
+            if (isalpha(static_cast<unsigned char>(pszTextString[i])))
                 pszTextString[i] = static_cast<char>(toupper(pszTextString[i]));
 
     /* Escape the double quote chars and expand the text */

--- a/ogr/ogrsf_frmts/mitab/mitab_feature.cpp
+++ b/ogr/ogrsf_frmts/mitab/mitab_feature.cpp
@@ -1819,7 +1819,8 @@ const char *TABCustomPoint::GetSymbolStyleString(double dfAngle) const
 
     for (i = 0; i < 7 && *pszPtr != '\0' && *pszPtr != ' '; i++, pszPtr++)
     {
-        szLowerExt[i] = static_cast<char>(tolower(*pszPtr));
+        szLowerExt[i] =
+            static_cast<char>(tolower(static_cast<unsigned char>(*pszPtr)));
     }
     szLowerExt[i] = '\0';
 
@@ -6312,7 +6313,8 @@ const char *TABText::GetLabelStyleString() const
     if (QueryFontStyle(TABFSAllCaps))
         for (int i = 0; pszTextString[i]; ++i)
             if (isalpha(static_cast<unsigned char>(pszTextString[i])))
-                pszTextString[i] = static_cast<char>(toupper(pszTextString[i]));
+                pszTextString[i] = static_cast<char>(
+                    toupper(static_cast<unsigned char>(pszTextString[i])));
 
     /* Escape the double quote chars and expand the text */
     char *pszTmpTextString = nullptr;

--- a/ogr/ogrsf_frmts/mitab/mitab_indfile.cpp
+++ b/ogr/ogrsf_frmts/mitab/mitab_indfile.cpp
@@ -600,7 +600,7 @@ GByte *TABINDFile::BuildKey(int nIndexNumber, const char *pszStr)
     for (i = 0; i < nKeyLength && pszStr[i] != '\0'; i++)
     {
         m_papbyKeyBuffers[nIndexNumber - 1][i] =
-            static_cast<GByte>(toupper(pszStr[i]));
+            static_cast<GByte>(toupper(static_cast<unsigned char>(pszStr[i])));
     }
 
     /* Pad the end of the buffer with '\0' */

--- a/ogr/ogrsf_frmts/mitab/mitab_utils.cpp
+++ b/ogr/ogrsf_frmts/mitab/mitab_utils.cpp
@@ -240,7 +240,8 @@ GBool TABAdjustFilenameExtension(char *pszFname)
     for (int i = static_cast<int>(strlen(pszFname)) - 1;
          i >= 0 && pszFname[i] != '.'; i--)
     {
-        pszFname[i] = static_cast<char>(toupper(pszFname[i]));
+        pszFname[i] =
+            static_cast<char>(toupper(static_cast<unsigned char>(pszFname[i])));
     }
 
     if (VSIStatL(pszFname, &sStatBuf) == 0)
@@ -252,7 +253,8 @@ GBool TABAdjustFilenameExtension(char *pszFname)
     for (int i = static_cast<int>(strlen(pszFname)) - 1;
          i >= 0 && pszFname[i] != '.'; i--)
     {
-        pszFname[i] = static_cast<char>(tolower(pszFname[i]));
+        pszFname[i] =
+            static_cast<char>(tolower(static_cast<unsigned char>(pszFname[i])));
     }
 
     if (VSIStatL(pszFname, &sStatBuf) == 0)

--- a/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdatasource.cpp
+++ b/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdatasource.cpp
@@ -1361,7 +1361,8 @@ char *OGRMSSQLSpatialDataSource::LaunderName(const char *pszSrcName)
 
     for (i = 0; pszSafeName[i] != '\0'; i++)
     {
-        pszSafeName[i] = (char)tolower(pszSafeName[i]);
+        pszSafeName[i] =
+            (char)tolower(static_cast<unsigned char>(pszSafeName[i]));
         if (pszSafeName[i] == '-' || pszSafeName[i] == '#')
             pszSafeName[i] = '_';
     }

--- a/ogr/ogrsf_frmts/mysql/ogrmysqldatasource.cpp
+++ b/ogr/ogrsf_frmts/mysql/ogrmysqldatasource.cpp
@@ -1084,7 +1084,8 @@ char *OGRMySQLDataSource::LaunderName(const char *pszSrcName)
 
     for (int i = 0; pszSafeName[i] != '\0'; i++)
     {
-        pszSafeName[i] = (char)tolower(pszSafeName[i]);
+        pszSafeName[i] =
+            (char)tolower(static_cast<unsigned char>(pszSafeName[i]));
         if (pszSafeName[i] == '-' || pszSafeName[i] == '#')
             pszSafeName[i] = '_';
     }

--- a/ogr/ogrsf_frmts/oci/ogrocisession.cpp
+++ b/ogr/ogrsf_frmts/oci/ogrocisession.cpp
@@ -560,7 +560,8 @@ void OGROCISession::CleanName(char *pszName)
 
     for (i = 0; pszName[i] != '\0'; i++)
     {
-        pszName[i] = static_cast<char>(toupper(pszName[i]));
+        pszName[i] =
+            static_cast<char>(toupper(static_cast<unsigned char>(pszName[i])));
 
         if ((pszName[i] < '0' || pszName[i] > '9') &&
             (pszName[i] < 'A' || pszName[i] > 'Z') && pszName[i] != '_')

--- a/ogr/ogrsf_frmts/ods/ods_formula.cpp
+++ b/ogr/ogrsf_frmts/ods/ods_formula.cpp
@@ -205,7 +205,7 @@ int ods_formulalex(YYSTYPE *ppNode, ods_formula_parse_context *context)
     /* -------------------------------------------------------------------- */
     /*      Handle alpha-numerics.                                          */
     /* -------------------------------------------------------------------- */
-    else if (*pszInput == '.' || isalnum(*pszInput))
+    else if (*pszInput == '.' || isalnum(static_cast<unsigned char>(*pszInput)))
     {
         int nReturn = ODST_IDENTIFIER;
         const char *pszNext = pszInput + 1;
@@ -214,8 +214,8 @@ int ods_formulalex(YYSTYPE *ppNode, ods_formula_parse_context *context)
         osToken += *pszInput;
 
         // collect text characters
-        while (isalnum(*pszNext) || *pszNext == '_' ||
-               ((unsigned char)*pszNext) > 127)
+        while (isalnum(static_cast<unsigned char>(*pszNext)) ||
+               *pszNext == '_' || ((unsigned char)*pszNext) > 127)
             osToken += *(pszNext++);
 
         context->pszNext = pszNext;

--- a/ogr/ogrsf_frmts/openfilegdb/filegdbindex_write.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/filegdbindex_write.cpp
@@ -147,7 +147,7 @@ bool FileGDBTable::CreateIndex(const std::string &osIndexName,
 
     for (const char ch : osIndexName)
     {
-        if (!isalnum(ch) && ch != '_')
+        if (!isalnum(static_cast<unsigned char>(ch)) && ch != '_')
         {
             CPLError(CE_Failure, CPLE_AppDefined,
                      "Invalid index name: must contain only alpha numeric "

--- a/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
@@ -785,7 +785,8 @@ int OGRPGDataSource::Open(const char *pszNewName, int bUpdate, int bTestOpen,
         /* Should work with "PostgreSQL X.Y.Z ..." or "EnterpriseDB X.Y.Z ..."
          */
         const char *pszSpace = strchr(pszVer, ' ');
-        if (pszSpace != nullptr && isdigit(pszSpace[1]))
+        if (pszSpace != nullptr &&
+            isdigit(static_cast<unsigned char>(pszSpace[1])))
         {
             OGRPGDecodeVersionString(&sPostgreSQLVersion, pszSpace + 1);
 #if defined(BINARY_CURSOR_ENABLED)

--- a/ogr/ogrsf_frmts/pgdump/ogrpgdumpdatasource.cpp
+++ b/ogr/ogrsf_frmts/pgdump/ogrpgdumpdatasource.cpp
@@ -135,7 +135,8 @@ char *OGRPGCommonLaunderName(const char *pszSrcName, const char *pszDebugPrefix)
     int i = 0;  // needed after loop
     for (; i < OGR_PG_NAMEDATALEN - 1 && pszSafeName[i] != '\0'; i++)
     {
-        pszSafeName[i] = (char)tolower(pszSafeName[i]);
+        pszSafeName[i] =
+            (char)tolower(static_cast<unsigned char>(pszSafeName[i]));
         if (pszSafeName[i] == '\'' || pszSafeName[i] == '-' ||
             pszSafeName[i] == '#')
         {

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
@@ -3712,7 +3712,8 @@ char *OGRSQLiteDataSource::LaunderName(const char *pszSrcName)
     char *pszSafeName = CPLStrdup(pszSrcName);
     for (int i = 0; pszSafeName[i] != '\0'; i++)
     {
-        pszSafeName[i] = (char)tolower(pszSafeName[i]);
+        pszSafeName[i] =
+            (char)tolower(static_cast<unsigned char>(pszSafeName[i]));
         if (pszSafeName[i] == '\'' || pszSafeName[i] == '-' ||
             pszSafeName[i] == '#')
             pszSafeName[i] = '_';

--- a/ogr/ogrsf_frmts/sqlite/ogrsqliteexecutesql.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqliteexecutesql.cpp
@@ -116,7 +116,7 @@ static CPLString OGR2SQLITEExtractUnquotedString(const char **ppszSQLCommand)
                     chQuoteChar = *pszSQLCommand;
                 }
                 else if (nParenthesisLevel == 0 &&
-                         (isspace((int)*pszSQLCommand) ||
+                         (isspace(static_cast<unsigned char>(*pszSQLCommand)) ||
                           *pszSQLCommand == '.' || *pszSQLCommand == ','))
                 {
                     break;
@@ -145,7 +145,7 @@ static LayerDesc OGR2SQLITEExtractLayerDesc(const char **ppszSQLCommand)
     const char *pszSQLCommand = *ppszSQLCommand;
     LayerDesc oLayerDesc;
 
-    while (isspace((int)*pszSQLCommand))
+    while (isspace(static_cast<unsigned char>(*pszSQLCommand)))
         pszSQLCommand++;
 
     const char *pszOriginalStrStart = pszSQLCommand;
@@ -291,7 +291,7 @@ static void OGR2SQLITEGetPotentialLayerNamesInternal(
             pszSQLCommand++;
             nParenthesisLevel++;
 
-            while (isspace((int)*pszSQLCommand))
+            while (isspace(static_cast<unsigned char>(*pszSQLCommand)))
                 pszSQLCommand++;
 
             OGR2SQLITEAddLayer(pszStart, nNum, pszSQLCommand, oSetLayers,
@@ -301,18 +301,19 @@ static void OGR2SQLITEGetPotentialLayerNamesInternal(
         else if (bLookforFTableName &&
                  STARTS_WITH_CI(pszSQLCommand, "f_table_name") &&
                  (pszSQLCommand[strlen("f_table_name")] == '=' ||
-                  isspace((int)pszSQLCommand[strlen("f_table_name")])))
+                  isspace(static_cast<unsigned char>(
+                      pszSQLCommand[strlen("f_table_name")]))))
         {
             pszSQLCommand += strlen("f_table_name");
 
-            while (isspace((int)*pszSQLCommand))
+            while (isspace(static_cast<unsigned char>(*pszSQLCommand)))
                 pszSQLCommand++;
 
             if (*pszSQLCommand == '=')
             {
                 pszSQLCommand++;
 
-                while (isspace((int)*pszSQLCommand))
+                while (isspace(static_cast<unsigned char>(*pszSQLCommand)))
                     pszSQLCommand++;
 
                 oSetSpatialIndex.insert(
@@ -323,15 +324,17 @@ static void OGR2SQLITEGetPotentialLayerNamesInternal(
         }
 
         else if (STARTS_WITH_CI(pszSQLCommand, "FROM") &&
-                 isspace(pszSQLCommand[strlen("FROM")]))
+                 isspace(
+                     static_cast<unsigned char>(pszSQLCommand[strlen("FROM")])))
         {
             pszSQLCommand += strlen("FROM") + 1;
 
-            while (isspace((int)*pszSQLCommand))
+            while (isspace(static_cast<unsigned char>(*pszSQLCommand)))
                 pszSQLCommand++;
 
             if (STARTS_WITH_CI(pszSQLCommand, "SpatialIndex") &&
-                isspace((int)pszSQLCommand[strlen("SpatialIndex")]))
+                isspace(static_cast<unsigned char>(
+                    pszSQLCommand[strlen("SpatialIndex")])))
             {
                 pszSQLCommand += strlen("SpatialIndex") + 1;
 
@@ -360,16 +363,17 @@ static void OGR2SQLITEGetPotentialLayerNamesInternal(
 
             while (*pszSQLCommand != '\0')
             {
-                if (isspace((int)*pszSQLCommand))
+                if (isspace(static_cast<unsigned char>(*pszSQLCommand)))
                 {
                     pszSQLCommand++;
-                    while (isspace((int)*pszSQLCommand))
+                    while (isspace(static_cast<unsigned char>(*pszSQLCommand)))
                         pszSQLCommand++;
 
                     if (STARTS_WITH_CI(pszSQLCommand, "AS"))
                     {
                         pszSQLCommand += 2;
-                        while (isspace((int)*pszSQLCommand))
+                        while (
+                            isspace(static_cast<unsigned char>(*pszSQLCommand)))
                             pszSQLCommand++;
                     }
 
@@ -384,7 +388,7 @@ static void OGR2SQLITEGetPotentialLayerNamesInternal(
                 else if (*pszSQLCommand == ',')
                 {
                     pszSQLCommand++;
-                    while (isspace((int)*pszSQLCommand))
+                    while (isspace(static_cast<unsigned char>(*pszSQLCommand)))
                         pszSQLCommand++;
 
                     if (*pszSQLCommand == '(')
@@ -410,21 +414,24 @@ static void OGR2SQLITEGetPotentialLayerNamesInternal(
             }
         }
         else if (STARTS_WITH_CI(pszSQLCommand, "JOIN") &&
-                 isspace(pszSQLCommand[strlen("JOIN")]))
+                 isspace(
+                     static_cast<unsigned char>(pszSQLCommand[strlen("JOIN")])))
         {
             pszSQLCommand += strlen("JOIN") + 1;
             OGR2SQLITEAddLayer(pszStart, nNum, pszSQLCommand, oSetLayers,
                                osModifiedSQL);
         }
         else if (STARTS_WITH_CI(pszSQLCommand, "INTO") &&
-                 isspace(pszSQLCommand[strlen("INTO")]))
+                 isspace(
+                     static_cast<unsigned char>(pszSQLCommand[strlen("INTO")])))
         {
             pszSQLCommand += strlen("INTO") + 1;
             OGR2SQLITEAddLayer(pszStart, nNum, pszSQLCommand, oSetLayers,
                                osModifiedSQL);
         }
         else if (STARTS_WITH_CI(pszSQLCommand, "UPDATE") &&
-                 isspace(pszSQLCommand[strlen("UPDATE")]))
+                 isspace(static_cast<unsigned char>(
+                     pszSQLCommand[strlen("UPDATE")])))
         {
             pszSQLCommand += strlen("UPDATE") + 1;
             OGR2SQLITEAddLayer(pszStart, nNum, pszSQLCommand, oSetLayers,
@@ -781,7 +788,8 @@ OGRLayer *OGRSQLiteExecuteSQL(GDALDataset *poDS, const char *pszStatement,
                               OGRGeometry *poSpatialFilter,
                               CPL_UNUSED const char *pszDialect)
 {
-    while (*pszStatement != '\0' && isspace(*pszStatement))
+    while (*pszStatement != '\0' &&
+           isspace(static_cast<unsigned char>(*pszStatement)))
         pszStatement++;
 
     if (STARTS_WITH_CI(pszStatement, "ALTER TABLE ") ||

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitevirtualogr.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitevirtualogr.cpp
@@ -1170,7 +1170,7 @@ static int OGR2SQLITE_Filter(sqlite3_vtab_cursor *pCursor,
             for (int j = 0; !bNeedsQuoting && (ch = pszFieldName[j]) != '\0';
                  j++)
             {
-                if (!(isalnum((int)ch) || ch == '_'))
+                if (!(isalnum(static_cast<unsigned char>(ch)) || ch == '_'))
                     bNeedsQuoting = true;
             }
 

--- a/ogr/ogrsf_frmts/tiger/ogrtigerdatasource.cpp
+++ b/ogr/ogrsf_frmts/tiger/ogrtigerdatasource.cpp
@@ -470,8 +470,10 @@ int OGRTigerDataSource::Open(const char *pszFilename, int bTestOpen,
             if (pszRecStart[0] != '1')
                 continue;
 
-            if (!isdigit(pszRecStart[1]) || !isdigit(pszRecStart[2]) ||
-                !isdigit(pszRecStart[3]) || !isdigit(pszRecStart[4]))
+            if (!isdigit(static_cast<unsigned char>(pszRecStart[1])) ||
+                !isdigit(static_cast<unsigned char>(pszRecStart[2])) ||
+                !isdigit(static_cast<unsigned char>(pszRecStart[3])) ||
+                !isdigit(static_cast<unsigned char>(pszRecStart[4])))
                 continue;
 
             nVersionCode = atoi(TigerFileBase::GetField(pszRecStart, 2, 5));

--- a/ogr/ogrsf_frmts/wfs/ogrwfsdatasource.cpp
+++ b/ogr/ogrsf_frmts/wfs/ogrwfsdatasource.cpp
@@ -2227,7 +2227,8 @@ OGRLayer *OGRWFSDataSource::ExecuteSQL(const char *pszSQLCommand,
                                        const char *pszDialect)
 
 {
-    while (*pszSQLCommand && isspace(*pszSQLCommand))
+    while (*pszSQLCommand &&
+           isspace(static_cast<unsigned char>(*pszSQLCommand)))
         ++pszSQLCommand;
 
     swq_select_parse_options oParseOptions;

--- a/ogr/ogrspatialreference.cpp
+++ b/ogr/ogrspatialreference.cpp
@@ -3720,7 +3720,7 @@ OGRErr OGRSpatialReference::SetFromUserInput(const char *pszDefinition,
                                              CSLConstList papszOptions)
 {
     // Skip leading white space
-    while (isspace(*pszDefinition))
+    while (isspace(static_cast<unsigned char>(*pszDefinition)))
         pszDefinition++;
 
     if (STARTS_WITH_CI(pszDefinition, "ESRI::"))

--- a/ogr/ogrutils.cpp
+++ b/ogr/ogrutils.cpp
@@ -512,9 +512,10 @@ const char *OGRWktReadPoints(const char *pszInput, OGRRawPoint **ppaoPoints,
         pszInput = OGRWktReadToken(pszInput, szTokenX);
         pszInput = OGRWktReadToken(pszInput, szTokenY);
 
-        if ((!isdigit(szTokenX[0]) && szTokenX[0] != '-' &&
-             szTokenX[0] != '.') ||
-            (!isdigit(szTokenY[0]) && szTokenY[0] != '-' && szTokenY[0] != '.'))
+        if ((!isdigit(static_cast<unsigned char>(szTokenX[0])) &&
+             szTokenX[0] != '-' && szTokenX[0] != '.') ||
+            (!isdigit(static_cast<unsigned char>(szTokenY[0])) &&
+             szTokenY[0] != '-' && szTokenY[0] != '.'))
             return nullptr;
 
         /* --------------------------------------------------------------------
@@ -550,7 +551,8 @@ const char *OGRWktReadPoints(const char *pszInput, OGRRawPoint **ppaoPoints,
          */
         pszInput = OGRWktReadToken(pszInput, szDelim);
 
-        if (isdigit(szDelim[0]) || szDelim[0] == '-' || szDelim[0] == '.')
+        if (isdigit(static_cast<unsigned char>(szDelim[0])) ||
+            szDelim[0] == '-' || szDelim[0] == '.')
         {
             if (*ppadfZ == nullptr)
             {
@@ -575,7 +577,8 @@ const char *OGRWktReadPoints(const char *pszInput, OGRRawPoint **ppaoPoints,
         /*      If we do, just skip it. */
         /* --------------------------------------------------------------------
          */
-        if (isdigit(szDelim[0]) || szDelim[0] == '-' || szDelim[0] == '.')
+        if (isdigit(static_cast<unsigned char>(szDelim[0])) ||
+            szDelim[0] == '-' || szDelim[0] == '.')
         {
             pszInput = OGRWktReadToken(pszInput, szDelim);
         }
@@ -658,10 +661,12 @@ const char *OGRWktReadPointsM(const char *pszInput, OGRRawPoint **ppaoPoints,
         pszInput = OGRWktReadToken(pszInput, szTokenX);
         pszInput = OGRWktReadToken(pszInput, szTokenY);
 
-        if ((!isdigit(szTokenX[0]) && szTokenX[0] != '-' &&
-             szTokenX[0] != '.' && !EQUAL(szTokenX, "nan")) ||
-            (!isdigit(szTokenY[0]) && szTokenY[0] != '-' &&
-             szTokenY[0] != '.' && !EQUAL(szTokenY, "nan")))
+        if ((!isdigit(static_cast<unsigned char>(szTokenX[0])) &&
+             szTokenX[0] != '-' && szTokenX[0] != '.' &&
+             !EQUAL(szTokenX, "nan")) ||
+            (!isdigit(static_cast<unsigned char>(szTokenY[0])) &&
+             szTokenY[0] != '-' && szTokenY[0] != '.' &&
+             !EQUAL(szTokenY, "nan")))
             return nullptr;
 
         /* --------------------------------------------------------------------
@@ -711,8 +716,8 @@ const char *OGRWktReadPointsM(const char *pszInput, OGRRawPoint **ppaoPoints,
 
         if (!(*flags & OGRGeometry::OGR_G_3D) &&
             !(*flags & OGRGeometry::OGR_G_MEASURED) &&
-            (isdigit(szDelim[0]) || szDelim[0] == '-' || szDelim[0] == '.' ||
-             EQUAL(szDelim, "nan")))
+            (isdigit(static_cast<unsigned char>(szDelim[0])) ||
+             szDelim[0] == '-' || szDelim[0] == '.' || EQUAL(szDelim, "nan")))
         {
             *flags |= OGRGeometry::OGR_G_3D;
         }
@@ -731,8 +736,8 @@ const char *OGRWktReadPointsM(const char *pszInput, OGRRawPoint **ppaoPoints,
                 *ppadfZ = static_cast<double *>(
                     CPLCalloc(sizeof(double), *pnMaxPoints));
             }
-            if (isdigit(szDelim[0]) || szDelim[0] == '-' || szDelim[0] == '.' ||
-                EQUAL(szDelim, "nan"))
+            if (isdigit(static_cast<unsigned char>(szDelim[0])) ||
+                szDelim[0] == '-' || szDelim[0] == '.' || EQUAL(szDelim, "nan"))
             {
                 (*ppadfZ)[*pnPointsRead] = CPLAtof(szDelim);
                 pszInput = OGRWktReadToken(pszInput, szDelim);
@@ -756,8 +761,8 @@ const char *OGRWktReadPointsM(const char *pszInput, OGRRawPoint **ppaoPoints,
          */
 
         if (!(*flags & OGRGeometry::OGR_G_MEASURED) &&
-            (isdigit(szDelim[0]) || szDelim[0] == '-' || szDelim[0] == '.' ||
-             EQUAL(szDelim, "nan")))
+            (isdigit(static_cast<unsigned char>(szDelim[0])) ||
+             szDelim[0] == '-' || szDelim[0] == '.' || EQUAL(szDelim, "nan")))
         {
             if (bNoFlags)
             {
@@ -783,8 +788,8 @@ const char *OGRWktReadPointsM(const char *pszInput, OGRRawPoint **ppaoPoints,
                 *ppadfM = static_cast<double *>(
                     CPLCalloc(sizeof(double), *pnMaxPoints));
             }
-            if (isdigit(szDelim[0]) || szDelim[0] == '-' || szDelim[0] == '.' ||
-                EQUAL(szDelim, "nan"))
+            if (isdigit(static_cast<unsigned char>(szDelim[0])) ||
+                szDelim[0] == '-' || szDelim[0] == '.' || EQUAL(szDelim, "nan"))
             {
                 (*ppadfM)[*pnPointsRead] = CPLAtof(szDelim);
                 pszInput = OGRWktReadToken(pszInput, szDelim);
@@ -808,8 +813,8 @@ const char *OGRWktReadPointsM(const char *pszInput, OGRRawPoint **ppaoPoints,
          */
 
         if (!(*flags & OGRGeometry::OGR_G_3D) &&
-            (isdigit(szDelim[0]) || szDelim[0] == '-' || szDelim[0] == '.' ||
-             EQUAL(szDelim, "nan")))
+            (isdigit(static_cast<unsigned char>(szDelim[0])) ||
+             szDelim[0] == '-' || szDelim[0] == '.' || EQUAL(szDelim, "nan")))
         {
             *flags |= OGRGeometry::OGR_G_3D;
             if (*ppadfZ == nullptr)
@@ -1313,7 +1318,9 @@ int OGRParseDate(const char *pszInput, OGRField *psField, int nOptions)
             if (pszInput[0] == '-')
                 psField->Date.TZFlag = -1 * (psField->Date.TZFlag - 100) + 100;
         }
-        else if (isdigit(pszInput[3]) && isdigit(pszInput[4])  // +HHMM offset
+        else if (isdigit(static_cast<unsigned char>(pszInput[3])) &&
+                 isdigit(
+                     static_cast<unsigned char>(pszInput[4]))  // +HHMM offset
                  && atoi(pszInput + 3) % 15 == 0)
         {
             psField->Date.TZFlag = static_cast<GByte>(
@@ -1323,7 +1330,8 @@ int OGRParseDate(const char *pszInput, OGRField *psField, int nOptions)
             if (pszInput[0] == '-')
                 psField->Date.TZFlag = -1 * (psField->Date.TZFlag - 100) + 100;
         }
-        else if (isdigit(pszInput[3]) && pszInput[4] == '\0'  // +HMM offset
+        else if (isdigit(static_cast<unsigned char>(pszInput[3])) &&
+                 pszInput[4] == '\0'  // +HMM offset
                  && atoi(pszInput + 2) % 15 == 0)
         {
             psField->Date.TZFlag = static_cast<GByte>(

--- a/ogr/swq.cpp
+++ b/ogr/swq.cpp
@@ -216,7 +216,7 @@ int swqlex(YYSTYPE *ppNode, swq_parse_context *context)
     /* -------------------------------------------------------------------- */
     /*      Handle alpha-numerics.                                          */
     /* -------------------------------------------------------------------- */
-    else if (isalnum(*pszInput))
+    else if (isalnum(static_cast<unsigned char>(*pszInput)))
     {
         int nReturn = SWQT_IDENTIFIER;
         CPLString osToken;
@@ -225,8 +225,8 @@ int swqlex(YYSTYPE *ppNode, swq_parse_context *context)
         osToken += *pszInput;
 
         // collect text characters
-        while (isalnum(*pszNext) || *pszNext == '_' ||
-               static_cast<unsigned char>(*pszNext) > 127)
+        while (isalnum(static_cast<unsigned char>(*pszNext)) ||
+               *pszNext == '_' || static_cast<unsigned char>(*pszNext) > 127)
             osToken += *(pszNext++);
 
         context->pszNext = pszNext;

--- a/ogr/swq_expr_node.cpp
+++ b/ogr/swq_expr_node.cpp
@@ -489,7 +489,8 @@ CPLString swq_expr_node::QuoteIfNecessary(const CPLString &osExpr, char chQuote)
     for (int i = 0; i < static_cast<int>(osExpr.size()); i++)
     {
         char ch = osExpr[i];
-        if ((!(isalnum(static_cast<int>(ch)) || ch == '_')) || ch == '.')
+        if ((!(isalnum(static_cast<unsigned char>(ch)) || ch == '_')) ||
+            ch == '.')
         {
             return Quote(osExpr, chQuote);
         }

--- a/ogr/swq_op_general.cpp
+++ b/ogr/swq_op_general.cpp
@@ -156,7 +156,9 @@ int swq_test_like(const char *input, const char *pattern, char chEscape,
                 input += input_codepoint_size;
             }
             else if ((!insensitive && *pattern != *input) ||
-                     (insensitive && tolower(*pattern) != tolower(*input)))
+                     (insensitive &&
+                      tolower(static_cast<unsigned char>(*pattern)) !=
+                          tolower(static_cast<unsigned char>(*input))))
             {
                 return 0;
             }

--- a/port/cpl_conv.cpp
+++ b/port/cpl_conv.cpp
@@ -2176,7 +2176,7 @@ void CPLLoadConfigOptionsFromFile(const char *pszFilename, int bOverrideEnvVars)
     {
         for (; *pszStr; ++pszStr)
         {
-            if (!isspace(*pszStr))
+            if (!isspace(static_cast<unsigned char>(*pszStr)))
                 return false;
         }
         return true;

--- a/port/cpl_conv.cpp
+++ b/port/cpl_conv.cpp
@@ -341,7 +341,8 @@ char *CPLStrlwr(char *pszString)
 
     while (*pszTemp)
     {
-        *pszTemp = static_cast<char>(tolower(*pszTemp));
+        *pszTemp =
+            static_cast<char>(tolower(static_cast<unsigned char>(*pszTemp)));
         pszTemp++;
     }
 

--- a/port/cpl_conv.cpp
+++ b/port/cpl_conv.cpp
@@ -2461,7 +2461,7 @@ double CPLDMSToDec(const char *is)
     double v = 0.0;
     for (; nl < 3; nl = n + 1)
     {
-        if (!(isdigit(*s) || *s == '.'))
+        if (!(isdigit(static_cast<unsigned char>(*s)) || *s == '.'))
             break;
         const double tv = proj_strtod(s, &s);
         if (tv == HUGE_VAL)

--- a/port/cpl_json_streaming_parser.cpp
+++ b/port/cpl_json_streaming_parser.cpp
@@ -170,8 +170,8 @@ bool CPLJSonStreamingParser::EmitUnexpectedChar(char ch,
 static bool IsValidNewToken(char ch)
 {
     return ch == '[' || ch == '{' || ch == '"' || ch == '-' || ch == '.' ||
-           isdigit(ch) || ch == 't' || ch == 'f' || ch == 'n' || ch == 'i' ||
-           ch == 'I' || ch == 'N';
+           isdigit(static_cast<unsigned char>(ch)) || ch == 't' || ch == 'f' ||
+           ch == 'n' || ch == 'i' || ch == 'I' || ch == 'N';
 }
 
 /************************************************************************/
@@ -208,8 +208,9 @@ bool CPLJSonStreamingParser::StartNewToken(const char *&pStr, size_t &nLength)
         m_aState.push_back(ARRAY);
         AdvanceChar(pStr, nLength);
     }
-    else if (ch == '-' || ch == '.' || isdigit(ch) || ch == 'i' || ch == 'I' ||
-             ch == 'N')
+    else if (ch == '-' || ch == '.' ||
+             isdigit(static_cast<unsigned char>(ch)) || ch == 'i' ||
+             ch == 'I' || ch == 'N')
     {
         m_aState.push_back(NUMBER);
     }

--- a/port/cpl_json_streaming_parser.cpp
+++ b/port/cpl_json_streaming_parser.cpp
@@ -843,7 +843,7 @@ bool CPLJSonStreamingParser::Parse(const char *pStr, size_t nLength,
                     m_aState.back() = NUMBER;
                     break;
                 }
-                if (isalpha(ch))
+                if (isalpha(static_cast<unsigned char>(ch)))
                 {
                     m_osToken += ch;
                     if (eCurState == STATE_TRUE &&

--- a/port/cpl_json_streaming_parser.cpp
+++ b/port/cpl_json_streaming_parser.cpp
@@ -123,7 +123,7 @@ void CPLJSonStreamingParser::AdvanceChar(const char *&pStr, size_t &nLength)
 
 void CPLJSonStreamingParser::SkipSpace(const char *&pStr, size_t &nLength)
 {
-    while (nLength > 0 && isspace(*pStr))
+    while (nLength > 0 && isspace(static_cast<unsigned char>(*pStr)))
     {
         AdvanceChar(pStr, nLength);
     }
@@ -457,7 +457,8 @@ bool CPLJSonStreamingParser::Parse(const char *pStr, size_t nLength,
             while (nLength)
             {
                 char ch = *pStr;
-                if (ch == '+' || ch == '-' || isdigit(ch) || ch == '.' ||
+                if (ch == '+' || ch == '-' ||
+                    isdigit(static_cast<unsigned char>(ch)) || ch == '.' ||
                     ch == 'e' || ch == 'E')
                 {
                     if (m_osToken.size() == 1024)
@@ -466,7 +467,8 @@ bool CPLJSonStreamingParser::Parse(const char *pStr, size_t nLength,
                     }
                     m_osToken += ch;
                 }
-                else if (isspace(ch) || ch == ',' || ch == '}' || ch == ']')
+                else if (isspace(static_cast<unsigned char>(ch)) || ch == ',' ||
+                         ch == '}' || ch == ']')
                 {
                     SkipSpace(pStr, nLength);
                     break;
@@ -865,7 +867,8 @@ bool CPLJSonStreamingParser::Parse(const char *pStr, size_t nLength,
                         return EmitUnexpectedChar(*pStr);
                     }
                 }
-                else if (isspace(ch) || ch == ',' || ch == '}' || ch == ']')
+                else if (isspace(static_cast<unsigned char>(ch)) || ch == ',' ||
+                         ch == '}' || ch == ']')
                 {
                     SkipSpace(pStr, nLength);
                     break;

--- a/port/cpl_minixml.cpp
+++ b/port/cpl_minixml.cpp
@@ -2249,8 +2249,9 @@ void CPLCleanXMLElementName(char *pszTarget)
 
     for (; *pszTarget != '\0'; pszTarget++)
     {
-        if ((*(reinterpret_cast<unsigned char *>(pszTarget)) & 0x80) ||
-            isalnum(*pszTarget) || *pszTarget == '_' || *pszTarget == '.')
+        if ((static_cast<unsigned char>(*pszTarget) & 0x80) ||
+            isalnum(static_cast<unsigned char>(*pszTarget)) ||
+            *pszTarget == '_' || *pszTarget == '.')
         {
             // Ok.
         }

--- a/port/cpl_path.cpp
+++ b/port/cpl_path.cpp
@@ -711,7 +711,7 @@ const char *CPLFormCIFilename(const char *pszPath, const char *pszBasename,
     {
         for (size_t i = 0; pszFilename[i] != '\0'; i++)
         {
-            if (isupper(pszFilename[i]))
+            if (isupper(static_cast<unsigned char>(pszFilename[i])))
                 pszFilename[i] = static_cast<char>(tolower(pszFilename[i]));
         }
 

--- a/port/cpl_path.cpp
+++ b/port/cpl_path.cpp
@@ -712,7 +712,8 @@ const char *CPLFormCIFilename(const char *pszPath, const char *pszBasename,
         for (size_t i = 0; pszFilename[i] != '\0'; i++)
         {
             if (isupper(static_cast<unsigned char>(pszFilename[i])))
-                pszFilename[i] = static_cast<char>(tolower(pszFilename[i]));
+                pszFilename[i] = static_cast<char>(
+                    tolower(static_cast<unsigned char>(pszFilename[i])));
         }
 
         pszFullPath = CPLFormFilename(pszPath, pszFilename, nullptr);

--- a/port/cpl_path.cpp
+++ b/port/cpl_path.cpp
@@ -699,7 +699,7 @@ const char *CPLFormCIFilename(const char *pszPath, const char *pszBasename,
     {
         for (size_t i = 0; pszFilename[i] != '\0'; i++)
         {
-            if (islower(pszFilename[i]))
+            if (islower(static_cast<unsigned char>(pszFilename[i])))
                 pszFilename[i] = static_cast<char>(toupper(pszFilename[i]));
         }
 

--- a/port/cpl_string.cpp
+++ b/port/cpl_string.cpp
@@ -1514,9 +1514,9 @@ int CPLsscanf(const char *str, CPL_SCANF_FORMAT_STRING(const char *fmt), ...)
                 break;
             }
         }
-        else if (isspace(*fmt))
+        else if (isspace(static_cast<unsigned char>(*fmt)))
         {
-            while (*str != '\0' && isspace(*str))
+            while (*str != '\0' && isspace(static_cast<unsigned char>(*str)))
                 ++str;
         }
         else if (*str != *fmt)

--- a/port/cpl_string.cpp
+++ b/port/cpl_string.cpp
@@ -2842,7 +2842,7 @@ CPLValueType CPLGetValueType(const char *pszValue)
             if (!bFoundMantissa)
                 return CPL_VALUE_STRING;
             if (!(pszValue[1] == '+' || pszValue[1] == '-' ||
-                  isdigit(pszValue[1])))
+                  isdigit(static_cast<unsigned char>(pszValue[1]))))
                 return CPL_VALUE_STRING;
 
             bIsReal = true;

--- a/port/cplstring.cpp
+++ b/port/cplstring.cpp
@@ -277,7 +277,8 @@ size_t CPLString::ifind(const char *s, size_t nPos) const
 
 {
     const char *pszHaystack = c_str();
-    const char chFirst = static_cast<char>(::tolower(s[0]));
+    const char chFirst =
+        static_cast<char>(::tolower(static_cast<unsigned char>(s[0])));
     const size_t nTargetLen = strlen(s);
 
     if (nPos > size())
@@ -287,7 +288,7 @@ size_t CPLString::ifind(const char *s, size_t nPos) const
 
     while (*pszHaystack != '\0')
     {
-        if (chFirst == ::tolower(*pszHaystack))
+        if (chFirst == ::tolower(static_cast<unsigned char>(*pszHaystack)))
         {
             if (EQUALN(pszHaystack, s, nTargetLen))
                 return nPos;
@@ -329,7 +330,8 @@ CPLString &CPLString::tolower()
 
 {
     for (size_t i = 0; i < size(); i++)
-        (*this)[i] = static_cast<char>(::tolower((*this)[i]));
+        (*this)[i] = static_cast<char>(
+            ::tolower(static_cast<unsigned char>((*this)[i])));
 
     return *this;
 }


### PR DESCRIPTION
Cf https://wiki.sei.cmu.edu/confluence/display/c/STR37-C.+Arguments+to+character-handling+functions+must+be+representable+as+an+unsigned+char