### PR TITLE
Introducing GDAL Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ GDAL - Geospatial Data Abstraction Library
 [![Coverage Status](https://coveralls.io/repos/github/OSGeo/gdal/badge.svg?branch=master)](https://coveralls.io/github/OSGeo/gdal?branch=master)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/8250/badge)](https://www.bestpractices.dev/projects/8250)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/OSGeo/gdal/badge)](https://securityscorecards.dev/viewer/?uri=github.com/OSGeo/gdal)
+[![Gurubase](https://img.shields.io/badge/Gurubase-Ask%20GDAL%20Guru-006BFF)](https://gurubase.io/g/gdal)
 
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.5884351.svg)](https://doi.org/10.5281/zenodo.5884351)
 


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [GDAL Guru](https://gurubase.io/g/gdal) to Gurubase. GDAL Guru uses the data from this repo and data from the [docs](https://gdal.org/en/latest/) to answer questions by leveraging the LLM.

In this PR, I showcased the "GDAL Guru", which highlights that GDAL now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable GDAL Guru in Gurubase, just let me know that's totally fine.
