### PR TITLE
netCDF: Add BAND_NAMES creation option

### DIFF
--- a/doc/source/drivers/raster/netcdf.rst
+++ b/doc/source/drivers/raster/netcdf.rst
@@ -429,6 +429,12 @@ Creation Options
       installations, but NC4 and NC4C are available if NetCDF was compiled
       with NetCDF-4 (and HDF5) support.
 
+-  .. co:: BAND_NAMES
+      :default: Band1,Band2,...
+      :since: 3.9.0
+
+      A comma-separated list of band names.
+
 -  .. co:: COMPRESS
       :choices: NONE, DEFLATE
 

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -9156,7 +9156,6 @@ netCDFDataset *netCDFDataset::CreateLL(const char *pszFilename, int nXSize,
 
         return poDS;
     }
-
     // Create the dataset.
     CPLString osFilenameForNCCreate(pszFilename);
 #if defined(_WIN32) && !defined(NETCDF_USES_UTF8)
@@ -9321,12 +9320,31 @@ GDALDataset *netCDFDataset::Create(const char *pszFilename, int nXSize,
                                            : GDAL_DEFAULT_NCDF_CONVENTIONS);
     }
 
+    CPLStringList aosBandNames;
+    if (const char *pszBandNames = aosOptions.FetchNameValue("BAND_NAMES"))
+    {
+        aosBandNames =
+            CSLTokenizeString2(pszBandNames, ",", CSLT_HONOURSTRINGS);
+
+        if (aosBandNames.Count() != nBandsIn)
+        {
+            CPLError(CE_Failure, CPLE_OpenFailed,
+                     "Attempted to create netCDF with %d bands but %d names "
+                     "provided in BAND_NAMES.",
+                     nBandsIn, aosBandNames.Count());
+            return nullptr;
+        }
+    }
+
     // Define bands.
     for (int iBand = 1; iBand <= nBandsIn; iBand++)
     {
-        poDS->SetBand(
-            iBand, new netCDFRasterBand(netCDFRasterBand::CONSTRUCTOR_CREATE(),
-                                        poDS, eType, iBand, poDS->bSignedData));
+        const char *pszBandName =
+            aosBandNames.empty() ? nullptr : aosBandNames[iBand - 1];
+
+        poDS->SetBand(iBand, new netCDFRasterBand(
+                                 netCDFRasterBand::CONSTRUCTOR_CREATE(), poDS,
+                                 eType, iBand, poDS->bSignedData, pszBandName));
     }
 
     CPLDebug("GDAL_netCDF", "netCDFDataset::Create(%s, ...) done", pszFilename);

--- a/frmts/netcdf/netcdfdrivercore.cpp
+++ b/frmts/netcdf/netcdfdrivercore.cpp
@@ -429,6 +429,7 @@ void netCDFDriverSetCommonMetadata(GDALDriver *poDriver)
         "description='Path to a XML configuration file (or content inlined)'/>"
         "   <Option name='WRITE_GDAL_VERSION' type='boolean' default='YES'/>"
         "   <Option name='WRITE_GDAL_HISTORY' type='boolean' default='YES'/>"
+        "   <Option name='BAND_NAMES' type='string' scope='raster' />"
         "</CreationOptionList>");
     poDriver->SetMetadataItem(GDAL_DMD_SUBDATASETS, "YES");
 


### PR DESCRIPTION
## What does this PR do?

Adds an option to control the names of netCDF variables created by GDAL. 

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/issues/1427
https://gis.stackexchange.com/questions/230642/setting-band-names-when-writing-multiple-layer-rasters-using-gdal-with-python
https://gis.stackexchange.com/questions/265204/gdal-creation-option-to-set-variable-name-to-netcdf

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed