### PR TITLE
GPKG: fix SetNextByIndex() followed by GetNextFeature() without explicit call to GetLayerDefn()

### DIFF
--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -10992,3 +10992,24 @@ def test_ogr_gpkg_field_operations_savepoint_release(
         expected,
         test_geometry=False,
     )
+
+
+###############################################################################
+
+
+def test_ogr_gpkg_set_next_by_index(tmp_vsimem):
+
+    filename = tmp_vsimem / "test_ogr_gpkg_set_next_by_index.gpkg"
+    with ogr.GetDriverByName("GPKG").CreateDataSource(filename) as ds:
+        lyr = ds.CreateLayer("test")
+        lyr.CreateField(ogr.FieldDefn("foo"))
+        lyr.SetNextByIndex(0)
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f["foo"] = "bar"
+        lyr.CreateFeature(f)
+
+    with ogr.Open(filename) as ds:
+        lyr = ds.GetLayer(0)
+        lyr.SetNextByIndex(0)
+        f = lyr.GetNextFeature()
+        assert f["foo"] == "bar"

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -123,6 +123,12 @@ OGRErr OGRGeoPackageTableLayer::UpdateExtent(const OGREnvelope *poExtent)
 //
 OGRErr OGRGeoPackageTableLayer::BuildColumns()
 {
+    if (m_bDeferredCreation && RunDeferredCreationIfNecessary() != OGRERR_NONE)
+        return OGRERR_FAILURE;
+
+    if (!m_bFeatureDefnCompleted)
+        GetLayerDefn();
+
     m_anFieldOrdinals.resize(m_poFeatureDefn->GetFieldCount());
     int iCurCol = 0;
 


### PR DESCRIPTION
Fixes #11974