### PR TITLE
[Backport release/3.10] gml:CircleByCenterPoint(): return a 5-point CIRCULARSTRING for compliance with ISO/IEC 13249-3:2011

### DIFF
--- a/autotest/ogr/ogr_gml_geom.py
+++ b/autotest/ogr/ogr_gml_geom.py
@@ -2399,7 +2399,7 @@ def test_gml_CircleByCenterPoint():
     geom = ogr.CreateGeometryFromGML(gml)
 
     ogrtest.check_feature_geometry(
-        geom, ogr.CreateGeometryFromWkt("CIRCULARSTRING (-1 2,3 2,-1 2)")
+        geom, ogr.CreateGeometryFromWkt("CIRCULARSTRING (-1 2,1 4,3 2,1 0,-1 2)")
     )
 
 

--- a/ogr/gml2ogrgeometry.cpp
+++ b/ogr/gml2ogrgeometry.cpp
@@ -2000,8 +2000,14 @@ static std::unique_ptr<OGRGeometry> GML2OGRGeometry_XMLNode_Internal(
         p.setX(dfCenterX - dfRadius);
         p.setY(dfCenterY);
         poCC->addPoint(&p);
+        p.setX(dfCenterX);
+        p.setY(dfCenterY + dfRadius);
+        poCC->addPoint(&p);
         p.setX(dfCenterX + dfRadius);
         p.setY(dfCenterY);
+        poCC->addPoint(&p);
+        p.setX(dfCenterX);
+        p.setY(dfCenterY - dfRadius);
         poCC->addPoint(&p);
         p.setX(dfCenterX - dfRadius);
         p.setY(dfCenterY);


### PR DESCRIPTION
Backport #11755
 **Authored by:** @rouault