### PR TITLE
[Backport release/3.9] PDF: avoid 'Non closed ring detected' warning when reading neatlines from OGC Best Practice encoding

### DIFF
--- a/autotest/gdrivers/pdf.py
+++ b/autotest/gdrivers/pdf.py
@@ -374,12 +374,14 @@ def test_pdf_ogcbp(poppler_or_pdfium_or_podofo):
         tst = gdaltest.GDALTest(
             "PDF", "byte.tif", 1, None, options=["GEO_ENCODING=OGC_BP"]
         )
+        gdal.ErrorReset()
         tst.testCreateCopy(
             check_minmax=0,
             check_gt=1,
             check_srs=True,
             check_checksum_not_null=pdf_checksum_available(),
         )
+        assert gdal.GetLastErrorMsg() == ""
 
 
 ###############################################################################

--- a/frmts/pdf/pdfdataset.cpp
+++ b/frmts/pdf/pdfdataset.cpp
@@ -5948,6 +5948,7 @@ int PDFDataset::ParseLGIDictDictFirstPass(GDALPDFDictionary *poLGIDict,
                 poRing->addPoint(dfX, dfY);
             }
         }
+        poRing->closeRings();
         m_poNeatLine->addRingDirectly(poRing);
     }
 


### PR DESCRIPTION
Backport #10849
 **Authored by:** @rouault