### PR TITLE
Remove dir only if it exists

### DIFF
--- a/autotest/gdrivers/tiledb_write.py
+++ b/autotest/gdrivers/tiledb_write.py
@@ -451,10 +451,6 @@ def test_tiledb_write_create_group(tmp_path):
     assert ds.RasterYSize == 2
 
 
-@pytest.mark.skipif(
-    gdaltest.is_travis_branch("build-windows-conda"),
-    reason="Fails with tiledb 2.27. Seehttps://github.com/OSGeo/gdal/issues/11485",
-)
 def test_tiledb_write_overviews(tmp_path):
 
     # This dataset name must be kept short, otherwise strange I/O errors will

--- a/frmts/tiledb/tiledbdense.cpp
+++ b/frmts/tiledb/tiledbdense.cpp
@@ -2933,7 +2933,9 @@ CPLErr TileDBRasterDataset::IBuildOverviews(
             {
                 CPL_IGNORE_RET_VAL(poODS->Close());
                 tiledb::Array::delete_array(*m_ctx, poODS->GetDescription());
-                vfs.remove_dir(poODS->GetDescription());
+                if (vfs.is_dir(poODS->GetDescription()) {
+                    vfs.remove_dir(poODS->GetDescription());
+                }
             }
             catch (const tiledb::TileDBError &e)
             {

--- a/frmts/tiledb/tiledbdense.cpp
+++ b/frmts/tiledb/tiledbdense.cpp
@@ -2933,7 +2933,8 @@ CPLErr TileDBRasterDataset::IBuildOverviews(
             {
                 CPL_IGNORE_RET_VAL(poODS->Close());
                 tiledb::Array::delete_array(*m_ctx, poODS->GetDescription());
-                if (vfs.is_dir(poODS->GetDescription())) {
+                if (vfs.is_dir(poODS->GetDescription()))
+                {
                     vfs.remove_dir(poODS->GetDescription());
                 }
             }

--- a/frmts/tiledb/tiledbdense.cpp
+++ b/frmts/tiledb/tiledbdense.cpp
@@ -2933,7 +2933,7 @@ CPLErr TileDBRasterDataset::IBuildOverviews(
             {
                 CPL_IGNORE_RET_VAL(poODS->Close());
                 tiledb::Array::delete_array(*m_ctx, poODS->GetDescription());
-                if (vfs.is_dir(poODS->GetDescription()) {
+                if (vfs.is_dir(poODS->GetDescription())) {
                     vfs.remove_dir(poODS->GetDescription());
                 }
             }


### PR DESCRIPTION
Hopefully this solves compatibility issues and resolves #11485 for all recent TileDB versions.

In TileDB 2.27.0, `delete_array()` and `delete_group()` will clean up the parent directory when they can. I suspect the test fails because the driver code tries to delete a directory that has already been removed.