### PR TITLE
[openfilegdb] Correctly use "features" as related table type

### DIFF
--- a/autotest/ogr/ogr_fgdb.py
+++ b/autotest/ogr/ogr_fgdb.py
@@ -2875,7 +2875,7 @@ def test_ogr_filegdb_read_relationships(openfilegdb_drv, fgdb_drv):
     assert rel.GetRightMappingTableFields() is None
     assert rel.GetForwardPathLabel() == "my forward path label"
     assert rel.GetBackwardPathLabel() == "my backward path label"
-    assert rel.GetRelatedTableType() == "feature"
+    assert rel.GetRelatedTableType() == "features"
 
     rel = ds.GetRelationship("simple_one_to_many")
     assert rel is not None
@@ -2887,7 +2887,7 @@ def test_ogr_filegdb_read_relationships(openfilegdb_drv, fgdb_drv):
     assert rel.GetType() == gdal.GRT_ASSOCIATION
     assert rel.GetLeftTableFields() == ["pk"]
     assert rel.GetRightTableFields() == ["parent_pk"]
-    assert rel.GetRelatedTableType() == "feature"
+    assert rel.GetRelatedTableType() == "features"
 
     rel = ds.GetRelationship("simple_many_to_many")
     assert rel is not None
@@ -2901,7 +2901,7 @@ def test_ogr_filegdb_read_relationships(openfilegdb_drv, fgdb_drv):
     assert rel.GetLeftMappingTableFields() == ["origin_foreign_key"]
     assert rel.GetRightTableFields() == ["parent_pk"]
     assert rel.GetRightMappingTableFields() == ["destination_foreign_key"]
-    assert rel.GetRelatedTableType() == "feature"
+    assert rel.GetRelatedTableType() == "features"
 
     rel = ds.GetRelationship("composite_one_to_one")
     assert rel is not None
@@ -2913,7 +2913,7 @@ def test_ogr_filegdb_read_relationships(openfilegdb_drv, fgdb_drv):
     assert rel.GetType() == gdal.GRT_COMPOSITE
     assert rel.GetLeftTableFields() == ["pk"]
     assert rel.GetRightTableFields() == ["parent_pk"]
-    assert rel.GetRelatedTableType() == "feature"
+    assert rel.GetRelatedTableType() == "features"
 
     rel = ds.GetRelationship("composite_one_to_many")
     assert rel is not None
@@ -2925,7 +2925,7 @@ def test_ogr_filegdb_read_relationships(openfilegdb_drv, fgdb_drv):
     assert rel.GetType() == gdal.GRT_COMPOSITE
     assert rel.GetLeftTableFields() == ["pk"]
     assert rel.GetRightTableFields() == ["parent_pk"]
-    assert rel.GetRelatedTableType() == "feature"
+    assert rel.GetRelatedTableType() == "features"
 
     rel = ds.GetRelationship("composite_many_to_many")
     assert rel is not None
@@ -2939,7 +2939,7 @@ def test_ogr_filegdb_read_relationships(openfilegdb_drv, fgdb_drv):
     assert rel.GetLeftMappingTableFields() == ["origin_foreign_key"]
     assert rel.GetRightTableFields() == ["parent_pk"]
     assert rel.GetRightMappingTableFields() == ["dest_foreign_key"]
-    assert rel.GetRelatedTableType() == "feature"
+    assert rel.GetRelatedTableType() == "features"
 
     rel = ds.GetRelationship("points__ATTACHREL")
     assert rel is not None

--- a/autotest/ogr/ogr_openfilegdb.py
+++ b/autotest/ogr/ogr_openfilegdb.py
@@ -2386,7 +2386,7 @@ def test_ogr_openfilegdb_read_relationships():
     assert rel.GetRightMappingTableFields() is None
     assert rel.GetForwardPathLabel() == "my forward path label"
     assert rel.GetBackwardPathLabel() == "my backward path label"
-    assert rel.GetRelatedTableType() == "feature"
+    assert rel.GetRelatedTableType() == "features"
 
     rel = ds.GetRelationship("simple_one_to_many")
     assert rel is not None
