### PR TITLE
VRT: add a new mode to apply chained processing steps that apply to several bands at the same time

### DIFF
--- a/.github/workflows/cifuzz.yml
+++ b/.github/workflows/cifuzz.yml
@@ -15,6 +15,7 @@ permissions:
 jobs:
   Fuzzing:
     runs-on: ubuntu-latest
+    if: github.repository == 'OSGeo/gdal'
     steps:
     - name: Build Fuzzers
       id: build

--- a/autotest/gdrivers/vrtprocesseddataset.py
+++ b/autotest/gdrivers/vrtprocesseddataset.py
@@ -1,0 +1,1258 @@
+#!/usr/bin/env pytest
+###############################################################################
+# $Id$
+#
+# Project:  GDAL/OGR Test Suite
+# Purpose:  Test VRTProcessedDataset support.
+# Author:   Even Rouault <even.rouault at spatialys.com>
+#
+###############################################################################
+# Copyright (c) 2024, Even Rouault <even.rouault at spatialys.com>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+###############################################################################
+
+import struct
+
+import gdaltest
+import pytest
+
+from osgeo import gdal
+
+###############################################################################
+# Test error cases in general VRTProcessedDataset XML structure
+
+
+def test_vrtprocesseddataset_errors(tmp_vsimem):
+
+    with pytest.raises(Exception, match="Input element missing"):
+        gdal.Open(
+            """<VRTDataset subclass='VRTProcessedDataset'>
+                    </VRTDataset>
+                    """
+        )
+
+    with pytest.raises(
+        Exception,
+        match="Input element should have a SourceFilename or VRTDataset element",
+    ):
+        gdal.Open(
+            """<VRTDataset subclass='VRTProcessedDataset'>
+                    <Input/>
+                    </VRTDataset>
+                    """
+        )
+
+    with pytest.raises(Exception):  # "No such file or directory'", but O/S dependent
+        gdal.Open(
+            """<VRTDataset subclass='VRTProcessedDataset'>
+                    <Input><SourceFilename/></Input>
+                    </VRTDataset>
+                    """
+        )
+
+    with pytest.raises(
+        Exception,
+        match="Missing one of rasterXSize, rasterYSize or bands on VRTDataset",
+    ):
+        gdal.Open(
+            """<VRTDataset subclass='VRTProcessedDataset'>
+                    <Input><VRTDataset/></Input>
+                    </VRTDataset>
+                    """
+        )
+
+    src_filename = str(tmp_vsimem / "src.tif")
+    src_ds = gdal.GetDriverByName("GTiff").Create(src_filename, 10, 5, 3)
+    src_ds.GetRasterBand(1).Fill(1)
+    src_ds.GetRasterBand(2).Fill(2)
+    src_ds.GetRasterBand(3).Fill(3)
+    src_ds.Close()
+
+    with pytest.raises(Exception, match="ProcessingSteps element missing"):
+        gdal.Open(
+            f"""<VRTDataset subclass='VRTProcessedDataset'>
+        <Input>
+            <SourceFilename>{src_filename}</SourceFilename>
+        </Input>
+        </VRTDataset>
+            """
+        )
+
+    with pytest.raises(
+        Exception, match="Inconsistent declared VRT dimensions with input dataset"
+    ):
+        gdal.Open(
+            f"""<VRTDataset subclass='VRTProcessedDataset' rasterXSize='1'>
+        <Input>
+            <SourceFilename>{src_filename}</SourceFilename>
+        </Input>
+        </VRTDataset>
+            """
+        )
+
+    with pytest.raises(
+        Exception, match="Inconsistent declared VRT dimensions with input dataset"
+    ):
+        gdal.Open(
+            f"""<VRTDataset subclass='VRTProcessedDataset' rasterYSize='1'>
+        <Input>
+            <SourceFilename>{src_filename}</SourceFilename>
+        </Input>
+        </VRTDataset>
+            """
+        )
+
+    with pytest.raises(Exception, match="At least one step should be defined"):
+        gdal.Open(
+            f"""<VRTDataset subclass='VRTProcessedDataset'>
+        <Input>
+            <SourceFilename>{src_filename}</SourceFilename>
+        </Input>
+        <ProcessingSteps/>
+        </VRTDataset>
+            """
+        )
+
+
+###############################################################################
+# Test nominal cases of BandAffineCombination algorithm
+
+
+def test_vrtprocesseddataset_affine_combination_nominal(tmp_vsimem):
+
+    src_filename = str(tmp_vsimem / "src.tif")
+    src_ds = gdal.GetDriverByName("GTiff").Create(src_filename, 2, 1, 3)
+    src_ds.GetRasterBand(1).WriteRaster(0, 0, 2, 1, b"\x01\x03")
+    src_ds.GetRasterBand(2).WriteRaster(0, 0, 2, 1, b"\x02\x06")
+    src_ds.GetRasterBand(3).WriteRaster(0, 0, 2, 1, b"\x03\x03")
+    src_ds.Close()
+
+    ds = gdal.Open(
+        f"""<VRTDataset subclass='VRTProcessedDataset'>
+    <Input>
+        <SourceFilename>{src_filename}</SourceFilename>
+    </Input>
+    <ProcessingSteps>
+        <Step name="Affine combination of band values">
+            <Algorithm>BandAffineCombination</Algorithm>
+            <Argument name="coefficients_1">10,0,1,0</Argument>
+            <Argument name="coefficients_2">20,0,0,1</Argument>
+            <Argument name="coefficients_3">30,1,0,0</Argument>
+            <Argument name="min">15</Argument>
+            <Argument name="max">32</Argument>
+        </Step>
+    </ProcessingSteps>
+    </VRTDataset>
+        """
+    )
+    assert ds.RasterXSize == 2
+    assert ds.RasterYSize == 1
+    assert ds.RasterCount == 3
+    assert ds.GetSpatialRef() is None
+    assert ds.GetGeoTransform(can_return_null=True) is None
+    assert ds.GetRasterBand(1).DataType == gdal.GDT_Byte
+    assert struct.unpack("B" * 2, ds.GetRasterBand(1).ReadRaster()) == (15, 10 + 6)
+    assert struct.unpack("B" * 2, ds.GetRasterBand(2).ReadRaster()) == (20 + 3, 20 + 3)
+    assert struct.unpack("B" * 2, ds.GetRasterBand(3).ReadRaster()) == (30 + 1, 32)
+
+
+###############################################################################
+# Test several steps in a VRTProcessedDataset
+
+
+def test_vrtprocesseddataset_several_steps(tmp_vsimem):
+
+    src_filename = str(tmp_vsimem / "src.tif")
+    src_ds = gdal.GetDriverByName("GTiff").Create(src_filename, 10, 5, 3)
+    src_ds.GetRasterBand(1).Fill(1)
+    src_ds.GetRasterBand(2).Fill(2)
+    src_ds.GetRasterBand(3).Fill(3)
+    src_ds.Close()
+
+    ds = gdal.Open(
+        f"""<VRTDataset subclass='VRTProcessedDataset'>
+    <Input>
+        <SourceFilename>{src_filename}</SourceFilename>
+    </Input>
+    <ProcessingSteps>
+        <Step>
+            <Algorithm>BandAffineCombination</Algorithm>
+            <Argument name="coefficients_1">0,0,1,0</Argument>
+            <Argument name="coefficients_2">0,0,0,1</Argument>
+            <Argument name="coefficients_3">0,1,0,0</Argument>
+        </Step>
+        <Step>
+            <Algorithm>BandAffineCombination</Algorithm>
+            <Argument name="coefficients_1">0,0,1,0</Argument>
+            <Argument name="coefficients_2">0,0,0,1</Argument>
+            <Argument name="coefficients_3">0,1,0,0</Argument>
+        </Step>
+        <Step>
+            <Algorithm>BandAffineCombination</Algorithm>
+            <Argument name="coefficients_1">0,0,1,0</Argument>
+            <Argument name="coefficients_2">0,0,0,1</Argument>
+            <Argument name="coefficients_3">0,1,0,0</Argument>
+        </Step>
+    </ProcessingSteps>
+    </VRTDataset>
+        """
+    )
+    assert ds.RasterXSize == 10
+    assert ds.RasterYSize == 5
+    assert ds.RasterCount == 3
+    assert ds.GetSpatialRef() is None
+    assert ds.GetGeoTransform(can_return_null=True) is None
+    assert ds.GetRasterBand(1).DataType == gdal.GDT_Byte
+    assert ds.GetRasterBand(1).ComputeRasterMinMax(False) == (1, 1)
+    assert ds.GetRasterBand(2).ComputeRasterMinMax(False) == (2, 2)
+    assert ds.GetRasterBand(3).ComputeRasterMinMax(False) == (3, 3)
+
+
+###############################################################################
+# Test nominal cases of BandAffineCombination algorithm with nodata
+
+
+def test_vrtprocesseddataset_affine_combination_nodata(tmp_vsimem):
+
+    src_filename = str(tmp_vsimem / "src.tif")
+    src_ds = gdal.GetDriverByName("GTiff").Create(src_filename, 2, 1, 2)
+    src_ds.GetRasterBand(1).WriteRaster(0, 0, 2, 1, b"\x01\x02")
+    src_ds.GetRasterBand(1).SetNoDataValue(1)
+    src_ds.GetRasterBand(2).WriteRaster(0, 0, 2, 1, b"\x03\x03")
+    src_ds.GetRasterBand(2).SetNoDataValue(1)
+    src_ds.Close()
+
+    ds = gdal.Open(
+        f"""<VRTDataset subclass='VRTProcessedDataset'>
+    <Input>
+        <SourceFilename>{src_filename}</SourceFilename>
+    </Input>
+    <ProcessingSteps>
+        <Step name="Affine combination of band values">
+            <Algorithm>BandAffineCombination</Algorithm>
+            <Argument name="coefficients_1">0,1,1</Argument>
+            <Argument name="coefficients_2">0,1,-1</Argument>
+        </Step>
+    </ProcessingSteps>
+    </VRTDataset>
+        """
+    )
+    assert ds.GetRasterBand(1).DataType == gdal.GDT_Byte
+    assert struct.unpack("B" * 2, ds.GetRasterBand(1).ReadRaster()) == (1, 5)
+    # 0 should actually be 3-2=1, but this is the nodata value hence the replacement value
+    assert struct.unpack("B" * 2, ds.GetRasterBand(2).ReadRaster()) == (1, 0)
+
+
+def test_vrtprocesseddataset_affine_combination_nodata_as_parameter(tmp_vsimem):
+
+    src_filename = str(tmp_vsimem / "src.tif")
+    src_ds = gdal.GetDriverByName("GTiff").Create(src_filename, 2, 1, 2)
+    src_ds.GetRasterBand(1).WriteRaster(0, 0, 2, 1, b"\x01\x02")
+    src_ds.GetRasterBand(2).WriteRaster(0, 0, 2, 1, b"\x03\x03")
+    src_ds.Close()
+
+    ds = gdal.Open(
+        f"""<VRTDataset subclass='VRTProcessedDataset'>
+    <Input>
+        <SourceFilename>{src_filename}</SourceFilename>
+    </Input>
+    <ProcessingSteps>
+        <Step name="Affine combination of band values">
+            <Algorithm>BandAffineCombination</Algorithm>
+            <Argument name="coefficients_1">0,1,1</Argument>
+            <Argument name="coefficients_2">256,1,-1</Argument>
+            <Argument name="src_nodata">1</Argument>
+            <Argument name="dst_nodata">255</Argument>
+            <Argument name="dst_intended_datatype">Byte</Argument>
+        </Step>
+    </ProcessingSteps>
+    </VRTDataset>
+        """
+    )
+    assert ds.GetRasterBand(1).DataType == gdal.GDT_Byte
+    assert struct.unpack("B" * 2, ds.GetRasterBand(1).ReadRaster()) == (255, 5)
+    # 254 should actually be 256+1*2+(-1)*3=255, but this is the nodata value hence the replacement value
+    assert struct.unpack("B" * 2, ds.GetRasterBand(2).ReadRaster()) == (255, 254)
+
+
+###############################################################################
+# Test replacement_nodata logic of BandAffineCombination
+
+
+def test_vrtprocesseddataset_affine_combination_replacement_nodata(tmp_vsimem):
+
+    src_filename = str(tmp_vsimem / "src.tif")
+    src_ds = gdal.GetDriverByName("GTiff").Create(src_filename, 2, 1, 2)
+    src_ds.GetRasterBand(1).WriteRaster(0, 0, 2, 1, b"\x01\x02")
+    src_ds.GetRasterBand(2).WriteRaster(0, 0, 2, 1, b"\x03\x03")
+    src_ds.Close()
+
+    ds = gdal.Open(
+        f"""<VRTDataset subclass='VRTProcessedDataset'>
+    <Input>
+        <SourceFilename>{src_filename}</SourceFilename>
+    </Input>
+    <ProcessingSteps>
+        <Step name="Affine combination of band values">
+            <Algorithm>BandAffineCombination</Algorithm>
+            <Argument name="coefficients_1">0,1,1</Argument>
+            <Argument name="coefficients_2">256,1,-1</Argument>
+            <Argument name="src_nodata">1</Argument>
+            <Argument name="dst_nodata">255</Argument>
+            <Argument name="replacement_nodata">128</Argument>
+        </Step>
+    </ProcessingSteps>
+    </VRTDataset>
+        """
+    )
+    assert ds.GetRasterBand(1).DataType == gdal.GDT_Byte
+    assert struct.unpack("B" * 2, ds.GetRasterBand(1).ReadRaster()) == (255, 5)
+    # 254 should actually be 256+1*2+(-1)*3=255, but this is the nodata value hence the replacement value
+    assert struct.unpack("B" * 2, ds.GetRasterBand(2).ReadRaster()) == (255, 128)
+
+
+###############################################################################
+# Test error cases of BandAffineCombination algorithm
+
+
+def test_vrtprocesseddataset_affine_combination_errors(tmp_vsimem):
+
+    src_filename = str(tmp_vsimem / "src.tif")
+    src_ds = gdal.GetDriverByName("GTiff").Create(src_filename, 10, 5, 3)
+    src_ds.GetRasterBand(1).Fill(1)
+    src_ds.GetRasterBand(2).Fill(2)
+    src_ds.GetRasterBand(3).Fill(3)
+    src_ds.Close()
+
+    with pytest.raises(
+        Exception,
+        match="Step 'Affine combination of band values' lacks required Argument 'coefficients_{band}'",
+    ):
+        gdal.Open(
+            f"""<VRTDataset subclass='VRTProcessedDataset'>
+        <Input>
+            <SourceFilename>{src_filename}</SourceFilename>
+        </Input>
+        <ProcessingSteps>
+            <Step name="Affine combination of band values">
+                <Algorithm>BandAffineCombination</Algorithm>
+            </Step>
+        </ProcessingSteps>
+        </VRTDataset>
+            """
+        )
+
+    with pytest.raises(
+        Exception, match="Argument coefficients_1 has 3 values, whereas 4 are expected"
+    ):
+        gdal.Open(
+            f"""<VRTDataset subclass='VRTProcessedDataset'>
+        <Input>
+            <SourceFilename>{src_filename}</SourceFilename>
+        </Input>
+        <ProcessingSteps>
+            <Step name="Affine combination of band values">
+                <Algorithm>BandAffineCombination</Algorithm>
+                <Argument name="coefficients_1">10,0,1</Argument>
+            </Step>
+        </ProcessingSteps>
+        </VRTDataset>
+            """
+        )
+
+    with pytest.raises(Exception, match="Argument coefficients_3 is missing"):
+        gdal.Open(
+            f"""<VRTDataset subclass='VRTProcessedDataset'>
+        <Input>
+            <SourceFilename>{src_filename}</SourceFilename>
+        </Input>
+        <ProcessingSteps>
+            <Step name="Affine combination of band values">
+                <Algorithm>BandAffineCombination</Algorithm>
+                <Argument name="coefficients_1">10,0,1,0</Argument>
+                <Argument name="coefficients_2">10,0,1,0</Argument>
+                <Argument name="coefficients_4">10,0,1,0</Argument>
+            </Step>
+        </ProcessingSteps>
+        </VRTDataset>
+            """
+        )
+
+    with pytest.raises(
+        Exception,
+        match="Final step expect 3 bands, but only 1 coefficient_XX are provided",
+    ):
+        gdal.Open(
+            f"""<VRTDataset subclass='VRTProcessedDataset'>
+        <Input>
+            <SourceFilename>{src_filename}</SourceFilename>
+        </Input>
+        <ProcessingSteps>
+            <Step name="Affine combination of band values">
+                <Algorithm>BandAffineCombination</Algorithm>
+                <Argument name="coefficients_1">10,0,1,0</Argument>
+            </Step>
+        </ProcessingSteps>
+        </VRTDataset>
+            """
+        )
+
+
+###############################################################################
+# Test nominal cases of LUT algorithm
+
+
+def test_vrtprocesseddataset_lut_nominal(tmp_vsimem):
+
+    src_filename = str(tmp_vsimem / "src.tif")
+    src_ds = gdal.GetDriverByName("GTiff").Create(src_filename, 3, 1, 2)
+    src_ds.GetRasterBand(1).WriteRaster(0, 0, 3, 1, b"\x01\x02\x03")
+    src_ds.GetRasterBand(2).WriteRaster(0, 0, 3, 1, b"\x01\x02\x03")
+    src_ds.Close()
+
+    ds = gdal.Open(
+        f"""<VRTDataset subclass='VRTProcessedDataset'>
+    <Input>
+        <SourceFilename>{src_filename}</SourceFilename>
+    </Input>
+    <ProcessingSteps>
+        <Step>
+            <Algorithm>LUT</Algorithm>
+            <Argument name="lut_1">1.5:10,2.5:20</Argument>
+            <Argument name="lut_2">1.5:100,2.5:200</Argument>
+        </Step>
+    </ProcessingSteps>
+    </VRTDataset>
+        """
+    )
+    assert struct.unpack("B" * 3, ds.GetRasterBand(1).ReadRaster()) == (10, 15, 20)
+    assert struct.unpack("B" * 3, ds.GetRasterBand(2).ReadRaster()) == (100, 150, 200)
+
+
+###############################################################################
+# Test nominal cases of LUT algorithm with nodata coming from input dataset
+
+
+def test_vrtprocesseddataset_lut_nodata(tmp_vsimem):
+
+    src_filename = str(tmp_vsimem / "src.tif")
+    src_ds = gdal.GetDriverByName("GTiff").Create(src_filename, 4, 1, 2)
+    src_ds.GetRasterBand(1).WriteRaster(0, 0, 4, 1, b"\x00\x01\x02\x03")
+    src_ds.GetRasterBand(1).SetNoDataValue(0)
+    src_ds.GetRasterBand(2).WriteRaster(0, 0, 4, 1, b"\x00\x01\x02\x03")
+    src_ds.GetRasterBand(2).SetNoDataValue(0)
+    src_ds.Close()
+
+    ds = gdal.Open(
+        f"""<VRTDataset subclass='VRTProcessedDataset'>
+    <Input>
+        <SourceFilename>{src_filename}</SourceFilename>
+    </Input>
+    <ProcessingSteps>
+        <Step>
+            <Algorithm>LUT</Algorithm>
+            <Argument name="lut_1">1.5:10,2.5:20</Argument>
+            <Argument name="lut_2">1.5:100,2.5:200</Argument>
+        </Step>
+    </ProcessingSteps>
+    </VRTDataset>
+        """
+    )
+    assert struct.unpack("B" * 4, ds.GetRasterBand(1).ReadRaster()) == (0, 10, 15, 20)
+    assert struct.unpack("B" * 4, ds.GetRasterBand(2).ReadRaster()) == (
+        0,
+        100,
+        150,
+        200,
+    )
+
+
+###############################################################################
+# Test nominal cases of LUT algorithm with nodata set as a parameter
+
+
+def test_vrtprocesseddataset_lut_nodata_as_parameter(tmp_vsimem):
+
+    src_filename = str(tmp_vsimem / "src.tif")
+    src_ds = gdal.GetDriverByName("GTiff").Create(src_filename, 4, 1, 2)
+    src_ds.GetRasterBand(1).WriteRaster(0, 0, 4, 1, b"\x00\x01\x02\x03")
+    src_ds.GetRasterBand(2).WriteRaster(0, 0, 4, 1, b"\x00\x01\x02\x03")
+    src_ds.Close()
+
+    ds = gdal.Open(
+        f"""<VRTDataset subclass='VRTProcessedDataset'>
+    <Input>
+        <SourceFilename>{src_filename}</SourceFilename>
+    </Input>
+    <ProcessingSteps>
+        <Step>
+            <Algorithm>LUT</Algorithm>
+            <Argument name="lut_1">1.5:10,2.5:20</Argument>
+            <Argument name="lut_2">1.5:100,2.5:200</Argument>
+            <Argument name="src_nodata">0</Argument>
+            <Argument name="dst_nodata">1</Argument>
+        </Step>
+    </ProcessingSteps>
+    </VRTDataset>
+        """
+    )
+    assert struct.unpack("B" * 4, ds.GetRasterBand(1).ReadRaster()) == (1, 10, 15, 20)
+    assert struct.unpack("B" * 4, ds.GetRasterBand(2).ReadRaster()) == (
+        1,
+        100,
+        150,
+        200,
+    )
+
+
+###############################################################################
+# Test error cases of LUT algorithm
+
+
+def test_vrtprocesseddataset_lut_errors(tmp_vsimem):
+
+    src_filename = str(tmp_vsimem / "src.tif")
+    src_ds = gdal.GetDriverByName("GTiff").Create(src_filename, 3, 1, 2)
+    src_ds.GetRasterBand(1).WriteRaster(0, 0, 3, 1, b"\x01\x02\x03")
+    src_ds.GetRasterBand(2).WriteRaster(0, 0, 3, 1, b"\x01\x02\x03")
+    src_ds.Close()
+
+    with pytest.raises(Exception, match="Step 'nr 1' lacks required Argument"):
+        gdal.Open(
+            f"""<VRTDataset subclass='VRTProcessedDataset'>
+        <Input>
+            <SourceFilename>{src_filename}</SourceFilename>
+        </Input>
+        <ProcessingSteps>
+            <Step>
+                <Algorithm>LUT</Algorithm>
+            </Step>
+        </ProcessingSteps>
+        </VRTDataset>
+            """
+        )
+
+    with pytest.raises(Exception, match="Invalid value for argument 'lut_1'"):
+        gdal.Open(
+            f"""<VRTDataset subclass='VRTProcessedDataset'>
+        <Input>
+            <SourceFilename>{src_filename}</SourceFilename>
+        </Input>
+        <ProcessingSteps>
+            <Step>
+                <Algorithm>LUT</Algorithm>
+                <Argument name="lut_1">1.5:10,2.5</Argument>
+            </Step>
+        </ProcessingSteps>
+        </VRTDataset>
+            """
+        )
+
+    with pytest.raises(Exception, match="Invalid band in argument 'lut_3'"):
+        gdal.Open(
+            f"""<VRTDataset subclass='VRTProcessedDataset'>
+        <Input>
+            <SourceFilename>{src_filename}</SourceFilename>
+        </Input>
+        <ProcessingSteps>
+            <Step>
+                <Algorithm>LUT</Algorithm>
+                <Argument name="lut_1">1.5:10,2.5:20</Argument>
+                <Argument name="lut_3">1.5:10,2.5:20</Argument>
+            </Step>
+        </ProcessingSteps>
+        </VRTDataset>
+            """
+        )
+
+    with pytest.raises(Exception, match="Missing lut_XX element"):
+        gdal.Open(
+            f"""<VRTDataset subclass='VRTProcessedDataset'>
+        <Input>
+            <SourceFilename>{src_filename}</SourceFilename>
+        </Input>
+        <ProcessingSteps>
+            <Step>
+                <Algorithm>LUT</Algorithm>
+                <Argument name="lut_1">1.5:10,2.5:20</Argument>
+            </Step>
+        </ProcessingSteps>
+        </VRTDataset>
+            """
+        )
+
+
+###############################################################################
+# Test nominal case of Dehazing algorithm
+
+
+def test_vrtprocesseddataset_dehazing_nominal(tmp_vsimem):
+
+    src_filename = str(tmp_vsimem / "src.tif")
+    src_ds = gdal.GetDriverByName("GTiff").Create(src_filename, 6, 1, 2)
+    src_ds.GetRasterBand(1).WriteRaster(0, 0, 6, 1, b"\x01\x02\x03\xff\x01\x01")
+    src_ds.GetRasterBand(2).WriteRaster(0, 0, 6, 1, b"\x01\x02\x03\xff\x01\x01")
+    src_ds.GetRasterBand(1).SetNoDataValue(255)
+    src_ds.GetRasterBand(2).SetNoDataValue(255)
+    src_ds.SetGeoTransform([0, 1, 0, 0, 0, 1])
+    src_ds.Close()
+
+    gain_filename = str(tmp_vsimem / "gain.tif")
+    gain_ds = gdal.GetDriverByName("GTiff").Create(gain_filename, 6, 1, 2)
+    gain_ds.GetRasterBand(1).WriteRaster(0, 0, 6, 1, b"\x02\x04\x06\x01\xfe\x01")
+    gain_ds.GetRasterBand(2).WriteRaster(0, 0, 6, 1, b"\x03\x05\x07\x01\xfe\x01")
+    gain_ds.GetRasterBand(1).SetNoDataValue(254)
+    gain_ds.GetRasterBand(2).SetNoDataValue(254)
+    gain_ds.SetGeoTransform([0, 1, 0, 0, 0, 1])
+    gain_ds.Close()
+
+    offset_filename = str(tmp_vsimem / "offset.tif")
+    offset_ds = gdal.GetDriverByName("GTiff").Create(offset_filename, 6, 1, 2)
+    offset_ds.GetRasterBand(1).WriteRaster(0, 0, 6, 1, b"\x01\x02\x03\x01\x01\xfd")
+    offset_ds.GetRasterBand(2).WriteRaster(0, 0, 6, 1, b"\x02\x03\x04\x01\x01\xfd")
+    offset_ds.GetRasterBand(1).SetNoDataValue(253)
+    offset_ds.GetRasterBand(2).SetNoDataValue(253)
+    offset_ds.SetGeoTransform([0, 1, 0, 0, 0, 1])
+    offset_ds.Close()
+
+    ds = gdal.Open(
+        f"""<VRTDataset subclass='VRTProcessedDataset'>
+    <Input>
+        <SourceFilename>{src_filename}</SourceFilename>
+    </Input>
+    <ProcessingSteps>
+        <Step>
+            <Algorithm>Dehazing</Algorithm>
+            <Argument name="gain_dataset_filename_1">{gain_filename}</Argument>
+            <Argument name="gain_dataset_band_1">1</Argument>
+            <Argument name="gain_dataset_filename_2">{gain_filename}</Argument>
+            <Argument name="gain_dataset_band_2">2</Argument>
+            <Argument name="offset_dataset_filename_1">{offset_filename}</Argument>
+            <Argument name="offset_dataset_band_1">1</Argument>
+            <Argument name="offset_dataset_filename_2">{offset_filename}</Argument>
+            <Argument name="offset_dataset_band_2">2</Argument>
+            <Argument name="min">2</Argument>
+            <Argument name="max">16</Argument>
+        </Step>
+    </ProcessingSteps>
+    </VRTDataset>
+        """
+    )
+    assert struct.unpack("B" * 6, ds.GetRasterBand(1).ReadRaster()) == (
+        2,
+        6,
+        15,
+        255,
+        255,
+        255,
+    )
+    assert struct.unpack("B" * 6, ds.GetRasterBand(2).ReadRaster()) == (
+        2,
+        7,
+        16,
+        255,
+        255,
+        255,
+    )
+
+
+###############################################################################
+# Test nominal case of Dehazing algorithm where gain and offset have a lower
+# resolution than the input dataset
+
+
+def test_vrtprocesseddataset_dehazing_different_resolution(tmp_vsimem):
+
+    src_filename = str(tmp_vsimem / "src.tif")
+    src_ds = gdal.GetDriverByName("GTiff").Create(src_filename, 6, 2, 1)
+    src_ds.GetRasterBand(1).WriteRaster(0, 0, 6, 2, b"\x01\x01\x02\x02\x03\x03" * 2)
+    src_ds.SetGeoTransform([0, 0.5, 0, 0, 0, 0.5])
+    src_ds.Close()
+
+    gain_filename = str(tmp_vsimem / "gain.tif")
+    gain_ds = gdal.GetDriverByName("GTiff").Create(gain_filename, 3, 1, 1)
+    gain_ds.GetRasterBand(1).WriteRaster(0, 0, 3, 1, b"\x02\x04\x06")
+    gain_ds.SetGeoTransform([0, 1, 0, 0, 0, 1])
+    gain_ds.Close()
+
+    offset_filename = str(tmp_vsimem / "offset.tif")
+    offset_ds = gdal.GetDriverByName("GTiff").Create(offset_filename, 3, 1, 1)
+    offset_ds.GetRasterBand(1).WriteRaster(0, 0, 3, 1, b"\x01\x02\x03")
+    offset_ds.SetGeoTransform([0, 1, 0, 0, 0, 1])
+    offset_ds.Close()
+
+    ds = gdal.Open(
+        f"""<VRTDataset subclass='VRTProcessedDataset'>
+    <Input>
+        <SourceFilename>{src_filename}</SourceFilename>
+    </Input>
+    <ProcessingSteps>
+        <Step>
+            <Algorithm>Dehazing</Algorithm>
+            <Argument name="gain_dataset_filename_1">{gain_filename}</Argument>
+            <Argument name="gain_dataset_band_1">1</Argument>
+            <Argument name="offset_dataset_filename_1">{offset_filename}</Argument>
+            <Argument name="offset_dataset_band_1">1</Argument>
+        </Step>
+    </ProcessingSteps>
+    </VRTDataset>
+        """
+    )
+    assert struct.unpack("B" * 12, ds.GetRasterBand(1).ReadRaster()) == (
+        1,
+        2,
+        6,
+        8,
+        15,
+        15,
+        1,
+        2,
+        6,
+        8,
+        15,
+        15,
+    )
+
+
+###############################################################################
+# Test error cases of Dehazing algorithm
+
+
+def test_vrtprocesseddataset_dehazing_error(tmp_vsimem):
+
+    src_filename = str(tmp_vsimem / "src.tif")
+    src_ds = gdal.GetDriverByName("GTiff").Create(src_filename, 3, 1, 1)
+    src_ds.GetRasterBand(1).WriteRaster(0, 0, 3, 1, b"\x01\x02\x03")
+    src_ds.SetGeoTransform([0, 1, 0, 0, 0, 1])
+    src_ds.Close()
+
+    with pytest.raises(
+        Exception,
+        match="Step 'nr 1' lacks required Argument 'offset_dataset_band_{band}'",
+    ):
+        gdal.Open(
+            f"""<VRTDataset subclass='VRTProcessedDataset'>
+        <Input>
+            <SourceFilename>{src_filename}</SourceFilename>
+        </Input>
+        <ProcessingSteps>
+            <Step>
+                <Algorithm>Dehazing</Algorithm>
+                <Argument name="gain_dataset_filename_1">{src_filename}</Argument>
+                <Argument name="gain_dataset_band_1">1</Argument>
+            </Step>
+        </ProcessingSteps>
+        </VRTDataset>
+            """
+        )
+
+    with pytest.raises(
+        Exception,
+        match="Invalid band in argument 'gain_dataset_filename_2'",
+    ):
+        gdal.Open(
+            f"""<VRTDataset subclass='VRTProcessedDataset'>
+        <Input>
+            <SourceFilename>{src_filename}</SourceFilename>
+        </Input>
+        <ProcessingSteps>
+            <Step>
+                <Algorithm>Dehazing</Algorithm>
+                <Argument name="gain_dataset_filename_2">{src_filename}</Argument>
+                <Argument name="gain_dataset_band_1">1</Argument>
+                <Argument name="offset_dataset_filename_1">{src_filename}</Argument>
+                <Argument name="offset_dataset_band_1">1</Argument>
+            </Step>
+        </ProcessingSteps>
+        </VRTDataset>
+            """
+        )
+
+    with pytest.raises(
+        Exception,
+        match="Invalid band in argument 'gain_dataset_band_2'",
+    ):
+        gdal.Open(
+            f"""<VRTDataset subclass='VRTProcessedDataset'>
+        <Input>
+            <SourceFilename>{src_filename}</SourceFilename>
+        </Input>
+        <ProcessingSteps>
+            <Step>
+                <Algorithm>Dehazing</Algorithm>
+                <Argument name="gain_dataset_filename_1">{src_filename}</Argument>
+                <Argument name="gain_dataset_band_2">1</Argument>
+                <Argument name="offset_dataset_filename_1">{src_filename}</Argument>
+                <Argument name="offset_dataset_band_1">1</Argument>
+            </Step>
+        </ProcessingSteps>
+        </VRTDataset>
+            """
+        )
+
+    with pytest.raises(
+        Exception,
+        match="Invalid band in argument 'offset_dataset_filename_2'",
+    ):
+        gdal.Open(
+            f"""<VRTDataset subclass='VRTProcessedDataset'>
+        <Input>
+            <SourceFilename>{src_filename}</SourceFilename>
+        </Input>
+        <ProcessingSteps>
+            <Step>
+                <Algorithm>Dehazing</Algorithm>
+                <Argument name="gain_dataset_filename_1">{src_filename}</Argument>
+                <Argument name="gain_dataset_band_1">1</Argument>
+                <Argument name="offset_dataset_filename_2">{src_filename}</Argument>
+                <Argument name="offset_dataset_band_1">1</Argument>
+            </Step>
+        </ProcessingSteps>
+        </VRTDataset>
+            """
+        )
+
+    with pytest.raises(
+        Exception,
+        match="Invalid band in argument 'offset_dataset_band_2'",
+    ):
+        gdal.Open(
+            f"""<VRTDataset subclass='VRTProcessedDataset'>
+        <Input>
+            <SourceFilename>{src_filename}</SourceFilename>
+        </Input>
+        <ProcessingSteps>
+            <Step>
+                <Algorithm>Dehazing</Algorithm>
+                <Argument name="gain_dataset_filename_1">{src_filename}</Argument>
+                <Argument name="gain_dataset_band_1">1</Argument>
+                <Argument name="offset_dataset_filename_1">{src_filename}</Argument>
+                <Argument name="offset_dataset_band_2">1</Argument>
+            </Step>
+        </ProcessingSteps>
+        </VRTDataset>
+            """
+        )
+
+    with pytest.raises(
+        Exception,
+        match=r"Invalid band number \(2\) for a gain dataset",
+    ):
+        gdal.Open(
+            f"""<VRTDataset subclass='VRTProcessedDataset'>
+        <Input>
+            <SourceFilename>{src_filename}</SourceFilename>
+        </Input>
+        <ProcessingSteps>
+            <Step>
+                <Algorithm>Dehazing</Algorithm>
+                <Argument name="gain_dataset_filename_1">{src_filename}</Argument>
+                <Argument name="gain_dataset_band_1">2</Argument>
+                <Argument name="offset_dataset_filename_1">{src_filename}</Argument>
+                <Argument name="offset_dataset_band_1">1</Argument>
+            </Step>
+        </ProcessingSteps>
+        </VRTDataset>
+            """
+        )
+
+    with pytest.raises(Exception):  # "No such file or directory'", but O/S dependent
+        gdal.Open(
+            f"""<VRTDataset subclass='VRTProcessedDataset'>
+        <Input>
+            <SourceFilename>{src_filename}</SourceFilename>
+        </Input>
+        <ProcessingSteps>
+            <Step>
+                <Algorithm>Dehazing</Algorithm>
+                <Argument name="gain_dataset_filename_1">invalid</Argument>
+                <Argument name="gain_dataset_band_1">1</Argument>
+                <Argument name="offset_dataset_filename_1">{src_filename}</Argument>
+                <Argument name="offset_dataset_band_1">1</Argument>
+            </Step>
+        </ProcessingSteps>
+        </VRTDataset>
+            """
+        )
+
+    nogt_filename = str(tmp_vsimem / "nogt.tif")
+    ds = gdal.GetDriverByName("GTiff").Create(nogt_filename, 1, 1, 1)
+    ds.Close()
+
+    with pytest.raises(Exception, match="lacks a geotransform"):
+        gdal.Open(
+            f"""<VRTDataset subclass='VRTProcessedDataset'>
+        <Input>
+            <SourceFilename>{src_filename}</SourceFilename>
+        </Input>
+        <ProcessingSteps>
+            <Step>
+                <Algorithm>Dehazing</Algorithm>
+                <Argument name="gain_dataset_filename_1">{nogt_filename}</Argument>
+                <Argument name="gain_dataset_band_1">1</Argument>
+                <Argument name="offset_dataset_filename_1">{nogt_filename}</Argument>
+                <Argument name="offset_dataset_band_1">1</Argument>
+            </Step>
+        </ProcessingSteps>
+        </VRTDataset>
+            """
+        )
+
+
+###############################################################################
+# Test nominal cases of Trimming algorithm
+
+
+def test_vrtprocesseddataset_trimming_nominal(tmp_vsimem):
+
+    src_filename = str(tmp_vsimem / "src.tif")
+    src_ds = gdal.GetDriverByName("GTiff").Create(src_filename, 6, 1, 4)
+
+    R = 100.0
+    G = 150.0
+    B = 200.0
+    NIR = 100.0
+
+    src_ds.GetRasterBand(1).WriteRaster(
+        0, 0, 6, 1, struct.pack("B" * 6, int(R), 150, 200, 0, 0, 0)
+    )
+    src_ds.GetRasterBand(2).WriteRaster(
+        0, 0, 6, 1, struct.pack("B" * 6, int(G), 200, 100, 0, 0, 0)
+    )
+    src_ds.GetRasterBand(3).WriteRaster(
+        0, 0, 6, 1, struct.pack("B" * 6, int(B), 100, 150, 0, 0, 0)
+    )
+    src_ds.GetRasterBand(4).WriteRaster(
+        0, 0, 6, 1, struct.pack("B" * 6, int(NIR), 150, 200, 0, 0, 0)
+    )
+    src_ds.SetGeoTransform([0, 1, 0, 0, 0, 1])
+    src_ds.Close()
+
+    trimming_filename = str(tmp_vsimem / "trimming.tif")
+    trimming_ds = gdal.GetDriverByName("GTiff").Create(trimming_filename, 6, 1, 1)
+
+    localMaxRGB = 205.0
+
+    trimming_ds.GetRasterBand(1).WriteRaster(
+        0, 0, 6, 1, struct.pack("B" * 6, int(localMaxRGB), 210, 220, 0, 0, 0)
+    )
+    trimming_ds.SetGeoTransform([0, 1, 0, 0, 0, 1])
+    trimming_ds.Close()
+
+    top_rgb = 200.0
+    tone_ceil = 190.0
+    top_margin = 0.1
+
+    ds = gdal.Open(
+        f"""<VRTDataset subclass='VRTProcessedDataset'>
+    <Input>
+        <SourceFilename>{src_filename}</SourceFilename>
+    </Input>
+    <ProcessingSteps>
+        <Step>
+            <Algorithm>Trimming</Algorithm>
+            <Argument name="trimming_dataset_filename">{trimming_filename}</Argument>
+            <Argument name="top_rgb">{top_rgb}</Argument>
+            <Argument name="tone_ceil">{tone_ceil}</Argument>
+            <Argument name="top_margin">{top_margin}</Argument>
+        </Step>
+    </ProcessingSteps>
+    </VRTDataset>
+        """
+    )
+
+    # Do algorithm at hand
+
+    # Extract local saturation value from trimming image
+    reducedRGB = min((1.0 - top_margin) * top_rgb / localMaxRGB, 1)
+
+    # RGB bands specific process
+    maxRGB = max(R, G, B)
+    toneMaxRGB = min(tone_ceil / maxRGB, 1)
+    toneR = min(tone_ceil / R, 1)
+    toneG = min(tone_ceil / G, 1)
+    toneB = min(tone_ceil / B, 1)
+    outputR = min(reducedRGB * R * toneR / toneMaxRGB, top_rgb)
+    outputG = min(reducedRGB * G * toneG / toneMaxRGB, top_rgb)
+    outputB = min(reducedRGB * B * toneB / toneMaxRGB, top_rgb)
+
+    # Other bands processing (NIR, ...): only apply RGB reduction factor
+    outputNIR = reducedRGB * NIR
+
+    # print(outputR, outputG, outputB, outputNIR)
+
+    assert (
+        round(outputR)
+        == struct.unpack("B", ds.GetRasterBand(1).ReadRaster(0, 0, 1, 1))[0]
+    )
+    assert (
+        round(outputG)
+        == struct.unpack("B", ds.GetRasterBand(2).ReadRaster(0, 0, 1, 1))[0]
+    )
+    assert (
+        round(outputB)
+        == struct.unpack("B", ds.GetRasterBand(3).ReadRaster(0, 0, 1, 1))[0]
+    )
+    assert (
+        round(outputNIR)
+        == struct.unpack("B", ds.GetRasterBand(4).ReadRaster(0, 0, 1, 1))[0]
+    )
+
+    assert struct.unpack("B" * 6, ds.GetRasterBand(1).ReadRaster()) == (
+        92,  # round(outputR)
+        135,
+        164,
+        0,
+        0,
+        0,
+    )
+    assert struct.unpack("B" * 6, ds.GetRasterBand(2).ReadRaster()) == (
+        139,  # round(outputG)
+        171,
+        86,
+        0,
+        0,
+        0,
+    )
+    assert struct.unpack("B" * 6, ds.GetRasterBand(3).ReadRaster()) == (
+        176,  # round(outputB)
+        90,
+        129,
+        0,
+        0,
+        0,
+    )
+    assert struct.unpack("B" * 6, ds.GetRasterBand(4).ReadRaster()) == (
+        88,  # round(outputNIR)
+        129,
+        164,
+        0,
+        0,
+        0,
+    )
+
+
+###############################################################################
+# Test error cases of Trimming algorithm
+
+
+def test_vrtprocesseddataset_trimming_errors(tmp_vsimem):
+
+    src_filename = str(tmp_vsimem / "src.tif")
+    src_ds = gdal.GetDriverByName("GTiff").Create(src_filename, 6, 1, 4)
+    src_ds.GetRasterBand(1).WriteRaster(
+        0, 0, 6, 1, struct.pack("B" * 6, 100, 150, 200, 0, 0, 0)
+    )
+    src_ds.GetRasterBand(2).WriteRaster(
+        0, 0, 6, 1, struct.pack("B" * 6, 150, 200, 100, 0, 0, 0)
+    )
+    src_ds.GetRasterBand(3).WriteRaster(
+        0, 0, 6, 1, struct.pack("B" * 6, 200, 100, 150, 0, 0, 0)
+    )
+    src_ds.GetRasterBand(4).WriteRaster(
+        0, 0, 6, 1, struct.pack("B" * 6, 100, 150, 200, 0, 0, 0)
+    )
+    src_ds.SetGeoTransform([0, 1, 0, 0, 0, 1])
+    src_ds.Close()
+
+    trimming_filename = str(tmp_vsimem / "trimming.tif")
+    trimming_ds = gdal.GetDriverByName("GTiff").Create(trimming_filename, 6, 1, 1)
+    trimming_ds.GetRasterBand(1).WriteRaster(
+        0, 0, 6, 1, struct.pack("B" * 6, 200, 210, 220, 0, 0, 0)
+    )
+    trimming_ds.SetGeoTransform([0, 1, 0, 0, 0, 1])
+    trimming_ds.Close()
+
+    trimming_two_bands_filename = str(tmp_vsimem / "trimming_two_bands.tif")
+    trimming_ds = gdal.GetDriverByName("GTiff").Create(
+        trimming_two_bands_filename, 6, 1, 2
+    )
+    trimming_ds.SetGeoTransform([0, 1, 0, 0, 0, 1])
+    trimming_ds.Close()
+
+    with pytest.raises(Exception):
+        gdal.Open(
+            f"""<VRTDataset subclass='VRTProcessedDataset'>
+        <Input>
+            <SourceFilename>{src_filename}</SourceFilename>
+        </Input>
+        <ProcessingSteps>
+            <Step>
+                <Algorithm>Trimming</Algorithm>
+                <Argument name="trimming_dataset_filename">invalid</Argument>
+                <Argument name="top_rgb">200</Argument>
+                <Argument name="tone_ceil">190</Argument>
+                <Argument name="top_margin">0.1</Argument>
+            </Step>
+        </ProcessingSteps>
+        </VRTDataset>
+            """
+        )
+
+    for val in (0, 5):
+        with pytest.raises(Exception, match="Invalid band in argument 'red_band'"):
+            gdal.Open(
+                f"""<VRTDataset subclass='VRTProcessedDataset'>
+            <Input>
+                <SourceFilename>{src_filename}</SourceFilename>
+            </Input>
+            <ProcessingSteps>
+                <Step>
+                    <Algorithm>Trimming</Algorithm>
+                    <Argument name="trimming_dataset_filename">{trimming_filename}</Argument>
+                    <Argument name="red_band">{val}</Argument>
+                    <Argument name="top_rgb">200</Argument>
+                    <Argument name="tone_ceil">190</Argument>
+                    <Argument name="top_margin">0.1</Argument>
+                </Step>
+            </ProcessingSteps>
+            </VRTDataset>
+                """
+            )
+
+    for val in (0, 5):
+        with pytest.raises(Exception, match="Invalid band in argument 'green_band'"):
+            gdal.Open(
+                f"""<VRTDataset subclass='VRTProcessedDataset'>
+            <Input>
+                <SourceFilename>{src_filename}</SourceFilename>
+            </Input>
+            <ProcessingSteps>
+                <Step>
+                    <Algorithm>Trimming</Algorithm>
+                    <Argument name="trimming_dataset_filename">{trimming_filename}</Argument>
+                    <Argument name="green_band">{val}</Argument>
+                    <Argument name="top_rgb">200</Argument>
+                    <Argument name="tone_ceil">190</Argument>
+                    <Argument name="top_margin">0.1</Argument>
+                </Step>
+            </ProcessingSteps>
+            </VRTDataset>
+                """
+            )
+
+    for val in (0, 5):
+        with pytest.raises(Exception, match="Invalid band in argument 'blue_band'"):
+            gdal.Open(
+                f"""<VRTDataset subclass='VRTProcessedDataset'>
+            <Input>
+                <SourceFilename>{src_filename}</SourceFilename>
+            </Input>
+            <ProcessingSteps>
+                <Step>
+                    <Algorithm>Trimming</Algorithm>
+                    <Argument name="trimming_dataset_filename">{trimming_filename}</Argument>
+                    <Argument name="blue_band">{val}</Argument>
+                    <Argument name="top_rgb">200</Argument>
+                    <Argument name="tone_ceil">190</Argument>
+                    <Argument name="top_margin">0.1</Argument>
+                </Step>
+            </ProcessingSteps>
+            </VRTDataset>
+                """
+            )
+
+    for (red_band, green_band, blue_band) in [(1, 1, 3), (3, 2, 3), (1, 3, 3)]:
+        with pytest.raises(
+            Exception,
+            match="red_band, green_band and blue_band must have distinct values",
+        ):
+            gdal.Open(
+                f"""<VRTDataset subclass='VRTProcessedDataset'>
+            <Input>
+                <SourceFilename>{src_filename}</SourceFilename>
+            </Input>
+            <ProcessingSteps>
+                <Step>
+                    <Algorithm>Trimming</Algorithm>
+                    <Argument name="trimming_dataset_filename">{trimming_filename}</Argument>
+                    <Argument name="red_band">{red_band}</Argument>
+                    <Argument name="green_band">{green_band}</Argument>
+                    <Argument name="blue_band">{blue_band}</Argument>
+                    <Argument name="top_rgb">200</Argument>
+                    <Argument name="tone_ceil">190</Argument>
+                    <Argument name="top_margin">0.1</Argument>
+                </Step>
+            </ProcessingSteps>
+            </VRTDataset>
+                """
+            )
+
+    with pytest.raises(Exception, match="Trimming dataset should have a single band"):
+        gdal.Open(
+            f"""<VRTDataset subclass='VRTProcessedDataset'>
+        <Input>
+            <SourceFilename>{src_filename}</SourceFilename>
+        </Input>
+        <ProcessingSteps>
+            <Step>
+                <Algorithm>Trimming</Algorithm>
+                <Argument name="trimming_dataset_filename">{trimming_two_bands_filename}</Argument>
+                <Argument name="top_rgb">200</Argument>
+                <Argument name="tone_ceil">190</Argument>
+                <Argument name="top_margin">0.1</Argument>
+            </Step>
+        </ProcessingSteps>
+        </VRTDataset>
+            """
+        )
+
+
+###############################################################################
+# Test that serialization (for example due to statistics computation) properly
+# works
+
+
+def test_vrtprocesseddataset_serialize(tmp_vsimem):
+
+    src_filename = str(tmp_vsimem / "src.tif")
+    src_ds = gdal.GetDriverByName("GTiff").Create(src_filename, 2, 1, 1)
+    src_ds.GetRasterBand(1).WriteRaster(0, 0, 2, 1, b"\x01\x02")
+    src_ds.Close()
+
+    vrt_filename = str(tmp_vsimem / "the.vrt")
+    content = f"""<VRTDataset subclass='VRTProcessedDataset'>
+    <VRTRasterBand subClass='VRTProcessedRasterBand' dataType='Byte'/>
+    <Input>
+        <SourceFilename>{src_filename}</SourceFilename>
+    </Input>
+    <ProcessingSteps>
+        <Step name="Affine combination of band values">
+            <Algorithm>BandAffineCombination</Algorithm>
+            <Argument name="coefficients_1">10,1</Argument>
+        </Step>
+    </ProcessingSteps>
+    </VRTDataset>
+        """
+    with gdaltest.tempfile(vrt_filename, content):
+        ds = gdal.Open(vrt_filename)
+        assert struct.unpack("B" * 2, ds.GetRasterBand(1).ReadRaster()) == (11, 12)
+        assert ds.GetRasterBand(1).GetStatistics(False, False) == [0.0, 0.0, 0.0, -1.0]
+        ds.GetRasterBand(1).ComputeStatistics(False)
+        ds.Close()
+
+        ds = gdal.Open(vrt_filename)
+        assert struct.unpack("B" * 2, ds.GetRasterBand(1).ReadRaster()) == (11, 12)
+        assert ds.GetRasterBand(1).GetStatistics(False, False) == [
+            11.0,
+            12.0,
+            11.5,
+            0.5,
+        ]

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1907,6 +1907,22 @@ See the dedicated :ref:`vrt_multidimensional` page.
 
    vrt_multidimensional
 
