### PR TITLE
Add VSICopyFileRestartable() to allow restart of upload of large files

### DIFF
--- a/autotest/gcore/vsifile.py
+++ b/autotest/gcore/vsifile.py
@@ -1341,3 +1341,26 @@ def test_vsifile_use_closed_file(tmp_path):
 
     with pytest.raises(ValueError, match="closed file"):
         gdal.VSIFWriteL("0123456789", 1, 10, f)
+
+
+###############################################################################
+# Test gdal.CopyFileRestartable()
+
+
+def test_vsifile_CopyFileRestartable(tmp_vsimem):
+
+    dstfilename = str(tmp_vsimem / "out.txt")
+
+    retcode, output_payload = gdal.CopyFileRestartable(
+        str(tmp_vsimem / "i_do_not_exist.txt"), dstfilename, None
+    )
+    assert retcode == -1
+    assert output_payload is None
+    assert gdal.VSIStatL(dstfilename) is None
+
+    srcfilename = str(tmp_vsimem / "in.txt")
+    gdal.FileFromMemBuffer(srcfilename, "foo")
+    retcode, output_payload = gdal.CopyFileRestartable(srcfilename, dstfilename, None)
+    assert retcode == 0
+    assert output_payload is None
+    assert gdal.VSIStatL(dstfilename).size == 3

--- a/autotest/gcore/vsioss.py
+++ b/autotest/gcore/vsioss.py
@@ -1229,6 +1229,31 @@ def test_vsioss_8(server):
 
 
 ###############################################################################
+# Test gdal.CopyFileRestartable() with fallback to regular copy
+
+
+def test_vsioss_CopyFileRestartable_fallback_to_regular_copy(tmp_vsimem, server):
+
+    gdal.VSICurlClearCache()
+
+    srcfilename = str(tmp_vsimem / "foo")
+    gdal.FileFromMemBuffer(srcfilename, "foo\n")
+
+    dstfilename = "/vsioss/test_bucket/foo"
+
+    handler = webserver.SequentialHandler()
+    handler.add("PUT", "/test_bucket/foo", 200, expected_body=b"foo\n")
+
+    with webserver.install_http_handler(handler):
+        ret_code, restart_payload = gdal.CopyFileRestartable(
+            srcfilename,
+            dstfilename,
+            None,  # input payload
+        )
+    assert ret_code == 0
+
+
+###############################################################################
 # Nominal cases (require valid credentials)
 
 

