### PR TITLE
Doc: mark GDALSimpleImageWarp() and GDALReprojectImage() as superseded per GDALWarp()

### DIFF
--- a/alg/gdalsimplewarp.cpp
+++ b/alg/gdalsimplewarp.cpp
@@ -211,6 +211,8 @@ static void GDALSimpleWarpRemapping(int nBandCount, GByte **papabySrcData,
  * Distinct values may be listed for each band separated by columns.
  * </ul>
  *
+ * For more advanced warping capabilities, consider using GDALWarp().
+ *
  * @param hSrcDS the source image dataset.
  * @param hDstDS the destination image dataset.
  * @param nBandCount the number of bands to be warped.  If zero, all bands
@@ -225,6 +227,7 @@ static void GDALSimpleWarpRemapping(int nBandCount, GByte **papabySrcData,
  * @param papszWarpOptions additional options controlling the warp.
  *
  * @return TRUE if the operation completes, or FALSE if an error occurs.
+ * @see GDALWarp()
  */
 
 int CPL_STDCALL GDALSimpleImageWarp(GDALDatasetH hSrcDS, GDALDatasetH hDstDS,

--- a/alg/gdalwarper.cpp
+++ b/alg/gdalwarper.cpp
@@ -66,11 +66,12 @@
  * implement the reprojection, and will default a variety of other
  * warp options.
  *
- * No metadata, projection info, or color tables are transferred
- * to the output file.
+ * Nodata values set on destination dataset are taken into account.
  *
- * Starting with GDAL 2.0, nodata values set on destination dataset are taken
- * into account.
+ * No metadata, projection info, or color tables are transferred
+ * to the output file. Source overviews are not considered.
+ *
+ * For more advanced warping capabilities, consider using GDALWarp().
  *
  * @param hSrcDS the source image file.
  * @param pszSrcWKT the source projection.  If NULL the source projection
@@ -91,6 +92,7 @@
  * @param psOptions warp options, normally NULL.
  *
  * @return CE_None on success or CE_Failure if something goes wrong.
+ * @see GDALWarp()
  */
 
 CPLErr CPL_STDCALL GDALReprojectImage(

--- a/swig/include/python/docs/gdal_operations_docs.i
+++ b/swig/include/python/docs/gdal_operations_docs.i
@@ -108,3 +108,13 @@ collections.namedtuple(is_visible: bool, col_intersection: int, row_intersection
     col_intersection is the raster column index where the LOS line intersects with terrain (will be set in the future, currently set to -1).
     row_intersection is the raster row index where the LOS line intersects with terrain (will be set in the future, currently set to -1).
 ";
+
+// gdal.ReprojectImage
+%feature("docstring") ReprojectImage "
+
+Reproject image.
+
+See :cpp:func:`GDALReprojectImage`.
+
+Consider using :py:func:`osgeo.gdal.Warp` and :py:func:`osgeo.gdal.WarpOptions` instead
+";


### PR DESCRIPTION
Refs #10001
