### PR TITLE
CPLHTTPFetch(): add a RETRY_CODES option, and C++'ify HTTP retry logic

### DIFF
--- a/autotest/gcore/vsiaz.py
+++ b/autotest/gcore/vsiaz.py
@@ -751,14 +751,14 @@ def test_vsiaz_write_blockblob_retry():
 
     gdal.VSICurlClearCache()
 
-    # Test creation of BlockBob
-    f = gdal.VSIFOpenL("/vsiaz/test_copy/file.bin", "wb")
-    assert f is not None
-
     with gdaltest.config_options(
         {"GDAL_HTTP_MAX_RETRY": "2", "GDAL_HTTP_RETRY_DELAY": "0.01"},
         thread_local=False,
     ):
+
+        # Test creation of BlockBob
+        f = gdal.VSIFOpenL("/vsiaz/test_copy/file.bin", "wb")
+        assert f is not None
 
         handler = webserver.SequentialHandler()
 

--- a/doc/source/user/configoptions.rst
+++ b/doc/source/user/configoptions.rst
@@ -744,14 +744,27 @@ Networking options
 
 -  .. config:: GDAL_HTTP_MAX_RETRY
       :since: 2.3
+      :default: 0
 
-      Set the number of HTTP attempts in case of HTTP errors 429, 502, 503, or 504.
+      Set the number of HTTP attempts, when a retry is allowed.
+      (cf :config:`GDAL_HTTP_RETRY_CODES` for conditions where a retry is attempted.)
+      The default value is 0, meaning no retry.
 
 -  .. config:: GDAL_HTTP_RETRY_DELAY
       :choices: <seconds>
       :since: 2.3
+      :default: 30
 
       Set the delay between HTTP attempts.
+
+-  .. config:: GDAL_HTTP_RETRY_CODES
+      :choices: ALL or comma-separated list of codes
+      :since: 3.10
+
+      Specify which HTTP error codes should trigger a retry attempt.
+      Valid values are ``ALL`` or a comma-separated list of HTTP codes.
+      By default, 429, 500, 502, 503 or 504 HTTP errors are considered, as
+      well as other situations with a particular HTTP or Curl error message.
 
 -  .. config:: GDAL_HTTP_TCP_KEEPALIVE
       :choices: YES, NO

--- a/doc/source/user/virtual_file_systems.rst
+++ b/doc/source/user/virtual_file_systems.rst
@@ -379,6 +379,7 @@ Starting with GDAL 2.3, options can be passed in the filename with the following
 - use_head=yes/no: whether the HTTP HEAD request can be emitted. Default to YES. Setting this option overrides the behavior of the :config:`CPL_VSIL_CURL_USE_HEAD` configuration option.
 - max_retry=number: default to 0. Setting this option overrides the behavior of the :config:`GDAL_HTTP_MAX_RETRY` configuration option.
 - retry_delay=number_in_seconds: default to 30. Setting this option overrides the behavior of the :config:`GDAL_HTTP_RETRY_DELAY` configuration option.
+- retry_codes=``ALL`` or comma-separated list of HTTP error codes. Setting this option overrides the behavior of the :config:`GDAL_HTTP_RETRY_CODES` configuration option. (GDAL >= 3.10)
 - list_dir=yes/no: whether an attempt to read the file list of the directory where the file is located should be done. Default to YES.
 - useragent=value: HTTP UserAgent header
 - referer=value: HTTP Referer header

