### PR TITLE
gdaltransform/gdallocationinfo: make it output extra content at end of input line, add echo mode and field separator

### DIFF
--- a/apps/gdaltransform.cpp
+++ b/apps/gdaltransform.cpp
@@ -31,6 +31,7 @@
 
 #include <cstdio>
 #include <cstdlib>
+#include <cctype>
 
 #include "cpl_conv.h"
 #include "cpl_error.h"
@@ -65,8 +66,8 @@ static void Usage(bool bIsError, const char *pszErrorMsg = nullptr)
             ">NAME>=<VALUE>]...\n"
             "    [-s_coord_epoch <epoch>] [-t_coord_epoch <epoch>]\n"
             "    [-ct <proj_string>] [-order <n>] [-tps] [-rpc] [-geoloc] \n"
-            "    [-gcp <pixel> <line> <easting> <northing> [elevation]]... "
-            "[-output_xy]\n"
+            "    [-gcp <pixel> <line> <easting> <northing> [elevation]]...\n"
+            "    [-output_xy] [-E] [-field_sep <sep>] [-ignore_extra_input]\n"
             "    [<srcfile> [<dstfile>]]\n"
             "\n");
 
@@ -147,6 +148,9 @@ MAIN_START(argc, argv)
     double dfZ = 0.0;
     double dfT = 0.0;
     bool bCoordOnCommandLine = false;
+    bool bIgnoreExtraInput = false;
+    bool bEchoInput = false;
+    std::string osFieldSep = " ";
 
     /* -------------------------------------------------------------------- */
     /*      Parse arguments.                                                */
@@ -266,6 +270,21 @@ MAIN_START(argc, argv)
         {
             bOutputXY = TRUE;
         }
+        else if (EQUAL(argv[i], "-ignore_extra_input"))
+        {
+            bIgnoreExtraInput = true;
+        }
+        else if (EQUAL(argv[i], "-E"))
+        {
+            bEchoInput = true;
+        }
+        else if (i < argc - 1 && EQUAL(argv[i], "-field_sep"))
+        {
+            osFieldSep = CPLString(argv[++i])
+                             .replaceAll("\\t", '\t')
+                             .replaceAll("\\r", '\r')
+                             .replaceAll("\\n", '\n');
+        }
         else if (EQUAL(argv[i], "-coord") && i + 2 < argc)
         {
             bCoordOnCommandLine = true;
@@ -372,8 +391,10 @@ MAIN_START(argc, argv)
         }
     }
 
+    int nLine = 0;
     while (bCoordOnCommandLine || !feof(stdin))
     {
+        std::string osExtraContent;
         if (!bCoordOnCommandLine)
         {
             char szLine[1024];
@@ -381,26 +402,62 @@ MAIN_START(argc, argv)
             if (fgets(szLine, sizeof(szLine) - 1, stdin) == nullptr)
                 break;
 
-            char **papszTokens = CSLTokenizeString(szLine);
-            const int nCount = CSLCount(papszTokens);
+            const CPLStringList aosTokens(CSLTokenizeString(szLine));
+            const int nCount = aosTokens.size();
 
+            ++nLine;
             if (nCount < 2)
             {
-                CSLDestroy(papszTokens);
+                fprintf(stderr, "Not enough values at line %d\n", nLine);
                 continue;
             }
 
-            dfX = CPLAtof(papszTokens[0]);
-            dfY = CPLAtof(papszTokens[1]);
+            dfX = CPLAtof(aosTokens[0]);
+            dfY = CPLAtof(aosTokens[1]);
+            dfZ = 0.0;
+            dfT = 0.0;
+            int iStartExtraContent = nCount;
             if (nCount >= 3)
-                dfZ = CPLAtof(papszTokens[2]);
-            else
-                dfZ = 0.0;
-            if (nCount == 4)
-                dfT = CPLAtof(papszTokens[3]);
-            else
-                dfT = 0.0;
-            CSLDestroy(papszTokens);
+            {
+                if (CPLGetValueType(aosTokens[2]) == CPL_VALUE_STRING)
+                {
+                    iStartExtraContent = 2;
+                }
+                else
+                {
+                    dfZ = CPLAtof(aosTokens[2]);
+
+                    if (nCount >= 4)
+                    {
+                        if (CPLGetValueType(aosTokens[3]) == CPL_VALUE_STRING)
+                        {
+                            iStartExtraContent = 3;
+                        }
+                        else
+                        {
+                            dfT = CPLAtof(aosTokens[3]);
+                            iStartExtraContent = 4;
+                        }
+                    }
+                }
+            }
+
+            if (!bIgnoreExtraInput)
+            {
+                for (int i = iStartExtraContent; i < nCount; ++i)
+                {
+                    if (!osExtraContent.empty())
+                        osExtraContent += ' ';
+                    osExtraContent += aosTokens[i];
+                }
+                while (!osExtraContent.empty() &&
+                       isspace(static_cast<int>(osExtraContent.back())))
+                {
+                    osExtraContent.pop_back();
+                }
+                if (!osExtraContent.empty())
+                    osExtraContent = osFieldSep + osExtraContent;
+            }
         }
         if (dfT != dfLastT && nGCPCount == 0)
         {
@@ -418,14 +475,29 @@ MAIN_START(argc, argv)
         }
 
         int bSuccess = TRUE;
+        const double dfXBefore = dfX;
+        const double dfYBefore = dfY;
+        const double dfZBefore = dfZ;
         if (pfnTransformer(hTransformArg, bInverse, 1, &dfX, &dfY, &dfZ,
                            &bSuccess) &&
             bSuccess)
         {
+            if (bEchoInput)
+            {
+                if (bOutputXY)
+                    CPLprintf("%.15g%s%.15g%s", dfXBefore, osFieldSep.c_str(),
+                              dfYBefore, osFieldSep.c_str());
+                else
+                    CPLprintf("%.15g%s%.15g%s%.15g%s", dfXBefore,
+                              osFieldSep.c_str(), dfYBefore, osFieldSep.c_str(),
+                              dfZBefore, osFieldSep.c_str());
+            }
             if (bOutputXY)
-                CPLprintf("%.15g %.15g\n", dfX, dfY);
+                CPLprintf("%.15g%s%.15g%s\n", dfX, osFieldSep.c_str(), dfY,
+                          osExtraContent.c_str());
             else
-                CPLprintf("%.15g %.15g %.15g\n", dfX, dfY, dfZ);
+                CPLprintf("%.15g%s%.15g%s%.15g%s\n", dfX, osFieldSep.c_str(),
+                          dfY, osFieldSep.c_str(), dfZ, osExtraContent.c_str());
         }
         else
         {

--- a/autotest/utilities/test_gdallocationinfo.py
+++ b/autotest/utilities/test_gdallocationinfo.py
@@ -161,3 +161,96 @@ def test_gdallocationinfo_wgs84(gdallocationinfo_path):
 
     expected_ret = """115"""
     assert expected_ret in ret
+
+
+###############################################################################
+
+
+def test_gdallocationinfo_field_sep(gdallocationinfo_path):
+
+    ret = gdaltest.runexternal(
+        gdallocationinfo_path + ' -valonly -field_sep "," ../gcore/data/byte.tif',
+        strin="0 0",
+    )
+
+    assert "107" in ret
+    assert "," not in ret
+
+    ret = gdaltest.runexternal(
+        gdallocationinfo_path + ' -valonly -field_sep "," ../gcore/data/rgbsmall.tif',
+        strin="15 16",
+    )
+
+    assert "72,102,16" in ret
+
+
+###############################################################################
+
+
+def test_gdallocationinfo_extra_input(gdallocationinfo_path):
+
+    ret = gdaltest.runexternal(
+        gdallocationinfo_path + " ../gcore/data/byte.tif", strin="0 0 foo bar"
+    )
+
+    assert "Extra input: foo bar" in ret
+
+    ret = gdaltest.runexternal(
+        gdallocationinfo_path + " -valonly ../gcore/data/byte.tif", strin="0 0 foo bar"
+    )
+
+    assert "107" in ret
+    assert "foo bar" not in ret
+
+    ret = gdaltest.runexternal(
+        gdallocationinfo_path + ' -valonly -field_sep "," ../gcore/data/byte.tif',
+        strin="0 0 foo bar",
+    )
+
+    assert "107,foo bar" in ret
+
+    ret = gdaltest.runexternal(
+        gdallocationinfo_path + " -xml ../gcore/data/byte.tif", strin="0 0 foo bar"
+    )
+
+    assert "<ExtraInput>foo bar</ExtraInput>" in ret
+
+
+###############################################################################
+
+
+def test_gdallocationinfo_extra_input_ignored(gdallocationinfo_path):
+
+    ret = gdaltest.runexternal(
+        gdallocationinfo_path
+        + ' -valonly -field_sep "," -ignore_extra_input ../gcore/data/byte.tif',
+        strin="0 0 foo bar",
+    )
+
+    assert "107" in ret
+    assert "foo bar" not in ret
+
+
+###############################################################################
+# Test echo mode
+
+
+def test_gdallocationinfo_echo(gdallocationinfo_path):
+
+    _, err = gdaltest.runexternal_out_and_err(
+        gdallocationinfo_path + " -E ../gcore/data/byte.tif 1 2"
+    )
+    assert "-E can only be used with -valonly" in err
+
+    _, err = gdaltest.runexternal_out_and_err(
+        gdallocationinfo_path + " -E -valonly ../gcore/data/byte.tif 1 2"
+    )
+    assert (
+        "-E can only be used if -field_sep is specified (to a non-newline value)" in err
+    )
+
+    ret = gdaltest.runexternal(
+        gdallocationinfo_path + ' -E -valonly -field_sep "," ../gcore/data/byte.tif',
+        strin="1 2",
+    )
+    assert "1,2,132" in ret

--- a/autotest/utilities/test_gdaltransform.py
+++ b/autotest/utilities/test_gdaltransform.py
@@ -285,3 +285,60 @@ def test_gdaltransform_s_t_coord_epoch(gdaltransform_path):
     assert len(values) == 3, ret
     assert abs(values[0] - -79.499999630188) < 1e-8, ret
     assert abs(values[1] - 60.4999999378478) < 1e-8, ret
+
+
+###############################################################################
+# Test extra input
+
+
+def test_gdaltransform_extra_input(gdaltransform_path):
+
+    strin = (
+        "2 49 1 my first point\n" + "3 50 second point\n" + "4 51 10 2 third point\n"
+    )
+    ret = gdaltest.runexternal(
+        gdaltransform_path + " -field_sep ,",
+        strin,
+    )
+
+    assert "2,49,1,my first point" in ret
+    assert "3,50,0,second point" in ret
+    assert "4,51,10,third point" in ret
+
+
+###############################################################################
+# Test ignoring extra input
+
+
+def test_gdaltransform_extra_input_ignored(gdaltransform_path):
+
+    strin = "2 49 1 my first point\n"
+    ret = gdaltest.runexternal(
+        gdaltransform_path + " -ignore_extra_input",
+        strin,
+    )
+
+    assert "my first point" not in ret
+
+
+###############################################################################
+# Test echo mode
+
+
+def test_gdaltransform_echo(gdaltransform_path):
+
+    strin = "0 0 1 my first point\n"
+
+    ret = gdaltest.runexternal(
+        gdaltransform_path + " -s_srs EPSG:4326 -t_srs EPSG:4978 -E -field_sep ,",
+        strin,
+    )
+
+    assert "0,0,1,6378138,0,0,my first point" in ret
+
+    ret = gdaltest.runexternal(
+        gdaltransform_path + " -s_srs EPSG:4326 -t_srs EPSG:4978 -E -output_xy",
+        strin,
+    )
+
+    assert "0 0 6378138 0 my first point" in ret

--- a/doc/source/programs/gdallocationinfo.rst
+++ b/doc/source/programs/gdallocationinfo.rst
@@ -17,6 +17,7 @@ Synopsis
 
     Usage: gdallocationinfo [--help] [--help-general]
                             [-xml] [-lifonly] [-valonly]
+                            [-E] [-field_sep <sep>] [-ignore_extra_input]
                             [-b <band>]... [-overview <overview_level>]
                             [-l_srs <srs_def>] [-geoloc] [-wgs84]
                             [-oo <NAME>=<VALUE>]... <srcfile> [<x> <y>]
@@ -45,7 +46,8 @@ reporting options are provided.
 .. option:: -valonly
 
     The only output is the pixel values of the selected pixel on each of
-    the selected bands.
+    the selected bands. By default, the value of each band is output on a
+    separate line, unless :option:`-field_sep` is specified.
 
 .. option:: -b <band>
 
@@ -73,6 +75,32 @@ reporting options are provided.
 .. option:: -oo <NAME>=<VALUE>
 
     Dataset open option (format specific)
+
+.. option:: -ignore_extra_input
+
+    .. versionadded:: 3.9
+
+    Set this flag to avoid extra non-numeric content at end of input lines to be
+    appended to the output lines in -valonly mode (requires :option:`-field_sep`
+    to be also defined), or as a dedicated field in default or :option:`-xml` modes.
+
+.. option:: -E
+
+    .. versionadded:: 3.9
+
+    Enable Echo mode, where input coordinates are prepended to the output lines
+    in :option:`-valonly` mode.
+
+.. option:: -field_sep <sep>
+
+    .. versionadded:: 3.9
+
+    Defines the field separator, used in :option:`-valonly` mode, to separate different values.
+    It defaults to the new-line character, which means that when querying
+    a raster with several bands, the output will contain one value per line, which
+    may make it hard to recognize which value belongs to which set of input x,y
+    points when several ones are provided. Defining the field separator is also
+    needed
 
 .. option:: <srcfile>
 
@@ -165,3 +193,8 @@ Reading location from stdin.
       Location: (52P,59L)
       Band 1:
         Value: 148
+
+    $ cat coordinates.txt | gdallocationinfo -geoloc -valonly -E -field_sep , utmsmall.tif
+    443020,3748359,214
+    441197,3749005,107
+    443852,3747743,148

--- a/doc/source/programs/gdaltransform.rst
+++ b/doc/source/programs/gdaltransform.rst
@@ -19,7 +19,8 @@ Synopsis
         [-i] [-s_srs <srs_def>] [-t_srs <srs_def>] [-to <NAME>=<VALUE>]...
         [-s_coord_epoch <epoch>] [-t_coord_epoch <epoch>]
         [-ct <proj_string>] [-order <n>] [-tps] [-rpc] [-geoloc]
-        [-gcp <pixel> <line> <easting> <northing> [elevation]]... [-output_xy]
+        [-gcp <pixel> <line> <easting> <northing> [elevation]]...
+        [-output_xy] [-E] [-field_sep <sep>] [-ignore_extra_input]
         [<srcfile> [<dstfile>]]
 
 
@@ -114,6 +115,26 @@ projection,including GCP-based transformations.
 
     Restrict output to "x y" instead of "x y z"
 
+.. option:: -ignore_extra_input
+
+    .. versionadded:: 3.9
+
+    Set this flag to avoid extra non-numeric content at end of input lines to be
+    appended to the output lines.
+
+.. option:: -E
+
+    .. versionadded:: 3.9
+
+    Enable Echo mode, where input coordinates are prepended to the output lines.
+
+.. option:: -field_sep <sep>
+
+    .. versionadded:: 3.9
+
+    Defines the field separator, to separate different values.
+    It defaults to the space character.
+
 .. option:: <srcfile>
 
     Raster dataset with source projection definition or GCPs. If
@@ -130,6 +151,10 @@ Coordinates are read as pairs, triples (for 3D,) or (since GDAL 3.0.0,) quadrupl
 (for X,Y,Z,time) of numbers per line from standard
 input, transformed, and written out to standard output in the same way. All
 transformations offered by gdalwarp are handled, including gcp-based ones.
+
+Starting with GDAL 3.9, additional non-numeric content (typically point name)
+at the end of an input line will also be appended to the output line, unless
+the :option:`-ignore_extra_input` is added.
 
 Note that input and output must always be in decimal form.  There is currently
 no support for DMS input or output.
@@ -194,7 +219,7 @@ for a coordinate at epoch 2000.0
     +proj=unitconvert +xy_in=rad +xy_out=deg"
     2 49 0 2000
 
-Produces this output measured in longitude degrees, latitude degrees and ellipsoid height in metres:
+Produces this output measured in longitude degrees, latitude degrees and ellipsoid height in meters:
 
 .. code-block:: bash
 
@@ -208,9 +233,9 @@ some nearby corners' coordinates?
 
 .. code-block:: bash
 
-    echo 300 -370 | gdaltransform \
+    echo 300 -370 my address | gdaltransform \
     -gcp 0   -500 -111.89114803 40.75846686 \
     -gcp 0   0    -111.89114717 40.76932606 \
     -gcp 500 0    -111.87685039 40.76940631
 
-    -111.8825697384 40.761338402 0
+    -111.8825697384 40.761338402 0 my address


### PR DESCRIPTION
Fixes #9411

- gdaltransform: make it output extra content at end of input line (unless -ignore_extra_input), and add -E echo mode, and -field_sep option
- gdallocationinfo: make it output extra content at end of input line (unless -ignore_extra_input), and add -E echo mode, and -field_sep option