### PR TITLE
Update ogrinfo.rst with -q, tidying up example

### DIFF
--- a/doc/source/programs/ogrinfo.rst
+++ b/doc/source/programs/ogrinfo.rst
@@ -498,66 +498,23 @@ Example of retrieving information on a file in JSON format without showing detai
     }
 
 
-Example of using an attribute query to restrict the output of the features
-in a layer:
+Example of using -q and an attribute query, to restrict the output to
+certain features in a layer:
 
-.. code-block::
+.. code-block:: bash
 
-    ogrinfo -ro \
-        -where 'GLOBAL_LINK_ID=185878' \
-        wrk/SHETLAND_ISLANDS.NTF BL2000_LINK
+    ogrinfo -q -ro \
+      -where 'GLOBAL_LINK_ID=185878' \
+      wrk/SHETLAND_ISLANDS.NTF BL2000_LINK
 
-    # INFO: Open of `wrk/SHETLAND_ISLANDS.NTF'
-    # using driver `UK .NTF' successful.
-    #
-    # Layer name: BL2000_LINK
-    # Geometry: Line String
-    # Feature Count: 1
-    # Extent: (419794.100000, 1069031.000000) - (419927.900000, 1069153.500000)
-    # Layer SRS WKT:
-    # PROJCS["OSGB 1936 / British National Grid",
-    # GEOGCS["OSGB 1936",
-    # DATUM["OSGB_1936",
-    # SPHEROID["Airy 1830",6377563.396,299.3249646]],
-    # PRIMEM["Greenwich",0],
-    # UNIT["degree",0.0174532925199433]],
-    # PROJECTION["Transverse_Mercator"],
-    # PARAMETER["latitude_of_origin",49],
-    # PARAMETER["central_meridian",-2],
-    # PARAMETER["scale_factor",0.999601272],
-    # PARAMETER["false_easting",400000],
-    # PARAMETER["false_northing",-100000],
-    # UNIT["metre",1]]
-    # LINE_ID: Integer (6.0)
-    # GEOM_ID: Integer (6.0)
-    # FEAT_CODE: String (4.0)
-    # GLOBAL_LINK_ID: Integer (10.0)
-    # TILE_REF: String (10.0)
-    # OGRFeature(BL2000_LINK):2
-    # LINE_ID (Integer) = 2
-    # GEOM_ID (Integer) = 2
-    # FEAT_CODE (String) = (null)
-    # GLOBAL_LINK_ID (Integer) = 185878
-    # TILE_REF (String) = SHETLAND I
-    # LINESTRING (419832.100 1069046.300,419820.100 1069043.800,419808.300
-    # 1069048.800,419805.100 1069046.000,419805.000 1069040.600,419809.400
-    # 1069037.400,419827.400 1069035.600,419842 1069031,419859.000
-    # 1069032.800,419879.500 1069049.500,419886.700 1069061.400,419890.100
-    # 1069070.500,419890.900 1069081.800,419896.500 1069086.800,419898.400
-    # 1069092.900,419896.700 1069094.800,419892.500 1069094.300,419878.100
-    # 1069085.600,419875.400 1069087.300,419875.100 1069091.100,419872.200
-    # 1069094.600,419890.400 1069106.400,419907.600 1069112.800,419924.600
-    # 1069133.800,419927.900 1069146.300,419927.600 1069152.400,419922.600
-    # 1069153.500,419917.100 1069153.500,419911.500 1069153.000,419908.700
-    # 1069152.500,419903.400 1069150.800,419898.800 1069149.400,419894.800
-    # 1069149.300,419890.700 1069149.400,419890.600 1069149.400,419880.800
-    # 1069149.800,419876.900 1069148.900,419873.100 1069147.500,419870.200
-    # 1069146.400,419862.100 1069143.000,419860 1069142,419854.900
-    # 1069138.600,419850 1069135,419848.800 1069134.100,419843
-    # 1069130,419836.200 1069127.600,419824.600 1069123.800,419820.200
-    # 1069126.900,419815.500 1069126.900,419808.200 1069116.500,419798.700
-    # 1069117.600,419794.100 1069115.100,419796.300 1069109.100,419801.800
-    # 1069106.800,419805.000  1069107.300)
+    Layer name: BL2000_LINK
+    OGRFeature(BL2000_LINK):2
+      LINE_ID (Integer) = 2
+      GEOM_ID (Integer) = 2
+      FEAT_CODE (String) = (null)
+      GLOBAL_LINK_ID (Integer) = 185878
+      TILE_REF (String) = SHETLAND I
+      LINESTRING (419832.100 1069046.300,419820.100 1069043.800,...
 
 Example of updating a value of an attribute in a shapefile with SQL by using the SQLite dialect:
 


### PR DESCRIPTION
Trim example to just the essentials. Not repeating coordinate systems for yet even another time on the page. Also we zap the '#' not present in today's ogrinfo output.