### PR TITLE
Revert "CI: disable cfchecker based tests"

### DIFF
--- a/.github/workflows/ubuntu_24.04/Dockerfile.ci
+++ b/.github/workflows/ubuntu_24.04/Dockerfile.ci
@@ -157,8 +157,7 @@ RUN python3 -m pip install -U --break-system-packages -r /tmp/requirements.txt
 
 # cfchecker requires udunits2
 RUN apt-get install -y --allow-unauthenticated libudunits2-0 libudunits2-data
-# cfchecker currently broken because of https://github.com/cedadev/cf-checker/issues/113
-# RUN python3 -m pip install --break-system-packages cfchecker
+RUN python3 -m pip install --break-system-packages cfchecker
 
 RUN python3 -m pip install --break-system-packages fsspec
 


### PR DESCRIPTION
This reverts commit 33d2b37943b836b1e86edde793fc5d48fbf0fae7.

http://cfconventions.org/Data/standardized-region-list/standardized-region-list.xml has been restored per https://github.com/cf-convention/cf-convention.github.io/issues/555

Fixes #11256
