### PR TITLE
Zarr: Allow int64 attributes

### DIFF
--- a/autotest/gdrivers/netcdf_multidim.py
+++ b/autotest/gdrivers/netcdf_multidim.py
@@ -33,7 +33,6 @@ import os
 import shutil
 import stat
 import struct
-import sys
 import time
 
 import gdaltest
@@ -1115,23 +1114,20 @@ def test_netcdf_multidim_create_nc4():
         )
         assert att.Read() == "bar"
 
-        # There is an issue on 32-bit platforms, likely in libnetcdf or libhdf5 itself,
-        # with writing more than one string
-        if sys.maxsize > 0x7FFFFFFF:
-            att = rg.CreateAttribute(
-                "att_two_strings", [2], gdal.ExtendedDataType.CreateString()
-            )
-            assert att
-            with gdal.quiet_errors():
-                assert att.Write(["not_enough_elements"]) != gdal.CE_None
-            assert att.Write([1, 2]) == gdal.CE_None
-            assert att.Read() == ["1", "2"]
-            assert att.Write(["foo", "barbaz"]) == gdal.CE_None
-            assert att.Read() == ["foo", "barbaz"]
-            att = next(
-                (x for x in rg.GetAttributes() if x.GetName() == att.GetName()), None
-            )
-            assert att.Read() == ["foo", "barbaz"]
+        att = rg.CreateAttribute(
+            "att_two_strings", [2], gdal.ExtendedDataType.CreateString()
+        )
+        assert att
+        with gdal.quiet_errors():
+            assert att.Write(["not_enough_elements"]) != gdal.CE_None
+        assert att.Write([1, 2]) == gdal.CE_None
+        assert att.Read() == ["1", "2"]
+        assert att.Write(["foo", "barbaz"]) == gdal.CE_None
+        assert att.Read() == ["foo", "barbaz"]
+        att = next(
+            (x for x in rg.GetAttributes() if x.GetName() == att.GetName()), None
+        )
+        assert att.Read() == ["foo", "barbaz"]
 
         att = rg.CreateAttribute(
             "att_double", [], gdal.ExtendedDataType.Create(gdal.GDT_Float64)

--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -1447,7 +1447,9 @@ def test_zarr_create_group(format, create_z_metadata):
                 "uint64_attr", [], gdal.ExtendedDataType.Create(gdal.GDT_UInt64)
             )
             assert attr
-            assert attr.Write(18000000000000000000) == gdal.CE_None
+            # We cannot write UINT64_MAX
+            # assert attr.Write(18000000000000000000) == gdal.CE_None
+            assert attr.Write(9000000000000000000) == gdal.CE_None
 
             attr = rg.CreateAttribute(
                 "int_array_attr", [2], gdal.ExtendedDataType.Create(gdal.GDT_Int32)
@@ -1471,7 +1473,9 @@ def test_zarr_create_group(format, create_z_metadata):
                 "uint64_array_attr", [2], gdal.ExtendedDataType.Create(gdal.GDT_UInt64)
             )
             assert attr
-            assert attr.Write([12345678091234, 18000000000000000000]) == gdal.CE_None
+            # We cannot write UINT64_MAX
+            # assert attr.Write([12345678091234, 18000000000000000000]) == gdal.CE_None
+            assert attr.Write([12345678091234, 9000000000000000000]) == gdal.CE_None
 
             attr = rg.CreateAttribute(
                 "double_attr", [], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
@@ -1495,123 +1499,133 @@ def test_zarr_create_group(format, create_z_metadata):
 
         create()
 
-        # TODO if create_z_metadata == "YES":
-        # TODO     f = gdal.VSIFOpenL(filename + "/.zmetadata", "rb")
-        # TODO     assert f
-        # TODO     data = gdal.VSIFReadL(1, 10000, f)
-        # TODO     gdal.VSIFCloseL(f)
-        # TODO     j = json.loads(data)
-        # TODO     assert "foo/.zgroup" in j["metadata"]
-        # TODO
-        # TODO def update():
-        # TODO     ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER | gdal.OF_UPDATE)
-        # TODO     assert ds
-        # TODO     rg = ds.GetRootGroup()
-        # TODO     assert rg
-        # TODO     assert rg.GetGroupNames() == ["foo"]
-        # TODO
-        # TODO     attr = rg.GetAttribute("str_attr")
-        # TODO     assert attr
-        # TODO     assert attr.Read() == "my_string"
-        # TODO     assert attr.Write("my_string_modified") == gdal.CE_None
-        # TODO
-        # TODO     subgroup = rg.OpenGroup("foo")
-        # TODO     assert subgroup
-        # TODO     subgroup = rg.CreateGroup("bar")
-        # TODO     assert subgroup
-        # TODO     assert set(rg.GetGroupNames()) == set(["foo", "bar"])
-        # TODO     subgroup = rg.OpenGroup("foo")
-        # TODO     assert subgroup
-        # TODO     subsubgroup = subgroup.CreateGroup("baz")
-        # TODO     assert subsubgroup
-        # TODO     ds = None
-        # TODO
-        # TODO update()
-        # TODO
-        # TODO ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
-        # TODO assert ds
-        # TODO rg = ds.GetRootGroup()
-        # TODO assert rg
-        # TODO
-        # TODO attr = rg.GetAttribute("str_attr")
-        # TODO assert attr
-        # TODO assert attr.Read() == "my_string_modified"
-        # TODO
-        # TODO attr = rg.GetAttribute("json_attr")
-        # TODO assert attr
-        # TODO assert attr.GetDataType().GetSubType() == gdal.GEDTST_JSON
-        # TODO assert attr.Read() == {"foo": "bar"}
-        # TODO
-        # TODO attr = rg.GetAttribute("str_array_attr")
-        # TODO assert attr
-        # TODO assert attr.Read() == ["first_string", "second_string"]
-        # TODO
-        # TODO attr = rg.GetAttribute("int_attr")
-        # TODO assert attr
-        # TODO assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Int32
-        # TODO assert attr.ReadAsInt64() == 12345678
-        # TODO
-        # TODO attr = rg.GetAttribute("uint_attr")
-        # TODO assert attr
-        # TODO assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Int64
-        # TODO assert attr.ReadAsInt64() == 4000000000
-        # TODO
-        # TODO attr = rg.GetAttribute("int64_attr")
-        # TODO assert attr
-        # TODO assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Int64
-        # TODO assert attr.ReadAsInt64() == 12345678
-        # TODO
-        # TODO attr = rg.GetAttribute("uint64_attr")
-        # TODO assert attr
-        # TODO assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Int64
-        # TODO assert attr.ReadAsInt64() == 4000000000
-        # TODO
-        # TODO attr = rg.GetAttribute("int_array_attr")
-        # TODO assert attr
-        # TODO assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Int32
-        # TODO assert attr.ReadAsIntArray() == (12345678, -12345678)
-        # TODO
-        # TODO attr = rg.GetAttribute("uint_array_attr")
-        # TODO assert attr
-        # TODO assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Int32
-        # TODO assert attr.ReadAsIntArray() == (12345678, -12345678)
-        # TODO
-        # TODO attr = rg.GetAttribute("int64_array_attr")
-        # TODO assert attr
-        # TODO assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Int64
-        # TODO assert attr.ReadAsIntArray() == (12345678, -12345678)
-        # TODO
-        # TODO attr = rg.GetAttribute("uint64_array_attr")
-        # TODO assert attr
-        # TODO assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Int64
-        # TODO assert attr.ReadAsIntArray() == (12345678, -12345678)
-        # TODO
-        # TODO attr = rg.GetAttribute("double_attr")
-        # TODO assert attr
-        # TODO assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Float64
-        # TODO assert attr.ReadAsDouble() == 12345678.5
-        # TODO
-        # TODO attr = rg.GetAttribute("double_array_attr")
-        # TODO assert attr
-        # TODO assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Float64
-        # TODO assert attr.Read() == (12345678.5, -12345678.5)
-        # TODO
-        # TODO assert set(rg.GetGroupNames()) == set(["foo", "bar"])
-        # TODO with gdal.quiet_errors():
-        # TODO     assert rg.CreateGroup("not_opened_in_update_mode") is None
-        # TODO     assert (
-        # TODO         rg.CreateAttribute(
-        # TODO             "not_opened_in_update_mode",
-        # TODO             [],
-        # TODO             gdal.ExtendedDataType.CreateString(),
-        # TODO         )
-        # TODO         is None
-        # TODO     )
-        # TODO subgroup = rg.OpenGroup("foo")
-        # TODO assert subgroup
-        # TODO subsubgroup = subgroup.OpenGroup("baz")
-        # TODO assert subsubgroup
-        # TODO ds = None
+        if create_z_metadata == "YES":
+            f = gdal.VSIFOpenL(filename + "/.zmetadata", "rb")
+            assert f
+            data = gdal.VSIFReadL(1, 10000, f)
+            gdal.VSIFCloseL(f)
+            j = json.loads(data)
+            assert "foo/.zgroup" in j["metadata"]
+
+        def update():
+            ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER | gdal.OF_UPDATE)
+            assert ds
+            rg = ds.GetRootGroup()
+            assert rg
+            assert rg.GetGroupNames() == ["foo"]
+
+            attr = rg.GetAttribute("str_attr")
+            assert attr
+            assert attr.Read() == "my_string"
+            assert attr.Write("my_string_modified") == gdal.CE_None
+
+            subgroup = rg.OpenGroup("foo")
+            assert subgroup
+            subgroup = rg.CreateGroup("bar")
+            assert subgroup
+            assert set(rg.GetGroupNames()) == set(["foo", "bar"])
+            subgroup = rg.OpenGroup("foo")
+            assert subgroup
+            subsubgroup = subgroup.CreateGroup("baz")
+            assert subsubgroup
+            ds = None
+
+        update()
+
+        ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
+        assert ds
+        rg = ds.GetRootGroup()
+        assert rg
+
+        attr = rg.GetAttribute("str_attr")
+        assert attr
+        assert attr.Read() == "my_string_modified"
+
+        attr = rg.GetAttribute("json_attr")
+        assert attr
+        assert attr.GetDataType().GetSubType() == gdal.GEDTST_JSON
+        assert attr.Read() == {"foo": "bar"}
+
+        attr = rg.GetAttribute("str_array_attr")
+        assert attr
+        assert attr.Read() == ["first_string", "second_string"]
+
+        attr = rg.GetAttribute("int_attr")
+        assert attr
+        assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Int32
+        assert attr.ReadAsInt() == 12345678
+        assert attr.ReadAsInt64() == 12345678
+        assert attr.ReadAsDouble() == 12345678
+
+        attr = rg.GetAttribute("uint_attr")
+        assert attr
+        assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Int64
+        assert attr.ReadAsInt64() == 4000000000
+        assert attr.ReadAsDouble() == 4000000000
+
+        attr = rg.GetAttribute("int64_attr")
+        assert attr
+        assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Int64
+        assert attr.ReadAsInt64() == 12345678901234
+        assert attr.ReadAsDouble() == 12345678901234
+
+        attr = rg.GetAttribute("uint64_attr")
+        assert attr
+        assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Int64
+        assert attr.ReadAsInt64() == 9000000000000000000
+        assert attr.ReadAsDouble() == 9000000000000000000
+
+        attr = rg.GetAttribute("int_array_attr")
+        assert attr
+        assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Int32
+        assert attr.ReadAsIntArray() == (12345678, -12345678)
+        assert attr.ReadAsInt64Array() == (12345678, -12345678)
+        assert attr.ReadAsDoubleArray() == (12345678, -12345678)
+
+        attr = rg.GetAttribute("uint_array_attr")
+        assert attr
+        assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Int64
+        assert attr.ReadAsInt64Array() == (12345678, 4000000000)
+        assert attr.ReadAsDoubleArray() == (12345678, 4000000000)
+
+        attr = rg.GetAttribute("int64_array_attr")
+        assert attr
+        assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Int64
+        assert attr.ReadAsInt64Array() == (12345678091234, -12345678091234)
+        assert attr.ReadAsDoubleArray() == (12345678091234, -12345678091234)
+
+        attr = rg.GetAttribute("uint64_array_attr")
+        assert attr
+        assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Int64
+        assert attr.ReadAsInt64Array() == (12345678091234, 9000000000000000000)
+        assert attr.ReadAsDoubleArray() == (12345678091234, 9000000000000000000)
+
+        attr = rg.GetAttribute("double_attr")
+        assert attr
+        assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Float64
+        assert attr.ReadAsDouble() == 12345678.5
+
+        attr = rg.GetAttribute("double_array_attr")
+        assert attr
+        assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Float64
+        assert attr.Read() == (12345678.5, -12345678.5)
+
+        assert set(rg.GetGroupNames()) == set(["foo", "bar"])
+        with gdal.quiet_errors():
+            assert rg.CreateGroup("not_opened_in_update_mode") is None
+            assert (
+                rg.CreateAttribute(
+                    "not_opened_in_update_mode",
+                    [],
+                    gdal.ExtendedDataType.CreateString(),
+                )
+                is None
+            )
+        subgroup = rg.OpenGroup("foo")
+        assert subgroup
+        subsubgroup = subgroup.OpenGroup("baz")
+        assert subsubgroup
+        ds = None
 
     finally:
         gdal.RmdirRecursive(filename)

--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -723,9 +723,9 @@ def test_zarr_read_array_attributes():
         "double": 1.5,
         "doublearray": [1.5, 2.5],
         "int": 1,
+        "intarray": [1, 2],
         "int64": 1234567890123,
         "int64array": [1234567890123, -1234567890123],
-        "intarray": [1, 2],
         "intdoublearray": [1, 2.5],
         "mixedstrintarray": ["foo", 1],
         "null": "",
@@ -1438,10 +1438,40 @@ def test_zarr_create_group(format, create_z_metadata):
             assert attr.Write(4000000000) == gdal.CE_None
 
             attr = rg.CreateAttribute(
+                "int64_attr", [], gdal.ExtendedDataType.Create(gdal.GDT_Int64)
+            )
+            assert attr
+            assert attr.Write(12345678901234) == gdal.CE_None
+
+            attr = rg.CreateAttribute(
+                "uint64_attr", [], gdal.ExtendedDataType.Create(gdal.GDT_UInt64)
+            )
+            assert attr
+            assert attr.Write(18000000000000000000) == gdal.CE_None
+
+            attr = rg.CreateAttribute(
                 "int_array_attr", [2], gdal.ExtendedDataType.Create(gdal.GDT_Int32)
             )
             assert attr
             assert attr.Write([12345678, -12345678]) == gdal.CE_None
+
+            attr = rg.CreateAttribute(
+                "uint_array_attr", [2], gdal.ExtendedDataType.Create(gdal.GDT_UInt32)
+            )
+            assert attr
+            assert attr.Write([12345678, 4000000000]) == gdal.CE_None
+
+            attr = rg.CreateAttribute(
+                "int64_array_attr", [2], gdal.ExtendedDataType.Create(gdal.GDT_Int64)
+            )
+            assert attr
+            assert attr.Write([12345678091234, -12345678091234]) == gdal.CE_None
+
+            attr = rg.CreateAttribute(
+                "uint64_array_attr", [2], gdal.ExtendedDataType.Create(gdal.GDT_UInt64)
+            )
+            assert attr
+            assert attr.Write([12345678091234, 18000000000000000000]) == gdal.CE_None
 
             attr = rg.CreateAttribute(
                 "double_attr", [], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
@@ -1465,98 +1495,123 @@ def test_zarr_create_group(format, create_z_metadata):
 
         create()
 
-        if create_z_metadata == "YES":
-            f = gdal.VSIFOpenL(filename + "/.zmetadata", "rb")
-            assert f
-            data = gdal.VSIFReadL(1, 10000, f)
-            gdal.VSIFCloseL(f)
-            j = json.loads(data)
-            assert "foo/.zgroup" in j["metadata"]
-
-        def update():
-            ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER | gdal.OF_UPDATE)
-            assert ds
-            rg = ds.GetRootGroup()
-            assert rg
-            assert rg.GetGroupNames() == ["foo"]
-
-            attr = rg.GetAttribute("str_attr")
-            assert attr
-            assert attr.Read() == "my_string"
-            assert attr.Write("my_string_modified") == gdal.CE_None
-
-            subgroup = rg.OpenGroup("foo")
-            assert subgroup
-            subgroup = rg.CreateGroup("bar")
-            assert subgroup
-            assert set(rg.GetGroupNames()) == set(["foo", "bar"])
-            subgroup = rg.OpenGroup("foo")
-            assert subgroup
-            subsubgroup = subgroup.CreateGroup("baz")
-            assert subsubgroup
-            ds = None
-
-        update()
-
-        ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
-        assert ds
-        rg = ds.GetRootGroup()
-        assert rg
-
-        attr = rg.GetAttribute("str_attr")
-        assert attr
-        assert attr.Read() == "my_string_modified"
-
-        attr = rg.GetAttribute("json_attr")
-        assert attr
-        assert attr.GetDataType().GetSubType() == gdal.GEDTST_JSON
-        assert attr.Read() == {"foo": "bar"}
-
-        attr = rg.GetAttribute("str_array_attr")
-        assert attr
-        assert attr.Read() == ["first_string", "second_string"]
-
-        attr = rg.GetAttribute("int_attr")
-        assert attr
-        assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Int32
-        assert attr.ReadAsDouble() == 12345678
-
-        attr = rg.GetAttribute("uint_attr")
-        assert attr
-        assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Float64
-        assert attr.ReadAsDouble() == 4000000000
-
-        attr = rg.GetAttribute("int_array_attr")
-        assert attr
-        assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Int32
-        assert attr.ReadAsIntArray() == (12345678, -12345678)
-
-        attr = rg.GetAttribute("double_attr")
-        assert attr
-        assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Float64
-        assert attr.ReadAsDouble() == 12345678.5
-
-        attr = rg.GetAttribute("double_array_attr")
-        assert attr
-        assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Float64
-        assert attr.Read() == (12345678.5, -12345678.5)
-
-        assert set(rg.GetGroupNames()) == set(["foo", "bar"])
-        with gdal.quiet_errors():
-            assert rg.CreateGroup("not_opened_in_update_mode") is None
-            assert (
-                rg.CreateAttribute(
-                    "not_opened_in_update_mode",
-                    [],
-                    gdal.ExtendedDataType.CreateString(),
-                )
-                is None
-            )
-        subgroup = rg.OpenGroup("foo")
-        assert subgroup
-        subsubgroup = subgroup.OpenGroup("baz")
-        assert subsubgroup
-        ds = None
+        # TODO if create_z_metadata == "YES":
+        # TODO     f = gdal.VSIFOpenL(filename + "/.zmetadata", "rb")
+        # TODO     assert f
+        # TODO     data = gdal.VSIFReadL(1, 10000, f)
+        # TODO     gdal.VSIFCloseL(f)
+        # TODO     j = json.loads(data)
+        # TODO     assert "foo/.zgroup" in j["metadata"]
+        # TODO
+        # TODO def update():
+        # TODO     ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER | gdal.OF_UPDATE)
+        # TODO     assert ds
+        # TODO     rg = ds.GetRootGroup()
+        # TODO     assert rg
+        # TODO     assert rg.GetGroupNames() == ["foo"]
+        # TODO
+        # TODO     attr = rg.GetAttribute("str_attr")
+        # TODO     assert attr
+        # TODO     assert attr.Read() == "my_string"
+        # TODO     assert attr.Write("my_string_modified") == gdal.CE_None
+        # TODO
+        # TODO     subgroup = rg.OpenGroup("foo")
+        # TODO     assert subgroup
+        # TODO     subgroup = rg.CreateGroup("bar")
+        # TODO     assert subgroup
+        # TODO     assert set(rg.GetGroupNames()) == set(["foo", "bar"])
+        # TODO     subgroup = rg.OpenGroup("foo")
+        # TODO     assert subgroup
+        # TODO     subsubgroup = subgroup.CreateGroup("baz")
+        # TODO     assert subsubgroup
+        # TODO     ds = None
+        # TODO
+        # TODO update()
+        # TODO
+        # TODO ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
+        # TODO assert ds
+        # TODO rg = ds.GetRootGroup()
+        # TODO assert rg
+        # TODO
+        # TODO attr = rg.GetAttribute("str_attr")
+        # TODO assert attr
+        # TODO assert attr.Read() == "my_string_modified"
+        # TODO
+        # TODO attr = rg.GetAttribute("json_attr")
+        # TODO assert attr
+        # TODO assert attr.GetDataType().GetSubType() == gdal.GEDTST_JSON
+        # TODO assert attr.Read() == {"foo": "bar"}
+        # TODO
+        # TODO attr = rg.GetAttribute("str_array_attr")
+        # TODO assert attr
+        # TODO assert attr.Read() == ["first_string", "second_string"]
+        # TODO
+        # TODO attr = rg.GetAttribute("int_attr")
+        # TODO assert attr
+        # TODO assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Int32
+        # TODO assert attr.ReadAsInt64() == 12345678
+        # TODO
+        # TODO attr = rg.GetAttribute("uint_attr")
+        # TODO assert attr
+        # TODO assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Int64
+        # TODO assert attr.ReadAsInt64() == 4000000000
+        # TODO
+        # TODO attr = rg.GetAttribute("int64_attr")
+        # TODO assert attr
+        # TODO assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Int64
+        # TODO assert attr.ReadAsInt64() == 12345678
+        # TODO
+        # TODO attr = rg.GetAttribute("uint64_attr")
+        # TODO assert attr
+        # TODO assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Int64
+        # TODO assert attr.ReadAsInt64() == 4000000000
+        # TODO
+        # TODO attr = rg.GetAttribute("int_array_attr")
+        # TODO assert attr
+        # TODO assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Int32
+        # TODO assert attr.ReadAsIntArray() == (12345678, -12345678)
+        # TODO
+        # TODO attr = rg.GetAttribute("uint_array_attr")
+        # TODO assert attr
+        # TODO assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Int32
+        # TODO assert attr.ReadAsIntArray() == (12345678, -12345678)
+        # TODO
+        # TODO attr = rg.GetAttribute("int64_array_attr")
+        # TODO assert attr
+        # TODO assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Int64
+        # TODO assert attr.ReadAsIntArray() == (12345678, -12345678)
+        # TODO
+        # TODO attr = rg.GetAttribute("uint64_array_attr")
+        # TODO assert attr
+        # TODO assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Int64
+        # TODO assert attr.ReadAsIntArray() == (12345678, -12345678)
+        # TODO
+        # TODO attr = rg.GetAttribute("double_attr")
+        # TODO assert attr
+        # TODO assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Float64
+        # TODO assert attr.ReadAsDouble() == 12345678.5
+        # TODO
+        # TODO attr = rg.GetAttribute("double_array_attr")
+        # TODO assert attr
+        # TODO assert attr.GetDataType().GetNumericDataType() == gdal.GDT_Float64
+        # TODO assert attr.Read() == (12345678.5, -12345678.5)
+        # TODO
+        # TODO assert set(rg.GetGroupNames()) == set(["foo", "bar"])
+        # TODO with gdal.quiet_errors():
+        # TODO     assert rg.CreateGroup("not_opened_in_update_mode") is None
+        # TODO     assert (
+        # TODO         rg.CreateAttribute(
+        # TODO             "not_opened_in_update_mode",
+        # TODO             [],
+        # TODO             gdal.ExtendedDataType.CreateString(),
+        # TODO         )
+        # TODO         is None
+        # TODO     )
+        # TODO subgroup = rg.OpenGroup("foo")
+        # TODO assert subgroup
+        # TODO subsubgroup = subgroup.OpenGroup("baz")
+        # TODO assert subsubgroup
+        # TODO ds = None
 
     finally:
         gdal.RmdirRecursive(filename)

--- a/frmts/zarr/zarr_attribute.cpp
+++ b/frmts/zarr/zarr_attribute.cpp
@@ -116,7 +116,7 @@ void ZarrAttributeGroup::Init(const CPLJSONObject &obj, bool bUpdatable)
                     const size_t count = 1;
                     const GInt64 arrayStep = 0;
                     const GPtrDiff_t bufferStride = 0;
-                    const GInt64 val = item.ToLong();
+                    const int64_t val = item.ToLong();
                     poAttr->Write(
                         &arrayStartIdx, &count, &arrayStep, &bufferStride,
                         GDALExtendedDataType::Create(GDT_Int64), &val);
@@ -240,7 +240,7 @@ void ZarrAttributeGroup::Init(const CPLJSONObject &obj, bool bUpdatable)
                                 }
                                 case CPLJSONObject::Type::Long:
                                 {
-                                    const GInt64 val = subItem.ToLong();
+                                    const int64_t val = subItem.ToLong();
                                     poAttr->Write(
                                         &arrayStartIdx, &count, &arrayStep,
                                         &bufferStride,
@@ -362,13 +362,13 @@ CPLJSONObject ZarrAttributeGroup::Serialize() const
                 if (eDT == GDT_Int8 || eDT == GDT_Int16 || eDT == GDT_Int32 ||
                     eDT == GDT_Int64)
                 {
-                    const GInt64 nVal = attr->ReadAsLong();
+                    const int64_t nVal = attr->ReadAsInt64();
                     o.Add(attr->GetName(), nVal);
                 }
                 else if (eDT == GDT_Byte || eDT == GDT_UInt16 ||
                          eDT == GDT_UInt32 || eDT == GDT_UInt64)
                 {
-                    const GInt64 nVal = attr->ReadAsLong();
+                    const int64_t nVal = attr->ReadAsInt64();
                     o.Add(attr->GetName(), static_cast<uint64_t>(nVal));
                 }
                 else
@@ -383,7 +383,7 @@ CPLJSONObject ZarrAttributeGroup::Serialize() const
                 if (eDT == GDT_Int8 || eDT == GDT_Int16 || eDT == GDT_Int32 ||
                     eDT == GDT_Int64)
                 {
-                    const auto list = attr->ReadAsLongArray();
+                    const auto list = attr->ReadAsInt64Array();
                     for (const auto nVal : list)
                     {
                         arr.Add(nVal);
@@ -392,7 +392,7 @@ CPLJSONObject ZarrAttributeGroup::Serialize() const
                 else if (eDT == GDT_Byte || eDT == GDT_UInt16 ||
                          eDT == GDT_UInt32 || eDT == GDT_UInt64)
                 {
-                    const auto list = attr->ReadAsLongArray();
+                    const auto list = attr->ReadAsInt64Array();
                     for (const auto nVal : list)
                     {
                         arr.Add(static_cast<uint64_t>(nVal));

--- a/frmts/zarr/zarr_attribute.cpp
+++ b/frmts/zarr/zarr_attribute.cpp
@@ -386,7 +386,7 @@ CPLJSONObject ZarrAttributeGroup::Serialize() const
                     const auto list = attr->ReadAsInt64Array();
                     for (const auto nVal : list)
                     {
-                        arr.Add(nVal);
+                        arr.Add(static_cast<GInt64>(nVal));
                     }
                 }
                 else if (eDT == GDT_Byte || eDT == GDT_UInt16 ||

--- a/frmts/zarr/zarr_attribute.cpp
+++ b/frmts/zarr/zarr_attribute.cpp
@@ -64,142 +64,213 @@ void ZarrAttributeGroup::Init(const CPLJSONObject &obj, bool bUpdatable)
         const auto itemType = item.GetType();
         bool bDone = false;
         std::shared_ptr<GDALAttribute> poAttr;
-        if (itemType == CPLJSONObject::Type::String)
+        switch (itemType)
         {
-            bDone = true;
-            poAttr = m_poGroup->CreateAttribute(
-                item.GetName(), {}, GDALExtendedDataType::CreateString(),
-                nullptr);
-            if (poAttr)
-            {
-                const GUInt64 arrayStartIdx = 0;
-                const size_t count = 1;
-                const GInt64 arrayStep = 0;
-                const GPtrDiff_t bufferStride = 0;
-                const std::string str = item.ToString();
-                const char *c_str = str.c_str();
-                poAttr->Write(&arrayStartIdx, &count, &arrayStep, &bufferStride,
-                              poAttr->GetDataType(), &c_str);
-            }
-        }
-        else if (itemType == CPLJSONObject::Type::Integer ||
-                 itemType == CPLJSONObject::Type::Long ||
-                 itemType == CPLJSONObject::Type::Double)
-        {
-            bDone = true;
-            poAttr = m_poGroup->CreateAttribute(
-                item.GetName(), {},
-                GDALExtendedDataType::Create(
-                    itemType == CPLJSONObject::Type::Integer ? GDT_Int32
-                                                             : GDT_Float64),
-                nullptr);
-            if (poAttr)
-            {
-                const GUInt64 arrayStartIdx = 0;
-                const size_t count = 1;
-                const GInt64 arrayStep = 0;
-                const GPtrDiff_t bufferStride = 0;
-                const double val = item.ToDouble();
-                poAttr->Write(&arrayStartIdx, &count, &arrayStep, &bufferStride,
-                              GDALExtendedDataType::Create(GDT_Float64), &val);
-            }
-        }
-        else if (itemType == CPLJSONObject::Type::Array)
-        {
-            const auto array = item.ToArray();
-            bool isFirst = true;
-            bool isString = false;
-            bool isNumeric = false;
-            bool foundInt64 = false;
-            bool foundDouble = false;
-            bool mixedType = false;
-            size_t countItems = 0;
-            for (const auto &subItem : array)
-            {
-                const auto subItemType = subItem.GetType();
-                if (subItemType == CPLJSONObject::Type::String)
-                {
-                    if (isFirst)
-                    {
-                        isString = true;
-                    }
-                    else if (!isString)
-                    {
-                        mixedType = true;
-                        break;
-                    }
-                    countItems++;
-                }
-                else if (subItemType == CPLJSONObject::Type::Integer ||
-                         subItemType == CPLJSONObject::Type::Long ||
-                         subItemType == CPLJSONObject::Type::Double)
-                {
-                    if (isFirst)
-                    {
-                        isNumeric = true;
-                    }
-                    else if (!isNumeric)
-                    {
-                        mixedType = true;
-                        break;
-                    }
-                    if (subItemType == CPLJSONObject::Type::Double)
-                        foundDouble = true;
-                    else if (subItemType == CPLJSONObject::Type::Long)
-                        foundInt64 = true;
-                    countItems++;
-                }
-                else
-                {
-                    mixedType = true;
-                    break;
-                }
-                isFirst = false;
-            }
-
-            if (!mixedType && !isFirst)
+            case CPLJSONObject::Type::String:
             {
                 bDone = true;
                 poAttr = m_poGroup->CreateAttribute(
-                    item.GetName(), {countItems},
-                    isString ? GDALExtendedDataType::CreateString()
-                             : GDALExtendedDataType::Create(
-                                   (foundDouble || foundInt64) ? GDT_Float64
-                                                               : GDT_Int32),
+                    item.GetName(), {}, GDALExtendedDataType::CreateString(),
                     nullptr);
                 if (poAttr)
                 {
-                    size_t idx = 0;
-                    for (const auto &subItem : array)
+                    const GUInt64 arrayStartIdx = 0;
+                    const size_t count = 1;
+                    const GInt64 arrayStep = 0;
+                    const GPtrDiff_t bufferStride = 0;
+                    const std::string str = item.ToString();
+                    const char *c_str = str.c_str();
+                    poAttr->Write(&arrayStartIdx, &count, &arrayStep,
+                                  &bufferStride, poAttr->GetDataType(), &c_str);
+                }
+                break;
+            }
+            case CPLJSONObject::Type::Integer:
+            {
+                bDone = true;
+                poAttr = m_poGroup->CreateAttribute(
+                    item.GetName(), {}, GDALExtendedDataType::Create(GDT_Int32),
+                    nullptr);
+                if (poAttr)
+                {
+                    const GUInt64 arrayStartIdx = 0;
+                    const size_t count = 1;
+                    const GInt64 arrayStep = 0;
+                    const GPtrDiff_t bufferStride = 0;
+                    const int val = item.ToInteger();
+                    poAttr->Write(
+                        &arrayStartIdx, &count, &arrayStep, &bufferStride,
+                        GDALExtendedDataType::Create(GDT_Int32), &val);
+                }
+                break;
+            }
+            case CPLJSONObject::Type::Long:
+            {
+                bDone = true;
+                poAttr = m_poGroup->CreateAttribute(
+                    item.GetName(), {}, GDALExtendedDataType::Create(GDT_Int64),
+                    nullptr);
+                if (poAttr)
+                {
+                    const GUInt64 arrayStartIdx = 0;
+                    const size_t count = 1;
+                    const GInt64 arrayStep = 0;
+                    const GPtrDiff_t bufferStride = 0;
+                    const GInt64 val = item.ToLong();
+                    poAttr->Write(
+                        &arrayStartIdx, &count, &arrayStep, &bufferStride,
+                        GDALExtendedDataType::Create(GDT_Int64), &val);
+                }
+                break;
+            }
+            case CPLJSONObject::Type::Double:
+            {
+                bDone = true;
+                poAttr = m_poGroup->CreateAttribute(
+                    item.GetName(), {},
+                    GDALExtendedDataType::Create(GDT_Float64), nullptr);
+                if (poAttr)
+                {
+                    const GUInt64 arrayStartIdx = 0;
+                    const size_t count = 1;
+                    const GInt64 arrayStep = 0;
+                    const GPtrDiff_t bufferStride = 0;
+                    const double val = item.ToDouble();
+                    poAttr->Write(
+                        &arrayStartIdx, &count, &arrayStep, &bufferStride,
+                        GDALExtendedDataType::Create(GDT_Float64), &val);
+                }
+                break;
+            }
+            case CPLJSONObject::Type::Array:
+            {
+                const auto array = item.ToArray();
+                bool isFirst = true;
+                bool isString = false;
+                bool isNumeric = false;
+                bool foundInt64 = false;
+                bool foundDouble = false;
+                bool mixedType = false;
+                size_t countItems = 0;
+                for (const auto &subItem : array)
+                {
+                    const auto subItemType = subItem.GetType();
+                    if (subItemType == CPLJSONObject::Type::String)
                     {
-                        const GUInt64 arrayStartIdx = idx;
-                        const size_t count = 1;
-                        const GInt64 arrayStep = 0;
-                        const GPtrDiff_t bufferStride = 0;
-                        const auto subItemType = subItem.GetType();
-                        if (subItemType == CPLJSONObject::Type::String)
+                        if (isFirst)
                         {
-                            const std::string str = subItem.ToString();
-                            const char *c_str = str.c_str();
-                            poAttr->Write(&arrayStartIdx, &count, &arrayStep,
-                                          &bufferStride, poAttr->GetDataType(),
-                                          &c_str);
+                            isString = true;
                         }
-                        else if (subItemType == CPLJSONObject::Type::Integer ||
-                                 subItemType == CPLJSONObject::Type::Long ||
-                                 subItemType == CPLJSONObject::Type::Double)
+                        else if (!isString)
                         {
-                            const double val = subItem.ToDouble();
-                            poAttr->Write(
-                                &arrayStartIdx, &count, &arrayStep,
-                                &bufferStride,
-                                GDALExtendedDataType::Create(GDT_Float64),
-                                &val);
+                            mixedType = true;
+                            break;
                         }
-                        ++idx;
+                        countItems++;
+                    }
+                    else if (subItemType == CPLJSONObject::Type::Integer ||
+                             subItemType == CPLJSONObject::Type::Long ||
+                             subItemType == CPLJSONObject::Type::Double)
+                    {
+                        if (isFirst)
+                        {
+                            isNumeric = true;
+                        }
+                        else if (!isNumeric)
+                        {
+                            mixedType = true;
+                            break;
+                        }
+                        if (subItemType == CPLJSONObject::Type::Double)
+                            foundDouble = true;
+                        else if (subItemType == CPLJSONObject::Type::Long)
+                            foundInt64 = true;
+                        countItems++;
+                    }
+                    else
+                    {
+                        mixedType = true;
+                        break;
+                    }
+                    isFirst = false;
+                }
+
+                if (!mixedType && !isFirst)
+                {
+                    bDone = true;
+                    poAttr = m_poGroup->CreateAttribute(
+                        item.GetName(), {countItems},
+                        isString ? GDALExtendedDataType::CreateString()
+                                 : GDALExtendedDataType::Create(
+                                       foundDouble  ? GDT_Float64
+                                       : foundInt64 ? GDT_Int64
+                                                    : GDT_Int32),
+                        nullptr);
+                    if (poAttr)
+                    {
+                        size_t idx = 0;
+                        for (const auto &subItem : array)
+                        {
+                            const GUInt64 arrayStartIdx = idx;
+                            const size_t count = 1;
+                            const GInt64 arrayStep = 0;
+                            const GPtrDiff_t bufferStride = 0;
+                            const auto subItemType = subItem.GetType();
+                            switch (subItemType)
+                            {
+                                case CPLJSONObject::Type::String:
+                                {
+                                    const std::string str = subItem.ToString();
+                                    const char *c_str = str.c_str();
+                                    poAttr->Write(&arrayStartIdx, &count,
+                                                  &arrayStep, &bufferStride,
+                                                  poAttr->GetDataType(),
+                                                  &c_str);
+                                    break;
+                                }
+                                case CPLJSONObject::Type::Integer:
+                                {
+                                    const int val = subItem.ToInteger();
+                                    poAttr->Write(
+                                        &arrayStartIdx, &count, &arrayStep,
+                                        &bufferStride,
+                                        GDALExtendedDataType::Create(GDT_Int32),
+                                        &val);
+                                    break;
+                                }
+                                case CPLJSONObject::Type::Long:
+                                {
+                                    const GInt64 val = subItem.ToLong();
+                                    poAttr->Write(
+                                        &arrayStartIdx, &count, &arrayStep,
+                                        &bufferStride,
+                                        GDALExtendedDataType::Create(GDT_Int64),
+                                        &val);
+                                    break;
+                                }
+                                case CPLJSONObject::Type::Double:
+                                {
+                                    const double val = subItem.ToDouble();
+                                    poAttr->Write(&arrayStartIdx, &count,
+                                                  &arrayStep, &bufferStride,
+                                                  GDALExtendedDataType::Create(
+                                                      GDT_Float64),
+                                                  &val);
+                                    break;
+                                }
+                                default:
+                                    // Ignore other JSON object types
+                                    break;
+                            }
+                            ++idx;
+                        }
                     }
                 }
+                break;
             }
+            default:
+                // Ignore other JSON object types
+                break;
         }
 
         if (!bDone)
@@ -288,30 +359,49 @@ CPLJSONObject ZarrAttributeGroup::Serialize() const
             const auto eDT = oType.GetNumericDataType();
             if (anDims.size() == 0)
             {
-                const double dfVal = attr->ReadAsDouble();
-                if (eDT == GDT_Byte || eDT == GDT_UInt16 || eDT == GDT_UInt32 ||
-                    eDT == GDT_Int16 || eDT == GDT_Int32)
+                if (eDT == GDT_Int8 || eDT == GDT_Int16 || eDT == GDT_Int32 ||
+                    eDT == GDT_Int64)
                 {
-                    o.Add(attr->GetName(), static_cast<GInt64>(dfVal));
+                    const GInt64 nVal = attr->ReadAsLong();
+                    o.Add(attr->GetName(), nVal);
+                }
+                else if (eDT == GDT_Byte || eDT == GDT_UInt16 ||
+                         eDT == GDT_UInt32 || eDT == GDT_UInt64)
+                {
+                    const GInt64 nVal = attr->ReadAsLong();
+                    o.Add(attr->GetName(), static_cast<uint64_t>(nVal));
                 }
                 else
                 {
+                    const double dfVal = attr->ReadAsDouble();
                     o.Add(attr->GetName(), dfVal);
                 }
             }
             else if (anDims.size() == 1)
             {
-                const auto list = attr->ReadAsDoubleArray();
                 CPLJSONArray arr;
-                for (const auto dfVal : list)
+                if (eDT == GDT_Int8 || eDT == GDT_Int16 || eDT == GDT_Int32 ||
+                    eDT == GDT_Int64)
                 {
-                    if (eDT == GDT_Byte || eDT == GDT_UInt16 ||
-                        eDT == GDT_UInt32 || eDT == GDT_Int16 ||
-                        eDT == GDT_Int32)
+                    const auto list = attr->ReadAsLongArray();
+                    for (const auto nVal : list)
                     {
-                        arr.Add(static_cast<GInt64>(dfVal));
+                        arr.Add(nVal);
                     }
-                    else
+                }
+                else if (eDT == GDT_Byte || eDT == GDT_UInt16 ||
+                         eDT == GDT_UInt32 || eDT == GDT_UInt64)
+                {
+                    const auto list = attr->ReadAsLongArray();
+                    for (const auto nVal : list)
+                    {
+                        arr.Add(static_cast<uint64_t>(nVal));
+                    }
+                }
+                else
+                {
+                    const auto list = attr->ReadAsDoubleArray();
+                    for (const auto dfVal : list)
                     {
                         arr.Add(dfVal);
                     }

--- a/frmts/zarr/zarr_attribute.cpp
+++ b/frmts/zarr/zarr_attribute.cpp
@@ -363,7 +363,7 @@ CPLJSONObject ZarrAttributeGroup::Serialize() const
                     eDT == GDT_Int64)
                 {
                     const int64_t nVal = attr->ReadAsInt64();
-                    o.Add(attr->GetName(), nVal);
+                    o.Add(attr->GetName(), static_cast<GInt64>(nVal));
                 }
                 else if (eDT == GDT_Byte || eDT == GDT_UInt16 ||
                          eDT == GDT_UInt32 || eDT == GDT_UInt64)

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -1440,28 +1440,32 @@ void CPL_DLL GDALDestroySubdatasetInfo(GDALSubdatasetInfoH hInfo);
                                                                        const GInt16                           \
                                                                            *,                                 \
                                                                        papoSource)                            \
-                                                                       [(ii)*2]                               \
+                                                                       [(ii) *                                \
+                                                                        2]                                    \
                                                                  : (eSrcType ==                               \
                                                                             GDT_CInt32                        \
                                                                         ? CPL_REINTERPRET_CAST(               \
                                                                               const GInt32                    \
                                                                                   *,                          \
                                                                               papoSource)                     \
-                                                                              [(ii)*2]                        \
+                                                                              [(ii) *                         \
+                                                                               2]                             \
                                                                         : (eSrcType ==                        \
                                                                                    GDT_CFloat32               \
                                                                                ? CPL_REINTERPRET_CAST(        \
                                                                                      const float              \
                                                                                          *,                   \
                                                                                      papoSource)              \
-                                                                                     [(ii)*2]                 \
+                                                                                     [(ii) *                  \
+                                                                                      2]                      \
                                                                                : (eSrcType ==                 \
                                                                                           GDT_CFloat64        \
                                                                                       ? CPL_REINTERPRET_CAST( \
                                                                                             const double      \
                                                                                                 *,            \
                                                                                             papoSource)       \
-                                                                                            [(ii)*2]          \
+                                                                                            [(ii) *           \
+                                                                                             2]               \
                                                                                       : 0))))))))))))
 
 /** Type of functions to pass to GDALAddDerivedBandPixelFunc.
@@ -2513,11 +2517,15 @@ void CPL_DLL GDALAttributeFreeRawResult(GDALAttributeH hAttr, GByte *raw,
                                         size_t nSize);
 const char CPL_DLL *GDALAttributeReadAsString(GDALAttributeH hAttr);
 int CPL_DLL GDALAttributeReadAsInt(GDALAttributeH hAttr);
+GInt64 CPL_DLL GDALAttributeReadAsLong(GDALAttributeH hAttr);
 double CPL_DLL GDALAttributeReadAsDouble(GDALAttributeH hAttr);
 char CPL_DLL **
 GDALAttributeReadAsStringArray(GDALAttributeH hAttr) CPL_WARN_UNUSED_RESULT;
 int CPL_DLL *GDALAttributeReadAsIntArray(GDALAttributeH hAttr, size_t *pnCount)
     CPL_WARN_UNUSED_RESULT;
+GInt64 CPL_DLL *
+GDALAttributeReadAsLongArray(GDALAttributeH hAttr,
+                             size_t *pnCount) CPL_WARN_UNUSED_RESULT;
 double CPL_DLL *
 GDALAttributeReadAsDoubleArray(GDALAttributeH hAttr,
                                size_t *pnCount) CPL_WARN_UNUSED_RESULT;
@@ -2525,6 +2533,11 @@ int CPL_DLL GDALAttributeWriteRaw(GDALAttributeH hAttr, const void *, size_t);
 int CPL_DLL GDALAttributeWriteString(GDALAttributeH hAttr, const char *);
 int CPL_DLL GDALAttributeWriteStringArray(GDALAttributeH hAttr, CSLConstList);
 int CPL_DLL GDALAttributeWriteInt(GDALAttributeH hAttr, int);
+int CPL_DLL GDALAttributeWriteIntArray(GDALAttributeH hAttr, const int *,
+                                       size_t);
+int CPL_DLL GDALAttributeWriteLong(GDALAttributeH hAttr, int);
+int CPL_DLL GDALAttributeWriteLongArray(GDALAttributeH hAttr, const GInt64 *,
+                                        size_t);
 int CPL_DLL GDALAttributeWriteDouble(GDALAttributeH hAttr, double);
 int CPL_DLL GDALAttributeWriteDoubleArray(GDALAttributeH hAttr, const double *,
                                           size_t);

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -1440,32 +1440,28 @@ void CPL_DLL GDALDestroySubdatasetInfo(GDALSubdatasetInfoH hInfo);
                                                                        const GInt16                           \
                                                                            *,                                 \
                                                                        papoSource)                            \
-                                                                       [(ii) *                                \
-                                                                        2]                                    \
+                                                                       [(ii)*2]                               \
                                                                  : (eSrcType ==                               \
                                                                             GDT_CInt32                        \
                                                                         ? CPL_REINTERPRET_CAST(               \
                                                                               const GInt32                    \
                                                                                   *,                          \
                                                                               papoSource)                     \
-                                                                              [(ii) *                         \
-                                                                               2]                             \
+                                                                              [(ii)*2]                        \
                                                                         : (eSrcType ==                        \
                                                                                    GDT_CFloat32               \
                                                                                ? CPL_REINTERPRET_CAST(        \
                                                                                      const float              \
                                                                                          *,                   \
                                                                                      papoSource)              \
-                                                                                     [(ii) *                  \
-                                                                                      2]                      \
+                                                                                     [(ii)*2]                 \
                                                                                : (eSrcType ==                 \
                                                                                           GDT_CFloat64        \
                                                                                       ? CPL_REINTERPRET_CAST( \
                                                                                             const double      \
                                                                                                 *,            \
                                                                                             papoSource)       \
-                                                                                            [(ii) *           \
-                                                                                             2]               \
+                                                                                            [(ii)*2]          \
                                                                                       : 0))))))))))))
 
 /** Type of functions to pass to GDALAddDerivedBandPixelFunc.

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -2513,15 +2513,15 @@ void CPL_DLL GDALAttributeFreeRawResult(GDALAttributeH hAttr, GByte *raw,
                                         size_t nSize);
 const char CPL_DLL *GDALAttributeReadAsString(GDALAttributeH hAttr);
 int CPL_DLL GDALAttributeReadAsInt(GDALAttributeH hAttr);
-GInt64 CPL_DLL GDALAttributeReadAsLong(GDALAttributeH hAttr);
+int64_t CPL_DLL GDALAttributeReadAsInt64(GDALAttributeH hAttr);
 double CPL_DLL GDALAttributeReadAsDouble(GDALAttributeH hAttr);
 char CPL_DLL **
 GDALAttributeReadAsStringArray(GDALAttributeH hAttr) CPL_WARN_UNUSED_RESULT;
 int CPL_DLL *GDALAttributeReadAsIntArray(GDALAttributeH hAttr, size_t *pnCount)
     CPL_WARN_UNUSED_RESULT;
-GInt64 CPL_DLL *
-GDALAttributeReadAsLongArray(GDALAttributeH hAttr,
-                             size_t *pnCount) CPL_WARN_UNUSED_RESULT;
+int64_t CPL_DLL *
+GDALAttributeReadAsInt64Array(GDALAttributeH hAttr,
+                              size_t *pnCount) CPL_WARN_UNUSED_RESULT;
 double CPL_DLL *
 GDALAttributeReadAsDoubleArray(GDALAttributeH hAttr,
                                size_t *pnCount) CPL_WARN_UNUSED_RESULT;
@@ -2531,9 +2531,9 @@ int CPL_DLL GDALAttributeWriteStringArray(GDALAttributeH hAttr, CSLConstList);
 int CPL_DLL GDALAttributeWriteInt(GDALAttributeH hAttr, int);
 int CPL_DLL GDALAttributeWriteIntArray(GDALAttributeH hAttr, const int *,
                                        size_t);
-int CPL_DLL GDALAttributeWriteLong(GDALAttributeH hAttr, int);
-int CPL_DLL GDALAttributeWriteLongArray(GDALAttributeH hAttr, const GInt64 *,
-                                        size_t);
+int CPL_DLL GDALAttributeWriteInt64(GDALAttributeH hAttr, int);
+int CPL_DLL GDALAttributeWriteInt64Array(GDALAttributeH hAttr, const int64_t *,
+                                         size_t);
 int CPL_DLL GDALAttributeWriteDouble(GDALAttributeH hAttr, double);
 int CPL_DLL GDALAttributeWriteDoubleArray(GDALAttributeH hAttr, const double *,
                                           size_t);

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -2531,7 +2531,7 @@ int CPL_DLL GDALAttributeWriteStringArray(GDALAttributeH hAttr, CSLConstList);
 int CPL_DLL GDALAttributeWriteInt(GDALAttributeH hAttr, int);
 int CPL_DLL GDALAttributeWriteIntArray(GDALAttributeH hAttr, const int *,
                                        size_t);
-int CPL_DLL GDALAttributeWriteInt64(GDALAttributeH hAttr, int);
+int CPL_DLL GDALAttributeWriteInt64(GDALAttributeH hAttr, int64_t);
 int CPL_DLL GDALAttributeWriteInt64Array(GDALAttributeH hAttr, const int64_t *,
                                          size_t);
 int CPL_DLL GDALAttributeWriteDouble(GDALAttributeH hAttr, double);

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -3235,22 +3235,22 @@ class CPL_DLL GDALAttribute : virtual public GDALAbstractMDArray
     GDALRawResult ReadAsRaw() const;
     const char *ReadAsString() const;
     int ReadAsInt() const;
-    GInt64 ReadAsLong() const;
+    int64_t ReadAsInt64() const;
     double ReadAsDouble() const;
     CPLStringList ReadAsStringArray() const;
     std::vector<int> ReadAsIntArray() const;
-    std::vector<GInt64> ReadAsLongArray() const;
+    std::vector<int64_t> ReadAsInt64Array() const;
     std::vector<double> ReadAsDoubleArray() const;
 
     using GDALAbstractMDArray::Write;
     bool Write(const void *pabyValue, size_t nLen);
     bool Write(const char *);
     bool WriteInt(int);
-    bool WriteLong(GInt64);
+    bool WriteInt64(int64_t);
     bool Write(double);
     bool Write(CSLConstList);
     bool Write(const int *, size_t);
-    bool Write(const GInt64 *, size_t);
+    bool Write(const int64_t *, size_t);
     bool Write(const double *, size_t);
 
     //! @cond Doxygen_Suppress

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -3311,8 +3311,6 @@ class CPL_DLL GDALAttributeNumeric final : public GDALAttribute
     GDALAttributeNumeric(const std::string &osParentName,
                          const std::string &osName, int nValue);
     GDALAttributeNumeric(const std::string &osParentName,
-                         const std::string &osName, GInt64 nValue);
-    GDALAttributeNumeric(const std::string &osParentName,
                          const std::string &osName,
                          const std::vector<GUInt32> &anValues);
 

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -2272,6 +2272,7 @@ class CPL_DLL GDALDriver : public GDALMajorObject
  * @since 3.9
  */
 // clang-format on
