### PR TITLE
GTIFF: fix ambiguous wording for 64b predictor=2

### DIFF
--- a/frmts/gtiff/gtiffdataset_write.cpp
+++ b/frmts/gtiff/gtiffdataset_write.cpp
@@ -5130,10 +5130,9 @@ TIFF *GTiffDataset::CreateLL(const char *pszFilename, int nXSize, int nYSize,
 #if !defined(HAVE_PREDICTOR_2_FOR_64BIT)
                 if (l_nBitsPerSample == 64)
                 {
-                    ReportError(
-                        pszFilename, CE_Failure, CPLE_AppDefined,
-                        "PREDICTOR=2 is supported on 64 bit samples "
-                        "starting with libtiff > 4.3.0.");
+                    ReportError(pszFilename, CE_Failure, CPLE_AppDefined,
+                                "PREDICTOR=2 is supported on 64 bit samples "
+                                "starting with libtiff > 4.3.0.");
                 }
                 else
 #endif

--- a/frmts/gtiff/gtiffdataset_write.cpp
+++ b/frmts/gtiff/gtiffdataset_write.cpp
@@ -5132,7 +5132,7 @@ TIFF *GTiffDataset::CreateLL(const char *pszFilename, int nXSize, int nYSize,
                 {
                     ReportError(
                         pszFilename, CE_Failure, CPLE_AppDefined,
-                        "PREDICTOR=2 is only supported with 64 bit samples "
+                        "PREDICTOR=2 is supported on 64 bit samples "
                         "starting with libtiff > 4.3.0.");
                 }
                 else


### PR DESCRIPTION
Previous wording could be read as "starting from libtiff >4.3.0, predictor is only supported with 64bit samples". 
