### PR TITLE
Add (minimum) support for libarrow 18.0.0

### DIFF
--- a/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
@@ -1427,6 +1427,10 @@ bool OGRParquetLayer::ReadNextBatch()
 {
     m_nIdxInBatch = 0;
 
+    const int nNumGroups = m_poArrowReader->num_row_groups();
+    if (nNumGroups == 0)
+        return false;
+
     if (m_bSingleBatch)
     {
         CPLAssert(m_iRecordBatch == 0);
@@ -1468,7 +1472,6 @@ bool OGRParquetLayer::ReadNextBatch()
         }
         else
         {
-            const int nNumGroups = m_poArrowReader->num_row_groups();
             OGRField sMin;
             OGRField sMax;
             OGR_RawField_SetNull(&sMin);


### PR DESCRIPTION
Essentially to fix compiler warnings about missing cases in switch() and fix a deprecation warning.

Support for DECIMAL32 and DECIMAL64 should work on the read side, but not actually tested. The ogrlayerarrow.cpp generic code isn't ready for them yet.
No support on the write side to limit backwards compatibility issues.