--- a/port/cpl_http.cpp
+++ b/port/cpl_http.cpp
@@ -529,6 +529,7 @@ constexpr TupleEnvVarOptionName asAssocEnvVarOptionName[] = {
     {"GDAL_HTTP_NETRC_FILE", "NETRC_FILE"},
     {"GDAL_HTTP_MAX_RETRY", "MAX_RETRY"},
     {"GDAL_HTTP_RETRY_DELAY", "RETRY_DELAY"},
+    {"GDAL_HTTP_RETRY_CODES", "RETRY_CODES"},
     {"GDAL_CURL_CA_BUNDLE", "CAINFO"},
     {"CURL_CA_BUNDLE", "CAINFO"},
     {"SSL_CERT_FILE", "CAINFO"},
@@ -576,18 +577,45 @@ char **CPLHTTPGetOptionsFromEnv(const char *pszFilename)
 /*                      CPLHTTPGetNewRetryDelay()                       */
 /************************************************************************/
 
+/** Return the new retry delay.
+ *
+ * This takes into account the HTTP response code, the previous delay, the
+ * HTTP payload error message, the Curl error message and a potential list of
+ * retriable HTTP codes.
+ *
+ * @param response_code HTTP response code (e.g. 400)
+ * @param dfOldDelay Previous delay (nominally in second)
+ * @param pszErrBuf HTTP response body of the failed request (may be NULL)
+ * @param pszCurlError Curl error as returned by CURLOPT_ERRORBUFFER (may be NULL)
+ * @param pszRetriableCodes nullptr to limit to the default hard-coded scenarios,
+ * "ALL" to ask to retry for all non-200 codes, or a comma-separated list of
+ * HTTP codes (e.g. "400,500") that are accepted for retry.
+ * @return the new delay, or 0 if no retry should be attempted.
+ */
 double CPLHTTPGetNewRetryDelay(int response_code, double dfOldDelay,
-                               const char *pszErrBuf, const char *pszCurlError)
+                               const char *pszErrBuf, const char *pszCurlError,
+                               const char *pszRetriableCodes)
 {
-    if (response_code == 429 || response_code == 500 ||
-        (response_code >= 502 && response_code <= 504) ||
-        // S3 sends some client timeout errors as 400 Client Error
-        (response_code == 400 && pszErrBuf &&
-         strstr(pszErrBuf, "RequestTimeout")) ||
-        (pszCurlError && (strstr(pszCurlError, "Connection timed out") ||
-                          strstr(pszCurlError, "Operation timed out") ||
-                          strstr(pszCurlError, "Connection reset by peer") ||
-                          strstr(pszCurlError, "Connection was reset"))))
+    bool bRetry = false;
+    if (pszRetriableCodes && pszRetriableCodes[0])
+    {
+        bRetry = EQUAL(pszRetriableCodes, "ALL") ||
+                 strstr(pszRetriableCodes, CPLSPrintf("%d", response_code));
+    }
+    else if (response_code == 429 || response_code == 500 ||
+             (response_code >= 502 && response_code <= 504) ||
+             // S3 sends some client timeout errors as 400 Client Error
+             (response_code == 400 && pszErrBuf &&
+              strstr(pszErrBuf, "RequestTimeout")) ||
+             (pszCurlError &&
+              (strstr(pszCurlError, "Connection timed out") ||
+               strstr(pszCurlError, "Operation timed out") ||
+               strstr(pszCurlError, "Connection reset by peer") ||
+               strstr(pszCurlError, "Connection was reset"))))
+    {
+        bRetry = true;
+    }
+    if (bRetry)
     {
         // 'Operation timed out': seen during some long running operation 'hang'
         // no error but no response from server and we are in the cURL loop
@@ -910,69 +938,133 @@ int CPLHTTPPopFetchCallback(void)
 /**
  * \brief Fetch a document from an url and return in a string.
  *
- * @param pszURL valid URL recognized by underlying download library (libcurl)
- * @param papszOptions option list as a NULL-terminated array of strings. May be
- * NULL. The following options are handled : <ul>
+ * Different options may be passed through the papszOptions function parameter,
+ * or for most of them through a configuration option:
+ * <ul>
  * <li>CONNECTTIMEOUT=val, where
  * val is in seconds (possibly with decimals). This is the maximum delay for the
- * connection to be established before being aborted (GDAL >= 2.2).</li>
+ * connection to be established before being aborted (GDAL >= 2.2).
+ * Corresponding configuration option: GDAL_HTTP_CONNECTTIMEOUT.
+ * </li>
  * <li>TIMEOUT=val, where val is in seconds. This is the maximum delay for the
- * whole request to complete before being aborted.</li>
+ * whole request to complete before being aborted.
+ * Corresponding configuration option: GDAL_HTTP_TIMEOUT.
+ * </li>
  * <li>LOW_SPEED_TIME=val,
  * where val is in seconds. This is the maximum time where the transfer speed
  * should be below the LOW_SPEED_LIMIT (if not specified 1b/s), before the
- * transfer to be considered too slow and aborted. (GDAL >= 2.1)</li>
+ * transfer to be considered too slow and aborted. (GDAL >= 2.1).
+ * Corresponding configuration option: GDAL_HTTP_LOW_SPEED_TIME.
+ * </li>
  * <li>LOW_SPEED_LIMIT=val, where val is in bytes/second. See LOW_SPEED_TIME.
- * Has only effect if LOW_SPEED_TIME is specified too. (GDAL >= 2.1)</li>
+ * Has only effect if LOW_SPEED_TIME is specified too. (GDAL >= 2.1).
+ * Corresponding configuration option: GDAL_HTTP_LOW_SPEED_LIMIT.
+ * </li>
  * <li>HEADERS=val, where val is an extra header to use when getting a web page.
- *                  For example "Accept: application/x-ogcwkt"</li>
+ *                  For example "Accept: application/x-ogcwkt"
+ * Corresponding configuration option: GDAL_HTTP_HEADERS.
+ * Starting with GDAL 3.6, the GDAL_HTTP_HEADERS configuration option can also
+ * be used to specify a comma separated list of key: value pairs. This is an
+ * alternative to the GDAL_HTTP_HEADER_FILE mechanism. If a comma or a
+ * double-quote character is needed in the value, then the key: value pair must
+ * be enclosed in double-quote characters. In that situation, backslash and
+ * double quote character must be backslash-escaped. e.g GDAL_HTTP_HEADERS=Foo:
+ * Bar,"Baz: escaped backslash \\, escaped double-quote \", end of
+ * value",Another: Header
+ * </li>
  * <li>HEADER_FILE=filename: filename of a text file with "key: value" headers.
  *     The content of the file is not cached, and thus it is read again before
- *     issuing each HTTP request. (GDAL >= 2.2)</li>
+ *     issuing each HTTP request. (GDAL >= 2.2)
+ * Corresponding configuration option: GDAL_HTTP_HEADER_FILE.
+ * </li>
  * <li>HTTPAUTH=[BASIC/NTLM/NEGOTIATE/ANY/ANYSAFE/BEARER] to specify an
- * authentication scheme to use.</li>
+ * authentication scheme to use.
+ * Corresponding configuration option: GDAL_HTTP_AUTH.
+ * </li>
  * <li>USERPWD=userid:password to specify a user and password for
- * authentication</li>
+ * authentication.
+ * Corresponding configuration option: GDAL_HTTP_USERPWD.
+ * </li>
  * <li>GSSAPI_DELEGATION=[NONE/POLICY/ALWAYS] set allowed
- * GSS-API delegation. Relevant only with HTTPAUTH=NEGOTIATE (GDAL >= 3.3).</li>
+ * GSS-API delegation. Relevant only with HTTPAUTH=NEGOTIATE (GDAL >= 3.3).
+ * Corresponding configuration option: GDAL_GSSAPI_DELEGATION (note: no "HTTP_" in the name)
+ * </li>
  * <li>HTTP_BEARER=val set OAuth 2.0 Bearer Access Token.
- * Relevant only with HTTPAUTH=BEARER (GDAL >= 3.9).</li>
+ * Relevant only with HTTPAUTH=BEARER (GDAL >= 3.9).
+ * Corresponding configuration option: GDAL_HTTP_BEARER
+ * </li>
  * <li>POSTFIELDS=val, where val is a nul-terminated string to be passed to the
- * server with a POST request.</li>
+ * server with a POST request.
+ * No Corresponding configuration option.
+ * </li>
  * <li>PROXY=val, to make requests go through a
  * proxy server, where val is of the form proxy.server.com:port_number. This
- * option affects both HTTP and HTTPS URLs.</li>
+ * option affects both HTTP and HTTPS URLs.
+ * Corresponding configuration option: GDAL_HTTP_PROXY.
+ * </li>
  * <li>HTTPS_PROXY=val (GDAL
  * >= 2.4), the same meaning as PROXY, but this option is taken into account
- * only for HTTPS URLs.</li>
- * <li>PROXYUSERPWD=val, where val is of the form
- * username:password</li>
+ * only for HTTPS URLs.
+ * Corresponding configuration option: GDAL_HTTPS_PROXY.
+ * </li>
+ * <li>PROXYUSERPWD=val, where val is of the form username:password.
+ * Corresponding configuration option: GDAL_HTTP_PROXYUSERPWD
+ * </li>
  * <li>PROXYAUTH=[BASIC/NTLM/DIGEST/NEGOTIATE/ANY/ANYSAFE] to
- * specify an proxy authentication scheme to use.</li>
+ * specify an proxy authentication scheme to use..
+ * Corresponding configuration option: GDAL_PROXYAUTH (note: no "HTTP_" in the name)
+ * </li>
  * <li>NETRC=[YES/NO] to
- * enable or disable use of $HOME/.netrc (or NETRC_FILE), default YES.</li>
- * <li>NETRC_FILE=file name to read .netrc info from  (GDAL >= 3.7).</li>
- * <li>CUSTOMREQUEST=val, where val is GET, PUT, POST, DELETE, etc.. (GDAL
- * >= 1.9.0)</li>
+ * enable or disable use of $HOME/.netrc (or NETRC_FILE), default YES.
+ * Corresponding configuration option: GDAL_HTTP_NETRC.
+ * </li>
+ * <li>NETRC_FILE=file name to read .netrc info from  (GDAL >= 3.7).
+ * Corresponding configuration option: GDAL_HTTP_NETRC_FILE.
+ * </li>
+ * <li>CUSTOMREQUEST=val, where val is GET, PUT, POST, DELETE, etc...
+ * No corresponding configuration option.
+ * </li>
  * <li>FORM_FILE_NAME=val, where val is upload file name. If this
- * option and FORM_FILE_PATH present, request type will set to POST.</li>
- * <li>FORM_FILE_PATH=val, where val is upload file path.</li>
- * <li>FORM_KEY_0=val...FORM_KEY_N, where val is name of form item.</li>
+ * option and FORM_FILE_PATH present, request type will set to POST.
+ * No corresponding configuration option.
+ * </li>
+ * <li>FORM_FILE_PATH=val, where val is upload file path.
+ * No corresponding configuration option.
+ * </li>
+ * <li>FORM_KEY_0=val...FORM_KEY_N, where val is name of form item.
+ * No corresponding configuration option.
+ * </li>
  * <li>FORM_VALUE_0=val...FORM_VALUE_N, where val is value of the form
- * item.</li>
- * <li>FORM_ITEM_COUNT=val, where val is count of form items.</li>
- * <li>COOKIE=val, where val is formatted as COOKIE1=VALUE1; COOKIE2=VALUE2;
- * ...</li>
+ * item.
+ * No corresponding configuration option.
+ * </li>
+ * <li>FORM_ITEM_COUNT=val, where val is count of form items.
+ * No corresponding configuration option.
+ * </li>
+ * <li>COOKIE=val, where val is formatted as COOKIE1=VALUE1; COOKIE2=VALUE2;...
+ * Corresponding configuration option: GDAL_HTTP_COOKIE.</li>
  * <li>COOKIEFILE=val, where val is file name to read cookies from
- * (GDAL >= 2.4)</li>
- * <li>COOKIEJAR=val, where val is file name to store cookies
- * to (GDAL >= 2.4)</li>
+ * (GDAL >= 2.4).
+ * Corresponding configuration option: GDAL_HTTP_COOKIEFILE.</li>
+ * <li>COOKIEJAR=val, where val is file name to store cookies to (GDAL >= 2.4).
+ * Corresponding configuration option: GDAL_HTTP_COOKIEJAR.</li>
  * <li>MAX_RETRY=val, where val is the maximum number of
- * retry attempts if a 429, 502, 503 or 504 HTTP error occurs. Default is 0.
- * (GDAL >= 2.0)</li>
+ * retry attempts, when a retry is allowed (cf RETRY_CODES option).
+ * Default is 0, meaning no retry.
+ * Corresponding configuration option: GDAL_HTTP_MAX_RETRY.
+ * </li>
  * <li>RETRY_DELAY=val, where val is the number of seconds
- * between retry attempts. Default is 30. (GDAL >= 2.0)</li>
- * <li>MAX_FILE_SIZE=val, where val is a number of bytes (GDAL >= 2.2)</li>
+ * between retry attempts. Default is 30.
+ * Corresponding configuration option: GDAL_HTTP_RETRY_DELAY.
+ * <li>RETRY_CODES=val, where val is "ALL" or a comma-separated list of HTTP
+ * codes that are considered for retry. By default, 429, 500, 502, 503 or 504
+ * HTTP errors are considered, as well as other situations with a particular
+ * HTTP or Curl error message. (GDAL >= 3.10).
+ * Corresponding configuration option: GDAL_HTTP_RETRY_CODES.
+ * </li>
+ * <li>MAX_FILE_SIZE=val, where val is a number of bytes (GDAL >= 2.2)
+ * No corresponding configuration option.
+ * </li>
  * <li>CAINFO=/path/to/bundle.crt. This is path to Certificate Authority (CA)
  *     bundle file. By default, it will be looked for in a system location. If
  *     the CAINFO option is not defined, GDAL will also look in the
@@ -985,64 +1077,67 @@ int CPLHTTPPopFetchCallback(void)
  *     like Google Compute Engine VMs, where 2TLS will be the default).
  *     Support for HTTP/2 requires curl 7.33 or later, built against nghttp2.
  *     "2TLS" means that HTTP/2 will be attempted for HTTPS connections only.
- * Whereas "2" means that HTTP/2 will be attempted for HTTP or HTTPS.</li>
+ *     Whereas "2" means that HTTP/2 will be attempted for HTTP or HTTPS.
+ *     Corresponding configuration option: GDAL_HTTP_VERSION.
+ * </li>
  * <li>SSL_VERIFYSTATUS=YES/NO (GDAL >= 2.3, and curl >= 7.41): determines
  * whether the status of the server cert using the "Certificate Status Request"
  * TLS extension (aka. OCSP stapling) should be checked. If this option is
  * enabled but the server does not support the TLS extension, the verification
- * will fail. Default to NO.</li>
+ * will fail. Default to NO.
+ * Corresponding configuration option: GDAL_HTTP_SSL_VERIFYSTATUS.
+ * </li>
  * <li>USE_CAPI_STORE=YES/NO (GDAL >= 2.3,
  * Windows only): whether CA certificates from the Windows certificate store.
- * Defaults to NO.</li>
+ * Defaults to NO.
+ * Corresponding configuration option: GDAL_HTTP_USE_CAPI_STORE.
+ * </li>
  * <li>TCP_KEEPALIVE=YES/NO (GDAL >= 3.6): whether to
- * enable TCP keep-alive. Defaults to NO</li> <li>TCP_KEEPIDLE=integer, in
+ * enable TCP keep-alive. Defaults to NO.
+ * Corresponding configuration option: GDAL_HTTP_TCP_KEEPALIVE.
+ * </li>
+ * <li>TCP_KEEPIDLE=integer, in
  * seconds (GDAL >= 3.6): keep-alive idle time. Defaults to 60. Only taken into
- * account if TCP_KEEPALIVE=YES.</li>
+ * account if TCP_KEEPALIVE=YES.
+ * Corresponding configuration option: GDAL_HTTP_TCP_KEEPIDLE.
+ * </li>
  * <li>TCP_KEEPINTVL=integer, in seconds
  * (GDAL >= 3.6): interval time between keep-alive probes. Defaults to 60. Only
- * taken into account if TCP_KEEPALIVE=YES.</li>
+ * taken into account if TCP_KEEPALIVE=YES.
+ * Corresponding configuration option: GDAL_HTTP_TCP_KEEPINTVL.
+ * </li>
  * <li>USERAGENT=string: value of User-Agent header. Starting with GDAL 3.7,
  * GDAL core sets it by default (during driver initialization) to GDAL/x.y.z
  * where x.y.z is the GDAL version number. Applications may override it with the
- * CPLHTTPSetDefaultUserAgent() function.</li>
+ * CPLHTTPSetDefaultUserAgent() function.
+ * Corresponding configuration option: GDAL_HTTP_USERAGENT.
+ * </li>
  * <li>SSLCERT=filename (GDAL >= 3.7): Filename of the the SSL client certificate.
- * Cf https://curl.se/libcurl/c/CURLOPT_SSLCERT.html</li>
+ * Cf https://curl.se/libcurl/c/CURLOPT_SSLCERT.html.
+ * Corresponding configuration option: GDAL_HTTP_SSLCERT.
+ * </li>
  * <li>SSLCERTTYPE=string (GDAL >= 3.7): Format of the SSL certificate: "PEM"
- * or "DER". Cf https://curl.se/libcurl/c/CURLOPT_SSLCERTTYPE.html</li>
+ * or "DER". Cf https://curl.se/libcurl/c/CURLOPT_SSLCERTTYPE.html.
+ * Corresponding configuration option: GDAL_HTTP_SSLCERTTYPE.
+ * </li>
  * <li>SSLKEY=filename (GDAL >= 3.7): Private key file for TLS and SSL client
- * certificate. Cf https://curl.se/libcurl/c/CURLOPT_SSLKEY.html</li>
+ * certificate. Cf https://curl.se/libcurl/c/CURLOPT_SSLKEY.html.
+ * Corresponding configuration option: GDAL_HTTP_SSLKEY.
+ * </li>
  * <li>KEYPASSWD=string (GDAL >= 3.7): Passphrase to private key.
- * Cf https://curl.se/libcurl/c/CURLOPT_KEYPASSWD.html</li>
+ * Cf https://curl.se/libcurl/c/CURLOPT_KEYPASSWD.html.
+ * Corresponding configuration option: GDAL_HTTP_KEYPASSWD.
  * </ul>
  *
- * Alternatively, if not defined in the papszOptions arguments, the following
- * CONNECTTIMEOUT, TIMEOUT,
- * LOW_SPEED_TIME, LOW_SPEED_LIMIT, USERPWD, PROXY, HTTPS_PROXY, PROXYUSERPWD,
- * PROXYAUTH, NETRC, NETRC_FILE, MAX_RETRY and RETRY_DELAY, HEADER_FILE, HTTP_VERSION,
- * SSL_VERIFYSTATUS, USE_CAPI_STORE, GSSAPI_DELEGATION, HTTP_BEARER, TCP_KEEPALIVE,
- * TCP_KEEPIDLE, TCP_KEEPINTVL, USERAGENT, SSLCERT, SSLCERTTYPE, SSLKEY,
- * KEYPASSWD values are searched in the configuration options
- * respectively named GDAL_HTTP_CONNECTTIMEOUT, GDAL_HTTP_TIMEOUT,
- * GDAL_HTTP_LOW_SPEED_TIME, GDAL_HTTP_LOW_SPEED_LIMIT, GDAL_HTTP_USERPWD,
- * GDAL_HTTP_PROXY, GDAL_HTTPS_PROXY, GDAL_HTTP_PROXYUSERPWD, GDAL_PROXY_AUTH,
- * GDAL_HTTP_NETRC, GDAL_HTTP_NETC_FILE, GDAL_HTTP_MAX_RETRY, GDAL_HTTP_RETRY_DELAY,
- * GDAL_HTTP_HEADER_FILE, GDAL_HTTP_VERSION, GDAL_HTTP_SSL_VERIFYSTATUS,
- * GDAL_HTTP_USE_CAPI_STORE, GDAL_GSSAPI_DELEGATION, GDAL_HTTP_BEARER,
- * GDAL_HTTP_TCP_KEEPALIVE, GDAL_HTTP_TCP_KEEPIDLE, GDAL_HTTP_TCP_KEEPINTVL,
- * GDAL_HTTP_USERAGENT, GDAL_HTTP_SSLCERT, GDAL_HTTP_SSLCERTTYPE,
- * GDAL_HTTP_SSLKEY and GDAL_HTTP_KEYPASSWD.
- *
- * Starting with GDAL 3.6, the GDAL_HTTP_HEADERS configuration option can also
- * be used to specify a comma separated list of key: value pairs. This is an
- * alternative to the GDAL_HTTP_HEADER_FILE mechanism. If a comma or a
- * double-quote character is needed in the value, then the key: value pair must
- * be enclosed in double-quote characters. In that situation, backslash and
- * double quote character must be backslash-escaped. e.g GDAL_HTTP_HEADERS=Foo:
- * Bar,"Baz: escaped backslash \\, escaped double-quote \", end of
- * value",Another: Header
+ * If an option is specified through papszOptions and as a configuration option,
+ * the former takes precedence over the later.
  *
  * Starting with GDAL 3.7, the above configuration options can also be specified
  * as path-specific options with VSISetPathSpecificOption().
+ *
+ * @param pszURL valid URL recognized by underlying download library (libcurl)
+ * @param papszOptions option list as a NULL-terminated array of strings. May be
+ * NULL.
  *
  * @return a CPLHTTPResult* structure that must be freed by
  * CPLHTTPDestroyResult(), or NULL if libcurl support is disabled
@@ -1349,8 +1444,7 @@ CPLHTTPResult *CPLHTTPFetchEx(const char *pszURL, CSLConstList papszOptions,
     }
 
     /* -------------------------------------------------------------------- */
-    /*      If 429, 502, 503 or 504 status code retry this HTTP call until max
-     */
+    /*      Depending on status code, retry this HTTP call until max        */
     /*      retry has been reached                                          */
     /* -------------------------------------------------------------------- */
     const char *pszRetryDelay = CSLFetchNameValue(papszOptions, "RETRY_DELAY");
@@ -1364,6 +1458,9 @@ CPLHTTPResult *CPLHTTPFetchEx(const char *pszURL, CSLConstList papszOptions,
     // coverity[tainted_data]
     double dfRetryDelaySecs = CPLAtof(pszRetryDelay);
     int nMaxRetries = atoi(pszMaxRetries);
+    const char *pszRetryCodes = CSLFetchNameValue(papszOptions, "RETRY_CODES");
+    if (!pszRetryCodes)
+        pszRetryCodes = CPLGetConfigOption("GDAL_HTTP_RETRY_CODES", nullptr);
     int nRetryCount = 0;
 
     while (true)
@@ -1395,7 +1492,7 @@ CPLHTTPResult *CPLHTTPFetchEx(const char *pszURL, CSLConstList papszOptions,
             const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
                 static_cast<int>(response_code), dfRetryDelaySecs,
                 reinterpret_cast<const char *>(psResult->pabyData),
-                szCurlErrBuf);
+                szCurlErrBuf, pszRetryCodes);
             if (dfNewRetryDelay > 0 && nRetryCount < nMaxRetries)
             {
                 CPLError(CE_Warning, CPLE_AppDefined,

--- a/port/cpl_http.h
+++ b/port/cpl_http.h
@@ -179,9 +179,44 @@ CPL_C_END
 void CPL_DLL *CPLHTTPSetOptions(void *pcurl, const char *pszURL,
                                 const char *const *papszOptions);
 char **CPLHTTPGetOptionsFromEnv(const char *pszFilename);
-double CPLHTTPGetNewRetryDelay(int response_code, double dfOldDelay,
-                               const char *pszErrBuf, const char *pszCurlError,
-                               const char *pszRetriableCodes = nullptr);
+
+/** Stores HTTP retry parameters */
+struct CPLHTTPRetryParameters
+{
+    int nMaxRetry = CPL_HTTP_MAX_RETRY;
+    double dfInitialDelay = CPL_HTTP_RETRY_DELAY;
+    std::string osRetryCodes{};
+
+    CPLHTTPRetryParameters() = default;
+    explicit CPLHTTPRetryParameters(const CPLStringList &aosHTTPOptions);
+};
+
+/** HTTP retry context */
+class CPLHTTPRetryContext
+{
+  public:
+    explicit CPLHTTPRetryContext(const CPLHTTPRetryParameters &oParams);
+
+    bool CanRetry(int response_code, const char *pszErrBuf,
+                  const char *pszCurlError);
+    bool CanRetry();
+
+    /** Returns the delay to apply. Only valid after a successful call to CanRetry() */
+    double GetCurrentDelay() const;
+
+    /** Reset retry counter. */
+    void ResetCounter()
+    {
+        m_nRetryCount = 0;
+    }
+
+  private:
+    CPLHTTPRetryParameters m_oParameters{};
+    int m_nRetryCount = 0;
+    double m_dfCurDelay = 0.0;
+    double m_dfNextDelay = 0.0;
+};
+
 void CPL_DLL *CPLHTTPIgnoreSigPipe();
 void CPL_DLL CPLHTTPRestoreSigPipeHandler(void *old_handler);
 bool CPLMultiPerformWait(void *hCurlMultiHandle, int &repeats);

--- a/port/cpl_http.h
+++ b/port/cpl_http.h
@@ -180,7 +180,8 @@ void CPL_DLL *CPLHTTPSetOptions(void *pcurl, const char *pszURL,
                                 const char *const *papszOptions);
 char **CPLHTTPGetOptionsFromEnv(const char *pszFilename);
 double CPLHTTPGetNewRetryDelay(int response_code, double dfOldDelay,
-                               const char *pszErrBuf, const char *pszCurlError);
+                               const char *pszErrBuf, const char *pszCurlError,
+                               const char *pszRetriableCodes = nullptr);
 void CPL_DLL *CPLHTTPIgnoreSigPipe();
 void CPL_DLL CPLHTTPRestoreSigPipeHandler(void *old_handler);
 bool CPLMultiPerformWait(void *hCurlMultiHandle, int &repeats);

--- a/port/cpl_vsil_adls.cpp
+++ b/port/cpl_vsil_adls.cpp
@@ -238,8 +238,9 @@ class VSIADLSFSHandler final : public IVSIS3LikeFSHandler
     bool UploadFile(const std::string &osFilename, Event event,
                     vsi_l_offset nPosition, const void *pabyBuffer,
                     size_t nBufferSize,
-                    IVSIS3LikeHandleHelper *poS3HandleHelper, int nMaxRetry,
-                    double dfRetryDelay, CSLConstList papszOptions);
+                    IVSIS3LikeHandleHelper *poS3HandleHelper,
+                    const CPLHTTPRetryParameters &oRetryParameters,
+                    CSLConstList papszOptions);
 
     // Multipart upload (mapping of S3 interface)
     bool SupportsParallelMultipartUpload() const override
@@ -247,13 +248,14 @@ class VSIADLSFSHandler final : public IVSIS3LikeFSHandler
         return true;
     }
 
-    std::string InitiateMultipartUpload(
-        const std::string &osFilename, IVSIS3LikeHandleHelper *poS3HandleHelper,
-        int nMaxRetry, double dfRetryDelay, CSLConstList papszOptions) override
+    std::string
+    InitiateMultipartUpload(const std::string &osFilename,
+                            IVSIS3LikeHandleHelper *poS3HandleHelper,
+                            const CPLHTTPRetryParameters &oRetryParameters,
+                            CSLConstList papszOptions) override
     {
         return UploadFile(osFilename, Event::CREATE_FILE, 0, nullptr, 0,
-                          poS3HandleHelper, nMaxRetry, dfRetryDelay,
-                          papszOptions)
+                          poS3HandleHelper, oRetryParameters, papszOptions)
                    ? std::string("dummy")
                    : std::string();
     }
