### PR TITLE
GDALArgumentParser: avoid potential read heap-buffer-overflow (master only)

### DIFF
--- a/autotest/utilities/test_gdal_translate_lib.py
+++ b/autotest/utilities/test_gdal_translate_lib.py
@@ -65,6 +65,20 @@ def test_gdal_translate_lib_1(tmp_path):
 
 
 ###############################################################################
+# Test error case of argument parser
+
+
+def test_gdal_translate_lib_error_case_arg_parser(tmp_vsimem):
+
+    dst_tif = tmp_vsimem / "test_gdal_translate_lib_error_case_arg_parser.tif"
+
+    with pytest.raises(Exception, match="Zero positional arguments expected"):
+        gdal.Translate(
+            dst_tif, "../gcore/data/byte.tif", options="unexpected_positional"
+        )
+
+
+###############################################################################
 # Test format option and callback
 
 


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=67588
