### PR TITLE
/vsis3/: include AWS_CONTAINER_CREDENTIALS_TOKEN in container credentials flow

### DIFF
--- a/port/cpl_aws.cpp
+++ b/port/cpl_aws.cpp
@@ -664,24 +664,22 @@ static EC2InstanceCertainty IsMachinePotentiallyEC2Instance()
 }
 
 /************************************************************************/
-/*                   ReadAWSWebIdentityTokenFile()                      */
+/*                   ReadAWSTokenFile()                                 */
 /************************************************************************/
 
-static bool
-ReadAWSWebIdentityTokenFile(const std::string &osWebIdentityTokenFile,
-                            std::string &webIdentityToken)
+static bool ReadAWSTokenFile(const std::string &osAWSTokenFile,
+                             std::string &awsToken)
 {
     GByte *pabyOut = nullptr;
-    if (!VSIIngestFile(nullptr, osWebIdentityTokenFile.c_str(), &pabyOut,
-                       nullptr, -1))
+    if (!VSIIngestFile(nullptr, osAWSTokenFile.c_str(), &pabyOut, nullptr, -1))
         return false;
 
-    webIdentityToken = reinterpret_cast<char *>(pabyOut);
+    awsToken = reinterpret_cast<char *>(pabyOut);
     VSIFree(pabyOut);
     // Remove trailing end-of-line character
-    if (!webIdentityToken.empty() && webIdentityToken.back() == '\n')
-        webIdentityToken.resize(webIdentityToken.size() - 1);
-    return !webIdentityToken.empty();
+    if (!awsToken.empty() && awsToken.back() == '\n')
+        awsToken.resize(awsToken.size() - 1);
+    return !awsToken.empty();
 }
 
 /************************************************************************/
@@ -753,7 +751,7 @@ bool VSIS3HandleHelper::GetConfigurationFromAssumeRoleWithWebIdentity(
 
     // Get token from web identity token file
     std::string webIdentityToken;
-    if (!ReadAWSWebIdentityTokenFile(webIdentityTokenFile, webIdentityToken))
+    if (!ReadAWSTokenFile(webIdentityTokenFile, webIdentityToken))
     {
         CPLDebug("AWS", "%s is empty", webIdentityTokenFile.c_str());
         return false;
@@ -879,7 +877,7 @@ bool VSIS3HandleHelper::GetConfigurationFromEC2(
     std::string osECSToken;
     if (!osECSTokenFile.empty())
     {
-        if (!ReadAWSWebIdentityTokenFile(osECSTokenFile, osECSToken))
+        if (!ReadAWSTokenFile(osECSTokenFile, osECSToken))
         {
             CPLDebug("AWS", "%s is empty", osECSTokenFile.c_str());
         }


### PR DESCRIPTION

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

This PR extends the [container credentials](https://docs.aws.amazon.com/sdkref/latest/guide/feature-container-credentials.html) functionality of `vsis3` to cover more cases, particularly [EKS Pod Identities](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html).

Two additional environment variables are now considered in the container credentials flow: `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` and `AWS_CONTAINER_AUTHORIZATION_TOKEN`, with the former taking precedence over the latter (as described in AWS SDK documentation).

In addition to the included tests, I have tested the `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE`-based credential flow in practice on EKS. 

## What are related issues/pull requests?

This functionality has been previously improved in #8859

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed