### PR TITLE
[Backport release/3.9] PG: avoid errors related to ogr_system_tables.metadata when user has not enough permissions

### DIFF
--- a/doc/source/drivers/vector/pg.rst
+++ b/doc/source/drivers/vector/pg.rst
@@ -449,6 +449,15 @@ available:
       be destroyed. Typical use case: ``ogr2ogr -append PG:dbname=foo
       abc.shp --config OGR_TRUNCATE YES``.
 
+-  .. config:: OGR_PG_ENABLE_METADATA
+      :choices: YES, NO
+      :default: YES
+      :since: 3.9
+
+      If set to "YES" (the default), the driver will try to use (and potentially
+      create) the ``ogr_system_tables.metadata`` table to retrieve and store
+      layer metadata.
+
 Examples
 ~~~~~~~~
 

--- a/ogr/ogrsf_frmts/pg/ogr_pg.h
+++ b/ogr/ogrsf_frmts/pg/ogr_pg.h
@@ -641,6 +641,12 @@ class OGRPGDataSource final : public OGRDataSource
     bool m_bOgrSystemTablesMetadataTableExistenceTested = false;
     bool m_bOgrSystemTablesMetadataTableFound = false;
 
+    bool m_bCreateMetadataTableIfNeededRun = false;
+    bool m_bCreateMetadataTableIfNeededSuccess = false;
+
+    bool m_bHasWritePermissionsOnMetadataTableRun = false;
+    bool m_bHasWritePermissionsOnMetadataTableSuccess = false;
+
     void LoadTables();
 
     CPLString osDebugLastTransactionCommand{};
@@ -749,8 +755,9 @@ class OGRPGDataSource final : public OGRDataSource
         return bUserTransactionActive;
     }
 
-    void CreateOgrSystemTablesMetadataTableIfNeeded();
+    bool CreateMetadataTableIfNeeded();
     bool HasOgrSystemTablesMetadataTable();
+    bool HasWritePermissionsOnMetadataTable();
 };
 
 #endif /* ndef OGR_PG_H_INCLUDED */

--- a/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
@@ -3199,13 +3199,69 @@ OGRErr OGRPGDataSource::EndCopy()
 }
 
 /************************************************************************/
-/*                CreateOgrSystemTablesMetadataTableIfNeeded()          */
+/*                     CreateMetadataTableIfNeeded()                    */
 /************************************************************************/
 
-void OGRPGDataSource::CreateOgrSystemTablesMetadataTableIfNeeded()
+bool OGRPGDataSource::CreateMetadataTableIfNeeded()
 {
-    PGresult *hResult =
+    if (m_bCreateMetadataTableIfNeededRun)
+        return m_bCreateMetadataTableIfNeededSuccess;
+
+    m_bCreateMetadataTableIfNeededRun = true;
+
+    PGresult *hResult;
+
+    hResult = OGRPG_PQexec(
+        hPGConn,
+        "SELECT c.oid FROM pg_class c "
+        "JOIN pg_namespace n ON c.relnamespace=n.oid "
+        "WHERE c.relname = 'metadata' AND n.nspname = 'ogr_system_tables'");
+    const bool bFound =
+        (hResult && PQntuples(hResult) == 1 && !PQgetisnull(hResult, 0, 0));
+    OGRPGClearResult(hResult);
+
+    hResult = OGRPG_PQexec(
+        hPGConn,
+        "SELECT has_database_privilege((select current_database()), 'CREATE')");
+    const bool bCanCreateSchema =
+        (hResult && PQntuples(hResult) == 1 && !PQgetisnull(hResult, 0, 0) &&
+         strcmp(PQgetvalue(hResult, 0, 0), "t") == 0);
+    OGRPGClearResult(hResult);
+
+    if (!bFound)
+    {
+        if (!bCanCreateSchema)
+        {
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "User lacks CREATE SCHEMA privilege to be able to create "
+                     "ogr_system_tables.metadata table");
+            return false;
+        }
+    }
+    else
+    {
+        if (!HasWritePermissionsOnMetadataTable())
+        {
+            return false;
+        }
+        if (!bCanCreateSchema)
+        {
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "User lacks CREATE SCHEMA privilege. Assuming "
+                     "ogr_system_tables.metadata table has correct structure");
+            m_bCreateMetadataTableIfNeededSuccess = true;
+            return true;
+        }
+    }
+
+    hResult =
         OGRPG_PQexec(hPGConn, "CREATE SCHEMA IF NOT EXISTS ogr_system_tables");
