### PR TITLE
[argparse] update library

### DIFF
--- a/apps/argparse/README.TXT
+++ b/apps/argparse/README.TXT
@@ -1,3 +1,4 @@
 Provenance: https://github.com/p-ranav/argparse
 
-Retrieved from https://github.com/p-ranav/argparse/blob/b85a0a414d415fccdf6d77072421b1d3887c8f79/include/argparse/argparse.hpp
+Retrieved: https://github.com/p-ranav/argparse/blob/8dead89026466b3818e9c6b6b1d938600db39d8f/include/argparse/argparse.hpp
+

--- a/apps/argparse/argparse.hpp
+++ b/apps/argparse/argparse.hpp
@@ -1002,7 +1002,8 @@ public:
             std::bind(is_optional, std::placeholders::_1, m_prefix_chars));
         dist = static_cast<std::size_t>(std::distance(start, end));
         if (dist < num_args_min) {
-          throw std::runtime_error("Too few arguments");
+          throw std::runtime_error("Too few arguments for '" +
+                                   std::string(m_used_name) + "'.");
         }
       }
 

--- a/apps/argparse/argparse.hpp
+++ b/apps/argparse/argparse.hpp
@@ -678,9 +678,9 @@ public:
         std::is_void_v<std::invoke_result_t<F, Args..., std::string const>>,
         void_action, valued_action>;
     if constexpr (sizeof...(Args) == 0) {
-      m_action.emplace<action_type>(std::forward<F>(callable));
+      m_actions.emplace_back<action_type>(std::forward<F>(callable));
     } else {
-      m_action.emplace<action_type>(
+      m_actions.emplace_back<action_type>(
           [f = std::forward<F>(callable),
            tup = std::make_tuple(std::forward<Args>(bound_args)...)](
               std::string const &opt) mutable {
@@ -702,14 +702,7 @@ public:
   template <typename T, typename std::enable_if<std::is_integral<T>::value>::type * = nullptr>
   auto &store_into(T &var) {
     if (m_default_value.has_value()) {
-      try
-      {
-        var = std::any_cast<T>(m_default_value);
-      }
-      catch (...)
-      {
-        var = static_cast<T>(std::any_cast<int>(m_default_value));
-      }
+      var = std::any_cast<T>(m_default_value);
     }
     action([&var](const auto &s) {
       var = details::parse_number<T, details::radix_10>()(s);
@@ -719,14 +712,7 @@ public:
 
   auto &store_into(double &var) {
     if (m_default_value.has_value()) {
-      try
-      {
-        var = std::any_cast<double>(m_default_value);
-      }
-      catch (...)
-      {
-        var = std::any_cast<int>(m_default_value);
-      }
+      var = std::any_cast<double>(m_default_value);
     }
     action([&var](const auto &s) {
       var = details::parse_number<double, details::chars_format::general>()(s);
@@ -994,7 +980,12 @@ public:
     if (num_args_max == 0) {
       if (!dry_run) {
         m_values.emplace_back(m_implicit_value);
-        std::visit([](const auto &f) { f({}); }, m_action);
+        for(auto &action: m_actions) {
+          std::visit([&](const auto &f) { f({}); }, action);
+        }
+        if(m_actions.empty()){
+          std::visit([&](const auto &f) { f({}); }, m_default_action);
+        }
         m_is_used = true;
       }
       return start;
@@ -1011,8 +1002,7 @@ public:
             std::bind(is_optional, std::placeholders::_1, m_prefix_chars));
         dist = static_cast<std::size_t>(std::distance(start, end));
         if (dist < num_args_min) {
-          throw std::runtime_error("Too few arguments for '" +
-                                   std::string(m_used_name) + "'.");
+          throw std::runtime_error("Too few arguments");
         }
       }
 
@@ -1035,7 +1025,12 @@ public:
         Argument &self;
       };
       if (!dry_run) {
-        std::visit(ActionApply{start, end, *this}, m_action);
+        for(auto &action: m_actions) {
+          std::visit(ActionApply{start, end, *this}, action);
+        }
+        if(m_actions.empty()){
+          std::visit(ActionApply{start, end, *this}, m_default_action);
+        }
         m_is_used = true;
       }
       return end;
@@ -1585,9 +1580,10 @@ private:
   std::optional<std::vector<std::string>> m_choices{std::nullopt};
   using valued_action = std::function<std::any(const std::string &)>;
   using void_action = std::function<void(const std::string &)>;
-  std::variant<valued_action, void_action> m_action{
-      std::in_place_type<valued_action>,
-      [](const std::string &value) { return value; }};
+  std::vector<std::variant<valued_action, void_action>> m_actions;
+  std::variant<valued_action, void_action> m_default_action{
+    std::in_place_type<valued_action>,
+    [](const std::string &value) { return value; }};
   std::vector<std::any> m_values;
   NArgsRange m_num_args_range{1, 1};
   // Bit field of bool values. Set default value in ctor.

--- a/apps/gdal_create.cpp
+++ b/apps/gdal_create.cpp
@@ -127,7 +127,6 @@ GDALCreateAppOptionsGetParser(GDALCreateOptions *psOptions)
         .metavar("<value>")
         .nargs(nargs_pattern::at_least_one)
         .append()
-        .scan<'g', double>()
         .action(
             [psOptions](const std::string &s)
             {


### PR DESCRIPTION
Update to PR https://github.com/p-ranav/argparse/pull/356

Also fixes the incompatibility between store_into and scan and action: when the three methods above were called, being all based on the (unique) action, the last one would overwrite the previous ones.

This issue was making the parser strictly dependent on the order of the scan/store_into/action calls making them mutually exclusive.
