### PR TITLE
Add gdal_minmax_element.hpp public header, that can also be vendored, to find the min/max elements in a buffer

### DIFF
--- a/autotest/cpp/CMakeLists.txt
+++ b/autotest/cpp/CMakeLists.txt
@@ -77,6 +77,7 @@ add_executable(
   test_gdal_aaigrid.cpp
   test_gdal_dted.cpp
   test_gdal_gtiff.cpp
+  test_gdal_minmax_element.cpp
   test_gdal_pixelfn.cpp
   test_gdal_typetraits.cpp
   test_ogr.cpp

--- a/autotest/cpp/test_gdal_minmax_element.cpp
+++ b/autotest/cpp/test_gdal_minmax_element.cpp
@@ -102,7 +102,7 @@ TEST_F(test_gdal_minmax_element, uint8)
     {
         std::vector<T> v(257, 0);
         auto idx_min = gdal::min_element(v.data(), v.size(), eDT, true, 0);
-        EXPECT_EQ(idx_min, 0);
+        EXPECT_TRUE(idx_min == 0 || idx_min == 256) << idx_min;
     }
     {
         std::vector<T> v(257, 0);

--- a/autotest/cpp/test_gdal_minmax_element.cpp
+++ b/autotest/cpp/test_gdal_minmax_element.cpp
@@ -1,0 +1,798 @@
+///////////////////////////////////////////////////////////////////////////////
+//
+// Project:  C++ Test Suite for GDAL/OGR
+// Purpose:  Test gdal_minmax_element.hpp
+// Author:   Even Rouault <even.rouault at spatialys.com>
+//
+///////////////////////////////////////////////////////////////////////////////
+// Copyright (c) 2023, Even Rouault <even.rouault at spatialys.com>
+/*
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#include "gdal_unit_test.h"
+
+#include "gdal_minmax_element.hpp"
+
+#include "gtest_include.h"
+
+#include <limits>
+
+namespace
+{
+
+struct test_gdal_minmax_element : public ::testing::Test
+{
+};
+
+TEST_F(test_gdal_minmax_element, uint8)
+{
+    using T = uint8_t;
+    constexpr GDALDataType eDT = GDT_Byte;
+    T min_v = 3;
+    T max_v = 7;
+    {
+        T nodata = 0;
+        std::vector<T> v{max_v, nodata, min_v};
+        {
+            auto idx_min = gdal::min_element(v.data(), 0, eDT, true, nodata);
+            EXPECT_EQ(idx_min, 0);
+        }
+        {
+            auto idx_min = gdal::min_element(v.data(), 0, eDT, false, 0);
+            EXPECT_EQ(idx_min, 0);
+        }
+        {
+            auto idx_min =
+                gdal::min_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_min], min_v);
+            auto idx_max =
+                gdal::max_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_max], max_v);
+        }
+        {
+            auto [idx_min, idx_max] =
+                gdal::minmax_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_min], min_v);
+            EXPECT_EQ(v[idx_max], max_v);
+        }
+    }
+    {
+        T nodata = 0;
+        std::vector<T> v{nodata, max_v, min_v};
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, true, nodata);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, true, nodata);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v{static_cast<T>((min_v + max_v) / 2),
+                         static_cast<T>(max_v - 1),
+                         max_v,
+                         static_cast<T>(max_v - 1),
+                         static_cast<T>(min_v + 1),
+                         min_v,
+                         static_cast<T>(min_v + 1)};
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v(257, static_cast<T>((min_v + max_v) / 2));
+        v[125] = static_cast<T>(min_v + 1);
+        v[126] = min_v;
+        v[127] = static_cast<T>(min_v + 1);
+        v[128] = static_cast<T>(max_v - 1);
+        v[129] = max_v;
+        v[130] = static_cast<T>(max_v - 1);
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v(259, static_cast<T>((min_v + max_v) / 2));
+        v[0] = min_v;
+        v[256] = static_cast<T>(max_v - 1);
+        v[257] = max_v;
+        v[258] = static_cast<T>(max_v - 1);
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v(257, static_cast<T>((min_v + max_v) / 2));
+        v[0] = min_v;
+        v[127] = max_v;
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v(257, static_cast<T>((min_v + max_v) / 2));
+        v[127] = min_v;
+        v[0] = max_v;
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v(257, static_cast<T>((min_v + max_v) / 2));
+        v[0] = min_v;
+        v[129] = max_v;
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v(257, static_cast<T>((min_v + max_v) / 2));
+        v[129] = min_v;
+        v[0] = max_v;
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v(257, static_cast<T>((min_v + max_v) / 2));
+        v[129] = min_v;
+        v[256] = max_v;
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v(257, static_cast<T>((min_v + max_v) / 2));
+        v[256] = min_v;
+        v[129] = max_v;
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+}
+
+TEST_F(test_gdal_minmax_element, int8)
+{
+    using T = int8_t;
+    T min_v = -1;
+    T max_v = 3;
+    constexpr GDALDataType eDT = GDT_Int8;
+    {
+        T nodata = 0;
+        std::vector<T> v{max_v, nodata, min_v};
+        {
+            auto idx_min = gdal::min_element(v.data(), 0, eDT, true, nodata);
+            EXPECT_EQ(idx_min, 0);
+        }
+        {
+            auto idx_min = gdal::min_element(v.data(), 0, eDT, false, 0);
+            EXPECT_EQ(idx_min, 0);
+        }
+        {
+            auto idx_min =
+                gdal::min_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_min], min_v);
+            auto idx_max =
+                gdal::max_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_max], max_v);
+        }
+        {
+            auto [idx_min, idx_max] =
+                gdal::minmax_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_min], min_v);
+            EXPECT_EQ(v[idx_max], max_v);
+        }
+    }
+    {
+        T nodata = 0;
+        std::vector<T> v{nodata, max_v, min_v};
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, true, nodata);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, true, nodata);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v{static_cast<T>((min_v + max_v) / 2), max_v, min_v};
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v(257, static_cast<T>((min_v + max_v) / 2));
+        v[5] = min_v;
+        v[31] = max_v;
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+}
+
+TEST_F(test_gdal_minmax_element, uint16)
+{
+    using T = uint16_t;
+    constexpr GDALDataType eDT = GDT_UInt16;
+    T min_v = 1000;
+    T max_v = 2000;
+    {
+        T nodata = 0;
+        std::vector<T> v{max_v, nodata, min_v};
+        {
+            auto idx_min = gdal::min_element(v.data(), 0, eDT, true, nodata);
+            EXPECT_EQ(idx_min, 0);
+        }
+        {
+            auto idx_min = gdal::min_element(v.data(), 0, eDT, false, 0);
+            EXPECT_EQ(idx_min, 0);
+        }
+        {
+            auto idx_min =
+                gdal::min_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_min], min_v);
+            auto idx_max =
+                gdal::max_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_max], max_v);
+        }
+        {
+            auto [idx_min, idx_max] =
+                gdal::minmax_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_min], min_v);
+            EXPECT_EQ(v[idx_max], max_v);
+        }
+    }
+    {
+        T nodata = 0;
+        std::vector<T> v{nodata, max_v, min_v};
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, true, nodata);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, true, nodata);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v{static_cast<T>((min_v + max_v) / 2), max_v, min_v};
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v(257, static_cast<T>((min_v + max_v) / 2));
+        v[5] = min_v;
+        v[31] = max_v;
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+}
+
+TEST_F(test_gdal_minmax_element, int16)
+{
+    using T = int16_t;
+    constexpr GDALDataType eDT = GDT_Int16;
+    T min_v = -1000;
+    T max_v = 2000;
+    {
+        T nodata = 0;
+        std::vector<T> v{max_v, nodata, min_v};
+        {
+            auto idx_min = gdal::min_element(v.data(), 0, eDT, true, nodata);
+            EXPECT_EQ(idx_min, 0);
+        }
+        {
+            auto idx_min = gdal::min_element(v.data(), 0, eDT, false, 0);
+            EXPECT_EQ(idx_min, 0);
+        }
+        {
+            auto idx_min =
+                gdal::min_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_min], min_v);
+            auto idx_max =
+                gdal::max_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_max], max_v);
+        }
+        {
+            auto [idx_min, idx_max] =
+                gdal::minmax_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_min], min_v);
+            EXPECT_EQ(v[idx_max], max_v);
+        }
+    }
+    {
+        T nodata = 0;
+        std::vector<T> v{nodata, max_v, min_v};
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, true, nodata);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, true, nodata);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v{static_cast<T>((min_v + max_v) / 2), max_v, min_v};
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v(257, static_cast<T>((min_v + max_v) / 2));
+        v[5] = min_v;
+        v[31] = max_v;
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+}
+
+TEST_F(test_gdal_minmax_element, uint32)
+{
+    using T = uint32_t;
+    constexpr GDALDataType eDT = GDT_UInt32;
+    T min_v = 10000000;
+    T max_v = 20000000;
+    {
+        T nodata = 0;
+        std::vector<T> v{max_v, nodata, min_v};
+        {
+            auto idx_min = gdal::min_element(v.data(), 0, eDT, true, nodata);
+            EXPECT_EQ(idx_min, 0);
+        }
+        {
+            auto idx_min = gdal::min_element(v.data(), 0, eDT, false, 0);
+            EXPECT_EQ(idx_min, 0);
+        }
+        {
+            auto idx_min =
+                gdal::min_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_min], min_v);
+            auto idx_max =
+                gdal::max_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_max], max_v);
+        }
+        {
+            auto [idx_min, idx_max] =
+                gdal::minmax_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_min], min_v);
+            EXPECT_EQ(v[idx_max], max_v);
+        }
+    }
+    {
+        T nodata = 0;
+        std::vector<T> v{nodata, max_v, min_v};
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, true, nodata);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, true, nodata);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v{static_cast<T>((min_v + max_v) / 2), max_v, min_v};
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v(257, static_cast<T>((min_v + max_v) / 2));
+        v[5] = min_v;
+        v[31] = max_v;
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+}
+
+TEST_F(test_gdal_minmax_element, int32)
+{
+    using T = int32_t;
+    constexpr GDALDataType eDT = GDT_Int32;
+    T min_v = -10000000;
+    T max_v = 20000000;
+    {
+        T nodata = 0;
+        std::vector<T> v{max_v, nodata, min_v};
+        {
+            auto idx_min = gdal::min_element(v.data(), 0, eDT, true, nodata);
+            EXPECT_EQ(idx_min, 0);
+        }
+        {
+            auto idx_min = gdal::min_element(v.data(), 0, eDT, false, 0);
+            EXPECT_EQ(idx_min, 0);
+        }
+        {
+            auto idx_min =
+                gdal::min_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_min], min_v);
+            auto idx_max =
+                gdal::max_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_max], max_v);
+        }
+        {
+            auto [idx_min, idx_max] =
+                gdal::minmax_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_min], min_v);
+            EXPECT_EQ(v[idx_max], max_v);
+        }
+    }
+    {
+        T nodata = 0;
+        std::vector<T> v{nodata, max_v, min_v};
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, true, nodata);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, true, nodata);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v{static_cast<T>((min_v + max_v) / 2), max_v, min_v};
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v(257, static_cast<T>((min_v + max_v) / 2));
+        v[5] = min_v;
+        v[31] = max_v;
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+}
+
+TEST_F(test_gdal_minmax_element, uint64)
+{
+    using T = uint64_t;
+    constexpr GDALDataType eDT = GDT_UInt64;
+    T min_v = 100000000000000;
+    T max_v = 200000000000000;
+    {
+        double nodata = 0;
+        std::vector<T> v{max_v, static_cast<T>(nodata), min_v};
+        {
+            auto idx_min = gdal::min_element(v.data(), 0, eDT, true, nodata);
+            EXPECT_EQ(idx_min, 0);
+        }
+        {
+            auto idx_min = gdal::min_element(v.data(), 0, eDT, false, 0);
+            EXPECT_EQ(idx_min, 0);
+        }
+        {
+            auto idx_min =
+                gdal::min_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_min], min_v);
+            auto idx_max =
+                gdal::max_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_max], max_v);
+        }
+        {
+            auto [idx_min, idx_max] =
+                gdal::minmax_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_min], min_v);
+            EXPECT_EQ(v[idx_max], max_v);
+        }
+    }
+    {
+        double nodata = 0;
+        std::vector<T> v{static_cast<T>(nodata), max_v, min_v};
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, true, nodata);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, true, nodata);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v{static_cast<T>((min_v + max_v) / 2), max_v, min_v};
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v(257, static_cast<T>((min_v + max_v) / 2));
+        v[5] = min_v;
+        v[31] = max_v;
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+}
+
+TEST_F(test_gdal_minmax_element, int64)
+{
+    using T = int64_t;
+    constexpr GDALDataType eDT = GDT_Int64;
+    T min_v = -100000000000000;
+    T max_v = 200000000000000;
+    {
+        double nodata = 0;
+        std::vector<T> v{max_v, static_cast<T>(nodata), min_v};
+        {
+            auto idx_min = gdal::min_element(v.data(), 0, eDT, true, nodata);
+            EXPECT_EQ(idx_min, 0);
+        }
+        {
+            auto idx_min = gdal::min_element(v.data(), 0, eDT, false, 0);
+            EXPECT_EQ(idx_min, 0);
+        }
+        {
+            auto idx_min =
+                gdal::min_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_min], min_v);
+            auto idx_max =
+                gdal::max_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_max], max_v);
+        }
+        {
+            auto [idx_min, idx_max] =
+                gdal::minmax_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_min], min_v);
+            EXPECT_EQ(v[idx_max], max_v);
+        }
+    }
+    {
+        double nodata = 0;
+        std::vector<T> v{static_cast<T>(nodata), max_v, min_v};
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, true, nodata);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, true, nodata);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v{static_cast<T>((min_v + max_v) / 2),
+                         max_v - 1,
+                         max_v,
+                         max_v - 1,
+                         min_v + 1,
+                         min_v,
+                         min_v + 1};
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v(257, static_cast<T>((min_v + max_v) / 2));
+        v[5] = min_v;
+        v[31] = max_v;
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+}
+
+TEST_F(test_gdal_minmax_element, float32)
+{
+    using T = float;
+    constexpr GDALDataType eDT = GDT_Float32;
+    T min_v = 1.0f;
+    T max_v = 1.5f;
+    {
+        T nodata = 2.0f;
+        std::vector<T> v{max_v, nodata, min_v};
+        {
+            auto idx_min = gdal::min_element(v.data(), 0, eDT, true, nodata);
+            EXPECT_EQ(idx_min, 0);
+        }
+        {
+            auto idx_min = gdal::min_element(v.data(), 0, eDT, false, 0);
+            EXPECT_EQ(idx_min, 0);
+        }
+        {
+            auto idx_min =
+                gdal::min_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_min], min_v);
+            auto idx_max =
+                gdal::max_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_max], max_v);
+        }
+        {
+            auto [idx_min, idx_max] =
+                gdal::minmax_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_min], min_v);
+            EXPECT_EQ(v[idx_max], max_v);
+        }
+    }
+    {
+        T nodata = 2.0f;
+        std::vector<T> v{nodata, max_v, min_v};
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, true, nodata);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, true, nodata);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        T nodata = 2.0f;
+        std::vector<T> v{std::numeric_limits<T>::quiet_NaN(),
+                         std::numeric_limits<T>::quiet_NaN(), nodata, max_v,
+                         min_v};
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, true, nodata);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, true, nodata);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        T nodata = std::numeric_limits<T>::quiet_NaN();
+        std::vector<T> v{std::numeric_limits<T>::quiet_NaN(),
+                         std::numeric_limits<T>::quiet_NaN(), nodata, max_v,
+                         min_v};
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, true, nodata);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, true, nodata);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v{std::numeric_limits<T>::quiet_NaN(),
+                         std::numeric_limits<T>::quiet_NaN(),
+                         max_v,
+                         std::numeric_limits<T>::quiet_NaN(),
+                         min_v,
+                         std::numeric_limits<T>::quiet_NaN()};
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v{max_v, std::numeric_limits<T>::quiet_NaN(), min_v};
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v(257, std::numeric_limits<T>::quiet_NaN());
+        v[125] = static_cast<T>(min_v + 0.1f);
+        v[126] = min_v;
+        v[127] = static_cast<T>(min_v + 0.1f);
+        v[128] = static_cast<T>(max_v - 0.1f);
+        v[129] = max_v;
+        v[130] = static_cast<T>(max_v - 0.1f);
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v(33, 1.2f);
+        v[5] = min_v;
+        v[15] = max_v;
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v(255, std::numeric_limits<T>::quiet_NaN());
+        v[v.size() - 2] = min_v;
+        v.back() = max_v;
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+}
+
+TEST_F(test_gdal_minmax_element, float64)
+{
+    using T = double;
+    constexpr GDALDataType eDT = GDT_Float64;
+    T min_v = 1.0;
+    T max_v = 1.5;
+    {
+        T nodata = 2.0;
+        std::vector<T> v{max_v, nodata, min_v};
+        {
+            auto idx_min = gdal::min_element(v.data(), 0, eDT, true, nodata);
+            EXPECT_EQ(idx_min, 0);
+        }
+        {
+            auto idx_min = gdal::min_element(v.data(), 0, eDT, false, 0);
+            EXPECT_EQ(idx_min, 0);
+        }
+        {
+            auto idx_min =
+                gdal::min_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_min], min_v);
+            auto idx_max =
+                gdal::max_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_max], max_v);
+        }
+        {
+            auto [idx_min, idx_max] =
+                gdal::minmax_element(v.data(), v.size(), eDT, true, nodata);
+            EXPECT_EQ(v[idx_min], min_v);
+            EXPECT_EQ(v[idx_max], max_v);
+        }
+    }
+    {
+        T nodata = 2.0;
+        std::vector<T> v{nodata, max_v, min_v};
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, true, nodata);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, true, nodata);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        T nodata = 2.0;
+        std::vector<T> v{std::numeric_limits<T>::quiet_NaN(),
+                         std::numeric_limits<T>::quiet_NaN(), nodata, max_v,
+                         min_v};
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, true, nodata);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, true, nodata);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v{max_v, std::numeric_limits<T>::quiet_NaN(), min_v};
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v{std::numeric_limits<T>::quiet_NaN(),
+                         std::numeric_limits<T>::quiet_NaN(),
+                         max_v,
+                         std::numeric_limits<T>::quiet_NaN(),
+                         min_v,
+                         std::numeric_limits<T>::quiet_NaN()};
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v(33, std::numeric_limits<T>::quiet_NaN());
+        v[5] = min_v;
+        v[15] = max_v;
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v(255, std::numeric_limits<T>::quiet_NaN());
+        v[v.size() - 2] = min_v;
+        v.back() = max_v;
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
+}
+
+TEST_F(test_gdal_minmax_element, unsupported)
+{
+    float v[2] = {0, 0};
+    CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
+    {
+        CPLErrorReset();
+        EXPECT_EQ(gdal::min_element(v, 1, GDT_CFloat32, false, 0), 0);
+        EXPECT_EQ(CPLGetLastErrorNo(), CPLE_NotSupported);
+    }
+    {
+        CPLErrorReset();
+        EXPECT_EQ(gdal::max_element(v, 1, GDT_CFloat32, false, 0), 0);
+        EXPECT_EQ(CPLGetLastErrorNo(), CPLE_NotSupported);
+    }
+    {
+        CPLErrorReset();
+        auto [idx_min, idx_max] =
+            gdal::minmax_element(v, 1, GDT_CFloat32, false, 0);
+        EXPECT_EQ(idx_min, 0);
+        EXPECT_EQ(idx_max, 0);
+        EXPECT_EQ(CPLGetLastErrorNo(), CPLE_NotSupported);
+    }
+}
+
+}  // namespace

--- a/autotest/cpp/test_gdal_minmax_element.cpp
+++ b/autotest/cpp/test_gdal_minmax_element.cpp
@@ -92,6 +92,26 @@ TEST_F(test_gdal_minmax_element, uint8)
         EXPECT_EQ(v[idx_max], max_v);
     }
     {
+        std::vector<T> v(257, static_cast<T>(min_v + 2));
+        v[128] = static_cast<T>(min_v + 1);
+        v[256] = min_v;
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, true,
+                                         static_cast<T>(min_v + 1));
+        EXPECT_EQ(v[idx_min], min_v);
+    }
+    {
+        std::vector<T> v(257, 0);
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, true, 0);
+        EXPECT_EQ(idx_min, 0);
+    }
+    {
+        std::vector<T> v(257, 0);
+        v[127] = static_cast<T>(min_v + 1);
+        v[255] = min_v;
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, true, 0);
+        EXPECT_EQ(v[idx_min], min_v);
+    }
+    {
         std::vector<T> v(259, static_cast<T>((min_v + max_v) / 2));
         v[0] = min_v;
         v[256] = static_cast<T>(max_v - 1);
@@ -156,6 +176,14 @@ TEST_F(test_gdal_minmax_element, uint8)
         auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
         EXPECT_EQ(v[idx_max], max_v);
     }
+    {
+        std::vector<T> v(257, 0);
+        v[65] = static_cast<T>(max_v - 2);
+        v[66] = static_cast<T>(max_v - 1);
+        v[129] = max_v;
+        auto idx_max = gdal::max_element(v.data(), v.size(), eDT, true, 0);
+        EXPECT_EQ(v[idx_max], max_v);
+    }
 }
 
 TEST_F(test_gdal_minmax_element, int8)
@@ -213,6 +241,14 @@ TEST_F(test_gdal_minmax_element, int8)
         EXPECT_EQ(v[idx_min], min_v);
         auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
         EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v(257, static_cast<T>(min_v + 2));
+        v[128] = static_cast<T>(min_v + 1);
+        v[256] = min_v;
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, true,
+                                         static_cast<T>(min_v + 1));
+        EXPECT_EQ(v[idx_min], min_v);
     }
 }
 
@@ -272,6 +308,14 @@ TEST_F(test_gdal_minmax_element, uint16)
         auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
         EXPECT_EQ(v[idx_max], max_v);
     }
+    {
+        std::vector<T> v(257, static_cast<T>(min_v + 2));
+        v[128] = static_cast<T>(min_v + 1);
+        v[256] = min_v;
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, true,
+                                         static_cast<T>(min_v + 1));
+        EXPECT_EQ(v[idx_min], min_v);
+    }
 }
 
 TEST_F(test_gdal_minmax_element, int16)
@@ -329,6 +373,14 @@ TEST_F(test_gdal_minmax_element, int16)
         EXPECT_EQ(v[idx_min], min_v);
         auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
         EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v(257, static_cast<T>(min_v + 2));
+        v[128] = static_cast<T>(min_v + 1);
+        v[256] = min_v;
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, true,
+                                         static_cast<T>(min_v + 1));
+        EXPECT_EQ(v[idx_min], min_v);
     }
 }
 
@@ -388,6 +440,14 @@ TEST_F(test_gdal_minmax_element, uint32)
         auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
         EXPECT_EQ(v[idx_max], max_v);
     }
+    {
+        std::vector<T> v(257, static_cast<T>(min_v + 2));
+        v[128] = static_cast<T>(min_v + 1);
+        v[256] = min_v;
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, true,
+                                         static_cast<T>(min_v + 1));
+        EXPECT_EQ(v[idx_min], min_v);
+    }
 }
 
 TEST_F(test_gdal_minmax_element, int32)
@@ -446,6 +506,14 @@ TEST_F(test_gdal_minmax_element, int32)
         auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
         EXPECT_EQ(v[idx_max], max_v);
     }
+    {
+        std::vector<T> v(257, static_cast<T>(min_v + 2));
+        v[128] = static_cast<T>(min_v + 1);
+        v[256] = min_v;
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, true,
+                                         static_cast<T>(min_v + 1));
+        EXPECT_EQ(v[idx_min], min_v);
+    }
 }
 
 TEST_F(test_gdal_minmax_element, uint64)
@@ -503,6 +571,15 @@ TEST_F(test_gdal_minmax_element, uint64)
         EXPECT_EQ(v[idx_min], min_v);
         auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
         EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v(257, static_cast<T>(min_v + 2));
+        v[128] = static_cast<T>(min_v + 1);
+        v[256] = min_v;
+        auto idx_min =
+            gdal::min_element(v.data(), v.size(), eDT, true,
+                              static_cast<double>(static_cast<T>(min_v + 1)));
+        EXPECT_EQ(v[idx_min], min_v);
     }
 }
 
@@ -567,6 +644,15 @@ TEST_F(test_gdal_minmax_element, int64)
         EXPECT_EQ(v[idx_min], min_v);
         auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
         EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v(257, static_cast<T>(min_v + 2));
+        v[128] = static_cast<T>(min_v + 1);
+        v[256] = min_v;
+        auto idx_min =
+            gdal::min_element(v.data(), v.size(), eDT, true,
+                              static_cast<double>(static_cast<T>(min_v + 1)));
+        EXPECT_EQ(v[idx_min], min_v);
     }
 }
 
@@ -680,6 +766,14 @@ TEST_F(test_gdal_minmax_element, float32)
         auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
         EXPECT_EQ(v[idx_max], max_v);
     }
+    {
+        std::vector<T> v(257, static_cast<T>(min_v + 0.2f));
+        v[128] = static_cast<T>(min_v + 0.1f);
+        v[256] = min_v;
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, true,
+                                         static_cast<T>(min_v + 0.1f));
+        EXPECT_EQ(v[idx_min], min_v);
+    }
 }
 
 TEST_F(test_gdal_minmax_element, float64)
@@ -768,6 +862,14 @@ TEST_F(test_gdal_minmax_element, float64)
         EXPECT_EQ(v[idx_min], min_v);
         auto idx_max = gdal::max_element(v.data(), v.size(), eDT, false, 0);
         EXPECT_EQ(v[idx_max], max_v);
+    }
+    {
+        std::vector<T> v(257, static_cast<T>(min_v + 0.2));
+        v[128] = static_cast<T>(min_v + 0.1);
+        v[256] = min_v;
+        auto idx_min = gdal::min_element(v.data(), v.size(), eDT, true,
+                                         static_cast<T>(min_v + 0.1));
+        EXPECT_EQ(v[idx_min], min_v);
     }
 }
 

--- a/ci/travis/osx/script.sh
+++ b/ci/travis/osx/script.sh
@@ -7,6 +7,9 @@ export PROJ_NETWORK=ON
 echo 'Running CPP unit tests'
 (cd build && make quicktest)
 
+echo 'Running CPP perftests'
+(cd build && ctest -V -R perf)
+
 echo 'Running Python unit tests'
 # install test dependencies
 sudo -H pip3 install -r autotest/requirements.txt

--- a/gcore/CMakeLists.txt
+++ b/gcore/CMakeLists.txt
@@ -210,6 +210,7 @@ target_public_header(
   gdal_typetraits.h
   gdal_adbc.h
   gdal_minmax_element.hpp
+  gdal_priv_templates.hpp  # Required by gdal_minmax_element.hpp
 )
 
 set(GDAL_DATA_FILES

--- a/gcore/CMakeLists.txt
+++ b/gcore/CMakeLists.txt
@@ -209,6 +209,7 @@ target_public_header(
   gdalsubdatasetinfo.h
   gdal_typetraits.h
   gdal_adbc.h
+  gdal_minmax_element.hpp
 )
 
 set(GDAL_DATA_FILES

--- a/gcore/gdal_minmax_element.hpp
+++ b/gcore/gdal_minmax_element.hpp
@@ -1,0 +1,971 @@
+/******************************************************************************
+ * Project:  GDAL Core
+ * Purpose:  Utility functions to find minimum and maximum values in a buffer
+ * Author:   Even Rouault, <even dot rouault at spatialys.com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2024, Even Rouault <even dot rouault at spatialys.com>
+ *
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#ifndef GDAL_MINMAX_ELEMENT_INCLUDED
+#define GDAL_MINMAX_ELEMENT_INCLUDED
+
+// NOTE: This header requires C++17
+
+// This file may be vendored by other applications than GDAL
+// WARNING: if modifying this file, please also update the upstream GDAL version
+// at https://github.com/OSGeo/gdal/blob/master/gcore/gdal_minmax_element.hpp
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <type_traits>
+#include <utility>
+
+#include "gdal.h"
+
+#ifdef GDAL_COMPILATION
+#define GDAL_MINMAXELT_NS gdal
+#elif !defined(GDAL_MINMAXELT_NS)
+#error "Please define the GDAL_MINMAXELT_NS macro to define the namespace"
+#endif
+
+#if defined(__x86_64) || defined(_M_X64)
+// SSE2 header
+#include <emmintrin.h>
+#endif
+
+#include "gdal_priv_templates.hpp"
+#if GDAL_VERSION < GDAL_COMPUTE_VERSION(3, 10, 0)
+// For vendoring in other applications
+namespace GDAL_MINMAXELT_NS
+{
+template <class T> inline bool GDALIsValueExactAs(double dfValue)
+{
+    return GDALIsValueInRange<T>(dfValue) &&
+           static_cast<double>(static_cast<T>(dfValue)) == dfValue;
+}
+
+template <> inline bool GDALIsValueExactAs<float>(double dfValue)
+{
+    return std::isnan(dfValue) ||
+           (GDALIsValueInRange<float>(dfValue) &&
+            static_cast<double>(static_cast<float>(dfValue)) == dfValue);
+}
+
+template <> inline bool GDALIsValueExactAs<double>(double)
+{
+    return true;
+}
+}  // namespace GDAL_MINMAXELT_NS
+#endif
+
+namespace GDAL_MINMAXELT_NS
+{
+namespace detail
+{
+
+/************************************************************************/
+/*                            compScalar()                              */
+/************************************************************************/
+
+template <class T, bool IS_MAX> inline static bool compScalar(T x, T y)
+{
+    if constexpr (IS_MAX)
+        return x > y;
+    else
+        return x < y;
+}
+
+/************************************************************************/
+/*                         extremum_element()                           */
+/************************************************************************/
+
+template <class T, bool IS_MAX>
+size_t extremum_element(const T *v, size_t size, T noDataValue)
+{
+    static_assert(!(std::is_floating_point_v<T>));
+    if (size == 0)
+        return 0;
+    size_t idx_of_extremum = 0;
+    T extremum = v[0];
+    bool extremum_is_nodata = extremum == noDataValue;
+    size_t i = 1;
+    for (; i < size; ++i)
+    {
+        if (v[i] != noDataValue &&
+            (compScalar<T, IS_MAX>(v[i], extremum) || extremum_is_nodata))
+        {
+            extremum = v[i];
+            idx_of_extremum = i;
+            extremum_is_nodata = false;
+        }
+    }
+    return idx_of_extremum;
+}
+
+/************************************************************************/
+/*                         extremum_element()                           */
+/************************************************************************/
+
+template <class T, bool IS_MAX> size_t extremum_element(const T *v, size_t size)
+{
+    static_assert(!(std::is_floating_point_v<T>));
+    if (size == 0)
+        return 0;
+    size_t idx_of_extremum = 0;
+    T extremum = v[0];
+    size_t i = 1;
+    for (; i < size; ++i)
+    {
+        if (compScalar<T, IS_MAX>(v[i], extremum))
+        {
+            extremum = v[i];
+            idx_of_extremum = i;
+        }
+    }
+    return idx_of_extremum;
+}
+
+#if defined(__x86_64) || defined(_M_X64)
+
+/************************************************************************/
+/*                    extremum_element_with_nan()                       */
+/************************************************************************/
+
+static inline int8_t Shift8(uint8_t x)
+{
+    return static_cast<int8_t>(x + std::numeric_limits<int8_t>::min());
+}
+
+static inline int16_t Shift16(uint16_t x)
+{
+    return static_cast<int16_t>(x + std::numeric_limits<int16_t>::min());
+}
+
+CPL_NOSANITIZE_UNSIGNED_INT_OVERFLOW
+static inline int32_t Shift32(uint32_t x)
+{
+    x += static_cast<uint32_t>(std::numeric_limits<int32_t>::min());
+    int32_t ret;
+    memcpy(&ret, &x, sizeof(x));
+    return ret;
+}
+
+// Return a _mm128[i|d] register with all its elements set to x
+template <class T> static inline auto set1(T x)
+{
+    if constexpr (std::is_same_v<T, uint8_t>)
+        return _mm_set1_epi8(Shift8(x));
+    else if constexpr (std::is_same_v<T, int8_t>)
+        return _mm_set1_epi8(x);
+    else if constexpr (std::is_same_v<T, uint16_t>)
+        return _mm_set1_epi16(Shift16(x));
+    else if constexpr (std::is_same_v<T, int16_t>)
+        return _mm_set1_epi16(x);
+    else if constexpr (std::is_same_v<T, uint32_t>)
+        return _mm_set1_epi32(Shift32(x));
+    else if constexpr (std::is_same_v<T, int32_t>)
+        return _mm_set1_epi32(x);
+    else if constexpr (std::is_same_v<T, float>)
+        return _mm_set1_ps(x);
+    else
+        return _mm_set1_pd(x);
+}
+
+// Load as many values of type T at a _mm128[i|d] register can contain from x
+template <class T> static inline auto loadv(const T *x)
+{
+    if constexpr (std::is_same_v<T, float>)
+        return _mm_loadu_ps(x);
+    else if constexpr (std::is_same_v<T, double>)
+        return _mm_loadu_pd(x);
+    else
+        return _mm_loadu_si128(reinterpret_cast<const __m128i *>(x));
+}
+
+// Return a __m128i register with bits set when x[i] < y[i] when !IS_MAX
+// or x[i] > y[i] when IS_MAX
+template <class T, bool IS_MAX, class SSE_T>
+static inline __m128i comp(SSE_T x, SSE_T y)
+{
+    if constexpr (IS_MAX)
+    {
+        if constexpr (std::is_same_v<T, uint8_t>)
+            return _mm_cmpgt_epi8(
+                _mm_add_epi8(x,
+                             _mm_set1_epi8(std::numeric_limits<int8_t>::min())),
+                y);
+        else if constexpr (std::is_same_v<T, int8_t>)
+            return _mm_cmpgt_epi8(x, y);
+        else if constexpr (std::is_same_v<T, uint16_t>)
+            return _mm_cmpgt_epi16(
+                _mm_add_epi16(
+                    x, _mm_set1_epi16(std::numeric_limits<int16_t>::min())),
+                y);
+        else if constexpr (std::is_same_v<T, int16_t>)
+            return _mm_cmpgt_epi16(x, y);
+        else if constexpr (std::is_same_v<T, uint32_t>)
+            return _mm_cmpgt_epi32(
+                _mm_add_epi32(
+                    x, _mm_set1_epi32(std::numeric_limits<int32_t>::min())),
+                y);
+        else if constexpr (std::is_same_v<T, int32_t>)
+            return _mm_cmpgt_epi32(x, y);
+        // We could use _mm_cmpgt_pX() if there was no NaN values
+        else if constexpr (std::is_same_v<T, float>)
+            return _mm_castps_si128(_mm_cmpnle_ps(x, y));
+        else
+            return _mm_castpd_si128(_mm_cmpnle_pd(x, y));
+    }
+    else
+    {
+        if constexpr (std::is_same_v<T, uint8_t>)
+            return _mm_cmplt_epi8(
+                _mm_add_epi8(x,
+                             _mm_set1_epi8(std::numeric_limits<int8_t>::min())),
+                y);
+        else if constexpr (std::is_same_v<T, int8_t>)
+            return _mm_cmplt_epi8(x, y);
+        else if constexpr (std::is_same_v<T, uint16_t>)
+            return _mm_cmplt_epi16(
+                _mm_add_epi16(
+                    x, _mm_set1_epi16(std::numeric_limits<int16_t>::min())),
+                y);
+        else if constexpr (std::is_same_v<T, int16_t>)
+            return _mm_cmplt_epi16(x, y);
+        else if constexpr (std::is_same_v<T, uint32_t>)
+            return _mm_cmplt_epi32(
+                _mm_add_epi32(
+                    x, _mm_set1_epi32(std::numeric_limits<int32_t>::min())),
+                y);
+        else if constexpr (std::is_same_v<T, int32_t>)
+            return _mm_cmplt_epi32(x, y);
+        // We could use _mm_cmplt_pX() if there was no NaN values
+        else if constexpr (std::is_same_v<T, float>)
+            return _mm_castps_si128(_mm_cmpnge_ps(x, y));
+        else
+            return _mm_castpd_si128(_mm_cmpnge_pd(x, y));
+    }
+}
+
+// Using SSE2
+template <class T, bool IS_MAX>
+inline size_t extremum_element_with_nan(const T *v, size_t size)
+{
+    static_assert(std::is_same_v<T, uint8_t> || std::is_same_v<T, int8_t> ||
+                  std::is_same_v<T, uint16_t> || std::is_same_v<T, int16_t> ||
+                  std::is_same_v<T, uint32_t> || std::is_same_v<T, int32_t> ||
+                  std::is_floating_point_v<T>);
+    if (size == 0)
+        return 0;
+    size_t idx_of_extremum = 0;
+    T extremum = v[0];
+    [[maybe_unused]] bool extremum_is_nan = std::isnan(extremum);
+    size_t i = 1;
+
+    constexpr size_t VALS_PER_REG = sizeof(set1(extremum)) / sizeof(extremum);
+    constexpr int LOOP_UNROLLING = 4;
+    // If changing the value, then we need to adjust the number of sse_valX
+    // loading in the loop.
+    static_assert(LOOP_UNROLLING == 4);
+    constexpr size_t VALS_PER_ITER = VALS_PER_REG * LOOP_UNROLLING;
+
+    const auto update =
+        [v, &extremum, &idx_of_extremum, &extremum_is_nan](size_t idx)
+    {
+        if (compScalar<T, IS_MAX>(v[idx], extremum))
+        {
+            extremum = v[idx];
+            idx_of_extremum = idx;
+            extremum_is_nan = false;
+        }
+        else if constexpr (std::is_floating_point_v<T>)
+        {
+            if (extremum_is_nan && !std::isnan(v[idx]))
+            {
+                extremum = v[idx];
+                idx_of_extremum = idx;
+                extremum_is_nan = false;
+            }
+        }
+    };
+
+    for (; i < VALS_PER_ITER && i < size; ++i)
+    {
+        update(i);
+    }
+
+    auto sse_extremum = set1(extremum);
+
+    [[maybe_unused]] size_t hits = 0;
+    const auto sse_iter_count = (size / VALS_PER_ITER) * VALS_PER_ITER;
+    for (; i < sse_iter_count; i += VALS_PER_ITER)
+    {
+        // A bit of loop unrolling to save 3/4 of slow movemask operations.
+        const auto sse_val0 = loadv(v + i + 0 * VALS_PER_REG);
+        const auto sse_val1 = loadv(v + i + 1 * VALS_PER_REG);
+        const auto sse_val2 = loadv(v + i + 2 * VALS_PER_REG);
+        const auto sse_val3 = loadv(v + i + 3 * VALS_PER_REG);
+        if (_mm_movemask_epi8(_mm_or_si128(
+                _mm_or_si128(comp<T, IS_MAX>(sse_val0, sse_extremum),
+                             comp<T, IS_MAX>(sse_val1, sse_extremum)),
+                _mm_or_si128(comp<T, IS_MAX>(sse_val2, sse_extremum),
+                             comp<T, IS_MAX>(sse_val3, sse_extremum)))) != 0)
+        {
+            if constexpr (!std::is_same_v<T, int8_t> &&
+                          !std::is_same_v<T, uint8_t>)
+            {
+                // The above tests excluding int8_t/uint8_t is due to the fact
+                // with those small ranges of values we will quickly converge
+                // to the minimum, so no need to do the below "smart" test.
+
+                if (++hits == size / 16)
+                {
+                    // If we have an almost sorted array, then using this code path
+                    // will hurt performance. Arbitrary give up if we get here
+                    // more than 1. / 16 of the size of the array.
+                    // fprintf(stderr, "going to non-vector path\n");
+                    break;
+                }
+            }
+            for (size_t j = 0; j < VALS_PER_ITER; j++)
+            {
+                update(i + j);
+            }
+            sse_extremum = set1(extremum);
+        }
+    }
+    for (; i < size; ++i)
+    {
+        update(i);
+    }
+    return idx_of_extremum;
+}
+
+#else
+
+/************************************************************************/
+/*                    extremum_element_with_nan()                       */
+/************************************************************************/
+
+template <class T, bool IS_MAX>
+inline size_t extremum_element_with_nan(const T *v, size_t size)
+{
+    if (size == 0)
+        return 0;
+    size_t idx_of_extremum = 0;
+    auto extremum = v[0];
+    bool extremum_is_nan = std::isnan(extremum);
+    size_t i = 1;
+    for (; i < size; ++i)
+    {
+        if (compScalar<T, IS_MAX>(v[i], extremum) ||
+            (extremum_is_nan && !std::isnan(v[i])))
+        {
+            extremum = v[i];
+            idx_of_extremum = i;
+            extremum_is_nan = false;
+        }
+    }
+    return idx_of_extremum;
+}
+#endif
+
+/************************************************************************/
+/*                         extremum_element()                           */
+/************************************************************************/
+
+#if defined(__x86_64) || defined(_M_X64)
+
+template <>
+size_t extremum_element<uint8_t, true>(const uint8_t *v, size_t size)
+{
+    return extremum_element_with_nan<uint8_t, true>(v, size);
+}
+
+template <>
+size_t extremum_element<uint8_t, false>(const uint8_t *v, size_t size)
+{
+    return extremum_element_with_nan<uint8_t, false>(v, size);
+}
+
+template <> size_t extremum_element<int8_t, true>(const int8_t *v, size_t size)
+{
+    return extremum_element_with_nan<int8_t, true>(v, size);
+}
+
+template <> size_t extremum_element<int8_t, false>(const int8_t *v, size_t size)
+{
+    return extremum_element_with_nan<int8_t, false>(v, size);
+}
+
+template <>
+size_t extremum_element<uint16_t, true>(const uint16_t *v, size_t size)
+{
+    return extremum_element_with_nan<uint16_t, true>(v, size);
+}
+
+template <>
+size_t extremum_element<uint16_t, false>(const uint16_t *v, size_t size)
+{
+    return extremum_element_with_nan<uint16_t, false>(v, size);
+}
+
+template <>
+size_t extremum_element<int16_t, true>(const int16_t *v, size_t size)
+{
+    return extremum_element_with_nan<int16_t, true>(v, size);
+}
+
+template <>
+size_t extremum_element<int16_t, false>(const int16_t *v, size_t size)
+{
+    return extremum_element_with_nan<int16_t, false>(v, size);
+}
+
+template <>
+size_t extremum_element<uint32_t, true>(const uint32_t *v, size_t size)
+{
+    return extremum_element_with_nan<uint32_t, true>(v, size);
+}
+
+template <>
+size_t extremum_element<uint32_t, false>(const uint32_t *v, size_t size)
+{
+    return extremum_element_with_nan<uint32_t, false>(v, size);
+}
+
+template <>
+size_t extremum_element<int32_t, true>(const int32_t *v, size_t size)
+{
+    return extremum_element_with_nan<int32_t, true>(v, size);
+}
+
+template <>
+size_t extremum_element<int32_t, false>(const int32_t *v, size_t size)
+{
+    return extremum_element_with_nan<int32_t, false>(v, size);
+}
+
+#endif
+
+template <> size_t extremum_element<float, true>(const float *v, size_t size)
+{
+    return extremum_element_with_nan<float, true>(v, size);
+}
+
+template <> size_t extremum_element<double, true>(const double *v, size_t size)
+{
+    return extremum_element_with_nan<double, true>(v, size);
+}
+
+template <> size_t extremum_element<float, false>(const float *v, size_t size)
+{
+    return extremum_element_with_nan<float, false>(v, size);
+}
+
+template <> size_t extremum_element<double, false>(const double *v, size_t size)
+{
+    return extremum_element_with_nan<double, false>(v, size);
+}
+
+/************************************************************************/
+/*                       extremum_element_with_nan()                    */
+/************************************************************************/
+
+template <class T, bool IS_MAX>
+inline size_t extremum_element_with_nan(const T *v, size_t size, T noDataValue)
+{
+    if (std::isnan(noDataValue))
+        return extremum_element_with_nan<T, IS_MAX>(v, size);
+    if (size == 0)
+        return 0;
+    size_t idx_of_extremum = 0;
+    auto extremum = v[0];
+    bool extremum_is_nan_or_nodata =
+        std::isnan(extremum) || (extremum == noDataValue);
+    size_t i = 1;
+    for (; i < size; ++i)
+    {
+        if (v[i] != noDataValue &&
+            (compScalar<T, IS_MAX>(v[i], extremum) ||
+             (extremum_is_nan_or_nodata && !std::isnan(v[i]))))
+        {
+            extremum = v[i];
+            idx_of_extremum = i;
+            extremum_is_nan_or_nodata = false;
+        }
+    }
+    return idx_of_extremum;
+}
+
+/************************************************************************/
+/*                            extremum_element()                        */
+/************************************************************************/
+
+template <>
+size_t extremum_element<float, true>(const float *v, size_t size,
+                                     float noDataValue)
+{
+    return extremum_element_with_nan<float, true>(v, size, noDataValue);
+}
+
+template <>
+size_t extremum_element<double, true>(const double *v, size_t size,
+                                      double noDataValue)
+{
+    return extremum_element_with_nan<double, true>(v, size, noDataValue);
+}
+
+template <>
+size_t extremum_element<float, false>(const float *v, size_t size,
+                                      float noDataValue)
+{
+    return extremum_element_with_nan<float, false>(v, size, noDataValue);
+}
+
+template <>
+size_t extremum_element<double, false>(const double *v, size_t size,
+                                       double noDataValue)
+{
+    return extremum_element_with_nan<double, false>(v, size, noDataValue);
+}
+
+template <class T, bool IS_MAX>
+inline size_t extremum_element(const T *buffer, size_t size, bool bHasNoData,
+                               T noDataValue)
+{
+    if (bHasNoData)
+        return extremum_element<T, IS_MAX>(buffer, size, noDataValue);
+    else
+        return extremum_element<T, IS_MAX>(buffer, size);
+}
+
+template <bool IS_MAX>
+size_t extremum_element(const void *buffer, size_t nElts, GDALDataType eDT,
+                        bool bHasNoData, double dfNoDataValue)
+{
+    switch (eDT)
+    {
+        case GDT_Int8:
+        {
+            using T = int8_t;
+            bHasNoData = bHasNoData && GDALIsValueExactAs<T>(dfNoDataValue);
+            return extremum_element<T, IS_MAX>(
+                static_cast<const T *>(buffer), nElts, bHasNoData,
+                bHasNoData ? static_cast<T>(dfNoDataValue) : 0);
+        }
+        case GDT_Byte:
+        {
+            using T = uint8_t;
+            bHasNoData = bHasNoData && GDALIsValueExactAs<T>(dfNoDataValue);
+            return extremum_element<T, IS_MAX>(
+                static_cast<const T *>(buffer), nElts, bHasNoData,
+                bHasNoData ? static_cast<T>(dfNoDataValue) : 0);
+        }
+        case GDT_Int16:
+        {
+            using T = int16_t;
+            bHasNoData = bHasNoData && GDALIsValueExactAs<T>(dfNoDataValue);
+            return extremum_element<T, IS_MAX>(
+                static_cast<const T *>(buffer), nElts, bHasNoData,
+                bHasNoData ? static_cast<T>(dfNoDataValue) : 0);
+        }
+        case GDT_UInt16:
+        {
+            using T = uint16_t;
+            bHasNoData = bHasNoData && GDALIsValueExactAs<T>(dfNoDataValue);
+            return extremum_element<T, IS_MAX>(
+                static_cast<const T *>(buffer), nElts, bHasNoData,
+                bHasNoData ? static_cast<T>(dfNoDataValue) : 0);
+        }
+        case GDT_Int32:
+        {
+            using T = int32_t;
+            bHasNoData = bHasNoData && GDALIsValueExactAs<T>(dfNoDataValue);
+            return extremum_element<T, IS_MAX>(
+                static_cast<const T *>(buffer), nElts, bHasNoData,
+                bHasNoData ? static_cast<T>(dfNoDataValue) : 0);
+        }
+        case GDT_UInt32:
+        {
+            using T = uint32_t;
+            bHasNoData = bHasNoData && GDALIsValueExactAs<T>(dfNoDataValue);
+            return extremum_element<T, IS_MAX>(
+                static_cast<const T *>(buffer), nElts, bHasNoData,
+                bHasNoData ? static_cast<T>(dfNoDataValue) : 0);
+        }
+        case GDT_Int64:
+        {
+            using T = int64_t;
+            bHasNoData = bHasNoData && GDALIsValueExactAs<T>(dfNoDataValue);
+            return extremum_element<T, IS_MAX>(
+                static_cast<const T *>(buffer), nElts, bHasNoData,
+                bHasNoData ? static_cast<T>(dfNoDataValue) : 0);
+        }
+        case GDT_UInt64:
+        {
+            using T = uint64_t;
+            bHasNoData = bHasNoData && GDALIsValueExactAs<T>(dfNoDataValue);
+            return extremum_element<T, IS_MAX>(
+                static_cast<const T *>(buffer), nElts, bHasNoData,
+                bHasNoData ? static_cast<T>(dfNoDataValue) : 0);
+        }
+        case GDT_Float32:
+        {
+            using T = float;
+            bHasNoData = bHasNoData && GDALIsValueExactAs<T>(dfNoDataValue);
+            return extremum_element<T, IS_MAX>(
+                static_cast<const T *>(buffer), nElts, bHasNoData,
+                bHasNoData ? static_cast<T>(dfNoDataValue) : 0);
+        }
+        case GDT_Float64:
+        {
+            using T = double;
+            bHasNoData = bHasNoData && GDALIsValueExactAs<T>(dfNoDataValue);
+            return extremum_element<T, IS_MAX>(
+                static_cast<const T *>(buffer), nElts, bHasNoData,
+                bHasNoData ? static_cast<T>(dfNoDataValue) : 0);
+        }
+        default:
+            break;
+    }
+    CPLError(CE_Failure, CPLE_NotSupported,
+             "%s not supported for this data type.", __FUNCTION__);
+    return 0;
+}
+
+}  // namespace detail
+
+/************************************************************************/
+/*                            max_element()                             */
+/************************************************************************/
+
+/** Return the index of the element where the maximum value is hit.
+ *
+ * If it is hit in several locations, it is not specified which one will be
+ * returned.
+ *
+ * @param buffer Vector of nElts elements of type eDT.
+ * @param nElts Number of elements in buffer.
+ * @param eDT Data type of the elements of buffer.
+ * @param bHasNoData Whether dfNoDataValue is valid.
+ * @param dfNoDataValue Nodata value, only taken into account if bHasNoData == true
+ *
+ * @since GDAL 3.11
+ */
+inline size_t max_element(const void *buffer, size_t nElts, GDALDataType eDT,
+                          bool bHasNoData, double dfNoDataValue)
+{
+    return detail::extremum_element<true>(buffer, nElts, eDT, bHasNoData,
+                                          dfNoDataValue);
+}
+
+/************************************************************************/
+/*                            min_element()                             */
+/************************************************************************/
+
+/** Return the index of the element where the minimum value is hit.
+ *
+ * If it is hit in several locations, it is not specified which one will be
+ * returned.
+ *
+ * @param buffer Vector of nElts elements of type eDT.
+ * @param nElts Number of elements in buffer.
+ * @param eDT Data type of the elements of buffer.
+ * @param bHasNoData Whether dfNoDataValue is valid.
+ * @param dfNoDataValue Nodata value, only taken into account if bHasNoData == true
+ *
+ * @since GDAL 3.11
+ */
+inline size_t min_element(const void *buffer, size_t nElts, GDALDataType eDT,
+                          bool bHasNoData, double dfNoDataValue)
+{
+    return detail::extremum_element<false>(buffer, nElts, eDT, bHasNoData,
+                                           dfNoDataValue);
+}
+
+namespace detail
+{
+
+#ifdef NOT_EFFICIENT
+
+/************************************************************************/
+/*                         minmax_element()                             */
+/************************************************************************/
+
+template <class T>
+std::pair<size_t, size_t> minmax_element(const T *v, size_t size, T noDataValue)
+{
+    static_assert(!(std::is_floating_point_v<T>));
+    if (size == 0)
+        return std::pair(0, 0);
+    size_t idx_of_min = 0;
+    size_t idx_of_max = 0;
+    T vmin = v[0];
+    T vmax = v[0];
+    bool extremum_is_nodata = vmin == noDataValue;
+    size_t i = 1;
+    for (; i < size; ++i)
+    {
+        if (v[i] != noDataValue && (v[i] < vmin || extremum_is_nodata))
+        {
+            vmin = v[i];
+            idx_of_min = i;
+            extremum_is_nodata = false;
+        }
+        if (v[i] != noDataValue && (v[i] > vmax || extremum_is_nodata))
+        {
+            vmax = v[i];
+            idx_of_max = i;
+            extremum_is_nodata = false;
+        }
+    }
+    return std::pair(idx_of_min, idx_of_max);
+}
+
+template <class T>
+std::pair<size_t, size_t> minmax_element(const T *v, size_t size)
+{
+    static_assert(!(std::is_floating_point_v<T>));
+    if (size == 0)
+        return std::pair(0, 0);
+    size_t idx_of_min = 0;
+    size_t idx_of_max = 0;
+    T vmin = v[0];
+    T vmax = v[0];
+    size_t i = 1;
+    for (; i < size; ++i)
+    {
+        if (v[i] < vmin)
+        {
+            vmin = v[i];
+            idx_of_min = i;
+        }
+        if (v[i] > vmax)
+        {
+            vmax = v[i];
+            idx_of_max = i;
+        }
+    }
+    return std::pair(idx_of_min, idx_of_max);
+}
+
+template <class T>
+inline std::pair<size_t, size_t> minmax_element_with_nan(const T *v,
+                                                         size_t size)
+{
+    if (size == 0)
+        return std::pair(0, 0);
+    size_t idx_of_min = 0;
+    size_t idx_of_max = 0;
+    T vmin = v[0];
+    T vmax = v[0];
+    size_t i = 1;
+    if (std::isnan(v[0]))
+    {
+        for (; i < size; ++i)
+        {
+            if (!std::isnan(v[i]))
+            {
+                vmin = v[i];
+                idx_of_min = i;
+                vmax = v[i];
+                idx_of_max = i;
+                break;
+            }
+        }
+    }
+    for (; i < size; ++i)
+    {
+        if (v[i] < vmin)
+        {
+            vmin = v[i];
+            idx_of_min = i;
+        }
+        if (v[i] > vmax)
+        {
+            vmax = v[i];
+            idx_of_max = i;
+        }
+    }
+    return std::pair(idx_of_min, idx_of_max);
+}
+
+template <>
+std::pair<size_t, size_t> minmax_element<float>(const float *v, size_t size)
+{
+    return minmax_element_with_nan<float>(v, size);
+}
+
+template <>
+std::pair<size_t, size_t> minmax_element<double>(const double *v, size_t size)
+{
+    return minmax_element_with_nan<double>(v, size);
+}
+
+template <class T>
+inline std::pair<size_t, size_t> minmax_element(const T *buffer, size_t size,
+                                                bool bHasNoData, T noDataValue)
+{
+    if (bHasNoData)
+    {
+        return minmax_element<T>(buffer, size, noDataValue);
+    }
+    else
+    {
+        return minmax_element<T>(buffer, size);
+    }
+}
+#else
+
+/************************************************************************/
+/*                         minmax_element()                             */
+/************************************************************************/
+
+template <class T>
+inline std::pair<size_t, size_t> minmax_element(const T *buffer, size_t size,
+                                                bool bHasNoData, T noDataValue)
+{
+#ifdef NOT_EFFICIENT
+    if (bHasNoData)
+    {
+        return minmax_element<T>(buffer, size, noDataValue);
+    }
+    else
+    {
+        return minmax_element<T>(buffer, size);
+        //auto [imin, imax] = std::minmax_element(buffer, buffer + size);
+        //return std::pair(imin - buffer, imax - buffer);
+    }
+#else
+    // Using separately min and max is more efficient than computing them
+    // within the same loop
+    return std::pair(
+        extremum_element<T, false>(buffer, size, bHasNoData, noDataValue),
+        extremum_element<T, true>(buffer, size, bHasNoData, noDataValue));
+#endif
+}
+#endif
+
+}  // namespace detail
+
+/************************************************************************/
+/*                          minmax_element()                            */
+/************************************************************************/
+
+/** Return the index of the elements where the minimum and maximum values are hit.
+ *
+ * If they are hit in several locations, it is not specified which one will be
+ * returned (contrary to std::minmax_element).
+ *
+ * @param buffer Vector of nElts elements of type eDT.
+ * @param nElts Number of elements in buffer.
+ * @param eDT Data type of the elements of buffer.
+ * @param bHasNoData Whether dfNoDataValue is valid.
+ * @param dfNoDataValue Nodata value, only taken into account if bHasNoData == true
+ *
+ * @since GDAL 3.11
+ */
+inline std::pair<size_t, size_t> minmax_element(const void *buffer,
+                                                size_t nElts, GDALDataType eDT,
+                                                bool bHasNoData,
+                                                double dfNoDataValue)
+{
+    switch (eDT)
+    {
+        case GDT_Int8:
+        {
+            using T = int8_t;
+            bHasNoData = bHasNoData && GDALIsValueExactAs<T>(dfNoDataValue);
+            return detail::minmax_element<T>(
+                static_cast<const T *>(buffer), nElts, bHasNoData,
+                bHasNoData ? static_cast<T>(dfNoDataValue) : 0);
+        }
+        case GDT_Byte:
+        {
+            using T = uint8_t;
+            bHasNoData = bHasNoData && GDALIsValueExactAs<T>(dfNoDataValue);
+            return detail::minmax_element<T>(
+                static_cast<const T *>(buffer), nElts, bHasNoData,
+                bHasNoData ? static_cast<T>(dfNoDataValue) : 0);
+        }
+        case GDT_Int16:
+        {
+            using T = int16_t;
+            bHasNoData = bHasNoData && GDALIsValueExactAs<T>(dfNoDataValue);
+            return detail::minmax_element<T>(
+                static_cast<const T *>(buffer), nElts, bHasNoData,
+                bHasNoData ? static_cast<T>(dfNoDataValue) : 0);
+        }
+        case GDT_UInt16:
+        {
+            using T = uint16_t;
+            bHasNoData = bHasNoData && GDALIsValueExactAs<T>(dfNoDataValue);
+            return detail::minmax_element<T>(
+                static_cast<const T *>(buffer), nElts, bHasNoData,
+                bHasNoData ? static_cast<T>(dfNoDataValue) : 0);
+        }
+        case GDT_Int32:
+        {
+            using T = int32_t;
+            bHasNoData = bHasNoData && GDALIsValueExactAs<T>(dfNoDataValue);
+            return detail::minmax_element<T>(
+                static_cast<const T *>(buffer), nElts, bHasNoData,
+                bHasNoData ? static_cast<T>(dfNoDataValue) : 0);
+        }
+        case GDT_UInt32:
+        {
+            using T = uint32_t;
+            bHasNoData = bHasNoData && GDALIsValueExactAs<T>(dfNoDataValue);
+            return detail::minmax_element<T>(
+                static_cast<const T *>(buffer), nElts, bHasNoData,
+                bHasNoData ? static_cast<T>(dfNoDataValue) : 0);
+        }
+        case GDT_Int64:
+        {
+            using T = int64_t;
+            bHasNoData = bHasNoData && GDALIsValueExactAs<T>(dfNoDataValue);
+            return detail::minmax_element<T>(
+                static_cast<const T *>(buffer), nElts, bHasNoData,
+                bHasNoData ? static_cast<T>(dfNoDataValue) : 0);
+        }
+        case GDT_UInt64:
+        {
+            using T = uint64_t;
+            bHasNoData = bHasNoData && GDALIsValueExactAs<T>(dfNoDataValue);
+            return detail::minmax_element<T>(
+                static_cast<const T *>(buffer), nElts, bHasNoData,
+                bHasNoData ? static_cast<T>(dfNoDataValue) : 0);
+        }
+        case GDT_Float32:
+        {
+            using T = float;
+            bHasNoData = bHasNoData && GDALIsValueExactAs<T>(dfNoDataValue);
+            return detail::minmax_element<T>(
+                static_cast<const T *>(buffer), nElts, bHasNoData,
+                bHasNoData ? static_cast<T>(dfNoDataValue) : 0);
+        }
+        case GDT_Float64:
+        {
+            using T = double;
+            bHasNoData = bHasNoData && GDALIsValueExactAs<T>(dfNoDataValue);
+            return detail::minmax_element<T>(
+                static_cast<const T *>(buffer), nElts, bHasNoData,
+                bHasNoData ? static_cast<T>(dfNoDataValue) : 0);
+        }
+        default:
+            break;
+    }
+    CPLError(CE_Failure, CPLE_NotSupported,
+             "%s not supported for this data type.", __FUNCTION__);
+    return std::pair(0, 0);
+}
+
+}  // namespace GDAL_MINMAXELT_NS
+
+#endif  // GDAL_MINMAX_ELEMENT_INCLUDED

