### PR TITLE
Python bindings: expose gdal_translate -eco and -epo

### DIFF
--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -1013,7 +1013,8 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
             CPLErr eErr = bIsError ? CE_Failure : CE_Warning;
 
             CPLError(eErr, CPLE_AppDefined,
-                     "%s-srcwin %g %g %g %g falls %s outside raster extent.%s",
+                     "%s-srcwin %g %g %g %g falls %s outside source raster "
+                     "extent.%s",
                      (psOptions->dfULX != 0.0 || psOptions->dfULY != 0.0 ||
                       psOptions->dfLRX != 0.0 || psOptions->dfLRY != 0.0)
                          ? "Computed "
@@ -1021,7 +1022,10 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
                      psOptions->srcWin.dfXOff, psOptions->srcWin.dfYOff,
                      psOptions->srcWin.dfXSize, psOptions->srcWin.dfYSize,
                      bCompletelyOutside ? "completely" : "partially",
-                     bIsError ? "" : " Going on however.");
+                     bIsError
+                         ? ""
+                         : " Pixels outside the source raster extent will be "
+                           "set to the NoData value (if defined), or zero.");
         }
         if (bIsError)
         {

--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -94,7 +94,7 @@ struct GDALTranslateOptions
     std::string osFormat{};
 
     /*! allow or suppress progress monitor and other non-error output */
-    bool bQuiet = true;
+    bool bQuiet = false;
 
     /*! the progress function to use */
     GDALProgressFunc pfnProgress = GDALDummyProgress;

--- a/autotest/utilities/test_gdal_translate_lib.py
+++ b/autotest/utilities/test_gdal_translate_lib.py
@@ -762,12 +762,11 @@ def test_gdal_translate_lib_projwin_polar(tmp_vsimem):
 # outside of the source
 
 
-@pytest.mark.parametrize("epo", (True, False))
-@pytest.mark.parametrize("eco", (True, False))
+@pytest.mark.parametrize("error", ("partially", "completely", False, True))
 @gdaltest.disable_exceptions()
-def test_gdal_translate_lib_projwin_partially_outside(epo, eco):
+def test_gdal_translate_lib_projwin_partially_outside(error):
 
-    msg_type = gdal.CE_Failure if epo else gdal.CE_Warning
+    msg_type = gdal.CE_Failure if error in ("partially", True) else gdal.CE_Warning
 
     with gdaltest.error_raised(msg_type, "partially outside"):
         ds = gdal.Translate(
@@ -775,23 +774,26 @@ def test_gdal_translate_lib_projwin_partially_outside(epo, eco):
             "../gcore/data/byte.tif",
             format="VRT",
             projWin=(440000, 3751320, 441920, 3750120),
-            errorIfWindowPartiallyOutsideSource=epo,
-            errorIfWindowCompletelyOutsideSource=eco,
+            errorIfWindowOutsideSource=error,
         )
 
-        if epo:
+        if error in ("partially", True):
             assert ds is None
         else:
+            assert ds is not None
             assert ds.RasterXSize == 32
             assert ds.RasterYSize == 20
 
 
-@pytest.mark.parametrize("eco", (True, False))
-@pytest.mark.parametrize("epo", (True, False))
+@pytest.mark.parametrize("error", ("partially", "completely", False, True))
 @gdaltest.disable_exceptions()
-def test_gdal_translate_lib_projwin_completely_outside(epo, eco):
+def test_gdal_translate_lib_projwin_completely_outside(error):
 
-    msg_type = gdal.CE_Failure if epo or eco else gdal.CE_Warning
+    msg_type = (
+        gdal.CE_Failure
+        if error in {"partially", "completely", True}
+        else gdal.CE_Warning
+    )
 
     with gdaltest.error_raised(msg_type, "completely outside"):
         ds = gdal.Translate(
@@ -799,15 +801,27 @@ def test_gdal_translate_lib_projwin_completely_outside(epo, eco):
             "../gcore/data/byte.tif",
             format="VRT",
             projWin=(0, 120, 120, 0),
-            errorIfWindowPartiallyOutsideSource=epo,
-            errorIfWindowCompletelyOutsideSource=eco,
+            errorIfWindowOutsideSource=error,
         )
 
-        if epo or eco:
+        if error in {"partially", "completely", True}:
             assert ds is None
         else:
+            assert ds is not None
             assert ds.RasterXSize == 3
             assert ds.RasterYSize == 2
+
+
+def test_gdal_translate_lib_projwin_invalid_error_if_window_outside_source():
+
+    with pytest.raises(RuntimeError, match="errorIfWindowOutsideSource must be one of"):
+        gdal.Translate(
+            "",
+            "../gcore/data/byte.tif",
+            format="VRT",
+            projWin=(0, 120, 120, 0),
+            errorIfWindowOutsideSource="possibly",
+        )
 
 
 ###############################################################################

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -2538,7 +2538,9 @@ def TranslateOptions(options=None, format=None,
               overviewLevel = 'AUTO',
               colorInterpretation=None,
               callback=None, callback_data=None,
-              domainMetadataOptions = None):
+              domainMetadataOptions = None,
+              errorIfWindowPartiallyOutsideSource = False,
+              errorIfWindowCompletelyOutsideSource = False):
     """Create a TranslateOptions() object that can be passed to gdal.Translate()
 
     Parameters
@@ -2615,6 +2617,10 @@ def TranslateOptions(options=None, format=None,
         user data for callback
     domainMetadataOptions:
         list or dict of domain-specific metadata options
+    errorIfWindowCompletelyOutsideSource : bool, default=False
+         raise an error if the requested window is completely outside the source dataset. This corresponds to the ``-eco`` option of ``gdal_translate``.
+    errorIfWindowPartiallyOutsideSource : bool, default=False
+         raise an error if the requested window is partially outside the source dataset. This corresponds to the ``-epo`` option of ``gdal_translate``.
     """
 
     # Only used for tests
