### PR TITLE
netCDF: add a GDAL_NETCDF_REPORT_EXTRA_DIM_VALUES config option ...

### DIFF
--- a/doc/source/drivers/raster/netcdf.rst
+++ b/doc/source/drivers/raster/netcdf.rst
@@ -617,6 +617,17 @@ Configuration Options
       geotransform has been found, and that geotransform is within the bounds
       -180,360 -90,90, if YES assume OGC:CRS84.
 
+-  .. config:: GDAL_NETCDF_REPORT_EXTRA_DIM_VALUES
+      :choices: YES, NO
+      :default: NO
+      :since: 3.10.1
+
+      For a netCDF dataset stored on a remote file system (``/vsicurl/``, ``/vsis3/``),
+      getting the content of the ``NETCDF_DIM_{dim_name}_VALUES`` metadata item
+      can be a slow operation when the dimension is unlimited. It is thus disabled
+      by default for such remote files. By setting this configuration option to YES,
+      you force GDAL to get the content of such metadata items.
+
 VSI Virtual File System API support
 -----------------------------------
 

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -8768,6 +8768,7 @@ GDALDataset *netCDFDataset::Open(GDALOpenInfo *poOpenInfo)
 
         char szDimName[NC_MAX_NAME + 1] = {};
 
+        bool bREPORT_EXTRA_DIM_VALUESWarningEmitted = false;
         for (int j = 0; j < nd; j++)
         {
             if ((poDS->m_anDimIds[j] != poDS->nXDimID) &&
@@ -8812,10 +8813,42 @@ GDALDataset *netCDFDataset::Open(GDALOpenInfo *poOpenInfo)
                         // dimension in its NETCDF_DIM_xxxx band metadata item
                         // Addresses use case of
                         // https://lists.osgeo.org/pipermail/gdal-dev/2023-May/057209.html
-                        if (VSIIsLocal(osFilenameForNCOpen.c_str()) ||
+                        bool bListDimValues =
+                            lev_count == 1 ||
                             !NCDFIsUnlimitedDim(poDS->eFormat ==
                                                     NCDF_FORMAT_NC4,
-                                                cdfid, poDS->m_anDimIds[j]))
+                                                cdfid, poDS->m_anDimIds[j]);
+                        if (!bListDimValues &&
+                            !VSIIsLocal(osFilenameForNCOpen.c_str()))
+                        {
+                            const char *pszGDAL_NETCDF_REPORT_EXTRA_DIM_VALUES =
+                                CPLGetConfigOption(
+                                    "GDAL_NETCDF_REPORT_EXTRA_DIM_VALUES",
+                                    nullptr);
+                            if (!pszGDAL_NETCDF_REPORT_EXTRA_DIM_VALUES)
+                            {
+                                if (!bREPORT_EXTRA_DIM_VALUESWarningEmitted)
+                                {
+                                    bREPORT_EXTRA_DIM_VALUESWarningEmitted =
+                                        true;
+                                    CPLDebug(
+                                        "GDAL_netCDF",
+                                        "Listing extra dimension values is "
+                                        "skipped because this dataset is "
+                                        "hosted on a network file system, and "
+                                        "such an operation could be slow. If "
+                                        "you still want to proceed, set the "
+                                        "GDAL_NETCDF_REPORT_EXTRA_DIM_VALUES "
+                                        "configuration option to YES");
+                                }
+                            }
+                            else
+                            {
+                                bListDimValues = CPLTestBool(
+                                    pszGDAL_NETCDF_REPORT_EXTRA_DIM_VALUES);
+                            }
+                        }
+                        if (bListDimValues)
                         {
                             char *pszTemp = nullptr;
                             if (NCDFGet1DVar(nIdxGroupID, nIdxVarID,


### PR DESCRIPTION
to force getting extra dimension values or files on a remote file system, but also enable it if the size of the dimension is just one

This amends the fix of 0ae885e6d8a74785c5898638b25129813ab1f51b

Fixes #11207

FYI @mdsumner 