### PR TITLE
autotest: add tests for gdal_translate error cases

### DIFF
--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -974,7 +974,7 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
             }
             else
             {
-                CPLError(CE_None, CPLE_None,
+                CPLError(CE_Warning, CPLE_None,
                          "-projwin_srs ignored since the dataset has no "
                          "projection.");
             }
@@ -1094,6 +1094,8 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
         const std::string osFormat = GetOutputDriverForRaster(pszDest);
         if (osFormat.empty())
         {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Could not identify an output driver for %s", pszDest);
             GDALTranslateOptionsFree(psOptions);
             return nullptr;
         }
@@ -1312,7 +1314,7 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
                                     fabs(adfSrcGeoTransform[5]) +
                                 0.5;
         if (dfOXSize < 1 || !GDALIsValueInRange<int>(dfOXSize) ||
-            dfOYSize < 1 || !GDALIsValueInRange<int>(dfOXSize))
+            dfOYSize < 1 || !GDALIsValueInRange<int>(dfOYSize))
         {
             CPLError(CE_Failure, CPLE_IllegalArg,
                      "Invalid output size: %g x %g", dfOXSize, dfOYSize);
@@ -1327,7 +1329,7 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
         double dfOXSize = ceil(psOptions->adfSrcWin[2] - 0.001);
         double dfOYSize = ceil(psOptions->adfSrcWin[3] - 0.001);
         if (dfOXSize < 1 || !GDALIsValueInRange<int>(dfOXSize) ||
-            dfOYSize < 1 || !GDALIsValueInRange<int>(dfOXSize))
+            dfOYSize < 1 || !GDALIsValueInRange<int>(dfOYSize))
         {
             CPLError(CE_Failure, CPLE_IllegalArg,
                      "Invalid output size: %g x %g", dfOXSize, dfOYSize);

--- a/autotest/pymod/gdaltest.py
+++ b/autotest/pymod/gdaltest.py
@@ -2131,7 +2131,7 @@ def error_raised(type, match=""):
 
     assert any(
         [err["level"] == type and match in err["message"] for err in errors]
-    ), f'Did not receive an error of type {err_levels[type]} matching "{match}"'
+    ), f'Did not receive an error of type {err_levels[type]} matching "{match}". Received: {[(err["level"], err["message"]) for err in errors]}'
 
 
 ###############################################################################


### PR DESCRIPTION
Adds some tests for `gdal_translate` error cases and fixes three issues uncovered:

- warning for `projwin_srs` was emitted with `CE_None` (consider `CE_Failure` for `gdal raster clip`)
- range check for `-srcwin` did not check height of window for overflow
- no error message raised if output driver cannot be detected 