### PR TITLE
gdaltest.py: Avoid error with pytest < 8.2

### DIFF
--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -2147,4 +2147,7 @@ def gdal_has_vrt_expression_dialect(dialect):
 
 
 def importorskip_gdal_array():
-    return pytest.importorskip("osgeo.gdal_array", exc_type=ImportError)
+    pytest_version = [int(x) for x in pytest.__version__.split(".")]
+    if pytest_version >= [8, 2, 0]:
+        return pytest.importorskip("osgeo.gdal_array", exc_type=ImportError)
+    return pytest.importorskip("osgeo.gdal_array")


### PR DESCRIPTION
Follow-up to https://github.com/OSGeo/gdal/pull/12040