### PR TITLE
MiraMonVector: Fixing chromium bug 68809

### DIFF
--- a/ogr/ogrsf_frmts/miramon/mm_gdal_functions.c
+++ b/ogr/ogrsf_frmts/miramon/mm_gdal_functions.c
@@ -1695,13 +1695,17 @@ reintenta_lectura_per_si_error_CreaCampBD_XP:
     return 0;
 }  // End of MM_ReadExtendedDBFHeaderFromFile()
 
-void MM_ReleaseDBFHeader(struct MM_DATA_BASE_XP *data_base_XP)
+void MM_ReleaseDBFHeader(struct MM_DATA_BASE_XP **data_base_XP)
 {
-    if (data_base_XP)
-    {
-        MM_ReleaseMainFields(data_base_XP);
-        free_function(data_base_XP);
-    }
+    if (!data_base_XP)
+        return;
+    if (!*data_base_XP)
+        return;
+
+    MM_ReleaseMainFields(*data_base_XP);
+    free_function(*data_base_XP);
+    *data_base_XP = nullptr;
+
     return;
 }
 

--- a/ogr/ogrsf_frmts/miramon/mm_gdal_functions.h
+++ b/ogr/ogrsf_frmts/miramon/mm_gdal_functions.h
@@ -102,7 +102,7 @@ MM_GiveOffsetExtendedFieldName(const struct MM_FIELD *camp);
 struct MM_DATA_BASE_XP *MM_CreateDBFHeader(MM_EXT_DBF_N_FIELDS n_camps,
                                            MM_BYTE nCharSet);
 void MM_ReleaseMainFields(struct MM_DATA_BASE_XP *data_base_XP);
-void MM_ReleaseDBFHeader(struct MM_DATA_BASE_XP *data_base_XP);
+void MM_ReleaseDBFHeader(struct MM_DATA_BASE_XP **data_base_XP);
 MM_BOOLEAN MM_CreateAndOpenDBFFile(struct MM_DATA_BASE_XP *bd_xp,
                                    const char *NomFitxer);
 int MM_DuplicateFieldDBXP(struct MM_FIELD *camp_final,

--- a/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
+++ b/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
@@ -7397,8 +7397,8 @@ static void MMDestroyMMDBFile(struct MiraMonVectLayerInfo *hMiraMonLayer,
 
     if (pMMAdmDB && pMMAdmDB->pMMBDXP)
     {
-        MM_ReleaseDBFHeader(pMMAdmDB->pMMBDXP);
-        hMiraMonLayer->pMMBDXP = pMMAdmDB->pMMBDXP = nullptr;
+        MM_ReleaseDBFHeader(&pMMAdmDB->pMMBDXP);
+        hMiraMonLayer->pMMBDXP = nullptr;
     }
     if (pMMAdmDB && pMMAdmDB->pRecList)
     {


### PR DESCRIPTION
## What does this PR do?
Fixes https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=68809
A copy of a pointer was freed instead of the pointer.

## What are related issues/pull requests?
https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=68809

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] All CI builds and checks have passed
