### PR TITLE
gdal CLI: add warning when setting the hidden --config option; …

### DIFF
--- a/autotest/gdrivers/gdalg.py
+++ b/autotest/gdrivers/gdalg.py
@@ -59,6 +59,23 @@ def test_gdalg_raster_pipeline_explicit_write_step():
     assert ds.GetRasterBand(1).Checksum() == 4672
 
 
+def test_gdalg_raster_pipeline_warn_about_config():
+    with gdal.quiet_errors():
+        ds = gdal.Open(
+            json.dumps(
+                {
+                    "type": "gdal_streamed_alg",
+                    "command_line": "gdal raster pipeline ! read --config FOO=BAR data/byte.tif",
+                }
+            )
+        )
+        assert (
+            gdal.GetLastErrorMsg()
+            == "read: Configuration options passed with the 'config' argument are ignored"
+        )
+    assert ds.GetRasterBand(1).Checksum() == 4672
+
+
 def test_gdalg_raster_pipeline_error():
     with pytest.raises(Exception):
         gdal.Open(

--- a/autotest/utilities/test_gdal.py
+++ b/autotest/utilities/test_gdal.py
@@ -88,6 +88,19 @@ def test_gdal_failure_during_finalize(gdal_path):
     assert "ret code = 1" in err
 
 
+def test_gdal_config_not_serialized_to_gdalg(tmp_path, gdal_path):
+
+    out_filename = str(tmp_path / "out.gdalg.json")
+    gdaltest.runexternal(
+        f"{gdal_path} raster reproject --config FOO=BAR ../gcore/data/byte.tif {out_filename}"
+    )
+    # Test that configuration option is not serialized
+    assert json.loads(gdal.VSIFile(out_filename, "rb").read()) == {
+        "command_line": "gdal raster reproject --input ../gcore/data/byte.tif --output-format stream --output streamed_dataset",
+        "type": "gdal_streamed_alg",
+    }
+
+
 def test_gdal_completion(gdal_path):
 
     out = gdaltest.runexternal(f"{gdal_path} completion gdal -").split(" ")

--- a/gcore/gdalalgorithm.cpp
+++ b/gcore/gdalalgorithm.cpp
@@ -3147,6 +3147,13 @@ bool GDALAlgorithm::Run(GDALProgressFunc pfnProgress, void *pProgressData)
     if (!ValidateArguments())
         return false;
 
+    if (!m_dummyConfigOptions.empty())
+    {
+        ReportError(CE_Warning, CPLE_AppDefined,
+                    "Configuration options passed with the 'config' argument "
+                    "are ignored");
+    }
+
     switch (ProcessGDALGOutput())
     {
         case ProcessGDALGOutputRet::GDALG_ERROR:


### PR DESCRIPTION
…add tests to check config options are ignored
