### PR TITLE
[Backport release/3.9] ogrinfo: fix error message when not specifying a filename

### DIFF
--- a/apps/ogrinfo_lib.cpp
+++ b/apps/ogrinfo_lib.cpp
@@ -2427,15 +2427,16 @@ static std::unique_ptr<GDALArgumentParser> GDALVectorInfoOptionsGetParser(
             })
         .help(_("Format/driver name(s) to try when opening the input file."));
 
-    argParser->add_argument("filename")
-        .nargs(argparse::nargs_pattern::optional)
-        .action(
-            [psOptionsForBinary](const std::string &s)
-            {
-                if (psOptionsForBinary)
-                    psOptionsForBinary->osFilename = s;
-            })
-        .help(_("The data source to open."));
+    auto &argFilename = argParser->add_argument("filename")
+                            .action(
+                                [psOptionsForBinary](const std::string &s)
+                                {
+                                    if (psOptionsForBinary)
+                                        psOptionsForBinary->osFilename = s;
+                                })
+                            .help(_("The data source to open."));
+    if (!psOptionsForBinary)
+        argFilename.nargs(argparse::nargs_pattern::optional);
 
     argParser->add_argument("layer")
         .remaining()

--- a/autotest/utilities/test_ogrinfo.py
+++ b/autotest/utilities/test_ogrinfo.py
@@ -64,6 +64,16 @@ def test_ogrinfo_1(ogrinfo_path):
 
 
 ###############################################################################
+# Missing filename
+
+
+def test_ogrinfo_missing_filename(ogrinfo_path):
+
+    (_, err) = gdaltest.runexternal_out_and_err(ogrinfo_path)
+    assert "filename: 1 argument(s) expected. 0 provided" in err
+
+
+###############################################################################
 # Test -ro option
 
 


### PR DESCRIPTION
Backport #9925
 **Authored by:** @rouault