### PR TITLE
[WIP] GDAL_GCP C++'ification: appropriate for 3.9 ?

### DIFF
--- a/autotest/cpp/test_gdal.cpp
+++ b/autotest/cpp/test_gdal.cpp
@@ -3597,4 +3597,72 @@ TEST_F(test_gdal, drop_cache)
     }
 }
 
+TEST_F(test_gdal, GDAL_GCP)
+{
+    // Test default constructor
+    {
+        GDAL_GCP x;
+        EXPECT_STREQ(x.pszId, "");
+        EXPECT_STREQ(x.pszInfo, "");
+        EXPECT_EQ(x.dfGCPPixel, 0.0);
+        EXPECT_EQ(x.dfGCPLine, 0.0);
+        EXPECT_EQ(x.dfGCPX, 0.0);
+        EXPECT_EQ(x.dfGCPY, 0.0);
+        EXPECT_EQ(x.dfGCPZ, 0.0);
+    }
+
+    // Test move constructor
+    {
+        GDAL_GCP x;
+        x.SetId("id");
+        x.SetInfo("info");
+        x.dfGCPPixel = 1.0;
+        x.dfGCPLine = 2.0;
+        x.dfGCPX = 3.0;
+        x.dfGCPY = 4.0;
+        x.dfGCPZ = 5.0;
+
+        const GDAL_GCP y(std::move(x));
+        EXPECT_STREQ(y.pszId, "id");
+        EXPECT_STREQ(y.pszInfo, "info");
+        EXPECT_EQ(y.dfGCPPixel, 1.0);
+        EXPECT_EQ(y.dfGCPLine, 2.0);
+        EXPECT_EQ(y.dfGCPX, 3.0);
+        EXPECT_EQ(y.dfGCPY, 4.0);
+        EXPECT_EQ(y.dfGCPZ, 5.0);
+    }
+
+    // Test move assignment operator
+    {
+        GDAL_GCP x;
+        x.SetId("id");
+        x.SetInfo("info");
+        x.dfGCPPixel = 1.0;
+        x.dfGCPLine = 2.0;
+        x.dfGCPX = 3.0;
+        x.dfGCPY = 4.0;
+        x.dfGCPZ = 5.0;
+
+        GDAL_GCP y;
+        y.SetId("id_old");
+        y.SetInfo("info_old");
+        y = std::move(x);
+        EXPECT_STREQ(y.pszId, "id");
+        EXPECT_STREQ(y.pszInfo, "info");
+        EXPECT_EQ(y.dfGCPPixel, 1.0);
+        EXPECT_EQ(y.dfGCPLine, 2.0);
+        EXPECT_EQ(y.dfGCPX, 3.0);
+        EXPECT_EQ(y.dfGCPY, 4.0);
+        EXPECT_EQ(y.dfGCPZ, 5.0);
+    }
+
+    // Non-nominal use, mixing C++ and C habits, but useful to ensure
+    // minimum backward compatibility with old practices.
+    {
+        GDAL_GCP x;
+        GDALInitGCPs(1, &x);
+        GDALDeinitGCPs(1, &x);
+    }
+}
+
 }  // namespace

--- a/frmts/hfa/hfadataset.cpp
+++ b/frmts/hfa/hfadataset.cpp
@@ -3064,7 +3064,6 @@ HFADataset::HFADataset()
 {
     m_oSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
 
-    memset(asGCPList, 0, sizeof(asGCPList));
     memset(adfGeoTransform, 0, sizeof(adfGeoTransform));
 }
 
@@ -3098,9 +3097,6 @@ HFADataset::~HFADataset()
         }
         hHFA = nullptr;
     }
-
-    if (nGCPCount > 0)
-        GDALDeinitGCPs(36, asGCPList);
 }
 
 /************************************************************************/
