### PR TITLE
JPEG2000 drivers: do not export GMLJP2 if the SRS isn't compatible

### DIFF
--- a/autotest/gdrivers/ecw.py
+++ b/autotest/gdrivers/ecw.py
@@ -2211,6 +2211,66 @@ def test_ecw_read_uint32_jpeg2000():
 
 
 ###############################################################################
+# Test unsupported XML SRS
+
+
+def test_jp2ecw_unsupported_srs_for_gmljp2(tmp_vsimem):
+
+    if gdaltest.jp2ecw_drv is None or not has_write_support():
+        pytest.skip("ECW write support not available")
+
+    filename = str(tmp_vsimem / "out.jp2")
+    # There is no EPSG code and Albers Equal Area is not supported by OGRSpatialReference::exportToXML()
+    wkt = """PROJCRS["Africa_Albers_Equal_Area_Conic",
+    BASEGEOGCRS["WGS 84",
+        DATUM["World Geodetic System 1984",
+            ELLIPSOID["WGS 84",6378137,298.257223563,
+                LENGTHUNIT["metre",1]]],
+        PRIMEM["Greenwich",0,
+            ANGLEUNIT["degree",0.0174532925199433]],
+        ID["EPSG",4326]],
+    CONVERSION["Albers Equal Area",
+        METHOD["Albers Equal Area",
+            ID["EPSG",9822]],
+        PARAMETER["Latitude of false origin",0,
+            ANGLEUNIT["degree",0.0174532925199433],
+            ID["EPSG",8821]],
+        PARAMETER["Longitude of false origin",25,
+            ANGLEUNIT["degree",0.0174532925199433],
+            ID["EPSG",8822]],
+        PARAMETER["Latitude of 1st standard parallel",20,
+            ANGLEUNIT["degree",0.0174532925199433],
+            ID["EPSG",8823]],
+        PARAMETER["Latitude of 2nd standard parallel",-23,
+            ANGLEUNIT["degree",0.0174532925199433],
+            ID["EPSG",8824]],
+        PARAMETER["Easting at false origin",0,
+            LENGTHUNIT["metre",1],
+            ID["EPSG",8826]],
+        PARAMETER["Northing at false origin",0,
+            LENGTHUNIT["metre",1],
+            ID["EPSG",8827]]],
+    CS[Cartesian,2],
+        AXIS["easting",east,
+            ORDER[1],
+            LENGTHUNIT["metre",1,
+                ID["EPSG",9001]]],
+        AXIS["northing",north,
+            ORDER[2],
+            LENGTHUNIT["metre",1,
+                ID["EPSG",9001]]]]"""
+    gdal.ErrorReset()
+    assert gdal.Translate(filename, "data/byte.tif", outputSRS=wkt, format="JP2ECW")
+    assert gdal.GetLastErrorMsg() == ""
+    ds = gdal.Open(filename)
+    ref_srs = osr.SpatialReference()
+    ref_srs.ImportFromWkt(wkt)
+    assert ds.GetSpatialRef().IsSame(ref_srs)
+    # Check that we do *not* have a GMLJP2 box
+    assert "xml:gml.root-instance" not in ds.GetMetadataDomainList()
+
+
+###############################################################################
 
 
 def test_ecw_online_1():

--- a/autotest/gdrivers/jp2openjpeg.py
+++ b/autotest/gdrivers/jp2openjpeg.py
@@ -3864,3 +3864,62 @@ def test_jp2openjpeg_limit_resolution_count_from_image_size(tmp_vsimem):
     # Check number of resolutions
     ret = gdal.GetJPEG2000StructureAsString(filename, ["ALL=YES"])
     assert '<Field name="SPcod_NumDecompositions" type="uint8">2</Field>' in ret
+
+
+###############################################################################
+# Test unsupported XML SRS
+
+
+def test_jp2openjpeg_unsupported_srs_for_gmljp2(tmp_vsimem):
+
+    filename = str(tmp_vsimem / "out.jp2")
+    # There is no EPSG code and Albers Equal Area is not supported by OGRSpatialReference::exportToXML()
+    wkt = """PROJCRS["Africa_Albers_Equal_Area_Conic",
+    BASEGEOGCRS["WGS 84",
+        DATUM["World Geodetic System 1984",
+            ELLIPSOID["WGS 84",6378137,298.257223563,
+                LENGTHUNIT["metre",1]]],
+        PRIMEM["Greenwich",0,
+            ANGLEUNIT["degree",0.0174532925199433]],
+        ID["EPSG",4326]],
+    CONVERSION["Albers Equal Area",
+        METHOD["Albers Equal Area",
+            ID["EPSG",9822]],
+        PARAMETER["Latitude of false origin",0,
+            ANGLEUNIT["degree",0.0174532925199433],
+            ID["EPSG",8821]],
+        PARAMETER["Longitude of false origin",25,
+            ANGLEUNIT["degree",0.0174532925199433],
+            ID["EPSG",8822]],
+        PARAMETER["Latitude of 1st standard parallel",20,
+            ANGLEUNIT["degree",0.0174532925199433],
+            ID["EPSG",8823]],
+        PARAMETER["Latitude of 2nd standard parallel",-23,
+            ANGLEUNIT["degree",0.0174532925199433],
+            ID["EPSG",8824]],
+        PARAMETER["Easting at false origin",0,
+            LENGTHUNIT["metre",1],
+            ID["EPSG",8826]],
+        PARAMETER["Northing at false origin",0,
+            LENGTHUNIT["metre",1],
+            ID["EPSG",8827]]],
+    CS[Cartesian,2],
+        AXIS["easting",east,
+            ORDER[1],
+            LENGTHUNIT["metre",1,
+                ID["EPSG",9001]]],
+        AXIS["northing",north,
+            ORDER[2],
+            LENGTHUNIT["metre",1,
+                ID["EPSG",9001]]]]"""
+    gdal.ErrorReset()
+    assert gdal.Translate(
+        filename, "data/byte.tif", outputSRS=wkt, format="JP2OpenJPEG"
+    )
+    assert gdal.GetLastErrorMsg() == ""
+    ds = gdal.Open(filename)
+    ref_srs = osr.SpatialReference()
+    ref_srs.ImportFromWkt(wkt)
+    assert ds.GetSpatialRef().IsSame(ref_srs)
+    # Check that we do *not* have a GMLJP2 box
+    assert "xml:gml.root-instance" not in ds.GetMetadataDomainList()

--- a/autotest/osr/osr_xml.py
+++ b/autotest/osr/osr_xml.py
@@ -31,6 +31,7 @@
 import re
 
 import gdaltest
+import pytest
 
 from osgeo import osr
 
@@ -200,3 +201,58 @@ def test_osr_xml_2():
     expected = re.sub(r' gml:id="[^"]*"', "", expected, 0)
 
     assert got == expected
+
+
+###############################################################################
+# Test the osr.SpatialReference.ExportToXML() function.
+#
+
+
+def test_osr_xml_export_failure():
+
+    srs = osr.SpatialReference()
+    srs.ImportFromWkt(
+        """PROJCRS["Africa_Albers_Equal_Area_Conic",
+    BASEGEOGCRS["WGS 84",
+        DATUM["World Geodetic System 1984",
+            ELLIPSOID["WGS 84",6378137,298.257223563,
+                LENGTHUNIT["metre",1]]],
+        PRIMEM["Greenwich",0,
+            ANGLEUNIT["degree",0.0174532925199433]],
+        ID["EPSG",4326]],
+    CONVERSION["Albers Equal Area",
+        METHOD["Albers Equal Area",
+            ID["EPSG",9822]],
+        PARAMETER["Latitude of false origin",0,
+            ANGLEUNIT["degree",0.0174532925199433],
+            ID["EPSG",8821]],
+        PARAMETER["Longitude of false origin",25,
+            ANGLEUNIT["degree",0.0174532925199433],
+            ID["EPSG",8822]],
+        PARAMETER["Latitude of 1st standard parallel",20,
+            ANGLEUNIT["degree",0.0174532925199433],
+            ID["EPSG",8823]],
+        PARAMETER["Latitude of 2nd standard parallel",-23,
+            ANGLEUNIT["degree",0.0174532925199433],
+            ID["EPSG",8824]],
+        PARAMETER["Easting at false origin",0,
+            LENGTHUNIT["metre",1],
+            ID["EPSG",8826]],
+        PARAMETER["Northing at false origin",0,
+            LENGTHUNIT["metre",1],
+            ID["EPSG",8827]]],
+    CS[Cartesian,2],
+        AXIS["easting",east,
+            ORDER[1],
+            LENGTHUNIT["metre",1,
+                ID["EPSG",9001]]],
+        AXIS["northing",north,
+            ORDER[2],
+            LENGTHUNIT["metre",1,
+                ID["EPSG",9001]]]]"""
+    )
+
+    with pytest.raises(
+        Exception, match="Unhandled projection method Albers_Conic_Equal_Area"
+    ):
+        srs.ExportToXML()

