### PR TITLE
gdalwarp: allow specifying units of warp memory

### DIFF
--- a/alg/gdalwarpoperation.cpp
+++ b/alg/gdalwarpoperation.cpp
@@ -1267,7 +1267,7 @@ void GDALWarpOperation::WipeChunkList()
 /*                       GetWorkingMemoryForWindow()                    */
 /************************************************************************/
 
-/** Retrurns the amount of working memory, in bytes, required to process
+/** Returns the amount of working memory, in bytes, required to process
  * a warped window of source dimensions nSrcXSize x nSrcYSize and target
  * dimensions nDstXSize x nDstYSize.
  */

--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -5767,11 +5767,21 @@ GDALWarpAppOptionsGetParser(GDALWarpAppOptions *psOptions,
         .action(
             [psOptions](const std::string &s)
             {
-                if (CPLAtofM(s.c_str()) < 10000)
-                    psOptions->dfWarpMemoryLimit =
-                        CPLAtofM(s.c_str()) * 1024 * 1024;
+                bool bUnitSpecified = false;
+                GIntBig nBytes;
+                if (CPLParseMemorySize(s.c_str(), &nBytes, &bUnitSpecified) ==
+                    CE_None)
+                {
+                    if (!bUnitSpecified && nBytes < 10000)
+                    {
+                        nBytes *= (1024 * 1024);
+                    }
+                    psOptions->dfWarpMemoryLimit = static_cast<double>(nBytes);
+                }
                 else
-                    psOptions->dfWarpMemoryLimit = CPLAtofM(s.c_str());
+                {
+                    throw std::invalid_argument("Failed to parse value of -wm");
+                }
             })
         .help(_("Set max warp memory."));
 

--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -1745,6 +1745,68 @@ TEST_F(test_cpl, CPLParseRFC822DateTime)
                                         &weekday));
 }
 
