### PR TITLE
[gdaldem] Use GDALArgumentParser

### DIFF
--- a/apps/gdal_utils_priv.h
+++ b/apps/gdal_utils_priv.h
@@ -58,11 +58,11 @@ struct GDALInfoOptionsForBinary
 
 struct GDALDEMProcessingOptionsForBinary
 {
-    char *pszProcessing;
-    char *pszSrcFilename;
-    char *pszColorFilename;
-    char *pszDstFilename;
-    int bQuiet;
+    std::string osProcessing;
+    std::string osSrcFilename;
+    std::string osColorFilename;
+    std::string osDstFilename;
+    bool bQuiet = false;
 };
 
 CPL_C_END
@@ -250,6 +250,14 @@ std::string CPL_DLL GDALBuildVRTGetParserUsage();
 std::string CPL_DLL GDALTileIndexAppGetParserUsage();
 
 std::string CPL_DLL GDALFootprintAppGetParserUsage();
+
+/**
+ * Returns the gdaldem usage help string
+ * @param osProcessingMode          Processing mode (subparser name)
+ * @return                          gdaldem usage help string
+ */
+std::string CPL_DLL
+GDALDEMAppGetParserUsage(const std::string &osProcessingMode);
 
 #endif /* #ifndef DOXYGEN_SKIP */
 

--- a/apps/gdalargumentparser.cpp
+++ b/apps/gdalargumentparser.cpp
@@ -381,6 +381,56 @@ Argument &GDALArgumentParser::add_inverted_logic_flag(const std::string &name,
         .help(help);
 }
 
