### PR TITLE
[Backport release/3.10] gdalinfo: fix bound checking for value of -sds argument

### DIFF
--- a/apps/gdal_translate_bin.cpp
+++ b/apps/gdal_translate_bin.cpp
@@ -194,6 +194,7 @@ MAIN_START(argc, argv)
         else
         {
             char **papszSubdatasets = GDALGetMetadata(hDataset, "SUBDATASETS");
+            const int nSubdatasets = CSLCount(papszSubdatasets) / 2;
             char *pszSubDest = static_cast<char *>(
                 CPLMalloc(strlen(sOptionsForBinary.osDest.c_str()) + 32));
 
@@ -205,11 +206,11 @@ MAIN_START(argc, argv)
             CPLString osTemp;
 
             const char *pszFormat = nullptr;
-            if (CSLCount(papszSubdatasets) / 2 < 10)
+            if (nSubdatasets < 10)
             {
                 pszFormat = "%s_%d";
             }
-            else if (CSLCount(papszSubdatasets) / 2 < 100)
+            else if (nSubdatasets < 100)
             {
                 pszFormat = "%s_%002d";
             }

--- a/apps/gdalinfo_bin.cpp
+++ b/apps/gdalinfo_bin.cpp
@@ -190,7 +190,7 @@ MAIN_START(argc, argv)
         if (sOptionsForBinary.nSubdataset > 0)
         {
             char **papszSubdatasets = GDALGetMetadata(hDataset, "SUBDATASETS");
-            int nSubdatasets = CSLCount(papszSubdatasets);
+            const int nSubdatasets = CSLCount(papszSubdatasets) / 2;
 
             if (nSubdatasets > 0 &&
                 sOptionsForBinary.nSubdataset <= nSubdatasets)


### PR DESCRIPTION
Backport #11324
 **Authored by:** @rouault