### PR TITLE
Add a gdal::GCP class to make GCP handling from C++ easier

### DIFF
--- a/autotest/cpp/test_gdal.cpp
+++ b/autotest/cpp/test_gdal.cpp
@@ -3597,4 +3597,141 @@ TEST_F(test_gdal, drop_cache)
     }
 }
 
+// Test gdal::gcp class
+TEST_F(test_gdal, gdal_gcp_class)
+{
+    {
+        gdal::GCP gcp;
+        EXPECT_STREQ(gcp.Id(), "");
+        EXPECT_STREQ(gcp.Info(), "");
+        EXPECT_EQ(gcp.Pixel(), 0.0);
+        EXPECT_EQ(gcp.Line(), 0.0);
+        EXPECT_EQ(gcp.X(), 0.0);
+        EXPECT_EQ(gcp.Y(), 0.0);
+        EXPECT_EQ(gcp.Z(), 0.0);
+    }
+    {
+        gdal::GCP gcp("id", "info", 1.5, 2.5, 3.5, 4.5, 5.5);
+        EXPECT_STREQ(gcp.Id(), "id");
+        EXPECT_STREQ(gcp.Info(), "info");
+        EXPECT_EQ(gcp.Pixel(), 1.5);
+        EXPECT_EQ(gcp.Line(), 2.5);
+        EXPECT_EQ(gcp.X(), 3.5);
+        EXPECT_EQ(gcp.Y(), 4.5);
+        EXPECT_EQ(gcp.Z(), 5.5);
+
+        gcp.SetId("id2");
+        gcp.SetInfo("info2");
+        gcp.Pixel() = -1.5;
+        gcp.Line() = -2.5;
+        gcp.X() = -3.5;
+        gcp.Y() = -4.5;
+        gcp.Z() = -5.5;
+        EXPECT_STREQ(gcp.Id(), "id2");
+        EXPECT_STREQ(gcp.Info(), "info2");
+        EXPECT_EQ(gcp.Pixel(), -1.5);
+        EXPECT_EQ(gcp.Line(), -2.5);
+        EXPECT_EQ(gcp.X(), -3.5);
+        EXPECT_EQ(gcp.Y(), -4.5);
+        EXPECT_EQ(gcp.Z(), -5.5);
+
+        {
+            gdal::GCP gcp_copy(gcp);
+            EXPECT_STREQ(gcp_copy.Id(), "id2");
+            EXPECT_STREQ(gcp_copy.Info(), "info2");
+            EXPECT_EQ(gcp_copy.Pixel(), -1.5);
+            EXPECT_EQ(gcp_copy.Line(), -2.5);
+            EXPECT_EQ(gcp_copy.X(), -3.5);
+            EXPECT_EQ(gcp_copy.Y(), -4.5);
+            EXPECT_EQ(gcp_copy.Z(), -5.5);
+        }
+
+        {
+            gdal::GCP gcp_copy;
+            gcp_copy = gcp;
+            EXPECT_STREQ(gcp_copy.Id(), "id2");
+            EXPECT_STREQ(gcp_copy.Info(), "info2");
+            EXPECT_EQ(gcp_copy.Pixel(), -1.5);
+            EXPECT_EQ(gcp_copy.Line(), -2.5);
+            EXPECT_EQ(gcp_copy.X(), -3.5);
+            EXPECT_EQ(gcp_copy.Y(), -4.5);
+            EXPECT_EQ(gcp_copy.Z(), -5.5);
+        }
+
+        {
+            gdal::GCP gcp_copy(gcp);
+            gdal::GCP gcp_from_moved(std::move(gcp_copy));
+            EXPECT_STREQ(gcp_from_moved.Id(), "id2");
+            EXPECT_STREQ(gcp_from_moved.Info(), "info2");
+            EXPECT_EQ(gcp_from_moved.Pixel(), -1.5);
+            EXPECT_EQ(gcp_from_moved.Line(), -2.5);
+            EXPECT_EQ(gcp_from_moved.X(), -3.5);
+            EXPECT_EQ(gcp_from_moved.Y(), -4.5);
+            EXPECT_EQ(gcp_from_moved.Z(), -5.5);
+        }
+
+        {
+            gdal::GCP gcp_copy(gcp);
+            gdal::GCP gcp_from_moved;
+            gcp_from_moved = std::move(gcp_copy);
+            EXPECT_STREQ(gcp_from_moved.Id(), "id2");
+            EXPECT_STREQ(gcp_from_moved.Info(), "info2");
+            EXPECT_EQ(gcp_from_moved.Pixel(), -1.5);
+            EXPECT_EQ(gcp_from_moved.Line(), -2.5);
+            EXPECT_EQ(gcp_from_moved.X(), -3.5);
+            EXPECT_EQ(gcp_from_moved.Y(), -4.5);
+            EXPECT_EQ(gcp_from_moved.Z(), -5.5);
+        }
+
+        {
+            const GDAL_GCP *c_gcp = gcp.c_ptr();
+            EXPECT_STREQ(c_gcp->pszId, "id2");
+            EXPECT_STREQ(c_gcp->pszInfo, "info2");
+            EXPECT_EQ(c_gcp->dfGCPPixel, -1.5);
+            EXPECT_EQ(c_gcp->dfGCPLine, -2.5);
+            EXPECT_EQ(c_gcp->dfGCPX, -3.5);
+            EXPECT_EQ(c_gcp->dfGCPY, -4.5);
+            EXPECT_EQ(c_gcp->dfGCPZ, -5.5);
+
+            const gdal::GCP gcp_from_c(*c_gcp);
+            EXPECT_STREQ(gcp_from_c.Id(), "id2");
+            EXPECT_STREQ(gcp_from_c.Info(), "info2");
+            EXPECT_EQ(gcp_from_c.Pixel(), -1.5);
+            EXPECT_EQ(gcp_from_c.Line(), -2.5);
+            EXPECT_EQ(gcp_from_c.X(), -3.5);
+            EXPECT_EQ(gcp_from_c.Y(), -4.5);
+            EXPECT_EQ(gcp_from_c.Z(), -5.5);
+        }
+    }
+
+    {
+        const std::vector<gdal::GCP> gcps{
+            gdal::GCP{nullptr, nullptr, 0, 0, 0, 0, 0},
+            gdal::GCP{"id", "info", 1.5, 2.5, 3.5, 4.5, 5.5}};
+
+        const GDAL_GCP *c_gcps = gdal::GCP::c_ptr(gcps);
+        EXPECT_STREQ(c_gcps[1].pszId, "id");
+        EXPECT_STREQ(c_gcps[1].pszInfo, "info");
+        EXPECT_EQ(c_gcps[1].dfGCPPixel, 1.5);
+        EXPECT_EQ(c_gcps[1].dfGCPLine, 2.5);
+        EXPECT_EQ(c_gcps[1].dfGCPX, 3.5);
+        EXPECT_EQ(c_gcps[1].dfGCPY, 4.5);
+        EXPECT_EQ(c_gcps[1].dfGCPZ, 5.5);
+
+        const auto gcps_from_c =
+            gdal::GCP::fromC(c_gcps, static_cast<int>(gcps.size()));
+        ASSERT_EQ(gcps_from_c.size(), gcps.size());
+        for (size_t i = 0; i < gcps.size(); ++i)
+        {
+            EXPECT_STREQ(gcps_from_c[i].Id(), gcps[i].Id());
+            EXPECT_STREQ(gcps_from_c[i].Info(), gcps[i].Info());
+            EXPECT_EQ(gcps_from_c[i].Pixel(), gcps[i].Pixel());
+            EXPECT_EQ(gcps_from_c[i].Line(), gcps[i].Line());
+            EXPECT_EQ(gcps_from_c[i].X(), gcps[i].X());
+            EXPECT_EQ(gcps_from_c[i].Y(), gcps[i].Y());
+            EXPECT_EQ(gcps_from_c[i].Z(), gcps[i].Z());
+        }
+    }
+}
+
 }  // namespace

