### PR TITLE
[Backport release/3.9] ogr2ogr: error out if GCP transform creation fails; GCPTransformer: accept only 2 points for order=1 transformer

### DIFF
--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -2641,6 +2641,10 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
         }
     }
 
+    // Automatically close poODS on error, if it has been created by this
+    // method.
+    GDALDatasetUniquePtr poODSUniquePtr(hDstDS == nullptr ? poODS : nullptr);
+
     // Some syntaxic sugar to make "ogr2ogr [-f PostgreSQL] PG:dbname=....
     // source [srclayer] -lco OVERWRITE=YES" work like "ogr2ogr -overwrite
     // PG:dbname=.... source [srclayer]" The former syntax used to work at
@@ -2658,8 +2662,6 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
         {
             CPLError(CE_Failure, CPLE_AppDefined,
                      "-append and -lco OVERWRITE=YES are mutually exclusive");
-            if (hDstDS == nullptr)
-                GDALClose(poODS);
             return nullptr;
         }
         bOverwrite = true;
@@ -2707,8 +2709,6 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
             CPLError(CE_Failure, CPLE_AppDefined,
                      "Failed to process SRS definition: %s",
                      psOptions->osOutputSRSDef.c_str());
-            if (hDstDS == nullptr)
-                GDALClose(poODS);
             return nullptr;
         }
         oOutputSRSHolder.get()->SetCoordinateEpoch(
@@ -2729,8 +2729,6 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
             CPLError(CE_Failure, CPLE_AppDefined,
                      "Failed to process SRS definition: %s",
                      psOptions->osSourceSRSDef.c_str());
-            if (hDstDS == nullptr)
-                GDALClose(poODS);
             return nullptr;
         }
         oSourceSRS.SetCoordinateEpoch(psOptions->dfSourceCoordinateEpoch);
@@ -2741,19 +2739,15 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
     /*      Create a transformation object from the source to               */
     /*      destination coordinate system.                                  */
     /* -------------------------------------------------------------------- */
-    GCPCoordTransformation *poGCPCoordTrans = nullptr;
+    std::unique_ptr<GCPCoordTransformation> poGCPCoordTrans;
     if (psOptions->oGCPs.nGCPCount > 0)
     {
-        poGCPCoordTrans = new GCPCoordTransformation(
+        poGCPCoordTrans = std::make_unique<GCPCoordTransformation>(
             psOptions->oGCPs.nGCPCount, psOptions->oGCPs.pasGCPs,
             psOptions->nTransformOrder,
             poSourceSRS ? poSourceSRS : oOutputSRSHolder.get());
         if (!(poGCPCoordTrans->IsValid()))
         {
-            delete poGCPCoordTrans;
-            poGCPCoordTrans = nullptr;
-            if (hDstDS == nullptr)
-                GDALClose(poODS);
             return nullptr;
         }
     }
@@ -2808,7 +2802,7 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
     oTranslator.m_poOutputSRS = oOutputSRSHolder.get();
     oTranslator.m_bNullifyOutputSRS = psOptions->bNullifyOutputSRS;
     oTranslator.m_poUserSourceSRS = poSourceSRS;
-    oTranslator.m_poGCPCoordTrans = poGCPCoordTrans;
+    oTranslator.m_poGCPCoordTrans = poGCPCoordTrans.get();
     oTranslator.m_eGType = psOptions->eGType;
     oTranslator.m_eGeomTypeConversion = psOptions->eGeomTypeConversion;
     oTranslator.m_bMakeValid = psOptions->bMakeValid;
@@ -2980,9 +2974,6 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
         {
             CPLError(CE_Failure, CPLE_AppDefined,
                      "-splitlistfields not supported in this mode");
-            if (hDstDS == nullptr)
-                GDALClose(poODS);
-            delete poGCPCoordTrans;
             return nullptr;
         }
 
@@ -2995,9 +2986,6 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
             {
                 CPLError(CE_Failure, CPLE_AppDefined,
                          "Couldn't fetch requested layer %s!", pszLayer);
-                if (hDstDS == nullptr)
-                    GDALClose(poODS);
-                delete poGCPCoordTrans;
                 return nullptr;
             }
         }
@@ -3047,9 +3035,6 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
                 {
                     CPLError(CE_Failure, CPLE_AppDefined,
                              "Couldn't fetch advertised layer %d!", iLayer);
-                    if (hDstDS == nullptr)
-                        GDALClose(poODS);
-                    delete poGCPCoordTrans;
                     return nullptr;
                 }
 
@@ -3088,9 +3073,6 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
             {
                 CPLError(CE_Failure, CPLE_AppDefined,
                          "Couldn't fetch advertised layer %d!", iLayer);
-                if (hDstDS == nullptr)
-                    GDALClose(poODS);
-                delete poGCPCoordTrans;
                 return nullptr;
             }
 
@@ -3109,9 +3091,6 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
                                  poLayer->GetName());
                         if (!psOptions->bSkipFailures)
                         {
-                            if (hDstDS == nullptr)
-                                GDALClose(poODS);
-                            delete poGCPCoordTrans;
                             return nullptr;
                         }
                     }
@@ -3136,8 +3115,8 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
         while (true)
         {
             OGRLayer *poFeatureLayer = nullptr;
-            OGRFeature *poFeature = poDS->GetNextFeature(
-                &poFeatureLayer, nullptr, pfnProgress, pProgressArg);
+            auto poFeature = std::unique_ptr<OGRFeature>(poDS->GetNextFeature(
+                &poFeatureLayer, nullptr, pfnProgress, pProgressArg));
             if (poFeature == nullptr)
                 break;
             std::map<OGRLayer *, int>::const_iterator oIter =
@@ -3145,7 +3124,7 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
             if (oIter == oMapLayerToIdx.end())
             {
                 // Feature in a layer that is not a layer of interest.
-                OGRFeature::DestroyFeature(poFeature);
+                // nothing to do
             }
             else
             {
@@ -3173,10 +3152,6 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
 
                         if (psInfo == nullptr && !psOptions->bSkipFailures)
                         {
-                            if (hDstDS == nullptr)
-                                GDALClose(poODS);
-                            delete poGCPCoordTrans;
-                            OGRFeature::DestroyFeature(poFeature);
                             return nullptr;
                         }
 
@@ -3189,9 +3164,9 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
                 int iLayer = oIter->second;
                 TargetLayerInfo *psInfo = pasAssocLayers[iLayer].psInfo.get();
                 if ((psInfo == nullptr ||
-                     !oTranslator.Translate(poFeature, psInfo, 0, nullptr,
-                                            nTotalEventsDone, nullptr, nullptr,
-                                            psOptions.get())) &&
+                     !oTranslator.Translate(poFeature.release(), psInfo, 0,
+                                            nullptr, nTotalEventsDone, nullptr,
+                                            nullptr, psOptions.get())) &&
                     !psOptions->bSkipFailures)
                 {
                     CPLError(
@@ -3204,8 +3179,6 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
                     nRetCode = 1;
                     break;
                 }
-                if (psInfo == nullptr)
-                    OGRFeature::DestroyFeature(poFeature);
             }
         }  // while true
 
@@ -3233,9 +3206,6 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
 
                 if (psInfo == nullptr && !psOptions->bSkipFailures)
                 {
-                    if (hDstDS == nullptr)
-                        GDALClose(poODS);
-                    delete poGCPCoordTrans;
                     return nullptr;
                 }
 
@@ -3265,9 +3235,6 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
                 {
                     CPLError(CE_Failure, CPLE_AppDefined,
                              "Couldn't fetch advertised layer %d!", iLayer);
-                    if (hDstDS == nullptr)
-                        GDALClose(poODS);
-                    delete poGCPCoordTrans;
                     return nullptr;
                 }
                 if (!poDS->IsLayerPrivate(iLayer))
@@ -3297,9 +3264,6 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
                              psOptions->aosLayers[iLayer]);
                     if (!psOptions->bSkipFailures)
                     {
-                        if (hDstDS == nullptr)
-                            GDALClose(poODS);
-                        delete poGCPCoordTrans;
                         return nullptr;
                     }
                 }
@@ -3349,9 +3313,6 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
                              psOptions->osWHERE.c_str(), poLayer->GetName());
                     if (!psOptions->bSkipFailures)
                     {
-                        if (hDstDS == nullptr)
-                            GDALClose(poODS);
-                        delete poGCPCoordTrans;
                         return nullptr;
                     }
                 }
@@ -3505,8 +3466,6 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
         }
     }
 
-    delete poGCPCoordTrans;
-
     // Note: this guarantees that the file can be opened in a consistent state,
     // without requiring to close poODS, only if the driver declares
     // DCAP_FLUSHCACHE_CONSISTENT_STATE
@@ -3514,10 +3473,13 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
         nRetCode = 1;
 
     if (nRetCode == 0)
-        return GDALDataset::ToHandle(poODS);
+    {
+        if (hDstDS)
+            return hDstDS;
+        else
+            return GDALDataset::ToHandle(poODSUniquePtr.release());
+    }
 
-    if (hDstDS == nullptr)
-        GDALClose(poODS);
     return nullptr;
 }
 

--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -2752,6 +2752,9 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
         {
             delete poGCPCoordTrans;
             poGCPCoordTrans = nullptr;
+            if (hDstDS == nullptr)
+                GDALClose(poODS);
+            return nullptr;
         }
     }
 

--- a/autotest/utilities/test_ogr2ogr_lib.py
+++ b/autotest/utilities/test_ogr2ogr_lib.py
@@ -2710,3 +2710,17 @@ def test_ogr2ogr_lib_coordinate_precision_with_geom():
         assert f.GetGeometryRef().ExportToWkt() == "LINESTRING (0 0,10 10)"
     else:
         assert f.GetGeometryRef().ExportToWkt() == "LINESTRING (1 1,9 9)"
+
+
+###############################################################################
+
+
+def test_ogr2ogr_lib_not_enough_gcp():
+
+    src_ds = gdal.GetDriverByName("Memory").Create("", 0, 0, 0, gdal.GDT_Unknown)
+    src_ds.CreateLayer("test")
+
+    with pytest.raises(
+        Exception, match="Failed to compute GCP transform: Not enough points available"
+    ):
+        gdal.VectorTranslate("", src_ds, options="-f Memory -gcp 0 0 0 0")

--- a/autotest/utilities/test_ogr2ogr_lib.py
+++ b/autotest/utilities/test_ogr2ogr_lib.py
@@ -2724,3 +2724,23 @@ def test_ogr2ogr_lib_not_enough_gcp():
         Exception, match="Failed to compute GCP transform: Not enough points available"
     ):
         gdal.VectorTranslate("", src_ds, options="-f Memory -gcp 0 0 0 0")
+
+
+###############################################################################
+
+
+def test_ogr2ogr_lib_two_gcps():
+
+    src_ds = gdal.GetDriverByName("Memory").Create("", 0, 0, 0, gdal.GDT_Unknown)
+    src_lyr = src_ds.CreateLayer("test")
+    f = ogr.Feature(src_lyr.GetLayerDefn())
+    f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (2 3)"))
+    src_lyr.CreateFeature(f)
+
+    out_ds = gdal.VectorTranslate(
+        "", src_ds, options="-f Memory -gcp 1 2 200 300 -gcp 3 4 300 400"
+    )
+    out_lyr = out_ds.GetLayer(0)
+    f = out_lyr.GetNextFeature()
+    assert f.GetGeometryRef().GetX(0) == pytest.approx(250)
+    assert f.GetGeometryRef().GetY(0) == pytest.approx(350)


### PR DESCRIPTION
Backport #10078
 **Authored by:** @rouault