### PR TITLE
doc: Put binaries first and link to Trac wiki on the download page

### DIFF
--- a/doc/source/download.rst
+++ b/doc/source/download.rst
@@ -10,105 +10,67 @@ Download
        :depth: 3
        :backlinks: none
 
+Binaries
+------------------------------------------------------------------------------
+
+The GDAL project itself does not produce regular downloadable binaries
+(executables) for each release. However, a variety of efforts do produce
+ready to use binaries.
+
+See **https://trac.osgeo.org/gdal/wiki/DownloadingGdalBinaries** for a list
+of sources for downloading GDAL binary packages for Windows, macOS and Linux.
+
+.. _conda:
+
+Conda
+................................................................................
+
+`Conda <https://anaconda.org>`__ can be used on multiple platforms (Windows, macOS, and Linux) to
+install software packages and manage environments. Conda packages for GDAL are
+available at https://anaconda.org/conda-forge/gdal.
+
+.. only:: html
+
+    Latest version: |Conda badge|
+
+    .. |Conda badge| image:: https://anaconda.org/conda-forge/gdal/badges/version.svg
+        :target: https://anaconda.org/conda-forge/gdal
+
+::
+
+    conda install [-c channel] [package...]
+
+
+::
+
+    conda install -c conda-forge gdal
+
+
+Linux Docker images
+................................................................................
+
+Images with nightly builds of GDAL master and tagged releases are available at
+`Docker Hub <https://hub.docker.com/r/osgeo/gdal/tags>`_
+
+Information on the content of the different configurations can be found at
+`https://github.com/OSGeo/gdal/tree/master/docker <https://github.com/OSGeo/gdal/tree/master/docker>`_
+
+Source Code
+------------------------------------------------------------------------------
+
+You can download source packages for current and previous GDAL versions.
+
 Current Release
