### PR TITLE
[Backport release/3.9] gdal2tiles: support an input dataset name not being a file

### DIFF
--- a/autotest/pyscripts/gdal2tiles/test_option_parser.py
+++ b/autotest/pyscripts/gdal2tiles/test_option_parser.py
@@ -48,7 +48,7 @@ class AttrDict(dict):
 
 class OptionParserInputOutputTest(TestCase):
     def test_vanilla_input_output(self):
-        _, input_file = tempfile.mkstemp()
+        input_file = "../../gcore/data/byte.tif"
         output_folder = tempfile.mkdtemp()
         parsed_input, parsed_output, options = gdal2tiles.process_args(
             [input_file, output_folder]
@@ -59,10 +59,10 @@ class OptionParserInputOutputTest(TestCase):
         self.assertNotEqual(options, {})
 
     def test_output_folder_is_the_input_file_folder_when_none_passed(self):
-        _, input_file = tempfile.mkstemp()
+        input_file = "../../gcore/data/byte.tif"
         _, parsed_output, _ = gdal2tiles.process_args([input_file])
 
-        self.assertEqual(parsed_output, os.path.basename(input_file))
+        self.assertEqual(parsed_output, "byte")
 
     def _asserts_exits_with_code_2(self, params):
         with self.assertRaises(SystemExit) as cm:

--- a/autotest/pyscripts/test_gdal2tiles.py
+++ b/autotest/pyscripts/test_gdal2tiles.py
@@ -36,6 +36,7 @@ import shutil
 import struct
 import sys
 
+import gdaltest
 import pytest
 import test_py_scripts  # noqa  # pylint: disable=E0401
 
@@ -140,13 +141,14 @@ def test_gdal2tiles_py_zoom_option(script_path, tmp_path):
 
     tiles_dir = str(tmp_path / "out_gdal2tiles_smallworld")
 
-    # Because of multiprocessing, run as external process, to avoid issues with
-    # Ubuntu 12.04 and socket.setdefaulttimeout()
-    # as well as on Windows that doesn't manage to fork
+    # Because of multiprocessing, run as external process, to avoid issues
+    # for example on Windows that doesn't manage to fork
+    # Also test non-file input dataset (e.g. vrt://)
     test_py_scripts.run_py_script_as_external_script(
         script_path,
         "gdal2tiles",
         "-q --force-kml --processes=2 -z 0-1 "
+        + "vrt://"
         + test_py_scripts.get_data_path("gdrivers")
         + f"small_world.tif {tiles_dir}",
     )
@@ -210,6 +212,9 @@ def test_gdal2tiles_py_resampling_option(script_path, tmp_path, resample):
 
 @pytest.mark.require_driver("PNG")
 def test_gdal2tiles_py_xyz(script_path, tmp_path):
+
+    if gdaltest.is_travis_branch("sanitize"):
+        pytest.skip("fails on sanitize for unknown reason")
 
     input_tif = str(tmp_path / "out_gdal2tiles_smallworld_xyz.tif")
     out_dir = input_tif.strip(".tif")

--- a/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
@@ -2010,9 +2010,14 @@ def process_args(argv: List[str], called_from_main=False) -> Tuple[str, str, Opt
         )
 
     input_file = args[0]
-    if not isfile(input_file):
+    try:
+        input_file_exists = gdal.Open(input_file) is not None
+    except Exception:
+        input_file_exists = False
+    if not input_file_exists:
         exit_with_error(
-            "The provided input file %s does not exist or is not a file" % input_file
+            "The provided input file %s does not exist or is not a recognized GDAL dataset"
+            % input_file
         )
 
     if len(args) == 2:


### PR DESCRIPTION
Backport #9809
 **Authored by:** @rouault