### PR TITLE
MiraMonVector: fix a case sensitive comparison

### DIFF
--- a/ogr/ogrsf_frmts/miramon/mm_gdal_functions.c
+++ b/ogr/ogrsf_frmts/miramon/mm_gdal_functions.c
@@ -1262,13 +1262,13 @@ reintenta_lectura_per_si_error_CreaCampBD_XP:
             if (11 > (read_bytes = fread_function(charset_cpg, 1, 10, f_cpg)))
             {
                 charset_cpg[read_bytes] = '\0';
-                p = strstr(charset_cpg, "UTF-8");
+                p = MM_stristr(charset_cpg, "UTF-8");
                 if (p)
                     pMMBDXP->CharSet = MM_JOC_CARAC_UTF8_DBF;
-                p = strstr(charset_cpg, "UTF8");
+                p = MM_stristr(charset_cpg, "UTF8");
                 if (p)
                     pMMBDXP->CharSet = MM_JOC_CARAC_UTF8_DBF;
-                p = strstr(charset_cpg, "ISO-8859-1");
+                p = MM_stristr(charset_cpg, "ISO-8859-1");
                 if (p)
                     pMMBDXP->CharSet = MM_JOC_CARAC_ANSI_DBASE;
             }
@@ -1945,6 +1945,28 @@ char *MM_oemansi_n(char *szszChain, size_t n_bytes)
         }
     }
     return szszChain;
+}
+
+// An implementation of non-sensitive strstr()
+char *MM_stristr(const char *haystack, const char *needle)
+{
+    if (!haystack)
+        return nullptr;
+
+    if (!needle)
+        return nullptr;
+
+    if (!*needle)
+        return (char *)haystack;
+
+    char *p1 = (char *)haystack;
+    while (*p1 != '\0' && !EQUALN(p1, needle, strlen(needle)))
+        p1++;
+
+    if (*p1 == '\0')
+        return nullptr;
+
+    return p1;
 }
 
 char *MM_oemansi(char *szszChain)

--- a/ogr/ogrsf_frmts/miramon/mm_gdal_functions.h
+++ b/ogr/ogrsf_frmts/miramon/mm_gdal_functions.h
@@ -95,6 +95,7 @@ extern char szNumberOfElementaryPolygonsSpa[];
 
 char *MM_oemansi(char *szcadena);
 char *MM_oemansi_n(char *szcadena, size_t n_bytes);
+char *MM_stristr(const char *haystack, const char *needle);
 void MM_InitializeField(struct MM_FIELD *camp);
 struct MM_FIELD *MM_CreateAllFields(MM_EXT_DBF_N_FIELDS ncamps);
 MM_FIRST_RECORD_OFFSET_TYPE

--- a/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
+++ b/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
@@ -828,7 +828,7 @@ static int MMChangeFinalPartOfTheName(char *pszName, size_t nMaxSizeOfName,
     // It's the implementation on windows of the linux strrstr()
     // pszLastFound = strrstr(pszWhereToFind, pszFinalPart);
     pszWhereToFind = pszName;
-    while (nullptr != (pAux = strstr(pszWhereToFind, pszFinalPart)))
+    while (nullptr != (pAux = MM_stristr(pszWhereToFind, pszFinalPart)))
     {
         pszLastFound = pAux;
         pszWhereToFind = pAux + strlen(pAux);
@@ -5387,7 +5387,7 @@ int MMReturnCodeFromMM_m_idofic(char *pMMSRS_or_pSRS, char *szResult,
                    "Wrong format in data\\MM_m_idofic.csv.\n");
         return 1;
     }
-    id_geodes = strstr(pszLine, "ID_GEODES");
+    id_geodes = MM_stristr(pszLine, "ID_GEODES");
     if (!id_geodes)
     {
         fclose_function(pfMMSRS);
@@ -5396,7 +5396,7 @@ int MMReturnCodeFromMM_m_idofic(char *pMMSRS_or_pSRS, char *szResult,
         return 1;
     }
     id_geodes[strlen("ID_GEODES")] = '\0';
-    psidgeodes = strstr(pszLine, "PSIDGEODES");
+    psidgeodes = MM_stristr(pszLine, "PSIDGEODES");
     if (!psidgeodes)
     {
         fclose_function(pfMMSRS);


### PR DESCRIPTION
## What does this PR do?
Solves the case of giving a false error when the translating a polígon with a capital extension reference to its arc.

Some other strstr() have been corrected to a version of windows stristr() called MM_stristr() cause it's not important to be case sensitive

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] All CI builds and checks have passed
