### PR TITLE
[Backport release/3.9] GDALContourGenerateEx(): validate LEVEL_INTERVAL option

### DIFF
--- a/alg/contour.cpp
+++ b/alg/contour.cpp
@@ -562,6 +562,14 @@ CPLErr GDALContourGenerateEx(GDALRasterBandH hBand, void *hLayer,
     if (opt)
     {
         contourInterval = CPLAtof(opt);
+        // Written this way to catch NaN as well.
+        if (!(contourInterval > 0))
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Invalid value for LEVEL_INTERVAL. Should be strictly "
+                     "positive.");
+            return CE_Failure;
+        }
     }
 
     double contourBase = 0.0;

--- a/autotest/alg/contour.py
+++ b/autotest/alg/contour.py
@@ -403,3 +403,18 @@ def test_contour_raster_acquisition_error():
         gdal.ContourGenerateEx(
             ds.GetRasterBand(1), ogr_lyr, options=["LEVEL_INTERVAL=1", "ID_FIELD=0"]
         )
+
+
+###############################################################################
+
+
+def test_contour_invalid_LEVEL_INTERVAL():
+
+    ogr_ds = ogr.GetDriverByName("Memory").CreateDataSource("")
+    ogr_lyr = ogr_ds.CreateLayer("contour", geom_type=ogr.wkbLineString)
+    ds = gdal.Open("../gcore/data/byte.tif")
+
+    with pytest.raises(Exception, match="Invalid value for LEVEL_INTERVAL"):
+        gdal.ContourGenerateEx(
+            ds.GetRasterBand(1), ogr_lyr, options=["LEVEL_INTERVAL=-1"]
+        )


### PR DESCRIPTION
Backport #10128
 **Authored by:** @rouault