### PR TITLE
GPKG: make CreateCopy() work on vector datasets

### DIFF
--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -10618,6 +10618,21 @@ def test_ogr_gpkg_ST_Length_on_ellipsoid(tmp_vsimem):
 
 
 ###############################################################################
+# Test that CreateCopy() works on a vector dataset
+# Test fix for https://github.com/OSGeo/gdal/issues/11282
+
+
+@gdaltest.enable_exceptions()
+@pytest.mark.usefixtures("tpoly")
+def test_ogr_gpkg_CreateCopy(gpkg_ds, tmp_vsimem):
+
+    tmpfilename = tmp_vsimem / "test_ogr_gpkg_CreateCopy.gpkg"
+
+    out_ds = gdal.GetDriverByName("GPKG").CreateCopy(tmpfilename, gpkg_ds)
+    assert out_ds.GetLayerCount() == 1
+
+
+###############################################################################
 # Test LAUNDER=YES layer creation option
 
 

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -6005,6 +6005,21 @@ GDALDataset *GDALGeoPackageDataset::CreateCopy(const char *pszFilename,
                                                GDALProgressFunc pfnProgress,
                                                void *pProgressData)
 {
+    const int nBands = poSrcDS->GetRasterCount();
+    if (nBands == 0)
+    {
+        GDALDataset *poDS = nullptr;
+        GDALDriver *poThisDriver =
+            GDALDriver::FromHandle(GDALGetDriverByName("GPKG"));
+        if (poThisDriver != nullptr)
+        {
+            poDS = poThisDriver->DefaultCreateCopy(pszFilename, poSrcDS,
+                                                   bStrict, papszOptions,
+                                                   pfnProgress, pProgressData);
+        }
+        return poDS;
+    }
+
     const char *pszTilingScheme =
         CSLFetchNameValueDef(papszOptions, "TILING_SCHEME", "CUSTOM");
 
@@ -6018,7 +6033,6 @@ GDALDataset *GDALGeoPackageDataset::CreateCopy(const char *pszFilename,
         apszUpdatedOptions.SetNameValue("RASTER_TABLE", osBasename);
     }
 
-    const int nBands = poSrcDS->GetRasterCount();
     if (nBands != 1 && nBands != 2 && nBands != 3 && nBands != 4)
     {
         CPLError(CE_Failure, CPLE_NotSupported,
@@ -6045,7 +6059,7 @@ GDALDataset *GDALGeoPackageDataset::CreateCopy(const char *pszFilename,
 
         GDALGeoPackageDataset *poDS = nullptr;
         GDALDriver *poThisDriver =
-            reinterpret_cast<GDALDriver *>(GDALGetDriverByName("GPKG"));
+            GDALDriver::FromHandle(GDALGetDriverByName("GPKG"));
         if (poThisDriver != nullptr)
         {
             apszUpdatedOptions.SetNameValue("SKIP_HOLES", "YES");


### PR DESCRIPTION
Fixes #11282, which is due to a9745e5f8df that mapped CopyDataSource() onto CreateCopy(), but the GPKG driver implementation of CreateCopy() wasn't ready to deal with vector dataset.
