### PR TITLE
PDF: Fix default value for DPI open option description

### DIFF
--- a/frmts/pdf/pdfdrivercore.cpp
+++ b/frmts/pdf/pdfdrivercore.cpp
@@ -29,7 +29,7 @@ static const char *const szOpenOptionList =
     "  </Option>"
 #endif
     "  <Option name='DPI' type='float' description='Resolution in Dot Per "
-    "Inch' default='72' alt_config_option='GDAL_PDF_DPI'/>"
+    "Inch' default='150' alt_config_option='GDAL_PDF_DPI'/>"
     "  <Option name='USER_PWD' type='string' description='Password' "
     "alt_config_option='PDF_USER_PWD'/>"
 #ifdef HAVE_MULTIPLE_PDF_BACKENDS


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

If I'm not mistaken, the default value for the DPI open option ( = GDAL_PDF_DPI config option) is 150, not 72, according to https://gdal.org/en/stable/drivers/raster/pdf.html.

This PR just fixes the DPI open option description.