@@ -2736,6 +2742,12 @@ def TranslateOptions(options=None, format=None,
 
         if overviewLevel is not None and overviewLevel != 'AUTO':
             new_options += ['-ovr', overviewLevel]
+
+        if errorIfWindowCompletelyOutsideSource:
+            new_options.append('-eco')
+
+        if errorIfWindowPartiallyOutsideSource:
+            new_options.append('-epo')
 
     if return_option_list:
         return new_options

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -2539,8 +2539,7 @@ def TranslateOptions(options=None, format=None,
               colorInterpretation=None,
               callback=None, callback_data=None,
               domainMetadataOptions = None,
-              errorIfWindowPartiallyOutsideSource = False,
-              errorIfWindowCompletelyOutsideSource = False):
+              errorIfWindowOutsideSource = False):
     """Create a TranslateOptions() object that can be passed to gdal.Translate()
 
     Parameters
@@ -2617,10 +2616,8 @@ def TranslateOptions(options=None, format=None,
         user data for callback
     domainMetadataOptions:
         list or dict of domain-specific metadata options
-    errorIfWindowCompletelyOutsideSource : bool, default=False
-         raise an error if the requested window is completely outside the source dataset. This corresponds to the ``-eco`` option of ``gdal_translate``.
-    errorIfWindowPartiallyOutsideSource : bool, default=False
-         raise an error if the requested window is partially outside the source dataset. This corresponds to the ``-epo`` option of ``gdal_translate``.
+    errorIfWindowOutsideSource : {True, False, "partially", "completely"}, default=True
+         raise an error if the requested window is partially or completely outside the source dataset. ("True" is a synonym for "partially"). This corresponds to the ``-epo`` and ``-eco`` options of ``gdal_translate``.
     """
 
     # Only used for tests
@@ -2743,11 +2740,14 @@ def TranslateOptions(options=None, format=None,
         if overviewLevel is not None and overviewLevel != 'AUTO':
             new_options += ['-ovr', overviewLevel]
 
-        if errorIfWindowCompletelyOutsideSource:
-            new_options.append('-eco')
+        if errorIfWindowOutsideSource is not False:
+            if errorIfWindowOutsideSource in ("partially", True):
+                new_options.append('-epo')
+            elif errorIfWindowOutsideSource == "completely":
+                new_options.append('-eco')
+            else:
+                raise RuntimeError("errorIfWindowOutsideSource must be one of 'partially', 'completely', or None")
 
-        if errorIfWindowPartiallyOutsideSource:
-            new_options.append('-epo')
 
     if return_option_list:
         return new_options


### PR DESCRIPTION
1) Sets `GDALTranslateOptions::bQuiet` to `true` by default. Otherwise, it is only `true` when called constructed with a progress callback. Possibly this variable could be removed altogether, as there are other methods for squelching errors.

2) Exposes `gdal_translate` options `-epo` and `-eco` as `errorIfWindowPartiallyOutsideSource` and `errorIfWindowCompletelyOutsideSource`. I would love for these to be True by default, but...backwards compatibility. (Maybe they could be the default for `gdal raster clip` though? ) I also don't love the names, maybe there is a better way to do it with a single text argument.

