### PR TITLE
gdalenhance: fix memory leaks

### DIFF
--- a/apps/gdalenhance.cpp
+++ b/apps/gdalenhance.cpp
@@ -526,9 +526,9 @@ CPLErr ReadLUTs(const char *pszConfigFile, int nBandCount, int nLUTBins,
                 int ***ppapanLUTs, double **ppadfScaleMin,
                 double **ppadfScaleMax)
 {
-    char **papszLines = CSLLoad(pszConfigFile);
+    const CPLStringList aosLines(CSLLoad(pszConfigFile));
 
-    if (CSLCount(papszLines) != nBandCount)
+    if (aosLines.size() != nBandCount)
     {
         CPLError(CE_Failure, CPLE_AppDefined,
                  "Did not get %d lines in config file as expected.\n",
@@ -544,10 +544,10 @@ CPLErr ReadLUTs(const char *pszConfigFile, int nBandCount, int nLUTBins,
 
     for (int iBand = 0; iBand < nBandCount; iBand++)
     {
-        char **papszTokens = CSLTokenizeString(papszLines[iBand]);
+        const CPLStringList aosTokens(CSLTokenizeString(aosLines[iBand]));
 
-        if (CSLCount(papszTokens) < (nLUTBins + 3) ||
-            atoi(papszTokens[0]) != iBand + 1)
+        if (aosTokens.size() < (nLUTBins + 3) ||
+            atoi(aosTokens[0]) != iBand + 1)
         {
             CPLError(CE_Failure, CPLE_AppDefined,
                      "Line %d seems to be corrupt.\n", iBand + 1);
@@ -556,8 +556,8 @@ CPLErr ReadLUTs(const char *pszConfigFile, int nBandCount, int nLUTBins,
 
         // Process scale min/max
 
-        (*ppadfScaleMin)[iBand] = CPLAtof(papszTokens[1]);
-        (*ppadfScaleMax)[iBand] = CPLAtof(papszTokens[2]);
+        (*ppadfScaleMin)[iBand] = CPLAtof(aosTokens[1]);
+        (*ppadfScaleMax)[iBand] = CPLAtof(aosTokens[2]);
 
         // process lut
 
@@ -565,11 +565,8 @@ CPLErr ReadLUTs(const char *pszConfigFile, int nBandCount, int nLUTBins,
             static_cast<int *>(CPLCalloc(nLUTBins, sizeof(int)));
 
         for (int iLUT = 0; iLUT < nLUTBins; iLUT++)
-            (*ppapanLUTs)[iBand][iLUT] = atoi(papszTokens[iLUT + 3]);
-
-        CSLDestroy(papszTokens);
+            (*ppapanLUTs)[iBand][iLUT] = atoi(aosTokens[iLUT + 3]);
     }
-    CSLDestroy(papszLines);
 
     return CE_None;
 }

--- a/apps/gdalenhance.cpp
+++ b/apps/gdalenhance.cpp
@@ -643,7 +643,7 @@ CPLErr WriteEnhanced(GDALDatasetH hDataset, int **papanLUTs, int nLUTBins,
                        GDALGetGCPProjection(hDataset));
     }
 
-    poVDS->SetMetadata(static_cast<GDALDataset *>(hDataset)->GetMetadata());
+    poVDS->SetMetadata(GDALDataset::FromHandle(hDataset)->GetMetadata());
 
     for (int iBand = 0; iBand < nBandCount; iBand++)
     {
@@ -651,8 +651,7 @@ CPLErr WriteEnhanced(GDALDatasetH hDataset, int **papanLUTs, int nLUTBins,
         GDALRasterBand *poSrcBand;
         GDALDataType eBandType;
 
-        poSrcBand =
-            static_cast<GDALDataset *>(hDataset)->GetRasterBand(iBand + 1);
+        poSrcBand = GDALDataset::FromHandle(hDataset)->GetRasterBand(iBand + 1);
 
         /* ---------------------------------------------------------------- */
         /*      Select output data type to match source.                    */

--- a/apps/gdalenhance.cpp
+++ b/apps/gdalenhance.cpp
@@ -26,6 +26,19 @@ static int ComputeEqualizationLUTs(GDALDatasetH hDataset, int nLUTBins,
                                    double **padfScaleMax, int ***ppapanLUTs,
                                    GDALProgressFunc pfnProgress);
 
+static CPLErr ReadLUTs(const char *pszConfigFile, int nBandCount, int nLUTBins,
+                       int ***ppapanLUTs, double **ppadfScaleMin,
+                       double **ppadfScaleMax);
+static void WriteLUTs(int **papanLUTs, int nBandCount, int nLUTBins,
+                      double *padfScaleMin, double *padfScaleMax,
+                      const char *pszConfigFile);
+static CPLErr WriteEnhanced(GDALDatasetH hDataset, int **papanLUTs,
+                            int nLUTBins, double *padfScaleMin,
+                            double *padfScaleMax, GDALDataType eOutputType,
+                            GDALDriverH hDriver, const char *pszDest,
+                            char **papszCreateOptions,
+                            GDALProgressFunc pfnProgress);
+
 static CPLErr EnhancerCallback(void *hCBData, int nXOff, int nYOff, int nXSize,
                                int nYSize, void *pData);
 
@@ -69,21 +82,21 @@ static void Usage()
 MAIN_START(argc, argv)
 
 {
-    GDALDatasetH hDataset, hOutDS;
-    int i;
+    GDALDatasetH hDataset = nullptr;
     const char *pszSource = nullptr, *pszDest = nullptr, *pszFormat = nullptr;
     GDALDriverH hDriver = nullptr;
     GDALDataType eOutputType = GDT_Unknown;
     char **papszCreateOptions = nullptr;
     GDALProgressFunc pfnProgress = GDALTermProgress;
+    int nBandCount = 0;
     int nLUTBins = 256;
     const char *pszMethod = "minmax";
     //    double              dfStdDevMult = 0.0;
     double *padfScaleMin = nullptr;
     double *padfScaleMax = nullptr;
     int **papanLUTs = nullptr;
-    int iBand;
     const char *pszConfigFile = nullptr;
+    int nRetCode = 0;
 
     /* Check strict compilation and runtime library version as we use C++ API */
     if (!GDAL_CHECK_VERSION(argv[0]))
@@ -95,19 +108,22 @@ MAIN_START(argc, argv)
     GDALAllRegister();
     argc = GDALGeneralCmdLineProcessor(argc, &argv, 0);
     if (argc < 1)
-        exit(-argc);
+    {
+        GDALDestroyDriverManager();
+        exit(0);
+    }
 
     /* -------------------------------------------------------------------- */
     /*      Handle command line arguments.                                  */
     /* -------------------------------------------------------------------- */
-    for (i = 1; i < argc; i++)
+    for (int i = 1; i < argc; i++)
     {
         if (EQUAL(argv[i], "--utility_version"))
         {
             printf("%s was compiled against GDAL %s and is running against "
                    "GDAL %s\n",
                    argv[0], GDAL_RELEASE_NAME, GDALVersionInfo("RELEASE_NAME"));
-            return 0;
+            goto exit;
         }
         else if (EQUAL(argv[i], "--help"))
         {
@@ -121,9 +137,7 @@ MAIN_START(argc, argv)
 
         else if (i < argc - 1 && EQUAL(argv[i], "-ot"))
         {
-            int iType;
-
-            for (iType = 1; iType < GDT_TypeCount; iType++)
+            for (int iType = 1; iType < GDT_TypeCount; iType++)
             {
                 if (GDALGetDataTypeName(static_cast<GDALDataType>(iType)) !=
                         nullptr &&
@@ -216,57 +230,60 @@ MAIN_START(argc, argv)
     {
         fprintf(stderr, "GDALOpen failed - %d\n%s\n", CPLGetLastErrorNo(),
                 CPLGetLastErrorMsg());
-        GDALDestroyDriverManager();
-        exit(1);
+        goto exit;
     }
 
-    int nBandCount = GDALGetRasterCount(hDataset);
+    nBandCount = GDALGetRasterCount(hDataset);
 
     /* -------------------------------------------------------------------- */
     /*      Find the output driver.                                         */
     /* -------------------------------------------------------------------- */
-    CPLString osFormat;
-    if (pszFormat == nullptr && pszDest != nullptr)
     {
-        osFormat = GetOutputDriverForRaster(pszDest);
-        if (osFormat.empty())
+        CPLString osFormat;
+        if (pszFormat == nullptr && pszDest != nullptr)
         {
-            GDALDestroyDriverManager();
-            exit(1);
-        }
-    }
-    else if (pszFormat != nullptr)
-    {
-        osFormat = pszFormat;
-    }
-
-    if (!osFormat.empty())
-    {
-        hDriver = GDALGetDriverByName(osFormat);
-        if (hDriver == nullptr)
-        {
-            int iDr;
-
-            printf("Output driver `%s' not recognised.\n", osFormat.c_str());
-            printf("The following format drivers are configured and support "
-                   "output:\n");
-            for (iDr = 0; iDr < GDALGetDriverCount(); iDr++)
+            osFormat = GetOutputDriverForRaster(pszDest);
+            if (osFormat.empty())
             {
-                hDriver = GDALGetDriver(iDr);
-
-                if (GDALGetMetadataItem(hDriver, GDAL_DCAP_RASTER, nullptr) !=
-                        nullptr &&
-                    (GDALGetMetadataItem(hDriver, GDAL_DCAP_CREATE, nullptr) !=
-                         nullptr ||
-                     GDALGetMetadataItem(hDriver, GDAL_DCAP_CREATECOPY,
-                                         nullptr) != nullptr))
-                {
-                    printf("  %s: %s\n", GDALGetDriverShortName(hDriver),
-                           GDALGetDriverLongName(hDriver));
-                }
+                GDALDestroyDriverManager();
+                exit(1);
             }
-            printf("\n");
-            Usage();
+        }
+        else if (pszFormat != nullptr)
+        {
+            osFormat = pszFormat;
+        }
+
+        if (!osFormat.empty())
+        {
+            hDriver = GDALGetDriverByName(osFormat);
+            if (hDriver == nullptr)
+            {
+                int iDr;
+
+                printf("Output driver `%s' not recognised.\n",
+                       osFormat.c_str());
+                printf(
+                    "The following format drivers are configured and support "
+                    "output:\n");
+                for (iDr = 0; iDr < GDALGetDriverCount(); iDr++)
+                {
+                    hDriver = GDALGetDriver(iDr);
+
+                    if (GDALGetMetadataItem(hDriver, GDAL_DCAP_RASTER,
+                                            nullptr) != nullptr &&
+                        (GDALGetMetadataItem(hDriver, GDAL_DCAP_CREATE,
+                                             nullptr) != nullptr ||
+                         GDALGetMetadataItem(hDriver, GDAL_DCAP_CREATECOPY,
+                                             nullptr) != nullptr))
+                    {
+                        printf("  %s: %s\n", GDALGetDriverShortName(hDriver),
+                               GDALGetDriverLongName(hDriver));
+                    }
+                }
+                printf("\n");
+                goto exit;
+            }
         }
     }
 
@@ -285,57 +302,11 @@ MAIN_START(argc, argv)
     /* -------------------------------------------------------------------- */
     else if (pszConfigFile != nullptr)
     {
-        char **papszLines = CSLLoad(pszConfigFile);
-        if (CSLCount(papszLines) == 0)
-            exit(1);
-
-        if (CSLCount(papszLines) != nBandCount)
+        if (ReadLUTs(pszConfigFile, nBandCount, nLUTBins, &papanLUTs,
+                     &padfScaleMin, &padfScaleMax) != CE_None)
         {
-            fprintf(stderr,
-                    "Did not get %d lines in config file as expected.\n",
-                    nBandCount);
-            exit(1);
-        }
-
-        padfScaleMin =
-            static_cast<double *>(CPLCalloc(nBandCount, sizeof(double)));
-        padfScaleMax =
-            static_cast<double *>(CPLCalloc(nBandCount, sizeof(double)));
-
-        for (iBand = 0; iBand < nBandCount; iBand++)
-        {
-            int iLUT;
-            char **papszTokens = CSLTokenizeString(papszLines[iBand]);
-
-            if (CSLCount(papszTokens) < 3 || atoi(papszTokens[0]) != iBand + 1)
-            {
-                fprintf(stderr, "Line %d seems to be corrupt.\n", iBand + 1);
-                exit(1);
-            }
-
-            // Process scale min/max
-
-            padfScaleMin[iBand] = CPLAtof(papszTokens[1]);
-            padfScaleMax[iBand] = CPLAtof(papszTokens[2]);
-
-            if (CSLCount(papszTokens) == 3)
-                continue;
-
-            // process lut
-            if (papanLUTs == nullptr)
-            {
-                nLUTBins = CSLCount(papszTokens) - 3;
-                papanLUTs =
-                    static_cast<int **>(CPLCalloc(sizeof(int *), nBandCount));
-            }
-
-            papanLUTs[iBand] =
-                static_cast<int *>(CPLCalloc(nLUTBins, sizeof(int)));
-
-            for (iLUT = 0; iLUT < nLUTBins; iLUT++)
-                papanLUTs[iBand][iLUT] = atoi(papszTokens[iLUT + 3]);
-
-            CSLDestroy(papszTokens);
+            nRetCode = 1;
+            goto exit;
         }
     }
 
@@ -352,137 +323,40 @@ MAIN_START(argc, argv)
     /* -------------------------------------------------------------------- */
     if (pszDest == nullptr)
     {
-        FILE *fpConfig = stdout;
-        if (pszConfigFile)
-            fpConfig = fopen(pszConfigFile, "w");
-
-        for (iBand = 0; iBand < nBandCount; iBand++)
-        {
-            fprintf(fpConfig, "%d:Band ", iBand + 1);
-            fprintf(fpConfig, "%g:ScaleMin %g:ScaleMax ", padfScaleMin[iBand],
-                    padfScaleMax[iBand]);
-
-            if (papanLUTs)
-            {
-                int iLUT;
-
-                for (iLUT = 0; iLUT < nLUTBins; iLUT++)
-                    fprintf(fpConfig, "%d ", papanLUTs[iBand][iLUT]);
-            }
-            fprintf(fpConfig, "\n");
-        }
-
-        if (pszConfigFile)
-            fclose(fpConfig);
-
-        exit(0);
-    }
-
-    /* ==================================================================== */
-    /*      Create a virtual dataset.                                       */
-    /* ==================================================================== */
-    EnhanceCBInfo *pasEInfo = static_cast<EnhanceCBInfo *>(
-        CPLCalloc(nBandCount, sizeof(EnhanceCBInfo)));
-
-    /* -------------------------------------------------------------------- */
-    /*      Make a virtual clone.                                           */
-    /* -------------------------------------------------------------------- */
-    VRTDataset *poVDS = new VRTDataset(GDALGetRasterXSize(hDataset),
-                                       GDALGetRasterYSize(hDataset));
-
-    if (GDALGetGCPCount(hDataset) == 0)
-    {
-        double adfGeoTransform[6];
-
-        const char *pszProjection = GDALGetProjectionRef(hDataset);
-        if (pszProjection != nullptr && strlen(pszProjection) > 0)
-            poVDS->SetProjection(pszProjection);
-
-        if (GDALGetGeoTransform(hDataset, adfGeoTransform) == CE_None)
-            poVDS->SetGeoTransform(adfGeoTransform);
+        WriteLUTs(papanLUTs, nBandCount, nLUTBins, padfScaleMin, padfScaleMax,
+                  pszConfigFile);
     }
     else
     {
-        poVDS->SetGCPs(GDALGetGCPCount(hDataset), GDALGetGCPs(hDataset),
-                       GDALGetGCPProjection(hDataset));
+        if (WriteEnhanced(hDataset, papanLUTs, nLUTBins, padfScaleMin,
+                          padfScaleMax, eOutputType, hDriver, pszDest,
+                          papszCreateOptions, pfnProgress) != CE_None)
+        {
+            nRetCode = 1;
+        }
     }
-
-    poVDS->SetMetadata(static_cast<GDALDataset *>(hDataset)->GetMetadata());
-
-    for (iBand = 0; iBand < nBandCount; iBand++)
-    {
-        VRTSourcedRasterBand *poVRTBand;
-        GDALRasterBand *poSrcBand;
-        GDALDataType eBandType;
-
-        poSrcBand =
-            static_cast<GDALDataset *>(hDataset)->GetRasterBand(iBand + 1);
-
-        /* --------------------------------------------------------------------
-         */
-        /*      Select output data type to match source. */
-        /* --------------------------------------------------------------------
-         */
-        if (eOutputType == GDT_Unknown)
-            eBandType = GDT_Byte;
-        else
-            eBandType = eOutputType;
-
-        /* --------------------------------------------------------------------
-         */
-        /*      Create this band. */
-        /* --------------------------------------------------------------------
-         */
-        poVDS->AddBand(eBandType, nullptr);
-        poVRTBand = cpl::down_cast<VRTSourcedRasterBand *>(
-            poVDS->GetRasterBand(iBand + 1));
-
-        /* --------------------------------------------------------------------
-         */
-        /*      Create a function based source with info on how to apply the */
-        /*      enhancement. */
-        /* --------------------------------------------------------------------
-         */
-        pasEInfo[iBand].poSrcBand = poSrcBand;
-        pasEInfo[iBand].eWrkType = eBandType;
-        pasEInfo[iBand].dfScaleMin = padfScaleMin[iBand];
-        pasEInfo[iBand].dfScaleMax = padfScaleMax[iBand];
-        pasEInfo[iBand].nLUTBins = nLUTBins;
-
-        if (papanLUTs)
-            pasEInfo[iBand].panLUT = papanLUTs[iBand];
-
-        poVRTBand->AddFuncSource(EnhancerCallback, pasEInfo + iBand);
-
-        /* --------------------------------------------------------------------
-         */
-        /*      copy over some other information of interest. */
-        /* --------------------------------------------------------------------
-         */
-        poVRTBand->CopyCommonInfoFrom(poSrcBand);
-    }
-
-    /* -------------------------------------------------------------------- */
-    /*      Write to the output file using CopyCreate().                    */
-    /* -------------------------------------------------------------------- */
-    hOutDS = GDALCreateCopy(hDriver, pszDest, static_cast<GDALDatasetH>(poVDS),
-                            FALSE, papszCreateOptions, pfnProgress, nullptr);
-    if (hOutDS != nullptr)
-        GDALClose(hOutDS);
-
-    GDALClose(poVDS);
-
-    GDALClose(hDataset);
 
     /* -------------------------------------------------------------------- */
     /*      Cleanup and exit.                                               */
     /* -------------------------------------------------------------------- */
+exit:
+    GDALClose(hDataset);
     GDALDumpOpenDatasets(stderr);
     GDALDestroyDriverManager();
     CSLDestroy(argv);
     CSLDestroy(papszCreateOptions);
+    if (papanLUTs)
+    {
+        for (int iBand = 0; iBand < nBandCount; iBand++)
+        {
+            CPLFree(papanLUTs[iBand]);
+        }
+        CPLFree(papanLUTs);
+    }
+    CPLFree(padfScaleMin);
+    CPLFree(padfScaleMax);
 
-    exit(0);
+    exit(nRetCode);
 }
 
 MAIN_END
@@ -500,10 +374,7 @@ static int ComputeEqualizationLUTs(GDALDatasetH hDataset, int nLUTBins,
                                    GDALProgressFunc pfnProgress)
 
 {
-    int iBand;
     int nBandCount = GDALGetRasterCount(hDataset);
-    int nHistSize = 0;
-    GUIntBig *panHistogram = nullptr;
 
     // For now we always compute min/max
     *ppadfScaleMin =
@@ -516,17 +387,16 @@ static int ComputeEqualizationLUTs(GDALDatasetH hDataset, int nLUTBins,
     /* ==================================================================== */
     /*      Process all bands.                                              */
     /* ==================================================================== */
-    for (iBand = 0; iBand < nBandCount; iBand++)
+    for (int iBand = 0; iBand < nBandCount; iBand++)
     {
         GDALRasterBandH hBand = GDALGetRasterBand(hDataset, iBand + 1);
-        CPLErr eErr;
+        GUIntBig *panHistogram = nullptr;
+        int nHistSize = 0;
 
-        /* --------------------------------------------------------------------
-         */
-        /*      Get a reasonable histogram. */
-        /* --------------------------------------------------------------------
-         */
-        eErr = GDALGetDefaultHistogramEx(
+        /* ----------------------------------------------------------------- */
+        /*      Get a reasonable histogram.                                  */
+        /* ----------------------------------------------------------------- */
+        CPLErr eErr = GDALGetDefaultHistogramEx(
             hBand, *ppadfScaleMin + iBand, *ppadfScaleMax + iBand, &nHistSize,
             &panHistogram, TRUE, pfnProgress, nullptr);
 
@@ -536,19 +406,16 @@ static int ComputeEqualizationLUTs(GDALDatasetH hDataset, int nLUTBins,
         panHistogram[0] = 0;  // zero out extremes (nodata, etc)
         panHistogram[nHistSize - 1] = 0;
 
-        /* --------------------------------------------------------------------
-         */
-        /*      Total histogram count, and build cumulative histogram. */
+        /* ----------------------------------------------------------------- */
+        /*      Total histogram count, and build cumulative histogram.       */
         /*      We take care to use big integers as there may be more than 4 */
-        /*      Gigapixels. */
-        /* --------------------------------------------------------------------
-         */
+        /*      Gigapixels.                                                  */
+        /* ----------------------------------------------------------------- */
         GUIntBig *panCumHist =
             static_cast<GUIntBig *>(CPLCalloc(sizeof(GUIntBig), nHistSize));
         GUIntBig nTotal = 0;
-        int iHist;
 
-        for (iHist = 0; iHist < nHistSize; iHist++)
+        for (int iHist = 0; iHist < nHistSize; iHist++)
         {
             panCumHist[iHist] = nTotal + panHistogram[iHist] / 2;
             nTotal += panHistogram[iHist];
@@ -564,17 +431,14 @@ static int ComputeEqualizationLUTs(GDALDatasetH hDataset, int nLUTBins,
             nTotal = 1;
         }
 
-        /* --------------------------------------------------------------------
-         */
-        /*      Now compute a LUT from the cumulative histogram. */
-        /* --------------------------------------------------------------------
-         */
+        /* ----------------------------------------------------------------- */
+        /*      Now compute a LUT from the cumulative histogram.             */
+        /* ----------------------------------------------------------------- */
         int *panLUT = static_cast<int *>(CPLCalloc(sizeof(int), nLUTBins));
-        int iLUT;
 
-        for (iLUT = 0; iLUT < nLUTBins; iLUT++)
+        for (int iLUT = 0; iLUT < nLUTBins; iLUT++)
         {
-            iHist = (iLUT * nHistSize) / nLUTBins;
+            int iHist = (iLUT * nHistSize) / nLUTBins;
             int nValue =
                 static_cast<int>((panCumHist[iHist] * nLUTBins) / nTotal);
 
@@ -605,17 +469,16 @@ static CPLErr EnhancerCallback(void *hCBData, int nXOff, int nYOff, int nXSize,
     {
         CPLError(CE_Failure, CPLE_AppDefined,
                  "Currently gdalenhance only supports Byte output.");
-        exit(2);
+        return CE_Failure;
     }
 
     GByte *pabyOutImage = static_cast<GByte *>(pData);
-    CPLErr eErr;
     float *pafSrcImage = static_cast<float *>(
         CPLCalloc(sizeof(float), static_cast<size_t>(nXSize) * nYSize));
 
-    eErr = psEInfo->poSrcBand->RasterIO(GF_Read, nXOff, nYOff, nXSize, nYSize,
-                                        pafSrcImage, nXSize, nYSize,
-                                        GDT_Float32, 0, 0, nullptr);
+    CPLErr eErr = psEInfo->poSrcBand->RasterIO(
+        GF_Read, nXOff, nYOff, nXSize, nYSize, pafSrcImage, nXSize, nYSize,
+        GDT_Float32, 0, 0, nullptr);
 
     if (eErr != CE_None)
     {
@@ -624,14 +487,13 @@ static CPLErr EnhancerCallback(void *hCBData, int nXOff, int nYOff, int nXSize,
     }
 
     int nPixelCount = nXSize * nYSize;
-    int iPixel;
     int bHaveNoData;
     float fNoData =
         static_cast<float>(psEInfo->poSrcBand->GetNoDataValue(&bHaveNoData));
     double dfScale =
         psEInfo->nLUTBins / (psEInfo->dfScaleMax - psEInfo->dfScaleMin);
 
-    for (iPixel = 0; iPixel < nPixelCount; iPixel++)
+    for (int iPixel = 0; iPixel < nPixelCount; iPixel++)
     {
         if (bHaveNoData && pafSrcImage[iPixel] == fNoData)
         {
@@ -652,4 +514,203 @@ static CPLErr EnhancerCallback(void *hCBData, int nXOff, int nYOff, int nXSize,
     CPLFree(pafSrcImage);
 
     return CE_None;
+}
+
+/************************************************************************/
+/*                      ReadLUTs()                                      */
+/*                                                                      */
+/*               Read a LUT for each band from a file.                  */
+/************************************************************************/
+
+CPLErr ReadLUTs(const char *pszConfigFile, int nBandCount, int nLUTBins,
+                int ***ppapanLUTs, double **ppadfScaleMin,
+                double **ppadfScaleMax)
+{
+    char **papszLines = CSLLoad(pszConfigFile);
+
+    if (CSLCount(papszLines) != nBandCount)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Did not get %d lines in config file as expected.\n",
+                 nBandCount);
+        return CE_Failure;
+    }
+
+    *ppadfScaleMin =
+        static_cast<double *>(CPLCalloc(nBandCount, sizeof(double)));
+    *ppadfScaleMax =
+        static_cast<double *>(CPLCalloc(nBandCount, sizeof(double)));
+    *ppapanLUTs = static_cast<int **>(CPLCalloc(sizeof(int *), nBandCount));
+
+    for (int iBand = 0; iBand < nBandCount; iBand++)
+    {
+        char **papszTokens = CSLTokenizeString(papszLines[iBand]);
+
+        if (CSLCount(papszTokens) < (nLUTBins + 3) ||
+            atoi(papszTokens[0]) != iBand + 1)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Line %d seems to be corrupt.\n", iBand + 1);
+            return CE_Failure;
+        }
+
+        // Process scale min/max
+
+        (*ppadfScaleMin)[iBand] = CPLAtof(papszTokens[1]);
+        (*ppadfScaleMax)[iBand] = CPLAtof(papszTokens[2]);
+
+        // process lut
+
+        (*ppapanLUTs)[iBand] =
+            static_cast<int *>(CPLCalloc(nLUTBins, sizeof(int)));
+
+        for (int iLUT = 0; iLUT < nLUTBins; iLUT++)
+            (*ppapanLUTs)[iBand][iLUT] = atoi(papszTokens[iLUT + 3]);
+
+        CSLDestroy(papszTokens);
+    }
+    CSLDestroy(papszLines);
+
+    return CE_None;
+}
+
+/************************************************************************/
+/*                      WriteLUTs()                                     */
+/*                                                                      */
+/*      Write the LUT for each band to a file or stdout.                */
+/************************************************************************/
+
+void WriteLUTs(int **papanLUTs, int nBandCount, int nLUTBins,
+               double *padfScaleMin, double *padfScaleMax,
+               const char *pszConfigFile)
+{
+    FILE *fpConfig = stdout;
+    if (pszConfigFile)
+        fpConfig = fopen(pszConfigFile, "w");
+
+    for (int iBand = 0; iBand < nBandCount; iBand++)
+    {
+        fprintf(fpConfig, "%d:Band ", iBand + 1);
+        fprintf(fpConfig, "%g:ScaleMin %g:ScaleMax ", padfScaleMin[iBand],
+                padfScaleMax[iBand]);
+
+        if (papanLUTs)
+        {
+            for (int iLUT = 0; iLUT < nLUTBins; iLUT++)
+                fprintf(fpConfig, "%d ", papanLUTs[iBand][iLUT]);
+        }
+        fprintf(fpConfig, "\n");
+    }
+
+    if (pszConfigFile)
+        fclose(fpConfig);
+}
+
+/************************************************************************/
+/*                      WriteEnhanced()                                 */
+/*                                                                      */
+/*      Write an enhanced image using the provided LUTs.                */
+/************************************************************************/
+
+CPLErr WriteEnhanced(GDALDatasetH hDataset, int **papanLUTs, int nLUTBins,
+                     double *padfScaleMin, double *padfScaleMax,
+                     GDALDataType eOutputType, GDALDriverH hDriver,
+                     const char *pszDest, char **papszCreateOptions,
+                     GDALProgressFunc pfnProgress)
+{
+    int nBandCount = GDALGetRasterCount(hDataset);
+
+    EnhanceCBInfo *pasEInfo = static_cast<EnhanceCBInfo *>(
+        CPLCalloc(nBandCount, sizeof(EnhanceCBInfo)));
+
+    /* -------------------------------------------------------------------- */
+    /*      Make a virtual clone.                                           */
+    /* -pixe------------------------------------------------------------------- */
+    VRTDataset *poVDS = new VRTDataset(GDALGetRasterXSize(hDataset),
+                                       GDALGetRasterYSize(hDataset));
+
+    if (GDALGetGCPCount(hDataset) == 0)
+    {
+        double adfGeoTransform[6];
+
+        const char *pszProjection = GDALGetProjectionRef(hDataset);
+        if (pszProjection != nullptr && strlen(pszProjection) > 0)
+            poVDS->SetProjection(pszProjection);
+
+        if (GDALGetGeoTransform(hDataset, adfGeoTransform) == CE_None)
+            poVDS->SetGeoTransform(adfGeoTransform);
+    }
+    else
+    {
+        poVDS->SetGCPs(GDALGetGCPCount(hDataset), GDALGetGCPs(hDataset),
+                       GDALGetGCPProjection(hDataset));
+    }
+
+    poVDS->SetMetadata(static_cast<GDALDataset *>(hDataset)->GetMetadata());
+
+    for (int iBand = 0; iBand < nBandCount; iBand++)
+    {
+        VRTSourcedRasterBand *poVRTBand;
+        GDALRasterBand *poSrcBand;
+        GDALDataType eBandType;
+
+        poSrcBand =
+            static_cast<GDALDataset *>(hDataset)->GetRasterBand(iBand + 1);
+
+        /* ---------------------------------------------------------------- */
+        /*      Select output data type to match source.                    */
+        /* ---------------------------------------------------------------- */
+        if (eOutputType == GDT_Unknown)
+            eBandType = GDT_Byte;
+        else
+            eBandType = eOutputType;
+
+        /* ---------------------------------------------------------------- */
+        /*      Create this band.                                           */
+        /* ---------------------------------------------------------------- */
+        poVDS->AddBand(eBandType, nullptr);
+        poVRTBand = cpl::down_cast<VRTSourcedRasterBand *>(
+            poVDS->GetRasterBand(iBand + 1));
+
+        /* ---------------------------------------------------------------- */
+        /*     Create a function based source with info on how to apply the */
+        /*     enhancement.                                                 */
+        /* ---------------------------------------------------------------- */
+        pasEInfo[iBand].poSrcBand = poSrcBand;
+        pasEInfo[iBand].eWrkType = eBandType;
+        pasEInfo[iBand].dfScaleMin = padfScaleMin[iBand];
+        pasEInfo[iBand].dfScaleMax = padfScaleMax[iBand];
+        pasEInfo[iBand].nLUTBins = nLUTBins;
+
+        if (papanLUTs)
+            pasEInfo[iBand].panLUT = papanLUTs[iBand];
+
+        poVRTBand->AddFuncSource(EnhancerCallback, pasEInfo + iBand);
+
+        /* ---------------------------------------------------------------- */
+        /*      copy over some other information of interest.               */
+        /* ---------------------------------------------------------------- */
+        poVRTBand->CopyCommonInfoFrom(poSrcBand);
+    }
+
+    /* -------------------------------------------------------------------- */
+    /*      Write to the output file using CopyCreate().                    */
+    /* -------------------------------------------------------------------- */
+    GDALDatasetH hOutDS =
+        GDALCreateCopy(hDriver, pszDest, static_cast<GDALDatasetH>(poVDS),
+                       FALSE, papszCreateOptions, pfnProgress, nullptr);
+    CPLErr eErr = CE_None;
+    if (hOutDS == nullptr)
+    {
+        eErr = CE_Failure;
+    }
+    else
+    {
+        GDALClose(hOutDS);
+    }
+
+    GDALClose(poVDS);
+    CPLFree(pasEInfo);
+
+    return eErr;
 }


### PR DESCRIPTION
## What does this PR do?

Resolves leaks in `gdalenhance`, as reported in #11159. In fact, the `gdalenhance` tests were never being run under the ASAN build configuration because the test invocation `gdalenhance --utility-version` leaked, which caused the test suite to determine that `gdalenhance` was unavailable and skip all tests.

Also adds some new tests to verify removal of leaks in other error situations.

## What are related issues/pull requests?

#11159

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed