### PR TITLE
[Backport release/3.9] CPLFormFilename()/CPLGetDirname()/CPLGetPath(): make it work with 'vsicurl/http://example.com?foo'…

### DIFF
--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -1062,6 +1062,25 @@ TEST_F(test_cpl, CPLFormFilename)
     EXPECT_TRUE(
         EQUAL(CPLFormFilename("\\\\$\\c:", "..", nullptr), "\\\\$\\c:/..") ||
         EQUAL(CPLFormFilename("\\\\$\\c:", "..", nullptr), "\\\\$\\c:\\.."));
+    EXPECT_STREQ(
+        CPLFormFilename("/vsicurl/http://example.com?foo", "bar", nullptr),
+        "/vsicurl/http://example.com/bar?foo");
+}
+
+TEST_F(test_cpl, CPLGetPath)
+{
+    EXPECT_STREQ(CPLGetPath("/foo/bar/"), "/foo/bar");
+    EXPECT_STREQ(CPLGetPath("/foo/bar"), "/foo");
+    EXPECT_STREQ(CPLGetPath("/vsicurl/http://example.com/foo/bar?suffix"),
+                 "/vsicurl/http://example.com/foo?suffix");
+}
+
+TEST_F(test_cpl, CPLGetDirname)
+{
+    EXPECT_STREQ(CPLGetDirname("/foo/bar/"), "/foo/bar");
+    EXPECT_STREQ(CPLGetDirname("/foo/bar"), "/foo");
+    EXPECT_STREQ(CPLGetDirname("/vsicurl/http://example.com/foo/bar?suffix"),
+                 "/vsicurl/http://example.com/foo?suffix");
 }
 
 TEST_F(test_cpl, VSIGetDiskFreeSpace)

--- a/gcore/gdalmultidim.cpp
+++ b/gcore/gdalmultidim.cpp
@@ -4097,6 +4097,17 @@ GDALMDArray::GetCacheRootGroup(bool bCanCreate,
     }
 
     osCacheFilenameOut = osFilename + ".gmac";
+    if (STARTS_WITH(osFilename.c_str(), "/vsicurl/http"))
+    {
+        const auto nPosQuestionMark = osFilename.find('?');
+        if (nPosQuestionMark != std::string::npos)
+        {
+            osCacheFilenameOut =
+                osFilename.substr(0, nPosQuestionMark)
+                    .append(".gmac")
+                    .append(osFilename.substr(nPosQuestionMark));
+        }
+    }
     const char *pszProxy = PamGetProxy(osCacheFilenameOut.c_str());
     if (pszProxy != nullptr)
         osCacheFilenameOut = pszProxy;


### PR DESCRIPTION
Backport #10495
 **Authored by:** @rouault