### PR TITLE
GML writer: fix missing SRS in Featurecollection's boundedBy element (3.9.1 regression)

### DIFF
--- a/ogr/ogrsf_frmts/gml/ogr_gml.h
+++ b/ogr/ogrsf_frmts/gml/ogr_gml.h
@@ -61,7 +61,6 @@ class OGRGMLLayer final : public OGRLayer
     char *pszFIDPrefix;
 
     bool bWriter;
-    bool bSameSRS;
 
     OGRGMLDataSource *poDS;
 
@@ -137,8 +136,14 @@ class OGRGMLDataSource final : public OGRDataSource
     OGRGMLSRSNameFormat eSRSNameFormat;
     bool bWriteSpaceIndentation;
 
-    OGRSpatialReference *poWriteGlobalSRS;
-    bool bWriteGlobalSRS;
+    //! Whether all geometry fields of all layers have the same SRS (or no SRS at all)
+    bool m_bWriteGlobalSRS = true;
+
+    //! The global SRS (may be null), that is valid only if m_bWriteGlobalSRS == true
+    std::unique_ptr<OGRSpatialReference> m_poWriteGlobalSRS{};
+
+    //! Whether at least one geometry field has been created
+    bool m_bWriteGlobalSRSInit = false;
 
     // input related parameters.
     CPLString osFilename;
@@ -299,6 +304,13 @@ class OGRGMLDataSource final : public OGRDataSource
     bool WriteFeatureBoundedBy() const;
     const char *GetSRSDimensionLoc() const;
     bool GMLFeatureCollection() const;
+
+    void DeclareNewWriteSRS(const OGRSpatialReference *poSRS);
+
+    bool HasWriteGlobalSRS() const
+    {
+        return m_bWriteGlobalSRS;
+    }
 
     virtual OGRLayer *ExecuteSQL(const char *pszSQLCommand,
                                  OGRGeometry *poSpatialFilter,


### PR DESCRIPTION
Fixes #10332

Was caused by the fix 3674ec7570f324ea43eef08b6f5ce3a29de2741d for #10071

The regression mostly occurs when writing a GML file using ogr2ogr when the source layer has a named geometry column, e.g if the source is a GeoPackage or if using -sql
The problem was acutally latent and also could have occured before 3.9.1 if using CreateLayer() without a SRS + CreateGeomField()
