### PR TITLE
MiraMonVector: fixing a word in Catalan language

### DIFF
--- a/ogr/ogrsf_frmts/miramon/mm_gdal_functions.c
+++ b/ogr/ogrsf_frmts/miramon/mm_gdal_functions.c
@@ -97,6 +97,7 @@ void MM_FillFieldDescriptorByLanguage(void)
                MM_MAX_IDENTIFIER_SIZE);
     CPLStrlcpy(szNumberOfVerticesSpa, "Numero de vertices",
                MM_MAX_IDENTIFIER_SIZE);
+    *(unsigned char *)&szNumberOfVerticesCat[11] = MM_e_WITH_GRAVE;
     *(unsigned char *)&szNumberOfVerticesSpa[1] = MM_u_WITH_ACUTE;
     *(unsigned char *)&szNumberOfVerticesSpa[11] = MM_e_WITH_ACUTE;
 


### PR DESCRIPTION
## What does this PR do?
Corrects the spelling of a Catalan word in metadata. It ensures that "Nombre de vèrtexs" is written instead of "Nombre de vertexs".
This change follows the same approach used for other words, making tests unnecessary as it is merely an aesthetic adjustment.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] All CI builds and checks have passed