@@ -2398,7 +2398,7 @@ def test_ogr_openfilegdb_read_relationships():
     assert rel.GetType() == gdal.GRT_ASSOCIATION
     assert rel.GetLeftTableFields() == ["pk"]
     assert rel.GetRightTableFields() == ["parent_pk"]
-    assert rel.GetRelatedTableType() == "feature"
+    assert rel.GetRelatedTableType() == "features"
 
     rel = ds.GetRelationship("simple_many_to_many")
     assert rel is not None
@@ -2412,7 +2412,7 @@ def test_ogr_openfilegdb_read_relationships():
     assert rel.GetLeftMappingTableFields() == ["origin_foreign_key"]
     assert rel.GetRightTableFields() == ["parent_pk"]
     assert rel.GetRightMappingTableFields() == ["destination_foreign_key"]
-    assert rel.GetRelatedTableType() == "feature"
+    assert rel.GetRelatedTableType() == "features"
 
     rel = ds.GetRelationship("composite_one_to_one")
     assert rel is not None
@@ -2424,7 +2424,7 @@ def test_ogr_openfilegdb_read_relationships():
     assert rel.GetType() == gdal.GRT_COMPOSITE
     assert rel.GetLeftTableFields() == ["pk"]
     assert rel.GetRightTableFields() == ["parent_pk"]
-    assert rel.GetRelatedTableType() == "feature"
+    assert rel.GetRelatedTableType() == "features"
 
     rel = ds.GetRelationship("composite_one_to_many")
     assert rel is not None
@@ -2436,7 +2436,7 @@ def test_ogr_openfilegdb_read_relationships():
     assert rel.GetType() == gdal.GRT_COMPOSITE
     assert rel.GetLeftTableFields() == ["pk"]
     assert rel.GetRightTableFields() == ["parent_pk"]
-    assert rel.GetRelatedTableType() == "feature"
+    assert rel.GetRelatedTableType() == "features"
 
     rel = ds.GetRelationship("composite_many_to_many")
     assert rel is not None
@@ -2450,7 +2450,7 @@ def test_ogr_openfilegdb_read_relationships():
     assert rel.GetLeftMappingTableFields() == ["origin_foreign_key"]
     assert rel.GetRightTableFields() == ["parent_pk"]
     assert rel.GetRightMappingTableFields() == ["dest_foreign_key"]
-    assert rel.GetRelatedTableType() == "feature"
+    assert rel.GetRelatedTableType() == "features"
 
     rel = ds.GetRelationship("points__ATTACHREL")
     assert rel is not None

--- a/autotest/ogr/ogr_openfilegdb_write.py
+++ b/autotest/ogr/ogr_openfilegdb_write.py
@@ -2833,7 +2833,7 @@ def test_ogr_openfilegdb_write_relationships():
         assert retrieved_rel.GetRightTableFields() == ["dest_pkey"]
         assert retrieved_rel.GetForwardPathLabel() == "fwd label"
         assert retrieved_rel.GetBackwardPathLabel() == "backward label"
-        assert retrieved_rel.GetRelatedTableType() == "feature"
+        assert retrieved_rel.GetRelatedTableType() == "features"
 
         items_lyr = ds.GetLayerByName("GDB_Items")
         f = items_lyr.GetFeature(8)
@@ -3182,7 +3182,7 @@ def test_ogr_openfilegdb_write_relationships():
         assert retrieved_rel.GetRightTableFields() == ["dest_pkey"]
         assert retrieved_rel.GetForwardPathLabel() == "my new fwd label"
         assert retrieved_rel.GetBackwardPathLabel() == "my new backward label"
-        assert retrieved_rel.GetRelatedTableType() == "feature"
+        assert retrieved_rel.GetRelatedTableType() == "features"
 
         # change relationship tables
         lyr = ds.CreateLayer("new_origin_table", geom_type=ogr.wkbNone)

--- a/autotest/ogr/ogr_pgeo.py
+++ b/autotest/ogr/ogr_pgeo.py
@@ -910,7 +910,7 @@ def test_ogr_openfilegdb_read_relationships():
     assert rel.GetRightMappingTableFields() is None
     assert rel.GetForwardPathLabel() == "forward label"
     assert rel.GetBackwardPathLabel() == "backward label"
