### PR TITLE
Set an empty GDAL_RELEASE_NICKNAME by default

### DIFF
--- a/gcore/gdal_misc.cpp
+++ b/gcore/gdal_misc.cpp
@@ -2837,7 +2837,7 @@ int CPL_STDCALL GDALWriteWorldFile(const char *pszBaseFilename,
  * string. i.e. "20230312".</li>
  * <li> "RELEASE_NAME": Returns the GDAL_RELEASE_NAME. ie. "3.6.3"</li>
  * <li> "RELEASE_NICKNAME": (>= 3.11) Returns the GDAL_RELEASE_NICKNAME.
- * i.e. "Trans rights are human rights"</li>
+ * (may be empty)</li>
  * <li> "--version": Returns one line version message suitable for
  * use in response to --version requests.  i.e. "GDAL 3.6.3, released
  * 2023/03/12"</li>
@@ -3002,7 +3002,7 @@ const char *CPL_STDCALL GDALVersionInfo(const char *pszRequest)
     else if (EQUAL(pszRequest, "RELEASE_NAME"))
         osVersionInfo.Printf(GDAL_RELEASE_NAME);
     else if (EQUAL(pszRequest, "RELEASE_NICKNAME"))
-        osVersionInfo.Printf(GDAL_RELEASE_NICKNAME);
+        osVersionInfo.Printf("%s", GDAL_RELEASE_NICKNAME);
     else  // --version
     {
         osVersionInfo.Printf(

--- a/gcore/gdal_version.h.in
+++ b/gcore/gdal_version.h.in
@@ -29,6 +29,8 @@
 #  define GDAL_RELEASE_NAME     "3.11.0dev"
 #endif
 
-#define GDAL_RELEASE_NICKNAME   "Trans rights are human rights"
+#ifndef GDAL_RELEASE_NICKNAME
+#define GDAL_RELEASE_NICKNAME   ""
+#endif
 
 #endif


### PR DESCRIPTION
Not that the previous default has to be denied in any way, but there are serious concerns that it could cause high collateral damage and endanger people doing good.
