### PR TITLE
Move 2 more tutorials to use tabs

### DIFF
--- a/doc/source/tutorials/code/vector_api_tut.py
+++ b/doc/source/tutorials/code/vector_api_tut.py
@@ -34,6 +34,6 @@ for feat in lyr:
     if geom is not None and geom.GetGeometryType() == ogr.wkbPoint:
         print("%.3f, %.3f" % (geom.GetX(), geom.GetY()))
     else:
-        print("no point geometry\n")
+        print("no point geometry")
 
 ds = None

--- a/doc/source/tutorials/code/vector_api_tut.py
+++ b/doc/source/tutorials/code/vector_api_tut.py
@@ -1,0 +1,42 @@
+import sys
+from osgeo import gdal
+from osgeo import ogr
+
+gdal.UseExceptions()
+
+ds = gdal.OpenEx("point", gdal.OF_VECTOR)
+if ds is None:
+    print("Open failed.\n")
+    sys.exit(1)
+
+lyr = ds.GetLayerByName("point")
+
+lyr.ResetReading()
+
+for feat in lyr:
+
+    feat_defn = lyr.GetLayerDefn()
+    for i in range(feat_defn.GetFieldCount()):
+        field_defn = feat_defn.GetFieldDefn(i)
+
+        # Tests below can be simplified with just :
+        # print feat.GetField(i)
+        if (
+            field_defn.GetType() == ogr.OFTInteger
+            or field_defn.GetType() == ogr.OFTInteger64
+        ):
+            print("%d" % feat.GetFieldAsInteger64(i))
+        elif field_defn.GetType() == ogr.OFTReal:
+            print("%.3f" % feat.GetFieldAsDouble(i))
+        elif field_defn.GetType() == ogr.OFTString:
+            print("%s" % feat.GetFieldAsString(i))
+        else:
+            print("%s" % feat.GetFieldAsString(i))
+
+    geom = feat.GetGeometryRef()
+    if geom is not None and geom.GetGeometryType() == ogr.wkbPoint:
+        print("%.3f, %.3f" % (geom.GetX(), geom.GetY()))
+    else:
+        print("no point geometry\n")
+
+ds = None

--- a/doc/source/tutorials/code/vector_api_tut.py
+++ b/doc/source/tutorials/code/vector_api_tut.py
@@ -5,9 +5,6 @@ from osgeo import ogr
 gdal.UseExceptions()
 
 ds = gdal.OpenEx("point", gdal.OF_VECTOR)
-if ds is None:
-    print("Open failed.\n")
-    sys.exit(1)
 
 lyr = ds.GetLayerByName("point")
 

--- a/doc/source/tutorials/code/vector_api_tut.py
+++ b/doc/source/tutorials/code/vector_api_tut.py
@@ -36,4 +36,4 @@ for feat in lyr:
     else:
         print("no point geometry")
 
-ds = None
+ds.Close()

--- a/doc/source/tutorials/code/vector_api_tut2.py
+++ b/doc/source/tutorials/code/vector_api_tut2.py
@@ -42,4 +42,4 @@ while len(linelist) == 3:
     linestring = input()
     linelist = linestring.split()
 
-ds = None
+ds.Close()

--- a/doc/source/tutorials/code/vector_api_tut2.py
+++ b/doc/source/tutorials/code/vector_api_tut2.py
@@ -1,6 +1,6 @@
 import sys
-from osgeo import gdal
-from osgeo import ogr
+
+from osgeo import gdal, ogr
 
 gdal.UseExceptions()
 driverName = "ESRI Shapefile"
@@ -16,7 +16,7 @@ lyr = ds.CreateLayer("point_out", None, ogr.wkbPoint)
 field_defn = ogr.FieldDefn("Name", ogr.OFTString)
 field_defn.SetWidth(32)
 
-lyr.CreateField(field_defn
+lyr.CreateField(field_defn)
 
 # Expected format of user input: x y name
 linestring = input()

--- a/doc/source/tutorials/code/vector_api_tut2.py
+++ b/doc/source/tutorials/code/vector_api_tut2.py
@@ -12,9 +12,6 @@ if drv is None:
 ds = drv.Create("point_out.shp", 0, 0, 0, gdal.GDT_Unknown)
 
 lyr = ds.CreateLayer("point_out", None, ogr.wkbPoint)
-if lyr is None:
-    print("Layer creation failed.\n")
-    sys.exit(1)
 
 field_defn = ogr.FieldDefn("Name", ogr.OFTString)
 field_defn.SetWidth(32)

--- a/doc/source/tutorials/code/vector_api_tut2.py
+++ b/doc/source/tutorials/code/vector_api_tut2.py
@@ -10,9 +10,6 @@ if drv is None:
     sys.exit(1)
 
 ds = drv.Create("point_out.shp", 0, 0, 0, gdal.GDT_Unknown)
-if ds is None:
-    print("Creation of output file failed.\n")
-    sys.exit(1)
 
 lyr = ds.CreateLayer("point_out", None, ogr.wkbPoint)
 if lyr is None:

--- a/doc/source/tutorials/code/vector_api_tut2.py
+++ b/doc/source/tutorials/code/vector_api_tut2.py
@@ -6,7 +6,7 @@ gdal.UseExceptions()
 driverName = "ESRI Shapefile"
 drv = gdal.GetDriverByName(driverName)
 if drv is None:
-    print("%s driver not available.\n" % driverName)
+    print("%s driver not available." % driverName)
     sys.exit(1)
 
 ds = drv.Create("point_out.shp", 0, 0, 0, gdal.GDT_Unknown)

--- a/doc/source/tutorials/code/vector_api_tut2.py
+++ b/doc/source/tutorials/code/vector_api_tut2.py
@@ -1,0 +1,55 @@
+import sys
+from osgeo import gdal
+from osgeo import ogr
+
+
+driverName = "ESRI Shapefile"
+drv = gdal.GetDriverByName(driverName)
+if drv is None:
+    print("%s driver not available.\n" % driverName)
+    sys.exit(1)
+
+ds = drv.Create("point_out.shp", 0, 0, 0, gdal.GDT_Unknown)
+if ds is None:
+    print("Creation of output file failed.\n")
+    sys.exit(1)
+
+lyr = ds.CreateLayer("point_out", None, ogr.wkbPoint)
+if lyr is None:
+    print("Layer creation failed.\n")
+    sys.exit(1)
+
+field_defn = ogr.FieldDefn("Name", ogr.OFTString)
+field_defn.SetWidth(32)
+
+if lyr.CreateField(field_defn) != 0:
+    print("Creating Name field failed.\n")
+    sys.exit(1)
+
+# Expected format of user input: x y name
+linestring = input()
+linelist = linestring.split()
+
+while len(linelist) == 3:
+    x = float(linelist[0])
+    y = float(linelist[1])
+    name = linelist[2]
+
+    feat = ogr.Feature(lyr.GetLayerDefn())
+    feat.SetField("Name", name)
+
+    pt = ogr.Geometry(ogr.wkbPoint)
+    pt.SetPoint_2D(0, x, y)
+
+    feat.SetGeometry(pt)
+
+    if lyr.CreateFeature(feat) != 0:
+        print("Failed to create feature in shapefile.\n")
+        sys.exit(1)
+
+    feat.Destroy()
+
+    linestring = input()
+    linelist = linestring.split()
+
+ds = None

--- a/doc/source/tutorials/code/vector_api_tut2.py
+++ b/doc/source/tutorials/code/vector_api_tut2.py
@@ -16,9 +16,7 @@ lyr = ds.CreateLayer("point_out", None, ogr.wkbPoint)
 field_defn = ogr.FieldDefn("Name", ogr.OFTString)
 field_defn.SetWidth(32)
 
-if lyr.CreateField(field_defn) != 0:
-    print("Creating Name field failed.\n")
-    sys.exit(1)
+lyr.CreateField(field_defn
 
 # Expected format of user input: x y name
 linestring = input()

--- a/doc/source/tutorials/code/vector_api_tut2.py
+++ b/doc/source/tutorials/code/vector_api_tut2.py
@@ -2,7 +2,7 @@ import sys
 from osgeo import gdal
 from osgeo import ogr
 
-
+gdal.UseExceptions()
 driverName = "ESRI Shapefile"
 drv = gdal.GetDriverByName(driverName)
 if drv is None:

--- a/doc/source/tutorials/code/vector_api_tut2.py
+++ b/doc/source/tutorials/code/vector_api_tut2.py
@@ -35,9 +35,7 @@ while len(linelist) == 3:
 
     feat.SetGeometry(pt)
 
-    if lyr.CreateFeature(feat) != 0:
-        print("Failed to create feature in shapefile.\n")
-        sys.exit(1)
+    lyr.CreateFeature(feat)
 
     feat.Destroy()
 

--- a/doc/source/tutorials/code/vector_api_tut2.py
+++ b/doc/source/tutorials/code/vector_api_tut2.py
@@ -37,8 +37,6 @@ while len(linelist) == 3:
 
     lyr.CreateFeature(feat)
 
-    feat.Destroy()
-
     linestring = input()
     linelist = linestring.split()
 

--- a/doc/source/tutorials/multidimensional_api_tut.rst
+++ b/doc/source/tutorials/multidimensional_api_tut.rst
@@ -7,146 +7,132 @@ Multidimensional raster API tutorial
 Read the content of an array
 ----------------------------
 
-In C++
-++++++
+.. tabs::
 
-.. code-block:: c++
+   .. code-tab:: c++
 
-    #include "gdal_priv.h"
-    int main()
-    {
-        GDALAllRegister();
-        auto poDataset = std::unique_ptr<GDALDataset>(
-            GDALDataset::Open( "in.nc", GDAL_OF_MULTIDIM_RASTER ));
-        if( !poDataset )
-        {
-            exit(1);
-        }
-        auto poRootGroup = poDataset->GetRootGroup();
-        if( !poRootGroup )
-        {
-            exit(1);
-        }
-        auto poVar = poRootGroup->OpenMDArray("temperature");
-        if( !poVar )
-        {
-            exit(1);
-        }
-        size_t nValues = 1;
-        std::vector<size_t> anCount;
-        for( const auto poDim: poVar->GetDimensions() )
-        {
-            anCount.push_back(static_cast<size_t>(poDim->GetSize()));
-            nValues *= anCount.back();
-        }
-        std::vector<double> values(nValues);
-        poVar->Read(std::vector<GUInt64>{0,0,0}.data(),
-                    anCount.data(),
-                    nullptr, /* step: defaults to 1,1,1 */
-                    nullptr, /* stride: default to row-major convention */
-                    GDALExtendedDataType::Create(GDT_Float64),
-                    &values[0]);
-        return 0;
-    }
+      #include "gdal_priv.h"
+      int main()
+      {
+          GDALAllRegister();
+          auto poDataset = std::unique_ptr<GDALDataset>(
+              GDALDataset::Open( "in.nc", GDAL_OF_MULTIDIM_RASTER ));
+          if( !poDataset )
+          {
+              exit(1);
+          }
+          auto poRootGroup = poDataset->GetRootGroup();
+          if( !poRootGroup )
+          {
+              exit(1);
+          }
+          auto poVar = poRootGroup->OpenMDArray("temperature");
+          if( !poVar )
+          {
+              exit(1);
+          }
+          size_t nValues = 1;
+          std::vector<size_t> anCount;
+          for( const auto poDim: poVar->GetDimensions() )
+          {
+              anCount.push_back(static_cast<size_t>(poDim->GetSize()));
+              nValues *= anCount.back();
+          }
+          std::vector<double> values(nValues);
+          poVar->Read(std::vector<GUInt64>{0,0,0}.data(),
+                      anCount.data(),
+                      nullptr, /* step: defaults to 1,1,1 */
+                      nullptr, /* stride: default to row-major convention */
+                      GDALExtendedDataType::Create(GDT_Float64),
+                      &values[0]);
+          return 0;
+      }
 
-In C
-++++
+   .. code-tab:: c
 
-.. code-block:: c
+      #include "gdal.h"
+      #include "cpl_conv.h"
+      int main()
+      {
+          GDALDatasetH hDS;
+          GDALGroupH hGroup;
+          GDALMDArrayH hVar;
+          size_t nDimCount;
+          GDALDimensionH* dims;
+          size_t nValues;
+          size_t i;
+          size_t* panCount;
+          GUInt64* panOffset;
+          double* padfValues;
+          GDALExtendedDataTypeH hDT;
 
-    #include "gdal.h"
-    #include "cpl_conv.h"
-    int main()
-    {
-        GDALDatasetH hDS;
-        GDALGroupH hGroup;
-        GDALMDArrayH hVar;
-        size_t nDimCount;
-        GDALDimensionH* dims;
-        size_t nValues;
-        size_t i;
-        size_t* panCount;
-        GUInt64* panOffset;
-        double* padfValues;
-        GDALExtendedDataTypeH hDT;
+          GDALAllRegister();
+          hDS = GDALOpenEx( "in.nc", GDAL_OF_MULTIDIM_RASTER, NULL, NULL, NULL);
+          if( !hDS )
+          {
+              exit(1);
+          }
+          hGroup = GDALDatasetGetRootGroup(hDS);
+          GDALReleaseDataset(hDS);
+          if( !hGroup )
+          {
+              exit(1);
+          }
+          hVar = GDALGroupOpenMDArray(hGroup, "temperature", NULL);
+          GDALGroupRelease(hGroup);
+          if( !hVar )
+          {
+              exit(1);
+          }
 
-        GDALAllRegister();
-        hDS = GDALOpenEx( "in.nc", GDAL_OF_MULTIDIM_RASTER, NULL, NULL, NULL);
-        if( !hDS )
-        {
-            exit(1);
-        }
-        hGroup = GDALDatasetGetRootGroup(hDS);
-        GDALReleaseDataset(hDS);
-        if( !hGroup )
-        {
-            exit(1);
-        }
-        hVar = GDALGroupOpenMDArray(hGroup, "temperature", NULL);
-        GDALGroupRelease(hGroup);
-        if( !hVar )
-        {
-            exit(1);
-        }
+          dims = GDALMDArrayGetDimensions(hVar, &nDimCount);
+          panCount = (size_t*)CPLMalloc(nDimCount * sizeof(size_t));
+          nValues = 1;
+          for( i = 0; i < nDimCount; i++ )
+          {
+              panCount[i] = GDALDimensionGetSize(dims[i]);
+              nValues *= panCount[i];
+          }
+          GDALReleaseDimensions(dims, nDimCount);
+          panOffset = (GUInt64*)CPLCalloc(nDimCount, sizeof(GUInt64));
 
-        dims = GDALMDArrayGetDimensions(hVar, &nDimCount);
-        panCount = (size_t*)CPLMalloc(nDimCount * sizeof(size_t));
-        nValues = 1;
-        for( i = 0; i < nDimCount; i++ )
-        {
-            panCount[i] = GDALDimensionGetSize(dims[i]);
-            nValues *= panCount[i];
-        }
-        GDALReleaseDimensions(dims, nDimCount);
-        panOffset = (GUInt64*)CPLCalloc(nDimCount, sizeof(GUInt64));
+          padfValues = (double*)VSIMalloc2(nValues, sizeof(double));
+          if( !padfValues )
+          {
+              GDALMDArrayRelease(hVar);
+              CPLFree(panOffset);
+              CPLFree(panCount);
+              exit(1);
+          }
+          hDT = GDALExtendedDataTypeCreate(GDT_Float64);
+          GDALMDArrayRead(hVar,
+                          panOffset,
+                          panCount,
+                          NULL, /* step: defaults to 1,1,1 */
+                          NULL, /* stride: default to row-major convention */
+                          hDT,
+                          padfValues,
+                          NULL, /* array start. Omitted */
+                          0 /* array size in bytes. Omitted */);
+          GDALExtendedDataTypeRelease(hDT);
+          GDALMDArrayRelease(hVar);
+          CPLFree(panOffset);
+          CPLFree(panCount);
+          VSIFree(padfValues);
 
-        padfValues = (double*)VSIMalloc2(nValues, sizeof(double));
-        if( !padfValues )
-        {
-            GDALMDArrayRelease(hVar);
-            CPLFree(panOffset);
-            CPLFree(panCount);
-            exit(1);
-        }
-        hDT = GDALExtendedDataTypeCreate(GDT_Float64);
-        GDALMDArrayRead(hVar,
-                        panOffset,
-                        panCount,
-                        NULL, /* step: defaults to 1,1,1 */
-                        NULL, /* stride: default to row-major convention */
-                        hDT,
-                        padfValues,
-                        NULL, /* array start. Omitted */
-                        0 /* array size in bytes. Omitted */);
-        GDALExtendedDataTypeRelease(hDT);
-        GDALMDArrayRelease(hVar);
-        CPLFree(panOffset);
-        CPLFree(panCount);
-        VSIFree(padfValues);
+          return 0;
+      }
 
-        return 0;
-    }
+   .. code-tab:: python
 
-In Python
-+++++++++
+      from osgeo import gdal
+      ds = gdal.OpenEx("in.nc", gdal.OF_MULTIDIM_RASTER)
+      rootGroup = ds.GetRootGroup()
+      var = rootGroup.OpenMDArray("temperature")
+      data = var.Read(buffer_datatype = gdal.ExtendedDataType.Create(gdal.GDT_Float64))
 
-.. code-block:: python
-
-    from osgeo import gdal
-    ds = gdal.OpenEx("in.nc", gdal.OF_MULTIDIM_RASTER)
-    rootGroup = ds.GetRootGroup()
-    var = rootGroup.OpenMDArray("temperature")
-    data = var.Read(buffer_datatype = gdal.ExtendedDataType.Create(gdal.GDT_Float64))
-
-If NumPy is available:
-
-.. code-block:: python
-
-    from osgeo import gdal
-    ds = gdal.OpenEx("in.nc", gdal.OF_MULTIDIM_RASTER)
-    rootGroup = ds.GetRootGroup()
-    var = rootGroup.OpenMDArray("temperature")
-    data = var.ReadAsArray(buffer_datatype = gdal.ExtendedDataType.Create(gdal.GDT_Float64))
+      # if NumPy is available we can use ReadAsArray
+      data = var.ReadAsArray(buffer_datatype = gdal.ExtendedDataType.Create(gdal.GDT_Float64))
 
 
 Other examples

--- a/doc/source/tutorials/vector_api_tut.rst
+++ b/doc/source/tutorials/vector_api_tut.rst
@@ -22,28 +22,26 @@ Initially it is necessary to register all the format drivers that are desired.
 This is normally accomplished by calling :cpp:func:`GDALAllRegister` which registers
 all format drivers built into GDAL/OGR.
 
-In C++ :
+.. tabs::
 
-.. code-block:: c++
+   .. code-tab:: c++
 
-    #include "ogrsf_frmts.h"
+      #include "ogrsf_frmts.h"
 
-    int main()
+      int main()
 
-    {
-        GDALAllRegister();
+      {
+          GDALAllRegister();
 
 
-In C :
+   .. code-tab:: c
 
-.. code-block:: c
+      #include "gdal.h"
 
-    #include "gdal.h"
+      int main()
 
-    int main()
-
-    {
-        GDALAllRegister();
+      {
+          GDALAllRegister();
 
 Next we need to open the input OGR datasource.  Datasources can be files,
 RDBMSes, directories full of files, or even remote web services depending on
@@ -54,224 +52,151 @@ that we want a vector driver to be use and that don't require update access.
 On failure NULL is returned, and
 we report an error.
 
-In C++ :
+.. tabs::
 
-.. code-block:: c++
+   .. code-tab:: c++
 
-    GDALDataset       *poDS;
+      GDALDataset       *poDS;
 
-    poDS = (GDALDataset*) GDALOpenEx( "point.shp", GDAL_OF_VECTOR, NULL, NULL, NULL );
-    if( poDS == NULL )
-    {
-        printf( "Open failed.\n" );
-        exit( 1 );
-    }
+      poDS = (GDALDataset*) GDALOpenEx( "point.shp", GDAL_OF_VECTOR, NULL, NULL, NULL );
+      if( poDS == NULL )
+      {
+          printf( "Open failed.\n" );
+          exit( 1 );
+      }
 
-In C :
+   .. code-tab:: c
 
-.. code-block:: c
+      GDALDatasetH hDS;
 
-    GDALDatasetH hDS;
-
-    hDS = GDALOpenEx( "point.shp", GDAL_OF_VECTOR, NULL, NULL, NULL );
-    if( hDS == NULL )
-    {
-        printf( "Open failed.\n" );
-        exit( 1 );
-    }
+      hDS = GDALOpenEx( "point.shp", GDAL_OF_VECTOR, NULL, NULL, NULL );
+      if( hDS == NULL )
+      {
+          printf( "Open failed.\n" );
+          exit( 1 );
+      }
 
 A GDALDataset can potentially have many layers associated with it.  The
 number of layers available can be queried with :cpp:func:`GDALDataset::GetLayerCount`
 and individual layers fetched by index using :cpp:func:`GDALDataset::GetLayer`.
 However, we will just fetch the layer by name.
 
-In C++ :
+.. tabs::
 
-.. code-block:: c++
+   .. code-tab:: c++
 
-    OGRLayer  *poLayer;
+      OGRLayer  *poLayer;
 
-    poLayer = poDS->GetLayerByName( "point" );
+      poLayer = poDS->GetLayerByName( "point" );
 
-In C :
+   .. code-tab:: c
 
-.. code-block:: c
+      OGRLayerH hLayer;
 
-    OGRLayerH hLayer;
-
-    hLayer = GDALDatasetGetLayerByName( hDS, "point" );
+      hLayer = GDALDatasetGetLayerByName( hDS, "point" );
 
 
 Now we want to start reading features from the layer.  Before we start we
 could assign an attribute or spatial filter to the layer to restrict the set
 of feature we get back, but for now we are interested in getting all features.
 
-With GDAL 2.3 and C++11:
+.. tabs::
 
-.. code-block:: c++
+   .. code-tab:: c++
 
-    for( auto& poFeature: poLayer )
-    {
+      for( auto& poFeature: poLayer )
+      {
 
-With GDAL 2.3 and C:
+   .. code-tab:: c
 
-.. code-block:: c
+      OGR_FOR_EACH_FEATURE_BEGIN(hFeature, hLayer)
+      {
 
-    OGR_FOR_EACH_FEATURE_BEGIN(hFeature, hLayer)
-    {
-
-If using older GDAL versions, while it isn't strictly necessary in this
-circumstance since we are starting fresh with the layer, it is often wise
-to call :cpp:func:`OGRLayer::ResetReading` to ensure we are starting at the beginning of
-the layer.  We iterate through all the features in the layer using
-OGRLayer::GetNextFeature().  It will return NULL when we run out of features.
-
-With GDAL < 2.3 and C++ :
-
-.. code-block:: c++
-
-    OGRFeature *poFeature;
-
-    poLayer->ResetReading();
-    while( (poFeature = poLayer->GetNextFeature()) != NULL )
-    {
-
-
-With GDAL < 2.3 and C :
-
-.. code-block:: c
-
-    OGRFeatureH hFeature;
-
-    OGR_L_ResetReading(hLayer);
-    while( (hFeature = OGR_L_GetNextFeature(hLayer)) != NULL )
-    {
 
 In order to dump all the attribute fields of the feature, it is helpful
 to get the :cpp:class:`OGRFeatureDefn`.  This is an object, associated with the layer,
 containing the definitions of all the fields.  We loop over all the fields,
 and fetch and report the attributes based on their type.
 
-With GDAL 2.3 and C++11:
+.. tabs::
 
-.. code-block:: c++
+   .. code-tab:: c++
 
-    for( auto&& oField: *poFeature )
-    {
-        if( oField.IsUnset() )
-        {
-            printf("(unset),");
-            continue;
-        }
-        if( oField.IsNull() )
-        {
-            printf("(null),");
-            continue;
-        }
-        switch( oField.GetType() )
-        {
-            case OFTInteger:
-                printf( "%d,", oField.GetInteger() );
-                break;
-            case OFTInteger64:
-                printf( CPL_FRMT_GIB ",", oField.GetInteger64() );
-                break;
-            case OFTReal:
-                printf( "%.3f,", oField.GetDouble() );
-                break;
-            case OFTString:
-                // GetString() returns a C string
-                printf( "%s,", oField.GetString() );
-                break;
-            default:
-                // Note: we use GetAsString() and not GetString(), since
-                // the later assumes the field type to be OFTString while the
-                // former will do a conversion from the original type to string.
-                printf( "%s,", oField.GetAsString() );
-                break;
-        }
-    }
+      for( auto&& oField: *poFeature )
+      {
+          if( oField.IsUnset() )
+          {
+              printf("(unset),");
+              continue;
+          }
+          if( oField.IsNull() )
+          {
+              printf("(null),");
+              continue;
+          }
+          switch( oField.GetType() )
+          {
+              case OFTInteger:
+                  printf( "%d,", oField.GetInteger() );
+                  break;
+              case OFTInteger64:
+                  printf( CPL_FRMT_GIB ",", oField.GetInteger64() );
+                  break;
+              case OFTReal:
+                  printf( "%.3f,", oField.GetDouble() );
+                  break;
+              case OFTString:
+                  // GetString() returns a C string
+                  printf( "%s,", oField.GetString() );
+                  break;
+              default:
+                  // Note: we use GetAsString() and not GetString(), since
+                  // the later assumes the field type to be OFTString while the
+                  // former will do a conversion from the original type to string.
+                  printf( "%s,", oField.GetAsString() );
+                  break;
+          }
+      }
 
-With GDAL < 2.3 and C++ :
+   .. code-tab:: c
 
-.. code-block:: c
+      OGRFeatureDefnH hFDefn = OGR_L_GetLayerDefn(hLayer);
+      int iField;
+   
+      for( iField = 0; iField < OGR_FD_GetFieldCount(hFDefn); iField++ )
+      {
+          OGRFieldDefnH hFieldDefn = OGR_FD_GetFieldDefn( hFDefn, iField );
+   
+          if( !OGR_F_IsFieldSet(hFeature, iField) )
+          {
+              printf("(unset),");
+              continue;
+          }
+          if( OGR_F_IsFieldNull(hFeature, iField) )
+          {
+              printf("(null),");
+              continue;
+          }
 
-    OGRFeatureDefn *poFDefn = poLayer->GetLayerDefn();
-    for( int iField = 0; iField < poFDefn->GetFieldCount(); iField++ )
-    {
-        if( !poFeature->IsFieldSet(iField) )
-        {
-            printf("(unset),");
-            continue;
-        }
-        if( poFeature->IsFieldNull(iField) )
-        {
-            printf("(null),");
-            continue;
-        }
-        OGRFieldDefn *poFieldDefn = poFDefn->GetFieldDefn( iField );
-
-        switch( poFieldDefn->GetType() )
-        {
-            case OFTInteger:
-                printf( "%d,", poFeature->GetFieldAsInteger( iField ) );
-                break;
-            case OFTInteger64:
-                printf( CPL_FRMT_GIB ",", poFeature->GetFieldAsInteger64( iField ) );
-                break;
-            case OFTReal:
-                printf( "%.3f,", poFeature->GetFieldAsDouble(iField) );
-                break;
-            case OFTString:
-                printf( "%s,", poFeature->GetFieldAsString(iField) );
-                break;
-            default:
-                printf( "%s,", poFeature->GetFieldAsString(iField) );
-                break;
-        }
-    }
-
-In C :
-
-.. code-block:: c
-
-    OGRFeatureDefnH hFDefn = OGR_L_GetLayerDefn(hLayer);
-    int iField;
-
-    for( iField = 0; iField < OGR_FD_GetFieldCount(hFDefn); iField++ )
-    {
-        OGRFieldDefnH hFieldDefn = OGR_FD_GetFieldDefn( hFDefn, iField );
-
-        if( !OGR_F_IsFieldSet(hFeature, iField) )
-        {
-            printf("(unset),");
-            continue;
-        }
-        if( OGR_F_IsFieldNull(hFeature, iField) )
-        {
-            printf("(null),");
-            continue;
-        }
-
-        switch( OGR_Fld_GetType(hFieldDefn) )
-        {
-            case OFTInteger:
-                printf( "%d,", OGR_F_GetFieldAsInteger( hFeature, iField ) );
-                break;
-            case OFTInteger64:
-                printf( CPL_FRMT_GIB ",", OGR_F_GetFieldAsInteger64( hFeature, iField ) );
-                break;
-            case OFTReal:
-                printf( "%.3f,", OGR_F_GetFieldAsDouble( hFeature, iField) );
-                break;
-            case OFTString:
-                printf( "%s,", OGR_F_GetFieldAsString( hFeature, iField) );
-                break;
-            default:
-                printf( "%s,", OGR_F_GetFieldAsString( hFeature, iField) );
-                break;
-        }
-    }
+          switch( OGR_Fld_GetType(hFieldDefn) )
+          {
+              case OFTInteger:
+                  printf( "%d,", OGR_F_GetFieldAsInteger( hFeature, iField ) );
+                  break;
+              case OFTInteger64:
+                  printf( CPL_FRMT_GIB ",", OGR_F_GetFieldAsInteger64( hFeature, iField ) );
+                  break;
+              case OFTReal:
+                  printf( "%.3f,", OGR_F_GetFieldAsDouble( hFeature, iField) );
+                  break;
+              case OFTString:
+                  printf( "%s,", OGR_F_GetFieldAsString( hFeature, iField) );
+                  break;
+              default:
+                  printf( "%s,", OGR_F_GetFieldAsString( hFeature, iField) );
+                  break;
+          }
+      }
 
 There are a few more field types than those explicitly handled above, but
 a reasonable representation of them can be fetched with the
@@ -284,45 +209,43 @@ We then determine the specific geometry type, and if it is a point, we
 cast it to point and operate on it.  If it is something else we write
 placeholders.
 
-In C++ :
+.. tabs::
 
-.. code-block:: c++
+   .. code-tab:: c++
 
-    OGRGeometry *poGeometry;
+      OGRGeometry *poGeometry;
 
-    poGeometry = poFeature->GetGeometryRef();
-    if( poGeometry != NULL
-            && wkbFlatten(poGeometry->getGeometryType()) == wkbPoint )
-    {
-    #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(2,3,0)
-        OGRPoint *poPoint = poGeometry->toPoint();
-    #else
-        OGRPoint *poPoint = (OGRPoint *) poGeometry;
-    #endif
+      poGeometry = poFeature->GetGeometryRef();
+      if( poGeometry != NULL
+              && wkbFlatten(poGeometry->getGeometryType()) == wkbPoint )
+      {
+      #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(2,3,0)
+          OGRPoint *poPoint = poGeometry->toPoint();
+      #else
+          OGRPoint *poPoint = (OGRPoint *) poGeometry;
+      #endif
 
-        printf( "%.3f,%3.f\n", poPoint->getX(), poPoint->getY() );
-    }
-    else
-    {
-        printf( "no point geometry\n" );
-    }
+          printf( "%.3f,%3.f\n", poPoint->getX(), poPoint->getY() );
+      }
+      else
+      {
+          printf( "no point geometry\n" );
+      }
 
-In C :
+   .. code-tab:: c
 
-.. code-block:: c
+      OGRGeometryH hGeometry;
 
-    OGRGeometryH hGeometry;
-
-    hGeometry = OGR_F_GetGeometryRef(hFeature);
-    if( hGeometry != NULL
-            && wkbFlatten(OGR_G_GetGeometryType(hGeometry)) == wkbPoint )
-    {
-        printf( "%.3f,%3.f\n", OGR_G_GetX(hGeometry, 0), OGR_G_GetY(hGeometry, 0) );
-    }
-    else
-    {
-        printf( "no point geometry\n" );
-    }
+      hGeometry = OGR_F_GetGeometryRef(hFeature);
+      if( hGeometry != NULL
+              && wkbFlatten(OGR_G_GetGeometryType(hGeometry)) == wkbPoint )
+      {
+          printf( "%.3f,%3.f\n", OGR_G_GetX(hGeometry, 0), OGR_G_GetY(hGeometry, 0) );
+      }
+      else
+      {
+          printf( "no point geometry\n" );
+      }
 
 The :cpp:func:`wkbFlatten` macro is used above to convert the type for a wkbPoint25D
 (a point with a z coordinate) into the base 2D geometry type code (wkbPoint).
@@ -332,72 +255,66 @@ handle 2D or 3D cases properly.
 
 Several geometry fields can be associated to a feature.
 
-In C++ :
+.. tabs::
 
-.. code-block:: c++
+   .. code-tab:: c++
 
-    OGRGeometry *poGeometry;
-    int iGeomField;
-    int nGeomFieldCount;
+      OGRGeometry *poGeometry;
+      int iGeomField;
+      int nGeomFieldCount;
 
-    nGeomFieldCount = poFeature->GetGeomFieldCount();
-    for(iGeomField = 0; iGeomField < nGeomFieldCount; iGeomField ++ )
-    {
-        poGeometry = poFeature->GetGeomFieldRef(iGeomField);
-        if( poGeometry != NULL
-                && wkbFlatten(poGeometry->getGeometryType()) == wkbPoint )
-        {
-    #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(2,3,0)
-            OGRPoint *poPoint = poGeometry->toPoint();
-    #else
-            OGRPoint *poPoint = (OGRPoint *) poGeometry;
-    #endif
+      nGeomFieldCount = poFeature->GetGeomFieldCount();
+      for(iGeomField = 0; iGeomField < nGeomFieldCount; iGeomField ++ )
+      {
+          poGeometry = poFeature->GetGeomFieldRef(iGeomField);
+          if( poGeometry != NULL
+                  && wkbFlatten(poGeometry->getGeometryType()) == wkbPoint )
+          {
+      #if GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(2,3,0)
+              OGRPoint *poPoint = poGeometry->toPoint();
+      #else
+              OGRPoint *poPoint = (OGRPoint *) poGeometry;
+      #endif
+     
+              printf( "%.3f,%3.f\n", poPoint->getX(), poPoint->getY() );
+          }
+          else
+          {
+              printf( "no point geometry\n" );
+          }
+      }
 
-            printf( "%.3f,%3.f\n", poPoint->getX(), poPoint->getY() );
-        }
-        else
-        {
-            printf( "no point geometry\n" );
-        }
-    }
+   .. code-tab:: c
 
+      OGRGeometryH hGeometry;
+      int iGeomField;
+      int nGeomFieldCount;
 
-In C :
+      nGeomFieldCount = OGR_F_GetGeomFieldCount(hFeature);
+      for(iGeomField = 0; iGeomField < nGeomFieldCount; iGeomField ++ )
+      {
+          hGeometry = OGR_F_GetGeomFieldRef(hFeature, iGeomField);
+          if( hGeometry != NULL
+                  && wkbFlatten(OGR_G_GetGeometryType(hGeometry)) == wkbPoint )
+          {
+              printf( "%.3f,%3.f\n", OGR_G_GetX(hGeometry, 0),
+                      OGR_G_GetY(hGeometry, 0) );
+          }
+          else
+          {
+              printf( "no point geometry\n" );
+          }
+      }
 
-.. code-block:: c
-
-    OGRGeometryH hGeometry;
-    int iGeomField;
-    int nGeomFieldCount;
-
-    nGeomFieldCount = OGR_F_GetGeomFieldCount(hFeature);
-    for(iGeomField = 0; iGeomField < nGeomFieldCount; iGeomField ++ )
-    {
-        hGeometry = OGR_F_GetGeomFieldRef(hFeature, iGeomField);
-        if( hGeometry != NULL
-                && wkbFlatten(OGR_G_GetGeometryType(hGeometry)) == wkbPoint )
-        {
-            printf( "%.3f,%3.f\n", OGR_G_GetX(hGeometry, 0),
-                    OGR_G_GetY(hGeometry, 0) );
-        }
-        else
-        {
-            printf( "no point geometry\n" );
-        }
-    }
-
-
-In Python:
-
-.. code-block:: python
+   .. code-tab:: python
 
     nGeomFieldCount = feat.GetGeomFieldCount()
     for iGeomField in range(nGeomFieldCount):
         geom = feat.GetGeomFieldRef(iGeomField)
         if geom is not None and geom.GetGeometryType() == ogr.wkbPoint:
-            print "%.3f, %.3f" % ( geom.GetX(), geom.GetY() )
+            print("%.3f, %.3f" % ( geom.GetX(), geom.GetY() ))
         else:
-            print "no point geometry\n"
+            print("no point geometry\n")
 
 Note that :cpp:func:`OGRFeature::GetGeometryRef` and :cpp:func:`OGRFeature::GetGeomFieldRef`
 return a pointer to
@@ -405,42 +322,18 @@ the internal geometry owned by the OGRFeature.  There we don't actually
 delete the return geometry.
 
 
-With GDAL 2.3 and C++11, the looping over features is simply terminated by
-a closing curly bracket.
+In C++ looping over features is simply terminated by a closing curly bracket.
 
 .. code-block:: c++
 
     }
 
-With GDAL 2.3 and C, the looping over features is simply terminated by
-the following.
+In C, the looping over features is simply terminated by the following.
 
 .. code-block:: c
 
     }
     OGR_FOR_EACH_FEATURE_END(hFeature)
-
-
-For GDAL < 2.3, as the :cpp:func:`OGRLayer::GetNextFeature` method
-returns a copy of the feature that is now owned by us.  So at the end of
-use we must free the feature.  We could just "delete" it, but this can cause
-problems in windows builds where the GDAL DLL has a different "heap" from the
-main program.  To be on the safe side we use a GDAL function to delete the
-feature.
-
-In C++ :
-
-.. code-block:: c++
-
-        OGRFeature::DestroyFeature( poFeature );
-    }
-
-In C :
-
-.. code-block:: c
-
-        OGR_F_Destroy( hFeature );
-    }
 
 
 The OGRLayer returned by :cpp:func:`GDALDataset::GetLayerByName` is also a reference
@@ -459,284 +352,168 @@ In C/C++ :
 
 All together our program looks like this.
 
-With GDAL 2.3 and C++11 :
+.. tabs::
 
-.. code-block:: c++
+   .. code-tab:: c++
 
-    #include "ogrsf_frmts.h"
+      #include "ogrsf_frmts.h"
 
-    int main()
+      int main()
 
-    {
-        GDALAllRegister();
+      {
+          GDALAllRegister();
 
-        GDALDatasetUniquePtr poDS(GDALDataset::Open( "point.shp", GDAL_OF_VECTOR));
-        if( poDS == nullptr )
-        {
-            printf( "Open failed.\n" );
-            exit( 1 );
-        }
+          GDALDatasetUniquePtr poDS(GDALDataset::Open( "point.shp", GDAL_OF_VECTOR));
+          if( poDS == nullptr )
+          {
+              printf( "Open failed.\n" );
+              exit( 1 );
+          }
 
-        for( const OGRLayer* poLayer: poDS->GetLayers() )
-        {
-            for( const auto& poFeature: *poLayer )
-            {
-                for( const auto& oField: *poFeature )
-                {
-                    if( oField.IsUnset() )
-                    {
-                        printf("(unset),");
-                        continue;
-                    }
-                    if( oField.IsNull() )
-                    {
-                        printf("(null),");
-                        continue;
-                    }
-                    switch( oField.GetType() )
-                    {
-                        case OFTInteger:
-                            printf( "%d,", oField.GetInteger() );
-                            break;
-                        case OFTInteger64:
-                            printf( CPL_FRMT_GIB ",", oField.GetInteger64() );
-                            break;
-                        case OFTReal:
-                            printf( "%.3f,", oField.GetDouble() );
-                            break;
-                        case OFTString:
-                            // GetString() returns a C string
-                            printf( "%s,", oField.GetString() );
-                            break;
-                        default:
-                            // Note: we use GetAsString() and not GetString(), since
-                            // the later assumes the field type to be OFTString while the
-                            // former will do a conversion from the original type to string.
-                            printf( "%s,", oField.GetAsString() );
-                            break;
-                    }
-                }
+          for( const OGRLayer* poLayer: poDS->GetLayers() )
+          {
+              for( const auto& poFeature: *poLayer )
+              {
+                  for( const auto& oField: *poFeature )
+                  {
+                      if( oField.IsUnset() )
+                      {
+                          printf("(unset),");
+                          continue;
+                      }
+                      if( oField.IsNull() )
+                      {
+                          printf("(null),");
+                          continue;
+                      }
+                      switch( oField.GetType() )
+                      {
+                          case OFTInteger:
+                              printf( "%d,", oField.GetInteger() );
+                              break;
+                          case OFTInteger64:
+                              printf( CPL_FRMT_GIB ",", oField.GetInteger64() );
+                              break;
+                          case OFTReal:
+                              printf( "%.3f,", oField.GetDouble() );
+                              break;
+                          case OFTString:
+                              // GetString() returns a C string
+                              printf( "%s,", oField.GetString() );
+                              break;
+                          default:
+                              // Note: we use GetAsString() and not GetString(), since
+                              // the later assumes the field type to be OFTString while the
+                              // former will do a conversion from the original type to string.
+                              printf( "%s,", oField.GetAsString() );
+                              break;
+                      }
+                  }
 
-                const OGRGeometry *poGeometry = poFeature->GetGeometryRef();
-                if( poGeometry != nullptr
-                        && wkbFlatten(poGeometry->getGeometryType()) == wkbPoint )
-                {
-                    const OGRPoint *poPoint = poGeometry->toPoint();
+                  const OGRGeometry *poGeometry = poFeature->GetGeometryRef();
+                  if( poGeometry != nullptr
+                          && wkbFlatten(poGeometry->getGeometryType()) == wkbPoint )
+                  {
+                      const OGRPoint *poPoint = poGeometry->toPoint();
 
-                    printf( "%.3f,%3.f\n", poPoint->getX(), poPoint->getY() );
-                }
-                else
-                {
-                    printf( "no point geometry\n" );
-                }
-            }
-        }
-        return 0;
-    }
+                      printf( "%.3f,%3.f\n", poPoint->getX(), poPoint->getY() );
+                  }
+                  else
+                  {
+                      printf( "no point geometry\n" );
+                  }
+              }
+          }
+          return 0;
+      }
 
-In C++ :
+   .. code-tab:: c
 
-.. code-block:: c++
+      #include "gdal.h"
 
-    #include "ogrsf_frmts.h"
+      int main()
 
-    int main()
+      {
+          GDALAllRegister();
 
-    {
-        GDALAllRegister();
+          GDALDatasetH hDS;
+          OGRLayerH hLayer;
+          OGRFeatureH hFeature;
+          OGRFeatureDefnH hFDefn;
 
-        GDALDataset *poDS = static_cast<GDALDataset*>(
-            GDALOpenEx( "point.shp", GDAL_OF_VECTOR, NULL, NULL, NULL ));
-        if( poDS == NULL )
-        {
-            printf( "Open failed.\n" );
-            exit( 1 );
-        }
+          hDS = GDALOpenEx( "point.shp", GDAL_OF_VECTOR, NULL, NULL, NULL );
+          if( hDS == NULL )
+          {
+              printf( "Open failed.\n" );
+              exit( 1 );
+          }
 
-        OGRLayer  *poLayer = poDS->GetLayerByName( "point" );
-        OGRFeatureDefn *poFDefn = poLayer->GetLayerDefn();
+          hLayer = GDALDatasetGetLayerByName( hDS, "point" );
+          hFDefn = OGR_L_GetLayerDefn(hLayer);
 
-        poLayer->ResetReading();
-        OGRFeature *poFeature;
-        while( (poFeature = poLayer->GetNextFeature()) != NULL )
-        {
-            for( int iField = 0; iField < poFDefn->GetFieldCount(); iField++ )
-            {
-                if( !poFeature->IsFieldSet(iField) )
-                {
-                    printf("(unset),");
-                    continue;
-                }
-                if( poFeature->IsFieldNull(iField) )
-                {
-                    printf("(null),");
-                    continue;
-                }
-                OGRFieldDefn *poFieldDefn = poFDefn->GetFieldDefn( iField );
+          OGR_L_ResetReading(hLayer);
+          while( (hFeature = OGR_L_GetNextFeature(hLayer)) != NULL )
+          {
+              int iField;
+              OGRGeometryH hGeometry;
 
-                switch( poFieldDefn->GetType() )
-                {
-                    case OFTInteger:
-                        printf( "%d,", poFeature->GetFieldAsInteger( iField ) );
-                        break;
-                    case OFTInteger64:
-                        printf( CPL_FRMT_GIB ",", poFeature->GetFieldAsInteger64( iField ) );
-                        break;
-                    case OFTReal:
-                        printf( "%.3f,", poFeature->GetFieldAsDouble(iField) );
-                        break;
-                    case OFTString:
-                        printf( "%s,", poFeature->GetFieldAsString(iField) );
-                        break;
-                    default:
-                        printf( "%s,", poFeature->GetFieldAsString(iField) );
-                        break;
-                }
-            }
+              for( iField = 0; iField < OGR_FD_GetFieldCount(hFDefn); iField++ )
+              {
+                  OGRFieldDefnH hFieldDefn = OGR_FD_GetFieldDefn( hFDefn, iField );
 
-            OGRGeometry *poGeometry = poFeature->GetGeometryRef();
-            if( poGeometry != NULL
-                    && wkbFlatten(poGeometry->getGeometryType()) == wkbPoint )
-            {
-                OGRPoint *poPoint = (OGRPoint *) poGeometry;
+                  if( !OGR_F_IsFieldSet(hFeature, iField) )
+                  {
+                      printf("(unset),");
+                      continue;
+                  }
+                  if( OGR_F_IsFieldNull(hFeature, iField) )
+                  {
+                      printf("(null),");
+                      continue;
+                  }
 
-                printf( "%.3f,%3.f\n", poPoint->getX(), poPoint->getY() );
-            }
-            else
-            {
-                printf( "no point geometry\n" );
-            }
-            OGRFeature::DestroyFeature( poFeature );
-        }
+                  switch( OGR_Fld_GetType(hFieldDefn) )
+                  {
+                      case OFTInteger:
+                          printf( "%d,", OGR_F_GetFieldAsInteger( hFeature, iField ) );
+                          break;
+                      case OFTInteger64:
+                          printf( CPL_FRMT_GIB ",", OGR_F_GetFieldAsInteger64( hFeature, iField ) );
+                          break;
+                      case OFTReal:
+                          printf( "%.3f,", OGR_F_GetFieldAsDouble( hFeature, iField) );
+                          break;
+                      case OFTString:
+                          printf( "%s,", OGR_F_GetFieldAsString( hFeature, iField) );
+                          break;
+                      default:
+                          printf( "%s,", OGR_F_GetFieldAsString( hFeature, iField) );
+                          break;
+                  }
+              }
 
-        GDALClose( poDS );
-    }
+              hGeometry = OGR_F_GetGeometryRef(hFeature);
+              if( hGeometry != NULL
+                  && wkbFlatten(OGR_G_GetGeometryType(hGeometry)) == wkbPoint )
+              {
+                  printf( "%.3f,%3.f\n", OGR_G_GetX(hGeometry, 0), OGR_G_GetY(hGeometry, 0) );
+              }
+              else
+              {
+                  printf( "no point geometry\n" );
+              }
 
-In C :
+              OGR_F_Destroy( hFeature );
+          }
 
-.. code-block:: c
+          GDALClose( hDS );
+      }
 
-    #include "gdal.h"
+   .. tab:: Python
 
-    int main()
+      .. literalinclude :: code/vector_api_tut.py
+         :language: python
 
-    {
-        GDALAllRegister();
-
-        GDALDatasetH hDS;
-        OGRLayerH hLayer;
-        OGRFeatureH hFeature;
-        OGRFeatureDefnH hFDefn;
-
-        hDS = GDALOpenEx( "point.shp", GDAL_OF_VECTOR, NULL, NULL, NULL );
-        if( hDS == NULL )
-        {
-            printf( "Open failed.\n" );
-            exit( 1 );
-        }
-
-        hLayer = GDALDatasetGetLayerByName( hDS, "point" );
-        hFDefn = OGR_L_GetLayerDefn(hLayer);
-
-        OGR_L_ResetReading(hLayer);
-        while( (hFeature = OGR_L_GetNextFeature(hLayer)) != NULL )
-        {
-            int iField;
-            OGRGeometryH hGeometry;
-
-            for( iField = 0; iField < OGR_FD_GetFieldCount(hFDefn); iField++ )
-            {
-                OGRFieldDefnH hFieldDefn = OGR_FD_GetFieldDefn( hFDefn, iField );
-
-                if( !OGR_F_IsFieldSet(hFeature, iField) )
-                {
-                    printf("(unset),");
-                    continue;
-                }
-                if( OGR_F_IsFieldNull(hFeature, iField) )
-                {
-                    printf("(null),");
-                    continue;
-                }
-
-                switch( OGR_Fld_GetType(hFieldDefn) )
-                {
-                    case OFTInteger:
-                        printf( "%d,", OGR_F_GetFieldAsInteger( hFeature, iField ) );
-                        break;
-                    case OFTInteger64:
-                        printf( CPL_FRMT_GIB ",", OGR_F_GetFieldAsInteger64( hFeature, iField ) );
-                        break;
-                    case OFTReal:
-                        printf( "%.3f,", OGR_F_GetFieldAsDouble( hFeature, iField) );
-                        break;
-                    case OFTString:
-                        printf( "%s,", OGR_F_GetFieldAsString( hFeature, iField) );
-                        break;
-                    default:
-                        printf( "%s,", OGR_F_GetFieldAsString( hFeature, iField) );
-                        break;
-                }
-            }
-
-            hGeometry = OGR_F_GetGeometryRef(hFeature);
-            if( hGeometry != NULL
-                && wkbFlatten(OGR_G_GetGeometryType(hGeometry)) == wkbPoint )
-            {
-                printf( "%.3f,%3.f\n", OGR_G_GetX(hGeometry, 0), OGR_G_GetY(hGeometry, 0) );
-            }
-            else
-            {
-                printf( "no point geometry\n" );
-            }
-
-            OGR_F_Destroy( hFeature );
-        }
-
-        GDALClose( hDS );
-    }
-
-
-In Python:
-
-.. code-block:: python
-
-    import sys
-    from osgeo import gdal
-
-    ds = gdal.OpenEx( "point.shp", gdal.OF_VECTOR )
-    if ds is None:
-        print "Open failed.\n"
-        sys.exit( 1 )
-
-    lyr = ds.GetLayerByName( "point" )
-
-    lyr.ResetReading()
-
-    for feat in lyr:
-
-        feat_defn = lyr.GetLayerDefn()
-        for i in range(feat_defn.GetFieldCount()):
-            field_defn = feat_defn.GetFieldDefn(i)
-
-            # Tests below can be simplified with just :
-            # print feat.GetField(i)
-            if field_defn.GetType() == ogr.OFTInteger or field_defn.GetType() == ogr.OFTInteger64:
-                print "%d" % feat.GetFieldAsInteger64(i)
-            elif field_defn.GetType() == ogr.OFTReal:
-                print "%.3f" % feat.GetFieldAsDouble(i)
-            elif field_defn.GetType() == ogr.OFTString:
-                print "%s" % feat.GetFieldAsString(i)
-            else:
-                print "%s" % feat.GetFieldAsString(i)
-
-        geom = feat.GetGeometryRef()
-        if geom is not None and geom.GetGeometryType() == ogr.wkbPoint:
-            print "%.3f, %.3f" % ( geom.GetX(), geom.GetY() )
-        else:
-            print "no point geometry\n"
-
-    ds = None
 
 .. _vector_api_tut_arrow_stream:
 
@@ -1037,45 +814,43 @@ will be written to a point shapefile via OGR.
 As usual, we start by registering all the drivers, and then fetch the
 Shapefile driver as we will need it to create our output file.
 
-In C++ :
+.. tabs::
 
-.. code-block:: c++
+   .. code-tab:: c++
 
-    #include "ogrsf_frmts.h"
+      #include "ogrsf_frmts.h"
 
-    int main()
-    {
-        const char *pszDriverName = "ESRI Shapefile";
-        GDALDriver *poDriver;
+      int main()
+      {
+          const char *pszDriverName = "ESRI Shapefile";
+          GDALDriver *poDriver;
 
-        GDALAllRegister();
+          GDALAllRegister();
 
-        poDriver = GetGDALDriverManager()->GetDriverByName(pszDriverName );
-        if( poDriver == NULL )
-        {
-            printf( "%s driver not available.\n", pszDriverName );
-            exit( 1 );
-        }
+          poDriver = GetGDALDriverManager()->GetDriverByName(pszDriverName );
+          if( poDriver == NULL )
+          {
+              printf( "%s driver not available.\n", pszDriverName );
+              exit( 1 );
+          }
 
-In C :
+   .. code-tab:: c
 
-.. code-block:: c
+      #include "ogr_api.h"
 
-    #include "ogr_api.h"
+      int main()
+      {
+          const char *pszDriverName = "ESRI Shapefile";
+          GDALDriver *poDriver;
 
-    int main()
-    {
-        const char *pszDriverName = "ESRI Shapefile";
-        GDALDriver *poDriver;
+          GDALAllRegister();
 
-        GDALAllRegister();
-
-        poDriver = (GDALDriver*) GDALGetDriverByName(pszDriverName );
-        if( poDriver == NULL )
-        {
-            printf( "%s driver not available.\n", pszDriverName );
-            exit( 1 );
-        }
+          poDriver = (GDALDriver*) GDALGetDriverByName(pszDriverName );
+          if( poDriver == NULL )
+          {
+              printf( "%s driver not available.\n", pszDriverName );
+              exit( 1 );
+          }
 
 Next we create the datasource.  The ESRI Shapefile driver allows us to create
 a directory full of shapefiles, or a single shapefile as a datasource.  In
@@ -1086,64 +861,58 @@ The second, third, fourth and fifth argument are related to raster dimensions
 the call is a list of option values, but we will just be using defaults in
 this case.  Details of the options supported are also format specific.
 
-In C ++ :
+.. tabs::
 
-.. code-block:: c++
+   .. code-tab:: c++
 
-    GDALDataset *poDS;
+      GDALDataset *poDS;
 
-    poDS = poDriver->Create( "point_out.shp", 0, 0, 0, GDT_Unknown, NULL );
-    if( poDS == NULL )
-    {
-        printf( "Creation of output file failed.\n" );
-        exit( 1 );
-    }
+      poDS = poDriver->Create( "point_out.shp", 0, 0, 0, GDT_Unknown, NULL );
+      if( poDS == NULL )
+      {
+          printf( "Creation of output file failed.\n" );
+          exit( 1 );
+      }
 
+   .. code-tab:: c
 
-In C :
+      GDALDatasetH hDS;
 
-.. code-block:: c
-
-    GDALDatasetH hDS;
-
-    hDS = GDALCreate( hDriver, "point_out.shp", 0, 0, 0, GDT_Unknown, NULL );
-    if( hDS == NULL )
-    {
-        printf( "Creation of output file failed.\n" );
-        exit( 1 );
-    }
+      hDS = GDALCreate( hDriver, "point_out.shp", 0, 0, 0, GDT_Unknown, NULL );
+      if( hDS == NULL )
+      {
+          printf( "Creation of output file failed.\n" );
+          exit( 1 );
+      }
 
 Now we create the output layer.  In this case since the datasource is a
 single file, we can only have one layer.  We pass wkbPoint to specify the
 type of geometry supported by this layer.  In this case we aren't passing
 any coordinate system information or other special layer creation options.
 
-In C++ :
+.. tabs::
 
-.. code-block:: c++
+   .. code-tab:: c++
 
-    OGRLayer *poLayer;
+      OGRLayer *poLayer;
 
-    poLayer = poDS->CreateLayer( "point_out", NULL, wkbPoint, NULL );
-    if( poLayer == NULL )
-    {
-        printf( "Layer creation failed.\n" );
-        exit( 1 );
-    }
+      poLayer = poDS->CreateLayer( "point_out", NULL, wkbPoint, NULL );
+      if( poLayer == NULL )
+      {
+          printf( "Layer creation failed.\n" );
+          exit( 1 );
+      }
 
+   .. code-tab:: c
 
-In C :
+      OGRLayerH hLayer;
 
-.. code-block:: c
-
-    OGRLayerH hLayer;
-
-    hLayer = GDALDatasetCreateLayer( hDS, "point_out", NULL, wkbPoint, NULL );
-    if( hLayer == NULL )
-    {
-        printf( "Layer creation failed.\n" );
-        exit( 1 );
-    }
+      hLayer = GDALDatasetCreateLayer( hDS, "point_out", NULL, wkbPoint, NULL );
+      if( hLayer == NULL )
+      {
+          printf( "Layer creation failed.\n" );
+          exit( 1 );
+      }
 
 
 Now that the layer exists, we need to create any attribute fields that should
@@ -1157,38 +926,35 @@ we will just have one attribute, a name string associated with the x,y point.
 Note that the template OGRField we pass to :cpp:func:`OGRLayer::CreateField` is copied internally.
 We retain ownership of the object.
 
-In C++:
+.. tabs::
 
-.. code-block:: c++
+   .. code-tab:: c++
 
-    OGRFieldDefn oField( "Name", OFTString );
+      OGRFieldDefn oField( "Name", OFTString );
 
-    oField.SetWidth(32);
+      oField.SetWidth(32);
 
-    if( poLayer->CreateField( &oField ) != OGRERR_NONE )
-    {
-        printf( "Creating Name field failed.\n" );
-        exit( 1 );
-    }
+      if( poLayer->CreateField( &oField ) != OGRERR_NONE )
+      {
+          printf( "Creating Name field failed.\n" );
+          exit( 1 );
+      }
 
+   .. code-tab:: c
 
-In C:
+      OGRFieldDefnH hFieldDefn;
 
-.. code-block:: c
+      hFieldDefn = OGR_Fld_Create( "Name", OFTString );
 
-    OGRFieldDefnH hFieldDefn;
+      OGR_Fld_SetWidth( hFieldDefn, 32);
 
-    hFieldDefn = OGR_Fld_Create( "Name", OFTString );
+      if( OGR_L_CreateField( hLayer, hFieldDefn, TRUE ) != OGRERR_NONE )
+      {
+          printf( "Creating Name field failed.\n" );
+          exit( 1 );
+      }
 
-    OGR_Fld_SetWidth( hFieldDefn, 32);
-
-    if( OGR_L_CreateField( hLayer, hFieldDefn, TRUE ) != OGRERR_NONE )
-    {
-        printf( "Creating Name field failed.\n" );
-        exit( 1 );
-    }
-
-    OGR_Fld_Destroy(hFieldDefn);
+      OGR_Fld_Destroy(hFieldDefn);
 
 
 The following snipping loops reading lines of the form "x,y,name" from stdin,
@@ -1210,23 +976,21 @@ and attach geometry before trying to write it to the layer.  It is
 imperative that this feature be instantiated from the OGRFeatureDefn
 associated with the layer it will be written to.
 
-In C++ :
+.. tabs::
 
-.. code-block:: c++
+   .. code-tab:: c++
 
-        OGRFeature *poFeature;
+          OGRFeature *poFeature;
 
-        poFeature = OGRFeature::CreateFeature( poLayer->GetLayerDefn() );
-        poFeature->SetField( "Name", szName );
+          poFeature = OGRFeature::CreateFeature( poLayer->GetLayerDefn() );
+          poFeature->SetField( "Name", szName );
 
-In C :
+   .. code-tab:: c
 
-.. code-block:: c
+          OGRFeatureH hFeature;
 
-        OGRFeatureH hFeature;
-
-        hFeature = OGR_F_Create( OGR_L_GetLayerDefn( hLayer ) );
-        OGR_F_SetFieldString( hFeature, OGR_F_GetFieldIndex(hFeature, "Name"), szName );
+          hFeature = OGR_F_Create( OGR_L_GetLayerDefn( hLayer ) );
+          OGR_F_SetFieldString( hFeature, OGR_F_GetFieldIndex(hFeature, "Name"), szName );
 
 We create a local geometry object, and assign its copy (indirectly) to the feature.
 The :cpp:func:`OGRFeature::SetGeometryDirectly` differs from :cpp:func:`OGRFeature::SetGeometry`
@@ -1234,57 +998,52 @@ in that the direct method gives ownership of the geometry to the feature.
 This is generally more efficient as it avoids an extra deep object copy
 of the geometry.
 
-In C++ :
+.. tabs::
 
-.. code-block:: c++
+   .. code-tab:: c++
 
-        OGRPoint pt;
-        pt.setX( x );
-        pt.setY( y );
+          OGRPoint pt;
+          pt.setX( x );
+          pt.setY( y );
 
-        poFeature->SetGeometry( &pt );
+          poFeature->SetGeometry( &pt );
 
+   .. code-tab:: c
 
-In C :
+          OGRGeometryH hPt;
+          hPt = OGR_G_CreateGeometry(wkbPoint);
+          OGR_G_SetPoint_2D(hPt, 0, x, y);
 
-.. code-block:: c
-
-        OGRGeometryH hPt;
-        hPt = OGR_G_CreateGeometry(wkbPoint);
-        OGR_G_SetPoint_2D(hPt, 0, x, y);
-
-        OGR_F_SetGeometry( hFeature, hPt );
-        OGR_G_DestroyGeometry(hPt);
+          OGR_F_SetGeometry( hFeature, hPt );
+          OGR_G_DestroyGeometry(hPt);
 
 
 Now we create a feature in the file.  The :cpp:func:`OGRLayer::CreateFeature` does not
 take ownership of our feature so we clean it up when done with it.
 
-In C++ :
+.. tabs::
 
-.. code-block:: c++
+   .. code-tab:: c++
 
-        if( poLayer->CreateFeature( poFeature ) != OGRERR_NONE )
-        {
-            printf( "Failed to create feature in shapefile.\n" );
-           exit( 1 );
-        }
+          if( poLayer->CreateFeature( poFeature ) != OGRERR_NONE )
+          {
+              printf( "Failed to create feature in shapefile.\n" );
+             exit( 1 );
+          }
 
-        OGRFeature::DestroyFeature( poFeature );
-   }
+          OGRFeature::DestroyFeature( poFeature );
+     }
 
-In C :
+   .. code-tab:: c
 
-.. code-block:: c
+          if( OGR_L_CreateFeature( hLayer, hFeature ) != OGRERR_NONE )
+          {
+              printf( "Failed to create feature in shapefile.\n" );
+             exit( 1 );
+          }
 
-        if( OGR_L_CreateFeature( hLayer, hFeature ) != OGRERR_NONE )
-        {
-            printf( "Failed to create feature in shapefile.\n" );
-           exit( 1 );
-        }
-
-        OGR_F_Destroy( hFeature );
-   }
+          OGR_F_Destroy( hFeature );
+     }
 
 
 Finally we need to close down the datasource in order to ensure headers
@@ -1300,223 +1059,164 @@ In C/C++ :
 
 The same program all in one block looks like this:
 
-In C++ :
+.. tabs::
 
-.. code-block:: c++
+   .. code-tab:: c++
 
-    #include "ogrsf_frmts.h"
+      #include "ogrsf_frmts.h"
 
-    int main()
-    {
-        const char *pszDriverName = "ESRI Shapefile";
-        GDALDriver *poDriver;
+      int main()
+      {
+          const char *pszDriverName = "ESRI Shapefile";
+          GDALDriver *poDriver;
 
-        GDALAllRegister();
+          GDALAllRegister();
 
-        poDriver = GetGDALDriverManager()->GetDriverByName(pszDriverName );
-        if( poDriver == NULL )
-        {
-            printf( "%s driver not available.\n", pszDriverName );
-            exit( 1 );
-        }
+          poDriver = GetGDALDriverManager()->GetDriverByName(pszDriverName );
+          if( poDriver == NULL )
+          {
+              printf( "%s driver not available.\n", pszDriverName );
+              exit( 1 );
+          }
 
-        GDALDataset *poDS;
+          GDALDataset *poDS;
 
-        poDS = poDriver->Create( "point_out.shp", 0, 0, 0, GDT_Unknown, NULL );
-        if( poDS == NULL )
-        {
-            printf( "Creation of output file failed.\n" );
-            exit( 1 );
-        }
+          poDS = poDriver->Create( "point_out.shp", 0, 0, 0, GDT_Unknown, NULL );
+          if( poDS == NULL )
+          {
+              printf( "Creation of output file failed.\n" );
+              exit( 1 );
+          }
 
-        OGRLayer *poLayer;
+          OGRLayer *poLayer;
 
-        poLayer = poDS->CreateLayer( "point_out", NULL, wkbPoint, NULL );
-        if( poLayer == NULL )
-        {
-            printf( "Layer creation failed.\n" );
-            exit( 1 );
-        }
+          poLayer = poDS->CreateLayer( "point_out", NULL, wkbPoint, NULL );
+          if( poLayer == NULL )
+          {
+              printf( "Layer creation failed.\n" );
+              exit( 1 );
+          }
 
-        OGRFieldDefn oField( "Name", OFTString );
+          OGRFieldDefn oField( "Name", OFTString );
 
-        oField.SetWidth(32);
+          oField.SetWidth(32);
 
-        if( poLayer->CreateField( &oField ) != OGRERR_NONE )
-        {
-            printf( "Creating Name field failed.\n" );
-            exit( 1 );
-        }
+          if( poLayer->CreateField( &oField ) != OGRERR_NONE )
+          {
+              printf( "Creating Name field failed.\n" );
+              exit( 1 );
+          }
 
-        double x, y;
-        char szName[33];
+          double x, y;
+          char szName[33];
 
-        while( !feof(stdin)
-            && fscanf( stdin, "%lf,%lf,%32s", &x, &y, szName ) == 3 )
-        {
-            OGRFeature *poFeature;
+          while( !feof(stdin)
+              && fscanf( stdin, "%lf,%lf,%32s", &x, &y, szName ) == 3 )
+          {
+              OGRFeature *poFeature;
 
-            poFeature = OGRFeature::CreateFeature( poLayer->GetLayerDefn() );
-            poFeature->SetField( "Name", szName );
+             poFeature = OGRFeature::CreateFeature( poLayer->GetLayerDefn() );
+             poFeature->SetField( "Name", szName );
 
-            OGRPoint pt;
+              OGRPoint pt;
 
-            pt.setX( x );
-            pt.setY( y );
+              pt.setX( x );
+              pt.setY( y );
 
-            poFeature->SetGeometry( &pt );
+              poFeature->SetGeometry( &pt );
 
-            if( poLayer->CreateFeature( poFeature ) != OGRERR_NONE )
-            {
-                printf( "Failed to create feature in shapefile.\n" );
-                exit( 1 );
-            }
+              if( poLayer->CreateFeature( poFeature ) != OGRERR_NONE )
+              {
+                  printf( "Failed to create feature in shapefile.\n" );
+                  exit( 1 );
+              }
 
-            OGRFeature::DestroyFeature( poFeature );
-        }
+              OGRFeature::DestroyFeature( poFeature );
+          }
 
-        GDALClose( poDS );
-    }
+          GDALClose( poDS );
+      }
 
+   .. code-tab:: c
 
-In C :
+      #include "gdal.h"
 
-.. code-block:: c
+      int main()
+      {
+          const char *pszDriverName = "ESRI Shapefile";
+          GDALDriverH hDriver;
+          GDALDatasetH hDS;
+          OGRLayerH hLayer;
+          OGRFieldDefnH hFieldDefn;
+          double x, y;
+          char szName[33];
 
-    #include "gdal.h"
+          GDALAllRegister();
 
-    int main()
-    {
-        const char *pszDriverName = "ESRI Shapefile";
-        GDALDriverH hDriver;
-        GDALDatasetH hDS;
-        OGRLayerH hLayer;
-        OGRFieldDefnH hFieldDefn;
-        double x, y;
-        char szName[33];
+          hDriver = GDALGetDriverByName( pszDriverName );
+          if( hDriver == NULL )
+          {
+              printf( "%s driver not available.\n", pszDriverName );
+              exit( 1 );
+          }
 
-        GDALAllRegister();
+          hDS = GDALCreate( hDriver, "point_out.shp", 0, 0, 0, GDT_Unknown, NULL );
+          if( hDS == NULL )
+          {
+              printf( "Creation of output file failed.\n" );
+              exit( 1 );
+          }
 
-        hDriver = GDALGetDriverByName( pszDriverName );
-        if( hDriver == NULL )
-        {
-            printf( "%s driver not available.\n", pszDriverName );
-            exit( 1 );
-        }
+          hLayer = GDALDatasetCreateLayer( hDS, "point_out", NULL, wkbPoint, NULL );
+          if( hLayer == NULL )
+          {
+              printf( "Layer creation failed.\n" );
+              exit( 1 );
+          }
 
-        hDS = GDALCreate( hDriver, "point_out.shp", 0, 0, 0, GDT_Unknown, NULL );
-        if( hDS == NULL )
-        {
-            printf( "Creation of output file failed.\n" );
-            exit( 1 );
-        }
+          hFieldDefn = OGR_Fld_Create( "Name", OFTString );
 
-        hLayer = GDALDatasetCreateLayer( hDS, "point_out", NULL, wkbPoint, NULL );
-        if( hLayer == NULL )
-        {
-            printf( "Layer creation failed.\n" );
-            exit( 1 );
-        }
+          OGR_Fld_SetWidth( hFieldDefn, 32);
 
-        hFieldDefn = OGR_Fld_Create( "Name", OFTString );
+          if( OGR_L_CreateField( hLayer, hFieldDefn, TRUE ) != OGRERR_NONE )
+          {
+              printf( "Creating Name field failed.\n" );
+              exit( 1 );
+          }
 
-        OGR_Fld_SetWidth( hFieldDefn, 32);
+          OGR_Fld_Destroy(hFieldDefn);
 
-        if( OGR_L_CreateField( hLayer, hFieldDefn, TRUE ) != OGRERR_NONE )
-        {
-            printf( "Creating Name field failed.\n" );
-            exit( 1 );
-        }
+          while( !feof(stdin)
+              && fscanf( stdin, "%lf,%lf,%32s", &x, &y, szName ) == 3 )
+          {
+              OGRFeatureH hFeature;
+              OGRGeometryH hPt;
 
-        OGR_Fld_Destroy(hFieldDefn);
+              hFeature = OGR_F_Create( OGR_L_GetLayerDefn( hLayer ) );
+              OGR_F_SetFieldString( hFeature, OGR_F_GetFieldIndex(hFeature, "Name"), szName );
 
-        while( !feof(stdin)
-            && fscanf( stdin, "%lf,%lf,%32s", &x, &y, szName ) == 3 )
-        {
-            OGRFeatureH hFeature;
-            OGRGeometryH hPt;
+              hPt = OGR_G_CreateGeometry(wkbPoint);
+              OGR_G_SetPoint_2D(hPt, 0, x, y);
 
-            hFeature = OGR_F_Create( OGR_L_GetLayerDefn( hLayer ) );
-            OGR_F_SetFieldString( hFeature, OGR_F_GetFieldIndex(hFeature, "Name"), szName );
+              OGR_F_SetGeometry( hFeature, hPt );
+              OGR_G_DestroyGeometry(hPt);
 
-            hPt = OGR_G_CreateGeometry(wkbPoint);
-            OGR_G_SetPoint_2D(hPt, 0, x, y);
+              if( OGR_L_CreateFeature( hLayer, hFeature ) != OGRERR_NONE )
+              {
+              printf( "Failed to create feature in shapefile.\n" );
+              exit( 1 );
+              }
 
-            OGR_F_SetGeometry( hFeature, hPt );
-            OGR_G_DestroyGeometry(hPt);
+              OGR_F_Destroy( hFeature );
+          }
 
-            if( OGR_L_CreateFeature( hLayer, hFeature ) != OGRERR_NONE )
-            {
-            printf( "Failed to create feature in shapefile.\n" );
-            exit( 1 );
-            }
+          GDALClose( hDS );
+      }
 
-            OGR_F_Destroy( hFeature );
-        }
+   .. tab:: Python
 
-        GDALClose( hDS );
-    }
-
-
-In Python :
-
-.. code-block:: python
-
-    import sys
-    from osgeo import gdal
-    from osgeo import ogr
-    import string
-
-    driverName = "ESRI Shapefile"
-    drv = gdal.GetDriverByName( driverName )
-    if drv is None:
-        print "%s driver not available.\n" % driverName
-        sys.exit( 1 )
-
-    ds = drv.Create( "point_out.shp", 0, 0, 0, gdal.GDT_Unknown )
-    if ds is None:
-        print "Creation of output file failed.\n"
-        sys.exit( 1 )
-
-    lyr = ds.CreateLayer( "point_out", None, ogr.wkbPoint )
-    if lyr is None:
-        print "Layer creation failed.\n"
-        sys.exit( 1 )
-
-    field_defn = ogr.FieldDefn( "Name", ogr.OFTString )
-    field_defn.SetWidth( 32 )
-
-    if lyr.CreateField ( field_defn ) != 0:
-        print "Creating Name field failed.\n"
-        sys.exit( 1 )
-
-    # Expected format of user input: x y name
-    linestring = raw_input()
-    linelist = string.split(linestring)
-
-    while len(linelist) == 3:
-        x = float(linelist[0])
-        y = float(linelist[1])
-        name = linelist[2]
-
-        feat = ogr.Feature( lyr.GetLayerDefn())
-        feat.SetField( "Name", name )
-
-        pt = ogr.Geometry(ogr.wkbPoint)
-        pt.SetPoint_2D(0, x, y)
-
-        feat.SetGeometry(pt)
-
-        if lyr.CreateFeature(feat) != 0:
-            print "Failed to create feature in shapefile.\n"
-            sys.exit( 1 )
-
-        feat.Destroy()
-
-        linestring = raw_input()
-        linelist = string.split(linestring)
-
-    ds = None
+      .. literalinclude :: code/vector_api_tut2.py
+         :language: python
 
 
 Several geometry fields can be associated to a feature. This capability
@@ -1525,69 +1225,66 @@ is just available for a few file formats, such as PostGIS.
 To create such datasources, geometry fields must be first created.
 Spatial reference system objects can be associated to each geometry field.
 
-In C++ :
+.. tabs::
 
-.. code-block:: c++
+   .. code-tab:: c++
 
-    OGRGeomFieldDefn oPointField( "PointField", wkbPoint );
-    OGRSpatialReference* poSRS = new OGRSpatialReference();
-    poSRS->importFromEPSG(4326);
-    oPointField.SetSpatialRef(poSRS);
-    poSRS->Release();
+      OGRGeomFieldDefn oPointField( "PointField", wkbPoint );
+      OGRSpatialReference* poSRS = new OGRSpatialReference();
+      poSRS->importFromEPSG(4326);
+      oPointField.SetSpatialRef(poSRS);
+      poSRS->Release();
 
-    if( poLayer->CreateGeomField( &oPointField ) != OGRERR_NONE )
-    {
-        printf( "Creating field PointField failed.\n" );
-        exit( 1 );
-    }
+      if( poLayer->CreateGeomField( &oPointField ) != OGRERR_NONE )
+      {
+          printf( "Creating field PointField failed.\n" );
+          exit( 1 );
+      }
 
-    OGRGeomFieldDefn oFieldPoint2( "PointField2", wkbPoint );
-    poSRS = new OGRSpatialReference();
-    poSRS->importFromEPSG(32631);
-    oPointField2.SetSpatialRef(poSRS);
-    poSRS->Release();
+      OGRGeomFieldDefn oFieldPoint2( "PointField2", wkbPoint );
+      poSRS = new OGRSpatialReference();
+      poSRS->importFromEPSG(32631);
+      oPointField2.SetSpatialRef(poSRS);
+      poSRS->Release();
 
-    if( poLayer->CreateGeomField( &oPointField2 ) != OGRERR_NONE )
-    {
-        printf( "Creating field PointField2 failed.\n" );
-        exit( 1 );
-    }
+      if( poLayer->CreateGeomField( &oPointField2 ) != OGRERR_NONE )
+      {
+          printf( "Creating field PointField2 failed.\n" );
+          exit( 1 );
+      }
 
+   .. code-tab:: c
 
-In C :
+      OGRGeomFieldDefnH hPointField;
+      OGRGeomFieldDefnH hPointField2;
+      OGRSpatialReferenceH hSRS;
 
-.. code-block:: c
+      hPointField = OGR_GFld_Create( "PointField", wkbPoint );
+      hSRS = OSRNewSpatialReference( NULL );
+      OSRImportFromEPSG(hSRS, 4326);
+      OGR_GFld_SetSpatialRef(hPointField, hSRS);
+      OSRRelease(hSRS);
 
-    OGRGeomFieldDefnH hPointField;
-    OGRGeomFieldDefnH hPointField2;
-    OGRSpatialReferenceH hSRS;
+      if( OGR_L_CreateGeomField( hLayer, hPointField ) != OGRERR_NONE )
+      {
+          printf( "Creating field PointField failed.\n" );
+          exit( 1 );
+      }
 
-    hPointField = OGR_GFld_Create( "PointField", wkbPoint );
-    hSRS = OSRNewSpatialReference( NULL );
-    OSRImportFromEPSG(hSRS, 4326);
-    OGR_GFld_SetSpatialRef(hPointField, hSRS);
-    OSRRelease(hSRS);
+      OGR_GFld_Destroy( hPointField );
 
-    if( OGR_L_CreateGeomField( hLayer, hPointField ) != OGRERR_NONE )
-    {
-        printf( "Creating field PointField failed.\n" );
-        exit( 1 );
-    }
+      hPointField2 = OGR_GFld_Create( "PointField2", wkbPoint );
+      OSRImportFromEPSG(hSRS, 32631);
+      OGR_GFld_SetSpatialRef(hPointField2, hSRS);
+      OSRRelease(hSRS);
 
-    OGR_GFld_Destroy( hPointField );
+      if( OGR_L_CreateGeomField( hLayer, hPointField2 ) != OGRERR_NONE )
+      {
+          printf( "Creating field PointField2 failed.\n" );
+          exit( 1 );
+      }
 
-    hPointField2 = OGR_GFld_Create( "PointField2", wkbPoint );
-    OSRImportFromEPSG(hSRS, 32631);
-    OGR_GFld_SetSpatialRef(hPointField2, hSRS);
-    OSRRelease(hSRS);
-
-    if( OGR_L_CreateGeomField( hLayer, hPointField2 ) != OGRERR_NONE )
-    {
-        printf( "Creating field PointField2 failed.\n" );
-        exit( 1 );
-    }
-
-    OGR_GFld_Destroy( hPointField2 );
+      OGR_GFld_Destroy( hPointField2 );
 
 
 To write a feature to disk, we must create a local OGRFeature, set attributes
@@ -1595,75 +1292,70 @@ and attach geometries before trying to write it to the layer.  It is
 imperative that this feature be instantiated from the OGRFeatureDefn
 associated with the layer it will be written to.
 
-In C++ :
+.. tabs::
 
-.. code-block:: c++
+   .. code-tab:: c++
 
-        OGRFeature *poFeature;
-        OGRGeometry *poGeometry;
-        char* pszWKT;
+          OGRFeature *poFeature;
+          OGRGeometry *poGeometry;
+          char* pszWKT;
 
-        poFeature = OGRFeature::CreateFeature( poLayer->GetLayerDefn() );
+          poFeature = OGRFeature::CreateFeature( poLayer->GetLayerDefn() );
 
-        pszWKT = (char*) "POINT (2 49)";
-        OGRGeometryFactory::createFromWkt( &pszWKT, NULL, &poGeometry );
-        poFeature->SetGeomFieldDirectly( "PointField", poGeometry );
+          pszWKT = (char*) "POINT (2 49)";
+          OGRGeometryFactory::createFromWkt( &pszWKT, NULL, &poGeometry );
+          poFeature->SetGeomFieldDirectly( "PointField", poGeometry );
 
-        pszWKT = (char*) "POINT (500000 4500000)";
-        OGRGeometryFactory::createFromWkt( &pszWKT, NULL, &poGeometry );
-        poFeature->SetGeomFieldDirectly( "PointField2", poGeometry );
+          pszWKT = (char*) "POINT (500000 4500000)";
+          OGRGeometryFactory::createFromWkt( &pszWKT, NULL, &poGeometry );
+          poFeature->SetGeomFieldDirectly( "PointField2", poGeometry );
 
-        if( poLayer->CreateFeature( poFeature ) != OGRERR_NONE )
-        {
-            printf( "Failed to create feature.\n" );
-            exit( 1 );
-        }
+          if( poLayer->CreateFeature( poFeature ) != OGRERR_NONE )
+          {
+              printf( "Failed to create feature.\n" );
+              exit( 1 );
+          }
 
-        OGRFeature::DestroyFeature( poFeature );
+          OGRFeature::DestroyFeature( poFeature );
 
-In C :
+   .. code-tab:: c
 
-.. code-block:: c
+          OGRFeatureH hFeature;
+          OGRGeometryH hGeometry;
+          char* pszWKT;
 
-        OGRFeatureH hFeature;
-        OGRGeometryH hGeometry;
-        char* pszWKT;
+          poFeature = OGR_F_Create( OGR_L_GetLayerDefn(hLayer) );
 
-        poFeature = OGR_F_Create( OGR_L_GetLayerDefn(hLayer) );
+          pszWKT = (char*) "POINT (2 49)";
+          OGR_G_CreateFromWkt( &pszWKT, NULL, &hGeometry );
+          OGR_F_SetGeomFieldDirectly( hFeature,
+              OGR_F_GetGeomFieldIndex(hFeature, "PointField"), hGeometry );
 
-        pszWKT = (char*) "POINT (2 49)";
-        OGR_G_CreateFromWkt( &pszWKT, NULL, &hGeometry );
-        OGR_F_SetGeomFieldDirectly( hFeature,
-            OGR_F_GetGeomFieldIndex(hFeature, "PointField"), hGeometry );
+          pszWKT = (char*) "POINT (500000 4500000)";
+          OGR_G_CreateFromWkt( &pszWKT, NULL, &hGeometry );
+          OGR_F_SetGeomFieldDirectly( hFeature,
+              OGR_F_GetGeomFieldIndex(hFeature, "PointField2"), hGeometry );
 
-        pszWKT = (char*) "POINT (500000 4500000)";
-        OGR_G_CreateFromWkt( &pszWKT, NULL, &hGeometry );
-        OGR_F_SetGeomFieldDirectly( hFeature,
-            OGR_F_GetGeomFieldIndex(hFeature, "PointField2"), hGeometry );
+          if( OGR_L_CreateFeature( hFeature ) != OGRERR_NONE )
+          {
+              printf( "Failed to create feature.\n" );
+              exit( 1 );
+          }
 
-        if( OGR_L_CreateFeature( hFeature ) != OGRERR_NONE )
-        {
-            printf( "Failed to create feature.\n" );
-            exit( 1 );
-        }
+          OGR_F_Destroy( hFeature );
 
-        OGR_F_Destroy( hFeature );
+   .. code-tab:: python
 
+          feat = ogr.Feature( lyr.GetLayerDefn() )
 
-In Python :
+          feat.SetGeomFieldDirectly( "PointField",
+              ogr.CreateGeometryFromWkt( "POINT (2 49)" ) )
+          feat.SetGeomFieldDirectly( "PointField2",
+              ogr.CreateGeometryFromWkt( "POINT (500000 4500000)" ) )
 
-.. code-block:: python
-
-        feat = ogr.Feature( lyr.GetLayerDefn() )
-
-        feat.SetGeomFieldDirectly( "PointField",
-            ogr.CreateGeometryFromWkt( "POINT (2 49)" ) )
-        feat.SetGeomFieldDirectly( "PointField2",
-            ogr.CreateGeometryFromWkt( "POINT (500000 4500000)" ) )
-
-        if lyr.CreateFeature( feat ) != 0:
-            print( "Failed to create feature.\n" );
-            sys.exit( 1 );
+          if lyr.CreateFeature( feat ) != 0:
+              print( "Failed to create feature.\n" );
+              sys.exit( 1 );
 
 .. _vector_api_tut_arrow_write:
 


### PR DESCRIPTION
Related to #11917, this PR updates 2 more tutorials to use tabs for C++/C/Python code examples.

Other changes:

- Legacy examples for "With GDAL < 2.3 and C++" removed as discussed in #11917
- Python2 code updated to Python3 (print statements missing parentheses, `raw_input` changed to `input`), and added `gdal.UseExceptions()`).
- Full Python scripts moved to own files, and then included in the tutorial using `literalinclude`. This made it easier to test and format the scripts.

I've run through and tested the Python examples, but not the C/C++ ones (I'm not sure if I'd be able to correct any issues with these, although I could open an issue if they aren't working). 

The full C/C++ examples could also be moved to separate code files - let me know if I should do this. 
