### PR TITLE
gdaldem: fix help message for subcommands

### DIFF
--- a/apps/argparse/argparse.hpp
+++ b/apps/argparse/argparse.hpp
@@ -2086,7 +2086,7 @@ public:
     std::stringstream stream;
 
     std::string curline("Usage: ");
-    curline += this->m_program_name;
+    curline += this->m_parser_path;
     const bool multiline_usage =
         this->m_usage_max_line_width < std::numeric_limits<std::size_t>::max();
     const size_t indent_size = curline.size();

--- a/apps/gdalargumentparser.cpp
+++ b/apps/gdalargumentparser.cpp
@@ -37,7 +37,7 @@ GDALArgumentParser::GDALArgumentParser(const std::string &program_name,
                 [this](const auto &)
                 {
                     std::cout << usage() << std::endl << std::endl;
-                    std::cout << _("Note: ") << m_program_name
+                    std::cout << _("Note: ") << m_parser_path
                               << _(" --long-usage for full help.") << std::endl;
                     std::exit(0);
                 })


### PR DESCRIPTION
Now:
```
$ gdaldem TPI --help
Usage: gdaldem TPI [--help] [--long-usage] [--help-general]
                   [-of <output_format>] [-compute_edges] [-b <value>] [-co <NAME>=<VALUE>]... [--quiet]
                   input_dem output_TPI_map

Note: gdaldem TPI --long-usage for full help.
```

vs before:
```
$ gdaldem TPI --help
Usage: TPI [--help] [--long-usage] [--help-general]
           [-of <output_format>] [-compute_edges] [-b <value>] [-co <NAME>=<VALUE>]... [--quiet]
           input_dem output_TPI_map

Note: TPI --long-usage for full help.
```

argparse.hpp stream fix submitted to upstream in https://github.com/p-ranav/argparse/pull/382
