### PR TITLE
Contour: include minimum raster value as contour line when it exactly matches the first level

### DIFF
--- a/alg/marching_squares/level_generator.h
+++ b/alg/marching_squares/level_generator.h
@@ -96,9 +96,10 @@ class FixedLevelRangeIterator
   public:
     typedef RangeIterator<FixedLevelRangeIterator> Iterator;
 
-    FixedLevelRangeIterator(const double *levels, size_t count,
-                            double maxLevel = Inf)
-        : levels_(levels), count_(count), maxLevel_(maxLevel)
+    FixedLevelRangeIterator(const double *levels, size_t count, double minLevel,
+                            double maxLevel)
+        : levels_(levels), count_(count), minLevel_(minLevel),
+          maxLevel_(maxLevel)
     {
     }
 
@@ -107,13 +108,15 @@ class FixedLevelRangeIterator
         if (min > max)
             std::swap(min, max);
         size_t b = 0;
-        for (; b != count_ && levels_[b] < fudge(levels_[b], min); b++)
+        for (; b != count_ && levels_[b] < fudge(min, minLevel_, levels_[b]);
+             b++)
             ;
         if (min == max)
             return Range<Iterator>(Iterator(*this, int(b)),
                                    Iterator(*this, int(b)));
         size_t e = b;
-        for (; e != count_ && levels_[e] <= fudge(levels_[e], max); e++)
+        for (; e != count_ && levels_[e] <= fudge(max, minLevel_, levels_[e]);
+             e++)
             ;
         return Range<Iterator>(Iterator(*this, int(b)),
                                Iterator(*this, int(e)));
@@ -126,10 +129,16 @@ class FixedLevelRangeIterator
         return levels_[size_t(idx)];
     }
 
+    double minLevel() const
+    {
+        return minLevel_;
+    }
+
   private:
     const double *levels_;
     size_t count_;
-    double maxLevel_;
+    const double minLevel_;
+    const double maxLevel_;
 };
 
 struct TooManyLevelsException : public std::exception
@@ -150,8 +159,8 @@ struct IntervalLevelRangeIterator
     typedef RangeIterator<IntervalLevelRangeIterator> Iterator;
 
     // Construction by a offset and an interval
-    IntervalLevelRangeIterator(double offset, double interval)
-        : offset_(offset), interval_(interval)
+    IntervalLevelRangeIterator(double offset, double interval, double minLevel)
+        : offset_(offset), interval_(interval), minLevel_(minLevel)
     {
     }
 
@@ -165,7 +174,7 @@ struct IntervalLevelRangeIterator
         if (!(df_i1 >= INT_MIN && df_i1 < INT_MAX))
             throw TooManyLevelsException();
         int i1 = static_cast<int>(df_i1);
-        double l1 = fudge(level(i1), min);
+        double l1 = fudge(min, minLevel_, level(i1));
         if (l1 > min)
         {
             df_i1 = ceil((l1 - offset_) / interval_);
@@ -183,7 +192,7 @@ struct IntervalLevelRangeIterator
         if (!(df_i2 >= INT_MIN && df_i2 < INT_MAX))
             throw TooManyLevelsException();
         int i2 = static_cast<int>(df_i2);
-        double l2 = fudge(level(i2), max);
+        double l2 = fudge(max, minLevel_, level(i2));
         if (l2 > max)
         {
             df_i2 = floor((l2 - offset_) / interval_) + 1;
@@ -206,9 +215,15 @@ struct IntervalLevelRangeIterator
         return idx * interval_ + offset_;
     }
 
+    double minLevel() const
+    {
+        return minLevel_;
+    }
+
   private:
     const double offset_;
     const double interval_;
+    const double minLevel_;
 };
 
 class ExponentialLevelRangeIterator
@@ -216,8 +231,8 @@ class ExponentialLevelRangeIterator
   public:
     typedef RangeIterator<ExponentialLevelRangeIterator> Iterator;
 
-    ExponentialLevelRangeIterator(double base)
-        : base_(base), base_ln_(std::log(base_))
+    ExponentialLevelRangeIterator(double base, double minLevel)
+        : base_(base), base_ln_(std::log(base_)), minLevel_(minLevel)
     {
     }
 
@@ -234,7 +249,7 @@ class ExponentialLevelRangeIterator
             std::swap(min, max);
 
         int i1 = index1(min);
-        double l1 = fudge(level(i1), min);
+        double l1 = fudge(min, minLevel_, level(i1));
         if (l1 > min)
             i1 = index1(l1);
         Iterator b(*this, i1);
@@ -243,7 +258,7 @@ class ExponentialLevelRangeIterator
             return Range<Iterator>(b, b);
 
         int i2 = index2(max);
-        double l2 = fudge(level(i2), max);
+        double l2 = fudge(max, minLevel_, level(i2));
         if (l2 > max)
             i2 = index2(l2);
         Iterator e(*this, i2);
@@ -254,6 +269,11 @@ class ExponentialLevelRangeIterator
             throw TooManyLevelsException();
 
         return Range<Iterator>(b, e);
+    }
+
+    double minLevel() const
+    {
+        return minLevel_;
     }
 
   private:
@@ -280,6 +300,7 @@ class ExponentialLevelRangeIterator
     // exponentiation base
     const double base_;
     const double base_ln_;
+    const double minLevel_;
 };
 
 }  // namespace marching_squares

--- a/alg/marching_squares/utility.h
+++ b/alg/marching_squares/utility.h
@@ -36,14 +36,14 @@ namespace marching_squares
 
 // This is used to determine the maximum level value for polygons,
 // the one that spans all the remaining plane
-const double Inf = std::numeric_limits<double>::max();
+constexpr double Inf = std::numeric_limits<double>::infinity();
 
-const double NaN = std::numeric_limits<double>::quiet_NaN();
+constexpr double NaN = std::numeric_limits<double>::quiet_NaN();
 
 #define debug(format, ...) CPLDebug("MarchingSquare", format, ##__VA_ARGS__)
 
 // Perturb a value if it is too close to a level value
-inline double fudge(double level, double value)
+inline double fudge(double value, double minLevel, double level)
 {
     // FIXME
     // This is too "hard coded". The perturbation to apply really depend on
@@ -55,6 +55,11 @@ inline double fudge(double level, double value)
     // are within a user-provided minimum distance.
 
     const double absTol = 1e-6;
+    // Do not fudge the level that would correspond to the absolute minimum
+    // level of the raster, so it gets included.
+    // Cf scenario of https://github.com/OSGeo/gdal/issues/10167
+    if (level == minLevel)
+        return value;
     return std::abs(level - value) < absTol ? value + absTol : value;
 }
 

--- a/autotest/cpp/test_marching_squares_contour.cpp
+++ b/autotest/cpp/test_marching_squares_contour.cpp
@@ -35,6 +35,8 @@
 #include "marching_squares/segment_merger.h"
 #include "marching_squares/contour_generator.h"
 
+#include <limits>
+
 #include "gtest_include.h"
 
 namespace marching_squares
@@ -179,7 +181,8 @@ TEST_F(test_ms_contour, dummy)
     std::vector<double> data = {2.0};
     TestRingAppender w;
     {
-        IntervalLevelRangeIterator levels(0.0, 10.0);
+        IntervalLevelRangeIterator levels(
+            0.0, 10.0, -std::numeric_limits<double>::infinity());
         SegmentMerger<TestRingAppender, IntervalLevelRangeIterator> writer(
             w, levels, /* polygonize */ true);
         ContourGenerator<decltype(writer), IntervalLevelRangeIterator> cg(
@@ -207,7 +210,8 @@ TEST_F(test_ms_contour, two_pixels)
     TestRingAppender w;
 
     {
-        IntervalLevelRangeIterator levels(8.0, 10.0);
+        IntervalLevelRangeIterator levels(
+            8.0, 10.0, -std::numeric_limits<double>::infinity());
         SegmentMerger<TestRingAppender, IntervalLevelRangeIterator> writer(
             w, levels, /* polygonize */ true);
         ContourGenerator<decltype(writer), IntervalLevelRangeIterator> cg(
@@ -319,7 +323,8 @@ TEST_F(test_ms_contour, four_pixels)
     TestRingAppender w;
 
     {
-        IntervalLevelRangeIterator levels(8.0, 10.0);
+        IntervalLevelRangeIterator levels(
+            8.0, 10.0, -std::numeric_limits<double>::infinity());
         SegmentMerger<TestRingAppender, IntervalLevelRangeIterator> writer(
             w, levels, /* polygonize */ true);
         ContourGenerator<decltype(writer), IntervalLevelRangeIterator> cg(
@@ -440,7 +445,8 @@ TEST_F(test_ms_contour, saddle_point)
     TestRingAppender w;
 
     {
-        IntervalLevelRangeIterator levels(8.0, 10.0);
+        IntervalLevelRangeIterator levels(
+            8.0, 10.0, -std::numeric_limits<double>::infinity());
         SegmentMerger<TestRingAppender, IntervalLevelRangeIterator> writer(
             w, levels, /* polygonize */ true);
         ContourGenerator<decltype(writer), IntervalLevelRangeIterator> cg(

--- a/autotest/cpp/test_marching_squares_polygon.cpp
+++ b/autotest/cpp/test_marching_squares_polygon.cpp
@@ -40,6 +40,8 @@
 #include <fstream>
 #endif
 
+#include <limits>
+
 #include "gtest_include.h"
 
 namespace marching_squares
@@ -171,7 +173,8 @@ TEST_F(test_ms_polygon, dummy)
     TestPolygonWriter w;
     {
         PolygonRingAppender<TestPolygonWriter> appender(w);
-        IntervalLevelRangeIterator levels(0.0, 10.0);
+        IntervalLevelRangeIterator levels(
+            0.0, 10.0, -std::numeric_limits<double>::infinity());
         SegmentMerger<PolygonRingAppender<TestPolygonWriter>,
                       IntervalLevelRangeIterator>
             writer(appender, levels, /* polygonize */ true);
@@ -234,7 +237,8 @@ TEST_F(test_ms_polygon, four_pixels)
     TestPolygonWriter w;
     {
         PolygonRingAppender<TestPolygonWriter> appender(w);
-        IntervalLevelRangeIterator levels(0.0, 10.0);
+        IntervalLevelRangeIterator levels(
+            0.0, 10.0, -std::numeric_limits<double>::infinity());
         SegmentMerger<PolygonRingAppender<TestPolygonWriter>,
                       IntervalLevelRangeIterator>
             writer(appender, levels, /* polygonize */ true);
@@ -304,7 +308,9 @@ TEST_F(test_ms_polygon, four_pixels_2)
     {
         PolygonRingAppender<TestPolygonWriter> appender(w);
         const double levels[] = {155.0};
-        FixedLevelRangeIterator levelGenerator(levels, 1);
+        FixedLevelRangeIterator levelGenerator(
+            levels, 1, -std::numeric_limits<double>::infinity(),
+            std::numeric_limits<double>::infinity());
         SegmentMerger<PolygonRingAppender<TestPolygonWriter>,
                       FixedLevelRangeIterator>
             writer(appender, levelGenerator, /* polygonize */ true);
@@ -400,7 +406,8 @@ TEST_F(test_ms_polygon, nine_pixels)
     TestPolygonWriter w;
     {
         PolygonRingAppender<TestPolygonWriter> appender(w);
-        IntervalLevelRangeIterator levels(1.0, 10.0);
+        IntervalLevelRangeIterator levels(
+            1.0, 10.0, -std::numeric_limits<double>::infinity());
         SegmentMerger<PolygonRingAppender<TestPolygonWriter>,
                       IntervalLevelRangeIterator>
             writer(appender, levels, /* polygonize */ true);
@@ -452,7 +459,8 @@ TEST_F(test_ms_polygon, three_nested_rings)
     TestPolygonWriter w;
     {
         PolygonRingAppender<TestPolygonWriter> appender(w);
-        IntervalLevelRangeIterator levels(1.0, 2.0);
+        IntervalLevelRangeIterator levels(
+            1.0, 2.0, -std::numeric_limits<double>::infinity());
         SegmentMerger<PolygonRingAppender<TestPolygonWriter>,
                       IntervalLevelRangeIterator>
             writer(appender, levels, /* polygonize */ true);

--- a/autotest/cpp/test_marching_squares_square.cpp
+++ b/autotest/cpp/test_marching_squares_square.cpp
@@ -34,6 +34,7 @@
 #include "marching_squares/square.h"
 #include "marching_squares/level_generator.h"
 #include <vector>
+#include <limits>
 #include <map>
 #include <fstream>
 
@@ -72,7 +73,9 @@ TEST_F(test_ms_square, dummy)
 {
     {
         const double levels[] = {0, 4};
-        FixedLevelRangeIterator levelGenerator(levels, 2);
+        FixedLevelRangeIterator levelGenerator(
+            levels, 2, -std::numeric_limits<double>::infinity(),
+            std::numeric_limits<double>::infinity());
         auto r = levelGenerator.range(0, 5.0);
         auto b = r.begin();
         EXPECT_EQ((*b).first, 1);
@@ -82,7 +85,8 @@ TEST_F(test_ms_square, dummy)
         EXPECT_EQ((*e).second, Inf);
     }
     {
-        IntervalLevelRangeIterator levelGenerator(0, 4);
+        IntervalLevelRangeIterator levelGenerator(
+            0, 4, -std::numeric_limits<double>::infinity());
         auto r = levelGenerator.range(0, 5.0);
         auto b = r.begin();
         EXPECT_EQ((*b).first, 1);
@@ -92,7 +96,8 @@ TEST_F(test_ms_square, dummy)
         EXPECT_EQ((*e).second, 8.0);
     }
     {
-        IntervalLevelRangeIterator levelGenerator(0, 10);
+        IntervalLevelRangeIterator levelGenerator(
+            0, 10, -std::numeric_limits<double>::infinity());
         auto r = levelGenerator.range(-18, 5.0);
         auto b = r.begin();
         EXPECT_EQ((*b).first, -1);
@@ -102,7 +107,8 @@ TEST_F(test_ms_square, dummy)
         EXPECT_EQ((*e).second, 10.0);
     }
     {
-        ExponentialLevelRangeIterator levelGenerator(2);
+        ExponentialLevelRangeIterator levelGenerator(
+            2, -std::numeric_limits<double>::infinity());
         auto r = levelGenerator.range(0, 5.0);
         auto b = r.begin();
         EXPECT_EQ((*b).first, 1);
@@ -124,7 +130,8 @@ TEST_F(test_ms_square, only_zero)
     // Square with only 0, level = 0.1
     Square square(ValuedPoint(0, 1, 0), ValuedPoint(1, 1, 0),
                   ValuedPoint(0, 0, 0), ValuedPoint(1, 0, 0));
-    Square::Segments segments(square.segments(.1));
+    Square::Segments segments(
+        square.segments(.1, -std::numeric_limits<double>::infinity()));
     //
     //   0                    0
     //    +------------------+
@@ -157,7 +164,8 @@ TEST_F(test_ms_square, only_one)
     //    |                  |
     //    +------------------+
     //   1                    1
-    Square::Segments segments(square.segments(.1));
+    Square::Segments segments(
+        square.segments(.1, -std::numeric_limits<double>::infinity()));
     EXPECT_EQ(segments.size(), size_t(0));
 }
 
@@ -178,7 +186,8 @@ TEST_F(test_ms_square, only_zero_level_1)
     //    |                  |
     //    +------------------+
     //   1                    1
-    Square::Segments segments(square.segments(1.0));
+    Square::Segments segments(
+        square.segments(1.0, -std::numeric_limits<double>::infinity()));
     EXPECT_EQ(segments.size(), size_t(0));
 }
 
@@ -199,7 +208,8 @@ TEST_F(test_ms_square, one_segment)
     //    | \                |
     //    +---o--------------+
     //   1                    0
-    Square::Segments segments(square.segments(.1));
+    Square::Segments segments(
+        square.segments(.1, -std::numeric_limits<double>::infinity()));
     EXPECT_EQ(segments.size(), size_t(1));
     EXPECT_TRUE(segments[0].first == Point(.9, 1));
     EXPECT_TRUE(segments[0].second == Point(0, .1));
@@ -224,11 +234,13 @@ TEST_F(test_ms_square, fudge_test_1)
     //   1                    1
     //  (0,0)
     {
-        Square::Segments segments(square.segments(0.0));
+        Square::Segments segments(
+            square.segments(0.0, -std::numeric_limits<double>::infinity()));
         EXPECT_EQ(segments.size(), size_t(0));
     }
     {
-        Square::Segments segments(square.segments(1.0));
+        Square::Segments segments(
+            square.segments(1.0, -std::numeric_limits<double>::infinity()));
         EXPECT_EQ(segments.size(), size_t(1));
         EXPECT_NEAR(segments[0].first.x, 0.0, 0.001);
         EXPECT_NEAR(segments[0].first.y, 0.0, 0.001);
@@ -256,7 +268,8 @@ TEST_F(test_ms_square, fudge_test_2)
     //   0                    0
     // (0,0)
     {
-        Square::Segments segments(square.segments(1.0));
+        Square::Segments segments(
+            square.segments(1.0, -std::numeric_limits<double>::infinity()));
         EXPECT_EQ(segments.size(), 1);
         EXPECT_NEAR(segments[0].first.x, 0.0, 0.001);
         EXPECT_NEAR(segments[0].first.y, 1.0, 0.001);
@@ -264,7 +277,8 @@ TEST_F(test_ms_square, fudge_test_2)
         EXPECT_NEAR(segments[0].second.y, 1.0, 0.001);
     }
     {
-        Square::Segments segments(square.segments(0.0));
+        Square::Segments segments(
+            square.segments(0.0, -std::numeric_limits<double>::infinity()));
         EXPECT_EQ(segments.size(), 0);
     }
 }
@@ -320,8 +334,10 @@ TEST_F(test_ms_square, nan)
     EXPECT_EQ(ul.lowerRight.y, ll.upperRight.y);
     EXPECT_EQ(ul.lowerRight.value, ll.upperRight.value);
 
-    const Square::Segments segments_up(ul.segments(225));
-    const Square::Segments segments_down(ll.segments(225));
+    const Square::Segments segments_up(
+        ul.segments(225, -std::numeric_limits<double>::infinity()));
+    const Square::Segments segments_down(
+        ll.segments(225, -std::numeric_limits<double>::infinity()));
 
     // segments on 225
     //
@@ -378,8 +394,10 @@ TEST_F(test_ms_square, border_test_1)
     //    +--------+---------+
     // 272.87   272.90000 272.93
 
-    Square::Segments segments_l(ll.segments(272.9));
-    Square::Segments segments_r(lr.segments(272.9));
+    Square::Segments segments_l(
+        ll.segments(272.9, -std::numeric_limits<double>::infinity()));
+    Square::Segments segments_r(
+        lr.segments(272.9, -std::numeric_limits<double>::infinity()));
 
     // the level falls exactly on corners
     // thanks to the fudge, each corner should be shifted away a bit
@@ -443,7 +461,8 @@ TEST_F(test_ms_square, multiple_levels)
 
     Writer writer;
     // levels starting at min and increasing by 0.1
-    IntervalLevelRangeIterator levelGenerator(0, .1);
+    IntervalLevelRangeIterator levelGenerator(
+        0, .1, -std::numeric_limits<double>::infinity());
 
     ul.process(levelGenerator, writer);
 
@@ -505,7 +524,8 @@ TEST_F(test_ms_square, border_test_3)
     {
         // ... with a level interval
         Writer writer;
-        IntervalLevelRangeIterator levelGenerator(7, 5);
+        IntervalLevelRangeIterator levelGenerator(
+            7, 5, -std::numeric_limits<double>::infinity());
         ul.process(levelGenerator, writer);
 
         // we have one contour at 7 and 12
@@ -546,7 +566,9 @@ TEST_F(test_ms_square, border_test_3)
     {
         Writer writer;
         std::vector<double> levels = {7.0};
-        FixedLevelRangeIterator levelGenerator(&levels[0], 1);
+        FixedLevelRangeIterator levelGenerator(
+            &levels[0], 1, -std::numeric_limits<double>::infinity(),
+            std::numeric_limits<double>::infinity());
         ul.process(levelGenerator, writer);
 
         // we have one contour at 7 and 12
@@ -604,7 +626,9 @@ TEST_F(test_ms_square, level_value_below_square_values)
     {
         Writer writer;
         std::vector<double> levels = {2.0};
-        FixedLevelRangeIterator levelGenerator(&levels[0], 1);
+        FixedLevelRangeIterator levelGenerator(
+            &levels[0], 1, -std::numeric_limits<double>::infinity(),
+            std::numeric_limits<double>::infinity());
         square.process(levelGenerator, writer);
         EXPECT_TRUE((writer.borders.size() == 0));
         EXPECT_TRUE((writer.contours.size() == 0));
@@ -630,7 +654,8 @@ TEST_F(test_ms_square, full_border_test_1)
     //   NaN                 5
     {
         Writer writer;
-        IntervalLevelRangeIterator levelGenerator(0, 10.0);
+        IntervalLevelRangeIterator levelGenerator(
+            0, 10.0, -std::numeric_limits<double>::infinity());
         square.process(levelGenerator, writer);
         EXPECT_TRUE((writer.borders.size() == 1));
         EXPECT_TRUE((writer.borders[1].size() == 2));
@@ -672,7 +697,8 @@ TEST_F(test_ms_square, full_border_test_2)
     //   NaN                 5
     {
         Writer writer;
-        IntervalLevelRangeIterator levelGenerator(5.0, 5.0);
+        IntervalLevelRangeIterator levelGenerator(
+            5.0, 5.0, -std::numeric_limits<double>::infinity());
         square.process(levelGenerator, writer);
         EXPECT_TRUE((writer.borders.size() == 1));
         EXPECT_TRUE((writer.borders[1].size() == 2));
@@ -696,7 +722,9 @@ TEST_F(test_ms_square, full_border_test_2)
     {
         Writer writer;
         std::vector<double> levels = {5.0};
-        FixedLevelRangeIterator levelGenerator(&levels[0], 1);
+        FixedLevelRangeIterator levelGenerator(
+            &levels[0], 1, -std::numeric_limits<double>::infinity(),
+            std::numeric_limits<double>::infinity());
         square.process(levelGenerator, writer);
         EXPECT_TRUE((writer.borders.size() == 1));
         EXPECT_TRUE((writer.borders[1].size() == 2));

--- a/autotest/cpp/test_marching_squares_tile.cpp
+++ b/autotest/cpp/test_marching_squares_tile.cpp
@@ -34,6 +34,7 @@
 #include "marching_squares/point.h"
 #include "marching_squares/level_generator.h"
 #include "marching_squares/contour_generator.h"
+#include <limits>
 #include <map>
 #include <fstream>
 
@@ -139,7 +140,8 @@ TEST_F(test_ms_tile, dummy)
     // only one pixel of value 2.0
     // levels = 0, 10
     std::vector<double> data = {2.0};
-    IntervalLevelRangeIterator levels(0.0, 10.0);
+    IntervalLevelRangeIterator levels(0.0, 10.0,
+                                      -std::numeric_limits<double>::infinity());
     Writer writer;
 
     ContourGenerator<Writer, IntervalLevelRangeIterator> cg(
@@ -173,7 +175,9 @@ TEST_F(test_ms_tile, tile_one_pixel)
     // levels = 0, 10
     std::vector<double> data = {2.0};
     const double levels[] = {0.0};
-    FixedLevelRangeIterator levelGenerator(levels, 1);
+    FixedLevelRangeIterator levelGenerator(
+        levels, 1, -std::numeric_limits<double>::infinity(),
+        std::numeric_limits<double>::infinity());
     Writer writer;
 
     ContourGenerator<Writer, FixedLevelRangeIterator> cg(
@@ -207,7 +211,8 @@ TEST_F(test_ms_tile, tile_one_pixel_two)
     // only one pixel of value 2.0
     // levels = 2, 10
     std::vector<double> data = {2.0};
-    IntervalLevelRangeIterator levels(2.0, 10.0);
+    IntervalLevelRangeIterator levels(2.0, 10.0,
+                                      -std::numeric_limits<double>::infinity());
     Writer writer;
 
     ContourGenerator<Writer, IntervalLevelRangeIterator> cg(
@@ -299,7 +304,8 @@ TEST_F(test_ms_tile, tile_two_pixels)
 
     std::vector<double> data = {10.0, 7.0};
     {
-        IntervalLevelRangeIterator levels(8.0, 10.0);
+        IntervalLevelRangeIterator levels(
+            8.0, 10.0, -std::numeric_limits<double>::infinity());
         Writer writer;
         ContourGenerator<Writer, IntervalLevelRangeIterator> cg(
             2, 1, /* hasNoData */ false, NaN, writer, levels);
@@ -421,7 +427,8 @@ TEST_F(test_ms_tile, tile_four_pixels)
     //  NaN                 NaN                NaN                NaN
     std::vector<double> data = {10.0, 7.0, 4.0, 5.0};
     {
-        IntervalLevelRangeIterator levels(8.0, 10.0);
+        IntervalLevelRangeIterator levels(
+            8.0, 10.0, -std::numeric_limits<double>::infinity());
         Writer writer;
         ContourGenerator<Writer, IntervalLevelRangeIterator> cg(
             2, 2, /* hasNoData */ false, NaN, writer, levels);
@@ -494,7 +501,9 @@ TEST_F(test_ms_tile, tile_four_pixels_2)
     std::vector<double> data = {155.0, 155.01, 154.99, 155.0};
     {
         const double levels[] = {155.0};
-        FixedLevelRangeIterator levelGenerator(levels, 1);
+        FixedLevelRangeIterator levelGenerator(
+            levels, 1, -std::numeric_limits<double>::infinity(),
+            std::numeric_limits<double>::infinity());
         Writer writer;
         ContourGenerator<Writer, FixedLevelRangeIterator> cg(
             2, 2, /* hasNoData */ false, NaN, writer, levelGenerator);


### PR DESCRIPTION
Fixes #10167

There's currently an asymmetry since the maximum raster value is included. This is due how the marching square thresholding compares pixel values to the candidate contour levels. Add a special case to modify the comparison for the level that matches the minimum raster value.
