### PR TITLE
MiraMonVector: Fix issue 68585 from chromium (and other similar ones)

### DIFF
--- a/ogr/ogrsf_frmts/miramon/mm_rdlayr.c
+++ b/ogr/ogrsf_frmts/miramon/mm_rdlayr.c
@@ -449,6 +449,15 @@ MMGetMultiPolygonCoordinates(struct MiraMonVectLayerInfo *hMiraMonLayer,
 
         pArcHeader = hMiraMonLayer->MMPolygon.MMArc.pArcHeader +
                      (hMiraMonLayer->pArcs + nIndex)->nIArc;
+
+        if (hMiraMonLayer->ReadFeature
+                .pNCoordRing[hMiraMonLayer->ReadFeature.nNRings] >
+            UINT64_MAX - pArcHeader->nElemCount)
+        {
+            free_function(pBuffer);
+            return 1;
+        }
+
         hMiraMonLayer->ReadFeature
             .pNCoordRing[hMiraMonLayer->ReadFeature.nNRings] +=
             pArcHeader->nElemCount;

--- a/ogr/ogrsf_frmts/miramon/mm_rdlayr.c
+++ b/ogr/ogrsf_frmts/miramon/mm_rdlayr.c
@@ -458,6 +458,14 @@ MMGetMultiPolygonCoordinates(struct MiraMonVectLayerInfo *hMiraMonLayer,
             return 1;
         }
 
+        if (hMiraMonLayer->ReadFeature
+                .pNCoordRing[hMiraMonLayer->ReadFeature.nNRings] >
+            UINT64_MAX - pArcHeader->nElemCount)
+        {
+            free_function(pBuffer);
+            return 1;
+        }
+
         hMiraMonLayer->ReadFeature
             .pNCoordRing[hMiraMonLayer->ReadFeature.nNRings] +=
             pArcHeader->nElemCount;
@@ -526,10 +534,19 @@ MMGetMultiPolygonCoordinates(struct MiraMonVectLayerInfo *hMiraMonLayer,
             return 1;
         }
 
+        if (hMiraMonLayer->ReadFeature
+                .pNCoordRing[hMiraMonLayer->ReadFeature.nNRings] >
+            UINT64_MAX - hMiraMonLayer->ReadFeature.nNumpCoord)
+        {
+            free_function(pBuffer);
+            return 1;
+        }
+
         hMiraMonLayer->ReadFeature
             .pNCoordRing[hMiraMonLayer->ReadFeature.nNRings] +=
             hMiraMonLayer->ReadFeature.nNumpCoord;
         nNAcumulVertices += hMiraMonLayer->ReadFeature.nNumpCoord;
+
         if ((hMiraMonLayer->pArcs + nIndex)->VFG & MM_POL_END_RING)
         {
             hMiraMonLayer->ReadFeature


### PR DESCRIPTION
## What does this PR do?
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=68585
Fixes other similar possible issues
Takes care of an overflow in a sum of unsigned int64's (everywhere "+=" is used)

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] All CI builds and checks have passed except 1
 - [ ] Confirm the failed check has nothing to do with MiraMonVector
