### PR TITLE
Zarr: Check SRS axis order when setting data axis to SRS axis mapping

### DIFF
--- a/frmts/zarr/zarr_array.cpp
+++ b/frmts/zarr/zarr_array.cpp
@@ -2798,11 +2798,13 @@ void ZarrArray::ParseSpecialAttributes(
         }
         if (iDimX > 0 && iDimY > 0)
         {
-            if (poSRS->GetDataAxisToSRSAxisMapping() == std::vector<int>{2, 1})
-                poSRS->SetDataAxisToSRSAxisMapping({iDimY, iDimX});
-            else if (poSRS->GetDataAxisToSRSAxisMapping() ==
-                     std::vector<int>{1, 2})
-                poSRS->SetDataAxisToSRSAxisMapping({iDimX, iDimY});
+            const bool bIsSRSNorthingEastingOrdered =
+                poSRS->EPSGTreatsAsLatLong() ||
+                poSRS->EPSGTreatsAsNorthingEasting();
+            if (bIsSRSNorthingEastingOrdered &&
+                poSRS->GetAxisMappingStrategy() == OAMS_AUTHORITY_COMPLIANT)
+                std::swap(iDimX, iDimY);
+            poSRS->SetDataAxisToSRSAxisMapping({iDimX, iDimY});
         }
 
         SetSRS(poSRS);


### PR DESCRIPTION
## What does this PR do?

We recently encountered issues when resampling EPSG:4326 Zarr files using gdalwarp, where the resulting output files would have correct bounds, but incorrectly sampled data (swapped latitude and longitude). This happens for example when warping a Zarr to a GTif file as  follows:


```bash
# Create a Zarr in 4326 spanning the whole world
gdal_create -of Zarr -a_srs EPSG:4326 -a_ullr -180 90 180 -90 -ot Byte -outsize 512 256 -burn 127 /tmp/empty.zarr

# Convert it to a Tiff using gdalwarp 
gdalwarp /tmp/empty.zarr /tmp/empty.tif
```
If you open `/tmp/empty.tif` in QGIS, you will see that only the +-90 longitude range is filled with nonzero values.

When debugging this, I found that the `data_axis_to_srs_axis_mapping` in the `gdalmdiminfo` output was not consistent with the axis order declared in the CRS and in the Zarr file. 
For example, if the Zarr file contains an array that is ordered latitude first, GDAL reports the axis mapping as [2, 1]. I think it should be [1, 2] in this case, because EPSG:4326 also has latitude ordered first.

After this patch, the initialization code explicitly checks:
- Is the SRS is oriented north-up?
- Are we using authority compliant axis order?

Only if both are true, the axis order is swapped. We believe that this is necessary since the axes in Zarr can be ordered in any way, but are annotated as X(longitude) or Y(latitude) using either name-based or attribute-based matching.

We tested this using UTM (XY order) and 4326 (YX order) files, and it resolves the problem for us.

This might not be the best way to do this, but it solves a critical issue for us. We are happy to receive feedback and change the logic if needed though!

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

* OS: Linux 6.12
* Compiler: gcc 14.2.1
* GDAL: 3.10
