### PR TITLE
Add VSIMultipartUploadXXXXX() API for multi-part upload

### DIFF
--- a/autotest/gcore/vsiadls.py
+++ b/autotest/gcore/vsiadls.py
@@ -1161,3 +1161,56 @@ def test_vsiadls_fake_metadata():
         assert not gdal.SetFileMetadata(
             "/vsiadls/test/foo.bin", {"x-ms-properties": "foo=bar"}, "PROPERTIES"
         )
+
+
+###############################################################################
+# Test VSIMultipartUploadXXXX()
+
+
+def test_vsiadls_MultipartUpload():
+
+    if gdaltest.webserver_port == 0:
+        pytest.skip()
+
+    # Test MultipartUploadGetCapabilities()
+    info = gdal.MultipartUploadGetCapabilities("/vsiadls/")
+    assert info.non_sequential_upload_supported
+    assert info.parallel_upload_supported
+    assert not info.abort_supported
+    assert info.min_part_size == 0
+    assert info.max_part_size >= 1024
+    assert info.max_part_count > 0
+
+    # Test MultipartUploadAddPart()
+    handler = webserver.SequentialHandler()
+    handler.add(
+        "PATCH",
+        "/azure/blob/myaccount/test_multipartupload/test.bin?action=append&position=123456",
+        202,
+        expected_body=b"foo",
+    )
+    with webserver.install_http_handler(handler):
+        part_id = gdal.MultipartUploadAddPart(
+            "/vsiadls/test_multipartupload/test.bin", "my_upload_id", 1, 123456, b"foo"
+        )
+    assert part_id == "dummy"
+
+    # Test MultipartUploadEnd()
+    handler = webserver.SequentialHandler()
+    handler.add(
+        "PATCH",
+        "/azure/blob/myaccount/test_multipartupload/test.bin?action=flush&close=true&position=3",
+        200,
+    )
+    with webserver.install_http_handler(handler):
+        assert gdal.MultipartUploadEnd(
+            "/vsiadls/test_multipartupload/test.bin", "my_upload_id", ["dummy"], 3
+        )
+
+    # Test unsupported MultipartUploadAbort()
+    with gdal.ExceptionMgr(useExceptions=True):
+        with pytest.raises(
+            Exception,
+            match=r"MultipartUploadAbort\(\) not supported by this file system",
+        ):
+            gdal.MultipartUploadAbort("/vsiadls/foo/bar", "upload_id")

--- a/autotest/gcore/vsiaz.py
+++ b/autotest/gcore/vsiaz.py
@@ -3059,3 +3059,30 @@ def test_vsiaz_copy_from_vsiaz_different_storage_bucket():
             )
             == 0
         )
+
+
+###############################################################################
+# Test VSIMultipartUploadXXXX()
+
+
+def test_vsiaz_MultipartUpload():
+
+    if gdaltest.webserver_port == 0:
+        pytest.skip()
+
+    # Test MultipartUploadGetCapabilities()
+    info = gdal.MultipartUploadGetCapabilities("/vsiaz/")
+    assert info.non_sequential_upload_supported
+    assert info.parallel_upload_supported
+    assert not info.abort_supported
+    assert info.min_part_size == 0
+    assert info.max_part_size >= 1024
+    assert info.max_part_count == 50000
+
+    # Test unsupported MultipartUploadAbort()
+    with gdal.ExceptionMgr(useExceptions=True):
+        with pytest.raises(
+            Exception,
+            match=r"MultipartUploadAbort\(\) not supported by this file system",
+        ):
+            gdal.MultipartUploadAbort("/vsiaz/foo/bar", "upload_id")

--- a/autotest/gcore/vsifile.py
+++ b/autotest/gcore/vsifile.py
@@ -1696,3 +1696,65 @@ def test_vsifile_stat_directory_trailing_slash():
     res = gdal.VSIStatL("data/")
     assert res
     assert res.IsDirectory()
+
+
+###############################################################################
+# Test VSIMultipartUploadXXXX(), unsupported on regular file systems
+
+
+def test_vsifile_MultipartUpload():
+
+    with gdal.ExceptionMgr(useExceptions=False):
+        with gdal.quiet_errors():
+            assert gdal.MultipartUploadGetCapabilities("foo") is None
+    with gdal.ExceptionMgr(useExceptions=True):
+        with pytest.raises(ValueError):
+            gdal.MultipartUploadGetCapabilities(None)
+
+        with pytest.raises(
+            Exception,
+            match=r"MultipartUploadGetCapabilities\(\) not supported by this file system",
+        ):
+            gdal.MultipartUploadGetCapabilities("foo")
+
+        with pytest.raises(ValueError):
+            gdal.MultipartUploadStart(None)
+
+        with pytest.raises(
+            Exception,
+            match=r"MultipartUploadStart\(\) not supported by this file system",
+        ):
+            gdal.MultipartUploadStart("foo")
+
+        with pytest.raises(ValueError):
+            gdal.MultipartUploadAddPart(None, "", 1, 0, b"")
+        with pytest.raises(ValueError):
+            gdal.MultipartUploadAddPart("", None, 1, 0, b"")
+
+        with pytest.raises(
+            Exception,
+            match=r"MultipartUploadAddPart\(\) not supported by this file system",
+        ):
+            gdal.MultipartUploadAddPart("", "", 1, 0, b"")
+
+        with pytest.raises(ValueError):
+            gdal.MultipartUploadEnd(None, "", [], 0)
+        with pytest.raises(ValueError):
+            gdal.MultipartUploadEnd("", None, [], 0)
+
+        with pytest.raises(
+            Exception,
+            match=r"MultipartUploadEnd\(\) not supported by this file system",
+        ):
+            gdal.MultipartUploadEnd("", "", [], 0)
+
+        with pytest.raises(ValueError):
+            gdal.MultipartUploadAbort(None, "")
+        with pytest.raises(ValueError):
+            gdal.MultipartUploadAbort("", None)
+
+        with pytest.raises(
+            Exception,
+            match=r"MultipartUploadAbort\(\) not supported by this file system",
+        ):
+            gdal.MultipartUploadAbort("", "")

--- a/autotest/gcore/vsigs.py
+++ b/autotest/gcore/vsigs.py
@@ -1615,6 +1615,22 @@ def test_vsigs_rmdirrecursive_empty_dir(gs_test_config, webserver_port):
 
 
 ###############################################################################