--- a/gcore/gdal_minmax_element.hpp
+++ b/gcore/gdal_minmax_element.hpp
@@ -43,29 +43,6 @@
 #endif
 
 #include "gdal_priv_templates.hpp"
-#if GDAL_VERSION < GDAL_COMPUTE_VERSION(3, 10, 0)
-// For vendoring in other applications
-namespace GDAL_MINMAXELT_NS
-{
-template <class T> inline bool GDALIsValueExactAs(double dfValue)
-{
-    return GDALIsValueInRange<T>(dfValue) &&
-           static_cast<double>(static_cast<T>(dfValue)) == dfValue;
-}
-
-template <> inline bool GDALIsValueExactAs<float>(double dfValue)
-{
-    return std::isnan(dfValue) ||
-           (GDALIsValueInRange<float>(dfValue) &&
-            static_cast<double>(static_cast<float>(dfValue)) == dfValue);
-}
-
-template <> inline bool GDALIsValueExactAs<double>(double)
-{
-    return true;
-}
-}  // namespace GDAL_MINMAXELT_NS
-#endif
 
 namespace GDAL_MINMAXELT_NS
 {
@@ -989,6 +966,7 @@ size_t extremum_element(const void *buffer, size_t nElts, GDALDataType eDT,
 {
     switch (eDT)
     {
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 7, 0)
         case GDT_Int8:
         {
             using T = int8_t;
@@ -997,6 +975,7 @@ size_t extremum_element(const void *buffer, size_t nElts, GDALDataType eDT,
                 static_cast<const T *>(buffer), nElts, bHasNoData,
                 bHasNoData ? static_cast<T>(dfNoDataValue) : 0);
         }
+#endif
         case GDT_Byte:
         {
             using T = uint8_t;
@@ -1037,6 +1016,7 @@ size_t extremum_element(const void *buffer, size_t nElts, GDALDataType eDT,
                 static_cast<const T *>(buffer), nElts, bHasNoData,
                 bHasNoData ? static_cast<T>(dfNoDataValue) : 0);
         }
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 5, 0)
         case GDT_Int64:
         {
             using T = int64_t;
@@ -1053,6 +1033,7 @@ size_t extremum_element(const void *buffer, size_t nElts, GDALDataType eDT,
                 static_cast<const T *>(buffer), nElts, bHasNoData,
                 bHasNoData ? static_cast<T>(dfNoDataValue) : 0);
         }
+#endif
         case GDT_Float32:
         {
             using T = float;
@@ -1330,6 +1311,7 @@ inline std::pair<size_t, size_t> minmax_element(const void *buffer,
 {
     switch (eDT)
     {
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 7, 0)
         case GDT_Int8:
         {
             using T = int8_t;
@@ -1338,6 +1320,7 @@ inline std::pair<size_t, size_t> minmax_element(const void *buffer,
                 static_cast<const T *>(buffer), nElts, bHasNoData,
                 bHasNoData ? static_cast<T>(dfNoDataValue) : 0);
         }
+#endif
         case GDT_Byte:
         {
             using T = uint8_t;
@@ -1378,6 +1361,7 @@ inline std::pair<size_t, size_t> minmax_element(const void *buffer,
                 static_cast<const T *>(buffer), nElts, bHasNoData,
                 bHasNoData ? static_cast<T>(dfNoDataValue) : 0);
         }
+#if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(3, 5, 0)
         case GDT_Int64:
         {
             using T = int64_t;
@@ -1394,6 +1378,7 @@ inline std::pair<size_t, size_t> minmax_element(const void *buffer,
                 static_cast<const T *>(buffer), nElts, bHasNoData,
                 bHasNoData ? static_cast<T>(dfNoDataValue) : 0);
         }
+#endif
         case GDT_Float32:
         {
             using T = float;

--- a/perftests/CMakeLists.txt
+++ b/perftests/CMakeLists.txt
@@ -10,3 +10,7 @@ target_link_libraries(bench_ogr_batch PRIVATE $<TARGET_NAME:${GDAL_LIB_TARGET_NA
 add_executable(bench_ogr_c_api bench_ogr_c_api.cpp)
 gdal_standard_includes(bench_ogr_c_api)
 target_link_libraries(bench_ogr_c_api PRIVATE $<TARGET_NAME:${GDAL_LIB_TARGET_NAME}>)
+
+add_executable(testperf_gdal_minmax_element testperf_gdal_minmax_element.cpp)
+gdal_standard_includes(testperf_gdal_minmax_element)
+target_link_libraries(testperf_gdal_minmax_element PRIVATE $<TARGET_NAME:${GDAL_LIB_TARGET_NAME}>)

--- a/perftests/CMakeLists.txt
+++ b/perftests/CMakeLists.txt
@@ -1,5 +1,18 @@
 include(GdalTestTarget)
 
+include(GdalSetRuntimeEnv)
+gdal_set_runtime_env(TEST_ENV)
+
+if (MINGW)
+  list(APPEND TEST_ENV SKIP_MEM_INTENSIVE_TEST=YES)
+endif ()
+
+if (WIN32)
+  # If running GDAL as a CustomBuild Command os MSBuild, "ERROR bla:" is considered as failing the job. This is rarely
+  # the intended behavior
+  list(APPEND TEST_ENV "CPL_ERROR_SEPARATOR=\\;")
+endif ()
+
 gdal_test_target(testperfcopywords testperfcopywords.cpp)
 gdal_test_target(testperfdeinterleave testperfdeinterleave.cpp)
 
@@ -11,6 +24,6 @@ add_executable(bench_ogr_c_api bench_ogr_c_api.cpp)
 gdal_standard_includes(bench_ogr_c_api)
 target_link_libraries(bench_ogr_c_api PRIVATE $<TARGET_NAME:${GDAL_LIB_TARGET_NAME}>)
 
-add_executable(testperf_gdal_minmax_element testperf_gdal_minmax_element.cpp)
-gdal_standard_includes(testperf_gdal_minmax_element)
-target_link_libraries(testperf_gdal_minmax_element PRIVATE $<TARGET_NAME:${GDAL_LIB_TARGET_NAME}>)
+gdal_test_target(testperf_gdal_minmax_element testperf_gdal_minmax_element.cpp)
+add_test(NAME testperf_gdal_minmax_element COMMAND testperf_gdal_minmax_element)
+set_property(TEST testperf_gdal_minmax_element PROPERTY ENVIRONMENT "${TEST_ENV}")

--- a/perftests/testperf_gdal_minmax_element.cpp
+++ b/perftests/testperf_gdal_minmax_element.cpp
@@ -88,10 +88,10 @@ int main(int /* argc */, char * /* argv */[])
             {
                 idx += static_cast<int>(std::distance(
                     x.begin(), std::min_element(x.begin(), x.end(),
-                                                [](T x, T y) {
-                                                    return y == 0   ? true
-                                                           : x == 0 ? false
-                                                                    : x < y;
+                                                [](T a, T b) {
+                                                    return b == 0   ? true
+                                                           : a == 0 ? false
+                                                                    : a < b;
                                                 })));
             }
             idx /= N_ITERS;
@@ -156,10 +156,10 @@ int main(int /* argc */, char * /* argv */[])
             {
                 idx += static_cast<int>(std::distance(
                     x.begin(), std::min_element(x.begin(), x.end(),
-                                                [](T x, T y) {
-                                                    return y == 0   ? true
-                                                           : x == 0 ? false
-                                                                    : x < y;
+                                                [](T a, T b) {
+                                                    return b == 0   ? true
+                                                           : a == 0 ? false
+                                                                    : a < b;
                                                 })));
             }
             idx /= N_ITERS;
@@ -224,10 +224,10 @@ int main(int /* argc */, char * /* argv */[])
             {
                 idx += static_cast<int>(std::distance(
                     x.begin(), std::min_element(x.begin(), x.end(),
-                                                [](T x, T y) {
-                                                    return y == 0   ? true
-                                                           : x == 0 ? false
-                                                                    : x < y;
+                                                [](T a, T b) {
+                                                    return b == 0   ? true
+                                                           : a == 0 ? false
+                                                                    : a < b;
                                                 })));
             }
             idx /= N_ITERS;
@@ -292,10 +292,10 @@ int main(int /* argc */, char * /* argv */[])
             {
                 idx += static_cast<int>(std::distance(
                     x.begin(), std::min_element(x.begin(), x.end(),
-                                                [](T x, T y) {
-                                                    return y == 0   ? true
-                                                           : x == 0 ? false
-                                                                    : x < y;
+                                                [](T a, T b) {
+                                                    return b == 0   ? true
+                                                           : a == 0 ? false
+                                                                    : a < b;
                                                 })));
             }
             idx /= N_ITERS;
@@ -360,10 +360,10 @@ int main(int /* argc */, char * /* argv */[])
             {
                 idx += static_cast<int>(std::distance(
                     x.begin(), std::min_element(x.begin(), x.end(),
-                                                [](T x, T y) {
-                                                    return y == 0   ? true
-                                                           : x == 0 ? false
-                                                                    : x < y;
+                                                [](T a, T b) {
+                                                    return b == 0   ? true
+                                                           : a == 0 ? false
+                                                                    : a < b;
                                                 })));
             }
             idx /= N_ITERS;
@@ -428,10 +428,10 @@ int main(int /* argc */, char * /* argv */[])
             {
                 idx += static_cast<int>(std::distance(
                     x.begin(), std::min_element(x.begin(), x.end(),
-                                                [](T x, T y) {
-                                                    return y == 0   ? true
-                                                           : x == 0 ? false
-                                                                    : x < y;
+                                                [](T a, T b) {
+                                                    return b == 0   ? true
+                                                           : a == 0 ? false
+                                                                    : a < b;
                                                 })));
             }
             idx /= N_ITERS;
@@ -470,11 +470,11 @@ int main(int /* argc */, char * /* argv */[])
             {
                 idx += static_cast<int>(std::distance(
                     x.begin(), std::min_element(x.begin(), x.end(),
-                                                [](float x, float y) {
-                                                    return std::isnan(y) ? true
-                                                           : std::isnan(x)
+                                                [](T a, T b) {
+                                                    return std::isnan(b) ? true
+                                                           : std::isnan(a)
                                                                ? false
-                                                               : x < y;
+                                                               : a < b;
                                                 })));
             }
             idx /= N_ITERS;
@@ -504,14 +504,14 @@ int main(int /* argc */, char * /* argv */[])
             {
                 idx += static_cast<int>(std::distance(
                     x.begin(), std::min_element(x.begin(), x.end(),
-                                                [](double x, double y)
+                                                [](T a, T b)
                                                 {
-                                                    return std::isnan(y) ? true
-                                                           : std::isnan(x)
+                                                    return std::isnan(b) ? true
+                                                           : std::isnan(a)
                                                                ? false
-                                                           : y == 0 ? true
-                                                           : x == 0 ? false
-                                                                    : x < y;
+                                                           : b == 0 ? true
+                                                           : a == 0 ? false
+                                                                    : a < b;
                                                 })));
             }
             idx /= N_ITERS;
@@ -576,10 +576,10 @@ int main(int /* argc */, char * /* argv */[])
             {
                 idx += static_cast<int>(std::distance(
                     x.begin(), std::min_element(x.begin(), x.end(),
-                                                [](T x, T y) {
-                                                    return y == 0   ? true
-                                                           : x == 0 ? false
-                                                                    : x < y;
+                                                [](T a, T b) {
+                                                    return b == 0   ? true
+                                                           : a == 0 ? false
+                                                                    : a < b;
                                                 })));
             }
             idx /= N_ITERS;
@@ -618,11 +618,11 @@ int main(int /* argc */, char * /* argv */[])
             {
                 idx += static_cast<int>(std::distance(
                     x.begin(), std::min_element(x.begin(), x.end(),
-                                                [](double x, double y) {
-                                                    return std::isnan(y) ? true
-                                                           : std::isnan(x)
+                                                [](T a, T b) {
+                                                    return std::isnan(b) ? true
+                                                           : std::isnan(a)
                                                                ? false
-                                                               : x < y;
+                                                               : a < b;
                                                 })));
             }
             idx /= N_ITERS;
@@ -652,14 +652,14 @@ int main(int /* argc */, char * /* argv */[])
             {
                 idx += static_cast<int>(std::distance(
                     x.begin(), std::min_element(x.begin(), x.end(),
-                                                [](double x, double y)
+                                                [](T a, T b)
                                                 {
-                                                    return std::isnan(y) ? true
-                                                           : std::isnan(x)
+                                                    return std::isnan(b) ? true
+                                                           : std::isnan(a)
                                                                ? false
-                                                           : y == 0 ? true
-                                                           : x == 0 ? false
-                                                                    : x < y;
+                                                           : b == 0 ? true
+                                                           : a == 0 ? false
+                                                                    : a < b;
                                                 })));
             }
             idx /= N_ITERS;
@@ -724,10 +724,10 @@ int main(int /* argc */, char * /* argv */[])
             {
                 idx += static_cast<int>(std::distance(
                     x.begin(), std::min_element(x.begin(), x.end(),
-                                                [](T x, T y) {
-                                                    return y == 0   ? true
-                                                           : x == 0 ? false
-                                                                    : x < y;
+                                                [](T a, T b) {
+                                                    return b == 0   ? true
+                                                           : a == 0 ? false
+                                                                    : a < b;
                                                 })));
             }
             idx /= N_ITERS;

--- a/perftests/testperf_gdal_minmax_element.cpp
+++ b/perftests/testperf_gdal_minmax_element.cpp
@@ -51,7 +51,7 @@ int main(int /* argc */, char * /* argv */[])
                     gdal::min_element(x.data(), x.size(), eDT, false, 0));
             }
             idx /= N_ITERS;
-            printf("min at idx %d\n", idx);
+            printf("min at idx %d (optimized)\n", idx);
             auto end = std::chrono::steady_clock::now();
             printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
         }
@@ -77,7 +77,27 @@ int main(int /* argc */, char * /* argv */[])
                     gdal::min_element(x.data(), x.size(), eDT, true, 0));
             }
             idx /= N_ITERS;
-            printf("min at idx %d(nodata case)\n", idx);
+            printf("min at idx %d (nodata case, optimized)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(std::distance(
+                    x.begin(), std::min_element(x.begin(), x.end(),
+                                                [](T x, T y) {
+                                                    return y == 0   ? true
+                                                           : x == 0 ? false
+                                                                    : x < y;
+                                                })));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d (nodata case, using std::min_element with "
+                   "nodata aware comparison)\n",
+                   idx);
             auto end = std::chrono::steady_clock::now();
             printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
         }
@@ -99,7 +119,7 @@ int main(int /* argc */, char * /* argv */[])
                     gdal::min_element(x.data(), x.size(), eDT, false, 0));
             }
             idx /= N_ITERS;
-            printf("min at idx %d\n", idx);
+            printf("min at idx %d (optimized)\n", idx);
             auto end = std::chrono::steady_clock::now();
             printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
         }
@@ -125,7 +145,27 @@ int main(int /* argc */, char * /* argv */[])
                     gdal::min_element(x.data(), x.size(), eDT, true, 0));
             }
             idx /= N_ITERS;
-            printf("min at idx %d(nodata case)\n", idx);
+            printf("min at idx %d (nodata case, optimized)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(std::distance(
+                    x.begin(), std::min_element(x.begin(), x.end(),
+                                                [](T x, T y) {
+                                                    return y == 0   ? true
+                                                           : x == 0 ? false
+                                                                    : x < y;
+                                                })));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d (nodata case, using std::min_element with "
+                   "nodata aware comparison)\n",
+                   idx);
             auto end = std::chrono::steady_clock::now();
             printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
         }
@@ -147,7 +187,7 @@ int main(int /* argc */, char * /* argv */[])
                     gdal::min_element(x.data(), x.size(), eDT, false, 0));
             }
             idx /= N_ITERS;
-            printf("min at idx %d\n", idx);
+            printf("min at idx %d (optimized)\n", idx);
             auto end = std::chrono::steady_clock::now();
             printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
         }
@@ -173,7 +213,27 @@ int main(int /* argc */, char * /* argv */[])
                     gdal::min_element(x.data(), x.size(), eDT, true, 0));
             }
             idx /= N_ITERS;
