### PR TITLE
GeoJSON/GeoJSONSeq/TopoJSON/ESRIJSON/JSONFG: relax identification checks 

### DIFF
--- a/autotest/ogr/data/geojson/feature_with_type_Topology_property.json
+++ b/autotest/ogr/data/geojson/feature_with_type_Topology_property.json
@@ -1,0 +1,7 @@
+{
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:EPSG::27700" } },
+"features": [
+{ "properties": { "type": "Topology" }, "geometry": null, "type": "Feature" }
+],
+"type": "FeatureCollection"
+}

--- a/autotest/ogr/data/geojson/point_with_utf8bom.json
+++ b/autotest/ogr/data/geojson/point_with_utf8bom.json
@@ -1,1 +1,1 @@
-﻿{ "geometry": { "type": "Point", "coordinates": [ 100.0, 0.0 ] } }
+﻿{ "geometry": { "type": "Point", "coordinates": [ 100.0, 0.0 ] }, "type": "Feature" }

--- a/autotest/ogr/ogr_esrijson.py
+++ b/autotest/ogr/ogr_esrijson.py
@@ -704,3 +704,34 @@ def test_ogr_esrijson_read_CadastralSpecialServices():
     f = lyr.GetNextFeature()
     assert f["landdescription"] == "WA330160N0260E0SN070"
     assert f.GetGeometryRef().GetGeometryType() == ogr.wkbPolygon
+
+
+###############################################################################
+# Test force opening a ESRIJSON file
+
+
+def test_ogr_esrijson_force_opening(tmp_vsimem):
+
+    filename = str(tmp_vsimem / "test.json")
+
+    with open("data/esrijson/esripoint.json", "rb") as fsrc:
+        with gdaltest.vsi_open(filename, "wb") as fdest:
+            fdest.write(fsrc.read(1))
+            fdest.write(b" " * (1000 * 1000))
+            fdest.write(fsrc.read())
+
+    with pytest.raises(Exception):
+        gdal.OpenEx(filename)
+
+    ds = gdal.OpenEx(filename, allowed_drivers=["ESRIJSON"])
+    assert ds.GetDriver().GetDescription() == "ESRIJSON"
+
+
+###############################################################################
+# Test force opening a URL as ESRIJSON
+
+
+def test_ogr_esrijson_force_opening_url():
+
+    drv = gdal.IdentifyDriverEx("http://example.com", allowed_drivers=["ESRIJSON"])
+    assert drv.GetDescription() == "ESRIJSON"

--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -5201,3 +5201,13 @@ def test_ogr_geojson_identify_jsonfg_with_geojson():
             "data/jsonfg/crs_none.json", allowed_drivers=["GeoJSON", "JSONFG"]
         )
         assert drv.GetDescription() == "JSONFG"
+
+
+###############################################################################
+# Test opening a file that has a "type: "Topology" feature property
+
+
+def test_ogr_geojson_feature_with_type_Topology_property():
+
+    ds = gdal.OpenEx("data/geojson/feature_with_type_Topology_property.json")
+    assert ds.GetDriver().GetDescription() == "GeoJSON"

--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -5211,3 +5211,42 @@ def test_ogr_geojson_feature_with_type_Topology_property():
 
     ds = gdal.OpenEx("data/geojson/feature_with_type_Topology_property.json")
     assert ds.GetDriver().GetDescription() == "GeoJSON"
+
+
+###############################################################################
+# Test force opening a GeoJSON file
+
+
+def test_ogr_geojson_force_opening(tmp_vsimem):
+
+    filename = str(tmp_vsimem / "test.json")
+
+    with gdaltest.vsi_open(filename, "wb") as f:
+        f.write(
+            b"{"
+            + b" " * (1000 * 1000)
+            + b' "type": "FeatureCollection", "features":[]}'
+        )
+
+    with pytest.raises(Exception):
+        gdal.OpenEx(filename)
+
+    ds = gdal.OpenEx(filename, allowed_drivers=["GeoJSON"])
+    assert ds.GetDriver().GetDescription() == "GeoJSON"
+
+    drv = gdal.IdentifyDriverEx("http://example.com", allowed_drivers=["GeoJSON"])
+    assert drv.GetDescription() == "GeoJSON"
+
+
+###############################################################################
+# Test force opening a STACTA file with GeoJSON
+
+
+def test_ogr_geojson_force_opening_stacta():
+
+    if gdal.GetDriverByName("STACTA"):
+        ds = gdal.OpenEx("../gdrivers/data/stacta/test.json")
+        assert ds.GetDriver().GetDescription() == "STACTA"
+
+    ds = gdal.OpenEx("../gdrivers/data/stacta/test.json", allowed_drivers=["GeoJSON"])
+    assert ds.GetDriver().GetDescription() == "GeoJSON"

--- a/autotest/ogr/ogr_geojsonseq.py
+++ b/autotest/ogr/ogr_geojsonseq.py
@@ -490,3 +490,28 @@ def test_ogr_geojsonseq_geom_coord_precision_not_4326(tmp_vsimem):
     gdal.VSIFCloseL(f)
 
     assert b'"coordinates": [ 2.363925, 45.151706, 9.877 ]' in data
+
+
+###############################################################################
+# Test force opening a GeoJSONSeq file
+
+
+def test_ogr_geojsonseq_force_opening(tmp_vsimem):
+
+    filename = str(tmp_vsimem / "test.json")
+
+    with gdaltest.vsi_open(filename, "wb") as f:
+        f.write(
+            b"{"
+            + b" " * (1000 * 1000)
+            + b' "type": "Feature", "properties":{},"geometry":null}\n'
+        )
+
+    with pytest.raises(Exception):
+        gdal.OpenEx(filename)
+
+    ds = gdal.OpenEx(filename, allowed_drivers=["GeoJSONSeq"])
+    assert ds.GetDriver().GetDescription() == "GeoJSONSeq"
+
+    drv = gdal.IdentifyDriverEx("http://example.com", allowed_drivers=["GeoJSONSeq"])
+    assert drv.GetDescription() == "GeoJSONSeq"

