### PR TITLE
OpenFileGDB: a couple writer side fixes

### DIFF
--- a/ogr/ogrsf_frmts/openfilegdb/filegdbtable.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/filegdbtable.cpp
@@ -965,7 +965,7 @@ bool FileGDBTable::Open(const char *pszFilename, bool bUpdate,
 
             OGRField sDefault;
             OGR_RawField_SetUnset(&sDefault);
-            if ((flags & 4) != 0)
+            if (flags & FileGDBField::MASK_EDITABLE)
             {
                 /* Default value */
                 /* Found on PreNIS.gdb/a0000000d.gdbtable */
@@ -1043,7 +1043,7 @@ bool FileGDBTable::Open(const char *pszFilename, bool bUpdate,
 
             if (eType == FGFT_OBJECTID)
             {
-                returnErrorIf(flags != 2);
+                returnErrorIf(flags != FileGDBField::MASK_REQUIRED);
                 returnErrorIf(m_iObjectIdField >= 0);
                 m_iObjectIdField = static_cast<int>(m_apoFields.size());
             }
@@ -1052,7 +1052,9 @@ bool FileGDBTable::Open(const char *pszFilename, bool bUpdate,
             poField->m_osName = osName;
             poField->m_osAlias = osAlias;
             poField->m_eType = eType;
-            poField->m_bNullable = (flags & 1) != 0;
+            poField->m_bNullable = (flags & FileGDBField::MASK_NULLABLE) != 0;
+            poField->m_bRequired = (flags & FileGDBField::MASK_REQUIRED) != 0;
+            poField->m_bEditable = (flags & FileGDBField::MASK_EDITABLE) != 0;
             poField->m_nMaxWidth = nMaxWidth;
             poField->m_sDefault = sDefault;
             m_apoFields.emplace_back(std::move(poField));
@@ -2834,11 +2836,19 @@ FileGDBField::FileGDBField(FileGDBTable *poParentIn) : m_poParent(poParentIn)
 
 FileGDBField::FileGDBField(const std::string &osName,
                            const std::string &osAlias, FileGDBFieldType eType,
-                           bool bNullable, int nMaxWidth,
-                           const OGRField &sDefault)
+                           bool bNullable, bool bRequired, bool bEditable,
+                           int nMaxWidth, const OGRField &sDefault)
     : m_osName(osName), m_osAlias(osAlias), m_eType(eType),
-      m_bNullable(bNullable), m_nMaxWidth(nMaxWidth)
+      m_bNullable(bNullable), m_bRequired(bRequired), m_bEditable(bEditable),
+      m_nMaxWidth(nMaxWidth)
 {
+    if (m_eType == FGFT_OBJECTID || m_eType == FGFT_GLOBALID)
+    {
+        CPLAssert(!m_bNullable);
+        CPLAssert(m_bRequired);
+        CPLAssert(!m_bEditable);
+    }
+
     if (m_eType == FGFT_STRING && !OGR_RawField_IsUnset(&sDefault) &&
         !OGR_RawField_IsNull(&sDefault))
     {
@@ -2918,7 +2928,8 @@ FileGDBGeomField::FileGDBGeomField(
     const std::string &osWKT, double dfXOrigin, double dfYOrigin,
     double dfXYScale, double dfXYTolerance,
     const std::vector<double> &adfSpatialIndexGridResolution)
-    : FileGDBField(osName, osAlias, FGFT_GEOMETRY, bNullable, 0,
+    : FileGDBField(osName, osAlias, FGFT_GEOMETRY, bNullable,
+                   /* bRequired = */ true, /* bEditable = */ true, 0,
                    FileGDBField::UNSET_FIELD),
       m_osWKT(osWKT), m_dfXOrigin(dfXOrigin), m_dfYOrigin(dfYOrigin),
       m_dfXYScale(dfXYScale), m_dfXYTolerance(dfXYTolerance),

--- a/ogr/ogrsf_frmts/openfilegdb/filegdbtable.h
+++ b/ogr/ogrsf_frmts/openfilegdb/filegdbtable.h
@@ -102,8 +102,11 @@ class FileGDBField
     std::string m_osAlias{};
     FileGDBFieldType m_eType = FGFT_UNDEFINED;
 
-    bool m_bNullable = false;
-    bool m_bHighPrecsion = false;  // for FGFT_DATETIME
+    bool m_bNullable = false;  // Bit 1 of flag field
+    bool m_bRequired =
+        false;  // Bit 2 of flag field. Set for ObjectID, geometry field and Shape_Area/Shape_Length
+    bool m_bEditable = false;       // Bit 3 of flag field.
+    bool m_bHighPrecision = false;  // for FGFT_DATETIME
     bool m_bReadAsDouble =
         false;           // used by FileGDBTable::CreateAttributeIndex()
     int m_nMaxWidth = 0; /* for string */
@@ -117,11 +120,17 @@ class FileGDBField
 
   public:
     static const OGRField UNSET_FIELD;
+    static constexpr int BIT_NULLABLE = 0;
+    static constexpr int BIT_REQUIRED = 1;
+    static constexpr int BIT_EDITABLE = 2;
+    static constexpr int MASK_NULLABLE = 1 << BIT_NULLABLE;
+    static constexpr int MASK_REQUIRED = 1 << BIT_REQUIRED;
+    static constexpr int MASK_EDITABLE = 1 << BIT_EDITABLE;
 
     explicit FileGDBField(FileGDBTable *m_poParent);
     FileGDBField(const std::string &osName, const std::string &osAlias,
-                 FileGDBFieldType eType, bool bNullable, int nMaxWidth,
-                 const OGRField &sDefault);
+                 FileGDBFieldType eType, bool bNullable, bool bRequired,
+                 bool bEditable, int nMaxWidth, const OGRField &sDefault);
     virtual ~FileGDBField();
 
     void SetParent(FileGDBTable *poParent)
@@ -149,6 +158,16 @@ class FileGDBField
         return m_bNullable;
     }
 
+    bool IsRequired() const
+    {
+        return m_bRequired;
+    }
+
+    bool IsEditable() const
+    {
+        return m_bEditable;
+    }
+
     int GetMaxWidth() const
     {
         return m_nMaxWidth;
@@ -161,12 +180,12 @@ class FileGDBField
 
     void SetHighPrecision()
     {
-        m_bHighPrecsion = true;
+        m_bHighPrecision = true;
     }
 
     bool IsHighPrecision() const
     {
-        return m_bHighPrecsion;
+        return m_bHighPrecision;
     }
 
     int HasIndex();

--- a/ogr/ogrsf_frmts/openfilegdb/filegdbtable.h
+++ b/ogr/ogrsf_frmts/openfilegdb/filegdbtable.h
@@ -450,6 +450,11 @@ class FileGDBTable
     vsi_l_offset m_nFileSize = 0; /* only read when needed */
     bool m_bUpdate = false;
 
+    //! This flag is set when we detect that a corruption of m_nHeaderBufferMaxSize
+    // prior to fix needs to  fdf39012788b1110b3bf0ae6b8422a528f0ae8b6 to be
+    // repaired
+    bool m_bHasWarnedAboutHeaderRepair = false;
+
     std::string m_osFilename{};
     bool m_bIsV9 = false;
     std::vector<std::unique_ptr<FileGDBField>> m_apoFields{};

--- a/ogr/ogrsf_frmts/openfilegdb/filegdbtable_write.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/filegdbtable_write.cpp
@@ -2016,6 +2016,7 @@ bool FileGDBTable::UpdateFeature(int nFID,
         m_nRowBufferMaxSize = std::max(m_nRowBufferMaxSize, m_nRowBlobLength);
         if (nFreeOffset == OFFSET_MINUS_ONE)
         {
+            m_bDirtyHeader = true;
             m_nFileSize += sizeof(uint32_t) + m_nRowBlobLength;
         }
 

--- a/ogr/ogrsf_frmts/openfilegdb/filegdbtable_write_fields.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/filegdbtable_write_fields.cpp
@@ -383,8 +383,17 @@ WriteFieldDescriptor(std::vector<GByte> &abyBuffer, const FileGDBField *psField,
     WriteUTF16String(abyBuffer, psField->GetAlias().c_str(),
                      NUMBER_OF_CHARS_ON_UINT8);
     WriteUInt8(abyBuffer, static_cast<uint8_t>(psField->GetType()));
-    constexpr int UNKNOWN_FIELD_FLAG = 4;
+
     const auto &sDefault = *(psField->GetDefault());
+
+    uint8_t nFlag = 0;
+    if (psField->IsNullable())
+        nFlag = static_cast<uint8_t>(nFlag | FileGDBField::MASK_NULLABLE);
+    if (psField->IsRequired())
+        nFlag = static_cast<uint8_t>(nFlag | FileGDBField::MASK_REQUIRED);
+    if (psField->IsEditable())
+        nFlag = static_cast<uint8_t>(nFlag | FileGDBField::MASK_EDITABLE);
+
     switch (psField->GetType())
     {
         case FGFT_UNDEFINED:
@@ -396,9 +405,7 @@ WriteFieldDescriptor(std::vector<GByte> &abyBuffer, const FileGDBField *psField,
         case FGFT_INT16:
         {
             WriteUInt8(abyBuffer, 2);  // sizeof(int16)
-            WriteUInt8(abyBuffer, static_cast<uint8_t>(
-                                      UNKNOWN_FIELD_FLAG |
-                                      static_cast<int>(psField->IsNullable())));
+            WriteUInt8(abyBuffer, nFlag);
             if (!OGR_RawField_IsNull(&sDefault) &&
                 !OGR_RawField_IsUnset(&sDefault))
             {
@@ -415,9 +422,7 @@ WriteFieldDescriptor(std::vector<GByte> &abyBuffer, const FileGDBField *psField,
         case FGFT_INT32:
         {
             WriteUInt8(abyBuffer, 4);  // sizeof(int32)
-            WriteUInt8(abyBuffer, static_cast<uint8_t>(
-                                      UNKNOWN_FIELD_FLAG |
-                                      static_cast<int>(psField->IsNullable())));
+            WriteUInt8(abyBuffer, nFlag);
             if (!OGR_RawField_IsNull(&sDefault) &&
                 !OGR_RawField_IsUnset(&sDefault))
             {
@@ -434,9 +439,7 @@ WriteFieldDescriptor(std::vector<GByte> &abyBuffer, const FileGDBField *psField,
         case FGFT_FLOAT32:
         {
             WriteUInt8(abyBuffer, 4);  // sizeof(float32)
-            WriteUInt8(abyBuffer, static_cast<uint8_t>(
-                                      UNKNOWN_FIELD_FLAG |
-                                      static_cast<int>(psField->IsNullable())));
+            WriteUInt8(abyBuffer, nFlag);
             if (!OGR_RawField_IsNull(&sDefault) &&
                 !OGR_RawField_IsUnset(&sDefault))
             {
@@ -453,9 +456,7 @@ WriteFieldDescriptor(std::vector<GByte> &abyBuffer, const FileGDBField *psField,
         case FGFT_FLOAT64:
         {
             WriteUInt8(abyBuffer, 8);  // sizeof(float64)
-            WriteUInt8(abyBuffer, static_cast<uint8_t>(
-                                      UNKNOWN_FIELD_FLAG |
-                                      static_cast<int>(psField->IsNullable())));
+            WriteUInt8(abyBuffer, nFlag);
             if (!OGR_RawField_IsNull(&sDefault) &&
                 !OGR_RawField_IsUnset(&sDefault))
             {
@@ -472,9 +473,7 @@ WriteFieldDescriptor(std::vector<GByte> &abyBuffer, const FileGDBField *psField,
         case FGFT_STRING:
         {
             WriteUInt32(abyBuffer, psField->GetMaxWidth());
-            WriteUInt8(abyBuffer, static_cast<uint8_t>(
-                                      UNKNOWN_FIELD_FLAG |
-                                      static_cast<int>(psField->IsNullable())));
+            WriteUInt8(abyBuffer, nFlag);
             if (!OGR_RawField_IsNull(&sDefault) &&
                 !OGR_RawField_IsUnset(&sDefault))
             {
@@ -505,9 +504,7 @@ WriteFieldDescriptor(std::vector<GByte> &abyBuffer, const FileGDBField *psField,
         case FGFT_DATE:
         {
             WriteUInt8(abyBuffer, 8);  // sizeof(float64)
-            WriteUInt8(abyBuffer, static_cast<uint8_t>(
-                                      UNKNOWN_FIELD_FLAG |
-                                      static_cast<int>(psField->IsNullable())));
+            WriteUInt8(abyBuffer, nFlag);
             if (!OGR_RawField_IsNull(&sDefault) &&
                 !OGR_RawField_IsUnset(&sDefault))
             {
@@ -536,9 +533,7 @@ WriteFieldDescriptor(std::vector<GByte> &abyBuffer, const FileGDBField *psField,
             const auto *geomField =
                 cpl::down_cast<const FileGDBGeomField *>(psField);
             WriteUInt8(abyBuffer, 0);  // unknown role
-            WriteUInt8(abyBuffer, static_cast<uint8_t>(
-                                      2 | UNKNOWN_FIELD_FLAG |
-                                      static_cast<int>(psField->IsNullable())));
+            WriteUInt8(abyBuffer, nFlag);
             WriteUTF16String(abyBuffer, geomField->GetWKT().c_str(),
                              NUMBER_OF_BYTES_ON_UINT16);
             WriteUInt8(
@@ -600,9 +595,7 @@ WriteFieldDescriptor(std::vector<GByte> &abyBuffer, const FileGDBField *psField,
         case FGFT_BINARY:
         {
             WriteUInt8(abyBuffer, 0);  // unknown role
-            WriteUInt8(abyBuffer, static_cast<uint8_t>(
-                                      UNKNOWN_FIELD_FLAG |
-                                      static_cast<int>(psField->IsNullable())));
+            WriteUInt8(abyBuffer, nFlag);
             break;
         }
 
@@ -617,27 +610,21 @@ WriteFieldDescriptor(std::vector<GByte> &abyBuffer, const FileGDBField *psField,
         case FGFT_GLOBALID:
         {
             WriteUInt8(abyBuffer, 38);  // size
-            WriteUInt8(abyBuffer, static_cast<uint8_t>(
-                                      UNKNOWN_FIELD_FLAG |
-                                      static_cast<int>(psField->IsNullable())));
+            WriteUInt8(abyBuffer, nFlag);
             break;
         }
 
         case FGFT_XML:
         {
             WriteUInt8(abyBuffer, 0);  // unknown role
-            WriteUInt8(abyBuffer, static_cast<uint8_t>(
-                                      UNKNOWN_FIELD_FLAG |
-                                      static_cast<int>(psField->IsNullable())));
+            WriteUInt8(abyBuffer, nFlag);
             break;
         }
 
         case FGFT_INT64:
         {
             WriteUInt8(abyBuffer, 8);  // sizeof(int64)
-            WriteUInt8(abyBuffer, static_cast<uint8_t>(
-                                      UNKNOWN_FIELD_FLAG |
-                                      static_cast<int>(psField->IsNullable())));
+            WriteUInt8(abyBuffer, nFlag);
             if (!OGR_RawField_IsNull(&sDefault) &&
                 !OGR_RawField_IsUnset(&sDefault))
             {
@@ -654,9 +641,7 @@ WriteFieldDescriptor(std::vector<GByte> &abyBuffer, const FileGDBField *psField,
         case FGFT_TIME:
         {
             WriteUInt8(abyBuffer, 8);  // sizeof(float64)
-            WriteUInt8(abyBuffer, static_cast<uint8_t>(
-                                      UNKNOWN_FIELD_FLAG |
-                                      static_cast<int>(psField->IsNullable())));
+            WriteUInt8(abyBuffer, nFlag);
             if (!OGR_RawField_IsNull(&sDefault) &&
                 !OGR_RawField_IsUnset(&sDefault))
             {
@@ -673,9 +658,7 @@ WriteFieldDescriptor(std::vector<GByte> &abyBuffer, const FileGDBField *psField,
         case FGFT_DATETIME_WITH_OFFSET:
         {
             WriteUInt8(abyBuffer, 8 + 2);  // sizeof(float64) + sizeof(int16)
-            WriteUInt8(abyBuffer, static_cast<uint8_t>(
-                                      UNKNOWN_FIELD_FLAG |
-                                      static_cast<int>(psField->IsNullable())));
+            WriteUInt8(abyBuffer, nFlag);
             if (!OGR_RawField_IsNull(&sDefault) &&
                 !OGR_RawField_IsUnset(&sDefault))
             {
@@ -978,7 +961,8 @@ bool FileGDBTable::AlterField(int iField, const std::string &osName,
     auto poIndex = m_apoFields[iField]->m_poIndex;
 
     m_apoFields[iField] = std::make_unique<FileGDBField>(
-        osName, osAlias, eType, bNullable, nMaxWidth, sDefault);
+        osName, osAlias, eType, bNullable, m_apoFields[iField]->IsRequired(),
+        m_apoFields[iField]->IsEditable(), nMaxWidth, sDefault);
     m_apoFields[iField]->SetParent(this);
     m_apoFields[iField]->m_poIndex = poIndex;
     if (poIndex && bRenameField)

--- a/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdbdatasource.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdbdatasource.cpp
@@ -681,7 +681,13 @@ bool OGROpenFileGDBDataSource::OpenFileGDBv10(
 
     CPLString osFilename(CPLFormFilename(
         m_osDirName, CPLSPrintf("a%08x.gdbtable", iGDBItems + 1), nullptr));
-    if (!oTable.Open(osFilename, false))
+
+    // Normally we don't need to update in update mode the GDB_Items table,
+    // but this may help repairing it, if we have corrupted it with past
+    // GDAL versions.
+    const bool bOpenInUpdateMode =
+        (poOpenInfo->nOpenFlags & GDAL_OF_UPDATE) != 0;
+    if (!oTable.Open(osFilename, bOpenInUpdateMode))
         return false;
 
     const int iUUID = oTable.GetFieldIdx("UUID");

--- a/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdbdatasource.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdbdatasource.cpp
@@ -2151,7 +2151,8 @@ OGROpenFileGDBDataSource::BuildSRS(const CPLXMLNode *psInfo)
             [](OGRSpatialReference &oSRS, int nLatestCode, int nCode)
         {
             bool bSuccess = false;
-            CPLPushErrorHandler(CPLQuietErrorHandler);
+            CPLErrorStateBackuper oQuietError(CPLQuietErrorHandler);
+
             // Try first with nLatestWKID as there is a higher chance it is a
             // EPSG code and not an ESRI one.
             if (nLatestCode > 0)
@@ -2193,8 +2194,7 @@ OGROpenFileGDBDataSource::BuildSRS(const CPLXMLNode *psInfo)
                     CPLDebug("OpenFileGDB", "Cannot import SRID %d", nCode);
                 }
             }
-            CPLPopErrorHandler();
-            CPLErrorReset();
+
             return bSuccess;
         };
 

--- a/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdbdatasource_write.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdbdatasource_write.cpp
@@ -566,14 +566,20 @@ bool OGROpenFileGDBDataSource::CreateGDBSystemCatalog()
     if (!oTable.Create(m_osGDBSystemCatalogFilename.c_str(), 4, FGTGT_NONE,
                        false, false) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "ID", std::string(), FGFT_OBJECTID, false, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "ID", std::string(), FGFT_OBJECTID,
+            /* bNullable = */ false,
+            /* bRequired = */ true,
+            /* bEditable = */ false, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "Name", std::string(), FGFT_STRING, false, 160,
-            FileGDBField::UNSET_FIELD)) ||
+            "Name", std::string(), FGFT_STRING,
+            /* bNullable = */ false,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 160, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "FileFormat", std::string(), FGFT_INT32, false, 0,
-            FileGDBField::UNSET_FIELD)))
+            "FileFormat", std::string(), FGFT_INT32,
+            /* bNullable = */ false,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)))
     {
         return false;
     }
@@ -616,14 +622,20 @@ bool OGROpenFileGDBDataSource::CreateGDBDBTune()
     FileGDBTable oTable;
     if (!oTable.Create(osFilename.c_str(), 4, FGTGT_NONE, false, false) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "Keyword", std::string(), FGFT_STRING, false, 32,
-            FileGDBField::UNSET_FIELD)) ||
+            "Keyword", std::string(), FGFT_STRING,
+            /* bNullable = */ false,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 32, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "ParameterName", std::string(), FGFT_STRING, false, 32,
-            FileGDBField::UNSET_FIELD)) ||
+            "ParameterName", std::string(), FGFT_STRING,
+            /* bNullable = */ false,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 32, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "ConfigString", std::string(), FGFT_STRING, true, 2048,
-            FileGDBField::UNSET_FIELD)))
+            "ConfigString", std::string(), FGFT_STRING,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 2048, FileGDBField::UNSET_FIELD)))
     {
         return false;
     }
@@ -709,41 +721,65 @@ bool OGROpenFileGDBDataSource::CreateGDBSpatialRefs()
     if (!oTable.Create(m_osGDBSpatialRefsFilename.c_str(), 4, FGTGT_NONE, false,
                        false) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "ID", std::string(), FGFT_OBJECTID, false, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "ID", std::string(), FGFT_OBJECTID,
+            /* bNullable = */ false,
+            /* bRequired = */ true,
+            /* bEditable = */ false, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "SRTEXT", std::string(), FGFT_STRING, false, 2048,
-            FileGDBField::UNSET_FIELD)) ||
+            "SRTEXT", std::string(), FGFT_STRING,
+            /* bNullable = */ false,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 2048, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "FalseX", std::string(), FGFT_FLOAT64, true, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "FalseX", std::string(), FGFT_FLOAT64,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "FalseY", std::string(), FGFT_FLOAT64, true, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "FalseY", std::string(), FGFT_FLOAT64,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "XYUnits", std::string(), FGFT_FLOAT64, true, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "XYUnits", std::string(), FGFT_FLOAT64,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "FalseZ", std::string(), FGFT_FLOAT64, true, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "FalseZ", std::string(), FGFT_FLOAT64,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "ZUnits", std::string(), FGFT_FLOAT64, true, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "ZUnits", std::string(), FGFT_FLOAT64,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "FalseM", std::string(), FGFT_FLOAT64, true, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "FalseM", std::string(), FGFT_FLOAT64,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "MUnits", std::string(), FGFT_FLOAT64, true, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "MUnits", std::string(), FGFT_FLOAT64,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "XYTolerance", std::string(), FGFT_FLOAT64, true, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "XYTolerance", std::string(), FGFT_FLOAT64,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "ZTolerance", std::string(), FGFT_FLOAT64, true, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "ZTolerance", std::string(), FGFT_FLOAT64,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "MTolerance", std::string(), FGFT_FLOAT64, true, 0,
-            FileGDBField::UNSET_FIELD)))
+            "MTolerance", std::string(), FGFT_FLOAT64,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)))
     {
         return false;
     }
@@ -789,53 +825,85 @@ bool OGROpenFileGDBDataSource::CreateGDBItems()
     if (!oTable.Create(m_osGDBItemsFilename.c_str(), 4, FGTGT_POLYGON, false,
                        false) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "ObjectID", std::string(), FGFT_OBJECTID, false, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "ObjectID", std::string(), FGFT_OBJECTID,
+            /* bNullable = */ false,
+            /* bRequired = */ true,
+            /* bEditable = */ false, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "UUID", std::string(), FGFT_GLOBALID, false, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "UUID", std::string(), FGFT_GLOBALID,
+            /* bNullable = */ false,
+            /* bRequired = */ true,
+            /* bEditable = */ false, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "Type", std::string(), FGFT_GUID, false, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "Type", std::string(), FGFT_GUID,
+            /* bNullable = */ false,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "Name", std::string(), FGFT_STRING, true, 160,
-            FileGDBField::UNSET_FIELD)) ||
+            "Name", std::string(), FGFT_STRING,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 160, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "PhysicalName", std::string(), FGFT_STRING, true, 160,
-            FileGDBField::UNSET_FIELD)) ||
+            "PhysicalName", std::string(), FGFT_STRING,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 160, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "Path", std::string(), FGFT_STRING, true, 260,
-            FileGDBField::UNSET_FIELD)) ||
+            "Path", std::string(), FGFT_STRING,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 260, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "DatasetSubtype1", std::string(), FGFT_INT32, true, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "DatasetSubtype1", std::string(), FGFT_INT32,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "DatasetSubtype2", std::string(), FGFT_INT32, true, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "DatasetSubtype2", std::string(), FGFT_INT32,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "DatasetInfo1", std::string(), FGFT_STRING, true, 255,
-            FileGDBField::UNSET_FIELD)) ||
+            "DatasetInfo1", std::string(), FGFT_STRING,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 255, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "DatasetInfo2", std::string(), FGFT_STRING, true, 255,
-            FileGDBField::UNSET_FIELD)) ||
+            "DatasetInfo2", std::string(), FGFT_STRING,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 255, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "URL", std::string(), FGFT_STRING, true, 255,
-            FileGDBField::UNSET_FIELD)) ||
+            "URL", std::string(), FGFT_STRING,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 255, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "Definition", std::string(), FGFT_XML, true, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "Definition", std::string(), FGFT_XML,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "Documentation", std::string(), FGFT_XML, true, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "Documentation", std::string(), FGFT_XML,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "ItemInfo", std::string(), FGFT_XML, true, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "ItemInfo", std::string(), FGFT_XML,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "Properties", std::string(), FGFT_INT32, true, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "Properties", std::string(), FGFT_INT32,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "Defaults", std::string(), FGFT_BINARY, true, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "Defaults", std::string(), FGFT_BINARY,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::move(poGeomField)))
     {
         return false;
@@ -899,17 +967,25 @@ bool OGROpenFileGDBDataSource::CreateGDBItemTypes()
     FileGDBTable oTable;
     if (!oTable.Create(osFilename.c_str(), 4, FGTGT_NONE, false, false) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "ObjectID", std::string(), FGFT_OBJECTID, false, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "ObjectID", std::string(), FGFT_OBJECTID,
+            /* bNullable = */ false,
+            /* bRequired = */ true,
+            /* bEditable = */ false, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "UUID", std::string(), FGFT_GUID, false, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "UUID", std::string(), FGFT_GUID,
+            /* bNullable = */ false,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "ParentTypeID", std::string(), FGFT_GUID, false, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "ParentTypeID", std::string(), FGFT_GUID,
+            /* bNullable = */ false,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "Name", std::string(), FGFT_STRING, false, 160,
-            FileGDBField::UNSET_FIELD)))
+            "Name", std::string(), FGFT_STRING,
+            /* bNullable = */ false,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 160, FileGDBField::UNSET_FIELD)))
     {
         return false;
     }
