### PR TITLE
OGR SQL: add SELECT expression [AS] OGR_STYLE HIDDEN to be able to specify feature style string without generating a visible column

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,5 +57,7 @@ repos:
                 ogr/ogrsf_frmts/geojson/libjson/|
                 ogr/ogrsf_frmts/flatgeobuf/flatbuffers/|
                 ogr/ogrsf_frmts/pmtiles/pmtiles/|
-                ogr/ogrsf_frmts/sqlite/sqlite_rtree_bulk_load
+                ogr/ogrsf_frmts/sqlite/sqlite_rtree_bulk_load|
+                ogr/swq_parser.cpp|
+                ogr/swq_parser.hpp
               )

--- a/doc/source/user/ogr_sql_dialect.rst
+++ b/doc/source/user/ogr_sql_dialect.rst
@@ -634,6 +634,25 @@ For example we can select the annotation features as:
 
     SELECT * FROM nation WHERE OGR_STYLE LIKE 'LABEL%'
 
+
+It is possible to use the ``OGR_STYLE`` field name as a special field name in
+the field selection as an alternate way of setting the :cpp:func:`OGRFeature::SetStyleString`
+value, typically by aliasing another field or a string literal.
+
+.. code-block::
+
+    SELECT *, 'BRUSH(fc:#01234567)' AS OGR_STYLE FROM source_layer
+
+
+By default, the OGR_STYLE field will still be visible as a regular field. If this
+is undesirable, starting with GDAL 3.10, it can be hidden by adding the HIDDEN
+keyword at the end of the field specification.
+
+.. code-block::
+
+    SELECT * EXCLUDE(my_style_field), my_style_field AS OGR_STYLE HIDDEN FROM source_layer
+
+
 CREATE INDEX
 ------------
 

--- a/ogr/CMakeLists.txt
+++ b/ogr/CMakeLists.txt
@@ -180,7 +180,7 @@ add_custom_target(check_swq_parser_md5 ALL
                   COMMAND ${CMAKE_COMMAND}
                       "-DIN_FILE=swq_parser.y"
                       "-DTARGET=generate_swq_parser"
-                      "-DEXPECTED_MD5SUM=f7faffefe55128fc8951556909523ef7"
+                      "-DEXPECTED_MD5SUM=6c82680a0abb18a011e872929a4a4ece"
                       "-DFILENAME_CMAKE=${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt"
                       -P "${PROJECT_SOURCE_DIR}/cmake/helpers/check_md5sum.cmake"
                   WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"

--- a/ogr/ogr_swq.h
+++ b/ogr/ogr_swq.h
@@ -186,6 +186,10 @@ class CPL_UNSTABLE_API swq_expr_node
     /* nOperation == SWQ_CUSTOM_FUNC */
     char *string_value = nullptr; /* column name when SNT_COLUMN */
 
+    // May be transiently used by swq_parser.h, but should not be relied upon
+    // after parsing. swq_col_def.bHidden captures it afterwards.
+    bool bHidden = false;
+
     static CPLString QuoteIfNecessary(const CPLString &, char chQuote = '\'');
     static CPLString Quote(const CPLString &, char chQuote = '\'');
 };
@@ -331,6 +335,7 @@ typedef struct
     int field_length;
     int field_precision;
     int distinct_flag;
+    bool bHidden;
     OGRwkbGeometryType eGeomType;
     int nSRID;
     swq_expr_node *expr;
@@ -412,8 +417,8 @@ class CPL_UNSTABLE_API swq_select
 
     char *raw_select = nullptr;
 
-    int PushField(swq_expr_node *poExpr, const char *pszAlias = nullptr,
-                  int distinct_flag = FALSE);
+    int PushField(swq_expr_node *poExpr, const char *pszAlias,
+                  bool distinct_flag, bool bHidden);
 
     int PushExcludeField(swq_expr_node *poExpr);
 

--- a/ogr/ogrsf_frmts/generic/ogr_gensql.cpp
+++ b/ogr/ogrsf_frmts/generic/ogr_gensql.cpp
@@ -1056,12 +1056,14 @@ bool OGRGenSQLResultsLayer::PrepareSummary()
 /*                       OGRMultiFeatureFetcher()                       */
 /************************************************************************/
 
+typedef std::vector<std::unique_ptr<OGRFeature>> VectorOfUniquePtrFeature;
+
 static swq_expr_node *OGRMultiFeatureFetcher(swq_expr_node *op,
                                              void *pFeatureList)
 
 {
-    std::vector<OGRFeature *> *papoFeatures =
-        static_cast<std::vector<OGRFeature *> *>(pFeatureList);
+    auto &apoFeatures =
+        *(static_cast<VectorOfUniquePtrFeature *>(pFeatureList));
     swq_expr_node *poRetNode = nullptr;
 
     CPLAssert(op->eNodeType == SNT_COLUMN);
@@ -1070,7 +1072,7 @@ static swq_expr_node *OGRMultiFeatureFetcher(swq_expr_node *op,
     /*      What feature are we using?  The primary or one of the joined ones?*/
     /* -------------------------------------------------------------------- */
     if (op->table_index < 0 ||
-        op->table_index >= static_cast<int>(papoFeatures->size()))
+        op->table_index >= static_cast<int>(apoFeatures.size()))
     {
         CPLError(CE_Failure, CPLE_AppDefined,
                  "Request for unexpected table_index (%d) in field fetcher.",
@@ -1078,7 +1080,7 @@ static swq_expr_node *OGRMultiFeatureFetcher(swq_expr_node *op,
         return nullptr;
     }
 
-    OGRFeature *poFeature = (*papoFeatures)[op->table_index];
+    OGRFeature *poFeature = apoFeatures[op->table_index].get();
 
     /* -------------------------------------------------------------------- */
     /*      Fetch the value.                                                */
@@ -1271,27 +1273,27 @@ static CPLString GetFilterForJoin(swq_expr_node *poExpr, OGRFeature *poSrcFeat,
 /*                          TranslateFeature()                          */
 /************************************************************************/
 
-OGRFeature *OGRGenSQLResultsLayer::TranslateFeature(OGRFeature *poSrcFeat)
+std::unique_ptr<OGRFeature> OGRGenSQLResultsLayer::TranslateFeature(
+    std::unique_ptr<OGRFeature> poSrcFeatUniquePtr)
 
 {
     swq_select *psSelectInfo = m_pSelectInfo.get();
-    std::vector<OGRFeature *> apoFeatures;
+    VectorOfUniquePtrFeature apoFeatures;
 
-    if (poSrcFeat == nullptr)
+    if (poSrcFeatUniquePtr == nullptr)
         return nullptr;
 
     m_nFeaturesRead++;
 
-    apoFeatures.push_back(poSrcFeat);
+    apoFeatures.push_back(std::move(poSrcFeatUniquePtr));
+    auto poSrcFeat = apoFeatures.front().get();
 
     /* -------------------------------------------------------------------- */
     /*      Fetch the corresponding features from any jointed tables.       */
     /* -------------------------------------------------------------------- */
     for (int iJoin = 0; iJoin < psSelectInfo->join_count; iJoin++)
     {
-        CPLString osFilter;
-
-        swq_join_def *psJoinInfo = psSelectInfo->join_defs + iJoin;
+        const swq_join_def *psJoinInfo = psSelectInfo->join_defs + iJoin;
 
         /* OGRMultiFeatureFetcher assumes that the features are pushed in */
         /* apoFeatures with increasing secondary_table, so make sure */
@@ -1300,8 +1302,9 @@ OGRFeature *OGRGenSQLResultsLayer::TranslateFeature(OGRFeature *poSrcFeat)
 
         OGRLayer *poJoinLayer = m_apoTableLayers[psJoinInfo->secondary_table];
 
-        osFilter = GetFilterForJoin(psJoinInfo->poExpr, poSrcFeat, poJoinLayer,
-                                    psJoinInfo->secondary_table);
+        const std::string osFilter =
+            GetFilterForJoin(psJoinInfo->poExpr, poSrcFeat, poJoinLayer,
+                             psJoinInfo->secondary_table);
         // CPLDebug("OGR", "Filter = %s\n", osFilter.c_str());
 
         // if source key is null, we can't do join.
@@ -1311,19 +1314,19 @@ OGRFeature *OGRGenSQLResultsLayer::TranslateFeature(OGRFeature *poSrcFeat)
             continue;
         }
 
-        OGRFeature *poJoinFeature = nullptr;
+        std::unique_ptr<OGRFeature> poJoinFeature;
 
         poJoinLayer->ResetReading();
         if (poJoinLayer->SetAttributeFilter(osFilter.c_str()) == OGRERR_NONE)
-            poJoinFeature = poJoinLayer->GetNextFeature();
+            poJoinFeature.reset(poJoinLayer->GetNextFeature());
 
-        apoFeatures.push_back(poJoinFeature);
+        apoFeatures.push_back(std::move(poJoinFeature));
     }
 
     /* -------------------------------------------------------------------- */
     /*      Create destination feature.                                     */
     /* -------------------------------------------------------------------- */
-    OGRFeature *poDstFeat = new OGRFeature(m_poDefn);
+    auto poDstFeat = std::make_unique<OGRFeature>(m_poDefn);
 
     poDstFeat->SetFID(poSrcFeat->GetFID());
 
@@ -1339,7 +1342,7 @@ OGRFeature *OGRGenSQLResultsLayer::TranslateFeature(OGRFeature *poSrcFeat)
     swq_evaluation_context sContext;
     for (int iField = 0; iField < psSelectInfo->result_columns(); iField++)
     {
-        swq_col_def *psColDef = &psSelectInfo->column_defs[iField];
+        const swq_col_def *psColDef = &psSelectInfo->column_defs[iField];
         if (psColDef->field_index != -1)
         {
             if (psColDef->field_type == SWQ_GEOMETRY ||
@@ -1350,12 +1353,11 @@ OGRFeature *OGRGenSQLResultsLayer::TranslateFeature(OGRFeature *poSrcFeat)
             continue;
         }
 
-        swq_expr_node *poResult = psColDef->expr->Evaluate(
-            OGRMultiFeatureFetcher, &apoFeatures, sContext);
+        auto poResult = std::unique_ptr<swq_expr_node>(psColDef->expr->Evaluate(
+            OGRMultiFeatureFetcher, &apoFeatures, sContext));
 
-        if (poResult == nullptr)
+        if (!poResult)
         {
-            delete poDstFeat;
             return nullptr;
         }
 
@@ -1365,7 +1367,6 @@ OGRFeature *OGRGenSQLResultsLayer::TranslateFeature(OGRFeature *poSrcFeat)
                 iGeomField++;
             else
                 iRegularField++;
-            delete poResult;
             continue;
         }
 
@@ -1431,8 +1432,6 @@ OGRFeature *OGRGenSQLResultsLayer::TranslateFeature(OGRFeature *poSrcFeat)
                 poDstFeat->SetField(iRegularField++, poResult->string_value);
                 break;
         }
-
-        delete poResult;
     }
 
     /* -------------------------------------------------------------------- */
@@ -1442,7 +1441,7 @@ OGRFeature *OGRGenSQLResultsLayer::TranslateFeature(OGRFeature *poSrcFeat)
     iGeomField = 0;
     for (int iField = 0; iField < psSelectInfo->result_columns(); iField++)
     {
-        swq_col_def *psColDef = &psSelectInfo->column_defs[iField];
+        const swq_col_def *psColDef = &psSelectInfo->column_defs[iField];
 
         if (psColDef->table_index != 0)
         {
@@ -1534,10 +1533,8 @@ OGRFeature *OGRGenSQLResultsLayer::TranslateFeature(OGRFeature *poSrcFeat)
     /* -------------------------------------------------------------------- */
     for (int iJoin = 0; iJoin < psSelectInfo->join_count; iJoin++)
     {
-        CPLString osFilter;
-
-        swq_join_def *psJoinInfo = psSelectInfo->join_defs + iJoin;
-        OGRFeature *poJoinFeature = apoFeatures[iJoin + 1];
+        const swq_join_def *psJoinInfo = psSelectInfo->join_defs + iJoin;
+        const OGRFeature *poJoinFeature = apoFeatures[iJoin + 1].get();
 
         if (poJoinFeature == nullptr)
             continue;
@@ -1546,7 +1543,7 @@ OGRFeature *OGRGenSQLResultsLayer::TranslateFeature(OGRFeature *poSrcFeat)
         iRegularField = 0;
         for (int iField = 0; iField < psSelectInfo->result_columns(); iField++)
         {
-            swq_col_def *psColDef = &psSelectInfo->column_defs[iField];
+            const swq_col_def *psColDef = &psSelectInfo->column_defs[iField];
 
             if (psColDef->field_type == SWQ_GEOMETRY ||
                 psColDef->target_type == SWQ_GEOMETRY)
@@ -1559,8 +1556,6 @@ OGRFeature *OGRGenSQLResultsLayer::TranslateFeature(OGRFeature *poSrcFeat)
 
             iRegularField++;
         }
-
-        delete poJoinFeature;
     }
 
     return poDstFeat;
@@ -1634,8 +1629,7 @@ OGRFeature *OGRGenSQLResultsLayer::GetNextFeature()
         if (poSrcFeat == nullptr)
             return nullptr;
 
-        auto poFeature =
-            std::unique_ptr<OGRFeature>(TranslateFeature(poSrcFeat.get()));
+        auto poFeature = TranslateFeature(std::move(poSrcFeat));
         if (poFeature == nullptr)
             return nullptr;
 
@@ -1751,7 +1745,7 @@ OGRFeature *OGRGenSQLResultsLayer::GetFeature(GIntBig nFID)
     if (poSrcFeature == nullptr)
         return nullptr;
 
-    return TranslateFeature(poSrcFeature.get());
+    return TranslateFeature(std::move(poSrcFeature)).release();
 }
 
 /************************************************************************/

--- a/ogr/ogrsf_frmts/generic/ogr_gensql.h
+++ b/ogr/ogrsf_frmts/generic/ogr_gensql.h
@@ -92,7 +92,7 @@ class OGRGenSQLResultsLayer final : public OGRLayer
 
     bool PrepareSummary();
 
-    OGRFeature *TranslateFeature(OGRFeature *);
+    std::unique_ptr<OGRFeature> TranslateFeature(std::unique_ptr<OGRFeature>);
     void CreateOrderByIndex();
     void ReadIndexFields(OGRFeature *poSrcFeat, int nOrderItems,
                          OGRField *pasIndexFields);

--- a/ogr/swq.cpp
+++ b/ogr/swq.cpp
@@ -289,6 +289,11 @@ int swqlex(YYSTYPE *ppNode, swq_parse_context *context)
             nReturn = SWQT_LIMIT;
         else if (EQUAL(osToken, "OFFSET"))
             nReturn = SWQT_OFFSET;
+        else if (EQUAL(osToken, "HIDDEN"))
+        {
+            *ppNode = new swq_expr_node(osToken);
+            nReturn = SWQT_HIDDEN;
+        }
 
         // Unhandled by OGR SQL.
         else if (EQUAL(osToken, "OUTER") || EQUAL(osToken, "INNER"))

--- a/ogr/swq_expr_node.cpp
+++ b/ogr/swq_expr_node.cpp
@@ -147,7 +147,8 @@ bool swq_expr_node::operator==(const swq_expr_node &other) const
         nOperation != other.nOperation || field_index != other.field_index ||
         table_index != other.table_index ||
         nSubExprCount != other.nSubExprCount || is_null != other.is_null ||
-        int_value != other.int_value || float_value != other.float_value)
+        int_value != other.int_value || float_value != other.float_value ||
+        bHidden != other.bHidden)
     {
         return false;
     }
@@ -234,6 +235,7 @@ swq_expr_node &swq_expr_node::operator=(const swq_expr_node &other)
             geometry_value = other.geometry_value->clone();
         if (other.string_value)
             string_value = CPLStrdup(other.string_value);
+        bHidden = other.bHidden;
     }
     return *this;
 }
@@ -269,6 +271,7 @@ swq_expr_node &swq_expr_node::operator=(swq_expr_node &&other)
         float_value = other.float_value;
         std::swap(geometry_value, other.geometry_value);
         std::swap(string_value, other.string_value);
+        bHidden = other.bHidden;
     }
     return *this;
 }

--- a/ogr/swq_parser.cpp
+++ b/ogr/swq_parser.cpp
@@ -63,12 +63,13 @@
 /* Pull parsers.  */
 #define YYPULL 1
 
+
 /* Substitute the variable and function names.  */
-#define yyparse swqparse
-#define yylex swqlex
-#define yyerror swqerror
-#define yydebug swqdebug
-#define yynerrs swqnerrs
+#define yyparse         swqparse
+#define yylex           swqlex
+#define yyerror         swqerror
+#define yydebug         swqdebug
+#define yynerrs         swqnerrs
 
 /* First part of user prologue.  */
 
@@ -114,6 +115,7 @@
 #include "ogr_core.h"
 #include "ogr_geometry.h"
 
+
 #define YYSTYPE swq_expr_node *
 
 /* Defining YYSTYPE_IS_TRIVIAL is needed because the parser is generated as a C++ file. */
@@ -123,116 +125,122 @@
 /* it appears to be a non documented feature of Bison */
 #define YYSTYPE_IS_TRIVIAL 1
 
-#ifndef YY_CAST
-#ifdef __cplusplus
-#define YY_CAST(Type, Val) static_cast<Type>(Val)
-#define YY_REINTERPRET_CAST(Type, Val) reinterpret_cast<Type>(Val)
-#else
-#define YY_CAST(Type, Val) ((Type)(Val))
-#define YY_REINTERPRET_CAST(Type, Val) ((Type)(Val))
-#endif
-#endif
-#ifndef YY_NULLPTR
-#if defined __cplusplus
-#if 201103L <= __cplusplus
-#define YY_NULLPTR nullptr
-#else
-#define YY_NULLPTR 0
-#endif
-#else
-#define YY_NULLPTR ((void *)0)
-#endif
-#endif
+
+# ifndef YY_CAST
+#  ifdef __cplusplus
+#   define YY_CAST(Type, Val) static_cast<Type> (Val)
+#   define YY_REINTERPRET_CAST(Type, Val) reinterpret_cast<Type> (Val)
+#  else
+#   define YY_CAST(Type, Val) ((Type) (Val))
+#   define YY_REINTERPRET_CAST(Type, Val) ((Type) (Val))
+#  endif
+# endif
+# ifndef YY_NULLPTR
+#  if defined __cplusplus
+#   if 201103L <= __cplusplus
+#    define YY_NULLPTR nullptr
+#   else
+#    define YY_NULLPTR 0
+#   endif
+#  else
+#   define YY_NULLPTR ((void*)0)
+#  endif
+# endif
 
 #include "swq_parser.hpp"
-
 /* Symbol kind.  */
 enum yysymbol_kind_t
 {
-    YYSYMBOL_YYEMPTY = -2,
-    YYSYMBOL_YYEOF = 0,                   /* "end of string"  */
-    YYSYMBOL_YYerror = 1,                 /* error  */
-    YYSYMBOL_YYUNDEF = 2,                 /* "invalid token"  */
-    YYSYMBOL_SWQT_INTEGER_NUMBER = 3,     /* "integer number"  */
-    YYSYMBOL_SWQT_FLOAT_NUMBER = 4,       /* "floating point number"  */
-    YYSYMBOL_SWQT_STRING = 5,             /* "string"  */
-    YYSYMBOL_SWQT_IDENTIFIER = 6,         /* "identifier"  */
-    YYSYMBOL_SWQT_IN = 7,                 /* "IN"  */
-    YYSYMBOL_SWQT_LIKE = 8,               /* "LIKE"  */
-    YYSYMBOL_SWQT_ILIKE = 9,              /* "ILIKE"  */
-    YYSYMBOL_SWQT_ESCAPE = 10,            /* "ESCAPE"  */
-    YYSYMBOL_SWQT_BETWEEN = 11,           /* "BETWEEN"  */
-    YYSYMBOL_SWQT_NULL = 12,              /* "NULL"  */
-    YYSYMBOL_SWQT_IS = 13,                /* "IS"  */
-    YYSYMBOL_SWQT_SELECT = 14,            /* "SELECT"  */
-    YYSYMBOL_SWQT_LEFT = 15,              /* "LEFT"  */
-    YYSYMBOL_SWQT_JOIN = 16,              /* "JOIN"  */
-    YYSYMBOL_SWQT_WHERE = 17,             /* "WHERE"  */
-    YYSYMBOL_SWQT_ON = 18,                /* "ON"  */
-    YYSYMBOL_SWQT_ORDER = 19,             /* "ORDER"  */
-    YYSYMBOL_SWQT_BY = 20,                /* "BY"  */
-    YYSYMBOL_SWQT_FROM = 21,              /* "FROM"  */
-    YYSYMBOL_SWQT_AS = 22,                /* "AS"  */
-    YYSYMBOL_SWQT_ASC = 23,               /* "ASC"  */
-    YYSYMBOL_SWQT_DESC = 24,              /* "DESC"  */
-    YYSYMBOL_SWQT_DISTINCT = 25,          /* "DISTINCT"  */
-    YYSYMBOL_SWQT_CAST = 26,              /* "CAST"  */
-    YYSYMBOL_SWQT_UNION = 27,             /* "UNION"  */
-    YYSYMBOL_SWQT_ALL = 28,               /* "ALL"  */
-    YYSYMBOL_SWQT_LIMIT = 29,             /* "LIMIT"  */
-    YYSYMBOL_SWQT_OFFSET = 30,            /* "OFFSET"  */
-    YYSYMBOL_SWQT_EXCEPT = 31,            /* "EXCEPT"  */
-    YYSYMBOL_SWQT_EXCLUDE = 32,           /* "EXCLUDE"  */
-    YYSYMBOL_SWQT_VALUE_START = 33,       /* SWQT_VALUE_START  */
-    YYSYMBOL_SWQT_SELECT_START = 34,      /* SWQT_SELECT_START  */
-    YYSYMBOL_SWQT_NOT = 35,               /* "NOT"  */
-    YYSYMBOL_SWQT_OR = 36,                /* "OR"  */
-    YYSYMBOL_SWQT_AND = 37,               /* "AND"  */
-    YYSYMBOL_38_ = 38,                    /* '='  */
-    YYSYMBOL_39_ = 39,                    /* '<'  */
-    YYSYMBOL_40_ = 40,                    /* '>'  */
-    YYSYMBOL_41_ = 41,                    /* '!'  */
-    YYSYMBOL_42_ = 42,                    /* '+'  */
-    YYSYMBOL_43_ = 43,                    /* '-'  */
-    YYSYMBOL_44_ = 44,                    /* '*'  */
-    YYSYMBOL_45_ = 45,                    /* '/'  */
-    YYSYMBOL_46_ = 46,                    /* '%'  */
-    YYSYMBOL_SWQT_UMINUS = 47,            /* SWQT_UMINUS  */
-    YYSYMBOL_SWQT_RESERVED_KEYWORD = 48,  /* "reserved keyword"  */
-    YYSYMBOL_49_ = 49,                    /* '('  */
-    YYSYMBOL_50_ = 50,                    /* ')'  */
-    YYSYMBOL_51_ = 51,                    /* ','  */
-    YYSYMBOL_52_ = 52,                    /* '.'  */
-    YYSYMBOL_YYACCEPT = 53,               /* $accept  */
-    YYSYMBOL_input = 54,                  /* input  */
-    YYSYMBOL_value_expr = 55,             /* value_expr  */
-    YYSYMBOL_value_expr_list = 56,        /* value_expr_list  */
-    YYSYMBOL_field_value = 57,            /* field_value  */
-    YYSYMBOL_value_expr_non_logical = 58, /* value_expr_non_logical  */
-    YYSYMBOL_type_def = 59,               /* type_def  */
-    YYSYMBOL_select_statement = 60,       /* select_statement  */
-    YYSYMBOL_select_core = 61,            /* select_core  */
-    YYSYMBOL_opt_union_all = 62,          /* opt_union_all  */
-    YYSYMBOL_union_all = 63,              /* union_all  */
-    YYSYMBOL_select_field_list = 64,      /* select_field_list  */
-    YYSYMBOL_exclude_field = 65,          /* exclude_field  */
-    YYSYMBOL_exclude_field_list = 66,     /* exclude_field_list  */
-    YYSYMBOL_except_or_exclude = 67,      /* except_or_exclude  */
-    YYSYMBOL_column_spec = 68,            /* column_spec  */
-    YYSYMBOL_as_clause = 69,              /* as_clause  */
-    YYSYMBOL_opt_where = 70,              /* opt_where  */
-    YYSYMBOL_opt_joins = 71,              /* opt_joins  */
-    YYSYMBOL_opt_order_by = 72,           /* opt_order_by  */
-    YYSYMBOL_sort_spec_list = 73,         /* sort_spec_list  */
-    YYSYMBOL_sort_spec = 74,              /* sort_spec  */
-    YYSYMBOL_opt_limit = 75,              /* opt_limit  */
-    YYSYMBOL_opt_offset = 76,             /* opt_offset  */
-    YYSYMBOL_table_def = 77               /* table_def  */
+  YYSYMBOL_YYEMPTY = -2,
+  YYSYMBOL_YYEOF = 0,                      /* "end of string"  */
+  YYSYMBOL_YYerror = 1,                    /* error  */
+  YYSYMBOL_YYUNDEF = 2,                    /* "invalid token"  */
+  YYSYMBOL_SWQT_INTEGER_NUMBER = 3,        /* "integer number"  */
+  YYSYMBOL_SWQT_FLOAT_NUMBER = 4,          /* "floating point number"  */
+  YYSYMBOL_SWQT_STRING = 5,                /* "string"  */
+  YYSYMBOL_SWQT_IDENTIFIER = 6,            /* "identifier"  */
+  YYSYMBOL_SWQT_IN = 7,                    /* "IN"  */
+  YYSYMBOL_SWQT_LIKE = 8,                  /* "LIKE"  */
+  YYSYMBOL_SWQT_ILIKE = 9,                 /* "ILIKE"  */
+  YYSYMBOL_SWQT_ESCAPE = 10,               /* "ESCAPE"  */
+  YYSYMBOL_SWQT_BETWEEN = 11,              /* "BETWEEN"  */
+  YYSYMBOL_SWQT_NULL = 12,                 /* "NULL"  */
+  YYSYMBOL_SWQT_IS = 13,                   /* "IS"  */
+  YYSYMBOL_SWQT_SELECT = 14,               /* "SELECT"  */
+  YYSYMBOL_SWQT_LEFT = 15,                 /* "LEFT"  */
+  YYSYMBOL_SWQT_JOIN = 16,                 /* "JOIN"  */
+  YYSYMBOL_SWQT_WHERE = 17,                /* "WHERE"  */
+  YYSYMBOL_SWQT_ON = 18,                   /* "ON"  */
+  YYSYMBOL_SWQT_ORDER = 19,                /* "ORDER"  */
+  YYSYMBOL_SWQT_BY = 20,                   /* "BY"  */
+  YYSYMBOL_SWQT_FROM = 21,                 /* "FROM"  */
+  YYSYMBOL_SWQT_AS = 22,                   /* "AS"  */
+  YYSYMBOL_SWQT_ASC = 23,                  /* "ASC"  */
+  YYSYMBOL_SWQT_DESC = 24,                 /* "DESC"  */
+  YYSYMBOL_SWQT_DISTINCT = 25,             /* "DISTINCT"  */
+  YYSYMBOL_SWQT_CAST = 26,                 /* "CAST"  */
+  YYSYMBOL_SWQT_UNION = 27,                /* "UNION"  */
+  YYSYMBOL_SWQT_ALL = 28,                  /* "ALL"  */
+  YYSYMBOL_SWQT_LIMIT = 29,                /* "LIMIT"  */
+  YYSYMBOL_SWQT_OFFSET = 30,               /* "OFFSET"  */
+  YYSYMBOL_SWQT_EXCEPT = 31,               /* "EXCEPT"  */
+  YYSYMBOL_SWQT_EXCLUDE = 32,              /* "EXCLUDE"  */
+  YYSYMBOL_SWQT_HIDDEN = 33,               /* "HIDDEN"  */
+  YYSYMBOL_SWQT_VALUE_START = 34,          /* SWQT_VALUE_START  */
+  YYSYMBOL_SWQT_SELECT_START = 35,         /* SWQT_SELECT_START  */
+  YYSYMBOL_SWQT_NOT = 36,                  /* "NOT"  */
+  YYSYMBOL_SWQT_OR = 37,                   /* "OR"  */
+  YYSYMBOL_SWQT_AND = 38,                  /* "AND"  */
+  YYSYMBOL_39_ = 39,                       /* '='  */
+  YYSYMBOL_40_ = 40,                       /* '<'  */
+  YYSYMBOL_41_ = 41,                       /* '>'  */
+  YYSYMBOL_42_ = 42,                       /* '!'  */
+  YYSYMBOL_43_ = 43,                       /* '+'  */
+  YYSYMBOL_44_ = 44,                       /* '-'  */
+  YYSYMBOL_45_ = 45,                       /* '*'  */
+  YYSYMBOL_46_ = 46,                       /* '/'  */
+  YYSYMBOL_47_ = 47,                       /* '%'  */
+  YYSYMBOL_SWQT_UMINUS = 48,               /* SWQT_UMINUS  */
+  YYSYMBOL_SWQT_RESERVED_KEYWORD = 49,     /* "reserved keyword"  */
+  YYSYMBOL_50_ = 50,                       /* '('  */
+  YYSYMBOL_51_ = 51,                       /* ')'  */
+  YYSYMBOL_52_ = 52,                       /* ','  */
+  YYSYMBOL_53_ = 53,                       /* '.'  */
+  YYSYMBOL_YYACCEPT = 54,                  /* $accept  */
+  YYSYMBOL_input = 55,                     /* input  */
+  YYSYMBOL_value_expr = 56,                /* value_expr  */
+  YYSYMBOL_value_expr_list = 57,           /* value_expr_list  */
+  YYSYMBOL_identifier = 58,                /* identifier  */
+  YYSYMBOL_field_value = 59,               /* field_value  */
+  YYSYMBOL_value_expr_non_logical = 60,    /* value_expr_non_logical  */
+  YYSYMBOL_type_def = 61,                  /* type_def  */
+  YYSYMBOL_select_statement = 62,          /* select_statement  */
+  YYSYMBOL_select_core = 63,               /* select_core  */
+  YYSYMBOL_opt_union_all = 64,             /* opt_union_all  */
+  YYSYMBOL_union_all = 65,                 /* union_all  */
+  YYSYMBOL_select_field_list = 66,         /* select_field_list  */
+  YYSYMBOL_exclude_field = 67,             /* exclude_field  */
+  YYSYMBOL_exclude_field_list = 68,        /* exclude_field_list  */
+  YYSYMBOL_except_or_exclude = 69,         /* except_or_exclude  */
+  YYSYMBOL_column_spec = 70,               /* column_spec  */
+  YYSYMBOL_as_clause = 71,                 /* as_clause  */
+  YYSYMBOL_as_clause_with_hidden = 72,     /* as_clause_with_hidden  */
+  YYSYMBOL_opt_where = 73,                 /* opt_where  */
+  YYSYMBOL_opt_joins = 74,                 /* opt_joins  */
+  YYSYMBOL_opt_order_by = 75,              /* opt_order_by  */
+  YYSYMBOL_sort_spec_list = 76,            /* sort_spec_list  */
+  YYSYMBOL_sort_spec = 77,                 /* sort_spec  */
+  YYSYMBOL_opt_limit = 78,                 /* opt_limit  */
+  YYSYMBOL_opt_offset = 79,                /* opt_offset  */
+  YYSYMBOL_table_def = 80                  /* table_def  */
 };
 typedef enum yysymbol_kind_t yysymbol_kind_t;
 
