### PR TITLE
PG/PGDump: make sure spatial index name is unique, even if several tables have a long enough prefix

### DIFF
--- a/autotest/ogr/ogr_pg.py
+++ b/autotest/ogr/ogr_pg.py
@@ -5887,7 +5887,8 @@ def test_ogr_pg_field_comment(pg_ds):
 def test_ogr_pg_long_identifiers(pg_ds):
 
     long_name = "test_" + ("X" * 64) + "_long_name"
-    short_name = "test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    short_name = "test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_3ba7c630"
+    assert len(short_name) == 63
     with gdal.quiet_errors():
         lyr = pg_ds.CreateLayer(long_name)
     assert lyr.GetName() == short_name
@@ -5895,11 +5896,25 @@ def test_ogr_pg_long_identifiers(pg_ds):
     assert lyr.CreateFeature(f) == ogr.OGRERR_NONE
     assert lyr.SyncToDisk() == ogr.OGRERR_NONE
 
+    long_name2 = "test_" + ("X" * 64) + "_long_name2"
+    short_name2 = "test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_bb4afe1c"
+    assert len(short_name2) == 63
+    with gdal.quiet_errors():
+        lyr = pg_ds.CreateLayer(long_name2)
+    assert lyr.GetName() == short_name2
+    f = ogr.Feature(lyr.GetLayerDefn())
+    assert lyr.CreateFeature(f) == ogr.OGRERR_NONE
+    assert lyr.SyncToDisk() == ogr.OGRERR_NONE
+
     pg_ds = reconnect(pg_ds, update=1)
 
-    got_lyr = pg_ds.GetLayerByName(long_name)
+    got_lyr = pg_ds.GetLayerByName(short_name)
     assert got_lyr
     assert got_lyr.GetName() == short_name
+
+    got_lyr = pg_ds.GetLayerByName(short_name2)
+    assert got_lyr
+    assert got_lyr.GetName() == short_name2
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_pgdump.py
+++ b/autotest/ogr/ogr_pgdump.py
@@ -1484,17 +1484,72 @@ def test_ogr_pgdump_CREATE_TABLE_NO(tmp_vsimem):
 # Test long identifiers
 
 
-def test_ogr_pgdump_long_identifiers(tmp_vsimem):
+@pytest.mark.parametrize(
+    "launder,long_name,geometry_name,short_name,pk_name,idx_name",
+    [
+        (
+            True,
+            "test_" + ("X" * (63 - len("test_"))),
+            "wkb_geometry",
+            "test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+            "test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_pk",
+            "test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_a5a5c85f_0_geom_idx",
+        ),
+        (
+            True,
+            "test_" + ("X" * (63 - len("test_") - len("wkb_geometry") - 2)),
+            "wkb_geometry",
+            "test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+            "test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_pk",
+            "test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_0_geom_idx",
+        ),
+        (
+            True,
+            "test_" + ("X" * 64) + "_long_name",
+            "wkb_geometry",
+            "test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_3ba7c630",
+            "test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_3ba7c_pk",
+            "test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_05e1f255_0_geom_idx",
+        ),
+        (
+            True,
+            "test_" + ("X" * 64) + "_long_name2",
+            "wkb_geometry",
+            "test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_bb4afe1c",
+            "test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_bb4af_pk",
+            "test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_950ad059_0_geom_idx",
+        ),
+        (
+            False,
+            "test_" + ("X" * 64) + "_long_name2",
+            "wkb_geometry",
+            "test_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_bb4afe1c",
+            "test_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_bb4af_pk",
+            "test_XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX_2c8a17fc_0_geom_idx",
+        ),
+    ],
+)
+def test_ogr_pgdump_long_identifiers(
+    tmp_vsimem, launder, long_name, geometry_name, short_name, pk_name, idx_name
+):
 
     ds = ogr.GetDriverByName("PGDump").CreateDataSource(
         tmp_vsimem / "test_ogr_pgdump_long_identifiers.sql", options=["LINEFORMAT=LF"]
     )
 
