### PR TITLE
Python bindings: Avoid linear scan in gdal_array.NumericTypeCodeToGDALTypeCode

### DIFF
--- a/autotest/gcore/numpy_rw.py
+++ b/autotest/gcore/numpy_rw.py
@@ -1040,4 +1040,4 @@ def test_numeric_type_code_to_gdal_type_code():
 def test_flip_code():
 
     assert gdal_array.flip_code(numpy.float32) == gdal.GDT_Float32
-    assert gdal_array.flip_code(numpy.int16) == gdal.GDT_Int16
+    assert gdal_array.flip_code(gdal.GDT_Int16) == numpy.int16

--- a/autotest/gcore/numpy_rw.py
+++ b/autotest/gcore/numpy_rw.py
@@ -1015,3 +1015,29 @@ def test_numpy_rw_masked_array_2():
     assert numpy.all(masked_arr.mask[mask != 255])
 
     assert masked_arr.sum() == arr[mask == 255].sum()
+
+
+###############################################################################
+# Test type code mapping
+
+
+def test_gdal_type_code_to_numeric_type_code():
+
+    assert gdal_array.GDALTypeCodeToNumericTypeCode(gdal.GDT_Float32) == numpy.float32
+
+    # invalid type code
+    assert gdal_array.GDALTypeCodeToNumericTypeCode(802) is None
+
+
+def test_numeric_type_code_to_gdal_type_code():
+
+    assert gdal_array.NumericTypeCodeToGDALTypeCode(numpy.float32) == gdal.GDT_Float32
+    assert (
+        gdal_array.NumericTypeCodeToGDALTypeCode(numpy.dtype("int16")) == gdal.GDT_Int16
+    )
+
+
+def test_flip_code():
+
+    assert gdal_array.flip_code(numpy.float32) == gdal.GDT_Float32
+    assert gdal_array.flip_code(numpy.int16) == gdal.GDT_Int16


### PR DESCRIPTION
## What does this PR do?

Avoids a surprisingly expensive lookup in `gdal_array.NumericTypeCodeToGDALTypeCode`. This was showing up in profiling of a script that calls `ReadAsArray` many times; these changes improve total script runtime by ~10%.

I re-implemented the function `flip_code` because I saw it used in the wild: https://github.com/search?q=gdal_array.flip_code&type=code

## What are related issues/pull requests?

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed