### PR TITLE
CPLJobQueue::SubmitJob(): avoid false-positive coverity warning about…

### DIFF
--- a/port/cpl_worker_thread_pool.cpp
+++ b/port/cpl_worker_thread_pool.cpp
@@ -612,6 +612,7 @@ bool CPLJobQueue::SubmitJob(std::function<void()> task)
 
     // cppcheck-suppress knownConditionTrueFalse
     return m_poPool->SubmitJob(
+        // coverity[uninit_member,copy_constructor_call]
         [this, task]
         {
             task();


### PR DESCRIPTION
… this not being initialized
