### PR TITLE
Deprecate GDALDestroyDriverManager() and OGRCleanupAll() for GDALCleanup()

### DIFF
--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -1045,9 +1045,7 @@ void CPL_DLL CPL_STDCALL GDALDestroyDriver(GDALDriverH);
 int CPL_DLL CPL_STDCALL GDALRegisterDriver(GDALDriverH);
 void CPL_DLL CPL_STDCALL GDALDeregisterDriver(GDALDriverH);
 void CPL_DLL CPL_STDCALL GDALDestroyDriverManager(void);
-#ifndef DOXYGEN_SKIP
 void CPL_DLL GDALDestroy(void);
-#endif
 CPLErr CPL_DLL CPL_STDCALL GDALDeleteDataset(GDALDriverH, const char *);
 CPLErr CPL_DLL CPL_STDCALL GDALRenameDataset(GDALDriverH,
                                              const char *pszNewName,

--- a/gcore/gdaldllmain.cpp
+++ b/gcore/gdaldllmain.cpp
@@ -47,6 +47,8 @@ int GDALIsInGlobalDestructor()
 
 void CPLFinalizeTLS();
 
+static bool bGDALDestroyAlreadyCalled = FALSE;
+
 /************************************************************************/
 /*                           GDALDestroy()                              */
 /************************************************************************/
@@ -69,8 +71,6 @@ void CPLFinalizeTLS();
  *
  * @since GDAL 2.0
  */
-
-static bool bGDALDestroyAlreadyCalled = FALSE;
 
 void GDALDestroy(void)
 {

--- a/gcore/gdaldrivermanager.cpp
+++ b/gcore/gdaldrivermanager.cpp
@@ -1692,6 +1692,9 @@ void GDALDriverManager::DeclareDeferredPluginDriver(
  *
  * NOTE: This function is not thread safe.  It should not be called while
  * other threads are actively using GDAL.
+ *
+ * \see GDALDestroy()
+ * \deprecated Use GDALDestroy() instead
  */
 
 void CPL_STDCALL GDALDestroyDriverManager(void)

--- a/ogr/ogrsf_frmts/generic/ogrmutexeddatasource.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrmutexeddatasource.cpp
@@ -301,15 +301,4 @@ std::shared_ptr<GDALGroup> OGRMutexedDataSource::GetRootGroup() const
     return m_poBaseDataSource->GetRootGroup();
 }
 
-#if defined(_WIN32) && defined(_MSC_VER)
-// Horrible hack: for some reason MSVC doesn't export the class
-// if it is not referenced from the DLL itself
-void OGRRegisterMutexedDataSource();
-
-void OGRRegisterMutexedDataSource()
-{
-    delete new OGRMutexedDataSource(NULL, FALSE, NULL, FALSE);
-}
-#endif
-
 #endif /* #ifndef DOXYGEN_SKIP */

--- a/ogr/ogrsf_frmts/generic/ogrmutexedlayer.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrmutexedlayer.cpp
@@ -331,16 +331,4 @@ OGRErr OGRMutexedLayer::Rename(const char *pszNewName)
     return OGRLayerDecorator::Rename(pszNewName);
 }
 
-#if defined(_WIN32) && defined(_MSC_VER)
-// Horrible hack: for some reason MSVC doesn't export the class
-// if it is not referenced from the DLL itself
-void OGRRegisterMutexedLayer();
-
-void OGRRegisterMutexedLayer()
-{
-    CPLAssert(false);  // Never call this function: it will segfault
-    delete new OGRMutexedLayer(NULL, FALSE, NULL);
-}
-#endif
-
 #endif /* #ifndef DOXYGEN_SKIP */

--- a/ogr/ogrsf_frmts/generic/ogrsfdriverregistrar.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrsfdriverregistrar.cpp
@@ -80,7 +80,8 @@ int OGRwillNeverBeTrue = FALSE;
 /**
  * \brief Cleanup all OGR related resources.
  *
- * FIXME
+ * \see GDALDestroy()
+ * \deprecated Use GDALDestroy() instead
  */
 void OGRCleanupAll()
 

--- a/ogr/ogrsf_frmts/generic/ogrsfdriverregistrar.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrsfdriverregistrar.cpp
@@ -70,13 +70,6 @@ OGRSFDriverRegistrar *OGRSFDriverRegistrar::GetRegistrar()
 /*                           OGRCleanupAll()                            */
 /************************************************************************/
 
-#if defined(_WIN32) && defined(_MSC_VER)
-#include "ogremulatedtransaction.h"
-void OGRRegisterMutexedDataSource();
-void OGRRegisterMutexedLayer();
-int OGRwillNeverBeTrue = FALSE;
-#endif
-
 /**
  * \brief Cleanup all OGR related resources.
  *
@@ -87,17 +80,6 @@ void OGRCleanupAll()
 
 {
     GDALDestroyDriverManager();
-#if defined(_WIN32) && defined(_MSC_VER)
-    // Horrible hack: for some reason MSVC doesn't export those classes&symbols
-    // if they are not referenced from the DLL itself
-    if (OGRwillNeverBeTrue)
-    {
-        OGRRegisterMutexedDataSource();
-        OGRRegisterMutexedLayer();
-        OGRCreateEmulatedTransactionDataSourceWrapper(nullptr, nullptr, FALSE,
-                                                      FALSE);
-    }
-#endif
 }
 
 /************************************************************************/


### PR DESCRIPTION
and another cleanup

CC @elpaso