### PR TITLE
Update gdal2xyz.rst removing bogus [<  >]

### DIFF
--- a/doc/source/programs/gdal2xyz.rst
+++ b/doc/source/programs/gdal2xyz.rst
@@ -22,7 +22,7 @@ Synopsis
         [-skipnodata]
         [-csv]
         [-srcnodata <value>] [-dstnodata <value>]
-        <src_dataset> [<dst_dataset>]
+        <src_dataset> <dst_dataset>
 
 Description
 -----------


### PR DESCRIPTION
1. You'll get an error if you don't give dst_dataset.
2. If you think about it, `[<    >]` is a contradiction too.