### PR TITLE
Fix issue related to wrapping a netCDF dataset accrong antimeridian

### DIFF
--- a/alg/gdaltransformer.cpp
+++ b/alg/gdaltransformer.cpp
@@ -1482,7 +1482,12 @@ static void InsertCenterLong(GDALDatasetH hDS, OGRSpatialReference *poSRS,
                           adfGeoTransform[0] + nXSize * adfGeoTransform[1] +
                               nYSize * adfGeoTransform[2]));
 
-    if (dfMaxLong - dfMinLong > 360.0)
+    const double dfEpsilon =
+        std::max(std::fabs(adfGeoTransform[1]), std::fabs(adfGeoTransform[2]));
+    // If the raster covers more than 360 degree (allow an extra pixel),
+    // give up
+    constexpr double RELATIVE_EPSILON = 0.05;  // for numeric precision issues
+    if (dfMaxLong - dfMinLong > 360.0 + dfEpsilon * (1 + RELATIVE_EPSILON))
         return;
 
     /* -------------------------------------------------------------------- */

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -1359,18 +1359,8 @@ def test_netcdf_36():
 
     gt = ds.GetGeoTransform()
     assert gt is not None, "got no GeoTransform"
-    gt_expected = (
-        -3.498749944898817,
-        0.0025000042385525173,
-        0.0,
-        46.61749818589952,
-        0.0,
-        -0.001666598849826389,
-    )
-    assert gt == gt_expected, "got GeoTransform %s, expected %s" % (
-        str(gt),
-        str(gt_expected),
-    )
+    gt_expected = (-3.49875, 0.0025, 0.0, 46.61749818589952, 0.0, -0.001666598849826389)
+    assert gt == pytest.approx(gt_expected, rel=1e-8)
 
 
 ###############################################################################

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -4186,3 +4186,23 @@ def test_target_extent_consistent_size():
 
     assert ds.RasterXSize == 4793
     assert ds.RasterYSize == 4143