+
+
+
 #ifdef short
-#undef short
+# undef short
 #endif
 
 /* On compilers that do not define __PTRDIFF_MAX__ etc., make sure
@@ -240,11 +248,11 @@ typedef enum yysymbol_kind_t yysymbol_kind_t;
    so that the code can choose integer types of a good width.  */
 
 #ifndef __PTRDIFF_MAX__
-#include <limits.h> /* INFRINGES ON USER NAME SPACE */
-#if defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
-#include <stdint.h> /* INFRINGES ON USER NAME SPACE */
-#define YY_STDINT_H
-#endif
+# include <limits.h> /* INFRINGES ON USER NAME SPACE */
+# if defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
+#  include <stdint.h> /* INFRINGES ON USER NAME SPACE */
+#  define YY_STDINT_H
+# endif
 #endif
 
 /* Narrow types that promote to a signed type and that can represent a
@@ -274,16 +282,16 @@ typedef short yytype_int16;
    (aka HP-UX 11i v2) only through the end of 2022; see Table 2 of
    <https://h20195.www2.hpe.com/V2/getpdf.aspx/4AA4-7673ENW.pdf>.  */
 #ifdef __hpux
-#undef UINT_LEAST8_MAX
-#undef UINT_LEAST16_MAX
-#define UINT_LEAST8_MAX 255
-#define UINT_LEAST16_MAX 65535
+# undef UINT_LEAST8_MAX
+# undef UINT_LEAST16_MAX
+# define UINT_LEAST8_MAX 255
+# define UINT_LEAST16_MAX 65535
 #endif
 
 #if defined __UINT_LEAST8_MAX__ && __UINT_LEAST8_MAX__ <= __INT_MAX__
 typedef __UINT_LEAST8_TYPE__ yytype_uint8;
-#elif (!defined __UINT_LEAST8_MAX__ && defined YY_STDINT_H &&                  \
-       UINT_LEAST8_MAX <= INT_MAX)
+#elif (!defined __UINT_LEAST8_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST8_MAX <= INT_MAX)
 typedef uint_least8_t yytype_uint8;
 #elif !defined __UINT_LEAST8_MAX__ && UCHAR_MAX <= INT_MAX
 typedef unsigned char yytype_uint8;
@@ -293,8 +301,8 @@ typedef short yytype_uint8;
 
 #if defined __UINT_LEAST16_MAX__ && __UINT_LEAST16_MAX__ <= __INT_MAX__
 typedef __UINT_LEAST16_TYPE__ yytype_uint16;
-#elif (!defined __UINT_LEAST16_MAX__ && defined YY_STDINT_H &&                 \
-       UINT_LEAST16_MAX <= INT_MAX)
+#elif (!defined __UINT_LEAST16_MAX__ && defined YY_STDINT_H \
+       && UINT_LEAST16_MAX <= INT_MAX)
 typedef uint_least16_t yytype_uint16;
 #elif !defined __UINT_LEAST16_MAX__ && USHRT_MAX <= INT_MAX
 typedef unsigned short yytype_uint16;
@@ -303,40 +311,42 @@ typedef int yytype_uint16;
 #endif
 
 #ifndef YYPTRDIFF_T
-#if defined __PTRDIFF_TYPE__ && defined __PTRDIFF_MAX__
-#define YYPTRDIFF_T __PTRDIFF_TYPE__
-#define YYPTRDIFF_MAXIMUM __PTRDIFF_MAX__
-#elif defined PTRDIFF_MAX
-#ifndef ptrdiff_t
-#include <stddef.h> /* INFRINGES ON USER NAME SPACE */
-#endif
-#define YYPTRDIFF_T ptrdiff_t
-#define YYPTRDIFF_MAXIMUM PTRDIFF_MAX
-#else
-#define YYPTRDIFF_T long
-#define YYPTRDIFF_MAXIMUM LONG_MAX
-#endif
+# if defined __PTRDIFF_TYPE__ && defined __PTRDIFF_MAX__
+#  define YYPTRDIFF_T __PTRDIFF_TYPE__
+#  define YYPTRDIFF_MAXIMUM __PTRDIFF_MAX__
+# elif defined PTRDIFF_MAX
+#  ifndef ptrdiff_t
+#   include <stddef.h> /* INFRINGES ON USER NAME SPACE */
+#  endif
+#  define YYPTRDIFF_T ptrdiff_t
+#  define YYPTRDIFF_MAXIMUM PTRDIFF_MAX
+# else
+#  define YYPTRDIFF_T long
+#  define YYPTRDIFF_MAXIMUM LONG_MAX
+# endif
 #endif
 
 #ifndef YYSIZE_T
-#ifdef __SIZE_TYPE__
-#define YYSIZE_T __SIZE_TYPE__
-#elif defined size_t
-#define YYSIZE_T size_t
-#elif defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
-#include <stddef.h> /* INFRINGES ON USER NAME SPACE */
-#define YYSIZE_T size_t
-#else
-#define YYSIZE_T unsigned
-#endif
+# ifdef __SIZE_TYPE__
+#  define YYSIZE_T __SIZE_TYPE__
+# elif defined size_t
+#  define YYSIZE_T size_t
+# elif defined __STDC_VERSION__ && 199901 <= __STDC_VERSION__
+#  include <stddef.h> /* INFRINGES ON USER NAME SPACE */
+#  define YYSIZE_T size_t
+# else
+#  define YYSIZE_T unsigned
+# endif
 #endif
 
-#define YYSIZE_MAXIMUM                                                         \
-    YY_CAST(YYPTRDIFF_T, (YYPTRDIFF_MAXIMUM < YY_CAST(YYSIZE_T, -1)            \
-                              ? YYPTRDIFF_MAXIMUM                              \
-                              : YY_CAST(YYSIZE_T, -1)))
+#define YYSIZE_MAXIMUM                                  \
+  YY_CAST (YYPTRDIFF_T,                                 \
+           (YYPTRDIFF_MAXIMUM < YY_CAST (YYSIZE_T, -1)  \
+            ? YYPTRDIFF_MAXIMUM                         \
+            : YY_CAST (YYSIZE_T, -1)))
 
-#define YYSIZEOF(X) YY_CAST(YYPTRDIFF_T, sizeof(X))
+#define YYSIZEOF(X) YY_CAST (YYPTRDIFF_T, sizeof (X))
+
 
 /* Stored state numbers (used for stacks). */
 typedef yytype_uint8 yy_state_t;
@@ -345,592 +355,670 @@ typedef yytype_uint8 yy_state_t;
 typedef int yy_state_fast_t;
 
 #ifndef YY_
-#if defined YYENABLE_NLS && YYENABLE_NLS
-#if ENABLE_NLS
-#include <libintl.h> /* INFRINGES ON USER NAME SPACE */
-#define YY_(Msgid) dgettext("bison-runtime", Msgid)
-#endif
-#endif
-#ifndef YY_
-#define YY_(Msgid) Msgid
-#endif
+# if defined YYENABLE_NLS && YYENABLE_NLS
+#  if ENABLE_NLS
+#   include <libintl.h> /* INFRINGES ON USER NAME SPACE */
+#   define YY_(Msgid) dgettext ("bison-runtime", Msgid)
+#  endif
+# endif
+# ifndef YY_
+#  define YY_(Msgid) Msgid
+# endif
 #endif
 
+
 #ifndef YY_ATTRIBUTE_PURE
-#if defined __GNUC__ && 2 < __GNUC__ + (96 <= __GNUC_MINOR__)
-#define YY_ATTRIBUTE_PURE __attribute__((__pure__))
-#else
-#define YY_ATTRIBUTE_PURE
-#endif
+# if defined __GNUC__ && 2 < __GNUC__ + (96 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_PURE __attribute__ ((__pure__))
+# else
+#  define YY_ATTRIBUTE_PURE
+# endif
 #endif
 
 #ifndef YY_ATTRIBUTE_UNUSED
-#if defined __GNUC__ && 2 < __GNUC__ + (7 <= __GNUC_MINOR__)
-#define YY_ATTRIBUTE_UNUSED __attribute__((__unused__))
-#else
-#define YY_ATTRIBUTE_UNUSED
-#endif
+# if defined __GNUC__ && 2 < __GNUC__ + (7 <= __GNUC_MINOR__)
+#  define YY_ATTRIBUTE_UNUSED __attribute__ ((__unused__))
+# else
+#  define YY_ATTRIBUTE_UNUSED
+# endif
 #endif
 
 /* Suppress unused-variable warnings by "using" E.  */
-#if !defined lint || defined __GNUC__
-#define YY_USE(E) ((void)(E))
+#if ! defined lint || defined __GNUC__
+# define YY_USE(E) ((void) (E))
 #else
-#define YY_USE(E) /* empty */
+# define YY_USE(E) /* empty */
 #endif
 
 /* Suppress an incorrect diagnostic about yylval being uninitialized.  */
-#if defined __GNUC__ && !defined __ICC && 406 <= __GNUC__ * 100 + __GNUC_MINOR__
-#if __GNUC__ * 100 + __GNUC_MINOR__ < 407
-#define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                                    \
-    _Pragma("GCC diagnostic push")                                             \
-        _Pragma("GCC diagnostic ignored \"-Wuninitialized\"")
+#if defined __GNUC__ && ! defined __ICC && 406 <= __GNUC__ * 100 + __GNUC_MINOR__
+# if __GNUC__ * 100 + __GNUC_MINOR__ < 407
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")
+# else
+#  define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                           \
+    _Pragma ("GCC diagnostic push")                                     \
+    _Pragma ("GCC diagnostic ignored \"-Wuninitialized\"")              \
+    _Pragma ("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
+# endif
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END      \
+    _Pragma ("GCC diagnostic pop")
 #else
-#define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN                                    \
-    _Pragma("GCC diagnostic push")                                             \
-        _Pragma("GCC diagnostic ignored \"-Wuninitialized\"")                  \
-            _Pragma("GCC diagnostic ignored \"-Wmaybe-uninitialized\"")
-#endif
-#define YY_IGNORE_MAYBE_UNINITIALIZED_END _Pragma("GCC diagnostic pop")
-#else
-#define YY_INITIAL_VALUE(Value) Value
+# define YY_INITIAL_VALUE(Value) Value
 #endif
 #ifndef YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-#define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-#define YY_IGNORE_MAYBE_UNINITIALIZED_END
+# define YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+# define YY_IGNORE_MAYBE_UNINITIALIZED_END
 #endif
 #ifndef YY_INITIAL_VALUE
-#define YY_INITIAL_VALUE(Value) /* Nothing. */
+# define YY_INITIAL_VALUE(Value) /* Nothing. */
 #endif
 
-#if defined __cplusplus && defined __GNUC__ && !defined __ICC && 6 <= __GNUC__
-#define YY_IGNORE_USELESS_CAST_BEGIN                                           \
-    _Pragma("GCC diagnostic push")                                             \
-        _Pragma("GCC diagnostic ignored \"-Wuseless-cast\"")
-#define YY_IGNORE_USELESS_CAST_END _Pragma("GCC diagnostic pop")
+#if defined __cplusplus && defined __GNUC__ && ! defined __ICC && 6 <= __GNUC__
+# define YY_IGNORE_USELESS_CAST_BEGIN                          \
+    _Pragma ("GCC diagnostic push")                            \
+    _Pragma ("GCC diagnostic ignored \"-Wuseless-cast\"")
+# define YY_IGNORE_USELESS_CAST_END            \
+    _Pragma ("GCC diagnostic pop")
 #endif
 #ifndef YY_IGNORE_USELESS_CAST_BEGIN
-#define YY_IGNORE_USELESS_CAST_BEGIN
-#define YY_IGNORE_USELESS_CAST_END
+# define YY_IGNORE_USELESS_CAST_BEGIN
+# define YY_IGNORE_USELESS_CAST_END
 #endif
 
-#define YY_ASSERT(E) ((void)(0 && (E)))
+
+#define YY_ASSERT(E) ((void) (0 && (E)))
 
 #if 1
 
 /* The parser invokes alloca or malloc; define the necessary symbols.  */
 
-#ifdef YYSTACK_USE_ALLOCA
-#if YYSTACK_USE_ALLOCA
-#ifdef __GNUC__
-#define YYSTACK_ALLOC __builtin_alloca
-#elif defined __BUILTIN_VA_ARG_INCR
-#include <alloca.h> /* INFRINGES ON USER NAME SPACE */
-#elif defined _AIX
-#define YYSTACK_ALLOC __alloca
-#elif defined _MSC_VER
-#include <malloc.h> /* INFRINGES ON USER NAME SPACE */
-#define alloca _alloca
-#else
-#define YYSTACK_ALLOC alloca
-#if !defined _ALLOCA_H && !defined EXIT_SUCCESS
-#include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
-/* Use EXIT_SUCCESS as a witness for stdlib.h.  */
-#ifndef EXIT_SUCCESS
-#define EXIT_SUCCESS 0
-#endif
-#endif
-#endif
-#endif
-#endif
+# ifdef YYSTACK_USE_ALLOCA
+#  if YYSTACK_USE_ALLOCA
+#   ifdef __GNUC__
+#    define YYSTACK_ALLOC __builtin_alloca
+#   elif defined __BUILTIN_VA_ARG_INCR
+#    include <alloca.h> /* INFRINGES ON USER NAME SPACE */
+#   elif defined _AIX
+#    define YYSTACK_ALLOC __alloca
+#   elif defined _MSC_VER
+#    include <malloc.h> /* INFRINGES ON USER NAME SPACE */
+#    define alloca _alloca
+#   else
+#    define YYSTACK_ALLOC alloca
+#    if ! defined _ALLOCA_H && ! defined EXIT_SUCCESS
+#     include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
+      /* Use EXIT_SUCCESS as a witness for stdlib.h.  */
+#     ifndef EXIT_SUCCESS
+#      define EXIT_SUCCESS 0
+#     endif
+#    endif
+#   endif
+#  endif
+# endif
 
-#ifdef YYSTACK_ALLOC
-/* Pacify GCC's 'empty if-body' warning.  */
-#define YYSTACK_FREE(Ptr)                                                      \
-    do                                                                         \
-    { /* empty */                                                              \
-        ;                                                                      \
-    } while (0)
-#ifndef YYSTACK_ALLOC_MAXIMUM
-/* The OS might guarantee only one guard page at the bottom of the stack,
+# ifdef YYSTACK_ALLOC
+   /* Pacify GCC's 'empty if-body' warning.  */
+#  define YYSTACK_FREE(Ptr) do { /* empty */; } while (0)
+#  ifndef YYSTACK_ALLOC_MAXIMUM
+    /* The OS might guarantee only one guard page at the bottom of the stack,
        and a page size can be as small as 4096 bytes.  So we cannot safely
        invoke alloca (N) if N exceeds 4096.  Use a slightly smaller number
        to allow for a few compiler-allocated temporary stack slots.  */
-#define YYSTACK_ALLOC_MAXIMUM 4032 /* reasonable circa 2006 */
-#endif
-#else
-#define YYSTACK_ALLOC YYMALLOC
-#define YYSTACK_FREE YYFREE
-#ifndef YYSTACK_ALLOC_MAXIMUM
-#define YYSTACK_ALLOC_MAXIMUM YYSIZE_MAXIMUM
-#endif
-#if (defined __cplusplus && !defined EXIT_SUCCESS &&                           \
-     !((defined YYMALLOC || defined malloc) &&                                 \
-       (defined YYFREE || defined free)))
-#include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
-#ifndef EXIT_SUCCESS
-#define EXIT_SUCCESS 0
-#endif
-#endif
-#ifndef YYMALLOC
-#define YYMALLOC malloc
-#if !defined malloc && !defined EXIT_SUCCESS
-void *malloc(YYSIZE_T); /* INFRINGES ON USER NAME SPACE */
-#endif
-#endif
-#ifndef YYFREE
-#define YYFREE free
-#if !defined free && !defined EXIT_SUCCESS
-void free(void *);      /* INFRINGES ON USER NAME SPACE */
-#endif
-#endif
-#endif
+#   define YYSTACK_ALLOC_MAXIMUM 4032 /* reasonable circa 2006 */
+#  endif
+# else
+#  define YYSTACK_ALLOC YYMALLOC
+#  define YYSTACK_FREE YYFREE
+#  ifndef YYSTACK_ALLOC_MAXIMUM
+#   define YYSTACK_ALLOC_MAXIMUM YYSIZE_MAXIMUM
+#  endif
+#  if (defined __cplusplus && ! defined EXIT_SUCCESS \
+       && ! ((defined YYMALLOC || defined malloc) \
+             && (defined YYFREE || defined free)))
+#   include <stdlib.h> /* INFRINGES ON USER NAME SPACE */
+#   ifndef EXIT_SUCCESS
+#    define EXIT_SUCCESS 0
+#   endif
+#  endif
+#  ifndef YYMALLOC
+#   define YYMALLOC malloc
+#   if ! defined malloc && ! defined EXIT_SUCCESS
+void *malloc (YYSIZE_T); /* INFRINGES ON USER NAME SPACE */
+#   endif
+#  endif
+#  ifndef YYFREE
+#   define YYFREE free
+#   if ! defined free && ! defined EXIT_SUCCESS
+void free (void *); /* INFRINGES ON USER NAME SPACE */
+#   endif
+#  endif
+# endif
 #endif /* 1 */
 
-#if (!defined yyoverflow &&                                                    \
-     (!defined __cplusplus ||                                                  \
-      (defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL)))
+#if (! defined yyoverflow \
+     && (! defined __cplusplus \
+         || (defined YYSTYPE_IS_TRIVIAL && YYSTYPE_IS_TRIVIAL)))
 
 /* A type that is properly aligned for any stack member.  */
 union yyalloc
 {
-    yy_state_t yyss_alloc;
-    YYSTYPE yyvs_alloc;
+  yy_state_t yyss_alloc;
+  YYSTYPE yyvs_alloc;
 };
 
 /* The size of the maximum gap between one aligned stack and the next.  */
-#define YYSTACK_GAP_MAXIMUM (YYSIZEOF(union yyalloc) - 1)
+# define YYSTACK_GAP_MAXIMUM (YYSIZEOF (union yyalloc) - 1)
 
 /* The size of an array large to enough to hold all stacks, each with
    N elements.  */
-#define YYSTACK_BYTES(N)                                                       \
-    ((N) * (YYSIZEOF(yy_state_t) + YYSIZEOF(YYSTYPE)) + YYSTACK_GAP_MAXIMUM)
+# define YYSTACK_BYTES(N) \
+     ((N) * (YYSIZEOF (yy_state_t) + YYSIZEOF (YYSTYPE)) \
+      + YYSTACK_GAP_MAXIMUM)
 
-#define YYCOPY_NEEDED 1
+# define YYCOPY_NEEDED 1
 
 /* Relocate STACK from its old location to the new one.  The
    local variables YYSIZE and YYSTACKSIZE give the old and new number of
    elements in the stack, and YYPTR gives the new location of the
    stack.  Advance YYPTR to a properly aligned location for the next
    stack.  */
-#define YYSTACK_RELOCATE(Stack_alloc, Stack)                                   \
-    do                                                                         \
-    {                                                                          \
-        YYPTRDIFF_T yynewbytes;                                                \
-        YYCOPY(&yyptr->Stack_alloc, Stack, yysize);                            \
-        Stack = &yyptr->Stack_alloc;                                           \
-        yynewbytes = yystacksize * YYSIZEOF(*Stack) + YYSTACK_GAP_MAXIMUM;     \
-        yyptr += yynewbytes / YYSIZEOF(*yyptr);                                \
-    } while (0)
+# define YYSTACK_RELOCATE(Stack_alloc, Stack)                           \
+    do                                                                  \
+      {                                                                 \
+        YYPTRDIFF_T yynewbytes;                                         \
+        YYCOPY (&yyptr->Stack_alloc, Stack, yysize);                    \
+        Stack = &yyptr->Stack_alloc;                                    \
+        yynewbytes = yystacksize * YYSIZEOF (*Stack) + YYSTACK_GAP_MAXIMUM; \
+        yyptr += yynewbytes / YYSIZEOF (*yyptr);                        \
+      }                                                                 \
+    while (0)
 
 #endif
 
 #if defined YYCOPY_NEEDED && YYCOPY_NEEDED
 /* Copy COUNT objects from SRC to DST.  The source and destination do
    not overlap.  */
-#ifndef YYCOPY
-#if defined __GNUC__ && 1 < __GNUC__
-#define YYCOPY(Dst, Src, Count)                                                \
-    __builtin_memcpy(Dst, Src, YY_CAST(YYSIZE_T, (Count)) * sizeof(*(Src)))
-#else
-#define YYCOPY(Dst, Src, Count)                                                \
-    do                                                                         \
-    {                                                                          \
-        YYPTRDIFF_T yyi;                                                       \
-        for (yyi = 0; yyi < (Count); yyi++)                                    \
-            (Dst)[yyi] = (Src)[yyi];                                           \
-    } while (0)
-#endif
-#endif
+# ifndef YYCOPY
+#  if defined __GNUC__ && 1 < __GNUC__
+#   define YYCOPY(Dst, Src, Count) \
+      __builtin_memcpy (Dst, Src, YY_CAST (YYSIZE_T, (Count)) * sizeof (*(Src)))
+#  else
+#   define YYCOPY(Dst, Src, Count)              \
+      do                                        \
+        {                                       \
+          YYPTRDIFF_T yyi;                      \
+          for (yyi = 0; yyi < (Count); yyi++)   \
+            (Dst)[yyi] = (Src)[yyi];            \
+        }                                       \
+      while (0)
+#  endif
+# endif
 #endif /* !YYCOPY_NEEDED */
 
 /* YYFINAL -- State number of the termination state.  */
-#define YYFINAL 20
+#define YYFINAL  22
 /* YYLAST -- Last index in YYTABLE.  */
