### PR TITLE
port/cpl_conv.cpp: Use the right header for std::endian in C++20/23

### DIFF
--- a/port/cpl_conv.cpp
+++ b/port/cpl_conv.cpp
@@ -84,7 +84,7 @@
 #include <string>
 
 #if __cplusplus >= 202002L
-#include <type_traits>  // For std::endian
+#include <bit>  // For std::endian
 #endif
 
 #include "cpl_config.h"


### PR DESCRIPTION
## What does this PR do?

Currently, we import `std::endian` via `type_traits` header from C++ standard library.
[cpl_conv.cpp#L87](https://github.com/OSGeo/gdal/blob/master/port/cpl_conv.cpp#L87)

However, based on [standard](https://en.cppreference.com/w/cpp/types/endian), `std::endian` should be included via `bit` header.

`type_traits` worked fine with C++20, as it transitevely includes `bit` header. 
However, in C++23 standard forced headers to clean up transitive includes, leading to failures in compilation in C++23 mode.

We were able to reproduce that both with clang 18, 19git, 20git both with libc++ (LLVM) and libstdc++ (GNU GCC).

This tiny fix replaces `type_traits` header with `bit` one. I've tested that both in C++20 and C++23 language modes, and it solves the compilation error.

For information purposes, the original error has been attached in file. 
[logs.txt](https://github.com/user-attachments/files/16800237/logs.txt)
