### PR TITLE
MiraMonVector fix error: Unexpected Non-nullptr Return

### DIFF
--- a/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
+++ b/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
@@ -5318,7 +5318,16 @@ char *MMReturnValueFromSectionINIFile(const char *filename, const char *section,
         }
         else
         {
-            value = section_header;  // Freed out
+            if (section_header)
+            {
+                if (!strcmp(section_header, section))
+                    value = section_header;  // Freed out
+                else
+                    value = nullptr;
+            }
+            else
+                value = nullptr;
+
             fclose_function(file);
             free_function(pszString);
             return value;
@@ -6107,6 +6116,7 @@ int MMCheck_REL_FILE(const char *szREL_file)
         MMCPLError(CE_Failure, CPLE_OpenFailed,
                    "The file \"%s\" must be REL4. "
                    "You can use ConvREL.exe from MiraMon software "
+                   " or GeM+ "
                    "to convert this file to REL4.",
                    szREL_file);
         return 1;


### PR DESCRIPTION
## What does this PR do?
Fixes the error: A nullptr is expected when the section is not present in an INI file. However, in a particular case, the function MMReturnValueFromSectionINIFile returned a value other than nullptr. Although this did not cause an immediate error, it resulted in incorrect information being presented to the user.

No tests needed because it's a matter of information in a rare case.

Some user information has been corrected and updated in a not supported old metadata case.

Ignore the name of the MiraMonRaster branch (it is a name I had prepared for a future development).

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] All CI builds and checks have passed
