### PR TITLE
CI: fix issue with build-linux-ubuntu-focal and setuptools 71.0.1

### DIFF
--- a/.github/workflows/cmake_builds.yml
+++ b/.github/workflows/cmake_builds.yml
@@ -94,7 +94,7 @@ jobs:
         # Workaround bug in ogdi packaging
         sudo ln -s /usr/lib/ogdi/libvrf.so /usr/lib
         #
-        python3 -m pip install -U pip wheel setuptools numpy
+        python3 -m pip install -U pip wheel setuptools numpy importlib_metadata
         python3 -m pip install -r $GITHUB_WORKSPACE/autotest/requirements.txt
 
     - name: Build libjxl


### PR DESCRIPTION
Fixes following error:
```
Traceback (most recent call last):
  File "/home/runner/work/gdal/gdal/superbuild/build/gdal/swig/python/setup.py", line 15, in <module>
    from setuptools.command.build_ext import build_ext
  File "/home/runner/.local/lib/python3.8/site-packages/setuptools/__init__.py", line 19, in <module>
    from .dist import Distribution
  File "/home/runner/.local/lib/python3.8/site-packages/setuptools/dist.py", line 30, in <module>
    from . import _entry_points
  File "/home/runner/.local/lib/python3.8/site-packages/setuptools/_entry_points.py", line 44, in <module>
    def validate(eps: metadata.EntryPoints):
AttributeError: module 'importlib_metadata' has no attribute 'EntryPoints'
CMake Error at build_ext.cmake:5 (message):
  setup.py bdist_wheel failed
```

Likely related to similar https://github.com/pypa/setuptools/issues/4482
