### PR TITLE
PAM only unset GPF_DIRTY flag

### DIFF
--- a/frmts/exr/exrdataset.cpp
+++ b/frmts/exr/exrdataset.cpp
@@ -822,7 +822,7 @@ GDALDataset *GDALEXRDataset::Open(GDALOpenInfo *poOpenInfo)
             poDS->SetMetadata(aosSubDS.List(), "SUBDATASETS");
         }
 
-        poDS->SetPamFlags(0);
+        poDS->SetPamFlags(poDS->GetPamFlags() & ~GPF_DIRTY);
 
         // Initialize any PAM information.
         poDS->SetDescription(poOpenInfo->pszFilename);

--- a/frmts/plmosaic/plmosaicdataset.cpp
+++ b/frmts/plmosaic/plmosaicdataset.cpp
@@ -664,7 +664,7 @@ GDALDataset *PLMosaicDataset::Open(GDALOpenInfo *poOpenInfo)
     }
 
     if (poDS)
-        poDS->SetPamFlags(0);
+        poDS->SetPamFlags(poDS->GetPamFlags() & ~GPF_DIRTY);
 
     return poDS;
 }

--- a/frmts/wmts/wmtsdataset.cpp
+++ b/frmts/wmts/wmtsdataset.cpp
@@ -2431,7 +2431,7 @@ GDALDataset *WMTSDataset::Open(GDALOpenInfo *poOpenInfo)
 
     CPLDestroyXMLNode(psXML);
 
-    poDS->SetPamFlags(0);
+    poDS->SetPamFlags(poDS->GetPamFlags() & ~GPF_DIRTY);
     return poDS;
 }
 /************************************************************************/

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -1870,7 +1870,7 @@ int GDALGeoPackageDataset::Open(GDALOpenInfo *poOpenInfo,
         FixupWrongMedataReferenceColumnNameUpdate();
     }
 
-    SetPamFlags(0);
+    SetPamFlags(GetPamFlags() & ~GPF_DIRTY);
 
     return bRet;
 }
@@ -3384,7 +3384,7 @@ CPLErr GDALGeoPackageDataset::FlushCache(bool bAtClosing)
 
     if (eAccess == GA_Update || !m_bMetadataDirty)
     {
-        SetPamFlags(0);
+        SetPamFlags(GetPamFlags() & ~GPF_DIRTY);
     }
 
     if (m_bRemoveOGREmptyTable)
@@ -3402,7 +3402,7 @@ CPLErr GDALGeoPackageDataset::FlushCache(bool bAtClosing)
         // Needed again as above IFlushCacheWithErrCode()
         // may have call GDALGeoPackageRasterBand::InvalidateStatistics()
         // which modifies metadata
-        SetPamFlags(0);
+        SetPamFlags(GetPamFlags() & ~GPF_DIRTY);
     }
 
     return eErr;
@@ -6017,7 +6017,7 @@ GDALDataset *GDALGeoPackageDataset::CreateCopy(const char *pszFilename,
             }
         }
         if (poDS)
-            poDS->SetPamFlags(0);
+            poDS->SetPamFlags(poDS->GetPamFlags() & ~GPF_DIRTY);
         return poDS;
     }
 
@@ -6397,7 +6397,7 @@ GDALDataset *GDALGeoPackageDataset::CreateCopy(const char *pszFilename,
     GDALDestroyWarpOptions(psWO);
 
     if (poDS)
-        poDS->SetPamFlags(0);
+        poDS->SetPamFlags(poDS->GetPamFlags() & ~GPF_DIRTY);
 
     return poDS;
 }


### PR DESCRIPTION
Metadata files would still be created even when `GDAL_PAM_ENABLED NO` config was used. In my case I had a GPKG raster with overviews and `gdalinfo raster_w_overviews.gpkg --config GDAL_PAM_ENABLED NO` resulted in a bunch of zoom.aux.xml files being created. 

The PAM-flags were completely reset in some cases in the code, so the GPF_ENABLED flag was ignored if it had been set on initialization.

I saw that the handling in some places were to only unset the GPF_DIRTY flag, so I replaced all the hard resets with only unsetting the 'dirty' flag, figured this was maybe the intention behind the hard resets