@@ -4618,28 +4614,26 @@ void HFADataset::UseXFormStack(int nStepCount, Efga_Polynomial *pasPLForward,
 
 {
     // Generate GCPs using the transform.
-    nGCPCount = 0;
-    GDALInitGCPs(36, asGCPList);
-
     for (double dfYRatio = 0.0; dfYRatio < 1.001; dfYRatio += 0.2)
     {
         for (double dfXRatio = 0.0; dfXRatio < 1.001; dfXRatio += 0.2)
         {
             const double dfLine = 0.5 + (GetRasterYSize() - 1) * dfYRatio;
             const double dfPixel = 0.5 + (GetRasterXSize() - 1) * dfXRatio;
-            const int iGCP = nGCPCount;
 
-            asGCPList[iGCP].dfGCPPixel = dfPixel;
-            asGCPList[iGCP].dfGCPLine = dfLine;
+            GDAL_GCP gcp;
+            gcp.dfGCPPixel = dfPixel;
+            gcp.dfGCPLine = dfLine;
 
-            asGCPList[iGCP].dfGCPX = dfPixel;
-            asGCPList[iGCP].dfGCPY = dfLine;
-            asGCPList[iGCP].dfGCPZ = 0.0;
+            gcp.dfGCPX = dfPixel;
+            gcp.dfGCPY = dfLine;
+            gcp.dfGCPZ = 0.0;
 
             if (HFAEvaluateXFormStack(nStepCount, FALSE, pasPLReverse,
-                                      &(asGCPList[iGCP].dfGCPX),
-                                      &(asGCPList[iGCP].dfGCPY)))
-                nGCPCount++;
+                                      &(gcp.dfGCPX), &(gcp.dfGCPY)))
+            {
+                m_aoGCPs.emplace_back(std::move(gcp));
+            }
         }
     }
 
@@ -4715,7 +4709,7 @@ void HFADataset::UseXFormStack(int nStepCount, Efga_Polynomial *pasPLForward,
 int HFADataset::GetGCPCount()
 {
     const int nPAMCount = GDALPamDataset::GetGCPCount();
-    return nPAMCount > 0 ? nPAMCount : nGCPCount;
+    return nPAMCount > 0 ? nPAMCount : static_cast<int>(m_aoGCPs.size());
 }
 
 /************************************************************************/
@@ -4728,7 +4722,7 @@ const OGRSpatialReference *HFADataset::GetGCPSpatialRef() const
     const OGRSpatialReference *poSRS = GDALPamDataset::GetGCPSpatialRef();
     if (poSRS)
         return poSRS;
-    return nGCPCount > 0 && !m_oSRS.IsEmpty() ? &m_oSRS : nullptr;
+    return !m_aoGCPs.empty() && !m_oSRS.IsEmpty() ? &m_oSRS : nullptr;
 }
 
 /************************************************************************/
@@ -4740,7 +4734,7 @@ const GDAL_GCP *HFADataset::GetGCPs()
     const GDAL_GCP *psPAMGCPs = GDALPamDataset::GetGCPs();
     if (psPAMGCPs)
         return psPAMGCPs;
-    return asGCPList;
+    return m_aoGCPs.data();
 }
 
 /************************************************************************/

--- a/frmts/hfa/hfadataset.h
+++ b/frmts/hfa/hfadataset.h
@@ -68,8 +68,7 @@ class HFADataset final : public GDALPamDataset
     bool bForceToPEString = false;
     bool bDisablePEString = false;
 
-    int nGCPCount = 0;
-    GDAL_GCP asGCPList[36];
+    std::vector<GDAL_GCP> m_aoGCPs{};
 
     void UseXFormStack(int nStepCount, Efga_Polynomial *pasPolyListForward,
                        Efga_Polynomial *pasPolyListReverse);

