### PR TITLE
gdaldrivermanager.cpp: Do not look for plugins in GetRealDriver when GDAL_NO_AUTOLOAD set.

### DIFF
--- a/gcore/gdaldrivermanager.cpp
+++ b/gcore/gdaldrivermanager.cpp
@@ -1380,6 +1380,9 @@ GDALDriver *GDALPluginDriverProxy::GetRealDriver()
     }
     else
     {
+#ifdef GDAL_NO_AUTOLOAD
+        return nullptr;
+#else
         CPLString osFuncName;
         if (STARTS_WITH(m_osPluginFileName.c_str(), "gdal_"))
         {
@@ -1443,6 +1446,7 @@ GDALDriver *GDALPluginDriverProxy::GetRealDriver()
                 poDriverManager->m_oMapRealDrivers.erase(oIter);
             }
         }
+#endif  // GDAL_NO_AUTOLOAD
     }
 
     if (m_poRealDriver)


### PR DESCRIPTION
Fixes #11332

## What does this PR do?

In GDALPluginDriverProxy::GetRealDriver(), return a nullptr if GDAL_NO_AUTOLOAD is set and plugins are not available. This avoids the call the CPLGetSymbol.

In custom builds like my bazel build, this lets me completely remove `CPLGetSymbol` from the build. When GDAL runs in a sandbox, it is helpful to not even have a chance for this function to run. Any call to CPLGetSymbol would cause the sandbox to trigger a violation and kill the work.

## What are related issues/pull requests?

#11332

## Environment

Provide environment details, if relevant:

* OS: Custom linux with bazel build
* Compiler: llvm

**Note**: Failure that I can't tell if it's related to the change I made. The most recent commits on head fail too, but it's luck on which one.

```
Executing transaction: ...working... done
+ test -f /home/runner/miniconda3/envs/test/conda-bld/libgdal-core_1732816510057/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl/lib/gdalplugins/gdal_PDF.so
+ gdalinfo --format PDF
ERROR 1: libpoppler.so.140: cannot open shared object file: No such file or directory
ERROR 1: libpoppler.so.140: cannot open shared object file: No such file or directory
+ ./test_pdf.sh
++ dirname ./test_pdf.sh
+ pushd ./test_data/
+ gdalinfo test_iso32000.pdf
ERROR 1: libpoppler.so.140: cannot open shared object file: No such file or directory
ERROR 1: libpoppler.so.140: cannot open shared object file: No such file or directory
gdalinfo failed - unable to open 'test_iso32000.pdf'. Did you intend to call ogrinfo?
WARNING: Tests failed for libgdal-pdf-3.10.0-hb578332_2112.tar.bz2 - moving package to /home/runner/miniconda3/envs/test/conda-bld/broken
Traceback (most recent call last):
export PREFIX=/home/runner/miniconda3/envs/test/conda-bld/libgdal-core_1732816510057/_test_env_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_placehold_pl

```
