### PR TITLE
Add OSRGetAuthorityListFromDatabase() to get the list of CRS authorities used in the PROJ database.

### DIFF
--- a/autotest/osr/osr_basic.py
+++ b/autotest/osr/osr_basic.py
@@ -2478,3 +2478,13 @@ def test_osr_basic_export_wkt_utm_south():
 
     j = json.loads(srs.ExportToPROJJSON())
     assert j["conversion"]["id"]["code"] == 16101
+
+
+###############################################################################
+
+
+def test_osr_basic_GetAuthorityListFromDatabase():
+
+    ret = osr.GetAuthorityListFromDatabase()
+    assert "EPSG" in ret
+    assert "PROJ" in ret

--- a/ogr/ogr_srs_api.h
+++ b/ogr/ogr_srs_api.h
@@ -1005,6 +1005,8 @@ OSRGetCRSInfoListFromDatabase(const char *pszAuthName,
 
 void CPL_DLL OSRDestroyCRSInfoList(OSRCRSInfo **list);
 
+char CPL_DLL **OSRGetAuthorityListFromDatabase(void);
+
 /* -------------------------------------------------------------------- */
 /*      OGRCoordinateTransform C API.                                   */
 /* -------------------------------------------------------------------- */

--- a/ogr/ogrspatialreference.cpp
+++ b/ogr/ogrspatialreference.cpp
@@ -12855,6 +12855,38 @@ void OSRDestroyCRSInfoList(OSRCRSInfo **list)
 }
 
 /************************************************************************/
+/*                   OSRGetAuthorityListFromDatabase()                  */
+/************************************************************************/
+
+/** \brief Return the list of CRS authorities used in the PROJ database.
+ *
+ * Such as "EPSG", "ESRI", "PROJ", "IGNF", "IAU_2015", etc.
+ *
+ * This is a direct mapping of https://proj.org/en/latest/development/reference/functions.html#c.proj_get_authorities_from_database
+ *
+ * @return nullptr in case of error, or a NULL terminated list of strings to
+ * free with CSLDestroy()
+ * @since GDAL 3.10
+ */
+char **OSRGetAuthorityListFromDatabase()
+{
+    PROJ_STRING_LIST list =
+        proj_get_authorities_from_database(OSRGetProjTLSContext());
+    if (!list)
+    {
+        return nullptr;
+    }
+    int count = 0;
+    while (list[count])
+        ++count;
+    char **res = static_cast<char **>(CPLCalloc(count + 1, sizeof(char *)));
+    for (int i = 0; i < count; ++i)
+        res[i] = CPLStrdup(list[i]);
+    proj_string_list_destroy(list);
+    return res;
+}
+
+/************************************************************************/
 /*                    UpdateCoordinateSystemFromGeogCRS()               */
 /************************************************************************/
 

--- a/swig/include/osr.i
+++ b/swig/include/osr.i
@@ -1556,6 +1556,15 @@ const char* OSRCRSInfo_projection_method_get( OSRCRSInfo *crsInfo ) {
 
 #endif
 
+%apply (char **CSL) {(char **)};
+%inline %{
+char** GetAuthorityListFromDatabase()
+{
+    return OSRGetAuthorityListFromDatabase();
+}
+%}
+%clear (char **);
+
 #ifdef SWIGPYTHON
 %inline %{
 void GetCRSInfoListFromDatabase( const char *authName,


### PR DESCRIPTION
Refs https://github.com/rasterio/rasterio/pull/3206/files#r1813149328
