### PR TITLE
[Doc] better formatting for Open Options in XYZ raster driver

### DIFF
--- a/doc/source/drivers/raster/xyz.rst
+++ b/doc/source/drivers/raster/xyz.rst
@@ -53,15 +53,17 @@ Open options
 |about-open-options|
 This driver supports the following open options:
 
-.. oo:: COLUMN_ORDER
-   :choices: AUTO, XYZ, YXZ
-   :since: 3.10
-   :default: AUTO
+-  .. oo:: COLUMN_ORDER
+     :choices: AUTO, XYZ, YXZ
+     :since: 3.10
+     :default: AUTO
 
-   Specifies the order of the columns. It overrides the header.
+     Specifies the order of the columns. It overrides the header.
 
 Creation options
 ----------------
+
+|about-creation-options|
 
 -  .. co:: COLUMN_SEPARATOR
       :choices: <string>

--- a/doc/source/drivers/raster/xyz.rst
+++ b/doc/source/drivers/raster/xyz.rst
@@ -64,6 +64,7 @@ Creation options
 ----------------
 
 |about-creation-options|
+This driver supports the following creation options:
 
 -  .. co:: COLUMN_SEPARATOR
       :choices: <string>


### PR DESCRIPTION
## What does this PR do?
Improves XYZ driver doc formatting for new Open Options

## What are related issues/pull requests?
In #10339 the Open Options were not clearly marked with bullets. This PR fixes that.
It also adds the `|about-creation-options|` paragraph to be consistent.