### PR TITLE
[Backport release/3.10] OGR SQL: fix wrong handling of NULL expression in AND and NOT (3.10.0 regression) 

### DIFF
--- a/MIGRATION_GUIDE.TXT
+++ b/MIGRATION_GUIDE.TXT
@@ -1,6 +1,14 @@
 MIGRATION GUIDE FROM GDAL 3.9 to GDAL 3.10
 ------------------------------------------
 
+- The OGR SQL parser has been modified to evaluate NULL values in boolean
+  operations similarly to other SQL engines (SQLite, PostgreSQL, etc.). Previously,
+  with a foo=NULL field, expressions ``foo NOT IN ('bar')`` and ``foo NOT LIKE ('bar')``
+  would evaluate as true. Now the result is false (with the NULL state being
+  propagated to it). Concretely, to get the same results as in previous versions,
+  the above expressions must be rewritten as ``foo IS NULL OR foo NOT IN ('bar')``
+  and ``foo IS NULL OR foo NOT LIKE ('bar')``.
+
 - MEM driver: opening a dataset with the MEM::: syntax is now disabled by
   default because of security implications. This can be enabled by setting the
   GDAL_MEM_ENABLE_OPEN build or configuration option. Creation of a 0-band MEM

--- a/autotest/cpp/test_ogr_swq.cpp
+++ b/autotest/cpp/test_ogr_swq.cpp
@@ -138,11 +138,10 @@ class PushNotOperationDownToStackFixture
             std::make_tuple("NOT(1 <= 2)", "1 > 2"),
             std::make_tuple("NOT(1 < 2)", "1 >= 2"),
             std::make_tuple("NOT(NOT(1))", "1"),
-            std::make_tuple("NOT(1 AND 2)", "(NOT (1)) OR (NOT (2))"),
-            std::make_tuple("NOT(1 OR 2)", "(NOT (1)) AND (NOT (2))"),
-            std::make_tuple("3 AND NOT(1 OR 2)",
-                            "3 AND ((NOT (1)) AND (NOT (2)))"),
-            std::make_tuple("NOT(NOT(1 = 2) OR 2)", "(1 = 2) AND (NOT (2))"),
+            std::make_tuple("NOT(1 AND 2)", "(NOT 1) OR (NOT 2)"),
+            std::make_tuple("NOT(1 OR 2)", "(NOT 1) AND (NOT 2)"),
+            std::make_tuple("3 AND NOT(1 OR 2)", "3 AND ((NOT 1) AND (NOT 2))"),
+            std::make_tuple("NOT(NOT(1 = 2) OR 2)", "(1 = 2) AND (NOT 2)"),
             std::make_tuple("1", "1"),
         };
     }

--- a/autotest/ogr/ogr_sql_test.py
+++ b/autotest/ogr/ogr_sql_test.py
@@ -1952,6 +1952,13 @@ def get_available_dialects():
         ("(NOT intfield = 0) AND NOT (intfield IS NULL)", 1),
         ("NOT (intfield = 0 OR intfield IS NOT NULL)", 0),
         ("(NOT intfield = 0) AND NOT (intfield IS NOT NULL)", 0),
+        ("intfield <> 0 AND intfield <> 2", 1),
+        ("intfield IS NOT NULL AND intfield NOT IN (2)", 1),
+        ("NOT(intfield NOT IN (1) AND NULL NOT IN (1))", 1),
+        ("NOT(intfield IS NOT NULL AND intfield NOT IN (2))", 1),
+        ("NOT(NOT(intfield IS NOT NULL AND intfield NOT IN (2)))", 1),
+        ("NOT (intfield = 0 AND intfield = 0)", 1),
+        ("(intfield NOT IN (1) AND NULL NOT IN (1)) IS NULL", 1),
         # realfield
         ("1 + realfield >= 0", 1),
         ("realfield = 0", 0),

--- a/ogr/swq_op_general.cpp
+++ b/ogr/swq_op_general.cpp
@@ -521,6 +521,7 @@ swq_expr_node *SWQGeneralEvaluator(swq_expr_node *node,
         poRet->field_type = node->field_type;
 
         if (node->nOperation != SWQ_ISNULL && node->nOperation != SWQ_OR &&
+            node->nOperation != SWQ_AND && node->nOperation != SWQ_NOT &&
             node->nOperation != SWQ_IN)
         {
             for (int i = 0; i < node->nSubExprCount; i++)
@@ -543,6 +544,8 @@ swq_expr_node *SWQGeneralEvaluator(swq_expr_node *node,
             case SWQ_AND:
                 poRet->int_value = sub_node_values[0]->int_value &&
                                    sub_node_values[1]->int_value;
+                poRet->is_null =
+                    sub_node_values[0]->is_null && sub_node_values[1]->is_null;
                 break;
 
             case SWQ_OR:
@@ -553,7 +556,9 @@ swq_expr_node *SWQGeneralEvaluator(swq_expr_node *node,
                 break;
 
             case SWQ_NOT:
-                poRet->int_value = !sub_node_values[0]->int_value;
+                poRet->int_value = !sub_node_values[0]->int_value &&
+                                   !sub_node_values[0]->is_null;
+                poRet->is_null = sub_node_values[0]->is_null;
                 break;
 
             case SWQ_EQ:


### PR DESCRIPTION
Backport #11190
 **Authored by:** @rouault