### PR TITLE
MIraMonVector: fixing MMResetFeatureRecord

### DIFF
--- a/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
+++ b/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
@@ -3657,7 +3657,9 @@ void MMResetFeatureRecord(struct MiraMonFeature *hMMFeature)
                     '\0';
             hMMFeature->pRecords[nIRecord].pField[nIField].bIsValid = 0;
         }
+        hMMFeature->pRecords[nIRecord].nNumField = 0;
     }
+    hMMFeature->nNumMRecords = 0;
 }
 
 // Destroys all allocated memory


### PR DESCRIPTION
## What does this PR do?
Ensures that MMResetFeatureRecord() resets the structure correctly by assigning 0 to number of fields and number of records.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] All CI builds and checks have passed

