### PR TITLE
heif: protect against testing for enums that might not exist

### DIFF
--- a/frmts/heif/heifdataset.cpp
+++ b/frmts/heif/heifdataset.cpp
@@ -824,6 +824,7 @@ void GDALRegister_HEIF()
         {
             poDriver->SetMetadataItem("SUPPORTS_JPEG_WRITE", "YES", "HEIF");
         }
+#if LIBHEIF_NUMERIC_VERSION >= BUILD_LIBHEIF_VERSION(1, 15, 0)
         if (heif_have_decoder_for_format(heif_compression_JPEG2000))
         {
             poDriver->SetMetadataItem("SUPPORTS_JPEG2000", "YES", "HEIF");
@@ -832,6 +833,8 @@ void GDALRegister_HEIF()
         {
             poDriver->SetMetadataItem("SUPPORTS_JPEG2000_WRITE", "YES", "HEIF");
         }
+#endif
+#if LIBHEIF_NUMERIC_VERSION >= BUILD_LIBHEIF_VERSION(1, 18, 0)
         if (heif_have_decoder_for_format(heif_compression_HTJ2K))
         {
             poDriver->SetMetadataItem("SUPPORTS_HTJ2K", "YES", "HEIF");
@@ -840,6 +843,8 @@ void GDALRegister_HEIF()
         {
             poDriver->SetMetadataItem("SUPPORTS_HTJ2K_WRITE", "YES", "HEIF");
         }
+#endif
+#if LIBHEIF_NUMERIC_VERSION >= BUILD_LIBHEIF_VERSION(1, 16, 0)
         if (heif_have_decoder_for_format(heif_compression_uncompressed))
         {
             poDriver->SetMetadataItem("SUPPORTS_UNCOMPRESSED", "YES", "HEIF");
@@ -849,6 +854,8 @@ void GDALRegister_HEIF()
             poDriver->SetMetadataItem("SUPPORTS_UNCOMPRESSED_WRITE", "YES",
                                       "HEIF");
         }
+#endif
+#if LIBHEIF_NUMERIC_VERSION >= BUILD_LIBHEIF_VERSION(1, 15, 0)
         if (heif_have_decoder_for_format(heif_compression_VVC))
         {
             poDriver->SetMetadataItem("SUPPORTS_VVC", "YES", "HEIF");
@@ -857,6 +864,7 @@ void GDALRegister_HEIF()
         {
             poDriver->SetMetadataItem("SUPPORTS_VVC_WRITE", "YES", "HEIF");
         }
+#endif
 #else
         // Anything that old probably supports only HEVC
         poDriver->SetMetadataItem("SUPPORTS_HEVC", "YES", "HEIF");


### PR DESCRIPTION
## What does this PR do?

Adds compile-time checks that the required enum values are present in the version of libheif we are compiling against.

## What are related issues/pull requests?

This came out of #11095.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [x] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