+Processed dataset VRT
+---------------------
+
+.. versionadded:: 3.9
+
+A VRT processed dataset is a specific variant of the :ref:`raster.vrt` format,
+to apply chained processing steps that apply to several bands at the same time.
+
+See the dedicated :ref:`vrt_processed_dataset` page.
+
+.. toctree::
+   :maxdepth: 1
+   :hidden:
+
+   vrt_processed_dataset
+
 vrt:// connection string
 ------------------------
 

--- a/doc/source/drivers/raster/vrt_processed_dataset.rst
+++ b/doc/source/drivers/raster/vrt_processed_dataset.rst
@@ -1,0 +1,261 @@
+.. _vrt_processed_dataset:
+
+================================================================================
+VRT processed dataset
+================================================================================
+
+.. versionadded:: 3.9
+
+A VRT processed dataset is a specific variant of the :ref:`raster.vrt` format,
+to apply chained processing steps that apply to several bands at the same time.
+
+The following built-in algorithms are introduced, and may typically be applied
+in the following order:
+
+- Dehazing: remove haze effects by applying (subsampled) gain and offset
+  auxiliary datasets.
+
+- BandAffineCombination: perform an affine transformation combination of bands.
+
+- Trimming: apply local thresholding of saturation
+
+- LUT: apply a look-up table (band per band)
+
+More algorithms can be registered are run-time with the :cpp:func:`GDALVRTRegisterProcessedDatasetFunc`
+function`
+
+Here's an example of such a file to apply various correction to a R,G,B,NIR dataset:
+
+.. code-block:: xml
+
+    <VRTDataset subClass="VRTProcessedDataset">
+      <Input>
+        <SourceFilename relativeToVRT="1">source.tif</SourceFilename>
+      </Input>
+
+      <ProcessingSteps>
+        <Step name="Dehazing">
+          <Algorithm>Dehazing</Algorithm>
+
+          <Argument name="relative_filenames">true</Argument>
+
+          <Argument name="gain_dataset_filename_1">gains.tif</Argument>
+          <Argument name="gain_dataset_filename_2">gains.tif</Argument>
+          <Argument name="gain_dataset_filename_3">gains.tif</Argument>
+          <Argument name="gain_dataset_filename_4">gains.tif</Argument>
+          <Argument name="gain_dataset_band_1">1</Argument>
+          <Argument name="gain_dataset_band_2">2</Argument>
+          <Argument name="gain_dataset_band_3">3</Argument>
+          <Argument name="gain_dataset_band_4">4</Argument>
+
+          <Argument name="offset_dataset_filename_1">offsets.tif</Argument>
+          <Argument name="offset_dataset_filename_2">offsets.tif</Argument>
+          <Argument name="offset_dataset_filename_3">offsets.tif</Argument>
+          <Argument name="offset_dataset_filename_4">offsets.tif</Argument>
+          <Argument name="offset_dataset_band_1">1</Argument>
+          <Argument name="offset_dataset_band_2">2</Argument>
+          <Argument name="offset_dataset_band_3">3</Argument>
+          <Argument name="offset_dataset_band_4">4</Argument>
+
+          <Argument name="nodata">0</Argument>
+          <Argument name="min">1</Argument>
+          <Argument name="max">10000</Argument>
+        </Step>
+
+        <Step name="Linear combination">
+          <Algorithm>BandAffineCombination</Algorithm>
+          <Argument name="coefficients_1">0,1.2,-0.2,0.0,0.0</Argument>
+          <Argument name="coefficients_2">0,-0.03,1.03,0.0,0.0</Argument>
+          <Argument name="coefficients_3">0,0.0,0.0,1.0,0.0</Argument>
+          <Argument name="coefficients_4">0,0.0,0.0,0.0,1.0</Argument>
+
+          <Argument name="min">1</Argument>
+          <Argument name="max">10000</Argument>
+        </Step>
+
+        <Step name="Trimming">
+          <Algorithm>Trimming</Algorithm>
+          <Argument name="relative_filenames">true</Argument>
+          <Argument name="trimming_dataset_filename">trimming.tif</Argument>
+          <Argument name="tone_ceil">10000</Argument>
+          <Argument name="top_margin">0</Argument>
+          <Argument name="top_rgb">10000</Argument>
+        </Step>
+
+        <Step name="LUT">
+          <Algorithm>LUT</Algorithm>
+          <Argument name="lut_1">
+              0:0,10000.0:255
+          </Argument>
+          <Argument name="lut_2">
+              0:0,10000.0:255
+          </Argument>
+          <Argument name="lut_3">
+              0:0,10000.0:255
+          </Argument>
+          <Argument name="lut_4">
+              0:0,10000.0:255
+          </Argument>
+        </Step>
+      </ProcessingSteps>
+
+      <VRTRasterBand dataType="Byte" band="1" subClass="VRTProcessedRasterBand">
+        <ColorInterp>Red</ColorInterp>
+      </VRTRasterBand>
+      <VRTRasterBand dataType="Byte" band="2" subClass="VRTProcessedRasterBand">
+        <ColorInterp>Green</ColorInterp>
+      </VRTRasterBand>
+      <VRTRasterBand dataType="Byte" band="3" subClass="VRTProcessedRasterBand">
+        <ColorInterp>Blue</ColorInterp>
+      </VRTRasterBand>
+      <VRTRasterBand dataType="Byte" band="4" subClass="VRTProcessedRasterBand">
+      </VRTRasterBand>
+    </VRTDataset>
+
+.vrt format
+-----------
+
+The ``VRTDataset`` root element must have a ``subClass="VRTProcessedDataset"`` attribute.
+
+The following child elements of ``VRTDataset`` may be defined: ``SRS``, ``GeoTransform``, ``Metadata``. If they are not explicitly set, they are inferred from the input dataset.
+
+``VRTRasterBand`` elements may be explicitly defined, in particular if the data type of the virtual dataset after all processing steps is different from the input one, or if the number of output bands is different from the number of input bands. If there is no explicit ``VRTRasterBand`` element, the number and data types of input bands are used implicitly. When explicitly defined, ``VRTRasterBand`` elements must have a ``subClass="VRTProcessedRasterBand"`` attribute.
+`
+It must also have the 2 following child elements:
+
+- ``Input``, which must have one and only one of the following ``SourceFilename`` or ``VRTDataset`` as child elements, to define the input dataset to which to apply the processing steps.
+
+- ``ProcessingSteps``, with at least one child ``Step`` element.
+
+Each ``Step`` must have a ``Algorithm`` child element, and an optional ``name`` attribute.
+The value of ``Algorithm`` must be a registered VRTProcessedDataset function. At time of writing, the following 4 algorithms are defined: ``Dehazing``, ``BandAffineCombination``, ``Trimming`` and ``LUT``.
+
+A ``Step`` will generally have one or several ``Argument`` child elements, some of them being required, others optional. Consult the documentation of each algorithm.
+
+Dehazing algorithm
+------------------
+
+Remove haze effects by applying (subsampled) gain and offset auxiliary datasets.
+
+The gain and offset auxiliary datasets must have a georeferencing consistent of
+the input dataset, but may have a different resolution.
+
+The formula applied by that algorithm is: ``output_value = clamp(input_value * gain - offset, min, max)``
+
+The following required arguments must be specified:
+
+- ``gain_dataset_filename_{band}``: Filename to the gain dataset, where {band} must be replaced by 1 to the number of input bands.
+
+- ``gain_dataset_band_{band}``: Band number corresponding to ``gain_dataset_filename_{band}``, where {band} must be replaced by 1 to the number of input bands.
+
+- ``offset_dataset_filename_{band}``: Filename to the offset dataset, where {band} must be replaced by 1 to the number of input bands.
+
+- ``offset_dataset_band_{band}``: Band number corresponding to ``offset_dataset_filename_{band}``, where {band} must be replaced by 1 to the number of input bands.
+
+
+The following optional arguments may be specified:
+
+- ``relative_filenames``: Whether gain and offset filenames are relative to the VRT. Allowed values are ``true`` and ``false``. Defaults to ``false``
+
+- ``min``: Clamp minimum value, applied before writing the output value.
+
+- ``max``: Clamp maximum value, applied before writing the output value.
+
+- ``nodata``: Override the input nodata value coming from the previous step (or the input dataset for the first step).
+
+- ``gain_nodata``: Override the nodata value coming from the gain dataset(s).
+
+- ``offset_nodata``: Override the nodata value coming from the offset dataset(s).
+
+
+BandAffineCombination algorithm
+-------------------------------
+
+Perform an affine transformation combination of bands.
+
+The following required argument must be specified:
+
+- ``coefficients_{band}``: Comma-separated coefficients for combining bands where {band} must be replaced by 1 to the number of output bands. The number of coefficients in each argument must be 1 + number_of_input_bands, where the first coefficient is a constant, the second coefficient is the weight of the first input band, the third coefficient is the weight of the second input band, etc.
+
+
+The following optional arguments may be specified:
+
+- ``src_nodata``: Override the input nodata value coming from the previous step (or the input dataset for the first step).
+
+- ``dst_nodata``: Set the output nodata value.
+
+- ``replacement_nodata``: Value to substitute to a valid computed value that would be equal to dst_nodata.
+
+- ``dst_intended_datatype``: Intended datatype of output (which might be different than the working data type). Used to infer an appropriate value for replacement_nodata when it is not specified.
+
+- ``min``: Clamp minimum value, applied before writing the output value.
+
+- ``max``: Clamp maximum value, applied before writing the output value.
+
+
+Trimming algorithm
+------------------
+
+Apply local thresholding of saturation, with a special processing of the R,G,B bands compared to other bands.
+
+The pseudo algorithm used for each pixel is:
+
+.. code-block::
+
+    // Extract local saturation value from trimming image
+    localMaxRGB = value from TrimmingImage
+    reducedRGB = min ( (1-top_margin)*top_rgb/localMaxRGB ; 1)
+
+    // RGB bands specific process
+    RGB[] = get red, green, blue components of input buffer
+    maxRGB = max(RGB[])
+    toneMaxRGB = min ( toneCeil/maxRGB ; 1)
+    toneBand[] = min ( toneCeil/RGB[] ; 1)
+
+    output_value_RGB[] = min ( reducedRGB*RGB[]*toneBand[] / toneMaxRGB ; topRGB)
+
+    // Other bands processing (NIR, ...): only apply RGB reduction factor
+    Trimmed(OtherBands[]) = reducedRGB * OtherBands[]
+
+
+The following required arguments must be specified:
+
+- ``trimming_dataset_filename``: Filename of the trimming dataset. It must have one single band. It must have a georeferencing consistent of the input dataset, but may have a different resolution.
+
+- ``top_rgb``: Maximum saturating RGB output value.
+
+- ``tone_ceil``: Maximum threshold beyond which we give up saturation.
+
+- ``top_margin``: Margin to allow for dynamics in brighest areas (between 0 and 1, should be close to 0)
+
+
+The following optional arguments may be specified:
+
+- ``relative_filenames``: Whether the trimming dataset filename is relative to the VRT. Allowed values are ``true`` and ``false``. Defaults to ``false``
+
+- ``red_band``: Index (one-based) of the red band. Defaults to 1.
+
+- ``green_band``: Index (one-based) of the green band. Defaults to 1.
+
+- ``blue_band``: Index (one-based) of the blue band. Defaults to 1.
+
+- ``nodata``: Override the input nodata value coming from the previous step (or the input dataset for the first step).
+
+- ``trimming_nodata``: Override the nodata value coming from the trimming dataset.
+
+
+LUT
+---
+
+Apply a look-up table (band per band), typically to get from UInt16 to Byte data types.
+
+The following required argument must be specified:
+
+- ``lut_{band}``: List of the form ``[src value 1]:[dest value 1],[src value 2]:[dest value 2],....``. {band} must be replaced by 1 to the number of bands.
+
+
+The following optional arguments may be specified:
+
+- ``src_nodata``: Override the input nodata value coming from the previous step (or the input dataset for the first step).
+
+- ``dst_nodata``: Set the output nodata value.

