### PR TITLE
[Backport release/3.9] GTFS: fix error when applying an attribute filter on a field whose advertized data type is not string

### DIFF
--- a/autotest/ogr/ogr_gtfs.py
+++ b/autotest/ogr/ogr_gtfs.py
@@ -99,6 +99,11 @@ def test_ogr_gtfs_content():
     f = lyr.GetNextFeature()
     assert f is None
 
+    lyr = ds.GetLayerByName("routes")
+    assert lyr
+    lyr.SetAttributeFilter("route_type = 3")
+    assert lyr.GetFeatureCount() == 30
+
     lyr = ds.GetLayerByName("stops")
     assert lyr
     assert lyr.GetGeomType() == ogr.wkbPoint


### PR DESCRIPTION
Backport #10454
 **Authored by:** @rouault