### PR TITLE
[Backport release/3.8] LIBKML: fix crash on a gx:Track without when subelements (fixes qgis/qgis#55963)

### DIFF
--- a/autotest/ogr/data/kml/gx_track_without_when.kml
+++ b/autotest/ogr/data/kml/gx_track_without_when.kml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2"
+ xmlns:gx="http://www.google.com/kml/ext/2.2">
+<Folder>
+  <Placemark>
+    <gx:Track>
+      <gx:coord>-122.207881 37.371915 156.000000</gx:coord>
+      <gx:coord>-122.205712 37.373288 152.000000</gx:coord>
+      <gx:coord>-122.204678 37.373939 147.000000</gx:coord>
+      <gx:coord>-122.203572 37.374630 142.199997</gx:coord>
+      <gx:coord>-122.203451 37.374706 141.800003</gx:coord>
+      <gx:coord>-122.203329 37.374780 141.199997</gx:coord>
+      <gx:coord>-122.203207 37.374857 140.199997</gx:coord>
+    </gx:Track>
+  </Placemark>
+</Folder>
+</kml>

--- a/autotest/ogr/ogr_libkml.py
+++ b/autotest/ogr/ogr_libkml.py
@@ -2193,3 +2193,21 @@ def test_ogr_libkml_write_reproject(tmp_vsimem):
     ds = None
 
     gdal.Unlink(outfilename)
+
+
+###############################################################################
+# Test reading a gx:Track without <when> elements
+
+
+def test_ogr_libkml_gx_track_without_when():
+    if not ogrtest.have_read_libkml:
+        pytest.skip()
+
+    ds = ogr.Open("data/kml/gx_track_without_when.kml")
+    lyr = ds.GetLayer(0)
+    feat = lyr.GetNextFeature()
+    ogrtest.check_feature_geometry(
+        feat,
+        "LINESTRING Z (-122.207881 37.371915 156,-122.205712 37.373288 152,-122.204678 37.373939 147,-122.203572 37.37463 142.199997,-122.203451 37.374706 141.800003,-122.203329 37.37478 141.199997,-122.203207 37.374857 140.199997)",
+    )
+    ds = None

--- a/ogr/ogrsf_frmts/libkml/ogrlibkmlfield.cpp
+++ b/ogr/ogrsf_frmts/libkml/ogrlibkmlfield.cpp
@@ -1273,7 +1273,7 @@ void kml2field(OGRFeature *poOgrFeat, FeaturePtr poKmlFeature)
             GxTrackPtr poKmlGxTrack = AsGxTrack(poKmlGeometry);
             if (poKmlGxTrack)
             {
-                size_t nCoords = poKmlGxTrack->get_gx_coord_array_size();
+                const size_t nCoords = poKmlGxTrack->get_when_array_size();
                 if (nCoords > 0)
                 {
                     kmldatetime2ogr(poOgrFeat, oFC.beginfield,
@@ -1293,28 +1293,35 @@ void kml2field(OGRFeature *poOgrFeat, FeaturePtr poKmlFeature)
             GxMultiTrackPtr poKmlGxMultiTrack = AsGxMultiTrack(poKmlGeometry);
             if (poKmlGxMultiTrack)
             {
-                size_t nGeom = poKmlGxMultiTrack->get_gx_track_array_size();
+                const size_t nGeom =
+                    poKmlGxMultiTrack->get_gx_track_array_size();
                 if (nGeom >= 1)
                 {
-                    GxTrackPtr poKmlGxTrack =
-                        poKmlGxMultiTrack->get_gx_track_array_at(0);
-                    size_t nCoords = poKmlGxTrack->get_gx_coord_array_size();
-                    if (nCoords > 0)
                     {
-                        kmldatetime2ogr(
-                            poOgrFeat, oFC.beginfield,
-                            poKmlGxTrack->get_when_array_at(0).c_str());
+                        GxTrackPtr poKmlGxTrack =
+                            poKmlGxMultiTrack->get_gx_track_array_at(0);
+                        const size_t nCoords =
+                            poKmlGxTrack->get_when_array_size();
+                        if (nCoords > 0)
+                        {
+                            kmldatetime2ogr(
+                                poOgrFeat, oFC.beginfield,
+                                poKmlGxTrack->get_when_array_at(0).c_str());
+                        }
                     }
 
-                    poKmlGxTrack =
-                        poKmlGxMultiTrack->get_gx_track_array_at(nGeom - 1);
-                    nCoords = poKmlGxTrack->get_gx_coord_array_size();
-                    if (nCoords > 0)
                     {
-                        kmldatetime2ogr(
-                            poOgrFeat, oFC.endfield,
-                            poKmlGxTrack->get_when_array_at(nCoords - 1)
-                                .c_str());
+                        GxTrackPtr poKmlGxTrack =
+                            poKmlGxMultiTrack->get_gx_track_array_at(nGeom - 1);
+                        const size_t nCoords =
+                            poKmlGxTrack->get_when_array_size();
+                        if (nCoords > 0)
+                        {
+                            kmldatetime2ogr(
+                                poOgrFeat, oFC.endfield,
+                                poKmlGxTrack->get_when_array_at(nCoords - 1)
+                                    .c_str());
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Backport #9131
 **Authored by:** @rouault