### PR TITLE
OGRGeometryFactory: Update createFromWkt usages to unique_ptr overload

### DIFF
--- a/apps/gdal_grid_lib.cpp
+++ b/apps/gdal_grid_lib.cpp
@@ -1342,10 +1342,9 @@ GDALGridOptionsNew(char **papszArgv,
                       STARTS_WITH_CI(osVal.c_str(), "MULTIPOLYGON")) &&
                      VSIStatL(osVal.c_str(), &sStat) != 0)
             {
-                OGRGeometry *poGeom = nullptr;
-                OGRGeometryFactory::createFromWkt(osVal.c_str(), nullptr,
-                                                  &poGeom);
-                psOptions->poClipSrc.reset(poGeom);
+                psOptions->poClipSrc =
+                    OGRGeometryFactory::createFromWkt(osVal.c_str(), nullptr)
+                        .first;
                 if (psOptions->poClipSrc == nullptr)
                 {
                     CPLError(CE_Failure, CPLE_IllegalArg,

--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -3358,10 +3358,10 @@ static CPLErr LoadCutline(const std::string &osCutlineDSNameOrWKT,
             poSRS->SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
             poSRS->SetFromUserInput(osSRS.c_str());
         }
-        OGRGeometry *poGeom = nullptr;
-        OGRGeometryFactory::createFromWkt(osCutlineDSNameOrWKT.c_str(),
-                                          poSRS.get(), &poGeom);
-        *phCutlineRet = OGRGeometry::ToHandle(poGeom);
+
+        auto [poGeom, _] = OGRGeometryFactory::createFromWkt(
+            osCutlineDSNameOrWKT.c_str(), poSRS.get());
+        *phCutlineRet = OGRGeometry::ToHandle(poGeom.release());
         return *phCutlineRet ? CE_None : CE_Failure;
     }
 

--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -8378,10 +8378,8 @@ GDALVectorTranslateOptions *GDALVectorTranslateOptionsNew(
                       STARTS_WITH_CI(osVal.c_str(), "MULTIPOLYGON")) &&
                      VSIStatL(osVal.c_str(), &sStat) != 0)
             {
-                OGRGeometry *poGeom = nullptr;
-                OGRGeometryFactory::createFromWkt(osVal.c_str(), nullptr,
-                                                  &poGeom);
-                psOptions->poClipSrc.reset(poGeom);
+                psOptions->poClipSrc =
+                    OGRGeometryFactory::createFromWkt(osVal.c_str()).first;
                 if (psOptions->poClipSrc == nullptr)
                 {
                     CPLError(
@@ -8433,10 +8431,8 @@ GDALVectorTranslateOptions *GDALVectorTranslateOptionsNew(
                       STARTS_WITH_CI(osVal.c_str(), "MULTIPOLYGON")) &&
                      VSIStatL(osVal.c_str(), &sStat) != 0)
             {
-                OGRGeometry *poGeom = nullptr;
-                OGRGeometryFactory::createFromWkt(osVal.c_str(), nullptr,
-                                                  &poGeom);
-                psOptions->poClipDst.reset(poGeom);
+                psOptions->poClipDst =
+                    OGRGeometryFactory::createFromWkt(osVal.c_str()).first;
                 if (psOptions->poClipDst == nullptr)
                 {
                     CPLError(

--- a/apps/test_ogrsf.cpp
+++ b/apps/test_ogrsf.cpp
@@ -822,9 +822,8 @@ static int TestCreateLayer(GDALDriver *poDriver, OGRwkbGeometryType eGeomType)
         const char *pszWKT = GetWKT(eGeomType);
         if (pszWKT != nullptr)
         {
-            OGRGeometry *poGeom = nullptr;
-            OGRGeometryFactory::createFromWkt(pszWKT, nullptr, &poGeom);
-            poFeature->SetGeometryDirectly(poGeom);
+            auto [poGeom, _] = OGRGeometryFactory::createFromWkt(pszWKT);
+            poFeature->SetGeometry(std::move(poGeom));
         }
 
         CPLErrorReset();
@@ -864,9 +863,8 @@ static int TestCreateLayer(GDALDriver *poDriver, OGRwkbGeometryType eGeomType)
         pszWKT = GetWKT(eOtherGeomType);
         if (pszWKT != nullptr)
         {
-            OGRGeometry *poGeom = nullptr;
-            OGRGeometryFactory::createFromWkt(pszWKT, nullptr, &poGeom);
-            poFeature->SetGeometryDirectly(poGeom);
+            auto [poGeom, _] = OGRGeometryFactory::createFromWkt(pszWKT);
+            poFeature->SetGeometry(std::move(poGeom));
         }
 
         CPLErrorReset();
@@ -915,9 +913,8 @@ static int TestCreateLayer(GDALDriver *poDriver, OGRwkbGeometryType eGeomType)
             pszWKT = GetWKT(eGeomType);
             if (pszWKT != nullptr)
             {
-                OGRGeometry *poGeom = nullptr;
-                OGRGeometryFactory::createFromWkt(pszWKT, nullptr, &poGeom);
-                poFeature->SetGeometryDirectly(poGeom);
+                auto [poGeom, _] = OGRGeometryFactory::createFromWkt(pszWKT);
+                poFeature->SetGeometry(std::move(poGeom));
             }
             CPLErrorReset();
             CPLPushErrorHandler(CPLQuietErrorHandler);

--- a/frmts/netcdf/netcdflayer.cpp
+++ b/frmts/netcdf/netcdflayer.cpp
@@ -1311,13 +1311,11 @@ bool netCDFLayer::FillFeatureFromVar(OGRFeature *poFeature, int nMainDimId,
         }
         if (pszWKT != nullptr)
         {
-            OGRGeometry *poGeom = nullptr;
-            CPL_IGNORE_RET_VAL(
-                OGRGeometryFactory::createFromWkt(pszWKT, nullptr, &poGeom));
+            auto [poGeom, _] = OGRGeometryFactory::createFromWkt(pszWKT);
             if (poGeom != nullptr)
             {
                 poGeom->assignSpatialReference(GetSpatialRef());
-                poFeature->SetGeometryDirectly(poGeom);
+                poFeature->SetGeometry(std::move(poGeom));
             }
             CPLFree(pszWKT);
         }

--- a/frmts/pdf/pdfcreatecopy.cpp
+++ b/frmts/pdf/pdfcreatecopy.cpp
@@ -690,8 +690,7 @@ GDALPDFObjectNum GDALPDFBaseWriter::WriteSRS_ISO32000(GDALDataset *poSrcDS,
         pszNEATLINE = poSrcDS->GetMetadataItem("NEATLINE");
     if (bHasGT && pszNEATLINE != nullptr && pszNEATLINE[0] != '\0')
     {
-        OGRGeometry *poGeom = nullptr;
-        OGRGeometryFactory::createFromWkt(pszNEATLINE, nullptr, &poGeom);
+        auto [poGeom, _] = OGRGeometryFactory::createFromWkt(pszNEATLINE);
         if (poGeom != nullptr &&
             wkbFlatten(poGeom->getGeometryType()) == wkbPolygon)
         {
@@ -748,7 +747,6 @@ GDALPDFObjectNum GDALPDFBaseWriter::WriteSRS_ISO32000(GDALDataset *poSrcDS,
                 }
             }
         }
-        delete poGeom;
     }
 
     if (pasGCPList)

--- a/frmts/pdf/pdfcreatefromcomposition.cpp
+++ b/frmts/pdf/pdfcreatefromcomposition.cpp
@@ -683,8 +683,8 @@ bool GDALPDFComposerWriter::GenerateGeoreferencing(
     std::vector<xyPair> aBoundingPolygon;
     if (pszBoundingPolygon)
     {
-        OGRGeometry *poGeom = nullptr;
-        OGRGeometryFactory::createFromWkt(pszBoundingPolygon, nullptr, &poGeom);
+        auto [poGeom, _] =
+            OGRGeometryFactory::createFromWkt(pszBoundingPolygon);
         if (poGeom && poGeom->getGeometryType() == wkbPolygon)
         {
             auto poPoly = poGeom->toPolygon();
@@ -707,7 +707,6 @@ bool GDALPDFComposerWriter::GenerateGeoreferencing(
                 }
             }
         }
-        delete poGeom;
     }
 
     const auto pszSRS = CPLGetXMLValue(psGeoreferencing, "SRS", nullptr);

--- a/ogr/ogr_wkb.cpp
+++ b/ogr/ogr_wkb.cpp
@@ -1618,7 +1618,7 @@ size_t OGRWKTToWKBTranslator::TranslateWKT(void *pabyWKTStart, size_t nLength,
     }
 
     // General case going through a OGRGeometry
-    OGRGeometry *poGeometry = nullptr;
+    std::unique_ptr<OGRGeometry> poGeometry = nullptr;
     if (bCanAlterByteAfter)
     {
         // Slight optimization for all geometries but the final one, to
@@ -1628,7 +1628,7 @@ size_t OGRWKTToWKBTranslator::TranslateWKT(void *pabyWKTStart, size_t nLength,
         char *pszEnd = static_cast<char *>(pabyWKTStart) + nLength;
         const char chBackup = *pszEnd;
         *pszEnd = 0;
-        OGRGeometryFactory::createFromWkt(pszPtrStart, nullptr, &poGeometry);
+        poGeometry = OGRGeometryFactory::createFromWkt(pszPtrStart).first;
         // cppcheck-suppress selfAssignment
         *pszEnd = chBackup;
     }
@@ -1636,7 +1636,7 @@ size_t OGRWKTToWKBTranslator::TranslateWKT(void *pabyWKTStart, size_t nLength,
     {
         std::string osTmp;
         osTmp.assign(pszPtrStart, nLength);
-        OGRGeometryFactory::createFromWkt(osTmp.c_str(), nullptr, &poGeometry);
+        poGeometry = OGRGeometryFactory::createFromWkt(osTmp.c_str()).first;
     }
     if (!poGeometry)
     {
@@ -1651,6 +1651,5 @@ size_t OGRWKTToWKBTranslator::TranslateWKT(void *pabyWKTStart, size_t nLength,
         return static_cast<size_t>(-1);
     }
     poGeometry->exportToWkb(wkbNDR, pabyWKB, wkbVariantIso);
-    delete poGeometry;
     return nWKBSize;
 }

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitelayer.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitelayer.cpp
@@ -565,9 +565,10 @@ void OGRSQLiteLayer::BuildFeatureDefn(const char *pszLayerName, bool bIsSelect,
                 {
                     OGRSQLiteGeomFormat eGeomFormat = OSGF_None;
                     CPLPushErrorHandler(CPLQuietErrorHandler);
-                    OGRGeometry *poGeometry = nullptr;
-                    if (OGRGeometryFactory::createFromWkt(
-                            pszText, nullptr, &poGeometry) == OGRERR_NONE)
+
+                    auto [poGeometry, eErr] =
+                        OGRGeometryFactory::createFromWkt(pszText);
+                    if (eErr == OGRERR_NONE)
                     {
                         eGeomFormat = OSGF_WKT;
                         auto poGeomFieldDefn =
@@ -579,7 +580,6 @@ void OGRSQLiteLayer::BuildFeatureDefn(const char *pszLayerName, bool bIsSelect,
                     }
                     CPLPopErrorHandler();
                     CPLErrorReset();
-                    delete poGeometry;
                     if (eGeomFormat != OSGF_None)
                         continue;
                 }

--- a/ogr/ogrsf_frmts/vrt/ogr_vrt.h
+++ b/ogr/ogrsf_frmts/vrt/ogr_vrt.h
@@ -46,7 +46,7 @@ class OGRVRTGeomFieldProps
     const OGRSpatialReference *poSRS;
 
     bool bSrcClip;
-    OGRGeometry *poSrcRegion;
+    std::unique_ptr<OGRGeometry> poSrcRegion;
 
     // Geometry interpretation related.
     OGRVRTGeometryStyle eGeometryStyle;

--- a/ogr/ogrsf_frmts/vrt/ogrvrtlayer.cpp
+++ b/ogr/ogrsf_frmts/vrt/ogrvrtlayer.cpp
@@ -75,8 +75,6 @@ OGRVRTGeomFieldProps::~OGRVRTGeomFieldProps()
 {
     if (poSRS != nullptr)
         const_cast<OGRSpatialReference *>(poSRS)->Release();
-    if (poSrcRegion != nullptr)
-        delete poSrcRegion;
 }
 
 /************************************************************************/
@@ -467,8 +465,9 @@ bool OGRVRTLayer::ParseGeometryField(CPLXMLNode *psNode,
     const char *pszSrcRegion = CPLGetXMLValue(psSrcRegionNode, "", nullptr);
     if (pszSrcRegion != nullptr)
     {
-        OGRGeometryFactory::createFromWkt(pszSrcRegion, nullptr,
-                                          &poProps->poSrcRegion);
+        poProps->poSrcRegion =
+            OGRGeometryFactory::createFromWkt(pszSrcRegion).first;
+
         if (poProps->poSrcRegion == nullptr)
         {
             CPLError(CE_Warning, CPLE_AppDefined,
@@ -1325,7 +1324,7 @@ bool OGRVRTLayer::ResetSourceReading()
     {
         OGRGeometry *poNewSpatialGeom = nullptr;
         OGRGeometry *poSrcRegion =
-            apoGeomFieldProps[m_iGeomFieldFilter]->poSrcRegion;
+            apoGeomFieldProps[m_iGeomFieldFilter]->poSrcRegion.get();
         std::unique_ptr<OGRGeometry> poIntersection;
 
         if (poSrcRegion == nullptr)
@@ -1442,7 +1441,8 @@ void OGRVRTLayer::ClipAndAssignSRS(OGRFeature *poFeature)
         if (apoGeomFieldProps[i]->poSrcRegion != nullptr &&
             apoGeomFieldProps[i]->bSrcClip && poGeom != nullptr)
         {
-            poGeom = poGeom->Intersection(apoGeomFieldProps[i]->poSrcRegion);
+            poGeom =
+                poGeom->Intersection(apoGeomFieldProps[i]->poSrcRegion.get());
             if (poGeom != nullptr)
                 poGeom->assignSpatialReference(
                     GetLayerDefn()->GetGeomFieldDefn(i)->GetSpatialRef());
@@ -1507,13 +1507,11 @@ retry:
 
             if (pszWKT != nullptr)
             {
-                OGRGeometry *poGeom = nullptr;
-
-                OGRGeometryFactory::createFromWkt(pszWKT, nullptr, &poGeom);
+                auto [poGeom, _] = OGRGeometryFactory::createFromWkt(pszWKT);
                 if (poGeom == nullptr)
                     CPLDebug("OGR_VRT", "Did not get geometry from %s", pszWKT);
 
-                poDstFeat->SetGeomFieldDirectly(i, poGeom);
+                poDstFeat->SetGeomField(i, std::move(poGeom));
             }
         }
         else if (eGeometryStyle == VGS_WKB && iGeomField != -1)
@@ -1619,7 +1617,7 @@ retry:
         {
             OGRGeometry *poGeom = poDstFeat->GetGeomFieldRef(i);
             if (poGeom != nullptr &&
-                !poGeom->Intersects(apoGeomFieldProps[i]->poSrcRegion))
+                !poGeom->Intersects(apoGeomFieldProps[i]->poSrcRegion.get()))
             {
                 delete poSrcFeat;
                 delete poDstFeat;


### PR DESCRIPTION
## What does this PR do?

Updates some calls to `OGRGeometryFactory::createFromWkt` to use the overload returning a `unique_ptr`.

## What are related issues/pull requests?

#11165

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE
