### PR TITLE
Internal libtiff: TIFFWriteDirectory: Avoid overwriting following data if an IFD is enlarged

### DIFF
--- a/frmts/gtiff/libtiff/tif_dir.c
+++ b/frmts/gtiff/libtiff/tif_dir.c
@@ -1652,6 +1652,16 @@ void TIFFFreeDirectory(TIFF *tif)
 
     _TIFFmemset(&(td->td_stripoffset_entry), 0, sizeof(TIFFDirEntry));
     _TIFFmemset(&(td->td_stripbytecount_entry), 0, sizeof(TIFFDirEntry));
+
+    /* Reset some internal parameters for IFD data size checking. */
+    tif->tif_dir.td_dirdatasize_read = 0;
+    tif->tif_dir.td_dirdatasize_write = 0;
+    if (tif->tif_dir.td_dirdatasize_offsets != NULL)
+    {
+        _TIFFfreeExt(tif, tif->tif_dir.td_dirdatasize_offsets);
+        tif->tif_dir.td_dirdatasize_offsets = NULL;
+        tif->tif_dir.td_dirdatasize_Noffsets = 0;
+    }
 }
 #undef CleanupField
 

--- a/frmts/gtiff/libtiff/tif_dir.c
+++ b/frmts/gtiff/libtiff/tif_dir.c
@@ -1676,6 +1676,8 @@ TIFFExtendProc TIFFSetTagExtender(TIFFExtendProc extender)
  */
 int TIFFCreateDirectory(TIFF *tif)
 {
+    /* Free previously allocated memory and setup default values. */
+    TIFFFreeDirectory(tif);
     TIFFDefaultDirectory(tif);
     tif->tif_diroff = 0;
     tif->tif_nextdiroff = 0;
@@ -1688,6 +1690,8 @@ int TIFFCreateDirectory(TIFF *tif)
 
 int TIFFCreateCustomDirectory(TIFF *tif, const TIFFFieldArray *infoarray)
 {
+    /* Free previously allocated memory and setup default values. */
+    TIFFFreeDirectory(tif);
     TIFFDefaultDirectory(tif);
 
     /*

--- a/frmts/gtiff/libtiff/tif_dir.h
+++ b/frmts/gtiff/libtiff/tif_dir.h
@@ -65,6 +65,12 @@ typedef struct
                             tif_dirread.c */
 } TIFFDirEntry;
 
+typedef struct
+{
+    uint64_t offset;
+    uint64_t length;
+} TIFFEntryOffsetAndLength; /* auxiliary for evaluating size of IFD data */
+
 /*
  * Internal format of a TIFF directory entry.
  */
@@ -115,6 +121,9 @@ typedef struct
 #ifdef STRIPBYTECOUNTSORTED_UNUSED
     int td_stripbytecountsorted; /* is the bytecount array sorted ascending? */
 #endif
+    /* Be aware that the parameters of td_stripoffset_entry and
+     * td_stripbytecount_entry are swapped but tdir_offset is not
+     * and has to be swapped when used. */
     TIFFDirEntry td_stripoffset_entry;    /* for deferred loading */
     TIFFDirEntry td_stripbytecount_entry; /* for deferred loading */
     uint16_t td_nsubifd;
@@ -135,6 +144,21 @@ typedef struct
 
     unsigned char
         td_deferstrilearraywriting; /* see TIFFDeferStrileArrayWriting() */
+
+    /* LibTIFF writes all data that does not fit into the IFD entries directly
+     * after the IFD tag enty part. When reading, only the IFD data directly and
+     * continuously behind the IFD tags is taken into account for the IFD data
+     * size.*/
+    uint64_t td_dirdatasize_write; /* auxiliary for evaluating size of IFD data
+                                       to be written */
+    uint64_t td_dirdatasize_read;  /* auxiliary for evaluating size of IFD data
+                                       read from file */
+    uint32_t td_dirdatasize_Noffsets; /* auxiliary counter for
+                                         tif_dir.td_dirdatasize_offsets array */
+    TIFFEntryOffsetAndLength
+        *td_dirdatasize_offsets; /* auxiliary array for all offsets of IFD tag
+                                    entries with data outside the IFD tag
+                                    entries. */
 } TIFFDirectory;
 
 /*

--- a/frmts/gtiff/libtiff/tif_dirinfo.c
+++ b/frmts/gtiff/libtiff/tif_dirinfo.c
@@ -374,7 +374,7 @@ static const TIFFField exifFields[] = {
     {EXIFTAG_BRIGHTNESSVALUE, 1, 1, TIFF_SRATIONAL, 0, TIFF_SETGET_FLOAT, TIFF_SETGET_UNDEFINED, FIELD_CUSTOM, 1, 0, "BrightnessValue", NULL},
     {EXIFTAG_EXPOSUREBIASVALUE, 1, 1, TIFF_SRATIONAL, 0, TIFF_SETGET_FLOAT, TIFF_SETGET_UNDEFINED, FIELD_CUSTOM, 1, 0, "ExposureBiasValue", NULL},
     {EXIFTAG_MAXAPERTUREVALUE, 1, 1, TIFF_RATIONAL, 0, TIFF_SETGET_FLOAT, TIFF_SETGET_UNDEFINED, FIELD_CUSTOM, 1, 0, "MaxApertureValue", NULL},
-    /*--: EXIFTAG_SUBJECTDISTANCE: LibTiff returns value of "-1" if numerator equals 4294967295 (0xFFFFFFFF) to indicate infinite distance! 
+    /*--: EXIFTAG_SUBJECTDISTANCE: LibTiff returns value of "-1" if numerator equals 4294967295 (0xFFFFFFFF) to indicate infinite distance!
      *    However, there are two other EXIF tags where numerator indicates a special value and six other cases where the denominator indicates special values,
      *    which are not treated within LibTiff!! */
     {EXIFTAG_SUBJECTDISTANCE, 1, 1, TIFF_RATIONAL, 0, TIFF_SETGET_FLOAT, TIFF_SETGET_UNDEFINED, FIELD_CUSTOM, 1, 0, "SubjectDistance", NULL},
