### PR TITLE
OGRFeature: Add SetGeometry overloads taking unique_ptr<OGRGeometry>

### DIFF
--- a/autotest/cpp/test_ogr.cpp
+++ b/autotest/cpp/test_ogr.cpp
@@ -4394,4 +4394,67 @@ TEST_F(test_ogr, OGRPolygon_addRingDirectly)
     ASSERT_EQ(p.addRingDirectly(lr.release()), OGRERR_NONE);
 }
 
+TEST_F(test_ogr, OGRFeature_SetGeometry)
+{
+    OGRFeatureDefn *poFeatureDefn = new OGRFeatureDefn();
+    poFeatureDefn->Reference();
+
+    OGRFeature oFeat(poFeatureDefn);
+    std::unique_ptr<OGRGeometry> poGeom;
+    OGRGeometry *poTmpGeom;
+    ASSERT_EQ(
+        OGRGeometryFactory::createFromWkt("POINT (3 7)", nullptr, &poTmpGeom),
+        OGRERR_NONE);
+    poGeom.reset(poTmpGeom);
+    ASSERT_EQ(oFeat.SetGeometry(std::move(poGeom)), OGRERR_NONE);
+    EXPECT_EQ(oFeat.GetGeometryRef()->toPoint()->getX(), 3);
+    EXPECT_EQ(oFeat.GetGeometryRef()->toPoint()->getY(), 7);
+
+    // set it again to make sure previous feature geometry is freed
+    ASSERT_EQ(
+        OGRGeometryFactory::createFromWkt("POINT (2 8)", nullptr, &poTmpGeom),
+        OGRERR_NONE);
+    poGeom.reset(poTmpGeom);
+    ASSERT_EQ(oFeat.SetGeometry(std::move(poGeom)), OGRERR_NONE);
+    EXPECT_EQ(oFeat.GetGeometryRef()->toPoint()->getX(), 2);
+    EXPECT_EQ(oFeat.GetGeometryRef()->toPoint()->getY(), 8);
+
+    poFeatureDefn->Release();
+}
+
+TEST_F(test_ogr, OGRFeature_SetGeomField)
+{
+    OGRFeatureDefn *poFeatureDefn = new OGRFeatureDefn();
+    poFeatureDefn->Reference();
+
+    OGRGeomFieldDefn oGeomField("second", wkbPoint);
+    poFeatureDefn->AddGeomFieldDefn(&oGeomField);
+
+    OGRFeature oFeat(poFeatureDefn);
+
+    // failure
+    {
+        std::unique_ptr<OGRGeometry> poGeom;
+        OGRGeometry *poTmpGeom;
+        ASSERT_EQ(OGRGeometryFactory::createFromWkt("POINT (3 7)", nullptr,
+                                                    &poTmpGeom),
+                  OGRERR_NONE);
+        poGeom.reset(poTmpGeom);
+        EXPECT_EQ(oFeat.SetGeomField(13, std::move(poGeom)), OGRERR_FAILURE);
+    }
+
+    // success
+    {
+        std::unique_ptr<OGRGeometry> poGeom;
+        OGRGeometry *poTmpGeom;
+        ASSERT_EQ(OGRGeometryFactory::createFromWkt("POINT (3 7)", nullptr,
+                                                    &poTmpGeom),
+                  OGRERR_NONE);
+        poGeom.reset(poTmpGeom);
+        EXPECT_EQ(oFeat.SetGeomField(1, std::move(poGeom)), OGRERR_NONE);
+    }
+
+    poFeatureDefn->Release();
+}
+
 }  // namespace

--- a/ogr/ogr_feature.h
+++ b/ogr/ogr_feature.h
@@ -1178,6 +1178,7 @@ class CPL_DLL OGRFeature
 
     OGRErr SetGeometryDirectly(OGRGeometry *);
     OGRErr SetGeometry(const OGRGeometry *);
+    OGRErr SetGeometry(std::unique_ptr<OGRGeometry>);
     OGRGeometry *GetGeometryRef();
     const OGRGeometry *GetGeometryRef() const;
     OGRGeometry *StealGeometry() CPL_WARN_UNUSED_RESULT;
@@ -1209,6 +1210,7 @@ class CPL_DLL OGRFeature
     const OGRGeometry *GetGeomFieldRef(const char *pszFName) const;
     OGRErr SetGeomFieldDirectly(int iField, OGRGeometry *);
     OGRErr SetGeomField(int iField, const OGRGeometry *);
+    OGRErr SetGeomField(int iField, std::unique_ptr<OGRGeometry>);
 
     void Reset();
 


### PR DESCRIPTION
## What does this PR do?

Adds `OGRFeature::SetGeometry(unique_ptr<OGRGeometry>)` and  `OGRFeature::SetGeomField(int, unique_ptr<OGRGeometry>)` 

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/issues/11146

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
