### PR TITLE
XODR: Implement handling of XML parsing errors

### DIFF
--- a/.github/workflows/ubuntu_20.04/Dockerfile.ci
+++ b/.github/workflows/ubuntu_20.04/Dockerfile.ci
@@ -260,7 +260,7 @@ RUN mkdir sqlite \
     && rm -rf sqlite
 
 # Build libOpenDRIVE
-ARG OPENDRIVE_VERSION=0.5.0-gdal
+ARG OPENDRIVE_VERSION=0.6.0-gdal
 RUN if test "${OPENDRIVE_VERSION}" != ""; then ( \
     wget -q https://github.com/DLR-TS/libOpenDRIVE/archive/refs/tags/${OPENDRIVE_VERSION}.tar.gz \
     && tar xzf ${OPENDRIVE_VERSION}.tar.gz \

--- a/.github/workflows/ubuntu_22.04/Dockerfile.ci
+++ b/.github/workflows/ubuntu_22.04/Dockerfile.ci
@@ -106,7 +106,7 @@ RUN mkdir mongocxx \
     && rm -rf mongocxx
 
 # Build libOpenDRIVE
-ARG OPENDRIVE_VERSION=0.5.0-gdal
+ARG OPENDRIVE_VERSION=0.6.0-gdal
 RUN if test "${OPENDRIVE_VERSION}" != ""; then ( \
     wget -q https://github.com/DLR-TS/libOpenDRIVE/archive/refs/tags/${OPENDRIVE_VERSION}.tar.gz \
     && tar xzf ${OPENDRIVE_VERSION}.tar.gz \

--- a/.github/workflows/ubuntu_24.04/Dockerfile.ci
+++ b/.github/workflows/ubuntu_24.04/Dockerfile.ci
@@ -107,7 +107,7 @@ RUN mkdir mongocxx \
     && rm -rf mongocxx
 
 # Build libOpenDRIVE
-ARG OPENDRIVE_VERSION=0.5.0-gdal
+ARG OPENDRIVE_VERSION=0.6.0-gdal
 RUN if test "${OPENDRIVE_VERSION}" != ""; then ( \
     wget -q https://github.com/DLR-TS/libOpenDRIVE/archive/refs/tags/${OPENDRIVE_VERSION}.tar.gz \
     && tar xzf ${OPENDRIVE_VERSION}.tar.gz \

--- a/doc/source/development/building_from_source.rst
+++ b/doc/source/development/building_from_source.rst
@@ -1160,7 +1160,7 @@ It is used by the internal libtiff library or the :ref:`raster.zarr` driver.
 libOpenDRIVE
 ************
 
-`libOpenDRIVE <https://github.com/pageldev/libOpenDRIVE>`_ is required for the :ref:`vector.xodr` driver.
+`libOpenDRIVE <https://github.com/pageldev/libOpenDRIVE>`_ in version >= 0.6.0 is required for the :ref:`vector.xodr` driver.
 
 .. option:: OpenDrive_DIR
 

--- a/doc/source/drivers/vector/xodr.rst
+++ b/doc/source/drivers/vector/xodr.rst
@@ -7,7 +7,7 @@ XODR -- OpenDRIVE Road Description Format
 
 .. shortname:: XODR
 
-.. build_dependencies:: libOpenDRIVE >= 0.5.0, GEOS
+.. build_dependencies:: libOpenDRIVE >= 0.6.0, GEOS
 
 This driver provides read access to road network elements of OpenDRIVE datasets.
 

--- a/doc/source/drivers/vector/xodr.rst
+++ b/doc/source/drivers/vector/xodr.rst
@@ -9,9 +9,9 @@ XODR -- OpenDRIVE Road Description Format
 
 .. build_dependencies:: libOpenDRIVE >= 0.6.0, GEOS
 
-This driver provides read access to road network elements of OpenDRIVE datasets.
+This driver provides read access to road network elements of ASAM OpenDRIVE datasets.
 
-`OpenDRIVE <https://www.asam.net/standards/detail/opendrive/>`_ is an open industry format for lane-detailed description of road networks, commonly used in applications of the automotive and transportation systems domains. It bundles polynomial, continuous road geometry modelling with all necessary topological links and semantic information from traffic-regulating infrastructure (signs and traffic lights).
+`ASAM OpenDRIVE <https://www.asam.net/standards/detail/opendrive/>`_ is an open industry format for lane-detailed description of road networks, commonly used in applications of the automotive and transportation systems domains. It bundles polynomial, continuous road geometry modelling with all necessary topological links and semantic information from traffic-regulating infrastructure (signs and traffic lights).
 
 Driver capabilities
 -------------------

--- a/docker/alpine-normal/Dockerfile
+++ b/docker/alpine-normal/Dockerfile
@@ -114,7 +114,7 @@ RUN if test "${HDF4_VERSION}" != "" -a "$(uname -m)" = "x86_64"; then ( \
     ); fi
 
 # Build libOpenDRIVE
-ARG OPENDRIVE_VERSION=0.5.0-gdal
+ARG OPENDRIVE_VERSION=0.6.0-gdal
 RUN if test "${OPENDRIVE_VERSION}" != ""; then ( \
     wget -q https://github.com/DLR-TS/libOpenDRIVE/archive/refs/tags/${OPENDRIVE_VERSION}.tar.gz \
     && tar xzf ${OPENDRIVE_VERSION}.tar.gz \

--- a/docker/ubuntu-full/Dockerfile
+++ b/docker/ubuntu-full/Dockerfile
@@ -173,7 +173,7 @@ RUN . /buildscripts/bh-set-envvars.sh \
     ); fi
 
 # Build libOpenDRIVE
-ARG OPENDRIVE_VERSION=0.5.0-gdal
+ARG OPENDRIVE_VERSION=0.6.0-gdal
 RUN . /buildscripts/bh-set-envvars.sh \
     && if test "${OPENDRIVE_VERSION}" != ""; then ( \
     wget -q https://github.com/DLR-TS/libOpenDRIVE/archive/refs/tags/${OPENDRIVE_VERSION}.tar.gz \

--- a/ogr/ogrsf_frmts/xodr/ogrxodrdatasource.cpp
+++ b/ogr/ogrsf_frmts/xodr/ogrxodrdatasource.cpp
@@ -35,6 +35,15 @@ using namespace std;
 bool OGRXODRDataSource::Open(const char *pszFilename, CSLConstList openOptions)
 {
     odr::OpenDriveMap xodr(pszFilename, false);
+    pugi::xml_parse_result parse_result = xodr.xml_parse_result;
+    if (!parse_result ||
+        parse_result.status != pugi::xml_parse_status::status_ok)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "OpenDRIVE dataset %s could not be parsed: %s.", pszFilename,
+                 parse_result.description());
+        return FALSE;
+    }
     bool parsingFailed = xodr.xml_doc.child("OpenDRIVE").empty();
     if (parsingFailed)
     {


### PR DESCRIPTION
## What does this PR do?

Now, catching of XML parsing errors is possible from within this XODR driver. This was not possible until recently where libOpenDRIVE dependency has been extended with the necessary functionality (see [Expose xml_parse_result for external queryability](https://github.com/pageldev/libOpenDRIVE/pull/98)).

## What are related issues/pull requests?

None

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
