### PR TITLE
LIBKML: fix handling of styleUrl element referencing to an external document

### DIFF
--- a/autotest/ogr/data/kml/point_with_external_style.kml
+++ b/autotest/ogr/data/kml/point_with_external_style.kml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+  <Document id="root_doc">
+    <Document id="point">
+      <name>point</name>
+      <Placemark id="point.1">
+        <name>my point</name>
+        <styleUrl>style_of_point_with_external_style/style.kml#myStyle</styleUrl>
+        <Point><coordinates>2,49,0</coordinates></Point>
+      </Placemark>
+    </Document>
+  </Document>
+</kml>

--- a/autotest/ogr/data/kml/style_of_point_with_external_style/style.kml
+++ b/autotest/ogr/data/kml/style_of_point_with_external_style/style.kml
@@ -1,0 +1,14 @@
+<kml xmlns="http://www.opengis.net/kml/2.2">
+    <Document>
+        <Style id="myStyle">
+            <LabelStyle>
+                <color>ffffffff</color>
+                <scale>1.1</scale>
+            </LabelStyle>
+            <BalloonStyle>
+                <bgColor>ff00ffff</bgColor>
+                <text><![CDATA[This is $[name]]]></text>
+            </BalloonStyle>
+        </Style>
+    </Document>
+</kml>

--- a/ogr/ogrsf_frmts/libkml/ogr_libkml.h
+++ b/ogr/ogrsf_frmts/libkml/ogr_libkml.h
@@ -233,7 +233,7 @@ class OGRLIBKMLDataSource final : public OGRDataSource
     kmldom::ContainerPtr m_poKmlDocKml;
     kmldom::ElementPtr m_poKmlDocKmlRoot;
     kmldom::ContainerPtr m_poKmlStyleKml;
-    char *pszStylePath;
+    std::string m_osStylePath{};
 
     /***** for dir *****/
     int m_isDir;
@@ -285,9 +285,9 @@ class OGRLIBKMLDataSource final : public OGRDataSource
         return m_poKmlFactory;
     }
 
-    const char *GetStylePath()
+    const std::string &GetStylePath() const
     {
-        return pszStylePath;
+        return m_osStylePath;
     }
 
     int ParseIntoStyleTable(std::string *oKmlStyleKml,

--- a/ogr/ogrsf_frmts/libkml/ogrlibkmldatasource.cpp
+++ b/ogr/ogrsf_frmts/libkml/ogrlibkmldatasource.cpp
@@ -91,8 +91,7 @@ OGRLIBKMLDataSource::OGRLIBKMLDataSource(KmlFactory *poKmlFactory)
       bUpdate(false), bUpdated(false), m_papszOptions(nullptr), m_isKml(false),
       m_poKmlDSKml(nullptr), m_poKmlDSContainer(nullptr),
       m_poKmlUpdate(nullptr), m_isKmz(false), m_poKmlDocKml(nullptr),
-      m_poKmlDocKmlRoot(nullptr), m_poKmlStyleKml(nullptr),
-      pszStylePath(const_cast<char *>("")), m_isDir(false),
+      m_poKmlDocKmlRoot(nullptr), m_poKmlStyleKml(nullptr), m_isDir(false),
       m_poKmlFactory(poKmlFactory)
 {
 }
@@ -701,9 +700,6 @@ OGRLIBKMLDataSource::~OGRLIBKMLDataSource()
 
     CPLFree(m_pszName);
 
-    if (!EQUAL(pszStylePath, ""))
-        CPLFree(pszStylePath);
-
     for (int i = 0; i < nLayers; i++)
         delete papoLayers[i];
 
@@ -1003,7 +999,7 @@ int OGRLIBKMLDataSource::ParseIntoStyleTable(std::string *poKmlStyleKml,
     if (!poKmlRoot)
     {
         CPLError(CE_Failure, CPLE_OpenFailed, "ERROR parsing style kml %s :%s",
-                 pszStylePath, oKmlErrors.c_str());
+                 pszMyStylePath, oKmlErrors.c_str());
         return false;
     }
 
@@ -1016,7 +1012,7 @@ int OGRLIBKMLDataSource::ParseIntoStyleTable(std::string *poKmlStyleKml,
     }
 
     ParseStyles(AsDocument(std::move(poKmlContainer)), &m_poStyleTable);
-    pszStylePath = CPLStrdup(pszMyStylePath);
+    m_osStylePath = pszMyStylePath;
 
     return true;
 }
@@ -1411,7 +1407,7 @@ int OGRLIBKMLDataSource::OpenDir(const char *pszFilename, int bUpdateIn)
         if (EQUAL(papszDirList[iFile], "style.kml"))
         {
             ParseStyles(AsDocument(poKmlContainer), &m_poStyleTable);
-            pszStylePath = CPLStrdup(const_cast<char *>("style.kml"));
+            m_osStylePath = "style.kml";
             continue;
         }
 
