### PR TITLE
KEA: fix overview writing so that tiles are correctly flushed

### DIFF
--- a/frmts/kea/keaoverview.cpp
+++ b/frmts/kea/keaoverview.cpp
@@ -48,6 +48,9 @@ KEAOverview::KEAOverview(KEADataset *pDataset, int nSrcBand,
 
 KEAOverview::~KEAOverview()
 {
+    // according to the docs, this is required
+    // otherwise not all tiles will be written.
+    this->FlushCache();
 }
 
 // overridden implementation - calls readFromOverview instead


### PR DESCRIPTION
## What does this PR do?

As per the documentation, classes that derive from `GDALRasterBand` should call `FlushCache()` in their destructor so that cached tiles are correctly written to file. In the KEA driver, this is correctly done for the `KEARasterBand` class, but not for the `KEAOverview` class (which also derives from `GDALRasterBand`). In some situations this was leading to the overviews not being written correctly.

## What are related issues/pull requests?
xref: https://github.com/ubarsc/kealib/pull/65
ping @neilflood 
