### PR TITLE
doc: update the ogr2ogr default value for -gt in SQLite performance hints

### DIFF
--- a/doc/source/drivers/vector/sqlite.rst
+++ b/doc/source/drivers/vector/sqlite.rst
@@ -504,10 +504,8 @@ OGR_L_StartTransaction() / OGR_L_CommitTransaction()) in order to get
 optimal performance. By default, if no transaction is explicitly
 started, SQLite will autocommit on every statement, which will be slow.
 If using ogr2ogr, its default behavior is to COMMIT a transaction every
-20000 inserted rows. The **-gt** argument allows explicitly setting the
-number of rows for each transaction. Increasing to **-gt 65536** or more
-ensures optimal performance while populating some table containing many
-hundredth thousand or million rows.
+100000 inserted rows. The **-gt** argument allows explicitly setting the
+number of rows for each transaction.
 
 SQLite usually has a very minimal memory foot-print; just about 20MB of
 RAM are reserved to store the internal Page Cache [merely 2000 pages].


### PR DESCRIPTION
This pull request updates the stated default value of the `ogr2ogr -gt` argument in the "Performance hints" section for SQLite/Spatialite. It updates to the default value 100000 as given in the `ogr2ogr` doc at:
https://gdal.org/programs/ogr2ogr.html#cmdoption-ogr2ogr-gt.

It also removes the recommendation
>Increasing to -gt 65536 or more ensures optimal performance while populating some table containing many hundredth thousand or million rows.

Should there be a recommendation to increase potentially >100000 in some cases?