-            printf("min at idx %d(nodata case)\n", idx);
+            printf("min at idx %d (nodata case, optimized)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(std::distance(
+                    x.begin(), std::min_element(x.begin(), x.end(),
+                                                [](T x, T y) {
+                                                    return y == 0   ? true
+                                                           : x == 0 ? false
+                                                                    : x < y;
+                                                })));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d (nodata case, using std::min_element with "
+                   "nodata aware comparison)\n",
+                   idx);
             auto end = std::chrono::steady_clock::now();
             printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
         }
@@ -195,7 +255,7 @@ int main(int /* argc */, char * /* argv */[])
                     gdal::min_element(x.data(), x.size(), eDT, false, 0));
             }
             idx /= N_ITERS;
-            printf("min at idx %d\n", idx);
+            printf("min at idx %d (optimized)\n", idx);
             auto end = std::chrono::steady_clock::now();
             printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
         }
@@ -221,7 +281,27 @@ int main(int /* argc */, char * /* argv */[])
                     gdal::min_element(x.data(), x.size(), eDT, true, 0));
             }
             idx /= N_ITERS;
-            printf("min at idx %d(nodata case)\n", idx);
+            printf("min at idx %d (nodata case, optimized)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(std::distance(
+                    x.begin(), std::min_element(x.begin(), x.end(),
+                                                [](T x, T y) {
+                                                    return y == 0   ? true
+                                                           : x == 0 ? false
+                                                                    : x < y;
+                                                })));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d (nodata case, using std::min_element with "
+                   "nodata aware comparison)\n",
+                   idx);
             auto end = std::chrono::steady_clock::now();
             printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
         }