--- a/autotest/ogr/ogr_jsonfg.py
+++ b/autotest/ogr/ogr_jsonfg.py
@@ -1292,3 +1292,27 @@ def test_ogr_jsonfg_geom_coord_precision(tmp_vsimem, single_layer):
     prec = geom_fld.GetCoordinatePrecision()
     assert prec.GetXYResolution() == 1e-2
     assert prec.GetZResolution() == 1e-3
+
+
+###############################################################################
+# Test force opening a GeoJSON file with JSONFG
+
+
+def test_ogr_jsonfg_force_opening():
+
+    if ogr.GetDriverByName("GeoJSON"):
+        ds = gdal.OpenEx("data/geojson/featuretype.json")
+        assert ds.GetDriver().GetDescription() == "GeoJSON"
+
+    ds = gdal.OpenEx("data/geojson/featuretype.json", allowed_drivers=["JSONFG"])
+    assert ds.GetDriver().GetDescription() == "JSONFG"
+
+
+###############################################################################
+# Test force opening a URL as JSONFG
+
+
+def test_ogr_jsonfg_force_opening_url():
+
+    drv = gdal.IdentifyDriverEx("http://example.com", allowed_drivers=["JSONFG"])
+    assert drv.GetDescription() == "JSONFG"

--- a/doc/source/drivers/vector/esrijson.rst
+++ b/doc/source/drivers/vector/esrijson.rst
@@ -49,7 +49,12 @@ The driver accepts three types of sources of data:
 -  Text passed directly and encoded in ESRI JSON
 
 Starting with GDAL 2.3, the URL/filename/text might be prefixed with
-ESRIJSON: to avoid any ambiguity with other drivers.
+ESRIJSON: to avoid any ambiguity with other drivers. Alternatively, starting
+with GDAL 3.10, specifying the ``-if ESRIJSON`` option to command line utilities
+accepting it, or ``ESRIJSON`` as the only value of the ``papszAllowedDrivers`` of
+:cpp:func:`GDALOpenEx`, also forces the driver to recognize the passed
+URL/filename/text.
+
 
 Open options
 ------------

--- a/doc/source/drivers/vector/geojson.rst
+++ b/doc/source/drivers/vector/geojson.rst
@@ -48,7 +48,11 @@ The OGR GeoJSON driver accepts three types of sources of data:
 -  Text passed directly and encoded in GeoJSON
 
 Starting with GDAL 2.3, the URL/filename/text might be prefixed with
-GeoJSON: to avoid any ambiguity with other drivers.
+GeoJSON: to avoid any ambiguity with other drivers. Alternatively, starting
+with GDAL 3.10, specifying the ``-if GeoJSON`` option to command line utilities
+accepting it, or ``GeoJSON`` as the only value of the ``papszAllowedDrivers`` of
+:cpp:func:`GDALOpenEx`, also forces the driver to recognize the passed
+URL/filename/text.
 
 Layer
 -----

--- a/doc/source/drivers/vector/geojsonseq.rst
+++ b/doc/source/drivers/vector/geojsonseq.rst
@@ -46,7 +46,11 @@ The driver accepts three types of sources of data:
 -  Text passed directly as filename, and encoded as GeoJSON sequences
 
 The URL/filename/text might be prefixed with GeoJSONSeq: to avoid any
-ambiguity with other drivers.
+ambiguity with other drivers. Alternatively, starting
+with GDAL 3.10, specifying the ``-if GeoJSONSeq`` option to command line utilities
+accepting it, or ``GeoJSONSeq`` as the only value of the ``papszAllowedDrivers`` of
+:cpp:func:`GDALOpenEx`, also forces the driver to recognize the passed
+URL/filename/text.
 
 Configuration options
 ---------------------
@@ -103,7 +107,7 @@ The following layer creation options are supported:
       :since: 3.8
 
       Whether to write
-      NaN / Infinity values. Such values are not allowed in strict JSON 
+      NaN / Infinity values. Such values are not allowed in strict JSON
       mode, but some JSON parsers (libjson-c >= 0.12 for example) can
       understand them as they are allowed by ECMAScript.
 

--- a/doc/source/drivers/vector/jsonfg.rst
+++ b/doc/source/drivers/vector/jsonfg.rst
@@ -50,7 +50,11 @@ The JSON-FG driver accepts three types of sources of data:
 -  Text passed directly and encoded in JSON-FG
 
 The URL/filename/text might be prefixed with
-``JSONFG:`` to avoid any ambiguity with other drivers.
+``JSONFG:`` to avoid any ambiguity with other drivers. Alternatively, starting
+with GDAL 3.10, specifying the ``-if JSONFG`` option to command line utilities
+accepting it, or ``JSONFG`` as the only value of the ``papszAllowedDrivers`` of
+:cpp:func:`GDALOpenEx`, also forces the driver to recognize the passed
+URL/filename/text.
 
 Time support
 ------------

--- a/doc/source/drivers/vector/topojson.rst
+++ b/doc/source/drivers/vector/topojson.rst
@@ -33,7 +33,11 @@ The driver accepts three types of sources of data:
 -  Text passed directly and encoded in Topo JSON
 
 Starting with GDAL 2.3, the URL/filename/text might be prefixed with
