### PR TITLE
[Backport release/3.10] DOC: configoptions fix ignore-env-vars directive

### DIFF
--- a/doc/source/user/configoptions.rst
+++ b/doc/source/user/configoptions.rst
@@ -115,7 +115,7 @@ or through the ``--config`` command line switch.
 The value of environment variables set before GDAL starts will be used instead
 of the value set in the configuration files, unless, starting with GDAL 3.6,
 the configuration file starts with a ``[directives]`` section that contains a
-``ignore-env-variables=yes`` entry.
+``ignore-env-vars=yes`` entry.
 
 .. code-block::
 
@@ -123,7 +123,7 @@ the configuration file starts with a ``[directives]`` section that contains a
     # ignore environment variables. Take only into account the content of the
     # [configoptions] section, or ones defined programmatically with
     # CPLSetConfigOption / CPLSetThreadLocalConfigOption.
-    ignore-env-variables=yes
+    ignore-env-vars=yes
 
 
 Starting with GDAL 3.5, a configuration file can also contain credentials


### PR DESCRIPTION
Backport #11647
 **Authored by:** @mdsumner