### PR TITLE
[Backport release/3.10] Python bindings: on Debian, fix install target with non-Debian provided python version

### DIFF
--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -454,7 +454,22 @@ if __name__ == '__main__':
     set(INSTALL_ARGS "${INSTALL_ARGS} --install-layout=${GDAL_PYTHON_INSTALL_LAYOUT}")
     set(SETUPTOOLS_USE_DISTUTILS stdlib)
   elseif ("${SITE_PACKAGE_DIR}" MATCHES "dist-packages")
-    set(INSTALL_ARGS "${INSTALL_ARGS} --install-layout=deb")
+
+    # We are running on Debian, but test if our setuptools version supports
+    # Debian --install-layout
+    # This might not be the case if using a regular (non-Debian patched) Python
+    # installation or setuptools (cf https://github.com/OSGeo/gdal/issues/11636)
+    execute_process(
+        COMMAND env GDAL_PYTHON_BINDINGS_WITHOUT_NUMPY=yes ${Python_EXECUTABLE_CMAKE} setup.py install --help
+        OUTPUT_VARIABLE SETUP_INSTALL_HELP
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    )
+    # If so, uses it.
+    if ("${SETUP_INSTALL_HELP}" MATCHES "install-layout")
+        set(INSTALL_ARGS "${INSTALL_ARGS} --install-layout=deb")
+    endif()
+
     if (NOT DEFINED GDAL_PYTHON_INSTALL_LIB AND "${PREFIX_FOR_TRIMMEDSYSCONFIG}" STREQUAL "/usr/local")
         # Scenario of https://github.com/OSGeo/gdal/issues/10242
         # For some reason patched setuptools of Debian fails to install by default

--- a/swig/python/install_python.cmake.in
+++ b/swig/python/install_python.cmake.in
@@ -1,4 +1,4 @@
-cmake_policy(VERSION 3.9)
+cmake_policy(VERSION 3.16)
 
 if(DEFINED ENV{DESTDIR})
   set(ROOT_DIR_ARG "--root=$ENV{DESTDIR}")


### PR DESCRIPTION
Backport #11637
 **Authored by:** @rouault