### PR TITLE
OpenFileGDB: Fixed the problem of not excluding straight line segments when parsin…

### DIFF
--- a/ogr/ogrpgeogeometry.cpp
+++ b/ogr/ogrpgeogeometry.cpp
@@ -2451,7 +2451,8 @@ OGRErr OGRCreateFromShapeBin(GByte *pabyShape, OGRGeometry **ppoGeom,
                     if (nBits & EXT_SHAPE_ARC_IP)
                         CPLDebug("OGR", "  DefinedIP");
 #endif
-                    if ((nBits & EXT_SHAPE_ARC_IP) != 0)
+                    if ((nBits & EXT_SHAPE_ARC_IP) != 0 &&
+                        (nBits & EXT_SHAPE_ARC_LINE) == 0)
                     {
                         pasCurves[iCurve].eType = CURVE_ARC_INTERIOR_POINT;
                         pasCurves[iCurve].u.ArcByIntermediatePoint.dfX = dfVal1;


### PR DESCRIPTION
Fixed the problem of not excluding straight line segments when parsing arcs.

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?
Fixed the problem of not excluding straight line segments when parsing circular arcs as `CURVE_ARC_INTERIOR_POINT` type.

## What are related issues/pull requests?
When using openfilegdb driver to parse circular arc data in filegdb, circular arc is mistakenly parsed as `CURVE_ARC_INTERIOR_POINT` when it is a line.

ArcGIS:
![image](https://github.com/user-attachments/assets/c2876cef-c37c-43fe-b182-f87251b38e04)

QGIS:
![image](https://github.com/user-attachments/assets/89d7a6bc-dac6-466f-9f09-c58a5a39a739)

This is the result of parsing the arc control point. It is actually a line, but it is classified as `CURVE_ARC_INTERIOR_POINT`:
![image](https://github.com/user-attachments/assets/0ce9ce8b-d0aa-4b63-8dbd-ccf5472bd33a)

