### PR TITLE
heif: fix memory leak of image data

### DIFF
--- a/frmts/heif/heifdataset.cpp
+++ b/frmts/heif/heifdataset.cpp
@@ -748,7 +748,7 @@ CPLErr GDALHEIFRasterBand::IReadBlock(int nBlockXOff, int nBlockYOff,
             }
         }
     }
-
+    heif_image_release(hImage);
     return CE_None;
 }
 #else


### PR DESCRIPTION
## What does this PR do?

In reworking the heif driver to support tiles (in #10982), I inadvertently introduced a memory leak. This fixes that.

## What are related issues/pull requests?

N/A

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