-#define YYLAST 409
+#define YYLAST   469
 
 /* YYNTOKENS -- Number of terminals.  */
-#define YYNTOKENS 53
+#define YYNTOKENS  54
 /* YYNNTS -- Number of nonterminals.  */
-#define YYNNTS 25
+#define YYNNTS  27
 /* YYNRULES -- Number of rules.  */
-#define YYNRULES 101
+#define YYNRULES  105
 /* YYNSTATES -- Number of states.  */
-#define YYNSTATES 211
+#define YYNSTATES  215
 
 /* YYMAXUTOK -- Last valid token kind.  */
-#define YYMAXUTOK 294
+#define YYMAXUTOK   295
+
 
 /* YYTRANSLATE(TOKEN-NUM) -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex, with out-of-bounds checking.  */
-#define YYTRANSLATE(YYX)                                                       \
-    (0 <= (YYX) && (YYX) <= YYMAXUTOK                                          \
-         ? YY_CAST(yysymbol_kind_t, yytranslate[YYX])                          \
-         : YYSYMBOL_YYUNDEF)
+#define YYTRANSLATE(YYX)                                \
+  (0 <= (YYX) && (YYX) <= YYMAXUTOK                     \
+   ? YY_CAST (yysymbol_kind_t, yytranslate[YYX])        \
+   : YYSYMBOL_YYUNDEF)
 
 /* YYTRANSLATE[TOKEN-NUM] -- Symbol number corresponding to TOKEN-NUM
    as returned by yylex.  */
-static const yytype_int8 yytranslate[] = {
-    0,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
-    2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  41, 2,  2,  2,  46,
-    2,  2,  49, 50, 44, 42, 51, 43, 52, 45, 2,  2,  2,  2,  2,  2,  2,  2,  2,
-    2,  2,  2,  39, 38, 40, 2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
-    2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
-    2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
-    2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
-    2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
-    2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
-    2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
-    2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
-    2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
-    2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,  2,
-    2,  2,  2,  2,  2,  2,  2,  2,  2,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
-    11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29,
-    30, 31, 32, 33, 34, 35, 36, 37, 47, 48};
+static const yytype_int8 yytranslate[] =
+{
+       0,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,    42,     2,     2,     2,    47,     2,     2,
+      50,    51,    45,    43,    52,    44,    53,    46,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+      40,    39,    41,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     2,     2,     2,     2,
+       2,     2,     2,     2,     2,     2,     1,     2,     3,     4,
+       5,     6,     7,     8,     9,    10,    11,    12,    13,    14,
+      15,    16,    17,    18,    19,    20,    21,    22,    23,    24,
+      25,    26,    27,    28,    29,    30,    31,    32,    33,    34,
+      35,    36,    37,    38,    48,    49
+};
 
 #if YYDEBUG
 /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
-static const yytype_int16 yyrline[] = {
-    0,   124, 124, 125, 131, 138, 143, 148, 153, 160, 168, 176, 184, 192, 200,
-    208, 216, 224, 232, 240, 252, 261, 274, 282, 294, 303, 316, 325, 338, 347,
-    360, 367, 379, 385, 392, 400, 413, 418, 423, 427, 432, 437, 442, 477, 484,
-    491, 498, 505, 512, 548, 556, 562, 569, 578, 596, 616, 617, 620, 625, 631,
-    632, 634, 642, 643, 646, 656, 657, 660, 661, 664, 673, 684, 699, 714, 735,
-    766, 801, 826, 855, 861, 863, 864, 869, 870, 876, 883, 884, 887, 888, 891,
-    897, 903, 910, 911, 918, 919, 927, 937, 948, 959, 972, 983};
+static const yytype_int16 yyrline[] =
+{
+       0,   125,   125,   126,   132,   139,   144,   149,   154,   161,
+     169,   177,   185,   193,   201,   209,   217,   225,   233,   241,
+     253,   262,   275,   283,   295,   304,   317,   326,   339,   348,
+     361,   368,   380,   386,   393,   395,   398,   406,   419,   424,
+     429,   433,   438,   443,   448,   483,   490,   497,   504,   511,
+     518,   554,   562,   568,   575,   584,   602,   622,   623,   626,
+     631,   637,   638,   640,   648,   649,   652,   662,   663,   666,
+     667,   670,   679,   690,   705,   720,   741,   772,   807,   832,
+     861,   867,   870,   872,   881,   882,   887,   888,   894,   901,
+     902,   905,   906,   909,   915,   921,   928,   929,   936,   937,
+     945,   955,   966,   977,   990,  1001
+};
 #endif
 
 /** Accessing symbol of state STATE.  */
-#define YY_ACCESSING_SYMBOL(State) YY_CAST(yysymbol_kind_t, yystos[State])
+#define YY_ACCESSING_SYMBOL(State) YY_CAST (yysymbol_kind_t, yystos[State])
 
 #if 1
+/* The user-facing name of the symbol whose (internal) number is
+   YYSYMBOL.  No bounds checking.  */
+static const char *yysymbol_name (yysymbol_kind_t yysymbol) YY_ATTRIBUTE_UNUSED;
+
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
-static const char *const yytname[] = {"\"end of string\"",
-                                      "error",
-                                      "\"invalid token\"",
-                                      "\"integer number\"",
-                                      "\"floating point number\"",
-                                      "\"string\"",
-                                      "\"identifier\"",
-                                      "\"IN\"",
-                                      "\"LIKE\"",
-                                      "\"ILIKE\"",
-                                      "\"ESCAPE\"",
-                                      "\"BETWEEN\"",
-                                      "\"NULL\"",
-                                      "\"IS\"",
-                                      "\"SELECT\"",
-                                      "\"LEFT\"",
-                                      "\"JOIN\"",
-                                      "\"WHERE\"",
-                                      "\"ON\"",
-                                      "\"ORDER\"",
-                                      "\"BY\"",
-                                      "\"FROM\"",
-                                      "\"AS\"",
-                                      "\"ASC\"",
-                                      "\"DESC\"",
-                                      "\"DISTINCT\"",
-                                      "\"CAST\"",
-                                      "\"UNION\"",
-                                      "\"ALL\"",
-                                      "\"LIMIT\"",
-                                      "\"OFFSET\"",
-                                      "\"EXCEPT\"",
-                                      "\"EXCLUDE\"",
-                                      "SWQT_VALUE_START",
-                                      "SWQT_SELECT_START",
-                                      "\"NOT\"",
-                                      "\"OR\"",
-                                      "\"AND\"",
-                                      "'='",
-                                      "'<'",
-                                      "'>'",
-                                      "'!'",
-                                      "'+'",
-                                      "'-'",
-                                      "'*'",
-                                      "'/'",
-                                      "'%'",
-                                      "SWQT_UMINUS",
-                                      "\"reserved keyword\"",
-                                      "'('",
-                                      "')'",
-                                      "','",
-                                      "'.'",
-                                      "$accept",
-                                      "input",
-                                      "value_expr",
-                                      "value_expr_list",
-                                      "field_value",
-                                      "value_expr_non_logical",
-                                      "type_def",
-                                      "select_statement",
-                                      "select_core",
-                                      "opt_union_all",
-                                      "union_all",
-                                      "select_field_list",
-                                      "exclude_field",
-                                      "exclude_field_list",
-                                      "except_or_exclude",
-                                      "column_spec",
-                                      "as_clause",
-                                      "opt_where",
-                                      "opt_joins",
-                                      "opt_order_by",
-                                      "sort_spec_list",
-                                      "sort_spec",
-                                      "opt_limit",
-                                      "opt_offset",
-                                      "table_def",
-                                      YY_NULLPTR};
+static const char *const yytname[] =
+{
+  "\"end of string\"", "error", "\"invalid token\"", "\"integer number\"",
+  "\"floating point number\"", "\"string\"", "\"identifier\"", "\"IN\"",
+  "\"LIKE\"", "\"ILIKE\"", "\"ESCAPE\"", "\"BETWEEN\"", "\"NULL\"",
+  "\"IS\"", "\"SELECT\"", "\"LEFT\"", "\"JOIN\"", "\"WHERE\"", "\"ON\"",
+  "\"ORDER\"", "\"BY\"", "\"FROM\"", "\"AS\"", "\"ASC\"", "\"DESC\"",
+  "\"DISTINCT\"", "\"CAST\"", "\"UNION\"", "\"ALL\"", "\"LIMIT\"",
+  "\"OFFSET\"", "\"EXCEPT\"", "\"EXCLUDE\"", "\"HIDDEN\"",
+  "SWQT_VALUE_START", "SWQT_SELECT_START", "\"NOT\"", "\"OR\"", "\"AND\"",
+  "'='", "'<'", "'>'", "'!'", "'+'", "'-'", "'*'", "'/'", "'%'",
+  "SWQT_UMINUS", "\"reserved keyword\"", "'('", "')'", "','", "'.'",
+  "$accept", "input", "value_expr", "value_expr_list", "identifier",
+  "field_value", "value_expr_non_logical", "type_def", "select_statement",
+  "select_core", "opt_union_all", "union_all", "select_field_list",
+  "exclude_field", "exclude_field_list", "except_or_exclude",
+  "column_spec", "as_clause", "as_clause_with_hidden", "opt_where",
+  "opt_joins", "opt_order_by", "sort_spec_list", "sort_spec", "opt_limit",
+  "opt_offset", "table_def", YY_NULLPTR
+};
+
+static const char *
+yysymbol_name (yysymbol_kind_t yysymbol)
+{
+  return yytname[yysymbol];
+}
 #endif
 
-#define YYPACT_NINF (-137)
+#define YYPACT_NINF (-136)
 
-#define yypact_value_is_default(Yyn) ((Yyn) == YYPACT_NINF)
+#define yypact_value_is_default(Yyn) \
+  ((Yyn) == YYPACT_NINF)
 
 #define YYTABLE_NINF (-1)
 
-#define yytable_value_is_error(Yyn) 0
+#define yytable_value_is_error(Yyn) \
+  0
 
 /* YYPACT[STATE-NUM] -- Index in YYTABLE of the portion describing
    STATE-NUM.  */
-static const yytype_int16 yypact[] = {
-    34,   206,  -10,  16,   -137, -137, -137, -35,  -137, -37,  206,  211,
-    206,  326,  -137, 298,  79,   11,   -137, 4,    -137, 206,  23,   206,
-    368,  -137, 254,  -11,  206,  206,  211,  -5,   12,   206,  206,  94,
-    104,  155,  5,    211,  211,  211,  211,  211,  8,    196,  93,   274,
-    48,   26,   30,   65,   -137, -10,  235,  45,   -137, 310,  -137, 206,
-    91,   101,  44,   -137, 103,  68,   206,  206,  211,  345,  361,  206,
-    206,  -137, 206,  206,  -137, 206,  -137, 206,  18,   18,   -137, -137,
-    -137, 145,  -3,   100,  -137, -137, 89,   -137, 140,  -137, 121,  196,
-    4,    -137, -137, 206,  -137, 146,  114,  206,  206,  211,  -137, 206,
-    144,  158,  182,  -137, -137, -137, -137, -137, -137, 159,  119,  -137,
-    121,  159,  -137, 120,  2,    116,  -137, -137, -137, 124,  125,  -137,
-    -137, -137, 298,  127,  206,  206,  211,  122,  128,  20,   116,  -137,
-    131,  129,  177,  178,  -137, 170,  121,  174,  53,   -137, -137, -137,
-    -137, 298,  20,   -137, 174,  159,  -137, 20,   20,   121,  169,  206,
-    173,  90,   105,  -137, 173,  -137, -137, -137, 179,  206,  326,  175,
-    167,  -137, 200,  -137, 202,  167,  206,  290,  159,  203,  183,  157,
-    171,  183,  290,  -137, 139,  -137, 184,  -137, 217,  -137, -137, -137,
-    -137, -137, -137, -137, 159,  -137, -137};
+static const yytype_int16 yypact[] =
+{
+      66,    93,   -13,    11,  -136,  -136,  -136,  -136,  -136,   -24,
+    -136,    93,   292,    93,   413,   -34,  -136,   174,   136,    21,
+    -136,    30,  -136,    93,   427,  -136,   315,    -9,    93,    93,
+     292,     2,   116,    93,    93,   172,   197,   239,    25,    93,
+       0,   292,   292,   292,   292,   292,   258,    84,   356,   -32,
+      27,    19,    23,    48,  -136,   -13,   377,  -136,    93,    73,
+      75,   145,  -136,    92,    57,    93,    93,   292,   420,   298,
+      93,    93,  -136,    93,    93,  -136,    93,  -136,    93,   308,
+      62,  -136,   -22,   -22,  -136,  -136,  -136,   107,  -136,  -136,
+      72,     0,  -136,   111,  -136,   223,    14,     7,   258,    30,
+    -136,  -136,     0,    95,    93,    93,   292,  -136,    93,   144,
+     149,   399,  -136,  -136,  -136,  -136,  -136,  -136,    93,  -136,
+       7,     0,  -136,  -136,     0,   109,  -136,   110,    55,   102,
+    -136,  -136,   114,   115,  -136,  -136,  -136,   174,   117,    93,
+      93,   292,  -136,   102,   118,  -136,   121,   119,   128,     9,
+       0,     0,  -136,   151,     7,   165,    -1,  -136,  -136,  -136,
+    -136,   174,   165,     0,  -136,     9,  -136,     9,     9,     7,
+     167,    93,   176,    83,   101,   176,  -136,  -136,  -136,  -136,
+     175,    93,   413,   179,   178,  -136,   193,  -136,   201,   178,
+      93,   364,     0,   207,   181,   163,   164,   181,   364,  -136,
+     134,  -136,   173,  -136,   221,  -136,  -136,  -136,  -136,  -136,
+    -136,  -136,     0,  -136,  -136
+};
 
 /* YYDEFACT[STATE-NUM] -- Default reduction number in state STATE-NUM.
    Performed when YYTABLE does not specify something else to do.  Zero
    means the default is an error.  */
-static const yytype_int8 yydefact[] = {
-    2,  0,  0,   0,  36, 37, 38, 34, 41, 0,  0,  0,  0,  3,   39, 5,  0,  0,
-    4,  59, 1,   0,  0,  0,  8,  42, 0,  0,  0,  0,  0,  0,   0,  0,  0,  0,
-    0,  0,  0,   0,  0,  0,  0,  0,  34, 0,  72, 69, 0,  62,  0,  0,  55, 0,
-    33, 0,  35,  0,  40, 0,  18, 22, 0,  30, 0,  0,  0,  0,   0,  7,  6,  0,
-    0,  9,  0,   0,  12, 0,  13, 0,  43, 44, 45, 46, 47, 0,   0,  0,  67, 68,
-    0,  79, 0,   70, 0,  0,  59, 61, 60, 0,  48, 0,  0,  0,   0,  0,  31, 0,
-    19, 23, 0,   15, 16, 14, 10, 17, 11, 0,  0,  73, 0,  0,   78, 0,  96, 82,
-    63, 56, 32,  50, 0,  26, 20, 24, 28, 0,  0,  0,  0,  34,  0,  74, 82, 64,
-    65, 0,  0,   0,  97, 0,  0,  80, 0,  49, 27, 21, 25, 29,  76, 75, 80, 0,
-    71, 98, 100, 0,  0,  0,  85, 0,  0,  77, 85, 66, 99, 101, 0,  0,  81, 0,
-    92, 51, 0,   53, 0,  92, 0,  82, 0,  0,  94, 0,  0,  94,  82, 83, 89, 86,
-    88, 93, 0,   57, 52, 54, 58, 84, 90, 91, 0,  95, 87};
+static const yytype_int8 yydefact[] =
+{
+       2,     0,     0,     0,    38,    39,    40,    34,    43,     0,
+      35,     0,     0,     0,     3,    36,    41,     5,     0,     0,
+       4,    61,     1,     0,     8,    44,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,     0,     0,     0,
+       0,     0,     0,     0,     0,     0,     0,    74,    71,    36,
+       0,    64,     0,     0,    57,     0,     0,    42,     0,    18,
+      22,     0,    30,     0,     0,     0,     0,     0,     7,     6,
+       0,     0,     9,     0,     0,    12,     0,    13,     0,    33,
+       0,    37,    45,    46,    47,    48,    49,     0,    69,    70,
+       0,     0,    81,    82,    72,     0,     0,     0,     0,    61,
+      63,    62,     0,     0,     0,     0,     0,    31,     0,    19,
+      23,     0,    15,    16,    14,    10,    17,    11,     0,    50,
+       0,     0,    80,    83,     0,     0,    75,     0,   100,    86,
+      65,    58,    52,     0,    26,    20,    24,    28,     0,     0,
+       0,     0,    32,    86,    36,    66,    67,     0,     0,    76,
+       0,     0,   101,     0,     0,    84,     0,    51,    27,    21,
+      25,    29,    84,     0,    73,    78,    77,   102,   104,     0,
+       0,     0,    89,     0,     0,    89,    68,    79,   103,   105,
+       0,     0,    85,     0,    96,    53,     0,    55,     0,    96,
+       0,    86,     0,     0,    98,     0,     0,    98,    86,    87,
+      93,    90,    92,    97,     0,    59,    54,    56,    60,    88,
+      94,    95,     0,    99,    91
+};
 
 /* YYPGOTO[NTERM-NUM].  */
-static const yytype_int16 yypgoto[] = {
-    -137, -137, -1,   -46, -116, 7,    -137, 176, 213,  137, -137, -43, -137,
-    73,   -137, -137, -45, 76,   -136, 66,   39,  -137, 67,  57,   -110};
+static const yytype_int16 yypgoto[] =
+{
+    -136,  -136,    16,   -48,   -18,  -117,    24,  -136,   177,   212,
+     135,  -136,   -43,  -136,    74,  -136,  -136,   -56,  -136,    77,
+    -135,    65,    34,  -136,    61,    56,  -111
+};
 
 /* YYDEFGOTO[NTERM-NUM].  */
-static const yytype_uint8 yydefgoto[] = {
-    0,   3,  54, 55, 14,  15,  130, 18,  19,  52,  53,  48, 144,
-    145, 90, 49, 93, 168, 151, 180, 197, 198, 190, 201, 125};
+static const yytype_uint8 yydefgoto[] =
+{
+       0,     3,    79,    80,    15,    16,    17,   133,    20,    21,
+      54,    55,    50,   146,   147,    90,    51,    93,    94,   172,
+     155,   184,   201,   202,   194,   205,   129
+};
 
 /* YYTABLE[YYPACT[STATE-NUM]] -- What to do in state STATE-NUM.  If
    positive, shift that token.  If negative, reduce the rule whose
    number is the opposite.  If YYTABLE_NINF, syntax error.  */
-static const yytype_uint8 yytable[] = {
-    13,  140, 87,  56,  16,  143, 160, 63,  91,  24,  142, 26,  23,  102, 21,
-    47,  20,  22,  25,  65,  66,  67,  57,  68,  92,  16,  91,  60,  61,  56,
-    64,  51,  69,  70,  73,  76,  78,  62,  59,  17,  166, 119, 92,  79,  47,
-    143, 80,  81,  82,  83,  84,  195, 126, 128, 147, 176, 169, 85,  205, 170,
-    86,  135, 41,  42,  43,  108, 109, 1,   2,   94,  111, 112, 196, 113, 114,
-    110, 115, 95,  116, 148, 96,  105, 4,   5,   6,   44,  39,  40,  41,  42,
-    43,  8,   196, 97,  47,  100, 159, 4,   5,   6,   7,   103, 132, 133, 45,
-    9,   8,   4,   5,   6,   7,   104, 134, 171, 10,  106, 8,   107, 174, 175,
-    9,   120, 11,  46,  88,  89,  123, 124, 12,  10,  9,   149, 150, 71,  72,
-    155, 156, 11,  121, 10,  181, 182, 74,  12,  75,  157, 122, 11,  4,   5,
-    6,   7,   129, 12,  136, 183, 184, 8,   4,   5,   6,   7,   206, 207, 131,
-    139, 178, 8,   137, 141, 117, 9,   146, 152, 22,  153, 187, 154, 158, 162,
-    10,  9,   161, 163, 164, 194, 165, 177, 11,  118, 10,  167, 179, 77,  12,
-    188, 189, 186, 11,  4,   5,   6,   44,  191, 12,  192, 199, 202, 8,   4,
-    5,   6,   7,   200, 4,   5,   6,   7,   8,   138, 209, 203, 9,   8,   39,
-    40,  41,  42,  43,  98,  50,  10,  9,   127, 173, 208, 172, 9,   185, 11,
-    46,  10,  27,  28,  29,  12,  30,  210, 31,  11,  204, 0,   193, 0,   11,
-    12,  0,   0,   0,   0,   12,  27,  28,  29,  0,   30,  0,   31,  0,   0,
-    32,  33,  34,  35,  36,  37,  38,  0,   0,   0,   91,  27,  28,  29,  0,
-    30,  99,  31,  0,   32,  33,  34,  35,  36,  37,  38,  92,  27,  28,  29,
-    0,   30,  0,   31,  58,  149, 150, 0,   0,   32,  33,  34,  35,  36,  37,
-    38,  0,   27,  28,  29,  0,   30,  0,   31,  0,   32,  33,  34,  35,  36,
-    37,  38,  101, 27,  28,  29,  0,   30,  0,   31,  39,  40,  41,  42,  43,
-    32,  33,  34,  35,  36,  37,  38,  27,  28,  29,  0,   30,  0,   31,  0,
-    0,   32,  33,  34,  35,  36,  37,  38,  27,  28,  29,  0,   30,  0,   31,
-    27,  28,  29,  0,   30,  32,  31,  34,  35,  36,  37,  38,  0,   0,   0,
-    0,   0,   0,   0,   0,   0,   32,  0,   0,   35,  36,  37,  38,  0,   0,
-    0,   35,  36,  37,  38};
+static const yytype_uint8 yytable[] =
+{
+      49,    18,   173,    87,   145,     7,     7,   148,   162,   143,
+     103,    22,   127,     7,    62,     7,    39,    14,    95,    40,
+       7,    96,    81,    43,    44,    45,    23,    24,    49,    26,
+      92,    91,    10,    10,    48,    18,    25,    19,    63,    56,
+      10,    58,    10,   170,    59,    60,   145,    10,    97,    68,
+      69,    72,    75,    77,    61,   130,   199,    53,   180,   126,
+     138,     7,    48,   209,    78,    82,    83,    84,    85,    86,
+     142,    98,   152,   122,    99,   200,   100,    91,    81,   128,
+      49,   109,   110,   104,   132,   105,   112,   113,    10,   114,
+     115,   111,   116,   166,   117,   200,     4,     5,     6,     7,
+       1,     2,   128,   144,   107,     8,   144,   108,   151,   177,
+      92,   178,   179,   119,    48,    88,    89,   153,   154,     9,
+     135,   136,   121,    64,    65,    66,    10,    67,   120,    11,
+     137,    92,   167,   168,   185,   186,   128,    12,   174,     4,
+       5,     6,     7,    13,   123,   144,   134,    92,     8,    92,
+      92,   128,   187,   188,   139,   159,   160,   210,   211,   140,
+     149,    46,     9,   150,   156,   161,   157,   169,   158,    10,
+     164,    40,    11,   163,   144,     4,     5,     6,     7,   165,
+      12,    47,   171,   106,     8,   181,    13,   182,    41,    42,
+      43,    44,    45,   190,   144,   183,   195,   191,     9,   192,
+       4,     5,     6,     7,   196,    10,   198,   193,    11,     8,
+     203,   204,    70,    71,   206,   207,    12,    41,    42,    43,
+      44,    45,    13,     9,   213,   212,     4,     5,     6,     7,
+      10,    52,   101,    11,   131,     8,    73,   176,    74,   175,
+     189,    12,     4,     5,     6,     7,   214,    13,   124,     9,
+     197,     8,     0,   208,     0,     0,    10,     0,     0,    11,
+       0,     4,     5,     6,     7,     9,     0,    12,   125,     0,
+       8,     0,    10,    13,     0,    11,     0,     0,    76,     0,
+       0,     0,     0,    12,     9,     0,     0,     0,     0,    13,
+       0,    10,     0,     0,    11,     4,     5,     6,     7,     0,
+       0,     0,    12,    47,     8,    27,    28,    29,    13,    30,
+       0,    31,     0,     0,     0,    27,    28,    29,     9,    30,
+       0,    31,    27,    28,    29,    10,    30,     0,    31,     0,
+       0,     0,     0,     0,    32,     0,    12,    35,    36,    37,
+      38,     0,    13,     0,    32,    33,    34,    35,    36,    37,
+      38,    32,    33,    34,    35,    36,    37,    38,     0,     0,
+     118,     0,     7,    27,    28,    29,    57,    30,     0,    31,
+       0,    27,    28,    29,     0,    30,     0,    31,    91,   153,
+     154,     0,     0,     0,    27,    28,    29,     0,    30,    10,
+      31,     0,    32,    33,    34,    35,    36,    37,    38,   102,
+      32,    33,    34,    35,    36,    37,    38,     0,     0,     0,
+       0,     0,     0,    32,    33,    34,    35,    36,    37,    38,
+      27,    28,    29,     0,    30,     0,    31,    27,    28,    29,
+       0,    30,     0,    31,    27,    28,    29,   141,    30,     0,
+      31,     0,    41,    42,    43,    44,    45,     0,     0,    32,
+      33,    34,    35,    36,    37,    38,    32,     0,    34,    35,
+      36,    37,    38,     0,     0,     0,    35,    36,    37,    38
+};
 
