### PR TITLE
[Backport release/3.9] EPSGTreatsAsNorthingEasting(): make it work correctly with compound CRS

### DIFF
--- a/autotest/osr/osr_epsg.py
+++ b/autotest/osr/osr_epsg.py
@@ -124,6 +124,8 @@ def test_osr_epsg_6():
         (5042, False),  # WGS 84 / UPS South (E,N)
         (3031, False),  # WGS 84 / Antarctic Polar Stereographic
         (5482, True),  # RSRGD2000 / RSPS2000
+        (3903, True),  # ETRS89 / TM35FIN(N,E) + N2000 height
+        (5698, False),  # RGF93 v1 / Lambert-93 + NGF-IGN69 height
     ],
 )
 def test_osr_epsg_treats_as_northing_easting(epsg_code, is_northing_easting):

--- a/ogr/ogrspatialreference.cpp
+++ b/ogr/ogrspatialreference.cpp
@@ -11927,7 +11927,7 @@ int OGRSpatialReference::EPSGTreatsAsNorthingEasting() const
     const auto ctxt = d->getPROJContext();
     if (d->m_pjType == PJ_TYPE_COMPOUND_CRS)
     {
-        projCRS = proj_crs_get_sub_crs(ctxt, d->m_pj_crs, 1);
+        projCRS = proj_crs_get_sub_crs(ctxt, d->m_pj_crs, 0);
         if (!projCRS || proj_get_type(projCRS) != PJ_TYPE_PROJECTED_CRS)
         {
             d->undoDemoteFromBoundCRS();


### PR DESCRIPTION
Backport #10520
 **Authored by:** @rouault