-------------------------------------------------------------------------------
-
-* **2024-01-08** `gdal-3.8.3.tar.gz`_ `3.8.3 Release Notes`_ (`3.8.3 md5`_)
-
-.. _`3.8.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.8.3/NEWS.md
-.. _`gdal-3.8.3.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.8.3/gdal-3.8.3.tar.gz
-.. _`3.8.3 md5`: https://github.com/OSGeo/gdal/releases/download/v3.8.3/gdal-3.8.3.tar.gz.md5
-
-Past Releases
-------------------------------------------------------------------------------
-
-* **2023-12-20** `gdal-3.8.2.tar.gz`_ `3.8.2 Release Notes`_ (`3.8.2 md5`_)
-
-.. _`3.8.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.8.2/NEWS.md
-.. _`gdal-3.8.2.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.8.2/gdal-3.8.2.tar.gz
-.. _`3.8.2 md5`: https://github.com/OSGeo/gdal/releases/download/v3.8.2/gdal-3.8.2.tar.gz.md5
-
-* **2023-11-30** `gdal-3.8.1.tar.gz`_ `3.8.1 Release Notes`_ (`3.8.1 md5`_)
-
-.. _`3.8.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.8.1/NEWS.md
-.. _`gdal-3.8.1.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.8.1/gdal-3.8.1.tar.gz
-.. _`3.8.1 md5`: https://github.com/OSGeo/gdal/releases/download/v3.8.1/gdal-3.8.1.tar.gz.md5
-
-* **2023-11-13** `gdal-3.8.0.tar.gz`_ `3.8.0 Release Notes`_ (`3.8.0 md5`_)
-
-.. _`3.8.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.8.0/NEWS.md
-.. _`gdal-3.8.0.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.8.0/gdal-3.8.0.tar.gz
-.. _`3.8.0 md5`: https://github.com/OSGeo/gdal/releases/download/v3.8.0/gdal-3.8.0.tar.gz.md5
-
-* **2023-11-03** `gdal-3.7.3.tar.gz`_ `3.7.3 Release Notes`_ (`3.7.3 md5`_)
-
-.. _`3.7.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.7.3/NEWS.md
-.. _`gdal-3.7.3.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.7.3/gdal-3.7.3.tar.gz
-.. _`3.7.3 md5`: https://github.com/OSGeo/gdal/releases/download/v3.7.3/gdal-3.7.3.tar.gz.md5
-
-* **2023-09-13** `gdal-3.7.2.tar.gz`_ `3.7.2 Release Notes`_ (`3.7.2 md5`_)
-
-.. _`3.7.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.7.2/NEWS.md
-.. _`gdal-3.7.2.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.7.2/gdal-3.7.2.tar.gz
-.. _`3.7.2 md5`: https://github.com/OSGeo/gdal/releases/download/v3.7.2/gdal-3.7.2.tar.gz.md5
-
-* **2023-07-13** `gdal-3.7.1.tar.gz`_ `3.7.1 Release Notes`_ (`3.7.1 md5`_)
-
-.. _`3.7.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.7.1/NEWS.md
-.. _`gdal-3.7.1.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.7.1/gdal-3.7.1.tar.gz
-.. _`3.7.1 md5`: https://github.com/OSGeo/gdal/releases/download/v3.7.1/gdal-3.7.1.tar.gz.md5
-
-* **2023-05-10** `gdal-3.7.0.tar.gz`_ `3.7.0 Release Notes`_ (`3.7.0 md5`_)
-
-.. _`3.7.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.7.0/NEWS.md
-.. _`gdal-3.7.0.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.7.0/gdal-3.7.0.tar.gz
-.. _`3.7.0 md5`: https://github.com/OSGeo/gdal/releases/download/v3.7.0/gdal-3.7.0.tar.gz.md5
-
-* **2023-04-21** `gdal-3.6.4.tar.gz`_ `3.6.4 Release Notes`_ (`3.6.4 md5`_)
-
-.. _`3.6.4 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.6.4/NEWS.md
-.. _`gdal-3.6.4.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.6.4/gdal-3.6.4.tar.gz
-.. _`3.6.4 md5`: https://github.com/OSGeo/gdal/releases/download/v3.6.4/gdal-3.6.4.tar.gz.md5
-
-* **2023-03-13** `gdal-3.6.3.tar.gz`_ `3.6.3 Release Notes`_ (`3.6.3 md5`_)
-
-.. _`3.6.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.6.3/NEWS.md
-.. _`gdal-3.6.3.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.6.3/gdal-3.6.3.tar.gz
-.. _`3.6.3 md5`: https://github.com/OSGeo/gdal/releases/download/v3.6.3/gdal-3.6.3.tar.gz.md5
-
-* **2023-01-05** `gdal-3.6.2.tar.gz`_ `3.6.2 Release Notes`_ (`3.6.2 md5`_)
-
-.. _`3.6.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.6.2/NEWS.md
-.. _`gdal-3.6.2.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.6.2/gdal-3.6.2.tar.gz
-.. _`3.6.2 md5`: https://github.com/OSGeo/gdal/releases/download/v3.6.2/gdal-3.6.2.tar.gz.md5
-
-* **2022-12-11** `gdal-3.6.1.tar.gz`_ `3.6.1 Release Notes`_ (`3.6.1 md5`_)
-
-.. _`3.6.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.6.1/NEWS.md
-.. _`gdal-3.6.1.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.6.1/gdal-3.6.1.tar.gz
-.. _`3.6.1 md5`: https://github.com/OSGeo/gdal/releases/download/v3.6.1/gdal-3.6.1.tar.gz.md5
-
-* **2022-11-06** `3.6.0 Release Notes`_ *Warning*: this version has been official retracted and superseded per 3.6.1
-
-.. _`3.6.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.6.0/NEWS.md
-
-* **2022-10-21** `gdal-3.5.3.tar.gz`_ `3.5.3 Release Notes`_ (`3.5.3 md5`_)
-
-.. _`3.5.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.5.3/NEWS.md
-.. _`gdal-3.5.3.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.5.3/gdal-3.5.3.tar.gz
-.. _`3.5.3 md5`: https://github.com/OSGeo/gdal/releases/download/v3.5.3/gdal-3.5.3.tar.gz.md5
-
-* **2022-09-12** `gdal-3.5.2.tar.gz`_ `3.5.2 Release Notes`_ (`3.5.2 md5`_)
-
-.. _`3.5.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.5.2/NEWS.md
-.. _`gdal-3.5.2.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.5.2/gdal-3.5.2.tar.gz
-.. _`3.5.2 md5`: https://github.com/OSGeo/gdal/releases/download/v3.5.2/gdal-3.5.2.tar.gz.md5
+................................................................................
 
 * **2022-07-06** `gdal-3.5.1.tar.gz`_ `3.5.1 Release Notes`_ (`3.5.1 md5`_)
 
 .. _`3.5.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.5.1/NEWS.md
 .. _`gdal-3.5.1.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.5.1/gdal-3.5.1.tar.gz
 .. _`3.5.1 md5`: https://github.com/OSGeo/gdal/releases/download/v3.5.1/gdal-3.5.1.tar.gz.md5
+
+Past Releases
+................................................................................
 
 * **2022-05-13** `gdal-3.5.0.tar.gz`_ `3.5.0 Release Notes`_ (`3.5.0 md5`_)
 
@@ -266,9 +228,9 @@ Past Releases
 .. _source:
 
 Development Source
-------------------------------------------------------------------------------
+................................................................................
 
-The main repository for GDAL is located on GitHub at
+The main repository for GDAL is located on github at
 https://github.com/OSGeo/GDAL.
 
 You can obtain a copy of the active source code by issuing the following
@@ -279,138 +241,29 @@ command
     git clone https://github.com/OSGeo/GDAL.git
 
 
-Additional information is available about :ref:`build_requirements` and :ref:`building_from_source`.
-
-Binaries
-------------------------------------------------------------------------------
-
-In this section we list a number of the binary distributions of GDAL
-all of which should have fully reproducible open source build recipes.
-
-Note that the maintainers of those distributions are generally not the maintainers
-of the GDAL sources, so please report any issue specific to those builds through
-their own support channels.
-
-Windows
+Building GDAL
 ................................................................................
 
-Windows builds are available via `Conda Forge`_ (64-bit only). See the
-:ref:`conda` section for more detailed information.
 
-.. _`Conda Forge`: https://anaconda.org/conda-forge/gdal
+Build requirements
+~~~~~~~~~~~~~~~~~~
 
-Debian
-................................................................................
-
-Debian packages are now available on `Debian Unstable`_.
-
-.. _`Debian Unstable`: https://tracker.debian.org/pkg/gdal
-
-.. _conda:
-
-Conda
-................................................................................
-
-`Conda <https://anaconda.org>`__ can be used on multiple platforms (Windows, macOS, and Linux) to
-install software packages and manage environments. Conda packages for GDAL are
-available at https://anaconda.org/conda-forge/gdal.
-
-.. only:: html
-
-    Latest version: |Conda badge|
-
-    .. |Conda badge| image:: https://anaconda.org/conda-forge/gdal/badges/version.svg
-        :target: https://anaconda.org/conda-forge/gdal
-
-::
-
-    conda install [-c channel] [package...]
+To build GDAL 3 or later, you need *at a minimum* a C++11 compatible compiler, and
+`PROJ 6 or later <https://proj.org>`_.
+This will only give you a minimum build which will lack a lot of drivers.
+Consult :ref:`raster_drivers` and :ref:`vector_drivers` pages for additional optional
+dependencies.
 
 
-::
+Build instructions
+~~~~~~~~~~~~~~~~~~
 
