### PR TITLE
[Backport release/3.8] Restore use of gmtime_r and localtime_r; extend to ctime_r; use Windows variants too

### DIFF
--- a/cmake/helpers/configure.cmake
+++ b/cmake/helpers/configure.cmake
@@ -44,6 +44,10 @@ check_type_size("long int" SIZEOF_LONG_INT)
 check_type_size("void*" SIZEOF_VOIDP)
 check_type_size("size_t" SIZEOF_SIZE_T)
 
+check_function_exists(ctime_r HAVE_CTIME_R)
+check_function_exists(gmtime_r HAVE_GMTIME_R)
+check_function_exists(localtime_r HAVE_LOCALTIME_R)
+
 if(MSVC AND NOT BUILD_SHARED_LIBS)
   set(CPL_DISABLE_DLL 1)
 endif()
@@ -58,7 +62,6 @@ if (MSVC)
   set(HAVE_SEARCH_H 1)
   set(HAVE_DIRECT_H 1)
 
-  set(HAVE_LOCALTIME_R 0)
   set(HAVE_DLFCN_H 1)
 
   set(VSI_STAT64 _stat64)

--- a/cmake/template/cpl_config.h.in
+++ b/cmake/template/cpl_config.h.in
@@ -198,6 +198,15 @@
 /* Define to 1 if you have the <atlbase.h> header file. */
 #cmakedefine HAVE_ATLBASE_H 1
 
+/* Define to 1 if you have the `ctime_r' function. */
+#cmakedefine HAVE_CTIME_R 1
+
+/* Define to 1 if you have the `localtime_r' function. */
+#cmakedefine HAVE_LOCALTIME_R 1
+
+/* Define to 1 if you have the `gmtime_r' function. */
+#cmakedefine HAVE_GMTIME_R 1
+
 #endif /* GDAL_COMPILATION */
 
 #endif

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -11752,9 +11752,10 @@ static void NCDFAddHistory(int fpImage, const char *pszAddHist,
     time_t tp = time(nullptr);
     if (tp != -1)
     {
-        struct tm *ltime = localtime(&tp);
+        struct tm ltime;
+        VSILocalTime(&tp, &ltime);
         (void)strftime(strtime, sizeof(strtime),
-                       "%a %b %d %H:%M:%S %Y: ", ltime);
+                       "%a %b %d %H:%M:%S %Y: ", &ltime);
     }
 
     // status = nc_get_att_text(fpImage, NC_GLOBAL,

--- a/frmts/pcidsk/sdk/core/pcidsk_utils.cpp
+++ b/frmts/pcidsk/sdk/core/pcidsk_utils.cpp
@@ -59,10 +59,16 @@ void    PCIDSK::GetCurrentDateTime( char *out_time )
 
 {
     time_t          clock;
-    char            ctime_out[25];
+    char            ctime_out[26] = {0};
 
     time( &clock );
-    strncpy( ctime_out, ctime(&clock), 24 ); // TODO: reentrance issue?
+#ifdef HAVE_CTIME_R
+    ctime_r(&clock, ctime_out);
+#elif defined(_WIN32)
+    ctime_s(ctime_out, sizeof(ctime_out), &clock);
+#else
+    strncpy( ctime_out, ctime(&clock), 25 );
+#endif
 
     // ctime() products: "Wed Jun 30 21:49:08 1993\n"
 

--- a/ogr/ogrsf_frmts/cad/libopencad/cadheader.cpp
+++ b/ogr/ogrsf_frmts/cad/libopencad/cadheader.cpp
@@ -345,7 +345,15 @@ CADVariant::CADVariant( long julianday, long milliseconds ) :
     dateTimeVal = static_cast<time_t>( dfUnix + dfSeconds );
 
     char str_buff[256] = "Invalid date";
-    struct tm *poLocaltime = localtime(&dateTimeVal);
+#if HAVE_LOCALTIME_R
+    struct tm localtime_tm;
+    const struct tm *poLocaltime = localtime_r(&dateTimeVal, &localtime_tm);
+#elif defined(_WIN32)
+    struct tm localtime_tm;
+    const struct tm *poLocaltime = localtime_s(&localtime_tm, &dateTimeVal) == 0 ? &localtime_tm : nullptr;
+#else
+    const struct tm *poLocaltime = localtime(&dateTimeVal);
+#endif
     if(poLocaltime)
         strftime(str_buff, 255, "%Y-%m-%d %H:%M:%S", poLocaltime);
     stringVal = str_buff;

--- a/port/cpl_vsisimple.cpp
+++ b/port/cpl_vsisimple.cpp
@@ -1309,8 +1309,21 @@ const char *VSICTime(unsigned long nTime)
 
 {
     time_t tTime = static_cast<time_t>(nTime);
-
+#if HAVE_CTIME_R
+    // Cf https://linux.die.net/man/3/ctime_r:
+    // "The reentrant version ctime_r() does the same, but stores the string in
+    // a user-supplied buffer which should have room for at least 26 bytes"
+    char buffer[26];
+    char *ret = ctime_r(&tTime, buffer);
+    return ret ? CPLSPrintf("%s", ret) : nullptr;
+#elif defined(_WIN32)
+    char buffer[26];
+    return ctime_s(buffer, sizeof(buffer), &tTime) == 0
+               ? CPLSPrintf("%s", buffer)
+               : nullptr;
+#else
     return reinterpret_cast<const char *>(ctime(&tTime));
+#endif
 }
 
 /************************************************************************/
@@ -1322,12 +1335,14 @@ struct tm *VSIGMTime(const time_t *pnTime, struct tm *poBrokenTime)
 
 #if HAVE_GMTIME_R
     gmtime_r(pnTime, poBrokenTime);
+    return poBrokenTime;
+#elif defined(_WIN32)
+    return gmtime_s(poBrokenTime, pnTime) == 0 ? poBrokenTime : nullptr;
 #else
     struct tm *poTime = gmtime(pnTime);
     memcpy(poBrokenTime, poTime, sizeof(tm));
-#endif
-
     return poBrokenTime;
+#endif
 }
 
 /************************************************************************/
@@ -1339,12 +1354,14 @@ struct tm *VSILocalTime(const time_t *pnTime, struct tm *poBrokenTime)
 
 #if HAVE_LOCALTIME_R
     localtime_r(pnTime, poBrokenTime);
+    return poBrokenTime;
+#elif defined(_WIN32)
+    return localtime_s(poBrokenTime, pnTime) == 0 ? poBrokenTime : nullptr;
 #else
     struct tm *poTime = localtime(pnTime);
     memcpy(poBrokenTime, poTime, sizeof(tm));
-#endif
-
     return poBrokenTime;
+#endif
 }
 
 /************************************************************************/


### PR DESCRIPTION
Backport #9058
 **Authored by:** @rouault