### PR TITLE
MiraMonVector: Fix issue 393742177 oss-fuzz

### DIFF
--- a/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
+++ b/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
@@ -3729,6 +3729,7 @@ static int MMCreateFeaturePolOrArc(struct MiraMonVectLayerInfo *hMiraMonLayer,
     MM_N_VERTICES_TYPE nPolVertices = 0;
     MM_BOOLEAN bReverseArc;
     int prevCoord = -1;
+    MM_BOOLEAN bPolZeroJustCreated = FALSE;
 
     if (!hMiraMonLayer)
         return MM_FATAL_ERROR_WRITING_FEATURES;
@@ -3824,7 +3825,16 @@ static int MMCreateFeaturePolOrArc(struct MiraMonVectLayerInfo *hMiraMonLayer,
 
             // Universal polygon have a record with ID_GRAFIC=0 and blancs
             if (MMAddPolygonRecordToMMDB(hMiraMonLayer, nullptr, 0, 0, nullptr))
+            {
+                // Rare case where polygon zero creates the database
+                // but some error occurs in the creation of the polygon zero.
+                // The database must be destroyed and created again
+                // next time the polygon zero is created.
+                MMCloseMMBD_XP(hMiraMonLayer);
+                MMDestroyMMDB(hMiraMonLayer);
                 return MM_FATAL_ERROR_WRITING_FEATURES;
+            }
+            bPolZeroJustCreated = TRUE;
         }
     }
 
@@ -3967,7 +3977,18 @@ static int MMCreateFeaturePolOrArc(struct MiraMonVectLayerInfo *hMiraMonLayer,
     pCoord = hMMFeature->pCoord;
 
     if (!pCoord)
+    {
+        if (bPolZeroJustCreated)
+        {
+            // Rare case where polygon zero creates the database
+            // but some error occurs in the creation of the polygon zero.
+            // The database must be destroyed and created again
+            // next time the polygon zero is created.
+            MMCloseMMBD_XP(hMiraMonLayer);
+            MMDestroyMMDB(hMiraMonLayer);
+        }
         return MM_FATAL_ERROR_WRITING_FEATURES;
+    }
 
     // Doing real job
     for (nIPart = 0; nIPart < hMMFeature->nNRings; nIPart++,


### PR DESCRIPTION
## What does this PR do?

Fixes a memory leak that happens in the case where polygon zero creates the database but some error occurs in the creation of the polygon zero. The database must be destroyed and created again next time the polygon zero is created. It's been reproduced in the case of skipFailures==true.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] All CI builds and checks have passed