@@ -1197,12 +1197,24 @@ int TIFFMergeFieldInfo(TIFF *tif, const TIFFFieldInfo info[], uint32_t n)
     for (i = 0; i < n; i++)
     {
         tp->field_tag = info[i].field_tag;
+        if (info[i].field_readcount < TIFF_VARIABLE2 ||
+            info[i].field_readcount == 0 ||
+            info[i].field_writecount < TIFF_VARIABLE2 ||
+            info[i].field_writecount == 0)
+        {
+            /* The fields (field_readcount) and (field_writecount) may use the
+             * values TIFF_VARIABLE (-1), TIFF_SPP (-2), TIFF_VARIABLE2 (-3). */
+            TIFFErrorExtR(tif, module,
+                          "The value of field_readcount and field_writecount "
+                          "must be greater than or equal to -3 and not zero.");
+            return -1;
+        }
         tp->field_readcount = info[i].field_readcount;
         tp->field_writecount = info[i].field_writecount;
         tp->field_type = info[i].field_type;
         tp->field_anonymous = 0;
         tp->set_field_type =
-            _TIFFSetGetType(info[i].field_type, info[i].field_readcount,
+            _TIFFSetGetType(info[i].field_type, info[i].field_writecount,
                             info[i].field_passcount);
         tp->get_field_type =
             _TIFFSetGetType(info[i].field_type, info[i].field_readcount,

--- a/frmts/gtiff/libtiff/tif_dirread.c
+++ b/frmts/gtiff/libtiff/tif_dirread.c
@@ -7445,7 +7445,7 @@ static void ChopUpSingleUncompressedStrip(TIFF *tif)
     /*
      * never increase the number of rows per strip
      */
-    if (rowsperstrip >= td->td_rowsperstrip)
+    if (rowsperstrip >= td->td_rowsperstrip || rowsperstrip == 0)
         return;
     nstrips = TIFFhowmany_32(td->td_imagelength, rowsperstrip);
     if (nstrips == 0)
@@ -7541,6 +7541,8 @@ static void TryChopUpUncompressedBigTiff(TIFF *tif)
     stripbytes = rowblocksperstrip * rowblockbytes;
     assert(stripbytes <= 0x7FFFFFFFUL);
 
+    if (rowsperstrip == 0)
+        return;
     nstrips = TIFFhowmany_32(td->td_imagelength, rowsperstrip);
     if (nstrips == 0)
         return;

--- a/frmts/gtiff/libtiff/tif_dirread.c
+++ b/frmts/gtiff/libtiff/tif_dirread.c
@@ -4078,6 +4078,141 @@ static int ByteCountLooksBad(TIFF *tif)
 }
 
 /*
+ * To evaluate the IFD data size when reading, save the offset and data size of
+ * all data that does not fit into the IFD entries themselves.
+ */
+static void EvaluateIFDdatasizeReading(TIFF *tif, TIFFDirEntry *dp)
+{
+    uint64_t datalength = dp->tdir_count * TIFFDataWidth(dp->tdir_type);
+    if (datalength > ((tif->tif_flags & TIFF_BIGTIFF) ? 0x8U : 0x4U))
+    {
+        tif->tif_dir.td_dirdatasize_read += datalength;
+        if (!(tif->tif_flags & TIFF_BIGTIFF))
+        {
+            /* The offset of TIFFDirEntry are not swapped when read in. That has
+             * to be done when used. */
+            uint32_t offset = dp->tdir_offset.toff_long;
+            if (tif->tif_flags & TIFF_SWAB)
+                TIFFSwabLong(&offset);
+            tif->tif_dir
+                .td_dirdatasize_offsets[tif->tif_dir.td_dirdatasize_Noffsets]
+                .offset = (uint64_t)offset;
+        }
+        else
+        {
+            tif->tif_dir
+                .td_dirdatasize_offsets[tif->tif_dir.td_dirdatasize_Noffsets]
+                .offset = dp->tdir_offset.toff_long8;
+            if (tif->tif_flags & TIFF_SWAB)
+                TIFFSwabLong8(
+                    &tif->tif_dir
+                         .td_dirdatasize_offsets[tif->tif_dir
+                                                     .td_dirdatasize_Noffsets]
+                         .offset);
+        }
+        tif->tif_dir
+            .td_dirdatasize_offsets[tif->tif_dir.td_dirdatasize_Noffsets]
+            .length = datalength;
+        tif->tif_dir.td_dirdatasize_Noffsets++;
+    }
+}
+
+/*
+ * Compare function for qsort() sorting TIFFEntryOffsetAndLength array entries.
+ */
+static int cmpTIFFEntryOffsetAndLength(const void *a, const void *b)
+{
+    const TIFFEntryOffsetAndLength *ta = (const TIFFEntryOffsetAndLength *)a;
+    const TIFFEntryOffsetAndLength *tb = (const TIFFEntryOffsetAndLength *)b;
+    /* Compare offsets */
+    if (ta->offset > tb->offset)
+        return 1;
+    else if (ta->offset < tb->offset)
+        return -1;
+    else
+        return 0;
+}
+
+/*
+ * Determine the IFD data size after reading an IFD from the file that can be
+ * overwritten and saving it in tif_dir.td_dirdatasize_read. This data size
+ * includes the IFD entries themselves as well as the data that does not fit
+ * directly into the IFD entries but is located directly after the IFD entries
+ * in the file.
+ */
+static void CalcFinalIFDdatasizeReading(TIFF *tif, uint16_t dircount)
+{
+    /* IFD data size is only needed if file-writing is enabled.
+     * This also avoids the seek() to EOF to determine the file size, which
+     * causes the stdin-streaming-friendly mode of libtiff for GDAL to fail. */
+    if (tif->tif_mode == O_RDONLY)
+        return;
+
+    /* Sort TIFFEntryOffsetAndLength array in ascending order. */
+    qsort(tif->tif_dir.td_dirdatasize_offsets,
+          tif->tif_dir.td_dirdatasize_Noffsets,
+          sizeof(TIFFEntryOffsetAndLength), cmpTIFFEntryOffsetAndLength);
+
+    /* Get offset of end of IFD entry space. */
+    uint64_t IFDendoffset;
+    if (!(tif->tif_flags & TIFF_BIGTIFF))
+        IFDendoffset = tif->tif_diroff + 2 + dircount * 12 + 4;
+    else
+        IFDendoffset = tif->tif_diroff + 8 + dircount * 20 + 8;
+
+    /* Check which offsets are right behind IFD entries. However, LibTIFF
+     * increments the writing address for every external data to an even offset.
+     * Thus gaps of 1 byte can occur. */
+    uint64_t size = 0;
+    uint64_t offset;
+    uint32_t i;
+    for (i = 0; i < tif->tif_dir.td_dirdatasize_Noffsets; i++)
+    {
+        offset = tif->tif_dir.td_dirdatasize_offsets[i].offset;
+        if (offset == IFDendoffset)
+        {
+            size += tif->tif_dir.td_dirdatasize_offsets[i].length;
+            IFDendoffset += tif->tif_dir.td_dirdatasize_offsets[i].length;
+        }
+        else if (offset == IFDendoffset + 1)
+        {
+            /* Add gap byte after previous IFD data set. */
+            size += tif->tif_dir.td_dirdatasize_offsets[i].length + 1;
+            IFDendoffset += tif->tif_dir.td_dirdatasize_offsets[i].length;
+        }
+        else
+        {
+            /* Further data is no more continously after IFD */
+            break;
+        }
+    }
+    /* Check for gap byte of some easy cases. This should cover 90% of cases.
+     * Otherwise, IFD will be re-written even it might be safely overwritten. */
+    if (tif->tif_nextdiroff != 0)
+    {
+        if (tif->tif_nextdiroff == IFDendoffset + 1)
+            size++;
+    }
+    else
+    {
+        /* Check for IFD data ends at EOF. Then IFD can always be safely
+         * overwritten. */
+        offset = TIFFSeekFile(tif, 0, SEEK_END);
+        if (offset == IFDendoffset)
+        {
+            tif->tif_dir.td_dirdatasize_read = UINT64_MAX;
+            return;
+        }
+    }
+
+    /* Finally, add the size of the IFD tag entries themselves. */
+    if (!(tif->tif_flags & TIFF_BIGTIFF))
+        tif->tif_dir.td_dirdatasize_read = 2 + dircount * 12 + 4 + size;
+    else
+        tif->tif_dir.td_dirdatasize_read = 8 + dircount * 20 + 8 + size;
+} /*-- CalcFinalIFDdatasizeReading() --*/
+
+/*
  * Read the next TIFF directory from a file and convert it to the internal
  * format. We read directories sequentially.
  */
@@ -4164,6 +4299,19 @@ int TIFFReadDirectory(TIFF *tif)
     /* free any old stuff and reinit */
     TIFFFreeDirectory(tif);
     TIFFDefaultDirectory(tif);
+
+    /* Allocate arrays for offset values outside IFD entry for IFD data size
+     * checking. Note: Counter are reset within TIFFFreeDirectory(). */
+    tif->tif_dir.td_dirdatasize_offsets =
+        (TIFFEntryOffsetAndLength *)_TIFFmallocExt(
+            tif, dircount * sizeof(TIFFEntryOffsetAndLength));
+    if (tif->tif_dir.td_dirdatasize_offsets == NULL)
+    {
+        TIFFErrorExtR(
+            tif, module,
+            "Failed to allocate memory for counting IFD data size at reading");
+        return 0;
+    }
     /*
      * Electronic Arts writes gray-scale TIFF files
      * without a PlanarConfiguration directory entry.
@@ -4361,6 +4509,7 @@ int TIFFReadDirectory(TIFF *tif)
                         uint16_t value;
                         enum TIFFReadDirEntryErr err;
                         err = TIFFReadDirEntryShort(tif, dp, &value);
+                        EvaluateIFDdatasizeReading(tif, dp);
                         if (err == TIFFReadDirEntryErrCount)
                             err =
                                 TIFFReadDirEntryPersampleShort(tif, dp, &value);
@@ -4391,6 +4540,7 @@ int TIFFReadDirectory(TIFF *tif)
                         err = TIFFReadDirEntryErrCount;
                     else
                         err = TIFFReadDirEntryDoubleArray(tif, dp, &data);
+                    EvaluateIFDdatasizeReading(tif, dp);
                     if (err != TIFFReadDirEntryErrOk)
                     {
                         fip = TIFFFieldWithTag(tif, dp->tdir_tag);
@@ -4410,6 +4560,7 @@ int TIFFReadDirectory(TIFF *tif)
                 break;
                 case TIFFTAG_STRIPOFFSETS:
                 case TIFFTAG_TILEOFFSETS:
+                {
                     switch (dp->tdir_type)
                     {
                         case TIFF_SHORT:
@@ -4432,9 +4583,12 @@ int TIFFReadDirectory(TIFF *tif)
                     }
                     _TIFFmemcpy(&(tif->tif_dir.td_stripoffset_entry), dp,
                                 sizeof(TIFFDirEntry));
-                    break;
+                    EvaluateIFDdatasizeReading(tif, dp);
+                }
+                break;
                 case TIFFTAG_STRIPBYTECOUNTS:
                 case TIFFTAG_TILEBYTECOUNTS:
+                {
                     switch (dp->tdir_type)
                     {
                         case TIFF_SHORT:
@@ -4457,7 +4611,9 @@ int TIFFReadDirectory(TIFF *tif)
                     }
                     _TIFFmemcpy(&(tif->tif_dir.td_stripbytecount_entry), dp,
                                 sizeof(TIFFDirEntry));
-                    break;
+                    EvaluateIFDdatasizeReading(tif, dp);
+                }
+                break;
                 case TIFFTAG_COLORMAP:
                 case TIFFTAG_TRANSFERFUNCTION:
                 {
@@ -4511,6 +4667,7 @@ int TIFFReadDirectory(TIFF *tif)
                         err = TIFFReadDirEntryErrCount;
                     else
                         err = TIFFReadDirEntryShortArray(tif, dp, &value);
+                    EvaluateIFDdatasizeReading(tif, dp);
                     if (err != TIFFReadDirEntryErrOk)
                     {
                         fip = TIFFFieldWithTag(tif, dp->tdir_tag);
@@ -4601,9 +4758,12 @@ int TIFFReadDirectory(TIFF *tif)
                 default:
                     (void)TIFFFetchNormalTag(tif, dp, TRUE);
                     break;
-            }
-        } /* -- if (!dp->tdir_ignore) */
-    }     /* -- for-loop -- */
+            } /* -- switch (dp->tdir_tag) -- */
+        }     /* -- if (!dp->tdir_ignore) */
+    }         /* -- for-loop -- */
+
+    /* Evaluate final IFD data size. */
+    CalcFinalIFDdatasizeReading(tif, dircount);
 
     /*
      * OJPEG hack:
@@ -5109,6 +5269,19 @@ int TIFFReadCustomDirectory(TIFF *tif, toff_t diroff,
     TIFFFreeDirectory(tif);
     _TIFFmemset(&tif->tif_dir, 0, sizeof(TIFFDirectory));
     TIFFReadDirectoryCheckOrder(tif, dir, dircount);
+    /* Allocate arrays for offset values outside IFD entry for IFD data size
+     * checking. Note: Counter are reset within TIFFFreeDirectory(). */
+    tif->tif_dir.td_dirdatasize_offsets =
+        (TIFFEntryOffsetAndLength *)_TIFFmallocExt(
+            tif, dircount * sizeof(TIFFEntryOffsetAndLength));
+    if (tif->tif_dir.td_dirdatasize_offsets == NULL)
+    {
+        TIFFErrorExtR(
+            tif, module,
+            "Failed to allocate memory for counting IFD data size at reading");
+        return 0;
+    }
+
     for (di = 0, dp = dir; di < dircount; di++, dp++)
     {
         TIFFReadDirectoryFindFieldInfo(tif, dp->tdir_tag, &fii);
@@ -5203,6 +5376,9 @@ int TIFFReadCustomDirectory(TIFF *tif, toff_t diroff,
             } /*-- if (!dp->tdir_ignore) */
         }
     }
