### PR TITLE
[Backport release/3.9] SQLite/GPKG: fix potential double-free issue when concurrently closing datasets when Spatialite is available

### DIFF
--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
@@ -47,6 +47,7 @@
 #include <cstring>
 #include <sys/stat.h>
 #include <map>
+#include <mutex>
 #include <set>
 #include <sstream>
 #include <string>
@@ -201,6 +202,11 @@ void OGRSQLiteBaseDataSource::FinishSpatialite()
 {
     if (hSpatialiteCtxt != nullptr)
     {
+        // Current implementation of spatialite_cleanup_ex() (as of libspatialite 5.1)
+        // is not re-entrant due to the use of xmlCleanupParser()
+        // Cf https://groups.google.com/g/spatialite-users/c/tsfZ_GDrRKs/m/aj-Dt4xoBQAJ?utm_medium=email&utm_source=footer
+        static std::mutex oCleanupMutex;
+        std::lock_guard oLock(oCleanupMutex);
         pfn_spatialite_cleanup_ex(hSpatialiteCtxt);
         hSpatialiteCtxt = nullptr;
     }


### PR DESCRIPTION
Backport #10687
 **Authored by:** @rouault