### PR TITLE
ogr2ogr: make -select tokenize only on comma (and not on space), and honour double-quoting 

### DIFF
--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -243,11 +243,8 @@ struct GDALVectorTranslateOptions
      * has been to disable fields. */
     bool bSelFieldsSet = false;
 
-    /*! list of fields from input layer to copy to the new layer. A field is
-       skipped if mentioned previously in the list even if the input layer has
-       duplicate field names. (Defaults to all; any field is skipped if a
-       subsequent field with same name is found.) Geometry fields can also be
-       specified in the list. */
+    /*! list of fields from input layer to copy to the new layer.
+     * Geometry fields can also be specified in the list. */
     CPLStringList aosSelFields{};
 
     /*! SQL statement to execute. The resulting table/layer will be saved to the
@@ -6776,7 +6773,7 @@ static std::unique_ptr<GDALArgumentParser> GDALVectorTranslateOptionsGetParser(
             {
                 psOptions->bSelFieldsSet = true;
                 psOptions->aosSelFields =
-                    CSLTokenizeStringComplex(s.c_str(), " ,", FALSE, FALSE);
+                    CSLTokenizeStringComplex(s.c_str(), ",", TRUE, FALSE);
             })
         .help(_("Comma-delimited list of fields from input layer to copy to "
                 "the new layer."));

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -2739,7 +2739,7 @@ def test_netcdf_64():
         "tmp/netcdf_64.nc",
         "data/netcdf/profile.nc",
         format="netCDF",
-        selectFields=["id,station,foo"],
+        selectFields=["id", "station", "foo"],
         layerCreationOptions=[
             "FEATURE_TYPE=PROFILE",
             "PROFILE_DIM_NAME=profile_dim",

--- a/autotest/utilities/test_ogr2ogr_lib.py
+++ b/autotest/utilities/test_ogr2ogr_lib.py
@@ -166,7 +166,7 @@ def test_ogr2ogr_lib_5():
 
 
 ###############################################################################
-# Test selFields
+# Test selectFields
 
 
 def test_ogr2ogr_lib_6():
@@ -184,7 +184,7 @@ def test_ogr2ogr_lib_6():
 
 
 ###############################################################################
-# Test selFields to []
+# Test selectFields to []
 
 
 def test_ogr2ogr_lib_sel_fields_empty():
@@ -193,6 +193,37 @@ def test_ogr2ogr_lib_sel_fields_empty():
     ds = gdal.VectorTranslate("", srcDS, format="Memory", selectFields=[])
     lyr = ds.GetLayer(0)
     assert lyr.GetLayerDefn().GetFieldCount() == 0
+
+
+###############################################################################
+# Test selectFields with field names with spaces
+
+
+def test_ogr2ogr_lib_sel_fields_with_space():
+
+    srcDS = gdal.GetDriverByName("Memory").Create("", 0, 0, 0, gdal.GDT_Unknown)
+    lyr = srcDS.CreateLayer("test")
+    lyr.CreateField(ogr.FieldDefn("with space"))
+    lyr.CreateField(ogr.FieldDefn("with,comma"))
+    lyr.CreateField(ogr.FieldDefn("unselected"))
+    lyr.CreateField(ogr.FieldDefn('with,double"quote'))
+    f = ogr.Feature(lyr.GetLayerDefn())
+    f["with space"] = "a"
+    f["with,comma"] = "b"
+    f['with,double"quote'] = "c"
+    lyr.CreateFeature(f)
+    ds = gdal.VectorTranslate(
+        "",
+        srcDS,
+        format="Memory",
+        selectFields=["with space", "with,comma", 'with,double"quote'],
+    )
+    lyr = ds.GetLayer(0)
+    assert lyr.GetLayerDefn().GetFieldCount() == 3
+    f = lyr.GetNextFeature()
+    assert f["with space"] == "a"
+    assert f["with,comma"] == "b"
+    assert f['with,double"quote'] == "c"
 
 
 ###############################################################################

--- a/doc/source/programs/ogr2ogr.rst
+++ b/doc/source/programs/ogr2ogr.rst
@@ -104,11 +104,28 @@ output coordinate system or even reprojecting the features during translation.
 
 .. option:: -select <field_list>
 
-    Comma-delimited list of fields from input layer to copy to the new layer. A
-    field is skipped if mentioned previously in the list even if the input
-    layer has duplicate field names. (Defaults to ``all``; any field is skipped
-    if a subsequent field with same name is found.) Geometry fields can also be
-    specified in the list.
+    Comma-delimited list of fields from input layer to copy to the new layer.
+
+    Starting with GDAL 3.9, field names with spaces, commas or double-quote
+    should be surrounded with a starting and ending double-quote character, and
+    double-quote characters in a field name should be escaped with backslash.
+
+    Depending on the shell used, this might require further quoting. For example,
+    to select ``regular_field``, ``a_field_with space, and comma`` and
+    ``a field with " double quote`` with a Unix shell:
+
+    .. code-block:: bash
+
+        -select "regular_field,\"a_field_with space, and comma\",\"a field with \\\" double quote\""
+
+    A field is only selected once, even if mentioned several times in the list
+    and if the input layer has duplicate field names.
+
+    Geometry fields can also be specified in the list.
+
+    All fields are selected when -select is not specified. Specifying the
+    empty string can be used to disable selecting any attribute field, and only
+    keep geometries.
 
     Note this setting cannot be used together with ``-append``. To control the
     selection of fields when appending to a layer, use ``-fieldmap`` or ``-sql``.

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -3097,7 +3097,10 @@ def VectorTranslateOptions(options=None, format=None,
             for item in selectFields:
                 if val:
                     val += ','
-                val += item
+                if ',' in item or ' ' in item or '"' in item:
+                    val += '"' + item.replace('"', '\\"') + '"'
+                else:
+                    val += item
             new_options += ['-select', val]
 
         if datasetCreationOptions is not None:


### PR DESCRIPTION
(fixes #9613)
