### PR TITLE
[Backport release/3.10] Fix CPLFormFilename(absolute_path, ../something, NULL) to strip the relative path

### DIFF
--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -1048,6 +1048,21 @@ TEST_F(test_cpl, CPLFormFilename)
     EXPECT_TRUE(
         EQUAL(CPLFormFilename("\\\\$\\c:", "..", nullptr), "\\\\$\\c:/..") ||
         EQUAL(CPLFormFilename("\\\\$\\c:", "..", nullptr), "\\\\$\\c:\\.."));
+    EXPECT_STREQ(CPLFormFilename("/a", "../", nullptr), "/");
+    EXPECT_STREQ(CPLFormFilename("/a/", "../", nullptr), "/");
+    EXPECT_STREQ(CPLFormFilename("/a", "../b", nullptr), "/b");
+    EXPECT_STREQ(CPLFormFilename("/a/", "../b", nullptr), "/b");
+    EXPECT_STREQ(CPLFormFilename("/a", "../b/c", nullptr), "/b/c");
+    EXPECT_STREQ(CPLFormFilename("/a/", "../b/c/d", nullptr), "/b/c/d");
+    EXPECT_STREQ(CPLFormFilename("/a/b", "../../c", nullptr), "/c");
+    EXPECT_STREQ(CPLFormFilename("/a/b/", "../../c/d", nullptr), "/c/d");
+    EXPECT_STREQ(CPLFormFilename("/a/b", "../..", nullptr), "/");
+    EXPECT_STREQ(CPLFormFilename("/a/b", "../../", nullptr), "/");
+    EXPECT_STREQ(CPLFormFilename("/a/b/c", "../../d", nullptr), "/a/d");
+    EXPECT_STREQ(CPLFormFilename("/a/b/c/", "../../d", nullptr), "/a/d");
+    // we could also just error out, but at least this preserves the original
+    // semantics
+    EXPECT_STREQ(CPLFormFilename("/a", "../../b", nullptr), "/a/../../b");
     EXPECT_STREQ(
         CPLFormFilename("/vsicurl/http://example.com?foo", "bar", nullptr),
         "/vsicurl/http://example.com/bar?foo");

--- a/port/cpl_vsil.cpp
+++ b/port/cpl_vsil.cpp
@@ -146,7 +146,7 @@ char **VSISiblingFiles(const char *pszFilename)
 /** Return the directory separator for the specified path.
  *
  * Default is forward slash. The only exception currently is the Windows
- * file system which returns anti-slash, unless the specified path is of the
+ * file system which returns backslash, unless the specified path is of the
  * form "{drive_letter}:/{rest_of_the_path}".
  *
  * @since 3.9


### PR DESCRIPTION
Backport #11581
 **Authored by:** @rouault