### PR TITLE
[3.10] Revert "CMake: Export -DGDAL_DEBUG as PUBLIC for debug builds"

### DIFF
--- a/autotest/postinstall/test_cpp/test_cpp.cpp
+++ b/autotest/postinstall/test_cpp/test_cpp.cpp
@@ -9,7 +9,6 @@
 #endif
 #include <cpl_vsi_virtual.h>
 #include <ogr_geometry.h>
-#include <ogr_spatialref.h>
 
 int main(int argc, char **argv)
 {
@@ -17,13 +16,5 @@ int main(int argc, char **argv)
     OGRGeometryFactory::createFromWkt("POINT(1 2)", nullptr, &poGeom);
     OGRGeometryFactory::destroyGeometry(poGeom);
     std::cout << GDALVersionInfo("RELEASE_NAME") << std::endl;
-
-    // Check fix for https://github.com/OSGeo/gdal/issues/11311
-    OGRSpatialReference oSRS;
-    int nEntries = 0;
-    int *panMatchCondidence = nullptr;
-    oSRS.FindMatches(nullptr, &nEntries, &panMatchCondidence);
-    CPLFree(panMatchCondidence);
-
     return (0);
 }

--- a/gdal.cmake
+++ b/gdal.cmake
@@ -189,10 +189,6 @@ if (MINGW AND BUILD_SHARED_LIBS)
     set_target_properties(${GDAL_LIB_TARGET_NAME} PROPERTIES SUFFIX "-${GDAL_SOVERSION}${CMAKE_SHARED_LIBRARY_SUFFIX}")
 endif ()
 
-# Some of the types in our public headers are dependent on whether GDAL_DEBUG
-# is defined or not
-target_compile_definitions(${GDAL_LIB_TARGET_NAME} PUBLIC $<$<CONFIG:DEBUG>:GDAL_DEBUG>)
-
 # Install properties
 if (GDAL_ENABLE_MACOSX_FRAMEWORK)
   set(FRAMEWORK_VERSION ${GDAL_VERSION_MAJOR}.${GDAL_VERSION_MINOR})

--- a/ogr/ogr_api.h
+++ b/ogr/ogr_api.h
@@ -43,7 +43,7 @@ bool CPL_DLL OGRGetGEOSVersion(int *pnMajor, int *pnMinor, int *pnPatch);
 /*! @cond Doxygen_Suppress */
 #define DEFINEH_OGRGeometryH
 /*! @endcond */
-#if defined(DEBUG) || defined(GDAL_DEBUG)
+#ifdef DEBUG
 typedef struct OGRGeometryHS *OGRGeometryH;
 #else
 /** Opaque type for a geometry */
@@ -57,7 +57,7 @@ typedef void *OGRGeometryH;
 /*! @endcond */
 
 #ifndef DOXYGEN_XML
-#if defined(DEBUG) || defined(GDAL_DEBUG)
+#ifdef DEBUG
 typedef struct OGRSpatialReferenceHS *OGRSpatialReferenceH;
 typedef struct OGRCoordinateTransformationHS *OGRCoordinateTransformationH;
 #else
@@ -396,7 +396,7 @@ int CPL_DLL OGRPreparedGeometryContains(OGRPreparedGeometryH hPreparedGeom,
 /*! @cond Doxygen_Suppress */
 #define DEFINE_OGRFeatureH
 /*! @endcond */
-#if defined(DEBUG) || defined(GDAL_DEBUG)
+#ifdef DEBUG
 typedef struct OGRFieldDefnHS *OGRFieldDefnH;
 typedef struct OGRFeatureDefnHS *OGRFeatureDefnH;
 typedef struct OGRFeatureHS *OGRFeatureH;
@@ -667,7 +667,7 @@ const char CPL_DLL *OGR_GlobFldDomain_GetGlob(OGRFieldDomainH);
 /*      ogrsf_frmts.h                                                   */
 /* -------------------------------------------------------------------- */
 
-#if defined(DEBUG) || defined(GDAL_DEBUG)
+#ifdef DEBUG
 typedef struct OGRLayerHS *OGRLayerH;
 typedef struct OGRDataSourceHS *OGRDataSourceH;
 typedef struct OGRDriverHS *OGRSFDriverH;
@@ -949,7 +949,7 @@ void CPL_DLL OGRCleanupAll(void);
 /*      ogrsf_featurestyle.h                                            */
 /* -------------------------------------------------------------------- */
 
-#if defined(DEBUG) || defined(GDAL_DEBUG)
+#ifdef DEBUG
 typedef struct OGRStyleMgrHS *OGRStyleMgrH;
 typedef struct OGRStyleToolHS *OGRStyleToolH;
 #else

--- a/ogr/ogr_feature.h
+++ b/ogr/ogr_feature.h
@@ -37,7 +37,7 @@
 /*! @cond Doxygen_Suppress */
 #define DEFINE_OGRFeatureH
 /*! @endcond */
-#if defined(DEBUG) || defined(GDAL_DEBUG)
+#ifdef DEBUG
 typedef struct OGRFieldDefnHS *OGRFieldDefnH;
 typedef struct OGRFeatureDefnHS *OGRFeatureDefnH;
 typedef struct OGRFeatureHS *OGRFeatureH;

--- a/ogr/ogr_geometry.h
+++ b/ogr/ogr_geometry.h
@@ -35,7 +35,7 @@
 /*! @cond Doxygen_Suppress */
 #ifndef DEFINEH_OGRGeometryH
 #define DEFINEH_OGRGeometryH
-#if defined(DEBUG) || defined(GDAL_DEBUG)
+#ifdef DEBUG
 typedef struct OGRGeometryHS *OGRGeometryH;
 #else
 typedef void *OGRGeometryH;

--- a/ogr/ogr_srs_api.h
+++ b/ogr/ogr_srs_api.h
@@ -426,7 +426,7 @@ const char CPL_DLL *OSRAxisEnumToName(OGRAxisOrientation eOrientation);
 #define DEFINED_OGRSpatialReferenceH
 /*! @endcond */
 
-#if defined(DEBUG) || defined(GDAL_DEBUG)
+#ifdef DEBUG
 typedef struct OGRSpatialReferenceHS *OGRSpatialReferenceH;
 typedef struct OGRCoordinateTransformationHS *OGRCoordinateTransformationH;
 #else

--- a/ogr/ograpispy.h
+++ b/ogr/ograpispy.h
@@ -45,7 +45,7 @@
  * @since GDAL 2.0
  */
 
-#if defined(DEBUG) || defined(GDAL_DEBUG)
+#ifdef DEBUG
 #define OGRAPISPY_ENABLED
 #endif
 

--- a/port/cpl_error.h
+++ b/port/cpl_error.h
@@ -179,7 +179,7 @@ void CPL_DLL CPLDebugProgress(const char *, CPL_FORMAT_STRING(const char *),
                               ...) CPL_PRINT_FUNC_FORMAT(2, 3);
 #endif
 
-#if defined(DEBUG) || defined(GDAL_DEBUG)
+#ifdef DEBUG
 /** Same as CPLDebug(), but expands to nothing for non-DEBUG builds.
  * @since GDAL 3.1
  */


### PR DESCRIPTION
This reverts commit d0dcf04a2685cb00cbe8a6a7983a543a1860dbd8.

This reverts PR #11363, which is probably inappropriate for the stable branch, given issue reported in https://lists.osgeo.org/pipermail/gdal-dev/2025-January/060023.html