### PR TITLE
Update osmconf.ini clarifying direction

### DIFF
--- a/ogr/ogrsf_frmts/osm/data/osmconf.ini
+++ b/ogr/ogrsf_frmts/osm/data/osmconf.ini
@@ -1,5 +1,5 @@
 #
-# Configuration file for exporting OSM data, importing it into OGR
+# Configuration file for importing OSM data into OGR
 #
 
 # put here the name of keys, or key=value, for ways that are assumed to be polygons if they are closed

--- a/ogr/ogrsf_frmts/osm/data/osmconf.ini
+++ b/ogr/ogrsf_frmts/osm/data/osmconf.ini
@@ -1,5 +1,5 @@
 #
-# Configuration file for OSM import
+# Configuration file for exporting OSM data, importing it into OGR
 #
 
 # put here the name of keys, or key=value, for ways that are assumed to be polygons if they are closed


### PR DESCRIPTION
In https://gdal.org/drivers/vector/osm.html#configuration we read
> The customization is essentially which OSM attributes and keys should be translated into OGR layer fields.

I therefore conclude the direction of the import is actually into OGR, and thus make it clear in the top of the file.