### PR TITLE
/vsicurl/: fix potential multithreaded crash when downloading the same region in parallel and that the download fails

### DIFF
--- a/port/cpl_vsil_curl_class.h
+++ b/port/cpl_vsil_curl_class.h
@@ -48,6 +48,7 @@
 #include <memory>
 #include <mutex>
 #include <thread>
+#include <utility>
 
 // To avoid aliasing to CopyFile to CopyFileA on Windows
 #ifdef CopyFile
@@ -308,9 +309,9 @@ class VSICurlFilesystemHandlerBase : public VSIFilesystemHandler
     void AddRegion(const char *pszURL, vsi_l_offset nFileOffsetStart,
                    size_t nSize, const char *pData);
 
-    std::string NotifyStartDownloadRegion(const std::string &osURL,
-                                          vsi_l_offset startOffset,
-                                          int nBlocks);
+    std::pair<bool, std::string>
+    NotifyStartDownloadRegion(const std::string &osURL,
+                              vsi_l_offset startOffset, int nBlocks);
     void NotifyStopDownloadRegion(const std::string &osURL,
                                   vsi_l_offset startOffset, int nBlocks,
                                   const std::string &osData);


### PR DESCRIPTION
If 2 threads tried to download the same region at the same time, one of them would wait for the first one to have finished. But if that download failed, the waiting thread would then wrongly try to unregister the region in m_oMapRegionInDownload (the first thread has already done that), resulting in either an assertion in debug mode on ```CPLAssert(oIter != m_oMapRegionInDownload.end())``` in NotifyStopDownloadRegion() or a crash later when trying to lock region.oMutex which would be random data.
