### PR TITLE
MRF: Allow open of MRF-in-TAR as MRF

### DIFF
--- a/autotest/gdrivers/mrf.py
+++ b/autotest/gdrivers/mrf.py
@@ -236,10 +236,7 @@ def test_mrf_zen_test():
 def test_mrf_in_tar():
     import tarfile
     out_ds = gdal.Translate(
-        "plain.mrf",
-        "data/byte.tif",
-        format="MRF",
-        creationOptions=["COMPRESS=DEFLATE"]
+        "plain.mrf", "data/byte.tif", format="MRF", creationOptions=["COMPRESS=DEFLATE"]
     )
     out_ds = None
     with tarfile.TarFile("plain.mrf.tar", "w", format=tarfile.GNU_FORMAT) as tar:

--- a/autotest/gdrivers/mrf.py
+++ b/autotest/gdrivers/mrf.py
@@ -235,10 +235,10 @@ def test_mrf_zen_test():
 
 def test_mrf_in_tar():
     import tarfile
-    out_ds = gdal.Translate(
+
+    gdal.Translate(
         "plain.mrf", "data/byte.tif", format="MRF", creationOptions=["COMPRESS=DEFLATE"]
     )
-    out_ds = None
     with tarfile.TarFile("plain.mrf.tar", "w", format=tarfile.GNU_FORMAT) as tar:
         for ext in ("mrf", "idx", "pzp"):
             tar.add("plain." + ext)

--- a/autotest/gdrivers/mrf.py
+++ b/autotest/gdrivers/mrf.py
@@ -245,12 +245,13 @@ def test_mrf_in_tar():
     with tarfile.TarFile("plain.mrf.tar", "w", format=tarfile.GNU_FORMAT) as tar:
         for ext in ("mrf", "idx", "pzp"):
             tar.add("plain." + ext)
+    for ext in ("mrf", "idx", "pzp", "mrf.aux.xml"):
+        gdal.Unlink("plain." + ext)
     ds = gdal.Open("plain.mrf.tar")
     cs = ds.GetRasterBand(1).Checksum()
     ds = None
     assert cs == 4672
-    for ext in ("mrf.tar", "mrf", "idx", "pzp", "mrf.aux.xml"):
-        gdal.Unlink("plain." + ext)
+    gdal.Unlink("plain.mrf.tar")
 
 
 def test_mrf_overview_nnb_fact_2():

--- a/autotest/gdrivers/mrf.py
+++ b/autotest/gdrivers/mrf.py
@@ -233,6 +233,26 @@ def test_mrf_zen_test():
             gdal.Unlink(f)
 
 
+def test_mrf_in_tar():
+    import tarfile
+    out_ds = gdal.Translate(
+        "plain.mrf",
+        "data/byte.tif",
+        format="MRF",
+        creationOptions=["COMPRESS=DEFLATE"]
+    )
+    out_ds = None
+    with tarfile.TarFile("plain.mrf.tar", "w", format=tarfile.GNU_FORMAT) as tar:
+        for ext in ("mrf", "idx", "pzp"):
+            tar.add("plain." + ext)
+    ds = gdal.Open("plain.mrf.tar")
+    cs = ds.GetRasterBand(1).Checksum()
+    ds = None
+    assert cs == 4672
+    for ext in ("mrf.tar", "mrf", "idx", "pzp", "mrf.aux.xml"):
+        gdal.Unlink("plain." + ext)
+
+
 def test_mrf_overview_nnb_fact_2():
 
     expected_cs = 1087

--- a/frmts/mrf/marfa.h
+++ b/frmts/mrf/marfa.h
@@ -554,6 +554,7 @@ class MRFDataset final : public GDALPamDataset
 
     // MRF file name
     CPLString fname;
+    CPLString publicname;
 
     // The source to be cached in this MRF
     CPLString source;

--- a/frmts/mrf/marfa.h
+++ b/frmts/mrf/marfa.h
@@ -292,6 +292,7 @@ ILOrder OrderToken(const char *, ILOrder def = IL_ERR_ORD);
 CPLString getFname(CPLXMLNode *, const char *, const CPLString &, const char *);
 CPLString getFname(const CPLString &, const char *);
 double getXMLNum(CPLXMLNode *, const char *, double);
+// Offset of index, pos is in pages
 GIntBig IdxOffset(const ILSize &, const ILImage &);
 double logbase(double val, double base);
 int IsPower(double value, double base);
@@ -343,9 +344,6 @@ typedef struct
     VSILFILE *FP;
     GDALRWFlag acc;
 } VF;
-
-// Offset of index, pos is in pages
-GIntBig IdxOffset(const ILSize &pos, const ILImage &img);
 
 enum
 {

--- a/frmts/mrf/marfa_dataset.cpp
+++ b/frmts/mrf/marfa_dataset.cpp
@@ -603,7 +603,7 @@ GDALDataset *MRFDataset::Open(GDALOpenInfo *poOpenInfo)
     int level = -1;   // All levels
     int version = 0;  // Current
     int zslice = 0;
-    string fn;  // Used to parse and adjust the file name
+    string fn;        // Used to parse and adjust the file name
     string insidefn;  // vsi inside file name
 
     // Different ways to open an MRF

--- a/frmts/mrf/marfa_dataset.cpp
+++ b/frmts/mrf/marfa_dataset.cpp
@@ -604,7 +604,7 @@ GDALDataset *MRFDataset::Open(GDALOpenInfo *poOpenInfo)
     int version = 0;  // Current
     int zslice = 0;
     string fn;        // Used to parse and adjust the file name
-    string insidefn;  // vsi inside file name
+    string insidefn;  // inside tar file name
 
     // Different ways to open an MRF
     if (poOpenInfo->nHeaderBytes >= 10)
@@ -654,7 +654,12 @@ GDALDataset *MRFDataset::Open(GDALOpenInfo *poOpenInfo)
         return nullptr;
 
     MRFDataset *ds = new MRFDataset();
-    ds->fname = (insidefn.size() == 0) ? pszFileName : insidefn;
+    ds->fname = pszFileName;
+    if (!insidefn.empty())
+    {
+        ds->publicname = pszFileName;
+        ds->fname = insidefn;
+    }
     ds->eAccess = poOpenInfo->eAccess;
     ds->level = level;
     ds->zslice = zslice;
@@ -1023,10 +1028,13 @@ char **MRFDataset::GetFileList()
 {
     char **papszFileList = nullptr;
 
+    string usename = fname;
+    if (!publicname.empty())
+        usename = publicname;
     // Add the header file name if it is real
     VSIStatBufL sStat;
-    if (VSIStatExL(fname, &sStat, VSI_STAT_EXISTS_FLAG) == 0)
-        papszFileList = CSLAddString(papszFileList, fname);
+    if (VSIStatExL(usename.c_str(), &sStat, VSI_STAT_EXISTS_FLAG) == 0)
+        papszFileList = CSLAddString(papszFileList, usename.c_str());
 
     // These two should be real
     // We don't really want to add these files, since they will be erased when

--- a/frmts/mrf/marfa_dataset.cpp
+++ b/frmts/mrf/marfa_dataset.cpp
@@ -87,7 +87,7 @@ MRFDataset::MRFDataset()
       pzscctx(nullptr), pzsdctx(nullptr), read_timer(), write_timer(0)
 {
     m_oSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
-    //                X0   Xx   Xy  Y0    Yx   Yy
+    //               X0   Xx   Xy  Y0    Yx   Yy
     double gt[6] = {0.0, 1.0, 0.0, 0.0, 0.0, 1.0};
 
     memcpy(GeoTransform, gt, sizeof(gt));
@@ -604,14 +604,25 @@ GDALDataset *MRFDataset::Open(GDALOpenInfo *poOpenInfo)
     int version = 0;  // Current
     int zslice = 0;
     string fn;  // Used to parse and adjust the file name
+    string insidefn;  // vsi inside file name
 
     // Different ways to open an MRF
     if (poOpenInfo->nHeaderBytes >= 10)
     {
         const char *pszHeader =
             reinterpret_cast<char *>(poOpenInfo->pabyHeader);
+        fn.assign(pszHeader, poOpenInfo->nHeaderBytes);
         if (STARTS_WITH(pszHeader, "<MRF_META>"))  // Regular file name
             config = CPLParseXMLFile(pszFileName);
+        else if (poOpenInfo->eAccess == GA_ReadOnly && fn.size() > 600 &&
+                 (fn[262] == 0 || fn[262] == 32) &&
+                 STARTS_WITH(fn.c_str() + 257, "ustar") &&
+                 strlen(CPLGetPath(fn.c_str())) == 0 &&
+                 STARTS_WITH(fn.c_str() + 512, "<MRF_META>"))
+        {  // An MRF inside a tar
+            insidefn = string("/vsitar/") + pszFileName + "/" + pszHeader;
+            config = CPLParseXMLFile(insidefn.c_str());
+        }
 #if defined(LERC)
         else
             config = LERC_Band::GetMRFConfig(poOpenInfo);
@@ -643,7 +654,7 @@ GDALDataset *MRFDataset::Open(GDALOpenInfo *poOpenInfo)
         return nullptr;
 
     MRFDataset *ds = new MRFDataset();
-    ds->fname = pszFileName;
+    ds->fname = (insidefn.size() == 0) ? pszFileName : insidefn;
     ds->eAccess = poOpenInfo->eAccess;
     ds->level = level;
     ds->zslice = zslice;
@@ -657,7 +668,7 @@ GDALDataset *MRFDataset::Open(GDALOpenInfo *poOpenInfo)
     {
         // Open the whole dataset, then pick one level
         ds->cds = new MRFDataset();
-        ds->cds->fname = pszFileName;
+        ds->cds->fname = ds->fname;
         ds->cds->eAccess = ds->eAccess;
         ds->zslice = zslice;
         ret = ds->cds->Initialize(config);
@@ -683,7 +694,7 @@ GDALDataset *MRFDataset::Open(GDALOpenInfo *poOpenInfo)
     }
 
     // Tell PAM what our real file name is, to help it find the aux.xml
-    ds->SetPhysicalFilename(pszFileName);
+    ds->SetPhysicalFilename(ds->fname);
     // Don't mess with metadata after this, otherwise PAM will re-write the
     // aux.xml
     ds->TryLoadXML();
@@ -691,7 +702,7 @@ GDALDataset *MRFDataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Open external overviews.                                        */
     /* -------------------------------------------------------------------- */
-    ds->oOvManager.Initialize(ds, pszFileName);
+    ds->oOvManager.Initialize(ds, ds->fname);
 
     return ds;
 }
@@ -1676,15 +1687,14 @@ GIntBig MRFDataset::AddOverviews(int scaleIn)
 
         // And adjust the offset again, within next level
         img.idxoffset += sizeof(ILIdx) * img.pagecount.l / img.size.z * zslice;
-
+        int l = static_cast<int>(img.size.l);
         // Create and register the overviews for each band
         for (int i = 1; i <= nBands; i++)
         {
             MRFRasterBand *b =
                 reinterpret_cast<MRFRasterBand *>(GetRasterBand(i));
-            if (!(b->GetOverview(static_cast<int>(img.size.l) - 1)))
-                b->AddOverview(newMRFRasterBand(this, img, i,
-                                                static_cast<int>(img.size.l)));
+            if (!(b->GetOverview(l - 1)))
+                b->AddOverview(newMRFRasterBand(this, img, i, l));
         }
     }
 

--- a/frmts/mrf/mrfdrivercore.cpp
+++ b/frmts/mrf/mrfdrivercore.cpp
@@ -98,10 +98,9 @@ int MRFDriverIdentify(GDALOpenInfo *poOpenInfo)
 #endif
 
     // accept a tar file if the first file has no folder look like an MRF
-    if (poOpenInfo->eAccess == GA_ReadOnly &&
-        fn.size() > 600 && (fn[262] == 0 || fn[262] == 32) &&
-        STARTS_WITH(fn + 257, "ustar") && strlen(CPLGetPath(fn)) == 0 &&
-        STARTS_WITH(fn + 512, "<MRF_META>"))
+    if (poOpenInfo->eAccess == GA_ReadOnly && fn.size() > 600 &&
+        (fn[262] == 0 || fn[262] == 32) && STARTS_WITH(fn + 257, "ustar") &&
+        strlen(CPLGetPath(fn)) == 0 && STARTS_WITH(fn + 512, "<MRF_META>"))
     {
         return TRUE;
     }

--- a/frmts/mrf/mrfdrivercore.cpp
+++ b/frmts/mrf/mrfdrivercore.cpp
@@ -97,6 +97,15 @@ int MRFDriverIdentify(GDALOpenInfo *poOpenInfo)
         return TRUE;
 #endif
 
+    // accept a tar file if the first file has no folder look like an MRF
+    if (poOpenInfo->eAccess == GA_ReadOnly &&
+        fn.size() > 600 && (fn[262] == 0 || fn[262] == 32) &&
+        STARTS_WITH(fn + 257, "ustar") && strlen(CPLGetPath(fn)) == 0 &&
+        STARTS_WITH(fn + 512, "<MRF_META>"))
+    {
+        return TRUE;
+    }
+
     return FALSE;
 }
 


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

Allow the use of a tar file containing a single MRF directly as an MRF.

It has always been possible to open an MRF (as any other gdal format) inside a tar file by using a vsitar path.
This change allows a tar file that starts with the MRF metadata file to be directly recognized and opened for reading without having to use the vsitar path. This makes an MRF inside a TAR file act as a single file raster format, making it easier to share. All the MRF files have to be inside the tar, with the main metadata (.mrf) being the first.

The identification of such an MRF-in-TAR candidate is done by directly inspecting the tar header and the beginning of the first file inside the tar, without invoking using /vsitar.

This change does not interfere with the use of any other file inside the tar using the normal /vsitar path. The only difference is that gdalinfo on such a mrf-in-tar file will return the MRF information, as opposed to listing the tar content as it does now.

The last file extension has to be .tar to be correctly opened by vsitar internally, the recommended file name for an MRF-in-TAR will be **filename.mrf.tar**

