### PR TITLE
gdal_viewshed: use functions in implementation

### DIFF
--- a/alg/viewshed.cpp
+++ b/alg/viewshed.cpp
@@ -27,13 +27,15 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 #include <limits>
-//ABELL
+#include <thread>
+/**
 #include <iostream>
 #pragma GCC diagnostic ignored "-Wold-style-cast"
+**/
 
 #include "gdal_alg.h"
-#include "gdal_priv.h"
 #include "gdal_priv_templates.hpp"
 
 #include "viewshed.h"
@@ -626,8 +628,7 @@ void Viewshed::setOutput(double& dfResult, double& dfCellVal, double dfZ)
 
 bool Viewshed::processFirstLine(int nX, int nY, int nLine, std::vector<double>& vLastLineVal)
 {
-    //ABELL - Should be zero.
-    int nYOffset = nLine - nY;
+    int nYOffset = nLine - nY;   // Should be zero.
     std::vector<double> vResult(oOutExtent.xSize());
     std::vector<double> vThisLineVal(oOutExtent.xSize());
 

--- a/alg/viewshed.cpp
+++ b/alg/viewshed.cpp
@@ -351,7 +351,8 @@ bool Viewshed::readLine(int nLine, double *data)
 /// Write an output line of either visibility or height data.
 ///
 /// @param  nLine  Line number being written.
-/// @return  Success or failure.
+/// @param vResult  Result line to write.
+/// @return  True on success, false otherwise.
 bool Viewshed::writeLine(int nLine, std::vector<double> &vResult)
 {
     // GDALRasterIO isn't thread-safe.

--- a/alg/viewshed.cpp
+++ b/alg/viewshed.cpp
@@ -28,7 +28,6 @@
 #include <algorithm>
 #include <array>
 #include <atomic>
-#include <limits>
 #include <thread>
 /**
 #include <iostream>
@@ -789,7 +788,7 @@ bool Viewshed::run(GDALRasterBandH band, GDALProgressFunc pfnProgress,
         zcalc = doMax;
 
     // scan upwards
-    std::atomic<bool> err;
+    std::atomic<bool> err(false);
     std::thread tUp([&]()
         {
             std::vector<double> vLastLineVal = vFirstLineVal;

--- a/alg/viewshed.cpp
+++ b/alg/viewshed.cpp
@@ -214,9 +214,6 @@ namespace gdal
 namespace
 {
 
-using ZCalc = std::function<double(int, int, double, double, double)>;
-ZCalc zcalc;
-
 // Calculate the height adjustment factor.
 double CalcHeightAdjFactor(const GDALDataset *poDataset, double dfCurveCoeff)
 {
@@ -584,7 +581,7 @@ void Viewshed::processLineLeft(int nX, int nYOffset, int iStart, int iEnd,
     {
         int nXOffset = std::abs(iPixel - nX);
         double dfZ =
-            zcalc(nXOffset, nYOffset, *(pThis + 1), *pLast, *(pLast + 1));
+            oZcalc(nXOffset, nYOffset, *(pThis + 1), *pLast, *(pLast + 1));
         setOutput(vResult[iPixel], *pThis, dfZ);
     }
 
@@ -616,7 +613,7 @@ void Viewshed::processLineRight(int nX, int nYOffset, int iStart, int iEnd,
     {
         int nXOffset = std::abs(iPixel - nX);
         double dfZ =
-            zcalc(nXOffset, nYOffset, *(pThis - 1), *pLast, *(pLast - 1));
+            oZcalc(nXOffset, nYOffset, *(pThis - 1), *pLast, *(pLast - 1));
         setOutput(vResult[iPixel], *pThis, dfZ);
     }
     // For cells outside of the [start, end) range, set the outOfRange value.
@@ -821,7 +818,7 @@ bool Viewshed::run(GDALRasterBandH band, GDALProgressFunc pfnProgress,
     if (!createOutputDataset())
         return false;
 
-    zcalc = doLine;
+    oZcalc = doLine;
 
     std::vector<double> vFirstLineVal(oOutExtent.xSize());
 
@@ -829,13 +826,13 @@ bool Viewshed::run(GDALRasterBandH band, GDALProgressFunc pfnProgress,
         return false;
 
     if (oOpts.cellMode == CellMode::Edge)
-        zcalc = doEdge;
+        oZcalc = doEdge;
     else if (oOpts.cellMode == CellMode::Diagonal)
-        zcalc = doDiagonal;
+        oZcalc = doDiagonal;
     else if (oOpts.cellMode == CellMode::Min)
-        zcalc = doMin;
+        oZcalc = doMin;
     else if (oOpts.cellMode == CellMode::Max)
-        zcalc = doMax;
+        oZcalc = doMax;
 
     // scan upwards
     std::atomic<bool> err(false);

--- a/alg/viewshed.cpp
+++ b/alg/viewshed.cpp
@@ -676,11 +676,6 @@ bool Viewshed::processFirstLine(int nX, int nY, int nLine,
     const auto [iLeft, iRight] =
         adjustHeight(nYOffset, nX, vThisLineVal.data() + nX);
 
-    processLineLeft(nX, nYOffset, nX - 2, iLeft - 1, vResult, vThisLineVal,
-                    vLastLineVal);
-    processLineRight(nX, nYOffset, nX + 2, iRight, vResult, vThisLineVal,
-                     vLastLineVal);
-    /**
     auto t1 = std::async(std::launch::async, [&, left = iLeft]()
         {
             processLineLeft(nX, nYOffset, nX - 2, left - 1, vResult,
@@ -694,7 +689,6 @@ bool Viewshed::processFirstLine(int nX, int nY, int nLine,
         });
     t1.wait();
     t2.wait();
-    **/
 
     // Make the current line the last line.
     vLastLineVal = std::move(vThisLineVal);
@@ -745,11 +739,6 @@ bool Viewshed::processLine(int nX, int nY, int nLine,
         vResult[nX] = oOpts.outOfRangeVal;
 
     // process left half then right half of line
-    processLineLeft(nX, nYOffset, nX - 1, iLeft - 1, vResult, vThisLineVal,
-                    vLastLineVal);
-    processLineRight(nX, nYOffset, nX + 1, iRight, vResult, vThisLineVal,
-                     vLastLineVal);
-    /**
     auto t1 = std::async(std::launch::async, [&, left = iLeft]()
         {
             processLineLeft(nX, nYOffset, nX - 1, left - 1, vResult,
@@ -763,7 +752,6 @@ bool Viewshed::processLine(int nX, int nY, int nLine,
         });
     t1.wait();
     t2.wait();
-    **/
 
     // Make the current line the last line.
     vLastLineVal = std::move(vThisLineVal);
@@ -844,16 +832,17 @@ bool Viewshed::run(GDALRasterBandH band, GDALProgressFunc pfnProgress,
 
     // scan upwards
     std::atomic<bool> err(false);
-    auto tUp = std::async(std::launch::async,
-                          [&]()
-                          {
-                              std::vector<double> vLastLineVal = vFirstLineVal;
+    auto tUp = std::async(
+        std::launch::async,
+        [&]()
+        {
+                             std::vector<double> vLastLineVal = vFirstLineVal;
 
-                              for (int nLine = nY - 1;
-                                   nLine >= oOutExtent.yStart && !err; nLine--)
-                                  if (!processLine(nX, nY, nLine, vLastLineVal))
-                                      err = true;
-                          });
+                             for (int nLine = nY - 1;
+                                  nLine >= oOutExtent.yStart && !err; nLine--)
+                                 if (!processLine(nX, nY, nLine, vLastLineVal))
+                                     err = true;
+                                     });
 
     // scan downwards
     auto tDown = std::async(

--- a/alg/viewshed.cpp
+++ b/alg/viewshed.cpp
@@ -676,17 +676,21 @@ bool Viewshed::processFirstLine(int nX, int nY, int nLine,
     const auto [iLeft, iRight] =
         adjustHeight(nYOffset, nX, vThisLineVal.data() + nX);
 
-    auto t1 = std::async(std::launch::async, [&, left = iLeft]()
-        {
-            processLineLeft(nX, nYOffset, nX - 2, left - 1, vResult,
-                            vThisLineVal, vLastLineVal);
-        });
+    auto t1 =
+        std::async(std::launch::async,
+                   [&, left = iLeft]()
+                   {
+                       processLineLeft(nX, nYOffset, nX - 2, left - 1, vResult,
+                                       vThisLineVal, vLastLineVal);
+                   });
 
-    auto t2 = std::async(std::launch::async, [&, right = iRight]()
-        {
-            processLineRight(nX, nYOffset, nX + 2, right, vResult, vThisLineVal,
-                             vLastLineVal);
-        });
+    auto t2 =
+        std::async(std::launch::async,
+                   [&, right = iRight]()
+                   {
+                       processLineRight(nX, nYOffset, nX + 2, right, vResult,
+                                        vThisLineVal, vLastLineVal);
+                   });
     t1.wait();
     t2.wait();
 
@@ -739,17 +743,21 @@ bool Viewshed::processLine(int nX, int nY, int nLine,
         vResult[nX] = oOpts.outOfRangeVal;
 
     // process left half then right half of line
-    auto t1 = std::async(std::launch::async, [&, left = iLeft]()
-        {
-            processLineLeft(nX, nYOffset, nX - 1, left - 1, vResult,
-                            vThisLineVal, vLastLineVal);
-        });
+    auto t1 =
+        std::async(std::launch::async,
+                   [&, left = iLeft]()
+                   {
+                       processLineLeft(nX, nYOffset, nX - 1, left - 1, vResult,
+                                       vThisLineVal, vLastLineVal);
+                   });
 
-    auto t2 = std::async(std::launch::async, [&, right = iRight]()
-        {
-            processLineRight(nX, nYOffset, nX + 1, right, vResult, vThisLineVal,
-                             vLastLineVal);
-        });
+    auto t2 =
+        std::async(std::launch::async,
+                   [&, right = iRight]()
+                   {
+                       processLineRight(nX, nYOffset, nX + 1, right, vResult,
+                                        vThisLineVal, vLastLineVal);
+                   });
     t1.wait();
     t2.wait();
 
@@ -832,17 +840,16 @@ bool Viewshed::run(GDALRasterBandH band, GDALProgressFunc pfnProgress,
 
     // scan upwards
     std::atomic<bool> err(false);
-    auto tUp = std::async(
-        std::launch::async,
-        [&]()
-        {
-                             std::vector<double> vLastLineVal = vFirstLineVal;
+    auto tUp = std::async(std::launch::async,
+                          [&]()
+                          {
+                              std::vector<double> vLastLineVal = vFirstLineVal;
 
-                             for (int nLine = nY - 1;
-                                  nLine >= oOutExtent.yStart && !err; nLine--)
-                                 if (!processLine(nX, nY, nLine, vLastLineVal))
-                                     err = true;
-                                     });
+                              for (int nLine = nY - 1;
+                                   nLine >= oOutExtent.yStart && !err; nLine--)
+                                  if (!processLine(nX, nY, nLine, vLastLineVal))
+                                      err = true;
+                          });
 
     // scan downwards
     auto tDown = std::async(

--- a/alg/viewshed.h
+++ b/alg/viewshed.h
@@ -28,6 +28,7 @@
 #include <array>
 #include <cstdint>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <string>

--- a/alg/viewshed.h
+++ b/alg/viewshed.h
@@ -172,6 +172,7 @@ class Viewshed
     void setVisibility(int iPixel, double dfZ);
     double calcHeight(double dfZ, double dfZ2);
     bool readLine(int nLine, double *data);
+    void processHalfLine(int nX, int nYOffset, int iStart, int iEnd, int iDir);
     std::pair<int, int> adjustHeight(int iLine, int nX, double dfObserverHeight,
                                      double *const pdfNx);
     bool calcOutputExtent(int nX, int nY);

--- a/alg/viewshed.h
+++ b/alg/viewshed.h
@@ -138,6 +138,7 @@ class Viewshed
     }
 
     Viewshed(const Viewshed&) = delete;
+    Viewshed& operator=(const Viewshed&) = delete;
 
     /**
      * Create the viewshed for the provided raster band.

--- a/alg/viewshed.h
+++ b/alg/viewshed.h
@@ -129,7 +129,7 @@ class Viewshed
      * @param opts Options to use when calculating viewshed.
     */
     CPL_DLL explicit Viewshed(const Options &opts)
-        : oOpts{opts}, dfMaxDistance2{opts.maxDistance * opts.maxDistance},
+        : oOpts{opts}, oOutExtent{}, dfMaxDistance2{opts.maxDistance * opts.maxDistance},
           dfZObserver{0}, poDstDS{}, pSrcBand{}, pDstBand{}, dfHeightAdjFactor{0}, nLineCount{0},
           adfTransform{0, 1, 0, 0, 0, 1}, adfInvTransform{}, oProgress{}, oMutex{}, iMutex{}
     {

--- a/alg/viewshed.h
+++ b/alg/viewshed.h
@@ -105,7 +105,7 @@ class Viewshed
     struct Options
     {
         Point observer{0, 0, 0};  //!< x, y, and z of the observer
-        double visibleVal{255};  //!< raster output value for visible pixels.
+        double visibleVal{255};   //!< raster output value for visible pixels.
         double invisibleVal{
             0};  //!< raster output value for non-visible pixels.
         double outOfRangeVal{
@@ -130,16 +130,18 @@ class Viewshed
      * @param opts Options to use when calculating viewshed.
     */
     CPL_DLL explicit Viewshed(const Options &opts)
-        : oOpts{opts}, oOutExtent{}, dfMaxDistance2{opts.maxDistance * opts.maxDistance},
-          dfZObserver{0}, poDstDS{}, pSrcBand{}, pDstBand{}, dfHeightAdjFactor{0}, nLineCount{0},
-          adfTransform{0, 1, 0, 0, 0, 1}, adfInvTransform{}, oProgress{}, oMutex{}, iMutex{}
+        : oOpts{opts}, oOutExtent{},
+          dfMaxDistance2{opts.maxDistance * opts.maxDistance}, dfZObserver{0},
+          poDstDS{}, pSrcBand{}, pDstBand{}, dfHeightAdjFactor{0},
+          nLineCount{0}, adfTransform{0, 1, 0, 0, 0, 1}, adfInvTransform{},
+          oProgress{}, oMutex{}, iMutex{}
     {
         if (dfMaxDistance2 == 0)
             dfMaxDistance2 = std::numeric_limits<double>::max();
     }
 
-    Viewshed(const Viewshed&) = delete;
-    Viewshed& operator=(const Viewshed&) = delete;
+    Viewshed(const Viewshed &) = delete;
+    Viewshed &operator=(const Viewshed &) = delete;
 
     /**
      * Create the viewshed for the provided raster band.
@@ -178,16 +180,22 @@ class Viewshed
     std::mutex oMutex;
     std::mutex iMutex;
 
-    void setOutput(double& dfResult, double& dfCellVal, double dfZ);
+    void setOutput(double &dfResult, double &dfCellVal, double dfZ);
     double calcHeight(double dfZ, double dfZ2);
     bool readLine(int nLine, double *data);
-    bool writeLine(int nLine, std::vector<double>& vResult);
-    bool processLine(int nX, int nY, int nLine, std::vector<double>& vLastLineVal);
-    bool processFirstLine(int nX, int nY, int nLine, std::vector<double>& vLastLineVal);
-    void processLineLeft(int nX, int nYOffset, int iStart, int iEnd, std::vector<double>& vResult,
-        std::vector<double>& vThisLineVal, std::vector<double>& vLastLineVal);
-    void processLineRight(int nX, int nYOffset, int iStart, int iEnd, std::vector<double>& vResult,
-        std::vector<double>& vThisLineVal, std::vector<double>& vLastLineVal);
+    bool writeLine(int nLine, std::vector<double> &vResult);
+    bool processLine(int nX, int nY, int nLine,
+                     std::vector<double> &vLastLineVal);
+    bool processFirstLine(int nX, int nY, int nLine,
+                          std::vector<double> &vLastLineVal);
+    void processLineLeft(int nX, int nYOffset, int iStart, int iEnd,
+                         std::vector<double> &vResult,
+                         std::vector<double> &vThisLineVal,
+                         std::vector<double> &vLastLineVal);
+    void processLineRight(int nX, int nYOffset, int iStart, int iEnd,
+                          std::vector<double> &vResult,
+                          std::vector<double> &vThisLineVal,
+                          std::vector<double> &vLastLineVal);
     std::pair<int, int> adjustHeight(int iLine, int nX, double *const pdfNx);
     bool calcOutputExtent(int nX, int nY);
     bool createOutputDataset();

--- a/alg/viewshed.h
+++ b/alg/viewshed.h
@@ -130,8 +130,8 @@ class Viewshed
     */
     CPL_DLL explicit Viewshed(const Options &opts)
         : oOpts{opts}, dfMaxDistance2{opts.maxDistance * opts.maxDistance},
-          dfZObserver{0}, poDstDS{}, dfHeightAdjFactor{0}, nLineCount{0},
-          adfTransform{0, 1, 0, 0, 0, 1}
+          dfZObserver{0}, poDstDS{}, pSrcBand{}, pDstBand{}, dfHeightAdjFactor{0}, nLineCount{0},
+          adfTransform{0, 1, 0, 0, 0, 1}, adfInvTransform{}, oProgress{}, oMutex{}, iMutex{}
     {
         if (dfMaxDistance2 == 0)
             dfMaxDistance2 = std::numeric_limits<double>::max();

--- a/alg/viewshed.h
+++ b/alg/viewshed.h
@@ -102,10 +102,10 @@ class Viewshed
     struct Options
     {
         Point observer{0, 0, 0};  //!< x, y, and z of the observer
-        uint8_t visibleVal{255};  //!< raster output value for visible pixels.
-        uint8_t invisibleVal{
+        double visibleVal{255};  //!< raster output value for visible pixels.
+        double invisibleVal{
             0};  //!< raster output value for non-visible pixels.
-        uint8_t outOfRangeVal{
+        double outOfRangeVal{
             0};  //!< raster output value for pixels outside of max distance.
         double nodataVal{-1};  //!< raster output value for pixels with no data
         double targetHeight{0.0};  //!< target height above the DEM surface
@@ -170,12 +170,10 @@ class Viewshed
     std::vector<double> vFirstLineVal;
     std::vector<double> vLastLineVal;
     std::vector<double> vThisLineVal;
-    std::vector<GByte> vResult;
-    std::vector<double> vHeightResult;
+    std::vector<double> vResult;
     using ProgressFunc = std::function<bool(double frac, const char *msg)>;
     ProgressFunc oProgress;
 
-    void setVisibility(int iPixel, double dfZ);
     double calcHeight(double dfZ, double dfZ2);
     bool readLine(int nLine, double *data);
     bool writeLine(int nLine);

--- a/alg/viewshed.h
+++ b/alg/viewshed.h
@@ -25,6 +25,7 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
+#include <array>
 #include <cstdint>
 #include <memory>
 #include <string>
@@ -102,7 +103,7 @@ class Viewshed
      *
      * @param opts Options to use when calculating viewshed.
     */
-    CPL_DLL explicit Viewshed(const Options &opts) : oOpts{opts}, poDstDS{}
+    CPL_DLL explicit Viewshed(const Options &opts) : oOpts{opts}, dfMaxDistance2{opts.maxDistance * opts.maxDistance}, poDstDS{}, dfHeightAdjFactor{0}, adfTransform{ 0, 1, 0, 0, 0, 1 }
     {
     }
 
@@ -128,11 +129,21 @@ class Viewshed
 
   private:
     Options oOpts;
+    double dfMaxDistance2;
     std::unique_ptr<GDALDataset> poDstDS;
+    double dfHeightAdjFactor;
+    std::array<double, 6> adfTransform;
+    std::vector<double> vFirstLineVal;
+    std::vector<double> vLastLineVal;
+    std::vector<double> vThisLineVal;
+    std::vector<GByte> vResult;
+    std::vector<double> vHeightResult;
 
-    void setVisibility(int iPixel, double dfZ, double *padfZVal,
-                       std::vector<GByte> &vResult);
+    void setVisibility(int iPixel, double dfZ, std::vector<double>& vHeight);
     double calcHeight(double dfZ, double dfZ2);
+    bool adjustHeightInRange(int iPixel, int iLine, double& dfHeight);
+    bool createOutputDataset(int nXSize, int nYSize);
+    bool allocate(int nXSize);
 };
 
 }  // namespace gdal

--- a/alg/viewshed.h
+++ b/alg/viewshed.h
@@ -103,7 +103,9 @@ class Viewshed
      *
      * @param opts Options to use when calculating viewshed.
     */
-    CPL_DLL explicit Viewshed(const Options &opts) : oOpts{opts}, dfMaxDistance2{opts.maxDistance * opts.maxDistance}, poDstDS{}, dfHeightAdjFactor{0}, adfTransform{ 0, 1, 0, 0, 0, 1 }
+    CPL_DLL explicit Viewshed(const Options &opts)
+        : oOpts{opts}, dfMaxDistance2{opts.maxDistance * opts.maxDistance},
+          poDstDS{}, dfHeightAdjFactor{0}, adfTransform{0, 1, 0, 0, 0, 1}
     {
     }
 
@@ -139,9 +141,9 @@ class Viewshed
     std::vector<GByte> vResult;
     std::vector<double> vHeightResult;
 
-    void setVisibility(int iPixel, double dfZ, std::vector<double>& vHeight);
+    void setVisibility(int iPixel, double dfZ);
     double calcHeight(double dfZ, double dfZ2);
-    bool adjustHeightInRange(int iPixel, int iLine, double& dfHeight);
+    bool adjustHeightInRange(int iPixel, int iLine, double &dfHeight);
     bool createOutputDataset(int nXSize, int nYSize);
     bool allocate(int nXSize);
 };

--- a/alg/viewshed.h
+++ b/alg/viewshed.h
@@ -28,7 +28,9 @@
 #include <array>
 #include <cstdint>
 #include <memory>
+#include <mutex>
 #include <string>
+#include <thread>
 
 #include "cpl_progress.h"
 #include "gdal_priv.h"
@@ -167,18 +169,20 @@ class Viewshed
     int nLineCount;
     std::array<double, 6> adfTransform;
     std::array<double, 6> adfInvTransform;
-    std::vector<double> vFirstLineVal;
     std::vector<double> vLastLineVal;
     std::vector<double> vThisLineVal;
-    std::vector<double> vResult;
     using ProgressFunc = std::function<bool(double frac, const char *msg)>;
     ProgressFunc oProgress;
+    std::vector<std::thread> vOutWriters;
+    std::mutex oMutex;
 
+    void setOutput(double& dfResult, double& dfCellVal, double dfZ);
     double calcHeight(double dfZ, double dfZ2);
     bool readLine(int nLine, double *data);
-    bool writeLine(int nLine);
+    bool writeLine(int nLine, std::vector<double>& vResult);
     bool processLine(int nX, int nY, int nLine);
-    void processHalfLine(int nX, int nYOffset, int iStart, int iEnd, int iDir);
+    bool processFirstLine(int nX, int nY, int nLine);
+    void processHalfLine(int nX, int nYOffset, int iStart, int iEnd, int iDir, std::vector<double>& vResult);
     std::pair<int, int> adjustHeight(int iLine, int nX, double dfObserverHeight,
                                      double *const pdfNx);
     bool calcOutputExtent(int nX, int nY);

--- a/alg/viewshed.h
+++ b/alg/viewshed.h
@@ -128,7 +128,8 @@ class Viewshed
     */
     CPL_DLL explicit Viewshed(const Options &opts)
         : oOpts{opts}, dfMaxDistance2{opts.maxDistance * opts.maxDistance},
-          poDstDS{}, dfHeightAdjFactor{0}, nLineCount(0), adfTransform{0, 1, 0, 0, 0, 1}
+          dfZObserver{0}, poDstDS{}, dfHeightAdjFactor{0}, nLineCount{0},
+          adfTransform{0, 1, 0, 0, 0, 1}
     {
         if (dfMaxDistance2 == 0)
             dfMaxDistance2 = std::numeric_limits<double>::max();
@@ -158,6 +159,7 @@ class Viewshed
     Options oOpts;
     Window oOutExtent;
     double dfMaxDistance2;
+    double dfZObserver;
     std::unique_ptr<GDALDataset> poDstDS;
     GDALRasterBand *pSrcBand;
     GDALRasterBand *pDstBand;
@@ -175,8 +177,9 @@ class Viewshed
 
     void setVisibility(int iPixel, double dfZ);
     double calcHeight(double dfZ, double dfZ2);
-    bool readLine(int nLine, double * data);
-    bool writeLine(int nLine, void * const data, GDALDataType dataType);
+    bool readLine(int nLine, double *data);
+    bool writeLine(int nLine);
+    bool processLine(int nX, int nY, int nLine);
     void processHalfLine(int nX, int nYOffset, int iStart, int iEnd, int iDir);
     std::pair<int, int> adjustHeight(int iLine, int nX, double dfObserverHeight,
                                      double *const pdfNx);

--- a/alg/viewshed.h
+++ b/alg/viewshed.h
@@ -143,13 +143,6 @@ class Viewshed
     Viewshed(const Viewshed &) = delete;
     Viewshed &operator=(const Viewshed &) = delete;
 
-    /**
-     * Create the viewshed for the provided raster band.
-     *
-     * @param hBand  Handle to the raster band.
-     * @param pfnProgress  Progress reporting callback function.
-     * @param pProgressArg  Argument to pass to the progress callback.
-    */
     CPL_DLL bool run(GDALRasterBandH hBand, GDALProgressFunc pfnProgress,
                      void *pProgressArg = nullptr);
 

--- a/alg/viewshed.h
+++ b/alg/viewshed.h
@@ -130,11 +130,11 @@ class Viewshed
      * @param opts Options to use when calculating viewshed.
     */
     CPL_DLL explicit Viewshed(const Options &opts)
-        : oOpts{opts}, oOutExtent{},
-          dfMaxDistance2{opts.maxDistance * opts.maxDistance}, dfZObserver{0},
-          poDstDS{}, pSrcBand{}, pDstBand{}, dfHeightAdjFactor{0},
-          nLineCount{0}, adfTransform{0, 1, 0, 0, 0, 1}, adfInvTransform{},
-          oProgress{}, oZcalc{}, oMutex{}, iMutex{}
+        : oOpts{opts}, oOutExtent{}, dfMaxDistance2{opts.maxDistance *
+                                                    opts.maxDistance},
+          dfZObserver{0}, poDstDS{}, pSrcBand{}, pDstBand{},
+          dfHeightAdjFactor{0}, nLineCount{0}, adfTransform{0, 1, 0, 0, 0, 1},
+          adfInvTransform{}, oProgress{}, oZcalc{}, oMutex{}, iMutex{}
     {
         if (dfMaxDistance2 == 0)
             dfMaxDistance2 = std::numeric_limits<double>::max();

--- a/alg/viewshed.h
+++ b/alg/viewshed.h
@@ -134,7 +134,7 @@ class Viewshed
           dfMaxDistance2{opts.maxDistance * opts.maxDistance}, dfZObserver{0},
           poDstDS{}, pSrcBand{}, pDstBand{}, dfHeightAdjFactor{0},
           nLineCount{0}, adfTransform{0, 1, 0, 0, 0, 1}, adfInvTransform{},
-          oProgress{}, oMutex{}, iMutex{}
+          oProgress{}, oZcalc{}, oMutex{}, iMutex{}
     {
         if (dfMaxDistance2 == 0)
             dfMaxDistance2 = std::numeric_limits<double>::max();

--- a/alg/viewshed.h
+++ b/alg/viewshed.h
@@ -27,10 +27,10 @@
 
 #include <array>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <string>
-#include <thread>
 
 #include "cpl_progress.h"
 #include "gdal_priv.h"
@@ -136,6 +136,8 @@ class Viewshed
         if (dfMaxDistance2 == 0)
             dfMaxDistance2 = std::numeric_limits<double>::max();
     }
+
+    Viewshed(const Viewshed&) = delete;
 
     /**
      * Create the viewshed for the provided raster band.

--- a/alg/viewshed.h
+++ b/alg/viewshed.h
@@ -177,6 +177,8 @@ class Viewshed
     std::array<double, 6> adfInvTransform;
     using ProgressFunc = std::function<bool(double frac, const char *msg)>;
     ProgressFunc oProgress;
+    using ZCalc = std::function<double(int, int, double, double, double)>;
+    ZCalc oZcalc;
     std::mutex oMutex;
     std::mutex iMutex;
 

--- a/alg/viewshed.h
+++ b/alg/viewshed.h
@@ -169,25 +169,24 @@ class Viewshed
     int nLineCount;
     std::array<double, 6> adfTransform;
     std::array<double, 6> adfInvTransform;
-    std::vector<double> vLastLineVal;
-    std::vector<double> vThisLineVal;
     using ProgressFunc = std::function<bool(double frac, const char *msg)>;
     ProgressFunc oProgress;
-    std::vector<std::thread> vOutWriters;
     std::mutex oMutex;
+    std::mutex iMutex;
 
     void setOutput(double& dfResult, double& dfCellVal, double dfZ);
     double calcHeight(double dfZ, double dfZ2);
     bool readLine(int nLine, double *data);
     bool writeLine(int nLine, std::vector<double>& vResult);
-    bool processLine(int nX, int nY, int nLine);
-    bool processFirstLine(int nX, int nY, int nLine);
-    void processHalfLine(int nX, int nYOffset, int iStart, int iEnd, int iDir, std::vector<double>& vResult);
-    std::pair<int, int> adjustHeight(int iLine, int nX, double dfObserverHeight,
-                                     double *const pdfNx);
+    bool processLine(int nX, int nY, int nLine, std::vector<double>& vLastLineVal);
+    bool processFirstLine(int nX, int nY, int nLine, std::vector<double>& vLastLineVal);
+    void processLineLeft(int nX, int nYOffset, int iStart, int iEnd, std::vector<double>& vResult,
+        std::vector<double>& vThisLineVal, std::vector<double>& vLastLineVal);
+    void processLineRight(int nX, int nYOffset, int iStart, int iEnd, std::vector<double>& vResult,
+        std::vector<double>& vThisLineVal, std::vector<double>& vLastLineVal);
+    std::pair<int, int> adjustHeight(int iLine, int nX, double *const pdfNx);
     bool calcOutputExtent(int nX, int nY);
     bool createOutputDataset();
-    bool allocate();
     bool lineProgress();
     bool emitProgress(double fraction);
 };

--- a/alg/viewshed.h
+++ b/alg/viewshed.h
@@ -74,6 +74,29 @@ class Viewshed
     };
 
     /**
+     * A window in a raster including pixels in [xStart, xEnd) and [yStart, yEnd).
+     */
+    struct Window
+    {
+        int xStart{};  //!< X start position
+        int xStop{};   //!< X end position
+        int yStart{};  //!< Y start position
+        int yStop{};   //!< Y end position
+
+        /// \brief  Window size in the X direction.
+        int xSize()
+        {
+            return xStop - xStart;
+        }
+
+        /// \brief  Window size in the Y direction.
+        int ySize()
+        {
+            return yStop - yStart;
+        }
+    };
+
+    /**
      * Options for viewshed generation.
      */
     struct Options
@@ -131,10 +154,13 @@ class Viewshed
 
   private:
     Options oOpts;
+    Window oOutExtent;
     double dfMaxDistance2;
     std::unique_ptr<GDALDataset> poDstDS;
+    GDALRasterBandH hBand;
     double dfHeightAdjFactor;
     std::array<double, 6> adfTransform;
+    std::array<double, 6> adfInvTransform;
     std::vector<double> vFirstLineVal;
     std::vector<double> vLastLineVal;
     std::vector<double> vThisLineVal;
@@ -143,9 +169,11 @@ class Viewshed
 
     void setVisibility(int iPixel, double dfZ);
     double calcHeight(double dfZ, double dfZ2);
+    bool readLine(int nLine, double *data);
     bool adjustHeightInRange(int iPixel, int iLine, double &dfHeight);
-    bool createOutputDataset(int nXSize, int nYSize);
-    bool allocate(int nXSize);
+    bool calcOutputExtent(int nX, int nY);
+    bool createOutputDataset();
+    bool allocate();
 };
 
 }  // namespace gdal

--- a/alg/viewshed.h
+++ b/alg/viewshed.h
@@ -130,6 +130,8 @@ class Viewshed
         : oOpts{opts}, dfMaxDistance2{opts.maxDistance * opts.maxDistance},
           poDstDS{}, dfHeightAdjFactor{0}, adfTransform{0, 1, 0, 0, 0, 1}
     {
+        if (dfMaxDistance2 == 0)
+            dfMaxDistance2 = std::numeric_limits<double>::max();
     }
 
     /**
@@ -171,6 +173,8 @@ class Viewshed
     double calcHeight(double dfZ, double dfZ2);
     bool readLine(int nLine, double *data);
     bool adjustHeightInRange(int iPixel, int iLine, double &dfHeight);
+    std::pair<int, int> adjustHeight(int iLine, int nX, double dfObserverHeight,
+                                     double *const pdfNx);
     bool calcOutputExtent(int nX, int nY);
     bool createOutputDataset();
     bool allocate();

--- a/alg/viewshed.h
+++ b/alg/viewshed.h
@@ -172,7 +172,6 @@ class Viewshed
     void setVisibility(int iPixel, double dfZ);
     double calcHeight(double dfZ, double dfZ2);
     bool readLine(int nLine, double *data);
-    bool adjustHeightInRange(int iPixel, int iLine, double &dfHeight);
     std::pair<int, int> adjustHeight(int iLine, int nX, double dfObserverHeight,
                                      double *const pdfNx);
     bool calcOutputExtent(int nX, int nY);

--- a/autotest/utilities/test_gdal_viewshed.py
+++ b/autotest/utilities/test_gdal_viewshed.py
@@ -68,7 +68,7 @@ def viewshed_input(tmp_path):
     gdaltest.runexternal(
         test_cli_utilities.get_gdalwarp_path()
         + " -t_srs EPSG:32617 -overwrite ../gdrivers/data/n43.tif "
-        + fname
+        + fname,
     )
 
     return fname
@@ -160,7 +160,6 @@ def test_gdal_viewshed_alternative_modes(gdal_viewshed_path, tmp_path, viewshed_
     assert cs == 8381
     assert nodata is None
 
-
 ###############################################################################
 
 
@@ -211,6 +210,89 @@ def test_gdal_viewshed_all_options(gdal_viewshed_path, tmp_path, viewshed_input)
     assert cs == 24435
     assert nodata == 0
 
+###############################################################################
+
+def test_gdal_viewshed_value_options(gdal_viewshed_path, tmp_path, viewshed_input):
+
+    viewshed_out = str(tmp_path / "test_gdal_viewshed_out.tif")
+
+    _, err = gdaltest.runexternal_out_and_err(
+        gdal_viewshed_path
+        + " -om NORMAL -f GTiff -oz {} -ox {} -oy {} -b 1 -a_nodata 0 -iv 127 -vv 254 -ov 0 {} {}".format(
+            oz[1], ox[0], oy[0], viewshed_input, viewshed_out
+        )
+    )
+    assert err is None or err == ""
+    ds = gdal.Open(viewshed_out)
+    assert ds
+    cs = ds.GetRasterBand(1).Checksum()
+    nodata = ds.GetRasterBand(1).GetNoDataValue()
+    ds = None
+    assert cs == 35091
+    assert nodata == 0
+
+###############################################################################
+
+def test_gdal_viewshed_tz_option(gdal_viewshed_path, tmp_path, viewshed_input):
+
+    viewshed_out = str(tmp_path / "test_gdal_viewshed_out.tif")
+
+    _, err = gdaltest.runexternal_out_and_err(
+        gdal_viewshed_path
+        + " -om NORMAL -f GTiff -oz {} -ox {} -oy {} -b 1 -a_nodata 0 -tz 5 {} {}".format(
+            oz[1], ox[0], oy[0], viewshed_input, viewshed_out
+        )
+    )
+    assert err is None or err == ""
+    ds = gdal.Open(viewshed_out)
+    assert ds
+    cs = ds.GetRasterBand(1).Checksum()
+    nodata = ds.GetRasterBand(1).GetNoDataValue()
+    ds = None
+    assert cs == 33725
+    assert nodata == 0
+
+###############################################################################
+
+def test_gdal_viewshed_cc_option(gdal_viewshed_path, tmp_path, viewshed_input):
+
+    viewshed_out = str(tmp_path / "test_gdal_viewshed_out.tif")
+
+    _, err = gdaltest.runexternal_out_and_err(
+        gdal_viewshed_path
+        + " -om NORMAL -f GTiff -oz {} -ox {} -oy {} -b 1 -a_nodata 0 -cc 0 {} {}".format(
+            oz[1], ox[0], oy[0], viewshed_input, viewshed_out
+        )
+    )
+    assert err is None or err == ""
+    ds = gdal.Open(viewshed_out)
+    assert ds
+    cs = ds.GetRasterBand(1).Checksum()
+    nodata = ds.GetRasterBand(1).GetNoDataValue()
+    ds = None
+    assert cs == 17241
+    assert nodata == 0
+
+###############################################################################
+
+def test_gdal_viewshed_md_option(gdal_viewshed_path, tmp_path, viewshed_input):
+
+    viewshed_out = str(tmp_path / "test_gdal_viewshed_out.tif")
+
+    _, err = gdaltest.runexternal_out_and_err(
+        gdal_viewshed_path
+        + " -om NORMAL -f GTiff -oz {} -ox {} -oy {} -b 1 -a_nodata 0 -tz 5 -md 20000 {} {}".format(
+            oz[1], ox[0], oy[0], viewshed_input, viewshed_out
+        )
+    )
+    assert err is None or err == ""
+    ds = gdal.Open(viewshed_out)
+    assert ds
+    cs = ds.GetRasterBand(1).Checksum()
+    nodata = ds.GetRasterBand(1).GetNoDataValue()
+    ds = None
+    assert cs == 22617
+    assert nodata == 0
 
 ###############################################################################
 

--- a/autotest/utilities/test_gdal_viewshed.py
+++ b/autotest/utilities/test_gdal_viewshed.py
@@ -160,6 +160,7 @@ def test_gdal_viewshed_alternative_modes(gdal_viewshed_path, tmp_path, viewshed_
     assert cs == 8381
     assert nodata is None
 
+
 ###############################################################################
 
 
@@ -210,7 +211,9 @@ def test_gdal_viewshed_all_options(gdal_viewshed_path, tmp_path, viewshed_input)
     assert cs == 24435
     assert nodata == 0
 
+
 ###############################################################################
+
 
 def test_gdal_viewshed_value_options(gdal_viewshed_path, tmp_path, viewshed_input):
 
@@ -231,7 +234,9 @@ def test_gdal_viewshed_value_options(gdal_viewshed_path, tmp_path, viewshed_inpu
     assert cs == 35091
     assert nodata == 0
 
+
 ###############################################################################
+
 
 def test_gdal_viewshed_tz_option(gdal_viewshed_path, tmp_path, viewshed_input):
 
@@ -252,7 +257,9 @@ def test_gdal_viewshed_tz_option(gdal_viewshed_path, tmp_path, viewshed_input):
     assert cs == 33725
     assert nodata == 0
 
+
 ###############################################################################
+
 
 def test_gdal_viewshed_cc_option(gdal_viewshed_path, tmp_path, viewshed_input):
 
@@ -273,7 +280,9 @@ def test_gdal_viewshed_cc_option(gdal_viewshed_path, tmp_path, viewshed_input):
     assert cs == 17241
     assert nodata == 0
 
+
 ###############################################################################
+
 
 def test_gdal_viewshed_md_option(gdal_viewshed_path, tmp_path, viewshed_input):
 
@@ -293,6 +302,7 @@ def test_gdal_viewshed_md_option(gdal_viewshed_path, tmp_path, viewshed_input):
     ds = None
     assert cs == 22617
     assert nodata == 0
+
 
 ###############################################################################
 


### PR DESCRIPTION
This changes the implementation to use functions and uses threads for the separable bits. It also merges the two result vectors into one.