### PR TITLE
Python bindings: Accept CRS definition in osr.SpatialReference constructor

### DIFF
--- a/autotest/osr/osr_basic.py
+++ b/autotest/osr/osr_basic.py
@@ -2495,47 +2495,173 @@ def test_osr_basic_GetAuthorityListFromDatabase():
 
 
 @pytest.mark.parametrize(
-    "arg,value",
+    "args,kwargs",
     (
-        pytest.param("epsg", 4326, id="epsg"),
-        pytest.param("proj4", "+proj=utm +zone=18 +datum=WGS84", id="proj4"),
+        pytest.param([], {"epsg": 4326}, id="epsg"),
+        pytest.param(["+proj=utm +zone=18 +datum=WGS84"], {}, id="proj4"),
         pytest.param(
-            "esri",
             [
-                "Projection    STATEPLANE",
-                "Fipszone      903",
-                "Datum         NAD83",
-                "Spheroid      GRS80",
-                "Units         FEET",
-                "Zunits        NO",
-                "Xshift        0.0",
-                "Yshift        0.0",
-                "Parameters    ",
-                "",
+                'PROJCS["NAD83 / Vermont (ftUS)",GEOGCS["NAD83",DATUM["North_American_Datum_1983",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],AUTHORITY["EPSG","6269"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4269"]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",42.5],PARAMETER["central_meridian",-72.5],PARAMETER["scale_factor",0.999964286],PARAMETER["false_easting",1640416.6667],PARAMETER["false_northing",0],UNIT["US survey foot",0.304800609601219,AUTHORITY["EPSG","9003"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","5646"]]'
             ],
-            id="esri",
+            {},
+            id="wkt",
         ),
         pytest.param(
-            "wkt",
-            'PROJCS["NAD83 / Vermont (ftUS)",GEOGCS["NAD83",DATUM["North_American_Datum_1983",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],AUTHORITY["EPSG","6269"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4269"]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",42.5],PARAMETER["central_meridian",-72.5],PARAMETER["scale_factor",0.999964286],PARAMETER["false_easting",1640416.6667],PARAMETER["false_northing",0],UNIT["US survey foot",0.304800609601219,AUTHORITY["EPSG","9003"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","5646"]]',
-            id="wkt",
+            [
+                '{\n  "$schema": "https://proj.org/schemas/v0.7/projjson.schema.json",\n  "type": "ProjectedCRS",\n  "name": "NAD83 / Vermont (ftUS)",\n  "base_crs": {\n    "name": "NAD83",\n    "datum": {\n      "type": "GeodeticReferenceFrame",\n      "name": "North American Datum 1983",\n      "ellipsoid": {\n        "name": "GRS 1980",\n        "semi_major_axis": 6378137,\n        "inverse_flattening": 298.257222101\n      }\n    },\n    "coordinate_system": {\n      "subtype": "ellipsoidal",\n      "axis": [\n        {\n          "name": "Geodetic latitude",\n          "abbreviation": "Lat",\n          "direction": "north",\n          "unit": "degree"\n        },\n        {\n          "name": "Geodetic longitude",\n          "abbreviation": "Lon",\n          "direction": "east",\n          "unit": "degree"\n        }\n      ]\n    },\n    "id": {\n      "authority": "EPSG",\n      "code": 4269\n    }\n  },\n  "conversion": {\n    "name": "SPCS83 Vermont zone (US survey foot)",\n    "method": {\n      "name": "Transverse Mercator",\n      "id": {\n        "authority": "EPSG",\n        "code": 9807\n      }\n    },\n    "parameters": [\n      {\n        "name": "Latitude of natural origin",\n        "value": 42.5,\n        "unit": "degree",\n        "id": {\n          "authority": "EPSG",\n          "code": 8801\n        }\n      },\n      {\n        "name": "Longitude of natural origin",\n        "value": -72.5,\n        "unit": "degree",\n        "id": {\n          "authority": "EPSG",\n          "code": 8802\n        }\n      },\n      {\n        "name": "Scale factor at natural origin",\n        "value": 0.999964286,\n        "unit": "unity",\n        "id": {\n          "authority": "EPSG",\n          "code": 8805\n        }\n      },\n      {\n        "name": "False easting",\n        "value": 1640416.6667,\n        "unit": {\n          "type": "LinearUnit",\n          "name": "US survey foot",\n          "conversion_factor": 0.304800609601219\n        },\n        "id": {\n          "authority": "EPSG",\n          "code": 8806\n        }\n      },\n      {\n        "name": "False northing",\n        "value": 0,\n        "unit": {\n          "type": "LinearUnit",\n          "name": "US survey foot",\n          "conversion_factor": 0.304800609601219\n        },\n        "id": {\n          "authority": "EPSG",\n          "code": 8807\n        }\n      }\n    ]\n  },\n  "coordinate_system": {\n    "subtype": "Cartesian",\n    "axis": [\n      {\n        "name": "Easting",\n        "abbreviation": "X",\n        "direction": "east",\n        "unit": {\n          "type": "LinearUnit",\n          "name": "US survey foot",\n          "conversion_factor": 0.304800609601219\n        }\n      },\n      {\n        "name": "Northing",\n        "abbreviation": "Y",\n        "direction": "north",\n        "unit": {\n          "type": "LinearUnit",\n          "name": "US survey foot",\n          "conversion_factor": 0.304800609601219\n        }\n      }\n    ]\n  },\n  "scope": "Engineering survey, topographic mapping.",\n  "area": "United States (USA) - Vermont - counties of Addison; Bennington; Caledonia; Chittenden; Essex; Franklin; Grand Isle; Lamoille; Orange; Orleans; Rutland; Washington; Windham; Windsor.",\n  "bbox": {\n    "south_latitude": 42.72,\n    "west_longitude": -73.44,\n    "north_latitude": 45.03,\n    "east_longitude": -71.5\n  },\n  "id": {\n    "authority": "EPSG",\n    "code": 5646\n  }\n}'
+            ],
+            {},
+            id="projjson text",
+        ),
+        pytest.param(
+            [
+                {
+                    "$schema": "https://proj.org/schemas/v0.7/projjson.schema.json",
+                    "type": "ProjectedCRS",
+                    "name": "NAD83 / Vermont (ftUS)",
+                    "base_crs": {
+                        "name": "NAD83",
+                        "datum": {
+                            "type": "GeodeticReferenceFrame",
+                            "name": "North American Datum 1983",
+                            "ellipsoid": {
+                                "name": "GRS 1980",
+                                "semi_major_axis": 6378137,
+                                "inverse_flattening": 298.257222101,
+                            },
+                        },
+                        "coordinate_system": {
+                            "subtype": "ellipsoidal",
+                            "axis": [
+                                {
+                                    "name": "Geodetic latitude",
+                                    "abbreviation": "Lat",
+                                    "direction": "north",
+                                    "unit": "degree",
+                                },
+                                {
+                                    "name": "Geodetic longitude",
+                                    "abbreviation": "Lon",
+                                    "direction": "east",
+                                    "unit": "degree",
+                                },
+                            ],
+                        },
+                        "id": {"authority": "EPSG", "code": 4269},
+                    },
+                    "conversion": {
+                        "name": "SPCS83 Vermont zone (US survey foot)",
+                        "method": {
+                            "name": "Transverse Mercator",
+                            "id": {"authority": "EPSG", "code": 9807},
+                        },
+                        "parameters": [
+                            {
+                                "name": "Latitude of natural origin",
+                                "value": 42.5,
+                                "unit": "degree",
+                                "id": {"authority": "EPSG", "code": 8801},
+                            },
+                            {
+                                "name": "Longitude of natural origin",
+                                "value": -72.5,
+                                "unit": "degree",
+                                "id": {"authority": "EPSG", "code": 8802},
+                            },
+                            {
+                                "name": "Scale factor at natural origin",
+                                "value": 0.999964286,
+                                "unit": "unity",
+                                "id": {"authority": "EPSG", "code": 8805},
+                            },
+                            {
+                                "name": "False easting",
+                                "value": 1640416.6667,
+                                "unit": {
+                                    "type": "LinearUnit",
+                                    "name": "US survey foot",
+                                    "conversion_factor": 0.304800609601219,
+                                },
+                                "id": {"authority": "EPSG", "code": 8806},
+                            },
+                            {
+                                "name": "False northing",
+                                "value": 0,
+                                "unit": {
+                                    "type": "LinearUnit",
+                                    "name": "US survey foot",
+                                    "conversion_factor": 0.304800609601219,
+                                },
+                                "id": {"authority": "EPSG", "code": 8807},
+                            },
+                        ],
+                    },
+                    "coordinate_system": {
+                        "subtype": "Cartesian",
+                        "axis": [
+                            {
+                                "name": "Easting",
+                                "abbreviation": "X",
+                                "direction": "east",
+                                "unit": {
+                                    "type": "LinearUnit",
+                                    "name": "US survey foot",
+                                    "conversion_factor": 0.304800609601219,
+                                },
+                            },
+                            {
+                                "name": "Northing",
+                                "abbreviation": "Y",
+                                "direction": "north",
+                                "unit": {
+                                    "type": "LinearUnit",
+                                    "name": "US survey foot",
+                                    "conversion_factor": 0.304800609601219,
+                                },
+                            },
+                        ],
+                    },
+                    "scope": "Engineering survey, topographic mapping.",
+                    "area": "United States (USA) - Vermont - counties of Addison; Bennington; Caledonia; Chittenden; Essex; Franklin; Grand Isle; Lamoille; Orange; Orleans; Rutland; Washington; Windham; Windsor.",
+                    "bbox": {
+                        "south_latitude": 42.72,
+                        "west_longitude": -73.44,
+                        "north_latitude": 45.03,
+                        "east_longitude": -71.5,
+                    },
+                    "id": {"authority": "EPSG", "code": 5646},
+                }
+            ],
+            {},
+            id="projjson dict",
         ),
     ),
 )
