### PR TITLE
Update libkml.rst adding vital "config option" setting example

### DIFF
--- a/doc/source/drivers/vector/libkml.rst
+++ b/doc/source/drivers/vector/libkml.rst
@@ -577,9 +577,15 @@ except for some special fields as noted below.
 A rich set of :ref:`configuration options <configoptions>` are
 available to define how fields in input and output, map to a KML
 `<Placemark> <https://developers.google.com/kml/documentation/kmlreference#placemark>`__.
-For example, if you want a field called 'Cities' to map to the
-`<name> <https://developers.google.com/kml/documentation/kmlreference#name>`__;
-tag in KML, you can set a configuration option.
+
+For example, if you want a field called 'Corner Point Identifier' to map to the
+`<name> <https://developers.google.com/kml/documentation/kmlreference#name>`__
+tag in KML, you can set the configuration option:
+
+.. code-block:: bash
+
+    --config LIBKML_NAME_FIELD "Corner Point Identifier"
+
 
 -  .. config:: LIBKML_NAME_FIELD
       :default: name


### PR DESCRIPTION
First, the user casually mentioning "a configuration option" will cause the user to look up and try each of
- -dsco NAME=VALUE: Dataset creation option (format specific)
- -lco  NAME=VALUE: Layer creation option (format specific)
- -oo   NAME=VALUE: Input dataset open option (format specific)
- -doo  NAME=VALUE: Destination dataset open option (format specific)

yes, even if each makes decreasing sense.

Finally, about to give up, he will try --help-general
stumbling upon
- --config key value: set system configuration option.

But that doesn't work either.

Then he thinks, "I know, perhaps I got the quoting wrong," and tries all five again...

My example brilliantly sweeps away all misunderstandings, pulling the user back before it's too late.
