### PR TITLE
[Backport 3.10] DXF writer: do not set 0 as the value for DXF code 5 (HANDLE)

### DIFF
--- a/autotest/ogr/ogr_dxf.py
+++ b/autotest/ogr/ogr_dxf.py
@@ -436,20 +436,28 @@ def test_ogr_dxf_12(tmp_path):
 
     dst_feat = ogr.Feature(feature_def=lyr.GetLayerDefn())
     dst_feat.SetGeometryDirectly(ogr.CreateGeometryFromWkt("LINESTRING(10 12, 60 65)"))
+    dst_feat.SetFID(0)
     lyr.CreateFeature(dst_feat)
+    # 80 is the minimum handle value we set in case of inapproriate or unsed
+    # initial FID value
+    assert dst_feat.GetFID() >= 80
     dst_feat = None
 
     dst_feat = ogr.Feature(feature_def=lyr.GetLayerDefn())
     dst_feat.SetGeometryDirectly(
         ogr.CreateGeometryFromWkt("POLYGON((0 0,100 0,100 100,0 0))")
     )
+    dst_feat.SetFID(79)
     lyr.CreateFeature(dst_feat)
+    assert dst_feat.GetFID() == 79
     dst_feat = None
 
     # Test 25D linestring with constant Z (#5210)
     dst_feat = ogr.Feature(feature_def=lyr.GetLayerDefn())
     dst_feat.SetGeometryDirectly(ogr.CreateGeometryFromWkt("LINESTRING(1 2 10,3 4 10)"))
+    dst_feat.SetFID(79)
     lyr.CreateFeature(dst_feat)
+    assert dst_feat.GetFID() > 79
     dst_feat = None
 
     # Test 25D linestring with different Z (#5210)

--- a/ogr/ogrsf_frmts/dxf/ogr_dxf.h
+++ b/ogr/ogrsf_frmts/dxf/ogr_dxf.h
@@ -972,8 +972,8 @@ class OGRDXFWriterDS final : public GDALDataset
                            CSLConstList papszOptions) override;
 
     bool CheckEntityID(const char *pszEntityID);
-    bool WriteEntityID(VSILFILE *fp, long &nAssignedFID,
-                       long nPreferredFID = OGRNullFID);
+    bool WriteEntityID(VSILFILE *fp, unsigned int &nAssignedFID,
+                       GIntBig nPreferredFID = OGRNullFID);
 
     void UpdateExtent(OGREnvelope *psEnvelope);
 };

--- a/ogr/ogrsf_frmts/dxf/ogrdxfwriterlayer.cpp
+++ b/ogr/ogrsf_frmts/dxf/ogrdxfwriterlayer.cpp
@@ -169,8 +169,8 @@ OGRErr OGRDXFWriterLayer::WriteCore(OGRFeature *poFeature)
     /*      Also, for reasons I don't understand these ids seem to have     */
     /*      to start somewhere around 0x50 hex (80 decimal).                */
     /* -------------------------------------------------------------------- */
-    long nGotFID = -1;
-    poDS->WriteEntityID(fp, nGotFID, (int)poFeature->GetFID());
+    unsigned int nGotFID = 0;
+    poDS->WriteEntityID(fp, nGotFID, poFeature->GetFID());
     poFeature->SetFID(nGotFID);
 
     WriteValue(100, "AcDbEntity");


### PR DESCRIPTION
as it is apparently a reserved value.

Fixes #11299

Backport of PR #11304