### PR TITLE
Simplify usage for older GDAL by using CMake's supplied find module

### DIFF
--- a/doc/source/development/cmake.rst
+++ b/doc/source/development/cmake.rst
@@ -26,22 +26,16 @@ the cache variable or environment variable ``CMAKE_PREFIX_PATH``. In
 particular, CMake will consult (and set) the cache variable
 ``GDAL_DIR``.
 
-Before GDAL 3.5, you can use the following to create the imported library target ``GDAL::GDAL``:
+Before GDAL 3.5, it is recommended to use `find module supplied with CMake <https://cmake.org/cmake/help/latest/module/FindGDAL.html>`__.
+This also creates the ``GDAL::GDAL`` target. It requires CMake version 3.14.
 
 .. code::
+
+    cmake_minimum_required(VERSION 3.14)
 
     find_package(GDAL CONFIG QUIET)
     if(NOT TARGET GDAL::GDAL)
         find_package(GDAL REQUIRED)
-        if(NOT TARGET GDAL::GDAL)
-            add_library(GDAL IMPORTED)
-            if(DEFINED GDAL_LIBRARIES)
-                target_link_libraries(GDAL INTERFACE "${GDAL_LIBRARIES}")
-                add_library(GDAL::GDAL ALIAS GDAL)
-            else()
-                message(FATAL_ERROR "Missing GDAL_LIBRARIES")
-            endif()
-        endif()
     endif()
 
     target_link_libraries(MyApp PRIVATE GDAL::GDAL)

--- a/doc/source/development/cmake.rst
+++ b/doc/source/development/cmake.rst
@@ -33,8 +33,8 @@ This also creates the ``GDAL::GDAL`` target. It requires CMake version 3.14.
 
     cmake_minimum_required(VERSION 3.14)
 
-    find_package(GDAL CONFIG QUIET)
-    if(NOT TARGET GDAL::GDAL)
+    find_package(GDAL CONFIG)
+    if(NOT GDAL_FOUND)
         find_package(GDAL REQUIRED)
     endif()
 


### PR DESCRIPTION

## What does this PR do?

* Recommend using CMake's supplied find module if using older GDAL versions
* Remove broken recommendation for creating a GDAL::GDAL target

Note - Ubuntu 20 comes with CMake 3.16, so this should cover all non-EOL OS's that people will generally be using.
We intentionally ignore the edge cases of custom find modules because we will assume people writing those know 
what they are doing.

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/pull/9714#discussion_r1575040858

## Tasklist

 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Ubuntu 22 with GDAL installed through APT
* Compiler: G++11