@@ -1014,26 +1090,40 @@ bool OGROpenFileGDBDataSource::CreateGDBItemRelationships()
     if (!oTable.Create(m_osGDBItemRelationshipsFilename.c_str(), 4, FGTGT_NONE,
                        false, false) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "ObjectID", std::string(), FGFT_OBJECTID, false, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "ObjectID", std::string(), FGFT_OBJECTID,
+            /* bNullable = */ false,
+            /* bRequired = */ true,
+            /* bEditable = */ false, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "UUID", std::string(), FGFT_GLOBALID, false, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "UUID", std::string(), FGFT_GLOBALID,
+            /* bNullable = */ false,
+            /* bRequired = */ true,
+            /* bEditable = */ false, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "OriginID", std::string(), FGFT_GUID, false, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "OriginID", std::string(), FGFT_GUID,
+            /* bNullable = */ false,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "DestID", std::string(), FGFT_GUID, false, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "DestID", std::string(), FGFT_GUID,
+            /* bNullable = */ false,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "Type", std::string(), FGFT_GUID, false, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "Type", std::string(), FGFT_GUID,
+            /* bNullable = */ false,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "Attributes", std::string(), FGFT_XML, true, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "Attributes", std::string(), FGFT_XML,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "Properties", std::string(), FGFT_INT32, true, 0,
-            FileGDBField::UNSET_FIELD)))
+            "Properties", std::string(), FGFT_INT32,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)))
     {
         return false;
     }
@@ -1057,29 +1147,45 @@ bool OGROpenFileGDBDataSource::CreateGDBItemRelationshipTypes()
     FileGDBTable oTable;
     if (!oTable.Create(osFilename.c_str(), 4, FGTGT_NONE, false, false) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "ObjectID", std::string(), FGFT_OBJECTID, false, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "ObjectID", std::string(), FGFT_OBJECTID,
+            /* bNullable = */ false,
+            /* bRequired = */ true,
+            /* bEditable = */ false, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "UUID", std::string(), FGFT_GUID, false, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "UUID", std::string(), FGFT_GUID,
+            /* bNullable = */ false,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "OrigItemTypeID", std::string(), FGFT_GUID, false, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "OrigItemTypeID", std::string(), FGFT_GUID,
+            /* bNullable = */ false,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "DestItemTypeID", std::string(), FGFT_GUID, false, 0,
-            FileGDBField::UNSET_FIELD)) ||
+            "DestItemTypeID", std::string(), FGFT_GUID,
+            /* bNullable = */ false,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "Name", std::string(), FGFT_STRING, true, 160,
-            FileGDBField::UNSET_FIELD)) ||
+            "Name", std::string(), FGFT_STRING,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 160, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "ForwardLabel", std::string(), FGFT_STRING, true, 255,
-            FileGDBField::UNSET_FIELD)) ||
+            "ForwardLabel", std::string(), FGFT_STRING,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 255, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "BackwardLabel", std::string(), FGFT_STRING, true, 255,
-            FileGDBField::UNSET_FIELD)) ||
+            "BackwardLabel", std::string(), FGFT_STRING,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 255, FileGDBField::UNSET_FIELD)) ||
         !oTable.CreateField(std::make_unique<FileGDBField>(
-            "IsContainment", std::string(), FGFT_INT16, true, 0,
-            FileGDBField::UNSET_FIELD)))
+            "IsContainment", std::string(), FGFT_INT16,
+            /* bNullable = */ true,
+            /* bRequired = */ false,
+            /* bEditable = */ true, 0, FileGDBField::UNSET_FIELD)))
     {
         return false;
     }

