### PR TITLE
Add VSIGetDirectorySeparator() and related changes

### DIFF
--- a/.github/workflows/cmake_builds.yml
+++ b/.github/workflows/cmake_builds.yml
@@ -43,10 +43,7 @@ jobs:
             ${{ runner.os }}-${{ env.cache-name }}
     - name: Install dependency
       run: |
-        # This currently fails as of https://lists.osgeo.org/pipermail/ubuntu/2023-October/002046.html
-        # sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
-        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 6B827C12C2D425E227EDCA75089EBE08314DF160
-        sudo add-apt-repository -y http://ppa.launchpad.net/ubuntugis/ubuntugis-unstable/ubuntu/
+        sudo add-apt-repository -y ppa:ubuntugis/ubuntugis-unstable
         sudo apt-get update
         sudo apt-get install -y -q bison libaec-dev libjpeg-dev libgif-dev liblzma-dev libzstd-dev libgeos-dev git \
            libcurl4-gnutls-dev libproj-dev libxml2-dev  libxerces-c-dev libnetcdf-dev netcdf-bin \

--- a/autotest/gcore/vsifile.py
+++ b/autotest/gcore/vsifile.py
@@ -937,8 +937,9 @@ def test_vsifile_opendir(basepath):
     for i in range(4):
         entry = gdal.GetNextDirEntry(d)
         assert entry
-        if entry.name == "test":
-            entries_found.append(entry.name)
+        name = entry.name.replace("\\", "/")
+        if name == "test":
+            entries_found.append(name)
             assert (entry.mode & 32768) != 0
             assert entry.modeKnown
             assert entry.size == 3
@@ -946,14 +947,14 @@ def test_vsifile_opendir(basepath):
             assert entry.mtime != 0
             assert entry.mtimeKnown
             assert not entry.extra
-        elif entry.name == "subdir":
-            entries_found.append(entry.name)
+        elif name == "subdir":
+            entries_found.append(name)
             assert (entry.mode & 16384) != 0
-        elif entry.name == "subdir/subdir2":
-            entries_found.append(entry.name)
+        elif name == "subdir/subdir2":
+            entries_found.append(name)
             assert (entry.mode & 16384) != 0
-        elif entry.name == "subdir/subdir2/test2":
-            entries_found.append(entry.name)
+        elif name == "subdir/subdir2/test2":
+            entries_found.append(name)
             assert (entry.mode & 32768) != 0
         else:
             assert False, entry.name
@@ -970,19 +971,20 @@ def test_vsifile_opendir(basepath):
     for i in range(4):
         entry = gdal.GetNextDirEntry(d)
         assert entry
-        if entry.name == "test":
-            entries_found.append(entry.name)
+        name = entry.name.replace("\\", "/")
+        if name == "test":
+            entries_found.append(name)
             assert (entry.mode & 32768) != 0
             if os.name == "posix" and basepath == "tmp/":
                 assert entry.size == 0
-        elif entry.name == "subdir":
-            entries_found.append(entry.name)
+        elif name == "subdir":
+            entries_found.append(name)
             assert (entry.mode & 16384) != 0
-        elif entry.name == "subdir/subdir2":
-            entries_found.append(entry.name)
+        elif name == "subdir/subdir2":
+            entries_found.append(name)
             assert (entry.mode & 16384) != 0
-        elif entry.name == "subdir/subdir2/test2":
-            entries_found.append(entry.name)
+        elif name == "subdir/subdir2/test2":
+            entries_found.append(name)
             assert (entry.mode & 32768) != 0
             if os.name == "posix" and basepath == "tmp/":
                 assert entry.size == 0
@@ -1009,7 +1011,10 @@ def test_vsifile_opendir(basepath):
 
     # Depth 1
     files = set(
-        [l_entry.name for l_entry in gdal.listdir(basepath + "/vsifile_opendir", 1)]
+        [
+            l_entry.name.replace("\\", "/")
+            for l_entry in gdal.listdir(basepath + "/vsifile_opendir", 1)
+        ]
     )
     assert files == set(["test", "subdir", "subdir/subdir2"])
 
@@ -1030,18 +1035,19 @@ def test_vsifile_opendir(basepath):
     entry = gdal.GetNextDirEntry(d)
     assert entry.name == "subdir"
     entry = gdal.GetNextDirEntry(d)
-    assert entry.name == "subdir/subdir2"
+    sep = "\\" if "\\" in entry.name else "/"
+    assert entry.name.replace("\\", "/") == "subdir/subdir2"
     entry = gdal.GetNextDirEntry(d)
-    assert entry.name == "subdir/subdir2/test2"
+    assert entry.name.replace("\\", "/") == "subdir/subdir2/test2"
     entry = gdal.GetNextDirEntry(d)
     assert not entry
     gdal.CloseDir(d)
 
