### PR TITLE
Warn about INIT_DEST in warp operation instead of failing

### DIFF
--- a/alg/gdalwarpoperation.cpp
+++ b/alg/gdalwarpoperation.cpp
@@ -801,16 +801,17 @@ CPLErr GDALWarpOperation::InitializeDestinationBuffer(void *pDstBuffer,
         {
             if (psOptions->padfDstNoDataReal == nullptr)
             {
-                CPLError(CE_Failure, CPLE_AppDefined,
+                CPLError(CE_Warning, CPLE_AppDefined,
                          "BAND_INIT was set to NO_DATA, but a NoData value was "
                          "not defined.");
-                return CE_Failure;
             }
-
-            adfInitRealImag[0] = psOptions->padfDstNoDataReal[iBand];
-            if (psOptions->padfDstNoDataImag != nullptr)
+            else
             {
-                adfInitRealImag[1] = psOptions->padfDstNoDataImag[iBand];
+                adfInitRealImag[0] = psOptions->padfDstNoDataReal[iBand];
+                if (psOptions->padfDstNoDataImag != nullptr)
+                {
+                    adfInitRealImag[1] = psOptions->padfDstNoDataImag[iBand];
+                }
             }
         }
         else

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -4389,14 +4389,6 @@ def test_gdalwarp_lib_init_dest_invalid(tmp_vsimem):
             warpOptions={"INIT_DEST": "NODATA"},
         )
 
-    with pytest.raises(Exception, match="NoData value was not defined"):
-        gdal.Warp(
-            tmp_vsimem / "out.tif",
-            src_ds,
-            outputBounds=(440000, 3750120, 441920, 3751320),
-            warpOptions={"INIT_DEST": "NO_DATA"},
-        )
-
 
 ###############################################################################
 # Test scenario of https://github.com/OSGeo/gdal/issues/11992


### PR DESCRIPTION
#11978 changed a no-op condition to a hard failure. This breaks every recent version of Rasterio, which sets `INIT_DEST=NO_DATA` by default: https://github.com/rasterio/rasterio/blob/0fe62a7106034021e0375746b2581ad595f44f86/rasterio/_warp.pyx#L584-L585.

Instead, how about restoring the no-op, but with a warning?