### PR TITLE
[Backport release/3.9] MiraMonVector: adding which polygon cycles the linestring in the linestring metadata information

### DIFF
--- a/ogr/ogrsf_frmts/miramon/mm_gdal_driver_structs.h
+++ b/ogr/ogrsf_frmts/miramon/mm_gdal_driver_structs.h
@@ -280,7 +280,7 @@ struct MiraMonVectorMetaData
 {
     char *szLayerTitle;
     char *aLayerName;
-    char *aArcFile;  // Polygon's arc name
+    char *aArcFile;  // Polygon's arc name or arc's polygon name.
     int ePlainLT;    // Plain layer type (no 3D specified): MM_LayerType_Point,
                      // MM_LayerType_Arc, MM_LayerType_Node, MM_LayerType_Pol
     char *pSRS;      // EPSG code of the spatial reference system.

--- a/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
+++ b/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
@@ -5584,14 +5584,22 @@ static int MMWriteMetadataFile(struct MiraMonVectorMetaData *hMMMD)
         }
     }
 
-    // Writing OVERVIEW:ASPECTES_TECNICS in polygon metadata file.
-    // ArcSource=fitx_pol.arc
-    if (hMMMD->ePlainLT == MM_LayerType_Pol)
+    if (hMMMD->ePlainLT == MM_LayerType_Pol && hMMMD->aArcFile)
     {
+        // Writing OVERVIEW:ASPECTES_TECNICS in polygon metadata file.
+        // ArcSource=fitx_pol.arc
         fprintf_function(pF, LineReturn "[%s]" LineReturn,
                          SECTION_OVVW_ASPECTES_TECNICS);
         fprintf_function(pF, "%s=\"%s\"" LineReturn, KEY_ArcSource,
                          hMMMD->aArcFile);
+    }
+    else if (hMMMD->ePlainLT == MM_LayerType_Arc && hMMMD->aArcFile)
+    {
+        // Writing OVERVIEW:ASPECTES_TECNICS in arc metadata file.
+        // Ciclat1=fitx_arc.pol
+        fprintf_function(pF, LineReturn "[%s]" LineReturn,
+                         SECTION_OVVW_ASPECTES_TECNICS);
+        fprintf_function(pF, "Ciclat1=\"%s\"" LineReturn, hMMMD->aArcFile);
     }
 
     // Writing EXTENT section
@@ -5868,6 +5876,8 @@ static int MMWriteVectorMetadataFile(struct MiraMonVectLayerInfo *hMiraMonLayer,
                    sizeof(hMMMD.hBB));
             hMMMD.pLayerDB = nullptr;
         }
+        hMMMD.aArcFile = strdup_function(
+            get_filename_function(hMiraMonLayer->MMPolygon.pszLayerName));
         return MMWriteMetadataFile(&hMMMD);
     }
     else if (layerPlainType == MM_LayerType_Pol)

--- a/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
+++ b/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
@@ -5854,6 +5854,8 @@ static int MMWriteVectorMetadataFile(struct MiraMonVectLayerInfo *hMiraMonLayer,
     }
     else if (layerPlainType == MM_LayerType_Arc)
     {
+        int nResult;
+
         // Arcs and not polygons
         if (layerMainPlainType == MM_LayerType_Arc)
         {
@@ -5878,7 +5880,9 @@ static int MMWriteVectorMetadataFile(struct MiraMonVectLayerInfo *hMiraMonLayer,
         }
         hMMMD.aArcFile = strdup_function(
             get_filename_function(hMiraMonLayer->MMPolygon.pszLayerName));
-        return MMWriteMetadataFile(&hMMMD);
+        nResult = MMWriteMetadataFile(&hMMMD);
+        free_function(hMMMD.aArcFile);
+        return nResult;
     }
     else if (layerPlainType == MM_LayerType_Pol)
     {


### PR DESCRIPTION
Backport #9883
 **Authored by:** @AbelPau