--- a/frmts/sentinel2/sentinel2dataset.cpp
+++ b/frmts/sentinel2/sentinel2dataset.cpp
@@ -2234,7 +2234,6 @@ GDALDataset *SENTINEL2Dataset::OpenL1BSubdataset(GDALOpenInfo *poOpenInfo)
             if (poRing != nullptr && poRing->getNumPoints() == 5)
             {
                 GDAL_GCP asGCPList[5];
-                memset(asGCPList, 0, sizeof(asGCPList));
                 for (int i = 0; i < 4; i++)
                 {
                     asGCPList[i].dfGCPX = poRing->getX(i);
@@ -2279,7 +2278,6 @@ GDALDataset *SENTINEL2Dataset::OpenL1BSubdataset(GDALOpenInfo *poOpenInfo)
                 }
 
                 poDS->SetGCPs(nGCPCount, asGCPList, SRS_WKT_WGS84_LAT_LONG);
-                GDALDeinitGCPs(nGCPCount, asGCPList);
             }
         }
         delete poGeom;

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -1061,8 +1061,23 @@ const char CPL_DLL *CPL_STDCALL GDALGetDriverCreationOptionList(GDALDriverH);
 /*      GDAL_GCP                                                        */
 /* ==================================================================== */
 
+/* clang-format off */
+
+#if defined(__cplusplus) && !defined(CPL_SUPRESS_CPLUSPLUS) && !defined(GDAL_SUPPRESS_GCP_CPLUSPLUS)
+extern "C++"
+{
+#endif
+
+#if defined(__cplusplus) && !defined(CPL_SUPRESS_CPLUSPLUS) && !defined(GDAL_SUPPRESS_GCP_CPLUSPLUS)
+/** Ground Control Point.
+ *
+ * Usable as a C++ object since GDAL 3.9.
+ */
+struct CPL_DLL GDAL_GCP
+#else
 /** Ground Control Point */
 typedef struct
+#endif
 {
     /** Unique identifier, often numeric */
     char *pszId;
@@ -1072,6 +1087,7 @@ typedef struct
 
     /** Pixel (x) location of GCP on raster */
     double dfGCPPixel;
+
     /** Line (y) location of GCP on raster */
     double dfGCPLine;
 
@@ -1083,7 +1099,35 @@ typedef struct
 
     /** Elevation of GCP, or zero if not known */
     double dfGCPZ;
-} GDAL_GCP;
+
+#if defined(__cplusplus) && !defined(CPL_SUPRESS_CPLUSPLUS) && !defined(GDAL_SUPPRESS_GCP_CPLUSPLUS)
+    /** Constructor. */
+    GDAL_GCP(): pszId(VSIGetStaticEmptyString()), pszInfo(VSIGetStaticEmptyString()),
+                dfGCPPixel(0), dfGCPLine(0),
+                dfGCPX(0), dfGCPY(0), dfGCPZ(0) {}
+    ~GDAL_GCP();
+    GDAL_GCP(GDAL_GCP &&);
+    GDAL_GCP &operator=(GDAL_GCP &&);
+
+    void SetId(const char* pszNewId);
+
+    void SetInfo(const char* pszNewInfo);
+
+  private:
+    GDAL_GCP(const GDAL_GCP &) = delete;
+    GDAL_GCP &operator=(const GDAL_GCP &) = delete;
+#endif
+}
+#if !(defined(__cplusplus) && !defined(CPL_SUPRESS_CPLUSPLUS) && !defined(GDAL_SUPPRESS_GCP_CPLUSPLUS))
+GDAL_GCP
+#endif
+;
+
+#if defined(__cplusplus) && !defined(CPL_SUPRESS_CPLUSPLUS) && !defined(GDAL_SUPPRESS_GCP_CPLUSPLUS)
+}  // extern "C++"
+#endif
+
+/* clang-format on */
 
 void CPL_DLL CPL_STDCALL GDALInitGCPs(int, GDAL_GCP *);
 void CPL_DLL CPL_STDCALL GDALDeinitGCPs(int, GDAL_GCP *);

--- a/gcore/gdalpamdataset.cpp
+++ b/gcore/gdalpamdataset.cpp
@@ -609,11 +609,8 @@ CPLErr GDALPamDataset::XMLInit(CPLXMLNode *psTree, const char *pszUnused)
                 {
                     std::vector<GDAL_GCP> asGCPs;
                     asGCPs.resize(adfSource.size() / 2);
-                    char szEmptyString[] = {0};
                     for (size_t i = 0; i + 1 < adfSource.size(); i += 2)
                     {
-                        asGCPs[i / 2].pszId = szEmptyString;
-                        asGCPs[i / 2].pszInfo = szEmptyString;
                         asGCPs[i / 2].dfGCPPixel = adfSource[i];
                         asGCPs[i / 2].dfGCPLine = ySourceAllNegative
                                                       ? -adfSource[i + 1]

--- a/port/cpl_vsi.h
+++ b/port/cpl_vsi.h
@@ -286,6 +286,8 @@ const char CPL_DLL *VSIGetCredential(const char *pszPath, const char *pszKey,
 /*      Memory allocation                                               */
 /* ==================================================================== */
 
+char CPL_DLL *VSIGetStaticEmptyString();
+
 void CPL_DLL *VSICalloc(size_t, size_t) CPL_WARN_UNUSED_RESULT;
 void CPL_DLL *VSIMalloc(size_t) CPL_WARN_UNUSED_RESULT;
 void CPL_DLL VSIFree(void *);

--- a/port/cpl_vsisimple.cpp
+++ b/port/cpl_vsisimple.cpp
@@ -835,6 +835,21 @@ void *VSIRealloc(void *pData, size_t nNewSize)
 }
 
 /************************************************************************/
+/*                       VSIGetStaticEmptyString()                      */
+/************************************************************************/
+
+static char *VSI_STATIC_EMPTY_STRING = const_cast<char *>("");
+
+/** Return an empty string ("") that VSIFree() does not free.
+ *
+ * That string should not be modified.
+ */
+char *VSIGetStaticEmptyString()
+{
+    return VSI_STATIC_EMPTY_STRING;
+}
+
+/************************************************************************/
 /*                              VSIFree()                               */
 /************************************************************************/
 
@@ -843,10 +858,10 @@ void *VSIRealloc(void *pData, size_t nNewSize)
 void VSIFree(void *pData)
 
 {
-#ifdef DEBUG_VSIMALLOC
-    if (pData == nullptr)
+    if (pData == nullptr || pData == VSI_STATIC_EMPTY_STRING)
         return;
 
+#ifdef DEBUG_VSIMALLOC
     char *ptr = ((char *)pData) - 2 * sizeof(void *);
     VSICheckMarkerBegin(ptr);
     size_t nOldSize = 0;
@@ -885,8 +900,7 @@ void VSIFree(void *pData)
 #endif
 
 #else
-    if (pData != nullptr)
-        free(pData);
+    free(pData);
 #endif
 }
 

--- a/port/cpl_vsisimple.cpp
+++ b/port/cpl_vsisimple.cpp
@@ -838,7 +838,7 @@ void *VSIRealloc(void *pData, size_t nNewSize)
 /*                       VSIGetStaticEmptyString()                      */
 /************************************************************************/
 
-static char *VSI_STATIC_EMPTY_STRING = const_cast<char *>("");
+static char VSI_STATIC_EMPTY_STRING = 0;
 
 /** Return an empty string ("") that VSIFree() does not free.
  *
@@ -846,7 +846,7 @@ static char *VSI_STATIC_EMPTY_STRING = const_cast<char *>("");
  */
 char *VSIGetStaticEmptyString()
 {
-    return VSI_STATIC_EMPTY_STRING;
+    return &VSI_STATIC_EMPTY_STRING;
 }
 
 /************************************************************************/
@@ -858,7 +858,7 @@ char *VSIGetStaticEmptyString()
 void VSIFree(void *pData)
 
 {
-    if (pData == nullptr || pData == VSI_STATIC_EMPTY_STRING)
+    if (pData == nullptr || pData == VSIGetStaticEmptyString())
         return;
 
 #ifdef DEBUG_VSIMALLOC


### PR DESCRIPTION
Up to now, GDAL_GCP was only a C-only structure. The typical/recommended pattern to create GCPs from C is:
```
GDAL_GCP* gcps = (GDAL_GCP*)CPLMalloc( count * sizeof(GDAL_GCP) );
GDALInitGCPs( count, gcps );  // zero-initialize  pixel,line,x,y,z double members of each gcps[], and affects a CPLStrdup("") string to pszId and pszInfo members of each gcps[]
CPLFree(gcps[0].pszId); // free the initial empty string
gcps[0].pszId = CPLStrdup("foo"); // for example
GDALDeinitGCPs( count, gcps ); // free memory of gcps[i].pszId and gcps[i].pszInfo
CPLFree(gcps); // free the arra itself
```
This is "fine" for a C user, but quite tedious in a C++ context. Big users of creating GCPs are GDAL drivers themselves.

So this pull request makes GDAL_GCP is a C++ struct, when gdal.h included from C++ code, with a default allocator, a destructor and move constructor / assignment operators.

This mostly works except a few details:

- If a GDAL_GCP is allocated as a C++ object ( ie something like ``GDAL_GCP gcp``, or ``GDAL_GCP gcps[5]`` or with ``std::vector<GDAL_GCP>``, or anything that is not ``CPLMalloc()``/``VSIMalloc()``), and then passed to ``GDALInitGCPs()``, a memory leak would occur because ``pszId`` will be initialized twice. Here the fix consists in the GDAL_GCP constructor to assign it to the return of a  ``VSIGetStaticEmptyString()``  function, which returns a special static instance of an empty string, that ``VSIFree()`` explicitly recognizes and does not free. Hence no leak occurs.

- For a GDAL_GCP created as a C++ object, one could run into issues with double-free, when explicitly calling ``GDALDeinitGCPs()``, and then when the GDAL_GCP destructor automatically runs. This was easily fixed by making ``GDALDeinitGCPs()`` to nullify ``pszId`` and ``pszInfo`` members after CPLFree()'ing them.

All above are just implementation details. More annoyingly, here are the few backward incompatibilities I found with a few instances of C++ code:

- In gdalpamdataset.cpp, we kind of abused the recommended workflow mentionned at the beginning, by assigning a static empty string to pszId and pszInfo on a GDAL_GCP[] object, and not use GDALInitGCPs() / GDALDeinitGCPs(). The issue now is that when ``~GDAL_GCP()`` is called it will try to ``CPLFree()`` that.  No other solution here than removing that initialization, that is no longer needed

- In ``GDALLoadTabFile()`` and ``GDALLoadOziMapFile()``, a GDAL_GCP[] array was allocated, and then memcpy()'d onto a dynamically array allocated with ``CPLMalloc( count * sizeof(GDAL_GCP) )`` returned to the user. This code has to be changed to remove the ``memcpy()`` part and do ``cpl_malloc_gcps[i] = std::move(asGCPs[i])``

- The Sentinel2 driver used ``memset(gcps, 0, sizeof(gcps))`` to initialize a GDAL_GCP[] array. Some compilers complained about memset()'ing a non plain-old-object instance. The fix is just to remove that now useless memset().

Except those details, all other drivers compile and pass their regression tests, which makes me believe, that while being backward incompatible, this is still reasonable. The compiler should complain in most problematic situations where the code has to be changed (this was for example for the memcpy() in GDALLoadTabile/GDALLoadOziMapFile). The only undetected change at compile time was the "clever trick" of gdalpamdataset.cpp which was only detected at runtime. Hopefully such a pattern should be exceptional.
In the worse case, users can define the new ``GDAL_SUPPRESS_GCP_CPLUSPLUS`` macro before including gdal.h, which will make their code see the POD C structure.

And to re-iterate, this has no impact on C-only users

The first commit introduces the minimum changes to get things working, and the second one modernizes the HFA driver to use a ``std::vector<GDAL_GCP>`` to show the benefits of the proposed change (less magic numbers, automatic construction/destruction) . More drivers could be modernized in a similar way