### PR TITLE
Parse dms in ISG format

### DIFF
--- a/autotest/gdrivers/data/isg/header_dms.isg
+++ b/autotest/gdrivers/data/isg/header_dms.isg
@@ -1,0 +1,28 @@
+begin_of_head ================================================
+model name     : GSIGEO2024bata
+model year     : 2024
+model type     : gravimetric
+data type      : geoid
+data units     : meters
+data format    : grid
+data ordering  : N-to-S, W-to-E
+ref ellipsoid  : GRS80
+ref frame      : ---
+height datum   : ---
+tide system    : ---
+coord type     : geodetic
+coord units    : dms
+map projection : ---
+EPSG code      : 6668
+lat min        =  15°00'00"
+lat max        =  50°00'00"
+lon min        = 120°00'00"
+lon max        = 160°00'00"
+delta lat      =   0°01'00"
+delta lon      =   0°01'30"
+nrows          =        2101
+ncols          =        1601
+nodata         =  -9999.0000
+creation date  =  27/03/2024
+ISG format     =         2.0
+end_of_head ==================================================

--- a/autotest/gdrivers/isg.py
+++ b/autotest/gdrivers/isg.py
@@ -123,3 +123,17 @@ def test_isg_header_larger_than_1024bytes():
         ds = gdal.Open("data/isg/header_larger_than_1024bytes.isg")
     expected_gt = [12.99375, 0.0125, 0.0, 47.00416666666666, 0.0, -0.008333333333333333]
     assert ds.GetGeoTransform() == pytest.approx(expected_gt, rel=1e-8)
+
+
+###############################################################################
+# Test if we can read dms angles
+
+
+def test_isg_dms():
+
+    gdal.ErrorReset()
+    # Header of https://www.gsi.go.jp/butsuri/data/GSIGEO2024beta.zip
+    ds = gdal.Open("data/isg/header_dms.isg")
+    assert gdal.GetLastErrorMsg() == ""
+    expected_gt = [119.9875, 0.025, 0.0, 50.0083333333, 0.0, -0.01666666666]
+    assert ds.GetGeoTransform() == pytest.approx(expected_gt, rel=1e-8)


### PR DESCRIPTION
## What does this PR do?
Parses ISG files that use "dms" format for "coord units" 

Context:
Trying to read the new geoid model for Japan, that is for now in beta.
https://www.gsi.go.jp/buturisokuchi/grageo_reference.html
https://www.gsi.go.jp/butsuri/data/GSIGEO2024beta.zip
I found it was not parsed by GDAL
It is in ISG 2.0 format
https://www.isgeoid.polimi.it/Geoid/ISG_format_v20_20200625.pdf
using `dms` for "coord units"

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed