### PR TITLE
Add PowerShell environment setup script

### DIFF
--- a/doc/source/development/dev_environment.rst
+++ b/doc/source/development/dev_environment.rst
@@ -168,16 +168,23 @@ For Windows, a similar ``scripts/setdevenv.bat`` script exists (it currently ass
     cd c:\dev\gdal\build
     ..\scripts\setdevenv.bat
 
+Alternatively, on Windows, you can set up a PowerShell development environment using the ``scripts/setdevenv.ps1`` script:
+
+.. code-block:: ps1
+
+    cd c:\dev\gdal\build
+    ..\scripts\setdevenv.ps1
+
 To verify that environment variables have been set correctly, you can check the version of a GDAL binary:
 
 .. code-block:: bash
 
     gdalinfo --version
-    # GDAL 3.7.0dev-5327c149f5-dirty, released 2018/99/99 (debug build)
+    # GDAL 3.11.0dev-c4a2e0b926-dirty, released 2025/04/10
 
 and the Python bindings:
 
 .. code-block:: bash
 
     python3 -c 'from osgeo import gdal; print(gdal.__version__)'
-    # 3.7.0dev-5327c149f5-dirty
+    # 3.11.0dev-c4a2e0b926-dirty

--- a/scripts/setdevenv.ps1
+++ b/scripts/setdevenv.ps1
@@ -1,0 +1,8 @@
+# This is a very simple script which must be called from a build
+# directory and sets the environment for a Release build
+
+$env:PATH = "$PWD\swig\python\bin;$PWD\apps\Release;$PWD\Release;" + $env:PATH
+$env:GDAL_DATA = "$PWD\data"
+$env:PYTHONPATH = "$PWD\swig\python"
+$env:GDAL_DRIVER_PATH = "$PWD\gdalplugins\Release"
+$env:USE_PATH_FOR_GDAL_PYTHON = "yes"


### PR DESCRIPTION
Similar to https://github.com/OSGeo/gdal/commit/60bd384411bb783194b24582c1bbd424cb5f01df this adds a PowerShell script for setting up a development environment for the Python bindings:

```ps1
cd C:\docs\gdal\build
cmake --build . --target python_binding

C:\docs\gdal\scripts\setdevenv.ps1
python
>>> import osgeo
```