### PR TITLE
Add a cpl::contains(container, value) helper

### DIFF
--- a/gcore/gdaldataset.cpp
+++ b/gcore/gdaldataset.cpp
@@ -3232,7 +3232,7 @@ char **GDALDataset::GetFileList()
     const GDALAntiRecursionStruct::DatasetContext datasetCtxt(osMainFilename, 0,
                                                               std::string());
     auto &aosDatasetList = sAntiRecursion.aosDatasetNamesWithFlags;
-    if (aosDatasetList.find(datasetCtxt) != aosDatasetList.end())
+    if (cpl::contains(aosDatasetList, datasetCtxt))
         return nullptr;
 
     /* -------------------------------------------------------------------- */
@@ -3626,8 +3626,7 @@ GDALDatasetH CPL_STDCALL GDALOpenEx(const char *pszFilename,
         osAllowedDrivers += pszDriverName;
     auto dsCtxt = GDALAntiRecursionStruct::DatasetContext(
         std::string(pszFilename), nOpenFlags, osAllowedDrivers);
-    if (sAntiRecursion.aosDatasetNamesWithFlags.find(dsCtxt) !=
-        sAntiRecursion.aosDatasetNamesWithFlags.end())
+    if (cpl::contains(sAntiRecursion.aosDatasetNamesWithFlags, dsCtxt))
     {
         CPLError(CE_Failure, CPLE_AppDefined,
                  "GDALOpen() called on %s recursively", pszFilename);

--- a/gcore/gdaldriver.cpp
+++ b/gcore/gdaldriver.cpp
@@ -1063,8 +1063,7 @@ CPLErr GDALDriver::QuietDeleteForCreateCopy(const char *pszFilename,
                 {
                     CPLString osFilename(pszFileInList);
                     osFilename.replaceAll('\\', '/');
-                    if (oSetExistingDestFiles.find(osFilename) !=
-                        oSetExistingDestFiles.end())
+                    if (cpl::contains(oSetExistingDestFiles, osFilename))
                     {
                         oSetExistingDestFilesFoundInSource.insert(osFilename);
                     }
@@ -1078,8 +1077,8 @@ CPLErr GDALDriver::QuietDeleteForCreateCopy(const char *pszFilename,
         {
             for (const std::string &osFilename : oSetExistingDestFiles)
             {
-                if (oSetExistingDestFilesFoundInSource.find(osFilename) ==
-                    oSetExistingDestFilesFoundInSource.end())
+                if (!cpl::contains(oSetExistingDestFilesFoundInSource,
+                                   osFilename))
                 {
                     VSIUnlink(osFilename.c_str());
                 }

--- a/gcore/gdaldrivermanager.cpp
+++ b/gcore/gdaldrivermanager.cpp
@@ -527,8 +527,7 @@ int GDALDriverManager::RegisterDriver(GDALDriver *poDriver, bool bHidden)
 
     if (m_bInDeferredDriverLoading)
     {
-        if (m_oMapRealDrivers.find(poDriver->GetDescription()) !=
-            m_oMapRealDrivers.end())
+        if (cpl::contains(m_oMapRealDrivers, poDriver->GetDescription()))
         {
             CPLError(
                 CE_Failure, CPLE_AppDefined,
@@ -1032,8 +1031,7 @@ void GDALDriverManager::AutoLoadDrivers()
                 continue;
             }
 
-            if (m_oSetPluginFileNames.find(papszFiles[iFile]) !=
-                m_oSetPluginFileNames.end())
+            if (cpl::contains(m_oSetPluginFileNames, papszFiles[iFile]))
             {
                 continue;
             }
@@ -1157,14 +1155,12 @@ void GDALDriverManager::ReorderDrivers()
         {
             CPLString osUCDriverName(pszLine);
             osUCDriverName.toupper();
-            if (oSetOrderedDrivers.find(osUCDriverName) !=
-                oSetOrderedDrivers.end())
+            if (cpl::contains(oSetOrderedDrivers, osUCDriverName))
             {
                 CPLError(CE_Warning, CPLE_AppDefined,
                          "Duplicated name %s in [order] section", pszLine);
             }
-            else if (oMapNameToDrivers.find(osUCDriverName) !=
-                     oMapNameToDrivers.end())
+            else if (cpl::contains(oMapNameToDrivers, osUCDriverName))
             {
                 aosOrderedDrivers.emplace_back(pszLine);
                 oSetOrderedDrivers.insert(osUCDriverName);
@@ -1189,8 +1185,7 @@ void GDALDriverManager::ReorderDrivers()
     for (int i = 0; i < nDrivers; ++i)
     {
         const char *pszName = papoDrivers[i]->GetDescription();
-        if (oSetOrderedDrivers.find(CPLString(pszName).toupper()) ==
-            oSetOrderedDrivers.end())
+        if (!cpl::contains(oSetOrderedDrivers, CPLString(pszName).toupper()))
         {
             // Could happen for a private plugin
             CPLDebug("GDAL",
@@ -1342,7 +1337,7 @@ const char *GDALPluginDriverProxy::GetMetadataItem(const char *pszName,
             }
             return pszValue;
         }
-        else if (m_oSetMetadataItems.find(pszName) != m_oSetMetadataItems.end())
+        else if (cpl::contains(m_oSetMetadataItems, pszName))
         {
             return GDALDriver::GetMetadataItem(pszName, pszDomain);
         }

--- a/gcore/gdaljp2metadata.cpp
+++ b/gcore/gdaljp2metadata.cpp
@@ -185,10 +185,8 @@ int GDALJP2Metadata::ReadAndParse(VSILFILE *fpLL, int nGEOJP2Index,
         aoSetPriorities.insert(nGMLJP2Index);
     if (nMSIGIndex >= 0)
         aoSetPriorities.insert(nMSIGIndex);
-    std::set<int>::iterator oIter = aoSetPriorities.begin();
-    for (; oIter != aoSetPriorities.end(); ++oIter)
+    for (const int nIndex : aoSetPriorities)
     {
-        int nIndex = *oIter;
         if ((nIndex == nGEOJP2Index && ParseJP2GeoTIFF()) ||
             (nIndex == nGMLJP2Index && ParseGMLCoverageDesc()) ||
             (nIndex == nMSIGIndex && ParseMSIG()))

--- a/gcore/gdalmultidim.cpp
+++ b/gcore/gdalmultidim.cpp
@@ -892,8 +892,8 @@ bool GDALGroup::CopyFrom(const std::shared_ptr<GDALGroup> &poDstRootGroup,
                                                          '_' + dim->GetName());
                             newDimName = newDimNamePrefix;
                             int nIterCount = 2;
-                            while (mapExistingDstDims.find(newDimName) !=
-                                   mapExistingDstDims.end())
+                            while (
+                                cpl::contains(mapExistingDstDims, newDimName))
                             {
                                 newDimName = newDimNamePrefix +
                                              CPLSPrintf("_%d", nIterCount);
@@ -1148,9 +1148,8 @@ bool GDALGroup::CopyFrom(const std::shared_ptr<GDALGroup> &poDstRootGroup,
             auto srcArray = poSrcGroup->OpenMDArray(name);
             EXIT_OR_CONTINUE_IF_NULL(srcArray);
 
-            const auto oIterDimName =
-                mapSrcVariableNameToIndexedDimName.find(srcArray->GetName());
-            if (oIterDimName != mapSrcVariableNameToIndexedDimName.end())
+            if (cpl::contains(mapSrcVariableNameToIndexedDimName,
+                              srcArray->GetName()))
             {
                 if (!CopyArray(srcArray))
                     return false;
@@ -1163,9 +1162,8 @@ bool GDALGroup::CopyFrom(const std::shared_ptr<GDALGroup> &poDstRootGroup,
             auto srcArray = poSrcGroup->OpenMDArray(name);
             EXIT_OR_CONTINUE_IF_NULL(srcArray);
 
-            const auto oIterDimName =
-                mapSrcVariableNameToIndexedDimName.find(srcArray->GetName());
-            if (oIterDimName == mapSrcVariableNameToIndexedDimName.end())
+            if (!cpl::contains(mapSrcVariableNameToIndexedDimName,
+                               srcArray->GetName()))
             {
                 if (!CopyArray(srcArray))
                     return false;
@@ -1308,8 +1306,8 @@ GDALGroup::ResolveMDArray(const std::string &osName,
                 GetInnerMostGroup(osPath, curGroupHolder, osLastPart);
             if (poGroupPtr)
                 poGroup = poGroupPtr->OpenGroup(osLastPart);
-            if (poGroup && oSetAlreadyVisited.find(poGroup->GetFullName()) ==
-                               oSetAlreadyVisited.end())
+            if (poGroup &&
+                !cpl::contains(oSetAlreadyVisited, poGroup->GetFullName()))
             {
                 oQueue.push(poGroup);
                 goOn = true;
@@ -1340,9 +1338,8 @@ GDALGroup::ResolveMDArray(const std::string &osName,
                 for (const auto &osGroupName : aosGroupNames)
                 {
                     auto poSubGroup = groupPtr->OpenGroup(osGroupName);
-                    if (poSubGroup &&
-                        oSetAlreadyVisited.find(poSubGroup->GetFullName()) ==
-                            oSetAlreadyVisited.end())
+                    if (poSubGroup && !cpl::contains(oSetAlreadyVisited,
+                                                     poSubGroup->GetFullName()))
                     {
                         oQueue.push(poSubGroup);
                         oSetAlreadyVisited.insert(poSubGroup->GetFullName());

--- a/port/cpl_port.h
+++ b/port/cpl_port.h
@@ -1161,6 +1161,14 @@ extern "C++"
     {
         return t;
     }
+
+    /** Emulates the C++20 .contains() method */
+    template <typename C, typename V>
+    inline bool contains(const C &container, const V &value)
+    {
+        return container.count(value) != 0;
+    }
+
     }  // namespace cpl
 }
 #endif


### PR DESCRIPTION
and use it in gcore

@dbaston Thoughts?   I'm quite tired of writing code like ``container.find(key) != containers.end()``. As of C++17, we could use ``container.count(key)``, as the closest alternative to C++20 ``container.contains(key)``, but using count() might complicate future modernization when we bump to C++20.  This ``cpl::contains(container, value)`` should be easily greppable to automate a change to ``container.contains(value)``