### PR TITLE
CMake: fix swig/csharp/CMakeLists.txt compatibility with CMake 3.31

### DIFF
--- a/swig/csharp/CMakeLists.txt
+++ b/swig/csharp/CMakeLists.txt
@@ -237,7 +237,7 @@ function (gdal_csharp_dll)
     add_custom_command(
       COMMAND ${CMAKE_COMMAND} -E "copy_if_different"
               "${CMAKE_CURRENT_BINARY_DIR}/${_CSHARP_TARGET_SUBDIR}/${_root}-$<CONFIG>.csproj" "${_CSHARP_PROJ}"
-      VERBATIM PRE_BUILD
+      VERBATIM
       DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/${_CSHARP_TARGET_SUBDIR}/${_root}-$<CONFIG>.csproj"
       OUTPUT ${_CSHARP_PROJ})
     add_dotnet(


### PR DESCRIPTION
that no longer accept invalid PRE_BUILD keyword in OUTPUT form of add_custom_command() per https://cmake.org/cmake/help/latest/policy/CMP0175.html

Should fix error of https://github.com/OSGeo/gdal/actions/runs/11805369849/job/32887659405?pr=11254
