### PR TITLE
MRF: Fix JPEG max size and caching relative path handling

### DIFF
--- a/frmts/mrf/JPEG_band.cpp
+++ b/frmts/mrf/JPEG_band.cpp
@@ -933,6 +933,11 @@ JPEG_Band::JPEG_Band(MRFDataset *pDS, const ILImage &image, int b, int level)
     {
         codec.optimize = true;  // Required for 12bit
     }
+    // For high Q, no downsampling and multispectral, output can be larger than the input
+    // This is just a guess, 20% larger plus some space for the headers and mask
+    // If too small, the empty_output_buffer() above will be called and an
+    // error will be generated
+    poMRFDS->SetPBufferSize(int(1.2 * image.pageSizeBytes + 4000));
 }
 #endif
 

--- a/frmts/mrf/PNG_band.cpp
+++ b/frmts/mrf/PNG_band.cpp
@@ -309,8 +309,12 @@ CPLErr PNG_Codec::CompressPNG(buf_mgr &dst, const buf_mgr &src)
     // Let the quality control the compression level
     // Start at level 1, level 0 means uncompressed
     int zlvl = img.quality / 10;
-    if (0 == zlvl)
+    if (1 > zlvl)
         zlvl = 1;
+    // Max zlvl is 9
+    if (zlvl > 9)
+        zlvl = 9;
+
     png_set_compression_level(pngp, zlvl);
 
     // Custom strategy for zlib, set using the band option Z_STRATEGY

--- a/frmts/mrf/marfa_dataset.cpp
+++ b/frmts/mrf/marfa_dataset.cpp
@@ -1631,7 +1631,7 @@ static inline bool is_absolute(const CPLString &name)
 // returns true if name was modified
 static inline bool make_absolute(CPLString &name, const CPLString &path)
 {
-    if (!is_absolute(path) && (path.find_first_of("/\\") != string::npos))
+    if (!is_absolute(name) && (path.find_first_of("/\\") != string::npos))
     {
         name = path.substr(0, path.find_last_of("/\\") + 1) + name;
         return true;
@@ -1649,9 +1649,12 @@ GDALDataset *MRFDataset::GetSrcDS()
     if (source.empty())
         return nullptr;
 
+    // Stub out the error handler
+    CPLPushErrorHandler(CPLQuietErrorHandler);
     // Try open the source dataset as is
     poSrcDS =
         GDALDataset::FromHandle(GDALOpenShared(source.c_str(), GA_ReadOnly));
+    CPLPopErrorHandler();
 
     // It the open fails, try again with the current dataset path prepended
     if (!poSrcDS && make_absolute(source, fname))


### PR DESCRIPTION
## What does this PR do?
Fix two bugs in MRF:
- Handling of relative source path inside caching/cloning MRF
- Allow for output JPEG tiles to be larger than the raw input

## What are related issues/pull requests?

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
