### PR TITLE
[cli][contour] Fix CLI issues #11957

### DIFF
--- a/apps/gdal_contour_lib.cpp
+++ b/apps/gdal_contour_lib.cpp
@@ -441,7 +441,7 @@ GDALContourAppOptionsGetParser(GDALContourOptions *psOptions,
 {
 
     auto argParser = std::make_unique<GDALArgumentParser>(
-        "gdal_contour", /* bForBinary */ true);
+        "gdal_contour", /* bForBinary=*/psOptionsForBinary != nullptr);
 
     argParser->add_description(_("Creates contour lines from a raster file."));
     argParser->add_epilog(_(

--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -3197,9 +3197,7 @@ std::string GDALTranslateGetParserUsage()
     try
     {
         GDALTranslateOptions sOptions;
-        GDALTranslateOptionsForBinary sOptionsForBinary;
-        auto argParser =
-            GDALTranslateOptionsGetParser(&sOptions, &sOptionsForBinary);
+        auto argParser = GDALTranslateOptionsGetParser(&sOptions, nullptr);
         return argParser->usage();
     }
     catch (const std::exception &err)

--- a/apps/gdalalg_raster_contour.h
+++ b/apps/gdalalg_raster_contour.h
@@ -80,6 +80,7 @@ class GDALRasterContourAlgorithm final : public GDALAlgorithm
     int m_expBase = 0;  // -e <base>
     bool m_polygonize = false;    // -p
     int m_groupTransactions = 0;  // gt <n>
+    bool m_overwrite = false;     // -overwrite
 };
 
 //! @endcond

--- a/autotest/utilities/test_gdalalg_raster_contour.py
+++ b/autotest/utilities/test_gdalalg_raster_contour.py
@@ -164,6 +164,7 @@ cellsize     1
             lyr = None
 
 
+@pytest.mark.require_driver("AAIGRID")
 def test_gdalalg_raster_contour_overwrite(tmp_vsimem):
 
     tmp_out_filename = str(tmp_vsimem / "out.shp")

--- a/autotest/utilities/test_gdalalg_raster_contour.py
+++ b/autotest/utilities/test_gdalalg_raster_contour.py
@@ -106,6 +106,16 @@ def get_contour_alg():
             True,
             "contour: Argument 'levels' is mutually exclusive with 'interval'.",
         ),
+        (
+            [],
+            True,
+            "contour: One of 'interval', 'levels', 'exp-base' must be specified.",
+        ),
+        (
+            ["--interval", "-10"],
+            True,
+            "contour: Interval must be a positive number.",
+        ),
     ],
 )
 def test_gdalalg_raster_contour(tmp_vsimem, options, polygonize, expected_elev_values):
@@ -152,3 +162,42 @@ cellsize     1
                     assert geom.GetGeometryType() == ogr.wkbLineString
                     assert feat.GetField("ELEV") == expected_elev_values[i]
             lyr = None
+
+
+def test_gdalalg_raster_contour_overwrite(tmp_vsimem):
+
+    tmp_out_filename = str(tmp_vsimem / "out.shp")
+    tmp_filename = str(tmp_vsimem / "tmp.asc")
+    dem = """ncols        2
+nrows        2
+xllcorner    0
+yllcorner    0
+cellsize     1
+4 15
+25 36"""
+
+    gdal.FileFromMemBuffer(tmp_filename, dem.encode("ascii"))
+
+    pipeline = get_contour_alg()
+    alg_options = [
+        tmp_filename,
+        tmp_out_filename,
+        "--interval",
+        "10",
+        "--min-name",
+        "ELEV_MIN",
+        "--max-name",
+        "ELEV_MAX",
+    ]
+
+    assert pipeline.ParseRunAndFinalize(alg_options)
+
+    # Run it again without --overwrite
+    pipeline = get_contour_alg()
+    with pytest.raises(RuntimeError, match="already exists"):
+        pipeline.ParseRunAndFinalize(alg_options)
+
+    # Run it again with --overwrite
+    pipeline = get_contour_alg()
+    alg_options.append("--overwrite")
+    assert pipeline.ParseRunAndFinalize(alg_options)

--- a/doc/source/programs/gdal_raster_contour.rst
+++ b/doc/source/programs/gdal_raster_contour.rst
@@ -52,6 +52,7 @@ Synopsis
     --off, --offset <OFFSET>                             Offset to apply to contour levels
     -p, --polygonize                                     Create polygons instead of lines
     --group-transactions <GROUP-TRANSACTIONS>            Group n features per transaction (default 100 000)
+    --overwrite                                          Whether overwriting existing output is allowed
 
     Advanced Options:
     --oo, --open-option <KEY=VALUE>                      Open options [may be repeated]
@@ -66,6 +67,13 @@ The following options are available:
 
 Standard options
 ++++++++++++++++
+
+
+.. include:: gdal_options/of_vector.rst
+
+.. include:: gdal_options/co.rst
+
+.. include:: gdal_options/overwrite.rst
 
 .. option:: -b, --band <BAND>
 
@@ -127,6 +135,7 @@ Advanced options
 .. include:: gdal_options/oo.rst
 
 .. include:: gdal_options/if.rst
+
 
 
 Examples


### PR DESCRIPTION
Fixes #11957

1. "gdal raster contour autotest/gcore/data/byte.tif out.gpkg", which lacks one of the required argument, shows the help message of the old gdal_contour utility. It should only indicate the name of one of the missing required arguments

2. "gdal raster contour --interval 1 autotest/gcore/data/byte.tif out.gpkg" repeated twice overwrites the output file. It should require a --overwrite flag to be specified to do that