+# Test VSIMultipartUploadXXXX()
+
+
+def test_vsigs_MultipartUpload(gs_test_config, webserver_port):
+
+    # Test MultipartUploadGetCapabilities()
+    info = gdal.MultipartUploadGetCapabilities("/vsigs/")
+    assert info.non_sequential_upload_supported
+    assert info.parallel_upload_supported
+    assert info.abort_supported
+    assert info.min_part_size == 5
+    assert info.max_part_size >= 1024
+    assert info.max_part_count == 10000
+
+
+###############################################################################
 # Nominal cases (require valid credentials)
 
 

--- a/autotest/gcore/vsioss.py
+++ b/autotest/gcore/vsioss.py
@@ -1119,6 +1119,22 @@ def test_vsioss_6(server):
 
 
 ###############################################################################
+# Test VSIMultipartUploadXXXX()
+
+
+def test_vsioss_MultipartUpload(server):
+
+    # Test MultipartUploadGetCapabilities()
+    info = gdal.MultipartUploadGetCapabilities("/vsioss/")
+    assert info.non_sequential_upload_supported
+    assert info.parallel_upload_supported
+    assert info.abort_supported
+    assert info.min_part_size == 5
+    assert info.max_part_size >= 1024
+    assert info.max_part_count == 10000
+
+
+###############################################################################
 # Test Mkdir() / Rmdir()
 
 

--- a/autotest/gcore/vsioss.py
+++ b/autotest/gcore/vsioss.py
@@ -1245,31 +1245,6 @@ def test_vsioss_8(server):
 
 
 ###############################################################################
-# Test gdal.CopyFileRestartable() with fallback to regular copy
-
-
-def test_vsioss_CopyFileRestartable_fallback_to_regular_copy(tmp_vsimem, server):
-
-    gdal.VSICurlClearCache()
-
-    srcfilename = str(tmp_vsimem / "foo")
-    gdal.FileFromMemBuffer(srcfilename, "foo\n")
-
-    dstfilename = "/vsioss/test_bucket/foo"
-
-    handler = webserver.SequentialHandler()
-    handler.add("PUT", "/test_bucket/foo", 200, expected_body=b"foo\n")
-
-    with webserver.install_http_handler(handler):
-        ret_code, restart_payload = gdal.CopyFileRestartable(
-            srcfilename,
-            dstfilename,
-            None,  # input payload
-        )
-    assert ret_code == 0
-
-
-###############################################################################
 # Nominal cases (require valid credentials)
 
 

--- a/port/CMakeLists.txt
+++ b/port/CMakeLists.txt
@@ -94,6 +94,7 @@ set(CPL_SOURCES
     cpl_swift.cpp
     cpl_vsil_adls.cpp
     cpl_vsil_az.cpp
+    cpl_vsil_chunked_write_handle.cpp
     cpl_vsil_uploadonclose.cpp
     cpl_vsil_gs.cpp
     cpl_vsil_webhdfs.cpp

--- a/port/cpl_vsi.h
+++ b/port/cpl_vsi.h
@@ -465,6 +465,29 @@ int CPL_DLL VSISync(const char *pszSource, const char *pszTarget,
                     const char *const *papszOptions,
                     GDALProgressFunc pProgressFunc, void *pProgressData,
                     char ***ppapszOutputs);
+
+int CPL_DLL VSIMultipartUploadGetCapabilities(
+    const char *pszFilename, int *pbNonSequentialUploadSupported,
+    int *pbParallelUploadSupported, int *pbAbortSupported,
+    size_t *pnMinPartSize, size_t *pnMaxPartSize, int *pnMaxPartCount);
+
+char CPL_DLL *VSIMultipartUploadStart(const char *pszFilename,
+                                      CSLConstList papszOptions);
+char CPL_DLL *VSIMultipartUploadAddPart(const char *pszFilename,
+                                        const char *pszUploadId,
+                                        int nPartNumber,
+                                        vsi_l_offset nFileOffset,
+                                        const void *pData, size_t nDataLength,
+                                        CSLConstList papszOptions);
+int CPL_DLL VSIMultipartUploadEnd(const char *pszFilename,
+                                  const char *pszUploadId, size_t nPartIdsCount,
+                                  const char *const *apszPartIds,
+                                  vsi_l_offset nTotalSize,
+                                  CSLConstList papszOptions);
+int CPL_DLL VSIMultipartUploadAbort(const char *pszFilename,
+                                    const char *pszUploadId,
+                                    CSLConstList papszOptions);
+
 int CPL_DLL VSIAbortPendingUploads(const char *pszFilename);
 
 char CPL_DLL *VSIStrerror(int);

--- a/port/cpl_vsi_virtual.h
+++ b/port/cpl_vsi_virtual.h
@@ -305,6 +305,31 @@ class CPL_DLL VSIFilesystemHandler
                                  const char *pszDomain,
                                  CSLConstList papszOptions);
 
+    virtual bool
+    MultipartUploadGetCapabilities(int *pbNonSequentialUploadSupported,
+                                   int *pbParallelUploadSupported,
+                                   int *pbAbortSupported, size_t *pnMinPartSize,
+                                   size_t *pnMaxPartSize, int *pnMaxPartCount);
+
+    virtual char *MultipartUploadStart(const char *pszFilename,
+                                       CSLConstList papszOptions);
+
+    virtual char *MultipartUploadAddPart(const char *pszFilename,
+                                         const char *pszUploadId,
+                                         int nPartNumber,
+                                         vsi_l_offset nFileOffset,
+                                         const void *pData, size_t nDataLength,
+                                         CSLConstList papszOptions);
+
+    virtual bool
+    MultipartUploadEnd(const char *pszFilename, const char *pszUploadId,
+                       size_t nPartIdsCount, const char *const *apszPartIds,
+                       vsi_l_offset nTotalSize, CSLConstList papszOptions);
+
+    virtual bool MultipartUploadAbort(const char *pszFilename,
+                                      const char *pszUploadId,
+                                      CSLConstList papszOptions);
+
     virtual bool AbortPendingUploads(const char * /*pszFilename*/)
     {
         return true;

--- a/port/cpl_vsil_az.cpp
+++ b/port/cpl_vsil_az.cpp
@@ -499,7 +499,7 @@ const VSIDIREntry *VSIDIRAz::NextDirEntry()
 /*                       VSIAzureFSHandler                              */
 /************************************************************************/
 
-class VSIAzureFSHandler final : public IVSIS3LikeFSHandler
+class VSIAzureFSHandler final : public IVSIS3LikeFSHandlerWithMultipartUpload
 {
     CPL_DISALLOW_COPY_ASSIGN(VSIAzureFSHandler)
     const std::string m_osPrefix;
@@ -607,11 +607,6 @@ class VSIAzureFSHandler final : public IVSIS3LikeFSHandler
 
     // Multipart upload (mapping of S3 interface to PutBlock/PutBlockList)
 
-    bool SupportsParallelMultipartUpload() const override
-    {
-        return true;
-    }
-
     std::string InitiateMultipartUpload(
         const std::string & /* osFilename */, IVSIS3LikeHandleHelper *,
         const CPLHTTPRetryParameters & /* oRetryParameters */,
@@ -649,6 +644,18 @@ class VSIAzureFSHandler final : public IVSIS3LikeFSHandler
         const CPLHTTPRetryParameters & /* oRetryParameters */) override
     {
         return true;
+    }
+
+    bool MultipartUploadAbort(const char *, const char *, CSLConstList) override
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "MultipartUploadAbort() not supported by this file system");
+        return false;
+    }
+
+    bool SupportsMultipartAbort() const override
+    {
+        return false;
     }
 
     std::string

