### PR TITLE
[Backport release/3.10] Doxygen docs: use \code instead of <pre>

### DIFF
--- a/ogr/ogr_api.h
+++ b/ogr/ogr_api.h
@@ -727,7 +727,7 @@ OGRFeatureH CPL_DLL OGR_L_GetNextFeature(OGRLayerH) CPL_WARN_UNUSED_RESULT;
 /** Conveniency macro to iterate over features of a layer.
  *
  * Typical usage is:
- * <pre>
+ * \code{.cpp}
  * OGR_FOR_EACH_FEATURE_BEGIN(hFeat, hLayer)
  * {
  *      // Do something, including continue, break;
@@ -735,14 +735,14 @@ OGRFeatureH CPL_DLL OGR_L_GetNextFeature(OGRLayerH) CPL_WARN_UNUSED_RESULT;
  *      // outside of the loop, in which case use OGR_F_Destroy(hFeat))
  * }
  * OGR_FOR_EACH_FEATURE_END(hFeat)
- * </pre>
+ * \endcode
  *
  * In C++, you might want to use instead range-based loop:
- * <pre>
+ * \code{.cpp}
  * for( auto&& poFeature: poLayer )
  * {
  * }
- * </pre>
+ * \endcode
  *
  * @param hFeat variable name for OGRFeatureH. The variable will be declared
  *              inside the macro body.

--- a/ogr/ogr_feature.h
+++ b/ogr/ogr_feature.h
@@ -1136,13 +1136,13 @@ class CPL_DLL OGRFeature
      * (dereference) more than one iterator step at a time, since you will get
      * a reference to the same object (FieldValue) at each iteration step.
      *
-     * <pre>
+     * \code{.cpp}
      * for( auto&& oField: poFeature )
      * {
      *      std::cout << oField.GetIndex() << "," << oField.GetName()<< ": " <<
      * oField.GetAsString() << std::endl;
      * }
-     * </pre>
+     * \endcode
      *
      * @since GDAL 2.3
      */

--- a/ogr/ogrsf_frmts/ogrsf_frmts.dox
+++ b/ogr/ogrsf_frmts/ogrsf_frmts.dox
@@ -49,9 +49,9 @@
   otherwise a handle to a GDALDataset.  This GDALDataset should be
   closed by deleting the object when it is no longer needed.
 
-  <b>Example:</b>
+  Example:
 
-  <pre>
+  \code{.cpp}
     OGRDataSourceH	hDS;
     OGRSFDriverH        *pahDriver;
 
@@ -64,7 +64,7 @@
     ... use the data source ...
 
     OGRReleaseDataSource( hDS );
-  </pre>
+  \endcode
 
 */
 
@@ -101,9 +101,9 @@
   otherwise a handle to a GDALDataset.  This GDALDataset should be
   closed by deleting the object when it is no longer needed.
 
-  <b>Example:</b>
+  Example:
 
-  <pre>
+  \code{.cpp}
     OGRDataSourceH  hDS;
     OGRSFDriverH        *pahDriver;
 
@@ -116,7 +116,7 @@
     ... use the data source ...
 
     OGRReleaseDataSource( hDS );
-  </pre>
+  \endcode
 
 */
 

--- a/port/cpl_conv.cpp
+++ b/port/cpl_conv.cpp
@@ -1658,7 +1658,7 @@ static void CPLAccessConfigOption(const char *pszKey, bool bGet)
  *
  * To override temporary a potentially existing option with a new value, you
  * can use the following snippet :
- * <pre>
+ * \code{.cpp}
  *     // backup old value
  *     const char* pszOldValTmp = CPLGetConfigOption(pszKey, NULL);
  *     char* pszOldVal = pszOldValTmp ? CPLStrdup(pszOldValTmp) : NULL;
@@ -1668,7 +1668,7 @@ static void CPLAccessConfigOption(const char *pszKey, bool bGet)
  *     // restore old value
  *     CPLSetConfigOption(pszKey, pszOldVal);
  *     CPLFree(pszOldVal);
