### PR TITLE
TileDB: migrate away from deprecated APIs

### DIFF
--- a/autotest/gdrivers/tiledb_multidim.py
+++ b/autotest/gdrivers/tiledb_multidim.py
@@ -38,18 +38,7 @@ import pytest
 
 from osgeo import gdal, osr
 
-
-def has_tiledb_multidim():
-    drv = gdal.GetDriverByName("TileDB")
-    if drv is None:
-        return False
-    return drv.GetMetadataItem(gdal.DCAP_CREATE_MULTIDIMENSIONAL) == "YES"
-
-
-pytestmark = [
-    pytest.mark.require_driver("TileDB"),
-    pytest.mark.skipif(not has_tiledb_multidim(), reason="TileDB >= 2.15 required"),
-]
+pytestmark = pytest.mark.require_driver("TileDB")
 
 
 def test_tiledb_multidim_basic():

--- a/autotest/ogr/ogr_tiledb.py
+++ b/autotest/ogr/ogr_tiledb.py
@@ -1029,11 +1029,6 @@ def test_ogr_tiledb_switch_between_read_and_write():
 
 def test_ogr_tiledb_create_group():
 
-    if "CREATE_GROUP" not in gdal.GetDriverByName("TileDB").GetMetadataItem(
-        gdal.DMD_CREATIONOPTIONLIST
-    ):
-        pytest.skip("CREATE_GROUP not supported in TileDB < 2.9")
-
     if os.path.exists("tmp/test.tiledb"):
         shutil.rmtree("tmp/test.tiledb")
 

--- a/autotest/ogr/ogr_tiledb.py
+++ b/autotest/ogr/ogr_tiledb.py
@@ -45,7 +45,7 @@ pytestmark = pytest.mark.require_driver("TileDB")
 ###############################################################################
 
 
-def create_tiledb_dataset(nullable, batch_size, include_bool, extra_feature=False):
+def create_tiledb_dataset(nullable, batch_size, extra_feature=False):
 
     ds = ogr.GetDriverByName("TileDB").CreateDataSource("tmp/test.tiledb")
     srs = osr.SpatialReference()
@@ -79,11 +79,10 @@ def create_tiledb_dataset(nullable, batch_size, include_bool, extra_feature=Fals
     with gdal.config_option("TILEDB_INT_TYPE", "UINT16"):
         lyr.CreateField(fld_defn)
 
-    if include_bool:
-        fld_defn = ogr.FieldDefn("boolfield", ogr.OFTInteger)
-        fld_defn.SetNullable(nullable)
-        fld_defn.SetSubType(ogr.OFSTBoolean)
-        lyr.CreateField(fld_defn)
+    fld_defn = ogr.FieldDefn("boolfield", ogr.OFTInteger)
+    fld_defn.SetNullable(nullable)
+    fld_defn.SetSubType(ogr.OFSTBoolean)
+    lyr.CreateField(fld_defn)
 
     fld_defn = ogr.FieldDefn("int64field", ogr.OFTInteger64)
     fld_defn.SetNullable(nullable)
@@ -111,11 +110,10 @@ def create_tiledb_dataset(nullable, batch_size, include_bool, extra_feature=Fals
     fld_defn.SetSubType(ogr.OFSTInt16)
     lyr.CreateField(fld_defn)
 
-    if include_bool:
-        fld_defn = ogr.FieldDefn("boollistfield", ogr.OFTIntegerList)
-        fld_defn.SetNullable(nullable)
-        fld_defn.SetSubType(ogr.OFSTBoolean)
-        lyr.CreateField(fld_defn)
+    fld_defn = ogr.FieldDefn("boollistfield", ogr.OFTIntegerList)
+    fld_defn.SetNullable(nullable)
+    fld_defn.SetSubType(ogr.OFSTBoolean)
+    lyr.CreateField(fld_defn)
 
     fld_defn = ogr.FieldDefn("doublelistfield", ogr.OFTRealList)
     fld_defn.SetNullable(nullable)
@@ -148,8 +146,7 @@ def create_tiledb_dataset(nullable, batch_size, include_bool, extra_feature=Fals
     f["strfield"] = "foo"
     f["intfield"] = -123456789
     f["int16field"] = -32768
-    if include_bool:
-        f["boolfield"] = True
+    f["boolfield"] = True
     f["uint8field"] = 0
     f["uint16field"] = 0
     f["int64field"] = -1234567890123456
@@ -158,8 +155,7 @@ def create_tiledb_dataset(nullable, batch_size, include_bool, extra_feature=Fals
     f["binaryfield"] = b"\xDE\xAD\xBE\xEF"
     f["intlistfield"] = [-123456789, 123]
     f["int16listfield"] = [-32768, 32767]
-    if include_bool:
-        f["boollistfield"] = [True, False]
+    f["boollistfield"] = [True, False]
     f["doublelistfield"] = [1.2345, -1.2345]
     f["floatlistfield"] = [1.5, -1.5, 0]
     f["datetimefield"] = "2023-04-07T12:34:56.789Z"
@@ -184,8 +180,7 @@ def create_tiledb_dataset(nullable, batch_size, include_bool, extra_feature=Fals
     f["strfield"] = "barbaz"
     f["intfield"] = 123456789
     f["int16field"] = 32767
-    if include_bool:
-        f["boolfield"] = False
+    f["boolfield"] = False
     f["uint8field"] = 255
     f["uint16field"] = 65535
     f["int64field"] = 1234567890123456
@@ -194,8 +189,7 @@ def create_tiledb_dataset(nullable, batch_size, include_bool, extra_feature=Fals
     f["binaryfield"] = b"\xBE\xEF\xDE\xAD"
     f["intlistfield"] = [123456789, -123]
     f["int16listfield"] = [32767, -32768]
-    if include_bool:
-        f["boollistfield"] = [False, True]
+    f["boollistfield"] = [False, True]
     f["doublelistfield"] = [-1.2345, 1.2345]
     f["floatlistfield"] = [0.0, -1.5, 1.5]
     # Will be transformed to "2023/04/07 10:19:56.789+00"
@@ -212,8 +206,7 @@ def create_tiledb_dataset(nullable, batch_size, include_bool, extra_feature=Fals
         f["strfield"] = "something"
         f["intfield"] = 8765432
         f["int16field"] = 32767
-        if include_bool:
-            f["boolfield"] = False
+        f["boolfield"] = False
         f["uint8field"] = 255
         f["uint16field"] = 65535
         f["int64field"] = 9876543210123456
@@ -222,8 +215,7 @@ def create_tiledb_dataset(nullable, batch_size, include_bool, extra_feature=Fals
         f["binaryfield"] = b"\xDE\xAD\xBE\xEF"
         f["intlistfield"] = [-123456789, -123]
         f["int16listfield"] = [32767, -32768]
-        if include_bool:
-            f["boollistfield"] = [False, True]
+        f["boollistfield"] = [False, True]
         f["doublelistfield"] = [-1.2345, 1.2345]
         f["floatlistfield"] = [0.0, -1.5, 1.5]
         # Will be transformed to "2023/04/07 10:19:56.789+00"
@@ -248,7 +240,7 @@ def test_ogr_tiledb_basic(nullable, batch_size):
     if os.path.exists("tmp/test.tiledb"):
         shutil.rmtree("tmp/test.tiledb")
 
-    field_count, srs, options = create_tiledb_dataset(nullable, batch_size, True)
+    field_count, srs, options = create_tiledb_dataset(nullable, batch_size)
 
     ds = gdal.OpenEx("tmp/test.tiledb", open_options=options)
     lyr = ds.GetLayer(0)
@@ -1132,10 +1124,7 @@ def test_ogr_tiledb_arrow_stream_pyarrow(nullable, batch_size):
     if os.path.exists("tmp/test.tiledb"):
         shutil.rmtree("tmp/test.tiledb")
 
-    include_bool = "Boolean" in gdal.GetDriverByName("TileDB").GetMetadataItem(
-        gdal.DMD_CREATIONFIELDDATASUBTYPES
-    )
-    _, _, options = create_tiledb_dataset(nullable, batch_size, include_bool)
+    _, _, options = create_tiledb_dataset(nullable, batch_size)
 
     ds = gdal.OpenEx("tmp/test.tiledb", open_options=options)
     lyr = ds.GetLayer(0)
@@ -1173,11 +1162,10 @@ def test_ogr_tiledb_arrow_stream_pyarrow(nullable, batch_size):
             ("timefield", "time32[ms]"),
             ("intfieldextra", "int32"),
             ("wkb_geometry", "large_binary"),
+            ("boolfield", "bool"),
+            ("boollistfield", "large_list<item: bool not null>"),
         ]
     )
-    if include_bool:
-        expected_fields.add(("boolfield", "bool"))
-        expected_fields.add(("boollistfield", "large_list<item: bool not null>"))
     assert fields == expected_fields
 
     def check_batch(batch):
@@ -1243,10 +1231,7 @@ def test_ogr_tiledb_arrow_stream_numpy(nullable, batch_size):
     if os.path.exists("tmp/test.tiledb"):
         shutil.rmtree("tmp/test.tiledb")
 
-    include_bool = True
-    _, _, options = create_tiledb_dataset(
-        nullable, batch_size, include_bool, extra_feature=True
-    )
+    _, _, options = create_tiledb_dataset(nullable, batch_size, extra_feature=True)
 
     ds = gdal.OpenEx("tmp/test.tiledb", open_options=options)
     lyr = ds.GetLayer(0)
@@ -1342,10 +1327,9 @@ def test_ogr_tiledb_arrow_stream_numpy(nullable, batch_size):
             "timefield",
             "intfieldextra",
             "wkb_geometry",
+            "boolfield",
+            "boollistfield",
         }
-        if include_bool:
-            expected_fields.add("boolfield")
-            expected_fields.add("boollistfield")
         assert batch.keys() == expected_fields
 
         check_batch(batch)

--- a/autotest/ogr/ogr_tiledb.py
+++ b/autotest/ogr/ogr_tiledb.py
@@ -578,38 +578,33 @@ def test_ogr_tiledb_basic(nullable, batch_size):
     assert set(f.GetFID() for f in lyr) == set([1])
 
     # Test OR
-    has_working_or_filter = (
-        gdal.GetDriverByName("TileDB").GetMetadataItem("HAS_TILEDB_WORKING_OR_FILTER")
-        != "NO"
-    )
-    if has_working_or_filter:
-        lyr.SetAttributeFilter("intfield = 321 OR intfield = -123456789")
-        assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
-        assert set(f.GetFID() for f in lyr) == set([1])
+    lyr.SetAttributeFilter("intfield = 321 OR intfield = -123456789")
+    assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
+    assert set(f.GetFID() for f in lyr) == set([1])
 
-        lyr.SetAttributeFilter("intfield = -123456789 OR intfield = 321")
-        assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
-        assert set(f.GetFID() for f in lyr) == set([1])
+    lyr.SetAttributeFilter("intfield = -123456789 OR intfield = 321")
+    assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
+    assert set(f.GetFID() for f in lyr) == set([1])
 
-        lyr.SetAttributeFilter("intfield = 321 OR intfield = 123")
-        assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
-        assert set(f.GetFID() for f in lyr) == set([])
+    lyr.SetAttributeFilter("intfield = 321 OR intfield = 123")
+    assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
+    assert set(f.GetFID() for f in lyr) == set([])
 
-        lyr.SetAttributeFilter("(1 = 1) OR intfield = -123456789")
-        assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "NONE"
-        assert set(f.GetFID() for f in lyr) == set([1, 2, 3])
+    lyr.SetAttributeFilter("(1 = 1) OR intfield = -123456789")
+    assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "NONE"
+    assert set(f.GetFID() for f in lyr) == set([1, 2, 3])
 
-        lyr.SetAttributeFilter("(1 = 0) OR intfield = -123456789")
-        assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "NONE"
-        assert set(f.GetFID() for f in lyr) == set([1])
+    lyr.SetAttributeFilter("(1 = 0) OR intfield = -123456789")
+    assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "NONE"
+    assert set(f.GetFID() for f in lyr) == set([1])
 
-        lyr.SetAttributeFilter("intfield = -123456789 OR (1 = 1)")
-        assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "NONE"
-        assert set(f.GetFID() for f in lyr) == set([1, 2, 3])
+    lyr.SetAttributeFilter("intfield = -123456789 OR (1 = 1)")
+    assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "NONE"
+    assert set(f.GetFID() for f in lyr) == set([1, 2, 3])
 
-        lyr.SetAttributeFilter("intfield = -123456789 OR (1 = 0)")
-        assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "NONE"
-        assert set(f.GetFID() for f in lyr) == set([1])
+    lyr.SetAttributeFilter("intfield = -123456789 OR (1 = 0)")
+    assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "NONE"
+    assert set(f.GetFID() for f in lyr) == set([1])
 
     # Test NOT
     lyr.SetAttributeFilter("NOT (intfield = -123456789)")
@@ -617,14 +612,13 @@ def test_ogr_tiledb_basic(nullable, batch_size):
     assert set(f.GetFID() for f in lyr) == (set([3]) if nullable else set([2, 3]))
 
     # Test IN
-    if has_working_or_filter:
-        lyr.SetAttributeFilter("intfield IN (321, -123456789)")
-        assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
-        assert set(f.GetFID() for f in lyr) == set([1])
+    lyr.SetAttributeFilter("intfield IN (321, -123456789)")
+    assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
+    assert set(f.GetFID() for f in lyr) == set([1])
 
-        lyr.SetAttributeFilter("intfield IN (-123456789, 321)")
-        assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
-        assert set(f.GetFID() for f in lyr) == set([1])
+    lyr.SetAttributeFilter("intfield IN (-123456789, 321)")
+    assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
+    assert set(f.GetFID() for f in lyr) == set([1])
 
     # Test IS NULL / IS NOT NULL
     lyr.SetAttributeFilter("strfield IS NULL")
@@ -688,54 +682,46 @@ def test_ogr_tiledb_basic(nullable, batch_size):
     assert set(f.GetFID() for f in lyr) == set()
 
     # Test IS NULL and OR (for always_false situations)
-    if has_working_or_filter:
-        lyr.SetAttributeFilter("intfield IS NULL OR intfieldextra <> 4")
-        assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
-        assert set(f.GetFID() for f in lyr) == set([1, 2, 3])
+    lyr.SetAttributeFilter("intfield IS NULL OR intfieldextra <> 4")
+    assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
+    assert set(f.GetFID() for f in lyr) == set([1, 2, 3])
 
-        lyr.SetAttributeFilter("intfield IS NULL OR intfield IS NULL")
-        assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
-        assert set(f.GetFID() for f in lyr) == (set([2]) if nullable else set())
+    lyr.SetAttributeFilter("intfield IS NULL OR intfield IS NULL")
+    assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
+    assert set(f.GetFID() for f in lyr) == (set([2]) if nullable else set())
 
-        lyr.SetAttributeFilter("intfieldextra <> 4 OR intfield IS NULL")
-        assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
-        assert set(f.GetFID() for f in lyr) == set([1, 2, 3])
+    lyr.SetAttributeFilter("intfieldextra <> 4 OR intfield IS NULL")
+    assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
+    assert set(f.GetFID() for f in lyr) == set([1, 2, 3])
 
-        lyr.SetAttributeFilter("intfield IS NULL OR intfieldextra = 4")
-        assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
-        assert set(f.GetFID() for f in lyr) == (set([2]) if nullable else set())
+    lyr.SetAttributeFilter("intfield IS NULL OR intfieldextra = 4")
+    assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
+    assert set(f.GetFID() for f in lyr) == (set([2]) if nullable else set())
 
-        lyr.SetAttributeFilter("intfieldextra = 4 OR intfield IS NULL")
-        assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
-        assert set(f.GetFID() for f in lyr) == (set([2]) if nullable else set())
+    lyr.SetAttributeFilter("intfieldextra = 4 OR intfield IS NULL")
+    assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
+    assert set(f.GetFID() for f in lyr) == (set([2]) if nullable else set())
 
     # Test IS NOT NULL and OR (for always_true situations)
-    if has_working_or_filter:
-        lyr.SetAttributeFilter("intfield IS NOT NULL OR intfieldextra <> 4")
-        assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
-        assert set(f.GetFID() for f in lyr) == set([1, 2, 3])
+    lyr.SetAttributeFilter("intfield IS NOT NULL OR intfieldextra <> 4")
+    assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
+    assert set(f.GetFID() for f in lyr) == set([1, 2, 3])
 
-        lyr.SetAttributeFilter("intfield IS NOT NULL OR intfield IS NOT NULL")
-        assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
-        assert set(f.GetFID() for f in lyr) == (
-            set([1, 3]) if nullable else set([1, 2, 3])
-        )
+    lyr.SetAttributeFilter("intfield IS NOT NULL OR intfield IS NOT NULL")
+    assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
+    assert set(f.GetFID() for f in lyr) == (set([1, 3]) if nullable else set([1, 2, 3]))
 
-        lyr.SetAttributeFilter("intfieldextra <> 4 OR intfield IS NOT NULL")
-        assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
-        assert set(f.GetFID() for f in lyr) == set([1, 2, 3])
+    lyr.SetAttributeFilter("intfieldextra <> 4 OR intfield IS NOT NULL")
+    assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
+    assert set(f.GetFID() for f in lyr) == set([1, 2, 3])
 
-        lyr.SetAttributeFilter("intfield IS NOT NULL OR intfieldextra = 4")
-        assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
-        assert set(f.GetFID() for f in lyr) == (
-            set([1, 3]) if nullable else set([1, 2, 3])
-        )
+    lyr.SetAttributeFilter("intfield IS NOT NULL OR intfieldextra = 4")
+    assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
+    assert set(f.GetFID() for f in lyr) == (set([1, 3]) if nullable else set([1, 2, 3]))
 
-        lyr.SetAttributeFilter("intfieldextra = 4 OR intfield IS NOT NULL")
-        assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
-        assert set(f.GetFID() for f in lyr) == (
-            set([1, 3]) if nullable else set([1, 2, 3])
-        )
+    lyr.SetAttributeFilter("intfieldextra = 4 OR intfield IS NOT NULL")
+    assert lyr.GetMetadataItem("ATTRIBUTE_FILTER_TRANSLATION", "_DEBUG_") == "WHOLE"
+    assert set(f.GetFID() for f in lyr) == (set([1, 3]) if nullable else set([1, 2, 3]))
 
     tiledb_md = json.loads(lyr.GetMetadata_List("json:TILEDB")[0])
     md = tiledb_md["array"]["metadata"]

--- a/cmake/helpers/CheckDependentLibraries.cmake
+++ b/cmake/helpers/CheckDependentLibraries.cmake
@@ -751,7 +751,7 @@ gdal_check_package(Crnlib "enable gdal_DDS driver" CAN_DISABLE)
 gdal_check_package(basisu "Enable BASISU driver" CONFIG CAN_DISABLE)
 gdal_check_package(IDB "enable ogr_IDB driver" CAN_DISABLE)
 gdal_check_package(rdb "enable RIEGL RDB library" CONFIG CAN_DISABLE)
-gdal_check_package(TileDB "enable TileDB driver" CONFIG CAN_DISABLE VERSION "2.7")
+gdal_check_package(TileDB "enable TileDB driver" CONFIG CAN_DISABLE VERSION "2.15")
 
 gdal_check_package(OpenEXR "OpenEXR >=2.2" CAN_DISABLE)
 gdal_check_package(MONGOCXX "Enable MongoDBV3 driver" CAN_DISABLE)

--- a/doc/source/development/building_from_source.rst
+++ b/doc/source/development/building_from_source.rst
@@ -1907,6 +1907,8 @@ TileDB
 The `TileDB <https://github.com/TileDB-Inc/TileDB>` library is required for the :ref:`raster.tiledb` driver.
 Specify install prefix in the ``CMAKE_PREFIX_PATH`` variable.
 
+TileDB >= 2.15 is required since GDAL 3.9
+
 .. option:: GDAL_USE_TILEDB=ON/OFF
 
     Control whether to use TileDB. Defaults to ON when TileDB is found.

--- a/frmts/tiledb/CMakeLists.txt
+++ b/frmts/tiledb/CMakeLists.txt
@@ -25,5 +25,4 @@ endif()
 gdal_standard_includes(gdal_TileDB)
 target_include_directories(gdal_TileDB PRIVATE
                            ${GDAL_RASTER_FORMAT_SOURCE_DIR}/mem)
-target_compile_definitions(gdal_TileDB PRIVATE -DTILEDB_DEPRECATED=)
 gdal_target_link_libraries(gdal_TileDB PRIVATE TileDB::tiledb_shared)

--- a/frmts/tiledb/include_tiledb.h
+++ b/frmts/tiledb/include_tiledb.h
@@ -43,11 +43,6 @@
 #endif
 
 #if TILEDB_VERSION_MAJOR > 2 ||                                                \
-    (TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 11)
-#define HAS_TILEDB_WORKING_OR_FILTER
-#endif
-
-#if TILEDB_VERSION_MAJOR > 2 ||                                                \
     (TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 14)
 #define HAS_TILEDB_WORKING_UTF8_STRING_FILTER
 #endif

--- a/frmts/tiledb/include_tiledb.h
+++ b/frmts/tiledb/include_tiledb.h
@@ -35,20 +35,11 @@
 #pragma GCC system_header
 #endif
 
-#ifdef _MSC_VER
-#pragma warning(push)
-#pragma warning(disable : 4996) /* XXXX was deprecated */
-#endif
-
 #ifdef INCLUDE_ONLY_TILEDB_VERSION
 #include "tiledb/tiledb_version.h"
 #else
 #include "tiledb/tiledb"
 #include "tiledb/tiledb_experimental"
-#endif
-
-#ifdef _MSC_VER
-#pragma warning(pop)
 #endif
 
 #if TILEDB_VERSION_MAJOR > 2 ||                                                \

--- a/frmts/tiledb/include_tiledb.h
+++ b/frmts/tiledb/include_tiledb.h
@@ -43,11 +43,6 @@
 #endif
 
 #if TILEDB_VERSION_MAJOR > 2 ||                                                \
-    (TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 10)
-#define HAS_TILEDB_BOOL
-#endif
-
-#if TILEDB_VERSION_MAJOR > 2 ||                                                \
     (TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 11)
 #define HAS_TILEDB_WORKING_OR_FILTER
 #endif

--- a/frmts/tiledb/include_tiledb.h
+++ b/frmts/tiledb/include_tiledb.h
@@ -43,11 +43,6 @@
 #endif
 
 #if TILEDB_VERSION_MAJOR > 2 ||                                                \
-    (TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 9)
-#define HAS_TILEDB_GROUP
-#endif
-
-#if TILEDB_VERSION_MAJOR > 2 ||                                                \
     (TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 10)
 #define HAS_TILEDB_BOOL
 #endif

--- a/frmts/tiledb/include_tiledb.h
+++ b/frmts/tiledb/include_tiledb.h
@@ -43,11 +43,6 @@
 #endif
 
 #if TILEDB_VERSION_MAJOR > 2 ||                                                \
-    (TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 14)
-#define HAS_TILEDB_WORKING_UTF8_STRING_FILTER
-#endif
-
-#if TILEDB_VERSION_MAJOR > 2 ||                                                \
     (TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 15)
 #define HAS_TILEDB_DIMENSION_LABEL
 #endif

--- a/frmts/tiledb/include_tiledb.h
+++ b/frmts/tiledb/include_tiledb.h
@@ -43,15 +43,6 @@
 #endif
 
 #if TILEDB_VERSION_MAJOR > 2 ||                                                \
-    (TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 15)
-#define HAS_TILEDB_DIMENSION_LABEL
-#endif
-
-#ifdef HAS_TILEDB_DIMENSION_LABEL
-#define HAS_TILEDB_MULTIDIM
-#endif
-
-#if TILEDB_VERSION_MAJOR > 2 ||                                                \
     (TILEDB_VERSION_MAJOR == 2 && TILEDB_VERSION_MINOR >= 21)
 #define HAS_TILEDB_GEOM_WKB_WKT
 #endif

--- a/frmts/tiledb/tiledbcommon.cpp
+++ b/frmts/tiledb/tiledbcommon.cpp
@@ -150,14 +150,12 @@ int TileDBDataset::Identify(GDALOpenInfo *poOpenInfo)
             CPLString osArrayPath =
                 TileDBDataset::VSI_to_tiledb_uri(poOpenInfo->pszFilename);
             const auto eType = tiledb::Object::object(ctx, osArrayPath).type();
-#ifdef HAS_TILEDB_GROUP
             if ((poOpenInfo->nOpenFlags & GDAL_OF_VECTOR) != 0)
             {
                 if (eType == tiledb::Object::Type::Array ||
                     eType == tiledb::Object::Type::Group)
                     return true;
             }
-#endif
 #ifdef HAS_TILEDB_MULTIDIM
             if ((poOpenInfo->nOpenFlags & GDAL_OF_MULTIDIM_RASTER) != 0)
             {
@@ -259,7 +257,6 @@ GDALDataset *TileDBDataset::Open(GDALOpenInfo *poOpenInfo)
                 TileDBDataset::VSI_to_tiledb_uri(poOpenInfo->pszFilename);
 
             const auto eType = tiledb::Object::object(oCtx, osPath).type();
-#ifdef HAS_TILEDB_GROUP
             if ((poOpenInfo->nOpenFlags & GDAL_OF_VECTOR) != 0 &&
                 eType == tiledb::Object::Type::Group)
             {
@@ -314,7 +311,6 @@ GDALDataset *TileDBDataset::Open(GDALOpenInfo *poOpenInfo)
                 }
                 return nullptr;
             }
-#endif
 #endif
 
             tiledb::ArraySchema schema(oCtx, osPath);

--- a/frmts/tiledb/tiledbcommon.cpp
+++ b/frmts/tiledb/tiledbcommon.cpp
@@ -156,20 +156,17 @@ int TileDBDataset::Identify(GDALOpenInfo *poOpenInfo)
                     eType == tiledb::Object::Type::Group)
                     return true;
             }
-#ifdef HAS_TILEDB_MULTIDIM
+
             if ((poOpenInfo->nOpenFlags & GDAL_OF_MULTIDIM_RASTER) != 0)
             {
                 if (eType == tiledb::Object::Type::Array ||
                     eType == tiledb::Object::Type::Group)
                     return true;
             }
-#endif
             if ((poOpenInfo->nOpenFlags & GDAL_OF_RASTER) != 0)
             {
-#ifdef HAS_TILEDB_MULTIDIM
                 if (eType == tiledb::Object::Type::Group)
                     return GDAL_IDENTIFY_UNKNOWN;
-#endif
                 return eType == tiledb::Object::Type::Array;
             }
         }
@@ -231,12 +228,10 @@ GDALDataset *TileDBDataset::Open(GDALOpenInfo *poOpenInfo)
         }
         else
         {
-#ifdef HAS_TILEDB_MULTIDIM
             if ((poOpenInfo->nOpenFlags & GDAL_OF_MULTIDIM_RASTER) != 0)
             {
                 return TileDBDataset::OpenMultiDimensional(poOpenInfo);
             }
-#endif
 
             const char *pszConfig = CSLFetchNameValue(
                 poOpenInfo->papszOpenOptions, "TILEDB_CONFIG");
@@ -262,7 +257,6 @@ GDALDataset *TileDBDataset::Open(GDALOpenInfo *poOpenInfo)
             {
                 return OGRTileDBDataset::Open(poOpenInfo, eType);
             }
-#ifdef HAS_TILEDB_MULTIDIM
             else if ((poOpenInfo->nOpenFlags & GDAL_OF_RASTER) != 0 &&
                      eType == tiledb::Object::Type::Group)
             {
@@ -311,7 +305,6 @@ GDALDataset *TileDBDataset::Open(GDALOpenInfo *poOpenInfo)
                 }
                 return nullptr;
             }
-#endif
 
             tiledb::ArraySchema schema(oCtx, osPath);
 
@@ -364,7 +357,6 @@ GDALDataset *TileDBDataset::CreateCopy(const char *pszFilename,
                                        void *pProgressData)
 
 {
-#ifdef HAS_TILEDB_MULTIDIM
     if (poSrcDS->GetRootGroup())
     {
         auto poDrv = GDALDriver::FromHandle(GDALGetDriverByName("TileDB"));
@@ -375,7 +367,6 @@ GDALDataset *TileDBDataset::CreateCopy(const char *pszFilename,
                                             pProgressData);
         }
     }
-#endif
 
     try
     {
@@ -413,9 +404,7 @@ void GDALRegister_TileDB()
     poDriver->pfnCreate = TileDBDataset::Create;
     poDriver->pfnCreateCopy = TileDBDataset::CreateCopy;
     poDriver->pfnDelete = TileDBDataset::Delete;
-#ifdef HAS_TILEDB_MULTIDIM
     poDriver->pfnCreateMultiDimensional = TileDBDataset::CreateMultiDimensional;
-#endif
 
     GetGDALDriverManager()->RegisterDriver(poDriver);
 }

--- a/frmts/tiledb/tiledbdense.cpp
+++ b/frmts/tiledb/tiledbdense.cpp
@@ -31,12 +31,6 @@
 
 #include "tiledbheaders.h"
 
-#ifdef _MSC_VER
-#pragma warning(push)
-// 'tiledb::Array::Array': was declared deprecated
-#pragma warning(disable : 4996) /* XXXX was deprecated */
-#endif
-
 constexpr const char *RASTER_DATASET_TYPE = "raster";
 
 /************************************************************************/
@@ -2412,7 +2406,3 @@ GDALDataset *TileDBRasterDataset::CreateCopy(const char *pszFilename,
     }
     return nullptr;
 }
