### PR TITLE
OSM: add a [general] section at top of osmconf.ini to make it INI compliant (and Python's configparser friendly)

### DIFF
--- a/autotest/ogr/ogr_osm.py
+++ b/autotest/ogr/ogr_osm.py
@@ -929,3 +929,21 @@ def test_ogr_osm_tags_json_special_characters():
     assert lyr_defn.GetFieldDefn(other_tags_idx).GetSubType() == ogr.OFSTJSON
     f = lyr.GetNextFeature()
     assert f["other_tags"] == """{"foo":"x'\\\\\\"\\t\\n\\ry"}"""
+
+
+###############################################################################
+# Test that osmconf.ini can be parsed with Python's configparser
+
+
+def test_ogr_osmconf_ini():
+
+    import configparser
+
+    with ogr.Open("data/osm/test_json.pbf") as ds:
+        with ds.ExecuteSQL("SHOW config_file_path") as sql_lyr:
+            f = sql_lyr.GetNextFeature()
+            osmconf_ini_filename = f.GetField(0)
+            config = configparser.ConfigParser()
+            config.read_file(open(osmconf_ini_filename))
+            assert "general" in config
+            assert "closed_ways_are_polygons" in config["general"]

--- a/ogr/ogrsf_frmts/osm/data/osmconf.ini
+++ b/ogr/ogrsf_frmts/osm/data/osmconf.ini
@@ -1,6 +1,8 @@
 #
 # Configuration file for importing OSM data into OGR
 #
+# NOTE: remove the below "[general]" line for GDAL < 3.10
+[general]
 
 # put here the name of keys, or key=value, for ways that are assumed to be polygons if they are closed
 # see http://wiki.openstreetmap.org/wiki/Map_Features

--- a/ogr/ogrsf_frmts/osm/ogr_osm.h
+++ b/ogr/ogrsf_frmts/osm/ogr_osm.h
@@ -394,6 +394,8 @@ class OGROSMDataSource final : public OGRDataSource
     std::vector<std::unique_ptr<OGROSMLayer>> m_apoLayers{};
     char *m_pszName = nullptr;
 
+    std::string m_osConfigFile{};
+
     OGREnvelope m_sExtent{};
     bool m_bExtentValid = false;
 

--- a/ogr/ogrsf_frmts/osm/ogrosmdatasource.cpp
+++ b/ogr/ogrsf_frmts/osm/ogrosmdatasource.cpp
@@ -3400,6 +3400,8 @@ bool OGROSMDataSource::ParseConf(char **papszOpenOptionsIn)
         return false;
     }
 
+    m_osConfigFile = pszFilename;
+
     VSILFILE *fpConf = VSIFOpenL(pszFilename, "rb");
     if (fpConf == nullptr)
         return false;
@@ -3422,6 +3424,12 @@ bool OGROSMDataSource::ParseConf(char **papszOpenOptionsIn)
             pszLine++;
             const_cast<char *>(pszLine)[strlen(pszLine) - 1] =
                 '\0'; /* Evil but OK */
+
+            if (strcmp(pszLine, "general") == 0)
+            {
+                continue;
+            }
+
             int i = 0;
             for (auto &&poLayer : m_apoLayers)
             {
@@ -4383,6 +4391,15 @@ OGRLayer *OGROSMDataSource::ExecuteSQL(const char *pszSQLCommand,
         snprintf(szVal, sizeof(szVal), CPL_FRMT_GUIB,
                  OSM_GetBytesRead(m_psParser));
         return new OGROSMSingleFeatureLayer("GetBytesRead", szVal);
+    }
+
+    /* -------------------------------------------------------------------- */
+    /*      Special SHOW config_file_path command                           */
+    /* -------------------------------------------------------------------- */
+    if (strcmp(pszSQLCommand, "SHOW config_file_path") == 0)
+    {
+        return new OGROSMSingleFeatureLayer("config_file_path",
+                                            m_osConfigFile.c_str());
     }
 
     if (m_poResultSetLayer != nullptr)


### PR DESCRIPTION
Refs https://github.com/geopandas/pyogrio/issues/419#issuecomment-2187640864