@@ -263,31 +265,31 @@ class VSIADLSFSHandler final : public IVSIS3LikeFSHandler
                            vsi_l_offset nPosition, const void *pabyBuffer,
                            size_t nBufferSize,
                            IVSIS3LikeHandleHelper *poS3HandleHelper,
-                           int nMaxRetry, double dfRetryDelay,
+                           const CPLHTTPRetryParameters &oRetryParameters,
                            CSLConstList /* papszOptions */) override
     {
         return UploadFile(osFilename, Event::APPEND_DATA, nPosition, pabyBuffer,
-                          nBufferSize, poS3HandleHelper, nMaxRetry,
-                          dfRetryDelay, nullptr)
+                          nBufferSize, poS3HandleHelper, oRetryParameters,
+                          nullptr)
                    ? std::string("dummy")
                    : std::string();
     }
 
-    bool CompleteMultipart(const std::string &osFilename,
-                           const std::string & /* osUploadID */,
-                           const std::vector<std::string> & /* aosEtags */,
-                           vsi_l_offset nTotalSize,
-                           IVSIS3LikeHandleHelper *poS3HandleHelper,
-                           int nMaxRetry, double dfRetryDelay) override
+    bool CompleteMultipart(
+        const std::string &osFilename, const std::string & /* osUploadID */,
+        const std::vector<std::string> & /* aosEtags */,
+        vsi_l_offset nTotalSize, IVSIS3LikeHandleHelper *poS3HandleHelper,
+        const CPLHTTPRetryParameters &oRetryParameters) override
     {
         return UploadFile(osFilename, Event::FLUSH, nTotalSize, nullptr, 0,
-                          poS3HandleHelper, nMaxRetry, dfRetryDelay, nullptr);
+                          poS3HandleHelper, oRetryParameters, nullptr);
     }
 
-    bool AbortMultipart(const std::string & /* osFilename */,
-                        const std::string & /* osUploadID */,
-                        IVSIS3LikeHandleHelper * /*poS3HandleHelper */,
-                        int /* nMaxRetry */, double /* dfRetryDelay */) override
+    bool
+    AbortMultipart(const std::string & /* osFilename */,
+                   const std::string & /* osUploadID */,
+                   IVSIS3LikeHandleHelper * /*poS3HandleHelper */,
+                   const CPLHTTPRetryParameters & /*oRetryParameters*/) override
     {
         return true;
     }
@@ -891,17 +893,11 @@ char **VSIADLSFSHandler::GetFileMetadata(const char *pszFilename,
     NetworkStatisticsAction oContextAction("GetFileMetadata");
 
     bool bRetry;
-    // coverity[tainted_data]
-    double dfRetryDelay = CPLAtof(
-        VSIGetPathSpecificOption(pszFilename, "GDAL_HTTP_RETRY_DELAY",
-                                 CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)));
-    const int nMaxRetry =
-        atoi(VSIGetPathSpecificOption(pszFilename, "GDAL_HTTP_MAX_RETRY",
-                                      CPLSPrintf("%d", CPL_HTTP_MAX_RETRY)));
-    int nRetryCount = 0;
     bool bError = true;
 
     const CPLStringList aosHTTPOptions(CPLHTTPGetOptionsFromEnv(pszFilename));
+    const CPLHTTPRetryParameters oRetryParameters(aosHTTPOptions);
+    CPLHTTPRetryContext oRetryContext(oRetryParameters);
 
     CPLStringList aosMetadata;
     do
@@ -932,20 +928,18 @@ char **VSIADLSFSHandler::GetFileMetadata(const char *pszFilename,
             requestHelper.sWriteFuncHeaderData.pBuffer == nullptr)
         {
             // Look if we should attempt a retry
-            const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
-                static_cast<int>(response_code), dfRetryDelay,
-                requestHelper.sWriteFuncHeaderData.pBuffer,
-                requestHelper.szCurlErrBuf);
-            if (dfNewRetryDelay > 0 && nRetryCount < nMaxRetry)
+            if (oRetryContext.CanRetry(
+                    static_cast<int>(response_code),
+                    requestHelper.sWriteFuncHeaderData.pBuffer,
+                    requestHelper.szCurlErrBuf))
             {
                 CPLError(CE_Warning, CPLE_AppDefined,
                          "HTTP error code: %d - %s. "
                          "Retrying again in %.1f secs",
                          static_cast<int>(response_code),
-                         poHandleHelper->GetURL().c_str(), dfRetryDelay);
-                CPLSleep(dfRetryDelay);
-                dfRetryDelay = dfNewRetryDelay;
-                nRetryCount++;
+                         poHandleHelper->GetURL().c_str(),
+                         oRetryContext.GetCurrentDelay());
+                CPLSleep(oRetryContext.GetCurrentDelay());
                 bRetry = true;
             }
             else
@@ -1024,18 +1018,11 @@ bool VSIADLSFSHandler::SetFileMetadata(const char *pszFilename,
     NetworkStatisticsAction oContextAction("SetFileMetadata");
 
     bool bRetry;
-    // coverity[tainted_data]
-    double dfRetryDelay = CPLAtof(
-        VSIGetPathSpecificOption(pszFilename, "GDAL_HTTP_RETRY_DELAY",
-                                 CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)));
-    const int nMaxRetry =
-        atoi(VSIGetPathSpecificOption(pszFilename, "GDAL_HTTP_MAX_RETRY",
-                                      CPLSPrintf("%d", CPL_HTTP_MAX_RETRY)));
-    int nRetryCount = 0;
-
     bool bRet = false;
 
     const CPLStringList aosHTTPOptions(CPLHTTPGetOptionsFromEnv(pszFilename));
+    const CPLHTTPRetryParameters oRetryParameters(aosHTTPOptions);
+    CPLHTTPRetryContext oRetryContext(oRetryParameters);
 
     do
     {
@@ -1116,20 +1103,18 @@ bool VSIADLSFSHandler::SetFileMetadata(const char *pszFilename,
         if (response_code != 200 && response_code != 202)
         {
             // Look if we should attempt a retry
-            const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
-                static_cast<int>(response_code), dfRetryDelay,
-                requestHelper.sWriteFuncHeaderData.pBuffer,
-                requestHelper.szCurlErrBuf);
-            if (dfNewRetryDelay > 0 && nRetryCount < nMaxRetry)
+            if (oRetryContext.CanRetry(
+                    static_cast<int>(response_code),
+                    requestHelper.sWriteFuncHeaderData.pBuffer,
+                    requestHelper.szCurlErrBuf))
             {
                 CPLError(CE_Warning, CPLE_AppDefined,
                          "HTTP error code: %d - %s. "
                          "Retrying again in %.1f secs",
                          static_cast<int>(response_code),
-                         poHandleHelper->GetURL().c_str(), dfRetryDelay);
-                CPLSleep(dfRetryDelay);
-                dfRetryDelay = dfNewRetryDelay;
-                nRetryCount++;
+                         poHandleHelper->GetURL().c_str(),
+                         oRetryContext.GetCurrentDelay());
+                CPLSleep(oRetryContext.GetCurrentDelay());
                 bRetry = true;
             }
             else
@@ -1224,22 +1209,14 @@ bool VSIADLSWriteHandle::Send(bool bIsLastBlock)
 bool VSIADLSWriteHandle::SendInternal(VSIADLSFSHandler::Event event,
                                       CSLConstList papszOptions)
 {
-    // coverity[tainted_data]
-    double dfRetryDelay = CPLAtof(
-        VSIGetPathSpecificOption(m_osFilename.c_str(), "GDAL_HTTP_RETRY_DELAY",
-                                 CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)));
-    const int nMaxRetry = atoi(
-        VSIGetPathSpecificOption(m_osFilename.c_str(), "GDAL_HTTP_MAX_RETRY",
-                                 CPLSPrintf("%d", CPL_HTTP_MAX_RETRY)));
-
     return cpl::down_cast<VSIADLSFSHandler *>(m_poFS)->UploadFile(
         m_osFilename, event,
         event == VSIADLSFSHandler::Event::CREATE_FILE ? 0
         : event == VSIADLSFSHandler::Event::APPEND_DATA
             ? m_nCurOffset - m_nBufferOff
             : m_nCurOffset,
-        m_pabyBuffer, m_nBufferOff, m_poHandleHelper.get(), nMaxRetry,
-        dfRetryDelay, papszOptions);
+        m_pabyBuffer, m_nBufferOff, m_poHandleHelper.get(), m_oRetryParameters,
+        papszOptions);
 }
 
 /************************************************************************/
@@ -1319,19 +1296,13 @@ int VSIADLSFSHandler::Rename(const char *oldpath, const char *newpath)
     int nRet = 0;
     bool bRetry;
 
-    // coverity[tainted_data]
-    double dfRetryDelay = CPLAtof(
-        VSIGetPathSpecificOption(oldpath, "GDAL_HTTP_RETRY_DELAY",
-                                 CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)));
-    const int nMaxRetry = atoi(VSIGetPathSpecificOption(
-        oldpath, "GDAL_HTTP_MAX_RETRY", CPLSPrintf("%d", CPL_HTTP_MAX_RETRY)));
-    int nRetryCount = 0;
-
     InvalidateCachedData(GetURLFromFilename(oldpath).c_str());
     InvalidateCachedData(GetURLFromFilename(newpath).c_str());
     InvalidateDirContent(CPLGetDirname(oldpath));
 
     const CPLStringList aosHTTPOptions(CPLHTTPGetOptionsFromEnv(oldpath));
+    const CPLHTTPRetryParameters oRetryParameters(aosHTTPOptions);
+    CPLHTTPRetryContext oRetryContext(oRetryParameters);
 
     do
     {
@@ -1365,20 +1336,18 @@ int VSIADLSFSHandler::Rename(const char *oldpath, const char *newpath)
         if (response_code != 201)
         {
             // Look if we should attempt a retry
-            const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
-                static_cast<int>(response_code), dfRetryDelay,
-                requestHelper.sWriteFuncHeaderData.pBuffer,
-                requestHelper.szCurlErrBuf);
-            if (dfNewRetryDelay > 0 && nRetryCount < nMaxRetry)
+            if (oRetryContext.CanRetry(
+                    static_cast<int>(response_code),
+                    requestHelper.sWriteFuncHeaderData.pBuffer,
+                    requestHelper.szCurlErrBuf))
             {
                 CPLError(CE_Warning, CPLE_AppDefined,
                          "HTTP error code: %d - %s. "
                          "Retrying again in %.1f secs",
                          static_cast<int>(response_code),
-                         poHandleHelper->GetURL().c_str(), dfRetryDelay);
-                CPLSleep(dfRetryDelay);
-                dfRetryDelay = dfNewRetryDelay;
-                nRetryCount++;
+                         poHandleHelper->GetURL().c_str(),
+                         oRetryContext.GetCurrentDelay());
+                CPLSleep(oRetryContext.GetCurrentDelay());
                 bRetry = true;
             }
             else
@@ -1397,7 +1366,7 @@ int VSIADLSFSHandler::Rename(const char *oldpath, const char *newpath)
                 requestHelper.sWriteFuncHeaderData.pBuffer);
             if (!osContinuation.empty())
             {
-                nRetryCount = 0;
+                oRetryContext.ResetCounter();
                 bRetry = true;
             }
         }
@@ -1462,16 +1431,9 @@ int VSIADLSFSHandler::MkdirInternal(const char *pszDirname, long nMode,
 
     bool bRetry;
 
-    // coverity[tainted_data]
-    double dfRetryDelay = CPLAtof(
-        VSIGetPathSpecificOption(pszDirname, "GDAL_HTTP_RETRY_DELAY",
-                                 CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)));
-    const int nMaxRetry =
-        atoi(VSIGetPathSpecificOption(pszDirname, "GDAL_HTTP_MAX_RETRY",
-                                      CPLSPrintf("%d", CPL_HTTP_MAX_RETRY)));
-    int nRetryCount = 0;
-
     const CPLStringList aosHTTPOptions(CPLHTTPGetOptionsFromEnv(pszDirname));
