### PR TITLE
autotest: avoid deprecation warning about pytest.importorskip("osgeo.gdal_array")

### DIFF
--- a/autotest/alg/sieve.py
+++ b/autotest/alg/sieve.py
@@ -13,6 +13,7 @@
 ###############################################################################
 
 
+import gdaltest
 import pytest
 
 from osgeo import gdal
@@ -176,7 +177,7 @@ def test_sieve_5():
 
 def test_sieve_6():
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     numpy = pytest.importorskip("numpy")
 
     # Try 3002. Should run in less than 10 seconds

--- a/autotest/alg/transformgeoloc.py
+++ b/autotest/alg/transformgeoloc.py
@@ -14,6 +14,7 @@
 ###############################################################################
 
 
+import gdaltest
 import pytest
 
 from osgeo import gdal, osr
@@ -24,7 +25,7 @@ from osgeo import gdal, osr
 
 def test_transformgeoloc_1():
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     numpy = pytest.importorskip("numpy")
 
     # Setup 2x2 geolocation arrays in a memory dataset with lat/long values.

--- a/autotest/alg/warp.py
+++ b/autotest/alg/warp.py
@@ -1212,7 +1212,7 @@ def test_warp_weighted_average():
 )
 def test_warp_weighted_mode(dtype):
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     np = pytest.importorskip("numpy")
 
     with gdal.GetDriverByName("MEM").Create("", 3, 3, eType=dtype) as src_ds:
@@ -1601,7 +1601,7 @@ def test_warp_55():
 @pytest.mark.parametrize("use_optim", ["YES", "NO"])
 def test_warp_56(use_optim):
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     numpy = pytest.importorskip("numpy")
 
     pix_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
@@ -1700,7 +1700,7 @@ def test_warp_rms_2():
 @pytest.mark.parametrize("dtype", (gdal.GDT_Int16, gdal.GDT_Int32))
 def test_warp_mode_ties(tie_strategy, dtype):
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     numpy = pytest.importorskip("numpy")
 
     # 1 and 5 are tied for the mode; 1 encountered first

--- a/autotest/gcore/basic_test.py
+++ b/autotest/gcore/basic_test.py
@@ -1009,7 +1009,7 @@ def test_ComputeMinMaxLocation():
 
 def test_create_numpy_types():
     np = pytest.importorskip("numpy")
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
 
     drv = gdal.GetDriverByName("MEM")
 

--- a/autotest/gcore/hfa_rfc40.py
+++ b/autotest/gcore/hfa_rfc40.py
@@ -13,6 +13,7 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
+import gdaltest
 import pytest
 
 from osgeo import gdal
@@ -24,7 +25,7 @@ pytestmark = [
 
 # All tests will be skipped if numpy is unavailable.
 np = pytest.importorskip("numpy")
-pytest.importorskip("osgeo.gdal_array")
+gdaltest.importorskip_gdal_array()
 
 INT_DATA = np.array([197, 83, 46, 29, 1, 78, 23, 90, 12, 45])
 DOUBLE_DATA = np.array([0.1, 43.2, 78.1, 9.9, 23.0, 0.92, 82.5, 0.0, 1.0, 99.0])

--- a/autotest/gcore/interpolateatpoint.py
+++ b/autotest/gcore/interpolateatpoint.py
@@ -68,7 +68,7 @@ def test_interpolateatpoint_throw():
 
 def test_interpolateatpoint_2_bands():
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     np = pytest.importorskip("numpy")
 
     mem_ds = gdal.GetDriverByName("MEM").Create(
@@ -97,7 +97,7 @@ def test_interpolateatpoint_2_bands():
 
 def test_interpolateatpoint_bilinear_several_points():
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     np = pytest.importorskip("numpy")
 
     mem_ds = gdal.GetDriverByName("MEM").Create(
@@ -136,7 +136,7 @@ def test_interpolateatpoint_bilinear_several_points():
 
 def test_interpolateatpoint_cubicspline_several_points():
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     np = pytest.importorskip("numpy")
 
     mem_ds = gdal.GetDriverByName("MEM").Create(
@@ -167,7 +167,7 @@ def test_interpolateatpoint_cubicspline_several_points():
 
 def test_interpolateatpoint_cubic_several_points():
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     np = pytest.importorskip("numpy")
 
     mem_ds = gdal.GetDriverByName("MEM").Create(
@@ -205,7 +205,7 @@ def test_interpolateatpoint_cubic_several_points():
 
 def test_interpolateatpoint_at_borders():
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     np = pytest.importorskip("numpy")
 
     mem_ds = gdal.GetDriverByName("MEM").Create(

--- a/autotest/gcore/numpy_rw.py
+++ b/autotest/gcore/numpy_rw.py
@@ -19,7 +19,7 @@ from osgeo import gdal
 
 # All tests will be skipped if numpy or gdal_array are unavailable.
 numpy = pytest.importorskip("numpy")
-gdal_array = pytest.importorskip("osgeo.gdal_array")
+gdal_array = gdaltest.importorskip_gdal_array()
 
 ###############################################################################
 @pytest.fixture(autouse=True, scope="module")

--- a/autotest/gcore/numpy_rw_multidim.py
+++ b/autotest/gcore/numpy_rw_multidim.py
@@ -27,7 +27,7 @@ from osgeo import gdal
 def setup_and_cleanup():
 
     # importing gdal_array will allow numpy driver registration
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
 
     gdal.AllRegister()
 

--- a/autotest/gcore/pixfun.py
+++ b/autotest/gcore/pixfun.py
@@ -25,7 +25,7 @@ pytestmark = pytest.mark.skipif(
 
 # All tests will be skipped if numpy is unavailable.
 numpy = pytest.importorskip("numpy")
-pytest.importorskip("osgeo.gdal_array")
+gdaltest.importorskip_gdal_array()
 
 ###############################################################################
 # Verify real part extraction from a complex dataset.

--- a/autotest/gcore/rasterio.py
+++ b/autotest/gcore/rasterio.py
@@ -709,7 +709,7 @@ def test_rasterio_9():
 
 def test_rasterio_overview_subpixel_resampling():
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     numpy = pytest.importorskip("numpy")
 
     temp_path = "/vsimem/rasterio_ovr.tif"
@@ -776,7 +776,7 @@ def test_rasterio_10():
 
 def test_rasterio_11():
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     numpy = pytest.importorskip("numpy")
 
     mem_ds = gdal.GetDriverByName("MEM").Create("", 4, 3)
@@ -814,7 +814,7 @@ def rasterio_12_progress_callback(pct, message, user_data):
 
 def test_rasterio_12():
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     numpy = pytest.importorskip("numpy")
 
     mem_ds = gdal.GetDriverByName("MEM").Create("", 4, 3, 4)
@@ -884,7 +884,7 @@ def test_rasterio_12():
 )
 def test_rasterio_13(dt):
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     numpy = pytest.importorskip("numpy")
 
     dt = gdal.GetDataTypeByName(dt)
@@ -957,7 +957,7 @@ def test_rasterio_13(dt):
 @pytest.mark.parametrize("use_nan", [True, False])
 def test_rasterio_nearest_or_mode(dt, resample_alg, use_nan):
     numpy = pytest.importorskip("numpy")
-    gdal_array = pytest.importorskip("osgeo.gdal_array")
+    gdal_array = gdaltest.importorskip_gdal_array()
 
     dt = gdal.GetDataTypeByName(dt)
     mem_ds = gdal.GetDriverByName("MEM").Create("", 4, 4, 1, dt)
@@ -1214,7 +1214,7 @@ cellsize     0
 
 def test_rasterio_nodata():
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     ndv = 123
@@ -1423,7 +1423,7 @@ nodata_value 0
 
 def test_rasterio_dataset_readarray_cint16():
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     numpy = pytest.importorskip("numpy")
 
     mem_ds = gdal.GetDriverByName("MEM").Create("", 1, 1, 2, gdal.GDT_CInt16)
@@ -1500,7 +1500,7 @@ def test_rasterio_floating_point_window_no_resampling():
 def test_rasterio_floating_point_window_no_resampling_numpy():
     # Same as above but using ReadAsArray() instead of ReadRaster()
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     numpy = pytest.importorskip("numpy")
 
     ds = gdal.Translate(
@@ -3172,7 +3172,7 @@ def test_rasterio_gdal_rasterio_resampling():
 
 def test_rasterio_numpy_datatypes_for_xoff():
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     np = pytest.importorskip("numpy")
 
     ds = gdal.Open("data/byte.tif")

--- a/autotest/gcore/thread_test.py
+++ b/autotest/gcore/thread_test.py
@@ -447,7 +447,7 @@ def test_thread_safe_BeginAsyncReader():
 def test_thread_safe_GetVirtualMem():
 
     pytest.importorskip("numpy")
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
 
     with gdal.OpenEx("data/byte.tif", gdal.OF_RASTER | gdal.OF_THREAD_SAFE) as ds:
         with pytest.raises(Exception, match="not supported"):

--- a/autotest/gcore/tiff_ovr.py
+++ b/autotest/gcore/tiff_ovr.py
@@ -2472,7 +2472,7 @@ def test_tiff_ovr_color_table_bug_3336_bis():
 
 def test_tiff_ovr_nodata_multiband():
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     numpy = pytest.importorskip("numpy")
 
     temp_path = "/vsimem/test.tif"

--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -149,7 +149,7 @@ def test_tiff_write_3():
 
 def test_tiff_write_4():
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     np = pytest.importorskip("numpy")
 
     options = ["TILED=YES", "BLOCKXSIZE=32", "BLOCKYSIZE=32"]

--- a/autotest/gcore/virtualmem.py
+++ b/autotest/gcore/virtualmem.py
@@ -14,12 +14,13 @@
 
 import sys
 
+import gdaltest
 import pytest
 
 from osgeo import gdal
 
 # All tests will be skipped if numpy unavailable or SKIP_VIRTUALMEM is set.
-pytest.importorskip("osgeo.gdal_array")
+gdaltest.importorskip_gdal_array()
 numpy = pytest.importorskip("numpy")
 
 pytestmark = pytest.mark.skipif(

--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -128,7 +128,7 @@ def test_vrt_read_3():
 
 def test_vrt_read_4():
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     np = pytest.importorskip("numpy")
 
     data = np.zeros((1, 1), np.complex64)
@@ -962,7 +962,7 @@ def test_vrt_read_22():
 
 def test_vrt_read_23():
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     numpy = pytest.importorskip("numpy")
 
     mem_ds = gdal.GetDriverByName("GTiff").Create("/vsimem/vrt_read_23.tif", 2, 1)

--- a/autotest/gdrivers/heif.py
+++ b/autotest/gdrivers/heif.py
@@ -16,6 +16,7 @@ import array
 import os
 import shutil
 
+import gdaltest
 import pytest
 
 from osgeo import gdal
@@ -178,7 +179,7 @@ def test_heif_tiled():
     assert ds.GetRasterBand(1).GetBlockSize() == [15, 5]
     assert ds.GetRasterBand(2).GetBlockSize() == [15, 5]
     assert ds.GetRasterBand(3).GetBlockSize() == [15, 5]
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     assert (
         ds.GetRasterBand(1).ReadAsArray(0, 0, 30, 1)
         == [

--- a/autotest/gdrivers/lcp.py
+++ b/autotest/gdrivers/lcp.py
@@ -850,7 +850,7 @@ def test_lcp_21():
 
 def test_lcp_22():
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     numpy = pytest.importorskip("numpy")
 
     mem_drv = gdal.GetDriverByName("MEM")

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -2920,7 +2920,7 @@ def test_netcdf_66(tmp_path):
 
 def test_netcdf_67():
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     numpy = pytest.importorskip("numpy")
 
     # disable bottom-up mode to use the real file's blocks size

--- a/autotest/gdrivers/pds4.py
+++ b/autotest/gdrivers/pds4.py
@@ -1791,7 +1791,7 @@ def test_pds4_oblique_cylindrical_write():
 def test_pds4_read_right_to_left(tmp_path):
 
     numpy = pytest.importorskip("numpy")
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
 
     tmp_filename = str(tmp_path / "tmp.xml")
     ref_ds = gdal.Open("data/byte.tif")

--- a/autotest/gdrivers/rmf.py
+++ b/autotest/gdrivers/rmf.py
@@ -703,7 +703,7 @@ def rmf_31e_data_gen(min_val, max_val, stripeSize, sx):
 
 def test_rmf_31e():
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     numpy = pytest.importorskip("numpy")
 
     drv = gdal.GetDriverByName("Gtiff")
@@ -849,7 +849,7 @@ def test_rmf_33c():
 
 def test_rmf_34():
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     numpy = pytest.importorskip("numpy")
 
     drv = gdal.GetDriverByName("RMF")

--- a/autotest/gdrivers/tiledb_write.py
+++ b/autotest/gdrivers/tiledb_write.py
@@ -74,7 +74,7 @@ def test_tiledb_write_custom_blocksize(tmp_path, mode):
 @pytest.mark.parametrize("mode", ["BAND", "PIXEL"])
 def test_tiledb_write_update(tmp_path, mode):
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     np = pytest.importorskip("numpy")
 
     gdaltest.tiledb_drv = gdal.GetDriverByName("TileDB")
@@ -243,7 +243,7 @@ def test_tiledb_write_band_meta(tmp_path, mode):
 @pytest.mark.parametrize("mode", ["BAND", "PIXEL"])
 def test_tiledb_write_history(tmp_path, mode):
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     np = pytest.importorskip("numpy")
 
     options = ["INTERLEAVE=%s" % (mode), "TILEDB_TIMESTAMP=1"]

--- a/autotest/gdrivers/vrtderived.py
+++ b/autotest/gdrivers/vrtderived.py
@@ -983,7 +983,7 @@ def identity(in_ar, out_ar, xoff, yoff, xsize, ysize, raster_xsize, raster_ysize
 @pytest.mark.parametrize("dtype", range(1, gdal.GDT_TypeCount))
 def test_vrt_derived_dtype(tmp_vsimem, dtype):
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     input_fname = tmp_vsimem / "input.tif"

--- a/autotest/gdrivers/vrtpansharpen.py
+++ b/autotest/gdrivers/vrtpansharpen.py
@@ -1315,7 +1315,7 @@ def test_vrtpansharpen_5():
 
 def test_vrtpansharpen_6():
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     numpy = pytest.importorskip("numpy")
 
     # i = 0: VRT has <BitDepth>7</BitDepth>

--- a/autotest/gdrivers/vrtprocesseddataset.py
+++ b/autotest/gdrivers/vrtprocesseddataset.py
@@ -26,7 +26,7 @@ pytestmark = pytest.mark.skipif(
 )
 
 np = pytest.importorskip("numpy")
-gdal_array = pytest.importorskip("osgeo.gdal_array")
+gdal_array = gdaltest.importorskip_gdal_array()
 
 ###############################################################################
 # Test error cases in general VRTProcessedDataset XML structure

--- a/autotest/ogr/ogr_adbc.py
+++ b/autotest/ogr/ogr_adbc.py
@@ -469,7 +469,7 @@ def test_ogr_adbc_test_ogrsf_geoparquet(OGR_ADBC_AUTO_LOAD_DUCKDB_SPATIAL):
 
 
 def test_ogr_adbc_arrow_stream_numpy_datetime_as_string(tmp_vsimem):
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     if not _has_libduckdb():

--- a/autotest/ogr/ogr_flatgeobuf.py
+++ b/autotest/ogr/ogr_flatgeobuf.py
@@ -968,7 +968,7 @@ def test_ogr_flatgeobuf_invalid_output_filename():
     ids=["regular", "no_spatial_index"],
 )
 def test_ogr_flatgeobuf_arrow_stream_numpy(layer_creation_options):
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     numpy = pytest.importorskip("numpy")
 
     ds = ogr.GetDriverByName("FlatGeoBuf").CreateDataSource("/vsimem/test.fgb")
@@ -1570,7 +1570,7 @@ def test_ogr_flatgeobuf_sql_arrow(tmp_vsimem):
 
 
 def test_ogr_flatgeobuf_arrow_stream_numpy_datetime_as_string(tmp_vsimem):
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     filename = str(tmp_vsimem / "datetime_as_string.fgb")

--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -8089,7 +8089,7 @@ def test_ogr_gpkg_arrow_stream_pyarrow_timezone(tmp_vsimem):
 
 
 def test_ogr_gpkg_arrow_stream_numpy(tmp_vsimem):
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     numpy = pytest.importorskip("numpy")
 
     filename = tmp_vsimem / "test.gpkg"
@@ -8383,7 +8383,7 @@ def test_ogr_gpkg_arrow_stream_numpy(tmp_vsimem):
 def test_ogr_gpkg_arrow_stream_numpy_multi_threading(
     tmp_vsimem, num_features, batch_size, num_threads
 ):
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     filename = tmp_vsimem / "test.gpkg"
@@ -8431,7 +8431,7 @@ def test_ogr_gpkg_arrow_stream_numpy_multi_threading(
 
 
 def test_ogr_gpkg_arrow_stream_numpy_bool_field(tmp_vsimem):
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     filename = tmp_vsimem / "test.gpkg"
@@ -8471,7 +8471,7 @@ def test_ogr_gpkg_arrow_stream_numpy_bool_field(tmp_vsimem):
 
 @pytest.mark.parametrize("with_filter", [False, True])
 def test_ogr_gpkg_arrow_stream_numpy_more_than_125_columns(tmp_vsimem, with_filter):
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     filename = tmp_vsimem / "test.gpkg"
@@ -8507,7 +8507,7 @@ def test_ogr_gpkg_arrow_stream_numpy_more_than_125_columns(tmp_vsimem, with_filt
 
 @pytest.mark.parametrize("layer_type", ["direct", "sql"])
 def test_ogr_gpkg_arrow_stream_numpy_detailed_spatial_filter(tmp_vsimem, layer_type):
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     filename = str(
@@ -10115,7 +10115,7 @@ def test_ogr_gpkg_sql_exact_spatial_filter_for_feature_count(tmp_vsimem):
 
 @pytest.mark.parametrize("too_big_field", ["huge_string", "huge_binary", "geometry"])
 def test_ogr_gpkg_arrow_stream_huge_array(tmp_vsimem, too_big_field):
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     filename = tmp_vsimem / "test_ogr_gpkg_arrow_stream_huge_array.gpkg"
@@ -10867,7 +10867,7 @@ def test_ogr_gpkg_write_check_golden_file(tmp_path, src_filename):
 
 
 def test_ogr_gpkg_arrow_stream_numpy_datetime_as_string(tmp_vsimem):
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     filename = str(tmp_vsimem / "datetime_as_string.gpkg")

--- a/autotest/ogr/ogr_mem.py
+++ b/autotest/ogr/ogr_mem.py
@@ -804,7 +804,7 @@ def test_ogr_mem_consume_arrow_array_pycapsule_interface():
 
 
 def test_ogr_mem_arrow_stream_numpy():
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     numpy = pytest.importorskip("numpy")
     import datetime
 
@@ -983,7 +983,7 @@ def test_ogr_mem_arrow_stream_numpy():
 
 
 def test_ogr_mem_arrow_stream_numpy_datetime_as_string():
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     ds = ogr.GetDriverByName("Memory").CreateDataSource("")
@@ -1091,7 +1091,7 @@ def test_ogr_mem_arrow_write_with_datetime_as_string():
     ],
 )
 def test_ogr_mem_arrow_stream_numpy_memlimit(limited_field):
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     ds = ogr.GetDriverByName("Memory").CreateDataSource("")
@@ -1265,7 +1265,7 @@ def test_ogr_mem_arrow_stream_numpy_memlimit(limited_field):
 
 
 def test_ogr_mem_arrow_stream_numpy_huge_string():
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     ds = ogr.GetDriverByName("Memory").CreateDataSource("")

--- a/autotest/ogr/ogr_parquet.py
+++ b/autotest/ogr/ogr_parquet.py
@@ -1835,7 +1835,7 @@ def test_ogr_parquet_write_crs_without_id_in_datum_ensemble_members():
 
 
 def test_ogr_parquet_arrow_stream_numpy():
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     numpy = pytest.importorskip("numpy")
 
     ds = ogr.Open("data/parquet/test.parquet")
@@ -2040,7 +2040,7 @@ def test_ogr_parquet_arrow_stream_empty_file():
 
 
 def test_ogr_parquet_arrow_stream_numpy_with_fid_column():
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     filename = "/vsimem/test_ogr_parquet_arrow_stream_numpy_with_fid_column.parquet"
@@ -2070,7 +2070,7 @@ def test_ogr_parquet_arrow_stream_numpy_with_fid_column():
 
 
 def test_ogr_parquet_arrow_stream_numpy_fast_spatial_filter():
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     numpy = pytest.importorskip("numpy")
     import datetime
 
@@ -2185,7 +2185,7 @@ def test_ogr_parquet_arrow_stream_numpy_fast_spatial_filter():
 
 
 def test_ogr_parquet_arrow_stream_numpy_detailed_spatial_filter(tmp_vsimem):
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     filename = str(
@@ -2331,7 +2331,7 @@ def test_ogr_parquet_arrow_stream_numpy_detailed_spatial_filter(tmp_vsimem):
     ],
 )
 def test_ogr_parquet_arrow_stream_numpy_fast_attribute_filter(filter):
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     ds = ogr.Open("data/parquet/test.parquet")
@@ -2359,7 +2359,7 @@ def test_ogr_parquet_arrow_stream_numpy_fast_attribute_filter(filter):
 
 
 def test_ogr_parquet_arrow_stream_numpy_attribute_filter_on_fid_without_fid_column():
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     ds = ogr.Open("data/parquet/test.parquet")
@@ -2406,7 +2406,7 @@ def test_ogr_parquet_arrow_stream_numpy_attribute_filter_on_fid_without_fid_colu
 
 
 def test_ogr_parquet_arrow_stream_numpy_attribute_filter_on_fid_with_fid_column():
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     filename = "/vsimem/test_ogr_parquet_arrow_stream_numpy_attribute_filter_on_fid_with_fid_column.parquet"
@@ -2578,7 +2578,7 @@ def test_ogr_parquet_arrow_stream_fast_attribute_filter_on_decimal128():
 
 
 def test_ogr_parquet_arrow_stream_numpy_fast_spatial_and_attribute_filter():
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     ds = ogr.Open("data/parquet/test.parquet")
@@ -2686,7 +2686,7 @@ def test_ogr_parquet_field_alternative_name_comment():
 def test_ogr_parquet_read_wkt_as_wkt_arrow_array(
     nullable_geom, ignore_geom_field, ignore_geom_before
 ):
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     outfilename = "/vsimem/out.parquet"
@@ -2804,7 +2804,7 @@ def test_ogr_parquet_read_wkt_as_wkt_arrow_array(
 
 
 def test_ogr_parquet_read_wkt_with_dict_as_wkt_arrow_array():
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     ds = ogr.Open("data/parquet/wkt_with_dict.parquet")
@@ -4200,7 +4200,7 @@ def test_ogr_parquet_ogr2ogr_reprojection(tmp_vsimem):
 
 
 def test_ogr_parquet_arrow_stream_numpy_datetime_as_string(tmp_vsimem):
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     with gdal.OpenEx(

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -5900,7 +5900,7 @@ def test_ogr_shape_write_date_0000_00_00(tmp_vsimem):
 
 
 def test_ogr_shape_arrow_stream():
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     ds = ogr.Open("data/poly.shp")
@@ -5936,7 +5936,7 @@ def test_ogr_shape_arrow_stream():
 
 
 def test_ogr_shape_arrow_stream_fid_optim(tmp_vsimem):
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     ds = ogr.Open("data/poly.shp")

--- a/autotest/ogr/ogr_tiledb.py
+++ b/autotest/ogr/ogr_tiledb.py
@@ -1202,7 +1202,7 @@ def test_ogr_tiledb_arrow_stream_pyarrow(nullable, batch_size):
 
 @pytest.mark.parametrize("nullable,batch_size", [(True, None), (False, 2)])
 def test_ogr_tiledb_arrow_stream_numpy(nullable, batch_size):
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     numpy = pytest.importorskip("numpy")
     import datetime
 
@@ -1432,7 +1432,7 @@ def test_ogr_tiledb_arrow_stream_numpy(nullable, batch_size):
 
 
 def test_ogr_tiledb_arrow_stream_numpy_point_no_wkb_geometry_col():
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     if os.path.exists("tmp/test.tiledb"):
@@ -1476,7 +1476,7 @@ def test_ogr_tiledb_arrow_stream_numpy_point_no_wkb_geometry_col():
 
 
 def test_ogr_tiledb_arrow_stream_numpy_pointz_no_fid_and_wkb_geometry_col():
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     if os.path.exists("tmp/test.tiledb"):
@@ -1518,7 +1518,7 @@ def test_ogr_tiledb_arrow_stream_numpy_pointz_no_fid_and_wkb_geometry_col():
 
 
 def test_ogr_tiledb_arrow_stream_numpy_detailed_spatial_filter():
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     if os.path.exists("tmp/test.tiledb"):

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -2141,3 +2141,10 @@ def error_raised(type, match=""):
 @functools.lru_cache()
 def gdal_has_vrt_expression_dialect(dialect):
     return dialect in gdal.GetDriverByName("VRT").GetMetadataItem("ExpressionDialects")
+
+
+###############################################################################
+
+
+def importorskip_gdal_array():
+    return pytest.importorskip("osgeo.gdal_array", exc_type=ImportError)

--- a/autotest/pyscripts/test_gdal2tiles.py
+++ b/autotest/pyscripts/test_gdal2tiles.py
@@ -723,7 +723,7 @@ def test_gdal2tiles_py_jpeg_3band_input(
     script_path, tmp_path, resampling, expected_stats_z0, expected_stats_z1
 ):
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
 
     if resampling == "antialias" and not pil_available():
         pytest.skip("'antialias' resampling is not available")
@@ -789,7 +789,7 @@ def test_gdal2tiles_py_jpeg_1band_input(
     script_path, tmp_path, resampling, expected_stats_z14, expected_stats_z13
 ):
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
 
     if resampling == "antialias" and not pil_available():
         pytest.skip("'antialias' resampling is not available")

--- a/autotest/pyscripts/test_gdal2xyz.py
+++ b/autotest/pyscripts/test_gdal2xyz.py
@@ -20,7 +20,7 @@ import test_py_scripts
 
 # test that osgeo_utils is available, if not skip all tests
 pytest.importorskip("osgeo_utils")
-pytest.importorskip("osgeo.gdal_array")
+gdaltest.importorskip_gdal_array()
 pytest.importorskip("numpy")
 
 from itertools import product

--- a/autotest/pyscripts/test_gdal_calc.py
+++ b/autotest/pyscripts/test_gdal_calc.py
@@ -19,6 +19,7 @@ import os
 import shutil
 import sys
 
+import gdaltest
 import pytest
 import test_py_scripts
 
@@ -27,7 +28,7 @@ from osgeo import gdal
 # test that numpy is available, if not skip all tests
 np = pytest.importorskip("numpy")
 gdal_calc = pytest.importorskip("osgeo_utils.gdal_calc")
-gdal_array = pytest.importorskip("osgeo.gdal_array")
+gdal_array = gdaltest.importorskip_gdal_array()
 try:
     GDALTypeCodeToNumericTypeCode = gdal_array.GDALTypeCodeToNumericTypeCode
 except AttributeError:

--- a/autotest/pyscripts/test_gdal_calc.py
+++ b/autotest/pyscripts/test_gdal_calc.py
@@ -27,7 +27,7 @@ from osgeo import gdal
 
 # test that numpy is available, if not skip all tests
 np = pytest.importorskip("numpy")
-gdal_calc = pytest.importorskip("osgeo_utils.gdal_calc")
+gdal_calc = pytest.importorskip("osgeo_utils.gdal_calc", exc_type=ImportError)
 gdal_array = gdaltest.importorskip_gdal_array()
 try:
     GDALTypeCodeToNumericTypeCode = gdal_array.GDALTypeCodeToNumericTypeCode

--- a/autotest/pyscripts/test_gdal_edit.py
+++ b/autotest/pyscripts/test_gdal_edit.py
@@ -230,7 +230,7 @@ def test_gdal_edit_py_4(script_path, tmp_path):
 
 def test_gdal_edit_py_5(script_path, tmp_path):
 
-    gdal_array = pytest.importorskip("osgeo.gdal_array")
+    gdal_array = gdaltest.importorskip_gdal_array()
     try:
         gdal_array.BandRasterIONumPy
     except AttributeError:

--- a/autotest/pyscripts/test_gdal_merge.py
+++ b/autotest/pyscripts/test_gdal_merge.py
@@ -14,6 +14,7 @@
 
 import os
 
+import gdaltest
 import pytest
 import test_py_scripts
 
@@ -205,7 +206,7 @@ def test_gdal_merge_4(script_path, tmp_path, sample_tifs):
 
 
 def test_gdal_merge_5(script_path, tmp_path):
-    gdal_array = pytest.importorskip("osgeo.gdal_array")
+    gdal_array = gdaltest.importorskip_gdal_array()
     try:
         gdal_array.BandRasterIONumPy
     except AttributeError:

--- a/autotest/pyscripts/test_gdal_retile.py
+++ b/autotest/pyscripts/test_gdal_retile.py
@@ -14,6 +14,7 @@
 import glob
 import os
 
+import gdaltest
 import pytest
 import test_py_scripts
 
@@ -351,7 +352,7 @@ def test_gdal_retile_4(script_path, tmp_path):
 
 def test_gdal_retile_5(script_path, tmp_path):
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     np = pytest.importorskip("numpy")
 
     nodata_value = -3.4028234663852886e38

--- a/autotest/pyscripts/test_gdallocationinfo_py.py
+++ b/autotest/pyscripts/test_gdallocationinfo_py.py
@@ -16,7 +16,7 @@ import pytest
 
 # test that numpy is available, if not skip all tests
 np = pytest.importorskip("numpy")
-pytest.importorskip("osgeo_utils.samples.gdallocationinfo")
+pytest.importorskip("osgeo_utils.samples.gdallocationinfo", exc_type=ImportError)
 
 from itertools import product
 

--- a/autotest/pyscripts/test_pct.py
+++ b/autotest/pyscripts/test_pct.py
@@ -104,7 +104,7 @@ def test_rgb2pct_1(rgb2pct1_tif):
 
 
 def test_pct2rgb_help(script_path):
-    gdal_array = pytest.importorskip("osgeo.gdal_array")
+    gdal_array = gdaltest.importorskip_gdal_array()
     try:
         gdal_array.BandRasterIONumPy
     except AttributeError:
@@ -120,7 +120,7 @@ def test_pct2rgb_help(script_path):
 
 
 def test_pct2rgb_version(script_path):
-    gdal_array = pytest.importorskip("osgeo.gdal_array")
+    gdal_array = gdaltest.importorskip_gdal_array()
     try:
         gdal_array.BandRasterIONumPy
     except AttributeError:
@@ -136,7 +136,7 @@ def test_pct2rgb_version(script_path):
 
 
 def test_pct2rgb_1(script_path, tmp_path, rgb2pct1_tif):
-    gdal_array = pytest.importorskip("osgeo.gdal_array")
+    gdal_array = gdaltest.importorskip_gdal_array()
     try:
         gdal_array.BandRasterIONumPy
     except AttributeError:
@@ -165,7 +165,7 @@ def test_pct2rgb_1(script_path, tmp_path, rgb2pct1_tif):
 
 
 def test_pct2rgb_no_color_table(script_path, tmp_path, rgb2pct1_tif):
-    gdal_array = pytest.importorskip("osgeo.gdal_array")
+    gdal_array = gdaltest.importorskip_gdal_array()
     try:
         gdal_array.BandRasterIONumPy
     except AttributeError:
@@ -239,7 +239,7 @@ def test_rgb2pct_3(script_path, tmp_path, rgb2pct2_tif):
 
 @pytest.mark.require_driver("HFA")
 def test_pct2rgb_4(script_path, tmp_path):
-    gdal_array = pytest.importorskip("osgeo.gdal_array")
+    gdal_array = gdaltest.importorskip_gdal_array()
     try:
         gdal_array.BandRasterIONumPy
     except AttributeError:

--- a/autotest/pyscripts/test_validate_geoparquet.py
+++ b/autotest/pyscripts/test_validate_geoparquet.py
@@ -247,7 +247,7 @@ def test_validate_geoparquet_invalid_bbox(tmp_path, bbox, error_msg):
 
 def test_validate_geoparquet_invalid_wkb(tmp_path):
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     test_dir = str(tmp_path / "tmp.parquet")
@@ -275,7 +275,7 @@ def test_validate_geoparquet_invalid_wkb(tmp_path):
 
 def test_validate_geoparquet_geom_type_not_consistent_with_declaration(tmp_path):
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     test_dir = str(tmp_path / "tmp.parquet")
@@ -306,7 +306,7 @@ def test_validate_geoparquet_geom_type_not_consistent_with_declaration(tmp_path)
 
 def test_validate_geoparquet_invalid_winding_order(tmp_path):
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
 
     test_dir = str(tmp_path / "tmp.parquet")

--- a/autotest/utilities/test_gdal_rasterize.py
+++ b/autotest/utilities/test_gdal_rasterize.py
@@ -346,7 +346,7 @@ def test_gdal_rasterize_6(gdal_rasterize_path, tmp_path):
 @pytest.mark.parametrize("sql_in_file", [False, True])
 def test_gdal_rasterize_7(gdal_rasterize_path, sql_in_file, tmp_path):
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
 
     input_csv = str(tmp_path / "test_gdal_rasterize_7.csv")
     output_tif = str(tmp_path / "test_gdal_rasterize_7.tif")

--- a/autotest/utilities/test_gdal_viewshed.py
+++ b/autotest/utilities/test_gdal_viewshed.py
@@ -207,7 +207,7 @@ def test_gdal_viewshed_all_options(gdal_viewshed_path, tmp_path, viewshed_input)
 def test_gdal_viewshed_cumulative(gdal_viewshed_path, tmp_path, viewshed_input):
 
     np = pytest.importorskip("numpy")
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
 
     viewshed_out = str(tmp_path / "test_gdal_viewshed_out.tif")
 

--- a/autotest/utilities/test_gdallocationinfo.py
+++ b/autotest/utilities/test_gdallocationinfo.py
@@ -404,7 +404,7 @@ def test_gdallocationinfo_value_interpolate_invalid_method(gdallocationinfo_path
 
 def test_gdallocationinfo_interpolate_float_data(gdallocationinfo_path, tmp_path):
 
-    pytest.importorskip("osgeo.gdal_array")
+    gdaltest.importorskip_gdal_array()
 
     dst_filename = str(tmp_path / "tmp_float.tif")
     driver = gdal.GetDriverByName("GTiff")


### PR DESCRIPTION
Fixes warnings like:
```
gcore/hfa_rfc40.py:27
   /Users/runner/work/gdal/gdal/build/autotest/gcore/hfa_rfc40.py:27: PytestDeprecationWarning:
   Module 'osgeo.gdal_array' was found, but when imported by pytest it raised:
       ImportError("cannot import name '_gdal_array' from 'osgeo' (/Users/runner/work/gdal/gdal/build/swig/python/osgeo/__init__.py)")
   In pytest 9.1 this warning will become an error by default.
   You can fix the underlying problem, or alternatively overwrite this behavior and silence this warning by passing exc_type=ImportError explicitly.
   See https://docs.pytest.org/en/stable/deprecations.html#pytest-importorskip-default-behavior-regarding-importerror
   pytest.importorskip("osgeo.gdal_array")
```
