### PR TITLE
GTIFF: store bJXLLossless as a bool

### DIFF
--- a/frmts/gtiff/gt_overview.cpp
+++ b/frmts/gtiff/gt_overview.cpp
@@ -1041,7 +1041,7 @@ CPLErr GTIFFBuildOverviewsEx(const char *pszFilename, int nBands,
         if (const char *pszJXLLossLess =
                 GetOptionValue("JXL_LOSSLESS", "JXL_LOSSLESS_OVERVIEW"))
         {
-            const double bJXLLossless = CPLTestBool(pszJXLLossLess);
+            const bool bJXLLossless = CPLTestBool(pszJXLLossLess);
             TIFFSetField(hTIFF, TIFFTAG_JXL_LOSSYNESS,
                          bJXLLossless ? JXL_LOSSLESS : JXL_LOSSY);
             GTIFFSetJXLLossless(GDALDataset::ToHandle(hODS), bJXLLossless);


### PR DESCRIPTION
"GTiff: fix type of bJXLLossless 

In frmts/gtiff/gt_overview.cpp we were storing a bool as a double, then using it as a bool without a cast.

clang++ warns:

/home/werdna/gdal/git/frmts/gtiff/gt_overview.cpp:1046:26: warning: implicit conversion turns floating-point number into integer: 'const double' to 'bool' [-Wfloat-conversion]
 1046 |                          bJXLLossless ? JXL_LOSSLESS : JXL_LOSSY);

/home/werdna/gdal/git/frmts/gtiff/gt_overview.cpp:1047:62: warning: implicit conversion turns floating-point number into integer: 'const double' to 'bool' [-Wfloat-conversion]
 1047 |             GTIFFSetJXLLossless(GDALDataset::ToHandle(hODS), bJXLLossless);
"

## Environment

Provide environment details, if relevant:

* OS: Ubuntu 24-10
* Compiler: clang++-20
