### PR TITLE
Update libkml.rst adding vital 'config option' setting example the mo…

### DIFF
--- a/doc/source/drivers/vector/libkml.rst
+++ b/doc/source/drivers/vector/libkml.rst
@@ -572,7 +572,11 @@ except for some special fields as noted below.
   .. config:: LIBKML_USE_SIMPLEFIELD
      :choices: YES, NO
 
-     If ``NO``, export fields as <Data>.
+     If ``NO``, export fields as <Data>. Here's how to set it:
+
+.. code-block:: bash
+
+    --config LIBKML_USE_SIMPLEFIELD NO
 
 A rich set of :ref:`configuration options <configoptions>` are
 available to define how fields in input and output, map to a KML


### PR DESCRIPTION
…ment they are mentioned

Nonchalantly mentioning "configuration options" without saying how to set them will cause a nightmare. 

Yes in #9617 I added further examples below this today, but there also needs to be an example right where the user first sees and tries it. Sorry if I made the page ugly.

By the way, here if the user says NO the data just goes somewhere else. How about if the user does not like either the YES or NO choices and just wants the data to disappear, without bloating the KML or KMZ. Therefore perhaps mention what the user might do in that case. Thanks.