-    conda install -c conda-forge gdal
+See https://trac.osgeo.org/gdal/wiki/BuildHints for hints for existing
+autoconf and nmake build systems.
 
+From GDAL 3.5, an *experimental* :ref:`CMake-based build <build_hints>` is available.
 
-To install the Arrow and Parquet drivers as plugins:
+.. toctree::
+   :maxdepth: 0
 
-::
-
-    conda install -c conda-forge libgdal-arrow-parquet
-
-
-GDAL master Conda builds
-~~~~~~~~~~~~~~~~~~~~~~~~
-
-GDAL master builds are available in the `gdal-master <https://anaconda.org/gdal-master/gdal>`__
-channel. They are based on dependencies from the ``conda-forge`` channel.
-
-First, install mamba into the ``base`` environment, create a dedicated ``gdal_master_env``
-environment, and then activate the dedicated ``gdal_master_env`` environment.
-
-::
-
-    conda update -n base -c conda-forge conda
-    conda install -n base --override-channels -c conda-forge mamba 'python_abi=*=*cp*'
-    conda create --name gdal_master_env
-    conda activate gdal_master_env
-
-Then install GDAL from the ``gdal-master`` channel:
-
-::
-
-    mamba install -c gdal-master gdal
-    mamba install -c gdal-master libgdal-arrow-parquet # if you need the Arrow and Parquet drivers
-
-
-Vcpkg
-................................................................................
-
-The gdal port in vcpkg is kept up to date by Microsoft team members and community contributors.
-The url of vcpkg is: https://github.com/Microsoft/vcpkg .
-You can download and install gdal using the vcpkg dependency manager:
-
-::
-
-    git clone https://github.com/Microsoft/vcpkg.git
-    cd vcpkg
-    ./bootstrap-vcpkg.sh  # ./bootstrap-vcpkg.bat for Windows
-    ./vcpkg integrate install
-    ./vcpkg install gdal
-
-If the version is out of date, please `create an issue or pull request <https://github.com/Microsoft/vcpkg>`__ on the vcpkg repository.
-
-Spack
-................................................................................
-
-Spack is a package management tool designed to support multiple versions and
-configurations of software on a wide variety of platforms and environments.
-It was designed for large supercomputing centers. Spack builds packages from
-sources, and allows tweaking their configurations.
-
-You can find information about GDAL in Spack at
-https://spack.readthedocs.io/en/latest/package_list.html#gdal
-
-For the default GDAL build with a reduced number of drivers:
-
-::
-
-    git clone -c feature.manyFiles=true https://github.com/spack/spack.git
-    cd spack/bin
-    ./spack install gdal
-
-For a build with netcdf driver enabled:
-
-::
-
-    ./spack install gdal +netcdf
-
-
-Linux Docker images
-................................................................................
-
-Images with nightly builds of GDAL master and tagged releases are available at
-`GitHub Container registry <https://github.com/OSGeo/gdal/pkgs/container/gdal>`_
-
-Information on the content of the different configurations can be found at
-`https://github.com/OSGeo/gdal/tree/master/docker <https://github.com/OSGeo/gdal/tree/master/docker>`_
+   build_hints

