### PR TITLE
PG: Avoid new SQL for GDAL multidomain metadata serialization breaking old versions of postgresql

### DIFF
--- a/ogr/ogrsf_frmts/pg/ogrpgtablelayer.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgtablelayer.cpp
@@ -351,7 +351,7 @@ void OGRPGTableLayer::SerializeMetadata()
         hResult = OGRPG_PQexec(
             hPGConn,
             "DROP FUNCTION IF EXISTS "
-            "ogr_system_tables.event_trigger_function_for_metadata CASCADE");
+            "ogr_system_tables.event_trigger_function_for_metadata() CASCADE");
         OGRPGClearResult(hResult);
 
         hResult = OGRPG_PQexec(


### PR DESCRIPTION
The changes from OSGeo/gdal#8965 added SQL commands including a DROP FUNCTION that omits parenthesis.  That's legal on all supported versions of PG but the parenthesis were required before PG 10.  While I'm sure PG 9.X is not officially supported by GDAL, there's no harm in including the parenthesis and it helps those of us who've fallen a bit behind on PG updates.

## What does this PR do?

Adds parenthesis to ``````DROP FUNCTION`

## What are related issues/pull requests?

OSGeo/gdal#8965

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* Postgresql: <10
