### PR TITLE
KEA: don't derive from PAM classes

### DIFF
--- a/frmts/kea/keaband.cpp
+++ b/frmts/kea/keaband.cpp
@@ -399,7 +399,7 @@ void KEARasterBand::SetDescription(const char *pszDescription)
     try
     {
         this->m_pImageIO->setImageBandDescription(this->nBand, pszDescription);
-        GDALPamRasterBand::SetDescription(pszDescription);
+        GDALRasterBand::SetDescription(pszDescription);
     }
     catch (const kealib::KEAIOException &)
     {
@@ -721,7 +721,7 @@ CPLErr KEARasterBand::GetDefaultHistogram(double *pdfMin, double *pdfMax,
 {
     if (bForce)
     {
-        return GDALPamRasterBand::GetDefaultHistogram(pdfMin, pdfMax, pnBuckets,
+        return GDALRasterBand::GetDefaultHistogram(pdfMin, pdfMax, pnBuckets,
                                                       ppanHistogram, bForce, fn,
                                                       pProgressData);
     }
@@ -1379,7 +1379,7 @@ GDALRasterBand *KEARasterBand::GetMaskBand()
             {
                 // use the base class implementation - GDAL will delete
                 // fprintf( stderr, "returning base GetMaskBand()\n" );
-                m_pMaskBand = GDALPamRasterBand::GetMaskBand();
+                m_pMaskBand = GDALRasterBand::GetMaskBand();
             }
         }
         catch (const kealib::KEAException &)
@@ -1399,7 +1399,7 @@ int KEARasterBand::GetMaskFlags()
             // need to return the base class one since we are using
             // the base class implementation of GetMaskBand()
             // fprintf( stderr, "returning base GetMaskFlags()\n" );
-            return GDALPamRasterBand::GetMaskFlags();
+            return GDALRasterBand::GetMaskFlags();
         }
     }
     catch (const kealib::KEAException &)

--- a/frmts/kea/keaband.cpp
+++ b/frmts/kea/keaband.cpp
@@ -722,8 +722,8 @@ CPLErr KEARasterBand::GetDefaultHistogram(double *pdfMin, double *pdfMax,
     if (bForce)
     {
         return GDALRasterBand::GetDefaultHistogram(pdfMin, pdfMax, pnBuckets,
-                                                      ppanHistogram, bForce, fn,
-                                                      pProgressData);
+                                                   ppanHistogram, bForce, fn,
+                                                   pProgressData);
     }
     else
     {

--- a/frmts/kea/keaband.h
+++ b/frmts/kea/keaband.h
@@ -31,14 +31,14 @@
 #ifndef KEABAND_H
 #define KEABAND_H
 
-#include "gdal_pam.h"
+#include "gdal_priv.h"
 #include "keadataset.h"
 
 class KEAOverview;
 class KEAMaskBand;
 
 // Provides the implementation of a GDAL raster band
-class KEARasterBand CPL_NON_FINAL : public GDALPamRasterBand
+class KEARasterBand CPL_NON_FINAL : public GDALRasterBand
 {
   private:
     LockedRefCount *m_pRefCount = nullptr;  // reference count of m_pImageIO

--- a/frmts/kea/keadataset.h
+++ b/frmts/kea/keadataset.h
@@ -31,14 +31,14 @@
 #ifndef KEADATASET_H
 #define KEADATASET_H
 
-#include "gdal_pam.h"
+#include "gdal_priv.h"
 #include "cpl_multiproc.h"
 #include "libkea_headers.h"
 
 class LockedRefCount;
 
 // class that implements a GDAL dataset
-class KEADataset final : public GDALPamDataset
+class KEADataset final : public GDALDataset
 {
     static H5::H5File *CreateLL(const char *pszFilename, int nXSize, int nYSize,
                                 int nBands, GDALDataType eType,


### PR DESCRIPTION
## What does this PR do?

KEA was always intended to be a fairly complete implementation of the GDAL data model so all data and metadata should be within the .kea file. However due to my oversight I derived from the PAM base classes. In some situations (like when calculating the histogram) these save also data into a `.aux.xml` file. The data is already in the KEA file so this is unnecessary. This PR changes the base classes so all metadata is saved in the KEA file itself and no `.aux.xml` file is created. 

## What are related issues/pull requests?

https://github.com/ubarsc/kealib/pull/64

cc: @neilflood @petebunting