### PR TITLE
[Backport 3.9] OpenFileGDB: fix attribute filter when an equality comparison is involved…

### DIFF
--- a/ogr/ogrsf_frmts/openfilegdb/filegdbtable.h
+++ b/ogr/ogrsf_frmts/openfilegdb/filegdbtable.h
@@ -774,7 +774,8 @@ typedef enum
     FGSO_LE,
     FGSO_EQ,
     FGSO_GE,
-    FGSO_GT
+    FGSO_GT,
+    FGSO_ILIKE
 } FileGDBSQLOp;
 
 /************************************************************************/

--- a/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer.cpp
@@ -1329,7 +1329,8 @@ OGROpenFileGDBLayer::BuildIteratorFromExprNode(swq_expr_node *poNode)
     }
 
     else if (poNode->eNodeType == SNT_OPERATION &&
-             OGROpenFileGDBIsComparisonOp(poNode->nOperation) &&
+             (OGROpenFileGDBIsComparisonOp(poNode->nOperation) ||
+              poNode->nOperation == SWQ_ILIKE) &&
              poNode->nSubExprCount == 2)
     {
         swq_expr_node *poColumn = GetColumnSubNode(poNode);
@@ -1373,6 +1374,9 @@ OGROpenFileGDBLayer::BuildIteratorFromExprNode(swq_expr_node *poNode)
                             case SWQ_GT:
                                 eOp = FGSO_GT;
                                 break;
+                            case SWQ_ILIKE:
+                                eOp = FGSO_ILIKE;
+                                break;
                             default:
                                 CPLAssert(false);
                                 break;
@@ -1402,6 +1406,9 @@ OGROpenFileGDBLayer::BuildIteratorFromExprNode(swq_expr_node *poNode)
                             case SWQ_GT:
                                 eOp = FGSO_LT;
                                 break;
+                            case SWQ_ILIKE:
+                                eOp = FGSO_ILIKE;
+                                break;
                             default:
                                 CPLAssert(false);
                                 break;
@@ -1414,10 +1421,31 @@ OGROpenFileGDBLayer::BuildIteratorFromExprNode(swq_expr_node *poNode)
                     if (poField->GetType() == FGFT_STRING &&
                         poFieldDefn->GetType() == OFTString)
                     {
+                        // If we have an equality comparison, but the index
+                        // uses LOWER(), transform it to a ILIKE comparison
+                        if (eOp == FGSO_EQ && poField->HasIndex() &&
+                            STARTS_WITH_CI(
+                                poField->GetIndex()->GetExpression().c_str(),
+                                "LOWER("))
+                        {
+                            // Note: FileGDBIndexIterator::SetConstraint()
+                            // checks that the string to compare with has no
+                            // wildcard
+                            eOp = FGSO_ILIKE;
+
+                            // In theory, a ILIKE is not sufficient as it is
+                            // case insensitive, whereas one could expect
+                            // equality testing to be case sensitive... but
+                            // it is not in OGR SQL...
+                            // So we can comment the below line
+                            // bIteratorSufficient = false;
+                        }
+
                         // As the index use ' ' as padding value, we cannot
                         // fully trust the index.
-                        if ((eOp == FGSO_EQ && poNode->nOperation != SWQ_NE) ||
-                            eOp == FGSO_GE)
+                        else if ((eOp == FGSO_EQ &&
+                                  poNode->nOperation != SWQ_NE) ||
+                                 eOp == FGSO_GE)
                             bIteratorSufficient = false;
                         else
                             return nullptr;
@@ -1450,6 +1478,8 @@ OGROpenFileGDBLayer::BuildIteratorFromExprNode(swq_expr_node *poNode)
                             }
                         }
                     }
+                    else if (eOp == FGSO_ILIKE)
+                        return nullptr;
 
                     FileGDBIterator *poIter = FileGDBIterator::Build(
                         m_poLyrTable, nTableColIdx, TRUE, eOp,


### PR DESCRIPTION
… with a field with an index created with a LOWER(field_name) expression

Fixes #10345

Backport of PR #10346