### PR TITLE
SWIG: Avoid losing error message

### DIFF
--- a/swig/python/modify_cpp_files.cmake
+++ b/swig/python/modify_cpp_files.cmake
@@ -42,7 +42,7 @@ string(REPLACE "#define SWIGPYTHON"
        _CONTENTS "${_CONTENTS}")
 
 string(REPLACE "return resultobj;"
-               "if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, CPLGetLastErrorMsg() ); return NULL; } }\n  return resultobj;"
+               "if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { std::string osMsg = CPLGetLastErrorMsg(); Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, osMsg.c_str() ); return NULL; } }\n  return resultobj;"
        _CONTENTS "${_CONTENTS}")
 
 # Below works around https://github.com/swig/swig/issues/2638 and https://github.com/swig/swig/issues/2037#issuecomment-874372082

--- a/swig/python/modify_cpp_files.cmake
+++ b/swig/python/modify_cpp_files.cmake
@@ -41,6 +41,7 @@ string(REPLACE "#define SWIGPYTHON"
                "#define SWIGPYTHON\n\#define SED_HACKS"
        _CONTENTS "${_CONTENTS}")
 
+# patch to avoid memory leaks on exception (see 594fe48)
 string(REPLACE "return resultobj;"
                "if ( ReturnSame(bLocalUseExceptionsCode) ) { CPLErr eclass = CPLGetLastErrorType(); if ( eclass == CE_Failure || eclass == CE_Fatal ) { std::string osMsg = CPLGetLastErrorMsg(); Py_XDECREF(resultobj); SWIG_Error( SWIG_RuntimeError, osMsg.c_str() ); return NULL; } }\n  return resultobj;"
        _CONTENTS "${_CONTENTS}")


### PR DESCRIPTION
Fixes https://github.com/OSGeo/gdal/issues/11795

Current code checks `CPLGetLastErrorType` to see if there is an error. If so, `Py_XDECREF(resultobj)` is called, which causes the error to be reset. The subsequent call to `CPLGetLastErrorMsg()` then returns an empty string.