--- a/autotest/gcore/vsis3.py
+++ b/autotest/gcore/vsis3.py
@@ -4214,6 +4214,334 @@ def test_vsis3_fake_sync_multithreaded_upload_chunk_size_failure(
 
 
 ###############################################################################
+# Test gdal.CopyFileRestartable() where upload is completed in a single attempt
+
+
+def test_vsis3_CopyFileRestartable_no_error(
+    tmp_vsimem, aws_test_config, webserver_port
+):
+
+    gdal.VSICurlClearCache()
+
+    srcfilename = str(tmp_vsimem / "foo")
+    gdal.FileFromMemBuffer(srcfilename, "foo\n")
+
+    dstfilename = "/vsis3/test_bucket/foo"
+
+    handler = webserver.SequentialHandler()
+    handler.add(
+        "POST",
+        "/test_bucket/foo?uploads",
+        200,
+        {"Content-type": "application:/xml"},
+        b"""<?xml version="1.0" encoding="UTF-8"?>
+        <InitiateMultipartUploadResult>
+        <UploadId>my_id</UploadId>
+        </InitiateMultipartUploadResult>""",
+    )
+    handler.add(
+        "PUT",
+        "/test_bucket/foo?partNumber=1&uploadId=my_id",
+        200,
+        {"ETag": '"first_etag"'},
+        expected_headers={"Content-Length": "4"},
+        expected_body=b"foo\n",
+    )
+    handler.add("POST", "/test_bucket/foo?uploadId=my_id", 200)
+
+    with webserver.install_http_handler(handler):
+        ret_code, restart_payload = gdal.CopyFileRestartable(
+            srcfilename, dstfilename, None
+        )
+    assert ret_code == 0
+    assert restart_payload is None
+
+
+###############################################################################
+# Test gdal.CopyFileRestartable() with one restart to complete the upload
+
+
+@pytest.mark.parametrize("failure_reason", ["progress_cbk", "failed_part_put"])
+def test_vsis3_CopyFileRestartable_with_restart(
+    tmp_vsimem, aws_test_config, webserver_port, failure_reason
+):
+
+    gdal.VSICurlClearCache()
+
+    srcfilename = str(tmp_vsimem / "foo")
+    gdal.FileFromMemBuffer(srcfilename, "foo\n")
+
+    dstfilename = "/vsis3/test_bucket/foo"
+
+    def progress_cbk(pct, msg, user_data):
+        if failure_reason == "progress_cbk":
+            return pct < 0.5
+        else:
+            return True
+
+    handler = webserver.SequentialHandler()
+    handler.add(
+        "POST",
+        "/test_bucket/foo?uploads",
+        200,
+        {"Content-type": "application:/xml"},
+        b"""<?xml version="1.0" encoding="UTF-8"?>
+        <InitiateMultipartUploadResult>
+        <UploadId>my_id</UploadId>
+        </InitiateMultipartUploadResult>""",
+    )
+    handler.add(
+        "PUT",
+        "/test_bucket/foo?partNumber=1&uploadId=my_id",
+        200,
+        {"ETag": '"first_etag"'},
+        expected_headers={"Content-Length": "3"},
+        expected_body=b"foo",
+    )
+    if failure_reason == "failed_part_put":
+        handler.add(
+            "PUT",
+            "/test_bucket/foo?partNumber=2&uploadId=my_id",
+            400,
+            expected_headers={"Content-Length": "1"},
+            expected_body=b"\n",
+        )
+    with webserver.install_http_handler(handler), gdal.quiet_errors():
+        ret_code, restart_payload = gdal.CopyFileRestartable(
+            srcfilename,
+            dstfilename,
+            None,  # input payload
+            ["CHUNK_SIZE=3"],
+            progress_cbk,
+        )
+    assert ret_code == 1
+    j = json.loads(restart_payload)
+    assert "source_mtime" in j
+    del j["source_mtime"]
+    assert j == {
+        "type": "CopyFileRestartablePayload",
+        "source": srcfilename,
+        "target": dstfilename,
+        "source_size": 4,
+        "chunk_size": 3,
+        "upload_id": "my_id",
+        "chunk_etags": ['"first_etag"', None],
+    }
+
+    handler = webserver.SequentialHandler()
+    handler.add(
+        "PUT",
+        "/test_bucket/foo?partNumber=2&uploadId=my_id",
+        200,
+        {"ETag": '"second_etag"'},
+        expected_headers={"Content-Length": "1"},
+        expected_body=b"\n",
+    )
+    handler.add(
+        "POST",
+        "/test_bucket/foo?uploadId=my_id",
+        200,
+        expected_body=b"""<CompleteMultipartUpload>
+<Part>
+<PartNumber>1</PartNumber><ETag>"first_etag"</ETag></Part>
+<Part>
+<PartNumber>2</PartNumber><ETag>"second_etag"</ETag></Part>
+</CompleteMultipartUpload>
+""",
+    )
+    with webserver.install_http_handler(handler):
+        ret_code, restart_payload = gdal.CopyFileRestartable(
+            srcfilename, dstfilename, restart_payload
+        )
+    assert ret_code == 0
+    assert restart_payload is None
+
+
+###############################################################################
+# Test gdal.CopyFileRestartable() with error cases
+
+
+def test_vsis3_CopyFileRestartable_src_file_does_not_exist(
+    tmp_vsimem, aws_test_config, webserver_port
+):
+
+    gdal.VSICurlClearCache()
+
+    with gdal.quiet_errors():
+        ret_code, restart_payload = gdal.CopyFileRestartable(
+            "/vsimem/i/do/not/exist", "/vsis3/test_bucket/dst", None
+        )
+    assert ret_code == -1
+    assert restart_payload is None
+
+
+###############################################################################
+# Test gdal.CopyFileRestartable() with error cases
+
+
+def test_vsis3_CopyFileRestartable_InitiateMultipartUpload_failed(
+    tmp_vsimem, aws_test_config, webserver_port
+):
+
+    gdal.VSICurlClearCache()
+
+    srcfilename = str(tmp_vsimem / "foo")
+    gdal.FileFromMemBuffer(srcfilename, "foo\n")
+
+    dstfilename = "/vsis3/test_bucket/foo"
+
+    handler = webserver.SequentialHandler()
+    handler.add("POST", "/test_bucket/foo?uploads", 400)
+    with webserver.install_http_handler(handler), gdal.quiet_errors():
+        ret_code, restart_payload = gdal.CopyFileRestartable(
+            srcfilename,
+            dstfilename,
+            None,  # input payload
+        )
+    assert ret_code == -1
+
+
+###############################################################################
+# Test gdal.CopyFileRestartable() with error cases
+
+
+def test_vsis3_CopyFileRestartable_CompleteMultipartUpload_failed(
+    tmp_vsimem, aws_test_config, webserver_port
+):
+
+    gdal.VSICurlClearCache()
+
+    srcfilename = str(tmp_vsimem / "foo")
+    gdal.FileFromMemBuffer(srcfilename, "foo\n")
+
+    dstfilename = "/vsis3/test_bucket/foo"
+
+    handler = webserver.SequentialHandler()
+    handler.add(
+        "POST",
+        "/test_bucket/foo?uploads",
+        200,
+        {"Content-type": "application:/xml"},
+        b"""<?xml version="1.0" encoding="UTF-8"?>
+        <InitiateMultipartUploadResult>
+        <UploadId>my_id</UploadId>
+        </InitiateMultipartUploadResult>""",
+    )
+    handler.add(
+        "PUT",
+        "/test_bucket/foo?partNumber=1&uploadId=my_id",
+        200,
+        {"ETag": '"first_etag"'},
+        expected_headers={"Content-Length": "4"},
+        expected_body=b"foo\n",
+    )
+    handler.add("POST", "/test_bucket/foo?uploadId=my_id", 400)
+    handler.add("DELETE", "/test_bucket/foo?uploadId=my_id", 200)
+
+    with webserver.install_http_handler(handler), gdal.quiet_errors():
+        ret_code, restart_payload = gdal.CopyFileRestartable(
+            srcfilename,
+            dstfilename,
+            None,  # input payload
+        )
+    assert ret_code == -1
+
+
+###############################################################################
+# Test gdal.CopyFileRestartable() with errors in input payload
+
+
+@pytest.mark.parametrize(
+    "key,value,error_msg",
+    [
+        ("source", None, "'source' field in input payload does not match pszSource"),
+        ("target", None, "'target' field in input payload does not match pszTarget"),
+        ("chunk_size", None, "'chunk_size' field in input payload missing or invalid"),
+        (
+            "source_size",
+            None,
+            "'source_size' field in input payload does not match source file size",
+        ),
+        (
+            "source_mtime",
+            None,
+            "'source_mtime' field in input payload does not match source file modification time",
+        ),
+        ("upload_id", None, "'upload_id' field in input payload missing or invalid"),
+        (
+            "chunk_etags",
+            None,
+            "'chunk_etags' field in input payload missing or invalid",
+        ),
+        (
+            "chunk_etags",
+            [],
+            "'chunk_etags' field in input payload has not expected size",
+        ),
+    ],
+)
+def test_vsis3_CopyFileRestartable_errors_input_payload(
+    tmp_vsimem, aws_test_config, key, value, error_msg
+):
+
+    srcfilename = str(tmp_vsimem / "foo")
+    gdal.FileFromMemBuffer(srcfilename, "foo\n")
+
+    dstfilename = "/vsis3/test_bucket/foo"
+
+    j = {
+        "type": "CopyFileRestartablePayload",
+        "source": srcfilename,
+        "target": dstfilename,
+        "source_size": 4,
+        "chunk_size": 3,
+        "upload_id": "my_id",
+        "chunk_etags": ['"first_etag"', None],
+    }
+    j["source_mtime"] = gdal.VSIStatL(srcfilename).mtime
+
+    j[key] = value
+    restart_payload = json.dumps(j)
+
+    gdal.ErrorReset()
+    with gdal.quiet_errors():
+        ret_code, restart_payload = gdal.CopyFileRestartable(
+            srcfilename, dstfilename, restart_payload
+        )
+    assert ret_code == -1
+    assert restart_payload is None
+    assert gdal.GetLastErrorMsg() == error_msg
+
+
+###############################################################################
+# Test gdal.CopyFileRestartable() with /vsis3/ to /vsis3/
+
+
+def test_vsis3_CopyFileRestartable_server_side(
+    tmp_vsimem, aws_test_config, webserver_port
+):
+
+    gdal.VSICurlClearCache()
+
+    srcfilename = "/vsis3/test_bucket/src"
+    dstfilename = "/vsis3/test_bucket/dst"
+
+    handler = webserver.SequentialHandler()
+    handler.add(
+        "PUT",
+        "/test_bucket/dst",
+        200,
+        expected_headers={"x-amz-copy-source": "/test_bucket/src"},
+    )
+    with webserver.install_http_handler(handler):
+        ret_code, restart_payload = gdal.CopyFileRestartable(
+            srcfilename, dstfilename, None
+        )
+    assert ret_code == 0
+    assert restart_payload is None
+
+
+###############################################################################
 # Test reading/writing metadata
 
 

--- a/port/cpl_vsi.h
+++ b/port/cpl_vsi.h
@@ -453,6 +453,12 @@ int CPL_DLL VSICopyFile(const char *pszSource, const char *pszTarget,
                         VSILFILE *fpSource, vsi_l_offset nSourceSize,
                         const char *const *papszOptions,
                         GDALProgressFunc pProgressFunc, void *pProgressData);
+int CPL_DLL VSICopyFileRestartable(const char *pszSource, const char *pszTarget,
+                                   const char *pszInputPayload,
+                                   char **ppszOutputPayload,
+                                   const char *const *papszOptions,
+                                   GDALProgressFunc pProgressFunc,
+                                   void *pProgressData);
 int CPL_DLL VSISync(const char *pszSource, const char *pszTarget,
                     const char *const *papszOptions,
                     GDALProgressFunc pProgressFunc, void *pProgressData,

--- a/port/cpl_vsi_virtual.h
+++ b/port/cpl_vsi_virtual.h
@@ -283,6 +283,12 @@ class CPL_DLL VSIFilesystemHandler
                          const char *const *papszOptions,
                          GDALProgressFunc pProgressFunc, void *pProgressData);
 
+    virtual int
+    CopyFileRestartable(const char *pszSource, const char *pszTarget,
+                        const char *pszInputPayload, char **ppszOutputPayload,
+                        CSLConstList papszOptions,
+                        GDALProgressFunc pProgressFunc, void *pProgressData);
+
     virtual VSIDIR *OpenDir(const char *pszPath, int nRecurseDepth,
                             const char *const *papszOptions);
 

--- a/port/cpl_vsil.cpp
+++ b/port/cpl_vsil.cpp
@@ -589,6 +589,98 @@ int VSICopyFile(const char *pszSource, const char *pszTarget,
 }
 
 /************************************************************************/
+/*                       VSICopyFileRestartable()                       */
+/************************************************************************/
+
+/**
+ \brief Copy a source file into a target file in a way that can (potentially)
+ be restarted.
+
+ This function provides the possibility of efficiently restarting upload of
+ large files to cloud storage that implements upload in a chunked way,
+ such as /vsis3/ and /vsigs/.
+ For other destination file systems, this function may fallback to
+ VSICopyFile() and not provide any smart restartable implementation.
+
+ Example of a potential workflow:
+
+ @code{.cpp}
+ char* pszOutputPayload = NULL;
+ int ret = VSICopyFileRestartable(pszSource, pszTarget, NULL,
+                                  &pszOutputPayload, NULL, NULL, NULL);
+ while( ret == 1 ) // add also a limiting counter to avoid potentiall endless looping
+ {
+     // TODO: wait for some time
+
+     char* pszOutputPayloadNew = NULL;
+     const char* pszInputPayload = pszOutputPayload;
+     ret = VSICopyFileRestartable(pszSource, pszTarget, pszInputPayload,
+                                  &pszOutputPayloadNew, NULL, NULL, NULL);
+     VSIFree(pszOutputPayload);
+     pszOutputPayload = pszOutputPayloadNew;
+ }
+ VSIFree(pszOutputPayload);
+ @endcode
+
+ @param pszSource Source filename. UTF-8 encoded. Must not be NULL
+ @param pszTarget Target filename. UTF-8 encoded. Must not be NULL
+ @param pszInputPayload NULL at the first invocation. When doing a retry,
+                        should be the content of *ppszOutputPayload from a
+                        previous invocation.
+ @param[out] ppszOutputPayload Pointer to an output string that will be set to
+                               a value that can be provided as pszInputPayload
+                               for a next call to VSICopyFileRestartable().
+                               ppszOutputPayload must not be NULL.
+                               The string set in *ppszOutputPayload, if not NULL,
+                               is JSON-encoded, and can be re-used in another
+                               process instance. It must be freed with VSIFree()
+                               when no longer needed.
+ @param papszOptions Null terminated list of options, or NULL.
+ Currently accepted options are:
+ <ul>
+ <li>CHUNK_SIZE=integer. Maximum size of chunk (in bytes) to use
+ to split large objects. For upload to /vsis3/, this chunk size must be set at
+ least to 5 MB. The default is 50 MB.
+ </li>
+ </ul>
+ @param pProgressFunc Progress callback, or NULL.
+ @param pProgressData User data of progress callback, or NULL.
+ @return 0 on success,
+         -1 on (non-restartable) failure,
+         1 if VSICopyFileRestartable() can be called again in a restartable way
+ @since GDAL 3.10
+
+ @see VSIAbortPendingUploads()
+*/
+
+int VSICopyFileRestartable(const char *pszSource, const char *pszTarget,
+                           const char *pszInputPayload,
+                           char **ppszOutputPayload,
+                           const char *const *papszOptions,
+                           GDALProgressFunc pProgressFunc, void *pProgressData)
+
+{
+    if (!pszSource)
+    {
+        return -1;
+    }
+    if (!pszTarget || pszTarget[0] == '\0')
+    {
+        return -1;
+    }
+    if (!ppszOutputPayload)
+    {
+        return -1;
+    }
+
+    VSIFilesystemHandler *poFSHandlerTarget =
+        VSIFileManager::GetHandler(pszTarget);
+    return poFSHandlerTarget->CopyFileRestartable(
+        pszSource, pszTarget, pszInputPayload, ppszOutputPayload, papszOptions,
+        pProgressFunc, pProgressData);
+}
+
+/************************************************************************/
 /*                             VSISync()                                */
 /************************************************************************/
 
@@ -699,7 +791,7 @@ int VSISync(const char *pszSource, const char *pszTarget,
 }
 
 /************************************************************************/
-/*                         VSIAbortOngoingUploads()                     */
+/*                         VSIAbortPendingUploads()                     */
 /************************************************************************/
 
 /**
@@ -1394,6 +1486,22 @@ int VSIFilesystemHandler::CopyFile(const char *pszSource, const char *pszTarget,
         ret = -1;
     }
     return ret;
+}
+
+/************************************************************************/
+/*                       CopyFileRestartable()                          */
+/************************************************************************/
+
+int VSIFilesystemHandler::CopyFileRestartable(
+    const char *pszSource, const char *pszTarget,
+    const char * /* pszInputPayload */, char **ppszOutputPayload,
+    CSLConstList papszOptions, GDALProgressFunc pProgressFunc,
+    void *pProgressData)
+{
+    *ppszOutputPayload = nullptr;
+    return CopyFile(pszSource, pszTarget, nullptr,
+                    static_cast<vsi_l_offset>(-1), papszOptions, pProgressFunc,
+                    pProgressData);
 }
 
 /************************************************************************/

--- a/port/cpl_vsil.cpp
+++ b/port/cpl_vsil.cpp
@@ -638,6 +638,10 @@ int VSICopyFile(const char *pszSource, const char *pszTarget,
  @param papszOptions Null terminated list of options, or NULL.
  Currently accepted options are:
  <ul>
+ <li>NUM_THREADS=integer or ALL_CPUS. Number of threads to use for parallel
+ file copying. Only use for when /vsis3/, /vsigs/, /vsiaz/ or /vsiadls/ is in
+ source or target. The default is 10.
+ </li>
  <li>CHUNK_SIZE=integer. Maximum size of chunk (in bytes) to use
  to split large objects. For upload to /vsis3/, this chunk size must be set at
  least to 5 MB. The default is 50 MB.

--- a/port/cpl_vsil.cpp
+++ b/port/cpl_vsil.cpp
@@ -1314,6 +1314,7 @@ int VSIFilesystemHandler::CopyFile(const char *pszSource, const char *pszTarget,
     VSIVirtualHandleUniquePtr poFileHandleAutoClose;
     if (!fpSource)
     {
+        CPLAssert(pszSource);
         fpSource = VSIFOpenExL(pszSource, "rb", TRUE);
         if (!fpSource)
         {
@@ -1342,6 +1343,8 @@ int VSIFilesystemHandler::CopyFile(const char *pszSource, const char *pszTarget,
     CPLString osMsg;
     if (pszSource)
         osMsg.Printf("Copying of %s", pszSource);
+    else
+        pszSource = "(unknown filename)";
 
     int ret = 0;
     constexpr size_t nBufferSize = 10 * 4096;

--- a/port/cpl_vsil_curl_class.h
+++ b/port/cpl_vsil_curl_class.h
@@ -625,6 +625,14 @@ class IVSIS3LikeFSHandler : public VSICurlFilesystemHandlerBaseWritable
                          GDALProgressFunc pProgressFunc,
                          void *pProgressData) override;
 
+    virtual int CopyFileRestartable(const char *pszSource,
+                                    const char *pszTarget,
+                                    const char *pszInputPayload,
+                                    char **ppszOutputPayload,
+                                    CSLConstList papszOptions,
+                                    GDALProgressFunc pProgressFunc,
+                                    void *pProgressData) override;
+
     virtual int DeleteObject(const char *pszFilename);
 
     bool Sync(const char *pszSource, const char *pszTarget,
@@ -661,6 +669,9 @@ class IVSIS3LikeFSHandler : public VSICurlFilesystemHandlerBaseWritable
                                 int nMaxRetry, double dfRetryDelay);
 
     bool AbortPendingUploads(const char *pszFilename) override;
+
+    int GetUploadChunkSizeInBytes(const char *pszFilename,
+                                  const char *pszSpecifiedValInBytes);
 };
 
 /************************************************************************/

--- a/port/cpl_vsil_s3.cpp
+++ b/port/cpl_vsil_s3.cpp
@@ -3648,11 +3648,18 @@ int IVSIS3LikeFSHandler::CopyFile(const char *pszSource, const char *pszTarget,
                                   GDALProgressFunc pProgressFunc,
                                   void *pProgressData)
 {
-    std::string osMsg("Copying of ");
-    osMsg += pszSource;
-
     NetworkStatisticsFileSystem oContextFS(GetFSPrefix().c_str());
     NetworkStatisticsAction oContextAction("CopyFile");
+
+    if (!pszSource)
+    {
+        return VSIFilesystemHandler::CopyFile(pszSource, pszTarget, fpSource,
+                                              nSourceSize, papszOptions,
+                                              pProgressFunc, pProgressData);
+    }
+
+    std::string osMsg("Copying of ");
+    osMsg += pszSource;
 
     const std::string osPrefix(GetFSPrefix());
     if (STARTS_WITH(pszSource, osPrefix.c_str()) &&

--- a/port/cpl_vsil_s3.cpp
+++ b/port/cpl_vsil_s3.cpp
@@ -28,6 +28,7 @@
 
 #include "cpl_atomic_ops.h"
 #include "cpl_port.h"
+#include "cpl_json.h"
 #include "cpl_http.h"
 #include "cpl_md5.h"
 #include "cpl_minixml.h"
@@ -756,25 +757,7 @@ VSIS3WriteHandle::VSIS3WriteHandle(IVSIS3LikeFSHandler *poFS,
 
     if (!m_bUseChunked)
     {
-        const int nChunkSizeMB = atoi(VSIGetPathSpecificOption(
-            pszFilename,
-            (std::string("VSI") + poFS->GetDebugKey() + "_CHUNK_SIZE").c_str(),
-            "50"));
-        if (nChunkSizeMB <= 0 || nChunkSizeMB > 1000)
-            m_nBufferSize = 0;
-        else
-            m_nBufferSize = nChunkSizeMB * 1024 * 1024;
-
-        // For testing only !
-        const char *pszChunkSizeBytes = VSIGetPathSpecificOption(
-            pszFilename,
-            (std::string("VSI") + poFS->GetDebugKey() + "_CHUNK_SIZE_BYTES")
-                .c_str(),
-            nullptr);
-        if (pszChunkSizeBytes)
-            m_nBufferSize = atoi(pszChunkSizeBytes);
-        if (m_nBufferSize <= 0 || m_nBufferSize > 1000 * 1024 * 1024)
-            m_nBufferSize = 50 * 1024 * 1024;
+        m_nBufferSize = poFS->GetUploadChunkSizeInBytes(pszFilename, nullptr);
 
         m_pabyBuffer = static_cast<GByte *>(VSIMalloc(m_nBufferSize));
         if (m_pabyBuffer == nullptr)
@@ -784,6 +767,42 @@ VSIS3WriteHandle::VSIS3WriteHandle(IVSIS3LikeFSHandler *poFS,
                      m_poFS->GetFSPrefix().c_str());
         }
     }
+}
+
+/************************************************************************/
+/*                      GetUploadChunkSizeInBytes()                     */
+/************************************************************************/
+
+int IVSIS3LikeFSHandler::GetUploadChunkSizeInBytes(
+    const char *pszFilename, const char *pszSpecifiedValInBytes)
+{
+    int nChunkSize = 0;
+
+    const int nChunkSizeMB = atoi(VSIGetPathSpecificOption(
+        pszFilename,
+        std::string("VSI").append(GetDebugKey()).append("_CHUNK_SIZE").c_str(),
+        "50"));
+    if (nChunkSizeMB <= 0 || nChunkSizeMB > 1000)
+        nChunkSize = 0;
+    else
+        nChunkSize = nChunkSizeMB * 1024 * 1024;
+
+    const char *pszChunkSizeBytes =
+        pszSpecifiedValInBytes ? pszSpecifiedValInBytes :
+                               // For testing only !
+            VSIGetPathSpecificOption(pszFilename,
+                                     std::string("VSI")
+                                         .append(GetDebugKey())
+                                         .append("_CHUNK_SIZE_BYTES")
+                                         .c_str(),
+                                     nullptr);
+    if (pszChunkSizeBytes)
+        nChunkSize = atoi(pszChunkSizeBytes);
+
+    if (nChunkSize <= 0 || nChunkSize > 1000 * 1024 * 1024)
+        nChunkSize = 50 * 1024 * 1024;
+
+    return nChunkSize;
 }
 
 /************************************************************************/
@@ -3727,6 +3746,296 @@ int IVSIS3LikeFSHandler::CopyFile(const char *pszSource, const char *pszTarget,
     }
 
     return ret;
+}
+
+/************************************************************************/
+/*                       CopyFileRestartable()                          */
+/************************************************************************/
+
+int IVSIS3LikeFSHandler::CopyFileRestartable(
+    const char *pszSource, const char *pszTarget, const char *pszInputPayload,
+    char **ppszOutputPayload, CSLConstList papszOptions,
+    GDALProgressFunc pProgressFunc, void *pProgressData)
+{
+    const std::string osPrefix(GetFSPrefix());
+    NetworkStatisticsFileSystem oContextFS(osPrefix.c_str());
+    NetworkStatisticsAction oContextAction("CopyFileRestartable");
+
+    *ppszOutputPayload = nullptr;
+
+    if (!STARTS_WITH(pszTarget, osPrefix.c_str()))
+        return -1;
+
+    std::string osMsg("Copying of ");
+    osMsg += pszSource;
+
+    // Can we use server-side copy ?
+    if (STARTS_WITH(pszSource, osPrefix.c_str()) &&
+        STARTS_WITH(pszTarget, osPrefix.c_str()))
+    {
+        bool bRet = CopyObject(pszSource, pszTarget, papszOptions) == 0;
+        if (bRet && pProgressFunc)
+        {
+            bRet = pProgressFunc(1.0, osMsg.c_str(), pProgressData) != 0;
+        }
+        return bRet ? 0 : -1;
+    }
+
+    // If multipart upload is not supported, fallback to regular CopyFile()
+    if (!SupportsParallelMultipartUpload())
+    {
+        return CopyFile(pszSource, pszTarget, nullptr,
+                        static_cast<vsi_l_offset>(-1), papszOptions,
+                        pProgressFunc, pProgressData);
+    }
+
+    VSIVirtualHandleUniquePtr fpSource(VSIFOpenExL(pszSource, "rb", TRUE));
+    if (!fpSource)
+    {
+        CPLError(CE_Failure, CPLE_FileIO, "Cannot open %s", pszSource);
+        return -1;
+    }
+
+    const char *pszChunkSize = CSLFetchNameValue(papszOptions, "CHUNK_SIZE");
+    int nChunkSize = GetUploadChunkSizeInBytes(pszTarget, pszChunkSize);
+
+    VSIStatBufL sStatBuf;
+    if (VSIStatL(pszSource, &sStatBuf) != 0)
+        return -1;
+
+    auto poS3HandleHelper = std::unique_ptr<IVSIS3LikeHandleHelper>(
+        CreateHandleHelper(pszTarget + osPrefix.size(), false));
+    if (poS3HandleHelper == nullptr)
+        return -1;
+
+    int nChunkCount = 0;
+    std::vector<std::string> aosEtags;
+    std::string osUploadID;
+
+    if (pszInputPayload)
+    {
+        // If there is an input payload, parse it, and do sanity checks
+        // and initial setup
+
+        CPLJSONDocument oDoc;
+        if (!oDoc.LoadMemory(pszInputPayload))
+            return -1;
+
+        auto oRoot = oDoc.GetRoot();
+        if (oRoot.GetString("source") != pszSource)
+        {
+            CPLError(
+                CE_Failure, CPLE_AppDefined,
+                "'source' field in input payload does not match pszSource");
+            return -1;
+        }
+
+        if (oRoot.GetString("target") != pszTarget)
+        {
+            CPLError(
+                CE_Failure, CPLE_AppDefined,
+                "'target' field in input payload does not match pszTarget");
+            return -1;
+        }
+
+        if (static_cast<uint64_t>(oRoot.GetLong("source_size")) !=
+            static_cast<uint64_t>(sStatBuf.st_size))
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "'source_size' field in input payload does not match "
+                     "source file size");
+            return -1;
+        }
+
+        if (oRoot.GetLong("source_mtime") !=
+            static_cast<GIntBig>(sStatBuf.st_mtime))
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "'source_mtime' field in input payload does not match "
+                     "source file modification time");
+            return -1;
+        }
+
+        osUploadID = oRoot.GetString("upload_id");
+        if (osUploadID.empty())
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "'upload_id' field in input payload missing or invalid");
+            return -1;
+        }
+
+        nChunkSize = oRoot.GetInteger("chunk_size");
+        if (nChunkSize <= 0)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "'chunk_size' field in input payload missing or invalid");
+            return -1;
+        }
+
+        auto oEtags = oRoot.GetArray("chunk_etags");
+        if (!oEtags.IsValid())
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "'chunk_etags' field in input payload missing or invalid");
+            return -1;
+        }
+
+        const auto nChunkCountLarge =
+            (sStatBuf.st_size + nChunkSize - 1) / nChunkSize;
+        if (nChunkCountLarge != oEtags.Size())
+        {
+            CPLError(
+                CE_Failure, CPLE_AppDefined,
+                "'chunk_etags' field in input payload has not expected size");
+            return -1;
+        }
+        nChunkCount = oEtags.Size();
+        for (int iChunk = 0; iChunk < nChunkCount; ++iChunk)
+        {
+            aosEtags.push_back(oEtags[iChunk].ToString());
+        }
+    }
+    else
+    {
+        // Compute the number of chunks
+        auto nChunkCountLarge =
+            (sStatBuf.st_size + nChunkSize - 1) / nChunkSize;
+        if (nChunkCountLarge > knMAX_PART_NUMBER)
+        {
+            // Re-adjust the chunk size if needed
+            constexpr int nWishedChunkCount = knMAX_PART_NUMBER / 10;
+            const auto nMinChunkSizeLarge =
+                (sStatBuf.st_size + nWishedChunkCount - 1) / nWishedChunkCount;
+            if (pszChunkSize)
+            {
+                CPLError(
+                    CE_Failure, CPLE_AppDefined,
+                    "Too small CHUNK_SIZE compared to file size. Should be at "
+                    "least " CPL_FRMT_GUIB,
+                    static_cast<GUIntBig>(nMinChunkSizeLarge));
+                return -1;
+            }
+            if (nMinChunkSizeLarge > 1000 * 1024 * 1024)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined, "Too large file");
+                return -1;
+            }
+            nChunkSize = static_cast<int>(nMinChunkSizeLarge);
+            nChunkCountLarge = (sStatBuf.st_size + nChunkSize - 1) / nChunkSize;
+        }
+        nChunkCount = static_cast<int>(nChunkCountLarge);
+        aosEtags.resize(nChunkCount);
+    }
+
+    // coverity[tainted_data]
+    const double dfRetryDelay = CPLAtof(
+        VSIGetPathSpecificOption(pszSource, "GDAL_HTTP_RETRY_DELAY",
+                                 CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)));
+    const int nMaxRetry =
+        atoi(VSIGetPathSpecificOption(pszSource, "GDAL_HTTP_MAX_RETRY",
+                                      CPLSPrintf("%d", CPL_HTTP_MAX_RETRY)));
+
+    std::vector<GByte> abyBuffer;
+    try
+    {
+        abyBuffer.resize(nChunkSize);
+    }
+    catch (const std::exception &)
+    {
+        CPLError(CE_Failure, CPLE_OutOfMemory,
+                 "Cannot allocate working buffer");
+        return -1;
+    }
+
+    if (osUploadID.empty())
+    {
+        osUploadID = InitiateMultipartUpload(pszTarget, poS3HandleHelper.get(),
+                                             nMaxRetry, dfRetryDelay, nullptr);
+        if (osUploadID.empty())
+        {
+            return -1;
+        }
+    }
+
+    bool bSuccess = true;
+    if (pProgressFunc && !pProgressFunc(0, osMsg.c_str(), pProgressData))
+    {
+        bSuccess = false;
+    }
+    for (int iChunk = 0; iChunk < nChunkCount && bSuccess; ++iChunk)
+    {
+        if (aosEtags[iChunk].empty())
+        {
+            const auto nCurPos = iChunk * static_cast<vsi_l_offset>(nChunkSize);
+            CPL_IGNORE_RET_VAL(fpSource->Seek(nCurPos, SEEK_SET));
+            const auto nRemaining = sStatBuf.st_size - nCurPos;
+            const size_t nToRead =
+                nRemaining > static_cast<vsi_l_offset>(nChunkSize)
+                    ? nChunkSize
+                    : static_cast<int>(nRemaining);
+            const size_t nRead = fpSource->Read(abyBuffer.data(), 1, nToRead);
+            if (nRead != nToRead)
+            {
+                CPLError(
+                    CE_Failure, CPLE_FileIO,
+                    "Did not get expected number of bytes from input file");
+                AbortMultipart(pszTarget, osUploadID, poS3HandleHelper.get(),
+                               nMaxRetry, dfRetryDelay);
+                return -1;
+            }
+            const auto osEtag =
+                UploadPart(pszTarget, 1 + iChunk, osUploadID, nCurPos,
+                           abyBuffer.data(), nToRead, poS3HandleHelper.get(),
+                           nMaxRetry, dfRetryDelay, nullptr);
+            if (osEtag.empty())
+            {
+                bSuccess = false;
+                break;
+            }
+            aosEtags[iChunk] = osEtag;
+        }
+        if (pProgressFunc && !pProgressFunc(double(iChunk + 1) / nChunkCount,
+                                            osMsg.c_str(), pProgressData))
+        {
+            bSuccess = false;
+            break;
+        }
+    }
+
+    if (!bSuccess)
+    {
+        // Compose an output restart payload
+        CPLJSONDocument oDoc;
+        auto oRoot = oDoc.GetRoot();
+        oRoot.Add("type", "CopyFileRestartablePayload");
+        oRoot.Add("source", pszSource);
+        oRoot.Add("target", pszTarget);
+        oRoot.Add("source_size", static_cast<uint64_t>(sStatBuf.st_size));
+        oRoot.Add("source_mtime", static_cast<GIntBig>(sStatBuf.st_mtime));
+        oRoot.Add("chunk_size", nChunkSize);
+        oRoot.Add("upload_id", osUploadID);
+        CPLJSONArray oArray;
+        for (int iChunk = 0; iChunk < nChunkCount; ++iChunk)
+        {
+            if (aosEtags[iChunk].empty())
+                oArray.AddNull();
+            else
+                oArray.Add(aosEtags[iChunk]);
+        }
+        oRoot.Add("chunk_etags", oArray);
+        *ppszOutputPayload = CPLStrdup(oDoc.SaveAsString().c_str());
+        return 1;
+    }
+
+    if (!CompleteMultipart(pszTarget, osUploadID, aosEtags, sStatBuf.st_size,
+                           poS3HandleHelper.get(), nMaxRetry, dfRetryDelay))
+    {
+        AbortMultipart(pszTarget, osUploadID, poS3HandleHelper.get(), nMaxRetry,
+                       dfRetryDelay);
+        return -1;
+    }
+
+    return 0;
 }
 
 /************************************************************************/

