### PR TITLE
VSICACHE: avoid EOF read

### DIFF
--- a/autotest/gcore/vsifile.py
+++ b/autotest/gcore/vsifile.py
@@ -1306,24 +1306,13 @@ def test_vsifile_win32_network_path():
 def test_vsifile_eof_cache_read(tmp_path):
     """Test issue GH #9658"""
 
-    np = pytest.importorskip("numpy")
-    # Create an empty GTiff file
-    filename = f"/vsizip/{tmp_path}/test.zip/testraster.tif"
-    driver = gdal.GetDriverByName("GTiff")
-    size = 1000
-    ds = driver.Create(
-        filename, size, size, 1, gdal.GDT_Byte, options=["STREAMABLE_OUTPUT=YES"]
-    )
-    assert ds
-    data = np.random.randint(0, 255, size=(size, size))
-    band = ds.GetRasterBand(1)
-    assert band.WriteArray(data) == 0
-    ds = None
-
-    # Read past EOF
+    tmp_filename = str(tmp_path / "vsifile_eof_cache_read.bin")
+    f = gdal.VSIFOpenL(tmp_filename, "wb")
+    gdal.VSIFWriteL(b"x" * 100000, 100000, 1, f)
+    gdal.VSIFCloseL(f)
     with gdal.config_option("VSI_CACHE", "YES"):
-        ds = gdal.Open(filename)
-        assert ds
-        b = ds.GetRasterBand(1)
-        # Read all
-        b.ReadRaster(0, 0, size, size)
+        f = gdal.VSIFOpenL(tmp_filename, "rb")
+        gdal.VSIFSeekL(f, 60000, 0)
+        data = gdal.VSIFReadL(1, 75000, f)  # reads past end of file
+        gdal.VSIFCloseL(f)
+        assert data == b"x" * 40000

--- a/port/cpl_vsil_cache.cpp
+++ b/port/cpl_vsil_cache.cpp
@@ -360,8 +360,15 @@ size_t VSICachedFile::Read(void *pBuffer, size_t nSize, size_t nCount)
     /*      Make sure the cache is loaded for the whole request region.     */
     /* ==================================================================== */
     const vsi_l_offset nStartBlock = m_nOffset / m_nChunkSize;
-    const vsi_l_offset nEndBlock =
-        (m_nOffset + nRequestedBytes - 1) / m_nChunkSize;
+    // Calculate last block
+    const vsi_l_offset nLastBlock = m_nFileSize / m_nChunkSize;
+    vsi_l_offset nEndBlock = (m_nOffset + nRequestedBytes - 1) / m_nChunkSize;
+
+    // if nLastBlock is not 0 consider the min value to avoid out-of-range reads
+    if (nLastBlock != 0 && nEndBlock > nLastBlock)
+    {
+        nEndBlock = nLastBlock;
+    }
 
     for (vsi_l_offset iBlock = nStartBlock; iBlock <= nEndBlock; iBlock++)
     {


### PR DESCRIPTION
Do not read past EOF even if the client (e.g. VSIZIP) code say so.

Fix #9658
