### PR TITLE
Arrow/Parquet/generic arrow: add write support for arrow.json extension

### DIFF
--- a/autotest/ogr/ogr_parquet.py
+++ b/autotest/ogr/ogr_parquet.py
@@ -4045,6 +4045,30 @@ def test_ogr_parquet_read_arrow_json_extension():
 
 
 ###############################################################################
+# Test writing a file with the arrow.json extension
+
+
+def test_ogr_parquet_writing_arrow_json_extension(tmp_vsimem):
+
+    outfilename = str(tmp_vsimem / "out.parquet")
+    with ogr.GetDriverByName("Parquet").CreateDataSource(outfilename) as ds:
+        lyr = ds.CreateLayer("test")
+        fld_defn = ogr.FieldDefn("extension_json")
+        fld_defn.SetSubType(ogr.OFSTJSON)
+        lyr.CreateField(fld_defn)
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f["extension_json"] = '{"foo":"bar"}'
+        lyr.CreateFeature(f)
+
+    with gdal.config_option("OGR_PARQUET_READ_GDAL_SCHEMA", "NO"):
+        ds = ogr.Open(outfilename)
+    lyr = ds.GetLayer(0)
+    assert lyr.GetLayerDefn().GetFieldDefn(0).GetSubType() == ogr.OFSTJSON
+    f = lyr.GetNextFeature()
+    assert f["extension_json"] == '{"foo":"bar"}'
+
+
+###############################################################################
 # Test ignored fields with arrow::dataset and bounding box column
 
 

--- a/ogr/ogrsf_frmts/arrow/ogrfeatherlayer.cpp
+++ b/ogr/ogrsf_frmts/arrow/ogrfeatherlayer.cpp
@@ -175,7 +175,7 @@ void OGRFeatherLayer::EstablishFeatureDefn()
         if (field_kv_metadata)
         {
             auto extension_name =
-                field_kv_metadata->Get("ARROW:extension:name");
+                field_kv_metadata->Get(ARROW_EXTENSION_NAME_KEY);
             if (extension_name.ok())
             {
                 osExtensionName = *extension_name;

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
@@ -304,16 +304,13 @@ inline bool OGRArrowLayer::MapArrowTypeToOGR(
     }
     else if (const auto &field_kv_metadata = field->metadata())
     {
-        auto extension_name = field_kv_metadata->Get("ARROW:extension:name");
+        auto extension_name = field_kv_metadata->Get(ARROW_EXTENSION_NAME_KEY);
         if (extension_name.ok())
         {
             osExtensionName = *extension_name;
         }
     }
 
-    // Preliminary/in-advance read support for future JSON Canonical Extension
-    // Cf https://github.com/apache/arrow/pull/41257 and
-    // https://github.com/apache/arrow/pull/13901
     if (!osExtensionName.empty() &&
         osExtensionName != EXTENSION_NAME_ARROW_JSON)
     {

--- a/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
@@ -212,7 +212,7 @@ bool OGRParquetLayerBase::DealWithGeometryColumn(
     std::string osExtensionName;
     if (field_kv_metadata)
     {
-        auto extension_name = field_kv_metadata->Get("ARROW:extension:name");
+        auto extension_name = field_kv_metadata->Get(ARROW_EXTENSION_NAME_KEY);
         if (extension_name.ok())
         {
             osExtensionName = *extension_name;


### PR DESCRIPTION
Read support was added in 3.9.0 per 21c06b9d486. Now that the arrow.json canonical extension has been made official, also implement it on the write side: i.e. in the CreateField() method of the Arrow/Parquet drivers, and in OGRLayer::GetArrowSchema() when generating a Arrow schema from a OGR layer definition.
