### PR TITLE
CMake: Remove unneeded dependency on Java AWT

### DIFF
--- a/.github/workflows/ubuntu_20.04/Dockerfile.ci
+++ b/.github/workflows/ubuntu_20.04/Dockerfile.ci
@@ -76,7 +76,7 @@ RUN apt-get update -y \
     numactl \
     ocl-icd-opencl-dev \
     opencl-c-headers \
-    openjdk-8-jdk \
+    openjdk-8-jdk-headless \
     pkg-config \
     python3-dev \
     python3-numpy \

--- a/.github/workflows/ubuntu_22.04/Dockerfile.ci
+++ b/.github/workflows/ubuntu_22.04/Dockerfile.ci
@@ -58,7 +58,7 @@ RUN apt-get update && \
     locales \
     mysql-client-core-8.0 \
     netcdf-bin \
-    openjdk-8-jdk \
+    openjdk-8-jdk-headless \
     poppler-utils \
     postgis \
     postgresql-client \
@@ -104,7 +104,7 @@ RUN mkdir mongocxx \
     && make install \
     && cd ../.. \
     && rm -rf mongocxx
-    
+
 # Build libOpenDRIVE
 ARG OPENDRIVE_VERSION=0.5.0-gdal
 RUN if test "${OPENDRIVE_VERSION}" != ""; then ( \

--- a/.github/workflows/ubuntu_24.04/Dockerfile.ci
+++ b/.github/workflows/ubuntu_24.04/Dockerfile.ci
@@ -59,7 +59,7 @@ RUN apt-get update && \
     locales \
     mysql-client-core-8.0 \
     netcdf-bin \
-    openjdk-8-jdk \
+    openjdk-8-jdk-headless \
     poppler-utils \
     postgis \
     postgresql-client \

--- a/cmake/helpers/CheckDependentLibraries.cmake
+++ b/cmake/helpers/CheckDependentLibraries.cmake
@@ -539,6 +539,8 @@ gdal_check_package(OpenDrive "Enable libOpenDRIVE" CAN_DISABLE)
 
 # finding python in top of project because of common for autotest and bindings
 
+set(JAVA_AWT_LIBRARY NotNeeded)
+set(JAVA_AWT_INCLUDE_PATH NotNeeded)
 find_package(JNI)
 find_package(Java COMPONENTS Runtime Development)
 find_program(


### PR DESCRIPTION
## What does this PR do?

Avoids an unintentional dependency on Java AWT caused by the implementation of FindJNI, applying a workaround suggested by https://stackoverflow.com/questions/51047978/cmake-could-not-find-jni
Reduces the size of the modified build environments by ~300MB.

## What are related issues/pull requests?

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed