### PR TITLE
GeoHEIF: Fixed respecting CRS axis order (e.g., for EPSG:4326)

### DIFF
--- a/autotest/gdrivers/avif.py
+++ b/autotest/gdrivers/avif.py
@@ -282,6 +282,9 @@ def test_avif_geoheif_wkt2():
     assert ds.GetGeoTransform() == pytest.approx(
         [691000.0, 0.1, 0.0, 6090000.0, 0.0, -0.1]
     )
+    assert ds.GetSpatialRef() is not None
+    assert ds.GetSpatialRef().GetAuthorityName(None) == "EPSG"
+    assert ds.GetSpatialRef().GetAuthorityCode(None) == "28355"
     assert ds.GetGCPCount() == 1
     gcp = ds.GetGCPs()[0]
     assert (
@@ -313,6 +316,10 @@ def test_avif_geoheif_uri():
     assert ds.GetGeoTransform() == pytest.approx(
         [691051.2, 0.1, 0.0, 6090000.0, 0.0, -0.1]
     )
+    assert ds.GetSpatialRef() is not None
+    assert ds.GetSpatialRef().GetAuthorityName(None) == "EPSG"
+    assert ds.GetSpatialRef().GetAuthorityCode(None) == "32755"
+
     assert ds.GetGCPCount() == 1
     gcp = ds.GetGCPs()[0]
     assert (
@@ -340,6 +347,10 @@ def test_avif_geoheif_curie():
         == 'CCBY "Jacobs Group (Australia) Pty Ltd and Australian Capital Territory"'
     )
     assert ds.GetMetadataItem("TAGS", "DESCRIPTION_en-AU") == "copyright"
+    assert ds.GetSpatialRef() is not None
+    assert ds.GetSpatialRef().GetAuthorityName(None) == "EPSG"
+    assert ds.GetSpatialRef().GetAuthorityCode(None) == "32755"
+
     assert ds.GetGeoTransform() is not None
     assert ds.GetGeoTransform() == pytest.approx(
         [691051.2, 0.1, 0.0, 6090000.0, 0.0, -0.1]

--- a/autotest/gdrivers/avif_heif.py
+++ b/autotest/gdrivers/avif_heif.py
@@ -61,9 +61,9 @@ if __name__ == "__main__":
         assert ds.GetGeoTransform() == pytest.approx(
             [691000.0, 0.1, 0.0, 6090000.0, 0.0, -0.1]
         )
-        print()
-        print("GCPs from avif_heif: ", ds.GetGCPCount())
-        print()
+        assert ds.GetSpatialRef() is not None
+        assert ds.GetSpatialRef().GetAuthorityName(None) == "EPSG"
+        assert ds.GetSpatialRef().GetAuthorityCode(None) == "28355"
         assert ds.GetGCPCount() == 1
         gcp = ds.GetGCPs()[0]
         assert (

--- a/autotest/gdrivers/heif.py
+++ b/autotest/gdrivers/heif.py
@@ -706,10 +706,47 @@ def test_heif_geoheif_curie():
         == 'CCBY "Jacobs Group (Australia) Pty Ltd and Australian Capital Territory"'
     )
     assert ds.GetMetadataItem("TAGS", "DESCRIPTION_en-AU") == "copyright"
+    assert ds.GetSpatialRef() is not None
+    assert ds.GetSpatialRef().GetAuthorityName(None) == "EPSG"
+    assert ds.GetSpatialRef().GetAuthorityCode(None) == "32755"
     assert ds.GetGeoTransform() is not None
     assert ds.GetGeoTransform() == pytest.approx(
         [691051.2, 0.1, 0.0, 6090000.0, 0.0, -0.1]
     )
+    assert ds.GetGCPCount() == 1
+    gcp = ds.GetGCPs()[0]
+    assert (
+        gcp.GCPPixel == pytest.approx(0, abs=1e-5)
+        and gcp.GCPLine == pytest.approx(0, abs=1e-5)
+        and gcp.GCPX == pytest.approx(691051.2, abs=1e-5)
+        and gcp.GCPY == pytest.approx(6090000.0, abs=1e-5)
+        and gcp.GCPZ == pytest.approx(0, abs=1e-5)
+    )
+
+
+@pytest.mark.skipif(
+    not _has_geoheif_support(),
+    reason="this libheif does not support opaque properties like geoheif",
+)
+def test_heif_geoheif_curie_order():
+    ds = gdal.Open("data/heif/geo_curi.heif")
+    assert ds
+    assert ds.RasterCount == 3
+    assert ds.RasterXSize == 256
+    assert ds.RasterYSize == 64
+    assert ds.GetMetadataItem("NAME", "DESCRIPTION_en-AU") == "Copyright Statement"
+    assert (
+        ds.GetMetadataItem("DESCRIPTION", "DESCRIPTION_en-AU")
+        == 'CCBY "Jacobs Group (Australia) Pty Ltd and Australian Capital Territory"'
+    )
+    assert ds.GetMetadataItem("TAGS", "DESCRIPTION_en-AU") == "copyright"
+    assert ds.GetGeoTransform() is not None
+    assert ds.GetGeoTransform() == pytest.approx(
+        [691051.2, 0.1, 0.0, 6090000.0, 0.0, -0.1]
+    )
+    assert ds.GetSpatialRef() is not None
+    assert ds.GetSpatialRef().GetAuthorityName(None) == "EPSG"
+    assert ds.GetSpatialRef().GetAuthorityCode(None) == "32755"
     assert ds.GetGCPCount() == 1
     gcp = ds.GetGCPs()[0]
     assert (

--- a/frmts/heif/heifdataset.h
+++ b/frmts/heif/heifdataset.h
@@ -44,6 +44,7 @@ class GDALHEIFDataset final : public GDALPamDataset
 #endif
 
 #if LIBHEIF_NUMERIC_VERSION >= BUILD_LIBHEIF_VERSION(1, 19, 0)
+    void processProperties();
     gdal::GeoHEIF geoHEIF{};
 #endif
 
@@ -62,7 +63,6 @@ class GDALHEIFDataset final : public GDALPamDataset
     bool Init(GDALOpenInfo *poOpenInfo);
     void ReadMetadata();
     void OpenThumbnails();
-    void ExtractUserDescription(const uint8_t *payload, size_t length);
 
 #ifdef HAS_CUSTOM_FILE_WRITER
     static heif_error VFS_WriterCallback(struct heif_context *ctx,

--- a/gcore/geoheif.cpp
+++ b/gcore/geoheif.cpp
@@ -124,12 +124,12 @@ void GeoHEIF::extractSRS(const uint8_t *payload, size_t length) const
     }
     else if (crsEncoding == "curi")
     {
-        if ((crs.at(0) != '[') || (crs.at(crs.length() - 1) != ']'))
+        if ((crs.at(0) != '[') || (crs.at(crs.length() - 2) != ']'))
         {
             CPLDebug("GeoHEIF", "CRS CURIE is not a safe CURIE");
             return;
         }
-        std::string curie = crs.substr(1, crs.length() - 2);
+        std::string curie = crs.substr(1, crs.length() - 3);
         size_t separatorPos = curie.find(':');
         if (separatorPos == std::string::npos)
         {

--- a/gcore/geoheif.cpp
+++ b/gcore/geoheif.cpp
@@ -124,7 +124,9 @@ void GeoHEIF::extractSRS(const uint8_t *payload, size_t length) const
     }
     else if (crsEncoding == "curi")
     {
-        if ((crs.at(0) != '[') || (crs.at(crs.length() - 2) != ']'))
+        // null terminated string in the form "[EPSG:4326]"
+        if ((crs.at(0) != '[') || (crs.at(crs.length() - 2) != ']') ||
+            (crs.at(crs.length() - 1) != '\0'))
         {
             CPLDebug("GeoHEIF", "CRS CURIE is not a safe CURIE");
             return;

--- a/gcore/geoheif.cpp
+++ b/gcore/geoheif.cpp
@@ -86,12 +86,27 @@ void GeoHEIF::setModelTransformation(const uint8_t *payload, size_t length)
 
 CPLErr GeoHEIF::GetGeoTransform(double *padfTransform) const
 {
-    padfTransform[1] = modelTransform[1];
-    padfTransform[2] = modelTransform[2];
-    padfTransform[0] = modelTransform[0];
-    padfTransform[4] = modelTransform[4];
-    padfTransform[5] = modelTransform[5];
-    padfTransform[3] = modelTransform[3];
+    std::vector<int> axes =
+        has_SRS() ? m_oSRS.GetDataAxisToSRSAxisMapping() : std::vector<int>();
+
+    if (axes.size() && axes[0] != 1)
+    {
+        padfTransform[1] = modelTransform[4];
+        padfTransform[2] = modelTransform[5];
+        padfTransform[0] = modelTransform[3];
+        padfTransform[4] = modelTransform[1];
+        padfTransform[5] = modelTransform[2];
+        padfTransform[3] = modelTransform[0];
+    }
+    else
+    {
+        padfTransform[1] = modelTransform[1];
+        padfTransform[2] = modelTransform[2];
+        padfTransform[0] = modelTransform[0];
+        padfTransform[4] = modelTransform[4];
+        padfTransform[5] = modelTransform[5];
+        padfTransform[3] = modelTransform[3];
+    }
     return CE_None;
 }
 
@@ -152,6 +167,7 @@ void GeoHEIF::extractSRS(const uint8_t *payload, size_t length) const
         CPLDebug("GeoHEIF", "CRS encoding is not supported");
         return;
     }
+    m_oSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
 }
 
 void GeoHEIF::addGCPs(const uint8_t *data, size_t length)


### PR DESCRIPTION
## What does this PR do?

Fixes an axis-ordering bug in GeoHEIF driver, in particular for EPSG:4326 CRS.

## What are related issues/pull requests?

https://gitlab.ogc.org/ogc/T20-GIMI/-/issues/59

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [X] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [N/A] Add documentation
 - [N/A] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

N/A