### PR TITLE
[Backport release/3.9] port/cpl_conv.cpp: Use the right header for std::endian in C++20/23

### DIFF
--- a/port/cpl_conv.cpp
+++ b/port/cpl_conv.cpp
@@ -84,7 +84,7 @@
 #include <string>
 
 #if __cplusplus >= 202002L
-#include <type_traits>  // For std::endian
+#include <bit>  // For std::endian
 #endif
 
 #include "cpl_config.h"


### PR DESCRIPTION
Backport #10677
 **Authored by:** @gorloffslava