### PR TITLE
docker/ubuntu-full: cache both PROJ builds

### DIFF
--- a/docker/ubuntu-full/Dockerfile
+++ b/docker/ubuntu-full/Dockerfile
@@ -303,7 +303,8 @@ COPY ./bh-proj.sh /buildscripts/bh-proj.sh
 # We want 2 separate steps for incremental builds where grids are refreshed
 # only when the content of cdn.proj.org has changed, independently if PROJ master
 # itself has changed.
-RUN . /buildscripts/bh-set-envvars.sh \
+RUN --mount=type=cache,id=ubuntu-full-proj,target=$HOME/.cache \
+    . /buildscripts/bh-set-envvars.sh \
     && DESTDIR=/build_tmp_proj /buildscripts/bh-proj.sh \
      && LD_LIBRARY_PATH=/build_tmp_proj/usr/local/lib /build_tmp_proj/usr/local/bin/projsync --target-dir /tmp/proj_grids --all \
      && rm -rf /build_tmp_proj


### PR DESCRIPTION
I did not realize that PROJ is built twice
in ubuntu-full, so add the cache mount
to the first build as well.
