### PR TITLE
[Backport release/3.10] MiraMonVector fix error: Unexpected Non-nullptr Return

### DIFF
--- a/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
+++ b/ogr/ogrsf_frmts/miramon/mm_wrlayr.c
@@ -5315,7 +5315,16 @@ char *MMReturnValueFromSectionINIFile(const char *filename, const char *section,
         }
         else
         {
-            value = section_header;  // Freed out
+            if (section_header)
+            {
+                if (!strcmp(section_header, section))
+                    value = section_header;  // Freed out
+                else
+                    value = nullptr;
+            }
+            else
+                value = nullptr;
+
             fclose_function(file);
             free_function(pszString);
             return value;
@@ -6079,6 +6088,7 @@ int MMCheck_REL_FILE(const char *szREL_file)
         MMCPLError(CE_Failure, CPLE_OpenFailed,
                    "The file \"%s\" must be REL4. "
                    "You can use ConvREL.exe from MiraMon software "
+                   " or GeM+ "
                    "to convert this file to REL4.",
                    szREL_file);
         return 1;


### PR DESCRIPTION
Backport #11884
 **Authored by:** @AbelPau