### PR TITLE
Use uniform note in Python utility docs

### DIFF
--- a/doc/source/programs/gdal2tiles.rst
+++ b/doc/source/programs/gdal2tiles.rst
@@ -53,6 +53,10 @@ can publish a picture without proper georeferencing too.
 
     Config options of the input drivers may have an effect on the output of gdal2tiles. An example driver config option is GDAL_PDF_DPI, which can be found at :ref:`configoptions`
 
+.. note::
+
+    gdal2tiles is a Python utility, and is only available if GDAL Python bindings are available.
+
 
 .. program:: gdal2tiles
 
@@ -228,10 +232,6 @@ Options for generated HTML viewers a la Google Maps
 
   Bing Maps API key from https://www.bingmapsportal.com/
 
-
-.. note::
-
-    gdal2tiles is a Python utility, and is only available if GDAL Python bindings are available.
 
 MapML options
 +++++++++++++

--- a/doc/source/programs/gdal2tiles.rst
+++ b/doc/source/programs/gdal2tiles.rst
@@ -231,7 +231,7 @@ Options for generated HTML viewers a la Google Maps
 
 .. note::
 
-    gdal2tiles is a Python script that needs to be run against Python GDAL binding.
+    gdal2tiles is a Python utility, and is only available if GDAL Python bindings are available.
 
 MapML options
 +++++++++++++

--- a/doc/source/programs/gdal2xyz.rst
+++ b/doc/source/programs/gdal2xyz.rst
@@ -34,6 +34,10 @@ The :program:`gdal2xyz` utility can be used to translate a raster file into xyz 
     * Skip or replace nodata value
     * Return the output as numpy arrays.
 
+.. note::
+
+    gdal2xyz is a Python utility, and is only available if GDAL Python bindings are available.
+
 .. program:: gdal2xyz
 
 .. include:: options/help_and_help_general.rst
@@ -110,7 +114,3 @@ Caveats
 -------
 
 gdal2xyz output values with a limited precision. Use ``gdal_translate -of XYZ`` if more precision is desired.
-
-.. note::
-
-    gdal2xyz is a Python utility, and is only available if GDAL Python bindings are available.

--- a/doc/source/programs/gdal2xyz.rst
+++ b/doc/source/programs/gdal2xyz.rst
@@ -111,4 +111,6 @@ Caveats
 
 gdal2xyz output values with a limited precision. Use ``gdal_translate -of XYZ`` if more precision is desired.
 
-gdal2xyz is a Python utility, and is only available if GDAL Python bindings are available.
+.. note::
+
+    gdal2xyz is a Python utility, and is only available if GDAL Python bindings are available.

--- a/doc/source/programs/gdal_calc.rst
+++ b/doc/source/programs/gdal_calc.rst
@@ -28,6 +28,10 @@ arithmetic supported by numpy arrays such as ``+``, ``-``, ``*``, and
 Note that all files must have the same dimensions (unless extent option is used),
 but no projection checking is performed (unless projectionCheck option is used).
 
+.. note::
+
+    gdal_calc is a Python utility, and is only available if GDAL Python bindings are available.
+
 .. include:: options/help_and_help_general.rst
 
 .. option:: --calc=<expression>
@@ -249,7 +253,3 @@ Work with multiple bands:
 
     gdal_calc -A input.tif --A_band=1 -B input.tif --B_band=2 \
       --outfile=result.tif --calc="(A+B)/2" --calc="B*logical_and(A>100,A<150)"
-
-.. note::
-
-    gdal_calc is a Python utility, and is only available if GDAL Python bindings are available.

--- a/doc/source/programs/gdal_calc.rst
+++ b/doc/source/programs/gdal_calc.rst
@@ -250,7 +250,6 @@ Work with multiple bands:
     gdal_calc -A input.tif --A_band=1 -B input.tif --B_band=2 \
       --outfile=result.tif --calc="(A+B)/2" --calc="B*logical_and(A>100,A<150)"
 
-Notes
------
+.. note::
 
-gdal_calc is a Python utility, and is only available if GDAL Python bindings are available.
+    gdal_calc is a Python utility, and is only available if GDAL Python bindings are available.

--- a/doc/source/programs/gdal_edit.rst
+++ b/doc/source/programs/gdal_edit.rst
@@ -43,6 +43,10 @@ It works only with raster formats that support update access to existing dataset
     through the GDAL API. This is for example the case of the :ref:`raster.gtiff`
     format (this is not a exhaustive list).
 
+.. note::
+
+    gdal_edit is a Python utility, and is only available if GDAL Python bindings are available.
+
 .. include:: options/help_and_help_general.rst
 
 .. option:: -ro
@@ -213,8 +217,3 @@ Example
 .. code-block::
 
     gdal_edit -scale 1e3 1e4 -offset 0 10 twoBand.tif
-
-
-.. note::
-
-    gdal_edit is a Python utility, and is only available if GDAL Python bindings are available.

--- a/doc/source/programs/gdal_edit.rst
+++ b/doc/source/programs/gdal_edit.rst
@@ -215,7 +215,6 @@ Example
     gdal_edit -scale 1e3 1e4 -offset 0 10 twoBand.tif
 
 
-Notes
------
+.. note::
 
-gdal_edit is a Python utility, and is only available if GDAL Python bindings are available.
+    gdal_edit is a Python utility, and is only available if GDAL Python bindings are available.

--- a/doc/source/programs/gdal_fillnodata.rst
+++ b/doc/source/programs/gdal_fillnodata.rst
@@ -31,6 +31,10 @@ nodata areas) by interpolating from valid pixels around the edges of the area.
 Additional details on the algorithm are available in the
 :cpp:func:`GDALFillNodata` docs.
 
+.. note::
+
+    gdal_fillnodata is a Python utility, and is only available if GDAL Python bindings are available.
+
 .. include:: options/help_and_help_general.rst
 
 .. option:: -q
@@ -83,8 +87,3 @@ Additional details on the algorithm are available in the
 
     The new file to create with the interpolated result.
     If not provided, the source band is updated in place.
-
-
-.. note::
-
-    gdal_fillnodata is a Python utility, and is only available if GDAL Python bindings are available.

--- a/doc/source/programs/gdal_fillnodata.rst
+++ b/doc/source/programs/gdal_fillnodata.rst
@@ -85,7 +85,6 @@ Additional details on the algorithm are available in the
     If not provided, the source band is updated in place.
 
 
-Notes
------
+.. note::
 
-gdal_fillnodata is a Python utility, and is only available if GDAL Python bindings are available.
+    gdal_fillnodata is a Python utility, and is only available if GDAL Python bindings are available.

--- a/doc/source/programs/gdal_merge.rst
+++ b/doc/source/programs/gdal_merge.rst
@@ -33,6 +33,10 @@ are considered on a band by band level, i.e. a nodata/transparent pixel on
 one source band will not set a nodata/transparent value on all bands for the
 target pixel in the resulting raster nor will it overwrite a valid pixel value.
 
+.. note::
+
+    gdal_merge is a Python utility, and is only available if GDAL Python bindings are available.
+
 .. program:: gdal_merge
 
 .. include:: options/help_and_help_general.rst
@@ -169,8 +173,3 @@ copied into the destination image if it is not already defined as nodata.
 .. code-block:: bash
 
    gdal_merge -o merge.tif -n 0 image1.tif image2.tif image3.tif image4.tif
-
-
-.. note::
-
-    gdal_merge is a Python utility, and is only available if GDAL Python bindings are available.

--- a/doc/source/programs/gdal_merge.rst
+++ b/doc/source/programs/gdal_merge.rst
@@ -171,7 +171,6 @@ copied into the destination image if it is not already defined as nodata.
    gdal_merge -o merge.tif -n 0 image1.tif image2.tif image3.tif image4.tif
 
 
-Notes
------
+.. note::
 
-gdal_merge is a Python utility, and is only available if GDAL Python bindings are available.
+    gdal_merge is a Python utility, and is only available if GDAL Python bindings are available.

--- a/doc/source/programs/gdal_pansharpen.rst
+++ b/doc/source/programs/gdal_pansharpen.rst
@@ -141,7 +141,6 @@ the pseudo panchromatic intensity on the 4 RGBNir bands:
     gdal_pansharpen -b 1 -b 2 -b 3 panchro.tif rgbnir.tif pansharpened_out.tif
 
 
-Notes
------
+.. note::
 
-gdal_pansharpen is a Python utility, and is only available if GDAL Python bindings are available.
+    gdal_pansharpen is a Python utility, and is only available if GDAL Python bindings are available.

--- a/doc/source/programs/gdal_pansharpen.rst
+++ b/doc/source/programs/gdal_pansharpen.rst
@@ -36,6 +36,10 @@ dataset describing the pan-sharpening operation.
 
 More details can be found in the :ref:`gdal_vrttut_pansharpen` section.
 
+.. note::
+
+    gdal_pansharpen is a Python utility, and is only available if GDAL Python bindings are available.
+
 .. include:: options/help_and_help_general.rst
 
 .. option:: -of <format>
@@ -139,8 +143,3 @@ the pseudo panchromatic intensity on the 4 RGBNir bands:
 .. code-block::
 
     gdal_pansharpen -b 1 -b 2 -b 3 panchro.tif rgbnir.tif pansharpened_out.tif
-
-
-.. note::
-
-    gdal_pansharpen is a Python utility, and is only available if GDAL Python bindings are available.

--- a/doc/source/programs/gdal_polygonize.rst
+++ b/doc/source/programs/gdal_polygonize.rst
@@ -106,7 +106,6 @@ details on the algorithm.
     messages are not displayed.
 
 
-Notes
------
+.. note::
 
-gdal_polygonize is a Python utility, and is only available if GDAL Python bindings are available.
+    gdal_polygonize is a Python utility, and is only available if GDAL Python bindings are available.

--- a/doc/source/programs/gdal_polygonize.rst
+++ b/doc/source/programs/gdal_polygonize.rst
@@ -34,6 +34,10 @@ otherwise it will try to append to an existing one.
 The utility is based on the ::cpp:func:`GDALPolygonize` function which has additional
 details on the algorithm.
 
+.. note::
+
+    gdal_polygonize is a Python utility, and is only available if GDAL Python bindings are available.
+
 .. program:: gdal_polygonize
 
 .. include:: options/help_and_help_general.rst
@@ -104,8 +108,3 @@ details on the algorithm.
 
     The script runs in quiet mode.  The progress monitor is suppressed and routine
     messages are not displayed.
-
-
-.. note::
-
-    gdal_polygonize is a Python utility, and is only available if GDAL Python bindings are available.

--- a/doc/source/programs/gdal_proximity.rst
+++ b/doc/source/programs/gdal_proximity.rst
@@ -95,7 +95,6 @@ raster for which the raster pixel value is in the set of target pixel values.
     -maxdist of target pixels (including the target pixels) instead of a distance value.
 
 
-Notes
------
+.. note::
 
-gdal_proximity is a Python utility, and is only available if GDAL Python bindings are available.
+    gdal_proximity is a Python utility, and is only available if GDAL Python bindings are available.

--- a/doc/source/programs/gdal_proximity.rst
+++ b/doc/source/programs/gdal_proximity.rst
@@ -31,6 +31,10 @@ the distance from the center of each pixel to the center of the nearest
 pixel identified as a target pixel.  Target pixels are those in the source
 raster for which the raster pixel value is in the set of target pixel values.
 
+.. note::
+
+    gdal_proximity is a Python utility, and is only available if GDAL Python bindings are available.
+
 .. program:: gdal_proximity
 
 .. include:: options/help_and_help_general.rst
@@ -93,8 +97,3 @@ raster for which the raster pixel value is in the set of target pixel values.
 
     Specify a value to be applied to all pixels that are within the
     -maxdist of target pixels (including the target pixels) instead of a distance value.
-
-
-.. note::
-
-    gdal_proximity is a Python utility, and is only available if GDAL Python bindings are available.

--- a/doc/source/programs/gdal_retile.rst
+++ b/doc/source/programs/gdal_retile.rst
@@ -42,6 +42,10 @@ It is possible to generate shape file(s) for the tiled output.
 If your number of input tiles exhausts the command line buffer, use the general
 :ref:`--optfile <raster_common_options_optfile>` option
 
+.. note::
+
+    gdal_retile is a Python utility, and is only available if GDAL Python bindings are available.
+
 .. program:: gdal_retile
 
 .. include:: options/help_and_help_general.rst
@@ -127,7 +131,3 @@ If your number of input tiles exhausts the command line buffer, use the general
 .. option:: -resume
 
     Resume mode. Generate only missing files.
-
-.. note::
-
-    gdal_retile is a Python utility, and is only available if GDAL Python bindings are available.

--- a/doc/source/programs/gdal_sieve.rst
+++ b/doc/source/programs/gdal_sieve.rst
@@ -34,7 +34,6 @@ some cases (e.g. 32-bit floating point data with min=0 and max=1).
 Additional details on the algorithm are available in the :cpp:func:`GDALSieveFilter` docs.
 
 
-Notes
------
+.. note::
 
-gdal_sieve is a Python utility, and is only available if GDAL Python bindings are available.
+    gdal_retile is a Python utility, and is only available if GDAL Python bindings are available.

--- a/doc/source/programs/gdalattachpct.rst
+++ b/doc/source/programs/gdalattachpct.rst
@@ -47,4 +47,6 @@ This utility will attach a color table file from an input raster file or a color
 
     The output RGB file that will be created.
 
