### PR TITLE
CI: adapt for setuptools >= 65.3

### DIFF
--- a/.github/workflows/cmake_builds.yml
+++ b/.github/workflows/cmake_builds.yml
@@ -234,7 +234,7 @@ jobs:
     - name: Standalone Python bindings build from source
       run: |
         (cd $GITHUB_WORKSPACE/superbuild/build/gdal/swig/python && python setup.py sdist)
-        mv $GITHUB_WORKSPACE/superbuild/build/gdal/swig/python/dist/GDAL-*.tar.gz gdal-python.tar.gz
+        mv $GITHUB_WORKSPACE/superbuild/build/gdal/swig/python/dist/gdal-*.tar.gz gdal-python.tar.gz
         mv $GITHUB_WORKSPACE/superbuild/build/gdal/swig/python gdal-swig-python
         python3 -m venv myvenv
         source myvenv/bin/activate

--- a/HOWTO-RELEASE
+++ b/HOWTO-RELEASE
@@ -216,14 +216,14 @@ the GDAL package by one of the current owners : HowardB/FrankW/EvenR)
 
     c) python3 setup.py sdist
 
-    d) Check the output:
-        twine check dist/GDAL-*.gz
+    d) Check the output (this assumes setuptools >= 65.3.0, otherwise the filename is GDAL-*.gz):
+        twine check dist/gdal-*.gz
 
     e) For trial :
-        twine upload dist/GDAL-*.gz -r pypitest
+        twine upload dist/gdal-*.gz -r pypitest
 
     f) For real :
-        twine upload dist/GDAL-*.gz
+        twine upload dist/gdal-*.gz
 
 15.3) create gdal-utils wheel and upload to pypi:
 


### PR DESCRIPTION
setuptools 65.3 has https://github.com/pypa/setuptools/issues/3593 "Implement PEP 625 - File Name of a Source Distribution" which modifies the source tarball. Adapt for it
