### PR TITLE
gdal::VectorX Prototype

### DIFF
--- a/alg/gdal_interpolateatpoint.cpp
+++ b/alg/gdal_interpolateatpoint.cpp
@@ -17,6 +17,8 @@
 
 #include "gdalresamplingkernels.h"
 
+#include "gdal_vectorx.h"
+
 #include <algorithm>
 #include <complex>
 
@@ -36,10 +38,15 @@ template <> bool areEqualReal(double dfNoDataValue, std::complex<double> dfOut)
 template <typename T>
 bool GDALInterpExtractValuesWindow(GDALRasterBand *pBand,
                                    std::unique_ptr<DoublePointsCache> &cache,
-                                   int nX, int nY, int nWidth, int nHeight,
-                                   T *padfOut)
+                                   gdal::Vector2i point,
+                                   gdal::Vector2i dimensions, T *padfOut)
 {
     constexpr int BLOCK_SIZE = 64;
+
+    const int nX = point.x();
+    const int nY = point.y();
+    const int nWidth = dimensions.x();
+    const int nHeight = dimensions.y();
 
     // Request the DEM by blocks of BLOCK_SIZE * BLOCK_SIZE and put them
     // in cache
@@ -153,29 +160,32 @@ bool GDALInterpolateAtPointImpl(GDALRasterBand *pBand,
                                 std::unique_ptr<DoublePointsCache> &cache,
                                 const double dfXIn, const double dfYIn, T &out)
 {
-    const int nRasterXSize = pBand->GetXSize();
-    const int nRasterYSize = pBand->GetYSize();
+    const gdal::Vector2i rasterSize{pBand->GetXSize(), pBand->GetYSize()};
+    const gdal::Vector2d inLoc{dfXIn, dfYIn};
+
     int bGotNoDataValue = FALSE;
     const double dfNoDataValue = pBand->GetNoDataValue(&bGotNoDataValue);
 
-    if (dfXIn < 0 || dfXIn > nRasterXSize || dfYIn < 0 || dfYIn > nRasterYSize)
+    if (inLoc.x() < 0 || inLoc.x() > rasterSize.x() || inLoc.y() < 0 ||
+        inLoc.y() > rasterSize.y())
     {
         return FALSE;
     }
 
     // Downgrade the interpolation algorithm if the image is too small
-    if ((nRasterXSize < 4 || nRasterYSize < 4) &&
+    if ((rasterSize.x() < 4 || rasterSize.y() < 4) &&
         (eResampleAlg == GRIORA_CubicSpline || eResampleAlg == GRIORA_Cubic))
     {
         eResampleAlg = GRIORA_Bilinear;
     }
-    if ((nRasterXSize < 2 || nRasterYSize < 2) &&
+    if ((rasterSize.x() < 2 || rasterSize.y() < 2) &&
         eResampleAlg == GRIORA_Bilinear)
     {
         eResampleAlg = GRIORA_NearestNeighbour;
     }
 
-    auto outOfBorderCorrection = [](int dNew, int nRasterSize, int nKernelsize)
+    auto outOfBorderCorrectionSimple =
+        [](int dNew, int nRasterSize, int nKernelsize)
     {
         int dOutOfBorder = 0;
         if (dNew < 0)
@@ -189,7 +199,17 @@ bool GDALInterpolateAtPointImpl(GDALRasterBand *pBand,
         return dOutOfBorder;
     };
 
-    auto dragReadDataInBorder =
+    auto outOfBorderCorrection =
+        [&outOfBorderCorrectionSimple,
+         &rasterSize](gdal::Vector2i input, int nKernelsize) -> gdal::Vector2i
+    {
+        return {
+            outOfBorderCorrectionSimple(input.x(), rasterSize.x(), nKernelsize),
+            outOfBorderCorrectionSimple(input.y(), rasterSize.y(),
+                                        nKernelsize)};
+    };
+
+    auto dragReadDataInBorderSimple =
         [](T *adfElevData, int dOutOfBorder, int nKernelSize, bool bIsX)
     {
         while (dOutOfBorder < 0)
@@ -222,9 +242,18 @@ bool GDALInterpolateAtPointImpl(GDALRasterBand *pBand,
             dOutOfBorder--;
         }
     };
+    auto dragReadDataInBorder = [&dragReadDataInBorderSimple](
+                                    T *adfElevData, gdal::Vector2i dOutOfBorder,
+                                    int nKernelSize) -> void
+    {
+        dragReadDataInBorderSimple(adfElevData, dOutOfBorder.x(), nKernelSize,
+                                   true);
+        dragReadDataInBorderSimple(adfElevData, dOutOfBorder.y(), nKernelSize,
+                                   false);
+    };
 
-    auto applyBilinearKernel = [&](double dfDeltaX, double dfDeltaY,
-                                   T *adfValues, T &pdfRes) -> bool
+    auto applyBilinearKernel = [&](gdal::Vector2d dfDelta, T *adfValues,
+                                   T &pdfRes) -> bool
     {
         if (bGotNoDataValue)
         {
@@ -240,18 +269,19 @@ bool GDALInterpolateAtPointImpl(GDALRasterBand *pBand,
                 return FALSE;
             }
         }
-        const double dfDeltaX1 = 1.0 - dfDeltaX;
-        const double dfDeltaY1 = 1.0 - dfDeltaY;
+        const gdal::Vector2d dfDelta1 = 1.0 - dfDelta;
 
-        const T dfXZ1 = adfValues[0] * dfDeltaX1 + adfValues[1] * dfDeltaX;
-        const T dfXZ2 = adfValues[2] * dfDeltaX1 + adfValues[3] * dfDeltaX;
-        const T dfYZ = dfXZ1 * dfDeltaY1 + dfXZ2 * dfDeltaY;
+        const T dfXZ1 =
+            adfValues[0] * dfDelta1.x() + adfValues[1] * dfDelta.x();
+        const T dfXZ2 =
+            adfValues[2] * dfDelta1.x() + adfValues[3] * dfDelta.x();
+        const T dfYZ = dfXZ1 * dfDelta1.y() + dfXZ2 * dfDelta.y();
 
         pdfRes = dfYZ;
         return TRUE;
     };
 
-    auto apply4x4Kernel = [&](double dfDeltaX, double dfDeltaY, T *adfValues,
+    auto apply4x4Kernel = [&](gdal::Vector2d dfDelta, T *adfValues,
                               T &pdfRes) -> bool
     {
         T dfSumH = 0.0;
@@ -264,14 +294,13 @@ bool GDALInterpolateAtPointImpl(GDALRasterBand *pBand,
                 // Calculate the weight for the specified pixel according
                 // to the bicubic b-spline kernel we're using for
                 // interpolation.
-                const int dKernIndX = k_j - 1;
-                const int dKernIndY = k_i - 1;
+                const gdal::Vector2i dKernInd = {k_j - 1, k_i - 1};
+                const gdal::Vector2d fPoint = dKernInd.cast<double>() - dfDelta;
                 const double dfPixelWeight =
                     eResampleAlg == GDALRIOResampleAlg::GRIORA_CubicSpline
-                        ? CubicSplineKernel(dKernIndX - dfDeltaX) *
-                              CubicSplineKernel(dKernIndY - dfDeltaY)
-                        : CubicKernel(dKernIndX - dfDeltaX) *
-                              CubicKernel(dKernIndY - dfDeltaY);
+                        ? CubicSplineKernel(fPoint.x()) *
+                              CubicSplineKernel(fPoint.y())
+                        : CubicKernel(fPoint.x()) * CubicKernel(fPoint.y());
 
                 // Create a sum of all values
                 // adjusted for the pixel's calculated weight.
@@ -298,32 +327,24 @@ bool GDALInterpolateAtPointImpl(GDALRasterBand *pBand,
     {
         // Convert from upper left corner of pixel coordinates to center of
         // pixel coordinates:
-        const double dfX = dfXIn - 0.5;
-        const double dfY = dfYIn - 0.5;
-        const int dX = static_cast<int>(std::floor(dfX));
-        const int dY = static_cast<int>(std::floor(dfY));
-        const double dfDeltaX = dfX - dX;
-        const double dfDeltaY = dfY - dY;
-
-        const int dXNew = dX - 1;
-        const int dYNew = dY - 1;
+        const gdal::Vector2d df = inLoc - 0.5;
+        const gdal::Vector2i d = df.floor().template cast<int>();
+        const gdal::Vector2d delta = df - d.cast<double>();
+        const gdal::Vector2i dNew = d - 1;
         const int nKernelSize = 4;
-        const int dXOutOfBorder =
-            outOfBorderCorrection(dXNew, nRasterXSize, nKernelSize);
-        const int dYOutOfBorder =
-            outOfBorderCorrection(dYNew, nRasterYSize, nKernelSize);
+        const gdal::Vector2i dOutOfBorder =
+            outOfBorderCorrection(dNew, nKernelSize);
 
         // CubicSpline interpolation.
         T adfReadData[16] = {0.0};
-        if (!GDALInterpExtractValuesWindow(pBand, cache, dXNew - dXOutOfBorder,
-                                           dYNew - dYOutOfBorder, nKernelSize,
-                                           nKernelSize, adfReadData))
+        if (!GDALInterpExtractValuesWindow(pBand, cache, dNew - dOutOfBorder,
+                                           {nKernelSize, nKernelSize},
+                                           adfReadData))
         {
             return FALSE;
         }
-        dragReadDataInBorder(adfReadData, dXOutOfBorder, nKernelSize, true);
-        dragReadDataInBorder(adfReadData, dYOutOfBorder, nKernelSize, false);
-        if (!apply4x4Kernel(dfDeltaX, dfDeltaY, adfReadData, out))
+        dragReadDataInBorder(adfReadData, dOutOfBorder, nKernelSize);
+        if (!apply4x4Kernel(delta, adfReadData, out))
             return FALSE;
 
         return TRUE;
@@ -332,41 +353,32 @@ bool GDALInterpolateAtPointImpl(GDALRasterBand *pBand,
     {
         // Convert from upper left corner of pixel coordinates to center of
         // pixel coordinates:
-        const double dfX = dfXIn - 0.5;
-        const double dfY = dfYIn - 0.5;
-        const int dX = static_cast<int>(std::floor(dfX));
-        const int dY = static_cast<int>(std::floor(dfY));
-        const double dfDeltaX = dfX - dX;
-        const double dfDeltaY = dfY - dY;
-
+        const gdal::Vector2d df = inLoc - 0.5;
+        const gdal::Vector2i d = df.floor().template cast<int>();
+        const gdal::Vector2d delta = df - d.cast<double>();
         const int nKernelSize = 2;
-        const int dXOutOfBorder =
-            outOfBorderCorrection(dX, nRasterXSize, nKernelSize);
-        const int dYOutOfBorder =
-            outOfBorderCorrection(dY, nRasterYSize, nKernelSize);
+        const gdal::Vector2i dOutOfBorder =
+            outOfBorderCorrection(d, nKernelSize);
 
         // Bilinear interpolation.
         T adfReadData[4] = {0.0};
-        if (!GDALInterpExtractValuesWindow(pBand, cache, dX - dXOutOfBorder,
-                                           dY - dYOutOfBorder, nKernelSize,
-                                           nKernelSize, adfReadData))
+        if (!GDALInterpExtractValuesWindow(pBand, cache, d - dOutOfBorder,
+                                           {nKernelSize, nKernelSize},
+                                           adfReadData))
         {
             return FALSE;
         }
-        dragReadDataInBorder(adfReadData, dXOutOfBorder, nKernelSize, true);
-        dragReadDataInBorder(adfReadData, dYOutOfBorder, nKernelSize, false);
-        if (!applyBilinearKernel(dfDeltaX, dfDeltaY, adfReadData, out))
+        dragReadDataInBorder(adfReadData, dOutOfBorder, nKernelSize);
+        if (!applyBilinearKernel(delta, adfReadData, out))
             return FALSE;
 
         return TRUE;
     }
     else
     {
-        const int dX = static_cast<int>(dfXIn);
-        const int dY = static_cast<int>(dfYIn);
+        const gdal::Vector2i d = inLoc.cast<int>();
         T dfOut{};
-        if (!GDALInterpExtractValuesWindow(pBand, cache, dX, dY, 1, 1,
-                                           &dfOut) ||
+        if (!GDALInterpExtractValuesWindow(pBand, cache, d, {1, 1}, &dfOut) ||
             (bGotNoDataValue && areEqualReal(dfNoDataValue, dfOut)))
         {
             return FALSE;

--- a/autotest/cpp/CMakeLists.txt
+++ b/autotest/cpp/CMakeLists.txt
@@ -80,6 +80,7 @@ add_executable(
   test_gdal_minmax_element.cpp
   test_gdal_pixelfn.cpp
   test_gdal_typetraits.cpp
+  test_gdal_vectorx.cpp
   test_ogr.cpp
   test_ogr_organize_polygons.cpp
   test_ogr_geometry_stealing.cpp

--- a/autotest/cpp/test_gdal_vectorx.cpp
+++ b/autotest/cpp/test_gdal_vectorx.cpp
@@ -1,0 +1,337 @@
+/******************************************************************************
+ * Project:  GDAL Vector abstraction
+ * Purpose:  Tests for the VectorX class
+ * Author:   Javier Jimenez Shaw
+ *
+ ******************************************************************************
+ * Copyright (c) 2024, Javier Jimenez Shaw
+ *
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#include "gdal_unit_test.h"
+
+#include "gdal_vectorx.h"
+
+#include <cmath>
+#include <complex>
+#include <limits>
+#include <type_traits>
+
+#include "gtest_include.h"
+
+namespace
+{
+
+// Common fixture with test data
+struct test_vectorx : public ::testing::Test
+{
+};
+
+// Dummy test
+TEST_F(test_vectorx, simple_int)
+{
+    gdal::Vector2i a;
+    EXPECT_EQ(0, a.x());
+    EXPECT_EQ(0, a.y());
+    static_assert(std::is_same_v<decltype(a)::value_type, int> == true);
+
+    gdal::Vector2i p2(2, 3);
+    EXPECT_EQ(2, p2.x());
+    EXPECT_EQ(3, p2.y());
+
+    gdal::Vector3i p3(12, 13, 14);
+    EXPECT_EQ(12, p3.x());
+    EXPECT_EQ(13, p3.y());
+    EXPECT_EQ(14, p3.z());
+
+    gdal::VectorX<int, 1> p1{2};
+    EXPECT_EQ(2, p1.x());
+
+    gdal::VectorX<int, 4> p4(12, 13, -14, 150);
+    EXPECT_EQ(12, p4.x());
+    EXPECT_EQ(13, p4.y());
+    EXPECT_EQ(-14, p4.z());
+    EXPECT_EQ(150, p4[3]);
+}
+
+TEST_F(test_vectorx, simple_double)
+{
+    gdal::Vector2d a;
+    EXPECT_EQ(0.0, a.x());
+    EXPECT_EQ(0.0, a.y());
+    EXPECT_EQ(2, a.size());
+    static_assert(std::is_same_v<decltype(a)::value_type, double> == true);
+
+    gdal::Vector2d p2(2.1, 3.6);
+    EXPECT_EQ(2.1, p2.x());
+    EXPECT_EQ(3.6, p2.y());
+    EXPECT_EQ(2, p2.size());
+
+    gdal::Vector3d p3(12e-2, -13.0, 14e3);
+    EXPECT_EQ(12e-2, p3.x());
+    EXPECT_EQ(-13.0, p3.y());
+    EXPECT_EQ(14e3, p3.z());
+    EXPECT_EQ(3, p3.size());
+
+    gdal::VectorX<double, 1> p1{2.1};
+    EXPECT_EQ(2.1, p1.x());
+    EXPECT_EQ(1, p1.size());
+
+    gdal::VectorX<double, 4> p4(12.0, 13.1, -14.2, 150.0);
+    EXPECT_EQ(12.0, p4.x());
+    EXPECT_EQ(13.1, p4.y());
+    EXPECT_EQ(-14.2, p4.z());
+    EXPECT_EQ(150.0, p4[3]);
+    EXPECT_EQ(4, p4.size());
+}
+
+TEST_F(test_vectorx, simple_float)
+{
+    gdal::VectorX<float, 1> p1{2.1f};
+    EXPECT_EQ(2.1f, p1.x());
+    static_assert(std::is_same_v<decltype(p1)::value_type, float> == true);
+
+    gdal::VectorX<float, 4> p4(12.0f, 13.1f, -14.2f, 150.0f);
+    EXPECT_EQ(12.0f, p4.x());
+    EXPECT_EQ(13.1f, p4.y());
+    EXPECT_EQ(-14.2f, p4.z());
+    EXPECT_EQ(150.0f, p4[3]);
+}
+
+TEST_F(test_vectorx, simple_complex)
+{
+    using namespace std::complex_literals;
+    gdal::VectorX<std::complex<double>, 2> p2{2.1 + 3.0i, -9.0 + -7.0i};
+    EXPECT_EQ(2.1 + 3.0i, p2.x());
+    EXPECT_EQ(-9.0 + -7.0i, p2.y());
+    static_assert(
+        std::is_same_v<decltype(p2)::value_type, std::complex<double>> == true);
+}
+
+TEST_F(test_vectorx, array)
+{
+    gdal::Vector2d p2(2.1, 3.6);
+    const std::array<double, 2> arr = p2.array();
+    EXPECT_EQ(2.1, arr[0]);
+    EXPECT_EQ(3.6, arr[1]);
+}
+
+TEST_F(test_vectorx, fill)
+{
+    const auto a = gdal::Vector3d().fill(42.0);
+    EXPECT_EQ(3, a.size());
+    EXPECT_EQ(42.0, a[0]);
+    EXPECT_EQ(42.0, a[1]);
+    EXPECT_EQ(42.0, a[2]);
+}
+
+TEST_F(test_vectorx, fill_nan)
+{
+    const auto a =
+        gdal::Vector3d().fill(std::numeric_limits<double>::quiet_NaN());
+    EXPECT_EQ(3, a.size());
+    EXPECT_TRUE(std::isnan(a[0]));
+    EXPECT_TRUE(std::isnan(a[1]));
+    EXPECT_TRUE(std::isnan(a[2]));
+}
+
+TEST_F(test_vectorx, change)
+{
+    gdal::Vector2d p2(2.1, 3.6);
+    p2[0] = 7;
+    EXPECT_EQ(7, p2.x());
+    p2[1] = 10.5;
+    EXPECT_EQ(10.5, p2.y());
+
+    gdal::Vector3d p3(12.1, 13.6, -9.0);
+    p3.x() = 79;
+    EXPECT_EQ(79, p3[0]);
+    p3.y() = 10.4;
+    EXPECT_EQ(10.4, p3[1]);
+    p3.z() = 1.5;
+    EXPECT_EQ(1.5, p3[2]);
+}
+
+TEST_F(test_vectorx, scalar_prod)
+{
+    gdal::Vector2d a(2.1, 3.6);
+    gdal::Vector2d b(-2.0, 10.0);
+    EXPECT_NEAR(2.1 * -2.0 + 3.6 * 10.0, a.scalarProd(b), 1e-10);
+}
+
+TEST_F(test_vectorx, norm2)
+{
+    gdal::Vector2d a(2.1, 3.6);
+    EXPECT_NEAR(2.1 * 2.1 + 3.6 * 3.6, a.norm2(), 1e-10);
+}
+
+TEST_F(test_vectorx, cast)
+{
+    gdal::Vector2d a(2.1, -3.6);
+    auto b = a.cast<int>();
+    static_assert(std::is_same_v<decltype(b)::value_type, int> == true);
+    EXPECT_EQ(2, b.x());
+    EXPECT_EQ(-3, b.y());
+
+    gdal::Vector2d c = b.cast<double>();
+    static_assert(std::is_same_v<decltype(c)::value_type, double> == true);
+    EXPECT_EQ(2.0, c.x());
+    EXPECT_EQ(-3.0, c.y());
+}
+
+TEST_F(test_vectorx, floor)
+{
+    const gdal::Vector2d a(2.1, -3.6);
+    const gdal::Vector2d d = a.floor();
+    EXPECT_EQ(2.0, d.x());
+    EXPECT_EQ(-4.0, d.y());
+
+    // just to show how to use the template keyword.
+    const gdal::Vector2i i = a.floor().template cast<int>();
+    EXPECT_EQ(2, i.x());
+    EXPECT_EQ(-4, i.y());
+}
+
+TEST_F(test_vectorx, ceil)
+{
+    const gdal::Vector2d a(2.1, -3.6);
+    const gdal::Vector2d d = a.ceil();
+    EXPECT_EQ(3.0, d.x());
+    EXPECT_EQ(-3.0, d.y());
+}
+
+TEST_F(test_vectorx, apply)
+{
+    const gdal::Vector2d a(2.1, -3.6);
+    const gdal::Vector2d d =
+        a.apply([](const gdal::Vector2d::value_type v) { return v + 1.0; });
+    EXPECT_NEAR(3.1, d.x(), 1e-10);
+    EXPECT_NEAR(-2.6, d.y(), 1e-10);
+}
+
+TEST_F(test_vectorx, sum)
+{
+    const gdal::Vector2d a(2.1, -3.6);
+    const gdal::Vector2d b = a + 2.2;
+    EXPECT_NEAR(4.3, b.x(), 1e-10);
+    EXPECT_NEAR(-1.4, b.y(), 1e-10);
+}
+
+TEST_F(test_vectorx, sum_eq)
+{
+    gdal::Vector2d a(2.1, -3.6);
+    a += 2.0;
+    EXPECT_NEAR(4.1, a.x(), 1e-10);
+    EXPECT_NEAR(-1.6, a.y(), 1e-10);
+}
+
+TEST_F(test_vectorx, sum_eq_int)
+{
+    gdal::Vector2i a(2, -3);
+    a += 1;
+    EXPECT_EQ(3, a.x());
+    EXPECT_EQ(-2, a.y());
+}
+
+TEST_F(test_vectorx, minus)
+{
+    const gdal::Vector2d a(2.1, -3.6);
+    const gdal::Vector2d b = a - 2.2;
+    EXPECT_NEAR(-0.1, b.x(), 1e-10);
+    EXPECT_NEAR(-5.8, b.y(), 1e-10);
+}
+
+TEST_F(test_vectorx, minus_eq)
+{
+    gdal::Vector2d a(2.1, -3.6);
+    a -= 2.0;
+    EXPECT_NEAR(0.1, a.x(), 1e-10);
+    EXPECT_NEAR(-5.6, a.y(), 1e-10);
+}
+
+TEST_F(test_vectorx, minus_eq_int)
+{
+    gdal::Vector2i a(2, -3);
+    a -= 1;
+    EXPECT_EQ(1, a.x());
+    EXPECT_EQ(-4, a.y());
+}
+
+TEST_F(test_vectorx, minus_op)
+{
+    gdal::Vector2d a(2.1, -3.6);
+    const auto b = -a;
+    EXPECT_NEAR(-2.1, b.x(), 1e-10);
+    EXPECT_NEAR(3.6, b.y(), 1e-10);
+}
+
+TEST_F(test_vectorx, multiply_int_double)
+{
+    gdal::Vector2i a(2, -3);
+    const auto b = a * 2.6;
+    static_assert(std::is_same_v<decltype(b)::value_type, int> == true);
+    EXPECT_EQ(5, b.x());
+    EXPECT_EQ(-7, b.y());
+}
+
+TEST_F(test_vectorx, multiply_double)
+{
+    gdal::Vector2d a(2.1, -3.2);
+    const auto b = a * 2.6;
+    EXPECT_NEAR(5.46, b.x(), 1e-10);
+    EXPECT_NEAR(-8.32, b.y(), 1e-10);
+}
+
+TEST_F(test_vectorx, divide_int_double)
+{
+    gdal::Vector2i a(4, -3);
+    const auto b = a / 2.2;
+    static_assert(std::is_same_v<decltype(b)::value_type, int> == true);
+    EXPECT_EQ(1, b.x());
+    EXPECT_EQ(-1, b.y());
+}
+
+TEST_F(test_vectorx, divide_double)
+{
+    gdal::Vector2d a(2.1, -3.2);
+    const auto b = a / 2.5;
+    EXPECT_NEAR(0.84, b.x(), 1e-10);
+    EXPECT_NEAR(-1.28, b.y(), 1e-10);
+}
+
+TEST_F(test_vectorx, plus_vectorx)
+{
+    const gdal::Vector2d a(2.1, -3.6);
+    const gdal::Vector2d b(10.0, 1.1);
+    const auto c = a + b;
+    EXPECT_NEAR(12.1, c.x(), 1e-10);
+    EXPECT_NEAR(-2.5, c.y(), 1e-10);
+}
+
+TEST_F(test_vectorx, minus_vectorx)
+{
+    const gdal::Vector2d a(2.1, -3.6);
+    const gdal::Vector2d b(10.0, 1.1);
+    const auto c = a - b;
+    EXPECT_NEAR(-7.9, c.x(), 1e-10);
+    EXPECT_NEAR(-4.7, c.y(), 1e-10);
+}
+
+TEST_F(test_vectorx, plus_scalar_vectorx)
+{
+    const gdal::Vector2d a(2.1, -3.6);
+    const auto b = 2.5 + a;
+    EXPECT_NEAR(4.6, b.x(), 1e-10);
+    EXPECT_NEAR(-1.1, b.y(), 1e-10);
+}
+
+TEST_F(test_vectorx, minus_scalar_vectorx)
+{
+    const gdal::Vector2d a(2.1, -3.6);
+    const auto b = 2.5 - a;
+    EXPECT_NEAR(0.4, b.x(), 1e-10);
+    EXPECT_NEAR(6.1, b.y(), 1e-10);
+}
+
+}  // namespace

--- a/gcore/gdal_vectorx.h
+++ b/gcore/gdal_vectorx.h
@@ -1,0 +1,291 @@
+/******************************************************************************
+ * Project:  GDAL Vector abstraction
+ * Purpose:
+ * Author:   Javier Jimenez Shaw
+ *
+ ******************************************************************************
+ * Copyright (c) 2024, Javier Jimenez Shaw
+ *
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#ifndef GDAL_VECTORX_H_INCLUDED
+#define GDAL_VECTORX_H_INCLUDED
+
+/*! @cond Doxygen_Suppress */
+
+#include <algorithm>
+#include <array>
+#include <functional>
+
+namespace gdal
+{
+
+/**
+ * @brief Template class to abstract a vector
+ *
+ * Inspired by Eigen3 Vector class, but much simpler.
+ * For GDAL internal use for now.
+ *
+ * @tparam T type of the values stored
+ * @tparam N size of the container/vector
+ */
+template <typename T, std::size_t N> class VectorX
+{
+  public:
+    using value_type = T;
+    using size_type = std::size_t;
+    using self_type = VectorX<T, N>;
+
+    /** Size of the container */
+    static constexpr size_type size() noexcept
+    {
+        return N;
+    }
+
+    VectorX()
+    {
+    }
+
+    // cppcheck-suppress noExplicitConstructor
+    template <typename... Args> VectorX(Args... args) : _values({args...})
+    {
+        static_assert(N == sizeof...(Args),
+                      "Invalid number of constructor params");
+    }
+
+    /** Container as an std::array */
+    const std::array<T, N> &array() const
+    {
+        return _values;
+    }
+
+    T &operator[](const size_type &pos)
+    {
+        return _values[pos];
+    }
+
+    const T &operator[](const size_type &pos) const
+    {
+        return _values[pos];
+    }
+
+    T x() const
+    {
+        static_assert(N >= 1, "Invalid template size for x()");
+        return _values[0];
+    }
+
+    T y() const
+    {
+        static_assert(N >= 2, "Invalid template size for y()");
+        return _values[1];
+    }
+
+    T z() const
+    {
+        static_assert(N >= 3, "Invalid template size for z()");
+        return _values[2];
+    }
+
+    T &x()
+    {
+        static_assert(N >= 1, "Invalid template size for x()");
+        return _values[0];
+    }
+
+    T &y()
+    {
+        static_assert(N >= 2, "Invalid template size for y()");
+        return _values[1];
+    }
+
+    T &z()
+    {
+        static_assert(N >= 3, "Invalid template size for z()");
+        return _values[2];
+    }
+
+    /** Fill all elements of the vector with the same value
+     * @return this
+     */
+    self_type &fill(T arg)
+    {
+        for (size_t i = 0; i < N; i++)
+            (*this)[i] = arg;
+
+        return *this;
+    }
+
+    /** Apply the unary operator to all the elements
+     * @param op unary opeartor to apply to every element
+     * @return a new object with the computed values
+     */
+    template <class UnaryOp> self_type apply(UnaryOp op) const
+    {
+        self_type res;
+        for (size_t i = 0; i < N; i++)
+            res[i] = op(_values[i]);
+        return res;
+    }
+
+    self_type floor() const
+    {
+        return apply([](const value_type &v) { return std::floor(v); });
+    }
+
+    self_type ceil() const
+    {
+        return apply([](const value_type &v) { return std::ceil(v); });
+    }
+
+    /** Compute the scalar product of two vectors */
+    T scalarProd(const self_type &arg) const
+    {
+        T accum{};
+        for (size_t i = 0; i < N; i++)
+            accum += _values[i] * arg[i];
+        return accum;
+    }
+
+    /** Compute the norm squared of the vector */
+    T norm2() const
+    {
+        return scalarProd(*this);
+    }
+
+    /**
+     * @brief cast the type to a different one, and convert the elements
+     *
+     * @tparam U output value type
+     * @return VectorX<U, N> object of new type, where all elements are casted
+     */
+    template <typename U> VectorX<U, N> cast() const
+    {
+        VectorX<U, N> res;
+        for (size_t i = 0; i < N; i++)
+            res[i] = static_cast<U>(_values[i]);
+        return res;
+    }
+
+    self_type operator+(T arg) const
+    {
+        return operatorImpl(arg, std::plus());
+    }
+
+    self_type &operator+=(T arg)
+    {
+        return operatorEqImpl(arg, std::plus());
+    }
+
+    self_type operator-(T arg) const
+    {
+        return operatorImpl(arg, std::minus());
+    }
+
+    self_type &operator-=(T arg)
+    {
+        return operatorEqImpl(arg, std::minus());
+    }
+
+    self_type operator-() const
+    {
+        return apply([](const value_type &v) { return -v; });
+    }
+
+    template <typename U> self_type operator*(U arg) const
+    {
+        self_type res;
+        for (size_t i = 0; i < N; i++)
+            res[i] = T(_values[i] * arg);
+        return res;
+    }
+
+    self_type operator*(T arg) const
+    {
+        return operatorImpl(arg, std::multiplies());
+    }
+
+    template <typename U> self_type operator/(U arg) const
+    {
+        self_type res;
+        for (size_t i = 0; i < N; i++)
+            res[i] = T(_values[i] / arg);
+        return res;
+    }
+
+    self_type operator/(T arg) const
+    {
+        return operatorImpl(arg, std::divides());
+    }
+
+    self_type operator+(const self_type &arg) const
+    {
+        return operatorImpl(arg, std::plus());
+    }
+
+    self_type operator-(const self_type &arg) const
+    {
+        return operatorImpl(arg, std::minus());
+    }
+
+    friend VectorX<T, N> operator+(T t, const VectorX<T, N> &arg)
+    {
+        VectorX<T, N> res;
+        for (size_t i = 0; i < N; i++)
+            res._values[i] = t + arg._values[i];
+        return res;
+    }
+
+    friend VectorX<T, N> operator-(T t, const VectorX<T, N> &arg)
+    {
+        VectorX<T, N> res;
+        for (size_t i = 0; i < N; i++)
+            res._values[i] = t - arg._values[i];
+        return res;
+    }
+
+  private:
+    std::array<T, N> _values{};
+
+    template <class Op> self_type operatorImpl(T arg, Op op) const
+    {
+        self_type res;
+        for (size_t i = 0; i < N; i++)
+            res[i] = op(_values[i], arg);
+        return res;
+    }
+
+    template <class Op> self_type &operatorEqImpl(T arg, Op op)
+    {
+        for (size_t i = 0; i < N; i++)
+            _values[i] = op(_values[i], arg);
+        return *this;
+    }
+
+    template <class Op>
+    self_type operatorImpl(const self_type &arg, Op op) const
+    {
+        self_type res;
+        for (size_t i = 0; i < N; i++)
+            res[i] = op(_values[i], arg[i]);
+        return res;
+    }
+
+    template <class Op> self_type &operatorEqImpl(const self_type &arg, Op op)
+    {
+        for (size_t i = 0; i < N; i++)
+            _values[i] = op(_values[i], arg[i]);
+        return *this;
+    }
+};
+
+using Vector2d = VectorX<double, 2>;
+using Vector2i = VectorX<int, 2>;
+using Vector3d = VectorX<double, 3>;
+using Vector3i = VectorX<int, 3>;
+}  // namespace gdal
+
+/*! @endcond */
+
+#endif /* ndef GDAL_VECTORX_H_INCLUDED */


### PR DESCRIPTION
## What does this PR do?
During my work on the file `alg/gdal_interpolateatpoint.cpp`, I saw that there was a repetitive pattern: doing everything on X and Y. Both as integer to manage the pixel, and as double to use the coordinates in the image.

I missed a functionality where x,y (or even x,y,z) could be used as an object, and do some basic operations on that, like subtract another point, multiply by a factor, etc. Something I am used to with Eigen library.

Once that development was finished I tried something, to see if it makes sense. This is it.

The main feature is the template class `VectorX`. Both the size and type are templated. You can make it double, int, even complex<double>. Size can be any, but I think the most common would be 2, maybe 3. Four predefined types are included: `Vector2i`, `Vector3i`, `Vector2d`, `Vector3d`


This PR is using it only in `alg/gdal_interpolateatpoint.cpp`.

**The idea is to use it internally. Not in any public API.**

It should make the code more readable, and I hope it will help to not forget the Y or the X during developments.

What do you think? Is it useful? In case it is included, I don't expect a massive migration, but just start using it when it is convenient.

## What are related issues/pull requests?
#10461, #10506, #10570

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
