### PR TITLE
cpl_vsi_mem.cpp: Add include for std::strtoll.

### DIFF
--- a/port/cpl_vsi_mem.cpp
+++ b/port/cpl_vsi_mem.cpp
@@ -17,6 +17,7 @@
 
 #include <cerrno>
 #include <cstddef>
+#include <cstdlib>
 #include <cstring>
 #include <ctime>
 #if HAVE_FCNTL_H


### PR DESCRIPTION
At least one config/platform needs `#include <cstdlib>`. std::strtoll here was introduced in 5b9ddbb4e9af9fa90edbe59e74bd94b0d6c52fb4 / #12099

This is on google3 linux with a bazel build and llvm less than 2 weeks old:

```
third_party/gdal/port/cpl_vsi_mem.cpp:782:37: error: no member named 'strtoll' in namespace 'std'; did you mean simply 'strtoll'?
  782 |                 static_cast<time_t>(std::strtoll(mtime, nullptr, 10));
      |                                     ^~~~~~~~~~~~
      |                                     strtoll
include/stdlib.h:200:22: note: 'strtoll' declared here
  200 | extern long long int strtoll
```

https://en.cppreference.com/w/cpp/string/byte/strtol
