### PR TITLE
[Backport release/3.9] VRT: fix reading from virtual overviews when SrcRect / DstRect elements are missing

### DIFF
--- a/autotest/gdrivers/vrtprocesseddataset.py
+++ b/autotest/gdrivers/vrtprocesseddataset.py
@@ -676,19 +676,20 @@ def test_vrtprocesseddataset_dehazing_different_resolution(tmp_vsimem):
     src_ds.GetRasterBand(1).WriteArray(
         np.array([[1, 1, 2, 2, 3, 3], [1, 1, 2, 2, 3, 3]])
     )
-    src_ds.SetGeoTransform([0, 0.5, 0, 0, 0, 0.5])
+    src_ds.SetGeoTransform([0, 0.5 * 10, 0, 0, 0, 0.5 * 10])
+    src_ds.BuildOverviews("NEAR", [2])
     src_ds.Close()
 
     gain_filename = str(tmp_vsimem / "gain.tif")
     gain_ds = gdal.GetDriverByName("GTiff").Create(gain_filename, 3, 1, 1)
     gain_ds.GetRasterBand(1).WriteArray(np.array([[2, 4, 6]]))
-    gain_ds.SetGeoTransform([0, 1, 0, 0, 0, 1])
+    gain_ds.SetGeoTransform([0, 1 * 10, 0, 0, 0, 1 * 10])
     gain_ds.Close()
 
     offset_filename = str(tmp_vsimem / "offset.tif")
     offset_ds = gdal.GetDriverByName("GTiff").Create(offset_filename, 3, 1, 1)
     offset_ds.GetRasterBand(1).WriteArray(np.array([[1, 2, 3]]))
-    offset_ds.SetGeoTransform([0, 1, 0, 0, 0, 1])
+    offset_ds.SetGeoTransform([0, 1 * 10, 0, 0, 0, 1 * 10])
     offset_ds.Close()
 
     ds = gdal.Open(
@@ -711,6 +712,10 @@ def test_vrtprocesseddataset_dehazing_different_resolution(tmp_vsimem):
     np.testing.assert_equal(
         ds.GetRasterBand(1).ReadAsArray(),
         np.array([[1, 2, 6, 8, 15, 15], [1, 2, 6, 8, 15, 15]]),
+    )
+    np.testing.assert_equal(
+        ds.GetRasterBand(1).GetOverview(0).ReadAsArray(),
+        np.array([[1, 6, 15]]),
     )
 
 

--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -1236,15 +1236,21 @@ class CPL_DLL VRTSimpleSource CPL_NON_FINAL : public VRTSource
     int m_nBand = 0;
     bool m_bGetMaskBand = false;
 
-    double m_dfSrcXOff = 0;
-    double m_dfSrcYOff = 0;
-    double m_dfSrcXSize = 0;
-    double m_dfSrcYSize = 0;
+    /* Value for uninitialized source or destination window. It is chosen such
+     * that SrcToDst() and DstToSrc() are no-ops if both source and destination
+     * windows are unset.
+     */
+    static constexpr double UNINIT_WINDOW = -1.0;
 
-    double m_dfDstXOff = 0;
-    double m_dfDstYOff = 0;
-    double m_dfDstXSize = 0;
-    double m_dfDstYSize = 0;
+    double m_dfSrcXOff = UNINIT_WINDOW;
+    double m_dfSrcYOff = UNINIT_WINDOW;
+    double m_dfSrcXSize = UNINIT_WINDOW;
+    double m_dfSrcYSize = UNINIT_WINDOW;
+
+    double m_dfDstXOff = UNINIT_WINDOW;
+    double m_dfDstYOff = UNINIT_WINDOW;
+    double m_dfDstXSize = UNINIT_WINDOW;
+    double m_dfDstYSize = UNINIT_WINDOW;
 
     CPLString m_osResampling{};
 
@@ -1273,6 +1279,20 @@ class CPL_DLL VRTSimpleSource CPL_NON_FINAL : public VRTSource
     virtual bool ValidateOpenedBand(GDALRasterBand * /*poBand*/) const
     {
         return true;
+    }
+
+    /** Returns whether the source window is set */
+    bool IsSrcWinSet() const
+    {
+        return m_dfSrcXOff != UNINIT_WINDOW || m_dfSrcYOff != UNINIT_WINDOW ||
+               m_dfSrcXSize != UNINIT_WINDOW || m_dfSrcYSize != UNINIT_WINDOW;
+    }
+
+    /** Returns whether the destination window is set */
+    bool IsDstWinSet() const
+    {
+        return m_dfDstXOff != UNINIT_WINDOW || m_dfDstYOff != UNINIT_WINDOW ||
+               m_dfDstXSize != UNINIT_WINDOW || m_dfDstYSize != UNINIT_WINDOW;
     }
 
   public:

--- a/frmts/vrt/vrtsources.cpp
+++ b/frmts/vrt/vrtsources.cpp
@@ -114,15 +114,34 @@ VRTSimpleSource::VRTSimpleSource(const VRTSimpleSource *poSrcSource,
       m_dfSrcYOff(poSrcSource->m_dfSrcYOff),
       m_dfSrcXSize(poSrcSource->m_dfSrcXSize),
       m_dfSrcYSize(poSrcSource->m_dfSrcYSize),
-      m_dfDstXOff(poSrcSource->m_dfDstXOff * dfXDstRatio),
-      m_dfDstYOff(poSrcSource->m_dfDstYOff * dfYDstRatio),
-      m_dfDstXSize(poSrcSource->m_dfDstXSize * dfXDstRatio),
-      m_dfDstYSize(poSrcSource->m_dfDstYSize * dfYDstRatio),
       m_nMaxValue(poSrcSource->m_nMaxValue), m_bRelativeToVRTOri(-1),
       m_nExplicitSharedStatus(poSrcSource->m_nExplicitSharedStatus),
       m_osSrcDSName(poSrcSource->m_osSrcDSName),
       m_bDropRefOnSrcBand(poSrcSource->m_bDropRefOnSrcBand)
 {
+    if (!poSrcSource->IsSrcWinSet() && !poSrcSource->IsDstWinSet() &&
+        (dfXDstRatio != 1.0 || dfYDstRatio != 1.0))
+    {
+        auto l_band = GetRasterBand();
+        if (l_band)
+        {
+            m_dfSrcXOff = 0;
+            m_dfSrcYOff = 0;
+            m_dfSrcXSize = l_band->GetXSize();
+            m_dfSrcYSize = l_band->GetYSize();
+            m_dfDstXOff = 0;
+            m_dfDstYOff = 0;
+            m_dfDstXSize = l_band->GetXSize() * dfXDstRatio;
+            m_dfDstYSize = l_band->GetYSize() * dfYDstRatio;
+        }
+    }
+    else if (poSrcSource->IsDstWinSet())
+    {
+        m_dfDstXOff = poSrcSource->m_dfDstXOff * dfXDstRatio;
+        m_dfDstYOff = poSrcSource->m_dfDstYOff * dfYDstRatio;
+        m_dfDstXSize = poSrcSource->m_dfDstXSize * dfXDstRatio;
+        m_dfDstYSize = poSrcSource->m_dfDstYSize * dfYDstRatio;
+    }
 }
 
 /************************************************************************/


### PR DESCRIPTION
Backport #10589
 **Authored by:** @rouault