### PR TITLE
GDALRasterizeLayers(): do not emit warning about missing SRS if the target raster dataset has no SRS

### DIFF
--- a/alg/gdalrasterize.cpp
+++ b/alg/gdalrasterize.cpp
@@ -1645,11 +1645,17 @@ CPLErr GDALRasterizeLayers(GDALDatasetH hDS, int nBandCount, int *panBandList,
             OGRSpatialReference *poSRS = poLayer->GetSpatialRef();
             if (!poSRS)
             {
-                CPLError(CE_Warning, CPLE_AppDefined,
-                         "Failed to fetch spatial reference on layer %s "
-                         "to build transformer, assuming matching coordinate "
-                         "systems.",
-                         poLayer->GetLayerDefn()->GetName());
+                if (poDS->GetSpatialRef() != nullptr ||
+                    poDS->GetGCPSpatialRef() != nullptr ||
+                    poDS->GetMetadata("RPC") != nullptr)
+                {
+                    CPLError(
+                        CE_Warning, CPLE_AppDefined,
+                        "Failed to fetch spatial reference on layer %s "
+                        "to build transformer, assuming matching coordinate "
+                        "systems.",
+                        poLayer->GetLayerDefn()->GetName());
+                }
             }
             else
             {


### PR DESCRIPTION
Related to https://lists.osgeo.org/pipermail/gdal-dev/2024-December/059948.html
