### PR TITLE
ogr2ogr/Parquet: add hack to avoid super lengthy processing when using -limit with a Parquet dataset source (workarounds/fixes #9497)

### DIFF
--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -5658,7 +5658,8 @@ bool LayerTranslator::TranslateArrow(
         }
 
         // Limit number of features in batch if needed
-        if (psOptions->nLimit >= 0 && nCount + array.length > psOptions->nLimit)
+        if (psOptions->nLimit >= 0 &&
+            nCount + array.length >= psOptions->nLimit)
         {
             const auto nAdjustedLength = psOptions->nLimit - nCount;
             for (int i = 0; i < array.n_children; ++i)

--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -5708,6 +5708,47 @@ bool LayerTranslator::TranslateArrow(
     }
 
     schema.release(&schema);
+
+    // Ugly hack to work around https://github.com/OSGeo/gdal/issues/9497
+    // Deleting a RecordBatchReader obtained from arrow::dataset::Scanner.ToRecordBatchReader()
+    // is a lengthy operation since all batches are read in its destructors.
+    // Here we ask to our custom I/O layer to return in error to short circuit
+    // that lengthy operation.
+    if (auto poDS = psInfo->m_poSrcLayer->GetDataset())
+    {
+        if (poDS->GetLayerCount() == 1 && poDS->GetDriver() &&
+            EQUAL(poDS->GetDriver()->GetDescription(), "PARQUET"))
+        {
+            bool bStopIO = false;
+            const char *pszArrowStopIO =
+                CPLGetConfigOption("OGR_ARROW_STOP_IO", nullptr);
+            if (pszArrowStopIO && CPLTestBool(pszArrowStopIO))
+            {
+                bStopIO = true;
+            }
+            else if (!pszArrowStopIO)
+            {
+                std::string osExePath;
+                osExePath.resize(1024);
+                if (CPLGetExecPath(osExePath.data(),
+                                   static_cast<int>(osExePath.size())))
+                {
+                    osExePath.resize(strlen(osExePath.data()));
+                    if (strcmp(CPLGetBasename(osExePath.data()), "ogr2ogr") ==
+                        0)
+                    {
+                        bStopIO = true;
+                    }
+                }
+            }
+            if (bStopIO)
+            {
+                CPLSetConfigOption("OGR_ARROW_STOP_IO", "YES");
+                CPLDebug("OGR2OGR", "Forcing interruption of Parquet I/O");
+            }
+        }
+    }
+
     stream.release(&stream);
     return bRet;
 }

--- a/autotest/utilities/test_ogr2ogr.py
+++ b/autotest/utilities/test_ogr2ogr.py
@@ -2269,3 +2269,23 @@ def test_ogr2ogr_if_ko(ogr2ogr_path):
         ogr2ogr_path + " -if GeoJSON /vsimem/out.gpkg ../ogr/data/gpkg/2d_envelope.gpkg"
     )
     assert "Unable to open datasource" in err
+
+
+###############################################################################
+# Test https://github.com/OSGeo/gdal/issues/9497
+
+
+@pytest.mark.require_driver("GPKG")
+@pytest.mark.require_driver("Parquet")
+def test_ogr2ogr_parquet_dataset_limit(ogr2ogr_path, tmp_path):
+
+    if gdal.GetDriverByName("PARQUET").GetMetadataItem("ARROW_DATASET") is None:
+        pytest.skip("GDAL built without ARROW_DATASET support")
+
+    out_filename = str(tmp_path / "out.gpkg")
+    gdaltest.runexternal(
+        ogr2ogr_path + f" -limit 1 {out_filename} ../ogr/data/parquet/partitioned_hive"
+    )
+
+    ds = ogr.Open(out_filename)
+    assert ds.GetLayer(0).GetFeatureCount() == 1

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowrandomaccessfile.h
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowrandomaccessfile.h
@@ -104,6 +104,12 @@ class OGRArrowRandomAccessFile final : public arrow::io::RandomAccessFile
 
     arrow::Result<std::shared_ptr<arrow::Buffer>> Read(int64_t nbytes) override
     {
+        // CPLDebug("ARROW", "Reading %d bytes", int(nbytes));
+        // Ugly hack for https://github.com/OSGeo/gdal/issues/9497
+        if (CPLGetConfigOption("OGR_ARROW_STOP_IO", nullptr))
+        {
+            return arrow::Result<std::shared_ptr<arrow::Buffer>>();
+        }
         auto buffer = arrow::AllocateResizableBuffer(nbytes);
         if (!buffer.ok())
         {

--- a/ogr/ogrsf_frmts/parquet/ogr_parquet.h
+++ b/ogr/ogrsf_frmts/parquet/ogr_parquet.h
@@ -65,6 +65,8 @@ class OGRParquetLayerBase CPL_NON_FINAL : public OGRArrowLayer
 
   public:
     int TestCapability(const char *) override;
+
+    GDALDataset *GetDataset() override;
 };
 
 /************************************************************************/
@@ -152,7 +154,6 @@ class OGRParquetLayer final : public OGRParquetLayerBase
     char **GetMetadata(const char *pszDomain = "") override;
     OGRErr SetNextByIndex(GIntBig nIndex) override;
 
-    GDALDataset *GetDataset() override;
     bool GetArrowStream(struct ArrowArrayStream *out_stream,
                         CSLConstList papszOptions = nullptr) override;
 

--- a/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
@@ -65,7 +65,7 @@ OGRParquetLayerBase::OGRParquetLayerBase(OGRParquetDataset *poDS,
 /*                           GetDataset()                               */
 /************************************************************************/
 
-GDALDataset *OGRParquetLayer::GetDataset()
+GDALDataset *OGRParquetLayerBase::GetDataset()
 {
     return m_poDS;
 }


### PR DESCRIPTION
Fixes https://github.com/OSGeo/gdal/issues/9497