--- a/swig/include/cpl.i
+++ b/swig/include/cpl.i
@@ -739,6 +739,23 @@ int wrapper_VSICopyFile(const char* pszSource,
         nSourceSize < 0 ? static_cast<vsi_l_offset>(-1) : static_cast<vsi_l_offset>(nSourceSize),
         options, callback, callback_data );
 }
+
+#if defined(SWIGPYTHON)
+void CopyFileRestartable(const char* pszSource,
+                         const char* pszTarget,
+                         const char* pszInputPayload,
+                         int* pnRetCode,
+                         char** ppszOutputPayload,
+                         char** options = NULL,
+                         GDALProgressFunc callback=NULL,
+                         void* callback_data=NULL)
+{
+    *pnRetCode = VSICopyFileRestartable(pszSource, pszTarget, pszInputPayload,
+                                        ppszOutputPayload, options, callback,
+                                        callback_data);
+}
+#endif
+
 }
 
 %clear (const char* pszSource);

--- a/swig/include/python/typemaps_python.i
+++ b/swig/include/python/typemaps_python.i
@@ -3468,3 +3468,30 @@ OBJECT_LIST_INPUT(GDALMDArrayHS);
   PyTuple_SetItem( r, 2, PyLong_FromLong(*$3) );
   $result = t_output_helper($result,r);
 }
