### PR TITLE
PAM .aux.xml classic vs multidim fixes

### DIFF
--- a/autotest/gdrivers/netcdf_multidim.py
+++ b/autotest/gdrivers/netcdf_multidim.py
@@ -4005,9 +4005,17 @@ def test_netcdf_multidim_serialize_statistics_asclassicdataset(tmp_path):
         rg_subset = rg.SubsetDimensionFromSelection("/x=440750")
         rg_subset.OpenMDArray("Band1").GetStatistics(False, force=True)
 
+    def test3():
+        ds = gdal.Open(filename)
+        ds.SetMetadataItem("foo", "bar")
+
     def reopen():
 
+        ds = gdal.Open(filename)
+        assert ds.GetMetadataItem("foo") == "bar"
+
         aux_xml = open(filename + ".aux.xml", "rb").read().decode("UTF-8")
+        assert '<MDI key="foo">bar</MDI>' in aux_xml
         assert (
             '<DerivedDataset name="AsClassicDataset(1,0) view of Sliced view of /Band1 ([0:10,...])">'
             in aux_xml
@@ -4053,6 +4061,7 @@ def test_netcdf_multidim_serialize_statistics_asclassicdataset(tmp_path):
 
     test()
     test2()
+    test3()
     reopen()
 
 

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -3033,6 +3033,7 @@ CPLErr netCDFDataset::SetMetadataItem(const char *pszName, const char *pszValue,
             strchr(osName.c_str(), '#') != nullptr)
         {
             // do nothing
+            return CE_None;
         }
         else
         {
@@ -3065,6 +3066,7 @@ CPLErr netCDFDataset::SetMetadata(char **papszMD, const char *pszDomain)
                 SetMetadataItem(pszName, pszValue);
             CPLFree(pszName);
         }
+        return CE_None;
     }
     return GDALPamDataset::SetMetadata(papszMD, pszDomain);
 }
@@ -3079,47 +3081,6 @@ const OGRSpatialReference *netCDFDataset::GetSpatialRef() const
         return m_oSRS.IsEmpty() ? nullptr : &m_oSRS;
 
     return GDALPamDataset::GetSpatialRef();
-}
-
-/************************************************************************/
-/*                           SerializeToXML()                           */
-/************************************************************************/
-
-CPLXMLNode *netCDFDataset::SerializeToXML(const char *pszUnused)
-
-{
-    // Overridden from GDALPamDataset to add only band histogram
-    // and statistics. See bug #4244.
-
-    if (psPam == nullptr)
-        return nullptr;
-
-    // Setup root node and attributes.
-    CPLXMLNode *psDSTree = CPLCreateXMLNode(nullptr, CXT_Element, "PAMDataset");
-
-    // Process bands.
-    for (int iBand = 0; iBand < GetRasterCount(); iBand++)
-    {
-        netCDFRasterBand *poBand =
-            static_cast<netCDFRasterBand *>(GetRasterBand(iBand + 1));
-
-        if (poBand == nullptr || !(poBand->GetMOFlags() & GMO_PAM_CLASS))
-            continue;
-
-        CPLXMLNode *psBandTree = poBand->SerializeToXML(pszUnused);
-
-        if (psBandTree != nullptr)
-            CPLAddXMLChild(psDSTree, psBandTree);
-    }
-
-    // We don't want to return anything if we had no metadata to attach.
-    if (psDSTree->psChild == nullptr)
-    {
-        CPLDestroyXMLNode(psDSTree);
-        psDSTree = nullptr;
-    }
-
-    return psDSTree;
 }
 
 /************************************************************************/

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -2833,7 +2833,7 @@ netCDFDataset::netCDFDataset()
       papszMetadata(nullptr), bBottomUp(true), eFormat(NCDF_FORMAT_NONE),
       bIsGdalFile(false), bIsGdalCfFile(false), pszCFProjection(nullptr),
       pszCFCoordinates(nullptr), nCFVersion(1.6), bSGSupport(false),
-      eMultipleLayerBehavior(SINGLE_LAYER), logCount(0), vcdf(cdfid),
+      eMultipleLayerBehavior(SINGLE_LAYER), logCount(0), vcdf(this, cdfid),
       GeometryScribe(vcdf, this->generateLogName()),
       FieldScribe(vcdf, this->generateLogName()),
       bufManager(CPLGetUsablePhysicalRAM() / 5),
@@ -2907,7 +2907,7 @@ CPLErr netCDFDataset::Close()
         if (netCDFDataset::FlushCache(true) != CE_None)
             eErr = CE_Failure;
 
-        if (!SGCommitPendingTransaction())
+        if (GetAccess() == GA_Update && !SGCommitPendingTransaction())
             eErr = CE_Failure;
 
         for (size_t i = 0; i < apoVectorDatasets.size(); i++)

