### PR TITLE
Fix read out of bounds in GDALInterpolateAtPoint

### DIFF
--- a/alg/gdal_interpolateatpoint.cpp
+++ b/alg/gdal_interpolateatpoint.cpp
@@ -174,9 +174,9 @@ bool GDALInterpolateAtPointImpl(GDALRasterBand *pBand,
         // Allow input coordinates right at the bottom or right edge
         // with GRIORA_NearestNeighbour.
         // "introduce" them in the pixel of the image.
-        if (dfXIn == rasterSize.x())
+        if (dfXIn >= rasterSize.x() && dfXIn <= rasterSize.x() + 1e-5)
             dfXIn -= 0.25;
-        if (dfYIn == rasterSize.y())
+        if (dfYIn >= rasterSize.y() && dfYIn <= rasterSize.y() + 1e-5)
             dfYIn -= 0.25;
     }
     const gdal::Vector2d inLoc{dfXIn, dfYIn};

--- a/alg/gdal_interpolateatpoint.cpp
+++ b/alg/gdal_interpolateatpoint.cpp
@@ -178,6 +178,11 @@ bool GDALInterpolateAtPointImpl(GDALRasterBand *pBand,
     {
         return FALSE;
     }
+    if (eResampleAlg == GRIORA_NearestNeighbour &&
+        (inLoc.x() == rasterSize.x() || inLoc.y() == rasterSize.y()))
+    {
+        return FALSE;
+    }
 
     // Downgrade the interpolation algorithm if the image is too small
     if ((rasterSize.x() < 4 || rasterSize.y() < 4) &&

--- a/alg/gdal_interpolateatpoint.cpp
+++ b/alg/gdal_interpolateatpoint.cpp
@@ -124,13 +124,20 @@ bool GDALInterpExtractValuesWindow(GDALRasterBand *pBand,
             // Compose the cached block to the final buffer
             for (int j = 0; j < nLinesToCopy; j++)
             {
-                memcpy(padfAsDouble + ((nFirstLineInOutput + j) * nWidth +
-                                       nFirstColInOutput) *
-                                          nTypeFactor,
-                       poValue->data() +
-                           ((nFirstLineInCachedBlock + j) * nReqXSize +
-                            nFirstColInCachedBlock) *
-                               nTypeFactor,
+                const size_t dstOffset =
+                    (static_cast<size_t>(nFirstLineInOutput + j) * nWidth +
+                     nFirstColInOutput) *
+                    nTypeFactor;
+                const size_t srcOffset =
+                    (static_cast<size_t>(nFirstLineInCachedBlock + j) *
+                         nReqXSize +
+                     nFirstColInCachedBlock) *
+                    nTypeFactor;
+                if (srcOffset + nColsToCopy * nTypeFactor > poValue->size())
+                {
+                    return false;
+                }
+                memcpy(padfAsDouble + dstOffset, poValue->data() + srcOffset,
                        nColsToCopy * sizeof(T));
             }
         }

--- a/autotest/gcore/interpolateatpoint.py
+++ b/autotest/gcore/interpolateatpoint.py
@@ -44,14 +44,23 @@ def test_interpolateatpoint_outofrange():
     assert res is None
     res = ds.GetRasterBand(1).InterpolateAtPoint(10, 1200, gdal.GRIORA_Bilinear)
     assert res is None
+    res = ds.GetRasterBand(1).InterpolateAtPoint(-1, 0, gdal.GRIORA_NearestNeighbour)
+    assert res is None
+    res = ds.GetRasterBand(1).InterpolateAtPoint(0, -0.5, gdal.GRIORA_NearestNeighbour)
+    assert res is None
+
+
+def test_interpolateatpoint_right_at_border():
+
+    ds = gdal.Open("data/byte.tif")
     res = ds.GetRasterBand(1).InterpolateAtPoint(20, 20, gdal.GRIORA_NearestNeighbour)
-    assert res is None
+    assert res == pytest.approx(107.0, 1e-5)
     res = ds.GetRasterBand(1).InterpolateAtPoint(18, 20, gdal.GRIORA_NearestNeighbour)
-    assert res is None
+    assert res == pytest.approx(99.0, 1e-5)
     res = ds.GetRasterBand(1).InterpolateAtPoint(20, 18, gdal.GRIORA_NearestNeighbour)
-    assert res is None
+    assert res == pytest.approx(123.0, 1e-5)
     res = ds.GetRasterBand(1).InterpolateAtPoint(20, 20, gdal.GRIORA_Bilinear)
-    assert res == pytest.approx(107.0, 1e-5)  # bilinear at the corner can interpolate.
+    assert res == pytest.approx(107.0, 1e-5)
     res = ds.GetRasterBand(1).InterpolateAtPoint(20.1, 20.1, gdal.GRIORA_Bilinear)
     assert res is None
 

--- a/autotest/gcore/interpolateatpoint.py
+++ b/autotest/gcore/interpolateatpoint.py
@@ -44,6 +44,16 @@ def test_interpolateatpoint_outofrange():
     assert res is None
     res = ds.GetRasterBand(1).InterpolateAtPoint(10, 1200, gdal.GRIORA_Bilinear)
     assert res is None
+    res = ds.GetRasterBand(1).InterpolateAtPoint(20, 20, gdal.GRIORA_NearestNeighbour)
+    assert res is None
+    res = ds.GetRasterBand(1).InterpolateAtPoint(19, 20, gdal.GRIORA_NearestNeighbour)
+    assert res is None
+    res = ds.GetRasterBand(1).InterpolateAtPoint(20, 19, gdal.GRIORA_NearestNeighbour)
+    assert res is None
+    res = ds.GetRasterBand(1).InterpolateAtPoint(20, 20, gdal.GRIORA_Bilinear)
+    assert res == pytest.approx(107.0, 1e-5)  # bilinear at the corner can interpolate.
+    res = ds.GetRasterBand(1).InterpolateAtPoint(20.1, 20.1, gdal.GRIORA_Bilinear)
+    assert res is None
 
 
 @gdaltest.disable_exceptions()

--- a/autotest/gcore/interpolateatpoint.py
+++ b/autotest/gcore/interpolateatpoint.py
@@ -46,9 +46,9 @@ def test_interpolateatpoint_outofrange():
     assert res is None
     res = ds.GetRasterBand(1).InterpolateAtPoint(20, 20, gdal.GRIORA_NearestNeighbour)
     assert res is None
-    res = ds.GetRasterBand(1).InterpolateAtPoint(19, 20, gdal.GRIORA_NearestNeighbour)
+    res = ds.GetRasterBand(1).InterpolateAtPoint(18, 20, gdal.GRIORA_NearestNeighbour)
     assert res is None
-    res = ds.GetRasterBand(1).InterpolateAtPoint(20, 19, gdal.GRIORA_NearestNeighbour)
+    res = ds.GetRasterBand(1).InterpolateAtPoint(20, 18, gdal.GRIORA_NearestNeighbour)
     assert res is None
     res = ds.GetRasterBand(1).InterpolateAtPoint(20, 20, gdal.GRIORA_Bilinear)
     assert res == pytest.approx(107.0, 1e-5)  # bilinear at the corner can interpolate.


### PR DESCRIPTION
## What does this PR do?
fixes a read out of bounds when reading with `InterpolateAtPoint` using `GRIORA_NearestNeighbour` one pixel just at the right or bottom border out of the image.

## What are related issues/pull requests?
fixes #12079

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [ ] ~Add documentation~
 - [ ] ~Updated Python API documentation (swig/include/python/docs/)~
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed