### PR TITLE
Raster MEM driver: disable opening a dataset with MEM::: syntax by default

### DIFF
--- a/autotest/gdrivers/mem.py
+++ b/autotest/gdrivers/mem.py
@@ -156,7 +156,14 @@ def test_mem_2(mem_native_memory):
         for i in range(width * height):
             float_p[i] = 5.0
 
-        dsro = gdal.Open(dsname)
+        with pytest.raises(
+            Exception,
+            match="Opening a MEM dataset with the MEM:::DATAPOINTER= syntax is no longer supported by default for security reasons",
+        ):
+            gdal.Open(dsname)
+
+        with gdal.config_option("GDAL_MEM_ENABLE_OPEN", "YES"):
+            dsro = gdal.Open(dsname)
         if dsro is None:
             free(p)
             pytest.fail("opening MEM dataset failed in read only mode.")
@@ -168,7 +175,8 @@ def test_mem_2(mem_native_memory):
             pytest.fail("checksum failed.")
         dsro = None
 
-        dsup = gdal.Open(dsname, gdal.GA_Update)
+        with gdal.config_option("GDAL_MEM_ENABLE_OPEN", "YES"):
+            dsup = gdal.Open(dsname, gdal.GA_Update)
         if dsup is None:
             free(p)
             pytest.fail("opening MEM dataset failed in update mode.")
@@ -210,9 +218,10 @@ def test_geotransform(ds_definition, expected_sr, mem_native_memory):
     proj_crs = "+proj=laea +lon_0=147 +lat_0=-42"
     ll_crs = """GEOGCS[\\"WGS 84\\",DATUM[\\"WGS_1984\\",SPHEROID[\\"WGS 84\\",6378137,298.257223563,AUTHORITY[\\"EPSG\\",\\"7030\\"]],AUTHORITY[\\"EPSG\\",\\"6326\\"]],PRIMEM[\\"Greenwich\\",0,AUTHORITY[\\"EPSG\\",\\"8901\\"]],UNIT[\\"degree\\",0.0174532925199433,AUTHORITY[\\"EPSG\\",\\"9122\\"]],AXIS[\\"Latitude\\",NORTH],AXIS[\\"Longitude\\",EAST],AUTHORITY[\\"EPSG\\",\\"4326\\"]]"""
 
-    dsro = gdal.Open(
-        ds_definition.format(datapointer=p, proj_crs=proj_crs, ll_crs=ll_crs)
-    )
+    with gdal.config_option("GDAL_MEM_ENABLE_OPEN", "YES"):
+        dsro = gdal.Open(
+            ds_definition.format(datapointer=p, proj_crs=proj_crs, ll_crs=ll_crs)
+        )
     if dsro is None:
         free(p)
         pytest.fail("opening MEM dataset failed in read only mode.")

--- a/doc/source/drivers/raster/mem.rst
+++ b/doc/source/drivers/raster/mem.rst
@@ -63,13 +63,28 @@ or
    the next.
 -  GEOTRANSFORM: Set the affine transformation coefficients. 6 real
    numbers with '/' as separator (optional)
--  SPATIALREFERENCE: (GDAL >= 3.7) Set the projection. The coordinate reference 
-   systems that can be passed are anything supported by the 
-   OGRSpatialReference.SetFromUserInput() as per '-a_srs' in  
+-  SPATIALREFERENCE: (GDAL >= 3.7) Set the projection. The coordinate reference
+   systems that can be passed are anything supported by the
+   OGRSpatialReference.SetFromUserInput() as per '-a_srs' in
    :ref:`gdal_translate`. If the passed string includes comma or double-quote characters (typically WKT),
    it should be surrounded by double-quote characters and the double-quote characters inside it
    should be escaped with anti-slash.
    e.g ``SPATIALREFERENCE="GEOGCRS[\"WGS 84\",[... snip ...],ID[\"EPSG\",4326]]"``
+
+.. warning::
+
+    Starting with GDAL 3.10, opening a MEM dataset using the above syntax is no
+    longer enabled by default for security reasons.
+    If you want to allow it, define the ``GDAL_MEM_ENABLE_OPEN`` configuration
+    option to ``YES``, or build GDAL with the ``GDAL_MEM_ENABLE_OPEN`` compilation
+    definition.
+
+    .. config:: GDAL_MEM_ENABLE_OPEN
+       :choices: YES, NO
+       :default: NO
+       :since: 3.10
+
+       Whether opening a MEM dataset with the ``MEM:::`` syntax is allowed.
 
 
 Creation Options

--- a/frmts/mem/memdataset.cpp
+++ b/frmts/mem/memdataset.cpp
@@ -1155,6 +1155,20 @@ GDALDataset *MEMDataset::Open(GDALOpenInfo *poOpenInfo)
         poOpenInfo->fpL != nullptr)
         return nullptr;
 
+#ifndef GDAL_MEM_ENABLE_OPEN
+    if (!CPLTestBool(CPLGetConfigOption("GDAL_MEM_ENABLE_OPEN", "NO")))
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Opening a MEM dataset with the MEM:::DATAPOINTER= syntax "
+                 "is no longer supported by default for security reasons. "
+                 "If you want to allow it, define the "
+                 "GDAL_MEM_ENABLE_OPEN "
+                 "configuration option to YES, or build GDAL with the "
+                 "GDAL_MEM_ENABLE_OPEN compilation definition");
+        return nullptr;
+    }
+#endif
+
     char **papszOptions =
         CSLTokenizeStringComplex(poOpenInfo->pszFilename + 6, ",", TRUE, FALSE);
 


### PR DESCRIPTION

```
    Starting with GDAL 3.10, opening a MEM dataset using the above syntax is no
    longer enabled by default for security reasons.
    If you want to allow it, define the ``GDAL_MEM_ENABLE_OPEN`` configuration
    option to ``YES``, or build GDAL with the ``GDAL_MEM_ENABLE_OPEN`` compilation
    definition.

    .. config:: GDAL_MEM_ENABLE_OPEN
       :choices: YES, NO
       :default: NO
       :since: 3.10

       Whether opening a MEM dataset with the ``MEM:::`` syntax is allowed.
```
