### PR TITLE
cog.py: Fix test_cog_creation_of_overviews_with_compression.

### DIFF
--- a/autotest/gcore/cog.py
+++ b/autotest/gcore/cog.py
@@ -322,16 +322,14 @@ def test_cog_creation_of_overviews_with_compression():
     assert ds.GetRasterBand(1).GetOverviewCount() == 2
     assert ds.GetMetadata("IMAGE_STRUCTURE")["COMPRESSION"] == "LZW"
 
-    ds_overview_a = gdal.Open("GTIFF_DIR:2:" + filename)
-    assert ds_overview_a.GetMetadata("IMAGE_STRUCTURE")["COMPRESSION"] == "JPEG"
-    assert ds_overview_a.GetMetadata("IMAGE_STRUCTURE")["JPEG_QUALITY"] == "50"
+    with gdal.Open("GTIFF_DIR:2:" + filename) as ds_overview:
+        assert ds_overview.GetMetadata("IMAGE_STRUCTURE")["COMPRESSION"] == "JPEG"
+        assert ds_overview.GetMetadata("IMAGE_STRUCTURE")["JPEG_QUALITY"] == "50"
 
-    ds_overview_b = gdal.Open("GTIFF_DIR:3:" + filename)
-    assert ds_overview_b.GetMetadata("IMAGE_STRUCTURE")["COMPRESSION"] == "JPEG"
-    assert ds_overview_a.GetMetadata("IMAGE_STRUCTURE")["JPEG_QUALITY"] == "50"
+    with gdal.Open("GTIFF_DIR:3:" + filename) as ds_overview:
+        assert ds_overview.GetMetadata("IMAGE_STRUCTURE")["COMPRESSION"] == "JPEG"
+        assert ds_overview.GetMetadata("IMAGE_STRUCTURE")["JPEG_QUALITY"] == "50"
 
-    ds_overview_a = None
-    ds_overview_b = None
     ds = None
 
     src_ds = None


### PR DESCRIPTION
a -> b

Just a minor typo such that the second JPEG_QUALITY check was a repeat of the first.