### PR TITLE
Fix 9 typos: endianess → endianness

### DIFF
--- a/frmts/mrf/marfa.h
+++ b/frmts/mrf/marfa.h
@@ -186,7 +186,7 @@ struct ILSize
 std::ostream &operator<<(std::ostream &out, const ILSize &sz);
 std::ostream &operator<<(std::ostream &out, const ILIdx &t);
 
-bool is_Endianess_Dependent(GDALDataType dt, ILCompression comp);
+bool is_Endianness_Dependent(GDALDataType dt, ILCompression comp);
 
 // Debugging support
 // #define PPMW

--- a/frmts/mrf/marfa_dataset.cpp
+++ b/frmts/mrf/marfa_dataset.cpp
@@ -953,7 +953,7 @@ static CPLErr Init_Raster(ILImage &image, MRFDataset *ds, CPLXMLNode *defimage)
     }
 
     // Check the endianness if needed, assume host order
-    if (is_Endianess_Dependent(image.dt, image.comp))
+    if (is_Endianness_Dependent(image.dt, image.comp))
         image.nbo = on(CPLGetXMLValue(defimage, "NetByteOrder", "No"));
 
     CPLXMLNode *DataValues = CPLGetXMLNode(defimage, "DataValues");
@@ -1323,7 +1323,7 @@ CPLXMLNode *MRFDataset::BuildConfig()
         }
     }
 
-    if (is_Endianess_Dependent(full.dt, full.comp))  // Need to set the order
+    if (is_Endianness_Dependent(full.dt, full.comp))  // Need to set the order
         CPLCreateXMLElementAndValue(raster, "NetByteOrder",
                                     (full.nbo || NET_ORDER) ? "TRUE" : "FALSE");
 
@@ -1462,7 +1462,7 @@ CPLErr MRFDataset::Initialize(CPLXMLNode *config)
     SetMetadataItem("INTERLEAVE", OrderName(current.order), "IMAGE_STRUCTURE");
     SetMetadataItem("COMPRESSION", CompName(current.comp), "IMAGE_STRUCTURE");
 
-    if (is_Endianess_Dependent(current.dt, current.comp))
+    if (is_Endianness_Dependent(current.dt, current.comp))
         SetMetadataItem("NETBYTEORDER", current.nbo ? "TRUE" : "FALSE",
                         "IMAGE_STRUCTURE");
 

--- a/frmts/mrf/mrf_band.cpp
+++ b/frmts/mrf/mrf_band.cpp
@@ -1198,7 +1198,7 @@ CPLErr MRFRasterBand::IReadBlock(int xblk, int yblk, void *buffer)
         img.pageSizeBytes;  // In case the decompress failed, force it back
 
     // Swap whatever we decompressed if we need to
-    if (is_Endianess_Dependent(img.dt, img.comp) && (img.nbo != NET_ORDER))
+    if (is_Endianness_Dependent(img.dt, img.comp) && (img.nbo != NET_ORDER))
         swab_buff(dst, img);
 
     CPLFree(data);
@@ -1265,7 +1265,7 @@ CPLErr MRFRasterBand::IWriteBlock(int xblk, int yblk, void *buffer)
                        poMRFDS->GetPBufferSize()};
 
         // Swab the source before encoding if we need to
-        if (is_Endianess_Dependent(img.dt, img.comp) && (img.nbo != NET_ORDER))
+        if (is_Endianness_Dependent(img.dt, img.comp) && (img.nbo != NET_ORDER))
             swab_buff(src, img);
 
         auto start_time = steady_clock::now();

--- a/frmts/mrf/mrf_util.cpp
+++ b/frmts/mrf/mrf_util.cpp
@@ -339,7 +339,7 @@ GIntBig IdxOffset(const ILSize &pos, const ILImage &img)
 }
 
 // Is compression type endianness dependent?
-bool is_Endianess_Dependent(GDALDataType dt, ILCompression comp)
+bool is_Endianness_Dependent(GDALDataType dt, ILCompression comp)
 {
     // Add here all endianness dependent compressions
     if (IL_ZLIB == comp || IL_NONE == comp)

--- a/frmts/zlib/crc32.c
+++ b/frmts/zlib/crc32.c
@@ -772,8 +772,8 @@ unsigned long ZEXPORT crc32_z(crc, buf, len)
         words = (z_word_t const *)buf;
 
         /* Do endian check at execution time instead of compile time, since ARM
-           processors can change the endianess at execution time. If the
-           compiler knows what the endianess will be, it can optimize out the
+           processors can change the endianness at execution time. If the
+           compiler knows what the endianness will be, it can optimize out the
            check and the unused branch. */
         endian = 1;
         if (*(unsigned char *)&endian) {


### PR DESCRIPTION
Fix 9 typos endianess → endianness
