### PR TITLE
[Backport release/3.9] SQLite/GPKG: detect UNIQUE constraints expressed as a ', CONSTRAINT name UNIQUE (column_name)' at the end of CREATE TABLE

### DIFF
--- a/autotest/ogr/ogr_sqlite.py
+++ b/autotest/ogr/ogr_sqlite.py
@@ -3314,7 +3314,7 @@ def test_ogr_sqlite_unique(tmp_vsimem):
     # and indexes
     # Note: leave create table in a single line because of regex spaces testing
     sql = (
-        'CREATE TABLE IF NOT EXISTS "test2" ( "fid" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,\n"field_default" TEXT, "field_no_unique" TEXT DEFAULT \'UNIQUE\',"field_unique" TEXT UNIQUE,`field unique2` TEXT UNIQUE,field_unique3 TEXT UNIQUE, FIELD_UNIQUE_INDEX TEXT, `field unique index2`, "field_unique_index3" TEXT, NOT_UNIQUE TEXT);',
+        'CREATE TABLE IF NOT EXISTS "test2" ( "fid" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,\n"field_default" TEXT, "field_no_unique" TEXT DEFAULT \'UNIQUE\',"field_unique" TEXT UNIQUE,`field unique2` TEXT UNIQUE,field_unique3 TEXT UNIQUE, FIELD_UNIQUE_INDEX TEXT, `field unique index2`, "field_unique_index3" TEXT, NOT_UNIQUE TEXT,field4 TEXT,field5 TEXT,field6 TEXT,CONSTRAINT ignored_constraint CHECK (fid >= 0),CONSTRAINT field5_6_uniq UNIQUE (field5, field6), CONSTRAINT field4_uniq UNIQUE (field4));',
         "CREATE UNIQUE INDEX test2_unique_idx ON test2(field_unique_index);",  # field_unique_index in lowercase whereas in uppercase in CREATE TABLE statement
         "CREATE UNIQUE INDEX test2_unique_idx2 ON test2(`field unique index2`);",
         'CREATE UNIQUE INDEX test2_unique_idx3 ON test2("field_unique_index3");',
@@ -3363,6 +3363,14 @@ def test_ogr_sqlite_unique(tmp_vsimem):
     assert fldDef.IsUnique()
 
     fldDef = layerDefinition.GetFieldDefn(8)
+    assert not fldDef.IsUnique()
+
+    # Constraint given by CONSTRAINT field4_uniq UNIQUE (field4)
+    fldDef = layerDefinition.GetFieldDefn(layerDefinition.GetFieldIndex("field4"))
+    assert fldDef.IsUnique()
+
+    # Constraint given by CONSTRAINT field5_6_uniq UNIQUE (field5, field6) ==> ignored
+    fldDef = layerDefinition.GetFieldDefn(layerDefinition.GetFieldIndex("field5"))
     assert not fldDef.IsUnique()
 
     ds = None


### PR DESCRIPTION
Backport #10262
 **Authored by:** @rouault