### PR TITLE
[argparse] Return argument reference from add methods

### DIFF
--- a/apps/gdalargumentparser.cpp
+++ b/apps/gdalargumentparser.cpp
@@ -107,7 +107,7 @@ void GDALArgumentParser::display_error_and_usage(const std::exception &err)
 /*                         add_quiet_argument()                         */
 /************************************************************************/
 
-void GDALArgumentParser::add_quiet_argument(bool *pVar)
+Argument &GDALArgumentParser::add_quiet_argument(bool *pVar)
 {
     auto &arg =
         this->add_argument("-q", "--quiet")
@@ -117,15 +117,17 @@ void GDALArgumentParser::add_quiet_argument(bool *pVar)
                   "output."));
     if (pVar)
         arg.store_into(*pVar);
+
+    return arg;
 }
 
 /************************************************************************/
 /*                      add_input_format_argument()                     */
 /************************************************************************/
 
-void GDALArgumentParser::add_input_format_argument(CPLStringList *pvar)
+Argument &GDALArgumentParser::add_input_format_argument(CPLStringList *pvar)
 {
-    add_argument("-if")
+    return add_argument("-if")
         .append()
         .metavar("<format>")
         .action(
@@ -149,22 +151,23 @@ void GDALArgumentParser::add_input_format_argument(CPLStringList *pvar)
 /*                      add_output_format_argument()                    */
 /************************************************************************/
 
-void GDALArgumentParser::add_output_format_argument(std::string &var)
+Argument &GDALArgumentParser::add_output_format_argument(std::string &var)
 {
     auto &arg = add_argument("-of")
                     .metavar("<output_format>")
                     .store_into(var)
                     .help(_("Output format."));
     add_hidden_alias_for(arg, "-f");
+    return arg;
 }
 
 /************************************************************************/
 /*                     add_creation_options_argument()                  */
 /************************************************************************/
 
-void GDALArgumentParser::add_creation_options_argument(CPLStringList &var)
+Argument &GDALArgumentParser::add_creation_options_argument(CPLStringList &var)
 {
-    add_argument("-co")
+    return add_argument("-co")
         .metavar("<NAME>=<VALUE>")
         .append()
         .action([&var](const std::string &s) { var.AddString(s.c_str()); })
@@ -175,9 +178,10 @@ void GDALArgumentParser::add_creation_options_argument(CPLStringList &var)
 /*                   add_metadata_item_options_argument()               */
 /************************************************************************/
 
-void GDALArgumentParser::add_metadata_item_options_argument(CPLStringList &var)
+Argument &
+GDALArgumentParser::add_metadata_item_options_argument(CPLStringList &var)
 {
-    add_argument("-mo")
+    return add_argument("-mo")
         .metavar("<NAME>=<VALUE>")
         .append()
         .action([&var](const std::string &s) { var.AddString(s.c_str()); })
@@ -188,16 +192,16 @@ void GDALArgumentParser::add_metadata_item_options_argument(CPLStringList &var)
 /*                       add_open_options_argument()                    */
 /************************************************************************/
 
-void GDALArgumentParser::add_open_options_argument(CPLStringList &var)
+Argument &GDALArgumentParser::add_open_options_argument(CPLStringList &var)
 {
-    add_open_options_argument(&var);
+    return add_open_options_argument(&var);
 }
 
 /************************************************************************/
 /*                       add_open_options_argument()                    */
 /************************************************************************/
 
-void GDALArgumentParser::add_open_options_argument(CPLStringList *pvar)
+Argument &GDALArgumentParser::add_open_options_argument(CPLStringList *pvar)
 {
     auto &arg = add_argument("-oo")
                     .metavar("<NAME>=<VALUE>")
@@ -208,15 +212,17 @@ void GDALArgumentParser::add_open_options_argument(CPLStringList *pvar)
         arg.action([pvar](const std::string &s)
                    { pvar->AddString(s.c_str()); });
     }
+
+    return arg;
 }
 
 /************************************************************************/
 /*                       add_output_type_argument()                     */
 /************************************************************************/
 
-void GDALArgumentParser::add_output_type_argument(GDALDataType &eDT)
+Argument &GDALArgumentParser::add_output_type_argument(GDALDataType &eDT)
 {
-    add_argument("-ot")
+    return add_argument("-ot")
         .metavar("Byte|Int8|[U]Int{16|32|64}|CInt{16|32}|[C]Float{32|64}")
         .action(
             [&eDT](const std::string &s)

--- a/apps/gdalargumentparser.h
+++ b/apps/gdalargumentparser.h
@@ -64,28 +64,28 @@ class GDALArgumentParser : public ArgumentParser
     void display_error_and_usage(const std::exception &err);
 
     //! Add -q/--quiet argument, and store its value in *pVar (if pVar not null)
-    void add_quiet_argument(bool *pVar);
+    Argument &add_quiet_argument(bool *pVar);
 
     //! Add "-if format_name" argument for input format, and store its value into *pvar.
-    void add_input_format_argument(CPLStringList *pvar);
+    Argument &add_input_format_argument(CPLStringList *pvar);
 
     //! Add "-of format_name" argument for output format, and store its value into var.
-    void add_output_format_argument(std::string &var);
+    Argument &add_output_format_argument(std::string &var);
 
     //! Add "-co KEY=VALUE" argument for creation options, and store its value into var.
-    void add_creation_options_argument(CPLStringList &var);
+    Argument &add_creation_options_argument(CPLStringList &var);
 
     //! Add "-mo KEY=VALUE" argument for metadata item options, and store its value into var.
-    void add_metadata_item_options_argument(CPLStringList &var);
+    Argument &add_metadata_item_options_argument(CPLStringList &var);
 
     //! Add "-oo KEY=VALUE" argument for open options, and store its value into var.
-    void add_open_options_argument(CPLStringList &var);
+    Argument &add_open_options_argument(CPLStringList &var);
 
     //! Add "-oo KEY=VALUE" argument for open options, and store its value into *pvar.
-    void add_open_options_argument(CPLStringList *pvar);
+    Argument &add_open_options_argument(CPLStringList *pvar);
 
     //! Add "-ot data_type" argument for output type, and store its value into eDT.
-    void add_output_type_argument(GDALDataType &eDT);
+    Argument &add_output_type_argument(GDALDataType &eDT);
 
     //! Parse command line arguments, without the initial program name.
     void parse_args_without_binary_name(CSLConstList papszArgs);


### PR DESCRIPTION
This can be used for further configuration of the
returned arguments.

As discussed in https://github.com/OSGeo/gdal/pull/9739#issuecomment-2074758905
