### PR TITLE
CI: msys2-mingw-w64: disable netCDF because of CMake issue with netCDF 4.9.3

### DIFF
--- a/.github/workflows/cmake_builds.yml
+++ b/.github/workflows/cmake_builds.yml
@@ -324,11 +324,12 @@ jobs:
           msystem: MINGW64
           update: true
           # Disable mingw-w64-x86_64-crypto++ as it crashes at runtime on eedai_3 test. Likely a build issue with crypto++ itself
+          # Disable mingw-w64-x86_64-netcdf because of https://github.com/msys2/MINGW-packages/commit/58330521730cc42db21b0f2472884a4d72a1847a#commitcomment-152309674
           install: |
             base-devel git mingw-w64-x86_64-toolchain mingw-w64-x86_64-cmake mingw-w64-x86_64-ccache
             mingw-w64-x86_64-pcre mingw-w64-x86_64-xerces-c mingw-w64-x86_64-zstd mingw-w64-x86_64-libarchive
             mingw-w64-x86_64-geos mingw-w64-x86_64-libspatialite mingw-w64-x86_64-proj
-            mingw-w64-x86_64-cgal mingw-w64-x86_64-libfreexl mingw-w64-x86_64-hdf5 mingw-w64-x86_64-muparser mingw-w64-x86_64-netcdf mingw-w64-x86_64-poppler  mingw-w64-x86_64-podofo mingw-w64-x86_64-postgresql
+            mingw-w64-x86_64-cgal mingw-w64-x86_64-libfreexl mingw-w64-x86_64-hdf5 mingw-w64-x86_64-muparser mingw-w64-x86_64-poppler  mingw-w64-x86_64-podofo mingw-w64-x86_64-postgresql
             mingw-w64-x86_64-libgeotiff mingw-w64-x86_64-libpng mingw-w64-x86_64-libtiff mingw-w64-x86_64-openjpeg2
             mingw-w64-x86_64-python-pip mingw-w64-x86_64-python-numpy mingw-w64-x86_64-python-pytest mingw-w64-x86_64-python-setuptools mingw-w64-x86_64-python-lxml mingw-w64-x86_64-swig mingw-w64-x86_64-python-psutil mingw-w64-x86_64-blosc mingw-w64-x86_64-libavif
       - name: Setup cache


### PR DESCRIPTION
Cf https://github.com/msys2/MINGW-packages/commit/58330521730cc42db21b0f2472884a4d72a1847a#commitcomment-152309674

The update to netCDF 4.9.3 breaks building GDAL against netCDF. Cf https://github.com/OSGeo/gdal/actions/runs/13217070591/job/36897548259?pr=11819 :
```
 CMake Error at D:/a/_temp/msys64/mingw64/lib/cmake/netCDF/netCDFConfig.cmake:15 (message):
  File or directory /mingw64 referenced by variable netCDF_INSTALL_PREFIX
  does not exist !
Call Stack (most recent call first):
  D:/a/_temp/msys64/mingw64/lib/cmake/netCDF/netCDFConfig.cmake:32 (set_and_check)
  cmake/helpers/CheckDependentLibrariesCommon.cmake:141 (find_package)
  cmake/helpers/CheckDependentLibraries.cmake:408 (gdal_check_package)
  gdal.cmake:76 (include)
  CMakeLists.txt:264 (include)
```
