### PR TITLE
DXF: Don't hide block entities on layer 0 when that layer is frozen

### DIFF
--- a/ogr/ogrsf_frmts/dxf/ogrdxf_feature.cpp
+++ b/ogr/ogrsf_frmts/dxf/ogrdxf_feature.cpp
@@ -146,9 +146,9 @@ OGRDXFFeature::GetColor(OGRDXFDataSource *const poDS,
         (poBlockFeature &&
          poBlockFeature->oStyleProperties.count("Hidden") > 0))
     {
-        // Hidden objects should never be shown no matter what happens,
-        // so they can be treated as if they are on a frozen layer
-        iHidden = 2;
+        // Hidden objects should never be shown no matter what happens
+        iHidden = 1;
+        oStyleProperties["Hidden"] = "1";
     }
     else
     {
@@ -166,13 +166,13 @@ OGRDXFFeature::GetColor(OGRDXFDataSource *const poDS,
             if (pszBlockHidden && atoi(pszBlockHidden) == 2)
                 iHidden = 2;
         }
-    }
 
-    // If this feature is on a frozen layer, make the object totally
-    // hidden so it won't reappear if we regenerate the style string again
-    // during block insertion
-    if (iHidden == 2)
-        oStyleProperties["Hidden"] = "1";
+        // If this feature is on a frozen layer (other than layer 0), make the
+        // object totally hidden so it won't reappear if we regenerate the style
+        // string again during block insertion
+        if (iHidden == 2 && !EQUAL(GetFieldAsString("Layer"), "0"))
+            oStyleProperties["Hidden"] = "1";
+    }
 
     // Helpful constants
     const int C_BYLAYER = 256;


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

Layer 0 is a magical layer in DWG/DXF files when it comes to block insertion. Freezing layer 0 in AutoCAD does not affect block entities on layer 0. This change brings GDAL into line with that behaviour.

## What are related issues/pull requests?

None - own motion

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
