### PR TITLE
CSharp bindings: Add VSIGetMemFileBuffer bindings

### DIFF
--- a/swig/include/csharp/gdal_csharp.i
+++ b/swig/include/csharp/gdal_csharp.i
@@ -381,17 +381,17 @@ public CPLErr SetGCPs(GCP[] pGCPs, string pszGCPProjection) {
 
 %rename (GetMemFileBuffer) wrapper_VSIGetMemFileBuffer;
 
-%typemap(cstype) (GIntBig *pnDataLength) "out int";
-%typemap(imtype) (GIntBig *pnDataLength) "out int";
-%apply (int *OUTPUT) {(GIntBig *pnDataLength)}
+%typemap(cstype) (vsi_l_offset *pnDataLength) "out ulong";
+%typemap(imtype) (vsi_l_offset *pnDataLength) "out ulong";
+%apply (unsigned long long *OUTPUT) {(vsi_l_offset *pnDataLength)}
 %typemap(cstype) (int bUnlinkAndSeize) "bool";
 %typemap(csin) (int bUnlinkAndSeize) "$csinput ? 1 : 0";
 
 %inline {
-GByte* wrapper_VSIGetMemFileBuffer(const char *utf8_path, GIntBig *pnDataLength, int bUnlinkAndSeize)
+GByte* wrapper_VSIGetMemFileBuffer(const char *utf8_path, vsi_l_offset *pnDataLength, int bUnlinkAndSeize)
 {
-    return VSIGetMemFileBuffer(utf8_path, reinterpret_cast<vsi_l_offset *>(pnDataLength), bUnlinkAndSeize);
+    return VSIGetMemFileBuffer(utf8_path, pnDataLength, bUnlinkAndSeize);
 }
 }
 
-%clear (GIntBig *pnDataLength);
+%clear (vsi_l_offset *pnDataLength);

--- a/swig/include/csharp/gdal_csharp.i
+++ b/swig/include/csharp/gdal_csharp.i
@@ -378,3 +378,20 @@ public CPLErr SetGCPs(GCP[] pGCPs, string pszGCPProjection) {
    }
 
 %}
+
+%rename (GetMemFileBuffer) wrapper_VSIGetMemFileBuffer;
+
+%typemap(cstype) (GIntBig *pnDataLength) "out int";
+%typemap(imtype) (GIntBig *pnDataLength) "out int";
+%apply (int *OUTPUT) {(GIntBig *pnDataLength)}
+%typemap(cstype) (int bUnlinkAndSeize) "bool";
+%typemap(csin) (int bUnlinkAndSeize) "$csinput ? 1 : 0";
+
+%inline {
+GByte* wrapper_VSIGetMemFileBuffer(const char *utf8_path, GIntBig *pnDataLength, int bUnlinkAndSeize)
+{
+    return VSIGetMemFileBuffer(utf8_path, reinterpret_cast<vsi_l_offset *>(pnDataLength), bUnlinkAndSeize);
+}
+}
+
+%clear (GIntBig *pnDataLength);


### PR DESCRIPTION
Fixes #11032

This is the first time I have dealt with configuration SWIG, and I'm not a C++ expert, so there might be a better way of generating the bindings. I tried to take inspiration of how the other SWIG interface code was written.

It is intentional that the `vsi_l_offset` is mapped to "int" in C#, since the use case will in most cases probably be:

```csharp
IntPtr ptr = Gdal.GetMemFileBuffer(vsiPath, out int length, false);
byte[] buffer = new byte[length];
Marshal.Copy(ptr, buffer, 0, length);
```

And Marshal.Copy only supports int for buffer length. It seems like unsigned long and unsigned long long pointers are handled similarly in other parts of the binding code (casted to signed int), so hopefully this is OK.