-TopoJSON: to avoid any ambiguity with other drivers.
+TopoJSON: to avoid any ambiguity with other drivers. Alternatively, starting
+with GDAL 3.10, specifying the ``-if TopoJSON`` option to command line utilities
+accepting it, or ``TopoJSON`` as the only value of the ``papszAllowedDrivers`` of
+:cpp:func:`GDALOpenEx`, also forces the driver to recognize the passed
+URL/filename/text.
 
 See Also
 --------

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -339,6 +339,8 @@ class CPL_DLL GDALOpenInfo
     char **StealSiblingFiles();
     bool AreSiblingFilesLoaded() const;
 
+    bool IsSingleAllowedDriver(const char *pszDriverName) const;
+
   private:
     CPL_DISALLOW_COPY_ASSIGN(GDALOpenInfo)
 };

--- a/gcore/gdalopeninfo.cpp
+++ b/gcore/gdalopeninfo.cpp
@@ -487,3 +487,22 @@ int GDALOpenInfo::TryToIngest(int nBytes)
 
     return TRUE;
 }
+
+/************************************************************************/
+/*                       IsSingleAllowedDriver()                        */
+/************************************************************************/
+
+/** Returns true if the driver name is the single in the list of allowed
+ * drivers.
+ *
+ * @param pszDriverName Driver name to test.
+ * @return true if the driver name is the single in the list of allowed
+ * drivers.
+ * @since GDAL 3.10
+ */
+bool GDALOpenInfo::IsSingleAllowedDriver(const char *pszDriverName) const
+{
+    return papszAllowedDrivers && papszAllowedDrivers[0] &&
+           !papszAllowedDrivers[1] &&
+           EQUAL(papszAllowedDrivers[0], pszDriverName);
+}

--- a/ogr/ogrsf_frmts/geojson/ogresrijsondriver.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogresrijsondriver.cpp
@@ -48,10 +48,14 @@ static int OGRESRIJSONDriverIdentify(GDALOpenInfo *poOpenInfo)
     GeoJSONSourceType nSrcType = ESRIJSONDriverGetSourceType(poOpenInfo);
     if (nSrcType == eGeoJSONSourceUnknown)
         return FALSE;
