### PR TITLE
[Backport 3.8] Overview/RasterIO resampling: fix infinite looping when nodata has a big absolute value (#9428)

### DIFF
--- a/autotest/gcore/rasterio.py
+++ b/autotest/gcore/rasterio.py
@@ -1265,14 +1265,14 @@ nodata_value 0
         buf_xsize=1, buf_ysize=1, resample_alg=gdal.GRIORA_Lanczos
     )
     data_ar = struct.unpack("f" * 1, data)
-    expected_ar = (1.1754943508222875e-38,)
+    expected_ar = (1.401298464324817e-45,)
     assert data_ar == expected_ar
 
     data = ds.GetRasterBand(1).ReadRaster(
         buf_xsize=1, buf_ysize=1, resample_alg=gdal.GRIORA_Average
     )
     data_ar = struct.unpack("f" * 1, data)
-    expected_ar = (1.1754943508222875e-38,)
+    expected_ar = (1.401298464324817e-45,)
     assert data_ar == expected_ar
 
     gdal.Unlink("/vsimem/in.asc")

--- a/gcore/gdal_priv_templates.hpp
+++ b/gcore/gdal_priv_templates.hpp
@@ -103,6 +103,34 @@ inline T GDALClampValue(const T tValue, const T tMax, const T tMin)
 }
 
 /************************************************************************/
