### PR TITLE
[Backport release/3.9] Python bindings: fix passing a dict value to the transformerOptions argument of gdal.Warp()

### DIFF
--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -1830,7 +1830,10 @@ def test_gdalwarp_lib_134(tmp_vsimem):
         "",
         src_ds,
         format="MEM",
-        transformerOptions=["SRC_METHOD=NO_GEOTRANSFORM", "DST_METHOD=NO_GEOTRANSFORM"],
+        transformerOptions={
+            "SRC_METHOD": "NO_GEOTRANSFORM",
+            "DST_METHOD": "NO_GEOTRANSFORM",
+        },
         outputBounds=[1, 2, 4, 6],
     )
     assert ds is not None

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -2839,7 +2839,7 @@ def WarpOptions(options=None, format=None,
         if transformerOptions is not None:
             if isinstance(transformerOptions, dict):
                 for k, v in transformerOptions.items():
-                    new_options += ['-to', opt]
+                    new_options += ['-to', f'{k}={v}']
             else:
                 for opt in transformerOptions:
                     new_options += ['-to', opt]


### PR DESCRIPTION
Backport #10921
 **Authored by:** @rouault