### PR TITLE
Doc: Updates to download.rst

### DIFF
--- a/doc/source/download.rst
+++ b/doc/source/download.rst
@@ -24,15 +24,6 @@ Current Release
 .. _`gdal-3.9.0.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.9.0/gdal-3.9.0.tar.gz
 .. _`3.9.0 md5`: https://github.com/OSGeo/gdal/releases/download/v3.9.0/gdal-3.9.0.tar.gz.md5
 
-Additional Supported Releases
-.............................
-
-* **2024-04-04** `gdal-3.8.5.tar.gz`_ `3.8.5 Release Notes`_ (`3.8.5 md5`_)
-
-.. _`3.8.5 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.8.5/NEWS.md
-.. _`gdal-3.8.5.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.8.5/gdal-3.8.5.tar.gz
-.. _`3.8.5 md5`: https://github.com/OSGeo/gdal/releases/download/v3.8.5/gdal-3.8.5.tar.gz.md5
-
 Past Releases
 .............
 

--- a/doc/source/download.rst
+++ b/doc/source/download.rst
@@ -10,8 +10,13 @@ Download
        :depth: 3
        :backlinks: none
 
+The GDAL project distributes GDAL as source code and :ref:`Containers` only. :ref:`Binaries` produced by others are available for a variety of platforms and package managers.
+
+Source Code
+-----------
+
 Current Release
-------------------------------------------------------------------------------
+...............
 
 * **2024-05-10** `gdal-3.9.0.tar.gz`_ `3.9.0 Release Notes`_ (`3.9.0 md5`_)
 
@@ -19,8 +24,8 @@ Current Release
 .. _`gdal-3.9.0.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.9.0/gdal-3.9.0.tar.gz
 .. _`3.9.0 md5`: https://github.com/OSGeo/gdal/releases/download/v3.9.0/gdal-3.9.0.tar.gz.md5
 
-Past Releases
-------------------------------------------------------------------------------
+Additional Supported Releases
+.............................
 
 * **2024-04-04** `gdal-3.8.5.tar.gz`_ `3.8.5 Release Notes`_ (`3.8.5 md5`_)
 
@@ -28,263 +33,15 @@ Past Releases
 .. _`gdal-3.8.5.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.8.5/gdal-3.8.5.tar.gz
 .. _`3.8.5 md5`: https://github.com/OSGeo/gdal/releases/download/v3.8.5/gdal-3.8.5.tar.gz.md5
 
-* **2024-02-18** `gdal-3.8.4.tar.gz`_ `3.8.4 Release Notes`_ (`3.8.4 md5`_)
+Past Releases
+.............
 
-.. _`3.8.4 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.8.4/NEWS.md
-.. _`gdal-3.8.4.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.8.4/gdal-3.8.4.tar.gz
-.. _`3.8.4 md5`: https://github.com/OSGeo/gdal/releases/download/v3.8.4/gdal-3.8.4.tar.gz.md5
-
-* **2024-01-08** `gdal-3.8.3.tar.gz`_ `3.8.3 Release Notes`_ (`3.8.3 md5`_)
-
-.. _`3.8.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.8.3/NEWS.md
-.. _`gdal-3.8.3.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.8.3/gdal-3.8.3.tar.gz
-.. _`3.8.3 md5`: https://github.com/OSGeo/gdal/releases/download/v3.8.3/gdal-3.8.3.tar.gz.md5
-
-* **2023-12-20** `gdal-3.8.2.tar.gz`_ `3.8.2 Release Notes`_ (`3.8.2 md5`_)
-
-.. _`3.8.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.8.2/NEWS.md
-.. _`gdal-3.8.2.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.8.2/gdal-3.8.2.tar.gz
-.. _`3.8.2 md5`: https://github.com/OSGeo/gdal/releases/download/v3.8.2/gdal-3.8.2.tar.gz.md5
-
-* **2023-11-30** `gdal-3.8.1.tar.gz`_ `3.8.1 Release Notes`_ (`3.8.1 md5`_)
-
-.. _`3.8.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.8.1/NEWS.md
-.. _`gdal-3.8.1.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.8.1/gdal-3.8.1.tar.gz
-.. _`3.8.1 md5`: https://github.com/OSGeo/gdal/releases/download/v3.8.1/gdal-3.8.1.tar.gz.md5
-
-* **2023-11-13** `gdal-3.8.0.tar.gz`_ `3.8.0 Release Notes`_ (`3.8.0 md5`_)
-
-.. _`3.8.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.8.0/NEWS.md
-.. _`gdal-3.8.0.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.8.0/gdal-3.8.0.tar.gz
-.. _`3.8.0 md5`: https://github.com/OSGeo/gdal/releases/download/v3.8.0/gdal-3.8.0.tar.gz.md5
-
-* **2023-11-03** `gdal-3.7.3.tar.gz`_ `3.7.3 Release Notes`_ (`3.7.3 md5`_)
-
-.. _`3.7.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.7.3/NEWS.md
-.. _`gdal-3.7.3.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.7.3/gdal-3.7.3.tar.gz
-.. _`3.7.3 md5`: https://github.com/OSGeo/gdal/releases/download/v3.7.3/gdal-3.7.3.tar.gz.md5
-
-* **2023-09-13** `gdal-3.7.2.tar.gz`_ `3.7.2 Release Notes`_ (`3.7.2 md5`_)
-
-.. _`3.7.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.7.2/NEWS.md
-.. _`gdal-3.7.2.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.7.2/gdal-3.7.2.tar.gz
-.. _`3.7.2 md5`: https://github.com/OSGeo/gdal/releases/download/v3.7.2/gdal-3.7.2.tar.gz.md5
-
-* **2023-07-13** `gdal-3.7.1.tar.gz`_ `3.7.1 Release Notes`_ (`3.7.1 md5`_)
-
-.. _`3.7.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.7.1/NEWS.md
-.. _`gdal-3.7.1.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.7.1/gdal-3.7.1.tar.gz
-.. _`3.7.1 md5`: https://github.com/OSGeo/gdal/releases/download/v3.7.1/gdal-3.7.1.tar.gz.md5
-
-* **2023-05-10** `gdal-3.7.0.tar.gz`_ `3.7.0 Release Notes`_ (`3.7.0 md5`_)
-
-.. _`3.7.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.7.0/NEWS.md
-.. _`gdal-3.7.0.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.7.0/gdal-3.7.0.tar.gz
-.. _`3.7.0 md5`: https://github.com/OSGeo/gdal/releases/download/v3.7.0/gdal-3.7.0.tar.gz.md5
-
-* **2023-04-21** `gdal-3.6.4.tar.gz`_ `3.6.4 Release Notes`_ (`3.6.4 md5`_)
-
-.. _`3.6.4 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.6.4/NEWS.md
-.. _`gdal-3.6.4.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.6.4/gdal-3.6.4.tar.gz
-.. _`3.6.4 md5`: https://github.com/OSGeo/gdal/releases/download/v3.6.4/gdal-3.6.4.tar.gz.md5
-
-* **2023-03-13** `gdal-3.6.3.tar.gz`_ `3.6.3 Release Notes`_ (`3.6.3 md5`_)
-
-.. _`3.6.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.6.3/NEWS.md
-.. _`gdal-3.6.3.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.6.3/gdal-3.6.3.tar.gz
-.. _`3.6.3 md5`: https://github.com/OSGeo/gdal/releases/download/v3.6.3/gdal-3.6.3.tar.gz.md5
-
-* **2023-01-05** `gdal-3.6.2.tar.gz`_ `3.6.2 Release Notes`_ (`3.6.2 md5`_)
-
-.. _`3.6.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.6.2/NEWS.md
-.. _`gdal-3.6.2.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.6.2/gdal-3.6.2.tar.gz
-.. _`3.6.2 md5`: https://github.com/OSGeo/gdal/releases/download/v3.6.2/gdal-3.6.2.tar.gz.md5
-
-* **2022-12-11** `gdal-3.6.1.tar.gz`_ `3.6.1 Release Notes`_ (`3.6.1 md5`_)
-
-.. _`3.6.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.6.1/NEWS.md
-.. _`gdal-3.6.1.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.6.1/gdal-3.6.1.tar.gz
-.. _`3.6.1 md5`: https://github.com/OSGeo/gdal/releases/download/v3.6.1/gdal-3.6.1.tar.gz.md5
-
-* **2022-11-06** `3.6.0 Release Notes`_ *Warning*: this version has been officially retracted and superseded per 3.6.1
-
-.. _`3.6.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.6.0/NEWS.md
-
-* **2022-10-21** `gdal-3.5.3.tar.gz`_ `3.5.3 Release Notes`_ (`3.5.3 md5`_)
-
-.. _`3.5.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.5.3/NEWS.md
-.. _`gdal-3.5.3.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.5.3/gdal-3.5.3.tar.gz
-.. _`3.5.3 md5`: https://github.com/OSGeo/gdal/releases/download/v3.5.3/gdal-3.5.3.tar.gz.md5
-
-* **2022-09-12** `gdal-3.5.2.tar.gz`_ `3.5.2 Release Notes`_ (`3.5.2 md5`_)
-
-.. _`3.5.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.5.2/NEWS.md
-.. _`gdal-3.5.2.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.5.2/gdal-3.5.2.tar.gz
-.. _`3.5.2 md5`: https://github.com/OSGeo/gdal/releases/download/v3.5.2/gdal-3.5.2.tar.gz.md5
-
-* **2022-07-06** `gdal-3.5.1.tar.gz`_ `3.5.1 Release Notes`_ (`3.5.1 md5`_)
-
-.. _`3.5.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.5.1/NEWS.md
-.. _`gdal-3.5.1.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.5.1/gdal-3.5.1.tar.gz
-.. _`3.5.1 md5`: https://github.com/OSGeo/gdal/releases/download/v3.5.1/gdal-3.5.1.tar.gz.md5
-
-* **2022-05-13** `gdal-3.5.0.tar.gz`_ `3.5.0 Release Notes`_ (`3.5.0 md5`_)
-
-.. _`3.5.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.5.0/NEWS.md
-.. _`gdal-3.5.0.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.5.0/gdal-3.5.0.tar.gz
-.. _`3.5.0 md5`: https://github.com/OSGeo/gdal/releases/download/v3.5.0/gdal-3.5.0.tar.gz.md5
-
-* **2022-04-22** `gdal-3.4.3.tar.gz`_ `3.4.3 Release Notes`_ (`3.4.3 md5`_)
-
-.. _`3.4.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.4.3/gdal/NEWS.md
-.. _`gdal-3.4.3.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.4.3/gdal-3.4.3.tar.gz
-.. _`3.4.3 md5`: https://github.com/OSGeo/gdal/releases/download/v3.4.3/gdal-3.4.3.tar.gz.md5
-
-* **2022-03-08** `gdal-3.4.2.tar.gz`_ `3.4.2 Release Notes`_ (`3.4.2 md5`_)
-
-.. _`3.4.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.4.2/gdal/NEWS.md
-.. _`gdal-3.4.2.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.4.2/gdal-3.4.2.tar.gz
-.. _`3.4.2 md5`: https://github.com/OSGeo/gdal/releases/download/v3.4.2/gdal-3.4.2.tar.gz.md5
-
-* **2021-12-27** `gdal-3.4.1.tar.gz`_ `3.4.1 Release Notes`_ (`3.4.1 md5`_)
-
-.. _`3.4.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.4.1/gdal/NEWS.md
-.. _`gdal-3.4.1.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.4.1/gdal-3.4.1.tar.gz
-.. _`3.4.1 md5`: https://github.com/OSGeo/gdal/releases/download/v3.4.1/gdal-3.4.1.tar.gz.md5
-
-* **2021-11-08** `gdal-3.4.0.tar.gz`_ `3.4.0 Release Notes`_ (`3.4.0 md5`_)
-
-.. _`3.4.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.4.0/gdal/NEWS.md
-.. _`gdal-3.4.0.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.4.0/gdal-3.4.0.tar.gz
-.. _`3.4.0 md5`: https://github.com/OSGeo/gdal/releases/download/v3.4.0/gdal-3.4.0.tar.gz.md5
-
-* **2021-10-29** `gdal-3.3.3.tar.gz`_ `3.3.3 Release Notes`_ (`3.3.3 md5`_)
-
-.. _`3.3.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.3.3/gdal/NEWS
-.. _`gdal-3.3.3.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.3.3/gdal-3.3.3.tar.gz
-.. _`3.3.3 md5`: https://github.com/OSGeo/gdal/releases/download/v3.3.3/gdal-3.3.3.tar.gz.md5
-
-* **2021-09-01** `gdal-3.3.2.tar.gz`_ `3.3.2 Release Notes`_ (`3.3.2 md5`_)
-
-.. _`3.3.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.3.2/gdal/NEWS
-.. _`gdal-3.3.2.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.3.2/gdal-3.3.2.tar.gz
-.. _`3.3.2 md5`: https://github.com/OSGeo/gdal/releases/download/v3.3.2/gdal-3.3.2.tar.gz.md5
-
-* **2021-07-05** `gdal-3.3.1.tar.gz`_ `3.3.1 Release Notes`_ (`3.3.1 md5`_)
-
-.. _`3.3.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.3.1/gdal/NEWS
-.. _`gdal-3.3.1.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.3.1/gdal-3.3.1.tar.gz
-.. _`3.3.1 md5`: https://github.com/OSGeo/gdal/releases/download/v3.3.1/gdal-3.3.1.tar.gz.md5
-
-* **2021-05-03** `gdal-3.3.0.tar.gz`_ `3.3.0 Release Notes`_ (`3.3.0 md5`_)
-
-.. _`3.3.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.3.0/gdal/NEWS
-.. _`gdal-3.3.0.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.3.0/gdal-3.3.0.tar.gz
-.. _`3.3.0 md5`: https://github.com/OSGeo/gdal/releases/download/v3.3.0/gdal-3.3.0.tar.gz.md5
-
-* **2021-05-04** `gdal-3.2.3.tar.gz`_ `3.2.3 Release Notes`_ (`3.2.3 md5`_)
-
-.. _`3.2.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.2.3/gdal/NEWS
-.. _`gdal-3.2.3.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.2.3/gdal-3.2.3.tar.gz
-.. _`3.2.3 md5`: https://github.com/OSGeo/gdal/releases/download/v3.2.3/gdal-3.2.3.tar.gz.md5
-
-* **2021-03-10** `gdal-3.2.2.tar.gz`_ `3.2.2 Release Notes`_ (`3.2.2 md5`_)
-
-.. _`3.2.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.2.2/gdal/NEWS
-.. _`gdal-3.2.2.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.2.2/gdal-3.2.2.tar.gz
-.. _`3.2.2 md5`: https://github.com/OSGeo/gdal/releases/download/v3.2.2/gdal-3.2.2.tar.gz.md5
-
-* **2020-12-28** `gdal-3.2.1.tar.gz`_ `3.2.1 Release Notes`_ (`3.2.1 md5`_)
-
-.. _`3.2.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.2.1/gdal/NEWS
-.. _`gdal-3.2.1.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.2.1/gdal-3.2.1.tar.gz
-.. _`3.2.1 md5`: https://github.com/OSGeo/gdal/releases/download/v3.2.1/gdal-3.2.1.tar.gz.md5
-
-* **2020-10-26** `gdal-3.2.0.tar.gz`_ `3.2.0 Release Notes`_ (`3.2.0 md5`_)
-
-.. _`3.2.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.2.0/gdal/NEWS
-.. _`gdal-3.2.0.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.2.0/gdal-3.2.0.tar.gz
-.. _`3.2.0 md5`: https://github.com/OSGeo/gdal/releases/download/v3.2.0/gdal-3.2.0.tar.gz.md5
-
-* **2020-10-23** `gdal-3.1.4.tar.gz`_ `3.1.4 Release Notes`_ (`3.1.4 md5`_)
-
-.. _`3.1.4 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.1.4/gdal/NEWS
-.. _`gdal-3.1.4.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.1.4/gdal-3.1.4.tar.gz
-.. _`3.1.4 md5`: https://github.com/OSGeo/gdal/releases/download/v3.1.4/gdal-3.1.4.tar.gz.md5
-
-* **2020-09-01** `gdal-3.1.3.tar.gz`_ `3.1.3 Release Notes`_ (`3.1.3 md5`_)
-
-.. _`3.1.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.1.3/gdal/NEWS
-.. _`gdal-3.1.3.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.1.3/gdal-3.1.3.tar.gz
-.. _`3.1.3 md5`: https://github.com/OSGeo/gdal/releases/download/v3.1.3/gdal-3.1.3.tar.gz.md5
-
-* **2020-07-07** `gdal-3.1.2.tar.gz`_ `3.1.2 Release Notes`_ (`3.1.2 md5`_)
-
-.. _`3.1.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.1.2/gdal/NEWS
-.. _`gdal-3.1.2.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.1.2/gdal-3.1.2.tar.gz
-.. _`3.1.2 md5`: https://github.com/OSGeo/gdal/releases/download/v3.1.2/gdal-3.1.2.tar.gz.md5
-
-* **2020-06-22** `gdal-3.1.1.tar.gz`_ `3.1.1 Release Notes`_ (`3.1.1 md5`_)
-
-.. _`3.1.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.1.1/gdal/NEWS
-.. _`gdal-3.1.1.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.1.1/gdal-3.1.1.tar.gz
-.. _`3.1.1 md5`: https://github.com/OSGeo/gdal/releases/download/v3.1.1/gdal-3.1.1.tar.gz.md5
-
-
-* **2020-05-03** `gdal-3.1.0.tar.gz`_ `3.1.0 Release Notes`_ (`3.1.0 md5`_)
-
-.. _`3.1.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.1.0/gdal/NEWS
-.. _`gdal-3.1.0.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.1.0/gdal-3.1.0.tar.gz
-.. _`3.1.0 md5`: https://github.com/OSGeo/gdal/releases/download/v3.1.0/gdal-3.1.0.tar.gz.md5
-
-* **2020-01-28** `gdal-3.0.4.tar.gz`_ `3.0.4 Release Notes`_ (`3.0.4 md5`_)
-
-.. _`3.0.4 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.0.4/gdal/NEWS
-.. _`gdal-3.0.4.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.0.4/gdal-3.0.4.tar.gz
-.. _`3.0.4 md5`: https://github.com/OSGeo/gdal/releases/download/v3.0.4/gdal-3.0.4.tar.gz.md5
-
-* **2020-01-08** `gdal-2.4.4.tar.gz`_ `2.4.4 Release Notes`_ (`2.4.4 md5`_)
-
-.. _`2.4.4 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.4.4/gdal/NEWS
-.. _`gdal-2.4.4.tar.gz`: https://download.osgeo.org/gdal/2.4.4/gdal-2.4.4.tar.gz
-.. _`2.4.4 md5`: https://download.osgeo.org/gdal/2.4.4/gdal-2.4.4.tar.gz.md5
-
-* **2020-01-08** `gdal-3.0.3.tar.gz`_ `3.0.3 Release Notes`_ (`3.0.3 md5`_)
-
-.. _`3.0.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.0.3/gdal/NEWS
-.. _`gdal-3.0.3.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.0.3/gdal-3.0.3.tar.gz
-.. _`3.0.3 md5`: https://github.com/OSGeo/gdal/releases/download/v3.0.3/gdal-3.0.3.tar.gz.md5
-
-* **2019-10-28** `gdal-3.0.2.tar.gz`_ `3.0.2 Release Notes`_ (`3.0.2 md5`_)
-
-.. _`3.0.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.0.2/gdal/NEWS
-.. _`gdal-3.0.2.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.0.2/gdal-3.0.2.tar.gz
-.. _`3.0.2 md5`: https://github.com/OSGeo/gdal/releases/download/v3.0.2/gdal-3.0.2.tar.gz.md5
-
-* **2019-10-28** `gdal-2.4.3.tar.gz`_ `2.4.3 Release Notes`_ (`2.4.3 md5`_)
-
-.. _`2.4.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.4.3/gdal/NEWS
-.. _`gdal-2.4.3.tar.gz`: https://download.osgeo.org/gdal/2.4.3/gdal-2.4.3.tar.gz
-.. _`2.4.3 md5`: https://download.osgeo.org/gdal/2.4.3/gdal-2.4.3.tar.gz.md5
-
-
-* **2019-06-28** `gdal-3.0.1.tar.gz`_ `3.0.1 Release Notes`_ (`3.0.1 md5`_)
-
-.. _`3.0.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.0.1/gdal/NEWS
-.. _`gdal-3.0.1.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.0.1/gdal-3.0.1.tar.gz
-.. _`3.0.1 md5`: https://github.com/OSGeo/gdal/releases/download/v3.0.1/gdal-3.0.1.tar.gz.md5
-
-
-* **2019-06-28** `gdal-2.4.2.tar.gz`_ `2.4.2 Release Notes`_ (`2.4.2 md5`_)
-
-.. _`2.4.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.4.2/gdal/NEWS
-.. _`gdal-2.4.2.tar.gz`: https://download.osgeo.org/gdal/2.4.2/gdal-2.4.2.tar.gz
-.. _`2.4.2 md5`: https://download.osgeo.org/gdal/2.4.2/gdal-2.4.2.tar.gz.md5
+Links to :ref:`download_past` are also available.
 
 .. _source:
 
 Development Source
-------------------------------------------------------------------------------
+..................
 
 The main repository for GDAL is located on GitHub at
 https://github.com/OSGeo/GDAL.
@@ -298,6 +55,9 @@ command
 
 
 Additional information is available about :ref:`build_requirements` and :ref:`building_from_source`.
+
+
+.. _binaries:
 
 Binaries
 ------------------------------------------------------------------------------
@@ -313,25 +73,43 @@ Windows
 ................................................................................
 
 Windows builds are available via `Conda Forge`_ (64-bit only). See the
-:ref:`conda` section for more detailed information.
+:ref:`conda` section for more detailed information. GDAL is also distributed
+by `GISInternals`_ and `OSGeo4W`_ and through the `NuGet`_ and :ref:`vcpkg` package managers.
 
 .. _`Conda Forge`: https://anaconda.org/conda-forge/gdal
+.. _`GISInternals`: https://www.gisinternals.com/index.html
+.. _`OSGeo4W`: https://trac.osgeo.org/osgeo4w/
+.. _`NuGet`: https://www.nuget.org/packages?q=GDAL
 
-Debian
+Linux
 ................................................................................
 
-Debian packages are now available on `Debian`_.
+Packages are available for `Debian`_, `Alpine_`, `Fedora_`, and other distributions.
 
 .. _`Debian`: https://tracker.debian.org/pkg/gdal
+.. _`Alpine`: https://pkgs.alpinelinux.org/package/edge/community/x86/gdal
+.. _`Fedora`: https://packages.fedoraproject.org/pkgs/gdal/
+
+
+Mac OS
+......
+
+GDAL packages are available on `Homebrew`_.
+
+.. _`Homebrew`: https://formulae.brew.sh/formula/gdal
+
+
+Cross-Platform Package Managers
+...............................
 
 .. _conda:
 
 Conda
-................................................................................
+^^^^^
 
 `Conda <https://anaconda.org>`__ can be used on multiple platforms (Windows, macOS, and Linux) to
 install software packages and manage environments. Conda packages for GDAL are
