### PR TITLE
[Backport 3.8] OpenFileGDB writer: fix corrupted maximum blob size header field in some SetFeature() scenarios (fixes #9388)

### DIFF
--- a/autotest/ogr/ogr_openfilegdb_write.py
+++ b/autotest/ogr/ogr_openfilegdb_write.py
@@ -54,7 +54,10 @@ def setup_driver():
     if filegdb_driver is not None:
         filegdb_driver.Deregister()
 
-    yield
+    with gdaltest.config_option(
+        "OGR_OPENFILEGDB_ERROR_ON_INCONSISTENT_BUFFER_MAX_SIZE", "YES"
+    ):
+        yield
 
     if filegdb_driver is not None:
         print("Reregistering FileGDB driver")
@@ -4348,3 +4351,37 @@ def test_ogr_openfilegdb_layer_alias_name():
 
     finally:
         gdal.RmdirRecursive(dirname)
+
+
+###############################################################################
+# Test updating an existing feature with one whose m_nRowBlobLength is
+# larger than m_nHeaderBufferMaxSize
+
+
+def test_ogr_openfilegdb_write_update_feature_larger(tmp_vsimem):
+
+    filename = str(tmp_vsimem / "out.gdb")
+    ds = ogr.GetDriverByName("OpenFileGDB").CreateDataSource(filename)
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(4326)
+    lyr = ds.CreateLayer("test", srs, ogr.wkbLineString)
+    f = ogr.Feature(lyr.GetLayerDefn())
+    g = ogr.Geometry(ogr.wkbLineString)
+    g.SetPoint_2D(10, 0, 0)
+    f.SetGeometry(g)
+    lyr.CreateFeature(f)
+    ds = None
+
+    ds = ogr.Open(filename, update=1)
+    lyr = ds.GetLayer(0)
+    f = lyr.GetNextFeature()
+    g = ogr.Geometry(ogr.wkbLineString)
+    g.SetPoint_2D(999, 0, 0)
+    f.SetGeometry(g)
+    lyr.SetFeature(f)
+    ds = None
+
+    ds = ogr.Open(filename)
+    lyr = ds.GetLayer(0)
+    f = lyr.GetNextFeature()
+    assert f.GetGeometryRef().GetGeometryRef(0).GetPointCount() == 1000

--- a/ogr/ogrsf_frmts/openfilegdb/filegdbtable.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/filegdbtable.cpp
@@ -1493,6 +1493,30 @@ int FileGDBTable::SelectRow(int iRow)
                     m_nRowBlobLength > INT_MAX - ZEROES_AFTER_END_OF_BUFFER,
                 m_nCurRow = -1);
 
+            if (m_nRowBlobLength > m_nHeaderBufferMaxSize)
+            {
+                if (CPLTestBool(CPLGetConfigOption(
+                        "OGR_OPENFILEGDB_ERROR_ON_INCONSISTENT_BUFFER_MAX_SIZE",
+                        "NO")))
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "Invalid row length (%u) on feature %u compared "
+                             "to the maximum size in the header (%u)",
+                             m_nRowBlobLength, iRow + 1,
+                             m_nHeaderBufferMaxSize);
+                    m_nCurRow = -1;
+                    return errorRetValue;
+                }
+                else
+                {
+                    CPLDebug("OpenFileGDB",
+                             "Invalid row length (%u) on feature %u compared "
+                             "to the maximum size in the header (%u)",
+                             m_nRowBlobLength, iRow + 1,
+                             m_nHeaderBufferMaxSize);
+                }
+            }
+
             if (m_nRowBlobLength > m_nRowBufferMaxSize)
             {
                 /* For suspicious row blob length, check if we don't go beyond

--- a/ogr/ogrsf_frmts/openfilegdb/filegdbtable_write.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/filegdbtable_write.cpp
@@ -1845,6 +1845,10 @@ bool FileGDBTable::CreateFeature(const std::vector<OGRField> &asRawFields,
         *pnFID = nObjectID;
 
     m_nRowBlobLength = static_cast<uint32_t>(m_abyBuffer.size());
+    if (m_nRowBlobLength > m_nHeaderBufferMaxSize)
+    {
+        m_nHeaderBufferMaxSize = m_nRowBlobLength;
+    }
     m_nRowBufferMaxSize = std::max(m_nRowBufferMaxSize, m_nRowBlobLength);
     if (nFreeOffset == OFFSET_MINUS_ONE)
     {
@@ -1977,6 +1981,11 @@ bool FileGDBTable::UpdateFeature(int nFID,
             return false;
 
         m_nRowBlobLength = static_cast<uint32_t>(m_abyBuffer.size());
+        if (m_nRowBlobLength > m_nHeaderBufferMaxSize)
+        {
+            m_bDirtyHeader = true;
+            m_nHeaderBufferMaxSize = m_nRowBlobLength;
+        }
         m_nRowBufferMaxSize = std::max(m_nRowBufferMaxSize, m_nRowBlobLength);
         if (nFreeOffset == OFFSET_MINUS_ONE)
         {


### PR DESCRIPTION
When SetFeature() involves generating a row whose blob size is larger than the maximum one in the file, the file header was no properly refreshed. This didn't cause issues to the OpenFileGDB driver, which is robust to that, but ESRI based readers, like ArcMap or the FileGDB SDK, were unable to read such features.

backport of https://github.com/OSGeo/gdal/pull/9400