### PR TITLE
LOS: Implement simple violation location reporting

### DIFF
--- a/alg/los.cpp
+++ b/alg/los.cpp
@@ -177,13 +177,11 @@ static bool IsAboveTerrain(const GDALRasterBandH hBand, const int x,
  *
  * @param[out] pnxTerrainIntersection The X location where the LOS line
  *             intersects with terrain, or nullptr if it does not intersect
- *             terrain. Not implemented currently (*pnxTerrainIntersection
- *             is set to -1)
+ *             terrain.
  *
  * @param[out] pnyTerrainIntersection The Y location where the LOS line
  *             intersects with terrain, or nullptr if it does not intersect
- *             terrain. Not implemented currently (*pnyTerrainIntersection
- *             is set to -1)
+ *             terrain.
  *
  * @param papszOptions Options for the line of sight algorithm (currently ignored).
  *

--- a/alg/los.cpp
+++ b/alg/los.cpp
@@ -201,6 +201,19 @@ bool GDALIsLineOfSightVisible(const GDALRasterBandH hBand, const int xA,
 {
     VALIDATE_POINTER1(hBand, "GDALIsLineOfSightVisible", false);
 
+    // A lambda to set the X-Y intersection if it's not null
+    auto SetXYIntersection = [&](const int x, const int y)
+    {
+        if (pnxTerrainIntersection != nullptr)
+        {
+            *pnxTerrainIntersection = x;
+        }
+        if (pnyTerrainIntersection != nullptr)
+        {
+            *pnyTerrainIntersection = y;
+        }
+    };
+
     if (pnxTerrainIntersection)
         *pnxTerrainIntersection = -1;
 
@@ -210,10 +223,12 @@ bool GDALIsLineOfSightVisible(const GDALRasterBandH hBand, const int xA,
     // Perform a preliminary check of the start and end points.
     if (!IsAboveTerrain(hBand, xA, yA, zA))
     {
+        SetXYIntersection(xA, yA);
         return false;
     }
     if (!IsAboveTerrain(hBand, xB, yB, zB))
     {
+        SetXYIntersection(xB, yB);
         return false;
     }
 
@@ -261,6 +276,7 @@ bool GDALIsLineOfSightVisible(const GDALRasterBandH hBand, const int xA,
                 const auto zTest = GetZValueFromY(y);
                 if (!IsAboveTerrain(hBand, xA, y, zTest))
                 {
+                    SetXYIntersection(xA, y);
                     return false;
                 }
             }
@@ -273,6 +289,7 @@ bool GDALIsLineOfSightVisible(const GDALRasterBandH hBand, const int xA,
                 const auto zTest = GetZValueFromY(y);
                 if (!IsAboveTerrain(hBand, xA, y, zTest))
                 {
+                    SetXYIntersection(xA, y);
                     return false;
                 }
             }
@@ -294,6 +311,7 @@ bool GDALIsLineOfSightVisible(const GDALRasterBandH hBand, const int xA,
                 const auto zTest = GetZValueFromX(x);
                 if (!IsAboveTerrain(hBand, x, yA, zTest))
                 {
+                    SetXYIntersection(x, yA);
                     return false;
                 }
             }
@@ -306,6 +324,7 @@ bool GDALIsLineOfSightVisible(const GDALRasterBandH hBand, const int xA,
                 const auto zTest = GetZValueFromX(x);
                 if (!IsAboveTerrain(hBand, x, yA, zTest))
                 {
+                    SetXYIntersection(x, yA);
                     return false;
                 }
             }
@@ -348,6 +367,11 @@ bool GDALIsLineOfSightVisible(const GDALRasterBandH hBand, const int xA,
     auto OnBresenhamPoint = [&](const int x, const int y) -> bool
     {
         const auto z = GetZValueFromXY(x, y);
+        const auto isAbove = IsAboveTerrain(hBand, x, y, z);
+        if (!isAbove)
+        {
+            SetXYIntersection(x, y);
+        }
         return IsAboveTerrain(hBand, x, y, z);
     };
 

--- a/autotest/cpp/test_alg.cpp
+++ b/autotest/cpp/test_alg.cpp
@@ -306,9 +306,19 @@ TEST_F(test_alg, GDALIsLineOfSightVisible_single_point_dataset)
     // One point below terrain
     EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 0, 0, 0.0, 0, 0, 43.0, nullptr,
                                           nullptr, nullptr));
+    int xIntersection, yIntersection;
+    int *pXIntersection = &xIntersection;
+    int *pYIntersection = &yIntersection;
+    EXPECT_FALSE(GDALIsLineOfSightVisible(
+        pBand, 0, 0, 0.0, 0, 0, 43.0, pXIntersection, pYIntersection, nullptr));
+    EXPECT_EQ(*pXIntersection, 0);
+    EXPECT_EQ(*pYIntersection, 0);
     // Both points above terrain
     EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, 0, 0, 44.0, 0, 0, 43.0, nullptr,
                                          nullptr, nullptr));
+    EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, 0, 0, 44.0, 0, 0, 43.0,
+                                         pXIntersection, pYIntersection,
+                                         nullptr));
 }
 
 // Test GDALIsLineOfSightVisible() with 10x10 default dataset
