### PR TITLE
MiraMonVector: Fixing chromium bug 68809 correctly

### DIFF
--- a/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
+++ b/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
@@ -4409,7 +4409,10 @@ static int MMCreateRecordDBF(struct MiraMonVectLayerInfo *hMiraMonLayer,
     if (hMiraMonLayer->TopHeader.nElemCount == 0)
     {
         if (MMCreateMMDB(hMiraMonLayer, nullptr))
+        {
+            MMDestroyMMDB(hMiraMonLayer);
             return MM_FATAL_ERROR_WRITING_FEATURES;
+        }
     }
 
     result = MMAddDBFRecordToMMDB(hMiraMonLayer, hMMFeature);


### PR DESCRIPTION
## What does this PR do?
Fixes chromium bug 68809.

The error was not to free the table MMDB when the first feature is created and fails. This table is created only when the first feature is successfully created. If is not successfully created this table has to be deleted.

## What are related issues/pull requests?
https://github.com/OSGeo/gdal/pull/9954

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] All CI builds and checks have passed except the ones below
 - [x] Verify that conda macos 14 check fail is not this PR fault
 - [ ] ⚠️ Coverage reporter does not yet know how to process this file: build-coverage/gdal_filtered.info