### PR TITLE
[Backport release/3.8] MySQL: fix/workaround server-side spatial filtering when SRS is geographic with MySQL >= 8 (fixes qgis/QGIS#55463)

### DIFF
--- a/autotest/ogr/ogr_mysql.py
+++ b/autotest/ogr/ogr_mysql.py
@@ -960,6 +960,11 @@ def test_ogr_mysql_longlat(mysql_ds, mysql_is_8_or_later):
             pytest.fail("Not found SRID definition with GEOMETORY field.")
         mysql_ds.ReleaseResultSet(sql_lyr)
 
+    lyr.SetSpatialFilterRect(-181, -91, 181, 91)
+    lyr.ResetReading()
+    f = lyr.GetNextFeature()
+    ogrtest.check_feature_geometry(f, geom)
+
 
 ###############################################################################
 # Test writing and reading back geometries


### PR DESCRIPTION
Backport #9152
 **Authored by:** @rouault