### PR TITLE
[Backport release/3.10] Fix read heap-buffer-overflow on nested /vsitar/ calls

### DIFF
--- a/port/cpl_path.cpp
+++ b/port/cpl_path.cpp
@@ -799,8 +799,12 @@ const char *CPLFormCIFilename(const char *pszPath, const char *pszBasename,
             pszFilename[i] = static_cast<char>(CPLToupper(pszFilename[i]));
         }
 
-        pszFullPath = CPLFormFilename(pszPath, pszFilename, nullptr);
-        nStatRet = VSIStatExL(pszFullPath, &sStatBuf, VSI_STAT_EXISTS_FLAG);
+        const std::string osTmpPath(
+            CPLFormFilename(pszPath, pszFilename, nullptr));
+        nStatRet =
+            VSIStatExL(osTmpPath.c_str(), &sStatBuf, VSI_STAT_EXISTS_FLAG);
+        if (nStatRet == 0)
+            pszFullPath = CPLFormFilename(pszPath, pszFilename, nullptr);
     }
 
     if (nStatRet != 0)
@@ -811,8 +815,12 @@ const char *CPLFormCIFilename(const char *pszPath, const char *pszBasename,
                 CPLTolower(static_cast<unsigned char>(pszFilename[i])));
         }
 
-        pszFullPath = CPLFormFilename(pszPath, pszFilename, nullptr);
-        nStatRet = VSIStatExL(pszFullPath, &sStatBuf, VSI_STAT_EXISTS_FLAG);
+        const std::string osTmpPath(
+            CPLFormFilename(pszPath, pszFilename, nullptr));
+        nStatRet =
+            VSIStatExL(osTmpPath.c_str(), &sStatBuf, VSI_STAT_EXISTS_FLAG);
+        if (nStatRet == 0)
+            pszFullPath = CPLFormFilename(pszPath, pszFilename, nullptr);
     }
 
     if (nStatRet != 0)

--- a/port/cpl_vsil_abstract_archive.cpp
+++ b/port/cpl_vsil_abstract_archive.cpp
@@ -457,7 +457,12 @@ char *VSIArchiveFilesystemHandler::SplitFilename(const char *pszFilename,
 
     const std::vector<CPLString> oExtensions = GetExtensions();
     int nAttempts = 0;
-    while (pszFilename[i])
+    // If we are called with pszFilename being one of the TLS buffers returned
+    // by cpl_path.cpp functions, then a call to Stat() in the loop (and its
+    // cascaded calls to other cpl_path.cpp functions) might lead to altering
+    // the buffer to be altered, hence take a copy
+    const std::string osFilenameCopy(pszFilename);
+    while (i < static_cast<int>(osFilenameCopy.size()))
     {
         int nToSkip = 0;
 
@@ -465,7 +470,7 @@ char *VSIArchiveFilesystemHandler::SplitFilename(const char *pszFilename,
              iter != oExtensions.end(); ++iter)
         {
             const CPLString &osExtension = *iter;
-            if (EQUALN(pszFilename + i, osExtension.c_str(),
+            if (EQUALN(osFilenameCopy.c_str() + i, osExtension.c_str(),
                        osExtension.size()))
             {
                 nToSkip = static_cast<int>(osExtension.size());
@@ -475,7 +480,8 @@ char *VSIArchiveFilesystemHandler::SplitFilename(const char *pszFilename,
 
 #ifdef DEBUG
         // For AFL, so that .cur_input is detected as the archive filename.
-        if (EQUALN(pszFilename + i, ".cur_input", strlen(".cur_input")))
+        if (EQUALN(osFilenameCopy.c_str() + i, ".cur_input",
+                   strlen(".cur_input")))
         {
             nToSkip = static_cast<int>(strlen(".cur_input"));
         }
@@ -491,7 +497,7 @@ char *VSIArchiveFilesystemHandler::SplitFilename(const char *pszFilename,
                 break;
             }
             VSIStatBufL statBuf;
-            char *archiveFilename = CPLStrdup(pszFilename);
+            char *archiveFilename = CPLStrdup(osFilenameCopy.c_str());
             bool bArchiveFileExists = false;
 
             if (IsEitherSlash(archiveFilename[i + nToSkip]))
@@ -532,10 +538,11 @@ char *VSIArchiveFilesystemHandler::SplitFilename(const char *pszFilename,
 
             if (bArchiveFileExists)
             {
-                if (IsEitherSlash(pszFilename[i + nToSkip]))
+                if (IsEitherSlash(osFilenameCopy[i + nToSkip]) &&
+                    i + nToSkip + 1 < static_cast<int>(osFilenameCopy.size()))
                 {
-                    osFileInArchive =
-                        CompactFilename(pszFilename + i + nToSkip + 1);
+                    osFileInArchive = CompactFilename(osFilenameCopy.c_str() +
+                                                      i + nToSkip + 1);
                 }
                 else
                 {
@@ -550,12 +557,22 @@ char *VSIArchiveFilesystemHandler::SplitFilename(const char *pszFilename,
                         osFileInArchive.pop_back();
                 }
 
+                // Messy! Restore the TLS buffer if it has been altered
+                if (osFilenameCopy != pszFilename)
+                    strcpy(const_cast<char *>(pszFilename),
+                           osFilenameCopy.c_str());
+
                 return archiveFilename;
             }
             CPLFree(archiveFilename);
         }
         i++;
     }
+
+    // Messy! Restore the TLS buffer if it has been altered
+    if (osFilenameCopy != pszFilename)
+        strcpy(const_cast<char *>(pszFilename), osFilenameCopy.c_str());
+
     return nullptr;
 }
 


### PR DESCRIPTION
Backport #11638
 **Authored by:** @rouault