### PR TITLE
ogr2ogr: do not warn when writing to .gdb without explicit OpenFileGDB/FileGDB output driver specification

### DIFF
--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -2629,7 +2629,9 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
     std::vector<std::string> aoDrivers;
     if (poODS == nullptr && psOptions->osFormat.empty())
     {
-        aoDrivers = GetOutputDriversFor(pszDest, GDAL_OF_VECTOR);
+        aoDrivers = CPLStringList(GDALGetOutputDriversForDatasetName(
+            pszDest, GDAL_OF_VECTOR, /* bSingleMatch = */ true,
+            /* bWarn = */ true));
         if (!bUpdate && aoDrivers.size() == 1)
         {
             GDALDriverH hDriver = GDALGetDriverByName(aoDrivers[0].c_str());
@@ -2734,13 +2736,6 @@ GDALDatasetH GDALVectorTranslate(const char *pszDest, GDALDatasetH hDstDS,
             }
             else
             {
-                if (aoDrivers.size() > 1)
-                {
-                    CPLError(CE_Warning, CPLE_AppDefined,
-                             "Several drivers matching %s extension. Using %s",
-                             CPLGetExtensionSafe(pszDest).c_str(),
-                             aoDrivers[0].c_str());
-                }
                 psOptions->osFormat = aoDrivers[0];
             }
             CPLDebug("GDAL", "Using %s driver", psOptions->osFormat.c_str());

--- a/autotest/ogr/ogr_openfilegdb_write.py
+++ b/autotest/ogr/ogr_openfilegdb_write.py
@@ -4254,13 +4254,14 @@ def test_ogr_openfilegdb_write_new_datetime_types(tmp_vsimem):
 
     filename = str(tmp_vsimem / "out.gdb")
     with gdal.quiet_errors():
+        gdal.ErrorReset()
         ds = gdal.VectorTranslate(
             filename,
             "data/filegdb/arcgis_pro_32_types.gdb",
-            format="OpenFileGDB",
             layers=["date_types", "date_types_high_precision"],
             layerCreationOptions=["TARGET_ARCGIS_VERSION=ARCGIS_PRO_3_2_OR_LATER"],
         )
+        assert gdal.GetLastErrorMsg() == ""
 
     lyr = ds.GetLayerByName("date_types")
     lyr_defn = lyr.GetLayerDefn()

--- a/gcore/gdaldriver.cpp
+++ b/gcore/gdaldriver.cpp
@@ -2892,6 +2892,23 @@ static bool DoesDriverHandleExtension(GDALDriverH hDriver, const char *pszExt)
 }
 
 /************************************************************************/
+/*                     IsOnlyExpectedGDBDrivers()                       */
+/************************************************************************/
+
+static bool IsOnlyExpectedGDBDrivers(const CPLStringList &aosDriverNames)
+{
+    for (const char *pszDrvName : aosDriverNames)
+    {
+        if (!EQUAL(pszDrvName, "OpenFileGDB") &&
+            !EQUAL(pszDrvName, "FileGDB") && !EQUAL(pszDrvName, "GPSBabel"))
+        {
+            return false;
+        }
+    }
+    return true;
+}
+
+/************************************************************************/
 /*                  GDALGetOutputDriversForDatasetName()                */
 /************************************************************************/
 
@@ -3016,6 +3033,15 @@ char **GDALGetOutputDriversForDatasetName(const char *pszDestDataset,
                 aosDriverNames.Clear();
                 aosDriverNames.AddString(osDrvName.c_str());
             }
+        }
+        else if (EQUAL(osExt.c_str(), "gdb") &&
+                 IsOnlyExpectedGDBDrivers(aosDriverNames))
+        {
+            // Do not warn about that case given that FileGDB write support
+            // forwards to OpenFileGDB one. And also consider GPSBabel as too
+            // marginal to deserve the warning.
+            aosDriverNames.Clear();
+            aosDriverNames.AddString("OpenFileGDB");
         }
         else if (aosDriverNames.size() >= 2)
         {


### PR DESCRIPTION
given that now FileGDB write support actually uses OpenFileGDB one.
