### PR TITLE
Java bindings: remove useless -link when invoking javadoc

### DIFF
--- a/swig/java/build_java_doc.cmake
+++ b/swig/java/build_java_doc.cmake
@@ -31,7 +31,6 @@ execute_process(COMMAND ${Java_JAVADOC_EXECUTABLE}
                         -d "${BUILD_DIR}/java"
                         -sourcepath "${BUILD_DIR}/org_patched"
                         -subpackages org.gdal
-                        -link http://java.sun.com/javase/6/docs/api
                         -windowtitle "GDAL/OGR ${GDAL_VERSION} Java bindings API"
                 WORKING_DIRECTORY "${BUILD_DIR}")
 

--- a/swig/java/make_doc.sh
+++ b/swig/java/make_doc.sh
@@ -19,7 +19,7 @@ cp gdal-package-info.java org_patched/org/gdal/gdal/package-info.java
 cp gdalconst-package-info.java org_patched/org/gdal/gdalconst/package-info.java
 cp ogr-package-info.java org_patched/org/gdal/ogr/package-info.java
 cp osr-package-info.java org_patched/org/gdal/osr/package-info.java
-javadoc -overview overview.html -public -d ./java -sourcepath org_patched -subpackages org.gdal -link http://java.sun.com/javase/6/docs/api -windowtitle "GDAL/OGR ${version} Java bindings API"
+javadoc -overview overview.html -public -d ./java -sourcepath org_patched -subpackages org.gdal -windowtitle "GDAL/OGR ${version} Java bindings API"
 
 # Create a zip with the Javadoc
 rm -f javadoc.zip


### PR DESCRIPTION
Cf https://lists.osgeo.org/pipermail/gdal-dev/2024-November/059815.html