+
+
+###############################################################################
+# Test warping an image with [-180,180] longitude to [180 - X, 180 + X]
+
+
+def test_gdalwarp_lib_minus_180_plus_180_to_span_over_180(tmp_vsimem):
+
+    dst_filename = str(tmp_vsimem / "out.tif")
+    src_ds = gdal.Open("../gdrivers/data/small_world.tif")
+    out_ds = gdal.Warp(dst_filename, src_ds, outputBounds=[0, -90, 360, 90])
+    # Check that east/west hemispheres have been switched
+    assert out_ds.ReadRaster(
+        0, 0, src_ds.RasterXSize // 2, src_ds.RasterYSize
+    ) == src_ds.ReadRaster(
+        src_ds.RasterXSize // 2, 0, src_ds.RasterXSize // 2, src_ds.RasterYSize
+    )
+    assert out_ds.ReadRaster(
+        src_ds.RasterXSize // 2, 0, src_ds.RasterXSize // 2, src_ds.RasterYSize
+    ) == src_ds.ReadRaster(0, 0, src_ds.RasterXSize // 2, src_ds.RasterYSize)

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -4192,17 +4192,41 @@ def test_target_extent_consistent_size():
 # Test warping an image with [-180,180] longitude to [180 - X, 180 + X]
 
 
-def test_gdalwarp_lib_minus_180_plus_180_to_span_over_180(tmp_vsimem):
+@pytest.mark.parametrize("extra_column", [False, True])
+def test_gdalwarp_lib_minus_180_plus_180_to_span_over_180(tmp_vsimem, extra_column):
 
     dst_filename = str(tmp_vsimem / "out.tif")
     src_ds = gdal.Open("../gdrivers/data/small_world.tif")
+    if extra_column:
+        tmp_ds = gdal.GetDriverByName("MEM").Create(
+            "", src_ds.RasterXSize + 1, src_ds.RasterYSize
+        )
+        tmp_ds.SetGeoTransform(src_ds.GetGeoTransform())
+        tmp_ds.SetSpatialRef(src_ds.GetSpatialRef())
+        tmp_ds.WriteRaster(
+            0,
+            0,
+            src_ds.RasterXSize,
+            src_ds.RasterYSize,
+            src_ds.GetRasterBand(1).ReadRaster(),
+        )
+        tmp_ds.WriteRaster(
+            src_ds.RasterXSize,
+            0,
+            1,
+            src_ds.RasterYSize,
+            src_ds.GetRasterBand(1).ReadRaster(0, 0, 1, src_ds.RasterYSize),
+        )
+        src_ds = tmp_ds
     out_ds = gdal.Warp(dst_filename, src_ds, outputBounds=[0, -90, 360, 90])
     # Check that east/west hemispheres have been switched
-    assert out_ds.ReadRaster(
+    assert out_ds.GetRasterBand(1).ReadRaster(
         0, 0, src_ds.RasterXSize // 2, src_ds.RasterYSize
-    ) == src_ds.ReadRaster(
+    ) == src_ds.GetRasterBand(1).ReadRaster(
         src_ds.RasterXSize // 2, 0, src_ds.RasterXSize // 2, src_ds.RasterYSize
     )
-    assert out_ds.ReadRaster(
+    assert out_ds.GetRasterBand(1).ReadRaster(
         src_ds.RasterXSize // 2, 0, src_ds.RasterXSize // 2, src_ds.RasterYSize
-    ) == src_ds.ReadRaster(0, 0, src_ds.RasterXSize // 2, src_ds.RasterYSize)
+    ) == src_ds.GetRasterBand(1).ReadRaster(
+        0, 0, src_ds.RasterXSize // 2, src_ds.RasterYSize
+    )

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -3901,6 +3901,56 @@ void netCDFDataset::SetProjectionFromVar(
             double xMinMax[2] = {0.0, 0.0};
             double yMinMax[2] = {0.0, 0.0};
 
+            const auto RoundMinMaxForFloatVals =
+                [](double &dfMin, double &dfMax, int nIntervals)
+            {
+                // Helps for a case where longitudes range from
+                // -179.99 to 180.0 with a 0.01 degree spacing.
+                // However as this is encoded in a float array,
+                // -179.99 is actually read as -179.99000549316406 as
+                // a double. Try to detect that and correct the rounding
+
+                const auto IsAlmostInteger = [](double dfVal)
+                {
+                    constexpr double THRESHOLD_INTEGER = 1e-3;
+                    return std::fabs(dfVal - std::round(dfVal)) <=
+                           THRESHOLD_INTEGER;
+                };
+
+                const double dfSpacing = (dfMax - dfMin) / nIntervals;
+                if (dfSpacing > 0)
+                {
+                    const double dfInvSpacing = 1.0 / dfSpacing;
+                    if (IsAlmostInteger(dfInvSpacing))
+                    {
+                        const double dfRoundedSpacing =
+                            1.0 / std::round(dfInvSpacing);
+                        const double dfMinDivRoundedSpacing =
+                            dfMin / dfRoundedSpacing;
+                        const double dfMaxDivRoundedSpacing =
+                            dfMax / dfRoundedSpacing;
+                        if (IsAlmostInteger(dfMinDivRoundedSpacing) &&
+                            IsAlmostInteger(dfMaxDivRoundedSpacing))
+                        {
+                            const double dfRoundedMin =
+                                std::round(dfMinDivRoundedSpacing) *
+                                dfRoundedSpacing;
+                            const double dfRoundedMax =
+                                std::round(dfMaxDivRoundedSpacing) *
+                                dfRoundedSpacing;
+                            if (static_cast<float>(dfMin) ==
+                                    static_cast<float>(dfRoundedMin) &&
+                                static_cast<float>(dfMax) ==
+                                    static_cast<float>(dfRoundedMax))
+                            {
+                                dfMin = dfRoundedMin;
+                                dfMax = dfRoundedMax;
+                            }
+                        }
+                    }
+                }
+            };
+
             if (!nc_get_att_double(nGroupDimXID, nVarDimXID, "actual_range",
                                    adfActualRange))
             {
@@ -3920,6 +3970,12 @@ void netCDFDataset::SetProjectionFromVar(
                 xMinMax[0] = pdfXCoord[0];
                 xMinMax[1] = pdfXCoord[xdim - 1];
                 node_offset = 0;
+
+                if (nc_var_dimx_datatype == NC_FLOAT)
+                {
+                    RoundMinMaxForFloatVals(xMinMax[0], xMinMax[1],
+                                            poDS->nRasterXSize - 1);
+                }
             }
 
             if (!nc_get_att_double(nGroupDimYID, nVarDimYID, "actual_range",
@@ -3941,6 +3997,12 @@ void netCDFDataset::SetProjectionFromVar(
                 yMinMax[0] = pdfYCoord[0];
                 yMinMax[1] = pdfYCoord[ydim - 1];
                 node_offset = 0;
+
+                if (nc_var_dimy_datatype == NC_FLOAT)
+                {
+                    RoundMinMaxForFloatVals(yMinMax[0], yMinMax[1],
+                                            poDS->nRasterYSize - 1);
+                }
             }
 
             double dfCoordOffset = 0.0;


### PR DESCRIPTION
Fixes https://lists.osgeo.org/pipermail/gdal-dev/2024-May/059050.html

- netCDF: try to better round geotransform values when read from single-precsion lon/lat float arrays
- Warper: relax longitude extend check to decide whether we can insert a CENTER_LONG wrapping longitude
