### PR TITLE
VRT: fix serialization of separatable kernel in VRTKernelFilteredSource

### DIFF
--- a/autotest/gdrivers/vrtfilt.py
+++ b/autotest/gdrivers/vrtfilt.py
@@ -238,3 +238,27 @@ def test_vrtfilt_invalid_kernel_size():
 
     with pytest.raises(Exception):
         vrt_ds.GetRasterBand(1).SetMetadata(md, "vrt_sources")
+
+
+###############################################################################
+
+
+def test_vrtfilt_serialize_separatable_kernel():
+
+    vrt_ds = gdal.GetDriverByName("VRT").Create("", 1, 1, 1)
+
+    filterSourceXML = """<KernelFilteredSource>
+      <SourceFilename relativeToVRT="0">data/rgbsmall.tif</SourceFilename>
+      <SourceBand>1</SourceBand>
+      <Kernel normalized="0">
+        <Size>3</Size>
+        <Coefs>1 1 1</Coefs>
+      </Kernel>
+    </KernelFilteredSource>"""
+
+    md = {}
+    md["source_0"] = filterSourceXML
+
+    vrt_ds.GetRasterBand(1).SetMetadata(md, "vrt_sources")
+
+    assert filterSourceXML in vrt_ds.GetMetadata("xml:VRT")[0]

--- a/frmts/vrt/vrtfilters.cpp
+++ b/frmts/vrt/vrtfilters.cpp
@@ -682,20 +682,18 @@ CPLXMLNode *VRTKernelFilteredSource::SerializeToXML(const char *pszVRTPath)
             CPLCreateXMLNode(psKernel, CXT_Attribute, "normalized"), CXT_Text,
             "0");
 
-    const int nCoefCount = m_nKernelSize * m_nKernelSize;
-    const size_t nBufLen = nCoefCount * 32;
-    char *pszKernelCoefs = static_cast<char *>(CPLMalloc(nBufLen));
-
-    strcpy(pszKernelCoefs, "");
+    const int nCoefCount =
+        m_bSeparable ? m_nKernelSize : m_nKernelSize * m_nKernelSize;
+    std::string osCoefs;
     for (int iCoef = 0; iCoef < nCoefCount; iCoef++)
-        CPLsnprintf(pszKernelCoefs + strlen(pszKernelCoefs),
-                    nBufLen - strlen(pszKernelCoefs), "%.8g ",
-                    m_padfKernelCoefs[iCoef]);
+    {
+        if (!osCoefs.empty())
+            osCoefs += ' ';
+        osCoefs += CPLSPrintf("%.8g", m_padfKernelCoefs[iCoef]);
+    }
 
     CPLSetXMLValue(psKernel, "Size", CPLSPrintf("%d", m_nKernelSize));
-    CPLSetXMLValue(psKernel, "Coefs", pszKernelCoefs);
-
-    CPLFree(pszKernelCoefs);
+    CPLSetXMLValue(psKernel, "Coefs", osCoefs.c_str());
 
     return psSrc;
 }


### PR DESCRIPTION
Fixes #10253
