### PR TITLE
ogr2ogr: error out if WKT argument of -clipsrc/-clipdst is an invalid geometry

### DIFF
--- a/apps/gdal_utils_priv.h
+++ b/apps/gdal_utils_priv.h
@@ -85,6 +85,7 @@ struct GDALVectorTranslateOptionsForBinary
     CPLStringList aosOpenOptions{};
     std::string osFormat;
     GDALVectorTranslateAccessMode eAccessMode = ACCESS_CREATION;
+    bool bShowUsageIfError = false;
 
     /* Allowed input drivers. */
     CPLStringList aosAllowInputDrivers{};

--- a/apps/ogr2ogr_bin.cpp
+++ b/apps/ogr2ogr_bin.cpp
@@ -104,7 +104,8 @@ MAIN_START(nArgc, papszArgv)
 
     if (psOptions == nullptr)
     {
-        Usage();
+        if (sOptionsForBinary.bShowUsageIfError)
+            Usage();
         goto exit;
     }
 

--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -667,20 +667,33 @@ static std::unique_ptr<OGRGeometry> LoadGeometry(const std::string &osDS,
                         CPLError(CE_Failure, CPLE_AppDefined,
                                  "Geometry of feature " CPL_FRMT_GIB " of %s "
                                  "is invalid. You can try to make it valid by "
-                                 "specifying -makevalid",
+                                 "specifying -makevalid, but the results of "
+                                 "the operation should be manually inspected.",
                                  poFeat->GetFID(), osDS.c_str());
                         oGC.empty();
                         break;
                     }
-                    CPLError(CE_Warning, CPLE_AppDefined,
-                             "Geometry of feature " CPL_FRMT_GIB " of %s "
-                             "is invalid. Trying to make it valid",
-                             poFeat->GetFID(), osDS.c_str());
                     auto poValid =
                         std::unique_ptr<OGRGeometry>(poSrcGeom->MakeValid());
                     if (poValid)
                     {
+                        CPLError(CE_Warning, CPLE_AppDefined,
+                                 "Geometry of feature " CPL_FRMT_GIB " of %s "
+                                 "was invalid and has been made valid, "
+                                 "but the results of the operation "
+                                 "should be manually inspected.",
+                                 poFeat->GetFID(), osDS.c_str());
+
                         oGC.addGeometryDirectly(poValid.release());
+                    }
+                    else
+                    {
+                        CPLError(CE_Failure, CPLE_AppDefined,
+                                 "Geometry of feature " CPL_FRMT_GIB " of %s "
+                                 "is invalid, and could not been made valid.",
+                                 poFeat->GetFID(), osDS.c_str());
+                        oGC.empty();
+                        break;
                     }
                 }
                 else
@@ -2346,7 +2359,8 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
         {
             CPLError(CE_Failure, CPLE_IllegalArg,
                      "-clipsrc geometry is invalid. You can try to make it "
-                     "valid with -makevalid");
+                     "valid with -makevalid, but the results of the operation "
+                     "should be manually inspected.");
             return nullptr;
         }
         auto poValid =
@@ -2354,9 +2368,13 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
         if (!poValid)
         {
             CPLError(CE_Failure, CPLE_IllegalArg,
-                     "-clipsrc geometry is invalid and cannot be made valid");
+                     "-clipsrc geometry is invalid and cannot be made valid.");
             return nullptr;
         }
+        CPLError(CE_Warning, CPLE_AppDefined,
+                 "-clipsrc geometry was invalid and has been made valid, "
+                 "but the results of the operation "
+                 "should be manually inspected.");
         psOptions->poClipSrc = std::move(poValid);
     }
 
@@ -2379,7 +2397,8 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
         {
             CPLError(CE_Failure, CPLE_IllegalArg,
                      "-clipdst geometry is invalid. You can try to make it "
-                     "valid with -makevalid");
+                     "valid with -makevalid, but the results of the operation "
+                     "should be manually inspected.");
             return nullptr;
         }
         auto poValid =
@@ -2387,9 +2406,13 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
         if (!poValid)
         {
             CPLError(CE_Failure, CPLE_IllegalArg,
-                     "-clipdst geometry is invalid and cannot be made valid");
+                     "-clipdst geometry is invalid and cannot be made valid.");
             return nullptr;
         }
+        CPLError(CE_Warning, CPLE_AppDefined,
+                 "-clipdst geometry was invalid and has been made valid, "
+                 "but the results of the operation "
+                 "should be manually inspected.");
         psOptions->poClipDst = std::move(poValid);
     }
 


### PR DESCRIPTION
If specifying -makevalid, MakeValid() will be run on it to make it valid.

For consistency, change behavior of -clipsrc/-clipdst {datasetname} to not automatically make valid invalid clip geometries, but do it only if -makevalid is specified.

Fixes #10289
