### PR TITLE
JP2Lura: fix Identify() method

### DIFF
--- a/frmts/jp2lura/jp2luradrivercore.cpp
+++ b/frmts/jp2lura/jp2luradrivercore.cpp
@@ -20,15 +20,11 @@
 int JP2LuraDriverIdentify(GDALOpenInfo *poOpenInfo)
 
 {
-    if (STARTS_WITH_CI(poOpenInfo->pszFilename, "JP2Lura:"))
-        return true;
-
-    // Check magic number
-    return poOpenInfo->fpL != nullptr && poOpenInfo->nHeaderBytes >= 4 &&
-           poOpenInfo->pabyHeader[0] == 0x76 &&
-           poOpenInfo->pabyHeader[1] == 0x2f &&
-           poOpenInfo->pabyHeader[2] == 0x31 &&
-           poOpenInfo->pabyHeader[3] == 0x01;
+    return poOpenInfo->nHeaderBytes >= 16 &&
+           (memcmp(poOpenInfo->pabyHeader, jpc_header, sizeof(jpc_header)) ==
+                0 ||
+            memcmp(poOpenInfo->pabyHeader + 4, jp2_box_jp,
+                   sizeof(jp2_box_jp)) == 0);
 }
 
 /************************************************************************/


### PR DESCRIPTION
I discovered accidentally the method was mis-identifying a EXR dataset as recognized by the JP2Lura driver while investigating https://github.com/OSGeo/gdal/issues/11095. This dates back to 2e650d8cace54238f863ca705cd20030409cf295 where for some reason (I suspect wrong copy&paste) the Identify() logic was completely changed
