### PR TITLE
Update gdal2xyz.rst

### DIFF
--- a/doc/source/programs/gdal2xyz.rst
+++ b/doc/source/programs/gdal2xyz.rst
@@ -28,8 +28,7 @@ Description
 -----------
 
 The :program:`gdal2xyz` utility can be used to translate a raster file into xyz format.
-`gdal2xyz` can be used as an alternative to `gdal_translate of=xyz`, but supporting other options,
-for example:
+`gdal2xyz` can be used as an alternative to `gdal_translate of=xyz`. Features include:
 
     * Select more then one band
     * Skip or replace nodata value


### PR DESCRIPTION
man gdal_translate says

       -b <band>
              Select an input band band for output. Bands are numbered from 1.
              Multiple  -b switches may be used to select a set of input bands
              to write to the output file, or to reorder bands...

Thus I remove the statement about what the other program (gdal_translate) doesn't have. In fact there might even be multiple features the other program already has...
