### PR TITLE
gdal vector: make 'read', 'clip' and 'reproject' compatible of OSM-type of datasources that require ODsCRandomLayerRead

### DIFF
--- a/apps/gdalalg_vector_clip.cpp
+++ b/apps/gdalalg_vector_clip.cpp
@@ -65,129 +65,99 @@ GDALVectorClipAlgorithm::GDALVectorClipAlgorithm(bool standaloneStep)
 
 namespace
 {
-class GDALVectorClipAlgorithmLayer final
-    : public OGRLayer,
-      public OGRGetNextFeatureThroughRaw<GDALVectorClipAlgorithmLayer>
+class GDALVectorClipAlgorithmLayer final : public GDALVectorPipelineOutputLayer
 {
-
-    DEFINE_GET_NEXT_FEATURE_THROUGH_RAW(GDALVectorClipAlgorithmLayer)
-
   public:
-    GDALVectorClipAlgorithmLayer(OGRLayer *poSrcLayer,
+    GDALVectorClipAlgorithmLayer(OGRLayer &oSrcLayer,
                                  std::unique_ptr<OGRGeometry> poClipGeom)
-        : m_poSrcLayer(poSrcLayer), m_poClipGeom(std::move(poClipGeom)),
-          m_eSrcLayerGeomType(m_poSrcLayer->GetGeomType()),
+        : GDALVectorPipelineOutputLayer(oSrcLayer),
+          m_poClipGeom(std::move(poClipGeom)),
+          m_eSrcLayerGeomType(oSrcLayer.GetGeomType()),
           m_eFlattenSrcLayerGeomType(wkbFlatten(m_eSrcLayerGeomType)),
           m_bSrcLayerGeomTypeIsCollection(OGR_GT_IsSubClassOf(
               m_eFlattenSrcLayerGeomType, wkbGeometryCollection))
     {
-        SetDescription(poSrcLayer->GetDescription());
-        poSrcLayer->SetSpatialFilter(m_poClipGeom.get());
+        SetDescription(oSrcLayer.GetDescription());
+        oSrcLayer.SetSpatialFilter(m_poClipGeom.get());
     }
 
     OGRFeatureDefn *GetLayerDefn() override
     {
-        return m_poSrcLayer->GetLayerDefn();
+        return m_srcLayer.GetLayerDefn();
     }
 
-    void ResetReading() override
+    void TranslateFeature(
+        std::unique_ptr<OGRFeature> poSrcFeature,
+        std::vector<std::unique_ptr<OGRFeature>> &apoOutFeatures) override
     {
-        m_poSrcLayer->ResetReading();
-        m_poSrcFeature.reset();
-        m_poCurGeomColl.reset();
-        m_idxInCurGeomColl = 0;
-    }
+        auto poGeom = poSrcFeature->GetGeometryRef();
+        if (!poGeom)
+            return;
 
-    OGRFeature *GetNextRawFeature()
-    {
-        if (m_poSrcFeature && m_poCurGeomColl)
+        auto poIntersection = std::unique_ptr<OGRGeometry>(
+            poGeom->Intersection(m_poClipGeom.get()));
+        if (!poIntersection)
+            return;
+
+        const auto eFeatGeomType =
+            wkbFlatten(poIntersection->getGeometryType());
+        if (m_eFlattenSrcLayerGeomType != wkbUnknown &&
+            m_eFlattenSrcLayerGeomType != eFeatGeomType)
         {
-            while (m_idxInCurGeomColl < m_poCurGeomColl->getNumGeometries())
+            // If the intersection is a collection of geometry and the
+            // layer geometry type is of non-collection type, create
+            // one feature per element of the collection.
+            if (!m_bSrcLayerGeomTypeIsCollection &&
+                OGR_GT_IsSubClassOf(eFeatGeomType, wkbGeometryCollection))
             {
-                const auto poGeom =
-                    m_poCurGeomColl->getGeometryRef(m_idxInCurGeomColl);
-                ++m_idxInCurGeomColl;
-                if (m_eFlattenSrcLayerGeomType == wkbUnknown ||
-                    m_eFlattenSrcLayerGeomType ==
-                        wkbFlatten(poGeom->getGeometryType()))
+                auto poGeomColl = std::unique_ptr<OGRGeometryCollection>(
+                    poIntersection.release()->toGeometryCollection());
+                for (const auto *poSubGeom : poGeomColl.get())
                 {
                     auto poDstFeature =
-                        std::unique_ptr<OGRFeature>(m_poSrcFeature->Clone());
-                    poDstFeature->SetGeometry(poGeom);
-                    return poDstFeature.release();
+                        std::unique_ptr<OGRFeature>(poSrcFeature->Clone());
+                    poDstFeature->SetGeometry(poSubGeom);
+                    apoOutFeatures.push_back(std::move(poDstFeature));
                 }
             }
-            m_poSrcFeature.reset();
-            m_poCurGeomColl.reset();
-            m_idxInCurGeomColl = 0;
+            else if (OGR_GT_GetCollection(eFeatGeomType) ==
+                     m_eFlattenSrcLayerGeomType)
+            {
+                poIntersection.reset(OGRGeometryFactory::forceTo(
+                    poIntersection.release(), m_eSrcLayerGeomType));
+                poSrcFeature->SetGeometryDirectly(poIntersection.release());
+                apoOutFeatures.push_back(std::move(poSrcFeature));
+            }
+            else if (m_eFlattenSrcLayerGeomType == wkbGeometryCollection)
+            {
+                auto poGeomColl = std::make_unique<OGRGeometryCollection>();
+                poGeomColl->addGeometry(std::move(poIntersection));
+                poSrcFeature->SetGeometryDirectly(poGeomColl.release());
+                apoOutFeatures.push_back(std::move(poSrcFeature));
+            }
+            // else discard geometries of incompatible type with the
+            // layer geometry type
         }
-
-        while (auto poFeature =
-                   std::unique_ptr<OGRFeature>(m_poSrcLayer->GetNextFeature()))
+        else
         {
-            auto poGeom = poFeature->GetGeometryRef();
-            if (!poGeom)
-                continue;
-
-            auto poIntersection = std::unique_ptr<OGRGeometry>(
-                poGeom->Intersection(m_poClipGeom.get()));
-            if (!poIntersection)
-                continue;
-
-            const auto eFeatGeomType =
-                wkbFlatten(poIntersection->getGeometryType());
-            if (m_eFlattenSrcLayerGeomType != wkbUnknown &&
-                m_eFlattenSrcLayerGeomType != eFeatGeomType)
-            {
-                // If the intersection is a collection of geometry and the
-                // layer geometry type is of non-collection type, create
-                // one feature per element of the collection.
-                if (!m_bSrcLayerGeomTypeIsCollection &&
-                    OGR_GT_IsSubClassOf(eFeatGeomType, wkbGeometryCollection))
-                {
-                    m_poSrcFeature = std::move(poFeature);
-                    m_poCurGeomColl.reset(
-                        poIntersection.release()->toGeometryCollection());
-                    m_idxInCurGeomColl = 0;
-                    return GetNextFeature();
-                }
-                else if (OGR_GT_GetCollection(eFeatGeomType) ==
-                         m_eFlattenSrcLayerGeomType)
-                {
-                    poIntersection.reset(OGRGeometryFactory::forceTo(
-                        poIntersection.release(), m_eSrcLayerGeomType));
-                    poFeature->SetGeometryDirectly(poIntersection.release());
-                    return poFeature.release();
-                }
-                // else discard geometries of incompatible type with the
-                // layer geometry type
-            }
-            else
-            {
-                poFeature->SetGeometryDirectly(poIntersection.release());
-                return poFeature.release();
-            }
+            poSrcFeature->SetGeometryDirectly(poIntersection.release());
+            apoOutFeatures.push_back(std::move(poSrcFeature));
         }
-        return nullptr;
     }
 
     int TestCapability(const char *pszCap) override
     {
         if (EQUAL(pszCap, OLCStringsAsUTF8) ||
             EQUAL(pszCap, OLCCurveGeometries) || EQUAL(pszCap, OLCZGeometries))
-            return m_poSrcLayer->TestCapability(pszCap);
+            return m_srcLayer.TestCapability(pszCap);
         return false;
     }
 
   private:
-    OGRLayer *m_poSrcLayer = nullptr;
     std::unique_ptr<OGRGeometry> m_poClipGeom{};
     const OGRwkbGeometryType m_eSrcLayerGeomType;
     const OGRwkbGeometryType m_eFlattenSrcLayerGeomType;
     const bool m_bSrcLayerGeomTypeIsCollection;
-    std::unique_ptr<OGRFeature> m_poSrcFeature{};
-    std::unique_ptr<OGRGeometryCollection> m_poCurGeomColl{};
-    int m_idxInCurGeomColl = 0;
 
     CPL_DISALLOW_COPY_ASSIGN(GDALVectorClipAlgorithmLayer)
 };
@@ -428,8 +398,7 @@ bool GDALVectorClipAlgorithm::RunStep(GDALProgressFunc, void *)
         return false;
     }
 
-    auto outDS = std::make_unique<GDALVectorPipelineOutputDataset>();
-    outDS->SetDescription(poSrcDS->GetDescription());
+    auto outDS = std::make_unique<GDALVectorPipelineOutputDataset>(*poSrcDS);
 
     bool ret = true;
     for (int i = 0; ret && i < nLayerCount; ++i)
@@ -448,8 +417,10 @@ bool GDALVectorClipAlgorithm::RunStep(GDALProgressFunc, void *)
             }
             if (ret)
             {
-                outDS->AddLayer(std::make_unique<GDALVectorClipAlgorithmLayer>(
-                    poSrcLayer, std::move(poClipGeomForLayer)));
+                outDS->AddLayer(
+                    *poSrcLayer,
+                    std::make_unique<GDALVectorClipAlgorithmLayer>(
+                        *poSrcLayer, std::move(poClipGeomForLayer)));
             }
         }
     }

--- a/apps/gdalalg_vector_pipeline.cpp
+++ b/apps/gdalalg_vector_pipeline.cpp
@@ -516,4 +516,175 @@ std::string GDALVectorPipelineAlgorithm::GetUsageForCLI(
     return ret;
 }
 
+/************************************************************************/
+/*                  GDALVectorPipelineOutputLayer                       */
+/************************************************************************/
+
+/************************************************************************/
+/*                  GDALVectorPipelineOutputLayer()                     */
+/************************************************************************/
+
+GDALVectorPipelineOutputLayer::GDALVectorPipelineOutputLayer(OGRLayer &srcLayer)
+    : m_srcLayer(srcLayer)
+{
+}
+
+/************************************************************************/
+/*             GDALVectorPipelineOutputLayer::ResetReading()            */
+/************************************************************************/
+
+void GDALVectorPipelineOutputLayer::ResetReading()
+{
+    m_srcLayer.ResetReading();
+    m_pendingFeatures.clear();
+    m_idxInPendingFeatures = 0;
+}
+
+/************************************************************************/
+/*           GDALVectorPipelineOutputLayer::GetNextRawFeature()         */
+/************************************************************************/
+
+OGRFeature *GDALVectorPipelineOutputLayer::GetNextRawFeature()
+{
+    if (m_idxInPendingFeatures < m_pendingFeatures.size())
+    {
+        OGRFeature *poFeature =
+            m_pendingFeatures[m_idxInPendingFeatures].release();
+        ++m_idxInPendingFeatures;
+        return poFeature;
+    }
+    m_pendingFeatures.clear();
+    m_idxInPendingFeatures = 0;
+    while (true)
+    {
+        auto poSrcFeature =
+            std::unique_ptr<OGRFeature>(m_srcLayer.GetNextFeature());
+        if (!poSrcFeature)
+            return nullptr;
+        TranslateFeature(std::move(poSrcFeature), m_pendingFeatures);
+        if (!m_pendingFeatures.empty())
+            break;
+    }
+    OGRFeature *poFeature = m_pendingFeatures[0].release();
+    m_idxInPendingFeatures = 1;
+    return poFeature;
+}
+
+/************************************************************************/
+/*                 GDALVectorPipelineOutputDataset                      */
+/************************************************************************/
+
+/************************************************************************/
+/*                 GDALVectorPipelineOutputDataset()                    */
+/************************************************************************/
+
+GDALVectorPipelineOutputDataset::GDALVectorPipelineOutputDataset(
+    GDALDataset &srcDS)
+    : m_srcDS(srcDS)
+{
+    SetDescription(m_srcDS.GetDescription());
+}
+
+/************************************************************************/
+/*            GDALVectorPipelineOutputDataset::AddLayer()               */
+/************************************************************************/
+
+void GDALVectorPipelineOutputDataset::AddLayer(
+    OGRLayer &oSrcLayer,
+    std::unique_ptr<OGRLayerWithTranslateFeature> poNewLayer)
+{
+    m_layersToDestroy.push_back(std::move(poNewLayer));
+    OGRLayerWithTranslateFeature *poNewLayerRaw =
+        m_layersToDestroy.back().get();
+    m_layers.push_back(poNewLayerRaw);
+    m_mapSrcLayerToNewLayer[&oSrcLayer] = poNewLayerRaw;
+}
+
+/************************************************************************/
+/*          GDALVectorPipelineOutputDataset::GetLayerCount()            */
+/************************************************************************/
+
+int GDALVectorPipelineOutputDataset::GetLayerCount()
+{
+    return static_cast<int>(m_layers.size());
+}
+
+/************************************************************************/
+/*             GDALVectorPipelineOutputDataset::GetLayer()              */
+/************************************************************************/
+
+OGRLayer *GDALVectorPipelineOutputDataset::GetLayer(int idx)
+{
+    return idx >= 0 && idx < GetLayerCount() ? m_layers[idx] : nullptr;
+}
+
+/************************************************************************/
+/*           GDALVectorPipelineOutputDataset::TestCapability()          */
+/************************************************************************/
+
+int GDALVectorPipelineOutputDataset::TestCapability(const char *pszCap)
+{
+    if (EQUAL(pszCap, ODsCRandomLayerRead))
+    {
+        return m_srcDS.TestCapability(pszCap);
+    }
+    return false;
+}
+
+/************************************************************************/
+/*             GDALVectorPipelineOutputDataset::ResetReading()          */
+/************************************************************************/
+
+void GDALVectorPipelineOutputDataset::ResetReading()
+{
+    m_srcDS.ResetReading();
+    m_pendingFeatures.clear();
+    m_idxInPendingFeatures = 0;
+}
+
+/************************************************************************/
+/*            GDALVectorPipelineOutputDataset::GetNextFeature()         */
+/************************************************************************/
+
+OGRFeature *GDALVectorPipelineOutputDataset::GetNextFeature(
+    OGRLayer **ppoBelongingLayer, double *pdfProgressPct,
+    GDALProgressFunc pfnProgress, void *pProgressData)
+{
+    if (m_idxInPendingFeatures < m_pendingFeatures.size())
+    {
+        OGRFeature *poFeature =
+            m_pendingFeatures[m_idxInPendingFeatures].release();
+        if (ppoBelongingLayer)
+            *ppoBelongingLayer = m_belongingLayer;
+        ++m_idxInPendingFeatures;
+        return poFeature;
+    }
+
+    m_pendingFeatures.clear();
+    m_idxInPendingFeatures = 0;
+
+    while (true)
+    {
+        OGRLayer *poSrcBelongingLayer = nullptr;
+        auto poSrcFeature = std::unique_ptr<OGRFeature>(m_srcDS.GetNextFeature(
+            &poSrcBelongingLayer, pdfProgressPct, pfnProgress, pProgressData));
+        if (!poSrcFeature)
+            return nullptr;
+        auto iterToDstLayer = m_mapSrcLayerToNewLayer.find(poSrcBelongingLayer);
+        if (iterToDstLayer != m_mapSrcLayerToNewLayer.end())
+        {
+            m_belongingLayer = iterToDstLayer->second;
+            m_belongingLayer->TranslateFeature(std::move(poSrcFeature),
+                                               m_pendingFeatures);
+            if (!m_pendingFeatures.empty())
+                break;
+        }
+    }
+    OGRFeature *poFeature = m_pendingFeatures[0].release();
+    if (ppoBelongingLayer)
+        *ppoBelongingLayer = m_belongingLayer;
+    m_idxInPendingFeatures = 1;
+    return poFeature;
+}
+
 //! @endcond

--- a/apps/gdalalg_vector_read.cpp
+++ b/apps/gdalalg_vector_read.cpp
@@ -33,6 +33,121 @@ GDALVectorReadAlgorithm::GDALVectorReadAlgorithm()
 }
 
 /************************************************************************/
+/*                 GDALVectorPipelineReadOutputDataset                  */
+/************************************************************************/
+
+/** Class used by vector pipeline steps to create an output on-the-fly
+ * dataset where they can store on-the-fly layers.
+ */
+class GDALVectorPipelineReadOutputDataset final : public GDALDataset
+{
+    GDALDataset &m_srcDS;
+    std::vector<OGRLayer *> m_layers{};
+
+    CPL_DISALLOW_COPY_ASSIGN(GDALVectorPipelineReadOutputDataset)
+
+  public:
+    explicit GDALVectorPipelineReadOutputDataset(GDALDataset &oSrcDS);
+
+    void AddLayer(OGRLayer &oSrcLayer);
+
+    int GetLayerCount() override;
+
+    OGRLayer *GetLayer(int idx) override;
+
+    int TestCapability(const char *pszCap) override;
+
+    void ResetReading() override;
+
+    OGRFeature *GetNextFeature(OGRLayer **ppoBelongingLayer,
+                               double *pdfProgressPct,
+                               GDALProgressFunc pfnProgress,
+                               void *pProgressData) override;
+};
+
+/************************************************************************/
+/*                 GDALVectorPipelineReadOutputDataset()                */
+/************************************************************************/
+
+GDALVectorPipelineReadOutputDataset::GDALVectorPipelineReadOutputDataset(
+    GDALDataset &srcDS)
+    : m_srcDS(srcDS)
+{
+    SetDescription(m_srcDS.GetDescription());
+}
+
+/************************************************************************/
+/*            GDALVectorPipelineReadOutputDataset::AddLayer()           */
+/************************************************************************/
+
+void GDALVectorPipelineReadOutputDataset::AddLayer(OGRLayer &oSrcLayer)
+{
+    m_layers.push_back(&oSrcLayer);
+}
+
+/************************************************************************/
+/*          GDALVectorPipelineReadOutputDataset::GetLayerCount()        */
+/************************************************************************/
+
+int GDALVectorPipelineReadOutputDataset::GetLayerCount()
+{
+    return static_cast<int>(m_layers.size());
+}
+
+/************************************************************************/
+/*           GDALVectorPipelineReadOutputDataset::GetLayer()            */
+/************************************************************************/
+
+OGRLayer *GDALVectorPipelineReadOutputDataset::GetLayer(int idx)
+{
+    return idx >= 0 && idx < GetLayerCount() ? m_layers[idx] : nullptr;
+}
+
+/************************************************************************/
+/*         GDALVectorPipelineReadOutputDataset::TestCapability()        */
+/************************************************************************/
+
+int GDALVectorPipelineReadOutputDataset::TestCapability(const char *pszCap)
+{
+    if (EQUAL(pszCap, ODsCRandomLayerRead))
+        return m_srcDS.TestCapability(pszCap);
+    return false;
+}
+
+/************************************************************************/
+/*           GDALVectorPipelineReadOutputDataset::ResetReading()        */
+/************************************************************************/
+
+void GDALVectorPipelineReadOutputDataset::ResetReading()
+{
+    m_srcDS.ResetReading();
+}
+
+/************************************************************************/
+/*          GDALVectorPipelineReadOutputDataset::GetNextFeature()       */
+/************************************************************************/
+
+OGRFeature *GDALVectorPipelineReadOutputDataset::GetNextFeature(
+    OGRLayer **ppoBelongingLayer, double *pdfProgressPct,
+    GDALProgressFunc pfnProgress, void *pProgressData)
+{
+    while (true)
+    {
+        OGRLayer *poBelongingLayer = nullptr;
+        auto poFeature = std::unique_ptr<OGRFeature>(m_srcDS.GetNextFeature(
+            &poBelongingLayer, pdfProgressPct, pfnProgress, pProgressData));
+        if (ppoBelongingLayer)
+            *ppoBelongingLayer = poBelongingLayer;
+        if (!poFeature)
+            break;
+        if (std::find(m_layers.begin(), m_layers.end(), poBelongingLayer) !=
+            m_layers.end())
+            return poFeature.release();
+    }
+    return nullptr;
+}
+
+/************************************************************************/
 /*                  GDALVectorReadAlgorithm::RunStep()                  */
 /************************************************************************/
 
