### PR TITLE
gdal_retile.py: resolution handling

### DIFF
--- a/doc/source/programs/gdal_retile.rst
+++ b/doc/source/programs/gdal_retile.rst
@@ -25,6 +25,7 @@ Synopsis
                    [-s_srs <srs_def>]  [-pyramidOnly]
                    [-r {near|bilinear|cubic|cubicspline|lanczos}]
                    -levels <numberoflevels>
+                   -res res_1,res_2,...,res_n
                    [-useDirForEachRow] [-resume]
                    -targetDir <TileDirectory> <input_file> <input_file>...
 
@@ -72,6 +73,12 @@ If your number of input tiles exhausts the command line buffer, use the general
 .. option:: -levels <numberOfLevels>
 
     Number of pyramids levels to build.
+
+.. option:: -res res_1,res_2,...,res_n
+
+    A list of resolutions (pixel size) to be used for pyramid creation. This option is
+    mutually exclusive to -levels. The number of pyramid levels is equal to the number 
+    of given resolutions. 
 
 .. option:: -v
 


### PR DESCRIPTION
## What does this PR do?

This adds an option to gdal_retile for calculating image pyramids for specific resolutions/pixel sizes. This can be used instead of specifying the number of levels. For example: 
  gdal_retile.py -pyramidOnly -ps 4096 4096 -res 1.0,5.0,25.0 -targetDir out/pyramid input/*.tif 
Will create an image pyramid with 
* level 1: 1 m/pixel
* level 2: 5 m/pixel
* level 3: 25 m/pixel
(assuming the input data uses as units meter)

## What are related issues/pull requests?

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [x] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
