### PR TITLE
Miramon: fix memleak in creation error case

### DIFF
--- a/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
+++ b/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
@@ -7203,7 +7203,14 @@ static int MMCloseMMBD_XPFile(struct MiraMonVectLayerInfo *hMiraMonLayer,
 
     ret_code = 0;
 end_label:
+
     // Closing database files
+    if (MMAdmDB->pMMBDXP && MMAdmDB->pMMBDXP->pfDataBase &&
+        MMAdmDB->pMMBDXP->pfDataBase != MMAdmDB->pFExtDBF)
+    {
+        fclose_and_nullify(&MMAdmDB->pMMBDXP->pfDataBase);
+    }
+
     fclose_and_nullify(&MMAdmDB->pFExtDBF);
 
     return ret_code;


### PR DESCRIPTION
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=68316

The minimum reproducer is:
```
$ printf "\x07\n " > weird.csv
$ valgrind --leak-check=full ogr2ogr "/vsimem/foo.pol" weird.csv
==3324747== Memcheck, a memory error detector
==3324747== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==3324747== Using Valgrind-3.15.0 and LibVEX; rerun with -h for copyright info
==3324747== Command: ogr2ogr /vsimem/foo.pol weird.csv
==3324747==
ERROR 3: MiraMon write failure: Success
ERROR 1: Unable to write feature 1 from layer weird.
ERROR 1: Terminating translation prematurely after failed
translation of layer weird (use -skipfailures to skip errors)
==3324747==
==3324747== HEAP SUMMARY:
==3324747==     in use at exit: 17,585 bytes in 9 blocks
==3324747==   total heap usage: 11,042 allocs, 11,033 frees, 1,873,525 bytes allocated
==3324747==
==3324747== 5,201 (40 direct, 5,161 indirect) bytes in 1 blocks are definitely lost in loss record 9 of 9
==3324747==    at 0x483BE63: operator new(unsigned long) (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==3324747==    by 0x51F8434: VSIMemFilesystemHandler::Open(char const*, char const*, bool, char const* const*) (cpl_vsi_mem.cpp:639)
==3324747==    by 0x50A4890: VSIFOpenEx2L (cpl_vsil.cpp:2008)
==3324747==    by 0x50A4802: VSIFOpenExL (cpl_vsil.cpp:1943)
==3324747==    by 0x50A20F7: VSIFOpenL (cpl_vsil.cpp:1289)
==3324747==    by 0x5EA3232: MM_UpdateEntireHeader (mm_gdal_functions.c:710)
==3324747==    by 0x5EA43BC: MM_CreateDBFFile (mm_gdal_functions.c:1090)
==3324747==    by 0x5E9EFB0: MMInitMMDB (mm_wrlayr.c:6107)
==3324747==    by 0x5E9FB08: MMCreateMMDB (mm_wrlayr.c:6347)
==3324747==    by 0x5E9AC9C: MMCreateRecordDBF (mm_wrlayr.c:4351)
==3324747==    by 0x5E9B52F: MMAddFeature (mm_wrlayr.c:4642)
==3324747==    by 0x5E8E5E4: OGRMiraMonLayer::MMWriteGeometry() (ogrmiramonlayer.cpp:1864)
==3324747==
```