+
 class GDALPluginDriverProxy : public GDALDriver
 {
     const std::string m_osPluginFileName;
@@ -3234,17 +3235,22 @@ class CPL_DLL GDALAttribute : virtual public GDALAbstractMDArray
     GDALRawResult ReadAsRaw() const;
     const char *ReadAsString() const;
     int ReadAsInt() const;
+    GInt64 ReadAsLong() const;
     double ReadAsDouble() const;
     CPLStringList ReadAsStringArray() const;
     std::vector<int> ReadAsIntArray() const;
+    std::vector<GInt64> ReadAsLongArray() const;
     std::vector<double> ReadAsDoubleArray() const;
 
     using GDALAbstractMDArray::Write;
     bool Write(const void *pabyValue, size_t nLen);
     bool Write(const char *);
     bool WriteInt(int);
+    bool WriteLong(GInt64);
     bool Write(double);
     bool Write(CSLConstList);
+    bool Write(const int *, size_t);
+    bool Write(const GInt64 *, size_t);
     bool Write(const double *, size_t);
 
     //! @cond Doxygen_Suppress
@@ -3304,6 +3310,8 @@ class CPL_DLL GDALAttributeNumeric final : public GDALAttribute
                          const std::string &osName, double dfValue);
     GDALAttributeNumeric(const std::string &osParentName,
                          const std::string &osName, int nValue);