--- a/doc/source/download.rst
+++ b/doc/source/download.rst
@@ -17,6 +17,13 @@ The GDAL project itself does not produce regular downloadable binaries
 (executables) for each release. However, a variety of efforts do produce
 ready to use binaries.
 
+Note that the maintainers of those distributions are generally not the maintainers
+of the GDAL sources, so please report any issue specific to those builds through
+their own support channels.
+
+Windows, macOS and Linux
+................................................................................
+
 See **https://trac.osgeo.org/gdal/wiki/DownloadingGdalBinaries** for a list
 of sources for downloading GDAL binary packages for Windows, macOS and Linux.
 
@@ -45,6 +52,103 @@ available at https://anaconda.org/conda-forge/gdal.
 
     conda install -c conda-forge gdal
 
+Conda
+................................................................................
+
+`Conda <https://anaconda.org>`__ can be used on multiple platforms (Windows, macOS, and Linux) to
+install software packages and manage environments. Conda packages for GDAL are
+available at https://anaconda.org/conda-forge/gdal.
+
+.. only:: html
+
+    Latest version: |Conda badge|
+
+    .. |Conda badge| image:: https://anaconda.org/conda-forge/gdal/badges/version.svg
+        :target: https://anaconda.org/conda-forge/gdal
+
+::
+
+    conda install [-c channel] [package...]
+
+
+::
+
+    conda install -c conda-forge gdal
+
+
+To install the Arrow and Parquet drivers as plugins:
+
+::
+
+    conda install -c conda-forge libgdal-arrow-parquet
+
+
+GDAL master Conda builds
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+GDAL master builds are available in the `gdal-master <https://anaconda.org/gdal-master/gdal>`__
+channel. They are based on dependencies from the ``conda-forge`` channel.
+
+First, install mamba into the ``base`` environment, create a dedicated ``gdal_master_env``
+environment, and then activate the dedicated ``gdal_master_env`` environment.
+
+::
+
+    conda update -n base -c conda-forge conda
+    conda install -n base --override-channels -c conda-forge mamba 'python_abi=*=*cp*'
+    conda create --name gdal_master_env
+    conda activate gdal_master_env
+
+Then install GDAL from the ``gdal-master`` channel:
+
+::
+
+    mamba install -c gdal-master gdal
+    mamba install -c gdal-master libgdal-arrow-parquet # if you need the Arrow and Parquet drivers
+
+
+Vcpkg
+................................................................................
+
+The gdal port in vcpkg is kept up to date by Microsoft team members and community contributors.
+The url of vcpkg is: https://github.com/Microsoft/vcpkg .
+You can download and install gdal using the vcpkg dependency manager:
+
+::
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh  # ./bootstrap-vcpkg.bat for Windows
+    ./vcpkg integrate install
+    ./vcpkg install gdal
+
+If the version is out of date, please `create an issue or pull request <https://github.com/Microsoft/vcpkg>`__ on the vcpkg repository.
+
+Spack
+................................................................................
+
+Spack is a package management tool designed to support multiple versions and
+configurations of software on a wide variety of platforms and environments.
+It was designed for large supercomputing centers. Spack builds packages from
+sources, and allows tweaking their configurations.
+
+You can find information about GDAL in Spack at
+https://spack.readthedocs.io/en/latest/package_list.html#gdal
+
+For the default GDAL build with a reduced number of drivers:
+
+::
+
+    git clone -c feature.manyFiles=true https://github.com/spack/spack.git
+    cd spack/bin
+    ./spack install gdal
+
+For a build with netcdf driver enabled:
+
+::
+
+    ./spack install gdal +netcdf
+
 
 Linux Docker images
 ................................................................................
@@ -61,16 +165,104 @@ Source Code
 You can download source packages for current and previous GDAL versions.
 
 Current Release
-................................................................................
+------------------------------------------------------------------------------
+
+* **2024-01-08** `gdal-3.8.3.tar.gz`_ `3.8.3 Release Notes`_ (`3.8.3 md5`_)
+
+.. _`3.8.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.8.3/NEWS.md
+.. _`gdal-3.8.3.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.8.3/gdal-3.8.3.tar.gz
+.. _`3.8.3 md5`: https://github.com/OSGeo/gdal/releases/download/v3.8.3/gdal-3.8.3.tar.gz.md5
+
+Past Releases
+------------------------------------------------------------------------------
+
+* **2023-12-20** `gdal-3.8.2.tar.gz`_ `3.8.2 Release Notes`_ (`3.8.2 md5`_)
+
+.. _`3.8.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.8.2/NEWS.md
+.. _`gdal-3.8.2.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.8.2/gdal-3.8.2.tar.gz
+.. _`3.8.2 md5`: https://github.com/OSGeo/gdal/releases/download/v3.8.2/gdal-3.8.2.tar.gz.md5
+
+* **2023-11-30** `gdal-3.8.1.tar.gz`_ `3.8.1 Release Notes`_ (`3.8.1 md5`_)
+
+.. _`3.8.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.8.1/NEWS.md
+.. _`gdal-3.8.1.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.8.1/gdal-3.8.1.tar.gz
+.. _`3.8.1 md5`: https://github.com/OSGeo/gdal/releases/download/v3.8.1/gdal-3.8.1.tar.gz.md5
+
+* **2023-11-13** `gdal-3.8.0.tar.gz`_ `3.8.0 Release Notes`_ (`3.8.0 md5`_)
+
+.. _`3.8.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.8.0/NEWS.md
+.. _`gdal-3.8.0.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.8.0/gdal-3.8.0.tar.gz
+.. _`3.8.0 md5`: https://github.com/OSGeo/gdal/releases/download/v3.8.0/gdal-3.8.0.tar.gz.md5
+
+* **2023-11-03** `gdal-3.7.3.tar.gz`_ `3.7.3 Release Notes`_ (`3.7.3 md5`_)
+
+.. _`3.7.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.7.3/NEWS.md
+.. _`gdal-3.7.3.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.7.3/gdal-3.7.3.tar.gz
+.. _`3.7.3 md5`: https://github.com/OSGeo/gdal/releases/download/v3.7.3/gdal-3.7.3.tar.gz.md5
+
+* **2023-09-13** `gdal-3.7.2.tar.gz`_ `3.7.2 Release Notes`_ (`3.7.2 md5`_)
+
+.. _`3.7.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.7.2/NEWS.md
+.. _`gdal-3.7.2.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.7.2/gdal-3.7.2.tar.gz
+.. _`3.7.2 md5`: https://github.com/OSGeo/gdal/releases/download/v3.7.2/gdal-3.7.2.tar.gz.md5
+
+* **2023-07-13** `gdal-3.7.1.tar.gz`_ `3.7.1 Release Notes`_ (`3.7.1 md5`_)
+
+.. _`3.7.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.7.1/NEWS.md
+.. _`gdal-3.7.1.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.7.1/gdal-3.7.1.tar.gz
+.. _`3.7.1 md5`: https://github.com/OSGeo/gdal/releases/download/v3.7.1/gdal-3.7.1.tar.gz.md5
+
+* **2023-05-10** `gdal-3.7.0.tar.gz`_ `3.7.0 Release Notes`_ (`3.7.0 md5`_)
+
+.. _`3.7.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.7.0/NEWS.md
+.. _`gdal-3.7.0.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.7.0/gdal-3.7.0.tar.gz
+.. _`3.7.0 md5`: https://github.com/OSGeo/gdal/releases/download/v3.7.0/gdal-3.7.0.tar.gz.md5
+
+* **2023-04-21** `gdal-3.6.4.tar.gz`_ `3.6.4 Release Notes`_ (`3.6.4 md5`_)
+
+.. _`3.6.4 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.6.4/NEWS.md
+.. _`gdal-3.6.4.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.6.4/gdal-3.6.4.tar.gz
+.. _`3.6.4 md5`: https://github.com/OSGeo/gdal/releases/download/v3.6.4/gdal-3.6.4.tar.gz.md5
+
+* **2023-03-13** `gdal-3.6.3.tar.gz`_ `3.6.3 Release Notes`_ (`3.6.3 md5`_)
+
+.. _`3.6.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.6.3/NEWS.md
+.. _`gdal-3.6.3.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.6.3/gdal-3.6.3.tar.gz
+.. _`3.6.3 md5`: https://github.com/OSGeo/gdal/releases/download/v3.6.3/gdal-3.6.3.tar.gz.md5
+
+* **2023-01-05** `gdal-3.6.2.tar.gz`_ `3.6.2 Release Notes`_ (`3.6.2 md5`_)
+
+.. _`3.6.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.6.2/NEWS.md
+.. _`gdal-3.6.2.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.6.2/gdal-3.6.2.tar.gz
+.. _`3.6.2 md5`: https://github.com/OSGeo/gdal/releases/download/v3.6.2/gdal-3.6.2.tar.gz.md5
+
+* **2022-12-11** `gdal-3.6.1.tar.gz`_ `3.6.1 Release Notes`_ (`3.6.1 md5`_)
+
+.. _`3.6.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.6.1/NEWS.md
+.. _`gdal-3.6.1.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.6.1/gdal-3.6.1.tar.gz
+.. _`3.6.1 md5`: https://github.com/OSGeo/gdal/releases/download/v3.6.1/gdal-3.6.1.tar.gz.md5
+
+* **2022-11-06** `3.6.0 Release Notes`_ *Warning*: this version has been official retracted and superseded per 3.6.1
+
+.. _`3.6.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.6.0/NEWS.md
+
+* **2022-10-21** `gdal-3.5.3.tar.gz`_ `3.5.3 Release Notes`_ (`3.5.3 md5`_)
+
+.. _`3.5.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.5.3/NEWS.md
+.. _`gdal-3.5.3.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.5.3/gdal-3.5.3.tar.gz
+.. _`3.5.3 md5`: https://github.com/OSGeo/gdal/releases/download/v3.5.3/gdal-3.5.3.tar.gz.md5
+
+* **2022-09-12** `gdal-3.5.2.tar.gz`_ `3.5.2 Release Notes`_ (`3.5.2 md5`_)
+
+.. _`3.5.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.5.2/NEWS.md
+.. _`gdal-3.5.2.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.5.2/gdal-3.5.2.tar.gz
+.. _`3.5.2 md5`: https://github.com/OSGeo/gdal/releases/download/v3.5.2/gdal-3.5.2.tar.gz.md5
 
 * **2022-07-06** `gdal-3.5.1.tar.gz`_ `3.5.1 Release Notes`_ (`3.5.1 md5`_)
 
 .. _`3.5.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.5.1/NEWS.md
 .. _`gdal-3.5.1.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.5.1/gdal-3.5.1.tar.gz
 .. _`3.5.1 md5`: https://github.com/OSGeo/gdal/releases/download/v3.5.1/gdal-3.5.1.tar.gz.md5
-
-Past Releases
-................................................................................
 
 * **2022-05-13** `gdal-3.5.0.tar.gz`_ `3.5.0 Release Notes`_ (`3.5.0 md5`_)
 
@@ -240,28 +432,7 @@ command
 
     git clone https://github.com/OSGeo/GDAL.git
 
-
-Building GDAL
-................................................................................
-
-
-Build requirements
-~~~~~~~~~~~~~~~~~~
-
-To build GDAL 3 or later, you need *at a minimum* a C++11 compatible compiler, and
-`PROJ 6 or later <https://proj.org>`_.
-This will only give you a minimum build which will lack a lot of drivers.
-Consult :ref:`raster_drivers` and :ref:`vector_drivers` pages for additional optional
-dependencies.
-
-
-Build instructions
-~~~~~~~~~~~~~~~~~~
-
-See https://trac.osgeo.org/gdal/wiki/BuildHints for hints for existing
-autoconf and nmake build systems.
-
-From GDAL 3.5, an *experimental* :ref:`CMake-based build <build_hints>` is available.
+Additional information is available about :ref:`build_requirements` and :ref:`building_from_source`.
 
 .. toctree::
    :maxdepth: 0


### PR DESCRIPTION
Fixes osgeo/gdal#9065.

I assume most users will want binaries, not source, so I'm putting the binaries section first.

For information on binaries (other than Conda builds), users are directed to the Trac wiki page, which is being continually updated by those who build GDAL binaries (https://github.com/OSGeo/gdal/issues/9065#issuecomment-1889250617).