### PR TITLE
GDALWarp: Harden NoData value parsing

### DIFF
--- a/alg/gdalwarpoperation.cpp
+++ b/alg/gdalwarpoperation.cpp
@@ -802,7 +802,7 @@ CPLErr GDALWarpOperation::InitializeDestinationBuffer(void *pDstBuffer,
             if (psOptions->padfDstNoDataReal == nullptr)
             {
                 CPLError(CE_Failure, CPLE_AppDefined,
-                         "BAND_INIT was set to NO_DATA, but a NoData value was "
+                         "INIT_DEST was set to NO_DATA, but a NoData value was "
                          "not defined.");
                 return CE_Failure;
             }
@@ -815,18 +815,13 @@ CPLErr GDALWarpOperation::InitializeDestinationBuffer(void *pDstBuffer,
         }
         else
         {
-            for (const char *c = pszBandInit; *c != '\0'; c++)
+            if (CPLStringToComplex(pszBandInit, &adfInitRealImag[0],
+                                   &adfInitRealImag[1]) != CE_None)
             {
-                if (std::isalpha(*c) && *c != 'i')
-                {
-                    CPLError(CE_Failure, CPLE_AppDefined,
-                             "Unexpected value of BAND_INIT: %s", pszBandInit);
-                    return CE_Failure;
-                }
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Error parsing INIT_DEST");
+                return CE_Failure;
             }
-
-            CPLStringToComplex(pszBandInit, adfInitRealImag + 0,
-                               adfInitRealImag + 1);
         }
 
         GByte *pBandData = static_cast<GByte *>(pDstBuffer) + iBand * nBandSize;

--- a/alg/gdalwarpoperation.cpp
+++ b/alg/gdalwarpoperation.cpp
@@ -805,7 +805,8 @@ CPLErr GDALWarpOperation::InitializeDestinationBuffer(void *pDstBuffer,
                 // See https://github.com/OSGeo/gdal/pull/12189
                 CPLError(CE_Warning, CPLE_AppDefined,
                          "INIT_DEST was set to NO_DATA, but a NoData value was "
-                         "not defined.");
+                         "not defined. This warning will become a failure in a "
+                         "future GDAL release.");
                 return CE_Failure;
             }
 

