### PR TITLE
MiraMonVector: Fixing the way that Z are written in MiraMon layers

### DIFF
--- a/autotest/ogr/ogr_miramon_vector.py
+++ b/autotest/ogr/ogr_miramon_vector.py
@@ -1173,7 +1173,16 @@ def test_ogr_miramon_write_basic_linestring(tmp_path):
     ds = None
 
 
-def test_ogr_miramon_write_basic_linestringZ(tmp_path):
+# There are to ways of writing/reading repeated Z's in a linestring file.
+# So let's test both ways (different Z's in each vertice or the same Z for all of them)
+@pytest.mark.parametrize(
+    "LinestringZ",
+    [
+        "LINESTRING Z (0 0 4,0 1 3,1 1 2)",
+        "LINESTRING Z (0 0 4,0 1 4,1 1 4)",
+    ],
+)
+def test_ogr_miramon_write_basic_linestringZ(tmp_path, LinestringZ):
 
     filename = str(tmp_path / "DataSetLINESTRING")
     ds = ogr.GetDriverByName("MiramonVector").CreateDataSource(filename)
@@ -1184,7 +1193,7 @@ def test_ogr_miramon_write_basic_linestringZ(tmp_path):
     f = ogr.Feature(lyr.GetLayerDefn())
     assign_common_attributes(f)
 
-    f.SetGeometry(ogr.CreateGeometryFromWkt("LINESTRING Z (0 0 4,0 1 3,1 1 2)"))
+    f.SetGeometry(ogr.CreateGeometryFromWkt(LinestringZ))
     lyr.CreateFeature(f)
     f = None
     ds = None
@@ -1198,7 +1207,7 @@ def test_ogr_miramon_write_basic_linestringZ(tmp_path):
     assert f["NODE_INI"] == [0, 0]
     assert f["NODE_FI"] == [1, 1]
     check_common_attributes(f)
-    assert f.GetGeometryRef().ExportToIsoWkt() == "LINESTRING Z (0 0 4,0 1 3,1 1 2)"
+    assert f.GetGeometryRef().ExportToIsoWkt() == LinestringZ
     ds = None
 
 

--- a/ogr/ogrsf_frmts/miramon/mm_gdal_driver_structs.h
+++ b/ogr/ogrsf_frmts/miramon/mm_gdal_driver_structs.h
@@ -99,14 +99,16 @@ CPL_C_START  // Necessary for compiling in GDAL project
 #define MM_LayerType_Node 7     // Layer of Nodes (internal)
 #define MM_LayerType_Raster 8   // Layer of Raster Type
 
-#define MM_FIRST_NUMBER_OF_POINTS 10000
-#define MM_INCR_NUMBER_OF_POINTS 1000
-#define MM_FIRST_NUMBER_OF_ARCS 10000
-#define MM_INCR_NUMBER_OF_ARCS 1000
-#define MM_FIRST_NUMBER_OF_NODES 20000  // 2*MM_FIRST_NUMBER_OF_ARCS
-#define MM_INCR_NUMBER_OF_NODES 2000
-#define MM_FIRST_NUMBER_OF_POLYGONS 10000
-#define MM_INCR_NUMBER_OF_POLYGONS 1000
+// FIRST are used for a first allocation and
+// INCR for needed memory increase
+#define MM_FIRST_NUMBER_OF_POINTS 100000    // 3.5 Mb
+#define MM_INCR_NUMBER_OF_POINTS 100000     // 3.5 Mb
+#define MM_FIRST_NUMBER_OF_ARCS 100000      // 5.3 Mb
+#define MM_INCR_NUMBER_OF_ARCS 100000       // 5.3 Mb
+#define MM_FIRST_NUMBER_OF_NODES 200000     // 2*MM_FIRST_NUMBER_OF_ARCS 1.5 Mb
+#define MM_INCR_NUMBER_OF_NODES 200000      // 1.5 Mb
+#define MM_FIRST_NUMBER_OF_POLYGONS 100000  // 6 Mb
+#define MM_INCR_NUMBER_OF_POLYGONS 100000   // 6 Mb
 #define MM_FIRST_NUMBER_OF_VERTICES 10000
 #define MM_INCR_NUMBER_OF_VERTICES 1000
 
@@ -653,6 +655,7 @@ struct MiraMonFeature
     // Number of used elements in *pZCoord
     MM_N_VERTICES_TYPE nNumpZCoord;
     MM_COORD_TYPE *pZCoord;
