### PR TITLE
vsisimple: explicitly allow NULL in VSIFree and VSIRealloc

### DIFF
--- a/port/cpl_vsisimple.cpp
+++ b/port/cpl_vsisimple.cpp
@@ -675,7 +675,10 @@ static void VSICheckMarkerEnd(char *ptr, size_t nEnd)
 /*                             VSIRealloc()                             */
 /************************************************************************/
 
-/** Analog of realloc(). Use VSIFree() to free */
+/** Analog of realloc(). Use VSIFree() to free.
+ *
+ * If the pointer is NULL, VSIRealloc is equivalent to VSIMalloc.
+ */
 void *VSIRealloc(void *pData, size_t nNewSize)
 
 {
@@ -824,7 +827,11 @@ void *VSIRealloc(void *pData, size_t nNewSize)
 /************************************************************************/
 
 /** Analog of free() for data allocated with VSIMalloc(), VSICalloc(),
- * VSIRealloc() */
+ * VSIRealloc().
+ *
+ * It is not an error to call VSIFree with a NULL pointer, and it will
+ * have no effect.
+ */
 void VSIFree(void *pData)
 
 {


### PR DESCRIPTION
## What does this PR do?

It's not always clear if `free` wrappers accept `nullptr`, so let's explicitly document that it's allowed.

Of course, I can update the PR if the intention is to forbid it in the future.

`malloc(0)` is even more problematic, but it's not addressed here.

## What are related issues/pull requests?

https://github.com/georust/gdal/pull/589#discussion_r1861983074

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
