### PR TITLE
PDFium: show proper error when lcms2 is missing

### DIFF
--- a/frmts/pdf/CMakeLists.txt
+++ b/frmts/pdf/CMakeLists.txt
@@ -79,7 +79,10 @@ if (GDAL_USE_PDFIUM)
     find_package(JPEG REQUIRED)
     find_package(PNG REQUIRED)
     find_package(OpenJPEG REQUIRED)
-    find_library(LCMS2_LIBRARY NAMES lcms2 REQUIRED)
+    find_library(LCMS2_LIBRARY NAMES lcms2)
+    if(NOT LCMS2_LIBRARY)
+      message(FATAL_ERROR "LCMS2 library not found. Please install liblcms2-dev.")
+    endif()
 
     # Rather hacky... Related how we build pdfium in https://github.com/rouault/pdfium_build_gdal_3_4
     gdal_target_link_libraries(


### PR DESCRIPTION
## What does this PR do?
 - closes #10643
