### PR TITLE
Python bindings: Make Geometry.RemoveGeometry invalidate references

### DIFF
--- a/autotest/ogr/ogr_geom.py
+++ b/autotest/ogr/ogr_geom.py
@@ -4519,3 +4519,13 @@ def test_ogr_geom_buffer_with_args():
 
     with pytest.raises(Exception, match="Unsupported buffer option"):
         geom.Buffer(1, {"QUALITY": "HIGH"})
+
+
+def test_ogr_subgeom_use_after_parent_free():
+
+    g = ogr.CreateGeometryFromWkt("POLYGON ((0 0, 1 0, 1 1, 0 0))")
+
+    exterior_ring = g.GetGeometryRef(0)
+    del g
+
+    assert exterior_ring.GetPointCount() > 0  # does not crash

--- a/autotest/ogr/ogr_geom.py
+++ b/autotest/ogr/ogr_geom.py
@@ -4529,3 +4529,12 @@ def test_ogr_subgeom_use_after_parent_free():
     del g
 
     assert exterior_ring.GetPointCount() > 0  # does not crash
+
+
+def test_ogr_subgeom_use_after_remove():
+    g = ogr.CreateGeometryFromWkt("MultiPoint ((0 0))")
+    point = g.GetGeometryRef(0)
+    g.RemoveGeometry(0)
+
+    with pytest.raises(Exception):
+        point.ExportToWkt()

--- a/ogr/ogrpolyhedralsurface.cpp
+++ b/ogr/ogrpolyhedralsurface.cpp
@@ -870,6 +870,9 @@ int OGRPolyhedralSurface::getNumGeometries() const
 
 OGRPolygon *OGRPolyhedralSurface::getGeometryRef(int i)
 {
+    if (i < 0 || i >= oMP.nGeomCount)
+        return nullptr;
+
     return oMP.papoGeoms[i]->toPolygon();
 }
 
@@ -892,6 +895,9 @@ OGRPolygon *OGRPolyhedralSurface::getGeometryRef(int i)
 
 const OGRPolygon *OGRPolyhedralSurface::getGeometryRef(int i) const
 {
+    if (i < 0 || i >= oMP.nGeomCount)
+        return nullptr;
+
     return oMP.papoGeoms[i]->toPolygon();
 }
 

--- a/swig/include/python/ogr_python.i
+++ b/swig/include/python/ogr_python.i
@@ -990,8 +990,13 @@ def _WarnIfUserHasNotSpecifiedIfUsingExceptions():
   def __iter__(self):
       for i in range(self.GetGeometryCount()):
           yield self.GetGeometryRef(i)
-
 %}
+
+%feature("pythonappend") GetGeometryRef %{
+    if val is not None:
+        val._parent_geom = self
+%}
+
 }
 
 

--- a/swig/include/python/ogr_python.i
+++ b/swig/include/python/ogr_python.i
@@ -995,6 +995,22 @@ def _WarnIfUserHasNotSpecifiedIfUsingExceptions():
 %feature("pythonappend") GetGeometryRef %{
     if val is not None:
         val._parent_geom = self
+
+        if not hasattr(self, '_geom_refs'):
+            self._geom_refs = {}
+
+        if int(val.this) not in self._geom_refs:
+            import weakref
+            self._geom_refs[int(val.this)] = weakref.WeakSet()
+        self._geom_refs[int(val.this)].add(val)
+%}
+
+%feature("pythonprepend") RemoveGeometry %{
+    g = self.GetGeometryRef(args[0])
+
+    if g is not None:
+        for obj in self._geom_refs[int(g.this)]:
+            obj.this = None
 %}
 
 }


### PR DESCRIPTION
## What does this PR do?

Continuation of #10230 to address https://github.com/OSGeo/gdal/issues/9920#issuecomment-2111025554

This fix is not without cost and I'm not sure it should be applied. It increases the runtime of 

```
python3 -m timeit -r 5 -s 'from osgeo import ogr; g=ogr.CreateGeometryFromWkt("MULTIPOINT ((0 0))")' 'q=g.GetGeometryRef(0)'
```
from 627 ns to 1490 ns.

## What are related issues/pull requests?

#9920

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
