### PR TITLE
VRTWarpedDataset::IRasterIO(): optimize I/O when requesting whole image at a resolution that doesn't match an overview

### DIFF
--- a/alg/gdal_alg_priv.h
+++ b/alg/gdal_alg_priv.h
@@ -173,6 +173,7 @@ constexpr const char *GDAL_APPROX_TRANSFORMER_CLASS_NAME =
     "GDALApproxTransformer";
 constexpr const char *GDAL_GEN_IMG_TRANSFORMER_CLASS_NAME =
     "GDALGenImgProjTransformer";
+constexpr const char *GDAL_RPC_TRANSFORMER_CLASS_NAME = "GDALRPCTransformer";
 
 bool GDALIsTransformer(void *hTransformerArg, const char *pszClassName);
 
@@ -205,6 +206,8 @@ bool GDALTransformIsTranslationOnPixelBoundaries(
 
 bool GDALTransformIsAffineNoRotation(GDALTransformerFunc pfnTransformer,
                                      void *pTransformerArg);
+
+bool GDALTransformHasFastClone(void *pTransformerArg);
 
 typedef struct _CPLQuadTree CPLQuadTree;
 

--- a/alg/gdal_rpc.cpp
+++ b/alg/gdal_rpc.cpp
@@ -48,6 +48,7 @@
 #include "gdal.h"
 #include "gdal_interpolateatpoint.h"
 #include "gdal_mdreader.h"
+#include "gdal_alg_priv.h"
 #include "gdal_priv.h"
 #if defined(__x86_64) || defined(_M_X64)
 #define USE_SSE2_OPTIM
@@ -837,7 +838,7 @@ void *GDALCreateRPCTransformerV2(const GDALRPCInfoV2 *psRPCInfo, int bReversed,
 
     memcpy(psTransform->sTI.abySignature, GDAL_GTI2_SIGNATURE,
            strlen(GDAL_GTI2_SIGNATURE));
-    psTransform->sTI.pszClassName = "GDALRPCTransformer";
+    psTransform->sTI.pszClassName = GDAL_RPC_TRANSFORMER_CLASS_NAME;
     psTransform->sTI.pfnTransform = GDALRPCTransform;
     psTransform->sTI.pfnCleanup = GDALDestroyRPCTransformer;
     psTransform->sTI.pfnSerialize = GDALSerializeRPCTransformer;

--- a/alg/gdaltransformer.cpp
+++ b/alg/gdaltransformer.cpp
@@ -4919,3 +4919,42 @@ bool GDALTransformIsAffineNoRotation(GDALTransformerFunc, void *pTransformerArg)
     }
     return false;
 }
+
+/************************************************************************/
+/*                        GDALTransformHasFastClone()                   */
+/************************************************************************/
+
+/** Returns whether GDALCloneTransformer() on this transformer is
+ * "fast"
+ * Counter-examples are GCPs or TPSs transformers.
+ */
+bool GDALTransformHasFastClone(void *pTransformerArg)
+{
+    if (GDALIsTransformer(pTransformerArg, GDAL_APPROX_TRANSFORMER_CLASS_NAME))
+    {
+        const auto *pApproxInfo =
+            static_cast<const ApproxTransformInfo *>(pTransformerArg);
+        pTransformerArg = pApproxInfo->pBaseCBData;
+        // Fallback to next lines
+    }
+
+    if (GDALIsTransformer(pTransformerArg, GDAL_GEN_IMG_TRANSFORMER_CLASS_NAME))
+    {
+        const auto *pGenImgpProjInfo =
+            static_cast<GDALGenImgProjTransformInfo *>(pTransformerArg);
+        return (pGenImgpProjInfo->pSrcTransformArg == nullptr ||
+                GDALTransformHasFastClone(
+                    pGenImgpProjInfo->pSrcTransformArg)) &&
+               (pGenImgpProjInfo->pDstTransformArg == nullptr ||
+                GDALTransformHasFastClone(pGenImgpProjInfo->pDstTransformArg));
+    }
+    else if (GDALIsTransformer(pTransformerArg,
+                               GDAL_RPC_TRANSFORMER_CLASS_NAME))
+    {
+        return true;
+    }
+    else
+    {
+        return false;
+    }
+}

