### PR TITLE
Update ogrinfo.rst removing obsolete "# " not present today

### DIFF
--- a/doc/source/programs/ogrinfo.rst
+++ b/doc/source/programs/ogrinfo.rst
@@ -254,12 +254,12 @@ Example of reporting the names of the layers in a NTF file:
 
     ogrinfo wrk/SHETLAND_ISLANDS.NTF
 
-    # INFO: Open of `wrk/SHETLAND_ISLANDS.NTF'
-    # using driver `UK .NTF' successful.
-    # 1: BL2000_LINK (Line String)
-    # 2: BL2000_POLY (None)
-    # 3: BL2000_COLLECTIONS (None)
-    # 4: FEATURE_CLASSES (None)
+    INFO: Open of `wrk/SHETLAND_ISLANDS.NTF'
+    using driver `UK .NTF' successful.
+    1: BL2000_LINK (Line String)
+    2: BL2000_POLY (None)
+    3: BL2000_COLLECTIONS (None)
+    4: FEATURE_CLASSES (None)
 
 Example of retrieving a summary (``-so``) of a layer without showing details about every single feature:
 
@@ -270,29 +270,29 @@ Example of retrieving a summary (``-so``) of a layer without showing details abo
       natural_earth_vector.gpkg \
       ne_10m_admin_0_antarctic_claim_limit_lines
 
-      # INFO: Open of `natural_earth_vector.gpkg'
-      #      using driver `GPKG' successful.
+      INFO: Open of `natural_earth_vector.gpkg'
+           using driver `GPKG' successful.
 
-      # Layer name: ne_10m_admin_0_antarctic_claim_limit_lines
-      # Geometry: Line String
-      # Feature Count: 23
-      # Extent: (-150.000000, -90.000000) - (160.100000, -60.000000)
-      # Layer SRS WKT:
-      # GEOGCS["WGS 84",
-      #     DATUM["WGS_1984",
-      #         SPHEROID["WGS 84",6378137,298.257223563,
-      #             AUTHORITY["EPSG","7030"]],
-      #         AUTHORITY["EPSG","6326"]],
-      #     PRIMEM["Greenwich",0,
-      #         AUTHORITY["EPSG","8901"]],
-      #     UNIT["degree",0.0174532925199433,
-      #         AUTHORITY["EPSG","9122"]],
-      #     AUTHORITY["EPSG","4326"]]
-      # FID Column = fid
-      # Geometry Column = geom
-      # type: String (15.0)
-      # scalerank: Integer (0.0)
-      # featurecla: String (50.0)
+      Layer name: ne_10m_admin_0_antarctic_claim_limit_lines
+      Geometry: Line String
+      Feature Count: 23
+      Extent: (-150.000000, -90.000000) - (160.100000, -60.000000)
+      Layer SRS WKT:
+      GEOGCS["WGS 84",
+          DATUM["WGS_1984",
+              SPHEROID["WGS 84",6378137,298.257223563,
+                  AUTHORITY["EPSG","7030"]],
+              AUTHORITY["EPSG","6326"]],
+          PRIMEM["Greenwich",0,
+              AUTHORITY["EPSG","8901"]],
+          UNIT["degree",0.0174532925199433,
+              AUTHORITY["EPSG","9122"]],
+          AUTHORITY["EPSG","4326"]]
+      FID Column = fid
+      Geometry Column = geom
+      type: String (15.0)
+      scalerank: Integer (0.0)
+      featurecla: String (50.0)
 
 Example of retrieving information on a file in JSON format without showing details about every single feature:
 


### PR DESCRIPTION
Ogrinfo doesn't add the "# " anymore. Today we sync the man page with the current output.