### PR TITLE
gdalwarp: allow unlimited warp memory with -wm unlimited

### DIFF
--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -5754,11 +5754,20 @@ GDALWarpAppOptionsGetParser(GDALWarpAppOptions *psOptions,
         .action(
             [psOptions](const std::string &s)
             {
-                if (CPLAtofM(s.c_str()) < 10000)
+                if (EQUAL("unlimited", s.c_str()))
+                {
+                    psOptions->dfWarpMemoryLimit =
+                        std::numeric_limits<double>::infinity();
+                }
+                else if (CPLAtofM(s.c_str()) < 10000)
+                {
                     psOptions->dfWarpMemoryLimit =
                         CPLAtofM(s.c_str()) * 1024 * 1024;
+                }
                 else
+                {
                     psOptions->dfWarpMemoryLimit = CPLAtofM(s.c_str());
+                }
             })
         .help(_("Set max warp memory."));
 

--- a/doc/source/programs/gdalwarp.rst
+++ b/doc/source/programs/gdalwarp.rst
@@ -394,6 +394,9 @@ with control information.
     the "warp memory" allowed it will subdivide the chunk into smaller chunks
     and try again.
 
+    A -wm value of "unlimited" will prevent this chunking. If sufficient
+    memory is not available, the program will fail.
+
     If the -wm value is very small there is some extra overhead in doing many
     small chunks so setting it larger is better but it is a matter of
     diminishing returns.


### PR DESCRIPTION
There may be good reasons not to allow this. I was just looking for an easy way to rule out chunk boundaries when investigating artifacts observed in gdalwarp output.