### PR TITLE
Revert "requirements.txt: add pin for importlib-resources to avoid issue with pytest with jsonschema"

### DIFF
--- a/autotest/requirements.txt
+++ b/autotest/requirements.txt
@@ -6,5 +6,3 @@ pytest-benchmark
 lxml
 jsonschema
 filelock
-# importlib 6.2 and 6.3 break pytest with jsonschema. Cf https://github.com/python/importlib_resources/issues/299
-importlib-resources<6.2.0


### PR DESCRIPTION
This reverts commit 6703d3071de7155d320a39a580f27230428dcaca.

According to https://github.com/python/importlib_resources/issues/298, the issue has been fixed in importlib-resources 6.3.2
