### PR TITLE
docker/ubuntu-full/Dockerfile: pin libarrow-acero-dev version (fixes #9183)

### DIFF
--- a/docker/ubuntu-full/Dockerfile
+++ b/docker/ubuntu-full/Dockerfile
@@ -241,6 +241,7 @@ RUN . /buildscripts/bh-set-envvars.sh \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y -V libarrow-dataset${ARROW_SOVERSION}${APT_ARCH_SUFFIX} \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y -V libarrow-dev${APT_ARCH_SUFFIX}=${ARROW_VERSION} \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y -V libparquet-dev${APT_ARCH_SUFFIX}=${ARROW_VERSION} \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y -V libarrow-acero-dev${APT_ARCH_SUFFIX}=${ARROW_VERSION} \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y -V libarrow-dataset-dev${APT_ARCH_SUFFIX}=${ARROW_VERSION} \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
This works around an apparent dependency bug in `libarrow-dataset-dev`, by first explicitly installing the matching version of `libarrow-acero-dev`.

## What does this PR do?

Changes the `Dockerfile` to install `libarrow-acero-dev` first, with the correct version (`${ARROW_VERSION}`), before installing `libarrow-dataset-dev`.
If this is not done, installing a specific version of `libarrow-dataset-dev` seems to try to install the _latest_ version of `libarrow-acero-dev`, instead of the one with matching version, and this makes `apt-get install` fail.

An advantage with this fix, compared to bumping `ARROW_VERSION` to the currently latest version of Apache Arrow (`libarrow-dataset-dev` et al.) is that "the currently latest version of Apache Arrow" can change at any time depending on the Apache Arrow release schedule, which would break the GDAL build again.

The real bug is presumably that `libarrow-dataset-dev` has incorrect dependency information.


Note: When I ran `ubuntu-full/build.sh` in Docker Desktop on my Intel Mac it successfully installed `libarrow-dataset-dev` but much later, during build of some `arm64`(!) thing, the build crashed:
```
...
Setting up libgnutls30:arm64 (3.7.3-4ubuntu1.4) ...
Processing triggers for libc-bin (2.35-0ubuntu3.6) ...
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
Segmentation fault
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
Segmentation fault
dpkg: error processing package libc-bin (--configure):
 installed libc-bin package post-installation script subprocess returned error exit status 139
Errors were encountered while processing:
 libc-bin
E: Sub-process /usr/bin/dpkg returned an error code (1)
The command '/bin/sh -c apt-get update -y && apt-get upgrade -y     && rm -rf /var/lib/apt/lists/*' returned a non-zero code: 100
```
I would guess this crash is completely unrelated to the changes in this PR.

## What are related issues/pull requests?
Issue #9183

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
