### PR TITLE
Add CPLErrorOnce() and CPLDebugOnce()

### DIFF
--- a/alg/gdalwarpkernel.cpp
+++ b/alg/gdalwarpkernel.cpp
@@ -1240,13 +1240,8 @@ CPLErr GDALWarpKernel::PerformWarp()
         if (pafUnifiedSrcDensity != nullptr)
         {
             // Typically if there's a cutline or an alpha band
-            static bool bHasWarned = false;
-            if (!bHasWarned)
-            {
-                bHasWarned = true;
-                CPLDebug("WARP", "pafUnifiedSrcDensity is not null, "
+            CPLDebugOnce("WARP", "pafUnifiedSrcDensity is not null, "
                                  "hence OpenCL warper cannot be used");
-            }
         }
         else
         {

--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -5987,12 +5987,9 @@ SetupCT(TargetLayerInfo *psInfo, OGRLayer *poSrcLayer, bool bTransform,
             }
             else
             {
-                static bool bHasWarned = false;
-                if (!bHasWarned)
-                    CPLError(CE_Failure, CPLE_IllegalArg,
+                CPLErrorOnce(CE_Failure, CPLE_IllegalArg,
                              "-wrapdateline option only works when "
                              "reprojecting to a geographic SRS");
-                bHasWarned = true;
             }
 
             psInfo->m_aoReprojectionInfo[iGeom].m_aosTransformOptions.Assign(

--- a/autotest/cpp/test_ogr.cpp
+++ b/autotest/cpp/test_ogr.cpp
@@ -4571,4 +4571,31 @@ TEST_F(test_ogr, OGRFieldDefnGetFieldTypeByName)
     }
 }
 
+// Test OGRGeometryFactory::GetDefaultArcStepSize()
+TEST_F(test_ogr, GetDefaultArcStepSize)
+{
+    if (CPLGetConfigOption("OGR_ARC_STEPSIZE", nullptr) == nullptr)
+    {
+        EXPECT_EQ(OGRGeometryFactory::GetDefaultArcStepSize(), 4.0);
+    }
+    {
+        CPLConfigOptionSetter oSetter("OGR_ARC_STEPSIZE", "0.00001",
+                                      /* bSetOnlyIfUndefined = */ false);
+        CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
+        EXPECT_EQ(OGRGeometryFactory::GetDefaultArcStepSize(), 1e-2);
+        EXPECT_TRUE(
+            strstr(CPLGetLastErrorMsg(),
+                   "Too small value for OGR_ARC_STEPSIZE. Clamping it to"));
+    }
+    {
+        CPLConfigOptionSetter oSetter("OGR_ARC_STEPSIZE", "190",
+                                      /* bSetOnlyIfUndefined = */ false);
+        CPLErrorHandlerPusher oErrorHandler(CPLQuietErrorHandler);
+        EXPECT_EQ(OGRGeometryFactory::GetDefaultArcStepSize(), 180);
+        EXPECT_TRUE(
+            strstr(CPLGetLastErrorMsg(),
+                   "Too large value for OGR_ARC_STEPSIZE. Clamping it to"));
+    }
+}
+
 }  // namespace

--- a/frmts/aigrid/gridlib.c
+++ b/frmts/aigrid/gridlib.c
@@ -13,6 +13,8 @@
 
 #include "aigrid.h"
 
+#include <stdbool.h>
+
 #ifndef CPL_IGNORE_RET_VAL_INT_defined
 #define CPL_IGNORE_RET_VAL_INT_defined
 
@@ -766,21 +768,15 @@ CPLErr AIGReadBlock(VSILFILE *fp, GUInt32 nBlockOffset, int nBlockSize,
 
         if (eErr == CE_Failure)
         {
-            static int bHasWarned = FALSE;
-
             for (i = 0; i < nBlockXSize * nBlockYSize; i++)
                 panData[i] = ESRI_GRID_NO_DATA;
 
-            if (!bHasWarned)
-            {
-                CPLError(CE_Warning, CPLE_AppDefined,
+            CPLErrorOnce(CE_Warning, CPLE_AppDefined,
                          "Unsupported Arc/Info Binary Grid tile of type 0x%X"
                          " encountered.\n"
                          "This and subsequent unsupported tile types set to"
                          " no data value.\n",
                          nMagic);
-                bHasWarned = TRUE;
-            }
         }
     }
 

--- a/frmts/bsb/bsb_read.c
+++ b/frmts/bsb/bsb_read.c
@@ -849,12 +849,7 @@ int BSBReadScanline(BSBInfo *psInfo, int nScanline,
             }
             if (nRunCount > psInfo->nXSize)
             {
-                static int bHasWarned = FALSE;
-                if (!bHasWarned)
-                {
-                    CPLDebug("BSB", "Too big run count : %d", nRunCount);
-                    bHasWarned = TRUE;
-                }
+                CPLDebugOnce("BSB", "Too big run count : %d", nRunCount);
             }
 
             if (iPixel + nRunCount + 1 > psInfo->nXSize)

--- a/frmts/gtiff/geotiff.cpp
+++ b/frmts/gtiff/geotiff.cpp
@@ -93,16 +93,11 @@ void GTIFFGetOverviewBlockSize(GDALRasterBandH hBand, int *pnBlockXSize,
         if (nOvrBlockSize < 64 || nOvrBlockSize > 4096 ||
             !CPLIsPowerOfTwo(nOvrBlockSize))
         {
-            static bool bHasWarned = false;
-            if (!bHasWarned)
-            {
-                CPLError(CE_Warning, CPLE_NotSupported,
+            CPLErrorOnce(CE_Warning, CPLE_NotSupported,
                          "Wrong value for GDAL_TIFF_OVR_BLOCKSIZE : %s. "
                          "Should be a power of 2 between 64 and 4096. "
                          "Defaulting to 128",
                          pszVal);
-                bHasWarned = true;
-            }
             nOvrBlockSize = 128;
         }
 

--- a/frmts/hfa/hfaband.cpp
+++ b/frmts/hfa/hfaband.cpp
@@ -2028,16 +2028,11 @@ static int HFAGetOverviewBlockSize()
     if (nOvrBlockSize < 32 || nOvrBlockSize > 2048 ||
         !CPLIsPowerOfTwo(nOvrBlockSize))
     {
-        static bool bHasWarned = false;
-        if (!bHasWarned)
-        {
-            CPLError(CE_Warning, CPLE_NotSupported,
+        CPLErrorOnce(CE_Warning, CPLE_NotSupported,
                      "Wrong value for GDAL_HFA_OVR_BLOCKSIZE : %s. "
                      "Should be a power of 2 between 32 and 2048. "
                      "Defaulting to 64",
                      pszVal);
-            bHasWarned = true;
-        }
         nOvrBlockSize = 64;
     }
 

--- a/frmts/vrt/vrtsources.cpp
+++ b/frmts/vrt/vrtsources.cpp
@@ -3535,13 +3535,8 @@ CPLErr VRTComplexSource::RasterIOInternal(
                     }
                     else
                     {
-                        static bool bHasWarned = false;
-                        if (!bHasWarned)
-                        {
-                            bHasWarned = true;
-                            CPLError(CE_Failure, CPLE_AppDefined,
+                        CPLErrorOnce(CE_Failure, CPLE_AppDefined,
                                      "No entry %d.", static_cast<int>(fResult));
-                        }
                         continue;
                     }
                 }

--- a/gcore/gdalrasterblock.cpp
+++ b/gcore/gdalrasterblock.cpp
@@ -184,14 +184,9 @@ int CPL_STDCALL GDALGetCacheMax()
     GIntBig nRes = GDALGetCacheMax64();
     if (nRes > INT_MAX)
     {
-        static bool bHasWarned = false;
-        if (!bHasWarned)
-        {
-            CPLError(CE_Warning, CPLE_AppDefined,
+        CPLErrorOnce(CE_Warning, CPLE_AppDefined,
                      "Cache max value doesn't fit on a 32 bit integer. "
                      "Call GDALGetCacheMax64() instead");
-            bHasWarned = true;
-        }
         nRes = INT_MAX;
     }
     return static_cast<int>(nRes);
@@ -280,14 +275,9 @@ int CPL_STDCALL GDALGetCacheUsed()
 {
     if (nCacheUsed > INT_MAX)
     {
-        static bool bHasWarned = false;
-        if (!bHasWarned)
-        {
-            CPLError(CE_Warning, CPLE_AppDefined,
+        CPLErrorOnce(CE_Warning, CPLE_AppDefined,
                      "Cache used value doesn't fit on a 32 bit integer. "
                      "Call GDALGetCacheUsed64() instead");
-            bHasWarned = true;
-        }
         return INT_MAX;
     }
     return static_cast<int>(nCacheUsed);

--- a/ogr/gml2ogrgeometry.cpp
+++ b/ogr/gml2ogrgeometry.cpp
@@ -1876,9 +1876,7 @@ GML2OGRGeometry_XMLNode_Internal(const CPLXMLNode *psNode, const char *pszId,
         if (bSRSUnitIsDegree && dfUOMConv > 0)
         {
             auto poLS = std::make_unique<OGRLineString>();
-            // coverity[tainted_data]
-            const double dfStep =
-                CPLAtof(CPLGetConfigOption("OGR_ARC_STEPSIZE", "4"));
+            const double dfStep = OGRGeometryFactory::GetDefaultArcStepSize();
             const double dfSign = dfStartAngle < dfEndAngle ? 1 : -1;
             for (double dfAngle = dfStartAngle;
                  (dfAngle - dfEndAngle) * dfSign < 0;
@@ -2010,8 +2008,7 @@ GML2OGRGeometry_XMLNode_Internal(const CPLXMLNode *psNode, const char *pszId,
         if (bSRSUnitIsDegree && dfUOMConv > 0)
         {
             auto poLS = std::make_unique<OGRLineString>();
-            const double dfStep =
-                CPLAtof(CPLGetConfigOption("OGR_ARC_STEPSIZE", "4"));
+            const double dfStep = OGRGeometryFactory::GetDefaultArcStepSize();
             for (double dfAngle = 0; dfAngle < 360; dfAngle += dfStep)
             {
                 double dfLong = 0.0;

--- a/ogr/ogr_geometry.h
+++ b/ogr/ogr_geometry.h
@@ -4381,6 +4381,8 @@ class CPL_DLL OGRGeometryFactory
         char **papszOptions,
         const TransformWithOptionsCache &cache = TransformWithOptionsCache());
 
+    static double GetDefaultArcStepSize();
+
     static OGRGeometry *
     approximateArcAngles(double dfX, double dfY, double dfZ,
                          double dfPrimaryRadius, double dfSecondaryAxis,

--- a/ogr/ogrct.cpp
+++ b/ogr/ogrct.cpp
@@ -1764,15 +1764,10 @@ static PJ *op_to_pj(PJ_CONTEXT *ctx, PJ *op,
     const char *pszUseETMERC = CPLGetConfigOption("OSR_USE_ETMERC", nullptr);
     if (pszUseETMERC && pszUseETMERC[0])
     {
-        static bool bHasWarned = false;
-        if (!bHasWarned)
-        {
-            CPLError(CE_Warning, CPLE_AppDefined,
+        CPLErrorOnce(CE_Warning, CPLE_AppDefined,
                      "OSR_USE_ETMERC is a legacy configuration option, which "
                      "now has only effect when set to NO (YES is the default). "
                      "Use OSR_USE_APPROX_TMERC=YES instead");
-            bHasWarned = true;
-        }
         bForceApproxTMerc = !CPLTestBool(pszUseETMERC);
     }
     else
@@ -2737,18 +2732,14 @@ int OGRProjCT::TransformWithErrorCodes(size_t nCount, double *x, double *y,
                 x[i] = HUGE_VAL;
                 y[i] = HUGE_VAL;
                 err = PROJ_ERR_COORD_TRANSFM_OUTSIDE_PROJECTION_DOMAIN;
-                static bool bHasWarned = false;
-                if (!bHasWarned)
-                {
+
 #ifdef DEBUG
-                    CPLError(CE_Warning, CPLE_AppDefined,
+                CPLErrorOnce(CE_Warning, CPLE_AppDefined,
                              "PROJ returned a NaN value. It should be fixed");
 #else
-                    CPLDebug("OGR_CT",
+                CPLDebugOnce("OGR_CT",
                              "PROJ returned a NaN value. It should be fixed");
 #endif
-                    bHasWarned = true;
-                }
             }
             else if (coord.xyzt.x == HUGE_VAL)
             {

--- a/ogr/ogrgeojsonwriter.cpp
+++ b/ogr/ogrgeojsonwriter.cpp
@@ -968,13 +968,8 @@ json_object *OGRGeoJSONWriteAttributes(OGRFeature *poFeature,
             {
                 if (!oOptions.bAllowNonFiniteValues)
                 {
-                    static bool bHasWarned = false;
-                    if (!bHasWarned)
-                    {
-                        bHasWarned = true;
-                        CPLError(CE_Warning, CPLE_AppDefined,
+                    CPLErrorOnce(CE_Warning, CPLE_AppDefined,
                                  "NaN of Infinity value found. Skipped");
-                    }
                     continue;
                 }
             }

--- a/ogr/ogrgeometryfactory.cpp
+++ b/ogr/ogrgeometryfactory.cpp
@@ -4024,15 +4024,10 @@ OGRGeometry *OGRGeometryFactory::transformWithOptions(
         if (poDstGeom->getSpatialReference() &&
             !poDstGeom->getSpatialReference()->IsGeographic())
         {
-            static bool bHasWarned = false;
-            if (!bHasWarned)
-            {
-                CPLError(
-                    CE_Warning, CPLE_AppDefined,
-                    "WRAPDATELINE is without effect when reprojecting to a "
-                    "non-geographic CRS");
-                bHasWarned = true;
-            }
+            CPLErrorOnce(
+                CE_Warning, CPLE_AppDefined,
+                "WRAPDATELINE is without effect when reprojecting to a "
+                "non-geographic CRS");
             return poDstGeom.release();
         }
         // TODO and we should probably also test that the axis order + data axis
@@ -4214,27 +4209,17 @@ double OGRGeometryFactory::GetDefaultArcStepSize()
     constexpr double MIN_VAL = 1e-2;
     if (dfVal < MIN_VAL)
     {
-        static bool bWarned = false;
-        if (!bWarned)
-        {
-            bWarned = true;
-            CPLError(CE_Warning, CPLE_AppDefined,
+        CPLErrorOnce(CE_Warning, CPLE_AppDefined,
                      "Too small value for OGR_ARC_STEPSIZE. Clamping it to %f",
                      MIN_VAL);
-        }
         return MIN_VAL;
     }
     constexpr double MAX_VAL = 180;
     if (dfVal > MAX_VAL)
     {
-        static bool bWarned = false;
-        if (!bWarned)
-        {
-            bWarned = true;
-            CPLError(CE_Warning, CPLE_AppDefined,
+        CPLErrorOnce(CE_Warning, CPLE_AppDefined,
                      "Too large value for OGR_ARC_STEPSIZE. Clamping it to %f",
                      MAX_VAL);
-        }
         return MAX_VAL;
     }
     return dfVal;

--- a/ogr/ogrgeometryfactory.cpp
+++ b/ogr/ogrgeometryfactory.cpp
@@ -4197,13 +4197,47 @@ void OGR_GeomTransformer_Destroy(OGRGeomTransformerH hTransformer)
 }
 
 /************************************************************************/
-/*                       OGRGF_GetDefaultStepSize()                     */
+/*                OGRGeometryFactory::GetDefaultArcStepSize()           */
 /************************************************************************/
 
-static double OGRGF_GetDefaultStepSize()
+/** Return the default value of the angular step used when stroking curves
+ * as lines. Defaults to 4 degrees.
+ * Can be modified by setting the OGR_ARC_STEPSIZE configuration option.
+ * Valid values are in [1e-2, 180] degree range.
+ * @since 3.11
+ */
+
+/* static */
+double OGRGeometryFactory::GetDefaultArcStepSize()
 {
-    // coverity[tainted_data]
-    return CPLAtofM(CPLGetConfigOption("OGR_ARC_STEPSIZE", "4"));
+    const double dfVal = CPLAtofM(CPLGetConfigOption("OGR_ARC_STEPSIZE", "4"));
+    constexpr double MIN_VAL = 1e-2;
+    if (dfVal < MIN_VAL)
+    {
+        static bool bWarned = false;
+        if (!bWarned)
+        {
+            bWarned = true;
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "Too small value for OGR_ARC_STEPSIZE. Clamping it to %f",
+                     MIN_VAL);
+        }
+        return MIN_VAL;
+    }
+    constexpr double MAX_VAL = 180;
+    if (dfVal > MAX_VAL)
+    {
+        static bool bWarned = false;
+        if (!bWarned)
+        {
+            bWarned = true;
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "Too large value for OGR_ARC_STEPSIZE. Clamping it to %f",
+                     MAX_VAL);
+        }
+        return MAX_VAL;
+    }
+    return dfVal;
 }
 
 /************************************************************************/
@@ -4266,7 +4300,7 @@ OGRGeometry *OGRGeometryFactory::approximateArcAngles(
     // Support default arc step setting.
     if (dfMaxAngleStepSizeDegrees < 1e-6)
     {
-        dfMaxAngleStepSizeDegrees = OGRGF_GetDefaultStepSize();
+        dfMaxAngleStepSizeDegrees = OGRGeometryFactory::GetDefaultArcStepSize();
     }
 
     // Determine maximum interpolation gap. This is the largest straight-line
@@ -5459,7 +5493,7 @@ OGRLineString *OGRGeometryFactory::curveToLineString(
     // support default arc step setting.
     if (dfMaxAngleStepSizeDegrees < 1e-6)
     {
-        dfMaxAngleStepSizeDegrees = OGRGF_GetDefaultStepSize();
+        dfMaxAngleStepSizeDegrees = OGRGeometryFactory::GetDefaultArcStepSize();
     }
 
     double dfStep = dfMaxAngleStepSizeDegrees / 180 * M_PI;

--- a/ogr/ogrpgeogeometry.cpp
+++ b/ogr/ogrpgeogeometry.cpp
@@ -1835,10 +1835,8 @@ static OGRCurve *OGRShapeCreateCompoundCurve(int nPartStartIdx, int nPartPoints,
                 dfStartAngle += 2 * M_PI;
             else if (dfEndAngle + M_PI < dfStartAngle)
                 dfEndAngle += 2 * M_PI;
-            // coverity[tainted_data]
             const double dfStepSizeRad =
-                CPLAtofM(CPLGetConfigOption("OGR_ARC_STEPSIZE", "4")) / 180.0 *
-                M_PI;
+                OGRGeometryFactory::GetDefaultArcStepSize() / 180.0 * M_PI;
             const double dfLengthTangentStart =
                 (dfX1 - dfX0) * (dfX1 - dfX0) + (dfY1 - dfY0) * (dfY1 - dfY0);
             const double dfLengthTangentEnd =

--- a/ogr/ogrsf_frmts/dwg/ogrdgnv8layer.cpp
+++ b/ogr/ogrsf_frmts/dwg/ogrdgnv8layer.cpp
@@ -574,7 +574,7 @@ static void ProcessCurve(OGRFeature *poFeature, const CPLString &osPen,
         else
             poSC = new OGRLineString();
         const double dfArcStepSize =
-            CPLAtofM(CPLGetConfigOption("OGR_ARC_STEPSIZE", "4"));
+            OGRGeometryFactory::GetDefaultArcStepSize();
         if (!ellipse.isNull())
         {
             nPoints = std::max(2, static_cast<int>(360 / dfArcStepSize));

--- a/ogr/ogrsf_frmts/elastic/ogrelasticlayer.cpp
+++ b/ogr/ogrsf_frmts/elastic/ogrelasticlayer.cpp
@@ -2405,16 +2405,11 @@ CPLString OGRElasticLayer::BuildJSonFromFeature(OGRFeature *poFeature)
                 else if (env.MinX < -180 || env.MinY < -90 || env.MaxX > 180 ||
                          env.MaxY > 90)
                 {
-                    static bool bHasWarned = false;
-                    if (!bHasWarned)
-                    {
-                        bHasWarned = true;
-                        CPLError(
-                            CE_Warning, CPLE_AppDefined,
-                            "At least one geometry has a bounding box outside "
-                            "of [-180,180] longitude range and/or [-90,90] "
-                            "latitude range. Undefined behavior");
-                    }
+                    CPLErrorOnce(
+                        CE_Warning, CPLE_AppDefined,
+                        "At least one geometry has a bounding box outside "
+                        "of [-180,180] longitude range and/or [-90,90] "
+                        "latitude range. Undefined behavior");
                 }
 
                 std::vector<CPLString> aosPath = m_aaosGeomFieldPaths[i];

--- a/ogr/ogrsf_frmts/filegdb/FGdbLayer.cpp
+++ b/ogr/ogrsf_frmts/filegdb/FGdbLayer.cpp
@@ -1302,16 +1302,11 @@ OGRErr FGdbLayer::PopulateRowWithFeature(Row &fgdb_row, OGRFeature *poFeature)
             {
                 if (fldvalue < -32768 || fldvalue > 32767)
                 {
-                    static int bHasWarned = FALSE;
-                    if (!bHasWarned)
-                    {
-                        bHasWarned = TRUE;
-                        CPLError(CE_Warning, CPLE_NotSupported,
+                    CPLErrorOnce(CE_Warning, CPLE_NotSupported,
                                  "Value %d for field %s does not fit into a "
                                  "short and will be clamped. "
                                  "This warning will not be emitted any more",
                                  fldvalue, field_name.c_str());
-                    }
                     if (fldvalue < -32768)
                         fldvalue = -32768;
                     else

--- a/ogr/ogrsf_frmts/gmlas/ogrgmlasxsdcache.cpp
+++ b/ogr/ogrsf_frmts/gmlas/ogrgmlasxsdcache.cpp
@@ -176,12 +176,7 @@ bool GMLASXSDCache::CacheAllGML321()
     CPLHTTPDestroyResult(psResult);
     if (!bSuccess)
     {
-        static bool bHasWarned = false;
-        if (!bHasWarned)
-        {
-            bHasWarned = true;
-            CPLDebug("GMLAS", "Cannot get GML schemas from %s", pszHTTPZIP);
-        }
+        CPLDebugOnce("GMLAS", "Cannot get GML schemas from %s", pszHTTPZIP);
     }
     return bSuccess;
 }
@@ -248,12 +243,7 @@ bool GMLASXSDCache::CacheAllISO20070417()
     CPLHTTPDestroyResult(psResult);
     if (!bSuccess)
     {
-        static bool bHasWarned = false;
-        if (!bHasWarned)
-        {
-            bHasWarned = true;
-            CPLDebug("GMLAS", "Cannot get ISO schemas from %s", pszHTTPZIP);
-        }
+        CPLDebugOnce("GMLAS", "Cannot get ISO schemas from %s", pszHTTPZIP);
     }
     return bSuccess;
 }

--- a/ogr/ogrsf_frmts/ili/ogrili1datasource.cpp
+++ b/ogr/ogrsf_frmts/ili/ogrili1datasource.cpp
@@ -148,18 +148,11 @@ int OGRILI1DataSource::Open(const char *pszNewName, char **papszOpenOptionsIn,
     if (osModelFilename.length() > 0)
         poReader->ReadModel(poImdReader, osModelFilename.c_str(), this);
 
-    int bResetConfigOption = FALSE;
-    if (EQUAL(CPLGetConfigOption("OGR_ARC_STEPSIZE", ""), ""))
-    {
-        bResetConfigOption = TRUE;
-        CPLSetThreadLocalConfigOption("OGR_ARC_STEPSIZE", "0.96");
-    }
+    CPLConfigOptionSetter oSetter("OGR_ARC_STEPSIZE", "0.96",
+                                  /* bSetOnlyIfUndefined = */ true);
 
     // Parse model and read data - without surface join and area polygonizing.
     poReader->ReadFeatures();
-
-    if (bResetConfigOption)
-        CPLSetThreadLocalConfigOption("OGR_ARC_STEPSIZE", nullptr);
 
     return TRUE;
 }

--- a/ogr/ogrsf_frmts/ili/ogrili1layer.cpp
+++ b/ogr/ogrsf_frmts/ili/ogrili1layer.cpp
@@ -444,12 +444,9 @@ OGRErr OGRILI1Layer::CreateField(const OGRFieldDefn *poField,
 void OGRILI1Layer::JoinGeomLayers()
 {
     bGeomsJoined = true;
-    bool bResetConfigOption = false;
-    if (EQUAL(CPLGetConfigOption("OGR_ARC_STEPSIZE", ""), ""))
-    {
-        bResetConfigOption = true;
-        CPLSetThreadLocalConfigOption("OGR_ARC_STEPSIZE", "0.96");
-    }
+
+    CPLConfigOptionSetter oSetter("OGR_ARC_STEPSIZE", "0.96",
+                                  /* bSetOnlyIfUndefined = */ true);
 
     for (GeomFieldInfos::const_iterator it = oGeomFieldInfos.begin();
          it != oGeomFieldInfos.end(); ++it)
@@ -477,9 +474,6 @@ void OGRILI1Layer::JoinGeomLayers()
             }
         }
     }
-
-    if (bResetConfigOption)
-        CPLSetThreadLocalConfigOption("OGR_ARC_STEPSIZE", nullptr);
 }
 
 void OGRILI1Layer::JoinSurfaceLayer(OGRILI1Layer *poSurfaceLineLayer,

--- a/ogr/ogrsf_frmts/parquet/ogrparquetwriterlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetwriterlayer.cpp
@@ -356,17 +356,12 @@ bool OGRParquetWriterLayer::SetOptions(CSLConstList papszOptions,
             m_eGeomEncoding = OGRArrowGeomEncoding::WKT;
         else if (EQUAL(pszGeomEncoding, "GEOARROW_INTERLEAVED"))
         {
-            static bool bHasWarned = false;
-            if (!bHasWarned)
-            {
-                bHasWarned = true;
-                CPLError(
-                    CE_Warning, CPLE_AppDefined,
-                    "Use of GEOMETRY_ENCODING=GEOARROW_INTERLEAVED is not "
-                    "recommended. "
-                    "GeoParquet 1.1 uses GEOMETRY_ENCODING=GEOARROW (struct) "
-                    "instead.");
-            }
+            CPLErrorOnce(
+                CE_Warning, CPLE_AppDefined,
+                "Use of GEOMETRY_ENCODING=GEOARROW_INTERLEAVED is not "
+                "recommended. "
+                "GeoParquet 1.1 uses GEOMETRY_ENCODING=GEOARROW (struct) "
+                "instead.");
             m_eGeomEncoding = OGRArrowGeomEncoding::GEOARROW_FSL_GENERIC;
         }
         else if (EQUAL(pszGeomEncoding, "GEOARROW") ||

--- a/ogr/ogrspatialreference.cpp
+++ b/ogr/ogrspatialreference.cpp
@@ -11469,14 +11469,9 @@ OGRErr OGRSpatialReference::importFromProj4(const char *pszProj4)
     if (osProj4.find("+init=epsg:") != std::string::npos &&
         getenv("PROJ_USE_PROJ4_INIT_RULES") == nullptr)
     {
-        static bool bHasWarned = false;
-        if (!bHasWarned)
-        {
-            CPLError(CE_Warning, CPLE_AppDefined,
+        CPLErrorOnce(CE_Warning, CPLE_AppDefined,
                      "+init=epsg:XXXX syntax is deprecated. It might return "
                      "a CRS with a non-EPSG compliant axis order.");
-            bHasWarned = true;
-        }
     }
     proj_context_use_proj4_init_rules(d->getPROJContext(), true);
     d->setPjCRS(proj_create(d->getPROJContext(), osProj4.c_str()));
@@ -11571,15 +11566,10 @@ OGRErr OGRSpatialReference::exportToProj4(char **ppszProj4) const
     const char *pszUseETMERC = CPLGetConfigOption("OSR_USE_ETMERC", nullptr);
     if (pszUseETMERC && pszUseETMERC[0])
     {
-        static bool bHasWarned = false;
-        if (!bHasWarned)
-        {
-            CPLError(CE_Warning, CPLE_AppDefined,
+        CPLErrorOnce(CE_Warning, CPLE_AppDefined,
                      "OSR_USE_ETMERC is a legacy configuration option, which "
                      "now has only effect when set to NO (YES is the default). "
                      "Use OSR_USE_APPROX_TMERC=YES instead");
-            bHasWarned = true;
-        }
         bForceApproxTMerc = !CPLTestBool(pszUseETMERC);
     }
     else

--- a/port/cpl_error.h
+++ b/port/cpl_error.h
@@ -125,6 +125,23 @@ typedef int CPLErrorNum;
 void CPL_DLL CPLError(CPLErr eErrClass, CPLErrorNum err_no,
                       CPL_FORMAT_STRING(const char *fmt), ...)
     CPL_PRINT_FUNC_FORMAT(3, 4);
+
+/** Similar to CPLError(), but only execute it once during the life-time
+ * of a process.
+ *
+ * @since 3.11
+ */
+#define CPLErrorOnce(...)                                                      \
+    do                                                                         \
+    {                                                                          \
+        static bool lbCPLErrorOnce = false;                                    \
+        if (!lbCPLErrorOnce)                                                   \
+        {                                                                      \
+            lbCPLErrorOnce = true;                                             \
+            CPLError(__VA_ARGS__);                                             \
+        }                                                                      \
+    } while (0)
+
 void CPL_DLL CPLErrorV(CPLErr, CPLErrorNum, const char *, va_list);
 void CPL_DLL CPLEmergencyError(const char *) CPL_NO_RETURN;
 void CPL_DLL CPL_STDCALL CPLErrorReset(void);
@@ -171,11 +188,39 @@ void CPL_DLL CPL_STDCALL CPLPopErrorHandler(void);
     do                                                                         \
     {                                                                          \
     } while (0) /* Eat all CPLDebugProgress calls. */
+
+/** Similar to CPLDebug(), but only execute it once during the life-time
+ * of a process.
+ *
+ * @since 3.11
+ */
+#define CPLDebugOnce(...)                                                      \
+    do                                                                         \
+    {                                                                          \
+    } while (0)
+
 #else
 void CPL_DLL CPLDebug(const char *, CPL_FORMAT_STRING(const char *), ...)
     CPL_PRINT_FUNC_FORMAT(2, 3);
 void CPL_DLL CPLDebugProgress(const char *, CPL_FORMAT_STRING(const char *),
                               ...) CPL_PRINT_FUNC_FORMAT(2, 3);
+
+/** Similar to CPLDebug(), but only execute it once during the life-time
+ * of a process.
+ *
+ * @since 3.11
+ */
+#define CPLDebugOnce(...)                                                      \
+    do                                                                         \
+    {                                                                          \
+        static bool lbCPLErrorOnce = false;                                    \
+        if (!lbCPLErrorOnce)                                                   \
+        {                                                                      \
+            lbCPLErrorOnce = true;                                             \
+            CPLDebug(__VA_ARGS__);                                             \
+        }                                                                      \
+    } while (0)
+
 #endif
 
 #if defined(DEBUG) || defined(GDAL_DEBUG)

--- a/port/cpl_error.h
+++ b/port/cpl_error.h
@@ -126,21 +126,36 @@ void CPL_DLL CPLError(CPLErr eErrClass, CPLErrorNum err_no,
                       CPL_FORMAT_STRING(const char *fmt), ...)
     CPL_PRINT_FUNC_FORMAT(3, 4);
 
+#ifdef GDAL_COMPILATION
+
+const char CPL_DLL *CPLSPrintf(CPL_FORMAT_STRING(const char *fmt), ...)
+    CPL_PRINT_FUNC_FORMAT(1, 2) CPL_WARN_UNUSED_RESULT;
+
 /** Similar to CPLError(), but only execute it once during the life-time
  * of a process.
  *
  * @since 3.11
  */
-#define CPLErrorOnce(...)                                                      \
+#define CPLErrorOnce(eErrClass, err_no, ...)                                   \
     do                                                                         \
     {                                                                          \
         static bool lbCPLErrorOnce = false;                                    \
         if (!lbCPLErrorOnce)                                                   \
         {                                                                      \
             lbCPLErrorOnce = true;                                             \
-            CPLError(__VA_ARGS__);                                             \
+            const char *lCPLErrorMsg = CPLSPrintf(__VA_ARGS__);                \
+            const size_t lCPLErrorMsgLen = strlen(lCPLErrorMsg);               \
+            const char *lCPLErrorMsgSuffix =                                   \
+                " Further messages of this type will be suppressed.";          \
+            if (lCPLErrorMsgLen && lCPLErrorMsg[lCPLErrorMsgLen - 1] == '.')   \
+                CPLError((eErrClass), (err_no), "%s%s", lCPLErrorMsg,          \
+                         lCPLErrorMsgSuffix);                                  \
+            else                                                               \
+                CPLError((eErrClass), (err_no), "%s.%s", lCPLErrorMsg,         \
+                         lCPLErrorMsgSuffix);                                  \
         }                                                                      \
     } while (0)
+#endif
 
 void CPL_DLL CPLErrorV(CPLErr, CPLErrorNum, const char *, va_list);
 void CPL_DLL CPLEmergencyError(const char *) CPL_NO_RETURN;
@@ -189,6 +204,7 @@ void CPL_DLL CPL_STDCALL CPLPopErrorHandler(void);
     {                                                                          \
     } while (0) /* Eat all CPLDebugProgress calls. */
 
+#ifdef GDAL_COMPILATION
 /** Similar to CPLDebug(), but only execute it once during the life-time
  * of a process.
  *
@@ -198,6 +214,7 @@ void CPL_DLL CPL_STDCALL CPLPopErrorHandler(void);
     do                                                                         \
     {                                                                          \
     } while (0)
+#endif
 
 #else
 void CPL_DLL CPLDebug(const char *, CPL_FORMAT_STRING(const char *), ...)
@@ -205,21 +222,32 @@ void CPL_DLL CPLDebug(const char *, CPL_FORMAT_STRING(const char *), ...)
 void CPL_DLL CPLDebugProgress(const char *, CPL_FORMAT_STRING(const char *),
                               ...) CPL_PRINT_FUNC_FORMAT(2, 3);
 
+#ifdef GDAL_COMPILATION
 /** Similar to CPLDebug(), but only execute it once during the life-time
  * of a process.
  *
  * @since 3.11
  */
-#define CPLDebugOnce(...)                                                      \
+#define CPLDebugOnce(category, ...)                                            \
     do                                                                         \
     {                                                                          \
-        static bool lbCPLErrorOnce = false;                                    \
-        if (!lbCPLErrorOnce)                                                   \
+        static bool lbCPLDebugOnce = false;                                    \
+        if (!lbCPLDebugOnce)                                                   \
         {                                                                      \
-            lbCPLErrorOnce = true;                                             \
-            CPLDebug(__VA_ARGS__);                                             \
+            lbCPLDebugOnce = true;                                             \
+            const char *lCPLDebugMsg = CPLSPrintf(__VA_ARGS__);                \
+            const size_t lCPLErrorMsgLen = strlen(lCPLDebugMsg);               \
+            const char *lCPLDebugMsgSuffix =                                   \
+                " Further messages of this type will be suppressed.";          \
+            if (lCPLErrorMsgLen && lCPLDebugMsg[lCPLErrorMsgLen - 1] == '.')   \
+                CPLDebug((category), "%s%s", lCPLDebugMsg,                     \
+                         lCPLDebugMsgSuffix);                                  \
+            else                                                               \
+                CPLDebug((category), "%s.%s", lCPLDebugMsg,                    \
+                         lCPLDebugMsgSuffix);                                  \
         }                                                                      \
     } while (0)
+#endif
 
 #endif
 

--- a/port/cpl_known_config_options.h
+++ b/port/cpl_known_config_options.h
@@ -663,7 +663,7 @@ constexpr static const char* const apszKnownConfigOptions[] =
    "OGR_API_SPY_SNAPSHOT_PATH", // from ograpispy.cpp
    "OGR_APPLY_GEOM_SET_PRECISION", // from ogr2ogr_lib.cpp, ogrlayer.cpp
    "OGR_ARC_MAX_GAP", // from ogrgeometryfactory.cpp
-   "OGR_ARC_STEPSIZE", // from gml2ogrgeometry.cpp, ogrdgnv8layer.cpp, ogrgeometryfactory.cpp, ogrili1datasource.cpp, ogrili1layer.cpp, ogrpgeogeometry.cpp
+   "OGR_ARC_STEPSIZE", // from ogrgeometryfactory.cpp
    "OGR_ARROW_COMPUTE_GEOMETRY_TYPE", // from ogrfeatherlayer.cpp
    "OGR_ARROW_LOAD_FILE_SYSTEM_FACTORIES", // from ogrfeatherdriver.cpp
    "OGR_ARROW_MEM_LIMIT", // from ograrrowarrayhelper.cpp


### PR DESCRIPTION
to emit an error/debug message only once during the life-time of a process.
