### PR TITLE
Fix build when iterators are raw pointers

### DIFF
--- a/apps/argparse/argparse.hpp
+++ b/apps/argparse/argparse.hpp
@@ -1007,8 +1007,7 @@ public:
     if ((dist = static_cast<std::size_t>(std::distance(start, end))) >=
         num_args_min) {
       if (num_args_max < dist) {
-        end = std::next(start, static_cast<typename Iterator::difference_type>(
-                                   num_args_max));
+        end = std::next(start, num_args_max));
       }
       if (!m_accepts_optional_like_value) {
         end = std::find_if(

--- a/apps/argparse/argparse.hpp
+++ b/apps/argparse/argparse.hpp
@@ -1007,7 +1007,7 @@ public:
     if ((dist = static_cast<std::size_t>(std::distance(start, end))) >=
         num_args_min) {
       if (num_args_max < dist) {
-        end = std::next(start, num_args_max));
+        end = std::next(start, num_args_max);
       }
       if (!m_accepts_optional_like_value) {
         end = std::find_if(


### PR DESCRIPTION
Similar to #11879, `typename Iterator` might be just a raw pointer. The most corrent way would be using `std::iterator_traits` to get the type properly, but it seems that current static_cast can be simply removed.