--- a/ogr/ogrsf_frmts/openfilegdb/test_ofgdb_write.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/test_ofgdb_write.cpp
@@ -40,24 +40,33 @@ int main()
     const int nTablxOffsetSize = 4;
     oTable.Create("test_ofgdb.gdbtable", nTablxOffsetSize, eTableGeomType,
                   bGeomTypeHasZ, bGeomTypeHasM);
-    oTable.CreateField(std::unique_ptr<FileGDBField>(
-        new FileGDBField("OBJECTID", "OBJECTID", FGFT_OBJECTID, false, 0,
-                         FileGDBField::UNSET_FIELD)));
+    oTable.CreateField(std::unique_ptr<FileGDBField>(new FileGDBField(
+        "OBJECTID", "OBJECTID", FGFT_OBJECTID,
+        /* nullable = */ false,
+        /* required = */ true,
+        /* editable = */ false, 0, FileGDBField::UNSET_FIELD)));
 
-    oTable.CreateField(std::unique_ptr<FileGDBField>(new FileGDBField(
-        "int16", "", FGFT_INT16, true, 0, FileGDBField::UNSET_FIELD)));
-    oTable.CreateField(std::unique_ptr<FileGDBField>(new FileGDBField(
-        "int32", "", FGFT_INT32, true, 0, FileGDBField::UNSET_FIELD)));
-    oTable.CreateField(std::unique_ptr<FileGDBField>(new FileGDBField(
-        "float32", "", FGFT_FLOAT32, true, 0, FileGDBField::UNSET_FIELD)));
-    oTable.CreateField(std::unique_ptr<FileGDBField>(new FileGDBField(
-        "float64", "", FGFT_FLOAT64, true, 0, FileGDBField::UNSET_FIELD)));
-    oTable.CreateField(std::unique_ptr<FileGDBField>(new FileGDBField(
-        "str", "", FGFT_STRING, true, 0, FileGDBField::UNSET_FIELD)));
-    oTable.CreateField(std::unique_ptr<FileGDBField>(new FileGDBField(
-        "datetime", "", FGFT_DATETIME, true, 0, FileGDBField::UNSET_FIELD)));
-    oTable.CreateField(std::unique_ptr<FileGDBField>(new FileGDBField(
-        "binary", "", FGFT_BINARY, true, 0, FileGDBField::UNSET_FIELD)));
+    oTable.CreateField(std::unique_ptr<FileGDBField>(
+        new FileGDBField("int16", "", FGFT_INT16, true, false, true, 0,
+                         FileGDBField::UNSET_FIELD)));
+    oTable.CreateField(std::unique_ptr<FileGDBField>(
+        new FileGDBField("int32", "", FGFT_INT32, true, false, true, 0,
+                         FileGDBField::UNSET_FIELD)));
+    oTable.CreateField(std::unique_ptr<FileGDBField>(
+        new FileGDBField("float32", "", FGFT_FLOAT32, true, false, true, 0,
+                         FileGDBField::UNSET_FIELD)));
+    oTable.CreateField(std::unique_ptr<FileGDBField>(
+        new FileGDBField("float64", "", FGFT_FLOAT64, true, false, true, 0,
+                         FileGDBField::UNSET_FIELD)));
+    oTable.CreateField(std::unique_ptr<FileGDBField>(
+        new FileGDBField("str", "", FGFT_STRING, true, false, true, 0,
+                         FileGDBField::UNSET_FIELD)));
+    oTable.CreateField(std::unique_ptr<FileGDBField>(
+        new FileGDBField("datetime", "", FGFT_DATETIME, true, false, true, 0,
+                         FileGDBField::UNSET_FIELD)));
+    oTable.CreateField(std::unique_ptr<FileGDBField>(
+        new FileGDBField("binary", "", FGFT_BINARY, true, false, true, 0,
+                         FileGDBField::UNSET_FIELD)));
 
     auto poGeomField = std::unique_ptr<FileGDBGeomField>(new FileGDBGeomField(
         "SHAPE", "", true, "{B286C06B-0879-11D2-AACA-00C04FA33C20}", -400, -400,


### PR DESCRIPTION
Related to https://github.com/qgis/QGIS/issues/57536. That issue itself is much likely due to using a version of GDAL prior to fdf39012788b1110b3bf0ae6b8422a528f0ae8b6 / GDAL 3.9.0.

The following set of fixes 

- OpenFileGDB writer: correctly set flag on non-editable Shape_Length/Shape_Area special fields
    
    We fix both the flag attribute of the field declaration in .gdbtable,
    and the XML declaration of the field.

- OpenFileGDB writer: .gdbtable header must be rewritten when updating an existing feature at the end of file
    
    The only consequence of the omission of that fix is that the file size
    in the .gdbtable could be incorrect. A wrong file size in the header has no
    consequence on OpenFileGDB reader/writer. It also doesn't seem to affect
    Esri reader side, but it could *potentially* affect the writing side, if
    that field was trusted to seek to the end of the file.

- OpenFileGDB: detect and try to repair corruption of .gdbtable header
    
    Versions of the driver before commit fdf39012788b1110b3bf0ae6b8422a528f0ae8b6
    didn't properly update the m_nHeaderBufferMaxSize field when updating an
    existing feature when the new version takes more space than the previous
    version. OpenFileGDB doesn't care but Esri software (FileGDB SDK or
    ArcMap/ArcGis) do, leading to issues such as
    https://github.com/qgis/QGIS/issues/57536

