### PR TITLE
[GPKG] Fix crash in GPKG rollback after PR #11609

### DIFF
--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -9721,7 +9721,8 @@ OGRErr GDALGeoPackageDataset::RollbackTransaction()
         }
     }
 
-    OGRErr eErr = OGRSQLiteBaseDataSource::RollbackTransaction();
+    const OGRErr eErr = OGRSQLiteBaseDataSource::RollbackTransaction();
+
 #ifdef ENABLE_GPKG_OGR_CONTENTS
     if (!abAddTriggers.empty())
     {

--- a/ogr/ogrsf_frmts/ogrsf_frmts.h
+++ b/ogr/ogrsf_frmts/ogrsf_frmts.h
@@ -285,8 +285,8 @@ class CPL_DLL OGRLayer : public GDALMajorObject
 
     //! @cond Doxygen_Suppress
     // Keep field definitions in sync with transactions
-    void PrepareStartTransaction();
-    void FinishRollbackTransaction();
+    virtual void PrepareStartTransaction();
+    virtual void FinishRollbackTransaction();
     //! @endcond
 
     virtual const char *GetFIDColumn();
@@ -414,15 +414,17 @@ class CPL_DLL OGRLayer : public GDALMajorObject
     {
 
         FieldDefnChange(std::unique_ptr<T> &&poFieldDefnIn, int iFieldIn,
-                        FieldChangeType eChangeTypeIn)
+                        FieldChangeType eChangeTypeIn, bool bGeneratedIn)
             : poFieldDefn(std::move(poFieldDefnIn)), iField(iFieldIn),
-              eChangeType(eChangeTypeIn)
+              eChangeType(eChangeTypeIn), bGenerated(bGeneratedIn)
         {
         }
 
         std::unique_ptr<T> poFieldDefn;
         int iField;
         FieldChangeType eChangeType;
+        // Used by drivers (GPKG) to track generated fields
+        bool bGenerated;
     };
 
     std::vector<FieldDefnChange<OGRFieldDefn>> m_apoFieldDefnChanges{};

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
@@ -4023,6 +4023,12 @@ OGRErr OGRSQLiteBaseDataSource::StartTransaction(CPL_UNUSED int bForce)
         return OGRERR_FAILURE;
     }
 
+    for (int i = 0; i < GetLayerCount(); i++)
+    {
+        OGRLayer *poLayer = GetLayer(i);
+        poLayer->PrepareStartTransaction();
+    }
+
     OGRErr eErr = SoftStartTransaction();
     if (eErr != OGRERR_NONE)
         return eErr;
@@ -4041,8 +4047,6 @@ OGRErr OGRSQLiteDataSource::StartTransaction(int bForce)
                 cpl::down_cast<OGRSQLiteTableLayer *>(poLayer.get());
             poTableLayer->RunDeferredCreationIfNecessary();
         }
-
-        poLayer->PrepareStartTransaction();
     }
 
     return OGRSQLiteBaseDataSource::StartTransaction(bForce);

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitetablelayer.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitetablelayer.cpp
@@ -1617,7 +1617,8 @@ OGRErr OGRSQLiteTableLayer::CreateField(const OGRFieldDefn *poFieldIn,
     {
         m_apoFieldDefnChanges.emplace_back(
             std::make_unique<OGRFieldDefn>(oField),
-            m_poFeatureDefn->GetFieldCount() - 1, FieldChangeType::ADD_FIELD);
+            m_poFeatureDefn->GetFieldCount() - 1, FieldChangeType::ADD_FIELD,
+            /* bGenerated */ false);
     }
 
     if (m_pszFIDColumn != nullptr && EQUAL(oField.GetNameRef(), m_pszFIDColumn))
@@ -1723,7 +1724,8 @@ OGRSQLiteTableLayer::CreateGeomField(const OGRGeomFieldDefn *poGeomFieldIn,
     {
         m_apoGeomFieldDefnChanges.emplace_back(
             std::make_unique<OGRGeomFieldDefn>(*poGeomField),
-            m_poFeatureDefn->GetGeomFieldCount(), FieldChangeType::ADD_FIELD);
+            m_poFeatureDefn->GetGeomFieldCount(), FieldChangeType::ADD_FIELD,
+            /* bGenerated */ false);
     }
 
     m_poFeatureDefn->AddGeomFieldDefn(std::move(poGeomField));
@@ -2177,7 +2179,7 @@ OGRErr OGRSQLiteTableLayer::DeleteField(int iFieldToDelete)
                 {
                     m_apoFieldDefnChanges.emplace_back(
                         std::move(poFieldDefn), iFieldToDelete,
-                        FieldChangeType::DELETE_FIELD);
+                        FieldChangeType::DELETE_FIELD, false);
                 }
                 else
                 {
@@ -2414,7 +2416,7 @@ OGRErr OGRSQLiteTableLayer::AlterFieldDefn(int iFieldToAlter,
     {
         m_apoFieldDefnChanges.emplace_back(
             std::make_unique<OGRFieldDefn>(poFieldDefn), iFieldToAlter,
-            FieldChangeType::ALTER_FIELD);
+            FieldChangeType::ALTER_FIELD, /* bGenerated */ false);
     }
 
     if (nActualFlags & ALTER_TYPE_FLAG)


### PR DESCRIPTION
Hopefully Fix #11679

Take care of syncing the array of generated
columns when rolling back.

I've made PrepareStartTransaction and FinishRollbackTransaction virtual for consistency with other methods of the same base class because I can foresee cases were we will need to override.