### PR TITLE
gdal_polygonize.py: handle error when the creation of the destination datasource fails

### DIFF
--- a/swig/python/gdal-utils/osgeo_utils/gdal_polygonize.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_polygonize.py
@@ -146,6 +146,9 @@ def gdal_polygonize(
         if not quiet:
             print("Creating output %s of format %s." % (dst_filename, driver_name))
         dst_ds = drv.CreateDataSource(dst_filename)
+        if dst_ds is None:
+            print('Cannot create datasource "%s"' % dst_filename)
+            return 1
 
     # =============================================================================
     #       Find or create destination layer.


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

Makes gdal_polygonize.py print an error message when the creation of the destination datasource fails.

Otherwise, in such case, the script will fails at https://github.com/OSGeo/gdal/blob/master/swig/python/gdal-utils/osgeo_utils/gdal_polygonize.py#L162 and a Python traceback error message will be printed.
