### PR TITLE
[gdal_contour] Do not include min/max when polygonize

### DIFF
--- a/alg/contour.cpp
+++ b/alg/contour.cpp
@@ -517,7 +517,9 @@ an averaged value from the two nearby points (in this case (12+3+5)/3).
  *   FIXED_LEVELS=f[,f]*
  *
  * The list of fixed contour levels at which contours should be generated.
- * This option has precedence on LEVEL_INTERVAL
+ * This option has precedence on LEVEL_INTERVAL. MIN and MAX can be used
+ * as special values to represent the minimum and maximum values of the
+ * raster.
  *
  *   NODATA=f
  *

--- a/alg/marching_squares/level_generator.h
+++ b/alg/marching_squares/level_generator.h
@@ -118,6 +118,11 @@ class FixedLevelRangeIterator
         return minLevel_;
     }
 
+    size_t levelsCount() const
+    {
+        return count_;
+    }
+
   private:
     const double *levels_;
     size_t count_;

--- a/alg/marching_squares/polygon_ring_appender.h
+++ b/alg/marching_squares/polygon_ring_appender.h
@@ -137,10 +137,14 @@ template <typename PolygonWriter> class PolygonRingAppender
 
     void addLine(double level, LineString &ls, bool)
     {
+        auto &levelRings = rings_[level];
+        if (ls.empty())
+        {
+            return;
+        }
         // Create a new ring from the LineString
         Ring newRing;
         newRing.points.swap(ls);
-        auto &levelRings = rings_[level];
         // This queue holds the rings to be checked
         std::deque<Ring *> queue;
         std::transform(levelRings.begin(), levelRings.end(),

--- a/alg/marching_squares/segment_merger.h
+++ b/alg/marching_squares/segment_merger.h
@@ -12,6 +12,7 @@
 #ifndef MARCHING_SQUARES_SEGMENT_MERGER_H
 #define MARCHING_SQUARES_SEGMENT_MERGER_H
 
+#include "cpl_error.h"
 #include "point.h"
 
 #include <list>
@@ -38,7 +39,7 @@ template <typename LineWriter, typename LevelGenerator> struct SegmentMerger
     SegmentMerger(LineWriter &lineWriter, const LevelGenerator &levelGenerator,
                   bool polygonize_)
         : polygonize(polygonize_), lineWriter_(lineWriter), lines_(),
-          levelGenerator_(levelGenerator)
+          levelGenerator_(levelGenerator), m_anSkipLevels()
     {
     }
 
@@ -56,6 +57,13 @@ template <typename LineWriter, typename LevelGenerator> struct SegmentMerger
         for (auto it = lines_.begin(); it != lines_.end(); ++it)
         {
             const int levelIdx = it->first;
+
+            // Skip levels that should be skipped
+            if (std::find(m_anSkipLevels.begin(), m_anSkipLevels.end(),
+                          levelIdx) != m_anSkipLevels.end())
+            {
+                continue;
+            }
             while (it->second.begin() != it->second.end())
             {
                 lineWriter_.addLine(levelGenerator_.level(levelIdx),
@@ -125,6 +133,23 @@ template <typename LineWriter, typename LevelGenerator> struct SegmentMerger
     SegmentMerger<LineWriter, LevelGenerator> &
     operator=(const SegmentMerger<LineWriter, LevelGenerator> &) = delete;
 
+    /**
+     * @brief setSkipLevels sets the levels that should be skipped
+     *        when polygonize option is set.
+     * @param anSkipLevels integer 0-based levels to skip.
+     */
+    void setSkipLevels(const std::vector<int> &anSkipLevels)
+    {
+        // Warn if polygonize is not set
+        if (!polygonize)
+        {
+            CPLError(
+                CE_Warning, CPLE_NotSupported,
+                "setSkipLevels is ignored when polygonize option is not set");
+        }
+        m_anSkipLevels = anSkipLevels;
+    }
+
     const bool polygonize;
 
   private:
@@ -133,8 +158,12 @@ template <typename LineWriter, typename LevelGenerator> struct SegmentMerger
     std::map<int, Lines> lines_;
     const LevelGenerator &levelGenerator_;
 
+    // Store 0-indexed levels to skip when polygonize option is set
+    std::vector<int> m_anSkipLevels;
+
     void addSegment_(int levelIdx, const Point &start, const Point &end)
     {
+
         Lines &lines = lines_[levelIdx];
 
         if (start == end)
@@ -257,11 +286,18 @@ template <typename LineWriter, typename LevelGenerator> struct SegmentMerger
     typename Lines::iterator emitLine_(int levelIdx,
                                        typename Lines::iterator it, bool closed)
     {
+
         Lines &lines = lines_[levelIdx];
         if (lines.empty())
             lines_.erase(levelIdx);
 
         // consume "it" and remove it from the list
+        // but clear the line if the level should be skipped
+        if (std::find(m_anSkipLevels.begin(), m_anSkipLevels.end(), levelIdx) !=
+            m_anSkipLevels.end())
+        {
+            it->ls.clear();
+        }
         lineWriter_.addLine(levelGenerator_.level(levelIdx), it->ls, closed);
         return lines.erase(it);
     }

--- a/apps/gdal_contour.cpp
+++ b/apps/gdal_contour.cpp
@@ -42,7 +42,7 @@ struct GDALContourOptions
     std::string osElevAttrib;
     std::string osElevAttribMin;
     std::string osElevAttribMax;
-    std::vector<double> adfFixedLevels;
+    std::vector<std::string> aosFixedLevels;
     CPLStringList aosOpenOptions;
     CPLStringList aosCreationOptions;
     bool bQuiet = false;
@@ -140,7 +140,7 @@ GDALContourAppOptionsGetParser(GDALContourOptions *psOptions)
                 "integer."));
 
     // Dealt manually as argparse::nargs_pattern::at_least_one is problematic
-    argParser->add_argument("-fl").scan<'g', double>().metavar("<level>").help(
+    argParser->add_argument("-fl").metavar("<level>").help(
         _("Name one or more \"fixed levels\" to extract."));
 
     argParser->add_argument("-off")
@@ -262,22 +262,49 @@ MAIN_START(argc, argv)
                         CSLTokenizeString(argv[i + 1]));
                     for (const char *pszToken : aosTokens)
                     {
-                        sOptions.adfFixedLevels.push_back(CPLAtof(pszToken));
+                        // Handle min/max special values
+                        if (EQUAL(pszToken, "MIN"))
+                        {
+                            sOptions.aosFixedLevels.push_back("MIN");
+                        }
+                        else if (EQUAL(pszToken, "MAX"))
+                        {
+                            sOptions.aosFixedLevels.push_back("MAX");
+                        }
+                        else
+                        {
+                            sOptions.aosFixedLevels.push_back(
+                                std::to_string(CPLAtof(pszToken)));
+                        }
                     }
                     i += 1;
                 }
                 else
                 {
-                    auto isNumeric = [](const char *pszArg) -> bool
+                    auto isNumericOrMinMax = [](const char *pszArg) -> bool
                     {
+                        if (EQUAL(pszArg, "MIN") || EQUAL(pszArg, "MAX"))
+                            return true;
                         char *pszEnd = nullptr;
                         CPLStrtod(pszArg, &pszEnd);
                         return pszEnd != nullptr && pszEnd[0] == '\0';
                     };
 
-                    while (i < argc - 1 && isNumeric(argv[i + 1]))
+                    while (i < argc - 1 && isNumericOrMinMax(argv[i + 1]))
                     {
-                        sOptions.adfFixedLevels.push_back(CPLAtof(argv[i + 1]));
+                        if (EQUAL(argv[i + 1], "MIN"))
+                        {
+                            sOptions.aosFixedLevels.push_back("MIN");
+                        }
+                        else if (EQUAL(argv[i + 1], "MAX"))
+                        {
+                            sOptions.aosFixedLevels.push_back("MAX");
+                        }
+                        else
+                        {
+                            sOptions.aosFixedLevels.push_back(
+                                std::to_string(CPLAtof(argv[i + 1])));
+                        }
                         i += 1;
                     }
                 }
@@ -291,7 +318,7 @@ MAIN_START(argc, argv)
         auto argParser = GDALContourAppOptionsGetParser(&sOptions);
         argParser->parse_args_without_binary_name(aosArgv.List());
 
-        if (sOptions.dfInterval == 0.0 && sOptions.adfFixedLevels.empty() &&
+        if (sOptions.dfInterval == 0.0 && sOptions.aosFixedLevels.empty() &&
             sOptions.dfExpBase == 0.0)
         {
             fprintf(stderr, "%s\n", argParser->usage().c_str());
@@ -465,24 +492,19 @@ MAIN_START(argc, argv)
                                    sOptions.osElevAttribMax.c_str());
 
     char **options = nullptr;
-    if (!sOptions.adfFixedLevels.empty())
+    if (!sOptions.aosFixedLevels.empty())
     {
         std::string values = "FIXED_LEVELS=";
-        for (size_t i = 0; i < sOptions.adfFixedLevels.size(); i++)
+        for (size_t i = 0; i < sOptions.aosFixedLevels.size(); i++)
         {
-            const int sz = 32;
-            char *newValue = new char[sz + 1];
-            if (i == sOptions.adfFixedLevels.size() - 1)
+            if (i == sOptions.aosFixedLevels.size() - 1)
             {
-                CPLsnprintf(newValue, sz + 1, "%f", sOptions.adfFixedLevels[i]);
+                values = values + sOptions.aosFixedLevels[i];
             }
             else
             {
-                CPLsnprintf(newValue, sz + 1, "%f,",
-                            sOptions.adfFixedLevels[i]);
+                values = values + sOptions.aosFixedLevels[i] + ",";
             }
-            values = values + std::string(newValue);
-            delete[] newValue;
         }
         options = CSLAddString(options, values.c_str());
     }

--- a/autotest/cpp/test_marching_squares_polygon.cpp
+++ b/autotest/cpp/test_marching_squares_polygon.cpp
@@ -287,37 +287,75 @@ TEST_F(test_ms_polygon, four_pixels_2)
     //  NaN                 NaN                NaN                NaN
 
     std::vector<double> data = {155.0, 155.01, 154.99, 155.0};
-    TestPolygonWriter w;
     {
-        PolygonRingAppender<TestPolygonWriter> appender(w);
-        const double levels[] = {155.0};
-        FixedLevelRangeIterator levelGenerator(
-            levels, 1, -std::numeric_limits<double>::infinity(),
-            std::numeric_limits<double>::infinity());
-        SegmentMerger<PolygonRingAppender<TestPolygonWriter>,
-                      FixedLevelRangeIterator>
-            writer(appender, levelGenerator, /* polygonize */ true);
-        ContourGenerator<decltype(writer), FixedLevelRangeIterator> cg(
-            2, 2, false, NaN, writer, levelGenerator);
-        cg.feedLine(&data[0]);
-        cg.feedLine(&data[2]);
+        TestPolygonWriter w;
+        {
+            PolygonRingAppender<TestPolygonWriter> appender(w);
+            const double levels[] = {155.0};
+            FixedLevelRangeIterator levelGenerator(
+                levels, 1, -std::numeric_limits<double>::infinity(),
+                std::numeric_limits<double>::infinity());
+            SegmentMerger<PolygonRingAppender<TestPolygonWriter>,
+                          FixedLevelRangeIterator>
+                writer(appender, levelGenerator, /* polygonize */ true);
+            ContourGenerator<decltype(writer), FixedLevelRangeIterator> cg(
+                2, 2, false, NaN, writer, levelGenerator);
+            cg.feedLine(&data[0]);
+            cg.feedLine(&data[2]);
+        }
+        EXPECT_EQ(w.polygons_.size(), 2);
+        {
+            std::ostringstream ostr;
+            w.out(ostr, 155.0);
+            // "Polygon #0"
+            EXPECT_EQ(
+                ostr.str(),
+                "{ { (1.4999,2) (1.4999,1.5) (0.5,0.5001) (0,0.5001) (0,1) "
+                "(0,1.5) (0,2) (0.5,2) (1,2) (1.4999,2) } } ");
+        }
+        {
+            std::ostringstream ostr;
+            w.out(ostr, Inf);
+            // "Polygon #1"
+            EXPECT_EQ(
+                ostr.str(),
+                "{ { (1.5,2) (2,2) (2,1.5) (2,1) (2,0.5) (2,0) (1.5,0) (1,0) "
+                "(0.5,0) (0,0) (0,0.5) (0,0.5001) (0.5,0.5001) (1.4999,1.5) "
+                "(1.4999,2) (1.5,2) } } ");
+        }
     }
+
     {
-        std::ostringstream ostr;
-        w.out(ostr, 155.0);
-        // "Polygon #0"
-        EXPECT_EQ(ostr.str(),
-                  "{ { (1.4999,2) (1.4999,1.5) (0.5,0.5001) (0,0.5001) (0,1) "
-                  "(0,1.5) (0,2) (0.5,2) (1,2) (1.4999,2) } } ");
-    }
-    {
-        std::ostringstream ostr;
-        w.out(ostr, Inf);
-        // "Polygon #1"
-        EXPECT_EQ(ostr.str(),
-                  "{ { (1.5,2) (2,2) (2,1.5) (2,1) (2,0.5) (2,0) (1.5,0) (1,0) "
-                  "(0.5,0) (0,0) (0,0.5) (0,0.5001) (0.5,0.5001) (1.4999,1.5) "
-                  "(1.4999,2) (1.5,2) } } ");
+        TestPolygonWriter w;
+        {
+            PolygonRingAppender<TestPolygonWriter> appender(w);
+            const double levels[] = {155.0};
+            FixedLevelRangeIterator levelGenerator(
+                levels, 1, -std::numeric_limits<double>::infinity(),
+                std::numeric_limits<double>::infinity());
+            SegmentMerger<PolygonRingAppender<TestPolygonWriter>,
+                          FixedLevelRangeIterator>
+                writer(appender, levelGenerator, /* polygonize */ true);
+            writer.setSkipLevels({1});
+            ContourGenerator<decltype(writer), FixedLevelRangeIterator> cg(
+                2, 2, false, NaN, writer, levelGenerator);
+            cg.feedLine(&data[0]);
+            cg.feedLine(&data[2]);
+        }
+        {
+            EXPECT_EQ(w.polygons_.size(), 2);
+            EXPECT_EQ(w.polygons_.find(Inf)->second.size(), 0);
+        }
+
+        {
+            std::ostringstream ostr;
+            w.out(ostr, 155.0);
+            // "Polygon #0"
+            EXPECT_EQ(
+                ostr.str(),
+                "{ { (1.4999,2) (1.4999,1.5) (0.5,0.5001) (0,0.5001) (0,1) "
+                "(0,1.5) (0,2) (0.5,2) (1,2) (1.4999,2) } } ");
+        }
     }
 }
 

--- a/doc/source/programs/gdal_contour.rst
+++ b/doc/source/programs/gdal_contour.rst
@@ -94,7 +94,7 @@ be on the right, i.e. a line string goes clockwise around a top.
 .. option:: -i <interval>
 
     Elevation interval between contours.
-    Must specify either -i or -fl or -e.
+    Must specify either :option:`-i` or :option:`-fl` or :option:`-e`.
 
 .. option:: -off <offset>
 
@@ -105,7 +105,7 @@ be on the right, i.e. a line string goes clockwise around a top.
 
 .. option:: -fl <level>
 
-    Name one or more "fixed levels" to extract.
+    Name one or more "fixed levels" to extract, in ascending order separated by spaces.
 
 .. option:: -e <base>
 
@@ -121,6 +121,15 @@ be on the right, i.e. a line string goes clockwise around a top.
 .. option:: -p
 
     Generate contour polygons rather than contour lines.
+
+    When this mode is selected the polygons are created for values between
+    each level specified by :option:`-i` or :option:`-fl` or :option:`-e`,
+    in case :option:`-fl` is used alone at least two fixed levels must be specified.
+
+    The minimum and maximum values from the raster are not automatically added to
+    the fixed levels list but the special values `MIN`` and `MAX`` (case insensitive)
+    can be used to include them.
+
 
     .. versionadded:: 2.4.0
 
@@ -146,12 +155,111 @@ Examples
 --------
 
 .. example::
-   :title: Creating contours from a DEM
 
-   .. code-block::
+    :title: Creating contours from a DEM
 
-       gdal_contour -a elev dem.tif contour.shp -i 10.0
+    .. code-block::
 
-   This would create 10-meter contours from the DEM data in :file:`dem.tif` and
-   produce a shapefile in :file:`contour.shp|shx|dbf` with the contour elevations
-   in the ``elev`` attribute.
+        gdal_contour -a elev dem.tif contour.shp -i 10.0
+
+    This would create 10-meter contours from the DEM data in :file:`dem.tif` and
+    produce a shapefile in :file:`contour.shp|shx|dbf` with the contour elevations
+    in the ``elev`` attribute.
+
+.. example::
+
+    :title: Creating polygonal contours from a DEM
+
+    .. code-block:: bash
+
+        $ cat test.asc
+        ncols        2
+        nrows        2
+        xllcorner    0
+        yllcorner    0
+        cellsize     1
+        4 15
+        25 36
+
+        $ gdal_contour test.asc -f GeoJSON /vsistdout/ -i 10 -p -amin min -amax max
+
+    This would create 10-meter polygonal contours from the DEM data in :file:`test.asc`
+    and produce a GeoJSON output with the contour min and max elevations in the ``min``
+    and ``max`` attributes, not including the minimum and maximum values from the raster.
+
+    .. code-block:: bash
+
+        {
+            "type": "FeatureCollection",
+            "name": "contour",
+            "features": [
+            { "type": "Feature", "properties": { "ID": 0, "min": 4.0, "max": 10.0 }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ 0.5, 1.214285714285714 ], [ 1.045454545454545, 1.5 ], [ 1.045454545454545, 2.0 ], [ 1.0, 2.0 ], [ 0.5, 2.0 ], [ 0.0, 2.0 ], [ 0.0, 1.5 ], [ 0.0, 1.214285714285714 ], [ 0.5, 1.214285714285714 ] ] ] ] } },
+            { "type": "Feature", "properties": { "ID": 1, "min": 10.0, "max": 20.0 }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ 1.5, 1.261904761904762 ], [ 2.0, 1.261904761904762 ], [ 2.0, 1.5 ], [ 2.0, 2.0 ], [ 1.5, 2.0 ], [ 1.045454545454545, 2.0 ], [ 1.045454545454545, 1.5 ], [ 0.5, 1.214285714285714 ], [ 0.0, 1.214285714285714 ], [ 0.0, 1.0 ], [ 0.0, 0.738095238095238 ], [ 0.5, 0.738095238095238 ], [ 1.5, 1.261904761904762 ] ] ] ] } },
+            { "type": "Feature", "properties": { "ID": 2, "min": 20.0, "max": 30.0 }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ 0.954545454545455, 0.0 ], [ 0.954545454545455, 0.5 ], [ 1.5, 0.785714285714286 ], [ 2.0, 0.785714285714286 ], [ 2.0, 1.0 ], [ 2.0, 1.261904761904762 ], [ 1.5, 1.261904761904762 ], [ 0.5, 0.738095238095238 ], [ 0.0, 0.738095238095238 ], [ 0.0, 0.5 ], [ 0.0, 0.0 ], [ 0.5, 0.0 ], [ 0.954545454545455, 0.0 ] ] ] ] } },
+            { "type": "Feature", "properties": { "ID": 3, "min": 30.0, "max": 36.0 }, "geometry": { "type": "MultiPolygon", "coordinates": [ [ [ [ 1.499999909090926, 0.0 ], [ 1.0, 0.0 ], [ 0.954545454545455, 0.0 ], [ 0.954545454545455, 0.5 ], [ 1.5, 0.785714285714286 ], [ 2.0, 0.785714285714286 ], [ 2.0, 0.500000047619043 ], [ 1.5, 0.500000047619043 ], [ 1.499999909090926, 0.5 ], [ 1.499999909090926, 0.0 ] ] ] ] } }
+            ]
+        }
+
+.. example::
+
+    :title: Creating contours from a DEM with fixed levels
+
+    .. code-block:: bash
+
+        $ cat test.asc
+        ncols        2
+        nrows        2
+        xllcorner    0
+        yllcorner    0
+        cellsize     1
+        4 15
+        25 36
+
+        $ gdal_contour test.asc -f GeoJSON /vsistdout/ -fl 10 20 -p -amin min -amax max
+
+    This would create a single polygonal contour between 10 and 20 meters from the DEM data in :file:`test.asc`
+    and produce a GeoJSON output with the contour min and max elevations in the ``min`` and ``max`` attributes.
+.
+
+    If the minimum and maximum values from the raster are desired, the special values `MIN`` and `MAX``
+    (case insensitive) can be used:
+
+    .. code-block:: bash
+
+        $ cat test.asc
+        ncols        2
+        nrows        2
+        xllcorner    0
+        yllcorner    0
+        cellsize     1
+        4 15
+        25 36
+
+        $ gdal_contour test.asc -f GeoJSON /vsistdout/ -fl MIN 10 20 MAX -p -amin min -amax max
+
+    This would create three polygonal contours from the DEM data in :file:`test.asc` and produce a GeoJSON output
+    with the contour min and max elevations in the ``min`` and ``max`` attributes, the values of these fields will
+    be: (4.0, 10.0), (10, 20.0) and (20, 36.0).
+
+.. example::
+
+    :title: Creating contours from a DEM specifying an interval and fixed levels at the same time
+
+    .. code-block:: bash
+
+        $ cat test.asc
+        ncols        2
+        nrows        2
+        xllcorner    0
+        yllcorner    0
+        cellsize     1
+        4 15
+        25 36
+
+        $ gdal_contour test.asc -f GeoJSON /vsistdout/ -i 10 -fl 15 -p -amin min -amax max
+
+    This would create 10-meter polygonal contours from the DEM data in :file:`test.asc` and produce a GeoJSON output
+    with the contour min and max elevations in the ``min`` and ``max`` attributes, the values of these fields will
+    be: (4.0, 10.0), (10, 15.0), (15, 20.0)  and (20, 36.0).
+
+

--- a/doc/source/programs/gdal_contour.rst
+++ b/doc/source/programs/gdal_contour.rst
@@ -219,7 +219,7 @@ Examples
 
     This would create a single polygonal contour between 10 and 20 meters from the DEM data in :file:`test.asc`
     and produce a GeoJSON output with the contour min and max elevations in the ``min`` and ``max`` attributes.
-.
+
 
     If the minimum and maximum values from the raster are desired, the special values `MIN`` and `MAX``
     (case insensitive) can be used:
@@ -239,7 +239,7 @@ Examples
 
     This would create three polygonal contours from the DEM data in :file:`test.asc` and produce a GeoJSON output
     with the contour min and max elevations in the ``min`` and ``max`` attributes, the values of these fields will
-    be: (4.0, 10.0), (10, 20.0) and (20, 36.0).
+    be: (4.0, 10.0), (10, 20.0) and (20.0, 36.0).
 
 .. example::
 
@@ -258,8 +258,9 @@ Examples
 
         $ gdal_contour test.asc -f GeoJSON /vsistdout/ -i 10 -fl 15 -p -amin min -amax max
 
-    This would create 10-meter polygonal contours from the DEM data in :file:`test.asc` and produce a GeoJSON output
-    with the contour min and max elevations in the ``min`` and ``max`` attributes, the values of these fields will
-    be: (4.0, 10.0), (10, 15.0), (15, 20.0)  and (20, 36.0).
+    Creates contours at regular 10 meter intervals and adds extra contour for a fixed 15 m level.
+    Finally turns areas between the contours into polygons  with the contour min and max elevations
+    in the ``min`` and ``max`` attributes, the values of these fields will be:
+    (4.0, 10.0), (10, 15.0), (15, 20.0), (20.0, 30.0)  and (30.0, 36.0).
 
 

--- a/doc/source/programs/gdal_contour.rst
+++ b/doc/source/programs/gdal_contour.rst
@@ -185,7 +185,7 @@ Examples
 
     This would create 10-meter polygonal contours from the DEM data in :file:`test.asc`
     and produce a GeoJSON output with the contour min and max elevations in the ``min``
-    and ``max`` attributes, not including the minimum and maximum values from the raster.
+    and ``max`` attributes, including the minimum and maximum values from the raster.
 
     .. code-block:: bash
 


### PR DESCRIPTION
Fixes #11564 by not including raster min/max when polygonize and fixed levels are specified.

MIN and MAX literals can be used to specify raster min/max values, e.g.:

-fl MIN 10 20 30 MAX