@@ -243,7 +323,7 @@ int main(int /* argc */, char * /* argv */[])
                     gdal::min_element(x.data(), x.size(), eDT, false, 0));
             }
             idx /= N_ITERS;
-            printf("min at idx %d\n", idx);
+            printf("min at idx %d (optimized)\n", idx);
             auto end = std::chrono::steady_clock::now();
             printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
         }
@@ -269,7 +349,27 @@ int main(int /* argc */, char * /* argv */[])
                     gdal::min_element(x.data(), x.size(), eDT, true, 0));
             }
             idx /= N_ITERS;
-            printf("min at idx %d(nodata case)\n", idx);
+            printf("min at idx %d (nodata case, optimized)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(std::distance(
+                    x.begin(), std::min_element(x.begin(), x.end(),
+                                                [](T x, T y) {
+                                                    return y == 0   ? true
+                                                           : x == 0 ? false
+                                                                    : x < y;
+                                                })));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d (nodata case, using std::min_element with "
+                   "nodata aware comparison)\n",
+                   idx);
             auto end = std::chrono::steady_clock::now();
             printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
         }
@@ -291,7 +391,7 @@ int main(int /* argc */, char * /* argv */[])
                     gdal::min_element(x.data(), x.size(), eDT, false, 0));
             }
             idx /= N_ITERS;
