### PR TITLE
Disable my_test_sqlite3_ext in static builds

### DIFF
--- a/ogr/ogrsf_frmts/sqlite/CMakeLists.txt
+++ b/ogr/ogrsf_frmts/sqlite/CMakeLists.txt
@@ -95,8 +95,7 @@ if (GDAL_USE_SPATIALITE)
 endif ()
 
 # Test sqlite3 extension
-find_path(SQLITE3EXT_INCLUDE_DIR NAMES sqlite3ext.h)
-if (SQLITE3EXT_INCLUDE_DIR)
+if (HAVE_SQLITE3EXT_H AND BUILD_SHARED_LIBS)
     add_library(my_test_sqlite3_ext MODULE my_test_sqlite3_ext.c)
     gdal_standard_includes(my_test_sqlite3_ext)
     get_target_property(PLUGIN_OUTPUT_DIR ${GDAL_LIB_TARGET_NAME} PLUGIN_OUTPUT_DIR)


### PR DESCRIPTION
Cf. https://lists.osgeo.org/pipermail/gdal-dev/2024-February/058508.html
The change disables the module for all static builds (`BUILD_SHARED_LIBS` off). But the key goal is to disable it in builds with `-static` CRT linkage on linux.
Alternatively, it could be flagged as `EXCLUDE_FROM_ALL`, but then it might bit rot.
AFAICS the module is neither used nor installed. 
