### PR TITLE
Exclude setup.py.in from Precommit Checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
         -   id: black
             exclude: >
               (?x)^(
+                swig/python/setup.py.in|
                 swig/python/osgeo/__init__.py|
                 swig/python/osgeo/gdalnumeric.py|
                 doc/source/_extensions/sphinxcontrib_programoutput_gdal.py|
@@ -16,6 +17,7 @@ repos:
         -   id: isort
             exclude: >
               (?x)^(
+                swig/python/setup.py.in|
                 swig/python/osgeo/__init__.py|
                 swig/python/osgeo/gdalnumeric.py|
                 doc/source/_extensions/sphinxcontrib_programoutput_gdal.py|
@@ -27,6 +29,7 @@ repos:
         -   id: flake8
             exclude: >
               (?x)^(
+                swig/python/setup.py.in|
                 swig/python/osgeo/__init__.py|
                 swig/python/osgeo/gdalnumeric.py|
                 doc/source/_extensions/sphinxcontrib_programoutput_gdal.py|


### PR DESCRIPTION
## What does this PR do?

Excludes `swig\python\setup.py.in` from Python precommit checks as it is a mix of Python and variable placeholders. 

## What are related issues/pull requests?

Fix for #12118
