### PR TITLE
[cli] Port gdal_fillnodata to CLI

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -24,8 +24,10 @@ add_library(
   gdalalg_raster_convert.cpp
   gdalalg_raster_create.cpp
   gdalalg_raster_edit.cpp
+
   gdalalg_raster_contour.cpp
   gdalalg_raster_footprint.cpp
+  gdalalg_raster_fillnodata.cpp
   gdalalg_raster_hillshade.cpp
   gdalalg_raster_index.cpp
   gdalalg_raster_mosaic.cpp

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -24,7 +24,6 @@ add_library(
   gdalalg_raster_convert.cpp
   gdalalg_raster_create.cpp
   gdalalg_raster_edit.cpp
-
   gdalalg_raster_contour.cpp
   gdalalg_raster_footprint.cpp
   gdalalg_raster_fillnodata.cpp

--- a/apps/gdalalg_raster.cpp
+++ b/apps/gdalalg_raster.cpp
@@ -24,6 +24,7 @@
 #include "gdalalg_raster_edit.h"
 #include "gdalalg_raster_contour.h"
 #include "gdalalg_raster_footprint.h"
+#include "gdalalg_raster_fillnodata.h"
 #include "gdalalg_raster_hillshade.h"
 #include "gdalalg_raster_index.h"
 #include "gdalalg_raster_mosaic.h"
@@ -67,6 +68,7 @@ class GDALRasterAlgorithm final : public GDALAlgorithm
         RegisterSubAlgorithm<GDALRasterEditAlgorithmStandalone>();
         RegisterSubAlgorithm<GDALRasterFootprintAlgorithm>();
         RegisterSubAlgorithm<GDALRasterHillshadeAlgorithmStandalone>();
+        RegisterSubAlgorithm<GDALRasterFillNodataAlgorithm>();
         RegisterSubAlgorithm<GDALRasterIndexAlgorithm>();
         RegisterSubAlgorithm<GDALRasterOverviewAlgorithm>();
         RegisterSubAlgorithm<GDALRasterPipelineAlgorithm>();

--- a/apps/gdalalg_raster_fillnodata.cpp
+++ b/apps/gdalalg_raster_fillnodata.cpp
@@ -71,7 +71,7 @@ GDALRasterFillNodataAlgorithm::GDALRasterFillNodataAlgorithm() noexcept
     SetAutoCompleteFunctionForFilename(mask, GDAL_OF_RASTER);
 
     mask.AddValidationAction(
-        [this, &mask]()
+        [&mask]()
         {
             // Check if the mask dataset is a valid raster dataset descriptor
             // Try to open the dataset as a raster

--- a/apps/gdalalg_raster_fillnodata.cpp
+++ b/apps/gdalalg_raster_fillnodata.cpp
@@ -149,13 +149,6 @@ bool GDALRasterFillNodataAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
     }
 
     GDALRasterBand *dstBand{poRetDS->GetRasterBand(1)};
-    if (!dstBand)
-    {
-        ReportError(CE_Failure, CPLE_AppDefined,
-                    "Cannot get destination band.");
-        return false;
-    }
-
     // Prepare options to pass to GDALFillNodata
     CPLStringList aosFillOptions;
     aosFillOptions.AddNameValue("INTERPOLATION", m_strategy.c_str());

--- a/apps/gdalalg_raster_fillnodata.cpp
+++ b/apps/gdalalg_raster_fillnodata.cpp
@@ -83,11 +83,11 @@ GDALRasterFillNodataAlgorithm::GDALRasterFillNodataAlgorithm() noexcept
 
     AddArg("strategy", 0,
            _("By default, pixels are interpolated using an inverse distance "
-             "weighting (inv_dist). It is also possible to choose a nearest "
+             "weighting (invdist). It is also possible to choose a nearest "
              "neighbour (nearest) strategy."),
            &m_strategy)
         .SetDefault(m_strategy)
-        .SetChoices("inv_dist", "nearest");
+        .SetChoices("invdist", "nearest");
 }
 
 /************************************************************************/
@@ -151,7 +151,12 @@ bool GDALRasterFillNodataAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
     GDALRasterBand *dstBand{poRetDS->GetRasterBand(1)};
     // Prepare options to pass to GDALFillNodata
     CPLStringList aosFillOptions;
-    aosFillOptions.AddNameValue("INTERPOLATION", m_strategy.c_str());
+
+    if (EQUAL(m_strategy.c_str(), "nearest"))
+        aosFillOptions.AddNameValue("INTERPOLATION", "NEAREST");
+    else
+        aosFillOptions.AddNameValue("INTERPOLATION",
+                                    "INV_DIST");  // default strategy
 
     auto retVal{GDALFillNodata(
         dstBand, maskBand, m_maxDistance, 0, m_smoothingIterations,

--- a/apps/gdalalg_raster_fillnodata.cpp
+++ b/apps/gdalalg_raster_fillnodata.cpp
@@ -1,0 +1,180 @@
+/******************************************************************************
+ *
+ * Project:  GDAL
+ * Purpose:  "gdal raster fillnodata" standalone command
+ * Author:   Alessandro Pasotti <elpaso at itopen dot it>
+ *
+ ******************************************************************************
+ * Copyright (c) 2025, Alessandro Pasotti <elpaso at itopen dot it>
+ *
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#include "gdalalg_raster_fillnodata.h"
+
+#include "gdal_priv.h"
+#include "gdal_utils.h"
+#include "gdal_alg.h"
+
+#include <algorithm>
+
+//! @cond Doxygen_Suppress
+
+#ifndef _
+#define _(x) (x)
+#endif
+
+/************************************************************************/
+/*   GDALRasterFillNodataAlgorithm::GDALRasterFillNodataAlgorithm()     */
+/************************************************************************/
+
+GDALRasterFillNodataAlgorithm::GDALRasterFillNodataAlgorithm() noexcept
+    : GDALAlgorithm(NAME, DESCRIPTION, HELP_URL)
+{
+
+    AddProgressArg();
+
+    AddInputFormatsArg(&m_inputFormats)
+        .AddMetadataItem(GAAMDI_REQUIRED_CAPABILITIES, {GDAL_DCAP_RASTER});
+    AddInputDatasetArg(&m_inputDataset, GDAL_OF_RASTER);
+    AddOutputDatasetArg(&m_outputDataset, GDAL_OF_RASTER);
+    AddOutputFormatArg(&m_format, /* bStreamAllowed = */ false,
+                       /* bGDALGAllowed = */ false)
+        .AddMetadataItem(GAAMDI_REQUIRED_CAPABILITIES,
+                         {GDAL_DCAP_CREATE, GDAL_DCAP_RASTER});
+
+    AddCreationOptionsArg(&m_creationOptions);
+    AddOverwriteArg(&m_overwrite);
+
+    AddBandArg(&m_band).SetDefault(m_band);
+
+    AddArg("max-distance", 'd',
+           _("The maximum distance (in pixels) that the algorithm will search "
+             "out for values to interpolate."),
+           &m_maxDistance)
+        .SetDefault(m_maxDistance)
+        .SetMetaVar("MAX_DISTANCE");
+
+    AddArg("smoothing-iterations", 's',
+           _("The number of 3x3 average filter smoothing iterations to run "
+             "after the interpolation to dampen artifacts. The default is zero "
+             "smoothing iterations."),
+           &m_smoothingIterations)
+        .SetDefault(m_smoothingIterations)
+        .SetMetaVar("SMOOTHING_ITERATIONS");
+
+    auto &mask{AddArg("mask", 0,
+                      _("Use the first band of the specified file as a "
+                        "validity mask (zero is invalid, non-zero is valid)."),
+                      &m_maskDataset)};
+
+    SetAutoCompleteFunctionForFilename(mask, GDAL_OF_RASTER);
+
+    mask.AddValidationAction(
+        [this, &mask]()
+        {
+            // Check if the mask dataset is a valid raster dataset descriptor
+            // Try to open the dataset as a raster
+            std::unique_ptr<GDALDataset> poDS(
+                GDALDataset::Open(mask.Get<std::string>().c_str(),
+                                  GDAL_OF_RASTER, nullptr, nullptr, nullptr));
+            return static_cast<bool>(poDS);
+        });
+
+    AddArg("strategy", 0,
+           _("By default, pixels are interpolated using an inverse distance "
+             "weighting (inv_dist). It is also possible to choose a nearest "
+             "neighbour (nearest) strategy."),
+           &m_strategy)
+        .SetDefault(m_strategy)
+        .SetChoices("inv_dist", "nearest");
+}
+
+/************************************************************************/
+/*                 GDALRasterFillNodataAlgorithm::RunImpl()             */
+/************************************************************************/
+
+bool GDALRasterFillNodataAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
+                                            void *pProgressData)
+{
+
+    VSIStatBufL sStat;
+    if (!m_overwrite && !m_outputDataset.GetName().empty() &&
+        (VSIStatL(m_outputDataset.GetName().c_str(), &sStat) == 0 ||
+         std::unique_ptr<GDALDataset>(
+             GDALDataset::Open(m_outputDataset.GetName().c_str()))))
+    {
+        ReportError(CE_Failure, CPLE_AppDefined,
+                    "File '%s' already exists. Specify the --overwrite "
+                    "option to overwrite it.",
+                    m_outputDataset.GetName().c_str());
+        return false;
+    }
+
+    CPLStringList aosOptions;
+    aosOptions.AddString("-of");
+    aosOptions.AddString(m_format.c_str());
+    aosOptions.AddString("-b");
+    aosOptions.AddString(CPLSPrintf("%d", m_band));
+
+    for (const auto &co : m_creationOptions)
+    {
+        aosOptions.AddString("-co");
+        aosOptions.AddString(co.c_str());
+    }
+
+    GDALTranslateOptions *psOptions =
+        GDALTranslateOptionsNew(aosOptions.List(), nullptr);
+
+    GDALDatasetH hSrcDS = GDALDataset::ToHandle(m_inputDataset.GetDatasetRef());
+    auto poRetDS =
+        std::unique_ptr<GDALDataset>(GDALDataset::FromHandle(GDALTranslate(
+            m_outputDataset.GetName().c_str(), hSrcDS, psOptions, nullptr)));
+    GDALTranslateOptionsFree(psOptions);
+
+    if (!poRetDS)
+    {
+        return false;
+    }
+
+    GDALRasterBand *maskBand{nullptr};
+    if (m_maskDataset.GetDatasetRef())
+    {
+        maskBand = m_maskDataset.GetDatasetRef()->GetRasterBand(1);
+        if (!maskBand)
+        {
+            ReportError(CE_Failure, CPLE_AppDefined, "Cannot get mask band.");
+            return false;
+        }
+    }
+
+    GDALRasterBand *dstBand{poRetDS->GetRasterBand(1)};
+    if (!dstBand)
+    {
+        ReportError(CE_Failure, CPLE_AppDefined,
+                    "Cannot get destination band.");
+        return false;
+    }
+
+    // Prepare options to pass to GDALFillNodata
+    CPLStringList aosFillOptions;
+    aosFillOptions.AddNameValue("INTERPOLATION", m_strategy.c_str());
+
+    auto retVal{GDALFillNodata(
+        dstBand, maskBand, m_maxDistance, 0, m_smoothingIterations,
+        aosFillOptions.List(), m_progressBarRequested ? pfnProgress : nullptr,
+        m_progressBarRequested ? pProgressData : nullptr)};
+    if (retVal != CE_None)
+    {
+        ReportError(CE_Failure, CPLE_AppDefined, "Cannot run fillNodata.");
+        return false;
+    }
+
+    poRetDS->FlushCache();
+
+    m_outputDataset.Set(std::move(poRetDS));
+
+    return true;
+}
+
+//! @endcond

--- a/apps/gdalalg_raster_fillnodata.h
+++ b/apps/gdalalg_raster_fillnodata.h
@@ -52,7 +52,7 @@ class GDALRasterFillNodataAlgorithm /* non final */
     // Use the first band of the specified file as a validity mask (zero is invalid, non-zero is valid).
     GDALArgDatasetValue m_maskDataset{};
     // By default, pixels are interpolated using an inverse distance weighting (inv_dist). It is also possible to choose a nearest neighbour (nearest) strategy.
-    std::string m_strategy = "inv_dist";
+    std::string m_strategy = "invdist";
 };
 
 //! @endcond

--- a/apps/gdalalg_raster_fillnodata.h
+++ b/apps/gdalalg_raster_fillnodata.h
@@ -1,0 +1,60 @@
+/******************************************************************************
+ *
+ * Project:  GDAL
+ * Purpose:  "gdal raster fillnodata" standalone command
+ * Author:   Alessandro Pasotti <elpaso at itopen dot it>
+ *
+ ******************************************************************************
+ * Copyright (c) 2025, Alessandro Pasotti <elpaso at itopen dot it>
+ *
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#ifndef GDALALG_RASTER_FILLNODATA_INCLUDED
+#define GDALALG_RASTER_FILLNODATA_INCLUDED
+
+#include "gdalalg_raster_pipeline.h"
+
+//! @cond Doxygen_Suppress
+
+/************************************************************************/
+/*                   GDALRasterFillNodataAlgorithm                      */
+/************************************************************************/
+
+class GDALRasterFillNodataAlgorithm /* non final */
+    : public GDALAlgorithm
+{
+  public:
+    static constexpr const char *NAME = "fillnodata";
+    static constexpr const char *DESCRIPTION =
+        "Fill nodata raster regions by interpolation from edges.";
+    static constexpr const char *HELP_URL =
+        "/programs/gdal_raster_fillnodata.html";
+
+    explicit GDALRasterFillNodataAlgorithm() noexcept;
+
+  private:
+    bool RunImpl(GDALProgressFunc pfnProgress, void *pProgressData) override;
+
+    GDALArgDatasetValue m_inputDataset{};
+    GDALArgDatasetValue m_outputDataset{};
+    std::string m_format{};
+    std::vector<std::string> m_creationOptions{};
+    std::vector<std::string> m_inputFormats{};
+
+    bool m_overwrite{false};
+    // The maximum distance (in pixels) that the algorithm will search out for values to interpolate. The default is 100 pixels.
+    int m_maxDistance = 100;
+    // The number of 3x3 average filter smoothing iterations to run after the interpolation to dampen artifacts. The default is zero smoothing iterations.
+    int m_smoothingIterations = 0;
+    // The band to operate on, by default the first band is operated on.
+    int m_band = 1;
+    // Use the first band of the specified file as a validity mask (zero is invalid, non-zero is valid).
+    GDALArgDatasetValue m_maskDataset{};
+    // By default, pixels are interpolated using an inverse distance weighting (inv_dist). It is also possible to choose a nearest neighbour (nearest) strategy.
+    std::string m_strategy = "inv_dist";
+};
+
+//! @endcond
+
+#endif /* GDALALG_RASTER_FILLNODATA_INCLUDED */

--- a/apps/gdalalg_raster_pipeline.cpp
+++ b/apps/gdalalg_raster_pipeline.cpp
@@ -17,6 +17,7 @@
 #include "gdalalg_raster_clip.h"
 #include "gdalalg_raster_color_map.h"
 #include "gdalalg_raster_edit.h"
+#include "gdalalg_raster_fillnodata.h"
 #include "gdalalg_raster_hillshade.h"
 #include "gdalalg_raster_reproject.h"
 #include "gdalalg_raster_resize.h"

--- a/apps/gdalalg_raster_pipeline.h
+++ b/apps/gdalalg_raster_pipeline.h
@@ -55,10 +55,9 @@ class GDALRasterPipelineStepAlgorithm /* non final */ : public GDALAlgorithm
     std::vector<std::string> m_creationOptions{};
     bool m_overwrite = false;
     std::string m_outputLayerName{};
-
-  private:
     GDALInConstructionAlgorithmArg *m_outputFormatArg = nullptr;
 
+  private:
     bool RunImpl(GDALProgressFunc pfnProgress, void *pProgressData) override;
     GDALAlgorithm::ProcessGDALGOutputRet ProcessGDALGOutput() override;
     bool CheckSafeForStreamOutput() override;

--- a/autotest/utilities/test_gdalalg_raster_fillnodata.py
+++ b/autotest/utilities/test_gdalalg_raster_fillnodata.py
@@ -90,7 +90,7 @@ def test_gdalalg_raster_fillnodata_overwrite(tmp_path, tmp_vsimem):
 def test_gdalalg_raster_fillnodata_smoothing(tmp_path, tmp_vsimem):
 
     alg = get_alg()
-    alg["si"] = 2
+    alg["s"] = 2
     ds = run_alg(alg, tmp_path, tmp_vsimem)
     assert ds.ReadAsArray(1, 1, 1, 1)[0][0] == 122
     del ds
@@ -99,7 +99,7 @@ def test_gdalalg_raster_fillnodata_smoothing(tmp_path, tmp_vsimem):
 def test_gdalalg_raster_fillnodata_max_distance(tmp_path, tmp_vsimem):
 
     alg = get_alg()
-    alg["md"] = 1
+    alg["d"] = 1
     ds = run_alg(alg, tmp_path, tmp_vsimem)
     assert ds.ReadAsArray(1, 1, 1, 1)[0][0] == 123
     del ds
@@ -108,7 +108,7 @@ def test_gdalalg_raster_fillnodata_max_distance(tmp_path, tmp_vsimem):
 def test_gdalalg_raster_fillnodata_strategy(tmp_path, tmp_vsimem):
 
     alg = get_alg()
-    alg["strategy"] = "inv_dist"
+    alg["strategy"] = "invdist"
     ds = run_alg(alg, tmp_path, tmp_vsimem)
     assert ds.ReadAsArray(1, 1, 1, 1)[0][0] == 125
     del ds

--- a/autotest/utilities/test_gdalalg_raster_fillnodata.py
+++ b/autotest/utilities/test_gdalalg_raster_fillnodata.py
@@ -19,6 +19,7 @@ from osgeo import gdal
 pytest.importorskip("numpy")
 gdaltest.importorskip_gdal_array()
 
+
 def get_alg():
     return gdal.GetGlobalAlgorithmRegistry()["raster"]["fillnodata"]
 

--- a/autotest/utilities/test_gdalalg_raster_fillnodata.py
+++ b/autotest/utilities/test_gdalalg_raster_fillnodata.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env pytest
+# -*- coding: utf-8 -*-
+###############################################################################
+# Project:  GDAL/OGR Test Suite
+# Purpose:  'gdal raster fillnodata' testing
+# Author:   Alessandro Pasotti <elpaso at itopen dot it>
+#
+###############################################################################
+# Copyright (c) 2025, Alessandro Pasotti <elpaso at itopen dot it>
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+
+import pytest
+
+from osgeo import gdal
+
+
+def get_alg():
+    return gdal.GetGlobalAlgorithmRegistry()["raster"]["fillnodata"]
+
+
+def test_gdalalg_raster_fillnodata_cannot_open_file():
+
+    alg = get_alg()
+    alg["input"] = "/i_do/not/exist/in.tif"
+    alg["output"] = "/i_do/not/exist/out.tif"
+    with pytest.raises(
+        Exception,
+        match="No such file or directory",
+    ):
+        alg.Run()
+
+
+def run_alg(alg, tmp_path, tmp_vsimem):
+    result_tif = str(tmp_path / "test_gdal_fillnodata_1.tif")
+    tmp_filename = str(tmp_vsimem / "tmp.tif")
+    gdal.FileFromMemBuffer(
+        tmp_filename, open("../gcore/data/nodata_byte.tif", "rb").read()
+    )
+    alg["input"] = tmp_filename
+    alg["output"] = result_tif
+
+    # Check the value of pixel 1 - 1 is nodata
+    ds = gdal.Open(tmp_filename)
+    assert ds is not None
+    assert ds.RasterCount == 1
+    assert ds.GetRasterBand(1).GetNoDataValue() == 0
+    assert ds.ReadAsArray(1, 1, 1, 1)[0][0] == 0
+    del ds
+
+    alg.Run()
+
+    # Check the value of pixel 1 - 1 is not nodata
+    ds = gdal.Open(result_tif)
+    assert ds is not None
+    assert ds.RasterCount == 1
+    assert ds.GetRasterBand(1).GetNoDataValue() == 0
+    return ds
+
+
+def test_gdalalg_raster_fillnodata(tmp_path, tmp_vsimem):
+
+    alg = get_alg()
+    ds = run_alg(alg, tmp_path, tmp_vsimem)
+
+    # Check the value of pixel 1 - 1
+    assert ds.ReadAsArray(1, 1, 1, 1)[0][0] == 125
+    del ds
+
+
+def test_gdalalg_raster_fillnodata_overwrite(tmp_path, tmp_vsimem):
+
+    alg = get_alg()
+    ds = run_alg(alg, tmp_path, tmp_vsimem)
+    del ds
+
+    with pytest.raises(
+        Exception,
+        match="already exists",
+    ):
+        alg.Run()
+
+    alg["overwrite"] = True
+    ds = run_alg(alg, tmp_path, tmp_vsimem)
+    assert ds.ReadAsArray(1, 1, 1, 1)[0][0] == 125
+    del ds
+
+
+def test_gdalalg_raster_fillnodata_smoothing(tmp_path, tmp_vsimem):
+
+    alg = get_alg()
+    alg["si"] = 2
+    ds = run_alg(alg, tmp_path, tmp_vsimem)
+    assert ds.ReadAsArray(1, 1, 1, 1)[0][0] == 122
+    del ds
+
+
+def test_gdalalg_raster_fillnodata_max_distance(tmp_path, tmp_vsimem):
+
+    alg = get_alg()
+    alg["md"] = 1
+    ds = run_alg(alg, tmp_path, tmp_vsimem)
+    assert ds.ReadAsArray(1, 1, 1, 1)[0][0] == 123
+    del ds
+
+
+def test_gdalalg_raster_fillnodata_strategy(tmp_path, tmp_vsimem):
+
+    alg = get_alg()
+    alg["strategy"] = "inv_dist"
+    ds = run_alg(alg, tmp_path, tmp_vsimem)
+    assert ds.ReadAsArray(1, 1, 1, 1)[0][0] == 125
+    del ds
+
+    alg["strategy"] = "nearest"
+    alg["overwrite"] = True
+    ds = run_alg(alg, tmp_path, tmp_vsimem)
+    assert ds.ReadAsArray(1, 1, 1, 1)[0][0] == 123
+    del ds
+
+
+def test_gdalalg_raster_fillnodata_mask(tmp_path, tmp_vsimem):
+
+    # Create a mask
+    mask_tif = str(tmp_vsimem / "mask.tif")
+    gdal.FileFromMemBuffer(mask_tif, open("../gcore/data/nodata_byte.tif", "rb").read())
+
+    alg = get_alg()
+    alg["mask"] = mask_tif
+
+    # Alter pixel 0 0 to NOT be invalid
+    ds = gdal.Open(mask_tif, gdal.GA_Update)
+    assert ds is not None
+    assert ds.RasterCount == 1
+    ds.GetRasterBand(1).SetNoDataValue(128)
+    ds.WriteRaster(0, 0, 1, 1, b"\x00")
+    del ds
+
+    ds = run_alg(alg, tmp_path, tmp_vsimem)
+    assert ds.ReadAsArray(0, 0, 1, 1)[0][0] == 120
+    del ds
+
+    # Restore 0 0 mask valid value
+    ds = gdal.Open(mask_tif, gdal.GA_Update)
+    assert ds is not None
+    assert ds.RasterCount == 1
+    ds.WriteRaster(0, 0, 1, 1, b"\x01")
+    ds.FlushCache()
+    del ds
+
+    alg["overwrite"] = True
+    ds = run_alg(alg, tmp_path, tmp_vsimem)
+    assert ds.ReadAsArray(1, 1, 1, 1)[0][0] == 125
+    del ds

--- a/autotest/utilities/test_gdalalg_raster_fillnodata.py
+++ b/autotest/utilities/test_gdalalg_raster_fillnodata.py
@@ -11,10 +11,13 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
+import gdaltest
 import pytest
 
 from osgeo import gdal
 
+pytest.importorskip("numpy")
+gdaltest.importorskip_gdal_array()
 
 def get_alg():
     return gdal.GetGlobalAlgorithmRegistry()["raster"]["fillnodata"]

--- a/autotest/utilities/test_gdalalg_raster_fillnodata.py
+++ b/autotest/utilities/test_gdalalg_raster_fillnodata.py
@@ -27,7 +27,7 @@ def test_gdalalg_raster_fillnodata_cannot_open_file():
     alg["output"] = "/i_do/not/exist/out.tif"
     with pytest.raises(
         Exception,
-        match="No such file or directory",
+        match=r"No such file or directory|does not exist",
     ):
         alg.Run()
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -316,6 +316,13 @@ man_pages = [
         1,
     ),
     (
+        "programs/gdal_raster_fillnodata",
+        "gdal-raster-fillnodata",
+        "Fill nodata values in a raster dataset",
+        [author_elpaso],
+        1,
+    ),
+    (
         "programs/gdal_raster_hillshade",
         "gdal-raster-hillshade",
         "Generate a shaded relief map",

--- a/doc/source/programs/gdal_raster.rst
+++ b/doc/source/programs/gdal_raster.rst
@@ -29,6 +29,7 @@ Available sub-commands
 - :ref:`gdal_raster_convert`
 - :ref:`gdal_raster_create`
 - :ref:`gdal_raster_footprint`
+- :ref:`gdal_raster_fillnodata`
 - :ref:`gdal_raster_hillshade`
 - :ref:`gdal_raster_index`
 - :ref:`gdal_raster_mosaic`

--- a/doc/source/programs/gdal_raster_fillnodata.rst
+++ b/doc/source/programs/gdal_raster_fillnodata.rst
@@ -72,6 +72,7 @@ Examples
    The output will be saved in `output.tif`.
 
    .. code-block:: bash
-        gdal raster fillnodata -b 2 --max-distance 50 --smoothing-iterations 3 \
-            --strategy nearest --mask mask.tif \
-            input.tif output.tif
+
+    gdal raster fillnodata -b 2 --max-distance 50 --smoothing-iterations 3 \
+        --strategy nearest --mask mask.tif \
+        input.tif output.tif

--- a/doc/source/programs/gdal_raster_fillnodata.rst
+++ b/doc/source/programs/gdal_raster_fillnodata.rst
@@ -1,0 +1,77 @@
+.. _gdal_raster_fillnodata:
+
+================================================================================
+``gdal raster fillnodata``
+================================================================================
+
+.. versionadded:: 3.11
+
+.. only:: html
+
+    Fill nodata raster regions by interpolation from edges
+
+.. Index:: gdal raster fillnodata
+
+Synopsis
+--------
+
+.. program-output:: gdal raster fillnodata --help-doc
+
+Description
+-----------
+
+:program:`gdal raster fillnodata` fills nodata areas by interpolating
+from valid pixels around the edges of the area.
+
+The following options are available:
+
+.. include:: gdal_options/of_raster_create.rst
+
+.. option:: --output-layer <OUTPUT-LAYER>
+
+    Output layer name.
+
+.. include:: gdal_options/overwrite.rst
+
+.. option:: -b <BAND>
+
+    Select an input <BAND> to be processed. Bands are numbered from 1.
+    Default is the first band of the input dataset.
+
+.. option:: -max-distance <MAX_DISTANCE>
+
+    Specifies the maximum distance (in pixels) that the algorithm will search
+    out for values to interpolate. Default is 100 pixels.
+
+.. option:: --smoothing-iterations <SMOOTHING_ITERATIONS>
+
+    Specifies the number of smoothing iterations to apply to the filled raster.
+    This can help to reduce artifacts in the filled areas.
+    Default is 0 iterations.
+
+.. option:: --strategy <STRATEGY>
+
+    Select the interpolation <STRATEGY> to use.
+    By default, pixels are interpolated using an inverse distance
+    weighting (`inv_dist`). It is also possible to choose a nearest
+    neighbour (`nearest`) strategy.
+
+.. option:: --mask <MASK>
+
+    Use the first band of the specified file as a
+    validity mask (zero is invalid, non-zero is valid).
+
+Examples
+--------
+
+.. example::
+   :title: Fill nodata areas in a raster
+
+   The command specifies to use the second band of the input raster, 50 px max distance,
+   3 smoothing iterations and the `nearest` strategy for interpolation.
+   The output will be saved in `output.tif`.
+
+   .. code-block:: bash
+        gdal raster fillnodata -b 2 -max-distance 50 -smoothing-iterations 3 \
+            --strategy nearest --mask mask.tif \
+            input.tif output.tif

--- a/doc/source/programs/gdal_raster_fillnodata.rst
+++ b/doc/source/programs/gdal_raster_fillnodata.rst
@@ -53,7 +53,7 @@ The following options are available:
 
     Select the interpolation <STRATEGY> to use.
     By default, pixels are interpolated using an inverse distance
-    weighting (`inv_dist`). It is also possible to choose a nearest
+    weighting (`invdist`). It is also possible to choose a nearest
     neighbour (`nearest`) strategy.
 
 .. option:: --mask <MASK>
@@ -72,6 +72,6 @@ Examples
    The output will be saved in `output.tif`.
 
    .. code-block:: bash
-        gdal raster fillnodata -b 2 -max-distance 50 -smoothing-iterations 3 \
+        gdal raster fillnodata -b 2 --max-distance 50 --smoothing-iterations 3 \
             --strategy nearest --mask mask.tif \
             input.tif output.tif

--- a/doc/source/programs/index.rst
+++ b/doc/source/programs/index.rst
@@ -48,6 +48,7 @@ single :program:`gdal` program that accepts commands and subcommands.
    gdal_raster_create
    gdal_raster_edit
    gdal_raster_footprint
+   gdal_raster_fillnodata
    gdal_raster_hillshade
    gdal_raster_index
    gdal_raster_mosaic
@@ -119,6 +120,7 @@ single :program:`gdal` program that accepts commands and subcommands.
     - :ref:`gdal_raster_create`: Create a new raster dataset
     - :ref:`gdal_raster_edit`: Edit in place a raster dataset
     - :ref:`gdal_raster_footprint`: Compute the footprint of a raster dataset.
+    - :ref:`gdal_raster_fillnodata`: Fill raster regions by interpolation from edges.
     - :ref:`gdal_raster_hillshade`: Generate a shaded relief map
     - :ref:`gdal_raster_index`: Create a vector index of raster datasets
     - :ref:`gdal_raster_mosaic`: Build a mosaic, either virtual (VRT) or materialized.


### PR DESCRIPTION
```bash
Usage: gdal raster fillnodata [OPTIONS] <INPUT> <OUTPUT>

Fill nodata raster regions by interpolation from edges.

Positional arguments:
  -i, --input <INPUT>                                  Input raster dataset [required]
  -o, --output <OUTPUT>                                Output raster dataset (created by algorithm) [required]

Common Options:
  -h, --help                                           Display help message and exit
  --version                                            Display GDAL version and exit
  --json-usage                                         Display usage as JSON document and exit
  --drivers                                            Display driver list as JSON document and exit
  --config <KEY>=<VALUE>                               Configuration option [may be repeated]
  --progress                                           Display progress bar

Options:
  -f, --of, --format, --output-format <OUTPUT-FORMAT>  Output format
  --co, --creation-option <KEY>=<VALUE>                Creation option [may be repeated]
  --overwrite                                          Whether overwriting existing output is allowed
  -b, --band <BAND>                                    Input band (1-based index) (default: 1)
  -d, --max-distance <MAX_DISTANCE>                    The maximum distance (in pixels) that the algorithm will search out for values to interpolate. (default: 100)
  -s, --smoothing-iterations <SMOOTHING_ITERATIONS>    The number of 3x3 average filter smoothing iterations to run after the interpolation to dampen artifacts. The default is zero smoothing iterations. (default: 0)
  --mask <MASK>                                        Use the first band of the specified file as a validity mask (zero is invalid, non-zero is valid).
  --strategy <STRATEGY>                                By default, pixels are interpolated using an inverse distance weighting (inv_dist). It is also possible to choose a nearest neighbour (nearest) strategy.. STRATEGY=inv_dist|nearest (default: inv_dist)

Advanced Options:
  --if, --input-format <INPUT-FORMAT>                  Input formats [may be repeated]

For more details, consult https://gdal.org/programs/gdal_raster_fillnodata.html
```