### PR TITLE
Doc: gdal_merge.py: Add missing `-q` documentation

### DIFF
--- a/doc/source/programs/gdal_merge.rst
+++ b/doc/source/programs/gdal_merge.rst
@@ -71,6 +71,10 @@ target pixel in the resulting raster nor will it overwrite a valid pixel value.
     If not specified the aggregate extents of all input files will be
     used.
 
+.. option:: -q, -quiet
+
+    Suppress progress messages.
+
 .. option:: -v
 
     Generate verbose output of mosaicing operations as they are done.


### PR DESCRIPTION
I tried to match the `-q` from `gdal_calc`, as I didn't see a common `options/quiet.rst`.

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

Fixes the missing documentation for an option of `gdal_merge.py`

## What are related issues/pull requests?

None

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
