### PR TITLE
[Backport release/3.10] Add missing #include with struct timeval declaration

### DIFF
--- a/ogr/ogr_geocoding.cpp
+++ b/ogr/ogr_geocoding.cpp
@@ -34,6 +34,7 @@
 
 #include <time.h>
 #include <windows.h>
+#include <winsock.h>
 
 // Recent mingw define struct timezone.
 #if !(defined(__GNUC__) && defined(_TIMEZONE_DEFINED))


### PR DESCRIPTION
Backport #11881
 **Authored by:** @georgthegreat