### PR TITLE
docker: fix ccache

### DIFF
--- a/docker/alpine-normal/Dockerfile
+++ b/docker/alpine-normal/Dockerfile
@@ -143,12 +143,12 @@ RUN mkdir proj \
     && cd proj \
     && if test "${RSYNC_REMOTE}" != ""; then \
         echo "Downloading cache..."; \
-        rsync -ra ${RSYNC_REMOTE}/proj/$(uname -m)/ $HOME/; \
+        mkdir -p "$HOME/.cache"; \
+        rsync -ra ${RSYNC_REMOTE}/proj/$(uname -m)/ $HOME/.cache/; \
         echo "Finished"; \
         export CC="ccache gcc"; \
         export CXX="ccache g++"; \
-        mkdir -p "$HOME/.ccache"; \
-        export PROJ_DB_CACHE_DIR="$HOME/.ccache"; \
+        export PROJ_DB_CACHE_DIR="$HOME/.cache"; \
         ccache -M 100M; \
     fi \
     # IPO disabled since it crashes with gcc 13.2.1
@@ -164,9 +164,9 @@ RUN mkdir proj \
     && if test "${RSYNC_REMOTE}" != ""; then \
         ccache -s; \
         echo "Uploading cache..."; \
-        rsync -ra --delete $HOME/.ccache ${RSYNC_REMOTE}/proj/$(uname -m)/; \
+        rsync -ra --delete $HOME/.cache/ ${RSYNC_REMOTE}/proj/$(uname -m)/; \
         echo "Finished"; \
-        rm -rf $HOME/.ccache; \
+        rm -rf $HOME/.cache; \
         unset CC; \
         unset CXX; \
     fi \
