### PR TITLE
OGRGeometryFactory::forceTo(): fix assertion with empty geometry and target type = unknown

### DIFF
--- a/autotest/cpp/test_ogr.cpp
+++ b/autotest/cpp/test_ogr.cpp
@@ -425,6 +425,11 @@ TEST_F(test_ogr, geometry_get_point)
     }
 }
 
+TEST_F(test_ogr, OGR_G_CreateGeometry_unknown)
+{
+    EXPECT_EQ(OGR_G_CreateGeometry(wkbUnknown), nullptr);
+}
+
 TEST_F(test_ogr, style_manager)
 {
     OGRStyleMgrH hSM = OGR_SM_Create(nullptr);

--- a/autotest/ogr/ogr_factory.py
+++ b/autotest/ogr/ogr_factory.py
@@ -903,6 +903,31 @@ def test_ogr_factory_8():
 
 
 ###############################################################################
+# Test forceTo() to wkbUnknown
+
+
+@pytest.mark.parametrize(
+    "src_wkt,target_type,exp_wkt",
+    [
+        (
+            "POINT (1 2)",
+            ogr.wkbUnknown,
+            "POINT (1 2)",
+        ),
+        (
+            "POINT EMPTY",
+            ogr.wkbUnknown,
+            "POINT EMPTY",
+        ),
+    ],
+)
+def test_ogr_factory_forceTo_unknown(src_wkt, target_type, exp_wkt):
+    src_geom = ogr.CreateGeometryFromWkt(src_wkt)
+    dst_geom = ogr.ForceTo(src_geom, target_type)
+    ogrtest.check_feature_geometry(dst_geom, exp_wkt)
+
+
+###############################################################################
 # Test forceTo()
 
 

--- a/ogr/ogrgeometryfactory.cpp
+++ b/ogr/ogrgeometryfactory.cpp
@@ -4554,6 +4554,10 @@ OGRGeometry *OGRGeometryFactory::forceTo(OGRGeometry *poGeom,
     if (poGeom == nullptr)
         return poGeom;
 
+    const OGRwkbGeometryType eTargetTypeFlat = wkbFlatten(eTargetType);
+    if (eTargetTypeFlat == wkbUnknown)
+        return poGeom;
+
     if (poGeom->IsEmpty())
     {
         OGRGeometry *poRet = createGeometry(eTargetType);
@@ -4566,10 +4570,6 @@ OGRGeometry *OGRGeometryFactory::forceTo(OGRGeometry *poGeom,
         delete poGeom;
         return poRet;
     }
-
-    const OGRwkbGeometryType eTargetTypeFlat = wkbFlatten(eTargetType);
-    if (eTargetTypeFlat == wkbUnknown)
-        return poGeom;
 
     OGRwkbGeometryType eType = poGeom->getGeometryType();
     OGRwkbGeometryType eTypeFlat = wkbFlatten(eType);

--- a/ogr/ogrgeometryfactory.cpp
+++ b/ogr/ogrgeometryfactory.cpp
@@ -621,6 +621,9 @@ OGRGeometryFactory::createGeometry(OGRwkbGeometryType eGeometryType)
             poGeom = new (std::nothrow) OGRTriangulatedSurface();
             break;
 
+        case wkbUnknown:
+            break;
+
         default:
             CPLAssert(false);
             break;


### PR DESCRIPTION
Found by CIFuzz: https://github.com/OSGeo/gdal/actions/runs/7740101693/job/21105197876?pr=9166
