### PR TITLE
VRT: add multi-threaded implementation for rasterband and dataset IRasterIO()

### DIFF
--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -2204,7 +2204,7 @@ def test_vrt_read_compute_statistics_mosaic_optimization(
     src_ds2 = gdal.Translate("", src_ds, options="-of MEM -srcwin 8 0 12 20")
     vrt_ds = gdal.BuildVRT("", [src_ds1, src_ds2])
 
-    with gdaltest.config_options({"GDAL_NUM_THREADS": "2"} if use_threads else {}):
+    with gdaltest.config_options({"VRT_NUM_THREADS": "2" if use_threads else "0"}):
         assert vrt_ds.GetRasterBand(1).ComputeRasterMinMax(
             approx_ok
         ) == src_ds.GetRasterBand(1).ComputeRasterMinMax(approx_ok)

--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -2639,3 +2639,76 @@ def test_vrt_read_virtual_overviews_match_src_overviews(tmp_vsimem):
     assert vrt_band.GetOverview(1).YSize == 1024
     assert vrt_band.GetOverview(2).XSize == 1024
     assert vrt_band.GetOverview(2).YSize == 512
+
+
+###############################################################################
+# Test multi-threaded reading
+
+
+@pytest.mark.parametrize("dataset_level", [True, False])
+@pytest.mark.parametrize("use_threads", [True, False])
+@pytest.mark.parametrize("num_tiles", [2, 128])
+def test_vrt_read_multi_threaded(tmp_vsimem, dataset_level, use_threads, num_tiles):
+
+    width = 2048
+    src_ds = gdal.Translate(
+        "", "../gdrivers/data/small_world.tif", width=width, format="MEM"
+    )
+    assert width % num_tiles == 0
+    tile_width = width // num_tiles
+    tile_filenames = []
+    for i in range(num_tiles):
+        tile_filename = str(tmp_vsimem / ("%d.tif" % i))
+        gdal.Translate(
+            tile_filename, src_ds, srcWin=[i * tile_width, 0, tile_width, 1024]
+        )
+        tile_filenames.append(tile_filename)
+    vrt_filename = str(tmp_vsimem / "test.vrt")
+    gdal.BuildVRT(vrt_filename, tile_filenames)
+    vrt_ds = gdal.Open(vrt_filename)
+
+    obj = vrt_ds if dataset_level else vrt_ds.GetRasterBand(1)
+    obj_ref = src_ds if dataset_level else src_ds.GetRasterBand(1)
+
+    pcts = []
+
+    def cbk(pct, msg, user_data):
+        if pcts:
+            assert pct >= pcts[-1]
+        pcts.append(pct)
+        return 1
+
+    with gdal.config_options({} if use_threads else {"VRT_NUM_THREADS": "0"}):
+        assert obj.ReadRaster(1, 2, 1030, 1020, callback=cbk) == obj_ref.ReadRaster(
+            1, 2, 1030, 1020
+        )
+    assert pcts[-1] == 1.0
+
+    assert vrt_ds.GetMetadataItem("MULTI_THREADED_RASTERIO_LAST_USED", "__DEBUG__") == (
+        "1" if gdal.GetNumCPUs() >= 2 and use_threads else "0"
+    )
+
+
+###############################################################################
+# Test multi-threaded reading
+
+
+def test_vrt_read_multi_threaded_disabled_since_overlapping_sources():
+
+    src_ds = gdal.Translate(
+        "", "../gdrivers/data/small_world.tif", width=2048, format="MEM"
+    )
+    OVERLAP = 1
+    left_ds = gdal.Translate(
+        "left", src_ds, format="MEM", srcWin=[0, 0, 1024 + OVERLAP, 1024]
+    )
+    right_ds = gdal.Translate(
+        "right", src_ds, format="MEM", srcWin=[1024, 0, 1024, 1024]
+    )
+    vrt_ds = gdal.BuildVRT("", [left_ds, right_ds])
+
+    assert vrt_ds.ReadRaster(1, 2, 1030, 1020) == src_ds.ReadRaster(1, 2, 1030, 1020)
+
+    assert (
+        vrt_ds.GetMetadataItem("MULTI_THREADED_RASTERIO_LAST_USED", "__DEBUG__") == "0"
+    )

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -2097,6 +2097,38 @@ multi-threading if the sources are not overlapping and belong to different
 datasets. This can be enabled by setting the :config:`GDAL_NUM_THREADS`
 configuration option to an integer or ``ALL_CPUS``.
 
+Starting with GDAL 3.10, the :oo:`NUM_THREADS` open option can
+be set to control specifically the multi-threading of VRT datasets.
+It defaults to ``ALL_CPUS``, and when set, overrides :config:`GDAL_NUM_THREADS`
+or :config:`VRT_NUM_THREADS`. It applies to
+ComputeStatistics() and band-level and dataset-level RasterIO().
+For band-level RasterIO(), multi-threading is only available if more than 1
+million pixels are requested and if the VRT is made of only non-overlapping
+SimpleSource or ComplexSource belonging to different datasets.
+For dataset-level RasterIO(), multi-threading is only available if more than 1
+million pixels are requested and if the VRT is made of only non-overlapping
+SimpleSource belonging to different datasets.
+
+-  .. oo:: NUM_THREADS
+      :choices: integer, ALL_CPUS
+      :default: ALL_CPUS
+
+      Determines the number of threads used when an operation reads from
+      multiple sources.
+
+This can also be specified globally with the :config:`VRT_NUM_THREADS`
+configuration option.
+
+-  .. config:: VRT_NUM_THREADS
+      :choices: integer, ALL_CPUS
+      :default: ALL_CPUS
+
+      Determines the number of threads used when an operation reads from
+      multiple sources.
+
+Note that the number of threads actually used is also limited by the
+:config:`GDAL_MAX_DATASET_POOL_SIZE` configuration option.
+
 Multi-threading issues
 ----------------------
 

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -2899,4 +2899,43 @@ std::string VRTDataset::BuildSourceFilename(const char *pszFilename,
     return osSrcDSName;
 }
 
+/************************************************************************/
+/*                   VRTMapSharedResources::Get()                       */
+/************************************************************************/
+
+GDALDataset *VRTMapSharedResources::Get(const std::string &osKey) const
+{
+    if (poMutex)
+        poMutex->lock();
+    auto oIter = oMap.find(osKey);
+    GDALDataset *poRet = nullptr;
+    if (oIter != oMap.end())
+        poRet = oIter->second;
+    if (poMutex)
+        poMutex->unlock();
+    return poRet;
+}
+
+/************************************************************************/
+/*                   VRTMapSharedResources::Get()                       */
+/************************************************************************/
+
+void VRTMapSharedResources::Insert(const std::string &osKey, GDALDataset *poDS)
+{
+    if (poMutex)
+        poMutex->lock();
+    oMap[osKey] = poDS;
+    if (poMutex)
+        poMutex->unlock();
+}
+
+/************************************************************************/
+/*                   VRTMapSharedResources::InitMutex()                 */
+/************************************************************************/
+
+void VRTMapSharedResources::InitMutex()
+{
+    poMutex = &oMutex;
+}
+
 /*! @endcond */

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -2288,12 +2288,17 @@ CPLErr VRTDataset::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
             const int nSavedSources = poBand->nSources;
             poBand->nSources = 0;
 
+            GDALProgressFunc pfnProgressGlobal = psExtraArg->pfnProgress;
+            psExtraArg->pfnProgress = nullptr;
+
             GByte *pabyBandData =
                 static_cast<GByte *>(pData) + iBandIndex * nBandSpace;
 
             poBand->IRasterIO(GF_Read, nXOff, nYOff, nXSize, nYSize,
                               pabyBandData, nBufXSize, nBufYSize, eBufType,
                               nPixelSpace, nLineSpace, psExtraArg);
+
+            psExtraArg->pfnProgress = pfnProgressGlobal;
 
             poBand->nSources = nSavedSources;
         }

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -33,6 +33,7 @@
 #include "cpl_string.h"
 #include "gdal_frmts.h"
 #include "ogr_spatialref.h"
+#include "gdal_thread_pool.h"
 #include "gdal_utils.h"
 
 #include <algorithm>
@@ -215,6 +216,22 @@ char **VRTDataset::GetMetadata(const char *pszDomain)
     }
 
     return GDALDataset::GetMetadata(pszDomain);
+}
+
+/************************************************************************/
+/*                          GetMetadataItem()                           */
+/************************************************************************/
+
+const char *VRTDataset::GetMetadataItem(const char *pszName,
+                                        const char *pszDomain)
+
+{
+    if (pszName && pszDomain && EQUAL(pszDomain, "__DEBUG__"))
+    {
+        if (EQUAL(pszName, "MULTI_THREADED_RASTERIO_LAST_USED"))
+            return m_bMultiThreadedRasterIOLastUsed ? "1" : "0";
+    }
+    return GDALDataset::GetMetadataItem(pszName, pszDomain);
 }
 
 /*! @endcond */
@@ -2198,6 +2215,29 @@ CPLErr VRTDataset::AdviseRead(int nXOff, int nYOff, int nXSize, int nYSize,
 }
 
 /************************************************************************/
+/*                           GetNumThreads()                            */
+/************************************************************************/
+
+/* static */ int VRTDataset::GetNumThreads(GDALDataset *poDS)
+{
+    const char *pszNumThreads = nullptr;
+    if (poDS)
+        pszNumThreads = CSLFetchNameValueDef(poDS->GetOpenOptions(),
+                                             "NUM_THREADS", nullptr);
+    if (!pszNumThreads)
+        pszNumThreads = CPLGetConfigOption("VRT_NUM_THREADS", nullptr);
+    if (!pszNumThreads)
+        pszNumThreads = CPLGetConfigOption("GDAL_NUM_THREADS", "ALL_CPUS");
+    if (EQUAL(pszNumThreads, "0") || EQUAL(pszNumThreads, "1"))
+        return atoi(pszNumThreads);
+    const int nMaxPoolSize = GDALGetMaxDatasetPoolSize();
+    const int nLimit = std::min(CPLGetNumCPUs(), nMaxPoolSize);
+    if (EQUAL(pszNumThreads, "ALL_CPUS"))
+        return nLimit;
+    return std::min(atoi(pszNumThreads), nLimit);
+}
+
+/************************************************************************/
 /*                              IRasterIO()                             */
 /************************************************************************/
 
