### PR TITLE
gdalinfo, ogrinfo: Improve error output when file cannotbe opened

### DIFF
--- a/apps/gdalinfo_bin.cpp
+++ b/apps/gdalinfo_bin.cpp
@@ -148,8 +148,21 @@ MAIN_START(argc, argv)
 #ifdef __AFL_HAVE_MANUAL_CONTROL
             continue;
 #else
-        fprintf(stderr, "gdalinfo failed - unable to open '%s'.\n",
-                psOptionsForBinary->pszFilename);
+        VSIStatBuf sStat;
+        CPLString message;
+        message.Printf("gdalinfo failed - unable to open '%s'.",
+                       psOptionsForBinary->pszFilename);
+        if (VSIStat(psOptionsForBinary->pszFilename, &sStat) == 0)
+        {
+            GDALDriverH drv =
+                GDALIdentifyDriverEx(psOptionsForBinary->pszFilename,
+                                     GDAL_OF_VECTOR, nullptr, nullptr);
+            if (drv)
+            {
+                message += " Did you intend to call ogrinfo?";
+            }
+        }
+        fprintf(stderr, "%s\n", message.c_str());
 
         /* --------------------------------------------------------------------
          */

--- a/apps/ogrinfo_bin.cpp
+++ b/apps/ogrinfo_bin.cpp
@@ -154,8 +154,22 @@ MAIN_START(argc, argv)
         if (poDS == nullptr)
         {
             nRet = 1;
-            fprintf(stderr, "ogrinfo failed - unable to open '%s'.\n",
-                    psOptionsForBinary->osFilename.c_str());
+
+            VSIStatBuf sStat;
+            CPLString message;
+            message.Printf("ogrinfo failed - unable to open '%s'.",
+                           psOptionsForBinary->osFilename.c_str());
+            if (VSIStat(psOptionsForBinary->osFilename.c_str(), &sStat) == 0)
+            {
+                GDALDriverH drv =
+                    GDALIdentifyDriverEx(psOptionsForBinary->osFilename.c_str(),
+                                         GDAL_OF_RASTER, nullptr, nullptr);
+                if (drv)
+                {
+                    message += " Did you intend to call gdalinfo?";
+                }
+            }
+            fprintf(stderr, "%s\n", message.c_str());
         }
         else
         {

--- a/autotest/utilities/test_gdalinfo.py
+++ b/autotest/utilities/test_gdalinfo.py
@@ -1044,3 +1044,24 @@ def test_gdalinfo_access_to_file_without_permission(gdalinfo_path, tmp_path):
     assert (len(lines)) == 3
 
     os.chmod(tmpfilename, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+
+
+###############################################################################
+# Test error messages when file cannot be opened
+
+
+def test_gdalinfo_file_does_not_exist(gdalinfo_path):
+
+    (ret, err) = gdaltest.runexternal_out_and_err(gdalinfo_path + " does_not_exist.tif")
+
+    assert "No such file or directory" in err
+    assert "ogrinfo" not in err
+
+
+def test_gdalinfo_open_vector(gdalinfo_path):
+
+    (ret, err) = gdaltest.runexternal_out_and_err(
+        gdalinfo_path + " ../ogr/data/poly.shp"
+    )
+
+    assert "Did you intend to call ogrinfo" in err

--- a/autotest/utilities/test_ogrinfo.py
+++ b/autotest/utilities/test_ogrinfo.py
@@ -789,3 +789,24 @@ def test_ogrinfo_access_to_file_without_permission(ogrinfo_path, tmp_path):
     assert (len(lines)) == 3
 
     os.chmod(tmpfilename, stat.S_IRUSR | stat.S_IWUSR | stat.S_IXUSR)
+
+
+###############################################################################
+# Test error messages when file cannot be opened
+
+
+def test_ogrinfo_file_does_not_exist(ogrinfo_path):
+
+    (ret, err) = gdaltest.runexternal_out_and_err(ogrinfo_path + " does_not_exist.shp")
+
+    assert "No such file or directory" in err
+    assert "gdalinfo" not in err
+
+
+def test_ogrinfo_open_raster(ogrinfo_path):
+
+    (ret, err) = gdaltest.runexternal_out_and_err(
+        ogrinfo_path + " ../gcore/data/byte.tif"
+    )
+
+    assert "Did you intend to call gdalinfo" in err

--- a/gcore/gdaldriver.cpp
+++ b/gcore/gdaldriver.cpp
@@ -2561,18 +2561,18 @@ int GDALValidateOptions(const char *pszOptionList,
 /************************************************************************/
 
 /**
- * \brief Identify the driver that can open a raster file.
+ * \brief Identify the driver that can open a dataset.
  *
  * This function will try to identify the driver that can open the passed file
  * name by invoking the Identify method of each registered GDALDriver in turn.
- * The first driver that successful identifies the file name will be returned.
+ * The first driver that successfully identifies the file name will be returned.
  * If all drivers fail then NULL is returned.
  *
- * In order to reduce the need for such searches touch the operating system
+ * In order to reduce the need for such searches to touch the operating system
  * file system machinery, it is possible to give an optional list of files.
  * This is the list of all files at the same level in the file system as the
  * target file, including the target file. The filenames will not include any
- * path components, are essentially just the output of VSIReadDir() on the
+ * path components, and are essentially just the output of VSIReadDir() on the
  * parent directory. If the target object does not have filesystem semantics
  * then the file list should be NULL.
  *
@@ -2600,18 +2600,18 @@ GDALDriverH CPL_STDCALL GDALIdentifyDriver(const char *pszFilename,
 /************************************************************************/
 
 /**
- * \brief Identify the driver that can open a raster file.
+ * \brief Identify the driver that can open a dataset.
  *
  * This function will try to identify the driver that can open the passed file
  * name by invoking the Identify method of each registered GDALDriver in turn.
- * The first driver that successful identifies the file name will be returned.
+ * The first driver that successfully identifies the file name will be returned.
  * If all drivers fail then NULL is returned.
  *
- * In order to reduce the need for such searches touch the operating system
+ * In order to reduce the need for such searches to touch the operating system
  * file system machinery, it is possible to give an optional list of files.
  * This is the list of all files at the same level in the file system as the
  * target file, including the target file. The filenames will not include any
- * path components, are essentially just the output of VSIReadDir() on the
+ * path components, and are essentially just the output of VSIReadDir() on the
  * parent directory. If the target object does not have filesystem semantics
  * then the file list should be NULL.
  *


### PR DESCRIPTION
## What does this PR do?

Updates `gdalinfo` to check if a file that cannot be opened has a name indicating a vector data type, and suggest the user call `ogrinfo` instead. Make the corresponding update to `ogrinfo`.

## What are related issues/pull requests?

#9618

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
