### PR TITLE
Handle MultiPoints in DXF writer (fixes #11686)

### DIFF
--- a/autotest/ogr/ogr_dxf.py
+++ b/autotest/ogr/ogr_dxf.py
@@ -423,7 +423,7 @@ def test_ogr_dxf_11():
 
 
 ###############################################################################
-# Write a simple file with a polygon and a line, and read back.
+# Write a simple file with a few geometries of different types, and read back.
 
 
 def test_ogr_dxf_12(tmp_path):
@@ -463,6 +463,14 @@ def test_ogr_dxf_12(tmp_path):
     dst_feat = ogr.Feature(feature_def=lyr.GetLayerDefn())
     dst_feat.SetGeometryDirectly(
         ogr.CreateGeometryFromWkt("LINESTRING(1 2 -10,3 4 10)")
+    )
+    lyr.CreateFeature(dst_feat)
+    dst_feat = None
+
+    # Test multipoint
+    dst_feat = ogr.Feature(feature_def=lyr.GetLayerDefn())
+    dst_feat.SetGeometryDirectly(
+        ogr.CreateGeometryFromWkt("MULTIPOINT((10 40),(40 30))")
     )
     lyr.CreateFeature(dst_feat)
     dst_feat = None
@@ -514,8 +522,23 @@ def test_ogr_dxf_12(tmp_path):
     ), feat.GetGeometryRef().ExportToWkt()
     feat = None
 
+    # Check 5th feature (1st multipoint part)
+    feat = lyr.GetNextFeature()
+
+    ogrtest.check_feature_geometry(
+        feat, "POINT(10 40)"
+    ), feat.GetGeometryRef().ExportToWkt()
+    feat = None
+
+    # Check 6th feature (2nd multipoint part)
+    feat = lyr.GetNextFeature()
+
+    ogrtest.check_feature_geometry(
+        feat, "POINT(40 30)"
+    ), feat.GetGeometryRef().ExportToWkt()
+    feat = None
+
     lyr = None
-    ds = None
     ds = None
 
 

--- a/ogr/ogrsf_frmts/dxf/ogrdxfwriterlayer.cpp
+++ b/ogr/ogrsf_frmts/dxf/ogrdxfwriterlayer.cpp
@@ -1278,7 +1278,7 @@ OGRErr OGRDXFWriterLayer::ICreateFeature(OGRFeature *poFeature)
     }
 
     // Explode geometry collections into multiple entities.
-    else if (eGType == wkbGeometryCollection)
+    else if (eGType == wkbGeometryCollection || eGType == wkbMultiPoint)
     {
         OGRGeometryCollection *poGC =
             poFeature->StealGeometry()->toGeometryCollection();


### PR DESCRIPTION
 <!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?
Adds support for writing MultiPoints by DXF driver.
#11686 
## What are related issues/pull requests?
It comes from this [thread](https://www.mail-archive.com/gdal-dev@lists.osgeo.org/msg42154.html).

## Tasklist

 - [ ] ADD YOUR TASKS HERE
 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
