### PR TITLE
[Backport release/3.10] OGRWarpedLayer: do not use source layer GetArrowStream() as this would skip reprojection...

### DIFF
--- a/ogr/ogrsf_frmts/generic/ogrwarpedlayer.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrwarpedlayer.cpp
@@ -543,6 +543,9 @@ int OGRWarpedLayer::TestCapability(const char *pszCapability)
 
     int bVal = m_poDecoratedLayer->TestCapability(pszCapability);
 
+    if (EQUAL(pszCapability, OLCFastGetArrowStream))
+        return false;
+
     if (EQUAL(pszCapability, OLCFastSpatialFilter) ||
         EQUAL(pszCapability, OLCRandomWrite) ||
         EQUAL(pszCapability, OLCSequentialWrite))
@@ -570,6 +573,16 @@ void OGRWarpedLayer::SetExtent(double dfXMin, double dfYMin, double dfXMax,
     sStaticEnvelope.MinY = dfYMin;
     sStaticEnvelope.MaxX = dfXMax;
     sStaticEnvelope.MaxY = dfYMax;
+}
+
+/************************************************************************/
+/*                            GetArrowStream()                          */
+/************************************************************************/
+
+bool OGRWarpedLayer::GetArrowStream(struct ArrowArrayStream *out_stream,
+                                    CSLConstList papszOptions)
+{
+    return OGRLayer::GetArrowStream(out_stream, papszOptions);
 }
 
 #endif /* #ifndef DOXYGEN_SKIP */

--- a/ogr/ogrsf_frmts/generic/ogrwarpedlayer.h
+++ b/ogr/ogrsf_frmts/generic/ogrwarpedlayer.h
@@ -85,6 +85,9 @@ class CPL_DLL OGRWarpedLayer : public OGRLayerDecorator
     virtual OGRErr GetExtent(OGREnvelope *psExtent, int bForce = TRUE) override;
 
     virtual int TestCapability(const char *) override;
+
+    virtual bool GetArrowStream(struct ArrowArrayStream *out_stream,
+                                CSLConstList papszOptions = nullptr) override;
 };
 
 #endif /* #ifndef DOXYGEN_SKIP */


### PR DESCRIPTION
Backport #11293
 **Authored by:** @rouault