### PR TITLE
gdalwarp / ogr2ogr: emit a warning if different coordinate operations are used during reprojection

### DIFF
--- a/alg/gdal_alg.h
+++ b/alg/gdal_alg.h
@@ -109,6 +109,8 @@ void *GDALCreateSimilarTransformer(void *psTransformerArg, double dfSrcRatioX,
    to image coordinates on another, potentially doing reprojection,
    utilizing GCPs or using the geotransform. */
 
+const char CPL_DLL *GDALGetGenImgProjTranformerOptionList(void);
+
 void CPL_DLL *
 GDALCreateGenImgProjTransformer(GDALDatasetH hSrcDS, const char *pszSrcWKT,
                                 GDALDatasetH hDstDS, const char *pszDstWKT,

--- a/alg/gdal_alg_priv.h
+++ b/alg/gdal_alg_priv.h
@@ -157,6 +157,8 @@ constexpr const char *GDAL_APPROX_TRANSFORMER_CLASS_NAME =
 constexpr const char *GDAL_GEN_IMG_TRANSFORMER_CLASS_NAME =
     "GDALGenImgProjTransformer";
 constexpr const char *GDAL_RPC_TRANSFORMER_CLASS_NAME = "GDALRPCTransformer";
+constexpr const char *GDAL_REPROJECTION_TRANSFORMER_CLASS_NAME =
+    "GDALReprojectionTransformer";
 
 bool GDALIsTransformer(void *hTransformerArg, const char *pszClassName);
 
@@ -270,6 +272,33 @@ struct GDALReprojectionTransformInfo
         delete;
     GDALReprojectionTransformInfo &
     operator=(const GDALReprojectionTransformInfo &) = delete;
+};
+
+/************************************************************************/
+/* ==================================================================== */
+/*      Approximate transformer.                                        */
+/* ==================================================================== */
+/************************************************************************/
+
+struct GDALApproxTransformInfo
+{
+    GDALTransformerInfo sTI;
+
+    GDALTransformerFunc pfnBaseTransformer = nullptr;
+    void *pBaseCBData = nullptr;
+    double dfMaxErrorForward = 0;
+    double dfMaxErrorReverse = 0;
+
+    int bOwnSubtransformer = 0;
+
+    GDALApproxTransformInfo() : sTI()
+    {
+        memset(&sTI, 0, sizeof(sTI));
+    }
+
+    GDALApproxTransformInfo(const GDALApproxTransformInfo &) = delete;
+    GDALApproxTransformInfo &
+    operator=(const GDALApproxTransformInfo &) = delete;
 };
 
 /************************************************************************/

--- a/alg/gdalwarper.h
+++ b/alg/gdalwarper.h
@@ -255,6 +255,8 @@ typedef struct
     GWKTieStrategy eTieStrategy;
 } GDALWarpOptions;
 
+const char CPL_DLL *GDALWarpGetOptionList(void);
+
 GDALWarpOptions CPL_DLL *CPL_STDCALL GDALCreateWarpOptions(void);
 void CPL_DLL CPL_STDCALL GDALDestroyWarpOptions(GDALWarpOptions *);
 GDALWarpOptions CPL_DLL *CPL_STDCALL

--- a/alg/gdalwarpoperation.cpp
+++ b/alg/gdalwarpoperation.cpp
@@ -375,6 +375,19 @@ int GDALWarpOperation::ValidateOptions()
         return FALSE;
     }
 
+    {
+        CPLStringList aosWO(CSLDuplicate(psOptions->papszWarpOptions));
+        // A few internal/undocumented options
+        aosWO.SetNameValue("EXTRA_ELTS", nullptr);
+        aosWO.SetNameValue("USE_GENERAL_CASE", nullptr);
+        aosWO.SetNameValue("ERROR_THRESHOLD", nullptr);
+        aosWO.SetNameValue("ERROR_OUT_IF_EMPTY_SOURCE_WINDOW", nullptr);
+        aosWO.SetNameValue("MULT_FACTOR_VERTICAL_SHIFT_PIPELINE", nullptr);
+        aosWO.SetNameValue("SRC_FILL_RATIO_HEURISTICS", nullptr);
+        GDALValidateOptions(GDALWarpGetOptionList(), aosWO.List(), "option",
+                            "warp options");
+    }
+
     const char *pszSampleSteps =
         CSLFetchNameValue(psOptions->papszWarpOptions, "SAMPLE_STEPS");
     if (pszSampleSteps)

--- a/apps/gdalalg_raster_reproject.cpp
+++ b/apps/gdalalg_raster_reproject.cpp
@@ -12,8 +12,10 @@
 
 #include "gdalalg_raster_reproject.h"
 
+#include "gdal_alg.h"
 #include "gdal_priv.h"
 #include "gdal_utils.h"
+#include "gdalwarper.h"
 
 #include <cmath>
 
@@ -115,14 +117,41 @@ GDALRasterReprojectAlgorithm::GDALRasterReprojectAlgorithm(bool standaloneStep)
              "raster have none."),
            &m_addAlpha)
         .SetCategory(GAAC_ADVANCED);
-    AddArg("warp-option", 0, _("Warping option(s)"), &m_warpOptions)
-        .AddAlias("wo")
-        .SetMetaVar("<NAME>=<VALUE>")
-        .SetCategory(GAAC_ADVANCED);
-    AddArg("transform-option", 0, _("Transform option(s)"), &m_transformOptions)
-        .AddAlias("to")
-        .SetMetaVar("<NAME>=<VALUE>")
-        .SetCategory(GAAC_ADVANCED);
+    {
+        auto &arg =
+            AddArg("warp-option", 0, _("Warping option(s)"), &m_warpOptions)
+                .AddAlias("wo")
+                .SetMetaVar("<NAME>=<VALUE>")
+                .SetCategory(GAAC_ADVANCED);
+        arg.AddValidationAction([this, &arg]()
+                                { return ValidateKeyValue(arg); });
+        arg.SetAutoCompleteFunction(
+            [](const std::string &currentValue)
+            {
+                std::vector<std::string> ret;
+                GDALAlgorithm::AddOptionsSuggestions(GDALWarpGetOptionList(), 0,
+                                                     currentValue, ret);
+                return ret;
+            });
+    }
+    {
+        auto &arg = AddArg("transform-option", 0, _("Transform option(s)"),
+                           &m_transformOptions)
+                        .AddAlias("to")
+                        .SetMetaVar("<NAME>=<VALUE>")
+                        .SetCategory(GAAC_ADVANCED);
+        arg.AddValidationAction([this, &arg]()
+                                { return ValidateKeyValue(arg); });
+        arg.SetAutoCompleteFunction(
+            [](const std::string &currentValue)
+            {
+                std::vector<std::string> ret;
+                GDALAlgorithm::AddOptionsSuggestions(
+                    GDALGetGenImgProjTranformerOptionList(), 0, currentValue,
+                    ret);
+                return ret;
+            });
+    }
     AddArg("error-threshold", 0, _("Error threshold"), &m_errorThreshold)
         .AddAlias("et")
         .SetCategory(GAAC_ADVANCED);

--- a/autotest/alg/warp.py
+++ b/autotest/alg/warp.py
@@ -28,6 +28,8 @@ pytestmark = pytest.mark.skipif(
     reason="VRT driver open missing",
 )
 
+from lxml import etree
+
 from osgeo import gdal, osr
 
 ###############################################################################
@@ -1708,7 +1710,8 @@ def test_warp_mode_ties(tie_strategy, dtype):
     src_ds.SetGeoTransform([1, 1, 0, 1, 0, 1])
     src_ds.GetRasterBand(1).WriteArray(numpy.array([[1, 1, 1], [2, 3, 4], [5, 5, 5]]))
 
