### PR TITLE
Add coordinate system retrieve for DWG using ODA (fixes https://github.com/OSGeo/gdal/issues/11672) 

### DIFF
--- a/doc/source/drivers/vector/dwg.rst
+++ b/doc/source/drivers/vector/dwg.rst
@@ -14,8 +14,9 @@ DWG driver work similarly to the OGR DXF driver which shares a common
 data model. The entire contents of the .dwg file is represented as a
 single layer named "entities".
 
-DWG files are considered to have no georeferencing information through
-OGR. Features will all have the following generic attributes:
+DWG files georeferencing information can be retrieved through OGR using ODA ; when CSMap dictionaries for ODA are correctly set up (see :ref:`ODA platform support <vector.oda>` "Adding ODA Geodata capabilities" section).
+
+Features will all have the following generic attributes:
 
 -  Layer: The name of the DXF layer. The default layer is "0".
 -  SubClasses: Where available, a list of classes to which an element

--- a/doc/source/drivers/vector/oda.rst
+++ b/doc/source/drivers/vector/oda.rst
@@ -17,7 +17,7 @@ Since Kernel SDK is required by all products, these two products must be downloa
 
 These libraries are not publicly available. You have to became a member to get access to the libraries. 
 Upon authentication the libraries are available from: 
-`ODA Member Downloads <https://www.opendesign.com/members/memberfiles>`__
+`ODA Member Downloads <https://account.opendesign.com/downloads>`__
 
 Get the libraries
 -----------------
@@ -26,24 +26,24 @@ To selected the appropriate files to download, consider the following ODA name c
 
 -  lnx - Linux
 -  X86, X64 - indicates X86 or X64 platform
--  4.4, 4.7, 4.8, 4.9, 5.2, 5.3, 6.3, 7.2, 8.3 - GCC versions
+-  8.3, 10.2, 11, 12, 13 - GCC versions
 -  dll - indicates a shared library version
 -  pic - compiled with Position Independent Code option
 
-ODA archives also contains a release suffix in order to distinguish between releases, like 21.2 or 21.6.
+ODA archives also contains a release suffix in order to distinguish between releases, like 2025.8 or 2025.12
 
 To download the required files for Linux, the following files could be downloaded:
 
--  `Kernel_lnxX64_7.2dll_21.6.tar.gz`
--  `Drawings_lnxX64_7.2dll_21.6.tar.gz`
+-  `Kernel_lnxX64_13dll_25.12.tar.gz`
+-  `Drawings_lnxX64_13dll_25.12.tar.gz`
 
 In this example, the files names are:
 
 -  `lnx` for Linux
 -  `X64` for X64 architecture
--  `7.2` for gcc 7.2
+-  `13` for gcc 7.2
 -  `dll` for shared library version
--  `21.6` ODA 2021 release, build 6
+-  `2025.12` ODA 2025 release, build 12
 
 Compiling the libraries
 -----------------------
@@ -52,27 +52,27 @@ The libraries must be merged before compiling.
 
 .. code:: bash
 
-   cd ~/dev/cpp/ODA21.6
-   mkdir base_7.2
-   tar xvzf Kernel_lnxX64_7.2dll_21.6.tar.gz -C base_7.2
-   tar xvzf Drawings_lnxX64_7.2dll_21.6.tar.gz -C base_7.2
+   cd ~/dev/cpp/ODA25.12
+   mkdir Oda_25_12
+   tar xvzf Kernel_lnxX64_13dll_25.12.tar.gz -C Oda_25_12
+   tar xvzf Drawings_lnxX64_13dll_25.12.tar.gz -C Oda_25_12
 
 To compile, an activation key is required. It can be requested from ODA Products Activation. 
 The activation key must be copied to `ThirdParty/activation/`.
 
 ::
 
-   cp OdActivationInfo base_7.2/ThirdParty/activation/
+   cp OdActivationInfo Oda_25_12/ThirdParty/activation/
 
 Compile the ODA libraries with:
 
 ::
 
-   cd base_7.2
+   cd Oda_25_12
    ./configure
    make -j8
 
-Make sure your gcc major version matches ODA libs gcc version. On Ubuntu, for example, you can install different gcc/g++ versions, like 7, 8 and 9. Switch between them with:
+Make sure your gcc major version matches ODA libs gcc version. On Ubuntu, for example, you can install different gcc/g++ versions, like 8, 10, 11, 12, 13. Switch between them with:
 
 ::
 
@@ -89,9 +89,9 @@ This might be an issue.
 You have different alternative options to compile and run GDAL/OGR with ODA:
 
 -  copy the ODA libraries to a standard location
--  set LD_LIBRARY_PATH (like `LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/jgr/dev/cpp/ODA21.6/base_7.2/bin/lnxX64_7.2dll`).
--  Adding ODA folder to the system library path (`echo "/home/jgr/dev/cpp/ODA21.6/base_7.2/bin/lnxX64_7.2dll" | sudo tee -a /etc/ld.so.conf.d/z_gdal-ODA.conf`)
--  Setting a run time path (`rpath`) when compiling GDAL (like `LDFLAGS="-Wl,-rpath=/home/jgr/dev/cpp/ODA21.6/base_7.2/bin/lnxX64_7.2dll"`).
+-  set LD_LIBRARY_PATH (like `LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/jgr/dev/cpp/ODA21.6/Oda_25_12/bin/lnxX64_25.12dll`).
+-  Adding ODA folder to the system library path (`echo "/home/jgr/dev/cpp/ODA21.6/Oda_25_12/bin/lnxX64_25.12dll" | sudo tee -a /etc/ld.so.conf.d/z_gdal-ODA.conf`)
+-  Setting a run time path (`rpath`) when compiling GDAL (like `LDFLAGS="-Wl,-rpath=/home/jgr/dev/cpp/ODA21.6/Oda_25_12/bin/lnxX64_25.12dll"`).
 
 
 ODA library names
@@ -100,7 +100,7 @@ Some ODA library names do not conform the usual Linux standard `lib*.so`. If you
 
 ::
 
-   cd ~/dev/cpp/ODA21.6/base_7.2/bin/lnxX64_7.2dll
+   cd ~/dev/cpp/ODA25.12/Oda_25_12/bin/lnxX64_25.12dll
    for f in *.tx
    do
       echo "Processing $f"
@@ -114,19 +114,19 @@ Check with `ldconfig -v` if all ODA libraries are now visible.
 Compiling GDAL
 --------------
 
-After compiling ODA libraries, GDAL can be build using two additional options:
+After compiling ODA libraries, GDAL can be build using three additional options:
 
--  `--with-teigha=/home/jgr/dev/cpp/ODA21.6/base_7.2`
--  `--with-teigha-plt=lnxX64_7.2dll`
+-  `-DTEIGHA_ROOT="/home/jgr/dev/cpp/ODA21.6/Oda_25_12" `
+-  `-DTEIGHA_PLATFORM="lnxX64_13dll" `
+-  `-DTEIGHA_ACTIVATION_FILE_DIRECTORY="/home/jgr/dev/cpp/ODA21.6/Oda_25_12/ThirdParty/Activation"`
 
-The value of `--with-teigha` is the full path of the folder where the libraries were merged and compiled.
+The value of `-DTEIGHA_ROOT` is the full path of the folder where the libraries were merged and compiled.
+The value of `-DTEIGHA_PLATFORM` must match the platform name used by ODA. The platform name is the folder name under `Platforms`:
 
-The value of `--with-teigha-plt` must match the platform name used by ODA. The platform name is the folder name under `Platforms`:
-
-::
-
-   ls -l Platforms/
+:: ls -l Platforms/
    lnxX64_7.2dll
+
+The value of `-DTEIGHA_ACTIVATION_FILE_DIRECTORY` is the full path of the folder where the OdActivationInfo file was copied.
 
 GDAL compilation
 ----------------
@@ -139,7 +139,7 @@ As an example, compiling GDAL can be:
 
    cd gdal
    ./autogen.sh
-   ./configure --without-libtool LDFLAGS="-L/usr/lib/x86_64-linux-gnu" --with-python=python3 --with-proj=/usr/local --with-pg=yes --with-poppler --with-teigha=/home/jgr/dev/cpp/ODA21.6/base_7.2 --with-teigha-plt=lnxX64_7.2dll  
+   ./configure --without-libtool LDFLAGS="-L/usr/lib/x86_64-linux-gnu" --with-python=python3 --with-proj=/usr/local --with-pg=yes --with-poppler -DTEIGHA_ROOT="/home/jgr/dev/cpp/ODA21.6/Oda_25_12" -DTEIGHA_PLATFORM="lnxX64_13dll" -DTEIGHA_ACTIVATION_FILE_DIRECTORY="/home/jgr/dev/cpp/ODA21.6/Oda_25_12/ThirdParty/Activation"
    make -j8
    sudo make install
    sudo ldconfig
@@ -149,6 +149,18 @@ As an example, compiling GDAL can be:
    sudo python3 setup.py install   
 
 We added `LDFLAGS="-L/usr/lib/x86_64-linux-gnu"` to use system libs over ODA's `libpcre`, `libcurl`, etc.
+
+Adding ODA Geodata capabilities
+-------------------------------
+
+Important infos from ODA documentation (https://docs.opendesign.com/td/db_geo_functionality.html) :
+
+- The csmap library implements coordinate system support and calculations. It's an alternative to proj; see here : https://trac.osgeo.org/csmap
+- The csmap library should have access to a folder with the required dictionaries. The dictionaries are available for downloading from your personal account.
+- Set the MENTOR_DICTIONARY_PATH or CS_MAP_DIR environment variables pointing to the CSDicts folder.
+
+So step 1 is to get and unzip those csmap dictionaries found at <https://account.opendesign.com/downloads>
+Step 2 is to set an env variable (CS_MAP_DIR for example) pointing at the unzipped folder.
 
 Testing
 -------

--- a/ogr/ogrsf_frmts/dwg/dwg_headers.h
+++ b/ogr/ogrsf_frmts/dwg/dwg_headers.h
@@ -73,5 +73,6 @@
 #include "FdField.h"
 
 #include "DbGeoData.h"
+#include "DynamicLinker.h"
 
 #endif  // TEIGHA_HEADERS_H

--- a/ogr/ogrsf_frmts/dwg/dwg_headers.h
+++ b/ogr/ogrsf_frmts/dwg/dwg_headers.h
@@ -72,4 +72,6 @@
 #include "RxDynamicModule.h"
 #include "FdField.h"
 
+#include "DbGeoData.h"
+
 #endif  // TEIGHA_HEADERS_H

--- a/ogr/ogrsf_frmts/dwg/ogr_dwg.h
+++ b/ogr/ogrsf_frmts/dwg/ogr_dwg.h
@@ -84,6 +84,9 @@ class OGRDWGBlocksLayer final : public OGRLayer
 /************************************************************************/
 class OGRDWGLayer final : public OGRLayer
 {
+
+    void AddSRSIfPresent();
+
     OGRDWGDataSource *poDS;
 
     OGRFeatureDefn *poFeatureDefn;

--- a/ogr/ogrsf_frmts/dwg/ogrdwglayer.cpp
+++ b/ogr/ogrsf_frmts/dwg/ogrdwglayer.cpp
@@ -17,22 +17,28 @@
 
 void OGRDWGLayer::AddSRSIfPresent()
 {
-    if(!poDS) return;
+    if (!poDS)
+        return;
 
-    OdRxModulePtr pOdSpatialReferenceModule = odrxDynamicLinker()->loadModule(L"OdSpatialReference");
+    OdRxModulePtr pOdSpatialReferenceModule =
+        odrxDynamicLinker()->loadModule(L"OdSpatialReference");
     if (pOdSpatialReferenceModule.isNull())
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Cannot load OdSpatialReference.tx The setup of MENTOR_DICTIONARY_PATH (or CS_MAP_DIR) is probably missing");
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Cannot load OdSpatialReference.tx The setup of "
+                 "MENTOR_DICTIONARY_PATH (or CS_MAP_DIR) is probably missing");
         return;
     }
 
-    OdRxModulePtr pOdGeoDataModule = odrxDynamicLinker()->loadModule(L"OdGeoData");
+    OdRxModulePtr pOdGeoDataModule =
+        odrxDynamicLinker()->loadModule(L"OdGeoData");
     if (pOdGeoDataModule.isNull())
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Cannot load OdGeoData.tx . GEO Protocol Extension (PE) interfaces couldn't have been loaded");
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Cannot load OdGeoData.tx . GEO Protocol Extension (PE) "
+                 "interfaces couldn't have been loaded");
         return;
     }
-
 
     OdDbDatabasePtr pDb = poDS->GetDB();
     if (pDb.isNull())
@@ -62,7 +68,8 @@ void OGRDWGLayer::AddSRSIfPresent()
     OdDbGeoCoordinateSystem::create(pGeoData->coordinateSystem(), pCS);
     if (pCS.isNull())
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Failed to create GeoCoordinateSystem.");
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Failed to create GeoCoordinateSystem.");
         return;
     }
 
@@ -82,14 +89,14 @@ void OGRDWGLayer::AddSRSIfPresent()
         }
         else
         {
-            CPLError(CE_Warning, CPLE_AppDefined, "Invalid WKT format extracted.");
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "Invalid WKT format extracted.");
         }
-    }else
+    }
+    else
     {
         CPLError(CE_Warning, CPLE_AppDefined, "Cannot get WKT Representation ");
     }
-
-
 }
 
 /************************************************************************/

--- a/ogr/ogrsf_frmts/dwg/ogrdwglayer.cpp
+++ b/ogr/ogrsf_frmts/dwg/ogrdwglayer.cpp
@@ -19,6 +19,21 @@ void OGRDWGLayer::AddSRSIfPresent()
 {
     if(!poDS) return;
 
+    OdRxModulePtr pOdSpatialReferenceModule = odrxDynamicLinker()->loadModule(L"OdSpatialReference");
+    if (pOdSpatialReferenceModule.isNull())
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Cannot load OdSpatialReference.tx The setup of MENTOR_DICTIONARY_PATH (or CS_MAP_DIR) is probably missing");
+        return;
+    }
+
+    OdRxModulePtr pOdGeoDataModule = odrxDynamicLinker()->loadModule(L"OdGeoData");
+    if (pOdGeoDataModule.isNull())
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Cannot load OdGeoData.tx . GEO Protocol Extension (PE) interfaces couldn't have been loaded");
+        return;
+    }
+
+
     OdDbDatabasePtr pDb = poDS->GetDB();
     if (pDb.isNull())
     {

--- a/ogr/ogrsf_frmts/dwg/ogrdwglayer.cpp
+++ b/ogr/ogrsf_frmts/dwg/ogrdwglayer.cpp
@@ -31,7 +31,6 @@ void OGRDWGLayer::AddSRSIfPresent()
     oddbGetGeoDataObjId(pDb, objId);
     if (objId.isNull())
     {
-        CPLError(CE_Warning, CPLE_AppDefined, "No GeoData found in DWG file.");
         return;
     }
 

--- a/ogr/ogrsf_frmts/dwg/ogrdwglayer.cpp
+++ b/ogr/ogrsf_frmts/dwg/ogrdwglayer.cpp
@@ -60,7 +60,7 @@ void OGRDWGLayer::AddSRSIfPresent()
         OGRSpatialReference *poSRS = new OGRSpatialReference();
         if (poSRS->importFromWkt(TextUnescape(sWktId, false)) == OGRERR_NONE)
         {
-            poFeatureDefn->SetGeomType(wkbUnknown);  // presumably, as I think DWG layers might fix geometries of different kind
+            poFeatureDefn->SetGeomType(wkbUnknown);
             poSRS->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
             poFeatureDefn->GetGeomFieldDefn(0)->SetSpatialRef(poSRS);
             poSRS->Release();


### PR DESCRIPTION
## What does this PR do?

Get Coordinate System WKT representation from ODA capabilities when GDAL is build with ODA. Uses the existing system of SpatialReference from gdal.

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/issues/11672

## Tasklist

 - [ v ] Fix the compilation
 - [  ] Fix using ODA's code into GDAL
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: All
* Compiler: gcc 13 (ODA compatibility)
* ODA version : 25.12 (Kernel & Drawing)

