### PR TITLE
netCDF: do not emit error when longitude axis unit is degrees_east and latitude axis unit is degrees_north

### DIFF
--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -546,7 +546,9 @@ def test_netcdf_11():
 
 def test_netcdf_cf_geog_with_srs():
 
+    gdal.ErrorReset()
     ds = gdal.Open("data/netcdf/cf_geog_with_srs.nc")
+    assert gdal.GetLastErrorMsg() == ""
 
     gt = ds.GetGeoTransform()
     assert gt == pytest.approx([-0.1, 0.2, 0, -79.1, 0, -0.2], rel=1e-5)

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -3470,6 +3470,12 @@ void netCDFDataset::SetProjectionFromVar(
     {
         const char *pszUnitsX = FetchAttr(nGroupDimXID, nVarDimXID, "units");
         const char *pszUnitsY = FetchAttr(nGroupDimYID, nVarDimYID, "units");
+        // Normalize degrees_east/degrees_north to degrees
+        // Cf https://github.com/OSGeo/gdal/issues/11009
+        if (pszUnitsX && EQUAL(pszUnitsX, "degrees_east"))
+            pszUnitsX = "degrees";
+        if (pszUnitsY && EQUAL(pszUnitsY, "degrees_north"))
+            pszUnitsY = "degrees";
 
         if (pszUnitsX && pszUnitsY)
         {


### PR DESCRIPTION
Fixes #11009
