### PR TITLE
Update gdal_grid.rst to mention -ot defaults to a guess that might no…

### DIFF
--- a/doc/source/programs/gdal_grid.rst
+++ b/doc/source/programs/gdal_grid.rst
@@ -48,6 +48,9 @@ computer.
 
 .. include:: options/ot.rst
 
+   If not set then a default type is used, which might not be supported
+   by the relevant driver.
+
 .. include:: options/of.rst
 
 .. option:: -txe <xmin> <xmax>


### PR DESCRIPTION
…t be appropriate for the relevant driver

Please be aware that I cannot see how my changes render on GitHub, even when looking at Preview, so, well, I hope they look good.

P.S., proof of validity of what I am trying to mention:
```
$ gdal_grid --debug on ... n.gpkg
...
GDAL: GDALDriver::Create(GPKG,n.gpkg,...,Float64,...)
ERROR 6: Only Byte, Int16, UInt16 or Float32 supported
```
