### PR TITLE
[Backport release/3.10] GDALGCPsToGeoTransform(): return FALSE when invalid geotransform is generated

### DIFF
--- a/autotest/gcore/gcps2geotransform.py
+++ b/autotest/gcore/gcps2geotransform.py
@@ -195,3 +195,34 @@ def test_gcps2gt_8():
         1.596921026218e-05,
     )
     gdaltest.check_geotransform(gt, gt_expected, 0.00001)
+
+
+###############################################################################
+# Test case of https://github.com/OSGeo/gdal/issues/11618
+
+
+def test_gcps2gt_broken_hour_glass():
+
+    gt = gdal.GCPsToGeoTransform(
+        _list2gcps(
+            [
+                (0, 0, 0, 0),
+                (0, 10, 0, 10),
+                (10, 0, 10, 10),
+                (10, 10, 10, 0),
+            ]
+        )
+    )
+    assert gt is None
+
+    gt = gdal.GCPsToGeoTransform(
+        _list2gcps(
+            [
+                (0, 0, 0, 0),
+                (0, 10, 10, 0),
+                (10, 0, 0, 10),
+                (10, 10, 10, 10),
+            ]
+        )
+    )
+    assert gt is None

--- a/gcore/gdal_misc.cpp
+++ b/gcore/gdal_misc.cpp
@@ -3242,6 +3242,13 @@ int CPL_STDCALL GDALGCPsToGeoTransform(int nGCPCount, const GDAL_GCP *pasGCPs,
     GDALComposeGeoTransforms(pl_normalize, gt_normalized, gt1p2);
     GDALComposeGeoTransforms(gt1p2, inv_geo_normalize, padfGeoTransform);
 
+    // "Hour-glass" like shape of GCPs. Cf https://github.com/OSGeo/gdal/issues/11618
+    if (std::abs(padfGeoTransform[1]) <= 1e-15 ||
+        std::abs(padfGeoTransform[5]) <= 1e-15)
+    {
+        return FALSE;
+    }
+
     /* -------------------------------------------------------------------- */
     /*      Now check if any of the input points fit this poorly.           */
     /* -------------------------------------------------------------------- */


### PR DESCRIPTION
Backport #11620
 **Authored by:** @rouault