### PR TITLE
gdalinfo: add -nonodata and -nomask options

### DIFF
--- a/autotest/utilities/test_gdalinfo_lib.py
+++ b/autotest/utilities/test_gdalinfo_lib.py
@@ -309,3 +309,35 @@ def test_gdalinfo_lib_json_engineering_crs():
     assert "coordinateSystem" in ret
     assert "cornerCoordinates" in ret
     assert "wgs84Extent" not in ret
+
+
+###############################################################################
+# Test -nonodata
+
+
+def test_gdalinfo_lib_nonodata(tmp_path):
+
+    ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    ds.GetRasterBand(1).SetNoDataValue(1)
+
+    ret = gdal.Info(ds, format="json")
+    assert "noDataValue" in ret["bands"][0]
+
+    ret = gdal.Info(ds, format="json", showNodata=False)
+    assert "noDataValue" not in ret["bands"][0]
+
+
+###############################################################################
+# Test -nomask
+
+
+def test_gdalinfo_lib_nomask(tmp_path):
+
+    ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    ds.GetRasterBand(1).CreateMaskBand(gdal.GMF_PER_DATASET)
+
+    ret = gdal.Info(ds, format="json")
+    assert "mask" in ret["bands"][0]
+
+    ret = gdal.Info(ds, format="json", showMask=False)
+    assert "mask" not in ret["bands"][0]

--- a/doc/source/programs/gdalinfo.rst
+++ b/doc/source/programs/gdalinfo.rst
@@ -17,7 +17,7 @@ Synopsis
 
     gdalinfo [--help] [--help-general]
              [-json] [-mm] [-stats | -approx_stats] [-hist]
-             [-nogcp] [-nomd] [-norat] [-noct] [-nofl]
+             [-nogcp] [-nomd] [-norat] [-noct] [-nofl] [-nonodata] [-nomask]
              [-checksum] [-listmdd] [-mdd <domain>|all]
              [-proj4] [-wkt_format {WKT1|WKT2|<other_format>}]...
              [-sd <subdataset>] [-oo <NAME>=<VALUE>]... [-if <format>]...
@@ -82,6 +82,21 @@ The following command line parameters can appear in any order
 .. option:: -noct
 
     Suppress printing of color table.
+
+.. option:: -nonodata
+
+    .. versionadded:: 3.10
+
+    Suppress nodata printing. Implies :option:`-nomask`.
+
+    Can be useful for example when querying a remove GRIB2 dataset that has an
+    index .idx side-car file, together with :option:`-nomd`
+
+.. option:: -nomask
+
+    .. versionadded:: 3.10
+
+    Suppress band mask printing. Is implied if :option:`-nonodata` is specified.
 
 .. option:: -checksum
 

--- a/frmts/grib/CMakeLists.txt
+++ b/frmts/grib/CMakeLists.txt
@@ -135,6 +135,11 @@ target_include_directories(
   gdal_GRIB PRIVATE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/degrib/degrib>
                     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/degrib/g2clib> $<TARGET_PROPERTY:gdal_MEM,SOURCE_DIR>)
 target_compile_options(gdal_GRIB PRIVATE ${GDAL_SOFTWARNFLAGS}) # FIXME: only needed for files within degrib/ actually
+
+if (BUILD_APPS)
+  target_compile_definitions(gdal_GRIB PRIVATE -DBUILD_APPS)
+endif()
+
 if (GDAL_USE_PNG_INTERNAL)
   gdal_add_vendored_lib(gdal_GRIB libpng)
   target_compile_definitions(gdal_GRIB PRIVATE -DUSE_PNG)

--- a/frmts/grib/gribdataset.h
+++ b/frmts/grib/gribdataset.h
@@ -44,6 +44,7 @@
 #if HAVE_FCNTL_H
 #include <fcntl.h>
 #endif
+#include <time.h>
 
 #include <algorithm>
 #include <memory>
@@ -114,8 +115,7 @@ class GRIBDataset final : public GDALPamDataset
   private:
     void SetGribMetaData(grib_MetaData *meta);
     static GDALDataset *OpenMultiDim(GDALOpenInfo *);
-    static std::unique_ptr<gdal::grib::InventoryWrapper>
-    Inventory(VSILFILE *, GDALOpenInfo *);
+    std::unique_ptr<gdal::grib::InventoryWrapper> Inventory(GDALOpenInfo *);
 
     VSILFILE *fp;
     // Calculate and store once as GetGeoTransform may be called multiple times.
@@ -135,6 +135,14 @@ class GRIBDataset final : public GDALPamDataset
     std::shared_ptr<OGRSpatialReference> m_poSRS{};
     std::unique_ptr<OGRSpatialReference> m_poLL{};
     std::unique_ptr<OGRCoordinateTransformation> m_poCT{};
+
+#ifdef BUILD_APPS
+    bool m_bSideCarIdxUsed = false;
+    bool m_bWarnedGdalinfoNomd = false;
+    time_t m_nFirstMetadataQueriedTimeStamp = 0;
+    bool m_bWarnedGdalinfoNonodata = false;
+    time_t m_nFirstNodataQueriedTimeStamp = 0;
+#endif
 };
 
 /************************************************************************/

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -2190,6 +2190,7 @@ def InfoOptions(options=None, format='text', deserialize=True,
          computeMinMax=False, reportHistograms=False, reportProj4=False,
          stats=False, approxStats=False, computeChecksum=False,
          showGCPs=True, showMetadata=True, showRAT=True, showColorTable=True,
+         showNodata=True, showMask=True,
          listMDD=False, showFileList=True, allMetadata=False,
          extraMDDomains=None, wktFormat=None):
     """ Create a InfoOptions() object that can be passed to gdal.Info()
@@ -2231,6 +2232,10 @@ def InfoOptions(options=None, format='text', deserialize=True,
             new_options += ['-norat']
         if not showColorTable:
             new_options += ['-noct']
+        if not showNodata:
+            new_options += ['-nonodata']
+        if not showMask:
+            new_options += ['-nomask']
         if listMDD:
             new_options += ['-listmdd']
         if not showFileList:


### PR DESCRIPTION
and: GRIB: display hint to speed-up operations when using gdalinfo on a remote GRIB2 file with an .idx side car file

Demo:
```
$ gdalinfo /vsis3/noaa-hrrr-bdp-pds/hrrr.20220804/conus/hrrr.t00z.wrfsfcf01.grib2
Warning 1: If metadata does not matter, faster result could be obtained by adding the -nomd switch to gdalinfo
Warning 1: If nodata value does not matter, faster result could be obtained by adding the -nonodata switch to gdalinfo
```