+    /* Evaluate final IFD data size. */
+    CalcFinalIFDdatasizeReading(tif, dircount);
+
     /* To be able to return from SubIFD or custom-IFD to main-IFD */
     tif->tif_setdirectory_force_absolute = TRUE;
     if (dir)
@@ -6088,6 +6264,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
                         }
                     }
                 }
+                EvaluateIFDdatasizeReading(tif, dp);
                 if (mb + 1 < (uint32_t)dp->tdir_count)
                     TIFFWarningExtR(
                         tif, module,
@@ -6215,6 +6392,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
             err = TIFFReadDirEntryLong8(tif, dp, &data);
             if (err == TIFFReadDirEntryErrOk)
             {
+                EvaluateIFDdatasizeReading(tif, dp);
                 if (!TIFFSetField(tif, dp->tdir_tag, data))
                     return (0);
             }
@@ -6228,6 +6406,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
             err = TIFFReadDirEntrySlong8(tif, dp, &data);
             if (err == TIFFReadDirEntryErrOk)
             {
+                EvaluateIFDdatasizeReading(tif, dp);
                 if (!TIFFSetField(tif, dp->tdir_tag, data))
                     return (0);
             }
@@ -6241,6 +6420,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
             err = TIFFReadDirEntryFloat(tif, dp, &data);
             if (err == TIFFReadDirEntryErrOk)
             {
+                EvaluateIFDdatasizeReading(tif, dp);
                 if (!TIFFSetField(tif, dp->tdir_tag, data))
                     return (0);
             }
@@ -6254,6 +6434,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
             err = TIFFReadDirEntryDouble(tif, dp, &data);
             if (err == TIFFReadDirEntryErrOk)
             {
+                EvaluateIFDdatasizeReading(tif, dp);
                 if (!TIFFSetField(tif, dp->tdir_tag, data))
                     return (0);
             }
@@ -6267,6 +6448,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
             err = TIFFReadDirEntryIfd8(tif, dp, &data);
             if (err == TIFFReadDirEntryErrOk)
             {
+                EvaluateIFDdatasizeReading(tif, dp);
                 if (!TIFFSetField(tif, dp->tdir_tag, data))
                     return (0);
             }
@@ -6316,6 +6498,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
                 err = TIFFReadDirEntryByteArray(tif, dp, &data);
                 if (err == TIFFReadDirEntryErrOk)
                 {
+                    EvaluateIFDdatasizeReading(tif, dp);
                     int m;
                     m = TIFFSetField(tif, dp->tdir_tag, data);
                     if (data != 0)
@@ -6345,6 +6528,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
                 err = TIFFReadDirEntrySbyteArray(tif, dp, &data);
                 if (err == TIFFReadDirEntryErrOk)
                 {
+                    EvaluateIFDdatasizeReading(tif, dp);
                     int m;
                     m = TIFFSetField(tif, dp->tdir_tag, data);
                     if (data != 0)
@@ -6374,6 +6558,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
                 err = TIFFReadDirEntryShortArray(tif, dp, &data);
                 if (err == TIFFReadDirEntryErrOk)
                 {
+                    EvaluateIFDdatasizeReading(tif, dp);
                     int m;
                     m = TIFFSetField(tif, dp->tdir_tag, data);
                     if (data != 0)
@@ -6403,6 +6588,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
                 err = TIFFReadDirEntrySshortArray(tif, dp, &data);
                 if (err == TIFFReadDirEntryErrOk)
                 {
+                    EvaluateIFDdatasizeReading(tif, dp);
                     int m;
                     m = TIFFSetField(tif, dp->tdir_tag, data);
                     if (data != 0)
@@ -6432,6 +6618,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
                 err = TIFFReadDirEntryLongArray(tif, dp, &data);
                 if (err == TIFFReadDirEntryErrOk)
                 {
+                    EvaluateIFDdatasizeReading(tif, dp);
                     int m;
                     m = TIFFSetField(tif, dp->tdir_tag, data);
                     if (data != 0)
@@ -6461,6 +6648,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
                 err = TIFFReadDirEntrySlongArray(tif, dp, &data);
                 if (err == TIFFReadDirEntryErrOk)
                 {
+                    EvaluateIFDdatasizeReading(tif, dp);
                     int m;
                     m = TIFFSetField(tif, dp->tdir_tag, data);
                     if (data != 0)
@@ -6490,6 +6678,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
                 err = TIFFReadDirEntryLong8Array(tif, dp, &data);
                 if (err == TIFFReadDirEntryErrOk)
                 {
+                    EvaluateIFDdatasizeReading(tif, dp);
                     int m;
                     m = TIFFSetField(tif, dp->tdir_tag, data);
                     if (data != 0)
@@ -6519,6 +6708,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
                 err = TIFFReadDirEntrySlong8Array(tif, dp, &data);
                 if (err == TIFFReadDirEntryErrOk)
                 {
+                    EvaluateIFDdatasizeReading(tif, dp);
                     int m;
                     m = TIFFSetField(tif, dp->tdir_tag, data);
                     if (data != 0)
@@ -6548,6 +6738,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
                 err = TIFFReadDirEntryFloatArray(tif, dp, &data);
                 if (err == TIFFReadDirEntryErrOk)
                 {
+                    EvaluateIFDdatasizeReading(tif, dp);
                     int m;
                     m = TIFFSetField(tif, dp->tdir_tag, data);
                     if (data != 0)
@@ -6579,6 +6770,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
                 err = TIFFReadDirEntryDoubleArray(tif, dp, &data);
                 if (err == TIFFReadDirEntryErrOk)
                 {
+                    EvaluateIFDdatasizeReading(tif, dp);
                     int m;
                     m = TIFFSetField(tif, dp->tdir_tag, data);
                     if (data != 0)
@@ -6601,6 +6793,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
                 err = TIFFReadDirEntryByteArray(tif, dp, &data);
                 if (err == TIFFReadDirEntryErrOk)
                 {
+                    EvaluateIFDdatasizeReading(tif, dp);
                     int m;
                     if (data != 0 && dp->tdir_count > 0 &&
                         data[dp->tdir_count - 1] != '\0')
@@ -6651,6 +6844,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
                 err = TIFFReadDirEntryByteArray(tif, dp, &data);
                 if (err == TIFFReadDirEntryErrOk)
                 {
+                    EvaluateIFDdatasizeReading(tif, dp);
                     int m;
                     m = TIFFSetField(tif, dp->tdir_tag,
                                      (uint16_t)(dp->tdir_count), data);
@@ -6674,6 +6868,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
                 err = TIFFReadDirEntrySbyteArray(tif, dp, &data);
                 if (err == TIFFReadDirEntryErrOk)
                 {
+                    EvaluateIFDdatasizeReading(tif, dp);
                     int m;
                     m = TIFFSetField(tif, dp->tdir_tag,
                                      (uint16_t)(dp->tdir_count), data);
@@ -6697,6 +6892,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
                 err = TIFFReadDirEntryShortArray(tif, dp, &data);
                 if (err == TIFFReadDirEntryErrOk)
                 {
+                    EvaluateIFDdatasizeReading(tif, dp);
                     int m;
                     m = TIFFSetField(tif, dp->tdir_tag,
                                      (uint16_t)(dp->tdir_count), data);
@@ -6720,6 +6916,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
                 err = TIFFReadDirEntrySshortArray(tif, dp, &data);
                 if (err == TIFFReadDirEntryErrOk)
                 {
+                    EvaluateIFDdatasizeReading(tif, dp);
                     int m;
                     m = TIFFSetField(tif, dp->tdir_tag,
                                      (uint16_t)(dp->tdir_count), data);
@@ -6743,6 +6940,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
                 err = TIFFReadDirEntryLongArray(tif, dp, &data);
                 if (err == TIFFReadDirEntryErrOk)
                 {
+                    EvaluateIFDdatasizeReading(tif, dp);
                     int m;
                     m = TIFFSetField(tif, dp->tdir_tag,
                                      (uint16_t)(dp->tdir_count), data);
@@ -6766,6 +6964,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
                 err = TIFFReadDirEntrySlongArray(tif, dp, &data);
                 if (err == TIFFReadDirEntryErrOk)
                 {
+                    EvaluateIFDdatasizeReading(tif, dp);
                     int m;
                     m = TIFFSetField(tif, dp->tdir_tag,
                                      (uint16_t)(dp->tdir_count), data);
@@ -6789,6 +6988,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
                 err = TIFFReadDirEntryLong8Array(tif, dp, &data);
                 if (err == TIFFReadDirEntryErrOk)
                 {
+                    EvaluateIFDdatasizeReading(tif, dp);
                     int m;
                     m = TIFFSetField(tif, dp->tdir_tag,
                                      (uint16_t)(dp->tdir_count), data);
@@ -6812,6 +7012,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
                 err = TIFFReadDirEntrySlong8Array(tif, dp, &data);
                 if (err == TIFFReadDirEntryErrOk)
                 {
+                    EvaluateIFDdatasizeReading(tif, dp);
                     int m;
                     m = TIFFSetField(tif, dp->tdir_tag,
                                      (uint16_t)(dp->tdir_count), data);
@@ -6835,6 +7036,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
                 err = TIFFReadDirEntryFloatArray(tif, dp, &data);
                 if (err == TIFFReadDirEntryErrOk)
                 {
+                    EvaluateIFDdatasizeReading(tif, dp);
                     int m;
                     m = TIFFSetField(tif, dp->tdir_tag,
                                      (uint16_t)(dp->tdir_count), data);
@@ -6858,6 +7060,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
                 err = TIFFReadDirEntryDoubleArray(tif, dp, &data);
                 if (err == TIFFReadDirEntryErrOk)
                 {
+                    EvaluateIFDdatasizeReading(tif, dp);
                     int m;
                     m = TIFFSetField(tif, dp->tdir_tag,
                                      (uint16_t)(dp->tdir_count), data);
@@ -6881,6 +7084,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
                 err = TIFFReadDirEntryIfd8Array(tif, dp, &data);
                 if (err == TIFFReadDirEntryErrOk)
                 {
+                    EvaluateIFDdatasizeReading(tif, dp);
                     int m;
                     m = TIFFSetField(tif, dp->tdir_tag,
                                      (uint16_t)(dp->tdir_count), data);
@@ -6900,6 +7104,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
             err = TIFFReadDirEntryByteArray(tif, dp, &data);
             if (err == TIFFReadDirEntryErrOk)
             {
+                EvaluateIFDdatasizeReading(tif, dp);
                 int m;
                 if (data != 0 && dp->tdir_count > 0 &&
                     data[dp->tdir_count - 1] != '\0')
@@ -6970,6 +7175,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
             }
             if (err == TIFFReadDirEntryErrOk)
             {
+                EvaluateIFDdatasizeReading(tif, dp);
                 int m;
                 m = TIFFSetField(tif, dp->tdir_tag, count, data);
                 if (data != 0)
@@ -6987,6 +7193,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
             err = TIFFReadDirEntrySbyteArray(tif, dp, &data);
             if (err == TIFFReadDirEntryErrOk)
             {
+                EvaluateIFDdatasizeReading(tif, dp);
                 int m;
                 m = TIFFSetField(tif, dp->tdir_tag, (uint32_t)(dp->tdir_count),
                                  data);
@@ -7005,6 +7212,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
             err = TIFFReadDirEntryShortArray(tif, dp, &data);
             if (err == TIFFReadDirEntryErrOk)
             {
+                EvaluateIFDdatasizeReading(tif, dp);
                 int m;
                 m = TIFFSetField(tif, dp->tdir_tag, (uint32_t)(dp->tdir_count),
                                  data);
@@ -7023,6 +7231,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
             err = TIFFReadDirEntrySshortArray(tif, dp, &data);
             if (err == TIFFReadDirEntryErrOk)
             {
+                EvaluateIFDdatasizeReading(tif, dp);
                 int m;
                 m = TIFFSetField(tif, dp->tdir_tag, (uint32_t)(dp->tdir_count),
                                  data);
@@ -7041,6 +7250,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
             err = TIFFReadDirEntryLongArray(tif, dp, &data);
             if (err == TIFFReadDirEntryErrOk)
             {
+                EvaluateIFDdatasizeReading(tif, dp);
                 int m;
                 m = TIFFSetField(tif, dp->tdir_tag, (uint32_t)(dp->tdir_count),
                                  data);
@@ -7059,6 +7269,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
             err = TIFFReadDirEntrySlongArray(tif, dp, &data);
             if (err == TIFFReadDirEntryErrOk)
             {
+                EvaluateIFDdatasizeReading(tif, dp);
                 int m;
                 m = TIFFSetField(tif, dp->tdir_tag, (uint32_t)(dp->tdir_count),
                                  data);
@@ -7077,6 +7288,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
             err = TIFFReadDirEntryLong8Array(tif, dp, &data);
             if (err == TIFFReadDirEntryErrOk)
             {
+                EvaluateIFDdatasizeReading(tif, dp);
                 int m;
                 m = TIFFSetField(tif, dp->tdir_tag, (uint32_t)(dp->tdir_count),
                                  data);
@@ -7095,6 +7307,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
             err = TIFFReadDirEntrySlong8Array(tif, dp, &data);
             if (err == TIFFReadDirEntryErrOk)
             {
+                EvaluateIFDdatasizeReading(tif, dp);
                 int m;
                 m = TIFFSetField(tif, dp->tdir_tag, (uint32_t)(dp->tdir_count),
                                  data);
@@ -7113,6 +7326,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
             err = TIFFReadDirEntryFloatArray(tif, dp, &data);
             if (err == TIFFReadDirEntryErrOk)
             {
+                EvaluateIFDdatasizeReading(tif, dp);
                 int m;
                 m = TIFFSetField(tif, dp->tdir_tag, (uint32_t)(dp->tdir_count),
                                  data);
@@ -7131,6 +7345,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
             err = TIFFReadDirEntryDoubleArray(tif, dp, &data);
             if (err == TIFFReadDirEntryErrOk)
             {
+                EvaluateIFDdatasizeReading(tif, dp);
                 int m;
                 m = TIFFSetField(tif, dp->tdir_tag, (uint32_t)(dp->tdir_count),
                                  data);
@@ -7149,6 +7364,7 @@ static int TIFFFetchNormalTag(TIFF *tif, TIFFDirEntry *dp, int recover)
             err = TIFFReadDirEntryIfd8Array(tif, dp, &data);
             if (err == TIFFReadDirEntryErrOk)
             {
+                EvaluateIFDdatasizeReading(tif, dp);
                 int m;
                 m = TIFFSetField(tif, dp->tdir_tag, (uint32_t)(dp->tdir_count),
                                  data);

--- a/frmts/gtiff/libtiff/tif_dirwrite.c
+++ b/frmts/gtiff/libtiff/tif_dirwrite.c
@@ -303,12 +303,14 @@ int TIFFWriteCustomDirectory(TIFF *tif, uint64_t *pdiroff)
 }
 
 /*
- * Similar to TIFFWriteDirectory(), but if the directory has already
+ * Similar to TIFFWriteDirectorySec(), but if the directory has already
  * been written once, it is relocated to the end of the file, in case it
  * has changed in size.  Note that this will result in the loss of the
  * previously used directory space.
  */
-int TIFFRewriteDirectory(TIFF *tif)
+
+static int TIFFRewriteDirectorySec(TIFF *tif, int isimage, int imagedone,
+                                   uint64_t *pdiroff)
 {
     static const char module[] = "TIFFRewriteDirectory";
 
@@ -464,10 +466,20 @@ int TIFFRewriteDirectory(TIFF *tif)
     }
 
     /*
-     * Now use TIFFWriteDirectory() normally.
+     * Now use TIFFWriteDirectorySec() normally.
      */
+    return TIFFWriteDirectorySec(tif, isimage, imagedone, pdiroff);
+} /*-- TIFFRewriteDirectorySec() --*/
 
-    return TIFFWriteDirectory(tif);
+/*
+ * Similar to TIFFWriteDirectory(), but if the directory has already
+ * been written once, it is relocated to the end of the file, in case it
+ * has changed in size.  Note that this will result in the loss of the
+ * previously used directory space.
+ */
+int TIFFRewriteDirectory(TIFF *tif)
+{
+    return TIFFRewriteDirectorySec(tif, TRUE, TRUE, NULL);
 }
 
 static int TIFFWriteDirectorySec(TIFF *tif, int isimage, int imagedone,
@@ -542,7 +554,12 @@ static int TIFFWriteDirectorySec(TIFF *tif, int isimage, int imagedone,
     dirsize = 0;
     while (1)
     {
+        /* The first loop only determines "ndir" and uses TIFFLinkDirectory() to
+         * set the offset at which the IFD is to be written to the file.
+         * The second loop writes IFD entries to the file. */
         ndir = 0;
+        if (dir == NULL)
+            tif->tif_dir.td_dirdatasize_write = 0;
         if (isimage)
         {
             if (TIFFFieldSet(tif, FIELD_IMAGEDIMENSIONS))
@@ -1085,8 +1102,18 @@ static int TIFFWriteDirectorySec(TIFF *tif, int isimage, int imagedone,
                     break;
             }
         }
+        /* "break" if IFD has been written above in second pass.*/
         if (dir != NULL)
             break;
+
+        /* Evaluate IFD data size: Finally, add the size of the IFD tag entries
+         * themselves. */
+        if (!(tif->tif_flags & TIFF_BIGTIFF))
+            tif->tif_dir.td_dirdatasize_write += 2 + ndir * 12 + 4;
+        else
+            tif->tif_dir.td_dirdatasize_write += 8 + ndir * 20 + 8;
+
+        /* Setup a new directory within first pass. */
         dir = _TIFFmallocExt(tif, ndir * sizeof(TIFFDirEntry));
         if (dir == NULL)
         {
@@ -1095,18 +1122,58 @@ static int TIFFWriteDirectorySec(TIFF *tif, int isimage, int imagedone,
         }
         if (isimage)
         {
-            if ((tif->tif_diroff == 0) && (!TIFFLinkDirectory(tif)))
-                goto bad;
+            /* Check, weather the IFD to be written is new or an already written
+             * IFD can be overwritten or needs to be re-written to a different
+             * location in the file because the IFD is extended with additional
+             * tags or the IFD data size is increased.
+             * - tif_diroff == 0, if a new directory has to be linked.
+             * - tif_diroff != 0, IFD has been re-read from file and will be
+             *   overwritten or re-written.
+             */
+            if (tif->tif_diroff == 0)
+            {
+                if (!TIFFLinkDirectory(tif))
+                    goto bad;
+            }
+            else if (tif->tif_dir.td_dirdatasize_write >
+                     tif->tif_dir.td_dirdatasize_read)
+            {
+                if (dir != NULL)
+                {
+                    _TIFFfreeExt(tif, dir);
+                    dir = NULL;
+                }
+                if (!TIFFRewriteDirectorySec(tif, isimage, imagedone, pdiroff))
+                    goto bad;
+                return (1);
+            }
         }
         else
-            tif->tif_diroff =
-                (TIFFSeekFile(tif, 0, SEEK_END) + 1) & (~((toff_t)1));
+        {
+            /* For !isimage, which means custom-IFD like EXIFIFD or
+             * checkpointing an IFD, determine whether to overwrite or append at
+             * the end of the file.
+             */
+            if (!((tif->tif_dir.td_dirdatasize_read > 0) &&
+                  (tif->tif_dir.td_dirdatasize_write <=
+                   tif->tif_dir.td_dirdatasize_read)))
+            {
+                /* Append at end of file and increment to an even offset. */
+                tif->tif_diroff =
+                    (TIFFSeekFile(tif, 0, SEEK_END) + 1) & (~((toff_t)1));
+            }
+        }
+        /* Return IFD offset */
         if (pdiroff != NULL)
             *pdiroff = tif->tif_diroff;
         if (!(tif->tif_flags & TIFF_BIGTIFF))
             dirsize = 2 + ndir * 12 + 4;
         else
             dirsize = 8 + ndir * 20 + 8;
+        /* Append IFD data stright after the IFD tag entries.
+         * Data that does not fit into an IFD tag entry is written to the file
+         * in the second pass of the while loop. That offset is stored in "dir".
+         */
         tif->tif_dataoff = tif->tif_diroff + dirsize;
         if (!(tif->tif_flags & TIFF_BIGTIFF))
             tif->tif_dataoff = (uint32_t)tif->tif_dataoff;
@@ -1125,9 +1192,10 @@ static int TIFFWriteDirectorySec(TIFF *tif, int isimage, int imagedone,
             else
                 tif->tif_curdir++;
         }
-    }
+    } /* while() */
     if (isimage)
     {
+        /* For SubIFDs remember offset of SubIFD tag within main IFD. */
         if (TIFFFieldSet(tif, FIELD_SUBIFD) && (tif->tif_subifdoff == 0))
         {
             uint32_t na;
@@ -1148,6 +1216,8 @@ static int TIFFWriteDirectorySec(TIFF *tif, int isimage, int imagedone,
                 tif->tif_subifdoff = tif->tif_diroff + 8 + na * 20 + 12;
         }
     }
+    /* Copy/swab IFD entries from "dir" into "dirmem",
+     * which is then written to file. */
     dirmem = _TIFFmallocExt(tif, dirsize);
     if (dirmem == NULL)
     {
@@ -1242,11 +1312,15 @@ static int TIFFWriteDirectorySec(TIFF *tif, int isimage, int imagedone,
         tif->tif_flags &= ~TIFF_DIRTYDIRECT;
         tif->tif_flags &= ~TIFF_DIRTYSTRIP;
         (*tif->tif_cleanup)(tif);
-        /*
-         * Reset directory-related state for subsequent
-         * directories.
-         */
+        /* Reset directory-related state for subsequent directories. */
         TIFFCreateDirectory(tif);
+    }
+    else
+    {
+        /* IFD is only checkpointed to file, thus set IFD data size written to
+         * file.
+         */
+        tif->tif_dir.td_dirdatasize_read = tif->tif_dir.td_dirdatasize_write;
     }
     return (1);
 bad:
@@ -1401,11 +1475,6 @@ static int TIFFWriteDirectoryTagAscii(TIFF *tif, uint32_t *ndir,
                                       TIFFDirEntry *dir, uint16_t tag,
                                       uint32_t count, char *value)
 {
-    if (dir == NULL)
-    {
-        (*ndir)++;
-        return (1);
-    }
     return (
         TIFFWriteDirectoryTagCheckedAscii(tif, ndir, dir, tag, count, value));
 }
@@ -1414,11 +1483,6 @@ static int TIFFWriteDirectoryTagUndefinedArray(TIFF *tif, uint32_t *ndir,
                                                TIFFDirEntry *dir, uint16_t tag,
                                                uint32_t count, uint8_t *value)
 {
-    if (dir == NULL)
-    {
-        (*ndir)++;
-        return (1);
-    }
     return (TIFFWriteDirectoryTagCheckedUndefinedArray(tif, ndir, dir, tag,
                                                        count, value));
 }
@@ -1427,11 +1491,6 @@ static int TIFFWriteDirectoryTagByteArray(TIFF *tif, uint32_t *ndir,
                                           TIFFDirEntry *dir, uint16_t tag,
                                           uint32_t count, uint8_t *value)
 {
-    if (dir == NULL)
-    {
-        (*ndir)++;
-        return (1);
-    }
     return (TIFFWriteDirectoryTagCheckedByteArray(tif, ndir, dir, tag, count,
                                                   value));
 }
@@ -1440,11 +1499,6 @@ static int TIFFWriteDirectoryTagSbyteArray(TIFF *tif, uint32_t *ndir,
                                            TIFFDirEntry *dir, uint16_t tag,
                                            uint32_t count, int8_t *value)
 {
-    if (dir == NULL)
-    {
-        (*ndir)++;
-        return (1);
-    }
     return (TIFFWriteDirectoryTagCheckedSbyteArray(tif, ndir, dir, tag, count,
                                                    value));
 }
@@ -1453,11 +1507,6 @@ static int TIFFWriteDirectoryTagShort(TIFF *tif, uint32_t *ndir,
                                       TIFFDirEntry *dir, uint16_t tag,
                                       uint16_t value)
 {
-    if (dir == NULL)
-    {
-        (*ndir)++;
-        return (1);
-    }
     return (TIFFWriteDirectoryTagCheckedShort(tif, ndir, dir, tag, value));
 }
 
@@ -1465,11 +1514,6 @@ static int TIFFWriteDirectoryTagShortArray(TIFF *tif, uint32_t *ndir,
                                            TIFFDirEntry *dir, uint16_t tag,
                                            uint32_t count, uint16_t *value)
 {
-    if (dir == NULL)
-    {
-        (*ndir)++;
-        return (1);
-    }
     return (TIFFWriteDirectoryTagCheckedShortArray(tif, ndir, dir, tag, count,
                                                    value));
 }
@@ -1485,8 +1529,9 @@ static int TIFFWriteDirectoryTagShortPerSample(TIFF *tif, uint32_t *ndir,
     int o;
     if (dir == NULL)
     {
-        (*ndir)++;
-        return (1);
+        /* only evaluate IFD data size and inc. ndir */
+        return (TIFFWriteDirectoryTagCheckedShortArray(
+            tif, ndir, dir, tag, tif->tif_dir.td_samplesperpixel, NULL));
     }
     m = _TIFFmallocExt(tif, tif->tif_dir.td_samplesperpixel * sizeof(uint16_t));
     if (m == NULL)
@@ -1506,11 +1551,6 @@ static int TIFFWriteDirectoryTagSshortArray(TIFF *tif, uint32_t *ndir,
                                             TIFFDirEntry *dir, uint16_t tag,
                                             uint32_t count, int16_t *value)
 {
-    if (dir == NULL)
-    {
-        (*ndir)++;
-        return (1);
-    }
     return (TIFFWriteDirectoryTagCheckedSshortArray(tif, ndir, dir, tag, count,
                                                     value));
 }
@@ -1519,11 +1559,6 @@ static int TIFFWriteDirectoryTagLong(TIFF *tif, uint32_t *ndir,
                                      TIFFDirEntry *dir, uint16_t tag,
                                      uint32_t value)
 {
-    if (dir == NULL)
-    {
-        (*ndir)++;
-        return (1);
-    }
     return (TIFFWriteDirectoryTagCheckedLong(tif, ndir, dir, tag, value));
 }
 
@@ -1531,11 +1566,6 @@ static int TIFFWriteDirectoryTagLongArray(TIFF *tif, uint32_t *ndir,
                                           TIFFDirEntry *dir, uint16_t tag,
                                           uint32_t count, uint32_t *value)
 {
-    if (dir == NULL)
-    {
-        (*ndir)++;
-        return (1);
-    }
     return (TIFFWriteDirectoryTagCheckedLongArray(tif, ndir, dir, tag, count,
                                                   value));
 }
@@ -1544,11 +1574,6 @@ static int TIFFWriteDirectoryTagSlongArray(TIFF *tif, uint32_t *ndir,
                                            TIFFDirEntry *dir, uint16_t tag,
                                            uint32_t count, int32_t *value)
 {
-    if (dir == NULL)
-    {
-        (*ndir)++;
-        return (1);
-    }
     return (TIFFWriteDirectoryTagCheckedSlongArray(tif, ndir, dir, tag, count,
                                                    value));
 }
@@ -1572,8 +1597,9 @@ static int TIFFWriteDirectoryTagLong8Array(TIFF *tif, uint32_t *ndir,
     /* is this just a counting pass? */
     if (dir == NULL)
     {
-        (*ndir)++;
-        return (1);
+        /* only evaluate IFD data size and inc. ndir */
+        return (TIFFWriteDirectoryTagCheckedLong8Array(tif, ndir, dir, tag,
+                                                       count, value));
     }
 
     /* We always write Long8 for BigTIFF, no checking needed. */
@@ -1632,8 +1658,9 @@ static int TIFFWriteDirectoryTagSlong8Array(TIFF *tif, uint32_t *ndir,
     /* is this just a counting pass? */
     if (dir == NULL)
     {
-        (*ndir)++;
-        return (1);
+        /* only evaluate IFD data size and inc. ndir */
+        return (TIFFWriteDirectoryTagCheckedSlong8Array(tif, ndir, dir, tag,
+                                                        count, value));
     }
     /* We always write SLong8 for BigTIFF, no checking needed. */
     if (tif->tif_flags & TIFF_BIGTIFF)
@@ -1686,11 +1713,6 @@ static int TIFFWriteDirectoryTagRational(TIFF *tif, uint32_t *ndir,
                                          TIFFDirEntry *dir, uint16_t tag,
                                          double value)
 {
-    if (dir == NULL)
-    {
-        (*ndir)++;
-        return (1);
-    }
     return (TIFFWriteDirectoryTagCheckedRational(tif, ndir, dir, tag, value));
 }
 
@@ -1698,11 +1720,6 @@ static int TIFFWriteDirectoryTagRationalArray(TIFF *tif, uint32_t *ndir,
                                               TIFFDirEntry *dir, uint16_t tag,
                                               uint32_t count, float *value)
 {
-    if (dir == NULL)
-    {
-        (*ndir)++;
-        return (1);
-    }
     return (TIFFWriteDirectoryTagCheckedRationalArray(tif, ndir, dir, tag,
                                                       count, value));
 }
@@ -1711,11 +1728,6 @@ static int TIFFWriteDirectoryTagSrationalArray(TIFF *tif, uint32_t *ndir,
                                                TIFFDirEntry *dir, uint16_t tag,
                                                uint32_t count, float *value)
 {
-    if (dir == NULL)
-    {
-        (*ndir)++;
-        return (1);
-    }
     return (TIFFWriteDirectoryTagCheckedSrationalArray(tif, ndir, dir, tag,
                                                        count, value));
 }
@@ -1727,11 +1739,6 @@ static int TIFFWriteDirectoryTagRationalDoubleArray(TIFF *tif, uint32_t *ndir,
                                                     uint32_t count,
                                                     double *value)
 {
-    if (dir == NULL)
-    {
-        (*ndir)++;
-        return (1);
-    }
     return (TIFFWriteDirectoryTagCheckedRationalDoubleArray(tif, ndir, dir, tag,
                                                             count, value));
 }
@@ -1742,11 +1749,6 @@ static int TIFFWriteDirectoryTagSrationalDoubleArray(TIFF *tif, uint32_t *ndir,
                                                      uint32_t count,
                                                      double *value)
 {
-    if (dir == NULL)
-    {
-        (*ndir)++;
-        return (1);
-    }
     return (TIFFWriteDirectoryTagCheckedSrationalDoubleArray(
         tif, ndir, dir, tag, count, value));
 }
@@ -1755,11 +1757,6 @@ static int TIFFWriteDirectoryTagFloatArray(TIFF *tif, uint32_t *ndir,
                                            TIFFDirEntry *dir, uint16_t tag,
                                            uint32_t count, float *value)
 {
-    if (dir == NULL)
-    {
-        (*ndir)++;
-        return (1);
-    }
     return (TIFFWriteDirectoryTagCheckedFloatArray(tif, ndir, dir, tag, count,
                                                    value));
 }
@@ -1768,11 +1765,6 @@ static int TIFFWriteDirectoryTagDoubleArray(TIFF *tif, uint32_t *ndir,
                                             TIFFDirEntry *dir, uint16_t tag,
                                             uint32_t count, double *value)
 {
-    if (dir == NULL)
-    {
-        (*ndir)++;
-        return (1);
-    }
     return (TIFFWriteDirectoryTagCheckedDoubleArray(tif, ndir, dir, tag, count,
                                                     value));
 }
@@ -1781,11 +1773,6 @@ static int TIFFWriteDirectoryTagIfdArray(TIFF *tif, uint32_t *ndir,
                                          TIFFDirEntry *dir, uint16_t tag,
                                          uint32_t count, uint32_t *value)
 {
-    if (dir == NULL)
-    {
-        (*ndir)++;
-        return (1);
-    }
     return (TIFFWriteDirectoryTagCheckedIfdArray(tif, ndir, dir, tag, count,
                                                  value));
 }
@@ -1794,11 +1781,6 @@ static int TIFFWriteDirectoryTagShortLong(TIFF *tif, uint32_t *ndir,
                                           TIFFDirEntry *dir, uint16_t tag,
                                           uint32_t value)
 {
-    if (dir == NULL)
-    {
-        (*ndir)++;
-        return (1);
-    }
     if (value <= 0xFFFF)
         return (TIFFWriteDirectoryTagCheckedShort(tif, ndir, dir, tag,
                                                   (uint16_t)value));
@@ -1824,7 +1806,7 @@ static int _WriteAsType(TIFF *tif, uint64_t strile_size,
              compression == COMPRESSION_WEBP || compression == COMPRESSION_JXL)
     {
         /* For a few select compression types, we assume that in the worst */
-        /* case the compressed size will be 10 times the uncompressed size */
+        /* case the compressed size will be 10 times the uncompressed size. */
         /* This is overly pessismistic ! */
         return strile_size >= uncompressed_threshold / 10;
     }
@@ -1856,15 +1838,16 @@ static int TIFFWriteDirectoryTagLongLong8Array(TIFF *tif, uint32_t *ndir,
     int o;
     int write_aslong4;
 
-    /* is this just a counting pass? */
-    if (dir == NULL)
-    {
-        (*ndir)++;
-        return (1);
-    }
-
     if (tif->tif_dir.td_deferstrilearraywriting)
     {
+        if (dir == NULL)
+        {
+            /* This is just a counting pass to count IFD entries.
+             * For deferstrilearraywriting no extra bytes will be written
+             * into IFD space. */
+            (*ndir)++;
+            return 1;
+        }
         return TIFFWriteDirectoryTagData(tif, ndir, dir, tag, TIFF_NOTYPE, 0, 0,
                                          NULL);
     }
@@ -1872,12 +1855,10 @@ static int TIFFWriteDirectoryTagLongLong8Array(TIFF *tif, uint32_t *ndir,
     if (tif->tif_flags & TIFF_BIGTIFF)
     {
         int write_aslong8 = 1;
-        /* In the case of ByteCounts array, we may be able to write them on */
-        /* LONG if the strip/tilesize is not too big. */
-        /* Also do that for count > 1 in the case someone would want to create
-         */
-        /* a single-strip file with a growing height, in which case using */
-        /* LONG8 will be safer. */
+        /* In the case of ByteCounts array, we may be able to write them on LONG
+         * if the strip/tilesize is not too big. Also do that for count > 1 in
+         * the case someone would want to create a single-strip file with a
+         * growing height, in which case using LONG8 will be safer. */
         if (count > 1 && tag == TIFFTAG_STRIPBYTECOUNTS)
         {
             write_aslong8 = WriteAsLong8(tif, TIFFStripSize64(tif));
@@ -1989,13 +1970,6 @@ static int TIFFWriteDirectoryTagIfdIfd8Array(TIFF *tif, uint32_t *ndir,
     uint32_t *q;
     int o;
 
-    /* is this just a counting pass? */
-    if (dir == NULL)
-    {
-        (*ndir)++;
-        return (1);
-    }
-
     /* We always write IFD8 for BigTIFF, no checking needed. */
     if (tif->tif_flags & TIFF_BIGTIFF)
         return TIFFWriteDirectoryTagCheckedIfd8Array(tif, ndir, dir, tag, count,
@@ -2032,6 +2006,26 @@ static int TIFFWriteDirectoryTagIfdIfd8Array(TIFF *tif, uint32_t *ndir,
     return (o);
 }
 
+/*
+ * Auxiliary function to determine the IFD data size to be written to the file.
+ * The IFD data size is finally the size of the IFD tag entries plus the IFD
+ * data that is written directly after the IFD tag entries.
+ */
+static void EvaluateIFDdatasizeWrite(TIFF *tif, uint32_t count,
+                                     uint32_t typesize, uint32_t *ndir)
+{
+    uint64_t datalength = count * typesize;
+    if (datalength > ((tif->tif_flags & TIFF_BIGTIFF) ? 0x8U : 0x4U))
+    {
+        /* LibTIFF increments write adress to an even offset, thus datalenght
+         * written is also incremented. */
+        if (datalength & 1)
+            datalength++;
+        tif->tif_dir.td_dirdatasize_write += datalength;
+    }
+    (*ndir)++;
+}
+
 static int TIFFWriteDirectoryTagColormap(TIFF *tif, uint32_t *ndir,
                                          TIFFDirEntry *dir)
 {
@@ -2039,12 +2033,13 @@ static int TIFFWriteDirectoryTagColormap(TIFF *tif, uint32_t *ndir,
     uint32_t m;
     uint16_t *n;
     int o;
-    if (dir == NULL)
-    {
-        (*ndir)++;
-        return (1);
-    }
     m = (1 << tif->tif_dir.td_bitspersample);
+    if (dir == NULL) /* Just evaluate IFD data size and increment ndir. */
+    {
+        EvaluateIFDdatasizeWrite(tif, 3 * m, sizeof(uint16_t), ndir);
+        return 1;
+    }
+
     n = _TIFFmallocExt(tif, 3 * m * sizeof(uint16_t));
     if (n == NULL)
     {
@@ -2068,11 +2063,6 @@ static int TIFFWriteDirectoryTagTransferfunction(TIFF *tif, uint32_t *ndir,
     uint16_t n;
     uint16_t *o;
     int p;
-    if (dir == NULL)
-    {
-        (*ndir)++;
-        return (1);
-    }
     /* TIFFTAG_TRANSFERFUNCTION expects (1 or 3) pointer to arrays with
      *  (1 << BitsPerSample) * uint16_t values.
      */
@@ -2086,9 +2076,9 @@ static int TIFFWriteDirectoryTagTransferfunction(TIFF *tif, uint32_t *ndir,
     {
         if (tif->tif_dir.td_transferfunction[i] == NULL)
         {
-            TIFFWarningExtR(
-                tif, module,
-                "Too few TransferFunctions provided. Tag not written to file");
+            TIFFWarningExtR(tif, module,
+                            "Too few TransferFunctions provided. Tag "
+                            "not written to file");
             return (1); /* Not an error; only tag is not written. */
         }
     }
@@ -2108,6 +2098,12 @@ static int TIFFWriteDirectoryTagTransferfunction(TIFF *tif, uint32_t *ndir,
                          m * sizeof(uint16_t)))
             n = 1;
     }
+    if (dir == NULL) /* Just evaluate IFD data size and increment ndir. */
+    {
+        EvaluateIFDdatasizeWrite(tif, n * m, 2, ndir);
+        return 1;
+    }
+
     o = _TIFFmallocExt(tif, n * m * sizeof(uint16_t));
     if (o == NULL)
     {
@@ -2136,11 +2132,6 @@ static int TIFFWriteDirectoryTagSubifd(TIFF *tif, uint32_t *ndir,
     int n;
     if (tif->tif_dir.td_nsubifd == 0)
         return (1);
-    if (dir == NULL)
-    {
-        (*ndir)++;
-        return (1);
-    }
     m = tif->tif_dataoff;
     if (!(tif->tif_flags & TIFF_BIGTIFF))
     {
@@ -2178,6 +2169,12 @@ static int TIFFWriteDirectoryTagSubifd(TIFF *tif, uint32_t *ndir,
         n = TIFFWriteDirectoryTagCheckedIfd8Array(
             tif, ndir, dir, TIFFTAG_SUBIFD, tif->tif_dir.td_nsubifd,
             tif->tif_dir.td_subifd);
+
+    if (dir == NULL)
+        /* Just have evaluated IFD data size and incremented ndir
+         * above in sub-functions. */
+        return (n);
+
     if (!n)
         return (0);
     /*
@@ -2202,6 +2199,11 @@ static int TIFFWriteDirectoryTagCheckedAscii(TIFF *tif, uint32_t *ndir,
                                              uint32_t count, char *value)
 {
     assert(sizeof(char) == 1);
+    if (dir == NULL) /* Just evaluate IFD data size and increment ndir. */
+    {
+        EvaluateIFDdatasizeWrite(tif, count, 1, ndir);
+        return 1;
+    }
     return (TIFFWriteDirectoryTagData(tif, ndir, dir, tag, TIFF_ASCII, count,
                                       count, value));
 }
@@ -2213,6 +2215,11 @@ static int TIFFWriteDirectoryTagCheckedUndefinedArray(TIFF *tif, uint32_t *ndir,
                                                       uint8_t *value)
 {
     assert(sizeof(uint8_t) == 1);
+    if (dir == NULL) /* Just evaluate IFD data size and increment ndir. */
+    {
+        EvaluateIFDdatasizeWrite(tif, count, 1, ndir);
+        return 1;
+    }
     return (TIFFWriteDirectoryTagData(tif, ndir, dir, tag, TIFF_UNDEFINED,
                                       count, count, value));
 }
@@ -2223,6 +2230,11 @@ static int TIFFWriteDirectoryTagCheckedByteArray(TIFF *tif, uint32_t *ndir,
                                                  uint8_t *value)
 {
     assert(sizeof(uint8_t) == 1);
+    if (dir == NULL) /* Just evaluate IFD data size and increment ndir. */
+    {
+        EvaluateIFDdatasizeWrite(tif, count, 1, ndir);
+        return 1;
+    }
     return (TIFFWriteDirectoryTagData(tif, ndir, dir, tag, TIFF_BYTE, count,
                                       count, value));
 }
@@ -2233,6 +2245,11 @@ static int TIFFWriteDirectoryTagCheckedSbyteArray(TIFF *tif, uint32_t *ndir,
                                                   int8_t *value)
 {
     assert(sizeof(int8_t) == 1);
+    if (dir == NULL) /* Just evaluate IFD data size and increment ndir. */
+    {
+        EvaluateIFDdatasizeWrite(tif, count, 1, ndir);
+        return 1;
+    }
     return (TIFFWriteDirectoryTagData(tif, ndir, dir, tag, TIFF_SBYTE, count,
                                       count, value));
 }
@@ -2243,6 +2260,12 @@ static int TIFFWriteDirectoryTagCheckedShort(TIFF *tif, uint32_t *ndir,
 {
     uint16_t m;
     assert(sizeof(uint16_t) == 2);
+    if (dir == NULL)
+    {
+        /* No additional data to IFD data size just increment ndir. */
+        (*ndir)++;
+        return 1;
+    }
     m = value;
     if (tif->tif_flags & TIFF_SWAB)
         TIFFSwabShort(&m);
@@ -2257,6 +2280,11 @@ static int TIFFWriteDirectoryTagCheckedShortArray(TIFF *tif, uint32_t *ndir,
 {
     assert(count < 0x80000000);
     assert(sizeof(uint16_t) == 2);
+    if (dir == NULL) /* Just evaluate IFD data size and increment ndir. */
+    {
+        EvaluateIFDdatasizeWrite(tif, count, 2, ndir);
+        return 1;
+    }
     if (tif->tif_flags & TIFF_SWAB)
         TIFFSwabArrayOfShort(value, count);
     return (TIFFWriteDirectoryTagData(tif, ndir, dir, tag, TIFF_SHORT, count,
@@ -2270,6 +2298,11 @@ static int TIFFWriteDirectoryTagCheckedSshortArray(TIFF *tif, uint32_t *ndir,
 {
     assert(count < 0x80000000);
     assert(sizeof(int16_t) == 2);
+    if (dir == NULL) /* Just evaluate IFD data size and increment ndir. */
+    {
+        EvaluateIFDdatasizeWrite(tif, count, 2, ndir);
+        return 1;
+    }
     if (tif->tif_flags & TIFF_SWAB)
         TIFFSwabArrayOfShort((uint16_t *)value, count);
     return (TIFFWriteDirectoryTagData(tif, ndir, dir, tag, TIFF_SSHORT, count,
@@ -2282,6 +2315,12 @@ static int TIFFWriteDirectoryTagCheckedLong(TIFF *tif, uint32_t *ndir,
 {
     uint32_t m;
     assert(sizeof(uint32_t) == 4);
+    if (dir == NULL)
+    {
+        /* No additional data to IFD data size just increment ndir. */
+        (*ndir)++;
+        return 1;
+    }
     m = value;
     if (tif->tif_flags & TIFF_SWAB)
         TIFFSwabLong(&m);
@@ -2296,6 +2335,11 @@ static int TIFFWriteDirectoryTagCheckedLongArray(TIFF *tif, uint32_t *ndir,
 {
     assert(count < 0x40000000);
     assert(sizeof(uint32_t) == 4);
+    if (dir == NULL) /* Just evaluate IFD data size and increment ndir. */
+    {
+        EvaluateIFDdatasizeWrite(tif, count, 4, ndir);
+        return 1;
+    }
     if (tif->tif_flags & TIFF_SWAB)
         TIFFSwabArrayOfLong(value, count);
     return (TIFFWriteDirectoryTagData(tif, ndir, dir, tag, TIFF_LONG, count,
@@ -2309,6 +2353,11 @@ static int TIFFWriteDirectoryTagCheckedSlongArray(TIFF *tif, uint32_t *ndir,
 {
     assert(count < 0x40000000);
     assert(sizeof(int32_t) == 4);
+    if (dir == NULL) /* Just evaluate IFD data size and increment ndir. */
+    {
+        EvaluateIFDdatasizeWrite(tif, count, 4, ndir);
+        return 1;
+    }
     if (tif->tif_flags & TIFF_SWAB)
         TIFFSwabArrayOfLong((uint32_t *)value, count);
     return (TIFFWriteDirectoryTagData(tif, ndir, dir, tag, TIFF_SLONG, count,
@@ -2328,6 +2377,11 @@ static int TIFFWriteDirectoryTagCheckedLong8Array(TIFF *tif, uint32_t *ndir,
                       "LONG8 not allowed for ClassicTIFF");
         return (0);
     }
+    if (dir == NULL) /* Just evaluate IFD data size and increment ndir. */
+    {
+        EvaluateIFDdatasizeWrite(tif, count, 8, ndir);
+        return 1;
+    }
     if (tif->tif_flags & TIFF_SWAB)
         TIFFSwabArrayOfLong8(value, count);
     return (TIFFWriteDirectoryTagData(tif, ndir, dir, tag, TIFF_LONG8, count,
@@ -2346,6 +2400,11 @@ static int TIFFWriteDirectoryTagCheckedSlong8Array(TIFF *tif, uint32_t *ndir,
         TIFFErrorExtR(tif, "TIFFWriteDirectoryTagCheckedSlong8Array",
                       "SLONG8 not allowed for ClassicTIFF");
         return (0);
+    }
+    if (dir == NULL) /* Just evaluate IFD data size and increment ndir. */
+    {
+        EvaluateIFDdatasizeWrite(tif, count, 8, ndir);
+        return 1;
     }
     if (tif->tif_flags & TIFF_SWAB)
         TIFFSwabArrayOfLong8((uint64_t *)value, count);
@@ -2370,15 +2429,16 @@ static int TIFFWriteDirectoryTagCheckedRational(TIFF *tif, uint32_t *ndir,
         TIFFErrorExtR(tif, module, "Not-a-number value is illegal");
         return 0;
     }
-    /*--Rational2Double: New function also used for non-custom rational tags.
-     *  However, could be omitted here, because
-     * TIFFWriteDirectoryTagCheckedRational() is not used by code for custom
-     * tags, only by code for named-tiff-tags like FIELD_RESOLUTION and
-     * FIELD_POSITION */
-    else
+
+    if (dir == NULL) /* Just evaluate IFD data size and increment ndir. */
     {
-        DoubleToRational(value, &m[0], &m[1]);
+        tif->tif_dir.td_dirdatasize_write +=
+            (tif->tif_flags & TIFF_BIGTIFF) ? 0 : 0x8U;
+        (*ndir)++;
+        return 1;
     }
+
+    DoubleToRational(value, &m[0], &m[1]);
 
     if (tif->tif_flags & TIFF_SWAB)
     {
@@ -2402,6 +2462,11 @@ static int TIFFWriteDirectoryTagCheckedRationalArray(TIFF *tif, uint32_t *ndir,
     uint32_t nc;
     int o;
     assert(sizeof(uint32_t) == 4);
+    if (dir == NULL) /* Just evaluate IFD data size and increment ndir. */
+    {
+        EvaluateIFDdatasizeWrite(tif, count * 2, sizeof(uint32_t), ndir);
+        return 1;
+    }
     m = _TIFFmallocExt(tif, count * 2 * sizeof(uint32_t));
     if (m == NULL)
     {
@@ -2433,6 +2498,11 @@ static int TIFFWriteDirectoryTagCheckedSrationalArray(TIFF *tif, uint32_t *ndir,
     uint32_t nc;
     int o;
     assert(sizeof(int32_t) == 4);
+    if (dir == NULL) /* Just evaluate IFD data size and increment ndir. */
+    {
+        EvaluateIFDdatasizeWrite(tif, count * 2, sizeof(int32_t), ndir);
+        return 1;
+    }
     m = _TIFFmallocExt(tif, count * 2 * sizeof(int32_t));
     if (m == NULL)
     {
@@ -2465,6 +2535,11 @@ TIFFWriteDirectoryTagCheckedRationalDoubleArray(TIFF *tif, uint32_t *ndir,
     uint32_t nc;
     int o;
     assert(sizeof(uint32_t) == 4);
+    if (dir == NULL) /* Just evaluate IFD data size and increment ndir. */
+    {
+        EvaluateIFDdatasizeWrite(tif, count * 2, sizeof(uint32_t), ndir);
+        return 1;
+    }
     m = _TIFFmallocExt(tif, count * 2 * sizeof(uint32_t));
     if (m == NULL)
     {
@@ -2495,6 +2570,11 @@ static int TIFFWriteDirectoryTagCheckedSrationalDoubleArray(
     uint32_t nc;
     int o;
     assert(sizeof(int32_t) == 4);
+    if (dir == NULL) /* Just evaluate IFD data size and increment ndir. */
+    {
+        EvaluateIFDdatasizeWrite(tif, count * 2, sizeof(int32_t), ndir);
+        return 1;
+    }
     m = _TIFFmallocExt(tif, count * 2 * sizeof(int32_t));
     if (m == NULL)
     {
@@ -2816,6 +2896,11 @@ static int TIFFWriteDirectoryTagCheckedFloatArray(TIFF *tif, uint32_t *ndir,
 {
     assert(count < 0x40000000);
     assert(sizeof(float) == 4);
+    if (dir == NULL) /* Just evaluate IFD data size and increment ndir. */
+    {
+        EvaluateIFDdatasizeWrite(tif, count, 4, ndir);
+        return 1;
+    }
     TIFFCvtNativeToIEEEFloat(tif, count, &value);
     if (tif->tif_flags & TIFF_SWAB)
         TIFFSwabArrayOfFloat(value, count);
@@ -2830,6 +2915,11 @@ static int TIFFWriteDirectoryTagCheckedDoubleArray(TIFF *tif, uint32_t *ndir,
 {
     assert(count < 0x20000000);
     assert(sizeof(double) == 8);
+    if (dir == NULL) /* Just evaluate IFD data size and increment ndir. */
+    {
+        EvaluateIFDdatasizeWrite(tif, count, 8, ndir);
+        return 1;
+    }
     TIFFCvtNativeToIEEEDouble(tif, count, &value);
     if (tif->tif_flags & TIFF_SWAB)
         TIFFSwabArrayOfDouble(value, count);
@@ -2843,6 +2933,11 @@ static int TIFFWriteDirectoryTagCheckedIfdArray(TIFF *tif, uint32_t *ndir,
 {
     assert(count < 0x40000000);
     assert(sizeof(uint32_t) == 4);
+    if (dir == NULL) /* Just evaluate IFD data size and increment ndir. */
+    {
+        EvaluateIFDdatasizeWrite(tif, count, 4, ndir);
+        return 1;
+    }
     if (tif->tif_flags & TIFF_SWAB)
         TIFFSwabArrayOfLong(value, count);
     return (TIFFWriteDirectoryTagData(tif, ndir, dir, tag, TIFF_IFD, count,
@@ -2857,6 +2952,11 @@ static int TIFFWriteDirectoryTagCheckedIfd8Array(TIFF *tif, uint32_t *ndir,
     assert(count < 0x20000000);
     assert(sizeof(uint64_t) == 8);
     assert(tif->tif_flags & TIFF_BIGTIFF);
+    if (dir == NULL) /* Just evaluate IFD data size and increment ndir. */
+    {
+        EvaluateIFDdatasizeWrite(tif, count, 8, ndir);
+        return 1;
+    }
     if (tif->tif_flags & TIFF_SWAB)
         TIFFSwabArrayOfLong8(value, count);
     return (TIFFWriteDirectoryTagData(tif, ndir, dir, tag, TIFF_IFD8, count,
@@ -3126,9 +3226,9 @@ static int TIFFLinkDirectory(TIFF *tif)
                 TIFFSwabLong8(&dircount64);
             if (dircount64 > 0xFFFF)
             {
-                TIFFErrorExtR(
-                    tif, module,
-                    "Sanity check on tag count failed, likely corrupt TIFF");
+                TIFFErrorExtR(tif, module,
+                              "Sanity check on tag count failed, "
+                              "likely corrupt TIFF");
                 return (0);
             }
             dircount = (uint16_t)dircount64;
@@ -3197,9 +3297,9 @@ int _TIFFRewriteField(TIFF *tif, uint16_t tag, TIFFDataType in_datatype,
     /* -------------------------------------------------------------------- */
     if (isMapped(tif))
     {
-        TIFFErrorExtR(
-            tif, module,
-            "Memory mapped files not currently supported for this operation.");
+        TIFFErrorExtR(tif, module,
+                      "Memory mapped files not currently supported for "
+                      "this operation.");
         return 0;
     }
 

--- a/frmts/gtiff/libtiff/tif_jpeg.c
+++ b/frmts/gtiff/libtiff/tif_jpeg.c
@@ -1215,6 +1215,12 @@ int TIFFJPEGIsFullStripRequired(TIFF *tif)
          * For PC 2, scale down the expected strip/tile size
          * to match a downsampled component
          */
+        if (sp->h_sampling == 0 || sp->v_sampling == 0)
+        {
+            TIFFErrorExtR(tif, module,
+                          "JPEG horizontal or vertical sampling is zero");
+            return (0);
+        }
         segment_width = TIFFhowmany_32(segment_width, sp->h_sampling);
         segment_height = TIFFhowmany_32(segment_height, sp->v_sampling);
     }
@@ -2164,6 +2170,12 @@ static int JPEGPreEncode(TIFF *tif, uint16_t s)
         /* for PC 2, scale down the strip/tile size
          * to match a downsampled component
          */
+        if (sp->h_sampling == 0 || sp->v_sampling == 0)
+        {
+            TIFFErrorExtR(tif, module,
+                          "JPEG horizontal or vertical sampling is zero");
+            return (0);
+        }
         segment_width = TIFFhowmany_32(segment_width, sp->h_sampling);
         segment_height = TIFFhowmany_32(segment_height, sp->v_sampling);
     }

--- a/frmts/gtiff/libtiff/tif_open.c
+++ b/frmts/gtiff/libtiff/tif_open.c
@@ -882,10 +882,7 @@ int TIFFIsBigEndian(TIFF *tif)
 /*
  * Return nonzero if given file is BigTIFF style.
  */
-int TIFFIsBigTIFF(TIFF *tif)
-{
-    return (tif->tif_header.common.tiff_version == TIFF_VERSION_BIG);
-}
+int TIFFIsBigTIFF(TIFF *tif) { return ((tif->tif_flags & TIFF_BIGTIFF) != 0); }
 
 /*
  * Return pointer to file read method.

--- a/frmts/gtiff/libtiff/tif_strip.c
+++ b/frmts/gtiff/libtiff/tif_strip.c
@@ -61,6 +61,11 @@ uint32_t TIFFNumberOfStrips(TIFF *tif)
     TIFFDirectory *td = &tif->tif_dir;
     uint32_t nstrips;
 
+    if (td->td_rowsperstrip == 0)
+    {
+        TIFFWarningExtR(tif, "TIFFNumberOfStrips", "RowsPerStrip is zero");
+        return 0;
+    }
     nstrips = (td->td_rowsperstrip == (uint32_t)-1
                    ? 1
                    : TIFFhowmany_32(td->td_imagelength, td->td_rowsperstrip));
@@ -107,7 +112,8 @@ uint64_t TIFFVStripSize64(TIFF *tif, uint32_t nrows)
         if ((ycbcrsubsampling[0] != 1 && ycbcrsubsampling[0] != 2 &&
              ycbcrsubsampling[0] != 4) ||
             (ycbcrsubsampling[1] != 1 && ycbcrsubsampling[1] != 2 &&
-             ycbcrsubsampling[1] != 4))
+             ycbcrsubsampling[1] != 4) ||
+            (ycbcrsubsampling[0] == 0 || ycbcrsubsampling[1] == 0))
         {
             TIFFErrorExtR(tif, module, "Invalid YCbCr subsampling (%dx%d)",
                           ycbcrsubsampling[0], ycbcrsubsampling[1]);
@@ -267,7 +273,8 @@ uint64_t TIFFScanlineSize64(TIFF *tif)
             if (((ycbcrsubsampling[0] != 1) && (ycbcrsubsampling[0] != 2) &&
                  (ycbcrsubsampling[0] != 4)) ||
                 ((ycbcrsubsampling[1] != 1) && (ycbcrsubsampling[1] != 2) &&
-                 (ycbcrsubsampling[1] != 4)))
+                 (ycbcrsubsampling[1] != 4)) ||
+                ((ycbcrsubsampling[0] == 0) || (ycbcrsubsampling[1] == 0)))
             {
                 TIFFErrorExtR(tif, module, "Invalid YCbCr subsampling");
                 return 0;

--- a/frmts/gtiff/libtiff/tiffiop.h
+++ b/frmts/gtiff/libtiff/tiffiop.h
@@ -168,7 +168,7 @@ struct tiff
     uint64_t tif_curoff;        /* current offset for read/write */
     uint64_t tif_lastvalidoff;  /* last valid offset allowed for rewrite in
                                    place. Used only by TIFFAppendToStrip() */
-    uint64_t tif_dataoff;       /* current offset for writing dir */
+    uint64_t tif_dataoff;       /* current offset for writing dir (IFD) */
     /* SubIFD support */
     uint16_t tif_nsubifd;   /* remaining subifds to write */
     uint64_t tif_subifdoff; /* offset for patching SubIFD link */


### PR DESCRIPTION
Cf https://gitlab.com/libtiff/libtiff/-/merge_requests/565
