### PR TITLE
SWIG: Add Driver.CreateVector

### DIFF
--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -6129,9 +6129,7 @@ def test_ogr_shape_arrow_stream_fid_optim(tmp_vsimem):
 def test_ogr_shape_logical_field(tmp_vsimem):
 
     filename = tmp_vsimem / "test_ogr_shape_logical_field.shp"
-    ds = gdal.GetDriverByName("ESRI Shapefile").Create(
-        filename, 0, 0, 0, gdal.GDT_Unknown
-    )
+    ds = gdal.GetDriverByName("ESRI Shapefile").CreateVector(filename)
     lyr = ds.CreateLayer("test")
     fld_defn = ogr.FieldDefn("bool_field", ogr.OFTInteger)
     fld_defn.SetSubType(ogr.OFSTBoolean)

--- a/swig/include/Driver.i
+++ b/swig/include/Driver.i
@@ -57,6 +57,15 @@ public:
     return ds;
   }
 
+%newobject Create;
+#ifndef SWIGJAVA
+%feature( "kwargs" ) CreateVector;
+#endif
+  GDALDatasetShadow *CreateVector(const char *utf8_path, char **options = 0) {
+    GDALDatasetShadow* ds = (GDALDatasetShadow*) GDALCreate(self, utf8_path, 0, 0, 0, GDT_Unknown, options);
+    return ds;
+  }
+
 %newobject CreateMultiDimensional;
 #ifndef SWIGJAVA
 %feature( "kwargs" ) CreateMultiDimensional;

--- a/swig/include/python/docs/gdal_driver_docs.i
+++ b/swig/include/python/docs/gdal_driver_docs.i
@@ -125,6 +125,29 @@ Examples
 
 ";
 
+%feature("docstring") CreateVector "
+
+Create a new vector :py:class:`Dataset` with this driver.
+This method is an alias for ``Create(name, 0, 0, 0, gdal.GDT_Unknown)``.
+
+Parameters
+----------
+utf8_path : str
+   Path of the dataset to create.
+
+Returns
+-------
+Dataset
+
+Examples
+--------
+>>> with gdal.GetDriverByName('ESRI Shapefile').CreateVector('test.shp') as ds:
+...     print(ds.GetLayerCount())
+... 
+0
+
+";
+
 %feature("docstring") Delete "
 Delete a :py:class:`Dataset`.
 See :cpp:func:`GDALDriver::Delete`.


### PR DESCRIPTION
This is simply an alias for `Create(fname, 0, 0, 0, GDT_Unknown)`. In Python this is also equivalent to `CreateDataSource`, but `CreateDataSource` implies a distinction between a `Dataset` and a `DataSource` that no longer exists.