### PR TITLE
gml:CircleByCenterPoint(): return a 5-point CIRCULARSTRING for compliance with ISO/IEC 13249-3:2011

### DIFF
--- a/autotest/ogr/ogr_gml_geom.py
+++ b/autotest/ogr/ogr_gml_geom.py
@@ -2398,7 +2398,7 @@ def test_gml_CircleByCenterPoint():
     geom = ogr.CreateGeometryFromGML(gml)
 
     ogrtest.check_feature_geometry(
-        geom, ogr.CreateGeometryFromWkt("CIRCULARSTRING (-1 2,3 2,-1 2)")
+        geom, ogr.CreateGeometryFromWkt("CIRCULARSTRING (-1 2,1 4,3 2,1 0,-1 2)")
     )
 
 

--- a/ogr/gml2ogrgeometry.cpp
+++ b/ogr/gml2ogrgeometry.cpp
@@ -2043,8 +2043,14 @@ GML2OGRGeometry_XMLNode_Internal(const CPLXMLNode *psNode, const char *pszId,
         p.setX(dfCenterX - dfRadius);
         p.setY(dfCenterY);
         poCC->addPoint(&p);
+        p.setX(dfCenterX);
+        p.setY(dfCenterY + dfRadius);
+        poCC->addPoint(&p);
         p.setX(dfCenterX + dfRadius);
         p.setY(dfCenterY);
+        poCC->addPoint(&p);
+        p.setX(dfCenterX);
+        p.setY(dfCenterY - dfRadius);
         poCC->addPoint(&p);
         p.setX(dfCenterX - dfRadius);
         p.setY(dfCenterY);


### PR DESCRIPTION
Fixes #11750
