### PR TITLE
VRT and multitthreaded warp: propagate errors from auxiliary threads to main thread

### DIFF
--- a/frmts/gtiff/gtiffsplitbitmapband.cpp
+++ b/frmts/gtiff/gtiffsplitbitmapband.cpp
@@ -84,21 +84,22 @@ CPLErr GTiffSplitBitmapBand::IReadBlock(int /* nBlockXOff */, int nBlockYOff,
     {
         ++m_poGDS->m_nLoadedBlock;
 
-        std::vector<CPLErrorHandlerAccumulatorStruct> aoErrors;
-        CPLInstallErrorHandlerAccumulator(aoErrors);
-        int nRet = TIFFReadScanline(m_poGDS->m_hTIFF, m_poGDS->m_pabyBlockBuf,
-                                    m_poGDS->m_nLoadedBlock, 0);
-        CPLUninstallErrorHandlerAccumulator();
-
-        for (size_t iError = 0; iError < aoErrors.size(); ++iError)
+        CPLErrorAccumulator oErrorAccumulator;
+        int nRet;
         {
-            ReportError(aoErrors[iError].type, aoErrors[iError].no, "%s",
-                        aoErrors[iError].msg.c_str());
+            auto oAccumulator = oErrorAccumulator.InstallForCurrentScope();
+            nRet = TIFFReadScanline(m_poGDS->m_hTIFF, m_poGDS->m_pabyBlockBuf,
+                                    m_poGDS->m_nLoadedBlock, 0);
+        }
+
+        for (const auto &oError : oErrorAccumulator.GetErrors())
+        {
+            ReportError(oError.type, oError.no, "%s", oError.msg.c_str());
             // FAX decoding only handles EOF condition as a warning, so
             // catch it so as to turn on error when attempting to read
             // following lines, to avoid performance issues.
             if (!m_poGDS->m_bIgnoreReadErrors &&
-                aoErrors[iError].msg.find("Premature EOF") != std::string::npos)
+                oError.msg.find("Premature EOF") != std::string::npos)
             {
                 m_nLastLineValid = nBlockYOff;
                 nRet = -1;

--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -245,6 +245,7 @@ class CPL_DLL VRTDataset CPL_NON_FINAL : public GDALDataset
     friend struct VRTFlushCacheStruct<VRTProcessedDataset>;
     friend class VRTSourcedRasterBand;
     friend class VRTSimpleSource;
+    friend struct VRTSourcedRasterBandRasterIOJob;
     friend VRTDatasetH CPL_STDCALL VRTCreate(int nXSize, int nYSize);
 
     std::vector<gdal::GCP> m_asGCPs{};
@@ -302,34 +303,6 @@ class CPL_DLL VRTDataset CPL_NON_FINAL : public GDALDataset
     bool GetShiftedDataset(int nXOff, int nYOff, int nXSize, int nYSize,
                            GDALDataset *&poSrcDataset, int &nSrcXOff,
                            int &nSrcYOff);
-
-    /** Structure used to declare a threaded job to satisfy IRasterIO()
-     * on a given source.
-     */
-    struct RasterIOJob
-    {
-        std::atomic<int> *pnCompletedJobs = nullptr;
-        std::atomic<bool> *pbSuccess = nullptr;
-
-        GDALDataType eVRTBandDataType = GDT_Unknown;
-        int nXOff = 0;
-        int nYOff = 0;
-        int nXSize = 0;
-        int nYSize = 0;
-        void *pData = nullptr;
-        int nBufXSize = 0;
-        int nBufYSize = 0;
-        int nBandCount = 0;
-        BANDMAP_TYPE panBandMap = nullptr;
-        GDALDataType eBufType = GDT_Unknown;
-        GSpacing nPixelSpace = 0;
-        GSpacing nLineSpace = 0;
-        GSpacing nBandSpace = 0;
-        GDALRasterIOExtraArg *psExtraArg = nullptr;
-        VRTSimpleSource *poSource = nullptr;
-
-        static void Func(void *pData);
-    };
 
     CPL_DISALLOW_COPY_ASSIGN(VRTDataset)
 
@@ -957,32 +930,6 @@ class CPL_DLL VRTSourcedRasterBand CPL_NON_FINAL : public VRTRasterBand
 
     bool IsMosaicOfNonOverlappingSimpleSourcesOfFullRasterNoResAndTypeChange(
         bool bAllowMaxValAdjustment) const;
-
-    /** Structure used to declare a threaded job to satisfy IRasterIO()
-     * on a given source.
-     */
-    struct RasterIOJob
-    {
-        std::atomic<int> *pnCompletedJobs = nullptr;
-        std::atomic<bool> *pbSuccess = nullptr;
-        VRTDataset::QueueWorkingStates *poQueueWorkingStates = nullptr;
-
-        GDALDataType eVRTBandDataType = GDT_Unknown;
-        int nXOff = 0;
-        int nYOff = 0;
-        int nXSize = 0;
-        int nYSize = 0;
-        void *pData = nullptr;
-        int nBufXSize = 0;
-        int nBufYSize = 0;
-        GDALDataType eBufType = GDT_Unknown;
-        GSpacing nPixelSpace = 0;
-        GSpacing nLineSpace = 0;
-        GDALRasterIOExtraArg *psExtraArg = nullptr;
-        VRTSimpleSource *poSource = nullptr;
-
-        static void Func(void *pData);
-    };
 
     CPL_DISALLOW_COPY_ASSIGN(VRTSourcedRasterBand)
 

--- a/port/cpl_error.cpp
+++ b/port/cpl_error.cpp
@@ -1536,30 +1536,6 @@ bool CPLIsDefaultErrorHandlerAndCatchDebug()
 }
 
 /************************************************************************/
-/*                    CPLErrorAccumulatorFunc()                         */
-/************************************************************************/
-
-static void CPL_STDCALL CPLErrorAccumulatorFunc(CPLErr eErr, CPLErrorNum no,
-                                                const char *msg)
-{
-    std::vector<CPLErrorHandlerAccumulatorStruct> *paoErrors =
-        static_cast<std::vector<CPLErrorHandlerAccumulatorStruct> *>(
-            CPLGetErrorHandlerUserData());
-    paoErrors->push_back(CPLErrorHandlerAccumulatorStruct(eErr, no, msg));
-}
-
-void CPLInstallErrorHandlerAccumulator(
-    std::vector<CPLErrorHandlerAccumulatorStruct> &aoErrors)
-{
-    CPLPushErrorHandlerEx(CPLErrorAccumulatorFunc, &aoErrors);
-}
-
-void CPLUninstallErrorHandlerAccumulator()
-{
-    CPLPopErrorHandler();
-}
-
-/************************************************************************/
 /*               CPLErrorStateBackuper::CPLErrorStateBackuper()         */
 /************************************************************************/
 

--- a/port/cpl_error_internal.h
+++ b/port/cpl_error_internal.h
@@ -19,10 +19,12 @@
 
 #include "cpl_error.h"
 #include "cpl_string.h"
+
+#include <mutex>
 #include <vector>
 
 /************************************************************************/
-/*                      ErrorHandlerAccumulator()                       */
+/*                CPLErrorHandlerAccumulatorStruct                      */
 /************************************************************************/
 
 class CPL_DLL CPLErrorHandlerAccumulatorStruct
@@ -46,6 +48,52 @@ class CPL_DLL CPLErrorHandlerAccumulatorStruct
 void CPL_DLL CPLInstallErrorHandlerAccumulator(
     std::vector<CPLErrorHandlerAccumulatorStruct> &aoErrors);
 void CPL_DLL CPLUninstallErrorHandlerAccumulator();
+
+/************************************************************************/
+/*                       CPLErrorAccumulator                            */
+/************************************************************************/
+
+/** Class typically used by a worker thread to store errors emitted by their
+ * worker functions, and replay them in the main thread.
+ *
+ * An instance of CPLErrorAccumulator can be shared by several
+ * threads. Each thread calls InstallForCurrentScope() in its processing
+ * function. The main thread may invoke ReplayErrors() to replay errors (and
+ * warnings).
+ *
+ * @since 3.11
+ */
+class CPL_DLL CPLErrorAccumulator
+{
+  public:
+    /** Constructor */
+    CPLErrorAccumulator() = default;
+
+    struct Context
+    {
+        ~Context();
+    };
+
+    /** Install a temporary error handler that will store errors and warnings.
+     */
+    Context InstallForCurrentScope() CPL_WARN_UNUSED_RESULT;
+
+    /** Return error list. */
+    const std::vector<CPLErrorHandlerAccumulatorStruct> &GetErrors() const
+    {
+        return errors;
+    }
+
+    /** Replay stored errors. */
+    void ReplayErrors();
+
+  private:
+    std::mutex mutex{};
+    std::vector<CPLErrorHandlerAccumulatorStruct> errors{};
+
+    static void CPL_STDCALL Accumulator(CPLErr eErr, CPLErrorNum no,
+                                        const char *msg);
+};
 
 #endif
 

--- a/port/cpl_error_internal.h
+++ b/port/cpl_error_internal.h
@@ -69,7 +69,7 @@ class CPL_DLL CPLErrorAccumulator
     /** Constructor */
     CPLErrorAccumulator() = default;
 
-    struct Context
+    struct CPL_DLL Context
     {
         ~Context();
     };

--- a/port/cpl_error_internal.h
+++ b/port/cpl_error_internal.h
@@ -45,10 +45,6 @@ class CPL_DLL CPLErrorHandlerAccumulatorStruct
     }
 };
 
-void CPL_DLL CPLInstallErrorHandlerAccumulator(
-    std::vector<CPLErrorHandlerAccumulatorStruct> &aoErrors);
-void CPL_DLL CPLUninstallErrorHandlerAccumulator();
-
 /************************************************************************/
 /*                       CPLErrorAccumulator                            */
 /************************************************************************/


### PR DESCRIPTION
Fixes #11904 

also uses a cleaner infrastructure to do that and retrofit its use everywhere where the old infrastructure was used previously