### PR TITLE
GTI driver fixes

### DIFF
--- a/autotest/gdrivers/gti.py
+++ b/autotest/gdrivers/gti.py
@@ -48,14 +48,19 @@ def create_basic_tileindex(
     sort_field_name=None,
     sort_field_type=None,
     sort_values=None,
+    lyr_name="index",
+    add_to_existing=False,
 ):
     if isinstance(src_ds, list):
         src_ds_list = src_ds
     else:
         src_ds_list = [src_ds]
-    index_ds = ogr.GetDriverByName("GPKG").CreateDataSource(index_filename)
+    if add_to_existing:
+        index_ds = ogr.Open(index_filename, update=1)
+    else:
+        index_ds = ogr.GetDriverByName("GPKG").CreateDataSource(index_filename)
     lyr = index_ds.CreateLayer(
-        "index", srs=(src_ds_list[0].GetSpatialRef() if src_ds_list else None)
+        lyr_name, srs=(src_ds_list[0].GetSpatialRef() if src_ds_list else None)
     )
     lyr.CreateField(ogr.FieldDefn(location_field_name))
     if sort_values:
@@ -2312,7 +2317,10 @@ def test_gti_xml(tmp_vsimem):
 
     index_filename = str(tmp_vsimem / "index.gti.gpkg")
 
-    src_ds = gdal.Open(os.path.join(os.getcwd(), "data", "byte.tif"))
+    tile_filename = str(tmp_vsimem / "byte.tif")
+    gdal.Translate(tile_filename, "data/byte.tif")
+
+    src_ds = gdal.Open(tile_filename)
     index_ds, _ = create_basic_tileindex(index_filename, src_ds)
     del index_ds
 
@@ -2437,30 +2445,46 @@ def test_gti_xml(tmp_vsimem):
     assert vrt_ds.GetRasterBand(1).GetOverview(0).XSize == 10
     del vrt_ds
 
+    tile_ovr_filename = str(tmp_vsimem / "byte_ovr.tif")
+    gdal.Translate(tile_ovr_filename, "data/byte.tif", width=10)
+
+    index2_filename = str(tmp_vsimem / "index2.gti.gpkg")
+    create_basic_tileindex(index2_filename, gdal.Open(tile_ovr_filename))
+
     xml_content = f"""<GDALTileIndexDataset>
   <IndexDataset>{index_filename}</IndexDataset>
+  <IndexLayer>index</IndexLayer>
       <Overview>
-          <Dataset>{index_filename}</Dataset>
+          <Dataset>{index2_filename}</Dataset>
       </Overview>
 </GDALTileIndexDataset>"""
     vrt_ds = gdal.Open(xml_content)
     assert vrt_ds.GetRasterBand(1).GetOverviewCount() == 1
-    assert vrt_ds.GetRasterBand(1).GetOverview(0).XSize == 20
+    assert vrt_ds.GetRasterBand(1).GetOverview(0).XSize == 10
     del vrt_ds
+
+    create_basic_tileindex(
+        index_filename,
+        gdal.Open(tile_ovr_filename),
+        add_to_existing=True,
+        lyr_name="index_ovr",
+    )
 
     xml_content = f"""<GDALTileIndexDataset>
   <IndexDataset>{index_filename}</IndexDataset>
+  <IndexLayer>index</IndexLayer>
       <Overview>
-          <Layer>index</Layer>
+          <Layer>index_ovr</Layer>
       </Overview>
 </GDALTileIndexDataset>"""
     vrt_ds = gdal.Open(xml_content)
     assert vrt_ds.GetRasterBand(1).GetOverviewCount() == 1
-    assert vrt_ds.GetRasterBand(1).GetOverview(0).XSize == 20
+    assert vrt_ds.GetRasterBand(1).GetOverview(0).XSize == 10
     del vrt_ds
 
     xml_content = f"""<GDALTileIndexDataset>
   <IndexDataset>{index_filename}</IndexDataset>
+  <IndexLayer>index</IndexLayer>
       <Overview>
           <Layer>index</Layer>
           <OpenOptions>
@@ -2523,6 +2547,7 @@ def test_gti_xml(tmp_vsimem):
 
     xml_content = f"""<GDALTileIndexDataset>
   <IndexDataset>{index_filename}</IndexDataset>
+  <IndexLayer>index</IndexLayer>
       <Overview>
       </Overview>
 </GDALTileIndexDataset>"""
@@ -2534,6 +2559,7 @@ def test_gti_xml(tmp_vsimem):
 
     xml_content = f"""<GDALTileIndexDataset>
   <IndexDataset>{index_filename}</IndexDataset>
