### PR TITLE
autotest: fix test failure with msys2 mingw64

### DIFF
--- a/autotest/gnm/gnm_test.py
+++ b/autotest/gnm/gnm_test.py
@@ -36,7 +36,7 @@ def test_gnm_filenetwork_create():
         pass
 
     drv = gdal.GetDriverByName("GNMFile")
-    ds = drv.Create(
+    with drv.Create(
         "tmp/",
         0,
         0,
@@ -47,17 +47,15 @@ def test_gnm_filenetwork_create():
             "net_description=Test file based GNM",
             "net_srs=EPSG:4326",
         ],
-    )
-    # cast to GNM
-    dn = gnm.CastToNetwork(ds)
-    assert dn is not None
-    assert dn.GetVersion() == 100, "GNM: Check GNM version failed"
-    assert dn.GetName() == "test_gnm", "GNM: Check GNM name failed"
-    assert (
-        dn.GetDescription() == "Test file based GNM"
-    ), "GNM: Check GNM description failed"
-
-    dn = None
+    ) as ds:
+        # cast to GNM
+        dn = gnm.CastToNetwork(ds)
+        assert dn is not None
+        assert dn.GetVersion() == 100, "GNM: Check GNM version failed"
+        assert dn.GetName() == "test_gnm", "GNM: Check GNM name failed"
+        assert (
+            dn.GetDescription() == "Test file based GNM"
+        ), "GNM: Check GNM description failed"
 
 
 ###############################################################################


### PR DESCRIPTION
A recent update of msys2 mingw (presumably Python 3.11 -> 3.12) causes the test_gnm_filenetwork_open() test to fail when run just after test_gnm_filenetwork_create(), presumably because the just created dataset has not been properly closed.
Cf https://github.com/OSGeo/gdal/actions/runs/11755814302/job/32752542561?pr=11224