-    with gdaltest.disable_exceptions():
+    with gdaltest.disable_exceptions(), gdal.quiet_errors():
+        gdal.ErrorReset()
         out_ds = gdal.Warp(
             "",
             src_ds,
@@ -1720,6 +1723,10 @@ def test_warp_mode_ties(tie_strategy, dtype):
         )
 
     if tie_strategy == "HOPE":
+        assert (
+            gdal.GetLastErrorMsg()
+            == "'HOPE' is an unexpected value for MODE_TIES option of type string-select."
+        )
         assert out_ds is None
         return
 
@@ -2028,3 +2035,80 @@ def test_warp_multi_threaded_errors(tmp_vsimem):
     with gdal.Open(vrt_filename) as ds:
         with pytest.raises(Exception):
             gdal.Warp("", ds, format="MEM", multithread=True)
+
+
+###############################################################################
+
+
+schema_optionlist = etree.XML(
+    r"""
+<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <xs:element name="Value">
+    <xs:complexType>
+      <xs:simpleContent>
+        <xs:extension base="xs:string">
+          <xs:attribute type="xs:string" name="alias" use="optional"/>
+        </xs:extension>
+      </xs:simpleContent>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="Option">
+    <xs:complexType mixed="true">
+      <xs:sequence>
+        <xs:element ref="Value" maxOccurs="unbounded" minOccurs="0"/>
+      </xs:sequence>
+      <xs:attribute name="name" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:pattern value="[^\s]*"/>
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute name="type" use="required">
+        <xs:simpleType>
+          <xs:restriction base="xs:string">
+            <xs:enumeration value="int" />
+            <xs:enumeration value="float" />
+            <xs:enumeration value="boolean" />
+            <xs:enumeration value="string-select" />
+            <xs:enumeration value="string" />
+          </xs:restriction>
+        </xs:simpleType>
+      </xs:attribute>
+      <xs:attribute type="xs:string" name="description" use="optional"/>
+      <xs:attribute type="xs:string" name="default" use="optional"/>
+      <xs:attribute type="xs:string" name="alias" use="optional"/>
+      <xs:attribute type="xs:string" name="min" use="optional"/>
+      <xs:attribute type="xs:string" name="max" use="optional"/>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="OptionList">
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element ref="Option" maxOccurs="unbounded" minOccurs="0"/>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
+</xs:schema>
+"""
+)
+
+
+def test_warp_validate_options():
+
+    if (
+        gdaltest.is_travis_branch("mingw64")
+        or gdaltest.is_travis_branch("build-windows-conda")
+        or gdaltest.is_travis_branch("build-windows-minimum")
+    ):
+        pytest.skip("Crashes for unknown reason")
+
+    schema = etree.XMLSchema(schema_optionlist)
+
+    xml = gdal.WarpGetOptionList()
+    try:
+        parser = etree.XMLParser(schema=schema)
+        etree.fromstring(xml, parser)
+    except Exception:
+        print(xml)
+        raise

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -4461,3 +4461,30 @@ def test_gdalwarp_lib_only_best_yes():
             dstSRS="EPSG:4326",  # WGS 84
             transformerOptions={"ALLOW_BALLPARK": "NO", "ONLY_BEST": "YES"},
         )
+
+
+###############################################################################
+# Test that we warn if different coordinate operations are used
+
+
+@gdaltest.disable_exceptions()
+@pytest.mark.require_proj(9, 1)
+def test_gdalwarp_lib_warn_different_coordinate_operations():
+    src_ds = gdal.GetDriverByName("MEM").Create("", 10, 10)
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(4267)  # NAD27
+    srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+    src_ds.SetSpatialRef(srs)
+    src_ds.SetGeoTransform([-100, 2, 0, 60, 0, -2])
+
+    with gdal.quiet_errors():
+        gdal.Warp(
+            "",
+            src_ds,
+            format="MEM",
+            dstSRS="EPSG:4326",  # WGS 84
+        )
+        assert (
+            gdal.GetLastErrorMsg()
+            == "Several coordinate operations are going to be used. Artifacts may appear. You may consider using the -wo ALLOW_BALLPARK=NO and/or -wo ONLY_BEST=YES warping options, or specify a particular coordinate operation with -ct"
+        )

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -4414,3 +4414,24 @@ def test_gdalwarp_lib_init_dest_no_source_window_mem():
     assert ds.GetRasterBand(1).GetNoDataValue() == 255
     ds.GetRasterBand(1).SetNoDataValue(0)
     assert ds.GetRasterBand(1).ComputeRasterMinMax() == (255, 255)
+
+
+###############################################################################
+# Test ALLOW_BALLPARK=NO transformer option
+
+
+def test_gdalwarp_lib_allow_ballpark_no():
+
+    src_ds = gdal.Open("../gcore/data/byte.tif")
+
+    with pytest.raises(
+        Exception,
+        match="Cannot find coordinate operations from `EPSG:26711' to `EPSG:4258'",
+    ):
+        gdal.Warp(
+            "",
+            src_ds,
+            format="MEM",
+            dstSRS="EPSG:4258",  # ETRS89
+            transformerOptions={"ALLOW_BALLPARK": "NO"},
+        )

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -4435,3 +4435,29 @@ def test_gdalwarp_lib_allow_ballpark_no():
             dstSRS="EPSG:4258",  # ETRS89
             transformerOptions={"ALLOW_BALLPARK": "NO"},
         )
+
+
+###############################################################################
+# Test ONLY_BEST=YES transformer option
+
+
+def test_gdalwarp_lib_only_best_yes():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 2, 2)
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(4746)  # PD/83
+    srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+    src_ds.SetSpatialRef(srs)
+    src_ds.SetGeoTransform([15, 1, 0, 47, 0, -1])
+
+    with pytest.raises(
+        Exception,
+        match="Cannot find coordinate operations from `EPSG:4746' to `EPSG:4326'",
+    ):
+        gdal.Warp(
+            "",
+            src_ds,
+            format="MEM",
+            dstSRS="EPSG:4326",  # WGS 84
+            transformerOptions={"ALLOW_BALLPARK": "NO", "ONLY_BEST": "YES"},
+        )

--- a/autotest/utilities/test_ogr2ogr_lib.py
+++ b/autotest/utilities/test_ogr2ogr_lib.py
@@ -3206,7 +3206,6 @@ def test_ogr2ogr_lib_datetime_in_shapefile(tmp_vsimem, OGR2OGR_USE_ARROW_API):
     else:
         assert "OGR2OGR: Using WriteArrowBatch()" not in got_msg
 
-    print(got_msg)
     assert "Field dt created as String field, though DateTime requested." in got_msg
 
     with ogr.Open(out_filename) as dst_ds:

--- a/autotest/utilities/test_ogr2ogr_lib.py
+++ b/autotest/utilities/test_ogr2ogr_lib.py
@@ -3211,3 +3211,62 @@ def test_ogr2ogr_lib_datetime_in_shapefile(tmp_vsimem, OGR2OGR_USE_ARROW_API):
     with ogr.Open(out_filename) as dst_ds:
         dst_lyr = dst_ds.GetLayer(0)
         assert [f.GetField("dt") for f in dst_lyr] == ["2022-05-31T12:34:56.789+05:30"]
