### PR TITLE
VRT: advertize expression dialects in 'ExpressionDialects' driver metadata item

### DIFF
--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -2140,20 +2140,4 @@ def error_raised(type, match=""):
 
 @functools.lru_cache()
 def gdal_has_vrt_expression_dialect(dialect):
-    with disable_exceptions(), gdal.quiet_errors():
-        vrt = f"""<VRTDataset rasterXSize="20" rasterYSize="20">
-          <VRTRasterBand dataType="Float64" band="1" subClass="VRTDerivedRasterBand">
-            <PixelFunctionType>expression</PixelFunctionType>
-            <PixelFunctionArguments expression="B1 + 5" dialect="{dialect}"/>
-            <ArraySource>
-                <Array name="test">
-                    <DataType>Float64</DataType>
-                    <Dimension name="Y" size="20"/>
-                    <Dimension name="X" size="20"/>
-                    <ConstantValue>10</ConstantValue>
-                </Array>
-            </ArraySource>
-          </VRTRasterBand>
-        </VRTDataset>"""
-        ds = gdal.Open(vrt)
-        return ds.ReadRaster() is not None
+    return dialect in gdal.GetDriverByName("VRT").GetMetadataItem("ExpressionDialects")

--- a/frmts/vrt/vrtdriver.cpp
+++ b/frmts/vrt/vrtdriver.cpp
@@ -552,6 +552,17 @@ void GDALRegister_VRT()
     poDriver->SetMetadataItem(GDAL_DCAP_VIRTUALIO, "YES");
     poDriver->SetMetadataItem(GDAL_DCAP_COORDINATE_EPOCH, "YES");
 
+    const char *pszExpressionDialects = "ExpressionDialects";
+#if defined(GDAL_VRT_ENABLE_MUPARSER) && defined(GDAL_VRT_ENABLE_EXPRTK)
+    poDriver->SetMetadataItem(pszExpressionDialects, "muparser,exprtk");
+#elif defined(GDAL_VRT_ENABLE_MUPARSER)
+    poDriver->SetMetadataItem(pszExpressionDialects, "muparser");
+#elif defined(GDAL_VRT_ENABLE_EXPRTK)
+    poDriver->SetMetadataItem(pszExpressionDialects, "exprtk");
+#else
+    poDriver->SetMetadataItem(pszExpressionDialects, "none");
+#endif
+
     poDriver->AddSourceParser("SimpleSource", VRTParseCoreSources);
     poDriver->AddSourceParser("ComplexSource", VRTParseCoreSources);
     poDriver->AddSourceParser("AveragedSource", VRTParseCoreSources);


### PR DESCRIPTION
This will make autotest simpler, as well as for end users / third party code that needs to determine the capabilities of the VRT driver

CC @dbaston