### PR TITLE
Add missing #include with struct timeval declaration

### DIFF
--- a/ogr/ogr_geocoding.cpp
+++ b/ogr/ogr_geocoding.cpp
@@ -34,6 +34,7 @@
 
 #include <time.h>
 #include <windows.h>
+#include <winsock.h>
 
 // Recent mingw define struct timezone.
 #if !(defined(__GNUC__) && defined(_TIMEZONE_DEFINED))


### PR DESCRIPTION
learn.microsoft.com explicitly recommends including winsock.h to get `struct timeval` definition.

Current version breaks when compiling with `-DWIN32_LEAN_AND_MEAN`.