+
+
+###############################################################################
+# Test that we warn if different coordinate operations are used
+
+
+@gdaltest.disable_exceptions()
+@pytest.mark.require_proj(9, 1)
+@pytest.mark.parametrize("source_format", ["Memory", "GPKG"])
+def test_ogr2ogr_lib_warn_different_coordinate_operations(tmp_vsimem, source_format):
+
+    if gdal.GetDriverByName(source_format) is None:
+        pytest.skip(f"Skipping as {source_format} is not available")
+
+    src_ds = gdal.GetDriverByName("Memory").Create("", 0, 0, 0, gdal.GDT_Unknown)
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(4267)  # NAD27
+    srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+    src_lyr = src_ds.CreateLayer("test", srs=srs)
+    f = ogr.Feature(src_lyr.GetLayerDefn())
+    f.SetGeometryDirectly(ogr.CreateGeometryFromWkt("POINT(-100 60)"))
+    src_lyr.CreateFeature(f)
+    f = ogr.Feature(src_lyr.GetLayerDefn())
+    f.SetGeometryDirectly(ogr.CreateGeometryFromWkt("POINT(-70 40)"))
+    src_lyr.CreateFeature(f)
+
+    if source_format == "GPKG":
+        src_ds = gdal.VectorTranslate(tmp_vsimem / "tmp.gpkg", src_ds)
+
+    with gdal.quiet_errors():
+        gdal.VectorTranslate(
+            "",
+            src_ds,
+            format="Memory",
+            dstSRS="EPSG:4326",  # WGS 84
+        )
+        assert gdal.GetLastErrorMsg().startswith(
+            "Several coordinate operations have been used to transform layer test."
+        )
+
+    gdal.ErrorReset()
+    gdal.VectorTranslate(
+        "",
+        src_ds,
+        format="Memory",
+        dstSRS="EPSG:4326",  # WGS 84
+        coordinateOperationOptions={"WARN_ABOUT_DIFFERENT_COORD_OP": "NO"},
+    )
+    assert gdal.GetLastErrorMsg() == ""
+
+    # Try ALLOW_BALLPARK and ONLY_BEST options
+    with gdal.quiet_errors():
+        gdal.VectorTranslate(
+            "",
+            src_ds,
+            format="Memory",
+            dstSRS="EPSG:4326",  # WGS 84
+            coordinateOperationOptions=["ALLOW_BALLPARK=NO", "ONLY_BEST=YES"],
+        )

--- a/doc/source/programs/ogr2ogr.rst
+++ b/doc/source/programs/ogr2ogr.rst
@@ -288,6 +288,8 @@ output coordinate system or even reprojecting the features during translation.
 
 .. option:: -ct <string>
 
+    .. versionadded:: 3.0
+
     A PROJ string (single step operation or multiple step string starting with
     +proj=pipeline), a WKT2 string describing a CoordinateOperation, or a
     urn:ogc:def:coordinateOperation:EPSG::XXXX URN overriding the default
@@ -298,7 +300,40 @@ output coordinate system or even reprojecting the features during translation.
     the pipeline if the source CRS has northing/easting axis order, and/or at
     the end of the pipeline if the target CRS has northing/easting axis order.
 
