### PR TITLE
Fix rendering of code block in python readme

### DIFF
--- a/swig/python/README.rst
+++ b/swig/python/README.rst
@@ -118,6 +118,7 @@ This is most often due to pip reusing a cached GDAL installation.
 Verify that the necessary dependencies have been installed and then run the following to force a clean build:
 
 ::
+
     pip install --no-cache --force-reinstall gdal[numpy]=="$(gdal-config --version).*"
 
 


### PR DESCRIPTION
The missing newline is preventing a code block from being correctly rendered in the python README and on GDAL's PyPI page: https://pypi.org/project/GDAL/

![Screenshot from 2024-06-07 09-06-55](https://github.com/OSGeo/gdal/assets/17994518/0a6c69fe-02cd-4989-bb4d-eb3f9226335e)
