### PR TITLE
PDFium: Avoid confusing/misleading error

### DIFF
--- a/frmts/pdf/CMakeLists.txt
+++ b/frmts/pdf/CMakeLists.txt
@@ -76,7 +76,10 @@ if (GDAL_USE_PDFIUM)
   target_compile_definitions(gdal_PDF PRIVATE -DHAVE_PDFIUM)
   gdal_target_link_libraries(gdal_PDF PRIVATE PDFIUM::PDFIUM)
   if (UNIX)
-    find_library(LCMS2_LIBRARY NAMES lcms2)
+    find_package(JPEG REQUIRED)
+    find_package(PNG REQUIRED)
+    find_package(OpenJPEG REQUIRED)
+    find_library(LCMS2_LIBRARY NAMES lcms2 REQUIRED)
 
     # Rather hacky... Related how we build pdfium in https://github.com/rouault/pdfium_build_gdal_3_4
     gdal_target_link_libraries(


### PR DESCRIPTION
When dependencies are missing, the error is totally misleading.
```
CMake Error at cmake/helpers/GdalDriverHelper.cmake:390 (message):
  gdal_target_link_libraries(): PRIVATE is a mandatory argument.
Call Stack (most recent call first):
  frmts/pdf/CMakeLists.txt:82 (gdal_target_link_libraries)
```

This simple patch explicitly generates better errors.

Only tested on Ubuntu.  closes #10568 
