### PR TITLE
Doc: document that JXL-in-GeoTIFF requires tiled=yes

### DIFF
--- a/doc/source/drivers/raster/gtiff.rst
+++ b/doc/source/drivers/raster/gtiff.rst
@@ -485,9 +485,10 @@ This driver supports the following creation options:
       * ``LERC_ZSTD`` is available when ``LERC`` and ``ZSTD`` are available.
 
       * ``JXL`` is for JPEG-XL, and is only available when using internal libtiff and building GDAL against
-        https://github.com/libjxl/libjxl . Supported data types are ``Byte``, ``UInt16`` and ``Float32`` only.
-        For GDAL < 3.6.0, JXL compression may only be used alongside ``INTERLEAVE=PIXEL`` (the default) on
-        datasets with 4 bands or less.
+        https://github.com/libjxl/libjxl . JXL compression should be used with the ``TILED=YES`` creation
+        option and block size of 256x256, 512x512, or 1024x1024 pixels. Supported data types are ``Byte``,
+        ``UInt16`` and ``Float32`` only. For GDAL < 3.6.0, JXL compression may only be used alongside 
+        ``INTERLEAVE=PIXEL`` (the default) on datasets with 4 bands or less.
 
       * ``NONE`` is the default.
 

--- a/doc/source/drivers/raster/gtiff.rst
+++ b/doc/source/drivers/raster/gtiff.rst
@@ -485,7 +485,7 @@ This driver supports the following creation options:
       * ``LERC_ZSTD`` is available when ``LERC`` and ``ZSTD`` are available.
 
       * ``JXL`` is for JPEG-XL, and is only available when using internal libtiff and building GDAL against
-        https://github.com/libjxl/libjxl . JXL compression should be used with the ``TILED=YES`` creation
+        https://github.com/libjxl/libjxl . It is recommended to use JXL compression with the ``TILED=YES`` creation
         option and block size of 256x256, 512x512, or 1024x1024 pixels. Supported data types are ``Byte``,
         ``UInt16`` and ``Float32`` only. For GDAL < 3.6.0, JXL compression may only be used alongside 
         ``INTERLEAVE=PIXEL`` (the default) on datasets with 4 bands or less.


### PR DESCRIPTION
I suppose that recommending 256x256, 512x512, or 1024x1024 sized blocks makes sense, because the "group" in JPEG XL is 256x256 pixels.