### PR TITLE
[gdal_contour] Allow to use -fl with -i and -e

### DIFF
--- a/alg/contour.cpp
+++ b/alg/contour.cpp
@@ -34,6 +34,7 @@
 #include "utility.h"
 #include "contour_generator.h"
 #include "segment_merger.h"
+#include <algorithm>
 
 #include "gdal.h"
 #include "gdal_alg.h"
@@ -686,15 +687,13 @@ CPLErr GDALContourGenerateEx(GDALRasterBandH hBand, void *hLayer,
         }
     }
 
-    // Global ok
     bool ok = false;
-    // Fixed levels ok
-    bool flOk = true;
 
     try
     {
         if (polygonize)
         {
+
             if (!fixedLevels.empty())
             {
                 // If the minimum raster value is larger than the first requested
@@ -716,8 +715,47 @@ CPLErr GDALContourGenerateEx(GDALRasterBandH hBand, void *hLayer,
             PolygonContourWriter w(&oCWI, dfMinimum);
             typedef PolygonRingAppender<PolygonContourWriter> RingAppender;
             RingAppender appender(w);
+
+            if (expBase > 0.0)
+            {
+                // Do not provide the actual minimum value to level iterator
+                // in polygonal case, otherwise it can result in a polygon
+                // with a degenerate min=max range.
+                ExponentialLevelRangeIterator generator(
+                    expBase, -std::numeric_limits<double>::infinity());
+                auto levelIt{generator.range(dfMinimum, dfMaximum)};
+                for (auto i = levelIt.begin(); i != levelIt.end(); ++i)
+                {
+                    const double level = (*i).second;
+                    fixedLevels.push_back(level);
+                }
+                // Append minimum value to fixed levels
+                fixedLevels.push_back(dfMinimum);
+            }
+            else if (contourInterval != 0)
+            {
+                // Do not provide the actual minimum value to level iterator
+                // in polygonal case, otherwise it can result in a polygon
+                // with a degenerate min=max range.
+                IntervalLevelRangeIterator generator(
+                    contourBase, contourInterval,
+                    -std::numeric_limits<double>::infinity());
+                auto levelIt{generator.range(dfMinimum, dfMaximum)};
+                for (auto i = levelIt.begin(); i != levelIt.end(); ++i)
+                {
+                    const double level = (*i).second;
+                    fixedLevels.push_back(level);
+                }
+                // Append minimum value to fixed levels
+                fixedLevels.push_back(dfMinimum);
+            }
+
             if (!fixedLevels.empty())
             {
+                std::sort(fixedLevels.begin(), fixedLevels.end());
+                auto uniqueIt =
+                    std::unique(fixedLevels.begin(), fixedLevels.end());
+                fixedLevels.erase(uniqueIt, fixedLevels.end());
                 // Do not provide the actual minimum value to level iterator
                 // in polygonal case, otherwise it can result in a polygon
                 // with a degenerate min=max range.
@@ -730,48 +768,41 @@ CPLErr GDALContourGenerateEx(GDALRasterBandH hBand, void *hLayer,
                                            FixedLevelRangeIterator>
                     cg(hBand, useNoData, noDataValue, writer, levels);
                 ok = cg.process(pfnProgress, pProgressArg);
-                flOk = ok;
-            }
-
-            if (flOk)
-            {
-                if (expBase > 0.0)
-                {
-                    // Do not provide the actual minimum value to level iterator
-                    // in polygonal case, otherwise it can result in a polygon
-                    // with a degenerate min=max range.
-                    ExponentialLevelRangeIterator levels(
-                        expBase, -std::numeric_limits<double>::infinity());
-                    SegmentMerger<RingAppender, ExponentialLevelRangeIterator>
-                        writer(appender, levels, /* polygonize */ true);
-                    ContourGeneratorFromRaster<decltype(writer),
-                                               ExponentialLevelRangeIterator>
-                        cg(hBand, useNoData, noDataValue, writer, levels);
-                    ok = cg.process(pfnProgress, pProgressArg);
-                }
-                else if (contourInterval != 0)
-                {
-                    // Do not provide the actual minimum value to level iterator
-                    // in polygonal case, otherwise it can result in a polygon
-                    // with a degenerate min=max range.
-                    IntervalLevelRangeIterator levels(
-                        contourBase, contourInterval,
-                        -std::numeric_limits<double>::infinity());
-                    SegmentMerger<RingAppender, IntervalLevelRangeIterator>
-                        writer(appender, levels, /* polygonize */ true);
-                    ContourGeneratorFromRaster<decltype(writer),
-                                               IntervalLevelRangeIterator>
-                        cg(hBand, useNoData, noDataValue, writer, levels);
-                    ok = cg.process(pfnProgress, pProgressArg);
-                }
             }
         }
         else
         {
             GDALRingAppender appender(OGRContourWriter, &oCWI);
 
+            // Append all exp levels to fixed levels
+            if (expBase > 0.0)
+            {
+                ExponentialLevelRangeIterator generator(expBase, dfMinimum);
+                auto levelIt{generator.range(dfMinimum, dfMaximum)};
+                for (auto i = levelIt.begin(); i != levelIt.end(); ++i)
+                {
+                    const double level = (*i).second;
+                    fixedLevels.push_back(level);
+                }
+            }
+            else if (contourInterval != 0)
+            {
+                IntervalLevelRangeIterator levels(contourBase, contourInterval,
+                                                  dfMinimum);
+                auto levelIt{levels.range(dfMinimum, dfMaximum)};
+                for (auto i = levelIt.begin(); i != levelIt.end(); ++i)
+                {
+                    const double level = (*i).second;
+                    fixedLevels.push_back(level);
+                }
+            }
+
             if (!fixedLevels.empty())
             {
+                std::sort(fixedLevels.begin(), fixedLevels.end());
+                auto uniqueIt =
+                    std::unique(fixedLevels.begin(), fixedLevels.end());
+                fixedLevels.erase(uniqueIt, fixedLevels.end());
                 FixedLevelRangeIterator levels(
                     &fixedLevels[0], fixedLevels.size(), dfMinimum, dfMaximum);
                 SegmentMerger<GDALRingAppender, FixedLevelRangeIterator> writer(
@@ -780,33 +811,6 @@ CPLErr GDALContourGenerateEx(GDALRasterBandH hBand, void *hLayer,
                                            FixedLevelRangeIterator>
                     cg(hBand, useNoData, noDataValue, writer, levels);
                 ok = cg.process(pfnProgress, pProgressArg);
-                flOk = ok;
-            }
-
-            if (flOk)
-            {
-                if (expBase > 0.0)
-                {
-                    ExponentialLevelRangeIterator levels(expBase, dfMinimum);
-                    SegmentMerger<GDALRingAppender,
-                                  ExponentialLevelRangeIterator>
-                        writer(appender, levels, /* polygonize */ false);
-                    ContourGeneratorFromRaster<decltype(writer),
-                                               ExponentialLevelRangeIterator>
-                        cg(hBand, useNoData, noDataValue, writer, levels);
-                    ok = cg.process(pfnProgress, pProgressArg);
-                }
-                else if (contourInterval != 0)
-                {
-                    IntervalLevelRangeIterator levels(
-                        contourBase, contourInterval, dfMinimum);
-                    SegmentMerger<GDALRingAppender, IntervalLevelRangeIterator>
-                        writer(appender, levels, /* polygonize */ false);
-                    ContourGeneratorFromRaster<decltype(writer),
-                                               IntervalLevelRangeIterator>
-                        cg(hBand, useNoData, noDataValue, writer, levels);
-                    ok = cg.process(pfnProgress, pProgressArg);
-                }
             }
         }
     }

--- a/apps/gdal_contour.cpp
+++ b/apps/gdal_contour.cpp
@@ -82,7 +82,7 @@ GDALContourAppOptionsGetParser(GDALContourOptions *psOptions)
         "utility: http://gdal.org/gdal_contour.html"));
 
     argParser->add_extra_usage_hint(
-        _("One and only one of -i, -fl or -e must be specified."));
+        _("One one of -i, -fl or -e must be specified."));
 
     argParser->add_argument("-b")
         .metavar("<name>")
@@ -147,20 +147,20 @@ GDALContourAppOptionsGetParser(GDALContourOptions *psOptions)
         .store_into(psOptions->dfInterval)
         .help(_("Elevation interval between contours."));
 
-    group.add_argument("-fl")
-        .metavar("<level>")
-        .nargs(argparse::nargs_pattern::at_least_one)
-        .scan<'g', double>()
-        .action([psOptions](const std::string &s)
-                { psOptions->adfFixedLevels.push_back(CPLAtof(s.c_str())); })
-        .help(_("Name one or more \"fixed levels\" to extract."));
-
     group.add_argument("-e")
         .metavar("<base>")
         .scan<'g', double>()
         .store_into(psOptions->dfExpBase)
         .help(_("Generate levels on an exponential scale: base ^ k, for k an "
                 "integer."));
+
+    argParser->add_argument("-fl")
+        .metavar("<level>")
+        .nargs(argparse::nargs_pattern::at_least_one)
+        .scan<'g', double>()
+        .action([psOptions](const std::string &s)
+                { psOptions->adfFixedLevels.push_back(CPLAtof(s.c_str())); })
+        .help(_("Name one or more \"fixed levels\" to extract."));
 
     argParser->add_argument("-off")
         .metavar("<offset>")
@@ -444,7 +444,8 @@ MAIN_START(argc, argv)
         }
         options = CSLAddString(options, values.c_str());
     }
