### PR TITLE
[Backport release/3.9] GDALCopyWords(): Fix double->uint64 when input value > UINT64_MAX thattwas wrongly converted to 0

### DIFF
--- a/autotest/cpp/testcopywords.cpp
+++ b/autotest/cpp/testcopywords.cpp
@@ -32,6 +32,7 @@
 
 #include <cstdint>
 #include <iostream>
+#include <limits>
 
 #include "gtest_include.h"
 
@@ -593,6 +594,150 @@ TEST_F(TestCopyWords, GDT_Float32and64)
         FROM_R(intype, -CST_5000000000, GDT_CFloat32, -CST_5000000000);
         FROM_R(intype, CST_5000000000, GDT_CFloat64, CST_5000000000);
         FROM_R(intype, -CST_5000000000, GDT_CFloat64, -CST_5000000000);
+    }
+
+    // Float32 to Int64
+    {
+        float in_value = std::numeric_limits<float>::quiet_NaN();
+        int64_t out_value = 0;
+        GDALCopyWords(&in_value, GDT_Float32, 0, &out_value, GDT_Int64, 0, 1);
+        EXPECT_EQ(out_value, 0);
+    }
+
+    {
+        float in_value = -std::numeric_limits<float>::infinity();
+        int64_t out_value = 0;
+        GDALCopyWords(&in_value, GDT_Float32, 0, &out_value, GDT_Int64, 0, 1);
+        EXPECT_EQ(out_value, INT64_MIN);
+    }
+
+    {
+        float in_value = -std::numeric_limits<float>::max();
+        int64_t out_value = 0;
+        GDALCopyWords(&in_value, GDT_Float32, 0, &out_value, GDT_Int64, 0, 1);
+        EXPECT_EQ(out_value, INT64_MIN);
+    }
+
+    {
+        float in_value = std::numeric_limits<float>::max();
+        int64_t out_value = 0;
+        GDALCopyWords(&in_value, GDT_Float32, 0, &out_value, GDT_Int64, 0, 1);
+        EXPECT_EQ(out_value, INT64_MAX);
+    }
+
+    {
+        float in_value = std::numeric_limits<float>::infinity();
+        int64_t out_value = 0;
+        GDALCopyWords(&in_value, GDT_Float32, 0, &out_value, GDT_Int64, 0, 1);
+        EXPECT_EQ(out_value, INT64_MAX);
+    }
+
+    // Float64 to Int64
+    {
+        double in_value = std::numeric_limits<double>::quiet_NaN();
+        int64_t out_value = 0;
+        GDALCopyWords(&in_value, GDT_Float64, 0, &out_value, GDT_Int64, 0, 1);
+        EXPECT_EQ(out_value, 0);
+    }
+
+    {
+        double in_value = -std::numeric_limits<double>::infinity();
+        int64_t out_value = 0;
+        GDALCopyWords(&in_value, GDT_Float64, 0, &out_value, GDT_Int64, 0, 1);
+        EXPECT_EQ(out_value, INT64_MIN);
+    }
+
+    {
+        double in_value = -std::numeric_limits<double>::max();
+        int64_t out_value = 0;
+        GDALCopyWords(&in_value, GDT_Float64, 0, &out_value, GDT_Int64, 0, 1);
+        EXPECT_EQ(out_value, INT64_MIN);
+    }
+
+    {
+        double in_value = std::numeric_limits<double>::max();
+        int64_t out_value = 0;
+        GDALCopyWords(&in_value, GDT_Float64, 0, &out_value, GDT_Int64, 0, 1);
+        EXPECT_EQ(out_value, INT64_MAX);
+    }
+
+    {
+        double in_value = std::numeric_limits<double>::infinity();
+        int64_t out_value = 0;
+        GDALCopyWords(&in_value, GDT_Float64, 0, &out_value, GDT_Int64, 0, 1);
+        EXPECT_EQ(out_value, INT64_MAX);
+    }
+
+    // Float32 to UInt64
+    {
+        float in_value = std::numeric_limits<float>::quiet_NaN();
+        uint64_t out_value = 0;
+        GDALCopyWords(&in_value, GDT_Float32, 0, &out_value, GDT_UInt64, 0, 1);
+        EXPECT_EQ(out_value, 0);
+    }
+
+    {
+        float in_value = -std::numeric_limits<float>::infinity();
+        uint64_t out_value = 0;
+        GDALCopyWords(&in_value, GDT_Float32, 0, &out_value, GDT_UInt64, 0, 1);
+        EXPECT_EQ(out_value, 0);
+    }
+
+    {
+        float in_value = -std::numeric_limits<float>::max();
+        uint64_t out_value = 0;
+        GDALCopyWords(&in_value, GDT_Float32, 0, &out_value, GDT_UInt64, 0, 1);
+        EXPECT_EQ(out_value, 0);
+    }
+
+    {
+        float in_value = std::numeric_limits<float>::max();
+        uint64_t out_value = 0;
+        GDALCopyWords(&in_value, GDT_Float32, 0, &out_value, GDT_UInt64, 0, 1);
+        EXPECT_EQ(out_value, UINT64_MAX);
+    }
+
+    {
+        float in_value = std::numeric_limits<float>::infinity();
+        uint64_t out_value = 0;
+        GDALCopyWords(&in_value, GDT_Float32, 0, &out_value, GDT_UInt64, 0, 1);
+        EXPECT_EQ(out_value, UINT64_MAX);
+    }
+
+    // Float64 to UInt64
+    {
+        double in_value = -std::numeric_limits<double>::quiet_NaN();
+        uint64_t out_value = 0;
+        GDALCopyWords(&in_value, GDT_Float64, 0, &out_value, GDT_UInt64, 0, 1);
+        EXPECT_EQ(out_value, 0);
+    }
+
+    {
+        double in_value = -std::numeric_limits<double>::infinity();
+        uint64_t out_value = 0;
+        GDALCopyWords(&in_value, GDT_Float64, 0, &out_value, GDT_UInt64, 0, 1);
+        EXPECT_EQ(out_value, 0);
+    }
+
+    {
+        double in_value = -std::numeric_limits<double>::max();
+        uint64_t out_value = 0;
+        GDALCopyWords(&in_value, GDT_Float64, 0, &out_value, GDT_UInt64, 0, 1);
+        EXPECT_EQ(out_value, 0);
+    }
+
+    {
+        double in_value = std::numeric_limits<double>::max();
+        uint64_t out_value = 0;
+        GDALCopyWords(&in_value, GDT_Float64, 0, &out_value, GDT_UInt64, 0, 1);
+        EXPECT_EQ(out_value, UINT64_MAX);
+    }
+
+    {
+        double in_value = std::numeric_limits<double>::infinity();
+        uint64_t out_value = 0;
+        GDALCopyWords(&in_value, GDT_Float64, 0, &out_value, GDT_UInt64, 0, 1);
+        EXPECT_EQ(out_value, UINT64_MAX);
     }
 }
 

--- a/gcore/gdal_priv_templates.hpp
+++ b/gcore/gdal_priv_templates.hpp
@@ -371,16 +371,45 @@ template <> struct sGDALCopyWord<double, std::int64_t>
 {
     static inline void f(const double dfValueIn, std::int64_t &nValueOut)
     {
-        if (CPLIsNan(dfValueIn))
+        if (std::isnan(dfValueIn))
         {
             nValueOut = 0;
-            return;
         }
-        double dfMaxVal, dfMinVal;
-        GDALGetDataLimits<double, std::int64_t>(dfMaxVal, dfMinVal);
-        double dfValue = dfValueIn >= 0.0 ? dfValueIn + 0.5 : dfValueIn - 0.5;
-        nValueOut = static_cast<std::int64_t>(
-            GDALClampValue(dfValue, dfMaxVal, dfMinVal));
+        else if (dfValueIn >=
+                 static_cast<double>(std::numeric_limits<std::int64_t>::max()))
+        {
+            nValueOut = std::numeric_limits<std::int64_t>::max();
+        }
+        else if (dfValueIn <=
+                 static_cast<double>(std::numeric_limits<std::int64_t>::min()))
+        {
+            nValueOut = std::numeric_limits<std::int64_t>::min();
+        }
+        else
+        {
+            nValueOut = static_cast<std::int64_t>(
+                dfValueIn > 0.0f ? dfValueIn + 0.5f : dfValueIn - 0.5f);
+        }
+    }
+};
+
+template <> struct sGDALCopyWord<double, std::uint64_t>
+{
+    static inline void f(const double dfValueIn, std::uint64_t &nValueOut)
+    {
+        if (!(dfValueIn > 0))
+        {
+            nValueOut = 0;
+        }
+        else if (dfValueIn >
+                 static_cast<double>(std::numeric_limits<uint64_t>::max()))
+        {
+            nValueOut = std::numeric_limits<uint64_t>::max();
+        }
+        else
+        {
+            nValueOut = static_cast<std::uint64_t>(dfValueIn + 0.5);
+        }
     }
 };
 
@@ -424,7 +453,12 @@ template <> struct sGDALCopyWord<float, int>
 {
     static inline void f(const float fValueIn, int &nValueOut)
     {
-        if (fValueIn >= static_cast<float>(std::numeric_limits<int>::max()))
+        if (std::isnan(fValueIn))
+        {
+            nValueOut = 0;
+        }
+        else if (fValueIn >=
+                 static_cast<float>(std::numeric_limits<int>::max()))
         {
             nValueOut = std::numeric_limits<int>::max();
         }
@@ -447,15 +481,14 @@ template <> struct sGDALCopyWord<float, unsigned int>
 {
     static inline void f(const float fValueIn, unsigned int &nValueOut)
     {
-        if (fValueIn >=
-            static_cast<float>(std::numeric_limits<unsigned int>::max()))
+        if (!(fValueIn > 0))
+        {
+            nValueOut = 0;
+        }
+        else if (fValueIn >=
+                 static_cast<float>(std::numeric_limits<unsigned int>::max()))
         {
             nValueOut = std::numeric_limits<unsigned int>::max();
-        }
-        else if (fValueIn <=
-                 static_cast<float>(std::numeric_limits<unsigned int>::min()))
-        {
-            nValueOut = std::numeric_limits<unsigned int>::min();
         }
         else
         {
@@ -470,8 +503,12 @@ template <> struct sGDALCopyWord<float, std::int64_t>
 {
     static inline void f(const float fValueIn, std::int64_t &nValueOut)
     {
-        if (fValueIn >=
-            static_cast<float>(std::numeric_limits<std::int64_t>::max()))
+        if (std::isnan(fValueIn))
+        {
+            nValueOut = 0;
+        }
+        else if (fValueIn >=
+                 static_cast<float>(std::numeric_limits<std::int64_t>::max()))
         {
             nValueOut = std::numeric_limits<std::int64_t>::max();
         }
@@ -494,15 +531,14 @@ template <> struct sGDALCopyWord<float, std::uint64_t>
 {
     static inline void f(const float fValueIn, std::uint64_t &nValueOut)
     {
-        if (fValueIn >=
-            static_cast<float>(std::numeric_limits<std::uint64_t>::max()))
+        if (!(fValueIn > 0))
+        {
+            nValueOut = 0;
+        }
+        else if (fValueIn >=
+                 static_cast<float>(std::numeric_limits<std::uint64_t>::max()))
         {
             nValueOut = std::numeric_limits<std::uint64_t>::max();
-        }
-        else if (fValueIn <=
-                 static_cast<float>(std::numeric_limits<std::uint64_t>::min()))
-        {
-            nValueOut = std::numeric_limits<std::uint64_t>::min();
         }
         else
         {


### PR DESCRIPTION
Backport #10468
 **Authored by:** @rouault