--- a/frmts/gtiff/gtiffdataset.cpp
+++ b/frmts/gtiff/gtiffdataset.cpp
@@ -367,13 +367,7 @@ std::tuple<CPLErr, bool> GTiffDataset::Finalize()
         m_fpToWrite = nullptr;
     }
 
-    if (m_nGCPCount > 0)
-    {
-        GDALDeinitGCPs(m_nGCPCount, m_pasGCPList);
-        CPLFree(m_pasGCPList);
-        m_pasGCPList = nullptr;
-        m_nGCPCount = 0;
-    }
+    m_aoGCPs.clear();
 
     CSLDestroy(m_papszCreationOptions);
     m_papszCreationOptions = nullptr;

--- a/frmts/gtiff/gtiffdataset.h
+++ b/frmts/gtiff/gtiffdataset.h
@@ -153,7 +153,7 @@ class GTiffDataset final : public GDALPamDataset
     std::unique_ptr<GDALDataset>
         m_poMaskExtOvrDS{};  // Used with MASK_OVERVIEW_DATASET open option
     GTiffJPEGOverviewDS **m_papoJPEGOverviewDS = nullptr;
-    GDAL_GCP *m_pasGCPList = nullptr;
+    std::vector<gdal::GCP> m_aoGCPs{};
     GDALColorTable *m_poColorTable = nullptr;
     char **m_papszMetadataFiles = nullptr;
     GByte *m_pabyBlockBuf = nullptr;
