### PR TITLE
GTiff: use main dataset GetSiblingFiles() for overviews

### DIFF
--- a/frmts/gtiff/gtiffdataset_read.cpp
+++ b/frmts/gtiff/gtiffdataset_read.cpp
@@ -5835,6 +5835,10 @@ CSLConstList GTiffDataset::GetSiblingFiles()
     {
         return oOvManager.GetSiblingFiles();
     }
+    if (m_poBaseDS)
+    {
+        return m_poBaseDS->GetSiblingFiles();
+    }
 
     m_bHasGotSiblingFiles = true;
     const int nMaxFiles =


### PR DESCRIPTION
Fixes https://github.com/cogeotiff/rio-tiler/issues/697
