### PR TITLE
autotest: run Python tests directly from source tree on Windows

### DIFF
--- a/autotest/CMakeLists.txt
+++ b/autotest/CMakeLists.txt
@@ -49,6 +49,9 @@ if (Python_Interpreter_FOUND)
   configure_file(${GDAL_CMAKE_TEMPLATE_PATH}/pytest.ini.in ${CMAKE_CURRENT_BINARY_DIR}/pytest.ini @ONLY)
   unset(PYTEST_INI_HEADER_MESSAGE)
 
+  # Symlink test files into the build directory so that we can run tests directly from that location.
+  # This doesn't work on Windows,
+
 function (copy_file_or_dir source dest)
     if (IS_DIRECTORY ${source})
         message(STATUS "Copying contents of ${source} to ${destination}")
@@ -72,44 +75,39 @@ endfunction ()
   symlink_or_copy(${CMAKE_CURRENT_SOURCE_DIR}/conftest.py ${CMAKE_CURRENT_BINARY_DIR}/conftest.py)
   symlink_or_copy(${CMAKE_CURRENT_SOURCE_DIR}/run_slow_tests.sh ${CMAKE_CURRENT_BINARY_DIR}/run_slow_tests.sh)
 
-  if (NOT "${CMAKE_BINARY_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
-      foreach (subdir IN ITEMS pymod proj_grids cpp/data)
-          if (SKIP_COPYING_AUTOTEST_SUBDIRS)
-            message(STATUS "Skipping copying ${CMAKE_CURRENT_SOURCE_DIR}/${subdir}")
-          else ()
+  SET(pytest_dirs alg benchmark gcore gdrivers gnm ogr osr pyscripts slow_tests utilities)
+
+  # Link test data/scripts into the build directory for convenience (non-Windows)
+  if (WIN32)
+      SET(python_test_path ${CMAKE_CURRENT_LIST_DIR})
+  else()
+      SET(python_test_path ${CMAKE_CURRENT_BINARY_DIR})
+      if (NOT "${CMAKE_BINARY_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
+          foreach (subdir IN ITEMS
+                  pymod
+                  proj_grids
+                  cpp/data
+                  ${pytest_dirs})
             symlink_or_copy(${CMAKE_CURRENT_SOURCE_DIR}/${subdir} ${CMAKE_CURRENT_BINARY_DIR}/${subdir})
-          endif ()
-      endforeach ()
+          endforeach ()
+          unset(subdir)
+      endif()
   endif()
 
-  foreach (
-    tgt IN
-    ITEMS ogr
-          gcore
-          gdrivers
-          alg
-          osr
-          gnm
-          pyscripts
-          utilities
-          benchmark
-          slow_tests)
-    if (NOT "${CMAKE_BINARY_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
-        if (SKIP_COPYING_AUTOTEST_SUBDIRS)
-          message(STATUS "Skipping copying ${CMAKE_CURRENT_SOURCE_DIR}/${tgt}")
-        else ()
-          symlink_or_copy(${CMAKE_CURRENT_SOURCE_DIR}/${tgt} ${CMAKE_CURRENT_BINARY_DIR}/${tgt})
-        endif ()
-    endif()
+  foreach (tgt IN ITEMS ${pytest_dirs})
     add_custom_target(
       autotest_${tgt}
-      COMMAND ${CMAKE_COMMAND} -E env ${PYTHON_RUN_ENV} ${Python_EXECUTABLE} -m pytest -c
-              ${CMAKE_CURRENT_BINARY_DIR}/pytest.ini ${tgt}
+      COMMAND ${CMAKE_COMMAND} -E env ${PYTHON_RUN_ENV} ${Python_EXECUTABLE} -m pytest
+              -c ${CMAKE_CURRENT_BINARY_DIR}/pytest.ini
+              ${python_test_path}/${tgt}
       DEPENDS ${GDAL_LIB_TARGET_NAME} gdalapps python_binding)
-    add_test(NAME autotest_${tgt} COMMAND ${Python_EXECUTABLE} -m pytest -c ${CMAKE_CURRENT_BINARY_DIR}/pytest.ini
-                                          ${tgt})
+    add_test(NAME autotest_${tgt}
+             COMMAND ${Python_EXECUTABLE} -m pytest
+                     -c ${CMAKE_CURRENT_BINARY_DIR}/pytest.ini
+                     ${python_test_path}/${tgt})
     set_property(TEST autotest_${tgt} PROPERTY ENVIRONMENT "${PYTHON_RUN_ENV}")
   endforeach ()
+
   add_custom_target(
     autotest
     COMMAND ${CMAKE_COMMAND} -E env ${PYTHON_RUN_ENV} ${Python_EXECUTABLE} -m pytest -c

--- a/doc/source/development/testing.rst
+++ b/doc/source/development/testing.rst
@@ -48,23 +48,33 @@ and the Python bindings:
     python3 -c 'from osgeo import gdal; print(gdal.__version__)'
     # 3.7.0dev-5327c149f5-dirty
 
-List tests containing "tiff" in the name:
-
-.. code-block:: bash
-
-    pytest --collect-only autotest -k tiff
-
-Running an individual test file
+Tests can then be run by calling ``pytest``, for example on an individual file.
+On Linux and MacOS builds, the tests are symlinked into the build directory, so this
+can be done by running the following from the build directory:
 
 .. code-block:: bash
 
     pytest autotest/gcore/vrt_read.py
+
+On Windows, the test files remain in the source tree, but the pytest configuration file ``pytest.ini`` is only available in the build directory. To accommodate this, the above command would be  modified as follows:
+
+.. code-block:: bash
+
+    pytest -c pytest.ini ../autotest/gcore/vrt_read.py
 
 A subset of tests within an individual test file can be run by providing a regular expression to the ``-k`` argument to ``pytest``.
 
 .. code-block:: bash
 
     pytest autotest/gcore/vrt_read.py -k test_vrt_read_non_existing_source
+
+``pytest`` can also report information on the tests without running them. For
+example, to list tests containing "tiff" in the name:
+
+.. code-block:: bash
+
+    pytest --collect-only autotest -k tiff
+
 
 .. warning:: Not all Python tests can be run independently; some tests depend on state set by a previous tests in the same file.
 

--- a/doc/source/development/testing.rst
+++ b/doc/source/development/testing.rst
@@ -56,7 +56,7 @@ can be done by running the following from the build directory:
 
     pytest autotest/gcore/vrt_read.py
 
-On Windows, the test files remain in the source tree, but the pytest configuration file ``pytest.ini`` is only available in the build directory. To accommodate this, the above command would be  modified as follows:
+On Windows, the test files remain in the source tree, but the pytest configuration file ``pytest.ini`` is only available in the build directory. To accommodate this, the above command would be modified as follows:
 
 .. code-block:: bash
 


### PR DESCRIPTION
## What does this PR do?

Modifies CMake configuration so that Python tests are run directly from the source tree, rather than from a symlink or copy in the build directory. This is an experiment in removing the following "gotcha":

> (be careful on Windows, the 
content of $build_dir/autotest is copied from $source_dir/autotest each 
time "cmake" is run, so if you edit your test .py file directly in the 
build directory, be super careful of not accidentally losing your work, 
and make sure to copy its content to the source directory first. That's 
admittedly an annoying point of the current test setup on Windows, 
compared to Unix where we use symbolic links)

described in https://lists.osgeo.org/pipermail/gdal-dev/2024-February/058425.html

A downside of this change is that, because `pytest.ini` lives only in the build directory, we must always explicitly provide the config file via `pytest -c pytest.ini`. Is it an overall reduction in complexity? I don't know, am interested in feedback.


## What are related issues/pull requests?

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed