### PR TITLE
Link to felt/tippecanoe

### DIFF
--- a/doc/source/drivers/vector/mvt.rst
+++ b/doc/source/drivers/vector/mvt.rst
@@ -442,7 +442,7 @@ See Also:
 -  `Mapbox Vector Tile
    Specification <https://github.com/mapbox/vector-tile-spec>`__
 -  :ref:`MBTiles <raster.mbtiles>` driver
--  `tippecanoe <https://github.com/mapbox/tippecanoe>`__: Builds vector
+-  `tippecanoe <https://github.com/felt/tippecanoe>`__: Builds vector
    tilesets from large (or small) collections of GeoJSON, Geobuf, or CSV
    features
 -  `Links to tools dealing with Mapbox Vector


### PR DESCRIPTION
[mapbox/tippecanoe](https://github.com/mapbox/tippecanoe) links to felt/tippecanoe with the mention

> Note: there is an active fork of this project over at https://github.com/felt/tippecanoe

So I think it is fair to update the link in the GDAL documentation as well.