### PR TITLE
LOS: Add intersection location parameters

### DIFF
--- a/alg/gdal_alg.h
+++ b/alg/gdal_alg.h
@@ -357,11 +357,10 @@ GDALDatasetH CPL_DLL GDALViewshedGenerate(
     void *pProgressArg, GDALViewshedOutputType heightMode,
     CSLConstList papszExtraOptions);
 
-bool CPL_DLL GDALIsLineOfSightVisible(const GDALRasterBandH, const int xA,
-                                      const int yA, const double zA,
-                                      const int xB, const int yB,
-                                      const double zB,
-                                      CSLConstList papszOptions);
+bool CPL_DLL GDALIsLineOfSightVisible(
+    const GDALRasterBandH, const int xA, const int yA, const double zA,
+    const int xB, const int yB, const double zB, int *xTerrainIntersection,
+    int *yTerrainIntersection, CSLConstList papszOptions);
 
 /************************************************************************/
 /*      Rasterizer API - geometries burned into GDAL raster.            */

--- a/alg/gdal_alg.h
+++ b/alg/gdal_alg.h
@@ -359,8 +359,8 @@ GDALDatasetH CPL_DLL GDALViewshedGenerate(
 
 bool CPL_DLL GDALIsLineOfSightVisible(
     const GDALRasterBandH, const int xA, const int yA, const double zA,
-    const int xB, const int yB, const double zB, int *xTerrainIntersection,
-    int *yTerrainIntersection, CSLConstList papszOptions);
+    const int xB, const int yB, const double zB, int *pnxTerrainIntersection,
+    int *pnyTerrainIntersection, CSLConstList papszOptions);
 
 /************************************************************************/
 /*      Rasterizer API - geometries burned into GDAL raster.            */

--- a/alg/los.cpp
+++ b/alg/los.cpp
@@ -162,27 +162,31 @@ static bool IsAboveTerrain(const GDALRasterBandH hBand, const int x,
  * For example, datasets referenced against geographic coordinate at high latitudes may have issues.
  *
  * @param hBand The band to read the DEM data from. This must NOT be null.
- * 
+ *
  * @param xA The X location (raster column) of the first point to check on the raster.
  *
  * @param yA The Y location (raster row) of the first point to check on the raster.
- * 
+ *
  * @param zA The Z location (height) of the first point to check.
- * 
+ *
  * @param xB The X location (raster column) of the second point to check on the raster.
  *
  * @param yB The Y location (raster row) of the second point to check on the raster.
- * 
+ *
  * @param zB The Z location (height) of the second point to check.
- * 
- * @param xTerrainIntersection The X location where the LOS line intersects with terrain,
- *        or nullptr if it does not intersect terrain. Currently ignored.
- * 
- * @param yTerrainIntersection The Y location where the LOS line intersects with terrain,
- *        or nullptr if it does not intersect terrain. Currently ignored.
- * 
+ *
+ * @param[out] pnxTerrainIntersection The X location where the LOS line
+ *             intersects with terrain, or nullptr if it does not intersect
+ *             terrain. Not implemented currently (*pnxTerrainIntersection
+ *             is set to -1)
+ *
+ * @param[out] pnyTerrainIntersection The Y location where the LOS line
+ *             intersects with terrain, or nullptr if it does not intersect
+ *             terrain. Not implemented currently (*pnyTerrainIntersection
+ *             is set to -1)
+ *
  * @param papszOptions Options for the line of sight algorithm (currently ignored).
- * 
+ *
  * @return True if the two points are within Line of Sight.
  *
  * @since GDAL 3.9
@@ -191,11 +195,17 @@ static bool IsAboveTerrain(const GDALRasterBandH hBand, const int x,
 bool GDALIsLineOfSightVisible(const GDALRasterBandH hBand, const int xA,
                               const int yA, const double zA, const int xB,
                               const int yB, const double zB,
-                              CPL_UNUSED int *xTerrainIntersection,
-                              CPL_UNUSED int *yTerrainIntersection,
+                              int *pnxTerrainIntersection,
+                              int *pnyTerrainIntersection,
                               CPL_UNUSED CSLConstList papszOptions)
 {
     VALIDATE_POINTER1(hBand, "GDALIsLineOfSightVisible", false);
+
+    if (pnxTerrainIntersection)
+        *pnxTerrainIntersection = -1;
+
+    if (pnyTerrainIntersection)
+        *pnyTerrainIntersection = -1;
 
     // Perform a preliminary check of the start and end points.
     if (!IsAboveTerrain(hBand, xA, yA, zA))

--- a/alg/los.cpp
+++ b/alg/los.cpp
@@ -175,6 +175,12 @@ static bool IsAboveTerrain(const GDALRasterBandH hBand, const int x,
  * 
  * @param zB The Z location (height) of the second point to check.
  * 
+ * @param xTerrainIntersection The X location where the LOS line intersects with terrain,
+ *        or nullptr if it does not intersect terrain. Currently ignored.
+ * 
+ * @param yTerrainIntersection The Y location where the LOS line intersects with terrain,
+ *        or nullptr if it does not intersect terrain. Currently ignored.
+ * 
  * @param papszOptions Options for the line of sight algorithm (currently ignored).
  * 
  * @return True if the two points are within Line of Sight.
@@ -185,6 +191,8 @@ static bool IsAboveTerrain(const GDALRasterBandH hBand, const int x,
 bool GDALIsLineOfSightVisible(const GDALRasterBandH hBand, const int xA,
                               const int yA, const double zA, const int xB,
                               const int yB, const double zB,
+                              CPL_UNUSED int *xTerrainIntersection,
+                              CPL_UNUSED int *yTerrainIntersection,
                               CPL_UNUSED CSLConstList papszOptions)
 {
     VALIDATE_POINTER1(hBand, "GDALIsLineOfSightVisible", false);

--- a/autotest/alg/los.py
+++ b/autotest/alg/los.py
@@ -37,10 +37,14 @@ def test_los_basic():
 
     mem_ds = gdal.GetDriverByName("MEM").Create("", 2, 1)
 
-    assert gdal.IsLineOfSightVisible(mem_ds.GetRasterBand(1), 0, 0, 1, 1, 0, 1)
-    assert gdal.IsLineOfSightVisible(mem_ds.GetRasterBand(1), 0, 0, 1, 0, 0, 1)
-    assert not gdal.IsLineOfSightVisible(mem_ds.GetRasterBand(1), 0, 0, -1, 1, 0, 1)
-    assert not gdal.IsLineOfSightVisible(mem_ds.GetRasterBand(1), 0, 0, 1, 1, 0, -1)
+    success, x, y = gdal.IsLineOfSightVisible(mem_ds.GetRasterBand(1), 0, 0, 1, 1, 0, 1)
+    assert success
+    assert x == -1
+    assert y == -1
+
+    assert gdal.IsLineOfSightVisible(mem_ds.GetRasterBand(1), 0, 0, 1, 0, 0, 1)[0]
+    assert not gdal.IsLineOfSightVisible(mem_ds.GetRasterBand(1), 0, 0, -1, 1, 0, 1)[0]
+    assert not gdal.IsLineOfSightVisible(mem_ds.GetRasterBand(1), 0, 0, 1, 1, 0, -1)[0]
 
     with pytest.raises(Exception, match="Received a NULL pointer"):
         assert gdal.IsLineOfSightVisible(None, 0, 0, 0, 0, 0, 0)

--- a/autotest/cpp/test_alg.cpp
+++ b/autotest/cpp/test_alg.cpp
@@ -301,14 +301,14 @@ TEST_F(test_alg, GDALIsLineOfSightVisible_single_point_dataset)
     ASSERT_TRUE(poDS->RasterIO(GF_Write, 0, 0, 1, 1, &val, 1, 1, GDT_Int8, 1,
                                nullptr, 0, 0, 0, nullptr) == CE_None);
     // Both points below terrain
-    EXPECT_FALSE(
-        GDALIsLineOfSightVisible(pBand, 0, 0, 0.0, 0, 0, 0.0, nullptr));
+    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 0, 0, 0.0, 0, 0, 0.0, nullptr,
+                                          nullptr, nullptr));
     // One point below terrain
-    EXPECT_FALSE(
-        GDALIsLineOfSightVisible(pBand, 0, 0, 0.0, 0, 0, 43.0, nullptr));
+    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 0, 0, 0.0, 0, 0, 43.0, nullptr,
+                                          nullptr, nullptr));
     // Both points above terrain
-    EXPECT_TRUE(
-        GDALIsLineOfSightVisible(pBand, 0, 0, 44.0, 0, 0, 43.0, nullptr));
+    EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, 0, 0, 44.0, 0, 0, 43.0, nullptr,
+                                         nullptr, nullptr));
 }
 
 // Test GDALIsLineOfSightVisible() with 10x10 default dataset