-
-#ifdef _MSC_VER
-#pragma warning(pop)
-#endif

--- a/frmts/tiledb/tiledbdrivercore.cpp
+++ b/frmts/tiledb/tiledbdrivercore.cpp
@@ -228,7 +228,6 @@ void TileDBDriverSetCommonMetadata(GDALDriver *poDriver)
         "</LayerCreationOptionList>");
     // clang-format on
 
-#ifdef HAS_TILEDB_MULTIDIM
     poDriver->SetMetadataItem(GDAL_DCAP_MULTIDIM_RASTER, "YES");
     poDriver->SetMetadataItem(GDAL_DCAP_CREATE_MULTIDIMENSIONAL, "YES");
 
@@ -276,7 +275,6 @@ void TileDBDriverSetCommonMetadata(GDALDriver *poDriver)
         "description='Whether the array should be only in-memory. Useful to "
         "create an indexing variable that is serialized as a dimension label'/>"
         "</MultiDimArrayCreationOptionList>");
-#endif
 
     poDriver->pfnIdentify = TileDBDriverIdentifySimplified;
     poDriver->SetMetadataItem(GDAL_DCAP_OPEN, "YES");

--- a/frmts/tiledb/tiledbdrivercore.cpp
+++ b/frmts/tiledb/tiledbdrivercore.cpp
@@ -102,12 +102,7 @@ void TileDBDriverSetCommonMetadata(GDALDriver *poDriver)
         "Integer Integer64 Real String Date Time DateTime "
         "IntegerList Integer64List RealList Binary");
     poDriver->SetMetadataItem(GDAL_DMD_CREATIONFIELDDATASUBTYPES,
-#ifdef HAS_TILEDB_BOOL
-                              "Boolean Int16 Float32"
-#else
-                              "Int16 Float32"
-#endif
-    );
+                              "Boolean Int16 Float32");
     poDriver->SetMetadataItem(
         GDAL_DMD_CREATIONOPTIONLIST,
         "<CreationOptionList>\n"

--- a/frmts/tiledb/tiledbdrivercore.cpp
+++ b/frmts/tiledb/tiledbdrivercore.cpp
@@ -218,11 +218,7 @@ void TileDBDriverSetCommonMetadata(GDALDriver *poDriver)
         "array at this timestamp, the timestamp should be > 0'/>"
         "   <Option name='TILEDB_STRING_TYPE' type='string-select' "
         "description='Which TileDB type to create string attributes' "
-#ifdef HAS_TILEDB_WORKING_UTF8_STRING_FILTER
        "default='UTF8'"
-#else
-       "default='ASCII'"
-#endif
         ">"
         "       <Value>UTF8</Value>"
         "       <Value>ASCII</Value>"
@@ -280,10 +276,6 @@ void TileDBDriverSetCommonMetadata(GDALDriver *poDriver)
         "description='Whether the array should be only in-memory. Useful to "
         "create an indexing variable that is serialized as a dimension label'/>"
         "</MultiDimArrayCreationOptionList>");
