### PR TITLE
DIMAP2: do not report SRS on products that have no geotransform (i.e. primary with RPC only)

### DIFF
--- a/autotest/gdrivers/dimap.py
+++ b/autotest/gdrivers/dimap.py
@@ -311,6 +311,7 @@ def test_dimap_2_vhr2020_ms_fs():
 
 def test_dimap2_pneo_primary_rpc_center_h():
     ds = gdal.Open("data/dimap2/primary_rpc_center_h/DIM_PNEO3_STD_x_1_1_F_1.XML")
+    assert ds.GetSpatialRef() is None
     assert ds.GetMetadata_Dict("RPC") == {
         "HEIGHT_DEFAULT": "123.45",
         "HEIGHT_OFF": "HEIGHT_OFF",

--- a/frmts/dimap/dimapdataset.cpp
+++ b/frmts/dimap/dimapdataset.cpp
@@ -1479,9 +1479,13 @@ int DIMAPDataset::ReadImageInformation2()
 
     if (pszSRS != nullptr)
     {
-        OGRSpatialReference &oSRS = nGCPCount > 0 ? m_oGCPSRS : m_oSRS;
-        oSRS.SetFromUserInput(
-            pszSRS, OGRSpatialReference::SET_FROM_USER_INPUT_LIMITATIONS_get());
+        if (bHaveGeoTransform)
+        {
+            OGRSpatialReference &oSRS = m_oSRS;
+            oSRS.SetFromUserInput(
+                pszSRS,
+                OGRSpatialReference::SET_FROM_USER_INPUT_LIMITATIONS_get());
+        }
     }
     else
     {
@@ -1489,7 +1493,8 @@ int DIMAPDataset::ReadImageInformation2()
         // HORIZONTAL_CS_CODE is empty and the underlying raster
         // is georeferenced (rprinceley).
         const auto poSRS = poImageDS->GetSpatialRef();
-        if (poSRS)
+        double adfGTTmp[6];
+        if (poSRS && poImageDS->GetGeoTransform(adfGTTmp) == CE_None)
         {
             m_oSRS = *poSRS;
         }


### PR DESCRIPTION
Fixes #12112
