### PR TITLE
CI: Fix ReadTheDocs test for [ci skip] with multiline commit messages

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ build:
 
   jobs:
     post_checkout:
-      - (git --no-pager log --pretty="tformat:%s -- %b" -1 | grep -viqP "skip ci|ci skip") || exit 183
+      - (git --no-pager log --pretty="tformat:%s -- %b" -1 | paste -s -d " " | grep -viqP "skip ci|ci skip") || exit 183
     pre_build:
       - ./doc/rtd/pre_build.sh
       - cd doc && make doxygen generated_rst_files


### PR DESCRIPTION
git log will emit a blank line which passes the grep -v test and prevents exiting.