### PR TITLE
CMake: Export GDAL library targets

### DIFF
--- a/gdal.cmake
+++ b/gdal.cmake
@@ -553,6 +553,11 @@ install(
   PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
   FRAMEWORK DESTINATION "${FRAMEWORK_DESTINATION}")
 
+# Generate targets file for importing directly from GDAL build tree
+export(TARGETS ${GDAL_LIB_TARGET_NAME}
+        NAMESPACE GDAL::
+        FILE "GDAL-targets.cmake")
+
 if (NOT GDAL_ENABLE_MACOSX_FRAMEWORK)
   # Generate GdalConfig.cmake and GdalConfigVersion.cmake
   install(


### PR DESCRIPTION
## What does this PR do?

When building a separate project, this allows `find_package(GDAL CONFIG)` to import from a GDAL build tree using `cmake -DCMAKE_FIND_ROOT_PATH=/home/dan/dev/gdal/build-release ..`

See https://cmake.org/cmake/help/latest/guide/importing-exporting/index.html#exporting-targets-from-the-build-tree