+GDALArgumentParser *
+GDALArgumentParser::add_subparser(const std::string &description,
+                                  bool bForBinary)
+{
+    auto parser = std::make_unique<GDALArgumentParser>(description, bForBinary);
+    ArgumentParser::add_subparser(*parser.get());
+    aoSubparsers.emplace_back(std::move(parser));
+    return aoSubparsers.back().get();
+}
+
+GDALArgumentParser *GDALArgumentParser::get_subparser(const std::string &name)
+{
+    auto it = std::find_if(
+        aoSubparsers.begin(), aoSubparsers.end(),
+        [&name](const auto &parser)
+        { return EQUAL(name.c_str(), parser->m_program_name.c_str()); });
+    return it != aoSubparsers.end() ? it->get() : nullptr;
+}
+
+bool GDALArgumentParser::is_used_globally(const std::string &name)
+{
+    try
+    {
+        return ArgumentParser::is_used(name);
+    }
+    catch (std::logic_error &)
+    {
+        // ignore
+    }
+
+    // Check if it is used by a subparser
+    // loop through subparsers
+    for (const auto &subparser : aoSubparsers)
+    {
+        // convert subparser name to lower case
+        std::string subparser_name = subparser->m_program_name;
+        std::transform(subparser_name.begin(), subparser_name.end(),
+                       subparser_name.begin(), ::tolower);
+        if (m_subparser_used.find(subparser_name) != m_subparser_used.end())
+        {
+            if (subparser->is_used_globally(name))
+            {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
 /************************************************************************/
 /*                           parse_args()                               */
 /************************************************************************/
@@ -431,6 +481,26 @@ void GDALArgumentParser::parse_args(const CPLStringList &aosArgs)
             }
             else
             {
+                // Check sub-parsers
+                auto subparser = get_subparser(current_argument);
+                if (subparser)
+                {
+
+                    // build list of remaining args
+                    const auto unprocessed_arguments =
+                        CPLStringList(std::vector<std::string>(it, end));
+
+                    // invoke subparser
+                    m_is_parsed = true;
+                    // convert to lower case
+                    std::string current_argument_lower = current_argument;
+                    std::transform(current_argument_lower.begin(),
+                                   current_argument_lower.end(),
+                                   current_argument_lower.begin(), ::tolower);
+                    m_subparser_used[current_argument_lower] = true;
+                    return subparser->parse_args(unprocessed_arguments);
+                }
+
                 if (m_positional_arguments.empty())
                 {
                     throw std::runtime_error(

--- a/apps/gdalargumentparser.cpp
+++ b/apps/gdalargumentparser.cpp
@@ -418,7 +418,9 @@ bool GDALArgumentParser::is_used_globally(const std::string &name)
         // convert subparser name to lower case
         std::string subparser_name = subparser->m_program_name;
         std::transform(subparser_name.begin(), subparser_name.end(),
-                       subparser_name.begin(), ::tolower);
+                       subparser_name.begin(),
+                       [](int c) -> char
+                       { return static_cast<char>(::tolower(c)); });
         if (m_subparser_used.find(subparser_name) != m_subparser_used.end())
         {
             if (subparser->is_used_globally(name))
@@ -496,7 +498,9 @@ void GDALArgumentParser::parse_args(const CPLStringList &aosArgs)
                     std::string current_argument_lower = current_argument;
                     std::transform(current_argument_lower.begin(),
                                    current_argument_lower.end(),
-                                   current_argument_lower.begin(), ::tolower);
+                                   current_argument_lower.begin(),
+                                   [](int c) -> char
+                                   { return static_cast<char>(::tolower(c)); });
                     m_subparser_used[current_argument_lower] = true;
                     return subparser->parse_args(unprocessed_arguments);
                 }

--- a/apps/gdalargumentparser.h
+++ b/apps/gdalargumentparser.h
@@ -113,9 +113,34 @@ class GDALArgumentParser : public ArgumentParser
                                       bool *store_into = nullptr,
                                       const std::string &help = "");
 
+    /**
+     * Create and add a subparser to the argument parser, keeping ownership
+     * @param description   Subparser description
+     * @param bForBinary    True if the subparser is for a binary utility, false for a library
+     * @return              A pointer to the created subparser
+     */
+    GDALArgumentParser *add_subparser(const std::string &description,
+                                      bool bForBinary);
+
+    /**
+     * Get a subparser by name (case insensitive)
+     * @param name          Subparser name
+     * @return              The subparser or nullptr if not found
+     */
+    GDALArgumentParser *get_subparser(const std::string &name);
+
+    /**
+     * Return true if the argument is used in the command line (also checking subparsers, if any)
+     * @param name      Argument name
+     * @return          True if the argument is used, false if it is not used.
+     * @note            Opposite to the is_used() function this is case insensitive, also checks subparsers and never throws
+     */
+    bool is_used_globally(const std::string &name);
+
   private:
     std::map<std::string, ArgumentParser::argument_it>::iterator
     find_argument(const std::string &name);
+    std::vector<std::unique_ptr<GDALArgumentParser>> aoSubparsers;
 };
 
 #endif /* GDALARGUMENTPARSER_H */


### PR DESCRIPTION
# General

```gdaldem --long-usage
Usage: gdaldem [--help] [--long-usage] [--help-general] {TPI,TRI,aspect,color-relief,hillshade,roughness,slope}

Tools to analyze and visualize DEMs.

Optional arguments:
  -h, --help         Shows short help message and exits. 
  --long-usage       Shows long help message and exits. 
  --help-general     Report detailed help on general options. 

Subcommands:
  TPI               Compute the Topographic Position Index.
  TRI               Compute the Terrain Ruggedness Index.
  aspect            Compute aspect.
  color-relief      Color relief computed from the elevation and a text-based color configuration file.
  hillshade         Compute hillshade.
  roughness         Compute the roughness of the DEM.
  slope             Compute slope.

For more details, consult https://gdal.org/programs/gdaldem.html
```

# Topographic Position Index

```
gdaldem tpi --long-usage
Usage: TPI [--help] [--long-usage] [--help-general]
           [-of <output_format>] [-compute_edges] [-b <value>] [-co <NAME>=<VALUE>]... [--quiet]
           input_dem output_TPI_map

Compute the Topographic Position Index.

Positional arguments:
  input_dem            The input DEM raster to be processed. 
  output_TPI_map       The output raster to be produced. 

Optional arguments:
  -h, --help           Shows short help message and exits. 
  --long-usage         Shows long help message and exits. 
  --help-general       Report detailed help on general options. 
  -of <output_format>  Output format. 
  -compute_edges       Do the computation at raster edges and near nodata values. 
  -b <value>           Select an input band. 
  -co <NAME>=<VALUE>   Creation option(s). [may be repeated]
  -q, --quiet          Quiet mode. No progress message is emitted on the standard output.
```

# Terrain Ruggedness Index

```
gdaldem tri --long-usage
Export manually or use this script as a wrapper for commands!!!!
Usage: TRI [--help] [--long-usage] [--help-general]
           [-alg Wilson|Riley] [-of <output_format>] [-compute_edges] [-b <value>] [-co <NAME>=<VALUE>]... [--quiet]
           input_dem output_TRI_map

Compute the Terrain Ruggedness Index.

Positional arguments:
  input_dem            The input DEM raster to be processed. 
  output_TRI_map       The output raster to be produced. 

Optional arguments:
  -h, --help           Shows short help message and exits. 
  --long-usage         Shows long help message and exits. 
  --help-general       Report detailed help on general options. 
  -alg Wilson|Riley    Choose between Wilson or Riley algorithms. 
  -of <output_format>  Output format. 
  -compute_edges       Do the computation at raster edges and near nodata values. 
  -b <value>           Select an input band. 
  -co <NAME>=<VALUE>   Creation option(s). [may be repeated]
  -q, --quiet          Quiet mode. No progress message is emitted on the standard output. 
```

# Hillshade

```
hillshade --long-usage
Usage: hillshade [--help] [--long-usage] [--help-general]
                 [-alg <Horn|ZevenbergenThorne>] [-z <factor>] [-s <scale>] [-az <azimuth>] [-alt <altitude>]
                 [[-combined]|[-multidirectional]|[-igor]]
                 [-of <output_format>] [-compute_edges] [-b <value>] [-co <NAME>=<VALUE>]... [--quiet]
                 input_dem output_hillshade

Compute hillshade.

Positional arguments:
  input_dem                      The input DEM raster to be processed. 
  output_hillshade               The output raster to be produced. 

Optional arguments:
  -h, --help                     Shows short help message and exits. 
  --long-usage                   Shows long help message and exits. 
  --help-general                 Report detailed help on general options. 
  -alg <Horn|ZevenbergenThorne>  Choose between ZevenbergenThorne or Horn algorithms. 
  -z <factor>                    Vertical exaggeration. 
  -s <scale>                     Ratio of vertical units to horizontal. 
  -az <azimuth>                  Azimuth of the light, in degrees. 
  -alt <altitude>                Altitude of the light, in degrees. 
  -combined                      Use combined shading. 
  -multidirectional              Use multidirectional shading. 
  -igor                          Use multidirectional shading. 
  -of <output_format>            Output format. 
  -compute_edges                 Do the computation at raster edges and near nodata values. 
  -b <value>                     Select an input band. 
  -co <NAME>=<VALUE>             Creation option(s). [may be repeated]
  -q, --quiet                    Quiet mode. No progress message is emitted on the standard output.
```

# Aspect

```
gdaldem aspect  --long-usage
Usage: aspect [--help] [--long-usage] [--help-general]
              [-alg Horn|ZevenbergenThorne] [-trigonometric] [-zero_for_flat] [-of <output_format>] [-compute_edges]
              [-b <value>] [-co <NAME>=<VALUE>]... [--quiet]
              input_dem output_aspect_map

Compute aspect.

Positional arguments:
  input_dem                    The input DEM raster to be processed. 
  output_aspect_map            The output raster to be produced. 

Optional arguments:
  -h, --help                   Shows short help message and exits. 
  --long-usage                 Shows long help message and exits. 
  --help-general               Report detailed help on general options. 
  -alg Horn|ZevenbergenThorne  Choose between ZevenbergenThorne or Horn algorithms. 
  -trigonometric               Express aspect in trigonometric format. 
  -zero_for_flat               Return 0 for flat areas with slope=0, instead of -9999. 
  -of <output_format>          Output format. 
  -compute_edges               Do the computation at raster edges and near nodata values. 
  -b <value>                   Select an input band. 
  -co <NAME>=<VALUE>           Creation option(s). [may be repeated]
  -q, --quiet                  Quiet mode. No progress message is emitted on the standard output.
```

# Color relief 

```
gdaldem color-relief  --long-usage
Usage: color-relief [--help] [--long-usage] [--help-general]
                    [-alpha] [-exact_color_entry] [-nearest_color_entry] [-of <output_format>] [-compute_edges]
                    [-b <value>] [-co <NAME>=<VALUE>]... [--quiet]
                    input_dem color_text_file output_color_relief_map

Color relief computed from the elevation and a text-based color configuration file.

Positional arguments:
  input_dem                The input DEM raster to be processed. 
  color_text_file          Text-based color configuration file. 
  output_color_relief_map  The output raster to be produced. 

Optional arguments:
  -h, --help               Shows short help message and exits. 
  --long-usage             Shows long help message and exits. 
  --help-general           Report detailed help on general options. 
  -alpha                   Add an alpha channel to the output raster. 
  -exact_color_entry       Use strict matching when searching in the configuration file. 
  -nearest_color_entry     Use the RGBA corresponding to the closest entry in the configuration file. 
  -of <output_format>      Output format. 
  -compute_edges           Do the computation at raster edges and near nodata values. 
  -b <value>               Select an input band. 
  -co <NAME>=<VALUE>       Creation option(s). [may be repeated]
  -q, --quiet              Quiet mode. No progress message is emitted on the standard output. 
```

# Roughness

```
gdaldem roughness --long-usage
Usage: roughness [--help] [--long-usage] [--help-general]
                 [-of <output_format>] [-compute_edges] [-b <value>] [-co <NAME>=<VALUE>]... [--quiet]
                 input_dem output_roughness_map

Compute the roughness of the DEM.

Positional arguments:
  input_dem             The input DEM raster to be processed. 
  output_roughness_map  The output raster to be produced. 

Optional arguments:
  -h, --help            Shows short help message and exits. 
  --long-usage          Shows long help message and exits. 
  --help-general        Report detailed help on general options. 
  -of <output_format>   Output format. 
  -compute_edges        Do the computation at raster edges and near nodata values. 
  -b <value>            Select an input band. 
  -co <NAME>=<VALUE>    Creation option(s). [may be repeated]
  -q, --quiet           Quiet mode. No progress message is emitted on the standard output.
```

# Slope

```
gdaldem slope --long-usage
Usage: slope [--help] [--long-usage] [--help-general]
             [-alg Horn|ZevenbergenThorne] [-p] [-s <scale>] [-of <output_format>] [-compute_edges] [-b <value>]
             [-co <NAME>=<VALUE>]... [--quiet]
             input_dem output_slope_map

Compute slope.

Positional arguments:
  input_dem                    The input DEM raster to be processed. 
  output_slope_map             The output raster to be produced. 

Optional arguments:
  -h, --help                   Shows short help message and exits. 
  --long-usage                 Shows long help message and exits. 
  --help-general               Report detailed help on general options. 
  -alg Horn|ZevenbergenThorne  Choose between ZevenbergenThorne or Horn algorithms. 
  -p                           Express slope as a percentage. 
  -s <scale>                   Ratio of vertical units to horizontal. 
  -of <output_format>          Output format. 
  -compute_edges               Do the computation at raster edges and near nodata values. 
  -b <value>                   Select an input band. 
  -co <NAME>=<VALUE>           Creation option(s). [may be repeated]
  -q, --quiet                  Quiet mode. No progress message is emitted on the standard output.
```