-    if (nSrcType == eGeoJSONSourceService &&
-        !STARTS_WITH_CI(poOpenInfo->pszFilename, "ESRIJSON:"))
+    if (nSrcType == eGeoJSONSourceService)
     {
-        return -1;
+        if (poOpenInfo->IsSingleAllowedDriver("ESRIJSON"))
+            return TRUE;
+        if (!STARTS_WITH_CI(poOpenInfo->pszFilename, "ESRIJSON:"))
+        {
+            return -1;
+        }
     }
     return TRUE;
 }

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsondatasource.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsondatasource.cpp
@@ -815,8 +815,9 @@ int OGRGeoJSONDataSource::ReadFromService(GDALOpenInfo *poOpenInfo,
     if (pszStoredContent != nullptr)
     {
         if ((osJSonFlavor_ == "ESRIJSON" &&
-             ESRIJSONIsObject(pszStoredContent)) ||
-            (osJSonFlavor_ == "TopoJSON" && TopoJSONIsObject(pszStoredContent)))
+             ESRIJSONIsObject(pszStoredContent, poOpenInfo)) ||
+            (osJSonFlavor_ == "TopoJSON" &&
+             TopoJSONIsObject(pszStoredContent, poOpenInfo)))
         {
             pszGeoData_ = pszStoredContent;
             nGeoDataLen_ = strlen(pszGeoData_);
@@ -882,11 +883,12 @@ int OGRGeoJSONDataSource::ReadFromService(GDALOpenInfo *poOpenInfo,
     /* -------------------------------------------------------------------- */
     if (EQUAL(pszSource, poOpenInfo->pszFilename) && osJSonFlavor_ == "GeoJSON")
     {
-        if (!GeoJSONIsObject(pszGeoData_, poOpenInfo->papszAllowedDrivers))
+        if (!GeoJSONIsObject(pszGeoData_, poOpenInfo))
         {
-            if (ESRIJSONIsObject(pszGeoData_) ||
-                TopoJSONIsObject(pszGeoData_) ||
-                GeoJSONSeqIsObject(pszGeoData_) || JSONFGIsObject(pszGeoData_))
+            if (ESRIJSONIsObject(pszGeoData_, poOpenInfo) ||
+                TopoJSONIsObject(pszGeoData_, poOpenInfo) ||
+                GeoJSONSeqIsObject(pszGeoData_, poOpenInfo) ||
+                JSONFGIsObject(pszGeoData_, poOpenInfo))
             {
                 OGRGeoJSONDriverStoreContent(pszSource, pszGeoData_);
                 pszGeoData_ = nullptr;
@@ -1003,7 +1005,7 @@ void OGRGeoJSONDataSource::LoadLayers(GDALOpenInfo *poOpenInfo,
         oOpenInfo.fpL = nullptr;
     }
 
-    if (!GeoJSONIsObject(pszGeoData_, poOpenInfo->papszAllowedDrivers))
+    if (!GeoJSONIsObject(pszGeoData_, poOpenInfo))
     {
         CPLDebug(pszJSonFlavor, "No valid %s data found in source '%s'",
                  pszJSonFlavor, pszName_);

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsondriver.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsondriver.cpp
@@ -484,10 +484,15 @@ static int OGRGeoJSONDriverIdentifyInternal(GDALOpenInfo *poOpenInfo,
 
         return FALSE;
     }
-    if (nSrcType == eGeoJSONSourceService &&
-        !STARTS_WITH_CI(poOpenInfo->pszFilename, "GeoJSON:"))
+
+    if (nSrcType == eGeoJSONSourceService)
     {
-        return -1;
+        if (poOpenInfo->IsSingleAllowedDriver("GeoJSON"))
+            return TRUE;
+        if (!STARTS_WITH_CI(poOpenInfo->pszFilename, "GeoJSON:"))
+        {
+            return -1;
+        }
     }
 
     // If this looks like a file that can be handled by the STACTA driver,
@@ -499,6 +504,8 @@ static int OGRGeoJSONDriverIdentifyInternal(GDALOpenInfo *poOpenInfo,
         strstr(pszHeader, "\"tiled-assets\"") != nullptr &&
         GDALGetDriverByName("STACTA") != nullptr)
     {
+        if (poOpenInfo->IsSingleAllowedDriver("GeoJSON"))
+            return TRUE;
         return FALSE;
     }
 

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonseqdriver.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonseqdriver.cpp
@@ -831,7 +831,7 @@ bool OGRGeoJSONSeqDataSource::Open(GDALOpenInfo *poOpenInfo,
             OGRGeoJSONDriverStealStoredContent(pszUnprefixedFilename);
         if (pszStoredContent)
         {
-            if (!GeoJSONSeqIsObject(pszStoredContent))
+            if (!GeoJSONSeqIsObject(pszStoredContent, poOpenInfo))
             {
                 OGRGeoJSONDriverStoreContent(poOpenInfo->pszFilename,
                                              pszStoredContent);
@@ -953,10 +953,14 @@ static int OGRGeoJSONSeqDriverIdentifyInternal(GDALOpenInfo *poOpenInfo,
     nSrcType = GeoJSONSeqGetSourceType(poOpenInfo);
     if (nSrcType == eGeoJSONSourceUnknown)
         return FALSE;
-    if (nSrcType == eGeoJSONSourceService &&
-        !STARTS_WITH_CI(poOpenInfo->pszFilename, "GeoJSONSeq:"))
+    if (nSrcType == eGeoJSONSourceService)
     {
-        return -1;
+        if (poOpenInfo->IsSingleAllowedDriver("GeoJSONSeq"))
+            return TRUE;
+        if (!STARTS_WITH_CI(poOpenInfo->pszFilename, "GeoJSONSeq:"))
+        {
+            return -1;
+        }
     }
     return TRUE;
 }

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonutils.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonutils.cpp
@@ -210,8 +210,8 @@ static CPLString GetCompactJSon(const char *pszText, size_t nMaxSize)
 /************************************************************************/
 
 static bool IsGeoJSONLikeObject(const char *pszText, bool &bMightBeSequence,
-                                bool &bReadMoreBytes,
-                                CSLConstList papszAllowedDrivers)
+                                bool &bReadMoreBytes, GDALOpenInfo *poOpenInfo,
+                                const char *pszExpectedDriverName)
 {
     bMightBeSequence = false;
     bReadMoreBytes = false;
@@ -223,9 +223,15 @@ static bool IsGeoJSONLikeObject(const char *pszText, bool &bMightBeSequence,
     if (osTopLevelType == "Topology")
         return false;
 
-    if ((!papszAllowedDrivers ||
-         CSLFindString(papszAllowedDrivers, "JSONFG") >= 0) &&
-        GDALGetDriverByName("JSONFG") && JSONFGIsObject(pszText))
+    if (poOpenInfo->IsSingleAllowedDriver(pszExpectedDriverName) &&
+        GDALGetDriverByName(pszExpectedDriverName))
+    {
+        return true;
+    }
+
+    if ((!poOpenInfo->papszAllowedDrivers ||
+         CSLFindString(poOpenInfo->papszAllowedDrivers, "JSONFG") >= 0) &&
+        GDALGetDriverByName("JSONFG") && JSONFGIsObject(pszText, poOpenInfo))
     {
         return false;
     }
@@ -251,7 +257,7 @@ static bool IsGeoJSONLikeObject(const char *pszText, bool &bMightBeSequence,
     // "{"bbox":...,"features":[..."
     if (osWithoutSpace.find(",\"features\":[") != std::string::npos)
     {
-        return !ESRIJSONIsObject(pszText);
+        return !ESRIJSONIsObject(pszText, poOpenInfo);
     }
 
     // See https://github.com/OSGeo/gdal/issues/2720
@@ -283,22 +289,29 @@ static bool IsGeoJSONLikeObject(const char *pszText, bool &bMightBeSequence,
     return false;
 }
 
-static bool IsGeoJSONLikeObject(const char *pszText)
+static bool IsGeoJSONLikeObject(const char *pszText, GDALOpenInfo *poOpenInfo,
+                                const char *pszExpectedDriverName)
 {
     bool bMightBeSequence;
     bool bReadMoreBytes;
     return IsGeoJSONLikeObject(pszText, bMightBeSequence, bReadMoreBytes,
-                               nullptr);
+                               poOpenInfo, pszExpectedDriverName);
 }
 
 /************************************************************************/
 /*                       ESRIJSONIsObject()                             */
 /************************************************************************/
 
-bool ESRIJSONIsObject(const char *pszText)
+bool ESRIJSONIsObject(const char *pszText, GDALOpenInfo *poOpenInfo)
 {
     if (!IsJSONObject(pszText))
         return false;
+
+    if (poOpenInfo->IsSingleAllowedDriver("ESRIJSON") &&
+        GDALGetDriverByName("ESRIJSON"))
+    {
+        return true;
+    }
 
     if (  // ESRI Json geometry
         (strstr(pszText, "\"geometryType\"") != nullptr &&
@@ -330,10 +343,16 @@ bool ESRIJSONIsObject(const char *pszText)
 /*                       TopoJSONIsObject()                             */
 /************************************************************************/
 
-bool TopoJSONIsObject(const char *pszText)
+bool TopoJSONIsObject(const char *pszText, GDALOpenInfo *poOpenInfo)
 {
     if (!IsJSONObject(pszText))
         return false;
+
+    if (poOpenInfo->IsSingleAllowedDriver("TopoJSON") &&
+        GDALGetDriverByName("TopoJSON"))
+    {
+        return true;
+    }
 
     return GetTopLevelType(pszText) == "Topology";
 }
@@ -342,9 +361,9 @@ bool TopoJSONIsObject(const char *pszText)
 /*                      IsLikelyNewlineSequenceGeoJSON()                */
 /************************************************************************/
 
-static bool IsLikelyNewlineSequenceGeoJSON(VSILFILE *fpL,
-                                           const GByte *pabyHeader,
-                                           const char *pszFileContent)
+static GDALIdentifyEnum
+IsLikelyNewlineSequenceGeoJSON(VSILFILE *fpL, const GByte *pabyHeader,
+                               const char *pszFileContent)
 {
     const size_t nBufferSize = 4096 * 10;
     std::vector<GByte> abyBuffer;
@@ -353,7 +372,6 @@ static bool IsLikelyNewlineSequenceGeoJSON(VSILFILE *fpL,
     int nCurlLevel = 0;
     bool bInString = false;
     bool bLastIsEscape = false;
-    bool bCompatibleOfSequence = true;
     bool bFirstIter = true;
     bool bEOLFound = false;
     int nCountObject = 0;
@@ -399,8 +417,7 @@ static bool IsLikelyNewlineSequenceGeoJSON(VSILFILE *fpL,
                 }
                 else if (!isspace(static_cast<unsigned char>(abyBuffer[i])))
                 {
-                    bCompatibleOfSequence = false;
-                    break;
+                    return GDAL_IDENTIFY_FALSE;
                 }
             }
             else if (bInString)
@@ -431,10 +448,12 @@ static bool IsLikelyNewlineSequenceGeoJSON(VSILFILE *fpL,
                 nCurlLevel--;
             }
         }
-        if (!fpL || bEnd || !bCompatibleOfSequence || nCountObject == 2)
+        if (!fpL || bEnd || nCountObject == 2)
             break;
     }
-    return bCompatibleOfSequence && bEOLFound && nCountObject == 2;
+    if (bEOLFound && nCountObject == 2)
+        return GDAL_IDENTIFY_TRUE;
+    return GDAL_IDENTIFY_UNKNOWN;
 }
 
 /************************************************************************/
@@ -456,40 +475,40 @@ static bool GeoJSONFileIsObject(GDALOpenInfo *poOpenInfo)
     bool bReadMoreBytes = false;
     if (!IsGeoJSONLikeObject(
             reinterpret_cast<const char *>(poOpenInfo->pabyHeader),
-            bMightBeSequence, bReadMoreBytes, poOpenInfo->papszAllowedDrivers))
+            bMightBeSequence, bReadMoreBytes, poOpenInfo, "GeoJSON"))
     {
         if (!(bReadMoreBytes && poOpenInfo->nHeaderBytes >= 6000 &&
               poOpenInfo->TryToIngest(1000 * 1000) &&
               !IsGeoJSONLikeObject(
                   reinterpret_cast<const char *>(poOpenInfo->pabyHeader),
-                  bMightBeSequence, bReadMoreBytes,
-                  poOpenInfo->papszAllowedDrivers)))
+                  bMightBeSequence, bReadMoreBytes, poOpenInfo, "GeoJSON")))
         {
             return false;
         }
     }
 
-    return !(bMightBeSequence &&
-             IsLikelyNewlineSequenceGeoJSON(poOpenInfo->fpL,
-                                            poOpenInfo->pabyHeader, nullptr));
+    return !(bMightBeSequence && IsLikelyNewlineSequenceGeoJSON(
+                                     poOpenInfo->fpL, poOpenInfo->pabyHeader,
+                                     nullptr) == GDAL_IDENTIFY_TRUE);
 }
 
 /************************************************************************/
 /*                           GeoJSONIsObject()                          */
 /************************************************************************/
 
-bool GeoJSONIsObject(const char *pszText, CSLConstList papszAllowedDrivers)
+bool GeoJSONIsObject(const char *pszText, GDALOpenInfo *poOpenInfo)
 {
     bool bMightBeSequence = false;
     bool bReadMoreBytes = false;
     if (!IsGeoJSONLikeObject(pszText, bMightBeSequence, bReadMoreBytes,
-                             papszAllowedDrivers))
+                             poOpenInfo, "GeoJSON"))
     {
         return false;
     }
 
     return !(bMightBeSequence &&
-             IsLikelyNewlineSequenceGeoJSON(nullptr, nullptr, pszText));
+             IsLikelyNewlineSequenceGeoJSON(nullptr, nullptr, pszText) ==
+                 GDAL_IDENTIFY_TRUE);
 }
 
 /************************************************************************/
@@ -510,44 +529,60 @@ static bool GeoJSONSeqFileIsObject(GDALOpenInfo *poOpenInfo)
     const char *pszText =
         reinterpret_cast<const char *>(poOpenInfo->pabyHeader);
     if (pszText[0] == '\x1e')
-        return IsGeoJSONLikeObject(pszText + 1);
+        return IsGeoJSONLikeObject(pszText + 1, poOpenInfo, "GeoJSONSeq");
 
     bool bMightBeSequence = false;
     bool bReadMoreBytes = false;
     if (!IsGeoJSONLikeObject(pszText, bMightBeSequence, bReadMoreBytes,
-                             poOpenInfo->papszAllowedDrivers))
+                             poOpenInfo, "GeoJSONSeq"))
     {
         if (!(bReadMoreBytes && poOpenInfo->nHeaderBytes >= 6000 &&
               poOpenInfo->TryToIngest(1000 * 1000) &&
               IsGeoJSONLikeObject(
                   reinterpret_cast<const char *>(poOpenInfo->pabyHeader),
-                  bMightBeSequence, bReadMoreBytes,
-                  poOpenInfo->papszAllowedDrivers)))
+                  bMightBeSequence, bReadMoreBytes, poOpenInfo, "GeoJSONSeq")))
         {
             return false;
         }
     }
 
