### PR TITLE
Arrow array: fix decoding of date32[days] values before Epoch (Arrow->OGRFeature)...

### DIFF
--- a/autotest/ogr/ogr_mem.py
+++ b/autotest/ogr/ogr_mem.py
@@ -914,7 +914,7 @@ def test_ogr_mem_arrow_stream_numpy():
     f.SetField("float32", 1.25)
     f.SetField("float64", 1.250123)
     f.SetField("str", "abc")
-    f.SetField("date", "2022-05-31")
+    f.SetField("date", "1899-05-31")
     f.SetField("time", "12:34:56.789")
     f.SetField("datetime", "2022-05-31T12:34:56.789Z")
     f.SetField("boollist", "[False,True]")
@@ -958,7 +958,7 @@ def test_ogr_mem_arrow_stream_numpy():
     for fieldname in ("bool", "int16", "int32", "int64", "float32", "float64"):
         assert batch[fieldname][1] == f.GetField(fieldname)
     assert batch["str"][1] == f.GetField("str").encode("utf-8")
-    assert batch["date"][1] == numpy.datetime64("2022-05-31")
+    assert batch["date"][1] == numpy.datetime64("1899-05-31")
     assert batch["time"][1] == datetime.time(12, 34, 56, 789000)
     assert batch["datetime"][1] == numpy.datetime64("2022-05-31T12:34:56.789")
     assert numpy.array_equal(batch["boollist"][1], numpy.array([False, True]))

--- a/ogr/ogrsf_frmts/generic/ogrlayerarrow.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrlayerarrow.cpp
@@ -1632,8 +1632,8 @@ static bool FillDateArray(struct ArrowArray *psChild,
             brokenDown.tm_year = psRawField->Date.Year - 1900;
             brokenDown.tm_mon = psRawField->Date.Month - 1;
             brokenDown.tm_mday = psRawField->Date.Day;
-            panValues[iFeat] = static_cast<int>(
-                (CPLYMDHMSToUnixTime(&brokenDown) + 36200) / 86400);
+            panValues[iFeat] =
+                static_cast<int>(CPLYMDHMSToUnixTime(&brokenDown) / 86400);
         }
         else if (bIsNullable)
         {
@@ -4247,7 +4247,7 @@ static bool SetFieldForOtherFormats(OGRFeature &oFeature,
     {
         // date32[days]
         // number of days since Epoch
-        int64_t timestamp = static_cast<int64_t>(static_cast<const uint32_t *>(
+        int64_t timestamp = static_cast<int64_t>(static_cast<const int32_t *>(
                                 array->buffers[1])[nOffsettedIndex]) *
                             3600 * 24;
         struct tm dt;


### PR DESCRIPTION
and fix rounding when encoding such values (OGRFeature->Arrow) (fixes #9636)
