### PR TITLE
gdaltindex: restore -ot option accidentally removed in GDAL 3.10.0

### DIFF
--- a/apps/gdaltindex_lib.cpp
+++ b/apps/gdaltindex_lib.cpp
@@ -275,6 +275,11 @@ static std::unique_ptr<GDALArgumentParser> GDALTileIndexAppOptionsGetParser(
         .scan<'g', double>()
         .help(_("Set target extent in SRS unit."));
 
+    argParser->add_argument("-ot")
+        .metavar("<datatype>")
+        .store_into(psOptions->osDataType)
+        .help(_("Output data type."));
+
     argParser->add_argument("-bandcount")
         .metavar("<val>")
         .store_into(psOptions->osBandCount)

--- a/autotest/utilities/test_gdaltindex_lib.py
+++ b/autotest/utilities/test_gdaltindex_lib.py
@@ -443,3 +443,19 @@ def test_gdaltindex_lib_fetch_md(tmp_path, four_tiles):
     lyr = ds.GetLayer(0)
     f = lyr.GetNextFeature()
     assert f["foo_field"] == "bar"
+
+
+###############################################################################
+# Test -ot
+
+
+@pytest.mark.require_driver("GPKG")
+def test_gdaltindex_lib_ot(tmp_path, four_tiles):
+
+    index_filename = str(tmp_path / "test_gdaltindex_lib_ot.gpkg")
+
+    gdal.TileIndex(index_filename, four_tiles[0], options="-ot UInt16")
+
+    ds = ogr.Open(index_filename)
+    lyr = ds.GetLayer(0)
+    assert lyr.GetMetadataItem("DATA_TYPE") == "UInt16"


### PR DESCRIPTION
Fixes #11246

This option was new of GDAL 3.9 for GTI tile indices. Workaround: ``-mo DATA_TYPE=<datatype>``
