### PR TITLE
tif_jxl: Add include for TIFF type and use TIFF_SIZE_FORMAT for error.

### DIFF
--- a/frmts/gtiff/tif_jxl.c
+++ b/frmts/gtiff/tif_jxl.c
@@ -413,8 +413,8 @@ static int JXLPreDecode(TIFF *tif, uint16_t s)
             if (buffer_size != channel_size)
             {
                 TIFFErrorExtR(tif, module,
-                              "JxlDecoderExtraChannelBufferSize returned %ld, "
-                              "expecting %u",
+                              "JxlDecoderExtraChannelBufferSize returned "
+                              "%" TIFF_SIZE_FORMAT ", expecting %u",
                               buffer_size, channel_size);
                 _TIFFfreeExt(tif, extra_channel_buffer);
                 return 0;

--- a/frmts/gtiff/tif_jxl.h
+++ b/frmts/gtiff/tif_jxl.h
@@ -25,6 +25,8 @@
 #ifndef TIFF_JXL_H_DEFINED
 #define TIFF_JXL_H_DEFINED
 
+#include "tiffio.h"
+
 #ifndef COMPRESSION_JXL
 #define COMPRESSION_JXL                                                        \
     50002 /* JPEGXL: WARNING not registered in Adobe-maintained registry */


### PR DESCRIPTION
Ran into errors on a custom Android build on Arm.

## What does this PR do?

Fixes build errors on an obscure target config when copying these two files into a custom build of libtiff.

1. The TIFF_SIZE_FORMAT use is generally good practice.
2. The head include fix is for a when the header is used in other files where  the `TIFF` type might not already be defined.

```
third_party/tiff/libtiff/tif_jxl.c:418:31: error: format specifies type 'long' but the argument has type 'size_t' (aka 'unsigned int') [-Werror,-Wformat]
  416 |                               "JxlDecoderExtraChannelBufferSize returned %ld, "
      |                                                                          ~~~
      |                                                                          %zu
  417 |                               "expecting %u",
  418 |                               buffer_size, channel_size);
      |                               ^~~~~~~~~~~
```

## What are related issues/pull requests?

None

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* Custom bazel build from debian-testing derivative
* OS: Android on Arm inside libtiff at head ( 673347a742a87ceb9558cdd6960d20705ebee918 )
* Compiler: clang near head
