### PR TITLE
Python bindings: Invalidate layer ref when Dataset closes

### DIFF
--- a/autotest/gcore/basic_test.py
+++ b/autotest/gcore/basic_test.py
@@ -876,6 +876,25 @@ def test_band_use_after_dataset_close_2():
         band.Checksum()
 
 
+def test_layer_use_after_dataset_close_1():
+    with gdal.OpenEx("../ogr/data/poly.shp") as ds:
+        lyr = ds.GetLayer(0)
+
+    # Make sure ds.__exit__() has invalidated "lyr" so we don't crash here
+    with pytest.raises(Exception):
+        lyr.GetFeatureCount()
+
+
+def test_layer_use_after_dataset_close_2():
+    ds = gdal.OpenEx("../ogr/data/poly.shp")
+    lyr = ds.GetLayerByName("poly")
+
+    del ds
+    # Make sure ds.__del__() has invalidated "lyr" so we don't crash here
+    with pytest.raises(Exception):
+        lyr.GetFeatureCount()
+
+
 def test_mask_band_use_after_dataset_close():
     with gdal.Open("data/byte.tif") as ds:
         m1 = ds.GetRasterBand(1).GetMaskBand()


### PR DESCRIPTION
## What does this PR do?

Prevents a crash when using a `Layer` after its parent `Dataset` closes. We already handle this for the `DataSource` - `Layer` relationship and the `Dataset` - `Band` relationship, but `Dataset` - `Layer` was missed.

## What are related issues/pull requests?

#7965

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed