### PR TITLE
Implement basic Line-of-sight algorithm

### DIFF
--- a/alg/CMakeLists.txt
+++ b/alg/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(
   gdalwarpkernel.cpp
   gdalwarpoperation.cpp
   llrasterize.cpp
+  los.cpp
   polygonize.cpp
   polygonize_polygonizer_impl.cpp
   rasterfill.cpp

--- a/alg/gdal_alg.h
+++ b/alg/gdal_alg.h
@@ -356,8 +356,8 @@ GDALDatasetH CPL_DLL GDALViewshedGenerate(
     void *pProgressArg, GDALViewshedOutputType heightMode,
     CSLConstList papszExtraOptions);
 
-bool CPL_DLL GDALIsLineOfSightVisible(GDALRasterBandH, double xA, double yA, double zA, double xB, double yB, double zB, char** papszOptions);
-
+bool CPL_DLL GDALIsLineOfSightVisible(
+    const GDALRasterBandH, const double xA, const double yA, const double zA, const double xB, const double yB, const double zB, const char** papszOptions);
 
 /************************************************************************/
 /*      Rasterizer API - geometries burned into GDAL raster.            */

--- a/alg/gdal_alg.h
+++ b/alg/gdal_alg.h
@@ -356,6 +356,9 @@ GDALDatasetH CPL_DLL GDALViewshedGenerate(
     void *pProgressArg, GDALViewshedOutputType heightMode,
     CSLConstList papszExtraOptions);
 
+bool CPL_DLL GDALIsLineOfSightVisible(GDALRasterBandH, double xA, double yA, double zA, double xB, double yB, double zB, char** papszOptions);
+
+
 /************************************************************************/
 /*      Rasterizer API - geometries burned into GDAL raster.            */
 /************************************************************************/

--- a/alg/gdal_alg.h
+++ b/alg/gdal_alg.h
@@ -360,7 +360,7 @@ bool CPL_DLL GDALIsLineOfSightVisible(const GDALRasterBandH, const int xA,
                                       const int yA, const double zA,
                                       const int xB, const int yB,
                                       const double zB,
-                                      const char **papszOptions);
+                                      CSLConstList papszOptions);
 
 /************************************************************************/
 /*      Rasterizer API - geometries burned into GDAL raster.            */

--- a/alg/gdal_alg.h
+++ b/alg/gdal_alg.h
@@ -356,8 +356,11 @@ GDALDatasetH CPL_DLL GDALViewshedGenerate(
     void *pProgressArg, GDALViewshedOutputType heightMode,
     CSLConstList papszExtraOptions);
 
-bool CPL_DLL GDALIsLineOfSightVisible(
-    const GDALRasterBandH, const int xA, const int yA, const double zA, const int xB, const int yB, const double zB, const char** papszOptions);
+bool CPL_DLL GDALIsLineOfSightVisible(const GDALRasterBandH, const int xA,
+                                      const int yA, const double zA,
+                                      const int xB, const int yB,
+                                      const double zB,
+                                      const char **papszOptions);
 
 /************************************************************************/
 /*      Rasterizer API - geometries burned into GDAL raster.            */

--- a/alg/gdal_alg.h
+++ b/alg/gdal_alg.h
@@ -357,7 +357,7 @@ GDALDatasetH CPL_DLL GDALViewshedGenerate(
     CSLConstList papszExtraOptions);
 
 bool CPL_DLL GDALIsLineOfSightVisible(
-    const GDALRasterBandH, const double xA, const double yA, const double zA, const double xB, const double yB, const double zB, const char** papszOptions);
+    const GDALRasterBandH, const int xA, const int yA, const double zA, const int xB, const int yB, const double zB, const char** papszOptions);
 
 /************************************************************************/
 /*      Rasterizer API - geometries burned into GDAL raster.            */

--- a/alg/los.cpp
+++ b/alg/los.cpp
@@ -155,8 +155,10 @@ static bool IsAboveTerrain(const GDALRasterBandH hBand, const int x,
  * Check Line of Sight between two points.
  * Both input coordinates must be within the raster coordinate bounds.
  *
- * This algorithm will check line of sight using a 3D Bresenham algorithm.
+ * This algorithm will check line of sight using a Bresenham algorithm.
  * https://www.researchgate.net/publication/2411280_Efficient_Line-of-Sight_Algorithms_for_Real_Terrain_Data
+ * Line of sight is computed in raster coordinate space, and thus may not be appropriate.
+ * For example, datasets referenced against geographic coordinate at high latitudes may have issues.
  *
  * @param hBand The band to read the DEM data from. This must NOT be null.
  * 

--- a/alg/los.cpp
+++ b/alg/los.cpp
@@ -126,12 +126,14 @@ bool Bresenham2D(int x1, int y1, int x2, int y2, std::function< auto(int, int) -
 
 
 // Get the elevation of a single point.
+static
 bool GetElevation(const GDALRasterBandH hBand, const int x, const int y, double& val)
 {
     return GDALRasterIO(hBand, GF_Read, x, y, 1, 1, &val, 1, 1, GDT_Float64, 0, 0) == CE_None;
 }
 
 // Check a single location is above terrain.
+static
 bool IsAboveTerrain(const GDALRasterBandH hBand, const int x, const int y, const double z)
 {
     double terrainHeight;

--- a/alg/los.cpp
+++ b/alg/los.cpp
@@ -49,8 +49,9 @@
 // The callback is run at every point along the line,
 // which should return True if the point is above terrain.
 // Bresenham2D will return true if all points have LOS between the start and end.
-static bool Bresenham2D(int x1, int y1, int x2, int y2,
-                        std::function<auto(int, int)->bool> OnBresenhamPoint)
+static bool
+Bresenham2D(const int x1, const int y1, const int x2, const int y2,
+            std::function<auto(const int, const int)->bool> OnBresenhamPoint)
 {
     bool isAboveTerrain = true;
     int dx, dy;

--- a/alg/los.cpp
+++ b/alg/los.cpp
@@ -152,7 +152,7 @@ bool IsAboveTerrain(const GDALRasterBandH hBand, const int x, const int y, const
  * Check Line of Sight between two points.
  * Both input coordinates must be within the raster coordinate bounds.
  *
- * This algorithm will check line of sight using a 3D bresenham algorithm.
+ * This algorithm will check line of sight using a 3D Bresenham algorithm.
  * https://www.researchgate.net/publication/2411280_Efficient_Line-of-Sight_Algorithms_for_Real_Terrain_Data
  *
  * @param hBand The band to read the DEM data from.

--- a/alg/los.cpp
+++ b/alg/los.cpp
@@ -210,7 +210,7 @@ bool GDALIsLineOfSightVisible(const GDALRasterBandH hBand, const int xA,
     // Use an interpolated Z height with 2D bresenham for the remaining cases.
 
     // Lambda for computing the square of a number
-    auto SQUARE = [](const int n) -> int { return std::pow(n, 2); };
+    auto SQUARE = [](const double d) -> double { return d * d; };
 
     // Lambda for Linear interpolate like C++20 std::lerp.
     auto lerp = [](const double a, const double b, const double t)
@@ -219,8 +219,10 @@ bool GDALIsLineOfSightVisible(const GDALRasterBandH hBand, const int xA,
     // Lambda for getting Z test height given x-y input along the bresenham line.
     auto GetZValue = [&](const int x, const int y) -> double
     {
-        const auto rNum = SQUARE(x - xA) + SQUARE(y - yA);
-        const auto rDenom = SQUARE(xB - xA) + SQUARE(yB - yA);
+        const auto rNum = SQUARE(static_cast<double>(x - xA)) +
+                          SQUARE(static_cast<double>(y - yA));
+        const auto rDenom = SQUARE(static_cast<double>(xB - xA)) +
+                            SQUARE(static_cast<double>(yB - yA));
         /// @todo In order to reduce CPU cost and avoid a sqrt operation, consider
         /// the approach to just the ratio along x or y depending on whether
         /// the line is steep or shallow.

--- a/alg/los.cpp
+++ b/alg/los.cpp
@@ -86,7 +86,7 @@ bool Bresenham2D(int x1, int y1, int x2, int y2, std::function< auto(int, int) -
 	{
 		dy <<= 1;
 		balance = dy - dx;
-		dx <<= 1;
+		dx *= 2;
 
 		while (x != x2 && isAboveTerrain)
 		{
@@ -104,9 +104,9 @@ bool Bresenham2D(int x1, int y1, int x2, int y2, std::function< auto(int, int) -
 	}
 	else
 	{
-		dx <<= 1;
+		dx *= 2;
 		balance = dx - dy;
-		dy <<= 1;
+		dy *= 2;
 
 		while (y != y2  && isAboveTerrain)
 		{

--- a/alg/los.cpp
+++ b/alg/los.cpp
@@ -165,11 +165,9 @@ bool IsAboveTerrain(const GDALRasterBandH hBand, const int x, const int y, const
  */
 
 bool GDALIsLineOfSightVisible(
-    const GDALRasterBandH hBand, const int xA, const int yA, const double zA, const int xB, const int yB, const double zB, const char** papszOptions)
+    const GDALRasterBandH hBand, const int xA, const int yA, const double zA, const int xB, const int yB, const double zB, CPL_UNUSED CSLConstList papszOptions)
 {
-    if(hBand == nullptr) {
-        return false;
-    }
+    VALIDATE_POINTER1(hBand, "GDALIsLineOfSightVisible", false);
 
     // Perform a preliminary check of the start and end points.
     if (!IsAboveTerrain(hBand, xA, yA, zA)) {

--- a/alg/los.cpp
+++ b/alg/los.cpp
@@ -1,0 +1,94 @@
+/******************************************************************************
+ *
+ * Project:  Line of Sight
+ * Purpose:  Core algorithm implementation for line of sight algorithms.
+ * Author:   Ryan Friedman, ryanfriedman5410+gdal@gmail.com
+ *
+ ******************************************************************************
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+// Test instructions:
+// * cmake -S . -B build -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug
+// * cmake --build build --target gdal_unit_test -j `nproc`
+// * ./build/autotest/cpp/gdal_unit_test --gtest_filter="test_alg.GDALIsLineOfSightVisible*"
+// Or, with GDB
+// *  gdb ./build/autotest/cpp/gdal_unit_test
+// * >>> r --gtest_filter="test_alg.GDALIsLineOfSightVisible*"
+
+#include "cpl_port.h"
+#include "gdal_alg.h"
+
+
+/************************************************************************/
+/*                        GDALIsLineOfSightVisible()                    */
+/************************************************************************/
+
+/**
+ * Check Line of Sight between two points.
+ *
+ * This algorithm will check line of sight using a 3D bresenham algorithm.
+ * Sightlines" published at
+ * https://www.researchgate.net/publication/2411280_Efficient_Line-of-Sight_Algorithms_for_Real_Terrain_Data
+ *
+ *
+ * @param hBand The band to read the DEM data from.
+ *
+ * @return True if the two points are within Line of Sight.
+ *
+ * @since GDAL 3.X
+ */
+
+bool GDALIsLineOfSightVisible(
+    GDALRasterBandH hBand, double xA, double yA, double zA, double xB, double yB, double zB, char** papszOptions)
+{
+    if(hBand == nullptr) {
+        return false;
+    }
+
+
+    // Always process as a double regardless of the input type.
+    double val;
+    const int iXa = static_cast<int>(xA);
+    const int iYa = static_cast<int>(yA);
+
+    if(GDALRasterIO(hBand, GF_Read, iXa, iYa, 1, 1, &val, 1, 1, GDT_Float64, 0, 0) != CE_None) {
+        return false;
+    }
+    if (zA < val) {
+        return false;
+    }
+
+    const int iXb = static_cast<int>(xB);
+    const int iYb = static_cast<int>(yB);
+
+    if(GDALRasterIO(hBand, GF_Read, iXb, iYb, 1, 1, &val, 1, 1, GDT_Float64, 0, 0) != CE_None) {
+        return false;
+    }
+    if (zB < val) {
+        return false;
+    }
+
+
+    // Perform a preliminary check of the start and end points first to check they are in LOS.
+    // ASSERT_TRUE(hBand->RasterIO(GF_Write, 0, 0, 1, 1, &val, 1, 1, GDT_Byte, 1, nullptr, 0, 0, 0, nullptr) == CE_None);
+
+    return true;
+}

--- a/alg/los.cpp
+++ b/alg/los.cpp
@@ -221,6 +221,10 @@ bool GDALIsLineOfSightVisible(const GDALRasterBandH hBand, const int xA,
     {
         const auto rNum = SQUARE(x - xA) + SQUARE(y - yA);
         const auto rDenom = SQUARE(xB - xA) + SQUARE(yB - yA);
+        /// @todo In order to reduce CPU cost and avoid a sqrt operation, consider
+        /// the approach to just the ratio along x or y depending on whether
+        /// the line is steep or shallow.
+        /// See https://github.com/OSGeo/gdal/pull/9506#discussion_r1532459689.
         const double ratio =
             sqrt(static_cast<double>(rNum) / static_cast<double>(rDenom));
         return lerp(zA, zB, ratio);

--- a/alg/los.cpp
+++ b/alg/los.cpp
@@ -128,11 +128,6 @@ bool Bresenham2D(int x1, int y1, int x2, int y2, std::function< auto(int, int) -
 // Get the elevation of a single point.
 bool GetElevation(const GDALRasterBandH hBand, const int x, const int y, double& val)
 {
-    CPLAssert(x >= 0);
-    CPLAssert(x <= GDALGetRasterBandXSize(hBand));
-    CPLAssert(y >= 0);
-    CPLAssert(y <= GDALGetRasterBandYSize(hBand));
-
     return GDALRasterIO(hBand, GF_Read, x, y, 1, 1, &val, 1, 1, GDT_Float64, 0, 0) == CE_None;
 }
 

--- a/alg/los.cpp
+++ b/alg/los.cpp
@@ -210,15 +210,15 @@ bool GDALIsLineOfSightVisible(const GDALRasterBandH hBand, const int xA,
     // Use an interpolated Z height with 2D bresenham for the remaining cases.
 
     // Lambda for Linear interpolate like C++20 std::lerp.
-    auto lerp = [](const int a, const int b, const float t)
+    auto lerp = [](const double a, const double b, const double t)
     { return a + t * (b - a); };
 
     // Lambda for getting Z test height given x input along the bresenham line.
     auto GetZValue = [&](const int x) -> double
     {
         const auto xDiff = xB - xA;
-        const float xPercent = static_cast<float>(x) / xDiff;
-        return lerp(static_cast<int>(zA), static_cast<int>(zB), xPercent);
+        const double xPercent = static_cast<double>(x) / xDiff;
+        return lerp(zA, zB, xPercent);
     };
 
     // Lambda to get elevation at a bresenham-computed location.

--- a/alg/los.cpp
+++ b/alg/los.cpp
@@ -127,6 +127,7 @@ static bool Bresenham2D(int x1, int y1, int x2, int y2,
 static bool GetElevation(const GDALRasterBandH hBand, const int x, const int y,
                          double &val)
 {
+    /// @todo GDALCachedPixelAccessor may give increased performance.
     return GDALRasterIO(hBand, GF_Read, x, y, 1, 1, &val, 1, 1, GDT_Float64, 0,
                         0) == CE_None;
 }

--- a/alg/los.cpp
+++ b/alg/los.cpp
@@ -25,14 +25,6 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
-// Test instructions:
-// * cmake -S . -B build -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug
-// * cmake --build build --target gdal_unit_test -j `nproc`
-// * ./build/autotest/cpp/gdal_unit_test --gtest_filter="test_alg.GDALIsLineOfSightVisible*"
-// Or, with GDB
-// *  gdb ./build/autotest/cpp/gdal_unit_test
-// * >>> r --gtest_filter="test_alg.GDALIsLineOfSightVisible*"
-
 #include <functional>
 #include <cmath>
 

--- a/alg/los.cpp
+++ b/alg/los.cpp
@@ -50,6 +50,7 @@
 // The callback is run at every point along the line,
 // which should return True if the point is above terrain.
 // Bresenham2D will return true if all points have LOS between the start and end.
+static
 bool Bresenham2D(int x1, int y1, int x2, int y2, std::function< auto(int, int) -> bool> OnBresenhamPoint) {
     bool isAboveTerrain = true;
 	int	dx, dy;

--- a/alg/los.cpp
+++ b/alg/los.cpp
@@ -159,8 +159,20 @@ static bool IsAboveTerrain(const GDALRasterBandH hBand, const int x,
  *
  * @param hBand The band to read the DEM data from. This must NOT be null.
  * 
- * @param xA The X location (raster column) to check on the raster to read the DEM data from.
+ * @param xA The X location (raster column) of the first point to check on the raster.
  *
+ * @param yA The Y location (raster row) of the first point to check on the raster.
+ * 
+ * @param zA The Z location (height) of the first point to check.
+ * 
+ * @param xB The X location (raster column) of the second point to check on the raster.
+ *
+ * @param yB The Y location (raster row) of the second point to check on the raster.
+ * 
+ * @param zB The Z location (height) of the second point to check.
+ * 
+ * @param papszOptions Options for the line of sight algorithm (currently ignored).
+ * 
  * @return True if the two points are within Line of Sight.
  *
  * @since GDAL 3.9

--- a/alg/los.cpp
+++ b/alg/los.cpp
@@ -157,7 +157,7 @@ bool IsAboveTerrain(const GDALRasterBandH hBand, const int x, const int y, const
  *
  * @param hBand The band to read the DEM data from.
  * 
- * @param xA The X location to check on the raster to read the DEM data from.
+ * @param xA The X location (raster column) to check on the raster to read the DEM data from.
  *
  * @return True if the two points are within Line of Sight.
  *

--- a/alg/los.cpp
+++ b/alg/los.cpp
@@ -154,14 +154,6 @@ bool IsAboveTerrain(const GDALRasterBandH hBand, const int x, const int y, const
     }
 }
 
-bool IsAboveTerrain(const GDALRasterBandH hBand, const double x, const double y, const double z)
-{
-    const int iX = static_cast<int>(x);
-    const int iY = static_cast<int>(y);
-    return IsAboveTerrain(hBand, iX, iY, z);
-}
-
-
 /************************************************************************/
 /*                        GDALIsLineOfSightVisible()                    */
 /************************************************************************/
@@ -183,7 +175,7 @@ bool IsAboveTerrain(const GDALRasterBandH hBand, const double x, const double y,
  */
 
 bool GDALIsLineOfSightVisible(
-    const GDALRasterBandH hBand, const double xA, const double yA, const double zA, const double xB, const double yB, const double zB, const char** papszOptions)
+    const GDALRasterBandH hBand, const int xA, const int yA, const double zA, const int xB, const int yB, const double zB, const char** papszOptions)
 {
     if(hBand == nullptr) {
         return false;
@@ -198,13 +190,8 @@ bool GDALIsLineOfSightVisible(
         return false;
     }
 
-    const auto xAi = static_cast<int>(xA);
-    const auto yAi = static_cast<int>(yA);
-    const auto xBi = static_cast<int>(xB);
-    const auto yBi = static_cast<int>(yB);
-
     // If both X and Y are the same, no further checks are needed.
-    if(xAi == xBi && yAi == yBi) {
+    if(xA == xB && yA == yB) {
         return true;
     }
 
@@ -231,10 +218,7 @@ bool GDALIsLineOfSightVisible(
         return IsAboveTerrain(hBand, x, y, z);
     };
 
-    return Bresenham2D(
-        static_cast<int>(xA),
-        static_cast<int>(yA),
-        static_cast<int>(xB),
-        static_cast<int>(yB),
-        OnBresenhamPoint);
+    return Bresenham2D(xA, yA, xB, yB, OnBresenhamPoint);
 }
+
+

--- a/alg/los.cpp
+++ b/alg/los.cpp
@@ -217,7 +217,7 @@ bool GDALIsLineOfSightVisible(const GDALRasterBandH hBand, const int xA,
     auto GetZValue = [&](const int x) -> double
     {
         const auto xDiff = xB - xA;
-        const auto xPercent = x / xDiff;
+        const float xPercent = static_cast<float>(x) / xDiff;
         return lerp(static_cast<int>(zA), static_cast<int>(zB), xPercent);
     };
 

--- a/alg/los.cpp
+++ b/alg/los.cpp
@@ -161,7 +161,7 @@ bool IsAboveTerrain(const GDALRasterBandH hBand, const int x, const int y, const
  *
  * @return True if the two points are within Line of Sight.
  *
- * @since GDAL 3.X
+ * @since GDAL 3.9
  */
 
 bool GDALIsLineOfSightVisible(

--- a/autotest/cpp/test_alg.cpp
+++ b/autotest/cpp/test_alg.cpp
@@ -293,7 +293,7 @@ TEST_F(test_alg, GDALIsLineOfSightVisible_single_point_dataset)
             ->Create("", sizeX, sizeY, numBands, GDT_Int8, nullptr));
     ASSERT_TRUE(poDS != nullptr);
 
-    uint8_t val = 42;
+    int8_t val = 42;
     auto pBand = poDS->GetRasterBand(1);
     ASSERT_TRUE(pBand != nullptr);
     ASSERT_TRUE(poDS->RasterIO(GF_Write, 0, 0, 1, 1, &val, 1, 1, GDT_Int8, 1,

--- a/autotest/cpp/test_alg.cpp
+++ b/autotest/cpp/test_alg.cpp
@@ -316,10 +316,10 @@ TEST_F(test_alg, GDALIsLineOfSightVisible_default_square_dataset)
     auto pBand = poDS->GetRasterBand(1);
     ASSERT_TRUE(pBand != nullptr);
 
-    const double x1 = 1;
-    const double y1 = 1;
-    const double x2 = 2;
-    const double y2 = 2;
+    const int x1 = 1;
+    const int y1 = 1;
+    const int x2 = 2;
+    const int y2 = 2;
 
     // Both points are above terrain.
     EXPECT_TRUE(

--- a/autotest/cpp/test_alg.cpp
+++ b/autotest/cpp/test_alg.cpp
@@ -358,7 +358,10 @@ TEST_F(test_alg, GDALIsLineOfSightVisible_through_mountain)
                              "SRTM1/ap_srtm1.zip/ap_srtm1.vrt";
     const auto poDS = GDALDatasetUniquePtr(
         GDALDataset::FromHandle(GDALOpen(path.c_str(), GA_ReadOnly)));
-    ASSERT_TRUE(poDS != nullptr);
+    if (!poDS )
+    {
+        GTEST_SKIP() << "Cannot open << path;
+    }
 
     auto pBand = poDS->GetRasterBand(1);
     ASSERT_TRUE(pBand != nullptr);

--- a/autotest/cpp/test_alg.cpp
+++ b/autotest/cpp/test_alg.cpp
@@ -428,6 +428,14 @@ TEST_F(test_alg, GDALIsLineOfSightVisible_through_mountain)
     // Both heights are 1m above in the corners, but middle terrain violates LOS.
     EXPECT_FALSE(
         GDALIsLineOfSightVisible(pBand, 0, 120, 203, 120, 0, 247, nullptr));
+
+    // Vertical line test with hill between two points.
+    EXPECT_FALSE(
+        GDALIsLineOfSightVisible(pBand, 83, 111, 154, 83, 117, 198, nullptr));
+
+    // Horizonal line test with hill between two points.
+    EXPECT_FALSE(
+        GDALIsLineOfSightVisible(pBand, 75, 115, 192, 89, 115, 191, nullptr));
 }
 
 }  // namespace

--- a/autotest/cpp/test_alg.cpp
+++ b/autotest/cpp/test_alg.cpp
@@ -278,7 +278,7 @@ TEST_F(test_alg, GDALAutoCreateWarpedVRT_alpha_band)
 // Test GDALIsLineOfSightVisible() reject null dataset
 TEST_F(test_alg, GDALIsLineOfSightVisible_null_dataset)
 {
-    EXPECT_FALSE(GDALIsLineOfSightVisible(nullptr, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, nullptr));
+    EXPECT_FALSE(GDALIsLineOfSightVisible(nullptr, 0, 0, 0.0, 0, 0, 0.0, nullptr));
 }
 
 // Test GDALIsLineOfSightVisible() with single point dataset
@@ -296,11 +296,11 @@ TEST_F(test_alg, GDALIsLineOfSightVisible_single_point_dataset)
     ASSERT_TRUE(pBand != nullptr);
     ASSERT_TRUE(poDS->RasterIO(GF_Write, 0, 0, 1, 1, &val, 1, 1, GDT_Int8, 1, nullptr, 0, 0, 0, nullptr) == CE_None);
     // Both points below terrain
-    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, nullptr));
+    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 0, 0, 0.0, 0, 0, 0.0, nullptr));
     // One point below terrain
-    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 0.0, 0.0, 0.0, 0.0, 0.0, 43.0, nullptr));
+    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 0, 0, 0.0, 0, 0, 43.0, nullptr));
     // Both points above terrain
-    EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, 0.0, 0.0, 44.0, 0.0, 0.0, 43.0, nullptr));
+    EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, 0, 0, 44.0, 0, 0, 43.0, nullptr));
 }
 
 // Test GDALIsLineOfSightVisible() with 10x10 default dataset
@@ -316,10 +316,10 @@ TEST_F(test_alg, GDALIsLineOfSightVisible_default_square_dataset)
     auto pBand = poDS->GetRasterBand(1);
     ASSERT_TRUE(pBand != nullptr);
 
-    const double x1 = 1.0;
-    const double y1 = 1.0;
-    const double x2 = 2.0;
-    const double y2 = 2.0;
+    const double x1 = 1;
+    const double y1 = 1;
+    const double x2 = 2;
+    const double y2 = 2;
     
     // Both points are above terrain.
     EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, x1, y1, 1.0, x2, y2, 1.0, nullptr));

--- a/autotest/cpp/test_alg.cpp
+++ b/autotest/cpp/test_alg.cpp
@@ -278,7 +278,8 @@ TEST_F(test_alg, GDALAutoCreateWarpedVRT_alpha_band)
 // Test GDALIsLineOfSightVisible() reject null dataset
 TEST_F(test_alg, GDALIsLineOfSightVisible_null_dataset)
 {
-    EXPECT_FALSE(GDALIsLineOfSightVisible(nullptr, 0, 0, 0.0, 0, 0, 0.0, nullptr));
+    EXPECT_FALSE(
+        GDALIsLineOfSightVisible(nullptr, 0, 0, 0.0, 0, 0, 0.0, nullptr));
 }
 
 // Test GDALIsLineOfSightVisible() with single point dataset
@@ -287,20 +288,25 @@ TEST_F(test_alg, GDALIsLineOfSightVisible_single_point_dataset)
     auto const sizeX = 1;
     auto const sizeY = 1;
     auto const numBands = 1;
-    GDALDatasetUniquePtr poDS(GDALDriver::FromHandle(GDALGetDriverByName("MEM"))
-        ->Create("", sizeX, sizeY, numBands, GDT_Int8, nullptr));
+    GDALDatasetUniquePtr poDS(
+        GDALDriver::FromHandle(GDALGetDriverByName("MEM"))
+            ->Create("", sizeX, sizeY, numBands, GDT_Int8, nullptr));
     ASSERT_TRUE(poDS != nullptr);
 
     uint8_t val = 42;
     auto pBand = poDS->GetRasterBand(1);
     ASSERT_TRUE(pBand != nullptr);
-    ASSERT_TRUE(poDS->RasterIO(GF_Write, 0, 0, 1, 1, &val, 1, 1, GDT_Int8, 1, nullptr, 0, 0, 0, nullptr) == CE_None);
+    ASSERT_TRUE(poDS->RasterIO(GF_Write, 0, 0, 1, 1, &val, 1, 1, GDT_Int8, 1,
+                               nullptr, 0, 0, 0, nullptr) == CE_None);
     // Both points below terrain
-    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 0, 0, 0.0, 0, 0, 0.0, nullptr));
+    EXPECT_FALSE(
+        GDALIsLineOfSightVisible(pBand, 0, 0, 0.0, 0, 0, 0.0, nullptr));
     // One point below terrain
-    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 0, 0, 0.0, 0, 0, 43.0, nullptr));
+    EXPECT_FALSE(
+        GDALIsLineOfSightVisible(pBand, 0, 0, 0.0, 0, 0, 43.0, nullptr));
     // Both points above terrain
-    EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, 0, 0, 44.0, 0, 0, 43.0, nullptr));
+    EXPECT_TRUE(
+        GDALIsLineOfSightVisible(pBand, 0, 0, 44.0, 0, 0, 43.0, nullptr));
 }
 
 // Test GDALIsLineOfSightVisible() with 10x10 default dataset
@@ -309,8 +315,9 @@ TEST_F(test_alg, GDALIsLineOfSightVisible_default_square_dataset)
     auto const sizeX = 10;
     auto const sizeY = 10;
     auto const numBands = 1;
-    GDALDatasetUniquePtr poDS(GDALDriver::FromHandle(GDALGetDriverByName("MEM"))
-        ->Create("", sizeX, sizeY, numBands, GDT_Int8, nullptr));
+    GDALDatasetUniquePtr poDS(
+        GDALDriver::FromHandle(GDALGetDriverByName("MEM"))
+            ->Create("", sizeX, sizeY, numBands, GDT_Int8, nullptr));
     ASSERT_TRUE(poDS != nullptr);
 
     auto pBand = poDS->GetRasterBand(1);
@@ -320,29 +327,37 @@ TEST_F(test_alg, GDALIsLineOfSightVisible_default_square_dataset)
     const double y1 = 1;
     const double x2 = 2;
     const double y2 = 2;
-    
+
     // Both points are above terrain.
-    EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, x1, y1, 1.0, x2, y2, 1.0, nullptr));
+    EXPECT_TRUE(
+        GDALIsLineOfSightVisible(pBand, x1, y1, 1.0, x2, y2, 1.0, nullptr));
     // Flip the order, same result.
-    EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, x2, y2, 1.0, x1, y1, 1.0, nullptr));
+    EXPECT_TRUE(
+        GDALIsLineOfSightVisible(pBand, x2, y2, 1.0, x1, y1, 1.0, nullptr));
 
     // One point is below terrain.
-    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, x1, y1, -1.0, x2, y2, 1.0, nullptr));
+    EXPECT_FALSE(
+        GDALIsLineOfSightVisible(pBand, x1, y1, -1.0, x2, y2, 1.0, nullptr));
     // Flip the order, same result.