+    if (!hResult || (PQresultStatus(hResult) != PGRES_COMMAND_OK &&
+                     PQresultStatus(hResult) != PGRES_TUPLES_OK))
+    {
+        OGRPGClearResult(hResult);
+        return false;
+    }
     OGRPGClearResult(hResult);
 
     hResult = OGRPG_PQexec(
@@ -3215,12 +3271,24 @@ void OGRPGDataSource::CreateOgrSystemTablesMetadataTableIfNeeded()
                  "table_name TEXT NOT NULL, "
                  "metadata TEXT,"
                  "UNIQUE(schema_name, table_name))");
+    if (!hResult || (PQresultStatus(hResult) != PGRES_COMMAND_OK &&
+                     PQresultStatus(hResult) != PGRES_TUPLES_OK))
+    {
+        OGRPGClearResult(hResult);
+        return false;
+    }
     OGRPGClearResult(hResult);
 
     hResult = OGRPG_PQexec(
         hPGConn,
         "DROP FUNCTION IF EXISTS "
         "ogr_system_tables.event_trigger_function_for_metadata() CASCADE");
+    if (!hResult || (PQresultStatus(hResult) != PGRES_COMMAND_OK &&
+                     PQresultStatus(hResult) != PGRES_TUPLES_OK))
+    {
+        OGRPGClearResult(hResult);
+        return false;
+    }
     OGRPGClearResult(hResult);
 
     hResult = OGRPG_PQexec(
@@ -3231,6 +3299,9 @@ void OGRPGDataSource::CreateOgrSystemTablesMetadataTableIfNeeded()
         "DECLARE\n"
         "    obj record;\n"
         "BEGIN\n"
+        "  IF has_schema_privilege('ogr_system_tables', 'USAGE') THEN\n"
+        "   IF has_table_privilege('ogr_system_tables.metadata', 'DELETE') "
+        "THEN\n"
         "    FOR obj IN SELECT * FROM pg_event_trigger_dropped_objects()\n"
         "    LOOP\n"
         "        IF obj.object_type = 'table' THEN\n"
@@ -3239,13 +3310,27 @@ void OGRPGDataSource::CreateOgrSystemTablesMetadataTableIfNeeded()
         "obj.object_name;\n"
         "        END IF;\n"
         "    END LOOP;\n"
+        "   END IF;\n"
+        "  END IF;\n"
         "END;\n"
         "$$;");
+    if (!hResult || (PQresultStatus(hResult) != PGRES_COMMAND_OK &&
+                     PQresultStatus(hResult) != PGRES_TUPLES_OK))
+    {
+        OGRPGClearResult(hResult);
+        return false;
+    }
     OGRPGClearResult(hResult);
 
     hResult =
         OGRPG_PQexec(hPGConn, "DROP EVENT TRIGGER IF EXISTS "
                               "ogr_system_tables_event_trigger_for_metadata");
+    if (!hResult || (PQresultStatus(hResult) != PGRES_COMMAND_OK &&
+                     PQresultStatus(hResult) != PGRES_TUPLES_OK))
+    {
+        OGRPGClearResult(hResult);
+        return false;
+    }
     OGRPGClearResult(hResult);
 
     hResult = OGRPG_PQexec(
@@ -3254,7 +3339,18 @@ void OGRPGDataSource::CreateOgrSystemTablesMetadataTableIfNeeded()
         "ON sql_drop "
         "EXECUTE FUNCTION "
         "ogr_system_tables.event_trigger_function_for_metadata()");
+    if (!hResult || (PQresultStatus(hResult) != PGRES_COMMAND_OK &&
+                     PQresultStatus(hResult) != PGRES_TUPLES_OK))
+    {
+        OGRPGClearResult(hResult);
+        return false;
+    }
     OGRPGClearResult(hResult);
+
+    m_bCreateMetadataTableIfNeededSuccess = true;
+    m_bOgrSystemTablesMetadataTableExistenceTested = true;
+    m_bOgrSystemTablesMetadataTableFound = true;
+    return true;
 }
 
 /************************************************************************/
@@ -3274,9 +3370,76 @@ bool OGRPGDataSource::HasOgrSystemTablesMetadataTable()
             "SELECT c.oid FROM pg_class c "
             "JOIN pg_namespace n ON c.relnamespace=n.oid "
             "WHERE c.relname = 'metadata' AND n.nspname = 'ogr_system_tables'");
-        m_bOgrSystemTablesMetadataTableFound =
+        const bool bFound =
             (hResult && PQntuples(hResult) == 1 && !PQgetisnull(hResult, 0, 0));
         OGRPGClearResult(hResult);
+        if (!bFound)
+            return false;
+
+        hResult = OGRPG_PQexec(
+            hPGConn,
+            "SELECT has_schema_privilege('ogr_system_tables', 'USAGE')");
+        const bool bHasSchemaPrivilege =
+            (hResult && PQntuples(hResult) == 1 &&
+             !PQgetisnull(hResult, 0, 0) &&
+             strcmp(PQgetvalue(hResult, 0, 0), "t") == 0);
+        OGRPGClearResult(hResult);
+        if (!bHasSchemaPrivilege)
+        {
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "Table ogr_system_tables.metadata exists but user lacks "
+                     "USAGE privilege on ogr_system_tables schema");
+            return false;
+        }
+
+        hResult = OGRPG_PQexec(
+            hPGConn, "SELECT has_table_privilege('ogr_system_tables.metadata', "
+                     "'SELECT')");
+        m_bOgrSystemTablesMetadataTableFound =
+            (hResult && PQntuples(hResult) == 1 &&
+             !PQgetisnull(hResult, 0, 0) &&
+             strcmp(PQgetvalue(hResult, 0, 0), "t") == 0);
+        OGRPGClearResult(hResult);
+        if (!m_bOgrSystemTablesMetadataTableFound)
+        {
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "Table ogr_system_tables.metadata exists but user lacks "
+                     "SELECT privilege on it");
+        }
     }
     return m_bOgrSystemTablesMetadataTableFound;
+}
+
+/************************************************************************/
+/*                   HasWritePermissionsOnMetadataTable()               */
+/************************************************************************/
+
+bool OGRPGDataSource::HasWritePermissionsOnMetadataTable()
+{
+    if (!m_bHasWritePermissionsOnMetadataTableRun)
+    {
+        m_bHasWritePermissionsOnMetadataTableRun = true;
+
+        if (HasOgrSystemTablesMetadataTable())
+        {
+            PGresult *hResult = OGRPG_PQexec(
+                hPGConn,
+                "SELECT has_table_privilege('ogr_system_tables.metadata', "
+                "'INSERT') "
+                "AND    has_table_privilege('ogr_system_tables.metadata', "
+                "'DELETE')");
+            m_bHasWritePermissionsOnMetadataTableSuccess =
+                (hResult && PQntuples(hResult) == 1 &&
+                 !PQgetisnull(hResult, 0, 0) &&
+                 strcmp(PQgetvalue(hResult, 0, 0), "t") == 0);
+            OGRPGClearResult(hResult);
+            if (!m_bHasWritePermissionsOnMetadataTableSuccess)
+            {
+                CPLError(CE_Warning, CPLE_AppDefined,
+                         "User lacks INSERT and/OR DELETE privilege on "
+                         "ogr_system_tables.metadata table");
+            }
+        }
+    }
+    return m_bHasWritePermissionsOnMetadataTableSuccess;
 }

