### PR TITLE
Doc: fix warning 'direct use of the spelling directive is deprecated,…

### DIFF
--- a/.github/workflows/doc_checks.yml
+++ b/.github/workflows/doc_checks.yml
@@ -56,10 +56,10 @@ jobs:
           ldconfig
           popd
 
-    - name: Update sphinx-rtd-theme
+    - name: Update components
       shell: bash -l {0}
       run: |
-          pip install -U "sphinx-rtd-theme>=3.0.0"
+          pip install -U "sphinx-rtd-theme>=3.0.0" "sphinxcontrib-spelling>=8.0.0"
 
     - name: Print versions
       shell: bash -l {0}

--- a/doc/source/thanks.rst
+++ b/doc/source/thanks.rst
@@ -134,7 +134,7 @@ You can also consult `Frank Warmerdam's sponsors, acknowledgments and credits <h
 
 .. below is an allow-list for spelling checker.
 
-.. spelling::
+.. spelling:word-list::
     Daho
     Arevalo
     Ragi


### PR DESCRIPTION
… replace ".. spelling::" with ".. spelling:word-list::"'

Cf https://readthedocs.org/projects/gdal/builds/25959246/

Related to the update to sphinxcontrib-spelling == 8.0.0, so do the same on our github action CI.
