### PR TITLE
Add example Python API gdal_mdm_doc

### DIFF
--- a/gcore/gdalmultidim.cpp
+++ b/gcore/gdalmultidim.cpp
@@ -722,7 +722,7 @@ std::shared_ptr<GDALDimension> GDALGroup::CreateDimension(
  * @param papszOptions Driver specific options determining how the array
  * should be created.
  *
- * @return the new array, or nullptr if case of error
+ * @return the new array, or nullptr in case of error
  */
 std::shared_ptr<GDALMDArray> GDALGroup::CreateMDArray(
     CPL_UNUSED const std::string &osName,

--- a/swig/include/python/docs/gdal_mdm_docs.i
+++ b/swig/include/python/docs/gdal_mdm_docs.i
@@ -3,7 +3,7 @@
 Create a multidimensional array within a group.
 
 It is recommended that the GDALDimension objects passed in ``dimensions``
-belong to this group, either by retrieving them with :py:func:`osgeo.gdal.Group.GetDimensions`
+belong to this group, either by retrieving them with :py:meth:`GetDimensions`
 or creating a new one with :py:func:`osgeo.gdal.Group.CreateDimension`.
 
 See :cpp:func:`GDALGroup::CreateMDArray`.

--- a/swig/include/python/docs/gdal_mdm_docs.i
+++ b/swig/include/python/docs/gdal_mdm_docs.i
@@ -4,7 +4,7 @@ Create a multidimensional array within a group.
 
 It is recommended that the GDALDimension objects passed in ``dimensions``
 belong to this group, either by retrieving them with :py:meth:`GetDimensions`
-or creating a new one with :py:func:`osgeo.gdal.Group.CreateDimension`.
+or creating a new one with :py:meth:`CreateDimension`.
 
 See :cpp:func:`GDALGroup::CreateMDArray`.
 

--- a/swig/include/python/docs/gdal_mdm_docs.i
+++ b/swig/include/python/docs/gdal_mdm_docs.i
@@ -2,7 +2,7 @@
 
 Create a multidimensional array within a group.
 
-It is recommended that the GDALDimension objects passed in aoDimensions
+It is recommended that the GDALDimension objects passed in ``dimensions``
 belong to this group, either by retrieving them with :py:func:`osgeo.gdal.Group.GetDimensions`
 or creating a new one with :py:func:`osgeo.gdal.Group.CreateDimension`.
 

--- a/swig/include/python/docs/gdal_mdm_docs.i
+++ b/swig/include/python/docs/gdal_mdm_docs.i
@@ -1,0 +1,33 @@
+%feature("docstring")  CreateMDArray "
+
+Create a multidimensional array within a group.
+
+See :cpp:func:`GDALGroup::CreateMDArray`.
+
+Parameters
+----------
+osName : str
+    name
+aoDimensions : list
+    List of dimensions, ordered from the slowest varying
+    dimension first to the fastest varying dimension last.
+    Might be empty for a scalar array (if supported by driver)
+oDataType: GDALExtendedDataType
+papszOptions : CSLConstList
+
+Returns
+-------
+
+GDALMDArray - the new array
+
+Examples
+--------
+>>> from osgeo import gdal
+>>> drv = gdal.GetDriverByName('MEM')
+>>> mem_ds = drv.CreateMultiDimensional('myds')
+>>> rg = mem_ds.GetRootGroup()
+>>> dimX = rg.CreateDimension('X', None, None, 3)
+>>> ar = rg.CreateMDArray('ar', [dimX], gdal.ExtendedDataType.Create(gdal.GDT_Byte))
+
+";
+

--- a/swig/include/python/docs/gdal_mdm_docs.i
+++ b/swig/include/python/docs/gdal_mdm_docs.i
@@ -2,27 +2,32 @@
 
 Create a multidimensional array within a group.
 
+It is recommended that the GDALDimension objects passed in aoDimensions
+belong to this group, either by retrieving them with :py:func:`osgeo.gdal.Group.GetDimensions`
+or creating a new one with :py:func:`osgeo.gdal.Group.CreateDimension`.
+
 See :cpp:func:`GDALGroup::CreateMDArray`.
 
 Parameters
 ----------
-osName : str
+name : str
     name
-aoDimensions : list
+dimensions : list
     List of dimensions, ordered from the slowest varying
     dimension first to the fastest varying dimension last.
     Might be empty for a scalar array (if supported by driver)
-oDataType: GDALExtendedDataType
-papszOptions : CSLConstList
+data_type: :py:class:`osgeo.gdal.ExtendedDataType`
+options: dict/list
+    an optional dict or list of driver specific ``NAME=VALUE`` option strings.
 
 Returns
 -------
 
-GDALMDArray - the new array
+MDArray:
+    the new :py:class:`osgeo.gdal.MDArray` or ``None`` on failure.
 
 Examples
 --------
->>> from osgeo import gdal
 >>> drv = gdal.GetDriverByName('MEM')
 >>> mem_ds = drv.CreateMultiDimensional('myds')
 >>> rg = mem_ds.GetRootGroup()

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -10,6 +10,7 @@
 %include "gdal_band_docs.i"
 %include "gdal_dataset_docs.i"
 %include "gdal_driver_docs.i"
+%include "gdal_mdm_docs.i"
 %include "gdal_operations_docs.i"
 
 %init %{

--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -26,6 +26,7 @@ set(GDAL_PYTHON_CSOURCES
        ${PROJECT_SOURCE_DIR}/swig/include/python/docs/gdal_band_docs.i
        ${PROJECT_SOURCE_DIR}/swig/include/python/docs/gdal_dataset_docs.i
        ${PROJECT_SOURCE_DIR}/swig/include/python/docs/gdal_driver_docs.i
+       ${PROJECT_SOURCE_DIR}/swig/include/python/docs/gdal_mdm_docs.i
        ${PROJECT_SOURCE_DIR}/swig/include/python/docs/gdal_operations_docs.i
        ${PROJECT_SOURCE_DIR}/swig/include/python/docs/ogr_docs.i
        ${PROJECT_SOURCE_DIR}/swig/include/python/docs/ogr_featuredef_docs.i


### PR DESCRIPTION
This pull request is a first attempt to create Python API documentation using the SWIG/Doxygen/Docstring approach. 
An example function from the "Multi-dimensional array API" has been documented, as discussed in #11916. 

The automated SWIG generated docstring is below:

```python
def CreateMDArray(self, *args):
    r"""
    CreateMDArray(Group self, char const * name, int dimensions, ExtendedDataType data_type, char ** options=None) -> MDArray
    """"
```
This is the source C++ function and docstring:

```c++
/** Create a multidimensional array within a group.
 *
 * It is recommended that the GDALDimension objects passed in aoDimensions
 * belong to this group, either by retrieving them with GetDimensions()
 * or creating a new one with CreateDimension().
 *
 * Optionally implemented.
 *
 * Drivers known to implement it: MEM, netCDF
 *
 * This is the same as the C function GDALGroupCreateMDArray().
 *
 * @note Driver implementation: drivers should take into account the possibility
 * that GDALDimension object passed in aoDimensions might belong to a different
 * group / dataset / driver and act accordingly.
 *
 * @param osName Array name.
 * @param aoDimensions List of dimensions, ordered from the slowest varying
 *                     dimension first to the fastest varying dimension last.
 *                     Might be empty for a scalar array (if supported by
 * driver)
 * @param oDataType  Array data type.
 * @param papszOptions Driver specific options determining how the array
 * should be created.
 *
 * @return the new array, or nullptr if case of error
 */
```

Questions!

> Some of our current docstrings are are essentially a single sentence, with a reference to the corresponding C or C++ docs:

1. Isn't this a good approach, to reduce duplication and to ensure the docs are up-to-date? If not should all the C++ docstring be copied into `gdal_mdm_docs.i`? A developer would then need to update both. 
2. When documenting Python parameters, is there any known approach on how to get the typemaps between the C++ parameters, and their Python equivalents? For example, ` char const * name` is clearly a `str`, but how do we know `ExtendedDataType data_type` would map to `oDataType: GDALExtendedDataType`? 
  In the SWIG output `dimensions` is an `int` but in the C++ function it is `const std::vector<std::shared_ptr<GDALDimension>> &aoDimensions,` . Correct types would be needed to allow linking in the Python API doc output. 
3. If adding examples, I presume these are best taken from the autotest suite? Would attempting to make them testable using [https://docs.python.org/3/library/doctest.html](doctest) be an option? However, many examples would benefit from referring to a dataset. 
4. Rather than inline examples, would sample scripts be a better option, with links from within the docs? E.g. a script or notebook demoing the Multidimensional API. 



Screenshot of current output below:

![image](https://github.com/user-attachments/assets/2c4bc959-5833-4d8d-829c-16aa6b4754ec)