### PR TITLE
Fix build issue of external code including gdal_priv.h with MSVC (master only)

### DIFF
--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -1625,7 +1625,7 @@ class CPL_DLL GDALRasterBand : public GDALMajorObject
     void InitRWLock();
     void SetValidPercent(GUIntBig nSampleCount, GUIntBig nValidCount);
 
-    mutable std::unique_ptr<GDALDoublePointsCache> m_oPointsCache{};
+    mutable GDALDoublePointsCache *m_poPointsCache = nullptr;
 
     //! @endcond
 

--- a/gcore/gdalrasterband.cpp
+++ b/gcore/gdalrasterband.cpp
@@ -107,6 +107,8 @@ GDALRasterBand::~GDALRasterBand()
 
     InvalidateMaskBand();
     nBand = -nBand;
+
+    delete m_poPointsCache;
 }
 
 /************************************************************************/
@@ -9398,11 +9400,11 @@ CPLErr GDALRasterBand::InterpolateAtPoint(double dfPixel, double dfLine,
     }
 
     GDALRasterBand *pBand = const_cast<GDALRasterBand *>(this);
-    if (!m_oPointsCache)
-        m_oPointsCache = std::make_unique<GDALDoublePointsCache>();
+    if (!m_poPointsCache)
+        m_poPointsCache = new GDALDoublePointsCache();
 
     const bool res =
-        GDALInterpolateAtPoint(pBand, eInterpolation, m_oPointsCache->cache,
+        GDALInterpolateAtPoint(pBand, eInterpolation, m_poPointsCache->cache,
                                dfPixel, dfLine, pdfRealValue, pdfImagValue);
 
     return res ? CE_None : CE_Failure;


### PR DESCRIPTION
MSVC complains about "use of undefined type 'GDALDoublePointsCache'" since presumably it tries to locate the destructor of GDALDoublePointsCache, to which it doesn't have access
