### PR TITLE
GDALMDArray::AsClassicDataset(): allow to set band IMAGERY metadata domain

### DIFF
--- a/gcore/gdalmultidim.cpp
+++ b/gcore/gdalmultidim.cpp
@@ -8551,6 +8551,15 @@ struct MetadataItem
     std::string osDefinition{};
     bool bDefinitionUsesPctForG = false;
 };
+
+struct BandImageryMetadata
+{
+    std::shared_ptr<GDALMDArray> poCentralWavelengthArray{};
+    double dfCentralWavelengthToMicrometer = 1.0;
+    std::shared_ptr<GDALMDArray> poFWHMArray{};
+    double dfFWHMToMicrometer = 1.0;
+};
+
 }  // namespace
 
 class GDALRasterBandFromArray final : public GDALPamRasterBand
@@ -8574,6 +8583,7 @@ class GDALRasterBandFromArray final : public GDALPamRasterBand
         const std::vector<GUInt64> &anOtherDimCoord,
         const std::vector<std::vector<MetadataItem>>
             &aoBandParameterMetadataItems,
+        const std::vector<BandImageryMetadata> &aoBandImageryMetadata,
         double dfDelay, time_t nStartTime, bool &bHasWarned);
 
     double GetNoDataValue(int *pbHasNoData) override;
@@ -8707,6 +8717,7 @@ class GDALDatasetFromArray final : public GDALPamDataset
 GDALRasterBandFromArray::GDALRasterBandFromArray(
     GDALDatasetFromArray *poDSIn, const std::vector<GUInt64> &anOtherDimCoord,
     const std::vector<std::vector<MetadataItem>> &aoBandParameterMetadataItems,
+    const std::vector<BandImageryMetadata> &aoBandImageryMetadata,
     double dfDelay, time_t nStartTime, bool &bHasWarned)
 {
     const auto &poArray(poDSIn->m_poArray);
@@ -8876,6 +8887,51 @@ GDALRasterBandFromArray::GDALRasterBandFromArray(
                 }
                 if (!osVal.empty())
                     SetMetadataItem(oItem.osName.c_str(), osVal);
+            }
+
+            if (aoBandImageryMetadata[j].poCentralWavelengthArray)
+            {
+                auto &poCentralWavelengthArray =
+                    aoBandImageryMetadata[j].poCentralWavelengthArray;
+                size_t nCount = 1;
+                const auto &dt(poCentralWavelengthArray->GetDataType());
+                std::vector<GByte> abyTmp(dt.GetSize());
+                if (poCentralWavelengthArray->Read(&(anOtherDimCoord[j]),
+                                                   &nCount, nullptr, nullptr,
+                                                   dt, &abyTmp[0]))
+                {
+                    double dfVal = 0;
+                    GDALExtendedDataType::CopyValue(
+                        &abyTmp[0], dt, &dfVal,
+                        GDALExtendedDataType::Create(GDT_Float64));
+                    SetMetadataItem(
+                        "CENTRAL_WAVELENGTH_UM",
+                        CPLSPrintf(
+                            "%g", dfVal * aoBandImageryMetadata[j]
+                                              .dfCentralWavelengthToMicrometer),
+                        "IMAGERY");
+                }
+            }
+
+            if (aoBandImageryMetadata[j].poFWHMArray)
+            {
+                auto &poFWHMArray = aoBandImageryMetadata[j].poFWHMArray;
+                size_t nCount = 1;
+                const auto &dt(poFWHMArray->GetDataType());
+                std::vector<GByte> abyTmp(dt.GetSize());
+                if (poFWHMArray->Read(&(anOtherDimCoord[j]), &nCount, nullptr,
+                                      nullptr, dt, &abyTmp[0]))
+                {
+                    double dfVal = 0;
+                    GDALExtendedDataType::CopyValue(
+                        &abyTmp[0], dt, &dfVal,
+                        GDALExtendedDataType::Create(GDT_Float64));
+                    SetMetadataItem(
+                        "FWHM_UM",
+                        CPLSPrintf("%g", dfVal * aoBandImageryMetadata[j]
+                                                     .dfFWHMToMicrometer),
+                        "IMAGERY");
+                }
             }
 
             m_anOffset[i] = anOtherDimCoord[j];
@@ -9161,12 +9217,22 @@ GDALDatasetFromArray *GDALDatasetFromArray::Create(
         }
     }
 