-    assert rel.GetRelatedTableType() == "feature"
+    assert rel.GetRelatedTableType() == "features"
 
     rel = ds.GetRelationship("simple_one_to_many")
     assert rel is not None
@@ -922,7 +922,7 @@ def test_ogr_openfilegdb_read_relationships():
     assert rel.GetType() == gdal.GRT_ASSOCIATION
     assert rel.GetLeftTableFields() == ["pk"]
     assert rel.GetRightTableFields() == ["primary_key"]
-    assert rel.GetRelatedTableType() == "feature"
+    assert rel.GetRelatedTableType() == "features"
 
     rel = ds.GetRelationship("simple_many_to_many")
     assert rel is not None
@@ -936,7 +936,7 @@ def test_ogr_openfilegdb_read_relationships():
     assert rel.GetLeftMappingTableFields() == ["rel_pk"]
     assert rel.GetRightTableFields() == ["primary_key"]
     assert rel.GetRightMappingTableFields() == ["rel_primary_key"]
-    assert rel.GetRelatedTableType() == "feature"
+    assert rel.GetRelatedTableType() == "features"
 
     rel = ds.GetRelationship("composite_one_to_one")
     assert rel is not None
@@ -948,7 +948,7 @@ def test_ogr_openfilegdb_read_relationships():
     assert rel.GetType() == gdal.GRT_COMPOSITE
     assert rel.GetLeftTableFields() == ["pk"]
     assert rel.GetRightTableFields() == ["primary_key"]
-    assert rel.GetRelatedTableType() == "feature"
+    assert rel.GetRelatedTableType() == "features"
 
     rel = ds.GetRelationship("composite_one_to_many")
     assert rel is not None
@@ -962,7 +962,7 @@ def test_ogr_openfilegdb_read_relationships():
     assert rel.GetLeftMappingTableFields() == None
     assert rel.GetRightTableFields() == ["primary_key"]
     assert rel.GetRightMappingTableFields() == None
-    assert rel.GetRelatedTableType() == "feature"
+    assert rel.GetRelatedTableType() == "features"
 
     rel = ds.GetRelationship("points__ATTACHREL")
     assert rel is not None

--- a/autotest/utilities/test_ogrinfo_lib.py
+++ b/autotest/utilities/test_ogrinfo_lib.py
@@ -637,7 +637,7 @@ def test_ogrinfo_lib_relationships():
     ret = gdal.VectorInfo(ds)
     expected = """Relationship: composite_many_to_many
   Type: Composite
-  Related table type: feature
+  Related table type: features
   Cardinality: ManyToMany
   Left table name: table6
   Right table name: table7
@@ -667,7 +667,7 @@ def test_ogrinfo_lib_json_relationships():
     # print(ret["relationships"]["composite_many_to_many"])
     assert ret["relationships"]["composite_many_to_many"] == {
         "type": "Composite",
-        "related_table_type": "feature",
+        "related_table_type": "features",
         "cardinality": "ManyToMany",
         "left_table_name": "table6",
         "right_table_name": "table7",

--- a/ogr/ogrsf_frmts/openfilegdb/filegdb_relationship.h
+++ b/ogr/ogrsf_frmts/openfilegdb/filegdb_relationship.h
@@ -242,7 +242,7 @@ ParseXMLRelationshipDef(const std::string &domainDef)
     }
     else
     {
-        poRelationship->SetRelatedTableType("feature");
+        poRelationship->SetRelatedTableType("features");
     }
     return poRelationship;
 }


### PR DESCRIPTION
Previously we reported the table type as "feature", which did not match the accepted values reported by GDAL_DMD_RELATIONSHIP_RELATED_TABLE_TYPES for the drivers (and differed from the "features" string used by other drivers, eg. GPKG).

This is purely a GDAL implementation detail, it does not affect how the relationships are actually recorded in the GDB (as we only check for the table type of "media" to apply special handling)
