### PR TITLE
JSONFG: fix reading non-FeatureCollection documents larger than 6,000 bytes

### DIFF
--- a/autotest/ogr/ogr_jsonfg.py
+++ b/autotest/ogr/ogr_jsonfg.py
@@ -474,6 +474,32 @@ def test_jsonfg_read_two_features_types():
 
 
 ###############################################################################
+# Test reading file with a single Feature larger than 6000 bytes
+
+
+def test_jsonfg_read_single_feature_large(tmp_vsimem):
+
+    tmp_file = str(tmp_vsimem / "test.json")
+    content = """{
+      "type": "Feature",
+      "conformsTo" : [ "[ogc-json-fg-1-0.1:core]" ],
+      %s
+      "id": 1,
+      "geometry": { "type": "Point", "coordinates": [2, 49] },
+      "properties": { "foo": 1 },
+      "place": null,
+      "time": null
+    }""" % (
+        " " * 100000
+    )
+
+    gdal.FileFromMemBuffer(tmp_file, content)
+
+    ds = gdal.OpenEx(tmp_file)
+    assert ds.GetDriver().GetDescription() == "JSONFG"
+
+
+###############################################################################
 # Test time handling
 
 

--- a/ogr/ogrsf_frmts/jsonfg/ogrjsonfgdataset.cpp
+++ b/ogr/ogrsf_frmts/jsonfg/ogrjsonfgdataset.cpp
@@ -324,13 +324,13 @@ bool OGRJSONFGDataset::Open(GDALOpenInfo *poOpenInfo,
             }
             if (!bCanTryWithNonStreamingParserOut)
                 return false;
-
-            // Fallback to in-memory ingestion
-            CPLAssert(poOpenInfo->fpL == nullptr);
-            poOpenInfo->fpL = fp.release();
-            if (!ReadFromFile(poOpenInfo, pszUnprefixed))
-                return false;
         }
+
+        // Fallback to in-memory ingestion
+        CPLAssert(poOpenInfo->fpL == nullptr);
+        poOpenInfo->fpL = fp.release();
+        if (!ReadFromFile(poOpenInfo, pszUnprefixed))
+            return false;
     }
 
     // In-memory ingestion of the file


### PR DESCRIPTION
Fixes #10525
