### PR TITLE
gdal2tiles: Fix case where --exclude still writes fully transparent tiles

### DIFF
--- a/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
@@ -1375,9 +1375,6 @@ def create_base_tile(tile_job_info: "TileJobInfo", tile_detail: "TileDetail") ->
             wysize,
             band_list=list(range(1, dataBandsCount + 1)),
         )
-    elif tile_job_info.exclude_transparent:
-        # If there are no pixels to copy, the tile will be fully transparent
-        return
 
     # The tile in memory is a transparent file by default. Write pixel values into it if
     # any
@@ -2803,6 +2800,13 @@ class GDAL2Tiles(object):
                         ry = ysize - (ty * tsize) - rysize
                         if wysize != self.tile_size:
                             wy = self.tile_size - wysize
+
+                if self.options.exclude_transparent and (
+                    rxsize == 0 or rysize == 0 or wxsize == 0 or wysize == 0
+                ):
+                    if self.options.verbose:
+                        logger.debug("\tExcluding tile with no pixel coverage")
+                    continue
 
                 # Read the source raster if anything is going inside the tile as per the computed
                 # geo_query

--- a/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
@@ -1375,6 +1375,9 @@ def create_base_tile(tile_job_info: "TileJobInfo", tile_detail: "TileDetail") ->
             wysize,
             band_list=list(range(1, dataBandsCount + 1)),
         )
+    elif tile_job_info.exclude_transparent:
+        # If there are no pixels to copy, the tile will be fully transparent
+        return
 
     # The tile in memory is a transparent file by default. Write pixel values into it if
     # any

--- a/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
@@ -2801,9 +2801,7 @@ class GDAL2Tiles(object):
                         if wysize != self.tile_size:
                             wy = self.tile_size - wysize
 
-                if self.options.exclude_transparent and (
-                    rxsize == 0 or rysize == 0 or wxsize == 0 or wysize == 0
-                ):
+                if rxsize == 0 or rysize == 0 or wxsize == 0 or wysize == 0:
                     if self.options.verbose:
                         logger.debug("\tExcluding tile with no pixel coverage")
                     continue


### PR DESCRIPTION
The alpha channel is only checked for a fully transparent tile when the source region is of nonzero size. When there are zero pixels to copy, the tile will also be transparent and should be skipped with `--exclude`.

This occurs when the edge of the input is aligned with the tile grid. To reproduce the issue, create a GeoTIFF with:

```console
$ gdal_create -outsize 1536 1536 -a_srs EPSG:3857 -a_ullr -114.65554242953658 114.65554242953658 114.65554242953658 -114.65554242953658 -bands 4 -burn 0 -co COMPRESS=DEFLATE empty.tif
```

This will be fully transparent so should produce no tiles with `--exclude`, but currently produces tiles along one edge:

```console
$ python3 swig/python/gdal-utils/osgeo_utils/gdal2tiles.py --exclude --xyz -w none empty.tif -z 11-20 /tmp/tiled_out 
...
$ find /tmp/tiled_out/20
/tmp/tiled_out/20
/tmp/tiled_out/20/524288
/tmp/tiled_out/20/524288/524291.png
/tmp/tiled_out/20/524287
/tmp/tiled_out/20/524287/524291.png
/tmp/tiled_out/20/524285
/tmp/tiled_out/20/524285/524291.png
/tmp/tiled_out/20/524289
/tmp/tiled_out/20/524289/524291.png
/tmp/tiled_out/20/524286
/tmp/tiled_out/20/524286/524291.png
/tmp/tiled_out/20/524284
/tmp/tiled_out/20/524284/524291.png
/tmp/tiled_out/20/524290
/tmp/tiled_out/20/524290/524291.png
```
