### PR TITLE
[Backport release/3.9] Parquet: fix ResetReading() implementation, when using the ParquetDataset API and when there's a single batch

### DIFF
--- a/autotest/ogr/ogr_parquet.py
+++ b/autotest/ogr/ogr_parquet.py
@@ -1551,6 +1551,24 @@ def test_ogr_parquet_read_partitioned_flat(use_vsi, use_metadata_file, prefix):
 
 
 ###############################################################################
+# Run test_ogrsf
+
+
+@pytest.mark.skipif(not _has_arrow_dataset(), reason="GDAL not built with ArrowDataset")
+def test_ogr_parquet_test_ogrsf_dataset():
+
+    if test_cli_utilities.get_test_ogrsf_path() is None:
+        pytest.skip()
+
+    ret = gdaltest.runexternal(
+        test_cli_utilities.get_test_ogrsf_path() + " -ro data/parquet/partitioned_flat"
+    )
+
+    assert "INFO" in ret
+    assert "ERROR" not in ret
+
+
+###############################################################################
 # Test reading a HIVE partitioned dataset
 
 

--- a/autotest/ogr/ogr_parquet.py
+++ b/autotest/ogr/ogr_parquet.py
@@ -1569,6 +1569,25 @@ def test_ogr_parquet_test_ogrsf_dataset():
 
 
 ###############################################################################
+# Run test_ogrsf
+
+
+@pytest.mark.skipif(not _has_arrow_dataset(), reason="GDAL not built with ArrowDataset")
+def test_ogr_parquet_test_ogrsf_dataset_on_file():
+
+    if test_cli_utilities.get_test_ogrsf_path() is None:
+        pytest.skip()
+
+    ret = gdaltest.runexternal(
+        test_cli_utilities.get_test_ogrsf_path()
+        + " -ro PARQUET:data/parquet/test.parquet"
+    )
+
+    assert "INFO" in ret
+    assert "ERROR" not in ret
+
+
+###############################################################################
 # Test reading a HIVE partitioned dataset
 
 

--- a/ogr/ogrsf_frmts/parquet/ogr_parquet.h
+++ b/ogr/ogrsf_frmts/parquet/ogr_parquet.h
@@ -66,6 +66,8 @@ class OGRParquetLayerBase CPL_NON_FINAL : public OGRArrowLayer
   public:
     int TestCapability(const char *) override;
 
+    void ResetReading() override;
+
     GDALDataset *GetDataset() override;
 };
 
@@ -245,7 +247,6 @@ class OGRParquetDatasetLayer final : public OGRParquetLayerBase
         const std::shared_ptr<arrow::Schema> &schema,
         CSLConstList papszOpenOptions);
 
-    void ResetReading() override;
     GIntBig GetFeatureCount(int bForce) override;
     OGRErr GetExtent(OGREnvelope *psExtent, int bForce = TRUE) override;
     OGRErr GetExtent(int iGeomField, OGREnvelope *psExtent,

--- a/ogr/ogrsf_frmts/parquet/ogrparquetdatasetlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetdatasetlayer.cpp
@@ -96,16 +96,6 @@ void OGRParquetDatasetLayer::EstablishFeatureDefn()
 }
 
 /************************************************************************/
-/*                           ResetReading()                             */
-/************************************************************************/
-
-void OGRParquetDatasetLayer::ResetReading()
-{
-    m_poRecordBatchReader.reset();
-    OGRParquetLayerBase::ResetReading();
-}
-
-/************************************************************************/
 /*                           ReadNextBatch()                            */
 /************************************************************************/
 

--- a/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
@@ -71,6 +71,19 @@ GDALDataset *OGRParquetLayerBase::GetDataset()
 }
 
 /************************************************************************/
+/*                           ResetReading()                             */
+/************************************************************************/
+
+void OGRParquetLayerBase::ResetReading()
+{
+    if (m_iRecordBatch != 0)
+    {
+        m_poRecordBatchReader.reset();
+    }
+    OGRArrowLayer::ResetReading();
+}
+
+/************************************************************************/
 /*                          LoadGeoMetadata()                           */
 /************************************************************************/
 
@@ -1250,10 +1263,6 @@ OGRFeature *OGRParquetLayer::GetFeature(GIntBig nFID)
 
 void OGRParquetLayer::ResetReading()
 {
-    if (m_iRecordBatch != 0)
-    {
-        m_poRecordBatchReader.reset();
-    }
     OGRParquetLayerBase::ResetReading();
     m_oFeatureIdxRemappingIter = m_asFeatureIdxRemapping.begin();
     m_nFeatureIdxSelected = 0;


### PR DESCRIPTION
Backport #9796
 **Authored by:** @rouault