### PR TITLE
ogr2ogr: fix -upsert with a GPKG source

### DIFF
--- a/apps/ogr2ogr_lib.cpp
+++ b/apps/ogr2ogr_lib.cpp
@@ -4198,11 +4198,11 @@ bool SetupTargetLayer::CanUseWriteArrowBatch(
           !psOptions->aosLCO.FetchNameValue("BATCH_SIZE") &&
           CPLTestBool(CPLGetConfigOption("OGR2OGR_USE_ARROW_API", "YES"))) ||
          CPLTestBool(CPLGetConfigOption("OGR2OGR_USE_ARROW_API", "NO"))) &&
-        !psOptions->bSkipFailures && !psOptions->poClipSrc &&
-        !psOptions->poClipDst && psOptions->oGCPs.nGCPCount == 0 &&
-        !psOptions->bWrapDateline && !m_papszSelFields &&
-        !m_bAddMissingFields && m_eGType == GEOMTYPE_UNCHANGED &&
-        psOptions->eGeomOp == GEOMOP_NONE &&
+        !psOptions->bUpsert && !psOptions->bSkipFailures &&
+        !psOptions->poClipSrc && !psOptions->poClipDst &&
+        psOptions->oGCPs.nGCPCount == 0 && !psOptions->bWrapDateline &&
+        !m_papszSelFields && !m_bAddMissingFields &&
+        m_eGType == GEOMTYPE_UNCHANGED && psOptions->eGeomOp == GEOMOP_NONE &&
         m_eGeomTypeConversion == GTC_DEFAULT && m_nCoordDim < 0 &&
         !m_papszFieldTypesToString && !m_papszMapFieldType &&
         !m_bUnsetFieldWidth && !m_bExplodeCollections && !m_pszZField &&

--- a/autotest/utilities/test_ogr2ogr_lib.py
+++ b/autotest/utilities/test_ogr2ogr_lib.py
@@ -941,26 +941,26 @@ def test_ogr2ogr_upsert(tmp_vsimem):
 
     create_gpkg_file()
 
-    def create_mem_file():
-        srcDS = gdal.GetDriverByName("Memory").Create("", 0, 0, 0, gdal.GDT_Unknown)
-        mem_lyr = srcDS.CreateLayer("foo")
-        assert (
-            mem_lyr.CreateField(ogr.FieldDefn("other", ogr.OFTString))
-            == ogr.OGRERR_NONE
+    def create_src_file():
+        src_filename = tmp_vsimem / "test_ogr_gpkg_upsert_src.gpkg"
+        srcDS = gdal.GetDriverByName("GPKG").Create(
+            src_filename, 0, 0, 0, gdal.GDT_Unknown
         )
+        lyr = srcDS.CreateLayer("foo")
+        assert lyr.CreateField(ogr.FieldDefn("other", ogr.OFTString)) == ogr.OGRERR_NONE
         unique_field = ogr.FieldDefn("unique_field", ogr.OFTString)
         unique_field.SetUnique(True)
-        assert mem_lyr.CreateField(unique_field) == ogr.OGRERR_NONE
+        assert lyr.CreateField(unique_field) == ogr.OGRERR_NONE
 
-        f = ogr.Feature(mem_lyr.GetLayerDefn())
+        f = ogr.Feature(lyr.GetLayerDefn())
         f.SetField("unique_field", "2")
         f.SetField("other", "foo")
         f.SetGeometryDirectly(ogr.CreateGeometryFromWkt("POINT (10 10)"))
-        mem_lyr.CreateFeature(f)
+        lyr.CreateFeature(f)
         return srcDS
 
     assert (
-        gdal.VectorTranslate(filename, create_mem_file(), accessMode="upsert")
+        gdal.VectorTranslate(filename, create_src_file(), accessMode="upsert")
         is not None
     )
 


### PR DESCRIPTION
Workaround is to set the OGR2OGR_USE_ARROW_API=NO configuration option

Fixes https://lists.osgeo.org/pipermail/gdal-dev/2025-March/060389.html