-            printf("min at idx %d\n", idx);
+            printf("min at idx %d (optimized)\n", idx);
             auto end = std::chrono::steady_clock::now();
             printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
         }
@@ -317,7 +417,27 @@ int main(int /* argc */, char * /* argv */[])
                     gdal::min_element(x.data(), x.size(), eDT, true, 0));
             }
             idx /= N_ITERS;
-            printf("min at idx %d(nodata case)\n", idx);
+            printf("min at idx %d (nodata case, optimized)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(std::distance(
+                    x.begin(), std::min_element(x.begin(), x.end(),
+                                                [](T x, T y) {
+                                                    return y == 0   ? true
+                                                           : x == 0 ? false
+                                                                    : x < y;
+                                                })));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d (nodata case, using std::min_element with "
+                   "nodata aware comparison)\n",
+                   idx);
             auto end = std::chrono::steady_clock::now();
             printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
         }
@@ -326,7 +446,7 @@ int main(int /* argc */, char * /* argv */[])
     {
         using T = float;
         constexpr GDALDataType eDT = GDT_Float32;
-        printf("float:\n");
+        printf("float (*with* NaN):\n");
         std::vector<T> x;
         x.resize(SIZE);
         randomFill(x.data(), x.size());
@@ -339,7 +459,7 @@ int main(int /* argc */, char * /* argv */[])
                     gdal::min_element(x.data(), x.size(), eDT, false, 0));
             }
             idx /= N_ITERS;
