### PR TITLE
Python bindings: Make ogr.GeneralCmdLineProcessor accept int, os.PathLike

### DIFF
--- a/autotest/gcore/misc.py
+++ b/autotest/gcore/misc.py
@@ -981,7 +981,7 @@ def test_misc_get_config_options():
 # Test GeneralCmdLineProcessor
 
 
-def test_misc_general_cmd_line_processor(capfd, tmp_path):
+def test_misc_general_cmd_line_processor(tmp_path):
 
     processed = gdal.GeneralCmdLineProcessor(
         ["program", 2, tmp_path / "a_path", "a_string"]

--- a/autotest/ogr/ogr_basic_test.py
+++ b/autotest/ogr/ogr_basic_test.py
@@ -1167,3 +1167,11 @@ def test_geom_use_after_transfer_to_feature(tmp_vsimem, arg_type):
 
     with pytest.raises(Exception):
         point.ExportToWkt()
+
+
+def test_general_cmd_line_processor(tmp_path):
+
+    processed = ogr.GeneralCmdLineProcessor(
+        ["program", 2, tmp_path / "a_path", "a_string"]
+    )
+    assert processed == ["program", "2", str(tmp_path / "a_path"), "a_string"]

--- a/swig/include/python/ogr_python.i
+++ b/swig/include/python/ogr_python.i
@@ -77,6 +77,13 @@ def _WarnIfUserHasNotSpecifiedIfUsingExceptions():
 
 // End: to be removed in GDAL 4.0
 
+%pythonprepend GeneralCmdLineProcessor %{
+    import os
+    for i in range(len(args[0])):
+        if isinstance(args[0][i], (os.PathLike, int)):
+            args[0][i] = str(args[0][i])
+%}
+
 %extend OGRDataSourceShadow {
   %pythoncode {
 


### PR DESCRIPTION
Same as 7a77e1 but for ogr module.