### PR TITLE
DIMAP: for PNEO products, use the new color interpretations for the NIR, RedEdge and DeepBlue/Coastal bands

### DIFF
--- a/autotest/gdrivers/dimap.py
+++ b/autotest/gdrivers/dimap.py
@@ -233,6 +233,14 @@ def test_dimap_2_vhr2020_ms_fs():
         "Red Edge",
         "Deep Blue",
     ]
+    assert [ds.GetRasterBand(i + 1).GetColorInterpretation() for i in range(6)] == [
+        gdal.GCI_RedBand,
+        gdal.GCI_GreenBand,
+        gdal.GCI_BlueBand,
+        gdal.GCI_NIRBand,
+        gdal.GCI_RedEdgeBand,
+        gdal.GCI_CoastalBand,
+    ]
     rgb_ds = gdal.Open("data/dimap2/vhr2020_ms_fs/MS-FS/IMG_RGB_R1C1.TIF")
     ned_ds = gdal.Open("data/dimap2/vhr2020_ms_fs/MS-FS/IMG_NED_R1C1.TIF")
     assert ds.ReadRaster() == rgb_ds.ReadRaster() + ned_ds.ReadRaster()

--- a/frmts/dimap/dimapdataset.cpp
+++ b/frmts/dimap/dimapdataset.cpp
@@ -1400,22 +1400,30 @@ int DIMAPDataset::ReadImageInformation2()
                 }
                 case 4:
                 {
+                    poBand->SetColorInterpretation(GCI_NIRBand);
                     poBand->SetDescription("NIR");
                     break;
                 }
                 case 5:
                 {
+                    poBand->SetColorInterpretation(GCI_RedEdgeBand);
                     poBand->SetDescription("Red Edge");
                     break;
                 }
                 case 6:
                 {
+                    poBand->SetColorInterpretation(GCI_CoastalBand);
                     poBand->SetDescription("Deep Blue");
                     break;
                 }
                 default:
                     break;
             }
+        }
+        else if (l_nBands == 1 && osSpectralProcessing == "PAN")
+        {
+            poBand->SetColorInterpretation(GCI_PanBand);
+            poBand->SetDescription("Panchromatic");
         }
         SetBand(iBand, poBand);
     }


### PR DESCRIPTION
CC @tbonfort 

In b3f3ce79e914164b57c7ca58a8e0515e7b5a836b , you added logic to register metadata on the bands, but it doesn't look to work with the fake dataset we have in autotest/gdrivers/data/dimap2/vhr2020_ms_fs/MS-FS/DIM_MS-FS.XML, nor a PNEO_ORTHO_BUNDLE-FS_REFLECTANCE_JPEG2000_4326_NONE_STD_A one I likely got during the development of the PNEO support.
The reason I ask is that I rather see a Radiometric_Data.Radiometric_Calibration.Band_Spectral_Range (rather than Radiometric_Data.Radiometric_Calibration.Instrument_Calibration.Band_Measurement_List as expected by the driver) element with subnodes like:
```
                        <Band_Spectral_Range>
                                <BAND_ID>R</BAND_ID>
                                <CALIBRATION_DATE>2019-05-20T09:07:00Z</CALIBRATION_DATE>
                                <MEASURE_DESC>Spectral Range values of raw radiometric Band</MEASURE_DESC>
                                <MEASURE_UNIT>micrometer</MEASURE_UNIT>
                                <MEASURE_UNCERTAINTY>0</MEASURE_UNCERTAINTY>
                                <FWHM>
                                        <MIN>0.619</MIN>
                                        <MAX>0.69</MAX>
                                </FWHM>
                                <GAIN>0</GAIN>
                                <BIAS>0</BIAS>
                        </Band_Spectral_Range>
```
I guess we could take the mean of FWHM.MIN and .MAX as the central wavelength, and MAX-MIN as the FWHM value to report in the new IMAGERY band metadata domain (cf https://gdal.org/en/latest/user/raster_data_model.html#imagery-domain-remote-sensing)