--- a/ogr/ogrsf_frmts/pg/ogrpgtablelayer.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgtablelayer.cpp
@@ -289,8 +289,8 @@ void OGRPGTableLayer::LoadMetadata()
 
 void OGRPGTableLayer::SerializeMetadata()
 {
-    if (!m_bMetadataModified &&
-        CPLTestBool(CPLGetConfigOption("OGR_PG_ENABLE_METADATA", "YES")))
+    if (!m_bMetadataModified ||
+        !CPLTestBool(CPLGetConfigOption("OGR_PG_ENABLE_METADATA", "YES")))
     {
         return;
     }

--- a/ogr/ogrsf_frmts/pg/ogrpgtablelayer.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgtablelayer.cpp
@@ -355,34 +355,38 @@ void OGRPGTableLayer::SerializeMetadata()
 
     if (psMD)
     {
-        poDS->CreateOgrSystemTablesMetadataTableIfNeeded();
+        if (poDS->CreateMetadataTableIfNeeded() &&
+            poDS->HasWritePermissionsOnMetadataTable())
+        {
+            CPLString osCommand;
+            osCommand.Printf("DELETE FROM ogr_system_tables.metadata WHERE "
+                             "schema_name = %s AND table_name = %s",
+                             OGRPGEscapeString(hPGConn, pszSchemaName).c_str(),
+                             OGRPGEscapeString(hPGConn, pszTableName).c_str());
+            PGresult *hResult = OGRPG_PQexec(hPGConn, osCommand.c_str());
+            OGRPGClearResult(hResult);
 
-        CPLString osCommand;
-        osCommand.Printf("DELETE FROM ogr_system_tables.metadata WHERE "
-                         "schema_name = %s AND table_name = %s",
-                         OGRPGEscapeString(hPGConn, pszSchemaName).c_str(),
-                         OGRPGEscapeString(hPGConn, pszTableName).c_str());
-        PGresult *hResult = OGRPG_PQexec(hPGConn, osCommand.c_str());
-        OGRPGClearResult(hResult);
+            CPLXMLNode *psRoot =
+                CPLCreateXMLNode(nullptr, CXT_Element, "GDALMetadata");
+            CPLAddXMLChild(psRoot, psMD);
+            char *pszXML = CPLSerializeXMLTree(psRoot);
+            // CPLDebug("PG", "Serializing %s", pszXML);
 
-        CPLXMLNode *psRoot =
-            CPLCreateXMLNode(nullptr, CXT_Element, "GDALMetadata");
-        CPLAddXMLChild(psRoot, psMD);
-        char *pszXML = CPLSerializeXMLTree(psRoot);
-        // CPLDebug("PG", "Serializing %s", pszXML);
+            osCommand.Printf(
+                "INSERT INTO ogr_system_tables.metadata (schema_name, "
+                "table_name, metadata) VALUES (%s, %s, %s)",
+                OGRPGEscapeString(hPGConn, pszSchemaName).c_str(),
+                OGRPGEscapeString(hPGConn, pszTableName).c_str(),
+                OGRPGEscapeString(hPGConn, pszXML).c_str());
+            hResult = OGRPG_PQexec(hPGConn, osCommand.c_str());
+            OGRPGClearResult(hResult);
 
-        osCommand.Printf("INSERT INTO ogr_system_tables.metadata (schema_name, "
-                         "table_name, metadata) VALUES (%s, %s, %s)",
-                         OGRPGEscapeString(hPGConn, pszSchemaName).c_str(),
-                         OGRPGEscapeString(hPGConn, pszTableName).c_str(),
-                         OGRPGEscapeString(hPGConn, pszXML).c_str());
-        hResult = OGRPG_PQexec(hPGConn, osCommand.c_str());
-        OGRPGClearResult(hResult);
-
-        CPLDestroyXMLNode(psRoot);
-        CPLFree(pszXML);
+            CPLDestroyXMLNode(psRoot);
+            CPLFree(pszXML);
+        }
     }
-    else if (poDS->HasOgrSystemTablesMetadataTable())
+    else if (poDS->HasOgrSystemTablesMetadataTable() &&
+             poDS->HasWritePermissionsOnMetadataTable())
     {
         CPLString osCommand;
         osCommand.Printf("DELETE FROM ogr_system_tables.metadata WHERE "


### PR DESCRIPTION
Backport #10004
 **Authored by:** @rouault