### PR TITLE
Make gdalinfo/ogrinfo --formats -json work

### DIFF
--- a/autotest/utilities/test_gdalinfo.py
+++ b/autotest/utilities/test_gdalinfo.py
@@ -344,6 +344,25 @@ def test_gdalinfo_20(gdalinfo_path):
 
 
 ###############################################################################
+# Test --formats -json
+
+
+@pytest.mark.require_driver("VRT")
+def test_gdalinfo_formats_json(gdalinfo_path):
+
+    ret = json.loads(
+        gdaltest.runexternal(gdalinfo_path + " --formats -json", check_memleak=False)
+    )
+    assert {
+        "short_name": "VRT",
+        "long_name": "Virtual Raster",
+        "scopes": ["raster", "multidimensional_raster"],
+        "capabilities": ["open", "create", "create_copy", "virtual_io"],
+        "file_extensions": ["vrt"],
+    } in ret
+
+
+###############################################################################
 # Test erroneous use of --format.
 
 

--- a/autotest/utilities/test_ogrinfo.py
+++ b/autotest/utilities/test_ogrinfo.py
@@ -29,6 +29,7 @@
 # DEALINGS IN THE SOFTWARE.
 ###############################################################################
 
+import json
 import os
 import pathlib
 import stat
@@ -322,6 +323,25 @@ def test_ogrinfo_19(ogrinfo_path):
 
     ret = gdaltest.runexternal(ogrinfo_path + " --formats", check_memleak=False)
     assert "ESRI Shapefile -vector- (rw+v): ESRI Shapefile" in ret
+
+
+###############################################################################
+# Test --formats -json
+
+
+@pytest.mark.require_driver("ESRI Shapefile")
+def test_ogrinfo_formats_json(ogrinfo_path):
+
+    ret = json.loads(
+        gdaltest.runexternal(ogrinfo_path + " --formats -json", check_memleak=False)
+    )
+    assert {
+        "short_name": "ESRI Shapefile",
+        "long_name": "ESRI Shapefile",
+        "scopes": ["vector"],
+        "capabilities": ["open", "create", "virtual_io"],
+        "file_extensions": ["shp", "dbf", "shz", "shp.zip"],
+    } in ret
 
 
 ###############################################################################

--- a/doc/source/programs/raster_common_options.rst
+++ b/doc/source/programs/raster_common_options.rst
@@ -21,6 +21,10 @@ All GDAL command line programs support the following common options.
 
     List detailed information about a single format driver. The format should be the short name reported in the --formats list, such as GTiff.
 
+.. option:: --formats
+
+    List all drivers. Can be combined with ``-json`` switch of :program:`gdalinfo` of since GDAL 3.10
+
 .. _raster_common_options_optfile:
 .. option:: --optfile <filename>
 

--- a/doc/source/programs/vector_common_options.rst
+++ b/doc/source/programs/vector_common_options.rst
@@ -22,6 +22,10 @@ All GDAL OGR command line programs support the following common options.
     The format should be the short name reported in the :option:`--formats`
     list, such as GML.
 
+.. option:: --formats
+
+    List all drivers. Can be combined with ``-json`` switch of :program:`ogrinfo` of since GDAL 3.10
+
 .. option:: --optfile <filename>
 
     Read the named file and substitute the contents into the command line


### PR DESCRIPTION
Fixes #10878

Note: only available in utilities-as-binaries, not utilities-as-libraries...

Returns drivers in the order of their registration.

Example
```shell
$ gdalinfo --formats -json
[
  {
    "short_name":"VRT",
    "long_name":"Virtual Raster",
    "scopes":[
      "raster",
      "multidimensional_raster"
    ],
    "capabilities":[
      "open",
      "create",
      "create_copy",
      "virtual_io"
    ],
    "file_extensions":[
      "vrt"
    ]
  },
  ...
]
```

```shell
$ ogrinfo --formats -json
[
  {
    "short_name":"FITS",
    "long_name":"Flexible Image Transport System",
    "scopes":[
      "raster",
      "vector"
    ],
    "capabilities":[
      "open",
      "create"
    ],
    "file_extensions":[
      "fits"
    ]
  },
  ...
]
```
