### PR TITLE
Python bindings: Avoid crash when using orphaned subgeometry

### DIFF
--- a/autotest/ogr/ogr_geom.py
+++ b/autotest/ogr/ogr_geom.py
@@ -4519,3 +4519,13 @@ def test_ogr_geom_buffer_with_args():
 
     with pytest.raises(Exception, match="Unsupported buffer option"):
         geom.Buffer(1, {"QUALITY": "HIGH"})
+
+
+def test_ogr_subgeom_use_after_parent_free():
+
+    g = ogr.CreateGeometryFromWkt("POLYGON ((0 0, 1 0, 1 1, 0 0))")
+
+    exterior_ring = g.GetGeometryRef(0)
+    del g
+
+    assert exterior_ring.GetPointCount() > 0  # does not crash

--- a/swig/include/python/ogr_python.i
+++ b/swig/include/python/ogr_python.i
@@ -990,8 +990,13 @@ def _WarnIfUserHasNotSpecifiedIfUsingExceptions():
   def __iter__(self):
       for i in range(self.GetGeometryCount()):
           yield self.GetGeometryRef(i)
-
 %}
+
+%feature("pythonappend") GetGeometryRef %{
+    if val is not None:
+        val._parent_geom = self
+%}
+
 }
 
 


### PR DESCRIPTION
Fixes https://github.com/OSGeo/gdal/issues/9920