### PR TITLE
Update sql_sqlite_dialect.rst avoiding unexplained case change

### DIFF
--- a/doc/source/user/sql_sqlite_dialect.rst
+++ b/doc/source/user/sql_sqlite_dialect.rst
@@ -127,7 +127,8 @@ For OGR layers that have a non-empty geometry column name (generally for RDBMS d
 as returned by OGRLayer::GetGeometryColumn(), the name of the geometry special field
 in the SQL statement will be the name of the geometry column of the underlying OGR layer.
 If the name of the geometry column in the source layer is empty, like with shapefiles etc.,
-the name to use in the SQL statement is always "geometry".
+the name to use in the SQL statement is always "geometry". Here we'll use it case-insensitively
+(as all field names are in a SELECT statement):
 
 .. code-block::
 


### PR DESCRIPTION
(Else the reader thinks, "Hey, you said 'geometry', and then you use 'GEOMETRY'!")