-def test_osr_basic_constructor(arg, value):
+def test_osr_basic_constructor(args, kwargs):
 
-    srs = osr.SpatialReference(**{arg: value})
+    srs = osr.SpatialReference(*args, **kwargs)
 
     assert srs.ExportToWkt() != ""
 
 
+@pytest.mark.parametrize("arg", ("", None))
+def test_osr_basic_constructor_empty(arg):
+
+    srs = osr.SpatialReference(arg)
+    assert srs is not None
+
+
 def test_osr_basic_constructor_overspecified():
 
-    with pytest.raises(ValueError, match="at most one"):
-        osr.SpatialReference(epsg=4326, proj4="+proj=utm +zone=18 +datum=WGS84")
+    # The arguments provided here don't make any sense.
+    # But SpatialReference.SetFromUserInput doesn't seem to complain if we pass it
+    # unexpected options, so we have no way to catch this for now.
+
+    with pytest.raises(ValueError, match="Unexpected argument"):
+        osr.SpatialReference(proj4="+proj=utm +zone=18 +datum=WGS84", epsg=4326)
 
 
 def test_osr_basic_constructor_invalid_kwarg():
 
-    with pytest.raises(TypeError, match="invalid keyword argument"):
+    with pytest.raises(ValueError, match="Unexpected argument"):
         osr.SpatialReference(description="VT State Plane")