@@ -185,11 +185,11 @@ RUN if test "${SPATIALITE_VERSION}" != "" -a "$(uname -m)" = "x86_64"; then ( \
     && apk add --no-cache minizip-dev \
     && if test "${RSYNC_REMOTE}" != ""; then \
         echo "Downloading cache..."; \
-        rsync -ra ${RSYNC_REMOTE}/spatialite/ $HOME/; \
+        mkdir -p "$HOME/.cache"; \
+        rsync -ra ${RSYNC_REMOTE}/spatialite/ $HOME/.cache/; \
         echo "Finished"; \
         export CC="ccache gcc"; \
         export CXX="ccache g++"; \
-        mkdir -p "$HOME/.ccache"; \
         ccache -M 100M; \
     fi \
     && ./configure --prefix=/usr --disable-static --disable-rttopo \
@@ -198,9 +198,9 @@ RUN if test "${SPATIALITE_VERSION}" != "" -a "$(uname -m)" = "x86_64"; then ( \
     && if test "${RSYNC_REMOTE}" != ""; then \
         ccache -s; \
         echo "Uploading cache..."; \
-        rsync -ra --delete $HOME/.ccache ${RSYNC_REMOTE}/spatialite/; \
+        rsync -ra --delete $HOME/.cache/ ${RSYNC_REMOTE}/spatialite/; \
         echo "Finished"; \
-        rm -rf $HOME/.ccache; \
+        rm -rf $HOME/.cache; \
         unset CC; \
         unset CXX; \
     fi \
@@ -236,7 +236,8 @@ RUN if test "${GDAL_VERSION}" = "master"; then \
     && cd gdal \
     && if test "${RSYNC_REMOTE}" != ""; then \
         echo "Downloading cache..."; \
-        rsync -ra ${RSYNC_REMOTE}/gdal/$(uname -m)/ $HOME/; \
+        mkdir -p "$HOME/.cache"; \
+        rsync -ra ${RSYNC_REMOTE}/gdal/$(uname -m)/ $HOME/.cache/; \
         echo "Finished"; \
         # Little trick to avoid issues with Python bindings
         printf "#!/bin/sh\nccache gcc \$*" > ccache_gcc.sh; \
@@ -245,7 +246,6 @@ RUN if test "${GDAL_VERSION}" = "master"; then \
         chmod +x ccache_g++.sh; \
         export CC=$PWD/ccache_gcc.sh; \
         export CXX=$PWD/ccache_g++.sh; \
-        mkdir -p "$HOME/.ccache"; \
         ccache -M 1G; \
     fi \
     && mkdir build \
@@ -267,9 +267,9 @@ RUN if test "${GDAL_VERSION}" = "master"; then \
     && if test "${RSYNC_REMOTE}" != ""; then \
         ccache -s; \
         echo "Uploading cache..."; \
-        rsync -ra --delete $HOME/.ccache ${RSYNC_REMOTE}/gdal/$(uname -m)/; \
+        rsync -ra --delete $HOME/.cache/ ${RSYNC_REMOTE}/gdal/$(uname -m)/; \
         echo "Finished"; \
-        rm -rf $HOME/.ccache; \
+        rm -rf $HOME/.cache; \
         unset CC; \
         unset CXX; \
     fi \

--- a/docker/alpine-small/Dockerfile
+++ b/docker/alpine-small/Dockerfile
@@ -61,12 +61,12 @@ RUN mkdir proj \
     && cd proj \
     && if test "${RSYNC_REMOTE}" != ""; then \
         echo "Downloading cache..."; \
-        rsync -ra ${RSYNC_REMOTE}/proj/$(uname -m)/ $HOME/; \
+        mkdir -p "$HOME/.cache"; \
+        rsync -ra ${RSYNC_REMOTE}/proj/$(uname -m)/ $HOME/.cache/; \
         echo "Finished"; \
         export CC="ccache gcc"; \
         export CXX="ccache g++"; \
-        mkdir -p "$HOME/.ccache"; \
-        export PROJ_DB_CACHE_DIR="$HOME/.ccache"; \
+        export PROJ_DB_CACHE_DIR="$HOME/.cache"; \
         ccache -M 100M; \
     fi \
     # IPO disabled since it crashes with gcc 13.2.1
@@ -82,9 +82,9 @@ RUN mkdir proj \
     && if test "${RSYNC_REMOTE}" != ""; then \
         ccache -s; \
         echo "Uploading cache..."; \
-        rsync -ra --delete $HOME/.ccache ${RSYNC_REMOTE}/proj/$(uname -m)/; \
+        rsync -ra --delete $HOME/.cache/ ${RSYNC_REMOTE}/proj/$(uname -m)/; \
         echo "Finished"; \
-        rm -rf $HOME/.ccache; \
+        rm -rf $HOME/.cache; \
         unset CC; \
         unset CXX; \
     fi \
@@ -110,11 +110,11 @@ RUN if test "${GDAL_VERSION}" = "master"; then \
     fi \
     && if test "${RSYNC_REMOTE}" != ""; then \
         echo "Downloading cache..."; \
-        rsync -ra ${RSYNC_REMOTE}/gdal/$(uname -m)/ $HOME/; \
+        mkdir -p "$HOME/.cache"; \
+        rsync -ra ${RSYNC_REMOTE}/gdal/$(uname -m)/ $HOME/.cache/; \
         echo "Finished"; \
         export CC="ccache gcc"; \
         export CXX="ccache g++"; \
-        mkdir -p "$HOME/.ccache"; \
         ccache -M 1G; \
     fi \
     && mkdir gdal \
@@ -135,9 +135,9 @@ RUN if test "${GDAL_VERSION}" = "master"; then \
     && if test "${RSYNC_REMOTE}" != ""; then \
         ccache -s; \
         echo "Uploading cache..."; \
-        rsync -ra --delete $HOME/.ccache ${RSYNC_REMOTE}/gdal/$(uname -m)/; \
+        rsync -ra --delete $HOME/.cache/ ${RSYNC_REMOTE}/gdal/$(uname -m)/; \
         echo "Finished"; \
-        rm -rf $HOME/.ccache; \
+        rm -rf $HOME/.cache; \
         unset CC; \
         unset CXX; \
     fi \

--- a/docker/ubuntu-full/bh-gdal.sh
+++ b/docker/ubuntu-full/bh-gdal.sh
@@ -23,7 +23,8 @@ curl -L -fsS "https://github.com/${GDAL_REPOSITORY}/archive/${GDAL_VERSION}.tar.
 
     if test "${RSYNC_REMOTE:-}" != ""; then
         echo "Downloading cache..."
-        rsync -ra "${RSYNC_REMOTE}/gdal/${GCC_ARCH}/" "$HOME/"
+        mkdir -p "$HOME/.cache/"
+        rsync -ra "${RSYNC_REMOTE}/gdal/${GCC_ARCH}/" "$HOME/.cache/"
         echo "Finished"
 
         # Little trick to avoid issues with Python bindings
@@ -85,7 +86,7 @@ curl -L -fsS "https://github.com/${GDAL_REPOSITORY}/archive/${GDAL_VERSION}.tar.
         ccache -s
 
         echo "Uploading cache..."
-        rsync -ra --delete "$HOME/.cache" "${RSYNC_REMOTE}/gdal/${GCC_ARCH}/"
+        rsync -ra --delete "$HOME/.cache/" "${RSYNC_REMOTE}/gdal/${GCC_ARCH}/"
         echo "Finished"
 
         rm -rf "$HOME/.cache"

--- a/docker/ubuntu-full/bh-proj.sh
+++ b/docker/ubuntu-full/bh-proj.sh
@@ -21,7 +21,8 @@ curl -L -fsS "https://github.com/OSGeo/PROJ/archive/${PROJ_VERSION}.tar.gz" \
 
     if [ -n "${RSYNC_REMOTE:-}" ]; then
         echo "Downloading cache..."
-        rsync -ra "${RSYNC_REMOTE}/proj/${GCC_ARCH}/" "$HOME/"
+        mkdir -p "$HOME/.cache"
+        rsync -ra "${RSYNC_REMOTE}/proj/${GCC_ARCH}/" "$HOME/.cache/"
         echo "Finished"
 
         export CC="ccache ${GCC_ARCH}-linux-gnu-gcc"
@@ -46,7 +47,7 @@ curl -L -fsS "https://github.com/OSGeo/PROJ/archive/${PROJ_VERSION}.tar.gz" \
         ccache -s
 
         echo "Uploading cache..."
-        rsync -ra --delete "$HOME/.cache" "${RSYNC_REMOTE}/proj/${GCC_ARCH}/"
+        rsync -ra --delete "$HOME/.cache/" "${RSYNC_REMOTE}/proj/${GCC_ARCH}/"
         echo "Finished"
 
         rm -rf "$HOME/.cache"

--- a/docker/ubuntu-small/Dockerfile
+++ b/docker/ubuntu-small/Dockerfile
@@ -103,11 +103,12 @@ RUN . /buildscripts/bh-set-envvars.sh \
     && cd proj \
     && if test "${RSYNC_REMOTE:-}" != ""; then \
         echo "Downloading cache..."; \
-        rsync -ra ${RSYNC_REMOTE}/proj/${GCC_ARCH}/ $HOME/; \
+        mkdir -p $HOME/.cache; \
+        rsync -ra ${RSYNC_REMOTE}/proj/${GCC_ARCH}/ $HOME/.cache/; \
         echo "Finished"; \
         export CC="ccache ${GCC_ARCH}-linux-gnu-gcc"; \
         export CXX="ccache ${GCC_ARCH}-linux-gnu-g++"; \
-        export PROJ_DB_CACHE_DIR="$HOME/.ccache"; \
+        export PROJ_DB_CACHE_DIR="$HOME/.cache"; \
         ccache -M 100M; \
     fi \
     && CFLAGS='-DPROJ_RENAME_SYMBOLS -O2' CXXFLAGS='-DPROJ_RENAME_SYMBOLS -DPROJ_INTERNAL_CPP_NAMESPACE -O2' \
@@ -121,9 +122,9 @@ RUN . /buildscripts/bh-set-envvars.sh \
     && if test "${RSYNC_REMOTE:-}" != ""; then \
         ccache -s; \
         echo "Uploading cache..."; \
-        rsync -ra --delete $HOME/.ccache ${RSYNC_REMOTE}/proj/${GCC_ARCH}/; \
+        rsync -ra --delete $HOME/.cache/ ${RSYNC_REMOTE}/proj/${GCC_ARCH}/; \
         echo "Finished"; \
-        rm -rf $HOME/.ccache; \
+        rm -rf $HOME/.cache; \
         unset CC; \
         unset CXX; \
     fi \
@@ -163,7 +164,8 @@ RUN . /buildscripts/bh-set-envvars.sh \
     && cd gdal \
     && if test "${RSYNC_REMOTE:-}" != ""; then \
         echo "Downloading cache..."; \
-        rsync -ra ${RSYNC_REMOTE}/gdal/${GCC_ARCH}/ $HOME/; \
+        mkdir -p $HOME/.cache; \
+        rsync -ra ${RSYNC_REMOTE}/gdal/${GCC_ARCH}/ $HOME/.cache/; \
         echo "Finished"; \
         # Little trick to avoid issues with Python bindings
         printf "#!/bin/sh\nccache %s-linux-gnu-gcc \$*" "${GCC_ARCH}" > ccache_gcc.sh; \
@@ -192,9 +194,9 @@ RUN . /buildscripts/bh-set-envvars.sh \
     && if test "${RSYNC_REMOTE:-}" != ""; then \
         ccache -s; \
         echo "Uploading cache..."; \
-        rsync -ra --delete $HOME/.ccache ${RSYNC_REMOTE}/gdal/${GCC_ARCH}/; \
+        rsync -ra --delete $HOME/.cache/ ${RSYNC_REMOTE}/gdal/${GCC_ARCH}/; \
         echo "Finished"; \
-        rm -rf $HOME/.ccache; \
+        rm -rf $HOME/.cache; \
         unset CC; \
         unset CXX; \
     fi \


### PR DESCRIPTION
The rsync commands use the wrong
directory, so the commands fail
and print an error message, but
the build continues.

Fix the commands so they work,
but leave the missing error
detection as is.