### PR TITLE
gdal_contour: add a -gt option to define the transaction flush interval (default it to 100,000)

### DIFF
--- a/alg/gdal_alg.h
+++ b/alg/gdal_alg.h
@@ -310,6 +310,9 @@ typedef struct
     int nElevFieldMax;
     int nIDField;
     int nNextID;
+
+    GIntBig nWrittenFeatureCountSinceLastCommit;
+    GIntBig nTransactionCommitInterval;
 } OGRContourWriterInfo;
 
 CPLErr CPL_DLL OGRContourWriter(double, int, double *, double *, void *pInfo);

--- a/apps/gdal_contour.cpp
+++ b/apps/gdal_contour.cpp
@@ -190,7 +190,7 @@ GDALContourAppOptionsGetParser(GDALContourOptions *psOptions)
                 else
                     psOptions->nGroupTransactions = atoi(s.c_str());
             })
-        .help(_("Group <n> features per transaction "));
+        .help(_("Group <n> features per transaction."));
 
     argParser->add_quiet_argument(&psOptions->bQuiet);
 

--- a/apps/gdal_contour.cpp
+++ b/apps/gdal_contour.cpp
@@ -64,6 +64,7 @@ struct GDALContourOptions
     bool bQuiet = false;
     std::string aosDestFilename;
     std::string aosSrcFilename;
+    GIntBig nGroupTransactions = 100 * 1000;
 };
 
 /************************************************************************/
@@ -178,6 +179,18 @@ GDALContourAppOptionsGetParser(GDALContourOptions *psOptions)
         .flag()
         .store_into(psOptions->bPolygonize)
         .help(_("Generate contour polygons instead of lines."));
+
+    argParser->add_argument("-gt")
+        .metavar("<n>|unlimited")
+        .action(
+            [psOptions](const std::string &s)
+            {
+                if (EQUAL(s.c_str(), "unlimited"))
+                    psOptions->nGroupTransactions = -1;
+                else
+                    psOptions->nGroupTransactions = atoi(s.c_str());
+            })
+        .help(_("Group <n> features per transaction "));
 
     argParser->add_quiet_argument(&psOptions->bQuiet);
 
@@ -358,6 +371,11 @@ MAIN_START(argc, argv)
     if (hLayer == nullptr)
         exit(1);
 
+    if (!OGR_L_TestCapability(hLayer, OLCTransactions))
+    {
+        sOptions.nGroupTransactions = 0;
+    }
+
     OGRFieldDefnH hFld = OGR_Fld_Create("ID", OFTInteger);
     OGR_Fld_SetWidth(hFld, 8);
     OGR_L_CreateField(hLayer, hFld, FALSE);
@@ -484,6 +502,11 @@ MAIN_START(argc, argv)
     if (sOptions.bPolygonize)
     {
         options = CSLAppendPrintf(options, "POLYGONIZE=YES");
+    }
+    if (sOptions.nGroupTransactions)
+    {
+        options = CSLAppendPrintf(options, "COMMIT_INTERVAL=" CPL_FRMT_GIB,
+                                  sOptions.nGroupTransactions);
     }
 
     CPLErr eErr =

--- a/autotest/utilities/test_gdal_contour.py
+++ b/autotest/utilities/test_gdal_contour.py
@@ -628,3 +628,28 @@ def test_gdal_contour_fl_e_polygonize(gdal_contour_path, tmp_path):
         )
         i = i + 1
         feat = lyr.GetNextFeature()
+
+
+###############################################################################
+# Test -gt
+
+
+@pytest.mark.require_driver("GPKG")
+@pytest.mark.parametrize("gt", ["0", "1", "unlimited"])
+def test_gdal_contour_gt(gdal_contour_path, tmp_path, gt):
+
+    out_filename = str(tmp_path / "contour.gpkg")
+
+    gdaltest.runexternal(
+        gdal_contour_path
+        + f" -p -amin elev -amax elev2 -fl 76 112 441 -e 3 -gt {gt} ../gdrivers/data/n43.tif {out_filename}"
+    )
+
+    ds = ogr.Open(out_filename)
+
+    lyr = ds.ExecuteSQL("select elev, elev2 from contour order by elev asc")
+
+    # Raster min is 75, max is 460
+    expected_heights = [75, 76, 81, 112, 243, 441]
+
+    assert lyr.GetFeatureCount() == len(expected_heights)

--- a/doc/source/programs/gdal_contour.rst
+++ b/doc/source/programs/gdal_contour.rst
@@ -20,7 +20,7 @@ Synopsis
                  [-3d] [-inodata] [-snodata <n>] [-f <formatname>] [-i <interval>]
                  [-dsco <NAME>=<VALUE>]... [-lco <NAME>=<VALUE>]...
                  [-off <offset>] [-fl <level> <level>...] [-e <exp_base>]
-                 [-nln <outlayername>] [-q] [-p]
+                 [-nln <outlayername>] [-q] [-p] [-gt <n>|unlimited]
                  <src_filename> <dst_filename>
 
 Description
@@ -123,6 +123,15 @@ be on the right, i.e. a line string goes clockwise around a top.
     Generate contour polygons rather than contour lines.
 
     .. versionadded:: 2.4.0
+
+.. option:: -gt <n>
+
+    Group n features per transaction (default 100 000). Increase the value for
+    better performance when writing into DBMS drivers that have transaction
+    support. ``n`` can be set to unlimited to load the data into a single
+    transaction. If set to 0, no explicit transaction is done.
+
+    .. versionadded:: 3.10
 
 .. option:: -q
 


### PR DESCRIPTION
Fixes #10729