-    d = gdal.OpenDir(basepath + "/vsifile_opendir", -1, ["PREFIX=subdir/sub"])
+    d = gdal.OpenDir(basepath + "/vsifile_opendir", -1, ["PREFIX=subdir" + sep + "sub"])
     entry = gdal.GetNextDirEntry(d)
-    assert entry.name == "subdir/subdir2"
+    assert entry.name.replace("\\", "/") == "subdir/subdir2"
     entry = gdal.GetNextDirEntry(d)
-    assert entry.name == "subdir/subdir2/test2"
+    assert entry.name.replace("\\", "/") == "subdir/subdir2/test2"
     entry = gdal.GetNextDirEntry(d)
     assert not entry
     gdal.CloseDir(d)

--- a/frmts/zarr/zarr_array.cpp
+++ b/frmts/zarr/zarr_array.cpp
@@ -2210,12 +2210,16 @@ bool ZarrArray::CacheTilePresence()
              "present...",
              osDirectoryName.c_str());
     uint64_t nCounter = 0;
+    const char chSrcFilenameDirSeparator =
+        VSIGetDirectorySeparator(osDirectoryName.c_str())[0];
     while (const VSIDIREntry *psEntry = VSIGetNextDirEntry(psDir))
     {
         if (!VSI_ISDIR(psEntry->nMode))
         {
-            const CPLStringList aosTokens =
-                GetTileIndicesFromFilename(psEntry->pszName);
+            const CPLStringList aosTokens = GetTileIndicesFromFilename(
+                CPLString(psEntry->pszName)
+                    .replaceAll(chSrcFilenameDirSeparator, '/')
+                    .c_str());
             if (aosTokens.size() == static_cast<int>(m_aoDims.size()))
             {
                 // Get tile indices from filename

--- a/port/cpl_vsi.h
+++ b/port/cpl_vsi.h
@@ -380,6 +380,8 @@ char CPL_DLL **VSIReadDirRecursive(const char *pszPath);
 char CPL_DLL **VSIReadDirEx(const char *pszPath, int nMaxFiles);
 char CPL_DLL **VSISiblingFiles(const char *pszPath);
 
+const char CPL_DLL *VSIGetDirectorySeparator(const char *pszPath);
+
 /** Opaque type for a directory iterator */
 typedef struct VSIDIR VSIDIR;
 

--- a/port/cpl_vsi_virtual.h
+++ b/port/cpl_vsi_virtual.h
@@ -305,6 +305,17 @@ class CPL_DLL VSIFilesystemHandler
                  "Duplicate() not supported on this file system");
         return nullptr;
     }
+
+    /** Return the directory separator.
+     *
+     * Default is forward slash. The only exception currently is the Windows
+     * file system which returns anti-slash, unless the specified path is of the
+     * form "{drive_letter}:/{rest_of_the_path}".
+     */
+    virtual const char *GetDirectorySeparator(CPL_UNUSED const char *pszPath)
+    {
+        return "/";
+    }
 };
 #endif /* #ifndef DOXYGEN_SKIP */
 

--- a/port/cpl_vsil.cpp
+++ b/port/cpl_vsil.cpp
@@ -156,6 +156,27 @@ char **VSISiblingFiles(const char *pszFilename)
 }
 
 /************************************************************************/
+/*                      VSIGetDirectorySeparator()                      */
+/************************************************************************/
+
+/** Return the directory separator for the specified path.
+ *
+ * Default is forward slash. The only exception currently is the Windows
+ * file system which returns anti-slash, unless the specified path is of the
+ * form "{drive_letter}:/{rest_of_the_path}".
+ *
+ * @since 3.9
+ */
+const char *VSIGetDirectorySeparator(const char *pszPath)
+{
+    if (STARTS_WITH(pszPath, "http://") || STARTS_WITH(pszPath, "https://"))
+        return "/";
+
+    VSIFilesystemHandler *poFSHandler = VSIFileManager::GetHandler(pszPath);
+    return poFSHandler->GetDirectorySeparator(pszPath);
+}
+
+/************************************************************************/
 /*                             VSIReadRecursive()                       */
 /************************************************************************/
 

--- a/port/cpl_vsil.cpp
+++ b/port/cpl_vsil.cpp
@@ -192,6 +192,11 @@ const char *VSIGetDirectorySeparator(const char *pszPath)
  * Note that no error is issued via CPLError() if the directory path is
  * invalid, though NULL is returned.
  *
+ * Note: since GDAL 3.9, for recursive mode, the directory separator will no
+ * longer be always forward slash, but will be the one returned by
+ * VSIGetDirectorySeparator(pszPathIn), so potentially backslash on Windows
+ * file systems.
+ *
  * @param pszPathIn the relative, or absolute path of a directory to read.
  * UTF-8 encoded.
  *
