### PR TITLE
Added modern Apple OS support

### DIFF
--- a/cmake/helpers/configure.cmake
+++ b/cmake/helpers/configure.cmake
@@ -257,7 +257,7 @@ else ()
   # available at build time.
   # This is also necessary for Mac Catalyst builds.
   # Cf https://lists.osgeo.org/pipermail/gdal-dev/2022-August/056174.html
-  if (${CMAKE_SYSTEM_NAME} MATCHES "iOS" OR ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+  if (${CMAKE_SYSTEM_NAME} MATCHES "iOS|visionOS|tvOS|watchOS|Darwin")
     set(VSI_FOPEN64 "fopen")
     set(VSI_FTRUNCATE64 "ftruncate")
     set(VSI_FTELL64 "ftell")


### PR DESCRIPTION
The commit fixes issue #9550.  Added new apple OS (visionOS, tvOS, watchOS) to cmake config generating rules. Tested compilation on:

* OS: MacOS 14.3.1
* Compiler: CMAKE 3.29.0 + Xcode 15.2
