### PR TITLE
Update csv.rst clarifying OGR_WKT_PRECISION

### DIFF
--- a/doc/source/drivers/vector/csv.rst
+++ b/doc/source/drivers/vector/csv.rst
@@ -502,7 +502,7 @@ The following configuration options are available:
       Number of decimals for coordinate
       values. A heuristic is used to remove insignificant
       trailing 00000x or 99999x that can appear when formatting decimal
-      numbers.
+      numbers. Examples: 6 gives 120.864, 24.1818; 2 gives 1.2E+02, 24.0.
 
 -  .. config:: OGR_WKT_ROUND
       :choices: YES, NO


### PR DESCRIPTION
Clarify OGR_WKT_PRECISION of e.g., 6 will not produce 123.123456, but instead 123.456. in contrast to C, perl, etc.  printf() usage of the word "precision."

Also show that using very low values will result in exponential notation. (Wonder if valid in WKT...)

See also 
- RFC 94: Numeric fields width/precision metadata.
- RFC 99: Geometry coordinate precision 

Indeed besides OGR_WKT_PRECISION there needs to be a new variable, else with  items nearer to the equator of prime meridian, you get a more precise value than near the poles or antimeridian. With loss of one digit occurring at 10 deg (N,S,E,W), and 100 deg(E,W).

I.e., it is a pity that OGR_WKT_PRECISION is this way, because as we see beyond 100 degrees, people lose one digit of precision. I.e., New York will have its longitude in more detail than Los Angeles...