### PR TITLE
[Backport release/3.9] MITAB .tab: AlterFieldDefn(): fix data corruption when altering (for …

### DIFF
--- a/ogr/ogrsf_frmts/mitab/mitab_imapinfofile.cpp
+++ b/ogr/ogrsf_frmts/mitab/mitab_imapinfofile.cpp
@@ -441,7 +441,8 @@ int IMapInfoFile::GetTABType(const OGRFieldDefn *poField,
 {
     TABFieldType eTABType;
     int nWidth = poField->GetWidth();
-    int nPrecision = poField->GetPrecision();
+    int nPrecision =
+        poField->GetType() == OFTReal ? poField->GetPrecision() : 0;
 
     if (poField->GetType() == OFTInteger)
     {
@@ -519,9 +520,12 @@ int IMapInfoFile::GetTABType(const OGRFieldDefn *poField,
         return -1;
     }
 
-    *peTABType = eTABType;
-    *pnWidth = nWidth;
-    *pnPrecision = nPrecision;
+    if (peTABType)
+        *peTABType = eTABType;
+    if (pnWidth)
+        *pnWidth = nWidth;
+    if (pnPrecision)
+        *pnPrecision = nPrecision;
 
     return 0;
 }

--- a/ogr/ogrsf_frmts/mitab/mitab_priv.h
+++ b/ogr/ogrsf_frmts/mitab/mitab_priv.h
@@ -231,7 +231,8 @@ typedef struct TABDATFieldDef_t
 {
     char szName[11];
     char cType;
-    GByte byLength;
+    GByte
+        byLength; /* caution: for a native .dat file, this is a binary width for most types */
     GByte byDecimals;
 
     TABFieldType eTABType;
@@ -1876,7 +1877,8 @@ class TABDATFile
 
     int DeleteField(int iField);
     int ReorderFields(int *panMap);
-    int AlterFieldDefn(int iField, OGRFieldDefn *poNewFieldDefn, int nFlags);
+    int AlterFieldDefn(int iField, const OGRFieldDefn *poSrcFieldDefn,
+                       OGRFieldDefn *poNewFieldDefn, int nFlags);
 
     int SyncToDisk();
 


### PR DESCRIPTION
Backport #9879
 **Authored by:** @rouault