-NOTE: gdalattachpct is a Python script, and will only work if GDAL was built with Python support.
+.. note::
+
+    gdalattachpct is a Python utility, and is only available if GDAL Python bindings are available.

--- a/doc/source/programs/gdalattachpct.rst
+++ b/doc/source/programs/gdalattachpct.rst
@@ -23,6 +23,10 @@ Description
 
 This utility will attach a color table file from an input raster file or a color table file to another raster.
 
+.. note::
+
+    gdalattachpct is a Python utility, and is only available if GDAL Python bindings are available.
+
 .. program:: gdalattachpct
 
 .. include:: options/help_and_help_general.rst
@@ -46,7 +50,3 @@ This utility will attach a color table file from an input raster file or a color
 .. option:: <dest_file>
 
     The output RGB file that will be created.
-
-.. note::
-
-    gdalattachpct is a Python utility, and is only available if GDAL Python bindings are available.

--- a/doc/source/programs/gdalcompare.rst
+++ b/doc/source/programs/gdalcompare.rst
@@ -35,6 +35,10 @@ byte comparison done which will count as one difference. So if it is
 only important that the GDAL visible data is identical a difference
 count of 1 (the binary difference) should be considered acceptable.
 
+.. note::
+
+    gdalcompare is a Python utility, and is only available if GDAL Python bindings are available.
+
 .. program:: gdalcompare
 
 .. include:: options/help_and_help_general.rst
@@ -129,8 +133,3 @@ Examples
     gdalcompare N.tiff N.tiff; echo $?
     Differences Found: 0
     0
-
-
-.. note::
-
-    gdalcompare is a Python utility, and is only available if GDAL Python bindings are available.

--- a/doc/source/programs/gdalcompare.rst
+++ b/doc/source/programs/gdalcompare.rst
@@ -131,7 +131,6 @@ Examples
     0
 
 
-Notes
------
+.. note::
 
-gdalcompare is a Python utility, and is only available if GDAL Python bindings are available.
+    gdalcompare is a Python utility, and is only available if GDAL Python bindings are available.

--- a/doc/source/programs/gdalmove.rst
+++ b/doc/source/programs/gdalmove.rst
@@ -38,6 +38,10 @@ Currently the transformed geotransform is computed based on the transformation
 of the top left, top right, and bottom left corners. A reduced overall error
 could be produced using a least squares fit of at least all four corner points.
 
+.. note::
+
+    gdalmove is a Python utility, and is only available if GDAL Python bindings are available.
+
 .. include:: options/help_and_help_general.rst
 
 .. option:: -s_srs <srs_defn>
@@ -61,7 +65,3 @@ could be produced using a least squares fit of at least all four corner points.
 
     The file to be operated on. To update this must be a file format that
     supports in place updates of the geotransform and SRS.
-
-.. note::
-
-    gdalmove is a Python utility, and is only available if GDAL Python bindings are available.

--- a/doc/source/programs/gdalmove.rst
+++ b/doc/source/programs/gdalmove.rst
@@ -61,3 +61,7 @@ could be produced using a least squares fit of at least all four corner points.
 
     The file to be operated on. To update this must be a file format that
     supports in place updates of the geotransform and SRS.
+
+.. note::
+
+    gdalmove is a Python utility, and is only available if GDAL Python bindings are available.

--- a/doc/source/programs/ogr_layer_algebra.rst
+++ b/doc/source/programs/ogr_layer_algebra.rst
@@ -149,7 +149,6 @@ input source , a method source and generates the output of the operation in the 
     PROJ.4 declarations, or the name of a .prj file containing a WKT CRS definition.
 
 
-Notes
------
+.. note::
 
-ogr_layer_algebra is a Python utility, and is only available if GDAL Python bindings are available.
+    ogr_layer_algebra is a Python utility, and is only available if GDAL Python bindings are available.

--- a/doc/source/programs/ogr_layer_algebra.rst
+++ b/doc/source/programs/ogr_layer_algebra.rst
@@ -33,6 +33,10 @@ Description
 The :program:`ogr_layer_algebra` provides a command line utility to perform various vector layer algebraic operations. The utility takes a vector
 input source , a method source and generates the output of the operation in the specified output file
 
+.. note::
+
+    ogr_layer_algebra is a Python utility, and is only available if GDAL Python bindings are available.
+
 .. program:: ogr_layer_algebra
 
 .. include:: options/help_and_help_general.rst
@@ -147,8 +151,3 @@ input source , a method source and generates the output of the operation in the 
     OGRSpatialReference.SetFromUserInput() call, which includes EPSG Projected,
     Geographic or Compound CRS (i.e. EPSG:4296), a well known text (WKT) CRS definition,
     PROJ.4 declarations, or the name of a .prj file containing a WKT CRS definition.
