### PR TITLE
VRTProcessedDataset: reduce block size when amount of RAM for temp buffers would be too large

### DIFF
--- a/gcore/gdalmultidim.cpp
+++ b/gcore/gdalmultidim.cpp
@@ -66,10 +66,10 @@ class GDALMDArrayUnscaled final : public GDALPamMDArray
         m_abyRawNoData.resize(m_dt.GetSize());
         const auto eNonComplexDT =
             GDALGetNonComplexDataType(m_dt.GetNumericDataType());
-        GDALCopyWords(&dfOverriddenDstNodata, GDT_Float64, 0,
-                      m_abyRawNoData.data(), eNonComplexDT,
-                      GDALGetDataTypeSizeBytes(eNonComplexDT),
-                      GDALDataTypeIsComplex(m_dt.GetNumericDataType()) ? 2 : 1);
+        GDALCopyWords64(
+            &dfOverriddenDstNodata, GDT_Float64, 0, m_abyRawNoData.data(),
+            eNonComplexDT, GDALGetDataTypeSizeBytes(eNonComplexDT),
+            GDALDataTypeIsComplex(m_dt.GetNumericDataType()) ? 2 : 1);
     }
 
     bool IRead(const GUInt64 *arrayStartIdx, const size_t *count,
@@ -1623,8 +1623,8 @@ bool GDALExtendedDataType::CopyValue(const void *pSrc,
     if (srcType.GetClass() == GEDTC_NUMERIC &&
         dstType.GetClass() == GEDTC_NUMERIC)
     {
-        GDALCopyWords(pSrc, srcType.GetNumericDataType(), 0, pDst,
-                      dstType.GetNumericDataType(), 0, 1);
+        GDALCopyWords64(pSrc, srcType.GetNumericDataType(), 0, pDst,
+                        dstType.GetNumericDataType(), 0, 1);
         return true;
     }
     if (srcType.GetClass() == GEDTC_STRING &&
@@ -1733,8 +1733,8 @@ bool GDALExtendedDataType::CopyValue(const void *pSrc,
         {
             // FIXME GDT_UInt64
             const double dfVal = srcStrPtr == nullptr ? 0 : CPLAtof(srcStrPtr);
-            GDALCopyWords(&dfVal, GDT_Float64, 0, pDst,
-                          dstType.GetNumericDataType(), 0, 1);
+            GDALCopyWords64(&dfVal, GDT_Float64, 0, pDst,
+                            dstType.GetNumericDataType(), 0, 1);
         }
         return true;
     }
@@ -2621,8 +2621,8 @@ double GDALMDArray::GetNoDataValueAsDouble(bool *pbHasNoData) const
     const bool ok = pNoData != nullptr && eDT.GetClass() == GEDTC_NUMERIC;
     if (ok)
     {
-        GDALCopyWords(pNoData, eDT.GetNumericDataType(), 0, &dfNoData,
-                      GDT_Float64, 0, 1);
+        GDALCopyWords64(pNoData, eDT.GetNumericDataType(), 0, &dfNoData,
+                        GDT_Float64, 0, 1);
     }
     if (pbHasNoData)
         *pbHasNoData = ok;
@@ -2652,8 +2652,8 @@ int64_t GDALMDArray::GetNoDataValueAsInt64(bool *pbHasNoData) const
     const bool ok = pNoData != nullptr && eDT.GetClass() == GEDTC_NUMERIC;
     if (ok)
     {
-        GDALCopyWords(pNoData, eDT.GetNumericDataType(), 0, &nNoData, GDT_Int64,
-                      0, 1);
+        GDALCopyWords64(pNoData, eDT.GetNumericDataType(), 0, &nNoData,
+                        GDT_Int64, 0, 1);
     }
     if (pbHasNoData)
         *pbHasNoData = ok;
@@ -2683,8 +2683,8 @@ uint64_t GDALMDArray::GetNoDataValueAsUInt64(bool *pbHasNoData) const
     const bool ok = pNoData != nullptr && eDT.GetClass() == GEDTC_NUMERIC;
     if (ok)
     {
-        GDALCopyWords(pNoData, eDT.GetNumericDataType(), 0, &nNoData,
-                      GDT_UInt64, 0, 1);
+        GDALCopyWords64(pNoData, eDT.GetNumericDataType(), 0, &nNoData,
+                        GDT_UInt64, 0, 1);
     }
     if (pbHasNoData)
         *pbHasNoData = ok;
@@ -6387,8 +6387,8 @@ bool GDALMDArrayUnscaled::IWrite(const GUInt64 *arrayStartIdx,
     double dfNoData = 0;
     if (m_bHasNoData)
     {
-        GDALCopyWords(m_abyRawNoData.data(), m_dt.GetNumericDataType(), 0,
-                      &dfNoData, GDT_Float64, 0, 1);
+        GDALCopyWords64(m_abyRawNoData.data(), m_dt.GetNumericDataType(), 0,
+                        &dfNoData, GDT_Float64, 0, 1);
     }
 
     double adfSrcNoData[2] = {0, 0};
@@ -6552,10 +6552,10 @@ lbl_next_depth:
         // Remaining elements
         for (size_t i = 1; i < nElts; ++i)
         {
-            GDALCopyWords(static_cast<GByte *>(pTempBuffer) + i * nDTSize,
-                          eNumericDT, 0,
-                          static_cast<GByte *>(pTempBuffer) + i * nParentDTSize,
-                          eParentNumericDT, 0, 1);
+            GDALCopyWords64(
+                static_cast<GByte *>(pTempBuffer) + i * nDTSize, eNumericDT, 0,
+                static_cast<GByte *>(pTempBuffer) + i * nParentDTSize,
+                eParentNumericDT, 0, 1);
         }
     }
 

--- a/gcore/gdalmultidim_gltorthorectification.cpp
+++ b/gcore/gdalmultidim_gltorthorectification.cpp
@@ -223,8 +223,8 @@ bool GLTOrthoRectifiedArray::IRead(const GUInt64 *arrayStartIdx,
     auto pRawNoDataValue = GetRawNoDataValue();
     std::vector<GByte> abyNoData(16);
     if (pRawNoDataValue)
-        GDALCopyWords(pRawNoDataValue, GetDataType().GetNumericDataType(), 0,
-                      abyNoData.data(), eBufferDT, 0, 1);
+        GDALCopyWords64(pRawNoDataValue, GetDataType().GetNumericDataType(), 0,
+                        abyNoData.data(), eBufferDT, 0, 1);
 
     const auto nBufferDTSize = bufferDataType.GetSize();
     const int nCopyWordsDstStride =
@@ -246,8 +246,9 @@ bool GLTOrthoRectifiedArray::IRead(const GUInt64 *arrayStartIdx,
                     static_cast<GByte *>(pDstBuffer) +
                     (iY * bufferStride[0] + iX * bufferStride[1]) *
                         static_cast<int>(nBufferDTSize);
-                GDALCopyWords(abyNoData.data(), eBufferDT, 0, pabyDstBuffer,
-                              eBufferDT, nCopyWordsDstStride, nCopyWordsCount);
+                GDALCopyWords64(abyNoData.data(), eBufferDT, 0, pabyDstBuffer,
+                                eBufferDT, nCopyWordsDstStride,
+                                nCopyWordsCount);
             }
         }
     };
@@ -401,9 +402,10 @@ bool GLTOrthoRectifiedArray::IRead(const GUInt64 *arrayStartIdx,
                 const GByte *pabySrcBuffer =
                     parentValues.data() +
                     (iSrcY * nXCount + iSrcX) * nBandCount * nBufferDTSize;
-                GDALCopyWords(pabySrcBuffer, eBufferDT,
-                              static_cast<int>(nBufferDTSize), pabyDstBuffer,
-                              eBufferDT, nCopyWordsDstStride, nCopyWordsCount);
+                GDALCopyWords64(pabySrcBuffer, eBufferDT,
+                                static_cast<int>(nBufferDTSize), pabyDstBuffer,
+                                eBufferDT, nCopyWordsDstStride,
+                                nCopyWordsCount);
                 if (bSomeBandInvalids)
                 {
                     for (size_t i = 0; i < count[2]; ++i)
@@ -412,18 +414,19 @@ bool GLTOrthoRectifiedArray::IRead(const GUInt64 *arrayStartIdx,
                             arrayStartIdx[2] + i * arrayStep[2]);
                         if (!m_abyBandValidity[iBand])
                         {
-                            GDALCopyWords(abyNoData.data(), eBufferDT, 0,
-                                          pabyDstBuffer +
-                                              i * nCopyWordsDstStride,
-                                          eBufferDT, 0, 1);
+                            GDALCopyWords64(abyNoData.data(), eBufferDT, 0,
+                                            pabyDstBuffer +
+                                                i * nCopyWordsDstStride,
+                                            eBufferDT, 0, 1);
                         }
                     }
                 }
             }
             else
             {
-                GDALCopyWords(abyNoData.data(), eBufferDT, 0, pabyDstBuffer,
-                              eBufferDT, nCopyWordsDstStride, nCopyWordsCount);
+                GDALCopyWords64(abyNoData.data(), eBufferDT, 0, pabyDstBuffer,
+                                eBufferDT, nCopyWordsDstStride,
+                                nCopyWordsCount);
             }
         }
     }

--- a/gcore/gdalnodatamaskband.cpp
+++ b/gcore/gdalnodatamaskband.cpp
@@ -539,7 +539,7 @@ CPLErr GDALNoDataMaskBand::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
 
     for (int iY = 0; iY < nBufYSize; iY++)
     {
-        GDALCopyWords(
+        GDALCopyWords64(
             static_cast<GByte *>(pTemp) + static_cast<size_t>(iY) * nBufXSize,
             GDT_Byte, 1, static_cast<GByte *>(pData) + iY * nLineSpace,
             eBufType, static_cast<int>(nPixelSpace), nBufXSize);

--- a/gcore/gdalrasterband.cpp
+++ b/gcore/gdalrasterband.cpp
@@ -9301,8 +9301,8 @@ class GDALMDArrayFromRasterBand final : public GDALMDArray
             if (bHasNoData)
             {
                 m_pabyNoData.resize(m_dt.GetSize());
-                GDALCopyWords(&nNoData, GDT_Int64, 0, &m_pabyNoData[0],
-                              m_dt.GetNumericDataType(), 0, 1);
+                GDALCopyWords64(&nNoData, GDT_Int64, 0, &m_pabyNoData[0],
+                                m_dt.GetNumericDataType(), 0, 1);
             }
         }
         else if (m_poBand->GetRasterDataType() == GDT_UInt64)
@@ -9311,8 +9311,8 @@ class GDALMDArrayFromRasterBand final : public GDALMDArray
             if (bHasNoData)
             {
                 m_pabyNoData.resize(m_dt.GetSize());
-                GDALCopyWords(&nNoData, GDT_UInt64, 0, &m_pabyNoData[0],
-                              m_dt.GetNumericDataType(), 0, 1);
+                GDALCopyWords64(&nNoData, GDT_UInt64, 0, &m_pabyNoData[0],
+                                m_dt.GetNumericDataType(), 0, 1);
             }
         }
         else
@@ -9321,8 +9321,8 @@ class GDALMDArrayFromRasterBand final : public GDALMDArray
             if (bHasNoData)
             {
                 m_pabyNoData.resize(m_dt.GetSize());
-                GDALCopyWords(&dfNoData, GDT_Float64, 0, &m_pabyNoData[0],
-                              m_dt.GetNumericDataType(), 0, 1);
+                GDALCopyWords64(&dfNoData, GDT_Float64, 0, &m_pabyNoData[0],
+                                m_dt.GetNumericDataType(), 0, 1);
             }
         }
 

--- a/gcore/overview.cpp
+++ b/gcore/overview.cpp
@@ -3706,11 +3706,11 @@ static CPLErr GDALResampleChunk_ConvolutionT(
 
         if (pafWrkScanline)
         {
-            GDALCopyWords(pafWrkScanline, eWrkDataType, nWrkDataTypeSize,
-                          static_cast<GByte *>(pDstBuffer) +
-                              static_cast<size_t>(iDstLine - nDstYOff) *
-                                  nDstXSize * nDstDataTypeSize,
-                          dstDataType, nDstDataTypeSize, nDstXSize);
+            GDALCopyWords64(pafWrkScanline, eWrkDataType, nWrkDataTypeSize,
+                            static_cast<GByte *>(pDstBuffer) +
+                                static_cast<size_t>(iDstLine - nDstYOff) *
+                                    nDstXSize * nDstDataTypeSize,
+                            dstDataType, nDstDataTypeSize, nDstXSize);
         }
     }
 

