### PR TITLE
OAPIF/OGCAPI: combine CURL error message and data payload (when it exists) to form error message

### DIFF
--- a/autotest/gdrivers/ogcapi.py
+++ b/autotest/gdrivers/ogcapi.py
@@ -382,7 +382,10 @@ def test_ogr_ogcapi_raster(api, collection, tmp_path):
 )
 def test_ogc_api_wrong_collection(api, of_type):
 
-    with pytest.raises(Exception, match="Invalid data collection"):
+    with pytest.raises(
+        Exception,
+        match=r"HTTP error code : 400, <h1>GNOSIS Map Server \(OGCAPI\) - 400 Bad Request</h1><h3>Invalid data collection</h3>",
+    ):
         gdal.OpenEx(
             f"OGCAPI:http://127.0.0.1:{gdaltest.webserver_port}/fakeogcapi/collections/NOT_EXISTS",
             of_type,

--- a/autotest/ogr/ogr_oapif.py
+++ b/autotest/ogr/ogr_oapif.py
@@ -66,7 +66,15 @@ def test_ogr_oapif_errors():
     handler = webserver.SequentialHandler()
     handler.add("GET", "/oapif/collections", 404)
     with webserver.install_http_handler(handler):
-        with pytest.raises(Exception):
+        with pytest.raises(Exception, match="HTTP error code : 404"):
+            ogr.Open("OAPIF:http://localhost:%d/oapif" % gdaltest.webserver_port)
+
+    handler = webserver.SequentialHandler()
+    handler.add("GET", "/oapif/collections", 404, {}, "unavailable resource")
+    with webserver.install_http_handler(handler):
+        with pytest.raises(
+            Exception, match="HTTP error code : 404, unavailable resource"
+        ):
             ogr.Open("OAPIF:http://localhost:%d/oapif" % gdaltest.webserver_port)
 
     # No Content-Type

--- a/frmts/ogcapi/gdalogcapidataset.cpp
+++ b/frmts/ogcapi/gdalogcapidataset.cpp
@@ -511,10 +511,15 @@ bool OGCAPIDataset::Download(const CPLString &osURL, const char *pszPostContent,
 
     if (psResult->pszErrBuf != nullptr)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "%s",
-                 psResult->pabyData
-                     ? reinterpret_cast<const char *>(psResult->pabyData)
-                     : psResult->pszErrBuf);
+        std::string osErrorMsg(psResult->pszErrBuf);
+        const char *pszData =
+            reinterpret_cast<const char *>(psResult->pabyData);
+        if (pszData)
+        {
+            osErrorMsg += ", ";
+            osErrorMsg.append(pszData, CPLStrnlen(pszData, 1000));
+        }
+        CPLError(CE_Failure, CPLE_AppDefined, "%s", osErrorMsg.c_str());
         CPLHTTPDestroyResult(psResult);
         return false;
     }

--- a/ogr/ogrsf_frmts/wfs/ogroapifdriver.cpp
+++ b/ogr/ogrsf_frmts/wfs/ogroapifdriver.cpp
@@ -431,10 +431,15 @@ bool OGROAPIFDataset::Download(const CPLString &osURL, const char *pszAccept,
 
     if (psResult->pszErrBuf != nullptr)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "%s",
-                 psResult->pabyData
-                     ? reinterpret_cast<const char *>(psResult->pabyData)
-                     : psResult->pszErrBuf);
+        std::string osErrorMsg(psResult->pszErrBuf);
+        const char *pszData =
+            reinterpret_cast<const char *>(psResult->pabyData);
+        if (pszData)
+        {
+            osErrorMsg += ", ";
+            osErrorMsg.append(pszData, CPLStrnlen(pszData, 1000));
+        }
+        CPLError(CE_Failure, CPLE_AppDefined, "%s", osErrorMsg.c_str());
         CPLHTTPDestroyResult(psResult);
         return false;
     }


### PR DESCRIPTION
Fixes #10653