### PR TITLE
OpenFileGDB writer: fix corrupted maximum blob size header field in some SetFeature() scenarios (fixes #9388)

### DIFF
--- a/ogr/ogrsf_frmts/openfilegdb/filegdbtable.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/filegdbtable.cpp
@@ -1532,6 +1532,30 @@ int FileGDBTable::SelectRow(int iRow)
                     m_nRowBlobLength > INT_MAX - ZEROES_AFTER_END_OF_BUFFER,
                 m_nCurRow = -1);
 
+            if (m_nRowBlobLength > m_nHeaderBufferMaxSize)
+            {
+                if (CPLTestBool(CPLGetConfigOption(
+                        "OGR_OPENFILEGDB_ERROR_ON_INCONSISTENT_BUFFER_MAX_SIZE",
+                        "NO")))
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "Invalid row length (%u) on feature %u compared "
+                             "to the maximum size in the header (%u)",
+                             m_nRowBlobLength, iRow + 1,
+                             m_nHeaderBufferMaxSize);
+                    m_nCurRow = -1;
+                    return errorRetValue;
+                }
+                else
+                {
+                    CPLDebug("OpenFileGDB",
+                             "Invalid row length (%u) on feature %u compared "
+                             "to the maximum size in the header (%u)",
+                             m_nRowBlobLength, iRow + 1,
+                             m_nHeaderBufferMaxSize);
+                }
+            }
+
             if (m_nRowBlobLength > m_nRowBufferMaxSize)
             {
                 /* For suspicious row blob length, check if we don't go beyond

--- a/ogr/ogrsf_frmts/openfilegdb/filegdbtable_write.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/filegdbtable_write.cpp
@@ -1880,6 +1880,10 @@ bool FileGDBTable::CreateFeature(const std::vector<OGRField> &asRawFields,
         *pnFID = nObjectID;
 
     m_nRowBlobLength = static_cast<uint32_t>(m_abyBuffer.size());
+    if (m_nRowBlobLength > m_nHeaderBufferMaxSize)
+    {
+        m_nHeaderBufferMaxSize = m_nRowBlobLength;
+    }
     m_nRowBufferMaxSize = std::max(m_nRowBufferMaxSize, m_nRowBlobLength);
     if (nFreeOffset == OFFSET_MINUS_ONE)
     {
@@ -2012,6 +2016,11 @@ bool FileGDBTable::UpdateFeature(int nFID,
             return false;
 
         m_nRowBlobLength = static_cast<uint32_t>(m_abyBuffer.size());
+        if (m_nRowBlobLength > m_nHeaderBufferMaxSize)
+        {
+            m_bDirtyHeader = true;
+            m_nHeaderBufferMaxSize = m_nRowBlobLength;
+        }
         m_nRowBufferMaxSize = std::max(m_nRowBufferMaxSize, m_nRowBlobLength);
         if (nFreeOffset == OFFSET_MINUS_ONE)
         {


### PR DESCRIPTION
When SetFeature() involves generating a row whose blob size is larger than the maximum one in the file, the file header was no properly refreshed. This didn't cause issues to the OpenFileGDB driver, which is robust to that, but ESRI based readers, like ArcMap or the FileGDB SDK, were unable to read such features.