@@ -1826,7 +1822,7 @@ int OGRLIBKMLDataSource::CreateKmz(const char * /* pszFilename */,
         }
     }
 
-    pszStylePath = CPLStrdup(const_cast<char *>("style/style.kml"));
+    m_osStylePath = "style/style.kml";
 
     m_isKmz = true;
     bUpdated = true;
@@ -1868,7 +1864,7 @@ int OGRLIBKMLDataSource::CreateDir(const char *pszFilename,
         }
     }
 
-    pszStylePath = CPLStrdup(const_cast<char *>("style.kml"));
+    m_osStylePath = "style.kml";
 
     return TRUE;
 }

--- a/ogr/ogrsf_frmts/libkml/ogrlibkmlfeaturestyle.cpp
+++ b/ogr/ogrsf_frmts/libkml/ogrlibkmlfeaturestyle.cpp
@@ -93,7 +93,7 @@ void featurestyle2kml(OGRLIBKMLDataSource *poOgrDS, OGRLayer *poOgrLayer,
             {
                 string oTmp;
 
-                if (poOgrDS->GetStylePath())
+                if (!poOgrDS->GetStylePath().empty())
                     oTmp.append(poOgrDS->GetStylePath());
                 oTmp.append("#");
                 oTmp.append(pszStyleName);
@@ -137,7 +137,7 @@ void featurestyle2kml(OGRLIBKMLDataSource *poOgrDS, OGRLayer *poOgrLayer,
                 /***** mayby the user will add it later. *****/
 
                 string oTmp;
-                if (poOgrDS->GetStylePath())
+                if (!poOgrDS->GetStylePath().empty())
                     oTmp.append(poOgrDS->GetStylePath());
                 oTmp.append("#");
                 oTmp.append(pszStyleName);
@@ -167,21 +167,23 @@ void kml2featurestyle(FeaturePtr poKmlFeature, OGRLIBKMLDataSource *poOgrDS,
                       OGRLayer *poOgrLayer, OGRFeature *poOgrFeat)
 {
     /***** does the placemark have a style url? *****/
-    if (poKmlFeature->has_styleurl())
+    const int nStyleURLIterations = poKmlFeature->has_styleurl() ? 2 : 0;
+    for (int i = 0; i < nStyleURLIterations; ++i)
     {
-        const string poKmlStyleUrl = poKmlFeature->get_styleurl();
-
         /***** is the name in the layer style table *****/
-        char *pszUrl = CPLStrdup(poKmlStyleUrl.c_str());
+        const std::string osUrl(poKmlFeature->get_styleurl());
 
         OGRStyleTable *poOgrSTBLLayer = nullptr;
         const char *pszTest = nullptr;
+        bool bRetry = false;
+
+        std::string osStyleString;
 
         /***** is it a layer style ? *****/
-        if (*pszUrl == '#' &&
+        if (!osUrl.empty() && osUrl.front() == '#' &&
             (poOgrSTBLLayer = poOgrLayer->GetStyleTable()) != nullptr)
         {
-            pszTest = poOgrSTBLLayer->Find(pszUrl + 1);
+            pszTest = poOgrSTBLLayer->Find(osUrl.c_str() + 1);
         }
 
         if (pszTest)
@@ -192,22 +194,27 @@ void kml2featurestyle(FeaturePtr poKmlFeature, OGRLIBKMLDataSource *poOgrDS,
 
             if (CPLTestBool(pszResolve))
             {
-                poOgrFeat->SetStyleString(pszTest);
+                osStyleString = pszTest;
             }
             else
             {
-                *pszUrl = '@';
-                poOgrFeat->SetStyleString(pszUrl);
+                osStyleString = std::string("@").append(osUrl.c_str() + 1);
             }
         }
         /***** is it a dataset style? *****/
         else
         {
-            const int nPathLen =
-                static_cast<int>(strlen(poOgrDS->GetStylePath()));
+            const size_t nPathLen = poOgrDS->GetStylePath().size();
 
-            if (nPathLen == 0 ||
-                EQUALN(pszUrl, poOgrDS->GetStylePath(), nPathLen))
+            if (nPathLen == 0)
+            {
+                if (!osUrl.empty() && osUrl[0] == '#')
+                    osStyleString = std::string("@").append(osUrl.c_str() + 1);
+            }
+            else if (osUrl.size() > nPathLen &&
+                     strncmp(osUrl.c_str(), poOgrDS->GetStylePath().c_str(),
+                             nPathLen) == 0 &&
+                     osUrl[nPathLen] == '#')
             {
                 /***** should we resolve the style *****/
                 const char *pszResolve =
@@ -215,19 +222,20 @@ void kml2featurestyle(FeaturePtr poKmlFeature, OGRLIBKMLDataSource *poOgrDS,
 
                 if (CPLTestBool(pszResolve) &&
                     (poOgrSTBLLayer = poOgrDS->GetStyleTable()) != nullptr &&
-                    (pszTest = poOgrSTBLLayer->Find(pszUrl + nPathLen + 1)) !=
-                        nullptr)
+                    (pszTest = poOgrSTBLLayer->Find(osUrl.c_str() + nPathLen +
+                                                    1)) != nullptr)
                 {
-                    poOgrFeat->SetStyleString(pszTest);
+                    osStyleString = pszTest;
                 }
                 else
                 {
-                    pszUrl[nPathLen] = '@';
-                    poOgrFeat->SetStyleString(pszUrl + nPathLen);
+                    osStyleString =
+                        std::string("@").append(osUrl.c_str() + nPathLen + 1);
                 }
             }
+
             /**** its someplace else *****/
-            else
+            if (i == 0 && osStyleString.empty())
             {
                 const char *pszFetch =
                     CPLGetConfigOption("LIBKML_EXTERNAL_STYLE", "no");
@@ -235,19 +243,31 @@ void kml2featurestyle(FeaturePtr poKmlFeature, OGRLIBKMLDataSource *poOgrDS,
                 if (CPLTestBool(pszFetch))
                 {
                     /***** load up the style table *****/
-                    char *pszUrlTmp = CPLStrdup(pszUrl);
-                    char *pszPound = strchr(pszUrlTmp, '#');
-                    if (pszPound != nullptr)
+                    std::string osUrlTmp(osUrl);
+                    const auto nPoundPos = osUrlTmp.find('#');
+                    if (nPoundPos != std::string::npos)
                     {
-                        *pszPound = '\0';
+                        osUrlTmp.resize(nPoundPos);
                     }
+                    const std::string osStyleFilename(osUrlTmp);
 
-                    /***** try it as a url then a file *****/
-                    VSILFILE *fp = nullptr;
-                    if ((fp = VSIFOpenL(
-                             CPLFormFilename("/vsicurl/", pszUrlTmp, nullptr),
-                             "r")) != nullptr ||
-                        (fp = VSIFOpenL(pszUrlTmp, "r")) != nullptr)
+                    if (STARTS_WITH(osUrlTmp.c_str(), "http://") ||
+                        STARTS_WITH(osUrlTmp.c_str(), "https://"))
+                    {
+                        osUrlTmp =
+                            std::string("/vsicurl_streaming/").append(osUrlTmp);
+                    }
+                    else if (CPLIsFilenameRelative(osUrlTmp.c_str()))
+                    {
+                        osUrlTmp = CPLFormFilename(
+                            CPLGetDirname(poOgrDS->GetDescription()),
+                            osUrlTmp.c_str(), nullptr);
+                    }
+                    CPLDebug("LIBKML", "Trying to resolve style %s",
+                             osUrlTmp.c_str());
+
+                    VSILFILE *fp = VSIFOpenL(osUrlTmp.c_str(), "r");
+                    if (fp)
                     {
                         char szbuf[1025] = {'\0'};
                         std::string oStyle = "";
@@ -271,26 +291,31 @@ void kml2featurestyle(FeaturePtr poKmlFeature, OGRLIBKMLDataSource *poOgrDS,
 
                         /***** parse the kml into the ds style table *****/
 
-                        if (poOgrDS->ParseIntoStyleTable(&oStyle, pszUrlTmp))
+                        if (poOgrDS->ParseIntoStyleTable(
+                                &oStyle, osStyleFilename.c_str()))
                         {
-                            kml2featurestyle(poKmlFeature, poOgrDS, poOgrLayer,
-                                             poOgrFeat);
-                        }
-                        else
-                        {
-                            /***** if failed just store the url *****/
-                            poOgrFeat->SetStyleString(pszUrl);
+                            bRetry = true;
                         }
                     }
-                    CPLFree(pszUrlTmp);
-                }
-                else
-                {
-                    poOgrFeat->SetStyleString(pszUrl);
                 }
             }
         }
-        CPLFree(pszUrl);
+
+        if (!bRetry)
+        {
+            if (osStyleString.empty())
+            {
+                // Note: storing the style URL doesn't really follow
+                // the OGR Feature Style string spec (https://gdal.org/user/ogr_feature_style.html#style-string-syntax),
+                // but is better than nothing
+                poOgrFeat->SetStyleString(osUrl.c_str());
+            }
+            else
+            {
+                poOgrFeat->SetStyleString(osStyleString.c_str());
+            }
+            break;
+        }
     }
 
     /***** does the placemark have a style selector *****/


### PR DESCRIPTION
Fixes #9975
