### PR TITLE
gdaldem: hillshade and slope: automatically set scale for geographic …

### DIFF
--- a/apps/gdaldem_lib.cpp
+++ b/apps/gdaldem_lib.cpp
@@ -116,6 +116,8 @@
 static const double kdfDegreesToRadians = M_PI / 180.0;
 static const double kdfRadiansToDegrees = 180.0 / M_PI;
 
+using VSIVoidUniquePtr = std::unique_ptr<void, VSIFreeReleaser>;
+
 typedef enum
 {
     COLOR_SELECTION_INTERPOLATE,
@@ -152,7 +154,10 @@ struct GDALDEMProcessingOptions
     void *pProgressData = nullptr;
 
     double z = 1.0;
-    double scale = 1.0;
+    double globalScale = std::numeric_limits<
+        double>::quiet_NaN();  // when set, copied to xscale and yscale
+    double xscale = std::numeric_limits<double>::quiet_NaN();
+    double yscale = std::numeric_limits<double>::quiet_NaN();
     double az = 315.0;
     double alt = 45.0;
     bool bSlopeFormatUseDegrees =
@@ -292,7 +297,7 @@ static CPLErr GDALGeneric3x3Processing(
     typename GDALGeneric3x3ProcessingAlg<T>::type pfnAlg,
     typename GDALGeneric3x3ProcessingAlg_multisample<T>::type
         pfnAlg_multisample,
-    void *pData, bool bComputeAtEdges, GDALProgressFunc pfnProgress,
+    VSIVoidUniquePtr pData, bool bComputeAtEdges, GDALProgressFunc pfnProgress,
     void *pProgressData)
 {
     if (pfnProgress == nullptr)
@@ -438,7 +443,7 @@ static CPLErr GDALGeneric3x3Processing(
             pafOutputBuf[j] =
                 ComputeVal(CPL_TO_BOOL(bSrcHasNoData), fSrcNoDataValue,
                            CPL_TO_BOOL(bIsSrcNoDataNan), afWin, fDstNoDataValue,
-                           pfnAlg, pData, bComputeAtEdges);
+                           pfnAlg, pData.get(), bComputeAtEdges);
         }
         eErr = GDALRasterIO(hDstBand, GF_Write, 0, 0, nXSize, 1, pafOutputBuf,
                             nXSize, 1, GDT_Float32, 0, 0);
@@ -536,10 +541,10 @@ static CPLErr GDALGeneric3x3Processing(
                           pafThreeLineWin[nLine3Off + j],
                           pafThreeLineWin[nLine3Off + j + 1]};
 
-            pafOutputBuf[j] =
-                ComputeVal(CPL_TO_BOOL(bOneOfThreeLinesHasNoData),
-                           fSrcNoDataValue, CPL_TO_BOOL(bIsSrcNoDataNan), afWin,
-                           fDstNoDataValue, pfnAlg, pData, bComputeAtEdges);
+            pafOutputBuf[j] = ComputeVal(
+                CPL_TO_BOOL(bOneOfThreeLinesHasNoData), fSrcNoDataValue,
+                CPL_TO_BOOL(bIsSrcNoDataNan), afWin, fDstNoDataValue, pfnAlg,
+                pData.get(), bComputeAtEdges);
         }
         else
         {
@@ -551,7 +556,8 @@ static CPLErr GDALGeneric3x3Processing(
         if (pfnAlg_multisample && !bOneOfThreeLinesHasNoData)
         {
             j = pfnAlg_multisample(pafThreeLineWin, nLine1Off, nLine2Off,
-                                   nLine3Off, nXSize, pData, pafOutputBuf);
+                                   nLine3Off, nXSize, pData.get(),
+                                   pafOutputBuf);
         }
 
         for (; j < nXSize - 1; j++)
@@ -566,10 +572,10 @@ static CPLErr GDALGeneric3x3Processing(
                           pafThreeLineWin[nLine3Off + j],
                           pafThreeLineWin[nLine3Off + j + 1]};
 
-            pafOutputBuf[j] =
-                ComputeVal(CPL_TO_BOOL(bOneOfThreeLinesHasNoData),
-                           fSrcNoDataValue, CPL_TO_BOOL(bIsSrcNoDataNan), afWin,
-                           fDstNoDataValue, pfnAlg, pData, bComputeAtEdges);
+            pafOutputBuf[j] = ComputeVal(
+                CPL_TO_BOOL(bOneOfThreeLinesHasNoData), fSrcNoDataValue,
+                CPL_TO_BOOL(bIsSrcNoDataNan), afWin, fDstNoDataValue, pfnAlg,
+                pData.get(), bComputeAtEdges);
         }
 
         if (bComputeAtEdges && nXSize >= 2)
@@ -592,10 +598,10 @@ static CPLErr GDALGeneric3x3Processing(
                                    pafThreeLineWin[nLine3Off + j - 1],
                                    bSrcHasNoData, fSrcNoDataValue)};
 
-            pafOutputBuf[j] =
-                ComputeVal(CPL_TO_BOOL(bOneOfThreeLinesHasNoData),
-                           fSrcNoDataValue, CPL_TO_BOOL(bIsSrcNoDataNan), afWin,
-                           fDstNoDataValue, pfnAlg, pData, bComputeAtEdges);
+            pafOutputBuf[j] = ComputeVal(
+                CPL_TO_BOOL(bOneOfThreeLinesHasNoData), fSrcNoDataValue,
+                CPL_TO_BOOL(bIsSrcNoDataNan), afWin, fDstNoDataValue, pfnAlg,
+                pData.get(), bComputeAtEdges);
         }
         else
         {
@@ -662,7 +668,7 @@ static CPLErr GDALGeneric3x3Processing(
             pafOutputBuf[j] =
                 ComputeVal(CPL_TO_BOOL(bSrcHasNoData), fSrcNoDataValue,
                            CPL_TO_BOOL(bIsSrcNoDataNan), afWin, fDstNoDataValue,
-                           pfnAlg, pData, bComputeAtEdges);
+                           pfnAlg, pData.get(), bComputeAtEdges);
         }
         eErr = GDALRasterIO(hDstBand, GF_Write, 0, i, nXSize, 1, pafOutputBuf,
                             nXSize, 1, GDT_Float32, 0, 0);
@@ -725,8 +731,8 @@ template <class T> struct Gradient<T, GradientAlg::ZEVENBERGEN_THORNE>
 
 typedef struct
 {
-    double inv_nsres;
-    double inv_ewres;
+    double inv_nsres_yscale;
+    double inv_ewres_xscale;
     double sin_altRadians;
     double cos_alt_mul_z;
     double azRadians;
@@ -740,17 +746,17 @@ typedef struct
     double square_z_mul_square_inv_res;
     double cos_az_mul_cos_alt_mul_z_mul_254_mul_inv_res;
     double sin_az_mul_cos_alt_mul_z_mul_254_mul_inv_res;
-    double z_scaled;
+    double z_factor;
 } GDALHillshadeAlgData;
 
 /* Unoptimized formulas are :
     x = psData->z*((afWin[0] + afWin[3] + afWin[3] + afWin[6]) -
         (afWin[2] + afWin[5] + afWin[5] + afWin[8])) /
-        (8.0 * psData->ewres * psData->scale);
+        (8.0 * psData->ewres * psData->xscale);
 
     y = psData->z*((afWin[6] + afWin[7] + afWin[7] + afWin[8]) -
         (afWin[0] + afWin[1] + afWin[1] + afWin[2])) /
-        (8.0 * psData->nsres * psData->scale);
+        (8.0 * psData->nsres * psData->yscale);
 
     slope = atan(sqrt(x*x + y*y));
 
@@ -774,7 +780,7 @@ We can avoid a lot of trigonometric computations:
         = sin(az - aspect)
         = -sin(aspect-az)
 
-==> cang = (sin(alt) - cos(alt) * sqrt(x*x + y*y)  * sin(aspect-as)) /
+==> cang = (sin(alt) - cos(alt) * sqrt(x*x + y*y)  * sin(aspect-az)) /
            sqrt(1+ x*x+y*y)
 
     But:
@@ -850,22 +856,22 @@ static float GDALHillshadeIgorAlg(const T *afWin, float /*fDstNoDataValue*/,
     {
         const double dx = ((afWin[0] + afWin[3] + afWin[3] + afWin[6]) -
                            (afWin[2] + afWin[5] + afWin[5] + afWin[8])) *
-                          psData->inv_ewres;
+                          psData->inv_ewres_xscale;
 
         const double dy = ((afWin[6] + afWin[7] + afWin[7] + afWin[8]) -
                            (afWin[0] + afWin[1] + afWin[1] + afWin[2])) *
-                          psData->inv_nsres;
+                          psData->inv_nsres_yscale;
 
         const double key = (dx * dx + dy * dy);
-        slopeDegrees = atan(sqrt(key) * psData->z_scaled) * kdfRadiansToDegrees;
+        slopeDegrees = atan(sqrt(key) * psData->z_factor) * kdfRadiansToDegrees;
     }
     else  // ZEVENBERGEN_THORNE
     {
-        const double dx = (afWin[3] - afWin[5]) * psData->inv_ewres;
-        const double dy = (afWin[7] - afWin[1]) * psData->inv_nsres;
+        const double dx = (afWin[3] - afWin[5]) * psData->inv_ewres_xscale;
+        const double dy = (afWin[7] - afWin[1]) * psData->inv_nsres_yscale;
         const double key = dx * dx + dy * dy;
 
-        slopeDegrees = atan(sqrt(key) * psData->z_scaled) * kdfRadiansToDegrees;
+        slopeDegrees = atan(sqrt(key) * psData->z_factor) * kdfRadiansToDegrees;
     }
 
     double aspect;
@@ -906,7 +912,8 @@ static float GDALHillshadeAlg(const T *afWin, float /*fDstNoDataValue*/,
 
     // First Slope ...
     double x, y;
-    Gradient<T, alg>::calc(afWin, psData->inv_ewres, psData->inv_nsres, x, y);
+    Gradient<T, alg>::calc(afWin, psData->inv_ewres_xscale,
+                           psData->inv_nsres_yscale, x, y);
 
     const double xx_plus_yy = x * x + y * y;
 
@@ -971,7 +978,6 @@ GDALHillshadeAlg_same_res_multisample(const T *pafThreeLineWin, int nLine1Off,
                                       void *pData, float *pafOutputBuf)
 {
     // Only valid for T == int
-
     GDALHillshadeAlgData *psData = static_cast<GDALHillshadeAlgData *>(pData);
     const __m128d reg_fact_x =
         _mm_load1_pd(&(psData->sin_az_mul_cos_alt_mul_z_mul_254_mul_inv_res));
@@ -1082,7 +1088,8 @@ static float GDALHillshadeCombinedAlg(const T *afWin, float /*fDstNoDataValue*/,
 
     // First Slope ...
     double x, y;
-    Gradient<T, alg>::calc(afWin, psData->inv_ewres, psData->inv_nsres, x, y);
+    Gradient<T, alg>::calc(afWin, psData->inv_ewres_xscale,
+                           psData->inv_nsres_yscale, x, y);
 
     const double xx_plus_yy = x * x + y * y;
 
@@ -1103,25 +1110,25 @@ static float GDALHillshadeCombinedAlg(const T *afWin, float /*fDstNoDataValue*/,
     return fcang;
 }
 
-static void *GDALCreateHillshadeData(double *adfGeoTransform, double z,
-                                     double scale, double alt, double az,
-                                     GradientAlg eAlg)
+static VSIVoidUniquePtr GDALCreateHillshadeData(const double *adfGeoTransform,
+                                                double z, double xscale,
+                                                double yscale, double alt,
+                                                double az, GradientAlg eAlg)
 {
     GDALHillshadeAlgData *pData = static_cast<GDALHillshadeAlgData *>(
         CPLCalloc(1, sizeof(GDALHillshadeAlgData)));
 
-    pData->inv_nsres = 1.0 / adfGeoTransform[5];
-    pData->inv_ewres = 1.0 / adfGeoTransform[1];
+    pData->inv_nsres_yscale = 1.0 / (adfGeoTransform[5] * yscale);
+    pData->inv_ewres_xscale = 1.0 / (adfGeoTransform[1] * xscale);
     pData->sin_altRadians = sin(alt * kdfDegreesToRadians);
     pData->azRadians = az * kdfDegreesToRadians;
-    pData->z_scaled =
-        z / ((eAlg == GradientAlg::ZEVENBERGEN_THORNE ? 2 : 8) * scale);
-    pData->cos_alt_mul_z = cos(alt * kdfDegreesToRadians) * pData->z_scaled;
+    pData->z_factor = z / (eAlg == GradientAlg::ZEVENBERGEN_THORNE ? 2 : 8);
+    pData->cos_alt_mul_z = cos(alt * kdfDegreesToRadians) * pData->z_factor;
     pData->cos_az_mul_cos_alt_mul_z =
         cos(pData->azRadians) * pData->cos_alt_mul_z;
     pData->sin_az_mul_cos_alt_mul_z =
         sin(pData->azRadians) * pData->cos_alt_mul_z;
-    pData->square_z = pData->z_scaled * pData->z_scaled;
+    pData->square_z = pData->z_factor * pData->z_factor;
 
     pData->sin_altRadians_mul_254 = 254.0 * pData->sin_altRadians;
     pData->cos_az_mul_cos_alt_mul_z_mul_254 =
@@ -1129,17 +1136,17 @@ static void *GDALCreateHillshadeData(double *adfGeoTransform, double z,
     pData->sin_az_mul_cos_alt_mul_z_mul_254 =
         254.0 * pData->sin_az_mul_cos_alt_mul_z;
 
-    if (adfGeoTransform[1] == -adfGeoTransform[5])
+    if (adfGeoTransform[1] == -adfGeoTransform[5] && xscale == yscale)
     {
         pData->square_z_mul_square_inv_res =
-            pData->square_z * pData->inv_ewres * pData->inv_ewres;
+            pData->square_z * pData->inv_ewres_xscale * pData->inv_ewres_xscale;
         pData->cos_az_mul_cos_alt_mul_z_mul_254_mul_inv_res =
-            pData->cos_az_mul_cos_alt_mul_z_mul_254 * -pData->inv_ewres;
+            pData->cos_az_mul_cos_alt_mul_z_mul_254 * -pData->inv_ewres_xscale;
         pData->sin_az_mul_cos_alt_mul_z_mul_254_mul_inv_res =
-            pData->sin_az_mul_cos_alt_mul_z_mul_254 * pData->inv_ewres;
+            pData->sin_az_mul_cos_alt_mul_z_mul_254 * pData->inv_ewres_xscale;
     }
 
-    return pData;
+    return VSIVoidUniquePtr(pData);
 }
 
 /************************************************************************/
@@ -1148,8 +1155,8 @@ static void *GDALCreateHillshadeData(double *adfGeoTransform, double z,
 
 typedef struct
 {
-    double inv_nsres;
-    double inv_ewres;
+    double inv_nsres_yscale;
+    double inv_ewres_xscale;
     double square_z;
     double sin_altRadians_mul_127;
     double sin_altRadians_mul_254;
@@ -1169,7 +1176,8 @@ static float GDALHillshadeMultiDirectionalAlg(const T *afWin,
 
     // First Slope ...
     double x, y;
-    Gradient<T, alg>::calc(afWin, psData->inv_ewres, psData->inv_nsres, x, y);
+    Gradient<T, alg>::calc(afWin, psData->inv_ewres_xscale,
+                           psData->inv_nsres_yscale, x, y);
 
     // See http://pubs.usgs.gov/of/1992/of92-422/of92-422.pdf
     // W225 = sin^2(aspect - 225) = 0.5 * (1 - 2 * sin(aspect) * cos(aspect))
@@ -1219,21 +1227,21 @@ static float GDALHillshadeMultiDirectionalAlg(const T *afWin,
     return static_cast<float>(cang);
 }
 
-static void *GDALCreateHillshadeMultiDirectionalData(double *adfGeoTransform,
-                                                     double z, double scale,
-                                                     double alt,
-                                                     GradientAlg eAlg)
+static VSIVoidUniquePtr
+GDALCreateHillshadeMultiDirectionalData(const double *adfGeoTransform, double z,
+                                        double xscale, double yscale,
+                                        double alt, GradientAlg eAlg)
 {
     GDALHillshadeMultiDirectionalAlgData *pData =
         static_cast<GDALHillshadeMultiDirectionalAlgData *>(
             CPLCalloc(1, sizeof(GDALHillshadeMultiDirectionalAlgData)));
 
-    pData->inv_nsres = 1.0 / adfGeoTransform[5];
-    pData->inv_ewres = 1.0 / adfGeoTransform[1];
-    const double z_scaled =
-        z / ((eAlg == GradientAlg::ZEVENBERGEN_THORNE ? 2 : 8) * scale);
-    const double cos_alt_mul_z = cos(alt * kdfDegreesToRadians) * z_scaled;
-    pData->square_z = z_scaled * z_scaled;
+    pData->inv_nsres_yscale = 1.0 / (adfGeoTransform[5] * yscale);
+    pData->inv_ewres_xscale = 1.0 / (adfGeoTransform[1] * xscale);
+    const double z_factor =
+        z / (eAlg == GradientAlg::ZEVENBERGEN_THORNE ? 2 : 8);
+    const double cos_alt_mul_z = cos(alt * kdfDegreesToRadians) * z_factor;
+    pData->square_z = z_factor * z_factor;
 
     pData->sin_altRadians_mul_127 = 127.0 * sin(alt * kdfDegreesToRadians);
     pData->sin_altRadians_mul_254 = 254.0 * sin(alt * kdfDegreesToRadians);
@@ -1241,7 +1249,7 @@ static void *GDALCreateHillshadeMultiDirectionalData(double *adfGeoTransform,
     pData->cos225_az_mul_cos_alt_mul_z_mul_127 =
         127.0 * cos(225 * kdfDegreesToRadians) * cos_alt_mul_z;
 
-    return pData;
+    return VSIVoidUniquePtr(pData);
 }
 
 /************************************************************************/
@@ -1250,9 +1258,8 @@ static void *GDALCreateHillshadeMultiDirectionalData(double *adfGeoTransform,
 
 typedef struct
 {
-    double nsres;
-    double ewres;
-    double scale;
+    double nsres_yscale;
+    double ewres_xscale;
     int slopeFormat;
 } GDALSlopeAlgData;
 
@@ -1265,19 +1272,18 @@ static float GDALSlopeHornAlg(const T *afWin, float /*fDstNoDataValue*/,
 
     const double dx = ((afWin[0] + afWin[3] + afWin[3] + afWin[6]) -
                        (afWin[2] + afWin[5] + afWin[5] + afWin[8])) /
-                      psData->ewres;
+                      psData->ewres_xscale;
 
     const double dy = ((afWin[6] + afWin[7] + afWin[7] + afWin[8]) -
                        (afWin[0] + afWin[1] + afWin[1] + afWin[2])) /
-                      psData->nsres;
+                      psData->nsres_yscale;
 
     const double key = (dx * dx + dy * dy);
 
     if (psData->slopeFormat == 1)
-        return static_cast<float>(atan(sqrt(key) / (8 * psData->scale)) *
-                                  kdfRadiansToDegrees);
+        return static_cast<float>(atan(sqrt(key) / 8) * kdfRadiansToDegrees);
 
-    return static_cast<float>(100 * (sqrt(key) / (8 * psData->scale)));
+    return static_cast<float>(100 * (sqrt(key) / 8));
 }
 
 template <class T>
@@ -1288,28 +1294,27 @@ static float GDALSlopeZevenbergenThorneAlg(const T *afWin,
     const GDALSlopeAlgData *psData =
         static_cast<const GDALSlopeAlgData *>(pData);
 
-    const double dx = (afWin[3] - afWin[5]) / psData->ewres;
-    const double dy = (afWin[7] - afWin[1]) / psData->nsres;
+    const double dx = (afWin[3] - afWin[5]) / psData->ewres_xscale;
+    const double dy = (afWin[7] - afWin[1]) / psData->nsres_yscale;
     const double key = dx * dx + dy * dy;
 
     if (psData->slopeFormat == 1)
-        return static_cast<float>(atan(sqrt(key) / (2 * psData->scale)) *
-                                  kdfRadiansToDegrees);
+        return static_cast<float>(atan(sqrt(key) / 2) * kdfRadiansToDegrees);
 
-    return static_cast<float>(100 * (sqrt(key) / (2 * psData->scale)));
+    return static_cast<float>(100 * (sqrt(key) / 2));
 }
 
-static void *GDALCreateSlopeData(double *adfGeoTransform, double scale,
-                                 int slopeFormat)
+static VSIVoidUniquePtr GDALCreateSlopeData(double *adfGeoTransform,
+                                            double xscale, double yscale,
+                                            int slopeFormat)
 {
     GDALSlopeAlgData *pData =
         static_cast<GDALSlopeAlgData *>(CPLMalloc(sizeof(GDALSlopeAlgData)));
 
-    pData->nsres = adfGeoTransform[5];
-    pData->ewres = adfGeoTransform[1];
-    pData->scale = scale;
+    pData->nsres_yscale = adfGeoTransform[5] * yscale;
+    pData->ewres_xscale = adfGeoTransform[1] * xscale;
     pData->slopeFormat = slopeFormat;
-    return pData;
+    return VSIVoidUniquePtr(pData);
 }
 
 /************************************************************************/
@@ -1393,13 +1398,13 @@ static float GDALAspectZevenbergenThorneAlg(const T *afWin,
     return aspect;
 }
 
-static void *GDALCreateAspectData(bool bAngleAsAzimuth)
+static VSIVoidUniquePtr GDALCreateAspectData(bool bAngleAsAzimuth)
 {
     GDALAspectAlgData *pData =
         static_cast<GDALAspectAlgData *>(CPLMalloc(sizeof(GDALAspectAlgData)));
 
     pData->bAngleAsAzimuth = bAngleAsAzimuth;
-    return pData;
+    return VSIVoidUniquePtr(pData);
 }
 
 /************************************************************************/
@@ -2543,7 +2548,7 @@ template <class T> class GDALGeneric3x3Dataset : public GDALDataset
     friend class GDALGeneric3x3RasterBand<T>;
 
     typename GDALGeneric3x3ProcessingAlg<T>::type pfnAlg;
-    void *pAlgData;
+    VSIVoidUniquePtr pAlgData{};
     GDALDatasetH hSrcDS;
     GDALRasterBandH hSrcBand;
     T *apafSourceBuf[3];
@@ -2559,7 +2564,7 @@ template <class T> class GDALGeneric3x3Dataset : public GDALDataset
                           GDALDataType eDstDataType, int bDstHasNoData,
                           double dfDstNoDataValue,
                           typename GDALGeneric3x3ProcessingAlg<T>::type pfnAlg,
-                          void *pAlgData, bool bComputeAtEdges);
+                          VSIVoidUniquePtr pAlgData, bool bComputeAtEdges);
     ~GDALGeneric3x3Dataset();
 
     bool InitOK() const
@@ -2600,9 +2605,9 @@ template <class T>
 GDALGeneric3x3Dataset<T>::GDALGeneric3x3Dataset(
     GDALDatasetH hSrcDSIn, GDALRasterBandH hSrcBandIn,
     GDALDataType eDstDataType, int bDstHasNoDataIn, double dfDstNoDataValueIn,
-    typename GDALGeneric3x3ProcessingAlg<T>::type pfnAlgIn, void *pAlgDataIn,
-    bool bComputeAtEdgesIn)
-    : pfnAlg(pfnAlgIn), pAlgData(pAlgDataIn), hSrcDS(hSrcDSIn),
+    typename GDALGeneric3x3ProcessingAlg<T>::type pfnAlgIn,
+    VSIVoidUniquePtr pAlgDataIn, bool bComputeAtEdgesIn)
+    : pfnAlg(pfnAlgIn), pAlgData(std::move(pAlgDataIn)), hSrcDS(hSrcDSIn),
       hSrcBand(hSrcBandIn), bDstHasNoData(bDstHasNoDataIn),
       dfDstNoDataValue(dfDstNoDataValueIn), nCurLine(-1),
       bComputeAtEdges(bComputeAtEdgesIn)
@@ -2755,7 +2760,7 @@ CPLErr GDALGeneric3x3RasterBand<T>::IReadBlock(int /*nBlockXOff*/,
                     CPL_TO_BOOL(bSrcHasNoData), fSrcNoDataValue,
                     CPL_TO_BOOL(bIsSrcNoDataNan), afWin,
                     static_cast<float>(poGDS->dfDstNoDataValue), poGDS->pfnAlg,
-                    poGDS->pAlgData, poGDS->bComputeAtEdges);
+                    poGDS->pAlgData.get(), poGDS->bComputeAtEdges);
 
                 if (eDataType == GDT_Byte)
                     static_cast<GByte *>(pImage)[j] =
@@ -2809,7 +2814,7 @@ CPLErr GDALGeneric3x3RasterBand<T>::IReadBlock(int /*nBlockXOff*/,
                     CPL_TO_BOOL(bSrcHasNoData), fSrcNoDataValue,
                     CPL_TO_BOOL(bIsSrcNoDataNan), afWin,
                     static_cast<float>(poGDS->dfDstNoDataValue), poGDS->pfnAlg,
-                    poGDS->pAlgData, poGDS->bComputeAtEdges);
+                    poGDS->pAlgData.get(), poGDS->bComputeAtEdges);
 
                 if (eDataType == GDT_Byte)
                     static_cast<GByte *>(pImage)[j] =
@@ -2887,7 +2892,7 @@ CPLErr GDALGeneric3x3RasterBand<T>::IReadBlock(int /*nBlockXOff*/,
                 CPL_TO_BOOL(bSrcHasNoData), fSrcNoDataValue,
                 CPL_TO_BOOL(bIsSrcNoDataNan), afWin,
                 static_cast<float>(poGDS->dfDstNoDataValue), poGDS->pfnAlg,
-                poGDS->pAlgData, poGDS->bComputeAtEdges);
+                poGDS->pAlgData.get(), poGDS->bComputeAtEdges);
 
             if (eDataType == GDT_Byte)
                 static_cast<GByte *>(pImage)[j] =
@@ -2914,11 +2919,11 @@ CPLErr GDALGeneric3x3RasterBand<T>::IReadBlock(int /*nBlockXOff*/,
             INTERPOL(poGDS->apafSourceBuf[2][j], poGDS->apafSourceBuf[2][j - 1],
                      bSrcHasNoData, fSrcNoDataValue);
 
-        const float fVal =
-            ComputeVal(CPL_TO_BOOL(bSrcHasNoData), fSrcNoDataValue,
-                       CPL_TO_BOOL(bIsSrcNoDataNan), afWin,
-                       static_cast<float>(poGDS->dfDstNoDataValue),
-                       poGDS->pfnAlg, poGDS->pAlgData, poGDS->bComputeAtEdges);
+        const float fVal = ComputeVal(
+            CPL_TO_BOOL(bSrcHasNoData), fSrcNoDataValue,
+            CPL_TO_BOOL(bIsSrcNoDataNan), afWin,
+            static_cast<float>(poGDS->dfDstNoDataValue), poGDS->pfnAlg,
+            poGDS->pAlgData.get(), poGDS->bComputeAtEdges);
 
         if (eDataType == GDT_Byte)
             static_cast<GByte *>(pImage)[j] = static_cast<GByte>(fVal + 0.5);
@@ -2954,11 +2959,11 @@ CPLErr GDALGeneric3x3RasterBand<T>::IReadBlock(int /*nBlockXOff*/,
             poGDS->apafSourceBuf[2][j - 1], poGDS->apafSourceBuf[2][j],
             poGDS->apafSourceBuf[2][j + 1]};
 
-        const float fVal =
-            ComputeVal(CPL_TO_BOOL(bSrcHasNoData), fSrcNoDataValue,
-                       CPL_TO_BOOL(bIsSrcNoDataNan), afWin,
-                       static_cast<float>(poGDS->dfDstNoDataValue),
-                       poGDS->pfnAlg, poGDS->pAlgData, poGDS->bComputeAtEdges);
+        const float fVal = ComputeVal(
+            CPL_TO_BOOL(bSrcHasNoData), fSrcNoDataValue,
+            CPL_TO_BOOL(bIsSrcNoDataNan), afWin,
+            static_cast<float>(poGDS->dfDstNoDataValue), poGDS->pfnAlg,
+            poGDS->pAlgData.get(), poGDS->bComputeAtEdges);
 
         if (eDataType == GDT_Byte)
             static_cast<GByte *>(pImage)[j] = static_cast<GByte>(fVal + 0.5);
@@ -3124,12 +3129,28 @@ static std::unique_ptr<GDALArgumentParser> GDALDEMAppOptionsGetParser(
         subCommandHillshade->add_argument("-s")
             .metavar("<scale>")
             .scan<'g', double>()
-            .store_into(psOptions->scale)
-            .help(_("Ratio of vertical units to horizontal."));
+            .store_into(psOptions->globalScale)
+            .help(_("Ratio of vertical units to horizontal units."));
 
     subCommandHillshade->add_hidden_alias_for(scaleHillshadeArg, "--s");
     subCommandHillshade->add_hidden_alias_for(scaleHillshadeArg, "-scale");
     subCommandHillshade->add_hidden_alias_for(scaleHillshadeArg, "--scale");
+
+    auto &xscaleHillshadeArg =
+        subCommandHillshade->add_argument("-xscale")
+            .metavar("<scale>")
+            .scan<'g', double>()
+            .store_into(psOptions->xscale)
+            .help(_("Ratio of vertical units to horizontal X axis units."));
+    subCommandHillshade->add_hidden_alias_for(xscaleHillshadeArg, "--xscale");
+
+    auto &yscaleHillshadeArg =
+        subCommandHillshade->add_argument("-yscale")
+            .metavar("<scale>")
+            .scan<'g', double>()
+            .store_into(psOptions->yscale)
+            .help(_("Ratio of vertical units to horizontal Y axis units."));
+    subCommandHillshade->add_hidden_alias_for(yscaleHillshadeArg, "--yscale");
 
     auto &azimuthHillshadeArg =
         subCommandHillshade->add_argument("-az")
@@ -3233,8 +3254,24 @@ static std::unique_ptr<GDALArgumentParser> GDALDEMAppOptionsGetParser(
     subCommandSlope->add_argument("-s")
         .metavar("<scale>")
         .scan<'g', double>()
-        .store_into(psOptions->scale)
+        .store_into(psOptions->globalScale)
         .help(_("Ratio of vertical units to horizontal."));
+
+    auto &xscaleSlopeArg =
+        subCommandSlope->add_argument("-xscale")
+            .metavar("<scale>")
+            .scan<'g', double>()
+            .store_into(psOptions->xscale)
+            .help(_("Ratio of vertical units to horizontal X axis units."));
+    subCommandSlope->add_hidden_alias_for(xscaleSlopeArg, "--xscale");
+
+    auto &yscaleSlopeArg =
+        subCommandSlope->add_argument("-yscale")
+            .metavar("<scale>")
+            .scan<'g', double>()
+            .store_into(psOptions->yscale)
+            .help(_("Ratio of vertical units to horizontal Y axis units."));
+    subCommandSlope->add_hidden_alias_for(yscaleSlopeArg, "--yscale");
 
     addCommonOptions(subCommandSlope);
 
@@ -3583,34 +3620,18 @@ GDALDatasetH GDALDEMProcessing(const char *pszDest, GDALDatasetH hSrcDataset,
         return nullptr;
     }
 
-    GDALDEMProcessingOptions *psOptionsToFree = nullptr;
-    const GDALDEMProcessingOptions *psOptions = psOptionsIn;
-    if (!psOptions)
+    std::unique_ptr<GDALDEMProcessingOptions> psOptionsToFree;
+    if (psOptionsIn)
     {
-        psOptionsToFree = GDALDEMProcessingOptionsNew(nullptr, nullptr);
-        psOptions = psOptionsToFree;
+        psOptionsToFree =
+            std::make_unique<GDALDEMProcessingOptions>(*psOptionsIn);
+    }
+    else
+    {
+        psOptionsToFree.reset(GDALDEMProcessingOptionsNew(nullptr, nullptr));
     }
 
-    if (psOptions->bGradientAlgSpecified &&
-        !(eUtilityMode == HILL_SHADE || eUtilityMode == SLOPE ||
-          eUtilityMode == ASPECT))
-    {
-        CPLError(CE_Failure, CPLE_IllegalArg,
-                 "This value of -alg is only value for hillshade, slope or "
-                 "aspect processing");
-        GDALDEMProcessingOptionsFree(psOptionsToFree);
-        return nullptr;
-    }
-
-    if (psOptions->bTRIAlgSpecified && !(eUtilityMode == TRI))
-    {
-        CPLError(CE_Failure, CPLE_IllegalArg,
-                 "This value of -alg is only value for TRI processing");
-        GDALDEMProcessingOptionsFree(psOptionsToFree);
-        return nullptr;
-    }
-
-    double adfGeoTransform[6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+    GDALDEMProcessingOptions *psOptions = psOptionsToFree.get();
 
     const int nXSize = GDALGetRasterXSize(hSrcDataset);
     const int nYSize = GDALGetRasterYSize(hSrcDataset);
@@ -3620,9 +3641,96 @@ GDALDatasetH GDALDEMProcessing(const char *pszDest, GDALDatasetH hSrcDataset,
     {
         CPLError(CE_Failure, CPLE_IllegalArg, "Unable to fetch band #%d",
                  psOptions->nBand);
-        GDALDEMProcessingOptionsFree(psOptionsToFree);
+
         return nullptr;
     }
+
+    if (std::isnan(psOptions->xscale))
+    {
+        psOptions->xscale = 1;
+        psOptions->yscale = 1;
+
+        double zunit = 1;
+
+        auto poSrcDS = GDALDataset::FromHandle(hSrcDataset);
+
+        const char *pszUnits =
+            poSrcDS->GetRasterBand(psOptions->nBand)->GetUnitType();
+        if (EQUAL(pszUnits, "m") || EQUAL(pszUnits, "metre") ||
+            EQUAL(pszUnits, "meter"))
+        {
+        }
+        else if (EQUAL(pszUnits, "ft") || EQUAL(pszUnits, "foot") ||
+                 EQUAL(pszUnits, "foot (International)") ||
+                 EQUAL(pszUnits, "feet"))
+        {
+            zunit = CPLAtof(SRS_UL_FOOT_CONV);
+        }
+        else if (EQUAL(pszUnits, "us-ft") || EQUAL(pszUnits, "Foot_US") ||
+                 EQUAL(pszUnits, "US survey foot"))
+        {
+            zunit = CPLAtof(SRS_UL_US_FOOT_CONV);
+        }
+        else if (!EQUAL(pszUnits, ""))
+        {
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "Unknown band unit '%s'. Assuming metre", pszUnits);
+        }
+
+        const auto poSrcSRS = poSrcDS->GetSpatialRef();
+        if (poSrcSRS && poSrcSRS->IsGeographic())
+        {
+            double adfGT[6];
+            if (poSrcDS->GetGeoTransform(adfGT) == CE_None)
+            {
+                const double dfAngUnits = poSrcSRS->GetAngularUnits();
+                // Rough conversion of angular units to linear units.
+                psOptions->yscale =
+                    dfAngUnits * poSrcSRS->GetSemiMajor() / zunit;
+                // Take the center latitude to compute the xscale.
+                const double dfMeanLat =
+                    (adfGT[3] + nYSize * adfGT[5] / 2) * dfAngUnits;
+                if (std::fabs(dfMeanLat) / M_PI * 180 > 80)
+                {
+                    CPLError(
+                        CE_Warning, CPLE_AppDefined,
+                        "Automatic computation of xscale at high latitudes may "
+                        "lead to incorrect results. The source dataset should "
+                        "likely be reprojected to a polar projection");
+                }
+                psOptions->xscale = psOptions->yscale * cos(dfMeanLat);
+            }
+        }
+        else if (poSrcSRS && poSrcSRS->IsProjected())
+        {
+            psOptions->xscale = poSrcSRS->GetLinearUnits() / zunit;
+            psOptions->yscale = psOptions->xscale;
+        }
+        CPLDebug("GDAL", "Using xscale=%f and yscale=%f", psOptions->xscale,
+                 psOptions->yscale);
+    }
+
+    if (psOptions->bGradientAlgSpecified &&
+        !(eUtilityMode == HILL_SHADE || eUtilityMode == SLOPE ||
+          eUtilityMode == ASPECT))
+    {
+        CPLError(CE_Failure, CPLE_IllegalArg,
+                 "This value of -alg is only valid for hillshade, slope or "
+                 "aspect processing");
+
+        return nullptr;
+    }
+
+    if (psOptions->bTRIAlgSpecified && !(eUtilityMode == TRI))
+    {
+        CPLError(CE_Failure, CPLE_IllegalArg,
+                 "This value of -alg is only valid for TRI processing");
+
+        return nullptr;
+    }
+
+    double adfGeoTransform[6] = {0.0, 0.0, 0.0, 0.0, 0.0, 0.0};
+
     GDALRasterBandH hSrcBand = GDALGetRasterBand(hSrcDataset, psOptions->nBand);
 
     GDALGetGeoTransform(hSrcDataset, adfGeoTransform);
@@ -3633,7 +3741,6 @@ GDALDatasetH GDALDEMProcessing(const char *pszDest, GDALDatasetH hSrcDataset,
         osFormat = GetOutputDriverForRaster(pszDest);
         if (osFormat.empty())
         {
-            GDALDEMProcessingOptionsFree(psOptionsToFree);
             return nullptr;
         }
     }
@@ -3669,13 +3776,12 @@ GDALDatasetH GDALDEMProcessing(const char *pszDest, GDALDatasetH hSrcDataset,
                         GDALGetDriverLongName(hDriver));
             }
         }
-        GDALDEMProcessingOptionsFree(psOptionsToFree);
         return nullptr;
     }
 
     double dfDstNoDataValue = 0.0;
     bool bDstHasNoData = false;
-    void *pData = nullptr;
+    VSIVoidUniquePtr pData;
     GDALGeneric3x3ProcessingAlg<float>::type pfnAlgFloat = nullptr;
     GDALGeneric3x3ProcessingAlg<GInt32>::type pfnAlgInt32 = nullptr;
     GDALGeneric3x3ProcessingAlg_multisample<GInt32>::type
@@ -3686,8 +3792,8 @@ GDALDatasetH GDALDEMProcessing(const char *pszDest, GDALDatasetH hSrcDataset,
         dfDstNoDataValue = 0;
         bDstHasNoData = true;
         pData = GDALCreateHillshadeMultiDirectionalData(
-            adfGeoTransform, psOptions->z, psOptions->scale, psOptions->alt,
-            psOptions->eGradientAlg);
+            adfGeoTransform, psOptions->z, psOptions->xscale, psOptions->yscale,
+            psOptions->alt, psOptions->eGradientAlg);
         if (psOptions->eGradientAlg == GradientAlg::ZEVENBERGEN_THORNE)
         {
             pfnAlgFloat = GDALHillshadeMultiDirectionalAlg<
@@ -3707,9 +3813,9 @@ GDALDatasetH GDALDEMProcessing(const char *pszDest, GDALDatasetH hSrcDataset,
     {
         dfDstNoDataValue = 0;
         bDstHasNoData = true;
-        pData = GDALCreateHillshadeData(adfGeoTransform, psOptions->z,
-                                        psOptions->scale, psOptions->alt,
-                                        psOptions->az, psOptions->eGradientAlg);
+        pData = GDALCreateHillshadeData(
+            adfGeoTransform, psOptions->z, psOptions->xscale, psOptions->yscale,
+            psOptions->alt, psOptions->az, psOptions->eGradientAlg);
         if (psOptions->eGradientAlg == GradientAlg::ZEVENBERGEN_THORNE)
         {
             if (psOptions->bCombined)
@@ -3754,7 +3860,8 @@ GDALDatasetH GDALDEMProcessing(const char *pszDest, GDALDatasetH hSrcDataset,
             }
             else
             {
-                if (adfGeoTransform[1] == -adfGeoTransform[5])
+                if (adfGeoTransform[1] == -adfGeoTransform[5] &&
+                    psOptions->xscale == psOptions->yscale)
                 {
                     pfnAlgFloat = GDALHillshadeAlg_same_res<float>;
                     pfnAlgInt32 = GDALHillshadeAlg_same_res<GInt32>;
@@ -3776,7 +3883,8 @@ GDALDatasetH GDALDEMProcessing(const char *pszDest, GDALDatasetH hSrcDataset,
         dfDstNoDataValue = -9999;
         bDstHasNoData = true;
 
-        pData = GDALCreateSlopeData(adfGeoTransform, psOptions->scale,
+        pData = GDALCreateSlopeData(adfGeoTransform, psOptions->xscale,
+                                    psOptions->yscale,
                                     psOptions->bSlopeFormatUseDegrees);
         if (psOptions->eGradientAlg == GradientAlg::ZEVENBERGEN_THORNE)
         {
@@ -3853,17 +3961,13 @@ GDALDatasetH GDALDEMProcessing(const char *pszDest, GDALDatasetH hSrcDataset,
                 pszDest, hSrcDataset, hSrcBand, pszColorFilename,
                 psOptions->eColorSelectionMode, psOptions->bAddAlpha);
 
-            CPLFree(pData);
-
-            GDALDEMProcessingOptionsFree(psOptionsToFree);
             return GDALOpen(pszDest, GA_Update);
         }
         else
         {
             CPLError(CE_Failure, CPLE_NotSupported,
                      "VRT driver can only be used with color-relief utility.");
-            GDALDEMProcessingOptionsFree(psOptionsToFree);
-            CPLFree(pData);
+
             return nullptr;
         }
     }
@@ -3922,8 +4026,6 @@ GDALDatasetH GDALDEMProcessing(const char *pszDest, GDALDatasetH hSrcDataset,
             if (!(poDS->InitOK()))
             {
                 delete poDS;
-                CPLFree(pData);
-                GDALDEMProcessingOptionsFree(psOptionsToFree);
                 return nullptr;
             }
             hIntermediateDataset = static_cast<GDALDatasetH>(poDS);
@@ -3936,14 +4038,12 @@ GDALDatasetH GDALDEMProcessing(const char *pszDest, GDALDatasetH hSrcDataset,
                 GDALGeneric3x3Dataset<GInt32> *poDS =
                     new GDALGeneric3x3Dataset<GInt32>(
                         hSrcDataset, hSrcBand, eDstDataType, bDstHasNoData,
-                        dfDstNoDataValue, pfnAlgInt32, pData,
+                        dfDstNoDataValue, pfnAlgInt32, std::move(pData),
                         psOptions->bComputeAtEdges);
 
                 if (!(poDS->InitOK()))
                 {
                     delete poDS;
-                    CPLFree(pData);
-                    GDALDEMProcessingOptionsFree(psOptionsToFree);
                     return nullptr;
                 }
                 hIntermediateDataset = static_cast<GDALDatasetH>(poDS);
@@ -3953,14 +4053,12 @@ GDALDatasetH GDALDEMProcessing(const char *pszDest, GDALDatasetH hSrcDataset,
                 GDALGeneric3x3Dataset<float> *poDS =
                     new GDALGeneric3x3Dataset<float>(
                         hSrcDataset, hSrcBand, eDstDataType, bDstHasNoData,
-                        dfDstNoDataValue, pfnAlgFloat, pData,
+                        dfDstNoDataValue, pfnAlgFloat, std::move(pData),
                         psOptions->bComputeAtEdges);
 
                 if (!(poDS->InitOK()))
                 {
                     delete poDS;
-                    CPLFree(pData);
-                    GDALDEMProcessingOptionsFree(psOptionsToFree);
                     return nullptr;
                 }
                 hIntermediateDataset = static_cast<GDALDatasetH>(poDS);
@@ -3973,9 +4071,6 @@ GDALDatasetH GDALDEMProcessing(const char *pszDest, GDALDatasetH hSrcDataset,
 
         GDALClose(hIntermediateDataset);
 
-        CPLFree(pData);
-
-        GDALDEMProcessingOptionsFree(psOptionsToFree);
         return hOutDS;
     }
 
@@ -3990,8 +4085,6 @@ GDALDatasetH GDALDEMProcessing(const char *pszDest, GDALDatasetH hSrcDataset,
     {
         CPLError(CE_Failure, CPLE_AppDefined, "Unable to create dataset %s",
                  pszDest);
-        GDALDEMProcessingOptionsFree(psOptionsToFree);
-        CPLFree(pData);
         return nullptr;
     }
 
@@ -4018,20 +4111,18 @@ GDALDatasetH GDALDEMProcessing(const char *pszDest, GDALDatasetH hSrcDataset,
         if (eSrcDT == GDT_Byte || eSrcDT == GDT_Int16 || eSrcDT == GDT_UInt16)
         {
             GDALGeneric3x3Processing<GInt32>(
-                hSrcBand, hDstBand, pfnAlgInt32, pfnAlgInt32_multisample, pData,
-                psOptions->bComputeAtEdges, pfnProgress, pProgressData);
+                hSrcBand, hDstBand, pfnAlgInt32, pfnAlgInt32_multisample,
+                std::move(pData), psOptions->bComputeAtEdges, pfnProgress,
+                pProgressData);
         }
         else
         {
             GDALGeneric3x3Processing<float>(
-                hSrcBand, hDstBand, pfnAlgFloat, nullptr, pData,
+                hSrcBand, hDstBand, pfnAlgFloat, nullptr, std::move(pData),
                 psOptions->bComputeAtEdges, pfnProgress, pProgressData);
         }
     }
 
-    CPLFree(pData);
-
-    GDALDEMProcessingOptionsFree(psOptionsToFree);
     return hDstDataset;
 }
 
@@ -4094,9 +4185,19 @@ GDALDEMProcessingOptions *GDALDEMProcessingOptionsNew(
             throw std::invalid_argument("Invalid value for -z");
         }
 
-        if (psOptions->scale <= 0)
+        if (psOptions->globalScale <= 0)
         {
             throw std::invalid_argument("Invalid value for -s");
+        }
+
+        if (psOptions->xscale <= 0)
+        {
+            throw std::invalid_argument("Invalid value for -xscale");
+        }
+
+        if (psOptions->yscale <= 0)
+        {
+            throw std::invalid_argument("Invalid value for -yscale");
         }
 
         if (psOptions->alt <= 0)
@@ -4186,6 +4287,26 @@ GDALDEMProcessingOptions *GDALDEMProcessingOptionsNew(
     {
         CPLError(CE_Failure, CPLE_AppDefined, "Unexpected exception: %s",
                  err.what());
+        return nullptr;
+    }
+
+    if (!std::isnan(psOptions->globalScale))
+    {
+        if (!std::isnan(psOptions->xscale) || !std::isnan(psOptions->yscale))
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "-scale and -xscale/-yscale are mutually exclusive.");
+            return nullptr;
+        }
+        psOptions->xscale = psOptions->globalScale;
+        psOptions->yscale = psOptions->globalScale;
+    }
+    else if ((!std::isnan(psOptions->xscale)) ^
+             (!std::isnan(psOptions->yscale)))
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "When one of -xscale or -yscale is specified, both must be "
+                 "specified.");
         return nullptr;
     }
 

--- a/autotest/utilities/test_gdaldem_lib.py
+++ b/autotest/utilities/test_gdaldem_lib.py
@@ -21,19 +21,49 @@ import pytest
 from osgeo import gdal, osr
 
 ###############################################################################
+# Test incorrect use of scale parameters
+
+
+@pytest.mark.parametrize(
+    "options",
+    [
+        {"scale": 111120, "xscale": 1},
+        {"scale": 111120, "yscale": 1},
+        {"xscale": 1},
+        {"yscale": 1},
+    ],
+)
+def test_gdaldem_lib_hillshade_incorrect_use_of_scale_params(options):
+
+    src_ds = gdal.Open("../gdrivers/data/n43.tif")
+    kwargs = {"format": "MEM", "zFactor": 30}
+    kwargs.update(options)
+    with pytest.raises(Exception):
+        gdal.DEMProcessing("", src_ds, "hillshade", **kwargs)
+
+
+###############################################################################
 # Test gdaldem hillshade
 
 
-def test_gdaldem_lib_hillshade():
+@pytest.mark.parametrize(
+    "options,checksum",
+    [
+        ({"scale": 111120}, 45587),
+        ({"xscale": 111120, "yscale": 111120}, 45587),
+        ({"xscale": 111120, "yscale": 111120 + 1}, 45587),
+        ({}, 46008),
+    ],
+)
+def test_gdaldem_lib_hillshade(options, checksum):
 
     src_ds = gdal.Open("../gdrivers/data/n43.tif")
-    ds = gdal.DEMProcessing(
-        "", src_ds, "hillshade", format="MEM", scale=111120, zFactor=30
-    )
+    kwargs = {"format": "MEM", "zFactor": 30}
+    kwargs.update(options)
+    ds = gdal.DEMProcessing("", src_ds, "hillshade", **kwargs)
     assert ds is not None
 
-    cs = ds.GetRasterBand(1).Checksum()
-    assert cs == 45587, "Bad checksum"
+    assert ds.GetRasterBand(1).Checksum() == checksum, "Bad checksum"
 
     src_gt = src_ds.GetGeoTransform()
     dst_gt = ds.GetGeoTransform()
@@ -47,6 +77,85 @@ def test_gdaldem_lib_hillshade():
 
     src_ds = None
     ds = None
+
+
+###############################################################################
+# Test gdaldem hillshade with projected CRS
+
+
+@pytest.mark.parametrize("proj_unit", ["m", "ft", "us-ft"])
+def test_gdaldem_lib_hillshade_proj_crs(proj_unit):
+
+    src_ds = gdal.Warp(
+        "",
+        "../gdrivers/data/n43.tif",
+        format="MEM",
+        dstSRS=f"+proj=tmerc +datum=WGS84 +lon_0=-79.5 +units={proj_unit}",
+    )
+    ds = gdal.DEMProcessing("", src_ds, "hillshade", format="MEM", zFactor=30)
+    assert ds.GetRasterBand(1).Checksum() == 36233
+
+
+###############################################################################
+# Test gdaldem hillshade with projected CRS and different vertical unit
+
+
+@pytest.mark.parametrize(
+    "name,factor",
+    [("m", 1), ("unknown", 1), ("ft", 0.3048), ("us-ft", 0.3048006096012192)],
+)
+def test_gdaldem_lib_hillshade_projected_crs_vertical_units(name, factor):
+
+    gdaltest.importorskip_gdal_array()
+    pytest.importorskip("numpy")
+
+    src_ds = gdal.Warp(
+        "",
+        "../gdrivers/data/n43.tif",
+        outputType=gdal.GDT_Float32,
+        format="MEM",
+        dstSRS="+proj=tmerc +datum=WGS84 +lon_0=-79.5 +units=m",
+    )
+    src_ds.GetRasterBand(1).SetUnitType(name)
+    src_ds.GetRasterBand(1).SetNoDataValue(
+        src_ds.GetRasterBand(1).GetNoDataValue() / factor
+    )
+    src_ds.GetRasterBand(1).WriteArray(src_ds.GetRasterBand(1).ReadAsArray() / factor)
+    if name == "unknown":
+        with gdal.quiet_errors():
+            ds = gdal.DEMProcessing("", src_ds, "hillshade", format="MEM", zFactor=30)
+    else:
+        ds = gdal.DEMProcessing("", src_ds, "hillshade", format="MEM", zFactor=30)
+    assert ds.GetRasterBand(1).Checksum() == 36233
+
+
+###############################################################################
+# Test gdaldem hillshade with geographic CRS and different vertical unit
+
+
+@pytest.mark.parametrize(
+    "name,factor",
+    [("m", 1), ("unknown", 1), ("ft", 0.3048), ("us-ft", 0.3048006096012192)],
+)
+def test_gdaldem_lib_hillshade_geographic_crs_vertical_units(name, factor):
+
+    gdaltest.importorskip_gdal_array()
+    pytest.importorskip("numpy")
+
+    src_ds = gdal.Translate(
+        "", "../gdrivers/data/n43.tif", format="MEM", outputType=gdal.GDT_Float32
+    )
+    src_ds.GetRasterBand(1).SetUnitType(name)
+    src_ds.GetRasterBand(1).SetNoDataValue(
+        src_ds.GetRasterBand(1).GetNoDataValue() / factor
+    )
+    src_ds.GetRasterBand(1).WriteArray(src_ds.GetRasterBand(1).ReadAsArray() / factor)
+    if name == "unknown":
+        with gdal.quiet_errors():
+            ds = gdal.DEMProcessing("", src_ds, "hillshade", format="MEM", zFactor=30)
+    else:
+        ds = gdal.DEMProcessing("", src_ds, "hillshade", format="MEM", zFactor=30)
+    assert ds.GetRasterBand(1).Checksum() == 46008
 
 
 ###############################################################################
@@ -127,16 +236,24 @@ def test_gdaldem_lib_hillshade_float_png(tmp_vsimem):
 # Test gdaldem hillshade -combined
 
 
-def test_gdaldem_lib_hillshade_combined():
+@pytest.mark.parametrize(
+    "options,checksum",
+    [
+        ({"scale": 111120}, 43876),
+        ({"xscale": 111120, "yscale": 111120}, 43876),
+        ({"xscale": 111120, "yscale": 111120 + 0.1}, 43876),
+        ({}, 42176),
+    ],
+)
+def test_gdaldem_lib_hillshade_combined(options, checksum):
 
     src_ds = gdal.Open("../gdrivers/data/n43.tif")
-    ds = gdal.DEMProcessing(
-        "", src_ds, "hillshade", format="MEM", combined=True, scale=111120, zFactor=30
-    )
+    kwargs = {"format": "MEM", "combined": True, "zFactor": 30}
+    kwargs.update(options)
+    ds = gdal.DEMProcessing("", src_ds, "hillshade", **kwargs)
     assert ds is not None
 
-    cs = ds.GetRasterBand(1).Checksum()
-    assert cs == 43876, "Bad checksum"
+    assert ds.GetRasterBand(1).Checksum() == checksum, "Bad checksum"
 
     src_gt = src_ds.GetGeoTransform()
     dst_gt = ds.GetGeoTransform()
@@ -156,22 +273,24 @@ def test_gdaldem_lib_hillshade_combined():
 # Test gdaldem hillshade -alg ZevenbergenThorne
 
 
-def test_gdaldem_lib_hillshade_ZevenbergenThorne():
+@pytest.mark.parametrize(
+    "options,checksum",
+    [
+        ({"scale": 111120}, 46544),
+        ({"xscale": 111120, "yscale": 111120}, 46544),
+        ({"xscale": 111120, "yscale": 111120 + 0.1}, 46544),
+        ({}, 45373),
+    ],
+)
+def test_gdaldem_lib_hillshade_ZevenbergenThorne(options, checksum):
 
     src_ds = gdal.Open("../gdrivers/data/n43.tif")
-    ds = gdal.DEMProcessing(
-        "",
-        src_ds,
-        "hillshade",
-        format="MEM",
-        alg="ZevenbergenThorne",
-        scale=111120,
-        zFactor=30,
-    )
+    kwargs = {"format": "MEM", "alg": "ZevenbergenThorne", "zFactor": 30}
+    kwargs.update(options)
+    ds = gdal.DEMProcessing("", src_ds, "hillshade", **kwargs)
     assert ds is not None
 
-    cs = ds.GetRasterBand(1).Checksum()
-    assert cs == 46544, "Bad checksum"
+    assert ds.GetRasterBand(1).Checksum() == checksum, "Bad checksum"
 
     src_gt = src_ds.GetGeoTransform()
     dst_gt = ds.GetGeoTransform()
@@ -191,23 +310,29 @@ def test_gdaldem_lib_hillshade_ZevenbergenThorne():
 # Test gdaldem hillshade -alg ZevenbergenThorne -combined
 
 
-def test_gdaldem_lib_hillshade_ZevenbergenThorne_combined():
+@pytest.mark.parametrize(
+    "options,checksum",
+    [
+        ({"scale": 111120}, 43112),
+        ({"xscale": 111120, "yscale": 111120}, 43112),
+        ({"xscale": 111120, "yscale": 111120 + 0.1}, 43112),
+        ({}, 42340),
+    ],
+)
+def test_gdaldem_lib_hillshade_ZevenbergenThorne_combined(options, checksum):
 
     src_ds = gdal.Open("../gdrivers/data/n43.tif")
-    ds = gdal.DEMProcessing(
-        "",
-        src_ds,
-        "hillshade",
-        format="MEM",
-        alg="ZevenbergenThorne",
-        combined=True,
-        scale=111120,
-        zFactor=30,
-    )
+    kwargs = {
+        "format": "MEM",
+        "alg": "ZevenbergenThorne",
+        "combined": True,
+        "zFactor": 30,
+    }
+    kwargs.update(options)
+    ds = gdal.DEMProcessing("", src_ds, "hillshade", **kwargs)
     assert ds is not None
 
-    cs = ds.GetRasterBand(1).Checksum()
-    assert cs == 43112, "Bad checksum"
+    assert ds.GetRasterBand(1).Checksum() == checksum, "Bad checksum"
 
     src_gt = src_ds.GetGeoTransform()
     dst_gt = ds.GetGeoTransform()
@@ -661,23 +786,24 @@ def test_gdaldem_lib_roughness():
 # Test gdaldem slope -alg ZevenbergenThorne
 
 
-def test_gdaldem_lib_slope_ZevenbergenThorne():
+@pytest.mark.parametrize(
+    "options,checksum",
+    [
+        ({"scale": 111120}, 64393),
+        ({"xscale": 111120, "yscale": 111120}, 64393),
+        ({"xscale": 111120, "yscale": 111120 + 0.1}, 64393),
+        ({}, 65468),
+    ],
+)
+def test_gdaldem_lib_slope_ZevenbergenThorne(options, checksum):
 
     src_ds = gdal.Open("../gdrivers/data/n43.tif")
-    ds = gdal.DEMProcessing(
-        "",
-        src_ds,
-        "slope",
-        format="MEM",
-        alg="ZevenbergenThorne",
-        slopeFormat="degree",
-        scale=111120,
-        zFactor=30,
-    )
+    kwargs = {"format": "MEM", "alg": "ZevenbergenThorne", "zFactor": 30}
+    kwargs.update(options)
+    ds = gdal.DEMProcessing("", src_ds, "slope", **kwargs)
     assert ds is not None
 
-    cs = ds.GetRasterBand(1).Checksum()
-    assert cs == 64393, "Bad checksum"
+    assert ds.GetRasterBand(1).Checksum() == checksum, "Bad checksum"
 
 
 ###############################################################################

--- a/doc/source/programs/gdaldem.rst
+++ b/doc/source/programs/gdaldem.rst
@@ -24,7 +24,7 @@ Generate a shaded relief map:
 .. code-block::
 
      gdaldem hillshade <input_dem> <output_hillshade>
-                 [-z <zfactor>] [-s <scale>]
+                 [-z <zfactor>] [[-s <scale>] | [-xscale <xscale> -yscale <yscale>]]
                  [-az <azimuth>] [-alt <altitude>]
                  [-alg ZevenbergenThorne] [-combined | -multidirectional | -igor]
                  [-compute_edges] [-b <Band>] [-of <format>] [-co <NAME>=<VALUE>]... [-q]
@@ -34,7 +34,7 @@ Generate a slope map:
 .. code-block::
 
      gdaldem slope <input_dem> <output_slope_map>
-                 [-p] [-s <scale>]
+                 [-p] [[-s <scale>] | [-xscale <xscale> -yscale <yscale>]]
                  [-alg ZevenbergenThorne]
                  [-compute_edges] [-b <band>] [-of <format>] [-co <NAME>=<VALUE>]... [-q]
 
@@ -83,9 +83,22 @@ Generate a roughness map:
 Description
 -----------
 
-The :program:`gdaldem` generally assumes that x, y and z units are identical.
-If x (east-west) and y (north-south) units are identical, but z (elevation)
-units are different, the scale (-s) option can be used to set the ratio of
+The :program:`gdaldem` generates output rasters using different algorithms for
+terrain analysis.
+
+In general, it assumes that x, y and z units are identical. However, for hillshade
+and slope computation, starting with GDAL 3.11, if none of :option:`-scale`,
+:option:`-xscale` and :option:`-yscale` are specified, and the CRS is a
+geographic or projected CRS, :program:`gdaldem` will automatically determine the
+appropriate ratio from the units of the CRS, as well as the potential value of
+the units of the raster band (as returned by :cpp:func:`GDALRasterBand::GetUnitsType`, if it
+is metre, foot international or US survey foot). Note that for geographic CRS,
+the result for source datasets at high latitudes may be incorrect, and prior
+reprojection to a polar projection might be needed.
+
+For hillshade and slope computation, if x (east-west) and y (north-south) units
+are identical, but z (elevation) units are different, the :option:`-scale` option
+(or :option:`-xscale` and :option:`-yscale`) can be used to set the ratio of
 vertical units to horizontal.
 For LatLong projections near the equator, where units of latitude and units of
 longitude are similar, elevation (z) units can be converted to be compatible
@@ -191,7 +204,53 @@ The following specific options are available :
 
 .. option:: -s <scale>
 
-    Ratio of vertical units to horizontal. If the horizontal unit of the source DEM is degrees (e.g Lat/Long WGS84 projection), you can use scale=111120 if the vertical units are meters (or scale=370400 if they are in feet)
+    Ratio of vertical units to horizontal units. If the horizontal unit of the source DEM is degrees (e.g Lat/Long WGS84 projection), you can use scale=111120 if the vertical units are meters (or scale=370400 if they are in feet).
+
+    Starting with GDAL 3.11, if none of :option:`-scale`, :option:`-xscale` and
+    :option:`-yscale` are specified, and the CRS is a geographic or projected CRS,
+    :program:`gdaldem` will automatically determine the appropriate ratio from
+    the units of the CRS, as well as the potential value of the units of the
+    raster band (as returned by :cpp:func:`GDALRasterBand::GetUnitsType`, if it
+    is metre, foot international or US survey foot). Note that for geographic CRS,
+    the result for source datasets at high latitudes may be incorrect, and prior
+    reprojection to a polar projection might be needed.
+
+    The effect of this option is the same as specifying :option:`-xscale` and :option:`-yscale` with the same value as :option:`-scale`.
+    :option:`-scale` is mutually exclusive with :option:`-xscale` and :option:`-yscale`
+
+.. option:: -xscale <scale>
+
+    .. versionadded:: 3.11
+
+    Ratio of vertical units to horizontal X axis units. If the horizontal unit of the source DEM is degrees (e.g Lat/Long WGS84 projection), you can use scale=111120 if the vertical units are meters (or scale=370400 if they are in feet).
+
+    Starting with GDAL 3.11, if none of :option:`-scale`, :option:`-xscale` and
+    :option:`-yscale` are specified, and the CRS is a geographic or projected CRS,
+    :program:`gdaldem` will automatically determine the appropriate ratio from
+    the units of the CRS, as well as the potential value of the units of the
+    raster band (as returned by :cpp:func:`GDALRasterBand::GetUnitsType`, if it
+    is metre, foot international or US survey foot). Note that for geographic CRS,
+    the result for source datasets at high latitudes may be incorrect, and prior
+    reprojection to a polar projection might be needed.
+
+    If :option:`-xscale` is specified, :option:`-yscale` must also be specified.
+
+.. option:: -yscale <scale>
+
+    .. versionadded:: 3.11
+
+    Ratio of vertical units to horizontal Y axis units. If the horizontal unit of the source DEM is degrees (e.g Lat/Long WGS84 projection), you can use scale=111120 if the vertical units are meters (or scale=370400 if they are in feet)
+
+    Starting with GDAL 3.11, if none of :option:`-scale`, :option:`-xscale` and
+    :option:`-yscale` are specified, and the CRS is a geographic or projected CRS,
+    :program:`gdaldem` will automatically determine the appropriate ratio from
+    the units of the CRS, as well as the potential value of the units of the
+    raster band (as returned by :cpp:func:`GDALRasterBand::GetUnitsType`, if it
+    is metre, foot international or US survey foot). Note that for geographic CRS,
+    the result for source datasets at high latitudes may be incorrect, and prior
+    reprojection to a polar projection might be needed.
+
+    If :option:`-yscale` is specified, :option:`-xscale` must also be specified.
 
 .. option:: -az <azimuth>
 
@@ -238,9 +297,55 @@ The following specific options are available :
 
     If specified, the slope will be expressed as percent slope. Otherwise, it is expressed as degrees
 
-:option:`-s`
+.. option:: -s <scale>
 
-    Ratio of vertical units to horizontal. If the horizontal unit of the source DEM is degrees (e.g Lat/Long WGS84 projection), you can use scale=111120 if the vertical units are meters (or scale=370400 if they are in feet).
+    Ratio of vertical units to horizontal units. If the horizontal unit of the source DEM is degrees (e.g Lat/Long WGS84 projection), you can use scale=111120 if the vertical units are meters (or scale=370400 if they are in feet).
+
+    Starting with GDAL 3.11, if none of :option:`-scale`, :option:`-xscale` and
+    :option:`-yscale` are specified, and the CRS is a geographic or projected CRS,
+    :program:`gdaldem` will automatically determine the appropriate ratio from
+    the units of the CRS, as well as the potential value of the units of the
+    raster band (as returned by :cpp:func:`GDALRasterBand::GetUnitsType`, if it
+    is metre, foot international or US survey foot). Note that for geographic CRS,
+    the result for source datasets at high latitudes may be incorrect, and prior
+    reprojection to a polar projection might be needed.
+
+    The effect of this option is the same as specifying :option:`-xscale` and :option:`-yscale` with the same value as :option:`-scale`.
+    :option:`-scale` is mutually exclusive with :option:`-xscale` and :option:`-yscale`
+
+.. option:: -xscale <scale>
+
+    .. versionadded:: 3.11
+
+    Ratio of vertical units to horizontal X axis units. If the horizontal unit of the source DEM is degrees (e.g Lat/Long WGS84 projection), you can use scale=111120 if the vertical units are meters (or scale=370400 if they are in feet).
+
+    Starting with GDAL 3.11, if none of :option:`-scale`, :option:`-xscale` and
+    :option:`-yscale` are specified, and the CRS is a geographic or projected CRS,
+    :program:`gdaldem` will automatically determine the appropriate ratio from
+    the units of the CRS, as well as the potential value of the units of the
+    raster band (as returned by :cpp:func:`GDALRasterBand::GetUnitsType`, if it
+    is metre, foot international or US survey foot). Note that for geographic CRS,
+    the result for source datasets at high latitudes may be incorrect, and prior
+    reprojection to a polar projection might be needed.
+
+    If :option:`-xscale` is specified, :option:`-yscale` must also be specified.
+
+.. option:: -yscale <scale>
+
+    .. versionadded:: 3.11
+
+    Ratio of vertical units to horizontal Y axis units. If the horizontal unit of the source DEM is degrees (e.g Lat/Long WGS84 projection), you can use scale=111120 if the vertical units are meters (or scale=370400 if they are in feet)
+
+    Starting with GDAL 3.11, if none of :option:`-scale`, :option:`-xscale` and
+    :option:`-yscale` are specified, and the CRS is a geographic or projected CRS,
+    :program:`gdaldem` will automatically determine the appropriate ratio from
+    the units of the CRS, as well as the potential value of the units of the
+    raster band (as returned by :cpp:func:`GDALRasterBand::GetUnitsType`, if it
+    is metre, foot international or US survey foot). Note that for geographic CRS,
+    the result for source datasets at high latitudes may be incorrect, and prior
+    reprojection to a polar projection might be needed.
+
+    If :option:`-yscale` is specified, :option:`-xscale` must also be specified.
 
 aspect
 ^^^^^^

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -3492,7 +3492,7 @@ def VectorTranslate(destNameOrDestDS, srcDS, **kwargs):
 
 def DEMProcessingOptions(options=None, colorFilename=None, format=None,
               creationOptions=None, computeEdges=False, alg=None, band=1,
-              zFactor=None, scale=None, azimuth=None, altitude=None,
+              zFactor=None, scale=None, xscale=None, yscale=None, azimuth=None, altitude=None,
               combined=False, multiDirectional=False, igor=False,
               slopeFormat=None, trigonometric=False, zeroForFlat=False,
               addAlpha=None, colorSelection=None,
@@ -3519,6 +3519,10 @@ def DEMProcessingOptions(options=None, colorFilename=None, format=None,
         (hillshade only) vertical exaggeration used to pre-multiply the elevations.
     scale:
         ratio of vertical units to horizontal.
+    xscale:
+        Ratio of vertical units to horizontal X axis units.
+    yscale:
+        Ratio of vertical units to horizontal Y axis units.
     azimuth:
         (hillshade only) azimuth of the light, in degrees. 0 if it comes from the top of the raster, 90 from the east, ... The default value, 315, should rarely be changed as it is the value generally used to generate shaded maps.
     altitude:
@@ -3569,6 +3573,10 @@ def DEMProcessingOptions(options=None, colorFilename=None, format=None,
             new_options += ['-z', str(zFactor)]
         if scale is not None:
             new_options += ['-s', str(scale)]
+        if xscale is not None:
+            new_options += ['-xscale', str(xscale)]
+        if yscale is not None:
+            new_options += ['-yscale', str(yscale)]
         if azimuth is not None:
             new_options += ['-az', str(azimuth)]
         if altitude is not None:


### PR DESCRIPTION
…and projected CRS; add -xscale and -yscale

This avoids in particular the need for defining the -s 111120 switch when the raster uses a geographic CRS
