### PR TITLE
[Backport 3.8] SWIG: Fix gdal.Warp segfault with dst=None

### DIFF
--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -3920,3 +3920,10 @@ def test_gdalwarp_lib_dict_arguments():
     )
 
     assert opt == ["-wo", "SKIP_NOSOURCE=YES", "-wo", "NUM_THREADS=2"]
+
+
+def test_gdalwarp_lib_no_crash_on_none_dst():
+
+    ds1 = gdal.Open("../gcore/data/byte.tif")
+    with pytest.raises(ValueError):
+        gdal.Warp(None, ds1)

--- a/swig/include/gdal.i
+++ b/swig/include/gdal.i
@@ -1280,6 +1280,8 @@ struct GDALWarpAppOptions {
 
 /* Note: we must use 2 distinct names due to different ownership of the result */
 
+
+%apply Pointer NONNULL { GDALDatasetShadow* dstDS };
 %inline %{
 
 int wrapper_GDALWarpDestDS( GDALDatasetShadow* dstDS,
@@ -1318,6 +1320,7 @@ int wrapper_GDALWarpDestDS( GDALDatasetShadow* dstDS,
     return bRet;
 }
 %}
+%clear GDALDatasetShadow* dstDS;
 
 #ifdef SWIGJAVA
 %rename (Warp) wrapper_GDALWarpDestName;


### PR DESCRIPTION
Backport of https://github.com/OSGeo/gdal/pull/9386