### PR TITLE
Generalize the use of GDALIsTransformer() 

### DIFF
--- a/alg/gdal_alg_priv.h
+++ b/alg/gdal_alg_priv.h
@@ -167,6 +167,13 @@ struct IntEqualityTest
 typedef GDALRasterPolygonEnumeratorT<std::int64_t, IntEqualityTest>
     GDALRasterPolygonEnumerator;
 
+constexpr const char *GDAL_APPROX_TRANSFORMER_CLASS_NAME =
+    "GDALApproxTransformer";
+constexpr const char *GDAL_GEN_IMG_TRANSFORMER_CLASS_NAME =
+    "GDALGenImgProjTransformer";
+
+bool GDALIsTransformer(void *hTransformerArg, const char *pszClassName);
+
 typedef void *(*GDALTransformDeserializeFunc)(CPLXMLNode *psTree);
 
 void CPL_DLL *GDALRegisterTransformDeserializer(


### PR DESCRIPTION
(added per c091eadda02fd2fcbe626eed7cc60f6925ac0fcb) to avoid potential problems on Windows
