### PR TITLE
OpenFileGDB/filegdbtable.cpp: Use comments for Python code snippets in C/C++ instead of conditional compilation statements to prevent choking pre-processor

### DIFF
--- a/ogr/ogrsf_frmts/openfilegdb/filegdbtable.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/filegdbtable.cpp
@@ -2730,55 +2730,8 @@ void FileGDBTable::GetMinMaxProjYForSpatialIndex(double &dfYMin,
         return;
     double dfMinLat;
     double dfMaxLat;
-    // Determined through experimentation, e.g with the following script
-    // ```python
-    // from osgeo import gdal, ogr, osr
-    // import struct
-    // gdal.RmdirRecursive('test.gdb')
-    // ds = ogr.GetDriverByName('FileGDB').CreateDataSource('test.gdb')
-    // srs = osr.SpatialReference()
-    // #srs.SetFromUserInput("+proj=tmerc +lon_0=-40 +lat_0=60 +k=0.9 +x_0=00000 +y_0=00000 +datum=WGS84")
-    // srs.SetFromUserInput("+proj=merc +lon_0=-40 +lat_0=60 +k=0.9 +x_0=00000 +y_0=00000 +datum=WGS84")
-    // srs_lonlat = srs.CloneGeogCS()
-    // srs_lonlat.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
-    // ct = osr.CoordinateTransformation(srs, srs_lonlat)
-    // grid_step = 0.1
-    // lyr = ds.CreateLayer('test', geom_type=ogr.wkbPoint, srs=srs)
-    // #Add 2 dummy features to set the grid_step to what we want
-    // f = ogr.Feature(lyr.GetLayerDefn())
-    // f.SetGeometry(ogr.CreateGeometryFromWkt('POINT(0 0)'))
-    // lyr.CreateFeature(f)
-    // f = ogr.Feature(lyr.GetLayerDefn())
-    // y = (2**0.5) * grid_step
-    // f.SetGeometry(ogr.CreateGeometryFromWkt('POINT(%f %f)' % (y, y)))
-    // lyr.CreateFeature(f)
-    // ds = None
-    // ds = ogr.GetDriverByName('FileGDB').Open('test.gdb', update=1)
-    // lyr = ds.GetLayer(0)
-    // lyr.DeleteFeature(1)
-    // lyr.DeleteFeature(2)
-    // y = 1e9 # some big value
-    // f = ogr.Feature(lyr.GetLayerDefn())
-    // g = ogr.CreateGeometryFromWkt('POINT(0 %f)' % y)
-    // f.SetGeometry(g)
-    // lyr.CreateFeature(f)
-    // f = ogr.Feature(lyr.GetLayerDefn())
-    // g = ogr.CreateGeometryFromWkt('POINT(0 %f)' % -y)
-    // f.SetGeometry(g)
-    // lyr.CreateFeature(f)
-    // ds = None
-    // f = open('test.gdb/a00000009.spx', 'rb')
-    // f.seek(4)
-    // n = ord(f.read(1))
-    // for x in range(n):
-    //     f.seek(1372 + x * 8, 0)
-    //     v = struct.unpack('Q', f.read(8))[0]
-    //     x = (v >> 31 & 0x7fffffff - (1 << 29))
-    //     y = (v & 0x7fffffff) - (1 << 29)
-    //     print(x, y)  # the y value will be clamped
-    //     print(ct.TransformPoint(srs.GetProjParm( osr.SRS_PP_FALSE_EASTING, 0.0 ), y * grid_step))
-    // ```
-    
+
+    // Determined through experimentation, e.g with the `find_srs_latitude_limits.py` script.
     if (EQUAL(pszProjection, SRS_PT_TRANSVERSE_MERCATOR))
     {
         dfMinLat = -90;

--- a/ogr/ogrsf_frmts/openfilegdb/filegdbtable.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/filegdbtable.cpp
@@ -2731,55 +2731,54 @@ void FileGDBTable::GetMinMaxProjYForSpatialIndex(double &dfYMin,
     double dfMinLat;
     double dfMaxLat;
     // Determined through experimentation, e.g with the following script
-#if 0
-    from osgeo import gdal, ogr, osr
-    import struct
-    gdal.RmdirRecursive('test.gdb')
-    ds = ogr.GetDriverByName('FileGDB').CreateDataSource('test.gdb')
-    srs = osr.SpatialReference()
-#srs.SetFromUserInput(                                                         \
-    "+proj=tmerc +lon_0=-40 +lat_0=60 +k=0.9 +x_0=00000 +y_0=00000 +datum=WGS84")
-    srs.SetFromUserInput("+proj=merc +lon_0=-40 +lat_0=60 +k=0.9 +x_0=00000 +y_0=00000 +datum=WGS84")
-    srs_lonlat = srs.CloneGeogCS()
-    srs_lonlat.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
-    ct = osr.CoordinateTransformation(srs, srs_lonlat)
-    grid_step = 0.1
-    lyr = ds.CreateLayer('test', geom_type=ogr.wkbPoint, srs=srs)
-#Add 2 dummy features to set the grid_step to what we want
-    f = ogr.Feature(lyr.GetLayerDefn())
-    f.SetGeometry(ogr.CreateGeometryFromWkt('POINT(0 0)'))
-    lyr.CreateFeature(f)
-    f = ogr.Feature(lyr.GetLayerDefn())
-    y = (2**0.5) * grid_step
-    f.SetGeometry(ogr.CreateGeometryFromWkt('POINT(%f %f)' % (y, y)))
-    lyr.CreateFeature(f)
-    ds = None
-    ds = ogr.GetDriverByName('FileGDB').Open('test.gdb', update=1)
-    lyr = ds.GetLayer(0)
-    lyr.DeleteFeature(1)
-    lyr.DeleteFeature(2)
-    y = 1e9 # some big value
-    f = ogr.Feature(lyr.GetLayerDefn())
-    g = ogr.CreateGeometryFromWkt('POINT(0 %f)' % y)
-    f.SetGeometry(g)
-    lyr.CreateFeature(f)
-    f = ogr.Feature(lyr.GetLayerDefn())
-    g = ogr.CreateGeometryFromWkt('POINT(0 %f)' % -y)
-    f.SetGeometry(g)
-    lyr.CreateFeature(f)
-    ds = None
-    f = open('test.gdb/a00000009.spx', 'rb')
-    f.seek(4)
-    n = ord(f.read(1))
-    for x in range(n):
-        f.seek(1372 + x * 8, 0)
-        v = struct.unpack('Q', f.read(8))[0]
-        x = (v >> 31 & 0x7fffffff - (1 << 29))
-        y = (v & 0x7fffffff) - (1 << 29)
-        print(x, y)  # the y value will be clamped
-        print(ct.TransformPoint(srs.GetProjParm( osr.SRS_PP_FALSE_EASTING, 0.0 ), y * grid_step))
-#endif
-
+    // ```python
+    // from osgeo import gdal, ogr, osr
+    // import struct
+    // gdal.RmdirRecursive('test.gdb')
+    // ds = ogr.GetDriverByName('FileGDB').CreateDataSource('test.gdb')
+    // srs = osr.SpatialReference()
+    // #srs.SetFromUserInput("+proj=tmerc +lon_0=-40 +lat_0=60 +k=0.9 +x_0=00000 +y_0=00000 +datum=WGS84")
+    // srs.SetFromUserInput("+proj=merc +lon_0=-40 +lat_0=60 +k=0.9 +x_0=00000 +y_0=00000 +datum=WGS84")
+    // srs_lonlat = srs.CloneGeogCS()
+    // srs_lonlat.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+    // ct = osr.CoordinateTransformation(srs, srs_lonlat)
+    // grid_step = 0.1
+    // lyr = ds.CreateLayer('test', geom_type=ogr.wkbPoint, srs=srs)
+    // #Add 2 dummy features to set the grid_step to what we want
+    // f = ogr.Feature(lyr.GetLayerDefn())
+    // f.SetGeometry(ogr.CreateGeometryFromWkt('POINT(0 0)'))
+    // lyr.CreateFeature(f)
+    // f = ogr.Feature(lyr.GetLayerDefn())
+    // y = (2**0.5) * grid_step
+    // f.SetGeometry(ogr.CreateGeometryFromWkt('POINT(%f %f)' % (y, y)))
+    // lyr.CreateFeature(f)
+    // ds = None
+    // ds = ogr.GetDriverByName('FileGDB').Open('test.gdb', update=1)
+    // lyr = ds.GetLayer(0)
+    // lyr.DeleteFeature(1)
+    // lyr.DeleteFeature(2)
+    // y = 1e9 # some big value
+    // f = ogr.Feature(lyr.GetLayerDefn())
+    // g = ogr.CreateGeometryFromWkt('POINT(0 %f)' % y)
+    // f.SetGeometry(g)
+    // lyr.CreateFeature(f)
+    // f = ogr.Feature(lyr.GetLayerDefn())
+    // g = ogr.CreateGeometryFromWkt('POINT(0 %f)' % -y)
+    // f.SetGeometry(g)
+    // lyr.CreateFeature(f)
+    // ds = None
+    // f = open('test.gdb/a00000009.spx', 'rb')
+    // f.seek(4)
+    // n = ord(f.read(1))
+    // for x in range(n):
+    //     f.seek(1372 + x * 8, 0)
+    //     v = struct.unpack('Q', f.read(8))[0]
+    //     x = (v >> 31 & 0x7fffffff - (1 << 29))
+    //     y = (v & 0x7fffffff) - (1 << 29)
+    //     print(x, y)  # the y value will be clamped
+    //     print(ct.TransformPoint(srs.GetProjParm( osr.SRS_PP_FALSE_EASTING, 0.0 ), y * grid_step))
+    // ```
+    
     if (EQUAL(pszProjection, SRS_PT_TRANSVERSE_MERCATOR))
     {
         dfMinLat = -90;

--- a/ogr/ogrsf_frmts/openfilegdb/find_srs_latitude_limits.py
+++ b/ogr/ogrsf_frmts/openfilegdb/find_srs_latitude_limits.py
@@ -1,46 +1,51 @@
-from osgeo import gdal, ogr, osr
 import struct
 
-gdal.RmdirRecursive('test.gdb')
-ds = ogr.GetDriverByName('FileGDB').CreateDataSource('test.gdb')
+from osgeo import gdal, ogr, osr
+
+gdal.RmdirRecursive("test.gdb")
+ds = ogr.GetDriverByName("FileGDB").CreateDataSource("test.gdb")
 srs = osr.SpatialReference()
-#srs.SetFromUserInput("+proj=tmerc +lon_0=-40 +lat_0=60 +k=0.9 +x_0=00000 +y_0=00000 +datum=WGS84")
-srs.SetFromUserInput("+proj=merc +lon_0=-40 +lat_0=60 +k=0.9 +x_0=00000 +y_0=00000 +datum=WGS84")
+# srs.SetFromUserInput("+proj=tmerc +lon_0=-40 +lat_0=60 +k=0.9 +x_0=00000 +y_0=00000 +datum=WGS84")
+srs.SetFromUserInput(
+    "+proj=merc +lon_0=-40 +lat_0=60 +k=0.9 +x_0=00000 +y_0=00000 +datum=WGS84"
+)
 srs_lonlat = srs.CloneGeogCS()
 srs_lonlat.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
 ct = osr.CoordinateTransformation(srs, srs_lonlat)
 grid_step = 0.1
-lyr = ds.CreateLayer('test', geom_type=ogr.wkbPoint, srs=srs)
-#Add 2 dummy features to set the grid_step to what we want
+lyr = ds.CreateLayer("test", geom_type=ogr.wkbPoint, srs=srs)
+# Add 2 dummy features to set the grid_step to what we want
 f = ogr.Feature(lyr.GetLayerDefn())
-f.SetGeometry(ogr.CreateGeometryFromWkt('POINT(0 0)'))
+f.SetGeometry(ogr.CreateGeometryFromWkt("POINT(0 0)"))
 lyr.CreateFeature(f)
 f = ogr.Feature(lyr.GetLayerDefn())
 y = (2**0.5) * grid_step
-f.SetGeometry(ogr.CreateGeometryFromWkt('POINT(%f %f)' % (y, y)))
+f.SetGeometry(ogr.CreateGeometryFromWkt("POINT(%f %f)" % (y, y)))
 lyr.CreateFeature(f)
 ds = None
-ds = ogr.GetDriverByName('FileGDB').Open('test.gdb', update=1)
+ds = ogr.GetDriverByName("FileGDB").Open("test.gdb", update=1)
 lyr = ds.GetLayer(0)
 lyr.DeleteFeature(1)
 lyr.DeleteFeature(2)
-y = 1e9 # some big value
+y = 1e9  # some big value
 f = ogr.Feature(lyr.GetLayerDefn())
-g = ogr.CreateGeometryFromWkt('POINT(0 %f)' % y)
+g = ogr.CreateGeometryFromWkt("POINT(0 %f)" % y)
 f.SetGeometry(g)
 lyr.CreateFeature(f)
 f = ogr.Feature(lyr.GetLayerDefn())
-g = ogr.CreateGeometryFromWkt('POINT(0 %f)' % -y)
+g = ogr.CreateGeometryFromWkt("POINT(0 %f)" % -y)
 f.SetGeometry(g)
 lyr.CreateFeature(f)
 ds = None
-f = open('test.gdb/a00000009.spx', 'rb')
+f = open("test.gdb/a00000009.spx", "rb")
 f.seek(4)
 n = ord(f.read(1))
 for x in range(n):
     f.seek(1372 + x * 8, 0)
-    v = struct.unpack('Q', f.read(8))[0]
-    x = (v >> 31 & 0x7fffffff - (1 << 29))
-    y = (v & 0x7fffffff) - (1 << 29)
+    v = struct.unpack("Q", f.read(8))[0]
+    x = v >> 31 & 0x7FFFFFFF - (1 << 29)
+    y = (v & 0x7FFFFFFF) - (1 << 29)
     print(x, y)  # the y value will be clamped
-    print(ct.TransformPoint(srs.GetProjParm( osr.SRS_PP_FALSE_EASTING, 0.0 ), y * grid_step))
+    print(
+        ct.TransformPoint(srs.GetProjParm(osr.SRS_PP_FALSE_EASTING, 0.0), y * grid_step)
+    )

--- a/ogr/ogrsf_frmts/openfilegdb/find_srs_latitude_limits.py
+++ b/ogr/ogrsf_frmts/openfilegdb/find_srs_latitude_limits.py
@@ -1,0 +1,46 @@
+from osgeo import gdal, ogr, osr
+import struct
+
+gdal.RmdirRecursive('test.gdb')
+ds = ogr.GetDriverByName('FileGDB').CreateDataSource('test.gdb')
+srs = osr.SpatialReference()
+#srs.SetFromUserInput("+proj=tmerc +lon_0=-40 +lat_0=60 +k=0.9 +x_0=00000 +y_0=00000 +datum=WGS84")
+srs.SetFromUserInput("+proj=merc +lon_0=-40 +lat_0=60 +k=0.9 +x_0=00000 +y_0=00000 +datum=WGS84")
+srs_lonlat = srs.CloneGeogCS()
+srs_lonlat.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+ct = osr.CoordinateTransformation(srs, srs_lonlat)
+grid_step = 0.1
+lyr = ds.CreateLayer('test', geom_type=ogr.wkbPoint, srs=srs)
+#Add 2 dummy features to set the grid_step to what we want
+f = ogr.Feature(lyr.GetLayerDefn())
+f.SetGeometry(ogr.CreateGeometryFromWkt('POINT(0 0)'))
+lyr.CreateFeature(f)
+f = ogr.Feature(lyr.GetLayerDefn())
+y = (2**0.5) * grid_step
+f.SetGeometry(ogr.CreateGeometryFromWkt('POINT(%f %f)' % (y, y)))
+lyr.CreateFeature(f)
+ds = None
+ds = ogr.GetDriverByName('FileGDB').Open('test.gdb', update=1)
+lyr = ds.GetLayer(0)
+lyr.DeleteFeature(1)
+lyr.DeleteFeature(2)
+y = 1e9 # some big value
+f = ogr.Feature(lyr.GetLayerDefn())
+g = ogr.CreateGeometryFromWkt('POINT(0 %f)' % y)
+f.SetGeometry(g)
+lyr.CreateFeature(f)
+f = ogr.Feature(lyr.GetLayerDefn())
+g = ogr.CreateGeometryFromWkt('POINT(0 %f)' % -y)
+f.SetGeometry(g)
+lyr.CreateFeature(f)
+ds = None
+f = open('test.gdb/a00000009.spx', 'rb')
+f.seek(4)
+n = ord(f.read(1))
+for x in range(n):
+    f.seek(1372 + x * 8, 0)
+    v = struct.unpack('Q', f.read(8))[0]
+    x = (v >> 31 & 0x7fffffff - (1 << 29))
+    y = (v & 0x7fffffff) - (1 << 29)
+    print(x, y)  # the y value will be clamped
+    print(ct.TransformPoint(srs.GetProjParm( osr.SRS_PP_FALSE_EASTING, 0.0 ), y * grid_step))


### PR DESCRIPTION
## What does this PR do?

Currently, [filegdbtable.cpp#L2734](https://github.com/OSGeo/gdal/blob/master/ogr/ogrsf_frmts/openfilegdb/filegdbtable.cpp#L2734) uses `#if 0 ... #endif` construct to comment out the Python code snippet. 

In many cases it works fine, but with some sets of pre-processor defines/macros, it chokes on this snippet as trying to expand some parts of that (we weren't able to narrow down that to the minimal sets of flags as fixing that is simply easier).

This tiny PR replaces `#if 0 ... #endif` construct with usual C/C++ comments. It shouldn't/doesn't affect the code compilation where it worked previously but should prevent pre-processor from erroring in all cases there. 

Please, find the errors log snippet attached.
[logs.txt](https://github.com/user-attachments/files/16800661/logs.txt)