@@ -49,8 +164,8 @@ bool GDALVectorReadAlgorithm::RunStep(GDALProgressFunc, void *)
     else
     {
         auto poSrcDS = m_inputDataset.GetDatasetRef();
-        auto poOutDS = std::make_unique<GDALVectorPipelineOutputDataset>();
-        poOutDS->SetDescription(poSrcDS->GetDescription());
+        auto poOutDS =
+            std::make_unique<GDALVectorPipelineReadOutputDataset>(*poSrcDS);
         for (const auto &srcLayerName : m_inputLayerNames)
         {
             auto poSrcLayer = poSrcDS->GetLayerByName(srcLayerName.c_str());
@@ -61,7 +176,7 @@ bool GDALVectorReadAlgorithm::RunStep(GDALProgressFunc, void *)
                             srcLayerName.c_str());
                 return false;
             }
-            poOutDS->AddLayer(poSrcLayer);
+            poOutDS->AddLayer(*poSrcLayer);
         }
         m_outputDataset.Set(std::move(poOutDS));
     }

--- a/apps/gdalalg_vector_reproject.cpp
+++ b/apps/gdalalg_vector_reproject.cpp
@@ -65,8 +65,7 @@ bool GDALVectorReprojectAlgorithm::RunStep(GDALProgressFunc, void *)
     auto poSrcDS = m_inputDataset.GetDatasetRef();
 
     auto reprojectedDataset =
