### PR TITLE
CI: linux_build.yml: remove pin to coverage-reporter-version v0.6.10

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -343,8 +343,6 @@ jobs:
         with:
           format: lcov
           file: build-coverage/gdal_filtered.info
-          # Pin to v0.6.10 because of issue with v0.6.11 (https://github.com/coverallsapp/coverage-reporter/issues/127)
-          coverage-reporter-version: v0.6.10
 
       - name: Push build environment
         if: github.event_name == 'push'


### PR DESCRIPTION
now that v0.6.12 is out with a fix
