### PR TITLE
[mysql] Remove deprecated reconnect option for mysql >= 80034

### DIFF
--- a/ogr/ogrsf_frmts/mysql/ogrmysqldatasource.cpp
+++ b/ogr/ogrsf_frmts/mysql/ogrmysqldatasource.cpp
@@ -217,6 +217,7 @@ int OGRMySQLDataSource::Open(const char *pszNewName, char **papszOpenOptionsIn,
         CSLDestroy(papszTableNames);
         return FALSE;
     }
+#if defined(LIBMYSQL_VERSION_ID) && (LIBMYSQL_VERSION_ID < 80034)
     else
     {
         // Enable automatic reconnection
@@ -229,6 +230,7 @@ int OGRMySQLDataSource::Open(const char *pszNewName, char **papszOpenOptionsIn,
         // and at any point on more recent versions.
         mysql_options(hConn, MYSQL_OPT_RECONNECT, &reconnect);
     }
+#endif
 
     bDSUpdate = bUpdate;
 


### PR DESCRIPTION
MYSQL_OPT_RECONNECT is deprecated since mysql 80034

Fixes #11842
