### PR TITLE
 /vsicurl/: no longer forward Authorization header when doing redirection to other hosts.

### DIFF
--- a/doc/source/spelling_wordlist.txt
+++ b/doc/source/spelling_wordlist.txt
@@ -2732,6 +2732,7 @@ RecordBatch
 RecordBatchAsNumpy
 recurse
 recursionLevel
+redirections
 Redistributable
 reentrancy
 reentrant

--- a/doc/source/user/configoptions.rst
+++ b/doc/source/user/configoptions.rst
@@ -626,6 +626,20 @@ Networking options
       Try to query quietly redirected URLs to Amazon S3 signed URLs during their
       validity period, so as to minimize round-trips.
 
+-  .. config:: CPL_VSIL_CURL_AUTHORIZATION_HEADER_ALLOWED_IF_REDIRECT
+      :choices: YES, NO, IF_SAME_HOST
+      :default: IF_SAME_HOST
+      :since: 3.10
+
+      Determines if the HTTP ``Authorization`` header must be forwarded when
+      redirections are followed:
+
+      - ``NO`` to always disable forwarding of Authorization header
+      - ``YES`` to always enable forwarding of Authorization header (was the
+        default value prior to GDAL 3.10)
+      - ``IF_SAME_HOST`` to enable forwarding of Authorization header only if
+        the redirection is to the same host.
+
 -  .. config:: CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE
       :choices: YES, NO
 

--- a/doc/source/user/virtual_file_systems.rst
+++ b/doc/source/user/virtual_file_systems.rst
@@ -413,6 +413,11 @@ As an alternative, starting with GDAL 3.6, the
 :config:`GDAL_HTTP_HEADERS` configuration option can also be
 used to specify headers. :config:`CPL_CURL_VERBOSE=YES` allows one to see them and more, when combined with ``--debug``.
 
+Starting with GDAL 3.10, the ``Authorization`` header is no longer automatically
+forwarded when redirections are followed.
+That behavior can be configured by setting the
+:config:`CPL_VSIL_CURL_AUTHORIZATION_HEADER_ALLOWED_IF_REDIRECT` configuration option.
+
 Starting with GDAL 2.3, the :config:`GDAL_HTTP_MAX_RETRY` (number of attempts) and :config:`GDAL_HTTP_RETRY_DELAY` (in seconds) configuration option can be set, so that request retries are done in case of HTTP errors 429, 502, 503 or 504.
 
 Starting with GDAL 3.6, the following configuration options control the TCP keep-alive functionality (cf https://daniel.haxx.se/blog/2020/02/10/curl-ootw-keepalive-time/ for a detailed explanation):

--- a/port/cpl_vsil_curl_class.h
+++ b/port/cpl_vsil_curl_class.h
@@ -116,7 +116,8 @@ struct WriteFuncStruct
     bool bMultiRange = false;
     vsi_l_offset nStartOffset = 0;
     vsi_l_offset nEndOffset = 0;
-    int nHTTPCode = 0;
+    int nHTTPCode = 0;       // potentially after redirect
+    int nFirstHTTPCode = 0;  // the one of the redirect
     vsi_l_offset nContentLength = 0;
     bool bFoundContentRange = false;
     bool bError = false;
@@ -423,7 +424,8 @@ class VSICurlHandle : public VSIVirtualHandle
     int ReadMultiRangeSingleGet(int nRanges, void **ppData,
                                 const vsi_l_offset *panOffsets,
                                 const size_t *panSizes);
-    std::string GetRedirectURLIfValid(bool &bHasExpired) const;
+    std::string GetRedirectURLIfValid(bool &bHasExpired,
+                                      CPLStringList &aosHTTPOptions) const;
 
     void UpdateRedirectInfo(CURL *hCurlHandle,
                             const WriteFuncStruct &sWriteFuncHeaderData);


### PR DESCRIPTION
Can be configured with the CPL_VSIL_CURL_AUTHORIZATION_HEADER_ALLOWED_IF_REDIRECT=YES/NO/IF_SAME_HOST config option

Fixes https://lists.osgeo.org/pipermail/gdal-dev/2024-September/059536.html