### PR TITLE
[doc] fix link to GDAL sponsorship prospectus

### DIFF
--- a/doc/source/sponsors/faq.rst
+++ b/doc/source/sponsors/faq.rst
@@ -38,7 +38,7 @@ various levels start with the `Sustainable GDAL Sponsorship Prospectus`_.
 If you are interested, need help convincing your key decision-makers, or have
 any questions, don't hesitate to contact gdal-sponsors@osgeo.org.
 
-.. _Sustainable GDAL Sponsorship Prospectus: https://gdal.org/sponsors/Sustainable%20GDAL%20Sponsorship%20Prospectus.pdf
+.. _Sustainable GDAL Sponsorship Prospectus: ../_static/Sustainable%20GDAL%20Sponsorship%20Prospectus.pdf
 
 What is NumFOCUS and why is the project using that foundation rather than using OSGeo for this effort?
 ------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?
Fix link in documentation. Broken due to migration to readthedocs.
The link is now the same as in index.html

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