-        std::make_unique<GDALVectorPipelineOutputDataset>();
-    reprojectedDataset->SetDescription(poSrcDS->GetDescription());
+        std::make_unique<GDALVectorPipelineOutputDataset>(*poSrcDS);
 
     const int nLayerCount = poSrcDS->GetLayerCount();
     bool ret = true;
@@ -95,10 +94,11 @@ bool GDALVectorReprojectAlgorithm::RunStep(GDALProgressFunc, void *)
             ret = (poCT != nullptr) && (poReversedCT != nullptr);
             if (ret)
             {
-                reprojectedDataset->AddLayer(std::make_unique<OGRWarpedLayer>(
-                    poSrcLayer, /* iGeomField = */ 0,
-                    /*bTakeOwnership = */ false, poCT.release(),
-                    poReversedCT.release()));
+                reprojectedDataset->AddLayer(
+                    *poSrcLayer, std::make_unique<OGRWarpedLayer>(
+                                     poSrcLayer, /* iGeomField = */ 0,
+                                     /*bTakeOwnership = */ false,
+                                     poCT.release(), poReversedCT.release()));
             }
         }
     }

--- a/apps/gdalalg_vector_write.cpp
+++ b/apps/gdalalg_vector_write.cpp
@@ -43,6 +43,12 @@ bool GDALVectorWriteAlgorithm::RunStep(GDALProgressFunc pfnProgress,
 {
     CPLAssert(m_inputDataset.GetDatasetRef());
 
+    if (m_format == "stream")
+    {
+        m_outputDataset.Set(m_inputDataset.GetDatasetRef());
+        return true;
+    }
+
     CPLStringList aosOptions;
     aosOptions.AddString("--invoked-from-gdal-vector-convert");
     if (!m_overwrite)

--- a/autotest/utilities/test_gdalalg_vector_reproject.py
+++ b/autotest/utilities/test_gdalalg_vector_reproject.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env pytest
+# -*- coding: utf-8 -*-
+###############################################################################
+# Project:  GDAL/OGR Test Suite
+# Purpose:  'gdal vector reproject' testing
+# Author:   Even Rouault <even dot rouault @ spatialys.com>
+#
+###############################################################################
+# Copyright (c) 2025, Even Rouault <even dot rouault at spatialys.com>
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+
+import pytest
+
+from osgeo import gdal, ogr
+
+
+def get_reproject_alg():
+    return gdal.GetGlobalAlgorithmRegistry()["vector"]["reproject"]
+
+
+# Most of the testing is done in test_gdalalg_vector_pipeline.py
+
+
+@pytest.mark.require_driver("OSM")
+def test_gdalalg_vector_reproject_dataset_getnextfeature():
+
+    alg = get_reproject_alg()
+    src_ds = gdal.OpenEx("../ogr/data/osm/test.pbf")
+    alg["input"] = src_ds
+    alg["dst-crs"] = "EPSG:4326"
+
+    assert alg.ParseCommandLineArguments(
+        ["--of", "stream", "--output", "streamed_output"]
+    )
+    assert alg.Run()
+
+    out_ds = alg["output"].GetDataset()
+    assert out_ds.TestCapability(ogr.ODsCRandomLayerRead)
+
+    expected = []
+    while True:
+        f, _ = src_ds.GetNextFeature()
+        if not f:
+            break
+        expected.append(str(f))
+
+    got = []
+    out_ds.ResetReading()
+    while True:
+        f, _ = out_ds.GetNextFeature()
+        if not f:
+            break
+        got.append(str(f))
+
+    assert expected == got

--- a/ogr/ogrsf_frmts/generic/CMakeLists.txt
+++ b/ogr/ogrsf_frmts/generic/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library(
   ogrunionlayer.cpp
   ogrlayerpool.cpp
   ogrlayerdecorator.cpp
+  ogrlayerwithtranslatefeature.cpp
   ogreditablelayer.cpp
   ogrmutexeddatasource.cpp
   ogrmutexedlayer.cpp

--- a/ogr/ogrsf_frmts/generic/ogrlayerdecorator.h
+++ b/ogr/ogrsf_frmts/generic/ogrlayerdecorator.h
@@ -17,7 +17,7 @@
 
 #include "ogrsf_frmts.h"
 
-class CPL_DLL OGRLayerDecorator : public OGRLayer
+class CPL_DLL OGRLayerDecorator : virtual public OGRLayer
 {
     CPL_DISALLOW_COPY_ASSIGN(OGRLayerDecorator)
 

--- a/ogr/ogrsf_frmts/generic/ogrlayerwithtranslatefeature.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrlayerwithtranslatefeature.cpp
@@ -1,0 +1,19 @@
+/******************************************************************************
+ *
+ * Project:  OpenGIS Simple Features Reference Implementation
+ * Purpose:  Defines OGRLayerWithTranslateFeature class
+ * Author:   Even Rouault, even dot rouault at spatialys.com
+ *
+ ******************************************************************************
+ * Copyright (c) 2025, Even Rouault <even dot rouault at spatialys.com>
+ *
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#include "ogrlayerwithtranslatefeature.h"
+
+#ifndef DOXYGEN_SKIP
+
+OGRLayerWithTranslateFeature::~OGRLayerWithTranslateFeature() = default;
+
+#endif

--- a/ogr/ogrsf_frmts/generic/ogrlayerwithtranslatefeature.h
+++ b/ogr/ogrsf_frmts/generic/ogrlayerwithtranslatefeature.h
@@ -1,0 +1,36 @@
+/******************************************************************************
+ *
+ * Project:  OpenGIS Simple Features Reference Implementation
+ * Purpose:  Defines OGRLayerWithTranslateFeature class
+ * Author:   Even Rouault, even dot rouault at spatialys.com
+ *
+ ******************************************************************************
+ * Copyright (c) 2025, Even Rouault <even dot rouault at spatialys.com>
+ *
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#ifndef OGRLAYERWITHTRANSLATEFEATURE_H_INCLUDED
+#define OGRLAYERWITHTRANSLATEFEATURE_H_INCLUDED
+
+#ifndef DOXYGEN_SKIP
+
+#include "ogrsf_frmts.h"
+
+/** Class that just extends by OGRLayer by mandating a pure virtual method
+ * TranslateFeature() to be implemented.
+ */
+class OGRLayerWithTranslateFeature /* non final */ : virtual public OGRLayer
+{
+  public:
+    virtual ~OGRLayerWithTranslateFeature();
+
+    /** Translate the source feature into one or several output features */
+    virtual void TranslateFeature(
+        std::unique_ptr<OGRFeature> poSrcFeature,
+        std::vector<std::unique_ptr<OGRFeature>> &apoOutFeatures) = 0;
+};
+
+#endif /* DOXYGEN_SKIP */
+
+#endif /* OGRLAYERWITHTRANSLATEFEATURE_H_INCLUDED */

--- a/ogr/ogrsf_frmts/generic/ogrmutexeddatasource.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrmutexeddatasource.cpp
@@ -160,7 +160,7 @@ void OGRMutexedDataSource::ReleaseResultSet(OGRLayer *poResultsSet)
     {
         std::map<OGRMutexedLayer *, OGRLayer *>::iterator oIter =
             m_oReverseMapLayers.find(
-                cpl::down_cast<OGRMutexedLayer *>(poResultsSet));
+                dynamic_cast<OGRMutexedLayer *>(poResultsSet));
         CPLAssert(oIter != m_oReverseMapLayers.end());
         delete poResultsSet;
         poResultsSet = oIter->second;

--- a/ogr/ogrsf_frmts/generic/ogrwarpedlayer.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrwarpedlayer.cpp
@@ -102,6 +102,18 @@ OGRErr OGRWarpedLayer::ISetSpatialFilter(int iGeomField,
 }
 
 /************************************************************************/
+/*                         TranslateFeature()                           */
+/************************************************************************/
+
+void OGRWarpedLayer::TranslateFeature(
+    std::unique_ptr<OGRFeature> poSrcFeature,
+    std::vector<std::unique_ptr<OGRFeature>> &apoOutFeatures)
+{
+    apoOutFeatures.push_back(
+        SrcFeatureToWarpedFeature(std::move(poSrcFeature)));
+}
+
+/************************************************************************/
 /*                     SrcFeatureToWarpedFeature()                      */
 /************************************************************************/
 

--- a/ogr/ogrsf_frmts/generic/ogrwarpedlayer.h
+++ b/ogr/ogrsf_frmts/generic/ogrwarpedlayer.h
@@ -16,13 +16,22 @@
 #ifndef DOXYGEN_SKIP
 
 #include "ogrlayerdecorator.h"
+#include "ogrlayerwithtranslatefeature.h"
+
 #include <memory>
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+// Silence warnings of the type warning C4250: 'OGRWarpedLayer': inherits 'OGRLayerDecorator::OGRLayerDecorator::GetMetadata' via dominance
+#pragma warning(disable : 4250)
+#endif
 
 /************************************************************************/
 /*                           OGRWarpedLayer                             */
 /************************************************************************/
 
-class CPL_DLL OGRWarpedLayer : public OGRLayerDecorator
+class CPL_DLL OGRWarpedLayer : public OGRLayerDecorator,
+                               public OGRLayerWithTranslateFeature
 {
     CPL_DISALLOW_COPY_ASSIGN(OGRWarpedLayer)
 
@@ -53,6 +62,10 @@ class CPL_DLL OGRWarpedLayer : public OGRLayerDecorator
             poReversedCT /* may be NULL, ownership acquired by OGRWarpedLayer */);
     virtual ~OGRWarpedLayer();
 
+    void TranslateFeature(
+        std::unique_ptr<OGRFeature> poSrcFeature,
+        std::vector<std::unique_ptr<OGRFeature>> &apoOutFeatures) override;
+
     void SetExtent(double dfXMin, double dfYMin, double dfXMax, double dfYMax);
 
     virtual OGRErr ISetSpatialFilter(int iGeomField,
@@ -82,6 +95,10 @@ class CPL_DLL OGRWarpedLayer : public OGRLayerDecorator
     virtual bool GetArrowStream(struct ArrowArrayStream *out_stream,
                                 CSLConstList papszOptions = nullptr) override;
 };
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 #endif /* #ifndef DOXYGEN_SKIP */
 


### PR DESCRIPTION
On-the-fly reading of OSM requires to be able to iterate over features at the dataset level, and not just at the layer level. Let's implement that.
