### PR TITLE
SWIG: Exposes additional Dataset methods for the csharp wrapper (fixes #918)

### DIFF
--- a/swig/include/Dataset.i
+++ b/swig/include/Dataset.i
@@ -889,6 +889,38 @@ CPLErr AdviseRead(  int xoff, int yoff, int xsize, int ysize,
 
 #endif /* defined(SWIGPYTHON) || defined(SWIGJAVA) */
 
+#ifdef SWIGCSHARP
+  
+  %newobject GetNextFeature;
+  OGRFeatureShadow *GetNextFeature( OGRLayerShadow** ppoBelongingLayer = NULL,
+                                    double* pdfProgressPct = NULL,
+                                    GDALProgressFunc callback = NULL,
+                                    void* callback_data=NULL )
+  {
+    return GDALDatasetGetNextFeature( self, ppoBelongingLayer, pdfProgressPct,
+                                      callback, callback_data );
+  }
+
+  int GetLayerCount() {
+    return GDALDatasetGetLayerCount(self);
+  }
+
+  OGRLayerShadow *GetLayer(int index ) {
+    OGRLayerShadow* layer = (OGRLayerShadow*) GDALDatasetGetLayer(self, index);
+    return layer;
+  }
+
+  OGRLayerShadow *GetLayerByName(const char* layerName) {
+    OGRLayerShadow* layer = (OGRLayerShadow*) GDALDatasetGetLayerByName(self, layerName);
+    return layer;
+  }
+
+  void ResetReading()
+  {
+    GDALDatasetResetReading(self);
+  }
+
+#endif
 
 OGRErr AbortSQL() {
     return GDALDatasetAbortSQL(self);

--- a/swig/include/csharp/gdal_csharp.i
+++ b/swig/include/csharp/gdal_csharp.i
@@ -86,6 +86,8 @@ typedef struct
 } GDALRasterIOExtraArg;
 
 DEFINE_EXTERNAL_CLASS(OGRLayerShadow, OSGeo.OGR.Layer)
+DEFINE_EXTERNAL_CLASS(OGRFeatureShadow, OSGeo.OGR.Feature)
+
 
 %define %rasterio_functions(GDALTYPE,CSTYPE)
  public CPLErr ReadRaster(int xOff, int yOff, int xSize, int ySize, CSTYPE[] buffer, int buf_xSize, int buf_ySize, int pixelSpace, int lineSpace) {

--- a/swig/include/csharp/typemaps_csharp.i
+++ b/swig/include/csharp/typemaps_csharp.i
@@ -599,3 +599,19 @@ OPTIONAL_POD(int, int);
 %typemap(imtype) (void* callback_data) "string"
 %typemap(cstype) (void* callback_data) "string"
 %typemap(csin) (void* callback_data) "$csinput"
+
+
+/******************************************************************************
+ * GDALGetNextFeature typemaps                                                *
+ *****************************************************************************/
+
+%apply (double *defaultval) {double* pdfProgressPct};
+
+%typemap(imtype) (OGRLayerShadow **ppoBelongingLayer)  "ref IntPtr"
+%typemap(cstype) (OGRLayerShadow **ppoBelongingLayer) "ref IntPtr"
+%typemap(csin) (OGRLayerShadow **ppoBelongingLayer)  "ref $csinput"
+
+/******************************************************************************
+ * GDALGetLayerByName typemaps                                                *
+ *****************************************************************************/
+%apply ( const char *utf8_path ) { const char* layerName };


### PR DESCRIPTION
SWIG: Exposes additional Dataset methods for the csharp wrapper:

- GetNextFeature (exposing _ppoBelongingLayer_ as a ref IntPtr and _pdfProgressPct_ as ref double),
- GetLayerCount, 
- GetLayer, 
- GetLayerByName, 
- ResetReading