### PR TITLE
[Backport release/3.9] Fix compilation against openssl-libs-3.2.2-3 of fedora:rawhide

### DIFF
--- a/port/cpl_http.cpp
+++ b/port/cpl_http.cpp
@@ -59,7 +59,6 @@
 #ifdef HAVE_OPENSSL_CRYPTO
 #include <openssl/err.h>
 #include <openssl/ssl.h>
-#include <openssl/engine.h>
 #include <openssl/x509v3.h>
 
 #if defined(_WIN32)


### PR DESCRIPTION
Backport #10354
 **Authored by:** @rouault