-            printf("min at idx %d\n", idx);
+            printf("min at idx %d (optimized)\n", idx);
             auto end = std::chrono::steady_clock::now();
             printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
         }
@@ -373,7 +493,31 @@ int main(int /* argc */, char * /* argv */[])
                     gdal::min_element(x.data(), x.size(), eDT, true, 0));
             }
             idx /= N_ITERS;
-            printf("min at idx %d(nodata case)\n", idx);
+            printf("min at idx %d (nodata case, optimized)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(std::distance(
+                    x.begin(), std::min_element(x.begin(), x.end(),
+                                                [](double x, double y)
+                                                {
+                                                    return std::isnan(y) ? true
+                                                           : std::isnan(x)
+                                                               ? false
+                                                           : y == 0 ? true
+                                                           : x == 0 ? false
+                                                                    : x < y;
+                                                })));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d (nodata case, using std::min_element with "
+                   "nodata aware and NaN aware comparison)\n",
+                   idx);
             auto end = std::chrono::steady_clock::now();
             printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
         }
@@ -395,7 +539,7 @@ int main(int /* argc */, char * /* argv */[])
                     gdal::min_element(x.data(), x.size(), eDT, false, 0));
             }
             idx /= N_ITERS;
-            printf("min at idx %d\n", idx);
+            printf("min at idx %d (optimized)\n", idx);
             auto end = std::chrono::steady_clock::now();
             printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
         }
@@ -421,7 +565,27 @@ int main(int /* argc */, char * /* argv */[])
                     gdal::min_element(x.data(), x.size(), eDT, true, 0));
             }
             idx /= N_ITERS;
-            printf("min at idx %d(nodata case)\n", idx);
+            printf("min at idx %d (nodata case, optimized)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(std::distance(
+                    x.begin(), std::min_element(x.begin(), x.end(),
+                                                [](T x, T y) {
+                                                    return y == 0   ? true
+                                                           : x == 0 ? false
+                                                                    : x < y;
+                                                })));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d (nodata case, using std::min_element with "
+                   "nodata aware comparison)\n",
+                   idx);
             auto end = std::chrono::steady_clock::now();
             printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
         }
@@ -430,7 +594,7 @@ int main(int /* argc */, char * /* argv */[])
     {
         using T = double;
         constexpr GDALDataType eDT = GDT_Float64;
-        printf("double:\n");
+        printf("double (*with* NaN):\n");
         std::vector<T> x;
         x.resize(SIZE);
         randomFill(x.data(), x.size());
@@ -443,7 +607,7 @@ int main(int /* argc */, char * /* argv */[])
                     gdal::min_element(x.data(), x.size(), eDT, false, 0));
             }
             idx /= N_ITERS;
-            printf("min at idx %d\n", idx);
+            printf("min at idx %d (optimized)\n", idx);
             auto end = std::chrono::steady_clock::now();
             printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
         }
@@ -477,7 +641,31 @@ int main(int /* argc */, char * /* argv */[])
                     gdal::min_element(x.data(), x.size(), eDT, true, 0));
             }
             idx /= N_ITERS;
-            printf("min at idx %d(nodata case)\n", idx);
+            printf("min at idx %d (nodata case, optimized)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(std::distance(
+                    x.begin(), std::min_element(x.begin(), x.end(),
+                                                [](double x, double y)
+                                                {
+                                                    return std::isnan(y) ? true
+                                                           : std::isnan(x)
+                                                               ? false
+                                                           : y == 0 ? true
+                                                           : x == 0 ? false
+                                                                    : x < y;
+                                                })));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d (nodata case, using std::min_element with "
+                   "nodata aware and NaN aware comparison)\n",
+                   idx);
             auto end = std::chrono::steady_clock::now();
             printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
         }
@@ -499,7 +687,7 @@ int main(int /* argc */, char * /* argv */[])
                     gdal::min_element(x.data(), x.size(), eDT, false, 0));
             }
             idx /= N_ITERS;
-            printf("min at idx %d\n", idx);
+            printf("min at idx %d (optimized)\n", idx);
             auto end = std::chrono::steady_clock::now();
             printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
         }
@@ -525,7 +713,27 @@ int main(int /* argc */, char * /* argv */[])
                     gdal::min_element(x.data(), x.size(), eDT, true, 0));
             }
             idx /= N_ITERS;
-            printf("min at idx %d(nodata case)\n", idx);
+            printf("min at idx %d (nodata case, optimized)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(std::distance(
+                    x.begin(), std::min_element(x.begin(), x.end(),
+                                                [](T x, T y) {
+                                                    return y == 0   ? true
+                                                           : x == 0 ? false
+                                                                    : x < y;
+                                                })));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d (nodata case, using std::min_element with "
+                   "nodata aware comparison)\n",
+                   idx);
             auto end = std::chrono::steady_clock::now();
             printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
         }

