### PR TITLE
GDALCopyWords64(): tidy code

### DIFF
--- a/swig/csharp/CMakeLists.txt
+++ b/swig/csharp/CMakeLists.txt
@@ -237,7 +237,7 @@ function (gdal_csharp_dll)
     add_custom_command(
       COMMAND ${CMAKE_COMMAND} -E "copy_if_different"
               "${CMAKE_CURRENT_BINARY_DIR}/${_CSHARP_TARGET_SUBDIR}/${_root}-$<CONFIG>.csproj" "${_CSHARP_PROJ}"
-      VERBATIM PRE_BUILD
+      VERBATIM
       DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${_CSHARP_TARGET_SUBDIR}/${_root}-$<CONFIG>.csproj"
       OUTPUT ${_CSHARP_PROJ})
     add_dotnet(


### PR DESCRIPTION
Technically it is safer to cast a pointer to uintptr_t than our custom type. At least, it better documents the intent. In practice, I doubt this changes much.

CC @schwehr  w.r.t #11253 . Very low chance that it fixes your issue