### PR TITLE
Docs: Remove duplicate from docs requirement.txt

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -6,7 +6,6 @@ numpy
 sphinx
 sphinx_bootstrap_theme
 sphinx-markdown-tables
-sphinx_rtd_theme
 sphinxcontrib-bibtex
 sphinxcontrib-jquery
 sphinx-rtd-theme >= 3.0.0


### PR DESCRIPTION
## What does this PR do?

Allows the doc requirements to be installed correctly when running:

```
cd /gdal/doc
python3 -m pip install -r requirements.txt
```

Currently, the following error is returned:

```
ERROR: Double requirement given: sphinx-rtd-theme>=3.0.0 (from -r requirements.txt (line 12)) (already in sphinx_rtd_theme (from -r requirements.txt (line 9)), name='sphinx-rtd-theme')
```
