### PR TITLE
gdalallregister.cpp: Finish removing rda driver.

### DIFF
--- a/frmts/gdalallregister.cpp
+++ b/frmts/gdalallregister.cpp
@@ -563,10 +563,6 @@ void CPL_STDCALL GDALAllRegister()
     GDALRegister_COASP();
 #endif
 
-#ifdef FRMT_r
-    GDALRegister_R();
-#endif
-
 #ifdef FRMT_map
     GDALRegister_MAP();
 #endif


### PR DESCRIPTION
Follow on to these commits:

- 67992681aeadfac03ca4793889ba34a8937cbe72 - Remove R Object Data Store (*.rda) driver
- a4de9c081b9a3a7022c0e79575b88b5fc17ae77a Merge pull request #11758 from rouault/remove_geoconcept
  - This was cumulative with previous PRs and contains the removal of rda