### PR TITLE
[Backport release/3.9] GML: fix issue with nested elements with identical names in GML_SKIP_RESOLVE_ELEMS=HUGE mode

### DIFF
--- a/autotest/ogr/data/gml/same_nested_property_name.gml
+++ b/autotest/ogr/data/gml/same_nested_property_name.gml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     gml:id="aFeatureCollection"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml/3.2">
+  <ogr:featureMember>
+    <ogr:test gml:id="test.0">
+      <ogr:geometryProperty><gml:Point gml:id="test.geom.0"><gml:posList>0 0</gml:posList></gml:Point></ogr:geometryProperty>
+      <ogr:foo><ogr:test>foo</ogr:test></ogr:foo>
+      <ogr:bar><ogr:test>bar</ogr:test></ogr:bar>
+    </ogr:test>
+  </ogr:featureMember>
+</ogr:FeatureCollection>

--- a/autotest/ogr/ogr_gml.py
+++ b/autotest/ogr/ogr_gml.py
@@ -1363,6 +1363,35 @@ def test_ogr_gml_38(tmp_path, resolver):
 
 
 ###############################################################################
+# Test GML_SKIP_RESOLVE_ELEMS=HUGE with a file with 2 nested identical property
+# names
+
+
+@pytest.mark.require_driver("SQLite")
+@pytest.mark.require_geos
+def test_ogr_gml_huge_resolver_same_nested_property_name(tmp_path):
+
+    shutil.copy(
+        "data/gml/same_nested_property_name.gml",
+        tmp_path,
+    )
+
+    def check_ds(ds):
+        lyr = ds.GetLayer(0)
+        f = lyr.GetNextFeature()
+        assert f["gml_id"] == "test.0"
+        assert f["test"] == "foo"
+        assert f["bar|test"] == "bar"
+
+    ds = ogr.Open(tmp_path / "same_nested_property_name.gml")
+    check_ds(ds)
+
+    with gdal.config_option("GML_SKIP_RESOLVE_ELEMS", "HUGE"):
+        ds = ogr.Open(tmp_path / "same_nested_property_name.gml")
+        check_ds(ds)
+
+
+###############################################################################
 # Test parsing XSD where simpleTypes not inlined, but defined elsewhere in the .xsd (#4328)
 
 

--- a/doc/source/drivers/vector/gml.rst
+++ b/doc/source/drivers/vector/gml.rst
@@ -623,6 +623,14 @@ Open options
       Whether to use gml:boundedBy at feature level as feature geometry,
       if there are no other geometry.
 
+
+.. note::
+
+  When changing the value of most of the above options, it is recommended to
+  delete the ``.gfs`` file if it pre-exists, otherwise mis-behavior might be
+  observed.
+
+
 Creation Issues
 ---------------
 

--- a/ogr/ogrsf_frmts/gml/gmlreaderp.h
+++ b/ogr/ogrsf_frmts/gml/gmlreaderp.h
@@ -226,6 +226,11 @@ class GMLHandler
                                     const char *pszAttributeName) = 0;
     virtual char *GetAttributeByIdx(void *attr, unsigned int idx,
                                     char **ppszKey) = 0;
+
+    GMLAppSchemaType GetAppSchemaType() const
+    {
+        return eAppSchemaType;
+    }
 };
 
 #if defined(HAVE_XERCES)

--- a/ogr/ogrsf_frmts/gml/hugefileresolver.cpp
+++ b/ogr/ogrsf_frmts/gml/hugefileresolver.cpp
@@ -1723,8 +1723,27 @@ static bool gmlHugeFileWriteResolved(huge_helper *helper,
                 {
                     char *gmlText = CPLEscapeString(
                         poProp->papszSubProperties[iSub], -1, CPLES_XML);
-                    VSIFPrintfL(fp, "      <%s>%s</%s>\n", pszPropName, gmlText,
-                                pszPropName);
+                    if (strchr(pszPropName, '|'))
+                    {
+                        const CPLStringList aosPropNameComps(
+                            CSLTokenizeString2(pszPropName, "|", 0));
+                        VSIFPrintfL(fp, "      ");
+                        for (int i = 0; i < aosPropNameComps.size(); ++i)
+                        {
+                            VSIFPrintfL(fp, "<%s>", aosPropNameComps[i]);
+                        }
+                        VSIFPrintfL(fp, "%s", gmlText);
+                        for (int i = aosPropNameComps.size() - 1; i >= 0; --i)
+                        {
+                            VSIFPrintfL(fp, "</%s>", aosPropNameComps[i]);
+                        }
+                        VSIFPrintfL(fp, "\n");
+                    }
+                    else
+                    {
+                        VSIFPrintfL(fp, "      <%s>%s</%s>\n", pszPropName,
+                                    gmlText, pszPropName);
+                    }
                     CPLFree(gmlText);
                 }
             }

--- a/ogr/ogrsf_frmts/gml/hugefileresolver.cpp
+++ b/ogr/ogrsf_frmts/gml/hugefileresolver.cpp
@@ -1701,7 +1701,15 @@ static bool gmlHugeFileWriteResolved(huge_helper *helper,
         const int iPropCount = poClass->GetPropertyCount();
 
         bool b_has_geom = false;
-        VSIFPrintfL(fp, "    <%s>\n", poClass->GetElementName());
+        VSIFPrintfL(fp, "    <%s", poClass->GetElementName());
+        const char *pszGmlId = poFeature->GetFID();
+        if (pszGmlId)
+        {
+            char *gmlText = CPLEscapeString(pszGmlId, -1, CPLES_XML);
+            VSIFPrintfL(fp, " gml:id=\"%s\"", gmlText);
+            CPLFree(gmlText);
+        }
+        VSIFPrintfL(fp, ">\n");
 
         for (int iProp = 0; iProp < iPropCount; iProp++)
         {

--- a/ogr/ogrsf_frmts/gml/ogrgmldatasource.cpp
+++ b/ogr/ogrsf_frmts/gml/ogrgmldatasource.cpp
@@ -850,7 +850,8 @@ bool OGRGMLDataSource::Open(GDALOpenInfo *poOpenInfo)
     }
 
     // Can we find a GML Feature Schema (.gfs) for the input file?
-    if (!osGFSFilename.empty() && !bHaveSchema && osXSDFilename.empty())
+    if (!osGFSFilename.empty() && !bHaveSchema && !bSchemaDone &&
+        osXSDFilename.empty())
     {
         VSIStatBufL sGFSStatBuf;
         if (bCheckAuxFile && VSIStatL(osGFSFilename, &sGFSStatBuf) == 0)


### PR DESCRIPTION
Backport #10040
 **Authored by:** @rouault