### PR TITLE
Use CPLParseMemorySize for GDAL_CACHEMAX and similar config options

### DIFF
--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -1777,6 +1777,16 @@ TEST_F(test_cpl, CPLParseMemorySize)
     EXPECT_GT(nValue, 100 * 1024 * 1024);
     EXPECT_TRUE(bUnitSpecified);
 
+    result = CPLParseMemorySize("0", &nValue, &bUnitSpecified);
+    EXPECT_EQ(result, CE_None);
+    EXPECT_EQ(nValue, 0);
+    EXPECT_FALSE(bUnitSpecified);
+
+    result = CPLParseMemorySize("0MB", &nValue, &bUnitSpecified);
+    EXPECT_EQ(result, CE_None);
+    EXPECT_EQ(nValue, 0);
+    EXPECT_TRUE(bUnitSpecified);
+
     result = CPLParseMemorySize("  802  ", &nValue, &bUnitSpecified);
     EXPECT_EQ(result, CE_None);
     EXPECT_EQ(nValue, 802);

--- a/autotest/gcore/vsifile.py
+++ b/autotest/gcore/vsifile.py
@@ -237,16 +237,16 @@ def test_vsifile_4():
 # Test vsicache
 
 
-@pytest.mark.parametrize("cache_size", ("0", "65536", None))
-def test_vsifile_5(cache_size):
+@pytest.mark.parametrize("cache_size", ("0", "64kb", None))
+def test_vsifile_5(tmp_path, cache_size):
 
-    fp = gdal.VSIFOpenL("tmp/vsifile_5.bin", "wb")
+    fp = gdal.VSIFOpenL(tmp_path / "vsifile_5.bin", "wb")
     ref_data = "".join(["%08X" % i for i in range(5 * 32768)])
     gdal.VSIFWriteL(ref_data, 1, len(ref_data), fp)
     gdal.VSIFCloseL(fp)
 
     with gdal.config_options({"VSI_CACHE": "YES", "VSI_CACHE_SIZE": cache_size}):
-        fp = gdal.VSIFOpenL("tmp/vsifile_5.bin", "rb")
+        fp = gdal.VSIFOpenL(tmp_path / "vsifile_5.bin", "rb")
 
         gdal.VSIFSeekL(fp, 50000, 0)
         if gdal.VSIFTellL(fp) != 50000:
@@ -276,8 +276,6 @@ def test_vsifile_5(cache_size):
             pytest.fail()
 
         gdal.VSIFCloseL(fp)
-
-    gdal.Unlink("tmp/vsifile_5.bin")
 
 
 ###############################################################################

--- a/doc/source/user/configoptions.rst
+++ b/doc/source/user/configoptions.rst
@@ -222,7 +222,10 @@ Performance and caching
       :program:`gdalwarp`.
       If its value is small (less than 100000), it is assumed to be measured in megabytes,
       otherwise in bytes. Alternatively, the value can be set to "X%" to mean X%
-      of the usable physical RAM. Note that this value is only consulted the first
+      of the usable physical RAM.
+      Since GDAL 3.11, the value of :config:`GDAL_CACHEMAX` may specify the
+      units directly (e.g., "500MB", "2GB").
+      Note that this value is only consulted the first
       time the cache size is requested.  To change this value programmatically
       during operation of the program it is better to use
       :cpp:func:`GDALSetCacheMax` (always in bytes) or or
@@ -421,7 +424,7 @@ General options
       option.
 
 -  .. config:: CPL_VSIL_DEFLATE_CHUNK_SIZE
-      :default: 1 M
+      :default: 1M
 
 -  .. config:: GDAL_DISABLE_CPLLOCALEC
       :choices: YES, NO

--- a/doc/source/user/configoptions.rst
+++ b/doc/source/user/configoptions.rst
@@ -321,6 +321,9 @@ Performance and caching
       Set the size of the VSI cache. Be wary of large values for
       ``VSI_CACHE_SIZE`` when opening VRT datasources containing many source
       rasters, as this is a per-file cache.
+      Since GDAL 3.11, the value of ``VSI_CACHE_SIZE`` may be specified using
+      memory units (e.g., "25 MB").
+
 
 Driver management
 ^^^^^^^^^^^^^^^^^

--- a/doc/source/user/configoptions.rst
+++ b/doc/source/user/configoptions.rst
@@ -616,7 +616,8 @@ Networking options
       :since: 2.3
 
       Size of global least-recently-used (LRU) cache shared among all downloaded
-      content.
+      content. Value is assumed to represent bytes unless memory units are
+      specified (since GDAL 3.11).
 
 -  .. config:: CPL_VSIL_CURL_USE_HEAD
       :choices: YES, NO
@@ -663,6 +664,9 @@ Networking options
 -  .. config:: CPL_VSIL_CURL_CHUNK_SIZE
       :choices: <bytes>
       :since: 2.3
+
+      Value is assumed to represent bytes unless memory units are
+      specified (since GDAL 3.11).
 
 -  .. config:: GDAL_INGESTED_BYTES_AT_OPEN
       :since: 2.3

--- a/port/cpl_string.cpp
+++ b/port/cpl_string.cpp
@@ -1848,7 +1848,10 @@ CPLErr CPLParseMemorySize(const char *pszValue, GIntBig *pnValue,
     }
 
     *pnValue = static_cast<GIntBig>(value);
-    *pbUnitSpecified = (unit != nullptr);
+    if (pbUnitSpecified)
+    {
+        *pbUnitSpecified = (unit != nullptr);
+    }
     return CE_None;
 }
 

--- a/port/cpl_string.cpp
+++ b/port/cpl_string.cpp
@@ -1779,10 +1779,10 @@ CPLErr CPLParseMemorySize(const char *pszValue, GIntBig *pnValue,
         return CE_Failure;
     }
 
-    if (value <= 0 || !std::isfinite(value))
+    if (value < 0 || !std::isfinite(value))
     {
         CPLError(CE_Failure, CPLE_IllegalArg,
-                 "Memory size must be a positive number.");
+                 "Memory size must be a positive number or zero.");
         return CE_Failure;
     }
 

--- a/port/cpl_string.cpp
+++ b/port/cpl_string.cpp
@@ -1800,6 +1800,12 @@ CPLErr CPLParseMemorySize(const char *pszValue, GIntBig *pnValue,
                     return CE_Failure;
                 }
                 auto bytes = CPLGetUsablePhysicalRAM();
+                if (bytes == 0)
+                {
+                    CPLError(CE_Failure, CPLE_NotSupported,
+                             "Cannot determine usable physical RAM");
+                    return CE_Failure;
+                }
                 value *= static_cast<double>(bytes / 100);
                 unit = c;
             }


### PR DESCRIPTION
## What does this PR do?

Uses `CPLParseMemorySize` for consistent parsing and error reporting from `GDAL_CACHEMAX`, `VSI_CACHE_SIZE`, `CPL_VSIL_CURL_CACHE_SIZE`, and `CPL_VSIL_CURL_CHUNK_SIZE`.

## What are related issues/pull requests?

## Tasklist

 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