-    return bMightBeSequence &&
-           IsLikelyNewlineSequenceGeoJSON(poOpenInfo->fpL,
-                                          poOpenInfo->pabyHeader, nullptr);
+    if (poOpenInfo->IsSingleAllowedDriver("GeoJSONSeq") &&
+        IsLikelyNewlineSequenceGeoJSON(poOpenInfo->fpL, poOpenInfo->pabyHeader,
+                                       nullptr) != GDAL_IDENTIFY_FALSE &&
+        GDALGetDriverByName("GeoJSONSeq"))
+    {
+        return true;
+    }
+
+    return bMightBeSequence && IsLikelyNewlineSequenceGeoJSON(
+                                   poOpenInfo->fpL, poOpenInfo->pabyHeader,
+                                   nullptr) == GDAL_IDENTIFY_TRUE;
 }
 
-bool GeoJSONSeqIsObject(const char *pszText)
+bool GeoJSONSeqIsObject(const char *pszText, GDALOpenInfo *poOpenInfo)
 {
     if (pszText[0] == '\x1e')
-        return IsGeoJSONLikeObject(pszText + 1);
+        return IsGeoJSONLikeObject(pszText + 1, poOpenInfo, "GeoJSONSeq");
 
     bool bMightBeSequence = false;
     bool bReadMoreBytes = false;
     if (!IsGeoJSONLikeObject(pszText, bMightBeSequence, bReadMoreBytes,
-                             nullptr))
+                             poOpenInfo, "GeoJSONSeq"))
     {
         return false;
     }
 
