### PR TITLE
argparse.hpp: add argument name after 'Too few arguments' error

### DIFF
--- a/apps/argparse/argparse.hpp
+++ b/apps/argparse/argparse.hpp
@@ -1011,7 +1011,8 @@ public:
             std::bind(is_optional, std::placeholders::_1, m_prefix_chars));
         dist = static_cast<std::size_t>(std::distance(start, end));
         if (dist < num_args_min) {
-          throw std::runtime_error("Too few arguments");
+          throw std::runtime_error("Too few arguments for '" +
+                                   std::string(m_used_name) + "'.");
         }
       }
 


### PR DESCRIPTION
Fixes #10011
