### PR TITLE
update reference since link is no longer available

### DIFF
--- a/doc/source/drivers/raster/gtiff.rst
+++ b/doc/source/drivers/raster/gtiff.rst
@@ -181,7 +181,7 @@ metadata :
 -  TIFFTAG_RESOLUTIONUNIT
 -  TIFFTAG_MINSAMPLEVALUE (read only)
 -  TIFFTAG_MAXSAMPLEVALUE (read only)
--  `GEO_METADATA <https://www.awaresystems.be/imaging/tiff/tifftags/geo_metadata.html>`__:
+-  `GEO_METADATA <https://portal.dgiwg.org/files/70843>`__:
    This tag may be used for embedding XML-encoded instance documents
    prepared using 19139-based schema (GeoTIFF DGIWG) (GDAL >= 2.3)
 -  `TIFF_RSID <https://www.awaresystems.be/imaging/tiff/tifftags/tiff_rsid.html>`__:


### PR DESCRIPTION
GTiff: docs fix bad link for geo_metadata tiff tag