-    .. versionadded:: 3.0
+.. option:: -ct_opt <NAME>=<VALUE>
+
+    .. versionadded:: 3.11
+
+    Specify a coordinate operation option that influences how PROJ selects
+    coordinate operations when :option:`-ct` is *not* set.
+
+    The following options are available:
+
+    - ``ONLY_BEST``=``YES``/``NO``. By default (at least in the PROJ 9.x series), PROJ may use
+      coordinate operations that are not the "best" if resources
+      (typically grids) needed to use them are missing. It will then
+      fallback to other coordinate operations that have a lesser
+      accuracy, for example using Helmert transformations, or in the
+      absence of such operations, to ones with potential very rough
+      accuracy, using "ballpark" transformations (see
+      https://proj.org/glossary.html).
+      When calling this method with YES, PROJ will only consider the
+      "best" operation, and error out (at Transform() time) if they
+      cannot be used. This method may be used together with
+      ``ALLOW_BALLPARK``=``NO`` to only allow best operations that have a known
+      accuracy. Note that this method has no effect on PROJ versions
+      before 9.2. The default value for this option can be also set with
+      the ``PROJ_ONLY_BEST_DEFAULT`` environment variable, or with the
+      ``only_best_default`` setting of proj.ini. Setting
+      ONLY_BEST=YES/NO overrides such default value.
+
+    - ``ALLOW_BALLPARK``=``YES``/``NO``. Whether ballpark coordinate operations are
+      allowed. Default is YES.
+
+    - ``WARN_ABOUT_DIFFERENT_COORD_OP``=``YES``/``NO``. Can be set to NO to avoid GDAL
+      warning when different coordinate operations are used to transform the
+      different geometries of the dataset (or part of the same geometry).
+      Default is YES.
 
 .. option:: -preserve_fid
 

--- a/ogr/ogrct.cpp
+++ b/ogr/ogrct.cpp
@@ -29,6 +29,7 @@
 #include "ogr_core.h"
 #include "ogr_srs_api.h"
 #include "ogr_proj_p.h"
+#include "ogrct_priv.h"
 
 #include "proj.h"
 #include "proj_experimental.h"
@@ -653,6 +654,13 @@ int OCTCoordinateTransformationOptionsSetOnlyBest(
 //! @cond Doxygen_Suppress
 class OGRProjCT : public OGRCoordinateTransformation
 {
+    friend void
+    OGRProjCTDifferentOperationsStart(OGRCoordinateTransformation *poCT);
+    friend void
+    OGRProjCTDifferentOperationsStop(OGRCoordinateTransformation *poCT);
+    friend bool
+    OGRProjCTDifferentOperationsUsed(OGRCoordinateTransformation *poCT);
+
     class PjPtr
     {
         PJ *m_pj = nullptr;
@@ -793,6 +801,10 @@ class OGRProjCT : public OGRCoordinateTransformation
     int m_iCurTransformation = -1;
     OGRCoordinateTransformationOptions m_options{};
 
+    bool m_recordDifferentOperationsUsed = false;
+    std::string m_lastPjUsedPROJString{};
+    bool m_differentOperationsUsed = false;
+
     void ComputeThreshold();
     void DetectWebMercatorToWGS84();
 
@@ -854,6 +866,66 @@ class OGRProjCT : public OGRCoordinateTransformation
                   const OGRSpatialReference *poTarget, const char *pszTargetSRS,
                   const OGRCoordinateTransformationOptions &options);
 };
+
+/************************************************************************/
+/*                   OGRProjCTDifferentOperationsStart()                */
+/************************************************************************/
+
+void OGRProjCTDifferentOperationsStart(OGRCoordinateTransformation *poCT)
+{
+    auto poOGRCT = dynamic_cast<OGRProjCT *>(poCT);
+    if (poOGRCT)
+    {
+        poOGRCT->m_recordDifferentOperationsUsed = true;
+        poOGRCT->m_differentOperationsUsed = false;
+        poOGRCT->m_lastPjUsedPROJString.clear();
+    }
+    else
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "OGRProjCTDifferentOperationsStart() called with a non "
+                 "OGRProjCT instance");
+    }
+}
+
+/************************************************************************/
+/*                   OGRProjCTDifferentOperationsStop()                 */
+/************************************************************************/
+
+void OGRProjCTDifferentOperationsStop(OGRCoordinateTransformation *poCT)
+{
+    auto poOGRCT = dynamic_cast<OGRProjCT *>(poCT);
+    if (poOGRCT)
+    {
+        poOGRCT->m_recordDifferentOperationsUsed = false;
+    }
+    else
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "OGRProjCTDifferentOperationsStop() called with a non "
+                 "OGRProjCT instance");
+    }
+}
+
+/************************************************************************/
+/*                   OGRProjCTDifferentOperationsUsed()                 */
+/************************************************************************/
+
+bool OGRProjCTDifferentOperationsUsed(OGRCoordinateTransformation *poCT)
+{
+    auto poOGRCT = dynamic_cast<OGRProjCT *>(poCT);
+    if (poOGRCT)
+    {
+        return poOGRCT->m_differentOperationsUsed;
+    }
+    else
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "OGRProjCTDifferentOperationsReset() called with a non "
+                 "OGRProjCT instance");
+        return false;
+    }
+}
 
 //! @endcond
 
