### PR TITLE
OGCAPI: do not emit 'Server does not support specified IMAGE_FORMAT: AUTO' when opening a vector layer with MVT tiles only

### DIFF
--- a/frmts/ogcapi/gdalogcapidataset.cpp
+++ b/frmts/ogcapi/gdalogcapidataset.cpp
@@ -1163,9 +1163,12 @@ SelectImageURL(const char *const *papszOptionOptions,
         }
     }
 
-    CPLError(CE_Failure, CPLE_AppDefined,
-             "Server does not support specified IMAGE_FORMAT: %s",
-             osFormat.c_str());
+    if (osFormat != "AUTO")
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Server does not support specified IMAGE_FORMAT: %s",
+                 osFormat.c_str());
+    }
     return std::pair<std::string, CPLString>();
 }
 


### PR DESCRIPTION
Avoids error message on
```ogrinfo OGCAPI:https://demo.ldproxy.net/daraa/collections/AeronauticCrv```
