### PR TITLE
ODS and XLSX: declare OLCStringsAsUTF8 on newly created layers

### DIFF
--- a/autotest/ogr/ogr_ods.py
+++ b/autotest/ogr/ogr_ods.py
@@ -59,6 +59,8 @@ def ogr_ods_check(ds):
 
     assert lyr.TestCapability("foo") == 0
 
+    assert lyr.TestCapability(ogr.OLCStringsAsUTF8) == 1
+
     lyr = ds.GetLayer(6)
     assert lyr.GetName() == "Feuille7", "bad layer name"
 
@@ -363,6 +365,7 @@ def test_ogr_ods_8():
     drv = ogr.GetDriverByName("ODS")
     ds = drv.CreateDataSource("/vsimem/ogr_ods_8.ods")
     lyr = ds.CreateLayer("foo")
+    assert lyr.TestCapability(ogr.OLCStringsAsUTF8) == 1
     lyr.CreateField(ogr.FieldDefn("Field1", ogr.OFTInteger64))
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetField(0, 1)

--- a/autotest/ogr/ogr_xlsx.py
+++ b/autotest/ogr/ogr_xlsx.py
@@ -59,6 +59,8 @@ def ogr_xlsx_check(ds):
 
     assert lyr.TestCapability("foo") == 0
 
+    assert lyr.TestCapability(ogr.OLCStringsAsUTF8) == 1
+
     lyr = ds.GetLayer(6)
     assert lyr.GetName() == "Feuille7", "bad layer name"
 
@@ -277,6 +279,7 @@ def test_ogr_xlsx_8():
 
     ds = ogr.GetDriverByName("XLSX").CreateDataSource("/vsimem/ogr_xlsx_8.xlsx")
     lyr = ds.CreateLayer("foo")
+    assert lyr.TestCapability(ogr.OLCStringsAsUTF8) == 1
     for i in range(30):
         lyr.CreateField(ogr.FieldDefn("Field%d" % (i + 1)))
     f = ogr.Feature(lyr.GetLayerDefn())

--- a/ogr/ogrsf_frmts/ods/ogrodsdatasource.cpp
+++ b/ogr/ogrsf_frmts/ods/ogrodsdatasource.cpp
@@ -72,6 +72,7 @@ OGRODSLayer::OGRODSLayer(OGRODSDataSource *poDSIn, const char *pszName,
       bUpdated(CPL_TO_BOOL(bUpdatedIn)), bHasHeaderLine(false),
       m_poAttrQueryODS(nullptr)
 {
+    SetAdvertizeUTF8(true);
 }
 
 /************************************************************************/
@@ -846,7 +847,6 @@ void OGRODSDataSource::endElementTable(
 
             reinterpret_cast<OGRMemLayer *>(poCurLayer)
                 ->SetUpdatable(bUpdatable);
-            reinterpret_cast<OGRMemLayer *>(poCurLayer)->SetAdvertizeUTF8(true);
             reinterpret_cast<OGRODSLayer *>(poCurLayer)->SetUpdated(false);
         }
 

--- a/ogr/ogrsf_frmts/xlsx/ogrxlsxdatasource.cpp
+++ b/ogr/ogrsf_frmts/xlsx/ogrxlsxdatasource.cpp
@@ -52,6 +52,7 @@ OGRXLSXLayer::OGRXLSXLayer(OGRXLSXDataSource *poDSIn, const char *pszFilename,
       poDS(poDSIn), osFilename(pszFilename), bUpdated(CPL_TO_BOOL(bUpdatedIn)),
       bHasHeaderLine(false)
 {
+    SetAdvertizeUTF8(true);
 }
 
 /************************************************************************/
@@ -822,7 +823,6 @@ void OGRXLSXDataSource::endElementTable(CPL_UNUSED const char *pszNameIn)
         if (poCurLayer)
         {
             ((OGRMemLayer *)poCurLayer)->SetUpdatable(CPL_TO_BOOL(bUpdatable));
-            ((OGRMemLayer *)poCurLayer)->SetAdvertizeUTF8(true);
             ((OGRXLSXLayer *)poCurLayer)->SetUpdated(false);
         }
 


### PR DESCRIPTION
Fixes https://github.com/OSGeo/gdal/pull/9295#discussion_r1501665102