--- a/frmts/vrt/CMakeLists.txt
+++ b/frmts/vrt/CMakeLists.txt
@@ -14,6 +14,8 @@ add_gdal_driver(
           vrtdataset.cpp
           pixelfunctions.cpp
           vrtpansharpened.cpp
+          vrtprocesseddataset.cpp
+          vrtprocesseddatasetfunctions.cpp
           vrtmultidim.cpp
           gdaltileindexdataset.cpp
           STRONG_CXX_WFLAGS)

--- a/frmts/vrt/data/gdalvrt.xsd
+++ b/frmts/vrt/data/gdalvrt.xsd
@@ -30,29 +30,75 @@
  ****************************************************************************/
 -->
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" version="1.0">
-    <xs:element name="VRTDataset">
-        <xs:complexType>
-            <xs:sequence>
-                <xs:choice minOccurs="0" maxOccurs="unbounded">
-                    <xs:element name="SRS" type="SRSType"/>
-                    <xs:element name="GeoTransform" type="xs:string"/>
-                    <xs:element name="GCPList" type="GCPListType"/>
-                    <xs:element name="BlockXSize" type="nonNegativeInteger32"/>
-                    <xs:element name="BlockYSize" type="nonNegativeInteger32"/>
-                    <xs:element name="Metadata" type="MetadataType"/> <!-- may be repeated -->
-                    <xs:element name="VRTRasterBand" type="VRTRasterBandType"/> <!-- may be repeated -->
-                    <xs:element name="MaskBand" type="MaskBandType"/>
-                    <xs:element name="GDALWarpOptions" type="GDALWarpOptionsType"/> <!-- only if subClass="VRTWarpedDataset" -->
-                    <xs:element name="PansharpeningOptions" type="PansharpeningOptionsType"/> <!-- only if subClass="VRTPansharpenedDataset" -->
-                    <xs:element name="Group" type="GroupType"/> <!-- only for multidimensional dataset -->
-                    <xs:element name="OverviewList" type="OverviewListType"/>
-                </xs:choice>
-            </xs:sequence>
-            <xs:attribute name="subClass" type="xs:string"/>
-            <xs:attribute name="rasterXSize" type="nonNegativeInteger32"/>
-            <xs:attribute name="rasterYSize" type="nonNegativeInteger32"/>
-        </xs:complexType>
+    <xs:element name="VRTDataset" type="VRTDatasetType">
+        <xs:annotation>
+            <xs:documentation>Root element</xs:documentation>
+        </xs:annotation>
     </xs:element>
+
+    <xs:complexType name="VRTDatasetType">
+        <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                <xs:element name="SRS" type="SRSType"/>
+                <xs:element name="GeoTransform" type="xs:string"/>
+                <xs:element name="GCPList" type="GCPListType"/>
+                <xs:element name="BlockXSize" type="nonNegativeInteger32"/>
+                <xs:element name="BlockYSize" type="nonNegativeInteger32"/>
+                <xs:element name="Metadata" type="MetadataType">
+                    <xs:annotation>
+                        <xs:documentation>May be repeated</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="VRTRasterBand" type="VRTRasterBandType">
+                    <xs:annotation>
+                        <xs:documentation>May be repeated</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="MaskBand" type="MaskBandType"/>
+                <xs:element name="GDALWarpOptions" type="GDALWarpOptionsType">
+                    <xs:annotation>
+                        <xs:documentation>Allowed only if subClass="VRTWarpedDataset"</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="PansharpeningOptions" type="PansharpeningOptionsType">
+                    <xs:annotation>
+                        <xs:documentation>Allowed only if subClass="VRTPansharpenedDataset"</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="Input" type="InputType">
+                    <xs:annotation>
+                        <xs:documentation>Allowed only if subClass="VRTProcessedDataset"</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="ProcessingSteps" type="ProcessingStepsType">
+                    <xs:annotation>
+                        <xs:documentation>Allowed only if subClass="VRTProcessedDataset"</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="Group" type="GroupType">
+                    <xs:annotation>
+                        <xs:documentation>only for multidimensional dataset</xs:documentation>
+                    </xs:annotation>
+                </xs:element>
+                <xs:element name="OverviewList" type="OverviewListType"/>
+            </xs:choice>
+        </xs:sequence>
+        <xs:attribute name="subClass" type="DatasetSubclassType"/>
+        <xs:attribute name="rasterXSize" type="nonNegativeInteger32"/>
+        <xs:attribute name="rasterYSize" type="nonNegativeInteger32"/>
+    </xs:complexType>
+
+    <xs:simpleType name="DatasetSubclassType">
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="VRTWarpedDataset"/>
+            <xs:enumeration value="VRTPansharpenedDataset"/>
+            <xs:enumeration value="VRTProcessedDataset">
+                <xs:annotation>
+                    <xs:documentation>Added in GDAL 3.9</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
 
     <xs:complexType name="OverviewListType">
         <xs:simpleContent>
@@ -158,6 +204,51 @@
         </xs:sequence>
     </xs:complexType>
 
+    <xs:complexType name="InputType">
+        <xs:sequence>
+            <xs:choice minOccurs="0" maxOccurs="1">
+                <xs:element name="SourceFilename" type="SourceFilenameType"/>
+                <xs:element name="VRTDataset" type="VRTDatasetType"/>
+            </xs:choice>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="ProcessingStepsType">
+        <xs:sequence minOccurs="1" maxOccurs="unbounded">
+            <xs:element name="Step" type="ProcessingStepType"/>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="ProcessingStepType">
+        <xs:annotation>
+            <xs:documentation>Processing step of a VRTPansharpenedDataset</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="Algorithm" type="xs:string" minOccurs="1">
+                <xs:annotation>
+                    <xs:documentation>Builtin allowed names are BandAffineCombination, LUT, Dehazing, Trimming. More algorithms can be registered at run-time.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+            <xs:element name="Argument" type="ArgumentType" maxOccurs="unbounded"/>
+        </xs:sequence>
+        <xs:attribute name="name" type="xs:string"/>
+    </xs:complexType>
+
+    <xs:complexType name="ArgumentType">
+        <xs:annotation>
+            <xs:documentation>Argument of a processing function</xs:documentation>
+        </xs:annotation>
+        <xs:simpleContent>
+            <xs:extension base="xs:string">
+                <xs:attribute name="name" type="xs:string" use="required">
+                    <xs:annotation>
+                        <xs:documentation>Allowed names are specific of each processing function</xs:documentation>
+                    </xs:annotation>
+                </xs:attribute>
+            </xs:extension>
+        </xs:simpleContent>
+    </xs:complexType>
+
     <xs:complexType name="MDIType">
         <xs:simpleContent>
             <xs:extension base="xs:string">
@@ -234,6 +325,7 @@
             <xs:enumeration value="VRTDerivedRasterBand"/>
             <xs:enumeration value="VRTRawRasterBand"/>
             <xs:enumeration value="VRTPansharpenedRasterBand"/>
