### PR TITLE
[Backport release/3.8] PDF vector stream parser: correcly parse structures like '[3 3.5] 0 d '

### DIFF
--- a/frmts/pdf/pdfreadvectors.cpp
+++ b/frmts/pdf/pdfreadvectors.cpp
@@ -156,7 +156,7 @@ static const PDFOperator asPDFOperators[] = {
     {"cm", 6},
     {"CS", 1},
     {"cs", 1},
-    {"d", 1}, /* we have ignored the first arg */
+    {"d", 1}, /* we have ignored the first arg which is an array */
     // d0
     // d1
     {"Do", 1},
@@ -784,6 +784,7 @@ OGRGeometry *PDFDataset::ParseContent(
         else if (!bInString && nArrayLevel && ch == ']')
         {
             nArrayLevel--;
+            nTokenSize = 0;  // completely ignore content in arrays
         }
 
         else if (!bInString && nTokenSize == 0 && ch == '(')


### PR DESCRIPTION
Backport #9213
 **Authored by:** @rouault