### PR TITLE
[Backport release/3.9] WKT geometry importer: accept (non conformant) PointZ/PointZM without space as generated by current QGIS versions

### DIFF
--- a/autotest/ogr/ogr_wkbwkt_geom.py
+++ b/autotest/ogr/ogr_wkbwkt_geom.py
@@ -373,76 +373,79 @@ def test_ogr_wkbwkt_test_broken_geom():
 # Test importing WKT SF1.2
 
 
-def test_ogr_wkbwkt_test_import_wkt_sf12():
-
-    list_wkt_tuples = [
+@pytest.mark.parametrize(
+    "input_wkt,expected_output_wkt",
+    [
         ("POINT EMPTY", "POINT EMPTY"),
-        ("POINT Z EMPTY", "POINT EMPTY"),
-        ("POINT M EMPTY", "POINT EMPTY"),
-        ("POINT ZM EMPTY", "POINT EMPTY"),
+        ("POINT Z EMPTY", "POINT Z EMPTY"),
+        ("POINT M EMPTY", "POINT M EMPTY"),
+        ("POINT ZM EMPTY", "POINT ZM EMPTY"),
         ("POINT (0 1)", "POINT (0 1)"),
-        ("POINT Z (0 1 2)", "POINT (0 1 2)"),
-        ("POINT M (0 1 2)", "POINT (0 1)"),
-        ("POINT ZM (0 1 2 3)", "POINT (0 1 2)"),
+        ("POINT Z (0 1 2)", "POINT Z (0 1 2)"),
+        ("POINT M (0 1 2)", "POINT M (0 1 2)"),
+        ("POINT ZM (0 1 2 3)", "POINT ZM (0 1 2 3)"),
         ("LINESTRING EMPTY", "LINESTRING EMPTY"),
-        ("LINESTRING Z EMPTY", "LINESTRING EMPTY"),
-        ("LINESTRING M EMPTY", "LINESTRING EMPTY"),
-        ("LINESTRING ZM EMPTY", "LINESTRING EMPTY"),
+        ("LINESTRING Z EMPTY", "LINESTRING Z EMPTY"),
+        ("LINESTRING M EMPTY", "LINESTRING M EMPTY"),
+        ("LINESTRING ZM EMPTY", "LINESTRING ZM EMPTY"),
         ("LINESTRING (0 1,2 3)", "LINESTRING (0 1,2 3)"),
-        ("LINESTRING Z (0 1 2,3 4 5)", "LINESTRING (0 1 2,3 4 5)"),
-        ("LINESTRING M (0 1 2,3 4 5)", "LINESTRING (0 1,3 4)"),
-        ("LINESTRING ZM (0 1 2 3,4 5 6 7)", "LINESTRING (0 1 2,4 5 6)"),
+        ("LINESTRING Z (0 1 2,3 4 5)", "LINESTRING Z (0 1 2,3 4 5)"),
+        ("LINESTRING M (0 1 2,3 4 5)", "LINESTRING M (0 1 2,3 4 5)"),
+        ("LINESTRING ZM (0 1 2 3,4 5 6 7)", "LINESTRING ZM (0 1 2 3,4 5 6 7)"),
         ("POLYGON EMPTY", "POLYGON EMPTY"),
         ("POLYGON (EMPTY)", "POLYGON EMPTY"),
-        ("POLYGON Z EMPTY", "POLYGON EMPTY"),
-        ("POLYGON Z (EMPTY)", "POLYGON EMPTY"),
-        ("POLYGON M EMPTY", "POLYGON EMPTY"),
-        ("POLYGON ZM EMPTY", "POLYGON EMPTY"),
+        ("POLYGON Z EMPTY", "POLYGON Z EMPTY"),
+        ("POLYGON Z (EMPTY)", "POLYGON Z EMPTY"),
+        ("POLYGON M EMPTY", "POLYGON M EMPTY"),
+        ("POLYGON ZM EMPTY", "POLYGON ZM EMPTY"),
         ("POLYGON ((0 1,2 3,4 5,0 1))", "POLYGON ((0 1,2 3,4 5,0 1))"),
         ("POLYGON ((0 1,2 3,4 5,0 1),EMPTY)", "POLYGON ((0 1,2 3,4 5,0 1))"),
         ("POLYGON (EMPTY,(0 1,2 3,4 5,0 1))", "POLYGON EMPTY"),
         ("POLYGON (EMPTY,(0 1,2 3,4 5,0 1),EMPTY)", "POLYGON EMPTY"),
         (
             "POLYGON Z ((0 1 10,2 3 20,4 5 30,0 1 10),(0 1 10,2 3 20,4 5 30,0 1 10))",
-            "POLYGON ((0 1 10,2 3 20,4 5 30,0 1 10),(0 1 10,2 3 20,4 5 30,0 1 10))",
+            "POLYGON Z ((0 1 10,2 3 20,4 5 30,0 1 10),(0 1 10,2 3 20,4 5 30,0 1 10))",
         ),
-        ("POLYGON M ((0 1 10,2 3 20,4 5 30,0 1 10))", "POLYGON ((0 1,2 3,4 5,0 1))"),
+        (
+            "POLYGON M ((0 1 10,2 3 20,4 5 30,0 1 10))",
+            "POLYGON M ((0 1 10,2 3 20,4 5 30,0 1 10))",
+        ),
         (
             "POLYGON ZM ((0 1 10 100,2 3 20 200,4 5 30 300,0 1 10 10))",
-            "POLYGON ((0 1 10,2 3 20,4 5 30,0 1 10))",
+            "POLYGON ZM ((0 1 10 100,2 3 20 200,4 5 30 300,0 1 10 10))",
         ),
         ("MULTIPOINT EMPTY", "MULTIPOINT EMPTY"),
         ("MULTIPOINT (EMPTY)", "MULTIPOINT EMPTY"),
-        ("MULTIPOINT Z EMPTY", "MULTIPOINT EMPTY"),
-        ("MULTIPOINT Z (EMPTY)", "MULTIPOINT EMPTY"),
-        ("MULTIPOINT M EMPTY", "MULTIPOINT EMPTY"),
-        ("MULTIPOINT ZM EMPTY", "MULTIPOINT EMPTY"),
+        ("MULTIPOINT Z EMPTY", "MULTIPOINT Z EMPTY"),
+        ("MULTIPOINT Z (EMPTY)", "MULTIPOINT Z EMPTY"),
+        ("MULTIPOINT M EMPTY", "MULTIPOINT M EMPTY"),
+        ("MULTIPOINT ZM EMPTY", "MULTIPOINT ZM EMPTY"),
         (
             "MULTIPOINT (0 1,2 3)",
-            "MULTIPOINT (0 1,2 3)",
+            "MULTIPOINT ((0 1),(2 3))",
         ),  # Not SF1.2 compliant but recognized
-        ("MULTIPOINT ((0 1),(2 3))", "MULTIPOINT (0 1,2 3)"),
+        ("MULTIPOINT ((0 1),(2 3))", "MULTIPOINT ((0 1),(2 3))"),
         (
             "MULTIPOINT ((0 1),EMPTY)",
-            "MULTIPOINT (0 1)",
+            "MULTIPOINT ((0 1))",
         ),  # We don't output empty points in multipoint
         (
             "MULTIPOINT (EMPTY,(0 1))",
-            "MULTIPOINT (0 1)",
+            "MULTIPOINT ((0 1))",
         ),  # We don't output empty points in multipoint
         (
             "MULTIPOINT (EMPTY,(0 1),EMPTY)",
-            "MULTIPOINT (0 1)",
+            "MULTIPOINT ((0 1))",
         ),  # We don't output empty points in multipoint
-        ("MULTIPOINT Z ((0 1 2),(3 4 5))", "MULTIPOINT (0 1 2,3 4 5)"),
-        ("MULTIPOINT M ((0 1 2),(3 4 5))", "MULTIPOINT (0 1,3 4)"),
-        ("MULTIPOINT ZM ((0 1 2 3),(4 5 6 7))", "MULTIPOINT (0 1 2,4 5 6)"),
+        ("MULTIPOINT Z ((0 1 2),(3 4 5))", "MULTIPOINT Z ((0 1 2),(3 4 5))"),
+        ("MULTIPOINT M ((0 1 2),(3 4 5))", "MULTIPOINT M ((0 1 2),(3 4 5))"),
+        ("MULTIPOINT ZM ((0 1 2 3),(4 5 6 7))", "MULTIPOINT ZM ((0 1 2 3),(4 5 6 7))"),
         ("MULTILINESTRING EMPTY", "MULTILINESTRING EMPTY"),
         ("MULTILINESTRING (EMPTY)", "MULTILINESTRING EMPTY"),
-        ("MULTILINESTRING Z EMPTY", "MULTILINESTRING EMPTY"),
-        ("MULTILINESTRING Z (EMPTY)", "MULTILINESTRING EMPTY"),
-        ("MULTILINESTRING M EMPTY", "MULTILINESTRING EMPTY"),
-        ("MULTILINESTRING ZM EMPTY", "MULTILINESTRING EMPTY"),
+        ("MULTILINESTRING Z EMPTY", "MULTILINESTRING Z EMPTY"),
+        ("MULTILINESTRING Z (EMPTY)", "MULTILINESTRING Z EMPTY"),
+        ("MULTILINESTRING M EMPTY", "MULTILINESTRING M EMPTY"),
+        ("MULTILINESTRING ZM EMPTY", "MULTILINESTRING ZM EMPTY"),
         ("MULTILINESTRING ((0 1,2 3,4 5,0 1))", "MULTILINESTRING ((0 1,2 3,4 5,0 1))"),
         (
             "MULTILINESTRING ((0 1,2 3,4 5,0 1),EMPTY)",
@@ -458,22 +461,22 @@ def test_ogr_wkbwkt_test_import_wkt_sf12():
         ),
         (
             "MULTILINESTRING Z ((0 1 10,2 3 20,4 5 30,0 1 10),(0 1 10,2 3 20,4 5 30,0 1 10))",
-            "MULTILINESTRING ((0 1 10,2 3 20,4 5 30,0 1 10),(0 1 10,2 3 20,4 5 30,0 1 10))",
+            "MULTILINESTRING Z ((0 1 10,2 3 20,4 5 30,0 1 10),(0 1 10,2 3 20,4 5 30,0 1 10))",
         ),
         (
             "MULTILINESTRING M ((0 1 10,2 3 20,4 5 30,0 1 10))",
-            "MULTILINESTRING ((0 1,2 3,4 5,0 1))",
+            "MULTILINESTRING M ((0 1 10,2 3 20,4 5 30,0 1 10))",
         ),
         (
             "MULTILINESTRING ZM ((0 1 10 100,2 3 20 200,4 5 30 300,0 1 10 10))",
-            "MULTILINESTRING ((0 1 10,2 3 20,4 5 30,0 1 10))",
+            "MULTILINESTRING ZM ((0 1 10 100,2 3 20 200,4 5 30 300,0 1 10 10))",
         ),
         ("MULTIPOLYGON EMPTY", "MULTIPOLYGON EMPTY"),
         ("MULTIPOLYGON (EMPTY)", "MULTIPOLYGON EMPTY"),
-        ("MULTIPOLYGON Z EMPTY", "MULTIPOLYGON EMPTY"),
-        ("MULTIPOLYGON Z (EMPTY)", "MULTIPOLYGON EMPTY"),
-        ("MULTIPOLYGON M EMPTY", "MULTIPOLYGON EMPTY"),
-        ("MULTIPOLYGON ZM EMPTY", "MULTIPOLYGON EMPTY"),
+        ("MULTIPOLYGON Z EMPTY", "MULTIPOLYGON Z EMPTY"),
+        ("MULTIPOLYGON Z (EMPTY)", "MULTIPOLYGON Z EMPTY"),
+        ("MULTIPOLYGON M EMPTY", "MULTIPOLYGON M EMPTY"),
+        ("MULTIPOLYGON ZM EMPTY", "MULTIPOLYGON ZM EMPTY"),
         ("MULTIPOLYGON ((EMPTY))", "MULTIPOLYGON EMPTY"),
         ("MULTIPOLYGON (((0 1,2 3,4 5,0 1)))", "MULTIPOLYGON (((0 1,2 3,4 5,0 1)))"),
         (
@@ -511,31 +514,31 @@ def test_ogr_wkbwkt_test_import_wkt_sf12():
         ),
         (
             "MULTIPOLYGON Z (((0 1 10,2 3 20,4 5 30,0 1 10)),((0 1 10,2 3 20,4 5 30,0 1 10)))",
-            "MULTIPOLYGON (((0 1 10,2 3 20,4 5 30,0 1 10)),((0 1 10,2 3 20,4 5 30,0 1 10)))",
+            "MULTIPOLYGON Z (((0 1 10,2 3 20,4 5 30,0 1 10)),((0 1 10,2 3 20,4 5 30,0 1 10)))",
         ),
         (
             "MULTIPOLYGON M (((0 1 10,2 3 20,4 5 30,0 1 10)))",
-            "MULTIPOLYGON (((0 1,2 3,4 5,0 1)))",
+            "MULTIPOLYGON M (((0 1 10,2 3 20,4 5 30,0 1 10)))",
         ),
         (
             "MULTIPOLYGON ZM (((0 1 10 100,2 3 20 200,4 5 30 300,0 1 10 10)))",
-            "MULTIPOLYGON (((0 1 10,2 3 20,4 5 30,0 1 10)))",
+            "MULTIPOLYGON ZM (((0 1 10 100,2 3 20 200,4 5 30 300,0 1 10 10)))",
         ),
         ("GEOMETRYCOLLECTION EMPTY", "GEOMETRYCOLLECTION EMPTY"),
-        ("GEOMETRYCOLLECTION Z EMPTY", "GEOMETRYCOLLECTION EMPTY"),
-        ("GEOMETRYCOLLECTION M EMPTY", "GEOMETRYCOLLECTION EMPTY"),
-        ("GEOMETRYCOLLECTION ZM EMPTY", "GEOMETRYCOLLECTION EMPTY"),
+        ("GEOMETRYCOLLECTION Z EMPTY", "GEOMETRYCOLLECTION Z EMPTY"),
+        ("GEOMETRYCOLLECTION M EMPTY", "GEOMETRYCOLLECTION M EMPTY"),
+        ("GEOMETRYCOLLECTION ZM EMPTY", "GEOMETRYCOLLECTION ZM EMPTY"),
         (
             "GEOMETRYCOLLECTION Z (POINT Z (0 1 2),LINESTRING Z (0 1 2,3 4 5))",
-            "GEOMETRYCOLLECTION (POINT (0 1 2),LINESTRING (0 1 2,3 4 5))",
+            "GEOMETRYCOLLECTION Z (POINT Z (0 1 2),LINESTRING Z (0 1 2,3 4 5))",
         ),
         (
             "GEOMETRYCOLLECTION M (POINT M (0 1 2),LINESTRING M (0 1 2,3 4 5))",
-            "GEOMETRYCOLLECTION (POINT (0 1),LINESTRING (0 1,3 4))",
+            "GEOMETRYCOLLECTION M (POINT M (0 1 2),LINESTRING M (0 1 2,3 4 5))",
         ),
         (
             "GEOMETRYCOLLECTION ZM (POINT ZM (0 1 2 10),LINESTRING ZM (0 1 2 10,3 4 5 20))",
-            "GEOMETRYCOLLECTION (POINT (0 1 2),LINESTRING (0 1 2,3 4 5))",
+            "GEOMETRYCOLLECTION ZM (POINT ZM (0 1 2 10),LINESTRING ZM (0 1 2 10,3 4 5 20))",
         ),
         (
             "GEOMETRYCOLLECTION (POINT EMPTY,LINESTRING EMPTY,POLYGON EMPTY,MULTIPOINT EMPTY,MULTILINESTRING EMPTY,MULTIPOLYGON EMPTY,GEOMETRYCOLLECTION EMPTY)",
@@ -543,7 +546,7 @@ def test_ogr_wkbwkt_test_import_wkt_sf12():
         ),
         (
             "GEOMETRYCOLLECTION (POINT Z EMPTY,LINESTRING Z EMPTY,POLYGON Z EMPTY,MULTIPOINT Z EMPTY,MULTILINESTRING Z EMPTY,MULTIPOLYGON Z EMPTY,GEOMETRYCOLLECTION Z EMPTY)",
-            "GEOMETRYCOLLECTION (POINT EMPTY,LINESTRING EMPTY,POLYGON EMPTY,MULTIPOINT EMPTY,MULTILINESTRING EMPTY,MULTIPOLYGON EMPTY,GEOMETRYCOLLECTION EMPTY)",
+            "GEOMETRYCOLLECTION Z (POINT Z EMPTY,LINESTRING Z EMPTY,POLYGON Z EMPTY,MULTIPOINT Z EMPTY,MULTILINESTRING Z EMPTY,MULTIPOLYGON Z EMPTY,GEOMETRYCOLLECTION Z EMPTY)",
         ),
         # Not SF1.2 compliant but recognized
         (
@@ -556,17 +559,20 @@ def test_ogr_wkbwkt_test_import_wkt_sf12():
         ("MULTICURVE (EMPTY)", "MULTICURVE EMPTY"),
         ("MULTISURFACE EMPTY", "MULTISURFACE EMPTY"),
         ("MULTISURFACE (EMPTY)", "MULTISURFACE EMPTY"),
-    ]
+    ],
+)
+def test_ogr_wkbwkt_test_import_wkt_sf12(input_wkt, expected_output_wkt):
 
-    for wkt_tuple in list_wkt_tuples:
-        geom = ogr.CreateGeometryFromWkt(wkt_tuple[0])
-        assert geom is not None, "could not instantiate geometry %s" % wkt_tuple[0]
-        out_wkt = geom.ExportToWkt()
-        assert out_wkt == wkt_tuple[1], "in=%s, out=%s, expected=%s." % (
-            wkt_tuple[0],
-            out_wkt,
-            wkt_tuple[1],
-        )
+    geom = ogr.CreateGeometryFromWkt(input_wkt)
+    assert geom is not None
+    out_wkt = geom.ExportToIsoWkt()
+    assert out_wkt == expected_output_wkt
+
+    # Test with input in lower case
+    geom = ogr.CreateGeometryFromWkt(input_wkt.lower())
+    assert geom is not None
+    out_wkt = geom.ExportToIsoWkt()
+    assert out_wkt == expected_output_wkt
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_wkbwkt_geom.py
+++ b/autotest/ogr/ogr_wkbwkt_geom.py
@@ -166,6 +166,7 @@ def test_ogr_wkbwkt_test_broken_geom():
         "POINT Z(EMPTY)",
         "POINT Z(A)",
         "POINT Z(0 1",
+        "POINTZ M EMPTY",
         "LINESTRING",
         "LINESTRING UNKNOWN",
         "LINESTRING(",
@@ -566,6 +567,38 @@ def test_ogr_wkbwkt_test_import_wkt_sf12():
             out_wkt,
             wkt_tuple[1],
         )
