### PR TITLE
netCDF: Use GeoTransform attribute to prevent precision loss

### DIFF
--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -6758,7 +6758,6 @@ def test_netcdf_geotransform_preserved_createcopy(tmp_path):
     res = 1.0 / 3600
     src.SetGeoTransform((25 - res / 2, res, 0, 80 + res / 2, 0, -res))
 
-    with gdaltest.error_raised(gdal.CE_Warning, match="differs from value calculated"):
-        dst = gdal.GetDriverByName("netCDF").CreateCopy(tmp_path / "test.nc", src)
+    dst = gdal.GetDriverByName("netCDF").CreateCopy(tmp_path / "test.nc", src)
 
     assert dst.GetGeoTransform() == src.GetGeoTransform()

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -6744,3 +6744,21 @@ def test_netcdf_LIST_ALL_ARRAYS():
             ('NETCDF:"data/netcdf/byte.nc":Band1', "[20x20] Band1 (8-bit integer)"),
         ]
     )
+
+
+###############################################################################
+# Test use of GeoTransform attribute to avoid precision loss
+# https://github.com/OSGeo/gdal/issues/11993
+
+
+def test_netcdf_geotransform_preserved_createcopy(tmp_path):
+
+    src = gdal.GetDriverByName("MEM").Create("", 3600, 3600)
+    src.SetProjection("EPSG:4326")
+    res = 1.0 / 3600
+    src.SetGeoTransform((25 - res / 2, res, 0, 80 + res / 2, 0, -res))
+
+    with gdaltest.error_raised(gdal.CE_Warning, match="differs from value calculated"):
+        dst = gdal.GetDriverByName("netCDF").CreateCopy(tmp_path / "test.nc", src)
+
+    assert dst.GetGeoTransform() == src.GetGeoTransform()

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -5561,7 +5561,7 @@ CPLErr netCDFDataset::AddProjectionVars(bool bDefsOnly,
                 for (int i = 0; i < 6; i++)
                 {
                     osGeoTransform +=
-                        CPLSPrintf("%.16g ", m_adfGeoTransform[i]);
+                        CPLSPrintf("%.17g ", m_adfGeoTransform[i]);
                 }
                 CPLDebug("GDAL_netCDF", "szGeoTransform = %s",
                          osGeoTransform.c_str());

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -4170,23 +4170,30 @@ void netCDFDataset::SetProjectionFromVar(
 
                 if (bGotCfGT)
                 {
-                    double dfMaxDiff = 0.0;
+                    constexpr double GT_RELERROR_WARN_THRESHOLD = 1e-6;
+                    double dfMaxAbsoluteError = 0.0;
                     for (int i = 0; i < 6; i++)
                     {
-                        dfMaxDiff =
-                            std::max(dfMaxDiff,
-                                     std::abs(adfTempGeoTransform[i] -
-                                              adfGeoTransformFromAttribute[i]));
+                        double dfAbsoluteError =
+                            std::abs(adfTempGeoTransform[i] -
+                                     adfGeoTransformFromAttribute[i]);
+                        if (dfAbsoluteError >
+                            std::abs(adfGeoTransformFromAttribute[i] *
+                                     GT_RELERROR_WARN_THRESHOLD))
+                        {
+                            dfMaxAbsoluteError =
+                                std::max(dfMaxAbsoluteError, dfAbsoluteError);
+                        }
                     }
 
-                    if (dfMaxDiff > 0)
+                    if (dfMaxAbsoluteError > 0)
                     {
                         CPLError(CE_Warning, CPLE_AppDefined,
                                  "GeoTransform read from attribute of %s "
                                  "variable differs from value calculated from "
                                  "dimension variables (max diff = %g). Using "
                                  "value from attribute.",
-                                 pszGridMappingValue, dfMaxDiff);
+                                 pszGridMappingValue, dfMaxAbsoluteError);
                     }
                 }
 


### PR DESCRIPTION
Increase precision of netCDF `GeoTransform` attribute and preferentially use it instead of calculated geotransform. Resolves https://github.com/OSGeo/gdal/issues/11993