### PR TITLE
ogr2ogr: fix crash with -ct and using Arrow code path (e.g source is GeoPackage) (3.10.0 regression)

### DIFF
--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -4099,12 +4099,11 @@ bool SetupTargetLayer::CanUseWriteArrowBatch(
             {
                 return false;
             }
-            auto poSrcSRS = m_poUserSourceSRS ? m_poUserSourceSRS
-                                              : poSrcLayer->GetLayerDefn()
-                                                    ->GetGeomFieldDefn(0)
-                                                    ->GetSpatialRef();
-            if (!poSrcSRS ||
-                !OGRGeometryFactory::isTransformWithOptionsRegularTransform(
+            const auto poSrcSRS = m_poUserSourceSRS ? m_poUserSourceSRS
+                                                    : poSrcLayer->GetLayerDefn()
+                                                          ->GetGeomFieldDefn(0)
+                                                          ->GetSpatialRef();
+            if (!OGRGeometryFactory::isTransformWithOptionsRegularTransform(
                     poSrcSRS, m_poOutputSRS, nullptr))
             {
                 return false;

--- a/ogr/ogrgeometryfactory.cpp
+++ b/ogr/ogrgeometryfactory.cpp
@@ -3886,7 +3886,8 @@ bool OGRGeometryFactory::isTransformWithOptionsRegularTransform(
         return false;
 
 #ifdef HAVE_GEOS
-    if (poSourceCRS->IsProjected() && poTargetCRS->IsGeographic() &&
+    if (poSourceCRS && poTargetCRS && poSourceCRS->IsProjected() &&
+        poTargetCRS->IsGeographic() &&
         poTargetCRS->GetAxisMappingStrategy() == OAMS_TRADITIONAL_GIS_ORDER &&
         // check that angular units is degree
         std::fabs(poTargetCRS->GetAngularUnits(nullptr) -


### PR DESCRIPTION
Fixes #11438

Passing "--config OGR2OGR_USE_ARROW_API=NO" or "-t_srs {srs_def}" can be used as a workaround

