### PR TITLE
ogr2ogr: speed-up -clipsrc/-clipdst, and add -skipinvalid

### DIFF
--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -578,14 +578,19 @@ class LayerTranslator
     int m_nCoordDim = 0;
     GeomOperation m_eGeomOp = GEOMOP_NONE;
     double m_dfGeomOpParam = 0;
+
     OGRGeometry *m_poClipSrcOri = nullptr;
     bool m_bWarnedClipSrcSRS = false;
     std::unique_ptr<OGRGeometry> m_poClipSrcReprojectedToSrcSRS;
     const OGRSpatialReference *m_poClipSrcReprojectedToSrcSRS_SRS = nullptr;
+    OGREnvelope m_oClipSrcEnv{};
+
     OGRGeometry *m_poClipDstOri = nullptr;
     bool m_bWarnedClipDstSRS = false;
     std::unique_ptr<OGRGeometry> m_poClipDstReprojectedToDstSRS;
     const OGRSpatialReference *m_poClipDstReprojectedToDstSRS_SRS = nullptr;
+    OGREnvelope m_oClipDstEnv{};
+
     bool m_bExplodeCollections = false;
     bool m_bNativeData = false;
     GIntBig m_nLimit = -1;
@@ -598,8 +603,10 @@ class LayerTranslator
                    const GDALVectorTranslateOptions *psOptions);
 
   private:
-    const OGRGeometry *GetDstClipGeom(const OGRSpatialReference *poGeomSRS);
-    const OGRGeometry *GetSrcClipGeom(const OGRSpatialReference *poGeomSRS);
+    std::pair<const OGRGeometry *, const OGREnvelope *>
+    GetDstClipGeom(const OGRSpatialReference *poGeomSRS);
+    std::pair<const OGRGeometry *, const OGREnvelope *>
+    GetSrcClipGeom(const OGRSpatialReference *poGeomSRS);
 };
 
 static OGRLayer *GetLayerAndOverwriteIfNecessary(GDALDataset *poDstDS,
@@ -6002,13 +6009,22 @@ bool LayerTranslator::Translate(
                 if (nDstGeomFieldCount == 0 && poStolenGeometry &&
                     m_poClipSrcOri)
                 {
-                    const OGRGeometry *poClipGeom =
+                    if (poStolenGeometry->IsEmpty())
+                        goto end_loop;
+
+                    const auto [poClipGeom, poClipGeomEnvelope] =
                         GetSrcClipGeom(poStolenGeometry->getSpatialReference());
 
-                    if (poClipGeom != nullptr &&
-                        !poClipGeom->Intersects(poStolenGeometry.get()))
+                    if (poClipGeom && poClipGeomEnvelope)
                     {
-                        goto end_loop;
+                        OGREnvelope oEnv;
+                        poStolenGeometry->getEnvelope(&oEnv);
+                        if (!poClipGeomEnvelope->Contains(oEnv) &&
+                            !(poClipGeomEnvelope->Intersects(oEnv) &&
+                              poClipGeom->Intersects(poStolenGeometry.get())))
+                        {
+                            goto end_loop;
+                        }
                     }
                 }
 
@@ -6207,49 +6223,51 @@ bool LayerTranslator::Translate(
 
                 if (m_poClipSrcOri)
                 {
+                    if (poDstGeometry->IsEmpty())
+                        goto end_loop;
 
-                    const OGRGeometry *poClipGeom =
+                    const auto [poClipGeom, poClipGeomEnvelope] =
                         GetSrcClipGeom(poDstGeometry->getSpatialReference());
 
-                    std::unique_ptr<OGRGeometry> poClipped;
-                    if (poClipGeom != nullptr)
+                    if (!(poClipGeom && poClipGeomEnvelope))
+                        goto end_loop;
+
+                    OGREnvelope oDstEnv;
+                    poDstGeometry->getEnvelope(&oDstEnv);
+
+                    if (!poClipGeomEnvelope->Contains(oDstEnv))
                     {
-                        OGREnvelope oClipEnv;
-                        OGREnvelope oDstEnv;
-
-                        poClipGeom->getEnvelope(&oClipEnv);
-                        poDstGeometry->getEnvelope(&oDstEnv);
-
-                        if (oClipEnv.Intersects(oDstEnv))
+                        std::unique_ptr<OGRGeometry> poClipped;
+                        if (poClipGeomEnvelope->Intersects(oDstEnv))
                         {
                             poClipped.reset(
                                 poClipGeom->Intersection(poDstGeometry.get()));
                         }
-                    }
+                        if (poClipped == nullptr || poClipped->IsEmpty())
+                        {
+                            goto end_loop;
+                        }
 
-                    if (poClipped == nullptr || poClipped->IsEmpty())
-                    {
-                        goto end_loop;
-                    }
+                        const int nDim = poDstGeometry->getDimension();
+                        if (poClipped->getDimension() < nDim &&
+                            wkbFlatten(poDstFDefn->GetGeomFieldDefn(iGeom)
+                                           ->GetType()) != wkbUnknown)
+                        {
+                            CPLDebug(
+                                "OGR2OGR",
+                                "Discarding feature " CPL_FRMT_GIB
+                                " of layer %s, "
+                                "as its intersection with -clipsrc is a %s "
+                                "whereas the input is a %s",
+                                nSrcFID, poSrcLayer->GetName(),
+                                OGRToOGCGeomType(poClipped->getGeometryType()),
+                                OGRToOGCGeomType(
+                                    poDstGeometry->getGeometryType()));
+                            goto end_loop;
+                        }
 
-                    const int nDim = poDstGeometry->getDimension();
-                    if (poClipped->getDimension() < nDim &&
-                        wkbFlatten(
-                            poDstFDefn->GetGeomFieldDefn(iGeom)->GetType()) !=
-                            wkbUnknown)
-                    {
-                        CPLDebug(
-                            "OGR2OGR",
-                            "Discarding feature " CPL_FRMT_GIB " of layer %s, "
-                            "as its intersection with -clipsrc is a %s "
-                            "whereas the input is a %s",
-                            nSrcFID, poSrcLayer->GetName(),
-                            OGRToOGCGeomType(poClipped->getGeometryType()),
-                            OGRToOGCGeomType(poDstGeometry->getGeometryType()));
-                        goto end_loop;
+                        poDstGeometry = std::move(poClipped);
                     }
-
-                    poDstGeometry = std::move(poClipped);
                 }
 
                 OGRCoordinateTransformation *const poCT =
@@ -6387,51 +6405,54 @@ bool LayerTranslator::Translate(
                 {
                     if (m_poClipDstOri)
                     {
-                        const OGRGeometry *poClipGeom = GetDstClipGeom(
+                        if (poDstGeometry->IsEmpty())
+                            goto end_loop;
+
+                        auto [poClipGeom, poClipGeomEnvelope] = GetDstClipGeom(
                             poDstGeometry->getSpatialReference());
-                        if (poClipGeom == nullptr)
+                        if (!poClipGeom || !poClipGeomEnvelope)
                         {
                             goto end_loop;
                         }
 
-                        std::unique_ptr<OGRGeometry> poClipped;
-
-                        OGREnvelope oClipEnv;
                         OGREnvelope oDstEnv;
-
-                        poClipGeom->getEnvelope(&oClipEnv);
                         poDstGeometry->getEnvelope(&oDstEnv);
 
-                        if (oClipEnv.Intersects(oDstEnv))
+                        if (!poClipGeomEnvelope->Contains(oDstEnv))
                         {
-                            poClipped.reset(
-                                poClipGeom->Intersection(poDstGeometry.get()));
-                        }
+                            std::unique_ptr<OGRGeometry> poClipped;
+                            if (poClipGeomEnvelope->Intersects(oDstEnv))
+                            {
+                                poClipped.reset(poClipGeom->Intersection(
+                                    poDstGeometry.get()));
+                            }
 
-                        if (poClipped == nullptr || poClipped->IsEmpty())
-                        {
-                            goto end_loop;
-                        }
+                            if (poClipped == nullptr || poClipped->IsEmpty())
+                            {
+                                goto end_loop;
+                            }
 
-                        const int nDim = poDstGeometry->getDimension();
-                        if (poClipped->getDimension() < nDim &&
-                            wkbFlatten(poDstFDefn->GetGeomFieldDefn(iGeom)
-                                           ->GetType()) != wkbUnknown)
-                        {
-                            CPLDebug(
-                                "OGR2OGR",
-                                "Discarding feature " CPL_FRMT_GIB
-                                " of layer %s, "
-                                "as its intersection with -clipdst is a %s "
-                                "whereas the input is a %s",
-                                nSrcFID, poSrcLayer->GetName(),
-                                OGRToOGCGeomType(poClipped->getGeometryType()),
-                                OGRToOGCGeomType(
-                                    poDstGeometry->getGeometryType()));
-                            goto end_loop;
-                        }
+                            const int nDim = poDstGeometry->getDimension();
+                            if (poClipped->getDimension() < nDim &&
+                                wkbFlatten(poDstFDefn->GetGeomFieldDefn(iGeom)
+                                               ->GetType()) != wkbUnknown)
+                            {
+                                CPLDebug(
+                                    "OGR2OGR",
+                                    "Discarding feature " CPL_FRMT_GIB
+                                    " of layer %s, "
+                                    "as its intersection with -clipdst is a %s "
+                                    "whereas the input is a %s",
+                                    nSrcFID, poSrcLayer->GetName(),
+                                    OGRToOGCGeomType(
+                                        poClipped->getGeometryType()),
+                                    OGRToOGCGeomType(
+                                        poDstGeometry->getGeometryType()));
+                                goto end_loop;
+                            }
 
-                        poDstGeometry = std::move(poClipped);
+                            poDstGeometry = std::move(poClipped);
+                        }
                     }
 
                     if (psOptions->dfXYRes !=
@@ -6603,7 +6624,13 @@ bool LayerTranslator::Translate(
 /*                LayerTranslator::GetDstClipGeom()                     */
 /************************************************************************/
 
-const OGRGeometry *
+/** Returns the destination clip geometry and its envelope
+ *
+ * @param poGeomSRS The SRS into which the destination clip geometry should be
+ *                  expressed.
+ * @return the destination clip geometry and its envelope, or (nullptr, nullptr)
+ */
+std::pair<const OGRGeometry *, const OGREnvelope *>
 LayerTranslator::GetDstClipGeom(const OGRSpatialReference *poGeomSRS)
 {
     if (m_poClipDstReprojectedToDstSRS_SRS != poGeomSRS)
@@ -6616,7 +6643,7 @@ LayerTranslator::GetDstClipGeom(const OGRSpatialReference *poGeomSRS)
             if (m_poClipDstReprojectedToDstSRS->transformTo(poGeomSRS) !=
                 OGRERR_NONE)
             {
-                return nullptr;
+                return std::make_pair(nullptr, nullptr);
             }
             m_poClipDstReprojectedToDstSRS_SRS = poGeomSRS;
         }
@@ -6633,17 +6660,30 @@ LayerTranslator::GetDstClipGeom(const OGRSpatialReference *poGeomSRS)
                          "same as the feature's geometry");
             }
         }
+        m_oClipDstEnv = OGREnvelope();
     }
 
-    return m_poClipDstReprojectedToDstSRS ? m_poClipDstReprojectedToDstSRS.get()
-                                          : m_poClipDstOri;
+    const auto poGeom = m_poClipDstReprojectedToDstSRS
+                            ? m_poClipDstReprojectedToDstSRS.get()
+                            : m_poClipDstOri;
+    if (poGeom && !m_oClipDstEnv.IsInit())
+    {
+        poGeom->getEnvelope(&m_oClipDstEnv);
+    }
+    return std::make_pair(poGeom, poGeom ? &m_oClipDstEnv : nullptr);
 }
 
 /************************************************************************/
 /*                LayerTranslator::GetSrcClipGeom()                     */
 /************************************************************************/
 
-const OGRGeometry *
+/** Returns the source clip geometry and its envelope
+ *
+ * @param poGeomSRS The SRS into which the source clip geometry should be
+ *                  expressed.
+ * @return the source clip geometry and its envelope, or (nullptr, nullptr)
+ */
+std::pair<const OGRGeometry *, const OGREnvelope *>
 LayerTranslator::GetSrcClipGeom(const OGRSpatialReference *poGeomSRS)
 {
     if (m_poClipSrcReprojectedToSrcSRS_SRS != poGeomSRS)
@@ -6656,7 +6696,7 @@ LayerTranslator::GetSrcClipGeom(const OGRSpatialReference *poGeomSRS)
             if (m_poClipSrcReprojectedToSrcSRS->transformTo(poGeomSRS) !=
                 OGRERR_NONE)
             {
-                return nullptr;
+                return std::make_pair(nullptr, nullptr);
             }
             m_poClipSrcReprojectedToSrcSRS_SRS = poGeomSRS;
         }
@@ -6672,10 +6712,17 @@ LayerTranslator::GetSrcClipGeom(const OGRSpatialReference *poGeomSRS)
                          "same as the feature's geometry");
             }
         }
+        m_oClipSrcEnv = OGREnvelope();
     }
 
-    return m_poClipSrcReprojectedToSrcSRS ? m_poClipSrcReprojectedToSrcSRS.get()
-                                          : m_poClipSrcOri;
+    const auto poGeom = m_poClipSrcReprojectedToSrcSRS
+                            ? m_poClipSrcReprojectedToSrcSRS.get()
+                            : m_poClipSrcOri;
+    if (poGeom && !m_oClipSrcEnv.IsInit())
+    {
+        poGeom->getEnvelope(&m_oClipSrcEnv);
+    }
+    return std::make_pair(poGeom, poGeom ? &m_oClipSrcEnv : nullptr);
 }
 
 /************************************************************************/

--- a/doc/source/programs/ogr2ogr.rst
+++ b/doc/source/programs/ogr2ogr.rst
@@ -43,7 +43,8 @@ Synopsis
            [-t_coord_epoch <epoch>] [-ct <pipeline_def>]
            [-spat_srs <srs_def>] [-geomfield <name>]
            [-segmentize <max_dist>] [-simplify <tolerance>]
-           [-makevalid] [-wrapdateline] [-datelineoffset <val_in_degree>]
+           [-makevalid] [-skipinvalid]
+           [-wrapdateline] [-datelineoffset <val_in_degree>]
            [-clipsrc [<xmin> <ymin> <xmax> <ymax>]|<WKT>|<datasource>|spat_extent]
            [-clipsrcsql <sql_statement>] [-clipsrclayer <layername>]
            [-clipsrcwhere <expression>]
@@ -474,7 +475,16 @@ output coordinate system or even reprojecting the features during translation.
     :cpp:func:`OGRGeometryFactory::removeLowerDimensionSubGeoms`, on geometries
     to ensure they are valid regarding the rules of the Simple Features specification.
 
-    .. versionadded: 3.1 (requires GEOS 3.8 or later)
+    .. versionadded: 3.1 (requires GEOS)
+
+.. option:: -skipinvalid
+
+    Run the :cpp:func:`OGRGeometry::IsValid` operation on geometries to check if
+    they are valid regarding the rules of the Simple Features specification.
+    If they are not, the feature is skipped. This check is done after all other
+    geometry operations.
+
+    .. versionadded: 3.10 (requires GEOS)
 
 .. option:: -fieldTypeToString All|<type1>[,<type2>]...
 

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -3051,6 +3051,7 @@ def VectorTranslateOptions(options=None, format=None,
          simplifyTolerance=None,
          segmentizeMaxDist=None,
          makeValid=False,
+         skipInvalid=False,
          mapFieldType=None,
          explodeCollections=False,
          zField=None,
@@ -3151,6 +3152,9 @@ def VectorTranslateOptions(options=None, format=None,
         maximum distance between consecutive nodes of a line geometry
     makeValid:
         run MakeValid() on geometries
+    skipInvalid:
+        whether to skip features with invalid geometries regarding the rules of
+        the Simple Features specification.
     mapFieldType:
         converts any field of the specified type to another type. Valid types are:
         Integer, Integer64, Real, String, Date, Time, DateTime, Binary, IntegerList,
@@ -3334,6 +3338,8 @@ def VectorTranslateOptions(options=None, format=None,
             new_options += ['-segmentize', str(segmentizeMaxDist)]
         if makeValid:
             new_options += ['-makevalid']
+        if skipInvalid:
+            new_options += ['-skipinvalid']
         if mapFieldType is not None:
             new_options += ['-mapFieldType']
             if isinstance(mapFieldType, str):


### PR DESCRIPTION
-   ogr2ogr: speed-up -clipsrc/-clipdst by avoiding GEOS when possible
    
    If the envelope of the feature's geometry is contained in the envelope
    of the -clipsrc/-clipdst geometry, we can just avoid any GEOS operation.

- ogr2ogr: add -skipinvalid to skip features whose geometry is not valid w.r.t Simple Features