+    MM_BOOLEAN bAllZHaveSameValue;
 
     // Records of the feature
     MM_EXT_DBF_N_MULTIPLE_RECORDS nNumMRecords;

--- a/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
+++ b/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
@@ -4272,7 +4272,7 @@ static int MMCreateFeaturePolOrArc(struct MiraMonVectLayerInfo *hMiraMonLayer,
                 pLastArcHeader =
                     pMMArc->pArcHeader + pArcTopHeader->nElemCount - 1;
 
-                if (hMMFeature->bAllZHaveSameValue)
+                if (pZDesc[pArcTopHeader->nElemCount - 1].nZCount < 0)
                 {
                     pZDesc[pArcTopHeader->nElemCount].nOffsetZ =
                         pZDesc[pArcTopHeader->nElemCount - 1].nOffsetZ +

--- a/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
+++ b/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
@@ -89,8 +89,9 @@ void MMUpdateBoundingBoxXY(struct MMBoundingBox *dfBB,
 void MMUpdateBoundingBox(struct MMBoundingBox *dfBBToBeAct,
                          struct MMBoundingBox *dfBBWithData);
 int MMCheckVersionFor3DOffset(struct MiraMonVectLayerInfo *hMiraMonLayer,
-                              MM_FILE_OFFSET nOffset,
-                              MM_INTERNAL_FID nElemCount);
+                              MM_INTERNAL_FID nElemCount,
+                              MM_FILE_OFFSET nOffsetAL,
+                              MM_FILE_OFFSET nZLOffset);
 int MMCheckVersionOffset(struct MiraMonVectLayerInfo *hMiraMonLayer,
                          MM_FILE_OFFSET OffsetToCheck);
 int MMCheckVersionForFID(struct MiraMonVectLayerInfo *hMiraMonLayer,
@@ -650,6 +651,15 @@ MMWriteZDescriptionHeaders(struct MiraMonVectLayerInfo *hMiraMonLayer,
                     free_function(pBuffer);
                 return 1;
             }
+        }
+
+        // Overflow?
+        if (hMiraMonLayer->LayerVersion == MM_32BITS_VERSION &&
+            (pZDescription + nIndex)->nOffsetZ >
+                MAXIMUM_OFFSET_IN_2GB_VECTORS - nOffsetDiff)
+        {
+            MMCPLError(CE_Failure, CPLE_OpenFailed, "Offset Overflow in V1.1");
+            return 1;
         }
 
         if (MMAppendIntegerDependingOnVersion(
@@ -3921,16 +3931,43 @@ static int MMCreateFeaturePolOrArc(struct MiraMonVectLayerInfo *hMiraMonLayer,
             // Where 3D part is going to start
             if (hMiraMonLayer->TopHeader.bIs3d)
             {
-                nArcOffset +=
-                    hMMFeature->pNCoordRing[nIPart] * pMMArc->nALElementSize;
-                if (MMCheckVersionFor3DOffset(
-                        hMiraMonLayer, nArcOffset,
-                        hMiraMonLayer->TopHeader.nElemCount +
-                            hMMFeature->nNRings))
+                if (nArcElemCount == 0)
                 {
-                    MMCPLDebug("MiraMon",
-                               "Error in MMCheckVersionFor3DOffset()");
-                    return MM_STOP_WRITING_FEATURES;
+                    if (MMCheckVersionFor3DOffset(hMiraMonLayer,
+                                                  nArcElemCount + 1, 0, 0))
+                        return MM_STOP_WRITING_FEATURES;
+                }
+                else
+                {
+                    pZDesc = pMMArc->pZSection.pZDescription;
+                    if (!pZDesc)
+                    {
+                        MMCPLError(
+                            CE_Failure, CPLE_ObjectNull,
+                            "Error: pZDescription should not be nullptr");
+                        return MM_STOP_WRITING_FEATURES;
+                    }
+
+                    if (pZDesc[nArcElemCount - 1].nZCount < 0)
+                    {
+                        // One altitude was written on last element
+                        if (MMCheckVersionFor3DOffset(
+                                hMiraMonLayer, nArcElemCount + 1, nArcOffset,
+                                pZDesc[nArcElemCount - 1].nOffsetZ +
+                                    sizeof(*pZ)))
+                            return MM_STOP_WRITING_FEATURES;
+                    }
+                    else
+                    {
+                        // One for each vertice altitude was written on last element
+                        if (MMCheckVersionFor3DOffset(
+                                hMiraMonLayer, nArcElemCount + 1, nArcOffset,
+                                pZDesc[nArcElemCount - 1].nOffsetZ +
+                                    sizeof(*pZ) * (pMMArc->pArcHeader +
+                                                   (nArcElemCount - 1))
+                                                      ->nElemCount))
+                            return MM_STOP_WRITING_FEATURES;
+                    }
                 }
             }
         }
@@ -4187,6 +4224,16 @@ static int MMCreateFeaturePolOrArc(struct MiraMonVectLayerInfo *hMiraMonLayer,
                 STATISTICAL_UNDEF_VALUE;
             pZDesc[pArcTopHeader->nElemCount].dfBBmaxz =
                 -STATISTICAL_UNDEF_VALUE;
+
+            // Number of arc altitudes. If the number of altitudes is
+            // positive this indicates the number of altitudes for
+            // each vertex of the arc, and all the altitudes of the
+            // vertex 0 are written first, then those of the vertex 1,
+            // etc. If the number of altitudes is negative this
+            // indicates the number of arc altitudes, understanding
+            // that all the vertices have the same altitude (it is
+            // the case of a contour line, for example).
+
             for (nIVertice = 0; nIVertice < pCurrentArcHeader->nElemCount;
                  nIVertice++, pZ++)
             {
@@ -4202,17 +4249,41 @@ static int MMCreateFeaturePolOrArc(struct MiraMonVectLayerInfo *hMiraMonLayer,
                     pZDesc[pArcTopHeader->nElemCount].dfBBminz = *pZ;
                 if (pZDesc[pArcTopHeader->nElemCount].dfBBmaxz < *pZ)
                     pZDesc[pArcTopHeader->nElemCount].dfBBmaxz = *pZ;
+
+                // Only one altitude (the same for all vertices) is written
+                if (hMMFeature->bAllZHaveSameValue)
+                    break;
             }
-            pZDesc[pArcTopHeader->nElemCount].nZCount = 1;
+            if (hMMFeature->bAllZHaveSameValue)
+            {
+                // Same altitude for all vertices
+                pZDesc[pArcTopHeader->nElemCount].nZCount = -1;
+            }
+            else
+            {
+                // One diferent altitude for each vertice
+                pZDesc[pArcTopHeader->nElemCount].nZCount = 1;
+            }
+
             if (pArcTopHeader->nElemCount == 0)
                 pZDesc[pArcTopHeader->nElemCount].nOffsetZ = 0;
             else
             {
                 pLastArcHeader =
                     pMMArc->pArcHeader + pArcTopHeader->nElemCount - 1;
-                pZDesc[pArcTopHeader->nElemCount].nOffsetZ =
-                    pZDesc[pArcTopHeader->nElemCount - 1].nOffsetZ +
-                    sizeof(*pZ) * (pLastArcHeader->nElemCount);
+
+                if (hMMFeature->bAllZHaveSameValue)
+                {
+                    pZDesc[pArcTopHeader->nElemCount].nOffsetZ =
+                        pZDesc[pArcTopHeader->nElemCount - 1].nOffsetZ +
+                        sizeof(*pZ);
+                }
+                else
+                {
+                    pZDesc[pArcTopHeader->nElemCount].nOffsetZ =
+                        pZDesc[pArcTopHeader->nElemCount - 1].nOffsetZ +
+                        sizeof(*pZ) * (pLastArcHeader->nElemCount);
+                }
             }
         }
 
@@ -4391,7 +4462,8 @@ static int MMCreateFeaturePoint(struct MiraMonVectLayerInfo *hMiraMonLayer,
         {
             if (nElemCount == 0)
             {
-                if (MMCheckVersionFor3DOffset(hMiraMonLayer, 0, nElemCount + 1))
+                if (MMCheckVersionFor3DOffset(hMiraMonLayer, (nElemCount + 1),
+                                              0, 0))
                     return MM_STOP_WRITING_FEATURES;
             }
             else
@@ -4403,10 +4475,10 @@ static int MMCreateFeaturePoint(struct MiraMonVectLayerInfo *hMiraMonLayer,
                                "Error: pZDescription should not be nullptr");
                     return MM_STOP_WRITING_FEATURES;
                 }
+
                 if (MMCheckVersionFor3DOffset(
-                        hMiraMonLayer,
-                        pZDescription[nElemCount - 1].nOffsetZ + sizeof(*pZ),
-                        nElemCount + 1))
+                        hMiraMonLayer, nElemCount + 1, 0,
+                        pZDescription[nElemCount - 1].nOffsetZ + sizeof(*pZ)))
                     return MM_STOP_WRITING_FEATURES;
             }
         }
@@ -4436,7 +4508,9 @@ static int MMCreateFeaturePoint(struct MiraMonVectLayerInfo *hMiraMonLayer,
 
             pZDescription[nElemCount].dfBBminz = *pZ;
             pZDescription[nElemCount].dfBBmaxz = *pZ;
-            pZDescription[nElemCount].nZCount = 1;
+
+            // Specification ask for a negative number.
+            pZDescription[nElemCount].nZCount = -1;
             if (nElemCount == 0)
                 pZDescription[nElemCount].nOffsetZ = 0;
             else
@@ -4557,8 +4631,9 @@ int MMCheckVersionOffset(struct MiraMonVectLayerInfo *hMiraMonLayer,
 // Checks whether a given offset in 3D section exceeds the maximum allowed
 // index for 2 GB vectors in a specific MiraMon layer.
 int MMCheckVersionFor3DOffset(struct MiraMonVectLayerInfo *hMiraMonLayer,
-                              MM_FILE_OFFSET nOffset,
-                              MM_INTERNAL_FID nElemCount)
+                              MM_INTERNAL_FID nElemCount,
+                              MM_FILE_OFFSET nOffsetAL,
+                              MM_FILE_OFFSET nZLOffset)
 {
     MM_FILE_OFFSET LastOffset;
 
@@ -4570,10 +4645,17 @@ int MMCheckVersionFor3DOffset(struct MiraMonVectLayerInfo *hMiraMonLayer,
         return 0;
 
     // User decided that if necessary, output version can be 2.0
-    LastOffset = nOffset + MM_HEADER_SIZE_32_BITS + nElemCount * MM_SIZE_OF_TL;
+    if (hMiraMonLayer->bIsPoint)
+        LastOffset = MM_HEADER_SIZE_32_BITS + nElemCount * MM_SIZE_OF_TL;
+    else  // Arc case
+    {
+        LastOffset = MM_HEADER_SIZE_32_BITS +
+                     nElemCount * MM_SIZE_OF_AH_32BITS + +nOffsetAL;
+    }
 
     LastOffset += MM_SIZE_OF_ZH;
     LastOffset += nElemCount * MM_SIZE_OF_ZD_32_BITS;
+    LastOffset += nZLOffset;
 
     if (LastOffset < MAXIMUM_OFFSET_IN_2GB_VECTORS)
         return 0;


### PR DESCRIPTION
## What does this PR do?
During the translation from a 30 Gigabyte GeoPackage, it was detected that the MiraMonVector driver did not properly detect when the offset for heights exceeded the maximum possible value in a 4-byte variable (in version 1.1). This has been fixed, and an extra check has been added at the end of the translation to ensure that no offset overflows occur.

Once this was corrected, it was also noticed that a key feature for saving space with heights was not being properly used: the MiraMon format allows writing a height only once if it is the same for all vertices of a linestring. According to the specifications, if the number of heights for the linestring is negative, then the height applies to each vertex of the linestring. While this was not a bug, it will represent significant space savings in some 3D files with linestrings that have many vertices. This affected only the writing of linestrings, as the reading was done correctly.

For points, it was detected that the number of Z-values for each point (1) was being written as a positive number when the specifications dictate that it should be negative. This affected only the writing of linestrings, as the reading was done correctly.

Additionally, two minor improvements have been made:

- Informs the user that the layer obtained when the version 1.1 limit is reached is valid and contains N elements (not the total of them). This, at least, allows the user to take a look at the obtained layer.
- Increases some defines to reduce the number of reallocs needed for large layers. The increase does not affect small layers as the increases are only a few megabytes.

A backport to 3.9 would be wonderful.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x]  Add a test for this fix
 - [x] All CI builds and checks have passed except the specified below
 - [ ] Confirm that Failed Travis is not this PR fault.
 - [ ] Confirm that Failed autotest_gdrivers is not this PR fault.
