### PR TITLE
doc: gti typo (and some others)

### DIFF
--- a/alg/viewshed/viewshed.cpp
+++ b/alg/viewshed/viewshed.cpp
@@ -48,7 +48,7 @@
  * by using a modified algorithm of "Generating Viewsheds without Using
  * Sightlines" published at
  * https://www.asprs.org/wp-content/uploads/pers/2000journal/january/2000_jan_87-90.pdf
- * This appoach provides a relatively fast calculation, since the output raster
+ * This approach provides a relatively fast calculation, since the output raster
  * is generated in a single scan. The gdal/apps/gdal_viewshed.cpp mainline can
  * be used as an example of how to use this function. The output raster will be
  * of type Byte or Float64.

--- a/doc/source/development/rfc/rfc12_filemanagement.rst
+++ b/doc/source/development/rfc/rfc12_filemanagement.rst
@@ -24,7 +24,7 @@ GetFileList()
 -------------
 
 The following new virtual method is added on the GDALDataset class, with
-an analygous C function.
+an analogous C function.
 
 ::
 

--- a/doc/source/drivers/raster/gti.rst
+++ b/doc/source/drivers/raster/gti.rst
@@ -176,7 +176,7 @@ PostGIS, ...), the following layer metadata items may be set:
   virtual mosaic (unless SORT_FIELD_ASC=NO is set)
 
 * ``SORT_FIELD_ASC=YES|NO``: whether the values in SORT_FIELD should be sorted
-  in ascendent or descent order. Defaults to YES (ascendent)
+  in ascending or descending order. Defaults to YES (ascending)
 
 * ``BLOCKXSIZE=<int>`` and ``BLOCKYSIZE=<int>``: Block size of bands of the
   virtual mosaic. Defaults to 256x256.
@@ -380,13 +380,13 @@ You can refer to the documentation of the :ref:`VRT <raster.vrt>` driver for
 their syntax and semantics.
 
 
-How to build a GTI comptatible index ?
+How to build a GTI compatible index ?
 ----------------------------------------
 
 The :ref:`gdaltindex` program may be used to generate both a vector tile index,
 and optionally a wrapping .gti XML file.
 
-A GTI comptatible index may also be created by any programmatic means, provided
+A GTI compatible index may also be created by any programmatic means, provided
 the above format specifications are met.
 
 
@@ -426,7 +426,7 @@ also defined as layer metadata items or in the .gti XML file
       :choices: YES, NO
       :default: YES
 
-      Whether the values in SORT_FIELD should be sorted in ascendent or descent order
+      Whether the values in SORT_FIELD should be sorted in ascending or descending order
 
 -  .. oo:: FILTER
       :choices: <string>

--- a/doc/source/drivers/raster/nitf.rst
+++ b/doc/source/drivers/raster/nitf.rst
@@ -146,7 +146,7 @@ The following creation options are available:
       :choices: -1, 0, >0
       :default: -1
 
-      Restart interval (in MCUs) for JPEG compressoin.
+      Restart interval (in MCUs) for JPEG compression.
       -1 for auto, 0 for none, > 0 for user specified.
 
 -  .. co:: NUMI

--- a/doc/source/drivers/vector/csv.rst
+++ b/doc/source/drivers/vector/csv.rst
@@ -84,7 +84,7 @@ per line must be present. Lines may be terminated by a DOS (CR/LF) or
 Unix (LF) style line terminators. Each record should have the same
 number of fields. The driver will also accept a semicolon, a tabulation,
 a pipe, or a space character as field separator.
-Starting with GDAL 3.8, the autodection will select the separator with the
+Starting with GDAL 3.8, the autodetection will select the separator with the
 most occurrences if there are several candidates  on the first line of the CSV
 file (and warn about that). The :oo:`SEPARATOR` open option may also be set to
 define the desired separator.

--- a/doc/source/spelling_wordlist.txt
+++ b/doc/source/spelling_wordlist.txt
@@ -58,7 +58,6 @@ Amici
 amongst
 amz
 Amz
-analygous
 analyse
 Analyse
 analysing
@@ -79,7 +78,6 @@ api
 Api
 apoNewDims
 apploy
-appoach
 approximator
 AppVeyor
 APSTILE
@@ -97,7 +95,6 @@ arra
 Arrayname
 arrayStartIdx
 ASC
-ascendent
 ascii
 askin
 aspatial
@@ -133,7 +130,7 @@ autocommit
 autoconf
 Autoconf
 autocorrelation
-autodection
+autodetection
 Autodesk
 autodetect
 autodetected
@@ -439,9 +436,6 @@ ComplexSource
 compoundcurves
 compressiblity
 compressions
-compressoin
-comptatible
-Conceptionally
 conceptualhelp
 cond
 conda

--- a/gcore/gdaldataset.cpp
+++ b/gcore/gdaldataset.cpp
@@ -544,7 +544,7 @@ void GDALDataset::AddToDatasetOpenList()
  *
  * The default implementation of this method just calls the FlushCache() method
  * on each of the raster bands and the SyncToDisk() method
- * on each of the layers.  Conceptionally, calling FlushCache() on a dataset
+ * on each of the layers.  Conceptually, calling FlushCache() on a dataset
  * should include any work that might be accomplished by calling SyncToDisk()
  * on layers in that dataset.
  *

--- a/swig/java/javadoc.java
+++ b/swig/java/javadoc.java
@@ -6336,7 +6336,7 @@ ogr.OGRERR_NONE.  An error is only returned if an error occurs while attempting
 to flush to disk.
 <p>
 The default implementation of this method just calls the SyncToDisk() method
-on each of the layers.  Conceptionally, calling SyncToDisk() on a datasource
+on each of the layers.  Conceptually, calling SyncToDisk() on a datasource
 should include any work that might be accomplished by calling SyncToDisk()
 on layers in that data source.
 <p>


### PR DESCRIPTION
Just a start here, will review the spelling list qnd have more PRs to come.

doc, small typos in 

- GTI driver
- NITF (found when updating the spelling list for GTI)
- core gdaldataset
- swig javadoc