--- a/frmts/netcdf/netcdfdataset.h
+++ b/frmts/netcdf/netcdfdataset.h
@@ -336,6 +336,7 @@ class netCDFDataset final : public GDALPamDataset
     friend class netCDFRasterBand;  // TMP
     friend class netCDFLayer;
     friend class netCDFVariable;
+    friend class nccfdriver::netCDFVID;
 
     typedef enum
     {

--- a/frmts/netcdf/netcdfdataset.h
+++ b/frmts/netcdf/netcdfdataset.h
@@ -544,8 +544,6 @@ class netCDFDataset final : public GDALPamDataset
     void SetSpatialRefNoUpdate(const OGRSpatialReference *);
 
   protected:
-    CPLXMLNode *SerializeToXML(const char *pszVRTPath) override;
-
     OGRLayer *ICreateLayer(const char *pszName,
                            const OGRGeomFieldDefn *poGeomFieldDefn,
                            CSLConstList papszOptions) override;

--- a/frmts/netcdf/netcdflayer.cpp
+++ b/frmts/netcdf/netcdflayer.cpp
@@ -51,7 +51,7 @@ netCDFLayer::netCDFLayer(netCDFDataset *poDS, int nLayerCDFId,
       m_bProfileVarUnlimited(false), m_nParentIndexVarID(-1),
       layerVID_alloc(poDS->cdfid == m_nLayerCDFId
                          ? nullptr
-                         : new nccfdriver::netCDFVID(m_nLayerCDFId)),
+                         : new nccfdriver::netCDFVID(poDS, m_nLayerCDFId)),
       layerVID(layerVID_alloc.get() == nullptr ? poDS->vcdf : *layerVID_alloc),
       m_SGeometryFeatInd(0), m_poLayerConfig(nullptr),
       m_layerSGDefn(poDS->cdfid, nccfdriver::OGRtoRaw(eGeomType), poDS->vcdf,

--- a/frmts/netcdf/netcdfvirtual.cpp
+++ b/frmts/netcdf/netcdfvirtual.cpp
@@ -154,12 +154,12 @@ void netCDFVID::nc_resize_vdim(int dimid, size_t dimlen)
 
 void netCDFVID::nc_set_define_mode()
 {
-    NCDF_ERR(nc_redef(ncid));
+    m_poDS->SetDefineMode(true);
 }
 
 void netCDFVID::nc_set_data_mode()
 {
-    NCDF_ERR(nc_enddef(ncid));
+    m_poDS->SetDefineMode(false);
 }
 
 void netCDFVID::nc_vmap()

--- a/frmts/netcdf/netcdfvirtual.h
+++ b/frmts/netcdf/netcdfvirtual.h
@@ -34,6 +34,8 @@
 #include "netcdfsg.h"
 #include "netcdf.h"
 
+class netCDFDataset;
+
 // netCDF Virtual
 // Provides a layer of "virtual ncID"
 // that can be mapped to a real netCDF ID
@@ -320,6 +322,7 @@ class netCDFVVariable
  */
 class netCDFVID
 {
+    netCDFDataset *m_poDS = nullptr;
     int &ncid;  // ncid REF. which tracks ncID changes that may be made upstream
     int dimTicket = 0;
     int varTicket = 0;
@@ -476,7 +479,8 @@ class netCDFVID
     }
 
     // Constructor
-    explicit netCDFVID(int &ncid_in) : ncid(ncid_in)
+    explicit netCDFVID(netCDFDataset *poDS, int &ncid_in)
+        : m_poDS(poDS), ncid(ncid_in)
     {
     }
 };

--- a/gcore/gdalpamdataset.cpp
+++ b/gcore/gdalpamdataset.cpp
@@ -702,7 +702,9 @@ CPLErr GDALPamDataset::XMLInit(const CPLXMLNode *psTree, const char *pszUnused)
          psIter = psIter->psNext)
     {
         if (psIter->eType == CXT_Element &&
-            strcmp(psIter->pszValue, "Array") == 0)
+            (strcmp(psIter->pszValue, "Array") == 0 ||
+             (psPam->osDerivedDatasetName.empty() &&
+              strcmp(psIter->pszValue, "DerivedDataset") == 0)))
         {
             CPLXMLNode sArrayTmp = *psIter;
             sArrayTmp.psNext = nullptr;


### PR DESCRIPTION
- GDALPamDataset::XMLInit(): preserve DerivedDataset nodes that affect S102 PAM saving
- netCDF: make nc_enddef/nc_reddef calls more consistent in netCDFVID
- netCDF: do not override GDALPamDataset::TrySaveXML() to allow proper mixing of classic and multidim PAM metadata
