### PR TITLE
Update gdaltransform.rst to hint that it is perfectly vector ready

### DIFF
--- a/doc/source/programs/gdaltransform.rst
+++ b/doc/source/programs/gdaltransform.rst
@@ -109,7 +109,7 @@ projection,including GCP-based transformations.
 
 .. option:: -gcp <pixel> <line> <easting> <northing> [<elevation>]
 
-    Provide a GCP to be used for transformation (generally three or more are required. Also unlike gdallocationinfo output, pixel and line need not be integers.)
+    Provide a GCP to be used for transformation (generally three or more are required). Pixel and line need not be integers.
 
 .. option:: -output_xy
 

--- a/doc/source/programs/gdaltransform.rst
+++ b/doc/source/programs/gdaltransform.rst
@@ -109,7 +109,7 @@ projection,including GCP-based transformations.
 
 .. option:: -gcp <pixel> <line> <easting> <northing> [<elevation>]
 
-    Provide a GCP to be used for transformation (generally three or more are required)
+    Provide a GCP to be used for transformation (generally three or more are required. Also unlike gdallocationinfo output, pixel and line need not be integers.)
 
 .. option:: -output_xy
 


### PR DESCRIPTION
Yes, `<pixel>` and `<line>` should just be called `<x>` and `<y>`, but I'm not that bold to rip things up here.

By the way I wonder if there is any _vector_ format that can contain GCPs so one needn't use `-gcp` but instead just have them in `srcfile`.
