### PR TITLE
[Backport release/3.9] OpenFileGDB raster: do not generate debug 'tmp.jpg' file when reading JPEG tiles

### DIFF
--- a/ogr/ogrsf_frmts/openfilegdb/gdalopenfilegdbrasterband.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/gdalopenfilegdbrasterband.cpp
@@ -1546,10 +1546,6 @@ CPLErr GDALOpenFileGDBRasterBand::IReadBlock(int nBlockXOff, int nBlockYOff,
                 return CE_Failure;
             }
 
-            VSILFILE *fp = VSIFOpenL("tmp.jpg", "wb");
-            VSIFWriteL(pabyData + nJPEGOffset, nJPEGSize, 1, fp);
-            VSIFCloseL(fp);
-
             CPLString osTmpFilename;
             osTmpFilename.Printf("/vsimem/_openfilegdb/%p.jpg", this);
             VSIFCloseL(VSIFileFromMemBuffer(


### PR DESCRIPTION
Backport #10603
 **Authored by:** @rouault