### PR TITLE
download.rst: add instructions to install via pixi (fixes #11551)

### DIFF
--- a/doc/source/download.rst
+++ b/doc/source/download.rst
@@ -77,7 +77,7 @@ Windows
 ................................................................................
 
 Windows builds are available via `Conda Forge`_ (64-bit only). See the
-:ref:`conda` section for more detailed information. GDAL is also distributed
+:ref:`conda` or :ref:`pixi` section for more detailed information. GDAL is also distributed
 by `GISInternals`_ and `OSGeo4W`_ and through the `NuGet`_ and :ref:`vcpkg` package managers.
 
 .. _`Conda Forge`: https://anaconda.org/conda-forge/gdal
@@ -211,6 +211,31 @@ Then install GDAL from the ``gdal-master`` channel:
     mamba install -c gdal-master gdal
     mamba install -c gdal-master libgdal-arrow-parquet # if you need the Arrow and Parquet drivers
 
+.. _pixi:
+
+pixi
+^^^^
+
+`Pixi <https://pixi.sh/latest/>`__  is a package management tool for developers. It allows the developer
+to install libraries and applications in a reproducible way. Packages for GDAL are
+available through the `conda-forge <https://anaconda.org/conda-forge/gdal>`__ channel.
+
+If you want to be able to use GDAL as part of a project:
+
+::
+
+    pixi init name-of-project
+    cd name-of-project
+    pixi add gdal libgdal-core
+    pixi add libgdal-arrow-parquet # if you need the Arrow and Parquet drivers
+    pixi shell
+
+Pixi supports using tools like GDAL and OGR globally, similar to conda's base environment, without having to use an activate command:
+
+::
+
+    pixi global install gdal libgdal-core
+    pixi global install libgdal-arrow-parquet # if you need the Arrow and Parquet drivers
 
 .. _vcpkg:
 

--- a/doc/source/spelling_wordlist.txt
+++ b/doc/source/spelling_wordlist.txt
@@ -2414,6 +2414,7 @@ pixelfunction
 pixelfunctions
 pixelsize
 pixi
+Pixi
 Pixmap
 pkgconfig
 pkid

--- a/doc/source/spelling_wordlist.txt
+++ b/doc/source/spelling_wordlist.txt
@@ -2413,6 +2413,7 @@ Pirmin
 pixelfunction
 pixelfunctions
 pixelsize
+pixi
 Pixmap
 pkgconfig
 pkid


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

Adds installation instructions for users of pixi as an alternative to conda/mamba.

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/issues/11551