--- a/port/cpl_vsil_az.cpp
+++ b/port/cpl_vsil_az.cpp
@@ -769,8 +769,8 @@ VSIAzureFSHandler::CreateWriteHandle(const char *pszFilename,
     const char *pszBlobType = CSLFetchNameValue(papszOptions, "BLOB_TYPE");
     if (pszBlobType && EQUAL(pszBlobType, "BLOCK"))
     {
-        auto poHandle = std::make_unique<VSIS3LikeWriteHandle>(
-            this, pszFilename, poHandleHelper, false, papszOptions);
+        auto poHandle = std::make_unique<VSIMultipartWriteHandle>(
+            this, pszFilename, poHandleHelper, papszOptions);
         if (!poHandle->IsOK())
         {
             return nullptr;

--- a/port/cpl_vsil_chunked_write_handle.cpp
+++ b/port/cpl_vsil_chunked_write_handle.cpp
@@ -1,0 +1,560 @@
+/******************************************************************************
+ *
+ * Project:  CPL - Common Portability Library
+ * Purpose:  Implement a write-only file handle using PUT chunked writing
+ * Author:   Even Rouault, even.rouault at spatialys.com
+ *
+ ******************************************************************************
+ * Copyright (c) 2024, Even Rouault <even.rouault at spatialys.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "cpl_vsil_curl_class.h"
+
+#ifdef HAVE_CURL
+
+//! @cond Doxygen_Suppress
+
+#define unchecked_curl_easy_setopt(handle, opt, param)                         \
+    CPL_IGNORE_RET_VAL(curl_easy_setopt(handle, opt, param))
+
+namespace cpl
+{
+
+/************************************************************************/
+/*                        VSIChunkedWriteHandle()                       */
+/************************************************************************/
+
+VSIChunkedWriteHandle::VSIChunkedWriteHandle(
+    IVSIS3LikeFSHandler *poFS, const char *pszFilename,
+    IVSIS3LikeHandleHelper *poS3HandleHelper, CSLConstList papszOptions)
+    : m_poFS(poFS), m_osFilename(pszFilename),
+      m_poS3HandleHelper(poS3HandleHelper), m_aosOptions(papszOptions),
+      m_aosHTTPOptions(CPLHTTPGetOptionsFromEnv(pszFilename)),
+      m_oRetryParameters(m_aosHTTPOptions)
+{
+}
+
+/************************************************************************/
+/*                      ~VSIChunkedWriteHandle()                        */
+/************************************************************************/
+
+VSIChunkedWriteHandle::~VSIChunkedWriteHandle()
+{
+    VSIChunkedWriteHandle::Close();
+    delete m_poS3HandleHelper;
+
+    if (m_hCurlMulti)
+    {
+        if (m_hCurl)
+        {
+            curl_multi_remove_handle(m_hCurlMulti, m_hCurl);
+            curl_easy_cleanup(m_hCurl);
+        }
+        VSICURLMultiCleanup(m_hCurlMulti);
+    }
+    CPLFree(m_sWriteFuncHeaderData.pBuffer);
+}
+
+/************************************************************************/
+/*                                 Close()                              */
+/************************************************************************/
+
+int VSIChunkedWriteHandle::Close()
+{
+    int nRet = 0;
+    if (!m_bClosed)
+    {
+        m_bClosed = true;
+        if (m_hCurlMulti != nullptr)
+        {
+            nRet = FinishChunkedTransfer();
+        }
+        else
+        {
+            if (!m_bError && !DoEmptyPUT())
+                nRet = -1;
+        }
+    }
+    return nRet;
+}
+
+/************************************************************************/
+/*                    InvalidateParentDirectory()                       */
+/************************************************************************/
+
+void VSIChunkedWriteHandle::InvalidateParentDirectory()
+{
+    m_poFS->InvalidateCachedData(m_poS3HandleHelper->GetURL().c_str());
+
+    std::string osFilenameWithoutSlash(m_osFilename);
+    if (!osFilenameWithoutSlash.empty() && osFilenameWithoutSlash.back() == '/')
+        osFilenameWithoutSlash.resize(osFilenameWithoutSlash.size() - 1);
+    m_poFS->InvalidateDirContent(CPLGetDirname(osFilenameWithoutSlash.c_str()));
+}
+
+/************************************************************************/
+/*                               Seek()                                 */
+/************************************************************************/
+
+int VSIChunkedWriteHandle::Seek(vsi_l_offset nOffset, int nWhence)
+{
+    if (!((nWhence == SEEK_SET && nOffset == m_nCurOffset) ||
+          (nWhence == SEEK_CUR && nOffset == 0) ||
+          (nWhence == SEEK_END && nOffset == 0)))
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "Seek not supported on writable %s files",
+                 m_poFS->GetFSPrefix().c_str());
+        m_bError = true;
+        return -1;
+    }
+    return 0;
+}
+
+/************************************************************************/
+/*                               Tell()                                 */
+/************************************************************************/
+
+vsi_l_offset VSIChunkedWriteHandle::Tell()
+{
+    return m_nCurOffset;
+}
+
+/************************************************************************/
+/*                               Read()                                 */
+/************************************************************************/
+
+size_t VSIChunkedWriteHandle::Read(void * /* pBuffer */, size_t /* nSize */,
+                                   size_t /* nMemb */)
+{
+    CPLError(CE_Failure, CPLE_NotSupported,
+             "Read not supported on writable %s files",
+             m_poFS->GetFSPrefix().c_str());
+    m_bError = true;
+    return 0;
+}
+
+/************************************************************************/
+/*                      ReadCallBackBufferChunked()                     */
+/************************************************************************/
+
+size_t VSIChunkedWriteHandle::ReadCallBackBufferChunked(char *buffer,
+                                                        size_t size,
+                                                        size_t nitems,
+                                                        void *instream)
+{
+    VSIChunkedWriteHandle *poThis =
+        static_cast<VSIChunkedWriteHandle *>(instream);
+    if (poThis->m_nChunkedBufferSize == 0)
+    {
+        // CPLDebug("VSIChunkedWriteHandle", "Writing 0 byte (finish)");
+        return 0;
+    }
+    const size_t nSizeMax = size * nitems;
+    size_t nSizeToWrite = nSizeMax;
+    size_t nChunkedBufferRemainingSize =
+        poThis->m_nChunkedBufferSize - poThis->m_nChunkedBufferOff;
+    if (nChunkedBufferRemainingSize < nSizeToWrite)
+        nSizeToWrite = nChunkedBufferRemainingSize;
+    memcpy(buffer,
+           static_cast<const GByte *>(poThis->m_pBuffer) +
+               poThis->m_nChunkedBufferOff,
+           nSizeToWrite);
+    poThis->m_nChunkedBufferOff += nSizeToWrite;
+    // CPLDebug("VSIChunkedWriteHandle", "Writing %d bytes", nSizeToWrite);
+    return nSizeToWrite;
+}
+
+/************************************************************************/
+/*                               Write()                                */
+/************************************************************************/
+
+size_t VSIChunkedWriteHandle::Write(const void *pBuffer, size_t nSize,
+                                    size_t nMemb)
+{
+    if (m_bError)
+        return 0;
+
+    const size_t nBytesToWrite = nSize * nMemb;
+    if (nBytesToWrite == 0)
+        return 0;
+
+    if (m_hCurlMulti == nullptr)
+    {
+        m_hCurlMulti = curl_multi_init();
+    }
+
+    WriteFuncStruct sWriteFuncData;
+    CPLHTTPRetryContext oRetryContext(m_oRetryParameters);
+    // We can only easily retry at the first chunk of a transfer
+    bool bCanRetry = (m_hCurl == nullptr);
+    bool bRetry;
+    do
+    {
+        bRetry = false;
+        struct curl_slist *headers = nullptr;
+        if (m_hCurl == nullptr)
+        {
+            CURL *hCurlHandle = curl_easy_init();
+            unchecked_curl_easy_setopt(hCurlHandle, CURLOPT_UPLOAD, 1L);
+            unchecked_curl_easy_setopt(hCurlHandle, CURLOPT_READFUNCTION,
+                                       ReadCallBackBufferChunked);
+            unchecked_curl_easy_setopt(hCurlHandle, CURLOPT_READDATA, this);
+
+            VSICURLInitWriteFuncStruct(&sWriteFuncData, nullptr, nullptr,
+                                       nullptr);
+            unchecked_curl_easy_setopt(hCurlHandle, CURLOPT_WRITEDATA,
+                                       &sWriteFuncData);
+            unchecked_curl_easy_setopt(hCurlHandle, CURLOPT_WRITEFUNCTION,
+                                       VSICurlHandleWriteFunc);
+
+            VSICURLInitWriteFuncStruct(&m_sWriteFuncHeaderData, nullptr,
+                                       nullptr, nullptr);
+            unchecked_curl_easy_setopt(hCurlHandle, CURLOPT_HEADERDATA,
+                                       &m_sWriteFuncHeaderData);
+            unchecked_curl_easy_setopt(hCurlHandle, CURLOPT_HEADERFUNCTION,
+                                       VSICurlHandleWriteFunc);
+
+            headers = static_cast<struct curl_slist *>(CPLHTTPSetOptions(
+                hCurlHandle, m_poS3HandleHelper->GetURL().c_str(),
+                m_aosHTTPOptions.List()));
+            headers = VSICurlSetCreationHeadersFromOptions(
+                headers, m_aosOptions.List(), m_osFilename.c_str());
+            headers = VSICurlMergeHeaders(
+                headers, m_poS3HandleHelper->GetCurlHeaders("PUT", headers));
+            unchecked_curl_easy_setopt(hCurlHandle, CURLOPT_HTTPHEADER,
+                                       headers);
+
+            m_osCurlErrBuf.resize(CURL_ERROR_SIZE + 1);
+            unchecked_curl_easy_setopt(hCurlHandle, CURLOPT_ERRORBUFFER,
+                                       &m_osCurlErrBuf[0]);
+
+            curl_multi_add_handle(m_hCurlMulti, hCurlHandle);
+            m_hCurl = hCurlHandle;
+        }
+
+        m_pBuffer = pBuffer;
+        m_nChunkedBufferOff = 0;
+        m_nChunkedBufferSize = nBytesToWrite;
+
+        int repeats = 0;
+        // cppcheck-suppress knownConditionTrueFalse
+        while (m_nChunkedBufferOff < m_nChunkedBufferSize && !bRetry)
+        {
+            int still_running;
+
+            memset(&m_osCurlErrBuf[0], 0, m_osCurlErrBuf.size());
+
+            while (curl_multi_perform(m_hCurlMulti, &still_running) ==
+                       CURLM_CALL_MULTI_PERFORM &&
+                   // cppcheck-suppress knownConditionTrueFalse
+                   m_nChunkedBufferOff < m_nChunkedBufferSize)
+            {
+                // loop
+            }
+            // cppcheck-suppress knownConditionTrueFalse
+            if (!still_running || m_nChunkedBufferOff == m_nChunkedBufferSize)
+                break;
+
+            CURLMsg *msg;
+            do
+            {
+                int msgq = 0;
+                msg = curl_multi_info_read(m_hCurlMulti, &msgq);
+                if (msg && (msg->msg == CURLMSG_DONE))
+                {
+                    CURL *e = msg->easy_handle;
+                    if (e == m_hCurl)
+                    {
+                        long response_code;
+                        curl_easy_getinfo(m_hCurl, CURLINFO_RESPONSE_CODE,
+                                          &response_code);
+                        if (response_code != 200 && response_code != 201)
+                        {
+                            // Look if we should attempt a retry
+                            if (bCanRetry &&
+                                oRetryContext.CanRetry(
+                                    static_cast<int>(response_code),
+                                    m_sWriteFuncHeaderData.pBuffer,
+                                    m_osCurlErrBuf.c_str()))
+                            {
+                                CPLError(CE_Warning, CPLE_AppDefined,
+                                         "HTTP error code: %d - %s. "
+                                         "Retrying again in %.1f secs",
+                                         static_cast<int>(response_code),
+                                         m_poS3HandleHelper->GetURL().c_str(),
+                                         oRetryContext.GetCurrentDelay());
+                                CPLSleep(oRetryContext.GetCurrentDelay());
+                                bRetry = true;
+                            }
+                            else if (sWriteFuncData.pBuffer != nullptr &&
+                                     m_poS3HandleHelper->CanRestartOnError(
+                                         sWriteFuncData.pBuffer,
+                                         m_sWriteFuncHeaderData.pBuffer, false))
+                            {
+                                bRetry = true;
+                            }
+                            else
+                            {
+                                CPLError(CE_Failure, CPLE_AppDefined,
+                                         "Error %d: %s",
+                                         static_cast<int>(response_code),
+                                         m_osCurlErrBuf.c_str());
+
+                                curl_slist_free_all(headers);
+                                bRetry = false;
+                            }
+
+                            curl_multi_remove_handle(m_hCurlMulti, m_hCurl);
+                            curl_easy_cleanup(m_hCurl);
+
+                            CPLFree(sWriteFuncData.pBuffer);
+                            CPLFree(m_sWriteFuncHeaderData.pBuffer);
+
+                            m_hCurl = nullptr;
+                            sWriteFuncData.pBuffer = nullptr;
+                            m_sWriteFuncHeaderData.pBuffer = nullptr;
+                            if (!bRetry)
+                                return 0;
+                        }
+                    }
+                }
+            } while (msg);
+
+            CPLMultiPerformWait(m_hCurlMulti, repeats);
+        }
+
+        m_nWrittenInPUT += nBytesToWrite;
+
+        curl_slist_free_all(headers);
+
+        m_pBuffer = nullptr;
+
+        if (!bRetry)
+        {
+            long response_code;
+            curl_easy_getinfo(m_hCurl, CURLINFO_RESPONSE_CODE, &response_code);
+            if (response_code != 100)
+            {
+                // Look if we should attempt a retry
+                if (bCanRetry &&
+                    oRetryContext.CanRetry(static_cast<int>(response_code),
+                                           m_sWriteFuncHeaderData.pBuffer,
+                                           m_osCurlErrBuf.c_str()))
+                {
+                    CPLError(CE_Warning, CPLE_AppDefined,
+                             "HTTP error code: %d - %s. "
+                             "Retrying again in %.1f secs",
+                             static_cast<int>(response_code),
+                             m_poS3HandleHelper->GetURL().c_str(),
+                             oRetryContext.GetCurrentDelay());
+                    CPLSleep(oRetryContext.GetCurrentDelay());
+                    bRetry = true;
+                }
+                else if (sWriteFuncData.pBuffer != nullptr &&
+                         m_poS3HandleHelper->CanRestartOnError(
+                             sWriteFuncData.pBuffer,
+                             m_sWriteFuncHeaderData.pBuffer, false))
+                {
+                    bRetry = true;
+                }
+                else
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined, "Error %d: %s",
+                             static_cast<int>(response_code),
+                             m_osCurlErrBuf.c_str());
+                    bRetry = false;
+                    nMemb = 0;
+                }
+
+                curl_multi_remove_handle(m_hCurlMulti, m_hCurl);
+                curl_easy_cleanup(m_hCurl);
+
+                CPLFree(sWriteFuncData.pBuffer);
+                CPLFree(m_sWriteFuncHeaderData.pBuffer);
+
+                m_hCurl = nullptr;
+                sWriteFuncData.pBuffer = nullptr;
+                m_sWriteFuncHeaderData.pBuffer = nullptr;
+            }
+        }
+    } while (bRetry);
+
+    m_nCurOffset += nBytesToWrite;
+
+    return nMemb;
+}
+
+/************************************************************************/
+/*                        FinishChunkedTransfer()                       */
+/************************************************************************/
+
+int VSIChunkedWriteHandle::FinishChunkedTransfer()
+{
+    if (m_hCurl == nullptr)
+        return -1;
+
+    NetworkStatisticsFileSystem oContextFS(m_poFS->GetFSPrefix().c_str());
+    NetworkStatisticsFile oContextFile(m_osFilename.c_str());
+    NetworkStatisticsAction oContextAction("Write");
+
+    NetworkStatisticsLogger::LogPUT(m_nWrittenInPUT);
+    m_nWrittenInPUT = 0;
+
+    m_pBuffer = nullptr;
+    m_nChunkedBufferOff = 0;
+    m_nChunkedBufferSize = 0;
+
+    VSICURLMultiPerform(m_hCurlMulti);
+
+    long response_code;
+    curl_easy_getinfo(m_hCurl, CURLINFO_RESPONSE_CODE, &response_code);
+    if (response_code == 200 || response_code == 201)
+    {
+        InvalidateParentDirectory();
+    }
+    else
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Error %d: %s",
+                 static_cast<int>(response_code), m_osCurlErrBuf.c_str());
+        return -1;
+    }
+    return 0;
+}
+
+/************************************************************************/
+/*                            DoEmptyPUT()                              */
+/************************************************************************/
+
+bool VSIChunkedWriteHandle::DoEmptyPUT()
+{
+    bool bSuccess = true;
+    bool bRetry;
+    CPLHTTPRetryContext oRetryContext(m_oRetryParameters);
+
+    NetworkStatisticsFileSystem oContextFS(m_poFS->GetFSPrefix().c_str());
+    NetworkStatisticsFile oContextFile(m_osFilename.c_str());
+    NetworkStatisticsAction oContextAction("Write");
+
+    do
+    {
+        bRetry = false;
+
+        PutData putData;
+        putData.pabyData = nullptr;
+        putData.nOff = 0;
+        putData.nTotalSize = 0;
+
+        CURL *hCurlHandle = curl_easy_init();
+        unchecked_curl_easy_setopt(hCurlHandle, CURLOPT_UPLOAD, 1L);
+        unchecked_curl_easy_setopt(hCurlHandle, CURLOPT_READFUNCTION,
+                                   PutData::ReadCallBackBuffer);
+        unchecked_curl_easy_setopt(hCurlHandle, CURLOPT_READDATA, &putData);
+        unchecked_curl_easy_setopt(hCurlHandle, CURLOPT_INFILESIZE, 0);
+
+        struct curl_slist *headers = static_cast<struct curl_slist *>(
+            CPLHTTPSetOptions(hCurlHandle, m_poS3HandleHelper->GetURL().c_str(),
+                              m_aosHTTPOptions.List()));
+        headers = VSICurlSetCreationHeadersFromOptions(
+            headers, m_aosOptions.List(), m_osFilename.c_str());
+        headers = VSICurlMergeHeaders(
+            headers, m_poS3HandleHelper->GetCurlHeaders("PUT", headers, "", 0));
+        headers = curl_slist_append(headers, "Expect: 100-continue");
+
+        CurlRequestHelper requestHelper;
+        const long response_code = requestHelper.perform(
+            hCurlHandle, headers, m_poFS, m_poS3HandleHelper);
+
+        NetworkStatisticsLogger::LogPUT(0);
+
+        if (response_code != 200 && response_code != 201)
+        {
+            // Look if we should attempt a retry
+            if (oRetryContext.CanRetry(
+                    static_cast<int>(response_code),
+                    requestHelper.sWriteFuncHeaderData.pBuffer,
+                    requestHelper.szCurlErrBuf))
+            {
+                CPLError(CE_Warning, CPLE_AppDefined,
+                         "HTTP error code: %d - %s. "
+                         "Retrying again in %.1f secs",
+                         static_cast<int>(response_code),
+                         m_poS3HandleHelper->GetURL().c_str(),
+                         oRetryContext.GetCurrentDelay());
+                CPLSleep(oRetryContext.GetCurrentDelay());
+                bRetry = true;
+            }
+            else if (requestHelper.sWriteFuncData.pBuffer != nullptr &&
+                     m_poS3HandleHelper->CanRestartOnError(
+                         requestHelper.sWriteFuncData.pBuffer,
+                         requestHelper.sWriteFuncHeaderData.pBuffer, false))
+            {
+                bRetry = true;
+            }
+            else
+            {
+                CPLDebug("S3", "%s",
+                         requestHelper.sWriteFuncData.pBuffer
+                             ? requestHelper.sWriteFuncData.pBuffer
+                             : "(null)");
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "DoSinglePartPUT of %s failed", m_osFilename.c_str());
+                bSuccess = false;
+            }
+        }
+        else
+        {
+            InvalidateParentDirectory();
+        }
+
+        if (requestHelper.sWriteFuncHeaderData.pBuffer != nullptr)
+        {
+            const char *pzETag =
+                strstr(requestHelper.sWriteFuncHeaderData.pBuffer, "ETag: \"");
+            if (pzETag)
+            {
+                pzETag += strlen("ETag: \"");
+                const char *pszEndOfETag = strchr(pzETag, '"');
+                if (pszEndOfETag)
+                {
+                    FileProp oFileProp;
+                    oFileProp.eExists = EXIST_YES;
+                    oFileProp.fileSize = m_nBufferOff;
+                    oFileProp.bHasComputedFileSize = true;
+                    oFileProp.ETag.assign(pzETag, pszEndOfETag - pzETag);
+                    m_poFS->SetCachedFileProp(
+                        m_poFS->GetURLFromFilename(m_osFilename.c_str())
+                            .c_str(),
+                        oFileProp);
+                }
+            }
+        }
+
+        curl_easy_cleanup(hCurlHandle);
+    } while (bRetry);
+    return bSuccess;
+}
+
+}  // namespace cpl
+
+//! @endcond
+
+#endif  // HAVE_CURL