--- a/autotest/osr/osr_basic.py
+++ b/autotest/osr/osr_basic.py
@@ -2489,3 +2489,53 @@ def test_osr_basic_GetAuthorityListFromDatabase():
     ret = osr.GetAuthorityListFromDatabase()
     assert "EPSG" in ret
     assert "PROJ" in ret
+
+
+###############################################################################
+
+
+@pytest.mark.parametrize(
+    "arg,value",
+    (
+        pytest.param("epsg", 4326, id="epsg"),
+        pytest.param("proj4", "+proj=utm +zone=18 +datum=WGS84", id="proj4"),
+        pytest.param(
+            "esri",
+            [
+                "Projection    STATEPLANE",
+                "Fipszone      903",
+                "Datum         NAD83",
+                "Spheroid      GRS80",
+                "Units         FEET",
+                "Zunits        NO",
+                "Xshift        0.0",
+                "Yshift        0.0",
+                "Parameters    ",
+                "",
+            ],
+            id="esri",
+        ),
+        pytest.param(
+            "wkt",
+            'PROJCS["NAD83 / Vermont (ftUS)",GEOGCS["NAD83",DATUM["North_American_Datum_1983",SPHEROID["GRS 1980",6378137,298.257222101,AUTHORITY["EPSG","7019"]],AUTHORITY["EPSG","6269"]],PRIMEM["Greenwich",0,AUTHORITY["EPSG","8901"]],UNIT["degree",0.0174532925199433,AUTHORITY["EPSG","9122"]],AUTHORITY["EPSG","4269"]],PROJECTION["Transverse_Mercator"],PARAMETER["latitude_of_origin",42.5],PARAMETER["central_meridian",-72.5],PARAMETER["scale_factor",0.999964286],PARAMETER["false_easting",1640416.6667],PARAMETER["false_northing",0],UNIT["US survey foot",0.304800609601219,AUTHORITY["EPSG","9003"]],AXIS["Easting",EAST],AXIS["Northing",NORTH],AUTHORITY["EPSG","5646"]]',
+            id="wkt",
+        ),
+    ),
+)
+def test_osr_basic_constructor(arg, value):
+
+    srs = osr.SpatialReference(**{arg: value})
+
+    assert srs.ExportToWkt() != ""
+
+
+def test_osr_basic_constructor_overspecified():
+
+    with pytest.raises(ValueError, match="at most one"):
+        osr.SpatialReference(epsg=4326, proj4="+proj=utm +zone=18 +datum=WGS84")
+
+
+def test_osr_basic_constructor_invalid_kwarg():
+
+    with pytest.raises(TypeError, match="invalid keyword argument"):
+        osr.SpatialReference(description="VT State Plane")

--- a/swig/include/python/docs/osr_spatialreference_docs.i
+++ b/swig/include/python/docs/osr_spatialreference_docs.i
@@ -1,5 +1,26 @@
 %feature("docstring") OSRSpatialReferenceShadow "
 Python proxy of an :cpp:class:`OGRSpatialReference`.
+
+Create a new spatial reference object. An empty object will be created
+unless exactly one of the following parameters is provided.
+
+Parameters
+----------
+epsg : int, optional
+    EPSG CRS code, as understood by :py:meth:`ImportFromEPSG`
+esri : list, optional
+    ESRI ``.prj`` text, as understood by :py:meth:`ImportFromESRI`
+proj4 : str, optional
+    PROJ CRS string, as understood by :py:meth:`ImportFromProj4`
+wkt : str, optional
+    WKT CRS string, as understood by :py:meth:`ImportFromWkt`
+
+Examples
+--------
+>>> osr.SpatialReference(epsg=5646).GetName()
+'NAD83 / Vermont (ftUS)'
+>>> osr.SpatialReference(proj4='+proj=utm +zone=18 +datum=WGS84').GetUTMZone()
+18
 ";
 
 %extend OSRSpatialReferenceShadow {

--- a/swig/include/python/docs/osr_spatialreference_docs.i
+++ b/swig/include/python/docs/osr_spatialreference_docs.i
@@ -6,12 +6,10 @@ unless exactly one of the following parameters is provided.
 
 Parameters
 ----------
+name : str / dict, optional
+    SRS description in a format understood by :py:meth:`SetFromUserInput`.
 epsg : int, optional
     EPSG CRS code, as understood by :py:meth:`ImportFromEPSG`
-esri : list, optional
-    ESRI ``.prj`` text, as understood by :py:meth:`ImportFromESRI`
-proj4 : str, optional
-    PROJ CRS string, as understood by :py:meth:`ImportFromProj4`
 wkt : str, optional
     WKT CRS string, as understood by :py:meth:`ImportFromWkt`
 
@@ -19,7 +17,7 @@ Examples
 --------
 >>> osr.SpatialReference(epsg=5646).GetName()
 'NAD83 / Vermont (ftUS)'
->>> osr.SpatialReference(proj4='+proj=utm +zone=18 +datum=WGS84').GetUTMZone()
+>>> osr.SpatialReference('+proj=utm +zone=18 +datum=WGS84').GetUTMZone()
 18
 ";
 

--- a/swig/include/python/osr_python.i
+++ b/swig/include/python/osr_python.i
@@ -53,17 +53,34 @@ def _WarnIfUserHasNotSpecifiedIfUsingExceptions():
 
         _WarnIfUserHasNotSpecifiedIfUsingExceptions()
 
-        if len(kwargs) > 1:
-            raise ValueError("Must specify at most one of: wkt, epsg, esri, proj4")
+        user_input = None
 
-        orig_kwargs = kwargs.copy()
-        for k in ("epsg", "esri", "proj4"):
-            if k in kwargs:
-                del kwargs[k]
+        if len(args) + len(kwargs) > 1:
+            # We could pass additional kwargs as options to SetFromUserInput,
+            # but that is not commonly needed and limits our ability to
+            # validate arguments here.
+            raise ValueError("Unexpected argument to SpatialReference")
+
+        if kwargs:
+            if "wkt" in kwargs:
+                user_input = kwargs["wkt"]
+            elif "name" in kwargs:
+                user_input = kwargs["name"]
+            elif "epsg" in kwargs:
+                user_input = f'EPSG:{kwargs["epsg"]}'
+            else:
+                raise ValueError("Unexpected argument to SpatialReference")
+
+        if args:
+            if type(args[0]) is dict:
+                import json
+                user_input = json.dumps(args[0])
+            else:
+                user_input = args[0]
 
         try:
             with ExceptionMgr(useExceptions=True):
-                this = _osr.new_SpatialReference(*args, **kwargs)
+                this = _osr.new_SpatialReference()
         finally:
             pass
         if hasattr(_osr, "SpatialReference_swiginit"):
@@ -76,12 +93,8 @@ def _WarnIfUserHasNotSpecifiedIfUsingExceptions():
             except __builtin__.Exception:
                 self.this = this
 
-        if "epsg" in orig_kwargs:
-            self.ImportFromEPSG(orig_kwargs["epsg"])
-        if "esri" in orig_kwargs:
-            self.ImportFromESRI(orig_kwargs["esri"])
-        if "proj4" in orig_kwargs:
-            self.ImportFromProj4(orig_kwargs["proj4"])
+        if user_input:
+            self.SetFromUserInput(user_input)
 
   %}
 

