### PR TITLE
Ogrinfo: command line help text fixes

### DIFF
--- a/apps/ogrinfo_lib.cpp
+++ b/apps/ogrinfo_lib.cpp
@@ -2305,18 +2305,18 @@ static std::unique_ptr<GDALArgumentParser> GDALVectorInfoOptionsGetParser(
     argParser->add_argument("-al")
         .store_into(psOptions->bAllLayers)
         .help(_("List all layers (used instead of having to give layer names "
-                "as arguments)"));
+                "as arguments)."));
 
     {
         auto &group = argParser->add_mutually_exclusive_group();
         group.add_argument("-so", "-summary")
             .store_into(psOptions->bSummaryParser)
-            .help(_("Summary only: list all layers (used instead of having to "
-                    "give layer names as arguments)"));
+            .help(_("Summary only: Show only summary information like "
+                    "projection, schema, feature count and extents."));
 
         group.add_argument("-features")
             .store_into(psOptions->bFeaturesParser)
-            .help(_("Enable listing of features"));
+            .help(_("Enable listing of features."));
     }
 
     argParser->add_argument("-limit")
@@ -2353,13 +2353,13 @@ static std::unique_ptr<GDALArgumentParser> GDALVectorInfoOptionsGetParser(
                 if (psOptionsForBinary)
                     psOptionsForBinary->aosOpenOptions.AddString(s.c_str());
             })
-        .help(_("Dataset open option (format-specific)"));
+        .help(_("Dataset open option (format-specific)."));
 
     argParser->add_argument("-nomd")
         .flag()
         .action([psOptions](const std::string &)
                 { psOptions->bShowMetadata = false; })
-        .help(_("Suppress metadata printing"));
+        .help(_("Suppress metadata printing."));
 
     argParser->add_argument("-listmdd")
         .store_into(psOptions->bListMDD)

--- a/apps/ogrinfo_lib.cpp
+++ b/apps/ogrinfo_lib.cpp
@@ -2311,7 +2311,7 @@ static std::unique_ptr<GDALArgumentParser> GDALVectorInfoOptionsGetParser(
         auto &group = argParser->add_mutually_exclusive_group();
         group.add_argument("-so", "-summary")
             .store_into(psOptions->bSummaryParser)
-            .help(_("Summary only: Show only summary information like "
+            .help(_("Summary only: show only summary information like "
                     "projection, schema, feature count and extents."));
 
         group.add_argument("-features")


### PR DESCRIPTION
Fix wrong command line help text for the "summary only" option and add points at the end of some help texts for making them consistent.

