### PR TITLE
Python bindings: return a namedtuple for gdal.IsLineOfSightVisible()

### DIFF
--- a/autotest/alg/los.py
+++ b/autotest/alg/los.py
@@ -37,14 +37,20 @@ def test_los_basic():
 
     mem_ds = gdal.GetDriverByName("MEM").Create("", 2, 1)
 
-    success, x, y = gdal.IsLineOfSightVisible(mem_ds.GetRasterBand(1), 0, 0, 1, 1, 0, 1)
-    assert success
-    assert x == -1
-    assert y == -1
+    res = gdal.IsLineOfSightVisible(mem_ds.GetRasterBand(1), 0, 0, 1, 1, 0, 1)
+    assert res.is_visible
+    assert res.col_intersection == -1
+    assert res.row_intersection == -1
 
-    assert gdal.IsLineOfSightVisible(mem_ds.GetRasterBand(1), 0, 0, 1, 0, 0, 1)[0]
-    assert not gdal.IsLineOfSightVisible(mem_ds.GetRasterBand(1), 0, 0, -1, 1, 0, 1)[0]
-    assert not gdal.IsLineOfSightVisible(mem_ds.GetRasterBand(1), 0, 0, 1, 1, 0, -1)[0]
+    assert gdal.IsLineOfSightVisible(
+        mem_ds.GetRasterBand(1), 0, 0, 1, 0, 0, 1
+    ).is_visible
+    assert not gdal.IsLineOfSightVisible(
+        mem_ds.GetRasterBand(1), 0, 0, -1, 1, 0, 1
+    ).is_visible
+    assert not gdal.IsLineOfSightVisible(
+        mem_ds.GetRasterBand(1), 0, 0, 1, 1, 0, -1
+    ).is_visible
 
     with pytest.raises(Exception, match="Received a NULL pointer"):
         gdal.IsLineOfSightVisible(None, 0, 0, 0, 0, 0, 0)

--- a/swig/include/python/docs/gdal_operations_docs.i
+++ b/swig/include/python/docs/gdal_operations_docs.i
@@ -29,8 +29,8 @@ options : dict/list, optional
 
 Returns
 -------
-(bool, int, int)
-    First value of tuple is True if the two points are within Line of Sight.
-    Second value is the X location where the LOS line intersects with terrain (will be set in the future, currently set to -1).
-    Third value is the Y location where the LOS line intersects with terrain (will be set in the future, currently set to -1).
+collections.namedtuple(is_visible: bool, col_intersection: int, row_intersection: int)
+    is_visible is True if the two points are within Line of Sight.
+    col_intersection is the raster column index where the LOS line intersects with terrain (will be set in the future, currently set to -1).
+    row_intersection is the raster row index where the LOS line intersects with terrain (will be set in the future, currently set to -1).
 ";

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -4747,3 +4747,14 @@ def quiet_errors():
     finally:
         PopErrorHandler()
 %}
+
+
+%feature("pythonappend") IsLineOfSightVisible %{
+    is_visible, col_intersection, row_intersection = val
+    import collections
+    tuple = collections.namedtuple('IsLineOfSightVisibleResult', ['is_visible', 'col_intersection', 'row_intersection'])
+    tuple.is_visible = is_visible
+    tuple.col_intersection = col_intersection
+    tuple.row_intersection = row_intersection
+    val = tuple
+%}


### PR DESCRIPTION
Implementin @dbaston good suggestion. I initially tried to do that using the Python C API from the typemap, but this turned out to be tricky. Couldn't manage to get rid of a DeprecationWarning about builtin type not having a __module__ attribute. Turning the basic tuple into a namedtuple from Python avoids that itssue.