--- a/swig/include/python/osr_python.i
+++ b/swig/include/python/osr_python.i
@@ -53,6 +53,14 @@ def _WarnIfUserHasNotSpecifiedIfUsingExceptions():
 
         _WarnIfUserHasNotSpecifiedIfUsingExceptions()
 
+        if len(kwargs) > 1:
+            raise ValueError("Must specify at most one of: wkt, epsg, esri, proj4")
+
+        orig_kwargs = kwargs.copy()
+        for k in ("epsg", "esri", "proj4"):
+            if k in kwargs:
+                del kwargs[k]
+
         try:
             with ExceptionMgr(useExceptions=True):
                 this = _osr.new_SpatialReference(*args, **kwargs)
@@ -67,6 +75,13 @@ def _WarnIfUserHasNotSpecifiedIfUsingExceptions():
                 self.this.append(this)
             except __builtin__.Exception:
                 self.this = this
+
+        if "epsg" in orig_kwargs:
+            self.ImportFromEPSG(orig_kwargs["epsg"])
+        if "esri" in orig_kwargs:
+            self.ImportFromESRI(orig_kwargs["esri"])
+        if "proj4" in orig_kwargs:
+            self.ImportFromProj4(orig_kwargs["proj4"])
 
   %}
 


### PR DESCRIPTION
Resolves #12006