+/*                          GDALClampDoubleValue()                            */
+/************************************************************************/
+/**
+ * Clamp double values to a specified range, this uses the same
+ * argument ordering as std::clamp, returns TRUE if the value was clamped.
+ *
+ * @param tValue the value
+ * @param tMin the min value
+ * @param tMax the max value
+ *
+ */
+template <class T2, class T3>
+inline bool GDALClampDoubleValue(double &tValue, const T2 tMin, const T3 tMax)
+{
+    const double tMin2{static_cast<double>(tMin)};
+    const double tMax2{static_cast<double>(tMax)};
+    if (tValue > tMax2 || tValue < tMin2)
+    {
+        tValue = tValue > tMax2 ? tMax2 : tValue < tMin2 ? tMin2 : tValue;
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}
+
+/************************************************************************/
 /*                         GDALIsValueInRange()                         */
 /************************************************************************/
 /**
@@ -114,7 +142,7 @@ inline T GDALClampValue(const T tValue, const T tMax, const T tMin)
  */
 template <class T> inline bool GDALIsValueInRange(double dfValue)
 {
-    return dfValue >= static_cast<double>(std::numeric_limits<T>::min()) &&
+    return dfValue >= static_cast<double>(std::numeric_limits<T>::lowest()) &&
            dfValue <= static_cast<double>(std::numeric_limits<T>::max());
 }
 

--- a/gcore/overview.cpp
+++ b/gcore/overview.cpp
@@ -246,100 +246,202 @@ std::vector<GDALColorEntry> ReadColorTable(const GDALColorTable &table,
 }  // unnamed  namespace
 
 /************************************************************************/
-/*                    GetReplacementValueIfNoData()                     */
+/*                      GDALGetNoDataReplacementValue()                 */
 /************************************************************************/
 
-static double GetReplacementValueIfNoData(GDALDataType dt, bool bHasNoData,
-                                          double dfNoDataValue)
+/**
+ * \brief Returns a replacement value for a nodata value or 0 if dfNoDataValue
+ *        is out of range for the specified data type (dt).
+ *        For UInt64 and Int64 data type this function cannot reliably trusted
+ *        because their nodata values might not always be representable exactly
+ *        as a double, in particular the maximum absolute value for those types
+ *        is 2^53.
+ *
+ * The replacement value is a value that can be used in a computation
+ * whose result would match by accident the nodata value, whereas it is
+ * meant to be valid. For example, for a dataset with a nodata value of 0,
+ * when averaging -1 and 1, one would get normally a value of 0. The
+ * replacement nodata value can then be substituted to that 0 value to still
+ * get a valid value, as close as practical to the true value, while being
+ * different from the nodata value.
+ *
+ * @param dt Data type
+ * @param dfNoDataValue The no data value
+
+ * @since GDAL 3.9
+ */
+static double GDALGetNoDataReplacementValue(GDALDataType dt,
+                                            double dfNoDataValue)
 {
-    double dfReplacementVal = 0.0f;
-    if (bHasNoData)
+
+    // The logic here is to check if the value is out of range for the
+    // specified data type and return a replacement value if it is, return
+    // 0 otherwise.
+    double dfReplacementVal = dfNoDataValue;
+    if (dt == GDT_Byte)
     {
-        if (dt == GDT_Byte)
+        if (GDALClampDoubleValue(dfNoDataValue,
+                                 std::numeric_limits<uint8_t>::lowest(),
+                                 std::numeric_limits<uint8_t>::max()))
         {
-            if (dfNoDataValue == std::numeric_limits<unsigned char>::max())
-                dfReplacementVal =
-                    std::numeric_limits<unsigned char>::max() - 1;
-            else
-                dfReplacementVal = dfNoDataValue + 1;
+            return 0;
         }
-        else if (dt == GDT_Int8)
-        {
-            if (dfNoDataValue == std::numeric_limits<GInt8>::max())
-                dfReplacementVal = std::numeric_limits<GInt8>::max() - 1;
-            else
-                dfReplacementVal = dfNoDataValue + 1;
-        }
-        else if (dt == GDT_UInt16)
-        {
-            if (dfNoDataValue == std::numeric_limits<GUInt16>::max())
-                dfReplacementVal = std::numeric_limits<GUInt16>::max() - 1;
-            else
-                dfReplacementVal = dfNoDataValue + 1;
-        }
-        else if (dt == GDT_Int16)
-        {
-            if (dfNoDataValue == std::numeric_limits<GInt16>::max())
-                dfReplacementVal = std::numeric_limits<GInt16>::max() - 1;
-            else
-                dfReplacementVal = dfNoDataValue + 1;
-        }
-        else if (dt == GDT_UInt32)
-        {
-            // Be careful to limited precision of float
+        if (dfNoDataValue == std::numeric_limits<unsigned char>::max())
+            dfReplacementVal = std::numeric_limits<unsigned char>::max() - 1;
+        else
             dfReplacementVal = dfNoDataValue + 1;
-            double dfVal = dfNoDataValue;
-            if (dfReplacementVal >= std::numeric_limits<GUInt32>::max() - 128)
-            {
-                while (dfReplacementVal == dfNoDataValue)
-                {
-                    dfVal -= 1.0;
-                    dfReplacementVal = dfVal;
-                }
-            }
-            else
-            {
-                while (dfReplacementVal == dfNoDataValue)
-                {
-                    dfVal += 1.0;
-                    dfReplacementVal = dfVal;
-                }
-            }
-        }
-        else if (dt == GDT_Int32)
+    }
+    else if (dt == GDT_Int8)
+    {
+        if (GDALClampDoubleValue(dfNoDataValue,
+                                 std::numeric_limits<int8_t>::lowest(),
+                                 std::numeric_limits<int8_t>::max()))
         {
-            // Be careful to limited precision of float
+            return 0;
+        }
+        if (dfNoDataValue == std::numeric_limits<GInt8>::max())
+            dfReplacementVal = std::numeric_limits<GInt8>::max() - 1;
+        else
             dfReplacementVal = dfNoDataValue + 1;
-            double dfVal = dfNoDataValue;
-            if (dfReplacementVal >= std::numeric_limits<GInt32>::max() - 64)
-            {
-                while (dfReplacementVal == dfNoDataValue)
-                {
-                    dfVal -= 1.0;
-                    dfReplacementVal = dfVal;
-                }
-            }
-            else
-            {
-                while (dfReplacementVal == dfNoDataValue)
-                {
-                    dfVal += 1.0;
-                    dfReplacementVal = dfVal;
-                }
-            }
-        }
-        else if (dt == GDT_Float32 || dt == GDT_Float64)
+    }
+    else if (dt == GDT_UInt16)
+    {
+        if (GDALClampDoubleValue(dfNoDataValue,
+                                 std::numeric_limits<uint16_t>::lowest(),
+                                 std::numeric_limits<uint16_t>::max()))
         {
-            if (dfNoDataValue == 0)
-            {
-                dfReplacementVal = std::numeric_limits<float>::min();
-            }
-            else
-            {
-                dfReplacementVal = dfNoDataValue + 1e-7 * dfNoDataValue;
-            }
+            return 0;
+        }
+        if (dfNoDataValue == std::numeric_limits<GUInt16>::max())
+            dfReplacementVal = std::numeric_limits<GUInt16>::max() - 1;
+        else
+            dfReplacementVal = dfNoDataValue + 1;
+    }
+    else if (dt == GDT_Int16)
+    {
+        if (GDALClampDoubleValue(dfNoDataValue,
+                                 std::numeric_limits<int16_t>::lowest(),
+                                 std::numeric_limits<int16_t>::max()))
+        {
+            return 0;
+        }
+        if (dfNoDataValue == std::numeric_limits<GInt16>::max())
+            dfReplacementVal = std::numeric_limits<GInt16>::max() - 1;
+        else
+            dfReplacementVal = dfNoDataValue + 1;
+    }
+    else if (dt == GDT_UInt32)
+    {
+        if (GDALClampDoubleValue(dfNoDataValue,
+                                 std::numeric_limits<uint32_t>::lowest(),
+                                 std::numeric_limits<uint32_t>::max()))
+        {
+            return 0;
+        }
+        if (dfNoDataValue == std::numeric_limits<GUInt32>::max())
+            dfReplacementVal = std::numeric_limits<GUInt32>::max() - 1;
+        else
+            dfReplacementVal = dfNoDataValue + 1;
+    }
+    else if (dt == GDT_Int32)
+    {
+        if (GDALClampDoubleValue(dfNoDataValue,
+                                 std::numeric_limits<int32_t>::lowest(),
+                                 std::numeric_limits<int32_t>::max()))
+        {
+            return 0;
+        }
+        if (dfNoDataValue == std::numeric_limits<int32_t>::max())
+            dfReplacementVal = std::numeric_limits<int32_t>::max() - 1;
+        else
+            dfReplacementVal = dfNoDataValue + 1;
+    }
+    else if (dt == GDT_UInt64)
+    {
+        // Implicit conversion from 'unsigned long' to 'double' changes value from 18446744073709551615 to 18446744073709551616
+        // so we take the next lower value representable as a double 18446744073709549567
+        static const double dfMaxUInt64Value{
+            std::nextafter(
+                static_cast<double>(std::numeric_limits<uint64_t>::max()), 0) -
+            1};
+
+        if (GDALClampDoubleValue(dfNoDataValue,
+                                 std::numeric_limits<uint64_t>::lowest(),
+                                 std::numeric_limits<uint64_t>::max()))
+        {
+            return 0;
+        }
+
+        if (dfNoDataValue >=
+            static_cast<double>(std::numeric_limits<uint64_t>::max()))
+            dfReplacementVal = dfMaxUInt64Value;
+        else
+            dfReplacementVal = dfNoDataValue + 1;
+    }
+    else if (dt == GDT_Int64)
+    {
+        // Implicit conversion from 'long' to 'double' changes value from 9223372036854775807 to 9223372036854775808
+        // so we take the next lower value representable as a double 9223372036854774784
+        static const double dfMaxInt64Value{
+            std::nextafter(
+                static_cast<double>(std::numeric_limits<int64_t>::max()), 0) -
+            1};
+
+        if (GDALClampDoubleValue(dfNoDataValue,
+                                 std::numeric_limits<int64_t>::lowest(),
+                                 std::numeric_limits<int64_t>::max()))
+        {
+            return 0;
+        }
+
+        if (dfNoDataValue >=
+            static_cast<double>(std::numeric_limits<int64_t>::max()))
+            dfReplacementVal = dfMaxInt64Value;
+        else
+            dfReplacementVal = dfNoDataValue + 1;
+    }
+    else if (dt == GDT_Float32)
+    {
+
+        if (GDALClampDoubleValue(dfNoDataValue,
+                                 std::numeric_limits<float>::lowest(),
+                                 std::numeric_limits<float>::max()))
+        {
+            return 0;
+        }
+
+        if (dfNoDataValue == std::numeric_limits<float>::max())
+        {
+            dfReplacementVal =
+                std::nextafter(static_cast<float>(dfNoDataValue), 0.0f);
+        }
+        else
+        {
+            dfReplacementVal =
+                std::nextafter(static_cast<float>(dfNoDataValue),
+                               std::numeric_limits<float>::max());
         }
     }
+    else if (dt == GDT_Float64)
+    {
+        if (GDALClampDoubleValue(dfNoDataValue,
+                                 std::numeric_limits<double>::lowest(),
+                                 std::numeric_limits<double>::max()))
+        {
+            return 0;
+        }
+
+        if (dfNoDataValue == std::numeric_limits<double>::max())
+        {
+            dfReplacementVal = std::nextafter(dfNoDataValue, 0.0f);
+        }
+        else
+        {
+            dfReplacementVal = std::nextafter(
+                dfNoDataValue, std::numeric_limits<double>::max());
+        }
+    }
+
     return dfReplacementVal;
 }
 
