### PR TITLE
Viewshed: Oor up down

### DIFF
--- a/alg/viewshed.h
+++ b/alg/viewshed.h
@@ -132,6 +132,14 @@ class Viewshed
             return xSize() ? std::clamp(nX, xStart, xStop - 1) : xStart;
         }
 
+        /// \brief  Clamp the argument to be in the window in the Y dimension.
+        /// \param  nY  Value to clamp.
+        /// \return  Clamped value.
+        int clampY(int nY) const
+        {
+            return ySize() ? std::clamp(nY, yStart, yStop - 1) : yStart;
+        }
+
         /// \brief  Shift the X dimension by nShift.
         /// \param  nShift  Amount to shift
         void shiftX(int nShift)
@@ -225,14 +233,16 @@ class Viewshed
     bool writeLine(int nLine, std::vector<double> &vResult);
     bool processLine(int nX, int nY, int nLine,
                      std::vector<double> &vLastLineVal);
-    bool processFirstLine(int nX, int nY, int nLine,
-                          std::vector<double> &vLastLineVal);
+    bool processFirstLine(int nX, int nY, std::vector<double> &vLastLineVal);
     void processFirstLineLeft(int nX, int iStart, int iEnd,
                               std::vector<double> &vResult,
                               std::vector<double> &vThisLineVal);
     void processFirstLineRight(int nX, int iStart, int iEnd,
                                std::vector<double> &vResult,
                                std::vector<double> &vThisLineVal);
+    void processFirstLineTopOrBottom(int iLeft, int iRight,
+                                     std::vector<double> &vResult,
+                                     std::vector<double> &vThisLineVal);
     void processLineLeft(int nX, int nYOffset, int iStart, int iEnd,
                          std::vector<double> &vResult,
                          std::vector<double> &vThisLineVal,

--- a/autotest/cpp/test_viewshed.cpp
+++ b/autotest/cpp/test_viewshed.cpp
@@ -308,7 +308,7 @@ TEST(Viewshed, oor_right)
     }
 }
 
-// Test an observer to the right of the raster.
+// Test an observer to the left of the raster.
 TEST(Viewshed, oor_left)
 {
     // clang-format off
@@ -361,6 +361,130 @@ TEST(Viewshed, oor_left)
             1, .5,  5 / 3.0, 2.25, 4.2,
             0, .5,  1,       2.5,  3.1,
             1, 1.5, 2,       2.5,  3.6
+        };
+        // clang-format on
+
+        for (size_t i = 0; i < out.size(); ++i)
+            EXPECT_DOUBLE_EQ(out[i], expected[i]);
+    }
+}
+
+// Test an observer above the raster
+TEST(Viewshed, oor_above)
+{
+    // clang-format off
+    const int xlen = 5;
+    const int ylen = 3;
+    std::array<int8_t, xlen * ylen> in
+    {
+        1, 2, 0, 4, 1,
+        0, 0, 2, 1, 0,
+        1, 0, 0, 3, 3
+    };
+    // clang-format on
+
+    {
+        Viewshed::Options opts = stdOptions(2, -2);
+        opts.outputMode = Viewshed::OutputMode::DEM;
+        DatasetPtr ds = runViewshed(in.data(), xlen, ylen, opts);
+        GDALRasterBand *band = ds->GetRasterBand(1);
+        std::array<double, xlen * ylen> out;
+        CPLErr err = band->RasterIO(GF_Read, 0, 0, xlen, ylen, out.data(), xlen,
+                                    ylen, GDT_Float64, 0, 0, nullptr);
+
+        EXPECT_EQ(err, CE_None);
+
+        // clang-format off
+        std::array<double, xlen * ylen> expected
+        {
+            1,   2,       0,       4,        1,
+            2.5, 2,       0,       4,        4.5,
+            3,   8 / 3.0, 8 / 3.0, 14 / 3.0, 17 / 3.0
+        };
+        // clang-format on
+
+        for (size_t i = 0; i < out.size(); ++i)
+            EXPECT_DOUBLE_EQ(out[i], expected[i]);
+    }
+
+    {
+        Viewshed::Options opts = stdOptions(-2, -2);
+        opts.outputMode = Viewshed::OutputMode::DEM;
+        DatasetPtr ds = runViewshed(in.data(), xlen, ylen, opts);
+        GDALRasterBand *band = ds->GetRasterBand(1);
+        std::array<double, xlen * ylen> out;
+        CPLErr err = band->RasterIO(GF_Read, 0, 0, xlen, ylen, out.data(), xlen,
+                                    ylen, GDT_Float64, 0, 0, nullptr);
+        EXPECT_EQ(err, CE_None);
+
+        // clang-format off
+        std::array<double, xlen * ylen> expected
+        {
+            1, 2,   0,   4,    1,
+            0, 1.5, 2.5, 1.25, 3.15,
+            1, 0.5, 2,   3,    2.2
+        };
+        // clang-format on
+
+        for (size_t i = 0; i < out.size(); ++i)
+            EXPECT_DOUBLE_EQ(out[i], expected[i]);
+    }
+}
+
+// Test an observer below the raster
+TEST(Viewshed, oor_below)
+{
+    // clang-format off
+    const int xlen = 5;
+    const int ylen = 3;
+    std::array<int8_t, xlen * ylen> in
+    {
+        1, 2, 0, 4, 1,
+        0, 0, 2, 1, 0,
+        1, 0, 0, 3, 3
+    };
+    // clang-format on
+
+    {
+        Viewshed::Options opts = stdOptions(2, 4);
+        opts.outputMode = Viewshed::OutputMode::DEM;
+        DatasetPtr ds = runViewshed(in.data(), xlen, ylen, opts);
+        GDALRasterBand *band = ds->GetRasterBand(1);
+        std::array<double, xlen * ylen> out;
+        CPLErr err = band->RasterIO(GF_Read, 0, 0, xlen, ylen, out.data(), xlen,
+                                    ylen, GDT_Float64, 0, 0, nullptr);
+
+        EXPECT_EQ(err, CE_None);
+
+        // clang-format off
+        std::array<double, xlen * ylen> expected
+        {
+            1 / 3.0, 2 / 3.0, 8 / 3.0, 11 / 3.0, 5,
+            0.5,     0,       0,       3,        4.5,
+            1,       0,       0,       3,        3
+        };
+        // clang-format on
+
+        for (size_t i = 0; i < out.size(); ++i)
+            EXPECT_DOUBLE_EQ(out[i], expected[i]);
+    }
+
+    {
+        Viewshed::Options opts = stdOptions(6, 4);
+        opts.outputMode = Viewshed::OutputMode::DEM;
+        DatasetPtr ds = runViewshed(in.data(), xlen, ylen, opts);
+        GDALRasterBand *band = ds->GetRasterBand(1);
+        std::array<double, xlen * ylen> out;
+        CPLErr err = band->RasterIO(GF_Read, 0, 0, xlen, ylen, out.data(), xlen,
+                                    ylen, GDT_Float64, 0, 0, nullptr);
+        EXPECT_EQ(err, CE_None);
+
+        // clang-format off
+        std::array<double, xlen * ylen> expected
+        {
+            4.2,  6,    6,   1.5, 1,
+            1.35, 2.25, 4.5, 4.5, 0,
+            1,    0,    0,   3,   3
         };
         // clang-format on
 

--- a/autotest/utilities/test_gdal_viewshed.py
+++ b/autotest/utilities/test_gdal_viewshed.py
@@ -369,17 +369,6 @@ def test_gdal_viewshed_invalid_band(gdal_viewshed_path, tmp_path):
 ###############################################################################
 
 
-def test_gdal_viewshed_invalid_observer_point(gdal_viewshed_path, tmp_path):
-
-    _, err = gdaltest.runexternal_out_and_err(
-        f"{gdal_viewshed_path} -ox 0 -oy 0 ../gdrivers/data/n43.tif {tmp_path}/tmp.tif"
-    )
-    assert "Observer position above or below" in err
-
-
-###############################################################################
-
-
 def test_gdal_viewshed_invalid_output_driver(gdal_viewshed_path, tmp_path):
 
     _, err = gdaltest.runexternal_out_and_err(

--- a/doc/source/programs/gdal_viewshed.rst
+++ b/doc/source/programs/gdal_viewshed.rst
@@ -60,11 +60,15 @@ Byte. With the -mode flag can also return a minimum visible height raster of typ
 
 .. option:: -ox <value>
 
-   The X position of the observer (in SRS units).
+   The X position of the observer (in SRS units).  If the coordinate is outside of the
+   raster, all space between the observer and the raster is assumed not to occlude
+   visibility of the raster.
 
 .. option:: -oy <value>
 
-   The Y position of the observer (in SRS units).
+   The Y position of the observer (in SRS units).  If the coordinate is outside of the
+   raster, all space between the observer and the raster is assumed not to occlude
+   visibility of the raster.
 
 .. option:: -oz <value>
 


### PR DESCRIPTION
Adds support and tests for observers above and below the raster. Adds text to the documentation describing the behavior if an observer is outside of the raster.
