### PR TITLE
Additional python packaging documentation, version correction

### DIFF
--- a/swig/python/README.rst
+++ b/swig/python/README.rst
@@ -54,10 +54,11 @@ It will be necessary to have libgdal and its development headers installed
 if pip is expected to do a source build because no wheel is available
 for your specified platform and Python version.
 
-To install with numpy support, you need to require the optional numpy component:
+To install with numpy support, you need to require the optional numpy component as well as the Python packaging tools wheel and setuptools:
 
 ::
 
+    pip install wheel setuptools>=67
     pip install gdal[numpy]
 
 To install the version of the Python bindings matching your native GDAL library:

--- a/swig/python/README.rst
+++ b/swig/python/README.rst
@@ -40,17 +40,16 @@ Once you have Anaconda or Miniconda installed, you should be able to install GDA
 pip
 ~~~
 
-GDAL can be installed from the `Python Package Index <https://pypi.org/project/GDAL>`__.
-Due to the complex nature of GDAL and its components, different bindings may require additional packages installation steps.
-The base GDAL package contains support for OGR, OSR, and GDAL vectors:
+Due to the complex nature of GDAL and its components, different bindings may require additional packages and installation steps.
+GDAL can be installed from the `Python Package Index <https://pypi.org/project/GDAL>`__:
 
 ::
 
     pip install gdal
 
 
-In order to enable raster support, libgdal and its development headers must be installed as well as the Python packages numpy, setuptools, and wheel.
-To install the Python dependencies and build raster support:
+In order to enable numpy-based raster support, libgdal and its development headers must be installed as well as the Python packages numpy, setuptools, and wheel.
+To install the Python dependencies and build numpy-based raster support:
 
 
 ::
@@ -59,14 +58,14 @@ To install the Python dependencies and build raster support:
     pip install gdal[numpy]=="$(gdal-config --version).*"
 
 
-Users can verify that reaster support has been installed with:
+Users can verify that numpy-based raster support has been installed with:
 
 ::
     
     python3 -c 'from osgeo import gdal_array'
 
 
-If this command raises an ImportError, raster support has not been properly installed:
+If this command raises an ImportError, numpy-based raster support has not been properly installed:
 
 ::
     

--- a/swig/python/README.rst
+++ b/swig/python/README.rst
@@ -36,36 +36,54 @@ Once you have Anaconda or Miniconda installed, you should be able to install GDA
 
 ``conda install -c conda-forge gdal``
 
-Unix
-~~~~
-
-The GDAL Python bindings requires setuptools.
 
 pip
 ~~~
 
-GDAL can be installed from the `Python Package Index <https://pypi.org/project/GDAL>`__:
+GDAL can be installed from the `Python Package Index <https://pypi.org/project/GDAL>`__.
+Due to the complex nature of GDAL and its components, different bindings may require additional packages installation steps.
+The base GDAL package contains support for OGR, OSR, and GDAL vectors:
 
 ::
 
     pip install gdal
 
-It will be necessary to have libgdal and its development headers installed
-if pip is expected to do a source build because no wheel is available
-for your specified platform and Python version.
 
-To install with numpy support, you need to require the optional numpy component as well as the Python packaging tools wheel and setuptools:
+In order to enable raster support, libgdal and its development headers must be installed as well as the Python packages numpy, setuptools, and wheel.
+To install the Python dependencies and build raster support:
 
-::
-
-    pip install wheel setuptools>=67
-    pip install gdal[numpy]
-
-To install the version of the Python bindings matching your native GDAL library:
 
 ::
 
-    pip install gdal=="$(gdal-config --version).*"
+    pip install numpy>1.0.0 wheel setuptools>=67
+    pip install gdal[numpy]=="$(gdal-config --version).*"
+
+
+Users can verify that reaster support has been installed with:
+
+::
+    
+    python3 -c 'from osgeo import gdal_array'
+
+
+If this command raises an ImportError, raster support has not been properly installed:
+
+::
+    
+    Traceback (most recent call last):
+    File "<string>", line 1, in <module>
+    File "/usr/local/lib/python3.12/dist-packages/osgeo/gdal_array.py", line 10, in <module>
+      from . import _gdal_array
+    ImportError: cannot import name '_gdal_array' from 'osgeo' (/usr/local/lib/python3.12/dist-packages/osgeo/__init__.py)
+
+
+This is most often due to pip reusing a cached GDAL installation.
+Verify that the necessary dependencies have been installed and then run the following to force a clean build:
+
+::
+    pip install --no-cache --force-reinstall gdal[numpy]=="$(gdal-config --version).*"
+
+
 
 Building as part of the GDAL library source tree
 ------------------------------------------------

--- a/swig/python/pyproject.toml
+++ b/swig/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=61.0.0", "oldest-supported-numpy", "wheel"]
+requires = ["setuptools>=67.0.0", "oldest-supported-numpy", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
## What does this PR do?
Updates docs on building numpy support. I've been maintaining [this SO answer on how to fix it](https://stackoverflow.com/a/75669898/6521809) for a year now and I just ran into a new problem installing the numpy bindings. I have tested it and wheel and setuptools cannot be installed alongside gdal[numpy], it must be done before.

There is also a tweak to the version of setuptools in the `pyproject.toml` I determined through experimentation. Pip, or setuptools, or whatever completely ignores this string (happens in my packages, too), but at least it's accurate now. On its own, pip will think >=48 is good enough, which is incredibly wrong for _multiple_ reasons. I'm unaware of a fix, I had the issue back in setuptools 64.

## What are related issues/pull requests?
None

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

ghcr.io/osgeo/gdal:ubuntu-full-3.8.3 with python 3.12.1
Gdal 3.8.4 via homebrew and Python 3.12.2 on Mac