### PR TITLE
[Backport release/3.8] PDF: correctly initialize PAM when opening a subdataset (specific page for example)

### DIFF
--- a/autotest/gdrivers/pdf.py
+++ b/autotest/gdrivers/pdf.py
@@ -30,6 +30,7 @@
 ###############################################################################
 
 import os
+import shutil
 import sys
 
 import gdaltest
@@ -1951,6 +1952,24 @@ def test_pdf_metadata(poppler_or_pdfium):
     ds = None
 
     gdal.GetDriverByName("PDF").Delete("tmp/pdf_metadata.pdf")
+
+
+###############################################################################
+# Test PAM support with subdatasets
+
+
+def test_pdf_pam_subdatasets(poppler_or_pdfium, tmp_path):
+
+    tmpfilename = str(tmp_path / "test_pdf_pam_subdatasets.pdf")
+    shutil.copy("data/pdf/byte_and_rgbsmall_2pages.pdf", tmpfilename)
+
+    ds = gdal.Open("PDF:1:" + tmpfilename)
+    ds.GetRasterBand(1).ComputeStatistics(False)
+    ds = None
+    assert gdal.VSIStatL(tmpfilename + ".aux.xml")
+    ds = gdal.Open("PDF:1:" + tmpfilename)
+    assert ds.GetRasterBand(1).GetMetadataItem("STATISTICS_MINIMUM") is not None
+    ds = None
 
 
 ###############################################################################

--- a/frmts/pdf/pdfdataset.cpp
+++ b/frmts/pdf/pdfdataset.cpp
@@ -4396,11 +4396,12 @@ PDFDataset *PDFDataset::Open(GDALOpenInfo *poOpenInfo)
     const char *pszUserPwd =
         GetOption(poOpenInfo->papszOpenOptions, "USER_PWD", nullptr);
 
-    int bOpenSubdataset = STARTS_WITH(poOpenInfo->pszFilename, "PDF:");
-    int bOpenSubdatasetImage =
+    const bool bOpenSubdataset = STARTS_WITH(poOpenInfo->pszFilename, "PDF:");
+    const bool bOpenSubdatasetImage =
         STARTS_WITH(poOpenInfo->pszFilename, "PDF_IMAGE:");
     int iPage = -1;
     int nImageNum = -1;
+    std::string osSubdatasetName;
     const char *pszFilename = poOpenInfo->pszFilename;
 
     if (bOpenSubdataset)
@@ -4412,6 +4413,7 @@ PDFDataset *PDFDataset::Open(GDALOpenInfo *poOpenInfo)
         if (pszFilename == nullptr)
             return nullptr;
         pszFilename++;
+        osSubdatasetName = CPLSPrintf("Page %d", iPage);
     }
     else if (bOpenSubdatasetImage)
     {
@@ -4428,6 +4430,7 @@ PDFDataset *PDFDataset::Open(GDALOpenInfo *poOpenInfo)
         if (pszFilename == nullptr)
             return nullptr;
         pszFilename++;
+        osSubdatasetName = CPLSPrintf("Image %d", nImageNum);
     }
     else
         iPage = 1;
@@ -5607,7 +5610,16 @@ PDFDataset *PDFDataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Initialize any PAM information.                                 */
     /* -------------------------------------------------------------------- */
-    poDS->SetDescription(poOpenInfo->pszFilename);
+    if (bOpenSubdataset || bOpenSubdatasetImage)
+    {
+        poDS->SetPhysicalFilename(pszFilename);
+        poDS->SetSubdatasetName(osSubdatasetName.c_str());
+    }
+    else
+    {
+        poDS->SetDescription(poOpenInfo->pszFilename);
+    }
+
     poDS->TryLoadXML();
 
     /* -------------------------------------------------------------------- */


### PR DESCRIPTION
Backport #9118
 **Authored by:** @rouault