@@ -202,7 +202,6 @@ class GTiffDataset final : public GDALPamDataset
     int m_nLastBandRead = -1;        // Used for the all-in-on-strip case.
     int m_nLastWrittenBlockId = -1;  // used for m_bStreamingOut
     int m_nRefBaseMapping = 0;
-    int m_nGCPCount = 0;
     int m_nDisableMultiThreadedRead = 0;
 
     GTIFFKeysFlavorEnum m_eGeoTIFFKeysFlavor = GEOTIFF_KEYS_STANDARD;

--- a/frmts/hdf4/hdf4imagedataset.cpp
+++ b/frmts/hdf4/hdf4imagedataset.cpp
@@ -130,8 +130,7 @@ class HDF4ImageDataset final : public HDF4Dataset
     OGRSpatialReference m_oGCPSRS{};
     bool bHasGeoTransform;
     double adfGeoTransform[6];
-    GDAL_GCP *pasGCPList;
-    int nGCPCount;
+    std::vector<gdal::GCP> m_aoGCPs{};
 
     HDF4DatasetType iDatasetType;
 
@@ -765,8 +764,8 @@ HDF4ImageDataset::HDF4ImageDataset()
       iPalDataType(0), nComps(0), nPalEntries(0), iXDim(0), iYDim(0),
       iBandDim(-1), i4Dim(0), nBandCount(0), pszSubdatasetName(nullptr),
       pszFieldName(nullptr), poColorTable(nullptr), bHasGeoTransform(false),
-      pasGCPList(nullptr), nGCPCount(0), iDatasetType(HDF4_UNKNOWN), iSDS(FAIL),
-      nBlockPreferredXSize(-1), nBlockPreferredYSize(-1), bReadTile(false)
+      iDatasetType(HDF4_UNKNOWN), iSDS(FAIL), nBlockPreferredXSize(-1),
+      nBlockPreferredYSize(-1), bReadTile(false)
 {
     m_oSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
     m_oGCPSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
@@ -810,16 +809,6 @@ HDF4ImageDataset::~HDF4ImageDataset()
     if (poColorTable != nullptr)
         delete poColorTable;
 
-    if (nGCPCount > 0)
-    {
-        for (int i = 0; i < nGCPCount; i++)
-        {
-            CPLFree(pasGCPList[i].pszId);
-            CPLFree(pasGCPList[i].pszInfo);
-        }
-
-        CPLFree(pasGCPList);
-    }
     if (hHDF4 > 0)
     {
         switch (iDatasetType)
@@ -905,7 +894,7 @@ CPLErr HDF4ImageDataset::SetSpatialRef(const OGRSpatialReference *poSRS)
 int HDF4ImageDataset::GetGCPCount()
 
 {
-    return nGCPCount;
+    return static_cast<int>(m_aoGCPs.size());
 }
 
 /************************************************************************/
@@ -915,7 +904,7 @@ int HDF4ImageDataset::GetGCPCount()
 const OGRSpatialReference *HDF4ImageDataset::GetGCPSpatialRef() const
 
 {
-    return m_oSRS.IsEmpty() || nGCPCount == 0 ? nullptr : &m_oGCPSRS;
+    return m_oSRS.IsEmpty() || m_aoGCPs.empty() ? nullptr : &m_oGCPSRS;
 }
 
 /************************************************************************/
@@ -924,7 +913,7 @@ const OGRSpatialReference *HDF4ImageDataset::GetGCPSpatialRef() const
 
 const GDAL_GCP *HDF4ImageDataset::GetGCPs()
 {
-    return pasGCPList;
+    return gdal::GCP::c_ptr(m_aoGCPs);
 }
 
 /************************************************************************/
@@ -1252,29 +1241,13 @@ void HDF4ImageDataset::CaptureL1GMTLInfo()
         "AUTHORITY[\"EPSG\",\"9108\"]],AXIS[\"Lat\",NORTH],AXIS[\"Long\",EAST]"
         ",AUTHORITY[\"EPSG\",\"4326\"]]");
 
-    nGCPCount = 4;
-    pasGCPList = (GDAL_GCP *)CPLCalloc(nGCPCount, sizeof(GDAL_GCP));
-    GDALInitGCPs(nGCPCount, pasGCPList);
-
-    pasGCPList[0].dfGCPX = dfULX;
-    pasGCPList[0].dfGCPY = dfULY;
-    pasGCPList[0].dfGCPPixel = 0.0;
-    pasGCPList[0].dfGCPLine = 0.0;
-
-    pasGCPList[1].dfGCPX = dfURX;
-    pasGCPList[1].dfGCPY = dfURY;
-    pasGCPList[1].dfGCPPixel = GetRasterXSize();
-    pasGCPList[1].dfGCPLine = 0.0;
-
-    pasGCPList[2].dfGCPX = dfLLX;
-    pasGCPList[2].dfGCPY = dfLLY;
-    pasGCPList[2].dfGCPPixel = 0.0;
-    pasGCPList[2].dfGCPLine = GetRasterYSize();
-
-    pasGCPList[3].dfGCPX = dfLRX;
-    pasGCPList[3].dfGCPY = dfLRY;
-    pasGCPList[3].dfGCPPixel = GetRasterXSize();
-    pasGCPList[3].dfGCPLine = GetRasterYSize();
+    m_aoGCPs.emplace_back(nullptr, nullptr, 0.0, 0.0, dfULX, dfULY);
+    m_aoGCPs.emplace_back(nullptr, nullptr, GetRasterXSize(), 0.0, dfURX,
+                          dfURY);
+    m_aoGCPs.emplace_back(nullptr, nullptr, 0.0, GetRasterYSize(), dfLLX,
+                          dfLLY);
+    m_aoGCPs.emplace_back(nullptr, nullptr, GetRasterXSize(), GetRasterYSize(),
+                          dfLRX, dfLRY);
 }
 
 /************************************************************************/
