### PR TITLE
Doc: Clarify the target of ticket number reference

### DIFF
--- a/doc/source/user/configoptions.rst
+++ b/doc/source/user/configoptions.rst
@@ -991,8 +991,7 @@ PROJ options
 
       Used by :cpp:func:`OGRLineString::transform`.
 
-      Can be set to YES to remove points that can't be reprojected. See
-      http://trac.osgeo.org/gdal/ticket/3758 for the purpose of this option.
+      Can be set to YES to remove points that cannot be reprojected. This can for example help reproject lines that have an extremity at a pole, when the reprojection does not support coordinates at poles.
 
 -  .. config:: OGR_CT_USE_SRS_COORDINATE_EPOCH
       :choices: YES, NO

--- a/doc/source/user/configoptions.rst
+++ b/doc/source/user/configoptions.rst
@@ -991,8 +991,8 @@ PROJ options
 
       Used by :cpp:func:`OGRLineString::transform`.
 
-      Can be set to YES to remove points that can't be reprojected. See #3758 for the
-      purpose of this option.
+      Can be set to YES to remove points that can't be reprojected. See
+      http://trac.osgeo.org/gdal/ticket/3758 for the purpose of this option.
 
 -  .. config:: OGR_CT_USE_SRS_COORDINATE_EPOCH
       :choices: YES, NO


### PR DESCRIPTION
## What does this PR do?

Converts a ticket number in documentation to a link, so that even people who are not so familiar with the project can easily access the ticket.

## What are related issues/pull requests?

None as far as I'm aware.

## Tasklist

 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed