### PR TITLE
New Transform type: Homography

### DIFF
--- a/alg/CMakeLists.txt
+++ b/alg/CMakeLists.txt
@@ -5,6 +5,7 @@ add_library(
   contour.cpp
   delaunay.c
   gdal_crs.cpp
+  gdal_homography.cpp
   gdal_octave.cpp
   gdal_rpc.cpp
   gdal_tps.cpp

--- a/alg/gdal_alg.h
+++ b/alg/gdal_alg.h
@@ -165,6 +165,16 @@ int CPL_DLL GDALGCPTransform(void *pTransformArg, int bDstToSrc,
                              int nPointCount, double *x, double *y, double *z,
                              int *panSuccess);
 
+/* Homography transformer ... forward is to georef coordinates */
+void CPL_DLL *GDALCreateHomographyTransformer(double adfHomography[9]);
+void CPL_DLL *
+GDALCreateHomographyTransformerFromGCPs(int nGCPCount,
+                                        const GDAL_GCP *pasGCPList);
+void CPL_DLL GDALDestroyHomographyTransformer(void *pTransformArg);
+int CPL_DLL GDALHomographyTransform(void *pTransformArg, int bDstToSrc,
+                                    int nPointCount, double *x, double *y,
+                                    double *z, int *panSuccess);
+
 /* Thin Plate Spine transformer ... forward is to georef coordinates */
 
 void CPL_DLL *GDALCreateTPSTransformer(int nGCPCount,

--- a/alg/gdal_homography.cpp
+++ b/alg/gdal_homography.cpp
@@ -233,7 +233,20 @@ int GDALGCPsToHomography(int nGCPCount, const GDAL_GCP *pasGCPList,
     }
 
     // "Hour-glass" like shape of GCPs. Cf https://github.com/OSGeo/gdal/issues/11618
-    if (false)  //TODO
+    double x[4] = {0, 1, 1, 0};
+    double y[4] = {0, 0, 1, 1};
+    for (int i = 0; i < 4; i++)
+    {
+        GDALApplyHomography(h_normalized.data(), x[i], y[i], &x[i], &y[i]);
+    }
+    for (int i = 3; i >= 0; i--)
+    {
+        x[i] -= x[0];
+        y[i] -= y[0];
+    }
+    double cross12 = x[1] * y[2] - x[2] * y[1];
+    double cross23 = x[2] * y[3] - x[3] * y[2];
+    if (cross12 * cross23 <= 0.0)
     {
         return FALSE;
     }

--- a/alg/gdal_homography.cpp
+++ b/alg/gdal_homography.cpp
@@ -1,0 +1,586 @@
+/******************************************************************************
+ *
+ * Project:  Homography Transformer
+ * Author:   Nathan Olson
+ *
+ ******************************************************************************
+ * Copyright (c) 2025, Nathan Olson <nathanmolson at gmail dot com>
+ *
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#include "cpl_port.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+#include "cpl_atomic_ops.h"
+#include "cpl_error.h"
+#include "cpl_string.h"
+#include "gdal.h"
+#include "gdal_alg.h"
+#include "gdallinearsystem.h"
+
+CPL_C_START
+CPLXMLNode *GDALSerializeHomographyTransformer(void *pTransformArg);
+void *GDALDeserializeHomographyTransformer(CPLXMLNode *psTree);
+CPL_C_END
+
+struct HomographyTransformInfo
+{
+    GDALTransformerInfo sTI{};
+
+    double poForward[9]{};
+    double poReverse[9]{};
+
+    volatile int nRefCount{};
+};
+
+/************************************************************************/
+/*                   GDALCreateSimilarHomographyTransformer()                  */
+/************************************************************************/
+
+static void *GDALCreateSimilarHomographyTransformer(void *hTransformArg,
+                                                    double dfRatioX,
+                                                    double dfRatioY)
+{
+    VALIDATE_POINTER1(hTransformArg, "GDALCreateSimilarHomographyTransformer",
+                      nullptr);
+
+    HomographyTransformInfo *psInfo =
+        static_cast<HomographyTransformInfo *>(hTransformArg);
+
+    if (dfRatioX == 1.0 && dfRatioY == 1.0)
+    {
+        // We can just use a ref count, since using the source transformation
+        // is thread-safe.
+        CPLAtomicInc(&(psInfo->nRefCount));
+    }
+    else
+    {
+        double homography[9];
+        for (int i = 0; i < 3; i++)
+        {
+            homography[3 * i] =
+                psInfo->poForward[3 * i] / dfRatioX;  //TODO check order
+            homography[3 * i + 1] = psInfo->poForward[3 * i + 1] / dfRatioY;
+            homography[3 * i + 2] = psInfo->poForward[3 * i + 2];
+        }
+        psInfo = static_cast<HomographyTransformInfo *>(
+            GDALCreateHomographyTransformer(homography));
+    }
+
+    return psInfo;
+}
+
+/************************************************************************/
+/*                      GDALCreateHomographyTransformer()                      */
+/************************************************************************/
+
+/**
+ * Create Homography transformer from GCPs.
+ *
+ * Homography Transformers are serializable.
+ *
+ * @param homography the forward homography.
+ *
+ * @return the transform argument or NULL if creation fails.
+ */
+
+void *GDALCreateHomographyTransformer(double adfHomography[9])
+{
+    /* -------------------------------------------------------------------- */
+    /*      Allocate transform info.                                        */
+    /* -------------------------------------------------------------------- */
+    HomographyTransformInfo *psInfo = new HomographyTransformInfo();
+
+    memcpy(psInfo->sTI.abySignature, GDAL_GTI2_SIGNATURE,
+           strlen(GDAL_GTI2_SIGNATURE));
+    psInfo->sTI.pszClassName = "GDALHomographyTransformer";
+    psInfo->sTI.pfnTransform = GDALHomographyTransform;
+    psInfo->sTI.pfnCleanup = GDALDestroyHomographyTransformer;
+    psInfo->sTI.pfnSerialize = GDALSerializeHomographyTransformer;
+    psInfo->sTI.pfnCreateSimilar = GDALCreateSimilarHomographyTransformer;
+
+    psInfo->nRefCount = 1;
+
+    memcpy(psInfo->poForward, adfHomography, 9 * sizeof(double));
+    if (GDALInvHomography(psInfo->poForward, psInfo->poReverse))
+    {
+        return psInfo;
+    }
+
+    GDALDestroyHomographyTransformer(psInfo);
+    return nullptr;
+}
+
+int GDALGCPsToHomography(int nGCPCount, const GDAL_GCP *pasGCPList,
+                         double *padfHomography)
+{
+    if (nGCPCount < 4)
+    {
+        padfHomography[6] = 1.0;
+        padfHomography[7] = 0.0;
+        padfHomography[8] = 0.0;
+        return GDALGCPsToGeoTransform(nGCPCount, pasGCPList, padfHomography,
+                                      FALSE);
+    }
+
+    /* -------------------------------------------------------------------- */
+    /*      Compute source and destination ranges so we can normalize       */
+    /*      the values to make the least squares computation more stable.   */
+    /* -------------------------------------------------------------------- */
+    double min_pixel = pasGCPList[0].dfGCPPixel;
+    double max_pixel = pasGCPList[0].dfGCPPixel;
+    double min_line = pasGCPList[0].dfGCPLine;
+    double max_line = pasGCPList[0].dfGCPLine;
+    double min_geox = pasGCPList[0].dfGCPX;
+    double max_geox = pasGCPList[0].dfGCPX;
+    double min_geoy = pasGCPList[0].dfGCPY;
+    double max_geoy = pasGCPList[0].dfGCPY;
+
+    for (int i = 1; i < nGCPCount; ++i)
+    {
+        min_pixel = std::min(min_pixel, pasGCPList[i].dfGCPPixel);
+        max_pixel = std::max(max_pixel, pasGCPList[i].dfGCPPixel);
+        min_line = std::min(min_line, pasGCPList[i].dfGCPLine);
+        max_line = std::max(max_line, pasGCPList[i].dfGCPLine);
+        min_geox = std::min(min_geox, pasGCPList[i].dfGCPX);
+        max_geox = std::max(max_geox, pasGCPList[i].dfGCPX);
+        min_geoy = std::min(min_geoy, pasGCPList[i].dfGCPY);
+        max_geoy = std::max(max_geoy, pasGCPList[i].dfGCPY);
+    }
+
+    double EPS = 1.0e-12;
+
+    if (std::abs(max_pixel - min_pixel) < EPS ||
+        std::abs(max_line - min_line) < EPS ||
+        std::abs(max_geox - min_geox) < EPS ||
+        std::abs(max_geoy - min_geoy) < EPS)
+    {
+        return FALSE;  // degenerate in at least one dimension.
+    }
+
+    double pl_normalize[9], geo_normalize[9];
+
+    pl_normalize[0] = -min_pixel / (max_pixel - min_pixel);
+    pl_normalize[1] = 1.0 / (max_pixel - min_pixel);
+    pl_normalize[2] = 0.0;
+    pl_normalize[3] = -min_line / (max_line - min_line);
+    pl_normalize[4] = 0.0;
+    pl_normalize[5] = 1.0 / (max_line - min_line);
+    pl_normalize[6] = 1.0;
+    pl_normalize[7] = 0.0;
+    pl_normalize[8] = 0.0;
+
+    geo_normalize[0] = -min_geox / (max_geox - min_geox);
+    geo_normalize[1] = 1.0 / (max_geox - min_geox);
+    geo_normalize[2] = 0.0;
+    geo_normalize[3] = -min_geoy / (max_geoy - min_geoy);
+    geo_normalize[4] = 0.0;
+    geo_normalize[5] = 1.0 / (max_geoy - min_geoy);
+    geo_normalize[6] = 1.0;
+    geo_normalize[7] = 0.0;
+    geo_normalize[8] = 0.0;
+
+    double inv_geo_normalize[9] = {0.0};
+    if (!GDALInvHomography(geo_normalize, inv_geo_normalize))
+    {
+        return FALSE;
+    }
+
+    GDALMatrix LtL(9, 9);
+    GDALMatrix rhs(9, 1);
+    rhs(6, 0) = 1;
+    LtL(6, 6) = 1;
+
+    for (int i = 0; i < nGCPCount; ++i)
+    {
+        double pixel, line, geox, geoy;
+
+        GDALApplyHomography(pl_normalize, pasGCPList[i].dfGCPPixel,
+                            pasGCPList[i].dfGCPLine, &pixel, &line);
+        GDALApplyHomography(geo_normalize, pasGCPList[i].dfGCPX,
+                            pasGCPList[i].dfGCPY, &geox, &geoy);
+
+        double Lx[] = {1, pixel, line,          0,           0,
+                       0, -geox, -geox * pixel, -geox * line};
+        double Ly[] = {0,           0, 0, 1, pixel, line, -geoy, -geoy * pixel,
+                       -geoy * line};
+        int j, k;
+        // Populate the lower triangle of symmetric LtL matrix
+        for (j = 0; j < 9; j++)
+        {
+            for (k = j; k < 9; k++)
+            {
+                LtL(j, k) += Lx[j] * Lx[k] + Ly[j] * Ly[k];
+            }
+        }
+    }
+    // Populate the upper triangle of symmetric LtL matrix
+    for (int j = 0; j < 9; j++)
+    {
+        for (int k = 0; k < j; k++)
+        {
+            LtL(j, k) = LtL(k, j);
+        }
+    }
+
+    GDALMatrix h_normalized(9, 1);
+    if (!GDALLinearSystemSolve(LtL, rhs, h_normalized))
+    {
+        return FALSE;
+    }
+
+    // "Hour-glass" like shape of GCPs. Cf https://github.com/OSGeo/gdal/issues/11618
+    if (false)  //TODO
+    {
+        return FALSE;
+    }
+
+    /* -------------------------------------------------------------------- */
+    /*      Compose the resulting transformation with the normalization     */
+    /*      homographies.                                             */
+    /* -------------------------------------------------------------------- */
+    double h1p2[9] = {0.0};
+
+    GDALComposeHomographies(pl_normalize, h_normalized.data(), h1p2);
+    GDALComposeHomographies(h1p2, inv_geo_normalize, padfHomography);
+
+    return TRUE;
+}
+
+/************************************************************************/
+/*                      GDALComposeHomographies()                      */
+/************************************************************************/
+
+/**
+ * \brief Compose two homographies.
+ *
+ * The resulting homography is the equivalent to padfH1 and then padfH2
+ * being applied to a point.
+ *
+ * @param padfH1 the first homography, nine values.
+ * @param padfH2 the second homography, nine values.
+ * @param padfHOut the output homography, nine values, may safely be the same
+ * array as padfH1 or padfH2.
+ */
+
+void GDALComposeHomographies(const double *padfH1, const double *padfH2,
+                             double *padfHOut)
+
+{
+    double hwrk[9] = {0.0};
+
+    hwrk[1] =
+        padfH2[1] * padfH1[1] + padfH2[2] * padfH1[4] + padfH2[0] * padfH1[7];
+    hwrk[2] =
+        padfH2[1] * padfH1[2] + padfH2[2] * padfH1[5] + padfH2[0] * padfH1[8];
+    hwrk[0] =
+        padfH2[1] * padfH1[0] + padfH2[2] * padfH1[3] + padfH2[0] * padfH1[6];
+
+    hwrk[4] =
+        padfH2[4] * padfH1[1] + padfH2[5] * padfH1[4] + padfH2[3] * padfH1[7];
+    hwrk[5] =
+        padfH2[4] * padfH1[2] + padfH2[5] * padfH1[5] + padfH2[3] * padfH1[8];
+    hwrk[3] =
+        padfH2[4] * padfH1[0] + padfH2[5] * padfH1[3] + padfH2[3] * padfH1[6];
+
+    hwrk[7] =
+        padfH2[7] * padfH1[1] + padfH2[8] * padfH1[4] + padfH2[6] * padfH1[7];
+    hwrk[8] =
+        padfH2[7] * padfH1[2] + padfH2[8] * padfH1[5] + padfH2[6] * padfH1[8];
+    hwrk[6] =
+        padfH2[7] * padfH1[0] + padfH2[8] * padfH1[3] + padfH2[6] * padfH1[6];
+    memcpy(padfHOut, hwrk, sizeof(hwrk));
+}
+
+/************************************************************************/
+/*                       GDALApplyHomography()                        */
+/************************************************************************/
+
+/**
+ * Apply Homography to x/y coordinate.
+ *
+ * Applies the following computation, converting a (pixel, line) coordinate
+ * into a georeferenced (geo_x, geo_y) location.
+ * \code{.c}
+ *  *pdfGeoX = (padfHomography[0] + dfPixel * padfHomography[1]
+ *                                + dfLine  * padfHomography[2]) / 
+ *             (padfHomography[6] + dfPixel * padfHomography[7]
+ *                                + dfLine  * padfHomography[8]);
+ *  *pdfGeoY = (padfHomography[3] + dfPixel * padfHomography[4]
+ *                                + dfLine  * padfHomography[5]) / 
+ *             (padfHomography[6] + dfPixel * padfHomography[7]
+ *                                + dfLine  * padfHomography[8]);
+ * \endcode
+ *
+ * @param padfGeoTransform Nine coefficient Homography to apply.
+ * @param dfPixel Input pixel position.
+ * @param dfLine Input line position.
+ * @param pdfGeoX output location where geo_x (easting/longitude)
+ * location is placed.
+ * @param pdfGeoY output location where geo_y (northing/latitude)
+ * location is placed.
+ */
+
+void CPL_STDCALL GDALApplyHomography(const double *padfHomography,
+                                     double dfPixel, double dfLine,
+                                     double *pdfGeoX, double *pdfGeoY)
+{
+    double wx = padfHomography[0] + dfPixel * padfHomography[1] +
+                dfLine * padfHomography[2];
+    double wy = padfHomography[3] + dfPixel * padfHomography[4] +
+                dfLine * padfHomography[5];
+    double w = padfHomography[6] + dfPixel * padfHomography[7] +
+               dfLine * padfHomography[8];
+    *pdfGeoX = wx / w;
+    *pdfGeoY = wy / w;
+}
+
+/************************************************************************/
+/*                        GDALInvHomography()                         */
+/************************************************************************/
+
+/**
+* Invert Homography.
+*
+* This function will invert a standard 3x3 set of Homography coefficients.
+* This converts the equation from being pixel to geo to being geo to pixel.
+*
+* @param padfHIn Input homography (nine doubles - unaltered).
+* @param padfHOut Output homography (nine doubles - updated).
+*
+* @return TRUE on success or FALSE if the equation is uninvertable.
+*/
+
+int CPL_STDCALL GDALInvHomography(const double *padfHIn, double *padfHOut)
+
+{
+    // Special case - no rotation - to avoid computing determinate
+    // and potential precision issues.
+    if (padfHIn[2] == 0.0 && padfHIn[4] == 0.0 && padfHIn[1] != 0.0 &&
+        padfHIn[5] != 0.0 && padfHIn[7] == 0.0 && padfHIn[8] == 0.0 &&
+        padfHIn[6] != 0.0)
+    {
+        padfHOut[0] = -padfHIn[0] / padfHIn[1] / padfHIn[6];
+        padfHOut[1] = 1.0 / padfHIn[1];
+        padfHOut[2] = 0.0;
+        padfHOut[3] = -padfHIn[3] / padfHIn[5] / padfHIn[6];
+        padfHOut[4] = 0.0;
+        padfHOut[5] = 1.0 / padfHIn[5];
+        padfHOut[6] = 1.0 / padfHIn[6];
+        padfHOut[7] = 0.0;
+        padfHOut[8] = 0.0;
+        return 1;
+    }
+
+    // Assume a 3rd row that is [1 0 0].
+
+    // Compute determinate.
+
+    const double det = padfHIn[1] * padfHIn[5] * padfHIn[6] -
+                       padfHIn[2] * padfHIn[4] * padfHIn[6] +
+                       padfHIn[2] * padfHIn[3] * padfHIn[7] -
+                       padfHIn[0] * padfHIn[5] * padfHIn[7] +
+                       padfHIn[0] * padfHIn[4] * padfHIn[8] -
+                       padfHIn[1] * padfHIn[3] * padfHIn[8];
+    const double magnitude =
+        std::max(std::max(fabs(padfHIn[1]), fabs(padfHIn[2])),
+                 std::max(fabs(padfHIn[4]), fabs(padfHIn[5])));
+
+    if (fabs(det) <= 1e-10 * magnitude * magnitude)
+        return 0;
+
+    const double inv_det = 1.0 / det;
+
+    // Compute adjoint, and divide by determinant.
+
+    padfHOut[1] = (padfHIn[5] * padfHIn[6] - padfHIn[3] * padfHIn[8]) * inv_det;
+    padfHOut[4] = (padfHIn[3] * padfHIn[7] - padfHIn[4] * padfHIn[6]) * inv_det;
+    padfHOut[7] = (padfHIn[4] * padfHIn[8] - padfHIn[5] * padfHIn[7]) * inv_det;
+
+    padfHOut[2] = (padfHIn[0] * padfHIn[8] - padfHIn[2] * padfHIn[6]) * inv_det;
+    padfHOut[5] = (padfHIn[1] * padfHIn[6] - padfHIn[0] * padfHIn[7]) * inv_det;
+    padfHOut[8] = (padfHIn[2] * padfHIn[7] - padfHIn[1] * padfHIn[8]) * inv_det;
+
+    padfHOut[0] = (padfHIn[2] * padfHIn[3] - padfHIn[0] * padfHIn[5]) * inv_det;
+    padfHOut[3] = (padfHIn[0] * padfHIn[4] - padfHIn[1] * padfHIn[3]) * inv_det;
+    padfHOut[6] = (padfHIn[1] * padfHIn[5] - padfHIn[2] * padfHIn[4]) * inv_det;
+
+    return 1;
+}
+
+/************************************************************************/
+/*                      GDALCreateHomographyTransformerFromGCPs()                      */
+/************************************************************************/
+
+/**
+ * Create Homography transformer from GCPs.
+ *
+ * Homography Transformers are serializable.
+ *
+ * @param nGCPCount the number of GCPs in pasGCPList.
+ * @param pasGCPList an array of GCPs to be used as input.
+ *
+ * @return the transform argument or NULL if creation fails.
+ */
+
+void *GDALCreateHomographyTransformerFromGCPs(int nGCPCount,
+                                              const GDAL_GCP *pasGCPList)
+{
+    double adfHomography[9];
+
+    if (GDALGCPsToHomography(nGCPCount, pasGCPList, adfHomography))
+    {
+        return GDALCreateHomographyTransformer(adfHomography);
+    }
+    return nullptr;
+}
+
+/************************************************************************/
+/*                     GDALDestroyHomographyTransformer()                      */
+/************************************************************************/
+
+/**
+ * Destroy Homography transformer.
+ *
+ * This function is used to destroy information about a homography
+ * transformation created with GDALCreateHomographyTransformer().
+ *
+ * @param pTransformArg the transform arg previously returned by
+ * GDALCreateHomographyTransformer().
+ */
+
+void GDALDestroyHomographyTransformer(void *pTransformArg)
+
+{
+    if (pTransformArg == nullptr)
+        return;
+
+    HomographyTransformInfo *psInfo =
+        static_cast<HomographyTransformInfo *>(pTransformArg);
+
+    if (CPLAtomicDec(&(psInfo->nRefCount)) == 0)
+    {
+        delete psInfo;
+    }
+}
+
+/************************************************************************/
+/*                          GDALHomographyTransform()                          */
+/************************************************************************/
+
+/**
+ * Transforms point based on homography.
+ *
+ * This function matches the GDALTransformerFunc signature, and can be
+ * used to transform one or more points from pixel/line coordinates to
+ * georeferenced coordinates (SrcToDst) or vice versa (DstToSrc).
+ *
+ * @param pTransformArg return value from GDALCreateHomographyTransformer().
+ * @param bDstToSrc TRUE if transformation is from the destination
+ * (georeferenced) coordinates to pixel/line or FALSE when transforming
+ * from pixel/line to georeferenced coordinates.
+ * @param nPointCount the number of values in the x, y and z arrays.
+ * @param x array containing the X values to be transformed.
+ * @param y array containing the Y values to be transformed.
+ * @param z array containing the Z values to be transformed.
+ * @param panSuccess array in which a flag indicating success (TRUE) or
+ * failure (FALSE) of the transformation are placed.
+ *
+ * @return TRUE if all points have been successfully transformed.
+ */
+
+int GDALHomographyTransform(void *pTransformArg, int bDstToSrc, int nPointCount,
+                            double *x, double *y, CPL_UNUSED double *z,
+                            int *panSuccess)
+{
+    VALIDATE_POINTER1(pTransformArg, "GDALHomographyTransform", 0);
+
+    HomographyTransformInfo *psInfo =
+        static_cast<HomographyTransformInfo *>(pTransformArg);
+
+    double *homography = bDstToSrc ? psInfo->poReverse : psInfo->poForward;
+    for (int i = 0; i < nPointCount; i++)
+    {
+        double wx = homography[0] + x[i] * homography[1] + y[i] * homography[2];
+        double wy = homography[3] + x[i] * homography[4] + y[i] * homography[5];
+        double w = homography[6] + x[i] * homography[7] + y[i] * homography[8];
+        x[i] = wx / w;
+        y[i] = wy / w;
+        panSuccess[i] = TRUE;
+    }
+
+    return TRUE;
+}
+
+/************************************************************************/
+/*                    GDALSerializeHomographyTransformer()                     */
+/************************************************************************/
+
+CPLXMLNode *GDALSerializeHomographyTransformer(void *pTransformArg)
+
+{
+    VALIDATE_POINTER1(pTransformArg, "GDALSerializeHomographyTransformer",
+                      nullptr);
+
+    HomographyTransformInfo *psInfo =
+        static_cast<HomographyTransformInfo *>(pTransformArg);
+
+    CPLXMLNode *psTree =
+        CPLCreateXMLNode(nullptr, CXT_Element, "HomographyTransformer");
+
+    /* -------------------------------------------------------------------- */
+    /*      Attach Homography.                                                */
+    /* -------------------------------------------------------------------- */
+    char szWork[300] = {};
+
+    CPLsnprintf(
+        szWork, sizeof(szWork),
+        "%.17g,%.17g,%.17g,%.17g,%.17g,%.17g,%.17g,%.17g,%.17g",
+        psInfo->poForward[0], psInfo->poForward[1], psInfo->poForward[2],
+        psInfo->poForward[3], psInfo->poForward[4], psInfo->poForward[5],
+        psInfo->poForward[6], psInfo->poForward[7], psInfo->poForward[8]);
+    CPLCreateXMLElementAndValue(psTree, "Homography", szWork);
+
+    return psTree;
+}
+
+/************************************************************************/
+/*                   GDALDeserializeHomography()                    */
+/************************************************************************/
+
+static void GDALDeserializeHomography(const char *pszH, double adfHomography[9])
+{
+    CPLsscanf(pszH, "%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf,%lf", adfHomography + 0,
+              adfHomography + 1, adfHomography + 2, adfHomography + 3,
+              adfHomography + 4, adfHomography + 5, adfHomography + 6,
+              adfHomography + 7, adfHomography + 8);
+}
+
+/************************************************************************/
+/*                   GDALDeserializeHomographyTransformer()                    */
+/************************************************************************/
+
+void *GDALDeserializeHomographyTransformer(CPLXMLNode *psTree)
+
+{
+    /* -------------------------------------------------------------------- */
+    /*      Homography                                                */
+    /* -------------------------------------------------------------------- */
+    double poForward[9];
+    if (CPLGetXMLNode(psTree, "Homography") != nullptr)
+    {
+        GDALDeserializeHomography(CPLGetXMLValue(psTree, "Homography", ""),
+                                  poForward);
+
+        /* -------------------------------------------------------------------- */
+        /*      Generate transformation.                                        */
+        /* -------------------------------------------------------------------- */
+        void *pResult = GDALCreateHomographyTransformer(poForward);
+
+        return pResult;
+    }
+    return nullptr;
+}

--- a/alg/gdal_homography.cpp
+++ b/alg/gdal_homography.cpp
@@ -114,6 +114,27 @@ void *GDALCreateHomographyTransformer(double adfHomography[9])
     return nullptr;
 }
 
+/************************************************************************/
+/*                       GDALGCPsToHomography()                       */
+/************************************************************************/
+
+/**
+ * \brief Generate Homography from GCPs.
+ *
+ * Given a set of GCPs perform least squares fit as a homography.
+ *
+ * A minimum of four GCPs are required to uniquely define a homography.
+ * If there are less than four GCPs, GDALGCPsToGeoTransform() is used to
+ * compute the transform.
+ *
+ * @param nGCPCount the number of GCPs being passed in.
+ * @param pasGCPs the list of GCP structures.
+ * @param padfHomography the nine double array in which the homography
+ * will be returned.
+ *
+ * @return TRUE on success or FALSE if there aren't enough points to prepare a
+ * homography, or pathological geometry is detected
+ */
 int GDALGCPsToHomography(int nGCPCount, const GDAL_GCP *pasGCPList,
                          double *padfHomography)
 {

--- a/alg/gdaltransformer.cpp
+++ b/alg/gdaltransformer.cpp
@@ -2054,7 +2054,7 @@ void *GDALCreateGenImgProjTransformer2(GDALDatasetH hSrcDS, GDALDatasetH hDstDS,
     else if (bGCPUseOK &&
              ((pszMethod == nullptr && GDALGetGCPCount(hSrcDS) >= 4 &&
                GDALGetGCPCount(hSrcDS) < 6) ||
-              EQUAL(pszMethod, "GCP_HOMOGRAPHY")) &&
+              (pszMethod != nullptr && EQUAL(pszMethod, "GCP_HOMOGRAPHY"))) &&
              GDALGetGCPCount(hSrcDS) > 0)
     {
         if (pszSrcSRS == nullptr)
@@ -2305,7 +2305,7 @@ void *GDALCreateGenImgProjTransformer2(GDALDatasetH hSrcDS, GDALDatasetH hDstDS,
     else if (bGCPUseOK &&
              ((pszDstMethod == nullptr && GDALGetGCPCount(hDstDS) >= 4 &&
                GDALGetGCPCount(hDstDS) < 6) ||
-              EQUAL(pszMethod, "GCP_HOMOGRAPHY")) &&
+              (pszMethod != nullptr && EQUAL(pszMethod, "GCP_HOMOGRAPHY"))) &&
              GDALGetGCPCount(hDstDS) > 0)
     {
         if (pszDstSRS == nullptr)

--- a/alg/gdaltransformer.cpp
+++ b/alg/gdaltransformer.cpp
@@ -46,6 +46,7 @@ void *GDALDeserializeGCPTransformer(CPLXMLNode *psTree);
 void *GDALDeserializeTPSTransformer(CPLXMLNode *psTree);
 void *GDALDeserializeGeoLocTransformer(CPLXMLNode *psTree);
 void *GDALDeserializeRPCTransformer(CPLXMLNode *psTree);
+void *GDALDeserializeHomographyTransformer(CPLXMLNode *psTree);
 CPL_C_END
 
 static CPLXMLNode *GDALSerializeReprojectionTransformer(void *pTransformArg);
@@ -4649,6 +4650,11 @@ CPLErr GDALDeserializeTransformer(CPLXMLNode *psTree,
     {
         *ppfnFunc = GDALApproxTransform;
         *ppTransformArg = GDALDeserializeApproxTransformer(psTree);
+    }
+    else if (EQUAL(psTree->pszValue, "HomographyTransformer"))
+    {
+        *ppfnFunc = GDALHomographyTransform;
+        *ppTransformArg = GDALDeserializeHomographyTransformer(psTree);
     }
     else
     {

--- a/alg/gdaltransformer.cpp
+++ b/alg/gdaltransformer.cpp
@@ -1762,14 +1762,15 @@ static void GDALGCPAntimeridianUnwrap(int nGCPCount, GDAL_GCP *pasGCPList,
  * a continuous set. This option can be set to YES to force that behavior
  * (useful if no SRS information is available), or to NO to disable it.
  * </li>
- * <li> SRC_METHOD: may have a value which is one of GEOTRANSFORM,
+ * <li> SRC_METHOD: may have a value which is one of GEOTRANSFORM, GCP_HOMOGRAPHY,
  * GCP_POLYNOMIAL, GCP_TPS, GEOLOC_ARRAY, RPC to force only one geolocation
  * method to be considered on the source dataset. Will be used for pixel/line
  * to georef transformation on the source dataset. NO_GEOTRANSFORM can be
  * used to specify the identity geotransform (ungeoreference image)
  * </li>
  * <li> DST_METHOD: may have a value which is one of GEOTRANSFORM,
- * GCP_POLYNOMIAL, GCP_TPS, GEOLOC_ARRAY (added in 3.5), RPC to force only one
+ * GCP_POLYNOMIAL, GCP_HOMOGRAPHY, GCP_TPS, GEOLOC_ARRAY (added in 3.5), RPC to
+ * force only one
  * geolocation method to be considered on the target dataset.  Will be used for
  * pixel/line to georef transformation on the destination dataset.
  * NO_GEOTRANSFORM can be used to specify the identity geotransform
@@ -2051,6 +2052,36 @@ void *GDALCreateGenImgProjTransformer2(GDALDatasetH hSrcDS, GDALDatasetH hDstDS,
         bCanUseSrcGeoTransform = true;
     }
     else if (bGCPUseOK &&
+             ((pszMethod == nullptr && GDALGetGCPCount(hSrcDS) >= 4 &&
+               GDALGetGCPCount(hSrcDS) < 6) ||
+              EQUAL(pszMethod, "GCP_HOMOGRAPHY")) &&
+             GDALGetGCPCount(hSrcDS) > 0)
+    {
+        if (pszSrcSRS == nullptr)
+        {
+            auto hSRS = GDALGetGCPSpatialRef(hSrcDS);
+            if (hSRS)
+                oSrcSRS = *(OGRSpatialReference::FromHandle(hSRS));
+        }
+
+        const auto nGCPCount = GDALGetGCPCount(hSrcDS);
+        auto pasGCPList = GDALDuplicateGCPs(nGCPCount, GDALGetGCPs(hSrcDS));
+        GDALGCPAntimeridianUnwrap(nGCPCount, pasGCPList, oSrcSRS, papszOptions);
+
+        psInfo->pSrcTransformArg =
+            GDALCreateHomographyTransformerFromGCPs(nGCPCount, pasGCPList);
+
+        GDALDeinitGCPs(nGCPCount, pasGCPList);
+        CPLFree(pasGCPList);
+
+        if (psInfo->pSrcTransformArg == nullptr)
+        {
+            GDALDestroyGenImgProjTransformer(psInfo);
+            return nullptr;
+        }
+        psInfo->pSrcTransformer = GDALHomographyTransform;
+    }
+    else if (bGCPUseOK &&
              (pszMethod == nullptr || EQUAL(pszMethod, "GCP_POLYNOMIAL")) &&
              GDALGetGCPCount(hSrcDS) > 0 && nOrder >= 0)
     {
@@ -2270,6 +2301,36 @@ void *GDALCreateGenImgProjTransformer2(GDALDatasetH hSrcDS, GDALDatasetH hDstDS,
             GDALDestroyGenImgProjTransformer(psInfo);
             return nullptr;
         }
+    }
+    else if (bGCPUseOK &&
+             ((pszDstMethod == nullptr && GDALGetGCPCount(hDstDS) >= 4 &&
+               GDALGetGCPCount(hDstDS) < 6) ||
+              EQUAL(pszMethod, "GCP_HOMOGRAPHY")) &&
+             GDALGetGCPCount(hDstDS) > 0)
+    {
+        if (pszDstSRS == nullptr)
+        {
+            auto hSRS = GDALGetGCPSpatialRef(hDstDS);
+            if (hSRS)
+                oDstSRS = *(OGRSpatialReference::FromHandle(hSRS));
+        }
+
+        const auto nGCPCount = GDALGetGCPCount(hDstDS);
+        auto pasGCPList = GDALDuplicateGCPs(nGCPCount, GDALGetGCPs(hDstDS));
+        GDALGCPAntimeridianUnwrap(nGCPCount, pasGCPList, oDstSRS, papszOptions);
+
+        psInfo->pDstTransformArg =
+            GDALCreateHomographyTransformerFromGCPs(nGCPCount, pasGCPList);
+
+        GDALDeinitGCPs(nGCPCount, pasGCPList);
+        CPLFree(pasGCPList);
+
+        if (psInfo->pDstTransformArg == nullptr)
+        {
+            GDALDestroyGenImgProjTransformer(psInfo);
+            return nullptr;
+        }
+        psInfo->pDstTransformer = GDALHomographyTransform;
     }
     else if (bGCPUseOK &&
              (pszDstMethod == nullptr ||

--- a/autotest/alg/gcps2homography.py
+++ b/autotest/alg/gcps2homography.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env pytest
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+# Project:  GDAL/OGR Test Suite
+# Purpose:  Test the GDALGCPsToHomography() method.
+# Author:   Nathan Olson <nathanmolson at gmail dot com>
+#
+###############################################################################
+# Copyright (c) 2025, Nathan Olson <nathanmolson at gmail dot com>
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+
+import gdaltest
+
+from osgeo import gdal
+
+###############################################################################
+# Helper to make gcps
+
+
+def _list2gcps(src_list):
+    gcp_list = []
+    for src_tuple in src_list:
+        gcp = gdal.GCP()
+        gcp.GCPPixel = src_tuple[0]
+        gcp.GCPLine = src_tuple[1]
+        gcp.GCPX = src_tuple[2]
+        gcp.GCPY = src_tuple[3]
+        gcp_list.append(gcp)
+    return gcp_list
+
+
+###############################################################################
+# Test if homographies are equal with an epsilon tolerance
+def check_homography(h1, h2, h_epsilon):
+    return gdaltest.check_geotransform(h1, h2, h_epsilon)
+
+
+###############################################################################
+# Test if homography satisfies the GCP with an epsilon tolerance
+def check_gcp(h, gcp, h_epsilon):
+    out = gdal.ApplyHomography(h, gcp.GCPPixel, gcp.GCPLine)
+    return (gcp.GCPX - out[0]) < h_epsilon and (gcp.GCPY - out[1]) < h_epsilon
+
+
+###############################################################################
+# Test if homography satisfies all GCPs in list with an epsilon tolerance
+def check_gcps(h, gcps, h_epsilon):
+    ret = True
+    for gcp in gcps:
+        ret = ret and check_gcp(h, gcp, h_epsilon)
+    return ret
+
+
+###############################################################################
+# Test simple exact case of turning GCPs into a Homography.
+
+
+def test_gcps2h_1():
+
+    h = gdal.GCPsToHomography(
+        _list2gcps(
+            [
+                (0.0, 0.0, 400000, 370000),
+                (100.0, 0.0, 410000, 370000),
+                (100.0, 200.0, 410000, 368000),
+            ]
+        )
+    )
+    check_homography(
+        h, (400000.0, 100.0, 0.0, 370000.0, 0.0, -10.0, 1.0, 0.0, 0.0), 0.000001
+    )
+
+
+###############################################################################
+# Similar but non-exact.
+
+
+def test_gcps2h_2():
+
+    gcps = _list2gcps(
+        [
+            (0.0, 0.0, 400000, 370000),
+            (100.0, 0.0, 410000, 370000),
+            (100.0, 200.0, 410000, 368000),
+            (0.0, 200.0, 400000, 368000.01),
+        ]
+    )
+
+    h = gdal.GCPsToHomography(gcps)
+    assert h is not None
+    check_gcps(h, gcps, 0.000001)
+
+
+###############################################################################
+# Not affine.
+
+
+def test_gcps2h_3():
+
+    gcps = _list2gcps(
+        [
+            (0.0, 0.0, 400000, 370000),
+            (100.0, 0.0, 410000, 370000),
+            (100.0, 200.0, 410000, 368000),
+            (0.0, 200.0, 400000, 360000),
+        ]
+    )
+
+    h = gdal.GCPsToHomography(gcps)
+    assert h is not None
+    check_gcps(h, gcps, 0.000001)
+
+
+###############################################################################
+# Single point - Should return None.
+
+
+def test_gcps2h_4():
+
+    h = gdal.GCPsToHomography(
+        _list2gcps(
+            [
+                (0.0, 0.0, 400000, 370000),
+            ]
+        )
+    )
+    assert h is None, "Expected failure for single GCP."
+
+
+###############################################################################
+# Two points - simple offset and scale, no rotation.
+
+
+def test_gcps2h_5():
+
+    h = gdal.GCPsToHomography(
+        _list2gcps(
+            [
+                (0.0, 0.0, 400000, 370000),
+                (100.0, 200.0, 410000, 368000),
+            ]
+        )
+    )
+    check_homography(
+        h, (400000.0, 100.0, 0.0, 370000.0, 0.0, -10.0, 1.0, 0.0, 0.0), 0.000001
+    )
+
+
+###############################################################################
+# Special case for four points in a particular order.  Exact result.
+
+
+def test_gcps2h_6():
+
+    h = gdal.GCPsToHomography(
+        _list2gcps(
+            [
+                (400000, 370000, 400000, 370000),
+                (410000, 370000, 410000, 370000),
+                (410000, 368000, 410000, 368000),
+                (400000, 368000, 400000, 368000),
+            ]
+        )
+    )
+    check_homography(h, (0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0), 0.000001)
+
+
+###############################################################################
+# Try a case that is hard to do without normalization.
+
+
+def test_gcps2h_7():
+
+    h = gdal.GCPsToHomography(
+        _list2gcps(
+            [
+                (400000, 370000, 400000, 370000),
+                (410000, 368000, 410000, 368000),
+                (410000, 370000, 410000, 370000),
+                (400000, 368000, 400000, 368000),
+            ]
+        )
+    )
+    check_homography(h, (0.0, 1.0, 0.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0), 0.000001)
+
+
+###############################################################################
+# A fairly messy real world case without a easy to predict result.
+
+
+def test_gcps2h_8():
+
+    h = gdal.GCPsToHomography(
+        _list2gcps(
+            [
+                (0.01, 0.04, -87.05528672907, 39.22759504228),
+                (0.01, 2688.02, -86.97079900719, 39.27075713986),
+                (4031.99, 2688.04, -87.05960736744, 39.37569137000),
+                (1988.16, 1540.80, -87.055069186699924, 39.304963106777514),
+                (1477.41, 2400.83, -87.013419295885001, 39.304705030894979),
+                (1466.02, 2376.92, -87.013906298363295, 39.304056190007913),
+            ]
+        )
+    )
+    h_expected = (
+        -86.9154734797766,
+        -0.000822802708802448,
+        0.0016903358388202546,
+        39.16439874542655,
+        0.00038733423466157704,
+        -0.0007330693484379306,
+        0.9983801902671235,
+        9.207539714141043e-06,
+        -1.9069099634950863e-05,
+    )
+    print(h)
+    check_homography(h, h_expected, 0.00001)
+
+
+###############################################################################
+# Test case of https://github.com/OSGeo/gdal/issues/11618
+
+
+def test_gcps2h_broken_hour_glass():
+
+    h = gdal.GCPsToHomography(
+        _list2gcps(
+            [
+                (0, 0, 0, 0),
+                (0, 10, 0, 10),
+                (10, 0, 10, 10),
+                (10, 10, 10, 0),
+            ]
+        )
+    )
+    print(h)
+    assert h is None
+
+    h = gdal.GCPsToHomography(
+        _list2gcps(
+            [
+                (0, 0, 0, 0),
+                (0, 10, 10, 0),
+                (10, 0, 0, 10),
+                (10, 10, 10, 10),
+            ]
+        )
+    )
+    assert h is None

--- a/autotest/alg/gcps2homography.py
+++ b/autotest/alg/gcps2homography.py
@@ -236,16 +236,15 @@ def test_gcps2h_broken_hour_glass():
             ]
         )
     )
-    print(h)
     assert h is None
 
     h = gdal.GCPsToHomography(
         _list2gcps(
             [
                 (0, 0, 0, 0),
-                (0, 10, 10, 0),
-                (10, 0, 0, 10),
-                (10, 10, 10, 10),
+                (0, 10, 10, 10),
+                (10, 0, 10, 0),
+                (10, 10, 0, 10),
             ]
         )
     )

--- a/autotest/alg/homography.py
+++ b/autotest/alg/homography.py
@@ -96,3 +96,7 @@ def test_homography_2():
     h = (10.0, 0.1, 0.0, 20.0, 0.0, -1.0, 1.0, 0.0, 0.0)
     res = gdal.ApplyHomography(h, 10, 1)
     assert res == [11.0, 19.0]
+
+    h = (10.0, 0.1, 3.0, 20.0, 7.0, -1.0, 2.0, 5.0, 4.0)
+    res = gdal.ApplyHomography(h, 10, 1)
+    assert res == [0.25, 1.5892857142857142]

--- a/autotest/alg/homography.py
+++ b/autotest/alg/homography.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env pytest
+# -*- coding: utf-8 -*-
+###############################################################################
+#
+# Project:  GDAL/OGR Test Suite
+# Purpose:  Various tests of GDAL homography.
+# Author:   Nathan Olson <nathanmolson at gmail dot com>
+#
+###############################################################################
+# Copyright (c) 2025, Nathan Olson <nathanmolson at gmail dot com>
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+
+import gdaltest
+import pytest
+
+from osgeo import gdal
+
+
+###############################################################################
+@pytest.fixture(autouse=True, scope="module")
+def module_disable_exceptions():
+    with gdaltest.disable_exceptions():
+        yield
+
+
+###############################################################################
+# Test gdal.InvHomography()
+
+
+def test_homography_1():
+
+    h = (10, 0.1, 0, 20, 0, -1.0, 1.0, 0.0, 0.0)
+    res = gdal.InvHomography(h)
+    expected_inv_h = (-100.0, 10.0, 0.0, 20.0, 0.0, -1.0, 1.0, 0.0, 0.0)
+    for i in range(9):
+        assert res[i] == pytest.approx(expected_inv_h[i], abs=1e-6), res
+
+    h = (3, 1, 2, 6, 4, 5, 11, 7, 8)
+    res = gdal.InvHomography(h)
+    expected_inv_h = (
+        0.5,
+        -1.166666666666666666,
+        -0.333333333333333333,
+        -1,
+        0.3333333333333333333,
+        1.6666666666666666666,
+        0.5,
+        0.5,
+        -1,
+    )
+    print(res)
+    for i in range(9):
+        assert res[i] == pytest.approx(expected_inv_h[i], abs=1e-6), res
+
+    h = (10, 1, 1, 20, 2, 2, 1, 0, 0)
+    res = gdal.InvHomography(h)
+    assert not res
+
+    h = (10, 1e10, 1e10, 20, 2e10, 2e10, 1, 0, 0)
+    res = gdal.InvHomography(h)
+    assert not res
+
+    h = (10, 1e-10, 1e-10, 20, 2e-10, 2e-10, 1, 0, 0)
+    res = gdal.InvHomography(h)
+    assert not res
+
+    # Test fix for #1615
+    h = (-2, 1e-8, 1e-9, 52, 1e-9, -1e-8, 1, 0, 0)
+    res = gdal.InvHomography(h)
+    expected_inv_h = (
+        -316831683.16831684,
+        99009900.990099,
+        9900990.099009901,
+        5168316831.683168,
+        9900990.099009901,
+        -99009900.990099,
+        1.0,
+        0.0,
+        0.0,
+    )
+    for i in range(9):
+        assert res[i] == pytest.approx(expected_inv_h[i], abs=1e-6), res
+    res2 = gdal.InvHomography(res)
+    for i in range(9):
+        assert res2[i] == pytest.approx(h[i], abs=1e-6), res2
+
+
+###############################################################################
+# Test gdal.ApplyHomography()
+
+
+def test_homography_2():
+
+    h = (10.0, 0.1, 0.0, 20.0, 0.0, -1.0, 1.0, 0.0, 0.0)
+    res = gdal.ApplyHomography(h, 10, 1)
+    assert res == [11.0, 19.0]

--- a/autotest/alg/warp.py
+++ b/autotest/alg/warp.py
@@ -1137,6 +1137,43 @@ def test_warp_39():
 
 
 ###############################################################################
+# Test a warp with GCPs for homography on the *destination* image.
+
+
+def test_warp_homography():
+
+    # Create an output file with GCPs.
+    out_file = "tmp/warp_homography.tif"
+    ds = gdal.GetDriverByName("GTiff").Create(out_file, 50, 50, 3)
+
+    gcp_list = [
+        gdal.GCP(397000, 5642000, 0, 0, 0),
+        gdal.GCP(397000, 5641990, 0, 0, 50),
+        gdal.GCP(397010, 5642000, 0, 50, 0),
+        gdal.GCP(397010, 5641990, 0, 50, 50),
+        gdal.GCP(397005, 5641995, 0, 25, 25),
+    ]
+    ds.SetGCPs(gcp_list, gdaltest.user_srs_to_wkt("EPSG:32632"))
+    ds = None
+
+    gdal.Warp(
+        out_file,
+        "data/test3658.tif",
+        options="-srcnodata none -to DST_METHOD=GCP_HOMOGRAPHY",
+    )
+
+    ds = gdal.Open(out_file)
+    cs = ds.GetRasterBand(1).Checksum()
+    ds = None
+
+    # Should exactly match the source file.
+    exp_cs = 30546
+    assert cs == exp_cs
+
+    os.unlink(out_file)
+
+
+###############################################################################
 # test average (#5311)
 
 

--- a/autotest/gcore/transformer.py
+++ b/autotest/gcore/transformer.py
@@ -114,6 +114,38 @@ def test_transformer_3():
 
 
 ###############################################################################
+# Test GCP based transformer with homography.
+
+
+@pytest.mark.skipif(
+    not gdaltest.vrt_has_open_support(),
+    reason="VRT driver open missing",
+)
+def test_transformer_homography():
+
+    ds = gdal.Open("data/gcps.vrt")
+    tr = gdal.Transformer(ds, None, ["METHOD=GCP_HOMOGRAPHY"])
+
+    (success, pnt) = tr.TransformPoint(0, 20, 10)
+
+    assert (
+        success
+        and pnt[0] == pytest.approx(441920, abs=0.001)
+        and pnt[1] == pytest.approx(3750720, abs=0.001)
+        and pnt[2] == 0
+    ), "got wrong forward transform result."
+
+    (success, pnt) = tr.TransformPoint(1, pnt[0], pnt[1], pnt[2])
+
+    assert (
+        success
+        and pnt[0] == pytest.approx(20, abs=0.001)
+        and pnt[1] == pytest.approx(10, abs=0.001)
+        and pnt[2] == 0
+    ), "got wrong reverse transform result."
+
+
+###############################################################################
 # Test geolocation based transformer.
 
 

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -1194,6 +1194,17 @@ void CPL_DLL CPL_STDCALL GDALApplyGeoTransform(const double *, double, double,
 void CPL_DLL GDALComposeGeoTransforms(const double *padfGeoTransform1,
                                       const double *padfGeoTransform2,
                                       double *padfGeoTransformOut);
+int CPL_DLL CPL_STDCALL
+GDALGCPsToHomography(int nGCPCount, const GDAL_GCP *pasGCPs,
+                     double *padfHomography) CPL_WARN_UNUSED_RESULT;
+int CPL_DLL CPL_STDCALL GDALInvHomography(const double *padfHomographyIn,
+                                          double *padfInvHomographyOut)
+    CPL_WARN_UNUSED_RESULT;
+void CPL_DLL CPL_STDCALL GDALApplyHomography(const double *, double, double,
+                                             double *, double *);
+void CPL_DLL GDALComposeHomographies(const double *padfHomography1,
+                                     const double *padfHomography2,
+                                     double *padfHomographyOut);
 
 /* ==================================================================== */
 /*      major objects (dataset, and, driver, drivermanager).            */

--- a/swig/include/gdal.i
+++ b/swig/include/gdal.i
@@ -344,6 +344,9 @@ $1;
 %rename (GCPsToGeoTransform) GDALGCPsToGeoTransform;
 %rename (ApplyGeoTransform) GDALApplyGeoTransform;
 %rename (InvGeoTransform) GDALInvGeoTransform;
+%rename (GCPsToHomography) GDALGCPsToHomography;
+%rename (ApplyHomography) GDALApplyHomography;
+%rename (InvHomography) GDALInvHomography;
 %rename (VersionInfo) GDALVersionInfo;
 %rename (AllRegister) GDALAllRegister;
 %rename (GetCacheMax) wrapper_GDALGetCacheMax;
@@ -561,6 +564,23 @@ RETURN_NONE GDALGCPsToGeoTransform( int nGCPs, GDAL_GCP const * pGCPs,
 %clear (RETURN_NONE);
 #endif
 
+#ifdef SWIGJAVA
+%rename (GCPsToHomography) wrapper_GDALGCPsToHomography;
+%inline
+{
+int wrapper_GDALGCPsToHomography( int nGCPs, GDAL_GCP const * pGCPs,
+    	                             double argout[9] )
+{
+    return GDALGCPsToHomography(nGCPs, pGCPs, argout);
+}
+}
+#else
+%apply (IF_FALSE_RETURN_NONE) { (RETURN_NONE) };
+RETURN_NONE GDALGCPsToHomography( int nGCPs, GDAL_GCP const * pGCPs,
+    	                             double argout[9]);
+%clear (RETURN_NONE);
+#endif
+
 %include "cplvirtualmem.i"
 
 //************************************************************************
@@ -638,6 +658,29 @@ RETURN_NONE GDALInvGeoTransform( double gt_in[6], double gt_out[6] );
 #endif
 %clear (double *gt_in);
 %clear (double *gt_out);
+
+%apply (double argin[ANY]) {(double padfHomography[9])};
+%apply (double *OUTPUT) {(double *pdfGeoX)};
+%apply (double *OUTPUT) {(double *pdfGeoY)};
+void GDALApplyHomography( double padfHomography[9],
+                            double dfPixel, double dfLine,
+                            double *pdfGeoX, double *pdfGeoY );
+%clear (double *padfHomography);
+%clear (double *pdfGeoX);
+%clear (double *pdfGeoY);
+
+%apply (double argin[ANY]) {double h_in[9]};
+%apply (double argout[ANY]) {double h_out[9]};
+#ifdef SWIGJAVA
+// FIXME: we should implement correctly the IF_FALSE_RETURN_NONE typemap
+int GDALInvHomography( double h_in[9], double h_out[9] );
+#else
+%apply (IF_FALSE_RETURN_NONE) { (RETURN_NONE) };
+RETURN_NONE GDALInvHomography( double h_in[9], double h_out[9] );
+%clear (RETURN_NONE);
+#endif
+%clear (double *h_in);
+%clear (double *h_out);
 
 #ifdef SWIGJAVA
 %apply (const char* stringWithDefaultValue) {const char *request};


### PR DESCRIPTION
## What does this PR do?

Adds new transform type, Homography.
Adds functions to compute homography from a list of GCPs.
Adds functions to serialize and deserialize a homography
Automatically selects homography transform when there are 4 or 5 GCPs present. Homography provides an exact fit for 4 GCPs, and a better fit for 5 GCPs than the existing method (affine transformation).

## What are related issues/pull requests?

#11940 

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [X] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [X] Add test case(s)
 - [X] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: WSL
* Compiler: gcc
