### PR TITLE
cpl::contains(): use find() method for implementation to address …

### DIFF
--- a/port/cpl_port.h
+++ b/port/cpl_port.h
@@ -1166,7 +1166,7 @@ extern "C++"
     template <typename C, typename V>
     inline bool contains(const C &container, const V &value)
     {
-        return container.count(value) != 0;
+        return container.find(value) != container.end();
     }
 
     }  // namespace cpl


### PR DESCRIPTION
…https://github.com/OSGeo/gdal/pull/10464#discussion_r1694287217
