### PR TITLE
FlatGeoBuf: more explicit error message in case of feature geometry type != layer geometry type

### DIFF
--- a/autotest/ogr/ogr_flatgeobuf.py
+++ b/autotest/ogr/ogr_flatgeobuf.py
@@ -1401,3 +1401,21 @@ def test_ogr_flatgeobuf_write_arrow(tmp_vsimem):
 
 """
     )
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_ogr_flatgeobuf_write_mismatch_geom_type(tmp_vsimem):
+
+    filename = str(tmp_vsimem / "temp.fgb")
+    ds = ogr.GetDriverByName("FlatGeoBuf").CreateDataSource(filename)
+    lyr = ds.CreateLayer("src_lyr", geom_type=ogr.wkbPoint)
+    f = ogr.Feature(lyr.GetLayerDefn())
+    f.SetGeometry(ogr.CreateGeometryFromWkt("LINESTRING (1 2,3 4)"))
+    with pytest.raises(
+        Exception,
+        match="ICreateFeature: Mismatched geometry type. Feature geometry type is Line String, expected layer geometry type is Point",
+    ):
+        lyr.CreateFeature(f)

--- a/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
+++ b/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
@@ -2285,7 +2285,11 @@ OGRErr OGRFlatGeobufLayer::ICreateFeature(OGRFeature *poNewFeature)
         ogrGeometry->getGeometryType() != m_eGType)
     {
         CPLError(CE_Failure, CPLE_AppDefined,
-                 "ICreateFeature: Mismatched geometry type");
+                 "ICreateFeature: Mismatched geometry type. "
+                 "Feature geometry type is %s, "
+                 "expected layer geometry type is %s",
+                 OGRGeometryTypeToName(ogrGeometry->getGeometryType()),
+                 OGRGeometryTypeToName(m_eGType));
         return OGRERR_FAILURE;
     }
 


### PR DESCRIPTION
Fixes #9893
