### PR TITLE
[Backport release/3.10] GDALRasterBlock: make sure mutex is initialize in repeated calls to GDALAllRegister / GDALDestroyDriverManager

### DIFF
--- a/gcore/gdalrasterblock.cpp
+++ b/gcore/gdalrasterblock.cpp
@@ -571,6 +571,13 @@ GDALRasterBlock::GDALRasterBlock(GDALRasterBand *poBandIn, int nXOffIn,
       nXOff(nXOffIn), nYOff(nYOffIn), nXSize(0), nYSize(0), pData(nullptr),
       poBand(poBandIn), poNext(nullptr), poPrevious(nullptr), bMustDetach(true)
 {
+    if (!hRBLock)
+    {
+        // Needed for scenarios where GDALAllRegister() is called after
+        // GDALDestroyDriverManager()
+        INITIALIZE_LOCK;
+    }
+
     CPLAssert(poBandIn != nullptr);
     poBand->GetBlockSize(&nXSize, &nYSize);
 }


### PR DESCRIPTION
Backport #11448
 **Authored by:** @rouault