### PR TITLE
gdal_rasterize: fix (workaround) regressions related to argparse for -b / -burn / -init arguments (master only)

### DIFF
--- a/apps/gdal_rasterize_lib.cpp
+++ b/apps/gdal_rasterize_lib.cpp
@@ -104,12 +104,12 @@ GDALRasterizeOptionsGetParser(GDALRasterizeOptions *psOptions,
         _("This program burns vector geometries (points, lines, and polygons) "
           "into the raster band(s) of a raster image."));
 
+    // Dealt manually as argparse::nargs_pattern::at_least_one is problematic
     argParser->add_argument("-b")
         .metavar("<band>")
         .append()
         .scan<'i', int>()
         .nargs(argparse::nargs_pattern::at_least_one)
-        .store_into(psOptions->anBandList)
         .help(_("The band(s) to burn values into."));
 
     argParser->add_argument("-i")
@@ -132,22 +132,12 @@ GDALRasterizeOptionsGetParser(GDALRasterizeOptions *psOptions,
         auto &group = argParser->add_mutually_exclusive_group(
             psOptionsForBinary != nullptr);
 
+        // Dealt manually as argparse::nargs_pattern::at_least_one is problematic
         group.add_argument("-burn")
             .metavar("<value>")
             .scan<'g', double>()
             .append()
-            .nargs(argparse::nargs_pattern::at_least_one)
-            .action(
-                [psOptions](const std::string &s)
-                {
-                    const CPLStringList aosTokens(
-                        CSLTokenizeString2(s.c_str(), " ", 0));
-                    for (int i = 0; i < aosTokens.size(); i++)
-                    {
-                        psOptions->adfBurnValues.push_back(
-                            CPLAtof(aosTokens[i]));
-                    }
-                })
+            //.nargs(argparse::nargs_pattern::at_least_one)
             .help(_("A fixed value to burn into the raster band(s)."));
 
         group.add_argument("-a")
@@ -238,22 +228,12 @@ GDALRasterizeOptionsGetParser(GDALRasterizeOptions *psOptions,
         .metavar("<value>")
         .help(_("Assign a specified nodata value to output bands."));
 
+    // Dealt manually as argparse::nargs_pattern::at_least_one is problematic
     argParser->add_argument("-init")
         .metavar("<value>")
         .append()
         .nargs(argparse::nargs_pattern::at_least_one)
         .scan<'g', double>()
-        .action(
-            [psOptions](const std::string &s)
-            {
-                const CPLStringList aosTokens(
-                    CSLTokenizeString2(s.c_str(), " ", 0));
-                for (int i = 0; i < aosTokens.size(); i++)
-                {
-                    psOptions->adfInitVals.push_back(CPLAtof(aosTokens[i]));
-                }
-                psOptions->bCreateOutput = true;
-            })
         .help(_("Initialize the output bands to the specified value."));
 
     argParser->add_argument("-a_srs")
@@ -1279,6 +1259,18 @@ GDALDatasetH GDALRasterize(const char *pszDest, GDALDatasetH hDstDS,
 }
 
 /************************************************************************/
+/*                       ArgIsNumericRasterize()                        */
+/************************************************************************/
+
+static bool ArgIsNumericRasterize(const char *pszArg)
+
+{
+    char *pszEnd = nullptr;
+    CPLStrtod(pszArg, &pszEnd);
+    return pszEnd != nullptr && pszEnd[0] == '\0';
+}
+
+/************************************************************************/
 /*                           GDALRasterizeOptionsNew()                  */
 /************************************************************************/
 
@@ -1328,11 +1320,80 @@ GDALRasterizeOptionsNew(char **papszArgv,
             psOptions->osNoData = s;
             psOptions->bCreateOutput = true;
         }
-    }
 
-    if (papszArgv)
-    {
-        for (int i = 0; papszArgv[i] != nullptr; i++)
+        // argparser is confused by arguments that have at_least_one
+        // cardinality, if they immediately precede positional arguments.
+        else if (EQUAL(papszArgv[i], "-burn") && papszArgv[i + 1])
+        {
+            if (strchr(papszArgv[i + 1], ' '))
+            {
+                const CPLStringList aosTokens(
+                    CSLTokenizeString(papszArgv[i + 1]));
+                for (const char *pszToken : aosTokens)
+                {
+                    psOptions->adfBurnValues.push_back(CPLAtof(pszToken));
+                }
+                i += 1;
+            }
+            else
+            {
+                while (i < argc - 1 && ArgIsNumericRasterize(papszArgv[i + 1]))
+                {
+                    psOptions->adfBurnValues.push_back(
+                        CPLAtof(papszArgv[i + 1]));
+                    i += 1;
+                }
+            }
+
+            // Dummy value to make argparse happy, as at least one of
+            // -burn, -a or -3d is required
+            aosArgv.AddString("-burn");
+            aosArgv.AddString("0");
+        }
+        else if (EQUAL(papszArgv[i], "-init") && papszArgv[i + 1])
+        {
+            if (strchr(papszArgv[i + 1], ' '))
+            {
+                const CPLStringList aosTokens(
+                    CSLTokenizeString(papszArgv[i + 1]));
+                for (const char *pszToken : aosTokens)
+                {
+                    psOptions->adfInitVals.push_back(CPLAtof(pszToken));
+                }
+                i += 1;
+            }
+            else
+            {
+                while (i < argc - 1 && ArgIsNumericRasterize(papszArgv[i + 1]))
+                {
+                    psOptions->adfInitVals.push_back(CPLAtof(papszArgv[i + 1]));
+                    i += 1;
+                }
+            }
+            psOptions->bCreateOutput = true;
+        }
+        else if (EQUAL(papszArgv[i], "-b") && papszArgv[i + 1])
+        {
+            if (strchr(papszArgv[i + 1], ' '))
+            {
+                const CPLStringList aosTokens(
+                    CSLTokenizeString(papszArgv[i + 1]));
+                for (const char *pszToken : aosTokens)
+                {
+                    psOptions->anBandList.push_back(atoi(pszToken));
+                }
+                i += 1;
+            }
+            else
+            {
+                while (i < argc - 1 && ArgIsNumericRasterize(papszArgv[i + 1]))
+                {
+                    psOptions->anBandList.push_back(atoi(papszArgv[i + 1]));
+                    i += 1;
+                }
+            }
+        }
+        else
         {
             aosArgv.AddString(papszArgv[i]);
         }

--- a/apps/gdal_rasterize_lib.cpp
+++ b/apps/gdal_rasterize_lib.cpp
@@ -109,7 +109,7 @@ GDALRasterizeOptionsGetParser(GDALRasterizeOptions *psOptions,
         .metavar("<band>")
         .append()
         .scan<'i', int>()
-        .nargs(argparse::nargs_pattern::at_least_one)
+        //.nargs(argparse::nargs_pattern::at_least_one)
         .help(_("The band(s) to burn values into."));
 
     argParser->add_argument("-i")
@@ -232,7 +232,7 @@ GDALRasterizeOptionsGetParser(GDALRasterizeOptions *psOptions,
     argParser->add_argument("-init")
         .metavar("<value>")
         .append()
-        .nargs(argparse::nargs_pattern::at_least_one)
+        //.nargs(argparse::nargs_pattern::at_least_one)
         .scan<'g', double>()
         .help(_("Initialize the output bands to the specified value."));
 

--- a/autotest/utilities/test_gdal_rasterize.py
+++ b/autotest/utilities/test_gdal_rasterize.py
@@ -425,7 +425,7 @@ def test_gdal_rasterize_8(gdal_rasterize_path, tmp_path):
     f.write('"LINESTRING (0 0, 5 5, 10 0, 10 10)",1'.encode("ascii"))
     f.close()
 
-    cmds = f"""{input_csv} {output_tif} -init 0 -burn 1 -tr 1 1"""
+    cmds = f"""{input_csv} {output_tif} -tr 1 1 -init 0 -burn 1"""
 
     gdaltest.runexternal(gdal_rasterize_path + " " + cmds)
 


### PR DESCRIPTION
Fixes #10766

argparser is confused by arguments that have at_least_one cardinality, if they immediately precede positional arguments, which is quite undersandable, because if we suppose that we have a -foo argument that takes strings. How would the parser be supposed to distinguish values of -foo from positional filename argument in: ``-foo value1 value2 filename`` ... ? For numeric values, it could probably be tweaked to correctly separate. The problem is that the parse stage doesn't know the type of values of an argument (as they are actions like others...). So my take is that is would be hard to fix argparse to deal with that without significant changes in its code. Basically, currently at_least_one cardinality only works for the last positional argument, and nothing else.
Hum actually my above theory is not completely right ... I see an interesting test case in https://github.com/p-ranav/argparse/blob/master/test/test_optional_arguments.cpp#L147 where there are both nargs_pattern::any positional and non-positional arguments. But in that case, the positional arguments must be specified first ...
For now, let's live with our workaround...