### PR TITLE
GPKG creation: set Z/M columns of gpkg_geometry_columns when there are Z/M geometries in a 2D declared layer

### DIFF
--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -718,7 +718,7 @@ class OGRGeoPackageTableLayer final : public OGRGeoPackageLayer
     void DisableFeatureCountTriggers(bool bNullifyFeatureCount = true);
 #endif
 
-    void CheckGeometryType(OGRFeature *poFeature);
+    void CheckGeometryType(const OGRFeature *poFeature);
 
     OGRErr ReadTableDefinition();
     void InitView();


### PR DESCRIPTION
Adresses remark of https://github.com/qgis/QGIS/pull/55320#discussion_r1467859166
