### PR TITLE
VRT: propagate user overridden blocksize to (non-external) overviews,…

### DIFF
--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -2632,6 +2632,10 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
     /* -------------------------------------------------------------------- */
     if (EQUAL(psOptions->osFormat.c_str(), "VRT") &&
         (psOptions->aosCreateOptions.empty() ||
+         (psOptions->aosCreateOptions.size() == 1 &&
+          psOptions->aosCreateOptions.FetchNameValue("BLOCKXSIZE")) ||
+         (psOptions->aosCreateOptions.size() == 1 &&
+          psOptions->aosCreateOptions.FetchNameValue("BLOCKYSIZE")) ||
          (psOptions->aosCreateOptions.size() == 2 &&
           psOptions->aosCreateOptions.FetchNameValue("BLOCKXSIZE") &&
           psOptions->aosCreateOptions.FetchNameValue("BLOCKYSIZE"))))

--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -299,6 +299,8 @@ class CPL_DLL VRTDataset CPL_NON_FINAL : public GDALDataset
                            GDALDataset *&poSrcDataset, int &nSrcXOff,
                            int &nSrcYOff);
 
+    static bool IsDefaultBlockSize(int nBlockSize, int nDimension);
+
     CPL_DISALLOW_COPY_ASSIGN(VRTDataset)
 
   protected:

--- a/frmts/vrt/vrtrasterband.cpp
+++ b/frmts/vrt/vrtrasterband.cpp
@@ -661,15 +661,17 @@ CPLXMLNode *VRTRasterBand::SerializeToXML(const char *pszVRTPath,
     // serialized at the dataset level.
     if (dynamic_cast<VRTWarpedRasterBand *>(this) == nullptr)
     {
-        if (nBlockXSize != 128 &&
-            !(nBlockXSize < 128 && nBlockXSize == nRasterXSize))
+        if (!VRTDataset::IsDefaultBlockSize(nBlockXSize, nRasterXSize))
+        {
             CPLSetXMLValue(psTree, "#blockXSize",
                            CPLSPrintf("%d", nBlockXSize));
+        }
 
-        if (nBlockYSize != 128 &&
-            !(nBlockYSize < 128 && nBlockYSize == nRasterYSize))
+        if (!VRTDataset::IsDefaultBlockSize(nBlockYSize, nRasterYSize))
+        {
             CPLSetXMLValue(psTree, "#blockYSize",
                            CPLSPrintf("%d", nBlockYSize));
+        }
     }
 
     CPLXMLNode *psMD = oMDMD.Serialize();


### PR DESCRIPTION
… such as defined by OverviewList

Fixes https://github.com/OSGeo/gdal/issues/9280#issuecomment-2766044002
