### PR TITLE
flake8 config does not support inline comments

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,21 +1,37 @@
 [flake8]
 max_line_length = 88
 ignore =
-    C408 # Unnecessary dict/list/tuple call - rewrite as a literal
-    E203 # whitespace before ':' - doesn't work well with black
-    E225 # missing whitespace around operator - let black worry about that
-    E262 # inline comment should start with '# '
-    E265 # block comment should start with '# '
-    E266 # too many leading '#' for block comment
-    E302 # expected 2 blank lines, found 1
-    E402 # module level import not at top of file
-    E501 # line too long - let black handle that
-    E711 # comparison to None should be
-    E712 # comparison to False/True should be
-    E741 # ambiguous variable name
-    F405 # may be undefined, or defined from star imports
-    W291 # trailing
-    W503 # line break occurred before a binary operator - let black worry about that
-    W504 # line break occurred adter a binary operator - let black worry about that
+    # Unnecessary dict/list/tuple call - rewrite as a literal
+    C408 
+    # whitespace before ':' - doesn't work well with black
+    E203 
+    # missing whitespace around operator - let black worry about that
+    E225 
+    # inline comment should start with '# '
+    E262 
+    # block comment should start with '# '
+    E265 
+    # too many leading '#' for block comment
+    E266 
+    # expected 2 blank lines, found 1
+    E302 
+    # module level import not at top of file
+    E402 
+    # line too long - let black handle that
+    E501 
+    # comparison to None should be
+    E711 
+    # comparison to False/True should be
+    E712 
+    # ambiguous variable name
+    E741 
+    # may be undefined, or defined from star imports
+    F405 
+    # trailing
+    W291 
+    # line break occurred before a binary operator - let black worry about that
+    W503 
+    # line break occurred adter a binary operator - let black worry about that
+    W504 
 per-file-ignores =
     .cmake-format.py:F821


### PR DESCRIPTION
 flake8 config does not support inline comments
 - although before flake v6 they do *appear* to work.

https://flake8.pycqa.org/en/latest/user/configuration.html

> Following the recommended settings for [Python’s configparser](https://docs.python.org/3/library/configparser.html#customizing-parser-behaviour), Flake8 does not support inline comments for any of the keys. So while this is fine:
> 
> [flake8]
> per-file-ignores =
>     # imported but unused
>     __init__.py: F401
> 
> this is not:
> 
> [flake8]
> per-file-ignores =
>     __init__.py: F401 # imported but unused


## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Ubuntu Noble 24-04
* Python 3.12
* pyflakes3 3.2.0-1 (Ubuntu 23-10 has 2.5.0-1)
* flake8 7.0.0-1 (Ubuntu 23-10 has 5.0.4-4)