--- a/gcore/rasterio.cpp
+++ b/gcore/rasterio.cpp
@@ -161,8 +161,8 @@ static bool DownsamplingIntegerXFactor(
         else
         {
             // Type to type conversion ...
-            GDALCopyWords(pabySrcData, eDataType, nIncSrcOffset, pabyDstData,
-                          eBufType, nPixelSpace, std::max(1, nIters));
+            GDALCopyWords64(pabySrcData, eDataType, nIncSrcOffset, pabyDstData,
+                            eBufType, nPixelSpace, std::max(1, nIters));
             if (nIters > 1)
             {
                 pabySrcData +=
@@ -330,18 +330,18 @@ CPLErr GDALRasterBand::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
                 // Type to type conversion.
 
                 if (eRWFlag == GF_Read)
-                    GDALCopyWords(
+                    GDALCopyWords64(
                         pabySrcBlock + nSrcByteOffset, eDataType, nBandDataSize,
                         static_cast<GByte *>(pData) +
                             static_cast<GPtrDiff_t>(iBufYOff) * nLineSpace,
                         eBufType, static_cast<int>(nPixelSpace), nBufXSize);
                 else
-                    GDALCopyWords(static_cast<GByte *>(pData) +
-                                      static_cast<GPtrDiff_t>(iBufYOff) *
-                                          nLineSpace,
-                                  eBufType, static_cast<int>(nPixelSpace),
-                                  pabySrcBlock + nSrcByteOffset, eDataType,
-                                  nBandDataSize, nBufXSize);
+                    GDALCopyWords64(static_cast<GByte *>(pData) +
+                                        static_cast<GPtrDiff_t>(iBufYOff) *
+                                            nLineSpace,
+                                    eBufType, static_cast<int>(nPixelSpace),
+                                    pabySrcBlock + nSrcByteOffset, eDataType,
+                                    nBandDataSize, nBufXSize);
             }
 
             if (psExtraArg->pfnProgress != nullptr &&
@@ -527,7 +527,7 @@ CPLErr GDALRasterBand::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
                     {
                         /* type to type conversion */
                         if (eRWFlag == GF_Read)
-                            GDALCopyWords(
+                            GDALCopyWords64(
                                 pabySrcBlock + iSrcOffset, eDataType,
                                 nBandDataSize,
                                 static_cast<GByte *>(pData) + iBufOffset +
@@ -535,7 +535,7 @@ CPLErr GDALRasterBand::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
                                 eBufType, static_cast<int>(nPixelSpace),
                                 nXSpan);
                         else
-                            GDALCopyWords(
+                            GDALCopyWords64(
                                 static_cast<GByte *>(pData) + iBufOffset +
                                     static_cast<GPtrDiff_t>(k) * nLineSpace,
                                 eBufType, static_cast<int>(nPixelSpace),
@@ -713,9 +713,9 @@ CPLErr GDALRasterBand::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
                     /* type to type conversion ... ouch, this is expensive way
                     of handling single words */
 
-                    GDALCopyWords(static_cast<GByte *>(pData) + iBufOffset,
-                                  eBufType, 0, pabyDstBlock + iDstOffset,
-                                  eDataType, 0, 1);
+                    GDALCopyWords64(static_cast<GByte *>(pData) + iBufOffset,
+                                    eBufType, 0, pabyDstBlock + iDstOffset,
+                                    eDataType, 0, 1);
                 }
             }
 
@@ -925,9 +925,10 @@ CPLErr GDALRasterBand::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
                         // Type to type conversion ...
                         GPtrDiff_t iSrcOffset =
                             (nDiffX + iSrcOffsetCst) * nBandDataSize;
-                        GDALCopyWords(pabySrcBlock + iSrcOffset, eDataType, 0,
-                                      static_cast<GByte *>(pData) + iBufOffset,
-                                      eBufType, 0, 1);
+                        GDALCopyWords64(pabySrcBlock + iSrcOffset, eDataType, 0,
+                                        static_cast<GByte *>(pData) +
+                                            iBufOffset,
+                                        eBufType, 0, 1);
                     }
 
                     iBufOffset += static_cast<int>(nPixelSpace);
@@ -1393,12 +1394,13 @@ CPLErr GDALRasterBand::RasterIOResampled(
                         {
                             for (int j = 0; j < nDstYCount; j++)
                             {
-                                GDALCopyWords(&dfNoDataValue, GDT_Float64, 0,
-                                              static_cast<GByte *>(pDataMem) +
-                                                  nLSMem * (j + nDstYOff) +
-                                                  nDstXOff * nPSMem,
-                                              eDTMem, static_cast<int>(nPSMem),
-                                              nDstXCount);
+                                GDALCopyWords64(&dfNoDataValue, GDT_Float64, 0,
+                                                static_cast<GByte *>(pDataMem) +
+                                                    nLSMem * (j + nDstYOff) +
+                                                    nDstXOff * nPSMem,
+                                                eDTMem,
+                                                static_cast<int>(nPSMem),
+                                                nDstXCount);
                             }
                             bSkipResample = true;
                         }
@@ -1856,7 +1858,7 @@ CPLErr GDALDataset::RasterIOResampled(
                             {
                                 for (int j = 0; j < nDstYCount; j++)
                                 {
-                                    GDALCopyWords(
+                                    GDALCopyWords64(
                                         abyZero, GDT_Byte, 0,
                                         static_cast<GByte *>(pData) +
                                             iBand * nBandSpace +
@@ -2955,7 +2957,7 @@ static void GDALReplicateWord(const void *CPL_RESTRICT pSrcData,
      */
     // Let the general translation case do the necessary conversions
     // on the first destination element.
-    GDALCopyWords(pSrcData, eSrcType, 0, pDstData, eDstType, 0, 1);
+    GDALCopyWords64(pSrcData, eSrcType, 0, pDstData, eDstType, 0, 1);
 
     // Now copy the first element to the nWordCount - 1 following destination
     // elements.
@@ -4313,15 +4315,15 @@ CPLErr GDALDataset::BlockBasedRasterIO(
                        of handling single words */
 
                     if (eRWFlag == GF_Read)
-                        GDALCopyWords(pabySrcBlock + iSrcOffset, eDataType, 0,
-                                      static_cast<GByte *>(pData) +
-                                          iBandBufOffset,
-                                      eBufType, 0, 1);
+                        GDALCopyWords64(pabySrcBlock + iSrcOffset, eDataType, 0,
+                                        static_cast<GByte *>(pData) +
+                                            iBandBufOffset,
+                                        eBufType, 0, 1);
                     else
-                        GDALCopyWords(static_cast<const GByte *>(pData) +
-                                          iBandBufOffset,
-                                      eBufType, 0, pabySrcBlock + iSrcOffset,
-                                      eDataType, 0, 1);
+                        GDALCopyWords64(static_cast<const GByte *>(pData) +
+                                            iBandBufOffset,
+                                        eBufType, 0, pabySrcBlock + iSrcOffset,
+                                        eDataType, 0, 1);
                 }
             }
 

--- a/gcore/rawdataset.cpp
+++ b/gcore/rawdataset.cpp
@@ -644,8 +644,8 @@ CPLErr RawRasterBand::IReadBlock(CPL_UNUSED int nBlockXOff, int nBlockYOff,
 
     // Copy data from disk buffer to user block buffer.
     const int nDTSize = GDALGetDataTypeSizeBytes(eDataType);
-    GDALCopyWords(pLineStart, eDataType, nPixelOffset, pImage, eDataType,
-                  nDTSize, nBlockXSize);
+    GDALCopyWords64(pLineStart, eDataType, nPixelOffset, pImage, eDataType,
+                    nDTSize, nBlockXSize);
 
     // Pre-cache block cache of other bands
     if (poDS != nullptr && poDS->GetRasterCount() > 1 && IsBIP())
@@ -666,9 +666,9 @@ CPLErr RawRasterBand::IReadBlock(CPL_UNUSED int nBlockXOff, int nBlockYOff,
                 poBlock = poOtherBand->GetLockedBlockRef(0, nBlockYOff, true);
                 if (poBlock != nullptr)
                 {
-                    GDALCopyWords(poOtherBand->pLineStart, eDataType,
-                                  nPixelOffset, poBlock->GetDataRef(),
-                                  eDataType, nDTSize, nBlockXSize);
+                    GDALCopyWords64(poOtherBand->pLineStart, eDataType,
+                                    nPixelOffset, poBlock->GetDataRef(),
+                                    eDataType, nDTSize, nBlockXSize);
                     poBlock->DropLock();
                 }
             }
@@ -763,8 +763,8 @@ CPLErr RawRasterBand::BIPWriteBlock(int nBlockYOff, int nCallingBand,
 
         GByte *pabyOut = static_cast<GByte *>(pLineStart) + iBand * nDTSize;
 
-        GDALCopyWords(pabyThisImage, eDataType, nDTSize, pabyOut, eDataType,
-                      nPixelOffset, nBlockXSize);
+        GDALCopyWords64(pabyThisImage, eDataType, nDTSize, pabyOut, eDataType,
+                        nPixelOffset, nBlockXSize);
 
         if (poBlock != nullptr)
         {
@@ -823,8 +823,8 @@ CPLErr RawRasterBand::IWriteBlock(CPL_UNUSED int nBlockXOff, int nBlockYOff,
         eErr = AccessLine(nBlockYOff);
 
     // Copy data from user buffer into disk buffer.
-    GDALCopyWords(pImage, eDataType, nDTSize, pLineStart, eDataType,
-                  nPixelOffset, nBlockXSize);
+    GDALCopyWords64(pImage, eDataType, nDTSize, pLineStart, eDataType,
+                    nPixelOffset, nBlockXSize);
 
     nLoadedScanline = nBlockYOff;
     bLoadedScanlineDirty = true;
@@ -1156,7 +1156,7 @@ CPLErr RawRasterBand::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
                 // subsample, if needed.
                 if (nXSize == nBufXSize && nYSize == nBufYSize)
                 {
-                    GDALCopyWords(
+                    GDALCopyWords64(
                         pabyData, eDataType, nPixelOffset,
                         static_cast<GByte *>(pData) + iLine * nLineSpace,
                         eBufType, static_cast<int>(nPixelSpace), nXSize);
@@ -1165,7 +1165,7 @@ CPLErr RawRasterBand::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
                 {
                     for (int iPixel = 0; iPixel < nBufXSize; iPixel++)
                     {
-                        GDALCopyWords(
+                        GDALCopyWords64(
                             pabyData + static_cast<vsi_l_offset>(
                                            iPixel * dfSrcXInc + EPS) *
                                            nPixelOffset,
@@ -1283,23 +1283,23 @@ CPLErr RawRasterBand::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
                 // subsample, if needed.
                 if (nXSize == nBufXSize && nYSize == nBufYSize)
                 {
-                    GDALCopyWords(static_cast<GByte *>(pData) +
-                                      iLine * nLineSpace,
-                                  eBufType, static_cast<int>(nPixelSpace),
-                                  pabyData, eDataType, nPixelOffset, nXSize);
+                    GDALCopyWords64(static_cast<GByte *>(pData) +
+                                        iLine * nLineSpace,
+                                    eBufType, static_cast<int>(nPixelSpace),
+                                    pabyData, eDataType, nPixelOffset, nXSize);
                 }
                 else
                 {
                     for (int iPixel = 0; iPixel < nBufXSize; iPixel++)
                     {
-                        GDALCopyWords(static_cast<GByte *>(pData) +
-                                          iLine * nLineSpace +
-                                          iPixel * nPixelSpace,
-                                      eBufType, static_cast<int>(nPixelSpace),
-                                      pabyData + static_cast<vsi_l_offset>(
-                                                     iPixel * dfSrcXInc + EPS) *
-                                                     nPixelOffset,
-                                      eDataType, nPixelOffset, 1);
+                        GDALCopyWords64(
+                            static_cast<GByte *>(pData) + iLine * nLineSpace +
+                                iPixel * nPixelSpace,
+                            eBufType, static_cast<int>(nPixelSpace),
+                            pabyData + static_cast<vsi_l_offset>(
+                                           iPixel * dfSrcXInc + EPS) *
+                                           nPixelOffset,
+                            eDataType, nPixelOffset, 1);
                     }
                 }
 


### PR DESCRIPTION
and also: gcore: use GDALCopyWords64() instead of GDALCopyWords() for microscopic perf improvement