+            <xs:enumeration value="VRTProcessedRasterBand"/>
         </xs:restriction>
     </xs:simpleType>
 

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -97,10 +97,6 @@ VRTDataset::~VRTDataset()
 
 {
     VRTDataset::FlushCache(true);
-    if (m_poSRS)
-        m_poSRS->Release();
-    if (m_poGCP_SRS)
-        m_poGCP_SRS->Release();
     CPLFree(m_pszVRTPath);
 
     delete m_poMaskBand;
@@ -144,6 +140,17 @@ CPLErr VRTPansharpenedDataset::FlushCache(bool bAtClosing)
 {
     return VRTFlushCacheStruct<VRTPansharpenedDataset>::FlushCache(*this,
                                                                    bAtClosing);
+}
+
+/************************************************************************/
+/*                             FlushCache()                             */
+/************************************************************************/
+
+CPLErr VRTProcessedDataset::FlushCache(bool bAtClosing)
+
+{
+    return VRTFlushCacheStruct<VRTProcessedDataset>::FlushCache(*this,
+                                                                bAtClosing);
 }
 
 /************************************************************************/
@@ -312,7 +319,7 @@ CPLXMLNode *VRTDataset::SerializeToXML(const char *pszVRTPathIn)
     /* -------------------------------------------------------------------- */
     if (!m_asGCPs.empty())
     {
-        GDALSerializeGCPListToXML(psDSTree, m_asGCPs, m_poGCP_SRS);
+        GDALSerializeGCPListToXML(psDSTree, m_asGCPs, m_poGCP_SRS.get());
     }
 
     /* -------------------------------------------------------------------- */
@@ -405,10 +412,18 @@ CPLXMLNode *CPL_STDCALL VRTSerializeToXML(VRTDatasetH hDataset,
 /************************************************************************/
 
 VRTRasterBand *VRTDataset::InitBand(const char *pszSubclass, int nBand,
-                                    bool bAllowPansharpened)
+                                    bool bAllowPansharpenedOrProcessed)
 {
     VRTRasterBand *poBand = nullptr;
-    if (EQUAL(pszSubclass, "VRTSourcedRasterBand"))
+    if (auto poProcessedDS = dynamic_cast<VRTProcessedDataset *>(this))
+    {
+        if (bAllowPansharpenedOrProcessed &&
+            EQUAL(pszSubclass, "VRTProcessedRasterBand"))
+        {
+            poBand = new VRTProcessedRasterBand(poProcessedDS, nBand);
+        }
+    }
+    else if (EQUAL(pszSubclass, "VRTSourcedRasterBand"))
         poBand = new VRTSourcedRasterBand(this, nBand);
     else if (EQUAL(pszSubclass, "VRTDerivedRasterBand"))
         poBand = new VRTDerivedRasterBand(this, nBand);
@@ -417,13 +432,17 @@ VRTRasterBand *VRTDataset::InitBand(const char *pszSubclass, int nBand,
     else if (EQUAL(pszSubclass, "VRTWarpedRasterBand") &&
              dynamic_cast<VRTWarpedDataset *>(this) != nullptr)
         poBand = new VRTWarpedRasterBand(this, nBand);
-    else if (bAllowPansharpened &&
+    else if (bAllowPansharpenedOrProcessed &&
              EQUAL(pszSubclass, "VRTPansharpenedRasterBand") &&
              dynamic_cast<VRTPansharpenedDataset *>(this) != nullptr)
         poBand = new VRTPansharpenedRasterBand(this, nBand);
-    else
+
+    if (!poBand)
+    {
         CPLError(CE_Failure, CPLE_AppDefined,
                  "VRTRasterBand of unrecognized subclass '%s'.", pszSubclass);
+    }
+
     return poBand;
 }
 
@@ -443,9 +462,7 @@ CPLErr VRTDataset::XMLInit(const CPLXMLNode *psTree, const char *pszVRTPathIn)
     const CPLXMLNode *psSRSNode = CPLGetXMLNode(psTree, "SRS");
     if (psSRSNode)
     {
-        if (m_poSRS)
-            m_poSRS->Release();
-        m_poSRS = new OGRSpatialReference();
+        m_poSRS.reset(new OGRSpatialReference());
         m_poSRS->SetFromUserInput(
             CPLGetXMLValue(psSRSNode, nullptr, ""),
             OGRSpatialReference::SET_FROM_USER_INPUT_LIMITATIONS_get());
@@ -500,7 +517,9 @@ CPLErr VRTDataset::XMLInit(const CPLXMLNode *psTree, const char *pszVRTPathIn)
     /* -------------------------------------------------------------------- */
     if (const CPLXMLNode *psGCPList = CPLGetXMLNode(psTree, "GCPList"))
     {
-        GDALDeserializeGCPListFromXML(psGCPList, m_asGCPs, &m_poGCP_SRS);
+        OGRSpatialReference *poSRS = nullptr;
+        GDALDeserializeGCPListFromXML(psGCPList, m_asGCPs, &poSRS);
+        m_poGCP_SRS.reset(poSRS);
     }
 
     /* -------------------------------------------------------------------- */
@@ -557,6 +576,13 @@ CPLErr VRTDataset::XMLInit(const CPLXMLNode *psTree, const char *pszVRTPathIn)
         {
             const char *pszSubclass =
                 CPLGetXMLValue(psChild, "subclass", "VRTSourcedRasterBand");
+            if (dynamic_cast<VRTProcessedDataset *>(this) &&
+                !EQUAL(pszSubclass, "VRTProcessedRasterBand"))
+            {
+                CPLError(CE_Failure, CPLE_NotSupported,
+                         "Only subClass=VRTProcessedRasterBand supported");
+                return CE_Failure;
+            }
 
             VRTRasterBand *poBand = InitBand(pszSubclass, l_nBands + 1, true);
             if (poBand != nullptr &&
@@ -636,10 +662,7 @@ CPLErr VRTDataset::SetGCPs(int nGCPCountIn, const GDAL_GCP *pasGCPListIn,
                            const OGRSpatialReference *poGCP_SRS)
 
 {
-    if (m_poGCP_SRS)
-        m_poGCP_SRS->Release();
-
-    m_poGCP_SRS = poGCP_SRS ? poGCP_SRS->Clone() : nullptr;
+    m_poGCP_SRS.reset(poGCP_SRS ? poGCP_SRS->Clone() : nullptr);
     m_asGCPs = gdal::GCP::fromC(pasGCPListIn, nGCPCountIn);
 
     SetNeedsFlush();
@@ -654,12 +677,7 @@ CPLErr VRTDataset::SetGCPs(int nGCPCountIn, const GDAL_GCP *pasGCPListIn,
 CPLErr VRTDataset::SetSpatialRef(const OGRSpatialReference *poSRS)
 
 {
-    if (m_poSRS)
-        m_poSRS->Release();
-    if (poSRS)
-        m_poSRS = poSRS->Clone();
-    else
-        m_poSRS = nullptr;
+    m_poSRS.reset(poSRS ? poSRS->Clone() : nullptr);
 
     SetNeedsFlush();
 
@@ -860,8 +878,7 @@ GDALDataset *VRTDataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Turn the XML representation into a VRTDataset.                  */
     /* -------------------------------------------------------------------- */
-    VRTDataset *poDS = static_cast<VRTDataset *>(
-        OpenXML(pszXML, pszVRTPath, poOpenInfo->eAccess));
+    VRTDataset *poDS = OpenXML(pszXML, pszVRTPath, poOpenInfo->eAccess);
 
     if (poDS != nullptr)
         poDS->m_bNeedsFlush = false;
@@ -1495,8 +1512,8 @@ GDALDataset *VRTDataset::OpenVRTProtocol(const char *pszSpec)
 /*      of the dataset.                                                 */
 /************************************************************************/
 
-GDALDataset *VRTDataset::OpenXML(const char *pszXML, const char *pszVRTPath,
-                                 GDALAccess eAccessIn)
+VRTDataset *VRTDataset::OpenXML(const char *pszXML, const char *pszVRTPath,
+                                GDALAccess eAccessIn)
 
 {
     /* -------------------------------------------------------------------- */
@@ -1517,8 +1534,10 @@ GDALDataset *VRTDataset::OpenXML(const char *pszXML, const char *pszVRTPath,
 
     const bool bIsPansharpened =
         strcmp(pszSubClass, "VRTPansharpenedDataset") == 0;
+    const bool bIsProcessed = strcmp(pszSubClass, "VRTProcessedDataset") == 0;
 
-    if (!bIsPansharpened && CPLGetXMLNode(psRoot, "Group") == nullptr &&
+    if (!bIsPansharpened && !bIsProcessed &&
+        CPLGetXMLNode(psRoot, "Group") == nullptr &&
         (CPLGetXMLNode(psRoot, "rasterXSize") == nullptr ||
          CPLGetXMLNode(psRoot, "rasterYSize") == nullptr ||
          CPLGetXMLNode(psRoot, "VRTRasterBand") == nullptr))
@@ -1535,7 +1554,8 @@ GDALDataset *VRTDataset::OpenXML(const char *pszXML, const char *pszVRTPath,
     const int nXSize = atoi(CPLGetXMLValue(psRoot, "rasterXSize", "0"));
     const int nYSize = atoi(CPLGetXMLValue(psRoot, "rasterYSize", "0"));
 
-    if (!bIsPansharpened && CPLGetXMLNode(psRoot, "VRTRasterBand") != nullptr &&
+    if (!bIsPansharpened && !bIsProcessed &&
+        CPLGetXMLNode(psRoot, "VRTRasterBand") != nullptr &&
         !GDALCheckDatasetDimensions(nXSize, nYSize))
     {
         return nullptr;
@@ -1546,6 +1566,8 @@ GDALDataset *VRTDataset::OpenXML(const char *pszXML, const char *pszVRTPath,
         poDS = new VRTWarpedDataset(nXSize, nYSize);
     else if (bIsPansharpened)
         poDS = new VRTPansharpenedDataset(nXSize, nYSize);
+    else if (bIsProcessed)
+        poDS = new VRTProcessedDataset(nXSize, nYSize);
     else
     {
         poDS = new VRTDataset(nXSize, nYSize);
@@ -2779,6 +2801,96 @@ void VRTDataset::ClearStatistics()
     }
 
     GDALDataset::ClearStatistics();
+}
+
+/************************************************************************/
+/*                         BuildSourceFilename()                        */
+/************************************************************************/
+
+/* static */
+std::string VRTDataset::BuildSourceFilename(const char *pszFilename,
+                                            const char *pszVRTPath,
+                                            bool bRelativeToVRT)
+{
+    std::string osSrcDSName;
+    if (pszVRTPath != nullptr && bRelativeToVRT)
+    {
+        // Try subdatasetinfo API first
+        // Note: this will become the only branch when subdatasetinfo will become
+        //       available for NITF_IM, RASTERLITE and TILEDB
+        const auto oSubDSInfo{GDALGetSubdatasetInfo(pszFilename)};
+        if (oSubDSInfo && !oSubDSInfo->GetPathComponent().empty())
+        {
+            auto path{oSubDSInfo->GetPathComponent()};
+            osSrcDSName = oSubDSInfo->ModifyPathComponent(
+                CPLProjectRelativeFilename(pszVRTPath, path.c_str()));
+            GDALDestroySubdatasetInfo(oSubDSInfo);
+        }
+        else
+        {
+            bool bDone = false;
+            for (const char *pszSyntax : VRTDataset::apszSpecialSyntax)
+            {
+                CPLString osPrefix(pszSyntax);
+                osPrefix.resize(strchr(pszSyntax, ':') - pszSyntax + 1);
+                if (pszSyntax[osPrefix.size()] == '"')
+                    osPrefix += '"';
+                if (EQUALN(pszFilename, osPrefix, osPrefix.size()))
+                {
+                    if (STARTS_WITH_CI(pszSyntax + osPrefix.size(), "{ANY}"))
+                    {
+                        const char *pszLastPart = strrchr(pszFilename, ':') + 1;
+                        // CSV:z:/foo.xyz
+                        if ((pszLastPart[0] == '/' || pszLastPart[0] == '\\') &&
+                            pszLastPart - pszFilename >= 3 &&
+                            pszLastPart[-3] == ':')
+                        {
+                            pszLastPart -= 2;
+                        }
+                        CPLString osPrefixFilename = pszFilename;
+                        osPrefixFilename.resize(pszLastPart - pszFilename);
+                        osSrcDSName =
+                            osPrefixFilename +
+                            CPLProjectRelativeFilename(pszVRTPath, pszLastPart);
+                        bDone = true;
+                    }
+                    else if (STARTS_WITH_CI(pszSyntax + osPrefix.size(),
+                                            "{FILENAME}"))
+                    {
+                        CPLString osFilename(pszFilename + osPrefix.size());
+                        size_t nPos = 0;
+                        if (osFilename.size() >= 3 && osFilename[1] == ':' &&
+                            (osFilename[2] == '\\' || osFilename[2] == '/'))
+                            nPos = 2;
+                        nPos = osFilename.find(
+                            pszSyntax[osPrefix.size() + strlen("{FILENAME}")],
+                            nPos);
+                        if (nPos != std::string::npos)
+                        {
+                            const CPLString osSuffix = osFilename.substr(nPos);
+                            osFilename.resize(nPos);
+                            osSrcDSName = osPrefix +
+                                          CPLProjectRelativeFilename(
+                                              pszVRTPath, osFilename) +
+                                          osSuffix;
+                            bDone = true;
+                        }
+                    }
+                    break;
+                }
+            }
+            if (!bDone)
+            {
+                osSrcDSName =
+                    CPLProjectRelativeFilename(pszVRTPath, pszFilename);
+            }
+        }
+    }
+    else
+    {
+        osSrcDSName = pszFilename;
+    }
+    return osSrcDSName;
 }
 
 /*! @endcond */

--- a/frmts/vrt/vrtdriver.cpp
+++ b/frmts/vrt/vrtdriver.cpp
@@ -34,6 +34,8 @@
 #include "gdal_alg_priv.h"
 #include "gdal_frmts.h"
 
+#include <mutex>
+
 /*! @cond Doxygen_Suppress */
 
 /************************************************************************/
@@ -504,8 +506,16 @@ void GDALRegister_VRT()
     if (GDALGetDriverByName("VRT") != nullptr)
         return;
 
-    // First register the pixel functions
-    GDALRegisterDefaultPixelFunc();
+    static std::once_flag flag;
+    std::call_once(flag,
+                   []()
+                   {
+                       // First register the pixel functions
+                       GDALRegisterDefaultPixelFunc();
+
+                       // Register functions for VRTProcessedDataset
+                       GDALVRTRegisterDefaultProcessedDatasetFuncs();
+                   });
 
     VRTDriver *poDriver = new VRTDriver();
 

--- a/frmts/vrt/vrtprocesseddataset.cpp
+++ b/frmts/vrt/vrtprocesseddataset.cpp
@@ -1,0 +1,1342 @@
+/******************************************************************************
+ *
+ * Project:  Virtual GDAL Datasets
+ * Purpose:  Implementation of VRTProcessedDataset.
+ * Author:   Even Rouault <even.rouault at spatialys.com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2024, Even Rouault <even.rouault at spatialys.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "cpl_minixml.h"
+#include "cpl_string.h"
+#include "vrtdataset.h"
+
+#include <algorithm>
+#include <limits>
+#include <map>
+#include <vector>
+
+/************************************************************************/
+/*                        VRTProcessedDatasetFunc                       */
+/************************************************************************/
+
+//! Structure holding information for a VRTProcessedDataset function.
+struct VRTProcessedDatasetFunc
+{
+    //! Processing function name
+    std::string osFuncName{};
+
+    //! User data to provide to pfnInit, pfnFree, pfnProcess callbacks.
+    void *pUserData = nullptr;
+
+    //! Whether XML metadata has been specified
+    bool bMetadataSpecified = false;
+
+    //! Map of (constant argument name, constant value)
+    std::map<std::string, std::string> oMapConstantArguments{};
+
+    //! Set of builtin argument names (e.g "offset", "scale", "nodata")
+    std::set<std::string> oSetBuiltinArguments{};
+
+    //! Arguments defined in the VRT
+    struct OtherArgument
+    {
+        std::string osType{};
+        bool bRequired = false;
+    };
+
+    std::map<std::string, OtherArgument> oOtherArguments{};
+
+    //! Requested input data type.
+    GDALDataType eRequestedInputDT = GDT_Unknown;
+
+    //! List of supported input datatypes. Empty if no restriction.
+    std::vector<GDALDataType> aeSupportedInputDT{};
+
+    //! List of supported input band counts. Empty if no restriction.
+    std::vector<int> anSupportedInputBandCount{};
+
+    //! Optional initialization function
+    GDALVRTProcessedDatasetFuncInit pfnInit = nullptr;
+
+    //! Optional free function
+    GDALVRTProcessedDatasetFuncFree pfnFree = nullptr;
+
+    //! Required processing function
+    GDALVRTProcessedDatasetFuncProcess pfnProcess = nullptr;
+};
+
+/************************************************************************/
+/*                      GetGlobalMapProcessedDatasetFunc()              */
+/************************************************************************/
+
+/** Return the registry of VRTProcessedDatasetFunc functions */
+static std::map<std::string, VRTProcessedDatasetFunc> &
+GetGlobalMapProcessedDatasetFunc()
+{
+    static std::map<std::string, VRTProcessedDatasetFunc> goMap;
+    return goMap;
+}
+
+/************************************************************************/
+/*                            Step::~Step()                             */
+/************************************************************************/
+
+/*! @cond Doxygen_Suppress */
+
+/** Step destructor */
+VRTProcessedDataset::Step::~Step()
+{
+    deinit();
+}
+
+/************************************************************************/
+/*                           Step::deinit()                             */
+/************************************************************************/
+
+/** Free pWorkingData */
+void VRTProcessedDataset::Step::deinit()
+{
+    if (pWorkingData)
+    {
+        const auto &oMapFunctions = GetGlobalMapProcessedDatasetFunc();
+        const auto oIterFunc = oMapFunctions.find(osAlgorithm);
+        if (oIterFunc != oMapFunctions.end())
+        {
+            if (oIterFunc->second.pfnFree)
+            {
+                oIterFunc->second.pfnFree(osAlgorithm.c_str(),
+                                          oIterFunc->second.pUserData,
+                                          pWorkingData);
+            }
+        }
+        else
+        {
+            CPLAssert(false);
+        }
+        pWorkingData = nullptr;
+    }
+}
+
+/************************************************************************/
+/*                        Step::Step(Step&& other)                      */
+/************************************************************************/
+
+/** Move constructor */
+VRTProcessedDataset::Step::Step(Step &&other)
+    : osAlgorithm(std::move(other.osAlgorithm)),
+      aosArguments(std::move(other.aosArguments)), eInDT(other.eInDT),
+      eOutDT(other.eOutDT), nInBands(other.nInBands),
+      nOutBands(other.nOutBands), adfInNoData(other.adfInNoData),
+      adfOutNoData(other.adfOutNoData), pWorkingData(other.pWorkingData)
+{
+    other.pWorkingData = nullptr;
+}
+
+/************************************************************************/
+/*                      Step operator=(Step&& other)                    */
+/************************************************************************/
+
+/** Move assignment operator */
+VRTProcessedDataset::Step &VRTProcessedDataset::Step::operator=(Step &&other)
+{
+    if (&other != this)
+    {
+        deinit();
+        osAlgorithm = std::move(other.osAlgorithm);
+        aosArguments = std::move(other.aosArguments);
+        eInDT = other.eInDT;
+        eOutDT = other.eOutDT;
+        nInBands = other.nInBands;
+        nOutBands = other.nOutBands;
+        adfInNoData = std::move(other.adfInNoData);
+        adfOutNoData = std::move(other.adfOutNoData);
+        std::swap(pWorkingData, other.pWorkingData);
+    }
+    return *this;
+}
+
+/************************************************************************/
+/*                        VRTProcessedDataset()                         */
+/************************************************************************/
+
+/** Constructor */
+VRTProcessedDataset::VRTProcessedDataset(int nXSize, int nYSize)
+    : VRTDataset(nXSize, nYSize)
+{
+}
+
+/************************************************************************/
+/*                       ~VRTProcessedDataset()                         */
+/************************************************************************/
+
+VRTProcessedDataset::~VRTProcessedDataset()
+
+{
+    VRTProcessedDataset::FlushCache(true);
+    VRTProcessedDataset::CloseDependentDatasets();
+}
+
+/************************************************************************/
+/*                              XMLInit()                               */
+/************************************************************************/
+
+/** Instantiate object from XML tree */
+CPLErr VRTProcessedDataset::XMLInit(const CPLXMLNode *psTree,
+                                    const char *pszVRTPathIn)
+
+{
+    if (Init(psTree, pszVRTPathIn, nullptr, nullptr, -1) != CE_None)
+        return CE_Failure;
+
+    const auto poSrcFirstBand = m_poSrcDS->GetRasterBand(1);
+    const int nOvrCount = poSrcFirstBand->GetOverviewCount();
+    for (int i = 0; i < nOvrCount; ++i)
+    {
+        auto poOvrDS = std::make_unique<VRTProcessedDataset>(0, 0);
+        if (poOvrDS->Init(psTree, pszVRTPathIn, this, m_poSrcDS.get(), i) !=
+            CE_None)
+            break;
+        m_apoOverviewDatasets.emplace_back(std::move(poOvrDS));
+    }
+
+    return CE_None;
+}
+
+/** Instantiate object from XML tree */
+CPLErr VRTProcessedDataset::Init(const CPLXMLNode *psTree,
+                                 const char *pszVRTPathIn,
+                                 const VRTProcessedDataset *poParentDS,
+                                 GDALDataset *poParentSrcDS, int iOvrLevel)
+
+{
+    const CPLXMLNode *psInput = CPLGetXMLNode(psTree, "Input");
+    if (!psInput)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Input element missing");
+        return CE_Failure;
+    }
+
+    if (pszVRTPathIn)
+        m_osVRTPath = pszVRTPathIn;
+
+    if (poParentSrcDS)
+    {
+        m_poSrcDS.reset(
+            GDALCreateOverviewDataset(poParentSrcDS, iOvrLevel, true));
+    }
+    else if (const CPLXMLNode *psSourceFileNameNode =
+                 CPLGetXMLNode(psInput, "SourceFilename"))
+    {
+        const bool bRelativeToVRT = CPL_TO_BOOL(
+            atoi(CPLGetXMLValue(psSourceFileNameNode, "relativetoVRT", "0")));
+        const std::string osFilename = VRTDataset::BuildSourceFilename(
+            CPLGetXMLValue(psInput, "SourceFilename", ""), pszVRTPathIn,
+            bRelativeToVRT);
+        m_poSrcDS.reset(GDALDataset::Open(
+            osFilename.c_str(), GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR, nullptr,
+            nullptr, nullptr));
+    }
+    else if (const CPLXMLNode *psVRTDataset =
+                 CPLGetXMLNode(psInput, "VRTDataset"))
+    {
+        CPLXMLNode sVRTDatasetTmp = *psVRTDataset;
+        sVRTDatasetTmp.psNext = nullptr;
+        char *pszXML = CPLSerializeXMLTree(&sVRTDatasetTmp);
+        m_poSrcDS.reset(VRTDataset::OpenXML(pszXML, pszVRTPathIn, GA_ReadOnly));
+        CPLFree(pszXML);
+    }
+    else
+    {
+        CPLError(
+            CE_Failure, CPLE_AppDefined,
+            "Input element should have a SourceFilename or VRTDataset element");
+        return CE_Failure;
+    }
+
+    if (!m_poSrcDS)
+        return CE_Failure;
+
+    if (nRasterXSize == 0 && nRasterYSize == 0)
+    {
+        nRasterXSize = m_poSrcDS->GetRasterXSize();
+        nRasterYSize = m_poSrcDS->GetRasterYSize();
+    }
+    else if (nRasterXSize != m_poSrcDS->GetRasterXSize() ||
+             nRasterYSize != m_poSrcDS->GetRasterYSize())
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Inconsistent declared VRT dimensions with input dataset");
+        return CE_Failure;
+    }
+
+    if (m_poSrcDS->GetRasterCount() == 0)
+        return CE_Failure;
+
+    // Inherit SRS from source if not explicitly defined in VRT
+    if (!CPLGetXMLNode(psTree, "SRS"))
+    {
+        const OGRSpatialReference *poSRS = m_poSrcDS->GetSpatialRef();
+        if (poSRS)
+        {
+            m_poSRS.reset(poSRS->Clone());
+        }
+    }
+
+    // Inherit GeoTransform from source if not explicitly defined in VRT
+    if (iOvrLevel < 0 && !CPLGetXMLNode(psTree, "GeoTransform"))
+    {
+        if (m_poSrcDS->GetGeoTransform(m_adfGeoTransform) == CE_None)
+            m_bGeoTransformSet = true;
+    }
+
+    /* -------------------------------------------------------------------- */
+    /*      Initialize blocksize before calling sub-init so that the        */
+    /*      band initializers can get it from the dataset object when       */
+    /*      they are created.                                               */
+    /* -------------------------------------------------------------------- */
+
+    const auto poSrcFirstBand = m_poSrcDS->GetRasterBand(1);
+    poSrcFirstBand->GetBlockSize(&m_nBlockXSize, &m_nBlockYSize);
+    if (const char *pszBlockXSize =
+            CPLGetXMLValue(psTree, "BlockXSize", nullptr))
+        m_nBlockXSize = atoi(pszBlockXSize);
+    if (const char *pszBlockYSize =
+            CPLGetXMLValue(psTree, "BlockYSize", nullptr))
+        m_nBlockYSize = atoi(pszBlockYSize);
+
+    // Initialize all the general VRT stuff.
+    if (VRTDataset::XMLInit(psTree, pszVRTPathIn) != CE_None)
+    {
+        return CE_Failure;
+    }
+
+    // Use geotransform from parent for overviews
+    if (iOvrLevel >= 0 && poParentDS->m_bGeoTransformSet)
+    {
+        m_bGeoTransformSet = true;
+        m_adfGeoTransform[0] = poParentDS->m_adfGeoTransform[0];
+        m_adfGeoTransform[1] = poParentDS->m_adfGeoTransform[1];
+        m_adfGeoTransform[2] = poParentDS->m_adfGeoTransform[2];
+        m_adfGeoTransform[3] = poParentDS->m_adfGeoTransform[3];
+        m_adfGeoTransform[4] = poParentDS->m_adfGeoTransform[4];
+        m_adfGeoTransform[5] = poParentDS->m_adfGeoTransform[5];
+
+        m_adfGeoTransform[1] *=
+            static_cast<double>(poParentDS->GetRasterXSize()) / nRasterXSize;
+        m_adfGeoTransform[2] *=
+            static_cast<double>(poParentDS->GetRasterYSize()) / nRasterYSize;
+        m_adfGeoTransform[4] *=
+            static_cast<double>(poParentDS->GetRasterXSize()) / nRasterXSize;
+        m_adfGeoTransform[5] *=
+            static_cast<double>(poParentDS->GetRasterYSize()) / nRasterYSize;
+    }
+
+    // Create bands automatically from source dataset if not explicitly defined
+    // in VRT.
+    if (!CPLGetXMLNode(psTree, "VRTRasterBand"))
+    {
+        for (int i = 0; i < m_poSrcDS->GetRasterCount(); ++i)
+        {
+            const auto poSrcBand = m_poSrcDS->GetRasterBand(i + 1);
+            auto poBand = new VRTProcessedRasterBand(
+                this, i + 1, poSrcBand->GetRasterDataType());
+            poBand->CopyCommonInfoFrom(poSrcBand);
+            SetBand(i + 1, poBand);
+        }
+    }
+
+    const CPLXMLNode *psProcessingSteps =
+        CPLGetXMLNode(psTree, "ProcessingSteps");
+    if (!psProcessingSteps)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "ProcessingSteps element missing");
+        return CE_Failure;
+    }
+
+    const auto eInDT = poSrcFirstBand->GetRasterDataType();
+    for (int i = 1; i < m_poSrcDS->GetRasterCount(); ++i)
+    {
+        const auto eDT = m_poSrcDS->GetRasterBand(i + 1)->GetRasterDataType();
+        if (eDT != eInDT)
+        {
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "Not all bands of the input dataset have the same data "
+                     "type. The data type of the first band will be used as "
+                     "the reference one.");
+            break;
+        }
+    }
+
+    GDALDataType eCurrentDT = eInDT;
+    int nCurrentBandCount = m_poSrcDS->GetRasterCount();
+
+    std::vector<double> adfNoData;
+    for (int i = 1; i <= nCurrentBandCount; ++i)
+    {
+        int bHasVal = FALSE;
+        const double dfVal =
+            m_poSrcDS->GetRasterBand(i)->GetNoDataValue(&bHasVal);
+        adfNoData.emplace_back(
+            bHasVal ? dfVal : std::numeric_limits<double>::quiet_NaN());
+    }
+
+    int nStepCount = 0;
+    for (const CPLXMLNode *psStep = psProcessingSteps->psChild; psStep;
+         psStep = psStep->psNext)
+    {
+        if (psStep->eType == CXT_Element &&
+            strcmp(psStep->pszValue, "Step") == 0)
+        {
+            ++nStepCount;
+        }
+    }
+
+    int iStep = 0;
+    for (const CPLXMLNode *psStep = psProcessingSteps->psChild; psStep;
+         psStep = psStep->psNext)
+    {
+        if (psStep->eType == CXT_Element &&
+            strcmp(psStep->pszValue, "Step") == 0)
+        {
+            ++iStep;
+            const bool bIsFinalStep = (iStep == nStepCount);
+            std::vector<double> adfOutNoData;
+            if (bIsFinalStep)
+            {
+                // Initialize adfOutNoData with nodata value of *output* bands
+                // for final step
+                for (int i = 1; i <= nBands; ++i)
+                {
+                    int bHasVal = FALSE;
+                    const double dfVal =
+                        GetRasterBand(i)->GetNoDataValue(&bHasVal);
+                    adfOutNoData.emplace_back(
+                        bHasVal ? dfVal
+                                : std::numeric_limits<double>::quiet_NaN());
+                }
+            }
+            if (!ParseStep(psStep, bIsFinalStep, eCurrentDT, nCurrentBandCount,
+                           adfNoData, adfOutNoData))
+                return CE_Failure;
+            adfNoData = std::move(adfOutNoData);
+        }
+    }
+
+    if (m_aoSteps.empty())
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "At least one step should be defined");
+        return CE_Failure;
+    }
+
+    if (nCurrentBandCount != nBands)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Number of output bands of last step is not consistent with "
+                 "number of VRTProcessedRasterBand's");
+        return CE_Failure;
+    }
+
+    if (nBands > 1)
+        SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+
+    m_oXMLTree.reset(CPLCloneXMLTree(psTree));
+
+    return CE_None;
+}
+
+/************************************************************************/
+/*                            ParseStep()                               */
+/************************************************************************/
+
+/** Parse the current Step node and create a corresponding entry in m_aoSteps.
+ *
+ * @param psStep Step node
+ * @param bIsFinalStep Whether this is the final step.
+ * @param[in,out] eCurrentDT Input data type for this step.
+ *                           Updated to output data type at end of method.
+ * @param[in,out] nCurrentBandCount Input band count for this step.
+ *                                  Updated to output band cout at end of
+ *                                  method.
+ * @param adfInNoData Input nodata values
+ * @param[in,out] adfOutNoData Output nodata values, to be filled by this
+ *                             method. When bIsFinalStep, this is also an
+ *                             input parameter.
+ * @return true on success.
+ */
+bool VRTProcessedDataset::ParseStep(const CPLXMLNode *psStep, bool bIsFinalStep,
+                                    GDALDataType &eCurrentDT,
+                                    int &nCurrentBandCount,
+                                    std::vector<double> &adfInNoData,
+                                    std::vector<double> &adfOutNoData)
+{
+    const char *pszStepName = CPLGetXMLValue(
+        psStep, "name", CPLSPrintf("nr %d", 1 + int(m_aoSteps.size())));
+    const char *pszAlgorithm = CPLGetXMLValue(psStep, "Algorithm", nullptr);
+    if (!pszAlgorithm)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Step '%s' lacks a Algorithm element", pszStepName);
+        return false;
+    }
+
+    const auto &oMapFunctions = GetGlobalMapProcessedDatasetFunc();
+    const auto oIterFunc = oMapFunctions.find(pszAlgorithm);
+    if (oIterFunc == oMapFunctions.end())
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Step '%s' uses unregistered algorithm '%s'", pszStepName,
+                 pszAlgorithm);
+        return false;
+    }
+
+    const auto &oFunc = oIterFunc->second;
+
+    if (!oFunc.aeSupportedInputDT.empty())
+    {
+        if (std::find(oFunc.aeSupportedInputDT.begin(),
+                      oFunc.aeSupportedInputDT.end(),
+                      eCurrentDT) == oFunc.aeSupportedInputDT.end())
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Step '%s' (using algorithm '%s') does not "
+                     "support input data type = '%s'",
+                     pszStepName, pszAlgorithm,
+                     GDALGetDataTypeName(eCurrentDT));
+            return false;
+        }
+    }
+
+    if (!oFunc.anSupportedInputBandCount.empty())
+    {
+        if (std::find(oFunc.anSupportedInputBandCount.begin(),
+                      oFunc.anSupportedInputBandCount.end(),
+                      nCurrentBandCount) ==
+            oFunc.anSupportedInputBandCount.end())
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Step '%s' (using algorithm '%s') does not "
+                     "support input band count = %d",
+                     pszStepName, pszAlgorithm, nCurrentBandCount);
+            return false;
+        }
+    }
+
+    Step oStep;
+    oStep.osAlgorithm = pszAlgorithm;
+    oStep.eInDT = oFunc.eRequestedInputDT != GDT_Unknown
+                      ? oFunc.eRequestedInputDT
+                      : eCurrentDT;
+    oStep.nInBands = nCurrentBandCount;
+
+    // Unless modified by pfnInit...
+    oStep.eOutDT = oStep.eInDT;
+
+    oStep.adfInNoData = adfInNoData;
+    oStep.adfOutNoData = bIsFinalStep ? adfOutNoData : adfInNoData;
+
+    // Deal with constant arguments
+    for (const auto &nameValuePair : oFunc.oMapConstantArguments)
+    {
+        oStep.aosArguments.AddNameValue(nameValuePair.first.c_str(),
+                                        nameValuePair.second.c_str());
+    }
+
+    // Deal with built-in arguments
+    if (oFunc.oSetBuiltinArguments.find("nodata") !=
+        oFunc.oSetBuiltinArguments.end())
+    {
+        int bHasVal = false;
+        const auto poSrcFirstBand = m_poSrcDS->GetRasterBand(1);
+        const double dfVal = poSrcFirstBand->GetNoDataValue(&bHasVal);
+        if (bHasVal)
+        {
+            oStep.aosArguments.AddNameValue("nodata",
+                                            CPLSPrintf("%.18g", dfVal));
+        }
+    }
+
+    if (oFunc.oSetBuiltinArguments.find("offset_{band}") !=
+        oFunc.oSetBuiltinArguments.end())
+    {
+        for (int i = 1; i <= m_poSrcDS->GetRasterCount(); ++i)
+        {
+            int bHasVal = false;
+            const double dfVal = GetRasterBand(i)->GetOffset(&bHasVal);
+            oStep.aosArguments.AddNameValue(
+                CPLSPrintf("offset_%d", i),
+                CPLSPrintf("%.18g", bHasVal ? dfVal : 0.0));
+        }
+    }
+
+    if (oFunc.oSetBuiltinArguments.find("scale_{band}") !=
+        oFunc.oSetBuiltinArguments.end())
+    {
+        for (int i = 1; i <= m_poSrcDS->GetRasterCount(); ++i)
+        {
+            int bHasVal = false;
+            const double dfVal = GetRasterBand(i)->GetScale(&bHasVal);
+            oStep.aosArguments.AddNameValue(
+                CPLSPrintf("scale_%d", i),
+                CPLSPrintf("%.18g", bHasVal ? dfVal : 1.0));
+        }
+    }
+
+    // Parse arguments specified in VRT
+    std::set<std::string> oFoundArguments;
+
+    for (const CPLXMLNode *psStepChild = psStep->psChild; psStepChild;
+         psStepChild = psStepChild->psNext)
+    {
+        if (psStepChild->eType == CXT_Element &&
+            strcmp(psStepChild->pszValue, "Argument") == 0)
+        {
+            const char *pszParamName =
+                CPLGetXMLValue(psStepChild, "name", nullptr);
+            if (!pszParamName)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Step '%s' has a Argument without a name attribute",
+                         pszStepName);
+                return false;
+            }
+            const char *pszValue = CPLGetXMLValue(psStepChild, nullptr, "");
+            auto oOtherArgIter =
+                oFunc.oOtherArguments.find(CPLString(pszParamName).tolower());
+            if (!oFunc.oOtherArguments.empty() &&
+                oOtherArgIter == oFunc.oOtherArguments.end())
+            {
+                // If we got a parameter name like 'coefficients_1',
+                // try to fetch the generic 'coefficients_{band}'
+                std::string osParamName(pszParamName);
+                const auto nPos = osParamName.rfind('_');
+                if (nPos != std::string::npos)
+                {
+                    osParamName.resize(nPos + 1);
+                    osParamName += "{band}";
+                    oOtherArgIter = oFunc.oOtherArguments.find(
+                        CPLString(osParamName).tolower());
+                }
+            }
+            if (oOtherArgIter != oFunc.oOtherArguments.end())
+            {
+                oFoundArguments.insert(oOtherArgIter->first);
+
+                const std::string &osType = oOtherArgIter->second.osType;
+                if (osType == "boolean")
+                {
+                    if (!EQUAL(pszValue, "true") && !EQUAL(pszValue, "false"))
+                    {
+                        CPLError(CE_Failure, CPLE_NotSupported,
+                                 "Step '%s' has a Argument '%s' whose "
+                                 "value '%s' is not a boolean",
+                                 pszStepName, pszParamName, pszValue);
+                        return false;
+                    }
+                }
+                else if (osType == "integer")
+                {
+                    if (CPLGetValueType(pszValue) != CPL_VALUE_INTEGER)
+                    {
+                        CPLError(CE_Failure, CPLE_NotSupported,
+                                 "Step '%s' has a Argument '%s' whose "
+                                 "value '%s' is not a integer",
+                                 pszStepName, pszParamName, pszValue);
+                        return false;
+                    }
+                }
+                else if (osType == "double")
+                {
+                    const auto eType = CPLGetValueType(pszValue);
+                    if (eType != CPL_VALUE_INTEGER && eType != CPL_VALUE_REAL)
+                    {
+                        CPLError(CE_Failure, CPLE_NotSupported,
+                                 "Step '%s' has a Argument '%s' whose "
+                                 "value '%s' is not a double",
+                                 pszStepName, pszParamName, pszValue);
+                        return false;
+                    }
+                }
+                else if (osType == "double_list")
+                {
+                    const CPLStringList aosTokens(
+                        CSLTokenizeString2(pszValue, ",", 0));
+                    for (int i = 0; i < aosTokens.size(); ++i)
+                    {
+                        const auto eType = CPLGetValueType(aosTokens[i]);
+                        if (eType != CPL_VALUE_INTEGER &&
+                            eType != CPL_VALUE_REAL)
+                        {
+                            CPLError(CE_Failure, CPLE_NotSupported,
+                                     "Step '%s' has a Argument '%s' "
+                                     "whose value '%s' is not a "
+                                     "comma-separated list of doubles",
+                                     pszStepName, pszParamName, pszValue);
+                            return false;
+                        }
+                    }
+                }
+                else if (osType != "string")
+                {
+                    CPLDebug("VRT", "Unhandled argument type '%s'",
+                             osType.c_str());
+                    CPLAssert(0);
+                }
+            }
+            else if (oFunc.bMetadataSpecified &&
+                     oFunc.oSetBuiltinArguments.find(
+                         CPLString(pszParamName).tolower()) ==
+                         oFunc.oSetBuiltinArguments.end() &&
+                     oFunc.oMapConstantArguments.find(
+                         CPLString(pszParamName).tolower()) ==
+                         oFunc.oMapConstantArguments.end())
+            {
+                CPLError(CE_Warning, CPLE_NotSupported,
+                         "Step '%s' has a Argument '%s' which is not "
+                         "supported",
+                         pszStepName, pszParamName);
+            }
+
+            oStep.aosArguments.AddNameValue(pszParamName, pszValue);
+        }
+    }
+
+    // Check that required arguments have been specified
+    for (const auto &oIter : oFunc.oOtherArguments)
+    {
+        if (oIter.second.bRequired &&
+            oFoundArguments.find(oIter.first) == oFoundArguments.end())
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Step '%s' lacks required Argument '%s'", pszStepName,
+                     oIter.first.c_str());
+            return false;
+        }
+    }
+
+    if (oFunc.pfnInit)
+    {
+        double *padfOutNoData = nullptr;
+        if (bIsFinalStep)
+        {
+            oStep.nOutBands = nBands;
+            padfOutNoData =
+                static_cast<double *>(CPLMalloc(nBands * sizeof(double)));
+            CPLAssert(adfOutNoData.size() == static_cast<size_t>(nBands));
+            memcpy(padfOutNoData, adfOutNoData.data(), nBands * sizeof(double));
+        }
+        else
+        {
+            oStep.nOutBands = 0;
+        }
+
+        if (oFunc.pfnInit(pszAlgorithm, oFunc.pUserData,
+                          oStep.aosArguments.List(), oStep.nInBands,
+                          oStep.eInDT, adfInNoData.data(), &(oStep.nOutBands),
+                          &(oStep.eOutDT), &padfOutNoData, m_osVRTPath.c_str(),
+                          &(oStep.pWorkingData)) != CE_None)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Step '%s' (using algorithm '%s') init() function "
+                     "failed",
+                     pszStepName, pszAlgorithm);
+            CPLFree(padfOutNoData);
+            return false;
+        }
+
+        // Input nodata values may have been modified by pfnInit()
+        oStep.adfInNoData = adfInNoData;
+
+        if (padfOutNoData)
+        {
+            adfOutNoData =
+                std::vector<double>(padfOutNoData, padfOutNoData + nBands);
+        }
+        else
+        {
+            adfOutNoData = std::vector<double>(
+                oStep.nOutBands, std::numeric_limits<double>::quiet_NaN());
+        }
+        CPLFree(padfOutNoData);
+
+        oStep.adfOutNoData = adfOutNoData;
+    }
+    else
+    {
+        oStep.nOutBands = oStep.nInBands;
+        adfOutNoData = oStep.adfOutNoData;
+    }
+
+    eCurrentDT = oStep.eOutDT;
+    nCurrentBandCount = oStep.nOutBands;
+
+    m_aoSteps.emplace_back(std::move(oStep));
+
+    return true;
+}
+
+/************************************************************************/
+/*                           SerializeToXML()                           */
+/************************************************************************/
+
+CPLXMLNode *VRTProcessedDataset::SerializeToXML(const char *pszVRTPathIn)
+
+{
+    CPLXMLNode *psTree = CPLCloneXMLTree(m_oXMLTree.get());
+    if (psTree == nullptr)
+        return psTree;
+
+    /* -------------------------------------------------------------------- */
+    /*      Remove VRTRasterBand nodes from the original tree and find the  */
+    /*      last child.                                                     */
+    /* -------------------------------------------------------------------- */
+    CPLXMLNode *psLastChild = psTree->psChild;
+    CPLXMLNode *psPrevChild = nullptr;
+    while (psLastChild)
+    {
+        CPLXMLNode *psNextChild = psLastChild->psNext;
+        if (psLastChild->eType == CXT_Element &&
+            strcmp(psLastChild->pszValue, "VRTRasterBand") == 0)
+        {
+            if (psPrevChild)
+                psPrevChild->psNext = psNextChild;
+            else
+                psTree->psChild = psNextChild;
+            psLastChild->psNext = nullptr;
+            CPLDestroyXMLNode(psLastChild);
+            psLastChild = psPrevChild ? psPrevChild : psTree->psChild;
+        }
+        else if (!psNextChild)
+        {
+            break;
+        }
+        else
+        {
+            psPrevChild = psLastChild;
+            psLastChild = psNextChild;
+        }
+    }
+    CPLAssert(psLastChild);  // we have at least Input
+
+    /* -------------------------------------------------------------------- */
+    /*      Serialize bands.                                                */
+    /* -------------------------------------------------------------------- */
+    bool bHasWarnedAboutRAMUsage = false;
+    size_t nAccRAMUsage = 0;
+    for (int iBand = 0; iBand < nBands; iBand++)
+    {
+        CPLXMLNode *psBandTree =
+            static_cast<VRTRasterBand *>(papoBands[iBand])
+                ->SerializeToXML(pszVRTPathIn, bHasWarnedAboutRAMUsage,
+                                 nAccRAMUsage);
+
+        if (psBandTree != nullptr)
+        {
+            psLastChild->psNext = psBandTree;
+            psLastChild = psBandTree;
+        }
+    }
+
+    return psTree;
+}
+
+/************************************************************************/
+/*                           SerializeToXML()                           */
+/************************************************************************/
+
+CPLXMLNode *
+VRTProcessedRasterBand::SerializeToXML(const char *pszVRTPathIn,
+                                       bool &bHasWarnedAboutRAMUsage,
+                                       size_t &nAccRAMUsage)
+
+{
+    CPLXMLNode *psTree = VRTRasterBand::SerializeToXML(
+        pszVRTPathIn, bHasWarnedAboutRAMUsage, nAccRAMUsage);
+
+    /* -------------------------------------------------------------------- */
+    /*      Set subclass.                                                   */
+    /* -------------------------------------------------------------------- */
+    CPLCreateXMLNode(CPLCreateXMLNode(psTree, CXT_Attribute, "subClass"),
+                     CXT_Text, "VRTProcessedRasterBand");
+
+    return psTree;
+}
+
+/************************************************************************/
+/*                            GetBlockSize()                            */
+/************************************************************************/
+
+/** Return block size */
+void VRTProcessedDataset::GetBlockSize(int *pnBlockXSize,
+                                       int *pnBlockYSize) const
+
+{
+    *pnBlockXSize = m_nBlockXSize;
+    *pnBlockYSize = m_nBlockYSize;
+}
+
+/************************************************************************/
+/*                            ProcessRegion()                           */
+/************************************************************************/
+
+/** Compute pixel values for the specified region.
+ *
+ * The output is stored in m_abyInput in a pixel-interleaved way.
+ */
+bool VRTProcessedDataset::ProcessRegion(int nXOff, int nYOff, int nBufXSize,
+                                        int nBufYSize)
+{
+
+    CPLAssert(!m_aoSteps.empty());
+
+    const int nFirstBandCount = m_aoSteps.front().nInBands;
+    CPLAssert(nFirstBandCount == m_poSrcDS->GetRasterCount());
+    const GDALDataType eFirstDT = m_aoSteps.front().eInDT;
+    const int nFirstDTSize = GDALGetDataTypeSizeBytes(eFirstDT);
+    auto &abyInput = m_abyInput;
+    auto &abyOutput = m_abyOutput;
+    try
+    {
+        abyInput.resize(static_cast<size_t>(nBufXSize) * nBufYSize *
+                        nFirstBandCount * nFirstDTSize);
+    }
+    catch (const std::bad_alloc &)
+    {
+        CPLError(CE_Failure, CPLE_OutOfMemory,
+                 "Out of memory allocating working buffer");
+        return false;
+    }
+
+    if (m_poSrcDS->RasterIO(GF_Read, nXOff, nYOff, nBufXSize, nBufYSize,
+                            abyInput.data(), nBufXSize, nBufYSize, eFirstDT,
+                            nFirstBandCount, nullptr,
+                            nFirstDTSize * nFirstBandCount,
+                            nFirstDTSize * nFirstBandCount * nBufXSize,
+                            nFirstDTSize, nullptr) != CE_None)
+    {
+        return false;
+    }
+
+    const double dfSrcXOff = nXOff;
+    const double dfSrcYOff = nYOff;
+    const double dfSrcXSize = nBufXSize;
+    const double dfSrcYSize = nBufYSize;
+
+    double adfSrcGT[6];
+    if (m_poSrcDS->GetGeoTransform(adfSrcGT) != CE_None)
+    {
+        adfSrcGT[0] = 0;
+        adfSrcGT[1] = 1;
+        adfSrcGT[2] = 0;
+        adfSrcGT[3] = 0;
+        adfSrcGT[4] = 0;
+        adfSrcGT[5] = 1;
+    }
+
+    GDALDataType eLastDT = eFirstDT;
+    const auto &oMapFunctions = GetGlobalMapProcessedDatasetFunc();
+    for (const auto &oStep : m_aoSteps)
+    {
+        const auto oIterFunc = oMapFunctions.find(oStep.osAlgorithm);
+        CPLAssert(oIterFunc != oMapFunctions.end());
+
+        // Data type adaptation
+        if (eLastDT != oStep.eInDT)
+        {
+            try
+            {
+                abyOutput.resize(static_cast<size_t>(nBufXSize) * nBufYSize *
+                                 oStep.nInBands *
+                                 GDALGetDataTypeSizeBytes(oStep.eInDT));
+            }
+            catch (const std::bad_alloc &)
+            {
+                CPLError(CE_Failure, CPLE_OutOfMemory,
+                         "Out of memory allocating working buffer");
+                return false;
+            }
+
+            GDALCopyWords64(abyInput.data(), eLastDT,
+                            GDALGetDataTypeSizeBytes(eLastDT), abyOutput.data(),
+                            oStep.eInDT, GDALGetDataTypeSizeBytes(oStep.eInDT),
+                            static_cast<size_t>(nBufXSize) * nBufYSize *
+                                oStep.nInBands);
+
+            std::swap(abyInput, abyOutput);
+        }
+
+        try
+        {
+            abyOutput.resize(static_cast<size_t>(nBufXSize) * nBufYSize *
+                             oStep.nOutBands *
+                             GDALGetDataTypeSizeBytes(oStep.eOutDT));
+        }
+        catch (const std::bad_alloc &)
+        {
+            CPLError(CE_Failure, CPLE_OutOfMemory,
+                     "Out of memory allocating working buffer");
+            return false;
+        }
+
+        const auto &oFunc = oIterFunc->second;
+        if (oFunc.pfnProcess(
+                oStep.osAlgorithm.c_str(), oFunc.pUserData, oStep.pWorkingData,
+                oStep.aosArguments.List(), nBufXSize, nBufYSize,
+                abyInput.data(), abyInput.size(), oStep.eInDT, oStep.nInBands,
+                oStep.adfInNoData.data(), abyOutput.data(), abyOutput.size(),
+                oStep.eOutDT, oStep.nOutBands, oStep.adfOutNoData.data(),
+                dfSrcXOff, dfSrcYOff, dfSrcXSize, dfSrcYSize, adfSrcGT,
+                m_osVRTPath.c_str(),
+                /*papszExtra=*/nullptr) != CE_None)
+        {
+            return false;
+        }
+
+        std::swap(abyInput, abyOutput);
+        eLastDT = oStep.eOutDT;
+    }
+
+    return true;
+}
+
+/************************************************************************/
+/*                        VRTProcessedRasterBand()                      */
+/************************************************************************/
+
+/** Constructor */
+VRTProcessedRasterBand::VRTProcessedRasterBand(VRTProcessedDataset *poDSIn,
+                                               int nBandIn,
+                                               GDALDataType eDataTypeIn)
+{
+    Initialize(poDSIn->GetRasterXSize(), poDSIn->GetRasterYSize());
+
+    poDS = poDSIn;
+    nBand = nBandIn;
+    eAccess = GA_Update;
+    eDataType = eDataTypeIn;
+
+    poDSIn->GetBlockSize(&nBlockXSize, &nBlockYSize);
+}
+
+/************************************************************************/
+/*                           GetOverviewCount()                         */
+/************************************************************************/
+
+int VRTProcessedRasterBand::GetOverviewCount()
+{
+    auto poVRTDS = cpl::down_cast<VRTProcessedDataset *>(poDS);
+    return static_cast<int>(poVRTDS->m_apoOverviewDatasets.size());
+}
+
+/************************************************************************/
+/*                              GetOverview()                           */
+/************************************************************************/
+
+GDALRasterBand *VRTProcessedRasterBand::GetOverview(int iOvr)
+{
+    auto poVRTDS = cpl::down_cast<VRTProcessedDataset *>(poDS);
+    if (iOvr < 0 ||
+        iOvr >= static_cast<int>(poVRTDS->m_apoOverviewDatasets.size()))
+        return nullptr;
+    return poVRTDS->m_apoOverviewDatasets[iOvr]->GetRasterBand(nBand);
+}
+
+/************************************************************************/
+/*                             IReadBlock()                             */
+/************************************************************************/
+
+CPLErr VRTProcessedRasterBand::IReadBlock(int nBlockXOff, int nBlockYOff,
+                                          void *pImage)
+
+{
+    auto poVRTDS = cpl::down_cast<VRTProcessedDataset *>(poDS);
+
+    int nBufXSize = 0;
+    int nBufYSize = 0;
+    GetActualBlockSize(nBlockXOff, nBlockYOff, &nBufXSize, &nBufYSize);
+
+    const int nXPixelOff = nBlockXOff * nBlockXSize;
+    const int nYPixelOff = nBlockYOff * nBlockYSize;
+    if (!poVRTDS->ProcessRegion(nXPixelOff, nYPixelOff, nBufXSize, nBufYSize))
+    {
+        return CE_Failure;
+    }
+
+    const int nOutBands = poVRTDS->m_aoSteps.back().nOutBands;
+    CPLAssert(nOutBands == poVRTDS->GetRasterCount());
+    const auto eLastDT = poVRTDS->m_aoSteps.back().eOutDT;
+    const int nLastDTSize = GDALGetDataTypeSizeBytes(eLastDT);
+    const int nDTSize = GDALGetDataTypeSizeBytes(eDataType);
+
+    // Dispatch final output buffer to cached blocks of output bands
+    for (int iDstBand = 0; iDstBand < nOutBands; ++iDstBand)
+    {
+        GDALRasterBlock *poBlock = nullptr;
+        GByte *pDst;
+        if (iDstBand + 1 == nBand)
+        {
+            pDst = static_cast<GByte *>(pImage);
+        }
+        else
+        {
+            auto poOtherBand = poVRTDS->papoBands[iDstBand];
+            poBlock = poOtherBand->TryGetLockedBlockRef(nBlockXOff, nBlockYOff);
+            if (poBlock)
+            {
+                poBlock->DropLock();
+                continue;
+            }
+            poBlock = poOtherBand->GetLockedBlockRef(
+                nBlockXOff, nBlockYOff, /* bJustInitialized = */ true);
+            if (!poBlock)
+                continue;
+            pDst = static_cast<GByte *>(poBlock->GetDataRef());
+        }
+        for (int iY = 0; iY < nBufYSize; ++iY)
+        {
+            GDALCopyWords(poVRTDS->m_abyInput.data() +
+                              (iDstBand + static_cast<size_t>(iY) * nBufXSize *
+                                              nOutBands) *
+                                  nLastDTSize,
+                          eLastDT, nLastDTSize * nOutBands,
+                          pDst +
+                              static_cast<size_t>(iY) * nBlockXSize * nDTSize,
+                          eDataType, nDTSize, nBufXSize);
+        }
+        if (poBlock)
+            poBlock->DropLock();
+    }
+
+    return CE_None;
+}
+
+/*! @endcond */
+
+/************************************************************************/
+/*                GDALVRTRegisterProcessedDatasetFunc()                 */
+/************************************************************************/
+
+/** Register a function to be used by VRTProcessedDataset.
+
+ An example of content for pszXMLMetadata is:
+ \verbatim
+  <ProcessedDatasetFunctionArgumentsList>
+     <Argument name='src_nodata' type='double' description='Override input nodata value'/>
+     <Argument name='dst_nodata' type='double' description='Override output nodata value'/>
+     <Argument name='replacement_nodata' description='value to substitute to a valid computed value that would be nodata' type='double'/>
+     <Argument name='dst_intended_datatype' type='string' description='Intented datatype of output (which might be different than the working data type)'/>
+     <Argument name='coefficients_{band}' description='Comma-separated coefficients for combining bands. First one is constant term' type='double_list' required='true'/>
+  </ProcessedDatasetFunctionArgumentsList>
+ \endverbatim
+
+ @param pszFuncName Function name. Must be unique and not null.
+ @param pUserData User data. May be nullptr. Must remain valid during the
+                  lifetime of GDAL.
+ @param pszXMLMetadata XML metadata describing the function arguments. May be
+                       nullptr if there are no arguments.
+ @param eRequestedInputDT If the pfnProcess callback only supports a single
+                          data type, it should be specified in this parameter.
+                          Otherwise set it to GDT_Unknown.
+ @param paeSupportedInputDT List of supported input data types. May be nullptr
+                            if all are supported or if eRequestedInputDT is
+                            set to a non GDT_Unknown value.
+ @param nSupportedInputDTSize Size of paeSupportedInputDT
+ @param panSupportedInputBandCount List of supported band count. May be nullptr
+                                   if any source band count is supported.
+ @param nSupportedInputBandCountSize Size of panSupportedInputBandCount
+ @param pfnInit Initialization function called when a VRTProcessedDataset
+                step uses the register function. This initialization function
+                will return the output data type, output band count and
+                potentially initialize a working structure, typically parsing
+                arguments. May be nullptr.
+                If not specified, it will be assumed that the input and output
+                data types are the same, and that the input number of bands
+                and output number of bands are the same.
+ @param pfnFree Free function that will free the working structure allocated
+                by pfnInit. May be nullptr.
+ @param pfnProcess Processing function called to compute pixel values. Must
+                   not be nullptr.
+ @param papszOptions Unused currently. Must be nullptr.
+ @return CE_None in case of success, error otherwise.
+ @since 3.9
+ */
+CPLErr GDALVRTRegisterProcessedDatasetFunc(
+    const char *pszFuncName, void *pUserData, const char *pszXMLMetadata,
+    GDALDataType eRequestedInputDT, const GDALDataType *paeSupportedInputDT,
+    size_t nSupportedInputDTSize, const int *panSupportedInputBandCount,
+    size_t nSupportedInputBandCountSize,
+    GDALVRTProcessedDatasetFuncInit pfnInit,
+    GDALVRTProcessedDatasetFuncFree pfnFree,
+    GDALVRTProcessedDatasetFuncProcess pfnProcess,
+    CPL_UNUSED CSLConstList papszOptions)
+{
+    if (pszFuncName == nullptr || pszFuncName[0] == '\0')
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "pszFuncName should be non-empty");
+        return CE_Failure;
+    }
+
+    auto &oMap = GetGlobalMapProcessedDatasetFunc();
+    if (oMap.find(pszFuncName) != oMap.end())
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "%s already registered",
+                 pszFuncName);
+        return CE_Failure;
+    }
+
+    if (!pfnProcess)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "pfnProcess should not be null");
+        return CE_Failure;
+    }
+
+    VRTProcessedDatasetFunc oFunc;
+    oFunc.osFuncName = pszFuncName;
+    oFunc.pUserData = pUserData;
+    if (pszXMLMetadata)
+    {
+        oFunc.bMetadataSpecified = true;
+        auto psTree = CPLXMLTreeCloser(CPLParseXMLString(pszXMLMetadata));
+        if (!psTree)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Cannot parse pszXMLMetadata=%s for %s", pszXMLMetadata,
+                     pszFuncName);
+            return CE_Failure;
+        }
+        const CPLXMLNode *psRoot = CPLGetXMLNode(
+            psTree.get(), "=ProcessedDatasetFunctionArgumentsList");
+        if (!psRoot)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "No root ProcessedDatasetFunctionArgumentsList element in "
+                     "pszXMLMetadata=%s for %s",
+                     pszXMLMetadata, pszFuncName);
+            return CE_Failure;
+        }
+        for (const CPLXMLNode *psIter = psRoot->psChild; psIter;
+             psIter = psIter->psNext)
+        {
+            if (psIter->eType == CXT_Element &&
+                strcmp(psIter->pszValue, "Argument") == 0)
+            {
+                const char *pszName = CPLGetXMLValue(psIter, "name", nullptr);
+                if (!pszName)
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "Missing Argument.name attribute in "
+                             "pszXMLMetadata=%s for %s",
+                             pszXMLMetadata, pszFuncName);
+                    return CE_Failure;
+                }
+                const char *pszType = CPLGetXMLValue(psIter, "type", nullptr);
+                if (!pszType)
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "Missing Argument.type attribute in "
+                             "pszXMLMetadata=%s for %s",
+                             pszXMLMetadata, pszFuncName);
+                    return CE_Failure;
+                }
+                if (strcmp(pszType, "constant") == 0)
+                {
+                    const char *pszValue =
+                        CPLGetXMLValue(psIter, "value", nullptr);
+                    if (!pszValue)
+                    {
+                        CPLError(CE_Failure, CPLE_AppDefined,
+                                 "Missing Argument.value attribute in "
+                                 "pszXMLMetadata=%s for %s",
+                                 pszXMLMetadata, pszFuncName);
+                        return CE_Failure;
+                    }
+                    oFunc.oMapConstantArguments[CPLString(pszName).tolower()] =
+                        pszValue;
+                }
+                else if (strcmp(pszType, "builtin") == 0)
+                {
+                    if (EQUAL(pszName, "nodata") ||
+                        EQUAL(pszName, "offset_{band}") ||
+                        EQUAL(pszName, "scale_{band}"))
+                    {
+                        oFunc.oSetBuiltinArguments.insert(
+                            CPLString(pszName).tolower());
+                    }
+                    else
+                    {
+                        CPLError(CE_Failure, CPLE_NotSupported,
+                                 "Unsupported builtin parameter name %s in "
+                                 "pszXMLMetadata=%s for %s. Only nodata, "
+                                 "offset_{band} and scale_{band} are supported",
+                                 pszName, pszXMLMetadata, pszFuncName);
+                        return CE_Failure;
+                    }
+                }
+                else if (strcmp(pszType, "boolean") == 0 ||
+                         strcmp(pszType, "string") == 0 ||
+                         strcmp(pszType, "integer") == 0 ||
+                         strcmp(pszType, "double") == 0 ||
+                         strcmp(pszType, "double_list") == 0)
+                {
+                    VRTProcessedDatasetFunc::OtherArgument otherArgument;
+                    otherArgument.bRequired = CPLTestBool(
+                        CPLGetXMLValue(psIter, "required", "false"));
+                    otherArgument.osType = pszType;
+                    oFunc.oOtherArguments[CPLString(pszName).tolower()] =
+                        std::move(otherArgument);
+                }
+                else
+                {
+                    CPLError(CE_Failure, CPLE_NotSupported,
+                             "Unsupported type for parameter %s in "
+                             "pszXMLMetadata=%s for %s. Only boolean, string, "
+                             "integer, double and double_list are supported",
+                             pszName, pszXMLMetadata, pszFuncName);
+                    return CE_Failure;
+                }
+            }
+        }
+    }
+    oFunc.eRequestedInputDT = eRequestedInputDT;
+    if (nSupportedInputDTSize)
+    {
+        oFunc.aeSupportedInputDT.insert(
+            oFunc.aeSupportedInputDT.end(), paeSupportedInputDT,
+            paeSupportedInputDT + nSupportedInputDTSize);
+    }
+    if (nSupportedInputBandCountSize)
+    {
+        oFunc.anSupportedInputBandCount.insert(
+            oFunc.anSupportedInputBandCount.end(), panSupportedInputBandCount,
+            panSupportedInputBandCount + nSupportedInputBandCountSize);
+    }
+    oFunc.pfnInit = pfnInit;
+    oFunc.pfnFree = pfnFree;
+    oFunc.pfnProcess = pfnProcess;
+
+    oMap[pszFuncName] = std::move(oFunc);
+
+    return CE_None;
+}

