### PR TITLE
LVBAG: only run IsValid() if bFixInvalidData

### DIFF
--- a/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
+++ b/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
@@ -638,7 +638,7 @@ void OGRLVBAGLayer::EndElementCbk(const char *pszName)
                     poGeom->flattenTo2D();
 
 #ifdef HAVE_GEOS
-                if (!poGeom->IsValid() && bFixInvalidData)
+                if (bFixInvalidData && !poGeom->IsValid())
                 {
                     std::unique_ptr<OGRGeometry> poSubGeom =
                         std::unique_ptr<OGRGeometry>{poGeom->MakeValid()};


### PR DESCRIPTION
This will speed up processing if not needing to fix invalid data. May be related to https://lists.osgeo.org/pipermail/gdal-dev/2024-November/059794.html

CC @yorickdewid 