### PR TITLE
CreateGeometryFromGML(): recognize aixm:ElevatedPoint (ignoring the elevation)

### DIFF
--- a/autotest/ogr/ogr_gml_geom.py
+++ b/autotest/ogr/ogr_gml_geom.py
@@ -3085,3 +3085,22 @@ def test_gml_OrientableCurve():
     )
     assert g is not None
     assert g.ExportToWkt() == "LINESTRING (2 3,0 1)"
+
+
+###############################################################################
+#
+
+
+def test_gml_aixm_ElevatedPoint():
+
+    geom = ogr.CreateGeometryFromGML(
+        """<aixm:ElevatedPoint srsName="urn:ogc:def:crs:EPSG::4326">
+            <gml:pos>49 2</gml:pos>
+            <aixm:elevation uom="M">10</aixm:elevation> <!-- ignored -->
+        </aixm:ElevatedPoint>"""
+    )
+
+    ogrtest.check_feature_geometry(
+        geom,
+        "POINT (49 2)",
+    )

--- a/ogr/gml2ogrgeometry.cpp
+++ b/ogr/gml2ogrgeometry.cpp
@@ -2061,6 +2061,7 @@ GML2OGRGeometry_XMLNode_Internal(const CPLXMLNode *psNode, const char *pszId,
     /* -------------------------------------------------------------------- */
     if (EQUAL(pszBaseGeometry, "PointType") ||
         EQUAL(pszBaseGeometry, "Point") ||
+        EQUAL(pszBaseGeometry, "ElevatedPoint") ||
         EQUAL(pszBaseGeometry, "ConnectionPoint"))
     {
         auto poPoint = std::make_unique<OGRPoint>();


### PR DESCRIPTION
Fixes #11582
