### PR TITLE
CI: gdal-master conda upload: harden script to detect errors

### DIFF
--- a/.github/workflows/conda.yml
+++ b/.github/workflows/conda.yml
@@ -80,10 +80,10 @@ jobs:
         path: ./gdal-feedstock/packages/
 
     - name: Deploy to gdal-master Conda channel
-      if: github.ref == 'refs/heads/master'
+      if: github.repository == 'OSGeo/GDAL' && github.ref == 'refs/heads/master'
       shell: bash -l {0}
       env:
         ANACONDA_TOKEN: ${{ secrets.ANACONDA_TOKEN }}
       run: |
-          source ../ci/travis/conda/upload.sh || true
+          source ../ci/travis/conda/upload.sh
       working-directory: ./gdal-feedstock

--- a/ci/travis/conda/upload.sh
+++ b/ci/travis/conda/upload.sh
@@ -1,20 +1,22 @@
 #!/bin/bash
 
+set -e
 
 if [ -z "${ANACONDA_TOKEN+x}" ]
 then
-    echo "Anaconda token is not set, not uploading"
-    exit 0;
+    echo "Anaconda token is not set!"
+    exit 1
 fi
 
 ls
 pwd
 find .
 
-if [ -z "${ANACONDA_TOKEN}" ]
-then
-    echo "Anaconda token is empty, not uploading"
-    exit 0;
+if [[ -n $(find . -name "*gdal*.conda") ]]; then
+  echo "Found packages to upload"
+else
+  echo "No packages matching *gdal*.conda to upload found"
+  exit 1
 fi
 
 echo "Anaconda token is available, attempting to upload"


### PR DESCRIPTION
As shown in https://github.com/OSGeo/gdal/issues/11676 our current strategy is to always consider the upload stage to have succeeded. Change that to fail on errors, or lack of packages to upload.
