### PR TITLE
Dockerfile Ubuntu - Remove apache arrow deb file

### DIFF
--- a/docker/ubuntu-full/Dockerfile
+++ b/docker/ubuntu-full/Dockerfile
@@ -243,7 +243,8 @@ RUN . /buildscripts/bh-set-envvars.sh \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y -V libparquet-dev${APT_ARCH_SUFFIX}=${ARROW_VERSION} \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y -V libarrow-acero-dev${APT_ARCH_SUFFIX}=${ARROW_VERSION} \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y -V libarrow-dataset-dev${APT_ARCH_SUFFIX}=${ARROW_VERSION} \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && rm apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb
 
 RUN apt-get update -y \
     && apt-get install -y --fix-missing --no-install-recommends rsync ccache \


### PR DESCRIPTION

## What does this PR do?

Removes apache-arrow-apt-source-latest-xxxx.deb from `/`

## Example

```
▶ docker run -it --rm ghcr.io/osgeo/gdal:ubuntu-full-latest bash
root@cc2c6905f59a:/# ls
apache-arrow-apt-source-latest-jammy.deb  boot  etc   lib    mnt  proc  run   srv  tmp  var
bin                                       dev   home  media  opt  root  sbin  sys  usr
root@cc2c6905f59a:/#
```