### PR TITLE
CI: 'miniforge-variant: Mambaforge' is no longer supported; use Miniforge instead

### DIFF
--- a/.github/workflows/cmake_builds.yml
+++ b/.github/workflows/cmake_builds.yml
@@ -417,7 +417,6 @@ jobs:
     - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca # v3.0.4
       with:
         activate-environment: gdalenv
-        miniforge-variant: Mambaforge
         miniforge-version: latest
         use-mamba: true
         auto-update-conda: true
@@ -525,7 +524,6 @@ jobs:
     - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca # v3.0.4
       with:
         activate-environment: gdalenv
-        miniforge-variant: Mambaforge
         miniforge-version: latest
         use-mamba: true
         auto-update-conda: true

--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -52,7 +52,6 @@ jobs:
 
     - uses: conda-incubator/setup-miniconda@a4260408e20b96e80095f42ff7f1a15b27dd94ca # v3.0.4
       with:
-        #miniforge-variant: Mambaforge
         miniforge-version: latest
         use-mamba: true
         channels: conda-forge


### PR DESCRIPTION
Fixes following action warning:
'Mambaforge is now deprecated! Future Miniforge releases will NOT build Mambaforge installers. We advise you switch to Miniforge at your earliest convenience. More details at
https://conda-forge.org/news/2024/07/29/sunsetting-mambaforge/. If you require Mambaforge, you may pin your installer to one found in https://github.com/conda-forge/miniforge/releases/tag/24.7.1-0'