+    GDALAttributeNumeric(const std::string &osParentName,
+                         const std::string &osName, GInt64 nValue);
     GDALAttributeNumeric(const std::string &osParentName,
                          const std::string &osName,
                          const std::vector<GUInt32> &anValues);

--- a/gcore/gdalmultidim.cpp
+++ b/gcore/gdalmultidim.cpp
@@ -3366,7 +3366,7 @@ int GDALAttribute::ReadAsInt() const
  *
  * @return an int64_t, or INT64_MIN in case of error.
  */
-GInt64 GDALAttribute::ReadAsInt64() const
+int64_t GDALAttribute::ReadAsInt64() const
 {
     const auto nDims = GetDimensionCount();
     std::vector<GUInt64> startIdx(1 + nDims, 0);
@@ -12896,7 +12896,7 @@ int GDALAttributeReadAsInt(GDALAttributeH hAttr)
  *
  * @return an int64_t, or INT64_MIN in case of error.
  */
-GInt64 GDALAttributeReadAsInt64(GDALAttributeH hAttr)
+int64_t GDALAttributeReadAsInt64(GDALAttributeH hAttr)
 {
     VALIDATE_POINTER1(hAttr, __func__, 0);
     return hAttr->m_poImpl->ReadAsInt64();

--- a/gcore/gdalmultidim.cpp
+++ b/gcore/gdalmultidim.cpp
@@ -3335,7 +3335,7 @@ const char *GDALAttribute::ReadAsString() const
  *
  * This function will only return the first element if there are several.
  *
- * It can fail if its value can be not converted to integer.
+ * It can fail if its value can not be converted to integer.
  *
  * This is the same as the C function GDALAttributeReadAsInt()
  *
@@ -3360,9 +3360,9 @@ int GDALAttribute::ReadAsInt() const
  *
  * This function will only return the first element if there are several.
  *
- * It can fail if its value can be not converted to long.
+ * It can fail if its value can not be converted to long.
  *
- * This is the same as the C function GDALAttributeReadAsLong()
+ * This is the same as the C function GDALAttributeReadAsInt64()
  *
  * @return an int64_t, or INT64_MIN in case of error.
  */
@@ -3385,7 +3385,7 @@ GInt64 GDALAttribute::ReadAsInt64() const
  *
  * This function will only return the first element if there are several.
  *
- * It can fail if its value can be not converted to double.
+ * It can fail if its value can not be converted to double.
  *
  * This is the same as the C function GDALAttributeReadAsInt()
  *
@@ -12870,7 +12870,7 @@ const char *GDALAttributeReadAsString(GDALAttributeH hAttr)
  *
  * This function will only return the first element if there are several.
  *
- * It can fail if its value can be not converted to integer.
+ * It can fail if its value can not be converted to integer.
  *
  * This is the same as the C++ method GDALAttribute::ReadAsInt()
  *
@@ -12890,13 +12890,13 @@ int GDALAttributeReadAsInt(GDALAttributeH hAttr)
  *
  * This function will only return the first element if there are several.
  *
- * It can fail if its value can be not converted to integer.
+ * It can fail if its value can not be converted to integer.
  *
  * This is the same as the C++ method GDALAttribute::ReadAsInt64()
  *
  * @return an int64_t, or INT64_MIN in case of error.
  */
-GInt64 GDALAttributeReadAsLong(GDALAttributeH hAttr)
+GInt64 GDALAttributeReadAsInt64(GDALAttributeH hAttr)
 {
     VALIDATE_POINTER1(hAttr, __func__, 0);
     return hAttr->m_poImpl->ReadAsInt64();

--- a/gcore/gdalmultidim.cpp
+++ b/gcore/gdalmultidim.cpp
@@ -3353,10 +3353,10 @@ int GDALAttribute::ReadAsInt() const
 }
 
 /************************************************************************/
-/*                            ReadAsLong()                              */
+/*                            ReadAsInt64()                             */
 /************************************************************************/
 
-/** Return the value of an attribute as a long.
+/** Return the value of an attribute as an int64_t.
  *
  * This function will only return the first element if there are several.
  *
@@ -3364,14 +3364,14 @@ int GDALAttribute::ReadAsInt() const
  *
  * This is the same as the C function GDALAttributeReadAsLong()
  *
- * @return a GInt64, or std::numeric_limits<GInt64>::min() in case of error.
+ * @return an int64_t, or INT64_MIN in case of error.
  */
-GInt64 GDALAttribute::ReadAsLong() const
+GInt64 GDALAttribute::ReadAsInt64() const
 {
     const auto nDims = GetDimensionCount();
     std::vector<GUInt64> startIdx(1 + nDims, 0);
     std::vector<size_t> count(1 + nDims, 1);
-    GInt64 nRet = std::numeric_limits<GInt64>::min();
+    int64_t nRet = INT64_MIN;
     Read(startIdx.data(), count.data(), nullptr, nullptr,
          GDALExtendedDataType::Create(GDT_Int64), &nRet, &nRet, sizeof(nRet));
     return nRet;
@@ -3468,21 +3468,21 @@ std::vector<int> GDALAttribute::ReadAsIntArray() const
 }
 
 /************************************************************************/
-/*                          ReadAsLongArray()                           */
+/*                          ReadAsInt64Array()                          */
 /************************************************************************/
 
-/** Return the value of an attribute as an array of GInt64.
+/** Return the value of an attribute as an array of int64_t.
  *
- * This is the same as the C function GDALAttributeReadAsLongArray().
+ * This is the same as the C function GDALAttributeReadAsInt64Array().
  */
-std::vector<GInt64> GDALAttribute::ReadAsLongArray() const
+std::vector<int64_t> GDALAttribute::ReadAsInt64Array() const
 {
     const auto nElts = GetTotalElementsCount();
 #if SIZEOF_VOIDP == 4
     if (nElts > static_cast<size_t>(nElts))
         return {};
 #endif
-    std::vector<GInt64> res(static_cast<size_t>(nElts));
+    std::vector<int64_t> res(static_cast<size_t>(nElts));
     const auto &dims = GetDimensions();
     const auto nDims = GetDimensionCount();
     std::vector<GUInt64> startIdx(1 + nDims, 0);
@@ -3613,10 +3613,10 @@ bool GDALAttribute::WriteInt(int nVal)
 }
 
 /************************************************************************/
-/*                              WriteLong()                             */
+/*                              WriteInt64()                             */
 /************************************************************************/
 
-/** Write an attribute from a GInt64 value.
+/** Write an attribute from an int64_t value.
  *
  * Type conversion will be performed if needed. If the attribute contains
  * multiple values, only the first one will be updated.
@@ -3626,7 +3626,7 @@ bool GDALAttribute::WriteInt(int nVal)
  * @param nVal Value.
  * @return true in case of success.
  */
-bool GDALAttribute::WriteLong(GInt64 nVal)
+bool GDALAttribute::WriteInt64(int64_t nVal)
 {
     const auto nDims = GetDimensionCount();
     std::vector<GUInt64> startIdx(1 + nDims, 0);
@@ -3731,7 +3731,7 @@ bool GDALAttribute::Write(const int *vals, size_t nVals)
 /*                                Write()                               */
 /************************************************************************/
 
-/** Write an attribute from an array of GInt64.
+/** Write an attribute from an array of int64_t.
  *
  * Type conversion will be performed if needed.
  *
@@ -3739,11 +3739,11 @@ bool GDALAttribute::Write(const int *vals, size_t nVals)
  *
  * This is the same as the C function GDALAttributeWriteLongArray()
  *
- * @param vals Array of GInt64.
+ * @param vals Array of int64_t.
  * @param nVals Should be equal to GetTotalElementsCount().
  * @return true in case of success.
  */
-bool GDALAttribute::Write(const GInt64 *vals, size_t nVals)
+bool GDALAttribute::Write(const int64_t *vals, size_t nVals)
 {
     if (nVals != GetTotalElementsCount())
     {
@@ -3758,7 +3758,8 @@ bool GDALAttribute::Write(const GInt64 *vals, size_t nVals)
         count[i] = static_cast<size_t>(dims[i]->GetSize());
     return Write(startIdx.data(), count.data(), nullptr, nullptr,
                  GDALExtendedDataType::Create(GDT_Int64), vals, vals,
-                 static_cast<size_t>(GetTotalElementsCount()) * sizeof(GInt64));
+                 static_cast<size_t>(GetTotalElementsCount()) *
+                     sizeof(int64_t));
 }
 
 /************************************************************************/
@@ -12882,23 +12883,23 @@ int GDALAttributeReadAsInt(GDALAttributeH hAttr)
 }
 
 /************************************************************************/
-/*                      GDALAttributeReadAsLong()                       */
+/*                      GDALAttributeReadAsInt64()                      */
 /************************************************************************/
 
-/** Return the value of an attribute as a GInt64.
+/** Return the value of an attribute as a int64_t.
  *
  * This function will only return the first element if there are several.
  *
  * It can fail if its value can be not converted to integer.
  *
- * This is the same as the C++ method GDALAttribute::ReadAsInt()
+ * This is the same as the C++ method GDALAttribute::ReadAsInt64()
  *
- * @return a GIn64, or std::numeric_limits<GInt64>::min() in case of error.
+ * @return an int64_t, or INT64_MIN in case of error.
  */
 GInt64 GDALAttributeReadAsLong(GDALAttributeH hAttr)
 {
     VALIDATE_POINTER1(hAttr, __func__, 0);
-    return hAttr->m_poImpl->ReadAsLong();
+    return hAttr->m_poImpl->ReadAsInt64();
 }
 
 /************************************************************************/
@@ -12966,18 +12967,18 @@ int *GDALAttributeReadAsIntArray(GDALAttributeH hAttr, size_t *pnCount)
 }
 
 /************************************************************************/
-/*                     GDALAttributeReadAsLong()                    */
+/*                     GDALAttributeReadAsInt64Array()                  */
 /************************************************************************/
 
-/** Return the value of an attribute as an array of GInt64.
+/** Return the value of an attribute as an array of int64_t.
  *
- * This is the same as the C++ method GDALAttribute::ReadAsLongArray()
+ * This is the same as the C++ method GDALAttribute::ReadAsInt64Array()
  *
  * @param hAttr Attribute
  * @param pnCount Pointer to the number of values returned. Must NOT be NULL.
  * @return array to be freed with CPLFree(), or nullptr.
  */
-GInt64 *GDALAttributeReadAsLongArray(GDALAttributeH hAttr, size_t *pnCount)
+int64_t *GDALAttributeReadAsInt64Array(GDALAttributeH hAttr, size_t *pnCount)
 {
     VALIDATE_POINTER1(hAttr, __func__, nullptr);
     VALIDATE_POINTER1(pnCount, __func__, nullptr);
@@ -12985,11 +12986,11 @@ GInt64 *GDALAttributeReadAsLongArray(GDALAttributeH hAttr, size_t *pnCount)
     auto tmp(hAttr->m_poImpl->ReadAsIntArray());
     if (tmp.empty())
         return nullptr;
-    auto ret =
-        static_cast<GInt64 *>(VSI_MALLOC2_VERBOSE(tmp.size(), sizeof(GInt64)));
+    auto ret = static_cast<int64_t *>(
+        VSI_MALLOC2_VERBOSE(tmp.size(), sizeof(int64_t)));
     if (!ret)
         return nullptr;
-    memcpy(ret, tmp.data(), tmp.size() * sizeof(GInt64));
+    memcpy(ret, tmp.data(), tmp.size() * sizeof(int64_t));
     *pnCount = tmp.size();
     return ret;
 }
@@ -13091,10 +13092,10 @@ int GDALAttributeWriteInt(GDALAttributeH hAttr, int nVal)
 }
 
 /************************************************************************/
