### PR TITLE
PDF vector stream parser: correcly parse structures like '[3 3.5] 0 d '

### DIFF
--- a/frmts/pdf/pdfreadvectors.cpp
+++ b/frmts/pdf/pdfreadvectors.cpp
@@ -156,7 +156,7 @@ static const PDFOperator asPDFOperators[] = {
     {"cm", 6},
     {"CS", 1},
     {"cs", 1},
-    {"d", 1}, /* we have ignored the first arg */
+    {"d", 1}, /* we have ignored the first arg which is an array */
     // d0
     // d1
     {"Do", 1},
@@ -784,6 +784,7 @@ OGRGeometry *PDFDataset::ParseContent(
         else if (!bInString && nArrayLevel && ch == ']')
         {
             nArrayLevel--;
+            nTokenSize = 0;  // completely ignore content in arrays
         }
 
         else if (!bInString && nTokenSize == 0 && ch == '(')


### PR DESCRIPTION
The content within the array should be completely ignored Fixes https://lists.osgeo.org/pipermail/gdal-dev/2024-February/058419.html
