### PR TITLE
tests: skip tests that crash with OpenEXR 3.3.2

### DIFF
--- a/autotest/gdrivers/exr.py
+++ b/autotest/gdrivers/exr.py
@@ -20,6 +20,15 @@ from osgeo import gdal
 pytestmark = pytest.mark.require_driver("EXR")
 
 
+def exr_is_gte(x, y):
+    drv = gdal.GetDriverByName("EXR")
+    if drv is None:
+        return False
+    return [
+        int(i) for i in drv.GetMetadataItem("OPENEXR_VERSION", "EXR").split(".")[0:2]
+    ] >= [x, y]
+
+
 def test_exr_byte_createcopy():
     tst = gdaltest.GDALTest("EXR", "byte.tif", 1, 4672)
     tst.testCreateCopy(vsimem=1)
@@ -114,6 +123,7 @@ def test_exr_compression_create():
     gdal.Unlink(tmpfilename)
 
 
+@pytest.mark.skipif(exr_is_gte(3, 3), reason="test crashes with OpenEXR 3.3.2")
 def test_exr_compression_dwa_compression_level():
     src_ds = gdal.Open("data/small_world.tif")
     tmpfilename = "/vsimem/temp.exr"
@@ -157,6 +167,7 @@ def test_exr_tiling_custom_tile_size():
     gdal.Unlink(tmpfilename)
 
 
+@pytest.mark.skipif(exr_is_gte(3, 3), reason="test crashes with OpenEXR 3.3.2")
 def test_exr_rgb_byte_tiled():
     src_ds = gdal.Open("data/small_world.tif")
     tmpfilename = "/vsimem/temp.exr"
@@ -170,6 +181,7 @@ def test_exr_rgb_byte_tiled():
     gdal.Unlink(tmpfilename)
 
 
+@pytest.mark.skipif(exr_is_gte(3, 3), reason="test crashes with OpenEXR 3.3.2")
 def test_exr_rgb_byte_strip_no_auto_rescale():
     src_ds = gdal.Open("data/small_world.tif")
     tmpfilename = "/vsimem/temp.exr"
@@ -183,6 +195,7 @@ def test_exr_rgb_byte_strip_no_auto_rescale():
     gdal.Unlink(tmpfilename)
 
 
+@pytest.mark.skipif(exr_is_gte(3, 3), reason="test crashes with OpenEXR 3.3.2")
 def test_exr_overviews():
     src_ds = gdal.Open("data/small_world.tif")
     tmpfilename = "/vsimem/temp.exr"

--- a/frmts/exr/exrdataset.cpp
+++ b/frmts/exr/exrdataset.cpp
@@ -2039,5 +2039,7 @@ void GDALRegister_EXR()
     poDriver->pfnCreateCopy = GDALEXRDataset::CreateCopy;
     poDriver->pfnCreate = GDALEXRDataset::Create;
 
+    poDriver->SetMetadataItem("OPENEXR_VERSION", OPENEXR_VERSION_STRING, "EXR");
+
     GetGDALDriverManager()->RegisterDriver(poDriver);
 }


### PR DESCRIPTION
The update of OpenEXR in alpine:edge from 3.1.13-r2 (https://github.com/OSGeo/gdal/actions/runs/11960737896/job/33345432787) to 3.3.2-r0
(https://github.com/OSGeo/gdal/actions/runs/12000822356/job/33450446198) causes multiple tests to crash when reading pixels. This is apparently linked to tiled files.

```
$ valgrind apps/gdallocationinfo temp.exr 0 0
Report:
  Location: (0P,0L)
  Band 1:
==96901== Invalid write of size 8
==96901==    at 0x11A9E833: ??? (in /usr/lib/libOpenEXRCore-3_3.so.32.3.3.2)
==96901==    by 0x11A9EFEC: ??? (in /usr/lib/libOpenEXRCore-3_3.so.32.3.3.2)
==96901==    by 0x11AA728A: exr_decoding_run (in /usr/lib/libOpenEXRCore-3_3.so.32.3.3.2)
==96901==    by 0xA2F275E: ??? (in /usr/lib/libOpenEXR-3_3.so.32.3.3.2)
==96901==    by 0xA2EFBFF: Imf_3_3::TiledInputFile::readTiles(int, int, int, int, int, int) (in /usr/lib/libOpenEXR-3_3.so.32.3.3.2)
==96901==    by 0xA2F2505: Imf_3_3::TiledInputFile::readTile(int, int, int, int) (in /usr/lib/libOpenEXR-3_3.so.32.3.3.2)
==96901==    by 0x59BE255: GDALEXRRasterBand::IReadBlock(int, int, void*) (in /home/even/gdal/gdal/build_ci_alpine/libgdal.so.36.3.11.0)
==96901==  Address 0x0 is not stack'd, malloc'd or (recently) free'd
==96901==
==96901==
==96901== Process terminating with default action of signal 11 (SIGSEGV): dumping core
==96901==  Access not within mapped region at address 0x0
==96901==    at 0x11A9E833: ??? (in /usr/lib/libOpenEXRCore-3_3.so.32.3.3.2)
==96901==    by 0x11A9EFEC: ??? (in /usr/lib/libOpenEXRCore-3_3.so.32.3.3.2)
==96901==    by 0x11AA728A: exr_decoding_run (in /usr/lib/libOpenEXRCore-3_3.so.32.3.3.2)
==96901==    by 0xA2F275E: ??? (in /usr/lib/libOpenEXR-3_3.so.32.3.3.2)
==96901==    by 0xA2EFBFF: Imf_3_3::TiledInputFile::readTiles(int, int, int, int, int, int) (in /usr/lib/libOpenEXR-3_3.so.32.3.3.2)
==96901==    by 0xA2F2505: Imf_3_3::TiledInputFile::readTile(int, int, int, int) (in /usr/lib/libOpenEXR-3_3.so.32.3.3.2)
==96901==    by 0x59BE255: GDALEXRRasterBand::IReadBlock(int, int, void*) (in /home/even/gdal/gdal/build_ci_alpine/libgdal.so.36.3.11.0)
```
