### PR TITLE
[Backport release/3.10] ogr_core.h: suppress warning when building with -Wpedantic for C < 23

### DIFF
--- a/ogr/ogr_core.h
+++ b/ogr/ogr_core.h
@@ -391,6 +391,13 @@ typedef int OGRBoolean;
 /*      ogr_geometry.h related definitions.                             */
 /* -------------------------------------------------------------------- */
 
+#if defined(HAVE_GCC_DIAGNOSTIC_PUSH) && __STDC_VERSION__ < 202311L
+/* wkbPoint25D and friends cause warnings with -Wpedantic prior to C23. */
+/* Cf https://github.com/OSGeo/gdal/issues/2322 */
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#endif
+
 /**
  * List of well known binary geometry types.  These are used within the BLOBs
  * but are also returned from OGRGeometry::getGeometryType() to identify the
@@ -511,6 +518,10 @@ typedef enum
     wkbGeometryCollection25D = 0x80000007 /**< 2.5D extension as per 99-402 */
 #endif
 } OGRwkbGeometryType;
+
+#if defined(HAVE_GCC_DIAGNOSTIC_PUSH) && __STDC_VERSION__ < 202311L
+#pragma GCC diagnostic pop
+#endif
 
 /* clang-format off */
 /**


### PR DESCRIPTION
Backport #11133
 **Authored by:** @rouault