### PR TITLE
Use p-ranav/argparse framework for command line argument parsing

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,6 +39,7 @@ repos:
                 third_party/|
                 autotest/ogr/data/|
                 alg/internal_libqhull/|
+                apps/argparse/|
                 frmts/gtiff/libtiff/|
                 frmts/gtiff/libgeotiff/|
                 frmts/hdf4/hdf-eos/|

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(
   appslib OBJECT
   commonutils.h
   gdal_utils.h
+  gdalargumentparser.cpp
   gdalinfo_lib.cpp
   gdalbuildvrt_lib.cpp
   gdal_grid_lib.cpp
@@ -78,6 +79,11 @@ if (BUILD_APPS)
 
   add_executable(sozip sozip.cpp)
 
+  add_library(utils_common OBJECT gdalargumentparser.cpp)
+  gdal_standard_includes(utils_common)
+  target_compile_options(utils_common PRIVATE ${GDAL_CXX_WARNING_FLAGS} ${WFLAG_OLD_STYLE_CAST})
+  add_dependencies(utils_common generate_gdal_version_h)
+
   set(APPS_TARGETS
       gdalinfo
       gdalbuildvrt
@@ -140,7 +146,7 @@ if (BUILD_APPS)
     if (MSVC OR MINGW)
       target_compile_definitions(${UTILCMD} PRIVATE -DSUPPORTS_WMAIN)
     endif ()
-    target_link_libraries(${UTILCMD} PRIVATE $<TARGET_NAME:${GDAL_LIB_TARGET_NAME}>)
+    target_link_libraries(${UTILCMD} PRIVATE $<TARGET_NAME:${GDAL_LIB_TARGET_NAME}> utils_common)
   endforeach ()
   install(TARGETS ${APPS_TARGETS} RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 

--- a/apps/argparse/.clang-format
+++ b/apps/argparse/.clang-format
@@ -1,0 +1,117 @@
+---
+Language:        Cpp
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: false
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeInheritanceComma: false
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: true
+ForEachMacros:
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories:
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: false
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Right
+RawStringFormats:
+  - Language: TextProto
+    Delimiters:
+      - 'pb'
+      - 'proto'
+    BasedOnStyle: google
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        c++17
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/apps/argparse/README.TXT
+++ b/apps/argparse/README.TXT
@@ -1,0 +1,3 @@
+Provenance: https://github.com/p-ranav/argparse
+
+Retrieved from https://github.com/p-ranav/argparse/blob/a1c41c5537c919c1a56661ec1cdf5a49b9e99af6/include/argparse/argparse.hpp

--- a/apps/argparse/argparse.hpp
+++ b/apps/argparse/argparse.hpp
@@ -1,0 +1,2482 @@
+/*
+  __ _ _ __ __ _ _ __   __ _ _ __ ___  ___
+ / _` | '__/ _` | '_ \ / _` | '__/ __|/ _ \ Argument Parser for Modern C++
+| (_| | | | (_| | |_) | (_| | |  \__ \  __/ http://github.com/p-ranav/argparse
+ \__,_|_|  \__, | .__/ \__,_|_|  |___/\___|
+           |___/|_|
+
+Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+SPDX-License-Identifier: MIT
+Copyright (c) 2019-2022 Pranav Srinivas Kumar <pranav.srinivas.kumar@gmail.com>
+and other contributors.
+
+Permission is hereby  granted, free of charge, to any  person obtaining a copy
+of this software and associated  documentation files (the "Software"), to deal
+in the Software  without restriction, including without  limitation the rights
+to  use, copy,  modify, merge,  publish, distribute,  sublicense, and/or  sell
+copies  of  the Software,  and  to  permit persons  to  whom  the Software  is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE  IS PROVIDED "AS  IS", WITHOUT WARRANTY  OF ANY KIND,  EXPRESS OR
+IMPLIED,  INCLUDING BUT  NOT  LIMITED TO  THE  WARRANTIES OF  MERCHANTABILITY,
+FITNESS FOR  A PARTICULAR PURPOSE AND  NONINFRINGEMENT. IN NO EVENT  SHALL THE
+AUTHORS  OR COPYRIGHT  HOLDERS  BE  LIABLE FOR  ANY  CLAIM,  DAMAGES OR  OTHER
+LIABILITY, WHETHER IN AN ACTION OF  CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE  OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+#pragma once
+
+#include <cerrno>
+
+#ifndef ARGPARSE_MODULE_USE_STD_MODULE
+#include <algorithm>
+#include <any>
+#include <array>
+#include <charconv>
+#include <cstdlib>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <iterator>
+#include <limits>
+#include <list>
+#include <map>
+#include <numeric>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <string_view>
+#include <tuple>
+#include <type_traits>
+#include <utility>
+#include <variant>
+#include <vector>
+#endif
+
+#ifndef ARGPARSE_CUSTOM_STRTOF
+#define ARGPARSE_CUSTOM_STRTOF strtof
+#endif
+
+#ifndef ARGPARSE_CUSTOM_STRTOD
+#define ARGPARSE_CUSTOM_STRTOD strtod
+#endif
+
+#ifndef ARGPARSE_CUSTOM_STRTOLD
+#define ARGPARSE_CUSTOM_STRTOLD strtold
+#endif
+
+namespace argparse {
+
+namespace details { // namespace for helper methods
+
+template <typename T, typename = void>
+struct HasContainerTraits : std::false_type {};
+
+template <> struct HasContainerTraits<std::string> : std::false_type {};
+
+template <> struct HasContainerTraits<std::string_view> : std::false_type {};
+
+template <typename T>
+struct HasContainerTraits<
+    T, std::void_t<typename T::value_type, decltype(std::declval<T>().begin()),
+                   decltype(std::declval<T>().end()),
+                   decltype(std::declval<T>().size())>> : std::true_type {};
+
+template <typename T>
+inline constexpr bool IsContainer = HasContainerTraits<T>::value;
+
+template <typename T, typename = void>
+struct HasStreamableTraits : std::false_type {};
+
+template <typename T>
+struct HasStreamableTraits<
+    T,
+    std::void_t<decltype(std::declval<std::ostream &>() << std::declval<T>())>>
+    : std::true_type {};
+
+template <typename T>
+inline constexpr bool IsStreamable = HasStreamableTraits<T>::value;
+
+constexpr std::size_t repr_max_container_size = 5;
+
+template <typename T> std::string repr(T const &val) {
+  if constexpr (std::is_same_v<T, bool>) {
+    return val ? "true" : "false";
+  } else if constexpr (std::is_convertible_v<T, std::string_view>) {
+    return '"' + std::string{std::string_view{val}} + '"';
+  } else if constexpr (IsContainer<T>) {
+    std::stringstream out;
+    out << "{";
+    const auto size = val.size();
+    if (size > 1) {
+      out << repr(*val.begin());
+      std::for_each(
+          std::next(val.begin()),
+          std::next(
+              val.begin(),
+              static_cast<typename T::iterator::difference_type>(
+                  std::min<std::size_t>(size, repr_max_container_size) - 1)),
+          [&out](const auto &v) { out << " " << repr(v); });
+      if (size <= repr_max_container_size) {
+        out << " ";
+      } else {
+        out << "...";
+      }
+    }
+    if (size > 0) {
+      out << repr(*std::prev(val.end()));
+    }
+    out << "}";
+    return out.str();
+  } else if constexpr (IsStreamable<T>) {
+    std::stringstream out;
+    out << val;
+    return out.str();
+  } else {
+    return "<not representable>";
+  }
+}
+
+namespace {
+
+template <typename T> constexpr bool standard_signed_integer = false;
+template <> constexpr bool standard_signed_integer<signed char> = true;
+template <> constexpr bool standard_signed_integer<short int> = true;
+template <> constexpr bool standard_signed_integer<int> = true;
+template <> constexpr bool standard_signed_integer<long int> = true;
+template <> constexpr bool standard_signed_integer<long long int> = true;
+
+template <typename T> constexpr bool standard_unsigned_integer = false;
+template <> constexpr bool standard_unsigned_integer<unsigned char> = true;
+template <> constexpr bool standard_unsigned_integer<unsigned short int> = true;
+template <> constexpr bool standard_unsigned_integer<unsigned int> = true;
+template <> constexpr bool standard_unsigned_integer<unsigned long int> = true;
+template <>
+constexpr bool standard_unsigned_integer<unsigned long long int> = true;
+
+} // namespace
+
+constexpr int radix_2 = 2;
+constexpr int radix_8 = 8;
+constexpr int radix_10 = 10;
+constexpr int radix_16 = 16;
+
+template <typename T>
+constexpr bool standard_integer =
+    standard_signed_integer<T> || standard_unsigned_integer<T>;
+
+template <class F, class Tuple, class Extra, std::size_t... I>
+constexpr decltype(auto)
+apply_plus_one_impl(F &&f, Tuple &&t, Extra &&x,
+                    std::index_sequence<I...> /*unused*/) {
+  return std::invoke(std::forward<F>(f), std::get<I>(std::forward<Tuple>(t))...,
+                     std::forward<Extra>(x));
+}
+
+template <class F, class Tuple, class Extra>
+constexpr decltype(auto) apply_plus_one(F &&f, Tuple &&t, Extra &&x) {
+  return details::apply_plus_one_impl(
+      std::forward<F>(f), std::forward<Tuple>(t), std::forward<Extra>(x),
+      std::make_index_sequence<
+          std::tuple_size_v<std::remove_reference_t<Tuple>>>{});
+}
+
+constexpr auto pointer_range(std::string_view s) noexcept {
+  return std::tuple(s.data(), s.data() + s.size());
+}
+
+template <class CharT, class Traits>
+constexpr bool starts_with(std::basic_string_view<CharT, Traits> prefix,
+                           std::basic_string_view<CharT, Traits> s) noexcept {
+  return s.substr(0, prefix.size()) == prefix;
+}
+
+enum class chars_format {
+  scientific = 0xf1,
+  fixed = 0xf2,
+  hex = 0xf4,
+  binary = 0xf8,
+  general = fixed | scientific
+};
+
+struct ConsumeBinaryPrefixResult {
+  bool is_binary;
+  std::string_view rest;
+};
+
+constexpr auto consume_binary_prefix(std::string_view s)
+    -> ConsumeBinaryPrefixResult {
+  if (starts_with(std::string_view{"0b"}, s) ||
+      starts_with(std::string_view{"0B"}, s)) {
+    s.remove_prefix(2);
+    return {true, s};
+  }
+  return {false, s};
+}
+
+struct ConsumeHexPrefixResult {
+  bool is_hexadecimal;
+  std::string_view rest;
+};
+
+using namespace std::literals;
+
+constexpr auto consume_hex_prefix(std::string_view s)
+    -> ConsumeHexPrefixResult {
+  if (starts_with("0x"sv, s) || starts_with("0X"sv, s)) {
+    s.remove_prefix(2);
+    return {true, s};
+  }
+  return {false, s};
+}
+
+template <class T, auto Param>
+inline auto do_from_chars(std::string_view s) -> T {
+  T x;
+  auto [first, last] = pointer_range(s);
+  auto [ptr, ec] = std::from_chars(first, last, x, Param);
+  if (ec == std::errc()) {
+    if (ptr == last) {
+      return x;
+    }
+    throw std::invalid_argument{"pattern '" + std::string(s) +
+                                "' does not match to the end"};
+  }
+  if (ec == std::errc::invalid_argument) {
+    throw std::invalid_argument{"pattern '" + std::string(s) + "' not found"};
+  }
+  if (ec == std::errc::result_out_of_range) {
+    throw std::range_error{"'" + std::string(s) + "' not representable"};
+  }
+  return x; // unreachable
+}
+
+template <class T, auto Param = 0> struct parse_number {
+  auto operator()(std::string_view s) -> T {
+    return do_from_chars<T, Param>(s);
+  }
+};
+
+template <class T> struct parse_number<T, radix_2> {
+  auto operator()(std::string_view s) -> T {
+    if (auto [ok, rest] = consume_binary_prefix(s); ok) {
+      return do_from_chars<T, radix_2>(rest);
+    }
+    throw std::invalid_argument{"pattern not found"};
+  }
+};
+
+template <class T> struct parse_number<T, radix_16> {
+  auto operator()(std::string_view s) -> T {
+    if (starts_with("0x"sv, s) || starts_with("0X"sv, s)) {
+      if (auto [ok, rest] = consume_hex_prefix(s); ok) {
+        try {
+          return do_from_chars<T, radix_16>(rest);
+        } catch (const std::invalid_argument &err) {
+          throw std::invalid_argument("Failed to parse '" + std::string(s) +
+                                      "' as hexadecimal: " + err.what());
+        } catch (const std::range_error &err) {
+          throw std::range_error("Failed to parse '" + std::string(s) +
+                                 "' as hexadecimal: " + err.what());
+        }
+      }
+    } else {
+      // Allow passing hex numbers without prefix
+      // Shape 'x' already has to be specified
+      try {
+        return do_from_chars<T, radix_16>(s);
+      } catch (const std::invalid_argument &err) {
+        throw std::invalid_argument("Failed to parse '" + std::string(s) +
+                                    "' as hexadecimal: " + err.what());
+      } catch (const std::range_error &err) {
+        throw std::range_error("Failed to parse '" + std::string(s) +
+                               "' as hexadecimal: " + err.what());
+      }
+    }
+
+    throw std::invalid_argument{"pattern '" + std::string(s) +
+                                "' not identified as hexadecimal"};
+  }
+};
+
+template <class T> struct parse_number<T> {
+  auto operator()(std::string_view s) -> T {
+    auto [ok, rest] = consume_hex_prefix(s);
+    if (ok) {
+      try {
+        return do_from_chars<T, radix_16>(rest);
+      } catch (const std::invalid_argument &err) {
+        throw std::invalid_argument("Failed to parse '" + std::string(s) +
+                                    "' as hexadecimal: " + err.what());
+      } catch (const std::range_error &err) {
+        throw std::range_error("Failed to parse '" + std::string(s) +
+                               "' as hexadecimal: " + err.what());
+      }
+    }
+
+    auto [ok_binary, rest_binary] = consume_binary_prefix(s);
+    if (ok_binary) {
+      try {
+        return do_from_chars<T, radix_2>(rest_binary);
+      } catch (const std::invalid_argument &err) {
+        throw std::invalid_argument("Failed to parse '" + std::string(s) +
+                                    "' as binary: " + err.what());
+      } catch (const std::range_error &err) {
+        throw std::range_error("Failed to parse '" + std::string(s) +
+                               "' as binary: " + err.what());
+      }
+    }
+
+    if (starts_with("0"sv, s)) {
+      try {
+        return do_from_chars<T, radix_8>(rest);
+      } catch (const std::invalid_argument &err) {
+        throw std::invalid_argument("Failed to parse '" + std::string(s) +
+                                    "' as octal: " + err.what());
+      } catch (const std::range_error &err) {
+        throw std::range_error("Failed to parse '" + std::string(s) +
+                               "' as octal: " + err.what());
+      }
+    }
+
+    try {
+      return do_from_chars<T, radix_10>(rest);
+    } catch (const std::invalid_argument &err) {
+      throw std::invalid_argument("Failed to parse '" + std::string(s) +
+                                  "' as decimal integer: " + err.what());
+    } catch (const std::range_error &err) {
+      throw std::range_error("Failed to parse '" + std::string(s) +
+                             "' as decimal integer: " + err.what());
+    }
+  }
+};
+
+namespace {
+
+template <class T> inline const auto generic_strtod = nullptr;
+template <> inline const auto generic_strtod<float> = ARGPARSE_CUSTOM_STRTOF;
+template <> inline const auto generic_strtod<double> = ARGPARSE_CUSTOM_STRTOD;
+template <>
+inline const auto generic_strtod<long double> = ARGPARSE_CUSTOM_STRTOLD;
+
+} // namespace
+
+template <class T> inline auto do_strtod(std::string const &s) -> T {
+  if (isspace(static_cast<unsigned char>(s[0])) || s[0] == '+') {
+    throw std::invalid_argument{"pattern '" + s + "' not found"};
+  }
+
+  auto [first, last] = pointer_range(s);
+  char *ptr;
+
+  errno = 0;
+  auto x = generic_strtod<T>(first, &ptr);
+  if (errno == 0) {
+    if (ptr == last) {
+      return x;
+    }
+    throw std::invalid_argument{"pattern '" + s +
+                                "' does not match to the end"};
+  }
+  if (errno == ERANGE) {
+    throw std::range_error{"'" + s + "' not representable"};
+  }
+  return x; // unreachable
+}
+
+template <class T> struct parse_number<T, chars_format::general> {
+  auto operator()(std::string const &s) -> T {
+    if (auto r = consume_hex_prefix(s); r.is_hexadecimal) {
+      throw std::invalid_argument{
+          "chars_format::general does not parse hexfloat"};
+    }
+    if (auto r = consume_binary_prefix(s); r.is_binary) {
+      throw std::invalid_argument{
+          "chars_format::general does not parse binfloat"};
+    }
+
+    try {
+      return do_strtod<T>(s);
+    } catch (const std::invalid_argument &err) {
+      throw std::invalid_argument("Failed to parse '" + s +
+                                  "' as number: " + err.what());
+    } catch (const std::range_error &err) {
+      throw std::range_error("Failed to parse '" + s +
+                             "' as number: " + err.what());
+    }
+  }
+};
+
+template <class T> struct parse_number<T, chars_format::hex> {
+  auto operator()(std::string const &s) -> T {
+    if (auto r = consume_hex_prefix(s); !r.is_hexadecimal) {
+      throw std::invalid_argument{"chars_format::hex parses hexfloat"};
+    }
+    if (auto r = consume_binary_prefix(s); r.is_binary) {
+      throw std::invalid_argument{"chars_format::hex does not parse binfloat"};
+    }
+
+    try {
+      return do_strtod<T>(s);
+    } catch (const std::invalid_argument &err) {
+      throw std::invalid_argument("Failed to parse '" + s +
+                                  "' as hexadecimal: " + err.what());
+    } catch (const std::range_error &err) {
+      throw std::range_error("Failed to parse '" + s +
+                             "' as hexadecimal: " + err.what());
+    }
+  }
+};
+
+template <class T> struct parse_number<T, chars_format::binary> {
+  auto operator()(std::string const &s) -> T {
+    if (auto r = consume_hex_prefix(s); r.is_hexadecimal) {
+      throw std::invalid_argument{
+          "chars_format::binary does not parse hexfloat"};
+    }
+    if (auto r = consume_binary_prefix(s); !r.is_binary) {
+      throw std::invalid_argument{"chars_format::binary parses binfloat"};
+    }
+
+    return do_strtod<T>(s);
+  }
+};
+
+template <class T> struct parse_number<T, chars_format::scientific> {
+  auto operator()(std::string const &s) -> T {
+    if (auto r = consume_hex_prefix(s); r.is_hexadecimal) {
+      throw std::invalid_argument{
+          "chars_format::scientific does not parse hexfloat"};
+    }
+    if (auto r = consume_binary_prefix(s); r.is_binary) {
+      throw std::invalid_argument{
+          "chars_format::scientific does not parse binfloat"};
+    }
+    if (s.find_first_of("eE") == std::string::npos) {
+      throw std::invalid_argument{
+          "chars_format::scientific requires exponent part"};
+    }
+
+    try {
+      return do_strtod<T>(s);
+    } catch (const std::invalid_argument &err) {
+      throw std::invalid_argument("Failed to parse '" + s +
+                                  "' as scientific notation: " + err.what());
+    } catch (const std::range_error &err) {
+      throw std::range_error("Failed to parse '" + s +
+                             "' as scientific notation: " + err.what());
+    }
+  }
+};
+
+template <class T> struct parse_number<T, chars_format::fixed> {
+  auto operator()(std::string const &s) -> T {
+    if (auto r = consume_hex_prefix(s); r.is_hexadecimal) {
+      throw std::invalid_argument{
+          "chars_format::fixed does not parse hexfloat"};
+    }
+    if (auto r = consume_binary_prefix(s); r.is_binary) {
+      throw std::invalid_argument{
+          "chars_format::fixed does not parse binfloat"};
+    }
+    if (s.find_first_of("eE") != std::string::npos) {
+      throw std::invalid_argument{
+          "chars_format::fixed does not parse exponent part"};
+    }
+
+    try {
+      return do_strtod<T>(s);
+    } catch (const std::invalid_argument &err) {
+      throw std::invalid_argument("Failed to parse '" + s +
+                                  "' as fixed notation: " + err.what());
+    } catch (const std::range_error &err) {
+      throw std::range_error("Failed to parse '" + s +
+                             "' as fixed notation: " + err.what());
+    }
+  }
+};
+
+template <typename StrIt>
+std::string join(StrIt first, StrIt last, const std::string &separator) {
+  if (first == last) {
+    return "";
+  }
+  std::stringstream value;
+  value << *first;
+  ++first;
+  while (first != last) {
+    value << separator << *first;
+    ++first;
+  }
+  return value.str();
+}
+
+template <typename T> struct can_invoke_to_string {
+  template <typename U>
+  static auto test(int)
+      -> decltype(std::to_string(std::declval<U>()), std::true_type{});
+
+  template <typename U> static auto test(...) -> std::false_type;
+
+  static constexpr bool value = decltype(test<T>(0))::value;
+};
+
+template <typename T> struct IsChoiceTypeSupported {
+  using CleanType = typename std::decay<T>::type;
+  static const bool value = std::is_integral<CleanType>::value ||
+                            std::is_same<CleanType, std::string>::value ||
+                            std::is_same<CleanType, std::string_view>::value ||
+                            std::is_same<CleanType, const char *>::value;
+};
+
+template <typename StringType>
+std::size_t get_levenshtein_distance(const StringType &s1,
+                                     const StringType &s2) {
+  std::vector<std::vector<std::size_t>> dp(
+      s1.size() + 1, std::vector<std::size_t>(s2.size() + 1, 0));
+
+  for (std::size_t i = 0; i <= s1.size(); ++i) {
+    for (std::size_t j = 0; j <= s2.size(); ++j) {
+      if (i == 0) {
+        dp[i][j] = j;
+      } else if (j == 0) {
+        dp[i][j] = i;
+      } else if (s1[i - 1] == s2[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1];
+      } else {
+        dp[i][j] = 1 + std::min({dp[i - 1][j], dp[i][j - 1], dp[i - 1][j - 1]});
+      }
+    }
+  }
+
+  return dp[s1.size()][s2.size()];
+}
+
+template <typename ValueType>
+std::string get_most_similar_string(const std::map<std::string, ValueType> &map,
+                                    const std::string &input) {
+  std::string most_similar{};
+  std::size_t min_distance = std::numeric_limits<std::size_t>::max();
+
+  for (const auto &entry : map) {
+    std::size_t distance = get_levenshtein_distance(entry.first, input);
+    if (distance < min_distance) {
+      min_distance = distance;
+      most_similar = entry.first;
+    }
+  }
+
+  return most_similar;
+}
+
+} // namespace details
+
+enum class nargs_pattern { optional, any, at_least_one };
+
+enum class default_arguments : unsigned int {
+  none = 0,
+  help = 1,
+  version = 2,
+  all = help | version,
+};
+
+inline default_arguments operator&(const default_arguments &a,
+                                   const default_arguments &b) {
+  return static_cast<default_arguments>(
+      static_cast<std::underlying_type<default_arguments>::type>(a) &
+      static_cast<std::underlying_type<default_arguments>::type>(b));
+}
+
+class ArgumentParser;
+
+class Argument {
+  friend class ArgumentParser;
+  friend auto operator<<(std::ostream &stream, const ArgumentParser &parser)
+      -> std::ostream &;
+
+  template <std::size_t N, std::size_t... I>
+  explicit Argument(std::string_view prefix_chars,
+                    std::array<std::string_view, N> &&a,
+                    std::index_sequence<I...> /*unused*/)
+      : m_accepts_optional_like_value(false),
+        m_is_optional((is_optional(a[I], prefix_chars) || ...)),
+        m_is_required(false), m_is_repeatable(false), m_is_used(false),
+        m_is_hidden(false), m_prefix_chars(prefix_chars) {
+    ((void)m_names.emplace_back(a[I]), ...);
+    std::sort(
+        m_names.begin(), m_names.end(), [](const auto &lhs, const auto &rhs) {
+          return lhs.size() == rhs.size() ? lhs < rhs : lhs.size() < rhs.size();
+        });
+  }
+
+public:
+  template <std::size_t N>
+  explicit Argument(std::string_view prefix_chars,
+                    std::array<std::string_view, N> &&a)
+      : Argument(prefix_chars, std::move(a), std::make_index_sequence<N>{}) {}
+
+  Argument &help(std::string help_text) {
+    m_help = std::move(help_text);
+    return *this;
+  }
+
+  Argument &metavar(std::string metavar) {
+    m_metavar = std::move(metavar);
+    return *this;
+  }
+
+  template <typename T> Argument &default_value(T &&value) {
+    m_num_args_range = NArgsRange{0, m_num_args_range.get_max()};
+    m_default_value_repr = details::repr(value);
+
+    if constexpr (std::is_convertible_v<T, std::string_view>) {
+      m_default_value_str = std::string{std::string_view{value}};
+    } else if constexpr (details::can_invoke_to_string<T>::value) {
+      m_default_value_str = std::to_string(value);
+    }
+
+    m_default_value = std::forward<T>(value);
+    return *this;
+  }
+
+  Argument &default_value(const char *value) {
+    return default_value(std::string(value));
+  }
+
+  Argument &required() {
+    m_is_required = true;
+    return *this;
+  }
+
+  Argument &implicit_value(std::any value) {
+    m_implicit_value = std::move(value);
+    m_num_args_range = NArgsRange{0, 0};
+    return *this;
+  }
+
+  // This is shorthand for:
+  //   program.add_argument("foo")
+  //     .default_value(false)
+  //     .implicit_value(true)
+  Argument &flag() {
+    default_value(false);
+    implicit_value(true);
+    return *this;
+  }
+
+  template <class F, class... Args>
+  auto action(F &&callable, Args &&... bound_args)
+      -> std::enable_if_t<std::is_invocable_v<F, Args..., std::string const>,
+                          Argument &> {
+    using action_type = std::conditional_t<
+        std::is_void_v<std::invoke_result_t<F, Args..., std::string const>>,
+        void_action, valued_action>;
+    if constexpr (sizeof...(Args) == 0) {
+      m_action.emplace<action_type>(std::forward<F>(callable));
+    } else {
+      m_action.emplace<action_type>(
+          [f = std::forward<F>(callable),
+           tup = std::make_tuple(std::forward<Args>(bound_args)...)](
+              std::string const &opt) mutable {
+            return details::apply_plus_one(f, tup, opt);
+          });
+    }
+    return *this;
+  }
+
+  auto &store_into(bool &var) {
+    flag();
+    if (m_default_value.has_value()) {
+      var = std::any_cast<bool>(m_default_value);
+    }
+    action([&var](const auto & /*unused*/) { var = true; });
+    return *this;
+  }
+
+  auto &store_into(int &var) {
+    if (m_default_value.has_value()) {
+      var = std::any_cast<int>(m_default_value);
+    }
+    action([&var](const auto &s) {
+      var = details::parse_number<int, details::radix_10>()(s);
+    });
+    return *this;
+  }
+
+  auto &store_into(double &var) {
+    if (m_default_value.has_value()) {
+      var = std::any_cast<double>(m_default_value);
+    }
+    action([&var](const auto &s) {
+      var = details::parse_number<double, details::chars_format::general>()(s);
+    });
+    return *this;
+  }
+
+  auto &store_into(std::string &var) {
+    if (m_default_value.has_value()) {
+      var = std::any_cast<std::string>(m_default_value);
+    }
+    action([&var](const std::string &s) { var = s; });
+    return *this;
+  }
+
+  auto &store_into(std::vector<std::string> &var) {
+    if (m_default_value.has_value()) {
+      var = std::any_cast<std::vector<std::string>>(m_default_value);
+    }
+    action([this, &var](const std::string &s) {
+      if (!m_is_used) {
+        var.clear();
+      }
+      m_is_used = true;
+      var.push_back(s);
+    });
+    return *this;
+  }
+
+  auto &append() {
+    m_is_repeatable = true;
+    return *this;
+  }
+
+  // Cause the argument to be invisible in usage and help
+  auto &hidden() {
+    m_is_hidden = true;
+    return *this;
+  }
+
+  template <char Shape, typename T>
+  auto scan() -> std::enable_if_t<std::is_arithmetic_v<T>, Argument &> {
+    static_assert(!(std::is_const_v<T> || std::is_volatile_v<T>),
+                  "T should not be cv-qualified");
+    auto is_one_of = [](char c, auto... x) constexpr {
+      return ((c == x) || ...);
+    };
+
+    if constexpr (is_one_of(Shape, 'd') && details::standard_integer<T>) {
+      action(details::parse_number<T, details::radix_10>());
+    } else if constexpr (is_one_of(Shape, 'i') &&
+                         details::standard_integer<T>) {
+      action(details::parse_number<T>());
+    } else if constexpr (is_one_of(Shape, 'u') &&
+                         details::standard_unsigned_integer<T>) {
+      action(details::parse_number<T, details::radix_10>());
+    } else if constexpr (is_one_of(Shape, 'b') &&
+                         details::standard_unsigned_integer<T>) {
+      action(details::parse_number<T, details::radix_2>());
+    } else if constexpr (is_one_of(Shape, 'o') &&
+                         details::standard_unsigned_integer<T>) {
+      action(details::parse_number<T, details::radix_8>());
+    } else if constexpr (is_one_of(Shape, 'x', 'X') &&
+                         details::standard_unsigned_integer<T>) {
+      action(details::parse_number<T, details::radix_16>());
+    } else if constexpr (is_one_of(Shape, 'a', 'A') &&
+                         std::is_floating_point_v<T>) {
+      action(details::parse_number<T, details::chars_format::hex>());
+    } else if constexpr (is_one_of(Shape, 'e', 'E') &&
+                         std::is_floating_point_v<T>) {
+      action(details::parse_number<T, details::chars_format::scientific>());
+    } else if constexpr (is_one_of(Shape, 'f', 'F') &&
+                         std::is_floating_point_v<T>) {
+      action(details::parse_number<T, details::chars_format::fixed>());
+    } else if constexpr (is_one_of(Shape, 'g', 'G') &&
+                         std::is_floating_point_v<T>) {
+      action(details::parse_number<T, details::chars_format::general>());
+    } else {
+      static_assert(alignof(T) == 0, "No scan specification for T");
+    }
+
+    return *this;
+  }
+
+  Argument &nargs(std::size_t num_args) {
+    m_num_args_range = NArgsRange{num_args, num_args};
+    return *this;
+  }
+
+  Argument &nargs(std::size_t num_args_min, std::size_t num_args_max) {
+    m_num_args_range = NArgsRange{num_args_min, num_args_max};
+    return *this;
+  }
+
+  Argument &nargs(nargs_pattern pattern) {
+    switch (pattern) {
+    case nargs_pattern::optional:
+      m_num_args_range = NArgsRange{0, 1};
+      break;
+    case nargs_pattern::any:
+      m_num_args_range =
+          NArgsRange{0, (std::numeric_limits<std::size_t>::max)()};
+      break;
+    case nargs_pattern::at_least_one:
+      m_num_args_range =
+          NArgsRange{1, (std::numeric_limits<std::size_t>::max)()};
+      break;
+    }
+    return *this;
+  }
+
+  Argument &remaining() {
+    m_accepts_optional_like_value = true;
+    return nargs(nargs_pattern::any);
+  }
+
+  template <typename T> void add_choice(T &&choice) {
+    static_assert(details::IsChoiceTypeSupported<T>::value,
+                  "Only string or integer type supported for choice");
+    static_assert(std::is_convertible_v<T, std::string_view> ||
+                      details::can_invoke_to_string<T>::value,
+                  "Choice is not convertible to string_type");
+    if (!m_choices.has_value()) {
+      m_choices = std::vector<std::string>{};
+    }
+
+    if constexpr (std::is_convertible_v<T, std::string_view>) {
+      m_choices.value().push_back(
+          std::string{std::string_view{std::forward<T>(choice)}});
+    } else if constexpr (details::can_invoke_to_string<T>::value) {
+      m_choices.value().push_back(std::to_string(std::forward<T>(choice)));
+    }
+  }
+
+  Argument &choices() {
+    if (!m_choices.has_value()) {
+      throw std::runtime_error("Zero choices provided");
+    }
+    return *this;
+  }
+
+  template <typename T, typename... U>
+  Argument &choices(T &&first, U &&... rest) {
+    add_choice(std::forward<T>(first));
+    choices(std::forward<U>(rest)...);
+    return *this;
+  }
+
+  void find_default_value_in_choices_or_throw() const {
+
+    const auto &choices = m_choices.value();
+
+    if (m_default_value.has_value()) {
+      if (std::find(choices.begin(), choices.end(), m_default_value_str) ==
+          choices.end()) {
+        // provided arg not in list of allowed choices
+        // report error
+
+        std::string choices_as_csv =
+            std::accumulate(choices.begin(), choices.end(), std::string(),
+                            [](const std::string &a, const std::string &b) {
+                              return a + (a.empty() ? "" : ", ") + b;
+                            });
+
+        throw std::runtime_error(
+            std::string{"Invalid default value "} + m_default_value_repr +
+            " - allowed options: {" + choices_as_csv + "}");
+      }
+    }
+  }
+
+  template <typename Iterator>
+  void find_value_in_choices_or_throw(Iterator it) const {
+
+    const auto &choices = m_choices.value();
+
+    if (std::find(choices.begin(), choices.end(), *it) == choices.end()) {
+      // provided arg not in list of allowed choices
+      // report error
+
+      std::string choices_as_csv =
+          std::accumulate(choices.begin(), choices.end(), std::string(),
+                          [](const std::string &a, const std::string &b) {
+                            return a + (a.empty() ? "" : ", ") + b;
+                          });
+
+      throw std::runtime_error(std::string{"Invalid argument "} +
+                               details::repr(*it) + " - allowed options: {" +
+                               choices_as_csv + "}");
+    }
+  }
+
+  /* The dry_run parameter can be set to true to avoid running the actions,
+   * and setting m_is_used. This may be used by a pre-processing step to do
+   * a first iteration over arguments.
+   */
+  template <typename Iterator>
+  Iterator consume(Iterator start, Iterator end,
+                   std::string_view used_name = {}, bool dry_run = false) {
+    if (!m_is_repeatable && m_is_used) {
+      throw std::runtime_error(
+          std::string("Duplicate argument ").append(used_name));
+    }
+    m_used_name = used_name;
+
+    if (m_choices.has_value()) {
+      // Check each value in (start, end) and make sure
+      // it is in the list of allowed choices/options
+      std::size_t i = 0;
+      auto max_number_of_args = m_num_args_range.get_max();
+      for (auto it = start; it != end; ++it) {
+        if (i == max_number_of_args) {
+          break;
+        }
+        find_value_in_choices_or_throw(it);
+        i += 1;
+      }
+    }
+
+    const auto num_args_max = m_num_args_range.get_max();
+    const auto num_args_min = m_num_args_range.get_min();
+    std::size_t dist = 0;
+    if (num_args_max == 0) {
+      if (!dry_run) {
+        m_values.emplace_back(m_implicit_value);
+        std::visit([](const auto &f) { f({}); }, m_action);
+        m_is_used = true;
+      }
+      return start;
+    }
+    if ((dist = static_cast<std::size_t>(std::distance(start, end))) >=
+        num_args_min) {
+      if (num_args_max < dist) {
+        end = std::next(start, static_cast<typename Iterator::difference_type>(
+                                   num_args_max));
+      }
+      if (!m_accepts_optional_like_value) {
+        end = std::find_if(
+            start, end,
+            std::bind(is_optional, std::placeholders::_1, m_prefix_chars));
+        dist = static_cast<std::size_t>(std::distance(start, end));
+        if (dist < num_args_min) {
+          throw std::runtime_error("Too few arguments");
+        }
+      }
+
+      struct ActionApply {
+        void operator()(valued_action &f) {
+          std::transform(first, last, std::back_inserter(self.m_values), f);
+        }
+
+        void operator()(void_action &f) {
+          std::for_each(first, last, f);
+          if (!self.m_default_value.has_value()) {
+            if (!self.m_accepts_optional_like_value) {
+              self.m_values.resize(
+                  static_cast<std::size_t>(std::distance(first, last)));
+            }
+          }
+        }
+
+        Iterator first, last;
+        Argument &self;
+      };
+      if (!dry_run) {
+        std::visit(ActionApply{start, end, *this}, m_action);
+        m_is_used = true;
+      }
+      return end;
+    }
+    if (m_default_value.has_value()) {
+      if (!dry_run) {
+        m_is_used = true;
+      }
+      return start;
+    }
+    throw std::runtime_error("Too few arguments for '" +
+                             std::string(m_used_name) + "'.");
+  }
+
+  /*
+   * @throws std::runtime_error if argument values are not valid
+   */
+  void validate() const {
+    if (m_is_optional) {
+      // TODO: check if an implicit value was programmed for this argument
+      if (!m_is_used && !m_default_value.has_value() && m_is_required) {
+        throw_required_arg_not_used_error();
+      }
+      if (m_is_used && m_is_required && m_values.empty()) {
+        throw_required_arg_no_value_provided_error();
+      }
+    } else {
+      if (!m_num_args_range.contains(m_values.size()) &&
+          !m_default_value.has_value()) {
+        throw_nargs_range_validation_error();
+      }
+    }
+
+    if (m_choices.has_value()) {
+      // Make sure the default value (if provided)
+      // is in the list of choices
+      find_default_value_in_choices_or_throw();
+    }
+  }
+
+  std::string get_names_csv(char separator = ',') const {
+    return std::accumulate(
+        m_names.begin(), m_names.end(), std::string{""},
+        [&](const std::string &result, const std::string &name) {
+          return result.empty() ? name : result + separator + name;
+        });
+  }
+
+  std::string get_usage_full() const {
+    std::stringstream usage;
+
+    usage << get_names_csv('/');
+    const std::string metavar = !m_metavar.empty() ? m_metavar : "VAR";
+    if (m_num_args_range.get_max() > 0) {
+      usage << " " << metavar;
+      if (m_num_args_range.get_max() > 1) {
+        usage << "...";
+      }
+    }
+    return usage.str();
+  }
+
+  std::string get_inline_usage() const {
+    std::stringstream usage;
+    // Find the longest variant to show in the usage string
+    std::string longest_name = m_names.front();
+    for (const auto &s : m_names) {
+      if (s.size() > longest_name.size()) {
+        longest_name = s;
+      }
+    }
+    if (!m_is_required) {
+      usage << "[";
+    }
+    usage << longest_name;
+    const std::string metavar = !m_metavar.empty() ? m_metavar : "VAR";
+    if (m_num_args_range.get_max() > 0) {
+      usage << " " << metavar;
+      if (m_num_args_range.get_max() > 1 &&
+          m_metavar.find("> <") == std::string::npos) {
+        usage << "...";
+      }
+    }
+    if (!m_is_required) {
+      usage << "]";
+    }
+    if (m_is_repeatable) {
+      usage << "...";
+    }
+    return usage.str();
+  }
+
+  std::size_t get_arguments_length() const {
+
+    std::size_t names_size = std::accumulate(
+        std::begin(m_names), std::end(m_names), std::size_t(0),
+        [](const auto &sum, const auto &s) { return sum + s.size(); });
+
+    if (is_positional(m_names.front(), m_prefix_chars)) {
+      // A set metavar means this replaces the names
+      if (!m_metavar.empty()) {
+        // Indent and metavar
+        return 2 + m_metavar.size();
+      }
+
+      // Indent and space-separated
+      return 2 + names_size + (m_names.size() - 1);
+    }
+    // Is an option - include both names _and_ metavar
+    // size = text + (", " between names)
+    std::size_t size = names_size + 2 * (m_names.size() - 1);
+    if (!m_metavar.empty() && m_num_args_range == NArgsRange{1, 1}) {
+      size += m_metavar.size() + 1;
+    }
+    return size + 2; // indent
+  }
+
+  friend std::ostream &operator<<(std::ostream &stream,
+                                  const Argument &argument) {
+    std::stringstream name_stream;
+    name_stream << "  "; // indent
+    if (argument.is_positional(argument.m_names.front(),
+                               argument.m_prefix_chars)) {
+      if (!argument.m_metavar.empty()) {
+        name_stream << argument.m_metavar;
+      } else {
+        name_stream << details::join(argument.m_names.begin(),
+                                     argument.m_names.end(), " ");
+      }
+    } else {
+      name_stream << details::join(argument.m_names.begin(),
+                                   argument.m_names.end(), ", ");
+      // If we have a metavar, and one narg - print the metavar
+      if (!argument.m_metavar.empty() &&
+          argument.m_num_args_range == NArgsRange{1, 1}) {
+        name_stream << " " << argument.m_metavar;
+      }
+      else if (!argument.m_metavar.empty() &&
+               argument.m_num_args_range.get_min() == argument.m_num_args_range.get_max() &&
+               argument.m_metavar.find("> <") != std::string::npos) {
+        name_stream << " " << argument.m_metavar;
+      }
+    }
+
+    // align multiline help message
+    auto stream_width = stream.width();
+    auto name_padding = std::string(name_stream.str().size(), ' ');
+    auto pos = std::string::size_type{};
+    auto prev = std::string::size_type{};
+    auto first_line = true;
+    auto hspace = "  "; // minimal space between name and help message
+    stream << name_stream.str();
+    std::string_view help_view(argument.m_help);
+    while ((pos = argument.m_help.find('\n', prev)) != std::string::npos) {
+      auto line = help_view.substr(prev, pos - prev + 1);
+      if (first_line) {
+        stream << hspace << line;
+        first_line = false;
+      } else {
+        stream.width(stream_width);
+        stream << name_padding << hspace << line;
+      }
+      prev += pos - prev + 1;
+    }
+    if (first_line) {
+      stream << hspace << argument.m_help;
+    } else {
+      auto leftover = help_view.substr(prev, argument.m_help.size() - prev);
+      if (!leftover.empty()) {
+        stream.width(stream_width);
+        stream << name_padding << hspace << leftover;
+      }
+    }
+
+    // print nargs spec
+    if (!argument.m_help.empty()) {
+      stream << " ";
+    }
+    stream << argument.m_num_args_range;
+
+    bool add_space = false;
+    if (argument.m_default_value.has_value() &&
+        argument.m_num_args_range != NArgsRange{0, 0}) {
+      stream << "[default: " << argument.m_default_value_repr << "]";
+      add_space = true;
+    } else if (argument.m_is_required) {
+      stream << "[required]";
+      add_space = true;
+    }
+    if (argument.m_is_repeatable) {
+      if (add_space) {
+        stream << " ";
+      }
+      stream << "[may be repeated]";
+    }
+    stream << "\n";
+    return stream;
+  }
+
+  template <typename T> bool operator!=(const T &rhs) const {
+    return !(*this == rhs);
+  }
+
+  /*
+   * Compare to an argument value of known type
+   * @throws std::logic_error in case of incompatible types
+   */
+  template <typename T> bool operator==(const T &rhs) const {
+    if constexpr (!details::IsContainer<T>) {
+      return get<T>() == rhs;
+    } else {
+      using ValueType = typename T::value_type;
+      auto lhs = get<T>();
+      return std::equal(std::begin(lhs), std::end(lhs), std::begin(rhs),
+                        std::end(rhs), [](const auto &a, const auto &b) {
+                          return std::any_cast<const ValueType &>(a) == b;
+                        });
+    }
+  }
+
+  /*
+   * positional:
+   *    _empty_
+   *    '-'
+   *    '-' decimal-literal
+   *    !'-' anything
+   */
+  static bool is_positional(std::string_view name,
+                            std::string_view prefix_chars) {
+    auto first = lookahead(name);
+
+    if (first == eof) {
+      return true;
+    }
+    if (prefix_chars.find(static_cast<char>(first)) !=
+                          std::string_view::npos) {
+      name.remove_prefix(1);
+      if (name.empty()) {
+        return true;
+      }
+      return is_decimal_literal(name);
+    }
+    return true;
+  }
+
+private:
+  class NArgsRange {
+    std::size_t m_min;
+    std::size_t m_max;
+
+  public:
+    NArgsRange(std::size_t minimum, std::size_t maximum)
+        : m_min(minimum), m_max(maximum) {
+      if (minimum > maximum) {
+        throw std::logic_error("Range of number of arguments is invalid");
+      }
+    }
+
+    bool contains(std::size_t value) const {
+      return value >= m_min && value <= m_max;
+    }
+
+    bool is_exact() const { return m_min == m_max; }
+
+    bool is_right_bounded() const {
+      return m_max < (std::numeric_limits<std::size_t>::max)();
+    }
+
+    std::size_t get_min() const { return m_min; }
+
+    std::size_t get_max() const { return m_max; }
+
+    // Print help message
+    friend auto operator<<(std::ostream &stream, const NArgsRange &range)
+        -> std::ostream & {
+      if (range.m_min == range.m_max) {
+        if (range.m_min != 0 && range.m_min != 1) {
+          stream << "[nargs: " << range.m_min << "] ";
+        }
+      } else {
+        if (range.m_max == (std::numeric_limits<std::size_t>::max)()) {
+          stream << "[nargs: " << range.m_min << " or more] ";
+        } else {
+          stream << "[nargs=" << range.m_min << ".." << range.m_max << "] ";
+        }
+      }
+      return stream;
+    }
+
+    bool operator==(const NArgsRange &rhs) const {
+      return rhs.m_min == m_min && rhs.m_max == m_max;
+    }
+
+    bool operator!=(const NArgsRange &rhs) const { return !(*this == rhs); }
+  };
+
+  void throw_nargs_range_validation_error() const {
+    std::stringstream stream;
+    if (!m_used_name.empty()) {
+      stream << m_used_name << ": ";
+    } else {
+      stream << m_names.front() << ": ";
+    }
+    if (m_num_args_range.is_exact()) {
+      stream << m_num_args_range.get_min();
+    } else if (m_num_args_range.is_right_bounded()) {
+      stream << m_num_args_range.get_min() << " to "
+             << m_num_args_range.get_max();
+    } else {
+      stream << m_num_args_range.get_min() << " or more";
+    }
+    stream << " argument(s) expected. " << m_values.size() << " provided.";
+    throw std::runtime_error(stream.str());
+  }
+
+  void throw_required_arg_not_used_error() const {
+    std::stringstream stream;
+    stream << m_names.front() << ": required.";
+    throw std::runtime_error(stream.str());
+  }
+
+  void throw_required_arg_no_value_provided_error() const {
+    std::stringstream stream;
+    stream << m_used_name << ": no value provided.";
+    throw std::runtime_error(stream.str());
+  }
+
+  static constexpr int eof = std::char_traits<char>::eof();
+
+  static auto lookahead(std::string_view s) -> int {
+    if (s.empty()) {
+      return eof;
+    }
+    return static_cast<int>(static_cast<unsigned char>(s[0]));
+  }
+
+  /*
+   * decimal-literal:
+   *    '0'
+   *    nonzero-digit digit-sequence_opt
+   *    integer-part fractional-part
+   *    fractional-part
+   *    integer-part '.' exponent-part_opt
+   *    integer-part exponent-part
+   *
+   * integer-part:
+   *    digit-sequence
+   *
+   * fractional-part:
+   *    '.' post-decimal-point
+   *
+   * post-decimal-point:
+   *    digit-sequence exponent-part_opt
+   *
+   * exponent-part:
+   *    'e' post-e
+   *    'E' post-e
+   *
+   * post-e:
+   *    sign_opt digit-sequence
+   *
+   * sign: one of
+   *    '+' '-'
+   */
+  static bool is_decimal_literal(std::string_view s) {
+    auto is_digit = [](auto c) constexpr {
+      switch (c) {
+      case '0':
+      case '1':
+      case '2':
+      case '3':
+      case '4':
+      case '5':
+      case '6':
+      case '7':
+      case '8':
+      case '9':
+        return true;
+      default:
+        return false;
+      }
+    };
+
+    // precondition: we have consumed or will consume at least one digit
+    auto consume_digits = [=](std::string_view sd) {
+      // NOLINTNEXTLINE(readability-qualified-auto)
+      auto it = std::find_if_not(std::begin(sd), std::end(sd), is_digit);
+      return sd.substr(static_cast<std::size_t>(it - std::begin(sd)));
+    };
+
+    switch (lookahead(s)) {
+    case '0': {
+      s.remove_prefix(1);
+      if (s.empty()) {
+        return true;
+      }
+      goto integer_part;
+    }
+    case '1':
+    case '2':
+    case '3':
+    case '4':
+    case '5':
+    case '6':
+    case '7':
+    case '8':
+    case '9': {
+      s = consume_digits(s);
+      if (s.empty()) {
+        return true;
+      }
+      goto integer_part_consumed;
+    }
+    case '.': {
+      s.remove_prefix(1);
+      goto post_decimal_point;
+    }
+    default:
+      return false;
+    }
+
+  integer_part:
+    s = consume_digits(s);
+  integer_part_consumed:
+    switch (lookahead(s)) {
+    case '.': {
+      s.remove_prefix(1);
+      if (is_digit(lookahead(s))) {
+        goto post_decimal_point;
+      } else {
+        goto exponent_part_opt;
+      }
+    }
+    case 'e':
+    case 'E': {
+      s.remove_prefix(1);
+      goto post_e;
+    }
+    default:
+      return false;
+    }
+
+  post_decimal_point:
+    if (is_digit(lookahead(s))) {
+      s = consume_digits(s);
+      goto exponent_part_opt;
+    }
+    return false;
+
+  exponent_part_opt:
+    switch (lookahead(s)) {
+    case eof:
+      return true;
+    case 'e':
+    case 'E': {
+      s.remove_prefix(1);
+      goto post_e;
+    }
+    default:
+      return false;
+    }
+
+  post_e:
+    switch (lookahead(s)) {
+    case '-':
+    case '+':
+      s.remove_prefix(1);
+    }
+    if (is_digit(lookahead(s))) {
+      s = consume_digits(s);
+      return s.empty();
+    }
+    return false;
+  }
+
+  static bool is_optional(std::string_view name,
+                          std::string_view prefix_chars) {
+    return !is_positional(name, prefix_chars);
+  }
+
+  /*
+   * Get argument value given a type
+   * @throws std::logic_error in case of incompatible types
+   */
+  template <typename T> T get() const {
+    if (!m_values.empty()) {
+      if constexpr (details::IsContainer<T>) {
+        return any_cast_container<T>(m_values);
+      } else {
+        return std::any_cast<T>(m_values.front());
+      }
+    }
+    if (m_default_value.has_value()) {
+      return std::any_cast<T>(m_default_value);
+    }
+    if constexpr (details::IsContainer<T>) {
+      if (!m_accepts_optional_like_value) {
+        return any_cast_container<T>(m_values);
+      }
+    }
+
+    throw std::logic_error("No value provided for '" + m_names.back() + "'.");
+  }
+
+  /*
+   * Get argument value given a type.
+   * @pre The object has no default value.
+   * @returns The stored value if any, std::nullopt otherwise.
+   */
+  template <typename T> auto present() const -> std::optional<T> {
+    if (m_default_value.has_value()) {
+      throw std::logic_error("Argument with default value always presents");
+    }
+    if (m_values.empty()) {
+      return std::nullopt;
+    }
+    if constexpr (details::IsContainer<T>) {
+      return any_cast_container<T>(m_values);
+    }
+    return std::any_cast<T>(m_values.front());
+  }
+
+  template <typename T>
+  static auto any_cast_container(const std::vector<std::any> &operand) -> T {
+    using ValueType = typename T::value_type;
+
+    T result;
+    std::transform(
+        std::begin(operand), std::end(operand), std::back_inserter(result),
+        [](const auto &value) { return std::any_cast<ValueType>(value); });
+    return result;
+  }
+
+  void set_usage_newline_counter(int i) { m_usage_newline_counter = i; }
+
+  void set_group_idx(std::size_t i) { m_group_idx = i; }
+
+  std::vector<std::string> m_names;
+  std::string_view m_used_name;
+  std::string m_help;
+  std::string m_metavar;
+  std::any m_default_value;
+  std::string m_default_value_repr;
+  std::optional<std::string>
+      m_default_value_str; // used for checking default_value against choices
+  std::any m_implicit_value;
+  std::optional<std::vector<std::string>> m_choices{std::nullopt};
+  using valued_action = std::function<std::any(const std::string &)>;
+  using void_action = std::function<void(const std::string &)>;
+  std::variant<valued_action, void_action> m_action{
+      std::in_place_type<valued_action>,
+      [](const std::string &value) { return value; }};
+  std::vector<std::any> m_values;
+  NArgsRange m_num_args_range{1, 1};
+  // Bit field of bool values. Set default value in ctor.
+  bool m_accepts_optional_like_value : 1;
+  bool m_is_optional : 1;
+  bool m_is_required : 1;
+  bool m_is_repeatable : 1;
+  bool m_is_used : 1;
+  bool m_is_hidden : 1;            // if set, does not appear in usage or help
+  std::string_view m_prefix_chars; // ArgumentParser has the prefix_chars
+  int m_usage_newline_counter = 0;
+  std::size_t m_group_idx = 0;
+};
+
+class ArgumentParser {
+public:
+  explicit ArgumentParser(std::string program_name = {},
+                          std::string version = "1.0",
+                          default_arguments add_args = default_arguments::all,
+                          bool exit_on_default_arguments = true,
+                          std::ostream &os = std::cout)
+      : m_program_name(std::move(program_name)), m_version(std::move(version)),
+        m_exit_on_default_arguments(exit_on_default_arguments),
+        m_parser_path(m_program_name) {
+    if ((add_args & default_arguments::help) == default_arguments::help) {
+      add_argument("-h", "--help")
+          .action([&](const auto & /*unused*/) {
+            os << help().str();
+            if (m_exit_on_default_arguments) {
+              std::exit(0);
+            }
+          })
+          .default_value(false)
+          .help("shows help message and exits")
+          .implicit_value(true)
+          .nargs(0);
+    }
+    if ((add_args & default_arguments::version) == default_arguments::version) {
+      add_argument("-v", "--version")
+          .action([&](const auto & /*unused*/) {
+            os << m_version << std::endl;
+            if (m_exit_on_default_arguments) {
+              std::exit(0);
+            }
+          })
+          .default_value(false)
+          .help("prints version information and exits")
+          .implicit_value(true)
+          .nargs(0);
+    }
+  }
+
+  ~ArgumentParser() = default;
+
+  // ArgumentParser is meant to be used in a single function.
+  // Setup everything and parse arguments in one place.
+  //
+  // ArgumentParser internally uses std::string_views,
+  // references, iterators, etc.
+  // Many of these elements become invalidated after a copy or move.
+  ArgumentParser(const ArgumentParser &other) = delete;
+  ArgumentParser &operator=(const ArgumentParser &other) = delete;
+  ArgumentParser(ArgumentParser &&) noexcept = delete;
+  ArgumentParser &operator=(ArgumentParser &&) = delete;
+
+  explicit operator bool() const {
+    auto arg_used = std::any_of(m_argument_map.cbegin(), m_argument_map.cend(),
+                                [](auto &it) { return it.second->m_is_used; });
+    auto subparser_used =
+        std::any_of(m_subparser_used.cbegin(), m_subparser_used.cend(),
+                    [](auto &it) { return it.second; });
+
+    return m_is_parsed && (arg_used || subparser_used);
+  }
+
+  // Parameter packing
+  // Call add_argument with variadic number of string arguments
+  template <typename... Targs> Argument &add_argument(Targs... f_args) {
+    using array_of_sv = std::array<std::string_view, sizeof...(Targs)>;
+    auto argument =
+        m_optional_arguments.emplace(std::cend(m_optional_arguments),
+                                     m_prefix_chars, array_of_sv{f_args...});
+
+    if (!argument->m_is_optional) {
+      m_positional_arguments.splice(std::cend(m_positional_arguments),
+                                    m_optional_arguments, argument);
+    }
+    argument->set_usage_newline_counter(m_usage_newline_counter);
+    argument->set_group_idx(m_group_names.size());
+
+    index_argument(argument);
+    return *argument;
+  }
+
+  class MutuallyExclusiveGroup {
+    friend class ArgumentParser;
+
+  public:
+    MutuallyExclusiveGroup() = delete;
+
+    explicit MutuallyExclusiveGroup(ArgumentParser &parent,
+                                    bool required = false)
+        : m_parent(parent), m_required(required), m_elements({}) {}
+
+    MutuallyExclusiveGroup(const MutuallyExclusiveGroup &other) = delete;
+    MutuallyExclusiveGroup &
+    operator=(const MutuallyExclusiveGroup &other) = delete;
+
+    MutuallyExclusiveGroup(MutuallyExclusiveGroup &&other) noexcept
+        : m_parent(other.m_parent), m_required(other.m_required),
+          m_elements(std::move(other.m_elements)) {
+      other.m_elements.clear();
+    }
+
+    template <typename... Targs> Argument &add_argument(Targs... f_args) {
+      auto &argument = m_parent.add_argument(std::forward<Targs>(f_args)...);
+      m_elements.push_back(&argument);
+      argument.set_usage_newline_counter(m_parent.m_usage_newline_counter);
+      argument.set_group_idx(m_parent.m_group_names.size());
+      return argument;
+    }
+
+  private:
+    ArgumentParser &m_parent;
+    bool m_required{false};
+    std::vector<Argument *> m_elements{};
+  };
+
+  MutuallyExclusiveGroup &add_mutually_exclusive_group(bool required = false) {
+    m_mutually_exclusive_groups.emplace_back(*this, required);
+    return m_mutually_exclusive_groups.back();
+  }
+
+  // Parameter packed add_parents method
+  // Accepts a variadic number of ArgumentParser objects
+  template <typename... Targs>
+  ArgumentParser &add_parents(const Targs &... f_args) {
+    for (const ArgumentParser &parent_parser : {std::ref(f_args)...}) {
+      for (const auto &argument : parent_parser.m_positional_arguments) {
+        auto it = m_positional_arguments.insert(
+            std::cend(m_positional_arguments), argument);
+        index_argument(it);
+      }
+      for (const auto &argument : parent_parser.m_optional_arguments) {
+        auto it = m_optional_arguments.insert(std::cend(m_optional_arguments),
+                                              argument);
+        index_argument(it);
+      }
+    }
+    return *this;
+  }
+
+  // Ask for the next optional arguments to be displayed on a separate
+  // line in usage() output. Only effective if set_usage_max_line_width() is
+  // also used.
+  ArgumentParser &add_usage_newline() {
+    ++m_usage_newline_counter;
+    return *this;
+  }
+
+  // Ask for the next optional arguments to be displayed in a separate section
+  // in usage() and help (<< *this) output.
+  // For usage(), this is only effective if set_usage_max_line_width() is
+  // also used.
+  ArgumentParser &add_group(std::string group_name) {
+    m_group_names.emplace_back(std::move(group_name));
+    return *this;
+  }
+
+  ArgumentParser &add_description(std::string description) {
+    m_description = std::move(description);
+    return *this;
+  }
+
+  ArgumentParser &add_epilog(std::string epilog) {
+    m_epilog = std::move(epilog);
+    return *this;
+  }
+
+  // Add a un-documented/hidden alias for an argument.
+  // Ideally we'd want this to be a method of Argument, but Argument
+  // does not own its owing ArgumentParser.
+  ArgumentParser &add_hidden_alias_for(Argument &arg, std::string_view alias) {
+    for (auto it = m_optional_arguments.begin();
+         it != m_optional_arguments.end(); ++it) {
+      if (&(*it) == &arg) {
+        m_argument_map.insert_or_assign(std::string(alias), it);
+        return *this;
+      }
+    }
+    throw std::logic_error(
+        "Argument is not an optional argument of this parser");
+  }
+
+  /* Getter for arguments and subparsers.
+   * @throws std::logic_error in case of an invalid argument or subparser name
+   */
+  template <typename T = Argument> T &at(std::string_view name) {
+    if constexpr (std::is_same_v<T, Argument>) {
+      return (*this)[name];
+    } else {
+      std::string str_name(name);
+      auto subparser_it = m_subparser_map.find(str_name);
+      if (subparser_it != m_subparser_map.end()) {
+        return subparser_it->second->get();
+      }
+      throw std::logic_error("No such subparser: " + str_name);
+    }
+  }
+
+  ArgumentParser &set_prefix_chars(std::string prefix_chars) {
+    m_prefix_chars = std::move(prefix_chars);
+    return *this;
+  }
+
+  ArgumentParser &set_assign_chars(std::string assign_chars) {
+    m_assign_chars = std::move(assign_chars);
+    return *this;
+  }
+
+  /* Call parse_args_internal - which does all the work
+   * Then, validate the parsed arguments
+   * This variant is used mainly for testing
+   * @throws std::runtime_error in case of any invalid argument
+   */
+  void parse_args(const std::vector<std::string> &arguments) {
+    parse_args_internal(arguments);
+    // Check if all arguments are parsed
+    for ([[maybe_unused]] const auto &[unused, argument] : m_argument_map) {
+      argument->validate();
+    }
+
+    // Check each mutually exclusive group and make sure
+    // there are no constraint violations
+    for (const auto &group : m_mutually_exclusive_groups) {
+      auto mutex_argument_used{false};
+      Argument *mutex_argument_it{nullptr};
+      for (Argument *arg : group.m_elements) {
+        if (!mutex_argument_used && arg->m_is_used) {
+          mutex_argument_used = true;
+          mutex_argument_it = arg;
+        } else if (mutex_argument_used && arg->m_is_used) {
+          // Violation
+          throw std::runtime_error("Argument '" + arg->get_usage_full() +
+                                   "' not allowed with '" +
+                                   mutex_argument_it->get_usage_full() + "'");
+        }
+      }
+
+      if (!mutex_argument_used && group.m_required) {
+        // at least one argument from the group is
+        // required
+        std::string argument_names{};
+        std::size_t i = 0;
+        std::size_t size = group.m_elements.size();
+        for (Argument *arg : group.m_elements) {
+          if (i + 1 == size) {
+            // last
+            argument_names += "'" + arg->get_usage_full() + "' ";
+          } else {
+            argument_names += "'" + arg->get_usage_full() + "' or ";
+          }
+          i += 1;
+        }
+        throw std::runtime_error("One of the arguments " + argument_names +
+                                 "is required");
+      }
+    }
+  }
+
+  /* Call parse_known_args_internal - which does all the work
+   * Then, validate the parsed arguments
+   * This variant is used mainly for testing
+   * @throws std::runtime_error in case of any invalid argument
+   */
+  std::vector<std::string>
+  parse_known_args(const std::vector<std::string> &arguments) {
+    auto unknown_arguments = parse_known_args_internal(arguments);
+    // Check if all arguments are parsed
+    for ([[maybe_unused]] const auto &[unused, argument] : m_argument_map) {
+      argument->validate();
+    }
+    return unknown_arguments;
+  }
+
+  /* Main entry point for parsing command-line arguments using this
+   * ArgumentParser
+   * @throws std::runtime_error in case of any invalid argument
+   */
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
+  void parse_args(int argc, const char *const argv[]) {
+    parse_args({argv, argv + argc});
+  }
+
+  /* Main entry point for parsing command-line arguments using this
+   * ArgumentParser
+   * @throws std::runtime_error in case of any invalid argument
+   */
+  // NOLINTNEXTLINE(cppcoreguidelines-avoid-c-arrays)
+  auto parse_known_args(int argc, const char *const argv[]) {
+    return parse_known_args({argv, argv + argc});
+  }
+
+  /* Getter for options with default values.
+   * @throws std::logic_error if parse_args() has not been previously called
+   * @throws std::logic_error if there is no such option
+   * @throws std::logic_error if the option has no value
+   * @throws std::bad_any_cast if the option is not of type T
+   */
+  template <typename T = std::string> T get(std::string_view arg_name) const {
+    if (!m_is_parsed) {
+      throw std::logic_error("Nothing parsed, no arguments are available.");
+    }
+    return (*this)[arg_name].get<T>();
+  }
+
+  /* Getter for options without default values.
+   * @pre The option has no default value.
+   * @throws std::logic_error if there is no such option
+   * @throws std::bad_any_cast if the option is not of type T
+   */
+  template <typename T = std::string>
+  auto present(std::string_view arg_name) const -> std::optional<T> {
+    return (*this)[arg_name].present<T>();
+  }
+
+  /* Getter that returns true for user-supplied options. Returns false if not
+   * user-supplied, even with a default value.
+   */
+  auto is_used(std::string_view arg_name) const {
+    return (*this)[arg_name].m_is_used;
+  }
+
+  /* Getter that returns true if a subcommand is used.
+   */
+  auto is_subcommand_used(std::string_view subcommand_name) const {
+    return m_subparser_used.at(std::string(subcommand_name));
+  }
+
+  /* Getter that returns true if a subcommand is used.
+   */
+  auto is_subcommand_used(const ArgumentParser &subparser) const {
+    return is_subcommand_used(subparser.m_program_name);
+  }
+
+  /* Indexing operator. Return a reference to an Argument object
+   * Used in conjunction with Argument.operator== e.g., parser["foo"] == true
+   * @throws std::logic_error in case of an invalid argument name
+   */
+  Argument &operator[](std::string_view arg_name) const {
+    std::string name(arg_name);
+    auto it = m_argument_map.find(name);
+    if (it != m_argument_map.end()) {
+      return *(it->second);
+    }
+    if (!is_valid_prefix_char(arg_name.front())) {
+      const auto legal_prefix_char = get_any_valid_prefix_char();
+      const auto prefix = std::string(1, legal_prefix_char);
+
+      // "-" + arg_name
+      name = prefix + name;
+      it = m_argument_map.find(name);
+      if (it != m_argument_map.end()) {
+        return *(it->second);
+      }
+      // "--" + arg_name
+      name = prefix + name;
+      it = m_argument_map.find(name);
+      if (it != m_argument_map.end()) {
+        return *(it->second);
+      }
+    }
+    throw std::logic_error("No such argument: " + std::string(arg_name));
+  }
+
+  // Print help message
+  friend auto operator<<(std::ostream &stream, const ArgumentParser &parser)
+      -> std::ostream & {
+    stream.setf(std::ios_base::left);
+
+    auto longest_arg_length = parser.get_length_of_longest_argument();
+
+    stream << parser.usage() << "\n\n";
+
+    if (!parser.m_description.empty()) {
+      stream << parser.m_description << "\n\n";
+    }
+
+    const bool has_visible_positional_args = std::find_if(
+      parser.m_positional_arguments.begin(),
+      parser.m_positional_arguments.end(),
+      [](const auto &argument) {
+      return !argument.m_is_hidden; }) !=
+      parser.m_positional_arguments.end();
+    if (has_visible_positional_args) {
+      stream << "Positional arguments:\n";
+    }
+
+    for (const auto &argument : parser.m_positional_arguments) {
+      if (!argument.m_is_hidden) {
+        stream.width(static_cast<std::streamsize>(longest_arg_length));
+        stream << argument;
+      }
+    }
+
+    if (!parser.m_optional_arguments.empty()) {
+      stream << (!has_visible_positional_args ? "" : "\n")
+             << "Optional arguments:\n";
+    }
+
+    for (const auto &argument : parser.m_optional_arguments) {
+      if (argument.m_group_idx == 0 && !argument.m_is_hidden) {
+        stream.width(static_cast<std::streamsize>(longest_arg_length));
+        stream << argument;
+      }
+    }
+
+    for (size_t i_group = 0; i_group < parser.m_group_names.size(); ++i_group) {
+      stream << "\n" << parser.m_group_names[i_group] << " (detailed usage):\n";
+      for (const auto &argument : parser.m_optional_arguments) {
+        if (argument.m_group_idx == i_group + 1 && !argument.m_is_hidden) {
+          stream.width(static_cast<std::streamsize>(longest_arg_length));
+          stream << argument;
+        }
+      }
+    }
+
+    bool has_visible_subcommands = std::any_of(
+        parser.m_subparser_map.begin(), parser.m_subparser_map.end(),
+        [](auto &p) { return !p.second->get().m_suppress; });
+
+    if (has_visible_subcommands) {
+      stream << (parser.m_positional_arguments.empty()
+                     ? (parser.m_optional_arguments.empty() ? "" : "\n")
+                     : "\n")
+             << "Subcommands:\n";
+      for (const auto &[command, subparser] : parser.m_subparser_map) {
+        if (subparser->get().m_suppress) {
+          continue;
+        }
+
+        stream << std::setw(2) << " ";
+        stream << std::setw(static_cast<int>(longest_arg_length - 2))
+               << command;
+        stream << " " << subparser->get().m_description << "\n";
+      }
+    }
+
+    if (!parser.m_epilog.empty()) {
+      stream << '\n';
+      stream << parser.m_epilog << "\n\n";
+    }
+
+    return stream;
+  }
+
+  // Format help message
+  auto help() const -> std::stringstream {
+    std::stringstream out;
+    out << *this;
+    return out;
+  }
+
+  // Sets the maximum width for a line of the Usage message
+  ArgumentParser &set_usage_max_line_width(size_t w) {
+    this->m_usage_max_line_width = w;
+    return *this;
+  }
+
+  // Asks to display arguments of mutually exclusive group on separate lines in
+  // the Usage message
+  ArgumentParser &set_usage_break_on_mutex() {
+    this->m_usage_break_on_mutex = true;
+    return *this;
+  }
+
+  // Format usage part of help only
+  auto usage() const -> std::string {
+    std::stringstream stream;
+
+    std::string curline("Usage: ");
+    curline += this->m_program_name;
+    const bool multiline_usage =
+        this->m_usage_max_line_width < std::numeric_limits<std::size_t>::max();
+    const size_t indent_size = curline.size();
+
+    const auto deal_with_options_of_group = [&](std::size_t group_idx) {
+      bool found_options = false;
+      // Add any options inline here
+      const MutuallyExclusiveGroup *cur_mutex = nullptr;
+      int usage_newline_counter = -1;
+      for (const auto &argument : this->m_optional_arguments) {
+        if (argument.m_is_hidden) {
+          continue;
+        }
+        if (multiline_usage) {
+          if (argument.m_group_idx != group_idx) {
+            continue;
+          }
+          if (usage_newline_counter != argument.m_usage_newline_counter) {
+            if (usage_newline_counter >= 0) {
+              if (curline.size() > indent_size) {
+                stream << curline << std::endl;
+                curline = std::string(indent_size, ' ');
+              }
+            }
+            usage_newline_counter = argument.m_usage_newline_counter;
+          }
+        }
+        found_options = true;
+        const std::string arg_inline_usage = argument.get_inline_usage();
+        const MutuallyExclusiveGroup *arg_mutex =
+            get_belonging_mutex(&argument);
+        if ((cur_mutex != nullptr) && (arg_mutex == nullptr)) {
+          curline += ']';
+          if (this->m_usage_break_on_mutex) {
+            stream << curline << std::endl;
+            curline = std::string(indent_size, ' ');
+          }
+        } else if ((cur_mutex == nullptr) && (arg_mutex != nullptr)) {
+          if ((this->m_usage_break_on_mutex && curline.size() > indent_size) ||
+              curline.size() + 3 + arg_inline_usage.size() >
+                  this->m_usage_max_line_width) {
+            stream << curline << std::endl;
+            curline = std::string(indent_size, ' ');
+          }
+          curline += " [";
+        } else if ((cur_mutex != nullptr) && (arg_mutex != nullptr)) {
+          if (cur_mutex != arg_mutex) {
+            curline += ']';
+            if (this->m_usage_break_on_mutex ||
+                curline.size() + 3 + arg_inline_usage.size() >
+                    this->m_usage_max_line_width) {
+              stream << curline << std::endl;
+              curline = std::string(indent_size, ' ');
+            }
+            curline += " [";
+          } else {
+            curline += '|';
+          }
+        }
+        cur_mutex = arg_mutex;
+        if (curline.size() + 1 + arg_inline_usage.size() >
+            this->m_usage_max_line_width) {
+          stream << curline << std::endl;
+          curline = std::string(indent_size, ' ');
+          curline += " ";
+        } else if (cur_mutex == nullptr) {
+          curline += " ";
+        }
+        curline += arg_inline_usage;
+      }
+      if (cur_mutex != nullptr) {
+        curline += ']';
+      }
+      return found_options;
+    };
+
+    const bool found_options = deal_with_options_of_group(0);
+
+    if (found_options && multiline_usage &&
+        !this->m_positional_arguments.empty()) {
+      stream << curline << std::endl;
+      curline = std::string(indent_size, ' ');
+    }
+    // Put positional arguments after the optionals
+    for (const auto &argument : this->m_positional_arguments) {
+      if (argument.m_is_hidden) {
+        continue;
+      }
+      const std::string pos_arg = !argument.m_metavar.empty()
+                                      ? argument.m_metavar
+                                      : argument.m_names.front();
+      if (curline.size() + 1 + pos_arg.size() > this->m_usage_max_line_width) {
+        stream << curline << std::endl;
+        curline = std::string(indent_size, ' ');
+      }
+      curline += " ";
+      if (argument.m_num_args_range.get_min() == 0 &&
+          !argument.m_num_args_range.is_right_bounded()) {
+        curline += "[";
+        curline += pos_arg;
+        curline += "]...";
+      } else if (argument.m_num_args_range.get_min() == 1 &&
+                 !argument.m_num_args_range.is_right_bounded()) {
+        curline += pos_arg;
+        curline += "...";
+      } else {
+        curline += pos_arg;
+      }
+    }
+
+    if (multiline_usage) {
+      // Display options of other groups
+      for (std::size_t i = 0; i < m_group_names.size(); ++i) {
+        stream << curline << std::endl << std::endl;
+        stream << m_group_names[i] << ":" << std::endl;
+        curline = std::string(indent_size, ' ');
+        deal_with_options_of_group(i + 1);
+      }
+    }
+
+    stream << curline;
+
+    // Put subcommands after positional arguments
+    if (!m_subparser_map.empty()) {
+      stream << " {";
+      std::size_t i{0};
+      for (const auto &[command, subparser] : m_subparser_map) {
+        if (subparser->get().m_suppress) {
+          continue;
+        }
+
+        if (i == 0) {
+          stream << command;
+        } else {
+          stream << "," << command;
+        }
+        ++i;
+      }
+      stream << "}";
+    }
+
+    return stream.str();
+  }
+
+  // Printing the one and only help message
+  // I've stuck with a simple message format, nothing fancy.
+  [[deprecated("Use cout << program; instead.  See also help().")]] std::string
+  print_help() const {
+    auto out = help();
+    std::cout << out.rdbuf();
+    return out.str();
+  }
+
+  void add_subparser(ArgumentParser &parser) {
+    parser.m_parser_path = m_program_name + " " + parser.m_program_name;
+    auto it = m_subparsers.emplace(std::cend(m_subparsers), parser);
+    m_subparser_map.insert_or_assign(parser.m_program_name, it);
+    m_subparser_used.insert_or_assign(parser.m_program_name, false);
+  }
+
+  void set_suppress(bool suppress) { m_suppress = suppress; }
+
+protected:
+  const MutuallyExclusiveGroup *get_belonging_mutex(const Argument *arg) const {
+    for (const auto &mutex : m_mutually_exclusive_groups) {
+      if (std::find(mutex.m_elements.begin(), mutex.m_elements.end(), arg) !=
+          mutex.m_elements.end()) {
+        return &mutex;
+      }
+    }
+    return nullptr;
+  }
+
+  bool is_valid_prefix_char(char c) const {
+    return m_prefix_chars.find(c) != std::string::npos;
+  }
+
+  char get_any_valid_prefix_char() const { return m_prefix_chars[0]; }
+
+  /*
+   * Pre-process this argument list. Anything starting with "--", that
+   * contains an =, where the prefix before the = has an entry in the
+   * options table, should be split.
+   */
+  std::vector<std::string>
+  preprocess_arguments(const std::vector<std::string> &raw_arguments) const {
+    std::vector<std::string> arguments{};
+    for (const auto &arg : raw_arguments) {
+
+      const auto argument_starts_with_prefix_chars =
+          [this](const std::string &a) -> bool {
+        if (!a.empty()) {
+
+          const auto legal_prefix = [this](char c) -> bool {
+            return m_prefix_chars.find(c) != std::string::npos;
+          };
+
+          // Windows-style
+          // if '/' is a legal prefix char
+          // then allow single '/' followed by argument name, followed by an
+          // assign char, e.g., ':' e.g., 'test.exe /A:Foo'
+          const auto windows_style = legal_prefix('/');
+
+          if (windows_style) {
+            if (legal_prefix(a[0])) {
+              return true;
+            }
+          } else {
+            // Slash '/' is not a legal prefix char
+            // For all other characters, only support long arguments
+            // i.e., the argument must start with 2 prefix chars, e.g,
+            // '--foo' e,g, './test --foo=Bar -DARG=yes'
+            if (a.size() > 1) {
+              return (legal_prefix(a[0]) && legal_prefix(a[1]));
+            }
+          }
+        }
+        return false;
+      };
+
+      // Check that:
+      // - We don't have an argument named exactly this
+      // - The argument starts with a prefix char, e.g., "--"
+      // - The argument contains an assign char, e.g., "="
+      auto assign_char_pos = arg.find_first_of(m_assign_chars);
+
+      if (m_argument_map.find(arg) == m_argument_map.end() &&
+          argument_starts_with_prefix_chars(arg) &&
+          assign_char_pos != std::string::npos) {
+        // Get the name of the potential option, and check it exists
+        std::string opt_name = arg.substr(0, assign_char_pos);
+        if (m_argument_map.find(opt_name) != m_argument_map.end()) {
+          // This is the name of an option! Split it into two parts
+          arguments.push_back(std::move(opt_name));
+          arguments.push_back(arg.substr(assign_char_pos + 1));
+          continue;
+        }
+      }
+      // If we've fallen through to here, then it's a standard argument
+      arguments.push_back(arg);
+    }
+    return arguments;
+  }
+
+  /*
+   * @throws std::runtime_error in case of any invalid argument
+   */
+  void parse_args_internal(const std::vector<std::string> &raw_arguments) {
+    auto arguments = preprocess_arguments(raw_arguments);
+    if (m_program_name.empty() && !arguments.empty()) {
+      m_program_name = arguments.front();
+    }
+    auto end = std::end(arguments);
+    auto positional_argument_it = std::begin(m_positional_arguments);
+    for (auto it = std::next(std::begin(arguments)); it != end;) {
+      const auto &current_argument = *it;
+      if (Argument::is_positional(current_argument, m_prefix_chars)) {
+        if (positional_argument_it == std::end(m_positional_arguments)) {
+
+          // Check sub-parsers
+          auto subparser_it = m_subparser_map.find(current_argument);
+          if (subparser_it != m_subparser_map.end()) {
+
+            // build list of remaining args
+            const auto unprocessed_arguments =
+                std::vector<std::string>(it, end);
+
+            // invoke subparser
+            m_is_parsed = true;
+            m_subparser_used[current_argument] = true;
+            return subparser_it->second->get().parse_args(
+                unprocessed_arguments);
+          }
+
+          if (m_positional_arguments.empty()) {
+
+            // Ask the user if they argument they provided was a typo
+            // for some sub-parser,
+            // e.g., user provided `git totes` instead of `git notes`
+            if (!m_subparser_map.empty()) {
+              throw std::runtime_error(
+                  "Failed to parse '" + current_argument + "', did you mean '" +
+                  std::string{details::get_most_similar_string(
+                      m_subparser_map, current_argument)} +
+                  "'");
+            }
+
+            // Ask the user if they meant to use a specific optional argument
+            if (!m_optional_arguments.empty()) {
+              for (const auto &opt : m_optional_arguments) {
+                if (!opt.m_implicit_value.has_value()) {
+                  // not a flag, requires a value
+                  if (!opt.m_is_used) {
+                    throw std::runtime_error(
+                        "Zero positional arguments expected, did you mean " +
+                        opt.get_usage_full());
+                  }
+                }
+              }
+
+              throw std::runtime_error("Zero positional arguments expected");
+            } else {
+              throw std::runtime_error("Zero positional arguments expected");
+            }
+          } else {
+            throw std::runtime_error("Maximum number of positional arguments "
+                                     "exceeded, failed to parse '" +
+                                     current_argument + "'");
+          }
+        }
+        auto argument = positional_argument_it++;
+        it = argument->consume(it, end);
+        continue;
+      }
+
+      auto arg_map_it = m_argument_map.find(current_argument);
+      if (arg_map_it != m_argument_map.end()) {
+        auto argument = arg_map_it->second;
+        it = argument->consume(std::next(it), end, arg_map_it->first);
+      } else if (const auto &compound_arg = current_argument;
+                 compound_arg.size() > 1 &&
+                 is_valid_prefix_char(compound_arg[0]) &&
+                 !is_valid_prefix_char(compound_arg[1])) {
+        ++it;
+        for (std::size_t j = 1; j < compound_arg.size(); j++) {
+          auto hypothetical_arg = std::string{'-', compound_arg[j]};
+          auto arg_map_it2 = m_argument_map.find(hypothetical_arg);
+          if (arg_map_it2 != m_argument_map.end()) {
+            auto argument = arg_map_it2->second;
+            it = argument->consume(it, end, arg_map_it2->first);
+          } else {
+            throw std::runtime_error("Unknown argument: " + current_argument);
+          }
+        }
+      } else {
+        throw std::runtime_error("Unknown argument: " + current_argument);
+      }
+    }
+    m_is_parsed = true;
+  }
+
+  /*
+   * Like parse_args_internal but collects unused args into a vector<string>
+   */
+  std::vector<std::string>
+  parse_known_args_internal(const std::vector<std::string> &raw_arguments) {
+    auto arguments = preprocess_arguments(raw_arguments);
+
+    std::vector<std::string> unknown_arguments{};
+
+    if (m_program_name.empty() && !arguments.empty()) {
+      m_program_name = arguments.front();
+    }
+    auto end = std::end(arguments);
+    auto positional_argument_it = std::begin(m_positional_arguments);
+    for (auto it = std::next(std::begin(arguments)); it != end;) {
+      const auto &current_argument = *it;
+      if (Argument::is_positional(current_argument, m_prefix_chars)) {
+        if (positional_argument_it == std::end(m_positional_arguments)) {
+
+          // Check sub-parsers
+          auto subparser_it = m_subparser_map.find(current_argument);
+          if (subparser_it != m_subparser_map.end()) {
+
+            // build list of remaining args
+            const auto unprocessed_arguments =
+                std::vector<std::string>(it, end);
+
+            // invoke subparser
+            m_is_parsed = true;
+            m_subparser_used[current_argument] = true;
+            return subparser_it->second->get().parse_known_args_internal(
+                unprocessed_arguments);
+          }
+
+          // save current argument as unknown and go to next argument
+          unknown_arguments.push_back(current_argument);
+          ++it;
+        } else {
+          // current argument is the value of a positional argument
+          // consume it
+          auto argument = positional_argument_it++;
+          it = argument->consume(it, end);
+        }
+        continue;
+      }
+
+      auto arg_map_it = m_argument_map.find(current_argument);
+      if (arg_map_it != m_argument_map.end()) {
+        auto argument = arg_map_it->second;
+        it = argument->consume(std::next(it), end, arg_map_it->first);
+      } else if (const auto &compound_arg = current_argument;
+                 compound_arg.size() > 1 &&
+                 is_valid_prefix_char(compound_arg[0]) &&
+                 !is_valid_prefix_char(compound_arg[1])) {
+        ++it;
+        for (std::size_t j = 1; j < compound_arg.size(); j++) {
+          auto hypothetical_arg = std::string{'-', compound_arg[j]};
+          auto arg_map_it2 = m_argument_map.find(hypothetical_arg);
+          if (arg_map_it2 != m_argument_map.end()) {
+            auto argument = arg_map_it2->second;
+            it = argument->consume(it, end, arg_map_it2->first);
+          } else {
+            unknown_arguments.push_back(current_argument);
+            break;
+          }
+        }
+      } else {
+        // current argument is an optional-like argument that is unknown
+        // save it and move to next argument
+        unknown_arguments.push_back(current_argument);
+        ++it;
+      }
+    }
+    m_is_parsed = true;
+    return unknown_arguments;
+  }
+
+  // Used by print_help.
+  std::size_t get_length_of_longest_argument() const {
+    if (m_argument_map.empty()) {
+      return 0;
+    }
+    std::size_t max_size = 0;
+    for ([[maybe_unused]] const auto &[unused, argument] : m_argument_map) {
+      max_size =
+          std::max<std::size_t>(max_size, argument->get_arguments_length());
+    }
+    for ([[maybe_unused]] const auto &[command, unused] : m_subparser_map) {
+      max_size = std::max<std::size_t>(max_size, command.size());
+    }
+    return max_size;
+  }
+
+  using argument_it = std::list<Argument>::iterator;
+  using mutex_group_it = std::vector<MutuallyExclusiveGroup>::iterator;
+  using argument_parser_it =
+      std::list<std::reference_wrapper<ArgumentParser>>::iterator;
+
+  void index_argument(argument_it it) {
+    for (const auto &name : std::as_const(it->m_names)) {
+      m_argument_map.insert_or_assign(name, it);
+    }
+  }
+
+  std::string m_program_name;
+  std::string m_version;
+  std::string m_description;
+  std::string m_epilog;
+  bool m_exit_on_default_arguments = true;
+  std::string m_prefix_chars{"-"};
+  std::string m_assign_chars{"="};
+  bool m_is_parsed = false;
+  std::list<Argument> m_positional_arguments;
+  std::list<Argument> m_optional_arguments;
+  std::map<std::string, argument_it> m_argument_map;
+  std::string m_parser_path;
+  std::list<std::reference_wrapper<ArgumentParser>> m_subparsers;
+  std::map<std::string, argument_parser_it> m_subparser_map;
+  std::map<std::string, bool> m_subparser_used;
+  std::vector<MutuallyExclusiveGroup> m_mutually_exclusive_groups;
+  bool m_suppress = false;
+  std::size_t m_usage_max_line_width = std::numeric_limits<std::size_t>::max();
+  bool m_usage_break_on_mutex = false;
+  int m_usage_newline_counter = 0;
+  std::vector<std::string> m_group_names;
+};
+
+} // namespace argparse

