### PR TITLE
gdal vector pipeline: ensure sources are opened as vectors

### DIFF
--- a/apps/gdalalg_vector_pipeline.cpp
+++ b/apps/gdalalg_vector_pipeline.cpp
@@ -548,6 +548,18 @@ bool GDALVectorPipelineAlgorithm::ParseCommandLineArguments(
         inputArg->GetType() == GAAT_DATASET_LIST &&
         inputArg->Get<std::vector<GDALArgDatasetValue>>().size() == 1)
     {
+        if (inputArg->GetType() == GAAT_DATASET_LIST)
+        {
+            for (auto &value :
+                 inputArg->Get<std::vector<GDALArgDatasetValue>>())
+            {
+                value.SetType(GDAL_OF_VECTOR);
+            }
+        }
+        else
+        {
+            inputArg->Get<GDALArgDatasetValue>().SetType(GDAL_OF_VECTOR);
+        }
         steps.front().alg->ProcessDatasetArg(inputArg, steps.back().alg.get());
     }
 


### PR DESCRIPTION
Resolves https://lists.osgeo.org/pipermail/gdal-dev/2025-April/060482.html

I suspect there is a better way to do this, though.