### PR TITLE
pyproject.toml: use numpy>=2.0.0rc1 for python >=3.9

### DIFF
--- a/swig/python/pyproject.toml
+++ b/swig/python/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["setuptools>=67.0.0", "oldest-supported-numpy", "wheel"]
+requires = ["setuptools>=67.0.0",
+            "wheel",
+            "oldest-supported-numpy; python_version=='3.8'",
+            "numpy >=2.0.0rc1; python_version>='3.9'"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/swig/python/setup.py.in
+++ b/swig/python/setup.py.in
@@ -73,6 +73,7 @@ def get_numpy_include():
     _set_builtin("__NUMPY_SETUP__", False)
 
     import numpy
+    print('Using numpy ' + numpy.__version__)
     return numpy.get_include()
 
 


### PR DESCRIPTION
Refs #9751
