### PR TITLE
gdal raster/vector pipeline: fix PROJ strings as CRS

### DIFF
--- a/apps/gdalalg_raster_pipeline.cpp
+++ b/apps/gdalalg_raster_pipeline.cpp
@@ -330,7 +330,8 @@ bool GDALRasterPipelineAlgorithm::ParseCommandLineArguments(
         else
         {
 #ifdef GDAL_PIPELINE_PROJ_NOSTALGIA
-            if (!arg.empty() && arg[0] == '+')
+            if (!arg.empty() && arg[0] == '+' &&
+                arg.find(' ') == std::string::npos)
             {
                 curStep.args.push_back("--" + arg.substr(1));
                 continue;

--- a/apps/gdalalg_vector_pipeline.cpp
+++ b/apps/gdalalg_vector_pipeline.cpp
@@ -351,7 +351,8 @@ bool GDALVectorPipelineAlgorithm::ParseCommandLineArguments(
         else
         {
 #ifdef GDAL_PIPELINE_PROJ_NOSTALGIA
-            if (!arg.empty() && arg[0] == '+')
+            if (!arg.empty() && arg[0] == '+' &&
+                arg.find(' ') == std::string::npos)
             {
                 curStep.args.push_back("--" + arg.substr(1));
                 continue;

--- a/autotest/utilities/test_gdalalg_raster_pipeline.py
+++ b/autotest/utilities/test_gdalalg_raster_pipeline.py
@@ -537,6 +537,33 @@ def test_gdalalg_raster_pipeline_reproject_almost_all_args(tmp_vsimem):
         assert ds.GetRasterBand(1).Checksum() == 8515
 
 
+def test_gdalalg_raster_pipeline_reproject_proj_string(tmp_vsimem):
+
+    out_filename = str(tmp_vsimem / "out.tif")
+
+    pipeline = get_pipeline_alg()
+    assert pipeline.ParseRunAndFinalize(
+        [
+            "read",
+            "../gcore/data/byte.tif",
+            "!",
+            "reproject",
+            "--src-crs=EPSG:32611",
+            "--dst-crs",
+            "+proj=laea +lon_0=147 +lat_0=-40 +datum=WGS84",
+            "!",
+            "write",
+            "--overwrite",
+            out_filename,
+        ]
+    )
+
+    with gdal.OpenEx(out_filename) as ds:
+        assert "Lambert Azimuthal Equal Area" in ds.GetSpatialRef().ExportToWkt(
+            ["FORMAT=WKT2"]
+        ), ds.GetSpatialRef().ExportToWkt(["FORMAT=WKT2"])
+
+
 def test_gdalalg_raster_pipeline_clip_missing_bbox_or_like(tmp_vsimem):
 
     out_filename = str(tmp_vsimem / "out.tif")

--- a/autotest/utilities/test_gdalalg_vector_pipeline.py
+++ b/autotest/utilities/test_gdalalg_vector_pipeline.py
@@ -762,3 +762,31 @@ def test_gdalalg_vector_pipeline_reproject_with_src_crs(tmp_vsimem):
         assert f.GetGeometryRef().GetEnvelope() == pytest.approx(
             (2.750130423614134, 2.759262932833617, 43.0361359661472, 43.0429263707128)
         )
+
+
+def test_gdalalg_vector_pipeline_reproject_proj_string(tmp_vsimem):
+
+    out_filename = str(tmp_vsimem / "out.shp")
+
+    pipeline = get_pipeline_alg()
+    assert pipeline.ParseRunAndFinalize(
+        [
+            "read",
+            "../ogr/data/poly.shp",
+            "!",
+            "reproject",
+            "--src-crs=EPSG:32631",
+            "--dst-crs",
+            "+proj=laea +lon_0=147 +lat_0=-40 +datum=WGS84",
+            "!",
+            "write",
+            "--overwrite",
+            out_filename,
+        ]
+    )
+
+    with gdal.OpenEx(out_filename) as ds:
+        lyr = ds.GetLayer(0)
+        assert "Lambert Azimuthal Equal Area" in lyr.GetSpatialRef().ExportToWkt(
+            ["FORMAT=WKT2"]
+        ), lyr.GetSpatialRef().ExportToWkt(["FORMAT=WKT2"])


### PR DESCRIPTION
Fixes #11998
