### PR TITLE
Explicitly set CMAKE_CXX_SCAN_FOR_MODULES=0

### DIFF
--- a/cmake/helpers/GdalCAndCXXStandards.cmake
+++ b/cmake/helpers/GdalCAndCXXStandards.cmake
@@ -8,3 +8,8 @@ if (NOT CMAKE_C_STANDARD)
     set(CMAKE_C_STANDARD 99)
     set(CMAKE_C_STANDARD_REQUIRED ON)
 endif()
+
+# explicitly tell CMake not to do module
+# dependency scanning
+# https://discourse.cmake.org/t/cmake-3-28-cmake-cxx-compiler-clang-scan-deps-notfound-not-found/9244/3
+set(CMAKE_CXX_SCAN_FOR_MODULES 0)


### PR DESCRIPTION
Something about my configuration was causing the following complaint

> CMAKE_CXX_COMPILER_CLANG_SCAN_DEPS-NOTFOUND 

Some searching showed https://discourse.cmake.org/t/cmake-3-28-cmake-cxx-compiler-clang-scan-deps-notfound-not-found/9244/3 

My configuration didn't have `clang-tools` installed, so I didn't have `clang-scan-deps` available. I shouldn't have *needed* it, but I don't understand why our CMake configuration thinks it does.

This PR tells CMake that it doesn't need it. When we upgrade to C++20 modules 😄, we can switch it back on. 