### PR TITLE
HANA: Add support for fast extent estimation

### DIFF
--- a/autotest/ogr/ogr_hana.py
+++ b/autotest/ogr/ogr_hana.py
@@ -1221,6 +1221,94 @@ def test_ogr_hana_38():
 
 
 ###############################################################################
+# Test reading a layer extent and verify a working fast extent implementation
+
+
+def test_ogr_hana_39():
+    conn = create_connection()
+
+    def delta_merge():
+        execute_sql(
+            conn,
+            f"MERGE DELTA OF {table_name}",
+        )
+
+    # Create test table
+    layer_name = get_test_name()
+    table_name = f'"{gdaltest.hana_schema_name}"."{layer_name}"'
+    execute_sql(
+        conn,
+        f"CREATE COLUMN TABLE {table_name} (id INT, geom ST_Geometry(4326)) NO AUTO MERGE",
+    )
+
+    # Insert points
+    points_wkt = ['POINT(0 0)', 'POINT(10 0)', 'POINT(40 0)']
+    for id, wkt in enumerate(points_wkt):
+        execute_sql(
+            conn,
+            f"INSERT INTO {table_name} (id, geom) VALUES ({id}, ST_GeomFromText('{wkt}', 4326))",
+        )
+    delta_merge()
+
+    # Check extent (1.)
+    ds = open_datasource(0)
+    layer = ds.GetLayerByName(layer_name)
+    assert layer is not None, "did not get layer"
+    check_extent(layer, (0, 40, 0, 0), force=False)
+
+    # Delete outer most point...
+    # Because of the disabled delta merge, the extent should remain unchanged
+    # when the fast extent estimation is used.
+    execute_sql(
+        conn,
+        f"DELETE FROM {table_name} WHERE id=2",
+    )
+    check_extent(layer, (0, 40, 0, 0), force=False)
+    delta_merge()
+    check_extent(layer, (0, 10, 0, 0), force=False)
+
+    # Tear-down
+    execute_sql(conn, f"DROP TABLE {table_name}")
+
+
+###############################################################################
+# Test reading a layer extent and verify a working fallback
+
+
+def test_ogr_hana_40():
+    conn = create_connection()
+
+    # Create test table
+    layer_name = get_test_name()
+    table_name = f'"{gdaltest.hana_schema_name}"."{layer_name}"'
+    execute_sql(
+        conn,
+        f"CREATE COLUMN TABLE {table_name} (id INT, geom ST_Geometry(4326)) NO AUTO MERGE",
+    )
+
+    # Check extent. The table is empty so the extent should be (0, 0, 0, 0)
+    ds = open_datasource(0)
+    layer = ds.GetLayerByName(layer_name)
+    assert layer is not None, "did not get layer"
+    check_extent(layer, (0, 0, 0, 0), force=False)
+
+    # Insert points without merging the delta.
+    # The fallback should be triggered and return the correct extent.
+    execute_sql(
+        conn,
+        f"INSERT INTO {table_name} (id, geom) VALUES (0, ST_GeomFromText('POINT(0 10)', 4326))",
+    )
+    execute_sql(
+        conn,
+        f"INSERT INTO {table_name} (id, geom) VALUES (0, ST_GeomFromText('POINT(0 40)', 4326))",
+    )
+    check_extent(layer, (0, 0, 10, 40), force=False)
+
+    # Tear-down
+    execute_sql(conn, f"DROP TABLE {table_name}")
+
+
+###############################################################################
 #  Create a table from data/poly.shp
 
 
@@ -1363,8 +1451,8 @@ def open_datasource(update=0, open_opts=None):
         return gdal.OpenEx(conn_str, update, open_options=[open_opts])
 
 
-def check_extent(layer, expected, max_error=0.001):
-    actual = layer.GetExtent()
+def check_extent(layer, expected, force=True, max_error=0.001):
+    actual = layer.GetExtent(force=force)
     minx = abs(actual[0] - expected[0])
     maxx = abs(actual[1] - expected[1])
     miny = abs(actual[2] - expected[2])

--- a/autotest/ogr/ogr_hana.py
+++ b/autotest/ogr/ogr_hana.py
@@ -1221,7 +1221,7 @@ def test_ogr_hana_38():
 
 
 ###############################################################################
-# Test reading a layer extent and verify a working fast extent implementation
+# Verify a working fast extent implementation
 
 
 def test_ogr_hana_39():
@@ -1272,7 +1272,7 @@ def test_ogr_hana_39():
 
 
 ###############################################################################
-# Test reading a layer extent and verify a working fallback
+# Verify a working fallback in case the fast extent estimation fails
 
 
 def test_ogr_hana_40():

--- a/autotest/ogr/ogr_hana.py
+++ b/autotest/ogr/ogr_hana.py
@@ -1242,7 +1242,7 @@ def test_ogr_hana_39():
     )
 
     # Insert points
-    points_wkt = ['POINT(0 0)', 'POINT(10 0)', 'POINT(40 0)']
+    points_wkt = ["POINT(0 0)", "POINT(10 0)", "POINT(40 0)"]
     for id, wkt in enumerate(points_wkt):
         execute_sql(
             conn,

--- a/ogr/ogrsf_frmts/hana/ogr_hana.h
+++ b/ogr/ogrsf_frmts/hana/ogr_hana.h
@@ -29,6 +29,7 @@
 #ifndef OGR_HANA_H_INCLUDED
 #define OGR_HANA_H_INCLUDED
 
+#include "hana/ogrhanautils.h"
 #include "ogrsf_frmts.h"
 #include "cpl_string.h"
 
@@ -230,7 +231,8 @@ class OGRHanaLayer : public OGRLayer
                                  const CPLString &tableName,
                                  const CPLString &query,
                                  const CPLString &featureDefName);
-    void ReadGeometryExtent(int geomField, OGREnvelope *extent);
+    void ReadGeometryExtent(int geomField, OGREnvelope *extent, int force, bool fastExtentMethod);
+    bool IsFastExtentAvailable();
 
   public:
     explicit OGRHanaLayer(OGRHanaDataSource *datasource);
@@ -416,13 +418,15 @@ class OGRHanaDataSource final : public GDALDataset
     SrsCache srsCache_;
     odbc::EnvironmentRef connEnv_;
     odbc::ConnectionRef conn_;
-    int majorVersion_ = 0;
+    OGRHANA::HANAVersion hanaVersion_;
+    OGRHANA::HANAVersion cloudVersion_;
 
   private:
     void CreateTable(const CPLString &tableName, const CPLString &fidName,
                      const CPLString &fidType, const CPLString &geomColumnName,
                      OGRwkbGeometryType geomType, bool geomColumnNullable,
                      const CPLString &geomColumnIndexType, int geomSrid);
+    void UpdateCloudVersion();
 
   protected:
     std::pair<CPLString, CPLString> FindSchemaAndTableNames(const char *query);
@@ -469,9 +473,14 @@ class OGRHanaDataSource final : public GDALDataset
 
     int Open(const char *newName, char **options, int update);
 
-    int GetMajorVersion() const
+    OGRHANA::HANAVersion GetHANAVersion() const
     {
-        return majorVersion_;
+        return hanaVersion_;
+    }
+
+    OGRHANA::HANAVersion GetHANACloudVersion() const
+    {
+        return cloudVersion_;
     }
 
     OGRErr DeleteLayer(int index) override;

--- a/ogr/ogrsf_frmts/hana/ogr_hana.h
+++ b/ogr/ogrsf_frmts/hana/ogr_hana.h
@@ -231,7 +231,8 @@ class OGRHanaLayer : public OGRLayer
                                  const CPLString &tableName,
                                  const CPLString &query,
                                  const CPLString &featureDefName);
-    void ReadGeometryExtent(int geomField, OGREnvelope *extent, int force, bool fastExtentMethod);
+    void ReadGeometryExtent(int geomField, OGREnvelope *extent, int force,
+                            bool fastExtentMethod);
     bool IsFastExtentAvailable();
 
   public:

--- a/ogr/ogrsf_frmts/hana/ogr_hana.h
+++ b/ogr/ogrsf_frmts/hana/ogr_hana.h
@@ -418,8 +418,8 @@ class OGRHanaDataSource final : public GDALDataset
     SrsCache srsCache_;
     odbc::EnvironmentRef connEnv_;
     odbc::ConnectionRef conn_;
-    OGRHANA::HANAVersion hanaVersion_;
-    OGRHANA::HANAVersion cloudVersion_;
+    OGRHANA::HanaVersion hanaVersion_;
+    OGRHANA::HanaVersion cloudVersion_;
 
   private:
     void CreateTable(const CPLString &tableName, const CPLString &fidName,
@@ -473,12 +473,12 @@ class OGRHanaDataSource final : public GDALDataset
 
     int Open(const char *newName, char **options, int update);
 
-    OGRHANA::HANAVersion GetHANAVersion() const
+    OGRHANA::HanaVersion GetHanaVersion() const
     {
         return hanaVersion_;
     }
 
-    OGRHANA::HANAVersion GetHANACloudVersion() const
+    OGRHANA::HanaVersion GetHanaCloudVersion() const
     {
         return cloudVersion_;
     }

--- a/ogr/ogrsf_frmts/hana/ogr_hana.h
+++ b/ogr/ogrsf_frmts/hana/ogr_hana.h
@@ -231,8 +231,7 @@ class OGRHanaLayer : public OGRLayer
                                  const CPLString &tableName,
                                  const CPLString &query,
                                  const CPLString &featureDefName);
-    void ReadGeometryExtent(int geomField, OGREnvelope *extent, int force,
-                            bool fastExtentMethod);
+    void ReadGeometryExtent(int geomField, OGREnvelope *extent, int force);
     bool IsFastExtentAvailable();
 
   public:
@@ -427,7 +426,7 @@ class OGRHanaDataSource final : public GDALDataset
                      const CPLString &fidType, const CPLString &geomColumnName,
                      OGRwkbGeometryType geomType, bool geomColumnNullable,
                      const CPLString &geomColumnIndexType, int geomSrid);
-    void UpdateCloudVersion();
+    void DetermineVersions();
 
   protected:
     std::pair<CPLString, CPLString> FindSchemaAndTableNames(const char *query);

--- a/ogr/ogrsf_frmts/hana/ogrhanadatasource.cpp
+++ b/ogr/ogrsf_frmts/hana/ogrhanadatasource.cpp
@@ -1735,7 +1735,6 @@ int OGRHanaDataSource::TestCapability(const char *capabilities)
         return updateMode_;
     else if (EQUAL(capabilities, ODsCTransactions))
         return TRUE;
-
     else
         return FALSE;
 }

--- a/ogr/ogrsf_frmts/hana/ogrhanadatasource.cpp
+++ b/ogr/ogrsf_frmts/hana/ogrhanadatasource.cpp
@@ -701,7 +701,8 @@ void OGRHanaDataSource::CreateTable(
 
 void OGRHanaDataSource::UpdateCloudVersion()
 {
-    if (hanaVersion_.major() < 4) {
+    if (hanaVersion_.major() < 4)
+    {
         cloudVersion_ = HANAVersion(0, 0, 0);
         return;
     }
@@ -711,7 +712,8 @@ void OGRHanaDataSource::UpdateCloudVersion()
 
     odbc::ResultSetRef rsVersion = stmt->executeQuery(sql);
     if (rsVersion->next())
-        cloudVersion_ = HANAVersion::fromVersionString(rsVersion->getString(1)->c_str());
+        cloudVersion_ =
+            HANAVersion::fromVersionString(rsVersion->getString(1)->c_str());
 
     rsVersion->close();
 }
@@ -1733,7 +1735,7 @@ int OGRHanaDataSource::TestCapability(const char *capabilities)
         return updateMode_;
     else if (EQUAL(capabilities, ODsCTransactions))
         return TRUE;
-    
+
     else
         return FALSE;
 }

--- a/ogr/ogrsf_frmts/hana/ogrhanadatasource.cpp
+++ b/ogr/ogrsf_frmts/hana/ogrhanadatasource.cpp
@@ -699,11 +699,11 @@ void OGRHanaDataSource::DetermineVersions()
 {
     odbc::DatabaseMetaDataRef dbmd = conn_->getDatabaseMetaData();
     CPLString dbVersion(dbmd->getDBMSVersion());
-    hanaVersion_ = HANAVersion::fromString(dbVersion);
+    hanaVersion_ = HanaVersion::fromString(dbVersion);
 
     if (hanaVersion_.major() < 4)
     {
-        cloudVersion_ = HANAVersion(0, 0, 0);
+        cloudVersion_ = HanaVersion(0, 0, 0);
         return;
     }
 
@@ -713,7 +713,7 @@ void OGRHanaDataSource::DetermineVersions()
     odbc::ResultSetRef rsVersion = stmt->executeQuery(sql);
     if (rsVersion->next())
         cloudVersion_ =
-            HANAVersion::fromString(rsVersion->getString(1)->c_str());
+            HanaVersion::fromString(rsVersion->getString(1)->c_str());
 
     rsVersion->close();
 }

--- a/ogr/ogrsf_frmts/hana/ogrhanalayer.cpp
+++ b/ogr/ogrsf_frmts/hana/ogrhanalayer.cpp
@@ -857,7 +857,7 @@ void OGRHanaLayer::ReadGeometryExtent(int geomField, OGREnvelope *extent, int fo
 
     rsExtent->close();
 
-    if (!set && fastExtentMethod && force)
+    if (!set && fastExtentMethod)
         ReadGeometryExtent(geomField, extent, force, false);
 }
 

--- a/ogr/ogrsf_frmts/hana/ogrhanalayer.cpp
+++ b/ogr/ogrsf_frmts/hana/ogrhanalayer.cpp
@@ -776,7 +776,8 @@ OGRErr OGRHanaLayer::InitFeatureDefinition(const CPLString &schemaName,
 /*                         ReadGeometryExtent()                         */
 /************************************************************************/
 
-void OGRHanaLayer::ReadGeometryExtent(int geomField, OGREnvelope *extent, int force, bool fastExtentMethod)
+void OGRHanaLayer::ReadGeometryExtent(int geomField, OGREnvelope *extent,
+                                      int force, bool fastExtentMethod)
 {
     EnsureInitialized();
 
@@ -791,30 +792,31 @@ void OGRHanaLayer::ReadGeometryExtent(int geomField, OGREnvelope *extent, int fo
     {
         auto names = dataSource_->FindSchemaAndTableNames(rawQuery_.c_str());
         CPLString columnLiteral = Literal(clmName);
-        CPLString schemaNameLiteral = Literal(
-            names.first == "" ? dataSource_->schemaName_ : names.first);
+        CPLString schemaNameLiteral =
+            Literal(names.first == "" ? dataSource_->schemaName_ : names.first);
         CPLString tableNameLiteral = Literal(names.second);
         CPLString whereClause = CPLString().Printf(
-                "SCHEMA_NAME=%s AND TABLE_NAME=%s AND COLUMN_NAME=%s",
-                schemaNameLiteral.c_str(),
-                tableNameLiteral.c_str(),
-                columnLiteral.c_str());
+            "SCHEMA_NAME=%s AND TABLE_NAME=%s AND COLUMN_NAME=%s",
+            schemaNameLiteral.c_str(), tableNameLiteral.c_str(),
+            columnLiteral.c_str());
 
-        sql = CPLString().Printf(
-            "SELECT MIN_X, MIN_Y, MAX_X, MAX_Y FROM SYS.M_ST_GEOMETRY_COLUMNS WHERE %s LIMIT 1",
-            whereClause.c_str());
+        sql = CPLString().Printf("SELECT MIN_X, MIN_Y, MAX_X, MAX_Y FROM "
+                                 "SYS.M_ST_GEOMETRY_COLUMNS WHERE %s LIMIT 1",
+                                 whereClause.c_str());
     }
     else
     {
         if (dataSource_->IsSrsRoundEarth(srid))
         {
             CPLString quotedClmName = QuotedIdentifier(clmName);
-            bool hasSrsPlanarEquivalent = dataSource_->HasSrsPlanarEquivalent(srid);
+            bool hasSrsPlanarEquivalent =
+                dataSource_->HasSrsPlanarEquivalent(srid);
             CPLString geomColumn =
                 !hasSrsPlanarEquivalent
                     ? quotedClmName
-                    : CPLString().Printf("%s.ST_SRID(%d)", quotedClmName.c_str(),
-                                        ToPlanarSRID(srid));
+                    : CPLString().Printf("%s.ST_SRID(%d)",
+                                         quotedClmName.c_str(),
+                                         ToPlanarSRID(srid));
             CPLString columns = CPLString().Printf(
                 "MIN(%s.ST_XMin()), MIN(%s.ST_YMin()), MAX(%s.ST_XMax()), "
                 "MAX(%s.ST_YMax())",
@@ -824,11 +826,13 @@ void OGRHanaLayer::ReadGeometryExtent(int geomField, OGREnvelope *extent, int fo
         }
         else
         {
-            CPLString columns = CPLString().Printf(
-                "ST_EnvelopeAggr(%s) AS ext", QuotedIdentifier(clmName).c_str());
+            CPLString columns =
+                CPLString().Printf("ST_EnvelopeAggr(%s) AS ext",
+                                   QuotedIdentifier(clmName).c_str());
             CPLString subQuery = BuildQuery(rawQuery_.c_str(), columns);
             sql = CPLString().Printf(
-                "SELECT ext.ST_XMin(),ext.ST_YMin(),ext.ST_XMax(),ext.ST_YMax() "
+                "SELECT "
+                "ext.ST_XMin(),ext.ST_YMin(),ext.ST_XMax(),ext.ST_YMax() "
                 "FROM (%s)",
                 subQuery.c_str());
         }
@@ -866,9 +870,13 @@ bool OGRHanaLayer::IsFastExtentAvailable()
     if (geomColumns_.empty())
         return false;
 
-    switch (dataSource_->GetHANAVersion().major()) {
-        case 2: return dataSource_->GetHANAVersion() >= HANAVersion(2, 0, 80);
-        case 4: return dataSource_->GetHANACloudVersion() >= HANAVersion(2024, 2, 0);
+    switch (dataSource_->GetHANAVersion().major())
+    {
+        case 2:
+            return dataSource_->GetHANAVersion() >= HANAVersion(2, 0, 80);
+        case 4:
+            return dataSource_->GetHANACloudVersion() >=
+                   HANAVersion(2024, 2, 0);
     }
 
     return false;
@@ -908,7 +916,8 @@ OGRErr OGRHanaLayer::GetExtent(int iGeomField, OGREnvelope *extent, int force)
 
     try
     {
-        ReadGeometryExtent(iGeomField, extent, force, TestCapability(OLCFastGetExtent));
+        ReadGeometryExtent(iGeomField, extent, force,
+                           TestCapability(OLCFastGetExtent));
         return OGRERR_NONE;
     }
     catch (const std::exception &ex)

--- a/ogr/ogrsf_frmts/hana/ogrhanalayer.cpp
+++ b/ogr/ogrsf_frmts/hana/ogrhanalayer.cpp
@@ -355,7 +355,7 @@ void OGRHanaLayer::BuildWhereClause()
             const GeometryColumnDescription &geomClmDesc =
                 geomColumns_[static_cast<std::size_t>(m_iGeomFieldFilter)];
             spatialFilter = BuildSpatialFilter(
-                dataSource_->GetHANAVersion().major(), *m_poFilterGeom,
+                dataSource_->GetHanaVersion().major(), *m_poFilterGeom,
                 geomClmDesc.name, geomClmDesc.srid);
         }
     }
@@ -864,13 +864,13 @@ bool OGRHanaLayer::IsFastExtentAvailable()
     if (geomColumns_.empty())
         return false;
 
-    switch (dataSource_->GetHANAVersion().major())
+    switch (dataSource_->GetHanaVersion().major())
     {
         case 2:
-            return dataSource_->GetHANAVersion() >= HANAVersion(2, 0, 80);
+            return dataSource_->GetHanaVersion() >= HanaVersion(2, 0, 80);
         case 4:
-            return dataSource_->GetHANACloudVersion() >=
-                   HANAVersion(2024, 2, 0);
+            return dataSource_->GetHanaCloudVersion() >=
+                   HanaVersion(2024, 2, 0);
     }
 
     return false;

--- a/ogr/ogrsf_frmts/hana/ogrhanaresultlayer.cpp
+++ b/ogr/ogrsf_frmts/hana/ogrhanaresultlayer.cpp
@@ -26,6 +26,7 @@
  * DEALINGS IN THE SOFTWARE.
  ****************************************************************************/
 
+#include "ogr_core.h"
 #include "ogr_hana.h"
 
 #include <memory>
@@ -69,9 +70,13 @@ OGRErr OGRHanaResultLayer::Initialize()
 
 int OGRHanaResultLayer::TestCapability(const char *capabilities)
 {
+    if (EQUAL(capabilities, OLCFastGetExtent))
+    {
+        EnsureInitialized();
+        return IsFastExtentAvailable();
+    }
     if (EQUAL(capabilities, OLCFastFeatureCount) ||
-        EQUAL(capabilities, OLCFastSpatialFilter) ||
-        EQUAL(capabilities, OLCFastGetExtent))
+        EQUAL(capabilities, OLCFastSpatialFilter))
     {
         EnsureInitialized();
         return (geomColumns_.size() > 0);

--- a/ogr/ogrsf_frmts/hana/ogrhanatablelayer.cpp
+++ b/ogr/ogrsf_frmts/hana/ogrhanatablelayer.cpp
@@ -1149,7 +1149,7 @@ int OGRHanaTableLayer::TestCapability(const char *capabilities)
     if (EQUAL(capabilities, OLCFastGetExtent))
     {
         EnsureInitialized();
-        return !geomColumns_.empty();
+        return IsFastExtentAvailable();
     }
     if (EQUAL(capabilities, OLCCreateField))
         return updateMode_;

--- a/ogr/ogrsf_frmts/hana/ogrhanautils.cpp
+++ b/ogr/ogrsf_frmts/hana/ogrhanautils.cpp
@@ -27,11 +27,26 @@
  ****************************************************************************/
 
 #include "ogrhanautils.h"
+#include "cpl_string.h"
 
 #include <algorithm>
 
 namespace OGRHANA
 {
+
+HANAVersion HANAVersion::fromVersionString(const char* version)
+{
+    CPLString splVersion(version);
+    splVersion.replaceAll('-', '.').replaceAll(' ', '.');
+
+    const CPLStringList parts(CSLTokenizeString2(splVersion, ".", 0));
+    if (parts.size() < 3)
+        return HANAVersion(0, 0, 0);
+
+    return HANAVersion(
+        atoi(parts[0]), atoi(parts[1]), atoi(parts[2])
+    );
+}
 
 const char *SkipLeadingSpaces(const char *value)
 {

--- a/ogr/ogrsf_frmts/hana/ogrhanautils.cpp
+++ b/ogr/ogrsf_frmts/hana/ogrhanautils.cpp
@@ -34,7 +34,7 @@
 namespace OGRHANA
 {
 
-HANAVersion HANAVersion::fromVersionString(const char* version)
+HANAVersion HANAVersion::fromVersionString(const char *version)
 {
     CPLString splVersion(version);
     splVersion.replaceAll('-', '.').replaceAll(' ', '.');
@@ -43,9 +43,7 @@ HANAVersion HANAVersion::fromVersionString(const char* version)
     if (parts.size() < 3)
         return HANAVersion(0, 0, 0);
 
-    return HANAVersion(
-        atoi(parts[0]), atoi(parts[1]), atoi(parts[2])
-    );
+    return HANAVersion(atoi(parts[0]), atoi(parts[1]), atoi(parts[2]));
 }
 
 const char *SkipLeadingSpaces(const char *value)

--- a/ogr/ogrsf_frmts/hana/ogrhanautils.cpp
+++ b/ogr/ogrsf_frmts/hana/ogrhanautils.cpp
@@ -34,7 +34,7 @@
 namespace OGRHANA
 {
 
-HANAVersion HANAVersion::fromVersionString(const char *version)
+HANAVersion HANAVersion::fromString(const char *version)
 {
     CPLString splVersion(version);
     splVersion.replaceAll('-', '.').replaceAll(' ', '.');

--- a/ogr/ogrsf_frmts/hana/ogrhanautils.cpp
+++ b/ogr/ogrsf_frmts/hana/ogrhanautils.cpp
@@ -34,16 +34,16 @@
 namespace OGRHANA
 {
 
-HANAVersion HANAVersion::fromString(const char *version)
+HanaVersion HanaVersion::fromString(const char *version)
 {
     CPLString splVersion(version);
     splVersion.replaceAll('-', '.').replaceAll(' ', '.');
 
     const CPLStringList parts(CSLTokenizeString2(splVersion, ".", 0));
     if (parts.size() < 3)
-        return HANAVersion(0, 0, 0);
+        return HanaVersion(0, 0, 0);
 
-    return HANAVersion(atoi(parts[0]), atoi(parts[1]), atoi(parts[2]));
+    return HanaVersion(atoi(parts[0]), atoi(parts[1]), atoi(parts[2]));
 }
 
 const char *SkipLeadingSpaces(const char *value)

--- a/ogr/ogrsf_frmts/hana/ogrhanautils.h
+++ b/ogr/ogrsf_frmts/hana/ogrhanautils.h
@@ -48,36 +48,34 @@ class HANAVersion
   public:
     explicit HANAVersion(unsigned int major, unsigned int minor,
                          unsigned int patch)
+        : components_{major, minor, patch}
     {
-        components[0] = major;
-        components[1] = minor;
-        components[2] = patch;
     }
 
-    HANAVersion()
+    HANAVersion() : components_{0, 0, 0}
     {
     }
 
     unsigned int major() const
     {
-        return components[0];
+        return components_[0];
     }
 
     unsigned int minor() const
     {
-        return components[1];
+        return components_[1];
     }
 
     unsigned int patch() const
     {
-        return components[2];
+        return components_[2];
     }
 
     bool operator<=(const HANAVersion &other)
     {
         for (size_t i = 0; i < 3; ++i)
-            if (components[i] > other.components[i])
-                return false;
+            if (components_[i] != other.components_[i])
+                return components_[i] < other.components_[i];
         return true;
     }
 
@@ -89,16 +87,16 @@ class HANAVersion
     bool operator==(const HANAVersion &other)
     {
         for (size_t i = 0; i < 3; ++i)
-            if (components[i] != other.components[i])
+            if (components_[i] != other.components_[i])
                 return false;
         return true;
     }
 
   public:
-    static HANAVersion fromVersionString(const char *str);
+    static HANAVersion fromString(const char *str);
 
   private:
-    unsigned int components[3];
+    unsigned int components_[3];
 };
 
 const char *SkipLeadingSpaces(const char *value);

--- a/ogr/ogrsf_frmts/hana/ogrhanautils.h
+++ b/ogr/ogrsf_frmts/hana/ogrhanautils.h
@@ -42,42 +42,62 @@ namespace OGRHANA
 
 constexpr const char *ARRAY_VALUES_DELIMITER = "^%^";
 
-class HANAVersion {
+class HANAVersion
+{
 
-public:
-    explicit HANAVersion(unsigned int major, unsigned int minor, unsigned int patch) {
+  public:
+    explicit HANAVersion(unsigned int major, unsigned int minor,
+                         unsigned int patch)
+    {
         components[0] = major;
         components[1] = minor;
         components[2] = patch;
     }
-    HANAVersion() {}
 
-    unsigned int major() const { return components[0]; }
-    unsigned int minor() const { return components[1]; }
-    unsigned int patch() const { return components[2]; }
+    HANAVersion()
+    {
+    }
 
-    bool operator<=(const HANAVersion& other) {
+    unsigned int major() const
+    {
+        return components[0];
+    }
+
+    unsigned int minor() const
+    {
+        return components[1];
+    }
+
+    unsigned int patch() const
+    {
+        return components[2];
+    }
+
+    bool operator<=(const HANAVersion &other)
+    {
         for (size_t i = 0; i < 3; ++i)
             if (components[i] > other.components[i])
                 return false;
         return true;
     }
 
-    bool operator>=(const HANAVersion& other) {
+    bool operator>=(const HANAVersion &other)
+    {
         return !(*this <= other) || (*this == other);
     }
 
-    bool operator==(const HANAVersion& other) {
+    bool operator==(const HANAVersion &other)
+    {
         for (size_t i = 0; i < 3; ++i)
             if (components[i] != other.components[i])
                 return false;
         return true;
     }
 
-public:
-    static HANAVersion fromVersionString(const char* str);
+  public:
+    static HANAVersion fromVersionString(const char *str);
 
-private:
+  private:
     unsigned int components[3];
 };
 

--- a/ogr/ogrsf_frmts/hana/ogrhanautils.h
+++ b/ogr/ogrsf_frmts/hana/ogrhanautils.h
@@ -42,17 +42,17 @@ namespace OGRHANA
 
 constexpr const char *ARRAY_VALUES_DELIMITER = "^%^";
 
-class HANAVersion
+class HanaVersion
 {
 
   public:
-    explicit HANAVersion(unsigned int major, unsigned int minor,
+    explicit HanaVersion(unsigned int major, unsigned int minor,
                          unsigned int patch)
         : components_{major, minor, patch}
     {
     }
 
-    HANAVersion() : components_{0, 0, 0}
+    HanaVersion() : components_{0, 0, 0}
     {
     }
 
@@ -71,7 +71,7 @@ class HANAVersion
         return components_[2];
     }
 
-    bool operator<=(const HANAVersion &other)
+    bool operator<=(const HanaVersion &other)
     {
         for (size_t i = 0; i < 3; ++i)
             if (components_[i] != other.components_[i])
@@ -79,12 +79,12 @@ class HANAVersion
         return true;
     }
 
-    bool operator>=(const HANAVersion &other)
+    bool operator>=(const HanaVersion &other)
     {
         return !(*this <= other) || (*this == other);
     }
 
-    bool operator==(const HANAVersion &other)
+    bool operator==(const HanaVersion &other)
     {
         for (size_t i = 0; i < 3; ++i)
             if (components_[i] != other.components_[i])
@@ -93,7 +93,7 @@ class HANAVersion
     }
 
   public:
-    static HANAVersion fromString(const char *str);
+    static HanaVersion fromString(const char *str);
 
   private:
     unsigned int components_[3];

--- a/ogr/ogrsf_frmts/hana/ogrhanautils.h
+++ b/ogr/ogrsf_frmts/hana/ogrhanautils.h
@@ -42,6 +42,45 @@ namespace OGRHANA
 
 constexpr const char *ARRAY_VALUES_DELIMITER = "^%^";
 
+class HANAVersion {
+
+public:
+    explicit HANAVersion(unsigned int major, unsigned int minor, unsigned int patch) {
+        components[0] = major;
+        components[1] = minor;
+        components[2] = patch;
+    }
+    HANAVersion() {}
+
+    unsigned int major() const { return components[0]; }
+    unsigned int minor() const { return components[1]; }
+    unsigned int patch() const { return components[2]; }
+
+    bool operator<=(const HANAVersion& other) {
+        for (size_t i = 0; i < 3; ++i)
+            if (components[i] > other.components[i])
+                return false;
+        return true;
+    }
+
+    bool operator>=(const HANAVersion& other) {
+        return !(*this <= other) || (*this == other);
+    }
+
+    bool operator==(const HANAVersion& other) {
+        for (size_t i = 0; i < 3; ++i)
+            if (components[i] != other.components[i])
+                return false;
+        return true;
+    }
+
+public:
+    static HANAVersion fromVersionString(const char* str);
+
+private:
+    unsigned int components[3];
+};
+
 const char *SkipLeadingSpaces(const char *value);
 CPLString JoinStrings(const std::vector<CPLString> &strs, const char *delimiter,
                       CPLString (*decorator)(const CPLString &str) = nullptr);


### PR DESCRIPTION
## What does this PR do?

With QRC/1 2024 a new and faster way to estimate extents of spatial column has been added to HANA.
More precisely, users can now use special columns in [this table](https://help.sap.com/docs/hana-cloud-database/sap-hana-cloud-sap-hana-database-spatial-reference/spatial-extent-with-sys-m-st-geometry-columns?locale=en-US) to get an estimation of the extent of a spatial column.
Even though the stored extent is only an estimation, it is often good enough.
Especially for very large tables costly aggregation functions are avoided every time the extent is recomputed.
The extent information in the mentioned HANA table is only available after a delta-merge, so a fallback to the standard behaviour, i.e. via aggregation functions, was added in case the data is unavailable or has not yet been computed.

## What are related issues/pull requests?

None.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [x] Add documentation (no documentation required, this change is not user-facing)
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

