### PR TITLE
Set GDAL_DEV_SUFFIX to the pre-release suffix if a corresponding Git tag was found

### DIFF
--- a/cmake/helpers/GdalVersion.cmake
+++ b/cmake/helpers/GdalVersion.cmake
@@ -48,6 +48,40 @@ endif ()
 
 if (EXISTS ${GDAL_ROOT_SOURCE_DIR}/.git)
     set(GDAL_DEV_SUFFIX "dev")
+
+    # Try look in the Git tags to see if it is a special version
+    find_package(Git QUIET)
+    if(GIT_FOUND)
+        execute_process(
+            COMMAND "${GIT_EXECUTABLE}" "tag" "--points-at" "HEAD"
+            WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+            RESULT_VARIABLE git_result
+            OUTPUT_VARIABLE git_tags
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+
+        if(git_result EQUAL 0)
+            # First replaces the line breaks by a ";", so we can iterate over it
+            string(REGEX REPLACE "\r?\n" ";" git_tags "${git_tags}")
+            foreach(git_tag ${git_tags})
+                # GDAL is currently not fully compatible with Semantic Versioning 2.0.0, as there would have to be a minus before the pre-release tag, so we allow it to be omitted.
+                if (git_tag MATCHES "^v${GDAL_VERSION_MAJOR}.${GDAL_VERSION_MINOR}.${GDAL_VERSION_REV}-?(.*)")
+                    # ${CMAKE_MATCH_1} contains the pre-release suffix
+                    if (NOT CMAKE_MATCH_1)
+                        # In case there is no pre-release suffix, it is a release version.
+                        set(GDAL_DEV_SUFFIX "")
+                        # Ignore further suffixes (e.g., a RC tag)
+                        break()
+                    else()
+                        # Take the pre-release suffix as dev suffix. Normally there should only be one pre-release tag,
+                        # so we don't need any logic here to compare the pre-release tags with each other. However,
+                        # as there may still be a release tag without a pre-release suffix, we do not break the loop.
+                        set(GDAL_DEV_SUFFIX "${CMAKE_MATCH_1}")
+                    endif()
+                endif()
+            endforeach()
+        endif()
+    endif()
 else()
     set(GDAL_DEV_SUFFIX "")
 endif()


### PR DESCRIPTION
As noted in #11315 as a side note, I wondered why we are getting as `${GDAL_VERSION}` `3.10.0dev` and not just `3.10.0` when checking out a release tag via:
```
git clone --depth 1 --branch v3.10.0 https://github.com/OSGeo/gdal.git .
```

Reason is, that the suffix `dev` will be always added when the `.git` directory is present even the `GDAL_RELEASE_NAME` (within `gdal_version.h.in`) doesn't contain it anymore. Therefore I added a logic to parse the git tags.

Results (from CMake output) when switching between different tags or current `master`:
- `master`:
  ```
  -- GDAL_VERSION          = 3.11.0dev
  -- GDAL_ABI_FULL_VERSION = 311
  ```
- Tag `3.10.0`
  ```
  -- GDAL_VERSION          = 3.10.0
  -- GDAL_ABI_FULL_VERSION = 310
  ```
- Tag `3.10.0RC3` (same Git revision as the release version)
  ```
  -- GDAL_VERSION          = 3.10.0
  -- GDAL_ABI_FULL_VERSION = 310
  ```
- Tag `3.10.0RC2`
  ```
  -- GDAL_VERSION          = 3.10.0RC2
  -- GDAL_ABI_FULL_VERSION = 310
  ```
- Tag `3.10.0beta1`
  ```
  -- GDAL_VERSION          = 3.10.0beta1
  -- GDAL_ABI_FULL_VERSION = 310
  ```

As far as I can see `${GDAL_DEV_SUFFIX}` is only used to setup `${GDAL_VERSION}` and didn't found any code which parses `${GDAL_VERSION}` (so it is only handled as string), so I think there should be no side effect.

// Note: Not sure about the coding guide lines related to CMake, as sometimes the indentation is two spaces and sometimes 4, sometimes the temporary variables are uppercase, sometimes lowercase, not sure about line length limit, ....