### PR TITLE
PG: add escaping syntax for TABLES open option to allow table names with open parenthesis

### DIFF
--- a/autotest/ogr/ogr_pg.py
+++ b/autotest/ogr/ogr_pg.py
@@ -1622,6 +1622,47 @@ def test_ogr_pg_31(pg_ds):
 
 
 ###############################################################################
+# Test the TABLES open option
+
+
+def test_ogr_pg_tables_open_option(pg_ds):
+
+    pg_ds.CreateLayer(
+        "test (with parenthesis and \\)",
+        geom_type=ogr.wkbPoint,
+    )
+    pg_ds.CreateLayer(
+        "test with, comma",
+        geom_type=ogr.wkbPoint,
+    )
+    pg_ds.FlushCache()
+
+    with gdal.OpenEx(
+        pg_ds.GetDescription(),
+        gdal.OF_VECTOR,
+        open_options=["TABLES=test \\(with parenthesis and \\\\)"],
+    ) as ds:
+        assert ds.GetLayerCount() == 1
+        assert ds.GetLayer(0).GetName() == "test (with parenthesis and \\)"
+
+    with gdal.OpenEx(
+        pg_ds.GetDescription(),
+        gdal.OF_VECTOR,
+        open_options=["TABLES=test \\(with parenthesis and \\\\)(geometry)"],
+    ) as ds:
+        assert ds.GetLayerCount() == 1
+        assert ds.GetLayer(0).GetName() == "test (with parenthesis and \\)"
+
+    with gdal.OpenEx(
+        pg_ds.GetDescription(),
+        gdal.OF_VECTOR,
+        open_options=['TABLES="test with, comma"'],
+    ) as ds:
+        assert ds.GetLayerCount() == 1
+        assert ds.GetLayer(0).GetName() == "test with, comma"
+
+
+###############################################################################
 # Test approximate srtext (#2123, #3508)
 
 

--- a/doc/source/drivers/vector/pg.rst
+++ b/doc/source/drivers/vector/pg.rst
@@ -199,6 +199,15 @@ The following open options are supported:
 -  .. oo:: TABLES
 
       Restricted set of tables to list (comma separated).
+      Each table name can be qualified by its schema, like ``schema_name.table_name``.
+      For tables with multiple geometry columns, the ``table_name(geometry_column)``
+      syntax can be used.
+
+      Starting with GDAL 3.11, if the table name itself contains an open parenthesis ``(``,
+      or a backslash character ``\``, they must be escaped with a preceding backslash
+      character. e.g. ``table_name \(with parenthesis)``.
+      If that table name contains a comma, the table name must be quoted with
+      double quotes. e.g. ``first_table,"second table, with comma"``.
 
 -  .. oo:: LIST_ALL_TABLES
       :choices: YES, NO


### PR DESCRIPTION
Fixes #11486

(not appropriate for backport)