### PR TITLE
Python utilities: do not display full traceback on OpenDS failures 

### DIFF
--- a/swig/python/gdal-utils/osgeo_utils/auxiliary/gdal_argparse.py
+++ b/swig/python/gdal-utils/osgeo_utils/auxiliary/gdal_argparse.py
@@ -228,6 +228,9 @@ class GDALScript(ABC):
         try:
             self.doit(**kwargs)
             return 0
+        except IOError as e:
+            print(str(e), file=sys.stderr)
+            return 1
         except Exception:
             import traceback
 

--- a/swig/python/gdal-utils/osgeo_utils/auxiliary/util.py
+++ b/swig/python/gdal-utils/osgeo_utils/auxiliary/util.py
@@ -241,9 +241,18 @@ class OpenDS:
     def __enter__(self) -> gdal.Dataset:
 
         if self.ds is None:
-            self.ds = self._open_ds(self.filename, *self.args, **self.kwargs)
+            try:
+                self.ds = self._open_ds(self.filename, *self.args, **self.kwargs)
+            except Exception as e:
+                if self.silent_fail:
+                    return None
+                msg = str(e)
+                prefix = f"{self.filename}: "
+                if msg.startswith(prefix):
+                    msg = msg[len(prefix) :]
+                raise IOError(f'Could not open file "{self.filename}": {msg}')
             if self.ds is None and not self.silent_fail:
-                raise IOError('could not open file "{}"'.format(self.filename))
+                raise IOError(f'Could not open file "{self.filename}"')
             self.own = True
         return self.ds
 


### PR DESCRIPTION
(fixes #9534)

Now
```shell
$ python swig/python/gdal-utils/scripts/gdal_calc.py --outfile out.tif -A foo.tif --calc "A"
```
just returns
```
Could not open file "foo.tif": No such file or directory
```
