### PR TITLE
Fix partially the problem with server paths on OAPIF driver

### DIFF
--- a/ogr/ogrsf_frmts/wfs/ogroapifdriver.cpp
+++ b/ogr/ogrsf_frmts/wfs/ogroapifdriver.cpp
@@ -293,8 +293,13 @@ CPLString OGROAPIFDataset::ReinjectAuthInURL(const CPLString &osURL) const
     CPLString osRet(osURL);
 
     if (!osRet.empty() && osRet[0] == '/')
-        osRet = m_osRootURL + osRet;
+    {
 
+        std::string tmp = m_osRootURL;
+        int thirdSlash = tmp.find('/', 8);
+        tmp.resize(thirdSlash);
+        osRet = tmp + osRet;
+    }
     const auto nArobaseInURLPos = m_osRootURL.find('@');
     if (!osRet.empty() && STARTS_WITH(m_osRootURL, "https://") &&
         STARTS_WITH(osRet, "https://") &&


### PR DESCRIPTION
There is an issue supporting server paths that contain relative links. This is described here: 
https://github.com/OSGeo/gdal/issues/10410

This PR  addresses relative paths beginning with /, but OGR should also handle paths starting with ./ and ../../ , so more work needs to be done.