### PR TITLE
Add recommendation for finding older GDAL using CMake

### DIFF
--- a/doc/source/development/cmake.rst
+++ b/doc/source/development/cmake.rst
@@ -29,6 +29,7 @@ particular, CMake will consult (and set) the cache variable
 Before GDAL 3.5, you can use the following to create the imported library target ``GDAL::GDAL``:
 
 .. code::
+
     find_package(GDAL CONFIG QUIET)
     if(NOT TARGET GDAL::GDAL)
         find_package(GDAL REQUIRED)

--- a/doc/source/development/cmake.rst
+++ b/doc/source/development/cmake.rst
@@ -6,7 +6,7 @@ Using GDAL in CMake projects
 
 .. versionadded:: 3.5
 
-The recommended way to use the GDAL library in a CMake project is to
+The recommended way to use the GDAL library 3.5 or higher in a CMake project is to
 link to the imported library target ``GDAL::GDAL`` provided by
 the CMake configuration which comes with the library. Typical usage is:
 
@@ -25,3 +25,22 @@ number of places. The lookup can be adjusted for all packages by setting
 the cache variable or environment variable ``CMAKE_PREFIX_PATH``. In
 particular, CMake will consult (and set) the cache variable
 ``GDAL_DIR``.
+
+Before GDAL 3.5, you can use the following to create the imported library target ``GDAL::GDAL``:
+
+.. code::
+    find_package(GDAL CONFIG QUIET)
+    if(NOT TARGET GDAL::GDAL)
+        find_package(GDAL REQUIRED)
+        if(NOT TARGET GDAL::GDAL)
+            add_library(GDAL IMPORTED)
+            if(DEFINED GDAL_LIBRARIES)
+                target_link_libraries(GDAL INTERFACE "${GDAL_LIBRARIES}")
+                add_library(GDAL::GDAL ALIAS GDAL)
+            else()
+                message(FATAL_ERROR "Missing GDAL_LIBRARIES")
+            endif()
+        endif()
+    endif()
+
+    target_link_libraries(MyApp PRIVATE GDAL::GDAL)


### PR DESCRIPTION

## What does this PR do?

* This adds a recommendation on how to find GDAL on Ubuntu 22 which is distributed with GDALL 3.4.

## What are related issues/pull requests?

n/A

## Tasklist

 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

* OS: Ubuntu 22 with GDAL 3.4 installed as binaries.
* Compiler: G++11.4
