### PR TITLE
CI(CodeQL): Speed up workflow by not compiling tests and using debug builds

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Install dependencies
       run: |
           sudo apt-get update
-          sudo apt-get install -y ccache cmake g++ swig python3-numpy libproj-dev libqhull-dev
+          sudo apt-get install -y g++ swig python3-numpy libproj-dev libqhull-dev
           sudo apt-get install -y \
             libblosc-dev \
             libboost-dev \
@@ -91,11 +91,17 @@ jobs:
             libzstd-dev \
             unixodbc-dev
 
+    - name: Install latest ninja
+      run: pip install ninja
+
     - name: Configure
       if: matrix.language == 'c-cpp'
       run: |
-          mkdir build
-          (cd build && cmake .. -DCMAKE_BUILD_TYPE=RelWithDebInfo -DGDAL_USE_LERC_INTERNAL=OFF)
+          cmake -S . -B build \
+            -DCMAKE_BUILD_TYPE=Debug \
+            -DGDAL_USE_LERC_INTERNAL=OFF \
+            -DBUILD_TESTING=OFF \
+            -G Ninja \
 
     # Initializes the CodeQL tools for scanning.
     # We do that after running CMake to avoid CodeQL to trigger during CMake time,
@@ -118,7 +124,7 @@ jobs:
     - name: Build
       if: matrix.language == 'c-cpp'
       run: |
-          (cd build && make -j$(nproc))
+        cmake --build build -j$(nproc)
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@d39d31e687223d841ef683f52467bd88e9b21c14 # v3.25.3


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?
Reduces time spent on the CodeQL workflow, where the build is required in order to do the scan, but the actual results of the compilation are not important. Caching cannot be used.

Changes:
 - Set build type to Debug, so less time is spent on unused optimizations passes.
 - Disable building tests, automatically enabled when including CTest.
 - Removing ccache and cmake from the list of software to install with apt-get, as they aren't used. (CMake is used, but not the one from apt-get).
 - Use shortcut syntax for generating the project's buildsystem and the folder in one step (cmake 3.13, minimum supported is 3.16), and a similar way to invoke the build, that is independent of the generator used
 - Use Ninja generator.

I finally opted in to use the Ninja Generator, as in my final comparisons, ninja more often finished earlier than makefiles on the GitHub runners (an advantage in the 30-second order, or I was multiple times in a row lucky with the hardware assigned). I also prefer its output, with the number of edges over total number of edges to do, but that wasn't a criterion as such. It also seems like it would be the only Linux build using Ninja generator run in GitHub Actions (I only found mentions of ninja for Windows builds here), so it is not a bad thing to vary the tools used.

## What are related issues/pull requests?
Closes #9856

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
