### PR TITLE
[Backport release/3.8] gdal2tiles.py: fix exception when -v flag is used (3.7.0 regression) …

### DIFF
--- a/autotest/pyscripts/gdal2tiles/test_logger.py
+++ b/autotest/pyscripts/gdal2tiles/test_logger.py
@@ -8,7 +8,7 @@
 # Author:   Even Rouault <even.rouault at spatialys.com>
 #
 ###############################################################################
-# Copyright (c) 2022, Even Rouault <even.rouault at spatialys.com>
+# Copyright (c) 2024, Even Rouault <even.rouault at spatialys.com>
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -35,17 +35,29 @@ from osgeo import gdal
 from osgeo_utils import gdal2tiles
 
 
-def test_gdal2tiles_vsimem():
+def test_gdal2tiles_logger():
 
     if gdal.GetDriverByName("PNG") is None:
         pytest.skip("PNG driver is missing")
 
     gdal2tiles.main(
-        argv=["gdal2tiles", "-q", "../../gcore/data/byte.tif", "/vsimem/gdal2tiles"]
+        argv=[
+            "gdal2tiles",
+            "--verbose",
+            "-z",
+            "13-14",
+            "../../gcore/data/byte.tif",
+            "/vsimem/gdal2tiles",
+        ]
     )
 
     assert set(gdal.ReadDirRecursive("/vsimem/gdal2tiles")) == set(
         [
+            "13/",
+            "13/1418/",
+            "13/1418/4916.png",
+            "13/1419/",
+            "13/1419/4916.png",
             "14/",
             "14/2837/",
             "14/2837/9833.png",

--- a/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
@@ -1573,7 +1573,10 @@ def create_overview_tile(
             gdal.Unlink(aux_xml)
 
     if options.verbose:
-        logger.debug(f"\tbuild from zoom {base_tz}, tiles: %s" % ",".join(base_tiles))
+        logger.debug(
+            f"\tbuild from zoom {base_tz}, tiles: %s"
+            % ",".join(["(%d, %d)" % (t[0], t[1]) for t in base_tiles])
+        )
 
     # Create a KML file for this tile.
     if tile_job_info.kml:


### PR DESCRIPTION
Backport #9282
 **Authored by:** @rouault