### PR TITLE
MEM: set IMAGE_STRUCTURE metadata for INTERLEAVE=BAND and document the creation option

### DIFF
--- a/autotest/gdrivers/mem.py
+++ b/autotest/gdrivers/mem.py
@@ -250,6 +250,10 @@ def test_mem_4():
             cs == expected_cs[i]
         ), "did not get expected checksum for band %d after fill" % (i + 1)
 
+    assert (
+        ds.GetMetadataItem("INTERLEAVE", "IMAGE_STRUCTURE") == "BAND"
+    ), "did not get expected INTERLEAVE value"
+
     ds = None
 
 

--- a/autotest/utilities/test_gdalalg_raster_info.py
+++ b/autotest/utilities/test_gdalalg_raster_info.py
@@ -113,6 +113,7 @@ def test_gdalalg_raster_info_mdd_all():
     j = json.loads(output_string)
     assert j["metadata"] == {
         "": {"AREA_OR_POINT": "Area"},
+        "IMAGE_STRUCTURE": {"INTERLEAVE": "BAND"},
         "MY_DOMAIN": {"foo": "bar"},
         "DERIVED_SUBDATASETS": {
             "DERIVED_SUBDATASET_1_NAME": "DERIVED_SUBDATASET:LOGAMPLITUDE:",

--- a/doc/source/drivers/raster/mem.rst
+++ b/doc/source/drivers/raster/mem.rst
@@ -90,7 +90,14 @@ or
 Creation Options
 ----------------
 
-There are no supported creation options.
+|about-creation-options|
+This driver supports the following creation option:
+
+-  .. co:: INTERLEAVE
+      :choices: BAND, PIXEL
+      :default: BAND
+
+      Set the interleaving to use
 
 The MEM format is one of the few that supports the AddBand() method. The
 AddBand() method supports DATAPOINTER, PIXELOFFSET and LINEOFFSET

--- a/frmts/mem/memdataset.cpp
+++ b/frmts/mem/memdataset.cpp
@@ -1404,6 +1404,8 @@ MEMDataset *MEMDataset::Create(const char * /* pszFilename */, int nXSize,
 
     if (bPixelInterleaved)
         poDS->SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
+    else
+        poDS->SetMetadataItem("INTERLEAVE", "BAND", "IMAGE_STRUCTURE");
 
     /* -------------------------------------------------------------------- */
     /*      Create band information objects.                                */


### PR DESCRIPTION
The MEM driver advertises an INTERLEAVE creation option.
```
gdalinfo --format MEM
...

<CreationOptionList>
  <Option name="INTERLEAVE" type="string-select" default="BAND">
    <Value>BAND</Value>
    <Value>PIXEL</Value>
  </Option>
</CreationOptionList>
```

But the MEM documentation currently states "There are no supported creation options". The IMAGE_STRUCTURE metadata is set only if INTERLEAVE=PIXEL is given as an undocumented option. It is not set in the default case of INTERLEAVE=BAND.

This PR sets IMAGE_STRUCTURE metadata for INTERLEAVE=BAND as the default when INTERLEAVE=PIXEL is not given as a creation option. It also adds INTERLEAVE in the MEM driver documentation.

## Tasklist

 - [ ] ~~AI (Copilot or something similar) supported my development of this PR~~
 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] ~~Updated Python API documentation (swig/include/python/docs/)~~
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed