### PR TITLE
Parquet: in dataset mode, make sure all files are closed before closing the GDALDataset

### DIFF
--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -5747,46 +5747,6 @@ bool LayerTranslator::TranslateArrow(
 
     schema.release(&schema);
 
-    // Ugly hack to work around https://github.com/OSGeo/gdal/issues/9497
-    // Deleting a RecordBatchReader obtained from arrow::dataset::Scanner.ToRecordBatchReader()
-    // is a lengthy operation since all batches are read in its destructors.
-    // Here we ask to our custom I/O layer to return in error to short circuit
-    // that lengthy operation.
-    if (auto poDS = psInfo->m_poSrcLayer->GetDataset())
-    {
-        if (poDS->GetLayerCount() == 1 && poDS->GetDriver() &&
-            EQUAL(poDS->GetDriver()->GetDescription(), "PARQUET"))
-        {
-            bool bStopIO = false;
-            const char *pszArrowStopIO =
-                CPLGetConfigOption("OGR_ARROW_STOP_IO", nullptr);
-            if (pszArrowStopIO && CPLTestBool(pszArrowStopIO))
-            {
-                bStopIO = true;
-            }
-            else if (!pszArrowStopIO)
-            {
-                std::string osExePath;
-                osExePath.resize(1024);
-                if (CPLGetExecPath(osExePath.data(),
-                                   static_cast<int>(osExePath.size())))
-                {
-                    osExePath.resize(strlen(osExePath.data()));
-                    if (strcmp(CPLGetBasename(osExePath.data()), "ogr2ogr") ==
-                        0)
-                    {
-                        bStopIO = true;
-                    }
-                }
-            }
-            if (bStopIO)
-            {
-                CPLSetConfigOption("OGR_ARROW_STOP_IO", "YES");
-                CPLDebug("OGR2OGR", "Forcing interruption of Parquet I/O");
-            }
-        }
-    }
-
     stream.release(&stream);
     return bRet;
 }

--- a/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
+++ b/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
@@ -352,6 +352,13 @@ class OGRArrowDataset CPL_NON_FINAL : public GDALPamDataset
     std::vector<std::string> m_aosDomainNames{};
     std::map<std::string, int> m_oMapDomainNameToCol{};
 
+  protected:
+    void close()
+    {
+        m_poLayer.reset();
+        m_poMemoryPool.reset();
+    }
+
   public:
     explicit OGRArrowDataset(
         const std::shared_ptr<arrow::MemoryPool> &poMemoryPool);

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowrandomaccessfile.h
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowrandomaccessfile.h
@@ -36,6 +36,9 @@
 #include "arrow/io/file.h"
 #include "arrow/io/interfaces.h"
 
+#include <atomic>
+#include <cinttypes>
+
 /************************************************************************/
 /*                        OGRArrowRandomAccessFile                      */
 /************************************************************************/
