### PR TITLE
[Backport release/3.10] SNAP_TIFF: do not declare extension to avoid confusing QGIS

### DIFF
--- a/.github/workflows/ubuntu_24.04/expected_gdalinfo_formats.txt
+++ b/.github/workflows/ubuntu_24.04/expected_gdalinfo_formats.txt
@@ -2,7 +2,7 @@ Supported Formats: (ro:read-only, rw:read-write, +:update, v:virtual-I/O s:subda
   VRT -raster,multidimensional raster- (rw+v): Virtual Raster (*.vrt)
   DERIVED -raster- (ro): Derived datasets using VRT pixel functions
   GTI -raster- (rov): GDAL Raster Tile Index (*.gti.gpkg, *.gti.fgb, *.gti)
-  SNAP_TIFF -raster- (rov): Sentinel Application Processing GeoTIFF (*.tif, *.tiff)
+  SNAP_TIFF -raster- (rov): Sentinel Application Processing GeoTIFF
   GTiff -raster- (rw+vs): GeoTIFF (*.tif, *.tiff)
   COG -raster- (wv): Cloud optimized GeoTIFF generator (*.tif, *.tiff)
   NITF -raster- (rw+vs): National Imagery Transmission Format (*.ntf)

--- a/.github/workflows/windows_conda_expected_gdalinfo_formats.txt
+++ b/.github/workflows/windows_conda_expected_gdalinfo_formats.txt
@@ -2,7 +2,7 @@ Supported Formats: (ro:read-only, rw:read-write, +:update, v:virtual-I/O s:subda
   VRT -raster,multidimensional raster- (rw+v): Virtual Raster (*.vrt)
   DERIVED -raster- (ro): Derived datasets using VRT pixel functions
   GTI -raster- (rov): GDAL Raster Tile Index (*.gti.gpkg, *.gti.fgb, *.gti)
-  SNAP_TIFF -raster- (rov): Sentinel Application Processing GeoTIFF (*.tif, *.tiff)
+  SNAP_TIFF -raster- (rov): Sentinel Application Processing GeoTIFF
   GTiff -raster- (rw+vs): GeoTIFF (*.tif, *.tiff)
   COG -raster- (wv): Cloud optimized GeoTIFF generator (*.tif, *.tiff)
   NITF -raster- (rw+vs): National Imagery Transmission Format (*.ntf)

--- a/frmts/snap_tiff/snaptiffdriver.cpp
+++ b/frmts/snap_tiff/snaptiffdriver.cpp
@@ -716,8 +716,11 @@ void GDALRegister_SNAP_TIFF()
                               "Sentinel Application Processing GeoTIFF");
     poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC,
                               "drivers/raster/snap_tiff.html");
-    poDriver->SetMetadataItem(GDAL_DMD_MIMETYPE, "image/tiff");
-    poDriver->SetMetadataItem(GDAL_DMD_EXTENSIONS, "tif tiff");
+    // Declaring the tif extension confuses QGIS
+    // Cf https://github.com/qgis/QGIS/issues/59112
+    // This driver is of too marginal usage to justify causing chaos downstream.
+    // poDriver->SetMetadataItem(GDAL_DMD_MIMETYPE, "image/tiff");
+    // poDriver->SetMetadataItem(GDAL_DMD_EXTENSIONS, "tif tiff");
     poDriver->SetMetadataItem(GDAL_DCAP_VIRTUALIO, "YES");
 
     poDriver->pfnOpen = SNAPTIFFDataset::Open;


### PR DESCRIPTION
Backport #11037
 **Authored by:** @rouault