--- a/alg/gdalwarper.h
+++ b/alg/gdalwarper.h
@@ -557,6 +557,9 @@ class CPL_DLL GDALWarpOperation
     CPLErr Initialize(const GDALWarpOptions *psNewOptions);
     void *CreateDestinationBuffer(int nDstXSize, int nDstYSize,
                                   int *pbWasInitialized = nullptr);
+    void InitializeDestinationBuffer(void *pDstBuffer, int nDstXSize,
+                                     int nDstYSize,
+                                     int *pbWasInitialized = nullptr);
     static void DestroyDestinationBuffer(void *pDstBuffer);
 
     const GDALWarpOptions *GetOptions();

--- a/alg/gdalwarpoperation.cpp
+++ b/alg/gdalwarpoperation.cpp
@@ -694,10 +694,40 @@ void *GDALWarpOperation::CreateDestinationBuffer(int nDstXSize, int nDstYSize,
     void *pDstBuffer = VSI_MALLOC3_VERBOSE(
         cpl::fits_on<int>(nWordSize * psOptions->nBandCount), nDstXSize,
         nDstYSize);
-    if (pDstBuffer == nullptr)
+    if (pDstBuffer)
     {
-        return nullptr;
+        InitializeDestinationBuffer(pDstBuffer, nDstXSize, nDstYSize,
+                                    pbInitialized);
     }
+    return pDstBuffer;
+}
+
+/**
+ * This method initializes a destination buffer for use with WarpRegionToBuffer.
+ *
+ * It is initialized based on the INIT_DEST settings.
+ *
+ * This method is called by CreateDestinationBuffer().
+ * It is meant at being used by callers that have already allocated the
+ * destination buffer without using CreateDestinationBuffer().
+ *
+ * @param pDstBuffer Buffer of size
+ *                   GDALGetDataTypeSizeBytes(psOptions->eWorkingDataType) *
+ *                   nDstXSize * nDstYSize * psOptions->nBandCount bytes.
+ * @param nDstXSize Width of output window on destination buffer to be produced.
+ * @param nDstYSize Height of output window on destination buffer to be
+ *                  produced.
+ * @param pbInitialized Filled with boolean indicating if the buffer was
+ *                      initialized.
+ * @since 3.10
+ */
+void GDALWarpOperation::InitializeDestinationBuffer(void *pDstBuffer,
+                                                    int nDstXSize,
+                                                    int nDstYSize,
+                                                    int *pbInitialized)
+{
+    const int nWordSize = GDALGetDataTypeSizeBytes(psOptions->eWorkingDataType);
+
     const GPtrDiff_t nBandSize =
         static_cast<GPtrDiff_t>(nWordSize) * nDstXSize * nDstYSize;
 
@@ -713,8 +743,7 @@ void *GDALWarpOperation::CreateDestinationBuffer(int nDstXSize, int nDstYSize,
         {
             *pbInitialized = FALSE;
         }
-
-        return pDstBuffer;
+        return;
     }
 
     if (pbInitialized != nullptr)
@@ -776,8 +805,6 @@ void *GDALWarpOperation::CreateDestinationBuffer(int nDstXSize, int nDstYSize,
     }
 
     CSLDestroy(papszInitValues);
-
-    return pDstBuffer;
 }
 
 /**

--- a/autotest/gdrivers/vrtwarp.py
+++ b/autotest/gdrivers/vrtwarp.py
@@ -734,8 +734,15 @@ def test_vrtwarp_irasterio_optim_three_band():
     assert warped_vrt_ds.ReadRaster(buf_type=gdal.GDT_UInt16) == expected_data
 
     with gdaltest.config_option("GDAL_VRT_WARP_USE_DATASET_RASTERIO", "NO"):
-        expected_data = warped_vrt_ds.ReadRaster(buf_xsize=20, buf_ysize=20)
-    assert warped_vrt_ds.ReadRaster(buf_xsize=20, buf_ysize=20) == expected_data
+        expected_data = warped_vrt_ds.ReadRaster(buf_xsize=20, buf_ysize=40)
+    assert warped_vrt_ds.ReadRaster(buf_xsize=20, buf_ysize=40) == expected_data
+
+    with gdaltest.config_option("GDAL_VRT_WARP_USE_DATASET_RASTERIO", "NO"):
+        expected_data = warped_vrt_ds.ReadRaster(1, 2, 3, 4, buf_xsize=20, buf_ysize=40)
+    assert (
+        warped_vrt_ds.ReadRaster(1, 2, 3, 4, buf_xsize=20, buf_ysize=40)
+        == expected_data
+    )
 
 
 ###############################################################################

--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -507,7 +507,7 @@ class CPL_DLL VRTWarpedDataset final : public VRTDataset
 
     bool GetOverviewSize(GDALDataset *poSrcDS, int iOvr, int iSrcOvr,
                          int &nOvrXSize, int &nOvrYSize, double &dfSrcRatioX,
-                         double &dfSrcRatioY, double &dfTargetRatio) const;
+                         double &dfSrcRatioY) const;
     int GetOverviewCount() const;
     int GetSrcOverviewLevel(int iOvr, bool &bThisLevelOnlyOut) const;
     VRTWarpedDataset *CreateImplicitOverview(int iOvr) const;


### PR DESCRIPTION
Fixes https://github.com/rasterio/rasterio/issues/3203

With that optimization:

```
$ gdalwarp /vsicurl/https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/T/VK/2023/10/S2B_15TVK_20231008_0_L2A/TCI.tif in.vrt

$ CPL_DEBUG=VSICURL GDAL_INGESTED_BYTES_AT_OPEN=32768 GDAL_HTTP_MULTIRANGE=YES GDAL_HTTP_MERGE_CONSECUTIVE_RANGES=YES GDAL_DISABLE_READDIR_ON_OPEN=EMPTY_DIR python -c "from osgeo import gdal; ds = gdal.Open('in.vrt'); ds.ReadRaster(0, 0, ds.RasterXSize, ds.RasterYSize, ds.RasterXSize // 5, ds.RasterYSize // 5)"
/home/even/gdal/gdal/build_cmake/swig/python/osgeo/gdal.py:311: FutureWarning: Neither gdal.UseExceptions() nor gdal.DontUseExceptions() has been explicitly called. In GDAL 4.0, exceptions will be enabled by default.
  warnings.warn(
VSICURL: GetFileSize(https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/T/VK/2023/10/S2B_15TVK_20231008_0_L2A/TCI.tif)=200959614  response_code=200
VSICURL: Downloading 0-32767 (https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/T/VK/2023/10/S2B_15TVK_20231008_0_L2A/TCI.tif)...
VSICURL: Got response_code=206
VSICURL: GetFileList(/vsicurl/https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/T/VK/2023/10/S2B_15TVK_20231008_0_L2A)
VSICURL: GetFileSize(https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/T/VK/2023/10/S2B_15TVK_20231008_0_L2A/TCI.xml)=0  response_code=404
VSICURL: GetFileSize(https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/T/VK/2023/10/S2B_15TVK_20231008_0_L2A/TCI.XML)=0  response_code=404
VSICURL: Downloading 3096576-13139967 (https://sentinel-cogs.s3.us-west-2.amazonaws.com/sentinel-s2-l2a-cogs/15/T/VK/2023/10/S2B_15TVK_20231008_0_L2A/TCI.tif)...
VSICURL: Got response_code=206
```