@@ -43,22 +46,58 @@
 class OGRArrowRandomAccessFile final : public arrow::io::RandomAccessFile
 {
     int64_t m_nSize = -1;
+    const std::string m_osFilename;
     VSILFILE *m_fp;
-    bool m_bOwnFP;
+    const bool m_bOwnFP;
+    std::atomic<bool> m_bAskedToClosed = false;
+
+#ifdef OGR_ARROW_USE_PREAD
+    const bool m_bDebugReadAt;
+    const bool m_bUsePRead;
+#endif
 
     OGRArrowRandomAccessFile(const OGRArrowRandomAccessFile &) = delete;
     OGRArrowRandomAccessFile &
     operator=(const OGRArrowRandomAccessFile &) = delete;
 
   public:
-    explicit OGRArrowRandomAccessFile(VSILFILE *fp, bool bOwnFP)
-        : m_fp(fp), m_bOwnFP(bOwnFP)
+    OGRArrowRandomAccessFile(const std::string &osFilename, VSILFILE *fp,
+                             bool bOwnFP)
+        : m_osFilename(osFilename), m_fp(fp), m_bOwnFP(bOwnFP)
+#ifdef OGR_ARROW_USE_PREAD
+          ,
+          m_bDebugReadAt(!VSIIsLocal(m_osFilename.c_str())),
+          // Due to the lack of caching for current /vsicurl PRead(), do not
+          // use the PRead() implementation on those files
+          m_bUsePRead(m_fp->HasPRead() &&
+                      CPLTestBool(CPLGetConfigOption(
+                          "OGR_ARROW_USE_PREAD",
+                          VSIIsLocal(m_osFilename.c_str()) ? "YES" : "NO")))
+#endif
     {
     }
 
-    explicit OGRArrowRandomAccessFile(VSIVirtualHandleUniquePtr &&fp)
-        : m_fp(fp.release()), m_bOwnFP(true)
+    OGRArrowRandomAccessFile(const std::string &osFilename,
+                             VSIVirtualHandleUniquePtr &&fp)
+        : m_osFilename(osFilename), m_fp(fp.release()), m_bOwnFP(true)
+#ifdef OGR_ARROW_USE_PREAD
+          ,
+          m_bDebugReadAt(!VSIIsLocal(m_osFilename.c_str())),
+          // Due to the lack of caching for current /vsicurl PRead(), do not
+          // use the PRead() implementation on those files
+          m_bUsePRead(m_fp->HasPRead() &&
+                      CPLTestBool(CPLGetConfigOption(
+                          "OGR_ARROW_USE_PREAD",
+                          VSIIsLocal(m_osFilename.c_str()) ? "YES" : "NO")))
+#endif
     {
+    }
+
+    void AskToClose()
+    {
+        m_bAskedToClosed = true;
+        if (m_fp)
+            m_fp->Interrupt();
     }
 
     ~OGRArrowRandomAccessFile() override
@@ -85,11 +124,14 @@ class OGRArrowRandomAccessFile final : public arrow::io::RandomAccessFile
 
     bool closed() const override
     {
-        return m_fp == nullptr;
+        return m_bAskedToClosed || m_fp == nullptr;
     }
 
     arrow::Status Seek(int64_t position) override
     {
+        if (m_bAskedToClosed)
+            return arrow::Status::IOError("File requested to close");
+
         if (VSIFSeekL(m_fp, static_cast<vsi_l_offset>(position), SEEK_SET) == 0)
             return arrow::Status::OK();
         return arrow::Status::IOError("Error while seeking");
@@ -97,6 +139,9 @@ class OGRArrowRandomAccessFile final : public arrow::io::RandomAccessFile
 
     arrow::Result<int64_t> Read(int64_t nbytes, void *out) override
     {
+        if (m_bAskedToClosed)
+            return arrow::Status::IOError("File requested to close");
+
         CPLAssert(static_cast<int64_t>(static_cast<size_t>(nbytes)) == nbytes);
         return static_cast<int64_t>(
             VSIFReadL(out, 1, static_cast<size_t>(nbytes), m_fp));
@@ -104,6 +149,9 @@ class OGRArrowRandomAccessFile final : public arrow::io::RandomAccessFile
 
     arrow::Result<std::shared_ptr<arrow::Buffer>> Read(int64_t nbytes) override
     {
+        if (m_bAskedToClosed)
+            return arrow::Status::IOError("File requested to close");
+
         // CPLDebug("ARROW", "Reading %d bytes", int(nbytes));
         // Ugly hack for https://github.com/OSGeo/gdal/issues/9497
         if (CPLGetConfigOption("OGR_ARROW_STOP_IO", nullptr))
@@ -122,8 +170,54 @@ class OGRArrowRandomAccessFile final : public arrow::io::RandomAccessFile
         return buffer;
     }
 
+#ifdef OGR_ARROW_USE_PREAD
+    using arrow::io::RandomAccessFile::ReadAt;
+
+    arrow::Result<std::shared_ptr<arrow::Buffer>>
+    ReadAt(int64_t position, int64_t nbytes) override
+    {
+        if (m_bAskedToClosed)
+            return arrow::Status::IOError("File requested to close");
+
+        if (m_bUsePRead)
+        {
+            auto buffer = arrow::AllocateResizableBuffer(nbytes);
+            if (!buffer.ok())
+            {
+                return buffer;
+            }
+            if (m_bDebugReadAt)
+            {
+                CPLDebug(
+                    "ARROW",
+                    "Start ReadAt() called on %s (this=%p) from "
+                    "thread=" CPL_FRMT_GIB ": pos=%" PRId64 ", nbytes=%" PRId64,
+                    m_osFilename.c_str(), this, CPLGetPID(), position, nbytes);
+            }
+            uint8_t *buffer_data = (*buffer)->mutable_data();
+            auto nread = m_fp->PRead(buffer_data, static_cast<size_t>(nbytes),
+                                     static_cast<vsi_l_offset>(position));
+            CPL_IGNORE_RET_VAL(
+                (*buffer)->Resize(nread));  // shrink --> cannot fail
+            if (m_bDebugReadAt)
+            {
+                CPLDebug(
+                    "ARROW",
+                    "End ReadAt() called on %s (this=%p) from "
+                    "thread=" CPL_FRMT_GIB ": pos=%" PRId64 ", nbytes=%" PRId64,
+                    m_osFilename.c_str(), this, CPLGetPID(), position, nbytes);
+            }
+            return buffer;
+        }
+        return arrow::io::RandomAccessFile::ReadAt(position, nbytes);
+    }
+#endif
+
     arrow::Result<int64_t> GetSize() override
     {
+        if (m_bAskedToClosed)
+            return arrow::Status::IOError("File requested to close");
+
         if (m_nSize < 0)
         {
             const auto nPos = VSIFTellL(m_fp);

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowrandomaccessfile.h
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowrandomaccessfile.h
@@ -153,11 +153,6 @@ class OGRArrowRandomAccessFile final : public arrow::io::RandomAccessFile
             return arrow::Status::IOError("File requested to close");
 
         // CPLDebug("ARROW", "Reading %d bytes", int(nbytes));
-        // Ugly hack for https://github.com/OSGeo/gdal/issues/9497
-        if (CPLGetConfigOption("OGR_ARROW_STOP_IO", nullptr))
-        {
-            return arrow::Result<std::shared_ptr<arrow::Buffer>>();
-        }
         auto buffer = arrow::AllocateResizableBuffer(nbytes);
         if (!buffer.ok())
         {

--- a/ogr/ogrsf_frmts/parquet/ogr_parquet.h
+++ b/ogr/ogrsf_frmts/parquet/ogr_parquet.h
@@ -304,9 +304,12 @@ class OGRParquetDatasetLayer final : public OGRParquetLayerBase
 
 class OGRParquetDataset final : public OGRArrowDataset
 {
+    std::shared_ptr<arrow::fs::FileSystem> m_poFS{};
+
   public:
     explicit OGRParquetDataset(
         const std::shared_ptr<arrow::MemoryPool> &poMemoryPool);
+    ~OGRParquetDataset();
 
     OGRLayer *ExecuteSQL(const char *pszSQLCommand,
                          OGRGeometry *poSpatialFilter,
@@ -314,6 +317,11 @@ class OGRParquetDataset final : public OGRArrowDataset
     void ReleaseResultSet(OGRLayer *poResultsSet) override;
 
     int TestCapability(const char *) override;
+
+    void SetFileSystem(const std::shared_ptr<arrow::fs::FileSystem> &fs)
+    {
+        m_poFS = fs;
+    }
 };
 
 /************************************************************************/

--- a/port/cpl_vsi_virtual.h
+++ b/port/cpl_vsi_virtual.h
@@ -139,6 +139,14 @@ struct CPL_DLL VSIVirtualHandle
     virtual size_t PRead(void *pBuffer, size_t nSize,
                          vsi_l_offset nOffset) const;
 
+    /** Ask current operations to be interrupted.
+     * Implementations must be thread-safe, as this will typically be called
+     * from another thread than the active one for this file.
+     */
+    virtual void Interrupt()
+    {
+    }
+
     // NOTE: when adding new methods, besides the "actual" implementations,
     // also consider the VSICachedFile one.
 

--- a/port/cpl_vsil_curl.cpp
+++ b/port/cpl_vsil_curl.cpp
@@ -831,7 +831,8 @@ static GIntBig VSICurlGetExpiresFromS3LikeSignedURL(const char *pszURL)
 /*                       VSICURLMultiPerform()                          */
 /************************************************************************/
 
-void VSICURLMultiPerform(CURLM *hCurlMultiHandle, CURL *hEasyHandle)
+void VSICURLMultiPerform(CURLM *hCurlMultiHandle, CURL *hEasyHandle,
+                         std::atomic<bool> *pbInterrupt)
 {
     int repeats = 0;
 
@@ -866,6 +867,9 @@ void VSICURLMultiPerform(CURLM *hCurlMultiHandle, CURL *hEasyHandle)
 #endif
 
         CPLMultiPerformWait(hCurlMultiHandle, repeats);
+
+        if (pbInterrupt && *pbInterrupt)
+            break;
     }
     CPLHTTPRestoreSigPipeHandler(old_handler);
 
@@ -1150,7 +1154,7 @@ retry:
 
     unchecked_curl_easy_setopt(hCurlHandle, CURLOPT_FILETIME, 1);
 
-    VSICURLMultiPerform(hCurlMultiHandle, hCurlHandle);
+    VSICURLMultiPerform(hCurlMultiHandle, hCurlHandle, &m_bInterrupt);
 
     VSICURLResetHeaderAndWriterFunctions(hCurlHandle);
 
@@ -1863,7 +1867,7 @@ retry:
 
     unchecked_curl_easy_setopt(hCurlHandle, CURLOPT_FILETIME, 1);
 
-    VSICURLMultiPerform(hCurlMultiHandle, hCurlHandle);
+    VSICURLMultiPerform(hCurlMultiHandle, hCurlHandle, &m_bInterrupt);
 
     VSICURLResetHeaderAndWriterFunctions(hCurlHandle);
 
@@ -1871,9 +1875,12 @@ retry:
 
     NetworkStatisticsLogger::LogGET(sWriteFuncData.nSize);
 
-    if (sWriteFuncData.bInterrupted)
+    if (sWriteFuncData.bInterrupted || m_bInterrupt)
     {
         bInterrupted = true;
+
+        // Notify that the download of the current region is finished
+        currentDownload.SetData(std::string());
 
         CPLFree(sWriteFuncData.pBuffer);
         CPLFree(sWriteFuncHeaderData.pBuffer);
@@ -3092,8 +3099,7 @@ size_t VSICurlHandle::PRead(void *pBuffer, size_t nSize,
     unchecked_curl_easy_setopt(hCurlHandle, CURLOPT_HTTPHEADER, headers);
 
     CURLM *hMultiHandle = poFS->GetCurlMultiHandleFor(osURL);
-    curl_multi_add_handle(hMultiHandle, hCurlHandle);
-    VSICURLMultiPerform(hMultiHandle);
+    VSICURLMultiPerform(hMultiHandle, hCurlHandle, &m_bInterrupt);
 
     {
         std::lock_guard<std::mutex> oLock(m_oMutex);
@@ -3116,9 +3122,12 @@ size_t VSICurlHandle::PRead(void *pBuffer, size_t nSize,
     if ((response_code != 206 && response_code != 225) ||
         sWriteFuncData.nSize == 0)
     {
-        CPLDebug(poFS->GetDebugKey(),
-                 "Request for %s failed with response_code=%ld", rangeStr,
-                 response_code);
+        if (!m_bInterrupt)
+        {
+            CPLDebug(poFS->GetDebugKey(),
+                     "Request for %s failed with response_code=%ld", rangeStr,
+                     response_code);
+        }
         nRet = static_cast<size_t>(-1);
     }
     else
@@ -3128,7 +3137,6 @@ size_t VSICurlHandle::PRead(void *pBuffer, size_t nSize,
             memcpy(pBuffer, sWriteFuncData.pBuffer, nRet);
     }
 
-    curl_multi_remove_handle(hMultiHandle, hCurlHandle);
     VSICURLResetHeaderAndWriterFunctions(hCurlHandle);
     curl_easy_cleanup(hCurlHandle);
     CPLFree(sWriteFuncData.pBuffer);

--- a/port/cpl_vsil_curl_class.h
+++ b/port/cpl_vsil_curl_class.h
@@ -42,6 +42,7 @@
 #include "cpl_curl_priv.h"
 
 #include <algorithm>
+#include <atomic>
 #include <condition_variable>
 #include <set>
 #include <map>
@@ -411,6 +412,8 @@ class VSICurlHandle : public VSIVirtualHandle
     bool m_bUseHead = false;
     bool m_bUseRedirectURLIfNoQueryStringParams = false;
 
+    mutable std::atomic<bool> m_bInterrupt = false;
+
     // Specific to Planetary Computer signing:
     // https://planetarycomputer.microsoft.com/docs/concepts/sas/
     mutable bool m_bPlanetaryComputerURLSigning = false;
@@ -496,6 +499,11 @@ class VSICurlHandle : public VSIVirtualHandle
     int Error() override;
     int Flush() override;
     int Close() override;
+
+    void Interrupt() override
+    {
+        m_bInterrupt = true;
+    }
 
     bool HasPRead() const override
     {
@@ -1188,7 +1196,8 @@ void VSICURLInitWriteFuncStruct(cpl::WriteFuncStruct *psStruct, VSILFILE *fp,
                                 void *pReadCbkUserData);
 size_t VSICurlHandleWriteFunc(void *buffer, size_t count, size_t nmemb,
                               void *req);
-void VSICURLMultiPerform(CURLM *hCurlMultiHandle, CURL *hEasyHandle = nullptr);
+void VSICURLMultiPerform(CURLM *hCurlMultiHandle, CURL *hEasyHandle = nullptr,
+                         std::atomic<bool> *pbInterrupt = nullptr);
 void VSICURLResetHeaderAndWriterFunctions(CURL *hCurlHandle);
 
 int VSICurlParseUnixPermissions(const char *pszPermissions);


### PR DESCRIPTION
- VSIVirtualHandle: add a Interrupt() method and implement in in /vsicurl/ (and related filesystems)
- Parquet: in dataset mode, make sure all files are closed before closing the GDALDataset, to avoid crashes particularly on /vsicurl/ (and related filesystems) files
- ogr2ogr: remove hack related to Parquet dataset
