### PR TITLE
OGRSQL: validate column name in COUNT(field_name)

### DIFF
--- a/autotest/ogr/ogr_sql_test.py
+++ b/autotest/ogr/ogr_sql_test.py
@@ -784,8 +784,10 @@ def test_ogr_sql_28():
         "SELECT COUNT(*) FROM",
         "SELECT COUNT(*) AS foo FROM",
         "SELECT COUNT(* FROM my_layer",
+        "SELECT COUNT(i_dont_exist) FROM my_layer",
         "SELECT COUNT(FOO intfield) FROM my_layer",
         "SELECT COUNT(DISTINCT intfield FROM my_layer",
+        "SELECT COUNT(DISTINCT i_dont_exist) FROM my_layer",
         "SELECT COUNT(DISTINCT *) FROM my_layer",
         "SELECT FOO(DISTINCT intfield) FROM my_layer",
         "SELECT FOO(DISTINCT intfield) as foo FROM my_layer",
@@ -1084,7 +1086,7 @@ def test_ogr_sql_36():
 # Test select count([distinct] column) with null values (#4354)
 
 
-def test_ogr_sql_37():
+def test_ogr_sql_count_and_null():
 
     ds = ogr.GetDriverByName("Memory").CreateDataSource("ogr_sql_37")
     lyr = ds.CreateLayer("layer")

--- a/ogr/ogrsf_frmts/generic/ogr_gensql.cpp
+++ b/ogr/ogrsf_frmts/generic/ogr_gensql.cpp
@@ -901,7 +901,7 @@ int OGRGenSQLResultsLayer::PrepareSummary()
 
     /* -------------------------------------------------------------------- */
     /*      We treat COUNT(*) as a special case, and fill with              */
-    /*      GetFeatureCount().                                            */
+    /*      GetFeatureCount().                                              */
     /* -------------------------------------------------------------------- */
 
     if (psSelectInfo->result_columns() == 1 &&

--- a/ogr/swq_select.cpp
+++ b/ogr/swq_select.cpp
@@ -981,7 +981,8 @@ CPLErr swq_select::parse(swq_field_list *field_list,
             // Record field type.
             def->field_type = this_type;
 
-            if (def->field_index == -1 && def->col_func != SWQCF_COUNT)
+            if (def->field_index == -1 && !(def->col_func == SWQCF_COUNT &&
+                                            strcmp(def->field_name, "*") == 0))
             {
                 CPLError(
                     CE_Failure, CPLE_AppDefined, "Unrecognized field name %s.",


### PR DESCRIPTION
and error out if it doesn't exist, otherwise it evaluates as COUNT(*)

Fixes #9972