@@ -333,6 +343,11 @@ TEST_F(test_alg, GDALIsLineOfSightVisible_default_square_dataset)
     // Both points are above terrain.
     EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, x1, y1, 1.0, x2, y2, 1.0,
                                          nullptr, nullptr, nullptr));
+    // Both points are above terrain, supply intersection.
+    int xIntersection, yIntersection;
+    EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, x1, y1, 1.0, x2, y2, 1.0,
+                                         &xIntersection, &yIntersection,
+                                         nullptr));
     // Flip the order, same result.
     EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, x2, y2, 1.0, x1, y1, 1.0,
                                          nullptr, nullptr, nullptr));
@@ -340,9 +355,19 @@ TEST_F(test_alg, GDALIsLineOfSightVisible_default_square_dataset)
     // One point is below terrain.
     EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, x1, y1, -1.0, x2, y2, 1.0,
                                           nullptr, nullptr, nullptr));
+    int *pXIntersection = &xIntersection;
+    int *pYIntersection = &yIntersection;
+    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, x1, y1, -1.0, x2, y2, 1.0,
+                                          pXIntersection, pYIntersection,
+                                          nullptr));
+    EXPECT_EQ(*pXIntersection, 1);
+    EXPECT_EQ(*pYIntersection, 1);
     // Flip the order, same result.
     EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, x2, y2, -1.0, x1, y1, 1.0,
-                                          nullptr, nullptr, nullptr));
+                                          pXIntersection, pYIntersection,
+                                          nullptr));
+    EXPECT_EQ(*pXIntersection, 2);
+    EXPECT_EQ(*pYIntersection, 2);
 
     // Both points are below terrain.
     EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, x1, y1, -1.0, x2, y2, -1.0,
@@ -421,6 +446,15 @@ TEST_F(test_alg, GDALIsLineOfSightVisible_through_mountain)
     EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 0, 0, 295, 120, 120, 183,
                                           nullptr, nullptr, nullptr));
 
+    int xIntersection, yIntersection;
+    int *pXIntersection = &xIntersection;
+    int *pYIntersection = &yIntersection;
+    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 0, 0, 295, 120, 120, 183,
+                                          pXIntersection, pYIntersection,
+                                          nullptr));
+    EXPECT_EQ(*pXIntersection, 2);
+    EXPECT_EQ(*pYIntersection, 2);
+
     // Test positive slope bresenham diagnoals across the whole raster.
     // Both high above terrain.
     EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, 0, 120, 460, 120, 0, 460,
@@ -428,6 +462,12 @@ TEST_F(test_alg, GDALIsLineOfSightVisible_through_mountain)
     // Both heights are 1m above in the corners, but middle terrain violates LOS.
     EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 0, 120, 203, 120, 0, 247,
                                           nullptr, nullptr, nullptr));
+    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 0, 120, 203, 120, 0, 247,
+                                          pXIntersection, pYIntersection,
+                                          nullptr));
+
+    EXPECT_EQ(*pXIntersection, 120);
+    EXPECT_EQ(*pYIntersection, 0);
 
     // Vertical line tests with hill between two points, in both directions.
     EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 83, 111, 154, 83, 117, 198,


### PR DESCRIPTION
## What does this PR do?

* Implements basic support for reporting a location where LOS  is violated. It reports the location of the first detected violation.
* It's not symmetric due to bresenham's optimizations, but it will at least return one location where terrain is violated (if it is)

## What are related issues/pull requests?

#9562 

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Ubuntu 22
* Compiler: G++11

## Instructions
```bash
cmake -S . -B build -DBUILD_TESTING=ON -DCMAKE_BUILD_TYPE=Debug
cmake --build build --target gdal_unit_test -j `nproc`
./build/autotest/cpp/gdal_unit_test --gtest_filter="test_alg.GDALIsLineOfSightVisible*"
# Or, with GDB
 gdb ./build/autotest/cpp/gdal_unit_test
>>> r --gtest_filter="test_alg.GDALIsLineOfSightVisible*"
```
