### PR TITLE
gdal2tiles.py: apply srcnodata values in non-reprojected datasets

### DIFF
--- a/autotest/pyscripts/test_gdal2tiles.py
+++ b/autotest/pyscripts/test_gdal2tiles.py
@@ -638,10 +638,11 @@ def test_gdal2tiles_nodata_values_pct_threshold(script_path, tmp_path):
     output_folder = str(tmp_path / "test_gdal2tiles_nodata_values_pct_threshold")
 
     src_ds = gdal.GetDriverByName("GTiff").Create(input_tif, 256, 256, 3, gdal.GDT_Byte)
-    src_ds.GetRasterBand(1).SetNoDataValue(20)
-    src_ds.GetRasterBand(1).WriteRaster(
-        0, 0, 2, 2, struct.pack("B" * 4, 10, 20, 30, 40)
-    )
+    for i in range(3):
+        src_ds.GetRasterBand(i + 1).SetNoDataValue(20)
+        src_ds.GetRasterBand(i + 1).WriteRaster(
+            0, 0, 2, 2, struct.pack("B" * 4, 10, 20, 30, 40)
+        )
     srs = osr.SpatialReference()
     srs.ImportFromEPSG(3857)
     src_ds.SetSpatialRef(srs)

--- a/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
@@ -2373,15 +2373,19 @@ class GDAL2Tiles:
                 self.warped_input_dataset = reproject_dataset(
                     input_dataset, self.in_srs, self.out_srs
                 )
-
-                if in_nodata:
-                    self.warped_input_dataset = update_no_data_values(
-                        self.warped_input_dataset, in_nodata, options=self.options
-                    )
-                else:
+                if not in_nodata:
                     self.warped_input_dataset = update_alpha_value_for_non_alpha_inputs(
                         self.warped_input_dataset, options=self.options
                     )
+            else:
+                self.warped_input_dataset = gdal.GetDriverByName("VRT").CreateCopy(
+                    "", input_dataset
+                )
+
+            if in_nodata:
+                self.warped_input_dataset = update_no_data_values(
+                    self.warped_input_dataset, in_nodata, options=self.options
+                )
 
             if self.warped_input_dataset and self.options.verbose:
                 logger.debug(


### PR DESCRIPTION
Fixes --srcnodata from being ignored when the dataset does not need to be reprojected.

(Continuation of PR #11965)