- * </pre>
+ * \endcode
  *
  * @param pszKey the key of the option to retrieve
  * @param pszDefault a default value if the key does not match existing defined

--- a/port/cpl_csv.cpp
+++ b/port/cpl_csv.cpp
@@ -1476,13 +1476,13 @@ will take in a CSV filename and return a full path to the file. The
 returned string should be to an internal static buffer so that the
 caller doesn't have to free the result.
 
-<b>Example:</b><br>
+Example:
 
 The listgeo utility uses the following override function if the user
 specified a CSV file directory with the -t commandline switch (argument
-put into CSVDirName).  <p>
+put into CSVDirName).
 
-<pre>
+\code{.cpp}
 
     ...
     SetCSVFilenameHook( CSVFileOverride );
@@ -1497,7 +1497,7 @@ static const char *CSVFileOverride( const char * pszInput )
 
     return szPath;
 }
-</pre>
+\endcode
 
 */
 

--- a/port/cpl_error.cpp
+++ b/port/cpl_error.cpp
@@ -1267,9 +1267,9 @@ CPLSetErrorHandlerEx(CPLErrorHandler pfnErrorHandlerNew, void *pUserData)
  * Allow the library's user to specify an error handler function.
  * A valid error handler is a C function with the following prototype:
  *
- * <pre>
+ * \code{.cpp}
  *     void MyErrorHandler(CPLErr eErrClass, int err_no, const char *msg)
- * </pre>
+ * \endcode
  *
  * Pass NULL to come back to the default behavior.  The default behavior
  * (CPLDefaultErrorHandler()) is to write the message to stderr.

--- a/port/cpl_path.cpp
+++ b/port/cpl_path.cpp
@@ -110,13 +110,13 @@ static int CPLFindFilenameStart(const char *pszFilename, size_t nStart = 0)
  * filename.  If there is no path in the passed filename an empty string
  * will be returned (not NULL).
  *
- * <pre>
+ * \code{.cpp}
  * CPLGetPath( "abc/def.xyz" ) == "abc"
  * CPLGetPath( "/abc/def/" ) == "/abc/def"
  * CPLGetPath( "/" ) == "/"
  * CPLGetPath( "/abc/def" ) == "/abc"
  * CPLGetPath( "abc" ) == ""
- * </pre>
+ * \endcode
  *
  * @param pszFilename the filename potentially including a path.
  *
@@ -179,13 +179,13 @@ const char *CPLGetPath(const char *pszFilename)
  * filename.  If there is no path in the passed filename the dot will be
  * returned.  It is the only difference from CPLGetPath().
  *
- * <pre>
+ * \code{.cpp}
  * CPLGetDirname( "abc/def.xyz" ) == "abc"
  * CPLGetDirname( "/abc/def/" ) == "/abc/def"
  * CPLGetDirname( "/" ) == "/"
  * CPLGetDirname( "/abc/def" ) == "/abc"
  * CPLGetDirname( "abc" ) == "."
- * </pre>
+ * \endcode
  *
  * @param pszFilename the filename potentially including a path.
  *
@@ -248,11 +248,11 @@ const char *CPLGetDirname(const char *pszFilename)
  * filename.  If there is no filename (passed value ends in trailing directory
  * separator) an empty string is returned.
  *
- * <pre>
+ * \code{.cpp}
  * CPLGetFilename( "abc/def.xyz" ) == "def.xyz"
  * CPLGetFilename( "/abc/def/" ) == ""
  * CPLGetFilename( "abc/def" ) == "def"
- * </pre>
+ * \endcode
  *
  * @param pszFullFilename the full filename potentially including a path.
  *
@@ -279,11 +279,11 @@ const char *CPLGetFilename(const char *pszFullFilename)
  * name.  If there is no basename (passed value ends in trailing directory
  * separator, or filename starts with a dot) an empty string is returned.
  *
- * <pre>
+ * \code{.cpp}
  * CPLGetBasename( "abc/def.xyz" ) == "def"
  * CPLGetBasename( "abc/def" ) == "def"
  * CPLGetBasename( "abc/def/" ) == ""
