### PR TITLE
XLSX: Add OLCStringsAsUTF8 capability

### DIFF
--- a/ogr/ogrsf_frmts/xlsx/ogrxlsxdatasource.cpp
+++ b/ogr/ogrsf_frmts/xlsx/ogrxlsxdatasource.cpp
@@ -260,6 +260,8 @@ int OGRXLSXDataSource::TestCapability(const char *pszCap)
         return true;
     else if (EQUAL(pszCap, ODsCCurveGeometries))
         return true;
+    else if (EQUAL(pszCap, OLCStringsAsUTF8))
+        return true;
     else
         return false;
 }


### PR DESCRIPTION
The OLCStringsAsUTF8 capability seems to be missing for the XLSX driver.

Noticed this when using this capability pyogrio to write XLSX files and getting an UTF-8 error when trying to read it again:
https://github.com/geopandas/pyogrio/pull/361