### PR TITLE
[Backport 3.9] LIBKML: fix LIBKML_RESOLVE_STYLE=YES when reading a KML file with dataset-level styles (3.9.1 regression)

### DIFF
--- a/autotest/ogr/ogr_libkml.py
+++ b/autotest/ogr/ogr_libkml.py
@@ -1405,6 +1405,13 @@ def test_ogr_libkml_read_write_style(tmp_vsimem):
         "style1_highlight", 'SYMBOL(id:"http://style1_highlight",c:#10325476)'
     )
     ds.SetStyleTable(style_table)
+    lyr = ds.CreateLayer("test")
+    feat = ogr.Feature(lyr.GetLayerDefn())
+    feat.SetStyleString("@style1_normal")
+    lyr.CreateFeature(feat)
+    feat = ogr.Feature(lyr.GetLayerDefn())
+    feat.SetStyleString("@unknown_style")
+    lyr.CreateFeature(feat)
     ds = None
 
     f = gdal.VSIFOpenL(tmp_vsimem / "ogr_libkml_read_write_style_write.kml", "rb")
@@ -1447,6 +1454,21 @@ def test_ogr_libkml_read_write_style(tmp_vsimem):
     if lines_got != lines_ref:
         print(data)
         pytest.fail(styles)
+
+    ds = ogr.Open(tmp_vsimem / "ogr_libkml_read_write_style_write.kml")
+    lyr = ds.GetLayer(0)
+    f = lyr.GetNextFeature()
+    assert f.GetStyleString() == "@style1_normal"
+    f = lyr.GetNextFeature()
+    assert f.GetStyleString() == "@unknown_style"
+
+    with gdaltest.config_option("LIBKML_RESOLVE_STYLE", "YES"):
+        ds = ogr.Open(tmp_vsimem / "ogr_libkml_read_write_style_write.kml")
+        lyr = ds.GetLayer(0)
+        f = lyr.GetNextFeature()
+        assert f.GetStyleString() == 'SYMBOL(id:"http://style1_normal",c:#67452301)'
+        f = lyr.GetNextFeature()
+        assert f.GetStyleString() == "@unknown_style"
 
 
 ###############################################################################

--- a/ogr/ogrsf_frmts/libkml/ogrlibkmlfeaturestyle.cpp
+++ b/ogr/ogrsf_frmts/libkml/ogrlibkmlfeaturestyle.cpp
@@ -205,16 +205,10 @@ void kml2featurestyle(FeaturePtr poKmlFeature, OGRLIBKMLDataSource *poOgrDS,
         else
         {
             const size_t nPathLen = poOgrDS->GetStylePath().size();
-
-            if (nPathLen == 0)
-            {
-                if (!osUrl.empty() && osUrl[0] == '#')
-                    osStyleString = std::string("@").append(osUrl.c_str() + 1);
-            }
-            else if (osUrl.size() > nPathLen &&
-                     strncmp(osUrl.c_str(), poOgrDS->GetStylePath().c_str(),
-                             nPathLen) == 0 &&
-                     osUrl[nPathLen] == '#')
+            if (osUrl.size() > nPathLen && osUrl[nPathLen] == '#' &&
+                (nPathLen == 0 ||
+                 strncmp(osUrl.c_str(), poOgrDS->GetStylePath().c_str(),
+                         nPathLen) == 0))
             {
                 /***** should we resolve the style *****/
                 const char *pszResolve =


### PR DESCRIPTION
Fixes https://github.com/qgis/QGIS/issues/58208

Backport of PR #10473 