### PR TITLE
doc/raster_data_model: Add Zarr driver to the list of drivers supporting subdatasets

### DIFF
--- a/doc/source/user/raster_data_model.rst
+++ b/doc/source/user/raster_data_model.rst
@@ -136,7 +136,7 @@ The value of the _NAME is the string that can be passed to :cpp:func:`GDALOpen` 
 
 Drivers which support subdatasets advertise the ``DMD_SUBDATASETS`` capability. This information is reported when the --format and --formats options are passed to the command line utilities.
 
-Currently, drivers which support subdatasets are: ADRG, ECRGTOC, GEORASTER, GTiff, HDF4, HDF5, netCDF, NITF, NTv2, OGDI, PDF, PostGISRaster, Rasterlite, RPFTOC, RS2, TileDB, WCS, and WMS.
+Currently, drivers which support subdatasets are: ADRG, ECRGTOC, GEORASTER, GTiff, HDF4, HDF5, netCDF, NITF, NTv2, OGDI, PDF, PostGISRaster, Rasterlite, RPFTOC, RS2, TileDB, WCS, WMS, and Zarr.
 
 IMAGE_STRUCTURE Domain
 ++++++++++++++++++++++


### PR DESCRIPTION
## What does this PR do?

Adds `Zarr` to the list of drivers supporting subdatsets: https://gdal.org/user/raster_data_model.html#subdatasets-domain 

```
 gdalinfo --format zarr | grep "Raster subdatasets"
  Supports: Raster subdatasets
```


## What are related issues/pull requests?

## Tasklist

 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [x] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