+  <IndexLayer>index</IndexLayer>
       <Overview>
           <Dataset>i_do_not_exist</Dataset>
       </Overview>
@@ -2544,6 +2570,7 @@ def test_gti_xml(tmp_vsimem):
 
     xml_content = f"""<GDALTileIndexDataset>
   <IndexDataset>{index_filename}</IndexDataset>
+  <IndexLayer>index</IndexLayer>
       <Overview>
           <Layer>i_do_not_exist</Layer>
       </Overview>

--- a/autotest/gdrivers/gti.py
+++ b/autotest/gdrivers/gti.py
@@ -2069,7 +2069,7 @@ def test_gti_ovr_factor(tmp_vsimem):
     src_ds = gdal.Open(os.path.join(os.getcwd(), "data", "byte.tif"))
     index_ds, lyr = create_basic_tileindex(index_filename, src_ds)
     lyr.SetMetadataItem("MASK_BAND", "YES")
-    lyr.SetMetadataItem("OVERVIEW_1_FACTOR", "2")
+    lyr.SetMetadataItem("OVERVIEW_0_FACTOR", "2")
     del index_ds
 
     vrt_ds = gdal.Open(index_filename)
@@ -2106,6 +2106,7 @@ def test_gti_ovr_factor_invalid(tmp_vsimem):
 
     src_ds = gdal.Open(os.path.join(os.getcwd(), "data", "byte.tif"))
     index_ds, lyr = create_basic_tileindex(index_filename, src_ds)
+    # Also test GDAL 3.9.0 and 3.9.1 where the idx started at 1
     lyr.SetMetadataItem("OVERVIEW_1_FACTOR", "0.5")
     del index_ds
 
@@ -2120,7 +2121,7 @@ def test_gti_ovr_ds_name(tmp_vsimem):
 
     src_ds = gdal.Open(os.path.join(os.getcwd(), "data", "byte.tif"))
     index_ds, lyr = create_basic_tileindex(index_filename, src_ds)
-    lyr.SetMetadataItem("OVERVIEW_1_DATASET", "/i/do/not/exist")
+    lyr.SetMetadataItem("OVERVIEW_0_DATASET", "/i/do/not/exist")
     del index_ds
 
     vrt_ds = gdal.Open(index_filename)
@@ -2134,7 +2135,7 @@ def test_gti_ovr_lyr_name(tmp_vsimem):
 
     src_ds = gdal.Open(os.path.join(os.getcwd(), "data", "byte.tif"))
     index_ds, lyr = create_basic_tileindex(index_filename, src_ds)
-    lyr.SetMetadataItem("OVERVIEW_1_LAYER", "non_existing")
+    lyr.SetMetadataItem("OVERVIEW_0_LAYER", "non_existing")
     del index_ds
 
     vrt_ds = gdal.Open(index_filename)

--- a/autotest/gdrivers/gti.py
+++ b/autotest/gdrivers/gti.py
@@ -2148,6 +2148,57 @@ def test_gti_ovr_lyr_name(tmp_vsimem):
         vrt_ds.GetRasterBand(1).GetOverviewCount()
 
 
+def test_gti_ovr_of_ovr(tmp_vsimem):
+
+    index_filename = str(tmp_vsimem / "index.gti.gpkg")
+
+    ovr_filename = str(tmp_vsimem / "byte_ovr.tif")
+    ovr_ds = gdal.Translate(ovr_filename, "data/byte.tif", width=10)
+    ovr_ds.BuildOverviews("NEAR", [2])
+    ovr_ds = None
+
+    src_ds = gdal.Open(os.path.join(os.getcwd(), "data", "byte.tif"))
+    index_ds, lyr = create_basic_tileindex(index_filename, src_ds)
+    lyr.SetMetadataItem("OVERVIEW_0_DATASET", ovr_filename)
+    del index_ds
+
+    vrt_ds = gdal.Open(index_filename)
+    ovr_ds = gdal.Open(ovr_filename)
+    assert vrt_ds.GetRasterBand(1).GetOverviewCount() == 2
+    assert (
+        vrt_ds.GetRasterBand(1).GetOverview(0).ReadRaster()
+        == ovr_ds.GetRasterBand(1).ReadRaster()
+    )
+    assert (
+        vrt_ds.GetRasterBand(1).GetOverview(1).ReadRaster()
+        == ovr_ds.GetRasterBand(1).GetOverview(0).ReadRaster()
+    )
+
+
+def test_gti_ovr_of_ovr_OVERVIEW_LEVEL_NONE(tmp_vsimem):
+
+    index_filename = str(tmp_vsimem / "index.gti.gpkg")
+
+    ovr_filename = str(tmp_vsimem / "byte_ovr.tif")
+    ovr_ds = gdal.Translate(ovr_filename, "data/byte.tif", width=10)
+    ovr_ds.BuildOverviews("NEAR", [2])
+    ovr_ds = None
+
+    src_ds = gdal.Open(os.path.join(os.getcwd(), "data", "byte.tif"))
+    index_ds, lyr = create_basic_tileindex(index_filename, src_ds)
+    lyr.SetMetadataItem("OVERVIEW_0_DATASET", ovr_filename)
+    lyr.SetMetadataItem("OVERVIEW_0_OPEN_OPTIONS", "OVERVIEW_LEVEL=NONE")
+    del index_ds
+
+    vrt_ds = gdal.Open(index_filename)
+    ovr_ds = gdal.Open(ovr_filename)
+    assert vrt_ds.GetRasterBand(1).GetOverviewCount() == 1
+    assert (
+        vrt_ds.GetRasterBand(1).GetOverview(0).ReadRaster()
+        == ovr_ds.GetRasterBand(1).ReadRaster()
+    )
+
+
 def test_gti_external_ovr(tmp_vsimem):
 
     index_filename = str(tmp_vsimem / "index.gti.gpkg")

--- a/doc/source/drivers/raster/gti.rst
+++ b/doc/source/drivers/raster/gti.rst
@@ -201,6 +201,10 @@ PostGIS, ...), the following layer metadata items may be set:
   This may also be a vector dataset with a GTI compatible layer, potentially
   specified with ``OVERVIEW_<idx>_LAYER``.
 
+  Starting with GDAL 3.9.2, overviews of ``OVERVIEW_<idx>_DATASET=<string>``
+  are also automatically added, unless ``OVERVIEW_<idx>_OPEN_OPTIONS=OVERVIEW_LEVEL=NONE``
+  is specified.
+
 * ``OVERVIEW_<idx>_OPEN_OPTIONS=<key1=value1>[,key2=value2]...`` where idx is an integer index (starting at 0
   since GDAL 3.9.2, starting at 1 in GDAL 3.9.0 and 3.9.1)
 
@@ -208,6 +212,9 @@ PostGIS, ...), the following layer metadata items may be set:
 
 * ``OVERVIEW_<idx>_LAYER=<string>`` where idx is an integer index (starting at 0
   since GDAL 3.9.2, starting at 1 in GDAL 3.9.0 and 3.9.1)
+
+  Only taken into account if ``OVERVIEW_<idx>_DATASET=<string>`` is not specified,
+  or points to a GTI dataset.
 
   Name of the vector layer to use as the first overview level, assuming
   ``OVERVIEW_<idx>_DATASET`` points to a vector dataset. ``OVERVIEW_<idx>_DATASET``
@@ -217,8 +224,12 @@ PostGIS, ...), the following layer metadata items may be set:
 * ``OVERVIEW_<idx>_FACTOR=<int>`` where idx is an integer index (starting at 0
   since GDAL 3.9.2, starting at 1 in GDAL 3.9.0 and 3.9.1)
 
-  Sub-sampling factor, strictly greater than 1. If ``OVERVIEW_<idx>_DATASET``
-  and ``OVERVIEW_<idx>_LAYER`` are not specified, then all tiles of the full
+  Sub-sampling factor, strictly greater than 1.
+
+  Only taken into account if ``OVERVIEW_<idx>_DATASET=<string>`` is not specified,
+  or points to a GTI dataset.
+
+  If ``OVERVIEW_<idx>_DATASET`` and ``OVERVIEW_<idx>_LAYER`` are not specified, then all tiles of the full
   resolution virtual mosaic are used, with the specified sub-sampling factor
   (it is recommended, but not required, that those tiles do have a corresponding overview).
   ``OVERVIEW_<idx>_DATASET`` and/or ``OVERVIEW_<idx>_LAYER`` may also be
@@ -227,6 +238,8 @@ PostGIS, ...), the following layer metadata items may be set:
 All overviews *must* have exactly the same extent as the full resolution
 virtual mosaic. The GTI driver does not check that, and if that condition is
 not met, subsampled pixel request will lead to incorrect result.
+
+They also must be listed by decreasing size with increasing overview index.
 
 In addition to those layer metadata items, the dataset-level metadata item
 ``TILE_INDEX_LAYER`` may be set to indicate, for dataset with multiple layers,
@@ -316,7 +329,8 @@ mentioned in the previous section.
         </Overview>
         <Overview>                                     <!-- optional -->
             <!-- 3rd overview level (and potentially 4th, 5th... depending on
-                 the number of overview levels in the pointed GeoTIFF file)
+                 the number of overview levels in the pointed GeoTIFF file.
+                 Only since GDAL 3.9.2)
             -->
             <Dataset>some.tif</Dataset>
         </Overview>

--- a/doc/source/drivers/raster/gti.rst
+++ b/doc/source/drivers/raster/gti.rst
@@ -193,25 +193,29 @@ PostGIS, ...), the following layer metadata items may be set:
 
   Unit of the band.
 
-* ``OVERVIEW_<idx>_DATASET=<string>`` where idx is an integer index starting at 0.
+* ``OVERVIEW_<idx>_DATASET=<string>`` where idx is an integer index (starting at 0
+  since GDAL 3.9.2, starting at 1 in GDAL 3.9.0 and 3.9.1)
 
   Name of the dataset to use as the first overview level. This may be a
   raster dataset (for example a GeoTIFF file, or another GTI dataset).
   This may also be a vector dataset with a GTI compatible layer, potentially
   specified with ``OVERVIEW_<idx>_LAYER``.
 
-* ``OVERVIEW_<idx>_OPEN_OPTIONS=<key1=value1>[,key2=value2]...`` where idx is an integer index starting at 0.
+* ``OVERVIEW_<idx>_OPEN_OPTIONS=<key1=value1>[,key2=value2]...`` where idx is an integer index (starting at 0
+  since GDAL 3.9.2, starting at 1 in GDAL 3.9.0 and 3.9.1)
 
   Open options(s) to use to open ``OVERVIEW_<idx>_DATASET``.
 
-* ``OVERVIEW_<idx>_LAYER=<string>`` where idx is an integer index starting at 0.
+* ``OVERVIEW_<idx>_LAYER=<string>`` where idx is an integer index (starting at 0
+  since GDAL 3.9.2, starting at 1 in GDAL 3.9.0 and 3.9.1)
 
   Name of the vector layer to use as the first overview level, assuming
   ``OVERVIEW_<idx>_DATASET`` points to a vector dataset. ``OVERVIEW_<idx>_DATASET``
   may also not be specified, in which case the vector dataset of the full
   resolution virtual mosaic is used.
 
-* ``OVERVIEW_<idx>_FACTOR=<int>`` where idx is an integer index starting at 0.
+* ``OVERVIEW_<idx>_FACTOR=<int>`` where idx is an integer index (starting at 0
+  since GDAL 3.9.2, starting at 1 in GDAL 3.9.0 and 3.9.1)
 
   Sub-sampling factor, strictly greater than 1. If ``OVERVIEW_<idx>_DATASET``
   and ``OVERVIEW_<idx>_LAYER`` are not specified, then all tiles of the full

--- a/frmts/vrt/gdaltileindexdataset.cpp
+++ b/frmts/vrt/gdaltileindexdataset.cpp
@@ -1738,7 +1738,7 @@ bool GDALTileIndexDataset::Open(GDALOpenInfo *poOpenInfo)
         }
         else
         {
-            for (int iOvr = 1;; ++iOvr)
+            for (int iOvr = 0;; ++iOvr)
             {
                 const char *pszOvrDSName =
                     GetOption(CPLSPrintf("OVERVIEW_%d_DATASET", iOvr));
@@ -1749,7 +1749,12 @@ bool GDALTileIndexDataset::Open(GDALOpenInfo *poOpenInfo)
                 const char *pszOvrFactor =
                     GetOption(CPLSPrintf("OVERVIEW_%d_FACTOR", iOvr));
                 if (!pszOvrDSName && !pszOvrLayer && !pszOvrFactor)
+                {
+                    // Before GDAL 3.9.2, we started the iteration at 1.
+                    if (iOvr == 0)
+                        continue;
                     break;
+                }
                 m_aoOverviewDescriptor.emplace_back(
                     std::string(pszOvrDSName ? pszOvrDSName : ""),
                     pszOpenOptions ? CPLStringList(CSLTokenizeString2(


### PR DESCRIPTION
Fix issues reported in https://lists.osgeo.org/pipermail/gdal-dev/2024-July/059230.html

- GTI: start looking for OVERVIEW_<idx>_xxxx metadata items at index 0
- GTI: automatically add overviews of overviews, unless the OVERVIEW_LEVEL=NONE open option is specified