### PR TITLE
FlatGeobuf writing: in SPATIAL_INDEX=NO mode, deal with empty geometries as if there were null

### DIFF
--- a/autotest/ogr/ogr_flatgeobuf.py
+++ b/autotest/ogr/ogr_flatgeobuf.py
@@ -1633,3 +1633,20 @@ def test_ogr_flatgeobuf_write_empty_geometries_no_spatial_index(tmp_vsimem):
         f = lyr.GetNextFeature()
         g = f.GetGeometryRef()
         assert g is None
+
+
+def test_ogr_flatgeobuf_write_empty_file_no_spatial_index(tmp_vsimem):
+    # Verify empty geom handling without spatial index
+    out_filename = str(tmp_vsimem / "out.fgb")
+    with ogr.GetDriverByName("FlatGeobuf").CreateDataSource(out_filename) as ds:
+        srs = osr.SpatialReference()
+        srs.ImportFromEPSG(32631)
+        ds.CreateLayer(
+            "test", geom_type=ogr.wkbPolygon, srs=srs, options=["SPATIAL_INDEX=NO"]
+        )
+
+    with gdal.OpenEx(out_filename) as ds:
+        lyr = ds.GetLayer(0)
+        assert lyr.GetFeatureCount() == 0
+        assert lyr.GetExtent(can_return_null=True) is None
+        assert lyr.GetSpatialRef().GetAuthorityCode(None) == "32631"

--- a/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
+++ b/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
@@ -2295,7 +2295,7 @@ OGRErr OGRFlatGeobufLayer::ICreateFeature(OGRFeature *poNewFeature)
         // the size of the FlatBuffer, but WKB might be a good approximation.
         // Takes an extra security margin of 10%
         flatbuffers::Offset<FlatGeobuf::Geometry> geometryOffset = 0;
-        if (ogrGeometry != nullptr)
+        if (ogrGeometry && !ogrGeometry->IsEmpty())
         {
             const auto nWKBSize = ogrGeometry->WkbSize();
             if (nWKBSize > feature_max_buffer_size - nWKBSize / 10)

--- a/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
+++ b/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobuflayer.cpp
@@ -27,6 +27,7 @@
 #include "geometrywriter.h"
 
 #include <algorithm>
+#include <cmath>
 #include <limits>
 #include <new>
 #include <stdexcept>
@@ -71,7 +72,9 @@ OGRFlatGeobufLayer::OGRFlatGeobufLayer(const Header *poHeader, GByte *headerBuf,
     m_hasM = m_poHeader->has_m();
     m_hasT = m_poHeader->has_t();
     const auto envelope = m_poHeader->envelope();
-    if (envelope && envelope->size() == 4)
+    if (envelope && envelope->size() == 4 && std::isfinite((*envelope)[0]) &&
+        std::isfinite((*envelope)[1]) && std::isfinite((*envelope)[2]) &&
+        std::isfinite((*envelope)[3]))
     {
         m_sExtent.MinX = (*envelope)[0];
         m_sExtent.MinY = (*envelope)[1];
@@ -536,8 +539,7 @@ bool OGRFlatGeobufLayer::CreateFinalFile()
     // no spatial index requested, we are (almost) done
     if (!m_bCreateSpatialIndexAtClose)
     {
-        if (m_poFpWrite == nullptr || m_featuresCount == 0 ||
-            !SupportsSeekWhileWriting(m_osFilename))
+        if (m_poFpWrite == nullptr || !SupportsSeekWhileWriting(m_osFilename))
         {
             return true;
         }
@@ -546,14 +548,24 @@ bool OGRFlatGeobufLayer::CreateFinalFile()
         VSIFSeekL(m_poFpWrite, 0, SEEK_SET);
         m_writeOffset = 0;
         std::vector<double> extentVector;
-        extentVector.push_back(m_sExtent.MinX);
-        extentVector.push_back(m_sExtent.MinY);
-        extentVector.push_back(m_sExtent.MaxX);
-        extentVector.push_back(m_sExtent.MaxY);
+        if (!m_sExtent.IsInit())
+        {
+            extentVector.resize(4, std::numeric_limits<double>::quiet_NaN());
+        }
+        else
+        {
+            extentVector.push_back(m_sExtent.MinX);
+            extentVector.push_back(m_sExtent.MinY);
+            extentVector.push_back(m_sExtent.MaxX);
+            extentVector.push_back(m_sExtent.MaxY);
+        }
         writeHeader(m_poFpWrite, m_featuresCount, &extentVector);
         // Sanity check to verify that the dummy header and the real header
         // have the same size.
-        CPLAssert(m_writeOffset == m_offsetAfterHeader);
+        if (m_featuresCount)
+        {
+            CPLAssert(m_writeOffset == m_offsetAfterHeader);
+        }
         CPL_IGNORE_RET_VAL(m_writeOffset);  // otherwise checkers might tell the
                                             // member is not used
         return true;


### PR DESCRIPTION
- this fixes the crash when writing an empty polygon. Fixes #11419
- this avoids a reading error when writing an empty line

@bjornharrtell Can you confirm that FlatGeobuf is not a fan of EMPTY geometries ?
