### PR TITLE
Doc: vrt.rst: Describe Common Elements of VRTDerivedRasterBand

### DIFF
--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1051,8 +1051,9 @@ additional pixel functions can be defined in :ref:`C++ <cpp_pixel_functions>`
 or :ref:`Python <python_pixel_functions>` and registered with GDAL using
 a unique key.
 
-Some of the Common subelements for VRTRasterBand (whose subclass specification must be set
-to VRTDerivedRasterBand) are :
+A VRTRasterBand can be made a VRTDerivedRasterBand by setting attribute subClass="VRTPansharpenedDataset".
+
+Some of the common subelements for VRTRasterBand (whose subClass="VRTPansharpenedDataset") are listed here. They can be used with built-in, C++, or Python pixel functions.
 
 - **PixelFunctionType**: (required): A pixel function with this name must be defined.
 - **SkipNonContributingSources**: (optional, added in GDAL 3.7, defaults to false) = true/false: Whether sources that do not intersect the VRTRasterBand RasterIO() requested region should be omitted. By default, data for all sources, including ones that do not intersect it, are passed to the pixel function. By setting this parameter to false, only sources that intersect the requested region will be passed.
@@ -1451,8 +1452,6 @@ set to VRTDerivedRasterBand) are :
 - **PixelFunctionCode** (required if PixelFunctionType is of the form "function_name", ignored otherwise). The in-lined code of a Python module, that must be at least have a function whose name is given by PixelFunctionType.
 
 - **BufferRadius** (optional, defaults to 0): Amount of extra pixels, with respect to the original RasterIO() request to satisfy, that are fetched at the left, right, bottom and top of the input and output buffers passed to the pixel function. Note that the values of the output buffer in this buffer zone will be ignored.
-
-- **SkipNonContributingSources** (optional, added in GDAL 3.7, defaults to false) = true/false: Whether sources that do not intersect the VRTRasterBand RasterIO() requested region should be omitted. By default, data for all sources, including ones that do not intersect it, are passed to the pixel function. By setting this parameter to false, only sources that intersect the requested region will be passed.
 
 The signature of the Python pixel function must have the following arguments:
 

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1051,6 +1051,12 @@ additional pixel functions can be defined in :ref:`C++ <cpp_pixel_functions>`
 or :ref:`Python <python_pixel_functions>` and registered with GDAL using
 a unique key.
 
+Some of the Common subelements for VRTRasterBand (whose subclass specification must be set
+to VRTDerivedRasterBand) are :
+
+- **PixelFunctionType**: (required): A pixel function with this name must be defined.
+- **SkipNonContributingSources**: (optional, added in GDAL 3.7, defaults to false) = true/false: Whether sources that do not intersect the VRTRasterBand RasterIO() requested region should be omitted. By default, data for all sources, including ones that do not intersect it, are passed to the pixel function. By setting this parameter to false, only sources that intersect the requested region will be passed.
+
 .. example::
    :title: Calculating a derived band
    :id: vrt-derived-1

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1051,9 +1051,9 @@ additional pixel functions can be defined in :ref:`C++ <cpp_pixel_functions>`
 or :ref:`Python <python_pixel_functions>` and registered with GDAL using
 a unique key.
 
-A VRTRasterBand can be made a VRTDerivedRasterBand by setting attribute subClass="VRTPansharpenedDataset".
+A VRTRasterBand can be made a VRTDerivedRasterBand by setting attribute subClass="VRTDerivedRasterBand".
 
-Some of the common subelements for VRTRasterBand (whose subClass="VRTPansharpenedDataset") are listed here. They can be used with built-in, C++, or Python pixel functions.
+Some of the common subelements for VRTRasterBand (whose subClass="VRTDerivedRasterBand") are listed here. They can be used with built-in, C++, or Python pixel functions.
 
 - **PixelFunctionType**: (required): A pixel function with this name must be defined.
 - **SkipNonContributingSources**: (optional, added in GDAL 3.7, defaults to false) = true/false: Whether sources that do not intersect the VRTRasterBand RasterIO() requested region should be omitted. By default, data for all sources, including ones that do not intersect it, are passed to the pixel function. By setting this parameter to false, only sources that intersect the requested region will be passed.

--- a/doc/source/spelling_wordlist.txt
+++ b/doc/source/spelling_wordlist.txt
@@ -3502,6 +3502,7 @@ vrf
 vrt
 VRT
 VRTDataset
+VRTDerivedRasterBand
 VRTPansharpenedDataset
 VRTWarpedDataset
 vsgis


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?
Some subelements of `VRTRasterDerivedBand` are applicable across different type of Pixel Functions but were mentioned in sub sections. This PR adds a top-level section for those subelements.

## What are related issues/pull requests?


## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [x] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
