### PR TITLE
CI: disable MSSQL Docker based testing

### DIFF
--- a/.github/workflows/ubuntu_22.04/services.sh
+++ b/.github/workflows/ubuntu_22.04/services.sh
@@ -7,9 +7,9 @@ set -ex
 ##################
 
 # MSSQL: server side
-docker rm -f gdal-sql1
-docker pull mcr.microsoft.com/mssql/server:2017-latest
-docker run  -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=DummyPassw0rd'  -p 1433:1433 --name gdal-sql1 -d mcr.microsoft.com/mssql/server:2017-latest
+#docker rm -f gdal-sql1
+#docker pull mcr.microsoft.com/mssql/server:2017-latest
+#docker run  -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=DummyPassw0rd'  -p 1433:1433 --name gdal-sql1 -d mcr.microsoft.com/mssql/server:2017-latest
 
 # MySQL 8
 docker rm -f gdal-mysql1
@@ -38,7 +38,7 @@ docker run --name gdal-mongo -p 27018:27017 -d mongo:4.4
 sleep 10
 
 # MSSQL
-docker exec -t gdal-sql1 /opt/mssql-tools/bin/sqlcmd -l 30 -S localhost -U SA -P DummyPassw0rd -Q "CREATE DATABASE TestDB"
+#docker exec -t gdal-sql1 /opt/mssql-tools/bin/sqlcmd -l 30 -S localhost -U SA -P DummyPassw0rd -Q "CREATE DATABASE TestDB"
 
 # MySQL
 docker exec gdal-mysql1 sh -c "echo 'CREATE DATABASE test; SELECT Version()' | mysql -uroot -ppasswd"

--- a/.github/workflows/ubuntu_22.04/test.sh
+++ b/.github/workflows/ubuntu_22.04/test.sh
@@ -31,6 +31,6 @@ AZURE_STORAGE_CONNECTION_STRING=${AZURITE_STORAGE_CONNECTION_STRING} python3 -c 
 # MongoDB v3
 (cd autotest && MONGODBV3_TEST_PORT=27018 MONGODBV3_TEST_HOST=$IP $PYTEST ogr/ogr_mongodbv3.py)
 
-(cd autotest && OGR_MSSQL_CONNECTION_STRING="MSSQL:server=$IP;database=TestDB;driver=ODBC Driver 17 for SQL Server;UID=SA;PWD=DummyPassw0rd" $PYTEST ogr/ogr_mssqlspatial.py)
+#(cd autotest && OGR_MSSQL_CONNECTION_STRING="MSSQL:server=$IP;database=TestDB;driver=ODBC Driver 17 for SQL Server;UID=SA;PWD=DummyPassw0rd" $PYTEST ogr/ogr_mssqlspatial.py)
 
 (cd autotest && $PYTEST)

--- a/.github/workflows/ubuntu_24.04/services.sh
+++ b/.github/workflows/ubuntu_24.04/services.sh
@@ -7,9 +7,9 @@ set -ex
 ##################
 
 # MSSQL: server side
-docker rm -f gdal-sql1
-docker pull mcr.microsoft.com/mssql/server:2017-latest
-docker run  -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=DummyPassw0rd'  -p 1433:1433 --name gdal-sql1 -d mcr.microsoft.com/mssql/server:2017-latest
+#docker rm -f gdal-sql1
+#docker pull mcr.microsoft.com/mssql/server:2017-latest
+#docker run  -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=DummyPassw0rd'  -p 1433:1433 --name gdal-sql1 -d mcr.microsoft.com/mssql/server:2017-latest
 
 # MySQL 8
 docker rm -f gdal-mysql1
@@ -38,7 +38,7 @@ docker run --name gdal-mongo -p 27018:27017 -d mongo:4.4
 sleep 10
 
 # MSSQL
-docker exec -t gdal-sql1 /opt/mssql-tools/bin/sqlcmd -l 30 -S localhost -U SA -P DummyPassw0rd -Q "CREATE DATABASE TestDB"
+#docker exec -t gdal-sql1 /opt/mssql-tools/bin/sqlcmd -l 30 -S localhost -U SA -P DummyPassw0rd -Q "CREATE DATABASE TestDB"
 
 # MySQL
 docker exec gdal-mysql1 sh -c "echo 'CREATE DATABASE test; SELECT Version()' | mysql -uroot -ppasswd"

--- a/.github/workflows/ubuntu_24.04/test.sh
+++ b/.github/workflows/ubuntu_24.04/test.sh
@@ -34,6 +34,6 @@ AZURE_STORAGE_CONNECTION_STRING=${AZURITE_STORAGE_CONNECTION_STRING} python3 -c 
 # MongoDB v3
 (cd autotest && MONGODBV3_TEST_PORT=27018 MONGODBV3_TEST_HOST=$IP $PYTEST ogr/ogr_mongodbv3.py)
 
-(cd autotest && OGR_MSSQL_CONNECTION_STRING="MSSQL:server=$IP;database=TestDB;driver=ODBC Driver 17 for SQL Server;UID=SA;PWD=DummyPassw0rd" $PYTEST ogr/ogr_mssqlspatial.py)
+# (cd autotest && OGR_MSSQL_CONNECTION_STRING="MSSQL:server=$IP;database=TestDB;driver=ODBC Driver 17 for SQL Server;UID=SA;PWD=DummyPassw0rd" $PYTEST ogr/ogr_mssqlspatial.py)
 
 (cd autotest && $PYTEST)


### PR DESCRIPTION
This has become unreliable lately with failures like in https://github.com/OSGeo/gdal/actions/runs/10930480309/job/30377732865?pr=10840

```
+ docker exec -t gdal-sql1 /opt/mssql-tools/bin/sqlcmd -l 30 -S localhost -U SA -P DummyPassw0rd -Q CREATE DATABASE TestDB
Error response from daemon: container fba0406fd45fd855feea4090a0b46c321d70c1b4e000ba318ff1045c400d1b43 is not running
```

Although I can't reproduce the error locally
