### PR TITLE
Parquet/Arrow: add support for GeoArrow (struct/separate) encoding (GeoParquet 1.1)

### DIFF
--- a/autotest/ogr/ogr_arrow.py
+++ b/autotest/ogr/ogr_arrow.py
@@ -112,7 +112,7 @@ def test_ogr_arrow_read_all_geom_types(filename_prefix, dim):
     ],
 )
 @pytest.mark.parametrize("dim", ["", "_z", "_m", "_zm"])
-@pytest.mark.parametrize("encoding", ["WKB", "WKT", "GEOARROW"])
+@pytest.mark.parametrize("encoding", ["WKB", "WKT", "GEOARROW", "GEOARROW_INTERLEAVED"])
 def test_ogr_arrow_write_all_geom_types(filename_prefix, dim, encoding):
 
     test_filename = (
@@ -124,7 +124,7 @@ def test_ogr_arrow_write_all_geom_types(filename_prefix, dim, encoding):
     ds_ref = ogr.Open(test_filename)
     lyr_ref = ds_ref.GetLayer(0)
 
-    if encoding != "GEOARROW" or lyr_ref.GetGeomType() not in (
+    if not encoding.startswith("GEOARROW") or lyr_ref.GetGeomType() not in (
         ogr.wkbGeometryCollection,
         ogr.wkbGeometryCollection25D,
         ogr.wkbGeometryCollectionM,

--- a/autotest/pymod/ogrtest.py
+++ b/autotest/pymod/ogrtest.py
@@ -172,6 +172,14 @@ def check_feature_geometry(
         if ogr.GT_Flatten(actual.GetGeometryType()) == ogr.wkbPoint:
             count = 1
 
+            # Point Empty is often encoded with NaN values, hence do not attempt
+            # X/Y comparisons
+            if expected.IsEmpty():
+                assert actual.IsEmpty()
+                return
+            else:
+                assert not actual.IsEmpty()
+
         for i in range(count):
             actual_pt = [actual.GetX(i), actual.GetY(i)]
             expected_pt = [expected.GetX(i), expected.GetY(i)]

--- a/doc/source/drivers/vector/arrow.rst
+++ b/doc/source/drivers/vector/arrow.rst
@@ -68,10 +68,17 @@ Layer creation options
      "/vsistdout/" or its extension is ".arrows", in which case STREAM is used.
 
 - .. lco:: GEOMETRY_ENCODING
-     :choices: GEOARROW, WKB, WKT
+     :choices: GEOARROW, WKB, WKT, GEOARROW_INTERLEAVED
      :default: GEOARROW
 
      Geometry encoding.
+     As of GDAL 3.9, GEOARROW uses the GeoArrow "struct" based
+     encodings (where points are modeled as a struct field with a x and y subfield,
+     lines are modeled as a list of such points, etc.).
+     The GEOARROW_INTERLEAVED option has been renamed in GDAL 3.9 from what was
+     named GEOARROW in previous versions, and uses an encoding where points uses
+     a FixedSizedList of (x,y), lines a variable-size list of such
+     FixedSizedList of points, etc.
 
 - .. lco:: BATCH_SIZE
      :choices: <integer>

--- a/doc/source/drivers/vector/parquet.rst
+++ b/doc/source/drivers/vector/parquet.rst
@@ -128,7 +128,10 @@ Layer creation options
      :since: 3.9
 
      Whether to write xmin/ymin/xmax/ymax columns with the bounding box of
-     geometries.
+     geometries. Writing the geometry bounding box may help applications to
+     perform faster spatial filtering. Writing a geometry bounding box is less
+     necessary for the GeoArrow geometry encoding than for the default WKB, as
+     implementations may be able to directly use the geometry columns.
 
 - .. lco:: SORT_BY_BBOX
      :choices: YES, NO

--- a/doc/source/drivers/vector/parquet.rst
+++ b/doc/source/drivers/vector/parquet.rst
@@ -16,9 +16,8 @@ Parquet is available in multiple languages including Java, C++, Python, etc..."
 
 This driver also supports geometry columns using the GeoParquet specification.
 
-.. note:: The driver should be considered experimental as the GeoParquet specification is not finalized yet.
-
-The GeoParquet 1.0.0 specification is supported since GDAL 3.8.0
+The GeoParquet 1.0.0 specification is supported since GDAL 3.8.0.
+The GeoParquet 1.1.0 specification is supported since GDAL 3.9.0.
 
 Driver capabilities
 -------------------
@@ -67,13 +66,21 @@ Layer creation options
       Defaults to SNAPPY when available, otherwise NONE.
 
 - .. lco:: GEOMETRY_ENCODING
-     :choices: WKB, WKT, GEOARROW
+     :choices: WKB, WKT, GEOARROW, GEOARROW_INTERLEAVED
      :default: WKB
 
      Geometry encoding.
-     Other encodings (WKT and GEOARROW) are *not* allowed by the GeoParquet
-     specification, but are handled as an extension, for symmetry with the Arrow
-     driver.
+     WKB is the default and recommended choice for maximal interoperability.
+     WKT is *not* allowed by the GeoParquet specification, but are handled as
+     an extension.
+     As of GDAL 3.9, GEOARROW uses the GeoParquet 1.1 GeoArrow "struct" based
+     encodings (where points are modeled as a struct field with a x and y subfield,
+     lines are modeled as a list of such points, etc.).
+     The GEOARROW_INTERLEAVED option has been renamed in GDAL 3.9 from what was
+     named GEOARROW in previous versions, and uses an encoding where points uses
+     a FixedSizedList of (x,y), lines a variable-size list of such
+     FixedSizedList of points, etc. This GEOARROW_INTERLEAVED encoding is not
+     part of the official GeoParquet specification, and its use is not encouraged.
 
 - .. lco:: ROW_GROUP_SIZE
      :choices: <integer>

--- a/ogr/ogrsf_frmts/arrow/ogrfeatherdriver.cpp
+++ b/ogr/ogrsf_frmts/arrow/ogrfeatherdriver.cpp
@@ -370,10 +370,14 @@ void OGRFeatherDriver::InitMetadata()
         CPLAddXMLAttributeAndValue(psOption, "description",
                                    "Encoding of geometry columns");
         CPLAddXMLAttributeAndValue(psOption, "default", "GEOARROW");
-        for (const char *pszEncoding : {"GEOARROW", "WKB", "WKT"})
+        for (const char *pszEncoding :
+             {"GEOARROW", "GEOARROW_INTERLEAVED", "WKB", "WKT"})
         {
             auto poValueNode = CPLCreateXMLNode(psOption, CXT_Element, "Value");
             CPLCreateXMLNode(poValueNode, CXT_Text, pszEncoding);
+            if (EQUAL(pszEncoding, "GEOARROW"))
+                CPLAddXMLAttributeAndValue(poValueNode, "alias",
+                                           "GEOARROW_STRUCT");
         }
     }
 

--- a/ogr/ogrsf_frmts/arrow/ogrfeatherwriterlayer.cpp
+++ b/ogr/ogrsf_frmts/arrow/ogrfeatherwriterlayer.cpp
@@ -97,7 +97,7 @@ bool OGRFeatherWriterLayer::SetOptions(const std::string &osFilename,
 
     const char *pszGeomEncoding =
         CSLFetchNameValue(papszOptions, "GEOMETRY_ENCODING");
-    m_eGeomEncoding = OGRArrowGeomEncoding::GEOARROW_GENERIC;
+    m_eGeomEncoding = OGRArrowGeomEncoding::GEOARROW_FSL_GENERIC;
     if (pszGeomEncoding)
     {
         if (EQUAL(pszGeomEncoding, "WKB"))
@@ -105,7 +105,7 @@ bool OGRFeatherWriterLayer::SetOptions(const std::string &osFilename,
         else if (EQUAL(pszGeomEncoding, "WKT"))
             m_eGeomEncoding = OGRArrowGeomEncoding::WKT;
         else if (EQUAL(pszGeomEncoding, "GEOARROW"))
-            m_eGeomEncoding = OGRArrowGeomEncoding::GEOARROW_GENERIC;
+            m_eGeomEncoding = OGRArrowGeomEncoding::GEOARROW_FSL_GENERIC;
         else
         {
             CPLError(CE_Failure, CPLE_NotSupported,
@@ -129,10 +129,11 @@ bool OGRFeatherWriterLayer::SetOptions(const std::string &osFilename,
 
         m_poFeatureDefn->SetGeomType(eGType);
         auto eGeomEncoding = m_eGeomEncoding;
-        if (eGeomEncoding == OGRArrowGeomEncoding::GEOARROW_GENERIC)
+        if (eGeomEncoding == OGRArrowGeomEncoding::GEOARROW_FSL_GENERIC)
         {
-            eGeomEncoding = GetPreciseArrowGeomEncoding(eGType);
-            if (eGeomEncoding == OGRArrowGeomEncoding::GEOARROW_GENERIC)
+            const auto eEncodingType = eGeomEncoding;
+            eGeomEncoding = GetPreciseArrowGeomEncoding(eEncodingType, eGType);
+            if (eGeomEncoding == eEncodingType)
                 return false;
         }
         m_aeGeomEncoding.push_back(eGeomEncoding);

--- a/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
+++ b/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
@@ -41,13 +41,24 @@ enum class OGRArrowGeomEncoding
 {
     WKB,
     WKT,
-    GEOARROW_GENERIC,  // only used by OGRArrowWriterLayer::m_eGeomEncoding
-    GEOARROW_POINT,
-    GEOARROW_LINESTRING,
-    GEOARROW_POLYGON,
-    GEOARROW_MULTIPOINT,
-    GEOARROW_MULTILINESTRING,
-    GEOARROW_MULTIPOLYGON,
+
+    // F(ixed) S(ize) L(ist) of (x,y[,z][,m]) values / Interleaved layout
+    GEOARROW_FSL_GENERIC,  // only used by OGRArrowWriterLayer::m_eGeomEncoding
+    GEOARROW_FSL_POINT,
+    GEOARROW_FSL_LINESTRING,
+    GEOARROW_FSL_POLYGON,
+    GEOARROW_FSL_MULTIPOINT,
+    GEOARROW_FSL_MULTILINESTRING,
+    GEOARROW_FSL_MULTIPOLYGON,
+
+    // Struct of (x,y,[,z][,m])
+    GEOARROW_STRUCT_GENERIC,  // only used by OGRArrowWriterLayer::m_eGeomEncoding
+    GEOARROW_STRUCT_POINT,
+    GEOARROW_STRUCT_LINESTRING,
+    GEOARROW_STRUCT_POLYGON,
+    GEOARROW_STRUCT_MULTIPOINT,
+    GEOARROW_STRUCT_MULTILINESTRING,
+    GEOARROW_STRUCT_MULTIPOLYGON,
 };
 
 /************************************************************************/
@@ -340,6 +351,10 @@ class OGRArrowWriterLayer CPL_NON_FINAL : public OGRLayer
     std::vector<OGRArrowGeomEncoding> m_aeGeomEncoding{};
     int m_nWKTCoordinatePrecision = -1;
 
+    //! Base struct data type for GeoArrow struct geometry columns.
+    // Constraint: if not empty, m_apoBaseStructGeomType.size() == m_poFeatureDefn->GetGeomFieldCount()
+    std::vector<std::shared_ptr<arrow::DataType>> m_apoBaseStructGeomType{};
+
     //! Whether to use a struct field with the values of the bounding box
     // of the geometries. Used by Parquet.
     bool m_bWriteBBoxStruct = false;
@@ -376,7 +391,8 @@ class OGRArrowWriterLayer CPL_NON_FINAL : public OGRLayer
         m_oSetWrittenGeometryTypes{};  // size: GetGeomFieldCount()
 
     static OGRArrowGeomEncoding
-    GetPreciseArrowGeomEncoding(OGRwkbGeometryType eGType);
+    GetPreciseArrowGeomEncoding(OGRArrowGeomEncoding eEncodingType,
+                                OGRwkbGeometryType eGType);
     static const char *
     GetGeomEncodingAsString(OGRArrowGeomEncoding eGeomEncoding,
                             bool bForParquetGeo);

--- a/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
+++ b/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
@@ -246,6 +246,11 @@ class OGRArrowLayer CPL_NON_FINAL
     int GetNextArrowArray(struct ArrowArrayStream *,
                           struct ArrowArray *out) override;
 
+    virtual void IncrFeatureIdx()
+    {
+        ++m_nFeatureIdx;
+    }
+
   public:
     virtual ~OGRArrowLayer() override;
 

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
@@ -836,6 +836,74 @@ static bool IsListOfPointType(const std::shared_ptr<arrow::DataType> &type,
 }
 
 /************************************************************************/
+/*                         IsPointStructType()                          */
+/************************************************************************/
+
+static bool IsPointStructType(const std::shared_ptr<arrow::DataType> &type,
+                              bool &bHasZOut, bool &bHasMOut)
+{
+    if (type->id() != arrow::Type::STRUCT)
+        return false;
+    auto poStructType = std::static_pointer_cast<arrow::StructType>(type);
+    const int nNumFields = poStructType->num_fields();
+    if (nNumFields < 2 || nNumFields > 4)
+        return false;
+    bHasZOut = false;
+    bHasMOut = false;
+    const auto poFieldX = poStructType->field(0);
+    if (poFieldX->name() != "x" ||
+        poFieldX->type()->id() != arrow::Type::DOUBLE)
+        return false;
+    const auto poFieldY = poStructType->field(1);
+    if (poFieldY->name() != "y" ||
+        poFieldY->type()->id() != arrow::Type::DOUBLE)
+        return false;
+    if (nNumFields == 2)
+        return true;
+    const auto poField2 = poStructType->field(2);
+    if (poField2->type()->id() != arrow::Type::DOUBLE)
+        return false;
+    if (poField2->name() == "z")
+    {
+        bHasZOut = true;
+        if (nNumFields == 4)
+        {
+            const auto poField3 = poStructType->field(3);
+            if (poField3->name() != "m" ||
+                poField3->type()->id() != arrow::Type::DOUBLE)
+                return false;
+            bHasMOut = true;
+        }
+    }
+    else if (poField2->name() == "m")
+    {
+        bHasMOut = true;
+    }
+    else
+    {
+        return false;
+    }
+    return true;
+}
+
+/************************************************************************/
+/*                    IsListOfPointStructType()                         */
+/************************************************************************/
+
+static bool
+IsListOfPointStructType(const std::shared_ptr<arrow::DataType> &type,
+                        int nDepth, bool &bHasZOut, bool &bHasMOut)
+{
+    if (type->id() != arrow::Type::LIST)
+        return false;
+    auto poListType = std::static_pointer_cast<arrow::ListType>(type);
+    return nDepth == 1
+               ? IsPointStructType(poListType->value_type(), bHasZOut, bHasMOut)
+               : IsListOfPointStructType(poListType->value_type(), nDepth - 1,
+                                         bHasZOut, bHasMOut);
+}
+
+/************************************************************************/
 /*                        IsValidGeometryEncoding()                     */
 /************************************************************************/
 
@@ -871,7 +939,7 @@ inline bool OGRArrowLayer::IsValidGeometryEncoding(
             CPLError(CE_Warning, CPLE_AppDefined,
                      "Geometry column %s has a non String type: %s. "
                      "Handling it as a regular field",
-                     fieldName.c_str(), fieldType->name().c_str());
+                     fieldName.c_str(), fieldType->ToString().c_str());
             return false;
         }
         eOGRArrowGeomEncodingOut = OGRArrowGeomEncoding::WKT;
@@ -891,7 +959,7 @@ inline bool OGRArrowLayer::IsValidGeometryEncoding(
             CPLError(CE_Warning, CPLE_AppDefined,
                      "Geometry column %s has a non Binary type: %s. "
                      "Handling it as a regular field",
-                     fieldName.c_str(), fieldType->name().c_str());
+                     fieldName.c_str(), fieldType->ToString().c_str());
             return false;
         }
         eOGRArrowGeomEncodingOut = OGRArrowGeomEncoding::WKB;
@@ -900,108 +968,168 @@ inline bool OGRArrowLayer::IsValidGeometryEncoding(
 
     bool bHasZ = false;
     bool bHasM = false;
-    if (osEncoding == "geoarrow.point")
+    if (osEncoding == "geoarrow.point" || osEncoding == "point")
     {
-        if (!IsPointType(fieldType, bHasZ, bHasM))
+        if (IsPointType(fieldType, bHasZ, bHasM))
+        {
+            eOGRArrowGeomEncodingOut = OGRArrowGeomEncoding::GEOARROW_FSL_POINT;
+        }
+        else if (IsPointStructType(fieldType, bHasZ, bHasM))
+        {
+            eOGRArrowGeomEncodingOut =
+                OGRArrowGeomEncoding::GEOARROW_STRUCT_POINT;
+        }
+        else
         {
             CPLError(CE_Warning, CPLE_AppDefined,
                      "Geometry column %s has a type != fixed_size_list<xy: "
-                     "double>[2]>: %s. "
+                     "double>[2]> and != struct<x: double, y: double>: %s. "
                      "Handling it as a regular field",
                      fieldName.c_str(), fieldType->name().c_str());
             return false;
         }
         eGeomTypeOut = OGR_GT_SetModifier(wkbPoint, static_cast<int>(bHasZ),
                                           static_cast<int>(bHasM));
-        eOGRArrowGeomEncodingOut = OGRArrowGeomEncoding::GEOARROW_POINT;
         return true;
     }
 
-    if (osEncoding == "geoarrow.linestring")
+    else if (osEncoding == "geoarrow.linestring" || osEncoding == "linestring")
     {
-        if (!IsListOfPointType(fieldType, 1, bHasZ, bHasM))
+        if (IsListOfPointType(fieldType, 1, bHasZ, bHasM))
+        {
+            eOGRArrowGeomEncodingOut =
+                OGRArrowGeomEncoding::GEOARROW_FSL_LINESTRING;
+        }
+        else if (IsListOfPointStructType(fieldType, 1, bHasZ, bHasM))
+        {
+            eOGRArrowGeomEncodingOut =
+                OGRArrowGeomEncoding::GEOARROW_STRUCT_LINESTRING;
+        }
+        else
         {
             CPLError(CE_Warning, CPLE_AppDefined,
                      "Geometry column %s has a type != fixed_size_list<xy: "
-                     "double>[2]>: %s. "
+                     "double>[2]> and != list<element: struct<x: double, y: "
+                     "double>>: %s. "
                      "Handling it as a regular field",
-                     fieldName.c_str(), fieldType->name().c_str());
+                     fieldName.c_str(), fieldType->ToString().c_str());
             return false;
         }
         eGeomTypeOut = OGR_GT_SetModifier(
             wkbLineString, static_cast<int>(bHasZ), static_cast<int>(bHasM));
-        eOGRArrowGeomEncodingOut = OGRArrowGeomEncoding::GEOARROW_LINESTRING;
         return true;
     }
 
-    if (osEncoding == "geoarrow.polygon")
+    else if (osEncoding == "geoarrow.polygon" || osEncoding == "polygon")
     {
-        if (!IsListOfPointType(fieldType, 2, bHasZ, bHasM))
+        if (IsListOfPointType(fieldType, 2, bHasZ, bHasM))
+        {
+            eOGRArrowGeomEncodingOut =
+                OGRArrowGeomEncoding::GEOARROW_FSL_POLYGON;
+        }
+        else if (IsListOfPointStructType(fieldType, 2, bHasZ, bHasM))
+        {
+            eOGRArrowGeomEncodingOut =
+                OGRArrowGeomEncoding::GEOARROW_STRUCT_POLYGON;
+        }
+        else
         {
             CPLError(CE_Warning, CPLE_AppDefined,
                      "Geometry column %s has a type != list<vertices: "
-                     "fixed_size_list<xy: double>[2]>>: %s. "
+                     "fixed_size_list<xy: double>[2]>> and != list<element: "
+                     "list<element: struct<x: double, y: double>>>: %s. "
                      "Handling it as a regular field",
-                     fieldName.c_str(), fieldType->name().c_str());
+                     fieldName.c_str(), fieldType->ToString().c_str());
             return false;
         }
         eGeomTypeOut = OGR_GT_SetModifier(wkbPolygon, static_cast<int>(bHasZ),
                                           static_cast<int>(bHasM));
-        eOGRArrowGeomEncodingOut = OGRArrowGeomEncoding::GEOARROW_POLYGON;
         return true;
     }
 
-    if (osEncoding == "geoarrow.multipoint")
+    else if (osEncoding == "geoarrow.multipoint" || osEncoding == "multipoint")
     {
-        if (!IsListOfPointType(fieldType, 1, bHasZ, bHasM))
+        if (IsListOfPointType(fieldType, 1, bHasZ, bHasM))
+        {
+            eOGRArrowGeomEncodingOut =
+                OGRArrowGeomEncoding::GEOARROW_FSL_MULTIPOINT;
+        }
+        else if (IsListOfPointStructType(fieldType, 1, bHasZ, bHasM))
+        {
+            eOGRArrowGeomEncodingOut =
+                OGRArrowGeomEncoding::GEOARROW_STRUCT_MULTIPOINT;
+        }
+        else
         {
             CPLError(CE_Warning, CPLE_AppDefined,
                      "Geometry column %s has a type != fixed_size_list<xy: "
-                     "double>[2]>: %s. "
+                     "double>[2]> and != list<element: struct<x: double, y: "
+                     "double>>: %s. "
                      "Handling it as a regular field",
-                     fieldName.c_str(), fieldType->name().c_str());
+                     fieldName.c_str(), fieldType->ToString().c_str());
             return false;
         }
         eGeomTypeOut = OGR_GT_SetModifier(
             wkbMultiPoint, static_cast<int>(bHasZ), static_cast<int>(bHasM));
-        eOGRArrowGeomEncodingOut = OGRArrowGeomEncoding::GEOARROW_MULTIPOINT;
         return true;
     }
 
-    if (osEncoding == "geoarrow.multilinestring")
+    else if (osEncoding == "geoarrow.multilinestring" ||
+             osEncoding == "multilinestring")
     {
-        if (!IsListOfPointType(fieldType, 2, bHasZ, bHasM))
+        if (IsListOfPointType(fieldType, 2, bHasZ, bHasM))
+        {
+            eOGRArrowGeomEncodingOut =
+                OGRArrowGeomEncoding::GEOARROW_FSL_MULTILINESTRING;
+        }
+        else if (IsListOfPointStructType(fieldType, 2, bHasZ, bHasM))
+        {
+            eOGRArrowGeomEncodingOut =
+                OGRArrowGeomEncoding::GEOARROW_STRUCT_MULTILINESTRING;
+        }
+        else
         {
             CPLError(CE_Warning, CPLE_AppDefined,
                      "Geometry column %s has a type != list<vertices: "
-                     "fixed_size_list<xy: double>[2]>>: %s. "
+                     "fixed_size_list<xy: double>[2]>> and != list<element: "
+                     "list<element: struct<x: double, y: double>>>: %s. "
                      "Handling it as a regular field",
-                     fieldName.c_str(), fieldType->name().c_str());
+                     fieldName.c_str(), fieldType->ToString().c_str());
             return false;
         }
         eGeomTypeOut =
             OGR_GT_SetModifier(wkbMultiLineString, static_cast<int>(bHasZ),
                                static_cast<int>(bHasM));
-        eOGRArrowGeomEncodingOut =
-            OGRArrowGeomEncoding::GEOARROW_MULTILINESTRING;
         return true;
     }
 
-    if (osEncoding == "geoarrow.multipolygon")
+    else if (osEncoding == "geoarrow.multipolygon" ||
+             osEncoding == "multipolygon")
     {
-        if (!IsListOfPointType(fieldType, 3, bHasZ, bHasM))
+        if (IsListOfPointType(fieldType, 3, bHasZ, bHasM))
+        {
+            eOGRArrowGeomEncodingOut =
+                OGRArrowGeomEncoding::GEOARROW_FSL_MULTIPOLYGON;
+        }
+        else if (IsListOfPointStructType(fieldType, 3, bHasZ, bHasM))
+        {
+            eOGRArrowGeomEncodingOut =
+                OGRArrowGeomEncoding::GEOARROW_STRUCT_MULTIPOLYGON;
+        }
+        else
         {
             CPLError(
                 CE_Warning, CPLE_AppDefined,
                 "Geometry column %s has a type != list<polygons: list<rings: "
-                "list<vertices: fixed_size_list<xy: double>[2]>>>: %s. "
+                "list<vertices: fixed_size_list<xy: double>[2]>>> and != "
+                "list<element: list<element: list<element: struct<x: double, "
+                "y: double>>>>: %s. "
                 "Handling it as a regular field",
-                fieldName.c_str(), fieldType->name().c_str());
+                fieldName.c_str(), fieldType->ToString().c_str());
             return false;
         }
         eGeomTypeOut = OGR_GT_SetModifier(
             wkbMultiPolygon, static_cast<int>(bHasZ), static_cast<int>(bHasM));
-        eOGRArrowGeomEncodingOut = OGRArrowGeomEncoding::GEOARROW_MULTIPOLYGON;
         return true;
     }
 
@@ -1653,9 +1781,8 @@ static void ReadList(OGRFeature *poFeature, int i, int64_t nIdxInArray,
 /************************************************************************/
 
 template <bool bHasZ, bool bHasM, int nDim>
-void SetPointsOfLine(OGRLineString *poLS,
-                     const std::shared_ptr<arrow::DoubleArray> &pointValues,
-                     int pointOffset, int numPoints)
+void SetPointsOfLine(OGRLineString *poLS, const arrow::DoubleArray *pointValues,
+                     size_t pointOffset, int numPoints)
 {
     if (!bHasZ && !bHasM)
     {
@@ -1670,9 +1797,9 @@ void SetPointsOfLine(OGRLineString *poLS,
     poLS->setNumPoints(numPoints, FALSE);
     for (int k = 0; k < numPoints; k++)
     {
-        if (bHasZ)
+        if constexpr (bHasZ)
         {
-            if (bHasM)
+            if constexpr (bHasM)
             {
                 poLS->setPoint(k, pointValues->Value(pointOffset + nDim * k),
                                pointValues->Value(pointOffset + nDim * k + 1),
@@ -1695,9 +1822,8 @@ void SetPointsOfLine(OGRLineString *poLS,
     }
 }
 
-typedef void (*SetPointsOfLineType)(OGRLineString *,
-                                    const std::shared_ptr<arrow::DoubleArray> &,
-                                    int, int);
+typedef void (*SetPointsOfLineType)(OGRLineString *, const arrow::DoubleArray *,
+                                    size_t, int);
 
 static SetPointsOfLineType GetSetPointsOfLine(bool bHasZ, bool bHasM)
 {
@@ -1708,6 +1834,89 @@ static SetPointsOfLineType GetSetPointsOfLine(bool bHasZ, bool bHasM)
     if (bHasM)
         return SetPointsOfLine<false, true, 3>;
     return SetPointsOfLine<false, false, 2>;
+}
+
+/************************************************************************/
+/*                        SetPointsOfLineStruct()                       */
+/************************************************************************/
+
+template <bool bHasZ, bool bHasM, int nDim>
+void SetPointsOfLineStruct(OGRLineString *poLS,
+                           const arrow::StructArray *structArray,
+                           size_t pointOffset, int numPoints)
+{
+    CPLAssert(structArray->num_fields() == nDim);
+    const auto &fields = structArray->fields();
+    const auto &fieldX = fields[0];
+    CPLAssert(fieldX->type_id() == arrow::Type::DOUBLE);
+    const auto fieldXDouble = static_cast<arrow::DoubleArray *>(fieldX.get());
+    const auto &fieldY = fields[1];
+    CPLAssert(fieldY->type_id() == arrow::Type::DOUBLE);
+    const auto fieldYDouble = static_cast<arrow::DoubleArray *>(fieldY.get());
+    const arrow::DoubleArray *fieldZDouble = nullptr;
+    const arrow::DoubleArray *fieldMDouble = nullptr;
+    int iField = 2;
+    if constexpr (bHasZ)
+    {
+        const auto &field = fields[iField];
+        ++iField;
+        CPLAssert(field->type_id() == arrow::Type::DOUBLE);
+        fieldZDouble = static_cast<arrow::DoubleArray *>(field.get());
+    }
+    if constexpr (bHasM)
+    {
+        const auto &field = fields[iField];
+        CPLAssert(field->type_id() == arrow::Type::DOUBLE);
+        fieldMDouble = static_cast<arrow::DoubleArray *>(field.get());
+    }
+
+    poLS->setNumPoints(numPoints, FALSE);
+    for (int k = 0; k < numPoints; k++)
+    {
+        if constexpr (bHasZ)
+        {
+            if constexpr (bHasM)
+            {
+                poLS->setPoint(k, fieldXDouble->Value(pointOffset + k),
+                               fieldYDouble->Value(pointOffset + k),
+                               fieldZDouble->Value(pointOffset + k),
+                               fieldMDouble->Value(pointOffset + k));
+            }
+            else
+            {
+                poLS->setPoint(k, fieldXDouble->Value(pointOffset + k),
+                               fieldYDouble->Value(pointOffset + k),
+                               fieldZDouble->Value(pointOffset + k));
+            }
+        }
+        else if constexpr (bHasM)
+        {
+            poLS->setPointM(k, fieldXDouble->Value(pointOffset + k),
+                            fieldYDouble->Value(pointOffset + k),
+                            fieldMDouble->Value(pointOffset + k));
+        }
+        else
+        {
+            poLS->setPoint(k, fieldXDouble->Value(pointOffset + k),
+                           fieldYDouble->Value(pointOffset + k));
+        }
+    }
+}
+
+typedef void (*SetPointsOfLineStructType)(OGRLineString *,
+                                          const arrow::StructArray *, size_t,
+                                          int);
+
+static SetPointsOfLineStructType GetSetPointsOfLineStruct(bool bHasZ,
+                                                          bool bHasM)
+{
+    if (bHasZ && bHasM)
+        return SetPointsOfLineStruct<true, true, 4>;
+    if (bHasZ)
+        return SetPointsOfLineStruct<true, false, 3>;
+    if (bHasM)
+        return SetPointsOfLineStruct<false, true, 3>;
+    return SetPointsOfLineStruct<false, false, 2>;
 }
 
 /************************************************************************/
@@ -2231,8 +2440,7 @@ inline OGRGeometry *OGRArrowLayer::ReadGeometry(int iGeomField,
     const int nDim = 2 + (bHasZ ? 1 : 0) + (bHasM ? 1 : 0);
 
     const auto CreatePoint =
-        [bHasZ, bHasM](const std::shared_ptr<arrow::DoubleArray> &pointValues,
-                       int pointOffset)
+        [bHasZ, bHasM](const arrow::DoubleArray *pointValues, int pointOffset)
     {
         if (bHasZ)
         {
@@ -2262,6 +2470,76 @@ inline OGRGeometry *OGRArrowLayer::ReadGeometry(int iGeomField,
                                 pointValues->Value(pointOffset + 1));
         }
     };
+
+    const auto CreateStructPoint =
+        [nDim, bHasZ, bHasM](const arrow::StructArray *structArray,
+                             int64_t pointOffset)
+    {
+        CPL_IGNORE_RET_VAL(nDim);
+        CPLAssert(structArray->num_fields() == nDim);
+        const auto &fieldX = structArray->field(0);
+        CPLAssert(fieldX->type_id() == arrow::Type::DOUBLE);
+        const auto fieldXDouble =
+            static_cast<arrow::DoubleArray *>(fieldX.get());
+        const auto &fieldY = structArray->field(1);
+        CPLAssert(fieldY->type_id() == arrow::Type::DOUBLE);
+        const auto fieldYDouble =
+            static_cast<arrow::DoubleArray *>(fieldY.get());
+        if (bHasZ)
+        {
+            const auto &fieldZ = structArray->field(2);
+            CPLAssert(fieldZ->type_id() == arrow::Type::DOUBLE);
+            const auto fieldZDouble =
+                static_cast<arrow::DoubleArray *>(fieldZ.get());
+            if (bHasM)
+            {
+                const auto &fieldM = structArray->field(3);
+                CPLAssert(fieldM->type_id() == arrow::Type::DOUBLE);
+                const auto fieldMDouble =
+                    static_cast<arrow::DoubleArray *>(fieldM.get());
+                return new OGRPoint(fieldXDouble->Value(pointOffset),
+                                    fieldYDouble->Value(pointOffset),
+                                    fieldZDouble->Value(pointOffset),
+                                    fieldMDouble->Value(pointOffset));
+            }
+            else
+            {
+                return new OGRPoint(fieldXDouble->Value(pointOffset),
+                                    fieldYDouble->Value(pointOffset),
+                                    fieldZDouble->Value(pointOffset));
+            }
+        }
+        else if (bHasM)
+        {
+            const auto &fieldM = structArray->field(2);
+            CPLAssert(fieldM->type_id() == arrow::Type::DOUBLE);
+            const auto fieldMDouble =
+                static_cast<arrow::DoubleArray *>(fieldM.get());
+            return OGRPoint::createXYM(fieldXDouble->Value(pointOffset),
+                                       fieldYDouble->Value(pointOffset),
+                                       fieldMDouble->Value(pointOffset));
+        }
+        else
+        {
+            return new OGRPoint(fieldXDouble->Value(pointOffset),
+                                fieldYDouble->Value(pointOffset));
+        }
+    };
+
+    // Arrow 14 since https://github.com/apache/arrow/commit/95a8bfb319b2729c8f6daa069433caba3b4ddddd
+    // returns reference to shared pointers, so we can safely take the raw pointer
+    // and cast it.
+    // Earlier versions returned a non-reference shared pointer, so formally it
+    // is safer to use static_pointer_cast (although in practice given that
+    // "values" is a member variable), the Arrow >= 14 path might work...
+#if ARROW_VERSION_MAJOR >= 14
+#define GET_PTR_FROM_VALUES(var, type, values)                                 \
+    const auto var = static_cast<const type *>((values).get())
+#else
+#define GET_PTR_FROM_VALUES(var, type, values)                                 \
+    const auto var##tmp = std::static_pointer_cast<type>(values);              \
+    const auto var = var##tmp.get()
+#endif
 
     switch (m_aeGeomEncoding[iGeomField])
     {
@@ -2330,21 +2608,21 @@ inline OGRGeometry *OGRArrowLayer::ReadGeometry(int iGeomField,
             break;
         }
 
-        case OGRArrowGeomEncoding::GEOARROW_GENERIC:
+        case OGRArrowGeomEncoding::GEOARROW_FSL_GENERIC:
+        case OGRArrowGeomEncoding::GEOARROW_STRUCT_GENERIC:
         {
             CPLAssert(false);
             break;
         }
 
-        case OGRArrowGeomEncoding::GEOARROW_POINT:
+        case OGRArrowGeomEncoding::GEOARROW_FSL_POINT:
         {
             CPLAssert(array->type_id() == arrow::Type::FIXED_SIZE_LIST);
             const auto listArray =
                 static_cast<const arrow::FixedSizeListArray *>(array);
             CPLAssert(listArray->values()->type_id() == arrow::Type::DOUBLE);
-            const auto pointValues =
-                std::static_pointer_cast<arrow::DoubleArray>(
-                    listArray->values());
+            GET_PTR_FROM_VALUES(pointValues, arrow::DoubleArray,
+                                listArray->values());
             if (!pointValues->IsNull(nDim * nIdxInBatch))
             {
                 poGeometry = CreatePoint(pointValues,
@@ -2355,20 +2633,18 @@ inline OGRGeometry *OGRArrowLayer::ReadGeometry(int iGeomField,
             break;
         }
 
-        case OGRArrowGeomEncoding::GEOARROW_LINESTRING:
+        case OGRArrowGeomEncoding::GEOARROW_FSL_LINESTRING:
         {
             CPLAssert(array->type_id() == arrow::Type::LIST);
             const auto listArray = static_cast<const arrow::ListArray *>(array);
             CPLAssert(listArray->values()->type_id() ==
                       arrow::Type::FIXED_SIZE_LIST);
-            const auto listOfPointsValues =
-                std::static_pointer_cast<arrow::FixedSizeListArray>(
-                    listArray->values());
+            GET_PTR_FROM_VALUES(listOfPointsValues, arrow::FixedSizeListArray,
+                                listArray->values());
             CPLAssert(listOfPointsValues->values()->type_id() ==
                       arrow::Type::DOUBLE);
-            const auto pointValues =
-                std::static_pointer_cast<arrow::DoubleArray>(
-                    listOfPointsValues->values());
+            GET_PTR_FROM_VALUES(pointValues, arrow::DoubleArray,
+                                listOfPointsValues->values());
             const auto nPoints = listArray->value_length(nIdxInBatch);
             const auto nPointOffset =
                 listArray->value_offset(nIdxInBatch) * nDim;
@@ -2389,26 +2665,23 @@ inline OGRGeometry *OGRArrowLayer::ReadGeometry(int iGeomField,
             break;
         }
 
-        case OGRArrowGeomEncoding::GEOARROW_POLYGON:
+        case OGRArrowGeomEncoding::GEOARROW_FSL_POLYGON:
         {
             CPLAssert(array->type_id() == arrow::Type::LIST);
             const auto listOfRingsArray =
                 static_cast<const arrow::ListArray *>(array);
             CPLAssert(listOfRingsArray->values()->type_id() ==
                       arrow::Type::LIST);
-            const auto listOfRingsValues =
-                std::static_pointer_cast<arrow::ListArray>(
-                    listOfRingsArray->values());
+            GET_PTR_FROM_VALUES(listOfRingsValues, arrow::ListArray,
+                                listOfRingsArray->values());
             CPLAssert(listOfRingsValues->values()->type_id() ==
                       arrow::Type::FIXED_SIZE_LIST);
-            const auto listOfPointsValues =
-                std::static_pointer_cast<arrow::FixedSizeListArray>(
-                    listOfRingsValues->values());
+            GET_PTR_FROM_VALUES(listOfPointsValues, arrow::FixedSizeListArray,
+                                listOfRingsValues->values());
             CPLAssert(listOfPointsValues->values()->type_id() ==
                       arrow::Type::DOUBLE);
-            const auto pointValues =
-                std::static_pointer_cast<arrow::DoubleArray>(
-                    listOfPointsValues->values());
+            GET_PTR_FROM_VALUES(pointValues, arrow::DoubleArray,
+                                listOfPointsValues->values());
             const auto setPointsFun = GetSetPointsOfLine(bHasZ, bHasM);
             const auto nRings = listOfRingsArray->value_length(nIdxInBatch);
             const auto nRingOffset =
@@ -2438,20 +2711,18 @@ inline OGRGeometry *OGRArrowLayer::ReadGeometry(int iGeomField,
             break;
         }
 
-        case OGRArrowGeomEncoding::GEOARROW_MULTIPOINT:
+        case OGRArrowGeomEncoding::GEOARROW_FSL_MULTIPOINT:
         {
             CPLAssert(array->type_id() == arrow::Type::LIST);
             const auto listArray = static_cast<const arrow::ListArray *>(array);
             CPLAssert(listArray->values()->type_id() ==
                       arrow::Type::FIXED_SIZE_LIST);
-            const auto listOfPointsValues =
-                std::static_pointer_cast<arrow::FixedSizeListArray>(
-                    listArray->values());
+            GET_PTR_FROM_VALUES(listOfPointsValues, arrow::FixedSizeListArray,
+                                listArray->values());
             CPLAssert(listOfPointsValues->values()->type_id() ==
                       arrow::Type::DOUBLE);
-            const auto pointValues =
-                std::static_pointer_cast<arrow::DoubleArray>(
-                    listOfPointsValues->values());
+            GET_PTR_FROM_VALUES(pointValues, arrow::DoubleArray,
+                                listOfPointsValues->values());
             const auto nPoints = listArray->value_length(nIdxInBatch);
             const auto nPointOffset =
                 listArray->value_offset(nIdxInBatch) * nDim;
@@ -2472,26 +2743,23 @@ inline OGRGeometry *OGRArrowLayer::ReadGeometry(int iGeomField,
             break;
         }
 
-        case OGRArrowGeomEncoding::GEOARROW_MULTILINESTRING:
+        case OGRArrowGeomEncoding::GEOARROW_FSL_MULTILINESTRING:
         {
             CPLAssert(array->type_id() == arrow::Type::LIST);
             const auto listOfStringsArray =
                 static_cast<const arrow::ListArray *>(array);
             CPLAssert(listOfStringsArray->values()->type_id() ==
                       arrow::Type::LIST);
-            const auto listOfStringsValues =
-                std::static_pointer_cast<arrow::ListArray>(
-                    listOfStringsArray->values());
+            GET_PTR_FROM_VALUES(listOfStringsValues, arrow::ListArray,
+                                listOfStringsArray->values());
             CPLAssert(listOfStringsValues->values()->type_id() ==
                       arrow::Type::FIXED_SIZE_LIST);
-            const auto listOfPointsValues =
-                std::static_pointer_cast<arrow::FixedSizeListArray>(
-                    listOfStringsValues->values());
+            GET_PTR_FROM_VALUES(listOfPointsValues, arrow::FixedSizeListArray,
+                                listOfStringsValues->values());
             CPLAssert(listOfPointsValues->values()->type_id() ==
                       arrow::Type::DOUBLE);
-            const auto pointValues =
-                std::static_pointer_cast<arrow::DoubleArray>(
-                    listOfPointsValues->values());
+            GET_PTR_FROM_VALUES(pointValues, arrow::DoubleArray,
+                                listOfPointsValues->values());
             const auto setPointsFun = GetSetPointsOfLine(bHasZ, bHasM);
             const auto nStrings = listOfStringsArray->value_length(nIdxInBatch);
             const auto nRingOffset =
@@ -2521,31 +2789,27 @@ inline OGRGeometry *OGRArrowLayer::ReadGeometry(int iGeomField,
             break;
         }
 
-        case OGRArrowGeomEncoding::GEOARROW_MULTIPOLYGON:
+        case OGRArrowGeomEncoding::GEOARROW_FSL_MULTIPOLYGON:
         {
             CPLAssert(array->type_id() == arrow::Type::LIST);
             const auto listOfPartsArray =
                 static_cast<const arrow::ListArray *>(array);
             CPLAssert(listOfPartsArray->values()->type_id() ==
                       arrow::Type::LIST);
-            const auto listOfPartsValues =
-                std::static_pointer_cast<arrow::ListArray>(
-                    listOfPartsArray->values());
+            GET_PTR_FROM_VALUES(listOfPartsValues, arrow::ListArray,
+                                listOfPartsArray->values());
             CPLAssert(listOfPartsValues->values()->type_id() ==
                       arrow::Type::LIST);
-            const auto listOfRingsValues =
-                std::static_pointer_cast<arrow::ListArray>(
-                    listOfPartsValues->values());
+            GET_PTR_FROM_VALUES(listOfRingsValues, arrow::ListArray,
+                                listOfPartsValues->values());
             CPLAssert(listOfRingsValues->values()->type_id() ==
                       arrow::Type::FIXED_SIZE_LIST);
-            const auto listOfPointsValues =
-                std::static_pointer_cast<arrow::FixedSizeListArray>(
-                    listOfRingsValues->values());
+            GET_PTR_FROM_VALUES(listOfPointsValues, arrow::FixedSizeListArray,
+                                listOfRingsValues->values());
             CPLAssert(listOfPointsValues->values()->type_id() ==
                       arrow::Type::DOUBLE);
-            const auto pointValues =
-                std::static_pointer_cast<arrow::DoubleArray>(
-                    listOfPointsValues->values());
+            GET_PTR_FROM_VALUES(pointValues, arrow::DoubleArray,
+                                listOfPointsValues->values());
             auto poMP = new OGRMultiPolygon();
             poGeometry = poMP;
             poGeometry->assignSpatialReference(
@@ -2567,6 +2831,212 @@ inline OGRGeometry *OGRArrowLayer::ReadGeometry(int iGeomField,
                         listOfRingsValues->value_length(nRingOffset + k);
                     const auto nPointOffset =
                         listOfRingsValues->value_offset(nRingOffset + k) * nDim;
+                    auto poRing = new OGRLinearRing();
+                    if (nPoints)
+                    {
+                        setPointsFun(poRing, pointValues, nPointOffset,
+                                     nPoints);
+                    }
+                    poPoly->addRingDirectly(poRing);
+                }
+                poMP->addGeometryDirectly(poPoly);
+            }
+            if (poGeometry->IsEmpty())
+            {
+                poGeometry->set3D(bHasZ);
+                poGeometry->setMeasured(bHasM);
+            }
+            break;
+        }
+
+        case OGRArrowGeomEncoding::GEOARROW_STRUCT_POINT:
+        {
+            CPLAssert(array->type_id() == arrow::Type::STRUCT);
+            const auto structArray =
+                static_cast<const arrow::StructArray *>(array);
+            if (!structArray->IsNull(nIdxInBatch))
+            {
+                poGeometry = CreateStructPoint(structArray, nIdxInBatch);
+                poGeometry->assignSpatialReference(
+                    poGeomFieldDefn->GetSpatialRef());
+            }
+            break;
+        }
+
+        case OGRArrowGeomEncoding::GEOARROW_STRUCT_LINESTRING:
+        {
+            CPLAssert(array->type_id() == arrow::Type::LIST);
+            const auto listArray = static_cast<const arrow::ListArray *>(array);
+            CPLAssert(listArray->values()->type_id() == arrow::Type::STRUCT);
+            GET_PTR_FROM_VALUES(pointValues, arrow::StructArray,
+                                listArray->values());
+            const auto nPoints = listArray->value_length(nIdxInBatch);
+            const auto nPointOffset = listArray->value_offset(nIdxInBatch);
+            auto poLineString = new OGRLineString();
+            poGeometry = poLineString;
+            poGeometry->assignSpatialReference(
+                poGeomFieldDefn->GetSpatialRef());
+            if (nPoints)
+            {
+                GetSetPointsOfLineStruct(bHasZ, bHasM)(
+                    poLineString, pointValues, nPointOffset, nPoints);
+            }
+            else
+            {
+                poGeometry->set3D(bHasZ);
+                poGeometry->setMeasured(bHasM);
+            }
+            break;
+        }
+
+        case OGRArrowGeomEncoding::GEOARROW_STRUCT_POLYGON:
+        {
+            CPLAssert(array->type_id() == arrow::Type::LIST);
+            const auto listOfRingsArray =
+                static_cast<const arrow::ListArray *>(array);
+            CPLAssert(listOfRingsArray->values()->type_id() ==
+                      arrow::Type::LIST);
+            GET_PTR_FROM_VALUES(listOfRingsValues, arrow::ListArray,
+                                listOfRingsArray->values());
+            CPLAssert(listOfRingsValues->values()->type_id() ==
+                      arrow::Type::STRUCT);
+            GET_PTR_FROM_VALUES(pointValues, arrow::StructArray,
+                                listOfRingsValues->values());
+            const auto setPointsFun = GetSetPointsOfLineStruct(bHasZ, bHasM);
+            const auto nRings = listOfRingsArray->value_length(nIdxInBatch);
+            const auto nRingOffset =
+                listOfRingsArray->value_offset(nIdxInBatch);
+            auto poPoly = new OGRPolygon();
+            poGeometry = poPoly;
+            poGeometry->assignSpatialReference(
+                poGeomFieldDefn->GetSpatialRef());
+            for (auto k = decltype(nRings){0}; k < nRings; k++)
+            {
+                const auto nPoints =
+                    listOfRingsValues->value_length(nRingOffset + k);
+                const auto nPointOffset =
+                    listOfRingsValues->value_offset(nRingOffset + k);
+                auto poRing = new OGRLinearRing();
+                if (nPoints)
+                {
+                    setPointsFun(poRing, pointValues, nPointOffset, nPoints);
+                }
+                poPoly->addRingDirectly(poRing);
+            }
+            if (poGeometry->IsEmpty())
+            {
+                poGeometry->set3D(bHasZ);
+                poGeometry->setMeasured(bHasM);
+            }
+            break;
+        }
+
+        case OGRArrowGeomEncoding::GEOARROW_STRUCT_MULTIPOINT:
+        {
+            CPLAssert(array->type_id() == arrow::Type::LIST);
+            const auto listArray = static_cast<const arrow::ListArray *>(array);
+            CPLAssert(listArray->values()->type_id() == arrow::Type::STRUCT);
+            GET_PTR_FROM_VALUES(pointValues, arrow::StructArray,
+                                listArray->values());
+            const auto nPoints = listArray->value_length(nIdxInBatch);
+            const auto nPointOffset = listArray->value_offset(nIdxInBatch);
+            auto poMultiPoint = new OGRMultiPoint();
+            poGeometry = poMultiPoint;
+            poGeometry->assignSpatialReference(
+                poGeomFieldDefn->GetSpatialRef());
+            for (auto k = decltype(nPoints){0}; k < nPoints; k++)
+            {
+                poMultiPoint->addGeometryDirectly(
+                    CreateStructPoint(pointValues, nPointOffset + k));
+            }
+            if (poGeometry->IsEmpty())
+            {
+                poGeometry->set3D(bHasZ);
+                poGeometry->setMeasured(bHasM);
+            }
+            break;
+        }
+
+        case OGRArrowGeomEncoding::GEOARROW_STRUCT_MULTILINESTRING:
+        {
+            CPLAssert(array->type_id() == arrow::Type::LIST);
+            const auto listOfStringsArray =
+                static_cast<const arrow::ListArray *>(array);
+            CPLAssert(listOfStringsArray->values()->type_id() ==
+                      arrow::Type::LIST);
+            GET_PTR_FROM_VALUES(listOfStringsValues, arrow::ListArray,
+                                listOfStringsArray->values());
+            CPLAssert(listOfStringsValues->values()->type_id() ==
+                      arrow::Type::STRUCT);
+            GET_PTR_FROM_VALUES(pointValues, arrow::StructArray,
+                                listOfStringsValues->values());
+            const auto setPointsFun = GetSetPointsOfLineStruct(bHasZ, bHasM);
+            const auto nStrings = listOfStringsArray->value_length(nIdxInBatch);
+            const auto nRingOffset =
+                listOfStringsArray->value_offset(nIdxInBatch);
+            auto poMLS = new OGRMultiLineString();
+            poGeometry = poMLS;
+            poGeometry->assignSpatialReference(
+                poGeomFieldDefn->GetSpatialRef());
+            for (auto k = decltype(nStrings){0}; k < nStrings; k++)
+            {
+                const auto nPoints =
+                    listOfStringsValues->value_length(nRingOffset + k);
+                const auto nPointOffset =
+                    listOfStringsValues->value_offset(nRingOffset + k);
+                auto poLS = new OGRLineString();
+                if (nPoints)
+                {
+                    setPointsFun(poLS, pointValues, nPointOffset, nPoints);
+                }
+                poMLS->addGeometryDirectly(poLS);
+            }
+            if (poGeometry->IsEmpty())
+            {
+                poGeometry->set3D(bHasZ);
+                poGeometry->setMeasured(bHasM);
+            }
+            break;
+        }
+
+        case OGRArrowGeomEncoding::GEOARROW_STRUCT_MULTIPOLYGON:
+        {
+            CPLAssert(array->type_id() == arrow::Type::LIST);
+            const auto listOfPartsArray =
+                static_cast<const arrow::ListArray *>(array);
+            CPLAssert(listOfPartsArray->values()->type_id() ==
+                      arrow::Type::LIST);
+            GET_PTR_FROM_VALUES(listOfPartsValues, arrow::ListArray,
+                                listOfPartsArray->values());
+            CPLAssert(listOfPartsValues->values()->type_id() ==
+                      arrow::Type::LIST);
+            GET_PTR_FROM_VALUES(listOfRingsValues, arrow::ListArray,
+                                listOfPartsValues->values());
+            CPLAssert(listOfRingsValues->values()->type_id() ==
+                      arrow::Type::STRUCT);
+            GET_PTR_FROM_VALUES(pointValues, arrow::StructArray,
+                                listOfRingsValues->values());
+            auto poMP = new OGRMultiPolygon();
+            poGeometry = poMP;
+            poGeometry->assignSpatialReference(
+                poGeomFieldDefn->GetSpatialRef());
+            const auto setPointsFun = GetSetPointsOfLineStruct(bHasZ, bHasM);
+            const auto nParts = listOfPartsArray->value_length(nIdxInBatch);
+            const auto nPartOffset =
+                listOfPartsArray->value_offset(nIdxInBatch);
+            for (auto j = decltype(nParts){0}; j < nParts; j++)
+            {
+                const auto nRings =
+                    listOfPartsValues->value_length(nPartOffset + j);
+                const auto nRingOffset =
+                    listOfPartsValues->value_offset(nPartOffset + j);
+                auto poPoly = new OGRPolygon();
+                for (auto k = decltype(nRings){0}; k < nRings; k++)
+                {
+                    const auto nPoints =
+                        listOfRingsValues->value_length(nRingOffset + k);
+                    const auto nPointOffset =
+                        listOfRingsValues->value_offset(nRingOffset + k);
                     auto poRing = new OGRLinearRing();
                     if (nPoints)
                     {
@@ -3580,8 +4050,9 @@ inline OGRFeature *OGRArrowLayer::GetNextRawFeature()
                 }
             }
         }
-        else if (iCol >= 0 && m_aeGeomEncoding[m_iGeomFieldFilter] ==
-                                  OGRArrowGeomEncoding::GEOARROW_MULTIPOLYGON)
+        else if (iCol >= 0 &&
+                 m_aeGeomEncoding[m_iGeomFieldFilter] ==
+                     OGRArrowGeomEncoding::GEOARROW_FSL_MULTIPOLYGON)
         {
             const auto poGeomFieldDefn =
                 m_poFeatureDefn->GetGeomFieldDefn(m_iGeomFieldFilter);
@@ -4000,7 +4471,7 @@ inline OGRErr OGRArrowLayer::GetExtent(int iGeomField, OGREnvelope *psExtent,
         }
     }
     else if (m_aeGeomEncoding[iGeomField] ==
-             OGRArrowGeomEncoding::GEOARROW_MULTIPOLYGON)
+             OGRArrowGeomEncoding::GEOARROW_FSL_MULTIPOLYGON)
     {
         ResetReading();
         if (m_poBatch == nullptr)

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
@@ -4040,7 +4040,7 @@ inline OGRFeature *OGRArrowLayer::GetNextRawFeature()
                     break;
                 }
 
-                m_nFeatureIdx++;
+                IncrFeatureIdx();
                 m_nIdxInBatch++;
                 if (m_nIdxInBatch == m_poBatch->num_rows())
                 {
@@ -4138,7 +4138,7 @@ inline OGRFeature *OGRArrowLayer::GetNextRawFeature()
                     break;
                 }
 
-                m_nFeatureIdx++;
+                IncrFeatureIdx();
                 m_nIdxInBatch++;
                 if (m_nIdxInBatch == m_poBatch->num_rows())
                 {
@@ -4187,7 +4187,7 @@ inline OGRFeature *OGRArrowLayer::GetNextRawFeature()
                     break;
                 }
 
-                m_nFeatureIdx++;
+                IncrFeatureIdx();
                 m_nIdxInBatch++;
                 if (m_nIdxInBatch == m_poBatch->num_rows())
                 {
@@ -4209,7 +4209,7 @@ inline OGRFeature *OGRArrowLayer::GetNextRawFeature()
                 break;
             }
 
-            m_nFeatureIdx++;
+            IncrFeatureIdx();
             m_nIdxInBatch++;
             if (m_nIdxInBatch == m_poBatch->num_rows())
             {
@@ -4225,7 +4225,7 @@ inline OGRFeature *OGRArrowLayer::GetNextRawFeature()
     if (m_iFIDArrowColumn < 0)
         poFeature->SetFID(m_nFeatureIdx);
 
-    m_nFeatureIdx++;
+    IncrFeatureIdx();
     m_nIdxInBatch++;
 
     return poFeature;
@@ -4441,7 +4441,6 @@ inline OGRErr OGRArrowLayer::GetExtent(int iGeomField, OGREnvelope *psExtent,
                 }
             }
 
-            m_nFeatureIdx++;
             m_nIdxInBatch++;
             if (m_nIdxInBatch == m_poBatch->num_rows())
             {
@@ -4541,7 +4540,6 @@ inline OGRErr OGRArrowLayer::GetExtent(int iGeomField, OGREnvelope *psExtent,
                 }
             }
 
-            m_nFeatureIdx++;
             m_nIdxInBatch++;
             if (m_nIdxInBatch == m_poBatch->num_rows())
             {
@@ -5070,7 +5068,11 @@ inline int OGRArrowLayer::GetNextArrowArray(struct ArrowArrayStream *stream,
         OverrideArrowRelease(m_poArrowDS, out_array);
 
         const auto nFeatureIdxCur = m_nFeatureIdx;
-        m_nFeatureIdx += m_nIdxInBatch;
+        // TODO: We likely have an issue regarding FIDs based on m_nFeatureIdx
+        // when m_iFIDArrowColumn < 0, only a subset of row groups is
+        // selected, and this batch goes accross non consecutive row groups.
+        for (int64_t i = 0; i < m_nIdxInBatch; ++i)
+            IncrFeatureIdx();
 
         if (m_poAttrQuery || m_poFilterGeom)
         {

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
@@ -4123,7 +4123,7 @@ inline OGRFeature *OGRArrowLayer::GetNextRawFeature()
                         }
                     }
 
-                    if (nParts != 0 && m_sFilterEnvelope.Intersects(sEnvelope))
+                    if (nParts != 0 && !m_sFilterEnvelope.Intersects(sEnvelope))
                     {
                         bSkipToNextFeature = true;
                     }

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowwriterlayer.hpp
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowwriterlayer.hpp
@@ -60,6 +60,13 @@ static constexpr int TZFLAG_UNINITIALIZED = -1;
 #define OGR_ARROW_RETURN_OGRERR_NOT_OK(status)                                 \
     OGR_ARROW_RETURN_NOT_OK(status, OGRERR_FAILURE)
 
+#define OGR_ARROW_PROPAGATE_OGRERR(ret_value)                                  \
+    do                                                                         \
+    {                                                                          \
+        if ((ret_value) != OGRERR_NONE)                                        \
+            return OGRERR_FAILURE;                                             \
+    } while (0)
+
 /************************************************************************/
 /*                      OGRArrowWriterLayer()                           */
 /************************************************************************/
@@ -275,6 +282,8 @@ inline void OGRArrowWriterLayer::CreateSchemaCommon()
             2 + (OGR_GT_HasZ(eGType) ? 1 : 0) + (OGR_GT_HasM(eGType) ? 1 : 0);
 
         const bool pointFieldNullable = GetDriverUCName() == "PARQUET";
+
+        // Fixed Size List GeoArrow encoding
         std::shared_ptr<arrow::Field> pointField;
         if (nDim == 2)
             pointField =
@@ -289,6 +298,20 @@ inline void OGRArrowWriterLayer::CreateSchemaCommon()
             pointField =
                 arrow::field("xyzm", arrow::float64(), pointFieldNullable);
 
+        // Struct GeoArrow encoding
+        auto xField(arrow::field("x", arrow::float64(), false));
+        auto yField(arrow::field("y", arrow::float64(), false));
+        std::vector<std::shared_ptr<arrow::Field>> pointFields{
+            arrow::field("x", arrow::float64(), false),
+            arrow::field("y", arrow::float64(), false)};
+        if (OGR_GT_HasZ(eGType))
+            pointFields.emplace_back(
+                arrow::field("z", arrow::float64(), false));
+        if (OGR_GT_HasM(eGType))
+            pointFields.emplace_back(
+                arrow::field("m", arrow::float64(), false));
+        auto pointStructType(arrow::struct_(std::move(pointFields)));
+
         std::shared_ptr<arrow::DataType> dt;
         switch (m_aeGeomEncoding[i])
         {
@@ -300,35 +323,60 @@ inline void OGRArrowWriterLayer::CreateSchemaCommon()
                 dt = arrow::utf8();
                 break;
 
-            case OGRArrowGeomEncoding::GEOARROW_GENERIC:
+            case OGRArrowGeomEncoding::GEOARROW_FSL_GENERIC:
+            case OGRArrowGeomEncoding::GEOARROW_STRUCT_GENERIC:
                 CPLAssert(false);
                 break;
 
-            case OGRArrowGeomEncoding::GEOARROW_POINT:
+            case OGRArrowGeomEncoding::GEOARROW_FSL_POINT:
                 dt = arrow::fixed_size_list(pointField, nDim);
                 break;
 
-            case OGRArrowGeomEncoding::GEOARROW_LINESTRING:
+            case OGRArrowGeomEncoding::GEOARROW_FSL_LINESTRING:
                 dt = arrow::list(arrow::fixed_size_list(pointField, nDim));
                 break;
 
-            case OGRArrowGeomEncoding::GEOARROW_POLYGON:
+            case OGRArrowGeomEncoding::GEOARROW_FSL_POLYGON:
                 dt = arrow::list(
                     arrow::list(arrow::fixed_size_list(pointField, nDim)));
                 break;
 
-            case OGRArrowGeomEncoding::GEOARROW_MULTIPOINT:
+            case OGRArrowGeomEncoding::GEOARROW_FSL_MULTIPOINT:
                 dt = arrow::list(arrow::fixed_size_list(pointField, nDim));
                 break;
 
-            case OGRArrowGeomEncoding::GEOARROW_MULTILINESTRING:
+            case OGRArrowGeomEncoding::GEOARROW_FSL_MULTILINESTRING:
                 dt = arrow::list(
                     arrow::list(arrow::fixed_size_list(pointField, nDim)));
                 break;
 
-            case OGRArrowGeomEncoding::GEOARROW_MULTIPOLYGON:
+            case OGRArrowGeomEncoding::GEOARROW_FSL_MULTIPOLYGON:
                 dt = arrow::list(arrow::list(
                     arrow::list(arrow::fixed_size_list(pointField, nDim))));
+                break;
+
+            case OGRArrowGeomEncoding::GEOARROW_STRUCT_POINT:
+                dt = pointStructType;
+                break;
+
+            case OGRArrowGeomEncoding::GEOARROW_STRUCT_LINESTRING:
+                dt = arrow::list(pointStructType);
+                break;
+
+            case OGRArrowGeomEncoding::GEOARROW_STRUCT_POLYGON:
+                dt = arrow::list(arrow::list(pointStructType));
+                break;
+
+            case OGRArrowGeomEncoding::GEOARROW_STRUCT_MULTIPOINT:
+                dt = arrow::list(pointStructType);
+                break;
+
+            case OGRArrowGeomEncoding::GEOARROW_STRUCT_MULTILINESTRING:
+                dt = arrow::list(arrow::list(pointStructType));
+                break;
+
+            case OGRArrowGeomEncoding::GEOARROW_STRUCT_MULTIPOLYGON:
+                dt = arrow::list(arrow::list(arrow::list(pointStructType)));
                 break;
         }
 
@@ -345,6 +393,8 @@ inline void OGRArrowWriterLayer::CreateSchemaCommon()
                 GetGeomEncodingAsString(m_aeGeomEncoding[i], false));
             field = field->WithMetadata(kvMetadata);
         }
+
+        m_apoBaseStructGeomType.emplace_back(std::move(pointStructType));
 
         fields.emplace_back(std::move(field));
     }
@@ -644,43 +694,57 @@ inline bool OGRArrowWriterLayer::CreateFieldFromArrowSchema(
 }
 
 /************************************************************************/
-/*                   GetPreciseArrowGeomEncoding()                    */
+/*                   GetPreciseArrowGeomEncoding()                      */
 /************************************************************************/
 
-inline OGRArrowGeomEncoding
-OGRArrowWriterLayer::GetPreciseArrowGeomEncoding(OGRwkbGeometryType eGType)
+inline OGRArrowGeomEncoding OGRArrowWriterLayer::GetPreciseArrowGeomEncoding(
+    OGRArrowGeomEncoding eEncodingType, OGRwkbGeometryType eGType)
 {
+    CPLAssert(eEncodingType == OGRArrowGeomEncoding::GEOARROW_FSL_GENERIC ||
+              eEncodingType == OGRArrowGeomEncoding::GEOARROW_STRUCT_GENERIC);
     const auto eFlatType = wkbFlatten(eGType);
     if (eFlatType == wkbPoint)
     {
-        return OGRArrowGeomEncoding::GEOARROW_POINT;
+        return eEncodingType == OGRArrowGeomEncoding::GEOARROW_FSL_GENERIC
+                   ? OGRArrowGeomEncoding::GEOARROW_FSL_POINT
+                   : OGRArrowGeomEncoding::GEOARROW_STRUCT_POINT;
     }
     else if (eFlatType == wkbLineString)
     {
-        return OGRArrowGeomEncoding::GEOARROW_LINESTRING;
+        return eEncodingType == OGRArrowGeomEncoding::GEOARROW_FSL_GENERIC
+                   ? OGRArrowGeomEncoding::GEOARROW_FSL_LINESTRING
+                   : OGRArrowGeomEncoding::GEOARROW_STRUCT_LINESTRING;
     }
     else if (eFlatType == wkbPolygon)
     {
-        return OGRArrowGeomEncoding::GEOARROW_POLYGON;
+        return eEncodingType == OGRArrowGeomEncoding::GEOARROW_FSL_GENERIC
+                   ? OGRArrowGeomEncoding::GEOARROW_FSL_POLYGON
+                   : OGRArrowGeomEncoding::GEOARROW_STRUCT_POLYGON;
     }
     else if (eFlatType == wkbMultiPoint)
     {
-        return OGRArrowGeomEncoding::GEOARROW_MULTIPOINT;
+        return eEncodingType == OGRArrowGeomEncoding::GEOARROW_FSL_GENERIC
+                   ? OGRArrowGeomEncoding::GEOARROW_FSL_MULTIPOINT
+                   : OGRArrowGeomEncoding::GEOARROW_STRUCT_MULTIPOINT;
     }
     else if (eFlatType == wkbMultiLineString)
     {
-        return OGRArrowGeomEncoding::GEOARROW_MULTILINESTRING;
+        return eEncodingType == OGRArrowGeomEncoding::GEOARROW_FSL_GENERIC
+                   ? OGRArrowGeomEncoding::GEOARROW_FSL_MULTILINESTRING
+                   : OGRArrowGeomEncoding::GEOARROW_STRUCT_MULTILINESTRING;
     }
     else if (eFlatType == wkbMultiPolygon)
     {
-        return OGRArrowGeomEncoding::GEOARROW_MULTIPOLYGON;
+        return eEncodingType == OGRArrowGeomEncoding::GEOARROW_FSL_GENERIC
+                   ? OGRArrowGeomEncoding::GEOARROW_FSL_MULTIPOLYGON
+                   : OGRArrowGeomEncoding::GEOARROW_STRUCT_MULTIPOLYGON;
     }
     else
     {
         CPLError(CE_Failure, CPLE_NotSupported,
-                 "GEOMETRY_FORMAT=GEOARROW is currently not supported for %s",
+                 "GeoArrow encoding is currently not supported for %s",
                  OGRGeometryTypeToName(eGType));
-        return OGRArrowGeomEncoding::GEOARROW_GENERIC;
+        return eEncodingType;
     }
 }
 
@@ -698,21 +762,35 @@ OGRArrowWriterLayer::GetGeomEncodingAsString(OGRArrowGeomEncoding eGeomEncoding,
             return bForParquetGeo ? "WKB" : "ogc.wkb";
         case OGRArrowGeomEncoding::WKT:
             return bForParquetGeo ? "WKT" : "ogc.wkt";
-        case OGRArrowGeomEncoding::GEOARROW_GENERIC:
+        case OGRArrowGeomEncoding::GEOARROW_FSL_GENERIC:
+        case OGRArrowGeomEncoding::GEOARROW_STRUCT_GENERIC:
             CPLAssert(false);
             break;
-        case OGRArrowGeomEncoding::GEOARROW_POINT:
+        case OGRArrowGeomEncoding::GEOARROW_FSL_POINT:
             return "geoarrow.point";
-        case OGRArrowGeomEncoding::GEOARROW_LINESTRING:
+        case OGRArrowGeomEncoding::GEOARROW_FSL_LINESTRING:
             return "geoarrow.linestring";
-        case OGRArrowGeomEncoding::GEOARROW_POLYGON:
+        case OGRArrowGeomEncoding::GEOARROW_FSL_POLYGON:
             return "geoarrow.polygon";
-        case OGRArrowGeomEncoding::GEOARROW_MULTIPOINT:
+        case OGRArrowGeomEncoding::GEOARROW_FSL_MULTIPOINT:
             return "geoarrow.multipoint";
-        case OGRArrowGeomEncoding::GEOARROW_MULTILINESTRING:
+        case OGRArrowGeomEncoding::GEOARROW_FSL_MULTILINESTRING:
             return "geoarrow.multilinestring";
-        case OGRArrowGeomEncoding::GEOARROW_MULTIPOLYGON:
+        case OGRArrowGeomEncoding::GEOARROW_FSL_MULTIPOLYGON:
             return "geoarrow.multipolygon";
+        case OGRArrowGeomEncoding::GEOARROW_STRUCT_POINT:
+            return bForParquetGeo ? "point" : "geoarrow.point";
+        case OGRArrowGeomEncoding::GEOARROW_STRUCT_LINESTRING:
+            return bForParquetGeo ? "linestring" : "geoarrow.linestring";
+        case OGRArrowGeomEncoding::GEOARROW_STRUCT_POLYGON:
+            return bForParquetGeo ? "polygon" : "geoarrow.polygon";
+        case OGRArrowGeomEncoding::GEOARROW_STRUCT_MULTIPOINT:
+            return bForParquetGeo ? "multipoint" : "geoarrow.multipoint";
+        case OGRArrowGeomEncoding::GEOARROW_STRUCT_MULTILINESTRING:
+            return bForParquetGeo ? "multilinestring"
+                                  : "geoarrow.multilinestring";
+        case OGRArrowGeomEncoding::GEOARROW_STRUCT_MULTIPOLYGON:
+            return bForParquetGeo ? "multipolygon" : "geoarrow.multipolygon";
     }
     return nullptr;
 }
@@ -743,10 +821,12 @@ OGRArrowWriterLayer::CreateGeomField(const OGRGeomFieldDefn *poField,
                  "Geometry column should have an associated CRS");
     }
     auto eGeomEncoding = m_eGeomEncoding;
-    if (eGeomEncoding == OGRArrowGeomEncoding::GEOARROW_GENERIC)
+    if (eGeomEncoding == OGRArrowGeomEncoding::GEOARROW_FSL_GENERIC ||
+        eGeomEncoding == OGRArrowGeomEncoding::GEOARROW_STRUCT_GENERIC)
     {
-        eGeomEncoding = GetPreciseArrowGeomEncoding(eGType);
-        if (eGeomEncoding == OGRArrowGeomEncoding::GEOARROW_GENERIC)
+        const auto eEncodingType = eGeomEncoding;
+        eGeomEncoding = GetPreciseArrowGeomEncoding(eEncodingType, eGType);
+        if (eGeomEncoding == eEncodingType)
             return OGRERR_FAILURE;
     }
     m_aeGeomEncoding.push_back(eGeomEncoding);
@@ -768,6 +848,29 @@ MakeGeoArrowBuilder(arrow::MemoryPool *poMemoryPool, int nDim, int nDepth)
     else
         return std::make_shared<arrow::ListBuilder>(
             poMemoryPool, MakeGeoArrowBuilder(poMemoryPool, nDim, nDepth - 1));
+}
+
+/************************************************************************/
+/*                      MakeGeoArrowStructBuilder()                     */
+/************************************************************************/
+
+static std::shared_ptr<arrow::ArrayBuilder>
+MakeGeoArrowStructBuilder(arrow::MemoryPool *poMemoryPool, int nDim, int nDepth,
+                          const std::shared_ptr<arrow::DataType> &eBaseType)
+{
+    if (nDepth == 0)
+    {
+        std::vector<std::shared_ptr<arrow::ArrayBuilder>> builders;
+        for (int i = 0; i < nDim; ++i)
+            builders.emplace_back(
+                std::make_shared<arrow::DoubleBuilder>(poMemoryPool));
+        return std::make_shared<arrow::StructBuilder>(eBaseType, poMemoryPool,
+                                                      std::move(builders));
+    }
+    else
+        return std::make_shared<arrow::ListBuilder>(
+            poMemoryPool, MakeGeoArrowStructBuilder(poMemoryPool, nDim,
+                                                    nDepth - 1, eBaseType));
 }
 
 /************************************************************************/
@@ -926,42 +1029,78 @@ inline void OGRArrowWriterLayer::CreateArrayBuilders()
         const int nDim =
             2 + (OGR_GT_HasZ(eGType) ? 1 : 0) + (OGR_GT_HasM(eGType) ? 1 : 0);
 
-        if (m_aeGeomEncoding[i] == OGRArrowGeomEncoding::WKB)
-            builder = std::make_shared<arrow::BinaryBuilder>(m_poMemoryPool);
-        else if (m_aeGeomEncoding[i] == OGRArrowGeomEncoding::WKT)
-            builder = std::make_shared<arrow::StringBuilder>(m_poMemoryPool);
-        else if (m_aeGeomEncoding[i] == OGRArrowGeomEncoding::GEOARROW_POINT)
+        switch (m_aeGeomEncoding[i])
         {
-            builder = MakeGeoArrowBuilder(m_poMemoryPool, nDim, 0);
+            case OGRArrowGeomEncoding::WKB:
+                builder =
+                    std::make_shared<arrow::BinaryBuilder>(m_poMemoryPool);
+                break;
+
+            case OGRArrowGeomEncoding::WKT:
+                builder =
+                    std::make_shared<arrow::StringBuilder>(m_poMemoryPool);
+                break;
+
+            case OGRArrowGeomEncoding::GEOARROW_FSL_POINT:
+                builder = MakeGeoArrowBuilder(m_poMemoryPool, nDim, 0);
+                break;
+
+            case OGRArrowGeomEncoding::GEOARROW_FSL_LINESTRING:
+                builder = MakeGeoArrowBuilder(m_poMemoryPool, nDim, 1);
+                break;
+
+            case OGRArrowGeomEncoding::GEOARROW_FSL_POLYGON:
+                builder = MakeGeoArrowBuilder(m_poMemoryPool, nDim, 2);
+                break;
+
+            case OGRArrowGeomEncoding::GEOARROW_FSL_MULTIPOINT:
+                builder = MakeGeoArrowBuilder(m_poMemoryPool, nDim, 1);
+                break;
+
+            case OGRArrowGeomEncoding::GEOARROW_FSL_MULTILINESTRING:
+                builder = MakeGeoArrowBuilder(m_poMemoryPool, nDim, 2);
+                break;
+
+            case OGRArrowGeomEncoding::GEOARROW_FSL_MULTIPOLYGON:
+                builder = MakeGeoArrowBuilder(m_poMemoryPool, nDim, 3);
+                break;
+
+            case OGRArrowGeomEncoding::GEOARROW_STRUCT_POINT:
+                builder = MakeGeoArrowStructBuilder(m_poMemoryPool, nDim, 0,
+                                                    m_apoBaseStructGeomType[i]);
+                break;
+
+            case OGRArrowGeomEncoding::GEOARROW_STRUCT_LINESTRING:
+                builder = MakeGeoArrowStructBuilder(m_poMemoryPool, nDim, 1,
+                                                    m_apoBaseStructGeomType[i]);
+                break;
+
+            case OGRArrowGeomEncoding::GEOARROW_STRUCT_POLYGON:
+                builder = MakeGeoArrowStructBuilder(m_poMemoryPool, nDim, 2,
+                                                    m_apoBaseStructGeomType[i]);
+                break;
+
+            case OGRArrowGeomEncoding::GEOARROW_STRUCT_MULTIPOINT:
+                builder = MakeGeoArrowStructBuilder(m_poMemoryPool, nDim, 1,
+                                                    m_apoBaseStructGeomType[i]);
+                break;
+
+            case OGRArrowGeomEncoding::GEOARROW_STRUCT_MULTILINESTRING:
+                builder = MakeGeoArrowStructBuilder(m_poMemoryPool, nDim, 2,
+                                                    m_apoBaseStructGeomType[i]);
+                break;
+
+            case OGRArrowGeomEncoding::GEOARROW_STRUCT_MULTIPOLYGON:
+                builder = MakeGeoArrowStructBuilder(m_poMemoryPool, nDim, 3,
+                                                    m_apoBaseStructGeomType[i]);
+                break;
+
+            case OGRArrowGeomEncoding::GEOARROW_FSL_GENERIC:
+            case OGRArrowGeomEncoding::GEOARROW_STRUCT_GENERIC:
+                CPLAssert(false);
+                break;
         }
-        else if (m_aeGeomEncoding[i] ==
-                 OGRArrowGeomEncoding::GEOARROW_LINESTRING)
-        {
-            builder = MakeGeoArrowBuilder(m_poMemoryPool, nDim, 1);
-        }
-        else if (m_aeGeomEncoding[i] == OGRArrowGeomEncoding::GEOARROW_POLYGON)
-        {
-            builder = MakeGeoArrowBuilder(m_poMemoryPool, nDim, 2);
-        }
-        else if (m_aeGeomEncoding[i] ==
-                 OGRArrowGeomEncoding::GEOARROW_MULTIPOINT)
-        {
-            builder = MakeGeoArrowBuilder(m_poMemoryPool, nDim, 1);
-        }
-        else if (m_aeGeomEncoding[i] ==
-                 OGRArrowGeomEncoding::GEOARROW_MULTILINESTRING)
-        {
-            builder = MakeGeoArrowBuilder(m_poMemoryPool, nDim, 2);
-        }
-        else if (m_aeGeomEncoding[i] ==
-                 OGRArrowGeomEncoding::GEOARROW_MULTIPOLYGON)
-        {
-            builder = MakeGeoArrowBuilder(m_poMemoryPool, nDim, 3);
-        }
-        else
-        {
-            CPLAssert(false);
-        }
+
         m_apoBuilders.emplace_back(builder);
 
         if (m_bWriteBBoxStruct)
@@ -1022,6 +1161,31 @@ static float castToFloatUp(double d)
 }
 
 /************************************************************************/
+/*                         GeoArrowLineBuilder()                        */
+/************************************************************************/
+
+template <class PointBuilderType>
+static OGRErr GeoArrowLineBuilder(const OGRLineString *poLS,
+                                  PointBuilderType *poPointBuilder,
+                                  arrow::DoubleBuilder *poXBuilder,
+                                  arrow::DoubleBuilder *poYBuilder,
+                                  arrow::DoubleBuilder *poZBuilder,
+                                  arrow::DoubleBuilder *poMBuilder)
+{
+    for (int j = 0; j < poLS->getNumPoints(); ++j)
+    {
+        OGR_ARROW_RETURN_OGRERR_NOT_OK(poPointBuilder->Append());
+        OGR_ARROW_RETURN_OGRERR_NOT_OK(poXBuilder->Append(poLS->getX(j)));
+        OGR_ARROW_RETURN_OGRERR_NOT_OK(poYBuilder->Append(poLS->getY(j)));
+        if (poZBuilder)
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(poZBuilder->Append(poLS->getZ(j)));
+        if (poMBuilder)
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(poMBuilder->Append(poLS->getM(j)));
+    }
+    return OGRERR_NONE;
+}
+
+/************************************************************************/
 /*                          BuildGeometry()                             */
 /************************************************************************/
 
@@ -1032,6 +1196,8 @@ inline OGRErr OGRArrowWriterLayer::BuildGeometry(OGRGeometry *poGeom,
     const auto eGType = poGeom ? poGeom->getGeometryType() : wkbNone;
     const auto eColumnGType =
         m_poFeatureDefn->GetGeomFieldDefn(iGeomField)->GetType();
+    const bool bHasZ = CPL_TO_BOOL(OGR_GT_HasZ(eColumnGType));
+    const bool bHasM = CPL_TO_BOOL(OGR_GT_HasM(eColumnGType));
     const bool bIsEmpty = poGeom != nullptr && poGeom->IsEmpty();
     OGREnvelope3D oEnvelope;
     if (poGeom != nullptr && !bIsEmpty)
@@ -1078,7 +1244,7 @@ inline OGRErr OGRArrowWriterLayer::BuildGeometry(OGRGeometry *poGeom,
     if (poGeom == nullptr)
     {
         if (m_aeGeomEncoding[iGeomField] ==
-                OGRArrowGeomEncoding::GEOARROW_POINT &&
+                OGRArrowGeomEncoding::GEOARROW_FSL_POINT &&
             GetDriverUCName() == "PARQUET")
         {
             // For some reason, Parquet doesn't support a NULL FixedSizeList
@@ -1103,265 +1269,408 @@ inline OGRErr OGRArrowWriterLayer::BuildGeometry(OGRGeometry *poGeom,
         {
             OGR_ARROW_RETURN_OGRERR_NOT_OK(poBuilder->AppendNull());
         }
+
+        return OGRERR_NONE;
     }
-    else if (m_aeGeomEncoding[iGeomField] == OGRArrowGeomEncoding::WKB)
+
+    // The following checks are only valid for GeoArrow encoding
+    if (m_aeGeomEncoding[iGeomField] != OGRArrowGeomEncoding::WKB &&
+        m_aeGeomEncoding[iGeomField] != OGRArrowGeomEncoding::WKT)
     {
-        std::unique_ptr<OGRGeometry> poGeomModified;
-        if (OGR_GT_HasM(eGType) && !OGR_GT_HasM(eColumnGType))
-        {
-            static bool bHasWarned = false;
-            if (!bHasWarned)
-            {
-                CPLError(CE_Warning, CPLE_AppDefined,
-                         "Removing M component from geometry");
-                bHasWarned = true;
-            }
-            poGeomModified.reset(poGeom->clone());
-            poGeomModified->setMeasured(false);
-            poGeom = poGeomModified.get();
-        }
-        FixupGeometryBeforeWriting(poGeom);
-        const auto nSize = poGeom->WkbSize();
-        if (nSize < INT_MAX)
-        {
-            m_abyBuffer.resize(nSize);
-            poGeom->exportToWkb(wkbNDR, &m_abyBuffer[0], wkbVariantIso);
-            OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                static_cast<arrow::BinaryBuilder *>(poBuilder)->Append(
-                    m_abyBuffer.data(), static_cast<int>(m_abyBuffer.size())));
-        }
-        else
+        if ((!bIsEmpty && eGType != eColumnGType) ||
+            (bIsEmpty && wkbFlatten(eGType) != wkbFlatten(eColumnGType)))
         {
             CPLError(CE_Warning, CPLE_AppDefined,
-                     "Too big geometry. "
-                     "Writing null geometry");
+                     "Geometry of type %s found, whereas %s is expected. "
+                     "Writing null geometry",
+                     OGRGeometryTypeToName(eGType),
+                     OGRGeometryTypeToName(eColumnGType));
             OGR_ARROW_RETURN_OGRERR_NOT_OK(poBuilder->AppendNull());
+
+            return OGRERR_NONE;
         }
     }
-    else if (m_aeGeomEncoding[iGeomField] == OGRArrowGeomEncoding::WKT)
+
+    switch (m_aeGeomEncoding[iGeomField])
     {
-        OGRWktOptions options;
-        options.variant = wkbVariantIso;
-        if (m_nWKTCoordinatePrecision >= 0)
+        case OGRArrowGeomEncoding::WKB:
         {
-            options.format = OGRWktFormat::F;
-            options.xyPrecision = m_nWKTCoordinatePrecision;
-            options.zPrecision = m_nWKTCoordinatePrecision;
-            options.mPrecision = m_nWKTCoordinatePrecision;
-        }
-        OGR_ARROW_RETURN_OGRERR_NOT_OK(
-            static_cast<arrow::StringBuilder *>(poBuilder)->Append(
-                poGeom->exportToWkt(options)));
-    }
-    // The following checks are only valid for GeoArrow encoding
-    else if ((!bIsEmpty && eGType != eColumnGType) ||
-             (bIsEmpty && wkbFlatten(eGType) != wkbFlatten(eColumnGType)))
-    {
-        CPLError(CE_Warning, CPLE_AppDefined,
-                 "Geometry of type %s found, whereas %s is expected. "
-                 "Writing null geometry",
-                 OGRGeometryTypeToName(eGType),
-                 OGRGeometryTypeToName(eColumnGType));
-        OGR_ARROW_RETURN_OGRERR_NOT_OK(poBuilder->AppendNull());
-    }
-    else if (!bIsEmpty && poGeom->Is3D() != OGR_GT_HasZ(eColumnGType))
-    {
-        CPLError(CE_Warning, CPLE_AppDefined,
-                 "Geometry Z flag (%d) != column geometry type Z flag (%d)d. "
-                 "Writing null geometry",
-                 poGeom->Is3D(), OGR_GT_HasZ(eColumnGType));
-        OGR_ARROW_RETURN_OGRERR_NOT_OK(poBuilder->AppendNull());
-    }
-    else if (!bIsEmpty && poGeom->IsMeasured() != OGR_GT_HasM(eColumnGType))
-    {
-        CPLError(CE_Warning, CPLE_AppDefined,
-                 "Geometry M flag (%d) != column geometry type M flag (%d)d. "
-                 "Writing null geometry",
-                 poGeom->IsMeasured(), OGR_GT_HasM(eColumnGType));
-        OGR_ARROW_RETURN_OGRERR_NOT_OK(poBuilder->AppendNull());
-    }
-    else if (m_aeGeomEncoding[iGeomField] ==
-             OGRArrowGeomEncoding::GEOARROW_POINT)
-    {
-        const auto poPoint = poGeom->toPoint();
-        auto poPointBuilder =
-            static_cast<arrow::FixedSizeListBuilder *>(poBuilder);
-        OGR_ARROW_RETURN_OGRERR_NOT_OK(poPointBuilder->Append());
-        auto poValueBuilder = static_cast<arrow::DoubleBuilder *>(
-            poPointBuilder->value_builder());
-        if (bIsEmpty)
-        {
-            OGR_ARROW_RETURN_OGRERR_NOT_OK(poValueBuilder->Append(
-                std::numeric_limits<double>::quiet_NaN()));
-            OGR_ARROW_RETURN_OGRERR_NOT_OK(poValueBuilder->Append(
-                std::numeric_limits<double>::quiet_NaN()));
-        }
-        else
-        {
-            OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                poValueBuilder->Append(poPoint->getX()));
-            OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                poValueBuilder->Append(poPoint->getY()));
-        }
-        if (OGR_GT_HasZ(eColumnGType))
-            OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                poValueBuilder->Append(poPoint->getZ()));
-        if (OGR_GT_HasM(eColumnGType))
-            OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                poValueBuilder->Append(poPoint->getM()));
-    }
-    else if (m_aeGeomEncoding[iGeomField] ==
-             OGRArrowGeomEncoding::GEOARROW_LINESTRING)
-    {
-        const auto poLS = poGeom->toLineString();
-        auto poListBuilder = static_cast<arrow::ListBuilder *>(poBuilder);
-        auto poPointBuilder = static_cast<arrow::FixedSizeListBuilder *>(
-            poListBuilder->value_builder());
-        auto poValueBuilder = static_cast<arrow::DoubleBuilder *>(
-            poPointBuilder->value_builder());
-        OGR_ARROW_RETURN_OGRERR_NOT_OK(poListBuilder->Append());
-        for (int j = 0; j < poLS->getNumPoints(); ++j)
-        {
-            OGR_ARROW_RETURN_OGRERR_NOT_OK(poPointBuilder->Append());
-            OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                poValueBuilder->Append(poLS->getX(j)));
-            OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                poValueBuilder->Append(poLS->getY(j)));
-            if (poGeom->Is3D())
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                    poValueBuilder->Append(poLS->getZ(j)));
-            if (poGeom->IsMeasured())
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                    poValueBuilder->Append(poLS->getM(j)));
-        }
-    }
-    else if (m_aeGeomEncoding[iGeomField] ==
-             OGRArrowGeomEncoding::GEOARROW_POLYGON)
-    {
-        const auto poPolygon = poGeom->toPolygon();
-        auto poPolygonBuilder = static_cast<arrow::ListBuilder *>(poBuilder);
-        auto poRingBuilder = static_cast<arrow::ListBuilder *>(
-            poPolygonBuilder->value_builder());
-        auto poPointBuilder = static_cast<arrow::FixedSizeListBuilder *>(
-            poRingBuilder->value_builder());
-        auto poValueBuilder = static_cast<arrow::DoubleBuilder *>(
-            poPointBuilder->value_builder());
-        OGR_ARROW_RETURN_OGRERR_NOT_OK(poPolygonBuilder->Append());
-        for (const auto *poRing : *poPolygon)
-        {
-            OGR_ARROW_RETURN_OGRERR_NOT_OK(poRingBuilder->Append());
-            for (int j = 0; j < poRing->getNumPoints(); ++j)
+            std::unique_ptr<OGRGeometry> poGeomModified;
+            if (OGR_GT_HasM(eGType) && !OGR_GT_HasM(eColumnGType))
             {
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(poPointBuilder->Append());
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                    poValueBuilder->Append(poRing->getX(j)));
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                    poValueBuilder->Append(poRing->getY(j)));
-                if (poGeom->Is3D())
-                    OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                        poValueBuilder->Append(poRing->getZ(j)));
-                if (poGeom->IsMeasured())
-                    OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                        poValueBuilder->Append(poRing->getM(j)));
+                static bool bHasWarned = false;
+                if (!bHasWarned)
+                {
+                    CPLError(CE_Warning, CPLE_AppDefined,
+                             "Removing M component from geometry");
+                    bHasWarned = true;
+                }
+                poGeomModified.reset(poGeom->clone());
+                poGeomModified->setMeasured(false);
+                poGeom = poGeomModified.get();
             }
+            FixupGeometryBeforeWriting(poGeom);
+            const auto nSize = poGeom->WkbSize();
+            if (nSize < INT_MAX)
+            {
+                m_abyBuffer.resize(nSize);
+                poGeom->exportToWkb(wkbNDR, &m_abyBuffer[0], wkbVariantIso);
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                    static_cast<arrow::BinaryBuilder *>(poBuilder)->Append(
+                        m_abyBuffer.data(),
+                        static_cast<int>(m_abyBuffer.size())));
+            }
+            else
+            {
+                CPLError(CE_Warning, CPLE_AppDefined,
+                         "Too big geometry. "
+                         "Writing null geometry");
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(poBuilder->AppendNull());
+            }
+            break;
         }
-    }
-    else if (m_aeGeomEncoding[iGeomField] ==
-             OGRArrowGeomEncoding::GEOARROW_MULTIPOINT)
-    {
-        const auto poMultiPoint = poGeom->toMultiPoint();
-        auto poListBuilder = static_cast<arrow::ListBuilder *>(poBuilder);
-        auto poPointBuilder = static_cast<arrow::FixedSizeListBuilder *>(
-            poListBuilder->value_builder());
-        auto poValueBuilder = static_cast<arrow::DoubleBuilder *>(
-            poPointBuilder->value_builder());
-        OGR_ARROW_RETURN_OGRERR_NOT_OK(poListBuilder->Append());
-        for (const auto *poPoint : *poMultiPoint)
+
+        case OGRArrowGeomEncoding::WKT:
         {
+            OGRWktOptions options;
+            options.variant = wkbVariantIso;
+            if (m_nWKTCoordinatePrecision >= 0)
+            {
+                options.format = OGRWktFormat::F;
+                options.xyPrecision = m_nWKTCoordinatePrecision;
+                options.zPrecision = m_nWKTCoordinatePrecision;
+                options.mPrecision = m_nWKTCoordinatePrecision;
+            }
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                static_cast<arrow::StringBuilder *>(poBuilder)->Append(
+                    poGeom->exportToWkt(options)));
+            break;
+        }
+
+        case OGRArrowGeomEncoding::GEOARROW_FSL_POINT:
+        {
+            const auto poPoint = poGeom->toPoint();
+            auto poPointBuilder =
+                static_cast<arrow::FixedSizeListBuilder *>(poBuilder);
             OGR_ARROW_RETURN_OGRERR_NOT_OK(poPointBuilder->Append());
-            OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                poValueBuilder->Append(poPoint->getX()));
-            OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                poValueBuilder->Append(poPoint->getY()));
-            if (poGeom->Is3D())
+            auto poValueBuilder = static_cast<arrow::DoubleBuilder *>(
+                poPointBuilder->value_builder());
+            if (bIsEmpty)
+            {
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(poValueBuilder->Append(
+                    std::numeric_limits<double>::quiet_NaN()));
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(poValueBuilder->Append(
+                    std::numeric_limits<double>::quiet_NaN()));
+            }
+            else
+            {
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                    poValueBuilder->Append(poPoint->getX()));
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                    poValueBuilder->Append(poPoint->getY()));
+            }
+            if (bHasZ)
                 OGR_ARROW_RETURN_OGRERR_NOT_OK(
                     poValueBuilder->Append(poPoint->getZ()));
