### PR TITLE
gdalinfo_output.schema.json: pin stac-extensions/eo to v1.1.0

### DIFF
--- a/apps/data/gdalinfo_output.schema.json
+++ b/apps/data/gdalinfo_output.schema.json
@@ -277,7 +277,7 @@
     },
 
     "stac": {
-      "$comment": "Derived from https://raw.githubusercontent.com/stac-extensions/projection/main/json-schema/schema.json#/definitions/fields, https://raw.githubusercontent.com/stac-extensions/eo/main/json-schema/schema.json#/definitions/bands and https://raw.githubusercontent.com/stac-extensions/eo/main/json-schema/schema.json#/definitions/bands",
+      "$comment": "Derived from https://raw.githubusercontent.com/stac-extensions/projection/main/json-schema/schema.json#/definitions/fields, https://raw.githubusercontent.com/stac-extensions/eo/v1.1.0/json-schema/schema.json#/definitions/bands and https://raw.githubusercontent.com/stac-extensions/eo/v1.1.0/json-schema/schema.json#/definitions/bands",
       "type": "object",
       "properties": {
         "proj:epsg": {
@@ -334,10 +334,10 @@
           }
         },
         "eo:bands": {
-          "$ref": "https://raw.githubusercontent.com/stac-extensions/eo/main/json-schema/schema.json#/definitions/bands"
+          "$ref": "https://raw.githubusercontent.com/stac-extensions/eo/v1.1.0/json-schema/schema.json#/definitions/bands"
         },
         "raster:bands": {
-          "$ref": "https://raw.githubusercontent.com/stac-extensions/eo/main/json-schema/schema.json#/definitions/bands"
+          "$ref": "https://raw.githubusercontent.com/stac-extensions/eo/v1.1.0/json-schema/schema.json#/definitions/bands"
         }
       },
       "additionalProperties": false


### PR DESCRIPTION
Breaking changes in stac-extensions/eo (for v2.0 presumably) have landed today per https://github.com/stac-extensions/eo/commit/81bb3b13dfed92e1a2d8776b2c9fe5f23e28a3ec
