### PR TITLE
Doc: Remove unused requirements.txt

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -4,8 +4,6 @@ breathe
 fsspec
 numpy
 sphinx
-sphinx_bootstrap_theme
-sphinx-markdown-tables
 sphinx-tabs
 sphinxcontrib-bibtex
 sphinxcontrib-jquery

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -12,4 +12,3 @@ sphinx-rtd-theme >= 3.0.0
 # sphinxcontrib-programoutput
 sphinxcontrib-spelling
 myst_nb
-recommonmark


### PR DESCRIPTION
## What does this PR do?

Removes `sphinx_bootstrap_theme` and `sphinx-markdown-tables` which are no longer used to build the GDAL docs. 
Also removes `recommonmark`, which again does not appear to be used in the GDAL project, and is archived as of 2022 https://github.com/readthedocs/recommonmark

@dbaston - should https://github.com/OSGeo/gdal/blob/master/doc/environment.yml be kept in sync with requirements.txt? I presume this is for a Conda setup but I can find no mention of it in the docs. 