-#endif
-
-#if !defined(HAS_TILEDB_WORKING_UTF8_STRING_FILTER)
-    poDriver->SetMetadataItem("HAS_TILEDB_WORKING_UTF8_STRING_FILTER", "NO");
 #endif
 
     poDriver->pfnIdentify = TileDBDriverIdentifySimplified;

--- a/frmts/tiledb/tiledbdrivercore.cpp
+++ b/frmts/tiledb/tiledbdrivercore.cpp
@@ -149,11 +149,9 @@ void TileDBDriverSetCommonMetadata(GDALDriver *poDriver)
         "   <Option name='BOUNDS' scope='raster' type='string' "
         "description='Specify "
         "bounds for sparse array, minx, miny, maxx, maxy'/>\n"
-#ifdef HAS_TILEDB_GROUP
         "   <Option name='CREATE_GROUP' scope='vector' type='boolean' "
         "description='Whether to create a group for multiple layer support' "
         "default='NO'/>"
-#endif
         "</CreationOptionList>\n");
 
     // clang-format off

--- a/frmts/tiledb/tiledbdrivercore.cpp
+++ b/frmts/tiledb/tiledbdrivercore.cpp
@@ -286,10 +286,6 @@ void TileDBDriverSetCommonMetadata(GDALDriver *poDriver)
     poDriver->SetMetadataItem("HAS_TILEDB_WORKING_UTF8_STRING_FILTER", "NO");
 #endif
 
