### PR TITLE
[Backport release/3.9] OGR SQL: do not make backslash a special character inside single-quoted strings, to improve compliance wih SQL92

### DIFF
--- a/autotest/ogr/ogr_sql_test.py
+++ b/autotest/ogr/ogr_sql_test.py
@@ -1219,11 +1219,11 @@ def test_ogr_sql_42(data_ds):
 
 def test_ogr_sql_43(data_ds):
 
-    sql = "SELECT '\"' as a, '\\'' as b, '''' as c FROM poly"
+    sql = "SELECT '\"' as a, '\\' as b, '''' as c FROM poly"
     with data_ds.ExecuteSQL(sql) as sql_lyr:
         feat = sql_lyr.GetNextFeature()
         assert feat["a"] == '"'
-        assert feat["b"] == "'"
+        assert feat["b"] == "\\"
         assert feat["c"] == "'"
 
 

--- a/ogr/swq.cpp
+++ b/ogr/swq.cpp
@@ -118,11 +118,14 @@ int swqlex(YYSTYPE *ppNode, swq_parse_context *context)
 
         while (*pszInput != '\0')
         {
-            if (chQuote == '"' && *pszInput == '\\' && pszInput[1] == '"')
+            // Not totally sure we need to preserve this way of escaping for
+            // strings between double-quotes
+            if (chQuote == '"' && *pszInput == '\\')
+            {
                 pszInput++;
-            else if (chQuote == '\'' && *pszInput == '\\' &&
-                     pszInput[1] == '\'')
-                pszInput++;
+                if (*pszInput == '\0')
+                    break;
+            }
             else if (chQuote == '\'' && *pszInput == '\'' &&
                      pszInput[1] == '\'')
                 pszInput++;


### PR DESCRIPTION
Backport #10425
 **Authored by:** @rouault