### PR TITLE
OGRLayer::GetArrowStream(): add a DATETIME_AS_STRING=YES/NO option

### DIFF
--- a/autotest/cpp/CMakeLists.txt
+++ b/autotest/cpp/CMakeLists.txt
@@ -110,7 +110,7 @@ gdal_standard_includes(gdal_unit_test)
 target_compile_options(gdal_unit_test PRIVATE ${GDAL_CXX_WARNING_FLAGS})
 target_compile_definitions(gdal_unit_test PRIVATE -DGDAL_TEST_ROOT_DIR="${GDAL_ROOT_TEST_DIR}")
 target_include_directories(
-  gdal_unit_test PRIVATE $<TARGET_PROPERTY:appslib,SOURCE_DIR> $<TARGET_PROPERTY:gdal_vrt,SOURCE_DIR>)
+  gdal_unit_test PRIVATE $<TARGET_PROPERTY:appslib,SOURCE_DIR> $<TARGET_PROPERTY:gdal_vrt,SOURCE_DIR> $<TARGET_PROPERTY:ogrsf_generic,SOURCE_DIR>)
 if (GDAL_USE_SQLITE3)
   target_compile_definitions(gdal_unit_test PRIVATE -DHAVE_SQLITE3)
   target_include_directories(

--- a/autotest/ogr/ogr_flatgeobuf.py
+++ b/autotest/ogr/ogr_flatgeobuf.py
@@ -1564,3 +1564,52 @@ def test_ogr_flatgeobuf_sql_arrow(tmp_vsimem):
             assert f["bar"] == "baz"
             assert f.GetGeometryRef().ExportToWkt() == "POINT (1 2)"
             f = tmp_lyr.GetNextFeature()
+
+
+###############################################################################
+# Test DATETIME_AS_STRING=YES GetArrowStream() option
+
+
+def test_ogr_flatgeobuf_arrow_stream_numpy_datetime_as_string(tmp_vsimem):
+    pytest.importorskip("osgeo.gdal_array")
+    pytest.importorskip("numpy")
+
+    filename = str(tmp_vsimem / "datetime_as_string.fgb")
+    with ogr.GetDriverByName("FlatGeoBuf").CreateDataSource(filename) as ds:
+        lyr = ds.CreateLayer("test")
+
+        field = ogr.FieldDefn("datetime", ogr.OFTDateTime)
+        lyr.CreateField(field)
+
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (1 2)"))
+        lyr.CreateFeature(f)
+
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f.SetField("datetime", "2022-05-31T12:34:56.789Z")
+        f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (1 2)"))
+        lyr.CreateFeature(f)
+
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f.SetField("datetime", "2022-05-31T12:34:56")
+        f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (1 2)"))
+        lyr.CreateFeature(f)
+
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f.SetField("datetime", "2022-05-31T12:34:56+12:30")
+        f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (1 2)"))
+        lyr.CreateFeature(f)
+
+    with ogr.Open(filename) as ds:
+        lyr = ds.GetLayer(0)
+        stream = lyr.GetArrowStreamAsNumPy(
+            options=["USE_MASKED_ARRAYS=NO", "DATETIME_AS_STRING=YES"]
+        )
+        batches = [batch for batch in stream]
+        assert len(batches) == 1
+        batch = batches[0]
+        assert len(batch["datetime"]) == 4
+        assert batch["datetime"][0] == b""
+        assert batch["datetime"][1] == b"2022-05-31T12:34:56.789Z"
+        assert batch["datetime"][2] == b"2022-05-31T12:34:56"
+        assert batch["datetime"][3] == b"2022-05-31T12:34:56+12:30"

--- a/autotest/ogr/ogr_mem.py
+++ b/autotest/ogr/ogr_mem.py
@@ -1023,6 +1023,58 @@ def test_ogr_mem_arrow_stream_numpy_datetime_as_string():
 
 
 ###############################################################################
+# Test CreateFieldFromArrowSchema() when there is a GDAL:OGR:type=DateTime
+# Arrow schema metadata.
+
+
+@gdaltest.enable_exceptions()
+def test_ogr_mem_arrow_write_with_datetime_as_string():
+
+    src_ds = ogr.GetDriverByName("Memory").CreateDataSource("")
+    src_lyr = src_ds.CreateLayer("src_lyr", geom_type=ogr.wkbNone)
+
+    field = ogr.FieldDefn("dt", ogr.OFTDateTime)
+    src_lyr.CreateField(field)
+
+    f = ogr.Feature(src_lyr.GetLayerDefn())
+    src_lyr.CreateFeature(f)
+
+    f = ogr.Feature(src_lyr.GetLayerDefn())
+    f.SetField("dt", "2022-05-31T12:34:56.789Z")
+    src_lyr.CreateFeature(f)
+
+    f = ogr.Feature(src_lyr.GetLayerDefn())
+    f.SetField("dt", "2022-05-31T12:34:56")
+    src_lyr.CreateFeature(f)
+
+    f = ogr.Feature(src_lyr.GetLayerDefn())
+    f.SetField("dt", "2022-05-31T12:34:56+12:30")
+    src_lyr.CreateFeature(f)
+
+    ds = ogr.GetDriverByName("Memory").CreateDataSource("")
+    dst_lyr = ds.CreateLayer("dst_lyr")
+
+    stream = src_lyr.GetArrowStream(["DATETIME_AS_STRING=YES"])
+    schema = stream.GetSchema()
+
+    for i in range(schema.GetChildrenCount()):
+        dst_lyr.CreateFieldFromArrowSchema(schema.GetChild(i))
+
+    while True:
+        array = stream.GetNextRecordBatch()
+        if array is None:
+            break
+        dst_lyr.WriteArrowBatch(schema, array)
+
+    assert [f.GetField("dt") for f in dst_lyr] == [
+        None,
+        "2022/05/31 12:34:56.789+00",
+        "2022/05/31 12:34:56",
+        "2022/05/31 12:34:56+1230",
+    ]
+
+
+###############################################################################
 
 
 @pytest.mark.parametrize(

--- a/autotest/ogr/ogr_parquet.py
+++ b/autotest/ogr/ogr_parquet.py
@@ -4167,4 +4167,25 @@ def test_ogr_parquet_ogr2ogr_reprojection(tmp_vsimem):
     with ogr.Open(outfilename) as ds:
         assert ds.GetLayer(0).GetExtent() == pytest.approx(
             (8.73380363499761, 8.774681944824946, 43.01833481785084, 43.04292637071279)
+
+
+###############################################################################
+# Test DATETIME_AS_STRING=YES GetArrowStream() option
+
+
+def test_ogr_parquet_arrow_stream_numpy_datetime_as_string(tmp_vsimem):
+    pytest.importorskip("osgeo.gdal_array")
+    pytest.importorskip("numpy")
+
+    with gdal.OpenEx(
+        "data/parquet/test.parquet", gdal.OF_VECTOR, allowed_drivers=["Parquet"]
+    ) as ds:
+        lyr = ds.GetLayer(0)
+        stream = lyr.GetArrowStreamAsNumPy(
+            options=["USE_MASKED_ARRAYS=NO", "DATETIME_AS_STRING=YES"]
+        )
+        batches = [batch for batch in stream]
+        batch = batches[0]
+        assert (
+            batch["timestamp_ms_gmt_minus_0215"][0] == b"2019-01-01T14:00:00.500-02:15"
         )

--- a/autotest/ogr/ogr_parquet.py
+++ b/autotest/ogr/ogr_parquet.py
@@ -4167,6 +4167,7 @@ def test_ogr_parquet_ogr2ogr_reprojection(tmp_vsimem):
     with ogr.Open(outfilename) as ds:
         assert ds.GetLayer(0).GetExtent() == pytest.approx(
             (8.73380363499761, 8.774681944824946, 43.01833481785084, 43.04292637071279)
+        )
 
 
 ###############################################################################

--- a/ogr/ogrsf_frmts/adbc/ogradbclayer.cpp
+++ b/ogr/ogrsf_frmts/adbc/ogradbclayer.cpp
@@ -155,8 +155,11 @@ GDALDataset *OGRADBCLayer::GetDataset()
 bool OGRADBCLayer::GetArrowStream(struct ArrowArrayStream *out_stream,
                                   CSLConstList papszOptions)
 {
-    if (m_poFilterGeom || m_poAttrQuery)
+    if (m_poFilterGeom || m_poAttrQuery ||
+        CPLFetchBool(papszOptions, GAS_OPT_DATETIME_AS_STRING, false))
+    {
         return OGRLayer::GetArrowStream(out_stream, papszOptions);
+    }
 
     if (m_stream)
     {

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
@@ -5490,6 +5490,24 @@ inline bool OGRArrowLayer::UseRecordBatchBaseImplementation() const
         return true;
     }
 
+    if (m_aosArrowArrayStreamOptions.FetchBool(GAS_OPT_DATETIME_AS_STRING,
+                                               false))
+    {
+        const int nFieldCount = m_poFeatureDefn->GetFieldCount();
+        for (int i = 0; i < nFieldCount; ++i)
+        {
+            const auto poFieldDefn = m_poFeatureDefn->GetFieldDefn(i);
+            if (!poFieldDefn->IsIgnored() &&
+                poFieldDefn->GetType() == OFTDateTime)
+            {
+                CPLDebug("ARROW",
+                         "DATETIME_AS_STRING=YES not compatible of fast "
+                         "Arrow implementation");
+                return true;
+            }
+        }
+    }
+
     if (EQUAL(m_aosArrowArrayStreamOptions.FetchNameValueDef(
                   "GEOMETRY_ENCODING", ""),
               "WKB"))

--- a/ogr/ogrsf_frmts/generic/ograrrowarrayhelper.cpp
+++ b/ogr/ogrsf_frmts/generic/ograrrowarrayhelper.cpp
@@ -11,6 +11,7 @@
  ****************************************************************************/
 
 #include "ograrrowarrayhelper.h"
+#include "ogrlayerarrow.h"
 #include "ogr_p.h"
 
 #include <limits>
@@ -94,6 +95,8 @@ OGRArrowArrayHelper::OGRArrowArrayHelper(
             nTZFlagOverride = OGR_TZFLAG_UTC;
         }
     }
+    const bool bDateTimeAsString =
+        aosArrowArrayStreamOptions.FetchBool(GAS_OPT_DATETIME_AS_STRING, false);
 
     if (m_bIncludeFID)
     {
@@ -222,6 +225,20 @@ OGRArrowArrayHelper::OGRArrowArrayHelper(
                     }
                     break;
                 }
+
+                case OFTDateTime:
+                {
+                    if (!bDateTimeAsString)
+                    {
+                        nEltSize = sizeof(int64_t);
+                        break;
+                    }
+                    else
+                    {
+                        [[fallthrough]];
+                    }
+                }
+
                 case OFTString:
                 case OFTBinary:
                 {
@@ -253,12 +270,6 @@ OGRArrowArrayHelper::OGRArrowArrayHelper(
                 case OFTTime:
                 {
                     nEltSize = sizeof(int32_t);
-                    break;
-                }
-
-                case OFTDateTime:
-                {
-                    nEltSize = sizeof(int64_t);
                     break;
                 }
 

--- a/ogr/ogrsf_frmts/generic/ogrlayerarrow.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrlayerarrow.cpp
@@ -32,6 +32,7 @@
 #include <utility>
 #include <set>
 
+constexpr const char *MD_GDAL_OGR_TYPE = "GDAL:OGR:type";
 constexpr const char *MD_GDAL_OGR_ALTERNATIVE_NAME =
     "GDAL:OGR:alternative_name";
 constexpr const char *MD_GDAL_OGR_COMMENT = "GDAL:OGR:comment";
@@ -579,6 +580,13 @@ int OGRLayer::GetArrowSchema(struct ArrowArrayStream *,
         }
 
         std::vector<std::pair<std::string, std::string>> oMetadata;
+
+        if (eType == OFTDateTime && bDateTimeAsString)
+        {
+            oMetadata.emplace_back(
+                std::pair(MD_GDAL_OGR_TYPE, OGR_GetFieldTypeName(eType)));
+        }
+
         const char *pszAlternativeName = poFieldDefn->GetAlternativeNameRef();
         if (pszAlternativeName && pszAlternativeName[0])
             oMetadata.emplace_back(
@@ -2472,6 +2480,9 @@ const char *OGRLayer::GetLastErrorArrowArrayStream(struct ArrowArrayStream *)
  * Starting with GDAL 3.8, the ArrowSchema::metadata field filled by the
  * get_schema() callback may be set with the potential following items:
  * <ul>
+ * <li>"GDAL:OGR:type": value of OGRFieldDefn::GetType(): (added in 3.11)
+ *      Only used for DateTime fields when the DATETIME_AS_STRING=YES option is
+ *      specified.</li>
  * <li>"GDAL:OGR:alternative_name": value of
  *     OGRFieldDefn::GetAlternativeNameRef()</li>
  * <li>"GDAL:OGR:comment": value of OGRFieldDefn::GetComment()</li>
@@ -2674,6 +2685,9 @@ bool OGRLayer::GetArrowStream(struct ArrowArrayStream *out_stream,
  * Starting with GDAL 3.8, the ArrowSchema::metadata field filled by the
  * get_schema() callback may be set with the potential following items:
  * <ul>
+ * <li>"GDAL:OGR:type": value of OGRFieldDefn::GetType(): (added in 3.11)
+ *      Only used for DateTime fields when the DATETIME_AS_STRING=YES option is
+ *      specified.</li>
  * <li>"GDAL:OGR:alternative_name": value of
  *     OGRFieldDefn::GetAlternativeNameRef()</li>
  * <li>"GDAL:OGR:comment": value of OGRFieldDefn::GetComment()</li>

--- a/ogr/ogrsf_frmts/generic/ogrlayerarrow.h
+++ b/ogr/ogrsf_frmts/generic/ogrlayerarrow.h
@@ -26,6 +26,9 @@ constexpr const char *EXTENSION_NAME_OGC_WKB = "ogc.wkb";
 constexpr const char *EXTENSION_NAME_GEOARROW_WKB = "geoarrow.wkb";
 constexpr const char *EXTENSION_NAME_ARROW_JSON = "arrow.json";
 
+// GetArrowStream(GAS) options
+constexpr const char *GAS_OPT_DATETIME_AS_STRING = "DATETIME_AS_STRING";
+
 std::map<std::string, std::string>
     CPL_DLL OGRParseArrowMetadata(const char *pabyMetadata);
 

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -87,6 +87,7 @@ struct OGRGPKGTableLayerFillArrowArray
     int nCountRows = 0;
     bool bErrorOccurred = false;
     bool bMemoryLimitReached = false;
+    bool bDateTimeAsString = false;
     std::string osErrorMsg{};
     OGRFeatureDefn *poFeatureDefn = nullptr;
     OGRGeoPackageLayer *poLayer = nullptr;

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -13,6 +13,7 @@
 
 #include "ogr_geopackage.h"
 #include "ogrgeopackageutility.h"
+#include "ogrlayerarrow.h"
 #include "ogrsqliteutility.h"
 #include "cpl_md5.h"
 #include "cpl_time.h"
@@ -7821,6 +7822,7 @@ void OGR_GPKG_FillArrowArray_Step(sqlite3_context *pContext, int /*argc*/,
     const auto nMemLimit = psFillArrowArray->nMemLimit;
     const int SQLITE_MAX_FUNCTION_ARG =
         sqlite3_limit(psFillArrowArray->hDB, SQLITE_LIMIT_FUNCTION_ARG, -1);
+    const bool bDateTimeAsString = psFillArrowArray->bDateTimeAsString;
 begin:
     int iFeat;
     OGRArrowArrayHelper *psHelper;
@@ -8172,18 +8174,25 @@ begin:
 
             case OFTDateTime:
             {
-                OGRField ogrField;
-                const auto pszTxt = reinterpret_cast<const char *>(
-                    sqlite3_value_text(argv[iCol]));
-                if (pszTxt != nullptr &&
-                    psFillArrowArray->poLayer->ParseDateTimeField(
-                        pszTxt, &ogrField, poFieldDefn, nFID))
+                if (!bDateTimeAsString)
                 {
-                    psHelper->SetDateTime(
-                        psArray, iFeat, psFillArrowArray->brokenDown,
-                        psHelper->m_anTZFlags[iField], ogrField);
+                    OGRField ogrField;
+                    const auto pszTxt = reinterpret_cast<const char *>(
+                        sqlite3_value_text(argv[iCol]));
+                    if (pszTxt != nullptr &&
+                        psFillArrowArray->poLayer->ParseDateTimeField(
+                            pszTxt, &ogrField, poFieldDefn, nFID))
+                    {
+                        psHelper->SetDateTime(
+                            psArray, iFeat, psFillArrowArray->brokenDown,
+                            psHelper->m_anTZFlags[iField], ogrField);
+                    }
+                    break;
                 }
-                break;
+                else
+                {
+                    [[fallthrough]];
+                }
             }
 
             case OFTString:
@@ -8338,6 +8347,9 @@ int OGRGeoPackageTableLayer::GetNextArrowArrayAsynchronous(
         m_poFillArrowArray->psHelper = std::move(psHelper);
         m_poFillArrowArray->nCountRows = 0;
         m_poFillArrowArray->bErrorOccurred = false;
+        m_poFillArrowArray->bDateTimeAsString =
+            m_aosArrowArrayStreamOptions.FetchBool(GAS_OPT_DATETIME_AS_STRING,
+                                                   false);
         m_poFillArrowArray->poFeatureDefn = m_poFeatureDefn;
         m_poFillArrowArray->poLayer = this;
         m_poFillArrowArray->hDB = m_poDS->GetDB();
@@ -8889,6 +8901,8 @@ int OGRGeoPackageTableLayer::GetNextArrowArrayInternal(
     sFillArrowArray.nCountRows = 0;
     sFillArrowArray.bMemoryLimitReached = false;
     sFillArrowArray.bErrorOccurred = false;
+    sFillArrowArray.bDateTimeAsString = m_aosArrowArrayStreamOptions.FetchBool(
+        GAS_OPT_DATETIME_AS_STRING, false);
     sFillArrowArray.poFeatureDefn = m_poFeatureDefn;
     sFillArrowArray.poLayer = this;
     sFillArrowArray.hDB = m_poDS->GetDB();


### PR DESCRIPTION
* GetArrowStream(): add DATETIME_AS_STRING=YES/NO. Defaults to NO. Added in GDAL 3.11. Whether DateTime fields should be returned as a (normally ISO-8601 formatted) string by drivers. The aim is to be able to handle mixed timezones (or timezone naive values) in the same column. All drivers must honour that option, and potentially fallback to the OGRLayer generic implementation if they cannot (which is the case for the Arrow, Parquet and ADBC drivers).
When DATETIME_AS_STRING=YES, the TIMEZONE option is ignored.

Fixes https://github.com/geopandas/pyogrio/issues/487

* OGRLayer::GetArrowStream(): when DATETIME_AS_STRING=YES, expose "GDAL:OGR:type":"DateTime" metadata in the ArrowSchema of DateTime fields

* CreateFieldFromArrowSchema(): take into account GDAL:OGR:Type=DataTime when ArrowSchema.format='u' (string)

* ogr2ogr: GPKG/FlatGeoBuf -> other format: in Arrow code path, use DATETIME_AS_STRING to preserve origin timezone

Fixes #11212