### PR TITLE
gml.rst: fix the link to the .gfx schema

### DIFF
--- a/doc/source/drivers/vector/gml.rst
+++ b/doc/source/drivers/vector/gml.rst
@@ -791,7 +791,7 @@ Syntax of .gfs files
 --------------------
 
 A XML Schema for .gfs files can be found at
-https://raw.githubusercontent.com/OSGeo/gdal/master/data/gfs.xsd .
+https://raw.githubusercontent.com/OSGeo/gdal/master/ogr/ogrsf_frmts/gml/data/gfs.xsd .
 
 Let's consider the following test.gml file :
 


### PR DESCRIPTION
The gfs.xsd XML schema file has been moved.