### PR TITLE
Speed optimizations for GML and GeoJSON writing

### DIFF
--- a/ogr/ogr_geometry.h
+++ b/ogr/ogr_geometry.h
@@ -64,22 +64,31 @@ struct CPL_DLL OGRWktOptions
     /// Precision of output for M coordinates.  Interpretation depends on \c format.
     int mPrecision;
     /// Whether GDAL-special rounding should be applied.
-    bool round = getDefaultRound();
+    bool round;
     /// Formatting type.
     OGRWktFormat format = OGRWktFormat::Default;
 
     /// Constructor.
     OGRWktOptions()
         : xyPrecision(getDefaultPrecision()), zPrecision(xyPrecision),
-          mPrecision(zPrecision)
+          mPrecision(zPrecision), round(getDefaultRound())
+    {
+    }
+
+    /// Constructor.
+    OGRWktOptions(int xyPrecisionIn, bool roundIn)
+        : xyPrecision(xyPrecisionIn), zPrecision(xyPrecision),
+          mPrecision(zPrecision), round(roundIn)
     {
     }
 
     /// Copy constructor
     OGRWktOptions(const OGRWktOptions &) = default;
 
-  private:
+    /// Return default precision
     static int getDefaultPrecision();
+
+    /// Return default rounding mode.
     static bool getDefaultRound();
 };
 

--- a/ogr/ogrsf_frmts/gml/ogr_gml.h
+++ b/ogr/ogrsf_frmts/gml/ogr_gml.h
@@ -205,8 +205,8 @@ class OGRGMLDataSource final : public GDALDataset
         return bExposeGMLId || bExposeFid;
     }
 
-    static void PrintLine(VSILFILE *fp, const char *fmt, ...)
-        CPL_PRINT_FUNC_FORMAT(2, 3);
+    void PrintLine(VSILFILE *fp, const char *fmt, ...)
+        CPL_PRINT_FUNC_FORMAT(3, 4);
 
     bool IsGML3Output() const
     {


### PR DESCRIPTION
Related to https://lists.osgeo.org/pipermail/gdal-dev/2024-November/059853.html

Before:
```
$ time ogr2ogr -f "mapinfo file" lakes.mif Jarvi10.shp -progress -limit 30000
real    0m7,983s

$ time ogr2ogr -f csv lakes.csv Jarvi10.shp -progress -limit 30000  -lco geometry=as_wkt
real    0m10,311s

$ time ogr2ogr -f gml lakes.gml Jarvi10.shp -progress -limit 30000
real    0m14,525s

$ time ogr2ogr -f geojson lakes.json Jarvi10.shp -progress -limit 30000
real    0m19,116s
```

After:
```
$ time ogr2ogr -f gml lakes.gml Jarvi10.shp -progress -limit 30000
real    0m12,706s

$ time ogr2ogr -f geojson lakes.json Jarvi10.shp -progress -limit 30000
real    0m15,565s
```


