### PR TITLE
/vsicurl/: Read(): emit error message when receiving HTTP 416 Range Not Satisfiable error

### DIFF
--- a/port/cpl_vsil_curl.cpp
+++ b/port/cpl_vsil_curl.cpp
@@ -1974,6 +1974,22 @@ retry:
                 CPLError(CE_Failure, CPLE_AppDefined, "%d: %s",
                          static_cast<int>(response_code), szCurlErrBuf);
         }
+        else if (response_code == 416) /* Range Not Satisfiable */
+        {
+            if (sWriteFuncData.pBuffer)
+            {
+                CPLError(
+                    CE_Failure, CPLE_AppDefined,
+                    "%d: Range downloading not supported by this server: %s",
+                    static_cast<int>(response_code), sWriteFuncData.pBuffer);
+            }
+            else
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "%d: Range downloading not supported by this server",
+                         static_cast<int>(response_code));
+            }
+        }
         if (!oFileProp.bHasComputedFileSize && startOffset == 0)
         {
             oFileProp.bHasComputedFileSize = true;


### PR DESCRIPTION
will now get:
```shell
$ gdalinfo /vsicurl/https://erddap.emodnet.eu/erddap/files/biology_6640_benthos_NorthSea_e4af_0f0e_6a73/04_2021_6640_diva_benthos_erddap.nc
ERROR 1: 416: Range downloading not supported by this server: Error {
    code=416;
    message="Requested Range Not Satisfiable: REQUESTED_RANGE_NOT_SATISFIABLE: Don't try to connect to .nc or .hdf files on ERDDAP's /files/ system as if they were local files. It is horribly inefficient and often causes other problems. Instead: a) Use (OPeN)DAP client software to connect to ERDDAP's DAP services for this dataset (which have /griddap/ or /tabledap/ in the URL). That's what DAP is for. b) Or, use the dataset's Data Access Form to request a subset of data. c) Or, if you need the entire file or repeated access over a long period of time, use curl, wget, or your browser to download the entire file, then access the data from your local copy of the file.";
}

gdalinfo failed - unable to open '/vsicurl/https://erddap.emodnet.eu/erddap/files/biology_6640_benthos_NorthSea_e4af_0f0e_6a73/04_2021_6640_diva_benthos_erddap.nc'.
```