### PR TITLE
CI: fix 'other_checks' job that breaks on 'cffconvert --validate'

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -143,7 +143,8 @@ jobs:
       - name: Install Requirements
         run: |
             sudo apt install python3-pip wget
-            sudo pip3 install cffconvert
+            # ruamel.yaml.clib 0.2.9 throws a 'TypeError: a string or stream input is required' when running cffconvert --validate
+            sudo pip3 install cffconvert "ruamel.yaml.clib<0.2.9"
 
       - name: Validate citation file
         run: |


### PR DESCRIPTION
Issue has been reported to https://sourceforge.net/p/ruamel-yaml-clib/tickets/38/