### PR TITLE
Python utilities: avoid UseExceptions() related deprecation warning when launched from launcher shell scripts

### DIFF
--- a/autotest/gcore/basic_test.py
+++ b/autotest/gcore/basic_test.py
@@ -331,6 +331,15 @@ def test_basic_test_11():
         with pytest.raises(Exception):
             gdal.OpenEx("non existing")
 
+    try:
+        with gdal.ExceptionMgr(useExceptions=True):
+            try:
+                gdal.OpenEx("non existing")
+            except Exception:
+                pass
+    except Exception:
+        pytest.fails("Exception thrown whereas it should not have")
+
 
 ###############################################################################
 # Test GDAL layer API

--- a/autotest/gcore/basic_test.py
+++ b/autotest/gcore/basic_test.py
@@ -340,6 +340,13 @@ def test_basic_test_11():
     except Exception:
         pytest.fails("Exception thrown whereas it should not have")
 
+    with gdal.ExceptionMgr(useExceptions=True):
+        try:
+            gdal.OpenEx("non existing")
+        except Exception:
+            pass
+        gdal.Open("data/byte.tif")
+
 
 ###############################################################################
 # Test GDAL layer API

--- a/autotest/pyscripts/test_gdal2tiles.py
+++ b/autotest/pyscripts/test_gdal2tiles.py
@@ -257,6 +257,9 @@ def test_gdal2tiles_py_invalid_srs(script_path, tmp_path):
     and no --s_srs option is provided. The script should fail validation and terminate.
     """
 
+    if gdaltest.is_travis_branch("sanitize"):
+        pytest.skip("fails on sanitize for unknown reason")
+
     input_vrt = str(tmp_path / "out_gdal2tiles_test_nosrs.vrt")
     byte_tif = str(tmp_path / "byte.tif")
     output_dir = input_vrt.strip(".vrt")

--- a/autotest/pyscripts/test_gdal2tiles.py
+++ b/autotest/pyscripts/test_gdal2tiles.py
@@ -116,9 +116,13 @@ def test_gdal2tiles_py_simple(script_path, tmp_path):
     prev_wd = os.getcwd()
     try:
         os.chdir(tmp_path)
-        test_py_scripts.run_py_script(script_path, "gdal2tiles", f"-q {input_tif}")
+        _, err = test_py_scripts.run_py_script(
+            script_path, "gdal2tiles", f"-q {input_tif}", return_stderr=True
+        )
     finally:
         os.chdir(prev_wd)
+
+    assert "UseExceptions" not in err
 
     _verify_raster_band_checksums(
         f"{tmp_path}/out_gdal2tiles_smallworld/0/0/0.png",

--- a/autotest/pyscripts/test_gdal2xyz.py
+++ b/autotest/pyscripts/test_gdal2xyz.py
@@ -30,6 +30,7 @@
 
 import os
 
+import gdaltest
 import pytest
 import test_py_scripts
 
@@ -63,6 +64,9 @@ def script_path():
 
 
 def test_gdal2xyz_help(script_path):
+
+    if gdaltest.is_travis_branch("sanitize"):
+        pytest.skip("fails on sanitize for unknown reason")
 
     assert "ERROR" not in test_py_scripts.run_py_script(
         script_path, "gdal2xyz", "--help"

--- a/autotest/pyscripts/test_gdal2xyz.py
+++ b/autotest/pyscripts/test_gdal2xyz.py
@@ -143,7 +143,10 @@ def test_gdal2xyz_py_2(script_path, tmp_path):
     arguments += " " + test_py_scripts.get_data_path("gcore") + "byte.tif "
     arguments += out_xyz
 
-    test_py_scripts.run_py_script(script_path, "gdal2xyz", arguments)
+    _, err = test_py_scripts.run_py_script(
+        script_path, "gdal2xyz", arguments, return_stderr=True
+    )
+    assert "UseExceptions" not in err
 
     assert os.path.exists(out_xyz)
 

--- a/autotest/pyscripts/test_gdal_calc.py
+++ b/autotest/pyscripts/test_gdal_calc.py
@@ -156,9 +156,14 @@ def test_gdal_calc_py_1(script_path, tmp_path, stefan_full_rgba):
     test_id, test_count = 1, 3
     out = make_temp_filename_list(tmp_path, test_id, test_count)
 
-    test_py_scripts.run_py_script(
-        script_path, "gdal_calc", f"-A {infile} --calc=A --overwrite --outfile {out[0]}"
+    _, err = test_py_scripts.run_py_script(
+        script_path,
+        "gdal_calc",
+        f"-A {infile} --calc=A --overwrite --outfile {out[0]}",
+        return_stderr=True,
     )
+    assert "UseExceptions" not in err
+
     test_py_scripts.run_py_script(
         script_path,
         "gdal_calc",

--- a/autotest/pyscripts/test_gdal_edit.py
+++ b/autotest/pyscripts/test_gdal_edit.py
@@ -97,7 +97,7 @@ def test_gdal_edit_py_1(script_path, tmp_path, read_only):
         val_encoded = val
 
     read_only_option = " -ro" if read_only else ""
-    test_py_scripts.run_py_script(
+    _, err = test_py_scripts.run_py_script(
         script_path,
         "gdal_edit",
         filename
@@ -107,7 +107,9 @@ def test_gdal_edit_py_1(script_path, tmp_path, read_only):
         + val_encoded
         + "=UTF8"
         + read_only_option,
+        return_stderr=True,
     )
+    assert "UseExceptions" not in err
 
     ds = gdal.Open(filename)
     wkt = ds.GetProjectionRef()

--- a/autotest/pyscripts/test_gdal_fillnodata.py
+++ b/autotest/pyscripts/test_gdal_fillnodata.py
@@ -76,11 +76,13 @@ def test_gdal_fillnodata_1(script_path, tmp_path):
 
     result_tif = str(tmp_path / "test_gdal_fillnodata_1.tif")
 
-    test_py_scripts.run_py_script(
+    _, err = test_py_scripts.run_py_script(
         script_path,
         "gdal_fillnodata",
         test_py_scripts.get_data_path("gcore") + f"byte.tif {result_tif}",
+        return_stderr=True,
     )
+    assert "UseExceptions" not in err
 
     ds = gdal.Open(result_tif)
     assert ds.GetRasterBand(1).Checksum() == 4672

--- a/autotest/pyscripts/test_gdal_merge.py
+++ b/autotest/pyscripts/test_gdal_merge.py
@@ -113,11 +113,13 @@ def test_gdal_merge_1(script_path, tmp_path):
 
     output_tif = str(tmp_path / "test_gdal_merge_1.tif")
 
-    test_py_scripts.run_py_script(
+    _, err = test_py_scripts.run_py_script(
         script_path,
         "gdal_merge",
         f"-o {output_tif} " + test_py_scripts.get_data_path("gcore") + "byte.tif",
+        return_stderr=True,
     )
+    assert "UseExceptions" not in err
 
     ds = gdal.Open(output_tif)
     assert ds.GetRasterBand(1).Checksum() == 4672

--- a/autotest/pyscripts/test_gdal_pansharpen.py
+++ b/autotest/pyscripts/test_gdal_pansharpen.py
@@ -99,14 +99,16 @@ def test_gdal_pansharpen_1(script_path, tmp_path, small_world_pan_tif):
 
     out_tif = str(tmp_path / "out.tif")
 
-    test_py_scripts.run_py_script(
+    _, err = test_py_scripts.run_py_script(
         script_path,
         "gdal_pansharpen",
         f" {small_world_pan_tif} "
         + test_py_scripts.get_data_path("gdrivers")
         + "small_world.tif "
         + out_tif,
+        return_stderr=True,
     )
+    assert "UseExceptions" not in err
 
     with gdal.Open(out_tif) as ds:
         cs = [ds.GetRasterBand(i + 1).Checksum() for i in range(ds.RasterCount)]

--- a/autotest/pyscripts/test_gdal_polygonize.py
+++ b/autotest/pyscripts/test_gdal_polygonize.py
@@ -90,11 +90,13 @@ def test_gdal_polygonize_1(script_path, tmp_path):
         shp_layer.CreateField(fd)
 
     # run the algorithm.
-    test_py_scripts.run_py_script(
+    _, err = test_py_scripts.run_py_script(
         script_path,
         "gdal_polygonize",
         test_py_scripts.get_data_path("alg") + f"polygonize_in.grd {tmp_path} poly DN",
+        return_stderr=True,
     )
+    assert "UseExceptions" not in err
 
     # Confirm we get the set of expected features in the output layer.
 

--- a/autotest/pyscripts/test_gdal_proximity.py
+++ b/autotest/pyscripts/test_gdal_proximity.py
@@ -79,11 +79,13 @@ def test_gdal_proximity_1(script_path, tmp_path):
     dst_ds = drv.Create(output_tif, 25, 25, 1, gdal.GDT_Byte)
     dst_ds = None
 
-    test_py_scripts.run_py_script(
+    _, err = test_py_scripts.run_py_script(
         script_path,
         "gdal_proximity",
         test_py_scripts.get_data_path("alg") + f"pat.tif {output_tif}",
+        return_stderr=True,
     )
+    assert "UseExceptions" not in err
 
     dst_ds = gdal.Open(output_tif)
     dst_band = dst_ds.GetRasterBand(1)

--- a/autotest/pyscripts/test_gdal_retile.py
+++ b/autotest/pyscripts/test_gdal_retile.py
@@ -118,13 +118,15 @@ def test_gdal_retile_2(script_path, tmp_path):
     out_dir = tmp_path / "outretile2"
     out_dir.mkdir()
 
-    test_py_scripts.run_py_script(
+    _, err = test_py_scripts.run_py_script(
         script_path,
         "gdal_retile",
         f"-v -levels 2 -r bilinear -targetDir {out_dir} "
         + test_py_scripts.get_data_path("gcore")
         + "rgba.tif",
+        return_stderr=True,
     )
+    assert "UseExceptions" not in err
 
     ds = gdal.Open(f"{out_dir}/2/rgba_1_1.tif")
     assert ds.GetRasterBand(1).Checksum() == 35, "wrong checksum for band 1"

--- a/autotest/pyscripts/test_gdal_sieve.py
+++ b/autotest/pyscripts/test_gdal_sieve.py
@@ -81,13 +81,15 @@ def test_gdal_sieve_1(script_path, tmp_path):
     dst_ds = drv.Create(test_tif, 5, 7, 1, gdal.GDT_Byte)
     dst_ds = None
 
-    test_py_scripts.run_py_script(
+    _, err = test_py_scripts.run_py_script(
         script_path,
         "gdal_sieve",
         "-nomask -st 2 -4 "
         + test_py_scripts.get_data_path("alg")
         + f"sieve_src.grd {test_tif}",
+        return_stderr=True,
     )
+    assert "UseExceptions" not in err
 
     dst_ds = gdal.Open(test_tif)
     dst_band = dst_ds.GetRasterBand(1)

--- a/autotest/pyscripts/test_gdalattachpct.py
+++ b/autotest/pyscripts/test_gdalattachpct.py
@@ -68,11 +68,13 @@ def test_gdalattachpct_basic(script_path, tmp_path, palette_file):
 
     out_filename = str(tmp_path / "dst.tif")
 
-    test_py_scripts.run_py_script(
+    _, err = test_py_scripts.run_py_script(
         script_path,
         "gdalattachpct",
         f" {palette_file} {src_filename} {out_filename}",
+        return_stderr=True,
     )
+    assert "UseExceptions" not in err
 
     ds = gdal.Open(out_filename)
     assert ds.GetDriver().ShortName == "GTiff"

--- a/autotest/pyscripts/test_gdalcompare.py
+++ b/autotest/pyscripts/test_gdalcompare.py
@@ -97,9 +97,13 @@ def test_gdalcompare_same(script_path, tmp_path):
 
     source_filename = str(tmp_path / "src.tif")
     shutil.copy("../gcore/data/byte.tif", source_filename)
-    ret = test_py_scripts.run_py_script(
-        script_path, "gdalcompare", f"{source_filename} {source_filename}"
+    ret, err = test_py_scripts.run_py_script(
+        script_path,
+        "gdalcompare",
+        f"{source_filename} {source_filename}",
+        return_stderr=True,
     )
+    assert "UseExceptions" not in err
     assert "Differences Found: 0" in ret
 
 

--- a/autotest/pyscripts/test_gdalmove.py
+++ b/autotest/pyscripts/test_gdalmove.py
@@ -78,11 +78,13 @@ def test_gdalmove_1(script_path, tmp_path):
 
     shutil.copy(test_py_scripts.get_data_path("gcore") + "byte.tif", test_tif)
 
-    test_py_scripts.run_py_script(
+    _, err = test_py_scripts.run_py_script(
         script_path,
         "gdalmove",
         f'-s_srs "+proj=utm +zone=11 +ellps=clrk66 +towgs84=0,0,0 +no_defs" -t_srs EPSG:32611 {test_tif} -et 1',
+        return_stderr=True,
     )
+    assert "UseExceptions" not in err
 
     ds = gdal.Open(test_tif)
     got_gt = ds.GetGeoTransform()

--- a/autotest/pyscripts/test_ogr_layer_algebra.py
+++ b/autotest/pyscripts/test_ogr_layer_algebra.py
@@ -110,11 +110,13 @@ def test_ogr_layer_algebra_intersection(script_path, tmp_path):
     method_layer = None
 
     # executing script
-    test_py_scripts.run_py_script(
+    _, err = test_py_scripts.run_py_script(
         script_path,
         "ogr_layer_algebra",
         f"Intersection -input_ds {input_path} -output_ds {output_path}  -method_ds {method_path}",
+        return_stderr=True,
     )
+    assert "UseExceptions" not in err
 
     driver = ogr.GetDriverByName("ESRI Shapefile")
     dataSource = driver.Open(output_path, 0)

--- a/autotest/pyscripts/test_ogrmerge.py
+++ b/autotest/pyscripts/test_ogrmerge.py
@@ -77,7 +77,7 @@ def test_ogrmerge_1(script_path, tmp_path):
 
     out_shp = str(tmp_path / "out.shp")
 
-    test_py_scripts.run_py_script(
+    _, err = test_py_scripts.run_py_script(
         script_path,
         "ogrmerge",
         f"-single -o {out_shp} "
@@ -85,7 +85,9 @@ def test_ogrmerge_1(script_path, tmp_path):
         + "poly.shp "
         + test_py_scripts.get_data_path("ogr")
         + "poly.shp",
+        return_stderr=True,
     )
+    assert "UseExceptions" not in err
 
     ds = ogr.Open(out_shp)
     lyr = ds.GetLayer(0)

--- a/autotest/pyscripts/test_pct.py
+++ b/autotest/pyscripts/test_pct.py
@@ -155,9 +155,10 @@ def test_pct2rgb_1(script_path, tmp_path, rgb2pct1_tif):
 
     output_tif = str(tmp_path / "test_pct2rgb_1.tif")
 
-    test_py_scripts.run_py_script(
-        script_path, "pct2rgb", f"{rgb2pct1_tif} {output_tif}"
+    _, err = test_py_scripts.run_py_script(
+        script_path, "pct2rgb", f"{rgb2pct1_tif} {output_tif}", return_stderr=True
     )
+    assert "UseExceptions" not in err
 
     ds = gdal.Open(output_tif)
     assert ds.GetRasterBand(1).Checksum() == 20963
@@ -220,13 +221,15 @@ def test_rgb2pct_3(script_path, tmp_path, rgb2pct2_tif):
 
     output_tif = str(tmp_path / "test_rgb2pct_3.tif")
 
-    test_py_scripts.run_py_script(
+    _, err = test_py_scripts.run_py_script(
         script_path,
         "rgb2pct",
         f"-pct {rgb2pct2_tif} "
         + test_py_scripts.get_data_path("gcore")
         + f"rgbsmall.tif {output_tif}",
+        return_stderr=True,
     )
+    assert "UseExceptions" not in err
 
     ds = gdal.Open(output_tif)
     assert ds.GetRasterBand(1).Checksum() == 16596

--- a/swig/include/python/python_exceptions.i
+++ b/swig/include/python/python_exceptions.i
@@ -65,7 +65,7 @@ PythonBindingErrorHandler(CPLErr eclass, CPLErrorNum err_no, const char *msg )
 %exception GetUseExceptions
 {
 %#ifdef SED_HACKS
-    if( bUseExceptions ) bLocalUseExceptionsCode = FALSE;
+    if( ReturnSame(TRUE) ) bLocalUseExceptionsCode = FALSE;
 %#endif
     result = GetUseExceptions();
 }
@@ -73,7 +73,7 @@ PythonBindingErrorHandler(CPLErr eclass, CPLErrorNum err_no, const char *msg )
 %exception _GetExceptionsLocal
 {
 %#ifdef SED_HACKS
-    if( bUseExceptions ) bLocalUseExceptionsCode = FALSE;
+    if( ReturnSame(TRUE) ) bLocalUseExceptionsCode = FALSE;
 %#endif
     $action
 }
@@ -89,7 +89,7 @@ PythonBindingErrorHandler(CPLErr eclass, CPLErrorNum err_no, const char *msg )
 %exception _UserHasSpecifiedIfUsingExceptions
 {
 %#ifdef SED_HACKS
-    if( bUseExceptions ) bLocalUseExceptionsCode = FALSE;
+    if( ReturnSame(TRUE) ) bLocalUseExceptionsCode = FALSE;
 %#endif
     $action
 }

--- a/swig/include/python/python_exceptions.i
+++ b/swig/include/python/python_exceptions.i
@@ -133,7 +133,7 @@ void _DontUseExceptions() {
 
 static int _UserHasSpecifiedIfUsingExceptions()
 {
-    return bUserHasSpecifiedIfUsingExceptions;
+    return bUserHasSpecifiedIfUsingExceptions || bUseExceptionsLocal >= 0;
 }
 
 %}

--- a/swig/include/python/python_exceptions.i
+++ b/swig/include/python/python_exceptions.i
@@ -81,7 +81,7 @@ PythonBindingErrorHandler(CPLErr eclass, CPLErrorNum err_no, const char *msg )
 %exception _SetExceptionsLocal
 {
 %#ifdef SED_HACKS
-    if( bUseExceptions ) bLocalUseExceptionsCode = FALSE;
+    if( ReturnSame(TRUE) ) bLocalUseExceptionsCode = FALSE;
 %#endif
     $action
 }

--- a/swig/python/gdal-utils/osgeo_utils/auxiliary/util.py
+++ b/swig/python/gdal-utils/osgeo_utils/auxiliary/util.py
@@ -34,7 +34,7 @@ from numbers import Real
 from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple, Union
 
 from osgeo import __version__ as gdal_version_str
-from osgeo import gdal
+from osgeo import gdal, ogr, osr
 from osgeo_utils.auxiliary.base import (
     MaybeSequence,
     OptionalBoolStr,
@@ -52,6 +52,16 @@ CreationOptions = Optional[Dict[str, Any]]
 gdal_version = tuple(int(s) for s in str(gdal_version_str).split(".") if s.isdigit())[
     :3
 ]
+
+
+def enable_gdal_exceptions(fun):
+    def enable_exceptions_wrapper(*args, **kwargs):
+        with gdal.ExceptionMgr(useExceptions=True), osr.ExceptionMgr(
+            useExceptions=True
+        ), ogr.ExceptionMgr(useExceptions=True):
+            return fun(*args, **kwargs)
+
+    return enable_exceptions_wrapper
 
 
 def DoesDriverHandleExtension(drv: gdal.Driver, ext: str) -> bool:

--- a/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
@@ -59,6 +59,8 @@ from osgeo import gdal, osr
 
 Options = Any
 
+gdal.UseExceptions()
+
 try:
     import numpy
     from PIL import Image

--- a/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
@@ -56,6 +56,7 @@ from uuid import uuid4
 from xml.etree import ElementTree
 
 from osgeo import gdal, osr
+from osgeo_utils.auxiliary.util import enable_gdal_exceptions
 
 Options = Any
 
@@ -4585,19 +4586,8 @@ def single_threaded_tiling(
     shutil.rmtree(os.path.dirname(conf.src_file))
 
 
+@enable_gdal_exceptions
 def multi_threaded_tiling(
-    input_file: str, output_folder: str, options: Options, pool
-) -> None:
-    with gdal.ExceptionMgr(), osr.ExceptionMgr():
-        return _multi_threaded_tiling(
-            input_file=input_file,
-            output_folder=output_folder,
-            options=options,
-            pool=pool,
-        )
-
-
-def _multi_threaded_tiling(
     input_file: str, output_folder: str, options: Options, pool
 ) -> None:
     nb_processes = options.nb_processes or 1
@@ -4696,14 +4686,8 @@ def main(argv: List[str] = sys.argv, called_from_main=False) -> int:
         return submain(argv, called_from_main=called_from_main)
 
 
+@enable_gdal_exceptions
 def submain(argv: List[str], pool=None, pool_size=0, called_from_main=False) -> int:
-    with gdal.ExceptionMgr(), osr.ExceptionMgr():
-        return _submain(
-            argv=argv, pool=pool, pool_size=pool_size, called_from_main=called_from_main
-        )
-
-
-def _submain(argv: List[str], pool=None, pool_size=0, called_from_main=False) -> int:
 
     argv = gdal.GeneralCmdLineProcessor(argv)
     if argv is None:

--- a/swig/python/gdal-utils/osgeo_utils/gdal2xyz.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal2xyz.py
@@ -61,6 +61,37 @@ def gdal2xyz(
     pre_allocate_np_arrays: bool = True,
     progress_callback: OptionalProgressCallback = ...,
 ) -> Optional[Tuple]:
+    with gdal.ExceptionMgr():
+        return _gdal2xyz(
+            srcfile=srcfile,
+            dstfile=dstfile,
+            srcwin=srcwin,
+            skip=skip,
+            band_nums=band_nums,
+            delim=delim,
+            skip_nodata=skip_nodata,
+            src_nodata=src_nodata,
+            dst_nodata=dst_nodata,
+            return_np_arrays=return_np_arrays,
+            pre_allocate_np_arrays=pre_allocate_np_arrays,
+            progress_callback=progress_callback,
+        )
+
+
+def _gdal2xyz(
+    srcfile: PathOrDS,
+    dstfile: PathLikeOrStr = None,
+    srcwin: Optional[Sequence[int]] = None,
+    skip: Union[int, Sequence[int]] = 1,
+    band_nums: Optional[Sequence[int]] = None,
+    delim: str = " ",
+    skip_nodata: bool = False,
+    src_nodata: Optional[Union[Sequence, Number]] = None,
+    dst_nodata: Optional[Union[Sequence, Number]] = None,
+    return_np_arrays: bool = False,
+    pre_allocate_np_arrays: bool = True,
+    progress_callback: OptionalProgressCallback = ...,
+) -> Optional[Tuple]:
     """
     translates a raster file (or dataset) into xyz format
 
@@ -423,7 +454,6 @@ class GDAL2XYZ(GDALScript):
 
 
 def main(argv=sys.argv):
-    gdal.UseExceptions()
     return GDAL2XYZ().main(argv)
 
 

--- a/swig/python/gdal-utils/osgeo_utils/gdal2xyz.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal2xyz.py
@@ -423,6 +423,7 @@ class GDAL2XYZ(GDALScript):
 
 
 def main(argv=sys.argv):
+    gdal.UseExceptions()
     return GDAL2XYZ().main(argv)
 
 

--- a/swig/python/gdal-utils/osgeo_utils/gdal2xyz.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal2xyz.py
@@ -44,41 +44,16 @@ from osgeo_utils.auxiliary.progress import (
     OptionalProgressCallback,
     get_progress_callback,
 )
-from osgeo_utils.auxiliary.util import PathOrDS, get_bands, open_ds
+from osgeo_utils.auxiliary.util import (
+    PathOrDS,
+    enable_gdal_exceptions,
+    get_bands,
+    open_ds,
+)
 
 
+@enable_gdal_exceptions
 def gdal2xyz(
-    srcfile: PathOrDS,
-    dstfile: PathLikeOrStr = None,
-    srcwin: Optional[Sequence[int]] = None,
-    skip: Union[int, Sequence[int]] = 1,
-    band_nums: Optional[Sequence[int]] = None,
-    delim: str = " ",
-    skip_nodata: bool = False,
-    src_nodata: Optional[Union[Sequence, Number]] = None,
-    dst_nodata: Optional[Union[Sequence, Number]] = None,
-    return_np_arrays: bool = False,
-    pre_allocate_np_arrays: bool = True,
-    progress_callback: OptionalProgressCallback = ...,
-) -> Optional[Tuple]:
-    with gdal.ExceptionMgr():
-        return _gdal2xyz(
-            srcfile=srcfile,
-            dstfile=dstfile,
-            srcwin=srcwin,
-            skip=skip,
-            band_nums=band_nums,
-            delim=delim,
-            skip_nodata=skip_nodata,
-            src_nodata=src_nodata,
-            dst_nodata=dst_nodata,
-            return_np_arrays=return_np_arrays,
-            pre_allocate_np_arrays=pre_allocate_np_arrays,
-            progress_callback=progress_callback,
-        )
-
-
-def _gdal2xyz(
     srcfile: PathOrDS,
     dstfile: PathLikeOrStr = None,
     srcwin: Optional[Sequence[int]] = None,

--- a/swig/python/gdal-utils/osgeo_utils/gdal_calc.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_calc.py
@@ -925,6 +925,7 @@ class GDALCalc(GDALScript):
 
 
 def main(argv=sys.argv):
+    gdal.UseExceptions()
     return GDALCalc().main(argv)
 
 

--- a/swig/python/gdal-utils/osgeo_utils/gdal_calc.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_calc.py
@@ -124,6 +124,49 @@ def Calc(
     progress_callback: Optional = gdal.TermProgress_nocb,
     **input_files,
 ):
+    with gdal.ExceptionMgr():
+        return _Calc(
+            calc=calc,
+            outfile=outfile,
+            NoDataValue=NoDataValue,
+            type=type,
+            format=format,
+            creation_options=creation_options,
+            allBands=allBands,
+            overwrite=overwrite,
+            hideNoData=hideNoData,
+            projectionCheck=projectionCheck,
+            color_table=color_table,
+            extent=extent,
+            projwin=projwin,
+            user_namespace=user_namespace,
+            debug=debug,
+            quiet=quiet,
+            progress_callback=progress_callback,
+            **input_files,
+        )
+
+
+def _Calc(
+    calc: MaybeSequence[str],
+    outfile: Optional[PathLikeOrStr] = None,
+    NoDataValue: Optional[Number] = None,
+    type: Optional[Union[GDALDataType, str]] = None,
+    format: Optional[str] = None,
+    creation_options: Optional[Sequence[str]] = None,
+    allBands: str = "",
+    overwrite: bool = False,
+    hideNoData: bool = False,
+    projectionCheck: bool = False,
+    color_table: Optional[ColorTableLike] = None,
+    extent: Optional[Extent] = None,
+    projwin: Optional[Union[Tuple, GeoRectangle]] = None,
+    user_namespace: Optional[Dict] = None,
+    debug: bool = False,
+    quiet: bool = False,
+    progress_callback: Optional = gdal.TermProgress_nocb,
+    **input_files,
+):
 
     if debug:
         print(f"gdal_calc.py starting calculation {calc}")
@@ -925,7 +968,6 @@ class GDALCalc(GDALScript):
 
 
 def main(argv=sys.argv):
-    gdal.UseExceptions()
     return GDALCalc().main(argv)
 
 

--- a/swig/python/gdal-utils/osgeo_utils/gdal_calc.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_calc.py
@@ -50,7 +50,11 @@ from osgeo_utils.auxiliary.color_table import ColorTableLike, get_color_table
 from osgeo_utils.auxiliary.extent_util import GT, Extent
 from osgeo_utils.auxiliary.gdal_argparse import GDALArgumentParser, GDALScript
 from osgeo_utils.auxiliary.rectangle import GeoRectangle
-from osgeo_utils.auxiliary.util import GetOutputDriverFor, open_ds
+from osgeo_utils.auxiliary.util import (
+    GetOutputDriverFor,
+    enable_gdal_exceptions,
+    open_ds,
+)
 
 GDALDataType = int
 
@@ -104,50 +108,8 @@ sum all files with hidden noDataValue
 """
 
 
+@enable_gdal_exceptions
 def Calc(
-    calc: MaybeSequence[str],
-    outfile: Optional[PathLikeOrStr] = None,
-    NoDataValue: Optional[Number] = None,
-    type: Optional[Union[GDALDataType, str]] = None,
-    format: Optional[str] = None,
-    creation_options: Optional[Sequence[str]] = None,
-    allBands: str = "",
-    overwrite: bool = False,
-    hideNoData: bool = False,
-    projectionCheck: bool = False,
-    color_table: Optional[ColorTableLike] = None,
-    extent: Optional[Extent] = None,
-    projwin: Optional[Union[Tuple, GeoRectangle]] = None,
-    user_namespace: Optional[Dict] = None,
-    debug: bool = False,
-    quiet: bool = False,
-    progress_callback: Optional = gdal.TermProgress_nocb,
-    **input_files,
-):
-    with gdal.ExceptionMgr():
-        return _Calc(
-            calc=calc,
-            outfile=outfile,
-            NoDataValue=NoDataValue,
-            type=type,
-            format=format,
-            creation_options=creation_options,
-            allBands=allBands,
-            overwrite=overwrite,
-            hideNoData=hideNoData,
-            projectionCheck=projectionCheck,
-            color_table=color_table,
-            extent=extent,
-            projwin=projwin,
-            user_namespace=user_namespace,
-            debug=debug,
-            quiet=quiet,
-            progress_callback=progress_callback,
-            **input_files,
-        )
-
-
-def _Calc(
     calc: MaybeSequence[str],
     outfile: Optional[PathLikeOrStr] = None,
     NoDataValue: Optional[Number] = None,

--- a/swig/python/gdal-utils/osgeo_utils/gdal_edit.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_edit.py
@@ -538,6 +538,7 @@ def gdal_edit(argv):
 
 
 def main(argv=sys.argv):
+    gdal.UseExceptions()
     return gdal_edit(argv)
 
 

--- a/swig/python/gdal-utils/osgeo_utils/gdal_edit.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_edit.py
@@ -32,6 +32,7 @@
 import sys
 
 from osgeo import gdal, osr
+from osgeo_utils.auxiliary.util import enable_gdal_exceptions
 
 
 def Usage(isError):
@@ -86,12 +87,8 @@ def ArgIsNumeric(s):
     return True
 
 
+@enable_gdal_exceptions
 def gdal_edit(argv):
-    with gdal.ExceptionMgr(), osr.ExceptionMgr():
-        return _gdal_edit(argv)
-
-
-def _gdal_edit(argv):
 
     argv = gdal.GeneralCmdLineProcessor(argv)
     if argv is None:

--- a/swig/python/gdal-utils/osgeo_utils/gdal_edit.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_edit.py
@@ -87,6 +87,11 @@ def ArgIsNumeric(s):
 
 
 def gdal_edit(argv):
+    with gdal.ExceptionMgr(), osr.ExceptionMgr():
+        return _gdal_edit(argv)
+
+
+def _gdal_edit(argv):
 
     argv = gdal.GeneralCmdLineProcessor(argv)
     if argv is None:
@@ -345,19 +350,15 @@ def gdal_edit(argv):
         print("", file=sys.stderr)
         return Usage(isError=True)
 
-    if open_options is not None:
+    try:
         if ro:
             ds = gdal.OpenEx(datasetname, gdal.OF_RASTER, open_options=open_options)
         else:
             ds = gdal.OpenEx(
                 datasetname, gdal.OF_RASTER | gdal.OF_UPDATE, open_options=open_options
             )
-    # GDAL 1.X compat
-    elif ro:
-        ds = gdal.Open(datasetname)
-    else:
-        ds = gdal.Open(datasetname, gdal.GA_Update)
-    if ds is None:
+    except Exception as e:
+        print(str(e), file=sys.stderr)
         return -1
 
     if scale:
@@ -538,7 +539,6 @@ def gdal_edit(argv):
 
 
 def main(argv=sys.argv):
-    gdal.UseExceptions()
     return gdal_edit(argv)
 
 

--- a/swig/python/gdal-utils/osgeo_utils/gdal_fillnodata.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_fillnodata.py
@@ -37,6 +37,7 @@ from typing import Optional
 
 from osgeo import gdal
 from osgeo_utils.auxiliary.gdal_argparse import GDALArgumentParser, GDALScript
+from osgeo_utils.auxiliary.util import enable_gdal_exceptions
 
 
 def CopyBand(srcband, dstband):
@@ -47,36 +48,8 @@ def CopyBand(srcband, dstband):
         )
 
 
+@enable_gdal_exceptions
 def gdal_fillnodata(
-    src_filename: Optional[str] = None,
-    band_number: int = 1,
-    dst_filename: Optional[str] = None,
-    driver_name: str = "GTiff",
-    creation_options: Optional[list] = None,
-    quiet: bool = False,
-    mask: str = "default",
-    max_distance: Real = 100,
-    smoothing_iterations: int = 0,
-    interpolation: Optional[str] = None,
-    options: Optional[list] = None,
-):
-    with gdal.ExceptionMgr():
-        return _gdal_fillnodata(
-            src_filename=src_filename,
-            band_number=band_number,
-            dst_filename=dst_filename,
-            driver_name=driver_name,
-            creation_options=creation_options,
-            quiet=quiet,
-            mask=mask,
-            max_distance=max_distance,
-            smoothing_iterations=smoothing_iterations,
-            interpolation=interpolation,
-            options=options,
-        )
-
-
-def _gdal_fillnodata(
     src_filename: Optional[str] = None,
     band_number: int = 1,
     dst_filename: Optional[str] = None,

--- a/swig/python/gdal-utils/osgeo_utils/gdal_fillnodata.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_fillnodata.py
@@ -285,6 +285,7 @@ class GDALFillNoData(GDALScript):
 
 
 def main(argv=sys.argv):
+    gdal.UseExceptions()
     return GDALFillNoData().main(argv)
 
 

--- a/swig/python/gdal-utils/osgeo_utils/gdal_fillnodata.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_fillnodata.py
@@ -60,6 +60,35 @@ def gdal_fillnodata(
     interpolation: Optional[str] = None,
     options: Optional[list] = None,
 ):
+    with gdal.ExceptionMgr():
+        return _gdal_fillnodata(
+            src_filename=src_filename,
+            band_number=band_number,
+            dst_filename=dst_filename,
+            driver_name=driver_name,
+            creation_options=creation_options,
+            quiet=quiet,
+            mask=mask,
+            max_distance=max_distance,
+            smoothing_iterations=smoothing_iterations,
+            interpolation=interpolation,
+            options=options,
+        )
+
+
+def _gdal_fillnodata(
+    src_filename: Optional[str] = None,
+    band_number: int = 1,
+    dst_filename: Optional[str] = None,
+    driver_name: str = "GTiff",
+    creation_options: Optional[list] = None,
+    quiet: bool = False,
+    mask: str = "default",
+    max_distance: Real = 100,
+    smoothing_iterations: int = 0,
+    interpolation: Optional[str] = None,
+    options: Optional[list] = None,
+):
     options = options or []
     creation_options = creation_options or []
 
@@ -285,7 +314,6 @@ class GDALFillNoData(GDALScript):
 
 
 def main(argv=sys.argv):
-    gdal.UseExceptions()
     return GDALFillNoData().main(argv)
 
 

--- a/swig/python/gdal-utils/osgeo_utils/gdal_merge.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_merge.py
@@ -393,6 +393,11 @@ def Usage(isError):
 
 
 def gdal_merge(argv=None):
+    with gdal.ExceptionMgr():
+        return _gdal_merge(argv=argv)
+
+
+def _gdal_merge(argv=None):
     verbose = 0
     quiet = 0
     names = []
@@ -544,8 +549,10 @@ def gdal_merge(argv=None):
         band_type = file_infos[0].band_type
 
     # Try opening as an existing file.
-    with gdal.quiet_errors(), gdal.ExceptionMgr(useExceptions=False):
+    try:
         t_fh = gdal.Open(out_file, gdal.GA_Update)
+    except Exception:
+        t_fh = None
 
     # Create output file if it does not already exist.
     if t_fh is None:
@@ -647,7 +654,6 @@ def gdal_merge(argv=None):
 
 
 def main(argv=sys.argv):
-    gdal.UseExceptions()
     return gdal_merge(argv)
 
 

--- a/swig/python/gdal-utils/osgeo_utils/gdal_merge.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_merge.py
@@ -647,6 +647,7 @@ def gdal_merge(argv=None):
 
 
 def main(argv=sys.argv):
+    gdal.UseExceptions()
     return gdal_merge(argv)
 
 

--- a/swig/python/gdal-utils/osgeo_utils/gdal_pansharpen.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_pansharpen.py
@@ -69,6 +69,9 @@ def Usage(isError):
 
 
 def main(argv=sys.argv):
+
+    gdal.UseExceptions()
+
     argv = gdal.GeneralCmdLineProcessor(argv)
     if argv is None:
         return 0

--- a/swig/python/gdal-utils/osgeo_utils/gdal_pansharpen.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_pansharpen.py
@@ -68,9 +68,12 @@ def Usage(isError):
     return 2 if isError else 0
 
 
-def main(argv=sys.argv):
+def main(argv=None):
+    with gdal.ExceptionMgr():
+        return _main(argv=argv)
 
-    gdal.UseExceptions()
+
+def _main(argv=sys.argv):
 
     argv = gdal.GeneralCmdLineProcessor(argv)
     if argv is None:

--- a/swig/python/gdal-utils/osgeo_utils/gdal_pansharpen.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_pansharpen.py
@@ -37,7 +37,7 @@ from numbers import Real
 from typing import List, Optional, Sequence, Union
 
 from osgeo import gdal
-from osgeo_utils.auxiliary.util import GetOutputDriverFor
+from osgeo_utils.auxiliary.util import GetOutputDriverFor, enable_gdal_exceptions
 
 
 def Usage(isError):
@@ -68,12 +68,8 @@ def Usage(isError):
     return 2 if isError else 0
 
 
+@enable_gdal_exceptions
 def main(argv=None):
-    with gdal.ExceptionMgr():
-        return _main(argv=argv)
-
-
-def _main(argv=sys.argv):
 
     argv = gdal.GeneralCmdLineProcessor(argv)
     if argv is None:

--- a/swig/python/gdal-utils/osgeo_utils/gdal_polygonize.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_polygonize.py
@@ -355,6 +355,7 @@ class GDALPolygonize(GDALScript):
 
 
 def main(argv=sys.argv):
+    gdal.UseExceptions()
     return GDALPolygonize().main(argv)
 
 

--- a/swig/python/gdal-utils/osgeo_utils/gdal_polygonize.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_polygonize.py
@@ -54,6 +54,37 @@ def gdal_polygonize(
     layer_creation_options: Optional[list] = None,
     connectedness8: bool = False,
 ):
+    with gdal.ExceptionMgr(), ogr.ExceptionMgr():
+        return _gdal_polygonize(
+            src_filename=src_filename,
+            band_number=band_number,
+            dst_filename=dst_filename,
+            overwrite=overwrite,
+            driver_name=driver_name,
+            dst_layername=dst_layername,
+            dst_fieldname=dst_fieldname,
+            quiet=quiet,
+            mask=mask,
+            options=options,
+            layer_creation_options=layer_creation_options,
+            connectedness8=connectedness8,
+        )
+
+
+def _gdal_polygonize(
+    src_filename: Optional[str] = None,
+    band_number: Union[int, str] = 1,
+    dst_filename: Optional[str] = None,
+    overwrite: bool = False,
+    driver_name: Optional[str] = None,
+    dst_layername: Optional[str] = None,
+    dst_fieldname: Optional[str] = None,
+    quiet: bool = False,
+    mask: str = "default",
+    options: Optional[list] = None,
+    layer_creation_options: Optional[list] = None,
+    connectedness8: bool = False,
+):
 
     if isinstance(band_number, str) and not band_number.startswith("mask"):
         band_number = int(band_number)
@@ -355,7 +386,6 @@ class GDALPolygonize(GDALScript):
 
 
 def main(argv=sys.argv):
-    gdal.UseExceptions()
     return GDALPolygonize().main(argv)
 
 

--- a/swig/python/gdal-utils/osgeo_utils/gdal_polygonize.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_polygonize.py
@@ -37,41 +37,11 @@ from typing import Optional, Union
 
 from osgeo import gdal, ogr
 from osgeo_utils.auxiliary.gdal_argparse import GDALArgumentParser, GDALScript
-from osgeo_utils.auxiliary.util import GetOutputDriverFor
+from osgeo_utils.auxiliary.util import GetOutputDriverFor, enable_gdal_exceptions
 
 
+@enable_gdal_exceptions
 def gdal_polygonize(
-    src_filename: Optional[str] = None,
-    band_number: Union[int, str] = 1,
-    dst_filename: Optional[str] = None,
-    overwrite: bool = False,
-    driver_name: Optional[str] = None,
-    dst_layername: Optional[str] = None,
-    dst_fieldname: Optional[str] = None,
-    quiet: bool = False,
-    mask: str = "default",
-    options: Optional[list] = None,
-    layer_creation_options: Optional[list] = None,
-    connectedness8: bool = False,
-):
-    with gdal.ExceptionMgr(), ogr.ExceptionMgr():
-        return _gdal_polygonize(
-            src_filename=src_filename,
-            band_number=band_number,
-            dst_filename=dst_filename,
-            overwrite=overwrite,
-            driver_name=driver_name,
-            dst_layername=dst_layername,
-            dst_fieldname=dst_fieldname,
-            quiet=quiet,
-            mask=mask,
-            options=options,
-            layer_creation_options=layer_creation_options,
-            connectedness8=connectedness8,
-        )
-
-
-def _gdal_polygonize(
     src_filename: Optional[str] = None,
     band_number: Union[int, str] = 1,
     dst_filename: Optional[str] = None,

--- a/swig/python/gdal-utils/osgeo_utils/gdal_proximity.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_proximity.py
@@ -55,6 +55,11 @@ Usage: gdal_proximity.py [--help] [--help-general]
 
 
 def main(argv=sys.argv):
+    with gdal.ExceptionMgr():
+        return _main(argv=argv)
+
+
+def _main(argv=sys.argv):
     driver_name = None
     creation_options = []
     alg_options = []
@@ -64,8 +69,6 @@ def main(argv=sys.argv):
     dst_band_n = 1
     creation_type = "Float32"
     quiet = False
-
-    gdal.UseExceptions()
 
     argv = gdal.GeneralCmdLineProcessor(argv)
     if argv is None:

--- a/swig/python/gdal-utils/osgeo_utils/gdal_proximity.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_proximity.py
@@ -35,7 +35,7 @@ import sys
 from typing import Optional, Sequence
 
 from osgeo import gdal
-from osgeo_utils.auxiliary.util import GetOutputDriverFor
+from osgeo_utils.auxiliary.util import GetOutputDriverFor, enable_gdal_exceptions
 
 
 def Usage(isError):
@@ -54,12 +54,9 @@ Usage: gdal_proximity.py [--help] [--help-general]
     return 2 if isError else 0
 
 
+@enable_gdal_exceptions
 def main(argv=sys.argv):
-    with gdal.ExceptionMgr():
-        return _main(argv=argv)
 
-
-def _main(argv=sys.argv):
     driver_name = None
     creation_options = []
     alg_options = []

--- a/swig/python/gdal-utils/osgeo_utils/gdal_proximity.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_proximity.py
@@ -65,6 +65,8 @@ def main(argv=sys.argv):
     creation_type = "Float32"
     quiet = False
 
+    gdal.UseExceptions()
+
     argv = gdal.GeneralCmdLineProcessor(argv)
     if argv is None:
         return 0

--- a/swig/python/gdal-utils/osgeo_utils/gdal_retile.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_retile.py
@@ -942,8 +942,11 @@ def Usage(isError):
 
 
 def main(args=None, g=None):
+    with gdal.ExceptionMgr(), ogr.ExceptionMgr(), osr.ExceptionMgr():
+        return _main(args=args, g=g)
 
-    gdal.UseExceptions()
+
+def _main(args=None, g=None):
 
     if g is None:
         g = RetileGlobals()

--- a/swig/python/gdal-utils/osgeo_utils/gdal_retile.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_retile.py
@@ -34,6 +34,7 @@ import os
 import sys
 
 from osgeo import gdal, ogr, osr
+from osgeo_utils.auxiliary.util import enable_gdal_exceptions
 
 progress = gdal.TermProgress_nocb
 
@@ -941,12 +942,8 @@ def Usage(isError):
     return 2 if isError else 0
 
 
+@enable_gdal_exceptions
 def main(args=None, g=None):
-    with gdal.ExceptionMgr(), ogr.ExceptionMgr(), osr.ExceptionMgr():
-        return _main(args=args, g=g)
-
-
-def _main(args=None, g=None):
 
     if g is None:
         g = RetileGlobals()

--- a/swig/python/gdal-utils/osgeo_utils/gdal_retile.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_retile.py
@@ -942,6 +942,9 @@ def Usage(isError):
 
 
 def main(args=None, g=None):
+
+    gdal.UseExceptions()
+
     if g is None:
         g = RetileGlobals()
 

--- a/swig/python/gdal-utils/osgeo_utils/gdal_sieve.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_sieve.py
@@ -60,6 +60,8 @@ def main(argv=sys.argv):
 
     mask = "default"
 
+    gdal.UseExceptions()
+
     argv = gdal.GeneralCmdLineProcessor(argv)
     if argv is None:
         return 0

--- a/swig/python/gdal-utils/osgeo_utils/gdal_sieve.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_sieve.py
@@ -60,8 +60,6 @@ def main(argv=sys.argv):
 
     mask = "default"
 
-    gdal.UseExceptions()
-
     argv = gdal.GeneralCmdLineProcessor(argv)
     if argv is None:
         return 0
@@ -131,6 +129,27 @@ def main(argv=sys.argv):
 
 
 def gdal_sieve(
+    src_filename: Optional[str] = None,
+    dst_filename: PathLikeOrStr = None,
+    driver_name: Optional[str] = None,
+    mask: str = "default",
+    threshold: int = 2,
+    connectedness: int = 4,
+    quiet: bool = False,
+):
+    with gdal.ExceptionMgr():
+        return _gdal_sieve(
+            src_filename=src_filename,
+            dst_filename=dst_filename,
+            driver_name=driver_name,
+            mask=mask,
+            threshold=threshold,
+            connectedness=connectedness,
+            quiet=quiet,
+        )
+
+
+def _gdal_sieve(
     src_filename: Optional[str] = None,
     dst_filename: PathLikeOrStr = None,
     driver_name: Optional[str] = None,

--- a/swig/python/gdal-utils/osgeo_utils/gdal_sieve.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal_sieve.py
@@ -35,7 +35,7 @@ from typing import Optional
 
 from osgeo import gdal
 from osgeo_utils.auxiliary.base import PathLikeOrStr
-from osgeo_utils.auxiliary.util import GetOutputDriverFor
+from osgeo_utils.auxiliary.util import GetOutputDriverFor, enable_gdal_exceptions
 
 
 def Usage(isError=True):
@@ -128,28 +128,8 @@ def main(argv=sys.argv):
     )
 
 
+@enable_gdal_exceptions
 def gdal_sieve(
-    src_filename: Optional[str] = None,
-    dst_filename: PathLikeOrStr = None,
-    driver_name: Optional[str] = None,
-    mask: str = "default",
-    threshold: int = 2,
-    connectedness: int = 4,
-    quiet: bool = False,
-):
-    with gdal.ExceptionMgr():
-        return _gdal_sieve(
-            src_filename=src_filename,
-            dst_filename=dst_filename,
-            driver_name=driver_name,
-            mask=mask,
-            threshold=threshold,
-            connectedness=connectedness,
-            quiet=quiet,
-        )
-
-
-def _gdal_sieve(
     src_filename: Optional[str] = None,
     dst_filename: PathLikeOrStr = None,
     driver_name: Optional[str] = None,

--- a/swig/python/gdal-utils/osgeo_utils/gdalattachpct.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdalattachpct.py
@@ -37,7 +37,11 @@ from typing import Optional
 from osgeo import gdal
 from osgeo_utils.auxiliary.base import PathLikeOrStr
 from osgeo_utils.auxiliary.color_table import ColorTableLike, get_color_table
-from osgeo_utils.auxiliary.util import GetOutputDriverFor, open_ds
+from osgeo_utils.auxiliary.util import (
+    GetOutputDriverFor,
+    enable_gdal_exceptions,
+    open_ds,
+)
 
 
 def Usage(isError=True):
@@ -47,12 +51,8 @@ def Usage(isError=True):
     return 2 if isError else 0
 
 
+@enable_gdal_exceptions
 def main(argv=sys.argv):
-    with gdal.ExceptionMgr():
-        return _main(argv=argv)
-
-
-def _main(argv=sys.argv):
 
     pct_filename = None
     src_filename = None

--- a/swig/python/gdal-utils/osgeo_utils/gdalattachpct.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdalattachpct.py
@@ -48,8 +48,11 @@ def Usage(isError=True):
 
 
 def main(argv=sys.argv):
+    with gdal.ExceptionMgr():
+        return _main(argv=argv)
 
-    gdal.UseExceptions()
+
+def _main(argv=sys.argv):
 
     pct_filename = None
     src_filename = None

--- a/swig/python/gdal-utils/osgeo_utils/gdalattachpct.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdalattachpct.py
@@ -48,6 +48,9 @@ def Usage(isError=True):
 
 
 def main(argv=sys.argv):
+
+    gdal.UseExceptions()
+
     pct_filename = None
     src_filename = None
     dst_filename = None

--- a/swig/python/gdal-utils/osgeo_utils/gdalcompare.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdalcompare.py
@@ -39,6 +39,7 @@ from osgeo import gdal, osr
 
 #######################################################
 from osgeo_utils.auxiliary.base import PathLikeOrStr
+from osgeo_utils.auxiliary.util import enable_gdal_exceptions
 
 my_print = print
 
@@ -502,12 +503,8 @@ def Usage(isError=True):
 #
 
 
+@enable_gdal_exceptions
 def main(argv=sys.argv):
-    with gdal.ExceptionMgr():
-        return _main(argv=argv)
-
-
-def _main(argv=sys.argv):
 
     # Default GDAL argument parsing.
     argv = gdal.GeneralCmdLineProcessor(argv)

--- a/swig/python/gdal-utils/osgeo_utils/gdalcompare.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdalcompare.py
@@ -503,8 +503,11 @@ def Usage(isError=True):
 
 
 def main(argv=sys.argv):
+    with gdal.ExceptionMgr():
+        return _main(argv=argv)
 
-    gdal.UseExceptions()
+
+def _main(argv=sys.argv):
 
     # Default GDAL argument parsing.
     argv = gdal.GeneralCmdLineProcessor(argv)

--- a/swig/python/gdal-utils/osgeo_utils/gdalcompare.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdalcompare.py
@@ -503,6 +503,9 @@ def Usage(isError=True):
 
 
 def main(argv=sys.argv):
+
+    gdal.UseExceptions()
+
     # Default GDAL argument parsing.
     argv = gdal.GeneralCmdLineProcessor(argv)
     if argv is None:

--- a/swig/python/gdal-utils/osgeo_utils/gdalmove.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdalmove.py
@@ -245,8 +245,10 @@ def Usage(isError=True):
 
 
 def main(argv=sys.argv):
-    # Default GDAL argument parsing.
 
+    gdal.UseExceptions()
+
+    # Default GDAL argument parsing.
     argv = gdal.GeneralCmdLineProcessor(argv)
     if argv is None:
         return 0

--- a/swig/python/gdal-utils/osgeo_utils/gdalmove.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdalmove.py
@@ -34,6 +34,7 @@ import sys
 from typing import Optional
 
 from osgeo import gdal, osr
+from osgeo_utils.auxiliary.util import enable_gdal_exceptions
 
 ###############################################################################
 
@@ -47,19 +48,8 @@ def fmt_loc(srs_obj, loc):
 ###############################################################################
 
 
+@enable_gdal_exceptions
 def move(
-    filename: str,
-    t_srs: str,
-    s_srs: Optional[str] = None,
-    pixel_threshold: Optional[float] = None,
-):
-    with gdal.ExceptionMgr(), osr.ExceptionMgr():
-        return _move(
-            filename=filename, t_srs=t_srs, s_srs=s_srs, pixel_threshold=pixel_threshold
-        )
-
-
-def _move(
     filename: str,
     t_srs: str,
     s_srs: Optional[str] = None,

--- a/swig/python/gdal-utils/osgeo_utils/gdalmove.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdalmove.py
@@ -53,6 +53,18 @@ def move(
     s_srs: Optional[str] = None,
     pixel_threshold: Optional[float] = None,
 ):
+    with gdal.ExceptionMgr(), osr.ExceptionMgr():
+        return _move(
+            filename=filename, t_srs=t_srs, s_srs=s_srs, pixel_threshold=pixel_threshold
+        )
+
+
+def _move(
+    filename: str,
+    t_srs: str,
+    s_srs: Optional[str] = None,
+    pixel_threshold: Optional[float] = None,
+):
 
     # -------------------------------------------------------------------------
     # Open the file.
@@ -245,8 +257,6 @@ def Usage(isError=True):
 
 
 def main(argv=sys.argv):
-
-    gdal.UseExceptions()
 
     # Default GDAL argument parsing.
     argv = gdal.GeneralCmdLineProcessor(argv)

--- a/swig/python/gdal-utils/osgeo_utils/ogr_layer_algebra.py
+++ b/swig/python/gdal-utils/osgeo_utils/ogr_layer_algebra.py
@@ -33,6 +33,7 @@ import os
 import sys
 
 from osgeo import gdal, ogr, osr
+from osgeo_utils.auxiliary.util import enable_gdal_exceptions
 
 ###############################################################################
 
@@ -171,12 +172,8 @@ def CreateLayer(
 ###############################################################################
 
 
+@enable_gdal_exceptions
 def main(argv=sys.argv):
-    with gdal.ExceptionMgr(), ogr.ExceptionMgr(), osr.ExceptionMgr():
-        return _main(argv=argv)
-
-
-def _main(argv=sys.argv):
 
     driver_name = "ESRI Shapefile"
     quiet = False

--- a/swig/python/gdal-utils/osgeo_utils/ogr_layer_algebra.py
+++ b/swig/python/gdal-utils/osgeo_utils/ogr_layer_algebra.py
@@ -191,6 +191,8 @@ def main(argv=sys.argv):
     srs_name = None
     srs = None
 
+    gdal.UseExceptions()
+
     argv = ogr.GeneralCmdLineProcessor(argv)
     if argv is None:
         return 0

--- a/swig/python/gdal-utils/osgeo_utils/ogr_layer_algebra.py
+++ b/swig/python/gdal-utils/osgeo_utils/ogr_layer_algebra.py
@@ -172,6 +172,12 @@ def CreateLayer(
 
 
 def main(argv=sys.argv):
+    with gdal.ExceptionMgr(), ogr.ExceptionMgr(), osr.ExceptionMgr():
+        return _main(argv=argv)
+
+
+def _main(argv=sys.argv):
+
     driver_name = "ESRI Shapefile"
     quiet = False
     input_ds_name = None
@@ -190,8 +196,6 @@ def main(argv=sys.argv):
     geom_type = ogr.wkbUnknown
     srs_name = None
     srs = None
-
-    gdal.UseExceptions()
 
     argv = ogr.GeneralCmdLineProcessor(argv)
     if argv is None:

--- a/swig/python/gdal-utils/osgeo_utils/ogrmerge.py
+++ b/swig/python/gdal-utils/osgeo_utils/ogrmerge.py
@@ -168,6 +168,11 @@ class XMLWriter(object):
 
 
 def process(argv, progress=None, progress_arg=None):
+    with gdal.ExceptionMgr(), ogr.ExceptionMgr(), osr.ExceptionMgr():
+        return _process(argv=argv, progress=progress, progress_arg=progress_arg)
+
+
+def _process(argv, progress=None, progress_arg=None):
 
     if not argv:
         return Usage(isError=True)
@@ -1203,7 +1208,6 @@ def ogrmerge(
 
 
 def main(argv=sys.argv):
-    gdal.UseExceptions()
     argv = ogr.GeneralCmdLineProcessor(argv)
     if argv is None:
         return 0

--- a/swig/python/gdal-utils/osgeo_utils/ogrmerge.py
+++ b/swig/python/gdal-utils/osgeo_utils/ogrmerge.py
@@ -518,10 +518,6 @@ def _gpkg_ogrmerge(
     if dst_ds is None:
         return 1
 
-    ogr.UseExceptions()
-    gdal.UseExceptions()
-    osr.UseExceptions()
-
     class ThreadedProgress:
         def __init__(self, dst_filename, estimated_final_size):
             self.stop_thread = False
@@ -1207,6 +1203,7 @@ def ogrmerge(
 
 
 def main(argv=sys.argv):
+    gdal.UseExceptions()
     argv = ogr.GeneralCmdLineProcessor(argv)
     if argv is None:
         return 0

--- a/swig/python/gdal-utils/osgeo_utils/ogrmerge.py
+++ b/swig/python/gdal-utils/osgeo_utils/ogrmerge.py
@@ -38,7 +38,7 @@ from typing import Optional, Sequence
 
 from osgeo import gdal, ogr, osr
 from osgeo_utils.auxiliary.base import PathLikeOrStr
-from osgeo_utils.auxiliary.util import GetOutputDriverFor
+from osgeo_utils.auxiliary.util import GetOutputDriverFor, enable_gdal_exceptions
 
 
 def Usage(isError):
@@ -167,12 +167,8 @@ class XMLWriter(object):
 # process()
 
 
+@enable_gdal_exceptions
 def process(argv, progress=None, progress_arg=None):
-    with gdal.ExceptionMgr(), ogr.ExceptionMgr(), osr.ExceptionMgr():
-        return _process(argv=argv, progress=progress, progress_arg=progress_arg)
-
-
-def _process(argv, progress=None, progress_arg=None):
 
     if not argv:
         return Usage(isError=True)

--- a/swig/python/gdal-utils/osgeo_utils/pct2rgb.py
+++ b/swig/python/gdal-utils/osgeo_utils/pct2rgb.py
@@ -42,31 +42,17 @@ from osgeo_utils.auxiliary.base import PathLikeOrStr
 from osgeo_utils.auxiliary.color_palette import get_color_palette
 from osgeo_utils.auxiliary.color_table import get_color_table
 from osgeo_utils.auxiliary.gdal_argparse import GDALArgumentParser, GDALScript
-from osgeo_utils.auxiliary.util import GetOutputDriverFor, open_ds
+from osgeo_utils.auxiliary.util import (
+    GetOutputDriverFor,
+    enable_gdal_exceptions,
+    open_ds,
+)
 
 progress = gdal.TermProgress_nocb
 
 
+@enable_gdal_exceptions
 def pct2rgb(
-    src_filename: PathLikeOrStr,
-    pct_filename: Optional[PathLikeOrStr],
-    dst_filename: PathLikeOrStr,
-    band_number: int = 1,
-    out_bands: int = 3,
-    driver_name: Optional[str] = None,
-):
-    with gdal.ExceptionMgr():
-        return _pct2rgb(
-            src_filename=src_filename,
-            pct_filename=pct_filename,
-            dst_filename=dst_filename,
-            band_number=band_number,
-            out_bands=out_bands,
-            driver_name=driver_name,
-        )
-
-
-def _pct2rgb(
     src_filename: PathLikeOrStr,
     pct_filename: Optional[PathLikeOrStr],
     dst_filename: PathLikeOrStr,

--- a/swig/python/gdal-utils/osgeo_utils/pct2rgb.py
+++ b/swig/python/gdal-utils/osgeo_utils/pct2rgb.py
@@ -55,6 +55,25 @@ def pct2rgb(
     out_bands: int = 3,
     driver_name: Optional[str] = None,
 ):
+    with gdal.ExceptionMgr():
+        return _pct2rgb(
+            src_filename=src_filename,
+            pct_filename=pct_filename,
+            dst_filename=dst_filename,
+            band_number=band_number,
+            out_bands=out_bands,
+            driver_name=driver_name,
+        )
+
+
+def _pct2rgb(
+    src_filename: PathLikeOrStr,
+    pct_filename: Optional[PathLikeOrStr],
+    dst_filename: PathLikeOrStr,
+    band_number: int = 1,
+    out_bands: int = 3,
+    driver_name: Optional[str] = None,
+):
     # Open source file
     src_ds = open_ds(src_filename)
     if src_ds is None:
@@ -223,7 +242,6 @@ class PCT2RGB(GDALScript):
 
 
 def main(argv=sys.argv):
-    gdal.UseExceptions()
     return PCT2RGB().main(argv)
 
 

--- a/swig/python/gdal-utils/osgeo_utils/pct2rgb.py
+++ b/swig/python/gdal-utils/osgeo_utils/pct2rgb.py
@@ -223,6 +223,7 @@ class PCT2RGB(GDALScript):
 
 
 def main(argv=sys.argv):
+    gdal.UseExceptions()
     return PCT2RGB().main(argv)
 
 

--- a/swig/python/gdal-utils/osgeo_utils/rgb2pct.py
+++ b/swig/python/gdal-utils/osgeo_utils/rgb2pct.py
@@ -39,27 +39,15 @@ from osgeo import gdal
 from osgeo_utils.auxiliary.base import PathLikeOrStr
 from osgeo_utils.auxiliary.color_table import get_color_table
 from osgeo_utils.auxiliary.gdal_argparse import GDALArgumentParser, GDALScript
-from osgeo_utils.auxiliary.util import GetOutputDriverFor, open_ds
+from osgeo_utils.auxiliary.util import (
+    GetOutputDriverFor,
+    enable_gdal_exceptions,
+    open_ds,
+)
 
 
+@enable_gdal_exceptions
 def rgb2pct(
-    src_filename: PathLikeOrStr,
-    pct_filename: Optional[PathLikeOrStr] = None,
-    dst_filename: Optional[PathLikeOrStr] = None,
-    color_count: int = 256,
-    driver_name: Optional[str] = None,
-):
-    with gdal.ExceptionMgr():
-        return _rgb2pct(
-            src_filename=src_filename,
-            pct_filename=pct_filename,
-            dst_filename=dst_filename,
-            color_count=color_count,
-            driver_name=driver_name,
-        )
-
-
-def _rgb2pct(
     src_filename: PathLikeOrStr,
     pct_filename: Optional[PathLikeOrStr] = None,
     dst_filename: Optional[PathLikeOrStr] = None,

--- a/swig/python/gdal-utils/osgeo_utils/rgb2pct.py
+++ b/swig/python/gdal-utils/osgeo_utils/rgb2pct.py
@@ -49,6 +49,23 @@ def rgb2pct(
     color_count: int = 256,
     driver_name: Optional[str] = None,
 ):
+    with gdal.ExceptionMgr():
+        return _rgb2pct(
+            src_filename=src_filename,
+            pct_filename=pct_filename,
+            dst_filename=dst_filename,
+            color_count=color_count,
+            driver_name=driver_name,
+        )
+
+
+def _rgb2pct(
+    src_filename: PathLikeOrStr,
+    pct_filename: Optional[PathLikeOrStr] = None,
+    dst_filename: Optional[PathLikeOrStr] = None,
+    color_count: int = 256,
+    driver_name: Optional[str] = None,
+):
     # Open source file
     src_ds = open_ds(src_filename)
     if src_ds is None:
@@ -202,7 +219,6 @@ class RGB2PCT(GDALScript):
 
 
 def main(argv=sys.argv):
-    gdal.UseExceptions()
     return RGB2PCT().main(argv)
 
 

--- a/swig/python/gdal-utils/osgeo_utils/rgb2pct.py
+++ b/swig/python/gdal-utils/osgeo_utils/rgb2pct.py
@@ -202,6 +202,7 @@ class RGB2PCT(GDALScript):
 
 
 def main(argv=sys.argv):
+    gdal.UseExceptions()
     return RGB2PCT().main(argv)
 
 

--- a/swig/python/gdal-utils/scripts/gdal2tiles.py
+++ b/swig/python/gdal-utils/scripts/gdal2tiles.py
@@ -5,9 +5,7 @@ import sys
 # Running main() must be protected that way due to use of multiprocessing on Windows:
 # https://docs.python.org/3/library/multiprocessing.html#the-spawn-and-forkserver-start-methods
 if __name__ == "__main__":
-    from osgeo.gdal import UseExceptions, deprecation_warn
-
-    UseExceptions()
+    from osgeo.gdal import deprecation_warn
 
     # import osgeo_utils.gdal2tiles as a convenience to use as a script
     from osgeo_utils.gdal2tiles import *  # noqa

--- a/swig/python/gdal-utils/scripts/gdal2xyz.py
+++ b/swig/python/gdal-utils/scripts/gdal2xyz.py
@@ -2,13 +2,11 @@
 
 import sys
 
-from osgeo.gdal import UseExceptions, deprecation_warn
+from osgeo.gdal import deprecation_warn
 
 # import osgeo_utils.gdal2xyz as a convenience to use as a script
 from osgeo_utils.gdal2xyz import *  # noqa
 from osgeo_utils.gdal2xyz import main
-
-UseExceptions()
 
 deprecation_warn("gdal2xyz")
 sys.exit(main(sys.argv))

--- a/swig/python/gdal-utils/scripts/gdal_calc.py
+++ b/swig/python/gdal-utils/scripts/gdal_calc.py
@@ -2,13 +2,11 @@
 
 import sys
 
-from osgeo.gdal import UseExceptions, deprecation_warn
+from osgeo.gdal import deprecation_warn
 
 # import osgeo_utils.gdal_calc as a convenience to use as a script
 from osgeo_utils.gdal_calc import *  # noqa
 from osgeo_utils.gdal_calc import main
-
-UseExceptions()
 
 deprecation_warn("gdal_calc")
 sys.exit(main(sys.argv))

--- a/swig/python/gdal-utils/scripts/gdal_edit.py
+++ b/swig/python/gdal-utils/scripts/gdal_edit.py
@@ -2,13 +2,11 @@
 
 import sys
 
-from osgeo.gdal import UseExceptions, deprecation_warn
+from osgeo.gdal import deprecation_warn
 
 # import osgeo_utils.gdal_edit as a convenience to use as a script
 from osgeo_utils.gdal_edit import *  # noqa
 from osgeo_utils.gdal_edit import main
-
-UseExceptions()
 
 deprecation_warn("gdal_edit")
 sys.exit(main(sys.argv))

--- a/swig/python/gdal-utils/scripts/gdal_fillnodata.py
+++ b/swig/python/gdal-utils/scripts/gdal_fillnodata.py
@@ -2,13 +2,11 @@
 
 import sys
 
-from osgeo.gdal import UseExceptions, deprecation_warn
+from osgeo.gdal import deprecation_warn
 
 # import osgeo_utils.gdal_fillnodata as a convenience to use as a script
 from osgeo_utils.gdal_fillnodata import *  # noqa
 from osgeo_utils.gdal_fillnodata import main
-
-UseExceptions()
 
 deprecation_warn("gdal_fillnodata")
 sys.exit(main(sys.argv))

--- a/swig/python/gdal-utils/scripts/gdal_merge.py
+++ b/swig/python/gdal-utils/scripts/gdal_merge.py
@@ -2,13 +2,11 @@
 
 import sys
 
-from osgeo.gdal import UseExceptions, deprecation_warn
+from osgeo.gdal import deprecation_warn
 
 # import osgeo_utils.gdal_merge as a convenience to use as a script
 from osgeo_utils.gdal_merge import *  # noqa
 from osgeo_utils.gdal_merge import main
-
-UseExceptions()
 
 deprecation_warn("gdal_merge")
 sys.exit(main(sys.argv))

--- a/swig/python/gdal-utils/scripts/gdal_pansharpen.py
+++ b/swig/python/gdal-utils/scripts/gdal_pansharpen.py
@@ -2,13 +2,11 @@
 
 import sys
 
-from osgeo.gdal import UseExceptions, deprecation_warn
+from osgeo.gdal import deprecation_warn
 
 # import osgeo_utils.gdal_pansharpen as a convenience to use as a script
 from osgeo_utils.gdal_pansharpen import *  # noqa
 from osgeo_utils.gdal_pansharpen import main
-
-UseExceptions()
 
 deprecation_warn("gdal_pansharpen")
 sys.exit(main(sys.argv))

--- a/swig/python/gdal-utils/scripts/gdal_polygonize.py
+++ b/swig/python/gdal-utils/scripts/gdal_polygonize.py
@@ -2,13 +2,11 @@
 
 import sys
 
-from osgeo.gdal import UseExceptions, deprecation_warn
+from osgeo.gdal import deprecation_warn
 
 # import osgeo_utils.gdal_polygonize as a convenience to use as a script
 from osgeo_utils.gdal_polygonize import *  # noqa
 from osgeo_utils.gdal_polygonize import main
-
-UseExceptions()
 
 deprecation_warn("gdal_polygonize")
 sys.exit(main(sys.argv))

--- a/swig/python/gdal-utils/scripts/gdal_proximity.py
+++ b/swig/python/gdal-utils/scripts/gdal_proximity.py
@@ -2,13 +2,11 @@
 
 import sys
 
-from osgeo.gdal import UseExceptions, deprecation_warn
+from osgeo.gdal import deprecation_warn
 
 # import osgeo_utils.gdal_proximity as a convenience to use as a script
 from osgeo_utils.gdal_proximity import *  # noqa
 from osgeo_utils.gdal_proximity import main
-
-UseExceptions()
 
 deprecation_warn("gdal_proximity")
 sys.exit(main(sys.argv))

--- a/swig/python/gdal-utils/scripts/gdal_retile.py
+++ b/swig/python/gdal-utils/scripts/gdal_retile.py
@@ -2,13 +2,11 @@
 
 import sys
 
-from osgeo.gdal import UseExceptions, deprecation_warn
+from osgeo.gdal import deprecation_warn
 
 # import osgeo_utils.gdal_retile as a convenience to use as a script
 from osgeo_utils.gdal_retile import *  # noqa
 from osgeo_utils.gdal_retile import main
-
-UseExceptions()
 
 deprecation_warn("gdal_retile")
 sys.exit(main(sys.argv))

--- a/swig/python/gdal-utils/scripts/gdal_sieve.py
+++ b/swig/python/gdal-utils/scripts/gdal_sieve.py
@@ -2,13 +2,11 @@
 
 import sys
 
-from osgeo.gdal import UseExceptions, deprecation_warn
+from osgeo.gdal import deprecation_warn
 
 # import osgeo_utils.gdal_sieve as a convenience to use as a script
 from osgeo_utils.gdal_sieve import *  # noqa
 from osgeo_utils.gdal_sieve import main
-
-UseExceptions()
 
 deprecation_warn("gdal_sieve")
 sys.exit(main(sys.argv))

--- a/swig/python/gdal-utils/scripts/gdalattachpct.py
+++ b/swig/python/gdal-utils/scripts/gdalattachpct.py
@@ -2,13 +2,11 @@
 
 import sys
 
-from osgeo.gdal import UseExceptions, deprecation_warn
+from osgeo.gdal import deprecation_warn
 
 # import osgeo_utils.gdalattachpct as a convenience to use as a script
 from osgeo_utils.gdalattachpct import *  # noqa
 from osgeo_utils.gdalattachpct import main
-
-UseExceptions()
 
 deprecation_warn("gdalattachpct")
 sys.exit(main(sys.argv))

--- a/swig/python/gdal-utils/scripts/gdalcompare.py
+++ b/swig/python/gdal-utils/scripts/gdalcompare.py
@@ -2,13 +2,11 @@
 
 import sys
 
-from osgeo.gdal import UseExceptions, deprecation_warn
+from osgeo.gdal import deprecation_warn
 
 # import osgeo_utils.gdalcompare as a convenience to use as a script
 from osgeo_utils.gdalcompare import *  # noqa
 from osgeo_utils.gdalcompare import main
-
-UseExceptions()
 
 deprecation_warn("gdalcompare")
 sys.exit(main(sys.argv))

--- a/swig/python/gdal-utils/scripts/gdalmove.py
+++ b/swig/python/gdal-utils/scripts/gdalmove.py
@@ -2,13 +2,11 @@
 
 import sys
 
-from osgeo.gdal import UseExceptions, deprecation_warn
+from osgeo.gdal import deprecation_warn
 
 # import osgeo_utils.gdalmove as a convenience to use as a script
 from osgeo_utils.gdalmove import *  # noqa
 from osgeo_utils.gdalmove import main
-
-UseExceptions()
 
 deprecation_warn("gdalmove")
 sys.exit(main(sys.argv))

--- a/swig/python/gdal-utils/scripts/ogr_layer_algebra.py
+++ b/swig/python/gdal-utils/scripts/ogr_layer_algebra.py
@@ -2,13 +2,11 @@
 
 import sys
 
-from osgeo.gdal import UseExceptions, deprecation_warn
+from osgeo.gdal import deprecation_warn
 
 # import osgeo_utils.ogr_layer_algebra as a convenience to use as a script
 from osgeo_utils.ogr_layer_algebra import *  # noqa
 from osgeo_utils.ogr_layer_algebra import main
-
-UseExceptions()
 
 deprecation_warn("ogr_layer_algebra")
 sys.exit(main(sys.argv))

--- a/swig/python/gdal-utils/scripts/ogrmerge.py
+++ b/swig/python/gdal-utils/scripts/ogrmerge.py
@@ -2,13 +2,11 @@
 
 import sys
 
-from osgeo.gdal import UseExceptions, deprecation_warn
+from osgeo.gdal import deprecation_warn
 
 # import osgeo_utils.ogrmerge as a convenience to use as a script
 from osgeo_utils.ogrmerge import *  # noqa
 from osgeo_utils.ogrmerge import main
-
-UseExceptions()
 
 deprecation_warn("ogrmerge")
 sys.exit(main(sys.argv))

--- a/swig/python/gdal-utils/scripts/pct2rgb.py
+++ b/swig/python/gdal-utils/scripts/pct2rgb.py
@@ -2,13 +2,11 @@
 
 import sys
 
-from osgeo.gdal import UseExceptions, deprecation_warn
+from osgeo.gdal import deprecation_warn
 
 # import osgeo_utils.pct2rgb as a convenience to use as a script
 from osgeo_utils.pct2rgb import *  # noqa
 from osgeo_utils.pct2rgb import main
-
-UseExceptions()
 
 deprecation_warn("pct2rgb")
 sys.exit(main(sys.argv))

--- a/swig/python/gdal-utils/scripts/rgb2pct.py
+++ b/swig/python/gdal-utils/scripts/rgb2pct.py
@@ -2,13 +2,11 @@
 
 import sys
 
-from osgeo.gdal import UseExceptions, deprecation_warn
+from osgeo.gdal import deprecation_warn
 
 # import osgeo_utils.rgb2pct as a convenience to use as a script
 from osgeo_utils.rgb2pct import *  # noqa
 from osgeo_utils.rgb2pct import main
-
-UseExceptions()
 
 deprecation_warn("rgb2pct")
 sys.exit(main(sys.argv))


### PR DESCRIPTION
Fixes #10010

The launcher shell scripts generated by setuptools don't use our gdal-utils/scripts/{script_name}.py scripts, but directly the gdal-utils/osgeo_utils/{script_name}.py one. Hence let's move the call to UseExceptions() from the former to the later.
