### PR TITLE
[Backport release/3.9] pyproject.toml: use numpy>=2.0.0rc1 for python >=3.9

### DIFF
--- a/doc/source/api/python_bindings.rst
+++ b/doc/source/api/python_bindings.rst
@@ -49,17 +49,58 @@ GDAL can be installed from the `Python Package Index <https://pypi.org/project/G
 
 ::
 
-    pip install GDAL
+    pip install gdal
 
-It will be necessary to have libgdal and its development headers installed
-if pip is expected to do a source build because no wheel is available
-for your specified platform and Python version.
 
-To install the version of the Python bindings matching your native GDAL library:
+In order to enable numpy-based raster support, libgdal and its development headers must be installed as well as the Python packages numpy, setuptools, and wheel.
+To install the Python dependencies and build numpy-based raster support:
+
 
 ::
 
-    pip install GDAL=="$(gdal-config --version).*"
+    pip install numpy>1.0.0 wheel setuptools>=67
+    pip install gdal[numpy]=="$(gdal-config --version).*"
+
+
+Users can verify that numpy-based raster support has been installed with:
+
+::
+
+    python3 -c 'from osgeo import gdal_array'
+
+
+If this command raises an ImportError, numpy-based raster support has not been properly installed:
+
+::
+
+    Traceback (most recent call last):
+    File "<string>", line 1, in <module>
+    File "/usr/local/lib/python3.12/dist-packages/osgeo/gdal_array.py", line 10, in <module>
+      from . import _gdal_array
+    ImportError: cannot import name '_gdal_array' from 'osgeo' (/usr/local/lib/python3.12/dist-packages/osgeo/__init__.py)
+
+
+This is most often due to pip reusing a cached GDAL installation.
+Verify that the necessary dependencies have been installed and then run the following to force a clean build:
+
+::
+    pip install --no-cache --force-reinstall gdal[numpy]=="$(gdal-config --version).*"
+
+
+Potential issues with GDAL >= 3.9, Python >= 3.9 and NumPy 2.0
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The pyproject.toml file of GDAL 3.9 requires numpy >= 2.0.0rc1 (for Python >= 3.9)
+at build time to be able to build bindings that are compatible of both NumPy 1
+and NumPy 2.
+If for some reason the numpy >= 2.0.0rc1 build dependency can not be installed,
+it is possible to manually install the build requirements, and invoke ``pip install``
+with the ``--no-build-isolation`` flag.
+
+::
+
+    pip install numpy==<required_version> wheel setuptools>=67
+    pip install gdal[numpy]=="$(gdal-config --version).*" --no-build-isolation
 
 
 Building as part of the GDAL library source tree

--- a/swig/python/README.rst
+++ b/swig/python/README.rst
@@ -83,6 +83,21 @@ Verify that the necessary dependencies have been installed and then run the foll
     pip install --no-cache --force-reinstall gdal[numpy]=="$(gdal-config --version).*"
 
 
+Potential issues with GDAL >= 3.9, Python >= 3.9 and NumPy 2.0
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The pyproject.toml file of GDAL 3.9 requires numpy >= 2.0.0rc1 (for Python >= 3.9)
+at build time to be able to build bindings that are compatible of both NumPy 1
+and NumPy 2.
+If for some reason the numpy >= 2.0.0rc1 build dependency can not be installed,
+it is possible to manually install the build requirements, and invoke ``pip install``
+with the ``--no-build-isolation`` flag.
+
+::
+
+    pip install numpy==<required_version> wheel setuptools>=67
+    pip install gdal[numpy]=="$(gdal-config --version).*" --no-build-isolation
+
 
 Building as part of the GDAL library source tree
 ------------------------------------------------

--- a/swig/python/pyproject.toml
+++ b/swig/python/pyproject.toml
@@ -1,5 +1,8 @@
 [build-system]
-requires = ["setuptools>=67.0.0", "oldest-supported-numpy", "wheel"]
+requires = ["setuptools>=67.0.0",
+            "wheel",
+            "oldest-supported-numpy; python_version=='3.8'",
+            "numpy >=2.0.0rc1; python_version>='3.9'"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/swig/python/setup.py.in
+++ b/swig/python/setup.py.in
@@ -73,6 +73,7 @@ def get_numpy_include():
     _set_builtin("__NUMPY_SETUP__", False)
 
     import numpy
+    print('Using numpy ' + numpy.__version__)
     return numpy.get_include()
 
 


### PR DESCRIPTION
Backport #9761
 **Authored by:** @rouault