### PR TITLE
OGR SQL: do not make backslash a special character inside single-quoted strings, to improve compliance wih SQL92

### DIFF
--- a/autotest/ogr/ogr_sql_test.py
+++ b/autotest/ogr/ogr_sql_test.py
@@ -1206,11 +1206,11 @@ def test_ogr_sql_42(data_ds):
 
 def test_ogr_sql_43(data_ds):
 
-    sql = "SELECT '\"' as a, '\\'' as b, '''' as c FROM poly"
+    sql = "SELECT '\"' as a, '\\' as b, '''' as c FROM poly"
     with data_ds.ExecuteSQL(sql) as sql_lyr:
         feat = sql_lyr.GetNextFeature()
         assert feat["a"] == '"'
-        assert feat["b"] == "'"
+        assert feat["b"] == "\\"
         assert feat["c"] == "'"
 
 

--- a/ci/travis/osx/before_install.sh
+++ b/ci/travis/osx/before_install.sh
@@ -7,6 +7,6 @@ conda install -y compilers automake pkgconfig cmake
 
 conda config --set channel_priority strict
 conda install --yes --quiet proj python=3.12 swig lxml jsonschema numpy
-conda install --yes --quiet --only-deps libgdal libgdal-arrow-parquet
-# Remove libgdal as above installation of libgdal-arrow-parquet installed it
-conda remove --yes libgdal
+conda install --yes --quiet libgdal libgdal-arrow-parquet
+# Now remove all libgdal* packages, but not their dependencies
+conda remove --yes --force $(conda list libgdal | grep libgdal | awk '{print $1}')

--- a/ogr/swq.cpp
+++ b/ogr/swq.cpp
@@ -118,11 +118,14 @@ int swqlex(YYSTYPE *ppNode, swq_parse_context *context)
 
         while (*pszInput != '\0')
         {
-            if (chQuote == '"' && *pszInput == '\\' && pszInput[1] == '"')
+            // Not totally sure we need to preserve this way of escaping for
+            // strings between double-quotes
+            if (chQuote == '"' && *pszInput == '\\')
+            {
                 pszInput++;
-            else if (chQuote == '\'' && *pszInput == '\\' &&
-                     pszInput[1] == '\'')
-                pszInput++;
+                if (*pszInput == '\0')
+                    break;
+            }
             else if (chQuote == '\'' && *pszInput == '\'' &&
                      pszInput[1] == '\'')
                 pszInput++;


### PR DESCRIPTION
The backslash followed by single-quote sequence was dealt as a way of
escaping the single-quote character, but this also prevented to use
backslash at the end of a single-quoted literal. So no longer make
backslash a special character inside single-quoted strings
    
Fixes #10416
