### PR TITLE
TileDB multidimensional fixes

### DIFF
--- a/frmts/tiledb/tiledbmultidim.h
+++ b/frmts/tiledb/tiledbmultidim.h
@@ -31,6 +31,8 @@
 
 #include "tiledbheaders.h"
 
+#include <set>
+
 constexpr const char *CRS_ATTRIBUTE_NAME = "_CRS";
 constexpr const char *UNIT_ATTRIBUTE_NAME = "_UNIT";
 constexpr const char *DIM_TYPE_ATTRIBUTE_NAME = "_DIM_TYPE";
@@ -164,6 +166,9 @@ class TileDBGroup final : public GDALGroup, public TileDBAttributeHolder
     mutable std::map<std::string, std::shared_ptr<TileDBArray>> m_oMapArrays{};
     mutable std::map<std::string, std::shared_ptr<GDALDimension>>
         m_oMapDimensions{};
+
+    //! To prevent OpenMDArray() to indefinitely recursing
+    mutable std::set<std::string> m_oSetArrayInOpening{};
 
     TileDBGroup(const std::shared_ptr<TileDBSharedResource> &poSharedResource,
                 const std::string &osParentName, const std::string &osName,

--- a/frmts/tiledb/tiledbmultidimgroup.cpp
+++ b/frmts/tiledb/tiledbmultidimgroup.cpp
@@ -478,9 +478,13 @@ TileDBGroup::OpenMDArray(const std::string &osName,
     if (osSubPath.empty())
         return nullptr;
 
+    if (m_oSetArrayInOpening.find(osName) != m_oSetArrayInOpening.end())
+        return nullptr;
+    m_oSetArrayInOpening.insert(osName);
     auto poArray = TileDBArray::OpenFromDisk(m_poSharedResource, m_pSelf.lock(),
                                              m_osFullName, osName, osNameSuffix,
                                              osSubPath, papszOptions);
+    m_oSetArrayInOpening.erase(osName);
     if (!poArray)
         return nullptr;
 

--- a/frmts/tiledb/tiledbmultidimgroup.cpp
+++ b/frmts/tiledb/tiledbmultidimgroup.cpp
@@ -469,7 +469,7 @@ TileDBGroup::OpenMDArray(const std::string &osName,
             }
             else if (MatchNameSuffix(CPLGetFilename(obj.uri().c_str())))
             {
-                osSubPathCandidate = osSubPath;
+                osSubPathCandidate = obj.uri();
             }
         }
     }


### PR DESCRIPTION
- TileDB multidim: prevent infinite recursion when opening an array in a group where there are 2 or more 2D+ arrays
- TileDBGroup::OpenMDArray(): fix opening an array, member of a group, which has no explicit name
