### PR TITLE
TIFF JXL: add support for Float16 and Compression=52546 which is JPEG XL from DNG 1.7 specification

### DIFF
--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -9785,6 +9785,39 @@ def test_tiff_write_jpegxl_five_bands_lossless(tmp_vsimem):
 
 
 ###############################################################################
+
+
+@pytest.mark.require_creation_option("GTiff", "JXL")
+def test_tiff_write_jpegxl_float16(tmp_vsimem):
+
+    outfilename = str(tmp_vsimem / "test_tiff_write_jpegxl_float16")
+    src_ds = gdal.Open("data/float16.tif")
+    gdal.GetDriverByName("GTiff").CreateCopy(
+        outfilename, src_ds, options=["COMPRESS=JXL", "JXL_LOSSLESS=YES"]
+    )
+    ds = gdal.Open(outfilename)
+    assert ds.GetRasterBand(1).DataType == gdal.GDT_Float32
+    assert ds.GetRasterBand(1).GetMetadataItem("NBITS", "IMAGE_STRUCTURE") == "16"
+    assert ds.GetRasterBand(1).Checksum() == 4672
+
+
+###############################################################################
+
+
+@pytest.mark.require_creation_option("GTiff", "JXL")
+@pytest.mark.parametrize("dt,nbits", [(gdal.GDT_Float64, None), (gdal.GDT_Byte, 1)])
+@gdaltest.enable_exceptions()
+def test_tiff_write_jpegxl_errors(tmp_vsimem, dt, nbits):
+
+    outfilename = str(tmp_vsimem / "test_tiff_write_jpegxl_errors")
+    with pytest.raises(Exception):
+        options = {"COMPRESS": "JXL"}
+        if nbits:
+            options["NBITS"] = str(nbits)
+        gdal.GetDriverByName("GTiff").Create(outfilename, 1, 1, 1, dt, options=options)
+
+
+###############################################################################
 # Test creating overviews with NaN nodata
 
 

--- a/frmts/gtiff/geotiff.cpp
+++ b/frmts/gtiff/geotiff.cpp
@@ -983,6 +983,7 @@ static void GTiffTagExtender(TIFF *tif)
 static std::mutex oDeleteMutex;
 #ifdef HAVE_JXL
 static TIFFCodec *pJXLCodec = nullptr;
+static TIFFCodec *pJXLCodecDNG17 = nullptr;
 #endif
 
 void GTiffOneTimeInit()
@@ -1000,6 +1001,8 @@ void GTiffOneTimeInit()
     if (pJXLCodec == nullptr)
     {
         pJXLCodec = TIFFRegisterCODEC(COMPRESSION_JXL, "JXL", TIFFInitJXL);
+        pJXLCodecDNG17 =
+            TIFFRegisterCODEC(COMPRESSION_JXL_DNG_1_7, "JXL", TIFFInitJXL);
     }
 #endif
 
@@ -1024,6 +1027,9 @@ static void GDALDeregister_GTiff(GDALDriver *)
     if (pJXLCodec)
         TIFFUnRegisterCODEC(pJXLCodec);
     pJXLCodec = nullptr;
+    if (pJXLCodecDNG17)
+        TIFFUnRegisterCODEC(pJXLCodecDNG17);
+    pJXLCodecDNG17 = nullptr;
 #endif
 }
 
@@ -1058,6 +1064,7 @@ static const struct
     {COMPRESSION_LERC, "LERC_ZSTD", true},
     COMPRESSION_ENTRY(WEBP, true),
     COMPRESSION_ENTRY(JXL, true),
+    COMPRESSION_ENTRY(JXL_DNG_1_7, true),
 
     // Compression methods in read-only
     COMPRESSION_ENTRY(OJPEG, false),

--- a/frmts/gtiff/gtiffdataset_write.cpp
+++ b/frmts/gtiff/gtiffdataset_write.cpp
@@ -5252,10 +5252,10 @@ TIFF *GTiffDataset::CreateLL(const char *pszFilename, int nXSize, int nYSize,
     }
 
 #ifdef HAVE_JXL
-    if (l_nCompression == COMPRESSION_JXL)
+    if (l_nCompression == COMPRESSION_JXL && eType != GDT_Float32)
     {
         // Reflects tif_jxl's GetJXLDataType()
-        if (eType != GDT_Byte && eType != GDT_UInt16 && eType != GDT_Float32)
+        if (eType != GDT_Byte && eType != GDT_UInt16)
         {
             ReportError(pszFilename, CE_Failure, CPLE_NotSupported,
                         "Data type %s not supported for JXL compression. Only "
@@ -5271,7 +5271,6 @@ TIFF *GTiffDataset::CreateLL(const char *pszFilename, int nXSize, int nYSize,
         } asSupportedDTBitsPerSample[] = {
             {GDT_Byte, 8},
             {GDT_UInt16, 16},
-            {GDT_Float32, 32},
         };
 
         for (const auto &sSupportedDTBitsPerSample : asSupportedDTBitsPerSample)

--- a/frmts/gtiff/libtiff/tiff.h
+++ b/frmts/gtiff/libtiff/tiff.h
@@ -216,6 +216,7 @@ typedef enum
 #define COMPRESSION_ZSTD 50000             /* ZSTD: WARNING not registered in Adobe-maintained registry */
 #define COMPRESSION_WEBP 50001             /* WEBP: WARNING not registered in Adobe-maintained registry */
 #define COMPRESSION_JXL 50002              /* JPEGXL: WARNING not registered in Adobe-maintained registry */
+#define COMPRESSION_JXL_DNG_1_7 52546      /* JPEGXL from DNG 1.7 specification */
 #define TIFFTAG_PHOTOMETRIC 262            /* photometric interpretation */
 #define PHOTOMETRIC_MINISWHITE 0           /* min value is white */
 #define PHOTOMETRIC_MINISBLACK 1           /* min value is black */

--- a/frmts/gtiff/tif_jxl.h
+++ b/frmts/gtiff/tif_jxl.h
@@ -30,6 +30,10 @@
     50002 /* JPEGXL: WARNING not registered in Adobe-maintained registry */
 #endif
 
+#ifndef COMPRESSION_JXL_DNG_1_7
+#define COMPRESSION_JXL_DNG_1_7 52546 /* JPEGXL from DNG 1.7 specification */
+#endif
+
 #ifndef TIFFTAG_JXL_LOSSYNESS
 
 /* Pseudo tags */


### PR DESCRIPTION
DNG 1.7 JXL support tested with https://github.com/darktable-org/darktable/files/14973538/input.zip from https://github.com/darktable-org/darktable/issues/16618 with: ``gdal_translate GTIFF_DIR:off:135912:input.dng out.tif``