### PR TITLE
Use stricter typing for void* pTransformerArg

### DIFF
--- a/MIGRATION_GUIDE.TXT
+++ b/MIGRATION_GUIDE.TXT
@@ -29,6 +29,15 @@ MIGRATION GUIDE FROM GDAL 3.9 to GDAL 3.10
 - New color interpretation (GCI_xxxx) items have been added to the GDALColorInterp
   enumeration. Code testing color interpretation may need to be adapted.
 
+- Out of tree code using GDALTransformer. "void* pTransformArg" arguments are
+  now "GDALTransformerArg pTransformArg" where GDALTransformerArg is
+  a typedef to a pointer to an anonymous struct. Code doing things like
+  static_cast<MyCustomTransformerInfo*>(...) must now use
+  reinterpret_cast<MyCustomTransformerInfo>(...)
+  and code returning a void* that is a transformer argument must use
+  reinterpret_cast<GDALTransformerArg>(...).
+
+
 MIGRATION GUIDE FROM GDAL 3.8 to GDAL 3.9
 -----------------------------------------
 

--- a/alg/gdal_alg.h
+++ b/alg/gdal_alg.h
@@ -81,7 +81,7 @@ CPLErr CPL_DLL CPL_STDCALL GDALSieveFilter(
  * All transformer arguments should have a GDALTransformerInfo member as their
  * first member.
  */
-typedef void *GDALTransformerArg;
+typedef struct GDALTransformerArgOpaque *GDALTransformerArg;
 
 typedef int (*GDALTransformerFunc)(GDALTransformerArg pTransformerArg,
                                    int bDstToSrc, int nPointCount, double *x,

--- a/alg/gdal_alg_priv.h
+++ b/alg/gdal_alg_priv.h
@@ -159,9 +159,10 @@ constexpr const char *GDAL_GEN_IMG_TRANSFORMER_CLASS_NAME =
     "GDALGenImgProjTransformer";
 constexpr const char *GDAL_RPC_TRANSFORMER_CLASS_NAME = "GDALRPCTransformer";
 
-bool GDALIsTransformer(void *hTransformerArg, const char *pszClassName);
+bool GDALIsTransformer(GDALTransformerArg hTransformerArg,
+                       const char *pszClassName);
 
-typedef void *(*GDALTransformDeserializeFunc)(CPLXMLNode *psTree);
+typedef GDALTransformerArg (*GDALTransformDeserializeFunc)(CPLXMLNode *psTree);
 
 void CPL_DLL *GDALRegisterTransformDeserializer(
     const char *pszTransformName, GDALTransformerFunc pfnTransformerFunc,
@@ -172,26 +173,29 @@ void GDALCleanupTransformDeserializerMutex();
 
 /* Transformer cloning */
 
-void *GDALCreateTPSTransformerInt(int nGCPCount, const GDAL_GCP *pasGCPList,
-                                  int bReversed, char **papszOptions);
+GDALTransformerArg GDALCreateTPSTransformerInt(int nGCPCount,
+                                               const GDAL_GCP *pasGCPList,
+                                               int bReversed,
+                                               char **papszOptions);
 
-void CPL_DLL *GDALCloneTransformer(void *pTransformerArg);
+GDALTransformerArg CPL_DLL
+GDALCloneTransformer(GDALTransformerArg pTransformerArg);
 
-void GDALRefreshGenImgProjTransformer(void *hTransformArg);
-void GDALRefreshApproxTransformer(void *hTransformArg);
+void GDALRefreshGenImgProjTransformer(GDALTransformerArg hTransformArg);
+void GDALRefreshApproxTransformer(GDALTransformerArg hTransformArg);
 
-int GDALTransformLonLatToDestGenImgProjTransformer(void *hTransformArg,
-                                                   double *pdfX, double *pdfY);
-int GDALTransformLonLatToDestApproxTransformer(void *hTransformArg,
+int GDALTransformLonLatToDestGenImgProjTransformer(
+    GDALTransformerArg hTransformArg, double *pdfX, double *pdfY);
+int GDALTransformLonLatToDestApproxTransformer(GDALTransformerArg hTransformArg,
                                                double *pdfX, double *pdfY);
 
 bool GDALTransformIsTranslationOnPixelBoundaries(
-    GDALTransformerFunc pfnTransformer, void *pTransformerArg);
+    GDALTransformerFunc pfnTransformer, GDALTransformerArg pTransformerArg);
 
 bool GDALTransformIsAffineNoRotation(GDALTransformerFunc pfnTransformer,
-                                     void *pTransformerArg);
+                                     GDALTransformerArg pTransformerArg);
 
-bool GDALTransformHasFastClone(void *pTransformerArg);
+bool GDALTransformHasFastClone(GDALTransformerArg pTransformerArg);
 
 typedef struct _CPLQuadTree CPLQuadTree;
 
@@ -287,16 +291,16 @@ typedef struct
     double adfSrcGeoTransform[6];
     double adfSrcInvGeoTransform[6];
 
-    void *pSrcTransformArg;
+    GDALTransformerArg pSrcTransformArg;
     GDALTransformerFunc pSrcTransformer;
 
-    void *pReprojectArg;
+    GDALTransformerArg pReprojectArg;
     GDALTransformerFunc pReproject;
 
     double adfDstGeoTransform[6];
     double adfDstInvGeoTransform[6];
 
-    void *pDstTransformArg;
+    GDALTransformerArg pDstTransformArg;
     GDALTransformerFunc pDstTransformer;
 
     // Memorize the value of the CHECK_WITH_INVERT_PROJ at the time we
@@ -376,10 +380,9 @@ CPLStringList GDALCreateGeolocationMetadata(GDALDatasetH hBaseDS,
                                             const char *pszGeolocationDataset,
                                             bool bIsSource);
 
-void *GDALCreateGeoLocTransformerEx(GDALDatasetH hBaseDS,
-                                    CSLConstList papszGeolocationInfo,
-                                    int bReversed, const char *pszSourceDataset,
-                                    CSLConstList papszTransformOptions);
+GDALTransformerArg GDALCreateGeoLocTransformerEx(
+    GDALDatasetH hBaseDS, CSLConstList papszGeolocationInfo, int bReversed,
+    const char *pszSourceDataset, CSLConstList papszTransformOptions);
 
 #endif /* #ifndef DOXYGEN_SKIP */
 

--- a/alg/gdal_crs.cpp
+++ b/alg/gdal_crs.cpp
@@ -137,7 +137,8 @@ static GDALTransformerArg
 GDALCreateSimilarGCPTransformer(GDALTransformerArg hTransformArg,
                                 double dfRatioX, double dfRatioY)
 {
-    GCPTransformInfo *psInfo = static_cast<GCPTransformInfo *>(hTransformArg);
+    GCPTransformInfo *psInfo =
+        reinterpret_cast<GCPTransformInfo *>(hTransformArg);
 
     VALIDATE_POINTER1(hTransformArg, "GDALCreateSimilarGCPTransformer",
                       nullptr);
@@ -158,12 +159,12 @@ GDALCreateSimilarGCPTransformer(GDALTransformerArg hTransformArg,
         }
         /* As remove_outliers modifies the provided GCPs we don't need to
          * reapply it */
-        psInfo = static_cast<GCPTransformInfo *>(GDALCreateGCPTransformer(
+        psInfo = reinterpret_cast<GCPTransformInfo *>(GDALCreateGCPTransformer(
             static_cast<int>(newGCPs.size()), gdal::GCP::c_ptr(newGCPs),
             psInfo->nOrder, psInfo->bReversed));
     }
 
-    return psInfo;
+    return reinterpret_cast<GDALTransformerArg>(psInfo);
 }
 
 /************************************************************************/
@@ -314,12 +315,12 @@ GDALCreateGCPTransformerEx(int nGCPCount, const GDAL_GCP *pasGCPList,
     {
         CPLError(CE_Failure, CPLE_AppDefined, "%s",
                  CRS_error_message[-nCRSresult]);
-        GDALDestroyGCPTransformer(psInfo);
+        GDALDestroyGCPTransformer(reinterpret_cast<GDALTransformerArg>(psInfo));
         return nullptr;
     }
     else
     {
-        return psInfo;
+        return reinterpret_cast<GDALTransformerArg>(psInfo);
     }
 }
 
@@ -395,7 +396,8 @@ void GDALDestroyGCPTransformer(GDALTransformerArg pTransformArg)
     if (pTransformArg == nullptr)
         return;
 
-    GCPTransformInfo *psInfo = static_cast<GCPTransformInfo *>(pTransformArg);
+    GCPTransformInfo *psInfo =
+        reinterpret_cast<GCPTransformInfo *>(pTransformArg);
 
     if (CPLAtomicDec(&(psInfo->nRefCount)) == 0)
     {
@@ -434,7 +436,8 @@ int GDALGCPTransform(GDALTransformerArg pTransformArg, int bDstToSrc,
 
 {
     int i = 0;
-    GCPTransformInfo *psInfo = static_cast<GCPTransformInfo *>(pTransformArg);
+    GCPTransformInfo *psInfo =
+        reinterpret_cast<GCPTransformInfo *>(pTransformArg);
 
     if (psInfo->bReversed)
         bDstToSrc = !bDstToSrc;
@@ -473,7 +476,8 @@ CPLXMLNode *GDALSerializeGCPTransformer(GDALTransformerArg pTransformArg)
 
 {
     CPLXMLNode *psTree = nullptr;
-    GCPTransformInfo *psInfo = static_cast<GCPTransformInfo *>(pTransformArg);
+    GCPTransformInfo *psInfo =
+        reinterpret_cast<GCPTransformInfo *>(pTransformArg);
 
     VALIDATE_POINTER1(pTransformArg, "GDALSerializeGCPTransformer", nullptr);
 

--- a/alg/gdal_tps.cpp
+++ b/alg/gdal_tps.cpp
@@ -64,7 +64,8 @@ GDALCreateSimilarTPSTransformer(GDALTransformerArg hTransformArg,
     VALIDATE_POINTER1(hTransformArg, "GDALCreateSimilarTPSTransformer",
                       nullptr);
 
-    TPSTransformInfo *psInfo = static_cast<TPSTransformInfo *>(hTransformArg);
+    TPSTransformInfo *psInfo =
+        reinterpret_cast<TPSTransformInfo *>(hTransformArg);
 
     if (dfRatioX == 1.0 && dfRatioY == 1.0)
     {
@@ -80,12 +81,12 @@ GDALCreateSimilarTPSTransformer(GDALTransformerArg hTransformArg,
             gcp.Pixel() /= dfRatioX;
             gcp.Line() /= dfRatioY;
         }
-        psInfo = static_cast<TPSTransformInfo *>(GDALCreateTPSTransformer(
+        psInfo = reinterpret_cast<TPSTransformInfo *>(GDALCreateTPSTransformer(
             static_cast<int>(newGCPs.size()), gdal::GCP::c_ptr(newGCPs),
             psInfo->bReversed));
     }
 
-    return psInfo;
+    return reinterpret_cast<GDALTransformerArg>(psInfo);
 }
 
 /************************************************************************/
@@ -226,7 +227,8 @@ GDALTransformerArg GDALCreateTPSTransformerInt(int nGCPCount,
         }
         if (!bOK)
         {
-            GDALDestroyTPSTransformer(psInfo);
+            GDALDestroyTPSTransformer(
+                reinterpret_cast<GDALTransformerArg>(psInfo));
             return nullptr;
         }
     }
@@ -268,11 +270,11 @@ GDALTransformerArg GDALCreateTPSTransformerInt(int nGCPCount,
 
     if (!psInfo->bForwardSolved || !psInfo->bReverseSolved)
     {
-        GDALDestroyTPSTransformer(psInfo);
+        GDALDestroyTPSTransformer(reinterpret_cast<GDALTransformerArg>(psInfo));
         return nullptr;
     }
 
-    return psInfo;
+    return reinterpret_cast<GDALTransformerArg>(psInfo);
 }
 
 /************************************************************************/
@@ -295,7 +297,8 @@ void GDALDestroyTPSTransformer(GDALTransformerArg pTransformArg)
     if (pTransformArg == nullptr)
         return;
 
-    TPSTransformInfo *psInfo = static_cast<TPSTransformInfo *>(pTransformArg);
+    TPSTransformInfo *psInfo =
+        reinterpret_cast<TPSTransformInfo *>(pTransformArg);
 
     if (CPLAtomicDec(&(psInfo->nRefCount)) == 0)
     {
@@ -337,7 +340,8 @@ int GDALTPSTransform(GDALTransformerArg pTransformArg, int bDstToSrc,
 {
     VALIDATE_POINTER1(pTransformArg, "GDALTPSTransform", 0);
 
-    TPSTransformInfo *psInfo = static_cast<TPSTransformInfo *>(pTransformArg);
+    TPSTransformInfo *psInfo =
+        reinterpret_cast<TPSTransformInfo *>(pTransformArg);
 
     for (int i = 0; i < nPointCount; i++)
     {
@@ -392,7 +396,8 @@ CPLXMLNode *GDALSerializeTPSTransformer(GDALTransformerArg pTransformArg)
 {
     VALIDATE_POINTER1(pTransformArg, "GDALSerializeTPSTransformer", nullptr);
 
-    TPSTransformInfo *psInfo = static_cast<TPSTransformInfo *>(pTransformArg);
+    TPSTransformInfo *psInfo =
+        reinterpret_cast<TPSTransformInfo *>(pTransformArg);
 
     CPLXMLNode *psTree =
         CPLCreateXMLNode(nullptr, CXT_Element, "TPSTransformer");

--- a/alg/gdalapplyverticalshiftgrid.cpp
+++ b/alg/gdalapplyverticalshiftgrid.cpp
@@ -440,7 +440,7 @@ GDALDatasetH GDALApplyVerticalShiftGrid(GDALDatasetH hSrcDataset,
                        dfSouthLatitudeDeg, dfEastLongitudeDeg,
                        dfNorthLatitudeDeg));
     }
-    void *hTransform = GDALCreateGenImgProjTransformer4(
+    GDALTransformerArg hTransform = GDALCreateGenImgProjTransformer4(
         hGridSRS, adfGridGT, OGRSpatialReference::ToHandle(&oSrcSRS), adfSrcGT,
         aosOptions.List());
     if (hTransform == nullptr)

--- a/alg/gdalcutline.cpp
+++ b/alg/gdalcutline.cpp
@@ -192,12 +192,12 @@ static CPLErr BlendMaskGenerator(int nXOff, int nYOff, int nXSize, int nYSize,
 /*      relative to the current chunk.                                  */
 /************************************************************************/
 
-static int CutlineTransformer(void *pTransformArg, int bDstToSrc,
+static int CutlineTransformer(GDALTransformerArg pTransformArg, int bDstToSrc,
                               int nPointCount, double *x, double *y,
                               double * /* z */, int * /* panSuccess */)
 {
-    int nXOff = static_cast<int *>(pTransformArg)[0];
-    int nYOff = static_cast<int *>(pTransformArg)[1];
+    int nXOff = reinterpret_cast<int *>(pTransformArg)[0];
+    int nYOff = reinterpret_cast<int *>(pTransformArg)[1];
 
     if (bDstToSrc)
     {
@@ -369,8 +369,9 @@ CPLErr GDALWarpCutlineMaskerEx(void *pMaskFuncArg, int /* nBandCount */,
     int anXYOff[2] = {nXOff, nYOff};
 
     CPLErr eErr = GDALRasterizeGeometries(
-        hMemDS, 1, &nTargetBand, 1, &hPolygon, CutlineTransformer, anXYOff,
-        &dfBurnValue, papszRasterizeOptions, nullptr, nullptr);
+        hMemDS, 1, &nTargetBand, 1, &hPolygon, CutlineTransformer,
+        reinterpret_cast<GDALTransformerArg>(anXYOff), &dfBurnValue,
+        papszRasterizeOptions, nullptr, nullptr);
 
     CSLDestroy(papszRasterizeOptions);
 

--- a/alg/gdalgeoloc.cpp
+++ b/alg/gdalgeoloc.cpp
@@ -58,6 +58,11 @@ CPLXMLNode *GDALSerializeGeoLocTransformer(GDALTransformerArg pTransformArg);
 GDALTransformerArg GDALDeserializeGeoLocTransformer(const CPLXMLNode *psTree);
 CPL_C_END
 
+static void GDALDestroyGeoLocTransformer(GDALGeoLocTransformInfo *psInfo)
+{
+    GDALDestroyGeoLocTransformer(reinterpret_cast<GDALTransformerArg>(psInfo));
+}
+
 /************************************************************************/
 /* ==================================================================== */
 /*                         GDALGeoLocTransformer                        */
@@ -1592,7 +1597,7 @@ GDALCreateSimilarGeoLocTransformer(GDALTransformerArg hTransformArg,
                       nullptr);
 
     GDALGeoLocTransformInfo *psInfo =
-        static_cast<GDALGeoLocTransformInfo *>(hTransformArg);
+        reinterpret_cast<GDALGeoLocTransformInfo *>(hTransformArg);
 
     char **papszGeolocationInfo = CSLDuplicate(psInfo->papszGeolocationInfo);
 
@@ -1607,13 +1612,13 @@ GDALCreateSimilarGeoLocTransformer(GDALTransformerArg hTransformArg,
     }
 
     auto psInfoNew =
-        static_cast<GDALGeoLocTransformInfo *>(GDALCreateGeoLocTransformer(
+        reinterpret_cast<GDALGeoLocTransformInfo *>(GDALCreateGeoLocTransformer(
             nullptr, papszGeolocationInfo, psInfo->bReversed));
     psInfoNew->dfOversampleFactor = psInfo->dfOversampleFactor;
 
     CSLDestroy(papszGeolocationInfo);
 
-    return psInfoNew;
+    return reinterpret_cast<GDALTransformerArg>(psInfoNew);
 }
 
 /************************************************************************/
@@ -2027,7 +2032,7 @@ GDALTransformerArg GDALCreateGeoLocTransformerEx(
         }
     }
 
-    return psTransform;
+    return reinterpret_cast<GDALTransformerArg>(psTransform);
 }
 
 /** Create GeoLocation transformer */
@@ -2052,7 +2057,7 @@ void GDALDestroyGeoLocTransformer(GDALTransformerArg pTransformAlg)
         return;
 
     GDALGeoLocTransformInfo *psTransform =
-        static_cast<GDALGeoLocTransformInfo *>(pTransformAlg);
+        reinterpret_cast<GDALGeoLocTransformInfo *>(pTransformAlg);
 
     CSLDestroy(psTransform->papszGeolocationInfo);
 
@@ -2083,7 +2088,7 @@ int GDALGeoLocTransform(GDALTransformerArg pTransformArg, int bDstToSrc,
                         double *padfZ, int *panSuccess)
 {
     GDALGeoLocTransformInfo *psTransform =
-        static_cast<GDALGeoLocTransformInfo *>(pTransformArg);
+        reinterpret_cast<GDALGeoLocTransformInfo *>(pTransformArg);
     if (psTransform->bUseArray)
     {
         return GDALGeoLoc<GDALGeoLocCArrayAccessors>::Transform(
@@ -2108,7 +2113,7 @@ CPLXMLNode *GDALSerializeGeoLocTransformer(GDALTransformerArg pTransformArg)
     VALIDATE_POINTER1(pTransformArg, "GDALSerializeGeoLocTransformer", nullptr);
 
     GDALGeoLocTransformInfo *psInfo =
-        static_cast<GDALGeoLocTransformInfo *>(pTransformArg);
+        reinterpret_cast<GDALGeoLocTransformInfo *>(pTransformArg);
 
     CPLXMLNode *psTree =
         CPLCreateXMLNode(nullptr, CXT_Element, "GeoLocTransformer");

--- a/alg/gdalrasterize.cpp
+++ b/alg/gdalrasterize.cpp
@@ -540,7 +540,7 @@ static void gv_rasterize_one_shape(
     GDALDataType eBurnValueType, const double *padfBurnValues,
     const int64_t *panBurnValues, GDALBurnValueSrc eBurnValueSrc,
     GDALRasterMergeAlg eMergeAlg, GDALTransformerFunc pfnTransformer,
-    void *pTransformArg)
+    GDALTransformerArg pTransformArg)
 
 {
     if (poShape == nullptr || poShape->IsEmpty())
@@ -828,7 +828,7 @@ static CPLErr GDALRasterizeOptions(CSLConstList papszOptions, int *pbAllTouched,
 static CPLErr GDALRasterizeGeometriesInternal(
     GDALDatasetH hDS, int nBandCount, const int *panBandList, int nGeomCount,
     const OGRGeometryH *pahGeometries, GDALTransformerFunc pfnTransformer,
-    void *pTransformArg, GDALDataType eBurnValueType,
+    GDALTransformerArg pTransformArg, GDALDataType eBurnValueType,
     const double *padfGeomBurnValues, const int64_t *panGeomBurnValues,
     CSLConstList papszOptions, GDALProgressFunc pfnProgress,
     void *pProgressArg);
@@ -945,7 +945,7 @@ static CPLErr GDALRasterizeGeometriesInternal(
 CPLErr GDALRasterizeGeometries(
     GDALDatasetH hDS, int nBandCount, const int *panBandList, int nGeomCount,
     const OGRGeometryH *pahGeometries, GDALTransformerFunc pfnTransformer,
-    void *pTransformArg, const double *padfGeomBurnValues,
+    GDALTransformerArg pTransformArg, const double *padfGeomBurnValues,
     CSLConstList papszOptions, GDALProgressFunc pfnProgress, void *pProgressArg)
 
 {
@@ -968,7 +968,7 @@ CPLErr GDALRasterizeGeometries(
 CPLErr GDALRasterizeGeometriesInt64(
     GDALDatasetH hDS, int nBandCount, const int *panBandList, int nGeomCount,
     const OGRGeometryH *pahGeometries, GDALTransformerFunc pfnTransformer,
-    void *pTransformArg, const int64_t *panGeomBurnValues,
+    GDALTransformerArg pTransformArg, const int64_t *panGeomBurnValues,
     CSLConstList papszOptions, GDALProgressFunc pfnProgress, void *pProgressArg)
 
 {
@@ -983,7 +983,7 @@ CPLErr GDALRasterizeGeometriesInt64(
 static CPLErr GDALRasterizeGeometriesInternal(
     GDALDatasetH hDS, int nBandCount, const int *panBandList, int nGeomCount,
     const OGRGeometryH *pahGeometries, GDALTransformerFunc pfnTransformer,
-    void *pTransformArg, GDALDataType eBurnValueType,
+    GDALTransformerArg pTransformArg, GDALDataType eBurnValueType,
     const double *padfGeomBurnValues, const int64_t *panGeomBurnValues,
     CSLConstList papszOptions, GDALProgressFunc pfnProgress, void *pProgressArg)
 
@@ -1492,9 +1492,9 @@ static CPLErr GDALRasterizeGeometriesInternal(
 CPLErr GDALRasterizeLayers(GDALDatasetH hDS, int nBandCount, int *panBandList,
                            int nLayerCount, OGRLayerH *pahLayers,
                            GDALTransformerFunc pfnTransformer,
-                           void *pTransformArg, double *padfLayerBurnValues,
-                           char **papszOptions, GDALProgressFunc pfnProgress,
-                           void *pProgressArg)
+                           GDALTransformerArg pTransformArg,
+                           double *padfLayerBurnValues, char **papszOptions,
+                           GDALProgressFunc pfnProgress, void *pProgressArg)
 
 {
     VALIDATE_POINTER1(hDS, "GDALRasterizeLayers", CE_Failure);
@@ -1867,8 +1867,9 @@ CPLErr GDALRasterizeLayersBuf(
     void *pData, int nBufXSize, int nBufYSize, GDALDataType eBufType,
     int nPixelSpace, int nLineSpace, int nLayerCount, OGRLayerH *pahLayers,
     const char *pszDstProjection, double *padfDstGeoTransform,
-    GDALTransformerFunc pfnTransformer, void *pTransformArg, double dfBurnValue,
-    char **papszOptions, GDALProgressFunc pfnProgress, void *pProgressArg)
+    GDALTransformerFunc pfnTransformer, GDALTransformerArg pTransformArg,
+    double dfBurnValue, char **papszOptions, GDALProgressFunc pfnProgress,
+    void *pProgressArg)
 
 {
     /* -------------------------------------------------------------------- */

--- a/alg/gdalsimplewarp.cpp
+++ b/alg/gdalsimplewarp.cpp
@@ -217,7 +217,7 @@ static void GDALSimpleWarpRemapping(int nBandCount, GByte **papabySrcData,
 int CPL_STDCALL GDALSimpleImageWarp(GDALDatasetH hSrcDS, GDALDatasetH hDstDS,
                                     int nBandCount, int *panBandList,
                                     GDALTransformerFunc pfnTransform,
-                                    void *pTransformArg,
+                                    GDALTransformerArg pTransformArg,
                                     GDALProgressFunc pfnProgress,
                                     void *pProgressArg, char **papszWarpOptions)
 

--- a/alg/gdaltransformgeolocs.cpp
+++ b/alg/gdaltransformgeolocs.cpp
@@ -49,7 +49,7 @@
 CPLErr GDALTransformGeolocations(GDALRasterBandH hXBand, GDALRasterBandH hYBand,
                                  GDALRasterBandH hZBand,
                                  GDALTransformerFunc pfnTransformer,
-                                 void *pTransformArg,
+                                 GDALTransformerArg pTransformArg,
                                  GDALProgressFunc pfnProgress,
                                  void *pProgressArg,
                                  CPL_UNUSED char **papszOptions)

--- a/alg/gdalwarper.cpp
+++ b/alg/gdalwarper.cpp
@@ -91,7 +91,7 @@ CPLErr CPL_STDCALL GDALReprojectImage(
     /* -------------------------------------------------------------------- */
     /*      Setup a reprojection based transformer.                         */
     /* -------------------------------------------------------------------- */
-    void *hTransformArg = GDALCreateGenImgProjTransformer(
+    GDALTransformerArg hTransformArg = GDALCreateGenImgProjTransformer(
         hSrcDS, pszSrcWKT, hDstDS, pszDstWKT, TRUE, 1000.0, 0);
 
     if (hTransformArg == nullptr)
@@ -251,7 +251,7 @@ CPLErr CPL_STDCALL GDALCreateAndReprojectImage(
     /*      Create a transformation object from the source to               */
     /*      destination coordinate system.                                  */
     /* -------------------------------------------------------------------- */
-    void *hTransformArg = GDALCreateGenImgProjTransformer(
+    GDALTransformerArg hTransformArg = GDALCreateGenImgProjTransformer(
         hSrcDS, pszSrcWKT, nullptr, pszDstWKT, TRUE, 1000.0, 0);
 
     if (hTransformArg == nullptr)

--- a/alg/gdalwarper.h
+++ b/alg/gdalwarper.h
@@ -199,7 +199,7 @@ typedef struct
     GDALTransformerFunc pfnTransformer;
 
     /*! Handle to image transformer setup structure */
-    void *pTransformerArg;
+    GDALTransformerArg pTransformerArg;
 
     /** Unused. Must be NULL */
     GDALMaskFunc *papfnSrcPerBandValidityMaskFunc;
@@ -423,7 +423,7 @@ class CPL_DLL GDALWarpKernel
     /** Pixel transformation function */
     GDALTransformerFunc pfnTransformer;
     /** User data provided to pfnTransformer */
-    void *pTransformerArg;
+    GDALTransformerArg pTransformerArg;
 
     /** Progress function */
     GDALProgressFunc pfnProgress;
@@ -463,7 +463,7 @@ class CPL_DLL GDALWarpKernel
 /*! @cond Doxygen_Suppress */
 void *GWKThreadsCreate(char **papszWarpOptions,
                        GDALTransformerFunc pfnTransformer,
-                       void *pTransformerArg);
+                       GDALTransformerArg pTransformerArg);
 void GWKThreadsEnd(void *psThreadDataIn);
 /*! @endcond */
 

--- a/alg/gdalwarpkernel.cpp
+++ b/alg/gdalwarpkernel.cpp
@@ -204,7 +204,7 @@ struct GWKJobStruct
     int iYMin;
     int iYMax;
     int (*pfnProgress)(GWKJobStruct *psJob);
-    void *pTransformerArg;
+    GDALTransformerArg pTransformerArg;
     void (*pfnFunc)(
         void *);  // used by GWKRun() to assign the proper pTransformerArg
 
@@ -227,9 +227,9 @@ struct GWKThreadData
     std::mutex mutex{};
     std::condition_variable cv{};
     bool bTransformerArgInputAssignedToThread{false};
-    void *pTransformerArgInput{
+    GDALTransformerArg pTransformerArgInput{
         nullptr};  // owned by calling layer. Not to be destroyed
-    std::map<GIntBig, void *> mapThreadToTransformerArg{};
+    std::map<GIntBig, GDALTransformerArg> mapThreadToTransformerArg{};
     int nTotalThreadCountForThisRun = 0;
     int nCurThreadCountForThisRun = 0;
 };
@@ -301,7 +301,7 @@ static CPLErr GWKGenericMonoThread(GDALWarpKernel *poWK,
 
 void *GWKThreadsCreate(char **papszWarpOptions,
                        GDALTransformerFunc /* pfnTransformer */,
-                       void *pTransformerArg)
+                       GDALTransformerArg pTransformerArg)
 {
     const char *pszWarpThreads =
         CSLFetchNameValue(papszWarpOptions, "NUM_THREADS");
@@ -370,7 +370,7 @@ static void ThreadFuncAdapter(void *pData)
         static_cast<GWKThreadData *>(psJob->poWK->psThreadData);
 
     // Look if we have already a per-thread transformer
-    void *pTransformerArg = nullptr;
+    GDALTransformerArg pTransformerArg = nullptr;
     const GIntBig nThreadId = CPLGetPID();
 
     {
@@ -4522,8 +4522,8 @@ bool GWKResampleNoMasksT<double>(const GDALWarpKernel *poWK, int iBand,
 static void GWKRoundSourceCoordinates(
     int nDstXSize, double *padfX, double *padfY, double *padfZ, int *pabSuccess,
     double dfSrcCoordPrecision, double dfErrorThreshold,
-    GDALTransformerFunc pfnTransformer, void *pTransformerArg, double dfDstXOff,
-    double dfDstY)
+    GDALTransformerFunc pfnTransformer, GDALTransformerArg pTransformerArg,
+    double dfDstXOff, double dfDstY)
 {
     double dfPct = 0.8;
     if (dfErrorThreshold > 0 && dfSrcCoordPrecision / dfErrorThreshold >= 10.0)

--- a/apps/gdal_rasterize_lib.cpp
+++ b/apps/gdal_rasterize_lib.cpp
@@ -693,7 +693,7 @@ static CPLErr ProcessLayer(OGRLayerH hSrcLayer, bool bSRSIsSet,
     /*      options.                                                        */
     /* -------------------------------------------------------------------- */
 
-    void *pTransformArg = nullptr;
+    GDALTransformerArg pTransformArg = nullptr;
     GDALTransformerFunc pfnTransformer = nullptr;
     CPLErr eErr = CE_None;
     if (papszTO != nullptr)

--- a/apps/gdaltransform.cpp
+++ b/apps/gdaltransform.cpp
@@ -120,7 +120,7 @@ MAIN_START(argc, argv)
     const char *pszSrcFilename = nullptr;
     const char *pszDstFilename = nullptr;
     int nOrder = 0;
-    void *hTransformArg;
+    GDALTransformerArg hTransformArg;
     GDALTransformerFunc pfnTransformer = nullptr;
     int nGCPCount = 0;
     GDAL_GCP *pasGCPs = nullptr;

--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -250,8 +250,8 @@ static CPLErr TransformCutlineToSource(GDALDataset *poSrcDS,
 static GDALDatasetH GDALWarpCreateOutput(
     int nSrcCount, GDALDatasetH *pahSrcDS, const char *pszFilename,
     const char *pszFormat, char **papszTO, CSLConstList papszCreateOptions,
-    GDALDataType eDT, void **phTransformArg, bool bSetColorInterpretation,
-    GDALWarpAppOptions *psOptions);
+    GDALDataType eDT, GDALTransformerArg *phTransformArg,
+    bool bSetColorInterpretation, GDALWarpAppOptions *psOptions);
 
 static void RemoveConflictingMetadata(GDALMajorObjectH hObj,
                                       CSLConstList papszMetadata,
@@ -1693,7 +1693,7 @@ static GDALDatasetH CreateOutput(const char *pszDest, int nSrcCount,
                                  GDALDatasetH *pahSrcDS,
                                  GDALWarpAppOptions *psOptions,
                                  const bool bInitDestSetByUser,
-                                 void *&hUniqueTransformArg)
+                                 GDALTransformerArg &hUniqueTransformArg)
 {
     if (nSrcCount == 1 && !psOptions->bDisableSrcAlpha)
     {
@@ -2329,7 +2329,8 @@ static void SetupSkipNoSource(int iSrc, GDALDatasetH hDstDS,
  */
 static bool AdjustOutputExtentForRPC(GDALDatasetH hSrcDS, GDALDatasetH hDstDS,
                                      GDALTransformerFunc pfnTransformer,
-                                     void *hTransformArg, GDALWarpOptions *psWO,
+                                     GDALTransformerArg hTransformArg,
+                                     GDALWarpOptions *psWO,
                                      GDALWarpAppOptions *psOptions,
                                      int &nWarpDstXOff, int &nWarpDstYOff,
                                      int &nWarpDstXSize, int &nWarpDstYSize)
@@ -2472,7 +2473,7 @@ static GDALDatasetH GDALWarpDirect(const char *pszDest, GDALDatasetH hDstDS,
     /* -------------------------------------------------------------------- */
     /*      If the target dataset does not exist, we need to create it.     */
     /* -------------------------------------------------------------------- */
-    void *hUniqueTransformArg = nullptr;
+    GDALTransformerArg hUniqueTransformArg = nullptr;
     const bool bInitDestSetByUser =
         (psOptions->aosWarpOptions.FetchNameValue("INIT_DEST") != nullptr);
 
@@ -2575,7 +2576,7 @@ static GDALDatasetH GDALWarpDirect(const char *pszDest, GDALDatasetH hDstDS,
     /*      Loop over all source files, processing each in turn.            */
     /* -------------------------------------------------------------------- */
     GDALTransformerFunc pfnTransformer = nullptr;
-    void *hTransformArg = nullptr;
+    GDALTransformerArg hTransformArg = nullptr;
     bool bHasGotErr = false;
     for (int iSrc = 0; iSrc < nSrcCount; iSrc++)
     {
@@ -3490,13 +3491,13 @@ error:
 static GDALDatasetH GDALWarpCreateOutput(
     int nSrcCount, GDALDatasetH *pahSrcDS, const char *pszFilename,
     const char *pszFormat, char **papszTO, CSLConstList papszCreateOptions,
-    GDALDataType eDT, void **phTransformArg, bool bSetColorInterpretation,
-    GDALWarpAppOptions *psOptions)
+    GDALDataType eDT, GDALTransformerArg *phTransformArg,
+    bool bSetColorInterpretation, GDALWarpAppOptions *psOptions)
 
 {
     GDALDriverH hDriver;
     GDALDatasetH hDstDS;
-    void *hTransformArg;
+    GDALTransformerArg hTransformArg;
     GDALColorTableH hCT = nullptr;
     GDALRasterAttributeTableH hRAT = nullptr;
     double dfWrkMinX = 0, dfWrkMaxX = 0, dfWrkMinY = 0, dfWrkMaxY = 0;
@@ -4882,9 +4883,9 @@ class CutlineTransformer : public OGRCoordinateTransformation
     CPL_DISALLOW_COPY_ASSIGN(CutlineTransformer)
 
   public:
-    void *hSrcImageTransformer = nullptr;
+    GDALTransformerArg hSrcImageTransformer = nullptr;
 
-    explicit CutlineTransformer(void *hTransformArg)
+    explicit CutlineTransformer(GDALTransformerArg hTransformArg)
         : hSrcImageTransformer(hTransformArg)
     {
     }

--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -3879,7 +3879,7 @@ static GDALDatasetH GDALWarpCreateOutput(
         }
 
         GDALTransformerInfo *psInfo =
-            static_cast<GDALTransformerInfo *>(hTransformArg);
+            reinterpret_cast<GDALTransformerInfo *>(hTransformArg);
 
         /* --------------------------------------------------------------------
          */
@@ -3935,7 +3935,7 @@ static GDALDatasetH GDALWarpCreateOutput(
             bool transformedToSrcCRS{false};
 
             GDALGenImgProjTransformInfo *psTransformInfo{
-                static_cast<GDALGenImgProjTransformInfo *>(hTransformArg)};
+                reinterpret_cast<GDALGenImgProjTransformInfo *>(hTransformArg)};
 
             // If a transformer is available, use an extent that covers the
             // target extent instead of the real source image extent, but also
@@ -3944,7 +3944,7 @@ static GDALDatasetH GDALWarpCreateOutput(
                 psTransformInfo->pSrcTransformer == nullptr)
             {
                 const GDALReprojectionTransformInfo *psRTI =
-                    static_cast<const GDALReprojectionTransformInfo *>(
+                    reinterpret_cast<const GDALReprojectionTransformInfo *>(
                         psTransformInfo->pReprojectArg);
                 if (psRTI && psRTI->poReverseTransform)
                 {

--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -1128,7 +1128,7 @@ class GCPCoordTransformation : public OGRCoordinateTransformation
     GCPCoordTransformation &operator=(const GCPCoordTransformation &) = delete;
 
   public:
-    void *hTransformArg;
+    GDALTransformerArg hTransformArg;
     bool bUseTPS;
     OGRSpatialReference *poSRS;
 

--- a/frmts/daas/daasdataset.cpp
+++ b/frmts/daas/daasdataset.cpp
@@ -1155,7 +1155,7 @@ bool GDALDAASDataset::SetupServerSideReprojection(const char *pszTargetSRS)
     char **papszTO = CSLSetNameValue(nullptr, "DST_SRS", pszWKT);
     CPLFree(pszWKT);
 
-    void *hTransformArg =
+    auto hTransformArg =
         GDALCreateGenImgProjTransformer2(this, nullptr, papszTO);
     if (hTransformArg == nullptr)
     {

--- a/frmts/gtiff/cogdriver.cpp
+++ b/frmts/gtiff/cogdriver.cpp
@@ -205,7 +205,7 @@ static bool COGGetWarpingCharacteristics(
 
     CPLStringList aosTO;
     aosTO.SetNameValue("DST_SRS", osTargetSRS);
-    void *hTransformArg = nullptr;
+    GDALTransformerArg hTransformArg = nullptr;
 
     OGRSpatialReference oTargetSRS;
     oTargetSRS.SetFromUserInput(

--- a/frmts/gtiff/cogdriver.cpp
+++ b/frmts/gtiff/cogdriver.cpp
@@ -287,7 +287,7 @@ static bool COGGetWarpingCharacteristics(
     }
 
     GDALTransformerInfo *psInfo =
-        static_cast<GDALTransformerInfo *>(hTransformArg);
+        reinterpret_cast<GDALTransformerInfo *>(hTransformArg);
     double adfGeoTransform[6];
     double adfExtent[4];
 

--- a/frmts/mbtiles/mbtilesdataset.cpp
+++ b/frmts/mbtiles/mbtilesdataset.cpp
@@ -3154,7 +3154,7 @@ GDALDataset *MBTilesDataset::CreateCopy(const char *pszFilename,
 
     char **papszTO = CSLSetNameValue(nullptr, "DST_SRS", SRS_EPSG_3857);
 
-    void *hTransformArg = nullptr;
+    GDALTransformerArg hTransformArg = nullptr;
 
     // Hack to compensate for GDALSuggestedWarpOutput2() failure (or not
     // ideal suggestion with PROJ 8) when reprojecting latitude = +/- 90 to

--- a/frmts/vrt/vrtwarped.cpp
+++ b/frmts/vrt/vrtwarped.cpp
@@ -1092,7 +1092,7 @@ VRTCreateWarpedOverviewTransformer(GDALTransformerFunc pfnBaseTransformer,
 #if 0
     psSCTInfo->sTI.pfnSerialize = VRTSerializeWarpedOverviewTransformer;
 #endif
-    return psSCTInfo;
+    return reinterpret_cast<GDALTransformerArg>(psSCTInfo);
 }
 
 /************************************************************************/
@@ -1102,7 +1102,7 @@ VRTCreateWarpedOverviewTransformer(GDALTransformerFunc pfnBaseTransformer,
 static void
 VRTDestroyWarpedOverviewTransformer(GDALTransformerArg pTransformArg)
 {
-    VWOTInfo *psInfo = static_cast<VWOTInfo *>(pTransformArg);
+    VWOTInfo *psInfo = reinterpret_cast<VWOTInfo *>(pTransformArg);
 
     if (psInfo->bOwnSubtransformer)
         GDALDestroyTransformer(psInfo->pBaseTransformerArg);
@@ -1120,7 +1120,7 @@ static int VRTWarpedOverviewTransform(GDALTransformerArg pTransformArg,
                                       double *padfZ, int *panSuccess)
 
 {
-    VWOTInfo *psInfo = static_cast<VWOTInfo *>(pTransformArg);
+    VWOTInfo *psInfo = reinterpret_cast<VWOTInfo *>(pTransformArg);
 
     if (bDstToSrc)
     {

--- a/gcore/rasterio.cpp
+++ b/gcore/rasterio.cpp
@@ -952,12 +952,12 @@ struct GDALRasterIOTransformerStruct
     double dfYRatioDstToSrc;
 };
 
-static int GDALRasterIOTransformer(void *pTransformerArg, int bDstToSrc,
-                                   int nPointCount, double *x, double *y,
-                                   double * /* z */, int *panSuccess)
+static int GDALRasterIOTransformer(GDALTransformerArg pTransformerArg,
+                                   int bDstToSrc, int nPointCount, double *x,
+                                   double *y, double * /* z */, int *panSuccess)
 {
     GDALRasterIOTransformerStruct *psParams =
-        static_cast<GDALRasterIOTransformerStruct *>(pTransformerArg);
+        reinterpret_cast<GDALRasterIOTransformerStruct *>(pTransformerArg);
     if (bDstToSrc)
     {
         for (int i = 0; i < nPointCount; i++)
@@ -1170,7 +1170,8 @@ CPLErr GDALRasterBand::RasterIOResampled(
         sTransformer.dfYOff = bHasYOffVirtual ? 0 : dfYOff;
         sTransformer.dfXRatioDstToSrc = dfXRatioDstToSrc;
         sTransformer.dfYRatioDstToSrc = dfYRatioDstToSrc;
-        psWarpOptions->pTransformerArg = &sTransformer;
+        psWarpOptions->pTransformerArg =
+            reinterpret_cast<GDALTransformerArg>(&sTransformer);
 
         GDALWarpOperationH hWarpOperation =
             GDALCreateWarpOperation(psWarpOptions);

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -6158,7 +6158,7 @@ GDALDataset *GDALGeoPackageDataset::CreateCopy(const char *pszFilename,
     }
 
     GDALTransformerInfo *psInfo =
-        static_cast<GDALTransformerInfo *>(hTransformArg);
+        reinterpret_cast<GDALTransformerInfo *>(hTransformArg);
     double adfGeoTransform[6];
     double adfExtent[4];
     int nXSize, nYSize;

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -6083,7 +6083,7 @@ GDALDataset *GDALGeoPackageDataset::CreateCopy(const char *pszFilename,
     oSRS.exportToWkt(&pszWKT);
     char **papszTO = CSLSetNameValue(nullptr, "DST_SRS", pszWKT);
 
-    void *hTransformArg = nullptr;
+    GDALTransformerArg hTransformArg = nullptr;
 
     // Hack to compensate for GDALSuggestedWarpOutput2() failure (or not
     // ideal suggestion with PROJ 8) when reprojecting latitude = +/- 90 to

--- a/swig/include/Operations.i
+++ b/swig/include/Operations.i
@@ -230,7 +230,7 @@ int  RasterizeLayer( GDALDatasetShadow *dataset,
                  int bands, int *band_list,
                  OGRLayerShadow *layer,
                  void *pfnTransformer = NULL,
-                 void *pTransformArg = NULL,
+                 GDALTransformerArg pTransformArg = NULL,
 		 int burn_values = 0, double *burn_values_list = NULL,
                  char **options = NULL,
                  GDALProgressFunc callback=NULL,
@@ -729,7 +729,7 @@ public:
 #endif
 
   ~GDALTransformerInfoShadow() {
-    GDALDestroyTransformer( self );
+    GDALDestroyTransformer( (GDALTransformerArg)self );
   }
 
 // Need to apply argin typemap second so the numinputs=1 version gets applied
@@ -743,7 +743,7 @@ public:
   int TransformPoint( int bDstToSrc, double inout[3] ) {
     int nRet, nSuccess = TRUE;
 
-    nRet = GDALUseTransformer( self, bDstToSrc,
+    nRet = GDALUseTransformer( (GDALTransformerArg)self, bDstToSrc,
                                1, &inout[0], &inout[1], &inout[2],
                                &nSuccess );
 
@@ -758,7 +758,7 @@ public:
     argout[0] = x;
     argout[1] = y;
     argout[2] = z;
-    nRet = GDALUseTransformer( self, bDstToSrc,
+    nRet = GDALUseTransformer( (GDALTransformerArg)self, bDstToSrc,
                                1, &argout[0], &argout[1], &argout[2],
                                &nSuccess );
 
@@ -774,7 +774,7 @@ public:
                        int *panSuccess ) {
     int nRet;
 
-    nRet = GDALUseTransformer( self, bDstToSrc, nCount, x, y, z, panSuccess );
+    nRet = GDALUseTransformer( (GDALTransformerArg)self, bDstToSrc, nCount, x, y, z, panSuccess );
 
     return nRet;
   }
@@ -803,7 +803,7 @@ public:
     CPLErrorReset();
 
     return GDALTransformGeolocations( xBand, yBand, zBand,
-                                      GDALUseTransformer, self,
+                                      GDALUseTransformer, (GDALTransformerArg)self,
                             	      callback, callback_data, options );
   }
 %clear GDALRasterBandShadow *xBand, GDALRasterBandShadow *yBand, GDALRasterBandShadow *zBand;
@@ -883,7 +883,7 @@ struct SuggestedWarpOutputRes
   {
     SuggestedWarpOutputRes* res = (SuggestedWarpOutputRes*)CPLMalloc(sizeof(SuggestedWarpOutputRes));
     double extent[4];
-    if( GDALSuggestedWarpOutput2(src, GDALGenImgProjTransform, transformer,
+    if( GDALSuggestedWarpOutput2(src, GDALGenImgProjTransform, (GDALTransformerArg)transformer,
                                  res->geotransform,&(res->width), &(res->height),
                                  extent, 0) != CE_None )
     {
@@ -914,7 +914,7 @@ struct SuggestedWarpOutputRes
   {
     SuggestedWarpOutputRes* res = (SuggestedWarpOutputRes*)CPLMalloc(sizeof(SuggestedWarpOutputRes));
     double extent[4];
-    void* pTransformArg = GDALCreateGenImgProjTransformer2( src, NULL, options );
+    GDALTransformerArg pTransformArg = GDALCreateGenImgProjTransformer2( src, NULL, options );
     if( GDALSuggestedWarpOutput2(src, GDALGenImgProjTransform, pTransformArg,
                                  res->geotransform,&(res->width), &(res->height),
                                  extent, 0) != CE_None )


### PR DESCRIPTION
@elpaso Implements what you discussed in https://github.com/OSGeo/gdal/pull/10952#discussion_r1791522527

The last commit ("Make GDALTransformerArg a typedef of an anonymous struct GDALTransformerArgOpaque*") is slightly backwards incompatible