### PR TITLE
GTiff/gdalwarp/COG: preserve pre-multiplied alpha information from source TIFF

### DIFF
--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -4712,6 +4712,19 @@ static GDALDatasetH GDALWarpCreateOutput(
             aosCreateOptions.FetchNameValue("PHOTOMETRIC") == nullptr)
         {
             aosCreateOptions.SetNameValue("PHOTOMETRIC", "RGB");
+
+            // Preserve potential ALPHA=PREMULTIPLIED from source alpha band
+            const char *pszAlpha;
+            if (aosCreateOptions.FetchNameValue("ALPHA") == nullptr &&
+                apeColorInterpretations.size() == 4 &&
+                apeColorInterpretations[3] == GCI_AlphaBand &&
+                GDALGetRasterCount(pahSrcDS[0]) == 4 &&
+                (pszAlpha =
+                     GDALGetMetadataItem(GDALGetRasterBand(pahSrcDS[0], 4),
+                                         "ALPHA", "IMAGE_STRUCTURE")))
+            {
+                aosCreateOptions.SetNameValue("ALPHA", pszAlpha);
+            }
         }
 
         /* The GTiff driver now supports writing band color interpretation */

--- a/autotest/gcore/cog.py
+++ b/autotest/gcore/cog.py
@@ -1961,3 +1961,32 @@ def test_cog_write_check_golden_file(tmp_path, src_filename, creation_options):
             )
     assert os.stat(src_filename).st_size == os.stat(out_filename).st_size
     assert open(src_filename, "rb").read() == open(out_filename, "rb").read()
+
+
+###############################################################################
+
+
+def test_cog_preserve_ALPHA_PREMULTIPLIED_on_copy(tmp_vsimem):
+
+    src_filename = str(tmp_vsimem / "src.tif")
+    src_ds = gdal.GetDriverByName("GTiff").Create(
+        src_filename, 1, 1, 4, options=["ALPHA=PREMULTIPLIED", "PROFILE=BASELINE"]
+    )
+    src_ds.SetGeoTransform([500000, 1, 0, 4500000, 0, -1])
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(32631)
+    src_ds.SetProjection(srs.ExportToWkt())
+
+    out_filename = str(tmp_vsimem / "out.tif")
+    gdal.GetDriverByName("COG").CreateCopy(
+        out_filename,
+        src_ds,
+        options=[
+            "TILING_SCHEME=GoogleMapsCompatible",
+        ],
+    )
+    with gdal.Open(out_filename) as ds:
+        assert (
+            ds.GetRasterBand(4).GetMetadataItem("ALPHA", "IMAGE_STRUCTURE")
+            == "PREMULTIPLIED"
+        )

--- a/frmts/gtiff/gtiffrasterband.cpp
+++ b/frmts/gtiff/gtiffrasterband.cpp
@@ -166,7 +166,12 @@ GTiffRasterBand::GTiffRasterBand(GTiffDataset *poDSIn, int nBandIn)
             if (nBand > nBaseSamples && nBand - nBaseSamples - 1 < count &&
                 (v[nBand - nBaseSamples - 1] == EXTRASAMPLE_ASSOCALPHA ||
                  v[nBand - nBaseSamples - 1] == EXTRASAMPLE_UNASSALPHA))
+            {
+                if (v[nBand - nBaseSamples - 1] == EXTRASAMPLE_ASSOCALPHA)
+                    m_oGTiffMDMD.SetMetadataItem("ALPHA", "PREMULTIPLIED",
+                                                 "IMAGE_STRUCTURE");
                 m_eBandInterp = GCI_AlphaBand;
+            }
             else
                 m_eBandInterp = GCI_Undefined;
         }


### PR DESCRIPTION
Fixes #11377
