### PR TITLE
CMake: add html, man, latexpdf, doxygen, doxygen_check_warnings, clean_doc targets

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -1,170 +1,71 @@
 # CMake4GDAL project is distributed under MIT license. See accompanying file LICENSE.txt.
 
-# Documentation rules
 find_package(Doxygen)
-if (DOXYGEN_FOUND)
-  set(TARGET_HTML_DIR ${CMAKE_BINARY_DIR}/html)
-  file(MAKE_DIRECTORY ${TARGET_HTML_DIR})
-  # Generate translated docs. Should go first, because index.html page should be overwritten with the main one later
-  add_custom_command(
-    OUTPUT ${TARGET_HTML_DIR}/header.html ${TARGET_HTML_DIR}/footer.html ${TARGET_HTML_DIR}/stylesheet.css
-    COMMAND ${DOXYGEN_EXECUTABLE} -w html header.html footer.html stylesheet.css
-    WORKING_DIRECTORY ${TARGET_HTML_DIR})
-  # Generate Russian document
-  set(GDAL_DOXYGEN_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
-  set(GDAL_DOXYGEN_PROJECT_NAME "RU")
-  set(GDAL_DOXYGEN_LANGUAGE "Russian")
-  set(GDAL_DOXYGEN_JAVADOC_AUTOBRIEF "NO")
-  set(GDAL_DOXYGEN_EXTRACT_LOCAL_CLASSES "YES")
-  set(GDAL_DOXYGEN_INPUT "gdal_building_ru.dox gdal_datamodel_ru.dox gdal_tutorial_ru.dox index_ru.dox")
-  set(GDAL_DOXYGEN_EXAMPLE_PATH "")
-  set(GDAL_DOXYGEN_IMAGE_PATH "")
-  set(GDAL_DOXYGEN_LAYOUT_FILE "")
-  set(GDAL_ENABLED_SECTIONS "")
-  set(GDAL_GENERATE_HTML "YES")
-  set(GDAL_FILE_PATTERNS
-      "*.h \
-                           *.cpp \
-                           *.c \
-                           *.dox")
-  set(GDAL_GENERATE_MAN "NO")
-  configure_file(${GDAL_CMAKE_TEMPLATE_PATH}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_ru)
-  add_custom_command(
-    OUTPUT ${TARGET_HTML_DIR}/index_ru.html
-    COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_ru
-    MAIN_DEPENDENCY ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_ru
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/ru)
-  add_custom_command(
-    OUTPUT ${TARGET_HTML_DIR}/header_ru.html
-    COMMAND
-      ${CMAKE_COMMAND} ARGS -Dinfile:FILEPATH=${TARGET_HTML_DIR}/header.html
-      -Doutfile:FILEPATH=${TARGET_HTML_DIR}/header_ru.html -Dfrom:STRING="iso-8859-1" -Dto:STRING="utf-8" -P
-      ${CMAKE_CURRENT_SOURCE_DIR}/ReplaceStr.cmake
-    MAIN_DEPENDENCY ${TARGET_HTML_DIR}/header.html
-    WORKING_DIRECTORY ${TARGET_HTML_DIR})
-  # generate Brazilian document
-  set(GDAL_DOXYGEN_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
-  set(GDAL_DOXYGEN_PROJECT_NAME "BR")
-  set(GDAL_DOXYGEN_LANGUAGE "Brazilian")
-  set(GDAL_DOXYGEN_JAVADOC_AUTOBRIEF "NO")
-  set(GDAL_DOXYGEN_EXTRACT_LOCAL_CLASSES "YES")
-  set(GDAL_DOXYGEN_INPUT "gdal_building_br.dox gdal_datamodel_br.dox gdal_tutorial_br.dox index_br.dox")
-  set(GDAL_DOXYGEN_EXAMPLE_PATH "")
-  set(GDAL_DOXYGEN_IMAGE_PATH "")
-  set(GDAL_ENABLED_SECTIONS "")
-  set(GDAL_DOXYGEN_LAYOUT_FILE "")
-  set(GDAL_GENERATE_HTML "YES")
-  set(GDAL_FILE_PATTERNS "*.h *.cpp *.c *.dox")
-  set(GDAL_GENERATE_MAN "NO")
-  configure_file(${GDAL_CMAKE_TEMPLATE_PATH}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_br)
-  add_custom_command(
-    OUTPUT ${TARGET_HTML_DIR}/index_br.html
-    COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_br
-    MAIN_DEPENDENCY ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_br
-    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/br)
-  add_custom_command(
-    OUTPUT ${TARGET_HTML_DIR}/header_br.html
-    COMMAND ${CMAKE_COMMAND} -E copy ${TARGET_HTML_DIR}/header.html ${TARGET_HTML_DIR}/header_br.html
-    DEPENDS ${TARGET_HTML_DIR}/header.html)
+find_program(SPHINX_BUILD sphinx-build)
+find_program(MAKE_EXECUTABLE make)
 
-  # run main doxygen
-  set(GDAL_DOXYGEN_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
-  set(GDAL_DOXYGEN_PROJECT_NAME "GDAL")
-  set(GDAL_DOXYGEN_LANGUAGE "English")
-  set(GDAL_DOXYGEN_JAVADOC_AUTOBRIEF "YES")
-  set(GDAL_DOXYGEN_EXTRACT_LOCAL_CLASSES "NO")
-  set(GDAL_ENABLED_SECTIONS "")
-  set(GDAL_GENERATE_HTML "YES")
-  set(GDAL_DOXYGEN_INCLUDE_PATH "${CMAKE_BINARY_DIR}/port ${CMAKE_BINARY_DIR}/gcore")
-  set(GDAL_DOXYGEN_INPUT
-      "port gcore frmts/gdalallregister.cpp alg frmts/vrt \
-               doc apps ogr ogr/ogrsf_frmts ogr/ogrsf_frmts/generic \
-               ogr/ogrsf_frmts/geojson/ogrgeojsonwriter.cpp \
-               ogr/ogrsf_frmts/kml/ogr2kmlgeometry.cpp \
-               swig/python/scripts gnm")
-  set(GDAL_DOXYGEN_EXAMPLE_PATH "apps frmts frmts/jdem")
-  set(GDAL_DOXYGEN_IMAGE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/grid)
-  set(GDAL_DOXYGEN_LAYOUT_FILE ${CMAKE_SOURCE_DIR}/DoxygenLayout.xml)
-  set(GDAL_GENERATE_MAN "NO")
-  configure_file(${GDAL_CMAKE_TEMPLATE_PATH}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_main)
-  add_custom_command(
-    OUTPUT ${CMAKE_BINARY_DIR}/html/index.html
-    COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_main
-    MAIN_DEPENDENCY ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_main
-    ${TARGET_HTML_DIR}/header.html ${TARGET_HTML_DIR}/index_ru.html ${TARGET_HTML_DIR}/index_br.html
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+if (UNIX
+    AND (NOT "${CMAKE_BINARY_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
+    AND DOXYGEN_FOUND
+    AND SPHINX_BUILD
+    AND MAKE_EXECUTABLE)
+    set(BUILD_DOCS_DEFAULT ON)
+else()
+    set(BUILD_DOCS_DEFAULT OFF)
+endif()
+option(BUILD_DOCS "Set to ON to define documentation targets: 'html', 'latexpdf', 'man', 'doxygen', 'doxygen_check_warnings', 'clean_doc'" ${BUILD_DOCS_DEFAULT})
 
-  # copy rest of files for html generation
-  file(
-    GLOB
-    OTHER_DOCS
-    ${CMAKE_CURRENT_SOURCE_DIR}/images/act-logo.png
-    ${CMAKE_CURRENT_SOURCE_DIR}/images/cadcorp_logo.jpg
-    ${CMAKE_CURRENT_SOURCE_DIR}/images/foss4g2013.png
-    ${CMAKE_CURRENT_SOURCE_DIR}/images/foss4g2014.png
-    ${CMAKE_CURRENT_SOURCE_DIR}/images/foss4g2017.png
-    ${CMAKE_CURRENT_SOURCE_DIR}/images/i3-logo.jpg
-    ${CMAKE_CURRENT_SOURCE_DIR}/images/ingres-logo.png
-    ${CMAKE_CURRENT_SOURCE_DIR}/images/OSGeo_project.png
-    ${CMAKE_CURRENT_SOURCE_DIR}/images/safe-logo.png
-    ${CMAKE_CURRENT_SOURCE_DIR}/images/src-logo.png
-    ${CMAKE_CURRENT_SOURCE_DIR}/images/waypoint_logo.png
-    ${CMAKE_CURRENT_SOURCE_DIR}/grid/*.png
-    ${CMAKE_SOURCE_DIR}/frmts/*.html
-    ${CMAKE_SOURCE_DIR}/frmts/*/frmt_*.html
-    ${CMAKE_SOURCE_DIR}/frmts/openjpeg/*.xml
-    ${CMAKE_SOURCE_DIR}/frmts/wms/frmt_*.xml
-    ${CMAKE_SOURCE_DIR}/ogr/ogrsf_frmts/*/frmt_*.html
-    ${CMAKE_SOURCE_DIR}/ogr/ogrsf_frmts/*/dev_*.html
-    ${CMAKE_SOURCE_DIR}/ogr/ogrsf_frmts/gpkg/geopackage_aspatial.html
-    ${CMAKE_SOURCE_DIR}/ogr/*.gif
-    ${CMAKE_SOURCE_DIR}/data/gdalicon.png
-    ${CMAKE_SOURCE_DIR}/ogr/ogrsf_frmts/ogr_formats.html
-    ${CMAKE_SOURCE_DIR}/ogr/ogrsf_frmts/ogr_formats.html
-    ${CMAKE_SOURCE_DIR}/ogr/ogr_feature_style.html)
-  add_custom_target(_copy_other_docs) # FIXME: are there any way without internal custom target?
-  foreach (f ${OTHER_DOCS})
-    add_custom_command(
-      TARGET _copy_other_docs
-      PRE_BUILD
-      COMMAND ${CMAKE_COMMAND} -E copy ${f} ${CMAKE_BINARY_DIR}/html)
-  endforeach ()
-  add_custom_target(
-    documents
-    DEPENDS ${CMAKE_BINARY_DIR}/html/index.html
-            ${CMAKE_BINARY_DIR}/html/index_ru.html
-            ${CMAKE_BINARY_DIR}/html/index_br.html
-            ${CMAKE_BINARY_DIR}/html/header.html
-            ${CMAKE_BINARY_DIR}/html/footer.html
-            ${CMAKE_BINARY_DIR}/html/stylesheet.css
-            ${CMAKE_BINARY_DIR}/html/header_br.html
-            ${CMAKE_BINARY_DIR}/html/header_ru.html
-            _copy_other_docs)
+if (BUILD_DOCS)
+    if (NOT UNIX)
+        message(FATAL_ERROR "BUILD_DOCS=ON requires a UNIX environment")
+    endif()
+    if ("${CMAKE_BINARY_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
+        message(FATAL_ERROR "BUILD_DOCS=ON not compatible of in-source builds (CMAKE_SOURCE_DIR=CMAKE_BINARY_DIR)")
+    endif()
+    if (NOT DOXYGEN_FOUND)
+        message(FATAL_ERROR "BUILD_DOCS=ON requires Doxygen")
+    endif()
+    if (NOT SPHINX_BUILD)
+        message(FATAL_ERROR "BUILD_DOCS=ON requires sphinx-build")
+    endif()
+    if (NOT MAKE_EXECUTABLE)
+        message(FATAL_ERROR "BUILD_DOCS=ON requires 'make' executable")
+    endif()
 
-  # Build man
-  set(GDAL_DOXYGEN_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}")
-  set(GDAL_DOXYGEN_PROJECT_NAME "GDAL")
-  set(GDAL_DOXYGEN_LANGUAGE "English")
-  set(GDAL_DOXYGEN_JAVADOC_AUTOBRIEF "YES")
-  set(GDAL_ENABLED_SECTIONS "man")
-  set(GDAL_DOXYGEN_EXTRACT_LOCAL_CLASSES "NO")
-  set(GDAL_DOXYGEN_INPUT "apps swig/python/scripts")
-  set(GDAL_FILE_PATTERNS "*.cpp *.dox")
-  set(GDAL_GENERATE_HTML "NO")
-  set(GDAL_DOXYGEN_EXAMPLE_PATH
-      "apps \
-             frmts \
-             frmts/jdem")
-  set(GDAL_DOXYGEN_IMAGE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/grid)
-  set(GDAL_DOXYGEN_LAYOUT_FILE "/dev/null")
-  set(GDAL_GENERATE_MAN "YES")
-  configure_file(${GDAL_CMAKE_TEMPLATE_PATH}/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_man)
-  add_custom_command(
-    OUTPUT ${CMAKE_BINARY_DIR}/man/man1/gdalinfo.1 ${CMAKE_BINARY_DIR}/man/man1/gdal-config.1
-           ${CMAKE_BINARY_DIR}/man/man1/ogrlinfo.1 ${CMAKE_BINARY_DIR}/man/man1/ogr2ogr.1
-    COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_man
-    MAIN_DEPENDENCY ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_man
-    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-  add_custom_target(manpages DEPENDS ${CMAKE_BINARY_DIR}/man/man1/gdalinfo.1 ${CMAKE_BINARY_DIR}/man/man1/gdal-config.1
-                                     ${CMAKE_BINARY_DIR}/man/man1/ogrlinfo.1 ${CMAKE_BINARY_DIR}/man/man1/ogr2ogr.1)
+    set(DOC_BUILDDIR "${CMAKE_CURRENT_BINARY_DIR}/build")
+
+    add_custom_target(
+        doxygen
+        COMMAND ${MAKE_EXECUTABLE} doxygen BUILDDIR=${DOC_BUILDDIR}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+    add_custom_target(
+        doxygen_check_warnings
+        COMMAND ${MAKE_EXECUTABLE} doxygen_check_warnings BUILDDIR=${DOC_BUILDDIR}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+    add_custom_target(
+        html
+        COMMAND ${MAKE_EXECUTABLE} html BUILDDIR=${DOC_BUILDDIR}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+    add_custom_target(
+        latexpdf
+        COMMAND ${MAKE_EXECUTABLE} latexpdf BUILDDIR=${DOC_BUILDDIR}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+    add_custom_target(
+        man
+        COMMAND ${MAKE_EXECUTABLE} man BUILDDIR=${DOC_BUILDDIR}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+    add_custom_target(
+        clean_doc
+        COMMAND ${MAKE_EXECUTABLE} clean BUILDDIR=${DOC_BUILDDIR}
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+
+    set_property(
+        TARGET clean_doc
+        APPEND
+        PROPERTY ADDITIONAL_CLEAN_FILES ${DOC_BUILDDIR})
 endif ()

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -22,12 +22,13 @@ help:
 	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 doxygen:
-	$(MAKE) -B .doxygen_up_to_date
+	$(MAKE) -B $(BUILDDIR)/.doxygen_up_to_date
 
 # Target run by the CI code_checks.yml workflow to check that there are no Doxygen warnings
 # Requires Doxygen >= 1.9.3
 doxygen_check_warnings:
-	@$(MAKE) -B .doxygen_up_to_date > /tmp/doxygen_gdal_log.txt 2>&1
+	@echo "Checking that Doxygen runs without warnings..."
+	@$(MAKE) -B $(BUILDDIR)/.doxygen_up_to_date > /tmp/doxygen_gdal_log.txt 2>&1
 	@if grep -i warning /tmp/doxygen_gdal_log.txt; then \
 		echo "Doxygen warnings found!"; \
 		echo "---------"; \
@@ -46,15 +47,27 @@ doxygen_check_warnings:
 		echo "No Doxygen warnings found"; \
 	fi
 
-.doxygen_up_to_date:
-	mkdir -p build/xml && cd .. && ((cat Doxyfile | sed "s/PREDEFINED             = /PREDEFINED             = DOXYGEN_XML /"; printf "GENERATE_HTML=NO\nGENERATE_XML=YES\nXML_OUTPUT=doc/build/xml\nXML_PROGRAMLISTING=NO") | doxygen -)
-	rm -rf build/doxygen_html
-	mkdir -p build/doxygen_html && cd .. && ((cat Doxyfile; printf "HTML_OUTPUT=doc/build/doxygen_html\nINLINE_INHERITED_MEMB=YES") | doxygen -)
-	# Doxygen replaces -- with <ndash/>. This is not desirable, so revert that
-	for i in build/xml/*.xml; do sed "s/<ndash\/>/--/g" < $$i > $$i.tmp; mv $$i.tmp $$i; done
-	touch .doxygen_up_to_date
+$(BUILDDIR)/.doxygen_up_to_date:
+	@set -e ; \
+	case $(BUILDDIR) in \
+	    "/"*) \
+	        BUILDDIR_ABS="$(BUILDDIR)"; \
+	        ;; \
+	    *) \
+	        BUILDDIR_ABS="${PWD}/$(BUILDDIR)" \
+	        ;; \
+	esac; \
+	rm -rf $(BUILDDIR)/xml; \
+	mkdir -p $(BUILDDIR)/xml; \
+	(cd .. && ((cat Doxyfile | sed "s/PREDEFINED             = /PREDEFINED             = DOXYGEN_XML /"; printf "GENERATE_HTML=NO\nGENERATE_XML=YES\nXML_OUTPUT=$$BUILDDIR_ABS/xml\nXML_PROGRAMLISTING=NO") | doxygen -)); \
+	rm -rf $(BUILDDIR)/doxygen_html; \
+	mkdir -p $(BUILDDIR)/doxygen_html; \
+	(cd .. && ((cat Doxyfile; printf "HTML_OUTPUT=$$BUILDDIR_ABS/doxygen_html\nINLINE_INHERITED_MEMB=YES") | doxygen -)); \
+	echo "Doxygen replaces -- with <ndash/>. This is not desirable, so revert that;"; \
+	for i in $(BUILDDIR)/xml/*.xml; do sed "s/<ndash\/>/--/g" < $$i > $$i.tmp; mv $$i.tmp $$i; done; \
+	touch $(BUILDDIR)/.doxygen_up_to_date
 
-generated_rst_files: .doxygen_up_to_date
+generated_rst_files: $(BUILDDIR)/.doxygen_up_to_date
 	$(PYTHON) "$(SOURCEDIR)/build_driver_summary.py" "$(SOURCEDIR)/drivers/raster" raster_driver_summary "$(SOURCEDIR)/drivers/raster/driver_summary.rst"
 	$(PYTHON) "$(SOURCEDIR)/build_driver_summary.py" "$(SOURCEDIR)/drivers/vector" vector_driver_summary "$(SOURCEDIR)/drivers/vector/driver_summary.rst"
 
@@ -70,10 +83,10 @@ html: generated_rst_files
 	mv "$(BUILDDIR)/html/api/index.html.mod" "$(BUILDDIR)/html/api/index.html"
 	sed 's/<div class="toctree-wrapper compound">/<div class="toctree-wrapper compound" style="display: none;">/' < "$(BUILDDIR)/html/sponsors/index.html" > "$(BUILDDIR)/html/sponsors/index.html.mod"
 	mv "$(BUILDDIR)/html/sponsors/index.html.mod" "$(BUILDDIR)/html/sponsors/index.html"
-	rm -rf build/html/doxygen
-	cp -r build/doxygen_html build/html/doxygen
-	ln -sf ../latex/gdal.pdf build/html
-	cp -f "source/sponsors/Sustainable GDAL Sponsorship Prospectus.pdf" build/html/sponsors
+	rm -rf $(BUILDDIR)/html/doxygen
+	cp -r $(BUILDDIR)/doxygen_html $(BUILDDIR)/html/doxygen
+	ln -sf ../latex/gdal.pdf $(BUILDDIR)/html
+	cp -f "source/sponsors/Sustainable GDAL Sponsorship Prospectus.pdf" $(BUILDDIR)/html/sponsors
 
 man: generated_rst_files
 	$(SPHINXBUILD) -M man "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
@@ -82,7 +95,7 @@ latexpdf: generated_rst_files
 	$(SPHINXBUILD) -M latexpdf "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
 clean:
-	rm -rf build/xml
-	rm -rf build/doxygen_html
-	rm -rf .doxygen_up_to_date
+	rm -rf "$(BUILDDIR)/xml"
+	rm -rf "$(BUILDDIR)/doxygen_html"
+	rm -f "$(BUILDDIR)/.doxygen_up_to_date"
 	@$(SPHINXBUILD) -M clean "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/doc/source/development/dev_documentation.rst
+++ b/doc/source/development/dev_documentation.rst
@@ -10,7 +10,7 @@ Documentation overview
 ###########################
 
 GDAL's documentation includes C and C++ :ref:`API documentation <api>` built
-automatically from source comments using doxygen and reStructuredText (rst)
+automatically from source comments using Doxygen and reStructuredText (rst)
 files containing manually-edited content.
 
 |Sphinx| is used to combine the above components into a complete set of documentation in HTML, PDF, and other formats.
@@ -21,11 +21,37 @@ the ``doc`` subdirectory.
 Building documentation
 ######################
 
-HTML documentation can be built by running ``make html`` in the ``doc`` subdirectory of the GDAL source repository.
-The generated files will be output to ``doc/build`` where they can be viewed using a web browser.
+Documentation can be generated with Makefile targets, from the ``doc`` subdirectory
+of the GDAL source repository (only on Unix systems).
 
-Doxygen content that is incorporated into the output is not automatically rebuilt but can be regenerated using ``make doxygen``.
-This ``make doxygen`` target is tolerant to Doxygen warnings, but continuous integration checks verify that there are no warnings. This can be checked by running ``make doxygen_check_warnings`` (requires Doxygen >= 1.9.3 to be warning free)
+The following targets are available:
+
+* ``html``: build HTML documentation into the ``doc/build/html`` directory, where
+  they can be viewed using a web browser.
+
+* ``man``: build MAN pages into the ``doc/build/man`` directory.
+
+* ``latexpdf``: build PDF documentation into the ``doc/build/pdf`` directory
+
+* ``doxygen``: regenerate API Doxygen XML and HTML output, that is used by the
+  ``html`` target. Doxygen content is not automatically rebuilt when source files
+  are modified, hence this target must be explicitly run to refresh it.
+
+* ``doxygen_check_warnings``: same as ``doxygen``, but errors out when Doxygen
+  emits a warning (the ``doxygen`` target is tolerant to Doxygen warnings).
+  This can be useful to reproduce one of the continuous integration checks that
+  verifies that there are no Doxygen warnings.
+  Requires Doxygen >= 1.9.3 to be warning free.
+
+* ``clean``: clean the ``doc/build`` directory.
+
+It is also possible to run those targets as CMake targets. In that case, the
+output directory will be the ``doc/build`` subdirectory of the CMake
+build directory. To only clean the documentation, the ``clean_doc`` target can
+be invoked.
+Note: those CMake targets are only available if the CMake BUILD_DOCS=ON variable
+is set (it is set by default if build preconditions are met, that is if Doxygen,
+Sphinx and make are available)
 
 To visualize documentation changes while editing, it may be useful to install the |sphinx-autobuild| python package.
 Once installed, running ``sphinx-autobuild -b html source build`` from the ``doc`` subdirectory will build documentation

--- a/gdal.cmake
+++ b/gdal.cmake
@@ -13,11 +13,6 @@ set(GDAL_SOVERSION 35)
 option(ENABLE_GNM "Build GNM (Geography Network Model) component" ON)
 option(ENABLE_PAM "Set ON to enable Persistent Auxiliary Metadata (.aux.xml)" ON)
 option(BUILD_APPS "Build command line utilities" ON)
-if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/doc" AND NOT "${CMAKE_BINARY_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
-  # In-tree builds do not support Doc building because Sphinx requires (at least
-  # at first sight) a Makefile file which conflicts with the CMake generated one
-  option(BUILD_DOCS "Build documentation" ON)
-endif()
 
 # This option is to build drivers as plugins, for drivers that have external dependencies, that are not parf of GDAL
 # core dependencies Examples are netCDF, HDF4, Oracle, PDF, etc. This global setting can be overridden at the driver
@@ -590,7 +585,7 @@ get_property(GDAL_PRIVATE_LINK_LIBRARIES GLOBAL PROPERTY gdal_private_link_libra
 target_link_libraries(${GDAL_LIB_TARGET_NAME} PRIVATE ${GDAL_PRIVATE_LINK_LIBRARIES} ${GDAL_EXTRA_LINK_LIBRARIES})
 
 # Document/Manuals
-if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/doc" AND BUILD_DOCS)
+if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/doc")
   add_subdirectory(doc)
 endif ()
 add_subdirectory(man)


### PR DESCRIPTION
Fixes #5484

Updated dev_documentation.rst:
```rst
Building documentation
######################

Documentation can be generated with Makefile targets, from the ``doc`` subdirectory
of the GDAL source repository (only on Unix systems).

The following targets are available:

* ``html``: build HTML documentation into the ``doc/build/html`` directory, where
  they can be viewed using a web browser.

* ``man``: build MAN pages into the ``doc/build/man`` directory.

* ``latexpdf``: build PDF documentation into the ``doc/build/pdf`` directory

* ``doxygen``: regenerate API Doxygen XML and HTML output, that is used by the
  ``html`` target. Doxygen content is not automatically rebuilt when source files
  are modified, hence this target must be explicitly run to refresh it.

* ``doxygen_check_warnings``: same as ``doxygen``, but errors out when Doxygen
  emits a warning (the ``doxygen`` target is tolerant to Doxygen warnings).
  This can be useful to reproduce one of the continuous integration checks that
  verifies that there are no Doxygen warnings.
  Requires Doxygen >= 1.9.3 to be warning free.

* ``clean``: clean the ``doc/build`` directory.

It is also possible to run those targets as CMake targets. In that case, the
output directory will be the ``doc/build`` subdirectory of the CMake
build directory. To only clean the documentation, the ``clean_doc`` target can
be invoked.
Note: those CMake targets are only available if the CMake BUILD_DOCS=ON variable
is set (it is set by default if build preconditions are met, that is if Doxygen,
Sphinx and make are available)
```

CC @dbaston @abellgithub 