### PR TITLE
gdal2xyz: Change -srcwin parameter type to integer.

### DIFF
--- a/swig/python/gdal-utils/osgeo_utils/gdal2xyz.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal2xyz.py
@@ -259,7 +259,7 @@ class GDAL2XYZ(GDALScript):
             "-srcwin",
             metavar=("xoff", "yoff", "xsize", "ysize"),
             dest="srcwin",
-            type=float,
+            type=int,
             nargs=4,
             help="Selects a subwindow from the source image for copying based on pixel/line location",
         )


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## PR fixes -srcwin parameter type

Window rectangle corners shall be specified as integers.