### PR TITLE
HANA: Upgrade EULA agreement to version 3.2

### DIFF
--- a/.github/workflows/cmake_builds.yml
+++ b/.github/workflows/cmake_builds.yml
@@ -62,7 +62,7 @@ jobs:
         sudo ACCEPT_EULA=Y apt-get install -y msodbcsql17 unixodbc-dev
         # HANA: client side
         # Install hdbsql tool
-        curl -v -j -k -s -L -H "Cookie: eula_3_1_agreed=tools.hana.ondemand.com/developer-license-3_1.txt" https://tools.hana.ondemand.com/additional/hanaclient-latest-linux-x64.tar.gz --output hanaclient-latest-linux-x64.tar.gz \
+        curl -v -j -k -s -L -H "Cookie: eula_3_2_agreed=tools.hana.ondemand.com/developer-license-3_2.txt" https://tools.hana.ondemand.com/additional/hanaclient-latest-linux-x64.tar.gz --output hanaclient-latest-linux-x64.tar.gz \
           && tar -xvf hanaclient-latest-linux-x64.tar.gz \
           && sudo mkdir /usr/sap \
           && sudo ./client/hdbinst -a client --sapmnt=/usr/sap \

--- a/.github/workflows/ubuntu_20.04/Dockerfile.ci
+++ b/.github/workflows/ubuntu_20.04/Dockerfile.ci
@@ -191,7 +191,7 @@ RUN wget -q https://github.com/rouault/pdfium_build_gdal_3_9/releases/download/p
 
 # HANA: client side
 # Install hdbsql tool
-RUN curl -v -j -k -s -L -H "Cookie: eula_3_1_agreed=tools.hana.ondemand.com/developer-license-3_1.txt" https://tools.hana.ondemand.com/additional/hanaclient-latest-linux-x64.tar.gz --output hanaclient-latest-linux-x64.tar.gz \
+RUN curl -v -j -k -s -L -H "Cookie: eula_3_2_agreed=tools.hana.ondemand.com/developer-license-3_2.txt" https://tools.hana.ondemand.com/additional/hanaclient-latest-linux-x64.tar.gz --output hanaclient-latest-linux-x64.tar.gz \
   && tar -xvf hanaclient-latest-linux-x64.tar.gz \
   && mkdir /usr/sap \
   && ./client/hdbinst -a client --sapmnt=/usr/sap \


### PR DESCRIPTION
This PR fixes an issue caused by the new version of EULA agreement for HANA Client binaries.
The fix must be backported to avoid CI fails by older versions.