### PR TITLE
Update gdaltransform.rst to hint on running gdalinfo on srcfile

### DIFF
--- a/doc/source/programs/gdaltransform.rst
+++ b/doc/source/programs/gdaltransform.rst
@@ -120,8 +120,7 @@ projection,including GCP-based transformations.
     not given, source projection/GCPs are read from the command-line :option:`-s_srs`
     or :option:`-gcp` parameters.
 
-    Ome might first inspect via gdalinfo <srcfile> to ensure all
-    projections/GCPs will be interpreted correctly.
+    Note that only the SRS and/or GCPs of this input file is taken into account, and not its pixel content.
 
 .. option:: <dstfile>
 

--- a/doc/source/programs/gdaltransform.rst
+++ b/doc/source/programs/gdaltransform.rst
@@ -116,9 +116,12 @@ projection,including GCP-based transformations.
 
 .. option:: <srcfile>
 
-    File with source projection definition or GCP's. If
-    not given, source projection is read from the command-line :option:`-s_srs`
-    or :option:`-gcp` parameters
+    File with source projection definition or GCPs. If
+    not given, source projection/GCPs are read from the command-line :option:`-s_srs`
+    or :option:`-gcp` parameters.
+
+    Ome might first inspect via gdalinfo <srcfile> to ensure all
+    projections/GCPs will be interpreted correctly.
 
 .. option:: <dstfile>
 


### PR DESCRIPTION
Else one might think GCPs can be given in srcfile one per line,
```
<pixel> <line> <easting> <northing> [<elevation>]
```