### PR TITLE
Docs: fix coordinate_epoch.rst since PROJ 9.4

### DIFF
--- a/doc/source/programs/gdaltransform.rst
+++ b/doc/source/programs/gdaltransform.rst
@@ -50,7 +50,7 @@ projection,including GCP-based transformations.
     source SRS is a dynamic CRS. Only taken into account if :option:`-s_srs`
     is used.
 
-    Before PROJ 9.4, :option:`-s_coord_epoch` and :option:`-t_coord_epoch` are
+    Before PROJ 9.4, :option:`-s_coord_epoch` and :option:`-t_coord_epoch` were
     mutually exclusive, due to lack of support for transformations between two dynamic CRS.
 
 .. option:: -t_srs <srs_def>
@@ -69,7 +69,7 @@ projection,including GCP-based transformations.
     output SRS is a dynamic CRS. Only taken into account if :option:`-t_srs`
     is used.
 
-    Before PROJ 9.4, :option:`-s_coord_epoch` and :option:`-t_coord_epoch` are
+    Before PROJ 9.4, :option:`-s_coord_epoch` and :option:`-t_coord_epoch` were
     mutually exclusive, due to lack of support for transformations between two dynamic CRS.
 
 .. option:: -ct <string>

--- a/doc/source/programs/gdalwarp.rst
+++ b/doc/source/programs/gdalwarp.rst
@@ -130,7 +130,7 @@ with control information.
     source SRS is a dynamic CRS. Only taken into account if :option:`-s_srs`
     is used.
 
-    Before PROJ 9.4, :option:`-s_coord_epoch` and :option:`-t_coord_epoch` are
+    Before PROJ 9.4, :option:`-s_coord_epoch` and :option:`-t_coord_epoch` were
     mutually exclusive, due to lack of support for transformations between two dynamic CRS.
 
 .. option:: -t_srs <srs_def>
@@ -151,7 +151,7 @@ with control information.
     target SRS is a dynamic CRS. Only taken into account if :option:`-t_srs`
     is used.
 
-    Before PROJ 9.4, :option:`-s_coord_epoch` and :option:`-t_coord_epoch` are
+    Before PROJ 9.4, :option:`-s_coord_epoch` and :option:`-t_coord_epoch` were
     mutually exclusive, due to lack of support for transformations between two dynamic CRS.
 
 .. option:: -ct <string>

--- a/doc/source/programs/ogr2ogr.rst
+++ b/doc/source/programs/ogr2ogr.rst
@@ -270,7 +270,7 @@ output coordinate system or even reprojecting the features during translation.
     output SRS is a dynamic CRS. Only taken into account if :option:`-t_srs`
     is used. It is also mutually exclusive with  :option:`-a_coord_epoch`.
 
-    Before PROJ 9.4, :option:`-s_coord_epoch` and :option:`-t_coord_epoch` are
+    Before PROJ 9.4, :option:`-s_coord_epoch` and :option:`-t_coord_epoch` were
     mutually exclusive, due to lack of support for transformations between two dynamic CRS.
 
 .. option:: -s_srs <srs_def>
@@ -332,7 +332,7 @@ output coordinate system or even reprojecting the features during translation.
     source SRS is a dynamic CRS. Only taken into account if :option:`-s_srs`
     is used.
 
-    Before PROJ 9.4, :option:`-s_coord_epoch` and :option:`-t_coord_epoch` are
+    Before PROJ 9.4, :option:`-s_coord_epoch` and :option:`-t_coord_epoch` were
     mutually exclusive, due to lack of support for transformations between two dynamic CRS.
 
 .. option:: -ct <string>

--- a/doc/source/user/coordinate_epoch.rst
+++ b/doc/source/user/coordinate_epoch.rst
@@ -169,9 +169,10 @@ from the source SRS when no SRS related options are specified.
 
 :program:`gdalwarp` and :program:`ogr2ogr` have a ``-s_coord_epoch`` option to be used together with ``-s_srs``
 (resp. ``-t_coord_epoch`` option to be used together with ``-t_srs``) to override/set the
-coordinate epoch of the source (resp. target) CRS. ``-s_coord_epoch`` and
-``-t_coord_epoch`` are currently mutually exclusive, due to lack of support for
-transformations between two dynamic CRS.
+coordinate epoch of the source (resp. target) CRS.
+
+Before PROJ 9.4, ``-s_coord_epoch`` and ``-t_coord_epoch`` were mutually exclusive, due to lack
+of support for transformations between two dynamic CRS.
 
 :program:`gdalwarp` preserves the coordinate epoch in the output SRS when appropriate.
 


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

Substitutes
`-s_coord_epoch and -t_coord_epoch are currently mutually exclusive, due to lack of support for transformations between two dynamic CRS.`
with
`Before PROJ 9.4, -s_coord_epoch and -t_coord_epoch were mutually exclusive, due to lack of support for transformations between two dynamic CRS.`
in [coordinate_epoch.rst](https://gdal.org/user/coordinate_epoch.html)

and substitutes
`Before PROJ 9.4, :option:`-s_coord_epoch` and :option:`-t_coord_epoch` are mutually exclusive`
with
`Before PROJ 9.4, :option:`-s_coord_epoch` and :option:`-t_coord_epoch` were mutually exclusive`
in [ogr2ogr.rst](https://gdal.org/programs/ogr2ogr.html), [gdalwarp.rst](https://gdal.org/programs/gdalwarp.html) and [gdaltransform.rst](https://gdal.org/programs/gdaltransform.html).

I'm not a native English speaker, but it seems to me `were` is more appropriate then `are` in such context.
P.S. Just now I've understood than the line was added before PROJ 9.4 was released, so the verb tense was correct then.

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
