### PR TITLE
MySQL: fix/workaround server-side spatial filtering when SRS is geographic with MySQL >= 8 (fixes qgis/QGIS#55463)

### DIFF
--- a/autotest/ogr/ogr_mysql.py
+++ b/autotest/ogr/ogr_mysql.py
@@ -960,6 +960,11 @@ def test_ogr_mysql_longlat(mysql_ds, mysql_is_8_or_later):
             pytest.fail("Not found SRID definition with GEOMETORY field.")
         mysql_ds.ReleaseResultSet(sql_lyr)
 
+    lyr.SetSpatialFilterRect(-181, -91, 181, 91)
+    lyr.ResetReading()
+    f = lyr.GetNextFeature()
+    ogrtest.check_feature_geometry(f, geom)
+
 
 ###############################################################################
 # Test writing and reading back geometries


### PR DESCRIPTION
(fixes qgis/QGIS#55463)

It seems spatial predicates are not directly usable when using geographic SRS. For some reason
```sql    
select MBRIntersects(ST_GeomFromText('POLYGON((-90 -90, 90 -90, 90 90, -90 90, -90 -90))', 4326), ST_GeomFromText('POINT(0 0)', 4326));
```
returns true as expected

But
```sql    
select MBRIntersects(ST_GeomFromText('POLYGON((-179 -89, 179 -89, 179 89, -179 89, -179 -89))', 4326, 'axis-order=long-lat'), ST_GeomFromText('POINT(0 0)', 4326));
```
returns false !!!!

And
```sql    
select MBRIntersects(ST_GeomFromText('POLYGON((-179 -89, 179 -89, 179 89, -179 89, -179 -89))', 32631), ST_GeomFromText('POINT(0 0)', 32631));
```
returns true as expected

Consequence, we need to force a projected SRS for the arguments of MBRIntersects()
