### PR TITLE
VRTWarpedDataset: add an optimized IRasterIO() implementation

### DIFF
--- a/alg/gdalwarper.h
+++ b/alg/gdalwarper.h
@@ -507,13 +507,6 @@ class CPL_DLL GDALWarpOperation
         double &dfMinXOut, double &dfMinYOut, double &dfMaxXOut,
         double &dfMaxYOut, int &nSamplePoints, int &nFailedCount);
 
-    CPLErr ComputeSourceWindow(int nDstXOff, int nDstYOff, int nDstXSize,
-                               int nDstYSize, int *pnSrcXOff, int *pnSrcYOff,
-                               int *pnSrcXSize, int *pnSrcYSize,
-                               double *pdfSrcXExtraSize,
-                               double *pdfSrcYExtraSize,
-                               double *pdfSrcFillRatio);
-
     void ComputeSourceWindowStartingFromSource(int nDstXOff, int nDstYOff,
                                                int nDstXSize, int nDstYSize,
                                                double *padfSrcMinX,
@@ -584,6 +577,18 @@ class CPL_DLL GDALWarpOperation
                               int nSrcYOff, int nSrcXSize, int nSrcYSize,
                               double dfSrcXExtraSize, double dfSrcYExtraSize,
                               double dfProgressBase, double dfProgressScale);
+
+  protected:
+    friend class VRTWarpedDataset;
+    CPLErr ComputeSourceWindow(int nDstXOff, int nDstYOff, int nDstXSize,
+                               int nDstYSize, int *pnSrcXOff, int *pnSrcYOff,
+                               int *pnSrcXSize, int *pnSrcYSize,
+                               double *pdfSrcXExtraSize,
+                               double *pdfSrcYExtraSize,
+                               double *pdfSrcFillRatio);
+
+    double GetWorkingMemoryForWindow(int nSrcXSize, int nSrcYSize,
+                                     int nDstXSize, int nDstYSize) const;
 };
 
 #endif /* def __cplusplus */

--- a/autotest/gdrivers/vrtwarp.py
+++ b/autotest/gdrivers/vrtwarp.py
@@ -670,3 +670,65 @@ def test_vrtwarp_float32_max_nodata(nodata):
     finally:
         gdal.Unlink(in_filename)
         gdal.Unlink(out_filename)
+
+
+###############################################################################
+# Test VRTWarpedDataset::IRasterIO() code path
+
+
+def test_vrtwarp_irasterio_optim_single_band():
+
+    src_ds = gdal.Translate("", "data/byte.tif", format="MEM", width=1000)
+    warped_vrt_ds = gdal.Warp("", src_ds, format="VRT")
+
+    with gdaltest.config_option("GDAL_VRT_WARP_USE_DATASET_RASTERIO", "NO"):
+        expected_data = warped_vrt_ds.ReadRaster()
+
+    assert warped_vrt_ds.ReadRaster() == expected_data
+    assert warped_vrt_ds.GetRasterBand(1).ReadRaster() == expected_data
+
+
+###############################################################################
+# Test VRTWarpedDataset::IRasterIO() code path
+
+
+def test_vrtwarp_irasterio_optim_three_band():
+
+    src_ds = gdal.Translate("", "data/rgbsmall.tif", format="MEM", width=1000)
+    warped_vrt_ds = gdal.Warp("", src_ds, format="VRT")
+
+    with gdaltest.config_option("GDAL_VRT_WARP_USE_DATASET_RASTERIO", "NO"):
+        expected_data = warped_vrt_ds.ReadRaster()
+    assert warped_vrt_ds.ReadRaster() == expected_data
+
+    with gdaltest.config_option("GDAL_VRT_WARP_USE_DATASET_RASTERIO", "NO"):
+        expected_data = warped_vrt_ds.ReadRaster(band_list=[3, 2, 1])
+    assert warped_vrt_ds.ReadRaster(band_list=[3, 2, 1]) == expected_data
+
+    with gdaltest.config_option("GDAL_VRT_WARP_USE_DATASET_RASTERIO", "NO"):
+        expected_data = warped_vrt_ds.ReadRaster(band_list=[1, 2, 1])
+    assert warped_vrt_ds.ReadRaster(band_list=[1, 2, 1]) == expected_data
+
+    with gdaltest.config_option("GDAL_VRT_WARP_USE_DATASET_RASTERIO", "NO"):
+        expected_data = warped_vrt_ds.ReadRaster(buf_type=gdal.GDT_UInt16)
+    assert warped_vrt_ds.ReadRaster(buf_type=gdal.GDT_UInt16) == expected_data
+
+    with gdaltest.config_option("GDAL_VRT_WARP_USE_DATASET_RASTERIO", "NO"):
+        expected_data = warped_vrt_ds.ReadRaster(buf_xsize=20, buf_ysize=20)
+    assert warped_vrt_ds.ReadRaster(buf_xsize=20, buf_ysize=20) == expected_data
+
+
+###############################################################################
+# Test VRTWarpedDataset::IRasterIO() code path
+
+
+def test_vrtwarp_irasterio_optim_window_splitting():
+
+    src_ds = gdal.Translate(
+        "", "data/rgbsmall.tif", format="MEM", width=1000, height=2000
+    )
+    warped_vrt_ds = gdal.Warp("", src_ds, format="VRT", warpMemoryLimit=1)  # 1 MB
+
+    with gdaltest.config_option("GDAL_VRT_WARP_USE_DATASET_RASTERIO", "NO"):
+        expected_data = warped_vrt_ds.ReadRaster()
+    assert warped_vrt_ds.ReadRaster() == expected_data