-    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, x2, y2, -1.0, x1, y1, 1.0, nullptr));
+    EXPECT_FALSE(
+        GDALIsLineOfSightVisible(pBand, x2, y2, -1.0, x1, y1, 1.0, nullptr));
 
     // Both points are below terrain.
-    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, x1, y1, -1.0, x2, y2, -1.0, nullptr));
+    EXPECT_FALSE(
+        GDALIsLineOfSightVisible(pBand, x1, y1, -1.0, x2, y2, -1.0, nullptr));
     // Flip the order, same result.
-    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, x2, y2, -1.0, x1, y1, -1.0, nullptr));
+    EXPECT_FALSE(
+        GDALIsLineOfSightVisible(pBand, x2, y2, -1.0, x1, y1, -1.0, nullptr));
 }
 
 // Test GDALIsLineOfSightVisible() through a mountain (not a unit test)
 TEST_F(test_alg, GDALIsLineOfSightVisible_through_mountain)
 {
     GDALAllRegister();
-    const std::string path = "/vsizip/vsicurl/https://terrain.ardupilot.org/SRTM1/ap_srtm1.zip/ap_srtm1.vrt";
-    const auto poDS = GDALDatasetUniquePtr(GDALDataset::FromHandle(GDALOpen(path.c_str(), GA_ReadOnly)));
+    const std::string path = "/vsizip/vsicurl/https://terrain.ardupilot.org/"
+                             "SRTM1/ap_srtm1.zip/ap_srtm1.vrt";
+    const auto poDS = GDALDatasetUniquePtr(
+        GDALDataset::FromHandle(GDALOpen(path.c_str(), GA_ReadOnly)));
     ASSERT_TRUE(poDS != nullptr);
 
     auto pBand = poDS->GetRasterBand(1);
@@ -350,7 +365,8 @@ TEST_F(test_alg, GDALIsLineOfSightVisible_through_mountain)
     std::array<double, 6> geoFwdTransform;
     ASSERT_TRUE(poDS->GetGeoTransform(geoFwdTransform.data()) == CE_None);
     std::array<double, 6> geoInvTransform;
-    ASSERT_TRUE(GDALInvGeoTransform(geoFwdTransform.data(), geoInvTransform.data()));
+    ASSERT_TRUE(
+        GDALInvGeoTransform(geoFwdTransform.data(), geoInvTransform.data()));
 
     // Check both sides of the continental divide in Colorado at Eisenhower tunnel.
     const double eisLatE = 39.679000;
@@ -359,16 +375,25 @@ TEST_F(test_alg, GDALIsLineOfSightVisible_through_mountain)
     const double eisLngW = -105.935403;
 
     double eisEx, eisEy, eisWx, eisWy;
-    GDALApplyGeoTransform(geoInvTransform.data(), eisLngE, eisLatE, &eisEx, &eisEy);
-    GDALApplyGeoTransform(geoInvTransform.data(), eisLngW, eisLatW, &eisWx, &eisWy);
-    
+    GDALApplyGeoTransform(geoInvTransform.data(), eisLngE, eisLatE, &eisEx,
+                          &eisEy);
+    GDALApplyGeoTransform(geoInvTransform.data(), eisLngW, eisLatW, &eisWx,
+                          &eisWy);
+    const int iEisEx = static_cast<int>(eisEx);
+    const int iEisEy = static_cast<int>(eisEy);
+    const int iEisWx = static_cast<int>(eisWx);
+    const int iEisWy = static_cast<int>(eisWy);
+
     // Both points are just above terrain, with terrain between.
-    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, eisEx, eisEy, 3380.0, eisWx, eisWy, 3450.0, nullptr));
+    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, iEisEx, iEisEy, 3380.0, iEisWx,
+                                          iEisWy, 3450.0, nullptr));
     // Flip the order, same result.
