### PR TITLE
Remove some unchecked float parsing in command line utils

### DIFF
--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -3276,6 +3276,12 @@ GDALTranslateOptionsNew(char **papszArgv,
             psOptions->asScaleParams[nIndex].bHaveScaleSrc = false;
             if (i < argc - 2 && ArgIsNumeric(papszArgv[i + 1]))
             {
+                if (!ArgIsNumeric(papszArgv[i + 2]))
+                {
+                    CPLError(CE_Failure, CPLE_IllegalArg,
+                             "Value of -scale must be numeric");
+                    return nullptr;
+                }
                 psOptions->asScaleParams[nIndex].bHaveScaleSrc = true;
                 psOptions->asScaleParams[nIndex].dfScaleSrcMin =
                     CPLAtofM(papszArgv[i + 1]);
@@ -3287,6 +3293,12 @@ GDALTranslateOptionsNew(char **papszArgv,
                 psOptions->asScaleParams[nIndex].bHaveScaleSrc &&
                 ArgIsNumeric(papszArgv[i + 1]))
             {
+                if (!ArgIsNumeric(papszArgv[i + 2]))
+                {
+                    CPLError(CE_Failure, CPLE_IllegalArg,
+                             "Value of -scale must be numeric");
+                    return nullptr;
+                }
                 psOptions->asScaleParams[nIndex].dfScaleDstMin =
                     CPLAtofM(papszArgv[i + 1]);
                 psOptions->asScaleParams[nIndex].dfScaleDstMax =

--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -5753,10 +5753,10 @@ GDALWarpAppOptionsGetParser(GDALWarpAppOptions *psOptions,
 
     argParser->add_argument("-et")
         .metavar("<err_threshold>")
+        .store_into(psOptions->dfErrorThreshold)
         .action(
-            [psOptions](const std::string &s)
+            [psOptions](const std::string &)
             {
-                psOptions->dfErrorThreshold = CPLAtofM(s.c_str());
                 psOptions->aosWarpOptions.AddString(CPLSPrintf(
                     "ERROR_THRESHOLD=%.16g", psOptions->dfErrorThreshold));
             })

--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -7522,22 +7522,16 @@ static std::unique_ptr<GDALArgumentParser> GDALVectorTranslateOptionsGetParser(
 
     argParser->add_argument("-segmentize")
         .metavar("<max_dist>")
-        .action(
-            [psOptions](const std::string &s)
-            {
-                psOptions->eGeomOp = GEOMOP_SEGMENTIZE;
-                psOptions->dfGeomOpParam = CPLAtofM(s.c_str());
-            })
+        .store_into(psOptions->dfGeomOpParam)
+        .action([psOptions](const std::string &)
+                { psOptions->eGeomOp = GEOMOP_SEGMENTIZE; })
         .help(_("Maximum distance between 2 nodes."));
 
     argParser->add_argument("-simplify")
         .metavar("<tolerance>")
-        .action(
-            [psOptions](const std::string &s)
-            {
-                psOptions->eGeomOp = GEOMOP_SIMPLIFY_PRESERVE_TOPOLOGY;
-                psOptions->dfGeomOpParam = CPLAtofM(s.c_str());
-            })
+        .store_into(psOptions->dfGeomOpParam)
+        .action([psOptions](const std::string &)
+                { psOptions->eGeomOp = GEOMOP_SIMPLIFY_PRESERVE_TOPOLOGY; })
         .help(_("Distance tolerance for simplification."));
 
     argParser->add_argument("-makevalid")

--- a/autotest/utilities/test_gdal_translate.py
+++ b/autotest/utilities/test_gdal_translate.py
@@ -588,7 +588,7 @@ def test_gdal_translate_21(gdal_translate_path, tmp_path):
 
 ###############################################################################
 # Test that statistics are copied only when appropriate (#3889)
-# in that case, they must *NOT* be copied
+# in this case, they must *NOT* be copied
 
 
 @pytest.mark.require_driver("HFA")
@@ -604,13 +604,11 @@ def test_gdal_translate_22(gdal_translate_path, tmp_path):
     md = ds.GetRasterBand(1).GetMetadata()
     ds = None
 
-    assert (
-        "STATISTICS_MINIMUM" not in md
-    ), "did not expected a STATISTICS_MINIMUM value."
+    assert "STATISTICS_MINIMUM" not in md, "did not expect a STATISTICS_MINIMUM value."
 
     assert (
         "STATISTICS_HISTOBINVALUES" not in md
-    ), "did not expected a STATISTICS_HISTOBINVALUES value."
+    ), "did not expect a STATISTICS_HISTOBINVALUES value."
 
 
 ###############################################################################
@@ -1137,3 +1135,19 @@ def test_gdal_translate_scale_and_unscale_incompatible(gdal_translate_path, tmp_
         + f" -a_scale 0.0001 -a_offset 0.1 -unscale ../gcore/data/byte.tif {tmp_vsimem}/out.tif"
     )
     assert "-a_scale/-a_offset are not applied by -unscale" in err
+
+
+###############################################################################
+# Test that invalid values of -scale are detected
+
+
+def test_gdal_translate_scale_invalid(gdal_translate_path, tmp_path):
+
+    outfile = tmp_path / "out.tif"
+
+    _, err = gdaltest.runexternal_out_and_err(
+        f"{gdal_translate_path} -scale 0 255 6 -badarg ../gcore/data/byte.tif {outfile}"
+    )
+
+    assert "must be numeric" in err
+    assert not outfile.exists()

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -435,6 +435,19 @@ def test_gdalwarp_lib_19(testgdalwarp_gcp_tif):
 
 
 ###############################################################################
+# Test invalid value of -et
+
+
+def test_gdalwarp_lib_invalid_et(testgdalwarp_gcp_tif):
+
+    with gdaltest.enable_exceptions():
+        with pytest.raises(Exception, match="Failed to parse"):
+            gdal.Warp(
+                "", "../gcore/data/byte.tif", format="MEM", errorThreshold="minimal"
+            )
+
+
+###############################################################################
 # Test cutline from OGR datasource.
 
 

--- a/autotest/utilities/test_ogr2ogr_lib.py
+++ b/autotest/utilities/test_ogr2ogr_lib.py
@@ -1633,6 +1633,13 @@ def test_ogr2ogr_lib_simplify():
     f.SetGeometry(ogr.CreateGeometryFromWkt("LINESTRING(0 0, 1 0, 10 0)"))
     src_lyr.CreateFeature(f)
 
+    with gdaltest.enable_exceptions(), pytest.raises(
+        Exception, match="Failed to parse"
+    ):
+        gdal.VectorTranslate(
+            "", src_ds, format="Memory", simplifyTolerance="reasonable"
+        )
+
     dst_ds = gdal.VectorTranslate("", src_ds, format="Memory", simplifyTolerance=5)
 
     dst_lyr = dst_ds.GetLayer(0)

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -2610,7 +2610,7 @@ def TranslateOptions(options=None, format=None,
         if width != 0 or height != 0:
             new_options += ['-outsize', str(width), str(height)]
         elif widthPct != 0 and heightPct != 0:
-            new_options += ['-outsize', str(widthPct) + '%%', str(heightPct) + '%%']
+            new_options += ['-outsize', str(widthPct) + '%', str(heightPct) + '%']
         if creationOptions is not None:
             _addCreationOptions(new_options, creationOptions)
         if srcWin is not None:


### PR DESCRIPTION
# What does this PR do?

Addresses some cases where invalid values to command line arguments would be silently accepted and converted to zero or otherwise misinterpreted.

## What are related issues/pull requests?

 #10889

## Tasklist

 - [x] Add test case(s)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