+    if (poOpenInfo->IsSingleAllowedDriver("GeoJSONSeq") &&
+        IsLikelyNewlineSequenceGeoJSON(nullptr, nullptr, pszText) !=
+            GDAL_IDENTIFY_FALSE &&
+        GDALGetDriverByName("GeoJSONSeq"))
+    {
+        return true;
+    }
+
     return bMightBeSequence &&
-           IsLikelyNewlineSequenceGeoJSON(nullptr, nullptr, pszText);
+           IsLikelyNewlineSequenceGeoJSON(nullptr, nullptr, pszText) ==
+               GDAL_IDENTIFY_TRUE;
 }
 
 /************************************************************************/
@@ -564,13 +599,19 @@ static bool JSONFGFileIsObject(GDALOpenInfo *poOpenInfo)
 
     const char *pszText =
         reinterpret_cast<const char *>(poOpenInfo->pabyHeader);
-    return JSONFGIsObject(pszText);
+    return JSONFGIsObject(pszText, poOpenInfo);
 }
 
-bool JSONFGIsObject(const char *pszText)
+bool JSONFGIsObject(const char *pszText, GDALOpenInfo *poOpenInfo)
 {
     if (!IsJSONObject(pszText))
         return false;
+
+    if (poOpenInfo->IsSingleAllowedDriver("JSONFG") &&
+        GDALGetDriverByName("JSONFG"))
+    {
+        return true;
+    }
 
     const std::string osWithoutSpace = GetCompactJSon(pszText, strlen(pszText));
 
@@ -707,6 +748,10 @@ GeoJSONSourceType GeoJSONGetSourceType(GDALOpenInfo *poOpenInfo)
              STARTS_WITH_CI(poOpenInfo->pszFilename, "https://") ||
              STARTS_WITH_CI(poOpenInfo->pszFilename, "ftp://"))
     {
+        if (poOpenInfo->IsSingleAllowedDriver("GeoJSON"))
+        {
+            return eGeoJSONSourceService;
+        }
         if ((strstr(poOpenInfo->pszFilename, "SERVICE=WFS") ||
              strstr(poOpenInfo->pszFilename, "service=WFS") ||
              strstr(poOpenInfo->pszFilename, "service=wfs")) &&
@@ -728,12 +773,11 @@ GeoJSONSourceType GeoJSONGetSourceType(GDALOpenInfo *poOpenInfo)
             return eGeoJSONSourceFile;
         }
         const char *pszText = poOpenInfo->pszFilename + strlen("GeoJSON:");
-        if (GeoJSONIsObject(pszText, poOpenInfo->papszAllowedDrivers))
+        if (GeoJSONIsObject(pszText, poOpenInfo))
             return eGeoJSONSourceText;
         return eGeoJSONSourceUnknown;
     }
-    else if (GeoJSONIsObject(poOpenInfo->pszFilename,
-                             poOpenInfo->papszAllowedDrivers))
+    else if (GeoJSONIsObject(poOpenInfo->pszFilename, poOpenInfo))
     {
         srcType = eGeoJSONSourceText;
     }
