### PR TITLE
Add geotiff as image_format option

### DIFF
--- a/frmts/ogcapi/gdalogcapidataset.cpp
+++ b/frmts/ogcapi/gdalogcapidataset.cpp
@@ -2918,6 +2918,7 @@ void GDALRegister_OGCAPI()
         "       <Value>PNG_PREFERRED</Value>"
         "       <Value>JPEG</Value>"
         "       <Value>JPEG_PREFERRED</Value>"
+        "       <Value>GEOTIFF</Value>"
         "  </Option>"
         "  <Option name='VECTOR_FORMAT' scope='vector' type='string-select' "
         "description='Which format to use for vector data acquisition' "


### PR DESCRIPTION
Add geotiff as supported image_format option to avoid warning message. This is foollow up to https://github.com/OSGeo/gdal/pull/9231