-#if !defined(HAS_TILEDB_WORKING_OR_FILTER)
-    poDriver->SetMetadataItem("HAS_TILEDB_WORKING_OR_FILTER", "NO");
-#endif
-
     poDriver->pfnIdentify = TileDBDriverIdentifySimplified;
     poDriver->SetMetadataItem(GDAL_DCAP_OPEN, "YES");
     poDriver->SetMetadataItem(GDAL_DCAP_CREATE, "YES");

--- a/frmts/tiledb/tiledbheaders.h
+++ b/frmts/tiledb/tiledbheaders.h
@@ -333,11 +333,7 @@ class OGRTileDBLayer final : public OGRLayer,
     uint64_t m_nRowCountInResultSet = 0;
     int m_nUseOptimizedAttributeFilter = -1;  // uninitialized
 
-#ifdef HAS_TILEDB_WORKING_UTF8_STRING_FILTER
     tiledb_datatype_t m_eTileDBStringType = TILEDB_STRING_UTF8;
-#else
-    tiledb_datatype_t m_eTileDBStringType = TILEDB_STRING_ASCII;
-#endif
 
     std::string m_osXDim = "_X";
     std::string m_osYDim = "_Y";

--- a/frmts/tiledb/tiledbheaders.h
+++ b/frmts/tiledb/tiledbheaders.h
@@ -190,13 +190,12 @@ class TileDBDataset : public GDALPamDataset
                                    char **papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
-#ifdef HAS_TILEDB_MULTIDIM
+
     static GDALDataset *OpenMultiDimensional(GDALOpenInfo *);
     static GDALDataset *
     CreateMultiDimensional(const char *pszFilename,
                            CSLConstList papszRootGroupOptions,
                            CSLConstList papszOptions);
-#endif
 };
 
 /************************************************************************/

--- a/frmts/tiledb/tiledbmultidim.cpp
+++ b/frmts/tiledb/tiledbmultidim.cpp
@@ -28,8 +28,6 @@
 
 #include "tiledbmultidim.h"
 
-#ifdef HAS_TILEDB_MULTIDIM
-
 /************************************************************************/
 /*              TileDBSingleArrayGroup::SanitizeNameForPath()           */
 /************************************************************************/
@@ -213,5 +211,3 @@ TileDBDataset::CreateMultiDimensional(const char *pszFilename,
     poDS->SetDescription(pszFilename);
     return poDS;
 }
-
-#endif  // HAS_TILEDB_MULTIDIM

--- a/frmts/tiledb/tiledbmultidim.h
+++ b/frmts/tiledb/tiledbmultidim.h
@@ -31,8 +31,6 @@
 
 #include "tiledbheaders.h"
 
-#ifdef HAS_TILEDB_MULTIDIM
-
 constexpr const char *CRS_ATTRIBUTE_NAME = "_CRS";
 constexpr const char *UNIT_ATTRIBUTE_NAME = "_UNIT";
 constexpr const char *DIM_TYPE_ATTRIBUTE_NAME = "_DIM_TYPE";
@@ -635,7 +633,5 @@ class TileDBMultiDimDataset final : public GDALDataset
         return m_poRG;
     }
 };
-
-#endif  // HAS_TILEDB_MULTIDIM
 
 #endif  // TILEDBMULTIDIM_H_INCLUDED

--- a/frmts/tiledb/tiledbmultidim.h
+++ b/frmts/tiledb/tiledbmultidim.h
@@ -596,7 +596,8 @@ class TileDBArrayGroup final : public GDALGroup
     std::vector<std::shared_ptr<GDALMDArray>> m_apoArrays;
 
   public:
-    TileDBArrayGroup(const std::vector<std::shared_ptr<GDALMDArray>> &apoArrays)
+    explicit TileDBArrayGroup(
+        const std::vector<std::shared_ptr<GDALMDArray>> &apoArrays)
         : GDALGroup(std::string(), "/"), m_apoArrays(apoArrays)
     {
     }
