### PR TITLE
Assorted set of fixes for WMTS issue

### DIFF
--- a/autotest/gdrivers/data/wmts/WMTSCapabilities_THEMIS_NightIR_ControlledMosaics_100m_v2_oct2018.xml
+++ b/autotest/gdrivers/data/wmts/WMTSCapabilities_THEMIS_NightIR_ControlledMosaics_100m_v2_oct2018.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Capabilities xmlns="http://www.opengis.net/wmts/1.0" xmlns:ows="http://www.opengis.net/ows/1.1" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gml="http://www.opengis.net/gml" xsi:schemaLocation="http://www.opengis.net/wmts/1.0 http://schemas.opengis.net/wmts/1.0/wmtsGetCapabilities_response.xsd" version="1.0.0">
+    <!-- Service Identification --> 
+    <ows:ServiceIdentification>
+        <ows:Title>THEMIS_NightIR_ControlledMosaics_100m_v2_oct2018</ows:Title>
+        <ows:ServiceType>OGC WMTS</ows:ServiceType>
+        <ows:ServiceTypeVersion>1.0.0</ows:ServiceTypeVersion>
+    </ows:ServiceIdentification> <!-- Operations Metadata --> 
+    <ows:OperationsMetadata>
+        <ows:Operation name="GetCapabilities">
+            <ows:DCP>
+                <ows:HTTP>
+                    <ows:Get xlink:href="https://trek.nasa.gov/tiles/Mars/EQ/THEMIS_NightIR_ControlledMosaics_100m_v2_oct2018/1.0.0/WMTSCapabilities.xml">
+                        <ows:Constraint name="GetEncoding">
+                            <ows:AllowedValues>
+                                <ows:Value>RESTful</ows:Value>
+                            </ows:AllowedValues>
+                        </ows:Constraint>
+                    </ows:Get>
+                    
+                </ows:HTTP>
+            </ows:DCP>
+        </ows:Operation>
+        <ows:Operation name="GetTile">
+            <ows:DCP>
+                <ows:HTTP>
+                    <ows:Get xlink:href="https://trek.nasa.gov/tiles/Mars/EQ/THEMIS_NightIR_ControlledMosaics_100m_v2_oct2018/1.0.0/">
+                        <ows:Constraint name="GetEncoding">
+                            <ows:AllowedValues>
+                                <ows:Value>RESTful</ows:Value>
+                            </ows:AllowedValues>
+                        </ows:Constraint>
+                    </ows:Get>
+                    
+                </ows:HTTP>
+            </ows:DCP>
+        </ows:Operation>
+    </ows:OperationsMetadata> 
+    <Contents>
+        <!--Layer--> 
+        <Layer>
+            <ows:Title>THEMIS_NightIR_ControlledMosaics_100m_v2_oct2018</ows:Title> 
+            <ows:Identifier>THEMIS_NightIR_ControlledMosaics_100m_v2_oct2018</ows:Identifier>
+            <ows:BoundingBox crs="urn:ogc:def:crs:EPSG::104905">
+                <ows:LowerCorner>-179.9999997 -65.0006576</ows:LowerCorner>
+                <ows:UpperCorner>179.9998849 65.0007535</ows:UpperCorner>
+            </ows:BoundingBox>
+            <ows:WGS84BoundingBox crs="urn:ogc:def:crs:OGC:2:84">
+                <ows:LowerCorner>-179.9999997 -65.0006576</ows:LowerCorner>
+                <ows:UpperCorner>179.9998849 65.0007535</ows:UpperCorner>
+            </ows:WGS84BoundingBox>
+            
+            <Style isDefault="true">
+                <ows:Title>Default Style</ows:Title>
+                <ows:Identifier>default</ows:Identifier>
+            </Style>
+            <Format>image/png</Format>
+            <TileMatrixSetLink>
+                <TileMatrixSet>default028mm</TileMatrixSet>
+            </TileMatrixSetLink>
+            <ResourceURL format="image/png" resourceType="tile" template="https://trek.nasa.gov/tiles/Mars/EQ/THEMIS_NightIR_ControlledMosaics_100m_v2_oct2018/1.0.0//{Style}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}.png"/>
+        </Layer> <!--TileMatrixSet-->
+        <TileMatrixSet>
+            <ows:Title>default</ows:Title>
+            <ows:Abstract>The tile matrix set that has scale values calculated based on the dpi defined by OGC specification (dpi assumes 0.28mm as the physical distance of a pixel).</ows:Abstract> 
+            <ows:Identifier>default028mm</ows:Identifier>
+            <ows:SupportedCRS>urn:ogc:def:crs:EPSG::104905</ows:SupportedCRS>
+            <TileMatrix><ows:Identifier>0</ows:Identifier><ScaleDenominator>2.7922763629807472E+08</ScaleDenominator><TopLeftCorner>-180.0 90.0</TopLeftCorner><TileWidth>256</TileWidth><TileHeight>256</TileHeight><MatrixWidth>2.0</MatrixWidth><MatrixHeight>1.0</MatrixHeight></TileMatrix>
+<TileMatrix><ows:Identifier>1</ows:Identifier><ScaleDenominator>1.3961381814903736E+08</ScaleDenominator><TopLeftCorner>-180.0 90.0</TopLeftCorner><TileWidth>256</TileWidth><TileHeight>256</TileHeight><MatrixWidth>4.0</MatrixWidth><MatrixHeight>2.0</MatrixHeight></TileMatrix>
+<TileMatrix><ows:Identifier>2</ows:Identifier><ScaleDenominator>6.9806909074518681E+07</ScaleDenominator><TopLeftCorner>-180.0 90.0</TopLeftCorner><TileWidth>256</TileWidth><TileHeight>256</TileHeight><MatrixWidth>8.0</MatrixWidth><MatrixHeight>4.0</MatrixHeight></TileMatrix>
+<TileMatrix><ows:Identifier>3</ows:Identifier><ScaleDenominator>3.4903454537259340E+07</ScaleDenominator><TopLeftCorner>-180.0 90.0</TopLeftCorner><TileWidth>256</TileWidth><TileHeight>256</TileHeight><MatrixWidth>16.0</MatrixWidth><MatrixHeight>8.0</MatrixHeight></TileMatrix>
+<TileMatrix><ows:Identifier>4</ows:Identifier><ScaleDenominator>1.7451727268629670E+07</ScaleDenominator><TopLeftCorner>-180.0 90.0</TopLeftCorner><TileWidth>256</TileWidth><TileHeight>256</TileHeight><MatrixWidth>32.0</MatrixWidth><MatrixHeight>16.0</MatrixHeight></TileMatrix>
+<TileMatrix><ows:Identifier>5</ows:Identifier><ScaleDenominator>8.7258636343148351E+06</ScaleDenominator><TopLeftCorner>-180.0 90.0</TopLeftCorner><TileWidth>256</TileWidth><TileHeight>256</TileHeight><MatrixWidth>64.0</MatrixWidth><MatrixHeight>32.0</MatrixHeight></TileMatrix>
+<TileMatrix><ows:Identifier>6</ows:Identifier><ScaleDenominator>4.3629318171574175E+06</ScaleDenominator><TopLeftCorner>-180.0 90.0</TopLeftCorner><TileWidth>256</TileWidth><TileHeight>256</TileHeight><MatrixWidth>128.0</MatrixWidth><MatrixHeight>64.0</MatrixHeight></TileMatrix>
+<TileMatrix><ows:Identifier>7</ows:Identifier><ScaleDenominator>2.1814659085787088E+06</ScaleDenominator><TopLeftCorner>-180.0 90.0</TopLeftCorner><TileWidth>256</TileWidth><TileHeight>256</TileHeight><MatrixWidth>256.0</MatrixWidth><MatrixHeight>128.0</MatrixHeight></TileMatrix>
+<TileMatrix><ows:Identifier>8</ows:Identifier><ScaleDenominator>1.0907329542893544E+06</ScaleDenominator><TopLeftCorner>-180.0 90.0</TopLeftCorner><TileWidth>256</TileWidth><TileHeight>256</TileHeight><MatrixWidth>512.0</MatrixWidth><MatrixHeight>256.0</MatrixHeight></TileMatrix>
+<TileMatrix><ows:Identifier>9</ows:Identifier><ScaleDenominator>5.4536647714467719E+05</ScaleDenominator><TopLeftCorner>-180.0 90.0</TopLeftCorner><TileWidth>256</TileWidth><TileHeight>256</TileHeight><MatrixWidth>1024.0</MatrixWidth><MatrixHeight>512.0</MatrixHeight></TileMatrix>
+
+            <!--<TileMatrix>
+                <ows:Identifier>0</ows:Identifier> 
+                <ScaleDenominator>2.3623511904761901E8</ScaleDenominator>
+                <TopLeftCorner>-180.0 90.0</TopLeftCorner> 
+                <TileWidth>256</TileWidth> 
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>3</MatrixWidth> 
+                <MatrixHeight>2</MatrixHeight>
+            </TileMatrix>
+            <TileMatrix>
+                <ows:Identifier>1</ows:Identifier> 
+                <ScaleDenominator>1.1811755952380951E8</ScaleDenominator>
+                <TopLeftCorner>-180.0 90.0</TopLeftCorner> 
+                <TileWidth>256</TileWidth> 
+                <TileHeight>256</TileHeight>
+                <MatrixWidth>5</MatrixWidth> 
+                <MatrixHeight>3</MatrixHeight>
+            </TileMatrix>
+            -->
+            
+        </TileMatrixSet>
+    </Contents>
+    <ServiceMetadataURL xlink:href="https://trek.nasa.gov/tiles/Mars/EQ/THEMIS_NightIR_ControlledMosaics_100m_v2_oct2018/1.0.0/WMTSCapabilities.xml"/> 
+</Capabilities>

--- a/autotest/gdrivers/wmts.py
+++ b/autotest/gdrivers/wmts.py
@@ -2001,3 +2001,32 @@ def test_wmts_force_opening_no_match():
 
     drv = gdal.IdentifyDriverEx("data/byte.tif", allowed_drivers=["WMTS"])
     assert drv is None
+
+
+###############################################################################
+# Test bug fix for https://github.com/OSGeo/gdal/issues/11387
+
+
+@pytest.mark.require_proj(9)
+@gdaltest.enable_exceptions()
+def test_wmts_read_esri_code_disguised_as_epsg_and_wrong_axis_order():
+
+    with gdaltest.error_handler():
+        with gdal.Open(
+            "data/wmts/WMTSCapabilities_THEMIS_NightIR_ControlledMosaics_100m_v2_oct2018.xml"
+        ) as ds:
+            assert gdal.GetLastErrorMsg().startswith(
+                "Auto-correcting wrongly swapped TileMatrix.TopLeftCorner coordinates"
+            )
+            assert ds.GetSpatialRef().GetAuthorityName(None) == "ESRI"
+            assert ds.GetSpatialRef().GetAuthorityCode(None) == "104905"
+            assert ds.GetGeoTransform() == pytest.approx(
+                (
+                    -180.0,
+                    0.0013717509172233527,
+                    0.0,
+                    65.00121128452162,
+                    0.0,
+                    -0.0013717509172233527,
+                )
+            )

--- a/autotest/osr/osr_epsg.py
+++ b/autotest/osr/osr_epsg.py
@@ -544,3 +544,31 @@ def test_osr_epsg_EPSGTreatsAsLatLong_for_CompoundCRS():
     srs = osr.SpatialReference()
     srs.ImportFromEPSG(6697)
     assert srs.EPSGTreatsAsLatLong() == 1
+
+
+###############################################################################
+#   Test importing a ESRI code as a EPSG code
+
+
+@pytest.mark.require_proj(9)
+def test_osr_epsg_import_esri_code():
+
+    srs = osr.SpatialReference()
+    with gdal.quiet_errors():
+        srs.ImportFromEPSG(104905)
+
+    assert srs.GetAuthorityName(None) == "ESRI"
+    assert srs.GetAuthorityCode(None) == "104905"
+
+
+###############################################################################
+#   Test importing a non-existent ESRI code presented as a EPSG code
+
+
+def test_osr_epsg_import_invalid_code_that_might_have_been_esri():
+
+    srs = osr.SpatialReference()
+    with pytest.raises(
+        Exception, match="PROJ: proj_create_from_database: crs not found"
+    ):
+        srs.ImportFromEPSG(987654)

--- a/ogr/ogrspatialreference.cpp
+++ b/ogr/ogrspatialreference.cpp
@@ -4569,6 +4569,14 @@ OGRErr OGRSpatialReference::importFromURNPart(const char *pszAuthority,
 OGRErr OGRSpatialReference::importFromURN(const char *pszURN)
 
 {
+    constexpr const char *EPSG_URN_CRS_PREFIX = "urn:ogc:def:crs:EPSG::";
+    if (STARTS_WITH(pszURN, EPSG_URN_CRS_PREFIX) &&
+        CPLGetValueType(pszURN + strlen(EPSG_URN_CRS_PREFIX)) ==
+            CPL_VALUE_INTEGER)
+    {
+        return importFromEPSG(atoi(pszURN + strlen(EPSG_URN_CRS_PREFIX)));
+    }
+
     TAKE_OPTIONAL_LOCK();
 
 #if PROJ_AT_LEAST_VERSION(8, 1, 0)
@@ -11923,12 +11931,56 @@ OGRErr OGRSpatialReference::importFromEPSGA(int nCode)
 
     CPLString osCode;
     osCode.Printf("%d", nCode);
-    auto obj =
-        proj_create_from_database(d->getPROJContext(), "EPSG", osCode.c_str(),
-                                  PJ_CATEGORY_CRS, true, nullptr);
-    if (!obj)
+    PJ *obj;
+    if (nCode <= 100000)
     {
-        return OGRERR_FAILURE;
+        obj = proj_create_from_database(d->getPROJContext(), "EPSG",
+                                        osCode.c_str(), PJ_CATEGORY_CRS, true,
+                                        nullptr);
+        if (!obj)
+        {
+            return OGRERR_FAILURE;
+        }
+    }
+    else
+    {
+        // Likely to be an ESRI CRS...
+        CPLErr eLastErrorType = CE_None;
+        CPLErrorNum eLastErrorNum = CPLE_None;
+        std::string osLastErrorMsg;
+        bool bIsESRI = false;
+        {
+            CPLErrorStateBackuper oBackuper(CPLQuietErrorHandler);
+            CPLErrorReset();
+            obj = proj_create_from_database(d->getPROJContext(), "EPSG",
+                                            osCode.c_str(), PJ_CATEGORY_CRS,
+                                            true, nullptr);
+            if (!obj)
+            {
+                eLastErrorType = CPLGetLastErrorType();
+                eLastErrorNum = CPLGetLastErrorNo();
+                osLastErrorMsg = CPLGetLastErrorMsg();
+                obj = proj_create_from_database(d->getPROJContext(), "ESRI",
+                                                osCode.c_str(), PJ_CATEGORY_CRS,
+                                                true, nullptr);
+                if (obj)
+                    bIsESRI = true;
+            }
+        }
+        if (!obj)
+        {
+            if (eLastErrorType != CE_None)
+                CPLError(eLastErrorType, eLastErrorNum, "%s",
+                         osLastErrorMsg.c_str());
+            return OGRERR_FAILURE;
+        }
+        if (bIsESRI)
+        {
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "EPSG:%d is not a valid CRS code, but ESRI:%d is. "
+                     "Assuming ESRI:%d was meant",
+                     nCode, nCode, nCode);
+        }
     }
 
     if (bUseNonDeprecated && proj_is_deprecated(obj))


### PR DESCRIPTION
Fixes #11387

- OGRSpatialReference::importFromEPSG(): tries with ESRI when it looks like an ESRI code, but with a warning when that succeeds
- WMTS: for geographic CRS with official lat,lon order, be robust to bounding box and TopLeftCorner being in the wrong axis order and emits a warning
- HTTP driver: re-emit warnings/errors raised by underlying driver