@@ -331,25 +331,25 @@ TEST_F(test_alg, GDALIsLineOfSightVisible_default_square_dataset)
     const int y2 = 2;
 
     // Both points are above terrain.
-    EXPECT_TRUE(
-        GDALIsLineOfSightVisible(pBand, x1, y1, 1.0, x2, y2, 1.0, nullptr));
+    EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, x1, y1, 1.0, x2, y2, 1.0,
+                                         nullptr, nullptr, nullptr));
     // Flip the order, same result.
-    EXPECT_TRUE(
-        GDALIsLineOfSightVisible(pBand, x2, y2, 1.0, x1, y1, 1.0, nullptr));
+    EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, x2, y2, 1.0, x1, y1, 1.0,
+                                         nullptr, nullptr, nullptr));
 
     // One point is below terrain.
-    EXPECT_FALSE(
-        GDALIsLineOfSightVisible(pBand, x1, y1, -1.0, x2, y2, 1.0, nullptr));
+    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, x1, y1, -1.0, x2, y2, 1.0,
+                                          nullptr, nullptr, nullptr));
     // Flip the order, same result.
-    EXPECT_FALSE(
-        GDALIsLineOfSightVisible(pBand, x2, y2, -1.0, x1, y1, 1.0, nullptr));
+    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, x2, y2, -1.0, x1, y1, 1.0,
+                                          nullptr, nullptr, nullptr));
 
     // Both points are below terrain.
-    EXPECT_FALSE(
-        GDALIsLineOfSightVisible(pBand, x1, y1, -1.0, x2, y2, -1.0, nullptr));
+    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, x1, y1, -1.0, x2, y2, -1.0,
+                                          nullptr, nullptr, nullptr));
     // Flip the order, same result.
-    EXPECT_FALSE(
-        GDALIsLineOfSightVisible(pBand, x2, y2, -1.0, x1, y1, -1.0, nullptr));
+    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, x2, y2, -1.0, x1, y1, -1.0,
+                                          nullptr, nullptr, nullptr));
 }
 
 // Test GDALIsLineOfSightVisible() through a mountain (not a unit test)
@@ -397,57 +397,57 @@ TEST_F(test_alg, GDALIsLineOfSightVisible_through_mountain)
     // Both points are just above terrain, with terrain between.
     EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, iMesaTopX, iMesaTopY, 222,
                                           iMesaBottomX, iMesaBottomY, 199,
-                                          nullptr));
+                                          nullptr, nullptr, nullptr));
     // Flip the order, same result.
     EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, iMesaBottomX, iMesaBottomY,
                                           199, iMesaTopX, iMesaTopY, 222,
-                                          nullptr));
+                                          nullptr, nullptr, nullptr));
 
     // Both points above terrain.
     EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, iMesaTopX, iMesaTopY, 322,
                                          iMesaBottomX, iMesaBottomY, 322,
-                                         nullptr));
+                                         nullptr, nullptr, nullptr));
 
     // Both points below terrain.
     EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, iMesaTopX, iMesaTopY, 0,
                                           iMesaBottomX, iMesaBottomY, 0,
-                                          nullptr));
+                                          nullptr, nullptr, nullptr));
 
     // Test negative slope bresenham diagonals across the whole raster.
     // Both high above terrain.
-    EXPECT_TRUE(
-        GDALIsLineOfSightVisible(pBand, 0, 0, 460, 120, 120, 460, nullptr));
+    EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, 0, 0, 460, 120, 120, 460,
+                                         nullptr, nullptr, nullptr));
     // Both heights are 1m above in the corners, but middle terrain violates LOS.
-    EXPECT_FALSE(
-        GDALIsLineOfSightVisible(pBand, 0, 0, 295, 120, 120, 183, nullptr));
+    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 0, 0, 295, 120, 120, 183,
+                                          nullptr, nullptr, nullptr));
 
     // Test positive slope bresenham diagnoals across the whole raster.
     // Both high above terrain.
-    EXPECT_TRUE(
-        GDALIsLineOfSightVisible(pBand, 0, 120, 460, 120, 0, 460, nullptr));
+    EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, 0, 120, 460, 120, 0, 460,
+                                         nullptr, nullptr, nullptr));
     // Both heights are 1m above in the corners, but middle terrain violates LOS.
