### PR TITLE
[Backport release/3.10] Pansharpen: avoid I/O errors when extent of PAN and MS bands differ by less than the resolution of the MS band

### DIFF
--- a/alg/gdalpansharpen.cpp
+++ b/alg/gdalpansharpen.cpp
@@ -1211,13 +1211,17 @@ CPLErr GDALPansharpenOperation::ProcessRegion(int nXOff, int nYOff, int nXSize,
     sExtraArg.dfXSize = nXSize * m_adfPanToMSGT[1];
     sExtraArg.dfYSize = nYSize * m_adfPanToMSGT[5];
     if (sExtraArg.dfXOff + sExtraArg.dfXSize > aMSBands[0]->GetXSize())
-        sExtraArg.dfXOff = aMSBands[0]->GetXSize() - sExtraArg.dfXSize;
+        sExtraArg.dfXSize = aMSBands[0]->GetXSize() - sExtraArg.dfXOff;
     if (sExtraArg.dfYOff + sExtraArg.dfYSize > aMSBands[0]->GetYSize())
-        sExtraArg.dfYOff = aMSBands[0]->GetYSize() - sExtraArg.dfYSize;
+        sExtraArg.dfYSize = aMSBands[0]->GetYSize() - sExtraArg.dfYOff;
     int nSpectralXOff = static_cast<int>(sExtraArg.dfXOff);
     int nSpectralYOff = static_cast<int>(sExtraArg.dfYOff);
     int nSpectralXSize = static_cast<int>(0.49999 + sExtraArg.dfXSize);
     int nSpectralYSize = static_cast<int>(0.49999 + sExtraArg.dfYSize);
+    if (nSpectralXOff + nSpectralXSize > aMSBands[0]->GetXSize())
+        nSpectralXSize = aMSBands[0]->GetXSize() - nSpectralXOff;
+    if (nSpectralYOff + nSpectralYSize > aMSBands[0]->GetYSize())
+        nSpectralYSize = aMSBands[0]->GetYSize() - nSpectralYOff;
     if (nSpectralXSize == 0)
         nSpectralXSize = 1;
     if (nSpectralYSize == 0)
@@ -1364,17 +1368,15 @@ CPLErr GDALPansharpenOperation::ProcessRegion(int nXOff, int nYOff, int nXSize,
                     pasJobs[i].dfXSize = sExtraArg.dfXSize;
                     pasJobs[i].dfYSize =
                         (iNextStartLine - iStartLine) * m_adfPanToMSGT[5];
-                    if (pasJobs[i].dfXOff + pasJobs[i].dfXSize >
-                        aMSBands[0]->GetXSize())
+                    if (pasJobs[i].dfXOff + pasJobs[i].dfXSize > nXSizeExtract)
                     {
-                        pasJobs[i].dfXOff =
-                            aMSBands[0]->GetXSize() - pasJobs[i].dfXSize;
+                        pasJobs[i].dfXSize = nYSizeExtract - pasJobs[i].dfXOff;
                     }
                     if (pasJobs[i].dfYOff + pasJobs[i].dfYSize >
                         aMSBands[0]->GetYSize())
                     {
-                        pasJobs[i].dfYOff =
-                            aMSBands[0]->GetYSize() - pasJobs[i].dfYSize;
+                        pasJobs[i].dfYSize =
+                            aMSBands[0]->GetYSize() - pasJobs[i].dfYOff;
                     }
                     pasJobs[i].nXOff = static_cast<int>(pasJobs[i].dfXOff);
                     pasJobs[i].nYOff = static_cast<int>(pasJobs[i].dfYOff);
@@ -1382,6 +1384,14 @@ CPLErr GDALPansharpenOperation::ProcessRegion(int nXOff, int nYOff, int nXSize,
                         static_cast<int>(0.4999 + pasJobs[i].dfXSize);
                     pasJobs[i].nYSize =
                         static_cast<int>(0.4999 + pasJobs[i].dfYSize);
+                    if (pasJobs[i].nXOff + pasJobs[i].nXSize > nXSizeExtract)
+                    {
+                        pasJobs[i].nXSize = nXSizeExtract - pasJobs[i].nXOff;
+                    }
+                    if (pasJobs[i].nYOff + pasJobs[i].nYSize > nYSizeExtract)
+                    {
+                        pasJobs[i].nYSize = nYSizeExtract - pasJobs[i].nYOff;
+                    }
                     if (pasJobs[i].nXSize == 0)
                         pasJobs[i].nXSize = 1;
                     if (pasJobs[i].nYSize == 0)
@@ -1399,6 +1409,8 @@ CPLErr GDALPansharpenOperation::ProcessRegion(int nXOff, int nYOff, int nXSize,
 #ifdef DEBUG_TIMING
                     pasJobs[i].ptv = &tv;
 #endif
+                    pasJobs[i].eErr = CE_Failure;
+
                     ahJobData[i] = &(pasJobs[i]);
                 }
 #ifdef DEBUG_TIMING
@@ -1407,6 +1419,21 @@ CPLErr GDALPansharpenOperation::ProcessRegion(int nXOff, int nYOff, int nXSize,
                 poThreadPool->SubmitJobs(PansharpenResampleJobThreadFunc,
                                          ahJobData);
                 poThreadPool->WaitCompletion();
+
+                for (int i = 0; i < nTasks; i++)
+                {
+                    if (pasJobs[i].eErr == CE_Failure)
+                    {
+                        CPLError(CE_Failure, CPLE_AppDefined, "%s",
+                                 pasJobs[i].osLastErrorMsg.c_str());
+                        GDALClose(poMEMDS);
+                        VSIFree(pSpectralBuffer);
+                        VSIFree(pUpsampledSpectralBuffer);
+                        VSIFree(pPanBuffer);
+
+                        return CE_Failure;
+                    }
+                }
             }
         }
 
@@ -1595,8 +1622,6 @@ CPLErr GDALPansharpenOperation::ProcessRegion(int nXOff, int nYOff, int nXSize,
 /*                   PansharpenResampleJobThreadFunc()                  */
 /************************************************************************/
 
-// static int acc=0;
-
 void GDALPansharpenOperation::PansharpenResampleJobThreadFunc(void *pUserData)
 {
     GDALPansharpenResampleJob *psJob =
@@ -1612,10 +1637,6 @@ void GDALPansharpenOperation::PansharpenResampleJobThreadFunc(void *pUserData)
                               static_cast<GIntBig>(tv.tv_usec);
 #endif
 
-#if 0
-    for(int i=0;i<1000000;i++)
-        acc += i * i;
-#else
     GDALRasterIOExtraArg sExtraArg;
     INIT_RASTERIO_EXTRA_ARG(sExtraArg);
     // cppcheck-suppress redundantAssignment
@@ -1632,12 +1653,12 @@ void GDALPansharpenOperation::PansharpenResampleJobThreadFunc(void *pUserData)
     // This call to RasterIO() in a thread to poMEMDS shared between several
     // threads is really risky, but works given the implementation details...
     // Do not do this at home!
-    CPL_IGNORE_RET_VAL(psJob->poMEMDS->RasterIO(
+    psJob->eErr = psJob->poMEMDS->RasterIO(
         GF_Read, psJob->nXOff, psJob->nYOff, psJob->nXSize, psJob->nYSize,
         psJob->pBuffer, psJob->nBufXSize, psJob->nBufYSize, psJob->eDT,
-        psJob->nBandCount, anBands.data(), 0, 0, psJob->nBandSpace,
-        &sExtraArg));
-#endif
+        psJob->nBandCount, anBands.data(), 0, 0, psJob->nBandSpace, &sExtraArg);
+    if (CPLGetLastErrorType() == CE_Failure)
+        psJob->osLastErrorMsg = CPLGetLastErrorMsg();
 
 #ifdef DEBUG_TIMING
     struct timeval tv_end;

--- a/alg/gdalpansharpen.h
+++ b/alg/gdalpansharpen.h
@@ -140,29 +140,32 @@ typedef struct
     CPLErr eErr;
 } GDALPansharpenJob;
 
-typedef struct
+struct GDALPansharpenResampleJob
 {
-    GDALDataset *poMEMDS;
-    int nXOff;
-    int nYOff;
-    int nXSize;
-    int nYSize;
-    double dfXOff;
-    double dfYOff;
-    double dfXSize;
-    double dfYSize;
-    void *pBuffer;
-    GDALDataType eDT;
-    int nBufXSize;
-    int nBufYSize;
-    int nBandCount;
-    GDALRIOResampleAlg eResampleAlg;
-    GSpacing nBandSpace;
+    GDALDataset *poMEMDS = nullptr;
+    int nXOff = 0;
+    int nYOff = 0;
+    int nXSize = 0;
+    int nYSize = 0;
+    double dfXOff = 0;
+    double dfYOff = 0;
+    double dfXSize = 0;
+    double dfYSize = 0;
+    void *pBuffer = nullptr;
+    GDALDataType eDT = GDT_Unknown;
+    int nBufXSize = 0;
+    int nBufYSize = 0;
+    int nBandCount = 0;
+    GDALRIOResampleAlg eResampleAlg = GRIORA_NearestNeighbour;
+    GSpacing nBandSpace = 0;
 
 #ifdef DEBUG_TIMING
-    struct timeval *ptv;
+    struct timeval *ptv = nullptr;
 #endif
-} GDALPansharpenResampleJob;
+
+    CPLErr eErr = CE_Failure;
+    std::string osLastErrorMsg{};
+};
 
 class CPLWorkerThreadPool;
 

--- a/autotest/gdrivers/vrtpansharpen.py
+++ b/autotest/gdrivers/vrtpansharpen.py
@@ -2388,3 +2388,51 @@ def test_vrtpansharpen_open_options_input_bands():
         )
         # Not the prettiest way to check that open options are used, but that does the job...
         assert "small_world.tif: Invalid value for NUM_THREADS: foo" in msgs
+
+
+###############################################################################
+# Test fix for #11889
+
+
+def test_vrtpansharpen_slightly_different_extent(tmp_vsimem):
+
+    ds = gdal.GetDriverByName("GTiff").Create(
+        "/vsimem/pan.tif", 1000, 1000, 1, gdal.GDT_Byte
+    )
+    ds.SetGeoTransform([0, 1.0 / 1000, 0, 0, 0, -1.0 / 1000])
+    ds.GetRasterBand(1).Fill(30)
+    ds = None
+    ds = gdal.GetDriverByName("GTiff").Create(
+        "/vsimem/ms.tif", 500, 500, 2, gdal.GDT_Byte
+    )
+    ds.SetGeoTransform(
+        [0, 1.0 / 500 - 1.0 / 300000, 0, 0, 0, -(1.0 / 500 - 1.0 / 300000)]
+    )
+    ds.GetRasterBand(1).Fill(10)
+    ds.GetRasterBand(2).Fill(20)
+    ds = None
+
+    vrt_ds = gdal.Open(
+        """<VRTDataset subClass="VRTPansharpenedDataset">
+        <PansharpeningOptions>
+            <NumThreads>ALL_CPUS</NumThreads>
+            <PanchroBand>
+                    <SourceFilename relativeToVRT="1">/vsimem/pan.tif</SourceFilename>
+                    <SourceBand>1</SourceBand>
+            </PanchroBand>
+            <SpectralBand dstBand="1">
+                    <SourceFilename relativeToVRT="1">/vsimem/ms.tif</SourceFilename>
+                    <SourceBand>1</SourceBand>
+            </SpectralBand>
+            <SpectralBand dstBand="2">
+                    <SourceFilename relativeToVRT="1">/vsimem/ms.tif</SourceFilename>
+                    <SourceBand>2</SourceBand>
+            </SpectralBand>
+        </PansharpeningOptions>
+    </VRTDataset>"""
+    )
+    mm = [
+        vrt_ds.GetRasterBand(i + 1).ComputeRasterMinMax()
+        for i in range(vrt_ds.RasterCount)
+    ]
+    assert mm == [(20.0, 20.0), (40.0, 40.0)]


### PR DESCRIPTION
Backport #11924
 **Authored by:** @rouault