### PR TITLE
[Backport release/3.8] JP2OpenJPEG: CreateCopy(): limit number of resolutions taking into account minimum block width/height 

### DIFF
--- a/autotest/gdrivers/jp2openjpeg.py
+++ b/autotest/gdrivers/jp2openjpeg.py
@@ -3850,3 +3850,17 @@ def test_jp2openjpeg_vrt_protocol():
         webserver.server_stop(webserver_process, webserver_port)
 
         gdal.VSICurlClearCache()
+
+
+###############################################################################
+# Test fix for https://github.com/OSGeo/gdal/issues/9236
+
+
+def test_jp2openjpeg_limit_resolution_count_from_image_size(tmp_vsimem):
+
+    filename = str(tmp_vsimem / "out.jp2")
+    assert gdal.Translate(filename, "data/byte.tif", width=1024, height=7)
+
+    # Check number of resolutions
+    ret = gdal.GetJPEG2000StructureAsString(filename, ["ALL=YES"])
+    assert '<Field name="SPcod_NumDecompositions" type="uint8">2</Field>' in ret

--- a/frmts/opjlike/jp2opjlikedataset.cpp
+++ b/frmts/opjlike/jp2opjlikedataset.cpp
@@ -2174,9 +2174,11 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
     }
 
     const int nMaxTileDim = std::max(nBlockXSize, nBlockYSize);
+    const int nMinTileDim = std::min(nBlockXSize, nBlockYSize);
     int nNumResolutions = 1;
     /* Pickup a reasonable value compatible with PROFILE_1 requirements */
-    while ((nMaxTileDim >> (nNumResolutions - 1)) > 128)
+    while ((nMaxTileDim >> (nNumResolutions - 1)) > 128 &&
+           (nMinTileDim >> nNumResolutions) > 0)
         nNumResolutions++;
     int nMinProfile1Resolutions = nNumResolutions;
     const char *pszResolutions =
@@ -2185,6 +2187,7 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
     {
         nNumResolutions = atoi(pszResolutions);
         if (nNumResolutions <= 0 || nNumResolutions >= 32 ||
+            (nMinTileDim >> nNumResolutions) == 0 ||
             (nMaxTileDim >> nNumResolutions) == 0)
         {
             CPLError(CE_Warning, CPLE_NotSupported,


### PR DESCRIPTION
Backport #9245
 **Authored by:** @rouault