### PR TITLE
MiraMonVector: Fixing recently introduced error in linestring metadata file

### DIFF
--- a/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
+++ b/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
@@ -5877,9 +5877,9 @@ static int MMWriteVectorMetadataFile(struct MiraMonVectLayerInfo *hMiraMonLayer,
             memcpy(&hMMMD.hBB, &hMiraMonLayer->MMPolygon.TopArcHeader.hBB,
                    sizeof(hMMMD.hBB));
             hMMMD.pLayerDB = nullptr;
+            hMMMD.aArcFile = strdup_function(
+                get_filename_function(hMiraMonLayer->MMPolygon.pszLayerName));
         }
-        hMMMD.aArcFile = strdup_function(
-            get_filename_function(hMiraMonLayer->MMPolygon.pszLayerName));
         nResult = MMWriteMetadataFile(&hMMMD);
         free_function(hMMMD.aArcFile);
         return nResult;


### PR DESCRIPTION
## What does this PR do?
Fixes an error recently introduced when a .arc is created with no .pol associated: a Ciclat1="" is wrongly created in A.rel metadata file. Usually Ciclat1 is filled with the polygon name that has the coordinates in this arc file.

## What are related issues/pull requests?
The error was introduced in https://github.com/OSGeo/gdal/pull/9885

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] All CI builds and checks have passed

