### PR TITLE
InterpolateAtPoint near borders

### DIFF
--- a/alg/gdal_interpolateatpoint.cpp
+++ b/alg/gdal_interpolateatpoint.cpp
@@ -31,6 +31,8 @@
 
 #include "gdal_interpolateatpoint.h"
 
+#include "gdalresamplingkernels.h"
+
 #include <algorithm>
 
 static bool
@@ -134,28 +136,6 @@ GDALInterpExtractDEMWindow(GDALRasterBand *pBand,
 #endif
 
     return true;
-}
-
-static double CubicKernel(double dfX)
-{
-    // http://en.wikipedia.org/wiki/Bicubic_interpolation#Bicubic_convolution_algorithm
-    // W(x) formula with a = -0.5 (cubic hermite spline )
-    // or
-    // https://www.cs.utexas.edu/~fussell/courses/cs384g-fall2013/lectures/mitchell/Mitchell.pdf
-    // k(x) (formula 8) with (B,C)=(0,0.5) the Catmull-Rom spline
-    double dfAbsX = fabs(dfX);
-    if (dfAbsX <= 1.0)
-    {
-        double dfX2 = dfX * dfX;
-        return dfX2 * (1.5 * dfAbsX - 2.5) + 1;
-    }
-    else if (dfAbsX <= 2.0)
-    {
-        double dfX2 = dfX * dfX;
-        return dfX2 * (-0.5 * dfAbsX + 2.5) - 4 * dfAbsX + 2;
-    }
-    else
-        return 0.0;
 }
 
 /************************************************************************/
@@ -283,8 +263,8 @@ bool GDALInterpolateAtPoint(GDALRasterBand *pBand,
                 const int dKernIndY = k_i - 1;
                 const double dfPixelWeight =
                     eResampleAlg == GDALRIOResampleAlg::GRIORA_CubicSpline
-                        ? BiCubicSplineKernel(dKernIndX - dfDeltaX) *
-                              BiCubicSplineKernel(dKernIndY - dfDeltaY)
+                        ? CubicSplineKernel(dKernIndX - dfDeltaX) *
+                              CubicSplineKernel(dKernIndY - dfDeltaY)
                         : CubicKernel(dKernIndX - dfDeltaX) *
                               CubicKernel(dKernIndY - dfDeltaY);
 

--- a/alg/gdal_interpolateatpoint.cpp
+++ b/alg/gdal_interpolateatpoint.cpp
@@ -136,6 +136,28 @@ GDALInterpExtractDEMWindow(GDALRasterBand *pBand,
     return true;
 }
 
+static double CubicKernel(double dfX)
+{
+    // http://en.wikipedia.org/wiki/Bicubic_interpolation#Bicubic_convolution_algorithm
+    // W(x) formula with a = -0.5 (cubic hermite spline )
+    // or
+    // https://www.cs.utexas.edu/~fussell/courses/cs384g-fall2013/lectures/mitchell/Mitchell.pdf
+    // k(x) (formula 8) with (B,C)=(0,0.5) the Catmull-Rom spline
+    double dfAbsX = fabs(dfX);
+    if (dfAbsX <= 1.0)
+    {
+        double dfX2 = dfX * dfX;
+        return dfX2 * (1.5 * dfAbsX - 2.5) + 1;
+    }
+    else if (dfAbsX <= 2.0)
+    {
+        double dfX2 = dfX * dfX;
+        return dfX2 * (-0.5 * dfAbsX + 2.5) - 4 * dfAbsX + 2;
+    }
+    else
+        return 0.0;
+}
+
 /************************************************************************/
 /*                        GDALInterpolateAtPoint()                      */
 /************************************************************************/
@@ -151,7 +173,73 @@ bool GDALInterpolateAtPoint(GDALRasterBand *pBand,
     int bGotNoDataValue = FALSE;
     const double dfNoDataValue = pBand->GetNoDataValue(&bGotNoDataValue);
 
-    if (eResampleAlg == GDALRIOResampleAlg::GRIORA_CubicSpline)
+    if (dfXIn < 0 || dfXIn > nRasterXSize || dfYIn < 0 || dfYIn > nRasterYSize)
+    {
+        return FALSE;
+    }
+
+    // Downgrade the interpolation algorithm if the image is too small
+    if ((nRasterXSize < 4 || nRasterYSize < 4) &&
+        (eResampleAlg == GRIORA_CubicSpline || eResampleAlg == GRIORA_Cubic))
+    {
+        eResampleAlg = GRIORA_Bilinear;
+    }
+    if ((nRasterXSize < 2 || nRasterYSize < 2) &&
+        eResampleAlg == GRIORA_Bilinear)
+    {
+        eResampleAlg = GRIORA_NearestNeighbour;
+    }
+
+    auto outOfBorderCorrection = [](int dNew, int nRasterSize, int nKernelsize)
+    {
+        int dOutOfBorder = 0;
+        if (dNew < 0)
+        {
+            dOutOfBorder = dNew;
+        }
+        if (dNew + nKernelsize >= nRasterSize)
+        {
+            dOutOfBorder = dNew + nKernelsize - nRasterSize;
+        }
+        return dOutOfBorder;
+    };
+
+    auto dragElevDataInBorder =
+        [](double *adfElevData, int dOutOfBorder, int nKernelSize, bool bIsX)
+    {
+        while (dOutOfBorder < 0)
+        {
+            for (int j = 0; j < nKernelSize; j++)
+                for (int ii = 0; ii < nKernelSize - 1; ii++)
+                {
+                    const int i = nKernelSize - ii - 2;  // iterate in reverse
+                    const int row_src = bIsX ? j : i;
+                    const int row_dst = bIsX ? j : i + 1;
+                    const int col_src = bIsX ? i : j;
+                    const int col_dst = bIsX ? i + 1 : j;
+                    adfElevData[nKernelSize * row_dst + col_dst] =
+                        adfElevData[nKernelSize * row_src + col_src];
+                }
+            dOutOfBorder++;
+        }
+        while (dOutOfBorder > 0)
+        {
+            for (int j = 0; j < nKernelSize; j++)
+                for (int i = 0; i < nKernelSize - 1; i++)
+                {
+                    const int row_src = bIsX ? j : i + 1;
+                    const int row_dst = bIsX ? j : i;
+                    const int col_src = bIsX ? i + 1 : j;
+                    const int col_dst = bIsX ? i : j;
+                    adfElevData[nKernelSize * row_dst + col_dst] =
+                        adfElevData[nKernelSize * row_src + col_src];
+                }
+            dOutOfBorder--;
+        }
+    };
+
+    if (eResampleAlg == GDALRIOResampleAlg::GRIORA_CubicSpline ||
+        eResampleAlg == GDALRIOResampleAlg::GRIORA_Cubic)
     {
         // Convert from upper left corner of pixel coordinates to center of
         // pixel coordinates:
@@ -164,18 +252,22 @@ bool GDALInterpolateAtPoint(GDALRasterBand *pBand,
 
         const int dXNew = dX - 1;
         const int dYNew = dY - 1;
-        if (!(dXNew >= 0 && dYNew >= 0 && dXNew + 4 <= nRasterXSize &&
-              dYNew + 4 <= nRasterYSize))
-        {
-            goto bilinear_fallback;
-        }
+        const int nKernelSize = 4;
+        const int dXOutOfBorder =
+            outOfBorderCorrection(dXNew, nRasterXSize, nKernelSize);
+        const int dYOutOfBorder =
+            outOfBorderCorrection(dYNew, nRasterYSize, nKernelSize);
+
         // CubicSpline interpolation.
         double adfElevData[16] = {0.0};
-        if (!GDALInterpExtractDEMWindow(pBand, cache, dXNew, dYNew, 4, 4,
-                                        adfElevData))
+        if (!GDALInterpExtractDEMWindow(pBand, cache, dXNew - dXOutOfBorder,
+                                        dYNew - dYOutOfBorder, nKernelSize,
+                                        nKernelSize, adfElevData))
         {
             return FALSE;
         }
+        dragElevDataInBorder(adfElevData, dXOutOfBorder, nKernelSize, true);
+        dragElevDataInBorder(adfElevData, dYOutOfBorder, nKernelSize, false);
 
         double dfSumH = 0.0;
         double dfSumWeight = 0.0;
@@ -190,8 +282,11 @@ bool GDALInterpolateAtPoint(GDALRasterBand *pBand,
                 const int dKernIndX = k_j - 1;
                 const int dKernIndY = k_i - 1;
                 const double dfPixelWeight =
-                    BiCubicSplineKernel(dKernIndX - dfDeltaX) *
-                    BiCubicSplineKernel(dKernIndY - dfDeltaY);
+                    eResampleAlg == GDALRIOResampleAlg::GRIORA_CubicSpline
+                        ? BiCubicSplineKernel(dKernIndX - dfDeltaX) *
+                              BiCubicSplineKernel(dKernIndY - dfDeltaY)
+                        : CubicKernel(dKernIndX - dfDeltaX) *
+                              CubicKernel(dKernIndY - dfDeltaY);
 
                 // Create a sum of all values
                 // adjusted for the pixel's calculated weight.
@@ -214,7 +309,6 @@ bool GDALInterpolateAtPoint(GDALRasterBand *pBand,
     }
     else if (eResampleAlg == GDALRIOResampleAlg::GRIORA_Bilinear)
     {
-    bilinear_fallback:
         // Convert from upper left corner of pixel coordinates to center of
         // pixel coordinates:
         const double dfX = dfXIn - 0.5;
@@ -224,19 +318,22 @@ bool GDALInterpolateAtPoint(GDALRasterBand *pBand,
         const double dfDeltaX = dfX - dX;
         const double dfDeltaY = dfY - dY;
 
-        if (!(dX >= 0 && dY >= 0 && dX + 2 <= nRasterXSize &&
-              dY + 2 <= nRasterYSize))
-        {
-            goto near_fallback;
-        }
+        const int nKernelSize = 2;
+        const int dXOutOfBorder =
+            outOfBorderCorrection(dX, nRasterXSize, nKernelSize);
+        const int dYOutOfBorder =
+            outOfBorderCorrection(dY, nRasterYSize, nKernelSize);
 
         // Bilinear interpolation.
         double adfElevData[4] = {0.0, 0.0, 0.0, 0.0};
-        if (!GDALInterpExtractDEMWindow(pBand, cache, dX, dY, 2, 2,
-                                        adfElevData))
+        if (!GDALInterpExtractDEMWindow(pBand, cache, dX - dXOutOfBorder,
+                                        dY - dYOutOfBorder, nKernelSize,
+                                        nKernelSize, adfElevData))
         {
             return FALSE;
         }
+        dragElevDataInBorder(adfElevData, dXOutOfBorder, nKernelSize, true);
+        dragElevDataInBorder(adfElevData, dYOutOfBorder, nKernelSize, false);
 
         if (bGotNoDataValue)
         {
@@ -267,13 +364,8 @@ bool GDALInterpolateAtPoint(GDALRasterBand *pBand,
     }
     else
     {
-    near_fallback:
         const int dX = static_cast<int>(dfXIn);
         const int dY = static_cast<int>(dfYIn);
-        if (!(dX >= 0 && dY >= 0 && dX < nRasterXSize && dY < nRasterYSize))
-        {
-            return FALSE;
-        }
         double dfDEMH = 0.0;
         if (!GDALInterpExtractDEMWindow(pBand, cache, dX, dY, 1, 1, &dfDEMH) ||
             (bGotNoDataValue && ARE_REAL_EQUAL(dfNoDataValue, dfDEMH)))

--- a/alg/gdal_rpc.cpp
+++ b/alg/gdal_rpc.cpp
@@ -57,6 +57,7 @@
 #include "ogr_geometry.h"
 #include "ogr_spatialref.h"
 #include "ogr_srs_api.h"
+#include "gdalresamplingkernels.h"
 
 // #define DEBUG_VERBOSE_EXTRACT_DEM
 
@@ -1485,8 +1486,8 @@ GDALRPCTransformWholeLineWithDEM(const GDALRPCTransformInfo *psTransform,
                     const int dKernIndX = k_j - 1;
                     const int dKernIndY = k_i - 1;
                     const double dfPixelWeight =
-                        BiCubicSplineKernel(dKernIndX - dfDeltaX) *
-                        BiCubicSplineKernel(dKernIndY - dfDeltaY);
+                        CubicSplineKernel(dKernIndX - dfDeltaX) *
+                        CubicSplineKernel(dKernIndY - dfDeltaY);
 
                     // Create a sum of all values
                     // adjusted for the pixel's calculated weight.

--- a/alg/gdalresamplingkernels.h
+++ b/alg/gdalresamplingkernels.h
@@ -29,33 +29,52 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
-#ifndef GDAL_INTERPOLATEATPOINT_H_INCLUDED
-#define GDAL_INTERPOLATEATPOINT_H_INCLUDED
+#ifndef GDALRESAMPLINGKERNELS_H_INCLUDED
+#define GDALRESAMPLINGKERNELS_H_INCLUDED
+
+#include <cmath>
 
 /*! @cond Doxygen_Suppress */
 
-#include "gdal.h"
-
-#include "cpl_mem_cache.h"
-#include "gdal_priv.h"
-
-#include <memory>
-
-using DoublePointsCache =
-    lru11::Cache<uint64_t, std::shared_ptr<std::vector<double>>>;
-
-class GDALDoublePointsCache
+static inline double CubicKernel(double dfX)
 {
-  public:
-    std::unique_ptr<DoublePointsCache> cache{};
-};
+    // http://en.wikipedia.org/wiki/Bicubic_interpolation#Bicubic_convolution_algorithm
+    // W(x) formula with a = -0.5 (cubic hermite spline )
+    // or
+    // https://www.cs.utexas.edu/~fussell/courses/cs384g-fall2013/lectures/mitchell/Mitchell.pdf
+    // k(x) (formula 8) with (B,C)=(0,0.5) the Catmull-Rom spline
+    double dfAbsX = fabs(dfX);
+    if (dfAbsX <= 1.0)
+    {
+        double dfX2 = dfX * dfX;
+        return dfX2 * (1.5 * dfAbsX - 2.5) + 1;
+    }
+    else if (dfAbsX <= 2.0)
+    {
+        double dfX2 = dfX * dfX;
+        return dfX2 * (-0.5 * dfAbsX + 2.5) - 4 * dfAbsX + 2;
+    }
+    else
+        return 0.0;
+}
 
-bool GDALInterpolateAtPoint(GDALRasterBand *pBand,
-                            GDALRIOResampleAlg eResampleAlg,
-                            std::unique_ptr<DoublePointsCache> &cache,
-                            const double dfXIn, const double dfYIn,
-                            double *pdfOutputValue);
+static inline double CubicSplineKernel(double dfVal)
+{
+    if (dfVal > 2.0)
+        return 0.0;
+
+    const double xm1 = dfVal - 1.0;
+    const double xp1 = dfVal + 1.0;
+    const double xp2 = dfVal + 2.0;
+
+    const double a = xp2 <= 0.0 ? 0.0 : xp2 * xp2 * xp2;
+    const double b = xp1 <= 0.0 ? 0.0 : xp1 * xp1 * xp1;
+    const double c = dfVal <= 0.0 ? 0.0 : dfVal * dfVal * dfVal;
+    const double d = xm1 <= 0.0 ? 0.0 : xm1 * xm1 * xm1;
+
+    return 0.16666666666666666667 * (a - (4.0 * b) + (6.0 * c) - (4.0 * d));
+}
 
 /*! @endcond */
 
-#endif /* ndef GDAL_INTERPOLATEATPOINT_H_INCLUDED */
+#endif /* ndef GDALRESAMPLINGKERNELS_H_INCLUDED */

--- a/alg/gdalwarpkernel.cpp
+++ b/alg/gdalwarpkernel.cpp
@@ -59,6 +59,7 @@
 #include "gdal_alg.h"
 #include "gdal_alg_priv.h"
 #include "gdal_thread_pool.h"
+#include "gdalresamplingkernels.h"
 #include "gdalwarpkernel_opencl.h"
 
 // #define CHECK_SUM_WITH_GEOS
@@ -3390,24 +3391,7 @@ static double GWKBilinear4Values(double *padfValues)
 
 static double GWKCubic(double dfX)
 {
-    // http://en.wikipedia.org/wiki/Bicubic_interpolation#Bicubic_convolution_algorithm
-    // W(x) formula with a = -0.5 (cubic hermite spline )
-    // or
-    // https://www.cs.utexas.edu/~fussell/courses/cs384g-fall2013/lectures/mitchell/Mitchell.pdf
-    // k(x) (formula 8) with (B,C)=(0,0.5) the Catmull-Rom spline
-    double dfAbsX = fabs(dfX);
-    if (dfAbsX <= 1.0)
-    {
-        double dfX2 = dfX * dfX;
-        return dfX2 * (1.5 * dfAbsX - 2.5) + 1;
-    }
-    else if (dfAbsX <= 2.0)
-    {
-        double dfX2 = dfX * dfX;
-        return dfX2 * (-0.5 * dfAbsX + 2.5) - 4 * dfAbsX + 2;
-    }
-    else
-        return 0.0;
+    return CubicKernel(dfX);
 }
 
 static double GWKCubic4Values(double *padfValues)

--- a/apps/gdallocationinfo.cpp
+++ b/apps/gdallocationinfo.cpp
@@ -140,7 +140,7 @@ MAIN_START(argc, argv)
     std::string osResampling;
     argParser.add_argument("-r")
         .store_into(osResampling)
-        .metavar("nearest|bilinear|cubicspline")
+        .metavar("nearest|bilinear|cubic|cubicspline")
         .help(_("Select an interpolation algorithm."));
 
     {
@@ -264,10 +264,14 @@ MAIN_START(argc, argv)
     {
         eInterpolation = GRIORA_CubicSpline;
     }
+    else if (EQUAL(osResampling.c_str(), "CUBIC"))
+    {
+        eInterpolation = GRIORA_Cubic;
+    }
     else
     {
-        fprintf(stderr, "-r can only be used with values nearest, bilinear and "
-                        "cubicspline\n");
+        fprintf(stderr, "-r can only be used with values nearest, bilinear, "
+                        "cubic and cubicspline\n");
         exit(1);
     }
 

--- a/autotest/alg/warp.py
+++ b/autotest/alg/warp.py
@@ -1409,7 +1409,7 @@ def test_warp_52():
     assert end - start <= 10, "processing time was way too long"
 
     cs = out_ds.GetRasterBand(4).Checksum()
-    assert cs == 3188
+    assert cs == 3177
 
 
 ###############################################################################

--- a/autotest/gcore/interpolateatpoint.py
+++ b/autotest/gcore/interpolateatpoint.py
@@ -34,12 +34,16 @@ def test_interpolateatpoint_1():
     assert got_bilinear == pytest.approx(139.75, 1e-6)
     got_cubic = ds.GetRasterBand(1).InterpolateAtPoint(10, 12, gdal.GRIORA_CubicSpline)
     assert got_cubic == pytest.approx(138.02, 1e-2)
+    got_cubic = ds.GetRasterBand(1).InterpolateAtPoint(10, 12, gdal.GRIORA_Cubic)
+    assert got_cubic == pytest.approx(145.57, 1e-2)
 
 
 def test_interpolateatpoint_outofrange():
 
     ds = gdal.Open("data/byte.tif")
-    res = ds.GetRasterBand(1).InterpolateAtPoint(1000, 120, gdal.GRIORA_Bilinear)
+    res = ds.GetRasterBand(1).InterpolateAtPoint(1000, 12, gdal.GRIORA_Bilinear)
+    assert res is None
+    res = ds.GetRasterBand(1).InterpolateAtPoint(10, 1200, gdal.GRIORA_Bilinear)
     assert res is None
 
 
@@ -58,7 +62,7 @@ def test_interpolateatpoint_throw():
     ds = gdal.Open("data/byte.tif")
     with pytest.raises(
         Exception,
-        match="Only nearest, bilinear and cubicspline interpolation methods allowed",
+        match="Only nearest, bilinear, cubic and cubicspline interpolation methods allowed",
     ):
         ds.GetRasterBand(1).InterpolateAtPoint(10, 12, gdal.GRIORA_Mode)
 
@@ -153,3 +157,114 @@ def test_interpolateatpoint_cubicspline_several_points():
         2.0, 2.0, gdal.GRIORA_CubicSpline
     )
     assert got_cubic == pytest.approx(1.6916666, 1e-6)
+
+
+def test_interpolateatpoint_cubic_several_points():
+
+    mem_ds = gdal.GetDriverByName("MEM").Create(
+        "", xsize=4, ysize=4, bands=1, eType=gdal.GDT_Float32
+    )
+    np = pytest.importorskip("numpy")
+    raster_array_1 = np.array(
+        (
+            [1.0, 2.0, 1.5, -0.3],
+            [1.0, 2.0, 1.5, -0.3],
+            [1.0, 2.0, 1.5, -0.3],
+            [1.0, 2.0, 1.5, -0.3],
+        )
+    )
+    mem_ds.GetRasterBand(1).WriteArray(raster_array_1)
+
+    got_cubic = mem_ds.GetRasterBand(1).InterpolateAtPoint(0.5, 1.5, gdal.GRIORA_Cubic)
+    assert got_cubic == pytest.approx(1.0, 1e-6)
+
+    got_cubic = mem_ds.GetRasterBand(1).InterpolateAtPoint(1.5, 1.5, gdal.GRIORA_Cubic)
+    assert got_cubic == pytest.approx(2.0, 1e-6)
+
+    got_cubic = mem_ds.GetRasterBand(1).InterpolateAtPoint(2.5, 1.5, gdal.GRIORA_Cubic)
+    assert got_cubic == pytest.approx(1.5, 1e-6)
+
+    got_cubic = mem_ds.GetRasterBand(1).InterpolateAtPoint(3.5, 1.5, gdal.GRIORA_Cubic)
+    assert got_cubic == pytest.approx(-0.3, 1e-6)
+
+    got_cubic = mem_ds.GetRasterBand(1).InterpolateAtPoint(2.0, 2.0, gdal.GRIORA_Cubic)
+    assert got_cubic == pytest.approx(1.925, 1e-6)
+
+    # cubic may exceed the highest value
+    got_cubic = mem_ds.GetRasterBand(1).InterpolateAtPoint(1.6, 1.5, gdal.GRIORA_Cubic)
+    assert got_cubic == pytest.approx(2.0166, 1e-6)
+
+
+def test_interpolateatpoint_at_borders():
+
+    mem_ds = gdal.GetDriverByName("MEM").Create(
+        "", xsize=6, ysize=5, bands=1, eType=gdal.GDT_Float32
+    )
+    np = pytest.importorskip("numpy")
+    raster_array_1 = np.array(
+        (
+            [1, 2, 4, 4, 5, 6],
+            [9, 8, 7, 6, 3, 4],
+            [4, 7, 6, 2, 1, 3],
+            [7, 8, 9, 6, 2, 1],
+            [2, 5, 2, 1, 7, 8],
+        )
+    )
+    mem_ds.GetRasterBand(1).WriteArray(raster_array_1)
+
+    # out of borders
+    res = mem_ds.GetRasterBand(1).InterpolateAtPoint(-0.01, 0.0, gdal.GRIORA_Bilinear)
+    assert res == None
+
+    res = mem_ds.GetRasterBand(1).InterpolateAtPoint(6.01, 0.0, gdal.GRIORA_Bilinear)
+    assert res == None
+
+    res = mem_ds.GetRasterBand(1).InterpolateAtPoint(0.01, -0.01, gdal.GRIORA_Bilinear)
+    assert res == None
+
+    res = mem_ds.GetRasterBand(1).InterpolateAtPoint(0.01, 5.01, gdal.GRIORA_Bilinear)
+    assert res == None
+
+    # near borders bilinear
+    res = mem_ds.GetRasterBand(1).InterpolateAtPoint(0.0, 0.0, gdal.GRIORA_Bilinear)
+    assert res == pytest.approx(1.0, 1e-6)
+
+    res = mem_ds.GetRasterBand(1).InterpolateAtPoint(1.0, 0.0, gdal.GRIORA_Bilinear)
+    assert res == pytest.approx(1.5, 1e-6)
+
+    res = mem_ds.GetRasterBand(1).InterpolateAtPoint(0.0, 1.0, gdal.GRIORA_Bilinear)
+    assert res == pytest.approx(5.0, 1e-6)
+
+    res = mem_ds.GetRasterBand(1).InterpolateAtPoint(0.0, 2.0, gdal.GRIORA_Bilinear)
+    assert res == pytest.approx(6.5, 1e-6)
+
+    res = mem_ds.GetRasterBand(1).InterpolateAtPoint(6.0, 0.0, gdal.GRIORA_Bilinear)
+    assert res == pytest.approx(6.0, 1e-6)
+
+    res = mem_ds.GetRasterBand(1).InterpolateAtPoint(3.0, 5.0, gdal.GRIORA_Bilinear)
+    assert res == pytest.approx(1.5, 1e-6)
+
+    res = mem_ds.GetRasterBand(1).InterpolateAtPoint(3.0, 4.6, gdal.GRIORA_Bilinear)
+    assert res == pytest.approx(1.5, 1e-6)
+
+    # near borders cubic
+    res = mem_ds.GetRasterBand(1).InterpolateAtPoint(0.0, 0.0, gdal.GRIORA_Cubic)
+    assert res == pytest.approx(0.4296875, 1e-6)
+
+    res = mem_ds.GetRasterBand(1).InterpolateAtPoint(1.0, 0.0, gdal.GRIORA_Cubic)
+    assert res == pytest.approx(0.92578125, 1e-6)
+
+    res = mem_ds.GetRasterBand(1).InterpolateAtPoint(0.0, 1.0, gdal.GRIORA_Cubic)
+    assert res == pytest.approx(5.328125, 1e-6)
+
+    res = mem_ds.GetRasterBand(1).InterpolateAtPoint(0.0, 2.0, gdal.GRIORA_Cubic)
+    assert res == pytest.approx(6.75, 1e-6)
+
+    res = mem_ds.GetRasterBand(1).InterpolateAtPoint(6.0, 0.0, gdal.GRIORA_Cubic)
+    assert res == pytest.approx(6.1875, 1e-6)
+
+    res = mem_ds.GetRasterBand(1).InterpolateAtPoint(3.0, 5.0, gdal.GRIORA_Cubic)
+    assert res == pytest.approx(0.5078125, 1e-6)
+
+    res = mem_ds.GetRasterBand(1).InterpolateAtPoint(3.0, 4.6, gdal.GRIORA_Cubic)
+    assert res == pytest.approx(0.6590625, 1e-6)

--- a/autotest/gcore/transformer.py
+++ b/autotest/gcore/transformer.py
@@ -761,8 +761,8 @@ def test_transformer_13():
     (success, pnt) = tr.TransformPoint(0, 6600, 24)
     assert (
         success
-        and pnt[0] == pytest.approx(-108.00066000065341, abs=1e-7)
-        and pnt[1] == pytest.approx(39.157694013439489, abs=1e-7)
+        and pnt[0] == pytest.approx(-108.00069819119149, abs=1e-7)
+        and pnt[1] == pytest.approx(39.15771125604824, abs=1e-7)
     )
 
 
@@ -800,11 +800,14 @@ def test_transformer_14():
         tr = gdal.Transformer(
             ds, None, ["METHOD=RPC", "RPC_DEM=data/transformer_14_dem.tif"]
         )
-    (success, pnt) = tr.TransformPoint(0, 5, 12)
+    (success, pnt) = tr.TransformPoint(0, 45, 73)
+    # on debug it should say this two messages
+    # Oscillation detected...
+    # Converged!
     assert (
         success
-        and pnt[0] == pytest.approx(-1.935617614186202e-05, abs=1e-7)
-        and pnt[1] == pytest.approx(-0.0034168871827151997, abs=1e-7)
+        and pnt[0] == pytest.approx(0.000801360096912016, abs=1e-7)
+        and pnt[1] == pytest.approx(-4.1346931131054286e-05, abs=1e-7)
     )
 
     f = gdal.VSIFOpenL("/vsimem/transformer_14.csvt", "rb")

--- a/autotest/utilities/test_gdallocationinfo.py
+++ b/autotest/utilities/test_gdallocationinfo.py
@@ -315,6 +315,17 @@ def test_gdallocationinfo_nad27_interpolate_bilinear(gdallocationinfo_path):
     assert float(ret) == pytest.approx(130.476908, rel=1e-4)
 
 
+def test_gdallocationinfo_nad27_interpolate_cubic(gdallocationinfo_path):
+
+    # run on nad27 explicitly to avoid datum transformations.
+    ret = gdaltest.runexternal(
+        gdallocationinfo_path
+        + " -valonly  -r cubic -l_srs EPSG:4267 ../gcore/data/byte.tif -117.6354747 33.8970515"
+    )
+
+    assert float(ret) == pytest.approx(134.65629, rel=1e-4)
+
+
 def test_gdallocationinfo_nad27_interpolate_cubicspline(gdallocationinfo_path):
 
     ret = gdaltest.runexternal(
@@ -350,6 +361,18 @@ def test_gdallocationinfo_report_interpolate_bilinear(gdallocationinfo_path):
     assert "Value: 137.24" in ret
 
 
+def test_gdallocationinfo_report_interpolate_cubic(gdallocationinfo_path):
+
+    ret = gdaltest.runexternal(
+        gdallocationinfo_path + " -r cubic ../gcore/data/byte.tif 9.98 11.97"
+    )
+    ret = ret.replace("\r\n", "\n")
+    assert "Report:" in ret
+    assert "Location: (9.98" in ret
+    assert "P,11.97" in ret
+    assert "Value: 141.58" in ret
+
+
 def test_gdallocationinfo_value_interpolate_bilinear(gdallocationinfo_path):
 
     # Those coordinates are almost 10,12. It is testing that they are not converted to integer.
@@ -358,6 +381,24 @@ def test_gdallocationinfo_value_interpolate_bilinear(gdallocationinfo_path):
         + " -valonly -r bilinear ../gcore/data/byte.tif 9.9999999 11.9999999"
     )
     assert float(ret) == pytest.approx(139.75, rel=1e-6)
+
+
+def test_gdallocationinfo_value_interpolate_bilinear_near_border(gdallocationinfo_path):
+
+    # Those coordinates are almost 10,12. It is testing that they are not converted to integer.
+    ret = gdaltest.runexternal(
+        gdallocationinfo_path
+        + " -valonly -r bilinear ../gcore/data/byte.tif 19 19.9999999"  # should we allow 20.0?
+    )
+    assert float(ret) == pytest.approx(103, rel=1e-6)
+
+
+def test_gdallocationinfo_value_interpolate_invalid_method(gdallocationinfo_path):
+
+    (_, err) = gdaltest.runexternal_out_and_err(
+        gdallocationinfo_path + " -valonly -r mode ../gcore/data/byte.tif 10 12"
+    )
+    assert "-r can only be used with values" in err
 
 
 def test_gdallocationinfo_interpolate_float_data(gdallocationinfo_path, tmp_path):

--- a/doc/source/programs/gdallocationinfo.rst
+++ b/doc/source/programs/gdallocationinfo.rst
@@ -19,7 +19,7 @@ Synopsis
                             [-xml] [-lifonly] [-valonly]
                             [-E] [-field_sep <sep>] [-ignore_extra_input]
                             [-b <band>]... [-overview <overview_level>]
-                            [-r {nearest|bilinear|cubicspline}]
+                            [-r {nearest|bilinear|cubic|cubicspline}]
                             [[-l_srs <srs_def>] | [-geoloc] | [-wgs84]]
                             [-oo <NAME>=<VALUE>]... <srcfile> [<x> <y>]
 
@@ -55,7 +55,7 @@ reporting options are provided.
     Selects a band to query.  Multiple bands can be listed.  By default all
     bands are queried.
 
-.. option:: -r {nearest|bilinear|cubicspline}
+.. option:: -r {nearest|bilinear|cubic|cubicspline}
 
     .. versionadded:: 3.10
 
@@ -66,6 +66,8 @@ reporting options are provided.
     ``nearest`` applies a nearest neighbour.
 
     ``bilinear`` applies a bilinear convolution kernel.
+
+    ``cubic`` applies a cubic convolution kernel.
 
     ``cubicspline`` applies a B-Spline convolution kernel.
 

--- a/gcore/gdalrasterband.cpp
+++ b/gcore/gdalrasterband.cpp
@@ -8881,7 +8881,7 @@ std::shared_ptr<GDALMDArray> GDALRasterBand::AsMDArray() const
  *
  * @param dfPixel pixel coordinate as a double, where interpolation should be done.
  * @param dfLine line coordinate as a double, where interpolation should be done.
- * @param eInterpolation interpolation type. Only near, bilinear and cubicspline are allowed.
+ * @param eInterpolation interpolation type. Only near, bilinear, cubic and cubicspline are allowed.
  * @param pdfRealValue pointer to real part of interpolated value
  * @param pdfImagValue pointer to imaginary part of interpolated value (may be null if not needed)
  *
@@ -8895,11 +8895,12 @@ CPLErr GDALRasterBand::InterpolateAtPoint(double dfPixel, double dfLine,
                                           double *pdfImagValue) const
 {
     if (eInterpolation != GRIORA_NearestNeighbour &&
-        eInterpolation != GRIORA_Bilinear &&
+        eInterpolation != GRIORA_Bilinear && eInterpolation != GRIORA_Cubic &&
         eInterpolation != GRIORA_CubicSpline)
     {
         CPLError(CE_Failure, CPLE_AppDefined,
-                 "Only nearest, bilinear and cubicspline interpolation methods "
+                 "Only nearest, bilinear, cubic and cubicspline interpolation "
+                 "methods "
                  "allowed");
 
         return CE_Failure;

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -4949,7 +4949,7 @@ def InterpolateAtPoint(self, *args, **kwargs):
        ----------
        pixel : float
        line : float
-       interpolation : GRIOResampleAlg (nearest, bilinear, cubicspline)
+       interpolation : GRIOResampleAlg (nearest, bilinear, cubic, cubicspline)
 
        Returns
        -------


### PR DESCRIPTION
## What does this PR do?
Makes `GDALRasterInterpolateAtPoint` continuous near the borders of the image.
It also adds `cubic` interpolation.
![cubic](https://github.com/user-attachments/assets/7682a417-2395-40d4-bab9-5b2a204cf387)
(why adding cubic here? Unlike cubicspline, cubic matches the values of the grid in the nodes. That makes testing during development easier. See that in the images at x=0.5 and y=0.5, that are cutting at the nodes of the grid).
See that cubic may get values bigger than the maximum of the grid values.

### Implementation
How is it getting data near the borders, if there are no point to interpolate with? It "extends" the image with the pixel value at the border.

For instance, this is how the top left corner is "extended" to have a 4x4 kernel:
```
.___      a a a b
|a b  =>  a a a b
|c i      a a a b
          c c c i
```

## What are related issues/pull requests?
Fixes #10501

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [x] Add documentation
 - [x] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
