### PR TITLE
GDALRegenerateOverviewsMultiBand(): make sure than when computing large reduction factors (like > 1024)…

### DIFF
--- a/autotest/gcore/tiff_ovr.py
+++ b/autotest/gcore/tiff_ovr.py
@@ -2642,7 +2642,9 @@ def test_tiff_ovr_fallback_to_multiband_overview_generate():
         "data/byte.tif",
         options="-b 1 -b 1 -b 1 -co INTERLEAVE=BAND -co TILED=YES -outsize 1024 1024",
     )
-    with gdaltest.config_option("GDAL_OVR_CHUNK_MAX_SIZE", "1000"):
+    with gdaltest.config_options(
+        {"GDAL_OVR_CHUNK_MAX_SIZE": "1000", "GDAL_OVR_TEMP_DRIVER": "MEM"}
+    ):
         ds.BuildOverviews("NEAR", overviewlist=[2, 4, 8])
     ds = None
 


### PR DESCRIPTION
… on huge rasters does not lead to excessive memory requirements

The new code paths are well tested by existing tests in tiff_ovr.py that set GDAL_OVR_CHUNK_MAX_SIZE
