### PR TITLE
Fix crash in ogr2ogr (or Arrow based workflows) from GeoPackage/GeoParquet to PMTiles (3.9.0 regression)

### DIFF
--- a/ogr/ogrsf_frmts/generic/ogrlayerarrow.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrlayerarrow.cpp
@@ -5862,10 +5862,13 @@ bool OGRLayer::CreateFieldFromArrowSchemaInternal(
     if (poDS)
     {
         auto poDriver = poDS->GetDriver();
-        const char *pszMetadataItem =
-            poDriver->GetMetadataItem(GDAL_DMD_CREATIONFIELDDATATYPES);
-        if (pszMetadataItem)
-            aosNativeTypes = CSLTokenizeString2(pszMetadataItem, " ", 0);
+        if (poDriver)
+        {
+            const char *pszMetadataItem =
+                poDriver->GetMetadataItem(GDAL_DMD_CREATIONFIELDDATATYPES);
+            if (pszMetadataItem)
+                aosNativeTypes = CSLTokenizeString2(pszMetadataItem, " ", 0);
+        }
     }
 
     if (schema->dictionary &&
@@ -7374,10 +7377,13 @@ bool OGRLayer::WriteArrowBatch(const struct ArrowSchema *schema,
     if (poDS)
     {
         auto poDriver = poDS->GetDriver();
-        const char *pszMetadataItem =
-            poDriver->GetMetadataItem(GDAL_DMD_CREATIONFIELDDATATYPES);
-        if (pszMetadataItem)
-            aosNativeTypes = CSLTokenizeString2(pszMetadataItem, " ", 0);
+        if (poDriver)
+        {
+            const char *pszMetadataItem =
+                poDriver->GetMetadataItem(GDAL_DMD_CREATIONFIELDDATATYPES);
+            if (pszMetadataItem)
+                aosNativeTypes = CSLTokenizeString2(pszMetadataItem, " ", 0);
+        }
     }
 
     std::vector<FieldInfo> asFieldInfo;

--- a/ogr/ogrsf_frmts/mvt/ogrmvtdataset.cpp
+++ b/ogr/ogrsf_frmts/mvt/ogrmvtdataset.cpp
@@ -6185,6 +6185,8 @@ GDALDataset *OGRMVTWriterDataset::Create(const char *pszFilename, int nXSize,
     }
 
     poDS->SetDescription(pszFilename);
+    poDS->poDriver = GDALDriver::FromHandle(GDALGetDriverByName("MVT"));
+
     return poDS;
 }
 


### PR DESCRIPTION
Fixes #10199