--- a/alg/gdalwarpoperation.cpp
+++ b/alg/gdalwarpoperation.cpp
@@ -801,7 +801,9 @@ CPLErr GDALWarpOperation::InitializeDestinationBuffer(void *pDstBuffer,
         {
             if (psOptions->padfDstNoDataReal == nullptr)
             {
-                CPLError(CE_Failure, CPLE_AppDefined,
+                // TODO: Change to CE_Failure for GDAL 3.12
+                // See https://github.com/OSGeo/gdal/pull/12189
+                CPLError(CE_Warning, CPLE_AppDefined,
                          "INIT_DEST was set to NO_DATA, but a NoData value was "
                          "not defined.");
                 return CE_Failure;

--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -5332,6 +5332,43 @@ TEST_F(test_cpl, CPLStrtod)
     }
 }
 
+TEST_F(test_cpl, CPLStringToComplex)
+{
+    const auto EXPECT_PARSED = [](const char *str, double real, double imag)
+    {
+        double r = -999;
+        double i = -999;
+        EXPECT_EQ(CPLStringToComplex(str, &r, &i), CE_None)
+            << "Unexpected error parsing " << str;
+        EXPECT_EQ(r, real);
+        EXPECT_EQ(i, imag);
+    };
+    const auto EXPECT_ERROR = [](const char *str)
+    {
+        CPLErrorStateBackuper state(CPLQuietErrorHandler);
+        double r, i;
+        EXPECT_EQ(CPLStringToComplex(str, &r, &i), CE_Failure)
+            << "Did not receive expected error parsing " << str;
+    };
+
+    EXPECT_PARSED("05401", 5401, 0);
+    EXPECT_PARSED("-5401", -5401, 0);
+    EXPECT_PARSED(" 611.2-38.4i", 611.2, -38.4);
+    EXPECT_PARSED("611.2+38.4i ", 611.2, 38.4);
+    EXPECT_PARSED("-611.2+38.4i", -611.2, 38.4);
+
+    EXPECT_ERROR("-611.2+38.4ii");
+    EXPECT_ERROR("-611.2+38.4ji");
+    EXPECT_ERROR("-611.2+38.4ij");
+    EXPECT_ERROR("f-611.2+38.4i");
+    EXPECT_ERROR("-611.2+f38.4i");
+    EXPECT_ERROR("-611.2+-38.4i");
+    EXPECT_ERROR("611.2+38.4");
+    EXPECT_ERROR("38.4i");
+    EXPECT_ERROR("38.4x");
+    EXPECT_ERROR("invalid");
+}
+
 TEST_F(test_cpl, CPLForceToASCII)
 {
     {

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -4391,7 +4391,9 @@ def test_gdalwarp_lib_init_dest_invalid(tmp_vsimem, init_dest):
 
 def test_gdalwarp_lib_init_dest_nodata_invalid(tmp_vsimem):
 
-    with pytest.raises(Exception, match="NoData value was not defined"):
+    # TODO: switch from warning to failure in GDAL 3.12
+    # with pytest.raises(Exception, match="NoData value was not defined"):
+    with gdaltest.error_raised(gdal.CE_Warning, "NoData value was not defined"):
         gdal.Warp(
             tmp_vsimem / "out.tif",
             "../gcore/data/byte.tif",

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -4377,22 +4377,24 @@ def test_gdalwarp_lib_cubic_multiband_uint16_4sample_optim():
 # Test invalid values of INIT_DEST
 
 
-def test_gdalwarp_lib_init_dest_invalid(tmp_vsimem):
+@pytest.mark.parametrize("init_dest", ("NODATA", "32.6x"))
+def test_gdalwarp_lib_init_dest_invalid(tmp_vsimem, init_dest):
 
-    src_ds = gdal.Open("../gcore/data/byte.tif")
-
-    with pytest.raises(Exception, match="Unexpected value of BAND_INIT"):
+    with pytest.raises(Exception, match="Error parsing INIT_DEST"):
         gdal.Warp(
             tmp_vsimem / "out.tif",
-            src_ds,
+            "../gcore/data/byte.tif",
             outputBounds=(440000, 3750120, 441920, 3751320),
-            warpOptions={"INIT_DEST": "NODATA"},
+            warpOptions={"INIT_DEST": init_dest},
         )
+
+
+def test_gdalwarp_lib_init_dest_nodata_invalid(tmp_vsimem):
 
     with pytest.raises(Exception, match="NoData value was not defined"):
         gdal.Warp(
             tmp_vsimem / "out.tif",
-            src_ds,
+            "../gcore/data/byte.tif",
             outputBounds=(440000, 3750120, 441920, 3751320),
             warpOptions={"INIT_DEST": "NO_DATA"},
         )

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -4488,3 +4488,19 @@ def test_gdalwarp_lib_warn_different_coordinate_operations():
             gdal.GetLastErrorMsg()
             == "Several coordinate operations are going to be used. Artifacts may appear. You may consider using the -to ALLOW_BALLPARK=NO and/or -to ONLY_BEST=YES transform options, or specify a particular coordinate operation with -ct"
         )
+
+
+###############################################################################
+# Test that invalid NoData values cause an error
+
+
+def test_gdalwarp_lib_invalid_dstnodata(tmp_vsimem):
+
+    with pytest.raises(RuntimeError, match="Error parsing dstnodata"):
+        gdal.Warp(tmp_vsimem / "out.tif", "../gcore/data/byte.tif", dstNodata="bad")
+
+
+def test_gdalwarp_lib_invalid_srcnodata(tmp_vsimem):
+
+    with pytest.raises(RuntimeError, match="Error parsing srcnodata"):
+        gdal.Warp(tmp_vsimem / "out.tif", "../gcore/data/byte.tif", srcNodata="bad")

--- a/frmts/vrt/vrtmultidim.cpp
+++ b/frmts/vrt/vrtmultidim.cpp
@@ -2222,7 +2222,15 @@ bool VRTMDArray::IRead(const GUInt64 *arrayStartIdx, const size_t *count,
         std::vector<GByte *> abyStackDstPtr;
         size_t iDim = 0;
         abyStackDstPtr.push_back(static_cast<GByte *>(pDstBuffer));
+        // GCC 15.1 on msys2-mingw64
+#if defined(__GNUC__)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
         abyStackDstPtr.resize(nDims + 1);
+#if defined(__GNUC__)
+#pragma GCC diagnostic pop
+#endif
     lbl_next_depth:
         if (iDim == nDims)
         {

--- a/ogr/ogrsf_frmts/cad/libopencad/dwg/r2000.cpp
+++ b/ogr/ogrsf_frmts/cad/libopencad/dwg/r2000.cpp
@@ -18,6 +18,7 @@
 #include "r2000.h"
 
 #include <cassert>
+#include <cstdint>
 #include <cstring>
 #include <iostream>
 #include <limits>

--- a/ogr/ogrsf_frmts/parquet/ogrparquetwriterlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetwriterlayer.cpp
@@ -1076,7 +1076,11 @@ OGRErr OGRParquetWriterLayer::ICreateFeature(OGRFeature *poFeature)
 
 bool OGRParquetWriterLayer::FlushGroup()
 {
+#if PARQUET_VERSION_MAJOR >= 20
+    auto status = m_poFileWriter->NewRowGroup();
+#else
     auto status = m_poFileWriter->NewRowGroup(m_apoBuilders[0]->length());
+#endif
     if (!status.ok())
     {
         CPLError(CE_Failure, CPLE_AppDefined, "NewRowGroup() failed with %s",

--- a/port/cpl_conv.h
+++ b/port/cpl_conv.h
@@ -283,8 +283,8 @@ const char CPL_DLL *CPLDecToDMS(double dfAngle, const char *pszAxis,
 double CPL_DLL CPLPackedDMSToDec(double);
 double CPL_DLL CPLDecToPackedDMS(double dfDec);
 
-void CPL_DLL CPLStringToComplex(const char *pszString, double *pdfReal,
-                                double *pdfImag);
+CPLErr CPL_DLL CPLStringToComplex(const char *pszString, double *pdfReal,
+                                  double *pdfImag);
 
 /* -------------------------------------------------------------------- */
 /*      Misc other functions.                                           */


### PR DESCRIPTION
- Issue error if `-srcnodata` and `-dstnodata` cannot be parsed
- Issue error if numeric input to `INIT_DEST` cannot be parsed
- Temporarily allow `INIT_DEST=NO_DATA`  without a NoData value, to accommodate rasterio usage