-    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, eisWx, eisWy, 3450.0, eisEx, eisEy, 3380.0, nullptr));
+    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, iEisWx, iEisWy, 3450.0, iEisEx,
+                                          iEisEy, 3380.0, nullptr));
 
     // Both points above terrain.
-    EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, eisEx, eisEy, 3900.0, eisWx, eisWy, 3900.0, nullptr));
+    EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, iEisEx, iEisEy, 3900.0, iEisWx,
+                                         iEisWy, 3900.0, nullptr));
 }
 
 }  // namespace

--- a/autotest/cpp/test_alg.cpp
+++ b/autotest/cpp/test_alg.cpp
@@ -275,13 +275,6 @@ TEST_F(test_alg, GDALAutoCreateWarpedVRT_alpha_band)
     GDALClose(hWarpedVRT);
 }
 
-// Test GDALIsLineOfSightVisible() reject null dataset
-TEST_F(test_alg, GDALIsLineOfSightVisible_null_dataset)
-{
-    EXPECT_FALSE(
-        GDALIsLineOfSightVisible(nullptr, 0, 0, 0.0, 0, 0, 0.0, nullptr));
-}
-
 // Test GDALIsLineOfSightVisible() with single point dataset
 TEST_F(test_alg, GDALIsLineOfSightVisible_single_point_dataset)
 {
@@ -358,9 +351,9 @@ TEST_F(test_alg, GDALIsLineOfSightVisible_through_mountain)
                              "SRTM1/ap_srtm1.zip/ap_srtm1.vrt";
     const auto poDS = GDALDatasetUniquePtr(
         GDALDataset::FromHandle(GDALOpen(path.c_str(), GA_ReadOnly)));
-    if (!poDS )
+    if (!poDS)
     {
-        GTEST_SKIP() << "Cannot open << path;
+        GTEST_SKIP() << "Cannot open " << path;
     }
 
     auto pBand = poDS->GetRasterBand(1);


### PR DESCRIPTION
## What does this PR do?

This implements a basic LOS check using 2D bresenham. Height is interpolated with a linear interpolation between points.
I would like preliminary feedback (see below). I used a 2D bresenham because the height values may be floating point. 

I think if the height values are known to be integer-type at compile time, I think some templating could be used to optimize it with the 3D bresenham algorithm. For now, I used linear interpolation because it should work with all cases, and convert the dataset's height to a double.

## Open Questions

1. Is there a way to unit test for asserts and only have the tests run if compiled in debug mode?
   *  Don't test for nullptr, mark it in the API as not-null
1. Are the asserts I added on the `int` limits of pixel coordinates correct?
   *  Yea, but the lower level library already checks those things
1. Is there a better function call structure for the bresenham algorithm taking in a callback? I was trying to use functional principles and keep the function pure.
    * This is fine, and is actually good for exposing the violation location
1. Are there any easy optimizations that can be made for LoS queries that line up directly with a row or column of raster data
   * Optimizations can come later
1. Is it inefficient to be calling RasterIO for single-pixel values like I did, or is there a better way? The reason I did single-pixel values is to avoid a large runtime heap allocation of data to service the LOS query. 
   * Yea, I added a TODO for other approachs
1. Is there a better local dataset I can use for testing LOS queries on than the publicly hosted one I used in `GDALIsLineOfSightVisible_through_mountain`?
   * Yea, autotest/cpp/data/n43.dt0
1. How should the uncertainty in the height values be handled? Ideally, for my use case, I can supply with which certainty I want the LOS algorithm, under the assumption that the error values follow a normal distribution. For example, I want the line of sight check to evaluate true if the line between points has  90% or higher certainty it is free from intersection with terrain. Right now, by assuming the dataset is exact, it means we're only 50% certain, which is not great odds for an aerial vehicle.
   * Ignore uncertainty for this PR, handle it later

## Limitations

This isn't the fastest way. Optimizations can come later, including GPU acceleration.

## What are related issues/pull requests?

#9050

## Test Data

The autotest folder has some nice DEM data that can be used directly instead of relying on the ArduPilot terrain server. 
```bash
gdaldem color-relief autotest/cpp/data/n43.dt0 n43_color.txt n43_color.tif
```
**n43_color.txt**
```
75 112 147 141
125 120 159 152
175 130 165 159
225 145 177 171
275 180 192 180
325 212 201 180
375 212 184 163
425 212 193 179
475 212 207 204
```

## Tasklist

 - [ ] Address open questions above
 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [x] Migrate from zipped/curl terrain from ArduPilot to file in the repo
 - [x] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Squash commits per subsystem
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Ubuntu 22.04
* Compiler: G++11

## Future extensions

Add a CLI tool to test LOS between two points. 

## Test instructions (mainly for myself)

```bash
 cmake -S . -B build -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug
cmake --build build --target gdal_unit_test -j `nproc`
./build/autotest/cpp/gdal_unit_test --gtest_filter="test_alg.GDALIsLineOfSightVisible*"
# Or, with GDB
 gdb ./build/autotest/cpp/gdal_unit_test
>>> r --gtest_filter="test_alg.GDALIsLineOfSightVisible*"
```
