### PR TITLE
Add open option COLUMN_ORDER to XYZ raster driver

### DIFF
--- a/doc/source/drivers/raster/xyz.rst
+++ b/doc/source/drivers/raster/xyz.rst
@@ -39,12 +39,26 @@ The driver tries to autodetect an header line and will look for 'x',
 'north' for the Y column and 'z', 'alt' or 'height' for the Z column. If
 no header is present or one of the column could not be identified in the
 header, the X, Y and Z columns (in that order) are assumed to be the
-first 3 columns of each line.
+first 3 columns of each line. The open option :oo:`COLUMN_ORDER` overrides
+these assumptions (except on 'AUTO').
 
 The opening of a big dataset can be slow as the driver must scan the
 whole file to determine the dataset size and spatial resolution. The
 driver will autodetect the data type among Byte, Int16, Int32 or
 Float32.
+
+Open options
+------------
+
+|about-open-options|
+This driver supports the following open options:
+
+.. oo:: COLUMN_ORDER
+   :choices: AUTO, XYZ, YXZ
+   :since: 3.10
+   :default: AUTO
+
+   Specifies the order of the columns. It overrides the header.
 
 Creation options
 ----------------


### PR DESCRIPTION
## What does this PR do?
Adds open option `COLUMN_ORDER` to XYZ raster driver

Options available are `AUTO` (default), `XYZ` and `YXZ`. `AUTO` behaves as before.

## Why?
Many XYZ files using geographic coordinates are in order "lat, long, z", but they do not have a header. (yes, geoid models ;).
Making (and deleting) a temporary file to add a header seems to be a bit strange looking at the ton of options in GDAL.
This PR adds the open option to directly set the format of the data.

If a different behaviour is needed, please let me know. I just use XYZ and YXZ because it is the cases I have met.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed