### PR TITLE
[Backport release/3.9] FileGDB: fix creating a geometry-less table with ogr2ogr (3.9.0 regression)

### DIFF
--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -4550,8 +4550,10 @@ SetupTargetLayer::Setup(OGRLayer *poSrcLayer, const char *pszNewLayerName,
         oGeomFieldDefn.SetSpatialRef(poOutputSRS);
         oGeomFieldDefn.SetCoordinatePrecision(oCoordPrec);
         oGeomFieldDefn.SetNullable(bGeomFieldNullable);
-        poDstLayer = m_poDstDS->CreateLayer(pszNewLayerName, &oGeomFieldDefn,
-                                            papszLCOTemp);
+        poDstLayer = m_poDstDS->CreateLayer(
+            pszNewLayerName,
+            eGCreateLayerType == wkbNone ? nullptr : &oGeomFieldDefn,
+            papszLCOTemp);
         CSLDestroy(papszLCOTemp);
 
         if (poDstLayer == nullptr)

--- a/autotest/ogr/ogr_fgdb.py
+++ b/autotest/ogr/ogr_fgdb.py
@@ -3139,3 +3139,30 @@ def test_ogr_filegdb_write_geom_coord_precision(tmp_path):
             "HighPrecision": "true",
         }
     }
+
+
+###############################################################################
+# Test dummy use of CreateLayerFromGeomFieldDefn() with a geometry field
+# definition of type wkbNone
+
+
+def test_ogr_filegdb_CreateLayerFromGeomFieldDefn_geom_type_none(tmp_path):
+
+    filename = str(tmp_path / "test.gdb")
+    ds = gdal.GetDriverByName("FileGDB").Create(filename, 0, 0, 0, gdal.GDT_Unknown)
+    geom_fld = ogr.GeomFieldDefn("geometry", ogr.wkbNone)
+    ds.CreateLayerFromGeomFieldDefn("test", geom_fld)
+    ds.Close()
+
+    ds = ogr.Open(filename)
+    lyr = ds.GetLayer(0)
+    assert lyr.GetGeomType() == ogr.wkbNone
+    ds.Close()
+
+    filename2 = str(tmp_path / "test2.gdb")
+    gdal.VectorTranslate(filename2, filename, format="FileGDB")
+
+    ds = ogr.Open(filename2)
+    lyr = ds.GetLayer(0)
+    assert lyr.GetGeomType() == ogr.wkbNone
+    ds.Close()

--- a/ogr/ogrsf_frmts/filegdb/FGdbLayer.cpp
+++ b/ogr/ogrsf_frmts/filegdb/FGdbLayer.cpp
@@ -2399,6 +2399,8 @@ bool FGdbLayer::Create(FGdbDataSource *pParentDataSource,
 
     const auto eType =
         poSrcGeomFieldDefn ? poSrcGeomFieldDefn->GetType() : wkbNone;
+    if (eType == wkbNone)
+        poSrcGeomFieldDefn = nullptr;
 
 #ifdef EXTENT_WORKAROUND
     m_bLayerJustCreated = true;


### PR DESCRIPTION
Backport #10082
 **Authored by:** @rouault