### PR TITLE
OpenFileGDB: add missing GetIndexCount() in FileGDBTable::CreateIndex

### DIFF
--- a/ogr/ogrsf_frmts/openfilegdb/filegdbindex_write.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/filegdbindex_write.cpp
@@ -163,6 +163,7 @@ bool FileGDBTable::CreateIndex(const std::string &osIndexName,
         return false;
     }
 
+    GetIndexCount();
     for (const auto &poIndex : m_apoIndexes)
     {
         if (EQUAL(poIndex->GetIndexName().c_str(), osIndexName.c_str()))


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?
It adds calling GetIndexCount() to retrieve all the existing indexes before creating a new index.

## What are related issues/pull requests?
Currently, creating a new index using OpenFileGDB drive causes all the existing indexes are lost.
For example, I have a table with two indexes "FDO_OBJECTID" for "OBJECTID" and "IDx" for "ID. Here are the contents of its gdbindexes file.
![image](https://github.com/user-attachments/assets/9c406114-3948-4938-9ede-efacc00f2833)
But after I run `./ogrinfo BASE.gdb -sql "CREATE INDEX DESCRIPTx ON PIPE_h(DESCRIPT)"`, there is only "DESCRIPTx" for "DESCRIPT" in its gdbindexes file.
![image](https://github.com/user-attachments/assets/22ada095-ae0e-49a5-9acc-162d976a8f31)
I find it doesn't call GetIndexCount() to retrieve the existing indexes before creating a new index in the FileGDBTable::CreateIndex function. I think it might be the reason. After I add this line, everything works properly now. 
