### PR TITLE
[Backport release/3.9] Fix crash in ogr2ogr (or Arrow based workflows) from GeoPackage/GeoParquet to PMTiles (3.9.0 regression)

### DIFF
--- a/ogr/ogrsf_frmts/generic/ogrlayerarrow.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrlayerarrow.cpp
@@ -5861,10 +5861,13 @@ bool OGRLayer::CreateFieldFromArrowSchemaInternal(
     if (poDS)
     {
         auto poDriver = poDS->GetDriver();
-        const char *pszMetadataItem =
-            poDriver->GetMetadataItem(GDAL_DMD_CREATIONFIELDDATATYPES);
-        if (pszMetadataItem)
-            aosNativeTypes = CSLTokenizeString2(pszMetadataItem, " ", 0);
+        if (poDriver)
+        {
+            const char *pszMetadataItem =
+                poDriver->GetMetadataItem(GDAL_DMD_CREATIONFIELDDATATYPES);
+            if (pszMetadataItem)
+                aosNativeTypes = CSLTokenizeString2(pszMetadataItem, " ", 0);
+        }
     }
 
     if (schema->dictionary &&
@@ -7373,10 +7376,13 @@ bool OGRLayer::WriteArrowBatch(const struct ArrowSchema *schema,
     if (poDS)
     {
         auto poDriver = poDS->GetDriver();
-        const char *pszMetadataItem =
-            poDriver->GetMetadataItem(GDAL_DMD_CREATIONFIELDDATATYPES);
-        if (pszMetadataItem)
-            aosNativeTypes = CSLTokenizeString2(pszMetadataItem, " ", 0);
+        if (poDriver)
+        {
+            const char *pszMetadataItem =
+                poDriver->GetMetadataItem(GDAL_DMD_CREATIONFIELDDATATYPES);
+            if (pszMetadataItem)
+                aosNativeTypes = CSLTokenizeString2(pszMetadataItem, " ", 0);
+        }
     }
 
     std::vector<FieldInfo> asFieldInfo;

--- a/ogr/ogrsf_frmts/mvt/ogrmvtdataset.cpp
+++ b/ogr/ogrsf_frmts/mvt/ogrmvtdataset.cpp
@@ -6187,6 +6187,8 @@ GDALDataset *OGRMVTWriterDataset::Create(const char *pszFilename, int nXSize,
     }
 
     poDS->SetDescription(pszFilename);
+    poDS->poDriver = GDALDriver::FromHandle(GDALGetDriverByName("MVT"));
+
     return poDS;
 }
 


### PR DESCRIPTION
Backport #10200
 **Authored by:** @rouault