@@ -2520,25 +2493,17 @@ int HDF4ImageDataset::ProcessSwathGeolocation(int32 hSW, char **papszDimList)
          */
         if (iGCPStepX > 0)
         {
-            nGCPCount = (((nXPoints - 1) / iGCPStepX) + 1) *
-                        (((nYPoints - 1) / iGCPStepY) + 1);
-
-            pasGCPList = reinterpret_cast<GDAL_GCP *>(
-                CPLCalloc(nGCPCount, sizeof(GDAL_GCP)));
-            GDALInitGCPs(nGCPCount, pasGCPList);
-
-            int iGCP = 0;
             for (int i = 0; i < nYPoints; i += iGCPStepY)
             {
                 for (int j = 0; j < nXPoints; j += iGCPStepX)
                 {
                     const int iGeoOff = i * nXPoints + j;
 
-                    pasGCPList[iGCP].dfGCPX = AnyTypeToDouble(
+                    double dfGCPX = AnyTypeToDouble(
                         iWrkNumType, reinterpret_cast<void *>(
                                          reinterpret_cast<char *>(pLong) +
                                          iGeoOff * iDataSize));
-                    pasGCPList[iGCP].dfGCPY = AnyTypeToDouble(
+                    double dfGCPY = AnyTypeToDouble(
                         iWrkNumType, reinterpret_cast<void *>(
                                          reinterpret_cast<char *>(pLat) +
                                          iGeoOff * iDataSize));
@@ -2552,27 +2517,24 @@ int HDF4ImageDataset::ProcessSwathGeolocation(int32 hSW, char **papszDimList)
                     if (eProduct == PROD_ASTER_L1A ||
                         eProduct == PROD_ASTER_L1B)
                     {
-                        pasGCPList[iGCP].dfGCPY =
-                            atan(tan(pasGCPList[iGCP].dfGCPY * PI / 180) /
-                                 0.99330562) *
-                            180 / PI;
+                        dfGCPY = atan(tan(dfGCPY * PI / 180) / 0.99330562) *
+                                 180 / PI;
                     }
 
-                    ToGeoref(&pasGCPList[iGCP].dfGCPX,
-                             &pasGCPList[iGCP].dfGCPY);
+                    ToGeoref(&dfGCPX, &dfGCPY);
 
-                    pasGCPList[iGCP].dfGCPZ = 0.0;
-
+                    double dfGCPPixel = 0.0;
+                    double dfGCPLine = 0.0;
                     if (pLatticeX && pLatticeY)
                     {
-                        pasGCPList[iGCP].dfGCPPixel =
+                        dfGCPPixel =
                             AnyTypeToDouble(
                                 iLatticeType,
                                 reinterpret_cast<void *>(
                                     reinterpret_cast<char *>(pLatticeX) +
                                     iGeoOff * iLatticeDataSize)) +
                             0.5;
-                        pasGCPList[iGCP].dfGCPLine =
+                        dfGCPLine =
                             AnyTypeToDouble(
                                 iLatticeType,
                                 reinterpret_cast<void *>(
@@ -2582,15 +2544,14 @@ int HDF4ImageDataset::ProcessSwathGeolocation(int32 hSW, char **papszDimList)
                     }
                     else if (paiOffset && paiIncrement)
                     {
-                        pasGCPList[iGCP].dfGCPPixel =
-                            paiOffset[iPixelDim] + j * paiIncrement[iPixelDim] +
-                            0.5;
-                        pasGCPList[iGCP].dfGCPLine =
-                            paiOffset[iLineDim] + i * paiIncrement[iLineDim] +
-                            0.5;
+                        dfGCPPixel = paiOffset[iPixelDim] +
+                                     j * paiIncrement[iPixelDim] + 0.5;
+                        dfGCPLine = paiOffset[iLineDim] +
+                                    i * paiIncrement[iLineDim] + 0.5;
                     }
 
-                    iGCP++;
+                    m_aoGCPs.emplace_back("", "", dfGCPPixel, dfGCPLine, dfGCPX,
+                                          dfGCPY);
                 }
             }
         }

--- a/frmts/hfa/hfadataset.h
+++ b/frmts/hfa/hfadataset.h
@@ -68,8 +68,7 @@ class HFADataset final : public GDALPamDataset
     bool bForceToPEString = false;
     bool bDisablePEString = false;
 
-    int nGCPCount = 0;
-    GDAL_GCP asGCPList[36];
+    std::vector<gdal::GCP> m_aoGCPs{};
 
     void UseXFormStack(int nStepCount, Efga_Polynomial *pasPolyListForward,
                        Efga_Polynomial *pasPolyListReverse);

--- a/frmts/jpeg/jpgdataset.h
+++ b/frmts/jpeg/jpgdataset.h
@@ -173,8 +173,7 @@ class JPGDatasetCommon CPL_NON_FINAL : public GDALPamDataset
     OGRSpatialReference m_oSRS{};
     bool bGeoTransformValid;
     double adfGeoTransform[6];
-    int nGCPCount;
-    GDAL_GCP *pasGCPList;
+    std::vector<gdal::GCP> m_aoGCPs{};
 
     VSILFILE *m_fpImage;
     GUIntBig nSubfileOffset;

--- a/frmts/mem/memdataset.h
+++ b/frmts/mem/memdataset.h
@@ -63,8 +63,7 @@ class CPL_DLL MEMDataset CPL_NON_FINAL : public GDALDataset
 
     OGRSpatialReference m_oSRS{};
 
-    int m_nGCPCount;
-    GDAL_GCP *m_pasGCPs;
+    std::vector<gdal::GCP> m_aoGCPs{};
     OGRSpatialReference m_oGCPSRS{};
 
     int m_nOverviewDSCount;

--- a/frmts/pdf/pdfcreatefromcomposition.h
+++ b/frmts/pdf/pdfcreatefromcomposition.h
@@ -160,13 +160,13 @@ class GDALPDFComposerWriter final : public GDALPDFBaseWriter
 
     GDALPDFObjectNum GenerateISO32000_Georeferencing(
         OGRSpatialReferenceH hSRS, double bboxX1, double bboxY1, double bboxX2,
-        double bboxY2, const std::vector<GDAL_GCP> &aGCPs,
+        double bboxY2, const std::vector<gdal::GCP> &aGCPs,
         const std::vector<xyPair> &aBoundingPolygon);
 
     GDALPDFObjectNum
     GenerateOGC_BP_Georeferencing(OGRSpatialReferenceH hSRS, double bboxX1,
                                   double bboxY1, double bboxX2, double bboxY2,
-                                  const std::vector<GDAL_GCP> &aGCPs,
+                                  const std::vector<gdal::GCP> &aGCPs,
                                   const std::vector<xyPair> &aBoundingPolygon);
 
     bool ExploreContent(const CPLXMLNode *psNode, PageContext &oPageContext);

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -99,11 +99,6 @@ VRTDataset::~VRTDataset()
         m_poSRS->Release();
     if (m_poGCP_SRS)
         m_poGCP_SRS->Release();
-    if (m_nGCPCount > 0)
-    {
-        GDALDeinitGCPs(m_nGCPCount, m_pasGCPList);
-        CPLFree(m_pasGCPList);
-    }
     CPLFree(m_pszVRTPath);
 
     delete m_poMaskBand;
@@ -313,10 +308,9 @@ CPLXMLNode *VRTDataset::SerializeToXML(const char *pszVRTPathIn)
     /* -------------------------------------------------------------------- */
     /*      GCPs                                                            */
     /* -------------------------------------------------------------------- */
-    if (m_nGCPCount > 0)
+    if (!m_asGCPs.empty())
     {
-        GDALSerializeGCPListToXML(psDSTree, m_pasGCPList, m_nGCPCount,
-                                  m_poGCP_SRS);
+        GDALSerializeGCPListToXML(psDSTree, m_asGCPs, m_poGCP_SRS);
     }
 
     /* -------------------------------------------------------------------- */
@@ -503,8 +497,7 @@ CPLErr VRTDataset::XMLInit(const CPLXMLNode *psTree, const char *pszVRTPathIn)
     /* -------------------------------------------------------------------- */
     if (const CPLXMLNode *psGCPList = CPLGetXMLNode(psTree, "GCPList"))
     {
-        GDALDeserializeGCPListFromXML(psGCPList, &m_pasGCPList, &m_nGCPCount,
-                                      &m_poGCP_SRS);
+        GDALDeserializeGCPListFromXML(psGCPList, m_asGCPs, &m_poGCP_SRS);
     }
 
     /* -------------------------------------------------------------------- */
@@ -619,7 +612,7 @@ CPLErr VRTDataset::XMLInit(const CPLXMLNode *psTree, const char *pszVRTPathIn)
 int VRTDataset::GetGCPCount()
 
 {
-    return m_nGCPCount;
+    return static_cast<int>(m_asGCPs.size());
 }
 
 /************************************************************************/
@@ -629,7 +622,7 @@ int VRTDataset::GetGCPCount()
 const GDAL_GCP *VRTDataset::GetGCPs()
 
 {
-    return m_pasGCPList;
+    return gdal::GCP::c_ptr(m_asGCPs);
 }
 
 /************************************************************************/
@@ -642,17 +635,9 @@ CPLErr VRTDataset::SetGCPs(int nGCPCountIn, const GDAL_GCP *pasGCPListIn,
 {
     if (m_poGCP_SRS)
         m_poGCP_SRS->Release();
-    if (m_nGCPCount > 0)
-    {
-        GDALDeinitGCPs(m_nGCPCount, m_pasGCPList);
-        CPLFree(m_pasGCPList);
-    }
 
     m_poGCP_SRS = poGCP_SRS ? poGCP_SRS->Clone() : nullptr;
-
-    m_nGCPCount = nGCPCountIn;
-
-    m_pasGCPList = GDALDuplicateGCPs(nGCPCountIn, pasGCPListIn);
+    m_asGCPs = gdal::GCP::fromC(pasGCPListIn, nGCPCountIn);
 
     SetNeedsFlush();
 

--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -214,8 +214,7 @@ class CPL_DLL VRTDataset CPL_NON_FINAL : public GDALDataset
     int m_bGeoTransformSet = false;
     double m_adfGeoTransform[6];
 
-    int m_nGCPCount = 0;
-    GDAL_GCP *m_pasGCPList = nullptr;
+    std::vector<gdal::GCP> m_asGCPs{};
     OGRSpatialReference *m_poGCP_SRS = nullptr;
 
     bool m_bNeedsFlush = false;

--- a/gcore/gdal_misc.cpp
+++ b/gcore/gdal_misc.cpp
@@ -1346,6 +1346,118 @@ int CPL_STDCALL GDALGetRandomRasterSample(GDALRasterBandH hBand, int nSamples,
 }
 
 /************************************************************************/
+/*                             gdal::GCP                                */
+/************************************************************************/
+
+namespace gdal
+{
+/** Constructor. */
+GCP::GCP(const char *pszId, const char *pszInfo, double dfPixel, double dfLine,
+         double dfX, double dfY, double dfZ)
+    : gcp{CPLStrdup(pszId ? pszId : ""),
+          CPLStrdup(pszInfo ? pszInfo : ""),
+          dfPixel,
+          dfLine,
+          dfX,
+          dfY,
+          dfZ}
+{
+    static_assert(sizeof(GCP) == sizeof(GDAL_GCP));
+}
+
+/** Destructor. */
+GCP::~GCP()
+{
+    CPLFree(gcp.pszId);
+    CPLFree(gcp.pszInfo);
+}
+
+/** Constructor from a C GDAL_GCP instance. */
+GCP::GCP(const GDAL_GCP &other)
+    : gcp{CPLStrdup(other.pszId),
+          CPLStrdup(other.pszInfo),
+          other.dfGCPPixel,
+          other.dfGCPLine,
+          other.dfGCPX,
+          other.dfGCPY,
+          other.dfGCPZ}
+{
+}
+
+/** Copy constructor. */
+GCP::GCP(const GCP &other) : GCP(other.gcp)
+{
+}
+
+/** Move constructor. */
+GCP::GCP(GCP &&other)
+    : gcp{other.gcp.pszId,     other.gcp.pszInfo, other.gcp.dfGCPPixel,
+          other.gcp.dfGCPLine, other.gcp.dfGCPX,  other.gcp.dfGCPY,
+          other.gcp.dfGCPZ}
+{
+    other.gcp.pszId = nullptr;
+    other.gcp.pszInfo = nullptr;
+}
+
+/** Copy assignment operator. */
+GCP &GCP::operator=(const GCP &other)
+{
+    if (this != &other)
+    {
+        CPLFree(gcp.pszId);
+        CPLFree(gcp.pszInfo);
+        gcp = other.gcp;
+        gcp.pszId = CPLStrdup(other.gcp.pszId);
+        gcp.pszInfo = CPLStrdup(other.gcp.pszInfo);
+    }
+    return *this;
+}
+
+/** Move assignment operator. */
+GCP &GCP::operator=(GCP &&other)
+{
+    if (this != &other)
+    {
+        CPLFree(gcp.pszId);
+        CPLFree(gcp.pszInfo);
+        gcp = other.gcp;
+        other.gcp.pszId = nullptr;
+        other.gcp.pszInfo = nullptr;
+    }
+    return *this;
+}
+
+/** Set the 'id' member of the GCP. */
+void GCP::SetId(const char *pszId)
+{
+    CPLFree(gcp.pszId);
+    gcp.pszId = CPLStrdup(pszId ? pszId : "");
+}
+
+/** Set the 'info' member of the GCP. */
+void GCP::SetInfo(const char *pszInfo)
+{
+    CPLFree(gcp.pszInfo);
+    gcp.pszInfo = CPLStrdup(pszInfo ? pszInfo : "");
+}
+
+/** Cast a vector of gdal::GCP as a C array of GDAL_GCP. */
+/*static */
+const GDAL_GCP *GCP::c_ptr(const std::vector<GCP> &asGCPs)
+{
+    return asGCPs.empty() ? nullptr : asGCPs.front().c_ptr();
+}
+
+/** Creates a vector of GDAL::GCP from a C array of GDAL_GCP. */
+/*static*/
+std::vector<GCP> GCP::fromC(const GDAL_GCP *pasGCPList, int nGCPCount)
+{
+    return std::vector<GCP>(pasGCPList, pasGCPList + nGCPCount);
+}
+
+} /* namespace gdal */
+
+/************************************************************************/
 /*                            GDALInitGCPs()                            */
 /************************************************************************/
 

--- a/gcore/gdal_pam.h
+++ b/gcore/gdal_pam.h
@@ -97,8 +97,7 @@ class GDALDatasetPamInfo
     int bHaveGeoTransform = false;
     double adfGeoTransform[6]{0, 0, 0, 0, 0, 0};
 
-    int nGCPCount = 0;
-    GDAL_GCP *pasGCPList = nullptr;
+    std::vector<gdal::GCP> asGCPs{};
     OGRSpatialReference *poGCP_SRS = nullptr;
 
     CPLString osPhysicalFilename{};

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -4169,11 +4169,11 @@ double GDALAdjustNoDataCloseToFloatMax(double dfVal);
 // (minimum value, maximum value, etc.)
 #define GDALSTAT_APPROX_NUMSAMPLES 2500
 
-void GDALSerializeGCPListToXML(CPLXMLNode *psParentNode, GDAL_GCP *pasGCPList,
-                               int nGCPCount,
+void GDALSerializeGCPListToXML(CPLXMLNode *psParentNode,
+                               const std::vector<gdal::GCP> &asGCPs,
                                const OGRSpatialReference *poGCP_SRS);
 void GDALDeserializeGCPListFromXML(const CPLXMLNode *psGCPList,
-                                   GDAL_GCP **ppasGCPList, int *pnGCPCount,
+                                   std::vector<gdal::GCP> &asGCPs,
                                    OGRSpatialReference **ppoGCP_SRS);
 
 void GDALSerializeOpenOptionsToXML(CPLXMLNode *psParentNode,

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -322,6 +322,122 @@ class CPL_DLL GDALOpenInfo
 };
 
 /* ******************************************************************** */
+/*                             gdal::GCP                                */
+/* ******************************************************************** */
+
+namespace gdal
+{
+/** C++ wrapper over the C GDAL_GCP structure.
+ *
+ * It has the same binary layout, and thus a gdal::GCP pointer can be cast as a
+ * GDAL_GCP pointer.
+ *
+ * @since 3.9
+ */
+class CPL_DLL GCP
+{
+  public:
+    explicit GCP(const char *pszId = "", const char *pszInfo = "",
+                 double dfPixel = 0, double dfLine = 0, double dfX = 0,
+                 double dfY = 0, double dfZ = 0);
+    ~GCP();
+    GCP(const GCP &);
+    explicit GCP(const GDAL_GCP &other);
+    GCP &operator=(const GCP &);
+    GCP(GCP &&);
+    GCP &operator=(GCP &&);
+
+    /** Returns the "id" member. */
+    inline const char *Id() const
+    {
+        return gcp.pszId;
+    }
+    void SetId(const char *pszId);
+
+    /** Returns the "info" member. */
+    inline const char *Info() const
+    {
+        return gcp.pszInfo;
+    }
+    void SetInfo(const char *pszInfo);
+
+    /** Returns the "pixel" member. */
+    inline double Pixel() const
+    {
+        return gcp.dfGCPPixel;
+    }
+
+    /** Returns a reference to the "pixel" member. */
+    inline double &Pixel()
+    {
+        return gcp.dfGCPPixel;
+    }
+
+    /** Returns the "line" member. */
+    inline double Line() const
+    {
+        return gcp.dfGCPLine;
+    }
+
+    /** Returns a reference to the "line" member. */
+    inline double &Line()
+    {
+        return gcp.dfGCPLine;
+    }
+
+    /** Returns the "X" member. */
+    inline double X() const
+    {
+        return gcp.dfGCPX;
+    }
+
+    /** Returns a reference to the "X" member. */
+    inline double &X()
+    {
+        return gcp.dfGCPX;
+    }
+
+    /** Returns the "Y" member. */
+    inline double Y() const
+    {
+        return gcp.dfGCPY;
+    }
+
+    /** Returns a reference to the "Y" member. */
+    inline double &Y()
+    {
+        return gcp.dfGCPY;
+    }
+
+    /** Returns the "Z" member. */
+    inline double Z() const
+    {
+        return gcp.dfGCPZ;
+    }
+
+    /** Returns a reference to the "Z" member. */
+    inline double &Z()
+    {
+        return gcp.dfGCPZ;
+    }
+
+    /** Casts as a C GDAL_GCP pointer */
+    inline const GDAL_GCP *c_ptr() const
+    {
+        return &gcp;
+    }
+
+    static const GDAL_GCP *c_ptr(const std::vector<GCP> &asGCPs);
+
+    static std::vector<GCP> fromC(const GDAL_GCP *pasGCPList, int nGCPCount);
+
+  private:
+    GDAL_GCP gcp;
+};
+
+} /* namespace gdal */
+
+/* ******************************************************************** */
 /*                             GDALDataset                              */
 /* ******************************************************************** */
 


### PR DESCRIPTION
GDAL_GCP is a C-only structure. The typical/recommended pattern to create GCPs from C is:
```
GDAL_GCP* gcps = (GDAL_GCP*)CPLMalloc( count * sizeof(GDAL_GCP) );
GDALInitGCPs( count, gcps );  // zero-initialize  pixel,line,x,y,z double members of each gcps[], and affects a CPLStrdup("") string to pszId and pszInfo members of each gcps[]
CPLFree(gcps[0].pszId); // free the initial empty string
gcps[0].pszId = CPLStrdup("foo"); // for example
GDALDeinitGCPs( count, gcps ); // free memory of gcps[i].pszId and gcps[i].pszInfo
CPLFree(gcps); // free the array itself
```
This is "fine" for a C user, but quite tedious in a C++ context. Big users of creating GCPs are GDAL drivers themselves.

So we introduce a gdal::GCP class that has a single GDAL_GCP private member, and handle memory allocation/deallocation, with helpers to navigate between the C and C++ worlds.

No attempt has been made (yet?) to modify the C++ API, in particularly the GDALDataset::GetGCPCount(), GetGCPs(), SetGCPs() method. I guess we'd need to keep the existing methods to avoid breaking external code, as wrappers over new methods that would return / accept ``std::vector<gdal::GCP>``

(This is an alternative to the messy earlier attempt of https://github.com/OSGeo/gdal/pull/9191)

@dg0yt @dbaston thoughts?
