### PR TITLE
Block cache: Use unordered_set for hash block cache.

### DIFF
--- a/gcore/gdalhashsetbandblockcache.cpp
+++ b/gcore/gdalhashsetbandblockcache.cpp
@@ -48,7 +48,7 @@ class GDALHashSetBandBlockCache final : public GDALAbstractBandBlockCache
 {
     struct BlockHash
     {
-        std::size_t operator()(GDALRasterBlock *const& b) const noexcept
+        std::size_t operator()(GDALRasterBlock *const &b) const noexcept
         {
             std::hash<int> h;
 
@@ -56,31 +56,20 @@ class GDALHashSetBandBlockCache final : public GDALAbstractBandBlockCache
             int y = b->GetYOff();
             return h(x) ^ (h(y) << 1);
         }
-        // Do not change this comparator, because this order is assumed by
-        // tests like tiff_write_133 for flushing from top to bottom, left
-        // to right.
-        /**
-        bool operator()(const GDALRasterBlock *const &lhs,
-                        const GDALRasterBlock *const &rhs) const
-        {
-            if (lhs->GetYOff() < rhs->GetYOff())
-                return true;
-            if (lhs->GetYOff() > rhs->GetYOff())
-                return false;
-            return lhs->GetXOff() < rhs->GetXOff();
-        }
-        **/
     };
 
     struct BlockEqual
     {
-        bool operator()(GDALRasterBlock *const& b1, GDALRasterBlock *const& b2) const noexcept
+        bool operator()(GDALRasterBlock *const &b1,
+                        GDALRasterBlock *const &b2) const noexcept
         {
-            return b1->GetXOff() == b2->GetXOff() && b1->GetYOff() == b2->GetYOff();
+            return b1->GetXOff() == b2->GetXOff() &&
+                   b1->GetYOff() == b2->GetYOff();
         }
     };
 
-    using BlockCache = std::unordered_set<GDALRasterBlock *, BlockHash, BlockEqual>;
+    using BlockCache =
+        std::unordered_set<GDALRasterBlock *, BlockHash, BlockEqual>;
 
     BlockCache m_oSet{};
     CPLLock *hLock = nullptr;


### PR DESCRIPTION
Hashing should perform better than an ordered container.

A comment in the code said that tests depended on the comparator, but things still pass and there is nothing in the hash block cache code itself that suggests that order matters.