### PR TITLE
apps: use unique_ptr overloads of addGeometry, addRing

### DIFF
--- a/apps/gdal_footprint_lib.cpp
+++ b/apps/gdal_footprint_lib.cpp
@@ -1028,7 +1028,7 @@ static bool GDALFootprintProcess(GDALDataset *poSrcDS, OGRLayer *poDstLayer,
             CPLAssert(poGeom);
             if (poGeom->getGeometryType() == wkbPolygon)
             {
-                poMP->addGeometryDirectly(poGeom.release());
+                poMP->addGeometry(std::move(poGeom));
             }
         }
         poMemLayer = std::make_unique<OGRMemLayer>("", nullptr, wkbUnknown);
@@ -1095,7 +1095,7 @@ static bool GDALFootprintProcess(GDALDataset *poSrcDS, OGRLayer *poDstLayer,
                         }
                     }
                     if (!poNewPoly->IsEmpty())
-                        poMP->addGeometryDirectly(poNewPoly.release());
+                        poMP->addGeometry(std::move(poNewPoly));
                 }
                 poGeom = std::move(poMP);
             }

--- a/apps/gdaltindex_lib.cpp
+++ b/apps/gdaltindex_lib.cpp
@@ -1269,7 +1269,7 @@ GDALDatasetH GDALTileIndex(const char *pszDest, int nSrcCount,
         auto poRing = std::make_unique<OGRLinearRing>();
         for (int k = 0; k < 5; k++)
             poRing->addPoint(adfX[k], adfY[k]);
-        poPoly->addRingDirectly(poRing.release());
+        poPoly->addRing(std::move(poRing));
         poFeature->SetGeometryDirectly(poPoly.release());
 
         if (poLayer->CreateFeature(poFeature.get()) != OGRERR_NONE)

--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -3427,7 +3427,7 @@ static CPLErr LoadCutline(const std::string &osCutlineDSNameOrWKT,
         OGRwkbGeometryType eType = wkbFlatten(poGeom->getGeometryType());
 
         if (eType == wkbPolygon)
-            poMultiPolygon->addGeometryDirectly(poGeom.release());
+            poMultiPolygon->addGeometry(std::move(poGeom));
         else if (eType == wkbMultiPolygon)
         {
             for (const auto *poSubGeom : poGeom->toMultiPolygon())
@@ -5401,7 +5401,7 @@ static CPLErr TransformCutlineToSource(GDALDataset *poSrcDS,
     {
         const double dfCutlineBlendDist = CPLAtof(CSLFetchNameValueDef(
             *ppapszWarpOptions, "CUTLINE_BLEND_DIST", "0"));
-        OGRLinearRing *poRing = new OGRLinearRing();
+        auto poRing = std::make_unique<OGRLinearRing>();
         poRing->addPoint(-dfCutlineBlendDist, -dfCutlineBlendDist);
         poRing->addPoint(-dfCutlineBlendDist,
                          dfCutlineBlendDist + poSrcDS->GetRasterYSize());
@@ -5411,7 +5411,7 @@ static CPLErr TransformCutlineToSource(GDALDataset *poSrcDS,
                          -dfCutlineBlendDist);
         poRing->addPoint(-dfCutlineBlendDist, -dfCutlineBlendDist);
         OGRPolygon oSrcDSFootprint;
-        oSrcDSFootprint.addRingDirectly(poRing);
+        oSrcDSFootprint.addRing(std::move(poRing));
         OGREnvelope sSrcDSEnvelope;
         oSrcDSFootprint.getEnvelope(&sSrcDSEnvelope);
         OGREnvelope sCutlineEnvelope;

--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -688,13 +688,13 @@ static std::unique_ptr<OGRGeometry> LoadGeometry(const std::string &osDS,
                                  "should be manually inspected.",
                                  poFeat->GetFID(), osDS.c_str());
 
-                        oGC.addGeometryDirectly(poValid.release());
+                        oGC.addGeometry(std::move(poValid));
                     }
                     else
                     {
                         CPLError(CE_Failure, CPLE_AppDefined,
                                  "Geometry of feature " CPL_FRMT_GIB " of %s "
-                                 "is invalid, and could not been made valid.",
+                                 "is invalid, and could not be made valid.",
                                  poFeat->GetFID(), osDS.c_str());
                         oGC.empty();
                         break;
@@ -702,7 +702,7 @@ static std::unique_ptr<OGRGeometry> LoadGeometry(const std::string &osDS,
                 }
                 else
                 {
-                    oGC.addGeometryDirectly(poSrcGeom.release());
+                    oGC.addGeometry(std::move(poSrcGeom));
                 }
             }
         }


### PR DESCRIPTION
## What does this PR do?

Removes usages of `add...Directly` methods in applications, preferring `unique_ptr` overloads instead.

## What are related issues/pull requests?

#4371