### PR TITLE
[gdalmanage] Use GDALArgumentParser

### DIFF
--- a/apps/gdalmanage.cpp
+++ b/apps/gdalmanage.cpp
@@ -33,22 +33,22 @@
 #include "gdal_version.h"
 #include "gdal.h"
 #include "commonutils.h"
+#include "gdalargumentparser.h"
 
 /************************************************************************/
-/*                               Usage()                                */
+/*                     GDALManageOptions()                              */
 /************************************************************************/
 
-static void Usage(bool bIsError)
-
+struct GDALManageOptions
 {
-    fprintf(bIsError ? stderr : stdout,
-            "Usage: gdalmanage [--help] [--help-general]\n"
-            "    or gdalmanage identify [-r|-fr] [-u] <files>*\n"
-            "    or gdalmanage copy [-f <driver>] <oldname> <newname>\n"
-            "    or gdalmanage rename [-f <driver>] <oldname> <newname>\n"
-            "    or gdalmanage delete [-f <driver>] <datasetname>\n");
-    exit(bIsError ? 1 : 0);
-}
+    bool bRecursive = false;
+    bool bForceRecurse = false;
+    bool bReportFailures = false;
+    std::string osNewName;
+    std::string osDatasetName;
+    std::vector<std::string> aosDatasetNames;
+    std::string osDriverName;
+};
 
 /************************************************************************/
 /*                       ProcessIdentifyTarget()                        */
@@ -92,73 +92,111 @@ static void ProcessIdentifyTarget(const char *pszTarget,
 }
 
 /************************************************************************/
-/*                              Identify()                              */
+/*                     GDALManageAppOptionsGetParser()                 */
 /************************************************************************/
 
-static void Identify(int nArgc, char **papszArgv)
-
+static std::unique_ptr<GDALArgumentParser>
+GDALManageAppOptionsGetParser(GDALManageOptions *psOptions)
 {
-    /* -------------------------------------------------------------------- */
-    /*      Scan for command line switches                                   */
-    /* -------------------------------------------------------------------- */
-    bool bRecursive = false;
-    bool bForceRecurse = false;
-    bool bReportFailures = false;
+    auto argParser = std::make_unique<GDALArgumentParser>(
+        "gdalmanage", /* bForBinary */ true);
 
-    int i = 0;
-    for (; i < nArgc && papszArgv[i][0] == '-'; ++i)
+    argParser->add_description(
+        _("Identify, delete, rename and copy raster data files."));
+    argParser->add_epilog(_("For more details, consult the full documentation "
+                            "for the gdalmanage utility "
+                            "https://gdal.org/programs/gdalmanage.html"));
+
+    auto addCommonOptions = [psOptions](GDALArgumentParser *subParser)
     {
-        if (EQUAL(papszArgv[i], "-r"))
-            bRecursive = true;
-        else if (EQUAL(papszArgv[i], "-fr"))
-        {
-            bForceRecurse = true;
-            bRecursive = true;
-        }
-        else if (EQUAL(papszArgv[i], "-u"))
-            bReportFailures = true;
-        else
-            Usage(true);
-    }
+        subParser->add_argument("-f")
+            .metavar("<format>")
+            .store_into(psOptions->osDriverName)
+            .help(_("Specify format of raster file if unknown by the "
+                    "application."));
 
-    /* -------------------------------------------------------------------- */
-    /*      Process given files.                                            */
-    /* -------------------------------------------------------------------- */
-    for (; i < nArgc; ++i)
-    {
-        ProcessIdentifyTarget(papszArgv[i], nullptr, bRecursive,
-                              bReportFailures, bForceRecurse);
-    }
-}
+        subParser->add_argument("newdatasetname")
+            .metavar("<newdatasetname>")
+            .store_into(psOptions->osNewName)
+            .help(_("Name of the new file."));
+    };
 
-/************************************************************************/
-/*                               Delete()                               */
-/************************************************************************/
+    // Identify
 
