### PR TITLE
ogr2ogr: speed-up reprojection in Arrow code path

### DIFF
--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -40,6 +40,7 @@
 #include <cstring>
 
 #include <algorithm>
+#include <atomic>
 #include <limits>
 #include <map>
 #include <memory>
@@ -47,6 +48,7 @@
 #include <set>
 #include <unordered_set>
 #include <string>
+#include <thread>
 #include <utility>
 #include <vector>
 
@@ -69,8 +71,10 @@
 #include "ogr_p.h"
 #include "ogr_recordbatch.h"
 #include "ogr_spatialref.h"
+#include "ogrlayerarrow.h"
 #include "ogrlayerdecorator.h"
 #include "ogrsf_frmts.h"
+#include "ogr_wkb.h"
 
 typedef enum
 {
@@ -520,38 +524,39 @@ class SetupTargetLayer
                                bool &bError);
 
   public:
-    GDALDataset *m_poSrcDS;
-    GDALDataset *m_poDstDS;
-    char **m_papszLCO;
-    OGRSpatialReference *m_poOutputSRS;
+    GDALDataset *m_poSrcDS = nullptr;
+    GDALDataset *m_poDstDS = nullptr;
+    CSLConstList m_papszLCO = nullptr;
+    const OGRSpatialReference *m_poUserSourceSRS = nullptr;
+    const OGRSpatialReference *m_poOutputSRS = nullptr;
     bool m_bTransform = false;
-    bool m_bNullifyOutputSRS;
+    bool m_bNullifyOutputSRS = false;
     bool m_bSelFieldsSet = false;
-    char **m_papszSelFields;
-    bool m_bAppend;
-    bool m_bAddMissingFields;
-    int m_eGType;
-    GeomTypeConversion m_eGeomTypeConversion;
-    int m_nCoordDim;
-    bool m_bOverwrite;
-    char **m_papszFieldTypesToString;
-    char **m_papszMapFieldType;
-    bool m_bUnsetFieldWidth;
-    bool m_bExplodeCollections;
-    const char *m_pszZField;
-    char **m_papszFieldMap;
-    const char *m_pszWHERE;
-    bool m_bExactFieldNameMatch;
-    bool m_bQuiet;
-    bool m_bForceNullable;
-    bool m_bResolveDomains;
-    bool m_bUnsetDefault;
-    bool m_bUnsetFid;
-    bool m_bPreserveFID;
-    bool m_bCopyMD;
-    bool m_bNativeData;
-    bool m_bNewDataSource;
-    const char *m_pszCTPipeline;
+    CSLConstList m_papszSelFields = nullptr;
+    bool m_bAppend = false;
+    bool m_bAddMissingFields = false;
+    int m_eGType = 0;
+    GeomTypeConversion m_eGeomTypeConversion = GTC_DEFAULT;
+    int m_nCoordDim = 0;
+    bool m_bOverwrite = false;
+    CSLConstList m_papszFieldTypesToString = nullptr;
+    CSLConstList m_papszMapFieldType = nullptr;
+    bool m_bUnsetFieldWidth = false;
+    bool m_bExplodeCollections = false;
+    const char *m_pszZField = nullptr;
+    CSLConstList m_papszFieldMap = nullptr;
+    const char *m_pszWHERE = nullptr;
+    bool m_bExactFieldNameMatch = false;
+    bool m_bQuiet = false;
+    bool m_bForceNullable = false;
+    bool m_bResolveDomains = false;
+    bool m_bUnsetDefault = false;
+    bool m_bUnsetFid = false;
+    bool m_bPreserveFID = false;
+    bool m_bCopyMD = false;
+    bool m_bNativeData = false;
+    bool m_bNewDataSource = false;
+    const char *m_pszCTPipeline = nullptr;
 
     std::unique_ptr<TargetLayerInfo>
     Setup(OGRLayer *poSrcLayer, const char *pszNewLayerName,
@@ -560,11 +565,10 @@ class SetupTargetLayer
 
 class LayerTranslator
 {
-    static bool TranslateArrow(const TargetLayerInfo *psInfo,
-                               GIntBig nCountLayerFeatures,
-                               GIntBig *pnReadFeatureCount,
-                               GDALProgressFunc pfnProgress, void *pProgressArg,
-                               const GDALVectorTranslateOptions *psOptions);
+    bool TranslateArrow(TargetLayerInfo *psInfo, GIntBig nCountLayerFeatures,
+                        GIntBig *pnReadFeatureCount,
+                        GDALProgressFunc pfnProgress, void *pProgressArg,
+                        const GDALVectorTranslateOptions *psOptions);
 
   public:
     GDALDataset *m_poSrcDS = nullptr;
@@ -572,9 +576,9 @@ class LayerTranslator
     bool m_bTransform = false;
     bool m_bWrapDateline = false;
     CPLString m_osDateLineOffset{};
-    OGRSpatialReference *m_poOutputSRS = nullptr;
+    const OGRSpatialReference *m_poOutputSRS = nullptr;
     bool m_bNullifyOutputSRS = false;
-    OGRSpatialReference *m_poUserSourceSRS = nullptr;
+    const OGRSpatialReference *m_poUserSourceSRS = nullptr;
     OGRCoordinateTransformation *m_poGCPCoordTrans = nullptr;
     int m_eGType = -1;
     GeomTypeConversion m_eGeomTypeConversion = GTC_DEFAULT;
@@ -586,20 +590,20 @@ class LayerTranslator
 
     OGRGeometry *m_poClipSrcOri = nullptr;
     bool m_bWarnedClipSrcSRS = false;
-    std::unique_ptr<OGRGeometry> m_poClipSrcReprojectedToSrcSRS;
+    std::unique_ptr<OGRGeometry> m_poClipSrcReprojectedToSrcSRS{};
     const OGRSpatialReference *m_poClipSrcReprojectedToSrcSRS_SRS = nullptr;
     OGREnvelope m_oClipSrcEnv{};
 
     OGRGeometry *m_poClipDstOri = nullptr;
     bool m_bWarnedClipDstSRS = false;
-    std::unique_ptr<OGRGeometry> m_poClipDstReprojectedToDstSRS;
+    std::unique_ptr<OGRGeometry> m_poClipDstReprojectedToDstSRS{};
     const OGRSpatialReference *m_poClipDstReprojectedToDstSRS_SRS = nullptr;
     OGREnvelope m_oClipDstEnv{};
 
     bool m_bExplodeCollections = false;
     bool m_bNativeData = false;
     GIntBig m_nLimit = -1;
-    OGRGeometryFactory::TransformWithOptionsCache m_transformWithOptionsCache;
+    OGRGeometryFactory::TransformWithOptionsCache m_transformWithOptionsCache{};
 
     bool Translate(OGRFeature *poFeatureIn, TargetLayerInfo *psInfo,
                    GIntBig nCountLayerFeatures, GIntBig *pnReadFeatureCount,
@@ -2910,6 +2914,7 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
     oSetup.m_poOutputSRS = oOutputSRSHolder.get();
     oSetup.m_bTransform = psOptions->bTransform;
     oSetup.m_bNullifyOutputSRS = psOptions->bNullifyOutputSRS;
+    oSetup.m_poUserSourceSRS = poSourceSRS;
     oSetup.m_bSelFieldsSet = psOptions->bSelFieldsSet;
     oSetup.m_papszSelFields = psOptions->aosSelFields.List();
     oSetup.m_bAppend = bAppend;
@@ -3807,8 +3812,8 @@ static OGRwkbGeometryType ConvertType(GeomTypeConversion eGeomTypeConversion,
 
 static void DoFieldTypeConversion(GDALDataset *poDstDS,
                                   OGRFieldDefn &oFieldDefn,
-                                  char **papszFieldTypesToString,
-                                  char **papszMapFieldType,
+                                  CSLConstList papszFieldTypesToString,
+                                  CSLConstList papszMapFieldType,
                                   bool bUnsetFieldWidth, bool bQuiet,
                                   bool bForceNullable, bool bUnsetDefault)
 {
@@ -3954,6 +3959,47 @@ static void DoFieldTypeConversion(GDALDataset *poDstDS,
 }
 
 /************************************************************************/
+/*                        GetArrowGeomFieldIndex()                      */
+/************************************************************************/
+
+static int GetArrowGeomFieldIndex(const struct ArrowSchema *psLayerSchema,
+                                  const char *pszFieldName)
+{
+    if (strcmp(psLayerSchema->format, "+s") == 0)  // struct
+    {
+        for (int i = 0; i < psLayerSchema->n_children; ++i)
+        {
+            const auto psSchema = psLayerSchema->children[i];
+            if (strcmp(psSchema->format, "z") == 0)  // binary
+            {
+                if (strcmp(psSchema->name, pszFieldName) == 0)
+                {
+                    return i;
+                }
+                else
+                {
+                    // Check if ARROW:extension:name = ogc.wkb or geoarrow.wkb
+                    const char *pabyMetadata = psSchema->metadata;
+                    if (pabyMetadata)
+                    {
+                        const auto oMetadata =
+                            OGRParseArrowMetadata(pabyMetadata);
+                        auto oIter = oMetadata.find(ARROW_EXTENSION_NAME_KEY);
+                        if (oIter != oMetadata.end() &&
+                            (oIter->second == EXTENSION_NAME_OGC_WKB ||
+                             oIter->second == EXTENSION_NAME_GEOARROW_WKB))
+                        {
+                            return i;
+                        }
+                    }
+                }
+            }
+        }
+    }
+    return -1;
+}
+
+/************************************************************************/
 /*                 SetupTargetLayer::CanUseWriteArrowBatch()            */
 /************************************************************************/
 
@@ -3980,11 +4026,11 @@ bool SetupTargetLayer::CanUseWriteArrowBatch(
           !psOptions->aosLCO.FetchNameValue("BATCH_SIZE") &&
           CPLTestBool(CPLGetConfigOption("OGR2OGR_USE_ARROW_API", "YES"))) ||
          CPLTestBool(CPLGetConfigOption("OGR2OGR_USE_ARROW_API", "NO"))) &&
-        !psOptions->bSkipFailures && !psOptions->bTransform &&
-        !psOptions->poClipSrc && !psOptions->poClipDst &&
-        psOptions->oGCPs.nGCPCount == 0 && !psOptions->bWrapDateline &&
-        !m_papszSelFields && !m_bAddMissingFields &&
-        m_eGType == GEOMTYPE_UNCHANGED && psOptions->eGeomOp == GEOMOP_NONE &&
+        !psOptions->bSkipFailures && !psOptions->poClipSrc &&
+        !psOptions->poClipDst && psOptions->oGCPs.nGCPCount == 0 &&
+        !psOptions->bWrapDateline && !m_papszSelFields &&
+        !m_bAddMissingFields && m_eGType == GEOMTYPE_UNCHANGED &&
+        psOptions->eGeomOp == GEOMOP_NONE &&
         m_eGeomTypeConversion == GTC_DEFAULT && m_nCoordDim < 0 &&
         !m_papszFieldTypesToString && !m_papszMapFieldType &&
         !m_bUnsetFieldWidth && !m_bExplodeCollections && !m_pszZField &&
@@ -3993,6 +4039,26 @@ bool SetupTargetLayer::CanUseWriteArrowBatch(
         psOptions->dfXYRes == OGRGeomCoordinatePrecision::UNKNOWN &&
         !psOptions->bMakeValid && !psOptions->bSkipInvalidGeom)
     {
+        if (psOptions->bTransform)
+        {
+            // To simplify implementation for now
+            if (poSrcLayer->GetLayerDefn()->GetGeomFieldCount() != 1 ||
+                poDstLayer->GetLayerDefn()->GetGeomFieldCount() != 1)
+            {
+                return false;
+            }
+            auto poSrcSRS = m_poUserSourceSRS ? m_poUserSourceSRS
+                                              : poSrcLayer->GetLayerDefn()
+                                                    ->GetGeomFieldDefn(0)
+                                                    ->GetSpatialRef();
+            if (!poSrcSRS ||
+                !OGRGeometryFactory::isTransformWithOptionsRegularTransform(
+                    poSrcSRS, m_poOutputSRS, nullptr))
+            {
+                return false;
+            }
+        }
+
         struct ArrowArrayStream streamSrc;
         const char *const apszOptions[] = {"SILENCE_GET_SCHEMA_ERROR=YES",
                                            nullptr};
@@ -4001,6 +4067,15 @@ bool SetupTargetLayer::CanUseWriteArrowBatch(
             struct ArrowSchema schemaSrc;
             if (streamSrc.get_schema(&streamSrc, &schemaSrc) == 0)
             {
+                if (psOptions->bTransform &&
+                    GetArrowGeomFieldIndex(&schemaSrc,
+                                           poSrcLayer->GetGeometryColumn()) < 0)
+                {
+                    schemaSrc.release(&schemaSrc);
+                    streamSrc.release(&streamSrc);
+                    return false;
+                }
+
                 std::string osErrorMsg;
                 if (poDstLayer->IsArrowSchemaSupported(&schemaSrc, nullptr,
                                                        osErrorMsg))
@@ -5699,7 +5774,7 @@ SetupCT(TargetLayerInfo *psInfo, OGRLayer *poSrcLayer, bool bTransform,
 /************************************************************************/
 
 bool LayerTranslator::TranslateArrow(
-    const TargetLayerInfo *psInfo, GIntBig nCountLayerFeatures,
+    TargetLayerInfo *psInfo, GIntBig nCountLayerFeatures,
     GIntBig *pnReadFeatureCount, GDALProgressFunc pfnProgress,
     void *pProgressArg, const GDALVectorTranslateOptions *psOptions)
 {
@@ -5749,10 +5824,52 @@ bool LayerTranslator::TranslateArrow(
         return false;
     }
 
+    int iArrowGeomFieldIndex = -1;
+    if (m_bTransform)
+    {
+        iArrowGeomFieldIndex = GetArrowGeomFieldIndex(
+            &schema, psInfo->m_poSrcLayer->GetGeometryColumn());
+        if (!SetupCT(psInfo, psInfo->m_poSrcLayer, m_bTransform,
+                     m_bWrapDateline, m_osDateLineOffset, m_poUserSourceSRS,
+                     nullptr, m_poOutputSRS, m_poGCPCoordTrans, false))
+        {
+            return false;
+        }
+    }
+
     bool bRet = true;
 
     GIntBig nCount = 0;
     bool bGoOn = true;
+    std::vector<GByte> abyModifiedWKB;
+    const int nNumReprojectionThreads = []()
+    {
+        const int nNumCPUs = CPLGetNumCPUs();
+        if (nNumCPUs <= 1)
+        {
+            return 1;
+        }
+        else
+        {
+            const char *pszNumThreads =
+                CPLGetConfigOption("GDAL_NUM_THREADS", nullptr);
+            if (pszNumThreads)
+            {
+                if (EQUAL(pszNumThreads, "ALL_CPUS"))
+                    return CPLGetNumCPUs();
+                return std::min(atoi(pszNumThreads), 1024);
+            }
+            else
+            {
+                return std::max(2, nNumCPUs / 2);
+            }
+        }
+    }();
+
+    // Somewhat arbitrary threshold (config option only/mostly for autotest purposes)
+    const int MIN_FEATURES_FOR_THREADED_REPROJ = atoi(CPLGetConfigOption(
+        "OGR2OGR_MIN_FEATURES_FOR_THREADED_REPROJ", "10000"));
+
     while (bGoOn)
     {
         struct ArrowArray array;
@@ -5789,9 +5906,121 @@ bool LayerTranslator::TranslateArrow(
             nCount += array.length;
         }
 
+        const auto nArrayLength = array.length;
+
+        // Coordinate reprojection
+        const void *backupGeomArrayBuffers2 = nullptr;
+        if (m_bTransform)
+        {
+            auto *psGeomArray = array.children[iArrowGeomFieldIndex];
+            GByte *pabyWKB = static_cast<GByte *>(
+                const_cast<void *>(psGeomArray->buffers[2]));
+            const uint32_t *panOffsets =
+                static_cast<const uint32_t *>(psGeomArray->buffers[1]);
+            auto poCT = psInfo->m_aoReprojectionInfo[0].m_poCT.get();
+
+            try
+            {
+                abyModifiedWKB.resize(panOffsets[nArrayLength]);
+            }
+            catch (const std::exception &)
+            {
+                CPLError(CE_Failure, CPLE_OutOfMemory, "Out of memory");
+                bRet = false;
+                if (array.release)
+                    array.release(&array);
+                break;
+            }
+            memcpy(abyModifiedWKB.data(), pabyWKB, panOffsets[nArrayLength]);
+            backupGeomArrayBuffers2 = psGeomArray->buffers[2];
+            psGeomArray->buffers[2] = abyModifiedWKB.data();
+
+            std::atomic<bool> atomicRet{true};
+            const auto oReprojectionLambda =
+                [psGeomArray, nArrayLength, panOffsets, &atomicRet,
+                 &abyModifiedWKB, &poCT](int iThread, int nThreads)
+            {
+                OGRWKBTransformCache oCache;
+                OGREnvelope3D sEnv3D;
+                auto poThisCT =
+                    std::unique_ptr<OGRCoordinateTransformation>(poCT->Clone());
+                if (!poThisCT)
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "Cannot clone OGRCoordinateTransformation");
+                    atomicRet = false;
+                    return;
+                }
+
+                const GByte *pabyValidity =
+                    static_cast<const GByte *>(psGeomArray->buffers[0]);
+                const size_t iStart =
+                    static_cast<size_t>(iThread * nArrayLength / nThreads);
+                const size_t iMax = static_cast<size_t>(
+                    (iThread + 1) * nArrayLength / nThreads);
+                for (size_t i = iStart; i < iMax; ++i)
+                {
+                    const size_t iShifted =
+                        static_cast<size_t>(i + psGeomArray->offset);
+                    if (!pabyValidity || (pabyValidity[iShifted >> 8] &
+                                          (1 << (iShifted % 8))) != 0)
+                    {
+                        const auto nWKBSize =
+                            panOffsets[iShifted + 1] - panOffsets[iShifted];
+                        if (!OGRWKBTransform(
+                                abyModifiedWKB.data() + panOffsets[iShifted],
+                                nWKBSize, poThisCT.get(), oCache, sEnv3D))
+                        {
+                            CPLError(CE_Failure, CPLE_AppDefined,
+                                     "Reprojection failed");
+                            atomicRet = false;
+                            break;
+                        }
+                    }
+                }
+            };
+
+            if (nArrayLength >= MIN_FEATURES_FOR_THREADED_REPROJ &&
+                nNumReprojectionThreads >= 2)
+            {
+                std::vector<std::thread> oThreads;
+                for (int iThread = 0; iThread < nNumReprojectionThreads;
+                     ++iThread)
+                {
+                    oThreads.emplace_back(oReprojectionLambda, iThread,
+                                          nNumReprojectionThreads);
+                }
+                for (auto &oThread : oThreads)
+                {
+                    oThread.join();
+                }
+            }
+            else
+            {
+                oReprojectionLambda(0, 1);
+            }
+
+            bRet = atomicRet;
+            if (!bRet)
+            {
+                psGeomArray->buffers[2] = backupGeomArrayBuffers2;
+                if (array.release)
+                    array.release(&array);
+                break;
+            }
+        }
+
         // Write batch to target layer
-        if (!psInfo->m_poDstLayer->WriteArrowBatch(
-                &schema, &array, aosOptionsWriteArrowBatch.List()))
+        const bool bWriteOK = psInfo->m_poDstLayer->WriteArrowBatch(
+            &schema, &array, aosOptionsWriteArrowBatch.List());
+
+        if (backupGeomArrayBuffers2)
+        {
+            auto *psGeomArray = array.children[iArrowGeomFieldIndex];
+            psGeomArray->buffers[2] = backupGeomArrayBuffers2;
+        }
+
+        if (!bWriteOK)
         {
             CPLError(CE_Failure, CPLE_AppDefined, "WriteArrowBatch() failed");
             if (array.release)

--- a/autotest/cpp/test_ogr_wkb.cpp
+++ b/autotest/cpp/test_ogr_wkb.cpp
@@ -524,4 +524,354 @@ INSTANTIATE_TEST_SUITE_P(
         OGRWKBIntersectsPessimisticFixture::ParamType> &l_info)
     { return std::get<6>(l_info.param); });
 
+class OGRWKBTransformFixture
+    : public test_ogr_wkb,
+      public ::testing::WithParamInterface<
+          std::tuple<const char *, OGRwkbByteOrder, const char *, const char *>>
+{
+  public:
+    static std::vector<
+        std::tuple<const char *, OGRwkbByteOrder, const char *, const char *>>
+    GetTupleValues()
+    {
+        return {
+            std::make_tuple("POINT EMPTY", wkbNDR, "POINT EMPTY",
+                            "POINT_EMPTY_NDR"),
+            std::make_tuple("POINT EMPTY", wkbXDR, "POINT EMPTY",
+                            "POINT_EMPTY_XDR"),
+            std::make_tuple("POINT (1 2)", wkbNDR, "POINT (2 4)", "POINT_NDR"),
+            std::make_tuple("POINT (1 2)", wkbXDR, "POINT (2 4)", "POINT_XDR"),
+            std::make_tuple("POINT Z EMPTY", wkbNDR, "POINT Z EMPTY",
+                            "POINT_Z_EMPTY_NDR"),
+            std::make_tuple("POINT Z EMPTY", wkbXDR, "POINT Z EMPTY",
+                            "POINT_Z_EMPTY_XDR"),
+            std::make_tuple("POINT Z (1 2 3)", wkbNDR, "POINT Z (2 4 6)",
+                            "POINT_Z_NDR"),
+            std::make_tuple("POINT Z (1 2 3)", wkbXDR, "POINT Z (2 4 6)",
+                            "POINT_Z_XDR"),
+            std::make_tuple("POINT M EMPTY", wkbNDR, "POINT M EMPTY",
+                            "POINT_M_EMPTY_NDR"),
+            std::make_tuple("POINT M EMPTY", wkbXDR, "POINT M EMPTY",
+                            "POINT_M_EMPTY_XDR"),
+            std::make_tuple("POINT M (1 2 -10)", wkbNDR, "POINT M (2 4 -10)",
+                            "POINT_M_NDR"),
+            std::make_tuple("POINT M (1 2 -10)", wkbXDR, "POINT M (2 4 -10)",
+                            "POINT_M_XDR"),
+            std::make_tuple("POINT ZM EMPTY", wkbNDR, "POINT ZM EMPTY",
+                            "POINT_ZM_EMPTY_NDR"),
+            std::make_tuple("POINT ZM EMPTY", wkbXDR, "POINT ZM EMPTY",
+                            "POINT_ZM_EMPTY_XDR"),
+            std::make_tuple("POINT ZM (1 2 3 10)", wkbNDR,
+                            "POINT ZM (2 4 6 10)", "POINT_ZM_NDR"),
+            std::make_tuple("POINT ZM (1 2 3 10)", wkbXDR,
+                            "POINT ZM (2 4 6 10)", "POINT_ZM_XDR"),
+
+            std::make_tuple("LINESTRING EMPTY", wkbNDR, "LINESTRING EMPTY",
+                            "LINESTRING_EMPTY"),
+            std::make_tuple("LINESTRING (1 2,11 12)", wkbNDR,
+                            "LINESTRING (2 4,12 14)", "LINESTRING_NDR"),
+            std::make_tuple("LINESTRING (1 2,11 12)", wkbXDR,
+                            "LINESTRING (2 4,12 14)", "LINESTRING_XDR"),
+            std::make_tuple("LINESTRING Z EMPTY", wkbNDR, "LINESTRING Z EMPTY",
+                            "LINESTRING_Z_EMPTY"),
+            std::make_tuple("LINESTRING Z (1 2 3,11 12 13)", wkbNDR,
+                            "LINESTRING Z (2 4 6,12 14 16)",
+                            "LINESTRING_Z_NDR"),
+            std::make_tuple("LINESTRING Z (1 2 3,11 12 13)", wkbXDR,
+                            "LINESTRING Z (2 4 6,12 14 16)",
+                            "LINESTRING_Z_XDR"),
+            std::make_tuple("LINESTRING M EMPTY", wkbNDR, "LINESTRING M EMPTY",
+                            "LINESTRING_M_EMPTY"),
+            std::make_tuple("LINESTRING M (1 2 -10,11 12 -20)", wkbNDR,
+                            "LINESTRING M (2 4 -10,12 14 -20)",
+                            "LINESTRING_M_NDR"),
+            std::make_tuple("LINESTRING M (1 2 -10,11 12 -20)", wkbXDR,
+                            "LINESTRING M (2 4 -10,12 14 -20)",
+                            "LINESTRING_M_XDR"),
+            std::make_tuple("LINESTRING ZM EMPTY", wkbNDR,
+                            "LINESTRING ZM EMPTY", "LINESTRING_ZM_EMPTY"),
+            std::make_tuple("LINESTRING ZM (1 2 3 -10,11 12 13 -20)", wkbNDR,
+                            "LINESTRING ZM (2 4 6 -10,12 14 16 -20)",
+                            "LINESTRING_ZM_NDR"),
+            std::make_tuple("LINESTRING ZM (1 2 3 -10,11 12 13 -20)", wkbXDR,
+                            "LINESTRING ZM (2 4 6 -10,12 14 16 -20)",
+                            "LINESTRING_ZM_XDR"),
+
+            // I know the polygon is invalid, but this is enough for our purposes
+            std::make_tuple("POLYGON EMPTY", wkbNDR, "POLYGON EMPTY",
+                            "POLYGON_EMPTY"),
+            std::make_tuple("POLYGON ((1 2,11 12))", wkbNDR,
+                            "POLYGON ((2 4,12 14))", "POLYGON_NDR"),
+            std::make_tuple("POLYGON ((1 2,11 12))", wkbXDR,
+                            "POLYGON ((2 4,12 14))", "POLYGON_XDR"),
+            std::make_tuple("POLYGON ((1 2,11 12),(21 22,31 32))", wkbNDR,
+                            "POLYGON ((2 4,12 14),(22 24,32 34))",
+                            "POLYGON_TWO_RINGS"),
+            std::make_tuple("POLYGON Z EMPTY", wkbNDR, "POLYGON Z EMPTY",
+                            "POLYGON_Z_EMPTY"),
+            std::make_tuple("POLYGON Z ((1 2 3,11 12 13))", wkbNDR,
+                            "POLYGON Z ((2 4 6,12 14 16))", "POLYGON_Z_NDR"),
+            std::make_tuple("POLYGON Z ((1 2 3,11 12 13))", wkbXDR,
+                            "POLYGON Z ((2 4 6,12 14 16))", "POLYGON_Z_XDR"),
+            std::make_tuple("POLYGON M EMPTY", wkbNDR, "POLYGON M EMPTY",
+                            "POLYGON_M_EMPTY"),
+            std::make_tuple("POLYGON M ((1 2 -10,11 12 -20))", wkbNDR,
+                            "POLYGON M ((2 4 -10,12 14 -20))", "POLYGON_M_NDR"),
+            std::make_tuple("POLYGON M ((1 2 -10,11 12 -20))", wkbXDR,
+                            "POLYGON M ((2 4 -10,12 14 -20))", "POLYGON_M_XDR"),
+            std::make_tuple("POLYGON ZM EMPTY", wkbNDR, "POLYGON ZM EMPTY",
+                            "POLYGON_ZM_EMPTY"),
+            std::make_tuple("POLYGON ZM ((1 2 3 -10,11 12 13 -20))", wkbNDR,
+                            "POLYGON ZM ((2 4 6 -10,12 14 16 -20))",
+                            "POLYGON_ZM_NDR"),
+            std::make_tuple("POLYGON ZM ((1 2 3 -10,11 12 13 -20))", wkbXDR,
+                            "POLYGON ZM ((2 4 6 -10,12 14 16 -20))",
+                            "POLYGON_ZM_XDR"),
+
+            std::make_tuple("MULTIPOINT EMPTY", wkbNDR, "MULTIPOINT EMPTY",
+                            "MULTIPOINT_EMPTY_NDR"),
+            std::make_tuple("MULTIPOINT ((1 2),(11 12))", wkbNDR,
+                            "MULTIPOINT ((2 4),(12 14))", "MULTIPOINT_NDR"),
+            std::make_tuple("MULTIPOINT Z ((1 2 3),(11 12 13))", wkbXDR,
+                            "MULTIPOINT Z ((2 4 6),(12 14 16))",
+                            "MULTIPOINT_Z_XDR"),
+
+            std::make_tuple("MULTILINESTRING ((1 2,11 12))", wkbNDR,
+                            "MULTILINESTRING ((2 4,12 14))",
+                            "MULTILINESTRING_NDR"),
+
+            std::make_tuple("MULTIPOLYGON (((1 2,11 12)))", wkbNDR,
+                            "MULTIPOLYGON (((2 4,12 14)))", "MULTIPOLYGON_NDR"),
+
+            std::make_tuple("GEOMETRYCOLLECTION (POLYGON ((1 2,11 12)))",
+                            wkbNDR,
+                            "GEOMETRYCOLLECTION (POLYGON ((2 4,12 14)))",
+                            "GEOMETRYCOLLECTION_NDR"),
+
+            std::make_tuple("CIRCULARSTRING (1 2,11 12,21 22)", wkbNDR,
+                            "CIRCULARSTRING (2 4,12 14,22 24)",
+                            "CIRCULARSTRING_NDR"),
+
+            std::make_tuple("COMPOUNDCURVE ((1 2,11 12))", wkbNDR,
+                            "COMPOUNDCURVE ((2 4,12 14))", "COMPOUNDCURVE_NDR"),
+
+            std::make_tuple("CURVEPOLYGON ((1 2,11 12,21 22,1 2))", wkbNDR,
+                            "CURVEPOLYGON ((2 4,12 14,22 24,2 4))",
+                            "CURVEPOLYGON_NDR"),
+
+            std::make_tuple("MULTICURVE ((1 2,11 12))", wkbNDR,
+                            "MULTICURVE ((2 4,12 14))", "MULTICURVE_NDR"),
+
+            std::make_tuple("MULTISURFACE (((1 2,11 12)))", wkbNDR,
+                            "MULTISURFACE (((2 4,12 14)))", "MULTISURFACE_NDR"),
+
+            std::make_tuple("TRIANGLE ((1 2,11 12,21 22,1 2))", wkbNDR,
+                            "TRIANGLE ((2 4,12 14,22 24,2 4))", "TRIANGLE_NDR"),
+
+            std::make_tuple("POLYHEDRALSURFACE (((1 2,11 12,21 22,1 2)))",
+                            wkbNDR,
+                            "POLYHEDRALSURFACE (((2 4,12 14,22 24,2 4)))",
+                            "POLYHEDRALSURFACE_NDR"),
+
+            std::make_tuple("TIN (((1 2,11 12,21 22,1 2)))", wkbNDR,
+                            "TIN (((2 4,12 14,22 24,2 4)))", "TIN_NDR"),
+        };
+    }
+};
+
+struct MyCT final : public OGRCoordinateTransformation
+{
+    const bool m_bSuccess;
+
+    explicit MyCT(bool bSuccess = true) : m_bSuccess(bSuccess)
+    {
+    }
+
+    const OGRSpatialReference *GetSourceCS() const override
+    {
+        return nullptr;
+    }
+
+    const OGRSpatialReference *GetTargetCS() const override
+    {
+        return nullptr;
+    }
+
+    int Transform(size_t nCount, double *x, double *y, double *z, double *,
+                  int *pabSuccess) override
+    {
+        for (size_t i = 0; i < nCount; ++i)
+        {
+            x[i] += 1;
+            y[i] += 2;
+            if (z)
+                z[i] += 3;
+            if (pabSuccess)
+                pabSuccess[i] = m_bSuccess;
+        }
+        return true;
+    }
+
+    OGRCoordinateTransformation *Clone() const override
+    {
+        return new MyCT();
+    }
+
+    OGRCoordinateTransformation *GetInverse() const override
+    {
+        return nullptr;
+    }  // unused
+};
+
+TEST_P(OGRWKBTransformFixture, test)
+{
+    const char *pszInput = std::get<0>(GetParam());
+    OGRwkbByteOrder eByteOrder = std::get<1>(GetParam());
+    const char *pszOutput = std::get<2>(GetParam());
+
+    MyCT oCT;
+    oCT.GetSourceCS();        // just for code coverage purpose
+    oCT.GetTargetCS();        // just for code coverage purpose
+    delete oCT.Clone();       // just for code coverage purpose
+    delete oCT.GetInverse();  // just for code coverage purpose
+
+    OGRGeometry *poGeom = nullptr;
+    EXPECT_EQ(OGRGeometryFactory::createFromWkt(pszInput, nullptr, &poGeom),
+              OGRERR_NONE);
+    ASSERT_TRUE(poGeom != nullptr);
+    std::vector<GByte> abyWkb(poGeom->WkbSize());
+    poGeom->exportToWkb(eByteOrder, abyWkb.data(), wkbVariantIso);
+    delete poGeom;
+
+    OGRWKBTransformCache oCache;
+    OGREnvelope3D sEnv;
+    EXPECT_TRUE(
+        OGRWKBTransform(abyWkb.data(), abyWkb.size(), &oCT, oCache, sEnv));
+    const auto abyWkbOri = abyWkb;
+
+    poGeom = nullptr;
+    OGRGeometryFactory::createFromWkb(abyWkb.data(), nullptr, &poGeom,
+                                      abyWkb.size());
+    ASSERT_TRUE(poGeom != nullptr);
+    char *pszWKT = nullptr;
+    poGeom->exportToWkt(&pszWKT, wkbVariantIso);
+    delete poGeom;
+    EXPECT_STREQ(pszWKT, pszOutput);
+    CPLFree(pszWKT);
+
+    {
+        CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
+
+        // Truncated geometry
+        for (size_t i = 0; i < abyWkb.size(); ++i)
+        {
+            abyWkb = abyWkbOri;
+            EXPECT_FALSE(OGRWKBTransform(abyWkb.data(), i, &oCT, oCache, sEnv));
+        }
+
+        // Check altering all bytes
+        for (size_t i = 0; i < abyWkb.size(); ++i)
+        {
+            abyWkb = abyWkbOri;
+            abyWkb[i] = 0xff;
+            CPL_IGNORE_RET_VAL(OGRWKBTransform(abyWkb.data(), abyWkb.size(),
+                                               &oCT, oCache, sEnv));
+        }
+
+        if (abyWkb.size() > 9)
+        {
+            abyWkb = abyWkbOri;
+            if (!STARTS_WITH(pszInput, "POINT"))
+            {
+                // Corrupt number of sub-geometries
+                abyWkb[5] = 0xff;
+                abyWkb[6] = 0xff;
+                abyWkb[7] = 0xff;
+                abyWkb[8] = 0xff;
+                EXPECT_FALSE(OGRWKBTransform(abyWkb.data(), abyWkb.size(), &oCT,
+                                             oCache, sEnv));
+            }
+        }
+    }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    test_ogr_wkb, OGRWKBTransformFixture,
+    ::testing::ValuesIn(OGRWKBTransformFixture::GetTupleValues()),
+    [](const ::testing::TestParamInfo<OGRWKBTransformFixture::ParamType>
+           &l_info) { return std::get<3>(l_info.param); });
+
+TEST_F(test_ogr_wkb, OGRWKBTransformFixture_rec_collection)
+{
+    std::vector<GByte> abyWkb;
+    constexpr int BEYOND_ALLOWED_RECURSION_LEVEL = 128;
+    for (int i = 0; i < BEYOND_ALLOWED_RECURSION_LEVEL; ++i)
+    {
+        abyWkb.push_back(wkbNDR);
+        abyWkb.push_back(wkbGeometryCollection);
+        abyWkb.push_back(0);
+        abyWkb.push_back(0);
+        abyWkb.push_back(0);
+        abyWkb.push_back(1);
+        abyWkb.push_back(0);
+        abyWkb.push_back(0);
+        abyWkb.push_back(0);
+    }
+    {
+        abyWkb.push_back(wkbNDR);
+        abyWkb.push_back(wkbGeometryCollection);
+        abyWkb.push_back(0);
+        abyWkb.push_back(0);
+        abyWkb.push_back(0);
+        abyWkb.push_back(0);
+        abyWkb.push_back(0);
+        abyWkb.push_back(0);
+        abyWkb.push_back(0);
+    }
+
+    MyCT oCT;
+    OGRWKBTransformCache oCache;
+    OGREnvelope3D sEnv;
+    EXPECT_FALSE(
+        OGRWKBTransform(abyWkb.data(), abyWkb.size(), &oCT, oCache, sEnv));
+}
+
+TEST_F(test_ogr_wkb, OGRWKBTransformFixture_ct_failure)
+{
+    MyCT oCT(/* bSuccess = */ false);
+    OGRWKBTransformCache oCache;
+    OGREnvelope3D sEnv;
+    {
+        OGRPoint p(1, 2);
+        std::vector<GByte> abyWkb(p.WkbSize());
+        static_cast<OGRGeometry &>(p).exportToWkb(wkbNDR, abyWkb.data(),
+                                                  wkbVariantIso);
+
+        EXPECT_FALSE(
+            OGRWKBTransform(abyWkb.data(), abyWkb.size(), &oCT, oCache, sEnv));
+    }
+    {
+        OGRLineString ls;
+        ls.addPoint(1, 2);
+        std::vector<GByte> abyWkb(ls.WkbSize());
+        static_cast<OGRGeometry &>(ls).exportToWkb(wkbNDR, abyWkb.data(),
+                                                   wkbVariantIso);
+
+        EXPECT_FALSE(
+            OGRWKBTransform(abyWkb.data(), abyWkb.size(), &oCT, oCache, sEnv));
+    }
+    {
+        OGRPolygon p;
+        auto poLR = std::make_unique<OGRLinearRing>();
+        poLR->addPoint(1, 2);
+        p.addRing(std::move(poLR));
+        std::vector<GByte> abyWkb(p.WkbSize());
+        static_cast<OGRGeometry &>(p).exportToWkb(wkbNDR, abyWkb.data(),
+                                                  wkbVariantIso);
+
+        EXPECT_FALSE(
+            OGRWKBTransform(abyWkb.data(), abyWkb.size(), &oCT, oCache, sEnv));
+    }
+}
+
 }  // namespace

--- a/ogr/ogr_geometry.h
+++ b/ogr/ogr_geometry.h
@@ -4285,6 +4285,12 @@ class CPL_DLL OGRGeometryFactory
         ~TransformWithOptionsCache();
     };
 
+    //! @cond Doxygen_Suppress
+    static bool isTransformWithOptionsRegularTransform(
+        const OGRSpatialReference *poSourceCRS,
+        const OGRSpatialReference *poTargetCRS, CSLConstList papszOptions);
+    //! @endcond
+
     static OGRGeometry *transformWithOptions(
         const OGRGeometry *poSrcGeom, OGRCoordinateTransformation *poCT,
         char **papszOptions,

--- a/ogr/ogr_wkb.cpp
+++ b/ogr/ogr_wkb.cpp
@@ -1073,6 +1073,357 @@ void OGRWKBFixupCounterClockWiseExternalRing(GByte *pabyWkb, size_t nWKBSize)
 }
 
 /************************************************************************/
+/*                        OGRWKBPointUpdater()                          */
+/************************************************************************/
+
+OGRWKBPointUpdater::OGRWKBPointUpdater() = default;
+
+/************************************************************************/
+/*              OGRWKBIntersectsPointSequencePessimistic()              */
+/************************************************************************/
+
+static bool OGRWKBUpdatePointsSequence(uint8_t *data, const size_t size,
+                                       OGRWKBPointUpdater &oUpdater,
+                                       const OGRwkbByteOrder eByteOrder,
+                                       const int nDim, const bool bHasZ,
+                                       const bool bHasM, size_t &iOffsetInOut)
+{
+    const uint32_t nPoints =
+        OGRWKBReadUInt32AtOffset(data, eByteOrder, iOffsetInOut);
+    if (nPoints > (size - iOffsetInOut) / (nDim * sizeof(double)))
+    {
+        return false;
+    }
+    const bool bNeedSwap = OGR_SWAP(eByteOrder);
+    for (uint32_t j = 0; j < nPoints; j++)
+    {
+        void *pdfX = data + iOffsetInOut;
+        void *pdfY = data + iOffsetInOut + sizeof(double);
+        void *pdfZ = bHasZ ? data + iOffsetInOut + 2 * sizeof(double) : nullptr;
+        void *pdfM =
+            bHasM ? data + iOffsetInOut + (bHasZ ? 3 : 2) * sizeof(double)
+                  : nullptr;
+        if (!oUpdater.update(bNeedSwap, pdfX, pdfY, pdfZ, pdfM))
+            return false;
+
+        iOffsetInOut += nDim * sizeof(double);
+    }
+
+    return true;
+}
+
+/************************************************************************/
+/*                        OGRWKBVisitRingSequence()                     */
+/************************************************************************/
+
+static bool OGRWKBVisitRingSequence(uint8_t *data, const size_t size,
+                                    OGRWKBPointUpdater &oUpdater,
+                                    const OGRwkbByteOrder eByteOrder,
+                                    const int nDim, const bool bHasZ,
+                                    const bool bHasM, size_t &iOffsetInOut)
+{
+    const uint32_t nRings =
+        OGRWKBReadUInt32AtOffset(data, eByteOrder, iOffsetInOut);
+    if (nRings > (size - iOffsetInOut) / sizeof(uint32_t))
+    {
+        return false;
+    }
+
+    for (uint32_t i = 0; i < nRings; ++i)
+    {
+        if (iOffsetInOut + sizeof(uint32_t) > size)
+        {
+            return false;
+        }
+        if (!OGRWKBUpdatePointsSequence(data, size, oUpdater, eByteOrder, nDim,
+                                        bHasZ, bHasM, iOffsetInOut))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+/************************************************************************/
+/*                      OGRWKBUpdatePoints()                             */
+/************************************************************************/
+
+static bool OGRWKBUpdatePoints(uint8_t *data, const size_t size,
+                               OGRWKBPointUpdater &oUpdater,
+                               size_t &iOffsetInOut, const int nRec)
+{
+    if (size - iOffsetInOut < MIN_WKB_SIZE)
+    {
+        return false;
+    }
+    const int nByteOrder = DB2_V72_FIX_BYTE_ORDER(data[iOffsetInOut]);
+    if (!(nByteOrder == wkbXDR || nByteOrder == wkbNDR))
+    {
+        return false;
+    }
+    const OGRwkbByteOrder eByteOrder = static_cast<OGRwkbByteOrder>(nByteOrder);
+
+    OGRwkbGeometryType eGeometryType = wkbUnknown;
+    OGRReadWKBGeometryType(data + iOffsetInOut, wkbVariantIso, &eGeometryType);
+    iOffsetInOut += 5;
+    const auto eFlatType = wkbFlatten(eGeometryType);
+
+    if (eFlatType == wkbGeometryCollection || eFlatType == wkbCompoundCurve ||
+        eFlatType == wkbCurvePolygon || eFlatType == wkbMultiPoint ||
+        eFlatType == wkbMultiLineString || eFlatType == wkbMultiPolygon ||
+        eFlatType == wkbMultiCurve || eFlatType == wkbMultiSurface ||
+        eFlatType == wkbPolyhedralSurface || eFlatType == wkbTIN)
+    {
+        if (nRec == 128)
+            return false;
+
+        const uint32_t nParts =
+            OGRWKBReadUInt32AtOffset(data, eByteOrder, iOffsetInOut);
+        if (nParts > (size - iOffsetInOut) / MIN_WKB_SIZE)
+        {
+            return false;
+        }
+        for (uint32_t k = 0; k < nParts; k++)
+        {
+            if (!OGRWKBUpdatePoints(data, size, oUpdater, iOffsetInOut,
+                                    nRec + 1))
+                return false;
+        }
+        return true;
+    }
+
+    const bool bHasZ = OGR_GT_HasZ(eGeometryType);
+    const bool bHasM = OGR_GT_HasM(eGeometryType);
+    const int nDim = 2 + (bHasZ ? 1 : 0) + (bHasM ? 1 : 0);
+
+    if (eFlatType == wkbPoint)
+    {
+        if (size - iOffsetInOut < nDim * sizeof(double))
+            return false;
+        void *pdfX = data + iOffsetInOut;
+        void *pdfY = data + iOffsetInOut + sizeof(double);
+        void *pdfZ = bHasZ ? data + iOffsetInOut + 2 * sizeof(double) : nullptr;
+        void *pdfM =
+            bHasM ? data + iOffsetInOut + (bHasZ ? 3 : 2) * sizeof(double)
+                  : nullptr;
+        const bool bNeedSwap = OGR_SWAP(eByteOrder);
+        if (!oUpdater.update(bNeedSwap, pdfX, pdfY, pdfZ, pdfM))
+            return false;
+        iOffsetInOut += nDim * sizeof(double);
+        return true;
+    }
+
+    if (eFlatType == wkbLineString || eFlatType == wkbCircularString)
+    {
+        return OGRWKBUpdatePointsSequence(data, size, oUpdater, eByteOrder,
+                                          nDim, bHasZ, bHasM, iOffsetInOut);
+    }
+
+    if (eFlatType == wkbPolygon || eFlatType == wkbTriangle)
+    {
+        return OGRWKBVisitRingSequence(data, size, oUpdater, eByteOrder, nDim,
+                                       bHasZ, bHasM, iOffsetInOut);
+    }
+
+    CPLDebug("OGR", "Unknown WKB geometry type");
+    return false;
+}
+
+/** Visit all points of a WKB geometry to update them.
+ */
+bool OGRWKBUpdatePoints(GByte *pabyWkb, size_t nWKBSize,
+                        OGRWKBPointUpdater &oUpdater)
+{
+    size_t iOffsetInOut = 0;
+    return OGRWKBUpdatePoints(pabyWkb, nWKBSize, oUpdater, iOffsetInOut,
+                              /* nRec = */ 0);
+}
+
+/************************************************************************/
+/*                    OGRWKBTransformCache::clear()                     */
+/************************************************************************/
+
+#ifdef OGR_WKB_TRANSFORM_ALL_AT_ONCE
+void OGRWKBTransformCache::clear()
+{
+    abNeedSwap.clear();
+    abIsEmpty.clear();
+    apdfX.clear();
+    apdfY.clear();
+    apdfZ.clear();
+    apdfM.clear();
+    adfX.clear();
+    adfY.clear();
+    adfZ.clear();
+    adfM.clear();
+    anErrorCodes.clear();
+}
+#endif
+
+/************************************************************************/
+/*                         OGRWKBTransform()                            */
+/************************************************************************/
+
+/** Visit all points of a WKB geometry to transform them.
+ */
+bool OGRWKBTransform(GByte *pabyWkb, size_t nWKBSize,
+                     OGRCoordinateTransformation *poCT,
+                     [[maybe_unused]] OGRWKBTransformCache &oCache,
+                     OGREnvelope3D &sEnvelope)
+{
+#ifndef OGR_WKB_TRANSFORM_ALL_AT_ONCE
+    struct OGRWKBPointUpdaterReproj final : public OGRWKBPointUpdater
+    {
+        OGRCoordinateTransformation *m_poCT;
+        OGREnvelope3D &m_sEnvelope;
+
+        explicit OGRWKBPointUpdaterReproj(OGRCoordinateTransformation *poCTIn,
+                                          OGREnvelope3D &sEnvelopeIn)
+            : m_poCT(poCTIn), m_sEnvelope(sEnvelopeIn)
+        {
+        }
+
+        bool update(bool bNeedSwap, void *x, void *y, void *z,
+                    void * /* m */) override
+        {
+            double dfX, dfY, dfZ;
+            memcpy(&dfX, x, sizeof(double));
+            memcpy(&dfY, y, sizeof(double));
+            if (bNeedSwap)
+            {
+                CPL_SWAP64PTR(&dfX);
+                CPL_SWAP64PTR(&dfY);
+            }
+            if (!(std::isnan(dfX) && std::isnan(dfY)))
+            {
+                if (z)
+                {
+                    memcpy(&dfZ, z, sizeof(double));
+                    if (bNeedSwap)
+                    {
+                        CPL_SWAP64PTR(&dfZ);
+                    }
+                }
+                else
+                    dfZ = 0;
+                int nErrorCode = 0;
+                m_poCT->TransformWithErrorCodes(1, &dfX, &dfY, &dfZ, nullptr,
+                                                &nErrorCode);
+                if (nErrorCode)
+                    return false;
+                m_sEnvelope.Merge(dfX, dfY, dfZ);
+                if (bNeedSwap)
+                {
+                    CPL_SWAP64PTR(&dfX);
+                    CPL_SWAP64PTR(&dfY);
+                    CPL_SWAP64PTR(&dfZ);
+                }
+                memcpy(x, &dfX, sizeof(double));
+                memcpy(y, &dfY, sizeof(double));
+                if (z)
+                    memcpy(z, &dfZ, sizeof(double));
+            }
+            return true;
+        }
+
+      private:
+        OGRWKBPointUpdaterReproj(const OGRWKBPointUpdaterReproj &) = delete;
+        OGRWKBPointUpdaterReproj &
+        operator=(const OGRWKBPointUpdaterReproj &) = delete;
+    };
+
+    sEnvelope = OGREnvelope3D();
+    OGRWKBPointUpdaterReproj oUpdater(poCT, sEnvelope);
+    return OGRWKBUpdatePoints(pabyWkb, nWKBSize, oUpdater);
+
+#else
+    struct OGRWKBPointUpdaterReproj final : public OGRWKBPointUpdater
+    {
+        OGRWKBTransformCache &m_oCache;
+
+        explicit OGRWKBPointUpdaterReproj(OGRWKBTransformCache &oCacheIn)
+            : m_oCache(oCacheIn)
+        {
+        }
+
+        bool update(bool bNeedSwap, void *x, void *y, void *z,
+                    void * /* m */) override
+        {
+            m_oCache.abNeedSwap.push_back(bNeedSwap);
+            m_oCache.apdfX.push_back(x);
+            m_oCache.apdfY.push_back(y);
+            m_oCache.apdfZ.push_back(z);
+            return true;
+        }
+    };
+
+    oCache.clear();
+    OGRWKBPointUpdaterReproj oUpdater(oCache);
+    if (!OGRWKBUpdatePoints(pabyWkb, nWKBSize, oUpdater))
+        return false;
+
+    oCache.adfX.resize(oCache.apdfX.size());
+    oCache.adfY.resize(oCache.apdfX.size());
+    oCache.adfZ.resize(oCache.apdfX.size());
+
+    for (size_t i = 0; i < oCache.apdfX.size(); ++i)
+    {
+        memcpy(&oCache.adfX[i], oCache.apdfX[i], sizeof(double));
+        memcpy(&oCache.adfY[i], oCache.apdfY[i], sizeof(double));
+        if (oCache.apdfZ[i])
+            memcpy(&oCache.adfZ[i], oCache.apdfZ[i], sizeof(double));
+        if (oCache.abNeedSwap[i])
+        {
+            CPL_SWAP64PTR(&oCache.adfX[i]);
+            CPL_SWAP64PTR(&oCache.adfY[i]);
+            CPL_SWAP64PTR(&oCache.adfZ[i]);
+        }
+        oCache.abIsEmpty.push_back(std::isnan(oCache.adfX[i]) &&
+                                   std::isnan(oCache.adfY[i]));
+    }
+
+    oCache.anErrorCodes.resize(oCache.apdfX.size());
+    poCT->TransformWithErrorCodes(static_cast<int>(oCache.apdfX.size()),
+                                  oCache.adfX.data(), oCache.adfY.data(),
+                                  oCache.adfZ.data(), nullptr,
+                                  oCache.anErrorCodes.data());
+
+    for (size_t i = 0; i < oCache.apdfX.size(); ++i)
+    {
+        if (!oCache.abIsEmpty[i] && oCache.anErrorCodes[i])
+            return false;
+    }
+
+    sEnvelope = OGREnvelope3D();
+    for (size_t i = 0; i < oCache.apdfX.size(); ++i)
+    {
+        if (oCache.abIsEmpty[i])
+        {
+            oCache.adfX[i] = std::numeric_limits<double>::quiet_NaN();
+            oCache.adfY[i] = std::numeric_limits<double>::quiet_NaN();
+            oCache.adfZ[i] = std::numeric_limits<double>::quiet_NaN();
+        }
+        else
+        {
+            sEnvelope.Merge(oCache.adfX[i], oCache.adfY[i], oCache.adfZ[i]);
+        }
+        if (oCache.abNeedSwap[i])
+        {
+            CPL_SWAP64PTR(&oCache.adfX[i]);
+            CPL_SWAP64PTR(&oCache.adfY[i]);
+            CPL_SWAP64PTR(&oCache.adfZ[i]);
+        }
+        memcpy(oCache.apdfX[i], &oCache.adfX[i], sizeof(double));
+        memcpy(oCache.apdfY[i], &oCache.adfY[i], sizeof(double));
+        if (oCache.apdfZ[i])
+            memcpy(oCache.apdfZ[i], &oCache.adfZ[i], sizeof(double));
+    }
+
+    return true;
+#endif
+}
+
+/************************************************************************/
 /*                         OGRAppendBuffer()                            */
 /************************************************************************/
 

--- a/ogr/ogrct.cpp
+++ b/ogr/ogrct.cpp
@@ -2232,6 +2232,18 @@ int OGRCoordinateTransformation::TransformWithErrorCodes(size_t nCount,
                                                          int *panErrorCodes)
 
 {
+    if (nCount == 1)
+    {
+        int nSuccess = 0;
+        const bool bOverallSuccess =
+            CPL_TO_BOOL(Transform(nCount, x, y, z, t, &nSuccess));
+        if (panErrorCodes)
+        {
+            panErrorCodes[0] = nSuccess ? 0 : -1;
+        }
+        return bOverallSuccess;
+    }
+
     std::vector<int> abSuccess;
     try
     {

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -37,6 +37,7 @@
 #include "cpl_threadsafe_queue.hpp"
 #include "ograrrowarrayhelper.h"
 #include "ogr_p.h"
+#include "ogr_wkb.h"
 
 #include <condition_variable>
 #include <limits>
@@ -185,6 +186,8 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource,
     int m_nLastCachedCTSrcSRId = -1;
     int m_nLastCachedCTDstSRId = -1;
     std::unique_ptr<OGRCoordinateTransformation> m_poLastCachedCT{};
+    OGRWKBTransformCache m_oWKBTransformCache{};
+    std::vector<GByte> m_abyWKBTransformCache{};
 
     int m_nOverviewCount = 0;
     GDALGeoPackageDataset **m_papoOverviewDS = nullptr;

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackageutility.h
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackageutility.h
@@ -72,4 +72,8 @@ bool OGRGeoPackageGetHeader(sqlite3_context *pContext, int /*argc*/,
                             bool bNeedExtent, bool bNeedExtent3D,
                             int iGeomIdx = 0);
 
+bool GPkgUpdateHeader(GByte *pabyGpkg, size_t nGpkgLen, int nSrsId, double MinX,
+                      double MaxX, double MinY, double MaxY, double MinZ,
+                      double MaxZ);
+
 #endif


### PR DESCRIPTION
(on top of PR #10716)

Use newly added OGRWKBTransform(), when possible, to speed-up -t_srs in Arrow code path (which is triggered in Parquet/GPKG -> anything, when no option or no other option than -t_srs is specified). Also use multi-threaded coordinate transformation by splitting the features within each batch in several sub-batches, each processed in its own thread.

Can result in a 3.3x speed-up in ogr2ogr Parquet->Parquet -t_srs use case on a 3.2 million feature dataset:

No reprojection:
```
$ time ogr2ogr out.parquet nz-building-outlines.parquet
real	0m5,687s
user	0m5,254s
sys	0m1,032s
```

Reprojection EPSG:2193 ("NZGD2000 / New Zealand Transverse Mercator 2000") to EPSG:4326 without optimization:
```
$ time ogr2ogr out.parquet nz-building-outlines.parquet -t_srs EPSG:4326 --config OGR2OGR_USE_ARROW_API=NO
real	0m24,038s
user	0m23,472s
sys	0m1,314s
```

Reprojection *with* optimization using 6 theads for reprojection:
```
$ time ogr2ogr out.parquet nz-building-outlines.parquet -t_srs EPSG:4326
real	0m7,100s
user	0m14,376s
sys	0m1,044s
```

Reprojection *with* optimization using 1 thead for reprojection:
```
$ time ogr2ogr out.parquet nz-building-outlines.parquet -t_srs EPSG:4326 --config GDAL_NUM_THREADS=1
real	0m13,773s
user	0m12,786s
sys	0m1,002s
```

Also applies for GPKG -> GPKG  with a 2x speedup:
```
$ time ogr2ogr out.gpkg nz-building-outlines.gpkg -t_srs EPSG:4326
real	0m17,976s
user	0m29,195s
sys	0m1,802s
```

Without optimization:
```
$ time ogr2ogr out.gpkg nz-building-outlines.gpkg -t_srs EPSG:4326 --config OGR2OGR_USE_ARROW_API=NO
real	0m36,688s
user	0m35,809s
sys	0m2,269s
```