+// Test CPLParseMemorySize()
+TEST_F(test_cpl, CPLParseMemorySize)
+{
+    GIntBig nValue;
+    bool bUnitSpecified;
+    CPLErr result;
+
+    result = CPLParseMemorySize("327mb", &nValue, &bUnitSpecified);
+    EXPECT_EQ(result, CE_None);
+    EXPECT_EQ(nValue, 327 * 1024 * 1024);
+    EXPECT_TRUE(bUnitSpecified);
+
+    result = CPLParseMemorySize("327MB", &nValue, &bUnitSpecified);
+    EXPECT_EQ(result, CE_None);
+    EXPECT_EQ(nValue, 327 * 1024 * 1024);
+    EXPECT_TRUE(bUnitSpecified);
+
+    result = CPLParseMemorySize("102.9K", &nValue, &bUnitSpecified);
+    EXPECT_EQ(result, CE_None);
+    EXPECT_EQ(nValue, static_cast<GIntBig>(102.9 * 1024));
+    EXPECT_TRUE(bUnitSpecified);
+
+    result = CPLParseMemorySize("102.9 kB", &nValue, &bUnitSpecified);
+    EXPECT_EQ(result, CE_None);
+    EXPECT_EQ(nValue, static_cast<GIntBig>(102.9 * 1024));
+    EXPECT_TRUE(bUnitSpecified);
+
+    result = CPLParseMemorySize("100%", &nValue, &bUnitSpecified);
+    EXPECT_EQ(result, CE_None);
+    EXPECT_GT(nValue, 100 * 1024 * 1024);
+    EXPECT_TRUE(bUnitSpecified);
+
+    result = CPLParseMemorySize("  802  ", &nValue, &bUnitSpecified);
+    EXPECT_EQ(result, CE_None);
+    EXPECT_EQ(nValue, 802);
+    EXPECT_FALSE(bUnitSpecified);
+
+    result = CPLParseMemorySize("110%", &nValue, &bUnitSpecified);
+    EXPECT_EQ(result, CE_Failure);
+
+    result = CPLParseMemorySize("8kbit", &nValue, &bUnitSpecified);
+    EXPECT_EQ(result, CE_Failure);
+
+    result = CPLParseMemorySize("8ZB", &nValue, &bUnitSpecified);
+    EXPECT_EQ(result, CE_Failure);
+
+    result = CPLParseMemorySize("8Z", &nValue, &bUnitSpecified);
+    EXPECT_EQ(result, CE_Failure);
+
+    result = CPLParseMemorySize("", &nValue, &bUnitSpecified);
+    EXPECT_EQ(result, CE_Failure);
+
+    result = CPLParseMemorySize("  ", &nValue, &bUnitSpecified);
+    EXPECT_EQ(result, CE_Failure);
+
+    result = CPLParseMemorySize("-100MB", &nValue, &bUnitSpecified);
+    EXPECT_EQ(result, CE_Failure);
+
+    result = CPLParseMemorySize("nan", &nValue, &bUnitSpecified);
+    EXPECT_EQ(result, CE_Failure);
+}
+
 // Test CPLCopyTree()
 TEST_F(test_cpl, CPLCopyTree)
 {

--- a/doc/source/programs/gdalwarp.rst
+++ b/doc/source/programs/gdalwarp.rst
@@ -385,8 +385,13 @@ with control information.
 .. option:: -wm <memory_in_mb>
 
     Set the amount of memory that the
-    warp API is allowed to use for caching. The value is interpreted as being
-    in megabytes if the value is less than 10000. For values >=10000, this is
+    warp API is allowed to use for caching.
+    Defaults to 64 MB.
+    Since GDAL 3.10, the value can be specified either as a fixed amount of
+    memory (e.g., ``-wm 200MB``, ``-wm 1G``) or as a percentage of usable
+    RAM (``-wm 10%``).
+    In earlier versions, or if a unit is not specified, the value is interpreted as being
+    in megabytes if the value is less than 10000. For values >=10000, it is
     interpreted as bytes.
 
     The warper will total up the memory required to hold the input and output

--- a/port/cpl_string.cpp
+++ b/port/cpl_string.cpp
@@ -1734,6 +1734,115 @@ int CSLFindName(CSLConstList papszStrList, const char *pszName)
     return -1;
 }
 
+/************************************************************************/
+/*                     CPLParseMemorySize()                             */
+/************************************************************************/
+
+/** Parse a memory size from a string.
+ *
+ * The string may indicate the units of the memory (e.g., "230k", "500MB").
+ * The string may alternatively specify memory as a fraction of the usable
+ * RAM (e.g., "25%"). If the string cannot be understood, the function
+ * will return CE_Failure.
+ *
+ * @param pszValue the string to parse
+ * @param[out] pnValue the parsed size, converted to bytes (if unit was specified)
+ * @param[out] pbUnitSpecified whether the string indicated the units
+ *
+ * @return CE_None on success, CE_Failure otherwise
+ * @since 3.10
+ */
+CPLErr CPLParseMemorySize(const char *pszValue, GIntBig *pnValue,
+                          bool *pbUnitSpecified)
+{
+    const char *start = pszValue;
+    char *end = nullptr;
+
+    // trim leading whitespace
+    while (*start == ' ')
+    {
+        start++;
+    }
+
+    auto len = CPLStrnlen(start, 100);
+    double value = CPLStrtodM(start, &end);
+    const char *unit = nullptr;
+    bool unitIsNotPercent = false;
+
+    if (end == start)
+    {
+        CPLError(CE_Failure, CPLE_IllegalArg, "Received non-numeric value: %s",
+                 pszValue);
+        return CE_Failure;
+    }
+
+    if (value <= 0 || !std::isfinite(value))
+    {
+        CPLError(CE_Failure, CPLE_IllegalArg,
+                 "Memory size must be a positive number.");
+        return CE_Failure;
+    }
+
+    for (const char *c = end; c < start + len; c++)
+    {
+        if (unit == nullptr)
+        {
+            // check various suffixes and convert number into bytes
+            if (*c == '%')
+            {
+                if (value < 0 || value > 100)
+                {
+                    CPLError(CE_Failure, CPLE_IllegalArg,
+                             "Memory percentage must be between 0 and 100.");
+                    return CE_Failure;
+                }
+                auto bytes = CPLGetUsablePhysicalRAM();
+                value *= static_cast<double>(bytes / 100);
+                unit = c;
+            }
+            else
+            {
+                switch (*c)
+                {
+                    case 'G':
+                    case 'g':
+                        value *= 1024;  // fall-through
+                    case 'M':
+                    case 'm':
+                        value *= 1024;  // fall-through
+                    case 'K':
+                    case 'k':
+                        value *= 1024;
+                        unit = c;
+                        unitIsNotPercent = true;
+                        break;
+                    case ' ':
+                        break;
+                    default:
+                        CPLError(CE_Failure, CPLE_IllegalArg,
+                                 "Unexpected value: %s", pszValue);
+                        return CE_Failure;
+                }
+            }
+        }
+        else if (unitIsNotPercent && c == unit + 1 && (*c == 'b' || *c == 'B'))
+        {
+            // ignore 'B' or 'b' as part of unit
+            continue;
+        }
+        else if (*c != ' ')
+        {
+            CPLError(CE_Failure, CPLE_IllegalArg, "Unexpected value: %s",
+                     pszValue);
+            return CE_Failure;
+        }
+    }
+
+    *pnValue = static_cast<GIntBig>(value);
+    *pbUnitSpecified = (unit != nullptr);
+    return CE_None;
+}
+
 /**********************************************************************
  *                       CPLParseNameValue()
  **********************************************************************/

