### PR TITLE
PG: emit warning when using GEOMETRY_NAME!=wkb_geometry on non-PostGIS enabled database

### DIFF
--- a/autotest/ogr/ogr_pg.py
+++ b/autotest/ogr/ogr_pg.py
@@ -5952,3 +5952,22 @@ def test_ogr_pg_LAUNDER_ASCII(pg_ds, tmp_schema):
     assert lyr.GetName() == f"{tmp_schema}.ae"
     lyr.CreateField(ogr.FieldDefn("b" + eacute))
     assert lyr.GetLayerDefn().GetFieldDefn(0).GetNameRef() == "be"
+
+
+###############################################################################
+# Test ignored GEOMETRY_NAME on non-PostGIS enabled database
+
+
+@only_without_postgis
+def test_ogr_pg_no_postgis_GEOMETRY_NAME(pg_ds):
+
+    with gdal.quiet_errors():
+        pg_ds.CreateLayer(
+            "test_ogr_pg_no_postgis_GEOMETRY_NAME",
+            geom_type=ogr.wkbPoint,
+            options=["GEOMETRY_NAME=foo"],
+        )
+        assert (
+            gdal.GetLastErrorMsg()
+            == "GEOMETRY_NAME=foo ignored, and set instead to 'wkb_geometry' as it is the only geometry column name recognized for non-PostGIS enabled databases."
+        )

--- a/autotest/ogr/ogr_pg.py
+++ b/autotest/ogr/ogr_pg.py
@@ -191,7 +191,7 @@ def only_with_postgis(func):
 
 
 def only_without_postgis(func):
-    @pytest.mark.parametrize("use_postgis", [True], ids=["no-postgis"], indirect=True)
+    @pytest.mark.parametrize("use_postgis", [False], ids=["no-postgis"], indirect=True)
     @functools.wraps(func)
     def wrapper(*args, **kwargs):
         return func(*args, **kwargs)
@@ -4803,7 +4803,6 @@ def test_ogr_pg_83(pg_ds, geom_type, options, wkt, expected_wkt):
 # Test description
 
 
-@only_without_postgis
 def test_ogr_pg_84(pg_ds):
 
     lyr = pg_ds.CreateLayer(

--- a/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
@@ -1211,10 +1211,14 @@ void OGRPGDataSource::LoadTables()
             osCommand += " ORDER BY oid, attnum";
         }
         else
-            osCommand.Printf("SELECT c.relname, n.nspname FROM "
-                             "pg_class c, pg_namespace n "
-                             "WHERE (c.relkind in (%s) AND c.relname !~ '^pg_' "
-                             "AND c.relnamespace=n.oid)",
+            osCommand.Printf("SELECT c.relname, n.nspname, d.description FROM "
+                             "pg_class c "
+                             "JOIN pg_namespace n ON c.relnamespace=n.oid "
+                             "LEFT JOIN pg_description d "
+                             "ON d.objoid = c.oid AND d.classoid = "
+                             "'pg_class'::regclass::oid AND d.objsubid = 0 "
+                             "WHERE (c.relkind in (%s) AND "
+                             "c.relname !~ '^pg_')",
                              pszAllowedRelations);
 
         PGresult *hResult = OGRPG_PQexec(hPGConn, osCommand.c_str());
@@ -1256,6 +1260,10 @@ void OGRPGDataSource::LoadTables()
                     atoi(PQgetvalue(hResult, iRecord, 6)));
                 bNullable = EQUAL(PQgetvalue(hResult, iRecord, 7), "f");
                 pszDescription = PQgetvalue(hResult, iRecord, 8);
+            }
+            else
+            {
+                pszDescription = PQgetvalue(hResult, iRecord, 2);
             }
 
             if (EQUAL(pszTable, "spatial_ref_sys") ||

--- a/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
@@ -1833,6 +1833,14 @@ OGRLayer *OGRPGDataSource::ICreateLayer(const char *pszLayerName,
         CPLString osCommand;
         if (eType != wkbNone && !bHavePostGIS)
         {
+            if (pszGFldName && !EQUAL(pszGFldName, "wkb_geometry"))
+            {
+                CPLError(CE_Warning, CPLE_AppDefined,
+                         "GEOMETRY_NAME=%s ignored, and set instead to "
+                         "'wkb_geometry' as it is the only geometry column "
+                         "name recognized for non-PostGIS enabled databases.",
+                         pszGFldName);
+            }
             pszGFldName = "wkb_geometry";
             osCommand.Printf("%s ( "
                              "    %s %s, "


### PR DESCRIPTION
Fixes #9852