### PR TITLE
CI: Skip running on pushes to dependabot and backport branches

### DIFF
--- a/.github/workflows/android_cmake.yml
+++ b/.github/workflows/android_cmake.yml
@@ -6,6 +6,7 @@ on:
             - 'doc/**'
         branches-ignore:
             - 'backport**'
+            - 'dependabot**'
     pull_request:
         paths-ignore:
             - 'doc/**'

--- a/.github/workflows/clang_static_analyzer.yml
+++ b/.github/workflows/clang_static_analyzer.yml
@@ -6,6 +6,7 @@ on:
             - 'doc/**'
         branches-ignore:
             - 'backport**'
+            - 'dependabot**'
     pull_request:
         paths-ignore:
             - 'doc/**'

--- a/.github/workflows/cmake_builds.yml
+++ b/.github/workflows/cmake_builds.yml
@@ -8,6 +8,7 @@ on:
             - 'doc/**'
         branches-ignore:
             - 'backport**'
+            - 'dependabot**'
     pull_request:
         paths-ignore:
             - 'doc/**'

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -6,6 +6,7 @@ on:
             - 'doc/**'
         branches-ignore:
             - 'backport**'
+            - 'dependabot**'
     pull_request:
         paths-ignore:
             - 'doc/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,7 @@ on:
             - 'doc/**'
         branches-ignore:
           - 'backport**'
+          - 'dependabot**'
     pull_request:
         paths-ignore:
             - 'doc/**'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -4,6 +4,8 @@ on:
     push:
         paths-ignore:
             - 'doc/**'
+        branches-ignore:
+          - 'backport**'
     pull_request:
         paths-ignore:
             - 'doc/**'

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -6,6 +6,7 @@ on:
             - 'doc/**'
         branches-ignore:
             - 'backport**'
+            - 'dependabot**'
 
     # Disabled because run is quite slow, especially for Mac
     #pull_request:

--- a/.github/workflows/delete_untagged_containers.yml
+++ b/.github/workflows/delete_untagged_containers.yml
@@ -6,6 +6,7 @@ on:
             - 'doc/**'
         branches-ignore:
             - 'backport**'
+            - 'dependabot**'
 
 permissions:
   contents: read

--- a/.github/workflows/doc_build.yml
+++ b/.github/workflows/doc_build.yml
@@ -4,6 +4,7 @@ on:
     push:
         branches-ignore:
             - 'backport**'
+            - 'dependabot**'
     pull_request:
 
 concurrency:

--- a/.github/workflows/freebsd.yml.disabled
+++ b/.github/workflows/freebsd.yml.disabled
@@ -6,6 +6,7 @@ on:
             - 'doc/**'
         branches:
             - '!backport**'
+            - '!dependabot**'
     pull_request:
         paths-ignore:
             - 'doc/**'

--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -6,6 +6,7 @@ on:
             - 'doc/**'
         branches-ignore:
             - 'backport**'
+            - 'dependabot**'
     pull_request:
         paths-ignore:
             - 'doc/**'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,6 +6,7 @@ on:
             - 'doc/**'
         branches-ignore:
             - 'backport**'
+            - 'dependabot**'
     pull_request:
         paths-ignore:
             - 'doc/**'

--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -6,6 +6,7 @@ on:
             - 'doc/**'
         branches-ignore:
             - 'backport**'
+            - 'dependabot**'
     pull_request:
         paths-ignore:
             - 'doc/**'


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

Adds `dependabot**` to push's branches-ignore for workflows with a `push` event trigger.
For CodeQL's workflow, it was also missing the branches-ignore for the `backport**` branches, it got also added.

## What are related issues/pull requests?
Closes #9851

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
