### PR TITLE
Backport 11802 to release/3.10

### DIFF
--- a/doc/source/download.rst
+++ b/doc/source/download.rst
@@ -77,7 +77,7 @@ Windows
 ................................................................................
 
 Windows builds are available via `Conda Forge`_ (64-bit only). See the
-:ref:`conda` section for more detailed information. GDAL is also distributed
+:ref:`conda` or :ref:`pixi` section for more detailed information. GDAL is also distributed
 by `GISInternals`_ and `OSGeo4W`_ and through the `NuGet`_ and :ref:`vcpkg` package managers.
 
 .. _`Conda Forge`: https://anaconda.org/conda-forge/gdal
@@ -209,6 +209,31 @@ Then install GDAL from the ``gdal-master`` channel:
     mamba install -c gdal-master gdal
     mamba install -c gdal-master libgdal-arrow-parquet # if you need the Arrow and Parquet drivers
 
+.. _pixi:
+
+pixi
+^^^^
+
+`Pixi <https://pixi.sh/latest/>`__  is a package management tool for developers. It allows the developer
+to install libraries and applications in a reproducible way. Packages for GDAL are
+available through the `conda-forge <https://anaconda.org/conda-forge/gdal>`__ channel.
+
+If you want to be able to use GDAL as part of a project:
+
+::
+
+    pixi init name-of-project
+    cd name-of-project
+    pixi add gdal libgdal-core
+    pixi add libgdal-arrow-parquet # if you need the Arrow and Parquet drivers
+    pixi shell
+
+Pixi supports using tools like GDAL and OGR globally, similar to conda's base environment, without having to use an activate command:
+
+::
+
+    pixi global install gdal libgdal-core
+    pixi global install libgdal-arrow-parquet # if you need the Arrow and Parquet drivers
 
 .. _vcpkg:
 

--- a/doc/source/spelling_wordlist.txt
+++ b/doc/source/spelling_wordlist.txt
@@ -2402,6 +2402,7 @@ Pirmin
 pixelfunction
 pixelfunctions
 pixelsize
+pixi
 Pixmap
 pkgconfig
 pkid

--- a/doc/source/spelling_wordlist.txt
+++ b/doc/source/spelling_wordlist.txt
@@ -2403,6 +2403,7 @@ pixelfunction
 pixelfunctions
 pixelsize
 pixi
+Pixi
 Pixmap
 pkgconfig
 pkid


### PR DESCRIPTION
Hey @rouault , I wasn't able to cherry-pick 9a253c049b12f6fe09f2db2ad27627aaf82f29 but I was able to cherry-pick the other commits you listed.

Apologies, I have never cherry-picked commits before.

Edit: Fixes https://github.com/OSGeo/gdal/pull/11802