@@ -761,6 +805,10 @@ GeoJSONSourceType ESRIJSONDriverGetSourceType(GDALOpenInfo *poOpenInfo)
              STARTS_WITH(poOpenInfo->pszFilename, "https://") ||
              STARTS_WITH(poOpenInfo->pszFilename, "ftp://"))
     {
+        if (poOpenInfo->IsSingleAllowedDriver("ESRIJSON"))
+        {
+            return eGeoJSONSourceService;
+        }
         if (IsLikelyESRIJSONURL(poOpenInfo->pszFilename))
         {
             return eGeoJSONSourceService;
@@ -777,7 +825,7 @@ GeoJSONSourceType ESRIJSONDriverGetSourceType(GDALOpenInfo *poOpenInfo)
             return eGeoJSONSourceFile;
         }
         const char *pszText = poOpenInfo->pszFilename + strlen("ESRIJSON:");
-        if (ESRIJSONIsObject(pszText))
+        if (ESRIJSONIsObject(pszText, poOpenInfo))
             return eGeoJSONSourceText;
         return eGeoJSONSourceUnknown;
     }
@@ -785,7 +833,7 @@ GeoJSONSourceType ESRIJSONDriverGetSourceType(GDALOpenInfo *poOpenInfo)
     if (poOpenInfo->fpL == nullptr)
     {
         const char *pszText = poOpenInfo->pszFilename;
-        if (ESRIJSONIsObject(pszText))
+        if (ESRIJSONIsObject(pszText, poOpenInfo))
             return eGeoJSONSourceText;
         return eGeoJSONSourceUnknown;
     }
@@ -799,8 +847,8 @@ GeoJSONSourceType ESRIJSONDriverGetSourceType(GDALOpenInfo *poOpenInfo)
     }
 
     if (poOpenInfo->pabyHeader != nullptr &&
-        ESRIJSONIsObject(
-            reinterpret_cast<const char *>(poOpenInfo->pabyHeader)))
+        ESRIJSONIsObject(reinterpret_cast<const char *>(poOpenInfo->pabyHeader),
+                         poOpenInfo))
     {
         return eGeoJSONSourceFile;
     }
@@ -823,6 +871,10 @@ GeoJSONSourceType TopoJSONDriverGetSourceType(GDALOpenInfo *poOpenInfo)
              STARTS_WITH(poOpenInfo->pszFilename, "https://") ||
              STARTS_WITH(poOpenInfo->pszFilename, "ftp://"))
     {
+        if (poOpenInfo->IsSingleAllowedDriver("TOPOJSON"))
+        {
+            return eGeoJSONSourceService;
+        }
         if (IsLikelyESRIJSONURL(poOpenInfo->pszFilename))
         {
             return eGeoJSONSourceUnknown;
@@ -839,7 +891,7 @@ GeoJSONSourceType TopoJSONDriverGetSourceType(GDALOpenInfo *poOpenInfo)
             return eGeoJSONSourceFile;
         }
         const char *pszText = poOpenInfo->pszFilename + strlen("TopoJSON:");
-        if (TopoJSONIsObject(pszText))
+        if (TopoJSONIsObject(pszText, poOpenInfo))
             return eGeoJSONSourceText;
         return eGeoJSONSourceUnknown;
     }
@@ -847,7 +899,7 @@ GeoJSONSourceType TopoJSONDriverGetSourceType(GDALOpenInfo *poOpenInfo)
     if (poOpenInfo->fpL == nullptr)
     {
         const char *pszText = poOpenInfo->pszFilename;
-        if (TopoJSONIsObject(pszText))
+        if (TopoJSONIsObject(pszText, poOpenInfo))
             return eGeoJSONSourceText;
         return eGeoJSONSourceUnknown;
     }
@@ -861,8 +913,8 @@ GeoJSONSourceType TopoJSONDriverGetSourceType(GDALOpenInfo *poOpenInfo)
     }
 
     if (poOpenInfo->pabyHeader != nullptr &&
-        TopoJSONIsObject(
-            reinterpret_cast<const char *>(poOpenInfo->pabyHeader)))
+        TopoJSONIsObject(reinterpret_cast<const char *>(poOpenInfo->pabyHeader),
+                         poOpenInfo))
     {
         return eGeoJSONSourceFile;
     }
@@ -887,6 +939,10 @@ GeoJSONSourceType GeoJSONSeqGetSourceType(GDALOpenInfo *poOpenInfo)
              STARTS_WITH_CI(poOpenInfo->pszFilename, "https://") ||
              STARTS_WITH_CI(poOpenInfo->pszFilename, "ftp://"))
     {
+        if (poOpenInfo->IsSingleAllowedDriver("GeoJSONSeq"))
+        {
+            return eGeoJSONSourceService;
+        }
         if (IsLikelyESRIJSONURL(poOpenInfo->pszFilename))
         {
             return eGeoJSONSourceUnknown;
@@ -902,11 +958,11 @@ GeoJSONSourceType GeoJSONSeqGetSourceType(GDALOpenInfo *poOpenInfo)
             return eGeoJSONSourceFile;
         }
         const char *pszText = poOpenInfo->pszFilename + strlen("GEOJSONSeq:");
-        if (GeoJSONSeqIsObject(pszText))
+        if (GeoJSONSeqIsObject(pszText, poOpenInfo))
             return eGeoJSONSourceText;
         return eGeoJSONSourceUnknown;
     }
-    else if (GeoJSONSeqIsObject(poOpenInfo->pszFilename))
+    else if (GeoJSONSeqIsObject(poOpenInfo->pszFilename, poOpenInfo))
     {
         srcType = eGeoJSONSourceText;
     }
