### PR TITLE
CSLConstList/CPLStringList improvements

### DIFF
--- a/apps/commonutils.h
+++ b/apps/commonutils.h
@@ -93,8 +93,8 @@ CPL_C_END
 #include "cpl_string.h"
 #include <vector>
 
-std::vector<CPLString> CPL_DLL GetOutputDriversFor(const char *pszDestFilename,
-                                                   int nFlagRasterVector);
+std::vector<std::string> CPL_DLL
+GetOutputDriversFor(const char *pszDestFilename, int nFlagRasterVector);
 CPLString CPL_DLL GetOutputDriverForRaster(const char *pszDestFilename);
 void GDALRemoveBOM(GByte *pabyData);
 std::string GDALRemoveSQLComments(const std::string &osInput);

--- a/apps/gdal_contour.cpp
+++ b/apps/gdal_contour.cpp
@@ -320,7 +320,7 @@ MAIN_START(argc, argv)
     CPLString osFormat;
     if (pszFormat == nullptr)
     {
-        std::vector<CPLString> aoDrivers =
+        const auto aoDrivers =
             GetOutputDriversFor(pszDstFilename, GDAL_OF_VECTOR);
         if (aoDrivers.empty())
         {

--- a/apps/gdal_footprint_lib.cpp
+++ b/apps/gdal_footprint_lib.cpp
@@ -404,8 +404,7 @@ GetOutputLayerAndUpdateDstDS(const char *pszDest, GDALDatasetH &hDstDS,
         std::string osFormat(psOptions->osFormat);
         if (osFormat.empty())
         {
-            std::vector<CPLString> aoDrivers =
-                GetOutputDriversFor(pszDest, GDAL_OF_VECTOR);
+            const auto aoDrivers = GetOutputDriversFor(pszDest, GDAL_OF_VECTOR);
             if (aoDrivers.empty())
             {
                 CPLError(CE_Failure, CPLE_AppDefined,

--- a/apps/gdal_rasterize_lib.cpp
+++ b/apps/gdal_rasterize_lib.cpp
@@ -1067,14 +1067,12 @@ GDALRasterizeOptionsNew(char **papszArgv,
         {
             if (strchr(papszArgv[i + 1], ' '))
             {
-                char **papszTokens = CSLTokenizeString(papszArgv[i + 1]);
-                char **papszIter = papszTokens;
-                while (papszIter && *papszIter)
+                const CPLStringList aosTokens(
+                    CSLTokenizeString(papszArgv[i + 1]));
+                for (const char *pszToken : aosTokens)
                 {
-                    psOptions->anBandList.push_back(atoi(*papszIter));
-                    papszIter++;
+                    psOptions->anBandList.push_back(atoi(pszToken));
                 }
-                CSLDestroy(papszTokens);
                 i += 1;
             }
             else
@@ -1120,14 +1118,12 @@ GDALRasterizeOptionsNew(char **papszArgv,
         {
             if (strchr(papszArgv[i + 1], ' '))
             {
-                char **papszTokens = CSLTokenizeString(papszArgv[i + 1]);
-                char **papszIter = papszTokens;
-                while (papszIter && *papszIter)
+                const CPLStringList aosTokens(
+                    CSLTokenizeString(papszArgv[i + 1]));
+                for (const char *pszToken : aosTokens)
                 {
-                    psOptions->adfBurnValues.push_back(CPLAtof(*papszIter));
-                    papszIter++;
+                    psOptions->adfBurnValues.push_back(CPLAtof(pszToken));
                 }
-                CSLDestroy(papszTokens);
                 i += 1;
             }
             else
@@ -1179,14 +1175,12 @@ GDALRasterizeOptionsNew(char **papszArgv,
         {
             if (strchr(papszArgv[i + 1], ' '))
             {
-                char **papszTokens = CSLTokenizeString(papszArgv[i + 1]);
-                char **papszIter = papszTokens;
-                while (papszIter && *papszIter)
+                const CPLStringList aosTokens(
+                    CSLTokenizeString(papszArgv[i + 1]));
+                for (const char *pszToken : aosTokens)
                 {
-                    psOptions->adfInitVals.push_back(CPLAtof(*papszIter));
-                    papszIter++;
+                    psOptions->adfInitVals.push_back(CPLAtof(pszToken));
                 }
-                CSLDestroy(papszTokens);
                 i += 1;
             }
             else

--- a/apps/gdaltindex_lib.cpp
+++ b/apps/gdaltindex_lib.cpp
@@ -394,8 +394,7 @@ GDALDatasetH GDALTileIndex(const char *pszDest, int nSrcCount,
     {
         if (psOptions->osFormat.empty())
         {
-            std::vector<CPLString> aoDrivers =
-                GetOutputDriversFor(pszDest, GDAL_OF_VECTOR);
+            const auto aoDrivers = GetOutputDriversFor(pszDest, GDAL_OF_VECTOR);
             if (aoDrivers.empty())
             {
                 CPLError(CE_Failure, CPLE_AppDefined,

--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -3616,14 +3616,12 @@ static GDALDatasetH GDALWarpCreateOutput(
             GDALDataset::Open(pszFilename, GDAL_OF_RASTER, apszAllowedDrivers));
         if (poExistingOutputDS)
         {
-            char **papszFileList = poExistingOutputDS->GetFileList();
-            for (char **papszIter = papszFileList; papszIter && *papszIter;
-                 ++papszIter)
+            for (const char *pszFilenameInList :
+                 CPLStringList(poExistingOutputDS->GetFileList()))
             {
                 oSetExistingDestFiles.insert(
-                    CPLString(*papszIter).replaceAll('\\', '/'));
+                    CPLString(pszFilenameInList).replaceAll('\\', '/'));
             }
-            CSLDestroy(papszFileList);
         }
         CPLPopErrorHandler();
     }
@@ -3668,11 +3666,10 @@ static GDALDatasetH GDALWarpCreateOutput(
                 poSrcDS->GetDescription(), GDAL_OF_RASTER, apszAllowedDrivers));
             if (poSrcDSTmp)
             {
-                char **papszFileList = poSrcDSTmp->GetFileList();
-                for (char **papszIter = papszFileList; papszIter && *papszIter;
-                     ++papszIter)
+                for (const char *pszFilenameInList :
+                     CPLStringList(poSrcDSTmp->GetFileList()))
                 {
-                    CPLString osFilename(*papszIter);
+                    CPLString osFilename(pszFilenameInList);
                     osFilename.replaceAll('\\', '/');
                     if (oSetExistingDestFiles.find(osFilename) !=
                         oSetExistingDestFiles.end())
@@ -3680,7 +3677,6 @@ static GDALDatasetH GDALWarpCreateOutput(
                         oSetExistingDestFilesFoundInSource.insert(osFilename);
                     }
                 }
-                CSLDestroy(papszFileList);
             }
         }
 

--- a/apps/ogrinfo_lib.cpp
+++ b/apps/ogrinfo_lib.cpp
@@ -713,17 +713,16 @@ static void GDALVectorInfoReportMetadata(CPLString &osRet, CPLJSONObject &oRoot,
     /* -------------------------------------------------------------------- */
     if (bListMDD)
     {
-        char **papszMDDList = GDALGetMetadataDomainList(hObject);
-        char **papszIter = papszMDDList;
+        const CPLStringList aosMDDList(GDALGetMetadataDomainList(hObject));
 
         CPLJSONArray metadataDomains;
 
-        if (papszMDDList != nullptr && !bJson)
+        if (!aosMDDList.empty() && !bJson)
             Concat(osRet, psOptions->bStdoutOutput, "%sMetadata domains:\n",
                    pszIndent);
-        while (papszIter != nullptr && *papszIter != nullptr)
+        for (const char *pszDomain : aosMDDList)
         {
-            if (EQUAL(*papszIter, ""))
+            if (EQUAL(pszDomain, ""))
             {
                 if (bJson)
                     metadataDomains.Add("");
@@ -734,14 +733,12 @@ static void GDALVectorInfoReportMetadata(CPLString &osRet, CPLJSONObject &oRoot,
             else
             {
                 if (bJson)
-                    metadataDomains.Add(*papszIter);
+                    metadataDomains.Add(pszDomain);
                 else
                     Concat(osRet, psOptions->bStdoutOutput, "%s  %s\n",
-                           pszIndent, *papszIter);
+                           pszIndent, pszDomain);
             }
-            papszIter++;
         }
-        CSLDestroy(papszMDDList);
 
         if (bJson)
             oRoot.Add("metadataDomains", metadataDomains);
@@ -763,43 +760,33 @@ static void GDALVectorInfoReportMetadata(CPLString &osRet, CPLJSONObject &oRoot,
     /* -------------------------------------------------------------------- */
     if (papszExtraMDDomains != nullptr)
     {
-        char **papszExtraMDDomainsExpanded = nullptr;
+        CPLStringList aosExtraMDDomainsExpanded;
 
         if (EQUAL(papszExtraMDDomains[0], "all") &&
             papszExtraMDDomains[1] == nullptr)
         {
-            char **papszMDDList = GDALGetMetadataDomainList(hObject);
-            char **papszIter = papszMDDList;
-
-            while (papszIter != nullptr && *papszIter != nullptr)
+            const CPLStringList aosMDDList(GDALGetMetadataDomainList(hObject));
+            for (const char *pszDomain : aosMDDList)
             {
-                if (!EQUAL(*papszIter, "") && !EQUAL(*papszIter, "SUBDATASETS"))
+                if (!EQUAL(pszDomain, "") && !EQUAL(pszDomain, "SUBDATASETS"))
                 {
-                    papszExtraMDDomainsExpanded =
-                        CSLAddString(papszExtraMDDomainsExpanded, *papszIter);
+                    aosExtraMDDomainsExpanded.AddString(pszDomain);
                 }
-                papszIter++;
             }
-            CSLDestroy(papszMDDList);
         }
         else
         {
-            papszExtraMDDomainsExpanded = CSLDuplicate(papszExtraMDDomains);
+            aosExtraMDDomainsExpanded = CSLDuplicate(papszExtraMDDomains);
         }
 
-        for (int iMDD = 0; papszExtraMDDomainsExpanded != nullptr &&
-                           papszExtraMDDomainsExpanded[iMDD] != nullptr;
-             iMDD++)
+        for (const char *pszDomain : aosExtraMDDomainsExpanded)
         {
-            char pszDisplayedname[256];
-            snprintf(pszDisplayedname, 256, "Metadata (%s)",
-                     papszExtraMDDomainsExpanded[iMDD]);
+            const std::string osDisplayedName =
+                std::string("Metadata (").append(pszDomain).append(")");
             GDALVectorInfoPrintMetadata(osRet, oMetadata, psOptions, hObject,
-                                        papszExtraMDDomainsExpanded[iMDD],
-                                        pszDisplayedname, pszIndent);
+                                        pszDomain, osDisplayedName.c_str(),
+                                        pszIndent);
         }
-
-        CSLDestroy(papszExtraMDDomainsExpanded);
     }
     GDALVectorInfoPrintMetadata(osRet, oMetadata, psOptions, hObject,
                                 "SUBDATASETS", "Subdatasets", pszIndent);
@@ -2139,15 +2126,14 @@ char *GDALVectorInfo(GDALDatasetH hDataset,
             /* --------------------------------------------------------------------
              */
 
-            for (CSLConstList papszIter = papszLayers; *papszIter != nullptr;
-                 ++papszIter)
+            for (const char *pszLayer : cpl::Iterate(papszLayers))
             {
-                OGRLayer *poLayer = poDS->GetLayerByName(*papszIter);
+                OGRLayer *poLayer = poDS->GetLayerByName(pszLayer);
 
                 if (poLayer == nullptr)
                 {
                     CPLError(CE_Failure, CPLE_AppDefined,
-                             "Couldn't fetch requested layer %s.", *papszIter);
+                             "Couldn't fetch requested layer %s.", pszLayer);
                     return nullptr;
                 }
 

--- a/apps/ogrtindex.cpp
+++ b/apps/ogrtindex.cpp
@@ -278,7 +278,7 @@ MAIN_START(nArgc, papszArgv)
         CPLString osFormat;
         if (pszFormat == nullptr)
         {
-            const std::vector<CPLString> aoDrivers =
+            const auto aoDrivers =
                 GetOutputDriversFor(pszOutputName, GDAL_OF_VECTOR);
             if (aoDrivers.empty())
             {

--- a/apps/sozip.cpp
+++ b/apps/sozip.cpp
@@ -562,22 +562,21 @@ MAIN_START(nArgc, papszArgv)
                                                pszZipFilename + "}/" +
                                                psEntry->pszName;
                 std::string osProperties;
-                char **papszMDGeneric =
-                    VSIGetFileMetadata(osFilename.c_str(), nullptr, nullptr);
-                for (char **papszIter = papszMDGeneric;
-                     papszIter && papszIter[0]; ++papszIter)
+                const CPLStringList aosMDGeneric(
+                    VSIGetFileMetadata(osFilename.c_str(), nullptr, nullptr));
+                for (const char *pszMDGeneric : aosMDGeneric)
                 {
                     if (!osProperties.empty())
                         osProperties += ',';
-                    osProperties += *papszIter;
+                    osProperties += pszMDGeneric;
                 }
-                CSLDestroy(papszMDGeneric);
-                char **papszMD =
-                    VSIGetFileMetadata(osFilename.c_str(), "ZIP", nullptr);
-                bool bSeekOptimized =
-                    CSLFetchNameValue(papszMD, "SOZIP_VALID") != nullptr;
+
+                const CPLStringList aosMD(
+                    VSIGetFileMetadata(osFilename.c_str(), "ZIP", nullptr));
+                const bool bSeekOptimized =
+                    aosMD.FetchNameValue("SOZIP_VALID") != nullptr;
                 const char *pszChunkSize =
-                    CSLFetchNameValue(papszMD, "SOZIP_CHUNK_SIZE");
+                    aosMD.FetchNameValue("SOZIP_CHUNK_SIZE");
                 printf("%11" CPL_FRMT_GB_WITHOUT_PREFIX
                        "u  %04d-%02d-%02d %02d:%02d:%02d  %s  %s               "
                        "%s\n",
@@ -589,7 +588,6 @@ MAIN_START(nArgc, papszArgv)
                            ? CPLSPrintf("   yes (%9s bytes)   ", pszChunkSize)
                            : "                           ",
                        psEntry->pszName, osProperties.c_str());
-                CSLDestroy(papszMD);
             }
         }
         VSICloseDir(psDir);

--- a/apps/test_ogrsf.cpp
+++ b/apps/test_ogrsf.cpp
@@ -4537,22 +4537,21 @@ static int TestVirtualIO(GDALDataset *poDS)
         return TRUE;
     }
 
-    char **papszFileList = LOG_ACTION(poDS->GetFileList());
-    char **papszIter = papszFileList;
+    const CPLStringList aosFileList(LOG_ACTION(poDS->GetFileList()));
     CPLString osPath;
     int bAllPathIdentical = TRUE;
-    for (; *papszIter != nullptr; papszIter++)
+    for (const char *pszFilename : aosFileList)
     {
-        if (papszIter == papszFileList)
-            osPath = CPLGetPath(*papszIter);
-        else if (strcmp(osPath, CPLGetPath(*papszIter)) != 0)
+        if (pszFilename == aosFileList[0])
+            osPath = CPLGetPath(pszFilename);
+        else if (strcmp(osPath, CPLGetPath(pszFilename)) != 0)
         {
             bAllPathIdentical = FALSE;
             break;
         }
     }
     CPLString osVirtPath;
-    if (bAllPathIdentical && CSLCount(papszFileList) > 1)
+    if (bAllPathIdentical && aosFileList.size() > 1)
     {
         osVirtPath =
             CPLFormFilename("/vsimem", CPLGetFilename(osPath), nullptr);
@@ -4560,14 +4559,14 @@ static int TestVirtualIO(GDALDataset *poDS)
     }
     else
         osVirtPath = "/vsimem";
-    papszIter = papszFileList;
-    for (; *papszIter != nullptr; papszIter++)
+
+    for (const char *pszFilename : aosFileList)
     {
         const char *pszDestFile =
-            CPLFormFilename(osVirtPath, CPLGetFilename(*papszIter), nullptr);
-        /* CPLDebug("test_ogrsf", "Copying %s to %s", *papszIter, pszDestFile);
+            CPLFormFilename(osVirtPath, CPLGetFilename(pszFilename), nullptr);
+        /* CPLDebug("test_ogrsf", "Copying %s to %s", pszFilename, pszDestFile);
          */
-        CPLCopyFile(pszDestFile, *papszIter);
+        CPLCopyFile(pszDestFile, pszFilename);
     }
 
     const char *pszVirtFile;
@@ -4611,13 +4610,11 @@ static int TestVirtualIO(GDALDataset *poDS)
         }
     }
 
-    papszIter = papszFileList;
-    for (; *papszIter != nullptr; papszIter++)
+    for (const char *pszFilename : aosFileList)
     {
         VSIUnlink(
-            CPLFormFilename(osVirtPath, CPLGetFilename(*papszIter), nullptr));
+            CPLFormFilename(osVirtPath, CPLGetFilename(pszFilename), nullptr));
     }
-    CSLDestroy(papszFileList);
 
     return bRet;
 }

--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -262,9 +262,9 @@ TEST_F(test_cpl, CSLTokenizeString2)
         CPLStringList aosStringList(
             CSLTokenizeString2("one two three", " ", 0));
         ASSERT_EQ(aosStringList.size(), 3);
-        ASSERT_TRUE(EQUAL(aosStringList[0], "one"));
-        ASSERT_TRUE(EQUAL(aosStringList[1], "two"));
-        ASSERT_TRUE(EQUAL(aosStringList[2], "three"));
+        EXPECT_STREQ(aosStringList[0], "one");
+        EXPECT_STREQ(aosStringList[1], "two");
+        EXPECT_STREQ(aosStringList[2], "three");
 
         // Test range-based for loop
         int i = 0;
@@ -290,48 +290,48 @@ TEST_F(test_cpl, CSLTokenizeString2)
         CPLStringList aosStringList(
             CSLTokenizeString2("one two, three;four,five; six", " ;,", 0));
         ASSERT_EQ(aosStringList.size(), 6);
-        ASSERT_TRUE(EQUAL(aosStringList[0], "one"));
-        ASSERT_TRUE(EQUAL(aosStringList[1], "two"));
-        ASSERT_TRUE(EQUAL(aosStringList[2], "three"));
-        ASSERT_TRUE(EQUAL(aosStringList[3], "four"));
-        ASSERT_TRUE(EQUAL(aosStringList[4], "five"));
-        ASSERT_TRUE(EQUAL(aosStringList[5], "six"));
+        EXPECT_STREQ(aosStringList[0], "one");
+        EXPECT_STREQ(aosStringList[1], "two");
+        EXPECT_STREQ(aosStringList[2], "three");
+        EXPECT_STREQ(aosStringList[3], "four");
+        EXPECT_STREQ(aosStringList[4], "five");
+        EXPECT_STREQ(aosStringList[5], "six");
     }
 
     {
         CPLStringList aosStringList(CSLTokenizeString2(
             "one two,,,five,six", " ,", CSLT_ALLOWEMPTYTOKENS));
         ASSERT_EQ(aosStringList.size(), 6);
-        ASSERT_TRUE(EQUAL(aosStringList[0], "one"));
-        ASSERT_TRUE(EQUAL(aosStringList[1], "two"));
-        ASSERT_TRUE(EQUAL(aosStringList[2], ""));
-        ASSERT_TRUE(EQUAL(aosStringList[3], ""));
-        ASSERT_TRUE(EQUAL(aosStringList[4], "five"));
-        ASSERT_TRUE(EQUAL(aosStringList[5], "six"));
+        EXPECT_STREQ(aosStringList[0], "one");
+        EXPECT_STREQ(aosStringList[1], "two");
+        EXPECT_STREQ(aosStringList[2], "");
+        EXPECT_STREQ(aosStringList[3], "");
+        EXPECT_STREQ(aosStringList[4], "five");
+        EXPECT_STREQ(aosStringList[5], "six");
     }
 
     {
         CPLStringList aosStringList(CSLTokenizeString2(
             "one two,\"three,four ,\",five,six", " ,", CSLT_HONOURSTRINGS));
         ASSERT_EQ(aosStringList.size(), 5);
-        ASSERT_TRUE(EQUAL(aosStringList[0], "one"));
-        ASSERT_TRUE(EQUAL(aosStringList[1], "two"));
-        ASSERT_TRUE(EQUAL(aosStringList[2], "three,four ,"));
-        ASSERT_TRUE(EQUAL(aosStringList[3], "five"));
-        ASSERT_TRUE(EQUAL(aosStringList[4], "six"));
+        EXPECT_STREQ(aosStringList[0], "one");
+        EXPECT_STREQ(aosStringList[1], "two");
+        EXPECT_STREQ(aosStringList[2], "three,four ,");
+        EXPECT_STREQ(aosStringList[3], "five");
+        EXPECT_STREQ(aosStringList[4], "six");
     }
 
     {
         CPLStringList aosStringList(CSLTokenizeString2(
             "one two,\"three,four ,\",five,six", " ,", CSLT_PRESERVEQUOTES));
         ASSERT_EQ(aosStringList.size(), 7);
-        ASSERT_TRUE(EQUAL(aosStringList[0], "one"));
-        ASSERT_TRUE(EQUAL(aosStringList[1], "two"));
-        ASSERT_TRUE(EQUAL(aosStringList[2], "\"three"));
-        ASSERT_TRUE(EQUAL(aosStringList[3], "four"));
-        ASSERT_TRUE(EQUAL(aosStringList[4], "\""));
-        ASSERT_TRUE(EQUAL(aosStringList[5], "five"));
-        ASSERT_TRUE(EQUAL(aosStringList[6], "six"));
+        EXPECT_STREQ(aosStringList[0], "one");
+        EXPECT_STREQ(aosStringList[1], "two");
+        EXPECT_STREQ(aosStringList[2], "\"three");
+        EXPECT_STREQ(aosStringList[3], "four");
+        EXPECT_STREQ(aosStringList[4], "\"");
+        EXPECT_STREQ(aosStringList[5], "five");
+        EXPECT_STREQ(aosStringList[6], "six");
     }
 
     {
@@ -339,11 +339,11 @@ TEST_F(test_cpl, CSLTokenizeString2)
             CSLTokenizeString2("one two,\"three,four ,\",five,six", " ,",
                                CSLT_HONOURSTRINGS | CSLT_PRESERVEQUOTES));
         ASSERT_EQ(aosStringList.size(), 5);
-        ASSERT_TRUE(EQUAL(aosStringList[0], "one"));
-        ASSERT_TRUE(EQUAL(aosStringList[1], "two"));
-        ASSERT_TRUE(EQUAL(aosStringList[2], "\"three,four ,\""));
-        ASSERT_TRUE(EQUAL(aosStringList[3], "five"));
-        ASSERT_TRUE(EQUAL(aosStringList[4], "six"));
+        EXPECT_STREQ(aosStringList[0], "one");
+        EXPECT_STREQ(aosStringList[1], "two");
+        EXPECT_STREQ(aosStringList[2], "\"three,four ,\"");
+        EXPECT_STREQ(aosStringList[3], "five");
+        EXPECT_STREQ(aosStringList[4], "six");
     }
 
     {
@@ -351,13 +351,13 @@ TEST_F(test_cpl, CSLTokenizeString2)
             CSLTokenizeString2("one \\two,\"three,\\four ,\",five,six", " ,",
                                CSLT_PRESERVEESCAPES));
         ASSERT_EQ(aosStringList.size(), 7);
-        ASSERT_TRUE(EQUAL(aosStringList[0], "one"));
-        ASSERT_TRUE(EQUAL(aosStringList[1], "\\two"));
-        ASSERT_TRUE(EQUAL(aosStringList[2], "\"three"));
-        ASSERT_TRUE(EQUAL(aosStringList[3], "\\four"));
-        ASSERT_TRUE(EQUAL(aosStringList[4], "\""));
-        ASSERT_TRUE(EQUAL(aosStringList[5], "five"));
-        ASSERT_TRUE(EQUAL(aosStringList[6], "six"));
+        EXPECT_STREQ(aosStringList[0], "one");
+        EXPECT_STREQ(aosStringList[1], "\\two");
+        EXPECT_STREQ(aosStringList[2], "\"three");
+        EXPECT_STREQ(aosStringList[3], "\\four");
+        EXPECT_STREQ(aosStringList[4], "\"");
+        EXPECT_STREQ(aosStringList[5], "five");
+        EXPECT_STREQ(aosStringList[6], "six");
     }
 
     {
@@ -365,46 +365,46 @@ TEST_F(test_cpl, CSLTokenizeString2)
             CSLTokenizeString2("one \\two,\"three,\\four ,\",five,six", " ,",
                                CSLT_PRESERVEQUOTES | CSLT_PRESERVEESCAPES));
         ASSERT_EQ(aosStringList.size(), 7);
-        ASSERT_TRUE(EQUAL(aosStringList[0], "one"));
-        ASSERT_TRUE(EQUAL(aosStringList[1], "\\two"));
-        ASSERT_TRUE(EQUAL(aosStringList[2], "\"three"));
-        ASSERT_TRUE(EQUAL(aosStringList[3], "\\four"));
-        ASSERT_TRUE(EQUAL(aosStringList[4], "\""));
-        ASSERT_TRUE(EQUAL(aosStringList[5], "five"));
-        ASSERT_TRUE(EQUAL(aosStringList[6], "six"));
+        EXPECT_STREQ(aosStringList[0], "one");
+        EXPECT_STREQ(aosStringList[1], "\\two");
+        EXPECT_STREQ(aosStringList[2], "\"three");
+        EXPECT_STREQ(aosStringList[3], "\\four");
+        EXPECT_STREQ(aosStringList[4], "\"");
+        EXPECT_STREQ(aosStringList[5], "five");
+        EXPECT_STREQ(aosStringList[6], "six");
     }
 
     {
         CPLStringList aosStringList(
             CSLTokenizeString2("one ,two, three, four ,five  ", ",", 0));
         ASSERT_EQ(aosStringList.size(), 5);
-        ASSERT_TRUE(EQUAL(aosStringList[0], "one "));
-        ASSERT_TRUE(EQUAL(aosStringList[1], "two"));
-        ASSERT_TRUE(EQUAL(aosStringList[2], " three"));
-        ASSERT_TRUE(EQUAL(aosStringList[3], " four "));
-        ASSERT_TRUE(EQUAL(aosStringList[4], "five  "));
+        EXPECT_STREQ(aosStringList[0], "one ");
+        EXPECT_STREQ(aosStringList[1], "two");
+        EXPECT_STREQ(aosStringList[2], " three");
+        EXPECT_STREQ(aosStringList[3], " four ");
+        EXPECT_STREQ(aosStringList[4], "five  ");
     }
 
     {
         CPLStringList aosStringList(CSLTokenizeString2(
             "one ,two, three, four ,five  ", ",", CSLT_STRIPLEADSPACES));
         ASSERT_EQ(aosStringList.size(), 5);
-        ASSERT_TRUE(EQUAL(aosStringList[0], "one "));
-        ASSERT_TRUE(EQUAL(aosStringList[1], "two"));
-        ASSERT_TRUE(EQUAL(aosStringList[2], "three"));
-        ASSERT_TRUE(EQUAL(aosStringList[3], "four "));
-        ASSERT_TRUE(EQUAL(aosStringList[4], "five  "));
+        EXPECT_STREQ(aosStringList[0], "one ");
+        EXPECT_STREQ(aosStringList[1], "two");
+        EXPECT_STREQ(aosStringList[2], "three");
+        EXPECT_STREQ(aosStringList[3], "four ");
+        EXPECT_STREQ(aosStringList[4], "five  ");
     }
 
     {
         CPLStringList aosStringList(CSLTokenizeString2(
             "one ,two, three, four ,five  ", ",", CSLT_STRIPENDSPACES));
         ASSERT_EQ(aosStringList.size(), 5);
-        ASSERT_TRUE(EQUAL(aosStringList[0], "one"));
-        ASSERT_TRUE(EQUAL(aosStringList[1], "two"));
-        ASSERT_TRUE(EQUAL(aosStringList[2], " three"));
-        ASSERT_TRUE(EQUAL(aosStringList[3], " four"));
-        ASSERT_TRUE(EQUAL(aosStringList[4], "five"));
+        EXPECT_STREQ(aosStringList[0], "one");
+        EXPECT_STREQ(aosStringList[1], "two");
+        EXPECT_STREQ(aosStringList[2], " three");
+        EXPECT_STREQ(aosStringList[3], " four");
+        EXPECT_STREQ(aosStringList[4], "five");
     }
 
     {
@@ -412,11 +412,89 @@ TEST_F(test_cpl, CSLTokenizeString2)
             CSLTokenizeString2("one ,two, three, four ,five  ", ",",
                                CSLT_STRIPLEADSPACES | CSLT_STRIPENDSPACES));
         ASSERT_EQ(aosStringList.size(), 5);
-        ASSERT_TRUE(EQUAL(aosStringList[0], "one"));
-        ASSERT_TRUE(EQUAL(aosStringList[1], "two"));
-        ASSERT_TRUE(EQUAL(aosStringList[2], "three"));
-        ASSERT_TRUE(EQUAL(aosStringList[3], "four"));
-        ASSERT_TRUE(EQUAL(aosStringList[4], "five"));
+        EXPECT_STREQ(aosStringList[0], "one");
+        EXPECT_STREQ(aosStringList[1], "two");
+        EXPECT_STREQ(aosStringList[2], "three");
+        EXPECT_STREQ(aosStringList[3], "four");
+        EXPECT_STREQ(aosStringList[4], "five");
+    }
+
+    {
+        const std::vector<std::string> oVector{"a", "bc"};
+        // Test CPLStringList(const std::vector<std::string>&) constructor
+        const CPLStringList aosList(oVector);
+        ASSERT_EQ(aosList.size(), 2);
+        EXPECT_STREQ(aosList[0], "a");
+        EXPECT_STREQ(aosList[1], "bc");
+        EXPECT_EQ(aosList[2], nullptr);
+
+        // Test CPLStringList::operator std::vector<std::string>(void) const
+        const std::vector<std::string> oVector2(aosList);
+        EXPECT_EQ(oVector, oVector2);
+
+        EXPECT_EQ(oVector, cpl::ToVector(aosList.List()));
+    }
+
+    {
+        const CPLStringList aosList(std::vector<std::string>{});
+        EXPECT_EQ(aosList.List(), nullptr);
+    }
+
+    {
+        // Test CPLStringList(std::initializer_list<const char*>) constructor
+        const CPLStringList aosList{"a", "bc"};
+        ASSERT_EQ(aosList.size(), 2);
+        EXPECT_STREQ(aosList[0], "a");
+        EXPECT_STREQ(aosList[1], "bc");
+        EXPECT_EQ(aosList[2], nullptr);
+
+        // Test cpl::Iterate(CSLConstList)
+        CSLConstList papszList = aosList.List();
+        CPLStringList aosList2;
+        for (const char *pszStr : cpl::Iterate(papszList))
+        {
+            aosList2.AddString(pszStr);
+        }
+        ASSERT_EQ(aosList2.size(), 2);
+        EXPECT_STREQ(aosList2[0], "a");
+        EXPECT_STREQ(aosList2[1], "bc");
+        EXPECT_EQ(aosList2[2], nullptr);
+    }
+
+    {
+        // Test cpl::Iterate() on a null list
+        CSLConstList papszList = nullptr;
+        auto oIteratorWrapper = cpl::Iterate(papszList);
+        EXPECT_TRUE(oIteratorWrapper.begin() == oIteratorWrapper.end());
+    }
+
+    {
+        // Test cpl::IterateNameValue()
+        const CPLStringList aosList{"foo=bar", "illegal", "bar=baz"};
+        CSLConstList papszList = aosList.List();
+        std::map<std::string, std::string> oMap;
+        for (const auto &[name, value] : cpl::IterateNameValue(papszList))
+        {
+            oMap[name] = value;
+        }
+        ASSERT_EQ(oMap.size(), 2);
+        EXPECT_EQ(oMap["foo"], "bar");
+        EXPECT_EQ(oMap["bar"], "baz");
+    }
+
+    {
+        // Test cpl::IterateNameValue() on a list wth only invalid values
+        const CPLStringList aosList{"illegal"};
+        CSLConstList papszList = aosList.List();
+        auto oIteratorWrapper = cpl::IterateNameValue(papszList);
+        EXPECT_TRUE(oIteratorWrapper.begin() == oIteratorWrapper.end());
+    }
+
+    {
+        // Test cpl::IterateNameValue() on a null list
+        CSLConstList papszList = nullptr;
+        auto oIteratorWrapper = cpl::IterateNameValue(papszList);
+        EXPECT_TRUE(oIteratorWrapper.begin() == oIteratorWrapper.end());
     }
 }
 

--- a/frmts/gtiff/gtiffdataset_read.cpp
+++ b/frmts/gtiff/gtiffdataset_read.cpp
@@ -4421,7 +4421,7 @@ void GTiffDataset::ApplyPamInfo()
     /*      Copy any PAM metadata into our GeoTIFF context, and with        */
     /*      the PAM info overriding the GeoTIFF context.                    */
     /* -------------------------------------------------------------------- */
-    char **papszPamDomains = oMDMD.GetDomainList();
+    CSLConstList papszPamDomains = oMDMD.GetDomainList();
 
     for (int iDomain = 0;
          papszPamDomains && papszPamDomains[iDomain] != nullptr; ++iDomain)

--- a/frmts/gtiff/gtiffdataset_write.cpp
+++ b/frmts/gtiff/gtiffdataset_write.cpp
@@ -3712,7 +3712,7 @@ static void WriteMDMetadata(GDALMultiDomainMetadata *poMDMD, TIFF *hTIFF,
     /* ==================================================================== */
     /*      Process each domain.                                            */
     /* ==================================================================== */
-    char **papszDomainList = poMDMD->GetDomainList();
+    CSLConstList papszDomainList = poMDMD->GetDomainList();
     for (int iDomain = 0; papszDomainList && papszDomainList[iDomain];
          ++iDomain)
     {
@@ -4306,7 +4306,7 @@ void GTiffDataset::PushMetadataToPam()
         /*      Loop over the available domains. */
         /* --------------------------------------------------------------------
          */
-        char **papszDomainList = poSrcMDMD->GetDomainList();
+        CSLConstList papszDomainList = poSrcMDMD->GetDomainList();
         for (int iDomain = 0; papszDomainList && papszDomainList[iDomain];
              ++iDomain)
         {

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -99,29 +99,40 @@ class GDALRelationship;
 class CPL_DLL GDALMultiDomainMetadata
 {
   private:
-    char **papszDomainList;
-    CPLStringList **papoMetadataLists;
+    CPLStringList aosDomainList{};
+    struct Comparator
+    {
+        bool operator()(const char *a, const char *b) const
+        {
+            return STRCASECMP(a, b) < 0;
+        }
+    };
+    std::map<const char *, CPLStringList, Comparator> oMetadata{};
 
   public:
     GDALMultiDomainMetadata();
     ~GDALMultiDomainMetadata();
 
     int XMLInit(const CPLXMLNode *psMetadata, int bMerge);
-    CPLXMLNode *Serialize();
+    CPLXMLNode *Serialize() const;
 
-    char **GetDomainList()
+    CSLConstList GetDomainList() const
     {
-        return papszDomainList;
+        return aosDomainList.List();
     }
 
     char **GetMetadata(const char *pszDomain = "");
-    CPLErr SetMetadata(char **papszMetadata, const char *pszDomain = "");
+    CPLErr SetMetadata(CSLConstList papszMetadata, const char *pszDomain = "");
     const char *GetMetadataItem(const char *pszName,
                                 const char *pszDomain = "");
     CPLErr SetMetadataItem(const char *pszName, const char *pszValue,
                            const char *pszDomain = "");
 
     void Clear();
+    inline void clear()
+    {
+        Clear();
+    }
 
   private:
     CPL_DISALLOW_COPY_ASSIGN(GDALMultiDomainMetadata)

--- a/gcore/gdaldriver.cpp
+++ b/gcore/gdaldriver.cpp
@@ -575,11 +575,10 @@ GDALDataset *GDALDriver::DefaultCreateCopy(const char *pszFilename,
     if (poSrcGroup != nullptr && GetMetadataItem(GDAL_DCAP_MULTIDIM_RASTER))
     {
         CPLStringList aosDatasetCO;
-        for (CSLConstList papszIter = papszOptions; papszIter && *papszIter;
-             ++papszIter)
+        for (const char *pszOption : cpl::Iterate(papszOptions))
         {
-            if (!STARTS_WITH_CI(*papszIter, "ARRAY:"))
-                aosDatasetCO.AddString(*papszIter);
+            if (!STARTS_WITH_CI(pszOption, "ARRAY:"))
+                aosDatasetCO.AddString(pszOption);
         }
         auto poDstDS = std::unique_ptr<GDALDataset>(
             CreateMultiDimensional(pszFilename, nullptr, aosDatasetCO.List()));
@@ -932,13 +931,9 @@ void GDALDriver::DefaultCopyMetadata(GDALDataset *poSrcDS, GDALDataset *poDstDS,
         if ((!EQUAL(pszCopySrcMDD, "AUTO") && CPLTestBool(pszCopySrcMDD)) ||
             papszSrcMDD)
         {
-            char **papszDomainList = poSrcDS->GetMetadataDomainList();
-            constexpr const char *apszReservedDomains[] = {
-                "IMAGE_STRUCTURE", "DERIVED_SUBDATASETS"};
-            for (char **papszIter = papszDomainList; papszIter && *papszIter;
-                 ++papszIter)
+            for (const char *pszDomain :
+                 CPLStringList(poSrcDS->GetMetadataDomainList()))
             {
-                const char *pszDomain = *papszIter;
                 if (pszDomain[0] != 0 &&
                     (!papszSrcMDD ||
                      CSLFindString(papszSrcMDD, pszDomain) >= 0))
@@ -960,6 +955,8 @@ void GDALDriver::DefaultCopyMetadata(GDALDataset *poSrcDS, GDALDataset *poDstDS,
                         }
                         if (!papszSrcMDD)
                         {
+                            constexpr const char *const apszReservedDomains[] =
+                                {"IMAGE_STRUCTURE", "DERIVED_SUBDATASETS"};
                             for (const char *pszOtherDomain :
                                  apszReservedDomains)
                             {
@@ -978,7 +975,6 @@ void GDALDriver::DefaultCopyMetadata(GDALDataset *poSrcDS, GDALDataset *poDstDS,
                     }
                 }
             }
-            CSLDestroy(papszDomainList);
         }
     }
     CSLDestroy(papszSrcMDD);
@@ -1018,14 +1014,12 @@ CPLErr GDALDriver::QuietDeleteForCreateCopy(const char *pszFilename,
                     pszFilename, GDAL_OF_RASTER, apszAllowedDrivers));
             if (poExistingOutputDS)
             {
-                char **papszFileList = poExistingOutputDS->GetFileList();
-                for (char **papszIter = papszFileList; papszIter && *papszIter;
-                     ++papszIter)
+                for (const char *pszFileInList :
+                     CPLStringList(poExistingOutputDS->GetFileList()))
                 {
                     oSetExistingDestFiles.insert(
-                        CPLString(*papszIter).replaceAll('\\', '/'));
+                        CPLString(pszFileInList).replaceAll('\\', '/'));
                 }
-                CSLDestroy(papszFileList);
             }
             CPLPopErrorHandler();
         }
@@ -1053,11 +1047,10 @@ CPLErr GDALDriver::QuietDeleteForCreateCopy(const char *pszFilename,
                 poSrcDS->papszOpenOptions));
             if (poSrcDSTmp)
             {
-                char **papszFileList = poSrcDSTmp->GetFileList();
-                for (char **papszIter = papszFileList; papszIter && *papszIter;
-                     ++papszIter)
+                for (const char *pszFileInList :
+                     CPLStringList(poSrcDSTmp->GetFileList()))
                 {
-                    CPLString osFilename(*papszIter);
+                    CPLString osFilename(pszFileInList);
                     osFilename.replaceAll('\\', '/');
                     if (oSetExistingDestFiles.find(osFilename) !=
                         oSetExistingDestFiles.end())
@@ -1065,7 +1058,6 @@ CPLErr GDALDriver::QuietDeleteForCreateCopy(const char *pszFilename,
                         oSetExistingDestFilesFoundInSource.insert(osFilename);
                     }
                 }
-                CSLDestroy(papszFileList);
             }
             CPLPopErrorHandler();
         }
@@ -1323,11 +1315,10 @@ GDALDataset *GDALDriver::CreateCopy(const char *pszFilename,
         if (poSrcGroup != nullptr && GetMetadataItem(GDAL_DCAP_MULTIDIM_RASTER))
         {
             CPLStringList aosDatasetCO;
-            for (CSLConstList papszIter = papszOptions; papszIter && *papszIter;
-                 ++papszIter)
+            for (const char *pszOption : cpl::Iterate(papszOptions))
             {
-                if (!STARTS_WITH_CI(*papszIter, "ARRAY:"))
-                    aosDatasetCO.AddString(*papszIter);
+                if (!STARTS_WITH_CI(pszOption, "ARRAY:"))
+                    aosDatasetCO.AddString(pszOption);
             }
             GDALValidateCreationOptions(this, aosDatasetCO.List());
         }
@@ -1462,10 +1453,10 @@ bool GDALDriver::CanVectorTranslateFrom(
         ppapszFailureReasons ? ppapszFailureReasons : &papszFailureReasons);
     if (!ppapszFailureReasons)
     {
-        for (CSLConstList papszIter = papszFailureReasons;
-             papszIter && *papszIter; ++papszIter)
+        for (const char *pszReason :
+             cpl::Iterate(CSLConstList(papszFailureReasons)))
         {
-            CPLDebug("GDAL", "%s", *papszIter);
+            CPLDebug("GDAL", "%s", pszReason);
         }
         CSLDestroy(papszFailureReasons);
     }
@@ -1560,11 +1551,10 @@ CPLErr GDALDriver::QuietDelete(const char *pszName,
     if (papszAllowedDrivers)
     {
         GDALOpenInfo oOpenInfo(pszName, GDAL_OF_ALL);
-        for (CSLConstList papszIter = papszAllowedDrivers; *papszIter;
-             ++papszIter)
+        for (const char *pszDriverName : cpl::Iterate(papszAllowedDrivers))
         {
             GDALDriver *poTmpDriver =
-                GDALDriver::FromHandle(GDALGetDriverByName(*papszIter));
+                GDALDriver::FromHandle(GDALGetDriverByName(pszDriverName));
             if (poTmpDriver)
             {
                 const bool bIdentifyRes =
@@ -2118,14 +2108,13 @@ int CPL_STDCALL GDALValidateCreationOptions(GDALDriverH hDriver,
     osDriver.Printf("driver %s",
                     GDALDriver::FromHandle(hDriver)->GetDescription());
     bool bFoundOptionToRemove = false;
-    for (CSLConstList papszIter = papszCreationOptions; papszIter && *papszIter;
-         ++papszIter)
+    for (const char *pszCO : cpl::Iterate(papszCreationOptions))
     {
         for (const char *pszExcludedOptions :
              {"APPEND_SUBDATASET", "COPY_SRC_MDD", "SRC_MDD"})
         {
-            if (STARTS_WITH_CI(*papszIter, pszExcludedOptions) &&
-                (*papszIter)[strlen(pszExcludedOptions)] == '=')
+            if (STARTS_WITH_CI(pszCO, pszExcludedOptions) &&
+                pszCO[strlen(pszExcludedOptions)] == '=')
             {
                 bFoundOptionToRemove = true;
                 break;
@@ -2138,23 +2127,21 @@ int CPL_STDCALL GDALValidateCreationOptions(GDALDriverH hDriver,
     char **papszOptionsToFree = nullptr;
     if (bFoundOptionToRemove)
     {
-        for (CSLConstList papszIter = papszCreationOptions;
-             papszIter && *papszIter; ++papszIter)
+        for (const char *pszCO : cpl::Iterate(papszCreationOptions))
         {
             bool bMatch = false;
             for (const char *pszExcludedOptions :
                  {"APPEND_SUBDATASET", "COPY_SRC_MDD", "SRC_MDD"})
             {
-                if (STARTS_WITH_CI(*papszIter, pszExcludedOptions) &&
-                    (*papszIter)[strlen(pszExcludedOptions)] == '=')
+                if (STARTS_WITH_CI(pszCO, pszExcludedOptions) &&
+                    pszCO[strlen(pszExcludedOptions)] == '=')
                 {
                     bMatch = true;
                     break;
                 }
             }
             if (!bMatch)
-                papszOptionsToFree =
-                    CSLAddString(papszOptionsToFree, *papszIter);
+                papszOptionsToFree = CSLAddString(papszOptionsToFree, pszCO);
         }
         papszOptionsToValidate = papszOptionsToFree;
     }

--- a/gcore/gdalmultidim.cpp
+++ b/gcore/gdalmultidim.cpp
@@ -913,12 +913,11 @@ bool GDALGroup::CopyFrom(const std::shared_ptr<GDALGroup> &poDstRootGroup,
             CPLStringList aosArrayCO;
             bool bAutoScale = false;
             GDALDataType eAutoScaleType = GDT_UInt16;
-            for (CSLConstList papszIter = papszOptions; papszIter && *papszIter;
-                 ++papszIter)
+            for (const char *pszItem : cpl::Iterate(papszOptions))
             {
-                if (STARTS_WITH_CI(*papszIter, "ARRAY:"))
+                if (STARTS_WITH_CI(pszItem, "ARRAY:"))
                 {
-                    const char *pszOption = *papszIter + strlen("ARRAY:");
+                    const char *pszOption = pszItem + strlen("ARRAY:");
                     if (STARTS_WITH_CI(pszOption, "IF(DIM="))
                     {
                         const char *pszNext = strchr(pszOption, ':');

--- a/gcore/gdalmultidomainmetadata.cpp
+++ b/gcore/gdalmultidomainmetadata.cpp
@@ -44,20 +44,13 @@
 /*                      GDALMultiDomainMetadata()                       */
 /************************************************************************/
 
-GDALMultiDomainMetadata::GDALMultiDomainMetadata()
-    : papszDomainList(nullptr), papoMetadataLists(nullptr)
-{
-}
+GDALMultiDomainMetadata::GDALMultiDomainMetadata() = default;
 
 /************************************************************************/
 /*                      ~GDALMultiDomainMetadata()                      */
 /************************************************************************/
 
-GDALMultiDomainMetadata::~GDALMultiDomainMetadata()
-
-{
-    Clear();
-}
+GDALMultiDomainMetadata::~GDALMultiDomainMetadata() = default;
 
 /************************************************************************/
 /*                               Clear()                                */
@@ -66,16 +59,17 @@ GDALMultiDomainMetadata::~GDALMultiDomainMetadata()
 void GDALMultiDomainMetadata::Clear()
 
 {
-    const int nDomainCount = CSLCount(papszDomainList);
-    CSLDestroy(papszDomainList);
-    papszDomainList = nullptr;
+    aosDomainList.clear();
+    oMetadata.clear();
+}
 
-    for (int i = 0; i < nDomainCount; i++)
-    {
-        delete papoMetadataLists[i];
-    }
-    CPLFree(papoMetadataLists);
-    papoMetadataLists = nullptr;
+/************************************************************************/
+/*                           SanitizeDomain()                           */
+/************************************************************************/
+
+static inline const char *SanitizeDomain(const char *pszDomain)
+{
+    return pszDomain ? pszDomain : "";
 }
 
 /************************************************************************/
@@ -85,50 +79,40 @@ void GDALMultiDomainMetadata::Clear()
 char **GDALMultiDomainMetadata::GetMetadata(const char *pszDomain)
 
 {
-    if (pszDomain == nullptr)
-        pszDomain = "";
-
-    const int iDomain = CSLFindString(papszDomainList, pszDomain);
-
-    if (iDomain == -1)
+    const auto oIter = oMetadata.find(SanitizeDomain(pszDomain));
+    if (oIter == oMetadata.end())
         return nullptr;
-
-    return papoMetadataLists[iDomain]->List();
+    return oIter->second.List();
 }
 
 /************************************************************************/
 /*                            SetMetadata()                             */
 /************************************************************************/
 
-CPLErr GDALMultiDomainMetadata::SetMetadata(char **papszMetadata,
+CPLErr GDALMultiDomainMetadata::SetMetadata(CSLConstList papszMetadata,
                                             const char *pszDomain)
 
 {
-    if (pszDomain == nullptr)
-        pszDomain = "";
+    pszDomain = SanitizeDomain(pszDomain);
 
-    int iDomain = CSLFindString(papszDomainList, pszDomain);
-
-    if (iDomain == -1)
+    auto oIter = oMetadata.find(pszDomain);
+    if (oIter == oMetadata.end())
     {
-        papszDomainList = CSLAddString(papszDomainList, pszDomain);
-        const int nDomainCount = CSLCount(papszDomainList);
-
-        papoMetadataLists = static_cast<CPLStringList **>(
-            CPLRealloc(papoMetadataLists, sizeof(void *) * (nDomainCount + 1)));
-        papoMetadataLists[nDomainCount] = nullptr;
-        papoMetadataLists[nDomainCount - 1] = new CPLStringList();
-        iDomain = nDomainCount - 1;
+        aosDomainList.AddString(pszDomain);
+        oIter =
+            oMetadata.insert(std::pair(aosDomainList.back(), CPLStringList()))
+                .first;
     }
 
-    papoMetadataLists[iDomain]->Assign(CSLDuplicate(papszMetadata));
+    auto &oMDList = oIter->second;
+    oMDList = papszMetadata;
 
     // we want to mark name/value pair domains as being sorted for fast
     // access.
     if (!STARTS_WITH_CI(pszDomain, "xml:") &&
         !STARTS_WITH_CI(pszDomain, "json:") && !EQUAL(pszDomain, "SUBDATASETS"))
     {
-        papoMetadataLists[iDomain]->Sort();
+        oMDList.Sort();
     }
 
     return CE_None;
@@ -142,15 +126,10 @@ const char *GDALMultiDomainMetadata::GetMetadataItem(const char *pszName,
                                                      const char *pszDomain)
 
 {
-    if (pszDomain == nullptr)
-        pszDomain = "";
-
-    const int iDomain = CSLFindString(papszDomainList, pszDomain);
-
-    if (iDomain == -1)
+    const auto oIter = oMetadata.find(SanitizeDomain(pszDomain));
+    if (oIter == oMetadata.end())
         return nullptr;
-
-    return papoMetadataLists[iDomain]->FetchNameValue(pszName);
+    return oIter->second.FetchNameValue(pszName);
 }
 
 /************************************************************************/
@@ -162,24 +141,25 @@ CPLErr GDALMultiDomainMetadata::SetMetadataItem(const char *pszName,
                                                 const char *pszDomain)
 
 {
-    if (pszDomain == nullptr)
-        pszDomain = "";
+    pszDomain = SanitizeDomain(pszDomain);
 
     /* -------------------------------------------------------------------- */
     /*      Create the domain if it does not already exist.                 */
     /* -------------------------------------------------------------------- */
-    int iDomain = CSLFindString(papszDomainList, pszDomain);
 
-    if (iDomain == -1)
+    auto oIter = oMetadata.find(pszDomain);
+    if (oIter == oMetadata.end())
     {
-        SetMetadata(nullptr, pszDomain);
-        iDomain = CSLFindString(papszDomainList, pszDomain);
+        aosDomainList.AddString(pszDomain);
+        oIter =
+            oMetadata.insert(std::pair(aosDomainList.back(), CPLStringList()))
+                .first;
     }
 
     /* -------------------------------------------------------------------- */
     /*      Set the value in the domain list.                               */
     /* -------------------------------------------------------------------- */
-    papoMetadataLists[iDomain]->SetNameValue(pszName, pszValue);
+    oIter->second.SetNameValue(pszName, pszValue);
 
     return CE_None;
 }
@@ -213,10 +193,10 @@ int GDALMultiDomainMetadata::XMLInit(const CPLXMLNode *psTree, int /* bMerge */)
         if (GetMetadata(pszDomain) == nullptr)
             SetMetadata(nullptr, pszDomain);
 
-        const int iDomain = CSLFindString(papszDomainList, pszDomain);
-        CPLAssert(iDomain != -1);
+        auto oIter = oMetadata.find(pszDomain);
+        CPLAssert(oIter != oMetadata.end());
 
-        CPLStringList *poMDList = papoMetadataLists[iDomain];
+        auto &oMDList = oIter->second;
 
         /* --------------------------------------------------------------------
          */
@@ -232,8 +212,8 @@ int GDALMultiDomainMetadata::XMLInit(const CPLXMLNode *psTree, int /* bMerge */)
 
             char *pszDoc = CPLSerializeXMLTree(psSubDoc);
 
-            poMDList->Clear();
-            poMDList->AddStringDirectly(pszDoc);
+            oMDList.Clear();
+            oMDList.AddStringDirectly(pszDoc);
         }
 
         /* --------------------------------------------------------------------
@@ -249,8 +229,8 @@ int GDALMultiDomainMetadata::XMLInit(const CPLXMLNode *psTree, int /* bMerge */)
                 psSubDoc = psSubDoc->psNext;
             if (psSubDoc)
             {
-                poMDList->Clear();
-                poMDList->AddString(psSubDoc->pszValue);
+                oMDList.Clear();
+                oMDList.AddString(psSubDoc->pszValue);
             }
         }
 
@@ -275,42 +255,39 @@ int GDALMultiDomainMetadata::XMLInit(const CPLXMLNode *psTree, int /* bMerge */)
                 char *pszName = psMDI->psChild->psChild->pszValue;
                 char *pszValue = psMDI->psChild->psNext->pszValue;
                 if (pszName != nullptr && pszValue != nullptr)
-                    poMDList->SetNameValue(pszName, pszValue);
+                    oMDList.SetNameValue(pszName, pszValue);
             }
         }
     }
 
-    return CSLCount(papszDomainList) != 0;
+    return !aosDomainList.empty();
 }
 
 /************************************************************************/
 /*                             Serialize()                              */
 /************************************************************************/
 
-CPLXMLNode *GDALMultiDomainMetadata::Serialize()
+CPLXMLNode *GDALMultiDomainMetadata::Serialize() const
 
 {
     CPLXMLNode *psFirst = nullptr;
 
-    for (int iDomain = 0;
-         papszDomainList != nullptr && papszDomainList[iDomain] != nullptr;
-         iDomain++)
+    for (const auto &[pszDomainName, oList] : oMetadata)
     {
-        char **papszMD = papoMetadataLists[iDomain]->List();
+        CSLConstList papszMD = oList.List();
         // Do not serialize empty domains.
         if (papszMD == nullptr || papszMD[0] == nullptr)
             continue;
 
         CPLXMLNode *psMD = CPLCreateXMLNode(nullptr, CXT_Element, "Metadata");
 
-        if (strlen(papszDomainList[iDomain]) > 0)
+        if (strlen(pszDomainName) > 0)
             CPLCreateXMLNode(CPLCreateXMLNode(psMD, CXT_Attribute, "domain"),
-                             CXT_Text, papszDomainList[iDomain]);
+                             CXT_Text, pszDomainName);
 
         bool bFormatXMLOrJSon = false;
 
-        if (STARTS_WITH_CI(papszDomainList[iDomain], "xml:") &&
-            CSLCount(papszMD) == 1)
+        if (STARTS_WITH_CI(pszDomainName, "xml:") && CSLCount(papszMD) == 1)
         {
             CPLXMLNode *psValueAsXML = CPLParseXMLString(papszMD[0]);
             if (psValueAsXML != nullptr)
@@ -325,8 +302,7 @@ CPLXMLNode *GDALMultiDomainMetadata::Serialize()
             }
         }
 
-        if (STARTS_WITH_CI(papszDomainList[iDomain], "json:") &&
-            CSLCount(papszMD) == 1)
+        if (STARTS_WITH_CI(pszDomainName, "json:") && CSLCount(papszMD) == 1)
         {
             bFormatXMLOrJSon = true;
 

--- a/gcore/gdalpamdataset.cpp
+++ b/gcore/gdalpamdataset.cpp
@@ -1800,26 +1800,24 @@ void GDALPamDataset::ClearStatistics()
     {
         bool bChanged = false;
         GDALRasterBand *poBand = GetRasterBand(i);
-        char **papszOldMD = poBand->GetMetadata();
-        char **papszNewMD = nullptr;
-        for (char **papszIter = papszOldMD; papszIter && papszIter[0];
-             ++papszIter)
+        CPLStringList aosNewMD;
+        for (const char *pszStr :
+             cpl::Iterate(CSLConstList(poBand->GetMetadata())))
         {
-            if (STARTS_WITH_CI(*papszIter, "STATISTICS_"))
+            if (STARTS_WITH_CI(pszStr, "STATISTICS_"))
             {
                 MarkPamDirty();
                 bChanged = true;
             }
             else
             {
-                papszNewMD = CSLAddString(papszNewMD, *papszIter);
+                aosNewMD.AddString(pszStr);
             }
         }
         if (bChanged)
         {
-            poBand->SetMetadata(papszNewMD);
+            poBand->SetMetadata(aosNewMD.List());
         }
-        CSLDestroy(papszNewMD);
     }
 
     GDALDataset::ClearStatistics();

--- a/gcore/gdalrelationship.cpp
+++ b/gcore/gdalrelationship.cpp
@@ -242,12 +242,7 @@ char **GDALRelationshipGetLeftTableFields(GDALRelationshipH hRelationship)
 
     auto fields =
         GDALRelationship::FromHandle(hRelationship)->GetLeftTableFields();
-    CPLStringList res;
-    for (const auto &field : fields)
-    {
-        res.AddString(field.c_str());
-    }
-    return res.StealList();
+    return CPLStringList(fields).StealList();
 }
 
 /************************************************************************/
@@ -273,12 +268,7 @@ char **GDALRelationshipGetRightTableFields(GDALRelationshipH hRelationship)
 
     auto fields =
         GDALRelationship::FromHandle(hRelationship)->GetRightTableFields();
-    CPLStringList res;
-    for (const auto &field : fields)
-    {
-        res.AddString(field.c_str());
-    }
-    return res.StealList();
+    return CPLStringList(fields).StealList();
 }
 
 /************************************************************************/
@@ -302,15 +292,8 @@ char **GDALRelationshipGetRightTableFields(GDALRelationshipH hRelationship)
 void GDALRelationshipSetLeftTableFields(GDALRelationshipH hRelationship,
                                         CSLConstList papszFields)
 {
-    std::vector<std::string> aosFields;
-    if (papszFields)
-    {
-        for (auto papszIter = papszFields; *papszIter; ++papszIter)
-        {
-            aosFields.emplace_back(*papszIter);
-        }
-    }
-    GDALRelationship::FromHandle(hRelationship)->SetLeftTableFields(aosFields);
+    GDALRelationship::FromHandle(hRelationship)
+        ->SetLeftTableFields(cpl::ToVector(papszFields));
 }
 
 /************************************************************************/
@@ -334,15 +317,8 @@ void GDALRelationshipSetLeftTableFields(GDALRelationshipH hRelationship,
 void GDALRelationshipSetRightTableFields(GDALRelationshipH hRelationship,
                                          CSLConstList papszFields)
 {
-    std::vector<std::string> aosFields;
-    if (papszFields)
-    {
-        for (auto papszIter = papszFields; *papszIter; ++papszIter)
-        {
-            aosFields.emplace_back(*papszIter);
-        }
-    }
-    GDALRelationship::FromHandle(hRelationship)->SetRightTableFields(aosFields);
+    GDALRelationship::FromHandle(hRelationship)
+        ->SetRightTableFields(cpl::ToVector(papszFields));
 }
 
 /************************************************************************/
@@ -369,12 +345,7 @@ GDALRelationshipGetLeftMappingTableFields(GDALRelationshipH hRelationship)
 
     auto fields = GDALRelationship::FromHandle(hRelationship)
                       ->GetLeftMappingTableFields();
-    CPLStringList res;
-    for (const auto &field : fields)
-    {
-        res.AddString(field.c_str());
-    }
-    return res.StealList();
+    return CPLStringList(fields).StealList();
 }
 
 /************************************************************************/
@@ -401,12 +372,7 @@ GDALRelationshipGetRightMappingTableFields(GDALRelationshipH hRelationship)
 
     auto fields = GDALRelationship::FromHandle(hRelationship)
                       ->GetRightMappingTableFields();
-    CPLStringList res;
-    for (const auto &field : fields)
-    {
-        res.AddString(field.c_str());
-    }
-    return res.StealList();
+    return CPLStringList(fields).StealList();
 }
 
 /************************************************************************/
@@ -430,16 +396,8 @@ GDALRelationshipGetRightMappingTableFields(GDALRelationshipH hRelationship)
 void GDALRelationshipSetLeftMappingTableFields(GDALRelationshipH hRelationship,
                                                CSLConstList papszFields)
 {
-    std::vector<std::string> aosFields;
-    if (papszFields)
-    {
-        for (auto papszIter = papszFields; *papszIter; ++papszIter)
-        {
-            aosFields.emplace_back(*papszIter);
-        }
-    }
     GDALRelationship::FromHandle(hRelationship)
-        ->SetLeftMappingTableFields(aosFields);
+        ->SetLeftMappingTableFields(cpl::ToVector(papszFields));
 }
 
 /************************************************************************/
@@ -463,16 +421,8 @@ void GDALRelationshipSetLeftMappingTableFields(GDALRelationshipH hRelationship,
 void GDALRelationshipSetRightMappingTableFields(GDALRelationshipH hRelationship,
                                                 CSLConstList papszFields)
 {
-    std::vector<std::string> aosFields;
-    if (papszFields)
-    {
-        for (auto papszIter = papszFields; *papszIter; ++papszIter)
-        {
-            aosFields.emplace_back(*papszIter);
-        }
-    }
     GDALRelationship::FromHandle(hRelationship)
-        ->SetRightMappingTableFields(aosFields);
+        ->SetRightMappingTableFields(cpl::ToVector(papszFields));
 }
 
 /************************************************************************/

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -4228,8 +4228,8 @@ char **GDALGeoPackageDataset::GetMetadata(const char *pszDomain)
                 {
                     papszMetadata =
                         CSLMerge(papszMetadata, oLocalMDMD.GetMetadata());
-                    char **papszDomainList = oLocalMDMD.GetDomainList();
-                    char **papszIter = papszDomainList;
+                    CSLConstList papszDomainList = oLocalMDMD.GetDomainList();
+                    CSLConstList papszIter = papszDomainList;
                     while (papszIter && *papszIter)
                     {
                         if (EQUAL(*papszIter, "IMAGE_STRUCTURE"))
@@ -4780,8 +4780,8 @@ void GDALGeoPackageDataset::FlushMetadata()
     CPLXMLNode *psXMLNode = nullptr;
     {
         GDALMultiDomainMetadata oLocalMDMD;
-        char **papszDomainList = oMDMD.GetDomainList();
-        char **papszIter = papszDomainList;
+        CSLConstList papszDomainList = oMDMD.GetDomainList();
+        CSLConstList papszIter = papszDomainList;
         oLocalMDMD.SetMetadata(papszMDDup);
         while (papszIter && *papszIter)
         {

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -6037,8 +6037,8 @@ char **OGRGeoPackageTableLayer::GetMetadata(const char *pszDomain)
 
                 papszMetadata =
                     CSLMerge(papszMetadata, oLocalMDMD.GetMetadata());
-                char **papszDomainList = oLocalMDMD.GetDomainList();
-                char **papszIter = papszDomainList;
+                CSLConstList papszDomainList = oLocalMDMD.GetDomainList();
+                CSLConstList papszIter = papszDomainList;
                 while (papszIter && *papszIter)
                 {
                     if (!EQUAL(*papszIter, ""))

--- a/port/cpl_string.h
+++ b/port/cpl_string.h
@@ -288,6 +288,7 @@ extern "C++"
 {
 #ifndef DOXYGEN_SKIP
 #include <string>
+#include <vector>
 #endif
 
 // VC++ implicitly applies __declspec(dllexport) to template base classes
@@ -452,9 +453,13 @@ extern "C++"
         CPLStringList();
         explicit CPLStringList(char **papszList, int bTakeOwnership = TRUE);
         explicit CPLStringList(CSLConstList papszList);
+        explicit CPLStringList(const std::vector<std::string> &aosList);
+        explicit CPLStringList(std::initializer_list<const char *> oInitList);
         CPLStringList(const CPLStringList &oOther);
         CPLStringList(CPLStringList &&oOther);
         ~CPLStringList();
+
+        static const CPLStringList BoundToConstList(CSLConstList papszList);
 
         CPLStringList &Clear();
 
@@ -576,16 +581,25 @@ extern "C++"
         {
             return List();
         }
+
         /** Return lists */
         operator CSLConstList(void) const
         {
             return List();
         }
+
+        /** Return the list as a vector of strings */
+        operator std::vector<std::string>(void) const
+        {
+            return std::vector<std::string>{begin(), end()};
+        }
     };
 
 #ifdef GDAL_COMPILATION
 
+#include <iterator>  // For std::input_iterator_tag
 #include <memory>
+#include <utility>  // For std::pair
 
     /*! @cond Doxygen_Suppress */
     struct CPL_DLL CSLDestroyReleaser
@@ -613,6 +627,191 @@ extern "C++"
     /** Unique pointer type to use with functions returning a char* to release
      * with CPLFree */
     using CPLCharUniquePtr = std::unique_ptr<char, CPLFreeReleaser>;
+
+    namespace cpl
+    {
+
+    /*! @cond Doxygen_Suppress */
+    /** Iterator for a CSLConstList */
+    struct CPL_DLL CSLIterator
+    {
+        using iterator_category = std::input_iterator_tag;
+        using difference_type = std::ptrdiff_t;
+        using value_type = const char *;
+        using pointer = value_type *;
+        using reference = value_type &;
+
+        CSLConstList m_papszList = nullptr;
+        bool m_bAtEnd = false;
+
+        inline const char *operator*() const
+        {
+            return *m_papszList;
+        }
+        inline CSLIterator &operator++()
+        {
+            if (m_papszList)
+                ++m_papszList;
+            return *this;
+        }
+        bool operator==(const CSLIterator &other) const;
+        inline bool operator!=(const CSLIterator &other) const
+        {
+            return !(operator==(other));
+        }
+    };
+    /*! @endcond */
+
+    /** Wrapper for a CSLConstList that can be used with C++ iterators.
+     *
+     * @since GDAL 3.9
+     */
+    struct CPL_DLL CSLIteratorWrapper
+    {
+      public:
+        /** Constructor */
+        inline explicit CSLIteratorWrapper(CSLConstList papszList)
+            : m_papszList(papszList)
+        {
+        }
+
+        /** Get the begin of the list */
+        inline CSLIterator begin() const
+        {
+            return {m_papszList, false};
+        }
+
+        /** Get the end of the list */
+        inline CSLIterator end() const
+        {
+            return {m_papszList, true};
+        }
+
+      private:
+        CSLConstList m_papszList;
+    };
+
+    /** Wraps a CSLConstList in a structure that can be used with C++ iterators.
+     *
+     * @since GDAL 3.9
+     */
+    inline CSLIteratorWrapper Iterate(CSLConstList papszList)
+    {
+        return CSLIteratorWrapper{papszList};
+    }
+
+    /*! @cond Doxygen_Suppress */
+    inline CSLIteratorWrapper Iterate(const CPLStringList &aosList)
+    {
+        return Iterate(aosList.List());
+    }
+    /*! @endcond */
+
+    /*! @cond Doxygen_Suppress */
+    inline CSLIteratorWrapper Iterate(char **) = delete;
+    /*! @endcond */
+
+    /*! @cond Doxygen_Suppress */
+    /** Iterator for a CSLConstList as (name, value) pairs. */
+    struct CPL_DLL CSLNameValueIterator
+    {
+        using iterator_category = std::input_iterator_tag;
+        using difference_type = std::ptrdiff_t;
+        using value_type = std::pair<const char *, const char *>;
+        using pointer = value_type *;
+        using reference = value_type &;
+
+        CSLConstList m_papszList = nullptr;
+        std::string m_osKey{};
+
+        value_type operator*();
+        inline CSLNameValueIterator &operator++()
+        {
+            if (m_papszList)
+                ++m_papszList;
+            return *this;
+        }
+        inline bool operator==(const CSLNameValueIterator &other) const
+        {
+            return m_papszList == other.m_papszList;
+        }
+        inline bool operator!=(const CSLNameValueIterator &other) const
+        {
+            return !(operator==(other));
+        }
+    };
+    /*! @endcond */
+
+    /** Wrapper for a CSLConstList that can be used with C++ iterators
+     * to get (name, value) pairs.
+     *
+     * This can for example be used to do the following:
+     * for (const auto& [name, value]: cpl::IterateNameValue(papszList)) {}
+     *
+     * Note that a (name, value) pair returned by dereferencing an iterator
+     * is invalidated by the next iteration on the iterator.
+     *
+     * @since GDAL 3.9
+     */
+    struct CPL_DLL CSLNameValueIteratorWrapper
+    {
+      public:
+        /** Constructor */
+        inline explicit CSLNameValueIteratorWrapper(CSLConstList papszList)
+            : m_papszList(papszList)
+        {
+        }
+
+        /** Get the begin of the list */
+        inline CSLNameValueIterator begin() const
+        {
+            return {m_papszList};
+        }
+
+        /** Get the end of the list */
+        CSLNameValueIterator end() const;
+
+      private:
+        CSLConstList m_papszList;
+    };
+
+    /** Wraps a CSLConstList in a structure that can be used with C++ iterators
+     * to get (name, value) pairs.
+     *
+     * This can for example be used to do the following:
+     * for (const auto& [name, value]: cpl::IterateNameValue(papszList)) {}
+     *
+     * Note that a (name, value) pair returned by dereferencing an iterator
+     * is invalidated by the next iteration on the iterator.
+     *
+     * @since GDAL 3.9
+     */
+    inline CSLNameValueIteratorWrapper IterateNameValue(CSLConstList papszList)
+    {
+        return CSLNameValueIteratorWrapper{papszList};
+    }
+
+    /*! @cond Doxygen_Suppress */
+    inline CSLNameValueIteratorWrapper
+    IterateNameValue(const CPLStringList &aosList)
+    {
+        return IterateNameValue(aosList.List());
+    }
+    /*! @endcond */
+
+    /*! @cond Doxygen_Suppress */
+    inline CSLIteratorWrapper IterateNameValue(char **) = delete;
+    /*! @endcond */
+
+    /** Converts a CSLConstList to a std::vector<std::string> */
+    inline std::vector<std::string> ToVector(CSLConstList papszList)
+    {
+        return CPLStringList::BoundToConstList(papszList);
+    }
+
+    inline std::vector<std::string> ToVector(char **) = delete;
+
+    }  // namespace cpl
 
 #endif
 

--- a/port/cpl_string.h
+++ b/port/cpl_string.h
@@ -463,6 +463,12 @@ extern "C++"
 
         CPLStringList &Clear();
 
+        /** Clear the list */
+        inline void clear()
+        {
+            Clear();
+        }
+
         /** Return size of list */
         int size() const
         {
@@ -543,6 +549,18 @@ extern "C++"
         const char *operator[](const char *pszKey) const
         {
             return FetchNameValue(pszKey);
+        }
+
+        /** Return first element */
+        inline const char *front() const
+        {
+            return papszList[0];
+        }
+
+        /** Return last element */
+        inline const char *back() const
+        {
+            return papszList[size() - 1];
         }
 
         /** begin() implementation */

--- a/port/cplstringlist.cpp
+++ b/port/cplstringlist.cpp
@@ -89,6 +89,55 @@ CPLStringList::CPLStringList(CSLConstList papszListIn) : CPLStringList()
 /*                           CPLStringList()                            */
 /************************************************************************/
 
+/**
+ * CPLStringList constructor.
+ *
+ * The input list is copied.
+ *
+ * @param aosList input list.
+ *
+ * @since GDAL 3.9
+ */
+CPLStringList::CPLStringList(const std::vector<std::string> &aosList)
+{
+    if (!aosList.empty())
+    {
+        bOwnList = true;
+        papszList = static_cast<char **>(
+            VSI_CALLOC_VERBOSE(aosList.size() + 1, sizeof(char *)));
+        nCount = static_cast<int>(aosList.size());
+        for (int i = 0; i < nCount; ++i)
+        {
+            papszList[i] = VSI_STRDUP_VERBOSE(aosList[i].c_str());
+        }
+    }
+}
+
+/************************************************************************/
+/*                           CPLStringList()                            */
+/************************************************************************/
+
+/**
+ * CPLStringList constructor.
+ *
+ * The input list is copied.
+ *
+ * @param oInitList input list.
+ *
+ * @since GDAL 3.9
+ */
+CPLStringList::CPLStringList(std::initializer_list<const char *> oInitList)
+{
+    for (const char *pszStr : oInitList)
+    {
+        AddString(pszStr);
+    }
+}
+
+/************************************************************************/
+/*                           CPLStringList()                            */
+/************************************************************************/
+
 //! Copy constructor
 CPLStringList::CPLStringList(const CPLStringList &oOther) : CPLStringList()
 
@@ -105,6 +154,27 @@ CPLStringList::CPLStringList(CPLStringList &&oOther) : CPLStringList()
 
 {
     operator=(std::move(oOther));
+}
+
+/************************************************************************/
+/*                           BoundToConstList()                         */
+/************************************************************************/
+
+/**
+ * Return a CPLStringList that wraps the passed list.
+ *
+ * The input list is *NOT* copied and must be kept alive while the
+ * return CPLStringList is used.
+ *
+ * @param papszListIn a NULL terminated list of strings to wrap into the CPLStringList
+ * @since GDAL 3.9
+ */
+
+/* static */
+const CPLStringList CPLStringList::BoundToConstList(CSLConstList papszListIn)
+{
+    return CPLStringList(const_cast<char **>(papszListIn),
+                         /* bTakeOwnership= */ false);
 }
 
 /************************************************************************/
@@ -919,3 +989,74 @@ int CPLStringList::FindSortedInsertionPoint(const char *pszLine)
 
     return iEnd;
 }
+
+namespace cpl
+{
+
+/************************************************************************/
+/*             CSLIterator::operator==(const CSLIterator &other)        */
+/************************************************************************/
+
+/*! @cond Doxygen_Suppress */
+bool CSLIterator::operator==(const CSLIterator &other) const
+{
+    if (!m_bAtEnd && other.m_bAtEnd)
+    {
+        return m_papszList == nullptr || *m_papszList == nullptr;
+    }
+    if (!m_bAtEnd && !other.m_bAtEnd)
+    {
+        return m_papszList == other.m_papszList;
+    }
+    if (m_bAtEnd && other.m_bAtEnd)
+    {
+        return true;
+    }
+    return false;
+}
+/*! @endcond */
+
+/************************************************************************/
+/*                      CSLNameValueIterator::operator*()               */
+/************************************************************************/
+
+/*! @cond Doxygen_Suppress */
+CSLNameValueIterator::value_type CSLNameValueIterator::operator*()
+{
+    if (m_papszList)
+    {
+        while (*m_papszList)
+        {
+            char *pszKey = nullptr;
+            const char *pszValue = CPLParseNameValue(*m_papszList, &pszKey);
+            if (pszKey)
+            {
+                m_osKey = pszKey;
+                CPLFree(pszKey);
+                return {m_osKey.c_str(), pszValue};
+            }
+            // Skip entries that are not name=value pairs.
+            ++m_papszList;
+        }
+    }
+    // Should not happen
+    CPLAssert(false);
+    return {"", ""};
+}
+/*! @endcond */
+
+/************************************************************************/
+/*                   CSLNameValueIteratorWrapper::end()                 */
+/************************************************************************/
+
+/*! @cond Doxygen_Suppress */
+CSLNameValueIterator CSLNameValueIteratorWrapper::end() const
+{
+    int nCount = CSLCount(m_papszList);
+    while (nCount > 0 && strchr(m_papszList[nCount - 1], '=') == nullptr)
+        --nCount;
+    return CSLNameValueIterator{m_papszList + nCount};
+}
+/*! @endcond */
+
+}  // namespace cpl


### PR DESCRIPTION
- CSLConstList/CPLStringList: add iterating facilities and better std::vector<std::string> operability

  * Add CPLStringList(const std::vector<std::string> &aosList) constructor
  * Add CPLStringList(std::initializer_list<const char *> oInitList) constructor
  * Add static CPLStringList BoundToConstList(CSLConstList) constructor-like
    (for cheap/non-copying instanciation of a CPLStringList from a CSLConstList)
  * Add CPLStringList::operator std::vector<std::string>(void)
  * Add cpl::Iterate(CSLConstList) which wraps a CSLConstList in a structure that
    can be used with C++ iterators.
  * Add cpl::IterateNameValue(CSLConstList) which wraps a CSLConstList in a
    structure that can be used with C++ iterators to get (name, value) pairs.
    like in ``for (const auto& [name, value]: cpl::IterateNameValue(papszList)) {}``
  * Add std::vector<std::string> cpl::ToVector(CSLConstList)

- gcore: use new CSLConstList/CPLStringList facilities

- apps: use new CSLConstList/CPLStringList facilities
