### PR TITLE
VRT: add a NoDataFromMaskSource source

### DIFF
--- a/apps/gdalbuildvrt_bin.cpp
+++ b/apps/gdalbuildvrt_bin.cpp
@@ -56,6 +56,7 @@ static void Usage(bool bIsError, const char *pszErrorMsg)
         "                    [-srcnodata \"<value>[ <value>]...\"] [-vrtnodata "
         "\"<value>[ <value>]...\"\n"
         "                    [-ignore_srcmaskband]\n"
+        "                    [-nodata_if_mask_less_or_equal <threshold>]\n"
         "                    [-a_srs <srs_def>]\n"
         "                    [-r "
         "{nearest|bilinear|cubic|cubicspline|lanczos|average|mode}]\n"

--- a/apps/gdalbuildvrt_bin.cpp
+++ b/apps/gdalbuildvrt_bin.cpp
@@ -56,7 +56,7 @@ static void Usage(bool bIsError, const char *pszErrorMsg)
         "                    [-srcnodata \"<value>[ <value>]...\"] [-vrtnodata "
         "\"<value>[ <value>]...\"\n"
         "                    [-ignore_srcmaskband]\n"
-        "                    [-nodata_if_mask_less_or_equal <threshold>]\n"
+        "                    [-nodata_max_mask_threshold <threshold>]\n"
         "                    [-a_srs <srs_def>]\n"
         "                    [-r "
         "{nearest|bilinear|cubic|cubicspline|lanczos|average|mode}]\n"