+
+
+###############################################################################
+# Test importing non-conformant WKT with Z/M modifier directly appended to
+# geometry type name
+
+
+@pytest.mark.parametrize(
+    "input_wkt,expected_output_wkt",
+    [
+        ("POINTZ EMPTY", "POINT Z EMPTY"),
+        ("POINTM EMPTY", "POINT M EMPTY"),
+        ("POINTZM EMPTY", "POINT ZM EMPTY"),
+        ("POINTZ (0 1 2)", "POINT Z (0 1 2)"),
+        ("POINTM (0 1 2)", "POINT M (0 1 2)"),
+        ("POINTZM (0 1 2 3)", "POINT ZM (0 1 2 3)"),
+    ],
+)
+def test_ogr_wkbwkt_test_import_wkt_z_m_modifier_without_space(
+    input_wkt, expected_output_wkt
+):
+
+    geom = ogr.CreateGeometryFromWkt(input_wkt)
+    assert geom is not None
+    out_wkt = geom.ExportToIsoWkt()
+    assert out_wkt == expected_output_wkt
+
+    # Test with input in lower case
+    geom = ogr.CreateGeometryFromWkt(input_wkt.lower())
+    assert geom is not None
+    out_wkt = geom.ExportToIsoWkt()
+    assert out_wkt == expected_output_wkt
 
 
 ###############################################################################

--- a/ogr/ogrgeometry.cpp
+++ b/ogr/ogrgeometry.cpp
@@ -1791,19 +1791,33 @@ OGRErr OGRGeometry::importPreambleFromWkt(const char **ppszInput, int *pbHasZ,
     /* -------------------------------------------------------------------- */
     bool bHasM = false;
     bool bHasZ = false;
-    bool bIsoWKT = true;
+    bool bAlreadyGotDimension = false;
 
     char szToken[OGR_WKT_TOKEN_MAX] = {};
     pszInput = OGRWktReadToken(pszInput, szToken);
     if (szToken[0] != '\0')
     {
         // Postgis EWKT: POINTM instead of POINT M.
+        // Current QGIS versions (at least <= 3.38) also export POINTZ.
         const size_t nTokenLen = strlen(szToken);
-        if (szToken[nTokenLen - 1] == 'M')
+        if (szToken[nTokenLen - 1] == 'M' || szToken[nTokenLen - 1] == 'm')
         {
             szToken[nTokenLen - 1] = '\0';
             bHasM = true;
-            bIsoWKT = false;
+            bAlreadyGotDimension = true;
+
+            if (nTokenLen > 2 && (szToken[nTokenLen - 2] == 'Z' ||
+                                  szToken[nTokenLen - 2] == 'z'))
+            {
+                bHasZ = true;
+                szToken[nTokenLen - 2] = '\0';
+            }
+        }
+        else if (szToken[nTokenLen - 1] == 'Z' || szToken[nTokenLen - 1] == 'z')
+        {
+            szToken[nTokenLen - 1] = '\0';
+            bHasZ = true;
+            bAlreadyGotDimension = true;
         }
     }
 
@@ -1811,55 +1825,44 @@ OGRErr OGRGeometry::importPreambleFromWkt(const char **ppszInput, int *pbHasZ,
         return OGRERR_CORRUPT_DATA;
 
     /* -------------------------------------------------------------------- */
-    /*      Check for EMPTY ...                                             */
+    /*      Check for Z, M or ZM                                            */
     /* -------------------------------------------------------------------- */
-    const char *pszPreScan = OGRWktReadToken(pszInput, szToken);
-    if (!bIsoWKT)
+    if (!bAlreadyGotDimension)
     {
-        // Go on.
-    }
-    else if (EQUAL(szToken, "EMPTY"))
-    {
-        *ppszInput = const_cast<char *>(pszPreScan);
-        *pbIsEmpty = true;
-        *pbHasM = bHasM;
-        empty();
-        return OGRERR_NONE;
-    }
-    /* -------------------------------------------------------------------- */
-    /*      Check for Z, M or ZM. Will ignore the Measure                   */
-    /* -------------------------------------------------------------------- */
-    else if (EQUAL(szToken, "Z"))
-    {
-        bHasZ = true;
-    }
-    else if (EQUAL(szToken, "M"))
-    {
-        bHasM = true;
-    }
-    else if (EQUAL(szToken, "ZM"))
-    {
-        bHasZ = true;
-        bHasM = true;
+        const char *pszNewInput = OGRWktReadToken(pszInput, szToken);
+        if (EQUAL(szToken, "Z"))
+        {
+            pszInput = pszNewInput;
+            bHasZ = true;
+        }
+        else if (EQUAL(szToken, "M"))
+        {
+            pszInput = pszNewInput;
+            bHasM = true;
+        }
+        else if (EQUAL(szToken, "ZM"))
+        {
+            pszInput = pszNewInput;
+            bHasZ = true;
+            bHasM = true;
+        }
     }
     *pbHasZ = bHasZ;
     *pbHasM = bHasM;
 
-    if (bIsoWKT && (bHasZ || bHasM))
+    /* -------------------------------------------------------------------- */
+    /*      Check for EMPTY ...                                             */
+    /* -------------------------------------------------------------------- */
+    const char *pszNewInput = OGRWktReadToken(pszInput, szToken);
+    if (EQUAL(szToken, "EMPTY"))
     {
-        pszInput = pszPreScan;
-        pszPreScan = OGRWktReadToken(pszInput, szToken);
-        if (EQUAL(szToken, "EMPTY"))
-        {
-            *ppszInput = pszPreScan;
-            empty();
-            if (bHasZ)
-                set3D(TRUE);
-            if (bHasM)
-                setMeasured(TRUE);
-            *pbIsEmpty = true;
-            return OGRERR_NONE;
-        }
+        *ppszInput = pszNewInput;
+        *pbIsEmpty = true;
+        if (bHasZ)
+            set3D(TRUE);
+        if (bHasM)
+            setMeasured(TRUE);
+        return OGRERR_NONE;
     }
 
     if (!EQUAL(szToken, "("))
@@ -1868,10 +1871,10 @@ OGRErr OGRGeometry::importPreambleFromWkt(const char **ppszInput, int *pbHasZ,
     if (!bHasZ && !bHasM)
     {
         // Test for old-style XXXXXXXXX(EMPTY).
-        pszPreScan = OGRWktReadToken(pszPreScan, szToken);
+        pszNewInput = OGRWktReadToken(pszNewInput, szToken);
         if (EQUAL(szToken, "EMPTY"))
         {
-            pszPreScan = OGRWktReadToken(pszPreScan, szToken);
+            pszNewInput = OGRWktReadToken(pszNewInput, szToken);
 
             if (EQUAL(szToken, ","))
             {
@@ -1883,7 +1886,7 @@ OGRErr OGRGeometry::importPreambleFromWkt(const char **ppszInput, int *pbHasZ,
             }
             else
             {
-                *ppszInput = pszPreScan;
+                *ppszInput = pszNewInput;
                 empty();
                 *pbIsEmpty = true;
                 return OGRERR_NONE;


### PR DESCRIPTION
Backport #10370
 **Authored by:** @rouault