@@ -1266,7 +1338,8 @@ OGRProjCT::OGRProjCT(const OGRProjCT &other)
       m_eStrategy(other.m_eStrategy),
       m_oTransformations(other.m_oTransformations),
       m_iCurTransformation(other.m_iCurTransformation),
-      m_options(other.m_options)
+      m_options(other.m_options), m_recordDifferentOperationsUsed(false),
+      m_lastPjUsedPROJString(std::string()), m_differentOperationsUsed(false)
 {
 }
 
@@ -2732,20 +2805,51 @@ int OGRProjCT::TransformWithErrorCodes(size_t nCount, double *x, double *y,
                 if (err == 0)
                     err = PROJ_ERR_COORD_TRANSFM_OUTSIDE_PROJECTION_DOMAIN;
             }
-            else if (m_options.d->bCheckWithInvertProj)
+            else
             {
-                // For some projections, we cannot detect if we are trying to
-                // reproject coordinates outside the validity area of the
-                // projection. So let's do the reverse reprojection and compare
-                // with the source coordinates.
-                coord = proj_trans(pj, m_bReversePj ? PJ_FWD : PJ_INV, coord);
-                if (fabs(coord.xyzt.x - xIn) > dfThreshold ||
-                    fabs(coord.xyzt.y - yIn) > dfThreshold)
+                if (m_recordDifferentOperationsUsed &&
+                    !m_differentOperationsUsed)
                 {
-                    bRet = FALSE;
-                    err = PROJ_ERR_COORD_TRANSFM_OUTSIDE_PROJECTION_DOMAIN;
-                    x[i] = HUGE_VAL;
-                    y[i] = HUGE_VAL;
+#if PROJ_VERSION_MAJOR > 9 ||                                                  \
+    (PROJ_VERSION_MAJOR == 9 && PROJ_VERSION_MINOR >= 1)
+
+                    PJ *lastOp = proj_trans_get_last_used_operation(pj);
+                    if (lastOp)
+                    {
+                        const char *projString = proj_as_proj_string(
+                            ctx, lastOp, PJ_PROJ_5, nullptr);
+                        if (projString)
+                        {
+                            if (m_lastPjUsedPROJString.empty())
+                            {
+                                m_lastPjUsedPROJString = projString;
+                            }
+                            else if (m_lastPjUsedPROJString != projString)
+                            {
+                                m_differentOperationsUsed = true;
+                            }
+                        }
+                        proj_destroy(lastOp);
+                    }
+#endif
+                }
+
+                if (m_options.d->bCheckWithInvertProj)
+                {
+                    // For some projections, we cannot detect if we are trying to
+                    // reproject coordinates outside the validity area of the
+                    // projection. So let's do the reverse reprojection and compare
+                    // with the source coordinates.
+                    coord =
+                        proj_trans(pj, m_bReversePj ? PJ_FWD : PJ_INV, coord);
+                    if (fabs(coord.xyzt.x - xIn) > dfThreshold ||
+                        fabs(coord.xyzt.y - yIn) > dfThreshold)
+                    {
+                        bRet = FALSE;
+                        err = PROJ_ERR_COORD_TRANSFM_OUTSIDE_PROJECTION_DOMAIN;
+                        x[i] = HUGE_VAL;
+                        y[i] = HUGE_VAL;
+                    }
                 }
             }
 

