### PR TITLE
LIBKML: dump feature when its geometry cannot be written

### DIFF
--- a/ogr/ogrsf_frmts/libkml/ogrlibkmlfeature.cpp
+++ b/ogr/ogrsf_frmts/libkml/ogrlibkmlfeature.cpp
@@ -815,7 +815,12 @@ FeaturePtr feat2kml(OGRLIBKMLDataSource *poOgrDS, OGRLIBKMLLayer *poOgrLayer,
         {
             ElementPtr poKmlElement = geom2kml(poOgrGeom, -1, poKmlFactory);
             if (!poKmlElement)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Cannot translate feature: %s",
+                         poOgrFeat->DumpReadableAsString().c_str());
                 return nullptr;
+            }
 
             poKmlPlacemark->set_geometry(AsGeometry(std::move(poKmlElement)));
         }


### PR DESCRIPTION
Fixes #10829

Example
```
$ ogr2ogr -f LIBKML test.kml test.csv || echo "==> failed"
Warning 1: Self-intersection at or near point 0.5 0.5
ERROR 6: Invalid polygon
ERROR 1: Cannot translate feature: OGRFeature(test):-1
  id (Integer) = 1
  i (Integer) = -21121
  WKT (String) = POLYGON((0 0,1 1,1 0,0 1,0 0))
  POLYGON ((0 0,1 1,1 0,0 1,0 0))

ERROR 1: Unable to write feature 1 from layer test.
ERROR 1: Terminating translation prematurely after failed
translation of layer test (use -skipfailures to skip errors)
==> failed
```
