### PR TITLE
Fix/suppress Coverity Scan warnings about locking

### DIFF
--- a/alg/gdalgrid.cpp
+++ b/alg/gdalgrid.cpp
@@ -2602,6 +2602,7 @@ static int GDALGridProgressMultiThread(GDALGridJob *psJob)
 static int GDALGridProgressMonoThread(GDALGridJob *psJob)
 {
     const int nCounter = ++(*psJob->pnCounter);
+    // coverity[missing_lock]
     if (!psJob->pfnRealProgress(nCounter / static_cast<double>(psJob->nYSize),
                                 "", psJob->pRealProgressArg))
     {

--- a/alg/gdalwarpkernel.cpp
+++ b/alg/gdalwarpkernel.cpp
@@ -275,6 +275,7 @@ static int GWKProgressThread(GWKJobStruct *psJob)
 static int GWKProgressMonoThread(GWKJobStruct *psJob)
 {
     GDALWarpKernel *poWK = psJob->poWK;
+    // coverity[missing_lock]
     if (!poWK->pfnProgress(
             poWK->dfProgressBase +
                 poWK->dfProgressScale *

--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -4616,6 +4616,7 @@ TEST_F(test_cpl, CPLWorkerThreadPool_recursion)
                 // takes sufficiently long that job 2 has been submitted
                 // before it completes
                 std::unique_lock<std::mutex> guard(psData2->psCtxt->mutex);
+                // coverity[missing_lock:FALSE]
                 while (!psData2->psCtxt->you_can_leave)
                 {
                     psData2->psCtxt->cv.wait(guard);

--- a/frmts/gtiff/gtiffdataset.cpp
+++ b/frmts/gtiff/gtiffdataset.cpp
@@ -248,8 +248,6 @@ std::tuple<CPLErr, bool> GTiffDataset::Finalize()
                 CPLFree(m_asCompressionJobs[i].pszTmpFilename);
             }
         }
-        CPLDestroyMutex(m_hCompressThreadPoolMutex);
-        m_hCompressThreadPoolMutex = nullptr;
         m_poCompressQueue.reset();
     }
 

--- a/frmts/gtiff/gtiffdataset.h
+++ b/frmts/gtiff/gtiffdataset.h
@@ -32,6 +32,7 @@
 
 #include "gdal_pam.h"
 
+#include <mutex>
 #include <queue>
 
 #include "cpl_mem_cache.h"
@@ -164,7 +165,7 @@ class GTiffDataset final : public GDALPamDataset
     CPLVirtualMem *m_psVirtualMemIOMapping = nullptr;
     CPLWorkerThreadPool *m_poThreadPool = nullptr;
     std::unique_ptr<CPLJobQueue> m_poCompressQueue{};
-    CPLMutex *m_hCompressThreadPoolMutex = nullptr;
+    std::mutex m_oCompressThreadPoolMutex{};
 
     lru11::Cache<int, std::pair<vsi_l_offset, vsi_l_offset>>
         m_oCacheStrileToOffsetByteCount{1024};

--- a/frmts/gtiff/gtiffdataset_write.cpp
+++ b/frmts/gtiff/gtiffdataset_write.cpp
@@ -1262,7 +1262,11 @@ void GTiffDataset::WaitCompletionForJobIdx(int i)
     }
     asJobs[i].pabyCompressedBuffer = nullptr;
     asJobs[i].nBufferSize = 0;
-    asJobs[i].bReady = false;
+    {
+        // Likely useless, but makes Coverity happy
+        std::lock_guard oLock(mutex);
+        asJobs[i].bReady = false;
+    }
     asJobs[i].nStripOrTile = -1;
     oQueue.pop();
 }

--- a/frmts/gtiff/gtiffdataset_write.cpp
+++ b/frmts/gtiff/gtiffdataset_write.cpp
@@ -943,8 +943,6 @@ void GTiffDataset::InitCompressionThreads(bool bUpdateMode,
                                                  &m_asCompressionJobs[i]));
                         m_asCompressionJobs[i].nStripOrTile = -1;
                     }
-                    m_hCompressThreadPoolMutex = CPLCreateMutex();
-                    CPLReleaseMutex(m_hCompressThreadPoolMutex);
 
                     // This is kind of a hack, but basically using
                     // TIFFWriteRawStrip/Tile and then TIFFReadEncodedStrip/Tile
@@ -1053,13 +1051,11 @@ void GTiffDataset::ThreadCompressionFunc(void *pData)
         psJob->nCompressedBufferSize = 0;
     }
 