-    else if (sOptions.dfExpBase != 0.0)
+
+    if (sOptions.dfExpBase != 0.0)
     {
         options =
             CSLAppendPrintf(options, "LEVEL_EXP_BASE=%f", sOptions.dfExpBase);

--- a/apps/gdal_contour.cpp
+++ b/apps/gdal_contour.cpp
@@ -82,7 +82,7 @@ GDALContourAppOptionsGetParser(GDALContourOptions *psOptions)
         "utility: http://gdal.org/gdal_contour.html"));
 
     argParser->add_extra_usage_hint(
-        _("One one of -i, -fl or -e must be specified."));
+        _("One of -i, -fl or -e must be specified."));
 
     argParser->add_argument("-b")
         .metavar("<name>")

--- a/autotest/utilities/test_gdal_contour.py
+++ b/autotest/utilities/test_gdal_contour.py
@@ -406,7 +406,7 @@ def test_gdal_contour_missing_fl_i_or_e(gdal_contour_path, testdata_tif, tmp_pat
 # Test -fl can be used with -i
 
 
-def test_gdal_contour_fl_i_and_fl(gdal_contour_path, testdata_tif, tmp_path):
+def test_gdal_contour_fl_and_i(gdal_contour_path, testdata_tif, tmp_path):
 
     contour_shp = str(tmp_path / "contour.shp")
 
@@ -488,5 +488,143 @@ def test_gdal_contour_fl_ignore_off(gdal_contour_path, testdata_tif, tmp_path):
     feat = lyr.GetNextFeature()
     while feat is not None:
         assert feat.GetField("elev") == expected_heights[i]
+        i = i + 1
+        feat = lyr.GetNextFeature()
+
+
+###############################################################################
+# Test there are no duplicated levels when -fl is used together with -i
+
+
+def test_gdal_contour_fl_and_i_no_dups(gdal_contour_path, testdata_tif, tmp_path):
+
+    contour_shp = str(tmp_path / "contour.shp")
+
+    _, err = gdaltest.runexternal_out_and_err(
+        gdal_contour_path + f" -a elev -fl 6 16 20 -i 10 {testdata_tif} {contour_shp}"
+    )
+
+    assert err is None or err == "", "got error/warning"
+
+    ds = ogr.Open(contour_shp)
+
+    lyr = ds.ExecuteSQL("select elev from contour order by elev asc")
+
+    expected_heights = [0, 6, 10, 16, 20]
+
+    assert lyr.GetFeatureCount() == len(expected_heights)
+
+    i = 0
+    feat = lyr.GetNextFeature()
+    while feat is not None:
+        assert feat.GetField("elev") == expected_heights[i]
+        i = i + 1
+        feat = lyr.GetNextFeature()
+
+
+###############################################################################
+# Test interval with polygonize
+
+
+def test_gdal_contour_i_polygonize(gdal_contour_path, testdata_tif, tmp_path):
+
+    contour_shp = str(tmp_path / "contour.shp")
+
+    _, err = gdaltest.runexternal_out_and_err(
+        gdal_contour_path
+        + f" -amin elev -amax elev2 -i 5 -p {testdata_tif} {contour_shp}"
+    )
+
+    assert err is None or err == "", "got error/warning"
+
+    ds = ogr.Open(contour_shp)
+
+    lyr = ds.ExecuteSQL("select elev, elev2 from contour order by elev asc")
+
+    # Raster max is 25 so the last contour is 20 (with amax of 25)
+    expected_heights = [0, 5, 10, 15, 20]
+
+    assert lyr.GetFeatureCount() == len(expected_heights)
+
+    i = 0
+    feat = lyr.GetNextFeature()
+    while feat is not None:
+        assert feat.GetField("elev") == expected_heights[i]
+        assert feat.GetField("elev2") == expected_heights[i] + 5
+        i = i + 1
+        feat = lyr.GetNextFeature()
+
+
+###############################################################################
+# Test there are no duplicated levels when -fl is used together with -i
+# and polygonize
+
+
+def test_gdal_contour_fl_and_i_no_dups_polygonize(
+    gdal_contour_path, testdata_tif, tmp_path
+):
+
+    contour_shp = str(tmp_path / "contour.shp")
+
+    _, err = gdaltest.runexternal_out_and_err(
+        gdal_contour_path
+        + f" -amin elev -amax elev2 -fl 6 16 20 -i 5 -p {testdata_tif} {contour_shp}"
+    )
+
+    assert err is None or err == "", "got error/warning"
+
+    ds = ogr.Open(contour_shp)
+
+    lyr = ds.ExecuteSQL("select elev, elev2 from contour order by elev asc")
+
+    # Raster max is 25 so the last contour is 20 (with amax of 25)
+    expected_heights = [0, 5, 6, 10, 15, 16, 20]
+
+    assert lyr.GetFeatureCount() == len(expected_heights)
+
+    i = 0
+    feat = lyr.GetNextFeature()
+    while feat is not None:
+        assert feat.GetField("elev") == expected_heights[i]
+        assert (
+            feat.GetField("elev2") == expected_heights[i + 1]
+            if i < len(expected_heights) - 2
+            else expected_heights[i] + 5
+        )
+        i = i + 1
+        feat = lyr.GetNextFeature()
+
+
+###############################################################################
+# Test -e with -fl and polygonize
+
+
+def test_gdal_contour_fl_e_polygonize(gdal_contour_path, tmp_path):
+
+    contour_shp = str(tmp_path / "contour.shp")
+
+    gdaltest.runexternal(
+        gdal_contour_path
+        + f" -p -amin elev -amax elev2 -fl 76 112 441 -e 3 ../gdrivers/data/n43.tif {contour_shp}"
+    )
+
+    ds = ogr.Open(contour_shp)
+
+    lyr = ds.ExecuteSQL("select elev, elev2 from contour order by elev asc")
+
+    # Raster min is 75, max is 460
+    expected_heights = [75, 76, 81, 112, 243, 441]
+
+    assert lyr.GetFeatureCount() == len(expected_heights)
+
+    i = 0
+    feat = lyr.GetNextFeature()
+    while feat is not None:
+        assert feat.GetField("elev") == expected_heights[i]
+        assert (
+            feat.GetField("elev2") == expected_heights[i + 1]
+            if i < len(expected_heights) - 2
+            else 460
+        )
         i = i + 1
         feat = lyr.GetNextFeature()

--- a/autotest/utilities/test_gdal_contour.py
+++ b/autotest/utilities/test_gdal_contour.py
@@ -399,7 +399,7 @@ def test_gdal_contour_missing_fl_i_or_e(gdal_contour_path, testdata_tif, tmp_pat
     _, err = gdaltest.runexternal_out_and_err(
         gdal_contour_path + f" {testdata_tif} {contour_shp}"
     )
-    assert "One one of -i, -fl or -e must be specified." in err
+    assert "One of -i, -fl or -e must be specified." in err
 
 
 ###############################################################################

--- a/doc/source/programs/gdal_contour.rst
+++ b/doc/source/programs/gdal_contour.rst
@@ -93,20 +93,19 @@ be on the right, i.e. a line string goes clockwise around a top.
 
 .. option:: -i <interval>
 
-    Elevation interval between contours. Ignored if -fl is used.
+    Elevation interval between contours.
     Must specify either -i or -fl or -e.
 
 .. option:: -off <offset>
 
-    Offset from zero relative to which to interpret intervals. Ignored if -fl is used.
+    Offset from zero relative to which to interpret intervals.
 
-    For example, `-i 100` requests contours at ...-100, 0, 100... 
+    For example, `-i 100` requests contours at ...-100, 0, 100...
     Further adding `-off 25` makes that request instead ...-75, 25, 125...
 
 .. option:: -fl <level>
 
     Name one or more "fixed levels" to extract.
-    Must specify either -i or -fl or -e.
 
 .. option:: -e <base>
 


### PR DESCRIPTION
Fixed levels are added to those automatically calculated from -i or -e.

Fixes #10172
