### PR TITLE
Update gdal_calc.rst eliminating disastrous "version added"

### DIFF
--- a/doc/source/programs/gdal_calc.rst
+++ b/doc/source/programs/gdal_calc.rst
@@ -177,18 +177,18 @@ They are not available using the command prompt.
 
     Allows specifying a ColorTable object (with Palette Index interpretation) to be used for the output raster.
 
-Example
--------
+Examples
+--------
 
 Add two files together:
 
-.. code-block::
+.. code-block:: bash
 
     gdal_calc.py -A input1.tif -B input2.tif --outfile=result.tif --calc="A+B"
 
 Average of two layers:
 
-.. code-block::
+.. code-block:: bash
 
     gdal_calc.py -A input1.tif -B input2.tif --outfile=result.tif --calc="(A+B)/2"
 
@@ -197,60 +197,54 @@ Average of two layers:
    In the previous example, beware that if A and B inputs are of the same datatype, for example integers, you
    may need to force the conversion of one of the operands before the division operation.
 
-   .. code-block::
+   .. code-block:: bash
 
       gdal_calc.py -A input.tif -B input2.tif --outfile=result.tif --calc="(A.astype(numpy.float64) + B) / 2"
 
 Add three files together (two options with the same result):
 
-.. code-block::
+.. code-block:: bash
 
     gdal_calc.py -A input1.tif -B input2.tif -C input3.tif --outfile=result.tif --calc="A+B+C"
 
-.. versionadded:: 3.3
-
-.. code-block::
+.. code-block:: bash
 
     gdal_calc.py -A input1.tif -A input2.tif -A input3.tif --outfile=result.tif --calc="numpy.sum(A,axis=0)".
 
 Average of three layers (two options with the same result):
 
-.. code-block::
+.. code-block:: bash
 
     gdal_calc.py -A input1.tif -B input2.tif -C input3.tif --outfile=result.tif --calc="(A+B+C)/3"
 
-.. versionadded:: 3.3
-
-.. code-block::
+.. code-block:: bash
 
     gdal_calc.py -A input1.tif input2.tif input3.tif --outfile=result.tif --calc="numpy.average(a,axis=0)".
 
 Maximum of three layers  (two options with the same result):
 
-.. code-block::
+.. code-block:: bash
 
     gdal_calc.py -A input1.tif -B input2.tif -C input3.tif --outfile=result.tif --calc="numpy.max((A,B,C),axis=0)"
 
-.. versionadded:: 3.3
-
-.. code-block::
+.. code-block:: bash
 
     gdal_calc.py -A input1.tif input2.tif input3.tif --outfile=result.tif --calc="numpy.max(A,axis=0)"
 
 Set values of zero and below to null:
 
-.. code-block::
+.. code-block:: bash
 
     gdal_calc.py -A input.tif --outfile=result.tif --calc="A*(A>0)" --NoDataValue=0
 
 Using logical operator to keep a range of values from input:
 
-.. code-block::
+.. code-block:: bash
 
     gdal_calc.py -A input.tif --outfile=result.tif --calc="A*logical_and(A>100,A<150)"
 
 Work with multiple bands:
 
-.. code-block::
+.. code-block:: bash
 
     gdal_calc.py -A input.tif --A_band=1 -B input.tif --B_band=2 --outfile=result.tif --calc="(A+B)/2" --calc="B*logical_and(A>100,A<150)"


### PR DESCRIPTION
On the man page, and even on the HTML, these "Version added" renders to make what was intended as

Example 1

Example 2

Example 3

Example 4

look like

Old Example 1

New Example 1

Old Example 2

New Example 2

It is a 100% disaster!

I am sure "Version added" is usually great, except in this particular spot on this particular man page!!