### PR TITLE
JP2Grok: new Grok JPEG 2000 driver based on Grok JPEG 2000 Library

### DIFF
--- a/autotest/gdrivers/jp2grok.py
+++ b/autotest/gdrivers/jp2grok.py
@@ -1,0 +1,3850 @@
+#!/usr/bin/env pytest
+# -*- coding: utf-8 -*-
+###############################################################################
+# $Id$
+#
+# Project:  GDAL/OGR Test Suite
+# Purpose:  Test read/write functionality for JP2Grok driver.
+# Author:   Even Rouault <even dot rouault at spatialys.com>
+# Author:   Aaron Boxer <boxerab at protonmail.com>
+#
+###############################################################################
+# Copyright (c) 2010-2013, Even Rouault <even dot rouault at spatialys.com>
+# Copyright (c) 2023, Grok Image Compression Inc.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+# OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+# FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+# DEALINGS IN THE SOFTWARE.
+###############################################################################
+
+import os
+import shutil
+import sys
+
+import gdaltest
+import pytest
+import webserver
+from test_py_scripts import samples_path
+
+from osgeo import gdal, ogr, osr
+
+pytestmark = pytest.mark.require_driver("JP2Grok")
+
+###############################################################################
+@pytest.fixture(autouse=True, scope="module")
+def module_disable_exceptions():
+    with gdaltest.disable_exceptions():
+        yield
+
+
+###############################################################################
+@pytest.fixture(autouse=True, scope="module")
+def startup_and_cleanup():
+
+    gdaltest.jp2openjpeg_drv = gdal.GetDriverByName("JP2Grok")
+    assert gdaltest.jp2openjpeg_drv is not None
+
+    gdaltest.deregister_all_jpeg2000_drivers_but("JP2Grok")
+
+    yield
+
+    gdaltest.reregister_all_jpeg2000_drivers()
+
+
+###############################################################################
+# Open byte.jp2
+
+
+def test_jp2openjpeg_2():
+
+    srs = """PROJCS["NAD27 / UTM zone 11N",
+    GEOGCS["NAD27",
+        DATUM["North_American_Datum_1927",
+            SPHEROID["Clarke 1866",6378206.4,294.9786982138982,
+                AUTHORITY["EPSG","7008"]],
+            AUTHORITY["EPSG","6267"]],
+        PRIMEM["Greenwich",0],
+        UNIT["degree",0.0174532925199433],
+        AUTHORITY["EPSG","4267"]],
+    PROJECTION["Transverse_Mercator"],
+    PARAMETER["latitude_of_origin",0],
+    PARAMETER["central_meridian",-117],
+    PARAMETER["scale_factor",0.9996],
+    PARAMETER["false_easting",500000],
+    PARAMETER["false_northing",0],
+    UNIT["metre",1,
+        AUTHORITY["EPSG","9001"]],
+    AUTHORITY["EPSG","26711"]]
+"""
+    gt = (440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0)
+
+    tst = gdaltest.GDALTest("JP2Grok", "jpeg2000/byte.jp2", 1, 50054)
+    tst.testOpen(check_prj=srs, check_gt=gt)
+
+
+###############################################################################
+# Open int16.jp2
+
+
+def test_jp2openjpeg_3():
+
+    ds = gdal.Open("data/jpeg2000/int16.jp2")
+    ds_ref = gdal.Open("data/int16.tif")
+
+    # 9x7 wavelet
+    assert ds.GetMetadata("IMAGE_STRUCTURE")["COMPRESSION_REVERSIBILITY"] == "LOSSY"
+    assert ds.GetMetadata("IMAGE_STRUCTURE")["COMPRESSION_REVERSIBILITY"] == "LOSSY"
+    assert ds.GetMetadataItem("COMPRESSION_REVERSIBILITY", "IMAGE_STRUCTURE") == "LOSSY"
+
+    maxdiff = gdaltest.compare_ds(ds, ds_ref)
+    # print(ds.GetRasterBand(1).Checksum())
+    # print(ds_ref.GetRasterBand(1).Checksum())
+
+    ds = None
+    ds_ref = None
+
+    # Quite a bit of difference...
+    assert maxdiff <= 6, "Image too different from reference"
+
+    ds = ogr.Open("data/jpeg2000/int16.jp2")
+    assert ds is None
+
+
+###############################################################################
+# Test copying byte.jp2
+
+
+def test_jp2openjpeg_4(out_filename="tmp/jp2openjpeg_4.jp2"):
+
+    src_ds = gdal.Open("data/jpeg2000/byte.jp2")
+    # 5x3 wavelet with Kakadu < 6.4 last layer at -256.0
+    assert (
+        src_ds.GetMetadataItem("COMPRESSION_REVERSIBILITY", "IMAGE_STRUCTURE")
+        == "LOSSLESS"
+    )
+    src_wkt = src_ds.GetProjectionRef()
+    src_gt = src_ds.GetGeoTransform()
+
+    vrt_ds = gdal.GetDriverByName("VRT").CreateCopy("/vsimem/jp2openjpeg_4.vrt", src_ds)
+    vrt_ds.SetMetadataItem("TIFFTAG_XRESOLUTION", "300")
+    vrt_ds.SetMetadataItem("TIFFTAG_YRESOLUTION", "200")
+    vrt_ds.SetMetadataItem("TIFFTAG_RESOLUTIONUNIT", "3 (pixels/cm)")
+
+    gdal.Unlink(out_filename)
+
+    out_ds = gdal.GetDriverByName("JP2Grok").CreateCopy(
+        out_filename, vrt_ds, options=["REVERSIBLE=YES", "QUALITY=100"]
+    )
+    del out_ds
+
+    vrt_ds = None
+    gdal.Unlink("/vsimem/jp2openjpeg_4.vrt")
+
+    assert gdal.VSIStatL(out_filename + ".aux.xml") is None
+
+    ds = gdal.Open(out_filename)
+    assert (
+        ds.GetMetadataItem("COMPRESSION_REVERSIBILITY", "IMAGE_STRUCTURE") == "LOSSLESS"
+    )
+    cs = ds.GetRasterBand(1).Checksum()
+    got_wkt = ds.GetProjectionRef()
+    got_gt = ds.GetGeoTransform()
+    xres = ds.GetMetadataItem("TIFFTAG_XRESOLUTION")
+    yres = ds.GetMetadataItem("TIFFTAG_YRESOLUTION")
+    resunit = ds.GetMetadataItem("TIFFTAG_RESOLUTIONUNIT")
+    ds = None
+
+    gdal.Unlink(out_filename)
+
+    assert (
+        xres == "300" and yres == "200" and resunit == "3 (pixels/cm)"
+    ), "bad resolution"
+
+    sr1 = osr.SpatialReference()
+    sr1.SetFromUserInput(got_wkt)
+    sr2 = osr.SpatialReference()
+    sr2.SetFromUserInput(src_wkt)
+
+    if sr1.IsSame(sr2) == 0:
+        print(got_wkt)
+        print(src_wkt)
+        pytest.fail("bad spatial reference")
+
+    for i in range(6):
+        assert got_gt[i] == pytest.approx(src_gt[i], abs=1e-8), "bad geotransform"
+
+    assert cs == 50054, "bad checksum"
+
+
+def test_jp2openjpeg_4_vsimem():
+    return test_jp2openjpeg_4("/vsimem/jp2openjpeg_4.jp2")
+
+
+###############################################################################
+# Test copying int16.jp2
+
+
+def test_jp2openjpeg_5():
+
+    tst = gdaltest.GDALTest(
+        "JP2Grok",
+        "jpeg2000/int16.jp2",
+        1,
+        None,
+        options=["REVERSIBLE=YES", "QUALITY=100", "CODEC=J2K"],
+    )
+    tst.testCreateCopy()
+
+
+###############################################################################
+# Test reading ll.jp2
+
+
+def test_jp2openjpeg_6():
+
+    tst = gdaltest.GDALTest("JP2Grok", "jpeg2000/ll.jp2", 1, None)
+    tst.testOpen()
+
+    ds = gdal.Open("data/jpeg2000/ll.jp2")
+    ds.GetRasterBand(1).Checksum()
+    ds = None
+
+
+###############################################################################
+# Open byte.jp2.gz (test use of the VSIL API)
+
+
+def test_jp2openjpeg_7():
+
+    tst = gdaltest.GDALTest(
+        "JP2Grok",
+        "/vsigzip/data/jpeg2000/byte.jp2.gz",
+        1,
+        50054,
+        filename_absolute=1,
+    )
+    tst.testOpen()
+    gdal.Unlink("data/jpeg2000/byte.jp2.gz.properties")
+
+
+###############################################################################
+# Test a JP2OpenJPEG with the 3 bands having 13bit depth and the 4th one 1 bit
+
+
+def test_jp2openjpeg_8():
+
+    ds = gdal.Open("data/jpeg2000/3_13bit_and_1bit.jp2")
+
+    expected_checksums = [64570, 57277, 56048, 61292]
+
+    for i in range(4):
+        assert (
+            ds.GetRasterBand(i + 1).Checksum() == expected_checksums[i]
+        ), "unexpected checksum (%d) for band %d" % (expected_checksums[i], i + 1)
+
+    assert ds.GetRasterBand(1).DataType == gdal.GDT_UInt16, "unexpected data type"
+
+
+###############################################################################
+# Check that we can use .j2w world files (#4651)
+
+
+def test_jp2openjpeg_9():
+
+    ds = gdal.Open("data/jpeg2000/byte_without_geotransform.jp2")
+
+    geotransform = ds.GetGeoTransform()
+    assert (
+        geotransform[0] == pytest.approx(440720, abs=0.1)
+        and geotransform[1] == pytest.approx(60, abs=0.001)
+        and geotransform[2] == pytest.approx(0, abs=0.001)
+        and geotransform[3] == pytest.approx(3751320, abs=0.1)
+        and geotransform[4] == pytest.approx(0, abs=0.001)
+        and geotransform[5] == pytest.approx(-60, abs=0.001)
+    ), "geotransform differs from expected"
+
+    ds = None
+
+
+###############################################################################
+# Test YCBCR420 creation option
+
+
+def test_jp2openjpeg_10():
+
+    src_ds = gdal.Open("data/rgbsmall.tif")
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_10.jp2", src_ds, options=["YCBCR420=YES", "RESOLUTIONS=3"]
+    )
+    maxdiff = gdaltest.compare_ds(src_ds, out_ds)
+    assert out_ds.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_RedBand
+    assert out_ds.GetRasterBand(2).GetColorInterpretation() == gdal.GCI_GreenBand
+    assert out_ds.GetRasterBand(3).GetColorInterpretation() == gdal.GCI_BlueBand
+    del out_ds
+    src_ds = None
+    gdal.Unlink("/vsimem/jp2openjpeg_10.jp2")
+
+    # Quite a bit of difference...
+    assert maxdiff <= 12, "Image too different from reference"
+
+
+###############################################################################
+# Test auto-promotion of 1bit alpha band to 8bit
+
+
+def test_jp2openjpeg_11():
+
+    ds = gdal.Open("data/jpeg2000/stefan_full_rgba_alpha_1bit.jp2")
+    fourth_band = ds.GetRasterBand(4)
+    assert fourth_band.GetMetadataItem("NBITS", "IMAGE_STRUCTURE") is None
+    got_cs = fourth_band.Checksum()
+    assert got_cs == 8527
+    jp2_bands_data = ds.ReadRaster(0, 0, ds.RasterXSize, ds.RasterYSize)
+    jp2_fourth_band_data = fourth_band.ReadRaster(0, 0, ds.RasterXSize, ds.RasterYSize)
+    fourth_band.ReadRaster(
+        0,
+        0,
+        ds.RasterXSize,
+        ds.RasterYSize,
+        int(ds.RasterXSize / 16),
+        int(ds.RasterYSize / 16),
+    )
+
+    tmp_ds = gdal.GetDriverByName("GTiff").CreateCopy("/vsimem/jp2openjpeg_11.tif", ds)
+    fourth_band = tmp_ds.GetRasterBand(4)
+    got_cs = fourth_band.Checksum()
+    gtiff_bands_data = tmp_ds.ReadRaster(0, 0, ds.RasterXSize, ds.RasterYSize)
+    gtiff_fourth_band_data = fourth_band.ReadRaster(
+        0, 0, ds.RasterXSize, ds.RasterYSize
+    )
+    # gtiff_fourth_band_subsampled_data = fourth_band.ReadRaster(0,0,ds.RasterXSize,ds.RasterYSize,ds.RasterXSize/16,ds.RasterYSize/16)
+    tmp_ds = None
+    gdal.GetDriverByName("GTiff").Delete("/vsimem/jp2openjpeg_11.tif")
+    assert got_cs == 8527
+
+    assert jp2_bands_data == gtiff_bands_data
+
+    assert jp2_fourth_band_data == gtiff_fourth_band_data
+
+    ds = gdal.OpenEx(
+        "data/jpeg2000/stefan_full_rgba_alpha_1bit.jp2",
+        open_options=["1BIT_ALPHA_PROMOTION=NO"],
+    )
+    fourth_band = ds.GetRasterBand(4)
+    assert fourth_band.GetMetadataItem("NBITS", "IMAGE_STRUCTURE") == "1"
+
+
+###############################################################################
+# Check that PAM overrides internal georeferencing (#5279)
+
+
+def test_jp2openjpeg_12():
+
+    # Override projection
+    shutil.copy("data/jpeg2000/byte.jp2", "tmp/jp2openjpeg_12.jp2")
+
+    ds = gdal.Open("tmp/jp2openjpeg_12.jp2")
+    sr = osr.SpatialReference()
+    sr.ImportFromEPSG(32631)
+    ds.SetProjection(sr.ExportToWkt())
+    ds = None
+
+    ds = gdal.Open("tmp/jp2openjpeg_12.jp2")
+    wkt = ds.GetProjectionRef()
+    ds = None
+
+    gdaltest.jp2openjpeg_drv.Delete("tmp/jp2openjpeg_12.jp2")
+
+    assert "32631" in wkt
+
+    # Override geotransform
+    shutil.copy("data/jpeg2000/byte.jp2", "tmp/jp2openjpeg_12.jp2")
+
+    ds = gdal.Open("tmp/jp2openjpeg_12.jp2")
+    ds.SetGeoTransform([1000, 1, 0, 2000, 0, -1])
+    ds = None
+
+    ds = gdal.Open("tmp/jp2openjpeg_12.jp2")
+    gt = ds.GetGeoTransform()
+    ds = None
+
+    gdaltest.jp2openjpeg_drv.Delete("tmp/jp2openjpeg_12.jp2")
+
+    assert gt == (1000, 1, 0, 2000, 0, -1)
+
+
+###############################################################################
+# Check that PAM overrides internal GCPs (#5279)
+
+
+def test_jp2openjpeg_13():
+
+    # Create a dataset with GCPs
+    src_ds = gdal.Open("data/rgb_gcp.vrt")
+    ds = gdaltest.jp2openjpeg_drv.CreateCopy("tmp/jp2openjpeg_13.jp2", src_ds)
+    ds = None
+    src_ds = None
+
+    assert gdal.VSIStatL("tmp/jp2openjpeg_13.jp2.aux.xml") is None
+
+    ds = gdal.Open("tmp/jp2openjpeg_13.jp2")
+    count = ds.GetGCPCount()
+    gcps = ds.GetGCPs()
+    wkt = ds.GetGCPProjection()
+    assert count == 4
+    assert len(gcps) == 4
+    assert "4326" in wkt
+    ds = None
+
+    # Override GCP
+    ds = gdal.Open("tmp/jp2openjpeg_13.jp2")
+    sr = osr.SpatialReference()
+    sr.ImportFromEPSG(32631)
+    gcps = [gdal.GCP(0, 1, 2, 3, 4)]
+    ds.SetGCPs(gcps, sr.ExportToWkt())
+    ds = None
+
+    ds = gdal.Open("tmp/jp2openjpeg_13.jp2")
+    count = ds.GetGCPCount()
+    gcps = ds.GetGCPs()
+    wkt = ds.GetGCPProjection()
+    ds = None
+
+    gdaltest.jp2openjpeg_drv.Delete("tmp/jp2openjpeg_13.jp2")
+
+    assert count == 1
+    assert len(gcps) == 1
+    assert "32631" in wkt
+
+
+###############################################################################
+# Check that we get GCPs even there's no projection info
+
+
+def test_jp2openjpeg_14():
+
+    ds = gdal.Open("data/jpeg2000/byte_2gcps.jp2")
+    assert ds.GetGCPCount() == 2
+
+
+###############################################################################
+# Test multi-threading reading and (possibly) writing
+
+
+@pytest.mark.parametrize("JP2OPENJPEG_USE_THREADED_IO", ["YES", "NO"])
+def test_jp2openjpeg_15(JP2OPENJPEG_USE_THREADED_IO):
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 256, 256)
+    src_ds.GetRasterBand(1).Fill(255)
+    data = src_ds.ReadRaster()
+    # Setting only used for writing
+    with gdaltest.config_option(
+        "JP2OPENJPEG_USE_THREADED_IO", JP2OPENJPEG_USE_THREADED_IO
+    ):
+        ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_15.jp2",
+            src_ds,
+            options=["BLOCKXSIZE=33", "BLOCKYSIZE=34"],
+        )
+    src_ds = None
+    got_data = ds.ReadRaster()
+    ds = None
+    gdaltest.jp2openjpeg_drv.Delete("/vsimem/jp2openjpeg_15.jp2")
+    assert got_data == data
+
+
+###############################################################################
+# Test reading PixelIsPoint file (#5437)
+
+
+def test_jp2openjpeg_16():
+
+    ds = gdal.Open("data/jpeg2000/byte_point.jp2")
+    gt = ds.GetGeoTransform()
+    assert (
+        ds.GetMetadataItem("AREA_OR_POINT") == "Point"
+    ), "did not get AREA_OR_POINT = Point"
+    ds = None
+
+    gt_expected = (440690.0, 60.0, 0.0, 3751350.0, 0.0, -60.0)
+
+    assert gt == gt_expected, "did not get expected geotransform"
+
+    with gdal.config_option("GTIFF_POINT_GEO_IGNORE", "TRUE"):
+
+        ds = gdal.Open("data/jpeg2000/byte_point.jp2")
+        gt = ds.GetGeoTransform()
+        ds = None
+
+    gt_expected = (440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0)
+
+    assert (
+        gt == gt_expected
+    ), "did not get expected geotransform with GTIFF_POINT_GEO_IGNORE TRUE"
+
+
+###############################################################################
+# Test writing PixelIsPoint file (#5437)
+
+
+def test_jp2openjpeg_17():
+
+    src_ds = gdal.Open("data/jpeg2000/byte_point.jp2")
+    ds = gdaltest.jp2openjpeg_drv.CreateCopy("/vsimem/jp2openjpeg_17.jp2", src_ds)
+    ds = None
+    src_ds = None
+
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_17.jp2.aux.xml") is None
+
+    ds = gdal.Open("/vsimem/jp2openjpeg_17.jp2")
+    gt = ds.GetGeoTransform()
+    assert (
+        ds.GetMetadataItem("AREA_OR_POINT") == "Point"
+    ), "did not get AREA_OR_POINT = Point"
+    ds = None
+
+    gt_expected = (440690.0, 60.0, 0.0, 3751350.0, 0.0, -60.0)
+
+    assert gt == gt_expected, "did not get expected geotransform"
+
+    gdal.Unlink("/vsimem/jp2openjpeg_17.jp2")
+
+
+###############################################################################
+# Test when using the decode_area API when one dimension of the dataset is not a
+# multiple of 1024 (#5480)
+
+
+def test_jp2openjpeg_18():
+
+    src_ds = gdal.GetDriverByName("Mem").Create("", 2000, 2000)
+    ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_18.jp2",
+        src_ds,
+        options=["BLOCKXSIZE=2000", "BLOCKYSIZE=2000"],
+    )
+    ds = None
+    src_ds = None
+
+    ds = gdal.Open("/vsimem/jp2openjpeg_18.jp2")
+    ds.GetRasterBand(1).Checksum()
+    assert gdal.GetLastErrorMsg() == ""
+    ds = None
+
+    gdal.Unlink("/vsimem/jp2openjpeg_18.jp2")
+
+
+###############################################################################
+# Test reading file where GMLJP2 has nul character instead of \n (#5760)
+
+
+def test_jp2openjpeg_19():
+
+    ds = gdal.Open("data/jpeg2000/byte_gmljp2_with_nul_car.jp2")
+    assert ds.GetProjectionRef() != ""
+    ds = None
+
+
+###############################################################################
+# Validate GMLJP2 content against schema
+
+
+def test_jp2openjpeg_20():
+
+    xmlvalidate = pytest.importorskip("xmlvalidate")
+
+    try:
+        os.stat("tmp/cache/SCHEMAS_OPENGIS_NET.zip")
+    except OSError:
+        try:
+            os.stat("../ogr/tmp/cache/SCHEMAS_OPENGIS_NET.zip")
+            shutil.copy("../ogr/tmp/cache/SCHEMAS_OPENGIS_NET.zip", "tmp/cache")
+        except OSError:
+            url = "http://schemas.opengis.net/SCHEMAS_OPENGIS_NET.zip"
+            gdaltest.download_or_skip(
+                url,
+                "SCHEMAS_OPENGIS_NET.zip",
+                force_download=True,
+                max_download_duration=20,
+            )
+
+    try:
+        os.mkdir("tmp/cache/SCHEMAS_OPENGIS_NET")
+    except OSError:
+        pass
+
+    try:
+        os.stat(
+            "tmp/cache/SCHEMAS_OPENGIS_NET/gml/3.1.1/profiles/gmlJP2Profile/1.0.0/gmlJP2Profile.xsd"
+        )
+    except OSError:
+        gdaltest.unzip(
+            "tmp/cache/SCHEMAS_OPENGIS_NET", "tmp/cache/SCHEMAS_OPENGIS_NET.zip"
+        )
+
+    try:
+        os.stat("tmp/cache/SCHEMAS_OPENGIS_NET/xlink.xsd")
+    except OSError:
+        xlink_xsd_url = "http://www.w3.org/1999/xlink.xsd"
+        if not gdaltest.download_file(
+            xlink_xsd_url,
+            "SCHEMAS_OPENGIS_NET/xlink.xsd",
+            force_download=True,
+            max_download_duration=10,
+        ):
+            xlink_xsd_url = "http://even.rouault.free.fr/xlink.xsd"
+            gdaltest.download_or_skip(
+                xlink_xsd_url,
+                "SCHEMAS_OPENGIS_NET/xlink.xsd",
+                force_download=True,
+                max_download_duration=10,
+            )
+
+    try:
+        os.stat("tmp/cache/SCHEMAS_OPENGIS_NET/xml.xsd")
+    except OSError:
+        xlink_xsd_url = "http://www.w3.org/1999/xml.xsd"
+        if not gdaltest.download_file(
+            xlink_xsd_url,
+            "SCHEMAS_OPENGIS_NET/xml.xsd",
+            force_download=True,
+            max_download_duration=10,
+        ):
+            xlink_xsd_url = "http://even.rouault.free.fr/xml.xsd"
+            gdaltest.download_or_skip(
+                xlink_xsd_url,
+                "SCHEMAS_OPENGIS_NET/xml.xsd",
+                force_download=True,
+                max_download_duration=10,
+            )
+
+    xmlvalidate.transform_abs_links_to_ref_links("tmp/cache/SCHEMAS_OPENGIS_NET")
+
+    src_ds = gdal.Open("data/byte.tif")
+    ds = gdaltest.jp2openjpeg_drv.CreateCopy("/vsimem/jp2openjpeg_20.jp2", src_ds)
+    gmljp2 = ds.GetMetadata_List("xml:gml.root-instance")[0]
+    ds = None
+    gdal.Unlink("/vsimem/jp2openjpeg_20.jp2")
+
+    assert xmlvalidate.validate(
+        gmljp2, ogc_schemas_location="tmp/cache/SCHEMAS_OPENGIS_NET"
+    )
+
+
+###############################################################################
+# Test YCC=NO creation option
+
+
+def test_jp2openjpeg_21():
+
+    src_ds = gdal.Open("data/rgbsmall.tif")
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_21.jp2",
+        src_ds,
+        options=["QUALITY=100", "REVERSIBLE=YES", "YCC=NO"],
+    )
+    maxdiff = gdaltest.compare_ds(src_ds, out_ds)
+    del out_ds
+    src_ds = None
+    gdal.Unlink("/vsimem/jp2openjpeg_21.jp2")
+
+    # Quite a bit of difference...
+    assert maxdiff <= 1, "Image too different from reference"
+
+
+###############################################################################
+# Test RGBA support
+
+
+def test_jp2openjpeg_22():
+
+    # RGBA
+    src_ds = gdal.Open("../gcore/data/stefan_full_rgba.tif")
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_22.jp2", src_ds, options=["QUALITY=100", "REVERSIBLE=YES"]
+    )
+    maxdiff = gdaltest.compare_ds(src_ds, out_ds)
+    del out_ds
+    src_ds = None
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_22.jp2.aux.xml") is None
+    ds = gdal.Open("/vsimem/jp2openjpeg_22.jp2")
+    assert ds.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_RedBand
+    assert ds.GetRasterBand(2).GetColorInterpretation() == gdal.GCI_GreenBand
+    assert ds.GetRasterBand(3).GetColorInterpretation() == gdal.GCI_BlueBand
+    assert ds.GetRasterBand(4).GetColorInterpretation() == gdal.GCI_AlphaBand
+    ds = None
+    gdal.Unlink("/vsimem/jp2openjpeg_22.jp2")
+
+    assert maxdiff <= 0, "Image too different from reference"
+
+    # RGBA with 1BIT_ALPHA=YES
+    src_ds = gdal.Open("../gcore/data/stefan_full_rgba.tif")
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_22.jp2", src_ds, options=["1BIT_ALPHA=YES"]
+    )
+    del out_ds
+    src_ds = None
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_22.jp2.aux.xml") is None
+    ds = gdal.OpenEx(
+        "/vsimem/jp2openjpeg_22.jp2", open_options=["1BIT_ALPHA_PROMOTION=NO"]
+    )
+    fourth_band = ds.GetRasterBand(4)
+    assert fourth_band.GetMetadataItem("NBITS", "IMAGE_STRUCTURE") == "1"
+    ds = None
+    ds = gdal.Open("/vsimem/jp2openjpeg_22.jp2")
+    assert ds.GetRasterBand(4).Checksum() == 23120
+    ds = None
+    gdal.Unlink("/vsimem/jp2openjpeg_22.jp2")
+
+    # RGBA with YCBCR420=YES
+    src_ds = gdal.Open("../gcore/data/stefan_full_rgba.tif")
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_22.jp2", src_ds, options=["YCBCR420=YES"]
+    )
+    del out_ds
+    src_ds = None
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_22.jp2.aux.xml") is None
+    ds = gdal.Open("/vsimem/jp2openjpeg_22.jp2")
+    assert ds.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_RedBand
+    assert ds.GetRasterBand(2).GetColorInterpretation() == gdal.GCI_GreenBand
+    assert ds.GetRasterBand(3).GetColorInterpretation() == gdal.GCI_BlueBand
+    assert ds.GetRasterBand(4).GetColorInterpretation() == gdal.GCI_AlphaBand
+    assert ds.GetRasterBand(1).Checksum() in [11457, 11450, 11498, 11502]
+    ds = None
+    gdal.Unlink("/vsimem/jp2openjpeg_22.jp2")
+
+    # RGBA with YCC=YES. Will emit a warning for now because of OpenJPEG
+    # bug (only fixed in trunk, not released versions at that time)
+    src_ds = gdal.Open("../gcore/data/stefan_full_rgba.tif")
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_22.jp2",
+        src_ds,
+        options=["YCC=YES", "QUALITY=100", "REVERSIBLE=YES"],
+    )
+    maxdiff = gdaltest.compare_ds(src_ds, out_ds)
+    del out_ds
+    src_ds = None
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_22.jp2.aux.xml") is None
+    gdal.Unlink("/vsimem/jp2openjpeg_22.jp2")
+
+    assert maxdiff <= 0, "Image too different from reference"
+
+    # RGB,undefined
+    src_ds = gdal.Open("../gcore/data/stefan_full_rgba_photometric_rgb.tif")
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_22.jp2", src_ds, options=["QUALITY=100", "REVERSIBLE=YES"]
+    )
+    maxdiff = gdaltest.compare_ds(src_ds, out_ds)
+    del out_ds
+    src_ds = None
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_22.jp2.aux.xml") is None
+    ds = gdal.Open("/vsimem/jp2openjpeg_22.jp2")
+    assert ds.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_RedBand
+    assert ds.GetRasterBand(2).GetColorInterpretation() == gdal.GCI_GreenBand
+    assert ds.GetRasterBand(3).GetColorInterpretation() == gdal.GCI_BlueBand
+    assert ds.GetRasterBand(4).GetColorInterpretation() == gdal.GCI_Undefined
+    ds = None
+    gdal.Unlink("/vsimem/jp2openjpeg_22.jp2")
+
+    assert maxdiff <= 0, "Image too different from reference"
+
+    # RGB,undefined with ALPHA=YES
+    src_ds = gdal.Open("../gcore/data/stefan_full_rgba_photometric_rgb.tif")
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_22.jp2",
+        src_ds,
+        options=["QUALITY=100", "REVERSIBLE=YES", "ALPHA=YES"],
+    )
+    maxdiff = gdaltest.compare_ds(src_ds, out_ds)
+    del out_ds
+    src_ds = None
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_22.jp2.aux.xml") is None
+    ds = gdal.Open("/vsimem/jp2openjpeg_22.jp2")
+    assert ds.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_RedBand
+    assert ds.GetRasterBand(2).GetColorInterpretation() == gdal.GCI_GreenBand
+    assert ds.GetRasterBand(3).GetColorInterpretation() == gdal.GCI_BlueBand
+    assert ds.GetRasterBand(4).GetColorInterpretation() == gdal.GCI_AlphaBand
+    ds = None
+    gdal.Unlink("/vsimem/jp2openjpeg_22.jp2")
+
+    assert maxdiff <= 0, "Image too different from reference"
+
+
+###############################################################################
+# Test NBITS support
+
+
+def test_jp2openjpeg_23():
+
+    src_ds = gdal.Open("../gcore/data/uint16.tif")
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_23.jp2",
+        src_ds,
+        options=["NBITS=9", "QUALITY=100", "REVERSIBLE=YES"],
+    )
+    maxdiff = gdaltest.compare_ds(src_ds, out_ds)
+    del out_ds
+    src_ds = None
+    ds = gdal.Open("/vsimem/jp2openjpeg_23.jp2")
+    assert ds.GetRasterBand(1).GetMetadataItem("NBITS", "IMAGE_STRUCTURE") == "9"
+
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy("/vsimem/jp2openjpeg_23_2.jp2", ds)
+    assert out_ds.GetRasterBand(1).GetMetadataItem("NBITS", "IMAGE_STRUCTURE") == "9"
+    del out_ds
+
+    ds = None
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_23.jp2.aux.xml") is None
+    gdal.Unlink("/vsimem/jp2openjpeg_23.jp2")
+    gdal.Unlink("/vsimem/jp2openjpeg_23_2.jp2")
+
+    assert maxdiff <= 1, "Image too different from reference"
+
+
+###############################################################################
+# Test Grey+alpha support
+
+
+def test_jp2openjpeg_24():
+
+    #  Grey+alpha
+    src_ds = gdal.Open("../gcore/data/stefan_full_greyalpha.tif")
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_24.jp2", src_ds, options=["QUALITY=100", "REVERSIBLE=YES"]
+    )
+    maxdiff = gdaltest.compare_ds(src_ds, out_ds)
+    del out_ds
+    src_ds = None
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_24.jp2.aux.xml") is None
+    ds = gdal.Open("/vsimem/jp2openjpeg_24.jp2")
+    assert ds.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_GrayIndex
+    assert ds.GetRasterBand(2).GetColorInterpretation() == gdal.GCI_AlphaBand
+    ds = None
+    gdal.Unlink("/vsimem/jp2openjpeg_24.jp2")
+
+    assert maxdiff <= 0, "Image too different from reference"
+
+    #  Grey+alpha with 1BIT_ALPHA=YES
+    src_ds = gdal.Open("../gcore/data/stefan_full_greyalpha.tif")
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_24.jp2", src_ds, options=["1BIT_ALPHA=YES"]
+    )
+    del out_ds
+    src_ds = None
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_24.jp2.aux.xml") is None
+    ds = gdal.OpenEx(
+        "/vsimem/jp2openjpeg_24.jp2", open_options=["1BIT_ALPHA_PROMOTION=NO"]
+    )
+    assert ds.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_GrayIndex
+    assert ds.GetRasterBand(2).GetColorInterpretation() == gdal.GCI_AlphaBand
+    assert ds.GetRasterBand(2).GetMetadataItem("NBITS", "IMAGE_STRUCTURE") == "1"
+    ds = None
+    ds = gdal.Open("/vsimem/jp2openjpeg_24.jp2")
+    assert ds.GetRasterBand(2).GetMetadataItem("NBITS", "IMAGE_STRUCTURE") is None
+    assert ds.GetRasterBand(2).Checksum() == 23120
+    ds = None
+    gdal.Unlink("/vsimem/jp2openjpeg_24.jp2")
+
+
+###############################################################################
+# Test multiband support
+
+
+def test_jp2openjpeg_25():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 100, 100, 5)
+    src_ds.GetRasterBand(1).Fill(255)
+    src_ds.GetRasterBand(2).Fill(250)
+    src_ds.GetRasterBand(3).Fill(245)
+    src_ds.GetRasterBand(4).Fill(240)
+    src_ds.GetRasterBand(5).Fill(235)
+
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_25.jp2", src_ds, options=["QUALITY=100", "REVERSIBLE=YES"]
+    )
+    maxdiff = gdaltest.compare_ds(src_ds, out_ds)
+    del out_ds
+    src_ds = None
+    ds = gdal.Open("/vsimem/jp2openjpeg_25.jp2")
+    assert ds.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_Undefined
+    ds = None
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_25.jp2.aux.xml") is None
+
+    gdal.Unlink("/vsimem/jp2openjpeg_25.jp2")
+
+    assert maxdiff <= 0, "Image too different from reference"
+
+
+###############################################################################
+
+
+def validate(
+    filename,
+    expected_gmljp2=True,
+    return_error_count=False,
+    oidoc=None,
+    inspire_tg=True,
+):
+
+    for path in ("../ogr", samples_path):
+        if path not in sys.path:
+            sys.path.append(path)
+
+    validate_jp2 = pytest.importorskip("validate_jp2")
+
+    try:
+        os.stat("tmp/cache/SCHEMAS_OPENGIS_NET")
+        os.stat("tmp/cache/SCHEMAS_OPENGIS_NET/xlink.xsd")
+        os.stat("tmp/cache/SCHEMAS_OPENGIS_NET/xml.xsd")
+        ogc_schemas_location = "tmp/cache/SCHEMAS_OPENGIS_NET"
+    except OSError:
+        ogc_schemas_location = "disabled"
+
+    if ogc_schemas_location != "disabled":
+        try:
+            import xmlvalidate
+
+            xmlvalidate.validate  # to make pyflakes happy
+        except (ImportError, AttributeError):
+            ogc_schemas_location = "disabled"
+
+    res = validate_jp2.validate(
+        filename, oidoc, inspire_tg, expected_gmljp2, ogc_schemas_location
+    )
+    if return_error_count:
+        return (res.error_count, res.warning_count)
+    if res.error_count == 0 and res.warning_count == 0:
+        return
+    pytest.fail()
+
+
+###############################################################################
+# Test INSPIRE_TG support
+
+
+def test_jp2openjpeg_26():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 2048, 2048, 1)
+    sr = osr.SpatialReference()
+    sr.ImportFromEPSG(32631)
+    src_ds.SetProjection(sr.ExportToWkt())
+    src_ds.SetGeoTransform([450000, 1, 0, 5000000, 0, -1])
+
+    # Nominal case: tiled
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_26.jp2", src_ds, options=["INSPIRE_TG=YES"]
+    )
+    overview_count = out_ds.GetRasterBand(1).GetOverviewCount()
+    # We have 2x2 1024x1024 tiles. Each of them can be reconstructed down to 128x128.
+    # So for full raster the smallest overview is 2*128
+    assert (
+        out_ds.GetRasterBand(1).GetOverview(overview_count - 1).XSize == 2 * 128
+        and out_ds.GetRasterBand(1).GetOverview(overview_count - 1).YSize == 2 * 128
+    )
+    out_ds = None
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_26.jp2.aux.xml") is None
+    assert validate("/vsimem/jp2openjpeg_26.jp2") != "fail"
+    gdal.Unlink("/vsimem/jp2openjpeg_26.jp2")
+
+    # Nominal case: untiled
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_26.jp2",
+        src_ds,
+        options=["INSPIRE_TG=YES", "BLOCKXSIZE=2048", "BLOCKYSIZE=2048"],
+    )
+    overview_count = out_ds.GetRasterBand(1).GetOverviewCount()
+    assert (
+        out_ds.GetRasterBand(1).GetOverview(overview_count - 1).XSize == 128
+        and out_ds.GetRasterBand(1).GetOverview(overview_count - 1).YSize == 128
+    )
+    gdal.ErrorReset()
+    out_ds.GetRasterBand(1).Checksum()
+    assert gdal.GetLastErrorMsg() == ""
+    out_ds.GetRasterBand(1).GetOverview(0).Checksum()
+    assert gdal.GetLastErrorMsg() == ""
+    out_ds = None
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_26.jp2.aux.xml") is None
+    assert validate("/vsimem/jp2openjpeg_26.jp2") != "fail"
+    gdal.Unlink("/vsimem/jp2openjpeg_26.jp2")
+
+    # Nominal case: RGBA
+    src_ds = gdal.GetDriverByName("MEM").Create("", 128, 128, 4)
+    src_ds.SetProjection(sr.ExportToWkt())
+    src_ds.SetGeoTransform([450000, 1, 0, 5000000, 0, -1])
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_26.jp2", src_ds, options=["INSPIRE_TG=YES", "ALPHA=YES"]
+    )
+    out_ds = None
+    ds = gdal.OpenEx(
+        "/vsimem/jp2openjpeg_26.jp2", open_options=["1BIT_ALPHA_PROMOTION=NO"]
+    )
+    assert ds.GetRasterBand(4).GetColorInterpretation() == gdal.GCI_AlphaBand
+    assert ds.GetRasterBand(4).GetMetadataItem("NBITS", "IMAGE_STRUCTURE") == "1"
+    ds = None
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_26.jp2.aux.xml") is None
+    assert validate("/vsimem/jp2openjpeg_26.jp2") != "fail"
+    gdal.Unlink("/vsimem/jp2openjpeg_26.jp2")
+
+    # Warning case: disabling JPX
+    gdal.ErrorReset()
+    with gdaltest.error_handler():
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_26.jp2", src_ds, options=["INSPIRE_TG=YES", "JPX=NO"]
+        )
+    assert gdal.GetLastErrorMsg() != ""
+    out_ds = None
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_26.jp2.aux.xml") is None
+    res = validate("/vsimem/jp2openjpeg_26.jp2", return_error_count=True)
+    assert res == "skip" or res == (2, 0)
+    gdal.Unlink("/vsimem/jp2openjpeg_26.jp2")
+
+    # Bilevel (1 bit)
+    src_ds = gdal.GetDriverByName("MEM").Create("", 128, 128, 1)
+    src_ds.GetRasterBand(1).SetMetadataItem("NBITS", "1", "IMAGE_STRUCTURE")
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_26.jp2", src_ds, options=["INSPIRE_TG=YES"]
+    )
+    assert out_ds.GetRasterBand(1).GetMetadataItem("NBITS", "IMAGE_STRUCTURE") == "1"
+    ds = None
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_26.jp2.aux.xml") is None
+    assert validate("/vsimem/jp2openjpeg_26.jp2", expected_gmljp2=False) != "fail"
+    gdal.Unlink("/vsimem/jp2openjpeg_26.jp2")
+
+    # Auto-promotion 12->16 bits
+    src_ds = gdal.GetDriverByName("MEM").Create("", 128, 128, 1, gdal.GDT_UInt16)
+    src_ds.GetRasterBand(1).SetMetadataItem("NBITS", "12", "IMAGE_STRUCTURE")
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_26.jp2", src_ds, options=["INSPIRE_TG=YES"]
+    )
+    assert out_ds.GetRasterBand(1).GetMetadataItem("NBITS", "IMAGE_STRUCTURE") is None
+    ds = None
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_26.jp2.aux.xml") is None
+    assert validate("/vsimem/jp2openjpeg_26.jp2", expected_gmljp2=False) != "fail"
+    gdal.Unlink("/vsimem/jp2openjpeg_26.jp2")
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 2048, 2048, 1)
+
+    # Error case: too big tile
+    with gdaltest.error_handler():
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_26.jp2",
+            src_ds,
+            options=["INSPIRE_TG=YES", "BLOCKXSIZE=1536", "BLOCKYSIZE=1536"],
+        )
+    assert out_ds is None
+
+    # Error case: non square tile
+    with gdaltest.error_handler():
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_26.jp2",
+            src_ds,
+            options=["INSPIRE_TG=YES", "BLOCKXSIZE=512", "BLOCKYSIZE=128"],
+        )
+    assert out_ds is None
+
+    # Error case: incompatible PROFILE
+    with gdaltest.error_handler():
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_26.jp2",
+            src_ds,
+            options=["INSPIRE_TG=YES", "PROFILE=UNRESTRICTED"],
+        )
+    assert out_ds is None
+
+    # Error case: valid, but too small number of resolutions regarding PROFILE_1
+    with gdaltest.error_handler():
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_26.jp2",
+            src_ds,
+            options=["INSPIRE_TG=YES", "RESOLUTIONS=1"],
+        )
+    assert out_ds is None
+
+    # Too big resolution number. Will fallback to default one
+    with gdaltest.error_handler():
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_26.jp2",
+            src_ds,
+            options=["INSPIRE_TG=YES", "RESOLUTIONS=100"],
+        )
+    assert out_ds is not None
+    out_ds = None
+    gdal.Unlink("/vsimem/jp2openjpeg_26.jp2")
+
+    # Error case: unsupported NBITS
+    with gdaltest.error_handler():
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_26.jp2", src_ds, options=["INSPIRE_TG=YES", "NBITS=2"]
+        )
+    assert out_ds is None
+
+    # Error case: unsupported CODEC (J2K)
+    with gdaltest.error_handler():
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_26.j2k", src_ds, options=["INSPIRE_TG=YES"]
+        )
+    assert out_ds is None
+
+    # Error case: invalid CODEBLOCK_WIDTH/HEIGHT
+    with gdaltest.error_handler():
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_26.jp2",
+            src_ds,
+            options=["INSPIRE_TG=YES", "CODEBLOCK_WIDTH=128", "CODEBLOCK_HEIGHT=32"],
+        )
+    assert out_ds is None
+    with gdaltest.error_handler():
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_26.jp2",
+            src_ds,
+            options=["INSPIRE_TG=YES", "CODEBLOCK_WIDTH=32", "CODEBLOCK_HEIGHT=128"],
+        )
+    assert out_ds is None
+
+
+###############################################################################
+# Test CreateCopy() from a JPEG2000 with a 2048x2048 tiling
+
+
+def test_jp2openjpeg_27():
+
+    # Test optimization in GDALCopyWholeRasterGetSwathSize()
+    # Not sure how we can check that except looking at logs with CPL_DEBUG=GDAL
+    # for "GDAL: GDALDatasetCopyWholeRaster(): 2048*2048 swaths, bInterleave=1"
+    src_ds = gdal.GetDriverByName("MEM").Create("", 2049, 2049, 4)
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_27.jp2",
+        src_ds,
+        options=["RESOLUTIONS=1", "BLOCKXSIZE=2048", "BLOCKYSIZE=2048"],
+    )
+    src_ds = None
+    # print('End of JP2 decoding')
+    out2_ds = gdal.GetDriverByName("GTiff").CreateCopy(
+        "/vsimem/jp2openjpeg_27.tif", out_ds, options=["TILED=YES"]
+    )
+    out_ds = None
+    del out2_ds
+    gdal.Unlink("/vsimem/jp2openjpeg_27.jp2")
+    gdal.Unlink("/vsimem/jp2openjpeg_27.tif")
+
+
+###############################################################################
+# Test CODEBLOCK_WIDTH/_HEIGHT
+
+
+XML_TYPE_IDX = 0
+XML_VALUE_IDX = 1
+XML_FIRST_CHILD_IDX = 2
+
+
+def find_xml_node(ar, element_name, only_attributes=False):
+    # type = ar[XML_TYPE_IDX]
+    value = ar[XML_VALUE_IDX]
+    if value == element_name:
+        return ar
+    for child_idx in range(XML_FIRST_CHILD_IDX, len(ar)):
+        child = ar[child_idx]
+        if only_attributes and child[XML_TYPE_IDX] != gdal.CXT_Attribute:
+            continue
+        found = find_xml_node(child, element_name)
+        if found is not None:
+            return found
+    return None
+
+
+def get_attribute_val(ar, attr_name):
+    node = find_xml_node(ar, attr_name, True)
+    if node is None or node[XML_TYPE_IDX] != gdal.CXT_Attribute:
+        return None
+    if (
+        len(ar) > XML_FIRST_CHILD_IDX
+        and node[XML_FIRST_CHILD_IDX][XML_TYPE_IDX] == gdal.CXT_Text
+    ):
+        return node[XML_FIRST_CHILD_IDX][XML_VALUE_IDX]
+    return None
+
+
+def find_element_with_name(ar, element_name, name):
+    typ = ar[XML_TYPE_IDX]
+    value = ar[XML_VALUE_IDX]
+    if (
+        typ == gdal.CXT_Element
+        and value == element_name
+        and get_attribute_val(ar, "name") == name
+    ):
+        return ar
+    for child_idx in range(XML_FIRST_CHILD_IDX, len(ar)):
+        child = ar[child_idx]
+        found = find_element_with_name(child, element_name, name)
+        if found:
+            return found
+    return None
+
+
+def get_element_val(node):
+    if node is None:
+        return None
+    for child_idx in range(XML_FIRST_CHILD_IDX, len(node)):
+        child = node[child_idx]
+        if child[XML_TYPE_IDX] == gdal.CXT_Text:
+            return child[XML_VALUE_IDX]
+    return None
+
+
+def jp2openjpeg_test_codeblock(filename, codeblock_width, codeblock_height):
+    node = gdal.GetJPEG2000Structure(filename, ["ALL=YES"])
+    xcb = 2 ** (
+        2
+        + int(
+            get_element_val(find_element_with_name(node, "Field", "SPcod_xcb_minus_2"))
+        )
+    )
+    ycb = 2 ** (
+        2
+        + int(
+            get_element_val(find_element_with_name(node, "Field", "SPcod_ycb_minus_2"))
+        )
+    )
+    if xcb != codeblock_width or ycb != codeblock_height:
+        return False
+    return True
+
+
+def test_jp2openjpeg_28():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 10, 10, 1)
+
+    tests = [
+        (["CODEBLOCK_WIDTH=2"], 64, 64, True),
+        (["CODEBLOCK_WIDTH=2048"], 64, 64, True),
+        (["CODEBLOCK_HEIGHT=2"], 64, 64, True),
+        (["CODEBLOCK_HEIGHT=2048"], 64, 64, True),
+        (["CODEBLOCK_WIDTH=128", "CODEBLOCK_HEIGHT=128"], 64, 64, True),
+        (["CODEBLOCK_WIDTH=63"], 32, 64, True),
+        (["CODEBLOCK_WIDTH=32", "CODEBLOCK_HEIGHT=32"], 32, 32, False),
+    ]
+
+    for (options, expected_cbkw, expected_cbkh, warning_expected) in tests:
+        gdal.ErrorReset()
+        with gdaltest.error_handler():
+            out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+                "/vsimem/jp2openjpeg_28.jp2", src_ds, options=options
+            )
+        if warning_expected and gdal.GetLastErrorMsg() == "":
+            print(options)
+            pytest.fail("warning expected")
+        del out_ds
+        if not jp2openjpeg_test_codeblock(
+            "/vsimem/jp2openjpeg_28.jp2", expected_cbkw, expected_cbkh
+        ):
+            print(options)
+            pytest.fail("unexpected codeblock size")
+
+    gdal.Unlink("/vsimem/jp2openjpeg_28.jp2")
+
+
+###############################################################################
+# Test TILEPARTS option
+
+
+def test_jp2openjpeg_29():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 128, 128, 1)
+
+    tests = [
+        (["TILEPARTS=DISABLED"], False),
+        (["TILEPARTS=RESOLUTIONS"], False),
+        (["TILEPARTS=LAYERS"], True),  # warning since there's only one quality layer
+        (["TILEPARTS=LAYERS", "QUALITY=1,2"], False),
+        (["TILEPARTS=COMPONENTS"], False),
+        (["TILEPARTS=ILLEGAL"], True),
+    ]
+
+    for (options, warning_expected) in tests:
+        gdal.ErrorReset()
+        with gdaltest.error_handler():
+            options.append("BLOCKXSIZE=64")
+            options.append("BLOCKYSIZE=64")
+            out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+                "/vsimem/jp2openjpeg_29.jp2", src_ds, options=options
+            )
+        if warning_expected and gdal.GetLastErrorMsg() == "":
+            print(options)
+            pytest.fail("warning expected")
+        # Not sure if that could be easily checked
+        del out_ds
+        # print gdal.GetJPEG2000StructureAsString('/vsimem/jp2openjpeg_29.jp2', ['ALL=YES'])
+
+    gdal.Unlink("/vsimem/jp2openjpeg_29.jp2")
+
+
+###############################################################################
+# Test color table support
+
+
+def test_jp2openjpeg_30():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 10, 10, 1)
+    ct = gdal.ColorTable()
+    ct.SetColorEntry(0, (255, 255, 255, 255))
+    ct.SetColorEntry(1, (255, 255, 0, 255))
+    ct.SetColorEntry(2, (255, 0, 255, 255))
+    ct.SetColorEntry(3, (0, 255, 255, 255))
+    src_ds.GetRasterBand(1).SetRasterColorTable(ct)
+
+    tests = [
+        ([], False),
+        (["QUALITY=100", "REVERSIBLE=YES"], False),
+        (["QUALITY=50"], True),
+        (["REVERSIBLE=NO"], True),
+    ]
+
+    for (options, warning_expected) in tests:
+        gdal.ErrorReset()
+        with gdaltest.error_handler():
+            out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+                "/vsimem/jp2openjpeg_30.jp2", src_ds, options=options
+            )
+        if warning_expected and gdal.GetLastErrorMsg() == "":
+            print(options)
+            pytest.fail("warning expected")
+        ct = out_ds.GetRasterBand(1).GetRasterColorTable()
+        assert (
+            ct.GetCount() == 4
+            and ct.GetColorEntry(0) == (255, 255, 255, 255)
+            and ct.GetColorEntry(1) == (255, 255, 0, 255)
+            and ct.GetColorEntry(2) == (255, 0, 255, 255)
+            and ct.GetColorEntry(3) == (0, 255, 255, 255)
+        ), "Wrong color table entry."
+        del out_ds
+
+        assert validate("/vsimem/jp2openjpeg_30.jp2", expected_gmljp2=False) != "fail"
+
+    gdal.Unlink("/vsimem/jp2openjpeg_30.jp2")
+
+    # Test with c4 != 255
+    src_ds = gdal.GetDriverByName("MEM").Create("", 10, 10, 1)
+    ct = gdal.ColorTable()
+    ct.SetColorEntry(0, (0, 0, 0, 0))
+    ct.SetColorEntry(1, (255, 255, 0, 255))
+    ct.SetColorEntry(2, (255, 0, 255, 255))
+    ct.SetColorEntry(3, (0, 255, 255, 255))
+    src_ds.GetRasterBand(1).SetRasterColorTable(ct)
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy("/vsimem/jp2openjpeg_30.jp2", src_ds)
+    ct = out_ds.GetRasterBand(1).GetRasterColorTable()
+    assert (
+        ct.GetCount() == 4
+        and ct.GetColorEntry(0) == (0, 0, 0, 0)
+        and ct.GetColorEntry(1) == (255, 255, 0, 255)
+        and ct.GetColorEntry(2) == (255, 0, 255, 255)
+        and ct.GetColorEntry(3) == (0, 255, 255, 255)
+    ), "Wrong color table entry."
+    del out_ds
+    gdal.Unlink("/vsimem/jp2openjpeg_30.jp2")
+
+    # Same but with CT_COMPONENTS=3
+    src_ds = gdal.GetDriverByName("MEM").Create("", 10, 10, 1)
+    ct = gdal.ColorTable()
+    ct.SetColorEntry(0, (0, 0, 0, 0))
+    ct.SetColorEntry(1, (255, 255, 0, 255))
+    ct.SetColorEntry(2, (255, 0, 255, 255))
+    ct.SetColorEntry(3, (0, 255, 255, 255))
+    src_ds.GetRasterBand(1).SetRasterColorTable(ct)
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_30.jp2", src_ds, options=["CT_COMPONENTS=3"]
+    )
+    ct = out_ds.GetRasterBand(1).GetRasterColorTable()
+    assert (
+        ct.GetCount() == 4
+        and ct.GetColorEntry(0) == (0, 0, 0, 255)
+        and ct.GetColorEntry(1) == (255, 255, 0, 255)
+        and ct.GetColorEntry(2) == (255, 0, 255, 255)
+        and ct.GetColorEntry(3) == (0, 255, 255, 255)
+    ), "Wrong color table entry."
+    del out_ds
+    gdal.Unlink("/vsimem/jp2openjpeg_30.jp2")
+
+    # Not supported: color table on first band, and other bands
+    src_ds = gdal.GetDriverByName("MEM").Create("", 10, 10, 2)
+    ct = gdal.ColorTable()
+    src_ds.GetRasterBand(1).SetRasterColorTable(ct)
+    gdal.ErrorReset()
+    with gdaltest.error_handler():
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_30.jp2", src_ds
+        )
+    assert out_ds is None
+
+
+###############################################################################
+# Test unusual band color interpretation order
+
+
+def test_jp2openjpeg_31():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 10, 10, 3)
+    src_ds.GetRasterBand(1).SetColorInterpretation(gdal.GCI_GreenBand)
+    src_ds.GetRasterBand(2).SetColorInterpretation(gdal.GCI_BlueBand)
+    src_ds.GetRasterBand(3).SetColorInterpretation(gdal.GCI_RedBand)
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy("/vsimem/jp2openjpeg_31.jp2", src_ds)
+    del out_ds
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_31.jp2.aux.xml") is None
+    ds = gdal.Open("/vsimem/jp2openjpeg_31.jp2")
+    assert ds.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_GreenBand
+    assert ds.GetRasterBand(2).GetColorInterpretation() == gdal.GCI_BlueBand
+    assert ds.GetRasterBand(3).GetColorInterpretation() == gdal.GCI_RedBand
+    ds = None
+    gdal.Unlink("/vsimem/jp2openjpeg_31.jp2")
+
+    # With alpha now
+    src_ds = gdal.GetDriverByName("MEM").Create("", 10, 10, 4)
+    src_ds.GetRasterBand(1).SetColorInterpretation(gdal.GCI_AlphaBand)
+    src_ds.GetRasterBand(2).SetColorInterpretation(gdal.GCI_GreenBand)
+    src_ds.GetRasterBand(3).SetColorInterpretation(gdal.GCI_BlueBand)
+    src_ds.GetRasterBand(4).SetColorInterpretation(gdal.GCI_RedBand)
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy("/vsimem/jp2openjpeg_31.jp2", src_ds)
+    del out_ds
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_31.jp2.aux.xml") is None
+    ds = gdal.Open("/vsimem/jp2openjpeg_31.jp2")
+    assert ds.GetRasterBand(1).GetColorInterpretation() == gdal.GCI_AlphaBand
+    assert ds.GetRasterBand(2).GetColorInterpretation() == gdal.GCI_GreenBand
+    assert ds.GetRasterBand(3).GetColorInterpretation() == gdal.GCI_BlueBand
+    assert ds.GetRasterBand(4).GetColorInterpretation() == gdal.GCI_RedBand
+    ds = None
+    gdal.Unlink("/vsimem/jp2openjpeg_31.jp2")
+
+
+###############################################################################
+# Test creation of "XLBoxes" for JP2C
+
+
+def test_jp2openjpeg_32():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 10, 10, 1)
+    with gdaltest.error_handler():
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_32.jp2", src_ds, options=["JP2C_XLBOX=YES"]
+        )
+    assert out_ds.GetRasterBand(1).Checksum() == 0
+    out_ds = None
+    gdal.Unlink("/vsimem/jp2openjpeg_32.jp2")
+
+
+###############################################################################
+# Test crazy tile size
+
+
+def test_jp2openjpeg_33():
+
+    src_ds = gdal.Open(
+        """<VRTDataset rasterXSize="100000" rasterYSize="100000">
+  <VRTRasterBand dataType="Byte" band="1">
+  </VRTRasterBand>
+</VRTDataset>"""
+    )
+    with gdaltest.error_handler():
+        # Limit number of resolutions, because of
+        # https://github.com/uclouvain/openjpeg/issues/493
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_33.jp2",
+            src_ds,
+            options=["BLOCKXSIZE=100000", "BLOCKYSIZE=100000", "RESOLUTIONS=5"],
+        )
+    assert out_ds is None
+    out_ds = None
+    gdal.Unlink("/vsimem/jp2openjpeg_33.jp2")
+
+
+###############################################################################
+# Test opening a file whose dimensions are > 2^31-1
+
+
+def test_jp2openjpeg_34():
+
+    with gdaltest.error_handler():
+        ds = gdal.Open("data/jpeg2000/dimensions_above_31bit.jp2")
+    assert ds is None
+
+
+###############################################################################
+# Test opening a truncated file
+
+
+def test_jp2openjpeg_35():
+
+    with gdaltest.error_handler():
+        ds = gdal.Open("data/jpeg2000/truncated.jp2")
+    assert ds is None
+
+
+###############################################################################
+# Test we cannot create files with more than 16384 bands
+
+
+def test_jp2openjpeg_36():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 2, 2, 16385)
+    with gdaltest.error_handler():
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_36.jp2", src_ds
+        )
+    assert out_ds is None and gdal.VSIStatL("/vsimem/jp2openjpeg_36.jp2") is None
+
+
+###############################################################################
+# Test metadata reading & writing
+
+
+def test_jp2openjpeg_37():
+
+    # No metadata
+    src_ds = gdal.GetDriverByName("MEM").Create("", 2, 2)
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_37.jp2", src_ds, options=["WRITE_METADATA=YES"]
+    )
+    del out_ds
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_37.jp2.aux.xml") is None
+    ds = gdal.Open("/vsimem/jp2openjpeg_37.jp2")
+    assert ds.GetMetadata() == {}
+    gdal.Unlink("/vsimem/jp2openjpeg_37.jp2")
+
+    # Simple metadata in main domain
+    for options in [["WRITE_METADATA=YES"], ["WRITE_METADATA=YES", "INSPIRE_TG=YES"]]:
+        src_ds = gdal.GetDriverByName("MEM").Create("", 2, 2)
+        src_ds.SetMetadataItem("FOO", "BAR")
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_37.jp2", src_ds, options=options
+        )
+        del out_ds
+        assert gdal.VSIStatL("/vsimem/jp2openjpeg_37.jp2.aux.xml") is None
+        ds = gdal.Open("/vsimem/jp2openjpeg_37.jp2")
+        assert ds.GetMetadata() == {"FOO": "BAR"}
+        ds = None
+
+        assert not (
+            "INSPIRE_TG=YES" in options
+            and validate("/vsimem/jp2openjpeg_37.jp2", expected_gmljp2=False) == "fail"
+        )
+
+        gdal.Unlink("/vsimem/jp2openjpeg_37.jp2")
+
+    # Simple metadata in auxiliary domain
+    src_ds = gdal.GetDriverByName("MEM").Create("", 2, 2)
+    src_ds.SetMetadataItem("FOO", "BAR", "SOME_DOMAIN")
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_37.jp2", src_ds, options=["WRITE_METADATA=YES"]
+    )
+    del out_ds
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_37.jp2.aux.xml") is None
+    ds = gdal.Open("/vsimem/jp2openjpeg_37.jp2")
+    md = ds.GetMetadata("SOME_DOMAIN")
+    assert md == {"FOO": "BAR"}
+    gdal.Unlink("/vsimem/jp2openjpeg_37.jp2")
+
+    # Simple metadata in auxiliary XML domain
+    src_ds = gdal.GetDriverByName("MEM").Create("", 2, 2)
+    src_ds.SetMetadata(["<some_arbitrary_xml_box/>"], "xml:SOME_DOMAIN")
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_37.jp2", src_ds, options=["WRITE_METADATA=YES"]
+    )
+    del out_ds
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_37.jp2.aux.xml") is None
+    ds = gdal.Open("/vsimem/jp2openjpeg_37.jp2")
+    assert ds.GetMetadata("xml:SOME_DOMAIN")[0] == "<some_arbitrary_xml_box />\n"
+    gdal.Unlink("/vsimem/jp2openjpeg_37.jp2")
+
+    # Special xml:BOX_ metadata domain
+    for options in [["WRITE_METADATA=YES"], ["WRITE_METADATA=YES", "INSPIRE_TG=YES"]]:
+        src_ds = gdal.GetDriverByName("MEM").Create("", 2, 2)
+        src_ds.SetMetadata(["<some_arbitrary_xml_box/>"], "xml:BOX_1")
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_37.jp2", src_ds, options=options
+        )
+        del out_ds
+        assert gdal.VSIStatL("/vsimem/jp2openjpeg_37.jp2.aux.xml") is None
+        ds = gdal.Open("/vsimem/jp2openjpeg_37.jp2")
+        assert ds.GetMetadata("xml:BOX_0")[0] == "<some_arbitrary_xml_box/>"
+        gdal.Unlink("/vsimem/jp2openjpeg_37.jp2")
+
+    # Special xml:XMP metadata domain
+    for options in [["WRITE_METADATA=YES"], ["WRITE_METADATA=YES", "INSPIRE_TG=YES"]]:
+        src_ds = gdal.GetDriverByName("MEM").Create("", 2, 2)
+        src_ds.SetMetadata(["<fake_xmp_box/>"], "xml:XMP")
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_37.jp2", src_ds, options=options
+        )
+        del out_ds
+        assert gdal.VSIStatL("/vsimem/jp2openjpeg_37.jp2.aux.xml") is None
+        ds = gdal.Open("/vsimem/jp2openjpeg_37.jp2")
+        assert ds.GetMetadata("xml:XMP")[0] == "<fake_xmp_box/>"
+        ds = None
+
+        assert not (
+            "INSPIRE_TG=YES" in options
+            and validate("/vsimem/jp2openjpeg_37.jp2", expected_gmljp2=False) == "fail"
+        )
+
+        gdal.Unlink("/vsimem/jp2openjpeg_37.jp2")
+
+    # Special xml:IPR metadata domain
+    for options in [["WRITE_METADATA=YES"]]:
+        src_ds = gdal.GetDriverByName("MEM").Create("", 2, 2)
+        src_ds.SetMetadata(["<fake_ipr_box/>"], "xml:IPR")
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_37.jp2", src_ds, options=options
+        )
+        del out_ds
+        assert gdal.VSIStatL("/vsimem/jp2openjpeg_37.jp2.aux.xml") is None
+        ds = gdal.Open("/vsimem/jp2openjpeg_37.jp2")
+        assert ds.GetMetadata("xml:IPR")[0] == "<fake_ipr_box/>"
+        ds = None
+
+        assert validate("/vsimem/jp2openjpeg_37.jp2", expected_gmljp2=False) != "fail"
+        gdal.Unlink("/vsimem/jp2openjpeg_37.jp2")
+
+
+###############################################################################
+# Test non-EPSG SRS (so written with a GML dictionary)
+
+
+def test_jp2openjpeg_38():
+
+    # No metadata
+    src_ds = gdal.GetDriverByName("MEM").Create("", 2, 2)
+    wkt = """PROJCS["UTM Zone 31, Northern Hemisphere",GEOGCS["unnamed ellipse",DATUM["unknown",SPHEROID["unnamed",100,2]],PRIMEM["Greenwich",0],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",3],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH]]"""
+    src_ds.SetProjection(wkt)
+    src_ds.SetGeoTransform([0, 60, 0, 0, 0, -60])
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_38.jp2", src_ds, options=["GeoJP2=NO"]
+    )
+    assert out_ds.GetProjectionRef() == wkt
+    crsdictionary = out_ds.GetMetadata_List("xml:CRSDictionary.gml")[0]
+    out_ds = None
+    gdal.Unlink("/vsimem/jp2openjpeg_38.jp2")
+    gdal.Unlink("/vsimem/jp2openjpeg_38.jp2.aux.xml")
+
+    do_validate = False
+    try:
+        import xmlvalidate
+
+        do_validate = True
+    except ImportError:
+        print("Cannot import xmlvalidate")
+
+    try:
+        os.stat("tmp/cache/SCHEMAS_OPENGIS_NET")
+    except OSError:
+        do_validate = False
+
+    if do_validate:
+        assert xmlvalidate.validate(
+            crsdictionary, ogc_schemas_location="tmp/cache/SCHEMAS_OPENGIS_NET"
+        )
+
+
+###############################################################################
+# Test GMLJP2OVERRIDE configuration option and DGIWG GMLJP2
+
+
+def test_jp2openjpeg_39():
+
+    # No metadata
+    src_ds = gdal.GetDriverByName("MEM").Create("", 20, 20)
+    src_ds.SetGeoTransform([0, 60, 0, 0, 0, -60])
+    # This GML has srsName only on RectifiedGrid (taken from D.2.2.2 from DGIWG_Profile_of_JPEG2000_for_Georeferenced_Imagery.pdf)
+    gdal.FileFromMemBuffer(
+        "/vsimem/override.gml",
+        """<?xml version="1.0" encoding="UTF-8"?>
+<gml:FeatureCollection xmlns:gml="http://www.opengis.net/gml"
+                       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                       xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                       xmlns:gco="http://www.isotc211.org/2005/gco"
+                       xsi:schemaLocation="http://www.opengis.net/gml file:///D:/dgiwg/jp2/GML-3.1.1/profiles/DGIWGgmlJP2Profile/1.1.0/DGIWGgmlJP2Profile.xsd">
+  <gml:featureMember>
+    <gml:FeatureCollection>
+      <!-- feature collection for a specific codestream -->
+      <gml:featureMember>
+        <gml:RectifiedGridCoverage>
+          <gml:rectifiedGridDomain>
+            <gml:RectifiedGrid dimension="2" srsName="urn:ogc:def:crs:EPSG::4326">
+              <gml:limits>
+                <gml:GridEnvelope>
+                  <!-- Image coordinates -->
+                  <gml:low>0 0</gml:low>
+                  <gml:high>4999 9999</gml:high>
+                </gml:GridEnvelope>
+              </gml:limits>
+              <gml:axisName>X</gml:axisName>
+              <gml:axisName>Y</gml:axisName>
+              <!-- The origin location in geo coordinates -->
+              <gml:origin>
+                <gml:Point>
+                  <gml:pos>19.1234567 37.1234567</gml:pos>
+                </gml:Point>
+              </gml:origin>
+              <!--offsetVectors says how much offset each pixel will contribute to, in practice, that is the cell size -->
+              <gml:offsetVector>0.0 0.00001234</gml:offsetVector>
+              <gml:offsetVector> -0.00001234 0.0</gml:offsetVector>
+            </gml:RectifiedGrid>
+          </gml:rectifiedGridDomain>
+          <!--A RectifiedGridCoverage uses the rangeSet to describe the data below is a description of the range of values described by the grid coverage -->
+          <gml:rangeSet>
+            <gml:File>
+              <gml:rangeParameters/>
+              <gml:fileName>gmljp2://codestream/0</gml:fileName>
+              <gml:fileStructure>Record Interleaved</gml:fileStructure>
+            </gml:File>
+          </gml:rangeSet>
+        </gml:RectifiedGridCoverage>
+      </gml:featureMember>
+    </gml:FeatureCollection>
+  </gml:featureMember>
+</gml:FeatureCollection>""",
+    )
+    with gdal.config_option("GMLJP2OVERRIDE", "/vsimem/override.gml"):
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_39.jp2", src_ds, options=["GeoJP2=NO"]
+        )
+    gdal.Unlink("/vsimem/override.gml")
+    del out_ds
+    ds = gdal.Open("/vsimem/jp2openjpeg_39.jp2")
+    assert ds.GetProjectionRef().find("4326") >= 0
+    ds = None
+    gdal.Unlink("/vsimem/jp2openjpeg_39.jp2")
+
+
+###############################################################################
+# Test we can parse GMLJP2 v2.0
+
+
+def test_jp2openjpeg_40():
+
+    # No metadata
+    src_ds = gdal.GetDriverByName("MEM").Create("", 20, 20)
+    src_ds.SetGeoTransform([0, 60, 0, 0, 0, -60])
+
+    gdal.FileFromMemBuffer(
+        "/vsimem/override.gml",
+        """<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
+<gmljp2:GMLJP2CoverageCollection gml:id="JPEG2000_0"
+    xmlns:gml="http://www.opengis.net/gml/3.2"
+    xmlns:gmlcov="http://www.opengis.net/gmlcov/1.0"
+    xmlns:gmljp2="http://www.opengis.net/gmljp2/2.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.opengis.net/gmljp2/2.0 http://schemas.opengis.net/gmljp2/2.0/gmljp2.xsd">
+    <gml:gridDomain/>
+    <gml:rangeSet>
+        <gml:File>
+            <gml:rangeParameters/>
+            <gml:fileName>gmljp2://codestream</gml:fileName>
+            <gml:fileStructure>inapplicable</gml:fileStructure>
+        </gml:File>
+    </gml:rangeSet>
+    <gmlcov:rangeType/>
+    <gmljp2:featureMember>
+        <gmljp2:GMLJP2RectifiedGridCoverage gml:id="CodeStream">
+            <gml:domainSet>
+                <gml:RectifiedGrid gml:id="rg0001" dimension="2"
+                            srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                    <gml:limits>
+                        <gml:GridEnvelope>
+                            <gml:low>0 0</gml:low>
+                            <gml:high>19 19</gml:high>
+                        </gml:GridEnvelope>
+                    </gml:limits>
+                    <gml:axisLabels>Lat Long</gml:axisLabels>
+                    <gml:origin>
+                        <gml:Point gml:id="P0001" srsName="http://www.opengis.net/def/crs/EPSG/0/4326">
+                            <gml:pos>48.95 2.05</gml:pos>
+                        </gml:Point>
+                    </gml:origin>
+                    <gml:offsetVector srsName="http://www.opengis.net/def/crs/EPSG/0/4326">0 0.1</gml:offsetVector>
+                    <gml:offsetVector srsName="http://www.opengis.net/def/crs/EPSG/0/4326">-0.1 0</gml:offsetVector>
+                </gml:RectifiedGrid>
+            </gml:domainSet>
+            <gml:rangeSet>
+                <gml:File>
+                    <gml:rangeParameters/>
+                    <gml:fileName>gmljp2://codestream</gml:fileName>
+                    <gml:fileStructure>inapplicable</gml:fileStructure>
+                </gml:File>
+            </gml:rangeSet>
+            <gmlcov:rangeType/>
+        </gmljp2:GMLJP2RectifiedGridCoverage>
+    </gmljp2:featureMember>
+</gmljp2:GMLJP2CoverageCollection>""",
+    )
+    with gdal.config_option("GMLJP2OVERRIDE", "/vsimem/override.gml"):
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_40.jp2", src_ds, options=["GeoJP2=NO"]
+        )
+    gdal.Unlink("/vsimem/override.gml")
+    del out_ds
+    ds = gdal.Open("/vsimem/jp2openjpeg_40.jp2")
+    assert ds.GetProjectionRef().find("4326") >= 0
+    got_gt = ds.GetGeoTransform()
+    expected_gt = (2, 0.1, 0, 49, 0, -0.1)
+    for i in range(6):
+        assert got_gt[i] == pytest.approx(expected_gt[i], abs=1e-5)
+    ds = None
+    gdal.Unlink("/vsimem/jp2openjpeg_40.jp2")
+
+
+###############################################################################
+# Test USE_SRC_CODESTREAM=YES
+
+
+def test_jp2openjpeg_41():
+
+    src_ds = gdal.Open("data/jpeg2000/byte.jp2")
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_41.jp2",
+        src_ds,
+        options=[
+            "USE_SRC_CODESTREAM=YES",
+            "PROFILE=PROFILE_1",
+            "GEOJP2=NO",
+            "GMLJP2=NO",
+        ],
+    )
+    assert src_ds.GetRasterBand(1).Checksum() == out_ds.GetRasterBand(1).Checksum()
+    del out_ds
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_41.jp2").size == 9923
+    gdal.Unlink("/vsimem/jp2openjpeg_41.jp2")
+    gdal.Unlink("/vsimem/jp2openjpeg_41.jp2.aux.xml")
+
+    # Warning if ignored option
+    gdal.ErrorReset()
+    with gdaltest.error_handler():
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_41.jp2",
+            src_ds,
+            options=["USE_SRC_CODESTREAM=YES", "QUALITY=1"],
+        )
+    del out_ds
+    assert gdal.GetLastErrorMsg() != ""
+    gdal.Unlink("/vsimem/jp2openjpeg_41.jp2")
+    gdal.Unlink("/vsimem/jp2openjpeg_41.jp2.aux.xml")
+
+    # Warning if source is not JPEG2000
+    src_ds = gdal.Open("data/byte.tif")
+    gdal.ErrorReset()
+    with gdaltest.error_handler():
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_41.jp2", src_ds, options=["USE_SRC_CODESTREAM=YES"]
+        )
+    del out_ds
+    assert gdal.GetLastErrorMsg() != ""
+    gdal.Unlink("/vsimem/jp2openjpeg_41.jp2")
+
+
+###############################################################################
+# Test update of existing file
+
+
+def test_jp2openjpeg_42():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 20, 20)
+    with gdaltest.error_handler():
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_42.jp2", src_ds, options=["JP2C_LENGTH_ZERO=YES"]
+        )
+    del out_ds
+
+    # Nothing to rewrite
+    ds = gdal.Open("/vsimem/jp2openjpeg_42.jp2", gdal.GA_Update)
+    del ds
+
+    # Add metadata: will be written after codestream since there's no other georef or metadata box before codestream
+    ds = gdal.Open("/vsimem/jp2openjpeg_42.jp2", gdal.GA_Update)
+    ds.SetMetadataItem("FOO", "BAR")
+    ds = None
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_42.jp2.aux.xml") is None
+
+    # Add metadata and GCP
+    ds = gdal.Open("/vsimem/jp2openjpeg_42.jp2", gdal.GA_Update)
+    assert ds.GetMetadata() == {"FOO": "BAR"}
+    sr = osr.SpatialReference()
+    sr.ImportFromEPSG(32631)
+    gcps = [gdal.GCP(0, 1, 2, 3, 4)]
+    ds.SetGCPs(gcps, sr.ExportToWkt())
+    ds = None
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_42.jp2.aux.xml") is None
+
+    # Check we got metadata and GCP, and there's no GMLJP2 box
+    ds = gdal.Open("/vsimem/jp2openjpeg_42.jp2", gdal.GA_Update)
+    assert ds.GetMetadata() == {"FOO": "BAR"}
+    assert ds.GetGCPCount() == 1
+    assert len(ds.GetMetadataDomainList()) == 2
+    # Unset metadata and GCP
+    ds.SetMetadata(None)
+    ds.SetGCPs([], "")
+    ds = None
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_42.jp2.aux.xml") is None
+
+    # Check we have no longer metadata or GCP
+    ds = gdal.Open("/vsimem/jp2openjpeg_42.jp2", gdal.GA_Update)
+    assert ds.GetMetadata() == {}
+    assert ds.GetGCPCount() == 0
+    assert ds.GetMetadataDomainList() == ["DERIVED_SUBDATASETS"]
+    # Add projection and geotransform
+    ds.SetProjection(sr.ExportToWkt())
+    ds.SetGeoTransform([0, 1, 2, 3, 4, 5])
+    ds = None
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_42.jp2.aux.xml") is None
+
+    # Check them
+    ds = gdal.Open("/vsimem/jp2openjpeg_42.jp2", gdal.GA_Update)
+    assert ds.GetProjectionRef().find("32631") >= 0
+    assert ds.GetGeoTransform() == (0, 1, 2, 3, 4, 5)
+    # Check that we have a GMLJP2 box
+    assert ds.GetMetadataDomainList() == [
+        "xml:gml.root-instance",
+        "DERIVED_SUBDATASETS",
+    ]
+    # Remove projection and geotransform
+    ds.SetProjection("")
+    ds.SetGeoTransform([0, 1, 0, 0, 0, 1])
+    ds = None
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_42.jp2.aux.xml") is None
+
+    # Check we have no longer anything
+    ds = gdal.Open("/vsimem/jp2openjpeg_42.jp2", gdal.GA_Update)
+    assert ds.GetProjectionRef() == ""
+    assert ds.GetGeoTransform() == (0, 1, 0, 0, 0, 1)
+    assert ds.GetMetadataDomainList() == ["DERIVED_SUBDATASETS"]
+    ds = None
+
+    # Create file with georef boxes before codestream, and disable GMLJP2
+    src_ds = gdal.GetDriverByName("MEM").Create("", 20, 20)
+    src_ds.SetProjection(sr.ExportToWkt())
+    src_ds.SetGeoTransform([0, 1, 2, 3, 4, 5])
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_42.jp2", src_ds, options=["GMLJP2=NO"]
+    )
+    del out_ds
+
+    # Modify geotransform
+    ds = gdal.Open("/vsimem/jp2openjpeg_42.jp2", gdal.GA_Update)
+    ds.SetGeoTransform([1, 2, 3, 4, 5, 6])
+    ds = None
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_42.jp2.aux.xml") is None
+
+    # Check it and that we don't have GMLJP2
+    ds = gdal.Open("/vsimem/jp2openjpeg_42.jp2", gdal.GA_Update)
+    assert ds.GetGeoTransform() == (1, 2, 3, 4, 5, 6)
+    assert ds.GetMetadataDomainList() == ["DERIVED_SUBDATASETS"]
+    ds = None
+
+    # Create file with georef boxes before codestream, and disable GeoJP2
+    src_ds = gdal.GetDriverByName("MEM").Create("", 20, 20)
+    src_ds.SetProjection(sr.ExportToWkt())
+    src_ds.SetGeoTransform([2, 3, 0, 4, 0, -5])
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_42.jp2", src_ds, options=["GeoJP2=NO"]
+    )
+    del out_ds
+
+    # Modify geotransform
+    ds = gdal.Open("/vsimem/jp2openjpeg_42.jp2", gdal.GA_Update)
+    assert ds.GetGeoTransform() == (2, 3, 0, 4, 0, -5)
+    ds.SetGeoTransform([1, 2, 0, 3, 0, -4])
+    ds = None
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_42.jp2.aux.xml") is None
+
+    # Check it
+    ds = gdal.Open("/vsimem/jp2openjpeg_42.jp2", gdal.GA_Update)
+    assert ds.GetGeoTransform() == (1, 2, 0, 3, 0, -4)
+    assert ds.GetMetadataDomainList() == [
+        "xml:gml.root-instance",
+        "DERIVED_SUBDATASETS",
+    ]
+    # Add GCPs
+    gcps = [gdal.GCP(0, 1, 2, 3, 4)]
+    ds.SetGCPs(gcps, sr.ExportToWkt())
+    ds = None
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_42.jp2.aux.xml") is None
+
+    # Check it (a GeoJP2 box has been added and GMLJP2 removed)
+    ds = gdal.Open("/vsimem/jp2openjpeg_42.jp2", gdal.GA_Update)
+    assert ds.GetGCPs()
+    assert ds.GetMetadataDomainList() == ["DERIVED_SUBDATASETS"]
+    # Add IPR box
+    ds.SetMetadata(["<fake_ipr_box/>"], "xml:IPR")
+    ds = None
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_42.jp2.aux.xml") is None
+
+    # Check it
+    ds = gdal.Open("/vsimem/jp2openjpeg_42.jp2", gdal.GA_Update)
+    assert ds.GetMetadata("xml:IPR")[0] == "<fake_ipr_box/>"
+    ds = None
+
+    gdal.Unlink("/vsimem/jp2openjpeg_42.jp2")
+
+
+###############################################################################
+# Check a file against a OrthoimageryCoverage document
+
+
+def test_jp2openjpeg_44():
+
+    src_ds = gdal.Open("data/utm.tif")
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_44.jp2", src_ds, options=["INSPIRE_TG=YES"]
+    )
+    del out_ds
+    ret = validate(
+        "/vsimem/jp2openjpeg_44.jp2", oidoc="data/jpeg2000/utm_inspire_tg_oi.xml"
+    )
+    gdal.Unlink("/vsimem/jp2openjpeg_44.jp2")
+    gdal.Unlink("/vsimem/jp2openjpeg_44.jp2.aux.xml")
+
+    return ret
+
+
+###############################################################################
+# Test GMLJP2v2
+
+
+def test_jp2openjpeg_45():
+
+    with gdaltest.error_handler():
+        if ogr.Open("../ogr/data/gml/ionic_wfs.gml") is None:
+            pytest.skip("GML read support missing")
+
+    with gdaltest.error_handler():
+        if ogr.Open("../ogr/data/kml/empty.kml") is None:
+            pytest.skip("KML support missing")
+
+    # Test GMLJP2V2_DEF=YES
+    src_ds = gdal.Open("data/byte.tif")
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_45.jp2", src_ds, options=["GMLJP2V2_DEF=YES"]
+    )
+    assert out_ds.GetLayerCount() == 0
+    assert out_ds.GetLayer(0) is None
+    del out_ds
+
+    ds = gdal.Open("/vsimem/jp2openjpeg_45.jp2")
+    gmljp2 = ds.GetMetadata_List("xml:gml.root-instance")[0]
+    minimal_instance = """<gmljp2:GMLJP2CoverageCollection gml:id="ID_GMLJP2_0"
+     xmlns:gml="http://www.opengis.net/gml/3.2"
+     xmlns:gmlcov="http://www.opengis.net/gmlcov/1.0"
+     xmlns:gmljp2="http://www.opengis.net/gmljp2/2.0"
+     xmlns:swe="http://www.opengis.net/swe/2.0"
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation="http://www.opengis.net/gmljp2/2.0 http://schemas.opengis.net/gmljp2/2.0/gmljp2.xsd">
+  <gml:domainSet nilReason="inapplicable"/>
+  <gml:rangeSet>
+    <gml:DataBlock>
+       <gml:rangeParameters nilReason="inapplicable"/>
+       <gml:doubleOrNilReasonTupleList>inapplicable</gml:doubleOrNilReasonTupleList>
+     </gml:DataBlock>
+  </gml:rangeSet>
+  <gmlcov:rangeType>
+    <swe:DataRecord>
+      <swe:field name="Collection"> </swe:field>
+    </swe:DataRecord>
+  </gmlcov:rangeType>
+  <gmljp2:featureMember>
+   <gmljp2:GMLJP2RectifiedGridCoverage gml:id="RGC_1_ID_GMLJP2_0">
+     <gml:boundedBy>
+       <gml:Envelope srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/26711">
+         <gml:lowerCorner>440720 3750120</gml:lowerCorner>
+         <gml:upperCorner>441920 3751320</gml:upperCorner>
+       </gml:Envelope>
+     </gml:boundedBy>
+     <gml:domainSet>
+      <gml:RectifiedGrid gml:id="RGC_1_GRID_ID_GMLJP2_0" dimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/26711">
+       <gml:limits>
+         <gml:GridEnvelope>
+           <gml:low>0 0</gml:low>
+           <gml:high>19 19</gml:high>
+         </gml:GridEnvelope>
+       </gml:limits>
+       <gml:axisName>x</gml:axisName>
+       <gml:axisName>y</gml:axisName>
+       <gml:origin>
+         <gml:Point gml:id="P0001" srsName="http://www.opengis.net/def/crs/EPSG/0/26711">
+           <gml:pos>440750 3751290</gml:pos>
+         </gml:Point>
+       </gml:origin>
+       <gml:offsetVector srsName="http://www.opengis.net/def/crs/EPSG/0/26711">60 0</gml:offsetVector>
+       <gml:offsetVector srsName="http://www.opengis.net/def/crs/EPSG/0/26711">0 -60</gml:offsetVector>
+      </gml:RectifiedGrid>
+     </gml:domainSet>
+     <gml:rangeSet>
+      <gml:File>
+        <gml:rangeParameters/>
+        <gml:fileName>gmljp2://codestream/0</gml:fileName>
+        <gml:fileStructure>inapplicable</gml:fileStructure>
+      </gml:File>
+     </gml:rangeSet>
+     <gmlcov:rangeType></gmlcov:rangeType>
+   </gmljp2:GMLJP2RectifiedGridCoverage>
+  </gmljp2:featureMember>
+</gmljp2:GMLJP2CoverageCollection>
+"""
+    assert gmljp2 == minimal_instance
+
+    ret = validate("/vsimem/jp2openjpeg_45.jp2", inspire_tg=False)
+    assert ret != "fail"
+
+    gdal.Unlink("/vsimem/jp2openjpeg_45.jp2")
+
+    # GMLJP2V2_DEF={} (inline JSon)
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_45.jp2", src_ds, options=["GMLJP2V2_DEF={}"]
+    )
+    del out_ds
+    ds = gdal.Open("/vsimem/jp2openjpeg_45.jp2")
+    gmljp2 = ds.GetMetadata_List("xml:gml.root-instance")[0]
+    assert gmljp2 == minimal_instance
+    ds = None
+    gdal.Unlink("/vsimem/jp2openjpeg_45.jp2")
+
+    # Invalid JSon
+    gdal.ErrorReset()
+    with gdaltest.error_handler():
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_45.jp2", src_ds, options=["GMLJP2V2_DEF={"]
+        )
+    assert out_ds is None
+
+    # Non existing file
+    gdal.ErrorReset()
+    with gdaltest.error_handler():
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_45.jp2",
+            src_ds,
+            options=["GMLJP2V2_DEF=/vsimem/i_do_not_exist"],
+        )
+    assert out_ds is None
+
+    # Test JSon conf file as a file
+    gdal.FileFromMemBuffer(
+        "/vsimem/conf.json",
+        '{ "root_instance": { "gml_id": "some_gml_id", "crs_url": false } }',
+    )
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_45.jp2", src_ds, options=["GMLJP2V2_DEF=/vsimem/conf.json"]
+    )
+    gdal.Unlink("/vsimem/conf.json")
+    del out_ds
+    ds = gdal.Open("/vsimem/jp2openjpeg_45.jp2")
+    gmljp2 = ds.GetMetadata_List("xml:gml.root-instance")[0]
+    assert "some_gml_id" in gmljp2
+    assert "urn:ogc:def:crs:EPSG::26711" in gmljp2
+    ds = None
+    gdal.Unlink("/vsimem/jp2openjpeg_45.jp2")
+
+    # Test valid values for grid_coverage_range_type_field_predefined_name
+    for predefined in [
+        ["Color", "Color"],
+        ["Elevation_meter", "Elevation"],
+        ["Panchromatic", "Panchromatic"],
+    ]:
+        gdal.FileFromMemBuffer(
+            "/vsimem/conf.json",
+            '{ "root_instance": { "grid_coverage_range_type_field_predefined_name": "%s" } }'
+            % predefined[0],
+        )
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_45.jp2",
+            src_ds,
+            options=["GMLJP2V2_DEF=/vsimem/conf.json"],
+        )
+        gdal.Unlink("/vsimem/conf.json")
+        del out_ds
+        ds = gdal.Open("/vsimem/jp2openjpeg_45.jp2")
+        gmljp2 = ds.GetMetadata_List("xml:gml.root-instance")[0]
+        assert predefined[1] in gmljp2
+        ds = None
+        gdal.Unlink("/vsimem/jp2openjpeg_45.jp2")
+
+    # Test invalid value for grid_coverage_range_type_field_predefined_name
+    gdal.FileFromMemBuffer(
+        "/vsimem/conf.json",
+        '{ "root_instance": { "grid_coverage_range_type_field_predefined_name": "invalid" } }',
+    )
+    with gdaltest.error_handler():
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_45.jp2",
+            src_ds,
+            options=["GMLJP2V2_DEF=/vsimem/conf.json"],
+        )
+    gdal.Unlink("/vsimem/conf.json")
+    del out_ds
+    ds = gdal.Open("/vsimem/jp2openjpeg_45.jp2")
+    gmljp2 = ds.GetMetadata_List("xml:gml.root-instance")[0]
+    assert "<gmlcov:rangeType></gmlcov:rangeType>" in gmljp2
+    ds = None
+    gdal.Unlink("/vsimem/jp2openjpeg_45.jp2")
+
+    # Test valid values for grid_coverage_range_type_file
+    gdal.FileFromMemBuffer(
+        "/vsimem/grid_coverage_range_type_file.xml",
+        """
+<swe:DataRecord><swe:field name="custom_datarecord">
+    <swe:Quantity definition="http://custom">
+        <swe:description>custom</swe:description>
+        <swe:uom code="unity"/>
+    </swe:Quantity></swe:field></swe:DataRecord>
+""",
+    )
+    gdal.FileFromMemBuffer(
+        "/vsimem/conf.json",
+        '{ "root_instance": { "grid_coverage_range_type_file": "/vsimem/grid_coverage_range_type_file.xml" } }',
+    )
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_45.jp2", src_ds, options=["GMLJP2V2_DEF=/vsimem/conf.json"]
+    )
+    gdal.Unlink("/vsimem/conf.json")
+    gdal.Unlink("/vsimem/grid_coverage_range_type_file.xml")
+    del out_ds
+    ds = gdal.Open("/vsimem/jp2openjpeg_45.jp2")
+    gmljp2 = ds.GetMetadata_List("xml:gml.root-instance")[0]
+    assert "custom_datarecord" in gmljp2, predefined[0]
+    ds = None
+    gdal.Unlink("/vsimem/jp2openjpeg_45.jp2")
+
+    # Test most invalid cases
+    import json
+
+    conf = {
+        "root_instance": {
+            "grid_coverage_file": "/vsimem/i_dont_exist.xml",
+        }
+    }
+
+    gdal.ErrorReset()
+    with gdaltest.error_handler():
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_45.jp2",
+            src_ds,
+            options=["GMLJP2V2_DEF=" + json.dumps(conf)],
+        )
+    assert out_ds is None
+
+    conf = {
+        "root_instance": {
+            "grid_coverage_range_type_file": "/vsimem/i_dont_exist.xml",
+            "metadata": [
+                "<invalid_root/>",
+                "/vsimem/i_dont_exist.xml",
+                {
+                    "file": "/vsimem/third_metadata.xml",
+                    "parent_node": "CoverageCollection",
+                },
+                {"content": "<invalid_content", "parent_node": "invalid_value"},
+            ],
+            "annotations": [
+                "/vsimem/i_dont_exist.shp",
+                "/vsimem/i_dont_exist.kml",
+                "../gcore/data/byte.tif",
+            ],
+            "gml_filelist": [
+                "/vsimem/i_dont_exist.xml",
+                "../gcore/data/byte.tif",
+                {
+                    "file": "/vsimem/i_dont_exist.shp",
+                    "parent_node": "invalid_value",
+                    "schema_location": "gmljp2://xml/schema_that_does_not_exist.xsd",
+                },
+            ],
+            "styles": [
+                "/vsimem/i_dont_exist.xml",
+                "../gcore/data/byte.tif",
+                {"file": "/vsimem/i_dont_exist.xml", "parent_node": "invalid_value"},
+            ],
+            "extensions": [
+                "/vsimem/i_dont_exist.xml",
+                "../gcore/data/byte.tif",
+                {"file": "/vsimem/i_dont_exist.xml", "parent_node": "invalid_value"},
+            ],
+        },
+        "boxes": [
+            "/vsimem/i_dont_exist.xsd",
+            {"file": "/vsimem/i_dont_exist_too.xsd", "label": "i_dont_exist.xsd"},
+        ],
+    }
+    with gdaltest.error_handler():
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_45.jp2",
+            src_ds,
+            options=["GMLJP2V2_DEF=" + json.dumps(conf)],
+        )
+    del out_ds
+    gdal.Unlink("/vsimem/jp2openjpeg_45.jp2")
+
+    # Test most options: valid case
+    gdal.FileFromMemBuffer(
+        "/vsimem/second_metadata.xml",
+        """<gmljp2:dcMetadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Second metadata</dc:title>
+</gmljp2:dcMetadata>""",
+    )
+
+    gdal.FileFromMemBuffer(
+        "/vsimem/third_metadata.xml",
+        """<gmljp2:dcMetadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dc:title>Third metadata</dc:title>
+</gmljp2:dcMetadata>""",
+    )
+
+    gdal.FileFromMemBuffer(
+        "/vsimem/feature.xml",
+        """<FeatureCollection gml:id="myFC1" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns="http://www.opengis.net/gml/3.2">
+    <featureMember>
+        <Observation gml:id="myFC1_Observation">
+            <validTime/>
+            <resultOf/>
+        </Observation>
+    </featureMember>
+</FeatureCollection>""",
+    )
+
+    gdal.FileFromMemBuffer(
+        "/vsimem/a_schema.xsd",
+        """<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:ogr="http://ogr.maptools.org/" targetNamespace="http://ogr.maptools.org/" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gmlsf="http://www.opengis.net/gmlsf/2.0" elementFormDefault="qualified" version="1.0">
+  <xs:annotation>
+    <xs:appinfo source="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd">
+      <gmlsf:ComplianceLevel>0</gmlsf:ComplianceLevel>
+    </xs:appinfo>
+  </xs:annotation>
+  <xs:import namespace="http://www.opengis.net/gml/3.2" schemaLocation="http://schemas.opengis.net/gml/3.2.1/gml.xsd" />
+  <xs:import namespace="http://www.opengis.net/gmlsf/2.0" schemaLocation="http://schemas.opengis.net/gmlsfProfile/2.0/gmlsfLevels.xsd" />
+  <xs:element name="FeatureCollection" type="ogr:FeatureCollectionType" substitutionGroup="gml:AbstractGML" />
+  <xs:complexType name="FeatureCollectionType">
+    <xs:complexContent>
+      <xs:extension base="gml:AbstractFeatureType">
+        <xs:sequence minOccurs="0" maxOccurs="unbounded">
+          <xs:element name="featureMember">
+            <xs:complexType>
+              <xs:complexContent>
+                <xs:extension base="gml:AbstractFeatureMemberType">
+                  <xs:sequence>
+                    <xs:element ref="gml:AbstractFeature" />
+                  </xs:sequence>
+                </xs:extension>
+              </xs:complexContent>
+            </xs:complexType>
+          </xs:element>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+  <xs:element name="myshape" type="ogr:myshape_Type" substitutionGroup="gml:AbstractFeature" />
+  <xs:complexType name="myshape_Type">
+    <xs:complexContent>
+      <xs:extension base="gml:AbstractFeatureType">
+        <xs:sequence>
+          <xs:element name="geometryProperty" type="gml:PointPropertyType" nillable="true" minOccurs="0" maxOccurs="1" />
+          <xs:element name="foo" nillable="true" minOccurs="0" maxOccurs="1">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:maxLength value="80" />
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:element>
+        </xs:sequence>
+      </xs:extension>
+    </xs:complexContent>
+  </xs:complexType>
+</xs:schema>""",
+    )
+
+    for name in ["myshape", "myshape2"]:
+        ds = ogr.GetDriverByName("ESRI Shapefile").CreateDataSource(
+            "/vsimem/" + name + ".shp"
+        )
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(4326)
+        lyr = ds.CreateLayer(name, srs=srs)
+        lyr.CreateField(ogr.FieldDefn("foo", ogr.OFTString))
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f.SetField("foo", "bar")
+        f.SetGeometry(ogr.CreateGeometryFromWkt("POINT(2 49)"))
+        lyr.CreateFeature(f)
+        ds = None
+
+    gdal.FileFromMemBuffer(
+        "/vsimem/feature2.gml",
+        """<FeatureCollection xmlns:ogr="http://ogr.maptools.org/" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ogr.maptools.org/ http://dummy" gml:id="myFC3">
+    <featureMember>
+        <Observation gml:id="myFC3_Observation">
+            <validTime/>
+            <resultOf/>
+        </Observation>
+    </featureMember>
+</FeatureCollection>""",
+    )
+
+    gdal.FileFromMemBuffer(
+        "/vsimem/feature3.gml",
+        """<FeatureCollection xmlns:ogr="http://ogr.maptools.org/" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd http://ogr.maptools.org/ http://dummy" gml:id="myFC4">
+    <featureMember>
+        <Observation gml:id="myFC4_Observation">
+            <validTime/>
+            <resultOf/>
+        </Observation>
+    </featureMember>
+</FeatureCollection>""",
+    )
+
+    gdal.FileFromMemBuffer(
+        "/vsimem/empty.kml",
+        """<?xml version="1.0" encoding="UTF-8"?>
+<kml xmlns="http://www.opengis.net/kml/2.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/kml/2.2 http://schemas.opengis.net/kml/2.2.0/ogckml22.xsd">
+    <Document id="empty_doc"/>
+</kml>
+""",
+    )
+
+    gdal.FileFromMemBuffer("/vsimem/style1.xml", '<style1 xmlns="http://dummy" />')
+    gdal.FileFromMemBuffer(
+        "/vsimem/style2.xml", '<mydummyns:style2 xmlns:mydummyns="http://dummy" />'
+    )
+    gdal.FileFromMemBuffer("/vsimem/style3.xml", "<style3 />")
+    gdal.FileFromMemBuffer("/vsimem/style4.xml", "<style4 />")
+
+    gdal.FileFromMemBuffer(
+        "/vsimem/extension1.xml", '<extension1 xmlns="http://dummy" />'
+    )
+    gdal.FileFromMemBuffer(
+        "/vsimem/extension2.xml",
+        '<mydummyns:extension2 xmlns:mydummyns="http://dummy" />',
+    )
+    gdal.FileFromMemBuffer("/vsimem/extension3.xml", "<extension3 />")
+    gdal.FileFromMemBuffer("/vsimem/extension4.xml", "<extension4 />")
+
+    # So that the Python text is real JSon
+    false = False
+
+    conf = {
+        "root_instance": {
+            "grid_coverage_file": "/vsimem/grid_coverage_file.xml",
+            "metadata": [
+                "<gmljp2:metadata>First metadata</gmljp2:metadata>",
+                "/vsimem/second_metadata.xml",
+                {
+                    "file": "/vsimem/third_metadata.xml",
+                    "parent_node": "CoverageCollection",
+                },
+                {
+                    "content": """<?xml version="1.0" encoding="UTF-8"?>
+<!-- some comments -->
+<gmljp2:eopMetadata>
+        <eop:EarthObservation xmlns:eop="http://www.opengis.net/eop/2.0" xmlns:om="http://www.opengis.net/om/2.0" gml:id="EOP1">
+                <om:phenomenonTime></om:phenomenonTime>
+                <om:resultTime></om:resultTime>
+                <om:procedure></om:procedure>
+                <om:observedProperty></om:observedProperty>
+                <om:featureOfInterest></om:featureOfInterest>
+                <om:result></om:result>
+                <eop:metaDataProperty>
+                        <eop:EarthObservationMetaData>
+                                <eop:identifier>Fourth metadata</eop:identifier>
+                                <eop:acquisitionType>NOMINAL</eop:acquisitionType>
+                                <eop:status>ACQUIRED</eop:status>
+                        </eop:EarthObservationMetaData>
+                </eop:metaDataProperty>
+        </eop:EarthObservation>
+</gmljp2:eopMetadata>""",
+                    "parent_node": "GridCoverage",
+                },
+            ],
+            "annotations": ["/vsimem/myshape.shp", "/vsimem/empty.kml"],
+            "gml_filelist": [
+                "/vsimem/feature.xml",
+                {
+                    "file": "/vsimem/myshape.shp",
+                    "inline": false,
+                    "parent_node": "CoverageCollection",
+                },
+                {
+                    "file": "/vsimem/myshape2.shp",
+                    "namespace": "http://ogr.maptools.org/",
+                    "inline": false,
+                    "schema_location": "gmljp2://xml/a_schema.xsd",
+                    "parent_node": "GridCoverage",
+                },
+                {
+                    "file": "/vsimem/feature2.gml",
+                    "inline": false,
+                    "schema_location": "gmljp2://xml/a_schema.xsd",
+                },
+                {
+                    "file": "/vsimem/feature3.gml",
+                    "inline": false,
+                    "namespace": "http://ogr.maptools.org/",
+                    "schema_location": "gmljp2://xml/a_schema.xsd",
+                },
+            ],
+            "styles": [
+                "/vsimem/style1.xml",
+                {"file": "/vsimem/style2.xml", "parent_node": "GridCoverage"},
+                {"file": "/vsimem/style3.xml", "parent_node": "CoverageCollection"},
+                {"file": "/vsimem/style4.xml"},
+            ],
+            "extensions": [
+                "/vsimem/extension1.xml",
+                {"file": "/vsimem/extension2.xml", "parent_node": "GridCoverage"},
+                {"file": "/vsimem/extension3.xml", "parent_node": "CoverageCollection"},
+                {"file": "/vsimem/extension4.xml"},
+            ],
+        },
+        "boxes": [
+            "/vsimem/a_schema.xsd",
+            {"file": "/vsimem/a_schema.xsd", "label": "duplicated.xsd"},
+        ],
+    }
+    gdal.FileFromMemBuffer(
+        "/vsimem/grid_coverage_file.xml",
+        """
+    <gmljp2:GMLJP2RectifiedGridCoverage gml:id="my_GMLJP2RectifiedGridCoverage">
+     <gml:domainSet>
+      <gml:RectifiedGrid gml:id="RGC_1_GRID_ID_GMLJP2_0" dimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/26711">
+       <gml:limits>
+         <gml:GridEnvelope>
+           <gml:low>0 0</gml:low>
+           <gml:high>19 19</gml:high>
+         </gml:GridEnvelope>
+       </gml:limits>
+       <gml:axisName>x</gml:axisName>
+       <gml:axisName>y</gml:axisName>
+       <gml:origin>
+         <gml:Point gml:id="P0001" srsName="http://www.opengis.net/def/crs/EPSG/0/26711">
+           <gml:pos>440750 3751290</gml:pos>
+         </gml:Point>
+       </gml:origin>
+       <gml:offsetVector srsName="http://www.opengis.net/def/crs/EPSG/0/26711">60 0</gml:offsetVector>
+       <gml:offsetVector srsName="http://www.opengis.net/def/crs/EPSG/0/26711">0 -60</gml:offsetVector>
+      </gml:RectifiedGrid>
+     </gml:domainSet>
+     <gml:rangeSet>
+      <gml:File>
+        <gml:rangeParameters/>
+        <gml:fileName>gmljp2://codestream/0</gml:fileName>
+        <gml:fileStructure>inapplicable</gml:fileStructure>
+      </gml:File>
+     </gml:rangeSet>
+     <gmlcov:rangeType/>
+   </gmljp2:GMLJP2RectifiedGridCoverage>
+""",
+    )
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_45.jp2",
+        src_ds,
+        options=["GMLJP2V2_DEF=" + json.dumps(conf)],
+    )
+    gdal.Unlink("/vsimem/grid_coverage_file.xml")
+    gdal.Unlink("/vsimem/second_metadata.xml")
+    gdal.Unlink("/vsimem/third_metadata.xml")
+    gdal.Unlink("/vsimem/feature.xml")
+    for name in ["myshape", "myshape2"]:
+        gdal.Unlink("/vsimem/" + name + ".shp")
+        gdal.Unlink("/vsimem/" + name + ".shx")
+        gdal.Unlink("/vsimem/" + name + ".dbf")
+        gdal.Unlink("/vsimem/" + name + ".prj")
+    gdal.Unlink("/vsimem/feature2.gml")
+    gdal.Unlink("/vsimem/feature3.gml")
+    gdal.Unlink("/vsimem/empty.kml")
+    gdal.Unlink("/vsimem/a_schema.xsd")
+    gdal.Unlink("/vsimem/style1.xml")
+    gdal.Unlink("/vsimem/style2.xml")
+    gdal.Unlink("/vsimem/style3.xml")
+    gdal.Unlink("/vsimem/style4.xml")
+    gdal.Unlink("/vsimem/extension1.xml")
+    gdal.Unlink("/vsimem/extension2.xml")
+    gdal.Unlink("/vsimem/extension3.xml")
+    gdal.Unlink("/vsimem/extension4.xml")
+    del out_ds
+
+    # Now do the checks
+    dircontent = gdal.ReadDir("/vsimem/gmljp2")
+    assert dircontent is None
+
+    ds = gdal.Open("/vsimem/jp2openjpeg_45.jp2")
+    gmljp2 = ds.GetMetadata_List("xml:gml.root-instance")[0]
+    assert "my_GMLJP2RectifiedGridCoverage" in gmljp2
+    first_metadata_pos = gmljp2.find("First metadata")
+    second_metadata_pos = gmljp2.find("Second metadata")
+    third_metadata_pos = gmljp2.find("Third metadata")
+    GMLJP2RectifiedGridCoverage_pos = gmljp2.find("GMLJP2RectifiedGridCoverage")
+    fourth_metadata_pos = gmljp2.find("Fourth metadata")
+    feature_pos = gmljp2.find("""<FeatureCollection gml:id="ID_GMLJP2_0_0_myFC1" """)
+    myshape_gml_pos = gmljp2.find(
+        """<gmljp2:feature xlink:href="gmljp2://xml/myshape.gml" """
+    )
+    myshape2_gml_pos = gmljp2.find(
+        """<gmljp2:feature xlink:href="gmljp2://xml/myshape2.gml" """
+    )
+    feature2_pos = gmljp2.find(
+        """<gmljp2:feature xlink:href="gmljp2://xml/feature2.gml" """
+    )
+    feature3_pos = gmljp2.find(
+        """<gmljp2:feature xlink:href="gmljp2://xml/feature3.gml" """
+    )
+    myshape_kml_pos = gmljp2.find("""<Document id="root_doc_0">""")
+    empty_kml_pos = gmljp2.find("""<Document id="empty_doc" />""")
+    style1_pos = gmljp2.find("""<style1 xmlns="http://dummy" />""")
+    style2_pos = gmljp2.find("""<mydummyns:style2 xmlns:mydummyns="http://dummy" />""")
+    style3_pos = gmljp2.find("""<style3 xmlns="http://undefined_namespace" />""")
+    style4_pos = gmljp2.find("""<style4 xmlns="http://undefined_namespace" />""")
+    extension1_pos = gmljp2.find("""<extension1 xmlns="http://dummy" />""")
+    extension2_pos = gmljp2.find(
+        """<mydummyns:extension2 xmlns:mydummyns="http://dummy" />"""
+    )
+    extension3_pos = gmljp2.find(
+        """<extension3 xmlns="http://undefined_namespace" />"""
+    )
+    extension4_pos = gmljp2.find(
+        """<extension4 xmlns="http://undefined_namespace" />"""
+    )
+
+    assert (
+        first_metadata_pos >= 0
+        and second_metadata_pos >= 0
+        and third_metadata_pos >= 0
+        and GMLJP2RectifiedGridCoverage_pos >= 0
+        and fourth_metadata_pos >= 0
+        and feature_pos >= 0
+        and myshape_gml_pos >= 0
+        and myshape2_gml_pos >= 0
+        and feature2_pos >= 0
+        and myshape_kml_pos >= 0
+        and empty_kml_pos >= 0
+        and style1_pos >= 0
+        and style2_pos >= 0
+        and style3_pos >= 0
+        and style4_pos >= 0
+        and extension1_pos >= 0
+        and extension2_pos >= 0
+        and extension3_pos >= 0
+        and extension4_pos >= 0
+        and (
+            first_metadata_pos < second_metadata_pos
+            and second_metadata_pos < third_metadata_pos
+            and third_metadata_pos < GMLJP2RectifiedGridCoverage_pos
+            and GMLJP2RectifiedGridCoverage_pos < fourth_metadata_pos
+            and fourth_metadata_pos < feature_pos
+            and fourth_metadata_pos < feature_pos
+            and myshape2_gml_pos < myshape_kml_pos
+            and myshape_kml_pos < empty_kml_pos
+            and empty_kml_pos < style2_pos
+            and style2_pos < extension2_pos
+            and extension2_pos < feature_pos
+            and feature_pos < myshape_gml_pos
+            and myshape_gml_pos < feature2_pos
+            and feature2_pos < feature3_pos
+            and feature3_pos < style1_pos
+            and style1_pos < style3_pos
+            and style3_pos < style4_pos
+            and style4_pos < extension1_pos
+            and extension1_pos < extension3_pos
+            and extension3_pos < extension4_pos
+        )
+    ), gmljp2
+    # print(gmljp2)
+
+    myshape_gml = ds.GetMetadata_List("xml:myshape.gml")[0]
+    assert (
+        """<ogr1:FeatureCollection gml:id="ID_GMLJP2_0_1_aFeatureCollection" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ogr.maptools.org/1 gmljp2://xml/myshape.xsd" xmlns:ogr1="http://ogr.maptools.org/1" xmlns:gml="http://www.opengis.net/gml/3.2">"""
+        in myshape_gml
+    )
+    assert """http://www.opengis.net/def/crs/EPSG/0/4326""" in myshape_gml
+
+    myshape_xsd = ds.GetMetadata_List("xml:myshape.xsd")[0]
+    assert (
+        """<xs:schema targetNamespace="http://ogr.maptools.org/1" xmlns:ogr1="http://ogr.maptools.org/1" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:gmlsf="http://www.opengis.net/gmlsf/2.0" elementFormDefault="qualified" version="1.0">"""
+        in myshape_xsd
+    )
+
+    myshape2_gml = ds.GetMetadata_List("xml:myshape2.gml")[0]
+    assert (
+        """<ogr2:FeatureCollection gml:id="ID_GMLJP2_0_2_aFeatureCollection" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ogr.maptools.org/ gmljp2://xml/a_schema.xsd" xmlns:ogr2="http://ogr.maptools.org/" xmlns:gml="http://www.opengis.net/gml/3.2">"""
+        in myshape2_gml
+    )
+
+    feature2_gml = ds.GetMetadata_List("xml:feature2.gml")[0]
+    assert (
+        """<FeatureCollection xmlns:ogr="http://ogr.maptools.org/" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://ogr.maptools.org/ gmljp2://xml/a_schema.xsd" gml:id="ID_GMLJP2_0_3_myFC3">"""
+        in feature2_gml
+    )
+
+    feature3_gml = ds.GetMetadata_List("xml:feature3.gml")[0]
+    assert (
+        """<FeatureCollection xmlns:ogr="http://ogr.maptools.org/" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.opengis.net/gml/3.2 http://schemas.opengis.net/gml/3.2.1/gml.xsd http://ogr.maptools.org/ gmljp2://xml/a_schema.xsd" gml:id="ID_GMLJP2_0_4_myFC4">"""
+        in feature3_gml
+    )
+
+    myshape2_xsd = ds.GetMetadata_List("xml:a_schema.xsd")[0]
+    assert """<xs:schema xmlns:ogr="http://ogr.maptools.org/" """ in myshape2_xsd
+
+    duplicated_xsd = ds.GetMetadata_List("xml:duplicated.xsd")[0]
+    assert (
+        """<xs:schema xmlns:ogr="http://ogr.maptools.org/" """ in duplicated_xsd
+    ), myshape2_xsd
+
+    ds = None
+
+    ds = ogr.Open("/vsimem/jp2openjpeg_45.jp2")
+    assert ds.GetLayerCount() == 6, [
+        ds.GetLayer(j).GetName() for j in range(ds.GetLayerCount())
+    ]
+    expected_layers = [
+        "FC_GridCoverage_1_myshape",
+        "FC_CoverageCollection_1_Observation",
+        "FC_CoverageCollection_2_myshape",
+        "FC_CoverageCollection_3_myshape",
+        "FC_CoverageCollection_4_myshape",
+        "Annotation_1_myshape",
+    ]
+    for j in range(6):
+        if ds.GetLayer(j).GetName() != expected_layers[j]:
+            for i in range(ds.GetLayerCount()):
+                print(ds.GetLayer(i).GetName())
+            pytest.fail()
+    ds = None
+
+    ret = validate("/vsimem/jp2openjpeg_45.jp2", inspire_tg=False)
+    assert ret != "fail"
+
+    gdal.Unlink("/vsimem/jp2openjpeg_45.jp2")
+
+    # Test reading a feature collection with a schema and within GridCoverage
+    conf = {
+        "root_instance": {
+            "gml_filelist": [
+                {"file": "../ogr/data/poly.shp", "parent_node": "GridCoverage"}
+            ]
+        }
+    }
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_45.jp2",
+        src_ds,
+        options=["GMLJP2V2_DEF=" + json.dumps(conf)],
+    )
+    del out_ds
+
+    dircontent = gdal.ReadDir("/vsimem/gmljp2")
+    assert dircontent is None
+
+    ds = ogr.Open("/vsimem/jp2openjpeg_45.jp2")
+    assert ds.GetLayerCount() == 1
+    assert ds.GetLayer(0).GetName() == "FC_GridCoverage_1_poly"
+    ds = None
+
+    gdal.Unlink("/vsimem/jp2openjpeg_45.jp2")
+
+    # Test serializing GDAL metadata
+    true = True
+    conf = {"root_instance": {"metadata": [{"gdal_metadata": true}]}}
+    src_ds = gdal.GetDriverByName("MEM").Create("", 10, 10)
+    sr = osr.SpatialReference()
+    sr.ImportFromEPSG(32631)
+    src_ds.SetProjection(sr.ExportToWkt())
+    src_ds.SetGeoTransform([450000, 1, 0, 5000000, 0, -1])
+    src_ds.SetMetadataItem("FOO", "BAR")
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_45.jp2",
+        src_ds,
+        options=["GMLJP2V2_DEF=" + json.dumps(conf)],
+    )
+    del out_ds
+    if gdal.VSIStatL("/vsimem/jp2openjpeg_45.jp2.aux.xml") is not None:
+        fp = gdal.VSIFOpenL("/vsimem/jp2openjpeg_45.jp2.aux.xml", "rb")
+        if fp is not None:
+            data = gdal.VSIFReadL(1, 100000, fp).decode("ascii")
+            gdal.VSIFCloseL(fp)
+            print(data)
+        pytest.fail()
+
+    ds = gdal.Open("/vsimem/jp2openjpeg_45.jp2")
+    assert ds.GetMetadata() == {"FOO": "BAR"}
+    ds = None
+
+    gdal.Unlink("/vsimem/jp2openjpeg_45.jp2")
+
+    # Test writing&reading a gmljp2:featureMember pointing to a remote resource
+    conf = {
+        "root_instance": {
+            "gml_filelist": [
+                {
+                    "remote_resource": "https://raw.githubusercontent.com/OSGeo/gdal/release/3.1/autotest/ogr/data/expected_gml_gml32.gml"
+                }
+            ]
+        }
+    }
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_45.jp2",
+        src_ds,
+        options=["GMLJP2V2_DEF=" + json.dumps(conf)],
+    )
+    del out_ds
+
+    # Nothing should be reported by default
+    ds = ogr.Open("/vsimem/jp2openjpeg_45.jp2")
+    assert ds is None
+    ds = None
+
+    # We have to explicitly allow it.
+    ds = gdal.OpenEx("/vsimem/jp2openjpeg_45.jp2", open_options=["OPEN_REMOTE_GML=YES"])
+    gdal.Unlink("/vsimem/jp2openjpeg_45.jp2")
+
+    if ds is None:
+        if (
+            gdaltest.gdalurlopen(
+                "https://raw.githubusercontent.com/OSGeo/gdal/release/3.1/autotest/ogr/data/expected_gml_gml32.gml"
+            )
+            is None
+        ):
+            pytest.skip()
+        pytest.fail()
+    assert ds.GetLayerCount() == 1
+    ds = None
+
+    gdal.Unlink("/vsimem/jp2openjpeg_45.jp2.aux.xml")
+
+
+###############################################################################
+# Test GMLJP2v2 metadata generator / XPath
+
+
+def test_jp2openjpeg_46():
+
+    import json
+
+    conf = {
+        "root_instance": {
+            "metadata": [
+                {
+                    "dynamic_metadata": {
+                        "template": "/vsimem/template.xml",
+                        "source": "/vsimem/source.xml",
+                    }
+                }
+            ]
+        }
+    }
+
+    gdal.FileFromMemBuffer(
+        "/vsimem/template.xml",
+        """<gmljp2:metadata>{{{ XPATH(1) }}} {{{ XPATH('str') }}} {{{ XPATH(true()) }}}X{{{ XPATH(//B) }}} {{{XPATH(if(//B/text() = 'my_value',if(false(),'not_expected',concat('yeah: ',uuid())),'doh!'))}}}</gmljp2:metadata>""",
+    )
+
+    gdal.FileFromMemBuffer("/vsimem/source.xml", """<A><B>my_value</B></A>""")
+
+    src_ds = gdal.Open("data/byte.tif")
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/jp2openjpeg_46.jp2",
+        src_ds,
+        options=["GMLJP2V2_DEF=" + json.dumps(conf)],
+    )
+    gdal.Unlink("/vsimem/template.xml")
+    gdal.Unlink("/vsimem/source.xml")
+    del out_ds
+    if gdal.GetLastErrorMsg().find("dynamic_metadata not supported") >= 0:
+        gdal.Unlink("/vsimem/jp2openjpeg_46.jp2")
+        pytest.skip()
+    # Maybe a conflict with FileGDB libxml2
+    if gdal.GetLastErrorMsg().find("An error occurred in libxml2") >= 0:
+        gdal.Unlink("/vsimem/jp2openjpeg_46.jp2")
+        pytest.skip()
+
+    ds = gdal.Open("/vsimem/jp2openjpeg_46.jp2")
+    gmljp2 = ds.GetMetadata_List("xml:gml.root-instance")[0]
+    if (
+        """<gmljp2:metadata>1 str trueX
+        <B>my_value</B>
+yeah: """
+        not in gmljp2
+    ):
+        if """<gmljp2:metadata>1 str true""" in gmljp2:
+            pytest.skip()
+        pytest.fail(gmljp2)
+    ds = None
+
+    gdal.Unlink("/vsimem/jp2openjpeg_46.jp2")
+
+    for invalid_template in [
+        "<gmljp2:metadata>{{{</gmljp2:metadata>",
+        "<gmljp2:metadata>{{{}}}</gmljp2:metadata>",
+        "<gmljp2:metadata>{{{XPATH</gmljp2:metadata>",
+        "<gmljp2:metadata>{{{XPATH(1)</gmljp2:metadata>",
+        "<gmljp2:metadata>{{{XPATH(}}}</gmljp2:metadata>",
+        "<gmljp2:metadata>{{{XPATH()}}}</gmljp2:metadata>",
+        "<gmljp2:metadata>{{{XPATH(//node[)}}}</gmljp2:metadata>",
+    ]:
+
+        gdal.FileFromMemBuffer("/vsimem/template.xml", invalid_template)
+        gdal.FileFromMemBuffer("/vsimem/source.xml", """<A/>""")
+
+        gdal.ErrorReset()
+        with gdaltest.error_handler():
+            out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+                "/vsimem/jp2openjpeg_46.jp2",
+                src_ds,
+                options=["GMLJP2V2_DEF=" + json.dumps(conf)],
+            )
+        # print('error : ' + gdal.GetLastErrorMsg())
+        gdal.Unlink("/vsimem/template.xml")
+        gdal.Unlink("/vsimem/source.xml")
+        del out_ds
+
+        ds = gdal.Open("/vsimem/jp2openjpeg_46.jp2")
+        gmljp2 = ds.GetMetadata_List("xml:gml.root-instance")[0]
+        ds = None
+
+        gdal.Unlink("/vsimem/jp2openjpeg_46.jp2")
+
+        assert "<gmljp2:metadata>" not in gmljp2, invalid_template
+
+    # Nonexistent template.
+    gdal.FileFromMemBuffer("/vsimem/source.xml", """<A/>""")
+    conf = {
+        "root_instance": {
+            "metadata": [
+                {
+                    "dynamic_metadata": {
+                        "template": "/vsimem/not_existing_template.xml",
+                        "source": "/vsimem/source.xml",
+                    }
+                }
+            ]
+        }
+    }
+    gdal.ErrorReset()
+    with gdaltest.error_handler():
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_46.jp2",
+            src_ds,
+            options=["GMLJP2V2_DEF=" + json.dumps(conf)],
+        )
+    del out_ds
+    gdal.Unlink("/vsimem/source.xml")
+    gdal.Unlink("/vsimem/jp2openjpeg_46.jp2")
+
+    # Nonexistent source
+    gdal.FileFromMemBuffer(
+        "/vsimem/template.xml", """<gmljp2:metadata></gmljp2:metadata>"""
+    )
+    conf = {
+        "root_instance": {
+            "metadata": [
+                {
+                    "dynamic_metadata": {
+                        "template": "/vsimem/template.xml",
+                        "source": "/vsimem/not_existing_source.xml",
+                    }
+                }
+            ]
+        }
+    }
+    gdal.ErrorReset()
+    with gdaltest.error_handler():
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_46.jp2",
+            src_ds,
+            options=["GMLJP2V2_DEF=" + json.dumps(conf)],
+        )
+    del out_ds
+    gdal.Unlink("/vsimem/template.xml")
+    gdal.Unlink("/vsimem/jp2openjpeg_46.jp2")
+
+    # Invalid source
+    gdal.FileFromMemBuffer(
+        "/vsimem/template.xml", """<gmljp2:metadata></gmljp2:metadata>"""
+    )
+    gdal.FileFromMemBuffer("/vsimem/source.xml", """<A""")
+    conf = {
+        "root_instance": {
+            "metadata": [
+                {
+                    "dynamic_metadata": {
+                        "template": "/vsimem/template.xml",
+                        "source": "/vsimem/source.xml",
+                    }
+                }
+            ]
+        }
+    }
+    gdal.ErrorReset()
+    with gdaltest.error_handler():
+        out_ds = gdaltest.jp2openjpeg_drv.CreateCopy(
+            "/vsimem/jp2openjpeg_46.jp2",
+            src_ds,
+            options=["GMLJP2V2_DEF=" + json.dumps(conf)],
+        )
+    del out_ds
+    gdal.Unlink("/vsimem/template.xml")
+    gdal.Unlink("/vsimem/source.xml")
+    # ds = gdal.Open('/vsimem/jp2openjpeg_46.jp2')
+    # gmljp2 = ds.GetMetadata_List("xml:gml.root-instance")[0]
+    # print(gmljp2)
+    # ds = None
+    gdal.Unlink("/vsimem/jp2openjpeg_46.jp2")
+
+
+###############################################################################
+# Test GMLJP2v2 and axis swap (#3866)
+
+
+def test_jp2openjpeg_gmljp2v2_axis_swap():
+
+    # Test GMLJP2V2_DEF=YES
+    src_ds = gdal.Open("data/byte.tif")
+    tmp_ds = gdal.Warp("", src_ds, options="-of MEM -t_srs EPSG:4267")
+    gdaltest.jp2openjpeg_drv.CreateCopy(
+        "/vsimem/test_jp2openjpeg_gmljp2v2_axis_swap.jp2",
+        tmp_ds,
+        options=["GMLJP2V2_DEF=YES"],
+    )
+
+    ds = gdal.Open("/vsimem/test_jp2openjpeg_gmljp2v2_axis_swap.jp2")
+    gdal.Unlink("/vsimem/test_jp2openjpeg_gmljp2v2_axis_swap.jp2")
+    gmljp2 = ds.GetMetadata_List("xml:gml.root-instance")[0]
+    # print(gmljp2)
+    assert (
+        """<gml:boundedBy>
+       <gml:Envelope srsDimension="2" srsName="http://www.opengis.net/def/crs/EPSG/0/4267">
+         <gml:lowerCorner>33.8916535473944 -117.641168620797</gml:lowerCorner>
+         <gml:upperCorner>33.9024195619211 -117.628010158598</gml:upperCorner>
+       </gml:Envelope>
+     </gml:boundedBy>"""
+        in gmljp2
+    )
+
+
+###############################################################################
+# Test writing & reading RPC in GeoJP2 box
+
+
+def test_jp2openjpeg_47():
+
+    src_ds = gdal.Open("../gcore/data/byte_rpc.tif")
+    out_ds = gdaltest.jp2openjpeg_drv.CreateCopy("/vsimem/jp2openjpeg_47.jp2", src_ds)
+    del out_ds
+    assert gdal.VSIStatL("/vsimem/jp2openjpeg_47.jp2.aux.xml") is None
+
+    ds = gdal.Open("/vsimem/jp2openjpeg_47.jp2")
+    assert ds.GetMetadata("RPC") is not None
+    ds = None
+
+    gdal.Unlink("/vsimem/jp2openjpeg_47.jp2")
+
+
+###############################################################################
+# Test reading a dataset whose tile dimensions are larger than dataset ones
+
+
+def test_jp2openjpeg_48():
+
+    ds = gdal.Open("data/jpeg2000/byte_tile_2048.jp2")
+    (blockxsize, blockysize) = ds.GetRasterBand(1).GetBlockSize()
+    assert (blockxsize, blockysize) == (20, 20)
+    assert ds.GetRasterBand(1).Checksum() == 4610
+    ds = None
+
+
+###############################################################################
+
+
+def test_jp2openjpeg_online_1():
+
+    gdaltest.download_or_skip(
+        "http://download.osgeo.org/gdal/data/jpeg2000/7sisters200.j2k",
+        "7sisters200.j2k",
+    )
+
+    # Checksum = 32669 on my PC
+    tst = gdaltest.GDALTest(
+        "JP2Grok", "tmp/cache/7sisters200.j2k", 1, None, filename_absolute=1
+    )
+
+    tst.testOpen()
+
+    ds = gdal.Open("tmp/cache/7sisters200.j2k")
+    ds.GetRasterBand(1).Checksum()
+    ds = None
+
+
+###############################################################################
+
+
+def test_jp2openjpeg_online_2():
+
+    gdaltest.download_or_skip(
+        "http://download.osgeo.org/gdal/data/jpeg2000/gcp.jp2", "gcp.jp2"
+    )
+
+    # Checksum = 15621 on my PC
+    tst = gdaltest.GDALTest(
+        "JP2Grok", "tmp/cache/gcp.jp2", 1, None, filename_absolute=1
+    )
+
+    tst.testOpen()
+
+    ds = gdal.Open("tmp/cache/gcp.jp2")
+    ds.GetRasterBand(1).Checksum()
+    assert len(ds.GetGCPs()) == 15, "bad number of GCP"
+
+    assert ds.GetGCPSpatialRef().GetAuthorityCode(None) == "4326"
+
+    ds = None
+
+
+###############################################################################
+
+
+def test_jp2openjpeg_online_3():
+
+    gdaltest.download_or_skip(
+        "http://www.openjpeg.org/samples/Bretagne1.j2k", "Bretagne1.j2k"
+    )
+
+    gdaltest.download_or_skip(
+        "http://www.openjpeg.org/samples/Bretagne1.bmp", "Bretagne1.bmp"
+    )
+
+    tst = gdaltest.GDALTest(
+        "JP2Grok", "tmp/cache/Bretagne1.j2k", 1, None, filename_absolute=1
+    )
+
+    tst.testOpen()
+
+    ds = gdal.Open("tmp/cache/Bretagne1.j2k")
+    ds_ref = gdal.Open("tmp/cache/Bretagne1.bmp")
+    maxdiff = gdaltest.compare_ds(ds, ds_ref)
+    print(ds.GetRasterBand(1).Checksum())
+    print(ds_ref.GetRasterBand(1).Checksum())
+
+    ds = None
+    ds_ref = None
+
+    # Difference between the image before and after compression
+    assert maxdiff <= 17, "Image too different from reference"
+
+
+###############################################################################
+
+
+def test_jp2openjpeg_online_4():
+
+    gdaltest.download_or_skip(
+        "http://www.openjpeg.org/samples/Bretagne2.j2k", "Bretagne2.j2k"
+    )
+
+    gdaltest.download_or_skip(
+        "http://www.openjpeg.org/samples/Bretagne2.bmp", "Bretagne2.bmp"
+    )
+
+    tst = gdaltest.GDALTest(
+        "JP2Grok", "tmp/cache/Bretagne2.j2k", 1, None, filename_absolute=1
+    )
+
+    tst.testOpen()
+
+    ds = gdal.Open("tmp/cache/Bretagne2.j2k")
+    ds_ref = gdal.Open("tmp/cache/Bretagne2.bmp")
+    maxdiff = gdaltest.compare_ds(ds, ds_ref, 0, 0, 1024, 1024)
+    print(ds.GetRasterBand(1).Checksum())
+    print(ds_ref.GetRasterBand(1).Checksum())
+
+    ds = None
+    ds_ref = None
+
+    # Difference between the image before and after compression
+    assert maxdiff <= 10, "Image too different from reference"
+
+
+###############################################################################
+# Try reading JP2OpenJPEG with color table
+
+
+def test_jp2openjpeg_online_5():
+
+    gdaltest.download_or_skip(
+        "http://www.gwg.nga.mil/ntb/baseline/software/testfile/Jpeg2000/jp2_09/file9.jp2",
+        "file9.jp2",
+    )
+
+    ds = gdal.Open("tmp/cache/file9.jp2")
+    cs1 = ds.GetRasterBand(1).Checksum()
+    assert cs1 == 47664, "Did not get expected checksums"
+    assert (
+        ds.GetRasterBand(1).GetColorTable() is not None
+    ), "Did not get expected color table"
+    ds = None
+
+
+###############################################################################
+# Try reading YCbCr JP2OpenJPEG as RGB
+
+
+def test_jp2openjpeg_online_6():
+
+    gdaltest.download_or_skip(
+        "http://www.gwg.nga.mil/ntb/baseline/software/testfile/Jpeg2000/jp2_03/file3.jp2",
+        "file3.jp2",
+    )
+
+    ds = gdal.Open("tmp/cache/file3.jp2")
+    cs1 = ds.GetRasterBand(1).Checksum()
+    cs2 = ds.GetRasterBand(2).Checksum()
+    cs3 = ds.GetRasterBand(3).Checksum()
+    assert (
+        cs1 == 26140 and cs2 == 32689 and cs3 == 48247
+    ), "Did not get expected checksums"
+
+    ds = None
+
+
+###############################################################################
+# Test GDAL_GEOREF_SOURCES
+
+
+def test_jp2openjpeg_49():
+
+    tests = [
+        (None, True, True, 'LOCAL_CS["PAM"]', (100.0, 1.0, 0.0, 300.0, 0.0, -1.0)),
+        (None, True, False, 'LOCAL_CS["PAM"]', (100.0, 1.0, 0.0, 300.0, 0.0, -1.0)),
+        (None, False, True, "", (99.5, 1.0, 0.0, 200.5, 0.0, -1.0)),
+        (None, False, False, "", (0.0, 1.0, 0.0, 0.0, 0.0, 1.0)),
+        ("INTERNAL", True, True, "", (0.0, 1.0, 0.0, 0.0, 0.0, 1.0)),
+        (
+            "INTERNAL,PAM",
+            True,
+            True,
+            'LOCAL_CS["PAM"]',
+            (100.0, 1.0, 0.0, 300.0, 0.0, -1.0),
+        ),
+        ("INTERNAL,WORLDFILE", True, True, "", (99.5, 1.0, 0.0, 200.5, 0.0, -1.0)),
+        (
+            "INTERNAL,PAM,WORLDFILE",
+            True,
+            True,
+            'LOCAL_CS["PAM"]',
+            (100.0, 1.0, 0.0, 300.0, 0.0, -1.0),
+        ),
+        (
+            "INTERNAL,WORLDFILE,PAM",
+            True,
+            True,
+            'LOCAL_CS["PAM"]',
+            (99.5, 1.0, 0.0, 200.5, 0.0, -1.0),
+        ),
+        ("WORLDFILE,PAM,INTERNAL", False, False, "", (0.0, 1.0, 0.0, 0.0, 0.0, 1.0)),
+        ("PAM,WORLDFILE,INTERNAL", False, False, "", (0.0, 1.0, 0.0, 0.0, 0.0, 1.0)),
+        ("PAM", True, True, 'LOCAL_CS["PAM"]', (100.0, 1.0, 0.0, 300.0, 0.0, -1.0)),
+        (
+            "PAM,WORLDFILE",
+            True,
+            True,
+            'LOCAL_CS["PAM"]',
+            (100.0, 1.0, 0.0, 300.0, 0.0, -1.0),
+        ),
+        ("WORLDFILE", True, True, "", (99.5, 1.0, 0.0, 200.5, 0.0, -1.0)),
+        (
+            "WORLDFILE,PAM",
+            True,
+            True,
+            'LOCAL_CS["PAM"]',
+            (99.5, 1.0, 0.0, 200.5, 0.0, -1.0),
+        ),
+        ("WORLDFILE,INTERNAL", True, True, "", (99.5, 1.0, 0.0, 200.5, 0.0, -1.0)),
+        (
+            "WORLDFILE,PAM,INTERNAL",
+            True,
+            True,
+            'LOCAL_CS["PAM"]',
+            (99.5, 1.0, 0.0, 200.5, 0.0, -1.0),
+        ),
+        (
+            "WORLDFILE,INTERNAL,PAM",
+            True,
+            True,
+            'LOCAL_CS["PAM"]',
+            (99.5, 1.0, 0.0, 200.5, 0.0, -1.0),
+        ),
+        ("NONE", True, True, "", (0.0, 1.0, 0.0, 0.0, 0.0, 1.0)),
+    ]
+
+    for (
+        config_option_value,
+        copy_pam,
+        copy_worldfile,
+        expected_srs,
+        expected_gt,
+    ) in tests:
+        with gdal.config_option("GDAL_GEOREF_SOURCES", config_option_value):
+            gdal.FileFromMemBuffer(
+                "/vsimem/byte_nogeoref.jp2",
+                open("data/jpeg2000/byte_nogeoref.jp2", "rb").read(),
+            )
+            if copy_pam:
+                gdal.FileFromMemBuffer(
+                    "/vsimem/byte_nogeoref.jp2.aux.xml",
+                    open("data/jpeg2000/byte_nogeoref.jp2.aux.xml", "rb").read(),
+                )
+            if copy_worldfile:
+                gdal.FileFromMemBuffer(
+                    "/vsimem/byte_nogeoref.j2w",
+                    open("data/jpeg2000/byte_nogeoref.j2w", "rb").read(),
+                )
+            ds = gdal.Open("/vsimem/byte_nogeoref.jp2")
+            gt = ds.GetGeoTransform()
+            srs_wkt = ds.GetProjectionRef()
+            ds = None
+        gdal.Unlink("/vsimem/byte_nogeoref.jp2")
+        gdal.Unlink("/vsimem/byte_nogeoref.jp2.aux.xml")
+        gdal.Unlink("/vsimem/byte_nogeoref.j2w")
+
+        if gt != expected_gt:
+            print("Got " + str(gt))
+            print("Expected " + str(expected_gt))
+            pytest.fail(
+                "Did not get expected gt for %s,copy_pam=%s,copy_worldfile=%s"
+                % (config_option_value, str(copy_pam), str(copy_worldfile))
+            )
+
+        if (
+            expected_srs == 'LOCAL_CS["PAM"]'
+            and srs_wkt
+            == 'LOCAL_CS["PAM",UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH]]'
+        ):
+            pass  # ok
+        elif (expected_srs == "" and srs_wkt != "") or (
+            expected_srs != "" and expected_srs not in srs_wkt
+        ):
+            print("Got " + srs_wkt)
+            print("Expected " + expected_srs)
+            pytest.fail(
+                "Did not get expected SRS for %s,copy_pam=%s,copy_worldfile=%s"
+                % (config_option_value, str(copy_pam), str(copy_worldfile))
+            )
+
+    tests = [
+        (None, True, True, 'LOCAL_CS["PAM"]', (100.0, 1.0, 0.0, 300.0, 0.0, -1.0)),
+        (None, True, False, 'LOCAL_CS["PAM"]', (100.0, 1.0, 0.0, 300.0, 0.0, -1.0)),
+        (None, False, True, "26711", (440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0)),
+        (None, False, False, "26711", (440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0)),
+        ("INTERNAL", True, True, "26711", (440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0)),
+        (
+            "INTERNAL,PAM",
+            True,
+            True,
+            "26711",
+            (440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0),
+        ),
+        (
+            "INTERNAL,WORLDFILE",
+            True,
+            True,
+            "26711",
+            (440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0),
+        ),
+        (
+            "INTERNAL,PAM,WORLDFILE",
+            True,
+            True,
+            "26711",
+            (440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0),
+        ),
+        (
+            "INTERNAL,WORLDFILE,PAM",
+            True,
+            True,
+            "26711",
+            (440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0),
+        ),
+        (
+            "WORLDFILE,PAM,INTERNAL",
+            False,
+            False,
+            "26711",
+            (440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0),
+        ),
+        (
+            "PAM,WORLDFILE,INTERNAL",
+            False,
+            False,
+            "26711",
+            (440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0),
+        ),
+        ("GEOJP2", True, True, "26711", (440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0)),
+        (
+            "GEOJP2,GMLJP2",
+            True,
+            True,
+            "26711",
+            (440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0),
+        ),
+        ("GMLJP2", True, True, "26712", (439970.0, 60.0, 0.0, 3751030.0, 0.0, -60.0)),
+        (
+            "GMLJP2,GEOJP2",
+            True,
+            True,
+            "26712",
+            (439970.0, 60.0, 0.0, 3751030.0, 0.0, -60.0),
+        ),
+        ("MSIG", True, True, "", (0.0, 1.0, 0.0, 0.0, 0.0, 1.0)),
+        (
+            "MSIG,GMLJP2,GEOJP2",
+            True,
+            True,
+            "26712",
+            (439970.0, 60.0, 0.0, 3751030.0, 0.0, -60.0),
+        ),
+        (
+            "MSIG,GEOJP2,GMLJP2",
+            True,
+            True,
+            "26711",
+            (440720.0, 60.0, 0.0, 3751320.0, 0.0, -60.0),
+        ),
+        ("PAM", True, True, 'LOCAL_CS["PAM"]', (100.0, 1.0, 0.0, 300.0, 0.0, -1.0)),
+        (
+            "PAM,WORLDFILE",
+            True,
+            True,
+            'LOCAL_CS["PAM"]',
+            (100.0, 1.0, 0.0, 300.0, 0.0, -1.0),
+        ),
+        ("WORLDFILE", True, True, "", (99.5, 1.0, 0.0, 200.5, 0.0, -1.0)),
+        (
+            "WORLDFILE,PAM",
+            True,
+            True,
+            'LOCAL_CS["PAM"]',
+            (99.5, 1.0, 0.0, 200.5, 0.0, -1.0),
+        ),
+        ("WORLDFILE,INTERNAL", True, True, "26711", (99.5, 1.0, 0.0, 200.5, 0.0, -1.0)),
+        (
+            "WORLDFILE,PAM,INTERNAL",
+            True,
+            True,
+            'LOCAL_CS["PAM"]',
+            (99.5, 1.0, 0.0, 200.5, 0.0, -1.0),
+        ),
+        (
+            "WORLDFILE,INTERNAL,PAM",
+            True,
+            True,
+            "26711",
+            (99.5, 1.0, 0.0, 200.5, 0.0, -1.0),
+        ),
+        ("NONE", True, True, "", (0.0, 1.0, 0.0, 0.0, 0.0, 1.0)),
+    ]
+
+    for (
+        config_option_value,
+        copy_pam,
+        copy_worldfile,
+        expected_srs,
+        expected_gt,
+    ) in tests:
+        gdal.FileFromMemBuffer(
+            "/vsimem/inconsitant_geojp2_gmljp2.jp2",
+            open("data/jpeg2000/inconsitant_geojp2_gmljp2.jp2", "rb").read(),
+        )
+        if copy_pam:
+            gdal.FileFromMemBuffer(
+                "/vsimem/inconsitant_geojp2_gmljp2.jp2.aux.xml",
+                open(
+                    "data/jpeg2000/inconsitant_geojp2_gmljp2.jp2.aux.xml", "rb"
+                ).read(),
+            )
+        if copy_worldfile:
+            gdal.FileFromMemBuffer(
+                "/vsimem/inconsitant_geojp2_gmljp2.j2w",
+                open("data/jpeg2000/inconsitant_geojp2_gmljp2.j2w", "rb").read(),
+            )
+        open_options = []
+        if config_option_value is not None:
+            open_options += ["GEOREF_SOURCES=" + config_option_value]
+        ds = gdal.OpenEx(
+            "/vsimem/inconsitant_geojp2_gmljp2.jp2", open_options=open_options
+        )
+        gt = ds.GetGeoTransform()
+        srs_wkt = ds.GetProjectionRef()
+        ds = None
+        gdal.Unlink("/vsimem/inconsitant_geojp2_gmljp2.jp2")
+        gdal.Unlink("/vsimem/inconsitant_geojp2_gmljp2.jp2.aux.xml")
+        gdal.Unlink("/vsimem/inconsitant_geojp2_gmljp2.j2w")
+
+        if gt != expected_gt:
+            print("Got " + str(gt))
+            print("Expected " + str(expected_gt))
+            pytest.fail(
+                "Did not get expected gt for %s,copy_pam=%s,copy_worldfile=%s"
+                % (config_option_value, str(copy_pam), str(copy_worldfile))
+            )
+
+        if (
+            expected_srs == 'LOCAL_CS["PAM"]'
+            and srs_wkt
+            == 'LOCAL_CS["PAM",UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH]]'
+        ):
+            pass  # ok
+        elif (expected_srs == "" and srs_wkt != "") or (
+            expected_srs != "" and expected_srs not in srs_wkt
+        ):
+            print("Got " + srs_wkt)
+            print("Expected " + expected_srs)
+            pytest.fail(
+                "Did not get expected SRS for %s,copy_pam=%s,copy_worldfile=%s"
+                % (config_option_value, str(copy_pam), str(copy_worldfile))
+            )
+
+    ds = gdal.OpenEx(
+        "data/jpeg2000/inconsitant_geojp2_gmljp2.jp2",
+        open_options=["GEOREF_SOURCES=PAM,WORLDFILE"],
+    )
+    fl = ds.GetFileList()
+    assert set(fl) == set(
+        [
+            "data/jpeg2000/inconsitant_geojp2_gmljp2.jp2",
+            "data/jpeg2000/inconsitant_geojp2_gmljp2.jp2.aux.xml",
+        ]
+    ), "Did not get expected filelist"
+
+    gdal.ErrorReset()
+    with gdaltest.error_handler():
+        gdal.OpenEx(
+            "data/jpeg2000/inconsitant_geojp2_gmljp2.jp2",
+            open_options=["GEOREF_SOURCES=unhandled"],
+        )
+        assert gdal.GetLastErrorMsg() != "", "expected warning"
+
+
+###############################################################################
+# Test opening an image of small dimension with very small tiles (#7012)
+
+
+def test_jp2openjpeg_50():
+
+    ds = gdal.Open("data/jpeg2000/fake_sent2_preview.jp2")
+    blockxsize, blockysize = ds.GetRasterBand(1).GetBlockSize()
+    assert (
+        blockxsize == ds.RasterXSize and blockysize == ds.RasterYSize
+    ), "expected warning"
+    cs = ds.GetRasterBand(1).Checksum()
+    assert cs == 2046, "expected warning"
+
+
+###############################################################################
+# Test CODEBLOCK_STYLE
+
+
+@pytest.mark.require_creation_option("JP2Grok", "CODEBLOCK_STYLE")
+def test_jp2openjpeg_codeblock_style():
+
+    filename = "/vsimem/jp2openjpeg_codeblock_style.jp2"
+    for options in [
+        ["CODEBLOCK_STYLE=63", "REVERSIBLE=YES", "QUALITY=100"],
+        [
+            "CODEBLOCK_STYLE=BYPASS,RESET,TERMALL,VSC,PREDICTABLE,SEGSYM",
+            "REVERSIBLE=YES",
+            "QUALITY=100",
+        ],
+    ]:
+        gdal.ErrorReset()
+        gdaltest.jp2openjpeg_drv.CreateCopy(
+            filename, gdal.Open("data/byte.tif"), options=options
+        )
+        assert gdal.GetLastErrorMsg() == ""
+        ds = gdal.Open(filename)
+        cs = ds.GetRasterBand(1).Checksum()
+        ds = None
+        assert cs == 4672
+
+    with gdaltest.error_handler():
+        gdaltest.jp2openjpeg_drv.CreateCopy(
+            filename, gdal.Open("data/byte.tif"), options=["CODEBLOCK_STYLE=64"]
+        )
+    assert gdal.GetLastErrorMsg() != ""
+
+    with gdaltest.error_handler():
+        gdaltest.jp2openjpeg_drv.CreateCopy(
+            filename,
+            gdal.Open("data/byte.tif"),
+            options=["CODEBLOCK_STYLE=UNSUPPORTED"],
+        )
+    assert gdal.GetLastErrorMsg() != ""
+
+    gdaltest.jp2openjpeg_drv.Delete(filename)
+
+
+###############################################################################
+# Test external overviews
+
+
+def test_jp2openjpeg_external_overviews_single_band():
+
+    filename = "/vsimem/jp2openjpeg_external_overviews_single_band.jp2"
+    gdaltest.jp2openjpeg_drv.CreateCopy(
+        filename,
+        gdal.Open("../gcore/data/utmsmall.tif"),
+        options=["REVERSIBLE=YES", "QUALITY=100"],
+    )
+    ds = gdal.Open(filename)
+    ds.BuildOverviews("NEAR", [2])
+    ds = None
+
+    ds = gdal.Open(filename)
+    cs = ds.GetRasterBand(1).GetOverview(0).Checksum()
+    ds = None
+
+    gdaltest.jp2openjpeg_drv.Delete(filename)
+
+    assert cs == 28926
+
+
+###############################################################################
+# Test external overviews
+
+
+def test_jp2openjpeg_external_overviews_multiple_band():
+
+    filename = "/vsimem/jp2openjpeg_external_overviews_multiple_band.jp2"
+    gdaltest.jp2openjpeg_drv.CreateCopy(
+        filename,
+        gdal.Open("data/small_world.tif"),
+        options=["REVERSIBLE=YES", "QUALITY=100"],
+    )
+    ds = gdal.Open(filename)
+    ds.BuildOverviews("NEAR", [2])
+    ds = None
+
+    ds = gdal.Open(filename)
+    cs = [ds.GetRasterBand(i + 1).GetOverview(0).Checksum() for i in range(3)]
+    ds = None
+
+    gdaltest.jp2openjpeg_drv.Delete(filename)
+
+    assert cs == [6233, 7706, 26085]
+
+
+###############################################################################
+# Test accessing overview levels when the dimensions of the full resolution
+# image are not a multiple of 2^numresolutions
+
+
+def test_jp2openjpeg_odd_dimensions():
+
+    ds = gdal.Open("data/jpeg2000/513x513.jp2")
+    cs = ds.GetRasterBand(1).GetOverview(0).Checksum()
+    ds = None
+
+    assert cs == 29642
+
+
+###############################################################################
+
+
+@pytest.mark.require_creation_option("JP2Grok", "CODEBLOCK_STYLE")
+def test_jp2openjpeg_odd_dimensions_overviews():
+
+    # Check that we don't request outside of the full resolution coordinates
+    ds = gdal.Open("data/jpeg2000/single_block_32769_16385.jp2")
+    assert ds.ReadRaster(0, 0, ds.RasterXSize, ds.RasterYSize, 2049, 1025)
+    assert gdal.GetLastErrorMsg() == ""
+    ds = None
+
+
+###############################################################################
+# Test reading an image whose origin is not (0,0)
+
+
+def test_jp2openjpeg_image_origin_not_zero():
+
+    ds = gdal.Open("data/jpeg2000/byte_image_origin_not_zero.jp2")
+    assert ds.GetRasterBand(1).Checksum() == 4672
+    assert ds.GetRasterBand(1).ReadRaster(0, 0, 20, 20, 10, 10) is not None
+
+
+###############################################################################
+# Test reading an image whose tile size is 16 (#2984)
+
+
+def test_jp2openjpeg_tilesize_16():
+
+    # Generated with gdal_translate byte.tif foo.jp2 -of jp2openjpeg -outsize 256 256 -co blockxsize=16 -co blockysize=16 -co BLOCKSIZE_STRICT=true -co resolutions=3
+    ds = gdal.Open("data/jpeg2000/tile_size_16.jp2")
+    assert ds.GetRasterBand(1).Checksum() == 44216
+    assert ds.GetRasterBand(1).GetOverview(0).Checksum() == 61711
+
+
+###############################################################################
+# Test generation of PLT marker segments
+
+
+@pytest.mark.require_creation_option(
+    "JP2Grok", "PLT"
+)  # Only try the test with openjpeg >= 2.4.0 that supports it
+def test_jp2openjpeg_generate_PLT():
+
+    filename = "/vsimem/temp.jp2"
+    gdaltest.jp2openjpeg_drv.CreateCopy(
+        filename,
+        gdal.Open("data/byte.tif"),
+        options=["PLT=YES", "REVERSIBLE=YES", "QUALITY=100"],
+    )
+
+    ds = gdal.Open(filename)
+    assert ds.GetRasterBand(1).Checksum() == 4672
+    ds = None
+
+    # Check presence of a PLT marker
+    ret = gdal.GetJPEG2000StructureAsString(filename, ["ALL=YES"])
+    assert '<Marker name="PLT"' in ret
+
+    gdaltest.jp2openjpeg_drv.Delete(filename)
+
+
+###############################################################################
+# Test generation of TLM marker segments
+
+
+@pytest.mark.require_creation_option(
+    "JP2Grok", "TLM"
+)  # Only try the test with openjpeg >= 2.5.0 that supports it
+def test_jp2openjpeg_generate_TLM():
+
+    filename = "/vsimem/temp.jp2"
+    gdaltest.jp2openjpeg_drv.CreateCopy(
+        filename,
+        gdal.Open("data/byte.tif"),
+        options=["TLM=YES", "REVERSIBLE=YES", "QUALITY=100"],
+    )
+
+    ds = gdal.Open(filename)
+    assert ds.GetRasterBand(1).Checksum() == 4672
+    ds = None
+
+    # Check presence of a TLM marker
+    ret = gdal.GetJPEG2000StructureAsString(filename, ["ALL=YES"])
+    assert '<Marker name="TLM"' in ret
+
+    gdaltest.jp2openjpeg_drv.Delete(filename)
+
+
+###############################################################################
+# Test STRICT=NO open option
+
+
+@pytest.mark.require_creation_option(
+    "JP2Grok", "'STRICT'"
+)  # Only try the test with openjpeg >= 2.5.0 that supports it
+def test_jp2openjpeg_STRICT_NO():
+
+    filename = "data/jpeg2000/small_world_truncated.jp2"
+
+    ds = gdal.Open(filename)
+    with gdaltest.error_handler():
+        assert ds.GetRasterBand(1).Checksum() == -1
+    ds = None
+
+    ds = gdal.OpenEx(filename, open_options=["STRICT=NO"])
+    with gdaltest.error_handler():
+        assert ds.GetRasterBand(1).Checksum() == 5058
+    ds = None
+
+
+###############################################################################
+# Test REVERSIBLE=YES with QUALITY != 100
+
+
+def test_jp2openjpeg_reversible_quality_not_100():
+
+    filename = "/vsimem/temp.jp2"
+    gdaltest.jp2openjpeg_drv.CreateCopy(
+        filename,
+        gdal.Open("data/byte.tif"),
+        options=["REVERSIBLE=YES", "QUALITY=90"],
+    )
+
+    ds = gdal.Open(filename)
+    assert ds.GetRasterBand(1).Checksum() != 4672
+    assert ds.GetMetadataItem("COMPRESSION_REVERSIBILITY", "IMAGE_STRUCTURE") == "LOSSY"
+    ds = None
+
+    gdaltest.jp2openjpeg_drv.Delete(filename)
+
+
+###############################################################################
+# Test https://github.com/OSGeo/gdal/pull/7055
+
+
+def test_jp2openjpeg_mosaic():
+
+    src_ds_names = []
+    for j in range(10):
+        for i in range(10):
+            src_ds = gdal.GetDriverByName("MEM").Create("", 10, 10)
+            src_ds.SetGeoTransform([i * 10, 1, 0, j * 10, 0, -1])
+            src_ds.GetRasterBand(1).Fill(255)
+            jp2_filename = "/vsimem/test_%d_%d.jp2" % (j, i)
+            gdaltest.jp2openjpeg_drv.CreateCopy(jp2_filename, src_ds)
+            src_ds_names.append(jp2_filename)
+    with gdal.config_option("GDAL_MAX_DATASET_POOL_RAM_USAGE", "500"):
+        vrt_ds = gdal.BuildVRT("", src_ds_names)
+        assert vrt_ds.GetRasterBand(1).Checksum() == 57182
+    for name in src_ds_names:
+        gdal.Unlink(name)
+
+
+###############################################################################
+
+
+@pytest.mark.require_curl()
+def test_jp2openjpeg_vrt_protocol():
+
+    (webserver_process, webserver_port) = webserver.launch(
+        handler=webserver.DispatcherHttpHandler
+    )
+    if webserver_port == 0:
+        pytest.skip("cannot start HTTP server")
+
+    gdal.VSICurlClearCache()
+
+    try:
+        handler = webserver.FileHandler(
+            {"/byte.jp2": open("data/jpeg2000/byte.jp2", "rb").read()}
+        )
+        with webserver.install_http_handler(handler):
+            gdal.ErrorReset()
+            http_filename = "http://localhost:%d/byte.jp2" % webserver_port
+            ds = gdal.Open("vrt://" + http_filename)
+            assert gdal.GetLastErrorMsg() == ""
+
+            gdal.GetDriverByName("VRT").CreateCopy("/vsimem/out.vrt", ds)
+
+            fp = gdal.VSIFOpenL("/vsimem/out.vrt", "rb")
+            if fp is not None:
+                data = gdal.VSIFReadL(1, 100000, fp).decode("ascii")
+                gdal.VSIFCloseL(fp)
+            gdal.Unlink("/vsimem/out.vrt")
+            assert http_filename in data
+
+    finally:
+        webserver.server_stop(webserver_process, webserver_port)
+
+        gdal.VSICurlClearCache()

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -1280,8 +1280,8 @@ def compare_ds(ds1, ds2, xoff=0, yoff=0, width=0, height=0, verbose=1):
 
 
 def deregister_all_jpeg2000_drivers_but(name_of_driver_to_keep):
-    global jp2kak_drv, jpeg2000_drv, jp2ecw_drv, jp2mrsid_drv, jp2openjpeg_drv, jp2lura_drv
-    global jp2kak_drv_unregistered, jpeg2000_drv_unregistered, jp2ecw_drv_unregistered, jp2mrsid_drv_unregistered, jp2openjpeg_drv_unregistered, jp2lura_drv_unregistered
+    global jp2kak_drv, jpeg2000_drv, jp2ecw_drv, jp2mrsid_drv, jp2openjpeg_drv, jp2lura_drv, jp2grok_drv
+    global jp2kak_drv_unregistered, jpeg2000_drv_unregistered, jp2ecw_drv_unregistered, jp2mrsid_drv_unregistered, jp2openjpeg_drv_unregistered, jp2lura_drv_unregistered, jp2grok_drv_unregistered
 
     # Deregister other potential conflicting JPEG2000 drivers that will
     # be re-registered in the cleanup
@@ -1315,6 +1315,12 @@ def deregister_all_jpeg2000_drivers_but(name_of_driver_to_keep):
         jp2openjpeg_drv.Deregister()
         jp2openjpeg_drv_unregistered = True
 
+    jp2grok_drv = gdal.GetDriverByName("JP2Grok")
+    if name_of_driver_to_keep != "JP2Grok" and jp2grok_drv:
+        gdal.Debug("gdaltest.", "Deregistering JP2Grok")
+        jp2grok_drv.Deregister()
+        jp2grok_drv_unregistered = True
+
     jp2lura_drv = gdal.GetDriverByName("JP2Lura")
     if name_of_driver_to_keep != "JP2Lura" and jp2lura_drv:
         gdal.Debug("gdaltest.", "Deregistering JP2Lura")
@@ -1330,8 +1336,8 @@ def deregister_all_jpeg2000_drivers_but(name_of_driver_to_keep):
 
 
 def reregister_all_jpeg2000_drivers():
-    global jp2kak_drv, jpeg2000_drv, jp2ecw_drv, jp2mrsid_drv, jp2openjpeg_drv, jp2lura_drv
-    global jp2kak_drv_unregistered, jpeg2000_drv_unregistered, jp2ecw_drv_unregistered, jp2mrsid_drv_unregistered, jp2openjpeg_drv_unregistered, jp2lura_drv_unregistered
+    global jp2kak_drv, jpeg2000_drv, jp2ecw_drv, jp2mrsid_drv, jp2openjpeg_drv, jp2lura_drv, jp2grok_drv
+    global jp2kak_drv_unregistered, jpeg2000_drv_unregistered, jp2ecw_drv_unregistered, jp2mrsid_drv_unregistered, jp2openjpeg_drv_unregistered, jp2lura_drv_unregistered, jp2grok_drv_unregistered
 
     if jp2kak_drv_unregistered:
         jp2kak_drv.Register()
@@ -1357,6 +1363,11 @@ def reregister_all_jpeg2000_drivers():
         jp2openjpeg_drv.Register()
         jp2openjpeg_drv_unregistered = False
         gdal.Debug("gdaltest", "Registering JP2OpenJPEG")
+
+    if jp2grok_drv_unregistered:
+        jp2grok_drv.Register()
+        jp2grok_drv_unregistered = False
+        gdal.Debug("gdaltest", "Registering JP2Grok")
 
     if jp2lura_drv_unregistered:
         jp2lura_drv.Register()

--- a/cmake/helpers/CheckDependentLibraries.cmake
+++ b/cmake/helpers/CheckDependentLibraries.cmake
@@ -759,6 +759,17 @@ gdal_check_package(MONGOCXX "Enable MongoDBV3 driver" CAN_DISABLE)
 define_find_package2(HEIF libheif/heif.h heif PKGCONFIG_NAME libheif)
 gdal_check_package(HEIF "HEIF >= 1.1" CAN_DISABLE)
 
+find_package(Grok MODULE)
+if (GDAL_USE_GROK)
+  if (NOT GROK_FOUND)
+    message(FATAL_ERROR "Configured to use GDAL_USE_GROK, but not found")
+  endif ()
+endif ()
+cmake_dependent_option(GDAL_USE_GROK "Set ON to use grok" ON GROK_FOUND OFF)
+if (GDAL_USE_GROK)
+  string(APPEND GDAL_IMPORT_DEPENDENCIES "find_dependency(Grok MODULE)\n")
+endif ()
+
 # OpenJPEG's cmake-CONFIG is broken with older OpenJPEG releases, so call module explicitly
 set(GDAL_FIND_PACKAGE_OpenJPEG_MODE "MODULE" CACHE STRING "Mode to use for find_package(OpenJPEG): CONFIG, MODULE or empty string")
 set_property(CACHE GDAL_FIND_PACKAGE_OpenJPEG_MODE PROPERTY STRINGS "CONFIG" "MODULE" "")

--- a/cmake/modules/packages/FindGrok.cmake
+++ b/cmake/modules/packages/FindGrok.cmake
@@ -1,0 +1,78 @@
+###
+# File:  FindGrok.cmake
+#
+
+function(transform_version _numerical_result _version_major _version_minor _version_patch)
+  set(factor 100)
+  if(_version_minor GREATER 99)
+      set(factor 1000)
+  endif()
+  if(_verion_patch GREATER 99)
+      set(factor 1000)
+  endif()
+  math(EXPR _internal_numerical_result
+          "${_version_major}*${factor}*${factor} + ${_version_minor}*${factor} + ${_version_patch}"
+          )
+  set(${_numerical_result} ${_internal_numerical_result} PARENT_SCOPE)
+endfunction()
+
+
+# - Find Grok
+# Find the Grok includes and library
+#
+# IMPORTED Target
+#      GROK::Grok
+#
+# This module defines
+#  GROK_INCLUDE_DIR, where to find openjpeg.h, etc.
+#  GROK_LIBRARIES, the libraries needed to use Grok.
+#  GROK_FOUND, If false, do not try to use Grok.
+# also defined, but not for general use are
+#  GROK_LIBRARY, where to find the Grok library.
+
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+    pkg_check_modules(PC_GROK QUIET libgrokj2k)
+    set(GROK_VERSION_STRING ${PC_GROK_VERSION})
+endif()
+
+
+find_path(GROK_INCLUDE_DIR grk_config.h
+          PATH_SUFFIXES
+              grok-10.0
+          HINTS ${PC_GROK_INCLUDE_DIRS}
+          DOC "Location of Grok Headers"
+)
+
+find_library(GROK_LIBRARY
+             NAMES grokj2k
+             HINTS ${PC_GROK_LIBRARY_DIRS}
+             )
+mark_as_advanced(GROK_LIBRARY GROK_INCLUDE_DIR)
+
+if(GROK_INCLUDE_DIR)
+     string(REGEX MATCH "([0-9]+).([0-9]+).([0-9]+)" GRK_VERSION ${GROK_VERSION_STRING})
+     if(GRK_VERSION)
+         transform_version(GROK_VERSION_NUM ${CMAKE_MATCH_1} ${CMAKE_MATCH_2} ${CMAKE_MATCH_3})
+     else()
+         message(FATAL "Grok version not found")
+     endif()
+endif ()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(Grok
+                                  FOUND_VAR GROK_FOUND
+                                  REQUIRED_VARS GROK_LIBRARY GROK_INCLUDE_DIR
+                                  VERSION_VAR GROK_VERSION_STRING)
+if(GROK_FOUND)
+  set(GROK_LIBRARIES "${GROK_LIBRARY}")
+  set(GROK_INCLUDE_DIRS "${GROK_INCLUDE_DIR}")
+
+  if(NOT TARGET GROK::Grok)
+    add_library(GROK::Grok UNKNOWN IMPORTED)
+    set_target_properties(GROK::Grok PROPERTIES
+                          INTERFACE_INCLUDE_DIRECTORIES "${GROK_INCLUDE_DIR}"
+                          IMPORTED_LINK_INTERFACE_LANGUAGES "C"
+                          IMPORTED_LOCATION "${GROK_LIBRARY}")
+  endif()
+endif()

--- a/doc/source/development/building_from_source.rst
+++ b/doc/source/development/building_from_source.rst
@@ -1555,6 +1555,24 @@ JPEG-2000 codec written in C language. It is required for the
     search is attempted. If set to empty string, default CMake logic
     (https://cmake.org/cmake/help/latest/command/find_package.html) applies.
 
+====
+Grok
+****
+
+The `Grok <https://github.com/GrokImageCompression/grok>`_ library is an open-source
+JPEG-2000 codec written in the C++ language.
+
+.. option:: GROK_INCLUDE_DIR
+
+    Path to an include directory with the ``grok.h`` header file.
+
+.. option:: GROK_LIBRARY
+
+    Path to a shared or static library file.
+
+.. option:: GDAL_USE_GROK=ON/OFF
+
+    Control whether to use Grok or not. Defaults to ON when Grok is found.
 
 OpenSSL
 *******

--- a/doc/source/drivers/raster/index.rst
+++ b/doc/source/drivers/raster/index.rst
@@ -98,6 +98,7 @@ Raster drivers
    isis3
    jdem
    jp2ecw
+   jp2grok
    jp2kak
    jp2lura
    jp2mrsid

--- a/doc/source/drivers/raster/jp2grok.rst
+++ b/doc/source/drivers/raster/jp2grok.rst
@@ -1,0 +1,552 @@
+
+.. _raster.JP2Grok:
+
+================================================================================
+JP2Grok -- JPEG2000 driver based on Grok library
+================================================================================
+
+.. shortname:: JP2Grok
+
+.. build_dependencies:: grok >= 9.6
+
+
+This driver is an implementation of a JPEG2000 reader/writer based on
+Grok library **v2**.
+
+The driver uses the VSI Virtual File API, so it can read JPEG2000
+compressed NITF files.
+
+XMP metadata can be extracted from JPEG2000 files, and will be stored as
+XML raw content in the xml:XMP metadata domain.
+
+The driver supports writing georeferencing information as GeoJP2 and
+GMLJP2 boxes.
+
+The driver supports creating files with
+transparency, arbitrary band count, and adding/reading metadata. Update
+of georeferencing or metadata of existing file is also supported.
+Optional intellectual property metadata can be read/written in the
+xml:IPR box.
+
+Driver capabilities
+-------------------
+
+.. supports_createcopy::
+
+.. supports_georeferencing::
+
+.. supports_virtualio::
+
+Georeferencing
+--------------
+
+Georeferencing information can come from different sources : internal
+(GeoJP2 or GMLJP2 boxes), worldfile .j2w/.wld sidecar files, or PAM
+(Persistent Auxiliary metadata) .aux.xml sidecar files. By default,
+information is fetched in following order (first listed is the most
+prioritary): PAM, GeoJP2, GMLJP2, WORLDFILE.
+
+Starting with GDAL 2.2, the allowed sources and their priority order can
+be changed with the GDAL_GEOREF_SOURCES configuration option (or
+GEOREF_SOURCES open option) whose value is a comma-separated list of the
+following keywords : PAM, GEOJP2, GMLJP2, INTERNAL (shortcut for
+GEOJP2,GMLJP2), WORLDFILE, NONE. First mentioned sources are the most
+prioritary over the next ones. A non mentioned source will be ignored.
+
+For example setting it to "WORLDFILE,PAM,INTERNAL" will make a
+geotransformation matrix from a potential worldfile prioritary over PAM
+or internal JP2 boxes. Setting it to "PAM,WORLDFILE,GEOJP2" will use the
+mentioned sources and ignore GMLJP2 boxes.
+
+Thread support
+--------------
+
+By default, if the JPEG2000 file has internal tiling, GDAL will try to
+decode several tiles in multiple threads if the RasterIO() request it
+receives intersect several tiles. This behavior can be controlled with
+the GDAL_NUM_THREADS configuration option that defaults to ALL_CPUS in
+that context. In case RAM is limited, it can be needed to set this
+configuration option to 1 to disable multi-threading
+
+Option Options
+--------------
+
+The following open option is available:
+
+-  **1BIT_ALPHA_PROMOTION=YES/NO**: Whether a 1-bit alpha channel should
+   be promoted to 8-bit. Defaults to YES.
+
+-  **GEOREF_SOURCES=string**: (GDAL > 2.2) Define which georeferencing
+   sources are allowed and their priority order. See
+   `Georeferencing <#georeferencing>`__ paragraph.
+
+-  **USE_TILE_AS_BLOCK=YES/NO**: (GDAL > 2.2) Whether to always use the
+   JPEG-2000 block size as the GDAL block size Defaults to NO. Setting
+   this option can be useful when doing whole image decompression and
+   the image is single-tiled. Note however that the tile size must not
+   exceed 2 GB since that's the limit supported by GDAL.
+
+Creation Options
+----------------
+
+-  **CODEC=JP2/J2K** : JP2 will add JP2 boxes around the codestream
+   data. The value is determined automatically from the file extension.
+   If it is neither JP2 nor J2K, J2K codec is used.
+
+-  **GMLJP2=YES/NO**: Indicates whether a GML
+   box conforming to the OGC GML in JPEG2000 specification should be
+   included in the file. Unless GMLJP2V2_DEF is used, the version of the
+   GMLJP2 box will be version 1. Defaults to YES.
+-  **GMLJP2V2_DEF=filename**: Indicates whether
+   a GML box conforming to the `OGC GML in JPEG2000, version
+   2.0.1 <http://docs.opengeospatial.org/is/08-085r5/08-085r5.html>`__
+   specification should be included in the file. *filename* must point
+   to a file with a JSon content that defines how the GMLJP2 v2 box
+   should be built. See below section for the syntax of the JSon
+   configuration file. It is also possible to directly pass the JSon
+   content inlined as a string. If filename is just set to YES, a
+   minimal instance will be built. Note: GDAL 2.0 and 2.1 use the older
+   `OGC GML in JPEG2000, version
+   2.0 <http://docs.opengeospatial.org/is/08-085r4/08-085r4.html>`__
+   specification, that differ essentially by the content of the
+   gml:domainSet, gml:rangeSet and gmlcov:rangeType elements of
+   gmljp2:GMLJP2CoverageCollection.
+-  **GeoJP2=YES/NO**: Indicates whether a
+   UUID/GeoTIFF box conforming to the GeoJP2 (GeoTIFF in JPEG2000)
+   specification should be included in the file. Defaults to YES.
+-  **QUALITY=float_value,float_value,...** : Percentage between 0 and
+   100. A value of 50 means the file will be half-size in comparison to
+   uncompressed data, 33 means 1/3, etc.. Defaults to 25 (unless the
+   dataset is made of a single band with color table, in which case the
+   default quality is 100). It is possible to
+   specify several quality values (comma separated) to ask for several
+   quality layers. Quality values should be increasing.
+
+-  **REVERSIBLE=YES/NO** : YES means use of reversible 5x3 integer-only
+   filter, NO use of the irreversible DWT 9-7. Defaults to NO (unless
+   the dataset is made of a single band with color table, in which case
+   reversible filter is used).
+
+-  **RESOLUTIONS=int_value** : Number of resolution levels. Default
+   value is selected such the smallest overview of a tile is no bigger
+   than 128x128.
+
+-  **BLOCKXSIZE=int_value** : Tile width. Defaults to 1024.
+
+-  **BLOCKYSIZE=int_value** : Tile height. Defaults to 1024.
+
+-  **PROGRESSION=LRCP/RLCP/RPCL/PCRL/CPRL** : Progession order. Defaults
+   to LRCP.
+
+-  **SOP=YES/NO** : YES means generate SOP (Start Of Packet) marker
+   segments. Defaults to NO.
+
+-  **EPH=YES/NO** : YES means generate EPH (End of Packet Header) marker
+   segments. Defaults to NO.
+
+-  **YCBCR420=YES/NO** : YES if RGB must be resampled to
+   YCbCr 4:2:0. Defaults to NO.
+
+-  **YCC=YES/NO** : YES if RGB must be transformed to YCC
+   color space ("MCT transform", i.e. internal transform, without visual
+   degradation). Defaults to YES.
+
+-  **NBITS=int_value** : Bits (precision) for sub-byte
+   files (1-7), sub-uint16 (9-15), sub-uint32 (17-31).
+
+-  **1BIT_ALPHA=YES/NO**: Whether to encode the alpha
+   channel as a 1-bit channel (when there's an alpha channel). Defaults
+   to NO, unless INSPIRE_TG=YES. Enabling this option might cause
+   compatibility problems with some readers. At the time of writing,
+   those based on the MrSID JPEG2000 SDK are unable to open such files.
+   And regarding the ECW JPEG2000 SDK, decoding of 1-bit alpha channel
+   with lossy/irreversible compression gives visual artifacts (OK with
+   lossless encoding).
+
+-  **ALPHA=YES/NO**: Whether to force encoding last
+   channel as alpha channel. Only useful if the color interpretation of
+   that channel is not already Alpha. Defaults to NO.
+
+-  **PROFILE=AUTO/UNRESTRICTED/PROFILE_1**: Determine
+   which codestream profile to use. UNRESTRICTED corresponds to the
+   "Unrestricted JPEG 2000 Part 1 codestream" (RSIZ=0). PROFILE_1
+   corresponds to the "JPEG 2000 Part 1 Profile 1 codestream" (RSIZ=2),
+   which add constraints on tile dimensions and number of resolutions.
+   In AUTO mode, the driver will determine if the BLOCKXSIZE,
+   BLOCKYSIZE, RESOLUTIONS, CODEBLOCK_WIDTH and CODEBLOCK_HEIGHT values
+   are compatible with PROFILE_1 and advertise it in the relevant case.
+   Note that the default values of those options are compatible with
+   PROFILE_1. Otherwise UNRESTRICTED is advertized. Defaults to AUTO.
+
+-  **INSPIRE_TG=YES/NO**: Whether to use JPEG2000 features
+   that comply with `Inspire Orthoimagery Technical
+   Guidelines <http://inspire.ec.europa.eu/documents/Data_Specifications/INSPIRE_DataSpecification_OI_v3.0.pdf>`__.
+   Defaults to NO. When set to YES, implies PROFILE=PROFILE_1,
+   1BIT_ALPHA=YES, GEOBOXES_AFTER_JP2C=YES. The CODEC, BLOCKXSIZE,
+   BLOCKYSIZE, RESOLUTIONS, NBITS, PROFILE, CODEBLOCK_WIDTH and
+   CODEBLOCK_HEIGHT options will be checked against the requirements and
+   recommendations of the Technical Guidelines.
+
+-  **JPX=YES/NO**: Whether to advertise JPX features, and
+   add a Reader requirement box, when a GMLJP2 box is written. Defaults
+   to YES. This option should not be used unless compatibility problems
+   with a reader occur.
+
+-  **GEOBOXES_AFTER_JP2C=YES/NO**: Whether to place
+   GeoJP2/GMLJP2 boxes after the code-stream. Defaults to NO, unless
+   INSPIRE_TG=YES. This option should not be used unless compatibility
+   problems with a reader occur.
+
+-  **PRECINCTS={prec_w,prec_h},{prec_w,prec_h},...**: A
+   list of {precincts width,precincts height} tuples to specify
+   precincts size. Each value should be a multiple of 2. The maximum
+   number of tuples used will be the number of resolutions. The first
+   tuple corresponds to the higher resolution level, and the following
+   ones to the lower resolution levels. If less tuples are specified,
+   the last one is used by dividing its values by 2 for each extra lower
+   resolution level. The default value used is
+   {512,512},{256,512},{128,512},{64,512},{32,512},{16,512},{8,512},{4,512},{2,512}.
+   An empty string may be used to disable precincts ( i.e. the default
+   {32767,32767},{32767,32767}, ... will then be used).
+
+-  **TILEPARTS=DISABLED/RESOLUTIONS/LAYERS/COMPONENTS**:
+   Whether to generate tile-parts and according to which criterion.
+   Defaults to DISABLED.
+
+-  **CODEBLOCK_WIDTH=int_value**: Codeblock width: power
+   of two value between 4 and 1024. Defaults to 64. Note that
+   CODEBLOCK_WIDTH \* CODEBLOCK_HEIGHT must not be greater than 4096.
+   For PROFILE_1 compatibility, CODEBLOCK_WIDTH must not be greater than
+   64.
+
+-  **CODEBLOCK_HEIGHT=int_value**: Codeblock height: power
+   of two value between 4 and 1024. Defaults to 64. Note that
+   CODEBLOCK_WIDTH \* CODEBLOCK_HEIGHT must not be greater than 4096.
+   For PROFILE_1 compatibility, CODEBLOCK_HEIGHT must not be greater
+   than 64.
+
+-  **CODEBLOCK_STYLE=string**: (GDAL >= 2.4 and OpenJPEG >= 2.3.0) Style
+   of the code-block coding passes. The following 6 independent settings
+   can be combined together (values should be comma separated):
+
+   -  *BYPASS* (1): enable selective arithmetic coding bypass (can
+      substantially improve coding/decoding speed, at the expense of
+      larger file size)
+   -  *RESET* (2): reset context probabilities on coding pass boundaries
+   -  *TERMALL* (4): enable termination on each coding pass
+   -  *VSC* (8): enable vertically causal context
+   -  *PREDICTABLE* (16): enable predictable termination (helps for
+      error detection)
+   -  *SEGSYM* (32): enable segmentation symbols (helps for error
+      detection)
+
+   Instead of specifying them by text, it is also possible to give the
+   corresponding numeric value of the global codeblock style, by adding
+   the selected options (for example "BYPASS,TERMALL" is equivalent to
+   "5"=1+4)
+
+   By default, none of them are enabled. Enabling them will generally
+   increase codestream size, but improve either coding/decoding speed or
+   resilience/error detection.
+
+-  **PLT=YES/NO**: (GDAL >= 3.1.1 and OpenJPEG >= 2.4.0) Whether to write a
+   PLT (Packet Length) marker segment in tile-part headers. Defaults to NO.
+
+-  **TLM=YES/NO**: (GDAL >= 3.4.0 and OpenJPEG >= 2.5.0) Whether to write a
+   TLM (Tile-part Length) marker segment in main header. Defaults to NO.
+
+-  **WRITE_METADATA=YES/NO**: Whether metadata should be
+   written, in a dedicated JP2 'xml ' box. Defaults to NO. The content
+   of the 'xml ' box will be like:
+
+   ::
+
+      <GDALMultiDomainMetadata>
+        <Metadata>
+          <MDI key="foo">bar</MDI>
+        </Metadata>
+        <Metadata domain='aux_domain'>
+          <MDI key="foo">bar</MDI>
+        </Metadata>
+        <Metadata domain='a_xml_domain' format='xml'>
+          <arbitrary_xml_content>
+          </arbitrary_xml_content>
+        </Metadata>
+      </GDALMultiDomainMetadata>
+
+   If there are metadata domain whose name starts with "xml:BOX\_", they
+   will be written each as separate JP2 'xml ' box.
+
+   If there is a metadata domain whose name is "xml:XMP", its content
+   will be written as a JP2 'uuid' XMP box.
+
+   If there is a metadata domain whose name is "xml:IPR", its content
+   will be written as a JP2 'jp2i' box.
+
+-  **MAIN_MD_DOMAIN_ONLY=YES/NO**: (Only if
+   WRITE_METADATA=YES) Whether only metadata from the main domain should
+   be written. Defaults to NO.
+
+-  **USE_SRC_CODESTREAM=YES/NO**: (EXPERIMENTAL!) When
+   source dataset is JPEG2000, whether to reuse the codestream of the
+   source dataset unmodified. Defaults to NO. Note that enabling that
+   feature might result in inconsistent content of the JP2 boxes w.r.t.
+   to the content of the source codestream. Most other creation options
+   will be ignored in that mode. Can be useful in some use cases when
+   adding/correcting georeferencing, metadata, ... INSPIRE_TG and
+   PROFILE options will be ignored, and the profile of the codestream
+   will be overridden with the one specified/implied by the options
+   (which may be inconsistent with the characteristics of the
+   codestream).
+
+Lossless compression
+~~~~~~~~~~~~~~~~~~~~
+
+Lossless compression can be achieved if ALL the following creation
+options are defined :
+
+-  QUALITY=100
+-  REVERSIBLE=YES
+-  YCBCR420=NO (which is the default)
+
+.. _gmjp2v2def:
+
+GMLJP2v2 definition file
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+A GMLJP2v2 box typically contains a GMLJP2RectifiedGridCoverage with the
+SRS information and geotransformation matrix. It is also possible to add
+metadata, vector features (GML feature collections), annotations (KML),
+styles (typically SLD, or other XML format) or any XML content as an
+extension. The value of the GMLJP2V2_DEF creation option should be a
+file that conforms with the below syntax (elements starting with "#" are
+documentation, and can be omitted):
+
+.. code-block:: json
+
+   {
+       "#doc" : "Unless otherwise specified, all elements are optional",
+
+       "#root_instance_doc": "Describe content of the GMLJP2CoverageCollection",
+       "root_instance": {
+           "#gml_id_doc": "Specify GMLJP2CoverageCollection gml:id. Default is ID_GMLJP2_0",
+           "gml_id": "some_gml_id",
+
+           "#grid_coverage_file_doc": [
+               "External XML file, whose root might be a GMLJP2GridCoverage, ",
+               "GMLJP2RectifiedGridCoverage or a GMLJP2ReferenceableGridCoverage.",
+               "If not specified, GDAL will auto-generate a GMLJP2RectifiedGridCoverage" ],
+           "grid_coverage_file": "gmljp2gridcoverage.xml",
+
+           "#grid_coverage_range_type_field_predefined_name_doc": [
+               "New in GDAL 2.2",
+               "One of Color, Elevation_meter or Panchromatic ",
+               "to fill gmlcov:rangeType/swe:DataRecord/swe:field",
+               "Only used if grid_coverage_file is not defined.",
+               "Exclusive with grid_coverage_range_type_file" ],
+           "grid_coverage_range_type_field_predefined_name": "Color",
+
+           "#grid_coverage_range_type_file_doc": [
+               "New in GDAL 2.2",
+               "File that is XML content to put under gml:RectifiedGrid/gmlcov:rangeType",
+               "Only used if grid_coverage_file is not defined.",
+               "Exclusive with grid_coverage_range_type_field_predefined_name" ],
+           "grid_coverage_range_type_file": "grid_coverage_range_type.xml",
+
+           "#crs_url_doc": [
+               "true for http://www.opengis.net/def/crs/EPSG/0/XXXX CRS URL.",
+               "If false, use CRS URN. Default value is true",
+               "Only taken into account for a auto-generated GMLJP2RectifiedGridCoverage"],
+           "crs_url": true,
+
+           "#metadata_doc": [ "An array of metadata items. Can be either strings, with ",
+                              "a filename or directly inline XML content, or either ",
+                              "a more complete description." ],
+           "metadata": [
+
+               "dcmetadata.xml",
+
+               {
+                   "#file_doc": "Can use relative or absolute paths. Exclusive of content, gdal_metadata and generated_metadata.",
+                   "file": "dcmetadata.xml",
+
+                   "#gdal_metadata_doc": "Whether to serialize GDAL metadata as GDALMultiDomainMetadata",
+                   "gdal_metadata": false,
+
+                   "#dynamic_metadata_doc":
+                       [ "The metadata file will be generated from a template and a source file.",
+                         "The template is a valid GMLJP2 metadata XML tree with placeholders like",
+                         "{{{XPATH(some_xpath_expression)}}}",
+                         "that are evaluated from the source XML file. Typical use case",
+                         "is to generate a gmljp2:eopMetadata from the XML metadata",
+                         "provided by the image provider in their own particular format." ],
+                   "dynamic_metadata" :
+                   {
+                       "template": "my_template.xml",
+                       "source": "my_source.xml"
+                   },
+
+                   "#content": "Exclusive of file. Inline XML metadata content",
+                   "content": "<gmljp2:metadata>Some simple textual metadata</gmljp2:metadata>",
+
+                   "#parent_node": ["Where to put the metadata.",
+                                    "Under CoverageCollection (default) or GridCoverage" ],
+                   "parent_node": "CoverageCollection"
+               }
+           ],
+
+           "#annotations_doc": [ "An array of filenames, either directly KML files",
+                                 "or other vector files recognized by GDAL that ",
+                                 "will be translated on-the-fly as KML" ],
+           "annotations": [
+               "my.kml"
+           ],
+
+           "#gml_filelist_doc" :[
+               "An array of GML files or vector files that will be on-the-fly converted",
+               "to GML 3.2. Can be either GML filenames (or other OGR datasource names), ",
+               "or a more complete description" ],
+           "gml_filelist": [
+
+               "my.gml",
+
+               "my.shp",
+
+               {
+                   "#file_doc": "OGR datasource. Can use relative or absolute paths. Exclusive of remote_resource",
+                   "file": "converted/test_0.gml",
+
+                   "#remote_resource_doc": "URL of a feature collection that must be referenced through a xlink:href",
+                   "remote_resource": "https://github.com/OSGeo/gdal/blob/master/autotest/ogr/data/expected_gml_gml32.gml",
+
+                   "#namespace_doc": ["The namespace in schemaLocation for which to substitute",
+                                     "its original schemaLocation with the one provided below.",
+                                     "Ignored for a remote_resource"],
+                   "namespace": "http://example.com",
+
+                   "#schema_location_doc": ["Value of the substituted schemaLocation. ",
+                                            "Typically a schema box label (link)",
+                                            "Ignored for a remote_resource"],
+                   "schema_location": "gmljp2://xml/schema_0.xsd",
+
+                   "#inline_doc": [
+                       "Whether to inline the content, or put it in a separate xml box. Default is true",
+                       "Ignored for a remote_resource." ],
+                   "inline": true,
+
+                   "#parent_node": ["Where to put the FeatureCollection.",
+                                    "Under CoverageCollection (default) or GridCoverage" ],
+                   "parent_node": "CoverageCollection"
+               }
+           ],
+
+
+           "#styles_doc": [ "An array of styles. For example SLD files" ],
+           "styles" : [
+               {
+                   "#file_doc": "Can use relative or absolute paths.",
+                   "file": "my.sld",
+
+                   "#parent_node": ["Where to put the FeatureCollection.",
+                                    "Under CoverageCollection (default) or GridCoverage" ],
+                   "parent_node": "CoverageCollection"
+               }
+           ],
+
+           "#extensions_doc": [ "An array of extensions." ],
+           "extensions" : [
+               {
+                   "#file_doc": "Can use relative or absolute paths.",
+                   "file": "my.xml",
+
+                   "#parent_node": ["Where to put the FeatureCollection.",
+                                    "Under CoverageCollection (default) or GridCoverage" ],
+                   "parent_node": "CoverageCollection"
+               }
+           ]
+       },
+
+       "#boxes_doc": "An array to describe the content of XML asoc boxes",
+       "boxes": [
+           {
+               "#file_doc": "can use relative or absolute paths. Required",
+               "file": "converted/test_0.xsd",
+
+               "#label_doc": ["the label of the XML box. If not specified, will be the ",
+                             "filename without the directory part." ],
+               "label": "schema_0.xsd"
+           }
+       ]
+   }
+
+Metadata can be dynamically generated from a template file (in that
+context, with a XML structure) and a XML source file. The template file
+is processed by searching for patterns like {{{XPATH(xpath_expr)}}} and
+replacing them by their evaluation against the content of the source
+file. xpath_expr must be a XPath 1.0 compatible expression, with the
+addition of the following functions :
+
+-  **if(cond_expr,expr_if_true,expr_if_false)**: if cond_expr evaluates
+   to true, returns expr_if_true. Otherwise returns expr_if_false
+-  **uuid()**: evaluates to a random UUID
+
+A template file to process XML metadata of Pleiades imagery can be found
+`here <eoptemplate_pleiades.xml>`__, and a template file to process XML
+metadata of GeoEye/WorldView imagery can be found
+`here <eoptemplate_worldviewgeoeye.xml>`__.
+
+Vector information
+------------------
+
+A JPEG2000 file containing a GMLJP2 v2 box with
+GML feature collections and/or KML annotations embedded can be opened as
+a vector file with the OGR API. For example:
+
+::
+
+   ogrinfo -ro my.jp2
+
+   INFO: Open of my.jp2'
+         using driver `JP2Grok' successful.
+   1: FC_GridCoverage_1_rivers (LineString)
+   2: FC_GridCoverage_1_borders (LineString)
+   3: Annotation_1_poly
+
+Feature collections can be linked from the GMLJP2 v2 box to a remote
+location. By default, the link is not followed. It will be followed if
+the open option OPEN_REMOTE_GML is set to YES.
+
+See Also
+---------
+
+-  Implemented as ``gdal/frmts/openjpeg/openjpegdataset.cpp``.
+
+-  `The Grok library home
+   page <https://github.com/GrokImageCompression/grok>`__
+
+-  `OGC GML in JPEG2000, version
+   2.0 <http://docs.opengeospatial.org/is/08-085r4/08-085r4.html>`__
+   (GDAL 2.0 and 2.1)
+
+-  `OGC GML in JPEG2000, version
+   2.0.1 <http://docs.opengeospatial.org/is/08-085r5/08-085r5.html>`__
+   (GDAL 2.2 and above)
+
+-  `Inspire Data Specification on Orthoimagery - Technical
+   Guidelines <http://inspire.ec.europa.eu/documents/Data_Specifications/INSPIRE_DataSpecification_OI_v3.0.pdf>`__
+
+Other JPEG2000 GDAL drivers :
+
+-  :ref:`JP2OpenJpeg: based on OpenJPEG library (open
+   source) <raster.jp2openjpeg>`
+
+-  :ref:`JPEG2000: based on Jasper library (open
+   source) <raster.jpeg2000>`
+
+-  :ref:`JP2ECW: based on Erdas ECW library
+   (proprietary) <raster.jp2ecw>`
+
+-  :ref:`JP2MRSID: based on LizardTech MrSID library
+   (proprietary) <raster.jp2mrsid>`
+
+-  :ref:`JP2KAK: based on Kakadu library (proprietary) <raster.jp2kak>`

--- a/frmts/CMakeLists.txt
+++ b/frmts/CMakeLists.txt
@@ -147,6 +147,8 @@ gdal_dependent_format(mbtiles "MBTile" "GDAL_USE_SQLITE3;OGR_ENABLE_DRIVER_GPKG;
 gdal_dependent_format(postgisraster "PostGIS Raster driver" "GDAL_USE_POSTGRESQL")
 gdal_dependent_format(dds "DirectDraw Surface" "GDAL_USE_CRNLIB")
 gdal_dependent_format(kea "Kea" "GDAL_USE_KEA;GDAL_USE_HDF5")
+gdal_dependent_format(grok "JPEG2000 driver based on Grok library" "GDAL_USE_GROK" DRIVER_NAME_OPTION
+                      "JP2Grok")
 gdal_dependent_format(openjpeg "JPEG2000 driver based on OpenJPEG library" "GDAL_USE_OPENJPEG" DRIVER_NAME_OPTION
                       "JP2OpenJPEG")
 gdal_dependent_format(tiledb "TileDB tiledb.io" "GDAL_USE_TILEDB")

--- a/frmts/gdalallregister.cpp
+++ b/frmts/gdalallregister.cpp
@@ -526,6 +526,11 @@ void CPL_STDCALL GDALAllRegister()
     GDALRegister_JP2ECW();
 #endif
 
+#ifdef FRMT_grok
+    // JPEG2000 support using Grok library
+    GDALRegister_JP2Grok();
+#endif
+
 #ifdef FRMT_openjpeg
     // JPEG2000 support using OpenJPEG library
     GDALRegister_JP2OpenJPEG();

--- a/frmts/grok/CMakeLists.txt
+++ b/frmts/grok/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_gdal_driver(
+  TARGET gdal_JP2Grok
+  SOURCES grokdataset.cpp
+  DEF FRMT_grok PLUGIN_CAPABLE)
+gdal_standard_includes(gdal_JP2Grok)
+target_include_directories(gdal_JP2Grok PRIVATE ../opjlike)
+gdal_target_link_libraries(gdal_JP2Grok PRIVATE GROK::Grok)

--- a/frmts/grok/grkdatasetbase.h
+++ b/frmts/grok/grkdatasetbase.h
@@ -1,0 +1,990 @@
+/******************************************************************************
+ *
+ * Author:   Aaron Boxer, <boxerab at protonmail dot com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2010-2014, Even Rouault <even dot rouault at spatialys dot com>
+ * Copyright (c) 2015, European Union (European Environment Agency)
+ * Copyright (c) 2023, Grok Image Compression Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+#pragma once
+
+#include <grok.h>
+#include <grk_config.h>
+#include <algorithm>
+
+typedef grk_image jp2_image;
+typedef grk_image_comp jp2_image_comp;
+typedef grk_codec jp2_codec;
+
+/************************************************************************/
+/*                 JP2_WarningCallback()                                */
+/************************************************************************/
+
+static void JP2_WarningCallback(const char *pszMsg, CPL_UNUSED void *unused)
+{
+    std::string osMsg(pszMsg);
+    if (!osMsg.empty() && osMsg.back() == '\n')
+        osMsg.resize(osMsg.size() - 1);
+    CPLError(CE_Warning, CPLE_AppDefined, "%s", osMsg.c_str());
+}
+
+/************************************************************************/
+/*                 JP2_InfoCallback()                                   */
+/************************************************************************/
+
+static void JP2_InfoCallback(const char *pszMsg, CPL_UNUSED void *unused)
+{
+    std::string osMsg(pszMsg);
+    if (!osMsg.empty() && osMsg.back() == '\n')
+        osMsg.resize(osMsg.size() - 1);
+    CPLDebug("GROK", "info: %s", osMsg.c_str());
+}
+
+/************************************************************************/
+/*                  JP2_ErrorCallback()                                 */
+/************************************************************************/
+
+static void JP2_ErrorCallback(const char *pszMsg, CPL_UNUSED void *unused)
+{
+    CPLError(CE_Failure, CPLE_AppDefined, "%s", pszMsg);
+}
+
+/************************************************************************/
+/*                      JP2Dataset_Read()                               */
+/************************************************************************/
+
+static size_t JP2Dataset_Read(uint8_t *pBuffer, size_t nBytes, void *pUserData)
+{
+    JP2File *psJP2File = (JP2File *)pUserData;
+    size_t nRet =
+        static_cast<size_t>(VSIFReadL(pBuffer, 1, nBytes, psJP2File->fp_));
+#ifdef DEBUG_IO
+    CPLDebug(debugId(), "JP2Dataset_Read(" CPL_FRMT_GUIB ") = " CPL_FRMT_GUIB,
+             static_cast<GUIntBig>(nBytes), static_cast<GUIntBig>(nRet));
+#endif
+    if (nRet == 0)
+        nRet = static_cast<size_t>(-1);
+
+    return nRet;
+}
+
+/************************************************************************/
+/*                      JP2Dataset_Write()                              */
+/************************************************************************/
+
+static size_t JP2Dataset_Write(const uint8_t *pBuffer, size_t nBytes,
+                               void *pUserData)
+{
+    JP2File *psJP2File = (JP2File *)pUserData;
+    size_t nRet =
+        static_cast<size_t>(VSIFWriteL(pBuffer, 1, nBytes, psJP2File->fp_));
+#ifdef DEBUG_IO
+    CPLDebug(debugId(), "JP2Dataset_Write(" CPL_FRMT_GUIB ") = " CPL_FRMT_GUIB,
+             static_cast<GUIntBig>(nBytes), static_cast<GUIntBig>(nRet));
+#endif
+    if (nRet != nBytes)
+        return static_cast<size_t>(-1);
+    return nRet;
+}
+
+/************************************************************************/
+/*                       JP2Dataset_Seek()                              */
+/************************************************************************/
+
+static bool JP2Dataset_Seek(uint64_t nBytes, void *pUserData)
+{
+    JP2File *psJP2File = (JP2File *)pUserData;
+#ifdef DEBUG_IO
+    CPLDebug(debugId(), "JP2Dataset_Seek(" CPL_FRMT_GUIB ")",
+             static_cast<GUIntBig>(nBytes));
+#endif
+    return VSIFSeekL(psJP2File->fp_, psJP2File->nBaseOffset + nBytes,
+                     SEEK_SET) == 0;
+}
+
+struct GRKCodecWrapper
+{
+    GRKCodecWrapper(void)
+        : pCodec(nullptr), psImage(nullptr), pasBandParams(nullptr),
+          psJP2File(nullptr)
+    {
+        grk_compress_set_default_params(&compressParams);
+        grk_decompress_set_default_params(&decompressParams);
+    }
+    explicit GRKCodecWrapper(GRKCodecWrapper *rhs)
+        : pCodec(rhs->pCodec), psImage(rhs->psImage),
+          pasBandParams(rhs->pasBandParams), psJP2File(rhs->psJP2File)
+    {
+        rhs->pCodec = nullptr;
+        rhs->psImage = nullptr;
+        rhs->pasBandParams = nullptr;
+        rhs->psJP2File = nullptr;
+    }
+    ~GRKCodecWrapper(void)
+    {
+        free();
+    }
+    void open(VSILFILE *fp, vsi_l_offset offset)
+    {
+        psJP2File = static_cast<JP2File *>(CPLMalloc(sizeof(JP2File)));
+        psJP2File->fp_ = fp;
+        psJP2File->nBaseOffset = offset;
+    }
+    void open(VSILFILE *fp)
+    {
+        psJP2File = static_cast<JP2File *>(CPLMalloc(sizeof(JP2File)));
+        psJP2File->fp_ = fp;
+        psJP2File->nBaseOffset = VSIFTellL(fp);
+    }
+    void transfer(GRKCodecWrapper *rhs)
+    {
+        pCodec = rhs->pCodec;
+        rhs->pCodec = nullptr;
+        psImage = rhs->psImage;
+        rhs->psImage = nullptr;
+        psJP2File = rhs->psJP2File;
+        rhs->psJP2File = nullptr;
+    }
+
+    static int cvtenum(JP2_ENUM enumeration)
+    {
+        switch (enumeration)
+        {
+            case JP2_CLRSPC_UNKNOWN:
+                return GRK_CLRSPC_UNKNOWN;
+                break;
+            case JP2_CLRSPC_SRGB:
+                return GRK_CLRSPC_SRGB;
+                break;
+            case JP2_CLRSPC_GRAY:
+                return GRK_CLRSPC_GRAY;
+                break;
+            case JP2_CLRSPC_SYCC:
+                return GRK_CLRSPC_SYCC;
+                break;
+            case JP2_CODEC_J2K:
+                return GRK_CODEC_J2K;
+                break;
+            case JP2_CODEC_JP2:
+                return GRK_CODEC_JP2;
+                break;
+            default:
+                return INT_MAX;
+                break;
+        }
+    }
+
+    std::string getComment(void)
+    {
+        (void)this;
+        std::string osComment = "Created by Grok version ";
+
+        return osComment + grk_version();
+    }
+    void updateStrict(CPL_UNUSED bool strict)
+    {
+        // prevent linter from treating this as potential static method
+        (void)this;
+    }
+
+    /* Depending on the way OpenJPEG <= r2950 is built, YCC with 4 bands might
+   * work on Debug mode, but this relies on unreliable stack buffer overflows,
+   * so better err on the safe side */
+    static bool supportsYCC_4Band(void)
+    {
+        return true;
+    }
+
+    static const char *debugId(void)
+    {
+        return "GROK";
+    }
+
+    void allocComponentParams(int nBands)
+    {
+        pasBandParams =
+            (grk_image_comp *)CPLMalloc(nBands * sizeof(grk_image_comp));
+    }
+
+    void free(void)
+    {
+        if (pCodec)
+            grk_object_unref(pCodec);
+        pCodec = nullptr;
+        // todo: unref compression image only
+        psImage = nullptr;
+
+        ::free(pasBandParams);
+        pasBandParams = nullptr;
+
+        CPLFree(psJP2File);
+        psJP2File = nullptr;
+    }
+
+    static bool preferPerBlockDeCompress(void)
+    {
+        return false;
+    }
+
+    static uint32_t stride(jp2_image_comp *comp)
+    {
+        return comp->stride;
+    }
+
+    bool setUpDecompress(CPL_UNUSED int numThreads,
+                         vsi_l_offset nCodeStreamLength, uint32_t *nTileW,
+                         uint32_t *nTileH, int *numResolutions)
+    {
+        grk_stream_params streamParams;
+        grk_set_default_stream_params(&streamParams);
+        streamParams.seek_fn = JP2Dataset_Seek;
+        streamParams.read_fn = JP2Dataset_Read;
+        streamParams.user_data = psJP2File;
+        streamParams.stream_len = nCodeStreamLength;
+        pCodec = grk_decompress_init(&streamParams, &decompressParams.core);
+        if (pCodec == nullptr)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined, "setUpDecompress() failed");
+            free();
+            CPLFree(psJP2File);
+            return false;
+        }
+        //        if (getenv("GRK_NUM_THREADS") == nullptr)
+        //        {
+        //            opj_codec_set_threads(pCodec, numThreads);
+        //        }
+        // read j2k header
+        grk_header_info headerInfo;
+        memset(&headerInfo, 0, sizeof(headerInfo));
+        VSIFSeekL(psJP2File->fp_, psJP2File->nBaseOffset, SEEK_SET);
+        if (!grk_decompress_read_header(pCodec, &headerInfo))
+        {
+            CPLError(CE_Failure, CPLE_AppDefined, "setUpDecompress() failed");
+            free();
+            CPLFree(psJP2File);
+            return false;
+        }
+
+        *nTileW = headerInfo.t_width;
+        *nTileH = headerInfo.t_height;
+#ifdef DEBUG
+        uint32_t nX0, nY0;
+        uint32_t nTilesX, nTilesY;
+        nX0 = headerInfo.tx0;
+        nY0 = headerInfo.ty0;
+        nTilesX = headerInfo.t_grid_width;
+        nTilesY = headerInfo.t_grid_height;
+        int mct = headerInfo.mct;
+#endif
+        *numResolutions = headerInfo.numresolutions;
+        psImage = grk_decompress_get_composited_image(pCodec);
+        if (psImage == nullptr)
+        {
+            free();
+            CPLFree(psJP2File);
+            return false;
+        }
+#ifdef DEBUG
+        CPLDebug(debugId(), "nX0 = %u", nX0);
+        CPLDebug(debugId(), "nY0 = %u", nY0);
+        CPLDebug(debugId(), "nTileW = %u", *nTileW);
+        CPLDebug(debugId(), "nTileH = %u", *nTileH);
+        CPLDebug(debugId(), "nTilesX = %u", nTilesX);
+        CPLDebug(debugId(), "nTilesY = %u", nTilesY);
+        CPLDebug(debugId(), "mct = %d", mct);
+        CPLDebug(debugId(), "psImage->x0 = %u", psImage->x0);
+        CPLDebug(debugId(), "psImage->y0 = %u", psImage->y0);
+        CPLDebug(debugId(), "psImage->x1 = %u", psImage->x1);
+        CPLDebug(debugId(), "psImage->y1 = %u", psImage->y1);
+        CPLDebug(debugId(), "psImage->numcomps = %d", psImage->numcomps);
+        //        CPLDebug(debugId(), "psImage->comps[%d].resno_decoded = %d", i,
+        //                 psImage->comps[i].resno_decoded);
+        //        CPLDebug(debugId(), "psImage->comps[%d].factor = %d", i,
+        //                 psImage->comps[i].factor);
+        // CPLDebug(debugId(), "psImage->color_space = %d", psImage->color_space);
+        CPLDebug(debugId(), "numResolutions = %d", *numResolutions);
+        for (int i = 0; i < (int)psImage->numcomps; i++)
+        {
+            CPLDebug(debugId(), "psImage->comps[%d].dx = %u", i,
+                     psImage->comps[i].dx);
+            CPLDebug(debugId(), "psImage->comps[%d].dy = %u", i,
+                     psImage->comps[i].dy);
+            CPLDebug(debugId(), "psImage->comps[%d].x0 = %u", i,
+                     psImage->comps[i].x0);
+            CPLDebug(debugId(), "psImage->comps[%d].y0 = %u", i,
+                     psImage->comps[i].y0);
+            CPLDebug(debugId(), "psImage->comps[%d].w = %u", i,
+                     psImage->comps[i].w);
+            CPLDebug(debugId(), "psImage->comps[%d].stride = %u", i,
+                     psImage->comps[i].stride);
+            CPLDebug(debugId(), "psImage->comps[%d].h = %u", i,
+                     psImage->comps[i].h);
+            CPLDebug(debugId(), "psImage->comps[%d].prec = %d", i,
+                     psImage->comps[i].prec);
+            CPLDebug(debugId(), "psImage->comps[%d].sgnd = %d", i,
+                     psImage->comps[i].sgnd);
+        }
+#endif
+        if (psImage->x1 <= psImage->x0 || psImage->y1 <= psImage->y0 ||
+            psImage->numcomps == 0 || (psImage->comps[0].w >> 31) != 0 ||
+            (psImage->comps[0].h >> 31) != 0 || (*nTileW >> 31) != 0 ||
+            (*nTileH >> 31) != 0 ||
+            psImage->comps[0].w != psImage->x1 - psImage->x0 ||
+            psImage->comps[0].h != psImage->y1 - psImage->y0)
+        {
+            CPLDebug(debugId(), "Unable to handle that image (1)");
+            free();
+            CPLFree(psJP2File);
+            return false;
+        }
+        return true;
+    }
+
+    static bool preferPerTileCompress(void)
+    {
+        return false;
+    }
+
+    bool initCompress(char **papszOptions, const std::vector<double> &adfRates,
+                      int nBlockXSize, int nBlockYSize, bool bIsIrreversible,
+                      int nNumResolutions, JP2_PROG_ORDER eProgOrder, int bYCC,
+                      int nCblockW, int nCblockH, int bYCBCR420, int bProfile1,
+                      int nBands, int nXSize, int nYSize,
+                      JP2_COLOR_SPACE eColorSpace, CPL_UNUSED int numThreads)
+    {
+        int bSOP =
+            CPLTestBool(CSLFetchNameValueDef(papszOptions, "SOP", "FALSE"));
+        int bEPH =
+            CPLTestBool(CSLFetchNameValueDef(papszOptions, "EPH", "FALSE"));
+
+        if (bSOP)
+            compressParams.csty |= 0x02;
+        if (bEPH)
+            compressParams.csty |= 0x04;
+        compressParams.allocationByRateDistoration = true;
+        compressParams.numlayers = (int)adfRates.size();
+        for (int i = 0; i < (int)adfRates.size(); i++)
+            compressParams.layer_rate[i] = (float)adfRates[i];
+        compressParams.tx0 = 0;
+        compressParams.ty0 = 0;
+        compressParams.tile_size_on = TRUE;
+        compressParams.t_width = nBlockXSize;
+        compressParams.t_height = nBlockYSize;
+        compressParams.irreversible = bIsIrreversible;
+        compressParams.numresolution = nNumResolutions;
+        compressParams.prog_order = (GRK_PROG_ORDER)eProgOrder;
+        compressParams.mct = static_cast<char>(bYCC);
+        compressParams.cblockw_init = nCblockW;
+        compressParams.cblockh_init = nCblockH;
+        compressParams.cblk_sty = 0;
+
+        std::string osComment;
+        const char *pszCOM = CSLFetchNameValue(papszOptions, "COMMENT");
+        if (pszCOM)
+        {
+            osComment = pszCOM;
+            compressParams.num_comments = 1;
+            compressParams.comment[0] = &osComment[0];
+        }
+        else if (!bIsIrreversible)
+        {
+            osComment = getComment();
+            if (adfRates.back() == 1.0 && !bYCBCR420)
+            {
+                osComment += ". LOSSLESS settings used";
+            }
+            else
+            {
+                osComment += ". LOSSY settings used";
+            }
+            compressParams.num_comments = 1;
+            compressParams.comment[0] = &osComment[0];
+        }
+
+        // Was buggy before for some of the options
+        const char *pszCodeBlockStyle =
+            CSLFetchNameValue(papszOptions, "CODEBLOCK_STYLE");
+        if (pszCodeBlockStyle)
+        {
+            if (CPLGetValueType(pszCodeBlockStyle) == CPL_VALUE_INTEGER)
+            {
+                int nVal = atoi(pszCodeBlockStyle);
+                if (nVal >= 0 && nVal <= 63)
+                {
+                    compressParams.cblk_sty = nVal;
+                }
+                else
+                {
+                    CPLError(CE_Warning, CPLE_NotSupported,
+                             "Invalid value for CODEBLOCK_STYLE: %s. "
+                             "Should be >= 0 and <= 63",
+                             pszCodeBlockStyle);
+                }
+            }
+            else
+            {
+                char **papszTokens =
+                    CSLTokenizeString2(pszCodeBlockStyle, ", ", 0);
+                for (char **papszIter = papszTokens; papszIter && *papszIter;
+                     ++papszIter)
+                {
+                    if (EQUAL(*papszIter, "BYPASS"))
+                    {
+                        compressParams.cblk_sty |= (1 << 0);
+                    }
+                    else if (EQUAL(*papszIter, "RESET"))
+                    {
+                        compressParams.cblk_sty |= (1 << 1);
+                    }
+                    else if (EQUAL(*papszIter, "TERMALL"))
+                    {
+                        compressParams.cblk_sty |= (1 << 2);
+                    }
+                    else if (EQUAL(*papszIter, "VSC"))
+                    {
+                        compressParams.cblk_sty |= (1 << 3);
+                    }
+                    else if (EQUAL(*papszIter, "PREDICTABLE"))
+                    {
+                        compressParams.cblk_sty |= (1 << 4);
+                    }
+                    else if (EQUAL(*papszIter, "SEGSYM"))
+                    {
+                        compressParams.cblk_sty |= (1 << 5);
+                    }
+                    else
+                    {
+                        CPLError(CE_Warning, CPLE_NotSupported,
+                                 "Unrecognized option for CODEBLOCK_STYLE: %s",
+                                 *papszIter);
+                    }
+                }
+                CSLDestroy(papszTokens);
+            }
+        }
+        /* Add precincts */
+        const char *pszPrecincts = CSLFetchNameValueDef(
+            papszOptions, "PRECINCTS",
+            "{512,512},{256,512},{128,512},{64,512},{32,512},{"
+            "16,512},{8,512},{4,512},{2,512}");
+        char **papszTokens =
+            CSLTokenizeStringComplex(pszPrecincts, "{},", FALSE, FALSE);
+        int nPrecincts = CSLCount(papszTokens) / 2;
+        for (int i = 0; i < nPrecincts && i < GRK_J2K_MAXRLVLS; i++)
+        {
+            int nPCRW = atoi(papszTokens[2 * i]);
+            int nPCRH = atoi(papszTokens[2 * i + 1]);
+            if (nPCRW < 1 || nPCRH < 1)
+                break;
+            compressParams.csty |= 0x01;
+            compressParams.res_spec++;
+            compressParams.prcw_init[i] = nPCRW;
+            compressParams.prch_init[i] = nPCRH;
+        }
+        CSLDestroy(papszTokens);
+
+        /* Add tileparts setting */
+        const char *pszTileParts =
+            CSLFetchNameValueDef(papszOptions, "TILEPARTS", "DISABLED");
+        if (EQUAL(pszTileParts, "RESOLUTIONS"))
+        {
+            compressParams.enableTilePartGeneration = true;
+            compressParams.newTilePartProgressionDivider = 'R';
+        }
+        else if (EQUAL(pszTileParts, "LAYERS"))
+        {
+            if (compressParams.numlayers == 1)
+            {
+                CPLError(
+                    CE_Warning, CPLE_AppDefined,
+                    "TILEPARTS=LAYERS has no real interest with single-layer "
+                    "codestream");
+            }
+            compressParams.enableTilePartGeneration = true;
+            compressParams.newTilePartProgressionDivider = 'L';
+        }
+        else if (EQUAL(pszTileParts, "COMPONENTS"))
+        {
+            compressParams.enableTilePartGeneration = true;
+            compressParams.newTilePartProgressionDivider = 'C';
+        }
+        else if (!EQUAL(pszTileParts, "DISABLED"))
+        {
+            CPLError(CE_Warning, CPLE_NotSupported,
+                     "Invalid value for TILEPARTS");
+        }
+
+        if (bProfile1)
+        {
+            compressParams.rsiz = GRK_PROFILE_1;
+        }
+        //  if (getenv("GRK_NUM_THREADS") == nullptr)
+        //      opj_codec_set_threads(pCodec, numThreads);
+        if (CPLTestBool(CSLFetchNameValueDef(papszOptions, "PLT", "FALSE")))
+        {
+            compressParams.writePLT = true;
+        }
+        if (CPLTestBool(CSLFetchNameValueDef(papszOptions, "TLM", "FALSE")))
+        {
+            compressParams.writeTLM = true;
+        }
+
+        psImage = grk_image_new(nBands, pasBandParams,
+                                (GRK_COLOR_SPACE)eColorSpace, true);
+        if (psImage == nullptr)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined, "grk_image_new() failed");
+            free();
+            return false;
+        }
+
+        psImage->x0 = 0;
+        psImage->y0 = 0;
+        psImage->x1 = nXSize;
+        psImage->y1 = nYSize;
+        psImage->color_space = (GRK_COLOR_SPACE)eColorSpace;
+        psImage->numcomps = nBands;
+
+        grk_stream_params streamParams;
+        grk_set_default_stream_params(&streamParams);
+        streamParams.seek_fn = JP2Dataset_Seek;
+        streamParams.write_fn = JP2Dataset_Write;
+        streamParams.user_data = psJP2File;
+
+        /* Always ask Grok to do codestream only. We will take care */
+        /* of JP2 boxes */
+        pCodec = grk_compress_init(&streamParams, &compressParams, psImage);
+        if (pCodec == nullptr)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined, "grk_compress_init() failed");
+            return false;
+        }
+
+        return true;
+    }
+
+    bool compressTile(CPL_UNUSED int tileIndex, CPL_UNUSED GByte *buff,
+                      CPL_UNUSED uint32_t buffLen)
+    {
+        return grk_compress(pCodec, nullptr) != 0;
+    }
+
+    bool finishCompress(void)
+    {
+        free();
+        return true;
+    }
+
+    void cleanUpDecompress(void)
+    {
+        free();
+    }
+
+    grk_decompress_parameters decompressParams;
+    grk_cparameters compressParams;
+    jp2_codec *pCodec;
+    jp2_image *psImage;
+    grk_image_comp *pasBandParams;
+    JP2File *psJP2File;
+};
+
+struct JP2GRKDatasetBase : public JP2DatasetBase
+{
+    JP2_COLOR_SPACE eColorSpace = GRKCodecWrapper::cvtenum(JP2_CLRSPC_UNKNOWN);
+    GRKCodecWrapper *m_codec = nullptr;
+    int *m_pnLastLevel = nullptr;
+    bool m_bStrict;
+
+    ~JP2GRKDatasetBase(void)
+    {
+        delete m_codec;
+    }
+
+    void init(void)
+    {
+        grk_initialize(nullptr, 0, false);
+        grk_set_msg_handlers(JP2_InfoCallback, nullptr, JP2_WarningCallback,
+                             nullptr, JP2_ErrorCallback, nullptr);
+    }
+
+    void deinit(void)
+    {
+    }
+
+    CPLErr readBlockInit(VSILFILE *fpIn, GRKCodecWrapper *codec, int nBlockXOff,
+                         int nBlockYOff, int nRasterXSize, int nRasterYSize,
+                         int nBlockXSize, int nBlockYSize, int nTileNumber)
+    {
+        const int nWidthToRead =
+            std::min(nBlockXSize, nRasterXSize - nBlockXOff * nBlockXSize);
+        const int nHeightToRead =
+            std::min(nBlockYSize, nRasterYSize - nBlockYOff * nBlockYSize);
+
+        if (!codec)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined, "null codec");
+            return CE_Failure;
+        }
+
+        if (m_codec && CPLTestBool(CPLGetConfigOption(
+                           "USE_OPENJPEG_SINGLE_TILE_OPTIM", "YES")))
+        {
+            if ((*m_pnLastLevel == -1 || *m_pnLastLevel == iLevel) &&
+                m_codec->pCodec != nullptr && m_codec->psImage != nullptr)
+            {
+                codec->transfer(m_codec);
+            }
+            else
+            {
+                // For some reason, we need to "reboot" all the machinery if
+                // changing of overview level. Should be fixed in openjpeg
+                m_codec->free();
+            }
+        }
+        *m_pnLastLevel = iLevel;
+
+        if (codec->pCodec == nullptr)
+        {
+            grk_decompress_parameters decompressParams;
+            grk_decompress_set_default_params(&decompressParams);
+            decompressParams.core.reduce = iLevel;
+
+            grk_stream_params streamParams;
+            grk_set_default_stream_params(&streamParams);
+            streamParams.seek_fn = JP2Dataset_Seek;
+            streamParams.read_fn = JP2Dataset_Read;
+            streamParams.stream_len = nCodeStreamLength;
+            if (m_codec && m_codec->psJP2File)
+            {
+                streamParams.user_data = m_codec->psJP2File;
+                if (VSIFSeekL(m_codec->psJP2File->fp_,
+                              m_codec->psJP2File->nBaseOffset, SEEK_SET))
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined, "VSIFSeekL failed");
+                    return CE_Failure;
+                }
+            }
+            else
+            {
+                codec->open(fpIn, nCodeStreamStart);
+                streamParams.user_data = codec->psJP2File;
+                if (VSIFSeekL(codec->psJP2File->fp_,
+                              codec->psJP2File->nBaseOffset, SEEK_SET))
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined, "VSIFSeekL failed");
+                    return CE_Failure;
+                }
+            }
+            codec->pCodec =
+                grk_decompress_init(&streamParams, &decompressParams.core);
+            if (codec->pCodec == nullptr)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "grk_decompress_init() failed");
+                return CE_Failure;
+            }
+            //            if (getenv("GRK_NUM_THREADS") == nullptr)
+            //            {
+            //                if (m_nBlocksToLoad <= 1)
+            //                    opj_codec_set_threads(local_ctx->pCodec, GetNumThreads());
+            //                else
+            //                    opj_codec_set_threads(local_ctx->pCodec,
+            //                                          GetNumThreads() / m_nBlocksToLoad);
+            //            }
+        }
+        grk_header_info headerInfo;
+        memset(&headerInfo, 0, sizeof(headerInfo));
+        if (!grk_decompress_read_header(codec->pCodec, &headerInfo))
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "grk_decompress_read_header() failed (psImage=%p)",
+                     codec->psImage);
+            // Hopefully the situation is better on openjpeg 2.2 regarding
+            // cleanup
+            // We may leak objects, but the cleanup of openjpeg can cause
+            // double frees sometimes...
+            return CE_Failure;
+        }
+        if (bUseSetDecodeArea)
+        {
+            /* The decode area must be expressed in grid reference, ie at full*/
+            /* scale */
+            if (!grk_decompress_set_window(
+                    codec->pCodec,
+                    m_nX0 + static_cast<int>(
+                                static_cast<GIntBig>(nBlockXOff * nBlockXSize) *
+                                nParentXSize / nRasterXSize),
+                    m_nY0 + static_cast<int>(
+                                static_cast<GIntBig>(nBlockYOff * nBlockYSize) *
+                                nParentYSize / nRasterYSize),
+                    m_nX0 + static_cast<int>(
+                                static_cast<GIntBig>(nBlockXOff * nBlockXSize +
+                                                     nWidthToRead) *
+                                nParentXSize / nRasterXSize),
+                    m_nY0 + static_cast<int>(
+                                static_cast<GIntBig>(nBlockYOff * nBlockYSize +
+                                                     nHeightToRead) *
+                                nParentYSize / nRasterYSize)))
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "grk_decompress_set_window() failed");
+                return CE_Failure;
+            }
+            if (!grk_decompress(codec->pCodec, nullptr))
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "grk_decompress() failed");
+                return CE_Failure;
+            }
+        }
+        else
+        {
+            if (!grk_decompress_tile(codec->pCodec, nTileNumber))
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "grk_decompress_tile() failed");
+                return CE_Failure;
+            }
+        }
+
+        codec->psImage = grk_decompress_get_composited_image(codec->pCodec);
+        if (!codec->psImage)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "grk_decompress_get_composited_image() failed");
+            return CE_Failure;
+        }
+
+        return CE_None;
+    }
+
+    void cache(JP2GRKDatasetBase *rhs)
+    {
+        // prevent linter from treating this as potential static method
+        (void)this;
+        if (m_codec && rhs)
+            m_codec->transfer(rhs->m_codec);
+    }
+
+    void cacheNew(GRKCodecWrapper *codec)
+    {
+        // prevent linter from treating this as potential static method
+        (void)this;
+        if (!codec)
+            return;
+        m_codec = new GRKCodecWrapper(codec);
+    }
+
+    void cache(GRKCodecWrapper *codec)
+    {
+        // prevent linter from treating this as potential static method
+        (void)this;
+        if (!codec)
+            return;
+        if (m_codec && CPLTestBool(CPLGetConfigOption(
+                           "USE_OPENJPEG_SINGLE_TILE_OPTIM", "YES")))
+        {
+            m_codec->transfer(codec);
+        }
+        else
+        {
+            codec->cleanUpDecompress();
+        }
+    }
+
+    void openCompleteJP2(GRKCodecWrapper *codec)
+    {
+        // prevent linter from treating this as potential static method
+        (void)this;
+        if (bSingleTiled && bUseSetDecodeArea)
+        {
+            // nothing
+        }
+        else
+        {
+            if (codec)
+                codec->free();
+        }
+    }
+
+    void closeJP2(void)
+    {
+        if (iLevel == 0)
+        {
+            if (m_codec)
+                m_codec->free();
+            delete m_pnLastLevel;
+        }
+    }
+
+    static void setMetaData(GDALDriver *poDriver)
+    {
+        poDriver->SetMetadataItem(
+            GDAL_DMD_OPENOPTIONLIST,
+            "<OpenOptionList>"
+            "   <Option name='1BIT_ALPHA_PROMOTION' type='boolean' "
+            "description='Whether a 1-bit alpha channel should be promoted to "
+            "8-bit' default='YES'/>"
+            "   <Option name='OPEN_REMOTE_GML' type='boolean' "
+            "description='Whether "
+            "to load remote vector layers referenced by a link in a GMLJP2 v2 "
+            "box' "
+            "default='NO'/>"
+            "   <Option name='GEOREF_SOURCES' type='string' description='Comma "
+            "separated list made with values "
+            "INTERNAL/GMLJP2/GEOJP2/WORLDFILE/PAM/NONE that describe the "
+            "priority "
+            "order for georeferencing' default='PAM,GEOJP2,GMLJP2,WORLDFILE'/>"
+            "   <Option name='USE_TILE_AS_BLOCK' type='boolean' "
+            "description='Whether to always use the JPEG-2000 block size as "
+            "the "
+            "GDAL block size' default='NO'/>"
+            "</OpenOptionList>");
+
+        poDriver->SetMetadataItem(
+            GDAL_DMD_CREATIONOPTIONLIST,
+            "<CreationOptionList>"
+            "   <Option name='CODEC' type='string-select' default='according "
+            "to "
+            "file extension. If unknown, default to J2K'>"
+            "       <Value>JP2</Value>"
+            "       <Value>J2K</Value>"
+            "   </Option>"
+            "   <Option name='GeoJP2' type='boolean' description='Whether to "
+            "emit "
+            "a GeoJP2 box' default='YES'/>"
+            "   <Option name='GMLJP2' type='boolean' description='Whether to "
+            "emit "
+            "a GMLJP2 v1 box' default='YES'/>"
+            "   <Option name='GMLJP2V2_DEF' type='string' "
+            "description='Definition "
+            "file to describe how a GMLJP2 v2 box should be generated. If set "
+            "to "
+            "YES, a minimal instance will be created'/>"
+            "   <Option name='QUALITY' type='string' description='Single "
+            "quality "
+            "value or comma separated list of increasing quality values for "
+            "several layers, each in the 0-100 range' default='25'/>"
+            "   <Option name='REVERSIBLE' type='boolean' description='True if "
+            "the "
+            "compression is reversible' default='false'/>"
+            "   <Option name='RESOLUTIONS' type='int' description='Number of "
+            "resolutions.' min='1' max='30'/>"
+            "   <Option name='BLOCKXSIZE' type='int' description='Tile Width' "
+            "default='1024'/>"
+            "   <Option name='BLOCKYSIZE' type='int' description='Tile Height' "
+            "default='1024'/>"
+            "   <Option name='PROGRESSION' type='string-select' default='LRCP'>"
+            "       <Value>LRCP</Value>"
+            "       <Value>RLCP</Value>"
+            "       <Value>RPCL</Value>"
+            "       <Value>PCRL</Value>"
+            "       <Value>CPRL</Value>"
+            "   </Option>"
+            "   <Option name='SOP' type='boolean' description='True to insert "
+            "SOP "
+            "markers' default='false'/>"
+            "   <Option name='EPH' type='boolean' description='True to insert "
+            "EPH "
+            "markers' default='false'/>"
+            "   <Option name='YCBCR420' type='boolean' description='if RGB "
+            "must be "
+            "resampled to YCbCr 4:2:0' default='false'/>"
+            "   <Option name='YCC' type='boolean' description='if RGB must be "
+            "transformed to YCC color space (lossless MCT transform)' "
+            "default='YES'/>"
+            "   <Option name='NBITS' type='int' description='Bits (precision) "
+            "for "
+            "sub-byte files (1-7), sub-uint16 (9-15), sub-uint32 (17-31)'/>"
+            "   <Option name='1BIT_ALPHA' type='boolean' description='Whether "
+            "to "
+            "encode the alpha channel as a 1-bit channel' default='NO'/>"
+            "   <Option name='ALPHA' type='boolean' description='Whether to "
+            "force "
+            "encoding last channel as alpha channel' default='NO'/>"
+            "   <Option name='PROFILE' type='string-select' description='Which "
+            "codestream profile to use' default='AUTO'>"
+            "       <Value>AUTO</Value>"
+            "       <Value>UNRESTRICTED</Value>"
+            "       <Value>PROFILE_1</Value>"
+            "   </Option>"
+            "   <Option name='INSPIRE_TG' type='boolean' description='Whether "
+            "to "
+            "use features that comply with Inspire Orthoimagery Technical "
+            "Guidelines' default='NO'/>"
+            "   <Option name='JPX' type='boolean' description='Whether to "
+            "advertise JPX features when a GMLJP2 box is written (or use JPX "
+            "branding if GMLJP2 v2)' default='YES'/>"
+            "   <Option name='GEOBOXES_AFTER_JP2C' type='boolean' "
+            "description='Whether to place GeoJP2/GMLJP2 boxes after the "
+            "code-stream' default='NO'/>"
+            "   <Option name='PRECINCTS' type='string' description='Precincts "
+            "size "
+            "as a string of the form {w,h},{w,h},... with power-of-two "
+            "values'/>"
+            "   <Option name='TILEPARTS' type='string-select' "
+            "description='Whether "
+            "to generate tile-parts and according to which criterion' "
+            "default='DISABLED'>"
+            "       <Value>DISABLED</Value>"
+            "       <Value>RESOLUTIONS</Value>"
+            "       <Value>LAYERS</Value>"
+            "       <Value>COMPONENTS</Value>"
+            "   </Option>"
+            "   <Option name='CODEBLOCK_WIDTH' type='int' "
+            "description='Codeblock "
+            "width' default='64' min='4' max='1024'/>"
+            "   <Option name='CODEBLOCK_HEIGHT' type='int' "
+            "description='Codeblock "
+            "height' default='64' min='4' max='1024'/>"
+            "   <Option name='CT_COMPONENTS' type='int' min='3' max='4' "
+            "description='If there is one color table, number of color table "
+            "components to write. Autodetected if not specified.'/>"
+            "   <Option name='WRITE_METADATA' type='boolean' "
+            "description='Whether "
+            "metadata should be written, in a dedicated JP2 XML box' "
+            "default='NO'/>"
+            "   <Option name='MAIN_MD_DOMAIN_ONLY' type='boolean' "
+            "description='(Only if WRITE_METADATA=YES) Whether only metadata "
+            "from "
+            "the main domain should be written' default='NO'/>"
+            "   <Option name='USE_SRC_CODESTREAM' type='boolean' "
+            "description='When "
+            "source dataset is JPEG2000, whether to reuse the codestream of "
+            "the "
+            "source dataset unmodified' default='NO'/>"
+            "   <Option name='CODEBLOCK_STYLE' type='string' "
+            "description='Comma-separated combination of BYPASS, RESET, "
+            "TERMALL, "
+            "VSC, PREDICTABLE, SEGSYM or value between 0 and 63'/>"
+            "   <Option name='PLT' type='boolean' description='True to insert "
+            "PLT "
+            "marker segments' default='false'/>"
+            "   <Option name='TLM' type='boolean' description='True to insert "
+            "TLM "
+            "marker segments' default='false'/>"
+            "   <Option name='COMMENT' type='string' description='Content of "
+            "the "
+            "comment (COM) marker'/>"
+            "</CreationOptionList>");
+    }
+};

--- a/frmts/grok/grokdataset.cpp
+++ b/frmts/grok/grokdataset.cpp
@@ -1,0 +1,39 @@
+/******************************************************************************
+ *
+ * Author:   Aaron Boxer, <boxerab at protonmail dot com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2023, Grok Image Compression Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a
+ * copy of this software and associated documentation files (the "Software"),
+ * to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ * and/or sell copies of the Software, and to permit persons to whom the
+ * Software is furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+ * OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ * THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ ****************************************************************************/
+
+#include "jp2opjlikedataset.h"
+#include "jp2opjlikedataset.cpp"
+
+#include "grkdatasetbase.h"
+
+/************************************************************************/
+/*                      GDALRegister_JP2Grok()                          */
+/************************************************************************/
+
+void GDALRegister_JP2Grok()
+{
+    GDALRegisterJP2<GRKCodecWrapper, JP2GRKDatasetBase>("Grok", "JP2Grok");
+}

--- a/gcore/gdal_frmts.h
+++ b/gcore/gdal_frmts.h
@@ -181,6 +181,7 @@ void CPL_DLL GDALRegister_GTX(void);
 void CPL_DLL GDALRegister_LOSLAS(void);
 void CPL_DLL GDALRegister_NTv2(void);
 void CPL_DLL GDALRegister_CTable2(void);
+void CPL_DLL GDALRegister_JP2Grok(void);
 void CPL_DLL GDALRegister_JP2OpenJPEG(void);
 void DeclareDeferredOPENJPEGPlugin(void);
 void CPL_DLL GDALRegister_XYZ(void);


### PR DESCRIPTION
Let's try this again !

## What does this PR do?

This PR adds a new driver for the JPEG 2000 format using [Grok](https://github.com/GrokImageCompression/grok) library.

### Design Strategy

In a previous merged PR, common features supporting both OpenJPEG and Grok libraries were refactored into a template driver named `JP2DatasetBase`. This PR creates a new Grok driver inheriting from `JP2DatasetBase`.

### Performance

Basic performance testing of `gdal_translate` with default settings on a large HiRISE image shows this driver outperforming the existing open source driver by 6 times.


## What are related issues/pull requests?

https://github.com/OSGeo/gdal/pull/3449
https://github.com/OSGeo/gdal/pull/5117
https://github.com/OSGeo/gdal/pull/8133

## Tasks

 - [ ] Support encode (currently disabled)
 - [ ] Address issues raised by @rouault in previous Grok PRs
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

