### PR TITLE
Remove references to RegisterOGRMEM after #12124

### DIFF
--- a/ogr/ogrsf_frmts/generic/ogrregisterall.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrregisterall.cpp
@@ -45,9 +45,6 @@ void OGRRegisterAllInternal()
 #ifdef VRT_ENABLED
     RegisterOGRVRT();
 #endif
-#ifdef MEM_ENABLED
-    RegisterOGRMEM();
-#endif
 #ifdef CSV_ENABLED
     RegisterOGRCSV();
 #endif

--- a/ogr/ogrsf_frmts/ogrsf_frmts.h
+++ b/ogr/ogrsf_frmts/ogrsf_frmts.h
@@ -705,7 +705,6 @@ void CPL_DLL RegisterOGRESRIJSON();
 void CPL_DLL RegisterOGRTopoJSON();
 void CPL_DLL RegisterOGRAVCBin();
 void CPL_DLL RegisterOGRAVCE00();
-void CPL_DLL RegisterOGRMEM();
 void CPL_DLL RegisterOGRVRT();
 void CPL_DLL RegisterOGRSQLite();
 void CPL_DLL RegisterOGRCSV();


### PR DESCRIPTION
Trivial cleanup:

The switch in #12124 / 9dbe489c4fcec4553c1eb01b4b227e6fafab76e0 to the MEM driver that can do both raster and vector in-memory work left references to `MEM_ENABLED` and `RegisterOGRMEM()`.

```shell
find . -name \*.cpp -o -name \*.h | xargs egrep 'MEM_ENABLED|RegisterOGRMEM'
./ogr/ogrsf_frmts/ogrsf_frmts.h:void CPL_DLL RegisterOGRMEM();
./ogr/ogrsf_frmts/generic/ogrregisterall.cpp:#ifdef MEM_ENABLED
./ogr/ogrsf_frmts/generic/ogrregisterall.cpp:    RegisterOGRMEM();
```