### PR TITLE
MiraMonVector deleting duplicate reference and adding some controls about deferred null pointers

### DIFF
--- a/ogr/ogrsf_frmts/miramon/mm_gdal_driver_structs.h
+++ b/ogr/ogrsf_frmts/miramon/mm_gdal_driver_structs.h
@@ -355,7 +355,7 @@ struct MMAdmDatabase
     // Name of the extended DBF file
     char pszExtDBFLayerName[MM_CPL_PATH_BUF_SIZE];
     // Pointer to the extended DBF file
-    FILE_TYPE *pFExtDBF;
+    //FILE_TYPE *pFExtDBF; // ==  pMMBDXP->pfDataBase
     // Pointer to a MiraMon table (auxiliary)
     struct MM_DATA_BASE_XP *pMMBDXP;
     // How to write all it to disk

--- a/ogr/ogrsf_frmts/miramon/mm_gdal_driver_structs.h
+++ b/ogr/ogrsf_frmts/miramon/mm_gdal_driver_structs.h
@@ -354,8 +354,6 @@ struct MMAdmDatabase
     // MiraMon table (extended DBF)
     // Name of the extended DBF file
     char pszExtDBFLayerName[MM_CPL_PATH_BUF_SIZE];
-    // Pointer to the extended DBF file
-    //FILE_TYPE *pFExtDBF; // ==  pMMBDXP->pfDataBase
     // Pointer to a MiraMon table (auxiliary)
     struct MM_DATA_BASE_XP *pMMBDXP;
     // How to write all it to disk

--- a/ogr/ogrsf_frmts/miramon/mm_gdal_functions.c
+++ b/ogr/ogrsf_frmts/miramon/mm_gdal_functions.c
@@ -704,6 +704,9 @@ MM_OpenIfNeededAndUpdateEntireHeader(struct MM_DATA_BASE_XP *data_base_XP)
     char nom_camp[MM_MAX_LON_FIELD_NAME_DBF];
     size_t retorn_fwrite;
 
+    if (!data_base_XP)
+        return FALSE;
+
     if (data_base_XP->pfDataBase == nullptr)
     {
         strcpy(ModeLectura_previ, data_base_XP->ReadingMode);
@@ -1140,7 +1143,7 @@ int MM_ReadExtendedDBFHeaderFromFile(const char *szFileName,
     GUInt32 nRecords32LowBits;
     char *pszString;
 
-    if (!szFileName)
+    if (!szFileName || !pMMBDXP)
         return 1;
 
     CPLStrlcpy(pMMBDXP->szFileName, szFileName, sizeof(pMMBDXP->szFileName));
@@ -2188,6 +2191,9 @@ int MM_ChangeDBFWidthField(struct MM_DATA_BASE_XP *data_base_XP,
     MM_EXT_DBF_N_FIELDS i_camp;
     size_t retorn_fwrite;
     int retorn_TruncaFitxer;
+
+    if (!data_base_XP)
+        return 1;
 
     canvi_amplada = nNewWidth - data_base_XP->pField[nIField].BytesPerField;
 

--- a/ogr/ogrsf_frmts/miramon/mm_gdal_functions.c
+++ b/ogr/ogrsf_frmts/miramon/mm_gdal_functions.c
@@ -640,11 +640,12 @@ MM_GiveOffsetExtendedFieldName(const struct MM_FIELD *camp)
 
 int MM_WriteNRecordsMMBD_XPFile(struct MMAdmDatabase *MMAdmDB)
 {
-    if (!MMAdmDB->pMMBDXP || !MMAdmDB->pFExtDBF)
+    if (!MMAdmDB->pMMBDXP || !MMAdmDB->pMMBDXP->pfDataBase)
         return 0;
 
     // Updating number of features in features table
-    fseek_function(MMAdmDB->pFExtDBF, MM_FIRST_OFFSET_to_N_RECORDS, SEEK_SET);
+    fseek_function(MMAdmDB->pMMBDXP->pfDataBase, MM_FIRST_OFFSET_to_N_RECORDS,
+                   SEEK_SET);
 
     if (MMAdmDB->pMMBDXP->nRecords > UINT32_MAX)
     {
@@ -658,35 +659,39 @@ int MM_WriteNRecordsMMBD_XPFile(struct MMAdmDatabase *MMAdmDB)
     {
         GUInt32 nRecords32LowBits =
             (GUInt32)(MMAdmDB->pMMBDXP->nRecords & UINT32_MAX);
-        if (fwrite_function(&nRecords32LowBits, 4, 1, MMAdmDB->pFExtDBF) != 1)
+        if (fwrite_function(&nRecords32LowBits, 4, 1,
+                            MMAdmDB->pMMBDXP->pfDataBase) != 1)
             return 1;
     }
 
-    fseek_function(MMAdmDB->pFExtDBF, MM_SECOND_OFFSET_to_N_RECORDS, SEEK_SET);
+    fseek_function(MMAdmDB->pMMBDXP->pfDataBase, MM_SECOND_OFFSET_to_N_RECORDS,
+                   SEEK_SET);
     if (MMAdmDB->pMMBDXP->dbf_version == MM_MARCA_VERSIO_1_DBF_ESTESA)
     {
         /* from 16 to 19, position MM_SECOND_OFFSET_to_N_RECORDS */
         GUInt32 nRecords32HighBits =
             (GUInt32)(MMAdmDB->pMMBDXP->nRecords >> 32);
-        if (fwrite_function(&nRecords32HighBits, 4, 1, MMAdmDB->pFExtDBF) != 1)
+        if (fwrite_function(&nRecords32HighBits, 4, 1,
+                            MMAdmDB->pMMBDXP->pfDataBase) != 1)
             return 1;
 
         /* from 20 to 27 */
         if (fwrite_function(&(MMAdmDB->pMMBDXP->dbf_on_a_LAN), 8, 1,
-                            MMAdmDB->pFExtDBF) != 1)
+                            MMAdmDB->pMMBDXP->pfDataBase) != 1)
             return 1;
     }
     else
     {
         if (fwrite_function(&(MMAdmDB->pMMBDXP->dbf_on_a_LAN), 12, 1,
-                            MMAdmDB->pFExtDBF) != 1)
+                            MMAdmDB->pMMBDXP->pfDataBase) != 1)
             return 1;
     }
 
     return 0;
 }
 
-static MM_BOOLEAN MM_UpdateEntireHeader(struct MM_DATA_BASE_XP *data_base_XP)
+static MM_BOOLEAN
+MM_OpenIfNeededAndUpdateEntireHeader(struct MM_DATA_BASE_XP *data_base_XP)
 {
     MM_BYTE variable_byte;
     MM_EXT_DBF_N_FIELDS i, j = 0;
@@ -698,12 +703,11 @@ static MM_BOOLEAN MM_UpdateEntireHeader(struct MM_DATA_BASE_XP *data_base_XP)
     int estat;
     char nom_camp[MM_MAX_LON_FIELD_NAME_DBF];
     size_t retorn_fwrite;
-    MM_BOOLEAN table_should_be_closed = FALSE;
 
     if (data_base_XP->pfDataBase == nullptr)
     {
         strcpy(ModeLectura_previ, data_base_XP->ReadingMode);
-        strcpy(data_base_XP->ReadingMode, "wb");
+        strcpy(data_base_XP->ReadingMode, "wb+");
 
         if ((data_base_XP->pfDataBase =
                  fopen_function(data_base_XP->szFileName,
@@ -711,8 +715,11 @@ static MM_BOOLEAN MM_UpdateEntireHeader(struct MM_DATA_BASE_XP *data_base_XP)
         {
             return FALSE;
         }
-
-        table_should_be_closed = TRUE;
+    }
+    else
+    {
+        // If it's open we just update the header
+        fseek_function(data_base_XP->pfDataBase, 0, SEEK_SET);
     }
 
     if ((data_base_XP->nFields) > MM_MAX_N_CAMPS_DBF_CLASSICA)
@@ -1067,23 +1074,18 @@ static MM_BOOLEAN MM_UpdateEntireHeader(struct MM_DATA_BASE_XP *data_base_XP)
         }
     }
 
-    if (table_should_be_closed)
-    {
-        fclose_and_nullify(&data_base_XP->pfDataBase);
-    }
-
     return TRUE;
-} /* End of MM_UpdateEntireHeader() */
+} /* End of MM_OpenIfNeededAndUpdateEntireHeader() */
 
-MM_BOOLEAN MM_CreateDBFFile(struct MM_DATA_BASE_XP *bd_xp,
-                            const char *NomFitxer)
+MM_BOOLEAN MM_CreateAndOpenDBFFile(struct MM_DATA_BASE_XP *bd_xp,
+                                   const char *NomFitxer)
 {
     if (!NomFitxer || MMIsEmptyString(NomFitxer) || !bd_xp)
         return FALSE;
 
     MM_CheckDBFHeader(bd_xp);
     CPLStrlcpy(bd_xp->szFileName, NomFitxer, sizeof(bd_xp->szFileName));
-    return MM_UpdateEntireHeader(bd_xp);
+    return MM_OpenIfNeededAndUpdateEntireHeader(bd_xp);
 }
 
 void MM_ReleaseMainFields(struct MM_DATA_BASE_XP *data_base_XP)
@@ -2379,7 +2381,7 @@ int MM_ChangeDBFWidthField(struct MM_DATA_BASE_XP *data_base_XP,
     }
     data_base_XP->pField[nIField].DecimalsIfFloat = nNewPrecision;
 
