### PR TITLE
heif: skip tests for unsupported codecs

### DIFF
--- a/frmts/heif/heifdataset.cpp
+++ b/frmts/heif/heifdataset.cpp
@@ -846,14 +846,47 @@ void GDALRegister_HEIF()
         HEIFDriverSetCommonMetadata(poDriver);
 
 #if LIBHEIF_NUMERIC_VERSION >= BUILD_LIBHEIF_VERSION(1, 12, 0)
+        if (heif_have_decoder_for_format(heif_compression_AVC))
+        {
+            poDriver->SetMetadataItem("SUPPORTS_AVC", "YES", "HEIF");
+        }
         // If the AVIF dedicated driver is not available, register an AVIF driver,
         // called AVIF_HEIF, based on libheif, if it has AV1 decoding capabilities.
         if (heif_have_decoder_for_format(heif_compression_AV1))
         {
             poDriver->SetMetadataItem("SUPPORTS_AVIF", "YES", "HEIF");
         }
+        if (heif_have_decoder_for_format(heif_compression_HEVC))
+        {
+            poDriver->SetMetadataItem("SUPPORTS_HEVC", "YES", "HEIF");
+        }
+        if (heif_have_decoder_for_format(heif_compression_JPEG))
+        {
+            poDriver->SetMetadataItem("SUPPORTS_JPEG", "YES", "HEIF");
+        }
+        if (heif_have_decoder_for_format(heif_compression_JPEG2000))
+        {
+            poDriver->SetMetadataItem("SUPPORTS_JPEG2000", "YES", "HEIF");
+        }
+        if (heif_have_decoder_for_format(heif_compression_HTJ2K))
+        {
+            poDriver->SetMetadataItem("SUPPORTS_JPEG2000_HT", "YES", "HEIF");
+        }
+        if (heif_have_decoder_for_format(heif_compression_uncompressed))
+        {
+            poDriver->SetMetadataItem("SUPPORTS_UNCOMPRESSED", "YES", "HEIF");
+        }
+        if (heif_have_decoder_for_format(heif_compression_VVC))
+        {
+            poDriver->SetMetadataItem("SUPPORTS_VVC", "YES", "HEIF");
+        }
+#else
+        // Anything that old probably supports only HEVC
+        poDriver->SetMetadataItem("SUPPORTS_HEVC", "YES", "HEIF");
 #endif
-
+#ifdef LIBHEIF_SUPPORTS_TILES
+        poDriver->SetMetadataItem("SUPPORTS_TILES", "YES", "HEIF");
+#endif
         poDriver->pfnOpen = GDALHEIFDataset::OpenHEIF;
         poDM->RegisterDriver(poDriver);
     }

--- a/frmts/heif/heifdrivercore.cpp
+++ b/frmts/heif/heifdrivercore.cpp
@@ -86,9 +86,6 @@ void HEIFDriverSetCommonMetadata(GDALDriver *poDriver)
 
     poDriver->pfnIdentify = HEIFDriverIdentifySimplified;
     poDriver->SetMetadataItem(GDAL_DCAP_OPEN, "YES");
-#ifdef LIBHEIF_SUPPORTS_TILES
-    poDriver->SetMetadataItem("HEIF_SUPPORTS_TILES", "YES");
-#endif
 }
 
 /************************************************************************/


### PR DESCRIPTION
## What does this PR do?

Adds metadata entries and test changes to selectively skip tests based on reported capabilities.

Recent versions of libheif support pluggable codecs, plus codecs can be disabled at build time (e.g. for licensing reasons), so there is no guarantee that any specific compression type is available. This uses libheif API to check what is enabled, sets a metadata item for each compression type, and then uses that in the tests to skip any unsupported compression type.

## What are related issues/pull requests?

None.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
