### PR TITLE
cpl_error.h: Move the include of stdbool for CPLErrorOnce into the header.

### DIFF
--- a/frmts/aigrid/gridlib.c
+++ b/frmts/aigrid/gridlib.c
@@ -13,8 +13,6 @@
 
 #include "aigrid.h"
 
-#include <stdbool.h>
-
 #ifndef CPL_IGNORE_RET_VAL_INT_defined
 #define CPL_IGNORE_RET_VAL_INT_defined
 

--- a/port/cpl_error.h
+++ b/port/cpl_error.h
@@ -17,9 +17,7 @@
 #include "cpl_port.h"
 
 #include <stdarg.h>
-CPL_C_START
 #include <stdbool.h>
-CPL_C_END
 #include <stddef.h>
 
 /*=====================================================================

--- a/port/cpl_error.h
+++ b/port/cpl_error.h
@@ -17,6 +17,9 @@
 #include "cpl_port.h"
 
 #include <stdarg.h>
+CPL_C_START
+#include <stdbool.h>
+CPL_C_END
 #include <stddef.h>
 
 /*=====================================================================


### PR DESCRIPTION
Callers of things in cpl_error.h should not have to be aware of internally required includes.

Minor cleanup from https://github.com/OSGeo/gdal/commit/ad15a8e141c4841ef1696ad88d0ea55272c82d01