### PR TITLE
GitHub Actions: fix disable tests flag when building proj for the Windows build

### DIFF
--- a/.github/workflows/windows_build.yml
+++ b/.github/workflows/windows_build.yml
@@ -157,7 +157,7 @@ jobs:
             $env:PATH="$env:GITHUB_WORKSPACE;$env:PATH"
             $env:PROJ_INSTALL_DIR="$env:GITHUB_WORKSPACE"+"\install-proj"
             $env:CMAKE_INSTALL_PREFIX="-DCMAKE_INSTALL_PREFIX=" + $env:PROJ_INSTALL_DIR
-            cmake -G $env:VS_VERSION -A $env:CMAKE_ARCHITECTURE .. $env:CMAKE_INSTALL_PREFIX -DPROJ_TESTS=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_LIBPROJ_SHARED=ON -DCMAKE_TOOLCHAIN_FILE=c:/vcpkg/scripts/buildsystems/vcpkg.cmake -DBUILD_SHARED_LIBS=ON -DENABLE_CURL=OFF -DENABLE_TIFF=OFF -DBUILD_PROJSYNC=OFF
+            cmake -G $env:VS_VERSION -A $env:CMAKE_ARCHITECTURE .. $env:CMAKE_INSTALL_PREFIX -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release -DBUILD_LIBPROJ_SHARED=ON -DCMAKE_TOOLCHAIN_FILE=c:/vcpkg/scripts/buildsystems/vcpkg.cmake -DBUILD_SHARED_LIBS=ON -DENABLE_CURL=OFF -DENABLE_TIFF=OFF -DBUILD_PROJSYNC=OFF
             exec { cmake --build . --config Release --target install }
             #
             cd $env:GITHUB_WORKSPACE


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

The GitHub Action for the Windows release builds the [PROJ](https://proj.org/) dependency from source.
The flag passed to disable building its testing tree was renamed and thus no longer working.

The flag was renamed with PROJ version `7.0`, and the version used for the build is `9.3`.

Properly disabling the testing tree building speeds up the PROJ build.

### References:
- https://github.com/OSGeo/gdal/blob/449d5f09b796a837ed5473ded4d8455106f1f235/.github/workflows/windows_build.yml#L33
- https://proj.org/en/9.4/install.html#cmdoption-arg-BUILD_TESTING

## What are related issues/pull requests?

N/A

## Tasklist

 - [x] All CI builds and checks have passed