--- a/frmts/jp2lura/jp2luradataset.cpp
+++ b/frmts/jp2lura/jp2luradataset.cpp
@@ -713,10 +713,19 @@ GDALDataset *JP2LuraDataset::CreateCopy(const char *pszFilename,
             {
                 bGeoreferencingCompatOfGeoJP2 = true;
                 oJP2MD.SetGeoTransform(adfGeoTransform);
+
+                if (poSRS && !poSRS->IsEmpty())
+                {
+                    bGeoreferencingCompatOfGMLJP2 =
+                        GDALJP2Metadata::IsSRSCompatible(poSRS);
+                    if (!bGeoreferencingCompatOfGMLJP2)
+                    {
+                        CPLDebug(
+                            "JP2LURA",
+                            "Cannot write GMLJP2 box due to unsupported SRS");
+                    }
+                }
             }
-            bGeoreferencingCompatOfGMLJP2 =
-                poSRS != nullptr && !poSRS->IsEmpty() &&
-                poSrcDS->GetGeoTransform(adfGeoTransform) == CE_None;
         }
         if (poSrcDS->GetMetadata("RPC") != nullptr)
         {

--- a/frmts/opjlike/jp2opjlikedataset.cpp
+++ b/frmts/opjlike/jp2opjlikedataset.cpp
@@ -2461,7 +2461,7 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
         else
         {
             const OGRSpatialReference *poSRS = poSrcDS->GetSpatialRef();
-            if (poSRS != nullptr)
+            if (poSRS)
             {
                 bGeoreferencingCompatOfGeoJP2 = TRUE;
                 oJP2MD.SetSpatialRef(poSRS);
@@ -2471,10 +2471,18 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
             {
                 bGeoreferencingCompatOfGeoJP2 = TRUE;
                 oJP2MD.SetGeoTransform(adfGeoTransform);
+                if (poSRS && !poSRS->IsEmpty())
+                {
+                    bGeoreferencingCompatOfGMLJP2 =
+                        GDALJP2Metadata::IsSRSCompatible(poSRS);
+                    if (!bGeoreferencingCompatOfGMLJP2)
+                    {
+                        CPLDebug(
+                            CODEC::debugId(),
+                            "Cannot write GMLJP2 box due to unsupported SRS");
+                    }
+                }
             }
-            bGeoreferencingCompatOfGMLJP2 =
-                poSRS != nullptr && !poSRS->IsEmpty() &&
-                poSrcDS->GetGeoTransform(adfGeoTransform) == CE_None;
         }
         if (poSrcDS->GetMetadata("RPC") != nullptr)
         {

--- a/gcore/gdaljp2metadata.h
+++ b/gcore/gdaljp2metadata.h
@@ -235,6 +235,8 @@ class CPL_DLL GDALJP2Metadata
     static GDALJP2Box *CreateIPRBox(GDALDataset *poSrcDS);
     static int IsUUID_MSI(const GByte *abyUUID);
     static int IsUUID_XMP(const GByte *abyUUID);
+
+    static bool IsSRSCompatible(const OGRSpatialReference *poSRS);
 };
 
 CPLXMLNode *GDALGetJPEG2000Structure(const char *pszFilename, VSILFILE *fp,

--- a/ogr/ogr_srs_xml.cpp
+++ b/ogr/ogr_srs_xml.cpp
@@ -633,8 +633,10 @@ static CPLXMLNode *exportProjCSToXML(const OGRSpatialReference *poSRS)
     }
     else
     {
-        CPLError(CE_Warning, CPLE_NotSupported,
+        CPLError(CE_Failure, CPLE_NotSupported,
                  "Unhandled projection method %s", pszProjection);
+        CPLDestroyXMLNode(psCRS_XML);
+        return nullptr;
     }
 
     /* -------------------------------------------------------------------- */
@@ -692,6 +694,9 @@ OGRErr OGRSpatialReference::exportToXML(char **ppszRawXML,
     }
     else
         return OGRERR_UNSUPPORTED_SRS;
+
+    if (!psXMLTree)
+        return OGRERR_FAILURE;
 
     *ppszRawXML = CPLSerializeXMLTree(psXMLTree);
     CPLDestroyXMLNode(psXMLTree);


### PR DESCRIPTION
 (fixes #9223)