### PR TITLE
CMake: Allow Sphinx build to proceed if Doxygen produces warnings

### DIFF
--- a/.github/workflows/doc_checks.yml
+++ b/.github/workflows/doc_checks.yml
@@ -47,6 +47,7 @@ jobs:
             -DBUILD_APPS=ON \
             -DBUILD_DOCS=ON \
             -DBUILD_TESTING=ON \
+            -DDOXYGEN_FAIL_ON_WARNINGS=ON \
             -DGDAL_BUILD_OPTIONAL_DRIVERS=OFF \
             -DOGR_BUILD_OPTIONAL_DRIVERS=OFF
           cmake --build . -j$(nproc)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -14,6 +14,8 @@ endif()
 
 option(BUILD_DOCS "Set to ON to define documentation targets: 'html', 'latexpdf', 'man', 'doxygen_xml', 'doxygen_html' " ${BUILD_DOCS_DEFAULT})
 
+option(DOXYGEN_FAIL_ON_WARNINGS "Set to ON to fail the build if Doxygen produces warnings" OFF)
+
 if (BUILD_DOCS)
     if ("${CMAKE_BINARY_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
         message(FATAL_ERROR "BUILD_DOCS=ON not compatible of in-source builds (CMAKE_SOURCE_DIR=CMAKE_BINARY_DIR)")
@@ -66,12 +68,17 @@ if (BUILD_DOCS)
     # for XML and HTML outputs
     file(READ ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile_base DOXYFILE_CONTENTS)
 
+    if (DOXYGEN_FAIL_ON_WARNINGS) 
+            string(JOIN "\n" DOXYFILE_CONTENTS
+                   ${DOXYFILE_CONTENTS}
+                   "FAIL_ON_WARNINGS=YES"
+                   "WARN_AS_ERROR=FAIL_ON_WARNINGS_PRINT")
+    endif()
+
     # Doxygen XML outputs
     # TODO <ndash> replacement?
     string(JOIN "\n" DOXYFILE_XML_CONTENTS
             ${DOXYFILE_CONTENTS}
-            "FAIL_ON_WARNINGS=YES"
-            "WARN_AS_ERROR=FAIL_ON_WARNINGS_PRINT"
             "GENERATE_HTML=NO"
             "GENERATE_XML=YES"
             "XML_OUTPUT=${SPHINX_BUILD_DIR}/xml"
@@ -94,8 +101,6 @@ if (BUILD_DOCS)
     # Doxygen HTML outputs
     string(JOIN "\n" DOXYFILE_HTML_CONTENTS
             "${DOXYFILE_CONTENTS}"
-            "FAIL_ON_WARNINGS=YES"
-            "WARN_AS_ERROR=FAIL_ON_WARNINGS_PRINT"
             "HTML_OUTPUT=${SPHINX_BUILD_DIR}/html_extra/doxygen"
             "INLINE_INHERITED_MEMB=YES"
     )


### PR DESCRIPTION
#11951 may have made it more difficult for contributors to build documentation by requiring that the Doxygen build succeed without warnings in order to run Sphinx. There are reasons this could fail spuriously (different Doxygen version, for example). This PR adds a build option so that we can require Doxygen to succeed in CI but not require it by default.

cc @chambbj