### PR TITLE
[Backport release/3.8] gdalinfo -json: fix wrong axis order in STAC proj:shape member (fixes #9337)

### DIFF
--- a/apps/gdalinfo_lib.cpp
+++ b/apps/gdalinfo_lib.cpp
@@ -341,19 +341,33 @@ char *GDALInfo(GDALDatasetH hDataset, const GDALInfoOptions *psOptions)
 
     if (bJson)
     {
-        json_object *poSize = json_object_new_array();
-        json_object *poSizeX =
-            json_object_new_int(GDALGetRasterXSize(hDataset));
-        json_object *poSizeY =
-            json_object_new_int(GDALGetRasterYSize(hDataset));
+        {
+            json_object *poSize = json_object_new_array();
+            json_object *poSizeX =
+                json_object_new_int(GDALGetRasterXSize(hDataset));
+            json_object *poSizeY =
+                json_object_new_int(GDALGetRasterYSize(hDataset));
 
-        json_object_array_add(poSize, poSizeX);
-        json_object_array_add(poSize, poSizeY);
+            // size is X, Y ordered
+            json_object_array_add(poSize, poSizeX);
+            json_object_array_add(poSize, poSizeY);
 
-        json_object *poStacSize = nullptr;
-        json_object_deep_copy(poSize, &poStacSize, nullptr);
-        json_object_object_add(poJsonObject, "size", poSize);
-        json_object_object_add(poStac, "proj:shape", poStacSize);
+            json_object_object_add(poJsonObject, "size", poSize);
+        }
+
+        {
+            json_object *poStacSize = json_object_new_array();
+            json_object *poSizeX =
+                json_object_new_int(GDALGetRasterXSize(hDataset));
+            json_object *poSizeY =
+                json_object_new_int(GDALGetRasterYSize(hDataset));
+
+            // ... but ... proj:shape is Y, X ordered.
+            json_object_array_add(poStacSize, poSizeY);
+            json_object_array_add(poStacSize, poSizeX);
+
+            json_object_object_add(poStac, "proj:shape", poStacSize);
+        }
     }
     else
     {

--- a/autotest/utilities/test_gdalinfo_lib.py
+++ b/autotest/utilities/test_gdalinfo_lib.py
@@ -263,3 +263,16 @@ def test_gdalinfo_lib_json_projjson_no_epsg():
     ret = gdal.Info(ds, options="-json")
     assert ret["stac"]["proj:epsg"] is None
     assert ret["stac"]["proj:wkt2"] is not None
+
+
+###############################################################################
+# Test fix for https://github.com/OSGeo/gdal/issues/9337
+
+
+def test_gdalinfo_lib_json_proj_shape():
+
+    width = 2
+    height = 1
+    ds = gdal.GetDriverByName("MEM").Create("", width, height)
+    ret = gdal.Info(ds, options="-json")
+    assert ret["stac"]["proj:shape"] == [height, width]

--- a/data/gdalinfo_output.schema.json
+++ b/data/gdalinfo_output.schema.json
@@ -176,6 +176,7 @@
           }
         },
         "size": {
+          "$comment": "note that the order of items in side is width,height",
           "$ref": "#/definitions/arrayOfTwoIntegers"
         },
         "coordinateSystem": {
@@ -306,6 +307,7 @@
         },
 
         "proj:shape": {
+          "$comment": "note that the order of items in proj:shape is height,width starting with GDAL 3.8.5 (previous versions ordered it wrongly as width,height)",
           "title": "Shape",
           "type": "array",
           "minItems": 2,


### PR DESCRIPTION
Backport #9341
 **Authored by:** @rouault