### PR TITLE
Polygonize: optimizations to reduce runtime

### DIFF
--- a/alg/polygonize.cpp
+++ b/alg/polygonize.cpp
@@ -336,17 +336,29 @@ static CPLErr GDALPolygonizeT(GDALRasterBandH hSrcBand,
                         : oFirstEnum.panPolyIdMap[panThisLineId[iX]];
             }
 
-            oPolygonizer.processLine(panLastLineId, panLastLineVal,
-                                     paoThisLineArm, paoLastLineArm, iY,
-                                     nXSize);
-            eErr = oPolygonWriter.getErr();
+            if (!oPolygonizer.processLine(panLastLineId, panLastLineVal,
+                                          paoThisLineArm, paoLastLineArm, iY,
+                                          nXSize))
+            {
+                eErr = CE_Failure;
+            }
+            else
+            {
+                eErr = oPolygonWriter.getErr();
+            }
         }
         else
         {
-            oPolygonizer.processLine(panThisLineId, panLastLineVal,
-                                     paoThisLineArm, paoLastLineArm, iY,
-                                     nXSize);
-            eErr = oPolygonWriter.getErr();
+            if (!oPolygonizer.processLine(panThisLineId, panLastLineVal,
+                                          paoThisLineArm, paoLastLineArm, iY,
+                                          nXSize))
+            {
+                eErr = CE_Failure;
+            }
+            else
+            {
+                eErr = oPolygonWriter.getErr();
+            }
         }
 
         if (eErr != CE_None)

