### PR TITLE
Update ogrinfo.rst to mention vital prefix method

### DIFF
--- a/doc/source/programs/ogrinfo.rst
+++ b/doc/source/programs/ogrinfo.rst
@@ -226,6 +226,7 @@ edit data.
 
     The data source to open. May be a filename, directory or other virtual
     name. See the OGR Vector Formats list for supported datasources.
+    A prefix may be used to force choosing a particular driver. See example below.
 
 .. option:: <layer>
 
@@ -528,4 +529,14 @@ Adding a column to an input file:
 
    ogrinfo input.shp -sql "ALTER TABLE input ADD fieldX float"
 
+Using a prefix to force opening with a particular driver:
 
+.. code-block:: bash
+
+    ogrinfo --formats | grep -i json
+      GeoJSON -vector- (rw+v): GeoJSON
+      GeoJSONSeq -vector- (rw+v): GeoJSON Sequence ...
+
+    ogrinfo GeoJSONSeq:file.json
+    INFO: Open of `file.GeoJSONSeq:file.json'
+          using driver `GeoJSONSeq' successful.


### PR DESCRIPTION
Without mentioning this, we see that sometimes
its just hit and miss what driver will be selected.
```
$ ogrinfo --formats|
 perl -awnle 'next unless /json/i; print $F[0];'|
 xargs -n 1 ogrinfo --format|egrep Extension\|Long\ N
  Long Name: GeoJSON
  Extensions: json geojson
  Long Name: GeoJSON Sequence
  Extensions: geojsonl geojsons
  Long Name: ESRIJSON
  Extension: json
  Long Name: TopoJSON
  Extensions: json topojson
 ```
Yes, individual driver pages do mention what I am mentioning here on ogrinfo, but only here do I tie them all together.