### PR TITLE
[Backport release/3.10] CPLGetPath()/CPLGetDirname(): make them work with /vsicurl? and URL encoded

### DIFF
--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -1059,6 +1059,12 @@ TEST_F(test_cpl, CPLGetPath)
     EXPECT_STREQ(CPLGetPath("/foo/bar"), "/foo");
     EXPECT_STREQ(CPLGetPath("/vsicurl/http://example.com/foo/bar?suffix"),
                  "/vsicurl/http://example.com/foo?suffix");
+    EXPECT_STREQ(
+        CPLGetPath(
+            "/vsicurl?foo=bar&url=https%3A%2F%2Fraw.githubusercontent.com%"
+            "2FOSGeo%2Fgdal%2Fmaster%2Fautotest%2Fogr%2Fdata%2Fpoly.shp"),
+        "/vsicurl?foo=bar&url=https%3A%2F%2Fraw.githubusercontent.com%2FOSGeo%"
+        "2Fgdal%2Fmaster%2Fautotest%2Fogr%2Fdata");
 }
 
 TEST_F(test_cpl, CPLGetDirname)
@@ -1067,6 +1073,12 @@ TEST_F(test_cpl, CPLGetDirname)
     EXPECT_STREQ(CPLGetDirname("/foo/bar"), "/foo");
     EXPECT_STREQ(CPLGetDirname("/vsicurl/http://example.com/foo/bar?suffix"),
                  "/vsicurl/http://example.com/foo?suffix");
+    EXPECT_STREQ(
+        CPLGetDirname(
+            "/vsicurl?foo=bar&url=https%3A%2F%2Fraw.githubusercontent.com%"
+            "2FOSGeo%2Fgdal%2Fmaster%2Fautotest%2Fogr%2Fdata%2Fpoly.shp"),
+        "/vsicurl?foo=bar&url=https%3A%2F%2Fraw.githubusercontent.com%2FOSGeo%"
+        "2Fgdal%2Fmaster%2Fautotest%2Fogr%2Fdata");
 }
 
 TEST_F(test_cpl, VSIGetDiskFreeSpace)

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -1747,6 +1747,35 @@ def test_ogr_shape_44():
 
 
 ###############################################################################
+# Test /vsicurl?url=
+
+
+@pytest.mark.require_curl()
+def test_ogr_shape_vsicurl_url():
+
+    conn = gdaltest.gdalurlopen(
+        "https://raw.githubusercontent.com/OSGeo/gdal/release/3.10/autotest/ogr/data/poly.shp"
+    )
+    if conn is None:
+        pytest.skip("cannot open URL")
+    conn.close()
+
+    ds = ogr.Open(
+        "/vsicurl?url=https%3A%2F%2Fraw.githubusercontent.com%2FOSGeo%2Fgdal%2Frelease%2F3.10%2Fautotest%2Fogr%2Fdata%2Fpoly.shp"
+    )
+    assert ds is not None
+
+    lyr = ds.GetLayer(0)
+
+    srs = lyr.GetSpatialRef()
+    wkt = srs.ExportToWkt()
+    assert wkt.find("OSGB") != -1, "did not get expected SRS"
+
+    f = lyr.GetNextFeature()
+    assert f is not None, "did not get expected feature"
+
+
+###############################################################################
 # Test ignored fields works ok on a shapefile.
 
 


### PR DESCRIPTION
Backport #11469
 **Authored by:** @rouault