### PR TITLE
OGRSQL: return in error when 'Did not find end-of-string character' is emitted

### DIFF
--- a/autotest/ogr/ogr_sql_rfc28.py
+++ b/autotest/ogr/ogr_sql_rfc28.py
@@ -741,12 +741,11 @@ def test_ogr_rfc28_union_all_three_branch_and(data_ds):
 # Test lack of end-of-string character
 
 
+@gdaltest.enable_exceptions()
 def test_ogr_rfc28_33(data_ds):
 
-    with gdal.quiet_errors():
-        lyr = data_ds.ExecuteSQL("select * from idlink where name='foo")
-
-    assert lyr is None
+    with pytest.raises(Exception, match="Did not find end-of-string character"):
+        data_ds.ExecuteSQL("select * from idlink'")
 
 
 ###############################################################################

--- a/ogr/swq.cpp
+++ b/ogr/swq.cpp
@@ -142,7 +142,7 @@ int swqlex(YYSTYPE *ppNode, swq_parse_context *context)
             CPLError(CE_Failure, CPLE_AppDefined,
                      "Did not find end-of-string character");
             CPLFree(token);
-            return 0;
+            return YYerror;
         }
 
         *ppNode = new swq_expr_node(token);


### PR DESCRIPTION
Fixes #10515
