### PR TITLE
[Backport 3.9] PG: fix ogr2ogr scenarios to PostgreSQL when there are several input …

### DIFF
--- a/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
@@ -2152,6 +2152,8 @@ OGRPGDataSource::FindSchema(const char *pszSchemaNameIn)
         return pszSchemaNameIn;
     }
 
+    EndCopy();
+
     std::string osSchemaName;
     std::string osCommand(
         "SELECT nspname FROM pg_catalog.pg_namespace WHERE nspname ILIKE ");


### PR DESCRIPTION
…layer names like schema_name.layer_name (3.9.0 regression)

Fixes #10311

Backport of PR #10327