-            if (poGeom->IsMeasured())
+            if (bHasM)
                 OGR_ARROW_RETURN_OGRERR_NOT_OK(
                     poValueBuilder->Append(poPoint->getM()));
+            break;
         }
-    }
-    else if (m_aeGeomEncoding[iGeomField] ==
-             OGRArrowGeomEncoding::GEOARROW_MULTILINESTRING)
-    {
-        const auto poMLS = poGeom->toMultiLineString();
-        auto poMLSBuilder = static_cast<arrow::ListBuilder *>(poBuilder);
-        auto poLSBuilder =
-            static_cast<arrow::ListBuilder *>(poMLSBuilder->value_builder());
-        auto poPointBuilder = static_cast<arrow::FixedSizeListBuilder *>(
-            poLSBuilder->value_builder());
-        auto poValueBuilder = static_cast<arrow::DoubleBuilder *>(
-            poPointBuilder->value_builder());
-        OGR_ARROW_RETURN_OGRERR_NOT_OK(poMLSBuilder->Append());
-        for (const auto *poLS : *poMLS)
+
+#define GET_XYZM_STRUCT_FIELD_BUILDERS_FROM(poPointBuilder)                    \
+    auto poXBuilder =                                                          \
+        static_cast<arrow::DoubleBuilder *>(poPointBuilder->field_builder(0)); \
+    auto poYBuilder =                                                          \
+        static_cast<arrow::DoubleBuilder *>(poPointBuilder->field_builder(1)); \
+    int iSubField = 2;                                                         \
+    arrow::DoubleBuilder *poZBuilder = nullptr;                                \
+    if (bHasZ)                                                                 \
+    {                                                                          \
+        poZBuilder = static_cast<arrow::DoubleBuilder *>(                      \
+            poPointBuilder->field_builder(iSubField));                         \
+        ++iSubField;                                                           \
+    }                                                                          \
+    arrow::DoubleBuilder *poMBuilder = nullptr;                                \
+    if (bHasM)                                                                 \
+    {                                                                          \
+        poMBuilder = static_cast<arrow::DoubleBuilder *>(                      \
+            poPointBuilder->field_builder(iSubField));                         \
+    }                                                                          \
+    do                                                                         \
+    {                                                                          \
+    } while (0)
+
+        case OGRArrowGeomEncoding::GEOARROW_STRUCT_POINT:
         {
-            OGR_ARROW_RETURN_OGRERR_NOT_OK(poLSBuilder->Append());
-            for (int j = 0; j < poLS->getNumPoints(); ++j)
+            const auto poPoint = poGeom->toPoint();
+            auto poPointBuilder =
+                static_cast<arrow::StructBuilder *>(poBuilder);
+            GET_XYZM_STRUCT_FIELD_BUILDERS_FROM(poPointBuilder);
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(poPointBuilder->Append());
+
+            if (bIsEmpty)
             {
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(poPointBuilder->Append());
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                    poValueBuilder->Append(poLS->getX(j)));
-                OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                    poValueBuilder->Append(poLS->getY(j)));
-                if (poGeom->Is3D())
-                    OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                        poValueBuilder->Append(poLS->getZ(j)));
-                if (poGeom->IsMeasured())
-                    OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                        poValueBuilder->Append(poLS->getM(j)));
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(poXBuilder->Append(
+                    std::numeric_limits<double>::quiet_NaN()));
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(poYBuilder->Append(
+                    std::numeric_limits<double>::quiet_NaN()));
             }
