### PR TITLE
rgb2pct.py - added options

### DIFF
--- a/autotest/pyscripts/test_pct.py
+++ b/autotest/pyscripts/test_pct.py
@@ -89,20 +89,6 @@ def rgb2pct2_tif(script_path, tmp_path_factory):
     yield tif_fname
 
 
-@pytest.fixture(scope="module")
-def rgb2pct2c_tif(script_path, tmp_path_factory):
-
-    tif_fname = str(tmp_path_factory.mktemp("tmp") / "test_rgb2pct_2c.tif")
-
-    test_py_scripts.run_py_script(
-        script_path,
-        "rgb2pct",
-        "-n 16 --compress-option COMPRESS=LZW " + test_py_scripts.get_data_path("gcore") + f"rgbsmall.tif {tif_fname}",
-    )
-
-    yield tif_fname
-
-
 ###############################################################################
 # Test rgb2pct
 
@@ -216,19 +202,24 @@ def test_rgb2pct_2(script_path, rgb2pct2_tif):
     ds = None
 
 
-def test_rgb2pct_2c(script_path, rgb2pct2c_tif):
+###############################################################################
+# Test rgb2pct --creation-option option
 
-    ds = gdal.Open(rgb2pct2c_tif)
-    assert ds.GetRasterBand(1).Checksum() == 16596
 
-    ct = ds.GetRasterBand(1).GetRasterColorTable()
-    for i in range(16, 255):
-        entry = ct.GetColorEntry(i)
-        assert (
-            entry[0] == 0 and entry[1] == 0 and entry[2] == 0
-        ), "Color table has more than 16 entries"
+def test_rgb2pct_creation_option(script_path, tmp_path):
 
-    ds = None
+    tif_fname = str(tmp_path / "test_rgb2pct_creation_option.tif")
+
+    test_py_scripts.run_py_script(
+        script_path,
+        "rgb2pct",
+        "--creation-option COMPRESS=LZW "
+        + test_py_scripts.get_data_path("gcore")
+        + f"rgbsmall.tif {tif_fname}",
+    )
+
+    ds = gdal.Open(tif_fname)
+    assert ds.GetMetadataItem("COMPRESSION", "IMAGE_STRUCTURE") == "LZW"
 
 
 ###############################################################################

--- a/doc/source/programs/rgb2pct.rst
+++ b/doc/source/programs/rgb2pct.rst
@@ -15,7 +15,7 @@ Synopsis
 
 .. code-block::
 
-    rgb2pct [--help] [--help-general]
+    rgb2pct [--help] [--help-general] [--options OPTION]
                [-n colors | -pct palette_file] [-of format] <source_file> <dest_file>
 
 Description
@@ -39,6 +39,11 @@ maximize output image visual quality.
 
     Select the number of colors in the generated
     color table.  Defaults to 256.  Must be between 2 and 256.
+
+.. option:: --options OPTION
+
+    Optional creation parameters for the GeoTIFF driver,
+    for example COMPRESS=LZW. Multiple options are space separated.
 
 .. option:: -pct <palette_file>
 

--- a/doc/source/programs/rgb2pct.rst
+++ b/doc/source/programs/rgb2pct.rst
@@ -40,10 +40,10 @@ maximize output image visual quality.
     Select the number of colors in the generated
     color table.  Defaults to 256.  Must be between 2 and 256.
 
-.. option:: --options OPTION
+.. option:: --creation-option OPTION
 
     Optional creation parameters for the GeoTIFF driver,
-    for example COMPRESS=LZW. Multiple options are space separated.
+    for example "COMPRESS=LZW". Can be specified multiple times.
 
 .. option:: -pct <palette_file>
 

--- a/doc/source/programs/rgb2pct.rst
+++ b/doc/source/programs/rgb2pct.rst
@@ -15,7 +15,7 @@ Synopsis
 
 .. code-block::
 
-    rgb2pct [--help] [--help-general] [--options OPTION]
+    rgb2pct [--help] [--help-general] [--creation-option OPTION]
                [-n colors | -pct palette_file] [-of format] <source_file> <dest_file>
 
 Description

