### PR TITLE
Doc: Fix curly braces in VFS, nested zip example with braces

### DIFF
--- a/doc/source/user/virtual_file_systems.rst
+++ b/doc/source/user/virtual_file_systems.rst
@@ -83,6 +83,7 @@ Examples:
     /vsizip/my.zip/my.tif  (relative path to the .zip)
     /vsizip//home/even/my.zip/subdir/my.tif  (absolute path to the .zip)
     /vsizip/c:\users\even\my.zip\subdir\my.tif
+    /vsizip/{/vsizip/my.zip/subdir/subzip.zip}/subdir_in_subzip/my.shp  (alternate syntax for a nested .zip)
 
 .kmz, .ods and .xlsx extensions are also detected as valid extensions for zip-compatible archives.
 
@@ -200,7 +201,7 @@ Examples:
     /vsitar//home/even/my.tar/subdir/my.tif # (absolute path to the .tar)
     /vsitar/c:\users\even\my.tar\subdir\my.tif
 
-Starting with GDAL 2.2, an alternate syntax is available so as to enable chaining and not being dependent on .tar extension, e.g.: :file:`/vsitar/{/path/to/the/archive}/path/inside/the/tar/file`. Note that :file:`/path/to/the/archive` may also itself use this alternate syntax.
+Starting with GDAL 2.2, an alternate syntax is available so as to enable chaining and not being dependent on .tar extension, e.g.: ``/vsitar/{/path/to/the/archive}/path/inside/the/tar/file``. Note that :file:`/path/to/the/archive` may also itself use this alternate syntax.
 
 .. _vsi7z:
 
@@ -227,7 +228,7 @@ Default extensions recognized by this virtual file system are:
 ``mpkx`` and ``ppkx`` (Esri ArcGIS Pro Project Package).
 
 An alternate syntax is available so as to enable chaining and not being
-dependent on those extensions, e.g.: :file:`/vsi7z/{/path/to/the/archive}/path/inside/the/archive`.
+dependent on those extensions, e.g.: ``/vsi7z/{/path/to/the/archive}/path/inside/the/archive``.
 Note that :file:`/path/to/the/archive` may also itself use this alternate syntax.
 
 Note that random seeking within a large compressed file will be inefficient when
@@ -257,7 +258,7 @@ is the relative path to the file inside the archive.`
 The default extension recognized by this virtual file system is: ``rar``
 
 An alternate syntax is available so as to enable chaining and not being
-dependent on those extensions, e.g.: :file:`/vsirar/{/path/to/the/archive}/path/inside/the/archive`.
+dependent on those extensions, e.g.: ``/vsirar/{/path/to/the/archive}/path/inside/the/archive``.
 Note that :file:`/path/to/the/archive` may also itself use this alternate syntax.
 
 Note that random seeking within a large compressed file will be inefficient when


### PR DESCRIPTION
Had some issues with a nested zip and fixed it after finding the curly brace logic.

Noticed broken formatting in the docs and the fix in https://github.com/OSGeo/gdal/pull/3270 which was easy to apply.

This commit also tries to make this syntax a bit more discoverable with an extra example :)  
Sorry for mixing it in but it was a quick edit using the GitHub web editor.

- Formatting fix from https://github.com/OSGeo/gdal/pull/3270 for the other occurrences of the curly brace syntax
- Additional vsizip example showing how to access a file in a nested zip, using the curly brace syntax