### PR TITLE
[Backport 3.10] Warp: fix reprojecting on empty source window with nodata != 0 and MEM driver

### DIFF
--- a/alg/gdalwarpoperation.cpp
+++ b/alg/gdalwarpoperation.cpp
@@ -1346,18 +1346,35 @@ CPLErr GDALWarpOperation::CollectChunkListInternal(int nDstXOff, int nDstYOff,
     double dfSrcXExtraSize = 0.0;
     double dfSrcYExtraSize = 0.0;
     double dfSrcFillRatio = 0.0;
-    CPLErr eErr =
-        ComputeSourceWindow(nDstXOff, nDstYOff, nDstXSize, nDstYSize, &nSrcXOff,
-                            &nSrcYOff, &nSrcXSize, &nSrcYSize, &dfSrcXExtraSize,
-                            &dfSrcYExtraSize, &dfSrcFillRatio);
+    CPLErr eErr;
+    {
+        CPLTurnFailureIntoWarning(true);
+        eErr = ComputeSourceWindow(nDstXOff, nDstYOff, nDstXSize, nDstYSize,
+                                   &nSrcXOff, &nSrcYOff, &nSrcXSize, &nSrcYSize,
+                                   &dfSrcXExtraSize, &dfSrcYExtraSize,
+                                   &dfSrcFillRatio);
+        CPLTurnFailureIntoWarning(false);
+    }
 
     if (eErr != CE_None)
     {
-        CPLError(CE_Warning, CPLE_AppDefined,
-                 "Unable to compute source region for "
-                 "output window %d,%d,%d,%d, skipping.",
-                 nDstXOff, nDstYOff, nDstXSize, nDstYSize);
-        return eErr;
+        const bool bErrorOutIfEmptySourceWindow =
+            CPLFetchBool(psOptions->papszWarpOptions,
+                         "ERROR_OUT_IF_EMPTY_SOURCE_WINDOW", true);
+        if (bErrorOutIfEmptySourceWindow)
+        {
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "Unable to compute source region for "
+                     "output window %d,%d,%d,%d, skipping.",
+                     nDstXOff, nDstYOff, nDstXSize, nDstYSize);
+        }
+        else
+        {
+            CPLDebug("WARP",
+                     "Unable to compute source region for "
+                     "output window %d,%d,%d,%d, skipping.",
+                     nDstXOff, nDstYOff, nDstXSize, nDstYSize);
+        }
     }
 
     /* -------------------------------------------------------------------- */
@@ -1419,7 +1436,7 @@ CPLErr GDALWarpOperation::CollectChunkListInternal(int nDstXOff, int nDstYOff,
              // 2x2 blocks large and the shapes of the source and target regions
              // are not excessively different. All those thresholds are a bit
              // arbitrary
-             (bOptimizeSizeAuto &&
+             (bOptimizeSizeAuto && nSrcXSize > 0 && nDstYSize > 0 &&
               (nDstXSize > nDstYSize ? fabs(double(nDstXSize) / nDstYSize -
                                             double(nSrcXSize) / nSrcYSize) <
                                            5 * double(nDstXSize) / nDstYSize
@@ -1645,10 +1662,13 @@ CPLErr GDALWarpOperation::WarpRegion(
     /* -------------------------------------------------------------------- */
     /*      Perform the warp.                                               */
     /* -------------------------------------------------------------------- */
-    CPLErr eErr = WarpRegionToBuffer(
-        nDstXOff, nDstYOff, nDstXSize, nDstYSize, pDstBuffer,
-        psOptions->eWorkingDataType, nSrcXOff, nSrcYOff, nSrcXSize, nSrcYSize,
-        dfSrcXExtraSize, dfSrcYExtraSize, dfProgressBase, dfProgressScale);
+    CPLErr eErr = nSrcXSize == 0
+                      ? CE_None
+                      : WarpRegionToBuffer(
+                            nDstXOff, nDstYOff, nDstXSize, nDstYSize,
+                            pDstBuffer, psOptions->eWorkingDataType, nSrcXOff,
+                            nSrcYOff, nSrcXSize, nSrcYSize, dfSrcXExtraSize,
+                            dfSrcYExtraSize, dfProgressBase, dfProgressScale);
 
     /* -------------------------------------------------------------------- */
     /*      Write the output data back to disk if all went well.            */

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -4330,3 +4330,21 @@ def test_gdalwarp_lib_src_is_geog_arc_second():
     assert out_ds.RasterXSize == 5464
     assert out_ds.RasterYSize == 5464
     assert out_ds.GetRasterBand(1).Checksum() == 31856
+
+
+###############################################################################
+# Test scenario of https://github.com/OSGeo/gdal/issues/11992
+
+
+def test_gdalwarp_lib_init_dest_no_source_window_mem():
+
+    # Extract a target area that is in space.
+    with gdal.quiet_errors():
+        ds = gdal.Warp(
+            "",
+            "../gdrivers/data/small_world.tif",
+            options="-t_srs +proj=ortho -overwrite -te -6378137 6356000 -6378000 6356752 -ts 100 100 -of MEM -dstnodata 255",
+        )
+    assert ds.GetRasterBand(1).GetNoDataValue() == 255
+    ds.GetRasterBand(1).SetNoDataValue(0)
+    assert ds.GetRasterBand(1).ComputeRasterMinMax() == (255, 255)


### PR DESCRIPTION
Fixes #11992
