### PR TITLE
gdal_rasterize: fix/simplify vertical/horizontal detection

### DIFF
--- a/alg/llrasterize.cpp
+++ b/alg/llrasterize.cpp
@@ -438,7 +438,8 @@ void GDALdllImageLineAllTouched(
             }
 
             // Special case for vertical lines.
-            if (floor(dfX) == floor(dfXEnd) || fabs(dfX - dfXEnd) < .01)
+
+            if (fabs(dfX - dfXEnd) < .01)
             {
                 if (bIntersectOnly)
                 {
@@ -518,7 +519,7 @@ void GDALdllImageLineAllTouched(
                 (dfXEnd - dfX);  // Per unit change in iX.
 
             // Special case for horizontal lines.
-            if (floor(dfY) == floor(dfYEnd) || fabs(dfY - dfYEnd) < .01)
+            if (fabs(dfY - dfYEnd) < .01)
             {
                 if (bIntersectOnly)
                 {

--- a/autotest/alg/rasterize.py
+++ b/autotest/alg/rasterize.py
@@ -998,3 +998,44 @@ def test_rasterize_bugfix_gh8918(wkt):
     )
 
     assert target_ds.GetRasterBand(1).Checksum() == 36
+
+###############################################################################
+
+def test_rasterize_bugfix_gh12129():
+    # Setup working spatial reference
+    sr_wkt = 'LOCAL_CS["arbitrary"]'
+    sr = osr.SpatialReference(sr_wkt)
+
+    # Create a memory raster to rasterize into.
+    target_ds = gdal.GetDriverByName("MEM").Create("", 20, 16, 1, gdal.GDT_Byte)
+    target_ds.SetGeoTransform((163600, 20, 0, 168000, 0, -20))
+
+    target_ds.SetProjection(sr_wkt)
+
+    # Create a memory layer to rasterize from.
+    rast_ogr_ds = ogr.GetDriverByName("MEM").CreateDataSource("wrk")
+    rast_mem_lyr = rast_ogr_ds.CreateLayer("poly", srs=sr)
+
+    # Add a polygon.
+    feat = ogr.Feature(rast_mem_lyr.GetLayerDefn())
+    feat.SetGeometryDirectly(ogr.Geometry(wkt="POLYGON ((163899.27734375 167988.154296875,163909.339662057 167743.621912878,163628.300781257 167745.908203129,163661.337890632 167785.683593765,163700 167880,163780.000000007 167860.000000011,163835.751953125 167942.617187511,163899.27734375 167988.154296875))"))
+
+    rast_mem_lyr.CreateFeature(feat)
+
+    # Run the algorithm.
+    gdal.RasterizeLayer(
+        target_ds,
+        [1],
+        rast_mem_lyr,
+        burn_values=[1],
+        options=["ALL_TOUCHED=YES"],
+    )
+
+    
+    print(target_ds.GetRasterBand(1))
+    checksum = target_ds.GetRasterBand(1).Checksum()
+    expected = 120
+    if checksum != expected:
+        print("checksum: " + str(checksum))
+        gdal.GetDriverByName("GTiff").CreateCopy("/tmp/rasterize_gh12129.tif", target_ds)
+        pytest.fail("Did not get expected image checksum")

--- a/autotest/alg/rasterize.py
+++ b/autotest/alg/rasterize.py
@@ -1037,12 +1037,4 @@ def test_rasterize_bugfix_gh12129():
         options=["ALL_TOUCHED=YES"],
     )
 
-    print(target_ds.GetRasterBand(1))
-    checksum = target_ds.GetRasterBand(1).Checksum()
-    expected = 120
-    if checksum != expected:
-        print("checksum: " + str(checksum))
-        gdal.GetDriverByName("GTiff").CreateCopy(
-            "/tmp/rasterize_gh12129.tif", target_ds
-        )
-        pytest.fail("Did not get expected image checksum")
+    assert target_ds.GetRasterBand(1).Checksum() == 120

--- a/autotest/alg/rasterize.py
+++ b/autotest/alg/rasterize.py
@@ -1037,4 +1037,5 @@ def test_rasterize_bugfix_gh12129():
         options=["ALL_TOUCHED=YES"],
     )
 
-    assert target_ds.GetRasterBand(1).Checksum() == 120
+    # 121 on s390x
+    assert target_ds.GetRasterBand(1).Checksum() in (120, 121)

--- a/autotest/alg/rasterize.py
+++ b/autotest/alg/rasterize.py
@@ -999,7 +999,9 @@ def test_rasterize_bugfix_gh8918(wkt):
 
     assert target_ds.GetRasterBand(1).Checksum() == 36
 
+
 ###############################################################################
+
 
 def test_rasterize_bugfix_gh12129():
     # Setup working spatial reference
@@ -1018,7 +1020,11 @@ def test_rasterize_bugfix_gh12129():
 
     # Add a polygon.
     feat = ogr.Feature(rast_mem_lyr.GetLayerDefn())
-    feat.SetGeometryDirectly(ogr.Geometry(wkt="POLYGON ((163899.27734375 167988.154296875,163909.339662057 167743.621912878,163628.300781257 167745.908203129,163661.337890632 167785.683593765,163700 167880,163780.000000007 167860.000000011,163835.751953125 167942.617187511,163899.27734375 167988.154296875))"))
+    feat.SetGeometryDirectly(
+        ogr.Geometry(
+            wkt="POLYGON ((163899.27734375 167988.154296875,163909.339662057 167743.621912878,163628.300781257 167745.908203129,163661.337890632 167785.683593765,163700 167880,163780.000000007 167860.000000011,163835.751953125 167942.617187511,163899.27734375 167988.154296875))"
+        )
+    )
 
     rast_mem_lyr.CreateFeature(feat)
 
@@ -1031,11 +1037,12 @@ def test_rasterize_bugfix_gh12129():
         options=["ALL_TOUCHED=YES"],
     )
 
-    
     print(target_ds.GetRasterBand(1))
     checksum = target_ds.GetRasterBand(1).Checksum()
     expected = 120
     if checksum != expected:
         print("checksum: " + str(checksum))
-        gdal.GetDriverByName("GTiff").CreateCopy("/tmp/rasterize_gh12129.tif", target_ds)
+        gdal.GetDriverByName("GTiff").CreateCopy(
+            "/tmp/rasterize_gh12129.tif", target_ds
+        )
         pytest.fail("Did not get expected image checksum")


### PR DESCRIPTION
## What does this PR do?

This fixes https://github.com/OSGeo/gdal/issues/12129

I could not come up with cases where floor would be more appropriate than the absolute difference, but maybe I don't see the full context here.
In addition, one could argue that EPSILON_INTERSECT_ONLY should be used instead of the fixed value of 0.01

I've added a test based on the initial failing file. 
