### PR TITLE
[gdalmdiminfo] Use GDALArgumentParser

### DIFF
--- a/apps/gdal_utils_priv.h
+++ b/apps/gdal_utils_priv.h
@@ -239,6 +239,8 @@ std::string CPL_DLL GDALWarpAppGetParserUsage();
 
 std::string CPL_DLL GDALInfoAppGetParserUsage();
 
+std::string CPL_DLL GDALMultiDimInfoAppGetParserUsage();
+
 std::string CPL_DLL GDALGridGetParserUsage();
 
 std::string CPL_DLL GDALBuildVRTGetParserUsage();

--- a/apps/gdalmdiminfo_bin.cpp
+++ b/apps/gdalmdiminfo_bin.cpp
@@ -33,26 +33,26 @@
 #include "commonutils.h"
 #include "gdal_utils_priv.h"
 
+/**
+ * @brief Makes sure the GDAL library is properly cleaned up before exiting.
+ * @param nCode exit code
+ * @todo Move to API
+ */
+static void GDALExit(const int nCode)
+{
+    GDALDestroy();
+    exit(nCode);
+}
+
 /************************************************************************/
 /*                               Usage()                                */
 /************************************************************************/
 
-static void Usage(bool bIsError, const char *pszErrorMsg = nullptr)
+static void Usage()
 
 {
-    fprintf(
-        bIsError ? stderr : stdout,
-        "Usage: gdalmdiminfo [--help] [--help-general]\n"
-        "                    [-oo <NAME>=<VALUE>]... [-arrayoption "
-        "<NAME>=<VALUE>]...\n"
-        "                    [-detailed] [-nopretty] [-array <array_name>]\n"
-        "                    [-limit <number>] [-stats] [-if <format>]...\n"
-        "                    <datasetname>\n");
-
-    if (pszErrorMsg != nullptr)
-        fprintf(stderr, "\nFAILURE: %s\n", pszErrorMsg);
-
-    exit(bIsError ? 1 : 0);
+    fprintf(stderr, "%s\n", GDALMultiDimInfoAppGetParserUsage().c_str());
+    GDALExit(1);
 }
 
 /************************************************************************/
@@ -68,34 +68,21 @@ MAIN_START(argc, argv)
 
     argc = GDALGeneralCmdLineProcessor(argc, &argv, 0);
     if (argc < 1)
-        exit(-argc);
+        GDALExit(-argc);
 
-    for (int i = 0; argv != nullptr && argv[i] != nullptr; i++)
-    {
-        if (EQUAL(argv[i], "--utility_version"))
-        {
-            printf("%s was compiled against GDAL %s and is running against "
-                   "GDAL %s\n",
-                   argv[0], GDAL_RELEASE_NAME, GDALVersionInfo("RELEASE_NAME"));
-            CSLDestroy(argv);
-            return 0;
-        }
-        else if (EQUAL(argv[i], "--help"))
-        {
-            Usage(false);
-        }
-    }
     argv = CSLAddString(argv, "-stdout");
 
     GDALMultiDimInfoOptionsForBinary sOptionsForBinary;
 
-    GDALMultiDimInfoOptions *psOptions =
-        GDALMultiDimInfoOptionsNew(argv + 1, &sOptionsForBinary);
-    if (psOptions == nullptr)
-        Usage(true);
+    std::unique_ptr<GDALMultiDimInfoOptions,
+                    decltype(&GDALMultiDimInfoOptionsFree)>
+        psOptions{GDALMultiDimInfoOptionsNew(argv + 1, &sOptionsForBinary),
+                  GDALMultiDimInfoOptionsFree};
 
-    if (sOptionsForBinary.osFilename.empty())
-        Usage(true, "No datasource specified.");
+    CSLDestroy(argv);
+
+    if (!psOptions)
+        Usage();
 
     GDALDatasetH hDataset =
         GDALOpenEx(sOptionsForBinary.osFilename.c_str(),
@@ -106,21 +93,10 @@ MAIN_START(argc, argv)
     {
         fprintf(stderr, "gdalmdiminfo failed - unable to open '%s'.\n",
                 sOptionsForBinary.osFilename.c_str());
-
-        GDALMultiDimInfoOptionsFree(psOptions);
-
-        CSLDestroy(argv);
-
-        GDALDumpOpenDatasets(stderr);
-
-        GDALDestroyDriverManager();
-
-        CPLDumpSharedList(nullptr);
-        CPLCleanupTLS();
-        exit(1);
+        GDALExit(1);
     }
 
-    char *pszGDALInfoOutput = GDALMultiDimInfo(hDataset, psOptions);
+    char *pszGDALInfoOutput = GDALMultiDimInfo(hDataset, psOptions.get());
 
     if (pszGDALInfoOutput)
         printf("%s", pszGDALInfoOutput);
@@ -129,18 +105,7 @@ MAIN_START(argc, argv)
 
     GDALClose(hDataset);
 
-    GDALMultiDimInfoOptionsFree(psOptions);
-
-    CSLDestroy(argv);
-
-    GDALDumpOpenDatasets(stderr);
-
-    GDALDestroyDriverManager();
-
-    CPLDumpSharedList(nullptr);
-    CPLCleanupTLS();
-
-    exit(0);
+    GDALExit(0);
 }
 
 MAIN_END

--- a/apps/gdalmdiminfo_lib.cpp
+++ b/apps/gdalmdiminfo_lib.cpp
@@ -33,6 +33,7 @@
 #include "cpl_json.h"
 #include "cpl_json_streaming_writer.h"
 #include "gdal_priv.h"
+#include "gdalargumentparser.h"
 #include <limits>
 #include <set>
 
@@ -1060,6 +1061,113 @@ static void WriteToStdout(const char *pszText, void *)
     printf("%s", pszText);
 }
 
+static std::unique_ptr<GDALArgumentParser> GDALMultiDimInfoAppOptionsGetParser(
+    GDALMultiDimInfoOptions *psOptions,
+    GDALMultiDimInfoOptionsForBinary *psOptionsForBinary)
+{
+    auto argParser = std::make_unique<GDALArgumentParser>(
+        "gdalmdiminfo", /* bForBinary=*/psOptionsForBinary != nullptr);
+
+    argParser->add_description(
+        _("Lists various information about a GDAL multidimensional dataset."));
+
+    argParser->add_epilog(_("For more details, consult "
+                            "https://gdal.org/programs/gdalmdiminfo.html"));
+
+    argParser->add_argument("-detailed")
+        .flag()
+        .store_into(psOptions->bDetailed)
+        .help(_("Most verbose output. Report attribute data types and array "
+                "values."));
+
+    argParser->add_inverted_logic_flag(
+        "-nopretty", &psOptions->bPretty,
+        _("Outputs on a single line without any indentation."));
+
+    argParser->add_argument("-array")
+        .metavar("<array_name>")
+        .store_into(psOptions->osArrayName)
+        .help(_("Name of the array, used to restrict the output to the "
+                "specified array."));
+
+    argParser->add_argument("-limit")
+        .metavar("<number>")
+        .scan<'i', int>()
+        .store_into(psOptions->nLimitValuesByDim)
+        .help(_("Number of values in each dimension that is used to limit the "
+                "display of array values."));
+
+    if (psOptionsForBinary)
+    {
+        argParser->add_open_options_argument(
+            psOptionsForBinary->aosOpenOptions);
+
+        argParser->add_argument("-if")
+            .append()
+            .metavar("<format>")
+            .action(
+                [psOptionsForBinary](const std::string &s)
+                {
+                    if (GDALGetDriverByName(s.c_str()) == nullptr)
+                    {
+                        CPLError(CE_Warning, CPLE_AppDefined,
+                                 "%s is not a recognized driver", s.c_str());
+                    }
+                    psOptionsForBinary->aosAllowInputDrivers.AddString(
+                        s.c_str());
+                })
+            .help(
+                _("Format/driver name(s) to try when opening the input file."));
+
+        argParser->add_argument("dataset_name")
+            .metavar("<dataset_name>")
+            .store_into(psOptionsForBinary->osFilename)
+            .help("Input dataset.");
+    }
+
+    argParser->add_argument("-arrayoption")
+        .metavar("<NAME=VALUE>")
+        .append()
+        .action([psOptions](const std::string &s)
+                { psOptions->aosArrayOptions.AddString(s.c_str()); })
+        .help(_("Option passed to GDALGroup::GetMDArrayNames() to filter "
+                "reported arrays."));
+
+    argParser->add_argument("-stats")
+        .flag()
+        .store_into(psOptions->bStats)
+        .help(_("Read and display image statistics."));
+
+    argParser->add_argument("-stdout")
+        .flag()
+        .store_into(psOptions->bStdoutOutput)
+        .help(_("Write output to stdout instead of a JSON file."));
+
+    return argParser;
+}
+
+/************************************************************************/
+/*                  GDALMultiDimInfoAppGetParserUsage()                 */
+/************************************************************************/
+
+std::string GDALMultiDimInfoAppGetParserUsage()
+{
+    try
+    {
+        GDALMultiDimInfoOptions sOptions;
+        GDALMultiDimInfoOptionsForBinary sOptionsForBinary;
+        auto argParser =
+            GDALMultiDimInfoAppOptionsGetParser(&sOptions, &sOptionsForBinary);
+        return argParser->usage();
+    }
+    catch (const std::exception &err)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Unexpected exception: %s",
+                 err.what());
+        return std::string();
+    }
+}
+
 /************************************************************************/
 /*                         GDALMultiDimInfo()                           */
 /************************************************************************/
@@ -1180,88 +1288,35 @@ GDALMultiDimInfoOptions *
 GDALMultiDimInfoOptionsNew(char **papszArgv,
                            GDALMultiDimInfoOptionsForBinary *psOptionsForBinary)
 {
-    bool bGotFilename = false;
-    GDALMultiDimInfoOptions *psOptions = new GDALMultiDimInfoOptions;
+    auto psOptions = std::make_unique<GDALMultiDimInfoOptions>();
 
     /* -------------------------------------------------------------------- */
     /*      Parse arguments.                                                */
     /* -------------------------------------------------------------------- */
-    for (int i = 0; papszArgv != nullptr && papszArgv[i] != nullptr; i++)
+
+    CPLStringList aosArgv;
+
+    if (papszArgv)
     {
-        if (EQUAL(papszArgv[i], "-oo") && papszArgv[i + 1] != nullptr)
-        {
-            i++;
-            if (psOptionsForBinary)
-            {
-                psOptionsForBinary->aosOpenOptions.AddString(papszArgv[i]);
-            }
-        }
-        /* Not documented: used by gdalinfo_bin.cpp only */
-        else if (EQUAL(papszArgv[i], "-stdout"))
-            psOptions->bStdoutOutput = true;
-        else if (EQUAL(papszArgv[i], "-detailed"))
-            psOptions->bDetailed = true;
-        else if (EQUAL(papszArgv[i], "-nopretty"))
-            psOptions->bPretty = false;
-        else if (EQUAL(papszArgv[i], "-array") && papszArgv[i + 1] != nullptr)
-        {
-            ++i;
-            psOptions->osArrayName = papszArgv[i];
-        }
-        else if (EQUAL(papszArgv[i], "-arrayoption") &&
-                 papszArgv[i + 1] != nullptr)
-        {
-            ++i;
-            psOptions->aosArrayOptions.AddString(papszArgv[i]);
-        }
-        else if (EQUAL(papszArgv[i], "-limit") && papszArgv[i + 1] != nullptr)
-        {
-            ++i;
-            psOptions->nLimitValuesByDim = atoi(papszArgv[i]);
-        }
-        else if (EQUAL(papszArgv[i], "-stats"))
-        {
-            psOptions->bStats = true;
-        }
-
-        else if (EQUAL(papszArgv[i], "-if") && papszArgv[i + 1] != nullptr)
-        {
-            i++;
-            if (psOptionsForBinary)
-            {
-                if (GDALGetDriverByName(papszArgv[i]) == nullptr)
-                {
-                    CPLError(CE_Warning, CPLE_AppDefined,
-                             "%s is not a recognized driver", papszArgv[i]);
-                }
-                psOptionsForBinary->aosAllowInputDrivers.AddString(
-                    papszArgv[i]);
-            }
-        }
-
-        else if (papszArgv[i][0] == '-')
-        {
-            CPLError(CE_Failure, CPLE_NotSupported, "Unknown option name '%s'",
-                     papszArgv[i]);
-            GDALMultiDimInfoOptionsFree(psOptions);
-            return nullptr;
-        }
-        else if (!bGotFilename)
-        {
-            bGotFilename = true;
-            if (psOptionsForBinary)
-                psOptionsForBinary->osFilename = papszArgv[i];
-        }
-        else
-        {
-            CPLError(CE_Failure, CPLE_NotSupported,
-                     "Too many command options '%s'", papszArgv[i]);
-            GDALMultiDimInfoOptionsFree(psOptions);
-            return nullptr;
-        }
+        const int nArgc = CSLCount(papszArgv);
+        for (int i = 0; i < nArgc; i++)
+            aosArgv.AddString(papszArgv[i]);
     }
 
-    return psOptions;
+    try
+    {
+        auto argParser = GDALMultiDimInfoAppOptionsGetParser(
+            psOptions.get(), psOptionsForBinary);
+        argParser->parse_args_without_binary_name(aosArgv);
+    }
+    catch (const std::exception &err)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Unexpected exception: %s",
+                 err.what());
+        return nullptr;
+    }
+
+    return psOptions.release();
 }
 
 /************************************************************************/


### PR DESCRIPTION
```
gdalmdiminfo --long-usage
Export manually or use this script as a wrapper for commands!!!!
Usage: gdalmdiminfo [--help] [--long-usage] [--help-general]
                        [-detailed] [-nopretty] [-array <array_name>] [-limit <number>] [-oo <NAME>=<VALUE>]...
                        [-if <format>]... [-arrayoption <NAME=VALUE>]... [-stats] [-stdout]
                        <dataset_name>

Lists various information about a GDAL multidimensional dataset.

Positional arguments:
  <dataset_name>             Input dataset. 

Optional arguments:
  -h, --help                 Shows short help message and exits. 
  --long-usage               Shows long help message and exits. 
  --help-general             Report detailed help on general options. 
  -detailed                  Most verbose output. Report attribute data types and array values. 
  -nopretty                  Outputs on a single line without any indentation. 
  -array <array_name>        Name of the array, used to restrict the output to the specified array. 
  -limit <number>            Number of values in each dimension that is used to limit the display of array values. 
  -oo <NAME>=<VALUE>         Open option(s) for input dataset. [may be repeated]
  -if <format>               Format/driver name(s) to try when opening the input file. [may be repeated]
  -arrayoption <NAME=VALUE>  Option passed to GDALGroup::GetMDArrayNames() to filter reported arrays. [may be repeated]
  -stats                     Read and display image statistics. 
  -stdout                    Write output to stdout instead of a JSON file. 

For more details, consult https://gdal.org/programs/gdalmdiminfo.html
```