### PR TITLE
Add new shapelib API functions to the symbol rename header

### DIFF
--- a/ogr/ogrsf_frmts/shape/gdal_shapelib_symbol_rename.h
+++ b/ogr/ogrsf_frmts/shape/gdal_shapelib_symbol_rename.h
@@ -32,6 +32,7 @@
 #define DBFReadIntegerAttribute gdal_DBFReadIntegerAttribute
 #define DBFReadLogicalAttribute gdal_DBFReadLogicalAttribute
 #define DBFReadStringAttribute gdal_DBFReadStringAttribute
+#define DBFReadDateAttribute gdal_DBFReadDateAttribute
 #define DBFReadTuple gdal_DBFReadTuple
 #define DBFReorderFields gdal_DBFReorderFields
 #define DBFSetLastModifiedDate gdal_DBFSetLastModifiedDate
@@ -45,6 +46,7 @@
 #define DBFWriteLogicalAttribute gdal_DBFWriteLogicalAttribute
 #define DBFWriteNULLAttribute gdal_DBFWriteNULLAttribute
 #define DBFWriteStringAttribute gdal_DBFWriteStringAttribute
+#define DBFWriteDateAttribute gdal_DBFWriteDateAttribute
 #define DBFWriteTuple gdal_DBFWriteTuple
 #define frame_dummy gdal_frame_dummy
 #define SASetupDefaultHooks gdal_SASetupDefaultHooks


### PR DESCRIPTION
Shapelib 1.6.1 introduced new API calls to read and write date attributes These need to be added to the rename header in order to avoid multiple definitions of these symbols