-
-
-.. note::
-
-    ogr_layer_algebra is a Python utility, and is only available if GDAL Python bindings are available.

--- a/doc/source/programs/ogrmerge.rst
+++ b/doc/source/programs/ogrmerge.rst
@@ -56,6 +56,10 @@ output format is not VRT, final translation is done with :program:`ogr2ogr`
 or :py:func:`gdal.VectorTranslate`. So, for advanced uses, output to VRT,
 potential manual editing of it and :program:`ogr2ogr` can be done.
 
+.. note::
+
+    ogrmerge is a Python utility, and is only available if GDAL Python bindings are available.
+
 .. program:: ogrmerge
 
 .. include:: options/help_and_help_general.rst
@@ -198,8 +202,3 @@ and adds a 'country' field to each feature whose value is 'france' or
 .. code-block::
 
     ogrmerge -single -o merged.shp france.shp germany.shp -src_layer_field_name country
-
-.. note::
-
-    ogrmerge is a Python utility, and is only available if GDAL Python bindings are available.
-

--- a/doc/source/programs/ogrmerge.rst
+++ b/doc/source/programs/ogrmerge.rst
@@ -199,8 +199,7 @@ and adds a 'country' field to each feature whose value is 'france' or
 
     ogrmerge -single -o merged.shp france.shp germany.shp -src_layer_field_name country
 
-Notes
------
+.. note::
 
-ogrmerge is a Python utility, and is only available if GDAL Python bindings are available.
+    ogrmerge is a Python utility, and is only available if GDAL Python bindings are available.
 

--- a/doc/source/programs/pct2rgb.rst
+++ b/doc/source/programs/pct2rgb.rst
@@ -57,7 +57,8 @@ RGB file of the desired format.
 
     The output RGB file that will be created.
 
-NOTE: pct2rgb is a Python script, and will only work if GDAL was built
-with Python support.
+.. note::
+
+    pct2rgb is a Python utility, and is only available if GDAL Python bindings are available.
 
 The '-expand rgb|rgba' option of :ref:`gdal_translate` obsoletes that utility.

--- a/doc/source/programs/pct2rgb.rst
+++ b/doc/source/programs/pct2rgb.rst
@@ -24,6 +24,10 @@ Description
 This utility will convert a pseudo-color band on the input file into an output
 RGB file of the desired format.
 
+.. note::
+
+    pct2rgb is a Python utility, and is only available if GDAL Python bindings are available.
+
 .. program:: pct2rgb
 
 .. include:: options/help_and_help_general.rst
@@ -56,9 +60,5 @@ RGB file of the desired format.
 .. option:: <dest_file>
 
     The output RGB file that will be created.
-
-.. note::
-
-    pct2rgb is a Python utility, and is only available if GDAL Python bindings are available.
 
 The '-expand rgb|rgba' option of :ref:`gdal_translate` obsoletes that utility.

--- a/doc/source/programs/rgb2pct.rst
+++ b/doc/source/programs/rgb2pct.rst
@@ -27,6 +27,10 @@ converts the image into a pseudo-colored image using the color table.
 This conversion utilizes Floyd-Steinberg dithering (error diffusion) to
 maximize output image visual quality.
 
+.. note::
+
+    rgb2pct is a Python utility, and is only available if GDAL Python bindings are available.
+
 .. program:: rgb2pct
 
 .. include:: options/help_and_help_general.rst
@@ -57,10 +61,6 @@ maximize output image visual quality.
 .. option:: <dest_file>
 
     The output pseudo-colored file that will be created.
-
-.. note::
-
-    rgb2pct is a Python utility, and is only available if GDAL Python bindings are available.
 
 Example
 -------

--- a/doc/source/programs/rgb2pct.rst
+++ b/doc/source/programs/rgb2pct.rst
@@ -58,7 +58,9 @@ maximize output image visual quality.
 
     The output pseudo-colored file that will be created.
 
-NOTE: rgb2pct is a Python script, and will only work if GDAL was built with Python support.
+.. note::
+
+    rgb2pct is a Python utility, and is only available if GDAL Python bindings are available.
 
 Example
 -------


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

This applies a uniform ReST note to the documentation of the Python utilities. The format from `gdal_retile` has been copied and applied to all the other utilities.

As pointed out by @jratike80 in #10053, the note was missing entirely for `gdalmove`. This is now fixed with this PR. 

## What are related issues/pull requests?

#10053

## Tasklist

 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
