### PR TITLE
Make OGRSFDriver::TestCapability(ODrCCreateDataSource) work with defered-loaded drivers

### DIFF
--- a/ogr/ogrsf_frmts/generic/ogrsfdriver.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrsfdriver.cpp
@@ -173,7 +173,8 @@ int OGR_Dr_TestCapability(OGRSFDriverH hDriver, const char *pszCap)
     GDALDriver *poDriver = reinterpret_cast<GDALDriver *>(hDriver);
     if (EQUAL(pszCap, ODrCCreateDataSource))
     {
-        return poDriver->pfnCreate != nullptr ||
+        return poDriver->GetMetadataItem(GDAL_DCAP_CREATE) ||
+               poDriver->pfnCreate != nullptr ||
                poDriver->pfnCreateVectorOnly != nullptr;
     }
     else if (EQUAL(pszCap, ODrCDeleteDataSource))


### PR DESCRIPTION
Fixes #10783