### PR TITLE
[Backport release/3.9] COG: properly deal with mask bands w.r.t resampling when generating JPEG output, or when input has a mask band

### DIFF
--- a/frmts/gtiff/cogdriver.cpp
+++ b/frmts/gtiff/cogdriver.cpp
@@ -737,19 +737,25 @@ GDALCOGCreator::~GDALCOGCreator()
     // may reference the later
     m_poRGBMaskDS.reset();
 
-    if (m_poReprojectedDS)
+    // Config option just for testing purposes
+    const bool bDeleteTempFiles =
+        CPLTestBool(CPLGetConfigOption("COG_DELETE_TEMP_FILES", "YES"));
+    if (bDeleteTempFiles)
     {
-        CPLString osProjectedDSName(m_poReprojectedDS->GetDescription());
-        m_poReprojectedDS.reset();
-        VSIUnlink(osProjectedDSName);
-    }
-    if (!m_osTmpOverviewFilename.empty())
-    {
-        VSIUnlink(m_osTmpOverviewFilename);
-    }
-    if (!m_osTmpMskOverviewFilename.empty())
-    {
-        VSIUnlink(m_osTmpMskOverviewFilename);
+        if (m_poReprojectedDS)
+        {
+            CPLString osProjectedDSName(m_poReprojectedDS->GetDescription());
+            m_poReprojectedDS.reset();
+            VSIUnlink(osProjectedDSName);
+        }
+        if (!m_osTmpOverviewFilename.empty())
+        {
+            VSIUnlink(m_osTmpOverviewFilename);
+        }
+        if (!m_osTmpMskOverviewFilename.empty())
+        {
+            VSIUnlink(m_osTmpMskOverviewFilename);
+        }
     }
 }
 

--- a/frmts/gtiff/gt_overview.cpp
+++ b/frmts/gtiff/gt_overview.cpp
@@ -203,7 +203,8 @@ toff_t GTIFFWriteDirectory(TIFF *hTIFF, int nSubfileType, int nXSize,
 /************************************************************************/
 
 void GTIFFBuildOverviewMetadata(const char *pszResampling,
-                                GDALDataset *poBaseDS, CPLString &osMetadata)
+                                GDALDataset *poBaseDS, bool bIsForMaskBand,
+                                CPLString &osMetadata)
 
 {
     osMetadata = "<GDALMetadata>";
@@ -216,7 +217,11 @@ void GTIFFBuildOverviewMetadata(const char *pszResampling,
         osMetadata += "</Item>";
     }
 
-    if (poBaseDS->GetMetadataItem("INTERNAL_MASK_FLAGS_1"))
+    if (bIsForMaskBand)
+    {
+        osMetadata += "<Item name=\"INTERNAL_MASK_FLAGS_1\">2</Item>";
+    }
+    else if (poBaseDS->GetMetadataItem("INTERNAL_MASK_FLAGS_1"))
     {
         for (int iBand = 0; iBand < 200; iBand++)
         {
@@ -771,7 +776,10 @@ CPLErr GTIFFBuildOverviewsEx(const char *pszFilename, int nBands,
     GDALDataset *poBaseDS = papoBandList[0]->GetDataset();
     if (poBaseDS)
     {
-        GTIFFBuildOverviewMetadata(pszResampling, poBaseDS, osMetadata);
+        const bool bIsForMaskBand =
+            nBands == 1 && papoBandList[0]->IsMaskBand();
+        GTIFFBuildOverviewMetadata(pszResampling, poBaseDS, bIsForMaskBand,
+                                   osMetadata);
     }
 
     if (poBaseDS != nullptr && poBaseDS->GetRasterCount() == nBands)

--- a/frmts/gtiff/gt_overview.h
+++ b/frmts/gtiff/gt_overview.h
@@ -53,7 +53,8 @@ toff_t GTIFFWriteDirectory(TIFF *hTIFF, int nSubfileType, int nXSize,
                            bool bDeferStrileArrayWriting);
 
 void GTIFFBuildOverviewMetadata(const char *pszResampling,
-                                GDALDataset *poBaseDS, CPLString &osMetadata);
+                                GDALDataset *poBaseDS, bool bIsForMaskBand,
+                                CPLString &osMetadata);
 
 CPLErr GTIFFBuildOverviewsEx(const char *pszFilename, int nBands,
                              GDALRasterBand *const *papoBandList,

--- a/frmts/gtiff/gtiffdataset_write.cpp
+++ b/frmts/gtiff/gtiffdataset_write.cpp
@@ -2799,7 +2799,7 @@ CPLErr GTiffDataset::CreateOverviewsFromSrcOverviews(GDALDataset *poSrcDS,
     /* -------------------------------------------------------------------- */
     CPLString osMetadata;
 
-    GTIFFBuildOverviewMetadata("NONE", this, osMetadata);
+    GTIFFBuildOverviewMetadata("NONE", this, false, osMetadata);
 
     int nCompression;
     uint16_t nPlanarConfig;
@@ -3086,7 +3086,8 @@ CPLErr GTiffDataset::IBuildOverviews(const char *pszResampling, int nOverviews,
     /* -------------------------------------------------------------------- */
     CPLString osMetadata;
 
-    GTIFFBuildOverviewMetadata(pszResampling, this, osMetadata);
+    const bool bIsForMaskBand = nBands == 1 && GetRasterBand(1)->IsMaskBand();
+    GTIFFBuildOverviewMetadata(pszResampling, this, bIsForMaskBand, osMetadata);
 
     int nCompression;
     uint16_t nPlanarConfig;


### PR DESCRIPTION
Backport #10558
 **Authored by:** @rouault