### PR TITLE
[Backport release/3.9] gdalinfo/ogrinfo text output: avoid weird truncation of coordinate epoch when its value is {year}.0

### DIFF
--- a/apps/gdalinfo_lib.cpp
+++ b/apps/gdalinfo_lib.cpp
@@ -639,10 +639,12 @@ char *GDALInfo(GDALDatasetH hDataset, const GDALInfoOptions *psOptions)
             {
                 std::string osCoordinateEpoch =
                     CPLSPrintf("%f", dfCoordinateEpoch);
-                if (osCoordinateEpoch.find('.') != std::string::npos)
+                const size_t nDotPos = osCoordinateEpoch.find('.');
+                if (nDotPos != std::string::npos)
                 {
-                    while (osCoordinateEpoch.back() == '0')
-                        osCoordinateEpoch.resize(osCoordinateEpoch.size() - 1);
+                    while (osCoordinateEpoch.size() > nDotPos + 2 &&
+                           osCoordinateEpoch.back() == '0')
+                        osCoordinateEpoch.pop_back();
                 }
                 Concat(osStr, psOptions->bStdoutOutput,
                        "Coordinate epoch: %s\n", osCoordinateEpoch.c_str());

--- a/apps/ogrinfo_lib.cpp
+++ b/apps/ogrinfo_lib.cpp
@@ -1191,10 +1191,12 @@ static void ReportOnLayer(CPLString &osRet, CPLJSONObject &oLayer,
             {
                 std::string osCoordinateEpoch =
                     CPLSPrintf("%f", dfCoordinateEpoch);
-                if (osCoordinateEpoch.find('.') != std::string::npos)
+                const size_t nDotPos = osCoordinateEpoch.find('.');
+                if (nDotPos != std::string::npos)
                 {
-                    while (osCoordinateEpoch.back() == '0')
-                        osCoordinateEpoch.resize(osCoordinateEpoch.size() - 1);
+                    while (osCoordinateEpoch.size() > nDotPos + 2 &&
+                           osCoordinateEpoch.back() == '0')
+                        osCoordinateEpoch.pop_back();
                 }
                 Concat(osRet, psOptions->bStdoutOutput,
                        "Coordinate epoch: %s\n", osCoordinateEpoch.c_str());

--- a/autotest/utilities/test_gdalinfo_lib.py
+++ b/autotest/utilities/test_gdalinfo_lib.py
@@ -199,17 +199,18 @@ def test_gdalinfo_lib_nodatavalues():
 ###############################################################################
 
 
-def test_gdalinfo_lib_coordinate_epoch():
+@pytest.mark.parametrize("epoch", ["2021.0", "2021.3"])
+def test_gdalinfo_lib_coordinate_epoch(epoch):
 
     ds = gdal.Translate(
-        "", "../gcore/data/byte.tif", options='-of MEM -a_coord_epoch 2021.3"'
+        "", "../gcore/data/byte.tif", options=f'-of MEM -a_coord_epoch {epoch}"'
     )
     ret = gdal.Info(ds)
-    assert "Coordinate epoch: 2021.3" in ret
+    assert f"Coordinate epoch: {epoch}" in ret
 
     ret = gdal.Info(ds, format="json")
     assert "coordinateEpoch" in ret
-    assert ret["coordinateEpoch"] == 2021.3
+    assert ret["coordinateEpoch"] == float(epoch)
 
 
 ###############################################################################


### PR DESCRIPTION
Backport #10145
 **Authored by:** @rouault