### PR TITLE
[Backport release/3.9] OGR_CT: use PROJJSON rather than in WKT:2019

### DIFF
--- a/autotest/osr/osr_ct.py
+++ b/autotest/osr/osr_ct.py
@@ -898,3 +898,58 @@ def test_osr_ct_source_and_target_mapping_minus_two_one():
     x, y, _ = ct.TransformPoint(10, 20, 0)
     assert x == pytest.approx(10)
     assert y == pytest.approx(20)
+
+
+###############################################################################
+# Test bug fix for https://github.com/OSGeo/gdal/issues/9732
+
+
+@pytest.mark.require_proj(9, 2)
+def test_osr_ct_fix_9732():
+
+    s = osr.SpatialReference()
+    s.ImportFromEPSG(6453)
+
+    assert not s.IsDerivedProjected()
+
+    t = osr.SpatialReference()
+    t.SetFromUserInput(
+        """DERIVEDPROJCRS["Ground for NAD83(2011) / Idaho West (ftUS)",
+    BASEPROJCRS["NAD83(2011) / Idaho West (ftUS)",
+        BASEGEOGCRS["NAD83(2011)",
+            DATUM["NAD83 (National Spatial Reference System 2011)",ELLIPSOID["GRS 1980",6378137,298.257222101,LENGTHUNIT["metre",1]]],
+            PRIMEM["Greenwich",0,ANGLEUNIT["degree",0.0174532925199433]],
+            ID["EPSG",6318]],
+        CONVERSION["SPCS83 Idaho West zone (US Survey feet)",
+            METHOD["Transverse Mercator",ID["EPSG",9807]],
+            PARAMETER["Latitude of natural origin",41.6666666666667,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8801]],
+            PARAMETER["Longitude of natural origin",-115.75,ANGLEUNIT["degree",0.0174532925199433],ID["EPSG",8802]],
+            PARAMETER["Scale factor at natural origin",0.999933333,SCALEUNIT["unity",1],ID["EPSG",8805]],
+            PARAMETER["False easting",2624666.667,LENGTHUNIT["US survey foot",0.304800609601219],ID["EPSG",8806]],
+            PARAMETER["False northing",0,LENGTHUNIT["US survey foot",0.304800609601219],ID["EPSG",8807]]],
+        CS[Cartesian,2],
+        AXIS["easting (X)",east,ORDER[1],LENGTHUNIT["US survey foot",0.304800609601219]],
+        AXIS["northing (Y)",north,ORDER[2],LENGTHUNIT["US survey foot",0.304800609601219]],
+        USAGE[SCOPE["Engineering survey, topographic mapping."],AREA["United States (USA) - Idaho - counties of Ada; Adams; Benewah; Boise; Bonner; Boundary; Canyon; Clearwater; Elmore; Gem; Idaho; Kootenai; Latah; Lewis; Nez Perce; Owyhee; Payette; Shoshone; Valley; Washington."],BBOX[41.99,-117.24,49.01,-114.32]],
+        ID["EPSG",6453]],
+    DERIVINGCONVERSION["Grid to ground",
+        METHOD["Similarity transformation",ID["EPSG",9621]],
+        PARAMETER["Ordinate 1 of evaluation point in target CRS",1000,LENGTHUNIT["US survey foot",0.304800609601219],ID["EPSG",8621]],
+        PARAMETER["Ordinate 2 of evaluation point in target CRS",0,LENGTHUNIT["US survey foot",0.304800609601219],ID["EPSG",8622]],
+        PARAMETER["Scale factor for source CRS axes",1,SCALEUNIT["unity",1],ID["EPSG",1061]],
+        PARAMETER["Rotation angle of source CRS axes", 0,ANGLEUNIT["degree",0.0],ID["EPSG",8614]]],
+    CS[Cartesian,2],
+    AXIS["easting (X)",east,
+        ORDER[1],
+        LENGTHUNIT["US survey foot",0.304800609601219]],
+    AXIS["northing (Y)",north,
+        ORDER[2],
+        LENGTHUNIT["US survey foot",0.304800609601219]]]"""
+    )
+
+    assert t.IsDerivedProjected()
+
+    ct = osr.CoordinateTransformation(s, t)
+    x, y, _ = ct.TransformPoint(2300000, 2000000, 0)
+    assert x == pytest.approx(2301000)
+    assert y == pytest.approx(2000000)

--- a/ogr/ogr_spatialref.h
+++ b/ogr/ogr_spatialref.h
@@ -387,6 +387,7 @@ class CPL_DLL OGRSpatialReference
     int IsGeographic() const;
     int IsDerivedGeographic() const;
     int IsProjected() const;
+    int IsDerivedProjected() const;
     int IsGeocentric() const;
     bool IsDynamic() const;
 

--- a/ogr/ogr_srs_api.h
+++ b/ogr/ogr_srs_api.h
@@ -553,6 +553,7 @@ int CPL_DLL OSRIsGeographic(OGRSpatialReferenceH);
 int CPL_DLL OSRIsDerivedGeographic(OGRSpatialReferenceH);
 int CPL_DLL OSRIsLocal(OGRSpatialReferenceH);
 int CPL_DLL OSRIsProjected(OGRSpatialReferenceH);
+int CPL_DLL OSRIsDerivedProjected(OGRSpatialReferenceH);
 int CPL_DLL OSRIsCompound(OGRSpatialReferenceH);
 int CPL_DLL OSRIsGeocentric(OGRSpatialReferenceH);
 int CPL_DLL OSRIsVertical(OGRSpatialReferenceH);

--- a/ogr/ogrspatialreference.cpp
+++ b/ogr/ogrspatialreference.cpp
@@ -4256,6 +4256,7 @@ OGRErr OGRSpatialReference::importFromURNPart(const char *pszAuthority,
                                               const char *pszURN)
 {
 #if PROJ_AT_LEAST_VERSION(8, 1, 0)
+    (void)this;
     (void)pszAuthority;
     (void)pszCode;
     (void)pszURN;

--- a/ogr/ogrspatialreference.cpp
+++ b/ogr/ogrspatialreference.cpp
@@ -8859,7 +8859,7 @@ int OGRSpatialReference::IsDerivedGeographic() const
 /*                      OSRIsDerivedGeographic()                        */
 /************************************************************************/
 /**
- * \brief Check if derived geographic coordinate system.
+ * \brief Check if the CRS is a derived geographic coordinate system.
  * (for example a rotated long/lat grid)
  *
  * This function is the same as OGRSpatialReference::IsDerivedGeographic().
@@ -8870,6 +8870,51 @@ int OSRIsDerivedGeographic(OGRSpatialReferenceH hSRS)
     VALIDATE_POINTER1(hSRS, "OSRIsDerivedGeographic", 0);
 
     return ToPointer(hSRS)->IsDerivedGeographic();
+}
+
+/************************************************************************/
+/*                      IsDerivedProjected()                            */
+/************************************************************************/
+
+/**
+ * \brief Check if the CRS is a derived projected coordinate system.
+ *
+ * This method is the same as the C function OSRIsDerivedGeographic().
+ *
+ * @since GDAL 3.9.0 (and may only return non-zero starting with PROJ 9.2.0)
+ */
+
+int OGRSpatialReference::IsDerivedProjected() const
+
+{
+#if PROJ_AT_LEAST_VERSION(9, 2, 0)
+    d->refreshProjObj();
+    d->demoteFromBoundCRS();
+    const bool isDerivedProjected =
+        d->m_pjType == PJ_TYPE_DERIVED_PROJECTED_CRS;
+    d->undoDemoteFromBoundCRS();
+    return isDerivedProjected ? TRUE : FALSE;
+#else
+    return FALSE;
+#endif
+}
+
+/************************************************************************/
+/*                      OSRIsDerivedProjected()                         */
+/************************************************************************/
+/**
+ * \brief Check if the CRS is a derived projected coordinate system.
+ *
+ * This function is the same as OGRSpatialReference::IsDerivedProjected().
+ *
+ * @since GDAL 3.9.0 (and may only return non-zero starting with PROJ 9.2.0)
+ */
+int OSRIsDerivedProjected(OGRSpatialReferenceH hSRS)
+
+{
+    VALIDATE_POINTER1(hSRS, "OSRIsDerivedProjected", 0);
+
+    return ToPointer(hSRS)->IsDerivedProjected();
 }
 
 /************************************************************************/

--- a/scripts/cppcheck.sh
+++ b/scripts/cppcheck.sh
@@ -99,6 +99,9 @@ for dirname in alg port gcore ogr frmts gnm apps fuzzers; do
         -DFLT_EVAL_METHOD \
         -DKDU_HAS_ROI_RECT \
         -Dflatbuffers=gdal_flatbuffers \
+        -DPROJ_VERSION_MAJOR=9 \
+        -DPROJ_VERSION_MINOR=4 \
+        -DPROJ_VERSION_PATCH=0 \
         --include="${CPL_CONFIG_H}" \
         --include=port/cpl_port.h \
         -I "${CPL_CONFIG_H_DIR}" \

--- a/swig/include/osr.i
+++ b/swig/include/osr.i
@@ -363,6 +363,10 @@ public:
     return OSRIsProjected(self);
   }
 
+  int IsDerivedProjected() {
+    return OSRIsDerivedProjected(self);
+  }
+
   int IsCompound() {
     return OSRIsCompound(self);
   }


### PR DESCRIPTION
Backport #9735
 **Authored by:** @rouault