--- a/frmts/vrt/vrtprocesseddatasetfunctions.cpp
+++ b/frmts/vrt/vrtprocesseddatasetfunctions.cpp
@@ -1,0 +1,1579 @@
+/******************************************************************************
+ *
+ * Project:  Virtual GDAL Datasets
+ * Purpose:  Implementation of VRTProcessedDataset processing functions
+ * Author:   Even Rouault <even.rouault at spatialys.com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2024, Even Rouault <even.rouault at spatialys.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "cpl_minixml.h"
+#include "cpl_string.h"
+#include "vrtdataset.h"
+
+#include <algorithm>
+#include <limits>
+#include <map>
+#include <set>
+#include <vector>
+
+/************************************************************************/
+/*                               GetDstValue()                          */
+/************************************************************************/
+
+/** Return a destination value given an initial value, the destination no data
+ * value and its replacement value
+ */
+static inline double GetDstValue(double dfVal, double dfDstNoData,
+                                 double dfReplacementDstNodata,
+                                 GDALDataType eIntendedDstDT,
+                                 bool bDstIntendedDTIsInteger)
+{
+    if (bDstIntendedDTIsInteger && std::round(dfVal) == dfDstNoData)
+    {
+        return dfReplacementDstNodata;
+    }
+    else if (eIntendedDstDT == GDT_Float32 &&
+             static_cast<float>(dfVal) == static_cast<float>(dfDstNoData))
+    {
+        return dfReplacementDstNodata;
+    }
+    else if (eIntendedDstDT == GDT_Float64 && dfVal == dfDstNoData)
+    {
+        return dfReplacementDstNodata;
+    }
+    else
+    {
+        return dfVal;
+    }
+}
+
+/************************************************************************/
+/*                    BandAffineCombinationData                         */
+/************************************************************************/
+
+namespace
+{
+/** Working structure for 'BandAffineCombination' builtin function. */
+struct BandAffineCombinationData
+{
+    static constexpr const char *const EXPECTED_SIGNATURE =
+        "BandAffineCombination";
+    //! Signature (to make sure callback functions are called with the right argument)
+    const std::string m_osSignature = EXPECTED_SIGNATURE;
+
+    /** Replacement nodata value */
+    std::vector<double> m_adfReplacementDstNodata{};
+
+    /** Intended destination data type. */
+    GDALDataType m_eIntendedDstDT = GDT_Float64;
+
+    /** Affine transformation coefficients.
+     * m_aadfCoefficients[i][0] is the constant term for the i(th) dst band
+     * m_aadfCoefficients[i][j] is the weight of the j(th) src band for the
+     * i(th) dst vand.
+     * Said otherwise dst[i] = m_aadfCoefficients[i][0] +
+     *      sum(m_aadfCoefficients[i][j + 1] * src[j] for j in 0...nSrcBands-1)
+     */
+    std::vector<std::vector<double>> m_aadfCoefficients{};
+
+    //! Minimum clamping value.
+    double m_dfClampMin = std::numeric_limits<double>::quiet_NaN();
+
+    //! Maximum clamping value.
+    double m_dfClampMax = std::numeric_limits<double>::quiet_NaN();
+};
+}  // namespace
+
+/************************************************************************/
+/*               SetOutputValuesForInNoDataAndOutNoData()               */
+/************************************************************************/
+
+static std::vector<double> SetOutputValuesForInNoDataAndOutNoData(
+    int nInBands, double *padfInNoData, int *pnOutBands,
+    double **ppadfOutNoData, bool bSrcNodataSpecified, double dfSrcNoData,
+    bool bDstNodataSpecified, double dfDstNoData, bool bIsFinalStep)
+{
+    if (bSrcNodataSpecified)
+    {
+        std::vector<double> adfNoData(nInBands, dfSrcNoData);
+        memcpy(padfInNoData, adfNoData.data(),
+               adfNoData.size() * sizeof(double));
+    }
+
+    std::vector<double> adfDstNoData;
+    if (bDstNodataSpecified)
+    {
+        adfDstNoData.resize(*pnOutBands, dfDstNoData);
+    }
+    else if (bIsFinalStep)
+    {
+        adfDstNoData =
+            std::vector<double>(*ppadfOutNoData, *ppadfOutNoData + *pnOutBands);
+    }
+    else
+    {
+        adfDstNoData =
+            std::vector<double>(padfInNoData, padfInNoData + nInBands);
+        adfDstNoData.resize(*pnOutBands, *padfInNoData);
+    }
+
+    if (*ppadfOutNoData == nullptr)
+    {
+        *ppadfOutNoData =
+            static_cast<double *>(CPLMalloc(*pnOutBands * sizeof(double)));
+    }
+    memcpy(*ppadfOutNoData, adfDstNoData.data(), *pnOutBands * sizeof(double));
+
+    return adfDstNoData;
+}
+
+/************************************************************************/
+/*                    BandAffineCombinationInit()                       */
+/************************************************************************/
+
+/** Init function for 'BandAffineCombination' builtin function. */
+static CPLErr BandAffineCombinationInit(
+    const char * /*pszFuncName*/, void * /*pUserData*/,
+    CSLConstList papszFunctionArgs, int nInBands, GDALDataType eInDT,
+    double *padfInNoData, int *pnOutBands, GDALDataType *peOutDT,
+    double **ppadfOutNoData, const char * /* pszVRTPath */,
+    VRTPDWorkingDataPtr *ppWorkingData)
+{
+    CPLAssert(eInDT == GDT_Float64);
+
+    *peOutDT = eInDT;
+    *ppWorkingData = nullptr;
+
+    auto data = std::make_unique<BandAffineCombinationData>();
+
+    std::map<int, std::vector<double>> oMapCoefficients{};
+    double dfSrcNoData = std::numeric_limits<double>::quiet_NaN();
+    bool bSrcNodataSpecified = false;
+    double dfDstNoData = std::numeric_limits<double>::quiet_NaN();
+    bool bDstNodataSpecified = false;
+    double dfReplacementDstNodata = std::numeric_limits<double>::quiet_NaN();
+    bool bReplacementDstNodataSpecified = false;
+
+    for (const auto &[pszKey, pszValue] :
+         cpl::IterateNameValue(papszFunctionArgs))
+    {
+        if (EQUAL(pszKey, "src_nodata"))
+        {
+            bSrcNodataSpecified = true;
+            dfSrcNoData = CPLAtof(pszValue);
+        }
+        else if (EQUAL(pszKey, "dst_nodata"))
+        {
+            bDstNodataSpecified = true;
+            dfDstNoData = CPLAtof(pszValue);
+        }
+        else if (EQUAL(pszKey, "replacement_nodata"))
+        {
+            bReplacementDstNodataSpecified = true;
+            dfReplacementDstNodata = CPLAtof(pszValue);
+        }
+        else if (EQUAL(pszKey, "dst_intended_datatype"))
+        {
+            for (GDALDataType eDT = GDT_Byte; eDT < GDT_TypeCount;
+                 eDT = static_cast<GDALDataType>(eDT + 1))
+            {
+                if (EQUAL(GDALGetDataTypeName(eDT), pszValue))
+                {
+                    data->m_eIntendedDstDT = eDT;
+                    break;
+                }
+            }
+        }
+        else if (STARTS_WITH_CI(pszKey, "coefficients_"))
+        {
+            const int nTargetBand = atoi(pszKey + strlen("coefficients_"));
+            if (nTargetBand <= 0 || nTargetBand > 65536)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Invalid band in argument '%s'", pszKey);
+                return CE_Failure;
+            }
+            const CPLStringList aosTokens(CSLTokenizeString2(pszValue, ",", 0));
+            if (aosTokens.size() != 1 + nInBands)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Argument %s has %d values, whereas %d are expected",
+                         pszKey, aosTokens.size(), 1 + nInBands);
+                return CE_Failure;
+            }
+            std::vector<double> adfValues;
+            for (int i = 0; i < aosTokens.size(); ++i)
+            {
+                adfValues.push_back(CPLAtof(aosTokens[i]));
+            }
+            oMapCoefficients[nTargetBand - 1] = std::move(adfValues);
+        }
+        else if (EQUAL(pszKey, "min"))
+        {
+            data->m_dfClampMin = CPLAtof(pszValue);
+        }
+        else if (EQUAL(pszKey, "max"))
+        {
+            data->m_dfClampMax = CPLAtof(pszValue);
+        }
+        else
+        {
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "Unrecognized argument name %s. Ignored", pszKey);
+        }
+    }
+
+    const bool bIsFinalStep = *pnOutBands != 0;
+    if (bIsFinalStep)
+    {
+        if (*pnOutBands != static_cast<int>(oMapCoefficients.size()))
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Final step expect %d bands, but only %d coefficient_XX "
+                     "are provided",
+                     *pnOutBands, static_cast<int>(oMapCoefficients.size()));
+            return CE_Failure;
+        }
+    }
+    else
+    {
+        *pnOutBands = static_cast<int>(oMapCoefficients.size());
+    }
+
+    const std::vector<double> adfDstNoData =
+        SetOutputValuesForInNoDataAndOutNoData(
+            nInBands, padfInNoData, pnOutBands, ppadfOutNoData,
+            bSrcNodataSpecified, dfSrcNoData, bDstNodataSpecified, dfDstNoData,
+            bIsFinalStep);
+
+    if (bReplacementDstNodataSpecified)
+    {
+        data->m_adfReplacementDstNodata.resize(*pnOutBands,
+                                               dfReplacementDstNodata);
+    }
+    else
+    {
+        for (double dfVal : adfDstNoData)
+        {
+            data->m_adfReplacementDstNodata.emplace_back(
+                GDALGetNoDataReplacementValue(data->m_eIntendedDstDT, dfVal));
+        }
+    }
+
+    // Check we have a set of coefficient for all output bands and
+    // convert the map to a vector
+    for (auto &oIter : oMapCoefficients)
+    {
+        const int iExpected = static_cast<int>(data->m_aadfCoefficients.size());
+        if (oIter.first != iExpected)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Argument coefficients_%d is missing", iExpected + 1);
+            return CE_Failure;
+        }
+        data->m_aadfCoefficients.emplace_back(std::move(oIter.second));
+    }
+    *ppWorkingData = data.release();
+    return CE_None;
+}
+
+/************************************************************************/
+/*                    BandAffineCombinationFree()                       */
+/************************************************************************/
+
+/** Free function for 'BandAffineCombination' builtin function. */
+static void BandAffineCombinationFree(const char * /*pszFuncName*/,
+                                      void * /*pUserData*/,
+                                      VRTPDWorkingDataPtr pWorkingData)
+{
+    BandAffineCombinationData *data =
+        static_cast<BandAffineCombinationData *>(pWorkingData);
+    CPLAssert(data->m_osSignature ==
+              BandAffineCombinationData::EXPECTED_SIGNATURE);
+    CPL_IGNORE_RET_VAL(data->m_osSignature);
+    delete data;
+}
+
+/************************************************************************/
+/*                    BandAffineCombinationProcess()                    */
+/************************************************************************/
+
+/** Processing function for 'BandAffineCombination' builtin function. */
+static CPLErr BandAffineCombinationProcess(
+    const char * /*pszFuncName*/, void * /*pUserData*/,
+    VRTPDWorkingDataPtr pWorkingData, CSLConstList /* papszFunctionArgs*/,
+    int nBufXSize, int nBufYSize, const void *pInBuffer, size_t nInBufferSize,
+    GDALDataType eInDT, int nInBands, const double *CPL_RESTRICT padfInNoData,
+    void *pOutBuffer, size_t nOutBufferSize, GDALDataType eOutDT, int nOutBands,
+    const double *CPL_RESTRICT padfOutNoData, double /*dfSrcXOff*/,
+    double /*dfSrcYOff*/, double /*dfSrcXSize*/, double /*dfSrcYSize*/,
+    const double /*adfSrcGT*/[], const char * /* pszVRTPath */,
+    CSLConstList /*papszExtra*/)
+{
+    const size_t nElts = static_cast<size_t>(nBufXSize) * nBufYSize;
+
+    CPL_IGNORE_RET_VAL(eInDT);
+    CPLAssert(eInDT == GDT_Float64);
+    CPL_IGNORE_RET_VAL(eOutDT);
+    CPLAssert(eOutDT == GDT_Float64);
+    CPL_IGNORE_RET_VAL(nInBufferSize);
+    CPLAssert(nInBufferSize == nElts * nInBands * sizeof(double));
+    CPL_IGNORE_RET_VAL(nOutBufferSize);
+    CPLAssert(nOutBufferSize == nElts * nOutBands * sizeof(double));
+
+    const BandAffineCombinationData *data =
+        static_cast<BandAffineCombinationData *>(pWorkingData);
+    CPLAssert(data->m_osSignature ==
+              BandAffineCombinationData::EXPECTED_SIGNATURE);
+    const double *CPL_RESTRICT padfSrc = static_cast<const double *>(pInBuffer);
+    double *CPL_RESTRICT padfDst = static_cast<double *>(pOutBuffer);
+    const bool bDstIntendedDTIsInteger =
+        GDALDataTypeIsInteger(data->m_eIntendedDstDT);
+    const double dfClampMin = data->m_dfClampMin;
+    const double dfClampMax = data->m_dfClampMax;
+    for (size_t i = 0; i < nElts; ++i)
+    {
+        for (int iDst = 0; iDst < nOutBands; ++iDst)
+        {
+            const auto &adfCoefficients = data->m_aadfCoefficients[iDst];
+            double dfVal = adfCoefficients[0];
+            bool bSetNoData = false;
+            for (int iSrc = 0; iSrc < nInBands; ++iSrc)
+            {
+                // written this way to work with a NaN value
+                if (!(padfSrc[iSrc] != padfInNoData[iSrc]))
+                {
+                    bSetNoData = true;
+                    break;
+                }
+                dfVal += adfCoefficients[iSrc + 1] * padfSrc[iSrc];
+            }
+            if (bSetNoData)
+            {
+                *padfDst = padfOutNoData[iDst];
+            }
+            else
+            {
+                double dfDstVal = GetDstValue(
+                    dfVal, padfOutNoData[iDst],
+                    data->m_adfReplacementDstNodata[iDst],
+                    data->m_eIntendedDstDT, bDstIntendedDTIsInteger);
+                if (dfDstVal < dfClampMin)
+                    dfDstVal = dfClampMin;
+                if (dfDstVal > dfClampMax)
+                    dfDstVal = dfClampMax;
+                *padfDst = dfDstVal;
+            }
+            ++padfDst;
+        }
+        padfSrc += nInBands;
+    }
+
+    return CE_None;
+}
+
+/************************************************************************/
+/*                                LUTData                               */
+/************************************************************************/
+
+namespace
+{
+/** Working structure for 'LUT' builtin function. */
+struct LUTData
+{
+    static constexpr const char *const EXPECTED_SIGNATURE = "LUT";
+    //! Signature (to make sure callback functions are called with the right argument)
+    const std::string m_osSignature = EXPECTED_SIGNATURE;
+
+    //! m_aadfLUTInputs[i][j] is the j(th) input value for that LUT of band i.
+    std::vector<std::vector<double>> m_aadfLUTInputs{};
+
+    //! m_aadfLUTOutputs[i][j] is the j(th) output value for that LUT of band i.
+    std::vector<std::vector<double>> m_aadfLUTOutputs{};
+
+    /************************************************************************/
+    /*                              LookupValue()                           */
+    /************************************************************************/
+
+    double LookupValue(int iBand, double dfInput) const
+    {
+        const auto &adfInput = m_aadfLUTInputs[iBand];
+        const auto &afdOutput = m_aadfLUTOutputs[iBand];
+
+        // Find the index of the first element in the LUT input array that
+        // is not smaller than the input value.
+        int i = static_cast<int>(
+            std::lower_bound(adfInput.data(), adfInput.data() + adfInput.size(),
+                             dfInput) -
+            adfInput.data());
+
+        if (i == 0)
+            return afdOutput[0];
+
+        // If the index is beyond the end of the LUT input array, the input
+        // value is larger than all the values in the array.
+        if (i == static_cast<int>(adfInput.size()))
+            return afdOutput.back();
+
+        if (adfInput[i] == dfInput)
+            return afdOutput[i];
+
+        // Otherwise, interpolate.
+        return afdOutput[i - 1] + (dfInput - adfInput[i - 1]) *
+                                      ((afdOutput[i] - afdOutput[i - 1]) /
+                                       (adfInput[i] - adfInput[i - 1]));
+    }
+};
+}  // namespace
+
+/************************************************************************/
+/*                                LUTInit()                             */
+/************************************************************************/
+
+/** Init function for 'LUT' builtin function. */
+static CPLErr LUTInit(const char * /*pszFuncName*/, void * /*pUserData*/,
+                      CSLConstList papszFunctionArgs, int nInBands,
+                      GDALDataType eInDT, double *padfInNoData, int *pnOutBands,
+                      GDALDataType *peOutDT, double **ppadfOutNoData,
+                      const char * /* pszVRTPath */,
+                      VRTPDWorkingDataPtr *ppWorkingData)
+{
+    CPLAssert(eInDT == GDT_Float64);
+
+    const bool bIsFinalStep = *pnOutBands != 0;
+    *peOutDT = eInDT;
+    *ppWorkingData = nullptr;
+
+    if (!bIsFinalStep)
+    {
+        *pnOutBands = nInBands;
+    }
+
+    auto data = std::make_unique<LUTData>();
+
+    double dfSrcNoData = std::numeric_limits<double>::quiet_NaN();
+    bool bSrcNodataSpecified = false;
+    double dfDstNoData = std::numeric_limits<double>::quiet_NaN();
+    bool bDstNodataSpecified = false;
+
+    std::map<int, std::pair<std::vector<double>, std::vector<double>>> oMap{};
+
+    for (const auto &[pszKey, pszValue] :
+         cpl::IterateNameValue(papszFunctionArgs))
+    {
+        if (EQUAL(pszKey, "src_nodata"))
+        {
+            bSrcNodataSpecified = true;
+            dfSrcNoData = CPLAtof(pszValue);
+        }
+        else if (EQUAL(pszKey, "dst_nodata"))
+        {
+            bDstNodataSpecified = true;
+            dfDstNoData = CPLAtof(pszValue);
+        }
+        else if (STARTS_WITH_CI(pszKey, "lut_"))
+        {
+            const int nBand = atoi(pszKey + strlen("lut_"));
+            if (nBand <= 0 || nBand > nInBands)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Invalid band in argument '%s'", pszKey);
+                return CE_Failure;
+            }
+            const CPLStringList aosTokens(CSLTokenizeString2(pszValue, ",", 0));
+            std::vector<double> adfInputValues;
+            std::vector<double> adfOutputValues;
+            for (int i = 0; i < aosTokens.size(); ++i)
+            {
+                const CPLStringList aosTokens2(
+                    CSLTokenizeString2(aosTokens[i], ":", 0));
+                if (aosTokens2.size() != 2)
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "Invalid value for argument '%s'", pszKey);
+                    return CE_Failure;
+                }
+                adfInputValues.push_back(CPLAtof(aosTokens2[0]));
+                adfOutputValues.push_back(CPLAtof(aosTokens2[1]));
+            }
+            oMap[nBand - 1] = std::pair(std::move(adfInputValues),
+                                        std::move(adfOutputValues));
+        }
+        else
+        {
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "Unrecognized argument name %s. Ignored", pszKey);
+        }
+    }
+
+    SetOutputValuesForInNoDataAndOutNoData(
+        nInBands, padfInNoData, pnOutBands, ppadfOutNoData, bSrcNodataSpecified,
+        dfSrcNoData, bDstNodataSpecified, dfDstNoData, bIsFinalStep);
+
+    int iExpected = 0;
+    // Check we have values for all bands and convert to vector
+    for (auto &oIter : oMap)
+    {
+        if (oIter.first != iExpected)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined, "Argument lut_%d is missing",
+                     iExpected + 1);
+            return CE_Failure;
+        }
+        ++iExpected;
+        data->m_aadfLUTInputs.emplace_back(std::move(oIter.second.first));
+        data->m_aadfLUTOutputs.emplace_back(std::move(oIter.second.second));
+    }
+
+    if (static_cast<int>(oMap.size()) < *pnOutBands)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Missing lut_XX element(s)");
+        return CE_Failure;
+    }
+
+    *ppWorkingData = data.release();
+    return CE_None;
+}
+
+/************************************************************************/
+/*                                LUTFree()                             */
+/************************************************************************/
+
+/** Free function for 'LUT' builtin function. */
+static void LUTFree(const char * /*pszFuncName*/, void * /*pUserData*/,
+                    VRTPDWorkingDataPtr pWorkingData)
+{
+    LUTData *data = static_cast<LUTData *>(pWorkingData);
+    CPLAssert(data->m_osSignature == LUTData::EXPECTED_SIGNATURE);
+    CPL_IGNORE_RET_VAL(data->m_osSignature);
+    delete data;
+}
+
+/************************************************************************/
+/*                             LUTProcess()                             */
+/************************************************************************/
+
+/** Processing function for 'LUT' builtin function. */
+static CPLErr
+LUTProcess(const char * /*pszFuncName*/, void * /*pUserData*/,
+           VRTPDWorkingDataPtr pWorkingData,
+           CSLConstList /* papszFunctionArgs*/, int nBufXSize, int nBufYSize,
+           const void *pInBuffer, size_t nInBufferSize, GDALDataType eInDT,
+           int nInBands, const double *CPL_RESTRICT padfInNoData,
+           void *pOutBuffer, size_t nOutBufferSize, GDALDataType eOutDT,
+           int nOutBands, const double *CPL_RESTRICT padfOutNoData,
+           double /*dfSrcXOff*/, double /*dfSrcYOff*/, double /*dfSrcXSize*/,
+           double /*dfSrcYSize*/, const double /*adfSrcGT*/[],
+           const char * /* pszVRTPath */, CSLConstList /*papszExtra*/)
+{
+    const size_t nElts = static_cast<size_t>(nBufXSize) * nBufYSize;
+
+    CPL_IGNORE_RET_VAL(eInDT);
+    CPLAssert(eInDT == GDT_Float64);
+    CPL_IGNORE_RET_VAL(eOutDT);
+    CPLAssert(eOutDT == GDT_Float64);
+    CPL_IGNORE_RET_VAL(nInBufferSize);
+    CPLAssert(nInBufferSize == nElts * nInBands * sizeof(double));
+    CPL_IGNORE_RET_VAL(nOutBufferSize);
+    CPLAssert(nOutBufferSize == nElts * nOutBands * sizeof(double));
+    CPLAssert(nInBands == nOutBands);
+    CPL_IGNORE_RET_VAL(nOutBands);
+
+    const LUTData *data = static_cast<LUTData *>(pWorkingData);
+    CPLAssert(data->m_osSignature == LUTData::EXPECTED_SIGNATURE);
+    const double *CPL_RESTRICT padfSrc = static_cast<const double *>(pInBuffer);
+    double *CPL_RESTRICT padfDst = static_cast<double *>(pOutBuffer);
+    for (size_t i = 0; i < nElts; ++i)
+    {
+        for (int iBand = 0; iBand < nInBands; ++iBand)
+        {
+            // written this way to work with a NaN value
+            if (!(*padfSrc != padfInNoData[iBand]))
+                *padfDst = padfOutNoData[iBand];
+            else
+                *padfDst = data->LookupValue(iBand, *padfSrc);
+            ++padfSrc;
+            ++padfDst;
+        }
+    }
+
+    return CE_None;
+}
+
+/************************************************************************/
+/*                           DehazingData                               */
+/************************************************************************/
+
+namespace
+{
+/** Working structure for 'Dehazing' builtin function. */
+struct DehazingData
+{
+    static constexpr const char *const EXPECTED_SIGNATURE = "Dehazing";
+    //! Signature (to make sure callback functions are called with the right argument)
+    const std::string m_osSignature = EXPECTED_SIGNATURE;
+
+    //! Nodata value for gain dataset(s)
+    double m_dfGainNodata = std::numeric_limits<double>::quiet_NaN();
+
+    //! Nodata value for offset dataset(s)
+    double m_dfOffsetNodata = std::numeric_limits<double>::quiet_NaN();
+
+    //! Minimum clamping value.
+    double m_dfClampMin = std::numeric_limits<double>::quiet_NaN();
+
+    //! Maximum clamping value.
+    double m_dfClampMax = std::numeric_limits<double>::quiet_NaN();
+
+    //! Map from gain/offset dataset name to datasets
+    std::map<std::string, std::unique_ptr<GDALDataset>> m_oDatasetMap{};
+
+    //! Vector of size nInBands that point to the raster band from which to read gains.
+    std::vector<GDALRasterBand *> m_oGainBands{};
+
+    //! Vector of size nInBands that point to the raster band from which to read offsets.
+    std::vector<GDALRasterBand *> m_oOffsetBands{};
+
+    //! Working buffer that contain gain values.
+    std::vector<VRTProcessedDataset::NoInitByte> m_abyGainBuffer{};
+
+    //! Working buffer that contain offset values.
+    std::vector<VRTProcessedDataset::NoInitByte> m_abyOffsetBuffer{};
+};
+}  // namespace
+
+/************************************************************************/
+/*                           CheckAllBands()                            */
+/************************************************************************/
+
+/** Return true if the key of oMap is the sequence of all integers between
+ * 0 and nExpectedBandCount-1.
+ */
+template <class T>
+static bool CheckAllBands(const std::map<int, T> &oMap, int nExpectedBandCount)
+{
+    int iExpected = 0;
+    for (const auto &kv : oMap)
+    {
+        if (kv.first != iExpected)
+            return false;
+        ++iExpected;
+    }
+    return iExpected == nExpectedBandCount;
+}
+
+/************************************************************************/
+/*                           DehazingInit()                             */
+/************************************************************************/
+
+/** Init function for 'Dehazing' builtin function. */
+static CPLErr DehazingInit(const char * /*pszFuncName*/, void * /*pUserData*/,
+                           CSLConstList papszFunctionArgs, int nInBands,
+                           GDALDataType eInDT, double *padfInNoData,
+                           int *pnOutBands, GDALDataType *peOutDT,
+                           double **ppadfOutNoData, const char *pszVRTPath,
+                           VRTPDWorkingDataPtr *ppWorkingData)
+{
+    CPLAssert(eInDT == GDT_Float64);
+
+    const bool bIsFinalStep = *pnOutBands != 0;
+    *peOutDT = eInDT;
+    *ppWorkingData = nullptr;
+
+    if (!bIsFinalStep)
+    {
+        *pnOutBands = nInBands;
+    }
+
+    auto data = std::make_unique<DehazingData>();
+
+    bool bNodataSpecified = false;
+    double dfNoData = std::numeric_limits<double>::quiet_NaN();
+
+    bool bGainNodataSpecified = false;
+    bool bOffsetNodataSpecified = false;
+
+    std::map<int, std::string> oGainDatasetNameMap;
+    std::map<int, int> oGainDatasetBandMap;
+
+    std::map<int, std::string> oOffsetDatasetNameMap;
+    std::map<int, int> oOffsetDatasetBandMap;
+
+    bool bRelativeFilenames = false;
+
+    for (const auto &[pszKey, pszValue] :
+         cpl::IterateNameValue(papszFunctionArgs))
+    {
+        if (EQUAL(pszKey, "relative_filenames"))
+        {
+            bRelativeFilenames = CPLTestBool(pszValue);
+        }
+        else if (EQUAL(pszKey, "nodata"))
+        {
+            bNodataSpecified = true;
+            dfNoData = CPLAtof(pszValue);
+        }
+        else if (EQUAL(pszKey, "gain_nodata"))
+        {
+            bGainNodataSpecified = true;
+            data->m_dfGainNodata = CPLAtof(pszValue);
+        }
+        else if (EQUAL(pszKey, "offset_nodata"))
+        {
+            bOffsetNodataSpecified = true;
+            data->m_dfOffsetNodata = CPLAtof(pszValue);
+        }
+        else if (STARTS_WITH_CI(pszKey, "gain_dataset_filename_"))
+        {
+            const int nBand = atoi(pszKey + strlen("gain_dataset_filename_"));
+            if (nBand <= 0 || nBand > nInBands)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Invalid band in argument '%s'", pszKey);
+                return CE_Failure;
+            }
+            oGainDatasetNameMap[nBand - 1] = pszValue;
+        }
+        else if (STARTS_WITH_CI(pszKey, "gain_dataset_band_"))
+        {
+            const int nBand = atoi(pszKey + strlen("gain_dataset_band_"));
+            if (nBand <= 0 || nBand > nInBands)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Invalid band in argument '%s'", pszKey);
+                return CE_Failure;
+            }
+            oGainDatasetBandMap[nBand - 1] = atoi(pszValue);
+        }
+        else if (STARTS_WITH_CI(pszKey, "offset_dataset_filename_"))
+        {
+            const int nBand = atoi(pszKey + strlen("offset_dataset_filename_"));
+            if (nBand <= 0 || nBand > nInBands)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Invalid band in argument '%s'", pszKey);
+                return CE_Failure;
+            }
+            oOffsetDatasetNameMap[nBand - 1] = pszValue;
+        }
+        else if (STARTS_WITH_CI(pszKey, "offset_dataset_band_"))
+        {
+            const int nBand = atoi(pszKey + strlen("offset_dataset_band_"));
+            if (nBand <= 0 || nBand > nInBands)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Invalid band in argument '%s'", pszKey);
+                return CE_Failure;
+            }
+            oOffsetDatasetBandMap[nBand - 1] = atoi(pszValue);
+        }
+        else if (EQUAL(pszKey, "min"))
+        {
+            data->m_dfClampMin = CPLAtof(pszValue);
+        }
+        else if (EQUAL(pszKey, "max"))
+        {
+            data->m_dfClampMax = CPLAtof(pszValue);
+        }
+        else
+        {
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "Unrecognized argument name %s. Ignored", pszKey);
+        }
+    }
+
+    if (!CheckAllBands(oGainDatasetNameMap, nInBands))
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Missing gain_dataset_filename_XX element(s)");
+        return CE_Failure;
+    }
+    if (!CheckAllBands(oGainDatasetBandMap, nInBands))
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Missing gain_dataset_band_XX element(s)");
+        return CE_Failure;
+    }
+    if (!CheckAllBands(oOffsetDatasetNameMap, nInBands))
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Missing offset_dataset_filename_XX element(s)");
+        return CE_Failure;
+    }
+    if (!CheckAllBands(oOffsetDatasetBandMap, nInBands))
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Missing offset_dataset_band_XX element(s)");
+        return CE_Failure;
+    }
+
+    data->m_oGainBands.resize(nInBands);
+    data->m_oOffsetBands.resize(nInBands);
+
+    constexpr int IDX_GAIN = 0;
+    constexpr int IDX_OFFSET = 1;
+    for (int i : {IDX_GAIN, IDX_OFFSET})
+    {
+        const auto &oMapNames =
+            (i == IDX_GAIN) ? oGainDatasetNameMap : oOffsetDatasetNameMap;
+        const auto &oMapBands =
+            (i == IDX_GAIN) ? oGainDatasetBandMap : oOffsetDatasetBandMap;
+        for (const auto &kv : oMapNames)
+        {
+            const int nInBandIdx = kv.first;
+            const auto osFilename = VRTDataset::BuildSourceFilename(
+                kv.second.c_str(), pszVRTPath, bRelativeFilenames);
+            auto oIter = data->m_oDatasetMap.find(osFilename);
+            if (oIter == data->m_oDatasetMap.end())
+            {
+                auto poDS = std::unique_ptr<GDALDataset>(GDALDataset::Open(
+                    osFilename.c_str(), GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR,
+                    nullptr, nullptr, nullptr));
+                if (!poDS)
+                    return CE_Failure;
+                double adfAuxGT[6];
+                if (poDS->GetGeoTransform(adfAuxGT) != CE_None)
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "%s lacks a geotransform", osFilename.c_str());
+                    return CE_Failure;
+                }
+                oIter = data->m_oDatasetMap
+                            .insert(std::pair(osFilename, std::move(poDS)))
+                            .first;
+            }
+            auto poDS = oIter->second.get();
+            const auto oIterBand = oMapBands.find(nInBandIdx);
+            CPLAssert(oIterBand != oMapBands.end());
+            const int nAuxBand = oIterBand->second;
+            if (nAuxBand <= 0 || nAuxBand > poDS->GetRasterCount())
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Invalid band number (%d) for a %s dataset", nAuxBand,
+                         (i == IDX_GAIN) ? "gain" : "offset");
+                return CE_Failure;
+            }
+            auto poAuxBand = poDS->GetRasterBand(nAuxBand);
+            int bAuxBandHasNoData = false;
+            const double dfAuxNoData =
+                poAuxBand->GetNoDataValue(&bAuxBandHasNoData);
+            if (i == IDX_GAIN)
+            {
+                data->m_oGainBands[nInBandIdx] = poAuxBand;
+                if (!bGainNodataSpecified && bAuxBandHasNoData)
+                    data->m_dfGainNodata = dfAuxNoData;
+            }
+            else
+            {
+                data->m_oOffsetBands[nInBandIdx] = poAuxBand;
+                if (!bOffsetNodataSpecified && bAuxBandHasNoData)
+                    data->m_dfOffsetNodata = dfAuxNoData;
+            }
+        }
+    }
+
+    SetOutputValuesForInNoDataAndOutNoData(
+        nInBands, padfInNoData, pnOutBands, ppadfOutNoData, bNodataSpecified,
+        dfNoData, bNodataSpecified, dfNoData, bIsFinalStep);
+
+    *ppWorkingData = data.release();
+    return CE_None;
+}
+
+/************************************************************************/
+/*                           DehazingFree()                             */
+/************************************************************************/
+
+/** Free function for 'Dehazing' builtin function. */
+static void DehazingFree(const char * /*pszFuncName*/, void * /*pUserData*/,
+                         VRTPDWorkingDataPtr pWorkingData)
+{
+    DehazingData *data = static_cast<DehazingData *>(pWorkingData);
+    CPLAssert(data->m_osSignature == DehazingData::EXPECTED_SIGNATURE);
+    CPL_IGNORE_RET_VAL(data->m_osSignature);
+    delete data;
+}
+
+/************************************************************************/
+/*                          LoadAuxData()                               */
+/************************************************************************/
+
+// Load auxiliary corresponding offset, gain or trimming data.
+static bool LoadAuxData(double dfULX, double dfULY, double dfLRX, double dfLRY,
+                        size_t nElts, int nBufXSize, int nBufYSize,
+                        const char *pszAuxType, GDALRasterBand *poAuxBand,
+                        std::vector<VRTProcessedDataset::NoInitByte> &abyBuffer)
+{
+    double adfAuxGT[6];
+    double adfAuxInvGT[6];
+
+    // Compute pixel/line coordinates from the georeferenced extent
+    CPL_IGNORE_RET_VAL(poAuxBand->GetDataset()->GetGeoTransform(
+        adfAuxGT));  // return code already tested
+    CPL_IGNORE_RET_VAL(GDALInvGeoTransform(adfAuxGT, adfAuxInvGT));
+    const double dfULPixel =
+        adfAuxInvGT[0] + adfAuxInvGT[1] * dfULX + adfAuxInvGT[2] * dfULY;
+    const double dfULLine =
+        adfAuxInvGT[3] + adfAuxInvGT[4] * dfULX + adfAuxInvGT[5] * dfULY;
+    const double dfLRPixel =
+        adfAuxInvGT[0] + adfAuxInvGT[1] * dfLRX + adfAuxInvGT[2] * dfLRY;
+    const double dfLRLine =
+        adfAuxInvGT[3] + adfAuxInvGT[4] * dfLRX + adfAuxInvGT[5] * dfLRY;
+    if (dfULPixel >= dfLRPixel || dfULLine >= dfLRLine)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Unexpected computed %s pixel/line", pszAuxType);
+        return false;
+    }
+    if (dfULPixel < -1 || dfLRPixel > poAuxBand->GetXSize() || dfULLine < -1 ||
+        dfLRLine > poAuxBand->GetYSize())
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Unexpected computed %s pixel/line", pszAuxType);
+        return false;
+    }
+
+    const int nAuxXOff = std::max(0, static_cast<int>(std::round(dfULPixel)));
+    const int nAuxYOff = std::max(0, static_cast<int>(std::round(dfULLine)));
+    const int nAuxX2Off = std::min(poAuxBand->GetXSize(),
+                                   static_cast<int>(std::round(dfLRPixel)));
+    const int nAuxY2Off =
+        std::min(poAuxBand->GetYSize(), static_cast<int>(std::round(dfLRLine)));
+
+    try
+    {
+        abyBuffer.resize(nElts * sizeof(float));
+    }
+    catch (const std::bad_alloc &)
+    {
+        CPLError(CE_Failure, CPLE_OutOfMemory,
+                 "Out of memory allocating working buffer");
+        return false;
+    }
+    GDALRasterIOExtraArg sExtraArg;
+    INIT_RASTERIO_EXTRA_ARG(sExtraArg);
+    sExtraArg.bFloatingPointWindowValidity = true;
+    CPL_IGNORE_RET_VAL(sExtraArg.eResampleAlg);
+    sExtraArg.eResampleAlg = GRIORA_Bilinear;
+    sExtraArg.dfXOff = std::max(0.0, dfULPixel);
+    sExtraArg.dfYOff = std::max(0.0, dfULLine);
+    sExtraArg.dfXSize = std::min<double>(poAuxBand->GetXSize(), dfLRPixel) -
+                        std::max(0.0, dfULPixel);
+    sExtraArg.dfYSize = std::min<double>(poAuxBand->GetYSize(), dfLRLine) -
+                        std::max(0.0, dfULLine);
+    return (poAuxBand->RasterIO(
+                GF_Read, nAuxXOff, nAuxYOff, std::max(1, nAuxX2Off - nAuxXOff),
+                std::max(1, nAuxY2Off - nAuxYOff), abyBuffer.data(), nBufXSize,
+                nBufYSize, GDT_Float32, 0, 0, &sExtraArg) == CE_None);
+}
+
+/************************************************************************/
+/*                         DehazingProcess()                            */
+/************************************************************************/
+
+/** Processing function for 'Dehazing' builtin function. */
+static CPLErr DehazingProcess(
+    const char * /*pszFuncName*/, void * /*pUserData*/,
+    VRTPDWorkingDataPtr pWorkingData, CSLConstList /* papszFunctionArgs*/,
+    int nBufXSize, int nBufYSize, const void *pInBuffer, size_t nInBufferSize,
+    GDALDataType eInDT, int nInBands, const double *CPL_RESTRICT padfInNoData,
+    void *pOutBuffer, size_t nOutBufferSize, GDALDataType eOutDT, int nOutBands,
+    const double *CPL_RESTRICT padfOutNoData, double dfSrcXOff,
+    double dfSrcYOff, double dfSrcXSize, double dfSrcYSize,
+    const double adfSrcGT[], const char * /* pszVRTPath */,
+    CSLConstList /*papszExtra*/)
+{
+    const size_t nElts = static_cast<size_t>(nBufXSize) * nBufYSize;
+
+    CPL_IGNORE_RET_VAL(eInDT);
+    CPLAssert(eInDT == GDT_Float64);
+    CPL_IGNORE_RET_VAL(eOutDT);
+    CPLAssert(eOutDT == GDT_Float64);
+    CPL_IGNORE_RET_VAL(nInBufferSize);
+    CPLAssert(nInBufferSize == nElts * nInBands * sizeof(double));
+    CPL_IGNORE_RET_VAL(nOutBufferSize);
+    CPLAssert(nOutBufferSize == nElts * nOutBands * sizeof(double));
+    CPLAssert(nInBands == nOutBands);
+    CPL_IGNORE_RET_VAL(nOutBands);
+
+    DehazingData *data = static_cast<DehazingData *>(pWorkingData);
+    CPLAssert(data->m_osSignature == DehazingData::EXPECTED_SIGNATURE);
+    const double *CPL_RESTRICT padfSrc = static_cast<const double *>(pInBuffer);
+    double *CPL_RESTRICT padfDst = static_cast<double *>(pOutBuffer);
+
+    // Compute georeferenced extent of input region
+    const double dfULX =
+        adfSrcGT[0] + adfSrcGT[1] * dfSrcXOff + adfSrcGT[2] * dfSrcYOff;
+    const double dfULY =
+        adfSrcGT[3] + adfSrcGT[4] * dfSrcXOff + adfSrcGT[5] * dfSrcYOff;
+    const double dfLRX = adfSrcGT[0] + adfSrcGT[1] * (dfSrcXOff + dfSrcXSize) +
+                         adfSrcGT[2] * (dfSrcYOff + dfSrcYSize);
+    const double dfLRY = adfSrcGT[3] + adfSrcGT[4] * (dfSrcXOff + dfSrcXSize) +
+                         adfSrcGT[5] * (dfSrcYOff + dfSrcYSize);
+
+    auto &abyOffsetBuffer = data->m_abyGainBuffer;
+    auto &abyGainBuffer = data->m_abyOffsetBuffer;
+
+    for (int iBand = 0; iBand < nInBands; ++iBand)
+    {
+        if (!LoadAuxData(dfULX, dfULY, dfLRX, dfLRY, nElts, nBufXSize,
+                         nBufYSize, "gain", data->m_oGainBands[iBand],
+                         abyGainBuffer) ||
+            !LoadAuxData(dfULX, dfULY, dfLRX, dfLRY, nElts, nBufXSize,
+                         nBufYSize, "offset", data->m_oOffsetBands[iBand],
+                         abyOffsetBuffer))
+        {
+            return CE_Failure;
+        }
+
+        const double *CPL_RESTRICT padfSrcThisBand = padfSrc + iBand;
+        double *CPL_RESTRICT padfDstThisBand = padfDst + iBand;
+        const float *pafGain =
+            reinterpret_cast<const float *>(abyGainBuffer.data());
+        const float *pafOffset =
+            reinterpret_cast<const float *>(abyOffsetBuffer.data());
+        const double dfSrcNodata = padfInNoData[iBand];
+        const double dfDstNodata = padfOutNoData[iBand];
+        const double dfGainNodata = data->m_dfGainNodata;
+        const double dfOffsetNodata = data->m_dfOffsetNodata;
+        const double dfClampMin = data->m_dfClampMin;
+        const double dfClampMax = data->m_dfClampMax;
+        for (size_t i = 0; i < nElts; ++i)
+        {
+            const double dfSrcVal = *padfSrcThisBand;
+            // written this way to work with a NaN value
+            if (!(dfSrcVal != dfSrcNodata))
+            {
+                *padfDstThisBand = dfDstNodata;
+            }
+            else
+            {
+                const double dfGain = pafGain[i];
+                const double dfOffset = pafOffset[i];
+                if (!(dfGain != dfGainNodata) || !(dfOffset != dfOffsetNodata))
+                {
+                    *padfDstThisBand = dfDstNodata;
+                }
+                else
+                {
+                    double dfDehazed = dfSrcVal * dfGain - dfOffset;
+                    if (dfDehazed < dfClampMin)
+                        dfDehazed = dfClampMin;
+                    if (dfDehazed > dfClampMax)
+                        dfDehazed = dfClampMax;
+
+                    *padfDstThisBand = dfDehazed;
+                }
+            }
+            padfSrcThisBand += nInBands;
+            padfDstThisBand += nInBands;
+        }
+    }
+
+    return CE_None;
+}
+
+/************************************************************************/
+/*                           TrimmingData                               */
+/************************************************************************/
+
+namespace
+{
+/** Working structure for 'Trimming' builtin function. */
+struct TrimmingData
+{
+    static constexpr const char *const EXPECTED_SIGNATURE = "Trimming";
+    //! Signature (to make sure callback functions are called with the right argument)
+    const std::string m_osSignature = EXPECTED_SIGNATURE;
+
+    //! Nodata value for trimming dataset
+    double m_dfTrimmingNodata = std::numeric_limits<double>::quiet_NaN();
+
+    //! Maximum saturating RGB output value.
+    double m_dfTopRGB = 0;
+
+    //! Maximum threshold beyond which we give up saturation
+    double m_dfToneCeil = 0;
+
+    //! Margin to allow for dynamics in brighest areas (in [0,1] range)
+    double m_dfTopMargin = 0;
+
+    //! Index (zero-based) of input/output red band.
+    int m_nRedBand = 1 - 1;
+
+    //! Index (zero-based) of input/output green band.
+    int m_nGreenBand = 2 - 1;
+
+    //! Index (zero-based) of input/output blue band.
+    int m_nBlueBand = 3 - 1;
+
+    //! Trimming dataset
+    std::unique_ptr<GDALDataset> m_poTrimmingDS{};
+
+    //! Trimming raster band.
+    GDALRasterBand *m_poTrimmingBand = nullptr;
+
+    //! Working buffer that contain trimming values.
+    std::vector<VRTProcessedDataset::NoInitByte> m_abyTrimmingBuffer{};
+};
+}  // namespace
+
+/************************************************************************/
+/*                           TrimmingInit()                             */
+/************************************************************************/
+
+/** Init function for 'Trimming' builtin function. */
+static CPLErr TrimmingInit(const char * /*pszFuncName*/, void * /*pUserData*/,
+                           CSLConstList papszFunctionArgs, int nInBands,
+                           GDALDataType eInDT, double *padfInNoData,
+                           int *pnOutBands, GDALDataType *peOutDT,
+                           double **ppadfOutNoData, const char *pszVRTPath,
+                           VRTPDWorkingDataPtr *ppWorkingData)
+{
+    CPLAssert(eInDT == GDT_Float64);
+
+    const bool bIsFinalStep = *pnOutBands != 0;
+    *peOutDT = eInDT;
+    *ppWorkingData = nullptr;
+
+    if (!bIsFinalStep)
+    {
+        *pnOutBands = nInBands;
+    }
+
+    auto data = std::make_unique<TrimmingData>();
+
+    bool bNodataSpecified = false;
+    double dfNoData = std::numeric_limits<double>::quiet_NaN();
+    std::string osTrimmingFilename;
+    bool bTrimmingNodataSpecified = false;
+    bool bRelativeFilenames = false;
+
+    for (const auto &[pszKey, pszValue] :
+         cpl::IterateNameValue(papszFunctionArgs))
+    {
+        if (EQUAL(pszKey, "relative_filenames"))
+        {
+            bRelativeFilenames = CPLTestBool(pszValue);
+        }
+        else if (EQUAL(pszKey, "nodata"))
+        {
+            bNodataSpecified = true;
+            dfNoData = CPLAtof(pszValue);
+        }
+        else if (EQUAL(pszKey, "trimming_nodata"))
+        {
+            bTrimmingNodataSpecified = true;
+            data->m_dfTrimmingNodata = CPLAtof(pszValue);
+        }
+        else if (EQUAL(pszKey, "trimming_dataset_filename"))
+        {
+            osTrimmingFilename = pszValue;
+        }
+        else if (EQUAL(pszKey, "red_band"))
+        {
+            const int nBand = atoi(pszValue) - 1;
+            if (nBand < 0 || nBand >= nInBands)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Invalid band in argument '%s'", pszKey);
+                return CE_Failure;
+            }
+            data->m_nRedBand = nBand;
+        }
+        else if (EQUAL(pszKey, "green_band"))
+        {
+            const int nBand = atoi(pszValue) - 1;
+            if (nBand < 0 || nBand >= nInBands)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Invalid band in argument '%s'", pszKey);
+                return CE_Failure;
+            }
+            data->m_nGreenBand = nBand;
+        }
+        else if (EQUAL(pszKey, "blue_band"))
+        {
+            const int nBand = atoi(pszValue) - 1;
+            if (nBand < 0 || nBand >= nInBands)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Invalid band in argument '%s'", pszKey);
+                return CE_Failure;
+            }
+            data->m_nBlueBand = nBand;
+        }
+        else if (EQUAL(pszKey, "top_rgb"))
+        {
+            data->m_dfTopRGB = CPLAtof(pszValue);
+        }
+        else if (EQUAL(pszKey, "tone_ceil"))
+        {
+            data->m_dfToneCeil = CPLAtof(pszValue);
+        }
+        else if (EQUAL(pszKey, "top_margin"))
+        {
+            data->m_dfTopMargin = CPLAtof(pszValue);
+        }
+        else
+        {
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "Unrecognized argument name %s. Ignored", pszKey);
+        }
+    }
+
+    if (data->m_nRedBand == data->m_nGreenBand ||
+        data->m_nRedBand == data->m_nBlueBand ||
+        data->m_nGreenBand == data->m_nBlueBand)
+    {
+        CPLError(
+            CE_Failure, CPLE_NotSupported,
+            "red_band, green_band and blue_band must have distinct values");
+        return CE_Failure;
+    }
+
+    const auto osFilename = VRTDataset::BuildSourceFilename(
+        osTrimmingFilename.c_str(), pszVRTPath, bRelativeFilenames);
+    data->m_poTrimmingDS.reset(GDALDataset::Open(
+        osFilename.c_str(), GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR, nullptr,
+        nullptr, nullptr));
+    if (!data->m_poTrimmingDS)
+        return CE_Failure;
+    if (data->m_poTrimmingDS->GetRasterCount() != 1)
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "Trimming dataset should have a single band");
+        return CE_Failure;
+    }
+    data->m_poTrimmingBand = data->m_poTrimmingDS->GetRasterBand(1);
+
+    double adfAuxGT[6];
+    if (data->m_poTrimmingDS->GetGeoTransform(adfAuxGT) != CE_None)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "%s lacks a geotransform",
+                 osFilename.c_str());
+        return CE_Failure;
+    }
+    int bAuxBandHasNoData = false;
+    const double dfAuxNoData =
+        data->m_poTrimmingBand->GetNoDataValue(&bAuxBandHasNoData);
+    if (!bTrimmingNodataSpecified && bAuxBandHasNoData)
+        data->m_dfTrimmingNodata = dfAuxNoData;
+
+    SetOutputValuesForInNoDataAndOutNoData(
+        nInBands, padfInNoData, pnOutBands, ppadfOutNoData, bNodataSpecified,
+        dfNoData, bNodataSpecified, dfNoData, bIsFinalStep);
+
+    *ppWorkingData = data.release();
+    return CE_None;
+}
+
+/************************************************************************/
+/*                           TrimmingFree()                             */
+/************************************************************************/
+
+/** Free function for 'Trimming' builtin function. */
+static void TrimmingFree(const char * /*pszFuncName*/, void * /*pUserData*/,
+                         VRTPDWorkingDataPtr pWorkingData)
+{
+    TrimmingData *data = static_cast<TrimmingData *>(pWorkingData);
+    CPLAssert(data->m_osSignature == TrimmingData::EXPECTED_SIGNATURE);
+    CPL_IGNORE_RET_VAL(data->m_osSignature);
+    delete data;
+}
+
+/************************************************************************/
+/*                         TrimmingProcess()                            */
+/************************************************************************/
+
+/** Processing function for 'Trimming' builtin function. */
+static CPLErr TrimmingProcess(
+    const char * /*pszFuncName*/, void * /*pUserData*/,
+    VRTPDWorkingDataPtr pWorkingData, CSLConstList /* papszFunctionArgs*/,
+    int nBufXSize, int nBufYSize, const void *pInBuffer, size_t nInBufferSize,
+    GDALDataType eInDT, int nInBands, const double *CPL_RESTRICT padfInNoData,
+    void *pOutBuffer, size_t nOutBufferSize, GDALDataType eOutDT, int nOutBands,
+    const double *CPL_RESTRICT padfOutNoData, double dfSrcXOff,
+    double dfSrcYOff, double dfSrcXSize, double dfSrcYSize,
+    const double adfSrcGT[], const char * /* pszVRTPath */,
+    CSLConstList /*papszExtra*/)
+{
+    const size_t nElts = static_cast<size_t>(nBufXSize) * nBufYSize;
+
+    CPL_IGNORE_RET_VAL(eInDT);
+    CPLAssert(eInDT == GDT_Float64);
+    CPL_IGNORE_RET_VAL(eOutDT);
+    CPLAssert(eOutDT == GDT_Float64);
+    CPL_IGNORE_RET_VAL(nInBufferSize);
+    CPLAssert(nInBufferSize == nElts * nInBands * sizeof(double));
+    CPL_IGNORE_RET_VAL(nOutBufferSize);
+    CPLAssert(nOutBufferSize == nElts * nOutBands * sizeof(double));
+    CPLAssert(nInBands == nOutBands);
+    CPL_IGNORE_RET_VAL(nOutBands);
+
+    TrimmingData *data = static_cast<TrimmingData *>(pWorkingData);
+    CPLAssert(data->m_osSignature == TrimmingData::EXPECTED_SIGNATURE);
+    const double *CPL_RESTRICT padfSrc = static_cast<const double *>(pInBuffer);
+    double *CPL_RESTRICT padfDst = static_cast<double *>(pOutBuffer);
+
+    // Compute georeferenced extent of input region
+    const double dfULX =
+        adfSrcGT[0] + adfSrcGT[1] * dfSrcXOff + adfSrcGT[2] * dfSrcYOff;
+    const double dfULY =
+        adfSrcGT[3] + adfSrcGT[4] * dfSrcXOff + adfSrcGT[5] * dfSrcYOff;
+    const double dfLRX = adfSrcGT[0] + adfSrcGT[1] * (dfSrcXOff + dfSrcXSize) +
+                         adfSrcGT[2] * (dfSrcYOff + dfSrcYSize);
+    const double dfLRY = adfSrcGT[3] + adfSrcGT[4] * (dfSrcXOff + dfSrcXSize) +
+                         adfSrcGT[5] * (dfSrcYOff + dfSrcYSize);
+
+    if (!LoadAuxData(dfULX, dfULY, dfLRX, dfLRY, nElts, nBufXSize, nBufYSize,
+                     "trimming", data->m_poTrimmingBand,
+                     data->m_abyTrimmingBuffer))
+    {
+        return CE_Failure;
+    }
+
+    const float *pafTrimming =
+        reinterpret_cast<const float *>(data->m_abyTrimmingBuffer.data());
+    const int nRedBand = data->m_nRedBand;
+    const int nGreenBand = data->m_nGreenBand;
+    const int nBlueBand = data->m_nBlueBand;
+    const double dfTopMargin = data->m_dfTopMargin;
+    const double dfTopRGB = data->m_dfTopRGB;
+    const double dfToneCeil = data->m_dfToneCeil;
+#if !defined(trimming_non_optimized_version)
+    const double dfInvToneCeil = 1.0 / dfToneCeil;
+#endif
+    const bool bRGBBandsAreFirst =
+        std::max(std::max(nRedBand, nGreenBand), nBlueBand) <= 2;
+    const double dfNoDataTrimming = data->m_dfTrimmingNodata;
+    const double dfNoDataRed = padfInNoData[nRedBand];
+    const double dfNoDataGreen = padfInNoData[nGreenBand];
+    const double dfNoDataBlue = padfInNoData[nBlueBand];
+    for (size_t i = 0; i < nElts; ++i)
+    {
+        // Extract local saturation value from trimming image
+        const double dfLocalMaxRGB = pafTrimming[i];
+        const double dfReducedRGB =
+            std::min((1.0 - dfTopMargin) * dfTopRGB / dfLocalMaxRGB, 1.0);
+
+        const double dfRed = padfSrc[nRedBand];
+        const double dfGreen = padfSrc[nGreenBand];
+        const double dfBlue = padfSrc[nBlueBand];
+        bool bNoDataPixel = false;
+        if ((dfLocalMaxRGB != dfNoDataTrimming) && (dfRed != dfNoDataRed) &&
+            (dfGreen != dfNoDataGreen) && (dfBlue != dfNoDataBlue))
+        {
+            // RGB bands specific process
+            const double dfMaxRGB = std::max(std::max(dfRed, dfGreen), dfBlue);
+#if !defined(trimming_non_optimized_version)
+            const double dfRedTimesToneRed = std::min(dfRed, dfToneCeil);
+            const double dfGreenTimesToneGreen = std::min(dfGreen, dfToneCeil);
+            const double dfBlueTimesToneBlue = std::min(dfBlue, dfToneCeil);
+            const double dfInvToneMaxRGB =
+                std::max(dfMaxRGB * dfInvToneCeil, 1.0);
+            const double dfReducedRGBTimesInvToneMaxRGB =
+                dfReducedRGB * dfInvToneMaxRGB;
+            padfDst[nRedBand] = std::min(
+                dfRedTimesToneRed * dfReducedRGBTimesInvToneMaxRGB, dfTopRGB);
+            padfDst[nGreenBand] =
+                std::min(dfGreenTimesToneGreen * dfReducedRGBTimesInvToneMaxRGB,
+                         dfTopRGB);
+            padfDst[nBlueBand] = std::min(
+                dfBlueTimesToneBlue * dfReducedRGBTimesInvToneMaxRGB, dfTopRGB);
+#else
+            // Original formulas. Slightly less optimized than the above ones.
+            const double dfToneMaxRGB = std::min(dfToneCeil / dfMaxRGB, 1.0);
+            const double dfToneRed = std::min(dfToneCeil / dfRed, 1.0);
+            const double dfToneGreen = std::min(dfToneCeil / dfGreen, 1.0);
+            const double dfToneBlue = std::min(dfToneCeil / dfBlue, 1.0);
+            padfDst[nRedBand] = std::min(
+                dfReducedRGB * dfRed * dfToneRed / dfToneMaxRGB, dfTopRGB);
+            padfDst[nGreenBand] = std::min(
+                dfReducedRGB * dfGreen * dfToneGreen / dfToneMaxRGB, dfTopRGB);
+            padfDst[nBlueBand] = std::min(
+                dfReducedRGB * dfBlue * dfToneBlue / dfToneMaxRGB, dfTopRGB);
+#endif
+
+            // Other bands processing (NIR, ...): only apply RGB reduction factor
+            if (bRGBBandsAreFirst)
+            {
+                // optimization
+                for (int iBand = 3; iBand < nInBands; ++iBand)
+                {
+                    if (padfSrc[iBand] != padfInNoData[iBand])
+                    {
+                        padfDst[iBand] = dfReducedRGB * padfSrc[iBand];
+                    }
+                    else
+                    {
+                        bNoDataPixel = true;
+                        break;
+                    }
+                }
+            }
+            else
+            {
+                for (int iBand = 0; iBand < nInBands; ++iBand)
+                {
+                    if (iBand != nRedBand && iBand != nGreenBand &&
+                        iBand != nBlueBand)
+                    {
+                        if (padfSrc[iBand] != padfInNoData[iBand])
+                        {
+                            padfDst[iBand] = dfReducedRGB * padfSrc[iBand];
+                        }
+                        else
+                        {
+                            bNoDataPixel = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        else
+        {
+            bNoDataPixel = true;
+        }
+        if (bNoDataPixel)
+        {
+            for (int iBand = 0; iBand < nInBands; ++iBand)
+            {
+                padfDst[iBand] = padfOutNoData[iBand];
+            }
+        }
+
+        padfSrc += nInBands;
+        padfDst += nInBands;
+    }
+
+    return CE_None;
+}
+
+/************************************************************************/
+/*              GDALVRTRegisterDefaultProcessedDatasetFuncs()           */
+/************************************************************************/
+
+/** Register builtin functions that can be used in a VRTProcessedDataset.
+ */
+void GDALVRTRegisterDefaultProcessedDatasetFuncs()
+{
+    GDALVRTRegisterProcessedDatasetFunc(
+        "BandAffineCombination", nullptr,
+        "<ProcessedDatasetFunctionArgumentsList>"
+        "   <Argument name='src_nodata' type='double' "
+        "description='Override input nodata value'/>"
+        "   <Argument name='dst_nodata' type='double' "
+        "description='Override output nodata value'/>"
+        "   <Argument name='replacement_nodata' "
+        "description='value to substitute to a valid computed value that "
+        "would be nodata' type='double'/>"
+        "   <Argument name='dst_intended_datatype' type='string' "
+        "description='Intented datatype of output (which might be "
+        "different than the working data type)'/>"
+        "   <Argument name='coefficients_{band}' "
+        "description='Comma-separated coefficients for combining bands. "
+        "First one is constant term' "
+        "type='double_list' required='true'/>"
+        "   <Argument name='min' description='clamp min value' type='double'/>"
+        "   <Argument name='max' description='clamp max value' type='double'/>"
+        "</ProcessedDatasetFunctionArgumentsList>",
+        GDT_Float64, nullptr, 0, nullptr, 0, BandAffineCombinationInit,
+        BandAffineCombinationFree, BandAffineCombinationProcess, nullptr);
+
+    GDALVRTRegisterProcessedDatasetFunc(
+        "LUT", nullptr,
+        "<ProcessedDatasetFunctionArgumentsList>"
+        "   <Argument name='src_nodata' type='double' "
+        "description='Override input nodata value'/>"
+        "   <Argument name='dst_nodata' type='double' "
+        "description='Override output nodata value'/>"
+        "   <Argument name='lut_{band}' "
+        "description='List of the form [src value 1]:[dest value 1],"
+        "[src value 2]:[dest value 2],...' "
+        "type='string' required='true'/>"
+        "</ProcessedDatasetFunctionArgumentsList>",
+        GDT_Float64, nullptr, 0, nullptr, 0, LUTInit, LUTFree, LUTProcess,
+        nullptr);
+
+    GDALVRTRegisterProcessedDatasetFunc(
+        "Dehazing", nullptr,
+        "<ProcessedDatasetFunctionArgumentsList>"
+        "   <Argument name='relative_filenames' "
+        "description='Whether gain and offset filenames are relative to "
+        "the VRT' type='boolean' default='false'/>"
+        "   <Argument name='gain_dataset_filename_{band}' "
+        "description='Filename to the gain dataset' "
+        "type='string' required='true'/>"
+        "   <Argument name='gain_dataset_band_{band}' "
+        "description='Band of the gain dataset' "
+        "type='integer' required='true'/>"
+        "   <Argument name='offset_dataset_filename_{band}' "
+        "description='Filename to the offset dataset' "
+        "type='string' required='true'/>"
+        "   <Argument name='offset_dataset_band_{band}' "
+        "description='Band of the offset dataset' "
+        "type='integer' required='true'/>"
+        "   <Argument name='min' description='clamp min value' type='double'/>"
+        "   <Argument name='max' description='clamp max value' type='double'/>"
+        "   <Argument name='nodata' type='double' "
+        "description='Override dataset nodata value'/>"
+        "   <Argument name='gain_nodata' type='double' "
+        "description='Override gain dataset nodata value'/>"
+        "   <Argument name='offset_nodata' type='double' "
+        "description='Override offset dataset nodata value'/>"
+        "</ProcessedDatasetFunctionArgumentsList>",
+        GDT_Float64, nullptr, 0, nullptr, 0, DehazingInit, DehazingFree,
+        DehazingProcess, nullptr);
+
+    GDALVRTRegisterProcessedDatasetFunc(
+        "Trimming", nullptr,
+        "<ProcessedDatasetFunctionArgumentsList>"
+        "   <Argument name='relative_filenames' "
+        "description='Whether trimming_dataset_filename is relative to the VRT'"
+        " type='boolean' default='false'/>"
+        "   <Argument name='trimming_dataset_filename' "
+        "description='Filename to the trimming dataset' "
+        "type='string' required='true'/>"
+        "   <Argument name='red_band' type='integer' default='1'/>"
+        "   <Argument name='green_band' type='integer' default='2'/>"
+        "   <Argument name='blue_band' type='integer' default='3'/>"
+        "   <Argument name='top_rgb' "
+        "description='Maximum saturating RGB output value' "
+        "type='double' required='true'/>"
+        "   <Argument name='tone_ceil' "
+        "description='Maximum threshold beyond which we give up saturation' "
+        "type='double' required='true'/>"
+        "   <Argument name='top_margin' "
+        "description='Margin to allow for dynamics in brighest areas "
+        "(between 0 and 1, should be close to 0)' "
+        "type='double' required='true'/>"
+        "   <Argument name='nodata' type='double' "
+        "description='Override dataset nodata value'/>"
+        "   <Argument name='trimming_nodata' type='double' "
+        "description='Override trimming dataset nodata value'/>"
+        "</ProcessedDatasetFunctionArgumentsList>",
+        GDT_Float64, nullptr, 0, nullptr, 0, TrimmingInit, TrimmingFree,
+        TrimmingProcess, nullptr);
+}

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -616,10 +616,11 @@ class CPL_DLL GDALDataset : public GDALMajorObject
 
     virtual CPLErr Close();
 
-    int GetRasterXSize();
-    int GetRasterYSize();
-    int GetRasterCount();
+    int GetRasterXSize() const;
+    int GetRasterYSize() const;
+    int GetRasterCount() const;
     GDALRasterBand *GetRasterBand(int);
+    const GDALRasterBand *GetRasterBand(int) const;
 
     /**
      * @brief SetQueryLoggerFunc
@@ -807,8 +808,8 @@ class CPL_DLL GDALDataset : public GDALMajorObject
     );
 
 #ifndef DOXYGEN_XML
-    void ReportError(CPLErr eErrClass, CPLErrorNum err_no, const char *fmt, ...)
-        CPL_PRINT_FUNC_FORMAT(4, 5);
+    void ReportError(CPLErr eErrClass, CPLErrorNum err_no, const char *fmt,
+                     ...) const CPL_PRINT_FUNC_FORMAT(4, 5);
 
     static void ReportError(const char *pszDSName, CPLErr eErrClass,
                             CPLErrorNum err_no, const char *fmt, ...)

--- a/gcore/gdaldataset.cpp
+++ b/gcore/gdaldataset.cpp
@@ -931,7 +931,7 @@ void GDALDataset::SetBand(int nNewBand, std::unique_ptr<GDALRasterBand> poBand)
 
 */
 
-int GDALDataset::GetRasterXSize()
+int GDALDataset::GetRasterXSize() const
 {
     return nRasterXSize;
 }
@@ -968,7 +968,7 @@ int CPL_STDCALL GDALGetRasterXSize(GDALDatasetH hDataset)
 
 */
 
-int GDALDataset::GetRasterYSize()
+int GDALDataset::GetRasterYSize() const
 {
     return nRasterYSize;
 }
@@ -1029,6 +1029,43 @@ GDALRasterBand *GDALDataset::GetRasterBand(int nBandId)
 }
 
 /************************************************************************/
+/*                           GetRasterBand()                            */
+/************************************************************************/
+
+/**
+
+ \brief Fetch a band object for a dataset.
+
+ See GetBands() for a C++ iterator version of this method.
+
+ Equivalent of the C function GDALGetRasterBand().
+
+ @param nBandId the index number of the band to fetch, from 1 to
+                GetRasterCount().
+
+ @return the nBandId th band object
+
+*/
+
+const GDALRasterBand *GDALDataset::GetRasterBand(int nBandId) const
+
+{
+    if (papoBands)
+    {
+        if (nBandId < 1 || nBandId > nBands)
+        {
+            ReportError(CE_Failure, CPLE_IllegalArg,
+                        "GDALDataset::GetRasterBand(%d) - Illegal band #\n",
+                        nBandId);
+            return nullptr;
+        }
+
+        return papoBands[nBandId - 1];
+    }
+    return nullptr;
+}
+
+/************************************************************************/
 /*                         GDALGetRasterBand()                          */
 /************************************************************************/
 
@@ -1058,7 +1095,7 @@ GDALRasterBandH CPL_STDCALL GDALGetRasterBand(GDALDatasetH hDS, int nBandId)
  * @return the number of raster bands.
  */
 
-int GDALDataset::GetRasterCount()
+int GDALDataset::GetRasterCount() const
 {
     return papoBands ? nBands : 0;
 }
@@ -4500,7 +4537,7 @@ int GDALDataset::CloseDependentDatasets()
  */
 
 void GDALDataset::ReportError(CPLErr eErrClass, CPLErrorNum err_no,
-                              const char *fmt, ...)
+                              const char *fmt, ...) const
 {
     va_list args;
     va_start(args, fmt);


### PR DESCRIPTION
The following built-in algorithms are introduced, and typically applied in the following order:
- Dehazing: remove haze effects by applying (subsampled) gain and offset auxiliary datasets.
- BandAffineCombination: to perform an affine transformation combination of bands.
- Trimming: local thresholding of saturation
- LUT: apply a look-up table (band per band)

