### PR TITLE
OGR SQL: avoid going through string serialization for MIN(), MAX(), SUM(), AVG() on numeric fields

### DIFF
--- a/ogr/ogr_swq.h
+++ b/ogr/ogr_swq.h
@@ -487,9 +487,15 @@ class CPL_UNSTABLE_API swq_select
     std::map<int, std::list<swq_col_def>> m_exclude_fields{};
 };
 
+/* This method should generally be invoked with pszValue set, except when
+ * called on a non-DISTINCT column definition of numeric type (SWQ_BOOLEAN,
+ * SWQ_INTEGER, SWQ_INTEGER64, SWQ_FLOAT), in which case pdfValue should
+ * rather be set.
+ */
 const char CPL_UNSTABLE_API *swq_select_summarize(swq_select *select_info,
                                                   int dest_column,
-                                                  const char *value);
+                                                  const char *pszValue,
+                                                  const double *pdfValue);
 
 int CPL_UNSTABLE_API swq_is_reserved_keyword(const char *pszStr);
 

--- a/ogr/ogr_swq.h
+++ b/ogr/ogr_swq.h
@@ -356,11 +356,22 @@ class CPL_UNSTABLE_API swq_summary
         bool operator()(const CPLString &, const CPLString &) const;
     };
 
+    //! Return the sum, using Kahan-Babuska-Neumaier algorithm.
+    // Cf cf KahanBabushkaNeumaierSum of https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements
+    double sum() const
+    {
+        return sum_only_finite_terms ? sum_acc + sum_correction : sum_acc;
+    }
+
     GIntBig count = 0;
 
     std::vector<CPLString> oVectorDistinctValues{};
     std::set<CPLString, Comparator> oSetDistinctValues{};
-    double sum = 0.0;
+    bool sum_only_finite_terms = true;
+    // Sum accumulator. To get the accurate sum, use the sum() method
+    double sum_acc = 0.0;
+    // Sum correction term.
+    double sum_correction = 0.0;
     double min = 0.0;
     double max = 0.0;
     CPLString osMin{};

--- a/ogr/ogrsf_frmts/generic/ogr_gensql.cpp
+++ b/ogr/ogrsf_frmts/generic/ogr_gensql.cpp
@@ -992,7 +992,7 @@ bool OGRGenSQLResultsLayer::PrepareSummary()
 
         for (int iField = 0; iField < psSelectInfo->result_columns(); iField++)
         {
-            swq_col_def *psColDef = &psSelectInfo->column_defs[iField];
+            const swq_col_def *psColDef = &psSelectInfo->column_defs[iField];
             if (!psSelectInfo->column_summary.empty())
             {
                 const swq_summary &oSummary =
@@ -1000,12 +1000,12 @@ bool OGRGenSQLResultsLayer::PrepareSummary()
 
                 if (psColDef->col_func == SWQCF_AVG && oSummary.count > 0)
                 {
+                    const double dfAvg = oSummary.sum() / oSummary.count;
                     if (psColDef->field_type == SWQ_DATE ||
                         psColDef->field_type == SWQ_TIME ||
                         psColDef->field_type == SWQ_TIMESTAMP)
                     {
                         struct tm brokendowntime;
-                        double dfAvg = oSummary.sum / oSummary.count;
                         CPLUnixTimeToYMDHMS(static_cast<GIntBig>(dfAvg),
                                             &brokendowntime);
                         m_poSummaryFeature->SetField(
@@ -1017,8 +1017,9 @@ bool OGRGenSQLResultsLayer::PrepareSummary()
                             0);
                     }
                     else
-                        m_poSummaryFeature->SetField(
-                            iField, oSummary.sum / oSummary.count);
+                    {
+                        m_poSummaryFeature->SetField(iField, dfAvg);
+                    }
                 }
                 else if (psColDef->col_func == SWQCF_MIN && oSummary.count > 0)
                 {
@@ -1045,7 +1046,7 @@ bool OGRGenSQLResultsLayer::PrepareSummary()
                 else if (psColDef->col_func == SWQCF_COUNT)
                     m_poSummaryFeature->SetField(iField, oSummary.count);
                 else if (psColDef->col_func == SWQCF_SUM && oSummary.count > 0)
-                    m_poSummaryFeature->SetField(iField, oSummary.sum);
+                    m_poSummaryFeature->SetField(iField, oSummary.sum());
             }
             else if (psColDef->col_func == SWQCF_COUNT)
                 m_poSummaryFeature->SetField(iField, 0);

--- a/ogr/swq.cpp
+++ b/ogr/swq.cpp
@@ -323,7 +323,7 @@ int swqlex(YYSTYPE *ppNode, swq_parse_context *context)
 /************************************************************************/
 
 const char *swq_select_summarize(swq_select *select_info, int dest_column,
-                                 const char *value)
+                                 const char *pszValue, const double *pdfValue)
 
 {
     /* -------------------------------------------------------------------- */
@@ -336,7 +336,7 @@ const char *swq_select_summarize(swq_select *select_info, int dest_column,
         dest_column >= static_cast<int>(select_info->column_defs.size()))
         return "dest_column out of range in swq_select_summarize().";
 
-    swq_col_def *def = &select_info->column_defs[dest_column];
+    const swq_col_def *def = &select_info->column_defs[dest_column];
     if (def->col_func == SWQCF_NONE && !def->distinct_flag)
         return nullptr;
 
@@ -403,18 +403,18 @@ const char *swq_select_summarize(swq_select *select_info, int dest_column,
 
     if (def->distinct_flag)
     {
-        if (value == nullptr)
-            value = SZ_OGR_NULL;
+        if (pszValue == nullptr)
+            pszValue = SZ_OGR_NULL;
         try
         {
-            if (summary.oSetDistinctValues.find(value) ==
+            if (summary.oSetDistinctValues.find(pszValue) ==
                 summary.oSetDistinctValues.end())
             {
-                summary.oSetDistinctValues.insert(value);
+                summary.oSetDistinctValues.insert(pszValue);
                 if (select_info->order_specs == 0)
                 {
                     // If not sorted, keep values in their original order
-                    summary.oVectorDistinctValues.emplace_back(value);
+                    summary.oVectorDistinctValues.emplace_back(pszValue);
                 }
                 summary.count++;
             }
@@ -434,59 +434,78 @@ const char *swq_select_summarize(swq_select *select_info, int dest_column,
     switch (def->col_func)
     {
         case SWQCF_MIN:
-            if (value != nullptr && value[0] != '\0')
+            if (pdfValue)
             {
-                if (def->field_type == SWQ_DATE ||
-                    def->field_type == SWQ_TIME ||
-                    def->field_type == SWQ_TIMESTAMP ||
-                    def->field_type == SWQ_STRING)
+                if (*pdfValue < summary.min)
+                    summary.min = *pdfValue;
+                summary.count++;
+            }
+            else if (pszValue && pszValue[0] != '\0')
+            {
+                if (summary.count == 0 || strcmp(pszValue, summary.osMin) < 0)
                 {
-                    if (summary.count == 0 || strcmp(value, summary.osMin) < 0)
-                    {
-                        summary.osMin = value;
-                    }
-                }
-                else
-                {
-                    double df_val = CPLAtof(value);
-                    if (df_val < summary.min)
-                        summary.min = df_val;
+                    summary.osMin = pszValue;
                 }
                 summary.count++;
             }
             break;
         case SWQCF_MAX:
-            if (value != nullptr && value[0] != '\0')
+            if (pdfValue)
             {
-                if (def->field_type == SWQ_DATE ||
-                    def->field_type == SWQ_TIME ||
-                    def->field_type == SWQ_TIMESTAMP ||
-                    def->field_type == SWQ_STRING)
+                if (*pdfValue > summary.max)
+                    summary.max = *pdfValue;
+                summary.count++;
+            }
+            else if (pszValue && pszValue[0] != '\0')
+            {
+                if (summary.count == 0 || strcmp(pszValue, summary.osMax) > 0)
                 {
-                    if (summary.count == 0 || strcmp(value, summary.osMax) > 0)
-                    {
-                        summary.osMax = value;
-                    }
-                }
-                else
-                {
-                    double df_val = CPLAtof(value);
-                    if (df_val > summary.max)
-                        summary.max = df_val;
+                    summary.osMax = pszValue;
                 }
                 summary.count++;
             }
             break;
         case SWQCF_AVG:
         case SWQCF_SUM:
-            if (value != nullptr && value[0] != '\0')
+            if (pdfValue)
+            {
+                summary.count++;
+
+                // Cf KahanBabushkaNeumaierSum of
+                // https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements
+                // We set a number of temporary variables as volatile, to
+                // prevent potential undesired compiler optimizations.
+
+                const double dfNewVal = *pdfValue;
+                const volatile double new_sum_acc = summary.sum_acc + dfNewVal;
+                if (summary.sum_only_finite_terms && std::isfinite(dfNewVal))
+                {
+                    if (std::fabs(summary.sum_acc) >= std::fabs(dfNewVal))
+                    {
+                        const volatile double diff =
+                            (summary.sum_acc - new_sum_acc);
+                        summary.sum_correction += (diff + dfNewVal);
+                    }
+                    else
+                    {
+                        const volatile double diff = (dfNewVal - new_sum_acc);
+                        summary.sum_correction += (diff + summary.sum_acc);
+                    }
+                }
+                else
+                {
+                    summary.sum_only_finite_terms = false;
+                }
+                summary.sum_acc = new_sum_acc;
+            }
+            else if (pszValue && pszValue[0] != '\0')
             {
                 if (def->field_type == SWQ_DATE ||
                     def->field_type == SWQ_TIME ||
                     def->field_type == SWQ_TIMESTAMP)
                 {
                     OGRField sField;
-                    if (OGRParseDate(value, &sField, 0))
+                    if (OGRParseDate(pszValue, &sField, 0))
                     {
                         struct tm brokendowntime;
                         brokendowntime.tm_year = sField.Date.Year - 1900;
@@ -504,43 +523,14 @@ const char *swq_select_summarize(swq_select *select_info, int dest_column,
                 }
                 else
                 {
-                    summary.count++;
-
-                    // Cf KahanBabushkaNeumaierSum of
-                    // https://en.wikipedia.org/wiki/Kahan_summation_algorithm#Further_enhancements
-                    // We set a number of temporary variables as volatile, to
-                    // prevent potential undesired compiler optimizations.
-
-                    const double dfNewVal = CPLAtof(value);
-                    const volatile double new_sum_acc =
-                        summary.sum_acc + dfNewVal;
-                    if (summary.sum_only_finite_terms &&
-                        std::isfinite(dfNewVal))
-                    {
-                        if (std::fabs(summary.sum_acc) >= std::fabs(dfNewVal))
-                        {
-                            const volatile double diff =
-                                (summary.sum_acc - new_sum_acc);
-                            summary.sum_correction += (diff + dfNewVal);
-                        }
-                        else
-                        {
-                            const volatile double diff =
-                                (dfNewVal - new_sum_acc);
-                            summary.sum_correction += (diff + summary.sum_acc);
-                        }
-                    }
-                    else
-                    {
-                        summary.sum_only_finite_terms = false;
-                    }
-                    summary.sum_acc = new_sum_acc;
+                    return "swq_select_summarize() - AVG()/SUM() called on "
+                           "unexpected field type";
                 }
             }
             break;
 
         case SWQCF_COUNT:
-            if (value != nullptr)
+            if (pdfValue || pszValue)
                 summary.count++;
             break;
 


### PR DESCRIPTION
(on top of PR #10278)