### PR TITLE
gdal2tiles: remap PIL (Python Imaging Library)' 'antialias' resampling to GDAL Lanczos

### DIFF
--- a/autotest/pyscripts/gdal2tiles/test_option_parser.py
+++ b/autotest/pyscripts/gdal2tiles/test_option_parser.py
@@ -159,18 +159,6 @@ class OptionParserPostProcessingTest(TestCase):
         )
         # No error means it worked as expected
 
-    def test_antialias_resampling_not_supported_wout_numpy(self):
-        gdal2tiles.numpy_available = False
-        if hasattr(gdal2tiles, "numpy"):
-            del gdal2tiles.numpy
-
-        self.DEFAULT_ATTRDICT_OPTIONS["resampling"] = "antialias"
-
-        with self.assertRaises(SystemExit):
-            gdal2tiles.options_post_processing(
-                self.DEFAULT_ATTRDICT_OPTIONS, "foo.tiff", "/bar/"
-            )
-
     def test_zoom_option_not_specified(self):
         self.DEFAULT_ATTRDICT_OPTIONS["zoom"] = None
 

--- a/doc/source/programs/gdal2tiles.rst
+++ b/doc/source/programs/gdal2tiles.rst
@@ -72,7 +72,7 @@ can publish a picture without proper georeferencing too.
 
 .. option:: -r <RESAMPLING>, --resampling=<RESAMPLING>
 
-  Resampling method (average, near, bilinear, cubic, cubicspline, lanczos, antialias, mode, max, min, med, q1, q3) - default 'average'.
+  Resampling method (average, near, bilinear, cubic, cubicspline, lanczos, mode, max, min, med, q1, q3) - default 'average'.
 
 .. option:: -s <SRS>, --s_srs=<SRS>
 

--- a/docker/alpine-normal/Dockerfile
+++ b/docker/alpine-normal/Dockerfile
@@ -404,9 +404,6 @@ RUN if test "$(uname -m)" = "x86_64"; then ( \
     apk add --no-cache librasterlite2 \
     ); fi
 
-# Install Pillow for -antialias option of gdal2tiles
-RUN apk add --no-cache py3-pillow
-
 # Order layers starting with less frequently varying ones
 COPY --from=builder  /build_thirdparty/usr/ /usr/
 

--- a/docker/ubuntu-full/Dockerfile
+++ b/docker/ubuntu-full/Dockerfile
@@ -550,8 +550,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         libspdlog1.12 libmagic1t64 \
         libmuparser2v5 \
         python-is-python3 \
-        # pil for antialias option of gdal2tiles
-        python3-pil \
         # for validate_geoparquet.py (cf https://github.com/OSGeo/gdal/issues/11953)
         python3-jsonschema \
     # Install JRE with --no-install-recommends, otherwise it draws default-jre, which draws systemd, which fails to install when running the arm64v8/ubuntu:24.04 image on a 64bit host

--- a/docker/ubuntu-small/Dockerfile
+++ b/docker/ubuntu-small/Dockerfile
@@ -244,8 +244,6 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
         libdeflate0 \
         libzstd1 bash libpq5 libssl3 libopenjp2-7 libspatialite8 \
         libmuparser2v5 \
-        # pil for antialias option of gdal2tiles
-        python3-pil \
     && apt-get install -y python-is-python3
 
 # Order layers starting with less frequently varying ones

--- a/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
@@ -41,17 +41,6 @@ from osgeo_utils.auxiliary.util import enable_gdal_exceptions
 
 Options = Any
 
-try:
-    import numpy
-    from PIL import Image
-
-    import osgeo.gdal_array as gdalarray
-
-    numpy_available = True
-except ImportError:
-    # 'antialias' resampling is not available
-    numpy_available = False
-
 __version__ = gdal.__version__
 
 resampling_list = (
@@ -907,40 +896,6 @@ def scale_query_to_tile(dsquery, dstile, options, tilefilename=""):
                     "RegenerateOverview() failed on %s, error %d" % (tilefilename, res)
                 )
 
-    elif options.resampling == "antialias" and numpy_available:
-
-        if tilefilename.startswith("/vsi"):
-            raise Exception(
-                "Outputting to /vsi file systems with antialias mode is not supported"
-            )
-
-        # Scaling by PIL (Python Imaging Library) - improved Lanczos
-        array = numpy.zeros((querysize, querysize, tilebands), numpy.uint8)
-        for i in range(tilebands):
-            array[:, :, i] = gdalarray.BandReadAsArray(
-                dsquery.GetRasterBand(i + 1), 0, 0, querysize, querysize
-            )
-        if options.tiledriver == "JPEG" and tilebands == 2:
-            im = Image.fromarray(array[:, :, 0], "L")
-        elif options.tiledriver == "JPEG" and tilebands == 4:
-            im = Image.fromarray(array[:, :, 0:3], "RGB")
-        else:
-            im = Image.fromarray(array, "RGBA")
-        im1 = im.resize((tile_size, tile_size), Image.LANCZOS)
-        if os.path.exists(tilefilename):
-            im0 = Image.open(tilefilename)
-            im1 = Image.composite(im1, im0, im1)
-
-        params = {}
-        if options.tiledriver == "WEBP":
-            if options.webp_lossless:
-                params["lossless"] = True
-            else:
-                params["quality"] = options.webp_quality
-        elif options.tiledriver == "JPEG":
-            params["quality"] = options.jpeg_quality
-        im1.save(tilefilename, options.tiledriver, **params)
-
     else:
 
         if options.resampling == "near":
@@ -1437,21 +1392,18 @@ def create_base_tile(tile_job_info: "TileJobInfo", tile_detail: "TileDetail") ->
 
     del data
 
-    if options.resampling != "antialias":
-        # Write a copy of tile to png/jpg
-        out_drv.CreateCopy(
-            tilefilename,
-            dstile
-            if tile_job_info.tile_driver != "JPEG"
-            else remove_alpha_band(dstile),
-            strict=0,
-            options=_get_creation_options(options),
-        )
+    # Write a copy of tile to png/jpg
+    out_drv.CreateCopy(
+        tilefilename,
+        dstile if tile_job_info.tile_driver != "JPEG" else remove_alpha_band(dstile),
+        strict=0,
+        options=_get_creation_options(options),
+    )
 
-        # Remove useless side car file
-        aux_xml = tilefilename + ".aux.xml"
-        if gdal.VSIStatL(aux_xml) is not None:
-            gdal.Unlink(aux_xml)
+    # Remove useless side car file
+    aux_xml = tilefilename + ".aux.xml"
+    if gdal.VSIStatL(aux_xml) is not None:
+        gdal.Unlink(aux_xml)
 
     del dstile
 
@@ -1658,21 +1610,18 @@ def create_overview_tile(
         return
 
     scale_query_to_tile(dsquery, dstile, options, tilefilename=tilefilename)
+
     # Write a copy of tile to png/jpg
-    if options.resampling != "antialias":
-        # Write a copy of tile to png/jpg
-        out_driver.CreateCopy(
-            tilefilename,
-            dstile
-            if tile_job_info.tile_driver != "JPEG"
-            else remove_alpha_band(dstile),
-            strict=0,
-            options=_get_creation_options(options),
-        )
-        # Remove useless side car file
-        aux_xml = tilefilename + ".aux.xml"
-        if gdal.VSIStatL(aux_xml) is not None:
-            gdal.Unlink(aux_xml)
+    out_driver.CreateCopy(
+        tilefilename,
+        dstile if tile_job_info.tile_driver != "JPEG" else remove_alpha_band(dstile),
+        strict=0,
+        options=_get_creation_options(options),
+    )
+    # Remove useless side car file
+    aux_xml = tilefilename + ".aux.xml"
+    if gdal.VSIStatL(aux_xml) is not None:
+        gdal.Unlink(aux_xml)
 
     if options.verbose:
         logger.debug(
@@ -2091,11 +2040,11 @@ def options_post_processing(
         options.url += os.path.basename(out_path) + "/"
 
     # Supported options
-    if options.resampling == "antialias" and not numpy_available:
-        exit_with_error(
-            "'antialias' resampling algorithm is not available.",
-            "Install PIL (Python Imaging Library) and numpy.",
+    if options.resampling == "antialias":
+        print(
+            "Use of --resampling antialias is deprecated. It is now an equivalent of lanczos"
         )
+        options.resampling = "lanczos"
 
     if options.tiledriver == "WEBP":
         if gdal.GetDriverByName(options.tiledriver) is None:
@@ -2591,11 +2540,10 @@ class GDAL2Tiles:
                 # one, generate an oversample temporary VRT file, and tile from
                 # it
                 oversample_factor = 1 << (self.tmaxz - self.nativezoom)
-                if self.options.resampling in ("average", "antialias"):
-                    resampleAlg = "average"
-                elif self.options.resampling in (
+                if self.options.resampling in (
                     "near",
                     "bilinear",
+                    "average",
                     "cubic",
                     "cubicspline",
                     "lanczos",


### PR DESCRIPTION
PIL 10.0 has deprecated antialias:
```
ANTIALIAS is deprecated and will be removed in Pillow 10 (2023-07-01). Use Resampling.LANCZOS instead.
https://pillow.readthedocs.io/en/stable/releasenotes/10.0.0.html#
```

Fixes #12030
