### PR TITLE
[Backport release/3.10] gdalvrt.xsd: fix schema to reflect that <Array> can be a child of <ArraySource>

### DIFF
--- a/autotest/gdrivers/data/vrt/arraysource_array_constant.vrt
+++ b/autotest/gdrivers/data/vrt/arraysource_array_constant.vrt
@@ -1,0 +1,13 @@
+<VRTDataset rasterXSize="20" rasterYSize="20">
+  <VRTRasterBand dataType="Float64" band="1" subClass="VRTDerivedRasterBand">
+    <PixelFunctionType>real</PixelFunctionType>
+    <ArraySource>
+        <Array name="test">
+            <DataType>Float64</DataType>
+            <Dimension name="Y" size="20"/>
+            <Dimension name="X" size="20"/>
+            <ConstantValue>10</ConstantValue>
+        </Array>
+    </ArraySource>
+  </VRTRasterBand>
+</VRTDataset>

--- a/autotest/gdrivers/vrtmultidim.py
+++ b/autotest/gdrivers/vrtmultidim.py
@@ -1421,6 +1421,12 @@ def test_vrtmultidim_arraysource_array():
     assert ds.GetRasterBand(1).Checksum() == 4855
 
 
+def test_vrtmultidim_arraysource_array_constant():
+
+    ds = gdal.Open("data/vrt/arraysource_array_constant.vrt")
+    assert ds.GetRasterBand(1).ComputeRasterMinMax() == (10, 10)
+
+
 @pytest.mark.require_driver("netCDF")
 def test_vrtmultidim_arraysource_derivedarray_view():
 

--- a/frmts/vrt/data/gdalvrt.xsd
+++ b/frmts/vrt/data/gdalvrt.xsd
@@ -635,34 +635,40 @@
     </xs:complexType>
 
     <xs:complexType name="ArrayType">
-        <xs:sequence>
-            <xs:element name="DataType" type="xs:string" minOccurs="1" maxOccurs="1"/>
-            <xs:sequence>
-                    <xs:choice minOccurs="0" maxOccurs="unbounded">
-                        <xs:element name="Dimension" type="DimensionType"/>
-                        <xs:element name="DimensionRef" type="DimensionRefType"/>
-                    </xs:choice>
-                </xs:sequence>
-            <xs:element name="SRS" type="SRSType" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="Unit" type="xs:string" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="NoDataValue" type="DoubleOrNanType" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="Offset" type="xs:double" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="Scale" type="xs:double" minOccurs="0" maxOccurs="1"/>
-            <xs:choice>
-                <xs:element name="RegularlySpacedValues" type="RegularlySpacedValuesType" minOccurs="0" maxOccurs="1"/>
+        <xs:complexContent>
+            <xs:extension base="AbstractArrayType">
                 <xs:sequence>
-                    <xs:choice minOccurs="0" maxOccurs="unbounded">
-                        <xs:element name="ConstantValue" type="ConstantValueType"/>
-                        <xs:element name="InlineValues" type="InlineValuesType"/>
-                        <xs:element name="InlineValuesWithValueElement" type="InlineValuesWithValueElementType"/>
-                        <xs:element name="Source" type="SourceType"/>
+                    <xs:element name="DataType" type="xs:string" minOccurs="1" maxOccurs="1"/>
+                    <xs:sequence>
+                            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                <xs:element name="Dimension" type="DimensionType"/>
+                                <xs:element name="DimensionRef" type="DimensionRefType"/>
+                            </xs:choice>
+                        </xs:sequence>
+                    <xs:element name="SRS" type="SRSType" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="Unit" type="xs:string" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="NoDataValue" type="DoubleOrNanType" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="Offset" type="xs:double" minOccurs="0" maxOccurs="1"/>
+                    <xs:element name="Scale" type="xs:double" minOccurs="0" maxOccurs="1"/>
+                    <xs:choice>
+                        <xs:element name="RegularlySpacedValues" type="RegularlySpacedValuesType" minOccurs="0" maxOccurs="1"/>
+                        <xs:sequence>
+                            <xs:choice minOccurs="0" maxOccurs="unbounded">
+                                <xs:element name="ConstantValue" type="ConstantValueType"/>
+                                <xs:element name="InlineValues" type="InlineValuesType"/>
+                                <xs:element name="InlineValuesWithValueElement" type="InlineValuesWithValueElementType"/>
+                                <xs:element name="Source" type="SourceType"/>
+                            </xs:choice>
+                        </xs:sequence>
                     </xs:choice>
+                    <xs:element name="Attribute" type="AttributeType" minOccurs="0" maxOccurs="unbounded"/>
                 </xs:sequence>
-            </xs:choice>
-            <xs:element name="Attribute" type="AttributeType" minOccurs="0" maxOccurs="unbounded"/>
-        </xs:sequence>
-        <xs:attribute name="name" type="xs:string" use="required"/>
+                <xs:attribute name="name" type="xs:string" use="required"/>
+            </xs:extension>
+        </xs:complexContent>
     </xs:complexType>
+
+    <xs:element name="Array" substitutionGroup="AbstractArray" type="ArrayType"/>
 
     <xs:complexType name="RegularlySpacedValuesType">
         <xs:attribute name="start" type="xs:double" use="required"/>


### PR DESCRIPTION
Backport #11435
 **Authored by:** @rouault