### PR TITLE
autotest: fixes for SWIG master

### DIFF
--- a/autotest/gcore/relationship.py
+++ b/autotest/gcore/relationship.py
@@ -35,7 +35,7 @@ from osgeo import gdal
 
 def test_gdal_relationship():
 
-    with pytest.raises(ValueError):
+    with pytest.raises(Exception):
         gdal.Relationship(None, None, None, gdal.GRC_ONE_TO_ONE)
 
     relationship = gdal.Relationship(

--- a/autotest/gcore/vsifile.py
+++ b/autotest/gcore/vsifile.py
@@ -776,12 +776,8 @@ def test_vsifile_19():
 
 def test_vsifile_20():
 
-    try:
+    with pytest.raises(Exception):
         gdal.VSIFReadL(1, 1, None)
-    except ValueError:
-        return
-
-    pytest.fail()
 
 
 ###############################################################################
@@ -1710,7 +1706,7 @@ def test_vsifile_MultipartUpload():
         with gdal.quiet_errors():
             assert gdal.MultipartUploadGetCapabilities("foo") is None
     with gdal.ExceptionMgr(useExceptions=True):
-        with pytest.raises(ValueError):
+        with pytest.raises(Exception):
             gdal.MultipartUploadGetCapabilities(None)
 
         with pytest.raises(
@@ -1719,7 +1715,7 @@ def test_vsifile_MultipartUpload():
         ):
             gdal.MultipartUploadGetCapabilities("foo")
 
-        with pytest.raises(ValueError):
+        with pytest.raises(Exception):
             gdal.MultipartUploadStart(None)
 
         with pytest.raises(
@@ -1728,9 +1724,9 @@ def test_vsifile_MultipartUpload():
         ):
             gdal.MultipartUploadStart("foo")
 
-        with pytest.raises(ValueError):
+        with pytest.raises(Exception):
             gdal.MultipartUploadAddPart(None, "", 1, 0, b"")
-        with pytest.raises(ValueError):
+        with pytest.raises(Exception):
             gdal.MultipartUploadAddPart("", None, 1, 0, b"")
 
         with pytest.raises(
@@ -1739,9 +1735,9 @@ def test_vsifile_MultipartUpload():
         ):
             gdal.MultipartUploadAddPart("", "", 1, 0, b"")
 
-        with pytest.raises(ValueError):
+        with pytest.raises(Exception):
             gdal.MultipartUploadEnd(None, "", [], 0)
-        with pytest.raises(ValueError):
+        with pytest.raises(Exception):
             gdal.MultipartUploadEnd("", None, [], 0)
 
         with pytest.raises(
@@ -1750,9 +1746,9 @@ def test_vsifile_MultipartUpload():
         ):
             gdal.MultipartUploadEnd("", "", [], 0)
 
-        with pytest.raises(ValueError):
+        with pytest.raises(Exception):
             gdal.MultipartUploadAbort(None, "")
-        with pytest.raises(ValueError):
+        with pytest.raises(Exception):
             gdal.MultipartUploadAbort("", None)
 
         with pytest.raises(

--- a/autotest/gdrivers/memmultidim.py
+++ b/autotest/gdrivers/memmultidim.py
@@ -90,7 +90,7 @@ def test_mem_md_subgroup():
 
     with gdal.quiet_errors():
         assert not rg.CreateGroup("")  # unnamed group not supported
-    with pytest.raises(ValueError):
+    with pytest.raises(Exception):
         assert not rg.CreateGroup(None)
 
     subg = rg.CreateGroup("subgroup")
@@ -339,12 +339,12 @@ def test_mem_md_datatypes():
     assert dt_byte.GetNumericDataType() == gdal.GDT_Byte
     assert dt_byte.GetSize() == 1
     assert dt_byte.CanConvertTo(dt_byte)
-    with pytest.raises(ValueError):
+    with pytest.raises(Exception):
         assert dt_byte.CanConvertTo(None)
     assert dt_byte == gdal.ExtendedDataType.Create(gdal.GDT_Byte)
     assert not dt_byte != gdal.ExtendedDataType.Create(gdal.GDT_Byte)
     assert dt_byte.Equals(dt_byte)
-    with pytest.raises(ValueError):
+    with pytest.raises(Exception):
         assert dt_byte.Equals(None)
     assert not dt_byte.GetComponents()
 
@@ -762,9 +762,9 @@ def test_mem_md_array_invalid_args():
         rg.CreateMDArray("myarray", [None], edt)
     with pytest.raises((TypeError, SystemError)):
         rg.CreateMDArray("myarray", [1], edt)
-    with pytest.raises(ValueError):
+    with pytest.raises(Exception):
         rg.CreateMDArray("myarray", [dim], None)
-    with pytest.raises(ValueError):
+    with pytest.raises(Exception):
         rg.CreateMDArray(None, [dim], edt)
 
 
@@ -837,7 +837,7 @@ def test_mem_md_group_attribute_single_numeric():
     float64dt = gdal.ExtendedDataType.Create(gdal.GDT_Float64)
     with gdal.quiet_errors():
         assert not rg.CreateAttribute("", [1], float64dt)  # unnamed attr not supported
-    with pytest.raises(ValueError):
+    with pytest.raises(Exception):
         rg.CreateAttribute(None, [1], float64dt)
 
     attr = rg.CreateAttribute("attr", [1], float64dt)
@@ -955,7 +955,7 @@ def test_mem_md_array_attribute():
         assert not myarray.CreateAttribute(
             "", [1], float64dt
         )  # unnamed attr not supported
-    with pytest.raises(ValueError):
+    with pytest.raises(Exception):
         myarray.CreateAttribute(None, [1], float64dt)
 
     attr = myarray.CreateAttribute("attr", [1], float64dt)

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -4102,7 +4102,7 @@ def DISABLED_test_gdalwarp_lib_to_projection_without_inverse_method():
 def test_gdalwarp_lib_no_crash_on_none_dst():
 
     ds1 = gdal.Open("../gcore/data/byte.tif")
-    with pytest.raises(ValueError):
+    with pytest.raises(Exception):
         gdal.Warp(None, ds1)
 
 


### PR DESCRIPTION
Commit https://github.com/swig/swig/commit/9bf4842002b34e11a310a9691bd07c2e1ec6df94 changed the Python exception emitted on NULL detection from ValueError to TypeError
