### PR TITLE
[Backport release/3.10] /vsigs/ (and /vsiaz/): invalidate cached state of files/directories when changing authentication parameters

### DIFF
--- a/autotest/gcore/vsigs.py
+++ b/autotest/gcore/vsigs.py
@@ -371,6 +371,69 @@ def test_vsigs_GDAL_HTTP_HEADERS(gs_test_config, webserver_port):
 
 
 ###############################################################################
+# Test re-opening after changing configuration option (#11964)
+
+
+def test_vsigs_open_after_config_option_change(gs_test_config, webserver_port):
+    gdal.VSICurlClearCache()
+
+    with gdaltest.config_options(
+        {
+            "GS_SECRET_ACCESS_KEY": "GS_SECRET_ACCESS_KEY",
+            "GS_ACCESS_KEY_ID": "GS_ACCESS_KEY_ID",
+        },
+        thread_local=False,
+    ):
+        handler = webserver.SequentialHandler()
+        handler.add(
+            "GET", "/test_vsigs_open_after_config_option_change/?delimiter=%2F", 403
+        )
+        handler.add("GET", "/test_vsigs_open_after_config_option_change/test.bin", 403)
+        with webserver.install_http_handler(handler):
+            with gdal.quiet_errors():
+                f = open_for_read(
+                    "/vsigs/test_vsigs_open_after_config_option_change/test.bin"
+                )
+            assert f is None
+
+    # Does not attempt any network access since we didn't change significant
+    # parameters
+    f = open_for_read("/vsigs/test_vsigs_open_after_config_option_change/test.bin")
+    assert f is None
+
+    with gdaltest.config_options(
+        {
+            "GS_SECRET_ACCESS_KEY": "GS_SECRET_ACCESS_KEY",
+            "GS_ACCESS_KEY_ID": "another_key_id",
+        },
+        thread_local=False,
+    ):
+        handler = webserver.SequentialHandler()
+        handler.add(
+            "GET",
+            "/test_vsigs_open_after_config_option_change/?delimiter=%2F",
+            200,
+            {"Content-type": "application/xml"},
+            """<?xml version="1.0" encoding="UTF-8"?>
+                        <ListBucketResult>
+                            <Prefix></Prefix>
+                            <Contents>
+                                <Key>test.bin</Key>
+                                <LastModified>1970-01-01T00:00:01.000Z</LastModified>
+                                <Size>123456</Size>
+                            </Contents>
+                        </ListBucketResult>
+                    """,
+        )
+        with webserver.install_http_handler(handler):
+            f = open_for_read(
+                "/vsigs/test_vsigs_open_after_config_option_change/test.bin"
+            )
+            assert f is not None
+            gdal.VSIFCloseL(f)
+
+
+###############################################################################
 # Test ReadDir() with a fake Google Cloud Storage server
 
 

--- a/port/cpl_conv.cpp
+++ b/port/cpl_conv.cpp
@@ -1883,9 +1883,16 @@ static void NotifyOtherComponentsConfigOptionChanged(const char *pszKey,
                                                      const char *pszValue,
                                                      bool bThreadLocal)
 {
-    // Hack
-    if (STARTS_WITH_CI(pszKey, "AWS_"))
+    // When changing authentication parameters of virtual file systems,
+    // partially invalidate cached state about file availability.
+    if (STARTS_WITH_CI(pszKey, "AWS_") || STARTS_WITH_CI(pszKey, "GS_") ||
+        STARTS_WITH_CI(pszKey, "GOOGLE_") ||
+        STARTS_WITH_CI(pszKey, "GDAL_HTTP_HEADER_FILE") ||
+        STARTS_WITH_CI(pszKey, "AZURE_") ||
+        (STARTS_WITH_CI(pszKey, "SWIFT_") && !EQUAL(pszKey, "SWIFT_MAX_KEYS")))
+    {
         VSICurlAuthParametersChanged();
+    }
 
     if (!gSetConfigOptionSubscribers.empty())
     {


### PR DESCRIPTION
Backport #11981
 **Authored by:** @rouault