### PR TITLE
Python bindings: fix/workaround installation into /usr/local/lib/python{version}/dist-packages when prefix is /usr/local

### DIFF
--- a/.github/workflows/cmake_builds.yml
+++ b/.github/workflows/cmake_builds.yml
@@ -214,15 +214,15 @@ jobs:
         test -f $GITHUB_WORKSPACE/install-gdal/share/man/man1/gdaladdo.1
         export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/install-gdal/lib
         $GITHUB_WORKSPACE/install-gdal/bin/gdalinfo --version
-        PYTHONPATH=$GITHUB_WORKSPACE/install-gdal/lib/python3/dist-packages python3 -c "from osgeo import gdal;print(gdal.VersionInfo(None))"
-        PYTHONPATH=$GITHUB_WORKSPACE/install-gdal/lib/python3/dist-packages python3 $GITHUB_WORKSPACE/scripts/check_doc.py
+        PYTHONPATH=$GITHUB_WORKSPACE/install-gdal/lib/python3.8/site-packages python3 -c "from osgeo import gdal;print(gdal.VersionInfo(None))"
+        PYTHONPATH=$GITHUB_WORKSPACE/install-gdal/lib/python3.8/site-packages python3 $GITHUB_WORKSPACE/scripts/check_doc.py
     - name: CMake with rpath
       run: |
         export PATH=$CMAKE_DIR:/usr/local/bin:/usr/bin:/bin # Avoid CMake config from brew etc.
         (cd $GITHUB_WORKSPACE/superbuild/build; cmake .. "-DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install-gdal-with-rpath" "-DCMAKE_INSTALL_RPATH=$GITHUB_WORKSPACE/install-gdal-with-rpath/lib")
         cmake --build $GITHUB_WORKSPACE/superbuild/build --target install -- -j$(nproc)
         # For some reason, during the install phase of above invocation, the Python bindings are rebuilt after the build phase, and without the rpath... Can't reproduce that locally
-        # PYTHONPATH=$GITHUB_WORKSPACE/install-gdal-with-rpath/lib/python3/dist-packages python -c "from osgeo import gdal;print(gdal.VersionInfo(None))"
+        # PYTHONPATH=$GITHUB_WORKSPACE/install-gdal-with-rpath/lib/python3.8/site-packages python -c "from osgeo import gdal;print(gdal.VersionInfo(None))"
     - name: Rerun using Mono
       run: |
         export PATH=$CMAKE_DIR:/usr/local/bin:/usr/bin:/bin # Avoid CMake config from brew etc.

--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -401,8 +401,15 @@ if __name__ == '__main__':
 
   # Install extension
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/trimmedsysconfig.py ${CMAKE_CURRENT_BINARY_DIR}/trimmedsysconfig.py @ONLY)
+  if (DEFINED GDAL_PYTHON_INSTALL_PREFIX)
+      set(PREFIX_FOR_TRIMMEDSYSCONFIG "${GDAL_PYTHON_INSTALL_PREFIX}")
+  elseif (DEFINED CMAKE_INSTALL_PREFIX)
+      set(PREFIX_FOR_TRIMMEDSYSCONFIG "${CMAKE_INSTALL_PREFIX}")
+  else()
+      set(PREFIX_FOR_TRIMMEDSYSCONFIG "")
+  endif()
   file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/get_python_lib.py
-       "from trimmedsysconfig import get_python_lib;print(get_python_lib(prefix=\"${GDAL_PYTHON_INSTALL_PREFIX}\"))\n")
+       "from trimmedsysconfig import get_python_lib;print(get_python_lib(prefix=\"${PREFIX_FOR_TRIMMEDSYSCONFIG}\"))\n")
   execute_process(
     COMMAND ${Python_EXECUTABLE_CMAKE} ${CMAKE_CURRENT_BINARY_DIR}/get_python_lib.py
     OUTPUT_VARIABLE SITE_PACKAGE_DIR
@@ -448,6 +455,13 @@ if __name__ == '__main__':
     set(SETUPTOOLS_USE_DISTUTILS stdlib)
   elseif ("${SITE_PACKAGE_DIR}" MATCHES "dist-packages")
     set(INSTALL_ARGS "${INSTALL_ARGS} --install-layout=deb")
+    if (NOT DEFINED GDAL_PYTHON_INSTALL_LIB AND "${PREFIX_FOR_TRIMMEDSYSCONFIG}" STREQUAL "/usr/local")
+        # Scenario of https://github.com/OSGeo/gdal/issues/10242
+        # For some reason patched setuptools of Debian fails to install by default
+        # in /usr/local/lib/python{version}/dist-packages even when passing
+        # --prefix=/usr/local and --install-layout=deb
+        set(INSTALL_ARGS "${INSTALL_ARGS} \"--install-lib=${SITE_PACKAGE_DIR}\"")
+    endif()
     if(Python_VERSION VERSION_LESS 3.12)
         # It no longer seems needed to mess with SETUPTOOLS_USE_DISTUTILS
         # with Debian Python 3.12 (or maybe its setuptools 68.1.2 version...),

--- a/swig/python/trimmedsysconfig.py
+++ b/swig/python/trimmedsysconfig.py
@@ -63,6 +63,14 @@ def get_python_lib(plat_specific=0, standard_lib=0, prefix=None):
             and "real_prefix" not in sys.__dict__
             and sys.prefix == sys.base_prefix
         ):
+            if (
+                prefix
+                and os.path.normpath(prefix) == "/usr/local"
+                and os.path.join(libpython, "dist-packages") in sys.path
+            ):
+                # GDAL specific to address https://github.com/OSGeo/gdal/issues/10242
+                # Not sure why Debian's patched distutils didn't do this
+                return os.path.join(libpython, "dist-packages")
             return os.path.join(prefix, "lib", "python3", "dist-packages")
         else:
             return os.path.join(libpython, "site-packages")


### PR DESCRIPTION
Fixes #10242