--- a/port/cpl_vsil_curl_class.h
+++ b/port/cpl_vsil_curl_class.h
@@ -720,6 +720,56 @@ class IVSIS3LikeFSHandler : public VSICurlFilesystemHandlerBaseWritable
 };
 
 /************************************************************************/
+/*                 IVSIS3LikeFSHandlerWithMultipartUpload               */
+/************************************************************************/
+
+class IVSIS3LikeFSHandlerWithMultipartUpload : public IVSIS3LikeFSHandler
+{
+    CPL_DISALLOW_COPY_ASSIGN(IVSIS3LikeFSHandlerWithMultipartUpload)
+
+  protected:
+    IVSIS3LikeFSHandlerWithMultipartUpload() = default;
+
+  public:
+    virtual bool SupportsNonSequentialMultipartUpload() const
+    {
+        return true;
+    }
+
+    bool SupportsParallelMultipartUpload() const override
+    {
+        return true;
+    }
+
+    virtual bool SupportsMultipartAbort() const = 0;
+
+    bool MultipartUploadGetCapabilities(int *pbNonSequentialUploadSupported,
+                                        int *pbParallelUploadSupported,
+                                        int *pbAbortSupported,
+                                        size_t *pnMinPartSize,
+                                        size_t *pnMaxPartSize,
+                                        int *pnMaxPartCount) override;
+
+    char *MultipartUploadStart(const char *pszFilename,
+                               CSLConstList papszOptions) override;
+
+    char *MultipartUploadAddPart(const char *pszFilename,
+                                 const char *pszUploadId, int nPartNumber,
+                                 vsi_l_offset nFileOffset, const void *pData,
+                                 size_t nDataLength,
+                                 CSLConstList papszOptions) override;
+
+    bool MultipartUploadEnd(const char *pszFilename, const char *pszUploadId,
+                            size_t nPartIdsCount,
+                            const char *const *apszPartIds,
+                            vsi_l_offset nTotalSize,
+                            CSLConstList papszOptions) override;
+
+    bool MultipartUploadAbort(const char *pszFilename, const char *pszUploadId,
+                              CSLConstList papszOptions) override;
+};
+
+/************************************************************************/
 /*                          IVSIS3LikeHandle                            */
 /************************************************************************/
 

--- a/port/cpl_vsil_gs.cpp
+++ b/port/cpl_vsil_gs.cpp
@@ -327,8 +327,8 @@ VSIGSFSHandler::CreateWriteHandle(const char *pszFilename,
         CreateHandleHelper(pszFilename + GetFSPrefix().size(), false);
     if (poHandleHelper == nullptr)
         return nullptr;
-    auto poHandle = std::make_unique<VSIS3LikeWriteHandle>(
-        this, pszFilename, poHandleHelper, false, papszOptions);
+    auto poHandle = std::make_unique<VSIMultipartWriteHandle>(
+        this, pszFilename, poHandleHelper, papszOptions);
     if (!poHandle->IsOK())
     {
         return nullptr;

--- a/port/cpl_vsil_gs.cpp
+++ b/port/cpl_vsil_gs.cpp
@@ -65,7 +65,7 @@ namespace cpl
 /*                         VSIGSFSHandler                               */
 /************************************************************************/
 
-class VSIGSFSHandler final : public IVSIS3LikeFSHandler
+class VSIGSFSHandler final : public IVSIS3LikeFSHandlerWithMultipartUpload
 {
     CPL_DISALLOW_COPY_ASSIGN(VSIGSFSHandler)
     const std::string m_osPrefix;
@@ -111,12 +111,6 @@ class VSIGSFSHandler final : public IVSIS3LikeFSHandler
     char *GetSignedURL(const char *pszFilename,
                        CSLConstList papszOptions) override;
 
-    // Multipart upload
-    bool SupportsParallelMultipartUpload() const override
-    {
-        return true;
-    }
-
     char **GetFileMetadata(const char *pszFilename, const char *pszDomain,
                            CSLConstList papszOptions) override;
 
@@ -133,6 +127,11 @@ class VSIGSFSHandler final : public IVSIS3LikeFSHandler
     VSIFilesystemHandler *Duplicate(const char *pszPrefix) override
     {
         return new VSIGSFSHandler(pszPrefix);
+    }
+
+    bool SupportsMultipartAbort() const override
+    {
+        return true;
     }
 };
 

--- a/port/cpl_vsil_gzip.cpp
+++ b/port/cpl_vsil_gzip.cpp
@@ -139,6 +139,11 @@ constexpr int gz_magic[2] = {0x1f, 0x8b};  // gzip magic header
     CPLError(CE_Failure, CPLE_AppDefined, "In file %s, at line %d, return %d", \
              __FILE__, __LINE__, ret)
 
+// To avoid aliasing to CopyFile to CopyFileA on Windows
+#ifdef CopyFile
+#undef CopyFile
+#endif
+
 // #define ENABLE_DEBUG 1
 
 /************************************************************************/

--- a/port/cpl_vsil_oss.cpp
+++ b/port/cpl_vsil_oss.cpp
@@ -62,7 +62,7 @@ namespace cpl
 /*                         VSIOSSFSHandler                              */
 /************************************************************************/
 
-class VSIOSSFSHandler final : public IVSIS3LikeFSHandler
+class VSIOSSFSHandler final : public IVSIS3LikeFSHandlerWithMultipartUpload
 {
     CPL_DISALLOW_COPY_ASSIGN(VSIOSSFSHandler)
 
@@ -102,6 +102,11 @@ class VSIOSSFSHandler final : public IVSIS3LikeFSHandler
     GetStreamingFilename(const std::string &osFilename) const override
     {
         return osFilename;
+    }
+
+    bool SupportsMultipartAbort() const override
+    {
+        return true;
     }
 };
 

--- a/port/cpl_vsil_oss.cpp
+++ b/port/cpl_vsil_oss.cpp
@@ -153,8 +153,8 @@ VSIOSSFSHandler::CreateWriteHandle(const char *pszFilename,
         CreateHandleHelper(pszFilename + GetFSPrefix().size(), false);
     if (poHandleHelper == nullptr)
         return nullptr;
-    auto poHandle = std::make_unique<VSIS3LikeWriteHandle>(
-        this, pszFilename, poHandleHelper, false, papszOptions);
+    auto poHandle = std::make_unique<VSIMultipartWriteHandle>(
+        this, pszFilename, poHandleHelper, papszOptions);
     if (!poHandle->IsOK())
     {
         return nullptr;

--- a/port/cpl_vsil_s3.cpp
+++ b/port/cpl_vsil_s3.cpp
@@ -3384,7 +3384,9 @@ int IVSIS3LikeFSHandler::CopyFile(const char *pszSource, const char *pszTarget,
     bool bUsingStreaming = false;
     if (!fpSource)
     {
-        if (STARTS_WITH(pszSource, osPrefix.c_str()))
+        if (STARTS_WITH(pszSource, osPrefix.c_str()) &&
+            CPLTestBool(CPLGetConfigOption(
+                "VSIS3_COPYFILE_USE_STREAMING_SOURCE", "YES")))
         {
             // Try to get a streaming path from the source path
             auto poSourceFSHandler = dynamic_cast<IVSIS3LikeFSHandler *>(

--- a/port/cpl_vsil_swift.cpp
+++ b/port/cpl_vsil_swift.cpp
@@ -301,12 +301,8 @@ VSISwiftFSHandler::CreateWriteHandle(const char *pszFilename,
         CreateHandleHelper(pszFilename + GetFSPrefix().size(), false);
     if (poHandleHelper == nullptr)
         return nullptr;
-    auto poHandle = std::make_unique<VSIS3LikeWriteHandle>(
-        this, pszFilename, poHandleHelper, true, papszOptions);
-    if (!poHandle->IsOK())
-    {
-        return nullptr;
-    }
+    auto poHandle = std::make_unique<VSIChunkedWriteHandle>(
+        this, pszFilename, poHandleHelper, papszOptions);
     return VSIVirtualHandleUniquePtr(poHandle.release());
 }
 

--- a/swig/include/cpl.i
+++ b/swig/include/cpl.i
@@ -989,3 +989,83 @@ int CPLGetNumCPUs();
 
 %rename (GetUsablePhysicalRAM) CPLGetUsablePhysicalRAM;
 GIntBig CPLGetUsablePhysicalRAM();
+
+#if defined(SWIGPYTHON)
+
+%apply Pointer NONNULL {const char *pszFilename};
+%apply Pointer NONNULL {const char *pszUploadId};
+
+%inline {
+void MultipartUploadGetCapabilities(
+    const char *pszFilename, int* pnRetCode, int *pbNonSequentialUploadSupported,
+    int *pbParallelUploadSupported, int *pbSupportsAbort, size_t *pnMinPartSize,
+    size_t *pnMaxPartSize, int *pnMaxPartCount)
+{
+    *pnRetCode = VSIMultipartUploadGetCapabilities(pszFilename,
+                        pbNonSequentialUploadSupported,
+                        pbParallelUploadSupported,
+                        pbSupportsAbort,
+                        pnMinPartSize,
+                        pnMaxPartSize,
+                        pnMaxPartCount);
+}
+}
+
+%inline {
+char* MultipartUploadStart(const char *pszFilename, char** options = NULL)
+{
+    return VSIMultipartUploadStart(pszFilename, options);
+}
+}
+
+%apply (size_t nLen, char *pBuf ) { (size_t nDataLength, const char *pData)};
+
+%inline {
+char* MultipartUploadAddPart(const char *pszFilename,
+                             const char *pszUploadId,
+                             int nPartNumber,
+                             GUIntBig nFileOffset,
+                             size_t nDataLength, const char *pData,
+                             char** options = NULL)
+{
+    return VSIMultipartUploadAddPart(pszFilename, pszUploadId,
+                                     nPartNumber, nFileOffset,
+                                     pData, nDataLength,
+                                     options);
+}
+}
+
+%apply (char **dict) { char ** partIds };
+
+%inline {
+bool MultipartUploadEnd(const char *pszFilename,
+                        const char *pszUploadId,
+                        char** partIds,
+                        GUIntBig nTotalSize,
+                        char** options = NULL)
+
+{
+    return VSIMultipartUploadEnd(pszFilename, pszUploadId,
+                                 CSLCount(partIds), partIds,
+                                 nTotalSize,
+                                 options);
+}
+}
+
+%clear (char ** partIds);
+
+%inline {
+bool MultipartUploadAbort(const char *pszFilename,
+                          const char *pszUploadId,
+                          char** options = NULL)
+{
+    return VSIMultipartUploadAbort(pszFilename, pszUploadId, options);
+}
+}
+
+%clear const char *pszFilename;
+%clear const char *pszUploadId;
+%clear (size_t nDataLength, const void *pData);
+
+#endif
+

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -4911,3 +4911,25 @@ def quiet_errors():
     tuple.row_intersection = row_intersection
     val = tuple
 %}
+
+
+%feature("pythonappend") MultipartUploadGetCapabilities %{
+    if val:
+        non_sequential_upload_supported, parallel_upload_supported, abort_supported, min_part_size, max_part_size, max_part_count = val
+        import collections
+        tuple = collections.namedtuple('MultipartUploadGetCapabilitiesResult',
+            ['non_sequential_upload_supported',
+             'parallel_upload_supported',
+             'abort_supported',
+             'min_part_size',
+             'max_part_size',
+             'max_part_count',
+             ])
+        tuple.non_sequential_upload_supported = non_sequential_upload_supported
+        tuple.parallel_upload_supported = parallel_upload_supported
+        tuple.abort_supported = abort_supported
+        tuple.min_part_size = min_part_size
+        tuple.max_part_size = max_part_size
+        tuple.max_part_count = max_part_count
+        val = tuple
+%}

--- a/swig/include/python/typemaps_python.i
+++ b/swig/include/python/typemaps_python.i
@@ -3585,3 +3585,55 @@ OBJECT_LIST_INPUT(GDALMDArrayHS);
   }
   $result = t_output_helper($result,r);
 }
+
+
+%typemap(in,numinputs=0) (int* pnRetCode,
+                          int *pbNonSequentialUploadSupported,
+                          int *pbParallelUploadSupported,
+                          int *pbSupportsAbort,
+                          size_t *pnMinPartSize,
+                          size_t *pnMaxPartSize,
+                          int *pnMaxPartCount) (
+                              int nRetCode = 0,
+                              int bNonSequentialUploadSupported = 0,
+                              int bParallelUploadSupported = 0,
+                              int bSupportsAbort = 0,
+                              size_t nMinPartSize = 0,
+                              size_t nMaxPartSize = 0,
+                              int nMaxPartCount = 0 )
+{
+  $1 = &nRetCode;
+  $2 = &bNonSequentialUploadSupported;
+  $3 = &bParallelUploadSupported;
+  $4 = &bSupportsAbort;
+  $5 = &nMinPartSize;
+  $6 = &nMaxPartSize;
+  $7 = &nMaxPartCount;
+}
+
+%typemap(argout) (int* pnRetCode,
+                  int *pbNonSequentialUploadSupported,
+                  int *pbParallelUploadSupported,
+                  int *pbSupportsAbort,
+                  size_t *pnMinPartSize,
+                  size_t *pnMaxPartSize,
+                  int *pnMaxPartCount)
+{
+  if( *$1 == 0 )
+  {
+      Py_DECREF($result);
+      $result = Py_None;
+      Py_INCREF(Py_None);
+  }
+  else
+  {
+      PyObject *r = PyTuple_New( 6 );
+      PyTuple_SetItem( r, 0, PyBool_FromLong(*$2) );
+      PyTuple_SetItem( r, 1, PyBool_FromLong(*$3) );
+      PyTuple_SetItem( r, 2, PyBool_FromLong(*$4) );
+      PyTuple_SetItem( r, 3, PyLong_FromUnsignedLongLong(*$5) );
+      PyTuple_SetItem( r, 4, PyLong_FromUnsignedLongLong(*$6) );
+      PyTuple_SetItem( r, 5, PyLong_FromUnsignedLongLong(*$7) );
+      $result = t_output_helper($result,r);
+  }
+}


### PR DESCRIPTION
Using this API directly is generally not needed, but in very advanced cases,
as VSIFOpenL(..., "wb") + VSIFWriteL(), VSISync(), VSICopyFile() or
VSICopyFileRestartable() may be able to leverage it when needed.

This is only implemented for the /vsis3/, /vsigs/, /vsiaz/, /vsiadls/
and /vsioss/ virtual file systems.

The typical workflow is to do :
 - VSIMultipartUploadStart()
 - VSIMultipartUploadAddPart(): several times
 - VSIMultipartUploadEnd()

If VSIMultipartUploadAbort() is supported by the filesystem (VSIMultipartUploadGetCapabilities()
can be used to determine it), this function should be called to cancel an
upload. This can be needed to avoid extra billing for some cloud storage
providers.

