### PR TITLE
CI: Download exprtk from GitHub

### DIFF
--- a/.github/workflows/ubuntu_20.04/Dockerfile.ci
+++ b/.github/workflows/ubuntu_20.04/Dockerfile.ci
@@ -276,9 +276,7 @@ RUN if test "${OPENDRIVE_VERSION}" != ""; then ( \
     ); fi
 
 # Install exprtk
-RUN wget -q https://www.partow.net/downloads/exprtk.zip && \
-    unzip -j -d /usr/local/include exprtk.zip exprtk/exprtk.hpp && \
-    rm exprtk.zip
+RUN wget -q -P /usr/local/include https://raw.githubusercontent.com/ArashPartow/exprtk/refs/heads/master/exprtk.hpp 
 
 RUN ldconfig
 


### PR DESCRIPTION
Download from GitHub master to avoid failures such as https://github.com/OSGeo/gdal/actions/runs/12948440864/job/36117116656

Currently the contents of this file are identical to the one downloaded from www.partow.net.

Downloading a specific hash would likely break when the repository is force-pushed (see https://gitlab.opengeosys.org/ogs/ogs/-/merge_requests/3981, https://github.com/LMMS/lmms/issues/5064)