+    const CPLHTTPRetryParameters oRetryParameters(aosHTTPOptions);
+    CPLHTTPRetryContext oRetryContext(oRetryParameters);
 
     do
     {
@@ -1515,20 +1477,18 @@ int VSIADLSFSHandler::MkdirInternal(const char *pszDirname, long nMode,
         if (response_code != 201)
         {
             // Look if we should attempt a retry
-            const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
-                static_cast<int>(response_code), dfRetryDelay,
-                requestHelper.sWriteFuncHeaderData.pBuffer,
-                requestHelper.szCurlErrBuf);
-            if (dfNewRetryDelay > 0 && nRetryCount < nMaxRetry)
+            if (oRetryContext.CanRetry(
+                    static_cast<int>(response_code),
+                    requestHelper.sWriteFuncHeaderData.pBuffer,
+                    requestHelper.szCurlErrBuf))
             {
                 CPLError(CE_Warning, CPLE_AppDefined,
                          "HTTP error code: %d - %s. "
                          "Retrying again in %.1f secs",
                          static_cast<int>(response_code),
-                         poHandleHelper->GetURL().c_str(), dfRetryDelay);
-                CPLSleep(dfRetryDelay);
-                dfRetryDelay = dfNewRetryDelay;
-                nRetryCount++;
+                         poHandleHelper->GetURL().c_str(),
+                         oRetryContext.GetCurrentDelay());
+                CPLSleep(oRetryContext.GetCurrentDelay());
                 bRetry = true;
             }
             else
@@ -1623,16 +1583,9 @@ int VSIADLSFSHandler::RmdirInternal(const char *pszDirname, bool bRecursive)
     int nRet = 0;
     bool bRetry;
 
-    // coverity[tainted_data]
-    double dfRetryDelay = CPLAtof(
-        VSIGetPathSpecificOption(pszDirname, "GDAL_HTTP_RETRY_DELAY",
-                                 CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)));
-    const int nMaxRetry =
-        atoi(VSIGetPathSpecificOption(pszDirname, "GDAL_HTTP_MAX_RETRY",
-                                      CPLSPrintf("%d", CPL_HTTP_MAX_RETRY)));
-    int nRetryCount = 0;
-
     const CPLStringList aosHTTPOptions(CPLHTTPGetOptionsFromEnv(pszDirname));
+    const CPLHTTPRetryParameters oRetryParameters(aosHTTPOptions);
+    CPLHTTPRetryContext oRetryContext(oRetryParameters);
 
     do
     {
@@ -1672,20 +1625,18 @@ int VSIADLSFSHandler::RmdirInternal(const char *pszDirname, bool bRecursive)
         if (response_code != 200 && response_code != 202)
         {
             // Look if we should attempt a retry
-            const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
-                static_cast<int>(response_code), dfRetryDelay,
-                requestHelper.sWriteFuncHeaderData.pBuffer,
-                requestHelper.szCurlErrBuf);
-            if (dfNewRetryDelay > 0 && nRetryCount < nMaxRetry)
+            if (oRetryContext.CanRetry(
+                    static_cast<int>(response_code),
+                    requestHelper.sWriteFuncHeaderData.pBuffer,
+                    requestHelper.szCurlErrBuf))
             {
                 CPLError(CE_Warning, CPLE_AppDefined,
                          "HTTP error code: %d - %s. "
                          "Retrying again in %.1f secs",
                          static_cast<int>(response_code),
-                         poHandleHelper->GetURL().c_str(), dfRetryDelay);
-                CPLSleep(dfRetryDelay);
-                dfRetryDelay = dfNewRetryDelay;
-                nRetryCount++;
+                         poHandleHelper->GetURL().c_str(),
+                         oRetryContext.GetCurrentDelay());
+                CPLSleep(oRetryContext.GetCurrentDelay());
                 bRetry = true;
             }
             else
@@ -1720,7 +1671,7 @@ int VSIADLSFSHandler::RmdirInternal(const char *pszDirname, bool bRecursive)
                 requestHelper.sWriteFuncHeaderData.pBuffer);
             if (!osContinuation.empty())
             {
-                nRetryCount = 0;
+                oRetryContext.ResetCounter();
                 bRetry = true;
             }
         }
@@ -1798,15 +1749,9 @@ int VSIADLSFSHandler::CopyObject(const char *oldpath, const char *newpath,
 
     bool bRetry;
 
-    // coverity[tainted_data]
-    double dfRetryDelay = CPLAtof(
-        VSIGetPathSpecificOption(oldpath, "GDAL_HTTP_RETRY_DELAY",
-                                 CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)));
-    const int nMaxRetry = atoi(VSIGetPathSpecificOption(
-        oldpath, "GDAL_HTTP_MAX_RETRY", CPLSPrintf("%d", CPL_HTTP_MAX_RETRY)));
-    int nRetryCount = 0;
-
     const CPLStringList aosHTTPOptions(CPLHTTPGetOptionsFromEnv(oldpath));
+    const CPLHTTPRetryParameters oRetryParameters(aosHTTPOptions);
+    CPLHTTPRetryContext oRetryContext(oRetryParameters);
 
     do
     {
@@ -1833,20 +1778,18 @@ int VSIADLSFSHandler::CopyObject(const char *oldpath, const char *newpath,
         if (response_code != 202)
         {
             // Look if we should attempt a retry
-            const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
-                static_cast<int>(response_code), dfRetryDelay,
-                requestHelper.sWriteFuncHeaderData.pBuffer,
-                requestHelper.szCurlErrBuf);
-            if (dfNewRetryDelay > 0 && nRetryCount < nMaxRetry)
+            if (oRetryContext.CanRetry(
+                    static_cast<int>(response_code),
+                    requestHelper.sWriteFuncHeaderData.pBuffer,
+                    requestHelper.szCurlErrBuf))
             {
                 CPLError(CE_Warning, CPLE_AppDefined,
                          "HTTP error code: %d - %s. "
                          "Retrying again in %.1f secs",
                          static_cast<int>(response_code),
-                         poAzHandleHelper->GetURL().c_str(), dfRetryDelay);
-                CPLSleep(dfRetryDelay);
-                dfRetryDelay = dfNewRetryDelay;
-                nRetryCount++;
+                         poAzHandleHelper->GetURL().c_str(),
+                         oRetryContext.GetCurrentDelay());
+                CPLSleep(oRetryContext.GetCurrentDelay());
                 bRetry = true;
             }
             else
@@ -1883,12 +1826,11 @@ int VSIADLSFSHandler::CopyObject(const char *oldpath, const char *newpath,
 /*                          UploadFile()                                */
 /************************************************************************/
 
-bool VSIADLSFSHandler::UploadFile(const std::string &osFilename, Event event,
-                                  vsi_l_offset nPosition,
-                                  const void *pabyBuffer, size_t nBufferSize,
-                                  IVSIS3LikeHandleHelper *poHandleHelper,
-                                  int nMaxRetry, double dfRetryDelay,
-                                  CSLConstList papszOptions)
+bool VSIADLSFSHandler::UploadFile(
+    const std::string &osFilename, Event event, vsi_l_offset nPosition,
+    const void *pabyBuffer, size_t nBufferSize,
+    IVSIS3LikeHandleHelper *poHandleHelper,
+    const CPLHTTPRetryParameters &oRetryParameters, CSLConstList papszOptions)
 {
     NetworkStatisticsFileSystem oContextFS(GetFSPrefix().c_str());
     NetworkStatisticsFile oContextFile(osFilename.c_str());
@@ -1904,7 +1846,7 @@ bool VSIADLSFSHandler::UploadFile(const std::string &osFilename, Event event,
         CPLHTTPGetOptionsFromEnv(osFilename.c_str()));
 
     bool bSuccess = true;
-    int nRetryCount = 0;
+    CPLHTTPRetryContext oRetryContext(oRetryParameters);
     bool bRetry;
     do
     {
@@ -1987,20 +1929,18 @@ bool VSIADLSFSHandler::UploadFile(const std::string &osFilename, Event event,
             response_code != 202)
         {
             // Look if we should attempt a retry
-            const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
-                static_cast<int>(response_code), dfRetryDelay,
-                requestHelper.sWriteFuncHeaderData.pBuffer,
-                requestHelper.szCurlErrBuf);
-            if (dfNewRetryDelay > 0 && nRetryCount < nMaxRetry)
+            if (oRetryContext.CanRetry(
+                    static_cast<int>(response_code),
+                    requestHelper.sWriteFuncHeaderData.pBuffer,
+                    requestHelper.szCurlErrBuf))
             {
                 CPLError(CE_Warning, CPLE_AppDefined,
                          "HTTP error code: %d - %s. "
                          "Retrying again in %.1f secs",
                          static_cast<int>(response_code),
-                         poHandleHelper->GetURL().c_str(), dfRetryDelay);
-                CPLSleep(dfRetryDelay);
-                dfRetryDelay = dfNewRetryDelay;
-                nRetryCount++;
+                         poHandleHelper->GetURL().c_str(),
+                         oRetryContext.GetCurrentDelay());
+                CPLSleep(oRetryContext.GetCurrentDelay());
                 bRetry = true;
             }
             else

--- a/port/cpl_vsil_az.cpp
+++ b/port/cpl_vsil_az.cpp
@@ -598,12 +598,12 @@ class VSIAzureFSHandler final : public IVSIS3LikeFSHandler
     std::string PutBlock(const std::string &osFilename, int nPartNumber,
                          const void *pabyBuffer, size_t nBufferSize,
                          IVSIS3LikeHandleHelper *poS3HandleHelper,
-                         int nMaxRetry, double dfRetryDelay,
+                         const CPLHTTPRetryParameters &oRetryParameters,
                          CSLConstList papszOptions);
     bool PutBlockList(const std::string &osFilename,
                       const std::vector<std::string> &aosBlockIds,
-                      IVSIS3LikeHandleHelper *poS3HandleHelper, int nMaxRetry,
-                      double dfRetryDelay);
+                      IVSIS3LikeHandleHelper *poS3HandleHelper,
+                      const CPLHTTPRetryParameters &oRetryParameters);
 
     // Multipart upload (mapping of S3 interface to PutBlock/PutBlockList)
 
@@ -612,11 +612,10 @@ class VSIAzureFSHandler final : public IVSIS3LikeFSHandler
         return true;
     }
 
-    std::string
-    InitiateMultipartUpload(const std::string & /* osFilename */,
-                            IVSIS3LikeHandleHelper *, int /* nMaxRetry */,
-                            double /* dfRetryDelay */,
-                            CSLConstList /* papszOptions */) override
+    std::string InitiateMultipartUpload(
+        const std::string & /* osFilename */, IVSIS3LikeHandleHelper *,
+        const CPLHTTPRetryParameters & /* oRetryParameters */,
+        CSLConstList /* papszOptions */) override
     {
         return "dummy";
     }
@@ -626,29 +625,28 @@ class VSIAzureFSHandler final : public IVSIS3LikeFSHandler
                            vsi_l_offset /* nPosition */, const void *pabyBuffer,
                            size_t nBufferSize,
                            IVSIS3LikeHandleHelper *poS3HandleHelper,
-                           int nMaxRetry, double dfRetryDelay,
+                           const CPLHTTPRetryParameters &oRetryParameters,
                            CSLConstList papszOptions) override
     {
         return PutBlock(osFilename, nPartNumber, pabyBuffer, nBufferSize,
-                        poS3HandleHelper, nMaxRetry, dfRetryDelay,
-                        papszOptions);
+                        poS3HandleHelper, oRetryParameters, papszOptions);
     }
 
-    bool CompleteMultipart(const std::string &osFilename,
-                           const std::string & /* osUploadID */,
-                           const std::vector<std::string> &aosEtags,
-                           vsi_l_offset /* nTotalSize */,
-                           IVSIS3LikeHandleHelper *poS3HandleHelper,
-                           int nMaxRetry, double dfRetryDelay) override
+    bool CompleteMultipart(
+        const std::string &osFilename, const std::string & /* osUploadID */,
+        const std::vector<std::string> &aosEtags, vsi_l_offset /* nTotalSize */,
+        IVSIS3LikeHandleHelper *poS3HandleHelper,
+        const CPLHTTPRetryParameters &oRetryParameters) override
     {
-        return PutBlockList(osFilename, aosEtags, poS3HandleHelper, nMaxRetry,
-                            dfRetryDelay);
+        return PutBlockList(osFilename, aosEtags, poS3HandleHelper,
+                            oRetryParameters);
     }
 
-    bool AbortMultipart(const std::string & /* osFilename */,
-                        const std::string & /* osUploadID */,
-                        IVSIS3LikeHandleHelper * /*poS3HandleHelper */,
-                        int /* nMaxRetry */, double /* dfRetryDelay */) override
+    bool AbortMultipart(
+        const std::string & /* osFilename */,
+        const std::string & /* osUploadID */,
+        IVSIS3LikeHandleHelper * /*poS3HandleHelper */,
+        const CPLHTTPRetryParameters & /* oRetryParameters */) override
     {
         return true;
     }
@@ -850,17 +848,11 @@ char **VSIAzureFSHandler::GetFileMetadata(const char *pszFilename,
     NetworkStatisticsAction oContextAction("GetFileMetadata");
 
     bool bRetry;
-    // coverity[tainted_data]
-    double dfRetryDelay = CPLAtof(
-        VSIGetPathSpecificOption(pszFilename, "GDAL_HTTP_RETRY_DELAY",
-                                 CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)));
-    const int nMaxRetry =
-        atoi(VSIGetPathSpecificOption(pszFilename, "GDAL_HTTP_MAX_RETRY",
-                                      CPLSPrintf("%d", CPL_HTTP_MAX_RETRY)));
-    int nRetryCount = 0;
     bool bError = true;
 
     const CPLStringList aosHTTPOptions(CPLHTTPGetOptionsFromEnv(pszFilename));
+    const CPLHTTPRetryParameters oRetryParameters(aosHTTPOptions);
+    CPLHTTPRetryContext oRetryContext(oRetryParameters);
 
     CPLStringList aosMetadata;
     do
