### PR TITLE
CMake: use enable_testing() instead of include(CTest)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,6 @@ include(cmake/helpers/GdalCMakeMinimumRequired.cmake)
 cmake_minimum_required(VERSION ${GDAL_CMAKE_VERSION_MIN}...${GDAL_CMAKE_VERSION_MAX})
 
 project(gdal LANGUAGES C CXX)
-include(CTest)
 
 set(GDAL_LIB_TARGET_NAME GDAL)
 
@@ -224,6 +223,10 @@ endif()
 #
 include(${CMAKE_CURRENT_SOURCE_DIR}/gdal.cmake)
 
+option(BUILD_TESTING "Build the testing tree." ON)
+if (BUILD_TESTING)
+  enable_testing()
+endif()
 if (BUILD_TESTING AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/autotest")
   # unit tests
   add_subdirectory(autotest/cpp)


### PR DESCRIPTION
According to Craig Scott in https://discourse.cmake.org/t/is-there-any-reason-to-prefer-include-ctest-or-enable-testing-over-the-other/1905/2 , using include(CTest) adds unnecessary clutter that is only needed for dashboard submission. enable_testing() is enough otherwise

"Port" of https://github.com/OSGeo/shapelib/pull/162
