### PR TITLE
State that VSISetPathSpecificOption path should not include trailing slash

### DIFF
--- a/port/cpl_vsil.cpp
+++ b/port/cpl_vsil.cpp
@@ -3503,7 +3503,7 @@ void VSISetCredential(const char *pszPathPrefix, const char *pszKey,
  *
  * @param pszPathPrefix a path prefix of a virtual file system handler.
  *                      Typically of the form "/vsiXXX/bucket". Must NOT be
- * NULL.
+ * NULL. Should not include trailing slashes.
  * @param pszKey        Option name. Must NOT be NULL.
  * @param pszValue      Option value. May be NULL to erase it.
  *


### PR DESCRIPTION
I was a little confused with this yesterday, found out my error was including a trailing slash after the bucket name...