### PR TITLE
[Backport release/3.9] GML: fix memory leak due do xlink:href substitution in a non-nominal case.

### DIFF
--- a/autotest/ogr/data/gml/link_to_immediate_child.gml
+++ b/autotest/ogr/data/gml/link_to_immediate_child.gml
@@ -1,0 +1,11 @@
+<Maastotiedot xmlns:gml="http://www.opengis.net/gml" xmlns:xlink="http://www.w3.org/1999/xlink">
+<a>
+    <A>
+        <gml:Point>
+            <foo xlink:href="#t">
+                <bar gml:id="t"/>
+            </foo>
+        </gml:Point>
+    </A>
+</a>
+</Maastotiedot>

--- a/autotest/ogr/ogr_gml.py
+++ b/autotest/ogr/ogr_gml.py
@@ -4315,3 +4315,15 @@ def test_ogr_gml_geom_coord_precision(tmp_vsimem):
     prec = geom_fld.GetCoordinatePrecision()
     assert prec.GetXYResolution() == 1e-5
     assert prec.GetZResolution() == 1e-3
+
+
+###############################################################################
+# Test weird scenario of https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=68850
+
+
+def test_ogr_gml_geom_link_to_immediate_child():
+
+    ds = gdal.OpenEx(
+        "data/gml/link_to_immediate_child.gml", open_options=["WRITE_GFS=NO"]
+    )
+    assert ds

--- a/ogr/ogrsf_frmts/gml/gmlhandler.cpp
+++ b/ogr/ogrsf_frmts/gml/gmlhandler.cpp
@@ -1685,7 +1685,20 @@ OGRErr GMLHandler::endElementGeometry()
                 // m_oMapElementToSubstitute at the end of the current feature.
                 while (psLastChild->psNext)
                     psLastChild = psLastChild->psNext;
-                psLastChild->psNext = CPLCloneXMLTree(psThisNode);
+                if (psLastChild == psThisNode)
+                {
+                    /* Can happen in situations like:
+                     <foo xlink:href="#X">
+                        <bar gml:id="X"/>
+                     </foo>
+                     Do not attempt substitution as that would cause a memory
+                     leak.
+                    */
+                }
+                else
+                {
+                    psLastChild->psNext = CPLCloneXMLTree(psThisNode);
+                }
                 psThisNode->psNext = psAfter;
             }
         }


### PR DESCRIPTION
Backport #9888
 **Authored by:** @rouault