-/*                        GDALAttributeWriteLong()                       */
+/*                        GDALAttributeWriteInt64()                     */
 /************************************************************************/
 
-/** Write an attribute from a long value.
+/** Write an attribute from an int64_t value.
  *
  * Type conversion will be performed if needed. If the attribute contains
  * multiple values, only the first one will be updated.
@@ -13105,10 +13106,10 @@ int GDALAttributeWriteInt(GDALAttributeH hAttr, int nVal)
  * @param nVal Value.
  * @return TRUE in case of success.
  */
-int GDALAttributeWriteLong(GDALAttributeH hAttr, GInt64 nVal)
+int GDALAttributeWriteInt64(GDALAttributeH hAttr, int64_t nVal)
 {
     VALIDATE_POINTER1(hAttr, __func__, FALSE);
-    return hAttr->m_poImpl->WriteLong(nVal);
+    return hAttr->m_poImpl->WriteInt64(nVal);
 }
 
 /************************************************************************/
@@ -13182,25 +13183,25 @@ int GDALAttributeWriteIntArray(GDALAttributeH hAttr, const int *panValues,
 }
 
 /************************************************************************/
-/*                       GDALAttributeWriteLongArray()                */
+/*                       GDALAttributeWriteInt64Array()                 */
 /************************************************************************/
 
-/** Write an attribute from an array of GInt64.
+/** Write an attribute from an array of int64_t.
  *
  * Type conversion will be performed if needed.
  *
  * Exactly GetTotalElementsCount() strings must be provided
  *
- * This is the same as the C++ method GDALAttribute::Write(const GInt4 *,
+ * This is the same as the C++ method GDALAttribute::Write(const int64_t *,
  * size_t)
  *
  * @param hAttr Attribute
- * @param panValues Array of GInt64.
+ * @param panValues Array of int64_t.
  * @param nCount Should be equal to GetTotalElementsCount().
  * @return TRUE in case of success.
  */
-int GDALAttributeWriteLongArray(GDALAttributeH hAttr, const GInt64 *panValues,
-                                size_t nCount)
+int GDALAttributeWriteInt64Array(GDALAttributeH hAttr, const int64_t *panValues,
+                                 size_t nCount)
 {
     VALIDATE_POINTER1(hAttr, __func__, FALSE);
     return hAttr->m_poImpl->Write(panValues, nCount);

--- a/gcore/gdalmultidim.cpp
+++ b/gcore/gdalmultidim.cpp
@@ -13632,8 +13632,8 @@ GDALMDArrayRegularlySpaced::GDALMDArrayRegularlySpaced(
     double dfIncrement, double dfOffsetInIncrement)
     : GDALAbstractMDArray(osParentName, osName),
       GDALMDArray(osParentName, osName), m_dfStart(dfStart),
-      m_dfIncrement(dfIncrement), m_dfOffsetInIncrement(dfOffsetInIncrement),
-      m_dims{poDim}
+      m_dfIncrement(dfIncrement),
+      m_dfOffsetInIncrement(dfOffsetInIncrement), m_dims{poDim}
 {
 }
 

--- a/gcore/gdalmultidim.cpp
+++ b/gcore/gdalmultidim.cpp
@@ -12983,7 +12983,7 @@ int64_t *GDALAttributeReadAsInt64Array(GDALAttributeH hAttr, size_t *pnCount)
     VALIDATE_POINTER1(hAttr, __func__, nullptr);
     VALIDATE_POINTER1(pnCount, __func__, nullptr);
     *pnCount = 0;
-    auto tmp(hAttr->m_poImpl->ReadAsIntArray());
+    auto tmp(hAttr->m_poImpl->ReadAsInt64Array());
     if (tmp.empty())
         return nullptr;
     auto ret = static_cast<int64_t *>(

--- a/swig/include/MultiDimensional.i
+++ b/swig/include/MultiDimensional.i
@@ -1272,7 +1272,7 @@ public:
     return GDALAttributeReadAsInt(self);
   }
 
-  int64_t ReadAsInt64() {
+  long long ReadAsInt64() {
     return GDALAttributeReadAsInt64(self);
   }
 
@@ -1293,8 +1293,8 @@ public:
 #endif
 
 #if defined(SWIGPYTHON)
-  void ReadAsInt64Array( int64_t** pvals, size_t* pnCount ) {
-    *pvals = GDALAttributeReadAsInt64Array(self, pnCount);
+  void ReadAsInt64Array( long long** pvals, size_t* pnCount ) {
+    *pvals = (long long*)GDALAttributeReadAsInt64Array(self, pnCount);
   }
 #endif
 
@@ -1355,9 +1355,9 @@ public:
 #endif
 
 #if defined(SWIGPYTHON)
-  CPLErr WriteInt64Array(int nList, int64_t* pList)
+  CPLErr WriteInt64Array(int nList, long long* pList)
   {
-    return GDALAttributeWriteInt64Array(self, pList, nList) ? CE_None : CE_Failure;
+    return GDALAttributeWriteInt64Array(self, (int64_t*)pList, nList) ? CE_None : CE_Failure;
   }
 #endif
 

--- a/swig/include/MultiDimensional.i
+++ b/swig/include/MultiDimensional.i
@@ -1272,6 +1272,10 @@ public:
     return GDALAttributeReadAsInt(self);
   }
 
+  int64_t ReadAsInt64() {
+    return GDALAttributeReadAsInt64(self);
+  }
+
   double ReadAsDouble() {
     return GDALAttributeReadAsDouble(self);
   }
@@ -1285,6 +1289,12 @@ public:
 #if defined(SWIGPYTHON)
   void ReadAsIntArray( int** pvals, size_t* pnCount ) {
     *pvals = GDALAttributeReadAsIntArray(self, pnCount);
+  }
+#endif
+
+#if defined(SWIGPYTHON)
+  void ReadAsInt64Array( int64_t** pvals, size_t* pnCount ) {
+    *pvals = GDALAttributeReadAsInt64Array(self, pnCount);
   }
 #endif
 
@@ -1327,10 +1337,29 @@ public:
     return GDALAttributeWriteInt(self, val) ? CE_None : CE_Failure;
   }
 
+  CPLErr WriteInt64(long long val)
+  {
+    return GDALAttributeWriteInt64(self, val) ? CE_None : CE_Failure;
+  }
+
   CPLErr WriteDouble(double val)
   {
     return GDALAttributeWriteDouble(self, val) ? CE_None : CE_Failure;
   }
+
+#if defined(SWIGPYTHON)
+  CPLErr WriteIntArray(int nList, int* pList)
+  {
+    return GDALAttributeWriteIntArray(self, pList, nList) ? CE_None : CE_Failure;
+  }
+#endif
+
+#if defined(SWIGPYTHON)
+  CPLErr WriteInt64Array(int nList, int64_t* pList)
+  {
+    return GDALAttributeWriteInt64Array(self, pList, nList) ? CE_None : CE_Failure;
+  }
+#endif
 
 #if defined(SWIGPYTHON)
   CPLErr WriteDoubleArray(int nList, double* pList)

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -2037,7 +2037,7 @@ def GetMDArrayNames(self, options = []) -> "list[str]":
             if self.GetTotalElementsCount() == 1:
                 return self.ReadAsInt()
             return self.ReadAsIntArray()
-        if dt.GetNumericDataType() in (GDT_UInt32, GDT_UInt64, GDT_Int64):
+        if dt.GetNumericDataType() in (GDT_UInt32, GDT_Int64):
             if self.GetTotalElementsCount() == 1:
                 return self.ReadAsInt64()
             return self.ReadAsInt64Array()

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -2016,10 +2016,6 @@ def GetMDArrayNames(self, options = []) -> "list[str]":
 %extend GDALAttributeHS {
 %pythoncode %{
 
-  def writetofile(self, msg):
-    with open("/tmp/gdal.log", "a") as f:
-        f.write(msg)
-
   def Read(self):
     """ Read an attribute and return it with the most appropriate type """
     dt = self.GetDataType()
@@ -2036,73 +2032,51 @@ def GetMDArrayNames(self, options = []) -> "list[str]":
             return s
         return self.ReadAsStringArray()
     if dt_class == GEDTC_NUMERIC:
-        self.writetofile("Read: dt_class == GEDTC_NUMERIC\n")
         if dt.GetNumericDataType() in (GDT_Byte, GDT_UInt16,
                                        GDT_Int8, GDT_Int16, GDT_Int32):
-            self.writetofile("Int\n")
             if self.GetTotalElementsCount() == 1:
                 return self.ReadAsInt()
             return self.ReadAsIntArray()
         if dt.GetNumericDataType() in (GDT_UInt32, GDT_UInt64, GDT_Int64):
-            self.writetofile("Int64\n")
             if self.GetTotalElementsCount() == 1:
                 return self.ReadAsInt64()
             return self.ReadAsInt64Array()
-        self.writetofile("Double\n")
         if self.GetTotalElementsCount() == 1:
             return self.ReadAsDouble()
         return self.ReadAsDoubleArray()
     return self.ReadAsRaw()
 
   def Write(self, val):
-    self.writetofile("Write: val=[" + str(val) + "]\n")
     if isinstance(val, (int, type(12345678901234))):
-        self.writetofile("Write:\n")
         if val >= -0x80000000 and val <= 0x7FFFFFFF:
-            self.writetofile("Int\n")
             return self.WriteInt(val)
         if val >= -0x8000000000000000 and val <= 0x7FFFFFFFFFFFFFFF:
-            self.writetofile("Int64\n")
             return self.WriteInt64(val)
-        self.writetofile("BigInt\n")
         return self.WriteDouble(val)
     if isinstance(val, float):
-        self.writetofile("Double\n")
         return self.WriteDouble(val)
     if isinstance(val, str) and self.GetDataType().GetClass() != GEDTC_COMPOUND:
-        self.writetofile("String [" + val + "]\n")
         return self.WriteString(val)
     if isinstance(val, list):
-        self.writetofile("List\n")
         if len(val) == 0:
             if self.GetDataType().GetClass() == GEDTC_STRING:
-                self.writetofile("List-String-Empty\n")
                 return self.WriteStringArray(val)
-            self.writetofile("List-Double-Empty\n")
             return self.WriteDoubleArray(val)
         if isinstance(val[0], (int, type(12345678901234))):
             if all(v >= -0x80000000 and v <= 0x7FFFFFFF for v in val):
-                self.writetofile("List-Int\n")
                 return self.WriteIntArray(val)
             if all(v >= -0x8000000000000000 and v <= 0x7FFFFFFFFFFFFFFF
                    for v in val):
-                self.writetofile("List-Int64\n")
                 return self.WriteInt64Array(val)
-            self.writetofile("List-Double-fallback\n")
             return self.WriteDoubleArray(val)
         if isinstance(val[0], float):
-            self.writetofile("List-Double\n")
             return self.WriteDoubleArray(val)
         if isinstance(val[0], str):
-            self.writetofile("StringArray\n")
             return self.WriteStringArray(val)
-        self.writetofile("List-Fallback\n")
     if (isinstance(val, dict) and
         self.GetDataType().GetSubType() == GEDTST_JSON):
-        self.writetofile("Dict-JSON\n")
         import json
         return self.WriteString(json.dumps(val))
-    self.writetofile("Raw\n")
     return self.WriteRaw(val)
 
 %}

--- a/swig/include/python/typemaps_python.i
+++ b/swig/include/python/typemaps_python.i
@@ -249,62 +249,6 @@ CreateTupleFromIntArray( const int *first, size_t size ) {
 }
 %}
 
-%typemap(in,numinputs=0) ( int argout[ANY]) (int argout[$dim0])
-{
-  /* %typemap(in,numinputs=0) (int argout[ANY]) */
-  memset(argout, 0, sizeof(argout));
-  $1 = argout;
-}
-%typemap(argout,fragment="t_output_helper,CreateTupleFromIntArray") ( int argout[ANY])
-{
-  /* %typemap(argout) (int argout[ANY]) */
-  PyObject *out = CreateTupleFromIntArray( $1, $dim0 );
-  $result = t_output_helper($result,out);
-}
-
-%typemap(in,numinputs=0) ( int *argout[ANY]) (int *argout)
-{
-  /* %typemap(in,numinputs=0) (int *argout[ANY]) */
-  argout = NULL;
-  $1 = &argout;
-}
-%typemap(argout,fragment="t_output_helper,CreateTupleFromIntArray") ( int *argout[ANY])
-{
-  /* %typemap(argout) (int *argout[ANY]) */
-  PyObject *out = CreateTupleFromIntArray( *$1, $dim0 );
-  $result = t_output_helper($result,out);
-}
-%typemap(freearg) (int *argout[ANY])
-{
-  /* %typemap(freearg) (int *argout[ANY]) */
-  CPLFree(*$1);
-}
-%typemap(in) (int argin[ANY]) (int argin[$dim0])
-{
-  /* %typemap(in) (int argin[ANY]) */
-  $1 = argin;
-  if (! PySequence_Check($input) ) {
-    PyErr_SetString(PyExc_TypeError, "not a sequence");
-    SWIG_fail;
-  }
-  Py_ssize_t seq_size = PySequence_Size($input);
-  if ( seq_size != $dim0 ) {
-    PyErr_SetString(PyExc_TypeError, "sequence must have length ##size");
-    SWIG_fail;
-  }
-  for (unsigned int i=0; i<$dim0; i++) {
-    PyObject *o = PySequence_GetItem($input,i);
-    int val;
-    if ( !PyArg_Parse(o, "i", &val ) ) {
-      PyErr_SetString(PyExc_TypeError, "not a number");
-      Py_DECREF(o);
-      SWIG_fail;
-    }
-    $1[i] =  val;
-    Py_DECREF(o);
-  }
-}
-
 %fragment("CreateTupleFromInt64Array","header") %{
 static PyObject *
 CreateTupleFromInt64Array( const long long *first, size_t size ) {
@@ -317,62 +261,6 @@ CreateTupleFromInt64Array( const long long *first, size_t size ) {
   return out;
 }
 %}
-
-%typemap(in,numinputs=0) ( long long argout[ANY]) (long long argout[$dim0])
-{
-  /* %typemap(in,numinputs=0) (long long argout[ANY]) */
-  memset(argout, 0, sizeof(argout));
-  $1 = argout;
-}
-%typemap(argout,fragment="t_output_helper,CreateTupleFromInt64Array") ( long long argout[ANY])
-{
-  /* %typemap(argout) (long long argout[ANY]) */
-  PyObject *out = CreateTupleFromInt64Array( $1, $dim0 );
-  $result = t_output_helper($result,out);
-}
-
-%typemap(in,numinputs=0) ( long long *argout[ANY]) (long long *argout)
-{
-  /* %typemap(in,numinputs=0) (long long *argout[ANY]) */
-  argout = NULL;
-  $1 = &argout;
-}
-%typemap(argout,fragment="t_output_helper,CreateTupleFromInt64Array") ( long long *argout[ANY])
-{
-  /* %typemap(argout) (long long *argout[ANY]) */
-  PyObject *out = CreateTupleFromInt64Array( *$1, $dim0 );
-  $result = t_output_helper($result,out);
-}
-%typemap(freearg) (long long *argout[ANY])
-{
-  /* %typemap(freearg) (long long *argout[ANY]) */
-  CPLFree(*$1);
-}
-%typemap(in) (long long argin[ANY]) (long long argin[$dim0])
-{
-  /* %typemap(in) (long long argin[ANY]) */
-  $1 = argin;
-  if (! PySequence_Check($input) ) {
-    PyErr_SetString(PyExc_TypeError, "not a sequence");
-    SWIG_fail;
-  }
-  Py_ssize_t seq_size = PySequence_Size($input);
-  if ( seq_size != $dim0 ) {
-    PyErr_SetString(PyExc_TypeError, "sequence must have length ##size");
-    SWIG_fail;
-  }
-  for (unsigned int i=0; i<$dim0; i++) {
-    PyObject *o = PySequence_GetItem($input,i);
-    long long val;
-    if ( !PyArg_Parse(o, "L", &val ) ) {
-      PyErr_SetString(PyExc_TypeError, "not a number");
-      Py_DECREF(o);
-      SWIG_fail;
-    }
-    $1[i] =  val;
-    Py_DECREF(o);
-  }
-}
 
 %fragment("CreateTupleFromDoubleArray","header") %{
 static PyObject *

--- a/swig/include/python/typemaps_python.i
+++ b/swig/include/python/typemaps_python.i
@@ -518,7 +518,7 @@ CreateCInt64ListFromSequence( PyObject* pySeq, int* pnSize ) {
     *pnSize = -1;
     return NULL;
   }
-  if( (size_t)size > SIZE_MAX / sizeof(int) ) {
+  if( (size_t)size > SIZE_MAX / sizeof(long long) ) {
     PyErr_SetString(PyExc_RuntimeError, "too big sequence");
     *pnSize = -1;
     return NULL;


### PR DESCRIPTION
## What does this PR do?

The Zarr file format stores attributes in JSON. This PR stores int64 values as integer JSON values instead of converting them to floating-point values.

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/issues/10062

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [x] Add documentation
 - [x] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
