### PR TITLE
CPLErrorStateBackuper: restore error count, and allow specifying the error handler ...

### DIFF
--- a/apps/gdalinfo_lib.cpp
+++ b/apps/gdalinfo_lib.cpp
@@ -428,8 +428,8 @@ char *GDALInfo(GDALDatasetH hDataset, const GDALInfoOptions *psOptions)
             }
             {
                 // PROJJSON requires PROJ >= 6.2
-                CPLErrorHandlerPusher oPusher(CPLQuietErrorHandler);
-                CPLErrorStateBackuper oCPLErrorHandlerPusher;
+                CPLErrorStateBackuper oCPLErrorHandlerPusher(
+                    CPLQuietErrorHandler);
                 char *pszProjJson = nullptr;
                 OGRErr result =
                     OSRExportToPROJJSON(hSRS, &pszProjJson, nullptr);
@@ -721,8 +721,7 @@ char *GDALInfo(GDALDatasetH hDataset, const GDALInfoOptions *psOptions)
         {
             // Check that it looks like Earth before trying to reproject to wgs84...
             // OSRGetSemiMajor() may raise an error on CRS like Engineering CRS
-            CPLErrorHandlerPusher oPusher(CPLQuietErrorHandler);
-            CPLErrorStateBackuper oCPLErrorHandlerPusher;
+            CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
             OGRErr eErr = OGRERR_NONE;
             if (fabs(OSRGetSemiMajor(hProj, &eErr) - 6378137.0) < 10000.0 &&
                 eErr == OGRERR_NONE)
@@ -759,8 +758,7 @@ char *GDALInfo(GDALDatasetH hDataset, const GDALInfoOptions *psOptions)
     /* -------------------------------------------------------------------- */
     if (bJson && GDALGetRasterXSize(hDataset))
     {
-        CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
-        CPLErrorStateBackuper oBackuper;
+        CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
 
         json_object *poLinearRing = json_object_new_array();
         json_object *poCornerCoordinates = json_object_new_object();
@@ -803,8 +801,7 @@ char *GDALInfo(GDALDatasetH hDataset, const GDALInfoOptions *psOptions)
     }
     else if (GDALGetRasterXSize(hDataset))
     {
-        CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
-        CPLErrorStateBackuper oBackuper;
+        CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
 
         Concat(osStr, psOptions->bStdoutOutput, "Corner Coordinates:\n");
         GDALInfoReportCorner(psOptions, hDataset, hTransform, "Upper Left", 0.0,

--- a/apps/gdalmdimtranslate_lib.cpp
+++ b/apps/gdalmdimtranslate_lib.cpp
@@ -904,8 +904,7 @@ static bool TranslateArray(
 
         std::shared_ptr<GDALDimension> dstDim;
         {
-            CPLErrorHandlerPusher oHandlerPusher(CPLQuietErrorHandler);
-            CPLErrorStateBackuper oErrorStateBackuper;
+            CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
             if (!srcDimFullName.empty() && srcDimFullName[0] == '/')
             {
                 dstDim =
@@ -1083,8 +1082,7 @@ static bool TranslateArray(
                 }
             }
 
-            CPLErrorHandlerPusher oHandlerPusher(CPLQuietErrorHandler);
-            CPLErrorStateBackuper oErrorStateBackuper;
+            CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
             auto poDstIndexingVar(poDstGroup->OpenMDArray(newDimName));
             if (poDstIndexingVar)
                 dstDim->SetIndexingVariable(std::move(poDstIndexingVar));
@@ -1319,8 +1317,7 @@ static bool CopyGroup(
                 mapSrcToDstDims.find(oIterDimName->second);
             if (oCorrespondingDimIter != mapSrcToDstDims.end())
             {
-                CPLErrorHandlerPusher oHandlerPusher(CPLQuietErrorHandler);
-                CPLErrorStateBackuper oErrorStateBackuper;
+                CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
                 oCorrespondingDimIter->second->SetIndexingVariable(
                     std::move(dstArray));
             }

--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -365,8 +365,7 @@ static CPLString GetSrcDSProjection(GDALDatasetH hDS, CSLConstList papszTO)
     {
         char *pszWKT = nullptr;
         {
-            CPLErrorStateBackuper oErrorStateBackuper;
-            CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
+            CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
             if (OSRExportToWkt(hSRS, &pszWKT) != OGRERR_NONE)
             {
                 CPLFree(pszWKT);
@@ -4195,8 +4194,7 @@ static GDALDatasetH GDALWarpCreateOutput(
             {
                 OGRSpatialReference oSrcSRS;
                 OGRSpatialReference oDstSRS;
-                CPLErrorStateBackuper oErrorStateBackuper;
-                CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
+                CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
                 // DemoteTo2D requires PROJ >= 6.3
                 if (oSrcSRS.SetFromUserInput(osThisSourceSRS.c_str()) ==
                         OGRERR_NONE &&

--- a/apps/ogrinfo_lib.cpp
+++ b/apps/ogrinfo_lib.cpp
@@ -957,8 +957,8 @@ static void ReportOnLayer(CPLString &osRet, CPLJSONObject &oLayer,
                         {
                             char *pszProjJson = nullptr;
                             // PROJJSON requires PROJ >= 6.2
-                            CPLErrorHandlerPusher oPusher(CPLQuietErrorHandler);
-                            CPLErrorStateBackuper oCPLErrorHandlerPusher;
+                            CPLErrorStateBackuper oCPLErrorHandlerPusher(
+                                CPLQuietErrorHandler);
                             CPL_IGNORE_RET_VAL(
                                 poSRS->exportToPROJJSON(&pszProjJson, nullptr));
                             if (pszProjJson)

--- a/frmts/gtiff/gtiffdataset_write.cpp
+++ b/frmts/gtiff/gtiffdataset_write.cpp
@@ -3506,8 +3506,7 @@ static bool IsSRSCompatibleOfGeoTIFF(const OGRSpatialReference *poSRS,
     }
     OGRErr eErr;
     {
-        CPLErrorStateBackuper oErrorStateBackuper;
-        CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
+        CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
         if (poSRS->IsDerivedGeographic() ||
             (poSRS->IsProjected() && !poSRS->IsCompound() &&
              poSRS->GetAxesCount() == 3))

--- a/frmts/nitf/nitfdataset.cpp
+++ b/frmts/nitf/nitfdataset.cpp
@@ -1627,8 +1627,7 @@ NITFDataset *NITFDataset::OpenInternal(GDALOpenInfo *poOpenInfo,
                            VSI_STAT_EXISTS_FLAG | VSI_STAT_NATURE_FLAG) == 0 &&
                 VSI_ISREG(sStatBuf.st_mode))
             {
-                CPLErrorStateBackuper oErrorStateBackuper;
-                CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
+                CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
                 CPLXMLNode *psTree = CPLParseXMLFile(pszPAMFilename);
                 if (psTree)
                 {
@@ -1660,8 +1659,7 @@ NITFDataset *NITFDataset::OpenInternal(GDALOpenInfo *poOpenInfo,
                        VSI_STAT_EXISTS_FLAG | VSI_STAT_NATURE_FLAG) == 0 &&
             VSI_ISREG(sStatBuf.st_mode))
         {
-            CPLErrorStateBackuper oErrorStateBackuper;
-            CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
+            CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
             CPLXMLNode *psTree = CPLParseXMLFile(pszPAMFilename);
             if (psTree)
             {

--- a/frmts/ogcapi/gdalogcapidataset.cpp
+++ b/frmts/ogcapi/gdalogcapidataset.cpp
@@ -1633,8 +1633,7 @@ ParseXMLSchema(const std::string &osURL,
                std::vector<std::unique_ptr<OGRFieldDefn>> &apoFields,
                OGRwkbGeometryType &eGeomType)
 {
-    CPLErrorHandlerPusher oErrorHandlerPusher(CPLQuietErrorHandler);
-    CPLErrorStateBackuper oErrorStateBackuper;
+    CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
 
     std::vector<GMLFeatureClass *> apoClasses;
     bool bFullyUnderstood = false;

--- a/frmts/rmf/rmfdataset.cpp
+++ b/frmts/rmf/rmfdataset.cpp
@@ -1197,8 +1197,7 @@ CPLErr RMFDataset::FlushCache(bool bAtClosing)
         {
             // ComputeRasterMinMax can setup error in case of dataset full
             // from NoData values, but it  makes no sense here.
-            CPLErrorStateBackuper oErrorStateBackuper;
-            CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
+            CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
             poBand->ComputeRasterMinMax(FALSE, sHeader.adfElevMinMax);
             bHeaderDirty = true;
         }

--- a/frmts/vrt/vrtsourcedrasterband.cpp
+++ b/frmts/vrt/vrtsourcedrasterband.cpp
@@ -1007,8 +1007,7 @@ CPLErr VRTSourcedRasterBand::ComputeRasterMinMax(int bApproxOK,
             CPLErr eErr;
             std::string osLastErrorMsg;
             {
-                CPLErrorHandlerPusher oPusher(CPLQuietErrorHandler);
-                CPLErrorStateBackuper oErrorStateBackuper;
+                CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
                 CPLErrorReset();
                 eErr =
                     ComputeStatistics(bApproxOK, &adfMinMax[0], &adfMinMax[1],
@@ -1404,8 +1403,7 @@ CPLErr VRTSourcedRasterBand::ComputeStatistics(int bApproxOK, double *pdfMin,
                 static_cast<uint64_t>(poSimpleSourceBand->GetXSize()) *
                 poSimpleSourceBand->GetYSize();
 
-            CPLErrorHandlerPusher oPusher(CPLQuietErrorHandler);
-            CPLErrorStateBackuper oErrorStateBackuper;
+            CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
             CPLErr eErr = poSimpleSourceBand->ComputeStatistics(
                 psContext->bApproxOK, &psJob->dfMin, &psJob->dfMax,
                 &psJob->dfMean, &psJob->dfStdDev,

--- a/frmts/zarr/zarr_array.cpp
+++ b/frmts/zarr/zarr_array.cpp
@@ -237,8 +237,7 @@ CPLJSONObject ZarrArray::SerializeSpecialAttributes()
         CPLFree(pszWKT);
 
         {
-            CPLErrorHandlerPusher quietError(CPLQuietErrorHandler);
-            CPLErrorStateBackuper errorStateBackuper;
+            CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
             char *projjson = nullptr;
             if (m_poSRS->exportToPROJJSON(&projjson, nullptr) == OGRERR_NONE &&
                 projjson != nullptr)

--- a/frmts/zarr/zarr_v2_array.cpp
+++ b/frmts/zarr/zarr_v2_array.cpp
@@ -1346,8 +1346,7 @@ ZarrV2Group::LoadArray(const std::string &osArrayName,
         CPLJSONDocument oDoc;
         const std::string osZattrsFilename(CPLFormFilename(
             CPLGetDirname(osZarrayFilename.c_str()), ".zattrs", nullptr));
-        CPLErrorHandlerPusher quietError(CPLQuietErrorHandler);
-        CPLErrorStateBackuper errorStateBackuper;
+        CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
         if (oDoc.Load(osZattrsFilename))
         {
             oAttributes = oDoc.GetRoot();

--- a/frmts/zarr/zarr_v2_group.cpp
+++ b/frmts/zarr/zarr_v2_group.cpp
@@ -219,8 +219,7 @@ void ZarrV2Group::LoadAttributes() const
     CPLJSONDocument oDoc;
     const std::string osZattrsFilename(
         CPLFormFilename(m_osDirectoryName.c_str(), ".zattrs", nullptr));
-    CPLErrorHandlerPusher quietError(CPLQuietErrorHandler);
-    CPLErrorStateBackuper errorStateBackuper;
+    CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
     if (!oDoc.Load(osZattrsFilename))
         return;
     auto oRoot = oDoc.GetRoot();

--- a/gcore/gdaldriver.cpp
+++ b/gcore/gdaldriver.cpp
@@ -1574,8 +1574,7 @@ CPLErr GDALDriver::QuietDelete(const char *pszName,
     }
     else
     {
-        CPLErrorStateBackuper oBackuper;
-        CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
+        CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
         poDriver = GDALDriver::FromHandle(GDALIdentifyDriver(pszName, nullptr));
     }
 
@@ -1589,8 +1588,7 @@ CPLErr GDALDriver::QuietDelete(const char *pszName,
                         poDriver->pfnDeleteDataSource == nullptr;
     if (bQuiet)
     {
-        CPLErrorStateBackuper oBackuper;
-        CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
+        CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
         return poDriver->Delete(pszName);
     }
     else

--- a/gcore/gdaljp2abstractdataset.cpp
+++ b/gcore/gdaljp2abstractdataset.cpp
@@ -655,8 +655,7 @@ char **GDALJP2AbstractDataset::GetMetadata(const char *pszDomain)
             m_aosImageStructureMetadata.Assign(
                 CSLDuplicate(GDALGeorefPamDataset::GetMetadata(pszDomain)),
                 true);
-            CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
-            CPLErrorStateBackuper oErrorStateBackuper;
+            CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
             const char *pszReversibility =
                 GDALGetJPEG2000Reversibility(GetDescription(), fp);
             if (pszReversibility)

--- a/gcore/gdaljp2metadata.cpp
+++ b/gcore/gdaljp2metadata.cpp
@@ -1270,8 +1270,7 @@ bool GDALJP2Metadata::IsSRSCompatible(const OGRSpatialReference *poSRS)
             return true;
     }
 
-    CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
-    CPLErrorStateBackuper oErrorStateBackuper;
+    CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
     char *pszGMLDef = nullptr;
     const bool bRet = (poSRS->exportToXML(&pszGMLDef, nullptr) == OGRERR_NONE);
     CPLFree(pszGMLDef);

--- a/gcore/gdalmultidim.cpp
+++ b/gcore/gdalmultidim.cpp
@@ -1130,8 +1130,8 @@ bool GDALGroup::CopyFrom(const std::shared_ptr<GDALGroup> &poDstRootGroup,
                     mapExistingDstDims.find(oIterDimName->second);
                 if (oCorrespondingDimIter != mapExistingDstDims.end())
                 {
-                    CPLErrorHandlerPusher oHandlerPusher(CPLQuietErrorHandler);
-                    CPLErrorStateBackuper oErrorStateBackuper;
+                    CPLErrorStateBackuper oErrorStateBackuper(
+                        CPLQuietErrorHandler);
                     oCorrespondingDimIter->second->SetIndexingVariable(
                         std::move(dstArray));
                 }
@@ -13516,8 +13516,7 @@ void GDALPamMultiDim::Load()
         pszProxyPam ? std::string(pszProxyPam) : d->m_osFilename + ".aux.xml";
     CPLXMLTreeCloser oTree(nullptr);
     {
-        CPLErrorStateBackuper oStateBackuper;
-        CPLErrorHandlerPusher oErrorHandlerPusher(CPLQuietErrorHandler);
+        CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
         oTree.reset(CPLParseXMLFile(d->m_osPamFilename.c_str()));
     }
     if (!oTree)
@@ -13638,8 +13637,7 @@ void GDALPamMultiDim::Save()
         {
             char *pszWKT = nullptr;
             {
-                CPLErrorStateBackuper oErrorStateBackuper;
-                CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
+                CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
                 const char *const apszOptions[] = {"FORMAT=WKT2", nullptr};
                 kv.second.poSRS->exportToWkt(&pszWKT, apszOptions);
             }

--- a/gcore/gdalpamdataset.cpp
+++ b/gcore/gdalpamdataset.cpp
@@ -233,8 +233,7 @@ CPLXMLNode *GDALPamDataset::SerializeToXML(const char *pszUnused)
     {
         char *pszWKT = nullptr;
         {
-            CPLErrorStateBackuper oErrorStateBackuper;
-            CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
+            CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
             if (psPam->poSRS->exportToWkt(&pszWKT) != OGRERR_NONE)
             {
                 CPLFree(pszWKT);
@@ -905,8 +904,7 @@ CPLErr GDALPamDataset::TryLoadXML(char **papszSiblingFiles)
             papszSiblingFiles, CPLGetFilename(psPam->pszPamFilename));
         if (iSibling >= 0)
         {
-            CPLErrorStateBackuper oErrorStateBackuper;
-            CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
+            CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
             psTree = CPLParseXMLFile(psPam->pszPamFilename);
         }
     }
@@ -914,8 +912,7 @@ CPLErr GDALPamDataset::TryLoadXML(char **papszSiblingFiles)
                         VSI_STAT_EXISTS_FLAG | VSI_STAT_NATURE_FLAG) == 0 &&
              VSI_ISREG(sStatBuf.st_mode))
     {
-        CPLErrorStateBackuper oErrorStateBackuper;
-        CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
+        CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
         psTree = CPLParseXMLFile(psPam->pszPamFilename);
     }
 
@@ -1042,8 +1039,7 @@ CPLErr GDALPamDataset::TrySaveXML()
                        VSI_STAT_EXISTS_FLAG | VSI_STAT_NATURE_FLAG) == 0 &&
             VSI_ISREG(sStatBuf.st_mode))
         {
-            CPLErrorStateBackuper oErrorStateBackuper;
-            CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
+            CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
             psOldTree = CPLParseXMLFile(psPam->pszPamFilename);
         }
 

--- a/ogr/ogrct.cpp
+++ b/ogr/ogrct.cpp
@@ -182,8 +182,7 @@ void OGRCoordinateTransformationOptions::Private::RefreshCheckWithInvertProj()
 
 static char *GetWktOrProjString(const OGRSpatialReference *poSRS)
 {
-    CPLErrorStateBackuper oErrorStateBackuper;
-    CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
+    CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
     const char *const apszOptionsWKT2_2018[] = {"FORMAT=WKT2_2018", nullptr};
     // If there's a PROJ4 EXTENSION node in WKT1, then use
     // it. For example when dealing with "+proj=longlat +lon_wrap=180"
@@ -1536,8 +1535,7 @@ int OGRProjCT::Initialize(const OGRSpatialReference *poSourceIn,
 
     const char *pszCENTER_LONG;
     {
-        CPLErrorStateBackuper oErrorStateBackuper;
-        CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
+        CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
         pszCENTER_LONG =
             poSRSSource ? poSRSSource->GetExtension("GEOGCS", "CENTER_LONG")
                         : nullptr;
@@ -1556,8 +1554,7 @@ int OGRProjCT::Initialize(const OGRSpatialReference *poSourceIn,
     }
 
     {
-        CPLErrorStateBackuper oErrorStateBackuper;
-        CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
+        CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
         pszCENTER_LONG =
             poSRSTarget ? poSRSTarget->GetExtension("GEOGCS", "CENTER_LONG")
                         : nullptr;
@@ -3358,8 +3355,7 @@ int OGRProjCT::TransformBounds(const double xmin, const double ymin,
 
         if (poSRSTarget->IsProjected())
         {
-            CPLErrorHandlerPusher oErrorHandlerPusher(CPLQuietErrorHandler);
-            CPLErrorStateBackuper oBackuper;
+            CPLErrorStateBackuper oBackuper(CPLQuietErrorHandler);
 
             auto poBaseTarget = std::unique_ptr<OGRSpatialReference>(
                 poSRSTarget->CloneGeogCS());

--- a/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
+++ b/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
@@ -163,8 +163,7 @@ OGRFlatGeobufLayer::OGRFlatGeobufLayer(const Header *poHeader, GByte *headerBuf,
     if (const auto metadata = poHeader->metadata())
     {
         CPLJSONDocument oDoc;
-        CPLErrorHandlerPusher oQuietError(CPLQuietErrorHandler);
-        CPLErrorStateBackuper oErrorStateBackuper;
+        CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
         if (oDoc.LoadMemory(metadata->c_str()) &&
             oDoc.GetRoot().GetType() == CPLJSONObject::Type::Object)
         {

--- a/ogr/ogrsf_frmts/generic/ogrlayerarrow.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrlayerarrow.cpp
@@ -7436,8 +7436,7 @@ bool OGRLayer::WriteArrowBatch(const struct ArrowSchema *schema,
 
     bool bTransactionOK;
     {
-        CPLErrorHandlerPusher oHandler(CPLQuietErrorHandler);
-        CPLErrorStateBackuper oBackuper;
+        CPLErrorStateBackuper oBackuper(CPLQuietErrorHandler);
         bTransactionOK = StartTransaction() == OGRERR_NONE;
     }
 

--- a/ogr/ogrsf_frmts/gmlas/ogrgmlasxsdcache.cpp
+++ b/ogr/ogrsf_frmts/gmlas/ogrgmlasxsdcache.cpp
@@ -180,8 +180,7 @@ bool GMLASXSDCache::CacheAllGML321()
     // Download the later and unzip it for faster fetching of GML schemas.
 
     bool bSuccess = false;
-    CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
-    CPLErrorStateBackuper oErrorStateBackuper;
+    CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
 
     const char *pszHTTPZIP = "https://schemas.opengis.net/gml/gml-3_2_2.zip";
     CPLHTTPResult *psResult = CPLHTTPFetch(pszHTTPZIP, nullptr);
@@ -248,8 +247,7 @@ bool GMLASXSDCache::CacheAllISO20070417()
     // Download the later and unzip it for faster fetching of ISO schemas.
 
     bool bSuccess = false;
-    CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
-    CPLErrorStateBackuper oErrorStateBackuper;
+    CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
 
     const char *pszHTTPZIP =
         "https://schemas.opengis.net/iso/19139/iso19139-20070417.zip";

--- a/ogr/ogrsf_frmts/gpsbabel/ogrgpsbabeldriver.cpp
+++ b/ogr/ogrsf_frmts/gpsbabel/ogrgpsbabeldriver.cpp
@@ -113,8 +113,7 @@ OGRGPSBabelDriverIdentifyInternal(GDALOpenInfo *poOpenInfo,
         if (!bGPSBabelFound)
 #endif
         {
-            CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
-            CPLErrorStateBackuper oErrorStateBackuper;
+            CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
             const char *const apszArgs[] = {"gpsbabel", "-V", nullptr};
             CPLString osTmpFileName("/vsimem/gpsbabel_tmp.tmp");
             VSILFILE *tmpfp = VSIFOpenL(osTmpFileName, "wb");

--- a/ogr/ogrsf_frmts/mvt/ogrmvtdataset.cpp
+++ b/ogr/ogrsf_frmts/mvt/ogrmvtdataset.cpp
@@ -3819,7 +3819,7 @@ bool OGRMVTWriterDataset::EncodeRepairedOuterRing(
         oOutPoly.addRingDirectly(poOutLinearRing.release());
         int bIsValid;
         {
-            CPLErrorStateBackuper oErrorStateBackuper;
+            CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
             bIsValid = oOutPoly.IsValid();
         }
         if (bIsValid)
@@ -3953,8 +3953,7 @@ OGRErr OGRMVTWriterDataset::PreGenerateForTileReal(
         OGRPolygon oPoly;
         oPoly.addRingDirectly(poLR);
 
-        CPLErrorStateBackuper oErrorStateBackuper;
-        CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
+        CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
         auto poTmp = poGeom->Intersection(&oPoly);
         poIntersection = poTmp;
         poIntersectionHolder.reset(poTmp);
@@ -4169,8 +4168,7 @@ OGRErr OGRMVTWriterDataset::PreGenerateForTileReal(
                                     dfAreaOrLength);
             int bIsValid;
             {
-                CPLErrorStateBackuper oErrorStateBackuper;
-                CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
+                CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
                 bIsValid = oOutPoly.IsValid();
             }
             if (!bIsValid)
@@ -4211,8 +4209,7 @@ OGRErr OGRMVTWriterDataset::PreGenerateForTileReal(
             }
             int bIsValid;
             {
-                CPLErrorStateBackuper oErrorStateBackuper;
-                CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
+                CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
                 bIsValid = oOutMP.IsValid();
             }
             if (!bIsValid)
@@ -4693,8 +4690,7 @@ GetReducedPrecisionGeometry(MVTTileLayerFeature::GeomType eGeomType,
                             poOutOuterRing = std::unique_ptr<OGRLinearRing>(
                                 poOutRing.release());
                             {
-                                CPLErrorStateBackuper oErrorStateBackuper;
-                                CPLErrorHandlerPusher oErrorHandler(
+                                CPLErrorStateBackuper oErrorStateBackuper(
                                     CPLQuietErrorHandler);
                                 bIsValid = oPoly.IsValid();
                             }
@@ -4715,8 +4711,7 @@ GetReducedPrecisionGeometry(MVTTileLayerFeature::GeomType eGeomType,
                         oPoly.addRing(poOutOuterRing.get());
                         oPoly.addRingDirectly(poOutRing.release());
                         {
-                            CPLErrorStateBackuper oErrorStateBackuper;
-                            CPLErrorHandlerPusher oErrorHandler(
+                            CPLErrorStateBackuper oErrorStateBackuper(
                                 CPLQuietErrorHandler);
                             bIsValid = oPoly.IsValid();
                         }

--- a/ogr/ogrsf_frmts/oci/ogrocidatasource.cpp
+++ b/ogr/ogrsf_frmts/oci/ogrocidatasource.cpp
@@ -838,8 +838,7 @@ OGRSpatialReference *OGROCIDataSource::FetchSRS(int nId)
     if (nId < LARGEST_EPSG_CRS_CODE && papszResult[1] != nullptr &&
         atoi(papszResult[1]) == nId)
     {
-        CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
-        CPLErrorStateBackuper oErrorStateBackuper;
+        CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
         OGRSpatialReference oSRS_EPSG;
         oSRS_EPSG.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
         const char *const apszOptions[] = {

--- a/ogr/ogrsf_frmts/pg/ogrpgtablelayer.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgtablelayer.cpp
@@ -254,8 +254,7 @@ void OGRPGTableLayer::LoadMetadata()
                    "schema_name = %s AND table_name = %s",
                    OGRPGEscapeString(hPGConn, pszSchemaName).c_str(),
                    OGRPGEscapeString(hPGConn, pszTableName).c_str()));
-    CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
-    CPLErrorStateBackuper oBackuper;
+    CPLErrorStateBackuper oBackuper(CPLQuietErrorHandler);
     auto poSqlLyr = poDS->ExecuteSQL(osSQL.c_str(), nullptr, nullptr);
     if (poSqlLyr)
     {

--- a/ogr/ogrsf_frmts/pgeo/ogrpgeodatasource.cpp
+++ b/ogr/ogrsf_frmts/pgeo/ogrpgeodatasource.cpp
@@ -658,8 +658,7 @@ bool OGRPGeoDataSource::CountStarWorking() const
         }
 #endif
 
-        CPLErrorHandlerPusher oErrorHandler(CPLErrorHandlerPusher);
-        CPLErrorStateBackuper oStateBackuper;
+        CPLErrorStateBackuper oStateBackuper(CPLErrorHandlerPusher);
 
         CPLODBCStatement oStmt(&oSession);
         oStmt.Append("SELECT COUNT(*) FROM GDB_GeomColumns");

--- a/ogr/ogrsf_frmts/pmtiles/vsipmtiles.cpp
+++ b/ogr/ogrsf_frmts/pmtiles/vsipmtiles.cpp
@@ -259,8 +259,7 @@ VSIPMTilesFilesystemHandler::Open(const char *pszFilename,
     if (nComponents != 3)
         return nullptr;
 
-    CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
-    CPLErrorStateBackuper oBackuper;
+    CPLErrorStateBackuper oBackuper(CPLQuietErrorHandler);
 
     OGRPMTilesTileIterator oIter(poDS.get(), nZ, nX, nY, nX, nY);
     auto sTile = oIter.GetNextTile();
@@ -320,8 +319,7 @@ int VSIPMTilesFilesystemHandler::Stat(const char *pszFilename,
         return 0;
     }
 
-    CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
-    CPLErrorStateBackuper oBackuper;
+    CPLErrorStateBackuper oBackuper(CPLQuietErrorHandler);
 
     OGRPMTilesTileIterator oIter(poDS.get(), nZ, nX, nY, nX, nY);
     auto sTile = oIter.GetNextTile();

--- a/ogr/ogrsf_frmts/sqlite/ogrsqliteselectlayer.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqliteselectlayer.cpp
@@ -141,8 +141,8 @@ OGRSQLiteSelectLayer::OGRSQLiteSelectLayer(
                     sqlite3_column_table_name(m_hStmt, poGeomFieldDefn->m_iCol);
                 if (pszTableName != nullptr)
                 {
-                    CPLErrorStateBackuper oErrorStateBackuper;
-                    CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
+                    CPLErrorStateBackuper oErrorStateBackuper(
+                        CPLQuietErrorHandler);
                     OGRSQLiteLayer *m_poLayer =
                         cpl::down_cast<OGRSQLiteLayer *>(
                             m_poDS->GetLayerByName(pszTableName));

--- a/ogr/ogrsf_frmts/wfs/ogroapifdriver.cpp
+++ b/ogr/ogrsf_frmts/wfs/ogroapifdriver.cpp
@@ -1636,8 +1636,7 @@ void OGROAPIFLayer::GetSchema()
     if (m_osDescribedByURL.empty() || m_poDS->m_bIgnoreSchema)
         return;
 
-    CPLErrorHandlerPusher oErrorHandlerPusher(CPLQuietErrorHandler);
-    CPLErrorStateBackuper oErrorStateBackuper;
+    CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
 
     if (m_bDescribedByIsXML)
     {

--- a/ogr/ogrsf_frmts/wfs/ogrwfsdatasource.cpp
+++ b/ogr/ogrsf_frmts/wfs/ogrwfsdatasource.cpp
@@ -1389,9 +1389,9 @@ int OGRWFSDataSource::Open(const char *pszFilename, int bUpdateIn,
                             apoSupportedCRSList.emplace_back(std::move(poSRS));
                         }
                     }
-                    CPLErrorHandlerPusher oErrorHandlerPusher(
+
+                    CPLErrorStateBackuper oErrorStateBackuper(
                         CPLQuietErrorHandler);
-                    CPLErrorStateBackuper oErrorStateBackuper;
                     for (const CPLXMLNode *psIter = psOtherSRS; psIter;
                          psIter = psIter->psNext)
                     {

--- a/ogr/ogrspatialreference.cpp
+++ b/ogr/ogrspatialreference.cpp
@@ -369,8 +369,7 @@ void OGRSpatialReference::Private::refreshRootFromProjObj()
 
         const char *pszWKT;
         {
-            CPLErrorStateBackuper oErrorStateBackuper;
-            CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
+            CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
             pszWKT = proj_as_wkt(getPROJContext(), m_pj_crs,
                                  m_bMorphToESRI ? PJ_WKT1_ESRI : PJ_WKT1_GDAL,
                                  aosOptions.List());


### PR DESCRIPTION
... as CPLQuietErrorHandler is used > 95% of time combined with it