### PR TITLE
GRIB2: fix reading Transverse Merctor with negative easting/falsing; also fix reading it with scale factor != 0.9996

### DIFF
--- a/autotest/gdrivers/grib.py
+++ b/autotest/gdrivers/grib.py
@@ -2425,3 +2425,22 @@ def test_grib_grib2_MANAL_2023030103_fake_wrong_grid_origin_latitude():
     assert gt == pytest.approx(
         (-2442500.0217935005, 5000.0, 0.0, 2042500.0318467868, 0.0, -5000.0), rel=1e-6
     )
+
+
+# Test reading a Transverse Mercator projection with negative false easting/northing (#12015)
+
+
+def test_grib_grib2_tmerc_negative_false_easting_false_northing(tmp_vsimem):
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 2, 2)
+    src_ds.SetProjection(
+        "+proj=tmerc +lat_0=-1 +lon_0=-2 +k=1 +x_0=-300000 +y_0=-400000"
+    )
+    src_ds.SetGeoTransform([0, 1, 0, 0, 0, -1])
+    out_filename = tmp_vsimem / "tmp.grb2"
+    gdal.GetDriverByName("GRIB").CreateCopy(out_filename, src_ds)
+    with gdal.Open(out_filename) as ds:
+        assert (
+            "+proj=tmerc +lat_0=-1 +lon_0=-2 +k=1 +x_0=-300000 +y_0=-400000"
+            in ds.GetSpatialRef().ExportToProj4()
+        )

--- a/frmts/grib/degrib/g2clib/gridtemplates.c
+++ b/frmts/grib/degrib/g2clib/gridtemplates.c
@@ -18,7 +18,7 @@ static const struct gridtemplate templatesgrid[MAXGRIDTEMP] = {
              // 3.5: Variable resolution rotate Latitude/Longitude
          { 5, 16, 1, {1,1,4,1,4,1,4,4,4,4,4,1,1,-4,4,4} },
              // 3.12: Transverse Mercator
-         {12, 22, 0, {1,1,4,1,4,1,4,4,4,-4,4,1,-4,4,4,1,4,4,-4,-4,-4,-4} },
+         {12, 22, 0, {1,1,4,1,4,1,4,4,4,-4,4,1,-4,-4,-4,1,4,4,-4,-4,-4,-4} },
              // 3.101: General unstructured grid
          {101, 4, 0, {1,4,1,-4} },
              // 3.140: Lambert Azimuthal Equal Area Projection

--- a/frmts/grib/gribdataset.cpp
+++ b/frmts/grib/gribdataset.cpp
@@ -2495,7 +2495,7 @@ void GRIBDataset::SetGribMetaData(grib_MetaData *meta)
         case GS3_TRANSVERSE_MERCATOR:
             oSRS.SetTM(meta->gds.latitude_of_origin,
                        Lon360to180(meta->gds.central_meridian),
-                       std::abs(meta->gds.scaleLat1 - 0.9996) < 1e8
+                       std::abs(meta->gds.scaleLat1 - 0.9996) < 1e-8
                            ? 0.9996
                            : meta->gds.scaleLat1,
                        meta->gds.x0, meta->gds.y0);


### PR DESCRIPTION
Fixes #12015