+
+
+
+%typemap(in,numinputs=0) (int* pnRetCode, char** ppszOutputPayload) ( int nRetCode = 0, char* pszOutputPayload = 0 )
+{
+  /* %typemap(in) (int* pnRetCode, char** ppszOutputPayload) */
+  $1 = &nRetCode;
+  $2 = &pszOutputPayload;
+}
+
+%typemap(argout) (int* pnRetCode, char** ppszOutputPayload)
+{
+   /* %typemap(argout) (int* pnRetCode, char** ppszOutputPayload)  */
+  PyObject *r = PyTuple_New( 2 );
+  PyTuple_SetItem( r, 0, PyLong_FromLong(*$1) );
+  if( *$2 )
+  {
+      PyTuple_SetItem( r, 1, GDALPythonObjectFromCStr(*$2) );
+      VSIFree(*$2);
+  }
+  else
+  {
+      Py_INCREF(Py_None);
+      PyTuple_SetItem( r, 1, Py_None );
+  }
+  $result = t_output_helper($result,r);
+}


### PR DESCRIPTION
Copy a source file into a target file in a way that can (potentially)
be restarted.

This function provides the possibility of efficiently restarting upload of
large files to cloud storage that implements upload in a chunked way,
such as /vsis3/ and /vsigs/.
For other destination file systems, this function may fallback to
VSICopyFile() and not provide any smart restartable implementation.

Example of a potential workflow:
```cpp
char* pszOutputPayload = NULL;
int ret = VSICopyFileRestartable(pszSource, pszTarget, NULL,
                                 &pszOutputPayload, NULL, NULL, NULL);
while( ret == 1 ) // add also a limiting counter to avoid potentiall endless looping
{
    // TODO: wait for some time

    char* pszOutputPayloadNew = NULL;
    const char* pszInputPayload = pszOutputPayload;
    ret = VSICopyFileRestartable(pszSource, pszTarget, pszInputPayload,
                                 &pszOutputPayloadNew, NULL, NULL, NULL);
    VSIFree(pszOutputPayload);
    pszOutputPayload = pszOutputPayloadNew;
}
VSIFree(pszOutputPayload);
```