--- a/alg/polygonize_polygonizer.cpp
+++ b/alg/polygonize_polygonizer.cpp
@@ -35,29 +35,18 @@ namespace gdal
 {
 namespace polygonizer
 {
-
-RPolygon::~RPolygon()
-{
-    for (auto &arc : oArcs)
-    {
-        delete arc;
-    }
-}
-
 IndexedArc RPolygon::newArc(bool bFollowRighthand)
 {
-    Arc *poArc = new Arc();
-    std::size_t iArcIndex = oArcs.size();
-    oArcs.push_back(poArc);
-    oArcRighthandFollow.push_back(bFollowRighthand);
-    oArcConnections.push_back(iArcIndex);
-    return IndexedArc{poArc, iArcIndex};
+    const std::size_t iArcIndex = oArcs.size();
+    const auto &oNewArc =
+        oArcs.emplace_back(static_cast<unsigned>(iArcIndex), bFollowRighthand);
+    return IndexedArc{oNewArc.poArc.get(), iArcIndex};
 }
 
 void RPolygon::setArcConnection(const IndexedArc &oArc,
                                 const IndexedArc &oNextArc)
 {
-    oArcConnections[oArc.iIndex] = oNextArc.iIndex;
+    oArcs[oArc.iIndex].nConnection = static_cast<unsigned>(oNextArc.iIndex);
 }
 
 void RPolygon::updateBottomRightPos(IndexType iRow, IndexType iCol)
@@ -361,13 +350,14 @@ Polygonizer<PolyIdType, DataType>::~Polygonizer()
 template <typename PolyIdType, typename DataType>
 RPolygon *Polygonizer<PolyIdType, DataType>::getPolygon(PolyIdType nPolygonId)
 {
-    if (oPolygonMap_.count(nPolygonId) == 0)
+    const auto oIter = oPolygonMap_.find(nPolygonId);
+    if (oIter == oPolygonMap_.end())
     {
         return createPolygon(nPolygonId);
     }
     else
     {
-        return oPolygonMap_[nPolygonId];
+        return oIter->second;
     }
 }
 
@@ -383,8 +373,10 @@ Polygonizer<PolyIdType, DataType>::createPolygon(PolyIdType nPolygonId)
 template <typename PolyIdType, typename DataType>
 void Polygonizer<PolyIdType, DataType>::destroyPolygon(PolyIdType nPolygonId)
 {
-    delete oPolygonMap_[nPolygonId];
-    oPolygonMap_.erase(nPolygonId);
+    const auto oIter = oPolygonMap_.find(nPolygonId);
+    CPLAssert(oIter != oPolygonMap_.end());
+    delete oIter->second;
+    oPolygonMap_.erase(oIter);
 }
 
 template <typename PolyIdType, typename DataType>
@@ -459,35 +451,55 @@ template <typename DataType>
 OGRPolygonWriter<DataType>::OGRPolygonWriter(OGRLayerH hOutLayer,
                                              int iPixValField,
                                              double *padfGeoTransform)
-    : PolygonReceiver<DataType>(), hOutLayer_(hOutLayer),
+    : PolygonReceiver<DataType>(), poOutLayer_(OGRLayer::FromHandle(hOutLayer)),
       iPixValField_(iPixValField), padfGeoTransform_(padfGeoTransform)
 {
+    poFeature_ = std::make_unique<OGRFeature>(poOutLayer_->GetLayerDefn());
+    poPolygon_ = new OGRPolygon();
+    poFeature_->SetGeometryDirectly(poPolygon_);
 }
 
 template <typename DataType>
 void OGRPolygonWriter<DataType>::receive(RPolygon *poPolygon,
                                          DataType nPolygonCellValue)
 {
-    std::vector<bool> oAccessedArc(poPolygon->oArcConnections.size(), false);
+    std::vector<bool> oAccessedArc(poPolygon->oArcs.size(), false);
     double *padfGeoTransform = padfGeoTransform_;
 
-    OGRGeometryH hPolygon = OGR_G_CreateGeometry(wkbPolygon);
-
-    auto AddRingToPolygon = [&poPolygon, &oAccessedArc, &hPolygon,
-                             padfGeoTransform](std::size_t iFirstArcIndex)
+    OGRLinearRing *poFirstRing = poPolygon_->getExteriorRing();
+    if (poFirstRing && poPolygon_->getNumInteriorRings() == 0)
     {
-        OGRGeometryH hRing = OGR_G_CreateGeometry(wkbLinearRing);
+        poFirstRing->empty();
+    }
+    else
+    {
+        poFirstRing = nullptr;
+        poPolygon_->empty();
+    }
+
+    auto AddRingToPolygon =
+        [this, &poPolygon, &oAccessedArc,
+         padfGeoTransform](std::size_t iFirstArcIndex, OGRLinearRing *poRing)
+    {
+        const bool bAddRing = poRing == nullptr;
+        if (!poRing)
+            poRing = new OGRLinearRing();
 
         auto AddArcToRing =
-            [&poPolygon, &hRing, padfGeoTransform](std::size_t iArcIndex)
+            [&poPolygon, poRing, padfGeoTransform](std::size_t iArcIndex)
         {
-            auto oArc = poPolygon->oArcs[iArcIndex];
-            bool bArcFollowRighthand =
-                poPolygon->oArcRighthandFollow[iArcIndex];
-            for (std::size_t i = 0; i < oArc->size(); ++i)
+            const auto &oArc = poPolygon->oArcs[iArcIndex];
+            const bool bArcFollowRighthand = oArc.bFollowRighthand;
+            const int nArcPointCount = static_cast<int>(oArc.poArc->size());
+            int nDstPointIdx = poRing->getNumPoints();
+            poRing->setNumPoints(nDstPointIdx + nArcPointCount,
+                                 /* bZeroizeNewContent = */ false);
+            for (int i = 0; i < nArcPointCount; ++i)
             {
                 const Point &oPixel =
-                    (*oArc)[bArcFollowRighthand ? i : (oArc->size() - i - 1)];
+                    (*oArc.poArc)[bArcFollowRighthand
+                                      ? i
+                                      : (nArcPointCount - i - 1)];
 
                 const double dfX = padfGeoTransform[0] +
                                    oPixel[1] * padfGeoTransform[1] +
@@ -496,51 +508,56 @@ void OGRPolygonWriter<DataType>::receive(RPolygon *poPolygon,
                                    oPixel[1] * padfGeoTransform[4] +
                                    oPixel[0] * padfGeoTransform[5];
 
-                OGR_G_AddPoint_2D(hRing, dfX, dfY);
+                poRing->setPoint(nDstPointIdx, dfX, dfY);
+                ++nDstPointIdx;
             }
         };
 
         AddArcToRing(iFirstArcIndex);
 
         std::size_t iArcIndex = iFirstArcIndex;
-        std::size_t iNextArcIndex = poPolygon->oArcConnections[iArcIndex];
+        std::size_t iNextArcIndex = poPolygon->oArcs[iArcIndex].nConnection;
         oAccessedArc[iArcIndex] = true;
         while (iNextArcIndex != iFirstArcIndex)
         {
             AddArcToRing(iNextArcIndex);
             iArcIndex = iNextArcIndex;
-            iNextArcIndex = poPolygon->oArcConnections[iArcIndex];
+            iNextArcIndex = poPolygon->oArcs[iArcIndex].nConnection;
             oAccessedArc[iArcIndex] = true;
         }
 
         // close ring manually
-        OGR_G_AddPoint_2D(hRing, OGR_G_GetX(hRing, 0), OGR_G_GetY(hRing, 0));
+        poRing->closeRings();
 
-        OGR_G_AddGeometryDirectly(hPolygon, hRing);
+        if (bAddRing)
+            poPolygon_->addRingDirectly(poRing);
     };
 
-    std::vector<bool>::iterator ite;
-    while ((ite = std::find_if_not(oAccessedArc.begin(), oAccessedArc.end(),
-                                   [](bool accessed) { return accessed; })) !=
-           oAccessedArc.end())
+    for (size_t i = 0; i < oAccessedArc.size(); ++i)
     {
-        AddRingToPolygon(ite - oAccessedArc.begin());
+        if (!oAccessedArc[i])
+        {
+            AddRingToPolygon(i, poFirstRing);
+            poFirstRing = nullptr;
+        }
     }
 
     // Create the feature object
-    OGRFeatureH hFeat = OGR_F_Create(OGR_L_GetLayerDefn(hOutLayer_));
-
-    OGR_F_SetGeometryDirectly(hFeat, hPolygon);
-
+    poFeature_->SetFID(OGRNullFID);
     if (iPixValField_ >= 0)
-        OGR_F_SetFieldDouble(hFeat, iPixValField_,
+        poFeature_->SetField(iPixValField_,
                              static_cast<double>(nPolygonCellValue));
 
     // Write the to the layer.
-    if (OGR_L_CreateFeature(hOutLayer_, hFeat) != OGRERR_NONE)
+    if (poOutLayer_->CreateFeature(poFeature_.get()) != OGRERR_NONE)
         eErr_ = CE_Failure;
 
-    OGR_F_Destroy(hFeat);
+    // Shouldn't happen for well behaved drivers, but better check...
+    else if (poFeature_->GetGeometryRef() != poPolygon_)
+    {
+        poPolygon_ = new OGRPolygon();
+        poFeature_->SetGeometryDirectly(poPolygon_);
+    }
 }
 
 }  // namespace polygonizer

--- a/alg/polygonize_polygonizer.h
+++ b/alg/polygonize_polygonizer.h
@@ -187,7 +187,7 @@ template <typename PolyIdType, typename DataType> class Polygonizer
         return poTheOuterPolygon_;
     }
 
-    void processLine(const PolyIdType *panThisLineId,
+    bool processLine(const PolyIdType *panThisLineId,
                      const DataType *panLastLineVal, TwoArm *poThisLineArm,
                      TwoArm *poLastLineArm, IndexType nCurrentRow,
                      IndexType nCols);

--- a/alg/polygonize_polygonizer.h
+++ b/alg/polygonize_polygonizer.h
@@ -41,6 +41,8 @@
 
 #include "cpl_error.h"
 #include "ogr_api.h"
+#include "ogr_geometry.h"
+#include "ogrsf_frmts.h"
 
 namespace gdal
 {
@@ -67,20 +69,30 @@ struct RPolygon
 {
     IndexType iBottomRightRow{0};
     IndexType iBottomRightCol{0};
+
+    struct ArcStruct
+    {
+        std::unique_ptr<Arc> poArc{};
+        // each element is the next arc index of the current arc
+        unsigned nConnection = 0;
+        // does arc follows the right-hand rule with
+        bool bFollowRighthand = false;
+
+        ArcStruct(unsigned nConnectionIn, bool bFollowRighthandIn)
+            : poArc(std::make_unique<Arc>()), nConnection(nConnectionIn),
+              bFollowRighthand(bFollowRighthandIn)
+        {
+        }
+    };
+
     // arc object list
-    std::vector<Arc *> oArcs{};
-    // does arc follows the right-hand rule with
-    std::vector<bool> oArcRighthandFollow{};
-    // each element is the next arc index of the current arc
-    std::vector<std::size_t> oArcConnections{};
+    std::vector<ArcStruct> oArcs{};
 
     RPolygon() = default;
 
     RPolygon(const RPolygon &) = delete;
 
     RPolygon &operator=(const RPolygon &) = delete;
-
-    ~RPolygon();
 
     /**
      * create a new arc object
@@ -187,9 +199,12 @@ template <typename PolyIdType, typename DataType> class Polygonizer
 template <typename DataType>
 class OGRPolygonWriter : public PolygonReceiver<DataType>
 {
-    OGRLayerH hOutLayer_;
+    OGRLayer *poOutLayer_ = nullptr;
     int iPixValField_;
     double *padfGeoTransform_;
+    std::unique_ptr<OGRFeature> poFeature_{};
+    OGRPolygon *poPolygon_ =
+        nullptr;  // = poFeature_->GetGeometryRef(), owned by poFeature
 
     CPLErr eErr_{CE_None};
 

--- a/swig/include/python/python_exceptions.i
+++ b/swig/include/python/python_exceptions.i
@@ -16,6 +16,7 @@ struct PythonBindingErrorHandlerContext
     std::string     osInitialMsg{};
     std::string     osFailureMsg{};
     CPLErrorNum     nLastCode = CPLE_None;
+    bool            bMemoryError = false;
 };
 
 static void CPL_STDCALL
@@ -46,16 +47,31 @@ PythonBindingErrorHandler(CPLErr eclass, CPLErrorNum err_no, const char *msg )
   }
   else {
     ctxt->nLastCode = err_no;
-    if( ctxt->osFailureMsg.empty() ) {
-      ctxt->osFailureMsg = msg;
-      ctxt->osInitialMsg = ctxt->osFailureMsg;
-    } else {
-      if( ctxt->osFailureMsg.size() < 10000 ) {
-        ctxt->osFailureMsg = std::string(msg) + "\nMay be caused by: " + ctxt->osFailureMsg;
-        ctxt->osInitialMsg = ctxt->osFailureMsg;
-      }
-      else
-        ctxt->osFailureMsg = std::string(msg) + "\n[...]\nMay be caused by: " + ctxt->osInitialMsg;
+    try
+    {
+        if( ctxt->osFailureMsg.empty() ) {
+          ctxt->osFailureMsg = msg;
+          ctxt->osInitialMsg = ctxt->osFailureMsg;
+        } else {
+          if( ctxt->osFailureMsg.size() < 10000 ) {
+            std::string osTmp(msg);
+            osTmp += "\nMay be caused by: ";
+            osTmp += ctxt->osFailureMsg;
+            ctxt->osFailureMsg = std::move(osTmp);
+            ctxt->osInitialMsg = ctxt->osFailureMsg;
+          }
+          else
+          {
+            std::string osTmp(msg);
+            osTmp += "\n[...]\nMay be caused by: ";
+            osTmp += ctxt->osInitialMsg;
+            ctxt->osFailureMsg = std::move(osTmp);
+          }
+        }
+    }
+    catch( const std::exception& )
+    {
+        ctxt->bMemoryError = true;
     }
   }
 }
@@ -167,7 +183,12 @@ static void popErrorHandler()
     PythonBindingErrorHandlerContext* ctxt = static_cast<
       PythonBindingErrorHandlerContext*>(CPLGetErrorHandlerUserData());
     CPLPopErrorHandler();
-    if( !ctxt->osFailureMsg.empty() )
+    if( ctxt->bMemoryError )
+    {
+        CPLErrorSetState(
+          CE_Failure, CPLE_OutOfMemory, "Out of memory");
+    }
+    else if( !ctxt->osFailureMsg.empty() )
     {
       CPLErrorSetState(
           CPLGetLastErrorType() == CE_Failure ? CE_Failure: CE_Warning,


### PR DESCRIPTION
On the test case of
https://lists.osgeo.org/pipermail/gdal-dev/2024-July/059158.html, this reduces the runtime to 8 minutes (with GeoParquet output, without spatial sorting), by optimizing some implementation details.
I believe this could be further reduced as most of the time is still spent in malloc/free of temporary objects (the output is 90 million polygons!) and some objects could be reused, but that would be more extensive changes
