### PR TITLE
Fix issues with gdalbuildvrt and gdalwarp regarding src/dst/vrtnodata arguments and negative values (3.9.0 regression)

### DIFF
--- a/apps/argparse/argparse.hpp
+++ b/apps/argparse/argparse.hpp
@@ -1411,6 +1411,10 @@ private:
    *    '+' '-'
    */
   static bool is_decimal_literal(std::string_view s) {
+    if (s == "inf") {
+      return true;
+    }
+
     auto is_digit = [](auto c) constexpr {
       switch (c) {
       case '0':

--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -3032,19 +3032,6 @@ GDALTranslateOptionsGetParser(GDALTranslateOptions *psOptions,
 
     argParser->add_argument("-a_nodata")
         .metavar("<value>|none")
-        .action(
-            [psOptions](const std::string &s)
-            {
-                if (EQUAL(s.c_str(), "none"))
-                {
-                    psOptions->bUnsetNoData = true;
-                }
-                else
-                {
-                    psOptions->bSetNoData = true;
-                    psOptions->osNoData = s;
-                }
-            })
         .help(_("Assign a specified nodata value to output bands."));
 
     argParser->add_argument("-a_gt")
@@ -3381,6 +3368,23 @@ GDALTranslateOptionsNew(char **papszArgv,
             }
             ++i;
             psOptions->anColorInterp[nIndex] = GetColorInterp(papszArgv[i]);
+        }
+
+        // argparser will be confused if the value of a string argument
+        // starts with a negative sign.
+        else if (EQUAL(papszArgv[i], "-a_nodata") && papszArgv[i + 1])
+        {
+            ++i;
+            const std::string s = papszArgv[i];
+            if (EQUAL(s.c_str(), "none"))
+            {
+                psOptions->bUnsetNoData = true;
+            }
+            else
+            {
+                psOptions->bSetNoData = true;
+                psOptions->osNoData = s;
+            }
         }
 
         else

--- a/apps/gdalbuildvrt_lib.cpp
+++ b/apps/gdalbuildvrt_lib.cpp
@@ -2268,6 +2268,21 @@ GDALBuildVRTOptionsNew(char **papszArgv,
             psOptionsForBinary->osDstFilename = papszArgv[i + 1];
             ++i;
         }
+        // argparser will be confused if the value of a string argument
+        // starts with a negative sign.
+        else if (EQUAL(papszArgv[i], "-srcnodata") && i + 1 < nArgc)
+        {
+            ++i;
+            psOptions->osSrcNoData = papszArgv[i];
+        }
+        // argparser will be confused if the value of a string argument
+        // starts with a negative sign.
+        else if (EQUAL(papszArgv[i], "-vrtnodata") && i + 1 < nArgc)
+        {
+            ++i;
+            psOptions->osVRTNoData = papszArgv[i];
+        }
+
         else
         {
             aosArgv.AddString(papszArgv[i]);

--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -5747,12 +5747,12 @@ GDALWarpAppOptionsGetParser(GDALWarpAppOptions *psOptions,
         .help(_("Set max warp memory."));
 
     argParser->add_argument("-srcnodata")
-        .metavar("<value>[ <value>...]")
+        .metavar("\"<value>[ <value>]...\"")
         .store_into(psOptions->osSrcNodata)
         .help(_("Nodata masking values for input bands."));
 
     argParser->add_argument("-dstnodata")
-        .metavar("<value>[ <value>...]")
+        .metavar("\"<value>[ <value>]...\"")
         .store_into(psOptions->osDstNodata)
         .help(_("Nodata masking values for output bands."));
 
@@ -6125,6 +6125,20 @@ GDALWarpAppOptionsNew(char **papszArgv,
                 return nullptr;
             }
             psOptions->bCreateOutput = true;
+        }
+        // argparser will be confused if the value of a string argument
+        // starts with a negative sign.
+        else if (EQUAL(papszArgv[i], "-srcnodata") && i + 1 < nArgc)
+        {
+            ++i;
+            psOptions->osSrcNodata = papszArgv[i];
+        }
+        // argparser will be confused if the value of a string argument
+        // starts with a negative sign.
+        else if (EQUAL(papszArgv[i], "-dstnodata") && i + 1 < nArgc)
+        {
+            ++i;
+            psOptions->osDstNodata = papszArgv[i];
         }
         else
         {

--- a/autotest/utilities/test_gdal_translate_lib.py
+++ b/autotest/utilities/test_gdal_translate_lib.py
@@ -1155,6 +1155,20 @@ def test_gdal_translate_lib_scale_and_unscale_incompatible():
 
 
 ###############################################################################
+# Test -a_offset -inf (dummy example, but to proove -inf works as a value
+# numeric value)
+
+
+@gdaltest.enable_exceptions()
+def test_gdal_translate_lib_assign_offset():
+
+    out_ds = gdal.Translate(
+        "", gdal.Open("../gcore/data/byte.tif"), options="-f MEM -a_offset -inf"
+    )
+    assert out_ds.GetRasterBand(1).GetOffset() == float("-inf")
+
+
+###############################################################################
 # Test option argument handling
 
 

--- a/autotest/utilities/test_gdal_translate_lib.py
+++ b/autotest/utilities/test_gdal_translate_lib.py
@@ -293,6 +293,18 @@ def test_gdal_translate_lib_nodata_int64():
 
 
 ###############################################################################
+# Test nodata=-inf
+
+
+def test_gdal_translate_lib_nodata_minus_inf():
+
+    ds = gdal.Translate(
+        "", "../gcore/data/float32.tif", format="MEM", noData=float("-inf")
+    )
+    assert ds.GetRasterBand(1).GetNoDataValue() == float("-inf"), "Bad nodata value"
+
+
+###############################################################################
 # Test srcWin option
 
 

--- a/autotest/utilities/test_gdalbuildvrt_lib.py
+++ b/autotest/utilities/test_gdalbuildvrt_lib.py
@@ -280,15 +280,15 @@ def test_gdalbuildvrt_lib_separate_nodata_2(tmp_vsimem):
     src2_ds.GetRasterBand(1).SetNoDataValue(2)
 
     gdal.BuildVRT(
-        tmp_vsimem / "out.vrt", [src1_ds, src2_ds], separate=True, srcNodata="3 4"
+        tmp_vsimem / "out.vrt", [src1_ds, src2_ds], separate=True, srcNodata="-3 4"
     )
 
     f = gdal.VSIFOpenL(tmp_vsimem / "out.vrt", "rb")
     data = gdal.VSIFReadL(1, 10000, f)
     gdal.VSIFCloseL(f)
 
-    assert b"<NoDataValue>3</NoDataValue>" in data
-    assert b"<NODATA>3</NODATA>" in data
+    assert b"<NoDataValue>-3</NoDataValue>" in data
+    assert b"<NODATA>-3</NODATA>" in data
     assert b"<NoDataValue>4</NoDataValue>" in data
     assert b"<NODATA>4</NODATA>" in data
 
@@ -309,14 +309,14 @@ def test_gdalbuildvrt_lib_separate_nodata_3(tmp_vsimem):
         [src1_ds, src2_ds],
         separate=True,
         srcNodata="3 4",
-        VRTNodata="5 6",
+        VRTNodata="-5 6",
     )
 
     f = gdal.VSIFOpenL(tmp_vsimem / "out.vrt", "rb")
     data = gdal.VSIFReadL(1, 10000, f)
     gdal.VSIFCloseL(f)
 
-    assert b"<NoDataValue>5</NoDataValue>" in data
+    assert b"<NoDataValue>-5</NoDataValue>" in data
     assert b"<NODATA>3</NODATA>" in data
     assert b"<NoDataValue>6</NoDataValue>" in data
     assert b"<NODATA>4</NODATA>" in data

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -1473,6 +1473,34 @@ def test_gdalwarp_lib_127():
     assert ds.GetRasterBand(1).Checksum() == 4672, "bad checksum"
 
 
+@pytest.mark.parametrize("srcNodata", [float("-inf"), -1])
+def test_gdalwarp_lib_srcnodata(srcNodata):
+
+    ds = gdal.Warp(
+        "",
+        "../gcore/data/byte.tif",
+        format="MEM",
+        srcNodata=srcNodata,
+        outputType=gdal.GDT_Float32,
+    )
+    assert ds.GetRasterBand(1).GetNoDataValue() == srcNodata, "bad nodata value"
+    assert ds.GetRasterBand(1).Checksum() == 4672, "bad checksum"
+
+
+@pytest.mark.parametrize("dstNodata", [float("-inf"), -1])
+def test_gdalwarp_lib_dstnodata(dstNodata):
+
+    ds = gdal.Warp(
+        "",
+        "../gcore/data/byte.tif",
+        format="MEM",
+        dstNodata=dstNodata,
+        outputType=gdal.GDT_Float32,
+    )
+    assert ds.GetRasterBand(1).GetNoDataValue() == dstNodata, "bad nodata value"
+    assert ds.GetRasterBand(1).Checksum() == 4672, "bad checksum"
+
+
 ###############################################################################
 # Test automatic densification of cutline (#6375)
 

--- a/doc/source/programs/gdalwarp.rst
+++ b/doc/source/programs/gdalwarp.rst
@@ -33,8 +33,8 @@ Synopsis
             [-order <1|2|3>] [-refine_gcps <tolerance> [<minimum_gcps>]]
             [-to <NAME>=<VALUE>]...
             [-et <err_threshold>] [-wm <memory_in_mb>]
-            [-srcnodata <value>[ <value>...]]
-            [-dstnodata <value>[ <value>...]] [-tap]
+            [-srcnodata "<value>[ <value>]..."]
+            [-dstnodata "<value>[ <value>]..."] [-tap]
             [-wt Byte|Int8|[U]Int{16|32|64}|CInt{16|32}|[C]Float{32|64}]
             [-cutline <datasource>|<WKT>] [-cutline_srs <srs_def>]
             [-cwhere <expression>]


### PR DESCRIPTION
Fixes https://lists.osgeo.org/pipermail/gdal-dev/2024-July/059162.html