@@ -936,6 +992,10 @@ GeoJSONSourceType JSONFGDriverGetSourceType(GDALOpenInfo *poOpenInfo)
              STARTS_WITH_CI(poOpenInfo->pszFilename, "https://") ||
              STARTS_WITH_CI(poOpenInfo->pszFilename, "ftp://"))
     {
+        if (poOpenInfo->IsSingleAllowedDriver("JSONFG"))
+        {
+            return eGeoJSONSourceService;
+        }
         if (IsLikelyESRIJSONURL(poOpenInfo->pszFilename))
         {
             return eGeoJSONSourceUnknown;
@@ -951,11 +1011,11 @@ GeoJSONSourceType JSONFGDriverGetSourceType(GDALOpenInfo *poOpenInfo)
             return eGeoJSONSourceFile;
         }
         const char *pszText = poOpenInfo->pszFilename + nJSONFGPrefixLen;
-        if (JSONFGIsObject(pszText))
+        if (JSONFGIsObject(pszText, poOpenInfo))
             return eGeoJSONSourceText;
         return eGeoJSONSourceUnknown;
     }
-    else if (JSONFGIsObject(poOpenInfo->pszFilename))
+    else if (JSONFGIsObject(poOpenInfo->pszFilename, poOpenInfo))
     {
         srcType = eGeoJSONSourceText;
     }

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonutils.h
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonutils.h
@@ -59,11 +59,11 @@ GeoJSONSourceType JSONFGDriverGetSourceType(GDALOpenInfo *poOpenInfo);
 /*                           GeoJSONIsObject                            */
 /************************************************************************/
 
-bool GeoJSONIsObject(const char *pszText, CSLConstList papszAllowedDrivers);
-bool GeoJSONSeqIsObject(const char *pszText);
-bool ESRIJSONIsObject(const char *pszText);
-bool TopoJSONIsObject(const char *pszText);
-bool JSONFGIsObject(const char *pszText);
+bool GeoJSONIsObject(const char *pszText, GDALOpenInfo *poOpenInfo);
+bool GeoJSONSeqIsObject(const char *pszText, GDALOpenInfo *poOpenInfo);
+bool ESRIJSONIsObject(const char *pszText, GDALOpenInfo *poOpenInfo);
+bool TopoJSONIsObject(const char *pszText, GDALOpenInfo *poOpenInfo);
+bool JSONFGIsObject(const char *pszText, GDALOpenInfo *poOpenInfo);
 
 /************************************************************************/
 /*                           GeoJSONPropertyToFieldType                 */

--- a/ogr/ogrsf_frmts/geojson/ogrtopojsondriver.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrtopojsondriver.cpp
@@ -48,10 +48,14 @@ static int OGRTopoJSONDriverIdentify(GDALOpenInfo *poOpenInfo)
     GeoJSONSourceType nSrcType = TopoJSONDriverGetSourceType(poOpenInfo);
     if (nSrcType == eGeoJSONSourceUnknown)
         return FALSE;
-    if (nSrcType == eGeoJSONSourceService &&
-        !STARTS_WITH_CI(poOpenInfo->pszFilename, "TopoJSON:"))
+    if (nSrcType == eGeoJSONSourceService)
     {
-        return -1;
+        if (poOpenInfo->IsSingleAllowedDriver("TopoJSON"))
+            return TRUE;
+        if (!STARTS_WITH_CI(poOpenInfo->pszFilename, "TopoJSON:"))
+        {
+            return -1;
+        }
     }
     return TRUE;
 }

--- a/ogr/ogrsf_frmts/jsonfg/ogrjsonfgdataset.cpp
+++ b/ogr/ogrsf_frmts/jsonfg/ogrjsonfgdataset.cpp
@@ -435,7 +435,7 @@ bool OGRJSONFGDataset::ReadFromService(GDALOpenInfo *poOpenInfo,
     char *pszStoredContent = OGRGeoJSONDriverStealStoredContent(pszSource);
     if (pszStoredContent != nullptr)
     {
-        if (JSONFGIsObject(pszStoredContent))
+        if (JSONFGIsObject(pszStoredContent, poOpenInfo))
         {
             pszGeoData_ = pszStoredContent;
             nGeoDataLen_ = strlen(pszGeoData_);
@@ -501,7 +501,7 @@ bool OGRJSONFGDataset::ReadFromService(GDALOpenInfo *poOpenInfo,
     /* -------------------------------------------------------------------- */
     if (EQUAL(pszSource, poOpenInfo->pszFilename))
     {
-        if (!JSONFGIsObject(pszGeoData_))
+        if (!JSONFGIsObject(pszGeoData_, poOpenInfo))
         {
             OGRGeoJSONDriverStoreContent(pszSource, pszGeoData_);
             pszGeoData_ = nullptr;

--- a/ogr/ogrsf_frmts/jsonfg/ogrjsonfgdriver.cpp
+++ b/ogr/ogrsf_frmts/jsonfg/ogrjsonfgdriver.cpp
@@ -41,10 +41,14 @@ static int OGRJSONFGDriverIdentify(GDALOpenInfo *poOpenInfo)
     GeoJSONSourceType nSrcType = JSONFGDriverGetSourceType(poOpenInfo);
     if (nSrcType == eGeoJSONSourceUnknown)
         return FALSE;
-    if (nSrcType == eGeoJSONSourceService &&
-        !STARTS_WITH_CI(poOpenInfo->pszFilename, "JSONFG:"))
+    if (nSrcType == eGeoJSONSourceService)
     {
-        return -1;
+        if (poOpenInfo->IsSingleAllowedDriver("JSONFG"))
+            return TRUE;
+        if (!STARTS_WITH_CI(poOpenInfo->pszFilename, "JSONFG:"))
+        {
+            return -1;
+        }
     }
     return TRUE;
 }


### PR DESCRIPTION
... when papszAllowedDrivers[] contains only the driver name

Refs https://github.com/OSGeo/gdal/issues/9978 (this PR will be followed by another one with other drivers)