### PR TITLE
[Backport release/3.10] Set GDAL_DEV_SUFFIX to the pre-release suffix if a corresponding Git tag was found

### DIFF
--- a/cmake/helpers/GdalVersion.cmake
+++ b/cmake/helpers/GdalVersion.cmake
@@ -48,6 +48,40 @@ endif ()
 
 if (EXISTS ${GDAL_ROOT_SOURCE_DIR}/.git)
     set(GDAL_DEV_SUFFIX "dev")
+
+    # Try look in the Git tags to see if it is a special version
+    find_package(Git QUIET)
+    if(GIT_FOUND)
+        execute_process(
+            COMMAND "${GIT_EXECUTABLE}" "tag" "--points-at" "HEAD"
+            WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+            RESULT_VARIABLE git_result
+            OUTPUT_VARIABLE git_tags
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+
+        if(git_result EQUAL 0)
+            # First replaces the line breaks by a ";", so we can iterate over it
+            string(REGEX REPLACE "\r?\n" ";" git_tags "${git_tags}")
+            foreach(git_tag ${git_tags})
+                # GDAL is currently not fully compatible with Semantic Versioning 2.0.0, as there would have to be a minus before the pre-release tag, so we allow it to be omitted.
+                if (git_tag MATCHES "^v${GDAL_VERSION_MAJOR}.${GDAL_VERSION_MINOR}.${GDAL_VERSION_REV}-?(.*)")
+                    # ${CMAKE_MATCH_1} contains the pre-release suffix
+                    if (NOT CMAKE_MATCH_1)
+                        # In case there is no pre-release suffix, it is a release version.
+                        set(GDAL_DEV_SUFFIX "")
+                        # Ignore further suffixes (e.g., a RC tag)
+                        break()
+                    else()
+                        # Take the pre-release suffix as dev suffix. Normally there should only be one pre-release tag,
+                        # so we don't need any logic here to compare the pre-release tags with each other. However,
+                        # as there may still be a release tag without a pre-release suffix, we do not break the loop.
+                        set(GDAL_DEV_SUFFIX "${CMAKE_MATCH_1}")
+                    endif()
+                endif()
+            endforeach()
+        endif()
+    endif()
 else()
     set(GDAL_DEV_SUFFIX "")
 endif()


### PR DESCRIPTION
Backport #11335
 **Authored by:** @SunBlack