-    if ((MM_UpdateEntireHeader(data_base_XP)) == FALSE)
+    if ((MM_OpenIfNeededAndUpdateEntireHeader(data_base_XP)) == FALSE)
         return 1;
 
     return 0;

--- a/ogr/ogrsf_frmts/miramon/mm_gdal_functions.h
+++ b/ogr/ogrsf_frmts/miramon/mm_gdal_functions.h
@@ -111,8 +111,8 @@ struct MM_DATA_BASE_XP *MM_CreateDBFHeader(MM_EXT_DBF_N_FIELDS n_camps,
                                            MM_BYTE nCharSet);
 void MM_ReleaseMainFields(struct MM_DATA_BASE_XP *data_base_XP);
 void MM_ReleaseDBFHeader(struct MM_DATA_BASE_XP *data_base_XP);
-MM_BOOLEAN MM_CreateDBFFile(struct MM_DATA_BASE_XP *bd_xp,
-                            const char *NomFitxer);
+MM_BOOLEAN MM_CreateAndOpenDBFFile(struct MM_DATA_BASE_XP *bd_xp,
+                                   const char *NomFitxer);
 int MM_DuplicateFieldDBXP(struct MM_FIELD *camp_final,
                           const struct MM_FIELD *camp_inicial);
 int MM_WriteNRecordsMMBD_XPFile(struct MMAdmDatabase *MMAdmDB);

--- a/ogr/ogrsf_frmts/miramon/mm_rdlayr.c
+++ b/ogr/ogrsf_frmts/miramon/mm_rdlayr.c
@@ -672,6 +672,8 @@ int MM_ReadExtendedDBFHeader(struct MiraMonVectLayerInfo *hMiraMonLayer)
         return 0;
 
     pMMBDXP = hMiraMonLayer->pMMBDXP = calloc_function(sizeof(*pMMBDXP));
+    if (!pMMBDXP)
+        return 1;
 
     if (hMiraMonLayer->bIsPoint)
     {

--- a/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
+++ b/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
@@ -6093,10 +6093,7 @@ int MMCheck_REL_FILE(const char *szREL_file)
 static int MMInitMMDB(struct MiraMonVectLayerInfo *hMiraMonLayer,
                       struct MMAdmDatabase *pMMAdmDB)
 {
-    if (!hMiraMonLayer)
-        return 1;
-
-    if (!pMMAdmDB)
+    if (!hMiraMonLayer || !pMMAdmDB)
         return 1;
 
     if (MMIsEmptyString(pMMAdmDB->pszExtDBFLayerName))
@@ -6361,7 +6358,8 @@ MMTestAndFixValueToRecordDBXP(struct MiraMonVectLayerInfo *hMiraMonLayer,
     struct MM_FIELD *camp;
     MM_BYTES_PER_FIELD_TYPE_DBF nNewWidth;
 
-    if (!hMiraMonLayer)
+    if (!hMiraMonLayer || !pMMAdmDB || !pMMAdmDB->pMMBDXP ||
+        !pMMAdmDB->pMMBDXP->pField || !pMMAdmDB->pMMBDXP->pfDataBase)
         return 1;
 
     camp = pMMAdmDB->pMMBDXP->pField + nIField;
@@ -6382,8 +6380,6 @@ MMTestAndFixValueToRecordDBXP(struct MiraMonVectLayerInfo *hMiraMonLayer,
         pMMAdmDB->FlushRecList.SizeOfBlockToBeSaved = 0;
         if (MMAppendBlockToBuffer(&pMMAdmDB->FlushRecList))
             return 1;
-
-        //pMMAdmDB->pMMBDXP->pfDataBase = pMMAdmDB->pFExtDBF;
 
         if (MM_ChangeDBFWidthField(
                 pMMAdmDB->pMMBDXP, nIField, nNewWidth,
@@ -7212,7 +7208,7 @@ int MMCloseMMBD_XP(struct MiraMonVectLayerInfo *hMiraMonLayer)
     if (!hMiraMonLayer)
         return 1;
 
-    if (hMiraMonLayer->pMMBDXP)
+    if (hMiraMonLayer->pMMBDXP && hMiraMonLayer->pMMBDXP->pfDataBase)
     {
         fclose_and_nullify(&hMiraMonLayer->pMMBDXP->pfDataBase);
     }


### PR DESCRIPTION
## What does this PR do?
There was a confusing access to the same file:
"pFExtDBF" and "pMMBDXP->pfDataBase"
This PR deletes pFExtDBF and substitute the use of pFExtDBF by pMMBDXP->pfDataBase.
Also controls some possible deferred null pointers to avoid crashes.

Actual tests are good enough to validate this PR.

## What are related issues/pull requests?
This PR is an alternative to the solution in https://github.com/OSGeo/gdal/pull/9787 which is still opened because it's not clear why there are to pointers to the same file.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] All CI builds and checks have passed