-available at https://anaconda.org/conda-forge/gdal.
+available through `conda-forge <https://anaconda.org/conda-forge/gdal>`__.
 
 .. only:: html
 
@@ -381,12 +159,13 @@ Then install GDAL from the ``gdal-master`` channel:
     mamba install -c gdal-master libgdal-arrow-parquet # if you need the Arrow and Parquet drivers
 
 
-Vcpkg
-................................................................................
+.. _vcpkg:
 
-The gdal port in vcpkg is kept up to date by Microsoft team members and community contributors.
-The url of vcpkg is: https://github.com/Microsoft/vcpkg .
-You can download and install gdal using the vcpkg dependency manager:
+vcpkg
+^^^^^
+
+The GDAL port in the `vcpkg <https://github.com/Microsoft/vcpkg>`__ dependency manager is kept up to date by Microsoft team members and community contributors.
+You can download and install GDAL using the vcpkg as follows:
 
 ::
 
@@ -399,7 +178,7 @@ You can download and install gdal using the vcpkg dependency manager:
 If the version is out of date, please `create an issue or pull request <https://github.com/Microsoft/vcpkg>`__ on the vcpkg repository.
 
 Spack
-................................................................................
+^^^^^
 
 Spack is a package management tool designed to support multiple versions and
 configurations of software on a wide variety of platforms and environments.
@@ -424,19 +203,21 @@ For a build with netcdf driver enabled:
     ./spack install gdal +netcdf
 
 
-Linux Docker images
-................................................................................
+.. _containers:
 
-Images with nightly builds of GDAL master and tagged releases are available at
-`GitHub Container registry <https://github.com/OSGeo/gdal/pkgs/container/gdal>`_
+Containers
+----------
+
+Docker images with nightly builds of GDAL master and tagged releases are available at
+`GitHub Container registry <https://github.com/OSGeo/gdal/pkgs/container/gdal>`_.
 
 Information on the content of the different configurations can be found at
-`https://github.com/OSGeo/gdal/tree/master/docker <https://github.com/OSGeo/gdal/tree/master/docker>`_
+`https://github.com/OSGeo/gdal/tree/master/docker <https://github.com/OSGeo/gdal/tree/master/docker>`_.
 
 
-Documentation only
-------------------------------------------------------------------------------
+Documentation
+-------------
 
 Besides being included when downloading the software, the documentation is
-also available independently as a `PDF file <gdal.pdf>`_,
-and `a .ZIP of individual HTML pages <https://github.com/OSGeo/gdal-docs/archive/refs/heads/master.zip>`_ for offline browsing. (The .ZIP also includes that .PDF.) The documentation reflects the latest state of the development branch of the software.
+also available independently as a `PDF file <https://gdal.org/gdal.pdf>`_,
+and `a ZIP of individual HTML pages <https://github.com/OSGeo/gdal-docs/archive/refs/heads/master.zip>`_ for offline browsing. (The ZIP also includes the PDF.) The documentation reflects the latest state of the development branch of the software.

--- a/doc/source/download_past.rst
+++ b/doc/source/download_past.rst
@@ -265,3 +265,368 @@ Past Releases
 .. _`2.4.2 md5`: https://download.osgeo.org/gdal/2.4.2/gdal-2.4.2.tar.gz.md5
 
 
+* **2019-05** `gdal-3.0.0.tar.gz`_ `3.0.0 Release Notes`_ (`3.0.0 md5`)_
+
+.. _`gdal-3.0.0.tar.gz`: http://download.osgeo.org/gdal/3.0.0/gdal-3.0.0.tar.gz
+.. _`3.0.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.0.0/gdal/NEWS
+.. _`3.0.0 md5`: http://download.osgeo.org/gdal/3.0.0/gdal-3.0.0.tar.gz.md5
+
+
+* **2019-03** `gdal-2.4.1.tar.gz`_ `2.4.1 Release Notes`_ (`2.4.1 md5`)_
+
+.. _`gdal-2.4.1.tar.gz`: http://download.osgeo.org/gdal/2.4.1/gdal-2.4.1.tar.gz
+.. _`2.4.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.4.1/gdal/NEWS
+.. _`2.4.1 md5`: http://download.osgeo.org/gdal/2.4.1/gdal-2.4.1.tar.gz.md5
+
+
+* **2018-12** `gdal-2.4.0.tar.gz`_ `2.4.0 Release Notes`_ (`2.4.0 md5`)_
+
+.. _`gdal-2.4.0.tar.gz`: http://download.osgeo.org/gdal/2.4.0/gdal-2.4.0.tar.gz
+.. _`2.4.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.4.0/gdal/NEWS
+.. _`2.4.0 md5`: http://download.osgeo.org/gdal/2.4.0/gdal-2.4.0.tar.gz.md5
+
+
+* **2019-05** `gdal-3.0.0.tar.gz`_ `3.0.0 Release Notes`_ (`3.0.0 md5`)_
+
+.. _`gdal-3.0.0.tar.gz`: http://download.osgeo.org/gdal/3.0.0/gdal-3.0.0.tar.gz
+.. _`3.0.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.0.0/gdal/NEWS
+.. _`3.0.0 md5`: http://download.osgeo.org/gdal/3.0.0/gdal-3.0.0.tar.gz.md5
+
+
+* **2019-03** `gdal-2.4.1.tar.gz`_ `2.4.1 Release Notes`_ (`2.4.1 md5`)_
+
+.. _`gdal-2.4.1.tar.gz`: http://download.osgeo.org/gdal/2.4.1/gdal-2.4.1.tar.gz
+.. _`2.4.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.4.1/gdal/NEWS
+.. _`2.4.1 md5`: http://download.osgeo.org/gdal/2.4.1/gdal-2.4.1.tar.gz.md5
+
+
+* **2018-12** `gdal-2.4.0.tar.gz`_ `2.4.0 Release Notes`_ (`2.4.0 md5`)_
+
+.. _`gdal-2.4.0.tar.gz`: http://download.osgeo.org/gdal/2.4.0/gdal-2.4.0.tar.gz
+.. _`2.4.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.4.0/gdal/NEWS
+.. _`2.4.0 md5`: http://download.osgeo.org/gdal/2.4.0/gdal-2.4.0.tar.gz.md5
+
+
+* **2018-12** `gdal-2.3.3.tar.gz`_ `2.3.3 Release Notes`_ (`2.3.3 md5`)_
+
+.. _`gdal-2.3.3.tar.gz`: http://download.osgeo.org/gdal/2.3.3/gdal-2.3.3.tar.gz
+.. _`2.3.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.3.3/gdal/NEWS
+.. _`2.3.3 md5`: http://download.osgeo.org/gdal/2.3.3/gdal-2.3.3.tar.gz.md5
+
+
+* **2018-09** `gdal-2.3.2.tar.gz`_ `2.3.2 Release Notes`_ (`2.3.2 md5`)_
+
+.. _`gdal-2.3.2.tar.gz`: http://download.osgeo.org/gdal/2.3.2/gdal-2.3.2.tar.gz
+.. _`2.3.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.3.2/gdal/NEWS
+.. _`2.3.2 md5`: http://download.osgeo.org/gdal/2.3.2/gdal-2.3.2.tar.gz.md5
+
+
+* **2018-06** `gdal-2.3.1.tar.gz`_ `2.3.1 Release Notes`_ (`2.3.1 md5`)_
+
+.. _`gdal-2.3.1.tar.gz`: http://download.osgeo.org/gdal/2.3.1/gdal-2.3.1.tar.gz
+.. _`2.3.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.3.1/gdal/NEWS
+.. _`2.3.1 md5`: http://download.osgeo.org/gdal/2.3.1/gdal-2.3.1.tar.gz.md5
+
+
+* **2018-05** `gdal-2.3.0.tar.gz`_ `2.3.0 Release Notes`_ (`2.3.0 md5`)_
+
+.. _`gdal-2.3.0.tar.gz`: http://download.osgeo.org/gdal/2.3.0/gdal-2.3.0.tar.gz
+.. _`2.3.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.3.0/gdal/NEWS
+.. _`2.3.0 md5`: http://download.osgeo.org/gdal/2.3.0/gdal-2.3.0.tar.gz.md5
+
+
+* **2018-03** `gdal-2.2.4.tar.gz`_ `2.2.4 Release Notes`_ (`2.2.4 md5`)_
+
+.. _`gdal-2.2.4.tar.gz`: http://download.osgeo.org/gdal/2.2.4/gdal-2.2.4.tar.gz
+.. _`2.2.4 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.2.4/gdal/NEWS
+.. _`2.2.4 md5`: http://download.osgeo.org/gdal/2.2.4/gdal-2.2.4.tar.gz.md5
+
+
+* **2017-11** `gdal-2.2.3.tar.gz`_ `2.2.3 Release Notes`_ (`2.2.3 md5`)_
+
+.. _`gdal-2.2.3.tar.gz`: http://download.osgeo.org/gdal/2.2.3/gdal-2.2.3.tar.gz
+.. _`2.2.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.2.3/gdal/NEWS
+.. _`2.2.3 md5`: http://download.osgeo.org/gdal/2.2.3/gdal-2.2.3.tar.gz.md5
+
+
+* **2017-09** `gdal-2.2.2.tar.gz`_ `2.2.2 Release Notes`_ (`2.2.2 md5`)_
+
+.. _`gdal-2.2.2.tar.gz`: http://download.osgeo.org/gdal/2.2.2/gdal-2.2.2.tar.gz
+.. _`2.2.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.2.2/gdal/NEWS
+.. _`2.2.2 md5`: http://download.osgeo.org/gdal/2.2.2/gdal-2.2.2.tar.gz.md5
+
+
+* **2017-06** `gdal-2.2.1.tar.gz`_ `2.2.1 Release Notes`_ (`2.2.1 md5`)_
+
+.. _`gdal-2.2.1.tar.gz`: http://download.osgeo.org/gdal/2.2.1/gdal-2.2.1.tar.gz
+.. _`2.2.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.2.1/gdal/NEWS
+.. _`2.2.1 md5`: http://download.osgeo.org/gdal/2.2.1/gdal-2.2.1.tar.gz.md5
+
+
+* **2017-06** `gdal-2.1.4.tar.gz`_ `2.1.4 Release Notes`_ (`2.1.4 md5`)_
+
+.. _`gdal-2.1.4.tar.gz`: http://download.osgeo.org/gdal/2.1.4/gdal-2.1.4.tar.gz
+.. _`2.1.4 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.1.4/gdal/NEWS
+.. _`2.1.4 md5`: http://download.osgeo.org/gdal/2.1.4/gdal-2.1.4.tar.gz.md5
+
+
+* **2017-04** `gdal-2.2.0.tar.gz`_ `2.2.0 Release Notes`_ (`2.2.0 md5`)_
+
+.. _`gdal-2.2.0.tar.gz`: http://download.osgeo.org/gdal/2.2.0/gdal-2.2.0.tar.gz
+.. _`2.2.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.2.0/gdal/NEWS
+.. _`2.2.0 md5`: http://download.osgeo.org/gdal/2.2.0/gdal-2.2.0.tar.gz.md5
+
+
+* **2017-01** `gdal-2.1.3.tar.gz`_ `2.1.3 Release Notes`_ (`2.1.3 md5`)_
+
+.. _`gdal-2.1.3.tar.gz`: http://download.osgeo.org/gdal/2.1.3/gdal-2.1.3.tar.gz
+.. _`2.1.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.1.3/gdal/NEWS
+.. _`2.1.3 md5`: http://download.osgeo.org/gdal/2.1.3/gdal-2.1.3.tar.gz.md5
+
+
+* **2016-10** `gdal-2.1.2.tar.gz`_ `2.1.2 Release Notes`_ (`2.1.2 md5`)_
+
+.. _`gdal-2.1.2.tar.gz`: http://download.osgeo.org/gdal/2.1.2/gdal-2.1.2.tar.gz
+.. _`2.1.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.1.2/gdal/NEWS
+.. _`2.1.2 md5`: http://download.osgeo.org/gdal/2.1.2/gdal-2.1.2.tar.gz.md5
+
+
+* **2016-07** `gdal-2.1.1.tar.gz`_ `2.1.1 Release Notes`_ (`2.1.1 md5`)_
+
+.. _`gdal-2.1.1.tar.gz`: http://download.osgeo.org/gdal/2.1.1/gdal-2.1.1.tar.gz
+.. _`2.1.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.1.1/gdal/NEWS
+.. _`2.1.1 md5`: http://download.osgeo.org/gdal/2.1.1/gdal-2.1.1.tar.gz.md5
+
+
+* **2016-07** `gdal-2.0.3.tar.gz`_ `2.0.3 Release Notes`_ (`2.0.3 md5`)_
+
+.. _`gdal-2.0.3.tar.gz`: http://download.osgeo.org/gdal/2.0.3/gdal-2.0.3.tar.gz
+.. _`2.0.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.0.3/gdal/NEWS
+.. _`2.0.3 md5`: http://download.osgeo.org/gdal/2.0.3/gdal-2.0.3.tar.gz.md5
+
+
+* **2016-07** `gdal-1.11.5.tar.gz`_ `1.11.5 Release Notes`_ (`1.11.5 md5`)_
+
+.. _`gdal-1.11.5.tar.gz`: http://download.osgeo.org/gdal/1.11.5/gdal-1.11.5.tar.gz
+.. _`1.11.5 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.11.5/gdal/NEWS
+.. _`1.11.5 md5`: http://download.osgeo.org/gdal/1.11.5/gdal-1.11.5.tar.gz.md5
+
+
+* **2016-04** `gdal-2.1.0.tar.gz`_ `2.1.0 Release Notes`_ (`2.1.0 md5`)_
+
+.. _`gdal-2.1.0.tar.gz`: http://download.osgeo.org/gdal/2.1.0/gdal-2.1.0.tar.gz
+.. _`2.1.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.1.0/gdal/NEWS
+.. _`2.1.0 md5`: http://download.osgeo.org/gdal/2.1.0/gdal-2.1.0.tar.gz.md5
+
+
+* **2016-01** `gdal-2.0.2.tar.gz`_ `2.0.2 Release Notes`_ (`2.0.2 md5`)_
+
+.. _`gdal-2.0.2.tar.gz`: http://download.osgeo.org/gdal/2.0.2/gdal-2.0.2.tar.gz
+.. _`2.0.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.0.2/gdal/NEWS
+.. _`2.0.2 md5`: http://download.osgeo.org/gdal/2.0.2/gdal-2.0.2.tar.gz.md5
+
+
+* **2016-01** `gdal-1.11.4.tar.gz`_ `1.11.4 Release Notes`_ (`1.11.4 md5`)_
+
+.. _`gdal-1.11.4.tar.gz`: http://download.osgeo.org/gdal/1.11.4/gdal-1.11.4.tar.gz
+.. _`1.11.4 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.11.4/gdal/NEWS
+.. _`1.11.4 md5`: http://download.osgeo.org/gdal/1.11.4/gdal-1.11.4.tar.gz.md5
+
+
+* **2015-09** `gdal-2.0.1.tar.gz`_ `2.0.1 Release Notes`_ (`2.0.1 md5`)_
+
+.. _`gdal-2.0.1.tar.gz`: http://download.osgeo.org/gdal/2.0.1/gdal-2.0.1.tar.gz
+.. _`2.0.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.0.1/gdal/NEWS
+.. _`2.0.1 md5`: http://download.osgeo.org/gdal/2.0.1/gdal-2.0.1.tar.gz.md5
+
+
+* **2015-09** `gdal-1.11.3.tar.gz`_ `1.11.3 Release Notes`_ (`1.11.3 md5`)_
+
+.. _`gdal-1.11.3.tar.gz`: http://download.osgeo.org/gdal/1.11.3/gdal-1.11.3.tar.gz
+.. _`1.11.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.11.3/gdal/NEWS
+.. _`1.11.3 md5`: http://download.osgeo.org/gdal/1.11.3/gdal-1.11.3.tar.gz.md5
+
+
+* **2015-06** `gdal-2.0.0.tar.gz`_ `2.0.0 Release Notes`_ (`2.0.0 md5`)_
+
+.. _`gdal-2.0.0.tar.gz`: http://download.osgeo.org/gdal/2.0.0/gdal-2.0.0.tar.gz
+.. _`2.0.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.0.0/gdal/NEWS
+.. _`2.0.0 md5`: http://download.osgeo.org/gdal/2.0.0/gdal-2.0.0.tar.gz.md5
+
+
+* **2015-02** `gdal-1.11.2.tar.gz`_ `1.11.2 Release Notes`_ (`1.11.2 md5`)_
+
+.. _`gdal-1.11.2.tar.gz`: http://download.osgeo.org/gdal/1.11.2/gdal-1.11.2.tar.gz
+.. _`1.11.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.11.2/gdal/NEWS
+.. _`1.11.2 md5`: http://download.osgeo.org/gdal/1.11.2/gdal-1.11.2.tar.gz.md5
+
+
+* **2014-09** `gdal-1.11.1.tar.gz`_ `1.11.1 Release Notes`_ (`1.11.1 md5`)_
+
+.. _`gdal-1.11.1.tar.gz`: http://download.osgeo.org/gdal/1.11.1/gdal-1.11.1.tar.gz
+.. _`1.11.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.11.1/gdal/NEWS
+.. _`1.11.1 md5`: http://download.osgeo.org/gdal/1.11.1/gdal-1.11.1.tar.gz.md5
+
+
+* **2014-04** `gdal-1.11.0.tar.gz`_ `1.11.0 Release Notes`_ (`1.11.0 md5`)_
+
+.. _`gdal-1.11.0.tar.gz`: http://download.osgeo.org/gdal/1.11.0/gdal-1.11.0.tar.gz
+.. _`1.11.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.11.0/gdal/NEWS
+.. _`1.11.0 md5`: http://download.osgeo.org/gdal/1.11.0/gdal-1.11.0.tar.gz.md5
+
+
+* **2013-08** `gdal-1.10.1.tar.gz`_ `1.10.1 Release Notes`_ (`1.10.1 md5`)_
+
+.. _`gdal-1.10.1.tar.gz`: http://download.osgeo.org/gdal/1.10.1/gdal-1.10.1.tar.gz
+.. _`1.10.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.10.1/gdal/NEWS
+.. _`1.10.1 md5`: http://download.osgeo.org/gdal/1.10.1/gdal-1.10.1.tar.gz.md5
+
+
+* **2013-04** `gdal-1.10.0.tar.gz`_ `1.10.0 Release Notes`_ (`1.10.0 md5`)_
+
+.. _`gdal-1.10.0.tar.gz`: http://download.osgeo.org/gdal/1.10.0/gdal-1.10.0.tar.gz
+.. _`1.10.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.10.0/gdal/NEWS
+.. _`1.10.0 md5`: http://download.osgeo.org/gdal/1.10.0/gdal-1.10.0.tar.gz.md5
+
+
+* **2012-10** `gdal-1.9.2.tar.gz`_ `1.9.2 Release Notes`_ (`1.9.2 md5`)_
+
+.. _`gdal-1.9.2.tar.gz`: http://download.osgeo.org/gdal/old_releases/gdal-1.9.2.tar.gz
+.. _`1.9.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.9.2/gdal/NEWS
+.. _`1.9.2 md5`: http://download.osgeo.org/gdal/old_releases/gdal-1.9.2.tar.gz.md5
+
+
+* **2012-05** `gdal-1.9.1.tar.gz`_ `1.9.1 Release Notes`_ (`1.9.1 md5`)_
+
+.. _`gdal-1.9.1.tar.gz`: http://download.osgeo.org/gdal/old_releases/gdal-1.9.1.tar.gz
+.. _`1.9.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.9.1/gdal/NEWS
+.. _`1.9.1 md5`: http://download.osgeo.org/gdal/old_releases/gdal-1.9.1.tar.gz.md5
+
+
+* **2011-12** `gdal-1.9.0.tar.gz`_ `1.9.0 Release Notes`_ (`1.9.0 md5`)_
+
+.. _`gdal-1.9.0.tar.gz`: http://download.osgeo.org/gdal/old_releases/gdal-1.9.0.tar.gz
+.. _`1.9.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.9.0/gdal/NEWS
+.. _`1.9.0 md5`: http://download.osgeo.org/gdal/old_releases/gdal-1.9.0.tar.gz.md5
+
+
+* **2011-07** `gdal-1.8.1.tar.gz`_ `1.8.1 Release Notes`_ (`1.8.1 md5`)_
+
+.. _`gdal-1.8.1.tar.gz`: http://download.osgeo.org/gdal/old_releases/gdal-1.8.1.tar.gz
+.. _`1.8.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.8.1/gdal/NEWS
+.. _`1.8.1 md5`: http://download.osgeo.org/gdal/old_releases/gdal-1.8.1.tar.gz.md5
+
+
+* **2011-01** `gdal-1.8.0.tar.gz`_ `1.8.0 Release Notes`_ (`1.8.0 md5`)_
+
+.. _`gdal-1.8.0.tar.gz`: http://download.osgeo.org/gdal/old_releases/gdal-1.8.0.tar.gz
+.. _`1.8.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.8.0/gdal/NEWS
+.. _`1.8.0 md5`: http://download.osgeo.org/gdal/old_releases/gdal-1.8.0.tar.gz.md5
+
+
+* **2010-11** `gdal-1.7.3.tar.gz`_ `1.7.3 Release Notes`_ (`1.7.3 md5`)_
+
+.. _`gdal-1.7.3.tar.gz`: http://download.osgeo.org/gdal/old_releases/gdal-1.7.3.tar.gz
+.. _`1.7.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.7.3/gdal/NEWS
+.. _`1.7.3 md5`: http://download.osgeo.org/gdal/old_releases/gdal-1.7.3.tar.gz.md5
+
+* **2010-04** `gdal-1.7.2.tar.gz`_ `1.7.2 Release Notes`_ (`1.7.2 md5`)_
+
+.. _`gdal-1.7.2.tar.gz`: http://download.osgeo.org/gdal/old_releases/gdal-1.7.2.tar.gz
+.. _`1.7.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.7.2/gdal/NEWS
+.. _`1.7.2 md5`: http://download.osgeo.org/gdal/old_releases/gdal-1.7.2.tar.gz.md5
+
+
+* **2010-02** `gdal-1.7.1.tar.gz`_ `1.7.1 Release Notes`_ (`1.7.1 md5`)_
+
+.. _`gdal-1.7.1.tar.gz`: http://download.osgeo.org/gdal/old_releases/gdal-1.7.1.tar.gz
+.. _`1.7.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.7.1/gdal/NEWS
+.. _`1.7.1 md5`: http://download.osgeo.org/gdal/old_releases/gdal-1.7.1.tar.gz.md5
+
+
+* **2010-01** `1.7.0 (retracted) Release Notes`_
+
+.. _`1.7.0 (retracted) Release Notes`: https://github.com/OSGeo/gdal/blob/v1.7.0/gdal/NEWS
+
+
+* **2009-11** `gdal-1.6.3.tar.gz`_ `1.6.3 Release Notes`_
+
+.. _`gdal-1.6.3.tar.gz`: http://download.osgeo.org/gdal/old_releases/gdal-1.6.3.tar.gz
+.. _`1.6.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.6.3/gdal/NEWS
+
+
+* **2009-08** `gdal-1.6.2.tar.gz`_ `1.6.2 Release Notes`_
+
+.. _`gdal-1.6.2.tar.gz`: http://download.osgeo.org/gdal/old_releases/gdal-1.6.2.tar.gz
+.. _`1.6.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.6.2/gdal/NEWS
+
+
+* **2009-05** `gdal-1.6.1.tar.gz`_ `1.6.1 Release Notes`_
+
+.. _`gdal-1.6.1.tar.gz`: http://download.osgeo.org/gdal/old_releases/gdal-1.6.1.tar.gz
+.. _`1.6.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.6.1/gdal/NEWS
+
+
+* **2008-12** `gdal-1.6.0.tar.gz`_ `1.6.0 Release Notes`_
+
+.. _`gdal-1.6.0.tar.gz`: http://download.osgeo.org/gdal/old_releases/gdal-1.6.0.tar.gz
+.. _`1.6.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.6.0/gdal/NEWS
+
+
+* **2009-01** `gdal-1.5.4.tar.gz`_ `1.5.4 Release Notes`_
+
+.. _`gdal-1.5.4.tar.gz`: http://download.osgeo.org/gdal/old_releases/gdal-1.5.4.tar.gz
+.. _`1.5.4 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.5.4/gdal/NEWS
+
+
+* **2008-10** `gdal-1.5.3.tar.gz`_ `1.5.3 Release Notes`_
+
+.. _`gdal-1.5.3.tar.gz`: http://download.osgeo.org/gdal/old_releases/gdal-1.5.3.tar.gz
+.. _`1.5.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.5.3/gdal/NEWS
+
+
+* **2008-05** `gdal-1.5.2.tar.gz`_ `1.5.2 Release Notes`_
+
+.. _`gdal-1.5.2.tar.gz`: http://download.osgeo.org/gdal/old_releases/gdal-1.5.2.tar.gz
+.. _`1.5.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.5.2/gdal/NEWS
+
+
+* **2008-03** `gdal-1.5.1.tar.gz`_ `1.5.1 Release Notes`_
+
+.. _`gdal-1.5.1.tar.gz`: http://download.osgeo.org/gdal/old_releases/gdal-1.5.1.tar.gz
+.. _`1.5.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.5.1/gdal/NEWS
+
+
+* **2007-12** `gdal-1.5.0.tar.gz`_ `1.5.0 Release Notes`_
+
+.. _`gdal-1.5.0.tar.gz`: http://download.osgeo.org/gdal/old_releases/gdal-1.5.0.tar.gz
+.. _`1.5.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.5.0/gdal/NEWS
+
+
+* **2008-12** `gdal-1.4.5.tar.gz`_ `1.4.5 Release Notes`_
+
+.. _`gdal-1.4.5.tar.gz`: http://download.osgeo.org/gdal/old_releases/gdal-1.4.5.tar.gz
+.. _`1.4.5 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.4.5/gdal/NEWS
+
+
+* **2007-11** `gdal-1.4.4.tar.gz`_ `1.4.4 Release Notes`_
+
+.. _`gdal-1.4.4.tar.gz`: http://download.osgeo.org/gdal/old_releases/gdal-1.4.4.tar.gz
+.. _`1.4.4 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.4.4/gdal/NEWS
+
+
+* **2007-06** `gdal-1.4.2.tar.gz`_ `1.4.2 Release Notes`_
+
+.. _`gdal-1.4.2.tar.gz`: http://download.osgeo.org/gdal/old_releases/gdal-1.4.2.tar.gz
+.. _`1.4.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.4.2/gdal/NEWS
+
+
+* **2007-04** `gdal-1.4.1.tar.gz`_ `1.4.1 Release Notes`_
+
+.. _`gdal-1.4.1.tar.gz`: http://download.osgeo.org/gdal/old_releases/gdal-1.4.1.tar.gz
+.. _`1.4.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v1.4.1/gdal/NEWS
+
+
+* **2007-01** `gdal-1.4.0.tar.gz`_
+
+.. _`gdal-1.4.0.tar.gz`: http://download.osgeo.org/gdal/old_releases/gdal-1.4.0.tar.gz

--- a/doc/source/download_past.rst
+++ b/doc/source/download_past.rst
@@ -5,6 +5,12 @@
 Past Releases
 =============
 
+* **2024-04-04** `gdal-3.8.5.tar.gz`_ `3.8.5 Release Notes`_ (`3.8.5 md5`_)
+
+.. _`3.8.5 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.8.5/NEWS.md
+.. _`gdal-3.8.5.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.8.5/gdal-3.8.5.tar.gz
+.. _`3.8.5 md5`: https://github.com/OSGeo/gdal/releases/download/v3.8.5/gdal-3.8.5.tar.gz.md5
+
 * **2024-02-18** `gdal-3.8.4.tar.gz`_ `3.8.4 Release Notes`_ (`3.8.4 md5`_)
 
 .. _`3.8.4 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.8.4/NEWS.md

--- a/doc/source/download_past.rst
+++ b/doc/source/download_past.rst
@@ -1,0 +1,261 @@
+:orphan:
+
+.. _download_past:
+
+Past Releases
+=============
+
+* **2024-02-18** `gdal-3.8.4.tar.gz`_ `3.8.4 Release Notes`_ (`3.8.4 md5`_)
+
+.. _`3.8.4 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.8.4/NEWS.md
+.. _`gdal-3.8.4.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.8.4/gdal-3.8.4.tar.gz
+.. _`3.8.4 md5`: https://github.com/OSGeo/gdal/releases/download/v3.8.4/gdal-3.8.4.tar.gz.md5
+
+* **2024-01-08** `gdal-3.8.3.tar.gz`_ `3.8.3 Release Notes`_ (`3.8.3 md5`_)
+
+.. _`3.8.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.8.3/NEWS.md
+.. _`gdal-3.8.3.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.8.3/gdal-3.8.3.tar.gz
+.. _`3.8.3 md5`: https://github.com/OSGeo/gdal/releases/download/v3.8.3/gdal-3.8.3.tar.gz.md5
+
+* **2023-12-20** `gdal-3.8.2.tar.gz`_ `3.8.2 Release Notes`_ (`3.8.2 md5`_)
+
+.. _`3.8.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.8.2/NEWS.md
+.. _`gdal-3.8.2.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.8.2/gdal-3.8.2.tar.gz
+.. _`3.8.2 md5`: https://github.com/OSGeo/gdal/releases/download/v3.8.2/gdal-3.8.2.tar.gz.md5
+
+* **2023-11-30** `gdal-3.8.1.tar.gz`_ `3.8.1 Release Notes`_ (`3.8.1 md5`_)
+
+.. _`3.8.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.8.1/NEWS.md
+.. _`gdal-3.8.1.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.8.1/gdal-3.8.1.tar.gz
+.. _`3.8.1 md5`: https://github.com/OSGeo/gdal/releases/download/v3.8.1/gdal-3.8.1.tar.gz.md5
+
+* **2023-11-13** `gdal-3.8.0.tar.gz`_ `3.8.0 Release Notes`_ (`3.8.0 md5`_)
+
+.. _`3.8.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.8.0/NEWS.md
+.. _`gdal-3.8.0.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.8.0/gdal-3.8.0.tar.gz
+.. _`3.8.0 md5`: https://github.com/OSGeo/gdal/releases/download/v3.8.0/gdal-3.8.0.tar.gz.md5
+
+* **2023-11-03** `gdal-3.7.3.tar.gz`_ `3.7.3 Release Notes`_ (`3.7.3 md5`_)
+
+.. _`3.7.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.7.3/NEWS.md
+.. _`gdal-3.7.3.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.7.3/gdal-3.7.3.tar.gz
+.. _`3.7.3 md5`: https://github.com/OSGeo/gdal/releases/download/v3.7.3/gdal-3.7.3.tar.gz.md5
+
+* **2023-09-13** `gdal-3.7.2.tar.gz`_ `3.7.2 Release Notes`_ (`3.7.2 md5`_)
+
+.. _`3.7.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.7.2/NEWS.md
+.. _`gdal-3.7.2.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.7.2/gdal-3.7.2.tar.gz
+.. _`3.7.2 md5`: https://github.com/OSGeo/gdal/releases/download/v3.7.2/gdal-3.7.2.tar.gz.md5
+
+* **2023-07-13** `gdal-3.7.1.tar.gz`_ `3.7.1 Release Notes`_ (`3.7.1 md5`_)
+
+.. _`3.7.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.7.1/NEWS.md
+.. _`gdal-3.7.1.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.7.1/gdal-3.7.1.tar.gz
+.. _`3.7.1 md5`: https://github.com/OSGeo/gdal/releases/download/v3.7.1/gdal-3.7.1.tar.gz.md5
+
+* **2023-05-10** `gdal-3.7.0.tar.gz`_ `3.7.0 Release Notes`_ (`3.7.0 md5`_)
+
+.. _`3.7.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.7.0/NEWS.md
+.. _`gdal-3.7.0.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.7.0/gdal-3.7.0.tar.gz
+.. _`3.7.0 md5`: https://github.com/OSGeo/gdal/releases/download/v3.7.0/gdal-3.7.0.tar.gz.md5
+
+* **2023-04-21** `gdal-3.6.4.tar.gz`_ `3.6.4 Release Notes`_ (`3.6.4 md5`_)
+
+.. _`3.6.4 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.6.4/NEWS.md
+.. _`gdal-3.6.4.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.6.4/gdal-3.6.4.tar.gz
+.. _`3.6.4 md5`: https://github.com/OSGeo/gdal/releases/download/v3.6.4/gdal-3.6.4.tar.gz.md5
+
+* **2023-03-13** `gdal-3.6.3.tar.gz`_ `3.6.3 Release Notes`_ (`3.6.3 md5`_)
+
+.. _`3.6.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.6.3/NEWS.md
+.. _`gdal-3.6.3.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.6.3/gdal-3.6.3.tar.gz
+.. _`3.6.3 md5`: https://github.com/OSGeo/gdal/releases/download/v3.6.3/gdal-3.6.3.tar.gz.md5
+
+* **2023-01-05** `gdal-3.6.2.tar.gz`_ `3.6.2 Release Notes`_ (`3.6.2 md5`_)
+
+.. _`3.6.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.6.2/NEWS.md
+.. _`gdal-3.6.2.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.6.2/gdal-3.6.2.tar.gz
+.. _`3.6.2 md5`: https://github.com/OSGeo/gdal/releases/download/v3.6.2/gdal-3.6.2.tar.gz.md5
+
+* **2022-12-11** `gdal-3.6.1.tar.gz`_ `3.6.1 Release Notes`_ (`3.6.1 md5`_)
+
+.. _`3.6.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.6.1/NEWS.md
+.. _`gdal-3.6.1.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.6.1/gdal-3.6.1.tar.gz
+.. _`3.6.1 md5`: https://github.com/OSGeo/gdal/releases/download/v3.6.1/gdal-3.6.1.tar.gz.md5
+
+* **2022-11-06** `3.6.0 Release Notes`_ *Warning*: this version has been officially retracted and superseded per 3.6.1
+
+.. _`3.6.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.6.0/NEWS.md
+
+* **2022-10-21** `gdal-3.5.3.tar.gz`_ `3.5.3 Release Notes`_ (`3.5.3 md5`_)
+
+.. _`3.5.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.5.3/NEWS.md
+.. _`gdal-3.5.3.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.5.3/gdal-3.5.3.tar.gz
+.. _`3.5.3 md5`: https://github.com/OSGeo/gdal/releases/download/v3.5.3/gdal-3.5.3.tar.gz.md5
+
+* **2022-09-12** `gdal-3.5.2.tar.gz`_ `3.5.2 Release Notes`_ (`3.5.2 md5`_)
+
+.. _`3.5.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.5.2/NEWS.md
+.. _`gdal-3.5.2.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.5.2/gdal-3.5.2.tar.gz
+.. _`3.5.2 md5`: https://github.com/OSGeo/gdal/releases/download/v3.5.2/gdal-3.5.2.tar.gz.md5
+
+* **2022-07-06** `gdal-3.5.1.tar.gz`_ `3.5.1 Release Notes`_ (`3.5.1 md5`_)
+
+.. _`3.5.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.5.1/NEWS.md
+.. _`gdal-3.5.1.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.5.1/gdal-3.5.1.tar.gz
+.. _`3.5.1 md5`: https://github.com/OSGeo/gdal/releases/download/v3.5.1/gdal-3.5.1.tar.gz.md5
+
+* **2022-05-13** `gdal-3.5.0.tar.gz`_ `3.5.0 Release Notes`_ (`3.5.0 md5`_)
+
+.. _`3.5.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.5.0/NEWS.md
+.. _`gdal-3.5.0.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.5.0/gdal-3.5.0.tar.gz
+.. _`3.5.0 md5`: https://github.com/OSGeo/gdal/releases/download/v3.5.0/gdal-3.5.0.tar.gz.md5
+
+* **2022-04-22** `gdal-3.4.3.tar.gz`_ `3.4.3 Release Notes`_ (`3.4.3 md5`_)
+
+.. _`3.4.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.4.3/gdal/NEWS.md
+.. _`gdal-3.4.3.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.4.3/gdal-3.4.3.tar.gz
+.. _`3.4.3 md5`: https://github.com/OSGeo/gdal/releases/download/v3.4.3/gdal-3.4.3.tar.gz.md5
+
+* **2022-03-08** `gdal-3.4.2.tar.gz`_ `3.4.2 Release Notes`_ (`3.4.2 md5`_)
+
+.. _`3.4.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.4.2/gdal/NEWS.md
+.. _`gdal-3.4.2.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.4.2/gdal-3.4.2.tar.gz
+.. _`3.4.2 md5`: https://github.com/OSGeo/gdal/releases/download/v3.4.2/gdal-3.4.2.tar.gz.md5
+
+* **2021-12-27** `gdal-3.4.1.tar.gz`_ `3.4.1 Release Notes`_ (`3.4.1 md5`_)
+
+.. _`3.4.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.4.1/gdal/NEWS.md
+.. _`gdal-3.4.1.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.4.1/gdal-3.4.1.tar.gz
+.. _`3.4.1 md5`: https://github.com/OSGeo/gdal/releases/download/v3.4.1/gdal-3.4.1.tar.gz.md5
+
+* **2021-11-08** `gdal-3.4.0.tar.gz`_ `3.4.0 Release Notes`_ (`3.4.0 md5`_)
+
+.. _`3.4.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.4.0/gdal/NEWS.md
+.. _`gdal-3.4.0.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.4.0/gdal-3.4.0.tar.gz
+.. _`3.4.0 md5`: https://github.com/OSGeo/gdal/releases/download/v3.4.0/gdal-3.4.0.tar.gz.md5
+
+* **2021-10-29** `gdal-3.3.3.tar.gz`_ `3.3.3 Release Notes`_ (`3.3.3 md5`_)
+
+.. _`3.3.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.3.3/gdal/NEWS
+.. _`gdal-3.3.3.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.3.3/gdal-3.3.3.tar.gz
+.. _`3.3.3 md5`: https://github.com/OSGeo/gdal/releases/download/v3.3.3/gdal-3.3.3.tar.gz.md5
+
+* **2021-09-01** `gdal-3.3.2.tar.gz`_ `3.3.2 Release Notes`_ (`3.3.2 md5`_)
+
+.. _`3.3.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.3.2/gdal/NEWS
+.. _`gdal-3.3.2.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.3.2/gdal-3.3.2.tar.gz
+.. _`3.3.2 md5`: https://github.com/OSGeo/gdal/releases/download/v3.3.2/gdal-3.3.2.tar.gz.md5
+
+* **2021-07-05** `gdal-3.3.1.tar.gz`_ `3.3.1 Release Notes`_ (`3.3.1 md5`_)
+
+.. _`3.3.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.3.1/gdal/NEWS
+.. _`gdal-3.3.1.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.3.1/gdal-3.3.1.tar.gz
+.. _`3.3.1 md5`: https://github.com/OSGeo/gdal/releases/download/v3.3.1/gdal-3.3.1.tar.gz.md5
+
+* **2021-05-03** `gdal-3.3.0.tar.gz`_ `3.3.0 Release Notes`_ (`3.3.0 md5`_)
+
+.. _`3.3.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.3.0/gdal/NEWS
+.. _`gdal-3.3.0.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.3.0/gdal-3.3.0.tar.gz
+.. _`3.3.0 md5`: https://github.com/OSGeo/gdal/releases/download/v3.3.0/gdal-3.3.0.tar.gz.md5
+
+* **2021-05-04** `gdal-3.2.3.tar.gz`_ `3.2.3 Release Notes`_ (`3.2.3 md5`_)
+
+.. _`3.2.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.2.3/gdal/NEWS
+.. _`gdal-3.2.3.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.2.3/gdal-3.2.3.tar.gz
+.. _`3.2.3 md5`: https://github.com/OSGeo/gdal/releases/download/v3.2.3/gdal-3.2.3.tar.gz.md5
+
+* **2021-03-10** `gdal-3.2.2.tar.gz`_ `3.2.2 Release Notes`_ (`3.2.2 md5`_)
+
+.. _`3.2.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.2.2/gdal/NEWS
+.. _`gdal-3.2.2.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.2.2/gdal-3.2.2.tar.gz
+.. _`3.2.2 md5`: https://github.com/OSGeo/gdal/releases/download/v3.2.2/gdal-3.2.2.tar.gz.md5
+
+* **2020-12-28** `gdal-3.2.1.tar.gz`_ `3.2.1 Release Notes`_ (`3.2.1 md5`_)
+
+.. _`3.2.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.2.1/gdal/NEWS
+.. _`gdal-3.2.1.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.2.1/gdal-3.2.1.tar.gz
+.. _`3.2.1 md5`: https://github.com/OSGeo/gdal/releases/download/v3.2.1/gdal-3.2.1.tar.gz.md5
+
+* **2020-10-26** `gdal-3.2.0.tar.gz`_ `3.2.0 Release Notes`_ (`3.2.0 md5`_)
+
+.. _`3.2.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.2.0/gdal/NEWS
+.. _`gdal-3.2.0.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.2.0/gdal-3.2.0.tar.gz
+.. _`3.2.0 md5`: https://github.com/OSGeo/gdal/releases/download/v3.2.0/gdal-3.2.0.tar.gz.md5
+
+* **2020-10-23** `gdal-3.1.4.tar.gz`_ `3.1.4 Release Notes`_ (`3.1.4 md5`_)
+
+.. _`3.1.4 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.1.4/gdal/NEWS
+.. _`gdal-3.1.4.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.1.4/gdal-3.1.4.tar.gz
+.. _`3.1.4 md5`: https://github.com/OSGeo/gdal/releases/download/v3.1.4/gdal-3.1.4.tar.gz.md5
+
+* **2020-09-01** `gdal-3.1.3.tar.gz`_ `3.1.3 Release Notes`_ (`3.1.3 md5`_)
+
+.. _`3.1.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.1.3/gdal/NEWS
+.. _`gdal-3.1.3.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.1.3/gdal-3.1.3.tar.gz
+.. _`3.1.3 md5`: https://github.com/OSGeo/gdal/releases/download/v3.1.3/gdal-3.1.3.tar.gz.md5
+
+* **2020-07-07** `gdal-3.1.2.tar.gz`_ `3.1.2 Release Notes`_ (`3.1.2 md5`_)
+
+.. _`3.1.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.1.2/gdal/NEWS
+.. _`gdal-3.1.2.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.1.2/gdal-3.1.2.tar.gz
+.. _`3.1.2 md5`: https://github.com/OSGeo/gdal/releases/download/v3.1.2/gdal-3.1.2.tar.gz.md5
+
+* **2020-06-22** `gdal-3.1.1.tar.gz`_ `3.1.1 Release Notes`_ (`3.1.1 md5`_)
+
+.. _`3.1.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.1.1/gdal/NEWS
+.. _`gdal-3.1.1.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.1.1/gdal-3.1.1.tar.gz
+.. _`3.1.1 md5`: https://github.com/OSGeo/gdal/releases/download/v3.1.1/gdal-3.1.1.tar.gz.md5
+
+
+* **2020-05-03** `gdal-3.1.0.tar.gz`_ `3.1.0 Release Notes`_ (`3.1.0 md5`_)
+
+.. _`3.1.0 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.1.0/gdal/NEWS
+.. _`gdal-3.1.0.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.1.0/gdal-3.1.0.tar.gz
+.. _`3.1.0 md5`: https://github.com/OSGeo/gdal/releases/download/v3.1.0/gdal-3.1.0.tar.gz.md5
+
+* **2020-01-28** `gdal-3.0.4.tar.gz`_ `3.0.4 Release Notes`_ (`3.0.4 md5`_)
+
+.. _`3.0.4 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.0.4/gdal/NEWS
+.. _`gdal-3.0.4.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.0.4/gdal-3.0.4.tar.gz
+.. _`3.0.4 md5`: https://github.com/OSGeo/gdal/releases/download/v3.0.4/gdal-3.0.4.tar.gz.md5
+
+* **2020-01-08** `gdal-2.4.4.tar.gz`_ `2.4.4 Release Notes`_ (`2.4.4 md5`_)
+
+.. _`2.4.4 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.4.4/gdal/NEWS
+.. _`gdal-2.4.4.tar.gz`: https://download.osgeo.org/gdal/2.4.4/gdal-2.4.4.tar.gz
+.. _`2.4.4 md5`: https://download.osgeo.org/gdal/2.4.4/gdal-2.4.4.tar.gz.md5
+
+* **2020-01-08** `gdal-3.0.3.tar.gz`_ `3.0.3 Release Notes`_ (`3.0.3 md5`_)
+
+.. _`3.0.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.0.3/gdal/NEWS
+.. _`gdal-3.0.3.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.0.3/gdal-3.0.3.tar.gz
+.. _`3.0.3 md5`: https://github.com/OSGeo/gdal/releases/download/v3.0.3/gdal-3.0.3.tar.gz.md5
+
+* **2019-10-28** `gdal-3.0.2.tar.gz`_ `3.0.2 Release Notes`_ (`3.0.2 md5`_)
+
+.. _`3.0.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.0.2/gdal/NEWS
+.. _`gdal-3.0.2.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.0.2/gdal-3.0.2.tar.gz
+.. _`3.0.2 md5`: https://github.com/OSGeo/gdal/releases/download/v3.0.2/gdal-3.0.2.tar.gz.md5
+
+* **2019-10-28** `gdal-2.4.3.tar.gz`_ `2.4.3 Release Notes`_ (`2.4.3 md5`_)
+
+.. _`2.4.3 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.4.3/gdal/NEWS
+.. _`gdal-2.4.3.tar.gz`: https://download.osgeo.org/gdal/2.4.3/gdal-2.4.3.tar.gz
+.. _`2.4.3 md5`: https://download.osgeo.org/gdal/2.4.3/gdal-2.4.3.tar.gz.md5
+
+
+* **2019-06-28** `gdal-3.0.1.tar.gz`_ `3.0.1 Release Notes`_ (`3.0.1 md5`_)
+
+.. _`3.0.1 Release Notes`: https://github.com/OSGeo/gdal/blob/v3.0.1/gdal/NEWS
+.. _`gdal-3.0.1.tar.gz`: https://github.com/OSGeo/gdal/releases/download/v3.0.1/gdal-3.0.1.tar.gz
+.. _`3.0.1 md5`: https://github.com/OSGeo/gdal/releases/download/v3.0.1/gdal-3.0.1.tar.gz.md5
+
+
+* **2019-06-28** `gdal-2.4.2.tar.gz`_ `2.4.2 Release Notes`_ (`2.4.2 md5`_)
+
+.. _`2.4.2 Release Notes`: https://github.com/OSGeo/gdal/blob/v2.4.2/gdal/NEWS
+.. _`gdal-2.4.2.tar.gz`: https://download.osgeo.org/gdal/2.4.2/gdal-2.4.2.tar.gz
+.. _`2.4.2 md5`: https://download.osgeo.org/gdal/2.4.2/gdal-2.4.2.tar.gz.md5
+
+


### PR DESCRIPTION
## What does this PR do?

- Move old releases to "Past Releases" page
- Migrate information about additional download sources from Trac
- Organize section headings:

![image](https://github.com/OSGeo/gdal/assets/6318931/3d46243a-eaef-491a-8f95-043fe6412cd7)

If merged, I would remove all content from https://trac.osgeo.org/gdal/wiki/DownloadingGdalBinaries.

## What are related issues/pull requests?

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed