### PR TITLE
gdal_edit: add -a_coord_epoch option and update doc

### DIFF
--- a/autotest/pyscripts/test_gdal_edit.py
+++ b/autotest/pyscripts/test_gdal_edit.py
@@ -444,3 +444,26 @@ def test_gdal_edit_py_unsetrpc(script_path):
         ds = None
     finally:
         gdal.GetDriverByName("GTiff").Delete(filename)
+
+
+###############################################################################
+# Test -a_coord_epoch
+
+
+def test_gdal_edit_py_epoch(script_path):
+
+    filename = "tmp/test_gdal_edit_py.tif"
+    shutil.copy(test_py_scripts.get_data_path("gcore") + "byte.tif", filename)
+
+    try:
+        test_py_scripts.run_py_script(
+            script_path, "gdal_edit", filename + " -a_coord_epoch 2021.3"
+        )
+
+        ds = gdal.Open(filename)
+        srs = ds.GetSpatialRef()
+        assert srs.GetCoordinateEpoch() == 2021.3
+        ds = None
+
+    finally:
+        gdal.GetDriverByName("GTiff").Delete(filename)

--- a/doc/source/programs/gdal_edit.rst
+++ b/doc/source/programs/gdal_edit.rst
@@ -15,9 +15,10 @@ Synopsis
 
 .. code-block::
 
-    gdal_edit [--help] [--help-general] [-ro] [-a_srs <srs_def>]
+    gdal_edit [--help] [--help-general] [-ro] [-a_srs <srs_def>] 
             [-a_ullr <ulx> <uly> <lrx> <lry>] [-a_ulurll <ulx> <uly> <urx> <ury> <llx> <lly>]
             [-tr <xres> <yres>] [-unsetgt] [-unsetrpc] [-a_nodata <value>] [-unsetnodata]
+            [-a_coord_epoch <epoch>] [-unsetepoch]
             [-unsetstats] [-stats] [-approx_stats]
             [-setstats <min> <max> <mean> <stddev>]
             [-scale <value>] [-offset <value>] [-units <value>]
@@ -57,6 +58,18 @@ It works only with raster formats that support update access to existing dataset
     If the empty string or None is specified, then the existing
     coordinate system will be removed (for TIFF/GeoTIFF, might not be well
     supported besides that).
+
+.. option:: -a_coord_epoch <epoch>
+
+    Assign/override the coordinate epoch of the dataset, as a decimal year (e.g., 2021.3).
+
+    .. versionadded:: 3.9
+
+.. option:: -unsetepoch
+
+    Remove the coordinate epoch of the dataset.
+
+    .. versionadded:: 3.9
 
 .. option:: -a_ullr  <ulx> <uly> <lrx> <lry>
 

--- a/doc/source/user/coordinate_epoch.rst
+++ b/doc/source/user/coordinate_epoch.rst
@@ -29,21 +29,20 @@ a CRS is a dynamic one.
 The :cpp:func:`OGRSpatialReference::SetCoordinateEpoch` and
 :cpp:func:`OGRSpatialReference::GetCoordinateEpoch` methods can be used to
 set/retrieve a coordinate epoch associated with a CRS. The coordinate epoch is
-expressed as a decimal year (e.g. 2021.3).
+expressed as a decimal year (e.g. 2021.3 for April 21, 2021).
 
 Formally, the coordinate epoch of an observation belongs to the
-observation.  However, almost all formats do not allow for storing
+observation. However, almost all formats do not allow for storing
 per-observation epoch, and typical usage is a set of observations with
-the same epoch.  Therefore we store the epoch as property of the CRS,
-and the meaning of this is as if that epoch value were part of every
-observation.  This choice eases processing, storage and format
-complexity for most usage.  For now, this means that a dataset where
-points have different epochs cannot be handled.
+the same epoch. Therefore we store the epoch as property of the CRS,
+and assume that it is valid for every observation. This choice eases processing,
+storage and format complexity for most usage. For now, this means that a dataset 
+containing observations or points with different epochs cannot be handled.
 
 For vector formats, per-geometry coordinate epoch could also make sense, but as
 most formats only support a per-layer CRS, we also for now limit support of
-coordinate epoch at the layer level. The coordinate transformation mechanics
-itself can support per-vertex coordinate epoch.
+coordinate epoch at the layer level. The underlying coordinate transformation mechanics
+can support per-vertex coordinate epoch.
 
 Support in raster and vector formats
 ------------------------------------
@@ -161,6 +160,8 @@ Support in utilities
 
 :program:`gdalinfo` and :program:`ogrinfo` report the coordinate epoch, when
 attached to a dataset/layer SRS.
+
+:program:`gdal_edit.py` has a ``-a_coord_epoch`` option to define the epoch of a dataset in place. 
 
 :program:`gdal_translate` and :program:`ogr2ogr` have a ``-a_coord_epoch`` option to be used
 together with ``-a_srs``, and otherwise preserve the coordinate epoch in the output SRS


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

Add new options to `gdal_edit.py` that will add, update or remove a user-defined coordinate epoch from the dataset SRS.  Updated documentation.  

## What are related issues/pull requests?

https://lists.osgeo.org/pipermail/gdal-dev/2024-January/058314.html

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [x] Add documentation
 - [x] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [x] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