-    long_name = "test_" + ("X" * 64) + "_long_name"
-    short_name = "test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    assert len(short_name) <= 63
+    assert len(idx_name) <= 63
+    assert len(pk_name) <= 63
 
     with gdal.quiet_errors():
-        lyr = ds.CreateLayer(long_name, geom_type=ogr.wkbPoint)
+        lyr = ds.CreateLayer(
+            long_name,
+            geom_type=ogr.wkbPoint,
+            options=[
+                "LAUNDER=" + ("YES" if launder else "NO"),
+                "GEOMETRY_NAME=" + geometry_name,
+            ],
+        )
     lyr.CreateField(ogr.FieldDefn("str", ogr.OFTString))
     f = ogr.Feature(lyr.GetLayerDefn())
     f["str"] = "foo"
@@ -1515,10 +1570,10 @@ def test_ogr_pgdump_long_identifiers(tmp_vsimem):
 
     check_and_remove(f"""CREATE TABLE "public"."{short_name}"();""")
     check_and_remove(
-        f"""ALTER TABLE "public"."{short_name}" ADD COLUMN "ogc_fid" SERIAL CONSTRAINT "test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_pk" PRIMARY KEY;"""
+        f"""ALTER TABLE "public"."{short_name}" ADD COLUMN "ogc_fid" SERIAL CONSTRAINT "{pk_name}" PRIMARY KEY;"""
     )
     check_and_remove(
-        f"""CREATE INDEX "test_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx_wkb_geometry_geom_idx" ON "public"."{short_name}" USING GIST ("wkb_geometry");"""
+        f"""CREATE INDEX "{idx_name}" ON "public"."{short_name}" USING GIST ("wkb_geometry");"""
     )
 
 

--- a/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
@@ -1589,7 +1589,9 @@ OGRLayer *OGRPGDataSource::ICreateLayer(const char *pszLayerName,
             pszTableName = OGRPGCommonLaunderName(pszDotPos + 1, "PG",
                                                   bUTF8ToASCII);  // skip "."
         else
-            pszTableName = CPLStrdup(pszDotPos + 1);  // skip "."
+            pszTableName = CPLStrdup(
+                OGRPGCommonGenerateShortEnoughIdentifier(pszDotPos + 1)
+                    .c_str());  // skip "."
     }
     else
     {
@@ -1598,7 +1600,9 @@ OGRLayer *OGRPGDataSource::ICreateLayer(const char *pszLayerName,
             pszTableName = OGRPGCommonLaunderName(pszLayerName, "PG",
                                                   bUTF8ToASCII);  // skip "."
         else
-            pszTableName = CPLStrdup(pszLayerName);  // skip "."
+            pszTableName =
+                CPLStrdup(OGRPGCommonGenerateShortEnoughIdentifier(pszLayerName)
+                              .c_str());  // skip "."
     }
 
     /* -------------------------------------------------------------------- */
@@ -1936,32 +1940,11 @@ OGRLayer *OGRPGDataSource::ICreateLayer(const char *pszLayerName,
 
         if (eType != wkbNone && bHavePostGIS && bCreateSpatialIndex)
         {
-            /* --------------------------------------------------------------------
-             */
-            /*      Create the spatial index. */
-            /*                                                                      */
-            /*      We're doing this before we add geometry and record to the
-             * table */
-            /*      so this may not be exactly the best way to do it. */
-            /* --------------------------------------------------------------------
-             */
-            std::string osIndexName(pszTableName);
-            std::string osSuffix("_");
-            osSuffix += pszGFldName;
-            osSuffix += "_geom_idx";
-            if (bLaunder)
-            {
-                if (osSuffix.size() >=
-                    static_cast<size_t>(OGR_PG_NAMEDATALEN - 1))
-                {
-                    osSuffix = "_0_geom_idx";
-                }
-                if (osIndexName.size() + osSuffix.size() >
-                    static_cast<size_t>(OGR_PG_NAMEDATALEN - 1))
-                    osIndexName.resize(OGR_PG_NAMEDATALEN - 1 -
-                                       osSuffix.size());
-            }
-            osIndexName += osSuffix;
+            // Create the spatial index.
+            // We're doing this before we add geometry and record to the
+            // table, so this may not be exactly the best way to do it.
+            const std::string osIndexName(OGRPGCommonGenerateSpatialIndexName(
+                pszTableName, pszGFldName, 0));
 
             osCommand.Printf("CREATE INDEX %s ON %s.%s USING %s (%s)",
                              OGRPGEscapeColumnName(osIndexName.c_str()).c_str(),

--- a/ogr/ogrsf_frmts/pg/ogrpgtablelayer.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgtablelayer.cpp
@@ -2536,23 +2536,8 @@ OGRPGTableLayer::RunCreateSpatialIndex(const OGRPGGeomFieldDefn *poGeomField,
     PGconn *hPGConn = poDS->GetPGConn();
     CPLString osCommand;
 
-    std::string osIndexName(pszTableName);
-    std::string osSuffix("_");
-    osSuffix += poGeomField->GetNameRef();
-    osSuffix += "_geom_idx";
-    if (bLaunderColumnNames)
-    {
-        if (osSuffix.size() >= static_cast<size_t>(OGR_PG_NAMEDATALEN - 1))
-        {
-            osSuffix = "_";
-            osSuffix += CPLSPrintf("%d", nIdx);
-            osSuffix += "_geom_idx";
-        }
-        if (osIndexName.size() + osSuffix.size() >
-            static_cast<size_t>(OGR_PG_NAMEDATALEN - 1))
-            osIndexName.resize(OGR_PG_NAMEDATALEN - 1 - osSuffix.size());
-    }
-    osIndexName += osSuffix;
+    const std::string osIndexName(OGRPGCommonGenerateSpatialIndexName(
+        pszTableName, poGeomField->GetNameRef(), nIdx));
 
     osCommand.Printf("CREATE INDEX %s ON %s USING %s (%s)",
                      OGRPGEscapeColumnName(osIndexName.c_str()).c_str(),

--- a/ogr/ogrsf_frmts/pgdump/ogr_pgdump.h
+++ b/ogr/ogrsf_frmts/pgdump/ogr_pgdump.h
@@ -72,6 +72,12 @@ char CPL_DLL *OGRPGCommonLaunderName(const char *pszSrcName,
                                      const char *pszDebugPrefix,
                                      bool bUTF8ToASCII);
 
+std::string CPL_DLL
+OGRPGCommonGenerateShortEnoughIdentifier(const char *pszIdentifier);
+
+std::string CPL_DLL OGRPGCommonGenerateSpatialIndexName(
+    const char *pszTableName, const char *pszGeomFieldName, int nGeomFieldIdx);
+
 /************************************************************************/
 /*                        OGRPGDumpGeomFieldDefn                        */
 /************************************************************************/

--- a/ogr/ogrsf_frmts/pgdump/ogrpgdumplayer.cpp
+++ b/ogr/ogrsf_frmts/pgdump/ogrpgdumplayer.cpp
@@ -28,6 +28,7 @@
 
 #include "ogr_pgdump.h"
 #include "cpl_conv.h"
+#include "cpl_md5.h"
 #include "cpl_string.h"
 #include "ogr_p.h"
 
@@ -1555,6 +1556,77 @@ CPLString OGRPGCommonLayerGetPGDefault(OGRFieldDefn *poFieldDefn)
 }
 
 /************************************************************************/
+/*                OGRPGCommonGenerateShortEnoughIdentifier()            */
+/************************************************************************/
+
+std::string OGRPGCommonGenerateShortEnoughIdentifier(const char *pszIdentifier)
+{
+    if (strlen(pszIdentifier) <= static_cast<size_t>(OGR_PG_NAMEDATALEN - 1))
+        return pszIdentifier;
+
+    constexpr int FIRST_8_CHARS_OF_MD5 = 8;
+    std::string osRet(pszIdentifier,
+                      OGR_PG_NAMEDATALEN - 1 - 1 - FIRST_8_CHARS_OF_MD5);
+    osRet += '_';
+    osRet += std::string(CPLMD5String(pszIdentifier), FIRST_8_CHARS_OF_MD5);
+    return osRet;
+}
+
+/************************************************************************/
+/*                 OGRPGCommonGenerateSpatialIndexName()                 */
+/************************************************************************/
+
+/** Generates the name of the spatial index on table pszTableName
+ * using pszGeomFieldName, such that it fits in OGR_PG_NAMEDATALEN - 1 bytes.
+ * The index of the geometry field may be used if the geometry field name
+ * is too long.
+ */
+std::string OGRPGCommonGenerateSpatialIndexName(const char *pszTableName,
+                                                const char *pszGeomFieldName,
+                                                int nGeomFieldIdx)
+{
+    // Nominal case: use full table and geometry field name
+    for (const char *pszSuffix : {"_geom_idx", "_idx"})
+    {
+        if (strlen(pszTableName) + 1 + strlen(pszGeomFieldName) +
+                strlen(pszSuffix) <=
+            static_cast<size_t>(OGR_PG_NAMEDATALEN - 1))
+        {
+            std::string osRet(pszTableName);
+            osRet += '_';
+            osRet += pszGeomFieldName;
+            osRet += pszSuffix;
+            return osRet;
+        }
+    }
+
+    // Slightly degraded case: use table name and geometry field index
+    const std::string osGeomFieldIdx(CPLSPrintf("%d", nGeomFieldIdx));
+    if (strlen(pszTableName) + 1 + osGeomFieldIdx.size() +
+            strlen("_geom_idx") <=
+        static_cast<size_t>(OGR_PG_NAMEDATALEN - 1))
+    {
+        std::string osRet(pszTableName);
+        osRet += '_';
+        osRet += osGeomFieldIdx;
+        osRet += "_geom_idx";
+        return osRet;
+    }
+
+    // Fallback case: use first characters of table name,
+    // first 8 chars of its MD5 and then the geometry field index.
+    constexpr int FIRST_8_CHARS_OF_MD5 = 8;
+    std::string osSuffix("_");
+    osSuffix += std::string(CPLMD5String(pszTableName), FIRST_8_CHARS_OF_MD5);
+    osSuffix += '_';
+    osSuffix += osGeomFieldIdx;
+    osSuffix += "_geom_idx";
+    std::string osRet(pszTableName, OGR_PG_NAMEDATALEN - 1 - osSuffix.size());
+    osRet += osSuffix;
+    return osRet;
+}
+
+/************************************************************************/
 /*                           GetNextFeature()                           */
 /************************************************************************/
 
@@ -1812,26 +1884,9 @@ OGRErr OGRPGDumpLayer::CreateGeomField(const OGRGeomFieldDefn *poGeomFieldIn,
 
         if (m_bCreateSpatialIndexFlag)
         {
-            std::string osIndexName(GetName());
-            std::string osSuffix("_");
-            osSuffix += poGeomField->GetNameRef();
-            osSuffix += "_geom_idx";
-            if (m_bLaunderColumnNames)
-            {
-                if (osSuffix.size() >=
-                    static_cast<size_t>(OGR_PG_NAMEDATALEN - 1))
-                {
-                    osSuffix = "_";
-                    osSuffix +=
-                        CPLSPrintf("%d", m_poFeatureDefn->GetGeomFieldCount());
-                    osSuffix += "_geom_idx";
-                }
-                if (osIndexName.size() + osSuffix.size() >
-                    static_cast<size_t>(OGR_PG_NAMEDATALEN - 1))
-                    osIndexName.resize(OGR_PG_NAMEDATALEN - 1 -
-                                       osSuffix.size());
-            }
-            osIndexName += osSuffix;
+            const std::string osIndexName(OGRPGCommonGenerateSpatialIndexName(
+                GetName(), poGeomField->GetNameRef(),
+                m_poFeatureDefn->GetGeomFieldCount()));
 
             osCommand.Printf(
                 "CREATE INDEX %s ON %s USING %s (%s)",


### PR DESCRIPTION
Also truncates too long table name and append part of their MD5 to make them unique.

Fixes #10522, #7629
