### PR TITLE
[Backport release/3.10] GPKG: fix memleaks in usage of GetSpatialRef(int, ...)

### DIFF
--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -372,8 +372,9 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource,
 
     int GetSrsId(const OGRSpatialReference *poSRS);
     const char *GetSrsName(const OGRSpatialReference &oSRS);
-    OGRSpatialReference *GetSpatialRef(int iSrsId, bool bFallbackToEPSG = false,
-                                       bool bEmitErrorIfNotFound = true);
+    std::unique_ptr<OGRSpatialReference, OGRSpatialReferenceReleaser>
+    GetSpatialRef(int iSrsId, bool bFallbackToEPSG = false,
+                  bool bEmitErrorIfNotFound = true);
     OGRErr CreateExtensionsTableIfNecessary();
     bool HasExtensionsTable();
 

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagelayer.cpp
@@ -1144,12 +1144,10 @@ void OGRGeoPackageLayer::BuildFeatureDefn(const char *pszLayerName,
                                                 wkbUnknown);
 
                     /* Read the SRS */
-                    OGRSpatialReference *poSRS =
-                        m_poDS->GetSpatialRef(nSRID, true);
+                    auto poSRS = m_poDS->GetSpatialRef(nSRID, true);
                     if (poSRS)
                     {
-                        oGeomField.SetSpatialRef(poSRS);
-                        poSRS->Dereference();
+                        oGeomField.SetSpatialRef(poSRS.get());
                     }
 
                     OGRwkbGeometryType eGeomType = poGeom->getGeometryType();

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -1202,12 +1202,11 @@ OGRErr OGRGeoPackageTableLayer::ReadTableDefinition()
                             FALSE);
 
                     /* Read the SRS */
-                    OGRSpatialReference *poSRS = m_poDS->GetSpatialRef(m_iSrs);
+                    auto poSRS = m_poDS->GetSpatialRef(m_iSrs);
                     if (poSRS)
                     {
                         m_poFeatureDefn->GetGeomFieldDefn(0)->SetSpatialRef(
-                            poSRS);
-                        poSRS->Dereference();
+                            poSRS.get());
                     }
                 }
                 else if (!STARTS_WITH(
@@ -5660,8 +5659,7 @@ void OGRGeoPackageTableLayer::SetCreationParameters(
                                           /* bEmitErrorIfNotFound = */ false);
                 if (poGotSRS)
                 {
-                    oGeomFieldDefn.SetSpatialRef(poGotSRS);
-                    poGotSRS->Release();
+                    oGeomFieldDefn.SetSpatialRef(poGotSRS.get());
                 }
                 else
                 {


### PR DESCRIPTION
Backport #11056
 **Authored by:** @rouault