### PR TITLE
Use 'gdalvsi://' protocol prefix (instead of 'vsi://') for Arrow VSI file system

### DIFF
--- a/autotest/ogr/ogr_arrow.py
+++ b/autotest/ogr/ogr_arrow.py
@@ -777,7 +777,7 @@ def test_ogr_arrow_vsi_arrow_file_system():
     if version < 16:
         pytest.skip("requires Arrow >= 16.0.0")
 
-    ogr.Open("vsi://data/arrow/test.feather")
+    ogr.Open("gdalvsi://data/arrow/test.feather")
 
 
 ###############################################################################

--- a/autotest/ogr/ogr_parquet.py
+++ b/autotest/ogr/ogr_parquet.py
@@ -4108,7 +4108,7 @@ def test_ogr_parquet_vsi_arrow_file_system():
     if version < 16:
         pytest.skip("requires Arrow >= 16.0.0")
 
-    ds = ogr.Open("PARQUET:vsi://data/parquet/test.parquet")
+    ds = ogr.Open("PARQUET:gdalvsi://data/parquet/test.parquet")
     lyr = ds.GetLayer(0)
     assert lyr.GetFeatureCount() > 0
 

--- a/doc/source/drivers/vector/arrow.rst
+++ b/doc/source/drivers/vector/arrow.rst
@@ -157,9 +157,9 @@ particular outside of the context of the OGR Arrow driver, by:
   GetGDALDriverManager()->GetDriverByName("ARROW")->GetMetadata(), the Arrow VSI
   file system will be also registered.
 
-- Prefixing any GDAL file name with the ``vsi://`` URI scheme prefix. In addition
+- Prefixing any GDAL file name with the ``gdalvsi://`` URI scheme prefix. In addition
   to any potential vsi prefix in the GDAL file name. So the ``/vsicurl/http://example.com``
-  GDAL file name becomes the ``vsi:///vsicurl/http://example.com`` Arrow URI.
+  GDAL file name becomes the ``gdalvsi:///vsicurl/http://example.com`` Arrow URI.
 
 Links
 -----

--- a/ogr/ogrsf_frmts/arrow/ogrfeatherdriver.cpp
+++ b/ogr/ogrsf_frmts/arrow/ogrfeatherdriver.cpp
@@ -121,10 +121,11 @@ static GDALDataset *OGRFeatherDriverOpen(GDALOpenInfo *poOpenInfo)
 
     GDALOpenInfo *poOpenInfoForIdentify = poOpenInfo;
     std::unique_ptr<GDALOpenInfo> poOpenInfoTmp;
-    if (STARTS_WITH(poOpenInfo->pszFilename, "vsi://"))
+    if (STARTS_WITH(poOpenInfo->pszFilename, "gdalvsi://"))
     {
-        poOpenInfoTmp = std::make_unique<GDALOpenInfo>(
-            poOpenInfo->pszFilename + strlen("vsi://"), poOpenInfo->nOpenFlags);
+        poOpenInfoTmp = std::make_unique<GDALOpenInfo>(poOpenInfo->pszFilename +
+                                                           strlen("gdalvsi://"),
+                                                       poOpenInfo->nOpenFlags);
         poOpenInfoForIdentify = poOpenInfoTmp.get();
     }
 

--- a/ogr/ogrsf_frmts/arrow/ogrfeatherdrivercore.cpp
+++ b/ogr/ogrsf_frmts/arrow/ogrfeatherdrivercore.cpp
@@ -131,9 +131,9 @@ bool OGRFeatherDriverIsArrowFileFormat(GDALOpenInfo *poOpenInfo)
 
 int OGRFeatherDriverIdentify(GDALOpenInfo *poOpenInfo)
 {
-    if (STARTS_WITH(poOpenInfo->pszFilename, "vsi://"))
+    if (STARTS_WITH(poOpenInfo->pszFilename, "gdalvsi://"))
     {
-        GDALOpenInfo oOpenInfo(poOpenInfo->pszFilename + strlen("vsi://"),
+        GDALOpenInfo oOpenInfo(poOpenInfo->pszFilename + strlen("gdalvsi://"),
                                poOpenInfo->nOpenFlags);
         return OGRFeatherDriverIdentify(&oOpenInfo);
     }

--- a/ogr/ogrsf_frmts/arrow/vsifilesystemregistrar.cpp
+++ b/ogr/ogrsf_frmts/arrow/vsifilesystemregistrar.cpp
@@ -31,13 +31,13 @@ auto kVSIFileSystemModule = ARROW_REGISTER_FILESYSTEM(
     []()
     {
         CPLDebugOnly("ARROW", "Register VSI Arrow file system");
-        return "vsi";
+        return "gdalvsi";
     }(),
     [](const arrow::fs::Uri &uri, const arrow::io::IOContext & /* io_context */,
        std::string *out_path)
         -> arrow::Result<std::shared_ptr<arrow::fs::FileSystem>>
     {
-        constexpr std::string_view kScheme = "vsi://";
+        constexpr std::string_view kScheme = "gdalvsi://";
         if (out_path)
             *out_path = uri.ToString().substr(kScheme.size());
         return std::make_shared<VSIArrowFileSystem>("ARROW", std::string());


### PR DESCRIPTION
In c889f141e44071e8c21627e4f2a5fc4229da989a (3.10.0dev), we have introduced a (C++) bridge from GDAL VSI to Arrow file system that used the 'vsi://' prefix. But as we are also going to introduce at the Python level as bridge from GDAL VSI to fsspec (https://github.com/OSGeo/gdal/pull/10985) that is going to use a 'gdalvsi://' prefix, better use the same prefix.
