### PR TITLE
cog.py: Fix typo in test_cog_write_jpegxl_alpha

### DIFF
--- a/autotest/gcore/cog.py
+++ b/autotest/gcore/cog.py
@@ -1706,7 +1706,7 @@ def test_cog_write_jpegxl_alpha():
             "COMPRESS=JXL",
             "JXL_LOSSLESS=NO",
             "TILED=YES",
-            "BLOCKSIZE=512",
+            "BLOCKXSIZE=512",
             "BLOCKYSIZE=512",
         ],
     )


### PR DESCRIPTION
`BLOCKSIZE` --> `BLOCKXSIZE`

I got a warning from running the test, but it passed before.

This is a trivial bug in testing.