+    std::map<std::string, size_t> oMapArrayDimNameToExtraDimIdx;
+    for (size_t i = 0, j = 0; i < nDimCount; ++i)
+    {
+        if (i != iXDim && !(nDimCount >= 2 && i == iYDim))
+        {
+            oMapArrayDimNameToExtraDimIdx[dims[i]->GetName()] = j;
+            ++j;
+        }
+    }
+
+    const size_t nNewDimCount = nDimCount >= 2 ? nDimCount - 2 : 0;
+
     const char *pszBandMetadata =
         CSLFetchNameValue(papszOptions, "BAND_METADATA");
-    const size_t nNewDimCount = nDimCount >= 2 ? nDimCount - 2 : 0;
     std::vector<std::vector<MetadataItem>> aoBandParameterMetadataItems(
         nNewDimCount);
-
     if (pszBandMetadata)
     {
         if (!poRootGroup)
@@ -9188,16 +9254,6 @@ GDALDatasetFromArray *GDALDatasetFromArray::Create(
             CPLError(CE_Failure, CPLE_AppDefined,
                      "Value of BAND_METADATA should be an array");
             return nullptr;
-        }
-
-        std::map<std::string, size_t> oMapArrayDimNameToExtraDimIdx;
-        for (size_t i = 0, j = 0; i < nDimCount; ++i)
-        {
-            if (i != iXDim && !(nDimCount >= 2 && i == iYDim))
-            {
-                oMapArrayDimNameToExtraDimIdx[dims[i]->GetName()] = j;
-                ++j;
-            }
         }
 
         auto oArray = oRoot.ToArray();
@@ -9382,6 +9438,155 @@ GDALDatasetFromArray *GDALDatasetFromArray::Create(
         }
     }
 
