### PR TITLE
[Backport release/3.10] Explicitly set CMAKE_CXX_SCAN_FOR_MODULES=0

### DIFF
--- a/cmake/helpers/GdalCAndCXXStandards.cmake
+++ b/cmake/helpers/GdalCAndCXXStandards.cmake
@@ -8,3 +8,8 @@ if (NOT CMAKE_C_STANDARD)
     set(CMAKE_C_STANDARD 99)
     set(CMAKE_C_STANDARD_REQUIRED ON)
 endif()
+
+# explicitly tell CMake not to do module
+# dependency scanning
+# https://discourse.cmake.org/t/cmake-3-28-cmake-cxx-compiler-clang-scan-deps-notfound-not-found/9244/3
+set(CMAKE_CXX_SCAN_FOR_MODULES 0)


### PR DESCRIPTION
Backport #11615
 **Authored by:** @hobu