### PR TITLE
ogrinfo: auto-select layer in datasets with only one layer

### DIFF
--- a/apps/ogrinfo_lib.cpp
+++ b/apps/ogrinfo_lib.cpp
@@ -2106,7 +2106,7 @@ char *GDALVectorInfo(GDALDatasetH hDataset,
 
                 CPLJSONObject oLayer;
                 oLayerArray.Add(oLayer);
-                if (!psOptions->bAllLayers)
+                if (nLayerCount > 1 && !psOptions->bAllLayers)
                 {
                     if (!bJson)
                         Concat(osRet, psOptions->bStdoutOutput,


### PR DESCRIPTION
## What does this PR do?

Avoids the need to specify the layer name in `ogrinfo` calls to single-layer datasets, e.g. 

```
ogrinfo -so tl_2022_us_county.shp
```
instead of
```
ogrinfo -so tl_2022_us_county.shp tl_2022_us_county
```

This matches the behavior when using `ogrinfo -json` or when calling `gdal.VectorInfo` from Python. It is also [described as](https://trac.osgeo.org/gdal/wiki/UserDocs/OgrInfo) "likely what is really wanted" by the author 17 years ago :)

Somewhat mixed feelings about this because forgetting `-al` is my reminder to also set `-so`. But I don't think that's a good reason to keep the current behavior (though there may be one).

## What are related issues/pull requests?

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
