### PR TITLE
MRF: allow deflate expansion

### DIFF
--- a/frmts/mrf/mrf_band.cpp
+++ b/frmts/mrf/mrf_band.cpp
@@ -281,10 +281,10 @@ static void *DeflateBlock(buf_mgr &src, size_t extrasize, int flags)
         CPLFree(dbuff);  // Safe to call with NULL
         return nullptr;
     }
-    if (dst.size > src.size)
+    if (dst.size > extrasize)
     {
         CPLError(CE_Failure, CPLE_AppDefined,
-                 "DeflateBlock(): dst.size > src.size");
+                 "DeflateBlock(): dst.size > extrasize");
         CPLFree(dbuff);  // Safe to call with NULL
         return nullptr;
     }

--- a/frmts/mrf/mrf_band.cpp
+++ b/frmts/mrf/mrf_band.cpp
@@ -281,13 +281,6 @@ static void *DeflateBlock(buf_mgr &src, size_t extrasize, int flags)
         CPLFree(dbuff);  // Safe to call with NULL
         return nullptr;
     }
-    if (dst.size > extrasize)
-    {
-        CPLError(CE_Failure, CPLE_AppDefined,
-                 "DeflateBlock(): dst.size > extrasize");
-        CPLFree(dbuff);  // Safe to call with NULL
-        return nullptr;
-    }
 
     // source size is used to hold the output size
     src.size = dst.size;


### PR DESCRIPTION
## What does this PR do?
When data is not compressible by DEFLATE, a slight increase happens, which is not an error. Output buffer overflow is not possible either, since DEFLATE is given the correct output buffer size available.