### PR TITLE
Python: Fix gdal.Warp segfault with dst=None

### DIFF
--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -4033,3 +4033,10 @@ def test_gdalwarp_lib_to_projection_without_inverse_method():
                 1218250.2778614,
             ],
         )
+
+
+def test_gdalwarp_lib_no_crash_on_none_dst():
+
+    ds1 = gdal.Open("../gcore/data/byte.tif")
+    with pytest.raises(ValueError):
+        gdal.Warp(None, ds1)

--- a/swig/include/gdal.i
+++ b/swig/include/gdal.i
@@ -1280,6 +1280,8 @@ struct GDALWarpAppOptions {
 
 /* Note: we must use 2 distinct names due to different ownership of the result */
 
+
+%apply Pointer NONNULL { GDALDatasetShadow* dstDS };
 %inline %{
 
 int wrapper_GDALWarpDestDS( GDALDatasetShadow* dstDS,
@@ -1318,6 +1320,7 @@ int wrapper_GDALWarpDestDS( GDALDatasetShadow* dstDS,
     return bRet;
 }
 %}
+%clear GDALDatasetShadow* dstDS;
 
 #ifdef SWIGJAVA
 %rename (Warp) wrapper_GDALWarpDestName;


### PR DESCRIPTION
## What does this PR do?

Fix gdal.Warp segfault with dst=None

It seems reasonable assume `format="MEM"` in this case, but I did not change that behavior.

## What are related issues/pull requests?

None

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed