### PR TITLE
Warper: add a NODATA_VALUES_PCT_THRESHOLD warping option, and expose it in gdal2tiles

### DIFF
--- a/alg/gdalwarper.cpp
+++ b/alg/gdalwarper.cpp
@@ -1265,7 +1265,17 @@ CPLErr GDALWarpDstAlphaMasker(void *pMaskFuncArg, int nBandCount,
  * <li>EXCLUDED_VALUES_PCT_THRESHOLD=[0-100]: (GDAL >= 3.9) Minimum percentage
  * of source pixels that must be set at one of the EXCLUDED_VALUES to cause
  * the excluded value, that is in majority among source pixels, to be used as the
- * target pixel value. Default value is 50 (%)</li>
+ * target pixel value. Default value is 50 (%).
+ * Only taken into account by Average currently.</li>
+ *
+ * <li>NODATA_VALUES_PCT_THRESHOLD=[0-100]: (GDAL >= 3.9) Minimum percentage
+ * of source pixels that must be at nodata (or alpha=0 or any other way to express
+ * transparent pixel) to cause the target pixel value to not be set. Default
+ * value is 100 (%), which means that a target pixel is not set only if all
+ * contributing source pixels are not set.
+ * Note that NODATA_VALUES_PCT_THRESHOLD is taken into account before
+ * EXCLUDED_VALUES_PCT_THRESHOLD.
+ * Only taken into account by Average currently.</li>
  *
  * </ul>
  */

--- a/doc/source/programs/gdal2tiles.rst
+++ b/doc/source/programs/gdal2tiles.rst
@@ -22,7 +22,9 @@ Synopsis
                   [-w <webviewer>] [-t <title>] [-c <copyright>]
                   [--processes=<NB_PROCESSES>] [--mpi] [--xyz]
                   [--tilesize=<PIXELS>] --tiledriver=<DRIVER> [--tmscompatible]
-                  [--excluded-values=<EXCLUDED_VALUES>] [--excluded-values-pct-threshold=<EXCLUDED_VALUES_PCT_THRESHOLD>]
+                  [--excluded-values=<EXCLUDED_VALUES>]
+                  [--excluded-values-pct-threshold=<EXCLUDED_VALUES_PCT_THRESHOLD>]
+                  [--nodata-values-pct-threshold=<NODATA_VALUES_PCT_THRESHOLD>]
                   [-g <googlekey] [-b <bingkey>] <input_file> [<output_dir>] [<COMMON_OPTIONS>]
 
 Description
@@ -155,10 +157,22 @@ can publish a picture without proper georeferencing too.
   that pixels matching one of the excluded value tuples are still considered
   as valid, when determining the target pixel validity/density.
 
+  .. versionadded:: 3.9
+
 .. option:: --excluded-values-pct-threshold=EXCLUDED_VALUES_PCT_THRESHOLD
 
   Minimum percentage of source pixels that must be set at one of the --excluded-values to cause the excluded
   value, that is in majority among source pixels, to be used as the target pixel value. Default value is 50(%)
+
+  .. versionadded:: 3.9
+
+.. option:: --nodata-values-pct-threshold=<NODATA_VALUES_PCT_THRESHOLD>
+
+  Minimum percentage of source pixels that must be at nodata (or alpha=0 or any
+  other way to express transparent pixel) to cause the target pixel value to
+  be transparent. Default value is 100 (%), which means that a target pixel is
+  transparent only if all contributing source pixels are transparent.
+  Only taken into account for average resampling.
 
   .. versionadded:: 3.9
 

--- a/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
@@ -885,12 +885,17 @@ def scale_query_to_tile(dsquery, dstile, options, tilefilename=""):
     )
     dstile.SetGeoTransform((0.0, 1.0, 0.0, 0.0, 0.0, 1.0))
 
-    if options.resampling == "average" and options.excluded_values:
+    if options.resampling == "average" and (
+        options.excluded_values or options.nodata_values_pct_threshold < 100
+    ):
 
         gdal.Warp(
             dstile,
             dsquery,
-            options=f"-r average -wo EXCLUDED_VALUES={options.excluded_values} -wo EXCLUDED_VALUES_PCT_THRESHOLD={options.excluded_values_pct_threshold}",
+            options="-r average "
+            + f"-wo EXCLUDED_VALUES={options.excluded_values} "
+            + f"-wo EXCLUDED_VALUES_PCT_THRESHOLD={options.excluded_values_pct_threshold} "
+            + f"-wo NODATA_VALUES_PCT_THRESHOLD={options.nodata_values_pct_threshold}",
         )
 
     elif options.resampling == "average":
@@ -1871,6 +1876,13 @@ def optparse_init() -> optparse.OptionParser:
         type=float,
         default=50,
         help="Minimum percentage of source pixels that must be set at one of the --excluded-values to cause the excluded value, that is in majority among source pixels, to be used as the target pixel value. Default value is 50 (%)",
+    )
+    p.add_option(
+        "--nodata-values-pct-threshold",
+        dest="nodata_values_pct_threshold",
+        type=float,
+        default=100,
+        help="Minimum percentage of source pixels that must be at nodata (or alpha=0 or any other way to express transparent pixel) to cause the target pixel value to be transparent. Default value is 100 (%). Only taken into account for average resampling",
     )
 
     # KML options


### PR DESCRIPTION
This is similar to the --excluded-values-pct-threshold option added in
https://github.com/OSGeo/gdal/pull/9631, but here this controls the
minimum amount of transparent/invalid/nodata source pixels to cause the
target pixels to be transparent.
Only used currently for average resampling