--- a/swig/python/gdal-utils/osgeo_utils/rgb2pct.py
+++ b/swig/python/gdal-utils/osgeo_utils/rgb2pct.py
@@ -36,6 +36,7 @@ def rgb2pct(
     dst_filename: Optional[PathLikeOrStr] = None,
     color_count: int = 256,
     driver_name: Optional[str] = None,
+    options: Optional[list] = None,
 ):
     # Open source file
     src_ds = open_ds(src_filename)
@@ -81,8 +82,14 @@ def rgb2pct(
 
     gtiff_driver = gdal.GetDriverByName("GTiff")
 
+    # Convert options to list
+    if isinstance(options, str):
+        options = options.split()
+    if not options:
+        options = []
+
     tif_ds = gtiff_driver.Create(
-        tif_filename, src_ds.RasterXSize, src_ds.RasterYSize, 1
+        tif_filename, src_ds.RasterXSize, src_ds.RasterYSize, 1, options=options
     )
 
     tif_ds.GetRasterBand(1).SetRasterColorTable(ct)
@@ -173,6 +180,13 @@ class RGB2PCT(GDALScript):
             "Can be used to have a consistent color table for multiple files. "
             "The palette file must be either a raster file in a GDAL supported format with a "
             "palette or a color file in a supported format (txt, qml, qlr).",
+        )
+
+        parser.add_argument(
+            "--options",
+            dest="options",
+            type=str,
+            help="GeoTIFF creation options, e.g. COMPRESS=LZW",
         )
 
         parser.add_argument("src_filename", type=str, help="The input RGB file.")

--- a/swig/python/gdal-utils/osgeo_utils/rgb2pct.py
+++ b/swig/python/gdal-utils/osgeo_utils/rgb2pct.py
@@ -89,7 +89,11 @@ def rgb2pct(
         creation_options = []
 
     tif_ds = gtiff_driver.Create(
-        tif_filename, src_ds.RasterXSize, src_ds.RasterYSize, 1, options=creation_options,
+        tif_filename,
+        src_ds.RasterXSize,
+        src_ds.RasterYSize,
+        1,
+        options=creation_options,
     )
 
     tif_ds.GetRasterBand(1).SetRasterColorTable(ct)

--- a/swig/python/gdal-utils/osgeo_utils/rgb2pct.py
+++ b/swig/python/gdal-utils/osgeo_utils/rgb2pct.py
@@ -183,7 +183,7 @@ class RGB2PCT(GDALScript):
         )
 
         parser.add_argument(
-            "--creation_option",
+            "--creation-option",
             "--co",
             dest="creation_options",
             default=[],

--- a/swig/python/gdal-utils/osgeo_utils/rgb2pct.py
+++ b/swig/python/gdal-utils/osgeo_utils/rgb2pct.py
@@ -36,7 +36,7 @@ def rgb2pct(
     dst_filename: Optional[PathLikeOrStr] = None,
     color_count: int = 256,
     driver_name: Optional[str] = None,
-    options: Optional[list] = None,
+    creation_options: Optional[list] = None,
 ):
     # Open source file
     src_ds = open_ds(src_filename)
@@ -83,13 +83,13 @@ def rgb2pct(
     gtiff_driver = gdal.GetDriverByName("GTiff")
 
     # Convert options to list
-    if isinstance(options, str):
-        options = options.split()
-    if not options:
-        options = []
+    if isinstance(creation_options, str):
+        creation_options = creation_options.split()
+    if not creation_options:
+        creation_options = []
 
     tif_ds = gtiff_driver.Create(
-        tif_filename, src_ds.RasterXSize, src_ds.RasterYSize, 1, options=options
+        tif_filename, src_ds.RasterXSize, src_ds.RasterYSize, 1, options=creation_options,
     )
 
     tif_ds.GetRasterBand(1).SetRasterColorTable(ct)
@@ -183,9 +183,11 @@ class RGB2PCT(GDALScript):
         )
 
         parser.add_argument(
-            "--options",
-            dest="options",
-            type=str,
+            "--creation_option",
+            "--co",
+            dest="creation_options",
+            default=[],
+            action="append",
             help="GeoTIFF creation options, e.g. COMPRESS=LZW",
         )
 


### PR DESCRIPTION
## What does this PR do?

Adds `--options` to `rgb2pct.py` so that GeoTIFF creation options can be passed to the GeoTIFF driver, for example `--options COMPRESS=LZW`

## What are related issues/pull requests?

#12031 

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE
