### PR TITLE
/vsicurl/: add GDAL_HTTP_MAX_CACHED_CONNECTIONS and GDAL_HTTP_MAX_TOTAL_CONNECTIONS config options

### DIFF
--- a/autotest/gcore/vsicurl.py
+++ b/autotest/gcore/vsicurl.py
@@ -1636,3 +1636,45 @@ def test_vsicurl_header_option(server):
         full_filename = f"/vsicurl?header.foo=bar&header.Accept=application%2Fjson&url=http%3A%2F%2Flocalhost%3A{server.port}%2Ftest_vsicurl_header_option.bin"
         statres = gdal.VSIStatL(full_filename)
         assert statres.size == 3
+
+
+###############################################################################
+# Test GDAL_HTTP_MAX_CACHED_CONNECTIONS
+# This test is rather dummy as it cannot check the effect of setting the option
+
+
+@gdaltest.enable_exceptions()
+def test_vsicurl_GDAL_HTTP_MAX_CACHED_CONNECTIONS(server):
+
+    gdal.VSICurlClearCache()
+
+    handler = webserver.SequentialHandler()
+    handler.add("HEAD", "/test.bin", 200, {"Content-Length": "3"})
+
+    with gdal.config_option(
+        "GDAL_HTTP_MAX_CACHED_CONNECTIONS", "0"
+    ), webserver.install_http_handler(handler):
+        full_filename = f"/vsicurl/http://localhost:{server.port}/test.bin"
+        statres = gdal.VSIStatL(full_filename)
+        assert statres.size == 3
+
+
+###############################################################################
+# Test GDAL_HTTP_MAX_TOTAL_CONNECTIONS
+# This test is rather dummy as it cannot check the effect of setting the option
+
+
+@gdaltest.enable_exceptions()
+def test_vsicurl_GDAL_HTTP_MAX_TOTAL_CONNECTIONS(server):
+
+    gdal.VSICurlClearCache()
+
+    handler = webserver.SequentialHandler()
+    handler.add("HEAD", "/test.bin", 200, {"Content-Length": "3"})
+
+    with gdal.config_option(
+        "GDAL_HTTP_MAX_TOTAL_CONNECTIONS", "0"
+    ), webserver.install_http_handler(handler):
+        full_filename = f"/vsicurl/http://localhost:{server.port}/test.bin"
+        statres = gdal.VSIStatL(full_filename)
+        assert statres.size == 3

--- a/doc/source/user/configoptions.rst
+++ b/doc/source/user/configoptions.rst
@@ -954,6 +954,18 @@ Networking options
       http://curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXYAUTH for more
       information.
 
+-  .. config:: GDAL_HTTP_MAX_CACHED_CONNECTIONS
+      :since: 3.11
+
+      Maximum amount of connections that libcurl may keep alive in its connection
+      cache after use. Cf https://curl.se/libcurl/c/CURLMOPT_MAXCONNECTS.html
+
+-  .. config:: GDAL_HTTP_MAX_TOTAL_CONNECTIONS
+      :since: 3.11
+
+      Maximum number of simultaneously open connections in total.
+      Cf https://curl.se/libcurl/c/CURLMOPT_MAX_TOTAL_CONNECTIONS.html
+
 -  .. config:: CPL_CURL_GZIP
       :choices: YES, NO
 

--- a/doc/source/user/virtual_file_systems.rst
+++ b/doc/source/user/virtual_file_systems.rst
@@ -444,6 +444,11 @@ More generally options of :cpp:func:`CPLHTTPFetch` available through configurati
 Starting with GDAL 3.7, the above configuration options can also be specified
 as path-specific options with :cpp:func:`VSISetPathSpecificOption`.
 
+Starting with GDAL 3.11, the following configuration options control the number of HTTP connections:
+
+- :config:`GDAL_HTTP_MAX_CACHED_CONNECTIONS` = integer_number. Maximum amount of connections that libcurl may keep alive in its connection cache after use. Cf https://curl.se/libcurl/c/CURLMOPT_MAXCONNECTS.html
+- :config:`GDAL_HTTP_MAX_TOTAL_CONNECTIONS` = integer_number. Maximum number of simultaneously open connections in total. Cf https://curl.se/libcurl/c/CURLMOPT_MAX_TOTAL_CONNECTIONS.html
+
 The file can be cached in RAM by setting the configuration option :config:`VSI_CACHE` to ``TRUE``. The cache size defaults to 25 MB, but can be modified by setting the configuration option :config:`VSI_CACHE_SIZE` (in bytes). Content in that cache is discarded when the file handle is closed.
 
 Starting with GDAL 2.3, the :config:`CPL_VSIL_CURL_NON_CACHED` configuration option can be set to values like :file:`/vsicurl/http://example.com/foo.tif:/vsicurl/http://example.com/some_directory`, so that at file handle closing, all cached content related to the mentioned file(s) is no longer cached. This can help when dealing with resources that can be modified during execution of GDAL related code. Alternatively, :cpp:func:`VSICurlClearCache` can be used.

--- a/port/cpl_known_config_options.h
+++ b/port/cpl_known_config_options.h
@@ -283,7 +283,9 @@ constexpr static const char* const apszKnownConfigOptions[] =
    "GDAL_HTTP_KEYPASSWD", // from cpl_http.cpp
    "GDAL_HTTP_LOW_SPEED_LIMIT", // from cpl_http.cpp
    "GDAL_HTTP_LOW_SPEED_TIME", // from cpl_http.cpp
+   "GDAL_HTTP_MAX_CACHED_CONNECTIONS", // from cpl_vsil_curl.cpp
    "GDAL_HTTP_MAX_RETRY", // from cpl_http.cpp
+   "GDAL_HTTP_MAX_TOTAL_CONNECTIONS", // from cpl_vsil_curl.cpp
    "GDAL_HTTP_MERGE_CONSECUTIVE_RANGES", // from cpl_vsil_curl.cpp
    "GDAL_HTTP_MULTIPLEX", // from cpl_vsil_curl.cpp
    "GDAL_HTTP_MULTIRANGE", // from cpl_vsil_curl.cpp

--- a/port/cpl_vsil_curl_class.h
+++ b/port/cpl_vsil_curl_class.h
@@ -430,6 +430,7 @@ class VSICurlHandle : public VSIVirtualHandle
 
     std::vector<std::unique_ptr<AdviseReadRange>> m_aoAdviseReadRanges{};
     std::thread m_oThreadAdviseRead{};
+    CURLM *m_hCurlMultiHandleForAdviseRead = nullptr;
 
   protected:
     virtual struct curl_slist *


### PR DESCRIPTION
- GDAL_HTTP_MAX_CACHED_CONNECTIONS corresponds to https://curl.se/libcurl/c/CURLMOPT_MAXCONNECTS.html
- GDAL_HTTP_MAX_TOTAL_CONNECTIONS corresponds to https://curl.se/libcurl/c/CURLMOPT_MAX_TOTAL_CONNECTIONS.html
    
Fixes #11855
