### PR TITLE
CI: tweak alpine configuration to use numpy 2.0.0rc1

### DIFF
--- a/.github/workflows/alpine/Dockerfile.ci
+++ b/.github/workflows/alpine/Dockerfile.ci
@@ -51,10 +51,6 @@ RUN apk add \
     poppler-dev \
     proj-dev \
     proj-util \
-    py3-pyarrow \
-    py3-pyarrow-pyc \
-    py3-numpy \
-    py3-numpy-dev \
     py3-pip \
     py3-setuptools \
     python3-dev \
@@ -71,5 +67,16 @@ RUN apk add \
     zlib-dev \
     zstd-dev
 
+# Commenting out those packages to be sure to test numpy 2.0.0rc1
+#    py3-numpy \
+#    py3-numpy-dev \
+#    py3-pyarrow \
+#    py3-pyarrow-pyc \
+
+# apache-arrow-dev actually comes with an embedded pyarrow version, which is not py3-pyarrow, and is non functional !
+RUN mv /usr/lib/python3.12/site-packages/pyarrow /usr/lib/python3.12/site-packages/pyarrow.disabled
+
 COPY requirements.txt /tmp/
+RUN python3 -m pip install --break-system-packages numpy==2.0.0rc1
 RUN python3 -m pip install --break-system-packages -U -r /tmp/requirements.txt
+


### PR DESCRIPTION
Refs #9751

This commit should be reverted once alpine:edge switches to numpy 2 as it disables pyarrow related tests (however the alpine 32 bit config still has it)
