### PR TITLE
[Backport release/3.9] OpenFileGDB writer: fix writing a Int32 field with value -21121

### DIFF
--- a/autotest/ogr/ogr_openfilegdb_write.py
+++ b/autotest/ogr/ogr_openfilegdb_write.py
@@ -4565,3 +4565,22 @@ def test_ogr_openfilegdb_repair_corrupted_header(tmp_vsimem):
         ds = ogr.Open(filename)
     assert gdal.GetLastErrorMsg() == ""
     assert ds.GetLayerCount() == 1
+
+
+###############################################################################
+# Test writing special value OGRUnsetMarker = -21121 in a int32 field
+
+
+def test_ogr_openfilegdb_write_OGRUnsetMarker(tmp_vsimem):
+
+    filename = str(tmp_vsimem / "out.gdb")
+    with ogr.GetDriverByName("OpenFileGDB").CreateDataSource(filename) as ds:
+        lyr = ds.CreateLayer("test", geom_type=ogr.wkbNone)
+        lyr.CreateField(ogr.FieldDefn("i32", ogr.OFTInteger))
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f["i32"] = -21121
+        lyr.CreateFeature(f)
+    with ogr.Open(filename) as ds:
+        lyr = ds.GetLayer(0)
+        f = lyr.GetNextFeature()
+        assert f["i32"] == -21121

--- a/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer_write.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer_write.cpp
@@ -2263,6 +2263,7 @@ bool OGROpenFileGDBLayer::PrepareFileGDBFeature(OGRFeature *poFeature,
             }
             continue;
         }
+        memset(&fields[idxFileGDB], 0, sizeof(OGRField));
         switch (m_poLyrTable->GetField(idxFileGDB)->GetType())
         {
             case FGFT_UNDEFINED:


### PR DESCRIPTION
Backport #10662
 **Authored by:** @rouault