--- a/apps/gdal_translate_bin.cpp
+++ b/apps/gdal_translate_bin.cpp
@@ -38,69 +38,11 @@
 /*                               Usage()                                */
 /* ******************************************************************** */
 
-static void Usage(bool bIsError, const char *pszErrorMsg = nullptr,
-                  bool bShort = true) CPL_NO_RETURN;
-
-static void Usage(bool bIsError, const char *pszErrorMsg, bool bShort)
-
+static void Usage()
 {
-    fprintf(
-        bIsError ? stderr : stdout,
-        "Usage: gdal_translate [--help] [--help-general] [--long-usage]\n"
-        "       [-ot "
-        "{Byte/Int8/Int16/UInt16/UInt32/Int32/UInt64/Int64/Float32/Float64/\n"
-        "             CInt16/CInt32/CFloat32/CFloat64}] [-strict]\n"
-        "       [-if <format>]... [-of <format>]\n"
-        "       [-b <band>] [-mask <band>] [-expand {gray|rgb|rgba}]\n"
-        "       [-outsize <xsize>[%%]|0 <ysize>[%%]|0] [-tr <xres> <yres>]\n"
-        "       [-ovr <level>|AUTO|AUTO-<n>|NONE]\n"
-        "       [-r "
-        "{nearest,bilinear,cubic,cubicspline,lanczos,average,mode}]\n"
-        "       [-unscale] [-scale[_bn] [<src_min> <src_max> [<dst_min> "
-        "<dst_max>]]]... "
-        "[-exponent[_bn] <exp_val>]...\n"
-        "       [-srcwin <xoff> <yoff> <xsize> <ysize>] [-epo] [-eco]\n"
-        "       [-projwin <ulx> <uly> <lrx> <lry>] [-projwin_srs <srs_def>]\n"
-        "       [-a_srs <srs_def>] [-a_coord_epoch <epoch>]\n"
-        "       [-a_ullr <ulx> <uly> <lrx> <lry>] [-a_nodata <value>]\n"
-        "       [-a_gt <gt0> <gt1> <gt2> <gt3> <gt4> <gt5>]\n"
-        "       [-a_scale <value>] [-a_offset <value>]\n"
-        "       [-nogcp] [-gcp <pixel> <line> <easting> <northing> "
-        "[<elevation>]]...\n"
-        "       |-colorinterp{_bn} {red|green|blue|alpha|gray|undefined}]\n"
-        "       |-colorinterp {red|green|blue|alpha|gray|undefined},...]\n"
-        "       [-mo <META-TAG>=<VALUE>]... [-dmo "
-        "<DOMAIN:META-TAG>=<VALUE>]... [-q] [-sds]\n"
-        "       [-co <NAME>=<VALUE>]... [-stats] [-norat] [-noxmp]\n"
-        "       [-oo <NAME>=<VALUE>]...\n"
-        "       <src_dataset> <dst_dataset>\n");
+    fprintf(stderr, "%s\n", GDALTranslateGetParserUsage().c_str());
 
-    if (!bShort)
-    {
-        printf("\n%s\n\n", GDALVersionInfo("--version"));
-        printf("The following format drivers are configured and support "
-               "output:\n");
-        for (int iDr = 0; iDr < GDALGetDriverCount(); iDr++)
-        {
-            GDALDriverH hDriver = GDALGetDriver(iDr);
-
-            if (GDALGetMetadataItem(hDriver, GDAL_DCAP_RASTER, nullptr) !=
-                    nullptr &&
-                (GDALGetMetadataItem(hDriver, GDAL_DCAP_CREATE, nullptr) !=
-                     nullptr ||
-                 GDALGetMetadataItem(hDriver, GDAL_DCAP_CREATECOPY, nullptr) !=
-                     nullptr))
-            {
-                printf("  %s: %s\n", GDALGetDriverShortName(hDriver),
-                       GDALGetDriverLongName(hDriver));
-            }
-        }
-    }
-
-    if (pszErrorMsg != nullptr)
-        fprintf(stderr, "\nFAILURE: %s\n", pszErrorMsg);
-
-    exit(bIsError ? 1 : 0);
+    exit(1);
 }
 
 /************************************************************************/