--- a/perftests/testperf_gdal_minmax_element.cpp
+++ b/perftests/testperf_gdal_minmax_element.cpp
@@ -1,0 +1,534 @@
+/******************************************************************************
+ * Project:  GDAL Core
+ * Purpose:  Test performance of gdal_minmax_element.hpp
+ * Author:   Even Rouault, <even dot rouault at spatialys.com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2024, Even Rouault <even dot rouault at spatialys.com>
+ *
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#include "gdal_minmax_element.hpp"
+
+#include <chrono>
+#include <random>
+
+template <class T> void randomFill(T *v, size_t size, bool withNaN = true)
+{
+    std::random_device rd;
+    std::mt19937 gen{rd()};
+    std::normal_distribution<> dist{127, 30};
+    for (size_t i = 0; i < size; i++)
+    {
+        v[i] = static_cast<T>(dist(gen));
+        if constexpr (std::is_same<T, float>::value ||
+                      std::is_same<T, double>::value)
+        {
+            if (withNaN && (i == 0 || (i > 10 && ((i + 1) % 1024) <= 4)))
+                v[i] = std::numeric_limits<float>::quiet_NaN();
+        }
+    }
+}
+
+int main(int /* argc */, char * /* argv */[])
+{
+    constexpr size_t SIZE = 10 * 1000 * 1000 + 1;
+    constexpr int N_ITERS = 1;
+    {
+        using T = uint8_t;
+        constexpr GDALDataType eDT = GDT_Byte;
+        printf("uint8:\n");
+        std::vector<T> x;
+        x.resize(SIZE);
+        randomFill(x.data(), x.size());
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(
+                    gdal::min_element(x.data(), x.size(), eDT, false, 0));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(std::distance(
+                    x.begin(), std::min_element(x.begin(), x.end())));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d (using std::min_element)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(
+                    gdal::min_element(x.data(), x.size(), eDT, true, 0));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d(nodata case)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+    }
+    printf("--------------------\n");
+    {
+        using T = int8_t;
+        constexpr GDALDataType eDT = GDT_Int8;
+        printf("int8:\n");
+        std::vector<T> x;
+        x.resize(SIZE);
+        randomFill(x.data(), x.size());
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(
+                    gdal::min_element(x.data(), x.size(), eDT, false, 0));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(std::distance(
+                    x.begin(), std::min_element(x.begin(), x.end())));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d (using std::min_element)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(
+                    gdal::min_element(x.data(), x.size(), eDT, true, 0));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d(nodata case)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+    }
+    printf("--------------------\n");
+    {
+        using T = uint16_t;
+        constexpr GDALDataType eDT = GDT_UInt16;
+        printf("uint16:\n");
+        std::vector<T> x;
+        x.resize(SIZE);
+        randomFill(x.data(), x.size());
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(
+                    gdal::min_element(x.data(), x.size(), eDT, false, 0));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(std::distance(
+                    x.begin(), std::min_element(x.begin(), x.end())));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d (using std::min_element)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(
+                    gdal::min_element(x.data(), x.size(), eDT, true, 0));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d(nodata case)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+    }
+    printf("--------------------\n");
+    {
+        using T = int16_t;
+        constexpr GDALDataType eDT = GDT_Int16;
+        printf("int16:\n");
+        std::vector<T> x;
+        x.resize(SIZE);
+        randomFill(x.data(), x.size());
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(
+                    gdal::min_element(x.data(), x.size(), eDT, false, 0));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(std::distance(
+                    x.begin(), std::min_element(x.begin(), x.end())));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d (using std::min_element)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(
+                    gdal::min_element(x.data(), x.size(), eDT, true, 0));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d(nodata case)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+    }
+    printf("--------------------\n");
+    {
+        using T = uint32_t;
+        constexpr GDALDataType eDT = GDT_UInt32;
+        printf("uint32:\n");
+        std::vector<T> x;
+        x.resize(SIZE);
+        randomFill(x.data(), x.size());
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(
+                    gdal::min_element(x.data(), x.size(), eDT, false, 0));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(std::distance(
+                    x.begin(), std::min_element(x.begin(), x.end())));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d (using std::min_element)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(
+                    gdal::min_element(x.data(), x.size(), eDT, true, 0));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d(nodata case)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+    }
+    printf("--------------------\n");
+    {
+        using T = int32_t;
+        constexpr GDALDataType eDT = GDT_Int32;
+        printf("int32:\n");
+        std::vector<T> x;
+        x.resize(SIZE);
+        randomFill(x.data(), x.size());
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(
+                    gdal::min_element(x.data(), x.size(), eDT, false, 0));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(std::distance(
+                    x.begin(), std::min_element(x.begin(), x.end())));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d (using std::min_element)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(
+                    gdal::min_element(x.data(), x.size(), eDT, true, 0));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d(nodata case)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+    }
+    printf("--------------------\n");
+    {
+        using T = float;
+        constexpr GDALDataType eDT = GDT_Float32;
+        printf("float:\n");
+        std::vector<T> x;
+        x.resize(SIZE);
+        randomFill(x.data(), x.size());
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(
+                    gdal::min_element(x.data(), x.size(), eDT, false, 0));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(std::distance(
+                    x.begin(), std::min_element(x.begin(), x.end(),
+                                                [](float x, float y) {
+                                                    return std::isnan(y) ? true
+                                                           : std::isnan(x)
+                                                               ? false
+                                                               : x < y;
+                                                })));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d (using std::min_element with NaN aware "
+                   "comparison)\n",
+                   idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(
+                    gdal::min_element(x.data(), x.size(), eDT, true, 0));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d(nodata case)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+    }
+    printf("--------------------\n");
+    {
+        using T = float;
+        constexpr GDALDataType eDT = GDT_Float32;
+        printf("float (without NaN):\n");
+        std::vector<T> x;
+        x.resize(SIZE);
+        randomFill(x.data(), x.size(), false);
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(
+                    gdal::min_element(x.data(), x.size(), eDT, false, 0));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(std::distance(
+                    x.begin(), std::min_element(x.begin(), x.end())));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d (using std::min_element)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(
+                    gdal::min_element(x.data(), x.size(), eDT, true, 0));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d(nodata case)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+    }
+    printf("--------------------\n");
+    {
+        using T = double;
+        constexpr GDALDataType eDT = GDT_Float64;
+        printf("double:\n");
+        std::vector<T> x;
+        x.resize(SIZE);
+        randomFill(x.data(), x.size());
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(
+                    gdal::min_element(x.data(), x.size(), eDT, false, 0));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(std::distance(
+                    x.begin(), std::min_element(x.begin(), x.end(),
+                                                [](double x, double y) {
+                                                    return std::isnan(y) ? true
+                                                           : std::isnan(x)
+                                                               ? false
+                                                               : x < y;
+                                                })));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d (using std::min_element with NaN aware "
+                   "comparison)\n",
+                   idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(
+                    gdal::min_element(x.data(), x.size(), eDT, true, 0));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d(nodata case)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+    }
+    printf("--------------------\n");
+    {
+        using T = double;
+        constexpr GDALDataType eDT = GDT_Float64;
+        printf("double (without NaN):\n");
+        std::vector<T> x;
+        x.resize(SIZE);
+        randomFill(x.data(), x.size(), false);
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(
+                    gdal::min_element(x.data(), x.size(), eDT, false, 0));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(std::distance(
+                    x.begin(), std::min_element(x.begin(), x.end())));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d (using std::min_element)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+        {
+            auto start = std::chrono::steady_clock::now();
+            int idx = 0;
+            for (int i = 0; i < N_ITERS; ++i)
+            {
+                idx += static_cast<int>(
+                    gdal::min_element(x.data(), x.size(), eDT, true, 0));
+            }
+            idx /= N_ITERS;
+            printf("min at idx %d(nodata case)\n", idx);
+            auto end = std::chrono::steady_clock::now();
+            printf("-> elapsed=%d\n", static_cast<int>((end - start).count()));
+        }
+    }
+    return 0;
+}


### PR DESCRIPTION
Refs https://github.com/qgis/QGIS/pull/59285

NaN values are taken into account for float/double
Contains a SSE2 optimized version for int8/uint8/int16/uint16/int32/uint32/float/double in the no-nodata case (also taking into account NaN), which is about 10x times than std::min_element / std::max_element
Also add SSE2 optimization for uint8, int8, uint16, int16, uint32, int32, float and double nodata cases

<details>
<summary>
With gcc 9.4 (not so different with gcc 14.2.1, which is just slightly bit better for the "(nodata case, using std::min_element with nodata aware comparison)" cases for uint8/int8/uint16/int16, and significantly better for uint32/int32, but still behind our manual optimization ):
</summary>

```bash
$ (cd perftests && g++ -DGDAL_COMPILATION -std=c++17 -I../../port -I../port -I../../gcore -I../gcore -I../../ogr -O2 ../../perftests/testperf_gdal_minmax_element.cpp  -o testperf_gdal_minmax_element  -Wl,-rpath,/home/even/gdal/gdal/build_cmake ../libgdal.so.36.3.11.0  && ./testperf_gdal_minmax_element)
uint8:
min at idx 210901 (optimized)
-> elapsed=697957
min at idx 210901 (using std::min_element)
-> elapsed=19272114
min at idx 349447 (nodata case, optimized)
-> elapsed=963895
min at idx 349447 (nodata case, using std::min_element with nodata aware comparison)
-> elapsed=22531919
--------------------
int8:
min at idx 0 (optimized)
-> elapsed=639479
min at idx 0 (using std::min_element)
-> elapsed=16144175
min at idx 0 (nodata case, optimized)
-> elapsed=742246
min at idx 0 (nodata case, using std::min_element with nodata aware comparison)
-> elapsed=16512409
--------------------
uint16:
min at idx 17343 (optimized)
-> elapsed=1318264
min at idx 17343 (using std::min_element)
-> elapsed=16481840
min at idx 119863 (nodata case, optimized)
-> elapsed=1514535
min at idx 119863 (nodata case, using std::min_element with nodata aware comparison)
-> elapsed=18770894
--------------------
int16:
min at idx 5640996 (optimized)
-> elapsed=1276417
min at idx 5640996 (using std::min_element)
-> elapsed=16151810
min at idx 5640996 (nodata case, optimized)
-> elapsed=1418040
min at idx 5640996 (nodata case, using std::min_element with nodata aware comparison)
-> elapsed=16776584
--------------------
uint32:
min at idx 80377 (optimized)
-> elapsed=2818077
min at idx 80377 (using std::min_element)
-> elapsed=20091509
min at idx 673426 (nodata case, optimized)
-> elapsed=3454202
min at idx 673426 (nodata case, using std::min_element with nodata aware comparison)
-> elapsed=23202776
--------------------
int32:
min at idx 1218835 (optimized)
-> elapsed=2664621
min at idx 1218835 (using std::min_element)
-> elapsed=20121713
min at idx 1218835 (nodata case, optimized)
-> elapsed=3315202
min at idx 1218835 (nodata case, using std::min_element with nodata aware comparison)
-> elapsed=20406416
--------------------
float (*with* NaN):
min at idx 9397452 (optimized)
-> elapsed=2814904
min at idx 9397452 (using std::min_element with NaN aware comparison)
-> elapsed=26458223
min at idx 9397452 (nodata case, optimized)
-> elapsed=3359474
min at idx 9397452 (nodata case, using std::min_element with nodata aware and NaN aware comparison)
-> elapsed=31366822
--------------------
float (without NaN):
min at idx 2563536 (optimized)
-> elapsed=2776674
min at idx 2563536 (using std::min_element)
-> elapsed=23035225
min at idx 2563536 (nodata case, optimized)
-> elapsed=4660543
min at idx 2563536 (nodata case, using std::min_element with nodata aware comparison)
-> elapsed=27234521
--------------------
double (*with* NaN):
min at idx 1557581 (optimized)
-> elapsed=5134599
min at idx 1557581 (using std::min_element with NaN aware comparison)
-> elapsed=28069525
min at idx 1557581 (nodata case, optimized)
-> elapsed=6045955
min at idx 1557581 (nodata case, using std::min_element with nodata aware and NaN aware comparison)
-> elapsed=38663605
--------------------
double (without NaN):
min at idx 6060085 (optimized)
-> elapsed=5207324
min at idx 6060085 (using std::min_element)
-> elapsed=23724625
min at idx 6060085 (nodata case, optimized)
-> elapsed=6293283
min at idx 6060085 (nodata case, using std::min_element with nodata aware comparison)
-> elapsed=28422715
```
</details>

<details>
<summary>
With clang 19.1:
</summary>

```bash
# (cd perftests &&  clang++ -g -O2 -DGDAL_COMPILATION -std=c++17 -I../../port -I../port -I../../gcore -I../gcore -I../../ogr ../../perftests/testperf_gdal_minmax_element.cpp  -o testperf_gdal_minmax_element  -L.. -lgdal  && LD_LIBRARY_PATH=.. ./testperf_gdal_minmax_element)
uint8:
min at idx 327280 (optimized)
-> elapsed=702975
min at idx 327280 (using std::min_element)
-> elapsed=5886167
min at idx 49077 (nodata case, optimized)
-> elapsed=806332
min at idx 49077 (nodata case, using std::min_element with nodata aware comparison)
-> elapsed=8446420
--------------------
int8:
min at idx 18 (optimized)
-> elapsed=878984
min at idx 18 (using std::min_element)
-> elapsed=7289681
min at idx 18 (nodata case, optimized)
-> elapsed=1193465
min at idx 18 (nodata case, using std::min_element with nodata aware comparison)
-> elapsed=13509020
--------------------
uint16:
min at idx 150727 (optimized)
-> elapsed=1343657
min at idx 150727 (using std::min_element)
-> elapsed=5412185
min at idx 128881 (nodata case, optimized)
-> elapsed=1572460
min at idx 128881 (nodata case, using std::min_element with nodata aware comparison)
-> elapsed=7933231
--------------------
int16:
min at idx 8813897 (optimized)
-> elapsed=1454923
min at idx 8813897 (using std::min_element)
-> elapsed=6584572
min at idx 8813897 (nodata case, optimized)
-> elapsed=1874499
min at idx 8813897 (nodata case, using std::min_element with nodata aware comparison)
-> elapsed=9559531
--------------------
uint32:
min at idx 5600 (optimized)
-> elapsed=2930964
min at idx 5600 (using std::min_element)
-> elapsed=7055374
min at idx 16454 (nodata case, optimized)
-> elapsed=3371695
min at idx 16454 (nodata case, using std::min_element with nodata aware comparison)
-> elapsed=11816755
--------------------
int32:
min at idx 1003763 (optimized)
-> elapsed=2761373
min at idx 1003763 (using std::min_element)
-> elapsed=6779637
min at idx 1003763 (nodata case, optimized)
-> elapsed=3354829
min at idx 1003763 (nodata case, using std::min_element with nodata aware comparison)
-> elapsed=9862882
--------------------
float (*with* NaN):
min at idx 8446860 (optimized)
-> elapsed=3543119
min at idx 8446860 (using std::min_element with NaN aware comparison)
-> elapsed=11681428
min at idx 8446860 (nodata case, optimized)
-> elapsed=3646478
min at idx 8446860 (nodata case, using std::min_element with nodata aware and NaN aware comparison)
-> elapsed=17201762
--------------------
float (without NaN):
min at idx 886712 (optimized)
-> elapsed=2948051
min at idx 886712 (using std::min_element)
-> elapsed=12590771
min at idx 886712 (nodata case, optimized)
-> elapsed=4169240
min at idx 886712 (nodata case, using std::min_element with nodata aware comparison)
-> elapsed=10769871
--------------------
double (*with* NaN):
min at idx 9899002 (optimized)
-> elapsed=6689751
min at idx 9899002 (using std::min_element with NaN aware comparison)
-> elapsed=13450989
min at idx 9899002 (nodata case, optimized)
-> elapsed=7377661
min at idx 9899002 (nodata case, using std::min_element with nodata aware and NaN aware comparison)
-> elapsed=20447686
--------------------
double (without NaN):
min at idx 719169 (optimized)
-> elapsed=5630569
min at idx 719169 (using std::min_element)
-> elapsed=13571327
min at idx 719169 (nodata case, optimized)
-> elapsed=6561235
min at idx 719169 (nodata case, using std::min_element with nodata aware comparison)
-> elapsed=11819741
```
</details>

<details>
<summary>
With Visual Studio 2019  v16.11.20 (in a VM):
</summary>

```bash
(myenv) C:\dev\gdal space\build_conda>perftests\Release\testperf_gdal_minmax_element.exe
uint8:
min at idx 93056 (optimized)
-> elapsed=2959400
min at idx 93056 (using std::min_element)
-> elapsed=22411800
min at idx 85897 (nodata case, optimized)
-> elapsed=4020700
min at idx 85897 (nodata case, using std::min_element with nodata aware comparison)
-> elapsed=32370100
--------------------
int8:
min at idx 34 (optimized)
-> elapsed=2761400
min at idx 34 (using std::min_element)
-> elapsed=22271700
min at idx 34 (nodata case, optimized)
-> elapsed=2697300
min at idx 34 (nodata case, using std::min_element with nodata aware comparison)
-> elapsed=30704800
--------------------
uint16:
min at idx 337913 (optimized)
-> elapsed=4275700
min at idx 337913 (using std::min_element)
-> elapsed=27022600
min at idx 629464 (nodata case, optimized)
-> elapsed=4677300
min at idx 629464 (nodata case, using std::min_element with nodata aware comparison)
-> elapsed=36056100
--------------------
int16:
min at idx 2937537 (optimized)
-> elapsed=3363900
min at idx 2937537 (using std::min_element)
-> elapsed=23434200
min at idx 2937537 (nodata case, optimized)
-> elapsed=4306900
min at idx 2937537 (nodata case, using std::min_element with nodata aware comparison)
-> elapsed=31916800
--------------------
uint32:
min at idx 50000 (optimized)
-> elapsed=5474900
min at idx 50000 (using std::min_element)
-> elapsed=24291700
min at idx 391987 (nodata case, optimized)
-> elapsed=6541000
min at idx 391987 (nodata case, using std::min_element with nodata aware comparison)
-> elapsed=33131400
--------------------
int32:
min at idx 190526 (optimized)
-> elapsed=5320200
min at idx 190526 (using std::min_element)
-> elapsed=24579100
min at idx 190526 (nodata case, optimized)
-> elapsed=6299800
min at idx 190526 (nodata case, using std::min_element with nodata aware comparison)
-> elapsed=31777400
--------------------
float (*with* NaN):
min at idx 9151103 (optimized)
-> elapsed=5996300
min at idx 9151103 (using std::min_element with NaN aware comparison)
-> elapsed=75801400
min at idx 9151103 (nodata case, optimized)
-> elapsed=8239900
min at idx 9151103 (nodata case, using std::min_element with nodata aware and NaN aware comparison)
-> elapsed=95373100
--------------------
float (without NaN):
min at idx 7098923 (optimized)
-> elapsed=5783200
min at idx 7098923 (using std::min_element)
-> elapsed=32004700
min at idx 7098923 (nodata case, optimized)
-> elapsed=5980400
min at idx 7098923 (nodata case, using std::min_element with nodata aware comparison)
-> elapsed=46188500
--------------------
double (*with* NaN):
min at idx 8988311 (optimized)
-> elapsed=10934900
min at idx 8988311 (using std::min_element with NaN aware comparison)
-> elapsed=87471100
min at idx 8988311 (nodata case, optimized)
-> elapsed=11863200
min at idx 8988311 (nodata case, using std::min_element with nodata aware and NaN aware comparison)
-> elapsed=95721200
--------------------
double (without NaN):
min at idx 5918741 (optimized)
-> elapsed=8857400
min at idx 5918741 (using std::min_element)
-> elapsed=35134900
min at idx 5918741 (nodata case, optimized)
-> elapsed=11234700
min at idx 5918741 (nodata case, using std::min_element with nodata aware comparison)
-> elapsed=50446300
```
</details>

Cf https://github.com/OSGeo/gdal/pull/11202 for a continuation that also significantly accelerates on ARM Neon