--- a/apps/gdalbuildvrt_lib.cpp
+++ b/apps/gdalbuildvrt_lib.cpp
@@ -2208,7 +2208,7 @@ GDALBuildVRTOptionsNew(char **papszArgv,
         {
             psOptions->bUseSrcMaskBand = false;
         }
-        else if (EQUAL(papszArgv[iArg], "-nodata_if_mask_less_or_equal") &&
+        else if (EQUAL(papszArgv[iArg], "-nodata_max_mask_threshold") &&
                  iArg + 1 < argc)
         {
             psOptions->bNoDataFromMask = true;

--- a/autotest/utilities/test_gdalbuildvrt_lib.py
+++ b/autotest/utilities/test_gdalbuildvrt_lib.py
@@ -753,7 +753,7 @@ def test_gdalbuildvrt_lib_stable_average():
 ###############################################################################
 
 
-def test_gdalbuildvrt_lib_nodataIfMaskLessOrEqual_rgba(tmp_vsimem):
+def test_gdalbuildvrt_lib_nodataMaxMaskThreshold_rgba(tmp_vsimem):
 
     ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 4)
     ds.SetGeoTransform([0, 1, 0, 0, 0, -1])
@@ -764,7 +764,7 @@ def test_gdalbuildvrt_lib_nodataIfMaskLessOrEqual_rgba(tmp_vsimem):
     ds.GetRasterBand(4).WriteRaster(0, 0, 2, 1, b"\x00\xFF")
     ds.GetRasterBand(4).SetColorInterpretation(gdal.GCI_AlphaBand)
 
-    vrt_ds = gdal.BuildVRT("", [ds], nodataIfMaskLessOrEqual=128, VRTNodata=0)
+    vrt_ds = gdal.BuildVRT("", [ds], nodataMaxMaskThreshold=128, VRTNodata=0)
     assert vrt_ds.RasterCount == 3
     assert vrt_ds.GetRasterBand(1).GetNoDataValue() == 0
     assert vrt_ds.GetRasterBand(1).ReadRaster() == b"\x00\x01"
@@ -777,7 +777,7 @@ def test_gdalbuildvrt_lib_nodataIfMaskLessOrEqual_rgba(tmp_vsimem):
         "h" * 2, vrt_ds.GetRasterBand(1).ReadRaster(buf_type=gdal.GDT_Int16)
     ) == (0, 1)
 
-    vrt_ds = gdal.BuildVRT("", [ds], nodataIfMaskLessOrEqual=128.5, VRTNodata=0)
+    vrt_ds = gdal.BuildVRT("", [ds], nodataMaxMaskThreshold=128.5, VRTNodata=0)
     assert vrt_ds.GetRasterBand(1).ReadRaster() == b"\x00\x01"
 
     # VRTNodata=255, test remapping of 255 to 254
@@ -787,14 +787,14 @@ def test_gdalbuildvrt_lib_nodataIfMaskLessOrEqual_rgba(tmp_vsimem):
     ds.GetRasterBand(2).WriteRaster(0, 0, 2, 1, b"\x00\xFF")
     ds.GetRasterBand(2).SetColorInterpretation(gdal.GCI_AlphaBand)
 
-    vrt_ds = gdal.BuildVRT("", [ds], nodataIfMaskLessOrEqual=128, VRTNodata=255)
+    vrt_ds = gdal.BuildVRT("", [ds], nodataMaxMaskThreshold=128, VRTNodata=255)
     assert vrt_ds.GetRasterBand(1).ReadRaster() == b"\xFF\xFE"
 
 
 ###############################################################################
 
 
-def test_gdalbuildvrt_lib_nodataIfMaskLessOrEqual_rgb_mask(tmp_vsimem):
+def test_gdalbuildvrt_lib_nodataMaxMaskThreshold_rgb_mask(tmp_vsimem):
 
     # UInt16, VRTNodata=0
     src_filename = str(tmp_vsimem / "src.tif")
@@ -808,9 +808,7 @@ def test_gdalbuildvrt_lib_nodataIfMaskLessOrEqual_rgb_mask(tmp_vsimem):
     ds.Close()
 
     vrt_filename = str(tmp_vsimem / "test.vrt")
-    gdal.BuildVRT(
-        vrt_filename, [src_filename], nodataIfMaskLessOrEqual=128, VRTNodata=0
-    )
+    gdal.BuildVRT(vrt_filename, [src_filename], nodataMaxMaskThreshold=128, VRTNodata=0)
     vrt_ds = gdal.Open(vrt_filename)
     assert struct.unpack(
         "H" * 2, vrt_ds.GetRasterBand(1).ReadRaster(buf_type=gdal.GDT_UInt16)
@@ -831,7 +829,7 @@ def test_gdalbuildvrt_lib_nodataIfMaskLessOrEqual_rgb_mask(tmp_vsimem):
 
     vrt_filename = str(tmp_vsimem / "test.vrt")
     gdal.BuildVRT(
-        vrt_filename, [src_filename], nodataIfMaskLessOrEqual=128, VRTNodata=65535
+        vrt_filename, [src_filename], nodataMaxMaskThreshold=128, VRTNodata=65535
     )
     vrt_ds = gdal.Open(vrt_filename)
     assert struct.unpack(
@@ -849,7 +847,7 @@ def test_gdalbuildvrt_lib_nodataIfMaskLessOrEqual_rgb_mask(tmp_vsimem):
 
     vrt_filename = str(tmp_vsimem / "test.vrt")
     gdal.BuildVRT(
-        vrt_filename, [src_filename], nodataIfMaskLessOrEqual=128, VRTNodata=-32768
+        vrt_filename, [src_filename], nodataMaxMaskThreshold=128, VRTNodata=-32768
     )
     vrt_ds = gdal.Open(vrt_filename)
     assert struct.unpack(
@@ -867,7 +865,7 @@ def test_gdalbuildvrt_lib_nodataIfMaskLessOrEqual_rgb_mask(tmp_vsimem):
 
     vrt_filename = str(tmp_vsimem / "test.vrt")
     gdal.BuildVRT(
-        vrt_filename, [src_filename], nodataIfMaskLessOrEqual=128, VRTNodata=32767
+        vrt_filename, [src_filename], nodataMaxMaskThreshold=128, VRTNodata=32767
     )
     vrt_ds = gdal.Open(vrt_filename)
     assert struct.unpack(
@@ -884,9 +882,7 @@ def test_gdalbuildvrt_lib_nodataIfMaskLessOrEqual_rgb_mask(tmp_vsimem):
     ds.Close()
 
     vrt_filename = str(tmp_vsimem / "test.vrt")
-    gdal.BuildVRT(
-        vrt_filename, [src_filename], nodataIfMaskLessOrEqual=128, VRTNodata=0
-    )
+    gdal.BuildVRT(vrt_filename, [src_filename], nodataMaxMaskThreshold=128, VRTNodata=0)
     vrt_ds = gdal.Open(vrt_filename)
     assert struct.unpack(
         "f" * 2, vrt_ds.GetRasterBand(1).ReadRaster(buf_type=gdal.GDT_Float32)
@@ -902,9 +898,7 @@ def test_gdalbuildvrt_lib_nodataIfMaskLessOrEqual_rgb_mask(tmp_vsimem):
     ds.Close()
 
     vrt_filename = str(tmp_vsimem / "test.vrt")
-    gdal.BuildVRT(
-        vrt_filename, [src_filename], nodataIfMaskLessOrEqual=128, VRTNodata=1
-    )
+    gdal.BuildVRT(vrt_filename, [src_filename], nodataMaxMaskThreshold=128, VRTNodata=1)
     vrt_ds = gdal.Open(vrt_filename)
     assert struct.unpack(
         "f" * 3, vrt_ds.GetRasterBand(1).ReadRaster(buf_type=gdal.GDT_Float32)

--- a/autotest/utilities/test_gdalbuildvrt_lib.py
+++ b/autotest/utilities/test_gdalbuildvrt_lib.py
@@ -757,9 +757,10 @@ def test_gdalbuildvrt_lib_nodataIfMaskLessOrEqual_rgba(tmp_vsimem):
 
     ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 4)
     ds.SetGeoTransform([0, 1, 0, 0, 0, -1])
-    ds.GetRasterBand(1).Fill(1)
-    ds.GetRasterBand(2).Fill(2)
-    ds.GetRasterBand(3).Fill(3)
+    # Test remapping of second valid pixel at 0 to 1
+    ds.GetRasterBand(1).WriteRaster(0, 0, 2, 1, b"\x01\x00")
+    ds.GetRasterBand(2).WriteRaster(0, 0, 2, 1, b"\x02\x02")
+    ds.GetRasterBand(3).WriteRaster(0, 0, 2, 1, b"\x03\x03")
     ds.GetRasterBand(4).WriteRaster(0, 0, 2, 1, b"\x00\xFF")
     ds.GetRasterBand(4).SetColorInterpretation(gdal.GCI_AlphaBand)
 
@@ -779,18 +780,29 @@ def test_gdalbuildvrt_lib_nodataIfMaskLessOrEqual_rgba(tmp_vsimem):
     vrt_ds = gdal.BuildVRT("", [ds], nodataIfMaskLessOrEqual=128.5, VRTNodata=0)
     assert vrt_ds.GetRasterBand(1).ReadRaster() == b"\x00\x01"
 
+    # VRTNodata=255, test remapping of 255 to 254
+    ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 2)
+    ds.SetGeoTransform([0, 1, 0, 0, 0, -1])
+    ds.GetRasterBand(1).WriteRaster(0, 0, 2, 1, b"\x01\xFF")
+    ds.GetRasterBand(2).WriteRaster(0, 0, 2, 1, b"\x00\xFF")
+    ds.GetRasterBand(2).SetColorInterpretation(gdal.GCI_AlphaBand)
+
+    vrt_ds = gdal.BuildVRT("", [ds], nodataIfMaskLessOrEqual=128, VRTNodata=255)
+    assert vrt_ds.GetRasterBand(1).ReadRaster() == b"\xFF\xFE"
+
 
 ###############################################################################
 
 
 def test_gdalbuildvrt_lib_nodataIfMaskLessOrEqual_rgb_mask(tmp_vsimem):
 
+    # UInt16, VRTNodata=0
     src_filename = str(tmp_vsimem / "src.tif")
     ds = gdal.GetDriverByName("GTiff").Create(src_filename, 2, 1, 3, gdal.GDT_UInt16)
     ds.SetGeoTransform([0, 1, 0, 0, 0, -1])
-    ds.GetRasterBand(1).Fill(1)
-    ds.GetRasterBand(2).Fill(2)
-    ds.GetRasterBand(3).Fill(3)
+    ds.GetRasterBand(1).WriteRaster(0, 0, 2, 1, struct.pack("H" * 2, 1, 0))
+    ds.GetRasterBand(2).WriteRaster(0, 0, 2, 1, struct.pack("H" * 2, 2, 2))
+    ds.GetRasterBand(3).WriteRaster(0, 0, 2, 1, struct.pack("H" * 2, 3, 2))
     ds.GetRasterBand(1).CreateMaskBand(gdal.GMF_PER_DATASET)
     ds.GetRasterBand(1).GetMaskBand().WriteRaster(0, 0, 2, 1, b"\x00\xFF")
     ds.Close()
@@ -807,3 +819,93 @@ def test_gdalbuildvrt_lib_nodataIfMaskLessOrEqual_rgb_mask(tmp_vsimem):
     assert struct.unpack(
         "B" * 2, vrt_ds.GetRasterBand(1).ReadRaster(buf_type=gdal.GDT_Byte)
     ) == (0, 1)
+
+    # UInt16, VRTNodata=65535
+    src_filename = str(tmp_vsimem / "src.tif")
+    ds = gdal.GetDriverByName("GTiff").Create(src_filename, 2, 1, 1, gdal.GDT_UInt16)
+    ds.SetGeoTransform([0, 1, 0, 0, 0, -1])
+    ds.GetRasterBand(1).WriteRaster(0, 0, 2, 1, struct.pack("H" * 2, 1, 65535))
+    ds.GetRasterBand(1).CreateMaskBand(gdal.GMF_PER_DATASET)
+    ds.GetRasterBand(1).GetMaskBand().WriteRaster(0, 0, 2, 1, b"\x00\xFF")
+    ds.Close()
+
+    vrt_filename = str(tmp_vsimem / "test.vrt")
+    gdal.BuildVRT(
+        vrt_filename, [src_filename], nodataIfMaskLessOrEqual=128, VRTNodata=65535
+    )
+    vrt_ds = gdal.Open(vrt_filename)
+    assert struct.unpack(
+        "H" * 2, vrt_ds.GetRasterBand(1).ReadRaster(buf_type=gdal.GDT_UInt16)
+    ) == (65535, 65534)
+
+    # Int16, VRTNodata=-32768
+    src_filename = str(tmp_vsimem / "src.tif")
+    ds = gdal.GetDriverByName("GTiff").Create(src_filename, 2, 1, 1, gdal.GDT_Int16)
+    ds.SetGeoTransform([0, 1, 0, 0, 0, -1])
+    ds.GetRasterBand(1).WriteRaster(0, 0, 2, 1, struct.pack("h" * 2, 1, -32768))
+    ds.GetRasterBand(1).CreateMaskBand(gdal.GMF_PER_DATASET)
+    ds.GetRasterBand(1).GetMaskBand().WriteRaster(0, 0, 2, 1, b"\x00\xFF")
+    ds.Close()
+
+    vrt_filename = str(tmp_vsimem / "test.vrt")
+    gdal.BuildVRT(
+        vrt_filename, [src_filename], nodataIfMaskLessOrEqual=128, VRTNodata=-32768
+    )
+    vrt_ds = gdal.Open(vrt_filename)
+    assert struct.unpack(
+        "h" * 2, vrt_ds.GetRasterBand(1).ReadRaster(buf_type=gdal.GDT_Int16)
+    ) == (-32768, -32767)
+
+    # Int16, VRTNodata=32767
+    src_filename = str(tmp_vsimem / "src.tif")
+    ds = gdal.GetDriverByName("GTiff").Create(src_filename, 2, 1, 1, gdal.GDT_Int16)
+    ds.SetGeoTransform([0, 1, 0, 0, 0, -1])
+    ds.GetRasterBand(1).WriteRaster(0, 0, 2, 1, struct.pack("h" * 2, 1, 32767))
+    ds.GetRasterBand(1).CreateMaskBand(gdal.GMF_PER_DATASET)
+    ds.GetRasterBand(1).GetMaskBand().WriteRaster(0, 0, 2, 1, b"\x00\xFF")
+    ds.Close()
+
+    vrt_filename = str(tmp_vsimem / "test.vrt")
+    gdal.BuildVRT(
+        vrt_filename, [src_filename], nodataIfMaskLessOrEqual=128, VRTNodata=32767
+    )
+    vrt_ds = gdal.Open(vrt_filename)
+    assert struct.unpack(
+        "h" * 2, vrt_ds.GetRasterBand(1).ReadRaster(buf_type=gdal.GDT_Int16)
+    ) == (32767, 32766)
+
+    # Float32, VRTNodata=0
+    src_filename = str(tmp_vsimem / "src.tif")
+    ds = gdal.GetDriverByName("GTiff").Create(src_filename, 2, 1, 1, gdal.GDT_Float32)
+    ds.SetGeoTransform([0, 1, 0, 0, 0, -1])
+    ds.GetRasterBand(1).WriteRaster(0, 0, 2, 1, struct.pack("f" * 2, 1, 0))
+    ds.GetRasterBand(1).CreateMaskBand(gdal.GMF_PER_DATASET)
+    ds.GetRasterBand(1).GetMaskBand().WriteRaster(0, 0, 2, 1, b"\x00\xFF")
+    ds.Close()
+
+    vrt_filename = str(tmp_vsimem / "test.vrt")
+    gdal.BuildVRT(
+        vrt_filename, [src_filename], nodataIfMaskLessOrEqual=128, VRTNodata=0
+    )
+    vrt_ds = gdal.Open(vrt_filename)
+    assert struct.unpack(
+        "f" * 2, vrt_ds.GetRasterBand(1).ReadRaster(buf_type=gdal.GDT_Float32)
+    ) == pytest.approx((0.0, 0.001))
+
+    # Float32, VRTNodata=1
+    src_filename = str(tmp_vsimem / "src.tif")
+    ds = gdal.GetDriverByName("GTiff").Create(src_filename, 3, 1, 1, gdal.GDT_Float32)
+    ds.SetGeoTransform([0, 1, 0, 0, 0, -1])
+    ds.GetRasterBand(1).WriteRaster(0, 0, 3, 1, struct.pack("f" * 3, 0, 1, 2))
+    ds.GetRasterBand(1).CreateMaskBand(gdal.GMF_PER_DATASET)
+    ds.GetRasterBand(1).GetMaskBand().WriteRaster(0, 0, 3, 1, b"\x00\xFF\xFF")
+    ds.Close()
+
+    vrt_filename = str(tmp_vsimem / "test.vrt")
+    gdal.BuildVRT(
+        vrt_filename, [src_filename], nodataIfMaskLessOrEqual=128, VRTNodata=1
+    )
+    vrt_ds = gdal.Open(vrt_filename)
+    assert struct.unpack(
+        "f" * 3, vrt_ds.GetRasterBand(1).ReadRaster(buf_type=gdal.GDT_Float32)
+    ) == pytest.approx((1.0, 1.001, 2.0))

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -506,14 +506,16 @@ NoDataFromMaskSource
 .. versionadded:: 3.9
 
 The NoDataFromMaskSource is derived from the SimpleSource and shares the same properties except that it replaces the value of the source with the value of the NODATA child element when the value of the mask band of the source is less or equal to the MaskValueThreshold child element.
+An optional RemappedValue element can be set to specify the value onto which valid pixels whose value is the one of NODATA should be remapped to. When RemappedValue is not explicitly specified, for Byte bands, if NODATA=255, it is implicitly set to 254, otherwise it is set to NODATA+1.
 
 .. code-block:: xml
 
     <NoDataFromMaskSource>
       <SourceFilename relativeToVRT="1">in.tif</SourceFilename>
       <SourceBand>1</SourceBand>
-      <MaskValueThreshold>128</MaskValueThreshold>
+      <MaskValueThreshold>128</MaskValueThreshold> <!-- if the mask value is &lt;= 128, pixels are set to NODATA=0 -->
       <NODATA>0</NODATA>
+      <RemappedValue>1</RemappedValue> <!-- valid/unmasked pixels at NODATA=0 are remapped to 1 -->
     </NoDataFromMaskSource>
 
 

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -185,7 +185,7 @@ The attributes for VRTRasterBand are:
 - **blockYSize** (optional, GDAL >= 3.3): block height.
   If not specified, defaults to the minimum of the raster height and 128.
 
-This element may have Metadata, ColorInterp, NoDataValue, HideNoDataValue, ColorTable, GDALRasterAttributeTable, Description and MaskBand subelements as well as the various kinds of source elements such as SimpleSource, ComplexSource, AveragedSource, KernelFilteredSource and ArraySource.  A raster band may have many "sources" indicating where the actual raster data should be fetched from, and how it should be mapped into the raster bands pixel space.
+This element may have Metadata, ColorInterp, NoDataValue, HideNoDataValue, ColorTable, GDALRasterAttributeTable, Description and MaskBand subelements as well as the various kinds of source elements such as SimpleSource, ComplexSource, AveragedSource, NoDataFromMaskSource, KernelFilteredSource and ArraySource.  A raster band may have many "sources" indicating where the actual raster data should be fetched from, and how it should be mapped into the raster bands pixel space.
 
 The allowed subelements for VRTRasterBand are :
 
@@ -303,6 +303,8 @@ The allowed subelements for VRTRasterBand are :
 - **SimpleSource**: The SimpleSource_ indicates that raster data should be read from a separate dataset, indicating the dataset, and band to be read from, and how the data should map into this band's raster space.
 
 - **AveragedSource**: The AveragedSource is derived from the SimpleSource and shares the same properties except that it uses an averaging resampling instead of a nearest neighbour algorithm as in SimpleSource, when the size of the destination rectangle is not the same as the size of the source rectangle. Note: a more general mechanism to specify resampling algorithms can be used. See above paragraph about the 'resampling' attribute.
+
+- **NoDataFromMaskSource**: (GDAL >= 3.9) The NoDataFromMaskSource is derived from the SimpleSource and shares the same properties except that it replaces the value of the source with the value of the NODATA child element when the value of the mask band of the source is less or equal to the MaskValueThreshold child element.
 
 - **ComplexSource**: The ComplexSource_ is derived from the SimpleSource (so it shares the SourceFilename, SourceBand, SrcRect and DstRect elements), but it provides support to rescale and offset the range of the source values. Certain regions of the source can be masked by specifying the NODATA value, or starting with GDAL 3.3, with the <UseMaskBand>true</UseMaskBand> element.
 
@@ -497,6 +499,23 @@ For example, a Gaussian blur:
         <Coefs>0.01111 0.04394 0.13534 0.32465 0.60653 0.8825 1.0 0.8825 0.60653 0.32465 0.13534 0.04394 0.01111</Coefs>
       </Kernel>
     </KernelFilteredSource>
+
+NoDataFromMaskSource
+~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 3.9
+
+The NoDataFromMaskSource is derived from the SimpleSource and shares the same properties except that it replaces the value of the source with the value of the NODATA child element when the value of the mask band of the source is less or equal to the MaskValueThreshold child element.
+
+.. code-block:: xml
+
+    <NoDataFromMaskSource>
+      <SourceFilename relativeToVRT="1">in.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <MaskValueThreshold>128</MaskValueThreshold>
+      <NODATA>0</NODATA>
+    </NoDataFromMaskSource>
+
 
 ArraySource
 ~~~~~~~~~~~

--- a/doc/source/programs/gdalbuildvrt.rst
+++ b/doc/source/programs/gdalbuildvrt.rst
@@ -24,6 +24,7 @@ Synopsis
                  [-addalpha] [-hidenodata]
                  [-srcnodata "<value>[ <value>]..."] [-vrtnodata "<value>[ <value>]..."
                  [-ignore_srcmaskband]
+                 [-nodata_if_mask_less_or_equal <threshold>]
                  [-a_srs <srs_def>]
                  [-r {nearest|bilinear|cubic|cubicspline|lanczos|average|mode}]
                  [-oo <NAME>=<VALUE>]...
@@ -145,6 +146,14 @@ changed in later versions.
     When specifying the -ignore_srcmaskband option, the mask band of sources will
     not be taken into account, and in case of overlapping between sources, the
     last one will override previous ones in areas of overlap.
+
+.. option:: -nodata_if_mask_less_or_equal <threshold>
+
+    .. versionadded:: 3.9
+
+    Insert a <NoDataFromMaskSource> source, which replaces the value of the source
+    with the value of :option:`-vrtnodata` (or 0 if not specified) when the value
+    of the mask band of the source is less or equal to the threshold.
 
 .. option:: -b <band>
 

--- a/doc/source/programs/gdalbuildvrt.rst
+++ b/doc/source/programs/gdalbuildvrt.rst
@@ -24,7 +24,7 @@ Synopsis
                  [-addalpha] [-hidenodata]
                  [-srcnodata "<value>[ <value>]..."] [-vrtnodata "<value>[ <value>]..."
                  [-ignore_srcmaskband]
-                 [-nodata_if_mask_less_or_equal <threshold>]
+                 [-nodata_max_mask_threshold <threshold>]
                  [-a_srs <srs_def>]
                  [-r {nearest|bilinear|cubic|cubicspline|lanczos|average|mode}]
                  [-oo <NAME>=<VALUE>]...
@@ -147,7 +147,7 @@ changed in later versions.
     not be taken into account, and in case of overlapping between sources, the
     last one will override previous ones in areas of overlap.
 
-.. option:: -nodata_if_mask_less_or_equal <threshold>
+.. option:: -nodata_max_mask_threshold <threshold>
 
     .. versionadded:: 3.9
 

--- a/frmts/vrt/data/gdalvrt.xsd
+++ b/frmts/vrt/data/gdalvrt.xsd
@@ -187,6 +187,7 @@
                 <xs:element name="SimpleSource" type="SimpleSourceType"/>
                 <xs:element name="ComplexSource" type="ComplexSourceType"/>
                 <xs:element name="AveragedSource" type="SimpleSourceType"/>
+                <xs:element name="NoDataFromMaskSource" type="NoDataFromMaskSourceType"/>
                 <xs:element name="KernelFilteredSource" type="KernelFilteredSourceType"/>
                 <xs:element name="ArraySource" type="ArraySourceType"/>
 
@@ -404,6 +405,20 @@
     <xs:complexType name="ComplexSourceType">
         <xs:group ref="ComplexSourceElementsGroup"/>
         <xs:attribute name="resampling" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:group name="NoDataFromMaskSourceElementsGroup">
+        <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:group ref="SimpleSourceElementsGroup"/>
+                <xs:element name="NODATA" type="DoubleOrNanType"/> <!-- NODATA and UseMaskBand are mutually exclusive -->
+                <xs:element name="MaskValueThreshold" type="xs:double"/>
+            </xs:choice>
+        </xs:sequence>
+    </xs:group>
+
+    <xs:complexType name="NoDataFromMaskSourceType">
+        <xs:group ref="NoDataFromMaskSourceElementsGroup"/>
     </xs:complexType>
 
     <xs:complexType name="KernelFilteredSourceType">

--- a/frmts/vrt/data/gdalvrt.xsd
+++ b/frmts/vrt/data/gdalvrt.xsd
@@ -413,6 +413,7 @@
                 <xs:group ref="SimpleSourceElementsGroup"/>
                 <xs:element name="NODATA" type="DoubleOrNanType"/> <!-- NODATA and UseMaskBand are mutually exclusive -->
                 <xs:element name="MaskValueThreshold" type="xs:double"/>
+                <xs:element name="RemappedValue" type="xs:double"/>
             </xs:choice>
         </xs:sequence>
     </xs:group>

--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -124,6 +124,10 @@ class CPL_DLL VRTSource
                 // do nothing
                 /* coverity[uninit_member] */
             }
+            inline operator GByte() const
+            {
+                return value;
+            }
         };
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
@@ -1186,6 +1190,46 @@ class VRTAveragedSource final : public VRTSimpleSource
     virtual const char *GetType() override
     {
         return "AveragedSource";
+    }
+};
+
+/************************************************************************/
+/*                       VRTNoDataFromMaskSource                        */
+/************************************************************************/
+
+class VRTNoDataFromMaskSource final : public VRTSimpleSource
+{
+    CPL_DISALLOW_COPY_ASSIGN(VRTNoDataFromMaskSource)
+
+    bool m_bNoDataSet = false;
+    double m_dfNoDataValue = 0;
+    double m_dfMaskValueThreshold = 0;
+
+  public:
+    VRTNoDataFromMaskSource();
+    virtual CPLErr RasterIO(GDALDataType eVRTBandDataType, int nXOff, int nYOff,
+                            int nXSize, int nYSize, void *pData, int nBufXSize,
+                            int nBufYSize, GDALDataType eBufType,
+                            GSpacing nPixelSpace, GSpacing nLineSpace,
+                            GDALRasterIOExtraArg *psExtraArgIn,
+                            WorkingState &oWorkingState) override;
+
+    virtual double GetMinimum(int nXSize, int nYSize, int *pbSuccess) override;
+    virtual double GetMaximum(int nXSize, int nYSize, int *pbSuccess) override;
+    virtual CPLErr GetHistogram(int nXSize, int nYSize, double dfMin,
+                                double dfMax, int nBuckets,
+                                GUIntBig *panHistogram, int bIncludeOutOfRange,
+                                int bApproxOK, GDALProgressFunc pfnProgress,
+                                void *pProgressData) override;
+
+    void SetParameters(double dfNoDataValue, double dfMaskValueThreshold);
+
+    virtual CPLErr XMLInit(CPLXMLNode *psTree, const char *,
+                           std::map<CPLString, GDALDataset *> &) override;
+    virtual CPLXMLNode *SerializeToXML(const char *pszVRTPath) override;
+    virtual const char *GetType() override
+    {
+        return "VRTNoDataFromMaskSource";
     }
 };
 

--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -1204,6 +1204,8 @@ class VRTNoDataFromMaskSource final : public VRTSimpleSource
     bool m_bNoDataSet = false;
     double m_dfNoDataValue = 0;
     double m_dfMaskValueThreshold = 0;
+    bool m_bHasRemappedValue = false;
+    double m_dfRemappedValue = 0;
 
   public:
     VRTNoDataFromMaskSource();
@@ -1223,6 +1225,8 @@ class VRTNoDataFromMaskSource final : public VRTSimpleSource
                                 void *pProgressData) override;
 
     void SetParameters(double dfNoDataValue, double dfMaskValueThreshold);
+    void SetParameters(double dfNoDataValue, double dfMaskValueThreshold,
+                       double dfRemappedValue);
 
     virtual CPLErr XMLInit(CPLXMLNode *psTree, const char *,
                            std::map<CPLString, GDALDataset *> &) override;

--- a/frmts/vrt/vrtdriver.cpp
+++ b/frmts/vrt/vrtdriver.cpp
@@ -555,6 +555,7 @@ void GDALRegister_VRT()
     poDriver->AddSourceParser("SimpleSource", VRTParseCoreSources);
     poDriver->AddSourceParser("ComplexSource", VRTParseCoreSources);
     poDriver->AddSourceParser("AveragedSource", VRTParseCoreSources);
+    poDriver->AddSourceParser("NoDataFromMaskSource", VRTParseCoreSources);
     poDriver->AddSourceParser("KernelFilteredSource", VRTParseFilterSources);
     poDriver->AddSourceParser("ArraySource", VRTParseArraySource);
 

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -3665,6 +3665,7 @@ def BuildVRTOptions(options=None,
                     srcNodata=None,
                     VRTNodata=None,
                     hideNodata=None,
+                    nodataIfMaskLessOrEqual=None,
                     strict=False,
                     callback=None, callback_data=None):
     """Create a BuildVRTOptions() object that can be passed to gdal.BuildVRT()
@@ -3702,6 +3703,8 @@ def BuildVRTOptions(options=None,
         nodata values at the VRT band level.
     hideNodata:
         whether to make the VRT band not report the NoData value.
+    nodataIfMaskLessOrEqual:
+        value of the mask band of a source below which the source band values should be replaced by VRTNodata (or 0 if not specified)
     strict:
         set to True if warnings should be failures
     callback:
@@ -3749,6 +3752,8 @@ def BuildVRTOptions(options=None,
             new_options += ['-srcnodata', str(srcNodata)]
         if VRTNodata is not None:
             new_options += ['-vrtnodata', str(VRTNodata)]
+        if nodataIfMaskLessOrEqual is not None:
+            new_options += ['-nodata_if_mask_less_or_equal', str(nodataIfMaskLessOrEqual)]
         if hideNodata:
             new_options += ['-hidenodata']
         if strict:

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -3665,7 +3665,7 @@ def BuildVRTOptions(options=None,
                     srcNodata=None,
                     VRTNodata=None,
                     hideNodata=None,
-                    nodataIfMaskLessOrEqual=None,
+                    nodataMaxMaskThreshold=None,
                     strict=False,
                     callback=None, callback_data=None):
     """Create a BuildVRTOptions() object that can be passed to gdal.BuildVRT()
@@ -3703,7 +3703,7 @@ def BuildVRTOptions(options=None,
         nodata values at the VRT band level.
     hideNodata:
         whether to make the VRT band not report the NoData value.
-    nodataIfMaskLessOrEqual:
+    nodataMaxMaskThreshold:
         value of the mask band of a source below which the source band values should be replaced by VRTNodata (or 0 if not specified)
     strict:
         set to True if warnings should be failures
@@ -3752,8 +3752,8 @@ def BuildVRTOptions(options=None,
             new_options += ['-srcnodata', str(srcNodata)]
         if VRTNodata is not None:
             new_options += ['-vrtnodata', str(VRTNodata)]
-        if nodataIfMaskLessOrEqual is not None:
-            new_options += ['-nodata_if_mask_less_or_equal', str(nodataIfMaskLessOrEqual)]
+        if nodataMaxMaskThreshold is not None:
+            new_options += ['-nodata_max_mask_threshold', str(nodataMaxMaskThreshold)]
         if hideNodata:
             new_options += ['-hidenodata']
         if strict:


### PR DESCRIPTION
The NoDataFromMaskSource is derived from the SimpleSource and shares the same properties except that it replaces the value of the source with the value of the NODATA child element when the value of the mask band of the source is less or equal to the MaskValueThreshold child element.

Also add a --nodata_max_mask_threshold <threshold> option to gdalbuildvrt

Example:
```
$ gdal_translate autotest/gcore/data/stefan_full_rgba.tif in.tif -a_srs EPSG:4326 -a_ullr -180 90 180 -90
$ gdalbuildvrt nodatafrommask.vrt in.tif -nodata_if_mask_less_or_equal 128 -vrtnodata 0
$ cat nodatafrommask.vrt
<VRTDataset rasterXSize="162" rasterYSize="150">
  <SRS dataAxisToSRSAxisMapping="2,1">GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563,AUTHORITY["EPSG","7030"]],AUTHORITY["EPSG","6326"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AXIS["Latitude",NORTH],AXIS["Longitude",EAST],AUTHORITY["EPSG","4326"]]</SRS>
  <GeoTransform> -1.8000000000000000e+02,  2.2222222222222223e+00,  0.0000000000000000e+00,  9.0000000000000000e+01,  0.0000000000000000e+00, -1.2000000000000000e+00</GeoTransform>
  <VRTRasterBand dataType="Byte" band="1">
    <NoDataValue>0</NoDataValue>
    <ColorInterp>Red</ColorInterp>
    <NoDataFromMaskSource>
      <SourceFilename relativeToVRT="1">in.tif</SourceFilename>
      <SourceBand>1</SourceBand>
      <SourceProperties RasterXSize="162" RasterYSize="150" DataType="Byte" BlockXSize="162" BlockYSize="12" />
      <SrcRect xOff="0" yOff="0" xSize="162" ySize="150" />
      <DstRect xOff="0" yOff="0" xSize="162" ySize="150" />
      <MaskValueThreshold>128</MaskValueThreshold>
      <NODATA>0</NODATA>
    </NoDataFromMaskSource>
  </VRTRasterBand>
  <VRTRasterBand dataType="Byte" band="2">
    <NoDataValue>0</NoDataValue>
    <ColorInterp>Green</ColorInterp>
    <NoDataFromMaskSource>
      <SourceFilename relativeToVRT="1">in.tif</SourceFilename>
      <SourceBand>2</SourceBand>
      <SourceProperties RasterXSize="162" RasterYSize="150" DataType="Byte" BlockXSize="162" BlockYSize="12" />
      <SrcRect xOff="0" yOff="0" xSize="162" ySize="150" />
      <DstRect xOff="0" yOff="0" xSize="162" ySize="150" />
      <MaskValueThreshold>128</MaskValueThreshold>
      <NODATA>0</NODATA>
    </NoDataFromMaskSource>
  </VRTRasterBand>
  <VRTRasterBand dataType="Byte" band="3">
    <NoDataValue>0</NoDataValue>
    <ColorInterp>Blue</ColorInterp>
    <NoDataFromMaskSource>
      <SourceFilename relativeToVRT="1">in.tif</SourceFilename>
      <SourceBand>3</SourceBand>
      <SourceProperties RasterXSize="162" RasterYSize="150" DataType="Byte" BlockXSize="162" BlockYSize="12" />
      <SrcRect xOff="0" yOff="0" xSize="162" ySize="150" />
      <DstRect xOff="0" yOff="0" xSize="162" ySize="150" />
      <MaskValueThreshold>128</MaskValueThreshold>
      <NODATA>0</NODATA>
    </NoDataFromMaskSource>
  </VRTRasterBand>
</VRTDataset>
```
