### PR TITLE
Update ogrinfo.rst chopping wild 1200 character long line

### DIFF
--- a/doc/source/programs/ogrinfo.rst
+++ b/doc/source/programs/ogrinfo.rst
@@ -330,7 +330,7 @@ Example of retrieving information on a file in JSON format without showing detai
                 4765610.5
               ],
               "coordinateSystem":{
-                "wkt":"PROJCRS[\"OSGB36 / British National Grid\",BASEGEOGCRS[\"OSGB36\",DATUM...
+                "wkt":"PROJCRS[\"OSGB36 / British National Grid\",BASEGEOGCRS[\"OSGB36\",DATUM...",
                 "projjson":{
                   "$schema":"https://proj.org/schemas/v0.6/projjson.schema.json",
                   "type":"ProjectedCRS",
@@ -443,7 +443,7 @@ Example of retrieving information on a file in JSON format without showing detai
                     ]
                   },
                   "scope":"Engineering survey, topographic mapping.",
-                  "area":"United Kingdom (UK) - offshore to boundary of UKCS within 49°45...
+                  "area":"United Kingdom (UK) - offshore to boundary of UKCS within 49°45...",
                   "bbox":{
                     "south_latitude":49.75,
                     "west_longitude":-9,

--- a/doc/source/programs/ogrinfo.rst
+++ b/doc/source/programs/ogrinfo.rst
@@ -330,7 +330,7 @@ Example of retrieving information on a file in JSON format without showing detai
                 4765610.5
               ],
               "coordinateSystem":{
-                "wkt":"PROJCRS[\"OSGB36 / British National Grid\",BASEGEOGCRS[\"OSGB36\",DATUM[\"Ordnance Survey of Great Britain 1936\",ELLIPSOID[\"Airy 1830\",6377563.396,299.3249646,LENGTHUNIT[\"metre\",1]]],PRIMEM[\"Greenwich\",0,ANGLEUNIT[\"degree\",0.0174532925199433]],ID[\"EPSG\",4277]],CONVERSION[\"British National Grid\",METHOD[\"Transverse Mercator\",ID[\"EPSG\",9807]],PARAMETER[\"Latitude of natural origin\",49,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8801]],PARAMETER[\"Longitude of natural origin\",-2,ANGLEUNIT[\"degree\",0.0174532925199433],ID[\"EPSG\",8802]],PARAMETER[\"Scale factor at natural origin\",0.9996012717,SCALEUNIT[\"unity\",1],ID[\"EPSG\",8805]],PARAMETER[\"False easting\",400000,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8806]],PARAMETER[\"False northing\",-100000,LENGTHUNIT[\"metre\",1],ID[\"EPSG\",8807]]],CS[Cartesian,2],AXIS[\"(E)\",east,ORDER[1],LENGTHUNIT[\"metre\",1]],AXIS[\"(N)\",north,ORDER[2],LENGTHUNIT[\"metre\",1]],USAGE[SCOPE[\"Engineering survey, topographic mapping.\"],AREA[\"United Kingdom (UK) - offshore to boundary of UKCS within 49°45'N to 61°N and 9°W to 2°E; onshore Great Britain (England, Wales and Scotland). Isle of Man onshore.\"],BBOX[49.75,-9,61.01,2.01]],ID[\"EPSG\",27700]]",
+                "wkt":"PROJCRS[\"OSGB36 / British National Grid\",BASEGEOGCRS[\"OSGB36\",DATUM...
                 "projjson":{
                   "$schema":"https://proj.org/schemas/v0.6/projjson.schema.json",
                   "type":"ProjectedCRS",
@@ -443,7 +443,7 @@ Example of retrieving information on a file in JSON format without showing detai
                     ]
                   },
                   "scope":"Engineering survey, topographic mapping.",
-                  "area":"United Kingdom (UK) - offshore to boundary of UKCS within 49°45'N to 61°N and 9°W to 2°E; onshore Great Britain (England, Wales and Scotland). Isle of Man onshore.",
+                  "area":"United Kingdom (UK) - offshore to boundary of UKCS within 49°45...
                   "bbox":{
                     "south_latitude":49.75,
                     "west_longitude":-9,


### PR DESCRIPTION
Here we truncate the coordinate system's out of control lines that need to be reined in on man pages.
1. At 1200 characters long, we have already gone beyond the edge of even the most luxurious man page terminal margin, and so it is wasted anyway. Looks terrible in many user setups.
2. Confirmed also wasted on https://gdal.org/programs/ogrinfo.html
1. The man page already has an example above of them.