- * </pre>
+ * \endcode
  *
  * @param pszFullFilename the full filename potentially including a path.
  *
@@ -334,10 +334,10 @@ const char *CPLGetBasename(const char *pszFullFilename)
  * name.  If there is no extension (the filename has no dot) an empty string
  * is returned.  The returned extension will not include the period.
  *
- * <pre>
+ * \code{.cpp}
  * CPLGetExtension( "abc/def.xyz" ) == "xyz"
  * CPLGetExtension( "abc/def" ) == ""
- * </pre>
+ * \endcode
  *
  * @param pszFullFilename the full filename potentially including a path.
  *
@@ -504,12 +504,12 @@ const char *CPLResetExtension(const char *pszPath, const char *pszExt)
  * The path, and extension are optional.  The basename may in fact contain
  * an extension if desired.
  *
- * <pre>
+ * \code{.cpp}
  * CPLFormFilename("abc/xyz", "def", ".dat" ) == "abc/xyz/def.dat"
  * CPLFormFilename(NULL,"def", NULL ) == "def"
  * CPLFormFilename(NULL, "abc/def.dat", NULL ) == "abc/def.dat"
  * CPLFormFilename("/abc/xyz/", "def.dat", NULL ) == "/abc/xyz/def.dat"
- * </pre>
+ * \endcode
  *
  * @param pszPath directory path to the directory containing the file.  This
  * may be relative or absolute, and may have a trailing path separator or
@@ -732,13 +732,13 @@ const char *CPLFormCIFilename(const char *pszPath, const char *pszBasename,
  * absolute, rather than relative, then it will be returned unaltered.
  *
  * Examples:
- * <pre>
+ * \code{.cpp}
  * CPLProjectRelativeFilename("abc/def", "tmp/abc.gif") == "abc/def/tmp/abc.gif"
  * CPLProjectRelativeFilename("abc/def", "/tmp/abc.gif") == "/tmp/abc.gif"
  * CPLProjectRelativeFilename("/xy", "abc.gif") == "/xy/abc.gif"
  * CPLProjectRelativeFilename("/abc/def", "../abc.gif") == "/abc/def/../abc.gif"
  * CPLProjectRelativeFilename("C:\WIN", "abc.gif") == "C:\WIN\abc.gif"
- * </pre>
+ * \endcode
  *
  * @param pszProjectDir the directory relative to which the secondary files
  * path should be interpreted.
@@ -923,13 +923,13 @@ const char *CPLExtractRelativePath(const char *pszBaseDir,
  * trailing slash removed. If there is no path in the passed filename
  * an empty string will be returned (not NULL).
  *
- * <pre>
+ * \code{.cpp}
  * CPLCleanTrailingSlash( "abc/def/" ) == "abc/def"
  * CPLCleanTrailingSlash( "abc/def" ) == "abc/def"
  * CPLCleanTrailingSlash( "c:\\abc\\def\\" ) == "c:\\abc\\def"
  * CPLCleanTrailingSlash( "c:\\abc\\def" ) == "c:\\abc\\def"
  * CPLCleanTrailingSlash( "abc" ) == "abc"
- * </pre>
+ * \endcode
  *
  * @param pszPath the path to be cleaned up
  *

--- a/port/cpl_vsil_curl.cpp
+++ b/port/cpl_vsil_curl.cpp
@@ -6289,7 +6289,7 @@ void VSINetworkStatsReset(void)
  * the CPL_VSIL_SHOW_NETWORK_STATS configuration option is set to YES.
  *
  * Example of output:
- * <pre>
+ * \code{.js}
  * {
  *   "methods":{
  *     "GET":{
@@ -6359,8 +6359,7 @@ void VSINetworkStatsReset(void)
  *     }
  *   }
  * }
-
- * </pre>
+ * \endcode
  *
  * @param papszOptions Unused.
  * @return a JSON serialized string to free with VSIFree(), or nullptr


### PR DESCRIPTION
Backport #11373
 **Authored by:** @rouault