### PR TITLE
Add support for `GDAL_HTTP_VERSION=2PRIOR_KNOWLEDGE`

### DIFF
--- a/doc/source/user/configoptions.rst
+++ b/doc/source/user/configoptions.rst
@@ -815,14 +815,15 @@ Networking options
 
 -  .. config:: GDAL_HTTP_VERSION
       :since: 2.3
-      :choices: 1.0, 1.1, 2, 2TLS
+      :choices: 1.0, 1.1, 2, 2TLS, 2PRIOR_KNOWLEDGE
 
       Specifies which HTTP version to use. Will default to 1.1 generally (except on
       some controlled environments, like Google Compute Engine VMs, where 2TLS will
       be the default). Support for HTTP/2 requires curl 7.33 or later, built
       against nghttp2. "2TLS" means that HTTP/2 will be attempted for HTTPS
       connections only. Whereas "2" means that HTTP/2 will be attempted for HTTP or
-      HTTPS. The interest of enabling HTTP/2 is the use of HTTP/2 multiplexing when
+      HTTPS. "2PRIOR_KNOWLEDGE" means that the server will be assumed to support
+      HTTP/2. The interest of enabling HTTP/2 is the use of HTTP/2 multiplexing when
       reading GeoTIFFs stored on /vsicurl/ and related virtual file systems.
 
 -  .. config:: GDAL_HTTP_MULTIPLEX

--- a/port/cpl_http.cpp
+++ b/port/cpl_http.cpp
@@ -1150,12 +1150,15 @@ int CPLHTTPPopFetchCallback(void)
  *     and use the first one found as the CAINFO value (GDAL >= 2.1.3). The
  *     GDAL_CURL_CA_BUNDLE environment variable may also be used to set the
  *     CAINFO value in GDAL >= 3.2.</li>
- * <li>HTTP_VERSION=1.0/1.1/2/2TLS (GDAL >= 2.3). Specify HTTP version to use.
+ * <li>HTTP_VERSION=1.0/1.1/2/2TLS (GDAL >= 2.3)/2PRIOR_KNOWLEDGE (GDAL >= 3.10).
+ *     Specify HTTP version to use.
  *     Will default to 1.1 generally (except on some controlled environments,
  *     like Google Compute Engine VMs, where 2TLS will be the default).
  *     Support for HTTP/2 requires curl 7.33 or later, built against nghttp2.
  *     "2TLS" means that HTTP/2 will be attempted for HTTPS connections only.
  *     Whereas "2" means that HTTP/2 will be attempted for HTTP or HTTPS.
+ *     "2PRIOR_KNOWLEDGE" means that the server will be assumed to support
+ *     HTTP/2.
  *     Corresponding configuration option: GDAL_HTTP_VERSION.
  * </li>
  * <li>SSL_VERIFYSTATUS=YES/NO (GDAL >= 2.3, and curl >= 7.41): determines
@@ -2134,6 +2137,17 @@ void *CPLHTTPSetOptions(void *pcurl, const char *pszURL,
             // Try HTTP/2 both for HTTP and HTTPS. With fallback to HTTP/1.1
             unchecked_curl_easy_setopt(http_handle, CURLOPT_HTTP_VERSION,
                                        CURL_HTTP_VERSION_2_0);
+        }
+    }
+    else if (pszHttpVersion && strcmp(pszHttpVersion, "2PRIOR_KNOWLEDGE") == 0)
+    {
+        if (bSupportHTTP2)
+        {
+            // Assume HTTP/2 is supported by the server. The cURL docs indicate
+            // that it makes no difference for HTTPS, but it does seem to work
+            // in practice.
+            unchecked_curl_easy_setopt(http_handle, CURLOPT_HTTP_VERSION,
+                                       CURL_HTTP_VERSION_2_PRIOR_KNOWLEDGE);
         }
     }
     else if (pszHttpVersion == nullptr || strcmp(pszHttpVersion, "2TLS") == 0)


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?
Adds `GDAL_HTTP_VERSION=2PRIOR_KNOWLEDGE`, which may allow forcing HTTP/2 on servers which don't advertise support for it.

## What are related issues/pull requests?
Closes #10361

## Tasklist

 - [ ] Check whether it actually works
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
