### PR TITLE
SQLite/GPKG: run PRELUDE_STATEMENTS after end of initialization, in particular after Spatialite loading

### DIFF
--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -5870,6 +5870,27 @@ def test_ogr_gpkg_prelude_statements(tmp_vsimem):
 
 
 ###############################################################################
+# Test PRELUDE_STATEMENTS open option
+
+
+def test_ogr_gpkg_prelude_statements_after_spatialite_loading(tmp_vsimem):
+
+    gdal.VectorTranslate(tmp_vsimem / "test.gpkg", "data/poly.shp", format="GPKG")
+
+    with ogr.Open(tmp_vsimem / "test.gpkg") as ds:
+        if not _has_spatialite_4_3_or_later(ds):
+            pytest.skip("spatialite missing")
+
+    with gdal.OpenEx(
+        tmp_vsimem / "test.gpkg",
+        open_options=["PRELUDE_STATEMENTS=SELECT setdecimalprecision(1)"],
+    ) as ds:
+        with ds.ExecuteSQL("SELECT ST_AsText(geom) FROM poly LIMIT 1") as sql_lyr:
+            f = sql_lyr.GetNextFeature()
+            assert f[0].startswith("POLYGON((479819.8 4765180.5,")
+
+
+###############################################################################
 # Test DATETIME_FORMAT
 
 

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -9643,6 +9643,14 @@ bool GDALGeoPackageDataset::OpenOrCreateDB(int flags)
         }
     }
 
+    const char *pszPreludeStatements =
+        CSLFetchNameValue(papszOpenOptions, "PRELUDE_STATEMENTS");
+    if (pszPreludeStatements)
+    {
+        if (SQLCommand(hDB, pszPreludeStatements) != OGRERR_NONE)
+            return false;
+    }
+
     return true;
 }
 

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
@@ -1557,14 +1557,6 @@ bool OGRSQLiteBaseDataSource::OpenOrCreateDB(int flagsIn,
         }
 #endif
 
-        const char *pszPreludeStatements =
-            CSLFetchNameValue(papszOpenOptions, "PRELUDE_STATEMENTS");
-        if (pszPreludeStatements)
-        {
-            if (SQLCommand(hDB, pszPreludeStatements) != OGRERR_NONE)
-                return false;
-        }
-
         if (pszSqlitePragma != nullptr)
         {
             char **papszTokens =
@@ -1820,6 +1812,14 @@ bool OGRSQLiteDataSource::OpenOrCreateDB(int flagsIn,
     // errour we catch, but only if OGR2SQLITEModule has been created by
     // above OGR2SQLITE_Setup()
     LoadExtensions();
+
+    const char *pszPreludeStatements =
+        CSLFetchNameValue(papszOpenOptions, "PRELUDE_STATEMENTS");
+    if (pszPreludeStatements)
+    {
+        if (SQLCommand(hDB, pszPreludeStatements) != OGRERR_NONE)
+            return false;
+    }
 
     return true;
 }


### PR DESCRIPTION
Fixes #11782 