### PR TITLE
HTTP driver: make parsing of Content-Disposition header aware of double quotes around filename=

### DIFF
--- a/autotest/ogr/ogr_openfilegdb.py
+++ b/autotest/ogr/ogr_openfilegdb.py
@@ -2870,3 +2870,76 @@ def test_ogr_openfilegdb_read_objectid_64bit_sparse_test_ogrsf(ogrsf_path):
 
     success = "INFO" in ret and "ERROR" not in ret
     assert success
+
+
+###############################################################################
+# Test reading http:// resource
+
+
+@pytest.mark.require_curl()
+@pytest.mark.require_driver("HTTP")
+def test_ogr_openfilegdb_read_from_http():
+
+    import webserver
+
+    (webserver_process, webserver_port) = webserver.launch(
+        handler=webserver.DispatcherHttpHandler
+    )
+    if webserver_port == 0:
+        pytest.skip()
+
+    response = open("data/filegdb/testopenfilegdb.gdb.zip", "rb").read()
+
+    try:
+        handler = webserver.SequentialHandler()
+        handler.add(
+            "GET",
+            "/foo",
+            200,
+            {
+                "Content-Disposition": 'attachment; filename="foo.gdb.zip"; size='
+                + str(len(response))
+            },
+            response,
+        )
+        with webserver.install_http_handler(handler):
+            ds = gdal.OpenEx(
+                "http://localhost:%d/foo" % webserver_port,
+                allowed_drivers=["OpenFileGDB", "HTTP"],
+            )
+            assert ds is not None
+            assert ds.GetLayerCount() != 0
+
+        # If we have the GeoJSON driver, there will be one initial GET done by it
+        if ogr.GetDriverByName("GeoJSON"):
+            handler = webserver.SequentialHandler()
+            handler.add(
+                "GET",
+                "/foo",
+                200,
+                {
+                    "Content-Disposition": 'attachment; filename="foo.gdb.zip"; size='
+                    + str(len(response))
+                },
+                response,
+            )
+            handler.add(
+                "GET",
+                "/foo",
+                200,
+                {
+                    "Content-Disposition": 'attachment; filename="foo.gdb.zip"; size='
+                    + str(len(response))
+                },
+                response,
+            )
+            with webserver.install_http_handler(handler):
+                ds = gdal.OpenEx(
+                    "http://localhost:%d/foo" % webserver_port,
+                    allowed_drivers=["GeoJSON", "OpenFileGDB", "HTTP"],
+                )
+                assert ds is not None
+                assert ds.GetLayerCount() != 0
+
+    finally:
+        webserver.server_stop(webserver_process, webserver_port)

--- a/ogr/ogrsf_frmts/geojson/ogr_geojson.h
+++ b/ogr/ogrsf_frmts/geojson/ogr_geojson.h
@@ -40,6 +40,9 @@
 #include "ogrgeojsonutils.h"
 #include "ogrgeojsonwriter.h"
 
+constexpr const char *INVALID_CONTENT_FOR_JSON_LIKE =
+    "__INVALID_CONTENT_FOR_JSON_LIKE__";
+
 class OGRGeoJSONDataSource;
 
 GDALDataset *OGRGeoJSONDriverOpenInternal(GDALOpenInfo *poOpenInfo,

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsondatasource.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsondatasource.cpp
@@ -814,10 +814,11 @@ int OGRGeoJSONDataSource::ReadFromService(GDALOpenInfo *poOpenInfo,
     char *pszStoredContent = OGRGeoJSONDriverStealStoredContent(pszSource);
     if (pszStoredContent != nullptr)
     {
-        if ((osJSonFlavor_ == "ESRIJSON" &&
-             ESRIJSONIsObject(pszStoredContent, poOpenInfo)) ||
-            (osJSonFlavor_ == "TopoJSON" &&
-             TopoJSONIsObject(pszStoredContent, poOpenInfo)))
+        if (!EQUAL(pszStoredContent, INVALID_CONTENT_FOR_JSON_LIKE) &&
+            ((osJSonFlavor_ == "ESRIJSON" &&
+              ESRIJSONIsObject(pszStoredContent, poOpenInfo)) ||
+             (osJSonFlavor_ == "TopoJSON" &&
+              TopoJSONIsObject(pszStoredContent, poOpenInfo))))
         {
             pszGeoData_ = pszStoredContent;
             nGeoDataLen_ = strlen(pszGeoData_);
@@ -893,6 +894,11 @@ int OGRGeoJSONDataSource::ReadFromService(GDALOpenInfo *poOpenInfo,
                 OGRGeoJSONDriverStoreContent(pszSource, pszGeoData_);
                 pszGeoData_ = nullptr;
                 nGeoDataLen_ = 0;
+            }
+            else
+            {
+                OGRGeoJSONDriverStoreContent(
+                    pszSource, CPLStrdup(INVALID_CONTENT_FOR_JSON_LIKE));
             }
             return false;
         }

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonseqdriver.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonseqdriver.cpp
@@ -831,7 +831,8 @@ bool OGRGeoJSONSeqDataSource::Open(GDALOpenInfo *poOpenInfo,
             OGRGeoJSONDriverStealStoredContent(pszUnprefixedFilename);
         if (pszStoredContent)
         {
-            if (!GeoJSONSeqIsObject(pszStoredContent, poOpenInfo))
+            if (EQUAL(pszStoredContent, INVALID_CONTENT_FOR_JSON_LIKE) ||
+                !GeoJSONSeqIsObject(pszStoredContent, poOpenInfo))
             {
                 OGRGeoJSONDriverStoreContent(poOpenInfo->pszFilename,
                                              pszStoredContent);


### PR DESCRIPTION
and GeoJSON like driver: avoid fetching unrecognized HTTP dataset more than once

Fixes https://lists.osgeo.org/pipermail/gdal-dev/2024-August/059364.html