--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -426,6 +426,14 @@ class CPL_DLL VRTWarpedDataset final : public VRTDataset
 
     virtual char **GetFileList() override;
 
+    virtual CPLErr IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
+                             int nXSize, int nYSize, void *pData, int nBufXSize,
+                             int nBufYSize, GDALDataType eBufType,
+                             int nBandCount, int *panBandMap,
+                             GSpacing nPixelSpace, GSpacing nLineSpace,
+                             GSpacing nBandSpace,
+                             GDALRasterIOExtraArg *psExtraArg) override;
+
     CPLErr ProcessBlock(int iBlockX, int iBlockY);
 
     void GetBlockSize(int *, int *) const;
@@ -819,8 +827,18 @@ class CPL_DLL VRTWarpedRasterBand final : public VRTRasterBand
     virtual CPLErr IReadBlock(int, int, void *) override;
     virtual CPLErr IWriteBlock(int, int, void *) override;
 
+    virtual CPLErr IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
+                             int nXSize, int nYSize, void *pData, int nBufXSize,
+                             int nBufYSize, GDALDataType eBufType,
+                             GSpacing nPixelSpace, GSpacing nLineSpace,
+                             GDALRasterIOExtraArg *psExtraArg) override;
+
     virtual int GetOverviewCount() override;
     virtual GDALRasterBand *GetOverview(int) override;
+
+  private:
+    int m_nIRasterIOCounter =
+        0;  //! Protects against infinite recursion inside IRasterIO()
 };
 /************************************************************************/
 /*                        VRTPansharpenedRasterBand                     */


### PR DESCRIPTION
This specialized implementation of IRasterIO() will be faster than using the VRTWarpedRasterBand::IReadBlock() method in situations where
- a large enough chunk of data is requested at once
- and multi-threaded warping is enabled (it only kicks in if the warped chunk is large enough) and/or when reading the source dataset is multi-threaded (e.g JP2KAK or JP2OpenJPEG driver).

e.g. with a 3909x3154 4-band UInt16 input JPEG2000 source dataset:

```
$ gdalwarp -overwrite -t_srs EPSG:4326 -r cubic -wo NUM_THREADS=12 input.jp2 test.vrt
Creating output file that is 3909P x 3154L.
```

Now:
```
$ time GDAL_SKIP=JP2KAK,JP2ECW gdal_translate test.vrt out.tif -co tiled=yes
Input file size is 3909, 3154
0...10...20...30...40...50...60...70...80...90...100 - done.

real    0m1,624s
user    0m11,910s
sys     0m0,270s
```

Before (or disabling the optimization):
```
$ time GDAL_VRT_WARP_USE_DATASET_RASTERIO=NO GDAL_SKIP=JP2KAK,JP2ECW gdal_translate test.vrt out.tif -co tiled=yes
Input file size is 3909, 3154
0...10...20...30...40...50...60...70...80...90...100 - done.

real    0m4,115s
user    0m9,934s
sys     0m0,218s
```