@@ -624,7 +625,8 @@ class TileDBMultiDimDataset final : public GDALDataset
     std::shared_ptr<GDALGroup> m_poRG{};
 
   public:
-    TileDBMultiDimDataset(const std::shared_ptr<GDALGroup> &poRG) : m_poRG(poRG)
+    explicit TileDBMultiDimDataset(const std::shared_ptr<GDALGroup> &poRG)
+        : m_poRG(poRG)
     {
     }
 

--- a/frmts/tiledb/tiledbmultidimarray.cpp
+++ b/frmts/tiledb/tiledbmultidimarray.cpp
@@ -31,8 +31,6 @@
 #include <algorithm>
 #include <limits>
 
-#ifdef HAS_TILEDB_MULTIDIM
-
 /************************************************************************/
 /*                   TileDBArray::TileDBArray()                         */
 /************************************************************************/
@@ -1576,5 +1574,3 @@ CSLConstList TileDBArray::GetStructuralInfo() const
 {
     return m_aosStructuralInfo.List();
 }
-
-#endif  // HAS_TILEDB_MULTIDIM

--- a/frmts/tiledb/tiledbmultidimarray.cpp
+++ b/frmts/tiledb/tiledbmultidimarray.cpp
@@ -924,7 +924,10 @@ bool TileDBArray::IRead(const GUInt64 *arrayStartIdx, const size_t *count,
         {
             tiledb::Query query(m_poSharedResource->GetCtx(),
                                 *(m_poTileDBArray.get()));
-            query.set_subarray(anSubArray);
+            tiledb::Subarray subarray(m_poSharedResource->GetCtx(),
+                                      *(m_poTileDBArray.get()));
+            subarray.set_subarray(anSubArray);
+            query.set_subarray(subarray);
             query.set_data_buffer(m_osAttrName, pDstBuffer, nBufferSize);
 
             if (m_bStats)
@@ -995,7 +998,10 @@ bool TileDBArray::IWrite(const GUInt64 *arrayStartIdx, const size_t *count,
         {
             tiledb::Query query(m_poSharedResource->GetCtx(),
                                 *(m_poTileDBArray.get()));
-            query.set_subarray(anSubArray);
+            tiledb::Subarray subarray(m_poSharedResource->GetCtx(),
+                                      *(m_poTileDBArray.get()));
+            subarray.set_subarray(anSubArray);
+            query.set_subarray(subarray);
             query.set_data_buffer(m_osAttrName, const_cast<void *>(pSrcBuffer),
                                   nBufferSize);
 

--- a/frmts/tiledb/tiledbmultidimarray.cpp
+++ b/frmts/tiledb/tiledbmultidimarray.cpp
@@ -1408,9 +1408,10 @@ std::shared_ptr<TileDBArray> TileDBArray::CreateOnDisk(
     {
         const auto osSanitizedName =
             TileDBSharedResource::SanitizeNameForPath(osName);
-        if (osSanitizedName.empty() || osName.find("./") == 0 ||
-            osName.find("../") == 0 || osName.find(".\\") == 0 ||
-            osName.find("..\\") == 0)
+        if (osSanitizedName.empty() || STARTS_WITH(osName.c_str(), "./") ||
+            STARTS_WITH(osName.c_str(), "../") ||
+            STARTS_WITH(osName.c_str(), ".\\") ||
+            STARTS_WITH(osName.c_str(), "..\\"))
         {
             CPLError(CE_Failure, CPLE_AppDefined, "Invalid array name");
             return nullptr;

--- a/frmts/tiledb/tiledbmultidimattribute.cpp
+++ b/frmts/tiledb/tiledbmultidimattribute.cpp
@@ -29,8 +29,6 @@
 #include "tiledbmultidim.h"
 #include "memmultidim.h"
 
-#ifdef HAS_TILEDB_MULTIDIM
-
 /************************************************************************/
 /*                TileDBAttribute::TileDBAttribute()                    */
 /************************************************************************/
@@ -199,5 +197,3 @@ bool TileDBAttribute::IWrite(const GUInt64 *arrayStartIdx, const size_t *count,
     return poParent->PutMetadata(m_osName, tiledb_dt, nValues,
                                  oRawResult.data());
 }
-
-#endif  // HAS_TILEDB_MULTIDIM

--- a/frmts/tiledb/tiledbmultidimattributeholder.cpp
+++ b/frmts/tiledb/tiledbmultidimattributeholder.cpp
@@ -28,8 +28,6 @@
 
 #include "tiledbmultidim.h"
 
-#ifdef HAS_TILEDB_MULTIDIM
-
 /************************************************************************/
 /*           TileDBAttributeHolder::~TileDBAttributeHolder()            */
 /************************************************************************/
@@ -300,5 +298,3 @@ bool TileDBAttributeHolder::PutMetadata(const std::string &key,
         return false;
     }
 }
-
-#endif

--- a/frmts/tiledb/tiledbmultidimgroup.cpp
+++ b/frmts/tiledb/tiledbmultidimgroup.cpp
@@ -28,8 +28,6 @@
 
 #include "tiledbmultidim.h"
 
-#ifdef HAS_TILEDB_MULTIDIM
-
 #include "memmultidim.h"
 
 /************************************************************************/
@@ -574,5 +572,3 @@ bool TileDBGroup::DeleteAttribute(const std::string &osName,
 {
     return DeleteAttributeImpl(osName, papszOptions);
 }
-
-#endif  // HAS_TILEDB_MULTIDIM

--- a/frmts/tiledb/tiledbsparse.cpp
+++ b/frmts/tiledb/tiledbsparse.cpp
@@ -73,12 +73,10 @@ template <> struct GetType<TILEDB_UINT16>
     using EltType = std::vector<uint16_t>;
 };
 
-#ifdef HAS_TILEDB_BOOL
 template <> struct GetType<TILEDB_BOOL>
 {
     using EltType = VECTOR_OF_BOOL;
 };
-#endif
 
 template <> struct GetType<TILEDB_INT64>
 {
@@ -143,11 +141,9 @@ template <template <class> class Func> struct ProcessField
             case TILEDB_UINT16:
                 Func<GetType<TILEDB_UINT16>::EltType>::exec(array);
                 break;
-#ifdef HAS_TILEDB_BOOL
             case TILEDB_BOOL:
                 Func<GetType<TILEDB_BOOL>::EltType>::exec(array);
                 break;
-#endif
             case TILEDB_INT64:
                 Func<GetType<TILEDB_INT64>::EltType>::exec(array);
                 break;
@@ -761,13 +757,11 @@ bool OGRTileDBLayer::InitFromStorage(tiledb::Context *poCtx,
                 eType = OFTString;
                 fieldValues.push_back(std::make_shared<std::string>());
                 break;
-#ifdef HAS_TILEDB_BOOL
             case TILEDB_BOOL:
                 eType = bIsSingle ? OFTInteger : OFTIntegerList;
                 eSubType = OFSTBoolean;
                 fieldValues.push_back(std::make_shared<VECTOR_OF_BOOL>());
                 break;
-#endif
             case TILEDB_DATETIME_DAY:
                 eType = OFTDate;
                 fieldValues.push_back(std::make_shared<std::vector<int64_t>>());
@@ -1298,7 +1292,6 @@ void OGRTileDBLayer::SetReadBuffers(bool bGrowVariableSizeArrays)
         {
             case OFTInteger:
             {
-#ifdef HAS_TILEDB_BOOL
                 if (m_aeFieldTypes[i] == TILEDB_BOOL)
                 {
                     auto &v = *(
@@ -1310,9 +1303,7 @@ void OGRTileDBLayer::SetReadBuffers(bool bGrowVariableSizeArrays)
                     m_query->set_data_buffer(pszFieldName, v);
 #endif
                 }
-                else
-#endif
-                    if (m_aeFieldTypes[i] == TILEDB_INT16)
+                else if (m_aeFieldTypes[i] == TILEDB_INT16)
                 {
                     auto &v = *(std::get<std::shared_ptr<std::vector<int16_t>>>(
                         fieldValues));
@@ -1356,7 +1347,6 @@ void OGRTileDBLayer::SetReadBuffers(bool bGrowVariableSizeArrays)
                         ? static_cast<int>(
                               std::min<uint64_t>(1000, iter->second))
                         : 8;
-#ifdef HAS_TILEDB_BOOL
                 if (m_aeFieldTypes[i] == TILEDB_BOOL)
                 {
                     auto &v = *(
@@ -1372,9 +1362,7 @@ void OGRTileDBLayer::SetReadBuffers(bool bGrowVariableSizeArrays)
                     m_query->set_data_buffer(pszFieldName, v);
 #endif
                 }
-                else
-#endif
-                    if (m_aeFieldTypes[i] == TILEDB_INT16)
+                else if (m_aeFieldTypes[i] == TILEDB_INT16)
                 {
                     auto &v = *(std::get<std::shared_ptr<std::vector<int16_t>>>(
                         fieldValues));
@@ -1909,16 +1897,13 @@ bool OGRTileDBLayer::SetupQuery(tiledb::QueryCondition *queryCondition)
             {
                 case OFTInteger:
                 {
-#ifdef HAS_TILEDB_BOOL
                     if (m_aeFieldTypes[i] == TILEDB_BOOL)
                     {
                         auto &v = *(std::get<std::shared_ptr<VECTOR_OF_BOOL>>(
                             fieldValues));
                         v.resize(result.second);
                     }
-                    else
-#endif
-                        if (m_aeFieldTypes[i] == TILEDB_INT16)
+                    else if (m_aeFieldTypes[i] == TILEDB_INT16)
                     {
                         auto &v =
                             *(std::get<std::shared_ptr<std::vector<int16_t>>>(
@@ -1955,7 +1940,6 @@ bool OGRTileDBLayer::SetupQuery(tiledb::QueryCondition *queryCondition)
 
                 case OFTIntegerList:
                 {
-#ifdef HAS_TILEDB_BOOL
                     if (m_aeFieldTypes[i] == TILEDB_BOOL)
                     {
                         auto &v = *(std::get<std::shared_ptr<VECTOR_OF_BOOL>>(
@@ -1969,9 +1953,7 @@ bool OGRTileDBLayer::SetupQuery(tiledb::QueryCondition *queryCondition)
                             v.resize(static_cast<size_t>(result.second));
                         }
                     }
-                    else
-#endif
-                        if (m_aeFieldTypes[i] == TILEDB_INT16)
+                    else if (m_aeFieldTypes[i] == TILEDB_INT16)
                     {
                         auto &v =
                             *(std::get<std::shared_ptr<std::vector<int16_t>>>(
@@ -2457,7 +2439,7 @@ std::unique_ptr<tiledb::QueryCondition> OGRTileDBLayer::CreateQueryCondition(
                     CPLAssert(false);
                     return nullptr;
                 }
-#ifdef HAS_TILEDB_BOOL
+
                 if (m_aeFieldTypes[poColumn->field_index] == TILEDB_BOOL)
                 {
                     if (nVal == 0 || nVal == 1)
@@ -2478,9 +2460,7 @@ std::unique_ptr<tiledb::QueryCondition> OGRTileDBLayer::CreateQueryCondition(
                         return nullptr;
                     }
                 }
-                else
-#endif
-                    if (m_aeFieldTypes[poColumn->field_index] == TILEDB_INT16)
+                else if (m_aeFieldTypes[poColumn->field_index] == TILEDB_INT16)
                 {
                     return CreateQueryConditionForIntType<int16_t>(
                         *(m_ctx.get()), poFieldDefn, nVal, tiledb_op,
@@ -3017,7 +2997,6 @@ OGRFeature *OGRTileDBLayer::TranslateCurrentFeature()
         {
             case OFTInteger:
             {
-#ifdef HAS_TILEDB_BOOL
                 if (m_aeFieldTypes[i] == TILEDB_BOOL)
                 {
                     const auto &v = *(
@@ -3025,9 +3004,7 @@ OGRFeature *OGRTileDBLayer::TranslateCurrentFeature()
                     poFeature->SetFieldSameTypeUnsafe(i,
                                                       v[m_nOffsetInResultSet]);
                 }
-                else
-#endif
-                    if (m_aeFieldTypes[i] == TILEDB_INT16)
+                else if (m_aeFieldTypes[i] == TILEDB_INT16)
                 {
                     const auto &v =
                         *(std::get<std::shared_ptr<std::vector<int16_t>>>(
@@ -3068,7 +3045,6 @@ OGRFeature *OGRTileDBLayer::TranslateCurrentFeature()
 
             case OFTIntegerList:
             {
-#ifdef HAS_TILEDB_BOOL
                 if (m_aeFieldTypes[i] == TILEDB_BOOL)
                 {
                     const auto &v = *(
@@ -3085,9 +3061,7 @@ OGRFeature *OGRTileDBLayer::TranslateCurrentFeature()
                     poFeature->SetField(i, static_cast<int>(nEltCount),
                                         tmp.data());
                 }
-                else
-#endif
-                    if (m_aeFieldTypes[i] == TILEDB_INT16)
+                else if (m_aeFieldTypes[i] == TILEDB_INT16)
                 {
                     const auto &v =
                         *(std::get<std::shared_ptr<std::vector<int16_t>>>(
@@ -3586,16 +3560,13 @@ void OGRTileDBLayer::InitializeSchemaAndArray()
                 case OFTInteger:
                 case OFTIntegerList:
                 {
-#ifdef HAS_TILEDB_BOOL
                     if (poFieldDefn->GetSubType() == OFSTBoolean)
                     {
                         CreateAttr(TILEDB_BOOL, eType == OFTIntegerList);
                         aFieldValues.push_back(
                             std::make_shared<VECTOR_OF_BOOL>());
                     }
-                    else
-#endif
-                        if (poFieldDefn->GetSubType() == OFSTInt16)
+                    else if (poFieldDefn->GetSubType() == OFSTInt16)
                     {
                         CreateAttr(TILEDB_INT16, eType == OFTIntegerList);
                         aFieldValues.push_back(
@@ -3971,13 +3942,10 @@ OGRErr OGRTileDBLayer::ICreateFeature(OGRFeature *poFeature)
             {
                 const int nVal =
                     bFieldIsValid ? poFeature->GetFieldAsIntegerUnsafe(i) : 0;
-#ifdef HAS_TILEDB_BOOL
                 if (m_aeFieldTypes[i] == TILEDB_BOOL)
                     std::get<std::shared_ptr<VECTOR_OF_BOOL>>(fieldValues)
                         ->push_back(static_cast<uint8_t>(nVal));
-                else
-#endif
-                    if (m_aeFieldTypes[i] == TILEDB_INT16)
+                else if (m_aeFieldTypes[i] == TILEDB_INT16)
                     std::get<std::shared_ptr<std::vector<int16_t>>>(fieldValues)
                         ->push_back(static_cast<int16_t>(nVal));
                 else if (m_aeFieldTypes[i] == TILEDB_INT32)
@@ -4004,7 +3972,6 @@ OGRErr OGRTileDBLayer::ICreateFeature(OGRFeature *poFeature)
                     poFeature->GetFieldAsIntegerList(i, &nCount);
                 if (anOffsets.empty())
                     anOffsets.push_back(0);
-#ifdef HAS_TILEDB_BOOL
                 if (m_aeFieldTypes[i] == TILEDB_BOOL)
                 {
                     auto &v = *(
@@ -4014,9 +3981,7 @@ OGRErr OGRTileDBLayer::ICreateFeature(OGRFeature *poFeature)
                     anOffsets.push_back(anOffsets.back() +
                                         nCount * sizeof(v[0]));
                 }
-                else
-#endif
-                    if (m_aeFieldTypes[i] == TILEDB_INT16)
+                else if (m_aeFieldTypes[i] == TILEDB_INT16)
                 {
                     auto &v = *(std::get<std::shared_ptr<std::vector<int16_t>>>(
                         fieldValues));
@@ -4332,7 +4297,6 @@ void OGRTileDBLayer::FlushArrays()
                         query.set_offsets_buffer(pszFieldName, anOffsets);
                     }
 
-#ifdef HAS_TILEDB_BOOL
                     if (m_aeFieldTypes[i] == TILEDB_BOOL)
                     {
                         auto &v = *(std::get<std::shared_ptr<VECTOR_OF_BOOL>>(
@@ -4343,9 +4307,7 @@ void OGRTileDBLayer::FlushArrays()
                         query.set_data_buffer(pszFieldName, v);
 #endif
                     }
-                    else
-#endif
-                        if (m_aeFieldTypes[i] == TILEDB_INT16)
+                    else if (m_aeFieldTypes[i] == TILEDB_INT16)
                     {
                         auto &v =
                             *(std::get<std::shared_ptr<std::vector<int16_t>>>(
@@ -4619,12 +4581,9 @@ int OGRTileDBLayer::GetArrowSchema(struct ArrowArrayStream *out_stream,
                 eType == OFTInteger
                     ? out_schema->children[iSchemaChild]->format
                     : out_schema->children[iSchemaChild]->children[0]->format;
-#ifdef HAS_TILEDB_BOOL
             if (m_aeFieldTypes[i] == TILEDB_BOOL)
                 format = "b";
-            else
-#endif
-                if (m_aeFieldTypes[i] == TILEDB_INT16)
+            else if (m_aeFieldTypes[i] == TILEDB_INT16)
                 format = "s";
             else if (m_aeFieldTypes[i] == TILEDB_INT32)
                 format = "i";
@@ -5319,14 +5278,11 @@ int OGRTileDBLayer::GetNextArrowArray(struct ArrowArrayStream *stream,
             {
                 case OFTInteger:
                 {
-#ifdef HAS_TILEDB_BOOL
                     if (m_aeFieldTypes[i] == TILEDB_BOOL)
                     {
                         FillBoolArray(psChild, i, abyValidityFromFilters);
                     }
-                    else
-#endif
-                        if (m_aeFieldTypes[i] == TILEDB_INT16)
+                    else if (m_aeFieldTypes[i] == TILEDB_INT16)
                     {
                         FillPrimitiveArray<int16_t>(psChild, i,
                                                     abyValidityFromFilters);
@@ -5355,14 +5311,11 @@ int OGRTileDBLayer::GetNextArrowArray(struct ArrowArrayStream *stream,
 
                 case OFTIntegerList:
                 {
-#ifdef HAS_TILEDB_BOOL
                     if (m_aeFieldTypes[i] == TILEDB_BOOL)
                     {
                         FillBoolListArray(psChild, i, abyValidityFromFilters);
                     }
-                    else
-#endif
-                        if (m_aeFieldTypes[i] == TILEDB_INT16)
+                    else if (m_aeFieldTypes[i] == TILEDB_INT16)
                     {
                         FillPrimitiveListArray<int16_t>(psChild, i,
                                                         abyValidityFromFilters);

--- a/frmts/tiledb/tiledbsparse.cpp
+++ b/frmts/tiledb/tiledbsparse.cpp
@@ -2679,7 +2679,6 @@ OGRTileDBLayer::CreateQueryCondition(const swq_expr_node *poNode,
         return right;
     }
 
-#ifdef HAS_TILEDB_WORKING_OR_FILTER
     // A OR B
     else if (poNode->eNodeType == SNT_OPERATION &&
              poNode->nOperation == SWQ_OR && poNode->nSubExprCount == 2)
@@ -2761,7 +2760,6 @@ OGRTileDBLayer::CreateQueryCondition(const swq_expr_node *poNode,
             bAlwaysFalse = true;
         return cond;
     }
-#endif
 
     // field_name =/<>/</>/<=/>= constant (or the reverse)
     else if (poNode->eNodeType == SNT_OPERATION &&

--- a/frmts/tiledb/tiledbsparse.cpp
+++ b/frmts/tiledb/tiledbsparse.cpp
@@ -2540,11 +2540,6 @@ std::unique_ptr<tiledb::QueryCondition> OGRTileDBLayer::CreateQueryCondition(
                     CPLAssert(false);
                     return nullptr;
                 }
-#if !defined(HAS_TILEDB_WORKING_UTF8_STRING_FILTER)
-                if (m_schema->attribute(poFieldDefn->GetNameRef()).type() !=
-                    TILEDB_STRING_ASCII)
-                    return nullptr;
-#endif
                 return std::make_unique<tiledb::QueryCondition>(
                     tiledb::QueryCondition::create(
                         *(m_ctx.get()), poFieldDefn->GetNameRef(),
@@ -2781,14 +2776,6 @@ OGRTileDBLayer::CreateQueryCondition(const swq_expr_node *poNode,
     {
         const OGRFieldDefn *poFieldDefn =
             m_poFeatureDefn->GetFieldDefn(poNode->papoSubExpr[0]->field_index);
-#if !defined(HAS_TILEDB_WORKING_UTF8_STRING_FILTER)
-        if (poFieldDefn->GetType() == OFTString &&
-            m_schema->attribute(poFieldDefn->GetNameRef()).type() !=
-                TILEDB_STRING_ASCII)
-        {
-            return nullptr;
-        }
-#endif
         if (!poFieldDefn->IsNullable())
         {
             bAlwaysFalse = true;
@@ -2810,14 +2797,6 @@ OGRTileDBLayer::CreateQueryCondition(const swq_expr_node *poNode,
     {
         const OGRFieldDefn *poFieldDefn = m_poFeatureDefn->GetFieldDefn(
             poNode->papoSubExpr[0]->papoSubExpr[0]->field_index);
-#if !defined(HAS_TILEDB_WORKING_UTF8_STRING_FILTER)
-        if (poFieldDefn->GetType() == OFTString &&
-            m_schema->attribute(poFieldDefn->GetNameRef()).type() !=
-                TILEDB_STRING_ASCII)
-        {
-            return nullptr;
-        }
-#endif
         if (!poFieldDefn->IsNullable())
         {
             bAlwaysTrue = true;


### PR DESCRIPTION
## What does this PR do?

This PR updates the TileDB backend to stop using deprecated TileDB APIs. The changes are straightforward and can be divided into three categories:

* `query.set_buffer(name, offsets, data)` → `query.set_data_buffer(name, data); query.set_offsets_buffer(name, offsets)`
  * `offsets` and `data` are usually `std::vector`s, but in some cases were pairs of pointers and lengths
* `tiledb::Array(ctx, path, mode, timestamp)` → `tiledb::Array(ctx, path, mode, tiledb::TemporalPolicy(tiledb::TimeTravel, timestamp))`
* `query.set_subarray(subarray)` → `tiledb::Subarray subarray_obj(ctx, array); subarray_obj.set_subarray(subarray); query.set_subarray(subarray_obj);`

Validated by successfully building the GDAL library with a special build of TileDB that excludes all deprecated APIs (TileDB-Inc/TileDB#4887).

## What are related issues/pull requests?

## Tasklist

 - [X] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks)) — ran `clang-format` on all files I changed
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed