### PR TITLE
Update ogr2ogr.rst fixing grammar

### DIFF
--- a/doc/source/programs/ogr2ogr.rst
+++ b/doc/source/programs/ogr2ogr.rst
@@ -145,9 +145,9 @@ output coordinate system or even reprojecting the features during translation.
 
 .. option:: -dialect <dialect>
 
-    SQL dialect. In some cases can be used to use (unoptimized) :ref:`ogr_sql_dialect` instead
+    SQL dialect. In some cases can be used to use the (unoptimized) :ref:`ogr_sql_dialect` instead
     of the native SQL of an RDBMS by passing the ``OGRSQL`` dialect value.
-    The :ref:`sql_sqlite_dialect` dialect can be select with the ``SQLITE``
+    The :ref:`sql_sqlite_dialect` dialect can be chosen with the ``SQLITE``
     and ``INDIRECT_SQLITE`` dialect values, and this can be used with any datasource.
 
 .. option:: -where <restricted_where>


### PR DESCRIPTION
Yes, we could have just said "selected" to fix the grammar error, but that is too much like SELECT.

In fact the ogr2ogr man page, and perhaps others, have the exact same paragraph. So do consider moving  this to a single  "include" file.