### PR TITLE
HFA: Fix some typos in HFA -- Erdas Imagine .img docs

### DIFF
--- a/doc/source/drivers/raster/hfa.rst
+++ b/doc/source/drivers/raster/hfa.rst
@@ -23,8 +23,8 @@ Metadata reading and writing is supported at the dataset and band level.
 But this is GDAL specific metadata, not metadata in an Imagine recognized form.
 The metadata is stored in a table called GDAL_MetaData which as many 
 columns as metadata items. 
-The title of the column is the {key} of the {key}={value} metadata item pair
-and the value of row 1 is {value}.
+The title of the column is the ``key`` of the ``key``=``value`` metadata item pair
+and the value of row 1 is ``value``.
 
 Driver capabilities
 -------------------

--- a/doc/source/drivers/raster/hfa.rst
+++ b/doc/source/drivers/raster/hfa.rst
@@ -16,10 +16,10 @@ and c128.
 Compressed and missing tiles in Erdas files should be handled properly
 on read. Files between 2GiB and 4GiB in size should work on Windows NT,
 and may work on some Unix platforms. Files with external spill files
-(needed for datasets larger than 2GiB) are also support for reading and
+(needed for datasets larger than 2GiB) are also supported for reading and
 writing.
 
-Metadata reading and writing is supported at the dataset level, and for
+Metadata reading and writing are supported at the dataset level, and for
 bands, but this is GDAL specific metadata - not metadata in an Imagine
 recognized form. The metadata is stored in a table called GDAL_MetaData
 with each column being a metadata item. The title is the key and the row
@@ -120,7 +120,7 @@ Creation Options:
       :since: 3.7
 
       Disable use of ArcGIS PE String in
-      file. Default is NO (that is ArcGIS PE String may be written if needed).
+      file. The default value is NO, allowing ArcGIS PE String to be written if needed.
 
 Erdas Imagine supports external creation of overviews (with gdaladdo for
 instance). To force them to be created in an .rrd file (rather than
@@ -180,7 +180,7 @@ by the HFA driver:
 
       The block size (tile width/height) used for overviews
       can be specified by setting this
-      configuration option to a power- of-two value between 32 and 2048.
+      configuration option to a power-of-two value between 32 and 2048.
 
 -  .. config:: USE_SPILL
       :choices: YES, NO

--- a/doc/source/drivers/raster/hfa.rst
+++ b/doc/source/drivers/raster/hfa.rst
@@ -19,11 +19,12 @@ and may work on some Unix platforms. Files with external spill files
 (needed for datasets larger than 2GiB) are also supported for reading and
 writing.
 
-Metadata reading and writing are supported at the dataset level, and for
-bands, but this is GDAL specific metadata - not metadata in an Imagine
-recognized form. The metadata is stored in a table called GDAL_MetaData
-with each column being a metadata item. The title is the key and the row
-1 value is the value.
+Metadata reading and writing is supported at the dataset and band level.
+But this is GDAL specific metadata, not metadata in an Imagine recognized form.
+The metadata is stored in a table called GDAL_MetaData which as many 
+columns as metadata items. 
+The title of the column is the {key} of the {key}={value} metadata item pair
+and the value of row 1 is {value}.
 
 Driver capabilities
 -------------------
@@ -43,7 +44,7 @@ Erdas Imagine files can be created with any GDAL defined band type,
 including the complex types. Created files may have any number of bands.
 Pseudo-Color tables will be written if using the
 GDALDriver::CreateCopy() methodology. Most projections should be
-supported though translation of unusual datums (other than WGS84, WGS72,
+supported, though translation of unusual datums (other than WGS84, WGS72,
 NAD83, and NAD27) may be problematic.
 
 Creation Options:

--- a/doc/source/drivers/raster/hfa.rst
+++ b/doc/source/drivers/raster/hfa.rst
@@ -111,7 +111,7 @@ Creation Options:
       :choices: YES, NO
       :default: NO
 
-      Force use of ArcGIS PE String in file
+      Force the use of ESRI Projection Engine (PE) String in file
       instead of Imagine coordinate system format. In some cases this
       improves ArcGIS coordinate system compatibility.
 
@@ -120,8 +120,9 @@ Creation Options:
       :default: NO
       :since: 3.7
 
-      Disable use of ArcGIS PE String in
-      file. The default value is NO, allowing ArcGIS PE String to be written if needed.
+      Disable use of ESRI Projection Engine (PE) String in file.
+      The default value is NO, allowing the ESRI PE String
+      to be written if needed.
 
 Erdas Imagine supports external creation of overviews (with gdaladdo for
 instance). To force them to be created in an .rrd file (rather than


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

I had to read the page https://gdal.org/drivers/raster/hfa.html and noticed some typos in the page.
I fixed the ones that I understood.

## What are related issues/pull requests?

## Tasklist

 - [ ] Please help reword the paragraph I linked to below, it is unclear. I included in this PR at least is->are, but it still doesn't make sense
       https://github.com/OSGeo/gdal/blob/ced6a0ded84a892aefcdbf449689026e3645494e/doc/source/drivers/raster/hfa.rst?plain=1#L22-L26
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed


## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