@@ -204,11 +209,7 @@ const char *VSIGetDirectorySeparator(const char *pszPath)
 
 char **VSIReadDirRecursive(const char *pszPathIn)
 {
-#if defined(_WIN32)
-    const char SEP = pszPathIn[0] == '\\' ? '\\' : '/';
-#else
-    constexpr char SEP = '/';
-#endif
+    const char SEP = VSIGetDirectorySeparator(pszPathIn)[0];
 
     const char *const apszOptions[] = {"NAME_AND_TYPE_ONLY=YES", nullptr};
     VSIDIR *psDir = VSIOpenDir(pszPathIn, -1, apszOptions);
@@ -315,6 +316,11 @@ VSIDIR *VSIOpenDir(const char *pszPath, int nRecurseDepth,
  *
  * The returned entry remains valid until the next call to VSINextDirEntry()
  * or VSICloseDir() with the same handle.
+ *
+ * Note: since GDAL 3.9, for recursive mode, the directory separator will no
+ * longer be always forward slash, but will be the one returned by
+ * VSIGetDirectorySeparator(pszPathIn), so potentially backslash on Windows
+ * file systems.
  *
  * @param dir Directory handled returned by VSIOpenDir(). Must not be NULL.
  *
@@ -1396,11 +1402,7 @@ bool VSIFilesystemHandler::Sync(const char *pszSource, const char *pszTarget,
                                 GDALProgressFunc pProgressFunc,
                                 void *pProgressData, char ***ppapszOutputs)
 {
-#if defined(_WIN32)
-    const char SOURCE_SEP = pszSource[0] == '\\' ? '\\' : '/';
-#else
-    constexpr char SOURCE_SEP = '/';
-#endif
+    const char SOURCE_SEP = VSIGetDirectorySeparator(pszSource)[0];
 
     if (ppapszOutputs)
     {
@@ -1685,11 +1687,7 @@ VSIDIR *VSIFilesystemHandler::OpenDir(const char *pszPath, int nRecurseDepth,
 
 const VSIDIREntry *VSIDIRGeneric::NextDirEntry()
 {
-#if defined(_WIN32)
-    const char SEP = osRootPath[0] == '\\' ? '\\' : '/';
-#else
-    constexpr char SEP = '/';
-#endif
+    const char SEP = VSIGetDirectorySeparator(osRootPath.c_str())[0];
 
 begin:
     if (VSI_ISDIR(entry.nMode) && nRecurseDepth != 0)
@@ -1837,11 +1835,7 @@ int VSIFilesystemHandler::RmdirRecursive(const char *pszDirname)
         osDirnameWithoutEndSlash.resize(osDirnameWithoutEndSlash.size() - 1);
     }
 
-#if defined(_WIN32)
-    const char SEP = pszDirname[0] == '\\' ? '\\' : '/';
-#else
-    constexpr char SEP = '/';
-#endif
+    const char SEP = VSIGetDirectorySeparator(pszDirname)[0];
 
     CPLStringList aosOptions;
     auto poDir =

--- a/port/cpl_vsil_win32.cpp
+++ b/port/cpl_vsil_win32.cpp
@@ -83,6 +83,14 @@ class VSIWin32FilesystemHandler final : public VSIFilesystemHandler
     virtual bool IsLocal(const char *pszPath) override;
     std::string
     GetCanonicalFilename(const std::string &osFilename) const override;
+
+    const char *GetDirectorySeparator(const char *pszPath) override
+    {
+        // Return forward slash for paths of the form
+        // "{drive_letter}:/{rest_of_the_path}", and backslash otherwise.
+        return (pszPath[0] && pszPath[1] == ':' && pszPath[2] == '/') ? "/"
+                                                                      : "\\";
+    }
 };
 
 /************************************************************************/


### PR DESCRIPTION
*  Add VSIGetDirectorySeparator() to return the directory separator for the specified path
    
    Default is forward slash. The only exception currently is the Windows
    file system which returns anti-slash, unless the specified path is of the
    form "{drive_letter}:/{rest_of_the_path}".

*  CPLFormFilename(), CPLProjectRelativeFilename(), VSIReadDirRecursive(), NextDirEntry(): useVSIGetDirectorySeparator()
    
    For VSIReadDirRecursive() and NextDirEntry(), this will be a slight
    change in behavior on Windows where antislash separator will now be
    returned unless an absolute path of the form X:/foo is provided

*  /vsis3 Sync(): use VSIGetDirectorySeparator(),
    
    and normalize target filename to the dir separator of the target
    filesystem.
    
    This fixes synchronization from Windows extended filenames with
    subdirectories to /vsis3/ to avoid antislash to be used on /vsis3

