### PR TITLE
[Backport release/3.9] MEM layer: fix UpdateFeature() that didn't mark the layer as updated, which caused GeoJSON files to not be updated

### DIFF
--- a/ogr/ogrsf_frmts/mem/ogrmemlayer.cpp
+++ b/ogr/ogrsf_frmts/mem/ogrmemlayer.cpp
@@ -498,6 +498,9 @@ OGRErr OGRMemLayer::IUpdateFeature(OGRFeature *poFeature,
     {
         poFeatureRef->SetStyleString(poFeature->GetStyleString());
     }
+
+    m_bUpdated = true;
+
     return OGRERR_NONE;
 }
 


### PR DESCRIPTION
Backport #10794
 **Authored by:** @rouault