### PR TITLE
CPLFormFilename()/CPLGetDirname()/CPLGetPath(): make it work with 'vsicurl/http://example.com?foo'…

### DIFF
--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -1062,6 +1062,25 @@ TEST_F(test_cpl, CPLFormFilename)
     EXPECT_TRUE(
         EQUAL(CPLFormFilename("\\\\$\\c:", "..", nullptr), "\\\\$\\c:/..") ||
         EQUAL(CPLFormFilename("\\\\$\\c:", "..", nullptr), "\\\\$\\c:\\.."));
+    EXPECT_STREQ(
+        CPLFormFilename("/vsicurl/http://example.com?foo", "bar", nullptr),
+        "/vsicurl/http://example.com/bar?foo");
+}
+
+TEST_F(test_cpl, CPLGetPath)
+{
+    EXPECT_STREQ(CPLGetPath("/foo/bar/"), "/foo/bar");
+    EXPECT_STREQ(CPLGetPath("/foo/bar"), "/foo");
+    EXPECT_STREQ(CPLGetPath("/vsicurl/http://example.com/foo/bar?suffix"),
+                 "/vsicurl/http://example.com/foo?suffix");
+}
+
+TEST_F(test_cpl, CPLGetDirname)
+{
+    EXPECT_STREQ(CPLGetDirname("/foo/bar/"), "/foo/bar");
+    EXPECT_STREQ(CPLGetDirname("/foo/bar"), "/foo");
+    EXPECT_STREQ(CPLGetDirname("/vsicurl/http://example.com/foo/bar?suffix"),
+                 "/vsicurl/http://example.com/foo?suffix");
 }
 
 TEST_F(test_cpl, VSIGetDiskFreeSpace)

--- a/gcore/gdalmultidim.cpp
+++ b/gcore/gdalmultidim.cpp
@@ -4243,6 +4243,17 @@ GDALMDArray::GetCacheRootGroup(bool bCanCreate,
     }
 
     osCacheFilenameOut = osFilename + ".gmac";
+    if (STARTS_WITH(osFilename.c_str(), "/vsicurl/http"))
+    {
+        const auto nPosQuestionMark = osFilename.find('?');
+        if (nPosQuestionMark != std::string::npos)
+        {
+            osCacheFilenameOut =
+                osFilename.substr(0, nPosQuestionMark)
+                    .append(".gmac")
+                    .append(osFilename.substr(nPosQuestionMark));
+        }
+    }
     const char *pszProxy = PamGetProxy(osCacheFilenameOut.c_str());
     if (pszProxy != nullptr)
         osCacheFilenameOut = pszProxy;


### PR DESCRIPTION
… type of filename, to fix Zarr driver

Fixes https://github.com/OSGeo/gdal/issues/9749#issuecomment-2230935288

Now the following suceeds
```
$ export TOKEN=$(curl --silent "https://planetarycomputer.microsoft.com/api/sas/v1/token/cil-gdpcir-cc0" | jq -r .token)
$ gdalmdiminfo 'ZARR:"/vsicurl/https://rhgeuwest.blob.core.windows.net/cil-gdpcir/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/pr/v1.1.zarr?"'$TOKEN'""'
```
as well as

