### PR TITLE
[Backport release/3.8] VRT/gdal_translate -of 200% 200%: make sure that the synthetized virtual overviews match the dimension of the source ones when possible

### DIFF
--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -2564,3 +2564,43 @@ def test_vrt_read_compute_statistics_approximate(tmp_vsimem):
     assert "STATISTICS_MEAN" in md
     assert "STATISTICS_STDDEV" in md
     assert md["STATISTICS_VALID_PERCENT"] == "100"
+
+
+###############################################################################
+# Test that when generating virtual overviews we select them as close as
+# possible to source ones
+
+
+def test_vrt_read_virtual_overviews_match_src_overviews(tmp_vsimem):
+
+    gtiff_filename = str(tmp_vsimem / "tmp.tif")
+    ds = gdal.GetDriverByName("GTiff").Create(
+        gtiff_filename, 4095, 2047, options=["SPARSE_OK=YES"]
+    )
+    ds.BuildOverviews("NONE", [2, 4, 8])
+    band = ds.GetRasterBand(1)
+    # The below assert is a pre-condition to test the behavior of the
+    # "vrt://{gtiff_filename}?outsize=200%,200%". If we decided to round
+    # differently overview dataset sizes in the GTiff driver, we'd need to
+    # change this source dataset
+    assert band.GetOverview(0).XSize == 2048
+    assert band.GetOverview(0).YSize == 1024
+    assert band.GetOverview(1).XSize == 1024
+    assert band.GetOverview(1).YSize == 512
+    ds = None
+
+    vrt_ds = gdal.Open(f"vrt://{gtiff_filename}?outsize=200%,200%")
+    assert vrt_ds.RasterXSize == 4095 * 2
+    assert vrt_ds.RasterYSize == 2047 * 2
+    vrt_band = vrt_ds.GetRasterBand(1)
+    assert vrt_band.XSize == 4095 * 2
+    assert vrt_band.YSize == 2047 * 2
+    assert vrt_band.GetOverviewCount() == 3
+    # We reuse the dimension of the source dataset
+    assert vrt_band.GetOverview(0).XSize == 4095
+    assert vrt_band.GetOverview(0).YSize == 2047
+    # We reuse the dimension of the overviews of the source dataset
+    assert vrt_band.GetOverview(1).XSize == 2048
+    assert vrt_band.GetOverview(1).YSize == 1024
+    assert vrt_band.GetOverview(2).XSize == 1024
+    assert vrt_band.GetOverview(2).YSize == 512

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -36,6 +36,8 @@
 #include "gdal_utils.h"
 
 #include <algorithm>
+#include <cmath>
+#include <set>
 #include <typeinfo>
 #include "gdal_proxy.h"
 
@@ -2274,6 +2276,7 @@ void VRTDataset::UnsetPreservedRelativeFilenames()
 
 static bool CheckBandForOverview(GDALRasterBand *poBand,
                                  GDALRasterBand *&poFirstBand, int &nOverviews,
+                                 std::set<std::pair<int, int>> &oSetOvrSizes,
                                  std::vector<GDALDataset *> &apoOverviewsBak)
 {
     if (!cpl::down_cast<VRTRasterBand *>(poBand)->IsSourcedRasterBand())
@@ -2300,6 +2303,17 @@ static bool CheckBandForOverview(GDALRasterBand *poBand,
     // To prevent recursion
     apoOverviewsBak.push_back(nullptr);
     const int nOvrCount = poSrcBand->GetOverviewCount();
+    oSetOvrSizes.insert(
+        std::pair<int, int>(poSrcBand->GetXSize(), poSrcBand->GetYSize()));
+    for (int i = 0; i < nOvrCount; ++i)
+    {
+        auto poSrcOvrBand = poSrcBand->GetOverview(i);
+        if (poSrcOvrBand)
+        {
+            oSetOvrSizes.insert(std::pair<int, int>(poSrcOvrBand->GetXSize(),
+                                                    poSrcOvrBand->GetYSize()));
+        }
+    }
     apoOverviewsBak.resize(0);
 
     if (nOvrCount == 0)
@@ -2326,18 +2340,19 @@ void VRTDataset::BuildVirtualOverviews()
 
     int nOverviews = 0;
     GDALRasterBand *poFirstBand = nullptr;
+    std::set<std::pair<int, int>> oSetOvrSizes;
 
     for (int iBand = 0; iBand < nBands; iBand++)
     {
         if (!CheckBandForOverview(papoBands[iBand], poFirstBand, nOverviews,
-                                  m_apoOverviewsBak))
+                                  oSetOvrSizes, m_apoOverviewsBak))
             return;
     }
 
     if (m_poMaskBand)
     {
         if (!CheckBandForOverview(m_poMaskBand, poFirstBand, nOverviews,
-                                  m_apoOverviewsBak))
+                                  oSetOvrSizes, m_apoOverviewsBak))
             return;
     }
     if (poFirstBand == nullptr)
@@ -2369,10 +2384,24 @@ void VRTDataset::BuildVirtualOverviews()
         {
             continue;
         }
-        const int nOvrXSize = static_cast<int>(0.5 + nRasterXSize * dfXRatio);
-        const int nOvrYSize = static_cast<int>(0.5 + nRasterYSize * dfYRatio);
+        int nOvrXSize = static_cast<int>(0.5 + nRasterXSize * dfXRatio);
+        int nOvrYSize = static_cast<int>(0.5 + nRasterYSize * dfYRatio);
         if (nOvrXSize < 128 || nOvrYSize < 128)
             break;
+
+        // Look for a source overview whose size is very close to the
+        // theoretical computed one.
+        for (const auto &ovrSize : oSetOvrSizes)
+        {
+            if (std::abs(ovrSize.first - nOvrXSize) <= 1 &&
+                std::abs(ovrSize.second - nOvrYSize) <= 1)
+            {
+                nOvrXSize = ovrSize.first;
+                nOvrYSize = ovrSize.second;
+                break;
+            }
+        }
+
         VRTDataset *poOvrVDS = new VRTDataset(nOvrXSize, nOvrYSize);
         m_apoOverviews.push_back(poOvrVDS);
 


### PR DESCRIPTION
Backport #9353
 **Authored by:** @rouault