-static void Delete(GDALDriverH hDriver, int nArgc, char **papszArgv)
+    auto identifyParser =
+        argParser->add_subparser("identify", /* bForBinary */ true);
+    identifyParser->add_description(_("List data format of file(s)."));
 
-{
-    if (nArgc != 1)
-        Usage(true);
+    identifyParser->add_argument("-r")
+        .flag()
+        .store_into(psOptions->bRecursive)
+        .help(_("Recursively scan files/folders for raster files."));
 
-    GDALDeleteDataset(hDriver, papszArgv[0]);
-}
+    identifyParser->add_argument("-fr")
+        .flag()
+        .store_into(psOptions->bRecursive)
+        .store_into(psOptions->bForceRecurse)
+        .help(_("Recursively scan folders for raster files, forcing "
+                "recursion in folders recognized as valid formats."));
 
-/************************************************************************/
-/*                                Copy()                                */
-/************************************************************************/
+    identifyParser->add_argument("-u")
+        .flag()
+        .store_into(psOptions->bReportFailures)
+        .help(_("Report failures if file type is unidentified."));
 
-static void Copy(GDALDriverH hDriver, int nArgc, char **papszArgv,
-                 const char *pszOperation)
+    // Note: this accepts multiple files
+    identifyParser->add_argument("datasetname")
+        .metavar("<datasetname>")
+        .store_into(psOptions->aosDatasetNames)
+        .remaining()
+        .help(_("Name(s) of the file(s) to identify."));
 
-{
-    if (nArgc != 2)
-        Usage(true);
+    // Copy
 
-    if (EQUAL(pszOperation, "copy"))
-        GDALCopyDatasetFiles(hDriver, papszArgv[1], papszArgv[0]);
-    else
-        GDALRenameDataset(hDriver, papszArgv[1], papszArgv[0]);
+    auto copyParser = argParser->add_subparser("copy", /* bForBinary */ true);
+    copyParser->add_description(
+        _("Create a copy of the raster file with a new name."));
+
+    addCommonOptions(copyParser);
+
+    copyParser->add_argument("datasetname")
+        .metavar("<datasetname>")
+        .store_into(psOptions->osDatasetName)
+        .help(_("Name of the file to copy."));
+
+    // Rename
+
+    auto renameParser =
+        argParser->add_subparser("rename", /* bForBinary */ true);
+    renameParser->add_description(_("Change the name of the raster file."));
+
+    addCommonOptions(renameParser);
+
+    renameParser->add_argument("datasetname")
+        .metavar("<datasetname>")
+        .store_into(psOptions->osDatasetName)
+        .help(_("Name of the file to rename."));
+
+    // Delete
+
+    auto deleteParser =
+        argParser->add_subparser("delete", /* bForBinary */ true);
+    deleteParser->add_description(_("Delete the raster file(s)."));
+
+    // Note: this accepts multiple files
+    deleteParser->add_argument("datasetname")
+        .metavar("<datasetname>")
+        .store_into(psOptions->aosDatasetNames)
+        .remaining()
+        .help(_("Name(s) of the file(s) to delete."));
+
+    deleteParser->add_argument("-f")
+        .metavar("<format>")
+        .store_into(psOptions->osDriverName)
+        .help(
+            _("Specify format of raster file if unknown by the application."));
+
+    return argParser;
 }
 
 /************************************************************************/
@@ -168,64 +206,70 @@ static void Copy(GDALDriverH hDriver, int nArgc, char **papszArgv,
 MAIN_START(argc, argv)
 
 {
-    char *pszDriver = nullptr;
-    GDALDriverH hDriver = nullptr;
 
-    /* Check that we are running against at least GDAL 1.5 */
-    /* Note to developers : if we use newer API, please change the requirement
-     */
-    if (atoi(GDALVersionInfo("VERSION_NUM")) < 1500)
-    {
-        fprintf(stderr,
-                "At least, GDAL >= 1.5.0 is required for this version of %s, "
-                "which was compiled against GDAL %s\n",
-                argv[0], GDAL_RELEASE_NAME);
-        exit(1);
-    }
-
-    GDALAllRegister();
+    EarlySetConfigOptions(argc, argv);
 
     argc = GDALGeneralCmdLineProcessor(argc, &argv, 0);
     if (argc < 1)
         exit(-argc);
 
-    for (int i = 0; i < argc; i++)
+    /* -------------------------------------------------------------------- */
+    /*      Parse arguments.                                                */
+    /* -------------------------------------------------------------------- */
+
+    if (argc < 2)
     {
-        if (EQUAL(argv[i], "--utility_version"))
+        try
         {
-            printf("%s was compiled against GDAL %s and is running against "
-                   "GDAL %s\n",
-                   argv[0], GDAL_RELEASE_NAME, GDALVersionInfo("RELEASE_NAME"));
-            return 0;
+            GDALManageOptions sOptions;
+            auto argParser = GDALManageAppOptionsGetParser(&sOptions);
+            fprintf(stderr, "%s\n", argParser->usage().c_str());
         }
-        else if (EQUAL(argv[i], "--help"))
+        catch (const std::exception &err)
         {
-            Usage(false);
+            CPLError(CE_Failure, CPLE_AppDefined, "Unexpected exception: %s",
+                     err.what());
         }
+        CSLDestroy(argv);
+        exit(1);
     }
 
-    if (argc < 3)
-        Usage(true);
+    GDALAllRegister();
 
-    /* -------------------------------------------------------------------- */
-    /*      Do we have a driver specifier?                                  */
-    /* -------------------------------------------------------------------- */
-    char **papszRemainingArgv = argv + 2;
-    int nRemainingArgc = argc - 2;
+    GDALManageOptions psOptions;
+    auto argParser = GDALManageAppOptionsGetParser(&psOptions);
 
-    if (EQUAL(papszRemainingArgv[0], "-f") && nRemainingArgc > 1)
+    try
     {
-        pszDriver = papszRemainingArgv[1];
-        papszRemainingArgv += 2;
-        nRemainingArgc -= 2;
+        argParser->parse_args_without_binary_name(argv + 1);
+        CSLDestroy(argv);
+    }
+    catch (const std::exception &error)
+    {
+        argParser->display_error_and_usage(error);
+        CSLDestroy(argv);
+        exit(1);
     }
 
-    if (pszDriver != nullptr)
+    // For some obscure reason datasetname is parsed as mandatory
+    // if used with remaining() in a subparser
+    if (psOptions.aosDatasetNames.empty() && psOptions.osDatasetName.empty())
     {
-        hDriver = GDALGetDriverByName(pszDriver);
+        std::invalid_argument error(
+            _("No dataset name provided. At least one dataset "
+              "name is required."));
+        argParser->display_error_and_usage(error);
+        exit(1);
+    }
+
+    GDALDriverH hDriver = nullptr;
+    if (!psOptions.osDriverName.empty())
+    {
+        hDriver = GDALGetDriverByName(psOptions.osDriverName.c_str());
         if (hDriver == nullptr)
         {
-            fprintf(stderr, "Unable to find driver named '%s'.\n", pszDriver);
+            CPLError(CE_Failure, CPLE_AppDefined, "Failed to find driver '%s'.",
+                     psOptions.osDriverName.c_str());
             exit(1);
         }
     }
@@ -233,26 +277,40 @@ MAIN_START(argc, argv)
     /* -------------------------------------------------------------------- */
     /*      Split out based on operation.                                   */
     /* -------------------------------------------------------------------- */
-    if (STARTS_WITH_CI(argv[1], "ident" /* identify" */))
-        Identify(nRemainingArgc, papszRemainingArgv);
 
-    else if (EQUAL(argv[1], "copy"))
-        Copy(hDriver, nRemainingArgc, papszRemainingArgv, "copy");
-
-    else if (EQUAL(argv[1], "rename"))
-        Copy(hDriver, nRemainingArgc, papszRemainingArgv, "rename");
-
-    else if (EQUAL(argv[1], "delete"))
-        Delete(hDriver, nRemainingArgc, papszRemainingArgv);
-
-    else
-        Usage(true);
+    if (argParser->is_subcommand_used("identify"))
+    {
+        // Process all files in aosDatasetName
+        for (const auto &datasetName : psOptions.aosDatasetNames)
+        {
+            ProcessIdentifyTarget(
+                datasetName.c_str(), nullptr, psOptions.bRecursive,
+                psOptions.bReportFailures, psOptions.bForceRecurse);
+        }
+    }
+    else if (argParser->is_subcommand_used("copy"))
+    {
+        GDALCopyDatasetFiles(hDriver, psOptions.osDatasetName.c_str(),
+                             psOptions.osNewName.c_str());
+    }
+    else if (argParser->is_subcommand_used("rename"))
+    {
+        GDALRenameDataset(hDriver, psOptions.osDatasetName.c_str(),
+                          psOptions.osNewName.c_str());
+    }
+    else if (argParser->is_subcommand_used("delete"))
+    {
+        // Process all files in aosDatasetName
+        for (const auto &datasetName : psOptions.aosDatasetNames)
+        {
+            GDALDeleteDataset(hDriver, datasetName.c_str());
+        }
+    }
 
     /* -------------------------------------------------------------------- */
     /*      Cleanup                                                         */
     /* -------------------------------------------------------------------- */
-    CSLDestroy(argv);
-    GDALDestroyDriverManager();
+    GDALDestroy();
 
     exit(0);
 }

--- a/autotest/pymod/test_cli_utilities.py
+++ b/autotest/pymod/test_cli_utilities.py
@@ -104,6 +104,14 @@ def get_gdalmdiminfo_path():
 #
 
 
+def get_gdalmanage_path():
+    return get_cli_utility_path("gdalmanage")
+
+
+###############################################################################
+#
+
+
 def get_gdal_translate_path():
     return get_cli_utility_path("gdal_translate")
 

--- a/autotest/utilities/test_gdalmanage.py
+++ b/autotest/utilities/test_gdalmanage.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env pytest
+# -*- coding: utf-8 -*-
+###############################################################################
+# $Id$
+#
+# Project:  GDAL/OGR Test Suite
+# Purpose:  gdalmanage testing
+# Author:   Alessandro Pasotti <elpaso at itopen.it>
+#
+###############################################################################
+# Copyright (c) 2024, Alessandro Pasotti <elpaso at itopen.it>
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+###############################################################################
+
+import os
+
+import gdaltest
+import pytest
+import test_cli_utilities
+
+pytestmark = pytest.mark.skipif(
+    test_cli_utilities.get_gdalmanage_path() is None,
+    reason="gdalmanage not available",
+)
+
+
+@pytest.fixture()
+def gdalmanage_path():
+    return test_cli_utilities.get_gdalmanage_path()
+
+
+###############################################################################
+# Simple identify test
+
+
+def test_gdalmanage_identify(gdalmanage_path):
+
+    (ret, err) = gdaltest.runexternal_out_and_err(
+        gdalmanage_path + " identify data/utmsmall.tif"
+    )
+    assert err == ""
+    assert "GTiff" in ret
+
+
+###############################################################################
+# Test -r option
+
+
+def test_gdalmanage_identify_recursive_option(gdalmanage_path):
+
+    (ret, err) = gdaltest.runexternal_out_and_err(gdalmanage_path + " identify -r data")
+    assert err == ""
+    assert "ESRI Shapefile" in ret
+    assert len(ret.split("\n")) == 2
+
+
+###############################################################################
+# Test -fr option
+
+
+def test_gdalmanage_identify_force_recursive_option(gdalmanage_path):
+
+    (ret, err) = gdaltest.runexternal_out_and_err(
+        gdalmanage_path + " identify -fr data"
+    )
+    assert err == ""
+    ret = ret.replace("\\", "/")
+    assert len(ret.split("\n")) > 10
+    assert "whiteblackred.tif: GTiff" in ret
+    assert "utmsmall.tif: GTiff" in ret
+    assert "ESRI Shapefile" in ret
+    assert "data/path.cpg: unrecognized" not in ret
+
+    # Test both the -r and -fr options (shouldn't change the output)
+    (ret2, err2) = gdaltest.runexternal_out_and_err(
+        gdalmanage_path + " identify -r -fr data"
+    )
+    ret2 = ret2.replace("\\", "/")
+    assert ret2 == ret and err2 == err
+
+
+###############################################################################
+# Test -u option
+
+
+def test_gdalmanage_identify_report_failures_option(gdalmanage_path):
+
+    (ret, err) = gdaltest.runexternal_out_and_err(
+        gdalmanage_path + " identify -fr -u data"
+    )
+    assert err == ""
+    ret = ret.replace("\\", "/")
+    assert "whiteblackred.tif: GTiff" in ret
+    assert "utmsmall.tif: GTiff" in ret
+    assert "ESRI Shapefile" in ret
+    assert "data/path.cpg: unrecognized" in ret
+
+
+###############################################################################
+# Test identify multiple files
+
+
+def test_gdalmanage_identify_multiple_files(gdalmanage_path):
+
+    (ret, err) = gdaltest.runexternal_out_and_err(
+        gdalmanage_path + " identify data/utmsmall.tif data/whiteblackred.tif"
+    )
+    assert err == ""
+    assert len(ret.split("\n")) == 3
+    assert "whiteblackred.tif: GTiff" in ret
+    assert "utmsmall.tif: GTiff" in ret
+
+
+###############################################################################
+# Test copy file
+
+
+def test_gdalmanage_copy_file(tmp_path, gdalmanage_path):
+
+    (ret, err) = gdaltest.runexternal_out_and_err(
+        gdalmanage_path + f" copy data/utmsmall.tif {tmp_path}/utmsmall.tif"
+    )
+    assert err == ""
+    # Verify the file was created
+    assert os.path.exists(f"{tmp_path}/utmsmall.tif")
+
+
+###############################################################################
+# Test copy file with -f option
+
+
+def test_gdalmanage_copy_file_format(tmp_path, gdalmanage_path):
+
+    (ret, err) = gdaltest.runexternal_out_and_err(
+        gdalmanage_path + f" copy -f GTiff data/utmsmall.tif {tmp_path}/utmsmall2.tif"
+    )
+    assert err == ""
+    # Verify the file was created
+    assert os.path.exists(f"{tmp_path}/utmsmall2.tif")
+
+    # Wrong format
+    (ret, err) = gdaltest.runexternal_out_and_err(
+        gdalmanage_path
+        + f" copy -f WRONGFORMAT data/utmsmall.tif {tmp_path}/utmsmall3.tif"
+    )
+    assert "Failed to find driver 'WRONGFORMAT'" in err
+
+
+###############################################################################
+# Test rename file
+
+
+def test_gdalmanage_rename_file(tmp_path, gdalmanage_path):
+
+    (ret, err) = gdaltest.runexternal_out_and_err(
+        gdalmanage_path + f" copy data/utmsmall.tif {tmp_path}/utmsmall_to_rename.tif"
+    )
+    assert err == ""
+    (ret, err) = gdaltest.runexternal_out_and_err(
+        gdalmanage_path
+        + f" rename {tmp_path}/utmsmall_to_rename.tif {tmp_path}/utmsmall_renamed.tif"
+    )
+    assert err == ""
+    # Verify the file was renamed
+    assert os.path.exists(f"{tmp_path}/utmsmall_renamed.tif")
+    assert not os.path.exists(f"{tmp_path}/utmsmall_to_rename.tif")
+
+
+###############################################################################
+# Test delete file
+
+
+def test_gdalmanage_delete_file(tmp_path, gdalmanage_path):
+
+    (ret, err) = gdaltest.runexternal_out_and_err(
+        gdalmanage_path + f" copy data/utmsmall.tif {tmp_path}/utmsmall_to_delete.tif"
+    )
+    assert err == ""
+    assert os.path.exists(f"{tmp_path}/utmsmall_to_delete.tif")
+    (ret, err) = gdaltest.runexternal_out_and_err(
+        gdalmanage_path + f" delete {tmp_path}/utmsmall_to_delete.tif"
+    )
+    assert err == ""
+    # Verify the file was deleted
+    assert not os.path.exists(f"{tmp_path}/utmsmall_to_delete.tif")
+
+
+###############################################################################
+# Test delete multiple files
+
+
+def test_gdalmanage_delete_multiple_files(tmp_path, gdalmanage_path):
+
+    (ret, err) = gdaltest.runexternal_out_and_err(
+        gdalmanage_path + f" copy data/utmsmall.tif {tmp_path}/utmsmall_to_delete.tif"
+    )
+    assert err == ""
+    assert os.path.exists(f"{tmp_path}/utmsmall_to_delete.tif")
+    (ret, err) = gdaltest.runexternal_out_and_err(
+        gdalmanage_path
+        + f" copy data/whiteblackred.tif {tmp_path}/whiteblackred_to_delete.tif"
+    )
+    assert err == ""
+    assert os.path.exists(f"{tmp_path}/whiteblackred_to_delete.tif")
+    (ret, err) = gdaltest.runexternal_out_and_err(
+        gdalmanage_path
+        + f" delete {tmp_path}/utmsmall_to_delete.tif {tmp_path}/whiteblackred_to_delete.tif"
+    )
+    assert err == ""
+    # Verify the files were deleted
+    assert not os.path.exists(f"{tmp_path}/utmsmall_to_delete.tif")
+    assert not os.path.exists(f"{tmp_path}/whiteblackred_to_delete.tif")
+
+
+###############################################################################
+# Test no arguments
+
+
+def test_gdalmanage_no_arguments(gdalmanage_path):
+
+    (ret, err) = gdaltest.runexternal_out_and_err(gdalmanage_path)
+    assert "Usage: gdalmanage" in err
+
+
+###############################################################################
+# Test invalid command
+
+
+def test_gdalmanage_invalid_command(gdalmanage_path):
+
+    (ret, err) = gdaltest.runexternal_out_and_err(gdalmanage_path + " invalidcommand")
+    assert "Usage: gdalmanage" in err
+
+
+###############################################################################
+# Test invalid argument
+
+
+def test_gdalmanage_invalid_argument(gdalmanage_path):
+
+    (ret, err) = gdaltest.runexternal_out_and_err(
+        gdalmanage_path + " identify -WTF data/utmsmall.tif"
+    )
+    assert "Usage: gdalmanage" in err
+    assert "Unknown argument: -WTF" in err
+
+
+###############################################################################
+# Test valid command with no required argument
+
+
+def test_gdalmanage_valid_command_no_argument(gdalmanage_path):
+
+    (ret, err) = gdaltest.runexternal_out_and_err(gdalmanage_path + " identify")
+    assert "Usage: gdalmanage" in err
+    assert (
+        "Error: No dataset name provided. At least one dataset name is required" in err
+    )

--- a/doc/source/programs/gdalmanage.rst
+++ b/doc/source/programs/gdalmanage.rst
@@ -16,7 +16,7 @@ Synopsis
 .. code-block::
 
     Usage: gdalmanage [--help] [--help-general]
-                      <mode> [-r] [-u] [-f <format>]
+                      <mode> [-r] [-fr] [-u] [-f <format>]
                       <datasetname> [<newdatasetname>]
 
 Description
@@ -31,17 +31,21 @@ data types and deleting, renaming or copying the files.
     Mode of operation
 
     **identify** *<datasetname>*:
-        List data format of file.
+        List data format of file(s).
     **copy** *<datasetname>* *<newdatasetname>*:
         Create a copy of the raster file with a new name.
     **rename** *<datasetname>* *<newdatasetname>*:
         Change the name of the raster file.
     **delete** *<datasetname>*:
-        Delete raster file.
+        Delete raster file(s).
 
 .. option:: -r
 
     Recursively scan files/folders for raster files.
+
+.. option:: -fr
+
+    Recursively scan folders for raster files, forcing recursion in folders recognized as valid formats.
 
 .. option:: -u
 
@@ -54,7 +58,7 @@ data types and deleting, renaming or copying the files.
 
 .. option:: <datasetname>
 
-    Raster file to operate on.
+    Raster file to operate on. With **identify** may be repeated for multiple files.
 
 .. option:: <newdatasetname>
 


### PR DESCRIPTION
# TODO:

- [x]  Tests


## general


```
Usage: gdalmanage [--help] [--long-usage] [--help-general] {copy,delete,identify,rename}

Identify, delete, rename and copy raster data files.

Optional arguments:
  -h, --help         Shows short help message and exits. 
  --long-usage       Shows long help message and exits. 
  --help-general     Report detailed help on general options. 

Subcommands:
  copy              Create a copy of the raster file with a new name.
  delete            Delete the raster file(s).
  identify          List data format of file(s).
  rename            Change the name of the raster file.

For more details, consult the full documentation for the gdalmanage utility https://gdal.org/programs/gdalmanage.html
```


## identify

```
Usage: identify [--help] [--long-usage] [--help-general]
                [-r] [-fr] [-u]
                [<datasetname>]...

List data format of file.

Positional arguments:
  <datasetname>      Name(s) of the file(s) to identify. [nargs: 0 or more] 

Optional arguments:
  -h, --help         Shows short help message and exits. 
  --long-usage       Shows long help message and exits. 
  --help-general     Report detailed help on general options. 
  -r                 Recursively scan files/folders for raster files. 
  -fr                Recursively scan folders for raster files, forcing recursion in folders recognized as valid formats. 
  -u                 Report failures if file type is unidentified. 
```

## copy

```
Usage: copy [--help] [--long-usage] [--help-general]
            [-f <format>]
            <newdatasetname> <datasetname>

Create a copy of the raster file with a new name.

Positional arguments:
  <newdatasetname>   Name of the new file. 
  <datasetname>      Name of the file to copy. 

Optional arguments:
  -h, --help         Shows short help message and exits. 
  --long-usage       Shows long help message and exits. 
  --help-general     Report detailed help on general options. 
  -f <format>        Specify format of raster file if unknown by the application.
```

## rename

```
Usage: rename [--help] [--long-usage] [--help-general]
              [-f <format>]
              <newdatasetname> <datasetname>

Change the name of the raster file.

Positional arguments:
  <newdatasetname>   Name of the new file. 
  <datasetname>      Name of the file to rename. 

Optional arguments:
  -h, --help         Shows short help message and exits. 
  --long-usage       Shows long help message and exits. 
  --help-general     Report detailed help on general options. 
  -f <format>        Specify format of raster file if unknown by the application. 
```


## delete

```
Usage: delete [--help] [--long-usage] [--help-general]
              [-f <format>]
              [<datasetname>]...

Delete the raster file(s).

Positional arguments:
  <datasetname>      Name(s) of the file(s) to delete. [nargs: 0 or more] 

Optional arguments:
  -h, --help         Shows short help message and exits. 
  --long-usage       Shows long help message and exits. 
  --help-general     Report detailed help on general options. 
  -f <format>        Specify format of raster file if unknown by the application.
```
