### PR TITLE
CPLTurnFailureIntoWarning backuper

### DIFF
--- a/alg/gdaltransformer.cpp
+++ b/alg/gdaltransformer.cpp
@@ -524,11 +524,11 @@ retry:
     /* -------------------------------------------------------------------- */
     /*      Transform them to the output coordinate system.                 */
     /* -------------------------------------------------------------------- */
-    CPLTurnFailureIntoWarning(true);
-    pfnTransformer(pTransformArg, FALSE, nSamplePoints, padfX, padfY, padfZ,
-                   pabSuccess);
-    CPLTurnFailureIntoWarning(false);
-
+    {
+        CPLTurnFailureIntoWarningBackuper oErrorsToWarnings{};
+        pfnTransformer(pTransformArg, FALSE, nSamplePoints, padfX, padfY, padfZ,
+                       pabSuccess);
+    }
     constexpr int SIGN_FINAL_UNINIT = -2;
     constexpr int SIGN_FINAL_INVALID = 0;
     int iSignDiscontinuity = SIGN_FINAL_UNINIT;
@@ -588,7 +588,7 @@ retry:
                     double ayTemp[2] = {padfY[i], padfY[i]};
                     double azTemp[2] = {padfZ[i], padfZ[i]};
                     int abSuccess[2] = {FALSE, FALSE};
-                    CPLTurnFailureIntoWarning(true);
+                    CPLTurnFailureIntoWarningBackuper oErrorsToWarnings{};
                     if (pfnTransformer(pTransformArg, TRUE, 2, axTemp, ayTemp,
                                        azTemp, abSuccess) &&
                         fabs(axTemp[0] - axTemp[1]) < 1e-8 &&
@@ -596,7 +596,6 @@ retry:
                     {
                         padfX[i] = iSignDiscontinuity * 180.0;
                     }
-                    CPLTurnFailureIntoWarning(false);
                 }
             }
         }
@@ -615,10 +614,11 @@ retry:
         memcpy(padfXRevert, padfX, nSamplePoints * sizeof(double));
         memcpy(padfYRevert, padfY, nSamplePoints * sizeof(double));
         memcpy(padfZRevert, padfZ, nSamplePoints * sizeof(double));
-        CPLTurnFailureIntoWarning(true);
-        pfnTransformer(pTransformArg, TRUE, nSamplePoints, padfXRevert,
-                       padfYRevert, padfZRevert, pabSuccess);
-        CPLTurnFailureIntoWarning(false);
+        {
+            CPLTurnFailureIntoWarningBackuper oErrorsToWarnings{};
+            pfnTransformer(pTransformArg, TRUE, nSamplePoints, padfXRevert,
+                           padfYRevert, padfZRevert, pabSuccess);
+        }
 
         for (int i = 0; nFailedCount == 0 && i < nSamplePoints; i++)
         {
@@ -693,10 +693,11 @@ retry:
 
         CPLAssert(nSamplePoints == nSampleMax);
 
-        CPLTurnFailureIntoWarning(true);
-        pfnTransformer(pTransformArg, FALSE, nSamplePoints, padfX, padfY, padfZ,
-                       pabSuccess);
-        CPLTurnFailureIntoWarning(false);
+        {
+            CPLTurnFailureIntoWarningBackuper oErrorsToWarnings{};
+            pfnTransformer(pTransformArg, FALSE, nSamplePoints, padfX, padfY,
+                           padfZ, pabSuccess);
+        }
     }
 
     /* -------------------------------------------------------------------- */

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -29,7 +29,7 @@ doxygen:
 doxygen_check_warnings:
 	@echo "Checking that Doxygen runs without warnings..."
 	@$(MAKE) -B $(BUILDDIR)/.doxygen_up_to_date > /tmp/doxygen_gdal_log.txt 2>&1
-	@if grep -i warning /tmp/doxygen_gdal_log.txt; then \
+	@if grep "warning:" /tmp/doxygen_gdal_log.txt; then \
 		echo "Doxygen warnings found!"; \
 		echo "---------"; \
 		echo "Full log:"; \
@@ -39,7 +39,7 @@ doxygen_check_warnings:
 		echo "--------------------"; \
 		echo "Extract of warnings:"; \
 		echo "--------------------"; \
-		grep -i warning /tmp/doxygen_gdal_log.txt; \
+		grep "warning:" /tmp/doxygen_gdal_log.txt; \
 		echo "-----------------------"; \
 		echo "Doxygen warnings found!"; \
 		/bin/false; \

--- a/frmts/gtiff/gtiffdataset_read.cpp
+++ b/frmts/gtiff/gtiffdataset_read.cpp
@@ -7123,12 +7123,15 @@ void *GTiffDataset::CacheMultiRange(int nXOff, int nYOff, int nXSize,
                 // as this method is an optimization, and if it fails,
                 // tile-by-tile data acquisition will be done, so we can
                 // temporary turn failures into warnings.
-                CPLTurnFailureIntoWarning(true);
-                const bool ok =
-                    VSIFReadMultiRangeL(static_cast<int>(anSizes.size()),
-                                        &apData[0], &anOffsets[0], &anSizes[0],
-                                        fp) == 0;
-                CPLTurnFailureIntoWarning(false);
+                bool ok;
+                {
+                    CPLTurnFailureIntoWarningBackuper
+                        oFailureToWarninBackuper{};
+                    ok = VSIFReadMultiRangeL(static_cast<int>(anSizes.size()),
+                                             &apData[0], &anOffsets[0],
+                                             &anSizes[0], fp) == 0;
+                }
+
                 if (ok)
                 {
                     if (!oMapStrileToOffsetByteCount.empty() &&

--- a/frmts/safe/safedataset.cpp
+++ b/frmts/safe/safedataset.cpp
@@ -1297,11 +1297,14 @@ GDALDataset *SAFEDataset::Open(GDALOpenInfo *poOpenInfo)
             /*      Try and open the file. */
             /* --------------------------------------------------------------------
              */
-            CPLTurnFailureIntoWarning(true);
-            auto poBandFile = std::unique_ptr<GDALDataset>(
-                GDALDataset::Open(osFullFilename.c_str(),
-                                  GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR));
-            CPLTurnFailureIntoWarning(false);
+            std::unique_ptr<GDALDataset> poBandFile;
+            {
+                CPLTurnFailureIntoWarningBackuper oErrorsToWarnings{};
+                poBandFile = std::unique_ptr<GDALDataset>(
+                    GDALDataset::Open(osFullFilename.c_str(),
+                                      GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR));
+            }
+
             if (poBandFile == nullptr)
             {
                 // NOP

--- a/gcore/gdal_misc.cpp
+++ b/gcore/gdal_misc.cpp
@@ -4518,14 +4518,13 @@ GDALDataset *GDALFindAssociatedAuxFile(const char *pszBasename,
             /* Avoid causing failure in opening of main file from SWIG bindings
              */
             /* when auxiliary file cannot be opened (#3269) */
-            CPLTurnFailureIntoWarning(TRUE);
+            CPLTurnFailureIntoWarningBackuper oErrorsToWarnings{};
             if (poDependentDS != nullptr && poDependentDS->GetShared())
                 poODS = GDALDataset::FromHandle(
                     GDALOpenShared(osAuxFilename, eAccess));
             else
                 poODS =
                     GDALDataset::FromHandle(GDALOpen(osAuxFilename, eAccess));
-            CPLTurnFailureIntoWarning(FALSE);
         }
         CPL_IGNORE_RET_VAL(VSIFCloseL(fp));
     }
@@ -4618,14 +4617,13 @@ GDALDataset *GDALFindAssociatedAuxFile(const char *pszBasename,
                 /* Avoid causing failure in opening of main file from SWIG
                  * bindings */
                 /* when auxiliary file cannot be opened (#3269) */
-                CPLTurnFailureIntoWarning(TRUE);
+                CPLTurnFailureIntoWarningBackuper oErrorsToWarnings{};
                 if (poDependentDS != nullptr && poDependentDS->GetShared())
                     poODS = GDALDataset::FromHandle(
                         GDALOpenShared(osAuxFilename, eAccess));
                 else
                     poODS = GDALDataset::FromHandle(
                         GDALOpen(osAuxFilename, eAccess));
-                CPLTurnFailureIntoWarning(FALSE);
             }
             CPL_IGNORE_RET_VAL(VSIFCloseL(fp));
         }

--- a/ogr/ogrsf_frmts/adbc/ogradbcdataset.cpp
+++ b/ogr/ogrsf_frmts/adbc/ogradbcdataset.cpp
@@ -518,10 +518,9 @@ bool OGRADBCDataset::Open(const GDALOpenInfo *poOpenInfo)
             const std::string osStatement =
                 CPLSPrintf("SELECT * FROM \"%s\"",
                            OGRDuplicateCharacter(pszLayerName, '"').c_str());
-            CPLTurnFailureIntoWarning(true);
+            CPLTurnFailureIntoWarningBackuper oErrorsToWarnings{};
             auto poLayer =
                 CreateLayer(osStatement.c_str(), pszLayerName, false);
-            CPLTurnFailureIntoWarning(false);
             if (poLayer)
             {
                 m_apoLayers.emplace_back(std::move(poLayer));
@@ -550,11 +549,10 @@ bool OGRADBCDataset::Open(const GDALOpenInfo *poOpenInfo)
                            OGRDuplicateCharacter(pszNamespace, '"').c_str(),
                            OGRDuplicateCharacter(pszTableName, '"').c_str());
 
-            CPLTurnFailureIntoWarning(true);
+            CPLTurnFailureIntoWarningBackuper oErrorsToWarnings{};
             auto poLayer = CreateLayer(
                 osStatement.c_str(),
                 CPLSPrintf("%s.%s", pszNamespace, pszTableName), false);
-            CPLTurnFailureIntoWarning(false);
             if (poLayer)
             {
                 m_apoLayers.emplace_back(std::move(poLayer));

--- a/port/cpl_error.h
+++ b/port/cpl_error.h
@@ -377,6 +377,23 @@ extern "C++"
          */
         ~CPLErrorStateBackuper();
     };
+
+    /** Class that turns errors into warning on construction, and
+     *  restores the previous state on destruction.
+     */
+    class CPL_DLL CPLTurnFailureIntoWarningBackuper
+    {
+      public:
+        CPLTurnFailureIntoWarningBackuper()
+        {
+            CPLTurnFailureIntoWarning(true);
+        }
+
+        ~CPLTurnFailureIntoWarningBackuper()
+        {
+            CPLTurnFailureIntoWarning(false);
+        }
+    };
 }
 
 #ifdef GDAL_COMPILATION


### PR DESCRIPTION
Small utility class to set TurnFailureIntoWarning and restore it when deleted.

Fix #11831
