### PR TITLE
[Backport release/3.9] gdal_retile: error out with clear message when trying to retile a file with a geotransform with rotation terms

### DIFF
--- a/autotest/pyscripts/test_gdal_retile.py
+++ b/autotest/pyscripts/test_gdal_retile.py
@@ -28,6 +28,7 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
+import glob
 import os
 
 import pytest
@@ -438,3 +439,81 @@ def test_gdal_retile_png(script_path, tmp_path):
         assert ds.GetRasterBand(1).Checksum() == 4672
 
     assert os.path.exists(out_dir / "byte_1_1.png.aux.xml")
+
+
+###############################################################################
+# Test gdal_retile on a input file with a geotransform with rotational terms
+# (unsupported)
+
+
+def test_gdal_retile_rotational_geotransform(script_path, tmp_path):
+
+    src_filename = str(tmp_path / "in.tif")
+    ds = gdal.GetDriverByName("GTiff").Create(src_filename, 2, 2)
+    ds.SetGeoTransform([2, 0.1, 0.001, 49, -0.01, -0.1])
+    ds.Close()
+
+    out_dir = tmp_path / "outretile"
+    out_dir.mkdir()
+
+    _, err = test_py_scripts.run_py_script(
+        script_path,
+        "gdal_retile",
+        "-ps 1 1 -targetDir " + '"' + str(out_dir) + '"' + " " + src_filename,
+        return_stderr=True,
+    )
+    assert "has a geotransform matrix with rotational terms" in err
+    assert len(glob.glob(os.path.join(str(out_dir), "*.tif"))) == 0
+
+
+###############################################################################
+# Test gdal_retile on input files with different projections
+# (unsupported)
+
+
+@pytest.mark.parametrize(
+    "srs1,srs2,expected_err",
+    [
+        (32631, 32632, "has a SRS different from other tiles"),
+        (32631, None, "has no SRS whether other tiles have one"),
+        (None, 32631, "has a SRS whether other tiles do not"),
+    ],
+)
+def test_gdal_retile_different_srs(script_path, tmp_path, srs1, srs2, expected_err):
+
+    src_filename1 = str(tmp_path / "in1.tif")
+    ds = gdal.GetDriverByName("GTiff").Create(src_filename1, 2, 2)
+    ds.SetGeoTransform([2, 0.1, 0, 49, 0, -0.1])
+    if srs1:
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(srs1)
+        ds.SetSpatialRef(srs)
+    ds.Close()
+
+    src_filename2 = str(tmp_path / "in2.tif")
+    ds = gdal.GetDriverByName("GTiff").Create(src_filename2, 2, 2)
+    ds.SetGeoTransform([2, 0.1, 0, 49, 0, -0.1])
+    if srs2:
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(srs2)
+        ds.SetSpatialRef(srs)
+    ds.Close()
+
+    out_dir = tmp_path / "outretile"
+    out_dir.mkdir()
+
+    _, err = test_py_scripts.run_py_script(
+        script_path,
+        "gdal_retile",
+        "-ps 1 1 -targetDir "
+        + '"'
+        + str(out_dir)
+        + '"'
+        + " "
+        + src_filename1
+        + " "
+        + src_filename2,
+        return_stderr=True,
+    )
+    assert expected_err in err
+    assert len(glob.glob(os.path.join(str(out_dir), "*.tif"))) == 0

--- a/doc/source/programs/gdal_retile.rst
+++ b/doc/source/programs/gdal_retile.rst
@@ -33,6 +33,7 @@ Description
 
 This utility will retile a set of input tile(s). All the input tile(s) must
 be georeferenced in the same coordinate system and have a matching number of bands.
+The geotransform matrix of input tiles must not contain rotation terms.
 
 Optionally pyramid levels are generated. All pyramid levels are generated from the
 input tiles (not from previous levels).


### PR DESCRIPTION
Backport #10399
 **Authored by:** @rouault