### PR TITLE
KEA: use native chunksize for copying RAT

### DIFF
--- a/frmts/kea/keacopy.cpp
+++ b/frmts/kea/keacopy.cpp
@@ -111,7 +111,6 @@ static bool KEACopyRasterData(GDALRasterBand *pBand,
     return true;
 }
 
-constexpr int RAT_CHUNKSIZE = 1000;
 
 // copies the raster attribute table
 static void KEACopyRAT(GDALRasterBand *pBand, kealib::KEAImageIO *pImageIO,
@@ -233,12 +232,12 @@ static void KEACopyRAT(GDALRasterBand *pBand, kealib::KEAImageIO *pImageIO,
         int numRows = gdalAtt->GetRowCount();
         keaAtt->addRows(numRows);
 
-        int *pnIntBuffer = new int[RAT_CHUNKSIZE];
-        int64_t *pnInt64Buffer = new int64_t[RAT_CHUNKSIZE];
-        double *pfDoubleBuffer = new double[RAT_CHUNKSIZE];
-        for (int ni = 0; ni < numRows; ni += RAT_CHUNKSIZE)
+        int *pnIntBuffer = new int[kealib::KEA_ATT_CHUNK_SIZE];
+        int64_t *pnInt64Buffer = new int64_t[kealib::KEA_ATT_CHUNK_SIZE];
+        double *pfDoubleBuffer = new double[kealib::KEA_ATT_CHUNK_SIZE];
+        for (int ni = 0; ni < numRows; ni += kealib::KEA_ATT_CHUNK_SIZE)
         {
-            int nLength = RAT_CHUNKSIZE;
+            int nLength = kealib::KEA_ATT_CHUNK_SIZE;
             if ((ni + nLength) > numRows)
             {
                 nLength = numRows - ni;

--- a/frmts/kea/keacopy.cpp
+++ b/frmts/kea/keacopy.cpp
@@ -111,7 +111,6 @@ static bool KEACopyRasterData(GDALRasterBand *pBand,
     return true;
 }
 
-
 // copies the raster attribute table
 static void KEACopyRAT(GDALRasterBand *pBand, kealib::KEAImageIO *pImageIO,
                        int nBand)


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

Changes the chunksize used for copying the RAT to be the default native HDF5 chunksize (10000) rather and 1000. This should improve performance while copying to a KEA file.

## What are related issues/pull requests?

https://github.com/ubarsc/kealib/pull/68

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
