### PR TITLE
gdaldem.rst - mention alpha column, not used without -alpha

### DIFF
--- a/doc/source/programs/gdaldem.rst
+++ b/doc/source/programs/gdaldem.rst
@@ -56,7 +56,7 @@ Generate a color relief map:
                  [-alpha] [-exact_color_entry | -nearest_color_entry]
                  [-b <band>] [-of format] [-co <NAME>=<VALUE>]... [-q]
 
-    where color_text_file contains lines of the format "elevation_value red green blue"
+    where color_text_file contains lines of the format "elevation_value red green blue [alpha]". If alpha column is present it can be enabled for use with '-alpha'. 
 
 Generate a Terrain Ruggedness Index (TRI) map:
 


### PR DESCRIPTION
Small doc addition for gdaldem color-relief about presence of an alpha column in the color map, transparancy  is not applied without explicitly specifying '-alpha'. 
