### PR TITLE
Warper: Add TIE_STRATEGY warp option

### DIFF
--- a/alg/gdalwarper.cpp
+++ b/alg/gdalwarper.cpp
@@ -1284,6 +1284,10 @@ CPLErr GDALWarpDstAlphaMasker(void *pMaskFuncArg, int nBandCount,
  * EXCLUDED_VALUES_PCT_THRESHOLD.
  * Only taken into account by Average currently.</li>
  *
+ * <li>MODE_TIES=FIRST/MIN/MAX: (GDAL >= 3.11) Strategy to use when breaking
+ * ties with MODE resampling. By default, the first value encountered will be used.
+ * Alternatively, the minimum or maximum value can be selected.</li>
+ *
  * </ul>
  */
 
@@ -1305,6 +1309,7 @@ GDALWarpOptions *CPL_STDCALL GDALCreateWarpOptions()
     psOptions->eResampleAlg = GRA_NearestNeighbour;
     psOptions->pfnProgress = GDALDummyProgress;
     psOptions->eWorkingDataType = GDT_Unknown;
+    psOptions->eTieStrategy = GWKTS_First;
 
     return psOptions;
 }

--- a/alg/gdalwarper.h
+++ b/alg/gdalwarper.h
@@ -130,6 +130,14 @@ CPLErr CPL_DLL GDALWarpCutlineMaskerEx(void *pMaskFuncArg, int nBandCount,
 
 /*! @endcond */
 
+/*! GWKMode tie-breaking strategy */
+typedef enum
+{
+    /* Choose the first value encountered */ GWKTS_First = 1,
+    /* Choose the minimal value */ GWKTS_Min = 2,
+    /* Choose the maximum value */ GWKTS_Max = 3,
+} GWKTieStrategy;
+
 /************************************************************************/
 /*                           GDALWarpOptions                            */
 /************************************************************************/
@@ -243,6 +251,8 @@ typedef struct
      * zero. */
     double dfCutlineBlendDist;
 
+    /** Tie-breaking method */
+    GWKTieStrategy eTieStrategy;
 } GDALWarpOptions;
 
 GDALWarpOptions CPL_DLL *CPL_STDCALL GDALCreateWarpOptions(void);
@@ -450,6 +460,8 @@ class CPL_DLL GDALWarpKernel
     // be ignored as contributing source pixels during resampling. Only taken into account by
     // Average currently
     std::vector<std::vector<double>> m_aadfExcludedValues{};
+
+    GWKTieStrategy eTieStrategy;
 
     /*! @endcond */
 

--- a/autotest/alg/warp.py
+++ b/autotest/alg/warp.py
@@ -1620,21 +1620,56 @@ def test_warp_rms_2():
     )
 
 
-def test_warp_mode_ties():
-    # when performing mode resampling the result in case of a tie will be
-    # the first value identified as the mode in scanline processing
+@pytest.mark.parametrize("tie_strategy", ("FIRST", "MIN", "MAX", "HOPE"))
+@pytest.mark.parametrize("dtype", (gdal.GDT_Int16, gdal.GDT_Int32))
+def test_warp_mode_ties(tie_strategy, dtype):
     numpy = pytest.importorskip("numpy")
 
-    src_ds = gdal.GetDriverByName("MEM").Create("", 3, 3, 1, gdal.GDT_Int16)
+    # 1 and 5 are tied for the mode; 1 encountered first
+    src_ds = gdal.GetDriverByName("MEM").Create("", 3, 3, 1, dtype)
     src_ds.SetGeoTransform([1, 1, 0, 1, 0, 1])
     src_ds.GetRasterBand(1).WriteArray(numpy.array([[1, 1, 1], [2, 3, 4], [5, 5, 5]]))
-    out_ds = gdal.Warp("", src_ds, format="MEM", resampleAlg="mode", xRes=3, yRes=3)
 
-    assert out_ds.GetRasterBand(1).ReadAsArray()[0, 0] == 1
+    with gdaltest.disable_exceptions():
+        out_ds = gdal.Warp(
+            "",
+            src_ds,
+            format="MEM",
+            resampleAlg="mode",
+            xRes=3,
+            yRes=3,
+            warpOptions={"MODE_TIES": tie_strategy},
+        )
 
+    if tie_strategy == "HOPE":
+        assert out_ds is None
+        return
+
+    result = out_ds.GetRasterBand(1).ReadAsArray()[0, 0]
+
+    if tie_strategy in ("FIRST", "MIN"):
+        assert result == 1
+    else:
+        assert result == 5
+
+    # 1 and 5 are tied for the mode; 5 encountered first
     src_ds.GetRasterBand(1).WriteArray(numpy.array([[1, 5, 1], [2, 5, 4], [5, 1, 0]]))
-    out_ds = gdal.Warp("", src_ds, format="MEM", resampleAlg="mode", xRes=3, yRes=3)
-    assert out_ds.GetRasterBand(1).ReadAsArray()[0, 0] == 5
+    out_ds = gdal.Warp(
+        "",
+        src_ds,
+        format="MEM",
+        resampleAlg="mode",
+        xRes=3,
+        yRes=3,
+        warpOptions={"MODE_TIES": tie_strategy},
+    )
+
+    result = out_ds.GetRasterBand(1).ReadAsArray()[0, 0]
+
+    if tie_strategy in ("FIRST", "MAX"):
+        assert result == 5
+    else:
+        assert result == 1
 
 
 ###############################################################################


### PR DESCRIPTION
## What does this PR do?

Adds a `TIE_STRATEGY` warping option to provide some control over the destination pixel value during "mode" resampling when multiple source values appear at the same frequency. The current behavior of choosing the first value encountered can introduce a spatial bias (favoring values from the north/west) that is undesirable in some applications. 

## What are related issues/pull requests?

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