```
$ gdalmdiminfo 'ZARR:"/vsicurl/https://rhgeuwest.blob.core.windows.net/cil-gdpcir/ScenarioMIP/BCC/BCC-CSM2-MR/ssp126/r1i1p1f1/day/pr/v1.1.zarr?"'$TOKEN'""' -array /lon -detailed
{
  "type": "array",
  "name": "lon",
  "datatype": "Float64",
  "dimensions": [
    {
      "name": "lon",
      "full_name": "/lon",
      "size": 1440,
      "indexing_variable": {
        "lon": {
          "datatype": "Float64",
          "dimensions": [
            "/lon"
          ],
          "dimension_size": [
            1440
          ],
          "block_size": [
            1440
          ],
          "attributes": {
            "long_name": {
              "datatype": "String",
              "value": "longitude"
            }
          },
          "unit": "degrees_east",
          "nodata_value": "NaN",
          "values": [-179.875, -179.625, -179.375, -179.125, -178.875, -178.625, -178.375, -178.125, -177.875, -177.625, -177.375, -177.125, -176.875, -176.625, -176.375, -176.125, -175.875, -175.625, -175.375, -175.125, -174.875, -174.625, -174.375, -174.125, -173.875, -173.625, -173.375, -173.125, -172.875, -172.625, -172.375, -172.125, -171.875, -171.625, -171.375, -171.125, -170.875, -170.625, -170.375, -170.125, -169.875, -169.625, -169.375, -169.125, -168.875, -168.625, -168.375, -168.125, -167.875, -167.625, -167.375, -167.125, -166.875, -166.625, -166.375, -166.125, -165.875, -165.625, -165.375, -165.125, -164.875, -164.625, -164.375, -164.125, -163.875, -163.625, -163.375, -163.125, -162.875, -162.625, -162.375, -162.125, -161.875, -161.625, -161.375, -161.125, -160.875, -160.625, -160.375, -160.125, -159.875, -159.625, -159.375, -159.125, -158.875, -158.625, -158.375, -158.125, -157.875, -157.625, -157.375, -157.125, -156.875, -156.625, -156.375, -156.125, -155.875, -155.625, -155.375, -155.125, -154.875, -154.625, -154.375, -154.125, -153.875, -153.625, -153.375, -153.125, -152.875, -152.625, -152.375, -152.125, -151.875, -151.625, -151.375, -151.125, -150.875, -150.625, -150.375, -150.125, -149.875, -149.625, -149.375, -149.125, -148.875, -148.625, -148.375, -148.125, -147.875, -147.625, -147.375, -147.125, -146.875, -146.625, -146.375, -146.125, -145.875, -145.625, -145.375, -145.125, -144.875, -144.625, -144.375, -144.125, -143.875, -143.625, -143.375, -143.125, -142.875, -142.625, -142.375, -142.125, -141.875, -141.625, -141.375, -141.125, -140.875, -140.625, -140.375, -140.125, -139.875, -139.625, -139.375, -139.125, -138.875, -138.625, -138.375, -138.125, -137.875, -137.625, -137.375, -137.125, -136.875, -136.625, -136.375, -136.125, -135.875, -135.625, -135.375, -135.125, -134.875, -134.625, -134.375, -134.125, -133.875, -133.625, -133.375, -133.125, -132.875, -132.625, -132.375, -132.125, -131.875, -131.625, -131.375, -131.125, -130.875, -130.625, -130.375, -130.125, -129.875, -129.625, -129.375, -129.125, -128.875, -128.625, -128.375, -128.125, -127.875, -127.625, -127.375, -127.125, -126.875, -126.625, -126.375, -126.125, -125.875, -125.625, -125.375, -125.125, -124.875, -124.625, -124.375, -124.125, -123.875, -123.625, -123.375, -123.125, -122.875, -122.625, -122.375, -122.125, -121.875, -121.625, -121.375, -121.125, -120.875, -120.625, -120.375, -120.125, -119.875, -119.625, -119.375, -119.125, -118.875, -118.625, -118.375, -118.125, -117.875, -117.625, -117.375, -117.125, -116.875, -116.625, -116.375, -116.125, -115.875, -115.625, -115.375, -115.125, -114.875, -114.625, -114.375, -114.125, -113.875, -113.625, -113.375, -113.125, -112.875, -112.625, -112.375, -112.125, -111.875, -111.625, -111.375, -111.125, -110.875, -110.625, -110.375, -110.125, -109.875, -109.625, -109.375, -109.125, -108.875, -108.625, -108.375, -108.125, -107.875, -107.625, -107.375, -107.125, -106.875, -106.625, -106.375, -106.125, -105.875, -105.625, -105.375, -105.125, -104.875, -104.625, -104.375, -104.125, -103.875, -103.625, -103.375, -103.125, -102.875, -102.625, -102.375, -102.125, -101.875, -101.625, -101.375, -101.125, -100.875, -100.625, -100.375, -100.125, -99.875, -99.625, -99.375, -99.125, -98.875, -98.625, -98.375, -98.125, -97.875, -97.625, -97.375, -97.125, -96.875, -96.625, -96.375, -96.125, -95.875, -95.625, -95.375, -95.125, -94.875, -94.625, -94.375, -94.125, -93.875, -93.625, -93.375, -93.125, -92.875, -92.625, -92.375, -92.125, -91.875, -91.625, -91.375, -91.125, -90.875, -90.625, -90.375, -90.125, -89.875, -89.625, -89.375, -89.125, -88.875, -88.625, -88.375, -88.125, -87.875, -87.625, -87.375, -87.125, -86.875, -86.625, -86.375, -86.125, -85.875, -85.625, -85.375, -85.125, -84.875, -84.625, -84.375, -84.125, -83.875, -83.625, -83.375, -83.125, -82.875, -82.625, -82.375, -82.125, -81.875, -81.625, -81.375, -81.125, -80.875, -80.625, -80.375, -80.125, -79.875, -79.625, -79.375, -79.125, -78.875, -78.625, -78.375, -78.125, -77.875, -77.625, -77.375, -77.125, -76.875, -76.625, -76.375, -76.125, -75.875, -75.625, -75.375, -75.125, -74.875, -74.625, -74.375, -74.125, -73.875, -73.625, -73.375, -73.125, -72.875, -72.625, -72.375, -72.125, -71.875, -71.625, -71.375, -71.125, -70.875, -70.625, -70.375, -70.125, -69.875, -69.625, -69.375, -69.125, -68.875, -68.625, -68.375, -68.125, -67.875, -67.625, -67.375, -67.125, -66.875, -66.625, -66.375, -66.125, -65.875, -65.625, -65.375, -65.125, -64.875, -64.625, -64.375, -64.125, -63.875, -63.625, -63.375, -63.125, -62.875, -62.625, -62.375, -62.125, -61.875, -61.625, -61.375, -61.125, -60.875, -60.625, -60.375, -60.125, -59.875, -59.625, -59.375, -59.125, -58.875, -58.625, -58.375, -58.125, -57.875, -57.625, -57.375, -57.125, -56.875, -56.625, -56.375, -56.125, -55.875, -55.625, -55.375, -55.125, -54.875, -54.625, -54.375, -54.125, -53.875, -53.625, -53.375, -53.125, -52.875, -52.625, -52.375, -52.125, -51.875, -51.625, -51.375, -51.125, -50.875, -50.625, -50.375, -50.125, -49.875, -49.625, -49.375, -49.125, -48.875, -48.625, -48.375, -48.125, -47.875, -47.625, -47.375, -47.125, -46.875, -46.625, -46.375, -46.125, -45.875, -45.625, -45.375, -45.125, -44.875, -44.625, -44.375, -44.125, -43.875, -43.625, -43.375, -43.125, -42.875, -42.625, -42.375, -42.125, -41.875, -41.625, -41.375, -41.125, -40.875, -40.625, -40.375, -40.125, -39.875, -39.625, -39.375, -39.125, -38.875, -38.625, -38.375, -38.125, -37.875, -37.625, -37.375, -37.125, -36.875, -36.625, -36.375, -36.125, -35.875, -35.625, -35.375, -35.125, -34.875, -34.625, -34.375, -34.125, -33.875, -33.625, -33.375, -33.125, -32.875, -32.625, -32.375, -32.125, -31.875, -31.625, -31.375, -31.125, -30.875, -30.625, -30.375, -30.125, -29.875, -29.625, -29.375, -29.125, -28.875, -28.625, -28.375, -28.125, -27.875, -27.625, -27.375, -27.125, -26.875, -26.625, -26.375, -26.125, -25.875, -25.625, -25.375, -25.125, -24.875, -24.625, -24.375, -24.125, -23.875, -23.625, -23.375, -23.125, -22.875, -22.625, -22.375, -22.125, -21.875, -21.625, -21.375, -21.125, -20.875, -20.625, -20.375, -20.125, -19.875, -19.625, -19.375, -19.125, -18.875, -18.625, -18.375, -18.125, -17.875, -17.625, -17.375, -17.125, -16.875, -16.625, -16.375, -16.125, -15.875, -15.625, -15.375, -15.125, -14.875, -14.625, -14.375, -14.125, -13.875, -13.625, -13.375, -13.125, -12.875, -12.625, -12.375, -12.125, -11.875, -11.625, -11.375, -11.125, -10.875, -10.625, -10.375, -10.125, -9.875, -9.625, -9.375, -9.125, -8.875, -8.625, -8.375, -8.125, -7.875, -7.625, -7.375, -7.125, -6.875, -6.625, -6.375, -6.125, -5.875, -5.625, -5.375, -5.125, -4.875, -4.625, -4.375, -4.125, -3.875, -3.625, -3.375, -3.125, -2.875, -2.625, -2.375, -2.125, -1.875, -1.625, -1.375, -1.125, -0.875, -0.625, -0.375, -0.125, 0.125, 0.375, 0.625, 0.875, 1.125, 1.375, 1.625, 1.875, 2.125, 2.375, 2.625, 2.875, 3.125, 3.375, 3.625, 3.875, 4.125, 4.375, 4.625, 4.875, 5.125, 5.375, 5.625, 5.875, 6.125, 6.375, 6.625, 6.875, 7.125, 7.375, 7.625, 7.875, 8.125, 8.375, 8.625, 8.875, 9.125, 9.375, 9.625, 9.875, 10.125, 10.375, 10.625, 10.875, 11.125, 11.375, 11.625, 11.875, 12.125, 12.375, 12.625, 12.875, 13.125, 13.375, 13.625, 13.875, 14.125, 14.375, 14.625, 14.875, 15.125, 15.375, 15.625, 15.875, 16.125, 16.375, 16.625, 16.875, 17.125, 17.375, 17.625, 17.875, 18.125, 18.375, 18.625, 18.875, 19.125, 19.375, 19.625, 19.875, 20.125, 20.375, 20.625, 20.875, 21.125, 21.375, 21.625, 21.875, 22.125, 22.375, 22.625, 22.875, 23.125, 23.375, 23.625, 23.875, 24.125, 24.375, 24.625, 24.875, 25.125, 25.375, 25.625, 25.875, 26.125, 26.375, 26.625, 26.875, 27.125, 27.375, 27.625, 27.875, 28.125, 28.375, 28.625, 28.875, 29.125, 29.375, 29.625, 29.875, 30.125, 30.375, 30.625, 30.875, 31.125, 31.375, 31.625, 31.875, 32.125, 32.375, 32.625, 32.875, 33.125, 33.375, 33.625, 33.875, 34.125, 34.375, 34.625, 34.875, 35.125, 35.375, 35.625, 35.875, 36.125, 36.375, 36.625, 36.875, 37.125, 37.375, 37.625, 37.875, 38.125, 38.375, 38.625, 38.875, 39.125, 39.375, 39.625, 39.875, 40.125, 40.375, 40.625, 40.875, 41.125, 41.375, 41.625, 41.875, 42.125, 42.375, 42.625, 42.875, 43.125, 43.375, 43.625, 43.875, 44.125, 44.375, 44.625, 44.875, 45.125, 45.375, 45.625, 45.875, 46.125, 46.375, 46.625, 46.875, 47.125, 47.375, 47.625, 47.875, 48.125, 48.375, 48.625, 48.875, 49.125, 49.375, 49.625, 49.875, 50.125, 50.375, 50.625, 50.875, 51.125, 51.375, 51.625, 51.875, 52.125, 52.375, 52.625, 52.875, 53.125, 53.375, 53.625, 53.875, 54.125, 54.375, 54.625, 54.875, 55.125, 55.375, 55.625, 55.875, 56.125, 56.375, 56.625, 56.875, 57.125, 57.375, 57.625, 57.875, 58.125, 58.375, 58.625, 58.875, 59.125, 59.375, 59.625, 59.875, 60.125, 60.375, 60.625, 60.875, 61.125, 61.375, 61.625, 61.875, 62.125, 62.375, 62.625, 62.875, 63.125, 63.375, 63.625, 63.875, 64.125, 64.375, 64.625, 64.875, 65.125, 65.375, 65.625, 65.875, 66.125, 66.375, 66.625, 66.875, 67.125, 67.375, 67.625, 67.875, 68.125, 68.375, 68.625, 68.875, 69.125, 69.375, 69.625, 69.875, 70.125, 70.375, 70.625, 70.875, 71.125, 71.375, 71.625, 71.875, 72.125, 72.375, 72.625, 72.875, 73.125, 73.375, 73.625, 73.875, 74.125, 74.375, 74.625, 74.875, 75.125, 75.375, 75.625, 75.875, 76.125, 76.375, 76.625, 76.875, 77.125, 77.375, 77.625, 77.875, 78.125, 78.375, 78.625, 78.875, 79.125, 79.375, 79.625, 79.875, 80.125, 80.375, 80.625, 80.875, 81.125, 81.375, 81.625, 81.875, 82.125, 82.375, 82.625, 82.875, 83.125, 83.375, 83.625, 83.875, 84.125, 84.375, 84.625, 84.875, 85.125, 85.375, 85.625, 85.875, 86.125, 86.375, 86.625, 86.875, 87.125, 87.375, 87.625, 87.875, 88.125, 88.375, 88.625, 88.875, 89.125, 89.375, 89.625, 89.875, 90.125, 90.375, 90.625, 90.875, 91.125, 91.375, 91.625, 91.875, 92.125, 92.375, 92.625, 92.875, 93.125, 93.375, 93.625, 93.875, 94.125, 94.375, 94.625, 94.875, 95.125, 95.375, 95.625, 95.875, 96.125, 96.375, 96.625, 96.875, 97.125, 97.375, 97.625, 97.875, 98.125, 98.375, 98.625, 98.875, 99.125, 99.375, 99.625, 99.875, 100.125, 100.375, 100.625, 100.875, 101.125, 101.375, 101.625, 101.875, 102.125, 102.375, 102.625, 102.875, 103.125, 103.375, 103.625, 103.875, 104.125, 104.375, 104.625, 104.875, 105.125, 105.375, 105.625, 105.875, 106.125, 106.375, 106.625, 106.875, 107.125, 107.375, 107.625, 107.875, 108.125, 108.375, 108.625, 108.875, 109.125, 109.375, 109.625, 109.875, 110.125, 110.375, 110.625, 110.875, 111.125, 111.375, 111.625, 111.875, 112.125, 112.375, 112.625, 112.875, 113.125, 113.375, 113.625, 113.875, 114.125, 114.375, 114.625, 114.875, 115.125, 115.375, 115.625, 115.875, 116.125, 116.375, 116.625, 116.875, 117.125, 117.375, 117.625, 117.875, 118.125, 118.375, 118.625, 118.875, 119.125, 119.375, 119.625, 119.875, 120.125, 120.375, 120.625, 120.875, 121.125, 121.375, 121.625, 121.875, 122.125, 122.375, 122.625, 122.875, 123.125, 123.375, 123.625, 123.875, 124.125, 124.375, 124.625, 124.875, 125.125, 125.375, 125.625, 125.875, 126.125, 126.375, 126.625, 126.875, 127.125, 127.375, 127.625, 127.875, 128.125, 128.375, 128.625, 128.875, 129.125, 129.375, 129.625, 129.875, 130.125, 130.375, 130.625, 130.875, 131.125, 131.375, 131.625, 131.875, 132.125, 132.375, 132.625, 132.875, 133.125, 133.375, 133.625, 133.875, 134.125, 134.375, 134.625, 134.875, 135.125, 135.375, 135.625, 135.875, 136.125, 136.375, 136.625, 136.875, 137.125, 137.375, 137.625, 137.875, 138.125, 138.375, 138.625, 138.875, 139.125, 139.375, 139.625, 139.875, 140.125, 140.375, 140.625, 140.875, 141.125, 141.375, 141.625, 141.875, 142.125, 142.375, 142.625, 142.875, 143.125, 143.375, 143.625, 143.875, 144.125, 144.375, 144.625, 144.875, 145.125, 145.375, 145.625, 145.875, 146.125, 146.375, 146.625, 146.875, 147.125, 147.375, 147.625, 147.875, 148.125, 148.375, 148.625, 148.875, 149.125, 149.375, 149.625, 149.875, 150.125, 150.375, 150.625, 150.875, 151.125, 151.375, 151.625, 151.875, 152.125, 152.375, 152.625, 152.875, 153.125, 153.375, 153.625, 153.875, 154.125, 154.375, 154.625, 154.875, 155.125, 155.375, 155.625, 155.875, 156.125, 156.375, 156.625, 156.875, 157.125, 157.375, 157.625, 157.875, 158.125, 158.375, 158.625, 158.875, 159.125, 159.375, 159.625, 159.875, 160.125, 160.375, 160.625, 160.875, 161.125, 161.375, 161.625, 161.875, 162.125, 162.375, 162.625, 162.875, 163.125, 163.375, 163.625, 163.875, 164.125, 164.375, 164.625, 164.875, 165.125, 165.375, 165.625, 165.875, 166.125, 166.375, 166.625, 166.875, 167.125, 167.375, 167.625, 167.875, 168.125, 168.375, 168.625, 168.875, 169.125, 169.375, 169.625, 169.875, 170.125, 170.375, 170.625, 170.875, 171.125, 171.375, 171.625, 171.875, 172.125, 172.375, 172.625, 172.875, 173.125, 173.375, 173.625, 173.875, 174.125, 174.375, 174.625, 174.875, 175.125, 175.375, 175.625, 175.875, 176.125, 176.375, 176.625, 176.875, 177.125, 177.375, 177.625, 177.875, 178.125, 178.375, 178.625, 178.875, 179.125, 179.375, 179.625, 179.875]
        }
      }
    }
  ],
  "dimension_size": [
    1440
  ],
  "block_size": [
    1440
  ],
  "attributes": {
    "long_name": {
      "datatype": "String",
      "value": "longitude"
    }
  },
  "unit": "degrees_east",
  "nodata_value": "NaN",
  "values": [-179.875, -179.625, -179.375, -179.125, -178.875, -178.625, -178.375, -178.125, -177.875, -177.625, -177.375, -177.125, -176.875, -176.625, -176.375, -176.125, -175.875, -175.625, -175.375, -175.125, -174.875, -174.625, -174.375, -174.125, -173.875, -173.625, -173.375, -173.125, -172.875, -172.625, -172.375, -172.125, -171.875, -171.625, -171.375, -171.125, -170.875, -170.625, -170.375, -170.125, -169.875, -169.625, -169.375, -169.125, -168.875, -168.625, -168.375, -168.125, -167.875, -167.625, -167.375, -167.125, -166.875, -166.625, -166.375, -166.125, -165.875, -165.625, -165.375, -165.125, -164.875, -164.625, -164.375, -164.125, -163.875, -163.625, -163.375, -163.125, -162.875, -162.625, -162.375, -162.125, -161.875, -161.625, -161.375, -161.125, -160.875, -160.625, -160.375, -160.125, -159.875, -159.625, -159.375, -159.125, -158.875, -158.625, -158.375, -158.125, -157.875, -157.625, -157.375, -157.125, -156.875, -156.625, -156.375, -156.125, -155.875, -155.625, -155.375, -155.125, -154.875, -154.625, -154.375, -154.125, -153.875, -153.625, -153.375, -153.125, -152.875, -152.625, -152.375, -152.125, -151.875, -151.625, -151.375, -151.125, -150.875, -150.625, -150.375, -150.125, -149.875, -149.625, -149.375, -149.125, -148.875, -148.625, -148.375, -148.125, -147.875, -147.625, -147.375, -147.125, -146.875, -146.625, -146.375, -146.125, -145.875, -145.625, -145.375, -145.125, -144.875, -144.625, -144.375, -144.125, -143.875, -143.625, -143.375, -143.125, -142.875, -142.625, -142.375, -142.125, -141.875, -141.625, -141.375, -141.125, -140.875, -140.625, -140.375, -140.125, -139.875, -139.625, -139.375, -139.125, -138.875, -138.625, -138.375, -138.125, -137.875, -137.625, -137.375, -137.125, -136.875, -136.625, -136.375, -136.125, -135.875, -135.625, -135.375, -135.125, -134.875, -134.625, -134.375, -134.125, -133.875, -133.625, -133.375, -133.125, -132.875, -132.625, -132.375, -132.125, -131.875, -131.625, -131.375, -131.125, -130.875, -130.625, -130.375, -130.125, -129.875, -129.625, -129.375, -129.125, -128.875, -128.625, -128.375, -128.125, -127.875, -127.625, -127.375, -127.125, -126.875, -126.625, -126.375, -126.125, -125.875, -125.625, -125.375, -125.125, -124.875, -124.625, -124.375, -124.125, -123.875, -123.625, -123.375, -123.125, -122.875, -122.625, -122.375, -122.125, -121.875, -121.625, -121.375, -121.125, -120.875, -120.625, -120.375, -120.125, -119.875, -119.625, -119.375, -119.125, -118.875, -118.625, -118.375, -118.125, -117.875, -117.625, -117.375, -117.125, -116.875, -116.625, -116.375, -116.125, -115.875, -115.625, -115.375, -115.125, -114.875, -114.625, -114.375, -114.125, -113.875, -113.625, -113.375, -113.125, -112.875, -112.625, -112.375, -112.125, -111.875, -111.625, -111.375, -111.125, -110.875, -110.625, -110.375, -110.125, -109.875, -109.625, -109.375, -109.125, -108.875, -108.625, -108.375, -108.125, -107.875, -107.625, -107.375, -107.125, -106.875, -106.625, -106.375, -106.125, -105.875, -105.625, -105.375, -105.125, -104.875, -104.625, -104.375, -104.125, -103.875, -103.625, -103.375, -103.125, -102.875, -102.625, -102.375, -102.125, -101.875, -101.625, -101.375, -101.125, -100.875, -100.625, -100.375, -100.125, -99.875, -99.625, -99.375, -99.125, -98.875, -98.625, -98.375, -98.125, -97.875, -97.625, -97.375, -97.125, -96.875, -96.625, -96.375, -96.125, -95.875, -95.625, -95.375, -95.125, -94.875, -94.625, -94.375, -94.125, -93.875, -93.625, -93.375, -93.125, -92.875, -92.625, -92.375, -92.125, -91.875, -91.625, -91.375, -91.125, -90.875, -90.625, -90.375, -90.125, -89.875, -89.625, -89.375, -89.125, -88.875, -88.625, -88.375, -88.125, -87.875, -87.625, -87.375, -87.125, -86.875, -86.625, -86.375, -86.125, -85.875, -85.625, -85.375, -85.125, -84.875, -84.625, -84.375, -84.125, -83.875, -83.625, -83.375, -83.125, -82.875, -82.625, -82.375, -82.125, -81.875, -81.625, -81.375, -81.125, -80.875, -80.625, -80.375, -80.125, -79.875, -79.625, -79.375, -79.125, -78.875, -78.625, -78.375, -78.125, -77.875, -77.625, -77.375, -77.125, -76.875, -76.625, -76.375, -76.125, -75.875, -75.625, -75.375, -75.125, -74.875, -74.625, -74.375, -74.125, -73.875, -73.625, -73.375, -73.125, -72.875, -72.625, -72.375, -72.125, -71.875, -71.625, -71.375, -71.125, -70.875, -70.625, -70.375, -70.125, -69.875, -69.625, -69.375, -69.125, -68.875, -68.625, -68.375, -68.125, -67.875, -67.625, -67.375, -67.125, -66.875, -66.625, -66.375, -66.125, -65.875, -65.625, -65.375, -65.125, -64.875, -64.625, -64.375, -64.125, -63.875, -63.625, -63.375, -63.125, -62.875, -62.625, -62.375, -62.125, -61.875, -61.625, -61.375, -61.125, -60.875, -60.625, -60.375, -60.125, -59.875, -59.625, -59.375, -59.125, -58.875, -58.625, -58.375, -58.125, -57.875, -57.625, -57.375, -57.125, -56.875, -56.625, -56.375, -56.125, -55.875, -55.625, -55.375, -55.125, -54.875, -54.625, -54.375, -54.125, -53.875, -53.625, -53.375, -53.125, -52.875, -52.625, -52.375, -52.125, -51.875, -51.625, -51.375, -51.125, -50.875, -50.625, -50.375, -50.125, -49.875, -49.625, -49.375, -49.125, -48.875, -48.625, -48.375, -48.125, -47.875, -47.625, -47.375, -47.125, -46.875, -46.625, -46.375, -46.125, -45.875, -45.625, -45.375, -45.125, -44.875, -44.625, -44.375, -44.125, -43.875, -43.625, -43.375, -43.125, -42.875, -42.625, -42.375, -42.125, -41.875, -41.625, -41.375, -41.125, -40.875, -40.625, -40.375, -40.125, -39.875, -39.625, -39.375, -39.125, -38.875, -38.625, -38.375, -38.125, -37.875, -37.625, -37.375, -37.125, -36.875, -36.625, -36.375, -36.125, -35.875, -35.625, -35.375, -35.125, -34.875, -34.625, -34.375, -34.125, -33.875, -33.625, -33.375, -33.125, -32.875, -32.625, -32.375, -32.125, -31.875, -31.625, -31.375, -31.125, -30.875, -30.625, -30.375, -30.125, -29.875, -29.625, -29.375, -29.125, -28.875, -28.625, -28.375, -28.125, -27.875, -27.625, -27.375, -27.125, -26.875, -26.625, -26.375, -26.125, -25.875, -25.625, -25.375, -25.125, -24.875, -24.625, -24.375, -24.125, -23.875, -23.625, -23.375, -23.125, -22.875, -22.625, -22.375, -22.125, -21.875, -21.625, -21.375, -21.125, -20.875, -20.625, -20.375, -20.125, -19.875, -19.625, -19.375, -19.125, -18.875, -18.625, -18.375, -18.125, -17.875, -17.625, -17.375, -17.125, -16.875, -16.625, -16.375, -16.125, -15.875, -15.625, -15.375, -15.125, -14.875, -14.625, -14.375, -14.125, -13.875, -13.625, -13.375, -13.125, -12.875, -12.625, -12.375, -12.125, -11.875, -11.625, -11.375, -11.125, -10.875, -10.625, -10.375, -10.125, -9.875, -9.625, -9.375, -9.125, -8.875, -8.625, -8.375, -8.125, -7.875, -7.625, -7.375, -7.125, -6.875, -6.625, -6.375, -6.125, -5.875, -5.625, -5.375, -5.125, -4.875, -4.625, -4.375, -4.125, -3.875, -3.625, -3.375, -3.125, -2.875, -2.625, -2.375, -2.125, -1.875, -1.625, -1.375, -1.125, -0.875, -0.625, -0.375, -0.125, 0.125, 0.375, 0.625, 0.875, 1.125, 1.375, 1.625, 1.875, 2.125, 2.375, 2.625, 2.875, 3.125, 3.375, 3.625, 3.875, 4.125, 4.375, 4.625, 4.875, 5.125, 5.375, 5.625, 5.875, 6.125, 6.375, 6.625, 6.875, 7.125, 7.375, 7.625, 7.875, 8.125, 8.375, 8.625, 8.875, 9.125, 9.375, 9.625, 9.875, 10.125, 10.375, 10.625, 10.875, 11.125, 11.375, 11.625, 11.875, 12.125, 12.375, 12.625, 12.875, 13.125, 13.375, 13.625, 13.875, 14.125, 14.375, 14.625, 14.875, 15.125, 15.375, 15.625, 15.875, 16.125, 16.375, 16.625, 16.875, 17.125, 17.375, 17.625, 17.875, 18.125, 18.375, 18.625, 18.875, 19.125, 19.375, 19.625, 19.875, 20.125, 20.375, 20.625, 20.875, 21.125, 21.375, 21.625, 21.875, 22.125, 22.375, 22.625, 22.875, 23.125, 23.375, 23.625, 23.875, 24.125, 24.375, 24.625, 24.875, 25.125, 25.375, 25.625, 25.875, 26.125, 26.375, 26.625, 26.875, 27.125, 27.375, 27.625, 27.875, 28.125, 28.375, 28.625, 28.875, 29.125, 29.375, 29.625, 29.875, 30.125, 30.375, 30.625, 30.875, 31.125, 31.375, 31.625, 31.875, 32.125, 32.375, 32.625, 32.875, 33.125, 33.375, 33.625, 33.875, 34.125, 34.375, 34.625, 34.875, 35.125, 35.375, 35.625, 35.875, 36.125, 36.375, 36.625, 36.875, 37.125, 37.375, 37.625, 37.875, 38.125, 38.375, 38.625, 38.875, 39.125, 39.375, 39.625, 39.875, 40.125, 40.375, 40.625, 40.875, 41.125, 41.375, 41.625, 41.875, 42.125, 42.375, 42.625, 42.875, 43.125, 43.375, 43.625, 43.875, 44.125, 44.375, 44.625, 44.875, 45.125, 45.375, 45.625, 45.875, 46.125, 46.375, 46.625, 46.875, 47.125, 47.375, 47.625, 47.875, 48.125, 48.375, 48.625, 48.875, 49.125, 49.375, 49.625, 49.875, 50.125, 50.375, 50.625, 50.875, 51.125, 51.375, 51.625, 51.875, 52.125, 52.375, 52.625, 52.875, 53.125, 53.375, 53.625, 53.875, 54.125, 54.375, 54.625, 54.875, 55.125, 55.375, 55.625, 55.875, 56.125, 56.375, 56.625, 56.875, 57.125, 57.375, 57.625, 57.875, 58.125, 58.375, 58.625, 58.875, 59.125, 59.375, 59.625, 59.875, 60.125, 60.375, 60.625, 60.875, 61.125, 61.375, 61.625, 61.875, 62.125, 62.375, 62.625, 62.875, 63.125, 63.375, 63.625, 63.875, 64.125, 64.375, 64.625, 64.875, 65.125, 65.375, 65.625, 65.875, 66.125, 66.375, 66.625, 66.875, 67.125, 67.375, 67.625, 67.875, 68.125, 68.375, 68.625, 68.875, 69.125, 69.375, 69.625, 69.875, 70.125, 70.375, 70.625, 70.875, 71.125, 71.375, 71.625, 71.875, 72.125, 72.375, 72.625, 72.875, 73.125, 73.375, 73.625, 73.875, 74.125, 74.375, 74.625, 74.875, 75.125, 75.375, 75.625, 75.875, 76.125, 76.375, 76.625, 76.875, 77.125, 77.375, 77.625, 77.875, 78.125, 78.375, 78.625, 78.875, 79.125, 79.375, 79.625, 79.875, 80.125, 80.375, 80.625, 80.875, 81.125, 81.375, 81.625, 81.875, 82.125, 82.375, 82.625, 82.875, 83.125, 83.375, 83.625, 83.875, 84.125, 84.375, 84.625, 84.875, 85.125, 85.375, 85.625, 85.875, 86.125, 86.375, 86.625, 86.875, 87.125, 87.375, 87.625, 87.875, 88.125, 88.375, 88.625, 88.875, 89.125, 89.375, 89.625, 89.875, 90.125, 90.375, 90.625, 90.875, 91.125, 91.375, 91.625, 91.875, 92.125, 92.375, 92.625, 92.875, 93.125, 93.375, 93.625, 93.875, 94.125, 94.375, 94.625, 94.875, 95.125, 95.375, 95.625, 95.875, 96.125, 96.375, 96.625, 96.875, 97.125, 97.375, 97.625, 97.875, 98.125, 98.375, 98.625, 98.875, 99.125, 99.375, 99.625, 99.875, 100.125, 100.375, 100.625, 100.875, 101.125, 101.375, 101.625, 101.875, 102.125, 102.375, 102.625, 102.875, 103.125, 103.375, 103.625, 103.875, 104.125, 104.375, 104.625, 104.875, 105.125, 105.375, 105.625, 105.875, 106.125, 106.375, 106.625, 106.875, 107.125, 107.375, 107.625, 107.875, 108.125, 108.375, 108.625, 108.875, 109.125, 109.375, 109.625, 109.875, 110.125, 110.375, 110.625, 110.875, 111.125, 111.375, 111.625, 111.875, 112.125, 112.375, 112.625, 112.875, 113.125, 113.375, 113.625, 113.875, 114.125, 114.375, 114.625, 114.875, 115.125, 115.375, 115.625, 115.875, 116.125, 116.375, 116.625, 116.875, 117.125, 117.375, 117.625, 117.875, 118.125, 118.375, 118.625, 118.875, 119.125, 119.375, 119.625, 119.875, 120.125, 120.375, 120.625, 120.875, 121.125, 121.375, 121.625, 121.875, 122.125, 122.375, 122.625, 122.875, 123.125, 123.375, 123.625, 123.875, 124.125, 124.375, 124.625, 124.875, 125.125, 125.375, 125.625, 125.875, 126.125, 126.375, 126.625, 126.875, 127.125, 127.375, 127.625, 127.875, 128.125, 128.375, 128.625, 128.875, 129.125, 129.375, 129.625, 129.875, 130.125, 130.375, 130.625, 130.875, 131.125, 131.375, 131.625, 131.875, 132.125, 132.375, 132.625, 132.875, 133.125, 133.375, 133.625, 133.875, 134.125, 134.375, 134.625, 134.875, 135.125, 135.375, 135.625, 135.875, 136.125, 136.375, 136.625, 136.875, 137.125, 137.375, 137.625, 137.875, 138.125, 138.375, 138.625, 138.875, 139.125, 139.375, 139.625, 139.875, 140.125, 140.375, 140.625, 140.875, 141.125, 141.375, 141.625, 141.875, 142.125, 142.375, 142.625, 142.875, 143.125, 143.375, 143.625, 143.875, 144.125, 144.375, 144.625, 144.875, 145.125, 145.375, 145.625, 145.875, 146.125, 146.375, 146.625, 146.875, 147.125, 147.375, 147.625, 147.875, 148.125, 148.375, 148.625, 148.875, 149.125, 149.375, 149.625, 149.875, 150.125, 150.375, 150.625, 150.875, 151.125, 151.375, 151.625, 151.875, 152.125, 152.375, 152.625, 152.875, 153.125, 153.375, 153.625, 153.875, 154.125, 154.375, 154.625, 154.875, 155.125, 155.375, 155.625, 155.875, 156.125, 156.375, 156.625, 156.875, 157.125, 157.375, 157.625, 157.875, 158.125, 158.375, 158.625, 158.875, 159.125, 159.375, 159.625, 159.875, 160.125, 160.375, 160.625, 160.875, 161.125, 161.375, 161.625, 161.875, 162.125, 162.375, 162.625, 162.875, 163.125, 163.375, 163.625, 163.875, 164.125, 164.375, 164.625, 164.875, 165.125, 165.375, 165.625, 165.875, 166.125, 166.375, 166.625, 166.875, 167.125, 167.375, 167.625, 167.875, 168.125, 168.375, 168.625, 168.875, 169.125, 169.375, 169.625, 169.875, 170.125, 170.375, 170.625, 170.875, 171.125, 171.375, 171.625, 171.875, 172.125, 172.375, 172.625, 172.875, 173.125, 173.375, 173.625, 173.875, 174.125, 174.375, 174.625, 174.875, 175.125, 175.375, 175.625, 175.875, 176.125, 176.375, 176.625, 176.875, 177.125, 177.375, 177.625, 177.875, 178.125, 178.375, 178.625, 178.875, 179.125, 179.375, 179.625, 179.875]
}
```