### PR TITLE
[Backport release/3.9] OpenFileGDB: add missing GetIndexCount() in FileGDBTable::CreateIndex

### DIFF
--- a/ogr/ogrsf_frmts/openfilegdb/filegdbindex_write.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/filegdbindex_write.cpp
@@ -163,6 +163,7 @@ bool FileGDBTable::CreateIndex(const std::string &osIndexName,
         return false;
     }
 
+    GetIndexCount();
     for (const auto &poIndex : m_apoIndexes)
     {
         if (EQUAL(poIndex->GetIndexName().c_str(), osIndexName.c_str()))


### PR DESCRIPTION
Backport #10624
 **Authored by:** @AlbertXingZhang