### PR TITLE
MiraMonVector refactoring: Code cleanup and relocation of three utility functions

### DIFF
--- a/ogr/ogrsf_frmts/miramon/mm_constants.h
+++ b/ogr/ogrsf_frmts/miramon/mm_constants.h
@@ -3,13 +3,7 @@
 /* -------------------------------------------------------------------- */
 /*      Constants used in GDAL and in MiraMon                           */
 /* -------------------------------------------------------------------- */
-#ifdef GDAL_COMPILATION
 CPL_C_START  // Necessary for compiling C in GDAL project
-#else
-#ifndef UINT32_MAX
-#define UINT32_MAX _UI32_MAX
-#endif
-#endif  // GDAL_COMPILATION
 
 #define MM_OFFSET_BYTESxCAMP_CAMP_CLASSIC 16
 #define MM_OFFSET_BYTESxCAMP_CAMP_ESPECIAL 21
@@ -78,11 +72,6 @@ CPL_C_START  // Necessary for compiling C in GDAL project
 
 #define MM_MAX_ID_SNY 41
 
-#ifndef GDAL_COMPILATION
-    typedef unsigned int uint32_t;
-typedef int int32_t;
-#endif
-
 // Extended DBF
 // Type of the number of records of an extended DBF
 #define MM_MAX_N_CAMPS_DBF_CLASSICA 255
@@ -141,7 +130,7 @@ typedef int int32_t;
 #define MM_JOC_CARAC_UTF8_DBF 0xFF
 #define MM_JOC_CARAC_UTF8_MM 8
 
-typedef unsigned char MM_BYTE;
+    typedef unsigned char MM_BYTE;
 
 #define MM_PRIMER_OFFSET_a_OFFSET_1a_FITXA 8
 #define MM_SEGON_OFFSET_a_OFFSET_1a_FITXA 30
@@ -163,7 +152,5 @@ typedef unsigned char MM_BYTE;
 
 #define MM_CHARACTERS_DOUBLE 40
 
-#ifdef GDAL_COMPILATION
 CPL_C_END  // Necessary for compiling in GDAL project
-#endif
-#endif  //__MM_CONSTANTS_H
+#endif     //__MM_CONSTANTS_H

--- a/ogr/ogrsf_frmts/miramon/mm_gdal_constants.h
+++ b/ogr/ogrsf_frmts/miramon/mm_gdal_constants.h
@@ -3,16 +3,8 @@
 /* -------------------------------------------------------------------- */
 /*      Constants used in GDAL and in MiraMon                           */
 /* -------------------------------------------------------------------- */
-#ifndef GDAL_COMPILATION
-#ifdef _WIN64
-#include "gdal\release-1911-x64\cpl_port.h"  // For GUInt64
-#else
-#include "gdal\release-1911-32\cpl_port.h"  // For GUInt64
-#endif
-#else
 #include "cpl_port.h"  // For GUInt64
-CPL_C_START  // Necessary for compiling C in GDAL project
-#endif                 // GDAL_COMPILATION
+CPL_C_START            // Necessary for compiling C in GDAL project
 
 #if defined(_WIN32) && !defined(strcasecmp)
 #define strcasecmp stricmp
@@ -22,8 +14,8 @@ CPL_C_START  // Necessary for compiling C in GDAL project
 
 #define sprintf_UINT64 "%llu"
 
-// Type of the Feature ID: determines the maximum number of features in a layer.
-typedef GUInt64 MM_INTERNAL_FID;
+    // Type of the Feature ID: determines the maximum number of features in a layer.
+    typedef GUInt64 MM_INTERNAL_FID;
 // Offset to the coordinates of the Features.
 typedef GUInt64 MM_FILE_OFFSET;
 
@@ -91,7 +83,5 @@ enum MM_TipusNomCamp
 #define MM_DonaBytesNomEstesCamp(camp)                                         \
     ((MM_BYTE)((camp)->reserved_2[MM_OFFSET_RESERVED2_EXTENDED_NAME_SIZE]))
 
-#ifdef GDAL_COMPILATION
 CPL_C_END  // Necessary for compiling in GDAL project
-#endif
-#endif  //__MM_GDAL_CONSTANTS_H
+#endif     //__MM_GDAL_CONSTANTS_H

--- a/ogr/ogrsf_frmts/miramon/mm_gdal_driver_structs.h
+++ b/ogr/ogrsf_frmts/miramon/mm_gdal_driver_structs.h
@@ -4,16 +4,10 @@
 /*      Necessary functions to read/write a MiraMon Vector File         */
 /* -------------------------------------------------------------------- */
 
-#ifdef GDAL_COMPILATION
 #include "mm_gdal_constants.h"
 #include "mm_gdal_structures.h"
 
 CPL_C_START  // Necessary for compiling in GDAL project
-#else
-#include <stdio.h>  // For FILE
-#include "mm_constants.h"
-#include "mm_gdal\mm_gdal_structures.h"
-#endif
 
 // For MetaData
 #define SECTION_VERSIO "VERSIO"
@@ -259,7 +253,7 @@ struct MM_FLUSH_INFO
     GUInt64 NTimesFlushed;
 
     // Pointer to an OPEN file where to flush.
-    FILE_TYPE *pF;
+    VSILFILE *pF;
     // Offset in the disk where to flush
     MM_FILE_OFFSET OffsetWhereToFlush;
 
@@ -493,19 +487,19 @@ struct MiraMonPointLayer
 {
     // Name of the layer with extension
     char pszLayerName[MM_CPL_PATH_BUF_SIZE];
-    FILE_TYPE *pF;
+    VSILFILE *pF;
 
     // Coordinates x,y of the points
     struct MM_FLUSH_INFO FlushTL;
     char *pTL;                             // (II mode)
     char pszTLName[MM_CPL_PATH_BUF_SIZE];  // Temporary file where to flush
-    FILE_TYPE *pFTL;  // Pointer to temporary file where to flush
+    VSILFILE *pFTL;  // Pointer to temporary file where to flush
 
     // Z section
     // Temporary file where the Z coordinates are stored
     // if necessary
     char psz3DLayerName[MM_CPL_PATH_BUF_SIZE];
-    FILE_TYPE *pF3d;
+    VSILFILE *pF3d;
     struct MM_ZSection pZSection;
 
     // MiraMon table (extended DBF)
@@ -519,7 +513,7 @@ struct MiraMonNodeLayer
 {
     char
         pszLayerName[MM_CPL_PATH_BUF_SIZE];  // Name of the layer with extension
-    FILE_TYPE *pF;
+    VSILFILE *pF;
 
     // Header of every node
     GUInt32 nSizeNodeHeader;
@@ -530,7 +524,7 @@ struct MiraMonNodeLayer
     struct MM_FLUSH_INFO FlushNL;          // (II mode)
     char *pNL;                             //
     char pszNLName[MM_CPL_PATH_BUF_SIZE];  // Temporary file where to flush
-    FILE_TYPE *pFNL;  // Pointer to temporary file where to flush
+    VSILFILE *pFNL;  // Pointer to temporary file where to flush
 
     struct MMAdmDatabase MMAdmDB;
 
@@ -542,12 +536,12 @@ struct MiraMonArcLayer
 {
     char
         pszLayerName[MM_CPL_PATH_BUF_SIZE];  // Name of the layer with extension
-    FILE_TYPE *pF;
+    VSILFILE *pF;
 
     // Temporal file where the Z coordinates are stored
     // if necessary
     char psz3DLayerName[MM_CPL_PATH_BUF_SIZE];
-    FILE_TYPE *pF3d;
+    VSILFILE *pF3d;
 
     // Header of every arc
     GUInt32 nSizeArcHeader;
@@ -559,7 +553,7 @@ struct MiraMonArcLayer
     unsigned short int nALElementSize;     // 16 bytes: 2 doubles (coordinates)
     char *pAL;                             // Arc List  // (II mode)
     char pszALName[MM_CPL_PATH_BUF_SIZE];  // Temporary file where to flush
-    FILE_TYPE *pFAL;  // Pointer to temporary file where to flush
+    VSILFILE *pFAL;  // Pointer to temporary file where to flush
 
     // Z section
     struct MM_ZSection pZSection;
@@ -583,14 +577,14 @@ struct MiraMonPolygonLayer
 {
     char
         pszLayerName[MM_CPL_PATH_BUF_SIZE];  // Name of the layer with extension
-    FILE_TYPE *pF;
+    VSILFILE *pF;
 
     // PS part
     struct MM_FLUSH_INFO FlushPS;
     unsigned short int nPSElementSize;
     char *pPS;                             // Polygon side (II mode)
     char pszPSName[MM_CPL_PATH_BUF_SIZE];  // Temporary file where to flush
-    FILE_TYPE *pFPS;  // Pointer to temporary file where to flush
+    VSILFILE *pFPS;  // Pointer to temporary file where to flush
 
     // Header of every polygon
     MM_INTERNAL_FID nMaxPolHeader;  // Number of pPolHeader allocated
@@ -602,7 +596,7 @@ struct MiraMonPolygonLayer
     unsigned short int nPALElementSize;
     char *pPAL;                             // Polygon Arc List  // (II mode)
     char pszPALName[MM_CPL_PATH_BUF_SIZE];  // Temporary file where to flush
-    FILE_TYPE *pFPAL;  // Pointer to temporary file where to flush
+    VSILFILE *pFPAL;  // Pointer to temporary file where to flush
 
     // Arc layer associated to the arc layer
     struct MM_TH TopArcHeader;
@@ -676,7 +670,7 @@ struct MiraMonFeature
 struct MiraMonVectMapInfo
 {
     char pszMapName[MM_CPL_PATH_BUF_SIZE];
-    FILE_TYPE *fMMMap;
+    VSILFILE *fMMMap;
     int nNumberOfLayers;
 };
 
@@ -832,7 +826,5 @@ enum TreatmentVariable
     MMTVCategorical
 };
 
-#ifdef GDAL_COMPILATION
 CPL_C_END  // Necessary for compiling in GDAL project
-#endif
-#endif  //__MM_GDAL_DRIVER_STRUCTS_H
+#endif     //__MM_GDAL_DRIVER_STRUCTS_H

--- a/ogr/ogrsf_frmts/miramon/mm_gdal_functions.h
+++ b/ogr/ogrsf_frmts/miramon/mm_gdal_functions.h
@@ -4,23 +4,17 @@
 /*      Constants used in GDAL and in MiraMon         */
 /* -------------------------------------------------------------------- */
 
-#ifdef GDAL_COMPILATION
 #include "mm_gdal_constants.h"       // MM_BYTE
 #include "mm_gdal_structures.h"      // struct BASE_DADES_XP
 #include "mm_gdal_driver_structs.h"  // struct MMAdmDatabase
 CPL_C_START                          // Necessary for compiling in GDAL project
-#else
-#include "mm_constants.h"                    // MM_BYTE
-#include "mm_gdal\mm_gdal_structures.h"      // struct BASE_DADES_XP
-#include "mm_gdal\mm_gdal_driver_structs.h"  // struct MMAdmDatabase
-#endif
 
 #define nullptr NULL
 
     // Log. It should be temporal
     extern const char *MM_pszLogFilename;
 
-void fclose_and_nullify(FILE_TYPE **pFunc);
+void fclose_and_nullify(VSILFILE **pFunc);
 
 // MiraMon feature table descriptors
 #define MM_MAX_IDENTIFIER_SIZE 50
@@ -136,7 +130,7 @@ int MM_ChangeDBFWidthField(struct MM_DATA_BASE_XP *data_base_XP,
                            MM_BYTES_PER_FIELD_TYPE_DBF novaamplada,
                            MM_BYTE nou_decimals);
 
-int MM_GetArcHeights(double *coord_z, FILE_TYPE *pF, MM_N_VERTICES_TYPE n_vrt,
+int MM_GetArcHeights(double *coord_z, VSILFILE *pF, MM_N_VERTICES_TYPE n_vrt,
                      struct MM_ZD *pZDescription, uint32_t flag);
 
 // Strings
@@ -146,7 +140,7 @@ char *MM_RemoveLeadingWhitespaceOfString(char *cadena);
 
 // DBF
 struct MM_ID_GRAFIC_MULTIPLE_RECORD *MMCreateExtendedDBFIndex(
-    FILE_TYPE *f, MM_EXT_DBF_N_RECORDS n_dbf,
+    VSILFILE *f, MM_EXT_DBF_N_RECORDS n_dbf,
     MM_FIRST_RECORD_OFFSET_TYPE offset_1era,
     MM_ACCUMULATED_BYTES_TYPE_DBF bytes_per_fitxa,
     MM_ACCUMULATED_BYTES_TYPE_DBF bytes_acumulats_id_grafic,
@@ -157,7 +151,21 @@ int MM_ReadExtendedDBFHeaderFromFile(const char *szFileName,
                                      struct MM_DATA_BASE_XP *pMMBDXP,
                                      const char *pszRelFile);
 
-#ifdef GDAL_COMPILATION
+// READING/CREATING MIRAMON METADATA
+char *MMReturnValueFromSectionINIFile(const char *filename, const char *section,
+                                      const char *key);
+
+int MMReturnCodeFromMM_m_idofic(char *pMMSRS_or_pSRS, char *result,
+                                MM_BYTE direction);
+
+#define EPSG_FROM_MMSRS 0
+#define MMSRS_FROM_EPSG 1
+#define ReturnEPSGCodeSRSFromMMIDSRS(pMMSRS, szResult)                         \
+    MMReturnCodeFromMM_m_idofic((pMMSRS), (szResult), EPSG_FROM_MMSRS)
+#define ReturnMMIDSRSFromEPSGCodeSRS(pSRS, szResult)                           \
+    MMReturnCodeFromMM_m_idofic((pSRS), (szResult), MMSRS_FROM_EPSG)
+
+int MMCheck_REL_FILE(const char *szREL_file);
+
 CPL_C_END  // Necessary for compiling in GDAL project
-#endif
-#endif  //__MM_GDAL_FUNCTIONS_H
+#endif     //__MM_GDAL_FUNCTIONS_H

--- a/ogr/ogrsf_frmts/miramon/mm_gdal_structures.h
+++ b/ogr/ogrsf_frmts/miramon/mm_gdal_structures.h
@@ -3,25 +3,11 @@
 /* -------------------------------------------------------------------- */
 /*      Constants used in GDAL and in MiraMon                           */
 /* -------------------------------------------------------------------- */
-#ifdef GDAL_COMPILATION
-#include "cpl_conv.h"  // For FILE_TYPE
+#include "cpl_conv.h"  // For VSILFILE
 #include "mm_gdal_constants.h"
-#else
-#include "F64_str.h"  // For FILE_64
-#include "mm_gdal\mm_gdal_constants.h"
-#endif
-
 #include "mm_constants.h"
 
-#ifdef GDAL_COMPILATION
 CPL_C_START  // Necessary for compiling in GDAL project
-#endif
-
-#ifdef GDAL_COMPILATION
-#define FILE_TYPE VSILFILE
-#else
-#define FILE_TYPE FILE_64
-#endif
 
     /* Internal field of an extended DBF. It is a copy of a MiraMon internal
 structure but translated to be understood by anyone who wants to
@@ -80,7 +66,7 @@ struct MM_DATA_BASE_XP  // MiraMon table Structure
     // Extended DBF file name
     char szFileName[MM_CPL_PATH_BUF_SIZE];  // In MiraMon code: szNomFitxer
 
-    FILE_TYPE *pfDataBase;  // In MiraMon code: pfBaseDades
+    VSILFILE *pfDataBase;  // In MiraMon code: pfBaseDades
 
     // Charset of the DBF
     MM_BYTE CharSet;
@@ -110,7 +96,6 @@ struct MM_DATA_BASE_XP  // MiraMon table Structure
     MM_BYTE reserved_2  // Used in extended DBF format to recompose BytesPerRecord
         [MM_MAX_LON_RESERVAT_2_BASE_DADES_XP];  // In MiraMon code: reservat_2
 };
-#ifdef GDAL_COMPILATION
+
 CPL_C_END  // Necessary for compiling in GDAL project
-#endif
-#endif  //__MM_GDAL_STRUCTURES_H
+#endif     //__MM_GDAL_STRUCTURES_H

--- a/ogr/ogrsf_frmts/miramon/mm_rdlayr.h
+++ b/ogr/ogrsf_frmts/miramon/mm_rdlayr.h
@@ -1,22 +1,16 @@
 #ifndef __MMRDLAYR_H
 #define __MMRDLAYR_H
 
-#ifndef GDAL_COMPILATION
-#include "mm_gdal\mm_gdal_driver_structs.h"
-#else
-//#include "ogr_api.h"    // For CPL_C_START
 #include "mm_gdal_driver_structs.h"
-CPL_C_START // Necessary for compiling in GDAL project
-#endif
+CPL_C_START  // Necessary for compiling in GDAL project
 
-int MMInitLayerToRead(struct MiraMonVectLayerInfo *hMiraMonLayer,
-                      FILE_TYPE *m_fp, const char *pszFilename);
+    int
+    MMInitLayerToRead(struct MiraMonVectLayerInfo *hMiraMonLayer,
+                      VSILFILE *m_fp, const char *pszFilename);
 
 int MMGetGeoFeatureFromVector(struct MiraMonVectLayerInfo *hMiraMonLayer,
                               MM_INTERNAL_FID i_elem);
 int MM_ReadExtendedDBFHeader(struct MiraMonVectLayerInfo *hMiraMonLayer);
 
-#ifdef GDAL_COMPILATION
 CPL_C_END  // Necessary for compiling in GDAL project
-#endif
-#endif  //__MMRDLAYR_H
+#endif     //__MMRDLAYR_H

--- a/ogr/ogrsf_frmts/miramon/mm_wrlayr.h
+++ b/ogr/ogrsf_frmts/miramon/mm_wrlayr.h
@@ -6,116 +6,15 @@
 /* -------------------------------------------------------------------- */
 
 #include "mm_gdal_driver_structs.h"
-#ifndef GDAL_COMPILATION
-#include "gdalmmf.h"  // For PTR_MM_CPLRecode, ptr_MM_CPLRecode(), ...
-#else
-#include "ogr_api.h"  // For OGRLayerH
 CPL_C_START  // Necessary for compiling in GDAL project
-#endif
 
-#ifndef GDAL_COMPILATION
-#include "memo.h"
-#include "F64_str.h"   //For FILE_64
-#include "FILE_64.h"   // Per a fseek_64(),...
-#include "bd_xp.h"     //For MAX_LON_CAMP_DBF
-#include "deftoler.h"  // For QUASI_IGUAL
-//#include "LbTopStr.h" // For struct GEOMETRIC_I_TOPOLOGIC_POL
-//#include "str_snyd.h" // For struct SNY_TRANSFORMADOR_GEODESIA
-#include "nomsfitx.h"  // Per a CanviaExtensio()
-#include "fitxers.h"   // Per a removeAO()
-#include "cadenes.h"   // Per a EsCadenaDeBlancs()
-#define calloc_function(a) MM_calloc((a))
-#define realloc_function MM_realloc
-#define free_function(a) MM_free((a))
-#define fopen_function(f, a) fopenAO_64((f), (a))
-#define fflush_function fflush_64
-#define fclose_function(f) fclose_64((f))
-#define ftell_function(f) ftell_64((f))
-#define fwrite_function(p, s, r, f) fwrite_64((p), (s), (r), (f))
-#define fread_function(p, s, r, f) fread_64((p), (s), (r), (f))
-#define fseek_function(f, s, g) fseek_64((f), (s), (g))
-#define fgets_function(f, s, g) fgets_64((f), (s), (g))
-#define TruncateFile_function(a, b) TruncaFitxer_64((a), (b))
-#define strdup_function(p) strdup((p))
-#define get_filename_function TreuAdreca
-#define get_path_function DonaAdreca
-#define fprintf_function fprintf_64
-#define max_function(a, b) max((a), (b))
-#define get_extension_function(a) extensio(a)
-#define reset_extension(a, b) CanviaExtensio((a), (b))
-#define remove_function(a) removeAO((a))
-#define OGR_F_GetFieldAsString_function(a, b)                                  \
-    ptr_MM_OGR_F_GetFieldAsString((a), (b))
-#define OGR_F_Destroy_function(a) ptr_MM_OGR_F_Destroy((a))
-#define GDALClose_function(a) ptr_MM_GDALClose((a))
-#define OGR_Fld_GetNameRef_function(a) ptr_MM_OGR_Fld_GetNameRef((a))
-#define OGR_FD_GetFieldDefn_function(a, b) ptr_MM_OGR_FD_GetFieldDefn((a), (b))
-#define GDALOpenEx_function(a, b, c, d, e)                                     \
-    ptr_MM_GDALOpenEx((a), (b), (c), (d), (e))
-#define OGR_FD_GetFieldCount_function(a) ptr_MM_OGR_FD_GetFieldCount((a))
-#define OGR_L_GetLayerDefn_function(a) ptr_MM_OGR_L_GetLayerDefn((a))
-#define OGR_L_GetNextFeature_function(a) ptr_MM_OGR_L_GetNextFeature((a))
-#define OGR_L_ResetReading_function(a) ptr_MM_OGR_L_ResetReading((a))
-#define GDALDatasetGetLayer_function(a, b) ptr_MM_GDALDatasetGetLayer((a), (b))
-#define CPLRecode_function(a, b, c) ptr_MM_CPLRecode((a), (b), (c))
-#define CPLFree_function(a) ptr_MM_CPLFree((a))
-#define form_filename_function(a, b) MuntaPath((a), (b), TRUE)
-#define MM_CPLGetBasename(a) TreuAdreca((a))
-#define MM_IsNANDouble(x) EsNANDouble((x))
-#define MM_IsDoubleInfinite(x) EsDoubleInfinit((x))
-#else
-#define calloc_function(a) VSICalloc(1, (a))
-#define realloc_function VSIRealloc
-#define free_function(a) VSIFree((a))
-#define fopen_function(f, a) VSIFOpenL((f), (a))
-#define fflush_function VSIFFlushL
-#define fclose_function(f) VSIFCloseL((f))
-#define ftell_function(f) VSIFTellL((f))
-#define fwrite_function(p, s, r, f) VSIFWriteL((p), (s), (r), (f))
-#define fread_function(p, s, r, f) VSIFReadL((p), (s), (r), (f))
-#define fseek_function(f, s, g) VSIFSeekL((f), (s), (g))
-#define TruncateFile_function(a, b) VSIFTruncateL((a), (b))
-#define strdup_function(p) CPLStrdup((p))
-#define get_filename_function CPLGetFilename
-#define get_path_function CPLGetPath
-#define fprintf_function VSIFPrintfL
-#define max_function(a, b) MAX((a), (b))
-#define get_extension_function(a) CPLGetExtension((a))
-#define reset_extension(a, b) CPLResetExtension((a), (b))
-#define remove_function(a) VSIUnlink((a))
-#define OGR_F_GetFieldAsString_function(a, b) OGR_F_GetFieldAsString((a), (b))
-#define OGR_F_Destroy_function(a) OGR_F_Destroy((a))
-#define GDALClose_function(a) GDALClose((a))
-#define OGR_Fld_GetNameRef_function(a) OGR_Fld_GetNameRef((a))
-#define OGR_FD_GetFieldDefn_function(a, b) OGR_FD_GetFieldDefn((a), (b))
-#define GDALOpenEx_function(a, b, c, d, e) GDALOpenEx((a), (b), (c), (d), (e))
-#define OGR_FD_GetFieldCount_function(a) OGR_FD_GetFieldCount((a))
-#define OGR_L_GetLayerDefn_function(a) OGR_L_GetLayerDefn((a))
-#define OGR_L_GetNextFeature_function(a) OGR_L_GetNextFeature((a))
-#define OGR_L_ResetReading_function(a) OGR_L_ResetReading((a))
-#define GDALDatasetGetLayer_function(a, b) GDALDatasetGetLayer((a), (b))
-#define CPLRecode_function(a, b, c) CPLRecode((a), (b), (c))
-#define CPLFree_function(a) CPLFree((a))
-#define form_filename_function(a, b) CPLFormFilename((a), (b), "")
-#define MM_CPLGetBasename(a) CPLGetBasename((a))
     bool
     MM_IsNANDouble(double x);
 bool MM_IsDoubleInfinite(double x);
-#endif
 
 /* -------------------------------------------------------------------- */
 /*      Functions                                                       */
 /* -------------------------------------------------------------------- */
-// MM-GDAL functions
-#ifdef GDAL_COMPILATION
-#define MMCPLError CPLError
-#define MMCPLWarning CPLError
-#define MMCPLDebug CPLDebugOnly
-#else
-void MMCPLError(int code, const char *fmt, ...);
-void MMCPLWarning(int code, const char *fmt, ...);
-void MMCPLDebug(int code, const char *fmt, ...);
-#endif
 
 // Layer functions
 int MMInitLayer(struct MiraMonVectLayerInfo *hMiraMonLayer,
@@ -125,13 +24,13 @@ int MMInitLayer(struct MiraMonVectLayerInfo *hMiraMonLayer,
 int MMInitLayerByType(struct MiraMonVectLayerInfo *hMiraMonLayer);
 int MMDestroyLayer(struct MiraMonVectLayerInfo *hMiraMonLayer);
 int MMCloseLayer(struct MiraMonVectLayerInfo *hMiraMonLayer);
-int MMReadHeader(FILE_TYPE *pF, struct MM_TH *pMMHeader);
+int MMReadHeader(VSILFILE *pF, struct MM_TH *pMMHeader);
 int MMReadAHArcSection(struct MiraMonVectLayerInfo *hMiraMonLayer);
 int MMReadPHPolygonSection(struct MiraMonVectLayerInfo *hMiraMonLayer);
 int MMReadZDescriptionHeaders(struct MiraMonVectLayerInfo *hMiraMonLayer,
-                              FILE_TYPE *pF, MM_INTERNAL_FID nElements,
+                              VSILFILE *pF, MM_INTERNAL_FID nElements,
                               struct MM_ZSection *pZSection);
-int MMReadZSection(struct MiraMonVectLayerInfo *hMiraMonLayer, FILE_TYPE *pF,
+int MMReadZSection(struct MiraMonVectLayerInfo *hMiraMonLayer, VSILFILE *pF,
                    struct MM_ZSection *pZSection);
 
 // Feature functions
@@ -143,7 +42,7 @@ int MMAddFeature(struct MiraMonVectLayerInfo *hMiraMonLayer,
                  struct MiraMonFeature *hMiraMonFeature);
 int MMCheckSize_t(GUInt64 nCount, GUInt64 nSize);
 int MMGetVectorVersion(struct MM_TH *pTopHeader);
-int MMInitFlush(struct MM_FLUSH_INFO *pFlush, FILE_TYPE *pF, GUInt64 nBlockSize,
+int MMInitFlush(struct MM_FLUSH_INFO *pFlush, VSILFILE *pF, GUInt64 nBlockSize,
                 char **pBuffer, MM_FILE_OFFSET DiskOffsetWhereToFlush,
                 GInt32 nMyDiskSize);
 int MMReadFlush(struct MM_FLUSH_INFO *pFlush);
@@ -156,8 +55,6 @@ int MMReadOffsetDependingOnVersion(struct MiraMonVectLayerInfo *hMiraMonLayer,
                                    MM_FILE_OFFSET *nUI64);
 
 // Tool functions
-char *MMReturnValueFromSectionINIFile(const char *filename, const char *section,
-                                      const char *key);
 
 // In order to be efficient we reserve space to reuse it every
 // time a feature is added.
@@ -200,20 +97,8 @@ int MMResizeStringToOperateIfNeeded(struct MiraMonVectLayerInfo *hMiraMonLayer,
                                     MM_EXT_DBF_N_FIELDS nNewSize);
 int MMIsEmptyString(const char *string);
 // Metadata functions
-int MMReturnCodeFromMM_m_idofic(char *pMMSRS_or_pSRS, char *result,
-                                MM_BYTE direction);
-
-#define EPSG_FROM_MMSRS 0
-#define MMSRS_FROM_EPSG 1
-#define ReturnEPSGCodeSRSFromMMIDSRS(pMMSRS, szResult)                         \
-    MMReturnCodeFromMM_m_idofic((pMMSRS), (szResult), EPSG_FROM_MMSRS)
-#define ReturnMMIDSRSFromEPSGCodeSRS(pSRS, szResult)                           \
-    MMReturnCodeFromMM_m_idofic((pSRS), (szResult), MMSRS_FROM_EPSG)
 
 int MMWriteVectorMetadata(struct MiraMonVectLayerInfo *hMiraMonLayer);
-int MMCheck_REL_FILE(const char *szREL_file);
 
-#ifdef GDAL_COMPILATION
 CPL_C_END  // Necessary for compiling in GDAL project
-#endif
-#endif  //__MM_WRLAYR_H
+#endif     //__MM_WRLAYR_H

--- a/ogr/ogrsf_frmts/miramon/ogrmiramonlayer.cpp
+++ b/ogr/ogrsf_frmts/miramon/ogrmiramonlayer.cpp
@@ -354,7 +354,7 @@ OGRMiraMonLayer::OGRMiraMonLayer(GDALDataset *poDS, const char *pszFilename,
         {
             if (!phMiraMonLayer->pMMBDXP->pfDataBase)
             {
-                if ((phMiraMonLayer->pMMBDXP->pfDataBase = fopen_function(
+                if ((phMiraMonLayer->pMMBDXP->pfDataBase = VSIFOpenL(
                          phMiraMonLayer->pMMBDXP->szFileName, "r")) == nullptr)
                 {
                     CPLDebugOnly("MiraMon", "File '%s' cannot be opened.",
@@ -663,51 +663,51 @@ OGRMiraMonLayer::~OGRMiraMonLayer()
 
     if (hMiraMonLayerPOL.ReadOrWrite == MM_WRITING_MODE)
     {
-        MMCPLDebug("MiraMon", "Destroying MiraMon polygons layer memory");
+        CPLDebugOnly("MiraMon", "Destroying MiraMon polygons layer memory");
     }
     MMDestroyLayer(&hMiraMonLayerPOL);
     if (hMiraMonLayerPOL.ReadOrWrite == MM_WRITING_MODE)
     {
-        MMCPLDebug("MiraMon", "MiraMon polygons layer memory destroyed");
+        CPLDebugOnly("MiraMon", "MiraMon polygons layer memory destroyed");
     }
 
     if (hMiraMonLayerARC.ReadOrWrite == MM_WRITING_MODE)
     {
-        MMCPLDebug("MiraMon", "Destroying MiraMon arcs layer memory");
+        CPLDebugOnly("MiraMon", "Destroying MiraMon arcs layer memory");
     }
     MMDestroyLayer(&hMiraMonLayerARC);
     if (hMiraMonLayerARC.ReadOrWrite == MM_WRITING_MODE)
     {
-        MMCPLDebug("MiraMon", "MiraMon arcs layer memory destroyed");
+        CPLDebugOnly("MiraMon", "MiraMon arcs layer memory destroyed");
     }
 
     if (hMiraMonLayerPNT.ReadOrWrite == MM_WRITING_MODE)
     {
-        MMCPLDebug("MiraMon", "Destroying MiraMon points layer memory");
+        CPLDebugOnly("MiraMon", "Destroying MiraMon points layer memory");
     }
     MMDestroyLayer(&hMiraMonLayerPNT);
     if (hMiraMonLayerPNT.ReadOrWrite == MM_WRITING_MODE)
     {
-        MMCPLDebug("MiraMon", "MiraMon points layer memory destroyed");
+        CPLDebugOnly("MiraMon", "MiraMon points layer memory destroyed");
     }
 
     if (hMiraMonLayerReadOrNonGeom.ReadOrWrite == MM_WRITING_MODE)
     {
-        MMCPLDebug("MiraMon", "Destroying MiraMon DBF table layer memory");
+        CPLDebugOnly("MiraMon", "Destroying MiraMon DBF table layer memory");
     }
     else
     {
-        MMCPLDebug("MiraMon", "Destroying MiraMon layer memory");
+        CPLDebugOnly("MiraMon", "Destroying MiraMon layer memory");
     }
 
     MMDestroyLayer(&hMiraMonLayerReadOrNonGeom);
     if (hMiraMonLayerReadOrNonGeom.ReadOrWrite == MM_WRITING_MODE)
     {
-        MMCPLDebug("MiraMon", "MiraMon DBF table layer memory destroyed");
+        CPLDebugOnly("MiraMon", "MiraMon DBF table layer memory destroyed");
     }
     else
     {
-        MMCPLDebug("MiraMon", "MiraMon layer memory destroyed");
+        CPLDebugOnly("MiraMon", "MiraMon layer memory destroyed");
     }
 
     memset(&hMiraMonLayerReadOrNonGeom, 0, sizeof(hMiraMonLayerReadOrNonGeom));
@@ -715,9 +715,9 @@ OGRMiraMonLayer::~OGRMiraMonLayer()
     memset(&hMiraMonLayerARC, 0, sizeof(hMiraMonLayerARC));
     memset(&hMiraMonLayerPOL, 0, sizeof(hMiraMonLayerPOL));
 
-    MMCPLDebug("MiraMon", "Destroying MiraMon temporary feature memory");
+    CPLDebugOnly("MiraMon", "Destroying MiraMon temporary feature memory");
     MMDestroyFeature(&hMMFeature);
-    MMCPLDebug("MiraMon", "MiraMon temporary feature memory");
+    CPLDebugOnly("MiraMon", "MiraMon temporary feature memory");
     memset(&hMMFeature, 0, sizeof(hMMFeature));
 
     /* -------------------------------------------------------------------- */
@@ -787,12 +787,12 @@ void OGRMiraMonLayer::GoToFieldOfMultipleRecord(MM_INTERNAL_FID iFID,
     if (!phMiraMonLayer->pMultRecordIndex)
         return;
 
-    fseek_function(
-        phMiraMonLayer->pMMBDXP->pfDataBase,
-        phMiraMonLayer->pMultRecordIndex[iFID].offset +
-            (MM_FILE_OFFSET)nIRecord * phMiraMonLayer->pMMBDXP->BytesPerRecord +
-            phMiraMonLayer->pMMBDXP->pField[nIField].AccumulatedBytes,
-        SEEK_SET);
+    VSIFSeekL(phMiraMonLayer->pMMBDXP->pfDataBase,
+              phMiraMonLayer->pMultRecordIndex[iFID].offset +
+                  (MM_FILE_OFFSET)nIRecord *
+                      phMiraMonLayer->pMMBDXP->BytesPerRecord +
+                  phMiraMonLayer->pMMBDXP->pField[nIField].AccumulatedBytes,
+              SEEK_SET);
 }
 
 /****************************************************************************/
@@ -1110,10 +1110,10 @@ OGRFeature *OGRMiraMonLayer::GetFeature(GIntBig nFeatureId)
                     {
                         GoToFieldOfMultipleRecord(nIElem, nIRecord, nIField);
 
-                        fread_function(phMiraMonLayer->szStringToOperate,
-                                       phMiraMonLayer->pMMBDXP->pField[nIField]
-                                           .BytesPerField,
-                                       1, phMiraMonLayer->pMMBDXP->pfDataBase);
+                        VSIFReadL(phMiraMonLayer->szStringToOperate,
+                                  phMiraMonLayer->pMMBDXP->pField[nIField]
+                                      .BytesPerField,
+                                  1, phMiraMonLayer->pMMBDXP->pfDataBase);
                         phMiraMonLayer
                             ->szStringToOperate[phMiraMonLayer->pMMBDXP
                                                     ->pField[nIField]
@@ -1173,10 +1173,10 @@ OGRFeature *OGRMiraMonLayer::GetFeature(GIntBig nFeatureId)
                         memset(phMiraMonLayer->szStringToOperate, 0,
                                phMiraMonLayer->pMMBDXP->pField[nIField]
                                    .BytesPerField);
-                        fread_function(phMiraMonLayer->szStringToOperate,
-                                       phMiraMonLayer->pMMBDXP->pField[nIField]
-                                           .BytesPerField,
-                                       1, phMiraMonLayer->pMMBDXP->pfDataBase);
+                        VSIFReadL(phMiraMonLayer->szStringToOperate,
+                                  phMiraMonLayer->pMMBDXP->pField[nIField]
+                                      .BytesPerField,
+                                  1, phMiraMonLayer->pMMBDXP->pfDataBase);
                         phMiraMonLayer
                             ->szStringToOperate[phMiraMonLayer->pMMBDXP
                                                     ->pField[nIField]
@@ -1253,7 +1253,7 @@ OGRFeature *OGRMiraMonLayer::GetFeature(GIntBig nFeatureId)
 
                 memset(phMiraMonLayer->szStringToOperate, 0,
                        phMiraMonLayer->pMMBDXP->pField[nIField].BytesPerField);
-                fread_function(
+                VSIFReadL(
                     phMiraMonLayer->szStringToOperate,
                     phMiraMonLayer->pMMBDXP->pField[nIField].BytesPerField, 1,
                     phMiraMonLayer->pMMBDXP->pfDataBase);
@@ -1305,7 +1305,7 @@ OGRFeature *OGRMiraMonLayer::GetFeature(GIntBig nFeatureId)
                     memset(
                         phMiraMonLayer->szStringToOperate, 0,
                         phMiraMonLayer->pMMBDXP->pField[nIField].BytesPerField);
-                    fread_function(
+                    VSIFReadL(
                         phMiraMonLayer->szStringToOperate,
                         phMiraMonLayer->pMMBDXP->pField[nIField].BytesPerField,
                         1, phMiraMonLayer->pMMBDXP->pfDataBase);
@@ -1362,7 +1362,7 @@ OGRFeature *OGRMiraMonLayer::GetFeature(GIntBig nFeatureId)
                     memset(
                         phMiraMonLayer->szStringToOperate, 0,
                         phMiraMonLayer->pMMBDXP->pField[nIField].BytesPerField);
-                    fread_function(
+                    VSIFReadL(
                         phMiraMonLayer->szStringToOperate,
                         phMiraMonLayer->pMMBDXP->pField[nIField].BytesPerField,
                         1, phMiraMonLayer->pMMBDXP->pfDataBase);
@@ -1432,7 +1432,7 @@ OGRFeature *OGRMiraMonLayer::GetFeature(GIntBig nFeatureId)
 
                 memset(phMiraMonLayer->szStringToOperate, 0,
                        phMiraMonLayer->pMMBDXP->pField[nIField].BytesPerField);
-                fread_function(
+                VSIFReadL(
                     phMiraMonLayer->szStringToOperate,
                     phMiraMonLayer->pMMBDXP->pField[nIField].BytesPerField, 1,
                     phMiraMonLayer->pMMBDXP->pfDataBase);
@@ -1513,7 +1513,7 @@ OGRFeature *OGRMiraMonLayer::GetFeature(GIntBig nFeatureId)
 
                 memset(phMiraMonLayer->szStringToOperate, 0,
                        phMiraMonLayer->pMMBDXP->pField[nIField].BytesPerField);
-                fread_function(
+                VSIFReadL(
                     phMiraMonLayer->szStringToOperate,
                     phMiraMonLayer->pMMBDXP->pField[nIField].BytesPerField, 1,
                     phMiraMonLayer->pMMBDXP->pfDataBase);
@@ -2275,8 +2275,7 @@ OGRErr OGRMiraMonLayer::TranslateFieldsValuesToMM(OGRFeature *poFeature)
             nRealNumRecords = nNumRecords = CSLCount(papszValues);
             if (nNumRecords == 0)
                 nNumRecords++;
-            hMMFeature.nNumMRecords =
-                max_function(hMMFeature.nNumMRecords, nNumRecords);
+            hMMFeature.nNumMRecords = MAX(hMMFeature.nNumMRecords, nNumRecords);
             if (MMResizeMiraMonRecord(
                     &hMMFeature.pRecords, &hMMFeature.nMaxMRecords,
                     hMMFeature.nNumMRecords, MM_INC_NUMBER_OF_RECORDS,
@@ -2349,8 +2348,7 @@ OGRErr OGRMiraMonLayer::TranslateFieldsValuesToMM(OGRFeature *poFeature)
             nRealNumRecords = nNumRecords = nCount;
             if (nNumRecords == 0)
                 nNumRecords++;
-            hMMFeature.nNumMRecords =
-                max_function(hMMFeature.nNumMRecords, nNumRecords);
+            hMMFeature.nNumMRecords = MAX(hMMFeature.nNumMRecords, nNumRecords);
             if (MMResizeMiraMonRecord(
                     &hMMFeature.pRecords, &hMMFeature.nMaxMRecords,
                     hMMFeature.nNumMRecords, MM_INC_NUMBER_OF_RECORDS,
@@ -2430,8 +2428,7 @@ OGRErr OGRMiraMonLayer::TranslateFieldsValuesToMM(OGRFeature *poFeature)
             nRealNumRecords = nNumRecords = nCount;
             if (nNumRecords == 0)
                 nNumRecords++;
-            hMMFeature.nNumMRecords =
-                max_function(hMMFeature.nNumMRecords, nNumRecords);
+            hMMFeature.nNumMRecords = MAX(hMMFeature.nNumMRecords, nNumRecords);
             if (MMResizeMiraMonRecord(
                     &hMMFeature.pRecords, &hMMFeature.nMaxMRecords,
                     hMMFeature.nNumMRecords, MM_INC_NUMBER_OF_RECORDS,
@@ -2483,8 +2480,7 @@ OGRErr OGRMiraMonLayer::TranslateFieldsValuesToMM(OGRFeature *poFeature)
             nRealNumRecords = nNumRecords = nCount;
             if (nNumRecords == 0)
                 nNumRecords++;
-            hMMFeature.nNumMRecords =
-                max_function(hMMFeature.nNumMRecords, nNumRecords);
+            hMMFeature.nNumMRecords = MAX(hMMFeature.nNumMRecords, nNumRecords);
             if (MMResizeMiraMonRecord(
                     &hMMFeature.pRecords, &hMMFeature.nMaxMRecords,
                     hMMFeature.nNumMRecords, MM_INC_NUMBER_OF_RECORDS,
@@ -2530,7 +2526,7 @@ OGRErr OGRMiraMonLayer::TranslateFieldsValuesToMM(OGRFeature *poFeature)
         }
         else if (eFType == OFTString)
         {
-            hMMFeature.nNumMRecords = max_function(hMMFeature.nNumMRecords, 1);
+            hMMFeature.nNumMRecords = MAX(hMMFeature.nNumMRecords, 1);
             hMMFeature.pRecords[0].nNumField = nNumFields;
             if (MMResizeMiraMonFieldValue(&(hMMFeature.pRecords[0].pField),
                                           &hMMFeature.pRecords[0].nMaxField,
@@ -2578,7 +2574,7 @@ OGRErr OGRMiraMonLayer::TranslateFieldsValuesToMM(OGRFeature *poFeature)
         {
             char szDate[15];
 
-            hMMFeature.nNumMRecords = max_function(hMMFeature.nNumMRecords, 1);
+            hMMFeature.nNumMRecords = MAX(hMMFeature.nNumMRecords, 1);
             hMMFeature.pRecords[0].nNumField = nNumFields;
             if (MMResizeMiraMonFieldValue(&(hMMFeature.pRecords[0].pField),
                                           &hMMFeature.pRecords[0].nMaxField,
@@ -2609,7 +2605,7 @@ OGRErr OGRMiraMonLayer::TranslateFieldsValuesToMM(OGRFeature *poFeature)
         }
         else if (eFType == OFTTime || eFType == OFTDateTime)
         {
-            hMMFeature.nNumMRecords = max_function(hMMFeature.nNumMRecords, 1);
+            hMMFeature.nNumMRecords = MAX(hMMFeature.nNumMRecords, 1);
             hMMFeature.pRecords[0].nNumField = nNumFields;
             if (MMResizeMiraMonFieldValue(&(hMMFeature.pRecords[0].pField),
                                           &hMMFeature.pRecords[0].nMaxField,
@@ -2634,7 +2630,7 @@ OGRErr OGRMiraMonLayer::TranslateFieldsValuesToMM(OGRFeature *poFeature)
         }
         else if (eFType == OFTInteger)
         {
-            hMMFeature.nNumMRecords = max_function(hMMFeature.nNumMRecords, 1);
+            hMMFeature.nNumMRecords = MAX(hMMFeature.nNumMRecords, 1);
             hMMFeature.pRecords[0].nNumField = nNumFields;
             if (MMResizeMiraMonFieldValue(&(hMMFeature.pRecords[0].pField),
                                           &hMMFeature.pRecords[0].nMaxField,
@@ -2689,7 +2685,7 @@ OGRErr OGRMiraMonLayer::TranslateFieldsValuesToMM(OGRFeature *poFeature)
         }
         else if (eFType == OFTInteger64)
         {
-            hMMFeature.nNumMRecords = max_function(hMMFeature.nNumMRecords, 1);
+            hMMFeature.nNumMRecords = MAX(hMMFeature.nNumMRecords, 1);
             hMMFeature.pRecords[0].nNumField = nNumFields;
             if (MMResizeMiraMonFieldValue(&(hMMFeature.pRecords[0].pField),
                                           &hMMFeature.pRecords[0].nMaxField,
@@ -2715,7 +2711,7 @@ OGRErr OGRMiraMonLayer::TranslateFieldsValuesToMM(OGRFeature *poFeature)
         }
         else if (eFType == OFTReal)
         {
-            hMMFeature.nNumMRecords = max_function(hMMFeature.nNumMRecords, 1);
+            hMMFeature.nNumMRecords = MAX(hMMFeature.nNumMRecords, 1);
             hMMFeature.pRecords[0].nNumField = nNumFields;
             if (MMResizeMiraMonFieldValue(&(hMMFeature.pRecords[0].pField),
                                           &hMMFeature.pRecords[0].nMaxField,


### PR DESCRIPTION
## What does this PR do?

- Cleans up the code:
- Removes the use of GDAL_COMPILATION.
- Rewrites certain wrapper functions to use native GDAL-style implementations.
- Moves the following functions from mm_wrlayr.c/h to mm_gdal_functions.c/h: 

  -   MMReturnValueFromSectionINIFile()
  -   MMReturnCodeFromMM_m_idofic()
  -   MMCheck_REL_FILE()

The existing tests are sufficient to verify that this cleanup has been applied correctly.
Everything should continue to work as before, as no functional changes have been introduced.

## What are related issues/pull requests?
Part of this PR is related to a future upcoming MiraMon raster driver — it involves code relocation only.
The other part addresses the removal of the GDAL_COMPILATION differentiation, which is no longer necessary in the current context.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [x] All CI builds and checks have passed
