### PR TITLE
MiraMonVector: writting VRS in metadata file + fixing error in Z header

### DIFF
--- a/ogr/ogrsf_frmts/miramon/mm_gdal_driver_structs.h
+++ b/ogr/ogrsf_frmts/miramon/mm_gdal_driver_structs.h
@@ -45,6 +45,7 @@ CPL_C_START  // Necessary for compiling in GDAL project
 #define KEY_CreationDate "CreationDate"
 #define SECTION_SPATIAL_REFERENCE_SYSTEM "SPATIAL_REFERENCE_SYSTEM"
 #define SECTION_HORIZONTAL "HORIZONTAL"
+#define SECTION_VERTICAL "VERTICAL"
 #define KEY_HorizontalSystemIdentifier "HorizontalSystemIdentifier"
 #define SECTION_TAULA_PRINCIPAL "TAULA_PRINCIPAL"
 #define KEY_IdGrafic "IdGrafic"
@@ -291,6 +292,7 @@ struct MiraMonVectorMetaData
     char *pXUnit;    // X units if pszSRS is empty.
     char *pYUnit;    // Y units if pszSRS is empty. If Y units is empty,
                      // X unit will be assigned as Y unit by default.
+    char *pZUnit;    // In 3D cases, Z unit can be assigned.
 
     struct MMBoundingBox hBB;  // Bounding box of the entire layer
 
@@ -739,6 +741,7 @@ struct MiraMonVectLayerInfo
     // EPSG code of the spatial reference system.
     char *pSRS;
     int nSRS_EPSG;  // Ref. system if has EPSG code.
+    char *pZUnit;   // In case of 3D data, Z unit can be assigned.
 
 // Used to write the precision of the reserved fields in the DBF
 #define MM_SRS_LAYER_IS_UNKNOWN_TYPE 0

--- a/ogr/ogrsf_frmts/miramon/ogrmiramonlayer.cpp
+++ b/ogr/ogrsf_frmts/miramon/ogrmiramonlayer.cpp
@@ -159,6 +159,30 @@ OGRMiraMonLayer::OGRMiraMonLayer(GDALDataset *poDS, const char *pszFilename,
             const char *pszAuthorityName = poSRS->GetAuthorityName(nullptr);
             const char *pszAuthorityCode = poSRS->GetAuthorityCode(nullptr);
 
+            // Reading Z units (in case of 3D vector file)
+            if (poSRS->GetAuthorityCode("VERT_CS") != nullptr)
+            {
+                const char *pszUnits = nullptr;
+                const double dfUnits = poSRS->GetLinearUnits(&pszUnits);
+                const auto IsAlmostEqual = [](double x, double y)
+                { return std::fabs(x - y) <= 1e-10; };
+                if (pszUnits)
+                {
+                    if (!strcmp(pszUnits, "metre") && IsAlmostEqual(dfUnits, 1))
+                    {
+                        hMiraMonLayerPNT.pZUnit = strdup("m");
+                        hMiraMonLayerARC.pZUnit = strdup("m");
+                        hMiraMonLayerPOL.pZUnit = strdup("m");
+                    }
+                    else
+                    {
+                        hMiraMonLayerPNT.pZUnit = strdup(pszUnits);
+                        hMiraMonLayerARC.pZUnit = strdup(pszUnits);
+                        hMiraMonLayerPOL.pZUnit = strdup(pszUnits);
+                    }
+                }
+            }
+
             if (pszAuthorityName && pszAuthorityCode &&
                 EQUAL(pszAuthorityName, "EPSG"))
             {


### PR DESCRIPTION
## What does this PR do?
Adds Vertical Reference System to MiraMon metadata file.
Corrects a minor issue with the zMin and zMax values in the Z header.

No tests required as this change only affects additional metadata information.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] All CI builds and checks have passed (except next two)
 - [ ] https://github.com/OSGeo/gdal/actions/runs/13944352315/job/39028005721?pr=11977
 - [ ] https://github.com/OSGeo/gdal/actions/runs/13944352315/job/39028005746?pr=11977