--- a/port/cpl_string.cpp
+++ b/port/cpl_string.cpp
@@ -1740,10 +1740,13 @@ int CSLFindName(CSLConstList papszStrList, const char *pszName)
 
 /** Parse a memory size from a string.
  *
- * The string may indicate the units of the memory (e.g., "230k", "500MB").
- * The string may alternatively specify memory as a fraction of the usable
- * RAM (e.g., "25%"). If the string cannot be understood, the function
- * will return CE_Failure.
+ * The string may indicate the units of the memory (e.g., "230k", "500 MB"),
+ * using the prefixes "k", "m", or "g" in either lower or upper-case,
+ * optionally followed by a "b" or "B". The string may alternatively specify
+ * memory as a fraction of the usable RAM (e.g., "25%"). Spaces before the
+ * number, between the number and the units, or after the units are ignored,
+ * but other characters will cause a parsing failure. If the string cannot
+ * be understood, the function will return CE_Failure.
  *
  * @param pszValue the string to parse
  * @param[out] pnValue the parsed size, converted to bytes (if unit was specified)

--- a/port/cpl_string.h
+++ b/port/cpl_string.h
@@ -112,6 +112,9 @@ bool CPL_DLL CPLTestBool(const char *pszValue);
 bool CPL_DLL CPLFetchBool(CSLConstList papszStrList, const char *pszKey,
                           bool bDefault);
 
+CPLErr CPL_DLL CPLParseMemorySize(const char *pszValue, GIntBig *pnValue,
+                                  bool *pbUnitSpecified);
+
 const char CPL_DLL *CPLParseNameValue(const char *pszNameValue, char **ppszKey);
 const char CPL_DLL *CPLParseNameValueSep(const char *pszNameValue,
                                          char **ppszKey, char chSep);


### PR DESCRIPTION
## What does this PR do?

Validates the `-wm` argument to gdalwarp so that invalid values cause a failure. Also allows more clear specification of memory amount with units (`-wm 1G`, `-wm 200MB`), or as a fraction of usable memory (`-wm 10%`). Probably overkill for this purpose but I think there are other places the same function could be used, such as the parsing of `GDAL_CACHEMAX`.

## What are related issues/pull requests?

#10888, #10889

## Tasklist

 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
