### PR TITLE
[Backport release/3.10] Python bindings: fix compatibility issue with SWIG 4.3.0 and PYTHONWARNINGS=error

### DIFF
--- a/.github/workflows/cmake_builds.yml
+++ b/.github/workflows/cmake_builds.yml
@@ -218,6 +218,8 @@ jobs:
         export LD_LIBRARY_PATH=$GITHUB_WORKSPACE/install-gdal/lib
         $GITHUB_WORKSPACE/install-gdal/bin/gdalinfo --version
         PYTHONPATH=$GITHUB_WORKSPACE/install-gdal/lib/python3.8/site-packages python3 -c "from osgeo import gdal;print(gdal.VersionInfo(None))"
+        # Test fix for https://github.com/conda-forge/gdal-feedstock/issues/995
+        PYTHONWARNINGS="error" PYTHONPATH=$GITHUB_WORKSPACE/install-gdal/lib/python3.8/site-packages python3 -c "from osgeo import gdal"
         PYTHONPATH=$GITHUB_WORKSPACE/install-gdal/lib/python3.8/site-packages python3 $GITHUB_WORKSPACE/scripts/check_doc.py
     - name: CMake with rpath
       run: |

--- a/swig/python/modify_cpp_files.cmake
+++ b/swig/python/modify_cpp_files.cmake
@@ -60,4 +60,8 @@ string(REPLACE "if (--interpreter_counter != 0) // another sub-interpreter may s
                "/* Even Rouault / GDAL hack for SWIG >= 4.1 related to objects not being freed. See swig/python/modify_cpp_files.cmake for more details */\nif( 1 )"
        _CONTENTS "${_CONTENTS}")
 
+# Works around https://github.com/swig/swig/issues/3061
+string(REPLACE "# define SWIG_HEAPTYPES" "// Below is disabled because of https://github.com/swig/swig/issues/3061\n// # define SWIG_HEAPTYPES"
+       _CONTENTS "${_CONTENTS}")
+
 file(WRITE ${FILE} "${_CONTENTS}")


### PR DESCRIPTION
Backport #11154
 **Authored by:** @rouault