### PR TITLE
libcsf: address (false positive) Coverity warnings

### DIFF
--- a/frmts/pcraster/libcsf/attrsize.c
+++ b/frmts/pcraster/libcsf/attrsize.c
@@ -12,9 +12,10 @@ size_t CsfAttributeSize(
 	 CSF_ATTR_ID id)    /* identification of attribute */
 {
 	ATTR_CNTRL_BLOCK b;
-        memset(&b, 0, sizeof(b));
+	int i;
+	memset(&b, 0, sizeof(b));
 
-	if (CsfGetAttrBlock(m, id, &b) != 0)
-		return b.attrs[CsfGetAttrIndex(id, &b)].attrSize;
-        return 0;
+	if (CsfGetAttrBlockAndIdx(m, id, &b, &i) != 0)
+		return b.attrs[i].attrSize;
+	return 0;
 }

--- a/frmts/pcraster/libcsf/csfimpl.h
+++ b/frmts/pcraster/libcsf/csfimpl.h
@@ -200,6 +200,7 @@ void  CsfGetVarType(void *dest, const CSF_VAR_TYPE *src, CSF_CR cellRepr);
 void  CsfReadAttrBlock( MAP *m, CSF_FADDR32 pos, ATTR_CNTRL_BLOCK *b);
 int   CsfWriteAttrBlock(MAP *m, CSF_FADDR32 pos, ATTR_CNTRL_BLOCK *b);
 int   CsfGetAttrIndex(CSF_ATTR_ID id, const ATTR_CNTRL_BLOCK *b);
+CSF_FADDR32 CsfGetAttrBlockAndIdx(MAP *m, CSF_ATTR_ID id, ATTR_CNTRL_BLOCK *b, int *i);
 CSF_FADDR32 CsfGetAttrBlock(MAP *m, CSF_ATTR_ID id, ATTR_CNTRL_BLOCK *b);
 CSF_FADDR32 CsfGetAttrPosSize(MAP *m, CSF_ATTR_ID id, size_t *size);
 size_t CsfWriteSwapped(void *buf, size_t size, size_t n, FILE  *f);

