### PR TITLE
HANA: Remove flaky fast extent estimation test

### DIFF
--- a/autotest/ogr/ogr_hana.py
+++ b/autotest/ogr/ogr_hana.py
@@ -1221,61 +1221,10 @@ def test_ogr_hana_38():
 
 
 ###############################################################################
-# Verify a working fast extent implementation
-
-
-def test_ogr_hana_39():
-    conn = create_connection()
-
-    def delta_merge():
-        execute_sql(
-            conn,
-            f"MERGE DELTA OF {table_name}",
-        )
-
-    # Create test table
-    layer_name = get_test_name()
-    table_name = f'"{gdaltest.hana_schema_name}"."{layer_name}"'
-    execute_sql(
-        conn,
-        f"CREATE COLUMN TABLE {table_name} (id INT, geom ST_Geometry(4326)) NO AUTO MERGE",
-    )
-
-    # Insert points
-    points_wkt = ["POINT(0 0)", "POINT(10 0)", "POINT(40 0)"]
-    for id, wkt in enumerate(points_wkt):
-        execute_sql(
-            conn,
-            f"INSERT INTO {table_name} (id, geom) VALUES ({id}, ST_GeomFromText('{wkt}', 4326))",
-        )
-    delta_merge()
-
-    # Check extent (1.)
-    ds = open_datasource(0)
-    layer = ds.GetLayerByName(layer_name)
-    assert layer is not None, "did not get layer"
-    check_extent(layer, (0, 40, 0, 0), force=False)
-
-    # Delete outer most point...
-    # Because of the disabled delta merge, the extent should remain unchanged
-    # when the fast extent estimation is used.
-    execute_sql(
-        conn,
-        f"DELETE FROM {table_name} WHERE id=2",
-    )
-    check_extent(layer, (0, 40, 0, 0), force=False)
-    delta_merge()
-    check_extent(layer, (0, 10, 0, 0), force=False)
-
-    # Tear-down
-    execute_sql(conn, f"DROP TABLE {table_name}")
-
-
-###############################################################################
 # Verify a working fallback in case the fast extent estimation fails
 
 
-def test_ogr_hana_40():
+def test_ogr_hana_39():
     conn = create_connection()
 
     # Create test table


### PR DESCRIPTION
## What does this PR do?

With PR #10543 , the new fast extent functionality for HANA was added to GDAL.
Unfortunately, one of the tests is failing randomly. Until a fixed test case is available, let's remove it for now.

## What are related issues/pull requests?

#10543
https://github.com/OSGeo/gdal/pull/10543#issuecomment-2271154989