### PR TITLE
EEDA/EEDAI drivers: add a VSI_PATH_FOR_AUTH open option to allow using…

### DIFF
--- a/autotest/gdrivers/eedai.py
+++ b/autotest/gdrivers/eedai.py
@@ -302,7 +302,8 @@ gwE6fxOLyJDxuWRf
 # Test OAuth2 with GOOGLE_APPLICATION_CREDENTIALS
 
 
-def test_eedai_GOOGLE_APPLICATION_CREDENTIALS():
+@pytest.mark.parametrize("use_vsi_path", [False, True])
+def test_eedai_GOOGLE_APPLICATION_CREDENTIALS(use_vsi_path):
 
     gdal.FileFromMemBuffer(
         "/vsimem/my.json",
@@ -313,7 +314,12 @@ def test_eedai_GOOGLE_APPLICATION_CREDENTIALS():
     )
 
     gdal.SetConfigOption("EEDA_URL", "/vsimem/ee/")
-    gdal.SetConfigOption("GOOGLE_APPLICATION_CREDENTIALS", "/vsimem/my.json")
+    if use_vsi_path:
+        gdal.SetPathSpecificOption(
+            "/vsigs/to_test_eeda", "GOOGLE_APPLICATION_CREDENTIALS", "/vsimem/my.json"
+        )
+    else:
+        gdal.SetConfigOption("GOOGLE_APPLICATION_CREDENTIALS", "/vsimem/my.json")
     gdal.SetConfigOption("EEDA_PRIVATE_KEY", None)
     gdal.SetConfigOption("EEDA_CLIENT_EMAIL", None)
     gdal.SetConfigOption("GO2A_AUD", "/vsimem/oauth2/v4/token")
@@ -323,8 +329,11 @@ def test_eedai_GOOGLE_APPLICATION_CREDENTIALS():
         '{ "access_token": "my_token", "token_type": "Bearer", "expires_in": 3600 }',
     )
 
+    open_options = []
+    if use_vsi_path:
+        open_options.append("VSI_PATH_FOR_AUTH=/vsigs/to_test_eeda")
     try:
-        ds = gdal.Open("EEDAI:image")
+        ds = gdal.OpenEx("EEDAI:image", open_options=open_options)
         assert ds is not None
     except RuntimeError:
         pass
@@ -335,6 +344,7 @@ def test_eedai_GOOGLE_APPLICATION_CREDENTIALS():
         gdal.SetConfigOption("GOOGLE_APPLICATION_CREDENTIALS", None)
         gdal.SetConfigOption("EEDA_PRIVATE_KEY", None)
         gdal.SetConfigOption("EEDA_CLIENT_EMAIL", None)
+        gdal.ClearPathSpecificOptions("/vsigs/to_test_eeda")
 
     if "CPLRSASHA256Sign() not implemented" in gdal.GetLastErrorMsg():
         pytest.skip("CPLRSASHA256Sign() not implemented")

--- a/doc/source/drivers/raster/eedai.rst
+++ b/doc/source/drivers/raster/eedai.rst
@@ -60,6 +60,12 @@ The following open options are available :
       Size of a GDAL block, which is the minimum
       unit to query pixels.
 
+-  .. oo:: VSI_PATH_FOR_AUTH
+      :since: 3.10
+
+      /vsigs/... path onto which a GOOGLE_APPLICATION_CREDENTIALS path specific
+      option is set
+
 Authentication methods
 ----------------------
 
@@ -68,7 +74,9 @@ The following authentication methods can be used:
 -  Authentication Bearer header passed through the :config:`EEDA_BEARER` or
    :config:`EEDA_BEARER_FILE` configuration options.
 -  Service account private key file, through the
-   :config:`GOOGLE_APPLICATION_CREDENTIALS` configuration option.
+   :config:`GOOGLE_APPLICATION_CREDENTIALS` configuration option, or set
+   as a path-specific option whose value is set in the VSI_PATH_FOR_AUTH
+   open option.
 -  OAuth2 Service Account authentication through the :config:`EEDA_PRIVATE_KEY`/
    :config:`EEDA_PRIVATE_KEY_FILE` + :config:`EEDA_CLIENT_EMAIL` configuration options.
 -  Finally if none of the above method succeeds, the code will check if

--- a/doc/source/drivers/vector/eeda.rst
+++ b/doc/source/drivers/vector/eeda.rst
@@ -40,6 +40,12 @@ The following open options are available:
       To specify the collection if not specified
       in the connection string.
 
+-  .. oo:: VSI_PATH_FOR_AUTH
+      :since: 3.10
+
+      /vsigs/... path onto which a GOOGLE_APPLICATION_CREDENTIALS path specific
+      option is set
+
 Authentication methods
 ----------------------
 
@@ -48,7 +54,9 @@ The following authentication methods can be used:
 -  Authentication Bearer header passed through the EEDA_BEARER or
    :config:`EEDA_BEARER_FILE` configuration options.
 -  Service account private key file, through the
-   :config:`GOOGLE_APPLICATION_CREDENTIALS` configuration option.
+   :config:`GOOGLE_APPLICATION_CREDENTIALS` configuration option, or set
+   as a path-specific option whose value is set in the VSI_PATH_FOR_AUTH
+   open option.
 -  OAuth2 Service Account authentication through the
    :config:`EEDA_PRIVATE_KEY`/
    :config:`EEDA_PRIVATE_KEY_FILE` +

--- a/frmts/eeda/eedacommon.cpp
+++ b/frmts/eeda/eedacommon.cpp
@@ -386,8 +386,15 @@ char **GDALEEDABaseDataset::GetBaseHTTPOptions()
                 }
             }
 
-            CPLString osServiceAccountJson(
-                CPLGetConfigOption("GOOGLE_APPLICATION_CREDENTIALS", ""));
+            CPLString osServiceAccountJson;
+            const char *pszVSIPath =
+                CSLFetchNameValue(papszOpenOptions, "VSI_PATH_FOR_AUTH");
+            if (pszVSIPath)
+                osServiceAccountJson = VSIGetPathSpecificOption(
+                    pszVSIPath, "GOOGLE_APPLICATION_CREDENTIALS", "");
+            if (osServiceAccountJson.empty())
+                osServiceAccountJson =
+                    CPLGetConfigOption("GOOGLE_APPLICATION_CREDENTIALS", "");
             if (!osServiceAccountJson.empty())
             {
                 CPLJSONDocument oDoc;
@@ -443,7 +450,8 @@ char **GDALEEDABaseDataset::GetBaseHTTPOptions()
                          "Missing EEDA_BEARER, EEDA_BEARER_FILE or "
                          "GOOGLE_APPLICATION_CREDENTIALS or "
                          "EEDA_PRIVATE_KEY/EEDA_PRIVATE_KEY_FILE + "
-                         "EEDA_CLIENT_EMAIL config option");
+                         "EEDA_CLIENT_EMAIL config option or "
+                         "VSI_PATH_FOR_AUTH open option");
                 CSLDestroy(papszOptions);
                 return nullptr;
             }

--- a/frmts/eeda/eedadataset.cpp
+++ b/frmts/eeda/eedadataset.cpp
@@ -1245,11 +1245,16 @@ void GDALRegister_EEDA()
     poDriver->SetMetadataItem(GDAL_DMD_LONGNAME, "Earth Engine Data API");
     poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC, "drivers/vector/eeda.html");
     poDriver->SetMetadataItem(GDAL_DMD_CONNECTION_PREFIX, "EEDA:");
-    poDriver->SetMetadataItem(GDAL_DMD_OPENOPTIONLIST,
-                              "<OpenOptionList>"
-                              "  <Option name='COLLECTION' type='string' "
-                              "description='Collection name'/>"
-                              "</OpenOptionList>");
+    poDriver->SetMetadataItem(
+        GDAL_DMD_OPENOPTIONLIST,
+        "<OpenOptionList>"
+        "  <Option name='COLLECTION' type='string' "
+        "description='Collection name'/>"
+        "  <Option name='VSI_PATH_FOR_AUTH' type='string' "
+        "description='/vsigs/... path onto which a "
+        "GOOGLE_APPLICATION_CREDENTIALS path specific "
+        "option is set'/>"
+        "</OpenOptionList>");
 
     poDriver->pfnOpen = GDALEEDAOpen;
     poDriver->pfnIdentify = GDALEEDAdentify;

--- a/frmts/eeda/eedaidataset.cpp
+++ b/frmts/eeda/eedaidataset.cpp
@@ -1558,6 +1558,10 @@ void GDALRegister_EEDAI()
         "   </Option>"
         "  <Option name='BLOCK_SIZE' type='integer' "
         "description='Size of a block' default='256'/>"
+        "  <Option name='VSI_PATH_FOR_AUTH' type='string' "
+        "description='/vsigs/... path onto which a "
+        "GOOGLE_APPLICATION_CREDENTIALS path specific "
+        "option is set'/>"
         "</OpenOptionList>");
     poDriver->SetMetadataItem(GDAL_DMD_SUBDATASETS, "YES");
 


### PR DESCRIPTION
…a /vsigs/ path-specific GOOGLE_APPLICATION_CREDENTIALS option
