### PR TITLE
[Backport release/3.9] gdalinfo and ogrinfo -json: add newline character at end of JSON output

### DIFF
--- a/apps/gdalinfo_lib.cpp
+++ b/apps/gdalinfo_lib.cpp
@@ -1898,6 +1898,7 @@ char *GDALInfo(GDALDatasetH hDataset, const GDALInfoOptions *psOptions)
 #endif
                    ));
         json_object_put(poJsonObject);
+        Concat(osStr, psOptions->bStdoutOutput, "\n");
     }
 
     if (psOptionsToFree != nullptr)

--- a/apps/ogrinfo_lib.cpp
+++ b/apps/ogrinfo_lib.cpp
@@ -2175,6 +2175,7 @@ char *GDALVectorInfo(GDALDatasetH hDataset,
                     | JSON_C_TO_STRING_NOSLASHESCAPE
 #endif
                 ));
+        ConcatStr(osRet, psOptions->bStdoutOutput, "\n");
     }
 
     return VSI_STRDUP_VERBOSE(osRet);


### PR DESCRIPTION
Backport #9794
 **Authored by:** @rouault