### PR TITLE
[Backport release/3.10] GeoJSON: fix detection of features starting with {"geometry":{"type":"xxxxx","coordinates":[...

### DIFF
--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -3939,6 +3939,37 @@ def test_ogr_geojson_starting_with_geometry_coordinates(tmp_vsimem):
 
 
 ###############################################################################
+# Test fix for https://github.com/qgis/QGIS/issues/61266
+
+
+@pytest.mark.parametrize(
+    "start,end",
+    [
+        ('{"type":"Point","coordinates":[', "2,49]}"),
+        ('{"type":"LineString","coordinates":[[', "2,49],[3,50]]}"),
+        ('{"type":"Polygon","coordinates":[[[', "0,0],[0,1],[1,1],[0,0]]]}"),
+        ('{"type":"MultiPoint","coordinates":[[', "2,49]]}"),
+        ('{"type":"MultiLineString","coordinates":[[[', "2,49],[3,50]]]}"),
+        ('{"type":"MultiPolygon","coordinates":[[[[', "0,0],[0,1],[1,1],[0,0]]]]}"),
+        ('{"type":"GeometryCollection","geometries":[', "]}"),
+    ],
+)
+def test_ogr_geojson_starting_with_geometry_type(tmp_vsimem, start, end):
+
+    tmpfilename = tmp_vsimem / "temp.json"
+    gdal.FileFromMemBuffer(
+        tmpfilename,
+        '{ "geometry":'
+        + start
+        + (" " * 10000)
+        + end
+        + ', "type":"Feature","properties":{}}',
+    )
+    ds = gdal.OpenEx(tmpfilename, gdal.OF_VECTOR)
+    assert ds is not None
+
+
+###############################################################################
 # Test serialization of Float32 values
 
 

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonutils.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonutils.cpp
@@ -247,7 +247,24 @@ static bool IsGeoJSONLikeObject(const char *pszText, bool &bMightBeSequence,
     // See https://github.com/OSGeo/gdal/issues/2720
     if (osWithoutSpace.find("{\"coordinates\":[") == 0 ||
         // and https://github.com/OSGeo/gdal/issues/2787
-        osWithoutSpace.find("{\"geometry\":{\"coordinates\":[") == 0)
+        osWithoutSpace.find("{\"geometry\":{\"coordinates\":[") == 0 ||
+        // and https://github.com/qgis/QGIS/issues/61266
+        osWithoutSpace.find(
+            "{\"geometry\":{\"type\":\"Point\",\"coordinates\":[") == 0 ||
+        osWithoutSpace.find(
+            "{\"geometry\":{\"type\":\"LineString\",\"coordinates\":[") == 0 ||
+        osWithoutSpace.find(
+            "{\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[") == 0 ||
+        osWithoutSpace.find(
+            "{\"geometry\":{\"type\":\"MultiPoint\",\"coordinates\":[") == 0 ||
+        osWithoutSpace.find(
+            "{\"geometry\":{\"type\":\"MultiLineString\",\"coordinates\":[") ==
+            0 ||
+        osWithoutSpace.find(
+            "{\"geometry\":{\"type\":\"MultiPolygon\",\"coordinates\":[") ==
+            0 ||
+        osWithoutSpace.find("{\"geometry\":{\"type\":\"GeometryCollection\","
+                            "\"geometries\":[") == 0)
     {
         return true;
     }


### PR DESCRIPTION
Backport #12055
 **Authored by:** @rouault