### PR TITLE
Pansharpen: avoid I/O errors when extent of PAN and MS bands differ by less than the resolution of the MS band

### DIFF
--- a/alg/gdalpansharpen.h
+++ b/alg/gdalpansharpen.h
@@ -140,29 +140,32 @@ typedef struct
     CPLErr eErr;
 } GDALPansharpenJob;
 
-typedef struct
+struct GDALPansharpenResampleJob
 {
-    GDALDataset *poMEMDS;
-    int nXOff;
-    int nYOff;
-    int nXSize;
-    int nYSize;
-    double dfXOff;
-    double dfYOff;
-    double dfXSize;
-    double dfYSize;
-    void *pBuffer;
-    GDALDataType eDT;
-    int nBufXSize;
-    int nBufYSize;
-    int nBandCount;
-    GDALRIOResampleAlg eResampleAlg;
-    GSpacing nBandSpace;
+    GDALDataset *poMEMDS = nullptr;
+    int nXOff = 0;
+    int nYOff = 0;
+    int nXSize = 0;
+    int nYSize = 0;
+    double dfXOff = 0;
+    double dfYOff = 0;
+    double dfXSize = 0;
+    double dfYSize = 0;
+    void *pBuffer = nullptr;
+    GDALDataType eDT = GDT_Unknown;
+    int nBufXSize = 0;
+    int nBufYSize = 0;
+    int nBandCount = 0;
+    GDALRIOResampleAlg eResampleAlg = GRIORA_NearestNeighbour;
+    GSpacing nBandSpace = 0;
 
 #ifdef DEBUG_TIMING
-    struct timeval *ptv;
+    struct timeval *ptv = nullptr;
 #endif
-} GDALPansharpenResampleJob;
+
+    CPLErr eErr = CE_Failure;
+    std::string osLastErrorMsg{};
+};
 
 class CPLWorkerThreadPool;
 

--- a/autotest/gdrivers/vrtpansharpen.py
+++ b/autotest/gdrivers/vrtpansharpen.py
@@ -2385,3 +2385,51 @@ def test_vrtpansharpen_open_options_input_bands():
         )
         # Not the prettiest way to check that open options are used, but that does the job...
         assert "small_world.tif: Invalid value for NUM_THREADS: foo" in msgs
+
+
+###############################################################################
+# Test fix for #11889
+
+
+def test_vrtpansharpen_slightly_different_extent(tmp_vsimem):
+
+    ds = gdal.GetDriverByName("GTiff").Create(
+        "/vsimem/pan.tif", 1000, 1000, 1, gdal.GDT_Byte
+    )
+    ds.SetGeoTransform([0, 1.0 / 1000, 0, 0, 0, -1.0 / 1000])
+    ds.GetRasterBand(1).Fill(30)
+    ds = None
+    ds = gdal.GetDriverByName("GTiff").Create(
+        "/vsimem/ms.tif", 500, 500, 2, gdal.GDT_Byte
+    )
+    ds.SetGeoTransform(
+        [0, 1.0 / 500 - 1.0 / 300000, 0, 0, 0, -(1.0 / 500 - 1.0 / 300000)]
+    )
+    ds.GetRasterBand(1).Fill(10)
+    ds.GetRasterBand(2).Fill(20)
+    ds = None
+
+    vrt_ds = gdal.Open(
+        """<VRTDataset subClass="VRTPansharpenedDataset">
+        <PansharpeningOptions>
+            <NumThreads>ALL_CPUS</NumThreads>
+            <PanchroBand>
+                    <SourceFilename relativeToVRT="1">/vsimem/pan.tif</SourceFilename>
+                    <SourceBand>1</SourceBand>
+            </PanchroBand>
+            <SpectralBand dstBand="1">
+                    <SourceFilename relativeToVRT="1">/vsimem/ms.tif</SourceFilename>
+                    <SourceBand>1</SourceBand>
+            </SpectralBand>
+            <SpectralBand dstBand="2">
+                    <SourceFilename relativeToVRT="1">/vsimem/ms.tif</SourceFilename>
+                    <SourceBand>2</SourceBand>
+            </SpectralBand>
+        </PansharpeningOptions>
+    </VRTDataset>"""
+    )
+    mm = [
+        vrt_ds.GetRasterBand(i + 1).ComputeRasterMinMax()
+        for i in range(vrt_ds.RasterCount)
+    ]
+    assert mm == [(20.0, 20.0), (40.0, 40.0)]


### PR DESCRIPTION
Fixes #11889