-    auto mutex = poDS->m_poBaseDS ? poDS->m_poBaseDS->m_hCompressThreadPoolMutex
-                                  : poDS->m_hCompressThreadPoolMutex;
-    if (mutex)
+    auto poMainDS = poDS->m_poBaseDS ? poDS->m_poBaseDS : poDS;
+    if (poMainDS->m_poCompressQueue)
     {
-        CPLAcquireMutex(mutex, 1000.0);
+        std::lock_guard oLock(poMainDS->m_oCompressThreadPoolMutex);
         psJob->bReady = true;
-        CPLReleaseMutex(mutex);
     }
 }
 
@@ -1223,13 +1219,11 @@ void GTiffDataset::WriteRawStripOrTile(int nStripOrTile,
 
 void GTiffDataset::WaitCompletionForJobIdx(int i)
 {
-    auto poQueue = m_poBaseDS ? m_poBaseDS->m_poCompressQueue.get()
-                              : m_poCompressQueue.get();
-    auto &oQueue = m_poBaseDS ? m_poBaseDS->m_asQueueJobIdx : m_asQueueJobIdx;
-    auto &asJobs =
-        m_poBaseDS ? m_poBaseDS->m_asCompressionJobs : m_asCompressionJobs;
-    auto mutex = m_poBaseDS ? m_poBaseDS->m_hCompressThreadPoolMutex
-                            : m_hCompressThreadPoolMutex;
+    auto poMainDS = m_poBaseDS ? m_poBaseDS : this;
+    auto poQueue = poMainDS->m_poCompressQueue.get();
+    auto &oQueue = poMainDS->m_asQueueJobIdx;
+    auto &asJobs = poMainDS->m_asCompressionJobs;
+    auto &mutex = poMainDS->m_oCompressThreadPoolMutex;
 
     CPLAssert(i >= 0 && static_cast<size_t>(i) < asJobs.size());
     CPLAssert(asJobs[i].nStripOrTile >= 0);
@@ -1238,9 +1232,11 @@ void GTiffDataset::WaitCompletionForJobIdx(int i)
     bool bHasWarned = false;
     while (true)
     {
-        CPLAcquireMutex(mutex, 1000.0);
-        const bool bReady = asJobs[i].bReady;
-        CPLReleaseMutex(mutex);
+        bool bReady;
+        {
+            std::lock_guard oLock(mutex);
+            bReady = asJobs[i].bReady;
+        }
         if (!bReady)
         {
             if (!bHasWarned)
@@ -1395,9 +1391,9 @@ bool GTiffDataset::SubmitCompressionJob(int nStripOrTile, GByte *pabyData,
         return false;
     }
 
-    auto &oQueue = m_poBaseDS ? m_poBaseDS->m_asQueueJobIdx : m_asQueueJobIdx;
-    auto &asJobs =
-        m_poBaseDS ? m_poBaseDS->m_asCompressionJobs : m_asCompressionJobs;
+    auto poMainDS = m_poBaseDS ? m_poBaseDS : this;
+    auto &oQueue = poMainDS->m_asQueueJobIdx;
+    auto &asJobs = poMainDS->m_asCompressionJobs;
 
     int nNextCompressionJobAvail = -1;
 

--- a/gcore/overview.cpp
+++ b/gcore/overview.cpp
@@ -4535,6 +4535,7 @@ CPLErr GDALRegenerateOverviewsEx(GDALRasterBandH hSrcBand, int nOverviewCount,
         auto poOldestJob = jobList.front().get();
         {
             std::unique_lock<std::mutex> oGuard(poOldestJob->mutex);
+            // coverity[missing_lock:FALSE]
             while (!poOldestJob->bFinished)
             {
                 poOldestJob->cv.wait(oGuard);
@@ -5283,6 +5284,7 @@ CPLErr GDALRegenerateOverviewsMultiBand(
             auto poOldestJob = jobList.front().get();
             {
                 std::unique_lock<std::mutex> oGuard(poOldestJob->mutex);
+                // coverity[missing_lock:FALSE]
                 while (!poOldestJob->bFinished)
                 {
                     poOldestJob->cv.wait(oGuard);

--- a/port/cpl_multiproc.cpp
+++ b/port/cpl_multiproc.cpp
@@ -218,15 +218,23 @@ CPLMutexHolder::CPLMutexHolder(CPLMutex * /* hMutexIn */,
 {
 }
 #else
-CPLMutexHolder::CPLMutexHolder(CPLMutex *hMutexIn, double dfWaitInSeconds,
-                               const char *pszFileIn, int nLineIn)
-    : hMutex(hMutexIn), pszFile(pszFileIn), nLine(nLineIn)
+
+static CPLMutex *GetMutexHolderMutexMember(CPLMutex *hMutexIn,
+                                           double dfWaitInSeconds)
 {
-    if (hMutex != nullptr && !CPLAcquireMutex(hMutex, dfWaitInSeconds))
+    if (hMutexIn && !CPLAcquireMutex(hMutexIn, dfWaitInSeconds))
     {
         fprintf(stderr, "CPLMutexHolder: Failed to acquire mutex!\n");
-        hMutex = nullptr;
+        return nullptr;
     }
+    return hMutexIn;
+}
+
+CPLMutexHolder::CPLMutexHolder(CPLMutex *hMutexIn, double dfWaitInSeconds,
+                               const char *pszFileIn, int nLineIn)
+    : hMutex(GetMutexHolderMutexMember(hMutexIn, dfWaitInSeconds)),
+      pszFile(pszFileIn), nLine(nLineIn)
+{
 }
 #endif  // ndef MUTEX_NONE
 

--- a/port/cpl_multiproc.cpp
+++ b/port/cpl_multiproc.cpp
@@ -2587,6 +2587,7 @@ void CPLReleaseLock(CPLLock *psLock)
     if (psLock->bDebugPerf && CPLAtomicDec(&(psLock->nCurrentHolders)) == 0)
     {
         const GUIntBig nStopTime = CPLrdtscp();
+        // coverity[missing_lock:FALSE]
         const GIntBig nDiffTime =
             static_cast<GIntBig>(nStopTime - psLock->nStartTime);
         if (nDiffTime > psLock->nMaxDiff)

--- a/port/cpl_vsi_mem.cpp
+++ b/port/cpl_vsi_mem.cpp
@@ -505,6 +505,7 @@ size_t VSIMemHandle::Write(const void *pBuffer, size_t nSize, size_t nCount)
 int VSIMemHandle::Eof()
 
 {
+    CPL_SHARED_LOCK oLock(poFile->m_oMutex);
     return bEOF;
 }
 

--- a/port/cpl_vsil_curl.cpp
+++ b/port/cpl_vsil_curl.cpp
@@ -3000,6 +3000,7 @@ size_t VSICurlHandle::PRead(void *pBuffer, size_t nSize,
             {
                 {
                     std::unique_lock<std::mutex> oLock(poRange->oMutex);
+                    // coverity[missing_lock:FALSE]
                     while (!poRange->bDone)
                     {
                         poRange->oCV.wait(oLock);
@@ -3472,6 +3473,7 @@ void VSICurlHandle::AdviseRead(int nRanges, const vsi_l_offset *panOffsets,
 
         for (size_t i = 0; i < m_aoAdviseReadRanges.size(); ++i)
         {
+            // coverity[missing_lock]
             if (!m_aoAdviseReadRanges[i]->bDone)
             {
                 DealWithRequest(aHandles[i]);

--- a/port/cpl_vsil_gzip.cpp
+++ b/port/cpl_vsil_gzip.cpp
@@ -2331,10 +2331,12 @@ bool VSIGZipWriteHandleMT::ProcessCompletedJobs()
             {
                 apoFinishedJobs_.erase(iter);
 
+                const bool bIsSeqNumberExpectedZero =
+                    (nSeqNumberExpected_ == 0);
                 sMutex_.unlock();
 
                 const size_t nToWrite = psJob->sCompressedData_.size();
-                if (panSOZIPIndex_ && nSeqNumberExpected_ != 0 &&
+                if (panSOZIPIndex_ && !bIsSeqNumberExpectedZero &&
                     !psJob->pBuffer_->empty())
                 {
                     uint64_t nOffset = poBaseHandle_->Tell() - nStartOffset_;

--- a/port/cpl_worker_thread_pool.cpp
+++ b/port/cpl_worker_thread_pool.cpp
@@ -691,6 +691,7 @@ bool CPLJobQueue::SubmitJob(CPLThreadFunc pfnFunc, void *pData)
 void CPLJobQueue::WaitCompletion(int nMaxRemainingJobs)
 {
     std::unique_lock<std::mutex> oGuard(m_mutex);
+    // coverity[missing_lock:FALSE]
     while (m_nPendingJobs > nMaxRemainingJobs)
     {
         m_cv.wait(oGuard);


### PR DESCRIPTION
Most of those warnings are thought to be false positive, or about very minor issues