### PR TITLE
Update ogrinfo.rst

### DIFF
--- a/doc/source/programs/ogrinfo.rst
+++ b/doc/source/programs/ogrinfo.rst
@@ -17,7 +17,7 @@ Synopsis
 .. code-block::
 
     ogrinfo [--help] [--help-general]
-            [-if <driver_name>] [-json] [-ro] [-q] [-where <restricted_where>|@f<ilename>]
+            [-if <driver_name>] [-json] [-ro] [-q] [-where <restricted_where>|@<filename>]
             [-spat <xmin> <ymin> <xmax> <ymax>] [-geomfield <field>] [-fid <fid>]
             [-sql <statement>|@<filename>] [-dialect <sql_dialect>] [-al] [-rl]
             [-so|-features] [-limit <nb_features>] [-fields={YES|NO}]]


### PR DESCRIPTION
P.S., be sure to add at least one example of usage of '@filename'.

Apparently it is meant to be the equivalent of Unix \`cat filename\`.

For instance, when it says

> An attribute query in a restricted form of the queries used in the SQL WHERE statement. Only features matching the attribute query will be reported. Starting with GDAL 2.1, the \@\<filename> syntax can be used to indicate that the content is in the pointed filename.

it seems like we can attach `@filename` to mean our query only applies to that filename,
```
ERROR 1: SQL Expression Parsing Error: syntax error, unexpected invalid token, expecting end of stri\
ng. Occurred around :
Name = 'CHOPPER_n'@chopper.kml
                  ^
```
Yes foolish as it seems. Therefore be sure to add an example.

By the way, on ogr2ogr
>When  specifying  a  datasource,  you  will generally want to use
-clipsrc in combination of the  -clipsrclayer,  -clipsrcwhere  or
-clipsrcsql options.

mention which of these cannot be used at the same time.