### PR TITLE
doc: update tile terminology in pmtiles.rst

### DIFF
--- a/doc/source/drivers/vector/pmtiles.rst
+++ b/doc/source/drivers/vector/pmtiles.rst
@@ -11,7 +11,7 @@ PMTiles -- ProtoMaps Tiles
 .. built_in_by_default::
 
 This driver supports reading and writing `PMTiles <https://github.com/protomaps/PMTiles>`__
-datasets containing vector tiles, encoded in the MapVector Tiles (MVT) format.
+datasets containing vector tiles, encoded in the Mapbox Vector Tiles (MVT) format.
 
 PMTiles is a single-file archive format for tiled data. A PMTiles archive can
 be hosted on a commodity storage platform such as S3, and enables low-cost,


### PR DESCRIPTION
This fixes what I think is a error in the `pmtiles` docs by fixing `MapVector` to be `Mapbox Vector`. This matches the upstream format name at https://github.com/mapbox/vector-tile-spec