### PR TITLE
Remove link to ndjson.org as it's now hosting malware

### DIFF
--- a/doc/source/drivers/vector/geojsonseq.rst
+++ b/doc/source/drivers/vector/geojsonseq.rst
@@ -123,3 +123,5 @@ See Also
    Text Sequences (RS separator)
 -  `GeoJSONL <https://www.interline.io/blog/geojsonl-extracts/>`__: An
    optimized format for large geographic datasets
+-  `JSON streaming on Wikipedia <https://en.wikipedia.org/wiki/JSON_streaming>`__: An
+   overview over formats for concatenated JSON in a single file 

--- a/doc/source/drivers/vector/geojsonseq.rst
+++ b/doc/source/drivers/vector/geojsonseq.rst
@@ -121,6 +121,5 @@ See Also
    GeoJSON Format.
 -  `RFC 8142 <https://tools.ietf.org/html/rfc8142>`__ standard: GeoJSON
    Text Sequences (RS separator)
--  `Newline Delimited JSON <http://ndjson.org/>`__
 -  `GeoJSONL <https://www.interline.io/blog/geojsonl-extracts/>`__: An
    optimized format for large geographic datasets


### PR DESCRIPTION
Removed link to ndjson.org as the author of it has abandoned the domain and it's now being used for hosting malware.

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?
Removes the link to ndjson.org

## What are related issues/pull requests?
[This issue in the ndjson repo,](https://github.com/ndjson/ndjson.github.io/issues/24) explains that the domain has been abandoned.

## Tasklist
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [x] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
