### PR TITLE
Speed-up geolocation-array based warping of Sentinel3 datasets

### DIFF
--- a/alg/gdalgeoloc.cpp
+++ b/alg/gdalgeoloc.cpp
@@ -2007,7 +2007,7 @@ void *GDALCreateGeoLocTransformerEx(GDALDatasetH hBaseDS,
     else
     {
         psTransform->bUseArray = nXSize < 16 * 1000 * 1000 / nYSize;
-        if (psTransform->bUseArray)
+        if (!psTransform->bUseArray)
         {
             CPLDebug("GEOLOC",
                      "Using temporary GTiff backing to store backmap, because "

--- a/alg/gdalgeoloc.cpp
+++ b/alg/gdalgeoloc.cpp
@@ -2006,14 +2006,20 @@ void *GDALCreateGeoLocTransformerEx(GDALDatasetH hBaseDS,
         psTransform->bUseArray = !CPLTestBool(pszUseTempDatasets);
     else
     {
-        psTransform->bUseArray = nXSize < 16 * 1000 * 1000 / nYSize;
+        constexpr int MEGAPIXEL_LIMIT = 24;
+        psTransform->bUseArray =
+            nXSize < MEGAPIXEL_LIMIT * 1000 * 1000 / nYSize;
         if (!psTransform->bUseArray)
         {
             CPLDebug("GEOLOC",
                      "Using temporary GTiff backing to store backmap, because "
-                     "geoloc arrays exceed 16 megapixels. You can set the "
+                     "geoloc arrays require %d megapixels, exceeding the %d "
+                     "megapixels limit. You can set the "
                      "GDAL_GEOLOC_USE_TEMP_DATASETS configuration option to "
-                     "NO to force RAM storage of backmap");
+                     "NO to force RAM storage of backmap",
+                     static_cast<int>(static_cast<int64_t>(nXSize) * nYSize /
+                                      (1000 * 1000)),
+                     MEGAPIXEL_LIMIT);
         }
     }
 

--- a/alg/gdalgeoloc_dataset_accessor.h
+++ b/alg/gdalgeoloc_dataset_accessor.h
@@ -53,13 +53,14 @@ class GDALGeoLocDatasetAccessors
     bool LoadGeoloc(bool bIsRegularGrid);
 
   public:
-    static constexpr int TILE_SIZE = 1024;
+    static constexpr int TILE_SIZE = 256;
+    static constexpr int TILE_COUNT = 64;
 
-    GDALCachedPixelAccessor<double, TILE_SIZE> geolocXAccessor;
-    GDALCachedPixelAccessor<double, TILE_SIZE> geolocYAccessor;
-    GDALCachedPixelAccessor<float, TILE_SIZE> backMapXAccessor;
-    GDALCachedPixelAccessor<float, TILE_SIZE> backMapYAccessor;
-    GDALCachedPixelAccessor<float, TILE_SIZE> backMapWeightAccessor;
+    GDALCachedPixelAccessor<double, TILE_SIZE, TILE_COUNT> geolocXAccessor;
+    GDALCachedPixelAccessor<double, TILE_SIZE, TILE_COUNT> geolocYAccessor;
+    GDALCachedPixelAccessor<float, TILE_SIZE, TILE_COUNT> backMapXAccessor;
+    GDALCachedPixelAccessor<float, TILE_SIZE, TILE_COUNT> backMapYAccessor;
+    GDALCachedPixelAccessor<float, TILE_SIZE, TILE_COUNT> backMapWeightAccessor;
 
     explicit GDALGeoLocDatasetAccessors(GDALGeoLocTransformInfo *psTransform)
         : m_psTransform(psTransform), geolocXAccessor(nullptr),

--- a/frmts/vrt/vrtsourcedrasterband.cpp
+++ b/frmts/vrt/vrtsourcedrasterband.cpp
@@ -420,7 +420,9 @@ CPLErr VRTSourcedRasterBand::IRasterIO(
         // Do nothing
     }
     else if (nPixelSpace == GDALGetDataTypeSizeBytes(eBufType) &&
-             (!m_bNoDataValueSet || m_dfNoDataValue == 0.0))
+             !(m_bNoDataValueSet && m_dfNoDataValue != 0.0) &&
+             !(m_bNoDataSetAsInt64 && m_nNoDataValueInt64 != 0) &&
+             !(m_bNoDataSetAsUInt64 && m_nNoDataValueUInt64 != 0))
     {
         if (nLineSpace == nBufXSize * nPixelSpace)
         {
@@ -434,6 +436,26 @@ CPLErr VRTSourcedRasterBand::IRasterIO(
                            static_cast<GIntBig>(iLine) * nLineSpace,
                        0, static_cast<size_t>(nBufXSize * nPixelSpace));
             }
+        }
+    }
+    else if (m_bNoDataSetAsInt64)
+    {
+        for (int iLine = 0; iLine < nBufYSize; iLine++)
+        {
+            GDALCopyWords(&m_nNoDataValueInt64, GDT_Int64, 0,
+                          static_cast<GByte *>(pData) +
+                              static_cast<GIntBig>(nLineSpace) * iLine,
+                          eBufType, static_cast<int>(nPixelSpace), nBufXSize);
+        }
+    }
+    else if (m_bNoDataSetAsUInt64)
+    {
+        for (int iLine = 0; iLine < nBufYSize; iLine++)
+        {
+            GDALCopyWords(&m_nNoDataValueUInt64, GDT_UInt64, 0,
+                          static_cast<GByte *>(pData) +
+                              static_cast<GIntBig>(nLineSpace) * iLine,
+                          eBufType, static_cast<int>(nPixelSpace), nBufXSize);
         }
     }
     else

--- a/frmts/vrt/vrtsources.cpp
+++ b/frmts/vrt/vrtsources.cpp
@@ -3081,6 +3081,52 @@ static inline bool hasZeroByte(uint32_t v)
 }
 
 /************************************************************************/
+/*                                CopyWord()                            */
+/************************************************************************/
+
+template <class SrcType>
+static void CopyWord(const SrcType *pSrcVal, GDALDataType eSrcType,
+                     void *pDstVal, GDALDataType eDstType)
+{
+    switch (eDstType)
+    {
+        case GDT_Byte:
+            GDALCopyWord(*pSrcVal, *static_cast<uint8_t *>(pDstVal));
+            break;
+        case GDT_Int8:
+            GDALCopyWord(*pSrcVal, *static_cast<int8_t *>(pDstVal));
+            break;
+        case GDT_UInt16:
+            GDALCopyWord(*pSrcVal, *static_cast<uint16_t *>(pDstVal));
+            break;
+        case GDT_Int16:
+            GDALCopyWord(*pSrcVal, *static_cast<int16_t *>(pDstVal));
+            break;
+        case GDT_UInt32:
+            GDALCopyWord(*pSrcVal, *static_cast<uint32_t *>(pDstVal));
+            break;
+        case GDT_Int32:
+            GDALCopyWord(*pSrcVal, *static_cast<int32_t *>(pDstVal));
+            break;
+        case GDT_UInt64:
+            GDALCopyWord(*pSrcVal, *static_cast<uint64_t *>(pDstVal));
+            break;
+        case GDT_Int64:
+            GDALCopyWord(*pSrcVal, *static_cast<int64_t *>(pDstVal));
+            break;
+        case GDT_Float32:
+            GDALCopyWord(*pSrcVal, *static_cast<float *>(pDstVal));
+            break;
+        case GDT_Float64:
+            GDALCopyWord(*pSrcVal, *static_cast<double *>(pDstVal));
+            break;
+        default:
+            GDALCopyWords(pSrcVal, eSrcType, 0, pDstVal, eDstType, 0, 1);
+            break;
+    }
+}
+
+/************************************************************************/
 /*                       RasterIOProcessNoData()                        */
 /************************************************************************/
 
@@ -3235,8 +3281,8 @@ CPLErr VRTComplexSource::RasterIOProcessNoData(
             {
                 if (paSrcData[idxBuffer] != nNoDataValue)
                 {
-                    GDALCopyWords(&paSrcData[idxBuffer], eSourceType, 0,
-                                  pDstLocation, eBufType, 0, 1);
+                    CopyWord(&paSrcData[idxBuffer], eSourceType, pDstLocation,
+                             eBufType);
                 }
             }
         }
@@ -3256,8 +3302,8 @@ CPLErr VRTComplexSource::RasterIOProcessNoData(
                 {
                     // Convert first to the VRTRasterBand data type
                     // to get its clamping, before outputting to buffer data type
-                    GDALCopyWords(&paSrcData[idxBuffer], eSourceType, 0,
-                                  abyTemp, eVRTBandDataType, 0, 1);
+                    CopyWord(&paSrcData[idxBuffer], eSourceType, abyTemp,
+                             eVRTBandDataType);
                     GDALCopyWords(abyTemp, eVRTBandDataType, 0, pDstLocation,
                                   eBufType, 0, 1);
                 }
@@ -3415,6 +3461,12 @@ CPLErr VRTComplexSource::RasterIOInternal(
     /*      Selectively copy into output buffer with nodata masking,        */
     /*      and/or scaling.                                                 */
     /* -------------------------------------------------------------------- */
+
+    const bool bTwoStepDataTypeConversion =
+        CPL_TO_BOOL(
+            GDALDataTypeIsConversionLossy(eWrkDataType, eVRTBandDataType)) &&
+        !CPL_TO_BOOL(GDALDataTypeIsConversionLossy(eVRTBandDataType, eBufType));
+
     size_t idxBuffer = 0;
     for (int iY = 0; iY < nOutYSize; iY++)
     {
@@ -3551,18 +3603,28 @@ CPLErr VRTComplexSource::RasterIOInternal(
                     255.0f,
                     std::max(0.0f, static_cast<float>(afResult[0]) + 0.5f)));
             }
-            else if (eBufType == eVRTBandDataType)
+            else if (!bTwoStepDataTypeConversion)
             {
-                GDALCopyWords(afResult, eWrkDataType, 0, pDstLocation, eBufType,
-                              0, 1);
+                CopyWord<WorkingDT>(afResult, eWrkDataType, pDstLocation,
+                                    eBufType);
+            }
+            else if (eVRTBandDataType == GDT_Float32 && eBufType == GDT_Float64)
+            {
+                // Particular case of the below 2-step conversion.
+                // Helps a bit for some geolocation based warping with Sentinel3
+                // data where the longitude/latitude arrays are Int32 bands,
+                // rescaled in VRT as Float32 and requested as Float64
+                float fVal;
+                GDALCopyWord(afResult[0], fVal);
+                *reinterpret_cast<double *>(pDstLocation) = fVal;
             }
             else
             {
                 GByte abyTemp[2 * sizeof(double)];
                 // Convert first to the VRTRasterBand data type
                 // to get its clamping, before outputting to buffer data type
-                GDALCopyWords(afResult, eWrkDataType, 0, abyTemp,
-                              eVRTBandDataType, 0, 1);
+                CopyWord<WorkingDT>(afResult, eWrkDataType, abyTemp,
+                                    eVRTBandDataType);
                 GDALCopyWords(abyTemp, eVRTBandDataType, 0, pDstLocation,
                               eBufType, 0, 1);
             }

--- a/frmts/vrt/vrtsources.cpp
+++ b/frmts/vrt/vrtsources.cpp
@@ -2986,10 +2986,10 @@ CPLErr VRTComplexSource::RasterIO(GDALDataType eVRTBandDataType, int nXOff,
     GByte *const pabyOut = static_cast<GByte *>(pData) +
                            nPixelSpace * nOutXOff +
                            static_cast<GPtrDiff_t>(nLineSpace) * nOutYOff;
+    const auto eSourceType = poSourceBand->GetRasterDataType();
     if (m_nProcessingFlags == PROCESSING_FLAG_NODATA)
     {
         // Optimization if doing only nodata processing
-        const auto eSourceType = poSourceBand->GetRasterDataType();
         if (eSourceType == GDT_Byte)
         {
             if (!GDALIsValueInRange<GByte>(m_dfNoDataValue))
@@ -3043,7 +3043,10 @@ CPLErr VRTComplexSource::RasterIO(GDALDataType eVRTBandDataType, int nXOff,
     // For Int32, float32 isn't sufficiently precise as working data type
     if (eVRTBandDataType == GDT_CInt32 || eVRTBandDataType == GDT_CFloat64 ||
         eVRTBandDataType == GDT_Int32 || eVRTBandDataType == GDT_UInt32 ||
-        eVRTBandDataType == GDT_Float64)
+        eVRTBandDataType == GDT_Int64 || eVRTBandDataType == GDT_UInt64 ||
+        eVRTBandDataType == GDT_Float64 || eSourceType == GDT_Int32 ||
+        eSourceType == GDT_UInt32 || eSourceType == GDT_Int64 ||
+        eSourceType == GDT_UInt64)
     {
         eErr = RasterIOInternal<double>(
             poSourceBand, eVRTBandDataType, nReqXOff, nReqYOff, nReqXSize,


### PR DESCRIPTION
Fixes #10809 

Timing back from ages (half an hour or so) to 20 seconds.
Also fixes a bug related to Int64/UInt64 VRT bands with nodata.