### PR TITLE
Docs: fix incorrect and missing World Files references (GIF, GTiff, JP2MrSID, JPEG, GTiff, PNG)

### DIFF
--- a/doc/source/drivers/raster/gif.rst
+++ b/doc/source/drivers/raster/gif.rst
@@ -16,8 +16,9 @@ A GIF image with transparency will have that entry marked as having an
 alpha value of 0.0 (transparent). Also, the transparent value will be
 returned as the NoData value for the band.
 
-If an ESRI world file exists with the .gfw, .gifw or .wld extension, it
-will be read and used to establish the geotransform for the image.
+If an ESRI :ref:`world file <raster.wld>` exists with the .gfw, .gifw
+or .wld extension, it will be read and used to establish the geotransform
+for the image.
 
 XMP metadata can be extracted from the file,
 and will be stored as XML raw content in the xml:XMP metadata domain.
@@ -45,6 +46,7 @@ The following creation options are supported:
      :default: OFF
 
      Force the generation of an associated ESRI world file (.wld).
+     See :ref:`World Files <raster.wld>` section for details.
 
 - .. co:: INTERLACING
      :choices: ON, OFF

--- a/doc/source/drivers/raster/gtiff.rst
+++ b/doc/source/drivers/raster/gtiff.rst
@@ -397,7 +397,7 @@ This driver supports the following creation options:
       :choices: YES, NO
 
       Force the generation of an associated ESRI world file
-      (.tfw).See the :ref:`World Files <raster.wld>` page for details.
+      (.tfw). See the :ref:`World Files <raster.wld>` page for details.
 
 -  .. co:: RPB
       :choices: YES, NO

--- a/doc/source/drivers/raster/jp2mrsid.rst
+++ b/doc/source/drivers/raster/jp2mrsid.rst
@@ -27,10 +27,10 @@ Georeferencing
 --------------
 
 Georeferencing information can come from different sources : internal
-(GeoJP2 or GMLJP2 boxes), worldfile .j2w/.wld sidecar files, or PAM
-(Persistent Auxiliary metadata) .aux.xml sidecar files. By default,
-information is fetched in following order (first listed is the highest
-priority): PAM, GeoJP2, GMLJP2, WORLDFILE.
+(GeoJP2 or GMLJP2 boxes), :ref:`worldfile <raster.wld>` .j2w/.wld sidecar
+files, or PAM (Persistent Auxiliary metadata) .aux.xml sidecar files. By
+default, information is fetched in following order (first listed is the
+highest priority): PAM, GeoJP2, GMLJP2, WORLDFILE.
 
 Starting with GDAL 2.2, the allowed sources and their priority order can
 be changed with the :config:`GDAL_GEOREF_SOURCES` configuration option (or
@@ -70,6 +70,7 @@ The following creation options are supported.
       :choices: YES
 
       to write an ESRI world file (with the extension .j2w).
+      See :ref:`World Files <raster.wld>` section for details.
 
 -  .. co:: COMPRESSION
 

--- a/doc/source/drivers/raster/jpeg.rst
+++ b/doc/source/drivers/raster/jpeg.rst
@@ -20,8 +20,8 @@ IMAGE_STRUCTURE domain.
 
 EXIF metadata can be read from JPEG files (but this will not result in a
 georeferenced image even if the EXIF_GPSLatitude and EXIF_GPSLongitude
-tags are set). But if an ESRI world file exists with the .jgw,
-.jpgw/.jpegw or .wld suffixes, it will be read and used to establish the
+tags are set). But if an ESRI :ref:`world file <raster.wld>` exists with the
+.jgw, .jpgw/.jpegw or .wld suffixes, it will be read and used to establish the
 geotransform for the image. If available a MapInfo .tab file will also
 be used for georeferencing. Overviews can be built for JPEG files as an
 external .ovr file.
@@ -169,7 +169,8 @@ The following creation options are supported:
       :choices: YES
 
       Force the generation of an associated ESRI world
-      file (with the extension .wld).
+      file (with the extension .wld). See :ref:`World Files <raster.wld>`
+      section for details.
 
 -  .. co:: QUALITY
       :choices: 1-100

--- a/doc/source/drivers/raster/png.rst
+++ b/doc/source/drivers/raster/png.rst
@@ -74,8 +74,8 @@ The following creation options are available:
       :default: NO
 
       Force the generation of an associated ESRI world
-      file (with the extension .wld). See `World File <#WLD>`__ section for
-      details.
+      file (with the extension .wld). See :ref:`World Files <raster.wld>`
+      section for details.
 
 -  .. co:: ZLEVEL=n
       :choices: [1-9]


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

Fixes incorrect / missing / typos World Files references in GIF, GTiff, JP2MrSID, JPEG, GTiff and PNG drivers' docs.

## What are related issues/pull requests?

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
