### PR TITLE
Revert "CI: disable running Windows tests on build-windows-conda to workaround issue with image windows-latest 20240603.1.0"

### DIFF
--- a/.github/workflows/cmake_builds.yml
+++ b/.github/workflows/cmake_builds.yml
@@ -466,30 +466,25 @@ jobs:
       shell: bash -l {0}
       run: |
         cmake --build $GITHUB_WORKSPACE/build --config Release --target quicktest
-    # FIXME !! Disabled because of actions/runner-images#10004
-    #- name: test (with ctest)
-    #  shell: bash -l {0}
-    #  run: |
-    #    ctest --test-dir $GITHUB_WORKSPACE/build -C Release -V -j 3
-    #  env:
-    #    SKIP_OGR_GMLAS_HUGE_PROCESSING_TIME: YES
-    #    SKIP_OGR_GMLAS_HTTP_RELATED: YES
-    #    SKIP_GDAL_HTTP_SSL_VERIFYSTATUS: YES
-    #    BUILD_NAME: "build-windows-conda"
+    - name: test (with ctest)
+      shell: bash -l {0}
+      run: |
+        ctest --test-dir $GITHUB_WORKSPACE/build -C Release -V -j 3
+      env:
+        SKIP_OGR_GMLAS_HUGE_PROCESSING_TIME: YES
+        SKIP_OGR_GMLAS_HTTP_RELATED: YES
+        SKIP_GDAL_HTTP_SSL_VERIFYSTATUS: YES
+        BUILD_NAME: "build-windows-conda"
     - name: Install
       shell: bash -l {0}
       run: |
         cmake --build $GITHUB_WORKSPACE/build --config Release --target install
-    # FIXME !! Disabled because of actions/runner-images#10004
-    #- name: Test install
-    #  shell: bash -l {0}
-    #  run: |
-    #    export PATH=$GITHUB_WORKSPACE/install-gdal/bin:$PATH
-    #    gdalinfo --version
-    #    python -VV
-    #    PYTHONPATH=$GITHUB_WORKSPACE/install-gdal/lib/site-packages python -c "from osgeo import gdal;print(gdal.VersionInfo(None))"
-    #    export PATH=$GITHUB_WORKSPACE/install-gdal/Scripts:$PATH
-    #    PYTHONPATH=$GITHUB_WORKSPACE/install-gdal/lib/site-packages gdal_edit --version
+        export PATH=$GITHUB_WORKSPACE/install-gdal/bin:$PATH
+        gdalinfo --version
+        python -VV
+        PYTHONPATH=$GITHUB_WORKSPACE/install-gdal/lib/site-packages python -c "from osgeo import gdal;print(gdal.VersionInfo(None))"
+        export PATH=$GITHUB_WORKSPACE/install-gdal/Scripts:$PATH
+        PYTHONPATH=$GITHUB_WORKSPACE/install-gdal/lib/site-packages gdal_edit --version
     - name: Show gdal.pc
       shell: bash -l {0}
       run: cat $GITHUB_WORKSPACE/build/gdal.pc


### PR DESCRIPTION
This reverts commit 81cb7e354d925fabac1aac80f5613566cf96ec65.

Fixes #10165