### PR TITLE
LIBKML writing: validate longitude, latitude to be in range

### DIFF
--- a/ogr/ogrsf_frmts/libkml/ogrlibkmlfeature.cpp
+++ b/ogr/ogrsf_frmts/libkml/ogrlibkmlfeature.cpp
@@ -456,6 +456,8 @@ FeaturePtr feat2kml(OGRLIBKMLDataSource *poOgrDS, OGRLIBKMLLayer *poOgrLayer,
             }
 
             ElementPtr poKmlElement = geom2kml(poOgrGeom, -1, poKmlFactory);
+            if (!poKmlElement)
+                return nullptr;
 
             poKmlPhotoOverlay->set_point(AsPoint(std::move(poKmlElement)));
         }
@@ -809,9 +811,14 @@ FeaturePtr feat2kml(OGRLIBKMLDataSource *poOgrDS, OGRLIBKMLLayer *poOgrLayer,
         const PlacemarkPtr poKmlPlacemark = poKmlFactory->CreatePlacemark();
         poKmlFeature = poKmlPlacemark;
 
-        ElementPtr poKmlElement = geom2kml(poOgrGeom, -1, poKmlFactory);
+        if (poOgrGeom)
+        {
+            ElementPtr poKmlElement = geom2kml(poOgrGeom, -1, poKmlFactory);
+            if (!poKmlElement)
+                return nullptr;
 
-        poKmlPlacemark->set_geometry(AsGeometry(std::move(poKmlElement)));
+            poKmlPlacemark->set_geometry(AsGeometry(std::move(poKmlElement)));
+        }
     }
 
     if (!camera)

--- a/ogr/ogrsf_frmts/libkml/ogrlibkmllayer.cpp
+++ b/ogr/ogrsf_frmts/libkml/ogrlibkmllayer.cpp
@@ -509,6 +509,8 @@ OGRErr OGRLIBKMLLayer::ICreateFeature(OGRFeature *poOgrFeat)
     FeaturePtr poKmlFeature =
         feat2kml(m_poOgrDS, this, poOgrFeat, m_poOgrDS->GetKmlFactory(),
                  m_bUseSimpleField);
+    if (!poKmlFeature)
+        return OGRERR_FAILURE;
 
     if (poGeomBackup)
         poOgrFeat->SetGeometryDirectly(poGeomBackup);


### PR DESCRIPTION
- For longitudes, accept in range [-540,540] and normalize to [-180,180]. Error out beyond
- For latitudes, accept in range [-90,90]. Error out beyond

Fixes #10483
