### PR TITLE
Remove uses of #ifdef CPL_HAS_GINT64

### DIFF
--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -1640,36 +1640,36 @@ TEST_F(test_cpl, CPLSM_unsigned)
     {
     }
 
-    ASSERT_EQ((CPLSM(static_cast<GUInt64>(2) * 1000 * 1000 * 1000) +
-               CPLSM(static_cast<GUInt64>(3) * 1000 * 1000 * 1000))
+    ASSERT_EQ((CPLSM(static_cast<uint64_t>(2) * 1000 * 1000 * 1000) +
+               CPLSM(static_cast<uint64_t>(3) * 1000 * 1000 * 1000))
                   .v(),
-              static_cast<GUInt64>(5) * 1000 * 1000 * 1000);
-    ASSERT_EQ((CPLSM(std::numeric_limits<GUInt64>::max() - 1) +
-               CPLSM(static_cast<GUInt64>(1)))
+              static_cast<uint64_t>(5) * 1000 * 1000 * 1000);
+    ASSERT_EQ((CPLSM(std::numeric_limits<uint64_t>::max() - 1) +
+               CPLSM(static_cast<uint64_t>(1)))
                   .v(),
-              std::numeric_limits<GUInt64>::max());
+              std::numeric_limits<uint64_t>::max());
     try
     {
-        (CPLSM(std::numeric_limits<GUInt64>::max()) +
-         CPLSM(static_cast<GUInt64>(1)));
+        (CPLSM(std::numeric_limits<uint64_t>::max()) +
+         CPLSM(static_cast<uint64_t>(1)));
     }
     catch (...)
     {
     }
 
-    ASSERT_EQ((CPLSM(static_cast<GUInt64>(2) * 1000 * 1000 * 1000) *
-               CPLSM(static_cast<GUInt64>(3) * 1000 * 1000 * 1000))
+    ASSERT_EQ((CPLSM(static_cast<uint64_t>(2) * 1000 * 1000 * 1000) *
+               CPLSM(static_cast<uint64_t>(3) * 1000 * 1000 * 1000))
                   .v(),
-              static_cast<GUInt64>(6) * 1000 * 1000 * 1000 * 1000 * 1000 *
+              static_cast<uint64_t>(6) * 1000 * 1000 * 1000 * 1000 * 1000 *
                   1000);
-    ASSERT_EQ((CPLSM(std::numeric_limits<GUInt64>::max()) *
-               CPLSM(static_cast<GUInt64>(1)))
+    ASSERT_EQ((CPLSM(std::numeric_limits<uint64_t>::max()) *
+               CPLSM(static_cast<uint64_t>(1)))
                   .v(),
-              std::numeric_limits<GUInt64>::max());
+              std::numeric_limits<uint64_t>::max());
     try
     {
-        (CPLSM(std::numeric_limits<GUInt64>::max()) *
-         CPLSM(static_cast<GUInt64>(2)));
+        (CPLSM(std::numeric_limits<uint64_t>::max()) *
+         CPLSM(static_cast<uint64_t>(2)));
     }
     catch (...)
     {

--- a/frmts/eeda/eedadataset.cpp
+++ b/frmts/eeda/eedadataset.cpp
@@ -19,6 +19,7 @@
 #include "eeda.h"
 
 #include <algorithm>
+#include <cinttypes>
 #include <vector>
 #include <map>
 #include <set>
@@ -778,7 +779,7 @@ CPLString GDALEEDALayer::BuildFilter(swq_expr_node *poNode, bool bIsAndTopLevel)
             poNode->papoSubExpr[1]->field_type == SWQ_INTEGER64)
         {
             osFilter +=
-                CPLSPrintf(CPL_FRMT_GIB, poNode->papoSubExpr[1]->int_value);
+                CPLSPrintf("%" PRId64, poNode->papoSubExpr[1]->int_value);
         }
         else if (poNode->papoSubExpr[1]->field_type == SWQ_FLOAT)
         {
@@ -869,7 +870,7 @@ CPLString GDALEEDALayer::BuildFilter(swq_expr_node *poNode, bool bIsAndTopLevel)
                 poNode->papoSubExpr[i]->field_type == SWQ_INTEGER64)
             {
                 osFilter +=
-                    CPLSPrintf(CPL_FRMT_GIB, poNode->papoSubExpr[i]->int_value);
+                    CPLSPrintf("%" PRId64, poNode->papoSubExpr[i]->int_value);
             }
             else if (poNode->papoSubExpr[i]->field_type == SWQ_FLOAT)
             {

--- a/frmts/pds/pdsdataset.cpp
+++ b/frmts/pds/pdsdataset.cpp
@@ -1201,7 +1201,7 @@ int PDSDataset::ParseImage(const CPLString &osPrefix,
     int nPixelOffset;
     vsi_l_offset nBandOffset;
 
-    const auto CPLSM64 = [](int x) { return CPLSM(static_cast<GInt64>(x)); };
+    const auto CPLSM64 = [](int x) { return CPLSM(static_cast<int64_t>(x)); };
 
     try
     {

--- a/frmts/pds/vicardataset.cpp
+++ b/frmts/pds/vicardataset.cpp
@@ -2630,15 +2630,15 @@ GDALDataset *VICARDataset::Open(GDALOpenInfo *poOpenInfo)
     /*      Compute the line offsets.                                        */
     /* -------------------------------------------------------------------- */
 
-    GUInt64 nPixelOffset;
-    GUInt64 nLineOffset;
-    GUInt64 nBandOffset;
-    GUInt64 nImageOffsetWithoutNBB;
-    GUInt64 nNBB;
-    GUInt64 nImageSize;
+    uint64_t nPixelOffset;
+    uint64_t nLineOffset;
+    uint64_t nBandOffset;
+    uint64_t nImageOffsetWithoutNBB;
+    uint64_t nNBB;
+    uint64_t nImageSize;
     if (!GetSpacings(poDS->oKeywords, nPixelOffset, nLineOffset, nBandOffset,
                      nImageOffsetWithoutNBB, nNBB, nImageSize) ||
-        nImageOffsetWithoutNBB > std::numeric_limits<GUInt64>::max() -
+        nImageOffsetWithoutNBB > std::numeric_limits<uint64_t>::max() -
                                      (nNBB + nBandOffset * (nBands - 1)))
     {
         CPLDebug("VICAR", "Invalid spacings found");
@@ -3076,22 +3076,22 @@ GDALDataType VICARDataset::GetDataTypeFromFormat(const char *pszFormat)
 /************************************************************************/
 
 bool VICARDataset::GetSpacings(const VICARKeywordHandler &keywords,
-                               GUInt64 &nPixelOffset, GUInt64 &nLineOffset,
-                               GUInt64 &nBandOffset,
-                               GUInt64 &nImageOffsetWithoutNBB, GUInt64 &nNBB,
-                               GUInt64 &nImageSize)
+                               uint64_t &nPixelOffset, uint64_t &nLineOffset,
+                               uint64_t &nBandOffset,
+                               uint64_t &nImageOffsetWithoutNBB, uint64_t &nNBB,
+                               uint64_t &nImageSize)
 {
     const GDALDataType eDataType =
         GetDataTypeFromFormat(keywords.GetKeyword("FORMAT", ""));
     if (eDataType == GDT_Unknown)
         return false;
-    const GUInt64 nItemSize = GDALGetDataTypeSizeBytes(eDataType);
+    const uint64_t nItemSize = GDALGetDataTypeSizeBytes(eDataType);
     const char *value = keywords.GetKeyword("ORG", "BSQ");
     // number of bytes of binary prefix before each record
     nNBB = atoi(keywords.GetKeyword("NBB", ""));
-    const GUInt64 nCols64 = atoi(keywords.GetKeyword("NS", ""));
-    const GUInt64 nRows64 = atoi(keywords.GetKeyword("NL", ""));
-    const GUInt64 nBands64 = atoi(keywords.GetKeyword("NB", ""));
+    const uint64_t nCols64 = atoi(keywords.GetKeyword("NS", ""));
+    const uint64_t nRows64 = atoi(keywords.GetKeyword("NL", ""));
+    const uint64_t nBands64 = atoi(keywords.GetKeyword("NB", ""));
     try
     {
         if (EQUAL(value, "BIP"))
@@ -3130,9 +3130,9 @@ bool VICARDataset::GetSpacings(const VICARKeywordHandler &keywords,
         return false;
     }
 
-    const GUInt64 nLabelSize = atoi(keywords.GetKeyword("LBLSIZE", ""));
-    const GUInt64 nRecordSize = atoi(keywords.GetKeyword("RECSIZE", ""));
-    const GUInt64 nNLB = atoi(keywords.GetKeyword("NLB", ""));
+    const uint64_t nLabelSize = atoi(keywords.GetKeyword("LBLSIZE", ""));
+    const uint64_t nRecordSize = atoi(keywords.GetKeyword("RECSIZE", ""));
+    const uint64_t nNLB = atoi(keywords.GetKeyword("NLB", ""));
     try
     {
         nImageOffsetWithoutNBB =

--- a/frmts/pds/vicardataset.h
+++ b/frmts/pds/vicardataset.h
@@ -132,10 +132,10 @@ class VICARDataset final : public RawDataset
 
     static GDALDataType GetDataTypeFromFormat(const char *pszFormat);
     static bool GetSpacings(const VICARKeywordHandler &keywords,
-                            GUInt64 &nPixelOffset, GUInt64 &nLineOffset,
-                            GUInt64 &nBandOffset,
-                            GUInt64 &nImageOffsetWithoutNBB, GUInt64 &nNBB,
-                            GUInt64 &nImageSize);
+                            uint64_t &nPixelOffset, uint64_t &nLineOffset,
+                            uint64_t &nBandOffset,
+                            uint64_t &nImageOffsetWithoutNBB, uint64_t &nNBB,
+                            uint64_t &nImageSize);
 };
 
 #endif  // VICARDATASET_H

--- a/frmts/pds/vicarkeywordhandler.cpp
+++ b/frmts/pds/vicarkeywordhandler.cpp
@@ -109,12 +109,12 @@ bool VICARKeywordHandler::Ingest(VSILFILE *fp, const GByte *pabyHeader)
     /*      There is a EOL!   e.G.  h4231_0000.nd4.06                       */
     /* -------------------------------------------------------------------- */
 
-    GUInt64 nPixelOffset;
-    GUInt64 nLineOffset;
-    GUInt64 nBandOffset;
-    GUInt64 nImageOffsetWithoutNBB;
-    GUInt64 nNBB;
-    GUInt64 nImageSize;
+    uint64_t nPixelOffset;
+    uint64_t nLineOffset;
+    uint64_t nBandOffset;
+    uint64_t nImageOffsetWithoutNBB;
+    uint64_t nNBB;
+    uint64_t nImageSize;
     if (!VICARDataset::GetSpacings(*this, nPixelOffset, nLineOffset,
                                    nBandOffset, nImageOffsetWithoutNBB, nNBB,
                                    nImageSize))
@@ -128,7 +128,7 @@ bool VICARKeywordHandler::Ingest(VSILFILE *fp, const GByte *pabyHeader)
     const vsi_l_offset nEOCI = (nEOCI2 << 32) | nEOCI1;
 
     if (nImageOffsetWithoutNBB >
-        std::numeric_limits<GUInt64>::max() - nImageSize)
+        std::numeric_limits<uint64_t>::max() - nImageSize)
     {
         CPLError(CE_Failure, CPLE_AppDefined, "Invalid label values");
         return false;

--- a/frmts/rmf/rmfdataset.cpp
+++ b/frmts/rmf/rmfdataset.cpp
@@ -1418,15 +1418,15 @@ RMFDataset *RMFDataset::Open(GDALOpenInfo *poOpenInfo, RMFDataset *poParentDS,
     bool bInvalidTileSize;
     try
     {
-        GUInt64 nMaxTileBits =
-            (CPLSM(static_cast<GUInt64>(2)) *
-             CPLSM(static_cast<GUInt64>(poDS->sHeader.nTileWidth)) *
-             CPLSM(static_cast<GUInt64>(poDS->sHeader.nTileHeight)) *
-             CPLSM(static_cast<GUInt64>(poDS->sHeader.nBitDepth)))
+        uint64_t nMaxTileBits =
+            (CPLSM(static_cast<uint64_t>(2)) *
+             CPLSM(static_cast<uint64_t>(poDS->sHeader.nTileWidth)) *
+             CPLSM(static_cast<uint64_t>(poDS->sHeader.nTileHeight)) *
+             CPLSM(static_cast<uint64_t>(poDS->sHeader.nBitDepth)))
                 .v();
         bInvalidTileSize =
             (nMaxTileBits >
-             static_cast<GUInt64>(std::numeric_limits<GUInt32>::max()));
+             static_cast<uint64_t>(std::numeric_limits<GUInt32>::max()));
     }
     catch (...)
     {

--- a/gcore/gdaljp2box.cpp
+++ b/gcore/gdaljp2box.cpp
@@ -155,21 +155,9 @@ int GDALJP2Box::ReadBox()
         if (VSIFReadL(abyXLBox, 8, 1, fpVSIL) != 1)
             return FALSE;
 
-#ifdef CPL_HAS_GINT64
         CPL_MSBPTR64(abyXLBox);
         memcpy(&nBoxLength, abyXLBox, 8);
-#else
-        // In case we lack a 64 bit integer type
-        if (abyXLBox[0] != 0 || abyXLBox[1] != 0 || abyXLBox[2] != 0 ||
-            abyXLBox[3] != 0)
-        {
-            CPLError(CE_Failure, CPLE_AppDefined,
-                     "Box size requires a 64 bit integer type");
-            return FALSE;
-        }
-        CPL_MSBPTR32(abyXLBox + 4);
-        memcpy(&nBoxLength, abyXLBox + 4, 4);
-#endif
+
         if (nBoxLength < 0)
         {
             CPLDebug("GDALJP2", "Invalid length for box %s", szBoxType);

--- a/gcore/gdalmultidim.cpp
+++ b/gcore/gdalmultidim.cpp
@@ -1887,8 +1887,8 @@ bool GDALAbstractMDArray::CheckReadWriteParams(
             bool bOK;
             try
             {
-                newStride = (CPLSM(static_cast<GUInt64>(stride)) *
-                             CPLSM(static_cast<GUInt64>(count[i])))
+                newStride = (CPLSM(static_cast<uint64_t>(stride)) *
+                             CPLSM(static_cast<uint64_t>(count[i])))
                                 .v();
                 bOK = static_cast<size_t>(newStride) == newStride &&
                       newStride < std::numeric_limits<size_t>::max() / 2;
@@ -1934,9 +1934,9 @@ bool GDALAbstractMDArray::CheckReadWriteParams(
         {
             try
             {
-                bOverflow = (CPLSM(static_cast<GUInt64>(arrayStartIdx[i])) +
-                             CPLSM(static_cast<GUInt64>(count[i] - 1)) *
-                                 CPLSM(static_cast<GUInt64>(arrayStep[i])))
+                bOverflow = (CPLSM(static_cast<uint64_t>(arrayStartIdx[i])) +
+                             CPLSM(static_cast<uint64_t>(count[i] - 1)) *
+                                 CPLSM(static_cast<uint64_t>(arrayStep[i])))
                                 .v() >= dims[i]->GetSize();
             }
             catch (...)
@@ -1960,10 +1960,10 @@ bool GDALAbstractMDArray::CheckReadWriteParams(
             {
                 bOverflow =
                     arrayStartIdx[i] <
-                    (CPLSM(static_cast<GUInt64>(count[i] - 1)) *
+                    (CPLSM(static_cast<uint64_t>(count[i] - 1)) *
                      CPLSM(arrayStep[i] == std::numeric_limits<GInt64>::min()
-                               ? (static_cast<GUInt64>(1) << 63)
-                               : static_cast<GUInt64>(-arrayStep[i])))
+                               ? (static_cast<uint64_t>(1) << 63)
+                               : static_cast<uint64_t>(-arrayStep[i])))
                         .v();
             }
             catch (...)
@@ -2002,10 +2002,10 @@ bool GDALAbstractMDArray::CheckReadWriteParams(
             {
                 try
                 {
-                    nOffset = (CPLSM(static_cast<GUInt64>(nOffset)) +
-                               CPLSM(static_cast<GUInt64>(bufferStride[i])) *
-                                   CPLSM(static_cast<GUInt64>(count[i] - 1)) *
-                                   CPLSM(static_cast<GUInt64>(elementSize)))
+                    nOffset = (CPLSM(static_cast<uint64_t>(nOffset)) +
+                               CPLSM(static_cast<uint64_t>(bufferStride[i])) *
+                                   CPLSM(static_cast<uint64_t>(count[i] - 1)) *
+                                   CPLSM(static_cast<uint64_t>(elementSize)))
                                   .v();
                 }
                 catch (...)
@@ -2272,8 +2272,8 @@ GUInt64 GDALAbstractMDArray::GetTotalElementsCount() const
     {
         try
         {
-            nElts = (CPLSM(static_cast<GUInt64>(nElts)) *
-                     CPLSM(static_cast<GUInt64>(dim->GetSize())))
+            nElts = (CPLSM(static_cast<uint64_t>(nElts)) *
+                     CPLSM(static_cast<uint64_t>(dim->GetSize())))
                         .v();
         }
         catch (...)

--- a/gcore/gdalrasterband.cpp
+++ b/gcore/gdalrasterband.cpp
@@ -4987,8 +4987,6 @@ CPLErr CPL_STDCALL GDALGetRasterStatistics(GDALRasterBandH hBand, int bApproxOK,
                                  pdfStdDev);
 }
 
-#ifdef CPL_HAS_GINT64
-
 /************************************************************************/
 /*                         GDALUInt128                                  */
 /************************************************************************/
@@ -6021,8 +6019,6 @@ struct ComputeStatisticsInternal<GUInt16, COMPUTE_OTHER_STATS>
 // (defined(__x86_64__) || defined(_M_X64)) && (defined(__GNUC__) ||
 // defined(_MSC_VER))
 
-#endif  // CPL_HAS_GINT64
-
 /************************************************************************/
 /*                          GetPixelValue()                             */
 /************************************************************************/
@@ -6431,7 +6427,6 @@ CPLErr GDALRasterBand::ComputeStatistics(int bApproxOK, double *pdfMin,
         if (nSampleRate == 1)
             bApproxOK = false;
 
-#ifdef CPL_HAS_GINT64
         // Particular case for GDT_Byte that only use integral types for all
         // intermediate computations. Only possible if the number of pixels
         // explored is lower than GUINTBIG_MAX / (255*255), so that nSumSquare
@@ -6580,7 +6575,6 @@ CPLErr GDALRasterBand::ComputeStatistics(int bApproxOK, double *pdfMin,
                         "in sampling.");
             return CE_Failure;
         }
-#endif
 
         GByte *pabyMaskData = nullptr;
         if (poMaskBand)

--- a/gcore/rasterio.cpp
+++ b/gcore/rasterio.cpp
@@ -2067,7 +2067,6 @@ void CPL_STDCALL GDALSwapWords(void *pData, int nWordSize, int nWordCount,
 
         case 8:
             CPLAssert(nWordSkip >= 8 || nWordCount == 1);
-#ifdef CPL_HAS_GINT64
             if (CPL_IS_ALIGNED(pabyData, 8) && (nWordSkip % 8) == 0)
             {
                 for (int i = 0; i < nWordCount; i++)
@@ -2078,7 +2077,6 @@ void CPL_STDCALL GDALSwapWords(void *pData, int nWordSize, int nWordCount,
                 }
             }
             else
-#endif
             {
                 for (int i = 0; i < nWordCount; i++)
                 {

--- a/gcore/rawdataset.cpp
+++ b/gcore/rawdataset.cpp
@@ -1760,17 +1760,17 @@ bool RAWDatasetCheckMemoryUsage(int nXSize, int nYSize, int nBands, int nDTSize,
         try
         {
             nExpectedFileSize =
-                (CPLSM(static_cast<GUInt64>(nHeaderSize)) +
-                 CPLSM(static_cast<GUInt64>(nBandOffset)) *
-                     CPLSM(static_cast<GUInt64>(nBands - 1)) +
+                (CPLSM(static_cast<uint64_t>(nHeaderSize)) +
+                 CPLSM(static_cast<uint64_t>(nBandOffset)) *
+                     CPLSM(static_cast<uint64_t>(nBands - 1)) +
                  (nLineOffset >= 0
-                      ? CPLSM(static_cast<GUInt64>(nYSize - 1)) *
-                            CPLSM(static_cast<GUInt64>(nLineOffset))
-                      : CPLSM(static_cast<GUInt64>(0))) +
+                      ? CPLSM(static_cast<uint64_t>(nYSize - 1)) *
+                            CPLSM(static_cast<uint64_t>(nLineOffset))
+                      : CPLSM(static_cast<uint64_t>(0))) +
                  (nPixelOffset >= 0
-                      ? CPLSM(static_cast<GUInt64>(nXSize - 1)) *
-                            CPLSM(static_cast<GUInt64>(nPixelOffset))
-                      : CPLSM(static_cast<GUInt64>(0))))
+                      ? CPLSM(static_cast<uint64_t>(nXSize - 1)) *
+                            CPLSM(static_cast<uint64_t>(nPixelOffset))
+                      : CPLSM(static_cast<uint64_t>(0))))
                     .v();
         }
         catch (...)

--- a/ogr/ogr_swq.h
+++ b/ogr/ogr_swq.h
@@ -183,7 +183,7 @@ class CPL_UNSTABLE_API swq_expr_node
 
     /* only for SNT_CONSTANT */
     int is_null = false;
-    GIntBig int_value = 0;
+    int64_t int_value = 0;
     double float_value = 0.0;
     OGRGeometry *geometry_value = nullptr;
 

--- a/ogr/ogrsf_frmts/cad/libopencad/cadheader.cpp
+++ b/ogr/ogrsf_frmts/cad/libopencad/cadheader.cpp
@@ -180,23 +180,23 @@ long CADHandle::getAsLong( const CADHandle& ref_handle ) const
         {
             case 0x06:
             {
-                return static_cast<long>((CPLSM(static_cast<GInt64>(getAsLong(ref_handle.handleOrOffset))) +
-                        CPLSM(static_cast<GInt64>(1))).v());
+                return static_cast<long>((CPLSM(static_cast<int64_t>(getAsLong(ref_handle.handleOrOffset))) +
+                        CPLSM(static_cast<int64_t>(1))).v());
             }
             case 0x08:
             {
-                return static_cast<long>((CPLSM(static_cast<GInt64>(getAsLong(ref_handle.handleOrOffset))) -
-                        CPLSM(static_cast<GInt64>(1))).v());
+                return static_cast<long>((CPLSM(static_cast<int64_t>(getAsLong(ref_handle.handleOrOffset))) -
+                        CPLSM(static_cast<int64_t>(1))).v());
             }
             case 0x0A:
             {
-                return static_cast<long>((CPLSM(static_cast<GInt64>(getAsLong(ref_handle.handleOrOffset))) +
-                        CPLSM(static_cast<GInt64>(getAsLong(handleOrOffset)))).v());
+                return static_cast<long>((CPLSM(static_cast<int64_t>(getAsLong(ref_handle.handleOrOffset))) +
+                        CPLSM(static_cast<int64_t>(getAsLong(handleOrOffset)))).v());
             }
             case 0x0C:
             {
-                return static_cast<long>((CPLSM(static_cast<GInt64>(getAsLong(ref_handle.handleOrOffset))) -
-                        CPLSM(static_cast<GInt64>(getAsLong(handleOrOffset)))).v());
+                return static_cast<long>((CPLSM(static_cast<int64_t>(getAsLong(ref_handle.handleOrOffset))) -
+                        CPLSM(static_cast<int64_t>(getAsLong(handleOrOffset)))).v());
             }
         }
     }

--- a/ogr/ogrsf_frmts/generic/ogr_gensql.cpp
+++ b/ogr/ogrsf_frmts/generic/ogr_gensql.cpp
@@ -1653,7 +1653,8 @@ std::unique_ptr<OGRFeature> OGRGenSQLResultsLayer::TranslateFeature(
             case SWQ_BOOLEAN:
             case SWQ_INTEGER:
             case SWQ_INTEGER64:
-                poDstFeat->SetField(iRegularField++, poResult->int_value);
+                poDstFeat->SetField(iRegularField++,
+                                    static_cast<GIntBig>(poResult->int_value));
                 break;
 
             case SWQ_FLOAT:

--- a/ogr/ogrsf_frmts/gmlutils/ogrwfsfilter.cpp
+++ b/ogr/ogrsf_frmts/gmlutils/ogrwfsfilter.cpp
@@ -13,6 +13,8 @@
 #include "ogrwfsfilter.h"
 #include "ogr_p.h"
 
+#include <cinttypes>
+
 typedef struct
 {
     int nVersion;
@@ -53,7 +55,7 @@ static bool WFS_ExprDumpGmlObjectIdFilter(CPLString &osFilter,
             poExpr->papoSubExpr[1]->field_type == SWQ_INTEGER64)
         {
             osFilter +=
-                CPLSPrintf(CPL_FRMT_GIB, poExpr->papoSubExpr[1]->int_value);
+                CPLSPrintf("%" PRId64, poExpr->papoSubExpr[1]->int_value);
         }
         else if (poExpr->papoSubExpr[1]->field_type == SWQ_STRING)
         {
@@ -92,7 +94,7 @@ static bool WFS_ExprDumpRawLitteral(CPLString &osFilter,
 {
     if (poExpr->field_type == SWQ_INTEGER ||
         poExpr->field_type == SWQ_INTEGER64)
-        osFilter += CPLSPrintf(CPL_FRMT_GIB, poExpr->int_value);
+        osFilter += CPLSPrintf("%" PRId64, poExpr->int_value);
     else if (poExpr->field_type == SWQ_FLOAT)
         osFilter += CPLSPrintf("%.16g", poExpr->float_value);
     else if (poExpr->field_type == SWQ_STRING)

--- a/ogr/ogrsf_frmts/oapif/ogroapifdriver.cpp
+++ b/ogr/ogrsf_frmts/oapif/ogroapifdriver.cpp
@@ -18,6 +18,7 @@
 #include "parsexsd.h"
 
 #include <algorithm>
+#include <cinttypes>
 #include <memory>
 #include <vector>
 #include <set>
@@ -2626,7 +2627,7 @@ CPLString OGROAPIFLayer::BuildFilter(const swq_expr_node *poNode)
                 CPLString osRet(osEscapedFieldName);
                 osRet += "=";
                 osRet +=
-                    CPLSPrintf(CPL_FRMT_GIB, poNode->papoSubExpr[1]->int_value);
+                    CPLSPrintf("%" PRId64, poNode->papoSubExpr[1]->int_value);
                 return osRet;
             }
         }
@@ -2806,7 +2807,7 @@ CPLString OGROAPIFLayer::BuildFilterCQLText(const swq_expr_node *poNode)
                 poNode->papoSubExpr[1]->field_type == SWQ_INTEGER64)
             {
                 osRet +=
-                    CPLSPrintf(CPL_FRMT_GIB, poNode->papoSubExpr[1]->int_value);
+                    CPLSPrintf("%" PRId64, poNode->papoSubExpr[1]->int_value);
                 return osRet;
             }
             if (poNode->papoSubExpr[1]->field_type == SWQ_FLOAT)
@@ -2993,7 +2994,7 @@ CPLString OGROAPIFLayer::BuildFilterJSONFilterExpr(const swq_expr_node *poNode)
         if (poNode->field_type == SWQ_INTEGER ||
             poNode->field_type == SWQ_INTEGER64)
         {
-            return CPLSPrintf(CPL_FRMT_GIB, poNode->int_value);
+            return CPLSPrintf("%" PRId64, poNode->int_value);
         }
         if (poNode->field_type == SWQ_FLOAT)
         {

--- a/ogr/swq_expr_node.cpp
+++ b/ogr/swq_expr_node.cpp
@@ -19,6 +19,7 @@
 
 #include <algorithm>
 #include <cctype>
+#include <cinttypes>
 #include <cstdio>
 #include <cstring>
 #include <string>
@@ -427,7 +428,7 @@ void swq_expr_node::Dump(FILE *fp, int depth)
     {
         if (field_type == SWQ_INTEGER || field_type == SWQ_INTEGER64 ||
             field_type == SWQ_BOOLEAN)
-            fprintf(fp, "%s  " CPL_FRMT_GIB "\n", spaces, int_value);
+            fprintf(fp, "%s  %" PRId64 "\n", spaces, int_value);
         else if (field_type == SWQ_FLOAT)
             fprintf(fp, "%s  %.15g\n", spaces, float_value);
         else if (field_type == SWQ_GEOMETRY)
@@ -538,7 +539,7 @@ char *swq_expr_node::Unparse(swq_field_list *field_list, char chColumnQuote)
 
         if (field_type == SWQ_INTEGER || field_type == SWQ_INTEGER64 ||
             field_type == SWQ_BOOLEAN)
-            osExpr.Printf(CPL_FRMT_GIB, int_value);
+            osExpr.Printf("%" PRId64, int_value);
         else if (field_type == SWQ_FLOAT)
         {
             osExpr.Printf("%.15g", float_value);

--- a/ogr/swq_op_general.cpp
+++ b/ogr/swq_op_general.cpp
@@ -17,6 +17,7 @@
 #include "ogr_swq.h"
 
 #include <cctype>
+#include <cinttypes>
 #include <climits>
 #include <cstdlib>
 #include <cstring>
@@ -1788,7 +1789,7 @@ swq_expr_node *SWQCastEvaluator(swq_expr_node *node,
                 case SWQ_INTEGER:
                 case SWQ_BOOLEAN:
                 case SWQ_INTEGER64:
-                    osRet.Printf(CPL_FRMT_GIB, poSrcNode->int_value);
+                    osRet.Printf("%" PRId64, poSrcNode->int_value);
                     break;
 
                 case SWQ_FLOAT:


### PR DESCRIPTION
The code base has assumed for many many years that we have access to 64-bit integer types.