@@ -890,20 +882,18 @@ char **VSIAzureFSHandler::GetFileMetadata(const char *pszFilename,
             requestHelper.sWriteFuncHeaderData.pBuffer == nullptr)
         {
             // Look if we should attempt a retry
-            const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
-                static_cast<int>(response_code), dfRetryDelay,
-                requestHelper.sWriteFuncHeaderData.pBuffer,
-                requestHelper.szCurlErrBuf);
-            if (dfNewRetryDelay > 0 && nRetryCount < nMaxRetry)
+            if (oRetryContext.CanRetry(
+                    static_cast<int>(response_code),
+                    requestHelper.sWriteFuncHeaderData.pBuffer,
+                    requestHelper.szCurlErrBuf))
             {
                 CPLError(CE_Warning, CPLE_AppDefined,
                          "HTTP error code: %d - %s. "
                          "Retrying again in %.1f secs",
                          static_cast<int>(response_code),
-                         poHandleHelper->GetURL().c_str(), dfRetryDelay);
-                CPLSleep(dfRetryDelay);
-                dfRetryDelay = dfNewRetryDelay;
-                nRetryCount++;
+                         poHandleHelper->GetURL().c_str(),
+                         oRetryContext.GetCurrentDelay());
+                CPLSleep(oRetryContext.GetCurrentDelay());
                 bRetry = true;
             }
             else
@@ -1001,15 +991,9 @@ bool VSIAzureFSHandler::SetFileMetadata(const char *pszFilename,
     NetworkStatisticsAction oContextAction("SetFileMetadata");
 
     bool bRetry;
-    // coverity[tainted_data]
-    double dfRetryDelay = CPLAtof(
-        VSIGetPathSpecificOption(pszFilename, "GDAL_HTTP_RETRY_DELAY",
-                                 CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)));
-    const int nMaxRetry =
-        atoi(VSIGetPathSpecificOption(pszFilename, "GDAL_HTTP_MAX_RETRY",
-                                      CPLSPrintf("%d", CPL_HTTP_MAX_RETRY)));
-    int nRetryCount = 0;
-
+    const CPLStringList aosHTTPOptions(CPLHTTPGetOptionsFromEnv(pszFilename));
+    const CPLHTTPRetryParameters oRetryParameters(aosHTTPOptions);
+    CPLHTTPRetryContext oRetryContext(oRetryParameters);
     bool bRet = false;
 
     // Compose XML content for TAGS
@@ -1041,8 +1025,6 @@ bool VSIAzureFSHandler::SetFileMetadata(const char *pszFilename,
         CPLFree(pszXML);
         CPLDestroyXMLNode(psXML);
     }
-
-    const CPLStringList aosHTTPOptions(CPLHTTPGetOptionsFromEnv(pszFilename));
 
     do
     {
@@ -1114,20 +1096,18 @@ bool VSIAzureFSHandler::SetFileMetadata(const char *pszFilename,
         if (response_code != 200 && response_code != 204)
         {
             // Look if we should attempt a retry
-            const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
-                static_cast<int>(response_code), dfRetryDelay,
-                requestHelper.sWriteFuncHeaderData.pBuffer,
-                requestHelper.szCurlErrBuf);
-            if (dfNewRetryDelay > 0 && nRetryCount < nMaxRetry)
+            if (oRetryContext.CanRetry(
+                    static_cast<int>(response_code),
+                    requestHelper.sWriteFuncHeaderData.pBuffer,
+                    requestHelper.szCurlErrBuf))
             {
                 CPLError(CE_Warning, CPLE_AppDefined,
                          "HTTP error code: %d - %s. "
                          "Retrying again in %.1f secs",
                          static_cast<int>(response_code),
-                         poHandleHelper->GetURL().c_str(), dfRetryDelay);
-                CPLSleep(dfRetryDelay);
-                dfRetryDelay = dfNewRetryDelay;
-                nRetryCount++;
+                         poHandleHelper->GetURL().c_str(),
+                         oRetryContext.GetCurrentDelay());
+                CPLSleep(oRetryContext.GetCurrentDelay());
                 bRetry = true;
             }
             else
@@ -1255,14 +1235,7 @@ bool VSIAzureWriteHandle::SendInternal(bool bInitOnly, bool bIsLastBlock)
         bIsLastBlock &&
         (m_nCurOffset <= static_cast<vsi_l_offset>(m_nBufferSize));
 
-    // coverity[tainted_data]
-    double dfRetryDelay = CPLAtof(
-        VSIGetPathSpecificOption(m_osFilename.c_str(), "GDAL_HTTP_RETRY_DELAY",
-                                 CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)));
-    const int nMaxRetry = atoi(
-        VSIGetPathSpecificOption(m_osFilename.c_str(), "GDAL_HTTP_MAX_RETRY",
-                                 CPLSPrintf("%d", CPL_HTTP_MAX_RETRY)));
-    int nRetryCount = 0;
+    CPLHTTPRetryContext oRetryContext(m_oRetryParameters);
     bool bHasAlreadyHandled409 = false;
     bool bRetry;
 
@@ -1350,20 +1323,18 @@ bool VSIAzureWriteHandle::SendInternal(bool bInitOnly, bool bIsLastBlock)
         else if (response_code != 201)
         {
             // Look if we should attempt a retry
-            const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
-                static_cast<int>(response_code), dfRetryDelay,
-                requestHelper.sWriteFuncHeaderData.pBuffer,
-                requestHelper.szCurlErrBuf);
-            if (dfNewRetryDelay > 0 && nRetryCount < nMaxRetry)
+            if (oRetryContext.CanRetry(
+                    static_cast<int>(response_code),
+                    requestHelper.sWriteFuncHeaderData.pBuffer,
+                    requestHelper.szCurlErrBuf))
             {
                 CPLError(CE_Warning, CPLE_AppDefined,
                          "HTTP error code: %d - %s. "
                          "Retrying again in %.1f secs",
                          static_cast<int>(response_code),
-                         m_poHandleHelper->GetURL().c_str(), dfRetryDelay);
-                CPLSleep(dfRetryDelay);
-                dfRetryDelay = dfNewRetryDelay;
-                nRetryCount++;
+                         m_poHandleHelper->GetURL().c_str(),
+                         oRetryContext.GetCurrentDelay());
+                CPLSleep(oRetryContext.GetCurrentDelay());
                 bRetry = true;
             }
             else
@@ -1490,13 +1461,9 @@ int *VSIAzureFSHandler::UnlinkBatch(CSLConstList papszFiles)
     NetworkStatisticsFileSystem oContextFS(GetFSPrefix().c_str());
     NetworkStatisticsAction oContextAction("UnlinkBatch");
 
-    // coverity[tainted_data]
-    double dfRetryDelay = CPLAtof(
-        VSIGetPathSpecificOption(pszFirstFilename, "GDAL_HTTP_RETRY_DELAY",
-                                 CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)));
-    const int nMaxRetry =
-        atoi(VSIGetPathSpecificOption(pszFirstFilename, "GDAL_HTTP_MAX_RETRY",
-                                      CPLSPrintf("%d", CPL_HTTP_MAX_RETRY)));
+    const CPLStringList aosHTTPOptions(
+        CPLHTTPGetOptionsFromEnv(pszFirstFilename));
+    const CPLHTTPRetryParameters oRetryParameters(aosHTTPOptions);
 
     // For debug / testing only
     const int nBatchSize =
@@ -1504,13 +1471,10 @@ int *VSIAzureFSHandler::UnlinkBatch(CSLConstList papszFiles)
                                       "CPL_VSIAZ_UNLINK_BATCH_SIZE", "256"))));
     std::string osPOSTContent;
 
-    const CPLStringList aosHTTPOptions(
-        CPLHTTPGetOptionsFromEnv(pszFirstFilename));
-
     int nFilesInBatch = 0;
     int nFirstIDInBatch = 0;
 
-    const auto DoPOST = [this, panRet, &nFilesInBatch, &dfRetryDelay, nMaxRetry,
+    const auto DoPOST = [this, panRet, &nFilesInBatch, &oRetryParameters,
                          &aosHTTPOptions, &poHandleHelper, &osPOSTContent,
                          &nFirstIDInBatch](int nLastID)
     {
@@ -1521,7 +1485,7 @@ int *VSIAzureFSHandler::UnlinkBatch(CSLConstList papszFiles)
 #endif
 
         // Run request
-        int nRetryCount = 0;
+        CPLHTTPRetryContext oRetryContext(oRetryParameters);
         bool bRetry;
         std::string osResponse;
         do
@@ -1559,20 +1523,18 @@ int *VSIAzureFSHandler::UnlinkBatch(CSLConstList papszFiles)
                 requestHelper.sWriteFuncData.pBuffer == nullptr)
             {
                 // Look if we should attempt a retry
-                const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
-                    static_cast<int>(response_code), dfRetryDelay,
-                    requestHelper.sWriteFuncHeaderData.pBuffer,
-                    requestHelper.szCurlErrBuf);
-                if (dfNewRetryDelay > 0 && nRetryCount < nMaxRetry)
+                if (oRetryContext.CanRetry(
+                        static_cast<int>(response_code),
+                        requestHelper.sWriteFuncHeaderData.pBuffer,
+                        requestHelper.szCurlErrBuf))
                 {
                     CPLError(CE_Warning, CPLE_AppDefined,
                              "HTTP error code: %d - %s. "
                              "Retrying again in %.1f secs",
                              static_cast<int>(response_code),
-                             poHandleHelper->GetURL().c_str(), dfRetryDelay);
-                    CPLSleep(dfRetryDelay);
-                    dfRetryDelay = dfNewRetryDelay;
-                    nRetryCount++;
+                             poHandleHelper->GetURL().c_str(),
+                             oRetryContext.GetCurrentDelay());
+                    CPLSleep(oRetryContext.GetCurrentDelay());
                     bRetry = true;
                 }
                 else
@@ -1770,17 +1732,10 @@ int VSIAzureFSHandler::CreateContainer(const std::string &osDirname)
 
     bool bRetry;
 
-    // coverity[tainted_data]
-    double dfRetryDelay = CPLAtof(
-        VSIGetPathSpecificOption(osDirname.c_str(), "GDAL_HTTP_RETRY_DELAY",
-                                 CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)));
-    const int nMaxRetry =
-        atoi(VSIGetPathSpecificOption(osDirname.c_str(), "GDAL_HTTP_MAX_RETRY",
-                                      CPLSPrintf("%d", CPL_HTTP_MAX_RETRY)));
-    int nRetryCount = 0;
-
     const CPLStringList aosHTTPOptions(
         CPLHTTPGetOptionsFromEnv(osDirname.c_str()));
+    const CPLHTTPRetryParameters oRetryParameters(aosHTTPOptions);
+    CPLHTTPRetryContext oRetryContext(oRetryParameters);
 
     do
     {
@@ -1807,20 +1762,18 @@ int VSIAzureFSHandler::CreateContainer(const std::string &osDirname)
         if (response_code != 201)
         {
             // Look if we should attempt a retry
-            const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
-                static_cast<int>(response_code), dfRetryDelay,
-                requestHelper.sWriteFuncHeaderData.pBuffer,
-                requestHelper.szCurlErrBuf);
-            if (dfNewRetryDelay > 0 && nRetryCount < nMaxRetry)
+            if (oRetryContext.CanRetry(
+                    static_cast<int>(response_code),
+                    requestHelper.sWriteFuncHeaderData.pBuffer,
+                    requestHelper.szCurlErrBuf))
             {
                 CPLError(CE_Warning, CPLE_AppDefined,
                          "HTTP error code: %d - %s. "
                          "Retrying again in %.1f secs",
                          static_cast<int>(response_code),
-                         poS3HandleHelper->GetURL().c_str(), dfRetryDelay);
-                CPLSleep(dfRetryDelay);
-                dfRetryDelay = dfNewRetryDelay;
-                nRetryCount++;
+                         poS3HandleHelper->GetURL().c_str(),
+                         oRetryContext.GetCurrentDelay());
+                CPLSleep(oRetryContext.GetCurrentDelay());
                 bRetry = true;
             }
             else
@@ -1939,17 +1892,10 @@ int VSIAzureFSHandler::DeleteContainer(const std::string &osDirname)
 
     bool bRetry;
 
-    // coverity[tainted_data]
-    double dfRetryDelay = CPLAtof(
-        VSIGetPathSpecificOption(osDirname.c_str(), "GDAL_HTTP_RETRY_DELAY",
-                                 CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)));
-    const int nMaxRetry =
-        atoi(VSIGetPathSpecificOption(osDirname.c_str(), "GDAL_HTTP_MAX_RETRY",
-                                      CPLSPrintf("%d", CPL_HTTP_MAX_RETRY)));
-    int nRetryCount = 0;
-
     const CPLStringList aosHTTPOptions(
         CPLHTTPGetOptionsFromEnv(osDirname.c_str()));
+    const CPLHTTPRetryParameters oRetryParameters(aosHTTPOptions);
+    CPLHTTPRetryContext oRetryContext(oRetryParameters);
 
     do
     {
@@ -1977,20 +1923,18 @@ int VSIAzureFSHandler::DeleteContainer(const std::string &osDirname)
         if (response_code != 202)
         {
             // Look if we should attempt a retry
-            const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
-                static_cast<int>(response_code), dfRetryDelay,
-                requestHelper.sWriteFuncHeaderData.pBuffer,
-                requestHelper.szCurlErrBuf);
-            if (dfNewRetryDelay > 0 && nRetryCount < nMaxRetry)
+            if (oRetryContext.CanRetry(
+                    static_cast<int>(response_code),
+                    requestHelper.sWriteFuncHeaderData.pBuffer,
+                    requestHelper.szCurlErrBuf))
             {
                 CPLError(CE_Warning, CPLE_AppDefined,
                          "HTTP error code: %d - %s. "
                          "Retrying again in %.1f secs",
                          static_cast<int>(response_code),
-                         poS3HandleHelper->GetURL().c_str(), dfRetryDelay);
-                CPLSleep(dfRetryDelay);
-                dfRetryDelay = dfNewRetryDelay;
-                nRetryCount++;
+                         poS3HandleHelper->GetURL().c_str(),
+                         oRetryContext.GetCurrentDelay());
+                CPLSleep(oRetryContext.GetCurrentDelay());
                 bRetry = true;
             }
             else
@@ -2118,15 +2062,9 @@ int VSIAzureFSHandler::CopyObject(const char *oldpath, const char *newpath,
 
     bool bRetry;
 
-    // coverity[tainted_data]
-    double dfRetryDelay = CPLAtof(
-        VSIGetPathSpecificOption(oldpath, "GDAL_HTTP_RETRY_DELAY",
-                                 CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)));
-    const int nMaxRetry = atoi(VSIGetPathSpecificOption(
-        oldpath, "GDAL_HTTP_MAX_RETRY", CPLSPrintf("%d", CPL_HTTP_MAX_RETRY)));
-    int nRetryCount = 0;
-
     const CPLStringList aosHTTPOptions(CPLHTTPGetOptionsFromEnv(oldpath));
+    const CPLHTTPRetryParameters oRetryParameters(aosHTTPOptions);
+    CPLHTTPRetryContext oRetryContext(oRetryParameters);
 
     do
     {
@@ -2153,20 +2091,18 @@ int VSIAzureFSHandler::CopyObject(const char *oldpath, const char *newpath,
         if (response_code != 202)
         {
             // Look if we should attempt a retry
-            const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
-                static_cast<int>(response_code), dfRetryDelay,
-                requestHelper.sWriteFuncHeaderData.pBuffer,
-                requestHelper.szCurlErrBuf);
-            if (dfNewRetryDelay > 0 && nRetryCount < nMaxRetry)
+            if (oRetryContext.CanRetry(
+                    static_cast<int>(response_code),
+                    requestHelper.sWriteFuncHeaderData.pBuffer,
+                    requestHelper.szCurlErrBuf))
             {
                 CPLError(CE_Warning, CPLE_AppDefined,
                          "HTTP error code: %d - %s. "
                          "Retrying again in %.1f secs",
                          static_cast<int>(response_code),
-                         poHandleHelper->GetURL().c_str(), dfRetryDelay);
-                CPLSleep(dfRetryDelay);
-                dfRetryDelay = dfNewRetryDelay;
-                nRetryCount++;
+                         poHandleHelper->GetURL().c_str(),
+                         oRetryContext.GetCurrentDelay());
+                CPLSleep(oRetryContext.GetCurrentDelay());
                 bRetry = true;
             }
             else
@@ -2205,15 +2141,15 @@ int VSIAzureFSHandler::CopyObject(const char *oldpath, const char *newpath,
 
 std::string VSIAzureFSHandler::PutBlock(
     const std::string &osFilename, int nPartNumber, const void *pabyBuffer,
-    size_t nBufferSize, IVSIS3LikeHandleHelper *poS3HandleHelper, int nMaxRetry,
-    double dfRetryDelay, CSLConstList papszOptions)
+    size_t nBufferSize, IVSIS3LikeHandleHelper *poS3HandleHelper,
+    const CPLHTTPRetryParameters &oRetryParameters, CSLConstList papszOptions)
 {
     NetworkStatisticsFileSystem oContextFS(GetFSPrefix().c_str());
     NetworkStatisticsFile oContextFile(osFilename.c_str());
     NetworkStatisticsAction oContextAction("PutBlock");
 
     bool bRetry;
-    int nRetryCount = 0;
+    CPLHTTPRetryContext oRetryContext(oRetryParameters);
     std::string osBlockId(CPLSPrintf("%012d", nPartNumber));
 
     const std::string osContentLength(
@@ -2278,20 +2214,18 @@ std::string VSIAzureFSHandler::PutBlock(
                  requestHelper.sWriteFuncHeaderData.pBuffer == nullptr)
         {
             // Look if we should attempt a retry
-            const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
-                static_cast<int>(response_code), dfRetryDelay,
-                requestHelper.sWriteFuncHeaderData.pBuffer,
-                requestHelper.szCurlErrBuf);
-            if (dfNewRetryDelay > 0 && nRetryCount < nMaxRetry)
+            if (oRetryContext.CanRetry(
+                    static_cast<int>(response_code),
+                    requestHelper.sWriteFuncHeaderData.pBuffer,
+                    requestHelper.szCurlErrBuf))
             {
                 CPLError(CE_Warning, CPLE_AppDefined,
                          "HTTP error code: %d - %s. "
                          "Retrying again in %.1f secs",
                          static_cast<int>(response_code),
-                         poS3HandleHelper->GetURL().c_str(), dfRetryDelay);
-                CPLSleep(dfRetryDelay);
-                dfRetryDelay = dfNewRetryDelay;
-                nRetryCount++;
+                         poS3HandleHelper->GetURL().c_str(),
+                         oRetryContext.GetCurrentDelay());
+                CPLSleep(oRetryContext.GetCurrentDelay());
                 bRetry = true;
             }
             else
@@ -2319,8 +2253,8 @@ std::string VSIAzureFSHandler::PutBlock(
 
 bool VSIAzureFSHandler::PutBlockList(
     const std::string &osFilename, const std::vector<std::string> &aosBlockIds,
-    IVSIS3LikeHandleHelper *poS3HandleHelper, int nMaxRetry,
-    double dfRetryDelay)
+    IVSIS3LikeHandleHelper *poS3HandleHelper,
+    const CPLHTTPRetryParameters &oRetryParameters)
 {
     bool bSuccess = true;
 
@@ -2342,7 +2276,7 @@ bool VSIAzureFSHandler::PutBlockList(
     const CPLStringList aosHTTPOptions(
         CPLHTTPGetOptionsFromEnv(osFilename.c_str()));
 
-    int nRetryCount = 0;
+    CPLHTTPRetryContext oRetryContext(oRetryParameters);
     bool bRetry;
     do
     {
@@ -2381,20 +2315,18 @@ bool VSIAzureFSHandler::PutBlockList(
         if (response_code != 201)
         {
             // Look if we should attempt a retry
-            const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
-                static_cast<int>(response_code), dfRetryDelay,
-                requestHelper.sWriteFuncHeaderData.pBuffer,
-                requestHelper.szCurlErrBuf);
-            if (dfNewRetryDelay > 0 && nRetryCount < nMaxRetry)
+            if (oRetryContext.CanRetry(
+                    static_cast<int>(response_code),
+                    requestHelper.sWriteFuncHeaderData.pBuffer,
+                    requestHelper.szCurlErrBuf))
             {
                 CPLError(CE_Warning, CPLE_AppDefined,
                          "HTTP error code: %d - %s. "
                          "Retrying again in %.1f secs",
                          static_cast<int>(response_code),
-                         poS3HandleHelper->GetURL().c_str(), dfRetryDelay);
-                CPLSleep(dfRetryDelay);
-                dfRetryDelay = dfNewRetryDelay;
-                nRetryCount++;
+                         poS3HandleHelper->GetURL().c_str(),
+                         oRetryContext.GetCurrentDelay());
+                CPLSleep(oRetryContext.GetCurrentDelay());
                 bRetry = true;
             }
             else

--- a/port/cpl_vsil_curl.cpp
+++ b/port/cpl_vsil_curl.cpp
@@ -298,10 +298,9 @@ static int VSICurlIsFileInList(char **papszList, const char *pszTarget)
 /************************************************************************/
 
 static std::string VSICurlGetURLFromFilename(
-    const char *pszFilename, int *pnMaxRetry, double *pdfRetryDelay,
-    std::string *posRetryCodes, bool *pbUseHead,
-    bool *pbUseRedirectURLIfNoQueryStringParams, bool *pbListDir,
-    bool *pbEmptyDir, char ***ppapszHTTPOptions,
+    const char *pszFilename, CPLHTTPRetryParameters *poRetryParameters,
+    bool *pbUseHead, bool *pbUseRedirectURLIfNoQueryStringParams,
+    bool *pbListDir, bool *pbEmptyDir, CPLStringList *paosHTTPOptions,
     bool *pbPlanetaryComputerURLSigning, char **ppszPlanetaryComputerCollection)
 {
     if (ppszPlanetaryComputerCollection)
@@ -349,18 +348,18 @@ static std::string VSICurlGetURLFromFilename(
             {
                 if (EQUAL(pszKey, "max_retry"))
                 {
-                    if (pnMaxRetry)
-                        *pnMaxRetry = atoi(pszValue);
+                    if (poRetryParameters)
+                        poRetryParameters->nMaxRetry = atoi(pszValue);
                 }
                 else if (EQUAL(pszKey, "retry_delay"))
                 {
-                    if (pdfRetryDelay)
-                        *pdfRetryDelay = CPLAtof(pszValue);
+                    if (poRetryParameters)
+                        poRetryParameters->dfInitialDelay = CPLAtof(pszValue);
                 }
                 else if (EQUAL(pszKey, "retry_codes"))
                 {
-                    if (posRetryCodes)
-                        *posRetryCodes = pszValue;
+                    if (poRetryParameters)
+                        poRetryParameters->osRetryCodes = pszValue;
                 }
                 else if (EQUAL(pszKey, "use_head"))
                 {
@@ -403,10 +402,9 @@ static std::string VSICurlGetURLFromFilename(
                 {
                     // Above names are the ones supported by
                     // CPLHTTPSetOptions()
-                    if (ppapszHTTPOptions)
+                    if (paosHTTPOptions)
                     {
-                        *ppapszHTTPOptions = CSLSetNameValue(*ppapszHTTPOptions,
-                                                             pszKey, pszValue);
+                        paosHTTPOptions->SetNameValue(pszKey, pszValue);
                     }
                 }
                 else if (EQUAL(pszKey, "url"))
@@ -458,16 +456,11 @@ namespace cpl
 VSICurlHandle::VSICurlHandle(VSICurlFilesystemHandlerBase *poFSIn,
                              const char *pszFilename, const char *pszURLIn)
     : poFS(poFSIn), m_osFilename(pszFilename),
-      m_nMaxRetry(atoi(CPLGetConfigOption(
-          "GDAL_HTTP_MAX_RETRY", CPLSPrintf("%d", CPL_HTTP_MAX_RETRY)))),
-      // coverity[tainted_data]
-      m_dfRetryDelay(CPLAtof(CPLGetConfigOption(
-          "GDAL_HTTP_RETRY_DELAY", CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)))),
-      m_osRetryCodes(CPLGetConfigOption("GDAL_HTTP_RETRY_CODES", "")),
+      m_aosHTTPOptions(CPLHTTPGetOptionsFromEnv(pszFilename)),
+      m_oRetryParameters(m_aosHTTPOptions),
       m_bUseHead(
           CPLTestBool(CPLGetConfigOption("CPL_VSIL_CURL_USE_HEAD", "YES")))
 {
-    m_papszHTTPOptions = CPLHTTPGetOptionsFromEnv(pszFilename);
     if (pszURLIn)
     {
         m_pszURL = CPLStrdup(pszURLIn);
@@ -475,13 +468,13 @@ VSICurlHandle::VSICurlHandle(VSICurlFilesystemHandlerBase *poFSIn,
     else
     {
         char *pszPCCollection = nullptr;
-        m_pszURL = CPLStrdup(
-            VSICurlGetURLFromFilename(
-                pszFilename, &m_nMaxRetry, &m_dfRetryDelay, &m_osRetryCodes,
-                &m_bUseHead, &m_bUseRedirectURLIfNoQueryStringParams, nullptr,
-                nullptr, &m_papszHTTPOptions, &m_bPlanetaryComputerURLSigning,
-                &pszPCCollection)
-                .c_str());
+        m_pszURL =
+            CPLStrdup(VSICurlGetURLFromFilename(
+                          pszFilename, &m_oRetryParameters, &m_bUseHead,
+                          &m_bUseRedirectURLIfNoQueryStringParams, nullptr,
+                          nullptr, &m_aosHTTPOptions,
+                          &m_bPlanetaryComputerURLSigning, &pszPCCollection)
+                          .c_str());
         if (pszPCCollection)
             m_osPlanetaryComputerCollection = pszPCCollection;
         CPLFree(pszPCCollection);
@@ -508,7 +501,6 @@ VSICurlHandle::~VSICurlHandle()
         poFS->InvalidateDirContent(CPLGetDirname(m_osFilename.c_str()));
     }
     CPLFree(m_pszURL);
-    CSLDestroy(m_papszHTTPOptions);
 }
 
 /************************************************************************/
@@ -1080,14 +1072,13 @@ vsi_l_offset VSICurlHandle::GetFileSizeOrHeaders(bool bSetError,
     std::string osURL(m_pszURL + m_osQueryString);
     bool bRetryWithGet = false;
     bool bS3LikeRedirect = false;
-    int nRetryCount = 0;
-    double dfRetryDelay = m_dfRetryDelay;
+    CPLHTTPRetryContext oRetryContext(m_oRetryParameters);
 
 retry:
     CURL *hCurlHandle = curl_easy_init();
 
     struct curl_slist *headers =
-        VSICurlSetOptions(hCurlHandle, osURL.c_str(), m_papszHTTPOptions);
+        VSICurlSetOptions(hCurlHandle, osURL.c_str(), m_aosHTTPOptions.List());
 
     WriteFuncStruct sWriteFuncHeaderData;
     VSICURLInitWriteFuncStruct(&sWriteFuncHeaderData, nullptr, nullptr,
@@ -1453,20 +1444,16 @@ retry:
         else if (response_code != 200)
         {
             // Look if we should attempt a retry
-            const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
-                static_cast<int>(response_code), dfRetryDelay,
-                sWriteFuncHeaderData.pBuffer, szCurlErrBuf,
-                m_osRetryCodes.c_str());
-            if (dfNewRetryDelay > 0 && nRetryCount < m_nMaxRetry)
+            if (oRetryContext.CanRetry(static_cast<int>(response_code),
+                                       sWriteFuncHeaderData.pBuffer,
+                                       szCurlErrBuf))
             {
                 CPLError(CE_Warning, CPLE_AppDefined,
                          "HTTP error code: %d - %s. "
                          "Retrying again in %.1f secs",
                          static_cast<int>(response_code), m_pszURL,
-                         dfRetryDelay);
-                CPLSleep(dfRetryDelay);
-                dfRetryDelay = dfNewRetryDelay;
-                nRetryCount++;
+                         oRetryContext.GetCurrentDelay());
+                CPLSleep(oRetryContext.GetCurrentDelay());
                 CPLFree(sWriteFuncData.pBuffer);
                 CPLFree(sWriteFuncHeaderData.pBuffer);
                 curl_easy_cleanup(hCurlHandle);
@@ -1814,13 +1801,12 @@ begin:
 
     WriteFuncStruct sWriteFuncData;
     WriteFuncStruct sWriteFuncHeaderData;
-    int nRetryCount = 0;
-    double dfRetryDelay = m_dfRetryDelay;
+    CPLHTTPRetryContext oRetryContext(m_oRetryParameters);
 
 retry:
     CURL *hCurlHandle = curl_easy_init();
     struct curl_slist *headers =
-        VSICurlSetOptions(hCurlHandle, osURL.c_str(), m_papszHTTPOptions);
+        VSICurlSetOptions(hCurlHandle, osURL.c_str(), m_aosHTTPOptions.List());
 
     if (!AllowAutomaticRedirection())
         unchecked_curl_easy_setopt(hCurlHandle, CURLOPT_FOLLOWLOCATION, 0);
@@ -1942,13 +1928,12 @@ retry:
         goto retry;
     }
 
-    if (response_code == 401 && nRetryCount < m_nMaxRetry)
+    if (response_code == 401 && oRetryContext.CanRetry())
     {
         CPLDebug(poFS->GetDebugKey(), "Unauthorized, trying to authenticate");
         CPLFree(sWriteFuncData.pBuffer);
         CPLFree(sWriteFuncHeaderData.pBuffer);
         curl_easy_cleanup(hCurlHandle);
-        nRetryCount++;
         if (Authenticate(m_osFilename.c_str()))
             goto retry;
         return std::string();
@@ -1973,18 +1958,15 @@ retry:
         }
 
         // Look if we should attempt a retry
-        const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
-            static_cast<int>(response_code), dfRetryDelay,
-            sWriteFuncHeaderData.pBuffer, szCurlErrBuf, m_osRetryCodes.c_str());
-        if (dfNewRetryDelay > 0 && nRetryCount < m_nMaxRetry)
+        if (oRetryContext.CanRetry(static_cast<int>(response_code),
+                                   sWriteFuncHeaderData.pBuffer, szCurlErrBuf))
         {
             CPLError(CE_Warning, CPLE_AppDefined,
                      "HTTP error code: %d - %s. "
                      "Retrying again in %.1f secs",
-                     static_cast<int>(response_code), m_pszURL, dfRetryDelay);
-            CPLSleep(dfRetryDelay);
-            dfRetryDelay = dfNewRetryDelay;
-            nRetryCount++;
+                     static_cast<int>(response_code), m_pszURL,
+                     oRetryContext.GetCurrentDelay());
+            CPLSleep(oRetryContext.GetCurrentDelay());
             CPLFree(sWriteFuncData.pBuffer);
             CPLFree(sWriteFuncHeaderData.pBuffer);
             curl_easy_cleanup(hCurlHandle);
@@ -2448,8 +2430,8 @@ int VSICurlHandle::ReadMultiRange(int const nRanges, void **const ppData,
         // need to wait as we already know if pipelining is possible
         // unchecked_curl_easy_setopt(hCurlHandle, CURLOPT_PIPEWAIT, 1);
 
-        struct curl_slist *headers =
-            VSICurlSetOptions(hCurlHandle, osURL.c_str(), m_papszHTTPOptions);
+        struct curl_slist *headers = VSICurlSetOptions(
+            hCurlHandle, osURL.c_str(), m_aosHTTPOptions.List());
 
         VSICURLInitWriteFuncStruct(&asWriteFuncData[iRequest], this, pfnReadCbk,
                                    pReadCbkUserData);
@@ -2669,7 +2651,7 @@ int VSICurlHandle::ReadMultiRangeSingleGet(int const nRanges,
     CURL *hCurlHandle = curl_easy_init();
 
     struct curl_slist *headers =
-        VSICurlSetOptions(hCurlHandle, m_pszURL, m_papszHTTPOptions);
+        VSICurlSetOptions(hCurlHandle, m_pszURL, m_aosHTTPOptions.List());
 
     WriteFuncStruct sWriteFuncData;
     WriteFuncStruct sWriteFuncHeaderData;
@@ -3052,7 +3034,7 @@ size_t VSICurlHandle::PRead(void *pBuffer, size_t nSize,
     CURL *hCurlHandle = curl_easy_init();
 
     struct curl_slist *headers =
-        VSICurlSetOptions(hCurlHandle, osURL.c_str(), m_papszHTTPOptions);
+        VSICurlSetOptions(hCurlHandle, osURL.c_str(), m_aosHTTPOptions.List());
 
     WriteFuncStruct sWriteFuncData;
     VSICURLInitWriteFuncStruct(&sWriteFuncData, nullptr, nullptr, nullptr);
@@ -3326,7 +3308,7 @@ void VSICurlHandle::AdviseRead(int nRanges, const vsi_l_offset *panOffsets,
             // unchecked_curl_easy_setopt(hCurlHandle, CURLOPT_PIPEWAIT, 1);
 
             struct curl_slist *headers = VSICurlSetOptions(
-                hCurlHandle, osURL.c_str(), m_papszHTTPOptions);
+                hCurlHandle, osURL.c_str(), m_aosHTTPOptions.List());
 
             VSICURLInitWriteFuncStruct(&asWriteFuncData[i], this, pfnReadCbk,
                                        pReadCbkUserData);
@@ -4140,9 +4122,9 @@ VSIVirtualHandle *VSICurlFilesystemHandlerBase::Open(const char *pszFilename,
 
     bool bListDir = true;
     bool bEmptyDir = false;
-    CPL_IGNORE_RET_VAL(VSICurlGetURLFromFilename(
-        pszFilename, nullptr, nullptr, nullptr, nullptr, nullptr, &bListDir,
-        &bEmptyDir, nullptr, nullptr, nullptr));
+    CPL_IGNORE_RET_VAL(VSICurlGetURLFromFilename(pszFilename, nullptr, nullptr,
+                                                 nullptr, &bListDir, &bEmptyDir,
+                                                 nullptr, nullptr, nullptr));
 
     const char *pszOptionVal = CSLFetchNameValueDef(
         papszOptions, "DISABLE_READDIR_ON_OPEN",
@@ -4400,9 +4382,9 @@ char **VSICurlFilesystemHandlerBase::ParseHTMLFileList(const char *pszFilename,
 {
     *pbGotFileList = false;
 
-    std::string osURL(VSICurlGetURLFromFilename(
-        pszFilename, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr,
-        nullptr, nullptr, nullptr, nullptr));
+    std::string osURL(VSICurlGetURLFromFilename(pszFilename, nullptr, nullptr,
+                                                nullptr, nullptr, nullptr,
+                                                nullptr, nullptr, nullptr));
     const char *pszDir = nullptr;
     if (STARTS_WITH_CI(osURL.c_str(), "http://"))
         pszDir = strchr(osURL.c_str() + strlen("http://"), '/');
@@ -4763,7 +4745,7 @@ VSICurlFilesystemHandlerBase::GetURLFromFilename(const std::string &osFilename)
 {
     return VSICurlGetURLFromFilename(osFilename.c_str(), nullptr, nullptr,
                                      nullptr, nullptr, nullptr, nullptr,
-                                     nullptr, nullptr, nullptr, nullptr);
+                                     nullptr, nullptr);
 }
 
 /************************************************************************/
@@ -4795,8 +4777,8 @@ char **VSICurlFilesystemHandlerBase::GetFileList(const char *pszDirname,
     bool bListDir = true;
     bool bEmptyDir = false;
     const std::string osURL(VSICurlGetURLFromFilename(
-        pszDirname, nullptr, nullptr, nullptr, nullptr, nullptr, &bListDir,
-        &bEmptyDir, nullptr, nullptr, nullptr));
+        pszDirname, nullptr, nullptr, nullptr, &bListDir, &bEmptyDir, nullptr,
+        nullptr, nullptr));
     if (bEmptyDir)
     {
         *pbGotFileList = true;
@@ -5121,9 +5103,9 @@ int VSICurlFilesystemHandlerBase::Stat(const char *pszFilename,
 
     bool bListDir = true;
     bool bEmptyDir = false;
-    std::string osURL(VSICurlGetURLFromFilename(
-        pszFilename, nullptr, nullptr, nullptr, nullptr, nullptr, &bListDir,
-        &bEmptyDir, nullptr, nullptr, nullptr));
+    std::string osURL(VSICurlGetURLFromFilename(pszFilename, nullptr, nullptr,
+                                                nullptr, &bListDir, &bEmptyDir,
+                                                nullptr, nullptr, nullptr));
 
     const char *pszOptionVal = VSIGetPathSpecificOption(
         pszFilename, "GDAL_DISABLE_READDIR_ON_OPEN", "NO");
@@ -5392,6 +5374,7 @@ VSIAppendWriteHandle::VSIAppendWriteHandle(VSICurlFilesystemHandlerBase *poFS,
                                            const char *pszFilename,
                                            int nChunkSize)
     : m_poFS(poFS), m_osFSPrefix(pszFSPrefix), m_osFilename(pszFilename),
+      m_oRetryParameters(CPLStringList(CPLHTTPGetOptionsFromEnv(pszFilename))),
       m_nBufferSize(nChunkSize)
 {
     m_pabyBuffer = static_cast<GByte *>(VSIMalloc(m_nBufferSize));

--- a/port/cpl_vsil_curl_class.h
+++ b/port/cpl_vsil_curl_class.h
@@ -382,7 +382,9 @@ class VSICurlHandle : public VSIVirtualHandle
     char *m_pszURL = nullptr;    // e.g "http://example.com/foo"
     mutable std::string m_osQueryString{};  // e.g. an Azure SAS
 
-    char **m_papszHTTPOptions = nullptr;
+    CPLStringList m_aosHTTPOptions{};
+    CPLHTTPRetryParameters
+        m_oRetryParameters;  // must be initialized in constructor
 
     vsi_l_offset lastDownloadedOffset = VSI_L_OFFSET_MAX;
     int nBlocksToDownload = 1;
@@ -391,10 +393,6 @@ class VSICurlHandle : public VSIVirtualHandle
     bool bInterrupted = false;
     VSICurlReadCbkFunc pfnReadCbk = nullptr;
     void *pReadCbkUserData = nullptr;
-
-    int m_nMaxRetry = 0;
-    double m_dfRetryDelay = 0.0;
-    std::string m_osRetryCodes{};
 
     CPLStringList m_aosHeaders{};
 
@@ -651,25 +649,27 @@ class IVSIS3LikeFSHandler : public VSICurlFilesystemHandlerBaseWritable
         return false;
     }
 
-    virtual std::string InitiateMultipartUpload(
-        const std::string &osFilename, IVSIS3LikeHandleHelper *poS3HandleHelper,
-        int nMaxRetry, double dfRetryDelay, CSLConstList papszOptions);
+    virtual std::string
+    InitiateMultipartUpload(const std::string &osFilename,
+                            IVSIS3LikeHandleHelper *poS3HandleHelper,
+                            const CPLHTTPRetryParameters &oRetryParameters,
+                            CSLConstList papszOptions);
     virtual std::string
     UploadPart(const std::string &osFilename, int nPartNumber,
                const std::string &osUploadID, vsi_l_offset nPosition,
                const void *pabyBuffer, size_t nBufferSize,
-               IVSIS3LikeHandleHelper *poS3HandleHelper, int nMaxRetry,
-               double dfRetryDelay, CSLConstList papszOptions);
-    virtual bool CompleteMultipart(const std::string &osFilename,
-                                   const std::string &osUploadID,
-                                   const std::vector<std::string> &aosEtags,
-                                   vsi_l_offset nTotalSize,
-                                   IVSIS3LikeHandleHelper *poS3HandleHelper,
-                                   int nMaxRetry, double dfRetryDelay);
+               IVSIS3LikeHandleHelper *poS3HandleHelper,
+               const CPLHTTPRetryParameters &oRetryParameters,
+               CSLConstList papszOptions);
+    virtual bool CompleteMultipart(
+        const std::string &osFilename, const std::string &osUploadID,
+        const std::vector<std::string> &aosEtags, vsi_l_offset nTotalSize,
+        IVSIS3LikeHandleHelper *poS3HandleHelper,
+        const CPLHTTPRetryParameters &oRetryParameters);
     virtual bool AbortMultipart(const std::string &osFilename,
                                 const std::string &osUploadID,
                                 IVSIS3LikeHandleHelper *poS3HandleHelper,
-                                int nMaxRetry, double dfRetryDelay);
+                                const CPLHTTPRetryParameters &oRetryParameters);
 
     bool AbortPendingUploads(const char *pszFilename) override;
 
@@ -730,6 +730,7 @@ class VSIS3WriteHandle final : public VSIVirtualHandle
     bool m_bUseChunked = false;
     CPLStringList m_aosOptions{};
     CPLStringList m_aosHTTPOptions{};
+    CPLHTTPRetryParameters m_oRetryParameters;
 
     vsi_l_offset m_nCurOffset = 0;
     int m_nBufferOff = 0;
@@ -749,8 +750,6 @@ class VSIS3WriteHandle final : public VSIVirtualHandle
     size_t m_nChunkedBufferSize = 0;
     size_t m_nWrittenInPUT = 0;
 
-    int m_nMaxRetry = 0;
-    double m_dfRetryDelay = 0.0;
     WriteFuncStruct m_sWriteFuncHeaderData{};
 
     bool UploadPart();
@@ -794,6 +793,7 @@ class VSIAppendWriteHandle : public VSIVirtualHandle
     VSICurlFilesystemHandlerBase *m_poFS = nullptr;
     std::string m_osFSPrefix{};
     std::string m_osFilename{};
+    CPLHTTPRetryParameters m_oRetryParameters{};
 
     vsi_l_offset m_nCurOffset = 0;
     int m_nBufferOff = 0;

--- a/port/cpl_vsil_curl_class.h
+++ b/port/cpl_vsil_curl_class.h
@@ -394,6 +394,7 @@ class VSICurlHandle : public VSIVirtualHandle
 
     int m_nMaxRetry = 0;
     double m_dfRetryDelay = 0.0;
+    std::string m_osRetryCodes{};
 
     CPLStringList m_aosHeaders{};
 

--- a/port/cpl_vsil_curl_streaming.cpp
+++ b/port/cpl_vsil_curl_streaming.cpp
@@ -261,7 +261,8 @@ class VSICurlStreamingHandle : public VSIVirtualHandle
 
   protected:
     VSICurlStreamingFSHandler *m_poFS = nullptr;
-    char **m_papszHTTPOptions = nullptr;
+    CPLStringList m_aosHTTPOptions{};
+    const CPLHTTPRetryParameters m_oRetryParameters;
 
   private:
     char *m_pszURL = nullptr;
@@ -377,9 +378,9 @@ class VSICurlStreamingHandle : public VSIVirtualHandle
 
 VSICurlStreamingHandle::VSICurlStreamingHandle(VSICurlStreamingFSHandler *poFS,
                                                const char *pszURL)
-    : m_poFS(poFS), m_papszHTTPOptions(CPLHTTPGetOptionsFromEnv(
+    : m_poFS(poFS), m_aosHTTPOptions(CPLHTTPGetOptionsFromEnv(
                         (poFS->GetFSPrefix() + pszURL).c_str())),
-      m_pszURL(CPLStrdup(pszURL))
+      m_oRetryParameters(m_aosHTTPOptions), m_pszURL(CPLStrdup(pszURL))
 {
     FileProp cachedFileProp;
     poFS->GetCachedFileProp(pszURL, cachedFileProp);
@@ -406,7 +407,6 @@ VSICurlStreamingHandle::~VSICurlStreamingHandle()
     StopDownload();
 
     CPLFree(m_pszURL);
-    CSLDestroy(m_papszHTTPOptions);
 
     CPLFree(pCachedData);
 
@@ -573,7 +573,7 @@ vsi_l_offset VSICurlStreamingHandle::GetFileSize()
     CURL *hLocalHandle = curl_easy_init();
 
     struct curl_slist *headers =
-        VSICurlSetOptions(hLocalHandle, m_pszURL, m_papszHTTPOptions);
+        VSICurlSetOptions(hLocalHandle, m_pszURL, m_aosHTTPOptions.List());
 
     VSICURLStreamingInitWriteFuncStructStreaming(&sWriteFuncHeaderData);
 
@@ -1010,7 +1010,7 @@ void VSICurlStreamingHandle::DownloadInThread()
     CURL *hCurlHandle = curl_easy_init();
 
     struct curl_slist *headers =
-        VSICurlSetOptions(hCurlHandle, m_pszURL, m_papszHTTPOptions);
+        VSICurlSetOptions(hCurlHandle, m_pszURL, m_aosHTTPOptions.List());
     headers = VSICurlMergeHeaders(headers, GetCurlHeaders("GET", headers));
     unchecked_curl_easy_setopt(hCurlHandle, CURLOPT_HTTPHEADER, headers);
 
@@ -1192,8 +1192,7 @@ size_t VSICurlStreamingHandle::Read(void *const pBuffer, size_t const nSize,
     if (nBufferRequestSize == 0)
         return 0;
 
-    int nRetryCount = 0;
-    double dfRetryDelay = 0;
+    CPLHTTPRetryContext oRetryContext(m_oRetryParameters);
 
 retry:
     GByte *pabyBuffer = static_cast<GByte *>(pBuffer);
@@ -1421,30 +1420,21 @@ retry:
 
     if (bErrorOccurred)
     {
-        const int nMaxRetry = atoi(CPLGetConfigOption(
-            "GDAL_HTTP_MAX_RETRY", CPLSPrintf("%d", CPL_HTTP_MAX_RETRY)));
-        // coverity[tainted_data]
-        if (dfRetryDelay == 0)
-            dfRetryDelay = CPLAtof(
-                CPLGetConfigOption("GDAL_HTTP_RETRY_DELAY",
-                                   CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)));
-
         // Look if we should attempt a retry
         AcquireMutex();
-        const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
-            static_cast<int>(nHTTPCode), dfRetryDelay, nullptr, m_szCurlErrBuf);
+        const bool bRetry = oRetryContext.CanRetry(static_cast<int>(nHTTPCode),
+                                                   nullptr, m_szCurlErrBuf);
         ReleaseMutex();
-        if (dfNewRetryDelay > 0 && nRetryCount < nMaxRetry)
+        if (bRetry)
         {
             StopDownload();
 
             CPLError(CE_Warning, CPLE_AppDefined,
                      "HTTP error code: %d - %s. "
                      "Retrying again in %.1f secs",
-                     static_cast<int>(nHTTPCode), m_pszURL, dfRetryDelay);
-            CPLSleep(dfRetryDelay);
-            dfRetryDelay = dfNewRetryDelay;
-            nRetryCount++;
+                     static_cast<int>(nHTTPCode), m_pszURL,
+                     oRetryContext.GetCurrentDelay());
+            CPLSleep(oRetryContext.GetCurrentDelay());
             curOffset = curOffsetOri;
             goto retry;
         }

--- a/port/cpl_vsil_gs.cpp
+++ b/port/cpl_vsil_gs.cpp
@@ -339,17 +339,10 @@ char **VSIGSFSHandler::GetFileMetadata(const char *pszFilename,
     NetworkStatisticsAction oContextAction("GetFileMetadata");
 
     const CPLStringList aosHTTPOptions(CPLHTTPGetOptionsFromEnv(pszFilename));
+    const CPLHTTPRetryParameters oRetryParameters(aosHTTPOptions);
+    CPLHTTPRetryContext oRetryContext(oRetryParameters);
 
     bool bRetry;
-    // coverity[tainted_data]
-    double dfRetryDelay = CPLAtof(
-        VSIGetPathSpecificOption(pszFilename, "GDAL_HTTP_RETRY_DELAY",
-                                 CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)));
-    const int nMaxRetry =
-        atoi(VSIGetPathSpecificOption(pszFilename, "GDAL_HTTP_MAX_RETRY",
-                                      CPLSPrintf("%d", CPL_HTTP_MAX_RETRY)));
-    int nRetryCount = 0;
-
     CPLStringList aosResult;
     do
     {
@@ -373,20 +366,18 @@ char **VSIGSFSHandler::GetFileMetadata(const char *pszFilename,
             requestHelper.sWriteFuncData.pBuffer == nullptr)
         {
             // Look if we should attempt a retry
-            const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
-                static_cast<int>(response_code), dfRetryDelay,
-                requestHelper.sWriteFuncHeaderData.pBuffer,
-                requestHelper.szCurlErrBuf);
-            if (dfNewRetryDelay > 0 && nRetryCount < nMaxRetry)
+            if (oRetryContext.CanRetry(
+                    static_cast<int>(response_code),
+                    requestHelper.sWriteFuncHeaderData.pBuffer,
+                    requestHelper.szCurlErrBuf))
             {
                 CPLError(CE_Warning, CPLE_AppDefined,
                          "HTTP error code: %d - %s. "
                          "Retrying again in %.1f secs",
                          static_cast<int>(response_code),
-                         poHandleHelper->GetURL().c_str(), dfRetryDelay);
-                CPLSleep(dfRetryDelay);
-                dfRetryDelay = dfNewRetryDelay;
-                nRetryCount++;
+                         poHandleHelper->GetURL().c_str(),
+                         oRetryContext.GetCurrentDelay());
+                CPLSleep(oRetryContext.GetCurrentDelay());
                 bRetry = true;
             }
             else
@@ -450,18 +441,11 @@ bool VSIGSFSHandler::SetFileMetadata(const char *pszFilename,
     NetworkStatisticsAction oContextAction("SetFileMetadata");
 
     bool bRetry;
-    // coverity[tainted_data]
-    double dfRetryDelay = CPLAtof(
-        VSIGetPathSpecificOption(pszFilename, "GDAL_HTTP_RETRY_DELAY",
-                                 CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)));
-    const int nMaxRetry =
-        atoi(VSIGetPathSpecificOption(pszFilename, "GDAL_HTTP_MAX_RETRY",
-                                      CPLSPrintf("%d", CPL_HTTP_MAX_RETRY)));
-    int nRetryCount = 0;
-
     bool bRet = false;
 
     const CPLStringList aosHTTPOptions(CPLHTTPGetOptionsFromEnv(pszFilename));
+    const CPLHTTPRetryParameters oRetryParameters(aosHTTPOptions);
+    CPLHTTPRetryContext oRetryContext(oRetryParameters);
 
     do
     {
@@ -487,20 +471,18 @@ bool VSIGSFSHandler::SetFileMetadata(const char *pszFilename,
         if (response_code != 200)
         {
             // Look if we should attempt a retry
-            const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
-                static_cast<int>(response_code), dfRetryDelay,
-                requestHelper.sWriteFuncHeaderData.pBuffer,
-                requestHelper.szCurlErrBuf);
-            if (dfNewRetryDelay > 0 && nRetryCount < nMaxRetry)
+            if (oRetryContext.CanRetry(
+                    static_cast<int>(response_code),
+                    requestHelper.sWriteFuncHeaderData.pBuffer,
+                    requestHelper.szCurlErrBuf))
             {
                 CPLError(CE_Warning, CPLE_AppDefined,
                          "HTTP error code: %d - %s. "
                          "Retrying again in %.1f secs",
                          static_cast<int>(response_code),
-                         poHandleHelper->GetURL().c_str(), dfRetryDelay);
-                CPLSleep(dfRetryDelay);
-                dfRetryDelay = dfNewRetryDelay;
-                nRetryCount++;
+                         poHandleHelper->GetURL().c_str(),
+                         oRetryContext.GetCurrentDelay());
+                CPLSleep(oRetryContext.GetCurrentDelay());
                 bRetry = true;
             }
             else
@@ -559,14 +541,6 @@ int *VSIGSFSHandler::UnlinkBatch(CSLConstList papszFiles)
     NetworkStatisticsFileSystem oContextFS(GetFSPrefix().c_str());
     NetworkStatisticsAction oContextAction("UnlinkBatch");
 
-    // coverity[tainted_data]
-    double dfRetryDelay = CPLAtof(
-        VSIGetPathSpecificOption(pszFirstFilename, "GDAL_HTTP_RETRY_DELAY",
-                                 CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)));
-    const int nMaxRetry =
-        atoi(VSIGetPathSpecificOption(pszFirstFilename, "GDAL_HTTP_MAX_RETRY",
-                                      CPLSPrintf("%d", CPL_HTTP_MAX_RETRY)));
-
     // For debug / testing only
     const int nBatchSize =
         std::max(1, std::min(100, atoi(CPLGetConfigOption(
@@ -575,6 +549,8 @@ int *VSIGSFSHandler::UnlinkBatch(CSLConstList papszFiles)
 
     const CPLStringList aosHTTPOptions(
         CPLHTTPGetOptionsFromEnv(pszFirstFilename));
+    const CPLHTTPRetryParameters oRetryParameters(aosHTTPOptions);
+    CPLHTTPRetryContext oRetryContext(oRetryParameters);
 
     for (int i = 0; papszFiles && papszFiles[i]; i++)
     {
@@ -654,7 +630,6 @@ int *VSIGSFSHandler::UnlinkBatch(CSLConstList papszFiles)
 #endif
 
             // Run request
-            int nRetryCount = 0;
             bool bRetry;
             std::string osResponse;
             do
@@ -691,21 +666,18 @@ int *VSIGSFSHandler::UnlinkBatch(CSLConstList papszFiles)
                     requestHelper.sWriteFuncData.pBuffer == nullptr)
                 {
                     // Look if we should attempt a retry
-                    const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
-                        static_cast<int>(response_code), dfRetryDelay,
-                        requestHelper.sWriteFuncHeaderData.pBuffer,
-                        requestHelper.szCurlErrBuf);
-                    if (dfNewRetryDelay > 0 && nRetryCount < nMaxRetry)
+                    if (oRetryContext.CanRetry(
+                            static_cast<int>(response_code),
+                            requestHelper.sWriteFuncHeaderData.pBuffer,
+                            requestHelper.szCurlErrBuf))
                     {
                         CPLError(CE_Warning, CPLE_AppDefined,
                                  "HTTP error code: %d - %s. "
                                  "Retrying again in %.1f secs",
                                  static_cast<int>(response_code),
                                  poHandleHelper->GetURL().c_str(),
-                                 dfRetryDelay);
-                        CPLSleep(dfRetryDelay);
-                        dfRetryDelay = dfNewRetryDelay;
-                        nRetryCount++;
+                                 oRetryContext.GetCurrentDelay());
+                        CPLSleep(oRetryContext.GetCurrentDelay());
                         bRetry = true;
                     }
                     else

--- a/port/cpl_vsil_swift.cpp
+++ b/port/cpl_vsil_swift.cpp
@@ -553,15 +553,13 @@ char **VSISwiftFSHandler::GetFileList(const char *pszDirname, int nMaxFiles,
     const std::string osPrefix(osObjectKey.empty() ? std::string()
                                                    : osObjectKey + "/");
 
+    const CPLStringList aosHTTPOptions(CPLHTTPGetOptionsFromEnv(pszDirname));
+    const CPLHTTPRetryParameters oRetryParameters(aosHTTPOptions);
+
     while (true)
     {
+        CPLHTTPRetryContext oRetryContext(oRetryParameters);
         bool bRetry;
-        int nRetryCount = 0;
-        const int nMaxRetry = atoi(CPLGetConfigOption(
-            "GDAL_HTTP_MAX_RETRY", CPLSPrintf("%d", CPL_HTTP_MAX_RETRY)));
-        // coverity[tainted_data]
-        double dfRetryDelay = CPLAtof(CPLGetConfigOption(
-            "GDAL_HTTP_RETRY_DELAY", CPLSPrintf("%f", CPL_HTTP_RETRY_DELAY)));
         do
         {
             bRetry = false;
@@ -633,19 +631,17 @@ char **VSISwiftFSHandler::GetFileList(const char *pszDirname, int nMaxFiles,
             if (response_code != 200)
             {
                 // Look if we should attempt a retry
-                const double dfNewRetryDelay = CPLHTTPGetNewRetryDelay(
-                    static_cast<int>(response_code), dfRetryDelay,
-                    sWriteFuncHeaderData.pBuffer, szCurlErrBuf);
-                if (dfNewRetryDelay > 0 && nRetryCount < nMaxRetry)
+                if (oRetryContext.CanRetry(static_cast<int>(response_code),
+                                           sWriteFuncHeaderData.pBuffer,
+                                           szCurlErrBuf))
                 {
                     CPLError(CE_Warning, CPLE_AppDefined,
                              "HTTP error code: %d - %s. "
                              "Retrying again in %.1f secs",
                              static_cast<int>(response_code),
-                             poS3HandleHelper->GetURL().c_str(), dfRetryDelay);
-                    CPLSleep(dfRetryDelay);
-                    dfRetryDelay = dfNewRetryDelay;
-                    nRetryCount++;
+                             poS3HandleHelper->GetURL().c_str(),
+                             oRetryContext.GetCurrentDelay());
+                    CPLSleep(oRetryContext.GetCurrentDelay());
                     bRetry = true;
                     CPLFree(sWriteFuncData.pBuffer);
                     CPLFree(sWriteFuncHeaderData.pBuffer);


### PR DESCRIPTION
*  CPLHTTPFetch(): add a RETRY_CODES option (GDAL_HTTP_RETRY_CODES config option)
    
    Fixes #9941
    
    ```
    -  .. config:: GDAL_HTTP_RETRY_CODES
          :choices: ALL or comma-separated list of codes
          :since: 3.10
    
          Specify which HTTP error codes should trigger a retry attempt.
          Valid values are ``ALL`` or a comma-separated list of HTTP codes.
          By default, 429, 500, 502, 503 or 504 HTTP errors are considered, as
          well as other situations with a particular HTTP or Curl error message.
    ```

*  Add C++ facilities for HTTP retry logic