+    std::vector<BandImageryMetadata> aoBandImageryMetadata(nNewDimCount);
+    const char *pszBandImageryMetadata =
+        CSLFetchNameValue(papszOptions, "BAND_IMAGERY_METADATA");
+    if (pszBandImageryMetadata)
+    {
+        if (!poRootGroup)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Root group should be provided when BAND_IMAGERY_METADATA "
+                     "is set");
+            return nullptr;
+        }
+        CPLJSONDocument oDoc;
+        if (!oDoc.LoadMemory(pszBandImageryMetadata))
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Invalid JSON content for BAND_IMAGERY_METADATA");
+            return nullptr;
+        }
+        auto oRoot = oDoc.GetRoot();
+        if (oRoot.GetType() != CPLJSONObject::Type::Object)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Value of BAND_IMAGERY_METADATA should be an object");
+            return nullptr;
+        }
+        for (const auto &oJsonItem : oRoot.GetChildren())
+        {
+            if (oJsonItem.GetName() == "CENTRAL_WAVELENGTH_UM" ||
+                oJsonItem.GetName() == "FWHM_UM")
+            {
+                auto osBandArrayFullname = oJsonItem.GetString("array");
+                if (osBandArrayFullname.empty())
+                {
+                    CPLError(
+                        CE_Failure, CPLE_AppDefined,
+                        "BAND_IMAGERY_METADATA[\"%s\"][\"array\"] is missing",
+                        oJsonItem.GetName().c_str());
+                    return nullptr;
+                }
+                auto poArray =
+                    poRootGroup->OpenMDArrayFromFullname(osBandArrayFullname);
+                if (!poArray)
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "Array %s cannot be found",
+                             osBandArrayFullname.c_str());
+                    return nullptr;
+                }
+                if (poArray->GetDimensionCount() != 1)
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "Array %s is not a 1D array",
+                             osBandArrayFullname.c_str());
+                    return nullptr;
+                }
+                const auto &osAuxArrayDimName =
+                    poArray->GetDimensions()[0]->GetName();
+                auto oIter =
+                    oMapArrayDimNameToExtraDimIdx.find(osAuxArrayDimName);
+                if (oIter == oMapArrayDimNameToExtraDimIdx.end())
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "Dimension \"%s\" of array \"%s\" is not a "
+                             "non-X/Y dimension of array \"%s\"",
+                             osAuxArrayDimName.c_str(),
+                             osBandArrayFullname.c_str(),
+                             array->GetName().c_str());
+                    return nullptr;
+                }
+                const size_t iExtraDimIdx = oIter->second;
+                CPLAssert(iExtraDimIdx < nNewDimCount);
+
+                std::string osUnit = oJsonItem.GetString("unit", "um");
+                if (STARTS_WITH(osUnit.c_str(), "${"))
+                {
+                    if (osUnit.back() != '}')
+                    {
+                        CPLError(CE_Failure, CPLE_AppDefined,
+                                 "Value of "
+                                 "BAND_IMAGERY_METADATA[\"%s\"][\"unit\"] = "
+                                 "%s is invalid",
+                                 oJsonItem.GetName().c_str(), osUnit.c_str());
+                        return nullptr;
+                    }
+                    const auto osAttrName = osUnit.substr(2, osUnit.size() - 3);
+                    auto poAttr = poArray->GetAttribute(osAttrName);
+                    if (!poAttr)
+                    {
+                        CPLError(CE_Failure, CPLE_AppDefined,
+                                 "Value of "
+                                 "BAND_IMAGERY_METADATA[\"%s\"][\"unit\"] = "
+                                 "%s is invalid: %s is not an attribute of %s",
+                                 oJsonItem.GetName().c_str(), osUnit.c_str(),
+                                 osAttrName.c_str(),
+                                 osBandArrayFullname.c_str());
+                        return nullptr;
+                    }
+                    const char *pszValue = poAttr->ReadAsString();
+                    if (!pszValue)
+                    {
+                        CPLError(CE_Failure, CPLE_AppDefined,
+                                 "Cannot get value of attribute %s of %s as a "
+                                 "string",
+                                 osAttrName.c_str(),
+                                 osBandArrayFullname.c_str());
+                        return nullptr;
+                    }
+                    osUnit = pszValue;
+                }
+                double dfConvToUM = 1.0;
+                if (osUnit == "nm" || osUnit == "nanometre" ||
+                    osUnit == "nanometres" || osUnit == "nanometer" ||
+                    osUnit == "nanometers")
+                {
+                    dfConvToUM = 1e-3;
+                }
+                else if (!(osUnit == "um" || osUnit == "micrometre" ||
+                           osUnit == "micrometres" || osUnit == "micrometer" ||
+                           osUnit == "micrometers"))
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "Unhandled value for "
+                             "BAND_IMAGERY_METADATA[\"%s\"][\"unit\"] = %s",
+                             oJsonItem.GetName().c_str(), osUnit.c_str());
+                    return nullptr;
+                }
+
+                BandImageryMetadata &item = aoBandImageryMetadata[iExtraDimIdx];
+                if (oJsonItem.GetName() == "CENTRAL_WAVELENGTH_UM")
+                {
+                    item.poCentralWavelengthArray = poArray;
+                    item.dfCentralWavelengthToMicrometer = dfConvToUM;
+                }
+                else
+                {
+                    item.poFWHMArray = poArray;
+                    item.dfFWHMToMicrometer = dfConvToUM;
+                }
+            }
+            else
+            {
+                CPLError(CE_Warning, CPLE_AppDefined,
+                         "Ignored member \"%s\" in BAND_IMAGERY_METADATA",
+                         oJsonItem.GetName().c_str());
+            }
+        }
+    }
+
     auto poDS = std::make_unique<GDALDatasetFromArray>(array, iXDim, iYDim);
 
     poDS->eAccess = array->IsWritable() ? GA_Update : GA_ReadOnly;
@@ -9462,10 +9667,11 @@ lbl_next_depth:
     }
     else
     {
-        poDS->SetBand(nCurBand, new GDALRasterBandFromArray(
-                                    poDS.get(), anOtherDimCoord,
-                                    aoBandParameterMetadataItems, dfDelay,
-                                    nStartTime, bHasWarned));
+        poDS->SetBand(nCurBand,
+                      new GDALRasterBandFromArray(
+                          poDS.get(), anOtherDimCoord,
+                          aoBandParameterMetadataItems, aoBandImageryMetadata,
+                          dfDelay, nStartTime, bHasWarned));
         ++nCurBand;
     }
     if (iDim > 0)
@@ -9513,7 +9719,7 @@ lbl_next_depth:
  * @param iYDim Index of the dimension that will be used as the Y/height axis.
  *              Ignored if the dimension count is 1.
  * @param poRootGroup (Added in GDAL 3.8) Root group. Used with the BAND_METADATA
- *                    option.
+ *                    and BAND_IMAGERY_METADATA option.
  * @param papszOptions (Added in GDAL 3.8) Null-terminated list of options, or
  *                     nullptr. Current supported options are:
  *                     <ul>
@@ -9555,6 +9761,47 @@ lbl_next_depth:
  *                              "item_value": "${units}"
  *                            }
  *                         ]
+ *                     </li>
+ *                     <li>BAND_IMAGERY_METADATA: (GDAL >= 3.11)
+ *                         JSON serialized object defining which arrays of the
+ *                         poRootGroup, indexed by non-X and Y dimensions,
+ *                         should be mapped as band metadata items in the
+ *                         band IMAGERY domain.
+ *                         The object currently accepts 2 members:
+ *                         - "CENTRAL_WAVELENGTH_UM": Central Wavelength in
+ *                           micrometers.
+ *                         - "FWHM_UM": Full-width half-maximum
+ *                           in micrometers.
+ *                         The value of each member should be an object with the
+ *                         following members:
+ *                         - "array": (required) full name of a band parameter
+ *                           array.
+ *                           Such array must be a one dimensional array, and its
+ *                           dimension must be one of the dimensions of the
+ *                           array on which the method is called
+ *                           (excluding the X and Y dimensons).
+ *                         - "unit": (optional) unit of the values pointed in
+ *                           the above array.
+ *                           Can be a literal string or a string of the form
+ *                           "${attribute_name}" to point to an attribute for
+ *                           the array.
+ *                           Accepted values are "um", "micrometer"
+ *                           (with UK vs US spelling, singular or plural), "nm",
+ *                           "nanometer" (with UK vs US spelling, singular or
+ *                           plural)
+ *                           If not provided, micrometer is assumed.
+ *
+ *                         Example for EMIT datasets:
+ *                         {
+ *                            "CENTRAL_WAVELENGTH_UM": {
+ *                                "array": "/sensor_band_parameters/wavelengths",
+ *                                "unit": "${units}"
+ *                            },
+ *                            "FWHM_UM": {
+ *                                "array": "/sensor_band_parameters/fwhm",
+ *                                "unit": "${units}"
+ *                            }
+ *                         }
  *                     </li>
  *                     <li>LOAD_EXTRA_DIM_METADATA_DELAY: Maximum delay in
  *                         seconds allowed to set the DIM_{dimname}_VALUE band
@@ -13594,7 +13841,8 @@ GDALDatasetH GDALMDArrayAsClassicDataset(GDALMDArrayH hArray, size_t iXDim,
  * @param iXDim Index of the dimension that will be used as the X/width axis.
  * @param iYDim Index of the dimension that will be used as the Y/height axis.
  *              Ignored if the dimension count is 1.
- * @param hRootGroup Root group, or NULL. Used with the BAND_METADATA option.
+ * @param hRootGroup Root group, or NULL. Used with the BAND_METADATA and
+ *                   BAND_IMAGERY_METADATA option.
  * @param papszOptions Cf GDALMDArray::AsClassicDataset()
  * @return a new GDALDataset that must be freed with GDALClose(), or nullptr
  * @since GDAL 3.8


### PR DESCRIPTION
Add a BAND_IMAGERY_METADATA options to papszOptions:

JSON serialized object defining which arrays of the poRootGroup, indexed by non-X and Y dimensions,
should be mapped as band metadata items in the
band IMAGERY domain.
The object currently accepts 2 members:
- "CENTRAL_WAVELENGTH_UM": Central Wavelength in micrometers.
- "FWHM_UM": Full-width half-maximum in micrometers.

The value of each member should be an object with the following members:
- "array": (required) full name of a band parameter array. Such array must be a one dimensional array, and its dimension must be one of the dimensions of the array on which the method is called (excluding the X and Y dimensons).
- "unit": (optional) unit of the values pointed in the above array. Can be a literal string or a string of the form "${attribute_name}" to point to an attribute for the array. Accepted values are "um", "micrometer" (with UK vs US spelling, singular or plural), "nm", "nanometer" (with UK vs US spelling, singular or plural) If not provided, micrometer is assumed.

Example for EMIT datasets:
```json
{
   "CENTRAL_WAVELENGTH_UM": {
       "array": "/sensor_band_parameters/wavelengths",
       "unit": "${units}"
   },
   "FWHM_UM": {
       "array": "/sensor_band_parameters/fwhm",
       "unit": "${units}"
   }
}
```
