### PR TITLE
Fix read heap-buffer-overflow on nested /vsitar/ calls

### DIFF
--- a/port/cpl_path.cpp
+++ b/port/cpl_path.cpp
@@ -801,8 +801,12 @@ const char *CPLFormCIFilename(const char *pszPath, const char *pszBasename,
             pszFilename[i] = static_cast<char>(CPLToupper(pszFilename[i]));
         }
 
-        pszFullPath = CPLFormFilename(pszPath, pszFilename, nullptr);
-        nStatRet = VSIStatExL(pszFullPath, &sStatBuf, VSI_STAT_EXISTS_FLAG);
+        const std::string osTmpPath(
+            CPLFormFilename(pszPath, pszFilename, nullptr));
+        nStatRet =
+            VSIStatExL(osTmpPath.c_str(), &sStatBuf, VSI_STAT_EXISTS_FLAG);
+        if (nStatRet == 0)
+            pszFullPath = CPLFormFilename(pszPath, pszFilename, nullptr);
     }
 
     if (nStatRet != 0)
@@ -813,8 +817,12 @@ const char *CPLFormCIFilename(const char *pszPath, const char *pszBasename,
                 CPLTolower(static_cast<unsigned char>(pszFilename[i])));
         }
 
-        pszFullPath = CPLFormFilename(pszPath, pszFilename, nullptr);
-        nStatRet = VSIStatExL(pszFullPath, &sStatBuf, VSI_STAT_EXISTS_FLAG);
+        const std::string osTmpPath(
+            CPLFormFilename(pszPath, pszFilename, nullptr));
+        nStatRet =
+            VSIStatExL(osTmpPath.c_str(), &sStatBuf, VSI_STAT_EXISTS_FLAG);
+        if (nStatRet == 0)
+            pszFullPath = CPLFormFilename(pszPath, pszFilename, nullptr);
     }
 
     if (nStatRet != 0)


### PR DESCRIPTION
Fixes https://issues.oss-fuzz.com/issues/388868487

This is just a band-aid... The use of CPLFormFilename() and friends is so dangerous with the rotating TLS buffers that may end up overwritten if too many calls are nested...
