### PR TITLE
VRT: allow to use a <VRTDataset> instead of a <SourceFilename> inside…

### DIFF
--- a/autotest/gcore/data/vrt/nested_VRTDataset.vrt
+++ b/autotest/gcore/data/vrt/nested_VRTDataset.vrt
@@ -1,0 +1,24 @@
+<VRTDataset rasterXSize="20" rasterYSize="20">
+  <SRS dataAxisToSRSAxisMapping="1,2">PROJCS["NAD27 / UTM zone 11N",GEOGCS["NAD27",DATUM["North_American_Datum_1927",SPHEROID["Clarke 1866",6378206.4,294.978698213898,AUTHORITY["EPSG","7008"]],AUTHORITY["EPSG","6267"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4267"]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",-117],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","26711"]]</SRS>
+  <GeoTransform>  4.4072000000000000e+05,  6.0000000000000000e+01,  0.0000000000000000e+00,  3.7513200000000000e+06,  0.0000000000000000e+00, -6.0000000000000000e+01</GeoTransform>
+  <VRTRasterBand dataType="Byte" band="1">
+    <ColorInterp>Gray</ColorInterp>
+    <SimpleSource>
+      <VRTDataset rasterXSize="20" rasterYSize="20">
+        <VRTRasterBand dataType="Byte" band="1">
+          <SimpleSource>
+            <SourceFilename relativeToVRT="1">../byte.tif</SourceFilename>
+            <SourceBand>1</SourceBand>
+            <SourceProperties RasterXSize="20" RasterYSize="20" DataType="Byte" BlockXSize="20" BlockYSize="20" />
+            <SrcRect xOff="0" yOff="0" xSize="20" ySize="20" />
+            <DstRect xOff="0" yOff="0" xSize="20" ySize="20" />
+          </SimpleSource>
+        </VRTRasterBand>
+      </VRTDataset>
+      <SourceBand>1</SourceBand>
+      <SourceProperties RasterXSize="20" RasterYSize="20" DataType="Byte" BlockXSize="20" BlockYSize="20" />
+      <SrcRect xOff="0" yOff="0" xSize="20" ySize="20" />
+      <DstRect xOff="0" yOff="0" xSize="20" ySize="20" />
+    </SimpleSource>
+  </VRTRasterBand>
+</VRTDataset>

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -405,6 +405,31 @@ cubicspline,lanczos,average,mode.
       <DstRect xOff="0" yOff="0" xSize="128" ySize="128"/>
     </SimpleSource>
 
+
+Starting with GDAL 3.11, it is also possible to use a in-line VRTDataset as
+the source by using the VRTDataset element instead of SourceFilename.
+
+.. code-block:: xml
+
+    <SimpleSource>
+      <VRTDataset rasterXSize="20" rasterYSize="20">
+        <VRTRasterBand dataType="Byte" band="1">
+          <SimpleSource>
+            <SourceFilename relativeToVRT="1">../byte.tif</SourceFilename>
+            <SourceBand>1</SourceBand>
+            <SourceProperties RasterXSize="20" RasterYSize="20" DataType="Byte" BlockXSize="20" BlockYSize="20" />
+            <SrcRect xOff="0" yOff="0" xSize="20" ySize="20" />
+            <DstRect xOff="0" yOff="0" xSize="20" ySize="20" />
+          </SimpleSource>
+        </VRTRasterBand>
+      </VRTDataset>
+      <SourceBand>1</SourceBand>
+      <SourceProperties RasterXSize="20" RasterYSize="20" DataType="Byte" BlockXSize="20" BlockYSize="20" />
+      <SrcRect xOff="0" yOff="0" xSize="20" ySize="20" />
+      <DstRect xOff="0" yOff="0" xSize="20" ySize="20" />
+    </SimpleSource>
+
+
 ComplexSource
 ~~~~~~~~~~~~~
 

--- a/frmts/vrt/data/gdalvrt.xsd
+++ b/frmts/vrt/data/gdalvrt.xsd
@@ -449,7 +449,10 @@
     <xs:group name="SimpleSourceElementsGroup">
         <xs:sequence>
             <xs:choice minOccurs="0" maxOccurs="unbounded">
-                <xs:element name="SourceFilename" type="SourceFilenameType"/>
+                <xs:choice minOccurs="0" maxOccurs="1">
+                    <xs:element name="SourceFilename" type="SourceFilenameType"/>
+                    <xs:element name="VRTDataset" type="VRTDatasetType"/> <!-- added in GDAL 3.11 -->
+                </xs:choice>
                 <xs:element name="OpenOptions" type="OpenOptionsType"/>
                 <xs:element name="SourceBand" type="xs:string"/>  <!-- should be refined into xs:nonNegativeInteger or mask,xs:nonNegativeInteger -->
                 <xs:element name="SourceProperties" type="SourcePropertiesType"/>

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -3071,8 +3071,19 @@ std::string VRTDataset::BuildSourceFilename(const char *pszFilename,
             }
             if (!bDone)
             {
+                std::string osVRTPath = pszVRTPath;
+                if (!CPLIsFilenameRelative(pszVRTPath))
+                {
+                    // Simplify path by replacing "foo/a/../b" with "foo/b"
+                    while (STARTS_WITH(pszFilename, "../"))
+                    {
+                        osVRTPath = CPLGetPath(osVRTPath.c_str());
+                        pszFilename += strlen("../");
+                    }
+                }
+
                 osSrcDSName =
-                    CPLProjectRelativeFilename(pszVRTPath, pszFilename);
+                    CPLProjectRelativeFilename(osVRTPath.c_str(), pszFilename);
             }
         }
     }

--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -1335,7 +1335,11 @@ class CPL_DLL VRTSimpleSource CPL_NON_FINAL : public VRTSource
     // from which the mask band is taken.
     mutable GDALRasterBand *m_poMaskBandMainBand = nullptr;
 
-    CPLStringList m_aosOpenOptions{};
+    CPLStringList m_aosOpenOptionsOri{};  // as read in the original source XML
+    CPLStringList
+        m_aosOpenOptions{};  // same as above, but potentially augmented with ROOT_PATH
+    bool m_bSrcDSNameFromVRT =
+        false;  // whereas content in m_osSrcDSName is a <VRTDataset> XML node
 
     void OpenSource() const;
 
@@ -1406,6 +1410,8 @@ class CPL_DLL VRTSimpleSource CPL_NON_FINAL : public VRTSource
         return m_dfDstXOff != UNINIT_WINDOW || m_dfDstYOff != UNINIT_WINDOW ||
                m_dfDstXSize != UNINIT_WINDOW || m_dfDstYSize != UNINIT_WINDOW;
     }
+
+    void AddSourceFilenameNode(const char *pszVRTPath, CPLXMLNode *psSrc);
 
   public:
     VRTSimpleSource();


### PR DESCRIPTION
… a ``<SimpleSource>`` or ``<ComplexSource>``

Currently a number of users use the ugly hack of putting ``<![CDATA[some stuff]]>`` as the value of ``<SourceFilename>``, typically when chaining (actually nesting) processing operations with VRTDerivedRasterBand. This will make things cleaner.

So now we can do:
```xml
<VRTDataset rasterXSize="20" rasterYSize="20">
  <SRS dataAxisToSRSAxisMapping="1,2">PROJCS["NAD27 / UTM zone 11N",GEOGCS["NAD27",DATUM["North_American_Datum_1927",SPHEROID["Clarke 1866",6378206.4,294.978698213898,AUTHORITY["EPSG","7008"]],AUTHORITY["EPSG","6267"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4267"]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",0],PARAMETER["central_meridian",-117],PARAMETER["scale_factor",0.9996],PARAMETER["false_easting",500000],PARAMETER["false_northing",0],UNIT["metre",1,AUTHORITY["EPSG","9001"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","26711"]]</SRS>
  <GeoTransform>  4.4072000000000000e+05,  6.0000000000000000e+01,  0.0000000000000000e+00,  3.7513200000000000e+06,  0.0000000000000000e+00, -6.0000000000000000e+01</GeoTransform>
  <VRTRasterBand dataType="Byte" band="1">
    <ColorInterp>Gray</ColorInterp>
    <SimpleSource>
      <VRTDataset rasterXSize="20" rasterYSize="20">
        <VRTRasterBand dataType="Byte" band="1">
          <SimpleSource>
            <SourceFilename relativeToVRT="1">../byte.tif</SourceFilename>
            <SourceBand>1</SourceBand>
            <SourceProperties RasterXSize="20" RasterYSize="20" DataType="Byte" BlockXSize="20" BlockYSize="20" />
            <SrcRect xOff="0" yOff="0" xSize="20" ySize="20" />
            <DstRect xOff="0" yOff="0" xSize="20" ySize="20" />
          </SimpleSource>
        </VRTRasterBand>
      </VRTDataset>
      <SourceBand>1</SourceBand>
      <SourceProperties RasterXSize="20" RasterYSize="20" DataType="Byte" BlockXSize="20" BlockYSize="20" />
      <SrcRect xOff="0" yOff="0" xSize="20" ySize="20" />
      <DstRect xOff="0" yOff="0" xSize="20" ySize="20" />
    </SimpleSource>
  </VRTRasterBand>
</VRTDataset>
```