### PR TITLE
Doc: Doxygen fixes

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -71,7 +71,6 @@ if (BUILD_DOCS)
     if (DOXYGEN_FAIL_ON_WARNINGS) 
             string(JOIN "\n" DOXYFILE_CONTENTS
                    ${DOXYFILE_CONTENTS}
-                   "FAIL_ON_WARNINGS=YES"
                    "WARN_AS_ERROR=FAIL_ON_WARNINGS_PRINT")
     endif()
 

--- a/gcore/gdaldrivermanager.cpp
+++ b/gcore/gdaldrivermanager.cpp
@@ -961,12 +961,12 @@ CPLErr GDALDriverManager::LoadPlugin(const char *name)
  * search separated by colons on UNIX, or semi-colons on Windows.  Otherwise
  * the /usr/local/lib/gdalplugins directory, and (if known) the
  * lib/gdalplugins subdirectory of the gdal home directory are searched on
- * UNIX and $(BINDIR)\\gdalplugins on Windows.
+ * UNIX and \$(BINDIR)\\gdalplugins on Windows.
  *
  * Auto loading can be completely disabled by setting the GDAL_DRIVER_PATH
  * config option to "disable".
  *
- * Starting with gdal 3.5, the default search path $(prefix)/lib/gdalplugins
+ * Starting with gdal 3.5, the default search path \$(prefix)/lib/gdalplugins
  * can be overridden at compile time by passing
  * -DINSTALL_PLUGIN_DIR=/another/path to cmake.
  */

--- a/port/cpl_conv.cpp
+++ b/port/cpl_conv.cpp
@@ -2464,9 +2464,9 @@ void CPLLoadConfigOptionsFromFile(const char *pszFilename, int bOverrideEnvVars)
  * to ${prefix}/etc, unless the \--sysconfdir switch of configure has been
  * invoked.
  *
- * Then CPLLoadConfigOptionsFromFile() will be called with $(HOME)/.gdal/gdalrc
+ * Then CPLLoadConfigOptionsFromFile() will be called with ${HOME}/.gdal/gdalrc
  * on Unix builds (potentially overriding what was loaded with the sysconfdir)
- * or $(USERPROFILE)/.gdal/gdalrc on Windows builds.
+ * or ${USERPROFILE}/.gdal/gdalrc on Windows builds.
  *
  * CPLLoadConfigOptionsFromFile() will be called with bOverrideEnvVars = false,
  * that is the value of environment variables previously set will be used


### PR DESCRIPTION
1) `FAIL_ON_WARNINGS` is not a real Doxygen option, not sure how that ended up there. It is ignored by my Doxygen install but causes a failure on Windows with Doxygen from conda. The intended behavior is already captured in `WARN_AS_ERROR=FAIL_ON_WARNINGS_PRINT`.

2) Incredibly, Doxygen substitutes environment variables referenced with parentheses like `$(VARNAME)`. If `$(VARNAME)` expands to a Windows-style path with `\` , it then tried to interpret each component of a path as a Doxygen directive and unsurprisingly fails.