### PR TITLE
[Backport release/3.9] KEA: fix overview writing so that tiles are correctly flushed

### DIFF
--- a/frmts/kea/keaoverview.cpp
+++ b/frmts/kea/keaoverview.cpp
@@ -48,6 +48,9 @@ KEAOverview::KEAOverview(KEADataset *pDataset, int nSrcBand,
 
 KEAOverview::~KEAOverview()
 {
+    // according to the docs, this is required
+    // otherwise not all tiles will be written.
+    this->FlushCache();
 }
 
 // overridden implementation - calls readFromOverview instead


### PR DESCRIPTION
Backport #10616
 **Authored by:** @gillins