### PR TITLE
gdalcompare: do not emit exception when all pixels are invalid 

### DIFF
--- a/autotest/gcore/gdal_stats.py
+++ b/autotest/gcore/gdal_stats.py
@@ -809,12 +809,13 @@ def test_stats_all_nodata():
     with pytest.raises(Exception):
         ds.GetRasterBand(1).ComputeRasterMinMax()
 
-    with pytest.raises(Exception):
-        ds.GetRasterBand(1).ComputeRasterMinMax(can_return_none=True)
+    assert ds.GetRasterBand(1).ComputeRasterMinMax(can_return_none=True) is None
 
-    with pytest.raises(Exception):
-        # can_return_null also accepted for similarity with other methods
-        ds.GetRasterBand(1).ComputeRasterMinMax(can_return_null=True)
+    with gdaltest.disable_exceptions(), gdal.quiet_errors():
+        assert ds.GetRasterBand(1).ComputeRasterMinMax(can_return_none=True) is None
+
+    # can_return_null also accepted for similarity with other methods
+    assert ds.GetRasterBand(1).ComputeRasterMinMax(can_return_null=True) is None
 
     approx_ok = 1
     force = 1

--- a/autotest/pyscripts/test_gdalcompare.py
+++ b/autotest/pyscripts/test_gdalcompare.py
@@ -320,3 +320,37 @@ def test_gdalcompare_different_overview(tmp_vsimem, captured_print, source_filen
         )
         == 1
     )
+
+
+###############################################################################
+# Test case of https://github.com/OSGeo/gdal/issues/12137
+
+
+def test_gdalcompare_float32_only_nodata(tmp_vsimem):
+
+    filename_all_nodata = str(tmp_vsimem / "all_nodata.tif")
+    ds = gdal.GetDriverByName("GTiff").Create(
+        filename_all_nodata, 1, 1, 1, gdal.GDT_Float32
+    )
+    ds.GetRasterBand(1).SetNoDataValue(0)
+    ds.Close()
+
+    assert (
+        gdalcompare.find_diff(
+            filename_all_nodata, filename_all_nodata, options=["SKIP_BINARY"]
+        )
+        == 0
+    )
+
+    filename_all_zero = str(tmp_vsimem / "all_zero.tif")
+    ds = gdal.GetDriverByName("GTiff").Create(
+        filename_all_zero, 1, 1, 1, gdal.GDT_Float32
+    )
+    ds.Close()
+
+    assert (
+        gdalcompare.find_diff(
+            filename_all_zero, filename_all_nodata, options=["SKIP_BINARY"]
+        )
+        == 2
+    )

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -982,7 +982,13 @@ def ComputeRasterMinMax(self, *args, **kwargs):
         kwargs["can_return_none"] = kwargs["can_return_null"];
         del kwargs["can_return_null"]
 
-    return $action(self, *args, **kwargs)
+    if "can_return_none" in kwargs and kwargs["can_return_none"]:
+        try:
+            return $action(self, *args, **kwargs)
+        except Exception:
+            return None
+    else:
+        return $action(self, *args, **kwargs)
 %}
 
 }

--- a/swig/python/gdal-utils/osgeo_utils/gdalcompare.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdalcompare.py
@@ -190,7 +190,9 @@ def compare_band(golden_band, new_band, id, options=None):
     else:
         # check a bit deeper in case of Float data type for which the Checksum() function is not reliable
         if golden_band.DataType in (gdal.GDT_Float32, gdal.GDT_Float64):
-            if golden_band.ComputeRasterMinMax() != new_band.ComputeRasterMinMax():
+            if golden_band.ComputeRasterMinMax(
+                can_return_none=True
+            ) != new_band.ComputeRasterMinMax(can_return_none=True):
                 my_print("Band %s statistics difference:" % 1)
                 my_print("  Golden: " + str(golden_band.ComputeBandStats()))
                 my_print("  New:    " + str(new_band.ComputeBandStats()))


### PR DESCRIPTION
Fixes #12137
