### PR TITLE
gdaldriver: Don't Lose papszOpenOptions

### DIFF
--- a/gcore/gdaldriver.cpp
+++ b/gcore/gdaldriver.cpp
@@ -1049,7 +1049,8 @@ CPLErr GDALDriver::QuietDeleteForCreateCopy(const char *pszFilename,
                                      : nullptr,
                 nullptr};
             auto poSrcDSTmp = std::unique_ptr<GDALDataset>(GDALDataset::Open(
-                poSrcDS->GetDescription(), GDAL_OF_RASTER, apszAllowedDrivers));
+                poSrcDS->GetDescription(), GDAL_OF_RASTER, apszAllowedDrivers,
+                poSrcDS->papszOpenOptions));
             if (poSrcDSTmp)
             {
                 char **papszFileList = poSrcDSTmp->GetFileList();


### PR DESCRIPTION
When using gdal_translate, the source datasource is opened twice. However, the second time does not use any open options specified when orginally opening the data soruce. This is a probelm for OGC Tile data sources if the user specified TILEMATRIXSET or TILEMATRIX because the driver will default to WorldCRS84Quad even when that is not what was originally specified or to a different zoom level.

For example,  if you request TILEMATRIXSET="foo" then gdal open will the correct tilematrixset definition on the first open, but on the second open it will instead load the definition for the WorldCRS84Quad tilematrixset (assuming it is a listed tilematrixset).

This PR fixes the issue by passing `poSrcDS->papszOpenOptions` to the newly opened datasource.