+            else
+            {
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                    poXBuilder->Append(poPoint->getX()));
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                    poYBuilder->Append(poPoint->getY()));
+            }
+            if (poZBuilder)
+            {
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(poZBuilder->Append(
+                    bIsEmpty ? std::numeric_limits<double>::quiet_NaN()
+                             : poPoint->getZ()));
+            }
+            if (poMBuilder)
+            {
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(poMBuilder->Append(
+                    bIsEmpty ? std::numeric_limits<double>::quiet_NaN()
+                             : poPoint->getM()));
+            }
+            break;
         }
-    }
-    else if (m_aeGeomEncoding[iGeomField] ==
-             OGRArrowGeomEncoding::GEOARROW_MULTIPOLYGON)
-    {
-        const auto poMPoly = poGeom->toMultiPolygon();
-        auto poMPolyBuilder = static_cast<arrow::ListBuilder *>(poBuilder);
-        auto poPolyBuilder =
-            static_cast<arrow::ListBuilder *>(poMPolyBuilder->value_builder());
-        auto poRingBuilder =
-            static_cast<arrow::ListBuilder *>(poPolyBuilder->value_builder());
-        auto poPointBuilder = static_cast<arrow::FixedSizeListBuilder *>(
-            poRingBuilder->value_builder());
-        auto poValueBuilder = static_cast<arrow::DoubleBuilder *>(
-            poPointBuilder->value_builder());
-        OGR_ARROW_RETURN_OGRERR_NOT_OK(poMPolyBuilder->Append());
-        for (const auto *poPolygon : *poMPoly)
+
+        case OGRArrowGeomEncoding::GEOARROW_FSL_LINESTRING:
         {
-            OGR_ARROW_RETURN_OGRERR_NOT_OK(poPolyBuilder->Append());
+            const auto poLS = poGeom->toLineString();
+            auto poListBuilder = static_cast<arrow::ListBuilder *>(poBuilder);
+            auto poPointBuilder = static_cast<arrow::FixedSizeListBuilder *>(
+                poListBuilder->value_builder());
+            auto poValueBuilder = static_cast<arrow::DoubleBuilder *>(
+                poPointBuilder->value_builder());
+
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(poListBuilder->Append());
+            OGR_ARROW_PROPAGATE_OGRERR(GeoArrowLineBuilder(
+                poLS, poPointBuilder, poValueBuilder, poValueBuilder,
+                bHasZ ? poValueBuilder : nullptr,
+                bHasM ? poValueBuilder : nullptr));
+            break;
+        }
+
+        case OGRArrowGeomEncoding::GEOARROW_STRUCT_LINESTRING:
+        {
+            const auto poLS = poGeom->toLineString();
+            auto poListBuilder = static_cast<arrow::ListBuilder *>(poBuilder);
+            auto poPointBuilder = static_cast<arrow::StructBuilder *>(
+                poListBuilder->value_builder());
+            GET_XYZM_STRUCT_FIELD_BUILDERS_FROM(poPointBuilder);
+
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(poListBuilder->Append());
+            OGR_ARROW_PROPAGATE_OGRERR(
+                GeoArrowLineBuilder(poLS, poPointBuilder, poXBuilder,
+                                    poYBuilder, poZBuilder, poMBuilder));
+            break;
+        }
+
+        case OGRArrowGeomEncoding::GEOARROW_FSL_POLYGON:
+        {
+            const auto poPolygon = poGeom->toPolygon();
+            auto poPolygonBuilder =
+                static_cast<arrow::ListBuilder *>(poBuilder);
+            auto poRingBuilder = static_cast<arrow::ListBuilder *>(
+                poPolygonBuilder->value_builder());
+            auto poPointBuilder = static_cast<arrow::FixedSizeListBuilder *>(
+                poRingBuilder->value_builder());
+            auto poValueBuilder = static_cast<arrow::DoubleBuilder *>(
+                poPointBuilder->value_builder());
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(poPolygonBuilder->Append());
             for (const auto *poRing : *poPolygon)
             {
                 OGR_ARROW_RETURN_OGRERR_NOT_OK(poRingBuilder->Append());
-                for (int j = 0; j < poRing->getNumPoints(); ++j)
+                OGR_ARROW_PROPAGATE_OGRERR(GeoArrowLineBuilder(
+                    poRing, poPointBuilder, poValueBuilder, poValueBuilder,
+                    bHasZ ? poValueBuilder : nullptr,
+                    bHasM ? poValueBuilder : nullptr));
+            }
+            break;
+        }
+
+        case OGRArrowGeomEncoding::GEOARROW_STRUCT_POLYGON:
+        {
+            const auto poPolygon = poGeom->toPolygon();
+            auto poPolygonBuilder =
+                static_cast<arrow::ListBuilder *>(poBuilder);
+            auto poRingBuilder = static_cast<arrow::ListBuilder *>(
+                poPolygonBuilder->value_builder());
+            auto poPointBuilder = static_cast<arrow::StructBuilder *>(
+                poRingBuilder->value_builder());
+            GET_XYZM_STRUCT_FIELD_BUILDERS_FROM(poPointBuilder);
+
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(poPolygonBuilder->Append());
+            for (const auto *poRing : *poPolygon)
+            {
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(poRingBuilder->Append());
+                OGR_ARROW_PROPAGATE_OGRERR(
+                    GeoArrowLineBuilder(poRing, poPointBuilder, poXBuilder,
+                                        poYBuilder, poZBuilder, poMBuilder));
+            }
+            break;
+        }
+
+        case OGRArrowGeomEncoding::GEOARROW_FSL_MULTIPOINT:
+        {
+            const auto poMultiPoint = poGeom->toMultiPoint();
+            auto poListBuilder = static_cast<arrow::ListBuilder *>(poBuilder);
+            auto poPointBuilder = static_cast<arrow::FixedSizeListBuilder *>(
+                poListBuilder->value_builder());
+            auto poValueBuilder = static_cast<arrow::DoubleBuilder *>(
+                poPointBuilder->value_builder());
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(poListBuilder->Append());
+            for (const auto *poPoint : *poMultiPoint)
+            {
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(poPointBuilder->Append());
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                    poValueBuilder->Append(poPoint->getX()));
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                    poValueBuilder->Append(poPoint->getY()));
+                if (bHasZ)
+                    OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                        poValueBuilder->Append(poPoint->getZ()));
+                if (bHasM)
+                    OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                        poValueBuilder->Append(poPoint->getM()));
+            }
+            break;
+        }
+
+        case OGRArrowGeomEncoding::GEOARROW_STRUCT_MULTIPOINT:
+        {
+            const auto poMultiPoint = poGeom->toMultiPoint();
+            auto poListBuilder = static_cast<arrow::ListBuilder *>(poBuilder);
+            auto poPointBuilder = static_cast<arrow::StructBuilder *>(
+                poListBuilder->value_builder());
+            GET_XYZM_STRUCT_FIELD_BUILDERS_FROM(poPointBuilder);
+
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(poListBuilder->Append());
+            for (const auto *poPoint : *poMultiPoint)
+            {
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(poPointBuilder->Append());
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                    poXBuilder->Append(poPoint->getX()));
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                    poYBuilder->Append(poPoint->getY()));
+                if (poZBuilder)
+                    OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                        poZBuilder->Append(poPoint->getZ()));
+                if (poMBuilder)
+                    OGR_ARROW_RETURN_OGRERR_NOT_OK(
+                        poMBuilder->Append(poPoint->getM()));
+            }
+            break;
+        }
+
+        case OGRArrowGeomEncoding::GEOARROW_FSL_MULTILINESTRING:
+        {
+            const auto poMLS = poGeom->toMultiLineString();
+            auto poMLSBuilder = static_cast<arrow::ListBuilder *>(poBuilder);
+            auto poLSBuilder = static_cast<arrow::ListBuilder *>(
+                poMLSBuilder->value_builder());
+            auto poPointBuilder = static_cast<arrow::FixedSizeListBuilder *>(
+                poLSBuilder->value_builder());
+            auto poValueBuilder = static_cast<arrow::DoubleBuilder *>(
+                poPointBuilder->value_builder());
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(poMLSBuilder->Append());
+            for (const auto *poLS : *poMLS)
+            {
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(poLSBuilder->Append());
+                OGR_ARROW_PROPAGATE_OGRERR(GeoArrowLineBuilder(
+                    poLS, poPointBuilder, poValueBuilder, poValueBuilder,
+                    bHasZ ? poValueBuilder : nullptr,
+                    bHasM ? poValueBuilder : nullptr));
+            }
+            break;
+        }
+
+        case OGRArrowGeomEncoding::GEOARROW_STRUCT_MULTILINESTRING:
+        {
+            const auto poMLS = poGeom->toMultiLineString();
+            auto poMLSBuilder = static_cast<arrow::ListBuilder *>(poBuilder);
+            auto poLSBuilder = static_cast<arrow::ListBuilder *>(
+                poMLSBuilder->value_builder());
+            auto poPointBuilder = static_cast<arrow::StructBuilder *>(
+                poLSBuilder->value_builder());
+            GET_XYZM_STRUCT_FIELD_BUILDERS_FROM(poPointBuilder);
+
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(poMLSBuilder->Append());
+            for (const auto *poLS : *poMLS)
+            {
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(poLSBuilder->Append());
+                OGR_ARROW_PROPAGATE_OGRERR(
+                    GeoArrowLineBuilder(poLS, poPointBuilder, poXBuilder,
+                                        poYBuilder, poZBuilder, poMBuilder));
+            }
+            break;
+        }
+
+        case OGRArrowGeomEncoding::GEOARROW_FSL_MULTIPOLYGON:
+        {
+            const auto poMPoly = poGeom->toMultiPolygon();
+            auto poMPolyBuilder = static_cast<arrow::ListBuilder *>(poBuilder);
+            auto poPolyBuilder = static_cast<arrow::ListBuilder *>(
+                poMPolyBuilder->value_builder());
+            auto poRingBuilder = static_cast<arrow::ListBuilder *>(
+                poPolyBuilder->value_builder());
+            auto poPointBuilder = static_cast<arrow::FixedSizeListBuilder *>(
+                poRingBuilder->value_builder());
+            auto poValueBuilder = static_cast<arrow::DoubleBuilder *>(
+                poPointBuilder->value_builder());
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(poMPolyBuilder->Append());
+            for (const auto *poPolygon : *poMPoly)
+            {
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(poPolyBuilder->Append());
+                for (const auto *poRing : *poPolygon)
                 {
-                    OGR_ARROW_RETURN_OGRERR_NOT_OK(poPointBuilder->Append());
-                    OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                        poValueBuilder->Append(poRing->getX(j)));
-                    OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                        poValueBuilder->Append(poRing->getY(j)));
-                    if (poGeom->Is3D())
-                        OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                            poValueBuilder->Append(poRing->getZ(j)));
-                    if (poGeom->IsMeasured())
-                        OGR_ARROW_RETURN_OGRERR_NOT_OK(
-                            poValueBuilder->Append(poRing->getM(j)));
+                    OGR_ARROW_RETURN_OGRERR_NOT_OK(poRingBuilder->Append());
+                    OGR_ARROW_PROPAGATE_OGRERR(GeoArrowLineBuilder(
+                        poRing, poPointBuilder, poValueBuilder, poValueBuilder,
+                        bHasZ ? poValueBuilder : nullptr,
+                        bHasM ? poValueBuilder : nullptr));
                 }
             }
+            break;
         }
-    }
-    else
-    {
-        CPLAssert(false);
+
+        case OGRArrowGeomEncoding::GEOARROW_STRUCT_MULTIPOLYGON:
+        {
+            const auto poMPoly = poGeom->toMultiPolygon();
+            auto poMPolyBuilder = static_cast<arrow::ListBuilder *>(poBuilder);
+            auto poPolyBuilder = static_cast<arrow::ListBuilder *>(
+                poMPolyBuilder->value_builder());
+            auto poRingBuilder = static_cast<arrow::ListBuilder *>(
+                poPolyBuilder->value_builder());
+            auto poPointBuilder = static_cast<arrow::StructBuilder *>(
+                poRingBuilder->value_builder());
+            GET_XYZM_STRUCT_FIELD_BUILDERS_FROM(poPointBuilder);
+
+            OGR_ARROW_RETURN_OGRERR_NOT_OK(poMPolyBuilder->Append());
+            for (const auto *poPolygon : *poMPoly)
+            {
+                OGR_ARROW_RETURN_OGRERR_NOT_OK(poPolyBuilder->Append());
+                for (const auto *poRing : *poPolygon)
+                {
+                    OGR_ARROW_RETURN_OGRERR_NOT_OK(poRingBuilder->Append());
+                    OGR_ARROW_PROPAGATE_OGRERR(GeoArrowLineBuilder(
+                        poRing, poPointBuilder, poXBuilder, poYBuilder,
+                        poZBuilder, poMBuilder));
+                }
+            }
+            break;
+        }
+
+        case OGRArrowGeomEncoding::GEOARROW_FSL_GENERIC:
+        case OGRArrowGeomEncoding::GEOARROW_STRUCT_GENERIC:
+        {
+            CPLAssert(false);
+            break;
+        }
     }
 
     return OGRERR_NONE;

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowwriterlayer.hpp
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowwriterlayer.hpp
@@ -759,9 +759,9 @@ OGRArrowWriterLayer::GetGeomEncodingAsString(OGRArrowGeomEncoding eGeomEncoding,
     switch (eGeomEncoding)
     {
         case OGRArrowGeomEncoding::WKB:
-            return bForParquetGeo ? "WKB" : "ogc.wkb";
+            return bForParquetGeo ? "WKB" : "geoarrow.wkb";
         case OGRArrowGeomEncoding::WKT:
-            return bForParquetGeo ? "WKT" : "ogc.wkt";
+            return bForParquetGeo ? "WKT" : "geoarrow.wkt";
         case OGRArrowGeomEncoding::GEOARROW_FSL_GENERIC:
         case OGRArrowGeomEncoding::GEOARROW_STRUCT_GENERIC:
             CPLAssert(false);

--- a/ogr/ogrsf_frmts/parquet/ogr_parquet.h
+++ b/ogr/ogrsf_frmts/parquet/ogr_parquet.h
@@ -86,7 +86,13 @@ class OGRParquetLayer final : public OGRParquetLayerBase
     std::vector<std::vector<int>> m_anMapGeomFieldIndexToParquetColumns{};
     bool m_bHasMissingMappingToParquet = false;
 
-    std::vector<int64_t> m_anSelectedGroupsStartFeatureIdx{};
+    //! Contains pairs of (selected feature idx, total feature idx) break points.
+    std::vector<std::pair<int64_t, int64_t>> m_asFeatureIdxRemapping{};
+    //! Iterator over m_asFeatureIdxRemapping
+    std::vector<std::pair<int64_t, int64_t>>::iterator
+        m_oFeatureIdxRemappingIter{};
+    //! Feature index among the potentially restricted set of selected row gropus
+    int64_t m_nFeatureIdxSelected = 0;
     std::vector<int> m_anRequestedParquetColumns{};  // only valid when
                                                      // m_bIgnoredFields is set
 #ifdef DEBUG
@@ -139,6 +145,8 @@ class OGRParquetLayer final : public OGRParquetLayerBase
     }
 
     bool FastGetExtent(int iGeomField, OGREnvelope *psExtent) const override;
+
+    void IncrFeatureIdx() override;
 
   public:
     OGRParquetLayer(OGRParquetDataset *poDS, const char *pszLayerName,

--- a/ogr/ogrsf_frmts/parquet/ogr_parquet.h
+++ b/ogr/ogrsf_frmts/parquet/ogr_parquet.h
@@ -83,7 +83,7 @@ class OGRParquetLayer final : public OGRParquetLayerBase
     std::vector<std::shared_ptr<arrow::DataType>>
         m_apoArrowDataTypes{};  // .size() == field ocunt
     std::vector<int> m_anMapFieldIndexToParquetColumn{};
-    std::vector<int> m_anMapGeomFieldIndexToParquetColumn{};
+    std::vector<std::vector<int>> m_anMapGeomFieldIndexToParquetColumns{};
     bool m_bHasMissingMappingToParquet = false;
 
     std::vector<int64_t> m_anSelectedGroupsStartFeatureIdx{};

--- a/ogr/ogrsf_frmts/parquet/ogrparquetdriver.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetdriver.cpp
@@ -838,10 +838,14 @@ void OGRParquetDriver::InitMetadata()
         CPLAddXMLAttributeAndValue(psOption, "description",
                                    "Encoding of geometry columns");
         CPLAddXMLAttributeAndValue(psOption, "default", "WKB");
-        for (const char *pszEncoding : {"WKB", "WKT", "GEOARROW"})
+        for (const char *pszEncoding :
+             {"WKB", "WKT", "GEOARROW", "GEOARROW_INTERLEAVED"})
         {
             auto poValueNode = CPLCreateXMLNode(psOption, CXT_Element, "Value");
             CPLCreateXMLNode(poValueNode, CXT_Text, pszEncoding);
+            if (EQUAL(pszEncoding, "GEOARROW"))
+                CPLAddXMLAttributeAndValue(poValueNode, "alias",
+                                           "GEOARROW_STRUCT");
         }
     }
 

--- a/ogr/ogrsf_frmts/parquet/ogrparquetwriterlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetwriterlayer.cpp
@@ -366,8 +366,24 @@ bool OGRParquetWriterLayer::SetOptions(CSLConstList papszOptions,
             m_eGeomEncoding = OGRArrowGeomEncoding::WKB;
         else if (EQUAL(pszGeomEncoding, "WKT"))
             m_eGeomEncoding = OGRArrowGeomEncoding::WKT;
-        else if (EQUAL(pszGeomEncoding, "GEOARROW"))
-            m_eGeomEncoding = OGRArrowGeomEncoding::GEOARROW_GENERIC;
+        else if (EQUAL(pszGeomEncoding, "GEOARROW_INTERLEAVED"))
+        {
+            static bool bHasWarned = false;
+            if (!bHasWarned)
+            {
+                bHasWarned = true;
+                CPLError(
+                    CE_Warning, CPLE_AppDefined,
+                    "Use of GEOMETRY_ENCODING=GEOARROW_INTERLEAVED is not "
+                    "recommended. "
+                    "GeoParquet 1.1 uses GEOMETRY_ENCODING=GEOARROW (struct) "
+                    "instead.");
+            }
+            m_eGeomEncoding = OGRArrowGeomEncoding::GEOARROW_FSL_GENERIC;
+        }
+        else if (EQUAL(pszGeomEncoding, "GEOARROW") ||
+                 EQUAL(pszGeomEncoding, "GEOARROW_STRUCT"))
+            m_eGeomEncoding = OGRArrowGeomEncoding::GEOARROW_STRUCT_GENERIC;
         else
         {
             CPLError(CE_Failure, CPLE_NotSupported,
@@ -395,10 +411,12 @@ bool OGRParquetWriterLayer::SetOptions(CSLConstList papszOptions,
 
         m_poFeatureDefn->SetGeomType(eGType);
         auto eGeomEncoding = m_eGeomEncoding;
-        if (eGeomEncoding == OGRArrowGeomEncoding::GEOARROW_GENERIC)
+        if (eGeomEncoding == OGRArrowGeomEncoding::GEOARROW_FSL_GENERIC ||
+            eGeomEncoding == OGRArrowGeomEncoding::GEOARROW_STRUCT_GENERIC)
         {
-            eGeomEncoding = GetPreciseArrowGeomEncoding(eGType);
-            if (eGeomEncoding == OGRArrowGeomEncoding::GEOARROW_GENERIC)
+            const auto eEncodingType = eGeomEncoding;
+            eGeomEncoding = GetPreciseArrowGeomEncoding(eEncodingType, eGType);
+            if (eGeomEncoding == eEncodingType)
                 return false;
         }
         m_aeGeomEncoding.push_back(eGeomEncoding);
@@ -634,7 +652,11 @@ std::string OGRParquetWriterLayer::GetGeoMetadata() const
         CPLTestBool(CPLGetConfigOption("OGR_PARQUET_WRITE_GEO", "YES")))
     {
         CPLJSONObject oRoot;
-        oRoot.Add("version", "1.0.0");
+        oRoot.Add("version",
+                  m_eGeomEncoding ==
+                          OGRArrowGeomEncoding::GEOARROW_STRUCT_GENERIC
+                      ? "1.1.0"
+                      : "1.0.0");
         oRoot.Add("primary_column",
                   m_poFeatureDefn->GetGeomFieldDefn(0)->GetNameRef());
         CPLJSONObject oColumns;

--- a/swig/python/gdal-utils/osgeo_utils/samples/validate_geoparquet.py
+++ b/swig/python/gdal-utils/osgeo_utils/samples/validate_geoparquet.py
@@ -181,8 +181,7 @@ class GeoParquetValidator(object):
             if not self.local_schema:
                 return
 
-        if self.local_schema:
-            schema_j = json.loads(open(self.local_schema, "rb").read())
+            version = None
         else:
             version = geo_j["version"]
             if not isinstance(version, str):
@@ -190,7 +189,15 @@ class GeoParquetValidator(object):
                     "'geo[\"version\"]' is not a string. Value of 'geo' = '%s'" % geo
                 )
 
-            schema_url = f"https://github.com/opengeospatial/geoparquet/releases/download/v{version}/schema.json"
+        if self.local_schema:
+            schema_j = json.loads(open(self.local_schema, "rb").read())
+        else:
+            # FIXME: Remove that temporary hack once GeoParquet 1.1 schema is released
+            if version == "1.1.0":
+                schema_url = "https://github.com/opengeospatial/geoparquet/releases/download/v1.0.0/schema.json"
+            else:
+                schema_url = f"https://github.com/opengeospatial/geoparquet/releases/download/v{version}/schema.json"
+
             if schema_url not in geoparquet_schemas:
                 import urllib
 
@@ -209,6 +216,16 @@ class GeoParquetValidator(object):
                     )
 
             schema_j = geoparquet_schemas[schema_url]
+
+        # FIXME: Remove that temporary hack once GeoParquet 1.1 schema is released
+        if version == "1.1.0":
+            schema_j["properties"]["version"] = {"const": "1.1.0", "type": "string"}
+            schema_j["properties"]["columns"]["patternProperties"][".+"]["properties"][
+                "encoding"
+            ] = {
+                "type": "string",
+                "pattern": "^(WKB|point|linestring|polygon|multipoint|multilinestring|multipolygon)$",
+            }
 
         try:
             self._validate(schema_j, geo_j)
@@ -313,7 +330,100 @@ class GeoParquetValidator(object):
                             f"{geometry_type} is declared several times in geometry_types[]"
                         )
 
+    def _check_data_with_high_level_ogr_api(self, lyr, columns):
+        """Use for GeoArrow validation"""
+
+        if gdal.VersionInfo() < "3090000":
+            raise Exception("GDAL 3.9 or later required for GeoArrow data validation")
+
+        lyr.SetIgnoredFields(
+            [
+                lyr.GetLayerDefn().GetFieldDefn(i).GetName()
+                for i in range(lyr.GetLayerDefn().GetFieldCount())
+            ]
+        )
+
+        list_of_set_geometry_types = []
+        orientations = []
+        encodings = []
+        assert len(columns) == lyr.GetLayerDefn().GetGeomFieldCount()
+        for i in range(lyr.GetLayerDefn().GetGeomFieldCount()):
+            column_def = columns[lyr.GetLayerDefn().GetGeomFieldDefn(i).GetName()]
+
+            encodings.append(column_def["encoding"])
+
+            if "geometry_types" in column_def:
+                geometry_types = column_def["geometry_types"]
+                set_geometry_types = set(geometry_types)
+            else:
+                set_geometry_types = set()
+            list_of_set_geometry_types.append(set_geometry_types)
+
+            if "orientation" in column_def:
+                orientation = column_def["orientation"]
+            else:
+                orientation = None
+            orientations.append(orientation)
+
+        map_ogr_geom_type_to_geoarrow_encoding = {
+            ogr.wkbPoint: "point",
+            ogr.wkbLineString: "linestring",
+            ogr.wkbPolygon: "polygon",
+            ogr.wkbMultiPoint: "multipoint",
+            ogr.wkbMultiLineString: "multilinestring",
+            ogr.wkbMultiPolygon: "multipolygon",
+        }
+
+        for row, f in enumerate(lyr):
+            for i in range(lyr.GetLayerDefn().GetGeomFieldCount()):
+                g = f.GetGeomFieldRef(i)
+                if g:
+                    ogr_geom_type = g.GetGeometryType()
+                    if ogr_geom_type not in map_ogr_geom_type_to_geoparquet:
+                        self._error(
+                            f"Geometry at row {row} is of unexpected type for GeoParquet: %s"
+                            % g.GetGeometryName()
+                        )
+                    elif list_of_set_geometry_types[i]:
+                        geoparquet_geom_type = map_ogr_geom_type_to_geoparquet[
+                            ogr_geom_type
+                        ]
+                        if geoparquet_geom_type not in list_of_set_geometry_types[i]:
+                            self._error(
+                                f"Geometry at row {row} is of type {geoparquet_geom_type}, but not listed in geometry_types[]"
+                            )
+
+                    ogr_flat_geom_type = ogr.GT_Flatten(ogr_geom_type)
+                    if ogr_flat_geom_type not in map_ogr_geom_type_to_geoarrow_encoding:
+                        self._error(
+                            f"Geometry at row {row} is of unexpected type for a GeoArrow encoding of GeoParquet: %s"
+                            % g.GetGeometryName()
+                        )
+                    elif (
+                        map_ogr_geom_type_to_geoarrow_encoding[ogr_flat_geom_type]
+                        != encodings[i]
+                    ):
+                        self._error(
+                            f"Geometry at row {row} is a %s but does not match the declared encoding of %s"
+                            % (ogr.GeometryTypeToName(ogr_geom_type), encodings[i])
+                        )
+
+                    if orientations[i] == "counterclockwise":
+                        self._check_counterclockwise(g, row)
+
     def _check_data(self, lyr, columns):
+
+        # For non-WKB encoding, just use the high level OGR API
+        use_high_level_ogr_api = False
+        for _, column_def in columns.items():
+            if column_def["encoding"] != "WKB":
+                use_high_level_ogr_api = True
+                break
+
+        if use_high_level_ogr_api:
+            self._check_data_with_high_level_ogr_api(lyr, columns)
+            return
+
         lyr.SetIgnoredFields(
             [
                 lyr.GetLayerDefn().GetFieldDefn(i).GetName()


### PR DESCRIPTION
Add support for https://github.com/opengeospatial/geoparquet/pull/189

*    GeoParquet: implement read/write support for the GeoParquet 1.1 GeoArrow (struct-based) encoding.
    
    ```
    - .. lco:: GEOMETRY_ENCODING
         :choices: WKB, WKT, GEOARROW, GEOARROW_INTERLEAVED
         :default: WKB
    
         Geometry encoding.
         WKB is the default and recommended choice for maximal interoperability.
         WKT is *not* allowed by the GeoParquet specification, but are handled as
         an extension.
         As of GDAL 3.9, GEOARROW uses the GeoParquet 1.1 GeoArrow "struct" based
         encodings (where points are modeled as a struct field with a x and y subfield,
         lines are modeled as a list of such points, etc.).
         The GEOARROW_INTERLEAVED option has been renamed in GDAL 3.9 from what was
         named GEOARROW in previous versions, and uses an encoding where points uses
         a FixedSizedList of (x,y), lines a variable-size list of such
         FixedSizedList of points, etc. This GEOARROW_INTERLEAVED encoding is not
         part of the official GeoParquet specification, and its use is not encouraged.
    ```

*     Arrow/Feather: implement read/write support for GeoArrow struct-based encoding
    
    ```
    - .. lco:: GEOMETRY_ENCODING
         :choices: GEOARROW, WKB, WKT, GEOARROW_INTERLEAVED
         :default: GEOARROW
    
         Geometry encoding.
         As of GDAL 3.9, GEOARROW uses the GeoArrow "struct" based
         encodings (where points are modeled as a struct field with a x and y subfield,
         lines are modeled as a list of such points, etc.).
         The GEOARROW_INTERLEAVED option has been renamed in GDAL 3.9 from what was
         named GEOARROW in previous versions, and uses an encoding where points uses
         a FixedSizedList of (x,y), lines a variable-size list of such
         FixedSizedList of points, etc.
    ```

* Parquet: avoid potential assertion/out-of-bounds access when a subset of row groups is selected
* Arrow/Parquet: fix inverted logic regarding spatial filtering of multipolygon with GeoArrow interleaved encoding
* Arrow/Parquet: optimize spatial filtering on GeoArrow struct encoding when there is no bbox column

CC @jorisvandenbossche @paleolimbot