--- a/frmts/pcraster/libcsf/delattr.c
+++ b/frmts/pcraster/libcsf/delattr.c
@@ -17,6 +17,7 @@ CSF_ATTR_ID MdelAttribute(
 	CSF_ATTR_ID id)   /* identification of attribute */
 {
 	ATTR_CNTRL_BLOCK b;
+	int i;
 	CSF_FADDR32 pos;
 
 	if (! WRITE_ENABLE(m))
@@ -25,11 +26,11 @@ CSF_ATTR_ID MdelAttribute(
 		goto error;
 	}
 
-	pos = CsfGetAttrBlock(m, id, &b);
+	pos = CsfGetAttrBlockAndIdx(m, id, &b, &i);
 	if (pos == 0)
 		goto error;
 
-	b.attrs[CsfGetAttrIndex(id, &b)].attrId = ATTR_NOT_USED;
+	b.attrs[i].attrId = ATTR_NOT_USED;
 	if (CsfWriteAttrBlock(m, pos, &b))
 	{
 		M_ERROR(WRITE_ERROR);

--- a/frmts/pcraster/libcsf/gattrblk.c
+++ b/frmts/pcraster/libcsf/gattrblk.c
@@ -2,6 +2,37 @@
 #include "csfimpl.h"
 
 /* get the attribute control block (LIBRARY_INTERNAL)
+ * CsfGetAttrBlockAndIdx searches for the attribute control block
+ * that keeps the information for the given id.
+ * returns
+ * 0 if attribute is not found,
+ * or if found, the file position of the attribute
+ * control block.
+ */
+CSF_FADDR32 CsfGetAttrBlockAndIdx(
+	MAP *m,     /* map handle */
+	CSF_ATTR_ID id,   /* identification of the attribute */
+	ATTR_CNTRL_BLOCK *b, /* write-only, attribute control block containing
+	                      * the id information.
+	                      */
+	int *i) /* write-only, return of CsfGetAttrIndex(id, b) */
+{
+	CSF_FADDR32 next;
+
+	next = m->main.attrTable;
+	while (next != 0 )
+	{
+		CsfReadAttrBlock(m, next, b);
+		*i = CsfGetAttrIndex(id, b);
+		if (*i != NR_ATTR_IN_BLOCK)
+			return next;
+		next = b->next;
+	}
+	*i = 0;
+	return 0;
+}
+
+/* get the attribute control block (LIBRARY_INTERNAL)
  * GetAttrBlock searches for the attribute control block
  * that keeps the information for the given id.
  * returns
@@ -16,17 +47,8 @@ CSF_FADDR32 CsfGetAttrBlock(
 	                      * the id information.
 	                      */
 {
-	CSF_FADDR32 next;
-
-	next = m->main.attrTable;
-	while (next != 0 )
-	{
-		CsfReadAttrBlock(m, next, b);
-		if (CsfGetAttrIndex(id, b) != NR_ATTR_IN_BLOCK)
-			break;
-		next = b->next;
-	}
-	return(next);
+	int i;
+	return CsfGetAttrBlockAndIdx(m, id, b, &i);
 }
 
 /* get the attribute position and size (LIBRARY_INTERNAL)
@@ -44,10 +66,9 @@ CSF_FADDR32 CsfGetAttrPosSize(
 	ATTR_CNTRL_BLOCK b;
 	int i;
 
-	if (CsfGetAttrBlock(m,id, &b) == 0)
+	if (CsfGetAttrBlockAndIdx(m,id,&b,&i) == 0)
 		return 0;
 
-	i = CsfGetAttrIndex(id, &b);
 	*size =	b.attrs[i].attrSize;
 	return b.attrs[i].attrOffset;
 }

--- a/frmts/pcraster/libcsf/getattr.c
+++ b/frmts/pcraster/libcsf/getattr.c
@@ -3,7 +3,7 @@
 
 /* read an attribute (LIBRARY_INTERNAL)
  * MgetAttribute reads an attribute if it is available.
- * Be aware that you can't pass a simple pointer to some 
+ * Be aware that you can't pass a simple pointer to some
  * (array of) structure(s) due to alignment en endian problems.
  * At some time there will be a separate get function for each attribute
  * returns 0 if the attribute is not found, arg id if
@@ -20,6 +20,7 @@ CSF_ATTR_ID CsfGetAttribute(
 {
 	ATTR_CNTRL_BLOCK b;
 	CSF_FADDR pos;
+	int i;
 	PRECOND(CsfValidSize(elSize));
 	CHECKHANDLE_GOTO(m, error);
 
@@ -29,19 +30,18 @@ CSF_ATTR_ID CsfGetAttribute(
 		goto error;
 	}
 
-	if (CsfGetAttrBlock(m, id, &b) != 0) 
+	if (CsfGetAttrBlockAndIdx(m, id, &b, &i) != 0)
 	{
-		int i = CsfGetAttrIndex(id, &b);
 		*nmemb =	b.attrs[i].attrSize;
 		POSTCOND( ((*nmemb) % elSize) == 0);
 		*nmemb /= elSize;
 		POSTCOND( (*nmemb) > 0);
 		pos =	b.attrs[i].attrOffset;
-		(void)csf_fseek(m->fp, pos, SEEK_SET); 
+		(void)csf_fseek(m->fp, pos, SEEK_SET);
 		m->read(attr,elSize, (size_t)(*nmemb),m->fp);
 		return(id);
 	}
-	else 
+	else
 		*nmemb = 0;
 error:	return(0);	/* not available  or an error */
 } /* MgetAttribute */


### PR DESCRIPTION
Coverity Scan has false positives about calls to CsfGetAttrIndex() that might return NR_ATTR_IN_BLOCK whereas they can not. Adding a CsfGetAttrBlockAndIdx() function that returns both the block and index should make it happy.

@kordejong can you double check that?