-    EXPECT_FALSE(
-        GDALIsLineOfSightVisible(pBand, 0, 120, 203, 120, 0, 247, nullptr));
+    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 0, 120, 203, 120, 0, 247,
+                                          nullptr, nullptr, nullptr));
 
     // Vertical line tests with hill between two points, in both directions.
-    EXPECT_FALSE(
-        GDALIsLineOfSightVisible(pBand, 83, 111, 154, 83, 117, 198, nullptr));
-    EXPECT_FALSE(
-        GDALIsLineOfSightVisible(pBand, 83, 117, 198, 83, 111, 154, nullptr));
-    EXPECT_TRUE(
-        GDALIsLineOfSightVisible(pBand, 83, 111, 460, 83, 117, 460, nullptr));
-    EXPECT_TRUE(
-        GDALIsLineOfSightVisible(pBand, 83, 117, 460, 83, 111, 460, nullptr));
+    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 83, 111, 154, 83, 117, 198,
+                                          nullptr, nullptr, nullptr));
+    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 83, 117, 198, 83, 111, 154,
+                                          nullptr, nullptr, nullptr));
+    EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, 83, 111, 460, 83, 117, 460,
+                                         nullptr, nullptr, nullptr));
+    EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, 83, 117, 460, 83, 111, 460,
+                                         nullptr, nullptr, nullptr));
 
     // Horizontal line tests with hill between two points, in both directions.
-    EXPECT_FALSE(
-        GDALIsLineOfSightVisible(pBand, 75, 115, 192, 89, 115, 191, nullptr));
-    EXPECT_FALSE(
-        GDALIsLineOfSightVisible(pBand, 89, 115, 191, 75, 115, 192, nullptr));
-    EXPECT_TRUE(
-        GDALIsLineOfSightVisible(pBand, 75, 115, 460, 89, 115, 460, nullptr));
-    EXPECT_TRUE(
-        GDALIsLineOfSightVisible(pBand, 89, 115, 460, 75, 115, 460, nullptr));
+    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 75, 115, 192, 89, 115, 191,
+                                          nullptr, nullptr, nullptr));
+    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 89, 115, 191, 75, 115, 192,
+                                          nullptr, nullptr, nullptr));
+    EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, 75, 115, 460, 89, 115, 460,
+                                         nullptr, nullptr, nullptr));
+    EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, 89, 115, 460, 75, 115, 460,
+                                         nullptr, nullptr, nullptr));
 }
 
 }  // namespace

--- a/swig/include/Operations.i
+++ b/swig/include/Operations.i
@@ -647,9 +647,10 @@ GDALDatasetShadow *ViewshedGenerate( GDALRasterBandShadow *srcBand,
 bool IsLineOfSightVisible(GDALRasterBandShadow *band,
                           int xA, int yA, double zA,
                           int xB, int yB, double zB,
+                          int *xTerrainIntersection, int *yTerrainIntersection,
                           char** options = NULL)
 {
-    return GDALIsLineOfSightVisible(band, xA, yA, zA, xB, yB, zB, options);
+    return GDALIsLineOfSightVisible(band, xA, yA, zA, xB, yB, zB, xTerrainIntersection, yTerrainIntersection, options);
 }
 %}
 %clear GDALRasterBandShadow *band;