@@ -1229,8 +1331,10 @@ static CPLErr GDALResampleChunk_AverageOrRMS_T(
         tNoDataValue = 0;
     else
         tNoDataValue = static_cast<T>(dfNoDataValue);
-    const T tReplacementVal = static_cast<T>(GetReplacementValueIfNoData(
-        poOverview->GetRasterDataType(), bHasNoData, dfNoDataValue));
+    const T tReplacementVal = static_cast<T>(
+        bHasNoData ? GDALGetNoDataReplacementValue(
+                         poOverview->GetRasterDataType(), dfNoDataValue)
+                   : dfNoDataValue);
 
     int nChunkRightXOff = nChunkXOff + nChunkXSize;
     int nChunkBottomYOff = nChunkYOff + nChunkYSize;
@@ -3094,7 +3198,8 @@ static CPLErr GDALResampleChunk_ConvolutionT(
     const auto dstDataType = poDstBand->GetRasterDataType();
     const int nDstDataTypeSize = GDALGetDataTypeSizeBytes(dstDataType);
     const double dfReplacementVal =
-        GetReplacementValueIfNoData(dstDataType, bHasNoData, dfNoDataValue);
+        bHasNoData ? GDALGetNoDataReplacementValue(dstDataType, dfNoDataValue)
+                   : dfNoDataValue;
     // cppcheck-suppress unreadVariable
     const int isIntegerDT = GDALDataTypeIsInteger(dstDataType);
     const auto nNodataValueInt64 = static_cast<GInt64>(dfNoDataValue);


### PR DESCRIPTION
Fix #9427

Backport of https://github.com/OSGeo/gdal/pull/9428, whose main change is to avoid to make the new function a public one to avoid extending the API.