--- a/ogr/ogrct.cpp
+++ b/ogr/ogrct.cpp
@@ -602,7 +602,7 @@ int OCTCoordinateTransformationOptionsSetBallparkAllowed(
  * operations that are not the "best" if resources (typically grids) needed
  * to use them are missing. It will then fallback to other coordinate operations
  * that have a lesser accuracy, for example using Helmert transformations,
- * or in the absence of such operations, to ones with potential very rought
+ * or in the absence of such operations, to ones with potential very rough
  * accuracy, using "ballpark" transformations
  * (see https://proj.org/glossary.html).
  *

--- a/ogr/ogrct_priv.h
+++ b/ogr/ogrct_priv.h
@@ -1,0 +1,25 @@
+/******************************************************************************
+ *
+ * Project:  GDAL
+ * Purpose:  Header for methods of OGRCoordinateTransformation only for GDAL
+ *           internal use.
+ * Author:   Even Rouault <even dot rouault at spatialys.com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2025, Even Rouault <even dot rouault at spatialys.com>
+ *
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#ifndef OGRCT_PRIV_H_INCLUDED
+#define OGRCT_PRIV_H_INCLUDED
+
+#include "ogr_spatialref.h"
+
+void OGRProjCTDifferentOperationsStart(OGRCoordinateTransformation *poCT);
+
+void OGRProjCTDifferentOperationsStop(OGRCoordinateTransformation *poCT);
+
+bool OGRProjCTDifferentOperationsUsed(OGRCoordinateTransformation *poCT);
+
+#endif  // OGRCT_PRIV_H_INCLUDED

--- a/swig/include/Operations.i
+++ b/swig/include/Operations.i
@@ -828,6 +828,8 @@ public:
 %}
 #endif
 
+%rename (WarpGetOptionList) GDALWarpGetOptionList;
+const char* GDALWarpGetOptionList();
 
 /************************************************************************/
 /*                        SuggestedWarpOutput()                         */

--- a/swig/include/Operations.i
+++ b/swig/include/Operations.i
@@ -709,6 +709,9 @@ GDALDatasetShadow*  CreatePansharpenedVRT( const char* pszXML,
 /*                             Transformer                              */
 /************************************************************************/
 
+%rename (GetTranformerOptionList) GDALGetGenImgProjTranformerOptionList;
+const char* GDALGetGenImgProjTranformerOptionList();
+
 #ifndef SWIGPYTHON
 %rename (Transformer) GDALTransformerInfoShadow;
 #endif

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -3078,6 +3078,7 @@ def VectorTranslateOptions(options=None, format=None,
          accessMode=None,
          srcSRS=None, dstSRS=None, reproject=True,
          coordinateOperation=None,
+         coordinateOperationOptions=None,
          SQLStatement=None, SQLDialect=None, where=None, selectFields=None,
          addFields=False,
          relaxedFieldNameMatch=False,
@@ -3134,6 +3135,8 @@ def VectorTranslateOptions(options=None, format=None,
         output SRS (with reprojection if reproject = True)
     coordinateOperation:
         coordinate operation as a PROJ string or WKT string
+    coordinateOperationOptions:
+        list or dict of coordinate operation options (ALLOW_BALLPARK=NO, ONLY_BEST=YES, WARN_ABOUT_DIFFERENT_COORD_OP=NO)
     reproject:
         whether to do reprojection
     SQLStatement:
@@ -3276,6 +3279,15 @@ def VectorTranslateOptions(options=None, format=None,
                 new_options += ['-a_srs', str(dstSRS)]
         if coordinateOperation is not None:
             new_options += ['-ct', coordinateOperation]
+
+        if coordinateOperationOptions is not None:
+            if isinstance(coordinateOperationOptions, dict):
+                for k, v in coordinateOperationOptions.items():
+                    new_options += ['-ct_opt', f'{k}={v}']
+            else:
+                for opt in coordinateOperationOptions:
+                    new_options += ['-ct_opt', opt]
+
         if SQLStatement is not None:
             new_options += ['-sql', str(SQLStatement)]
         if SQLDialect is not None:


### PR DESCRIPTION
and add options to set PROJ's ALLOW_BALLPARK=NO and ONLY_BEST=YES

Fixes #11945