@@ -124,26 +66,6 @@ MAIN_START(argc, argv)
     argc = GDALGeneralCmdLineProcessor(argc, &argv, 0);
     if (argc < 1)
         exit(-argc);
-
-    for (int i = 0; argv != nullptr && argv[i] != nullptr; i++)
-    {
-        if (EQUAL(argv[i], "--utility_version"))
-        {
-            printf("%s was compiled against GDAL %s and is running against "
-                   "GDAL %s\n",
-                   argv[0], GDAL_RELEASE_NAME, GDALVersionInfo("RELEASE_NAME"));
-            CSLDestroy(argv);
-            return 0;
-        }
-        else if (EQUAL(argv[i], "--help"))
-        {
-            Usage(false, nullptr);
-        }
-        else if (EQUAL(argv[i], "--long-usage"))
-        {
-            Usage(false, nullptr, FALSE);
-        }
-    }
 
     /* -------------------------------------------------------------------- */
     /*      Set optimal setting for best performance with huge input VRT.   */
@@ -171,17 +93,7 @@ MAIN_START(argc, argv)
 
     if (psOptions == nullptr)
     {
-        Usage(true, nullptr);
-    }
-
-    if (sOptionsForBinary.osSource.empty())
-    {
-        Usage(true, "No source dataset specified.");
-    }
-
-    if (sOptionsForBinary.osDest.empty())
-    {
-        Usage(true, "No target dataset specified.");
+        Usage();
     }
 
     if (sOptionsForBinary.osDest == "/vsistdout/")
@@ -350,7 +262,7 @@ MAIN_START(argc, argv)
         }
 
         if (bUsageError == TRUE)
-            Usage(true);
+            Usage();
         GDALClose(hDataset);
         GDALTranslateOptionsFree(psOptions);
 
@@ -365,7 +277,7 @@ MAIN_START(argc, argv)
     hOutDS = GDALTranslate(sOptionsForBinary.osDest.c_str(), hDataset,
                            psOptions, &bUsageError);
     if (bUsageError == TRUE)
-        Usage(true);
+        Usage();
     int nRetCode = hOutDS ? 0 : 1;
 
     /* Close hOutDS before hDataset for the -f VRT case */

--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -31,6 +31,7 @@
 #include "cpl_port.h"
 #include "gdal_utils.h"
 #include "gdal_utils_priv.h"
+#include "gdalargumentparser.h"
 
 #include <cmath>
 #include <cstdlib>
@@ -125,6 +126,9 @@ struct GDALTranslateOptions
 
     /*! for the output bands to be of the indicated data type */
     GDALDataType eOutputType = GDT_Unknown;
+
+    /*! Used only by parser logic */
+    bool bParsedMaskArgument = false;
 
     MaskMode eMaskMode = MASK_AUTO;
 
@@ -2752,6 +2756,441 @@ static int GetColorInterp(const char *pszStr)
 }
 
 /************************************************************************/
+/*                     GDALTranslateOptionsGetParser()                  */
+/************************************************************************/
+
+static std::unique_ptr<GDALArgumentParser>
+GDALTranslateOptionsGetParser(GDALTranslateOptions *psOptions,
+                              GDALTranslateOptionsForBinary *psOptionsForBinary)
+{
+    auto argParser = std::make_unique<GDALArgumentParser>(
+        "gdal_translate", /* bForBinary=*/psOptionsForBinary != nullptr);
+
+    argParser->add_description(
+        _("Convert raster data between different formats, with potential "
+          "subsetting, resampling, and rescaling pixels in the process."));
+
+    argParser->add_epilog(_("https://gdal.org/programs/gdal_translate.html"));
+
+    argParser->add_output_type_argument(psOptions->eOutputType);
+
+    argParser->add_argument("-if")
+        .append()
+        .metavar("<format>")
+        .action(
+            [psOptionsForBinary](const std::string &s)
+            {
+                if (psOptionsForBinary)
+                {
+                    if (GDALGetDriverByName(s.c_str()) == nullptr)
+                    {
+                        CPLError(CE_Warning, CPLE_AppDefined,
+                                 "%s is not a recognized driver", s.c_str());
+                    }
+                    psOptionsForBinary->aosAllowedInputDrivers.AddString(
+                        s.c_str());
+                }
+            })
+        .help(_("Format/driver name(s) to try when opening the input file."));
+
+    argParser->add_output_format_argument(psOptions->osFormat);
+
+    // Written that way so that in library mode, users can still use the -q
+    // switch, even if it has no effect
+    argParser->add_quiet_argument(
+        psOptionsForBinary ? &(psOptionsForBinary->bQuiet) : nullptr);
+
+    argParser->add_argument("-b")
+        .append()
+        .metavar("<band>")
+        .action(
+            [psOptions](const std::string &s)
+            {
+                const char *pszBand = s.c_str();
+                bool bMask = false;
+                if (EQUAL(pszBand, "mask"))
+                    pszBand = "mask,1";
+                if (STARTS_WITH_CI(pszBand, "mask,"))
+                {
+                    bMask = true;
+                    pszBand += 5;
+                    /* If we use the source mask band as a regular band */
+                    /* don't create a target mask band by default */
+                    if (!psOptions->bParsedMaskArgument)
+                        psOptions->eMaskMode = MASK_DISABLED;
+                }
+                const int nBand = atoi(pszBand);
+                if (nBand < 1)
+                {
+                    throw std::invalid_argument(CPLSPrintf(
+                        "Unrecognizable band number (%s).", s.c_str()));
+                }
+
+                psOptions->nBandCount++;
+                psOptions->anBandList.emplace_back(nBand * (bMask ? -1 : 1));
+            })
+        .help(_("Select input band(s)"));
+
+    argParser->add_argument("-mask")
+        .metavar("<mask>")
+        .action(
+            [psOptions](const std::string &s)
+            {
+                psOptions->bParsedMaskArgument = true;
+                const char *pszBand = s.c_str();
+                if (EQUAL(pszBand, "none"))
+                {
+                    psOptions->eMaskMode = MASK_DISABLED;
+                }
+                else if (EQUAL(pszBand, "auto"))
+                {
+                    psOptions->eMaskMode = MASK_AUTO;
+                }
+                else
+                {
+                    bool bMask = false;
+
+                    if (EQUAL(pszBand, "mask"))
+                        pszBand = "mask,1";
+                    if (STARTS_WITH_CI(pszBand, "mask,"))
+                    {
+                        bMask = true;
+                        pszBand += 5;
+                    }
+                    const int nBand = atoi(pszBand);
+                    if (nBand < 1)
+                    {
+                        throw std::invalid_argument(CPLSPrintf(
+                            "Unrecognizable band number (%s).", s.c_str()));
+                    }
+
+                    psOptions->eMaskMode = MASK_USER;
+                    psOptions->nMaskBand = nBand;
+                    if (bMask)
+                        psOptions->nMaskBand *= -1;
+                }
+            })
+        .help(_("Select an input band to create output dataset mask band"));
+
+    argParser->add_argument("-expand")
+        .metavar("gray|rgb|rgba")
+        .action(
+            [psOptions](const std::string &s)
+            {
+                if (EQUAL(s.c_str(), "gray"))
+                    psOptions->nRGBExpand = 1;
+                else if (EQUAL(s.c_str(), "rgb"))
+                    psOptions->nRGBExpand = 3;
+                else if (EQUAL(s.c_str(), "rgba"))
+                    psOptions->nRGBExpand = 4;
+                else
+                {
+                    throw std::invalid_argument(CPLSPrintf(
+                        "Value %s unsupported. Only gray, rgb or rgba are "
+                        "supported.",
+                        s.c_str()));
+                }
+            })
+        .help(_("To expose a dataset with 1 band with a color table as a "
+                "dataset with 3 (RGB) or 4 (RGBA) bands."));
+
+    {
+        auto &group = argParser->add_mutually_exclusive_group();
+        group.add_argument("-strict")
+            .store_into(psOptions->bStrict)
+            .help(_("Enable strict mode"));
+
+        group.add_argument("-not_strict")
+            .flag()
+            .action([psOptions](const std::string &)
+                    { psOptions->bStrict = false; })
+            .help(_("Disable strict mode"));
+    }
+
+    argParser->add_argument("-outsize")
+        .metavar("<xsize[%]|0> <ysize[%]|0>")
+        .nargs(2)
+        .help(_("Set the size of the output file."));
+
+    argParser->add_argument("-tr")
+        .metavar("<xres> <yes>")
+        .nargs(2)
+        .scan<'g', double>()
+        .help(_("Set target resolution."));
+
+    argParser->add_argument("-ovr")
+        .metavar("<level>|AUTO|AUTO-<n>|NONE")
+        .action(
+            [psOptions](const std::string &s)
+            {
+                const char *pszOvLevel = s.c_str();
+                if (EQUAL(pszOvLevel, "AUTO"))
+                    psOptions->nOvLevel = OVR_LEVEL_AUTO;
+                else if (STARTS_WITH_CI(pszOvLevel, "AUTO-"))
+                    psOptions->nOvLevel =
+                        OVR_LEVEL_AUTO - atoi(pszOvLevel + strlen("AUTO-"));
+                else if (EQUAL(pszOvLevel, "NONE"))
+                    psOptions->nOvLevel = OVR_LEVEL_NONE;
+                else if (CPLGetValueType(pszOvLevel) == CPL_VALUE_INTEGER)
+                    psOptions->nOvLevel = atoi(pszOvLevel);
+                else
+                {
+                    throw std::invalid_argument(CPLSPrintf(
+                        "Invalid value '%s' for -ovr option", pszOvLevel));
+                }
+            })
+        .help(_("Specify which overview level of source file must be used"));
+
+    if (psOptionsForBinary)
+    {
+        argParser->add_argument("-sds")
+            .store_into(psOptionsForBinary->bCopySubDatasets)
+            .help(_("Copy subdatasets"));
+    }
+
+    argParser->add_argument("-r")
+        .metavar("nearest,bilinear,cubic,cubicspline,lanczos,average,mode")
+        .store_into(psOptions->osResampling)
+        .help(_("Resampling algorithm."));
+
+    {
+        auto &group = argParser->add_mutually_exclusive_group();
+        group.add_argument("-scale")
+            .metavar("[<src_min> <src_max> [<dst_min> <dst_max>]]")
+            //.nargs(0, 4)
+            .append()
+            .scan<'g', double>()
+            .help(_("Rescale the input pixels values from the range src_min to "
+                    "src_max to the range dst_min to dst_max."));
+
+        group.add_argument("-scale_X")
+            .metavar("[<src_min> <src_max> [<dst_min> <dst_max>]]")
+            //.nargs(0, 4)
+            .append()
+            .scan<'g', double>()
+            .help(_("Rescale the input pixels values for band X."));
+
+        group.add_argument("-unscale")
+            .store_into(psOptions->bUnscale)
+            .help(_("Apply the scale/offset metadata for the bands to convert "
+                    "scaled values to unscaled values."));
+    }
+
+    {
+        auto &group = argParser->add_mutually_exclusive_group();
+        group.add_argument("-exponent")
+            .metavar("<value>")
+            .scan<'g', double>()
+            .help(_(
+                "Exponent to apply non-linear scaling with a power function"));
+
+        group.add_argument("-exponent_X")
+            .append()
+            .metavar("<value>")
+            .scan<'g', double>()
+            .help(
+                _("Exponent to apply non-linear scaling with a power function, "
+                  "for band X"));
+    }
+
+    argParser->add_argument("-srcwin")
+        .metavar("<xoff> <yoff> <xsize> <ysize>")
+        .nargs(4)
+        .scan<'g', double>()
+        .help(_("Selects a subwindow from the source image based on pixel/line "
+                "location."));
+
+    argParser->add_argument("-projwin")
+        .metavar("<ulx> <uly> <lrx> <lry>")
+        .nargs(4)
+        .scan<'g', double>()
+        .help(_("Selects a subwindow from the source image based on "
+                "georeferenced coordinates."));
+
+    argParser->add_argument("-projwin_srs")
+        .metavar("<srs_def>")
+        .store_into(psOptions->osProjSRS)
+        .help(_("Specifies the SRS in which to interpret the coordinates given "
+                "with -projwin."));
+
+    argParser->add_argument("-epo")
+        .flag()
+        .action(
+            [psOptions](const std::string &)
+            {
+                psOptions->bErrorOnPartiallyOutside = true;
+                psOptions->bErrorOnCompletelyOutside = true;
+            })
+        .help(_("Error when Partially Outside."));
+
+    argParser->add_argument("-eco")
+        .store_into(psOptions->bErrorOnCompletelyOutside)
+        .help(_("Error when Completely Outside."));
+
+    argParser->add_argument("-a_srs")
+        .metavar("<srs_def>")
+        .store_into(psOptions->osOutputSRS)
+        .help(_("Override the projection for the output file."));
+
+    argParser->add_argument("-a_coord_epoch")
+        .metavar("<epoch>")
+        .store_into(psOptions->dfOutputCoordinateEpoch)
+        .help(_("Assign a coordinate epoch."));
+
+    argParser->add_argument("-a_ullr")
+        .metavar("<ulx> <uly> <lrx> <lry>")
+        .nargs(4)
+        .scan<'g', double>()
+        .help(
+            _("Assign/override the georeferenced bounds of the output file."));
+
+    argParser->add_argument("-a_nodata")
+        .metavar("<value>|none")
+        .action(
+            [psOptions](const std::string &s)
+            {
+                if (EQUAL(s.c_str(), "none"))
+                {
+                    psOptions->bUnsetNoData = true;
+                }
+                else
+                {
+                    psOptions->bSetNoData = true;
+                    psOptions->osNoData = s;
+                }
+            })
+        .help(_("Assign a specified nodata value to output bands."));
+
+    argParser->add_argument("-a_gt")
+        .metavar("<gt(0)> <gt(1)> <gt(2)> <gt(3)> <gt(4)> <gt(5)>")
+        .nargs(6)
+        .scan<'g', double>()
+        .help(_("Assign/override the geotransform of the output file."));
+
+    argParser->add_argument("-a_scale")
+        .metavar("<value>")
+        .store_into(psOptions->dfScale)
+        .help(_("Set band scaling value."));
+
+    argParser->add_argument("-a_offset")
+        .metavar("<value>")
+        .store_into(psOptions->dfOffset)
+        .help(_("Set band offset value."));
+
+    argParser->add_argument("-nogcp")
+        .store_into(psOptions->bNoGCP)
+        .help(_("Do not copy the GCPs in the source dataset to the output "
+                "dataset."));
+
+    argParser->add_argument("-gcp")
+        .metavar("<pixel> <line> <easting> <northing> [<elevation>]")
+        .nargs(4, 5)
+        .append()
+        .scan<'g', double>()
+        .help(
+            _("Add the indicated ground control point to the output dataset."));
+
+    argParser->add_argument("-colorinterp")
+        .metavar("{red|green|blue|alpha|gray|undefined},...")
+        .action(
+            [psOptions](const std::string &s)
+            {
+                CPLStringList aosList(CSLTokenizeString2(s.c_str(), ",", 0));
+                psOptions->anColorInterp.resize(aosList.size());
+                for (int j = 0; j < aosList.size(); j++)
+                {
+                    psOptions->anColorInterp[j] = GetColorInterp(aosList[j]);
+                }
+            })
+        .help(_("Override the color interpretation of all specified bands."));
+
+    argParser->add_argument("-colorinterp_X")
+        .append()
+        .metavar("{red|green|blue|alpha|gray|undefined}")
+        .help(_("Override the color interpretation of band X."));
+
+    {
+        auto &group = argParser->add_mutually_exclusive_group();
+        group.add_argument("-stats")
+            .flag()
+            .action(
+                [psOptions](const std::string &)
+                {
+                    psOptions->bStats = true;
+                    psOptions->bApproxStats = false;
+                })
+            .help(_("Force (re)computation of statistics."));
+
+        group.add_argument("-approx_stats")
+            .flag()
+            .action(
+                [psOptions](const std::string &)
+                {
+                    psOptions->bStats = true;
+                    psOptions->bApproxStats = true;
+                })
+            .help(_("Force (re)computation of approximate statistics."));
+    }
+
+    argParser->add_argument("-norat")
+        .store_into(psOptions->bNoRAT)
+        .help(_("Do not copy source RAT into destination dataset."));
+
+    argParser->add_argument("-noxmp")
+        .store_into(psOptions->bNoXMP)
+        .help(_("Do not copy the XMP metadata into destination dataset."));
+
+    argParser->add_creation_options_argument(psOptions->aosCreateOptions);
+
+    argParser->add_metadata_item_options_argument(
+        psOptions->aosMetadataOptions);
+
+    argParser->add_argument("-dmo")
+        .metavar("<DOMAIN>:<KEY>=<VALUE>")
+        .append()
+        .action([psOptions](const std::string &s)
+                { psOptions->aosDomainMetadataOptions.AddString(s.c_str()); })
+        .help(_("Passes a metadata key and value in specified domain to set on "
+                "the output dataset if possible."));
+
+    argParser->add_open_options_argument(
+        psOptionsForBinary ? &(psOptionsForBinary->aosOpenOptions) : nullptr);
+
+    // Undocumented option used by gdal_translate_fuzzer
+    argParser->add_argument("-limit_outsize")
+        .hidden()
+        .store_into(psOptions->nLimitOutSize);
+
+    if (psOptionsForBinary)
+    {
+        argParser->add_argument("input_file")
+            .metavar("<input_file>")
+            .store_into(psOptionsForBinary->osSource)
+            .help(_("Input file."));
+
+        argParser->add_argument("output_file")
+            .metavar("<output_file>")
+            .store_into(psOptionsForBinary->osDest)
+            .help(_("Output file."));
+    }
+
+    return argParser;
+}
+
+/************************************************************************/
+/*                      GDALTranslateGetParserUsage()                   */
+/************************************************************************/
+
+std::string GDALTranslateGetParserUsage()
+{
+    GDALTranslateOptions sOptions;
+    GDALTranslateOptionsForBinary sOptionsForBinary;
+    auto argParser =
+        GDALTranslateOptionsGetParser(&sOptions, &sOptionsForBinary);
+    return argParser->usage();
+}
+
+/************************************************************************/
 /*                             GDALTranslateOptionsNew()                */
 /************************************************************************/
 
@@ -2775,140 +3214,19 @@ GDALTranslateOptions *
 GDALTranslateOptionsNew(char **papszArgv,
                         GDALTranslateOptionsForBinary *psOptionsForBinary)
 {
-    GDALTranslateOptions *psOptions = new GDALTranslateOptions;
-
-    bool bParsedMaskArgument = false;
-    bool bOutsizeExplicitlySet = false;
-    bool bGotSourceFilename = false;
-    bool bGotDestFilename = false;
+    auto psOptions = std::make_unique<GDALTranslateOptions>();
 
     /* -------------------------------------------------------------------- */
-    /*      Handle command line arguments.                                  */
+    /*      Pre-processing for custom syntax that ArgumentParser does not   */
+    /*      support.                                                        */
     /* -------------------------------------------------------------------- */
+
+    CPLStringList aosArgv;
     const int argc = CSLCount(papszArgv);
     for (int i = 0; i < argc && papszArgv != nullptr && papszArgv[i] != nullptr;
          i++)
     {
-        if (i < argc - 1 &&
-            (EQUAL(papszArgv[i], "-of") || EQUAL(papszArgv[i], "-f")))
-        {
-            ++i;
-            psOptions->osFormat = papszArgv[i];
-        }
-
-        else if (EQUAL(papszArgv[i], "-q") || EQUAL(papszArgv[i], "-quiet"))
-        {
-            if (psOptionsForBinary)
-                psOptionsForBinary->bQuiet = true;
-        }
-
-        else if (EQUAL(papszArgv[i], "-ot") && papszArgv[i + 1])
-        {
-            for (int iType = 1; iType < GDT_TypeCount; iType++)
-            {
-                if (GDALGetDataTypeName(static_cast<GDALDataType>(iType)) !=
-                        nullptr &&
-                    EQUAL(GDALGetDataTypeName(static_cast<GDALDataType>(iType)),
-                          papszArgv[i + 1]))
-                {
-                    psOptions->eOutputType = static_cast<GDALDataType>(iType);
-                }
-            }
-
-            if (psOptions->eOutputType == GDT_Unknown)
-            {
-                CPLError(CE_Failure, CPLE_NotSupported,
-                         "Unknown output pixel type: %s.", papszArgv[i + 1]);
-                GDALTranslateOptionsFree(psOptions);
-                return nullptr;
-            }
-            i++;
-        }
-        else if (EQUAL(papszArgv[i], "-b") && papszArgv[i + 1])
-        {
-            const char *pszBand = papszArgv[i + 1];
-            bool bMask = false;
-            if (EQUAL(pszBand, "mask"))
-                pszBand = "mask,1";
-            if (STARTS_WITH_CI(pszBand, "mask,"))
-            {
-                bMask = true;
-                pszBand += 5;
-                /* If we use the source mask band as a regular band */
-                /* don't create a target mask band by default */
-                if (!bParsedMaskArgument)
-                    psOptions->eMaskMode = MASK_DISABLED;
-            }
-            const int nBand = atoi(pszBand);
-            if (nBand < 1)
-            {
-                CPLError(CE_Failure, CPLE_NotSupported,
-                         "Unrecognizable band number (%s).", papszArgv[i + 1]);
-                GDALTranslateOptionsFree(psOptions);
-                return nullptr;
-            }
-            i++;
-
-            psOptions->nBandCount++;
-            psOptions->anBandList.emplace_back(nBand * (bMask ? -1 : 1));
-        }
-        else if (EQUAL(papszArgv[i], "-mask") && papszArgv[i + 1])
-        {
-            bParsedMaskArgument = true;
-            const char *pszBand = papszArgv[i + 1];
-            if (EQUAL(pszBand, "none"))
-            {
-                psOptions->eMaskMode = MASK_DISABLED;
-            }
-            else if (EQUAL(pszBand, "auto"))
-            {
-                psOptions->eMaskMode = MASK_AUTO;
-            }
-            else
-            {
-                bool bMask = false;
-                if (EQUAL(pszBand, "mask"))
-                    pszBand = "mask,1";
-                if (STARTS_WITH_CI(pszBand, "mask,"))
-                {
-                    bMask = true;
-                    pszBand += 5;
-                }
-                const int nBand = atoi(pszBand);
-                if (nBand < 1)
-                {
-                    CPLError(CE_Failure, CPLE_NotSupported,
-                             "Unrecognizable band number (%s).",
-                             papszArgv[i + 1]);
-                    GDALTranslateOptionsFree(psOptions);
-                    return nullptr;
-                }
-
-                psOptions->eMaskMode = MASK_USER;
-                psOptions->nMaskBand = nBand;
-                if (bMask)
-                    psOptions->nMaskBand *= -1;
-            }
-            i++;
-        }
-        else if (EQUAL(papszArgv[i], "-not_strict"))
-        {
-            psOptions->bStrict = false;
-        }
-        else if (EQUAL(papszArgv[i], "-strict"))
-        {
-            psOptions->bStrict = true;
-        }
-        else if (EQUAL(papszArgv[i], "-sds"))
-        {
-            if (psOptionsForBinary)
-                psOptionsForBinary->bCopySubDatasets = TRUE;
-        }
-        else if (EQUAL(papszArgv[i], "-nogcp"))
-        {
-            psOptions->bNoGCP = true;
-        }
-        else if (i + 4 < argc && EQUAL(papszArgv[i], "-gcp"))
+        if (i + 4 < argc && EQUAL(papszArgv[i], "-gcp"))
         {
             /* -gcp pixel line easting northing [elev] */
             psOptions->nGCPCount++;
@@ -2941,61 +3259,6 @@ GDALTranslateOptionsNew(char **papszArgv,
             /* should set id and info? */
         }
 
-        else if (EQUAL(papszArgv[i], "-a_nodata") && papszArgv[i + 1])
-        {
-            if (EQUAL(papszArgv[i + 1], "none"))
-            {
-                psOptions->bUnsetNoData = true;
-            }
-            else
-            {
-                psOptions->bSetNoData = true;
-                psOptions->osNoData = papszArgv[i + 1];
-            }
-            i += 1;
-        }
-
-        else if (EQUAL(papszArgv[i], "-a_scale") && papszArgv[i + 1])
-        {
-            psOptions->bSetScale = true;
-            psOptions->dfScale = CPLAtofM(papszArgv[i + 1]);
-            i += 1;
-        }
-
-        else if (EQUAL(papszArgv[i], "-a_offset") && papszArgv[i + 1])
-        {
-            psOptions->bSetOffset = true;
-            psOptions->dfOffset = CPLAtofM(papszArgv[i + 1]);
-            i += 1;
-        }
-
-        else if (i + 4 < argc && EQUAL(papszArgv[i], "-a_ullr"))
-        {
-            psOptions->adfULLR[0] = CPLAtofM(papszArgv[i + 1]);
-            psOptions->adfULLR[1] = CPLAtofM(papszArgv[i + 2]);
-            psOptions->adfULLR[2] = CPLAtofM(papszArgv[i + 3]);
-            psOptions->adfULLR[3] = CPLAtofM(papszArgv[i + 4]);
-
-            i += 4;
-        }
-
-        else if (i + 6 < argc && EQUAL(papszArgv[i], "-a_gt"))
-        {
-            psOptions->adfGT[0] = CPLAtofM(papszArgv[i + 1]);
-            psOptions->adfGT[1] = CPLAtofM(papszArgv[i + 2]);
-            psOptions->adfGT[2] = CPLAtofM(papszArgv[i + 3]);
-            psOptions->adfGT[3] = CPLAtofM(papszArgv[i + 4]);
-            psOptions->adfGT[4] = CPLAtofM(papszArgv[i + 5]);
-            psOptions->adfGT[5] = CPLAtofM(papszArgv[i + 6]);
-
-            i += 6;
-        }
-
-        else if (EQUAL(papszArgv[i], "-co") && papszArgv[i + 1])
-        {
-            psOptions->aosCreateOptions.AddString(papszArgv[++i]);
-        }
-
         else if (EQUAL(papszArgv[i], "-scale") ||
                  STARTS_WITH_CI(papszArgv[i], "-scale_"))
         {
@@ -3007,7 +3270,6 @@ GDALTranslateOptionsNew(char **papszArgv,
                 {
                     CPLError(CE_Failure, CPLE_NotSupported,
                              "Cannot mix -scale and -scale_XX syntax");
-                    GDALTranslateOptionsFree(psOptions);
                     return nullptr;
                 }
                 psOptions->bHasUsedExplicitScaleBand = true;
@@ -3016,7 +3278,6 @@ GDALTranslateOptionsNew(char **papszArgv,
                 {
                     CPLError(CE_Failure, CPLE_NotSupported,
                              "Invalid parameter name: %s", papszArgv[i]);
-                    GDALTranslateOptionsFree(psOptions);
                     return nullptr;
                 }
                 nIndex--;
@@ -3027,7 +3288,6 @@ GDALTranslateOptionsNew(char **papszArgv,
                 {
                     CPLError(CE_Failure, CPLE_NotSupported,
                              "Cannot mix -scale and -scale_XX syntax");
-                    GDALTranslateOptionsFree(psOptions);
                     return nullptr;
                 }
                 nIndex = static_cast<int>(psOptions->asScaleParams.size());
@@ -3077,7 +3337,6 @@ GDALTranslateOptionsNew(char **papszArgv,
                 {
                     CPLError(CE_Failure, CPLE_NotSupported,
                              "Cannot mix -exponent and -exponent_XX syntax");
-                    GDALTranslateOptionsFree(psOptions);
                     return nullptr;
                 }
                 psOptions->bHasUsedExplicitExponentBand = true;
@@ -3086,7 +3345,6 @@ GDALTranslateOptionsNew(char **papszArgv,
                 {
                     CPLError(CE_Failure, CPLE_NotSupported,
                              "Invalid parameter name: %s", papszArgv[i]);
-                    GDALTranslateOptionsFree(psOptions);
                     return nullptr;
                 }
                 nIndex--;
@@ -3097,7 +3355,6 @@ GDALTranslateOptionsNew(char **papszArgv,
                 {
                     CPLError(CE_Failure, CPLE_NotSupported,
                              "Cannot mix -exponent and -exponent_XX syntax");
-                    GDALTranslateOptionsFree(psOptions);
                     return nullptr;
                 }
                 nIndex = static_cast<int>(psOptions->adfExponent.size());
@@ -3111,155 +3368,6 @@ GDALTranslateOptionsNew(char **papszArgv,
             psOptions->adfExponent[nIndex] = dfExponent;
         }
 
-        else if (EQUAL(papszArgv[i], "-unscale"))
-        {
-            psOptions->bUnscale = true;
-        }
-
-        else if (EQUAL(papszArgv[i], "-mo") && papszArgv[i + 1])
-        {
-            psOptions->aosMetadataOptions.AddString(papszArgv[++i]);
-        }
-
-        else if (EQUAL(papszArgv[i], "-dmo") && papszArgv[i + 1])
-        {
-            psOptions->aosDomainMetadataOptions.AddString(papszArgv[++i]);
-        }
-        else if (i + 2 < argc && EQUAL(papszArgv[i], "-outsize") &&
-                 papszArgv[i + 1] != nullptr)
-        {
-            ++i;
-            if (papszArgv[i][0] != '\0' &&
-                papszArgv[i][strlen(papszArgv[i]) - 1] == '%')
-                psOptions->dfOXSizePct = CPLAtofM(papszArgv[i]);
-            else
-                psOptions->nOXSizePixel = atoi(papszArgv[i]);
-            ++i;
-            if (papszArgv[i][0] != '\0' &&
-                papszArgv[i][strlen(papszArgv[i]) - 1] == '%')
-                psOptions->dfOYSizePct = CPLAtofM(papszArgv[i]);
-            else
-                psOptions->nOYSizePixel = atoi(papszArgv[i]);
-            bOutsizeExplicitlySet = true;
-        }
-
-        else if (i + 2 < argc && EQUAL(papszArgv[i], "-tr"))
-        {
-            psOptions->dfXRes = CPLAtofM(papszArgv[++i]);
-            psOptions->dfYRes = fabs(CPLAtofM(papszArgv[++i]));
-            if (psOptions->dfXRes == 0 || psOptions->dfYRes == 0)
-            {
-                CPLError(CE_Failure, CPLE_IllegalArg,
-                         "Wrong value for -tr parameters.");
-                GDALTranslateOptionsFree(psOptions);
-                return nullptr;
-            }
-        }
-
-        else if (i + 4 < argc && EQUAL(papszArgv[i], "-srcwin"))
-        {
-            psOptions->adfSrcWin[0] = CPLAtof(papszArgv[++i]);
-            psOptions->adfSrcWin[1] = CPLAtof(papszArgv[++i]);
-            psOptions->adfSrcWin[2] = CPLAtof(papszArgv[++i]);
-            psOptions->adfSrcWin[3] = CPLAtof(papszArgv[++i]);
-        }
-
-        else if (i + 4 < argc && EQUAL(papszArgv[i], "-projwin"))
-        {
-            psOptions->dfULX = CPLAtofM(papszArgv[++i]);
-            psOptions->dfULY = CPLAtofM(papszArgv[++i]);
-            psOptions->dfLRX = CPLAtofM(papszArgv[++i]);
-            psOptions->dfLRY = CPLAtofM(papszArgv[++i]);
-        }
-
-        else if (i + 1 < argc && EQUAL(papszArgv[i], "-projwin_srs"))
-        {
-            psOptions->osProjSRS = papszArgv[i + 1];
-            i++;
-        }
-
-        else if (EQUAL(papszArgv[i], "-epo"))
-        {
-            psOptions->bErrorOnPartiallyOutside = true;
-            psOptions->bErrorOnCompletelyOutside = true;
-        }
-
-        else if (EQUAL(papszArgv[i], "-eco"))
-        {
-            psOptions->bErrorOnCompletelyOutside = true;
-        }
-
-        else if (i + 1 < argc && EQUAL(papszArgv[i], "-a_srs"))
-        {
-            psOptions->osOutputSRS = papszArgv[i + 1];
-            i++;
-        }
-
-        else if (i + 1 < argc && EQUAL(papszArgv[i], "-a_coord_epoch"))
-        {
-            psOptions->dfOutputCoordinateEpoch = CPLAtofM(papszArgv[i + 1]);
-            i++;
-        }
-
-        else if (i + 1 < argc && EQUAL(papszArgv[i], "-expand") &&
-                 papszArgv[i + 1] != nullptr)
-        {
-            i++;
-            if (EQUAL(papszArgv[i], "gray"))
-                psOptions->nRGBExpand = 1;
-            else if (EQUAL(papszArgv[i], "rgb"))
-                psOptions->nRGBExpand = 3;
-            else if (EQUAL(papszArgv[i], "rgba"))
-                psOptions->nRGBExpand = 4;
-            else
-            {
-                CPLError(CE_Failure, CPLE_IllegalArg,
-                         "Value %s unsupported. Only gray, rgb or rgba are "
-                         "supported.",
-                         papszArgv[i]);
-                GDALTranslateOptionsFree(psOptions);
-                return nullptr;
-            }
-        }
-
-        else if (EQUAL(papszArgv[i], "-stats"))
-        {
-            psOptions->bStats = true;
-            psOptions->bApproxStats = false;
-        }
-        else if (EQUAL(papszArgv[i], "-approx_stats"))
-        {
-            psOptions->bStats = true;
-            psOptions->bApproxStats = true;
-        }
-        else if (EQUAL(papszArgv[i], "-norat"))
-        {
-            psOptions->bNoRAT = true;
-        }
-        else if (i + 1 < argc && EQUAL(papszArgv[i], "-oo"))
-        {
-            i++;
-            if (psOptionsForBinary)
-            {
-                psOptionsForBinary->aosOpenOptions.AddString(papszArgv[i]);
-            }
-        }
-        else if (i + 1 < argc && EQUAL(papszArgv[i], "-r"))
-        {
-            psOptions->osResampling = papszArgv[++i];
-        }
-
-        else if (EQUAL(papszArgv[i], "-colorinterp") && papszArgv[i + 1])
-        {
-            ++i;
-            CPLStringList aosList(CSLTokenizeString2(papszArgv[i], ",", 0));
-            psOptions->anColorInterp.resize(aosList.size());
-            for (int j = 0; j < aosList.size(); j++)
-            {
-                psOptions->anColorInterp[j] = GetColorInterp(aosList[j]);
-            }
-        }
-
         else if (STARTS_WITH_CI(papszArgv[i], "-colorinterp_") &&
                  papszArgv[i + 1])
         {
@@ -3268,7 +3376,6 @@ GDALTranslateOptionsNew(char **papszArgv,
             {
                 CPLError(CE_Failure, CPLE_NotSupported,
                          "Invalid parameter name: %s", papszArgv[i]);
-                GDALTranslateOptionsFree(psOptions);
                 return nullptr;
             }
             nIndex--;
@@ -3281,87 +3388,88 @@ GDALTranslateOptionsNew(char **papszArgv,
             psOptions->anColorInterp[nIndex] = GetColorInterp(papszArgv[i]);
         }
 
-        // Undocumented option used by gdal_translate_fuzzer
-        else if (i + 1 < argc && EQUAL(papszArgv[i], "-limit_outsize"))
-        {
-            psOptions->nLimitOutSize = atoi(papszArgv[i + 1]);
-            i++;
-        }
-
-        else if (i + 1 < argc && EQUAL(papszArgv[i], "-if"))
-        {
-            i++;
-            if (psOptionsForBinary)
-            {
-                if (GDALGetDriverByName(papszArgv[i]) == nullptr)
-                {
-                    CPLError(CE_Warning, CPLE_AppDefined,
-                             "%s is not a recognized driver", papszArgv[i]);
-                }
-                psOptionsForBinary->aosAllowedInputDrivers.AddString(
-                    papszArgv[i]);
-            }
-        }
-
-        else if (EQUAL(papszArgv[i], "-noxmp"))
-        {
-            psOptions->bNoXMP = true;
-        }
-
-        else if (EQUAL(papszArgv[i], "-ovr") && i + 1 < argc)
-        {
-            const char *pszOvLevel = papszArgv[++i];
-            if (EQUAL(pszOvLevel, "AUTO"))
-                psOptions->nOvLevel = OVR_LEVEL_AUTO;
-            else if (STARTS_WITH_CI(pszOvLevel, "AUTO-"))
-                psOptions->nOvLevel =
-                    OVR_LEVEL_AUTO - atoi(pszOvLevel + strlen("AUTO-"));
-            else if (EQUAL(pszOvLevel, "NONE"))
-                psOptions->nOvLevel = OVR_LEVEL_NONE;
-            else if (CPLGetValueType(pszOvLevel) == CPL_VALUE_INTEGER)
-                psOptions->nOvLevel = atoi(pszOvLevel);
-            else
-            {
-                CPLError(CE_Failure, CPLE_IllegalArg,
-                         "Invalid value '%s' for -ovr option", pszOvLevel);
-                GDALTranslateOptionsFree(psOptions);
-                return nullptr;
-            }
-        }
-
-        else if (papszArgv[i][0] == '-')
-        {
-            CPLError(CE_Failure, CPLE_NotSupported, "Unknown option name '%s'",
-                     papszArgv[i]);
-            GDALTranslateOptionsFree(psOptions);
-            return nullptr;
-        }
-        else if (!bGotSourceFilename)
-        {
-            bGotSourceFilename = true;
-            if (psOptionsForBinary)
-                psOptionsForBinary->osSource = papszArgv[i];
-        }
-        else if (!bGotDestFilename)
-        {
-            bGotDestFilename = true;
-            if (psOptionsForBinary)
-                psOptionsForBinary->osDest = papszArgv[i];
-        }
         else
         {
-            CPLError(CE_Failure, CPLE_NotSupported,
-                     "Too many command options '%s'", papszArgv[i]);
-            GDALTranslateOptionsFree(psOptions);
+            aosArgv.AddString(papszArgv[i]);
+        }
+    }
+
+    auto argParser =
+        GDALTranslateOptionsGetParser(psOptions.get(), psOptionsForBinary);
+
+    try
+    {
+        argParser->parse_args_without_binary_name(aosArgv.List());
+    }
+    catch (const std::exception &err)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "%s", err.what());
+        return nullptr;
+    }
+
+    psOptions->bSetScale = argParser->is_used("-a_scale");
+    psOptions->bSetOffset = argParser->is_used("-a_offset");
+
+    if (auto adfULLR = argParser->present<std::vector<double>>("-a_ullr"))
+    {
+        CPLAssert(psOptions->adfULLR.size() == adfULLR->size());
+        for (size_t i = 0; i < adfULLR->size(); ++i)
+            psOptions->adfULLR[i] = (*adfULLR)[i];
+    }
+
+    if (auto adfGT = argParser->present<std::vector<double>>("-a_gt"))
+    {
+        CPLAssert(psOptions->adfGT.size() == adfGT->size());
+        for (size_t i = 0; i < adfGT->size(); ++i)
+            psOptions->adfGT[i] = (*adfGT)[i];
+    }
+
+    bool bOutsizeExplicitlySet = false;
+    if (auto aosOutSize =
+            argParser->present<std::vector<std::string>>("-outsize"))
+    {
+        if ((*aosOutSize)[0].back() == '%')
+            psOptions->dfOXSizePct = CPLAtofM((*aosOutSize)[0].c_str());
+        else
+            psOptions->nOXSizePixel = atoi((*aosOutSize)[0].c_str());
+
+        if ((*aosOutSize)[1].back() == '%')
+            psOptions->dfOYSizePct = CPLAtofM((*aosOutSize)[1].c_str());
+        else
+            psOptions->nOYSizePixel = atoi((*aosOutSize)[1].c_str());
+        bOutsizeExplicitlySet = true;
+    }
+
+    if (auto adfTargetRes = argParser->present<std::vector<double>>("-tr"))
+    {
+        psOptions->dfXRes = (*adfTargetRes)[0];
+        psOptions->dfYRes = fabs((*adfTargetRes)[1]);
+        if (psOptions->dfXRes == 0 || psOptions->dfYRes == 0)
+        {
+            CPLError(CE_Failure, CPLE_IllegalArg,
+                     "Wrong value for -tr parameters.");
             return nullptr;
         }
+    }
+
+    if (auto adfSrcWin = argParser->present<std::vector<double>>("-srcwin"))
+    {
+        for (int i = 0; i < 4; ++i)
+            psOptions->adfSrcWin[i] = (*adfSrcWin)[i];
+    }
+
+    if (auto adfProjWin = argParser->present<std::vector<double>>("-projwin"))
+    {
+        psOptions->dfULX = (*adfProjWin)[0];
+        psOptions->dfULY = (*adfProjWin)[1];
+        psOptions->dfLRX = (*adfProjWin)[2];
+        psOptions->dfLRY = (*adfProjWin)[3];
     }
 
     if (psOptions->nGCPCount > 0 && psOptions->bNoGCP)
     {
         CPLError(CE_Failure, CPLE_IllegalArg,
                  "-nogcp and -gcp cannot be used as the same time");
-        GDALTranslateOptionsFree(psOptions);
         return nullptr;
     }
 
@@ -3371,7 +3479,6 @@ GDALTranslateOptionsNew(char **papszArgv,
     {
         CPLError(CE_Failure, CPLE_NotSupported, "-outsize %d %d invalid.",
                  psOptions->nOXSizePixel, psOptions->nOYSizePixel);
-        GDALTranslateOptionsFree(psOptions);
         return nullptr;
     }
 
@@ -3379,7 +3486,6 @@ GDALTranslateOptionsNew(char **papszArgv,
     {
         CPLError(CE_Failure, CPLE_IllegalArg,
                  "-scale and -unscale cannot be used as the same time");
-        GDALTranslateOptionsFree(psOptions);
         return nullptr;
     }
 
@@ -3389,7 +3495,7 @@ GDALTranslateOptionsNew(char **papszArgv,
             psOptionsForBinary->osFormat = psOptions->osFormat;
     }
 
-    return psOptions;
+    return psOptions.release();
 }
 
 /************************************************************************/

--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -3241,8 +3241,7 @@ GDALTranslateOptionsNew(char **papszArgv,
             i++;
             if (psOptionsForBinary)
             {
-                psOptionsForBinary->papszOpenOptions = CSLAddString(
-                    psOptionsForBinary->papszOpenOptions, papszArgv[i]);
+                psOptionsForBinary->aosOpenOptions.AddString(papszArgv[i]);
             }
         }
         else if (i + 1 < argc && EQUAL(papszArgv[i], "-r"))
@@ -3299,8 +3298,8 @@ GDALTranslateOptionsNew(char **papszArgv,
                     CPLError(CE_Warning, CPLE_AppDefined,
                              "%s is not a recognized driver", papszArgv[i]);
                 }
-                psOptionsForBinary->papszAllowInputDrivers = CSLAddString(
-                    psOptionsForBinary->papszAllowInputDrivers, papszArgv[i]);
+                psOptionsForBinary->aosAllowedInputDrivers.AddString(
+                    papszArgv[i]);
             }
         }
 
@@ -3341,13 +3340,13 @@ GDALTranslateOptionsNew(char **papszArgv,
         {
             bGotSourceFilename = true;
             if (psOptionsForBinary)
-                psOptionsForBinary->pszSource = CPLStrdup(papszArgv[i]);
+                psOptionsForBinary->osSource = papszArgv[i];
         }
         else if (!bGotDestFilename)
         {
             bGotDestFilename = true;
             if (psOptionsForBinary)
-                psOptionsForBinary->pszDest = CPLStrdup(papszArgv[i]);
+                psOptionsForBinary->osDest = papszArgv[i];
         }
         else
         {
@@ -3387,8 +3386,7 @@ GDALTranslateOptionsNew(char **papszArgv,
     if (psOptionsForBinary)
     {
         if (!psOptions->osFormat.empty())
-            psOptionsForBinary->pszFormat =
-                CPLStrdup(psOptions->osFormat.c_str());
+            psOptionsForBinary->osFormat = psOptions->osFormat;
     }
 
     return psOptions;

--- a/apps/gdal_utils_priv.h
+++ b/apps/gdal_utils_priv.h
@@ -97,13 +97,6 @@ struct GDALDEMProcessingOptionsForBinary
     int bQuiet;
 };
 
-struct GDALNearblackOptionsForBinary
-{
-    char *pszInFile;
-    char *pszOutFile;
-    int bQuiet;
-};
-
 struct GDALBuildVRTOptionsForBinary
 {
     int nSrcFiles;
@@ -229,6 +222,15 @@ struct GDALTileIndexOptionsForBinary
     std::string osDest{};
     bool bQuiet = false;
 };
+
+struct GDALNearblackOptionsForBinary
+{
+    std::string osInFile{};
+    std::string osOutFile{};
+    bool bQuiet = false;
+};
+
+std::string CPL_DLL GDALNearblackGetParserUsage();
 
 #endif /* #ifndef DOXYGEN_SKIP */
 

--- a/apps/gdal_utils_priv.h
+++ b/apps/gdal_utils_priv.h
@@ -232,6 +232,8 @@ struct GDALNearblackOptionsForBinary
 
 std::string CPL_DLL GDALNearblackGetParserUsage();
 
+std::string CPL_DLL GDALVectorInfoGetParserUsage();
+
 #endif /* #ifndef DOXYGEN_SKIP */
 
 #endif /* GDAL_UTILS_PRIV_H_INCLUDED */

--- a/apps/gdal_utils_priv.h
+++ b/apps/gdal_utils_priv.h
@@ -56,19 +56,6 @@ struct GDALInfoOptionsForBinary
     char **papszAllowInputDrivers;
 };
 
-struct GDALTranslateOptionsForBinary
-{
-    char *pszSource;
-    char *pszDest;
-    int bQuiet;
-    int bCopySubDatasets;
-    char **papszOpenOptions;
-    char *pszFormat;
-
-    /* Allowed input drivers. */
-    char **papszAllowInputDrivers;
-};
-
 struct GDALWarpAppOptionsForBinary
 {
     char **papszSrcFiles;
@@ -228,6 +215,19 @@ struct GDALNearblackOptionsForBinary
     std::string osInFile{};
     std::string osOutFile{};
     bool bQuiet = false;
+};
+
+struct GDALTranslateOptionsForBinary
+{
+    std::string osSource{};
+    std::string osDest{};
+    bool bQuiet = false;
+    bool bCopySubDatasets = false;
+    CPLStringList aosOpenOptions{};
+    std::string osFormat{};
+
+    /* Allowed input drivers. */
+    CPLStringList aosAllowedInputDrivers{};
 };
 
 std::string CPL_DLL GDALNearblackGetParserUsage();

--- a/apps/gdal_utils_priv.h
+++ b/apps/gdal_utils_priv.h
@@ -234,6 +234,8 @@ std::string CPL_DLL GDALNearblackGetParserUsage();
 
 std::string CPL_DLL GDALVectorInfoGetParserUsage();
 
+std::string CPL_DLL GDALTranslateGetParserUsage();
+
 #endif /* #ifndef DOXYGEN_SKIP */
 
 #endif /* GDAL_UTILS_PRIV_H_INCLUDED */

--- a/apps/gdal_utils_priv.h
+++ b/apps/gdal_utils_priv.h
@@ -108,7 +108,6 @@ typedef enum
 struct GDALVectorTranslateOptionsForBinary
 {
     std::string osDataSource{};
-    bool bDestSpecified = false;
     std::string osDestDataSource{};
     bool bQuiet = false;
     CPLStringList aosOpenOptions{};
@@ -235,6 +234,8 @@ std::string CPL_DLL GDALNearblackGetParserUsage();
 std::string CPL_DLL GDALVectorInfoGetParserUsage();
 
 std::string CPL_DLL GDALTranslateGetParserUsage();
+
+std::string CPL_DLL GDALVectorTranslateGetParserUsage();
 
 #endif /* #ifndef DOXYGEN_SKIP */
 

--- a/apps/gdalargumentparser.cpp
+++ b/apps/gdalargumentparser.cpp
@@ -1,0 +1,369 @@
+/******************************************************************************
+ * Project:  GDAL Utilities
+ * Purpose:  GDAL argument parser
+ * Author:   Even Rouault <even.rouault at spatialys.com>
+ *
+ * ****************************************************************************
+ * Copyright (c) 2024, Even Rouault <even.rouault at spatialys.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "gdal_version_full/gdal_version.h"
+
+#include "gdal.h"
+#include "gdalargumentparser.h"
+#include "commonutils.h"
+
+#include <algorithm>
+
+/************************************************************************/
+/*                         GDALArgumentParser()                         */
+/************************************************************************/
+
+GDALArgumentParser::GDALArgumentParser(const std::string &program_name,
+                                       bool bForBinary)
+    : ArgumentParser(program_name, "", default_arguments::none)
+{
+    set_usage_max_line_width(120);
+    set_usage_break_on_mutex();
+    add_usage_newline();
+
+    if (bForBinary)
+    {
+        add_argument("-h", "--help")
+            .flag()
+            .action(
+                [this, program_name](const auto &)
+                {
+                    std::cout << usage() << std::endl << std::endl;
+                    std::cout << _("Note: ") << program_name
+                              << _(" --long-usage for full help.") << std::endl;
+                    std::exit(0);
+                })
+            .help(_("Shows short help message and exits."));
+
+        add_argument("--long-usage")
+            .flag()
+            .action(
+                [this](const auto & /*unused*/)
+                {
+                    std::cout << *this;
+                    std::exit(0);
+                })
+            .help(_("Shows long help message and exits."));
+
+        add_argument("--help-general")
+            .flag()
+            .help(_("Report detailed help on general options."));
+
+        add_argument("--utility_version")
+            .flag()
+            .hidden()
+            .action(
+                [program_name](const auto &)
+                {
+                    printf("%s was compiled against GDAL %s and "
+                           "is running against GDAL %s\n",
+                           program_name.c_str(), GDAL_RELEASE_NAME,
+                           GDALVersionInfo("RELEASE_NAME"));
+                    std::exit(0);
+                })
+            .help(_("Shows compile-time and run-time GDAL version."));
+
+        add_usage_newline();
+    }
+}
+
+/************************************************************************/
+/*                      display_error_and_usage()                       */
+/************************************************************************/
+
+void GDALArgumentParser::display_error_and_usage(const std::exception &err)
+{
+    std::cerr << _("Error: ") << err.what() << std::endl;
+    std::cerr << usage() << std::endl << std::endl;
+    std::cout << _("Note: ") << m_program_name
+              << _(" --long-usage for full help.") << std::endl;
+}
+
+/************************************************************************/
+/*                         add_quiet_argument()                         */
+/************************************************************************/
+
+void GDALArgumentParser::add_quiet_argument(bool *pVar)
+{
+    auto &arg =
+        this->add_argument("-q", "--quiet")
+            .flag()
+            .help(
+                _("Quiet mode. No progress message is emitted on the standard "
+                  "output."));
+    if (pVar)
+        arg.store_into(*pVar);
+}
+
+/************************************************************************/
+/*                      add_output_format_argument()                    */
+/************************************************************************/
+
+void GDALArgumentParser::add_output_format_argument(std::string &var)
+{
+    auto &arg = add_argument("-of")
+                    .metavar("<output_format>")
+                    .store_into(var)
+                    .help(_("Output format."));
+    add_hidden_alias_for(arg, "-f");
+}
+
+/************************************************************************/
+/*                     add_creation_options_argument()                  */
+/************************************************************************/
+
+void GDALArgumentParser::add_creation_options_argument(CPLStringList &var)
+{
+    add_argument("-co")
+        .metavar("<NAME>=<VALUE>")
+        .append()
+        .action([&var](const std::string &s) { var.AddString(s.c_str()); })
+        .help(_("Creation option(s)."));
+}
+
+/************************************************************************/
+/*                   add_metadata_item_options_argument()               */
+/************************************************************************/
+
+void GDALArgumentParser::add_metadata_item_options_argument(CPLStringList &var)
+{
+    add_argument("-mo")
+        .metavar("<NAME>=<VALUE>")
+        .append()
+        .action([&var](const std::string &s) { var.AddString(s.c_str()); })
+        .help(_("Metadata item option(s)."));
+}
+
+/************************************************************************/
+/*                       add_open_options_argument()                    */
+/************************************************************************/
+
+void GDALArgumentParser::add_open_options_argument(CPLStringList &var)
+{
+    add_open_options_argument(&var);
+}
+
+/************************************************************************/
+/*                       add_open_options_argument()                    */
+/************************************************************************/
+
+void GDALArgumentParser::add_open_options_argument(CPLStringList *pvar)
+{
+    auto &arg = add_argument("-oo")
+                    .metavar("<NAME>=<VALUE>")
+                    .append()
+                    .help(_("Open option(s) for input dataset."));
+    if (pvar)
+    {
+        arg.action([pvar](const std::string &s)
+                   { pvar->AddString(s.c_str()); });
+    }
+}
+
+/************************************************************************/
+/*                       add_output_type_argument()                     */
+/************************************************************************/
+
+void GDALArgumentParser::add_output_type_argument(GDALDataType &eDT)
+{
+    add_argument("-ot")
+        .metavar("Byte|Int8|[U]Int{16|32|64}|CInt{16|32}|[C]Float{32|64}")
+        .action(
+            [&eDT](const std::string &s)
+            {
+                eDT = GDALGetDataTypeByName(s.c_str());
+                if (eDT == GDT_Unknown)
+                {
+                    throw std::invalid_argument(
+                        std::string("Unknown output pixel type: ").append(s));
+                }
+            })
+        .help(_("Output data type."));
+}
+
+/************************************************************************/
+/*                     parse_args_without_binary_name()                 */
+/************************************************************************/
+
+void GDALArgumentParser::parse_args_without_binary_name(CSLConstList papszArgs)
+{
+    CPLStringList aosArgs;
+    aosArgs.AddString(m_program_name.c_str());
+    for (CSLConstList papszIter = papszArgs; papszIter && *papszIter;
+         ++papszIter)
+        aosArgs.AddString(*papszIter);
+    parse_args(aosArgs);
+}
+
+/************************************************************************/
+/*                           find_argument()                            */
+/************************************************************************/
+
+std::map<std::string, ArgumentParser::argument_it>::iterator
+GDALArgumentParser::find_argument(const std::string &name)
+{
+    auto arg_map_it = m_argument_map.find(name);
+    if (arg_map_it == m_argument_map.end())
+    {
+        // Attempt case insensitive lookup
+        arg_map_it =
+            std::find_if(m_argument_map.begin(), m_argument_map.end(),
+                         [&name](const auto &oArg)
+                         { return EQUAL(name.c_str(), oArg.first.c_str()); });
+    }
+    return arg_map_it;
+}
+
+/************************************************************************/
+/*                    get_non_positional_arguments()                    */
+/************************************************************************/
+
+CPLStringList
+GDALArgumentParser::get_non_positional_arguments(const CPLStringList &aosArgs)
+{
+    CPLStringList args;
+
+    // Simplified logic borrowed from ArgumentParser::parse_args_internal()
+    // that make sure that positional arguments are moved after optional ones,
+    // as this is what ArgumentParser::parse_args() only supports.
+    // This doesn't support advanced settings, such as sub-parsers or compound
+    // argument
+    std::vector<std::string> raw_arguments{m_program_name};
+    raw_arguments.insert(raw_arguments.end(), aosArgs.List(),
+                         aosArgs.List() + aosArgs.size());
+    auto arguments = preprocess_arguments(raw_arguments);
+    auto end = std::end(arguments);
+    auto positional_argument_it = std::begin(m_positional_arguments);
+    for (auto it = std::next(std::begin(arguments)); it != end;)
+    {
+        const auto &current_argument = *it;
+        if (Argument::is_positional(current_argument, m_prefix_chars))
+        {
+            auto argument = positional_argument_it++;
+            auto next_it = argument->consume(it, end, "", /* dry_run = */ true);
+            it = next_it;
+            continue;
+        }
+
+        auto arg_map_it = find_argument(current_argument);
+        if (arg_map_it != m_argument_map.end())
+        {
+            auto argument = arg_map_it->second;
+            auto next_it = argument->consume(
+                std::next(it), end, arg_map_it->first, /* dry_run = */ true);
+            // Add official argument name (correcting possible case)
+            args.AddString(arg_map_it->first.c_str());
+            ++it;
+            // Add its values
+            for (; it != next_it; ++it)
+            {
+                args.AddString(it->c_str());
+            }
+            it = next_it;
+        }
+        else
+        {
+            throw std::runtime_error("Unknown argument: " + current_argument);
+        }
+    }
+
+    return args;
+}
+
+/************************************************************************/
+/*                           parse_args()                               */
+/************************************************************************/
+
+void GDALArgumentParser::parse_args(const CPLStringList &aosArgs)
+{
+    std::vector<std::string> reorderedArgs;
+    std::vector<std::string> positionalArgs;
+
+    // ArgumentParser::parse_args() expects the first argument to be the
+    // binary name
+    if (!aosArgs.empty())
+    {
+        reorderedArgs.push_back(aosArgs[0]);
+    }
+
+    // Simplified logic borrowed from ArgumentParser::parse_args_internal()
+    // that make sure that positional arguments are moved after optional ones,
+    // as this is what ArgumentParser::parse_args() only supports.
+    // This doesn't support advanced settings, such as sub-parsers or compound
+    // argument
+    std::vector<std::string> raw_arguments{aosArgs.List(),
+                                           aosArgs.List() + aosArgs.size()};
+    auto arguments = preprocess_arguments(raw_arguments);
+    auto end = std::end(arguments);
+    auto positional_argument_it = std::begin(m_positional_arguments);
+    for (auto it = std::next(std::begin(arguments)); it != end;)
+    {
+        const auto &current_argument = *it;
+        if (Argument::is_positional(current_argument, m_prefix_chars))
+        {
+            auto argument = positional_argument_it++;
+            auto next_it = argument->consume(it, end, "", /* dry_run = */ true);
+            for (; it != next_it; ++it)
+            {
+                if ((*it)[0] == '-')
+                {
+                    next_it = it;
+                    break;
+                }
+                positionalArgs.push_back(*it);
+            }
+            it = next_it;
+            continue;
+        }
+
+        auto arg_map_it = find_argument(current_argument);
+        if (arg_map_it != m_argument_map.end())
+        {
+            auto argument = arg_map_it->second;
+            auto next_it = argument->consume(
+                std::next(it), end, arg_map_it->first, /* dry_run = */ true);
+            // Add official argument name (correcting possible case)
+            reorderedArgs.push_back(arg_map_it->first);
+            ++it;
+            // Add its values
+            for (; it != next_it; ++it)
+            {
+                reorderedArgs.push_back(*it);
+            }
+            it = next_it;
+        }
+        else
+        {
+            throw std::runtime_error("Unknown argument: " + current_argument);
+        }
+    }
+
+    reorderedArgs.insert(reorderedArgs.end(), positionalArgs.begin(),
+                         positionalArgs.end());
+
+    ArgumentParser::parse_args(reorderedArgs);
+}

--- a/apps/gdalargumentparser.h
+++ b/apps/gdalargumentparser.h
@@ -1,0 +1,101 @@
+/******************************************************************************
+ * Project:  GDAL Utilities
+ * Purpose:  GDAL argument parser
+ * Author:   Even Rouault <even.rouault at spatialys.com>
+ *
+ * ****************************************************************************
+ * Copyright (c) 2024, Even Rouault <even.rouault at spatialys.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#ifndef GDALARGUMENTPARSER_H
+#define GDALARGUMENTPARSER_H
+
+#include "cpl_port.h"
+#include "cpl_conv.h"
+#include "cpl_string.h"
+
+// Rename argparse namespace to a GDAL private one
+#define argparse gdal_argparse
+
+// Use our locale-unaware strtod()
+#define ARGPARSE_CUSTOM_STRTOD CPLStrtodM
+
+#include "argparse/argparse.hpp"
+
+using namespace argparse;
+
+// Place-holder macro using gettext() convention to indicate (future) translatable strings
+#ifndef _
+#define _(x) (x)
+#endif
+
+/** Parse command-line arguments for GDAL utilities.
+ *
+ * Add helpers over the standard argparse::ArgumentParser class
+ *
+ * @since GDAL 3.9
+ */
+class GDALArgumentParser : public ArgumentParser
+{
+  public:
+    //! Constructor
+    explicit GDALArgumentParser(const std::string &program_name,
+                                bool bForBinary);
+
+    //! Format an exception as an error message and display the program usage
+    void display_error_and_usage(const std::exception &err);
+
+    //! Add -q/--quiet argument, and store its value in *pVar (if pVar not null)
+    void add_quiet_argument(bool *pVar);
+
+    //! Add "-of format_name" argument for output format, and store its value into var.
+    void add_output_format_argument(std::string &var);
+
+    //! Add "-co KEY=VALUE" argument for creation options, and store its value into var.
+    void add_creation_options_argument(CPLStringList &var);
+
+    //! Add "-mo KEY=VALUE" argument for metadata item options, and store its value into var.
+    void add_metadata_item_options_argument(CPLStringList &var);
+
+    //! Add "-oo KEY=VALUE" argument for open options, and store its value into var.
+    void add_open_options_argument(CPLStringList &var);
+
+    //! Add "-oo KEY=VALUE" argument for open options, and store its value into *pvar.
+    void add_open_options_argument(CPLStringList *pvar);
+
+    //! Add "-ot data_type" argument for output type, and store its value into eDT.
+    void add_output_type_argument(GDALDataType &eDT);
+
+    //! Parse command line arguments, without the initial program name.
+    void parse_args_without_binary_name(CSLConstList papszArgs);
+
+    //! Parse command line arguments, with the initial program name.
+    void parse_args(const CPLStringList &aosArgs);
+
+    //! Return the non positional arguments.
+    CPLStringList get_non_positional_arguments(const CPLStringList &aosArgs);
+
+  private:
+    std::map<std::string, ArgumentParser::argument_it>::iterator
+    find_argument(const std::string &name);
+};
+
+#endif /* GDALARGUMENTPARSER_H */

--- a/apps/nearblack_bin.cpp
+++ b/apps/nearblack_bin.cpp
@@ -35,45 +35,14 @@
 /*                               Usage()                                */
 /************************************************************************/
 
-static void Usage(bool bIsError, const char *pszErrorMsg = nullptr)
+static void Usage(const char *pszErrorMsg = nullptr)
 {
-    fprintf(bIsError ? stderr : stdout,
-            "Usage: nearblack [--help] [--help-general]\n"
-            "          [-of <format>] [-white | [-color "
-            "<c1>,<c2>,<c3>...<cn>]...]\n"
-            "          [-near <dist>] [-nb <non_black_pixels>]\n"
-            "          [-setalpha] [-setmask] [-alg twopasses|floodfill]\n"
-            "          [-o <outfile>] [-q] [-co <NAME>=<VALUE>]... <infile>\n");
+    fprintf(stderr, "%s\n\n", GDALNearblackGetParserUsage().c_str());
 
     if (pszErrorMsg != nullptr)
         fprintf(stderr, "\nFAILURE: %s\n", pszErrorMsg);
 
-    exit(bIsError ? 1 : 0);
-}
-
-/************************************************************************/
-/*                       GDALNearblackOptionsForBinaryNew()             */
-/************************************************************************/
-
-static GDALNearblackOptionsForBinary *GDALNearblackOptionsForBinaryNew()
-{
-    return static_cast<GDALNearblackOptionsForBinary *>(
-        CPLCalloc(1, sizeof(GDALNearblackOptionsForBinary)));
-}
-
-/************************************************************************/
-/*                       GDALNearblackOptionsForBinaryFree()            */
-/************************************************************************/
-
-static void GDALNearblackOptionsForBinaryFree(
-    GDALNearblackOptionsForBinary *psOptionsForBinary)
-{
-    if (psOptionsForBinary)
-    {
-        CPLFree(psOptionsForBinary->pszInFile);
-        CPLFree(psOptionsForBinary->pszOutFile);
-        CPLFree(psOptionsForBinary);
-    }
+    exit(1);
 }
 
 /************************************************************************/
@@ -99,44 +68,23 @@ MAIN_START(argc, argv)
     if (argc < 1)
         exit(-argc);
 
-    for (int i = 0; i < argc; i++)
-    {
-        if (EQUAL(argv[i], "--utility_version"))
-        {
-            printf("%s was compiled against GDAL %s and "
-                   "is running against GDAL %s\n",
-                   argv[0], GDAL_RELEASE_NAME, GDALVersionInfo("RELEASE_NAME"));
-            CSLDestroy(argv);
-            return 0;
-        }
-        else if (EQUAL(argv[i], "--help"))
-        {
-            Usage(false);
-        }
-    }
-
-    GDALNearblackOptionsForBinary *psOptionsForBinary =
-        GDALNearblackOptionsForBinaryNew();
+    GDALNearblackOptionsForBinary sOptionsForBinary;
     GDALNearblackOptions *psOptions =
-        GDALNearblackOptionsNew(argv + 1, psOptionsForBinary);
+        GDALNearblackOptionsNew(argv + 1, &sOptionsForBinary);
     CSLDestroy(argv);
 
     if (psOptions == nullptr)
     {
-        Usage(true);
+        Usage();
     }
 
-    if (!(psOptionsForBinary->bQuiet))
+    if (!(sOptionsForBinary.bQuiet))
     {
         GDALNearblackOptionsSetProgress(psOptions, GDALTermProgress, nullptr);
     }
 
-    if (psOptionsForBinary->pszInFile == nullptr)
-        Usage(true, "No input file specified.");
-
-    if (psOptionsForBinary->pszOutFile == nullptr)
-        psOptionsForBinary->pszOutFile =
-            CPLStrdup(psOptionsForBinary->pszInFile);
+    if (sOptionsForBinary.osOutFile.empty())
+        sOptionsForBinary.osOutFile = sOptionsForBinary.osInFile;
 
     /* -------------------------------------------------------------------- */
     /*      Open input file.                                                */
@@ -145,15 +93,14 @@ MAIN_START(argc, argv)
     GDALDatasetH hOutDS = nullptr;
     bool bCloseRetDS = false;
 
-    if (strcmp(psOptionsForBinary->pszOutFile, psOptionsForBinary->pszInFile) ==
-        0)
+    if (sOptionsForBinary.osOutFile == sOptionsForBinary.osInFile)
     {
-        hInDS = GDALOpen(psOptionsForBinary->pszInFile, GA_Update);
+        hInDS = GDALOpen(sOptionsForBinary.osInFile.c_str(), GA_Update);
         hOutDS = hInDS;
     }
     else
     {
-        hInDS = GDALOpen(psOptionsForBinary->pszInFile, GA_ReadOnly);
+        hInDS = GDALOpen(sOptionsForBinary.osInFile.c_str(), GA_ReadOnly);
         bCloseRetDS = true;
     }
 
@@ -161,10 +108,10 @@ MAIN_START(argc, argv)
         exit(1);
 
     int bUsageError = FALSE;
-    GDALDatasetH hRetDS = GDALNearblack(psOptionsForBinary->pszOutFile, hOutDS,
-                                        hInDS, psOptions, &bUsageError);
+    GDALDatasetH hRetDS = GDALNearblack(sOptionsForBinary.osOutFile.c_str(),
+                                        hOutDS, hInDS, psOptions, &bUsageError);
     if (bUsageError)
-        Usage(true);
+        Usage();
     int nRetCode = hRetDS ? 0 : 1;
 
     if (GDALClose(hInDS) != CE_None)
@@ -175,7 +122,6 @@ MAIN_START(argc, argv)
             nRetCode = 1;
     }
     GDALNearblackOptionsFree(psOptions);
-    GDALNearblackOptionsForBinaryFree(psOptionsForBinary);
 
     GDALDestroyDriverManager();
 

--- a/apps/ogr2ogr_bin.cpp
+++ b/apps/ogr2ogr_bin.cpp
@@ -57,177 +57,9 @@
 /*                               Usage()                                */
 /************************************************************************/
 
-static bool StringCISortFunction(const CPLString &a, const CPLString &b)
+static void Usage()
 {
-    return STRCASECMP(a.c_str(), b.c_str()) < 0;
-}
-
-static void Usage(bool bIsError, const char *pszAdditionalMsg = nullptr,
-                  bool bShort = true)
-{
-    fprintf(
-        bIsError ? stderr : stdout,
-        "Usage: ogr2ogr [--help] [--help-general] [--long-usage]\n"
-        "               [-skipfailures] [-append | -upsert] [-update]\n"
-        "               [-select <field_list>] [-where "
-        "<restricted_where>|@<filename>]\n"
-        "               [-progress] [-sql <sql statement>|@<filename>] "
-        "[-dialect "
-        "<dialect>]\n"
-        "               [-preserve_fid] [-fid <FID>] [-limit <nb_features>]\n"
-        "               [-spat <xmin> <ymin> <xmax> <ymax>] [-spat_srs "
-        "<srs_def>] "
-        "[-geomfield <field>]\n"
-        "               [-a_srs <srs_def>] [-t_srs <srs_def>] [-s_srs "
-        "<srs_def>] "
-        "[-ct <string>]\n"
-        "               [-if <input_drv_name>] [-f <output_drv_name>] "
-        "[-overwrite] "
-        "[-dsco <NAME>=<VALUE>]...\n"
-        "               [-lco <NAME>=<VALUE>]... [-nln <name>] \n"
-        "               [-nlt "
-        "<type>|PROMOTE_TO_MULTI|CONVERT_TO_LINEAR|CONVERT_TO_CURVE]\n"
-        "               [-dim XY|XYZ|XYM|XYZM|<layer_dim>]\n"
-        "               <dst_datasource_name> <src_datasource_name>\n"
-        "               [<layer> [<layer>...]]\n"
-        "\n"
-        "Advanced options :\n"
-        "               [-gt n] [-ds_transaction]\n"
-        "               [-oo <NAME>=<VALUE>]... [-doo <NAME>=<VALUE>]...\n"
-        "               [-clipsrc {[<xmin> <ymin> <xmax> <ymax>]|<WKT>|"
-        "<datasource>|spat_extent}]\n"
-        "               [-clipsrcsql <sql_statement>] [-clipsrclayer <layer>]\n"
-        "               [-clipsrcwhere <expression>]\n"
-        "               [-clipdst {[<xmin> <ymin> <xmax> "
-        "<ymax>]|<WKT>|<datasource>}]\n"
-        "               [-clipdstsql <sql_statement>] [-clipdstlayer <layer>]\n"
-        "               [-clipdstwhere <expression>]\n"
-        "               [-wrapdateline][-datelineoffset <val>]\n"
-        "               [[-simplify <tolerance>] | [-segmentize <max_dist>]]\n"
-        "               [-makevalid]\n"
-        "               [-addfields] [-unsetFid] [-emptyStrAsNull]\n"
-        "               [-relaxedFieldNameMatch] [-forceNullable] "
-        "[-unsetDefault]\n"
-        "               [-fieldTypeToString {All|{<type1>[,<type2>]}...}] "
-        "[-unsetFieldWidth]\n"
-        "               [-mapFieldType "
-        "{<srctype>|All=<dsttype>[,<srctype2>=<dsttype2>]...}]\n"
-        "               [-dateTimeTo {UTC|UTC(+|-)<HH>|UTC(+|-)<HH>:<MM>}]\n"
-        "               [-fieldmap {identity|{<index1>[,<index2>]...}]\n"
-        "               [-splitlistfields] [-maxsubfields <val>]\n"
-        "               [-resolveDomains]\n"
-        "               [-explodecollections] [-zfield <field_name>]\n"
-        "               [-gcp <ungeoref_x> <ungeoref_y> <georef_x> <georef_y> "
-        "[<elevation>]]... [[-order <n>]|[-tps]]\n"
-        "               [-xyRes \"<val>[ m|mm|deg]\"] [-zRes \"<val>[ m|mm]\"] "
-        "[-mRes <val>]\n"
-        "               [-unsetCoordPrecision]\n"
-        "               [-s_coord_epoch <epoch>] [-t_coord_epoch <epoch>] "
-        "[-a_coord_epoch <epoch>]\n"
-        "               [-nomd] [-mo <META-TAG>=<VALUE>]... [-noNativeData]\n");
-
-    if (bShort)
-    {
-        printf("\nNote: ogr2ogr --long-usage for full help.\n");
-        if (pszAdditionalMsg)
-            fprintf(stderr, "\nFAILURE: %s\n", pszAdditionalMsg);
-        exit(1);
-    }
-
-    printf(
-        "\n -f format_name: output file format name, possible values are:\n");
-
-    std::vector<CPLString> aoSetDrivers;
-    OGRSFDriverRegistrar *poR = OGRSFDriverRegistrar::GetRegistrar();
-    for (int iDriver = 0; iDriver < poR->GetDriverCount(); iDriver++)
-    {
-        GDALDriver *poDriver = poR->GetDriver(iDriver);
-
-        if (CPLTestBool(CSLFetchNameValueDef(poDriver->GetMetadata(),
-                                             GDAL_DCAP_CREATE, "FALSE")))
-            aoSetDrivers.push_back(poDriver->GetDescription());
-    }
-    std::sort(aoSetDrivers.begin(), aoSetDrivers.end(), StringCISortFunction);
-    for (const auto &oDriver : aoSetDrivers)
-    {
-        printf("     -f \"%s\"\n", oDriver.c_str());
-    }
-
-    printf(
-        " -append: Append to existing layer instead of creating new if it "
-        "exists\n"
-        " -overwrite: delete the output layer and recreate it empty\n"
-        " -update: Open existing output datasource in update mode\n"
-        " -progress: Display progress on terminal. Only works if input layers "
-        "have the \n"
-        "                                          \"fast feature count\" "
-        "capability\n"
-        " -select field_list: Comma-delimited list of fields from input layer "
-        "to\n"
-        "                     copy to the new layer (defaults to all)\n"
-        " -where restricted_where: Attribute query (like SQL WHERE)\n"
-        " -wrapdateline: split geometries crossing the dateline meridian\n"
-        "                (long. = +/- 180deg)\n"
-        " -datelineoffset: offset from dateline in degrees\n"
-        "                (default long. = +/- 10deg,\n"
-        "                geometries within 170deg to -170deg will be split)\n"
-        " -sql statement: Execute given SQL statement and save result.\n"
-        " -dialect value: select a dialect, usually OGRSQL to avoid native "
-        "sql.\n"
-        " -skipfailures: skip features or layers that fail to convert\n"
-        " -gt n: group n features per transaction (default 20000). n can be "
-        "set to unlimited\n"
-        " -spat xmin ymin xmax ymax: spatial query extents\n"
-        " -simplify tolerance: distance tolerance for simplification.\n"
-        " -segmentize max_dist: maximum distance between 2 nodes.\n"
-        "                       Used to create intermediate points\n"
-        " -dsco NAME=VALUE: Dataset creation option (format specific)\n"
-        " -lco  NAME=VALUE: Layer creation option (format specific)\n"
-        " -oo   NAME=VALUE: Input dataset open option (format specific)\n"
-        " -doo  NAME=VALUE: Destination dataset open option (format specific)\n"
-        " -nln name: Assign an alternate name to the new layer\n"
-        " -nlt type: Force a geometry type for new layer.  One of NONE, "
-        "GEOMETRY,\n"
-        "      POINT, LINESTRING, POLYGON, GEOMETRYCOLLECTION, MULTIPOINT,\n"
-        "      MULTIPOLYGON, or MULTILINESTRING, or PROMOTE_TO_MULTI or "
-        "CONVERT_TO_LINEAR.  Add \"25D\" for 3D layers.\n"
-        "      Default is type of source layer.\n"
-        " -dim dimension: Force the coordinate dimension to the specified "
-        "value.\n"
-        " -fieldTypeToString type1,...: Converts fields of specified types to\n"
-        "      fields of type string in the new layer. Valid types are : "
-        "Integer,\n"
-        "      Integer64, Real, String, Date, Time, DateTime, Binary, "
-        "IntegerList, Integer64List, RealList,\n"
-        "      StringList. Special value All will convert all fields to "
-        "strings.\n"
-        " -fieldmap index1,index2,...: Specifies the list of field indexes to "
-        "be\n"
-        "      copied from the source to the destination. The (n)th value "
-        "specified\n"
-        "      in the list is the index of the field in the target layer "
-        "definition\n"
-        "      in which the n(th) field of the source layer must be copied. "
-        "Index count\n"
-        "      starts at zero. There must be exactly as many values in the "
-        "list as\n"
-        "      the count of the fields in the source layer. We can use the "
-        "'identity'\n"
-        "      setting to specify that the fields should be transferred by "
-        "using the\n"
-        "      same order. This setting should be used along with the append "
-        "setting.\n");
-
-    printf(" -a_srs srs_def: Assign an output SRS\n"
-           " -t_srs srs_def: Reproject/transform to this SRS on output\n"
-           " -s_srs srs_def: Override source SRS\n"
-           "\n"
-           " Srs_def can be a full WKT definition (hard to escape properly),\n"
-           " or a well known definition (i.e. EPSG:4326) or a file with a WKT\n"
-           " definition.\n");
-
-    if (pszAdditionalMsg)
-        fprintf(stderr, "\nFAILURE: %s\n", pszAdditionalMsg);
+    fprintf(stderr, "%s\n", GDALVectorTranslateGetParserUsage().c_str());
 }
 
 /************************************************************************/
@@ -267,48 +99,12 @@ MAIN_START(nArgc, papszArgv)
         goto exit;
     }
 
-    for (int iArg = 1; iArg < nArgc; iArg++)
-    {
-        if (EQUAL(papszArgv[iArg], "--utility_version"))
-        {
-            printf("%s was compiled against GDAL %s and "
-                   "is running against GDAL %s\n",
-                   papszArgv[0], GDAL_RELEASE_NAME,
-                   GDALVersionInfo("RELEASE_NAME"));
-            nRetCode = 0;
-            goto exit;
-        }
-        else if (EQUAL(papszArgv[iArg], "--help"))
-        {
-            Usage(false);
-            nRetCode = 0;
-            goto exit;
-        }
-        else if (EQUAL(papszArgv[iArg], "--long-usage"))
-        {
-            Usage(false, nullptr, false);
-            nRetCode = 0;
-            goto exit;
-        }
-    }
-
     psOptions =
         GDALVectorTranslateOptionsNew(papszArgv + 1, &sOptionsForBinary);
 
     if (psOptions == nullptr)
     {
-        Usage(true);
-        goto exit;
-    }
-
-    if (sOptionsForBinary.osDataSource.empty() ||
-        !sOptionsForBinary.bDestSpecified)
-    {
-        if (!sOptionsForBinary.bDestSpecified)
-            Usage(true, "no target datasource provided");
-        else
-            Usage(true, "no source datasource provided");
-        GDALVectorTranslateOptionsFree(psOptions);
+        Usage();
         goto exit;
     }
 
@@ -426,7 +222,7 @@ MAIN_START(nArgc, papszArgv)
         hDstDS = GDALVectorTranslate(sOptionsForBinary.osDestDataSource.c_str(),
                                      hODS, 1, &hDS, psOptions, &bUsageError);
         if (bUsageError)
-            Usage(true);
+            Usage();
         else
             nRetCode = hDstDS ? 0 : 1;
     }

--- a/apps/ogrinfo_bin.cpp
+++ b/apps/ogrinfo_bin.cpp
@@ -40,32 +40,10 @@
 /*                               Usage()                                */
 /************************************************************************/
 
-static void Usage(bool bIsError, const char *pszErrorMsg = nullptr)
+static void Usage()
 {
-    fprintf(bIsError ? stderr : stdout,
-            "Usage: ogrinfo [--help] [--help-general]\n"
-            "               [-if <driver_name>] [-json] [-ro] [-q] [-where "
-            "<restricted_where>|@f<ilename>]\n"
-            "               [-spat <xmin> <ymin> <xmax> <ymax>] [-geomfield "
-            "<field>] "
-            "[-fid <fid>]\n"
-            "               [-sql <statement>|@<filename>] [-dialect "
-            "<sql_dialect>] "
-            "[-al] [-rl]\n"
-            "               [-so|-features] [-fields={YES|NO}]]\n"
-            "               [-geom={YES|NO|SUMMARY|WKT|ISO_WKT}] "
-            "[-oo <NAME>=<VALUE>]...\n"
-            "               [-nomd] [-listmdd] [-mdd {<domain>|all}]...\n"
-            "               [-nocount] [-nogeomtype] "
-            "[[-noextent] | [-extent3D]]\n"
-            "               [-wkt_format WKT1|WKT2|<other_values>]\n"
-            "               [-fielddomain <name>]\n"
-            "               <datasource_name> [<layer> [<layer> ...]]\n");
-
-    if (pszErrorMsg != nullptr)
-        fprintf(stderr, "\nFAILURE: %s\n", pszErrorMsg);
-
-    exit(bIsError ? 1 : 0);
+    fprintf(stderr, "%s\n", GDALVectorInfoGetParserUsage().c_str());
+    exit(1);
 }
 
 /************************************************************************/
@@ -87,33 +65,13 @@ MAIN_START(argc, argv)
     if (argc < 1)
         exit(-argc);
 
-    for (int i = 0; argv != nullptr && argv[i] != nullptr; i++)
-    {
-        if (EQUAL(argv[i], "--utility_version"))
-        {
-            printf("%s was compiled against GDAL %s and is running against "
-                   "GDAL %s\n",
-                   argv[0], GDAL_RELEASE_NAME, GDALVersionInfo("RELEASE_NAME"));
-            CSLDestroy(argv);
-            return 0;
-        }
-        else if (EQUAL(argv[i], "--help"))
-        {
-            Usage(false);
-        }
-    }
-    argv = CSLAddString(argv, "-stdout");
-
     auto psOptionsForBinary =
         std::make_unique<GDALVectorInfoOptionsForBinary>();
 
     GDALVectorInfoOptions *psOptions =
         GDALVectorInfoOptionsNew(argv + 1, psOptionsForBinary.get());
     if (psOptions == nullptr)
-        Usage(true);
-
-    if (psOptionsForBinary->osFilename.empty())
-        Usage(true, "No datasource specified.");
+        Usage();
 
 /* -------------------------------------------------------------------- */
 /*      Open dataset.                                                   */

--- a/autotest/gdrivers/wcs.py
+++ b/autotest/gdrivers/wcs.py
@@ -547,10 +547,9 @@ def test_wcs_6(wcs_server, tmp_path, server, version):
     projwin = [
         int(x) for x in setup[server]["Projwin"].replace("-projwin ", "").split()
     ]
-    options = [cache]
 
     tmpfile = tmp_path / f"{server}{version}.tiff"
-    gdal.Translate(str(tmpfile), ds, projWin=projwin, width=size, options=options)
+    gdal.Translate(str(tmpfile), ds, projWin=projwin, width=size)
 
     assert tmpfile.exists()
 
@@ -565,10 +564,7 @@ def test_wcs_6(wcs_server, tmp_path, server, version):
 
         assert ds is not None, f"OpenEx failed: WCS:{url}/?{query}"
 
-        options = [cache]
-        gdal.Translate(
-            str(tmpfile_non_scaled), ds, srcWin=[0, 0, 2, 2], options=options
-        )
+        gdal.Translate(str(tmpfile_non_scaled), ds, srcWin=[0, 0, 2, 2])
 
         assert tmpfile_non_scaled.exists()
     else:

--- a/autotest/utilities/test_gdal_translate.py
+++ b/autotest/utilities/test_gdal_translate.py
@@ -968,12 +968,12 @@ def test_gdal_translate_34(gdal_translate_path, tmp_path):
 def test_gdal_translate_35(gdal_translate_path, tmp_vsimem):
 
     (_, err) = gdaltest.runexternal_out_and_err(gdal_translate_path)
-    assert "No source dataset specified" in err
+    assert "input_file: 1 argument(s) expected. 0 provided." in err
 
     (_, err) = gdaltest.runexternal_out_and_err(
         gdal_translate_path + " ../gcore/data/byte.tif"
     )
-    assert "No target dataset specified" in err
+    assert "output_file: 1 argument(s) expected. 0 provided." in err
 
     (_, err) = gdaltest.runexternal_out_and_err(
         f"{gdal_translate_path} /non_existing_path/non_existing.tif {tmp_vsimem}/out.tif"

--- a/autotest/utilities/test_gdal_viewshed.py
+++ b/autotest/utilities/test_gdal_viewshed.py
@@ -217,8 +217,8 @@ def test_gdal_viewshed_all_options(gdal_viewshed_path, tmp_path, viewshed_input)
 
 def test_gdal_viewshed_missing_source(gdal_viewshed_path):
 
-    _, err = gdaltest.runexternal_out_and_err(gdal_viewshed_path)
-    assert "Missing source filename" in err
+    _, err = gdaltest.runexternal_out_and_err(gdal_viewshed_path + " -ox 0 -oy 0")
+    assert "dst_filename: 1 argument(s) expected. 0 provided" in err
 
 
 ###############################################################################
@@ -226,8 +226,10 @@ def test_gdal_viewshed_missing_source(gdal_viewshed_path):
 
 def test_gdal_viewshed_missing_destination(gdal_viewshed_path):
 
-    _, err = gdaltest.runexternal_out_and_err(gdal_viewshed_path + " /dev/null")
-    assert "Missing destination filename" in err
+    _, err = gdaltest.runexternal_out_and_err(
+        gdal_viewshed_path + " -ox 0 -oy 0 /dev/null"
+    )
+    assert "Error: dst_filename: 1 argument(s) expected. 0 provided" in err
 
 
 ###############################################################################
@@ -238,7 +240,7 @@ def test_gdal_viewshed_missing_ox(gdal_viewshed_path):
     _, err = gdaltest.runexternal_out_and_err(
         gdal_viewshed_path + " /dev/null /dev/null"
     )
-    assert "Missing -ox" in err
+    assert "-ox: required" in err
 
 
 ###############################################################################
@@ -249,7 +251,7 @@ def test_gdal_viewshed_missing_oy(gdal_viewshed_path):
     _, err = gdaltest.runexternal_out_and_err(
         gdal_viewshed_path + " -ox 0 /dev/null /dev/null"
     )
-    assert "Missing -oy" in err
+    assert "-oy: required" in err
 
 
 ###############################################################################

--- a/autotest/utilities/test_ogr2ogr_lib.py
+++ b/autotest/utilities/test_ogr2ogr_lib.py
@@ -2516,13 +2516,13 @@ def test_ogr2ogr_lib_coordinate_precision(tmp_vsimem):
 
     with pytest.raises(
         Exception,
-        match="Invalid value for -mRes",
+        match="Failed to parse 'invalid' as number",
     ):
         gdal.VectorTranslate(out_filename, src_ds, mRes="invalid")
 
     with pytest.raises(
         Exception,
-        match="Invalid value for -mRes",
+        match="Failed to parse '1 invalid' as number",
     ):
         gdal.VectorTranslate(out_filename, src_ds, mRes="1 invalid")
 

--- a/doc/source/programs/ogr2ogr.rst
+++ b/doc/source/programs/ogr2ogr.rst
@@ -15,47 +15,37 @@ Synopsis
 
 .. code-block::
 
-    ogr2ogr [--help] [--help-general] [--long-usage]
-            [-skipfailures] [-append | -upsert] [-update]
-            [-select <field_list>] [-where <restricted_where>|@<filename>]
-            [-progress] [-sql <sql statement>|@<filename>] [-dialect <dialect>]
-            [-preserve_fid] [-fid <FID>] [-limit <nb_features>]
-            [-spat <xmin> <ymin> <xmax> <ymax>] [-spat_srs <srs_def>] [-geomfield <field>]
-            [-a_srs <srs_def>] [-t_srs <srs_def>] [-s_srs <srs_def>] [-ct <string>]
-            [-if <input_drv_name>] [-f <format_name>] [-overwrite] [-dsco <NAME>=<VALUE>]...
-            [-lco <NAME>=<VALUE>]... [-nln <name>]
-            [-nlt <type>|PROMOTE_TO_MULTI|CONVERT_TO_LINEAR|CONVERT_TO_CURVE]
-            [-dim XY|XYZ|XYM|XYZM|<layer_dim>]
-            <dst_datasource_name> <src_datasource_name>
-            [<layer> [<layer>...]]
+    ogr2ogr [--help] [--long-usage] [--help-general]
+            [-of <output_format>] [-dsco <NAME>=<VALUE>]... [-lco <NAME>=<VALUE>]...
+            [[-append]|[-upsert]|[-overwrite]]
+            [-update] [-sql <statement>|@<filename>] [-dialect <dialect>] [-spat <xmin> <ymin> <xmax> <ymax>]
+            [-where <restricted_where>|@<filename>] [-select <field_list>] [-nln <name>] [-nlt <type>]...
+            [-s_srs <srs_def>]
+            [[-a_srs <srs_def>]|[-t_srs <srs_def>]]
+            <dst_dataset_name> <src_dataset_name> [<layer_name>]...
 
-            # Advanced options
-            [-gt n] [-ds_transaction]
-            [-oo <NAME>=<VALUE>]... [-doo <NAME>=<VALUE>]...
-            [-clipsrc {[<xmin> <ymin> <xmax> <ymax>]|<WKT>|<datasource>|spat_extent}]
-            [-clipsrcsql <sql_statement>] [-clipsrclayer <layer>]
-            [-clipsrcwhere <expression>]
-            [-clipdst {[<xmin> <ymin> <xmax> <ymax>]|<WKT>|<datasource>}]
-            [-clipdstsql <sql_statement>] [-clipdstlayer <layer>]
-            [-clipdstwhere <expression>]
-            [-wrapdateline][-datelineoffset <val>]
-            [[-simplify <tolerance>] | [-segmentize <max_dist>]]
-            [-makevalid]
-            [-addfields] [-unsetFid] [-emptyStrAsNull]
-            [-relaxedFieldNameMatch] [-forceNullable] [-unsetDefault]
-            [-fieldTypeToString {All|{<type1>[,<type2>]}...}] [-unsetFieldWidth]
-            [-mapFieldType {<srctype>|All=<dsttype>[,<srctype2>=<dsttype2>]...}]
-            [-dateTimeTo {UTC|UTC(+|-)<HH>|UTC(+|-)<HH>:<MM>}]
-            [-fieldmap {identity|{<index1>[,<index2>]...}]
-            [-splitlistfields] [-maxsubfields <val>]
-            [-resolveDomains]
-            [-explodecollections] [-zfield <field_name>]
-            [-gcp <ungeoref_x> <ungeoref_y> <georef_x> <georef_y> [<elevation>]]... [-order <n> | -tps]
-            [-xyRes "<val>[ m|mm|deg]"] [-zRes "<val>[ m|mm]"] [-mRes <val>]
-            [-unsetCoordPrecision]
-            [-s_coord_epoch <epoch>] [-t_coord_epoch <epoch>] [-a_coord_epoch <epoch>]
-            [-nomd] [-mo <META-TAG>=<VALUE>]... [-noNativeData]
+    Field related options:
+           [-addfields] [-relaxedFieldNameMatch] [-fieldTypeToString All|<type1>[,<type2>]...]
+           [-mapFieldType <srctype>|All=<dsttype>[,<srctype2>=<dsttype2>]...] [-fieldmap <field_1>[,<field_2>]...]
+           [-splitlistfields] [-maxsubfields <n>] [-emptyStrAsNull] [-forceNullable] [-unsetFieldWidth]
+           [-unsetDefault] [-resolveDomains] [-dateTimeTo UTC|UTC(+|-)<HH>|UTC(+|-)<HH>:<MM>] [-noNativeData]
 
+    Advanced geometry and SRS related options:
+           [-dim layer_dim|2|XY|3|XYZ|XYM|XYZM] [-s_coord_epoch <epoch>] [-a_coord_epoch <epoch>]
+           [-t_coord_epoch <epoch>] [-ct <pipeline_def>] [-spat_srs <srs_def>] [-geomfield <name>]
+           [-segmentize <max_dist>] [-simplify <tolerance>] [-makevalid] [-wrapdateline]
+           [-datelineoffset <val_in_degree>] [-clipsrc [<xmin> <ymin> <xmax> <ymax>]|<WKT>|<datasource>|spat_extent]
+           [-clipsrcsql <sql_statement>] [-clipsrclayer <layername>] [-clipsrcwhere <expression>]
+           [-clipdst [<xmin> <ymin> <xmax> <ymax>]|<WKT>|<datasource>] [-clipdstsql <sql_statement>]
+           [-clipdstlayer <layername>] [-clipdstwhere <expression>] [-explodecollections] [-zfield <name>]
+           [-gcp <ungeoref_x> <ungeoref_y> <georef_x> <georef_y> [<elevation>]]... [-tps] [-order 1|2|3]
+           [-xyRes <val>[ m|mm|deg]] [-zRes <val>[ m|mm]] [-mRes <val>] [-unsetCoordPrecision]
+
+    Other options:
+           [--quiet] [-progress] [-if <format>]... [-oo <NAME>=<VALUE>]... [-doo <NAME>=<VALUE>]...
+           [-fid <FID>] [-preserve_fid] [-unsetFid]
+           [[-skipfailures]|[-gt <n>|unlimited]]
+           [-limit <nb_features>] [-ds_transaction] [-mo <NAME>=<VALUE>]... [-nomd]
 
 Description
 -----------
@@ -71,7 +61,7 @@ output coordinate system or even reprojecting the features during translation.
 
 .. include:: options/if.rst
 
-.. option:: -f <format_name>
+.. option:: -of <format_name>, -f <format_name>
 
     Output file format name, e.g. ``ESRI Shapefile``, ``MapInfo File``,
     ``PostgreSQL``.  Starting with GDAL 2.3, if not specified, the format is
@@ -587,6 +577,20 @@ output coordinate system or even reprojecting the features during translation.
     (like GeoJSON) when converting to same format.
 
     .. versionadded:: 2.1
+
+.. option:: <dst_dataset_name>
+
+    Output dataset name.
+
+.. option:: <src_dataset_name>
+
+    Source dataset name.
+
+.. option:: <layer_name>
+
+    One or more source layer names to copy to the output dataset. If no layer
+    names are passed, then all source layers are copied.
+
 
 Performance Hints
 -----------------

--- a/port/cpl_conv.h
+++ b/port/cpl_conv.h
@@ -113,6 +113,7 @@ const char CPL_DLL *CPLReadLine3L(VSILFILE *, int, int *, CSLConstList);
 double CPL_DLL CPLAtof(const char *);
 double CPL_DLL CPLAtofDelim(const char *, char);
 double CPL_DLL CPLStrtod(const char *, char **);
+double CPL_DLL CPLStrtodM(const char *, char **);
 double CPL_DLL CPLStrtodDelim(const char *, char **, char);
 float CPL_DLL CPLStrtof(const char *, char **);
 float CPL_DLL CPLStrtofDelim(const char *, char **, char);

--- a/port/cpl_strtod.cpp
+++ b/port/cpl_strtod.cpp
@@ -381,7 +381,7 @@ double CPLStrtodDelim(const char *nptr, char **endptr, char point)
         }
         else
         {
-            errno = answer.ptr == nptr ? EINVAL : ERANGE;
+            errno = answer.ptr == nptr ? 0 : ERANGE;
         }
     }
     if (endptr)

--- a/port/cpl_strtod.cpp
+++ b/port/cpl_strtod.cpp
@@ -440,6 +440,44 @@ double CPLStrtod(const char *nptr, char **endptr)
 }
 
 /************************************************************************/
+/*                            CPLStrtodM()                              */
+/************************************************************************/
+
+/**
+ * Converts ASCII string to floating point number.
+ *
+ * This function converts the initial portion of the string pointed to
+ * by nptr to double floating point representation. This function does the
+ * same as standard strtod(3), but does not take locale in account.
+ *
+ * That function accepts '.' (decimal point) or ',' (comma) as decimal
+ * delimiter.
+ *
+ * @param nptr Pointer to string to convert.
+ * @param endptr If is not NULL, a pointer to the character after the last
+ * character used in the conversion is stored in the location referenced
+ * by endptr.
+ *
+ * @return Converted value, if any.
+ * @since GDAL 3.9
+ */
+double CPLStrtodM(const char *nptr, char **endptr)
+
+{
+    const int nMaxSearch = 50;
+
+    for (int i = 0; i < nMaxSearch; i++)
+    {
+        if (nptr[i] == ',')
+            return CPLStrtodDelim(nptr, endptr, ',');
+        if (nptr[i] == '.' || nptr[i] == '\0')
+            return CPLStrtodDelim(nptr, endptr, '.');
+    }
+
+    return CPLStrtodDelim(nptr, endptr, '.');
+}
+
+/************************************************************************/
 /*                          CPLStrtofDelim()                            */
 /************************************************************************/
 

--- a/scripts/cppcheck.sh
+++ b/scripts/cppcheck.sh
@@ -140,6 +140,10 @@ mv ${LOG_FILE}.tmp ${LOG_FILE}
 grep -v -e "ogr/ogrsf_frmts/pmtiles/pmtiles/" ${LOG_FILE} > ${LOG_FILE}.tmp
 mv ${LOG_FILE}.tmp ${LOG_FILE}
 
+# Ignore apps/argparse/ header
+grep -v -e "apps/argparse/" ${LOG_FILE} > ${LOG_FILE}.tmp
+mv ${LOG_FILE}.tmp ${LOG_FILE}
+
 # Ignore third_party/fast_float
 grep -v -e "third_party/fast_float" ${LOG_FILE} > ${LOG_FILE}.tmp
 mv ${LOG_FILE}.tmp ${LOG_FILE}


### PR DESCRIPTION
Cf email thread at https://lists.osgeo.org/pipermail/gdal-dev/2024-March/thread.html#58647

Up to now, ``sozip``, ``gdal_viewshed``, ``nearblack``, ``ogrinfo``, ``gdaladdo``, ``gdal_translate``, ``ogr2ogr`` (so a mix of pure command line utilitys and utility-as-a-C-function) have been converted. This should exercise pretty much all what we need: optional and positional arguments, boolean/integer/double data types, repeated arguments, mutually exclusive arguments. So I'm quite confident now we could generalize the use of that framework to all other utilities

I've had to extend p-ranav/argparse with various changes to improve the usage/synopsis output, and add some helpers to make it easier to use:
- add Argument::store_into(variable) helpers to define in the same time the argument and where its value is stored (EDIT: upstreamed)
- allow using a locale-independent strtod() for floating-point parsing (EDIT: upstreamed)
- add hidden alias for deprecated versions of option names (EDIT: upstreamed)
- allow positional arguments to be put anywhere, and not just after optional arguments (that one was tricky!) (EDIT: argparse related change now upstreamed; another part is in the GDALArgumentParser extended class)
- add "groups" to categorize optional arguments, like between basic/regular and advanced options (EDIT: upstreamed)
- ask for the usage summary to be split on multiple lines, and nicer way of presenting mutually exclusive arguments (EDIT: upstreamed)
- add "..." for repeated arguments in the synosys (EDIT: upstreamed)

All of the above changes have been merged by upstream.
<s>I'll try to submit them to upstream if they are interested into them (I've started with a bugfix to make the library usable with clang's -fsanitize=undefined-integer-overflow that we use in one of our CI config. EDIT: now merged upstream)</s>

I've added a GDALArgumentParser class extending the base argparse::ArgumentParse that adds a few GDAL specific helpers, in particuler to define arguments that are common to multiple utilities (like -of, -co, etc.)

A few examples:

- Running ``sozip`` without required argument outputs the short usage. This also demonstrates a separation between basic/regular and advanced options:
```
Error: zip_filename: 1 argument(s) expected. 0 provided.
Usage: sozip [--help] [--long-usage] [--help-general] [--recurse-paths]
             [[--grow]|[--overwrite]]
             [[--list]|[--validate]|[--optimize-from <input.zip>]
             <zip_filename> [<input_files>]...

Advanced options:
             [[--quiet]|[--verbose]]
             [--junk-paths] [--enable-sozip auto|yes|no] [--sozip-chunk-size <value in bytes or with K/M suffix>]
             [--sozip-min-file-size <value in bytes or with K/M/G suffix>] [--content-type <string>]

Note: sozip --long-usage for full help.
```

- ``sozip --long-usage``:
```
Usage: sozip [--help] [--long-usage] [--help-general]
             [--recurse-paths]
             [[--grow]|[--overwrite]]
             [[--list]|[--validate]|[--optimize-from <input.zip>]
             <zip_filename> [<input_files>]...

Advanced options:
             [[--quiet]|[--verbose]]
             [--junk-paths] [--enable-sozip auto|yes|no] [--sozip-chunk-size <value in bytes or with K/M suffix>]
             [--sozip-min-file-size <value in bytes or with K/M/G suffix>] [--content-type <string>]

Generate a seek-optimized ZIP (SOZip) file.

Positional arguments:
  <zip_filename>                                               ZIP filename 
  <input_files>                                                Filename of the file to add. [nargs: 0 or more] 

Optional arguments:
  -h, --help                                                   Shows short help message and exits 
  --long-usage                                                 Shows long help message and exits 
  --help-general                                               Report detailed help on general options 
  -r, --recurse-paths                                          Travels the directory structure of the specified directories recursively. 
  -g, --grow                                                   Grow an existing zip file with the content of the specified filename(s). Default mode 
  --overwrite                                                  Overwrite the target zip file if it already exists. 
  -l, --list                                                   List the files contained in the zip file 
  --validate                                                   Validates a ZIP/SOZip file 
  --optimize-from <input.zip>                                  Re-process {input.zip} to generate a SOZip-optimized .zip 

Advanced options: (detailed usage)
  --quiet                                                      Quiet mode. No progress message is emitted on the standard output. 
  --verbose                                                    Verbose mode 
  -j, --junk-paths                                             Store just the name of a saved file (junk the path), and do not store directory names. 
  --enable-sozip auto|yes|no                                   In auto mode, a file is seek-optimized only if its size is above the value of
                                                               --sozip-chunk-size. In yes mode, all input files will be seek-optimized.
                                                               In no mode, no input files will be seek-optimized. 
  --sozip-chunk-size <value in bytes or with K/M suffix>       Chunk size for a seek-optimized file. Defaults to 32768 bytes. 
  --sozip-min-file-size <value in bytes or with K/M/G suffix>  Minimum file size to decide if a file should be seek-optimized. Defaults to 1 MB byte. 
  --content-type <string>                                      Store the Content-Type for the file being added 

For more details, consult https://gdal.org/programs/sozip.html
```

- ``gdal_viewshed --long-usage``:
```
Usage: gdal_viewshed [--help] [--long-usage] [--help-general]
                     [-of <output_format>] -ox <value> -oy <value> [-oz <value>]
                     [-vv <value>] [-iv <value>] [-ov <value>] [-co <KEY=VALUE>]...
                     [-a_nodata <value>] [-tz <value>] [-md <value>] [-cc <value>] [-b <value>] [-om NORMAL|DEM|GROUND]
                     [--quiet]
                     <src_filename> <dst_filename>

Calculates a viewshed raster from an input raster DEM.

Positional arguments:
  <src_filename>         
  <dst_filename>         

Optional arguments:
  -h, --help             Shows short help message and exits 
  --long-usage           Shows long help message and exits 
  --help-general         Report detailed help on general options 
  -of <output_format>    Output format 
  -ox <value>            The X position of the observer (in SRS units). [required]
  -oy <value>            The Y position of the observer (in SRS units). [required]
  -oz <value>            The height of the observer above the DEM surface in the height unit of the DEM. [default: 2]
  -vv <value>            Pixel value to set for visible areas. [default: 255]
  -iv <value>            Pixel value to set for invisible areas. [default: 0]
  -ov <value>            Pixel value to set for the cells that fall outside of the range specified by the observer location and the maximum distance. [default: 0]
  -co <KEY=VALUE>        Creation option(s) [may be repeated]
  -a_nodata <value>      The value to be set for the cells in the output raster that have no data. [default: -1]
  -tz <value>            The height of the target above the DEM surface in the height unit of the DEM. [default: 0]
  -md <value>            Maximum distance from observer to compute visibility. [default: 0]
  -cc <value>            Coefficient to consider the effect of the curvature and refraction. [default: 0.85714]
  -b <value>             Select an input band band containing the DEM data. [default: 1]
  -om NORMAL|DEM|GROUND  Sets what information the output contains. [default: "NORMAL"]
  -q, --quiet            Quiet mode. No progress message is emitted on the standard output. 

For more details, consult https://gdal.org/programs/gdal_viewshed.html
```

- ``ogr2ogr``: Ported, and improve categorization of options

```
Usage: ogr2ogr [--help] [--long-usage] [--help-general]
               [-of <output_format>] [-dsco <NAME>=<VALUE>]... [-lco <NAME>=<VALUE>]...
               [[-append]|[-upsert]|[-overwrite]]
               [-update] [-sql <statement>|@<filename>] [-dialect <dialect>] [-spat <xmin> <ymin> <xmax> <ymax>]
               [-where <restricted_where>|@<filename>] [-select <field_list>] [-nln <name>] [-nlt <type>]...
               [-s_srs <srs_def>]
               [[-a_srs <srs_def>]|[-t_srs <srs_def>]]
               <dst_dataset_name> <src_dataset_name> [<layer_name>]...

Field related options:
               [-addfields] [-relaxedFieldNameMatch] [-fieldTypeToString All|<type1>[,<type2>]...]
               [-mapFieldType <srctype>|All=<dsttype>[,<srctype2>=<dsttype2>]...] [-fieldmap <field_1>[,<field_2>]...]
               [-splitlistfields] [-maxsubfields <n>] [-emptyStrAsNull] [-forceNullable] [-unsetFieldWidth]
               [-unsetDefault] [-resolveDomains] [-dateTimeTo UTC|UTC(+|-)<HH>|UTC(+|-)<HH>:<MM>] [-noNativeData]

Advanced geometry and SRS related options:
               [-dim layer_dim|2|XY|3|XYZ|XYM|XYZM] [-s_coord_epoch <epoch>] [-a_coord_epoch <epoch>]
               [-t_coord_epoch <epoch>] [-ct <pipeline_def>] [-spat_srs <srs_def>] [-geomfield <name>]
               [-segmentize <max_dist>] [-simplify <tolerance>] [-makevalid] [-wrapdateline]
               [-datelineoffset <val_in_degree>] [-clipsrc [<xmin> <ymin> <xmax> <ymax>]|<WKT>|<datasource>|spat_extent]
               [-clipsrcsql <sql_statement>] [-clipsrclayer <layername>] [-clipsrcwhere <expression>]
               [-clipdst [<xmin> <ymin> <xmax> <ymax>]|<WKT>|<datasource>] [-clipdstsql <sql_statement>]
               [-clipdstlayer <layername>] [-clipdstwhere <expression>] [-explodecollections] [-zfield <name>]
               [-gcp <ungeoref_x> <ungeoref_y> <georef_x> <georef_y> [<elevation>]]... [-tps] [-order 1|2|3]
               [-xyRes <val>[ m|mm|deg]] [-zRes <val>[ m|mm]] [-mRes <val>] [-unsetCoordPrecision]

Other options:
               [--quiet] [-progress] [-if <format>]... [-oo <NAME>=<VALUE>]... [-doo <NAME>=<VALUE>]...
               [-fid <FID>] [-preserve_fid] [-unsetFid]
               [[-skipfailures]|[-gt <n>|unlimited]]
               [-limit <nb_features>] [-ds_transaction] [-mo <NAME>=<VALUE>]... [-nomd]
```