### PR TITLE
JP2KAK: add Cycc=yes/no creation option to set YCbCr/YUV color space …

### DIFF
--- a/doc/source/drivers/raster/jp2kak.rst
+++ b/doc/source/drivers/raster/jp2kak.rst
@@ -234,19 +234,20 @@ The following creation options are tightly tied to the Kakadu SDK, and are
 considered to be for advanced use only. Consult the Kakadu SDK documentation to
 better understand their meaning.
 
--  **Corder**: Defaults to "PRCL".
--  **Cprecincts**: Defaults to
+-  **Corder**: Progression order. Defaults to "PRCL".
+-  **Cprecincts**: Precincts settings. Defaults to
    "{512,512},{256,512},{128,512},{64,512},{32,512},{16,512},{8,512},{4,512},{2,512}".
--  **ORGgen_plt**: Defaults to "yes".
--  **ORGgen_tlm**: Kakadu SDK defaults used.
+-  **ORGgen_plt**: Whether to generate PLT markers (Paquet Length). Defaults to "yes".
+-  **ORGgen_tlm**: Whether to generate TLM markers (Tile Length). Kakadu SDK defaults used.
 -  **ORGtparts**: Kakadu SDK defaults used.
 -  **Cmodes**: Kakadu SDK defaults used.
--  **Clevels**: Kakadu SDK defaults used.
+-  **Clevels**: Quality levels. Kakadu SDK defaults used.
+-  **Cycc** =YES/NO: Whether to use YCbCr (lossy compression) or YUV (lossless compression) color space when encoding RGB images. Default to YES starting with GDAL 3.10 (was hardcoded to NO in previous versions)
 -  **Rshift**: Kakadu SDK defaults used.
 -  **Rlevels**: Kakadu SDK defaults used.
 -  **Rweight**: Kakadu SDK defaults used.
 -  **Qguard**: Kakadu SDK defaults used.
--  **Creversible**: If not set and QUALITY >= 99.5, set to "yes", otherwise to "false".
+-  **Creversible** = YES/NO: If not set and QUALITY >= 99.5, set to "yes", otherwise to "false".
 -  **Sprofile**: Kakadu SDK defaults used.
 -  **RATE**: Kakadu SDK defaults used.
    One or more bit-rates, expressed in terms of the ratio between the total number of compressed bits

--- a/frmts/jp2kak/jp2kakdataset.cpp
+++ b/frmts/jp2kak/jp2kakdataset.cpp
@@ -2472,7 +2472,6 @@ static GDALDataset *JP2KAKCreateCopy(const char *pszFilename,
     // Set some particular parameters.
     oCodeStream.access_siz()->parse_string(
         CPLString().Printf("Clayers=%d", layer_count).c_str());
-    oCodeStream.access_siz()->parse_string("Cycc=no");
     if (eType == GDT_Int16 || eType == GDT_UInt16)
         oCodeStream.access_siz()->parse_string(
             "Qstep=0.0000152588");  // 1. / (1 << 16)
@@ -2487,6 +2486,8 @@ static GDALDataset *JP2KAKCreateCopy(const char *pszFilename,
 
     // Set some user-overridable parameters.
     const char *const apszParams[] = {
+        "Cycc",
+        "yes",
         "Corder",
         "PCRL",
         "Cprecincts",

--- a/frmts/jp2kak/jp2kakdrivercore.cpp
+++ b/frmts/jp2kak/jp2kakdrivercore.cpp
@@ -96,6 +96,7 @@ void JP2KAKDriverSetCommonMetadata(GDALDriver *poDriver)
         "   <Option name='Cprecincts' type='string'/>"
         "   <Option name='Cmodes' type='string'/>"
         "   <Option name='Clevels' type='string'/>"
+        "   <Option name='Cycc' type='boolean' default='YES'/>"
         "   <Option name='ORGgen_plt' type='string'/>"
         "   <Option name='ORGgen_tlm' type='string'/>"
         "   <Option name='ORGtparts' type='string'/>"


### PR DESCRIPTION
…and set it to YES by default

Fixes #10623
