### PR TITLE
Pytest: Add missing requirements for test cases with minimum driver support

### DIFF
--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -4319,6 +4319,7 @@ def test_tiff_write_100():
 
 
 @pytest.mark.slow()
+@pytest.mark.require_driver("ENVI")
 def test_tiff_write_101():
 
     md = gdaltest.tiff_drv.GetMetadata()

--- a/autotest/requirements.txt
+++ b/autotest/requirements.txt
@@ -6,4 +6,3 @@ pytest-benchmark
 lxml
 jsonschema
 filelock
-psutil

--- a/autotest/requirements.txt
+++ b/autotest/requirements.txt
@@ -6,3 +6,4 @@ pytest-benchmark
 lxml
 jsonschema
 filelock
+psutil


### PR DESCRIPTION
Pytest: Add missing requirements for test cases with minimum driver support.

When build on Win10 / VS2022 / cmake with minumum driver support and minimum Python package requirements some pytests fail.
`cmake -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release   -DGDAL_BUILD_OPTIONAL_DRIVERS=OFF -DOGR_BUILD_OPTIONAL_DRIVERS=OFF   -DGDAL_USE_EXTERNAL_LIBS:BOOL=OFF ..\`

- For test_tiff_write_101() the required driver is ENVI, which is not available when built with minimum driver support.
- Some pytest cases require package "psutil" to import (e.g.: netcdf.py, gpkg.py, conftest.py, vrtwarp.py)

This PR adds the missing requirements.

