### PR TITLE
OGRGeometryFactory: Add createFromWkt overload returning unique_ptr

### DIFF
--- a/autotest/cpp/test_ogr.cpp
+++ b/autotest/cpp/test_ogr.cpp
@@ -4400,21 +4400,16 @@ TEST_F(test_ogr, OGRFeature_SetGeometry)
     poFeatureDefn->Reference();
 
     OGRFeature oFeat(poFeatureDefn);
-    std::unique_ptr<OGRGeometry> poGeom;
-    OGRGeometry *poTmpGeom;
-    ASSERT_EQ(
-        OGRGeometryFactory::createFromWkt("POINT (3 7)", nullptr, &poTmpGeom),
-        OGRERR_NONE);
-    poGeom.reset(poTmpGeom);
+    auto [poGeom, err] = OGRGeometryFactory::createFromWkt("POINT (3 7)");
+    ASSERT_EQ(err, OGRERR_NONE);
+
     ASSERT_EQ(oFeat.SetGeometry(std::move(poGeom)), OGRERR_NONE);
     EXPECT_EQ(oFeat.GetGeometryRef()->toPoint()->getX(), 3);
     EXPECT_EQ(oFeat.GetGeometryRef()->toPoint()->getY(), 7);
 
     // set it again to make sure previous feature geometry is freed
-    ASSERT_EQ(
-        OGRGeometryFactory::createFromWkt("POINT (2 8)", nullptr, &poTmpGeom),
-        OGRERR_NONE);
-    poGeom.reset(poTmpGeom);
+    std::tie(poGeom, err) = OGRGeometryFactory::createFromWkt("POINT (2 8)");
+    ASSERT_EQ(err, OGRERR_NONE);
     ASSERT_EQ(oFeat.SetGeometry(std::move(poGeom)), OGRERR_NONE);
     EXPECT_EQ(oFeat.GetGeometryRef()->toPoint()->getX(), 2);
     EXPECT_EQ(oFeat.GetGeometryRef()->toPoint()->getY(), 8);
@@ -4434,23 +4429,15 @@ TEST_F(test_ogr, OGRFeature_SetGeomField)
 
     // failure
     {
-        std::unique_ptr<OGRGeometry> poGeom;
-        OGRGeometry *poTmpGeom;
-        ASSERT_EQ(OGRGeometryFactory::createFromWkt("POINT (3 7)", nullptr,
-                                                    &poTmpGeom),
-                  OGRERR_NONE);
-        poGeom.reset(poTmpGeom);
+        auto [poGeom, err] = OGRGeometryFactory::createFromWkt("POINT (3 7)");
+        ASSERT_EQ(err, OGRERR_NONE);
         EXPECT_EQ(oFeat.SetGeomField(13, std::move(poGeom)), OGRERR_FAILURE);
     }
 
     // success
     {
-        std::unique_ptr<OGRGeometry> poGeom;
-        OGRGeometry *poTmpGeom;
-        ASSERT_EQ(OGRGeometryFactory::createFromWkt("POINT (3 7)", nullptr,
-                                                    &poTmpGeom),
-                  OGRERR_NONE);
-        poGeom.reset(poTmpGeom);
+        auto [poGeom, err] = OGRGeometryFactory::createFromWkt("POINT (3 7)");
+        ASSERT_EQ(err, OGRERR_NONE);
         EXPECT_EQ(oFeat.SetGeomField(1, std::move(poGeom)), OGRERR_NONE);
     }
 

--- a/ogr/ogr_geometry.h
+++ b/ogr/ogr_geometry.h
@@ -25,6 +25,7 @@
 #include <climits>
 #include <cmath>
 #include <memory>
+#include <utility>
 
 /**
  * \file ogr_geometry.h
@@ -4234,6 +4235,8 @@ class CPL_DLL OGRGeometryFactory
                                 OGRGeometry **);
     static OGRErr createFromWkt(const char **, const OGRSpatialReference *,
                                 OGRGeometry **);
+    static std::pair<std::unique_ptr<OGRGeometry>, OGRErr>
+    createFromWkt(const char *, const OGRSpatialReference * = nullptr);
 
     /** Deprecated.
      * @deprecated in GDAL 2.3

--- a/ogr/ogrgeometryfactory.cpp
+++ b/ogr/ogrgeometryfactory.cpp
@@ -481,6 +481,37 @@ OGRErr OGRGeometryFactory::createFromWkt(const char *pszData,
     return createFromWkt(&pszData, poSR, ppoReturn);
 }
 
+/**
+ * \brief Create a geometry object of the appropriate type from its
+ * well known text representation.
+ *
+ * The C function OGR_G_CreateFromWkt() is the same as this method.
+ *
+ * @param pszData input zero terminated string containing well known text
+ *                representation of the geometry to be created.
+ * @param poSR pointer to the spatial reference to be assigned to the
+ *             created geometry object.  This may be NULL.
+
+ * @return a pair of the newly created geometry an error code of OGRERR_NONE
+ * if all goes well, otherwise any of OGRERR_NOT_ENOUGH_DATA,
+ * OGRERR_UNSUPPORTED_GEOMETRY_TYPE, or OGRERR_CORRUPT_DATA.
+ *
+ * @since GDAL 3.11
+ */
+
+std::pair<std::unique_ptr<OGRGeometry>, OGRErr>
+OGRGeometryFactory::createFromWkt(const char *pszData,
+                                  const OGRSpatialReference *poSR)
+
+{
+    std::unique_ptr<OGRGeometry> poGeom;
+    OGRGeometry *poTmpGeom;
+    auto err = createFromWkt(&pszData, poSR, &poTmpGeom);
+    poGeom.reset(poTmpGeom);
+
+    return {std::move(poGeom), err};
+}
+
 /************************************************************************/
 /*                        OGR_G_CreateFromWkt()                         */
 /************************************************************************/


### PR DESCRIPTION
## What does this PR do?

Adds an overload of `OGRGeometry::createFromWkt` to more easily get a `unique_ptr<OGRGeometry>` from a WKT string. I don't know how others feel about the `std::pair` return in place of an "out" parameter. The diff in [autotest/cpp/test_ogr.cpp](https://github.com/OSGeo/gdal/compare/master...dbaston:gdal:ogrgf-fromwkt-return-unique#diff-ffa7db56afd816d72be86c8da3ea0e2c938a35b5e648ea49de5a7aa5b3efe2ff)[autotest/cpp/test_ogr.cpp](https://github.com/OSGeo/gdal/compare/master...dbaston:gdal:ogrgf-fromwkt-return-unique#diff-ffa7db56afd816d72be86c8da3ea0e2c938a35b5e648ea49de5a7aa5b3efe2ff) demonstrates the simplification nicely. 

Unfortunately this technique isn't generally applicable to methods currently returning a raw pointer. I'm not sure what the best pattern for addressing those is. Maybe just adding a new method with a `U` at the end? For example, `std::unique_ptr<OGRPolygon> OGRGeometryFactory::forceToPolygonU(const OGRGeometry*)`. Ugly, but I haven't thought of a better idea yet.