### PR TITLE
autotest/ogr/ogr_ogrtest.py: fix with GEOS 3.13

### DIFF
--- a/autotest/ogr/ogr_ogrtest.py
+++ b/autotest/ogr/ogr_ogrtest.py
@@ -87,7 +87,7 @@ def test_check_geometry_equals_ngeoms_mismatch():
 
 def test_check_geometry_equals_orientation_differs():
     poly_ccw = ogr.CreateGeometryFromWkt("POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))")
-    poly_cw = ogr.CreateGeometryFromWkt("POLYGON ((0 0, 0 1, 1 1, 0 1, 0 0))")
+    poly_cw = ogr.CreateGeometryFromWkt("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))")
 
     if ogrtest.have_geos():
         ogrtest.check_feature_geometry(poly_ccw, poly_cw)


### PR DESCRIPTION
The ogrtest.check_feature_geometry(poly_ccw, poly_cw) used to wrongly pass with earlier GEOS versions!