--- a/swig/include/Operations.i
+++ b/swig/include/Operations.i
@@ -639,6 +639,21 @@ GDALDatasetShadow *ViewshedGenerate( GDALRasterBandShadow *srcBand,
 /*                         IsLineOfSightVisible()                       */
 /************************************************************************/
 
+#ifdef SWIGPYTHON
+%feature( "kwargs" ) IsLineOfSightVisible;
+%apply Pointer NONNULL {GDALRasterBandShadow *band};
+%inline %{
+void IsLineOfSightVisible(GDALRasterBandShadow *band,
+                          int xA, int yA, double zA,
+                          int xB, int yB, double zB,
+                          bool *pbVisible, int *pnXIntersection, int *pnYIntersection,
+                          char** options = NULL)
+{
+    *pbVisible = GDALIsLineOfSightVisible(band, xA, yA, zA, xB, yB, zB, pnXIntersection, pnYIntersection, options);
+}
+%}
+%clear GDALRasterBandShadow *band;
+#else
 #ifndef SWIGJAVA
 %feature( "kwargs" ) IsLineOfSightVisible;
 #endif
@@ -647,13 +662,13 @@ GDALDatasetShadow *ViewshedGenerate( GDALRasterBandShadow *srcBand,
 bool IsLineOfSightVisible(GDALRasterBandShadow *band,
                           int xA, int yA, double zA,
                           int xB, int yB, double zB,
-                          int *xTerrainIntersection, int *yTerrainIntersection,
                           char** options = NULL)
 {
-    return GDALIsLineOfSightVisible(band, xA, yA, zA, xB, yB, zB, xTerrainIntersection, yTerrainIntersection, options);
+    return GDALIsLineOfSightVisible(band, xA, yA, zA, xB, yB, zB, NULL, NULL, options);
 }
 %}
 %clear GDALRasterBandShadow *band;
+#endif
 
 /************************************************************************/
 /*                        AutoCreateWarpedVRT()                         */

--- a/swig/include/python/docs/gdal_operations_docs.i
+++ b/swig/include/python/docs/gdal_operations_docs.i
@@ -24,6 +24,12 @@ yB : int
     The Y location (raster row) of the second point to check on the raster.
 zB : float
     The Z location (height) of the second point to check.
+xTerrainIntersection : int
+    The X location where the LOS line intersects with terrain, or nullptr if it does not
+    intersect terrain. Currently ignored.
+yTerrainIntersection : int
+    The Y location where the LOS line intersects with terrain, or nullptr if it does not
+    intersect terrain. Currently ignored.
 options : dict/list, optional
     A dict or list of name=value of options for the line of sight algorithm (currently ignored).
 

--- a/swig/include/python/docs/gdal_operations_docs.i
+++ b/swig/include/python/docs/gdal_operations_docs.i
@@ -24,17 +24,13 @@ yB : int
     The Y location (raster row) of the second point to check on the raster.
 zB : float
     The Z location (height) of the second point to check.
-xTerrainIntersection : int
-    The X location where the LOS line intersects with terrain, or nullptr if it does not
-    intersect terrain. Currently ignored.
-yTerrainIntersection : int
-    The Y location where the LOS line intersects with terrain, or nullptr if it does not
-    intersect terrain. Currently ignored.
 options : dict/list, optional
     A dict or list of name=value of options for the line of sight algorithm (currently ignored).
 
 Returns
 -------
-bool
-    True if the two points are within Line of Sight.
+(bool, int, int)
+    First value of tuple is True if the two points are within Line of Sight.
+    Second value is the X location where the LOS line intersects with terrain (will be set in the future, currently set to -1).
+    Third value is the Y location where the LOS line intersects with terrain (will be set in the future, currently set to -1).
 ";

--- a/swig/include/python/typemaps_python.i
+++ b/swig/include/python/typemaps_python.i
@@ -3449,3 +3449,22 @@ OBJECT_LIST_INPUT(GDALMDArrayHS);
   /* %typemap(freearg) (int nUsages, GDALRATFieldUsage *paeUsages)*/
   CPLFree( $2 );
 }
+
+
+%typemap(in,numinputs=0) (bool *pbVisible, int *pnXIntersection, int *pnYIntersection) ( bool visible = 0, int nxintersection = 0, int nyintersection = 0  )
+{
+  /* %typemap(in) (bool *pbVisible, int *pnXIntersection, int *pnYIntersection) */
+  $1 = &visible;
+  $2 = &nxintersection;
+  $3 = &nyintersection;
+}
+
+%typemap(argout) (bool *pbVisible, int *pnXIntersection, int *pnYIntersection)
+{
+   /* %typemap(argout) (bool *pbVisible, int *pnXIntersection, int *pnYIntersection)  */
+  PyObject *r = PyTuple_New( 3 );
+  PyTuple_SetItem( r, 0, PyBool_FromLong(*$1) );
+  PyTuple_SetItem( r, 1, PyLong_FromLong(*$2) );
+  PyTuple_SetItem( r, 2, PyLong_FromLong(*$3) );
+  $result = t_output_helper($result,r);
+}


### PR DESCRIPTION




## What does this PR do?

* Lock in ABI before release to support x and y terrain intersection locations
* Implementation will come later
* Attempts to also add in the SWIG binding docs (Please verify, particularly the param types for the pointer args)

## What are related issues/pull requests?

#9562 

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Verify there isn't anything special for pointer parameters in the python swig bindings (perhaps it should be a python callback...)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Ubuntu 22
* Compiler: G++11
