### PR TITLE
JPEGXL: allow a minimum DISTANCE of 0.01, max of 25 and revise QUALITY to DISTANCE formula

### DIFF
--- a/autotest/gdrivers/jpegxl.py
+++ b/autotest/gdrivers/jpegxl.py
@@ -127,7 +127,7 @@ def test_jpegxl_rgba_distance():
 
 
 @pytest.mark.parametrize(
-    "quality,equivalent_distance", [(100, 0), (90, 1), (10, 12.65)]
+    "quality,equivalent_distance", [(100, 0), (10, 15.266666666666667)]
 )
 def test_jpegxl_rgba_quality(quality, equivalent_distance):
 

--- a/doc/source/drivers/raster/cog.rst
+++ b/doc/source/drivers/raster/cog.rst
@@ -125,7 +125,7 @@ General creation options
       The higher, the smaller file and slower compression time.
 
 -  .. co:: JXL_DISTANCE
-      :choices: 0.1-15
+      :choices: 0.01-25
       :default: 1.0
 
       Distance level for lossy JPEG-XL compression.
@@ -137,7 +137,7 @@ General creation options
       The recommended range is [0.5,3].
 
 -  .. co:: JXL_ALPHA_DISTANCE
-      :choices: -1, 0, 0.1-15
+      :choices: -1, 0, 0.01-25
       :default: -1
       :since: 3.7
 

--- a/doc/source/drivers/raster/gtiff.rst
+++ b/doc/source/drivers/raster/gtiff.rst
@@ -634,7 +634,7 @@ This driver supports the following creation options:
       The higher, the smaller file and slower compression time.
 
 -  .. co:: JXL_DISTANCE
-      :choices: [0.1-15]
+      :choices: [0.01-25]
       :default: 1.0
 
       Distance level for lossy JPEG-XL compression.
@@ -646,7 +646,7 @@ This driver supports the following creation options:
       The recommended range is [0.5,3].
 
 -  .. co:: JXL_ALPHA_DISTANCE
-      :choices: -1,0,[0.1-15]
+      :choices: -1,0,[0.01-25]
       :default: -1
       :since: 3.7
 

--- a/doc/source/drivers/raster/jpegxl.rst
+++ b/doc/source/drivers/raster/jpegxl.rst
@@ -108,7 +108,7 @@ The following creation options are available:
       The higher, the smaller file and slower compression time.
 
 -  .. co:: DISTANCE
-      :choices: 0.1-15
+      :choices: 0.01-25
       :default: 1.0
 
       Distance level for lossy JPEG-XL compression.
@@ -120,7 +120,7 @@ The following creation options are available:
       The recommended range is [0.5,3].
 
 -  .. co:: ALPHA_DISTANCE
-      :choices: -1, 0, 0.1-15
+      :choices: -1, 0, 0.01-25
       :default: -1.0
       :since: 3.7
 

--- a/frmts/gtiff/cogdriver.cpp
+++ b/frmts/gtiff/cogdriver.cpp
@@ -1505,13 +1505,13 @@ void GDALCOGDriver::InitializeCreationOptionList()
         "1(fast)-9(slow)' default='5'/>"
         "   <Option name='JXL_DISTANCE' type='float' description='Distance "
         "level for lossy compression (0=mathematically lossless, 1.0=visually "
-        "lossless, usual range [0.5,3])' default='1.0' min='0.1' max='15.0'/>";
+        "lossless, usual range [0.5,3])' default='1.0' min='0.01' max='25.0'/>";
 #ifdef HAVE_JxlEncoderSetExtraChannelDistance
     osOptions += "   <Option name='JXL_ALPHA_DISTANCE' type='float' "
                  "description='Distance level for alpha channel "
                  "(-1=same as non-alpha channels, "
                  "0=mathematically lossless, 1.0=visually lossless, "
-                 "usual range [0.5,3])' default='-1' min='-1' max='15.0'/>";
+                 "usual range [0.5,3])' default='-1' min='-1' max='25.0'/>";
 #endif
 #endif
     osOptions +=

--- a/frmts/gtiff/geotiff.cpp
+++ b/frmts/gtiff/geotiff.cpp
@@ -1412,13 +1412,13 @@ void GDALRegister_GTiff()
         "1(fast)-9(slow)' default='5'/>"
         "   <Option name='JXL_DISTANCE' type='float' description='Distance "
         "level for lossy compression (0=mathematically lossless, 1.0=visually "
-        "lossless, usual range [0.5,3])' default='1.0' min='0.1' max='15.0'/>";
+        "lossless, usual range [0.5,3])' default='1.0' min='0.01' max='25.0'/>";
 #ifdef HAVE_JxlEncoderSetExtraChannelDistance
     osOptions += "   <Option name='JXL_ALPHA_DISTANCE' type='float' "
                  "description='Distance level for alpha channel "
                  "(-1=same as non-alpha channels, "
                  "0=mathematically lossless, 1.0=visually lossless, "
-                 "usual range [0.5,3])' default='-1' min='-1' max='15.0'/>";
+                 "usual range [0.5,3])' default='-1' min='-1' max='25.0'/>";
 #endif
 #endif
     osOptions +=

--- a/frmts/jpegxl/jpegxl.cpp
+++ b/frmts/jpegxl/jpegxl.cpp
@@ -37,6 +37,8 @@ struct VSILFileReleaser
 };
 }  // namespace
 
+constexpr float MIN_DISTANCE = 0.01f;
+
 /************************************************************************/
 /*                        JPEGXLDataset                                 */
 /************************************************************************/
@@ -2136,18 +2138,19 @@ GDALDataset *JPEGXLDataset::CreateCopy(const char *pszFilename,
             }
             else
             {
-                fDistance = static_cast<float>(
-                    6.4 + pow(2.5, (30 - quality) / 5.0f) / 6.25f);
+                fDistance =
+                    static_cast<float>(53.0 / 3000.0 * quality * quality -
+                                       23.0 / 20.0 * quality + 25.0);
             }
         }
-        if (fDistance >= 0.0f && fDistance < 0.1f)
-            fDistance = 0.1f;
+        if (fDistance >= 0.0f && fDistance < MIN_DISTANCE)
+            fDistance = MIN_DISTANCE;
 
         if (pszAlphaDistance)
         {
             fAlphaDistance = static_cast<float>(CPLAtof(pszAlphaDistance));
-            if (fAlphaDistance > 0.0f && fAlphaDistance < 0.1f)
-                fAlphaDistance = 0.1f;
+            if (fAlphaDistance > 0.0f && fAlphaDistance < MIN_DISTANCE)
+                fAlphaDistance = MIN_DISTANCE;
         }
     }
 

--- a/frmts/jpegxl/jpegxldrivercore.cpp
+++ b/frmts/jpegxl/jpegxldrivercore.cpp
@@ -96,13 +96,13 @@ void JPEGXLDriverSetCommonMetadata(GDALDriver *poDriver)
         "1(fast)-9(slow)' default='5'/>"
         "   <Option name='DISTANCE' type='float' description='Distance level "
         "for lossy compression (0=mathematically lossless, 1.0=visually "
-        "lossless, usual range [0.5,3])' default='1.0' min='0.1' max='15.0'/>"
+        "lossless, usual range [0.5,3])' default='1.0' min='0.01' max='25.0'/>"
 #ifdef HAVE_JxlEncoderSetExtraChannelDistance
         "  <Option name='ALPHA_DISTANCE' type='float' "
         "description='Distance level for alpha channel "
         "(-1=same as non-alpha channels, "
         "0=mathematically lossless, 1.0=visually lossless, "
-        "usual range [0.5,3])' default='-1' min='-1' max='15.0'/>"
+        "usual range [0.5,3])' default='-1' min='-1' max='25.0'/>"
 #endif
         "   <Option name='QUALITY' type='float' description='Alternative "
         "setting to DISTANCE to specify lossy compression, roughly matching "


### PR DESCRIPTION
to be in sync with latest libjxl

Fixes #11095
