### PR TITLE
Warper: add a EXCLUDED_VALUES warping option, and use it in gdal2tiles

### DIFF
--- a/alg/gdalwarper.cpp
+++ b/alg/gdalwarper.cpp
@@ -1249,6 +1249,24 @@ CPLErr GDALWarpDstAlphaMasker(void *pMaskFuncArg, int nBandCount,
  * an explicit source and target SRS.</li>
  * <li>MULT_FACTOR_VERTICAL_SHIFT: Multiplication factor for the vertical
  * shift. Default 1.0</li>
+ *
+ * <li>EXCLUDED_VALUES: (GDAL >= 3.9) Comma-separated tuple of values
+ * (thus typically "R,G,B"), that are ignored as contributing source
+ * pixels during resampling. The number of values in the tuple must be the same
+ * as the number of bands, excluding the alpha band.
+ * Several tuples of excluded values may be specified using the
+ * "(R1,G1,B2),(R2,G2,B2)" syntax.
+ * Only taken into account by Average currently.
+ * This concept is a bit similar to nodata/alpha, but the main difference is
+ * that pixels matching one of the excluded value tuples are still considered
+ * as valid, when determining the target pixel validity/density.
+ * </li>
+ *
+ * <li>EXCLUDED_VALUES_PCT_THRESHOLD=[0-100]: (GDAL >= 3.9) Minimum percentage
+ * of source pixels that must be set at one of the EXCLUDED_VALUES to cause
+ * the excluded value, that is in majority among source pixels, to be used as the
+ * target pixel value. Default value is 50 (%)</li>
+ *
  * </ul>
  */
 

--- a/alg/gdalwarper.h
+++ b/alg/gdalwarper.h
@@ -461,6 +461,12 @@ class CPL_DLL GDALWarpKernel
     bool bApplyVerticalShift = false;
 
     double dfMultFactorVerticalShift = 1.0;
+
+    // Tuples of values (e.g. "<R>,<G>,<B>" or "(<R1>,<G1>,<B1>),(<R2>,<G2>,<B2>)") that must
+    // be ignored as contributing source pixels during resampling. Only taken into account by
+    // Average currently
+    std::vector<std::vector<double>> m_aadfExcludedValues{};
+
     /*! @endcond */
 
     GDALWarpKernel();

--- a/doc/source/programs/gdal2tiles.rst
+++ b/doc/source/programs/gdal2tiles.rst
@@ -22,6 +22,7 @@ Synopsis
                   [-w <webviewer>] [-t <title>] [-c <copyright>]
                   [--processes=<NB_PROCESSES>] [--mpi] [--xyz]
                   [--tilesize=<PIXELS>] [--tmscompatible]
+                  [--excluded-values=<EXCLUDED_VALUES>] [--excluded-values-pct-threshold=<EXCLUDED_VALUES_PCT_THRESHOLD>]
                   [-g <googlekey] [-b <bingkey>] <input_file> [<output_dir>] [<COMMON_OPTIONS>]
 
 Description
@@ -143,6 +144,23 @@ can publish a picture without proper georeferencing too.
 
   .. versionadded:: 3.6
 
+.. option:: --excluded-values=<EXCLUDED_VALUES>
+
+  Comma-separated tuple of values (thus typically "R,G,B"), that are ignored
+  as contributing source * pixels during resampling. The number of values in
+  the tuple must be the same as the number of bands, excluding the alpha band.
+  Several tuples of excluded values may be specified using the "(R1,G1,B2),(R2,G2,B2)" syntax.
+  Only taken into account by Average currently.
+  This concept is a bit similar to nodata/alpha, but the main difference is
+  that pixels matching one of the excluded value tuples are still considered
+  as valid, when determining the target pixel validity/density.
+
+.. option:: --excluded-values-pct-threshold=EXCLUDED_VALUES_PCT_THRESHOLD
+
+  Minimum percentage of source pixels that must be set at one of the --excluded-values to cause the excluded
+  value, that is in majority among source pixels, to be used as the target pixel value. Default value is 50(%)
+
+  .. versionadded:: 3.9
 
 .. option:: -h, --help
 


### PR DESCRIPTION
- Warper: add a EXCLUDED_VALUES warping option to specify pixel values to be ignored as contributing source pixels during resampling. Limited to average resampling for now
- gdal2tiles: add --excluded-values and --excluded-values-pct-threshold switches


