### PR TITLE
Python bindings: avoid deprecation warning with setuptools >= 77

### DIFF
--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -180,7 +180,16 @@ if (Python_Interpreter_FOUND)
   endif ()
 
   configure_file(${CMAKE_CURRENT_SOURCE_DIR}/README.rst ${CMAKE_CURRENT_BINARY_DIR}/README.rst @ONLY)
-  configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pyproject.toml ${CMAKE_CURRENT_BINARY_DIR}/pyproject.toml @ONLY)
+
+  execute_process(
+    COMMAND ${Python_EXECUTABLE} -c "import setuptools; print(setuptools.__version__)"
+    OUTPUT_VARIABLE SETUPTOOLS_VERSION
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if (SETUPTOOLS_VERSION VERSION_GREATER_EQUAL 77.0.3)
+      configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pyproject.toml.setuptools_gte_77 ${CMAKE_CURRENT_BINARY_DIR}/pyproject.toml @ONLY)
+  else()
+      configure_file(${CMAKE_CURRENT_SOURCE_DIR}/pyproject.toml ${CMAKE_CURRENT_BINARY_DIR}/pyproject.toml @ONLY)
+  endif()
 
   file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/get_suffix.py
        "from importlib.machinery import EXTENSION_SUFFIXES; print(EXTENSION_SUFFIXES[0])\n")

--- a/swig/python/pyproject.toml.setuptools_gte_77
+++ b/swig/python/pyproject.toml.setuptools_gte_77
@@ -1,0 +1,44 @@
+[build-system]
+requires = ["setuptools>=77.0.3",
+            "wheel",
+            "oldest-supported-numpy; python_version=='3.8'",
+            "numpy >=2.0.0rc1; python_version>='3.9'"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "GDAL"
+dynamic = ["version", "scripts"]
+authors = [
+    {name = "Frank Warmerdam"},
+    {name = "Howard Butler"},
+    {name = "Even Rouault"},
+]
+maintainers = [
+    {name = "GDAL contributors", email = "gdal-dev@lists.osgeo.org"},
+]
+description = "GDAL: Geospatial Data Abstraction Library"
+readme = "README.rst"
+keywords = ["gis", "raster", "vector"]
+license = "MIT"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Science/Research",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: C",
+    "Programming Language :: C++",
+    "Topic :: Scientific/Engineering :: GIS",
+    "Topic :: Scientific/Engineering :: Information Analysis",
+]
+requires-python = ">=3.8"
+
+[project.optional-dependencies]
+numpy = ['numpy>1.0.0']
+
+[project.urls]
+Homepage = "https://gdal.org"
+Documentation = "https://gdal.org"
+Repository = "https://github.com/OSGeo/GDAL.git"
+Changelog = "https://github.com/OSGeo/gdal/blob/master/NEWS.md"
+Issues = "https://github.com/OSGeo/gdal/issues"


### PR DESCRIPTION
Avoids:
```

        ********************************************************************************
        Please use a simple string containing a SPDX expression for `project.license`. You can also use `project.license-files`. (Both options available on setuptools>=77.0.0).

        By 2026-Feb-18, you need to update your project and remove deprecated calls
        or your builds will no longer be supported.

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************

        ********************************************************************************
        Please consider removing the following classifiers in favor of a SPDX license expression:

        License :: OSI Approved :: MIT License

        See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
        ********************************************************************************
```
