### PR TITLE
GPKG: change default value of OGR_GPKG_ALLOW_THREADED_RTREE to NO on OSX Arm64

### DIFF
--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -8907,8 +8907,15 @@ def test_ogr_gpkg_get_geometry_types(tmp_vsimem):
 
 @pytest.mark.parametrize("write_to_disk", (True, False), ids=["on_disk", "in_memory"])
 @pytest.mark.parametrize("OGR_GPKG_MAX_RAM_USAGE_RTREE", (1, 1000, None))
+@pytest.mark.parametrize(
+    "OGR_GPKG_SIMULATE_INSERT_INTO_MY_RTREE_PREPARATION_ERROR", (True, False)
+)
 def test_ogr_gpkg_background_rtree_build(
-    tmp_path, tmp_vsimem, write_to_disk, OGR_GPKG_MAX_RAM_USAGE_RTREE
+    tmp_path,
+    tmp_vsimem,
+    write_to_disk,
+    OGR_GPKG_MAX_RAM_USAGE_RTREE,
+    OGR_GPKG_SIMULATE_INSERT_INTO_MY_RTREE_PREPARATION_ERROR,
 ):
 
     if write_to_disk:
@@ -8918,13 +8925,17 @@ def test_ogr_gpkg_background_rtree_build(
 
     # Batch insertion only
     gdal.ErrorReset()
-    with gdaltest.config_option(
-        "OGR_GPKG_MAX_RAM_USAGE_RTREE",
+
+    options = {}
+    options["OGR_GPKG_MAX_RAM_USAGE_RTREE"] = (
         str(OGR_GPKG_MAX_RAM_USAGE_RTREE)
         if OGR_GPKG_MAX_RAM_USAGE_RTREE is not None
-        else None,
-        thread_local=False,
-    ):
+        else None
+    )
+    options["OGR_GPKG_SIMULATE_INSERT_INTO_MY_RTREE_PREPARATION_ERROR"] = (
+        "TRUE" if OGR_GPKG_SIMULATE_INSERT_INTO_MY_RTREE_PREPARATION_ERROR else None
+    )
+    with gdaltest.config_options(options, thread_local=False):
         ds = gdaltest.gpkg_dr.CreateDataSource(filename)
         with gdaltest.config_option("OGR_GPKG_THREADED_RTREE_AT_FIRST_FEATURE", "YES"):
             lyr = ds.CreateLayer("foo")

--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -8964,13 +8964,7 @@ def test_ogr_gpkg_background_rtree_build(
         f = sql_lyr.GetNextFeature()
         assert f.GetField(0) == "ok"
     with ds.ExecuteSQL("SELECT * FROM rtree_foo_geom") as sql_lyr:
-        fc = sql_lyr.GetFeatureCount()
-        if fc != 1000 and gdaltest.is_travis_branch("macos_build_conda"):
-            # Fails with
-            # ERROR 1: failed to prepare SQL: INSERT INTO my_rtree VALUES (?,?,?,?,?)
-            # FAILED ogr/ogr_gpkg.py::test_ogr_gpkg_background_rtree_build[1000-in_memory] - AssertionError: assert 0 == 1000
-            pytest.xfail("fails for unknown reason on MacOS ARM64")
-        assert fc == 1000
+        assert sql_lyr.GetFeatureCount() == 1000
     foo_lyr = ds.GetLayerByName("foo")
     for i in range(1000):
         foo_lyr.SetSpatialFilterRect(10000 + i - 0.5, i - 0.5, 10000 + i + 0.5, i + 0.5)

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -2725,8 +2725,6 @@ void OGRGeoPackageTableLayer::StartAsyncRTree()
             OGRErr eErr = SQLCommand(m_poDS->GetDB(), pszSQL);
             sqlite3_free(pszSQL);
 
-            VSIUnlink(m_osAsyncDBName.c_str());
-
             if (eErr == OGRERR_NONE)
             {
                 try
@@ -2936,7 +2934,8 @@ void OGRGeoPackageTableLayer::AsyncRTreeThreadFunction()
                                    nullptr) != SQLITE_OK)
             {
                 CPLError(CE_Failure, CPLE_AppDefined,
-                         "failed to prepare SQL: %s", pszInsertSQL);
+                         "failed to prepare SQL: %s: %s", pszInsertSQL,
+                         sqlite3_errmsg(m_hAsyncDBHandle));
                 m_oQueueRTreeEntries.clear();
                 m_bErrorDuringRTreeThread = true;
                 return;

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -2644,8 +2644,19 @@ void OGRGeoPackageTableLayer::SetDeferredSpatialIndexCreation(bool bFlag)
         m_bAllowedRTreeThread =
             m_poDS->GetLayerCount() == 0 && sqlite3_threadsafe() != 0 &&
             CPLGetNumCPUs() >= 2 &&
-            CPLTestBool(
-                CPLGetConfigOption("OGR_GPKG_ALLOW_THREADED_RTREE", "YES"));
+            CPLTestBool(CPLGetConfigOption("OGR_GPKG_ALLOW_THREADED_RTREE",
+        // For a not yet understood reason, threaded RTree building
+        // (randomly?) fails on OSX Arm64. This may not be at all specific
+        // to that platform, but a more general problem, but it can't be
+        // reproduced elsewhere.
+        // Cf https://gis.stackexchange.com/questions/479958/how-to-fix-failed-to-prepare-sql-error-when-creating-gpkg-file-from-osm-extrac/479964#479964
+        // and random (frequent) failures on GDAL CI (https://github.com/OSGeo/gdal/commit/a83942422fd67471aee23ae11c5d06af27db2857)
+#if defined(__arm64__) && defined(__APPLE__)
+                                           "NO"
+#else
+                                           "YES"
+#endif
+                                           ));
 
         // For unit tests
         if (CPLTestBool(CPLGetConfigOption(


### PR DESCRIPTION
Workaround for https://gis.stackexchange.com/questions/479958/how-to-fix-failed-to-prepare-sql-error-when-creating-gpkg-file-from-osm-extrac/479964#479964 / https://lists.osgeo.org/pipermail/gdal-dev/2024-April/058840.html

For a not yet understood reason, threaded RTree building (randomly?) fails on OSX Arm64. This may not be at all specific to that platform, but a more general problem, but it can't be reproduced elsewhere. Cf https://gis.stackexchange.com/questions/479958/how-to-fix-failed-to-prepare-sql-error-when-creating-gpkg-file-from-osm-extrac/479964#479964 and random (frequent) failures on GDAL CI (https://github.com/OSGeo/gdal/commit/a83942422fd67471aee23ae11c5d06af27db2857)