-static const yytype_int16 yycheck[] = {
-    1,   117, 45, 6,   14, 121, 142, 12,  6,   10,  120, 12, 49,  59,  49,  16,
-    0,   52,  11, 7,   8,  9,   23,  11,  22,  14,  6,   28, 29,  6,   35,  27,
-    33,  34,  35, 36,  37, 30,  49,  49,  150, 44,  22,  38, 45,  161, 39,  40,
-    41,  42,  43, 187, 95, 99,  52,  165, 3,   49,  194, 6,  52,  107, 44,  45,
-    46,  66,  67, 33,  34, 21,  71,  72,  188, 74,  75,  68, 77,  51,  79,  124,
-    50,  37,  3,  4,   5,  6,   42,  43,  44,  45,  46,  12, 208, 28,  95,  50,
-    141, 3,   4,  5,   6,  10,  103, 104, 25,  26,  12,  3,  4,   5,   6,   10,
-    105, 158, 35, 12,  12, 49,  163, 164, 26,  21,  43,  44, 31,  32,  5,   6,
-    49,  35,  26, 15,  16, 39,  40,  136, 137, 43,  49,  35, 50,  51,  38,  49,
-    40,  138, 6,  43,  3,  4,   5,   6,   6,   49,  10,  50, 51,  12,  3,   4,
-    5,   6,   23, 24,  50, 6,   167, 12,  10,  50,  25,  26, 52,  49,  52,  50,
-    177, 50,  50, 50,  35, 26,  51,  6,   6,   186, 16,  18, 43,  44,  35,  17,
-    19,  38,  49, 20,  29, 18,  43,  3,   4,   5,   6,   3,  49,  3,   3,   50,
-    12,  3,   4,  5,   6,  30,  3,   4,   5,   6,   12,  37, 3,   50,  26,  12,
-    42,  43,  44, 45,  46, 53,  17,  35,  26,  96,  161, 51, 160, 26,  172, 43,
-    44,  35,  7,  8,   9,  49,  11,  208, 13,  43,  193, -1, 185, -1,  43,  49,
-    -1,  -1,  -1, -1,  49, 7,   8,   9,   -1,  11,  -1,  13, -1,  -1,  35,  36,
-    37,  38,  39, 40,  41, -1,  -1,  -1,  6,   7,   8,   9,  -1,  11,  51,  13,
-    -1,  35,  36, 37,  38, 39,  40,  41,  22,  7,   8,   9,  -1,  11,  -1,  13,
-    50,  15,  16, -1,  -1, 35,  36,  37,  38,  39,  40,  41, -1,  7,   8,   9,
-    -1,  11,  -1, 13,  -1, 35,  36,  37,  38,  39,  40,  41, 22,  7,   8,   9,
-    -1,  11,  -1, 13,  42, 43,  44,  45,  46,  35,  36,  37, 38,  39,  40,  41,
-    7,   8,   9,  -1,  11, -1,  13,  -1,  -1,  35,  36,  37, 38,  39,  40,  41,
-    7,   8,   9,  -1,  11, -1,  13,  7,   8,   9,   -1,  11, 35,  13,  37,  38,
-    39,  40,  41, -1,  -1, -1,  -1,  -1,  -1,  -1,  -1,  -1, 35,  -1,  -1,  38,
-    39,  40,  41, -1,  -1, -1,  38,  39,  40,  41};
+static const yytype_int16 yycheck[] =
+{
+      18,    14,     3,    46,   121,     6,     6,   124,   143,   120,
+      58,     0,     5,     6,    12,     6,    50,     1,    50,    53,
+       6,    53,    40,    45,    46,    47,    50,    11,    46,    13,
+      48,    22,    33,    33,    18,    14,    12,    50,    36,    23,
+      33,    50,    33,   154,    28,    29,   163,    33,    21,    33,
+      34,    35,    36,    37,    30,    98,   191,    27,   169,    45,
+     108,     6,    46,   198,    39,    41,    42,    43,    44,    45,
+     118,    52,   128,    91,    51,   192,    28,    22,    96,    97,
+      98,    65,    66,    10,   102,    10,    70,    71,    33,    73,
+      74,    67,    76,   149,    78,   212,     3,     4,     5,     6,
+      34,    35,   120,   121,    12,    12,   124,    50,    53,   165,
+     128,   167,   168,    51,    98,    31,    32,    15,    16,    26,
+     104,   105,    50,     7,     8,     9,    33,    11,    21,    36,
+     106,   149,   150,   151,    51,    52,   154,    44,   156,     3,
+       4,     5,     6,    50,    33,   163,    51,   165,    12,   167,
+     168,   169,    51,    52,    10,   139,   140,    23,    24,    10,
+      51,    25,    26,    53,    50,   141,    51,    16,    51,    33,
+      51,    53,    36,    52,   192,     3,     4,     5,     6,    51,
+      44,    45,    17,    38,    12,    18,    50,   171,    43,    44,
+      45,    46,    47,    18,   212,    19,     3,   181,    26,    20,
+       3,     4,     5,     6,     3,    33,   190,    29,    36,    12,
+       3,    30,    40,    41,    51,    51,    44,    43,    44,    45,
+      46,    47,    50,    26,     3,    52,     3,     4,     5,     6,
+      33,    19,    55,    36,    99,    12,    39,   163,    41,   162,
+     175,    44,     3,     4,     5,     6,   212,    50,    25,    26,
+     189,    12,    -1,   197,    -1,    -1,    33,    -1,    -1,    36,
+      -1,     3,     4,     5,     6,    26,    -1,    44,    45,    -1,
+      12,    -1,    33,    50,    -1,    36,    -1,    -1,    39,    -1,
+      -1,    -1,    -1,    44,    26,    -1,    -1,    -1,    -1,    50,
+      -1,    33,    -1,    -1,    36,     3,     4,     5,     6,    -1,
+      -1,    -1,    44,    45,    12,     7,     8,     9,    50,    11,
+      -1,    13,    -1,    -1,    -1,     7,     8,     9,    26,    11,
+      -1,    13,     7,     8,     9,    33,    11,    -1,    13,    -1,
+      -1,    -1,    -1,    -1,    36,    -1,    44,    39,    40,    41,
+      42,    -1,    50,    -1,    36,    37,    38,    39,    40,    41,
+      42,    36,    37,    38,    39,    40,    41,    42,    -1,    -1,
+      52,    -1,     6,     7,     8,     9,    51,    11,    -1,    13,
+      -1,     7,     8,     9,    -1,    11,    -1,    13,    22,    15,
+      16,    -1,    -1,    -1,     7,     8,     9,    -1,    11,    33,
+      13,    -1,    36,    37,    38,    39,    40,    41,    42,    22,
+      36,    37,    38,    39,    40,    41,    42,    -1,    -1,    -1,
+      -1,    -1,    -1,    36,    37,    38,    39,    40,    41,    42,
+       7,     8,     9,    -1,    11,    -1,    13,     7,     8,     9,
+      -1,    11,    -1,    13,     7,     8,     9,    38,    11,    -1,
+      13,    -1,    43,    44,    45,    46,    47,    -1,    -1,    36,
+      37,    38,    39,    40,    41,    42,    36,    -1,    38,    39,
+      40,    41,    42,    -1,    -1,    -1,    39,    40,    41,    42
+};
 
 /* YYSTOS[STATE-NUM] -- The symbol kind of the accessing symbol of
    state STATE-NUM.  */
-static const yytype_int8 yystos[] = {
-    0,  33, 34, 54, 3,  4,  5,  6,  12, 26, 35, 43, 49, 55, 57, 58, 14, 49,
-    60, 61, 0,  49, 52, 49, 55, 58, 55, 7,  8,  9,  11, 13, 35, 36, 37, 38,
-    39, 40, 41, 42, 43, 44, 45, 46, 6,  25, 44, 55, 64, 68, 61, 27, 62, 63,
-    55, 56, 6,  55, 50, 49, 55, 55, 58, 12, 35, 7,  8,  9,  11, 55, 55, 39,
-    40, 55, 38, 40, 55, 38, 55, 38, 58, 58, 58, 58, 58, 49, 52, 64, 31, 32,
-    67, 6,  22, 69, 21, 51, 50, 28, 60, 51, 50, 22, 56, 10, 10, 37, 12, 49,
-    55, 55, 58, 55, 55, 55, 55, 55, 55, 25, 44, 44, 21, 49, 6,  5,  6,  77,
-    64, 62, 56, 6,  59, 50, 55, 55, 58, 56, 10, 10, 37, 6,  57, 50, 77, 57,
-    65, 66, 52, 52, 69, 15, 16, 71, 49, 50, 50, 55, 55, 58, 50, 69, 71, 51,
-    50, 6,  6,  16, 77, 17, 70, 3,  6,  69, 70, 66, 69, 69, 77, 18, 55, 19,
-    72, 50, 51, 50, 51, 72, 18, 55, 20, 29, 75, 3,  3,  75, 55, 71, 57, 73,
-    74, 3,  30, 76, 50, 50, 76, 71, 23, 24, 51, 3,  73};
-
-/* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
-static const yytype_int8 yyr1[] = {
-    0,  53, 54, 54, 54, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55,
-    55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 55, 56, 56,
-    57, 57, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 58, 59,
-    59, 59, 59, 59, 60, 60, 61, 61, 62, 62, 63, 64, 64, 65, 66, 66, 67,
-    67, 68, 68, 68, 68, 68, 68, 68, 68, 68, 69, 69, 70, 70, 71, 71, 71,
-    72, 72, 73, 73, 74, 74, 74, 75, 75, 76, 76, 77, 77, 77, 77, 77, 77};
-
-/* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
-static const yytype_int8 yyr2[] = {
-    0, 2, 0, 2, 2, 1, 3, 3, 2, 3, 4, 4, 3, 3, 4, 4, 4,  4, 3, 4, 5,
-    6, 3, 4, 5, 6, 5, 6, 5, 6, 3, 4, 3, 1, 1, 3, 1, 1,  1, 1, 3, 1,
-    2, 3, 3, 3, 3, 3, 4, 6, 1, 4, 6, 4, 6, 2, 4, 9, 10, 0, 2, 2, 1,
-    3, 1, 1, 3, 1, 1, 1, 2, 5, 1, 3, 4, 5, 5, 6, 2, 1,  0, 2, 0, 5,
-    6, 0, 3, 3, 1, 1, 2, 2, 0, 2, 0, 2, 1, 2, 3, 4, 3,  4};
-
-enum
+static const yytype_int8 yystos[] =
 {
-    YYENOMEM = -2
+       0,    34,    35,    55,     3,     4,     5,     6,    12,    26,
+      33,    36,    44,    50,    56,    58,    59,    60,    14,    50,
+      62,    63,     0,    50,    56,    60,    56,     7,     8,     9,
+      11,    13,    36,    37,    38,    39,    40,    41,    42,    50,
+      53,    43,    44,    45,    46,    47,    25,    45,    56,    58,
+      66,    70,    63,    27,    64,    65,    56,    51,    50,    56,
+      56,    60,    12,    36,     7,     8,     9,    11,    56,    56,
+      40,    41,    56,    39,    41,    56,    39,    56,    39,    56,
+      57,    58,    60,    60,    60,    60,    60,    66,    31,    32,
+      69,    22,    58,    71,    72,    50,    53,    21,    52,    51,
+      28,    62,    22,    57,    10,    10,    38,    12,    50,    56,
+      56,    60,    56,    56,    56,    56,    56,    56,    52,    51,
+      21,    50,    58,    33,    25,    45,    45,     5,    58,    80,
+      66,    64,    58,    61,    51,    56,    56,    60,    57,    10,
+      10,    38,    57,    80,    58,    59,    67,    68,    59,    51,
+      53,    53,    71,    15,    16,    74,    50,    51,    51,    56,
+      56,    60,    74,    52,    51,    51,    71,    58,    58,    16,
+      80,    17,    73,     3,    58,    73,    68,    71,    71,    71,
+      80,    18,    56,    19,    75,    51,    52,    51,    52,    75,
+      18,    56,    20,    29,    78,     3,     3,    78,    56,    74,
+      59,    76,    77,     3,    30,    79,    51,    51,    79,    74,
+      23,    24,    52,     3,    76
 };
 
-#define yyerrok (yyerrstatus = 0)
-#define yyclearin (yychar = YYEMPTY)
+/* YYR1[RULE-NUM] -- Symbol kind of the left-hand side of rule RULE-NUM.  */
+static const yytype_int8 yyr1[] =
+{
+       0,    54,    55,    55,    55,    56,    56,    56,    56,    56,
+      56,    56,    56,    56,    56,    56,    56,    56,    56,    56,
+      56,    56,    56,    56,    56,    56,    56,    56,    56,    56,
+      56,    56,    57,    57,    58,    58,    59,    59,    60,    60,
+      60,    60,    60,    60,    60,    60,    60,    60,    60,    60,
+      60,    60,    61,    61,    61,    61,    61,    62,    62,    63,
+      63,    64,    64,    65,    66,    66,    67,    68,    68,    69,
+      69,    70,    70,    70,    70,    70,    70,    70,    70,    70,
+      71,    71,    72,    72,    73,    73,    74,    74,    74,    75,
+      75,    76,    76,    77,    77,    77,    78,    78,    79,    79,
+      80,    80,    80,    80,    80,    80
+};
 
-#define YYACCEPT goto yyacceptlab
-#define YYABORT goto yyabortlab
-#define YYERROR goto yyerrorlab
-#define YYNOMEM goto yyexhaustedlab
+/* YYR2[RULE-NUM] -- Number of symbols on the right-hand side of rule RULE-NUM.  */
+static const yytype_int8 yyr2[] =
+{
+       0,     2,     0,     2,     2,     1,     3,     3,     2,     3,
+       4,     4,     3,     3,     4,     4,     4,     4,     3,     4,
+       5,     6,     3,     4,     5,     6,     5,     6,     5,     6,
+       3,     4,     3,     1,     1,     1,     1,     3,     1,     1,
+       1,     1,     3,     1,     2,     3,     3,     3,     3,     3,
+       4,     6,     1,     4,     6,     4,     6,     2,     4,     9,
+      10,     0,     2,     2,     1,     3,     1,     1,     3,     1,
+       1,     1,     2,     5,     1,     3,     4,     5,     5,     6,
+       2,     1,     1,     2,     0,     2,     0,     5,     6,     0,
+       3,     3,     1,     1,     2,     2,     0,     2,     0,     2,
+       1,     2,     3,     4,     3,     4
+};
 
-#define YYRECOVERING() (!!yyerrstatus)
 
-#define YYBACKUP(Token, Value)                                                 \
-    do                                                                         \
-        if (yychar == YYEMPTY)                                                 \
-        {                                                                      \
-            yychar = (Token);                                                  \
-            yylval = (Value);                                                  \
-            YYPOPSTACK(yylen);                                                 \
-            yystate = *yyssp;                                                  \
-            goto yybackup;                                                     \
-        }                                                                      \
-        else                                                                   \
-        {                                                                      \
-            yyerror(context, YY_("syntax error: cannot back up"));             \
-            YYERROR;                                                           \
-        }                                                                      \
-    while (0)
+enum { YYENOMEM = -2 };
+
+#define yyerrok         (yyerrstatus = 0)
+#define yyclearin       (yychar = YYEMPTY)
+
+#define YYACCEPT        goto yyacceptlab
+#define YYABORT         goto yyabortlab
+#define YYERROR         goto yyerrorlab
+#define YYNOMEM         goto yyexhaustedlab
+
+
+#define YYRECOVERING()  (!!yyerrstatus)
+
+#define YYBACKUP(Token, Value)                                    \
+  do                                                              \
+    if (yychar == YYEMPTY)                                        \
+      {                                                           \
+        yychar = (Token);                                         \
+        yylval = (Value);                                         \
+        YYPOPSTACK (yylen);                                       \
+        yystate = *yyssp;                                         \
+        goto yybackup;                                            \
+      }                                                           \
+    else                                                          \
+      {                                                           \
+        yyerror (context, YY_("syntax error: cannot back up")); \
+        YYERROR;                                                  \
+      }                                                           \
+  while (0)
 
 /* Backward compatibility with an undocumented macro.
    Use YYerror or YYUNDEF. */
 #define YYERRCODE YYUNDEF
 
+
 /* Enable debugging if requested.  */
 #if YYDEBUG
 
-#ifndef YYFPRINTF
-#include <stdio.h> /* INFRINGES ON USER NAME SPACE */
-#define YYFPRINTF fprintf
-#endif
+# ifndef YYFPRINTF
+#  include <stdio.h> /* INFRINGES ON USER NAME SPACE */
+#  define YYFPRINTF fprintf
+# endif
 
-#define YYDPRINTF(Args)                                                        \
-    do                                                                         \
-    {                                                                          \
-        if (yydebug)                                                           \
-            YYFPRINTF Args;                                                    \
-    } while (0)
+# define YYDPRINTF(Args)                        \
+do {                                            \
+  if (yydebug)                                  \
+    YYFPRINTF Args;                             \
+} while (0)
 
-#define YY_SYMBOL_PRINT(Title, Kind, Value, Location)                          \
-    do                                                                         \
-    {                                                                          \
-        if (yydebug)                                                           \
-        {                                                                      \
-            YYFPRINTF(stderr, "%s ", Title);                                   \
-            yy_symbol_print(stderr, Kind, Value, context);                     \
-            YYFPRINTF(stderr, "\n");                                           \
-        }                                                                      \
-    } while (0)
+
+
+
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)                    \
+do {                                                                      \
+  if (yydebug)                                                            \
+    {                                                                     \
+      YYFPRINTF (stderr, "%s ", Title);                                   \
+      yy_symbol_print (stderr,                                            \
+                  Kind, Value, context); \
+      YYFPRINTF (stderr, "\n");                                           \
+    }                                                                     \
+} while (0)
+
 
 /*-----------------------------------.
 | Print this symbol's value on YYO.  |
 `-----------------------------------*/
 
-static void yy_symbol_value_print(FILE *yyo, yysymbol_kind_t yykind,
-                                  YYSTYPE const *const yyvaluep,
-                                  swq_parse_context *context)
+static void
+yy_symbol_value_print (FILE *yyo,
+                       yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, swq_parse_context *context)
 {
-    FILE *yyoutput = yyo;
-    YY_USE(yyoutput);
-    YY_USE(context);
-    if (!yyvaluep)
-        return;
-    YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-    YY_USE(yykind);
-    YY_IGNORE_MAYBE_UNINITIALIZED_END
+  FILE *yyoutput = yyo;
+  YY_USE (yyoutput);
+  YY_USE (context);
+  if (!yyvaluep)
+    return;
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  YY_USE (yykind);
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
+
 
 /*---------------------------.
 | Print this symbol on YYO.  |
 `---------------------------*/
 
-static void yy_symbol_print(FILE *yyo, yysymbol_kind_t yykind,
-                            YYSTYPE const *const yyvaluep,
-                            swq_parse_context *context)
+static void
+yy_symbol_print (FILE *yyo,
+                 yysymbol_kind_t yykind, YYSTYPE const * const yyvaluep, swq_parse_context *context)
 {
-    YYFPRINTF(yyo, "%s %s (", yykind < YYNTOKENS ? "token" : "nterm",
-              yysymbol_name(yykind));
+  YYFPRINTF (yyo, "%s %s (",
+             yykind < YYNTOKENS ? "token" : "nterm", yysymbol_name (yykind));
 
-    yy_symbol_value_print(yyo, yykind, yyvaluep, context);
-    YYFPRINTF(yyo, ")");
+  yy_symbol_value_print (yyo, yykind, yyvaluep, context);
+  YYFPRINTF (yyo, ")");
 }
 
 /*------------------------------------------------------------------.
@@ -938,66 +1026,69 @@ static void yy_symbol_print(FILE *yyo, yysymbol_kind_t yykind,
 | TOP (included).                                                   |
 `------------------------------------------------------------------*/
 
-static void yy_stack_print(yy_state_t *yybottom, yy_state_t *yytop)
+static void
+yy_stack_print (yy_state_t *yybottom, yy_state_t *yytop)
 {
-    YYFPRINTF(stderr, "Stack now");
-    for (; yybottom <= yytop; yybottom++)
+  YYFPRINTF (stderr, "Stack now");
+  for (; yybottom <= yytop; yybottom++)
     {
-        int yybot = *yybottom;
-        YYFPRINTF(stderr, " %d", yybot);
+      int yybot = *yybottom;
+      YYFPRINTF (stderr, " %d", yybot);
     }
-    YYFPRINTF(stderr, "\n");
+  YYFPRINTF (stderr, "\n");
 }
 
-#define YY_STACK_PRINT(Bottom, Top)                                            \
-    do                                                                         \
-    {                                                                          \
-        if (yydebug)                                                           \
-            yy_stack_print((Bottom), (Top));                                   \
-    } while (0)
+# define YY_STACK_PRINT(Bottom, Top)                            \
+do {                                                            \
+  if (yydebug)                                                  \
+    yy_stack_print ((Bottom), (Top));                           \
+} while (0)
+
 
 /*------------------------------------------------.
 | Report that the YYRULE is going to be reduced.  |
 `------------------------------------------------*/
 
-static void yy_reduce_print(yy_state_t *yyssp, YYSTYPE *yyvsp, int yyrule,
-                            swq_parse_context *context)
+static void
+yy_reduce_print (yy_state_t *yyssp, YYSTYPE *yyvsp,
+                 int yyrule, swq_parse_context *context)
 {
-    int yylno = yyrline[yyrule];
-    int yynrhs = yyr2[yyrule];
-    int yyi;
-    YYFPRINTF(stderr, "Reducing stack by rule %d (line %d):\n", yyrule - 1,
-              yylno);
-    /* The symbols being reduced.  */
-    for (yyi = 0; yyi < yynrhs; yyi++)
+  int yylno = yyrline[yyrule];
+  int yynrhs = yyr2[yyrule];
+  int yyi;
+  YYFPRINTF (stderr, "Reducing stack by rule %d (line %d):\n",
+             yyrule - 1, yylno);
+  /* The symbols being reduced.  */
+  for (yyi = 0; yyi < yynrhs; yyi++)
     {
-        YYFPRINTF(stderr, "   $%d = ", yyi + 1);
-        yy_symbol_print(stderr, YY_ACCESSING_SYMBOL(+yyssp[yyi + 1 - yynrhs]),
-                        &yyvsp[(yyi + 1) - (yynrhs)], context);
-        YYFPRINTF(stderr, "\n");
+      YYFPRINTF (stderr, "   $%d = ", yyi + 1);
+      yy_symbol_print (stderr,
+                       YY_ACCESSING_SYMBOL (+yyssp[yyi + 1 - yynrhs]),
+                       &yyvsp[(yyi + 1) - (yynrhs)], context);
+      YYFPRINTF (stderr, "\n");
     }
 }
 
-#define YY_REDUCE_PRINT(Rule)                                                  \
-    do                                                                         \
-    {                                                                          \
-        if (yydebug)                                                           \
-            yy_reduce_print(yyssp, yyvsp, Rule, context);                      \
-    } while (0)
+# define YY_REDUCE_PRINT(Rule)          \
+do {                                    \
+  if (yydebug)                          \
+    yy_reduce_print (yyssp, yyvsp, Rule, context); \
+} while (0)
 
 /* Nonzero means print parse trace.  It is left uninitialized so that
    multiple parsers can coexist.  */
 int yydebug;
 #else /* !YYDEBUG */
-#define YYDPRINTF(Args) ((void)0)
-#define YY_SYMBOL_PRINT(Title, Kind, Value, Location)
-#define YY_STACK_PRINT(Bottom, Top)
-#define YY_REDUCE_PRINT(Rule)
+# define YYDPRINTF(Args) ((void) 0)
+# define YY_SYMBOL_PRINT(Title, Kind, Value, Location)
+# define YY_STACK_PRINT(Bottom, Top)
+# define YY_REDUCE_PRINT(Rule)
 #endif /* !YYDEBUG */
+
 
 /* YYINITDEPTH -- initial size of the parser's stacks.  */
 #ifndef YYINITDEPTH
-#define YYINITDEPTH 200
+# define YYINITDEPTH 200
 #endif
 
 /* YYMAXDEPTH -- maximum size the stacks can grow to (effective only
@@ -1008,14 +1099,15 @@ int yydebug;
    evaluated with infinite-precision integer arithmetic.  */
 
 #ifndef YYMAXDEPTH
-#define YYMAXDEPTH 10000
+# define YYMAXDEPTH 10000
 #endif
+
 
 /* Context of a parse error.  */
 typedef struct
 {
-    yy_state_t *yyssp;
-    yysymbol_kind_t yytoken;
+  yy_state_t *yyssp;
+  yysymbol_kind_t yytoken;
 } yypcontext_t;
 
 /* Put in YYARG at most YYARGN of the expected tokens given the
@@ -1024,71 +1116,77 @@ typedef struct
    be less than YYNTOKENS).  Return YYENOMEM on memory exhaustion.
    Return 0 if there are more than YYARGN expected tokens, yet fill
    YYARG up to YYARGN. */
-static int yypcontext_expected_tokens(const yypcontext_t *yyctx,
-                                      yysymbol_kind_t yyarg[], int yyargn)
+static int
+yypcontext_expected_tokens (const yypcontext_t *yyctx,
+                            yysymbol_kind_t yyarg[], int yyargn)
 {
-    /* Actual size of YYARG. */
-    int yycount = 0;
-    int yyn = yypact[+*yyctx->yyssp];
-    if (!yypact_value_is_default(yyn))
+  /* Actual size of YYARG. */
+  int yycount = 0;
+  int yyn = yypact[+*yyctx->yyssp];
+  if (!yypact_value_is_default (yyn))
     {
-        /* Start YYX at -YYN if negative to avoid negative indexes in
+      /* Start YYX at -YYN if negative to avoid negative indexes in
          YYCHECK.  In other words, skip the first -YYN actions for
          this state because they are default actions.  */
-        int yyxbegin = yyn < 0 ? -yyn : 0;
-        /* Stay within bounds of both yycheck and yytname.  */
-        int yychecklim = YYLAST - yyn + 1;
-        int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
-        int yyx;
-        for (yyx = yyxbegin; yyx < yyxend; ++yyx)
-            if (yycheck[yyx + yyn] == yyx && yyx != YYSYMBOL_YYerror &&
-                !yytable_value_is_error(yytable[yyx + yyn]))
-            {
-                if (!yyarg)
-                    ++yycount;
-                else if (yycount == yyargn)
-                    return 0;
-                else
-                    yyarg[yycount++] = YY_CAST(yysymbol_kind_t, yyx);
-            }
+      int yyxbegin = yyn < 0 ? -yyn : 0;
+      /* Stay within bounds of both yycheck and yytname.  */
+      int yychecklim = YYLAST - yyn + 1;
+      int yyxend = yychecklim < YYNTOKENS ? yychecklim : YYNTOKENS;
+      int yyx;
+      for (yyx = yyxbegin; yyx < yyxend; ++yyx)
+        if (yycheck[yyx + yyn] == yyx && yyx != YYSYMBOL_YYerror
+            && !yytable_value_is_error (yytable[yyx + yyn]))
+          {
+            if (!yyarg)
+              ++yycount;
+            else if (yycount == yyargn)
+              return 0;
+            else
+              yyarg[yycount++] = YY_CAST (yysymbol_kind_t, yyx);
+          }
     }
-    if (yyarg && yycount == 0 && 0 < yyargn)
-        yyarg[0] = YYSYMBOL_YYEMPTY;
-    return yycount;
+  if (yyarg && yycount == 0 && 0 < yyargn)
+    yyarg[0] = YYSYMBOL_YYEMPTY;
+  return yycount;
 }
 
+
+
+
 #ifndef yystrlen
-#if defined __GLIBC__ && defined _STRING_H
-#define yystrlen(S) (YY_CAST(YYPTRDIFF_T, strlen(S)))
-#else
+# if defined __GLIBC__ && defined _STRING_H
+#  define yystrlen(S) (YY_CAST (YYPTRDIFF_T, strlen (S)))
+# else
 /* Return the length of YYSTR.  */
-static YYPTRDIFF_T yystrlen(const char *yystr)
+static YYPTRDIFF_T
+yystrlen (const char *yystr)
 {
-    YYPTRDIFF_T yylen;
-    for (yylen = 0; yystr[yylen]; yylen++)
-        continue;
-    return yylen;
+  YYPTRDIFF_T yylen;
+  for (yylen = 0; yystr[yylen]; yylen++)
+    continue;
+  return yylen;
 }
-#endif
+# endif
 #endif
 
 #ifndef yystpcpy
-#if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
-#define yystpcpy stpcpy
-#else
+# if defined __GLIBC__ && defined _STRING_H && defined _GNU_SOURCE
+#  define yystpcpy stpcpy
+# else
 /* Copy YYSRC to YYDEST, returning the address of the terminating '\0' in
    YYDEST.  */
-static char *yystpcpy(char *yydest, const char *yysrc)
+static char *
+yystpcpy (char *yydest, const char *yysrc)
 {
-    char *yyd = yydest;
-    const char *yys = yysrc;
+  char *yyd = yydest;
+  const char *yys = yysrc;
 
-    while ((*yyd++ = *yys++) != '\0')
-        continue;
+  while ((*yyd++ = *yys++) != '\0')
+    continue;
 
-    return yyd - 1;
+  return yyd - 1;
 }
-#endif
+# endif
 #endif
 
 #ifndef yytnamerr
@@ -1099,53 +1197,56 @@ static char *yystpcpy(char *yydest, const char *yysrc)
    backslash-backslash).  YYSTR is taken from yytname.  If YYRES is
    null, do not copy; instead, return the length of what the result
    would have been.  */
-static YYPTRDIFF_T yytnamerr(char *yyres, const char *yystr)
+static YYPTRDIFF_T
+yytnamerr (char *yyres, const char *yystr)
 {
-    if (*yystr == '"')
+  if (*yystr == '"')
     {
-        YYPTRDIFF_T yyn = 0;
-        char const *yyp = yystr;
-        for (;;)
-            switch (*++yyp)
-            {
-                case '\'':
-                case ',':
-                    goto do_not_strip_quotes;
+      YYPTRDIFF_T yyn = 0;
+      char const *yyp = yystr;
+      for (;;)
+        switch (*++yyp)
+          {
+          case '\'':
+          case ',':
+            goto do_not_strip_quotes;
 
-                case '\\':
-                    if (*++yyp != '\\')
-                        goto do_not_strip_quotes;
-                    else
-                        goto append;
+          case '\\':
+            if (*++yyp != '\\')
+              goto do_not_strip_quotes;
+            else
+              goto append;
 
-                append:
-                default:
-                    if (yyres)
-                        yyres[yyn] = *yyp;
-                    yyn++;
-                    break;
+          append:
+          default:
+            if (yyres)
+              yyres[yyn] = *yyp;
+            yyn++;
+            break;
 
-                case '"':
-                    if (yyres)
-                        yyres[yyn] = '\0';
-                    return yyn;
-            }
-    do_not_strip_quotes:;
+          case '"':
+            if (yyres)
+              yyres[yyn] = '\0';
+            return yyn;
+          }
+    do_not_strip_quotes: ;
     }
 
-    if (yyres)
-        return yystpcpy(yyres, yystr) - yyres;
-    else
-        return yystrlen(yystr);
+  if (yyres)
+    return yystpcpy (yyres, yystr) - yyres;
+  else
+    return yystrlen (yystr);
 }
 #endif
 
-static int yy_syntax_error_arguments(const yypcontext_t *yyctx,
-                                     yysymbol_kind_t yyarg[], int yyargn)
+
+static int
+yy_syntax_error_arguments (const yypcontext_t *yyctx,
+                           yysymbol_kind_t yyarg[], int yyargn)
 {
-    /* Actual size of YYARG. */
-    int yycount = 0;
-    /* There are many possibilities here to consider:
+  /* Actual size of YYARG. */
+  int yycount = 0;
+  /* There are many possibilities here to consider:
      - If this state is a consistent state with a default action, then
        the only way this function was invoked is if the default action
        is an error action.  In that case, don't check for expected
@@ -1168,20 +1269,20 @@ static int yy_syntax_error_arguments(const yypcontext_t *yyctx,
        one exception: it will still contain any token that will not be
        accepted due to an error action in a later state.
   */
-    if (yyctx->yytoken != YYSYMBOL_YYEMPTY)
+  if (yyctx->yytoken != YYSYMBOL_YYEMPTY)
     {
-        int yyn;
-        if (yyarg)
-            yyarg[yycount] = yyctx->yytoken;
-        ++yycount;
-        yyn = yypcontext_expected_tokens(yyctx, yyarg ? yyarg + 1 : yyarg,
-                                         yyargn - 1);
-        if (yyn == YYENOMEM)
-            return YYENOMEM;
-        else
-            yycount += yyn;
+      int yyn;
+      if (yyarg)
+        yyarg[yycount] = yyctx->yytoken;
+      ++yycount;
+      yyn = yypcontext_expected_tokens (yyctx,
+                                        yyarg ? yyarg + 1 : yyarg, yyargn - 1);
+      if (yyn == YYENOMEM)
+        return YYENOMEM;
+      else
+        yycount += yyn;
     }
-    return yycount;
+  return yycount;
 }
 
 /* Copy into *YYMSG, which is of size *YYMSG_ALLOC, an error message
@@ -1192,187 +1293,175 @@ static int yy_syntax_error_arguments(const yypcontext_t *yyctx,
    not large enough to hold the message.  In that case, also set
    *YYMSG_ALLOC to the required number of bytes.  Return YYENOMEM if the
    required number of bytes is too large to store.  */
-static int yysyntax_error(YYPTRDIFF_T *yymsg_alloc, char **yymsg,
-                          const yypcontext_t *yyctx)
+static int
+yysyntax_error (YYPTRDIFF_T *yymsg_alloc, char **yymsg,
+                const yypcontext_t *yyctx)
 {
-    enum
-    {
-        YYARGS_MAX = 5
-    };
-
-    /* Internationalized format string. */
-    const char *yyformat = YY_NULLPTR;
-    /* Arguments of yyformat: reported tokens (one for the "unexpected",
+  enum { YYARGS_MAX = 5 };
+  /* Internationalized format string. */
+  const char *yyformat = YY_NULLPTR;
+  /* Arguments of yyformat: reported tokens (one for the "unexpected",
      one per "expected"). */
-    yysymbol_kind_t yyarg[YYARGS_MAX];
-    /* Cumulated lengths of YYARG.  */
-    YYPTRDIFF_T yysize = 0;
+  yysymbol_kind_t yyarg[YYARGS_MAX];
+  /* Cumulated lengths of YYARG.  */
+  YYPTRDIFF_T yysize = 0;
 
-    /* Actual size of YYARG. */
-    int yycount = yy_syntax_error_arguments(yyctx, yyarg, YYARGS_MAX);
-    if (yycount == YYENOMEM)
-        return YYENOMEM;
+  /* Actual size of YYARG. */
+  int yycount = yy_syntax_error_arguments (yyctx, yyarg, YYARGS_MAX);
+  if (yycount == YYENOMEM)
+    return YYENOMEM;
 
-    switch (yycount)
+  switch (yycount)
     {
-#define YYCASE_(N, S)                                                          \
-    case N:                                                                    \
-        yyformat = S;                                                          \
+#define YYCASE_(N, S)                       \
+      case N:                               \
+        yyformat = S;                       \
         break
-        default: /* Avoid compiler warnings. */
-            YYCASE_(0, YY_("syntax error"));
-            YYCASE_(1, YY_("syntax error, unexpected %s"));
-            YYCASE_(2, YY_("syntax error, unexpected %s, expecting %s"));
-            YYCASE_(3, YY_("syntax error, unexpected %s, expecting %s or %s"));
-            YYCASE_(
-                4,
-                YY_("syntax error, unexpected %s, expecting %s or %s or %s"));
-            YYCASE_(5, YY_("syntax error, unexpected %s, expecting %s or %s or "
-                           "%s or %s"));
+    default: /* Avoid compiler warnings. */
+      YYCASE_(0, YY_("syntax error"));
+      YYCASE_(1, YY_("syntax error, unexpected %s"));
+      YYCASE_(2, YY_("syntax error, unexpected %s, expecting %s"));
+      YYCASE_(3, YY_("syntax error, unexpected %s, expecting %s or %s"));
+      YYCASE_(4, YY_("syntax error, unexpected %s, expecting %s or %s or %s"));
+      YYCASE_(5, YY_("syntax error, unexpected %s, expecting %s or %s or %s or %s"));
 #undef YYCASE_
     }
 
-    /* Compute error message size.  Don't count the "%s"s, but reserve
+  /* Compute error message size.  Don't count the "%s"s, but reserve
      room for the terminator.  */
-    yysize = yystrlen(yyformat) - 2 * yycount + 1;
+  yysize = yystrlen (yyformat) - 2 * yycount + 1;
+  {
+    int yyi;
+    for (yyi = 0; yyi < yycount; ++yyi)
+      {
+        YYPTRDIFF_T yysize1
+          = yysize + yytnamerr (YY_NULLPTR, yytname[yyarg[yyi]]);
+        if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
+          yysize = yysize1;
+        else
+          return YYENOMEM;
+      }
+  }
+
+  if (*yymsg_alloc < yysize)
     {
-        int yyi;
-        for (yyi = 0; yyi < yycount; ++yyi)
-        {
-            YYPTRDIFF_T yysize1 =
-                yysize + yytnamerr(YY_NULLPTR, yytname[yyarg[yyi]]);
-            if (yysize <= yysize1 && yysize1 <= YYSTACK_ALLOC_MAXIMUM)
-                yysize = yysize1;
-            else
-                return YYENOMEM;
-        }
+      *yymsg_alloc = 2 * yysize;
+      if (! (yysize <= *yymsg_alloc
+             && *yymsg_alloc <= YYSTACK_ALLOC_MAXIMUM))
+        *yymsg_alloc = YYSTACK_ALLOC_MAXIMUM;
+      return -1;
     }
 
-    if (*yymsg_alloc < yysize)
-    {
-        *yymsg_alloc = 2 * yysize;
-        if (!(yysize <= *yymsg_alloc && *yymsg_alloc <= YYSTACK_ALLOC_MAXIMUM))
-            *yymsg_alloc = YYSTACK_ALLOC_MAXIMUM;
-        return -1;
-    }
-
-    /* Avoid sprintf, as that infringes on the user's name space.
+  /* Avoid sprintf, as that infringes on the user's name space.
      Don't have undefined behavior even if the translation
      produced a string with the wrong number of "%s"s.  */
-    {
-        char *yyp = *yymsg;
-        int yyi = 0;
-        while ((*yyp = *yyformat) != '\0')
-            if (*yyp == '%' && yyformat[1] == 's' && yyi < yycount)
-            {
-                yyp += yytnamerr(yyp, yytname[yyarg[yyi++]]);
-                yyformat += 2;
-            }
-            else
-            {
-                ++yyp;
-                ++yyformat;
-            }
-    }
-    return 0;
+  {
+    char *yyp = *yymsg;
+    int yyi = 0;
+    while ((*yyp = *yyformat) != '\0')
+      if (*yyp == '%' && yyformat[1] == 's' && yyi < yycount)
+        {
+          yyp += yytnamerr (yyp, yytname[yyarg[yyi++]]);
+          yyformat += 2;
+        }
+      else
+        {
+          ++yyp;
+          ++yyformat;
+        }
+  }
+  return 0;
 }
+
 
 /*-----------------------------------------------.
 | Release the memory associated to this symbol.  |
 `-----------------------------------------------*/
 
-static void yydestruct(const char *yymsg, yysymbol_kind_t yykind,
-                       YYSTYPE *yyvaluep, swq_parse_context *context)
+static void
+yydestruct (const char *yymsg,
+            yysymbol_kind_t yykind, YYSTYPE *yyvaluep, swq_parse_context *context)
 {
-    YY_USE(yyvaluep);
-    YY_USE(context);
-    if (!yymsg)
-        yymsg = "Deleting";
-    YY_SYMBOL_PRINT(yymsg, yykind, yyvaluep, yylocationp);
+  YY_USE (yyvaluep);
+  YY_USE (context);
+  if (!yymsg)
+    yymsg = "Deleting";
+  YY_SYMBOL_PRINT (yymsg, yykind, yyvaluep, yylocationp);
 
-    YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-    switch (yykind)
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  switch (yykind)
     {
-        case YYSYMBOL_SWQT_INTEGER_NUMBER: /* "integer number"  */
-        {
-            delete (*yyvaluep);
-        }
+    case YYSYMBOL_SWQT_INTEGER_NUMBER: /* "integer number"  */
+            { delete (*yyvaluep); }
         break;
 
-        case YYSYMBOL_SWQT_FLOAT_NUMBER: /* "floating point number"  */
-        {
-            delete (*yyvaluep);
-        }
+    case YYSYMBOL_SWQT_FLOAT_NUMBER: /* "floating point number"  */
+            { delete (*yyvaluep); }
         break;
 
-        case YYSYMBOL_SWQT_STRING: /* "string"  */
-        {
-            delete (*yyvaluep);
-        }
+    case YYSYMBOL_SWQT_STRING: /* "string"  */
+            { delete (*yyvaluep); }
         break;
 
-        case YYSYMBOL_SWQT_IDENTIFIER: /* "identifier"  */
-        {
-            delete (*yyvaluep);
-        }
+    case YYSYMBOL_SWQT_IDENTIFIER: /* "identifier"  */
+            { delete (*yyvaluep); }
         break;
 
-        case YYSYMBOL_value_expr: /* value_expr  */
-        {
-            delete (*yyvaluep);
-        }
+    case YYSYMBOL_SWQT_HIDDEN: /* "HIDDEN"  */
+            { delete (*yyvaluep); }
         break;
 
-        case YYSYMBOL_value_expr_list: /* value_expr_list  */
-        {
-            delete (*yyvaluep);
-        }
+    case YYSYMBOL_value_expr: /* value_expr  */
+            { delete (*yyvaluep); }
         break;
 
-        case YYSYMBOL_field_value: /* field_value  */
-        {
-            delete (*yyvaluep);
-        }
+    case YYSYMBOL_value_expr_list: /* value_expr_list  */
+            { delete (*yyvaluep); }
         break;
 
-        case YYSYMBOL_value_expr_non_logical: /* value_expr_non_logical  */
-        {
-            delete (*yyvaluep);
-        }
+    case YYSYMBOL_field_value: /* field_value  */
+            { delete (*yyvaluep); }
         break;
 
-        case YYSYMBOL_type_def: /* type_def  */
-        {
-            delete (*yyvaluep);
-        }
+    case YYSYMBOL_value_expr_non_logical: /* value_expr_non_logical  */
+            { delete (*yyvaluep); }
         break;
 
-        case YYSYMBOL_table_def: /* table_def  */
-        {
-            delete (*yyvaluep);
-        }
+    case YYSYMBOL_type_def: /* type_def  */
+            { delete (*yyvaluep); }
         break;
 
-        default:
-            break;
+    case YYSYMBOL_table_def: /* table_def  */
+            { delete (*yyvaluep); }
+        break;
+
+      default:
+        break;
     }
-    YY_IGNORE_MAYBE_UNINITIALIZED_END
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 }
+
+
+
+
+
 
 /*----------.
 | yyparse.  |
 `----------*/
 
-int yyparse(swq_parse_context *context)
+int
+yyparse (swq_parse_context *context)
 {
-    /* Lookahead token kind.  */
-    int yychar;
+/* Lookahead token kind.  */
+int yychar;
 
-    /* The semantic value of the lookahead symbol.  */
-    /* Default value used for initialization, for pacifying older GCCs
+
+/* The semantic value of the lookahead symbol.  */
+/* Default value used for initialization, for pacifying older GCCs
    or non-GCC compilers.  */
-    YY_INITIAL_VALUE(static YYSTYPE yyval_default;)
-    YYSTYPE yylval YY_INITIAL_VALUE(= yyval_default);
+YY_INITIAL_VALUE (static YYSTYPE yyval_default;)
+YYSTYPE yylval YY_INITIAL_VALUE (= yyval_default);
 
     /* Number of syntax errors so far.  */
     int yynerrs = 0;
@@ -1397,207 +1486,215 @@ int yyparse(swq_parse_context *context)
     YYSTYPE *yyvs = yyvsa;
     YYSTYPE *yyvsp = yyvs;
 
-    int yyn;
-    /* The return value of yyparse.  */
-    int yyresult;
-    /* Lookahead symbol kind.  */
-    yysymbol_kind_t yytoken = YYSYMBOL_YYEMPTY;
-    /* The variables used to return semantic value and location from the
+  int yyn;
+  /* The return value of yyparse.  */
+  int yyresult;
+  /* Lookahead symbol kind.  */
+  yysymbol_kind_t yytoken = YYSYMBOL_YYEMPTY;
+  /* The variables used to return semantic value and location from the
      action routines.  */
-    YYSTYPE yyval;
+  YYSTYPE yyval;
 
-    /* Buffer for error messages, and its allocated size.  */
-    char yymsgbuf[128];
-    char *yymsg = yymsgbuf;
-    YYPTRDIFF_T yymsg_alloc = sizeof yymsgbuf;
+  /* Buffer for error messages, and its allocated size.  */
+  char yymsgbuf[128];
+  char *yymsg = yymsgbuf;
+  YYPTRDIFF_T yymsg_alloc = sizeof yymsgbuf;
 
-#define YYPOPSTACK(N) (yyvsp -= (N), yyssp -= (N))
+#define YYPOPSTACK(N)   (yyvsp -= (N), yyssp -= (N))
 
-    /* The number of symbols on the RHS of the reduced rule.
+  /* The number of symbols on the RHS of the reduced rule.
      Keep to zero when no symbol should be popped.  */
-    int yylen = 0;
+  int yylen = 0;
 
-    YYDPRINTF((stderr, "Starting parse\n"));
+  YYDPRINTF ((stderr, "Starting parse\n"));
 
-    yychar = YYEMPTY; /* Cause a token to be read.  */
+  yychar = YYEMPTY; /* Cause a token to be read.  */
 
-    goto yysetstate;
+  goto yysetstate;
+
 
 /*------------------------------------------------------------.
 | yynewstate -- push a new state, which is found in yystate.  |
 `------------------------------------------------------------*/
 yynewstate:
-    /* In all cases, when you get here, the value and location stacks
+  /* In all cases, when you get here, the value and location stacks
      have just been pushed.  So pushing a state here evens the stacks.  */
-    yyssp++;
+  yyssp++;
+
 
 /*--------------------------------------------------------------------.
 | yysetstate -- set current state (the top of the stack) to yystate.  |
 `--------------------------------------------------------------------*/
 yysetstate:
-    YYDPRINTF((stderr, "Entering state %d\n", yystate));
-    YY_IGNORE_USELESS_CAST_BEGIN
-    *yyssp = YY_CAST(yy_state_t, yystate);
-    YY_IGNORE_USELESS_CAST_END
-    YY_STACK_PRINT(yyss, yyssp);
+  YYDPRINTF ((stderr, "Entering state %d\n", yystate));
+  YY_ASSERT (0 <= yystate && yystate < YYNSTATES);
+  YY_IGNORE_USELESS_CAST_BEGIN
+  *yyssp = YY_CAST (yy_state_t, yystate);
+  YY_IGNORE_USELESS_CAST_END
+  YY_STACK_PRINT (yyss, yyssp);
 
-    if (yyss + yystacksize - 1 <= yyssp)
+  if (yyss + yystacksize - 1 <= yyssp)
 #if !defined yyoverflow && !defined YYSTACK_RELOCATE
-        YYNOMEM;
+    YYNOMEM;
 #else
     {
-        /* Get the current used size of the three stacks, in elements.  */
-        YYPTRDIFF_T yysize = yyssp - yyss + 1;
+      /* Get the current used size of the three stacks, in elements.  */
+      YYPTRDIFF_T yysize = yyssp - yyss + 1;
 
-#if defined yyoverflow
-        {
-            /* Give user a chance to reallocate the stack.  Use copies of
+# if defined yyoverflow
+      {
+        /* Give user a chance to reallocate the stack.  Use copies of
            these so that the &'s don't force the real ones into
            memory.  */
-            yy_state_t *yyss1 = yyss;
-            YYSTYPE *yyvs1 = yyvs;
+        yy_state_t *yyss1 = yyss;
+        YYSTYPE *yyvs1 = yyvs;
 
-            /* Each stack pointer address is followed by the size of the
+        /* Each stack pointer address is followed by the size of the
            data in use in that stack, in bytes.  This used to be a
            conditional around just the two extra args, but that might
            be undefined if yyoverflow is a macro.  */
-            yyoverflow(YY_("memory exhausted"), &yyss1,
-                       yysize * YYSIZEOF(*yyssp), &yyvs1,
-                       yysize * YYSIZEOF(*yyvsp), &yystacksize);
-            yyss = yyss1;
-            yyvs = yyvs1;
-        }
-#else /* defined YYSTACK_RELOCATE */
-        /* Extend the stack our own way.  */
-        if (YYMAXDEPTH <= yystacksize)
-            YYNOMEM;
-        yystacksize *= 2;
-        if (YYMAXDEPTH < yystacksize)
-            yystacksize = YYMAXDEPTH;
+        yyoverflow (YY_("memory exhausted"),
+                    &yyss1, yysize * YYSIZEOF (*yyssp),
+                    &yyvs1, yysize * YYSIZEOF (*yyvsp),
+                    &yystacksize);
+        yyss = yyss1;
+        yyvs = yyvs1;
+      }
+# else /* defined YYSTACK_RELOCATE */
+      /* Extend the stack our own way.  */
+      if (YYMAXDEPTH <= yystacksize)
+        YYNOMEM;
+      yystacksize *= 2;
+      if (YYMAXDEPTH < yystacksize)
+        yystacksize = YYMAXDEPTH;
 
-        {
-            yy_state_t *yyss1 = yyss;
-            union yyalloc *yyptr = YY_CAST(
-                union yyalloc *,
-                YYSTACK_ALLOC(YY_CAST(YYSIZE_T, YYSTACK_BYTES(yystacksize))));
-            if (!yyptr)
-                YYNOMEM;
-            YYSTACK_RELOCATE(yyss_alloc, yyss);
-            YYSTACK_RELOCATE(yyvs_alloc, yyvs);
-#undef YYSTACK_RELOCATE
-            if (yyss1 != yyssa)
-                YYSTACK_FREE(yyss1);
-        }
-#endif
+      {
+        yy_state_t *yyss1 = yyss;
+        union yyalloc *yyptr =
+          YY_CAST (union yyalloc *,
+                   YYSTACK_ALLOC (YY_CAST (YYSIZE_T, YYSTACK_BYTES (yystacksize))));
+        if (! yyptr)
+          YYNOMEM;
+        YYSTACK_RELOCATE (yyss_alloc, yyss);
+        YYSTACK_RELOCATE (yyvs_alloc, yyvs);
+#  undef YYSTACK_RELOCATE
+        if (yyss1 != yyssa)
+          YYSTACK_FREE (yyss1);
+      }
+# endif
 
-        yyssp = yyss + yysize - 1;
-        yyvsp = yyvs + yysize - 1;
+      yyssp = yyss + yysize - 1;
+      yyvsp = yyvs + yysize - 1;
 
-        YY_IGNORE_USELESS_CAST_BEGIN
-        YYDPRINTF((stderr, "Stack size increased to %ld\n",
-                   YY_CAST(long, yystacksize)));
-        YY_IGNORE_USELESS_CAST_END
+      YY_IGNORE_USELESS_CAST_BEGIN
+      YYDPRINTF ((stderr, "Stack size increased to %ld\n",
+                  YY_CAST (long, yystacksize)));
+      YY_IGNORE_USELESS_CAST_END
 
-        if (yyss + yystacksize - 1 <= yyssp)
-            YYABORT;
+      if (yyss + yystacksize - 1 <= yyssp)
+        YYABORT;
     }
 #endif /* !defined yyoverflow && !defined YYSTACK_RELOCATE */
 
-    if (yystate == YYFINAL)
-        YYACCEPT;
 
-    goto yybackup;
+  if (yystate == YYFINAL)
+    YYACCEPT;
+
+  goto yybackup;
+
 
 /*-----------.
 | yybackup.  |
 `-----------*/
 yybackup:
-    /* Do appropriate processing given the current state.  Read a
+  /* Do appropriate processing given the current state.  Read a
      lookahead token if we need one and don't already have one.  */
 
-    /* First try to decide what to do without reference to lookahead token.  */
-    yyn = yypact[yystate];
-    if (yypact_value_is_default(yyn))
-        goto yydefault;
+  /* First try to decide what to do without reference to lookahead token.  */
+  yyn = yypact[yystate];
+  if (yypact_value_is_default (yyn))
+    goto yydefault;
 
-    /* Not known => get a lookahead token if don't already have one.  */
+  /* Not known => get a lookahead token if don't already have one.  */
 
-    /* YYCHAR is either empty, or end-of-input, or a valid lookahead.  */
-    if (yychar == YYEMPTY)
+  /* YYCHAR is either empty, or end-of-input, or a valid lookahead.  */
+  if (yychar == YYEMPTY)
     {
-        YYDPRINTF((stderr, "Reading a token\n"));
-        yychar = yylex(&yylval, context);
+      YYDPRINTF ((stderr, "Reading a token\n"));
+      yychar = yylex (&yylval, context);
     }
 
-    if (yychar <= END)
+  if (yychar <= END)
     {
-        yychar = END;
-        yytoken = YYSYMBOL_YYEOF;
-        YYDPRINTF((stderr, "Now at end of input.\n"));
+      yychar = END;
+      yytoken = YYSYMBOL_YYEOF;
+      YYDPRINTF ((stderr, "Now at end of input.\n"));
     }
-    else if (yychar == YYerror)
+  else if (yychar == YYerror)
     {
-        /* The scanner already issued an error message, process directly
+      /* The scanner already issued an error message, process directly
          to error recovery.  But do not keep the error token as
          lookahead, it is too special and may lead us to an endless
          loop in error recovery. */
-        yychar = YYUNDEF;
-        yytoken = YYSYMBOL_YYerror;
-        goto yyerrlab1;
+      yychar = YYUNDEF;
+      yytoken = YYSYMBOL_YYerror;
+      goto yyerrlab1;
     }
-    else
+  else
     {
-        yytoken = YYTRANSLATE(yychar);
-        YY_SYMBOL_PRINT("Next token is", yytoken, &yylval, &yylloc);
+      yytoken = YYTRANSLATE (yychar);
+      YY_SYMBOL_PRINT ("Next token is", yytoken, &yylval, &yylloc);
     }
 
-    /* If the proper action on seeing token YYTOKEN is to reduce or to
+  /* If the proper action on seeing token YYTOKEN is to reduce or to
      detect an error, take that action.  */
-    yyn += yytoken;
-    if (yyn < 0 || YYLAST < yyn || yycheck[yyn] != yytoken)
-        goto yydefault;
-    yyn = yytable[yyn];
-    if (yyn <= 0)
+  yyn += yytoken;
+  if (yyn < 0 || YYLAST < yyn || yycheck[yyn] != yytoken)
+    goto yydefault;
+  yyn = yytable[yyn];
+  if (yyn <= 0)
     {
-        if (yytable_value_is_error(yyn))
-            goto yyerrlab;
-        yyn = -yyn;
-        goto yyreduce;
+      if (yytable_value_is_error (yyn))
+        goto yyerrlab;
+      yyn = -yyn;
+      goto yyreduce;
     }
 
-    /* Count tokens shifted since error; after three, turn off error
+  /* Count tokens shifted since error; after three, turn off error
      status.  */
-    if (yyerrstatus)
-        yyerrstatus--;
+  if (yyerrstatus)
+    yyerrstatus--;
 
-    /* Shift the lookahead token.  */
-    YY_SYMBOL_PRINT("Shifting", yytoken, &yylval, &yylloc);
-    yystate = yyn;
-    YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-    *++yyvsp = yylval;
-    YY_IGNORE_MAYBE_UNINITIALIZED_END
+  /* Shift the lookahead token.  */
+  YY_SYMBOL_PRINT ("Shifting", yytoken, &yylval, &yylloc);
+  yystate = yyn;
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  *++yyvsp = yylval;
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 
-    /* Discard the shifted token.  */
-    yychar = YYEMPTY;
-    goto yynewstate;
+  /* Discard the shifted token.  */
+  yychar = YYEMPTY;
+  goto yynewstate;
+
 
 /*-----------------------------------------------------------.
 | yydefault -- do the default action for the current state.  |
 `-----------------------------------------------------------*/
 yydefault:
-    yyn = yydefact[yystate];
-    if (yyn == 0)
-        goto yyerrlab;
-    goto yyreduce;
+  yyn = yydefact[yystate];
+  if (yyn == 0)
+    goto yyerrlab;
+  goto yyreduce;
+
 
 /*-----------------------------.
 | yyreduce -- do a reduction.  |
 `-----------------------------*/
 yyreduce:
-    /* yyn is the number of a rule to reduce with.  */
-    yylen = yyr2[yyn];
+  /* yyn is the number of a rule to reduce with.  */
+  yylen = yyr2[yyn];
 
-    /* If YYLEN is nonzero, implement the default value of the action:
+  /* If YYLEN is nonzero, implement the default value of the action:
      '$$ = $1'.
 
      Otherwise, the following line sets YYVAL to garbage.
@@ -1605,316 +1702,317 @@ yyreduce:
      users should not rely upon it.  Assigning to YYVAL
      unconditionally makes the parser a bit smaller, and it avoids a
      GCC warning that YYVAL may be used uninitialized.  */
-    yyval = yyvsp[1 - yylen];
+  yyval = yyvsp[1-yylen];
 
-    YY_REDUCE_PRINT(yyn);
-    switch (yyn)
+
+  YY_REDUCE_PRINT (yyn);
+  switch (yyn)
     {
-        case 3: /* input: SWQT_VALUE_START value_expr  */
+  case 3: /* input: SWQT_VALUE_START value_expr  */
         {
             context->poRoot = yyvsp[0];
             swq_fixup(context);
         }
-        break;
+    break;
 
-        case 4: /* input: SWQT_SELECT_START select_statement  */
+  case 4: /* input: SWQT_SELECT_START select_statement  */
         {
             context->poRoot = yyvsp[0];
             // swq_fixup() must be done by caller
         }
-        break;
+    break;
 
-        case 5: /* value_expr: value_expr_non_logical  */
+  case 5: /* value_expr: value_expr_non_logical  */
         {
             yyval = yyvsp[0];
         }
-        break;
+    break;
 
-        case 6: /* value_expr: value_expr "AND" value_expr  */
+  case 6: /* value_expr: value_expr "AND" value_expr  */
         {
-            yyval = swq_create_and_or_or(SWQ_AND, yyvsp[-2], yyvsp[0]);
+            yyval = swq_create_and_or_or( SWQ_AND, yyvsp[-2], yyvsp[0] );
         }
-        break;
+    break;
 
-        case 7: /* value_expr: value_expr "OR" value_expr  */
+  case 7: /* value_expr: value_expr "OR" value_expr  */
         {
-            yyval = swq_create_and_or_or(SWQ_OR, yyvsp[-2], yyvsp[0]);
+            yyval = swq_create_and_or_or( SWQ_OR, yyvsp[-2], yyvsp[0] );
         }
-        break;
+    break;
 
-        case 8: /* value_expr: "NOT" value_expr  */
+  case 8: /* value_expr: "NOT" value_expr  */
         {
-            yyval = new swq_expr_node(SWQ_NOT);
+            yyval = new swq_expr_node( SWQ_NOT );
             yyval->field_type = SWQ_BOOLEAN;
-            yyval->PushSubExpression(yyvsp[0]);
+            yyval->PushSubExpression( yyvsp[0] );
         }
-        break;
+    break;
 
-        case 9: /* value_expr: value_expr '=' value_expr  */
+  case 9: /* value_expr: value_expr '=' value_expr  */
         {
-            yyval = new swq_expr_node(SWQ_EQ);
+            yyval = new swq_expr_node( SWQ_EQ );
             yyval->field_type = SWQ_BOOLEAN;
-            yyval->PushSubExpression(yyvsp[-2]);
-            yyval->PushSubExpression(yyvsp[0]);
+            yyval->PushSubExpression( yyvsp[-2] );
+            yyval->PushSubExpression( yyvsp[0] );
         }
-        break;
+    break;
 
-        case 10: /* value_expr: value_expr '<' '>' value_expr  */
+  case 10: /* value_expr: value_expr '<' '>' value_expr  */
         {
-            yyval = new swq_expr_node(SWQ_NE);
+            yyval = new swq_expr_node( SWQ_NE );
             yyval->field_type = SWQ_BOOLEAN;
-            yyval->PushSubExpression(yyvsp[-3]);
-            yyval->PushSubExpression(yyvsp[0]);
+            yyval->PushSubExpression( yyvsp[-3] );
+            yyval->PushSubExpression( yyvsp[0] );
         }
-        break;
+    break;
 
-        case 11: /* value_expr: value_expr '!' '=' value_expr  */
+  case 11: /* value_expr: value_expr '!' '=' value_expr  */
         {
-            yyval = new swq_expr_node(SWQ_NE);
+            yyval = new swq_expr_node( SWQ_NE );
             yyval->field_type = SWQ_BOOLEAN;
-            yyval->PushSubExpression(yyvsp[-3]);
-            yyval->PushSubExpression(yyvsp[0]);
+            yyval->PushSubExpression( yyvsp[-3] );
+            yyval->PushSubExpression( yyvsp[0] );
         }
-        break;
+    break;
 
-        case 12: /* value_expr: value_expr '<' value_expr  */
+  case 12: /* value_expr: value_expr '<' value_expr  */
         {
-            yyval = new swq_expr_node(SWQ_LT);
+            yyval = new swq_expr_node( SWQ_LT );
             yyval->field_type = SWQ_BOOLEAN;
-            yyval->PushSubExpression(yyvsp[-2]);
-            yyval->PushSubExpression(yyvsp[0]);
+            yyval->PushSubExpression( yyvsp[-2] );
+            yyval->PushSubExpression( yyvsp[0] );
         }
-        break;
+    break;
 
-        case 13: /* value_expr: value_expr '>' value_expr  */
+  case 13: /* value_expr: value_expr '>' value_expr  */
         {
-            yyval = new swq_expr_node(SWQ_GT);
+            yyval = new swq_expr_node( SWQ_GT );
             yyval->field_type = SWQ_BOOLEAN;
-            yyval->PushSubExpression(yyvsp[-2]);
-            yyval->PushSubExpression(yyvsp[0]);
+            yyval->PushSubExpression( yyvsp[-2] );
+            yyval->PushSubExpression( yyvsp[0] );
         }
-        break;
+    break;
 
-        case 14: /* value_expr: value_expr '<' '=' value_expr  */
+  case 14: /* value_expr: value_expr '<' '=' value_expr  */
         {
-            yyval = new swq_expr_node(SWQ_LE);
+            yyval = new swq_expr_node( SWQ_LE );
             yyval->field_type = SWQ_BOOLEAN;
-            yyval->PushSubExpression(yyvsp[-3]);
-            yyval->PushSubExpression(yyvsp[0]);
+            yyval->PushSubExpression( yyvsp[-3] );
+            yyval->PushSubExpression( yyvsp[0] );
         }
-        break;
+    break;
 
-        case 15: /* value_expr: value_expr '=' '<' value_expr  */
+  case 15: /* value_expr: value_expr '=' '<' value_expr  */
         {
-            yyval = new swq_expr_node(SWQ_LE);
+            yyval = new swq_expr_node( SWQ_LE );
             yyval->field_type = SWQ_BOOLEAN;
-            yyval->PushSubExpression(yyvsp[-3]);
-            yyval->PushSubExpression(yyvsp[0]);
+            yyval->PushSubExpression( yyvsp[-3] );
+            yyval->PushSubExpression( yyvsp[0] );
         }
-        break;
+    break;
 
-        case 16: /* value_expr: value_expr '=' '>' value_expr  */
+  case 16: /* value_expr: value_expr '=' '>' value_expr  */
         {
-            yyval = new swq_expr_node(SWQ_LE);
+            yyval = new swq_expr_node( SWQ_LE );
             yyval->field_type = SWQ_BOOLEAN;
-            yyval->PushSubExpression(yyvsp[-3]);
-            yyval->PushSubExpression(yyvsp[0]);
+            yyval->PushSubExpression( yyvsp[-3] );
+            yyval->PushSubExpression( yyvsp[0] );
         }
-        break;
+    break;
 
-        case 17: /* value_expr: value_expr '>' '=' value_expr  */
+  case 17: /* value_expr: value_expr '>' '=' value_expr  */
         {
-            yyval = new swq_expr_node(SWQ_GE);
+            yyval = new swq_expr_node( SWQ_GE );
             yyval->field_type = SWQ_BOOLEAN;
-            yyval->PushSubExpression(yyvsp[-3]);
-            yyval->PushSubExpression(yyvsp[0]);
+            yyval->PushSubExpression( yyvsp[-3] );
+            yyval->PushSubExpression( yyvsp[0] );
         }
-        break;
+    break;
 
-        case 18: /* value_expr: value_expr "LIKE" value_expr  */
+  case 18: /* value_expr: value_expr "LIKE" value_expr  */
         {
-            yyval = new swq_expr_node(SWQ_LIKE);
+            yyval = new swq_expr_node( SWQ_LIKE );
             yyval->field_type = SWQ_BOOLEAN;
-            yyval->PushSubExpression(yyvsp[-2]);
-            yyval->PushSubExpression(yyvsp[0]);
+            yyval->PushSubExpression( yyvsp[-2] );
+            yyval->PushSubExpression( yyvsp[0] );
         }
-        break;
+    break;
 
-        case 19: /* value_expr: value_expr "NOT" "LIKE" value_expr  */
+  case 19: /* value_expr: value_expr "NOT" "LIKE" value_expr  */
         {
-            swq_expr_node *like = new swq_expr_node(SWQ_LIKE);
+            swq_expr_node *like = new swq_expr_node( SWQ_LIKE );
             like->field_type = SWQ_BOOLEAN;
-            like->PushSubExpression(yyvsp[-3]);
-            like->PushSubExpression(yyvsp[0]);
+            like->PushSubExpression( yyvsp[-3] );
+            like->PushSubExpression( yyvsp[0] );
 
-            yyval = new swq_expr_node(SWQ_NOT);
+            yyval = new swq_expr_node( SWQ_NOT );
             yyval->field_type = SWQ_BOOLEAN;
-            yyval->PushSubExpression(like);
+            yyval->PushSubExpression( like );
         }
-        break;
+    break;
 
-        case 20: /* value_expr: value_expr "LIKE" value_expr "ESCAPE" value_expr  */
+  case 20: /* value_expr: value_expr "LIKE" value_expr "ESCAPE" value_expr  */
         {
-            yyval = new swq_expr_node(SWQ_LIKE);
+            yyval = new swq_expr_node( SWQ_LIKE );
             yyval->field_type = SWQ_BOOLEAN;
-            yyval->PushSubExpression(yyvsp[-4]);
-            yyval->PushSubExpression(yyvsp[-2]);
-            yyval->PushSubExpression(yyvsp[0]);
+            yyval->PushSubExpression( yyvsp[-4] );
+            yyval->PushSubExpression( yyvsp[-2] );
+            yyval->PushSubExpression( yyvsp[0] );
         }
-        break;
+    break;
 
-        case 21: /* value_expr: value_expr "NOT" "LIKE" value_expr "ESCAPE" value_expr  */
+  case 21: /* value_expr: value_expr "NOT" "LIKE" value_expr "ESCAPE" value_expr  */
         {
-            swq_expr_node *like = new swq_expr_node(SWQ_LIKE);
+            swq_expr_node *like = new swq_expr_node( SWQ_LIKE );
             like->field_type = SWQ_BOOLEAN;
-            like->PushSubExpression(yyvsp[-5]);
-            like->PushSubExpression(yyvsp[-2]);
-            like->PushSubExpression(yyvsp[0]);
+            like->PushSubExpression( yyvsp[-5] );
+            like->PushSubExpression( yyvsp[-2] );
+            like->PushSubExpression( yyvsp[0] );
 
-            yyval = new swq_expr_node(SWQ_NOT);
+            yyval = new swq_expr_node( SWQ_NOT );
             yyval->field_type = SWQ_BOOLEAN;
-            yyval->PushSubExpression(like);
+            yyval->PushSubExpression( like );
         }
-        break;
+    break;
 
-        case 22: /* value_expr: value_expr "ILIKE" value_expr  */
+  case 22: /* value_expr: value_expr "ILIKE" value_expr  */
         {
-            yyval = new swq_expr_node(SWQ_ILIKE);
+            yyval = new swq_expr_node( SWQ_ILIKE );
             yyval->field_type = SWQ_BOOLEAN;
-            yyval->PushSubExpression(yyvsp[-2]);
-            yyval->PushSubExpression(yyvsp[0]);
+            yyval->PushSubExpression( yyvsp[-2] );
+            yyval->PushSubExpression( yyvsp[0] );
         }
-        break;
+    break;
 
-        case 23: /* value_expr: value_expr "NOT" "ILIKE" value_expr  */
+  case 23: /* value_expr: value_expr "NOT" "ILIKE" value_expr  */
         {
-            swq_expr_node *like = new swq_expr_node(SWQ_ILIKE);
+            swq_expr_node *like = new swq_expr_node( SWQ_ILIKE );
             like->field_type = SWQ_BOOLEAN;
-            like->PushSubExpression(yyvsp[-3]);
-            like->PushSubExpression(yyvsp[0]);
+            like->PushSubExpression( yyvsp[-3] );
+            like->PushSubExpression( yyvsp[0] );
 
-            yyval = new swq_expr_node(SWQ_NOT);
+            yyval = new swq_expr_node( SWQ_NOT );
             yyval->field_type = SWQ_BOOLEAN;
-            yyval->PushSubExpression(like);
+            yyval->PushSubExpression( like );
         }
-        break;
+    break;
 
-        case 24: /* value_expr: value_expr "ILIKE" value_expr "ESCAPE" value_expr  */
+  case 24: /* value_expr: value_expr "ILIKE" value_expr "ESCAPE" value_expr  */
         {
-            yyval = new swq_expr_node(SWQ_ILIKE);
+            yyval = new swq_expr_node( SWQ_ILIKE );
             yyval->field_type = SWQ_BOOLEAN;
-            yyval->PushSubExpression(yyvsp[-4]);
-            yyval->PushSubExpression(yyvsp[-2]);
-            yyval->PushSubExpression(yyvsp[0]);
+            yyval->PushSubExpression( yyvsp[-4] );
+            yyval->PushSubExpression( yyvsp[-2] );
+            yyval->PushSubExpression( yyvsp[0] );
         }
-        break;
+    break;
 
-        case 25: /* value_expr: value_expr "NOT" "ILIKE" value_expr "ESCAPE" value_expr  */
+  case 25: /* value_expr: value_expr "NOT" "ILIKE" value_expr "ESCAPE" value_expr  */
         {
-            swq_expr_node *like = new swq_expr_node(SWQ_ILIKE);
+            swq_expr_node *like = new swq_expr_node( SWQ_ILIKE );
             like->field_type = SWQ_BOOLEAN;
-            like->PushSubExpression(yyvsp[-5]);
-            like->PushSubExpression(yyvsp[-2]);
-            like->PushSubExpression(yyvsp[0]);
+            like->PushSubExpression( yyvsp[-5] );
+            like->PushSubExpression( yyvsp[-2] );
+            like->PushSubExpression( yyvsp[0] );
 
-            yyval = new swq_expr_node(SWQ_NOT);
+            yyval = new swq_expr_node( SWQ_NOT );
             yyval->field_type = SWQ_BOOLEAN;
-            yyval->PushSubExpression(like);
+            yyval->PushSubExpression( like );
         }
-        break;
+    break;
 
-        case 26: /* value_expr: value_expr "IN" '(' value_expr_list ')'  */
+  case 26: /* value_expr: value_expr "IN" '(' value_expr_list ')'  */
         {
             yyval = yyvsp[-1];
             yyval->field_type = SWQ_BOOLEAN;
             yyval->nOperation = SWQ_IN;
-            yyval->PushSubExpression(yyvsp[-4]);
+            yyval->PushSubExpression( yyvsp[-4] );
             yyval->ReverseSubExpressions();
         }
-        break;
+    break;
 
-        case 27: /* value_expr: value_expr "NOT" "IN" '(' value_expr_list ')'  */
+  case 27: /* value_expr: value_expr "NOT" "IN" '(' value_expr_list ')'  */
         {
             swq_expr_node *in = yyvsp[-1];
             in->field_type = SWQ_BOOLEAN;
             in->nOperation = SWQ_IN;
-            in->PushSubExpression(yyvsp[-5]);
+            in->PushSubExpression( yyvsp[-5] );
             in->ReverseSubExpressions();
 
-            yyval = new swq_expr_node(SWQ_NOT);
+            yyval = new swq_expr_node( SWQ_NOT );
             yyval->field_type = SWQ_BOOLEAN;
-            yyval->PushSubExpression(in);
+            yyval->PushSubExpression( in );
         }
-        break;
+    break;
 
-        case 28: /* value_expr: value_expr "BETWEEN" value_expr_non_logical "AND" value_expr_non_logical  */
+  case 28: /* value_expr: value_expr "BETWEEN" value_expr_non_logical "AND" value_expr_non_logical  */
         {
-            yyval = new swq_expr_node(SWQ_BETWEEN);
+            yyval = new swq_expr_node( SWQ_BETWEEN );
             yyval->field_type = SWQ_BOOLEAN;
-            yyval->PushSubExpression(yyvsp[-4]);
-            yyval->PushSubExpression(yyvsp[-2]);
-            yyval->PushSubExpression(yyvsp[0]);
+            yyval->PushSubExpression( yyvsp[-4] );
+            yyval->PushSubExpression( yyvsp[-2] );
+            yyval->PushSubExpression( yyvsp[0] );
         }
-        break;
+    break;
 
-        case 29: /* value_expr: value_expr "NOT" "BETWEEN" value_expr_non_logical "AND" value_expr_non_logical  */
+  case 29: /* value_expr: value_expr "NOT" "BETWEEN" value_expr_non_logical "AND" value_expr_non_logical  */
         {
-            swq_expr_node *between = new swq_expr_node(SWQ_BETWEEN);
+            swq_expr_node *between = new swq_expr_node( SWQ_BETWEEN );
             between->field_type = SWQ_BOOLEAN;
-            between->PushSubExpression(yyvsp[-5]);
-            between->PushSubExpression(yyvsp[-2]);
-            between->PushSubExpression(yyvsp[0]);
+            between->PushSubExpression( yyvsp[-5] );
+            between->PushSubExpression( yyvsp[-2] );
+            between->PushSubExpression( yyvsp[0] );
 
-            yyval = new swq_expr_node(SWQ_NOT);
+            yyval = new swq_expr_node( SWQ_NOT );
             yyval->field_type = SWQ_BOOLEAN;
-            yyval->PushSubExpression(between);
+            yyval->PushSubExpression( between );
         }
-        break;
+    break;
 
-        case 30: /* value_expr: value_expr "IS" "NULL"  */
+  case 30: /* value_expr: value_expr "IS" "NULL"  */
         {
-            yyval = new swq_expr_node(SWQ_ISNULL);
+            yyval = new swq_expr_node( SWQ_ISNULL );
             yyval->field_type = SWQ_BOOLEAN;
-            yyval->PushSubExpression(yyvsp[-2]);
+            yyval->PushSubExpression( yyvsp[-2] );
         }
-        break;
+    break;
 
-        case 31: /* value_expr: value_expr "IS" "NOT" "NULL"  */
+  case 31: /* value_expr: value_expr "IS" "NOT" "NULL"  */
         {
-            swq_expr_node *isnull = new swq_expr_node(SWQ_ISNULL);
+            swq_expr_node *isnull = new swq_expr_node( SWQ_ISNULL );
             isnull->field_type = SWQ_BOOLEAN;
-            isnull->PushSubExpression(yyvsp[-3]);
+            isnull->PushSubExpression( yyvsp[-3] );
 
-            yyval = new swq_expr_node(SWQ_NOT);
+            yyval = new swq_expr_node( SWQ_NOT );
             yyval->field_type = SWQ_BOOLEAN;
-            yyval->PushSubExpression(isnull);
+            yyval->PushSubExpression( isnull );
         }
-        break;
+    break;
 
-        case 32: /* value_expr_list: value_expr ',' value_expr_list  */
+  case 32: /* value_expr_list: value_expr ',' value_expr_list  */
         {
             yyval = yyvsp[0];
-            yyvsp[0]->PushSubExpression(yyvsp[-2]);
+            yyvsp[0]->PushSubExpression( yyvsp[-2] );
         }
-        break;
+    break;
 
-        case 33: /* value_expr_list: value_expr  */
-        {
-            yyval = new swq_expr_node(SWQ_ARGUMENT_LIST); /* temporary value */
-            yyval->PushSubExpression(yyvsp[0]);
+  case 33: /* value_expr_list: value_expr  */
+            {
+            yyval = new swq_expr_node( SWQ_ARGUMENT_LIST ); /* temporary value */
+            yyval->PushSubExpression( yyvsp[0] );
         }
-        break;
+    break;
 
-        case 34: /* field_value: "identifier"  */
+  case 36: /* field_value: identifier  */
         {
             yyval = yyvsp[0];  // validation deferred.
             yyval->eNodeType = SNT_COLUMN;
             yyval->field_index = -1;
             yyval->table_index = -1;
         }
-        break;
+    break;
 
-        case 35: /* field_value: "identifier" '.' "identifier"  */
+  case 37: /* field_value: identifier '.' identifier  */
         {
             yyval = yyvsp[-2];  // validation deferred.
             yyval->eNodeType = SNT_COLUMN;
@@ -1925,63 +2023,61 @@ yyreduce:
             delete yyvsp[0];
             yyvsp[0] = nullptr;
         }
-        break;
+    break;
 
-        case 36: /* value_expr_non_logical: "integer number"  */
+  case 38: /* value_expr_non_logical: "integer number"  */
         {
             yyval = yyvsp[0];
         }
-        break;
+    break;
 
-        case 37: /* value_expr_non_logical: "floating point number"  */
+  case 39: /* value_expr_non_logical: "floating point number"  */
         {
             yyval = yyvsp[0];
         }
-        break;
+    break;
 
-        case 38: /* value_expr_non_logical: "string"  */
+  case 40: /* value_expr_non_logical: "string"  */
         {
             yyval = yyvsp[0];
         }
-        break;
+    break;
 
-        case 39: /* value_expr_non_logical: field_value  */
+  case 41: /* value_expr_non_logical: field_value  */
         {
             yyval = yyvsp[0];
         }
-        break;
+    break;
 
-        case 40: /* value_expr_non_logical: '(' value_expr ')'  */
+  case 42: /* value_expr_non_logical: '(' value_expr ')'  */
         {
             yyval = yyvsp[-1];
         }
-        break;
+    break;
 
-        case 41: /* value_expr_non_logical: "NULL"  */
+  case 43: /* value_expr_non_logical: "NULL"  */
         {
-            yyval = new swq_expr_node(static_cast<const char *>(nullptr));
+            yyval = new swq_expr_node(static_cast<const char*>(nullptr));
         }
-        break;
+    break;
 
-        case 42: /* value_expr_non_logical: '-' value_expr_non_logical  */
+  case 44: /* value_expr_non_logical: '-' value_expr_non_logical  */
         {
             if (yyvsp[0]->eNodeType == SNT_CONSTANT)
             {
-                if (yyvsp[0]->field_type == SWQ_FLOAT &&
+                if( yyvsp[0]->field_type == SWQ_FLOAT &&
                     yyvsp[0]->string_value &&
-                    strcmp(yyvsp[0]->string_value, "9223372036854775808") == 0)
+                    strcmp(yyvsp[0]->string_value, "9223372036854775808") == 0 )
                 {
                     yyval = yyvsp[0];
                     yyval->field_type = SWQ_INTEGER64;
                     yyval->int_value = std::numeric_limits<GIntBig>::min();
-                    yyval->float_value = static_cast<double>(
-                        std::numeric_limits<GIntBig>::min());
+                    yyval->float_value = static_cast<double>(std::numeric_limits<GIntBig>::min());
                 }
                 // - (-9223372036854775808) cannot be represented on int64
                 // the classic overflow is that its negation is itself.
-                else if (yyvsp[0]->field_type == SWQ_INTEGER64 &&
-                         yyvsp[0]->int_value ==
-                             std::numeric_limits<GIntBig>::min())
+                else if( yyvsp[0]->field_type == SWQ_INTEGER64 &&
+                         yyvsp[0]->int_value == std::numeric_limits<GIntBig>::min() )
                 {
                     yyval = yyvsp[0];
                 }
@@ -1994,61 +2090,61 @@ yyreduce:
             }
             else
             {
-                yyval = new swq_expr_node(SWQ_MULTIPLY);
-                yyval->PushSubExpression(new swq_expr_node(-1));
-                yyval->PushSubExpression(yyvsp[0]);
+                yyval = new swq_expr_node( SWQ_MULTIPLY );
+                yyval->PushSubExpression( new swq_expr_node(-1) );
+                yyval->PushSubExpression( yyvsp[0] );
             }
         }
-        break;
+    break;
 
-        case 43: /* value_expr_non_logical: value_expr_non_logical '+' value_expr_non_logical  */
+  case 45: /* value_expr_non_logical: value_expr_non_logical '+' value_expr_non_logical  */
         {
-            yyval = new swq_expr_node(SWQ_ADD);
-            yyval->PushSubExpression(yyvsp[-2]);
-            yyval->PushSubExpression(yyvsp[0]);
+            yyval = new swq_expr_node( SWQ_ADD );
+            yyval->PushSubExpression( yyvsp[-2] );
+            yyval->PushSubExpression( yyvsp[0] );
         }
-        break;
+    break;
 
-        case 44: /* value_expr_non_logical: value_expr_non_logical '-' value_expr_non_logical  */
+  case 46: /* value_expr_non_logical: value_expr_non_logical '-' value_expr_non_logical  */
         {
-            yyval = new swq_expr_node(SWQ_SUBTRACT);
-            yyval->PushSubExpression(yyvsp[-2]);
-            yyval->PushSubExpression(yyvsp[0]);
+            yyval = new swq_expr_node( SWQ_SUBTRACT );
+            yyval->PushSubExpression( yyvsp[-2] );
+            yyval->PushSubExpression( yyvsp[0] );
         }
-        break;
+    break;
 
-        case 45: /* value_expr_non_logical: value_expr_non_logical '*' value_expr_non_logical  */
+  case 47: /* value_expr_non_logical: value_expr_non_logical '*' value_expr_non_logical  */
         {
-            yyval = new swq_expr_node(SWQ_MULTIPLY);
-            yyval->PushSubExpression(yyvsp[-2]);
-            yyval->PushSubExpression(yyvsp[0]);
+            yyval = new swq_expr_node( SWQ_MULTIPLY );
+            yyval->PushSubExpression( yyvsp[-2] );
+            yyval->PushSubExpression( yyvsp[0] );
         }
-        break;
+    break;
 
-        case 46: /* value_expr_non_logical: value_expr_non_logical '/' value_expr_non_logical  */
+  case 48: /* value_expr_non_logical: value_expr_non_logical '/' value_expr_non_logical  */
         {
-            yyval = new swq_expr_node(SWQ_DIVIDE);
-            yyval->PushSubExpression(yyvsp[-2]);
-            yyval->PushSubExpression(yyvsp[0]);
+            yyval = new swq_expr_node( SWQ_DIVIDE );
+            yyval->PushSubExpression( yyvsp[-2] );
+            yyval->PushSubExpression( yyvsp[0] );
         }
-        break;
+    break;
 
-        case 47: /* value_expr_non_logical: value_expr_non_logical '%' value_expr_non_logical  */
+  case 49: /* value_expr_non_logical: value_expr_non_logical '%' value_expr_non_logical  */
         {
-            yyval = new swq_expr_node(SWQ_MODULUS);
-            yyval->PushSubExpression(yyvsp[-2]);
-            yyval->PushSubExpression(yyvsp[0]);
+            yyval = new swq_expr_node( SWQ_MODULUS );
+            yyval->PushSubExpression( yyvsp[-2] );
+            yyval->PushSubExpression( yyvsp[0] );
         }
-        break;
+    break;
 
-        case 48: /* value_expr_non_logical: "identifier" '(' value_expr_list ')'  */
+  case 50: /* value_expr_non_logical: identifier '(' value_expr_list ')'  */
         {
             const swq_operation *poOp =
-                swq_op_registrar::GetOperator(yyvsp[-3]->string_value);
+                    swq_op_registrar::GetOperator( yyvsp[-3]->string_value );
 
-            if (poOp == nullptr)
+            if( poOp == nullptr )
             {
-                if (context->bAcceptCustomFuncs)
+                if( context->bAcceptCustomFuncs )
                 {
                     yyval = yyvsp[-1];
                     yyval->eNodeType = SNT_OPERATION;
@@ -2059,9 +2155,9 @@ yyreduce:
                 }
                 else
                 {
-                    CPLError(CE_Failure, CPLE_AppDefined,
-                             "Undefined function '%s' used.",
-                             yyvsp[-3]->string_value);
+                    CPLError( CE_Failure, CPLE_AppDefined,
+                                    "Undefined function '%s' used.",
+                                    yyvsp[-3]->string_value );
                     delete yyvsp[-3];
                     delete yyvsp[-1];
                     YYERROR;
@@ -2076,125 +2172,122 @@ yyreduce:
                 delete yyvsp[-3];
             }
         }
-        break;
+    break;
 
-        case 49: /* value_expr_non_logical: "CAST" '(' value_expr "AS" type_def ')'  */
+  case 51: /* value_expr_non_logical: "CAST" '(' value_expr "AS" type_def ')'  */
         {
             yyval = yyvsp[-1];
-            yyval->PushSubExpression(yyvsp[-3]);
+            yyval->PushSubExpression( yyvsp[-3] );
             yyval->ReverseSubExpressions();
         }
-        break;
+    break;
 
-        case 50: /* type_def: "identifier"  */
+  case 52: /* type_def: identifier  */
+    {
+        yyval = new swq_expr_node( SWQ_CAST );
+        yyval->PushSubExpression( yyvsp[0] );
+    }
+    break;
+
+  case 53: /* type_def: identifier '(' "integer number" ')'  */
+    {
+        yyval = new swq_expr_node( SWQ_CAST );
+        yyval->PushSubExpression( yyvsp[-1] );
+        yyval->PushSubExpression( yyvsp[-3] );
+    }
+    break;
+
+  case 54: /* type_def: identifier '(' "integer number" ',' "integer number" ')'  */
+    {
+        yyval = new swq_expr_node( SWQ_CAST );
+        yyval->PushSubExpression( yyvsp[-1] );
+        yyval->PushSubExpression( yyvsp[-3] );
+        yyval->PushSubExpression( yyvsp[-5] );
+    }
+    break;
+
+  case 55: /* type_def: identifier '(' identifier ')'  */
+    {
+        OGRwkbGeometryType eType = OGRFromOGCGeomType(yyvsp[-1]->string_value);
+        if( !EQUAL(yyvsp[-3]->string_value, "GEOMETRY") ||
+            (wkbFlatten(eType) == wkbUnknown &&
+            !STARTS_WITH_CI(yyvsp[-1]->string_value, "GEOMETRY")) )
         {
-            yyval = new swq_expr_node(SWQ_CAST);
-            yyval->PushSubExpression(yyvsp[0]);
+            yyerror (context, "syntax error");
+            delete yyvsp[-3];
+            delete yyvsp[-1];
+            YYERROR;
         }
-        break;
+        yyval = new swq_expr_node( SWQ_CAST );
+        yyval->PushSubExpression( yyvsp[-1] );
+        yyval->PushSubExpression( yyvsp[-3] );
+    }
+    break;
 
-        case 51: /* type_def: "identifier" '(' "integer number" ')'  */
+  case 56: /* type_def: identifier '(' identifier ',' "integer number" ')'  */
+    {
+        OGRwkbGeometryType eType = OGRFromOGCGeomType(yyvsp[-3]->string_value);
+        if( !EQUAL(yyvsp[-5]->string_value, "GEOMETRY") ||
+            (wkbFlatten(eType) == wkbUnknown &&
+            !STARTS_WITH_CI(yyvsp[-3]->string_value, "GEOMETRY")) )
         {
-            yyval = new swq_expr_node(SWQ_CAST);
-            yyval->PushSubExpression(yyvsp[-1]);
-            yyval->PushSubExpression(yyvsp[-3]);
-        }
-        break;
-
-        case 52: /* type_def: "identifier" '(' "integer number" ',' "integer number" ')'  */
-        {
-            yyval = new swq_expr_node(SWQ_CAST);
-            yyval->PushSubExpression(yyvsp[-1]);
-            yyval->PushSubExpression(yyvsp[-3]);
-            yyval->PushSubExpression(yyvsp[-5]);
-        }
-        break;
-
-        case 53: /* type_def: "identifier" '(' "identifier" ')'  */
-        {
-            OGRwkbGeometryType eType =
-                OGRFromOGCGeomType(yyvsp[-1]->string_value);
-            if (!EQUAL(yyvsp[-3]->string_value, "GEOMETRY") ||
-                (wkbFlatten(eType) == wkbUnknown &&
-                 !STARTS_WITH_CI(yyvsp[-1]->string_value, "GEOMETRY")))
-            {
-                yyerror(context, "syntax error");
-                delete yyvsp[-3];
-                delete yyvsp[-1];
-                YYERROR;
-            }
-            yyval = new swq_expr_node(SWQ_CAST);
-            yyval->PushSubExpression(yyvsp[-1]);
-            yyval->PushSubExpression(yyvsp[-3]);
-        }
-        break;
-
-        case 54: /* type_def: "identifier" '(' "identifier" ',' "integer number" ')'  */
-        {
-            OGRwkbGeometryType eType =
-                OGRFromOGCGeomType(yyvsp[-3]->string_value);
-            if (!EQUAL(yyvsp[-5]->string_value, "GEOMETRY") ||
-                (wkbFlatten(eType) == wkbUnknown &&
-                 !STARTS_WITH_CI(yyvsp[-3]->string_value, "GEOMETRY")))
-            {
-                yyerror(context, "syntax error");
-                delete yyvsp[-5];
-                delete yyvsp[-3];
-                delete yyvsp[-1];
-                YYERROR;
-            }
-            yyval = new swq_expr_node(SWQ_CAST);
-            yyval->PushSubExpression(yyvsp[-1]);
-            yyval->PushSubExpression(yyvsp[-3]);
-            yyval->PushSubExpression(yyvsp[-5]);
-        }
-        break;
-
-        case 57: /* select_core: "SELECT" select_field_list "FROM" table_def opt_joins opt_where opt_order_by opt_limit opt_offset  */
-        {
+            yyerror (context, "syntax error");
             delete yyvsp[-5];
+            delete yyvsp[-3];
+            delete yyvsp[-1];
+            YYERROR;
         }
-        break;
+        yyval = new swq_expr_node( SWQ_CAST );
+        yyval->PushSubExpression( yyvsp[-1] );
+        yyval->PushSubExpression( yyvsp[-3] );
+        yyval->PushSubExpression( yyvsp[-5] );
+    }
+    break;
 
-        case 58: /* select_core: "SELECT" "DISTINCT" select_field_list "FROM" table_def opt_joins opt_where opt_order_by opt_limit opt_offset  */
-        {
-            context->poCurSelect->query_mode = SWQM_DISTINCT_LIST;
-            delete yyvsp[-5];
-        }
-        break;
+  case 59: /* select_core: "SELECT" select_field_list "FROM" table_def opt_joins opt_where opt_order_by opt_limit opt_offset  */
+    {
+        delete yyvsp[-5];
+    }
+    break;
 
-        case 61: /* union_all: "UNION" "ALL"  */
-        {
-            swq_select *poNewSelect = new swq_select();
-            context->poCurSelect->PushUnionAll(poNewSelect);
-            context->poCurSelect = poNewSelect;
-        }
-        break;
+  case 60: /* select_core: "SELECT" "DISTINCT" select_field_list "FROM" table_def opt_joins opt_where opt_order_by opt_limit opt_offset  */
+    {
+        context->poCurSelect->query_mode = SWQM_DISTINCT_LIST;
+        delete yyvsp[-5];
+    }
+    break;
 
-        case 64: /* exclude_field: field_value  */
+  case 63: /* union_all: "UNION" "ALL"  */
+    {
+        swq_select* poNewSelect = new swq_select();
+        context->poCurSelect->PushUnionAll(poNewSelect);
+        context->poCurSelect = poNewSelect;
+    }
+    break;
+
+  case 66: /* exclude_field: field_value  */
         {
-            if (!context->poCurSelect->PushExcludeField(yyvsp[0]))
+            if ( !context->poCurSelect->PushExcludeField( yyvsp[0] ) )
             {
                 delete yyvsp[0];
                 YYERROR;
             }
         }
-        break;
+    break;
 
-        case 69: /* column_spec: value_expr  */
+  case 71: /* column_spec: value_expr  */
         {
-            if (!context->poCurSelect->PushField(yyvsp[0]))
+            if( !context->poCurSelect->PushField( yyvsp[0], nullptr, false, false ) )
             {
                 delete yyvsp[0];
                 YYERROR;
             }
         }
-        break;
+    break;
 
-        case 70: /* column_spec: value_expr as_clause  */
+  case 72: /* column_spec: value_expr as_clause_with_hidden  */
         {
-            if (!context->poCurSelect->PushField(yyvsp[-1],
-                                                 yyvsp[0]->string_value))
+            if( !context->poCurSelect->PushField( yyvsp[-1], yyvsp[0]->string_value, false, yyvsp[0]->bHidden ) )
             {
                 delete yyvsp[-1];
                 delete yyvsp[0];
@@ -2202,41 +2295,41 @@ yyreduce:
             }
             delete yyvsp[0];
         }
-        break;
+    break;
 
-        case 71: /* column_spec: '*' except_or_exclude '(' exclude_field_list ')'  */
+  case 73: /* column_spec: '*' except_or_exclude '(' exclude_field_list ')'  */
         {
             swq_expr_node *poNode = new swq_expr_node();
             poNode->eNodeType = SNT_COLUMN;
-            poNode->string_value = CPLStrdup("*");
+            poNode->string_value = CPLStrdup( "*" );
             poNode->table_index = -1;
             poNode->field_index = -1;
 
-            if (!context->poCurSelect->PushField(poNode))
+            if( !context->poCurSelect->PushField( poNode, nullptr, false, false ) )
             {
                 delete poNode;
                 YYERROR;
             }
         }
-        break;
+    break;
 
-        case 72: /* column_spec: '*'  */
+  case 74: /* column_spec: '*'  */
         {
             swq_expr_node *poNode = new swq_expr_node();
             poNode->eNodeType = SNT_COLUMN;
-            poNode->string_value = CPLStrdup("*");
+            poNode->string_value = CPLStrdup( "*" );
             poNode->table_index = -1;
             poNode->field_index = -1;
 
-            if (!context->poCurSelect->PushField(poNode))
+            if( !context->poCurSelect->PushField( poNode, nullptr, false, false ) )
             {
                 delete poNode;
                 YYERROR;
             }
         }
-        break;
+    break;
 
-        case 73: /* column_spec: "identifier" '.' '*'  */
+  case 75: /* column_spec: identifier '.' '*'  */
         {
             CPLString osTableName = yyvsp[-2]->string_value;
 
@@ -2245,26 +2338,27 @@ yyreduce:
 
             swq_expr_node *poNode = new swq_expr_node();
             poNode->eNodeType = SNT_COLUMN;
-            poNode->table_name = CPLStrdup(osTableName);
-            poNode->string_value = CPLStrdup("*");
+            poNode->table_name = CPLStrdup(osTableName );
+            poNode->string_value = CPLStrdup( "*" );
             poNode->table_index = -1;
             poNode->field_index = -1;
 
-            if (!context->poCurSelect->PushField(poNode))
+            if( !context->poCurSelect->PushField( poNode, nullptr, false, false ) )
             {
                 delete poNode;
                 YYERROR;
             }
         }
-        break;
+    break;
 
-        case 74: /* column_spec: "identifier" '(' '*' ')'  */
+  case 76: /* column_spec: identifier '(' '*' ')'  */
         {
-            // special case for COUNT(*), confirm it.
-            if (!EQUAL(yyvsp[-3]->string_value, "COUNT"))
+                // special case for COUNT(*), confirm it.
+            if( !EQUAL(yyvsp[-3]->string_value, "COUNT") )
             {
-                CPLError(CE_Failure, CPLE_AppDefined,
-                         "Syntax Error with %s(*).", yyvsp[-3]->string_value);
+                CPLError( CE_Failure, CPLE_AppDefined,
+                        "Syntax Error with %s(*).",
+                        yyvsp[-3]->string_value );
                 delete yyvsp[-3];
                 YYERROR;
             }
@@ -2274,28 +2368,29 @@ yyreduce:
 
             swq_expr_node *poNode = new swq_expr_node();
             poNode->eNodeType = SNT_COLUMN;
-            poNode->string_value = CPLStrdup("*");
+            poNode->string_value = CPLStrdup( "*" );
             poNode->table_index = -1;
             poNode->field_index = -1;
 
-            swq_expr_node *count = new swq_expr_node(SWQ_COUNT);
-            count->PushSubExpression(poNode);
+            swq_expr_node *count = new swq_expr_node( SWQ_COUNT );
+            count->PushSubExpression( poNode );
 
-            if (!context->poCurSelect->PushField(count))
+            if( !context->poCurSelect->PushField( count, nullptr, false, false ) )
             {
                 delete count;
                 YYERROR;
             }
         }
-        break;
+    break;
 
-        case 75: /* column_spec: "identifier" '(' '*' ')' as_clause  */
+  case 77: /* column_spec: identifier '(' '*' ')' as_clause  */
         {
-            // special case for COUNT(*), confirm it.
-            if (!EQUAL(yyvsp[-4]->string_value, "COUNT"))
+                // special case for COUNT(*), confirm it.
+            if( !EQUAL(yyvsp[-4]->string_value, "COUNT") )
             {
-                CPLError(CE_Failure, CPLE_AppDefined,
-                         "Syntax Error with %s(*).", yyvsp[-4]->string_value);
+                CPLError( CE_Failure, CPLE_AppDefined,
+                        "Syntax Error with %s(*).",
+                        yyvsp[-4]->string_value );
                 delete yyvsp[-4];
                 delete yyvsp[0];
                 YYERROR;
@@ -2306,14 +2401,14 @@ yyreduce:
 
             swq_expr_node *poNode = new swq_expr_node();
             poNode->eNodeType = SNT_COLUMN;
-            poNode->string_value = CPLStrdup("*");
+            poNode->string_value = CPLStrdup( "*" );
             poNode->table_index = -1;
             poNode->field_index = -1;
 
-            swq_expr_node *count = new swq_expr_node(SWQ_COUNT);
-            count->PushSubExpression(poNode);
+            swq_expr_node *count = new swq_expr_node( SWQ_COUNT );
+            count->PushSubExpression( poNode );
 
-            if (!context->poCurSelect->PushField(count, yyvsp[0]->string_value))
+            if( !context->poCurSelect->PushField( count, yyvsp[0]->string_value, false, yyvsp[0]->bHidden ) )
             {
                 delete count;
                 delete yyvsp[0];
@@ -2322,53 +2417,51 @@ yyreduce:
 
             delete yyvsp[0];
         }
-        break;
+    break;
 
-        case 76: /* column_spec: "identifier" '(' "DISTINCT" field_value ')'  */
+  case 78: /* column_spec: identifier '(' "DISTINCT" field_value ')'  */
         {
-            // special case for COUNT(DISTINCT x), confirm it.
-            if (!EQUAL(yyvsp[-4]->string_value, "COUNT"))
+                // special case for COUNT(DISTINCT x), confirm it.
+            if( !EQUAL(yyvsp[-4]->string_value, "COUNT") )
             {
                 CPLError(
                     CE_Failure, CPLE_AppDefined,
-                    "DISTINCT keyword can only be used in COUNT() operator.");
+                    "DISTINCT keyword can only be used in COUNT() operator." );
                 delete yyvsp[-4];
                 delete yyvsp[-1];
-                YYERROR;
+                    YYERROR;
             }
 
             delete yyvsp[-4];
 
-            swq_expr_node *count = new swq_expr_node(SWQ_COUNT);
-            count->PushSubExpression(yyvsp[-1]);
+            swq_expr_node *count = new swq_expr_node( SWQ_COUNT );
+            count->PushSubExpression( yyvsp[-1] );
 
-            if (!context->poCurSelect->PushField(count, nullptr, TRUE))
+            if( !context->poCurSelect->PushField( count, nullptr, true, false ) )
             {
                 delete count;
                 YYERROR;
             }
         }
-        break;
+    break;
 
-        case 77: /* column_spec: "identifier" '(' "DISTINCT" field_value ')' as_clause  */
+  case 79: /* column_spec: identifier '(' "DISTINCT" field_value ')' as_clause  */
         {
             // special case for COUNT(DISTINCT x), confirm it.
-            if (!EQUAL(yyvsp[-5]->string_value, "COUNT"))
+            if( !EQUAL(yyvsp[-5]->string_value, "COUNT") )
             {
-                CPLError(
-                    CE_Failure, CPLE_AppDefined,
-                    "DISTINCT keyword can only be used in COUNT() operator.");
+                CPLError( CE_Failure, CPLE_AppDefined,
+                        "DISTINCT keyword can only be used in COUNT() operator." );
                 delete yyvsp[-5];
                 delete yyvsp[-2];
                 delete yyvsp[0];
                 YYERROR;
             }
 
-            swq_expr_node *count = new swq_expr_node(SWQ_COUNT);
-            count->PushSubExpression(yyvsp[-2]);
+            swq_expr_node *count = new swq_expr_node( SWQ_COUNT );
+            count->PushSubExpression( yyvsp[-2] );
 
-            if (!context->poCurSelect->PushField(count, yyvsp[0]->string_value,
-                                                 TRUE))
+            if( !context->poCurSelect->PushField( count, yyvsp[0]->string_value, true, yyvsp[0]->bHidden ) )
             {
                 delete yyvsp[-5];
                 delete count;
@@ -2379,153 +2472,167 @@ yyreduce:
             delete yyvsp[-5];
             delete yyvsp[0];
         }
-        break;
+    break;
 
-        case 78: /* as_clause: "AS" "identifier"  */
+  case 80: /* as_clause: "AS" identifier  */
         {
-            delete yyvsp[-1];
             yyval = yyvsp[0];
+            yyvsp[0] = nullptr;
         }
-        break;
+    break;
 
-        case 81: /* opt_where: "WHERE" value_expr  */
+  case 83: /* as_clause_with_hidden: as_clause "HIDDEN"  */
+        {
+            yyval = yyvsp[-1];
+            yyvsp[-1] = nullptr;
+            delete yyvsp[0];
+            yyvsp[0] = nullptr;
+            yyval->bHidden = true;
+        }
+    break;
+
+  case 85: /* opt_where: "WHERE" value_expr  */
         {
             context->poCurSelect->where_expr = yyvsp[0];
         }
-        break;
+    break;
 
-        case 83: /* opt_joins: "JOIN" table_def "ON" value_expr opt_joins  */
+  case 87: /* opt_joins: "JOIN" table_def "ON" value_expr opt_joins  */
         {
-            context->poCurSelect->PushJoin(
-                static_cast<int>(yyvsp[-3]->int_value), yyvsp[-1]);
+            context->poCurSelect->PushJoin( static_cast<int>(yyvsp[-3]->int_value),
+                                            yyvsp[-1] );
             delete yyvsp[-3];
         }
-        break;
+    break;
 
-        case 84: /* opt_joins: "LEFT" "JOIN" table_def "ON" value_expr opt_joins  */
+  case 88: /* opt_joins: "LEFT" "JOIN" table_def "ON" value_expr opt_joins  */
         {
-            context->poCurSelect->PushJoin(
-                static_cast<int>(yyvsp[-3]->int_value), yyvsp[-1]);
+            context->poCurSelect->PushJoin( static_cast<int>(yyvsp[-3]->int_value),
+                                            yyvsp[-1] );
             delete yyvsp[-3];
         }
-        break;
+    break;
 
-        case 89: /* sort_spec: field_value  */
+  case 93: /* sort_spec: field_value  */
         {
-            context->poCurSelect->PushOrderBy(yyvsp[0]->table_name,
-                                              yyvsp[0]->string_value, TRUE);
+            context->poCurSelect->PushOrderBy( yyvsp[0]->table_name, yyvsp[0]->string_value, TRUE );
             delete yyvsp[0];
             yyvsp[0] = nullptr;
         }
-        break;
+    break;
 
-        case 90: /* sort_spec: field_value "ASC"  */
+  case 94: /* sort_spec: field_value "ASC"  */
         {
-            context->poCurSelect->PushOrderBy(yyvsp[-1]->table_name,
-                                              yyvsp[-1]->string_value, TRUE);
+            context->poCurSelect->PushOrderBy( yyvsp[-1]->table_name, yyvsp[-1]->string_value, TRUE );
             delete yyvsp[-1];
             yyvsp[-1] = nullptr;
         }
-        break;
+    break;
 
-        case 91: /* sort_spec: field_value "DESC"  */
+  case 95: /* sort_spec: field_value "DESC"  */
         {
-            context->poCurSelect->PushOrderBy(yyvsp[-1]->table_name,
-                                              yyvsp[-1]->string_value, FALSE);
+            context->poCurSelect->PushOrderBy( yyvsp[-1]->table_name, yyvsp[-1]->string_value, FALSE );
             delete yyvsp[-1];
             yyvsp[-1] = nullptr;
         }
-        break;
+    break;
 
-        case 93: /* opt_limit: "LIMIT" "integer number"  */
-        {
-            context->poCurSelect->SetLimit(yyvsp[0]->int_value);
-            delete yyvsp[0];
-            yyvsp[0] = nullptr;
-        }
-        break;
-
-        case 95: /* opt_offset: "OFFSET" "integer number"  */
-        {
-            context->poCurSelect->SetOffset(yyvsp[0]->int_value);
-            delete yyvsp[0];
-            yyvsp[0] = nullptr;
-        }
-        break;
-
-        case 96: /* table_def: "identifier"  */
-        {
-            const int iTable = context->poCurSelect->PushTableDef(
-                nullptr, yyvsp[0]->string_value, nullptr);
-            delete yyvsp[0];
-
-            yyval = new swq_expr_node(iTable);
-        }
-        break;
-
-        case 97: /* table_def: "identifier" as_clause  */
-        {
-            const int iTable = context->poCurSelect->PushTableDef(
-                nullptr, yyvsp[-1]->string_value, yyvsp[0]->string_value);
-            delete yyvsp[-1];
-            delete yyvsp[0];
-
-            yyval = new swq_expr_node(iTable);
-        }
-        break;
-
-        case 98: /* table_def: "string" '.' "identifier"  */
-        {
-            const int iTable = context->poCurSelect->PushTableDef(
-                yyvsp[-2]->string_value, yyvsp[0]->string_value, nullptr);
-            delete yyvsp[-2];
-            delete yyvsp[0];
-
-            yyval = new swq_expr_node(iTable);
-        }
-        break;
-
-        case 99: /* table_def: "string" '.' "identifier" as_clause  */
-        {
-            const int iTable = context->poCurSelect->PushTableDef(
-                yyvsp[-3]->string_value, yyvsp[-1]->string_value,
-                yyvsp[0]->string_value);
-            delete yyvsp[-3];
-            delete yyvsp[-1];
-            delete yyvsp[0];
-
-            yyval = new swq_expr_node(iTable);
-        }
-        break;
-
-        case 100: /* table_def: "identifier" '.' "identifier"  */
-        {
-            const int iTable = context->poCurSelect->PushTableDef(
-                yyvsp[-2]->string_value, yyvsp[0]->string_value, nullptr);
-            delete yyvsp[-2];
-            delete yyvsp[0];
-
-            yyval = new swq_expr_node(iTable);
-        }
-        break;
-
-        case 101: /* table_def: "identifier" '.' "identifier" as_clause  */
-        {
-            const int iTable = context->poCurSelect->PushTableDef(
-                yyvsp[-3]->string_value, yyvsp[-1]->string_value,
-                yyvsp[0]->string_value);
-            delete yyvsp[-3];
-            delete yyvsp[-1];
-            delete yyvsp[0];
-
-            yyval = new swq_expr_node(iTable);
-        }
-        break;
-
-        default:
-            break;
+  case 97: /* opt_limit: "LIMIT" "integer number"  */
+    {
+        context->poCurSelect->SetLimit( yyvsp[0]->int_value );
+        delete yyvsp[0];
+        yyvsp[0] = nullptr;
     }
-    /* User semantic actions sometimes alter yychar, and that requires
+    break;
+
+  case 99: /* opt_offset: "OFFSET" "integer number"  */
+    {
+        context->poCurSelect->SetOffset( yyvsp[0]->int_value );
+        delete yyvsp[0];
+        yyvsp[0] = nullptr;
+    }
+    break;
+
+  case 100: /* table_def: identifier  */
+    {
+        const int iTable =
+            context->poCurSelect->PushTableDef( nullptr, yyvsp[0]->string_value,
+                                                nullptr );
+        delete yyvsp[0];
+
+        yyval = new swq_expr_node( iTable );
+    }
+    break;
+
+  case 101: /* table_def: identifier as_clause  */
+    {
+        const int iTable =
+            context->poCurSelect->PushTableDef( nullptr, yyvsp[-1]->string_value,
+                                                yyvsp[0]->string_value );
+        delete yyvsp[-1];
+        delete yyvsp[0];
+
+        yyval = new swq_expr_node( iTable );
+    }
+    break;
+
+  case 102: /* table_def: "string" '.' identifier  */
+    {
+        const int iTable =
+            context->poCurSelect->PushTableDef( yyvsp[-2]->string_value,
+                                                yyvsp[0]->string_value, nullptr );
+        delete yyvsp[-2];
+        delete yyvsp[0];
+
+        yyval = new swq_expr_node( iTable );
+    }
+    break;
+
+  case 103: /* table_def: "string" '.' identifier as_clause  */
+    {
+        const int iTable =
+            context->poCurSelect->PushTableDef( yyvsp[-3]->string_value,
+                                                yyvsp[-1]->string_value,
+                                                yyvsp[0]->string_value );
+        delete yyvsp[-3];
+        delete yyvsp[-1];
+        delete yyvsp[0];
+
+        yyval = new swq_expr_node( iTable );
+    }
+    break;
+
+  case 104: /* table_def: identifier '.' identifier  */
+    {
+        const int iTable =
+            context->poCurSelect->PushTableDef( yyvsp[-2]->string_value,
+                                                yyvsp[0]->string_value, nullptr );
+        delete yyvsp[-2];
+        delete yyvsp[0];
+
+        yyval = new swq_expr_node( iTable );
+    }
+    break;
+
+  case 105: /* table_def: identifier '.' identifier as_clause  */
+    {
+        const int iTable =
+            context->poCurSelect->PushTableDef( yyvsp[-3]->string_value,
+                                                yyvsp[-1]->string_value,
+                                                yyvsp[0]->string_value );
+        delete yyvsp[-3];
+        delete yyvsp[-1];
+        delete yyvsp[0];
+
+        yyval = new swq_expr_node( iTable );
+    }
+    break;
+
+
+
+      default: break;
+    }
+  /* User semantic actions sometimes alter yychar, and that requires
      that yytoken be updated with the new translation.  We take the
      approach of translating immediately before every use of yytoken.
      One alternative is translating here after every semantic action,
@@ -2536,203 +2643,212 @@ yyreduce:
      case of YYERROR or YYBACKUP, subsequent parser actions might lead
      to an incorrect destructor call or verbose syntax error message
      before the lookahead is translated.  */
-    YY_SYMBOL_PRINT("-> $$ =", YY_CAST(yysymbol_kind_t, yyr1[yyn]), &yyval,
-                    &yyloc);
+  YY_SYMBOL_PRINT ("-> $$ =", YY_CAST (yysymbol_kind_t, yyr1[yyn]), &yyval, &yyloc);
 
-    YYPOPSTACK(yylen);
-    yylen = 0;
+  YYPOPSTACK (yylen);
+  yylen = 0;
 
-    *++yyvsp = yyval;
+  *++yyvsp = yyval;
 
-    /* Now 'shift' the result of the reduction.  Determine what state
+  /* Now 'shift' the result of the reduction.  Determine what state
      that goes to, based on the state we popped back to and the rule
      number reduced by.  */
-    {
-        const int yylhs = yyr1[yyn] - YYNTOKENS;
-        const int yyi = yypgoto[yylhs] + *yyssp;
-        yystate = (0 <= yyi && yyi <= YYLAST && yycheck[yyi] == *yyssp
-                       ? yytable[yyi]
-                       : yydefgoto[yylhs]);
-    }
+  {
+    const int yylhs = yyr1[yyn] - YYNTOKENS;
+    const int yyi = yypgoto[yylhs] + *yyssp;
+    yystate = (0 <= yyi && yyi <= YYLAST && yycheck[yyi] == *yyssp
+               ? yytable[yyi]
+               : yydefgoto[yylhs]);
+  }
 
-    goto yynewstate;
+  goto yynewstate;
+
 
 /*--------------------------------------.
 | yyerrlab -- here on detecting error.  |
 `--------------------------------------*/
 yyerrlab:
-    /* Make sure we have latest lookahead translation.  See comments at
+  /* Make sure we have latest lookahead translation.  See comments at
      user semantic actions for why this is necessary.  */
-    yytoken = yychar == YYEMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE(yychar);
-    /* If not already recovering from an error, report this error.  */
-    if (!yyerrstatus)
+  yytoken = yychar == YYEMPTY ? YYSYMBOL_YYEMPTY : YYTRANSLATE (yychar);
+  /* If not already recovering from an error, report this error.  */
+  if (!yyerrstatus)
     {
-        ++yynerrs;
-        (void)yynerrs;
-        {
-            yypcontext_t yyctx = {yyssp, yytoken};
-            char const *yymsgp = YY_("syntax error");
-            int yysyntax_error_status;
-            yysyntax_error_status =
-                yysyntax_error(&yymsg_alloc, &yymsg, &yyctx);
-            if (yysyntax_error_status == 0)
+      ++yynerrs; (void)yynerrs;
+      {
+        yypcontext_t yyctx
+          = {yyssp, yytoken};
+        char const *yymsgp = YY_("syntax error");
+        int yysyntax_error_status;
+        yysyntax_error_status = yysyntax_error (&yymsg_alloc, &yymsg, &yyctx);
+        if (yysyntax_error_status == 0)
+          yymsgp = yymsg;
+        else if (yysyntax_error_status == -1)
+          {
+            if (yymsg != yymsgbuf)
+              YYSTACK_FREE (yymsg);
+            yymsg = YY_CAST (char *,
+                             YYSTACK_ALLOC (YY_CAST (YYSIZE_T, yymsg_alloc)));
+            if (yymsg)
+              {
+                yysyntax_error_status
+                  = yysyntax_error (&yymsg_alloc, &yymsg, &yyctx);
                 yymsgp = yymsg;
-            else if (yysyntax_error_status == -1)
-            {
-                if (yymsg != yymsgbuf)
-                    YYSTACK_FREE(yymsg);
-                yymsg = YY_CAST(char *,
-                                YYSTACK_ALLOC(YY_CAST(YYSIZE_T, yymsg_alloc)));
-                if (yymsg)
-                {
-                    yysyntax_error_status =
-                        yysyntax_error(&yymsg_alloc, &yymsg, &yyctx);
-                    yymsgp = yymsg;
-                }
-                else
-                {
-                    yymsg = yymsgbuf;
-                    yymsg_alloc = sizeof yymsgbuf;
-                    yysyntax_error_status = YYENOMEM;
-                }
-            }
-            yyerror(context, yymsgp);
-            if (yysyntax_error_status == YYENOMEM)
-                YYNOMEM;
-        }
+              }
+            else
+              {
+                yymsg = yymsgbuf;
+                yymsg_alloc = sizeof yymsgbuf;
+                yysyntax_error_status = YYENOMEM;
+              }
+          }
+        yyerror (context, yymsgp);
+        if (yysyntax_error_status == YYENOMEM)
+          YYNOMEM;
+      }
     }
 
-    if (yyerrstatus == 3)
+  if (yyerrstatus == 3)
     {
-        /* If just tried and failed to reuse lookahead token after an
+      /* If just tried and failed to reuse lookahead token after an
          error, discard it.  */
 
-        if (yychar <= END)
+      if (yychar <= END)
         {
-            /* Return failure if at end of input.  */
-            if (yychar == END)
-                YYABORT;
+          /* Return failure if at end of input.  */
+          if (yychar == END)
+            YYABORT;
         }
-        else
+      else
         {
-            yydestruct("Error: discarding", yytoken, &yylval, context);
-            yychar = YYEMPTY;
+          yydestruct ("Error: discarding",
+                      yytoken, &yylval, context);
+          yychar = YYEMPTY;
         }
     }
 
-    /* Else will try to reuse lookahead token after shifting the error
+  /* Else will try to reuse lookahead token after shifting the error
      token.  */
-    goto yyerrlab1;
+  goto yyerrlab1;
+
 
 /*---------------------------------------------------.
 | yyerrorlab -- error raised explicitly by YYERROR.  |
 `---------------------------------------------------*/
 yyerrorlab:
-    /* Pacify compilers when the user code never invokes YYERROR and the
+  /* Pacify compilers when the user code never invokes YYERROR and the
      label yyerrorlab therefore never appears in user code.  */
-    if (0)
-        YYERROR;
-    ++yynerrs;
-    (void)yynerrs;
+  if (0)
+    YYERROR;
+  ++yynerrs; (void)yynerrs;
 
-    /* Do not reclaim the symbols of the rule whose action triggered
+  /* Do not reclaim the symbols of the rule whose action triggered
      this YYERROR.  */
-    YYPOPSTACK(yylen);
-    yylen = 0;
-    YY_STACK_PRINT(yyss, yyssp);
-    yystate = *yyssp;
-    goto yyerrlab1;
+  YYPOPSTACK (yylen);
+  yylen = 0;
+  YY_STACK_PRINT (yyss, yyssp);
+  yystate = *yyssp;
+  goto yyerrlab1;
+
 
 /*-------------------------------------------------------------.
 | yyerrlab1 -- common code for both syntax error and YYERROR.  |
 `-------------------------------------------------------------*/
 yyerrlab1:
-    yyerrstatus = 3; /* Each real token shifted decrements this.  */
+  yyerrstatus = 3;      /* Each real token shifted decrements this.  */
 
-    /* Pop stack until we find a state that shifts the error token.  */
-    for (;;)
+  /* Pop stack until we find a state that shifts the error token.  */
+  for (;;)
     {
-        yyn = yypact[yystate];
-        if (!yypact_value_is_default(yyn))
+      yyn = yypact[yystate];
+      if (!yypact_value_is_default (yyn))
         {
-            yyn += YYSYMBOL_YYerror;
-            if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYSYMBOL_YYerror)
+          yyn += YYSYMBOL_YYerror;
+          if (0 <= yyn && yyn <= YYLAST && yycheck[yyn] == YYSYMBOL_YYerror)
             {
-                yyn = yytable[yyn];
-                if (0 < yyn)
-                    break;
+              yyn = yytable[yyn];
+              if (0 < yyn)
+                break;
             }
         }
 
-        /* Pop the current state because it cannot handle the error token.  */
-        if (yyssp == yyss)
-            YYABORT;
+      /* Pop the current state because it cannot handle the error token.  */
+      if (yyssp == yyss)
+        YYABORT;
 
-        yydestruct("Error: popping", YY_ACCESSING_SYMBOL(yystate), yyvsp,
-                   context);
-        YYPOPSTACK(1);
-        yystate = *yyssp;
-        YY_STACK_PRINT(yyss, yyssp);
+
+      yydestruct ("Error: popping",
+                  YY_ACCESSING_SYMBOL (yystate), yyvsp, context);
+      YYPOPSTACK (1);
+      yystate = *yyssp;
+      YY_STACK_PRINT (yyss, yyssp);
     }
 
-    YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
-    *++yyvsp = yylval;
-    YY_IGNORE_MAYBE_UNINITIALIZED_END
+  YY_IGNORE_MAYBE_UNINITIALIZED_BEGIN
+  *++yyvsp = yylval;
+  YY_IGNORE_MAYBE_UNINITIALIZED_END
 
-    /* Shift the error token.  */
-    YY_SYMBOL_PRINT("Shifting", YY_ACCESSING_SYMBOL(yyn), yyvsp, yylsp);
 
-    yystate = yyn;
-    goto yynewstate;
+  /* Shift the error token.  */
+  YY_SYMBOL_PRINT ("Shifting", YY_ACCESSING_SYMBOL (yyn), yyvsp, yylsp);
+
+  yystate = yyn;
+  goto yynewstate;
+
 
 /*-------------------------------------.
 | yyacceptlab -- YYACCEPT comes here.  |
 `-------------------------------------*/
 yyacceptlab:
-    yyresult = 0;
-    goto yyreturnlab;
+  yyresult = 0;
+  goto yyreturnlab;
+
 
 /*-----------------------------------.
 | yyabortlab -- YYABORT comes here.  |
 `-----------------------------------*/
 yyabortlab:
-    yyresult = 1;
-    goto yyreturnlab;
+  yyresult = 1;
+  goto yyreturnlab;
+
 
 /*-----------------------------------------------------------.
 | yyexhaustedlab -- YYNOMEM (memory exhaustion) comes here.  |
 `-----------------------------------------------------------*/
 yyexhaustedlab:
-    yyerror(context, YY_("memory exhausted"));
-    yyresult = 2;
-    goto yyreturnlab;
+  yyerror (context, YY_("memory exhausted"));
+  yyresult = 2;
+  goto yyreturnlab;
+
 
 /*----------------------------------------------------------.
 | yyreturnlab -- parsing is finished, clean up and return.  |
 `----------------------------------------------------------*/
 yyreturnlab:
-    if (yychar != YYEMPTY)
+  if (yychar != YYEMPTY)
     {
-        /* Make sure we have latest lookahead translation.  See comments at
+      /* Make sure we have latest lookahead translation.  See comments at
          user semantic actions for why this is necessary.  */
-        yytoken = YYTRANSLATE(yychar);
-        yydestruct("Cleanup: discarding lookahead", yytoken, &yylval, context);
+      yytoken = YYTRANSLATE (yychar);
+      yydestruct ("Cleanup: discarding lookahead",
+                  yytoken, &yylval, context);
     }
-    /* Do not reclaim the symbols of the rule whose action triggered
+  /* Do not reclaim the symbols of the rule whose action triggered
      this YYABORT or YYACCEPT.  */
-    YYPOPSTACK(yylen);
-    YY_STACK_PRINT(yyss, yyssp);
-    while (yyssp != yyss)
+  YYPOPSTACK (yylen);
+  YY_STACK_PRINT (yyss, yyssp);
+  while (yyssp != yyss)
     {
-        yydestruct("Cleanup: popping", YY_ACCESSING_SYMBOL(+*yyssp), yyvsp,
-                   context);
-        YYPOPSTACK(1);
+      yydestruct ("Cleanup: popping",
+                  YY_ACCESSING_SYMBOL (+*yyssp), yyvsp, context);
+      YYPOPSTACK (1);
     }
 #ifndef yyoverflow
-    if (yyss != yyssa)
-        YYSTACK_FREE(yyss);
+  if (yyss != yyssa)
+    YYSTACK_FREE (yyss);
 #endif
-    if (yymsg != yymsgbuf)
-        YYSTACK_FREE(yymsg);
-    return yyresult;
+  if (yymsg != yymsgbuf)
+    YYSTACK_FREE (yymsg);
+  return yyresult;
 }
+

--- a/ogr/swq_parser.cpp
+++ b/ogr/swq_parser.cpp
@@ -639,10 +639,11 @@ static const yytype_int16 yyrline[] =
 /** Accessing symbol of state STATE.  */
 #define YY_ACCESSING_SYMBOL(State) YY_CAST (yysymbol_kind_t, yystos[State])
 
-#if 1
+#if 0
 /* The user-facing name of the symbol whose (internal) number is
    YYSYMBOL.  No bounds checking.  */
 static const char *yysymbol_name (yysymbol_kind_t yysymbol) YY_ATTRIBUTE_UNUSED;
+#endif
 
 /* YYTNAME[SYMBOL-NUM] -- String name of the symbol SYMBOL-NUM.
    First, the terminals, then, starting at YYNTOKENS, nonterminals.  */
@@ -667,6 +668,7 @@ static const char *const yytname[] =
   "opt_offset", "table_def", YY_NULLPTR
 };
 
+#if 0
 static const char *
 yysymbol_name (yysymbol_kind_t yysymbol)
 {

--- a/ogr/swq_parser.hpp
+++ b/ogr/swq_parser.hpp
@@ -36,10 +36,10 @@
    private implementation details that can be changed or removed.  */
 
 #ifndef YY_SWQ_SWQ_PARSER_HPP_INCLUDED
-#define YY_SWQ_SWQ_PARSER_HPP_INCLUDED
+# define YY_SWQ_SWQ_PARSER_HPP_INCLUDED
 /* Debug traces.  */
 #ifndef YYDEBUG
-#define YYDEBUG 0
+# define YYDEBUG 0
 #endif
 #if YYDEBUG
 extern int swqdebug;
@@ -47,62 +47,66 @@ extern int swqdebug;
 
 /* Token kinds.  */
 #ifndef YYTOKENTYPE
-#define YYTOKENTYPE
-
-enum yytokentype
-{
+# define YYTOKENTYPE
+  enum yytokentype
+  {
     YYEMPTY = -2,
-    END = 0,                    /* "end of string"  */
-    YYerror = 256,              /* error  */
-    YYUNDEF = 257,              /* "invalid token"  */
-    SWQT_INTEGER_NUMBER = 258,  /* "integer number"  */
-    SWQT_FLOAT_NUMBER = 259,    /* "floating point number"  */
-    SWQT_STRING = 260,          /* "string"  */
-    SWQT_IDENTIFIER = 261,      /* "identifier"  */
-    SWQT_IN = 262,              /* "IN"  */
-    SWQT_LIKE = 263,            /* "LIKE"  */
-    SWQT_ILIKE = 264,           /* "ILIKE"  */
-    SWQT_ESCAPE = 265,          /* "ESCAPE"  */
-    SWQT_BETWEEN = 266,         /* "BETWEEN"  */
-    SWQT_NULL = 267,            /* "NULL"  */
-    SWQT_IS = 268,              /* "IS"  */
-    SWQT_SELECT = 269,          /* "SELECT"  */
-    SWQT_LEFT = 270,            /* "LEFT"  */
-    SWQT_JOIN = 271,            /* "JOIN"  */
-    SWQT_WHERE = 272,           /* "WHERE"  */
-    SWQT_ON = 273,              /* "ON"  */
-    SWQT_ORDER = 274,           /* "ORDER"  */
-    SWQT_BY = 275,              /* "BY"  */
-    SWQT_FROM = 276,            /* "FROM"  */
-    SWQT_AS = 277,              /* "AS"  */
-    SWQT_ASC = 278,             /* "ASC"  */
-    SWQT_DESC = 279,            /* "DESC"  */
-    SWQT_DISTINCT = 280,        /* "DISTINCT"  */
-    SWQT_CAST = 281,            /* "CAST"  */
-    SWQT_UNION = 282,           /* "UNION"  */
-    SWQT_ALL = 283,             /* "ALL"  */
-    SWQT_LIMIT = 284,           /* "LIMIT"  */
-    SWQT_OFFSET = 285,          /* "OFFSET"  */
-    SWQT_EXCEPT = 286,          /* "EXCEPT"  */
-    SWQT_EXCLUDE = 287,         /* "EXCLUDE"  */
-    SWQT_VALUE_START = 288,     /* SWQT_VALUE_START  */
-    SWQT_SELECT_START = 289,    /* SWQT_SELECT_START  */
-    SWQT_NOT = 290,             /* "NOT"  */
-    SWQT_OR = 291,              /* "OR"  */
-    SWQT_AND = 292,             /* "AND"  */
-    SWQT_UMINUS = 293,          /* SWQT_UMINUS  */
-    SWQT_RESERVED_KEYWORD = 294 /* "reserved keyword"  */
-};
-typedef enum yytokentype yytoken_kind_t;
+    END = 0,                       /* "end of string"  */
+    YYerror = 256,                 /* error  */
+    YYUNDEF = 257,                 /* "invalid token"  */
+    SWQT_INTEGER_NUMBER = 258,     /* "integer number"  */
+    SWQT_FLOAT_NUMBER = 259,       /* "floating point number"  */
+    SWQT_STRING = 260,             /* "string"  */
+    SWQT_IDENTIFIER = 261,         /* "identifier"  */
+    SWQT_IN = 262,                 /* "IN"  */
+    SWQT_LIKE = 263,               /* "LIKE"  */
+    SWQT_ILIKE = 264,              /* "ILIKE"  */
+    SWQT_ESCAPE = 265,             /* "ESCAPE"  */
+    SWQT_BETWEEN = 266,            /* "BETWEEN"  */
+    SWQT_NULL = 267,               /* "NULL"  */
+    SWQT_IS = 268,                 /* "IS"  */
+    SWQT_SELECT = 269,             /* "SELECT"  */
+    SWQT_LEFT = 270,               /* "LEFT"  */
+    SWQT_JOIN = 271,               /* "JOIN"  */
+    SWQT_WHERE = 272,              /* "WHERE"  */
+    SWQT_ON = 273,                 /* "ON"  */
+    SWQT_ORDER = 274,              /* "ORDER"  */
+    SWQT_BY = 275,                 /* "BY"  */
+    SWQT_FROM = 276,               /* "FROM"  */
+    SWQT_AS = 277,                 /* "AS"  */
+    SWQT_ASC = 278,                /* "ASC"  */
+    SWQT_DESC = 279,               /* "DESC"  */
+    SWQT_DISTINCT = 280,           /* "DISTINCT"  */
+    SWQT_CAST = 281,               /* "CAST"  */
+    SWQT_UNION = 282,              /* "UNION"  */
+    SWQT_ALL = 283,                /* "ALL"  */
+    SWQT_LIMIT = 284,              /* "LIMIT"  */
+    SWQT_OFFSET = 285,             /* "OFFSET"  */
+    SWQT_EXCEPT = 286,             /* "EXCEPT"  */
+    SWQT_EXCLUDE = 287,            /* "EXCLUDE"  */
+    SWQT_HIDDEN = 288,             /* "HIDDEN"  */
+    SWQT_VALUE_START = 289,        /* SWQT_VALUE_START  */
+    SWQT_SELECT_START = 290,       /* SWQT_SELECT_START  */
+    SWQT_NOT = 291,                /* "NOT"  */
+    SWQT_OR = 292,                 /* "OR"  */
+    SWQT_AND = 293,                /* "AND"  */
+    SWQT_UMINUS = 294,             /* SWQT_UMINUS  */
+    SWQT_RESERVED_KEYWORD = 295    /* "reserved keyword"  */
+  };
+  typedef enum yytokentype yytoken_kind_t;
 #endif
 
 /* Value type.  */
-#if !defined YYSTYPE && !defined YYSTYPE_IS_DECLARED
+#if ! defined YYSTYPE && ! defined YYSTYPE_IS_DECLARED
 typedef int YYSTYPE;
-#define YYSTYPE_IS_TRIVIAL 1
-#define YYSTYPE_IS_DECLARED 1
+# define YYSTYPE_IS_TRIVIAL 1
+# define YYSTYPE_IS_DECLARED 1
 #endif
 
-int swqparse(swq_parse_context *context);
+
+
+
+int swqparse (swq_parse_context *context);
+
 
 #endif /* !YY_SWQ_SWQ_PARSER_HPP_INCLUDED  */

--- a/scripts/cppcheck.sh
+++ b/scripts/cppcheck.sh
@@ -172,6 +172,12 @@ mv ${LOG_FILE}.tmp ${LOG_FILE}
 grep -v -e "stlIfStrFind" ${LOG_FILE} > ${LOG_FILE}.tmp
 mv ${LOG_FILE}.tmp ${LOG_FILE}
 
+# False positive in swq_parser.cpp
+grep -v -e "The expression '0 <= yystate' is always true" ${LOG_FILE} > ${LOG_FILE}.tmp
+mv ${LOG_FILE}.tmp ${LOG_FILE}
+grep -v -e "The comparison '0 <= yystate' is always true" ${LOG_FILE} > ${LOG_FILE}.tmp
+mv ${LOG_FILE}.tmp ${LOG_FILE}
+
 if grep "null pointer" ${LOG_FILE} ; then
     echo "Null pointer check failed"
     ret_code=1


### PR DESCRIPTION
This is a bit inspired by the HIDDEN keyword used by some other SQL implementations, but generally in other contexts, such as hidden columns in SQLite3 virtual tables (https://www.sqlite.org/vtab.html) or MySQL invisible columns (https://dev.mysql.com/doc/refman/8.4/en/invisible-columns.html), although those are in a CREATE TABLE context.
    
Fixes #10259

@elpaso / @dbaston  opinions?

Other alternatives I considered by decreasing order of appeal:
- having OGRGenSQLResultsLayer consider a field name "OGR_STYLE_HIDDEN" to mean "take that field value to set SetStyleString() but do not expose it"
- having some config option (OGR_STYLE_HIDDEN=YES) read by OGRGenSQLResultsLayer to do the same
- always hide OGR_STYLE (but only when it is used in the form "expression AS OGR_STYLE", not just "OGR_STYLE" from source layer), although this has the potential for breaking some workflows
- per-driver options (no, we definitely don't want that)

One downside of the implementation is that it makes 'HIDDEN' a reserved keyword, so any field/table with that name must now be quoted, although I could probably tune the BNF to accept 'HIDDEN' as an identifier as I don't think there would be grammar ambiguity in doing so (to be tested...)

I finally selected the HIDDEN SQL keyword because we might potentially use it for other situations (potentially to do things like "SELECT my_id_field AS FID HIDDEN, ..." to set the FID  (we can currently select the source fid with SELECT FID ... but not set it)