@@ -2209,6 +2249,8 @@ CPLErr VRTDataset::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
                              GSpacing nBandSpace,
                              GDALRasterIOExtraArg *psExtraArg)
 {
+    m_bMultiThreadedRasterIOLastUsed = false;
+
     if (nBands == 1 && nBandCount == 1)
     {
         VRTSourcedRasterBand *poBand =
@@ -2304,35 +2346,139 @@ CPLErr VRTDataset::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
         }
 
         CPLErr eErr = CE_None;
-        GDALProgressFunc pfnProgressGlobal = psExtraArg->pfnProgress;
-        void *pProgressDataGlobal = psExtraArg->pProgressData;
 
         // Use the last band, because when sources reference a GDALProxyDataset,
         // they don't necessary instantiate all underlying rasterbands.
         VRTSourcedRasterBand *poBand =
             static_cast<VRTSourcedRasterBand *>(papoBands[nBands - 1]);
-        for (int iSource = 0; eErr == CE_None && iSource < poBand->nSources;
-             iSource++)
+
+        double dfXOff = nXOff;
+        double dfYOff = nYOff;
+        double dfXSize = nXSize;
+        double dfYSize = nYSize;
+        if (psExtraArg->bFloatingPointWindowValidity)
         {
-            psExtraArg->pfnProgress = GDALScaledProgress;
-            psExtraArg->pProgressData = GDALCreateScaledProgress(
-                1.0 * iSource / poBand->nSources,
-                1.0 * (iSource + 1) / poBand->nSources, pfnProgressGlobal,
-                pProgressDataGlobal);
-
-            VRTSimpleSource *poSource =
-                static_cast<VRTSimpleSource *>(poBand->papoSources[iSource]);
-
-            eErr = poSource->DatasetRasterIO(
-                poBand->GetRasterDataType(), nXOff, nYOff, nXSize, nYSize,
-                pData, nBufXSize, nBufYSize, eBufType, nBandCount, panBandMap,
-                nPixelSpace, nLineSpace, nBandSpace, psExtraArg);
-
-            GDALDestroyScaledProgress(psExtraArg->pProgressData);
+            dfXOff = psExtraArg->dfXOff;
+            dfYOff = psExtraArg->dfYOff;
+            dfXSize = psExtraArg->dfXSize;
+            dfYSize = psExtraArg->dfYSize;
         }
 
-        psExtraArg->pfnProgress = pfnProgressGlobal;
-        psExtraArg->pProgressData = pProgressDataGlobal;
+        int nContributingSources = 0;
+        int nMaxThreads = 0;
+        constexpr int MINIMUM_PIXEL_COUNT_FOR_THREADED_IO = 1000 * 1000;
+        if ((static_cast<int64_t>(nBufXSize) * nBufYSize >=
+                 MINIMUM_PIXEL_COUNT_FOR_THREADED_IO ||
+             static_cast<int64_t>(nXSize) * nYSize >=
+                 MINIMUM_PIXEL_COUNT_FOR_THREADED_IO) &&
+            poBand->CanMultiThreadRasterIO(dfXOff, dfYOff, dfXSize, dfYSize,
+                                           nContributingSources) &&
+            nContributingSources > 1 &&
+            (nMaxThreads = VRTDataset::GetNumThreads(this)) > 1)
+        {
+            m_bMultiThreadedRasterIOLastUsed = true;
+            m_oMapSharedSources.InitMutex();
+
+            std::atomic<bool> bSuccess = true;
+            CPLWorkerThreadPool *psThreadPool = GDALGetGlobalThreadPool(
+                std::min(nContributingSources, nMaxThreads));
+
+            CPLDebugOnly(
+                "VRT",
+                "IRasterIO(): use optimized "
+                "multi-threaded code path for mosaic. "
+                "Using %d threads",
+                std::min(nContributingSources, psThreadPool->GetThreadCount()));
+
+            auto oQueue = psThreadPool->CreateJobQueue();
+            std::atomic<int> nCompletedJobs = 0;
+            for (int iSource = 0; iSource < poBand->nSources; iSource++)
+            {
+                auto poSource = poBand->papoSources[iSource];
+                if (!poSource->IsSimpleSource())
+                    continue;
+                auto poSimpleSource =
+                    cpl::down_cast<VRTSimpleSource *>(poSource);
+                if (poSimpleSource->DstWindowIntersects(dfXOff, dfYOff, dfXSize,
+                                                        dfYSize))
+                {
+                    auto psJob = new RasterIOJob();
+                    psJob->pbSuccess = &bSuccess;
+                    psJob->pnCompletedJobs = &nCompletedJobs;
+                    psJob->eVRTBandDataType = poBand->GetRasterDataType();
+                    psJob->nXOff = nXOff;
+                    psJob->nYOff = nYOff;
+                    psJob->nXSize = nXSize;
+                    psJob->nYSize = nYSize;
+                    psJob->pData = pData;
+                    psJob->nBufXSize = nBufXSize;
+                    psJob->nBufYSize = nBufYSize;
+                    psJob->eBufType = eBufType;
+                    psJob->nBandCount = nBandCount;
+                    psJob->panBandMap = panBandMap;
+                    psJob->nPixelSpace = nPixelSpace;
+                    psJob->nLineSpace = nLineSpace;
+                    psJob->nBandSpace = nBandSpace;
+                    psJob->psExtraArg = psExtraArg;
+                    psJob->poSource = poSimpleSource;
+
+                    if (!oQueue->SubmitJob(RasterIOJob::Func, psJob))
+                    {
+                        delete psJob;
+                        bSuccess = false;
+                        break;
+                    }
+                }
+            }
+
+            while (oQueue->WaitEvent())
+            {
+                // Quite rough progress callback. We could do better by counting
+                // the number of contributing pixels.
+                if (psExtraArg->pfnProgress)
+                {
+                    psExtraArg->pfnProgress(double(nCompletedJobs.load()) /
+                                                nContributingSources,
+                                            "", psExtraArg->pProgressData);
+                }
+            }
+
+            eErr = bSuccess ? CE_None : CE_Failure;
+        }
+        else
+        {
+            GDALProgressFunc pfnProgressGlobal = psExtraArg->pfnProgress;
+            void *pProgressDataGlobal = psExtraArg->pProgressData;
+
+            for (int iSource = 0; eErr == CE_None && iSource < poBand->nSources;
+                 iSource++)
+            {
+                psExtraArg->pfnProgress = GDALScaledProgress;
+                psExtraArg->pProgressData = GDALCreateScaledProgress(
+                    1.0 * iSource / poBand->nSources,
+                    1.0 * (iSource + 1) / poBand->nSources, pfnProgressGlobal,
+                    pProgressDataGlobal);
+
+                VRTSimpleSource *poSource = static_cast<VRTSimpleSource *>(
+                    poBand->papoSources[iSource]);
+
+                eErr = poSource->DatasetRasterIO(
+                    poBand->GetRasterDataType(), nXOff, nYOff, nXSize, nYSize,
+                    pData, nBufXSize, nBufYSize, eBufType, nBandCount,
+                    panBandMap, nPixelSpace, nLineSpace, nBandSpace,
+                    psExtraArg);
+
+                GDALDestroyScaledProgress(psExtraArg->pProgressData);
+            }
+
+            psExtraArg->pfnProgress = pfnProgressGlobal;
+            psExtraArg->pProgressData = pProgressDataGlobal;
+        }
+
+        if (eErr == CE_None && psExtraArg->pfnProgress)
+        {
+            psExtraArg->pfnProgress(1.0, "", psExtraArg->pProgressData);
+        }
 
         return eErr;
     }
@@ -2358,6 +2504,34 @@ CPLErr VRTDataset::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
                                       nLineSpace, nBandSpace, psExtraArg);
     }
     return eErr;
+}
+
+/************************************************************************/
+/*                    VRTDataset::RasterIOJob::Func()                   */
+/************************************************************************/
+
+void VRTDataset::RasterIOJob::Func(void *pData)
+{
+    auto psJob =
+        std::unique_ptr<RasterIOJob>(static_cast<RasterIOJob *>(pData));
+    if (*psJob->pbSuccess)
+    {
+        GDALRasterIOExtraArg sArg = *(psJob->psExtraArg);
+        sArg.pfnProgress = nullptr;
+        sArg.pProgressData = nullptr;
+
+        if (psJob->poSource->DatasetRasterIO(
+                psJob->eVRTBandDataType, psJob->nXOff, psJob->nYOff,
+                psJob->nXSize, psJob->nYSize, psJob->pData, psJob->nBufXSize,
+                psJob->nBufYSize, psJob->eBufType, psJob->nBandCount,
+                psJob->panBandMap, psJob->nPixelSpace, psJob->nLineSpace,
+                psJob->nBandSpace, &sArg) != CE_None)
+        {
+            *psJob->pbSuccess = false;
+        }
+    }
+
+    ++(*psJob->pnCompletedJobs);
 }
 
 /************************************************************************/

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -2030,7 +2030,7 @@ int VRTDataset::CheckCompatibleForDatasetIO()
 
                 VRTSimpleSource *poSource =
                     static_cast<VRTSimpleSource *>(papoSources[iSource]);
-                if (!EQUAL(poSource->GetType(), "SimpleSource"))
+                if (poSource->GetType() != VRTSimpleSource::GetTypeStatic())
                     return FALSE;
 
                 if (poSource->m_nBand != iBand + 1 ||
@@ -2054,7 +2054,7 @@ int VRTDataset::CheckCompatibleForDatasetIO()
 
                 VRTSimpleSource *poSource = static_cast<VRTSimpleSource *>(
                     poBand->papoSources[iSource]);
-                if (!EQUAL(poSource->GetType(), "SimpleSource"))
+                if (poSource->GetType() != VRTSimpleSource::GetTypeStatic())
                     return FALSE;
                 if (poSource->m_nBand != iBand + 1 ||
                     poSource->m_bGetMaskBand || poSource->m_osSrcDSName.empty())
@@ -2386,9 +2386,12 @@ static bool CheckBandForOverview(GDALRasterBand *poBand,
 
     VRTSimpleSource *poSource =
         cpl::down_cast<VRTSimpleSource *>(poVRTBand->papoSources[0]);
-    if (!EQUAL(poSource->GetType(), "SimpleSource") &&
-        !EQUAL(poSource->GetType(), "ComplexSource"))
+    const char *pszType = poSource->GetType();
+    if (pszType != VRTSimpleSource::GetTypeStatic() &&
+        pszType != VRTComplexSource::GetTypeStatic())
+    {
         return false;
+    }
     GDALRasterBand *poSrcBand = poBand->GetBand() == 0
                                     ? poSource->GetMaskBandMainBand()
                                     : poSource->GetRasterBand();
@@ -2515,12 +2518,13 @@ void VRTDataset::BuildVirtualOverviews()
             VRTSimpleSource *poSrcSource =
                 cpl::down_cast<VRTSimpleSource *>(poVRTBand->papoSources[0]);
             VRTSimpleSource *poNewSource = nullptr;
-            if (EQUAL(poSrcSource->GetType(), "SimpleSource"))
+            const char *pszType = poSrcSource->GetType();
+            if (pszType == VRTSimpleSource::GetTypeStatic())
             {
                 poNewSource =
                     new VRTSimpleSource(poSrcSource, dfXRatio, dfYRatio);
             }
-            else if (EQUAL(poSrcSource->GetType(), "ComplexSource"))
+            else if (pszType == VRTComplexSource::GetTypeStatic())
             {
                 poNewSource = new VRTComplexSource(
                     cpl::down_cast<VRTComplexSource *>(poSrcSource), dfXRatio,

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -2209,6 +2209,18 @@ CPLErr VRTDataset::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
                              GSpacing nBandSpace,
                              GDALRasterIOExtraArg *psExtraArg)
 {
+    if (nBands == 1 && nBandCount == 1)
+    {
+        VRTSourcedRasterBand *poBand =
+            dynamic_cast<VRTSourcedRasterBand *>(papoBands[0]);
+        if (poBand)
+        {
+            return poBand->IRasterIO(eRWFlag, nXOff, nYOff, nXSize, nYSize,
+                                     pData, nBufXSize, nBufYSize, eBufType,
+                                     nPixelSpace, nLineSpace, psExtraArg);
+        }
+    }
+
     bool bLocalCompatibleForDatasetIO =
         CPL_TO_BOOL(CheckCompatibleForDatasetIO());
     if (bLocalCompatibleForDatasetIO && eRWFlag == GF_Read &&

--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -265,8 +265,8 @@ class CPL_DLL VRTDataset CPL_NON_FINAL : public GDALDataset
 
     VRTRasterBand *m_poMaskBand = nullptr;
 
-    int m_bCompatibleForDatasetIO = -1;
-    int CheckCompatibleForDatasetIO();
+    mutable int m_nCompatibleForDatasetIO = -1;
+    bool CheckCompatibleForDatasetIO() const;
 
     // Virtual (ie not materialized) overviews, created either implicitly
     // when it is cheap to do it, or explicitly.
@@ -397,6 +397,12 @@ class CPL_DLL VRTDataset CPL_NON_FINAL : public GDALDataset
     std::shared_ptr<GDALGroup> GetRootGroup() const override;
 
     void ClearStatistics() override;
+
+    /** To be called when a new source is added, to invalidate cached states. */
+    void SourceAdded()
+    {
+        m_nCompatibleForDatasetIO = -1;
+    }
 
     /* Used by PDF driver for example */
     GDALDataset *GetSingleSimpleSource();
@@ -1404,7 +1410,7 @@ class CPL_DLL VRTSimpleSource CPL_NON_FINAL : public VRTSource
 
     GDALRasterBand *GetRasterBand() const;
     GDALRasterBand *GetMaskBandMainBand();
-    int IsSameExceptBandNumber(VRTSimpleSource *poOtherSource);
+    bool IsSameExceptBandNumber(const VRTSimpleSource *poOtherSource) const;
     CPLErr DatasetRasterIO(GDALDataType eVRTBandDataType, int nXOff, int nYOff,
                            int nXSize, int nYSize, void *pData, int nBufXSize,
                            int nBufYSize, GDALDataType eBufType, int nBandCount,

--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -1353,7 +1353,9 @@ class CPL_DLL VRTSimpleSource CPL_NON_FINAL : public VRTSource
     void SetSrcMaskBand(GDALRasterBand *);
     void SetSrcWindow(double, double, double, double);
     void SetDstWindow(double, double, double, double);
-    void GetDstWindow(double &, double &, double &, double &);
+    void GetDstWindow(double &, double &, double &, double &) const;
+    bool DstWindowIntersects(double dfXOff, double dfYOff, double dfXSize,
+                             double dfYSize) const;
 
     const std::string &GetSourceDatasetName() const
     {

--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -1236,15 +1236,21 @@ class CPL_DLL VRTSimpleSource CPL_NON_FINAL : public VRTSource
     int m_nBand = 0;
     bool m_bGetMaskBand = false;
 
-    double m_dfSrcXOff = 0;
-    double m_dfSrcYOff = 0;
-    double m_dfSrcXSize = 0;
-    double m_dfSrcYSize = 0;
+    /* Value for uninitialized source or destination window. It is chosen such
+     * that SrcToDst() and DstToSrc() are no-ops if both source and destination
+     * windows are unset.
+     */
+    static constexpr double UNINIT_WINDOW = -1.0;
 
-    double m_dfDstXOff = 0;
-    double m_dfDstYOff = 0;
-    double m_dfDstXSize = 0;
-    double m_dfDstYSize = 0;
+    double m_dfSrcXOff = UNINIT_WINDOW;
+    double m_dfSrcYOff = UNINIT_WINDOW;
+    double m_dfSrcXSize = UNINIT_WINDOW;
+    double m_dfSrcYSize = UNINIT_WINDOW;
+
+    double m_dfDstXOff = UNINIT_WINDOW;
+    double m_dfDstYOff = UNINIT_WINDOW;
+    double m_dfDstXSize = UNINIT_WINDOW;
+    double m_dfDstYSize = UNINIT_WINDOW;
 
     CPLString m_osResampling{};
 
@@ -1273,6 +1279,20 @@ class CPL_DLL VRTSimpleSource CPL_NON_FINAL : public VRTSource
     virtual bool ValidateOpenedBand(GDALRasterBand * /*poBand*/) const
     {
         return true;
+    }
+
+    /** Returns whether the source window is set */
+    bool IsSrcWinSet() const
+    {
+        return m_dfSrcXOff != UNINIT_WINDOW || m_dfSrcYOff != UNINIT_WINDOW ||
+               m_dfSrcXSize != UNINIT_WINDOW || m_dfSrcYSize != UNINIT_WINDOW;
+    }
+
+    /** Returns whether the destination window is set */
+    bool IsDstWinSet() const
+    {
+        return m_dfDstXOff != UNINIT_WINDOW || m_dfDstYOff != UNINIT_WINDOW ||
+               m_dfDstXSize != UNINIT_WINDOW || m_dfDstYSize != UNINIT_WINDOW;
     }
 
   public:

--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -165,10 +165,18 @@ class CPL_DLL VRTSource
     virtual void GetFileList(char ***ppapszFileList, int *pnSize,
                              int *pnMaxSize, CPLHashSet *hSetFiles);
 
-    virtual int IsSimpleSource()
+    /** Returns whether this instance can be cast to a VRTSimpleSource
+     * (and its subclasses).
+     */
+    virtual bool IsSimpleSource() const
     {
-        return FALSE;
+        return false;
     }
+
+    /** Returns a string with the VRTSource class type.
+     * This method must be implemented in all subclasses
+     */
+    virtual const char *GetType() const = 0;
 
     virtual CPLErr FlushCache(bool /*bAtClosing*/)
     {
@@ -1353,15 +1361,17 @@ class CPL_DLL VRTSimpleSource CPL_NON_FINAL : public VRTSource
     virtual void GetFileList(char ***ppapszFileList, int *pnSize,
                              int *pnMaxSize, CPLHashSet *hSetFiles) override;
 
-    virtual int IsSimpleSource() override
+    bool IsSimpleSource() const override
     {
-        return TRUE;
+        return true;
     }
 
-    virtual const char *GetType()
-    {
-        return "SimpleSource";
-    }
+    /** Returns the same value as GetType() called on objects that are exactly
+     * instances of VRTSimpleSource.
+     */
+    static const char *GetTypeStatic();
+
+    const char *GetType() const override;
 
     virtual CPLErr FlushCache(bool bAtClosing) override;
 
@@ -1415,10 +1425,12 @@ class VRTAveragedSource final : public VRTSimpleSource
 
     virtual CPLXMLNode *SerializeToXML(const char *pszVRTPath) override;
 
-    virtual const char *GetType() override
-    {
-        return "AveragedSource";
-    }
+    /** Returns the same value as GetType() called on objects that are exactly
+     * instances of VRTAveragedSource.
+     */
+    static const char *GetTypeStatic();
+
+    const char *GetType() const override;
 };
 
 /************************************************************************/
@@ -1460,10 +1472,12 @@ class VRTNoDataFromMaskSource final : public VRTSimpleSource
                            std::map<CPLString, GDALDataset *> &) override;
     virtual CPLXMLNode *SerializeToXML(const char *pszVRTPath) override;
 
-    virtual const char *GetType() override
-    {
-        return "VRTNoDataFromMaskSource";
-    }
+    /** Returns the same value as GetType() called on objects that are exactly
+     * instances of VRTNoDataFromMaskSource.
+     */
+    static const char *GetTypeStatic();
+
+    const char *GetType() const override;
 };
 
 /************************************************************************/
@@ -1552,10 +1566,12 @@ class CPL_DLL VRTComplexSource CPL_NON_FINAL : public VRTSimpleSource
     virtual CPLErr XMLInit(const CPLXMLNode *, const char *,
                            std::map<CPLString, GDALDataset *> &) override;
 
-    virtual const char *GetType() override
-    {
-        return "ComplexSource";
-    }
+    /** Returns the same value as GetType() called on objects that are exactly
+     * instances of VRTComplexSource.
+     */
+    static const char *GetTypeStatic();
+
+    const char *GetType() const override;
 
     bool AreValuesUnchanged() const;
 
@@ -1598,6 +1614,8 @@ class VRTFilteredSource CPL_NON_FINAL : public VRTComplexSource
     VRTFilteredSource();
     virtual ~VRTFilteredSource();
 
+    const char *GetType() const override = 0;
+
     void SetExtraEdgePixels(int);
     void SetFilteringDataTypesSupported(int, GDALDataType *);
 
@@ -1630,6 +1648,8 @@ class VRTKernelFilteredSource CPL_NON_FINAL : public VRTFilteredSource
   public:
     VRTKernelFilteredSource();
 
+    const char *GetType() const override;
+
     virtual CPLErr XMLInit(const CPLXMLNode *psTree, const char *,
                            std::map<CPLString, GDALDataset *> &) override;
     virtual CPLXMLNode *SerializeToXML(const char *pszVRTPath) override;
@@ -1653,6 +1673,8 @@ class VRTAverageFilteredSource final : public VRTKernelFilteredSource
   public:
     explicit VRTAverageFilteredSource(int nKernelSize);
     virtual ~VRTAverageFilteredSource();
+
+    const char *GetType() const override;
 
     virtual CPLErr XMLInit(const CPLXMLNode *psTree, const char *,
                            std::map<CPLString, GDALDataset *> &) override;
@@ -1692,6 +1714,8 @@ class VRTFuncSource final : public VRTSource
                                 GUIntBig *panHistogram, int bIncludeOutOfRange,
                                 int bApproxOK, GDALProgressFunc pfnProgress,
                                 void *pProgressData) override;
+
+    const char *GetType() const override;
 
     VRTImageReadFunc pfnReadFunc;
     void *pCBData;

--- a/frmts/vrt/vrtderivedrasterband.cpp
+++ b/frmts/vrt/vrtderivedrasterband.cpp
@@ -1416,9 +1416,9 @@ int VRTDerivedRasterBand::IGetDataCoverageStatus(
 /*                              XMLInit()                               */
 /************************************************************************/
 
-CPLErr VRTDerivedRasterBand::XMLInit(
-    const CPLXMLNode *psTree, const char *pszVRTPath,
-    std::map<CPLString, GDALDataset *> &oMapSharedSources)
+CPLErr VRTDerivedRasterBand::XMLInit(const CPLXMLNode *psTree,
+                                     const char *pszVRTPath,
+                                     VRTMapSharedResources &oMapSharedSources)
 
 {
     const CPLErr eErr =

--- a/frmts/vrt/vrtdriver.cpp
+++ b/frmts/vrt/vrtdriver.cpp
@@ -137,9 +137,9 @@ void VRTDriver::AddSourceParser(const char *pszElementName,
 /*                            ParseSource()                             */
 /************************************************************************/
 
-VRTSource *
-VRTDriver::ParseSource(const CPLXMLNode *psSrc, const char *pszVRTPath,
-                       std::map<CPLString, GDALDataset *> &oMapSharedSources)
+VRTSource *VRTDriver::ParseSource(const CPLXMLNode *psSrc,
+                                  const char *pszVRTPath,
+                                  VRTMapSharedResources &oMapSharedSources)
 
 {
 

--- a/frmts/vrt/vrtdriver.cpp
+++ b/frmts/vrt/vrtdriver.cpp
@@ -557,6 +557,9 @@ void GDALRegister_VRT()
         "relative paths inside the VRT. Mainly useful for inlined VRT, or "
         "in-memory "
         "VRT, where their own directory does not make sense'/>"
+        "<Option name='NUM_THREADS' type='string' description="
+        "'Number of worker threads for reading. Can be set to ALL_CPUS' "
+        "default='ALL_CPUS'/>"
         "</OpenOptionList>");
 
     poDriver->SetMetadataItem(GDAL_DCAP_VIRTUALIO, "YES");

--- a/frmts/vrt/vrtfilters.cpp
+++ b/frmts/vrt/vrtfilters.cpp
@@ -426,6 +426,16 @@ VRTKernelFilteredSource::VRTKernelFilteredSource()
 }
 
 /************************************************************************/
+/*                            GetType()                                 */
+/************************************************************************/
+
+const char *VRTKernelFilteredSource::GetType() const
+{
+    static const char *TYPE = "KernelFilteredSource";
+    return TYPE;
+}
+
+/************************************************************************/
 /*                           SetNormalized()                            */
 /************************************************************************/
 

--- a/frmts/vrt/vrtfilters.cpp
+++ b/frmts/vrt/vrtfilters.cpp
@@ -591,9 +591,10 @@ CPLErr VRTKernelFilteredSource::FilterData(int nXSize, int nYSize,
 /*                              XMLInit()                               */
 /************************************************************************/
 
-CPLErr VRTKernelFilteredSource::XMLInit(
-    const CPLXMLNode *psTree, const char *pszVRTPath,
-    std::map<CPLString, GDALDataset *> &oMapSharedSources)
+CPLErr
+VRTKernelFilteredSource::XMLInit(const CPLXMLNode *psTree,
+                                 const char *pszVRTPath,
+                                 VRTMapSharedResources &oMapSharedSources)
 
 {
     {
@@ -691,9 +692,9 @@ CPLXMLNode *VRTKernelFilteredSource::SerializeToXML(const char *pszVRTPath)
 /*                       VRTParseFilterSources()                        */
 /************************************************************************/
 
-VRTSource *
-VRTParseFilterSources(const CPLXMLNode *psChild, const char *pszVRTPath,
-                      std::map<CPLString, GDALDataset *> &oMapSharedSources)
+VRTSource *VRTParseFilterSources(const CPLXMLNode *psChild,
+                                 const char *pszVRTPath,
+                                 VRTMapSharedResources &oMapSharedSources)
 
 {
     if (EQUAL(psChild->pszValue, "KernelFilteredSource"))

--- a/frmts/vrt/vrtmultidim.cpp
+++ b/frmts/vrt/vrtmultidim.cpp
@@ -2626,6 +2626,11 @@ class VRTArraySource : public VRTSource
             bIncludeOutOfRange, bApproxOK, pfnProgress, pProgressData);
     }
 
+    const char *GetType() const override
+    {
+        return "ArraySource";
+    }
+
     CPLErr
     XMLInit(const CPLXMLNode *psTree, const char *pszVRTPath,
             std::map<CPLString, GDALDataset *> &oMapSharedSources) override;

--- a/frmts/vrt/vrtmultidim.cpp
+++ b/frmts/vrt/vrtmultidim.cpp
@@ -2631,9 +2631,8 @@ class VRTArraySource : public VRTSource
         return "ArraySource";
     }
 
-    CPLErr
-    XMLInit(const CPLXMLNode *psTree, const char *pszVRTPath,
-            std::map<CPLString, GDALDataset *> &oMapSharedSources) override;
+    CPLErr XMLInit(const CPLXMLNode *psTree, const char *pszVRTPath,
+                   VRTMapSharedResources &oMapSharedSources) override;
     CPLXMLNode *SerializeToXML(const char *pszVRTPath) override;
 };
 
@@ -2710,9 +2709,8 @@ ParseSingleSourceArray(const CPLXMLNode *psSingleSourceArray,
 /*                              XMLInit()                               */
 /************************************************************************/
 
-CPLErr VRTArraySource::XMLInit(
-    const CPLXMLNode *psTree, const char *pszVRTPath,
-    std::map<CPLString, GDALDataset *> & /*oMapSharedSources*/)
+CPLErr VRTArraySource::XMLInit(const CPLXMLNode *psTree, const char *pszVRTPath,
+                               VRTMapSharedResources & /*oMapSharedSources*/)
 {
     const auto poArray = ParseArray(psTree, pszVRTPath, "ArraySource");
     if (!poArray)
@@ -2982,9 +2980,9 @@ static std::shared_ptr<GDALMDArray> ParseArray(const CPLXMLNode *psTree,
 /*                       VRTParseArraySource()                          */
 /************************************************************************/
 
-VRTSource *
-VRTParseArraySource(const CPLXMLNode *psChild, const char *pszVRTPath,
-                    std::map<CPLString, GDALDataset *> &oMapSharedSources)
+VRTSource *VRTParseArraySource(const CPLXMLNode *psChild,
+                               const char *pszVRTPath,
+                               VRTMapSharedResources &oMapSharedSources)
 {
     VRTSource *poSource = nullptr;
 

--- a/frmts/vrt/vrtrasterband.cpp
+++ b/frmts/vrt/vrtrasterband.cpp
@@ -342,9 +342,8 @@ VRTParseColorTable(const CPLXMLNode *psColorTable)
 /*                              XMLInit()                               */
 /************************************************************************/
 
-CPLErr
-VRTRasterBand::XMLInit(const CPLXMLNode *psTree, const char *pszVRTPath,
-                       std::map<CPLString, GDALDataset *> &oMapSharedSources)
+CPLErr VRTRasterBand::XMLInit(const CPLXMLNode *psTree, const char *pszVRTPath,
+                              VRTMapSharedResources &oMapSharedSources)
 
 {
     /* -------------------------------------------------------------------- */

--- a/frmts/vrt/vrtrawrasterband.cpp
+++ b/frmts/vrt/vrtrawrasterband.cpp
@@ -343,9 +343,9 @@ CPLVirtualMem *VRTRawRasterBand::GetVirtualMemAuto(GDALRWFlag eRWFlag,
 /*                              XMLInit()                               */
 /************************************************************************/
 
-CPLErr
-VRTRawRasterBand::XMLInit(const CPLXMLNode *psTree, const char *pszVRTPath,
-                          std::map<CPLString, GDALDataset *> &oMapSharedSources)
+CPLErr VRTRawRasterBand::XMLInit(const CPLXMLNode *psTree,
+                                 const char *pszVRTPath,
+                                 VRTMapSharedResources &oMapSharedSources)
 
 {
     const CPLErr eErr =

--- a/frmts/vrt/vrtsourcedrasterband.cpp
+++ b/frmts/vrt/vrtsourcedrasterband.cpp
@@ -1766,7 +1766,9 @@ CPLErr VRTSourcedRasterBand::AddSource(VRTSource *poNewSource)
         CPLRealloc(papoSources, sizeof(void *) * nSources));
     papoSources[nSources - 1] = poNewSource;
 
-    static_cast<VRTDataset *>(poDS)->SetNeedsFlush();
+    auto l_poDS = static_cast<VRTDataset *>(poDS);
+    l_poDS->SetNeedsFlush();
+    l_poDS->SourceAdded();
 
     if (poNewSource->IsSimpleSource())
     {

--- a/frmts/vrt/vrtsourcedrasterband.cpp
+++ b/frmts/vrt/vrtsourcedrasterband.cpp
@@ -1812,9 +1812,9 @@ CPLErr CPL_STDCALL VRTAddSource(VRTSourcedRasterBandH hVRTBand,
 /*                              XMLInit()                               */
 /************************************************************************/
 
-CPLErr VRTSourcedRasterBand::XMLInit(
-    const CPLXMLNode *psTree, const char *pszVRTPath,
-    std::map<CPLString, GDALDataset *> &oMapSharedSources)
+CPLErr VRTSourcedRasterBand::XMLInit(const CPLXMLNode *psTree,
+                                     const char *pszVRTPath,
+                                     VRTMapSharedResources &oMapSharedSources)
 
 {
     {

--- a/frmts/vrt/vrtsourcedrasterband.cpp
+++ b/frmts/vrt/vrtsourcedrasterband.cpp
@@ -887,10 +887,7 @@ bool VRTSourcedRasterBand::
         sBounds.maxy = nOutYOff + nOutYSize - EPSILON;
 
         // Check that the new source doesn't overlap an existing one.
-        int nFeatureCount = 0;
-        void **pahRet = CPLQuadTreeSearch(hQuadTree, &sBounds, &nFeatureCount);
-        CPLFree(pahRet);
-        if (nFeatureCount != 0)
+        if (CPLQuadTreeHasMatch(hQuadTree, &sBounds))
         {
             bRet = false;
             break;

--- a/frmts/vrt/vrtsourcedrasterband.cpp
+++ b/frmts/vrt/vrtsourcedrasterband.cpp
@@ -816,11 +816,16 @@ bool VRTSourcedRasterBand::
         }
 
         auto poSimpleSource = cpl::down_cast<VRTSimpleSource *>(papoSources[i]);
-        auto poComplexSource = dynamic_cast<VRTComplexSource *>(papoSources[i]);
-        if (poComplexSource)
+        const char *pszType = poSimpleSource->GetType();
+        if (pszType == VRTSimpleSource::GetTypeStatic())
         {
-            if (!EQUAL(poComplexSource->GetType(), "ComplexSource") ||
-                !poComplexSource->AreValuesUnchanged())
+            // ok
+        }
+        else if (pszType == VRTComplexSource::GetTypeStatic())
+        {
+            auto poComplexSource =
+                cpl::down_cast<VRTComplexSource *>(papoSources[i]);
+            if (!poComplexSource->AreValuesUnchanged())
             {
                 bRet = false;
                 break;
@@ -828,11 +833,8 @@ bool VRTSourcedRasterBand::
         }
         else
         {
-            if (!EQUAL(poSimpleSource->GetType(), "SimpleSource"))
-            {
-                bRet = false;
-                break;
-            }
+            bRet = false;
+            break;
         }
 
         if (!bAllowMaxValAdjustment && poSimpleSource->NeedMaxValAdjustment())
@@ -1936,7 +1938,7 @@ bool VRTSourcedRasterBand::SkipBufferInitialization()
         return false;
     }
     VRTSimpleSource *poSS = static_cast<VRTSimpleSource *>(papoSources[0]);
-    if (strcmp(poSS->GetType(), "SimpleSource") == 0)
+    if (poSS->GetType() == VRTSimpleSource::GetTypeStatic())
     {
         auto l_poBand = poSS->GetRasterBand();
         if (l_poBand != nullptr && poSS->m_dfSrcXOff >= 0.0 &&

--- a/frmts/vrt/vrtsourcedrasterband.cpp
+++ b/frmts/vrt/vrtsourcedrasterband.cpp
@@ -240,6 +240,106 @@ bool VRTSourcedRasterBand::CanIRasterIOBeForwardedToEachSource(
 }
 
 /************************************************************************/
+/*                      CanMultiThreadRasterIO()                        */
+/************************************************************************/
+
+bool VRTSourcedRasterBand::CanMultiThreadRasterIO(
+    double dfXOff, double dfYOff, double dfXSize, double dfYSize,
+    int &nContributingSources) const
+{
+    int iLastSource = 0;
+    CPLRectObj sSourceBounds;
+    CPLQuadTree *hQuadTree = nullptr;
+    bool bRet = true;
+    std::set<std::string> oSetDSName;
+
+    nContributingSources = 0;
+    for (int iSource = 0; iSource < nSources; iSource++)
+    {
+        const auto poSource = papoSources[iSource];
+        if (!poSource->IsSimpleSource())
+        {
+            bRet = false;
+            break;
+        }
+        const auto poSimpleSource = cpl::down_cast<VRTSimpleSource *>(poSource);
+        if (poSimpleSource->DstWindowIntersects(dfXOff, dfYOff, dfXSize,
+                                                dfYSize))
+        {
+            // Only build hQuadTree if there are 2 or more sources
+            if (nContributingSources == 1)
+            {
+                std::string &oFirstSrcDSName =
+                    cpl::down_cast<VRTSimpleSource *>(papoSources[iLastSource])
+                        ->m_osSrcDSName;
+                oSetDSName.insert(oFirstSrcDSName);
+
+                CPLRectObj sGlobalBounds;
+                sGlobalBounds.minx = dfXOff;
+                sGlobalBounds.miny = dfYOff;
+                sGlobalBounds.maxx = dfXOff + dfXSize;
+                sGlobalBounds.maxy = dfYOff + dfYSize;
+                hQuadTree = CPLQuadTreeCreate(&sGlobalBounds, nullptr);
+
+                CPLQuadTreeInsertWithBounds(
+                    hQuadTree,
+                    reinterpret_cast<void *>(
+                        static_cast<uintptr_t>(iLastSource)),
+                    &sSourceBounds);
+            }
+
+            // Check there are not several sources with the same name, to avoid
+            // the same GDALDataset* to be used from multiple threads. We may
+            // be a bit too pessimistic, for example if working with unnamed
+            // Memory datasets, but that would involve comparing
+            // poSource->GetRasterBandNoOpen()->GetDataset()
+            if (oSetDSName.find(poSimpleSource->m_osSrcDSName) !=
+                oSetDSName.end())
+            {
+                bRet = false;
+                break;
+            }
+            oSetDSName.insert(poSimpleSource->m_osSrcDSName);
+
+            double dfSourceXOff;
+            double dfSourceYOff;
+            double dfSourceXSize;
+            double dfSourceYSize;
+            poSimpleSource->GetDstWindow(dfSourceXOff, dfSourceYOff,
+                                         dfSourceXSize, dfSourceYSize);
+            constexpr double EPSILON = 1e-1;
+            sSourceBounds.minx = dfSourceXOff + EPSILON;
+            sSourceBounds.miny = dfSourceYOff + EPSILON;
+            sSourceBounds.maxx = dfSourceXOff + dfSourceXSize - EPSILON;
+            sSourceBounds.maxy = dfSourceYOff + dfSourceYSize - EPSILON;
+            iLastSource = iSource;
+
+            if (hQuadTree)
+            {
+                // Check that the new source doesn't overlap an existing one.
+                if (CPLQuadTreeHasMatch(hQuadTree, &sSourceBounds))
+                {
+                    bRet = false;
+                    break;
+                }
+
+                CPLQuadTreeInsertWithBounds(
+                    hQuadTree,
+                    reinterpret_cast<void *>(static_cast<uintptr_t>(iSource)),
+                    &sSourceBounds);
+            }
+
+            ++nContributingSources;
+        }
+    }
+
+    if (hQuadTree)
+        CPLQuadTreeDestroy(hQuadTree);
+
+    return bRet;
+}
+
+/************************************************************************/
 /*                             IRasterIO()                              */
 /************************************************************************/
 
@@ -351,35 +451,195 @@ CPLErr VRTSourcedRasterBand::IRasterIO(
         }
     }
 
-    GDALProgressFunc const pfnProgressGlobal = psExtraArg->pfnProgress;
-    void *const pProgressDataGlobal = psExtraArg->pProgressData;
-
     /* -------------------------------------------------------------------- */
     /*      Overlay each source in turn over top this.                      */
     /* -------------------------------------------------------------------- */
     CPLErr eErr = CE_None;
-    VRTSource::WorkingState oWorkingState;
-    for (int iSource = 0; eErr == CE_None && iSource < nSources; iSource++)
+
+    double dfXOff = nXOff;
+    double dfYOff = nYOff;
+    double dfXSize = nXSize;
+    double dfYSize = nYSize;
+    if (psExtraArg->bFloatingPointWindowValidity)
     {
-        psExtraArg->pfnProgress = GDALScaledProgress;
-        psExtraArg->pProgressData = GDALCreateScaledProgress(
-            1.0 * iSource / nSources, 1.0 * (iSource + 1) / nSources,
-            pfnProgressGlobal, pProgressDataGlobal);
-        if (psExtraArg->pProgressData == nullptr)
-            psExtraArg->pfnProgress = nullptr;
-
-        eErr = papoSources[iSource]->RasterIO(
-            eDataType, nXOff, nYOff, nXSize, nYSize, pData, nBufXSize,
-            nBufYSize, eBufType, nPixelSpace, nLineSpace, psExtraArg,
-            l_poDS ? l_poDS->m_oWorkingState : oWorkingState);
-
-        GDALDestroyScaledProgress(psExtraArg->pProgressData);
+        dfXOff = psExtraArg->dfXOff;
+        dfYOff = psExtraArg->dfYOff;
+        dfXSize = psExtraArg->dfXSize;
+        dfYSize = psExtraArg->dfYSize;
     }
 
-    psExtraArg->pfnProgress = pfnProgressGlobal;
-    psExtraArg->pProgressData = pProgressDataGlobal;
+    if (l_poDS)
+        l_poDS->m_bMultiThreadedRasterIOLastUsed = false;
+
+    int nContributingSources = 0;
+    int nMaxThreads = 0;
+    constexpr int MINIMUM_PIXEL_COUNT_FOR_THREADED_IO = 1000 * 1000;
+    if (l_poDS &&
+        (static_cast<int64_t>(nBufXSize) * nBufYSize >=
+             MINIMUM_PIXEL_COUNT_FOR_THREADED_IO ||
+         static_cast<int64_t>(nXSize) * nYSize >=
+             MINIMUM_PIXEL_COUNT_FOR_THREADED_IO) &&
+        CanMultiThreadRasterIO(dfXOff, dfYOff, dfXSize, dfYSize,
+                               nContributingSources) &&
+        nContributingSources > 1 &&
+        (nMaxThreads = VRTDataset::GetNumThreads(l_poDS)) > 1)
+    {
+        l_poDS->m_bMultiThreadedRasterIOLastUsed = true;
+        l_poDS->m_oMapSharedSources.InitMutex();
+
+        std::atomic<bool> bSuccess = true;
+        CPLWorkerThreadPool *psThreadPool = GDALGetGlobalThreadPool(
+            std::min(nContributingSources, nMaxThreads));
+        const int nThreads =
+            std::min(nContributingSources, psThreadPool->GetThreadCount());
+        CPLDebugOnly("VRT",
+                     "IRasterIO(): use optimized "
+                     "multi-threaded code path for mosaic. "
+                     "Using %d threads",
+                     nThreads);
+
+        {
+            std::lock_guard oLock(l_poDS->m_oQueueWorkingStates.oMutex);
+            if (l_poDS->m_oQueueWorkingStates.oStates.size() <
+                static_cast<size_t>(nThreads))
+            {
+                l_poDS->m_oQueueWorkingStates.oStates.resize(nThreads);
+            }
+            for (int i = 0; i < nThreads; ++i)
+            {
+                if (!l_poDS->m_oQueueWorkingStates.oStates[i])
+                    l_poDS->m_oQueueWorkingStates.oStates[i] =
+                        std::make_unique<VRTSource::WorkingState>();
+            }
+        }
+
+        auto oQueue = psThreadPool->CreateJobQueue();
+        std::atomic<int> nCompletedJobs = 0;
+        for (int iSource = 0; iSource < nSources; iSource++)
+        {
+            auto poSource = papoSources[iSource];
+            if (!poSource->IsSimpleSource())
+                continue;
+            auto poSimpleSource = cpl::down_cast<VRTSimpleSource *>(poSource);
+            if (poSimpleSource->DstWindowIntersects(dfXOff, dfYOff, dfXSize,
+                                                    dfYSize))
+            {
+                auto psJob = new RasterIOJob();
+                psJob->pbSuccess = &bSuccess;
+                psJob->pnCompletedJobs = &nCompletedJobs;
+                psJob->poQueueWorkingStates = &(l_poDS->m_oQueueWorkingStates);
+                psJob->eVRTBandDataType = eDataType;
+                psJob->nXOff = nXOff;
+                psJob->nYOff = nYOff;
+                psJob->nXSize = nXSize;
+                psJob->nYSize = nYSize;
+                psJob->pData = pData;
+                psJob->nBufXSize = nBufXSize;
+                psJob->nBufYSize = nBufYSize;
+                psJob->eBufType = eBufType;
+                psJob->nPixelSpace = nPixelSpace;
+                psJob->nLineSpace = nLineSpace;
+                psJob->psExtraArg = psExtraArg;
+                psJob->poSource = poSimpleSource;
+
+                if (!oQueue->SubmitJob(RasterIOJob::Func, psJob))
+                {
+                    delete psJob;
+                    bSuccess = false;
+                    break;
+                }
+            }
+        }
+
+        while (oQueue->WaitEvent())
+        {
+            // Quite rough progress callback. We could do better by counting
+            // the number of contributing pixels.
+            if (psExtraArg->pfnProgress)
+            {
+                psExtraArg->pfnProgress(double(nCompletedJobs.load()) /
+                                            nContributingSources,
+                                        "", psExtraArg->pProgressData);
+            }
+        }
+
+        eErr = bSuccess ? CE_None : CE_Failure;
+    }
+    else
+    {
+        GDALProgressFunc const pfnProgressGlobal = psExtraArg->pfnProgress;
+        void *const pProgressDataGlobal = psExtraArg->pProgressData;
+
+        VRTSource::WorkingState oWorkingState;
+        for (int iSource = 0; eErr == CE_None && iSource < nSources; iSource++)
+        {
+            psExtraArg->pfnProgress = GDALScaledProgress;
+            psExtraArg->pProgressData = GDALCreateScaledProgress(
+                1.0 * iSource / nSources, 1.0 * (iSource + 1) / nSources,
+                pfnProgressGlobal, pProgressDataGlobal);
+            if (psExtraArg->pProgressData == nullptr)
+                psExtraArg->pfnProgress = nullptr;
+
+            eErr = papoSources[iSource]->RasterIO(
+                eDataType, nXOff, nYOff, nXSize, nYSize, pData, nBufXSize,
+                nBufYSize, eBufType, nPixelSpace, nLineSpace, psExtraArg,
+                l_poDS ? l_poDS->m_oWorkingState : oWorkingState);
+
+            GDALDestroyScaledProgress(psExtraArg->pProgressData);
+        }
+
+        psExtraArg->pfnProgress = pfnProgressGlobal;
+        psExtraArg->pProgressData = pProgressDataGlobal;
+    }
+
+    if (eErr == CE_None && psExtraArg->pfnProgress)
+    {
+        psExtraArg->pfnProgress(1.0, "", psExtraArg->pProgressData);
+    }
 
     return eErr;
+}
+
+/************************************************************************/
+/*                 VRTSourcedRasterBand::RasterIOJob::Func()            */
+/************************************************************************/
+
+void VRTSourcedRasterBand::RasterIOJob::Func(void *pData)
+{
+    auto psJob =
+        std::unique_ptr<RasterIOJob>(static_cast<RasterIOJob *>(pData));
+    if (*psJob->pbSuccess)
+    {
+        GDALRasterIOExtraArg sArg = *(psJob->psExtraArg);
+        sArg.pfnProgress = nullptr;
+        sArg.pProgressData = nullptr;
+
+        std::unique_ptr<VRTSource::WorkingState> poWorkingState;
+        {
+            std::lock_guard oLock(psJob->poQueueWorkingStates->oMutex);
+            poWorkingState =
+                std::move(psJob->poQueueWorkingStates->oStates.back());
+            psJob->poQueueWorkingStates->oStates.pop_back();
+            CPLAssert(poWorkingState.get());
+        }
+
+        if (psJob->poSource->RasterIO(
+                psJob->eVRTBandDataType, psJob->nXOff, psJob->nYOff,
+                psJob->nXSize, psJob->nYSize, psJob->pData, psJob->nBufXSize,
+                psJob->nBufYSize, psJob->eBufType, psJob->nPixelSpace,
+                psJob->nLineSpace, &sArg, *(poWorkingState.get())) != CE_None)
+        {
+            *psJob->pbSuccess = false;
+        }
+
+        {
+            std::lock_guard oLock(psJob->poQueueWorkingStates->oMutex);
+            psJob->poQueueWorkingStates->oStates.push_back(
+                std::move(poWorkingState));
+        }
+    }
+
+    ++(*psJob->pnCompletedJobs);
 }
 
 /************************************************************************/

--- a/frmts/vrt/vrtsources.cpp
+++ b/frmts/vrt/vrtsources.cpp
@@ -1304,6 +1304,11 @@ CPLErr VRTSimpleSource::RasterIO(GDALDataType eVRTBandDataType, int nXOff,
     psExtraArg->dfYOff = dfReqYOff;
     psExtraArg->dfXSize = dfReqXSize;
     psExtraArg->dfYSize = dfReqYSize;
+    if (psExtraArgIn)
+    {
+        psExtraArg->pfnProgress = psExtraArgIn->pfnProgress;
+        psExtraArg->pProgressData = psExtraArgIn->pProgressData;
+    }
 
     GByte *pabyOut = static_cast<unsigned char *>(pData) +
                      nOutXOff * nPixelSpace +
@@ -1364,6 +1369,9 @@ CPLErr VRTSimpleSource::RasterIO(GDALDataType eVRTBandDataType, int nXOff,
             }
         }
     }
+
+    if (psExtraArg->pfnProgress)
+        psExtraArg->pfnProgress(1.0, "", psExtraArg->pProgressData);
 
     return eErr;
 }
@@ -1577,6 +1585,11 @@ CPLErr VRTSimpleSource::DatasetRasterIO(
     psExtraArg->dfYOff = dfReqYOff;
     psExtraArg->dfXSize = dfReqXSize;
     psExtraArg->dfYSize = dfReqYSize;
+    if (psExtraArgIn)
+    {
+        psExtraArg->pfnProgress = psExtraArgIn->pfnProgress;
+        psExtraArg->pProgressData = psExtraArgIn->pProgressData;
+    }
 
     GByte *pabyOut = static_cast<unsigned char *>(pData) +
                      nOutXOff * nPixelSpace +
@@ -1651,6 +1664,9 @@ CPLErr VRTSimpleSource::DatasetRasterIO(
             }
         }
     }
+
+    if (psExtraArg->pfnProgress)
+        psExtraArg->pfnProgress(1.0, "", psExtraArg->pProgressData);
 
     return eErr;
 }
@@ -1819,6 +1835,11 @@ CPLErr VRTAveragedSource::RasterIO(GDALDataType /*eVRTBandDataType*/, int nXOff,
     psExtraArg->dfYOff = dfReqYOff;
     psExtraArg->dfXSize = dfReqXSize;
     psExtraArg->dfYSize = dfReqYSize;
+    if (psExtraArgIn)
+    {
+        psExtraArg->pfnProgress = psExtraArgIn->pfnProgress;
+        psExtraArg->pProgressData = psExtraArgIn->pProgressData;
+    }
 
     const CPLErr eErr = l_band->RasterIO(
         GF_Read, nReqXOff, nReqYOff, nReqXSize, nReqYSize, pafSrc, nReqXSize,
@@ -1933,6 +1954,9 @@ CPLErr VRTAveragedSource::RasterIO(GDALDataType /*eVRTBandDataType*/, int nXOff,
     }
 
     VSIFree(pafSrc);
+
+    if (psExtraArg->pfnProgress)
+        psExtraArg->pfnProgress(1.0, "", psExtraArg->pProgressData);
 
     return CE_None;
 }
@@ -2287,6 +2311,11 @@ CPLErr VRTNoDataFromMaskSource::RasterIO(
     psExtraArg->dfYOff = dfReqYOff;
     psExtraArg->dfXSize = dfReqXSize;
     psExtraArg->dfYSize = dfReqYSize;
+    if (psExtraArgIn)
+    {
+        psExtraArg->pfnProgress = psExtraArgIn->pfnProgress;
+        psExtraArg->pProgressData = psExtraArgIn->pProgressData;
+    }
 
     if (l_band->RasterIO(GF_Read, nReqXOff, nReqYOff, nReqXSize, nReqYSize,
                          pabyWrkBuffer, nOutXSize, nOutYSize, eSrcBandDT, 0, 0,
@@ -2402,6 +2431,9 @@ CPLErr VRTNoDataFromMaskSource::RasterIO(
             }
         }
     }
+
+    if (psExtraArg->pfnProgress)
+        psExtraArg->pfnProgress(1.0, "", psExtraArg->pProgressData);
 
     return CE_None;
 }
@@ -2926,6 +2958,11 @@ CPLErr VRTComplexSource::RasterIO(GDALDataType eVRTBandDataType, int nXOff,
     psExtraArg->dfYOff = dfReqYOff;
     psExtraArg->dfXSize = dfReqXSize;
     psExtraArg->dfYSize = dfReqYSize;
+    if (psExtraArgIn)
+    {
+        psExtraArg->pfnProgress = psExtraArgIn->pfnProgress;
+        psExtraArg->pProgressData = psExtraArgIn->pProgressData;
+    }
 
     GByte *const pabyOut = static_cast<GByte *>(pData) +
                            nPixelSpace * nOutXOff +
@@ -3003,6 +3040,9 @@ CPLErr VRTComplexSource::RasterIO(GDALDataType eVRTBandDataType, int nXOff,
             nLineSpace, psExtraArg, bIsComplex ? GDT_CFloat32 : GDT_Float32,
             oWorkingState);
     }
+
+    if (psExtraArg->pfnProgress)
+        psExtraArg->pfnProgress(1.0, "", psExtraArg->pProgressData);
 
     return eErr;
 }

--- a/frmts/vrt/vrtsources.cpp
+++ b/frmts/vrt/vrtsources.cpp
@@ -150,6 +150,25 @@ VRTSimpleSource::~VRTSimpleSource()
 }
 
 /************************************************************************/
+/*                           GetTypeStatic()                            */
+/************************************************************************/
+
+const char *VRTSimpleSource::GetTypeStatic()
+{
+    static const char *TYPE = "SimpleSource";
+    return TYPE;
+}
+
+/************************************************************************/
+/*                            GetType()                                 */
+/************************************************************************/
+
+const char *VRTSimpleSource::GetType() const
+{
+    return GetTypeStatic();
+}
+
+/************************************************************************/
 /*                           FlushCache()                               */
 /************************************************************************/
 
@@ -297,7 +316,7 @@ CPLXMLNode *VRTSimpleSource::SerializeToXML(const char *pszVRTPath)
 
 {
     CPLXMLNode *const psSrc =
-        CPLCreateXMLNode(nullptr, CXT_Element, "SimpleSource");
+        CPLCreateXMLNode(nullptr, CXT_Element, GetTypeStatic());
 
     if (!m_osResampling.empty())
     {
@@ -1478,7 +1497,7 @@ CPLErr VRTSimpleSource::DatasetRasterIO(
     GSpacing nLineSpace, GSpacing nBandSpace,
     GDALRasterIOExtraArg *psExtraArgIn)
 {
-    if (!EQUAL(GetType(), "SimpleSource"))
+    if (GetType() != VRTSimpleSource::GetTypeStatic())
     {
         CPLError(CE_Failure, CPLE_NotSupported,
                  "DatasetRasterIO() not implemented for %s", GetType());
@@ -1649,6 +1668,25 @@ VRTAveragedSource::VRTAveragedSource()
 }
 
 /************************************************************************/
+/*                           GetTypeStatic()                            */
+/************************************************************************/
+
+const char *VRTAveragedSource::GetTypeStatic()
+{
+    static const char *TYPE = "AveragedSource";
+    return TYPE;
+}
+
+/************************************************************************/
+/*                            GetType()                                 */
+/************************************************************************/
+
+const char *VRTAveragedSource::GetType() const
+{
+    return GetTypeStatic();
+}
+
+/************************************************************************/
 /*                           SerializeToXML()                           */
 /************************************************************************/
 
@@ -1661,7 +1699,7 @@ CPLXMLNode *VRTAveragedSource::SerializeToXML(const char *pszVRTPath)
         return nullptr;
 
     CPLFree(psSrc->pszValue);
-    psSrc->pszValue = CPLStrdup("AveragedSource");
+    psSrc->pszValue = CPLStrdup(GetTypeStatic());
 
     return psSrc;
 }
@@ -1976,6 +2014,25 @@ CPLErr VRTNoDataFromMaskSource::XMLInit(
 }
 
 /************************************************************************/
+/*                           GetTypeStatic()                            */
+/************************************************************************/
+
+const char *VRTNoDataFromMaskSource::GetTypeStatic()
+{
+    static const char *TYPE = "NoDataFromMaskSource";
+    return TYPE;
+}
+
+/************************************************************************/
+/*                            GetType()                                 */
+/************************************************************************/
+
+const char *VRTNoDataFromMaskSource::GetType() const
+{
+    return GetTypeStatic();
+}
+
+/************************************************************************/
 /*                           SerializeToXML()                           */
 /************************************************************************/
 
@@ -1988,7 +2045,7 @@ CPLXMLNode *VRTNoDataFromMaskSource::SerializeToXML(const char *pszVRTPath)
         return nullptr;
 
     CPLFree(psSrc->pszValue);
-    psSrc->pszValue = CPLStrdup("NoDataFromMaskSource");
+    psSrc->pszValue = CPLStrdup(GetTypeStatic());
 
     if (m_bNoDataSet)
     {
@@ -2401,6 +2458,25 @@ VRTComplexSource::VRTComplexSource(const VRTComplexSource *poSrcSource,
 }
 
 /************************************************************************/
+/*                           GetTypeStatic()                            */
+/************************************************************************/
+
+const char *VRTComplexSource::GetTypeStatic()
+{
+    static const char *TYPE = "ComplexSource";
+    return TYPE;
+}
+
+/************************************************************************/
+/*                            GetType()                                 */
+/************************************************************************/
+
+const char *VRTComplexSource::GetType() const
+{
+    return GetTypeStatic();
+}
+
+/************************************************************************/
 /*                           SetNoDataValue()                           */
 /************************************************************************/
 
@@ -2448,7 +2524,7 @@ CPLXMLNode *VRTComplexSource::SerializeToXML(const char *pszVRTPath)
         return nullptr;
 
     CPLFree(psSrc->pszValue);
-    psSrc->pszValue = CPLStrdup("ComplexSource");
+    psSrc->pszValue = CPLStrdup(GetTypeStatic());
 
     if ((m_nProcessingFlags & PROCESSING_FLAG_USE_MASK_BAND) != 0)
     {
@@ -3517,6 +3593,16 @@ VRTFuncSource::~VRTFuncSource()
 }
 
 /************************************************************************/
+/*                            GetType()                                 */
+/************************************************************************/
+
+const char *VRTFuncSource::GetType() const
+{
+    static const char *TYPE = "FuncSource";
+    return TYPE;
+}
+
+/************************************************************************/
 /*                           SerializeToXML()                           */
 /************************************************************************/
 
@@ -3604,22 +3690,22 @@ VRTParseCoreSources(const CPLXMLNode *psChild, const char *pszVRTPath,
 {
     VRTSource *poSource = nullptr;
 
-    if (EQUAL(psChild->pszValue, "AveragedSource") ||
-        (EQUAL(psChild->pszValue, "SimpleSource") &&
+    if (EQUAL(psChild->pszValue, VRTAveragedSource::GetTypeStatic()) ||
+        (EQUAL(psChild->pszValue, VRTSimpleSource::GetTypeStatic()) &&
          STARTS_WITH_CI(CPLGetXMLValue(psChild, "Resampling", "Nearest"),
                         "Aver")))
     {
         poSource = new VRTAveragedSource();
     }
-    else if (EQUAL(psChild->pszValue, "SimpleSource"))
+    else if (EQUAL(psChild->pszValue, VRTSimpleSource::GetTypeStatic()))
     {
         poSource = new VRTSimpleSource();
     }
-    else if (EQUAL(psChild->pszValue, "ComplexSource"))
+    else if (EQUAL(psChild->pszValue, VRTComplexSource::GetTypeStatic()))
     {
         poSource = new VRTComplexSource();
     }
-    else if (EQUAL(psChild->pszValue, "NoDataFromMaskSource"))
+    else if (EQUAL(psChild->pszValue, VRTNoDataFromMaskSource::GetTypeStatic()))
     {
         poSource = new VRTNoDataFromMaskSource();
     }

--- a/frmts/vrt/vrtsources.cpp
+++ b/frmts/vrt/vrtsources.cpp
@@ -292,12 +292,24 @@ void VRTSimpleSource::SetDstWindow(double dfNewXOff, double dfNewYOff,
 /************************************************************************/
 
 void VRTSimpleSource::GetDstWindow(double &dfDstXOff, double &dfDstYOff,
-                                   double &dfDstXSize, double &dfDstYSize)
+                                   double &dfDstXSize, double &dfDstYSize) const
 {
     dfDstXOff = m_dfDstXOff;
     dfDstYOff = m_dfDstYOff;
     dfDstXSize = m_dfDstXSize;
     dfDstYSize = m_dfDstYSize;
+}
+
+/************************************************************************/
+/*                        DstWindowIntersects()                         */
+/************************************************************************/
+
+bool VRTSimpleSource::DstWindowIntersects(double dfXOff, double dfYOff,
+                                          double dfXSize, double dfYSize) const
+{
+    return IsDstWinSet() && m_dfDstXOff + m_dfDstXSize > dfXOff &&
+           m_dfDstYOff + m_dfDstYSize > dfYOff &&
+           m_dfDstXOff < dfXOff + dfXSize && m_dfDstYOff < dfYOff + dfYSize;
 }
 
 /************************************************************************/

--- a/frmts/vrt/vrtsources.cpp
+++ b/frmts/vrt/vrtsources.cpp
@@ -520,9 +520,8 @@ CPLXMLNode *VRTSimpleSource::SerializeToXML(const char *pszVRTPath)
 /*                              XMLInit()                               */
 /************************************************************************/
 
-CPLErr
-VRTSimpleSource::XMLInit(const CPLXMLNode *psSrc, const char *pszVRTPath,
-                         std::map<CPLString, GDALDataset *> &oMapSharedSources)
+CPLErr VRTSimpleSource::XMLInit(const CPLXMLNode *psSrc, const char *pszVRTPath,
+                                VRTMapSharedResources &oMapSharedSources)
 
 {
     m_poMapSharedSources = &oMapSharedSources;
@@ -733,9 +732,8 @@ void VRTSimpleSource::OpenSource() const
             osKeyMapSharedSources += m_aosOpenOptions[i];
         }
 
-        auto oIter = m_poMapSharedSources->find(osKeyMapSharedSources);
-        if (oIter != m_poMapSharedSources->end())
-            proxyDS = cpl::down_cast<GDALProxyPoolDataset *>(oIter->second);
+        proxyDS = cpl::down_cast<GDALProxyPoolDataset *>(
+            m_poMapSharedSources->Get(osKeyMapSharedSources));
     }
 
     if (proxyDS == nullptr)
@@ -788,7 +786,7 @@ void VRTSimpleSource::OpenSource() const
 
     if (m_poMapSharedSources)
     {
-        (*m_poMapSharedSources)[osKeyMapSharedSources] = proxyDS;
+        m_poMapSharedSources->Insert(osKeyMapSharedSources, proxyDS);
     }
 }
 
@@ -1979,9 +1977,10 @@ VRTNoDataFromMaskSource::VRTNoDataFromMaskSource()
 /*                              XMLInit()                               */
 /************************************************************************/
 
-CPLErr VRTNoDataFromMaskSource::XMLInit(
-    const CPLXMLNode *psSrc, const char *pszVRTPath,
-    std::map<CPLString, GDALDataset *> &oMapSharedSources)
+CPLErr
+VRTNoDataFromMaskSource::XMLInit(const CPLXMLNode *psSrc,
+                                 const char *pszVRTPath,
+                                 VRTMapSharedResources &oMapSharedSources)
 
 {
     /* -------------------------------------------------------------------- */
@@ -2628,9 +2627,9 @@ CPLXMLNode *VRTComplexSource::SerializeToXML(const char *pszVRTPath)
 /*                              XMLInit()                               */
 /************************************************************************/
 
-CPLErr
-VRTComplexSource::XMLInit(const CPLXMLNode *psSrc, const char *pszVRTPath,
-                          std::map<CPLString, GDALDataset *> &oMapSharedSources)
+CPLErr VRTComplexSource::XMLInit(const CPLXMLNode *psSrc,
+                                 const char *pszVRTPath,
+                                 VRTMapSharedResources &oMapSharedSources)
 
 {
     /* -------------------------------------------------------------------- */
@@ -3683,9 +3682,9 @@ CPLErr VRTFuncSource::GetHistogram(
 /*                        VRTParseCoreSources()                         */
 /************************************************************************/
 
-VRTSource *
-VRTParseCoreSources(const CPLXMLNode *psChild, const char *pszVRTPath,
-                    std::map<CPLString, GDALDataset *> &oMapSharedSources)
+VRTSource *VRTParseCoreSources(const CPLXMLNode *psChild,
+                               const char *pszVRTPath,
+                               VRTMapSharedResources &oMapSharedSources)
 
 {
     VRTSource *poSource = nullptr;

--- a/frmts/vrt/vrtsources.cpp
+++ b/frmts/vrt/vrtsources.cpp
@@ -816,7 +816,8 @@ GDALRasterBand *VRTSimpleSource::GetMaskBandMainBand()
 /*                       IsSameExceptBandNumber()                       */
 /************************************************************************/
 
-int VRTSimpleSource::IsSameExceptBandNumber(VRTSimpleSource *poOtherSource)
+bool VRTSimpleSource::IsSameExceptBandNumber(
+    const VRTSimpleSource *poOtherSource) const
 {
     return m_dfSrcXOff == poOtherSource->m_dfSrcXOff &&
            m_dfSrcYOff == poOtherSource->m_dfSrcYOff &&

--- a/gcore/gdal_proxy.h
+++ b/gcore/gdal_proxy.h
@@ -450,6 +450,8 @@ void CPL_DLL GDALProxyPoolDatasetAddSrcBandDescription(
     GDALProxyPoolDatasetH hProxyPoolDataset, GDALDataType eDataType,
     int nBlockXSize, int nBlockYSize);
 
+int CPL_DLL GDALGetMaxDatasetPoolSize(void);
+
 CPL_C_END
 
 #endif /* #ifndef DOXYGEN_SKIP */

--- a/port/cpl_quad_tree.h
+++ b/port/cpl_quad_tree.h
@@ -102,6 +102,9 @@ void CPL_DLL CPLQuadTreeRemove(CPLQuadTree *hQuadtree, void *hFeature,
 void CPL_DLL **CPLQuadTreeSearch(const CPLQuadTree *hQuadtree,
                                  const CPLRectObj *pAoi, int *pnFeatureCount);
 
+bool CPL_DLL CPLQuadTreeHasMatch(const CPLQuadTree *hQuadtree,
+                                 const CPLRectObj *pAoi);
+
 void CPL_DLL CPLQuadTreeForeach(const CPLQuadTree *hQuadtree,
                                 CPLQuadTreeForeachFunc pfnForeach,
                                 void *pUserData);

--- a/port/cpl_worker_thread_pool.cpp
+++ b/port/cpl_worker_thread_pool.cpp
@@ -726,3 +726,22 @@ void CPLJobQueue::WaitCompletion(int nMaxRemainingJobs)
         m_cv.wait(oGuard);
     }
 }
+
+/************************************************************************/
+/*                             WaitEvent()                              */
+/************************************************************************/
+
+/** Wait for completion for at least one job.
+ *
+ * @return true if there are remaining jobs.
+ */
+bool CPLJobQueue::WaitEvent()
+{
+    std::unique_lock<std::mutex> oGuard(m_mutex);
+    // coverity[missing_lock:FALSE]
+    if (m_nPendingJobs > 0)
+    {
+        m_cv.wait(oGuard);
+    }
+    return m_nPendingJobs > 0;
+}

--- a/port/cpl_worker_thread_pool.h
+++ b/port/cpl_worker_thread_pool.h
@@ -144,6 +144,7 @@ class CPL_DLL CPLJobQueue
 
     bool SubmitJob(CPLThreadFunc pfnFunc, void *pData);
     void WaitCompletion(int nMaxRemainingJobs = 0);
+    bool WaitEvent();
 };
 
 #endif  // CPL_WORKER_THREAD_POOL_H_INCLUDED_


### PR DESCRIPTION
```rst

Starting with GDAL 3.10, the :oo:`NUM_THREADS` open option can
be set to control specifically the multi-threading of VRT datasets.
It defaults to ``ALL_CPUS``, and when set, overrides :config:`GDAL_NUM_THREADS`
or :config:`VRT_NUM_THREADS`. It applies to
ComputeStatistics() and band-level and dataset-level RasterIO().
For band-level RasterIO(), multi-threading is only available if more than 1
million pixels are requested and if the VRT is made of only non-overlapping
SimpleSource or ComplexSource belonging to different datasets.
For dataset-level RasterIO(), multi-threading is only available if more than 1
million pixels are requested and if the VRT is made of only non-overlapping
SimpleSource belonging to different datasets.

-  .. oo:: NUM_THREADS
      :choices: integer, ALL_CPUS
      :default: ALL_CPUS

      Determines the number of threads used when an operation reads from
      multiple sources.

This can also be specified globally with the :config:`VRT_NUM_THREADS`
configuration option.

-  .. config:: VRT_NUM_THREADS
      :choices: integer, ALL_CPUS
      :default: ALL_CPUS

      Determines the number of threads used when an operation reads from
      multiple sources.
```

On a 32,768 x 16,384 mosaic made of 2048 tiles of size 512x512,

```
$ time VRT_NUM_THREADS=1 python -c "from osgeo import gdal; ds = gdal.Open('in_rgb.vrt'); ds.ReadRaster()"
real	0m5,803s
user	0m4,671s
sys	0m1,128s

$ time VRT_NUM_THREADS=12 python -c "from osgeo import gdal; ds = gdal.Open('in_rgb.vrt'); ds.ReadRaster()"
real	0m1,871s
user	0m10,508s
sys	0m1,875s
```