### PR TITLE
[Backport release/3.9] GeoRaster: Preserve quote in the connection string to the GeoRaster driver so th…

### DIFF
--- a/frmts/georaster/georaster_wrapper.cpp
+++ b/frmts/georaster/georaster_wrapper.cpp
@@ -214,12 +214,11 @@ char **GeoRasterWrapper::ParseIdentificator(const char *pszStringID)
 
     char *pszStartPos = (char *)strstr(pszStringID, ":") + 1;
 
-    char **papszParam =
-        CSLTokenizeString2(pszStartPos, ",@",
-                           CSLT_HONOURSTRINGS | CSLT_ALLOWEMPTYTOKENS |
-                               CSLT_STRIPLEADSPACES | CSLT_STRIPENDSPACES |
-                               CSLT_PRESERVEQUOTES);
-
+    char **papszParam = CSLTokenizeString2(
+        pszStartPos, ",@",
+        CSLT_HONOURSTRINGS | CSLT_ALLOWEMPTYTOKENS | CSLT_STRIPLEADSPACES |
+            CSLT_STRIPENDSPACES | CSLT_PRESERVEQUOTES);
+     
     //  -------------------------------------------------------------------
     //  The "/" should not be catch on the previous parser
     //  -------------------------------------------------------------------

--- a/frmts/georaster/georaster_wrapper.cpp
+++ b/frmts/georaster/georaster_wrapper.cpp
@@ -218,7 +218,7 @@ char **GeoRasterWrapper::ParseIdentificator(const char *pszStringID)
         pszStartPos, ",@",
         CSLT_HONOURSTRINGS | CSLT_ALLOWEMPTYTOKENS | CSLT_STRIPLEADSPACES |
             CSLT_STRIPENDSPACES | CSLT_PRESERVEQUOTES);
-     
+
     //  -------------------------------------------------------------------
     //  The "/" should not be catch on the previous parser
     //  -------------------------------------------------------------------

--- a/frmts/georaster/georaster_wrapper.cpp
+++ b/frmts/georaster/georaster_wrapper.cpp
@@ -217,7 +217,8 @@ char **GeoRasterWrapper::ParseIdentificator(const char *pszStringID)
     char **papszParam =
         CSLTokenizeString2(pszStartPos, ",@",
                            CSLT_HONOURSTRINGS | CSLT_ALLOWEMPTYTOKENS |
-                               CSLT_STRIPLEADSPACES | CSLT_STRIPENDSPACES);
+                               CSLT_STRIPLEADSPACES | CSLT_STRIPENDSPACES |
+                               CSLT_PRESERVEQUOTES);
 
     //  -------------------------------------------------------------------
     //  The "/" should not be catch on the previous parser


### PR DESCRIPTION
Backport #10865
 **Authored by:** @fechen123