### PR TITLE
[cli] gdal raster sieve

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -39,6 +39,7 @@ add_library(
   gdalalg_raster_roughness.cpp
   gdalalg_raster_scale.cpp
   gdalalg_raster_select.cpp
+  gdalalg_raster_sieve.cpp
   gdalalg_raster_slope.cpp
   gdalalg_raster_stack.cpp
   gdalalg_raster_tpi.cpp

--- a/apps/gdalalg_raster.cpp
+++ b/apps/gdalalg_raster.cpp
@@ -35,6 +35,7 @@
 #include "gdalalg_raster_roughness.h"
 #include "gdalalg_raster_scale.h"
 #include "gdalalg_raster_select.h"
+#include "gdalalg_raster_sieve.h"
 #include "gdalalg_raster_slope.h"
 #include "gdalalg_raster_stack.h"
 #include "gdalalg_raster_tpi.h"
@@ -78,6 +79,7 @@ class GDALRasterAlgorithm final : public GDALAlgorithm
         RegisterSubAlgorithm<GDALRasterContourAlgorithm>();
         RegisterSubAlgorithm<GDALRasterScaleAlgorithmStandalone>();
         RegisterSubAlgorithm<GDALRasterSelectAlgorithmStandalone>();
+        RegisterSubAlgorithm<GDALRasterSieveAlgorithm>();
         RegisterSubAlgorithm<GDALRasterSlopeAlgorithmStandalone>();
         RegisterSubAlgorithm<GDALRasterStackAlgorithm>();
         RegisterSubAlgorithm<GDALRasterTPIAlgorithmStandalone>();

--- a/apps/gdalalg_raster_sieve.cpp
+++ b/apps/gdalalg_raster_sieve.cpp
@@ -74,8 +74,8 @@ GDALRasterSieveAlgorithm::GDALRasterSieveAlgorithm()
            &m_sizeThreshold)
         .SetDefault(m_sizeThreshold);
 
-    AddArg("connectedness", 'c', _("Consider diagonal pixels as connected"),
-           &m_connectDiagonalPixels)
+    AddArg("connect-diagonal-pixels", 'c',
+           _("Consider diagonal pixels as connected"), &m_connectDiagonalPixels)
         .SetDefault(m_connectDiagonalPixels);
 }
 

--- a/apps/gdalalg_raster_sieve.cpp
+++ b/apps/gdalalg_raster_sieve.cpp
@@ -1,0 +1,245 @@
+/******************************************************************************
+ *
+ * Project:  GDAL
+ * Purpose:  gdal "raster sieve" subcommand
+ * Author:   Alessandro Pasotti <elpaso at itopen dot it>
+ *
+ ******************************************************************************
+ * Copyright (c) 2025, Alessandro Pasotti <elpaso at itopen dot it>
+ *
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#include "gdalalg_raster_sieve.h"
+
+#include "cpl_conv.h"
+#include "cpl_vsi_virtual.h"
+
+#include "gdal_alg.h"
+#include "gdal_priv.h"
+#include "gdal_utils.h"
+#include "commonutils.h"
+
+//! @cond Doxygen_Suppress
+
+#ifndef _
+#define _(x) (x)
+#endif
+
+/************************************************************************/
+/*      GDALRasterSieveAlgorithm::GDALRasterSieveAlgorithm()            */
+/************************************************************************/
+
+GDALRasterSieveAlgorithm::GDALRasterSieveAlgorithm()
+    : GDALAlgorithm(NAME, DESCRIPTION, HELP_URL)
+{
+
+    AddProgressArg();
+
+    AddOpenOptionsArg(&m_openOptions);
+    AddInputFormatsArg(&m_inputFormats)
+        .AddMetadataItem(GAAMDI_REQUIRED_CAPABILITIES, {GDAL_DCAP_RASTER});
+    AddInputDatasetArg(&m_inputDataset, GDAL_OF_RASTER);
+
+    AddOutputDatasetArg(&m_outputDataset, GDAL_OF_RASTER);
+    AddOutputFormatArg(&m_format, /* bStreamAllowed = */ false,
+                       /* bGDALGAllowed = */ false)
+        .AddMetadataItem(GAAMDI_REQUIRED_CAPABILITIES,
+                         {GDAL_DCAP_RASTER, GDAL_DCAP_CREATE});
+    AddCreationOptionsArg(&m_creationOptions);
+    AddOverwriteArg(&m_overwrite);
+
+    auto &mask{AddArg("mask", 0,
+                      _("Use the first band of the specified file as a "
+                        "validity mask (zero is invalid, non-zero is valid)"),
+                      &m_maskDataset)};
+
+    SetAutoCompleteFunctionForFilename(mask, GDAL_OF_RASTER);
+
+    mask.AddValidationAction(
+        [&mask]()
+        {
+            // Check if the mask dataset is a valid raster dataset descriptor
+            // Try to open the dataset as a raster
+            std::unique_ptr<GDALDataset> poDS(
+                GDALDataset::Open(mask.Get<std::string>().c_str(),
+                                  GDAL_OF_RASTER, nullptr, nullptr, nullptr));
+            return static_cast<bool>(poDS);
+        });
+
+    AddBandArg(&m_band);
+    AddArg("size-threshold", 's', _("Minimum size of polygons to keep"),
+           &m_sizeThreshold)
+        .SetDefault(m_sizeThreshold);
+
+    AddArg("connectedness", 'c', _("Consider diagonal pixels as connected"),
+           &m_connectDiagonalPixels)
+        .SetDefault(m_connectDiagonalPixels);
+}
+
+/************************************************************************/
+/*                 GDALRasterSieveAlgorithm::RunImpl()                  */
+/************************************************************************/
+
+bool GDALRasterSieveAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
+                                       void *pProgressData)
+{
+
+    VSIStatBufL sStat;
+    if (!m_overwrite && !m_outputDataset.GetName().empty() &&
+        (VSIStatL(m_outputDataset.GetName().c_str(), &sStat) == 0 ||
+         std::unique_ptr<GDALDataset>(
+             GDALDataset::Open(m_outputDataset.GetName().c_str()))))
+    {
+        ReportError(CE_Failure, CPLE_AppDefined,
+                    "File '%s' already exists. Specify the --overwrite "
+                    "option to overwrite it.",
+                    m_outputDataset.GetName().c_str());
+        return false;
+    }
+
+    const CPLStringList creationOptions{m_creationOptions};
+    const std::string destinationFormat{
+        m_format.empty()
+            ? GetOutputDriverForRaster(m_outputDataset.GetName().c_str())
+            : m_format};
+    const bool isGtiff{EQUAL(destinationFormat.c_str(), "GTiff")};
+    const bool isMem{EQUAL(destinationFormat.c_str(), "MEM")};
+    const bool isCompressed{
+        CSLFetchNameValue(creationOptions, "COMPRESS") != nullptr &&
+        !EQUAL(CSLFetchNameValue(creationOptions, "COMPRESS"), "NONE")};
+    const bool isTiled{
+        isGtiff && CSLFetchNameValue(creationOptions, "TILED") != nullptr &&
+        CPLTestBool(CSLFetchNameValue(creationOptions, "TILED"))};
+    const bool useTemporaryFile{
+        !(isMem || (isGtiff && isTiled && !isCompressed))};
+
+    std::string workingFileName{useTemporaryFile
+                                    ? CPLGenerateTempFilenameSafe(nullptr)
+                                    : m_outputDataset.GetName()};
+    std::unique_ptr<GDALDataset> workingDSHandler;
+
+    if (useTemporaryFile)
+    {
+        // Translate the single required band to uncompressed TILED GTiff
+        CPLStringList options;
+        options.AddString("-b");
+        options.AddString(CPLSPrintf("%d", m_band));
+        options.AddString("-of");
+        options.AddString("GTiff");
+        options.AddString("-co");
+        options.AddString("TILED=YES");
+        GDALTranslateOptions *translateOptions =
+            GDALTranslateOptionsNew(options.List(), nullptr);
+
+        GDALDatasetH hSrcDS =
+            GDALDataset::ToHandle(m_inputDataset.GetDatasetRef());
+        workingDSHandler.reset(GDALDataset::FromHandle(
+            GDALTranslate(m_outputDataset.GetName().c_str(), hSrcDS,
+                          translateOptions, nullptr)));
+        GDALTranslateOptionsFree(translateOptions);
+    }
+    else
+    {
+        // Translate the single required band to the destination format
+        CPLStringList options;
+        options.AddString("-b");
+        options.AddString(CPLSPrintf("%d", m_band));
+        options.AddString("-of");
+        options.AddString(m_format.c_str());
+        for (const auto &co : m_creationOptions)
+        {
+            if (co.find('=') != std::string::npos)
+            {
+                options.AddString(co.c_str());
+            }
+            else
+            {
+                options.AddString(CPLSPrintf("-co %s", co.c_str()));
+            }
+        }
+        GDALTranslateOptions *translateOptions =
+            GDALTranslateOptionsNew(options.List(), nullptr);
+        GDALDatasetH hSrcDS =
+            GDALDataset::ToHandle(m_inputDataset.GetDatasetRef());
+        workingDSHandler.reset(GDALDataset::FromHandle(GDALTranslate(
+            workingFileName.c_str(), hSrcDS, translateOptions, nullptr)));
+        GDALTranslateOptionsFree(translateOptions);
+    }
+
+    if (!workingDSHandler)
+    {
+        ReportError(CE_Failure, CPLE_AppDefined,
+                    "Failed to create temporary dataset");
+        return false;
+    }
+
+    GDALRasterBand *maskBand{nullptr};
+    if (m_maskDataset.GetDatasetRef())
+    {
+        maskBand = m_maskDataset.GetDatasetRef()->GetRasterBand(1);
+        if (!maskBand)
+        {
+            ReportError(CE_Failure, CPLE_AppDefined, "Cannot get mask band.");
+            return false;
+        }
+    }
+
+    // Get the output band
+    GDALRasterBand *dstBand{workingDSHandler->GetRasterBand(1)};
+
+    if (!dstBand)
+    {
+        ReportError(CE_Failure, CPLE_AppDefined,
+                    "Failed to get band %d from output dataset", m_band);
+        return false;
+    }
+
+    const CPLErr err = GDALSieveFilter(
+        dstBand, maskBand, dstBand, m_sizeThreshold,
+        m_connectDiagonalPixels ? 8 : 4, nullptr, pfnProgress, pProgressData);
+
+    if (err != CE_None)
+    {
+        ReportError(CE_Failure, CPLE_AppDefined,
+                    "Failed to apply sieve filter");
+        return false;
+    }
+
+    workingDSHandler->FlushCache();
+
+    // If we were using a temporary file we need to translate to the final desired format
+    if (useTemporaryFile)
+    {
+        // Translate the temporary dataset to the final format
+        CPLStringList options;
+        options.AddString("-b");
+        options.AddString(CPLSPrintf("%d", m_band));
+        options.AddString("-of");
+        options.AddString(m_format.c_str());
+        for (const auto &co : m_creationOptions)
+        {
+            if (co.find('=') != std::string::npos)
+            {
+                options.AddString(co.c_str());
+            }
+            else
+            {
+                options.AddString(CPLSPrintf("-co %s", co.c_str()));
+            }
+        }
+        GDALTranslateOptions *translateOptions =
+            GDALTranslateOptionsNew(options.List(), nullptr);
+        workingDSHandler.reset(GDALDataset::FromHandle(
+            GDALTranslate(workingFileName.c_str(),
+                          GDALDataset::ToHandle(workingDSHandler.get()),
+                          translateOptions, nullptr)));
+        GDALTranslateOptionsFree(translateOptions);
+    }
+
+    m_outputDataset.Set(std::move(workingDSHandler));
+
+    return true;
+}
+
+//! @endcond

--- a/apps/gdalalg_raster_sieve.h
+++ b/apps/gdalalg_raster_sieve.h
@@ -1,0 +1,54 @@
+/******************************************************************************
+ *
+ * Project:  GDAL
+ * Purpose:  gdal "raster sieve" subcommand
+ * Author:   Alessandro Pasotti <elpaso at itopen dot it>
+ *
+ ******************************************************************************
+ * Copyright (c) 2025, Alessandro Pasotti <elpaso at itopen dot it>
+ *
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#ifndef GDALALG_RASTER_SIEVE_INCLUDED
+#define GDALALG_RASTER_SIEVE_INCLUDED
+
+#include "gdalalgorithm.h"
+
+//! @cond Doxygen_Suppress
+
+/************************************************************************/
+/*                   GDALRasterSieveAlgorithm                           */
+/************************************************************************/
+
+class GDALRasterSieveAlgorithm final : public GDALAlgorithm
+{
+  public:
+    static constexpr const char *NAME = "sieve";
+    static constexpr const char *DESCRIPTION =
+        "Remove small polygons from a raster dataset.";
+    static constexpr const char *HELP_URL = "/programs/gdal_raster_sieve.html";
+
+    explicit GDALRasterSieveAlgorithm();
+
+  private:
+    bool RunImpl(GDALProgressFunc pfnProgress, void *pProgressData) override;
+
+    GDALArgDatasetValue m_inputDataset{};
+    std::vector<std::string> m_openOptions{};
+    std::vector<std::string> m_inputFormats{};
+
+    std::string m_format{};
+    GDALArgDatasetValue m_outputDataset{};
+    std::vector<std::string> m_creationOptions{};
+    bool m_overwrite = false;
+
+    int m_band = 1;
+    int m_sizeThreshold = 2;
+    bool m_connectDiagonalPixels = false;
+    GDALArgDatasetValue m_maskDataset{};
+};
+
+//! @endcond
+
+#endif

--- a/autotest/utilities/test_gdalalg_raster_sieve.py
+++ b/autotest/utilities/test_gdalalg_raster_sieve.py
@@ -30,7 +30,7 @@ def get_alg():
 @pytest.mark.require_driver("AAIGRID")
 @pytest.mark.require_driver("GTiff")
 @pytest.mark.parametrize(
-    "connectedness,expected_checksum",
+    "connect_diagonal_pixels,expected_checksum",
     (
         (False, 364),
         (True, 370),
@@ -40,7 +40,7 @@ def get_alg():
     "creation_options", ({}, {"TILED": "YES"}, {"COMPRESS": "LZW"})
 )
 def test_gdalalg_raster_sieve(
-    tmp_path, tmp_vsimem, connectedness, expected_checksum, creation_options
+    tmp_path, tmp_vsimem, connect_diagonal_pixels, expected_checksum, creation_options
 ):
 
     result_tif = str(tmp_path / "test_gdal_sieve.tif")
@@ -52,7 +52,7 @@ def test_gdalalg_raster_sieve(
     alg["input"] = tmp_filename
     alg["output"] = result_tif
     alg["size-threshold"] = 2
-    alg["connectedness"] = connectedness
+    alg["connect-diagonal-pixels"] = connect_diagonal_pixels
     alg["creation-option"] = creation_options
     alg.Run()
 

--- a/autotest/utilities/test_gdalalg_raster_sieve.py
+++ b/autotest/utilities/test_gdalalg_raster_sieve.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env pytest
+# -*- coding: utf-8 -*-
+###############################################################################
+# Project:  GDAL/OGR Test Suite
+# Purpose:  'gdal raster sieve' testing
+# Author:   Alessandro Pasotti
+#
+###############################################################################
+# Copyright (c) 2025, Alessandro Pasotti
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+
+
+import gdaltest
+import pytest
+
+from osgeo import gdal
+
+pytest.importorskip("numpy")
+gdaltest.importorskip_gdal_array()
+
+gdal.UseExceptions()
+
+
+def get_alg():
+    return gdal.GetGlobalAlgorithmRegistry()["raster"]["sieve"]
+
+
+@pytest.mark.require_driver("AAIGRID")
+@pytest.mark.require_driver("GTiff")
+@pytest.mark.parametrize(
+    "connectedness,expected_checksum",
+    (
+        (False, 364),
+        (True, 370),
+    ),
+)
+@pytest.mark.parametrize("creation_options", ("", "TILED=YES"))
+def test_gdalalg_raster_sieve(
+    tmp_path, tmp_vsimem, connectedness, expected_checksum, creation_options
+):
+
+    result_tif = str(tmp_path / "test_gdal_sieve.tif")
+    tmp_filename = str(tmp_vsimem / "tmp.grd")
+
+    gdal.FileFromMemBuffer(tmp_filename, open("../alg/data/sieve_src.grd", "rb").read())
+
+    alg = get_alg()
+    alg["input"] = tmp_filename
+    alg["output"] = result_tif
+    alg["size-threshold"] = 2
+    alg["connectedness"] = connectedness
+    if creation_options != "":
+        alg["co"] = creation_options
+    alg.Run()
+
+    ds = gdal.Open(result_tif)
+    assert ds is not None
+    assert ds.RasterCount == 1
+
+    dst_band = ds.GetRasterBand(1)
+
+    assert dst_band.Checksum() == expected_checksum
+
+
+@pytest.mark.require_driver("AAIGRID")
+@pytest.mark.require_driver("GTiff")
+def test_gdalalg_raster_sieve_mask(tmp_path, tmp_vsimem):
+
+    result_tif = str(tmp_path / "test_gdal_sieve.tif")
+    tmp_filename = str(tmp_vsimem / "tmp.grd")
+
+    gdal.FileFromMemBuffer(
+        tmp_filename,
+        """ncols        7
+nrows        7
+xllcorner    440720.000000000000
+yllcorner    3750120.000000000000
+cellsize     60.000000000000
+NODATA_value 0
+ 0 0 0 0 0 0 0
+ 0 1 1 1 1 1 1
+ 0 1 0 0 1 1 1
+ 0 1 0 2 2 2 1
+ 0 1 1 2 1 2 1
+ 0 1 1 2 2 2 1
+ 0 1 1 1 1 1 1
+ """,
+    )
+
+    alg = get_alg()
+    alg["input"] = tmp_filename
+    alg["output"] = result_tif
+    alg["size-threshold"] = 2
+    alg["mask"] = tmp_filename
+    alg.Run()
+
+    ds = gdal.Open(result_tif)
+    assert ds is not None
+    assert ds.RasterCount == 1
+
+    dst_band = ds.GetRasterBand(1)
+
+    assert dst_band.Checksum() == 42
+
+
+@pytest.mark.require_driver("AAIGRID")
+@pytest.mark.require_driver("GTiff")
+def test_gdalalg_raster_sieve_overwrite(tmp_path, tmp_vsimem):
+
+    result_tif = str(tmp_path / "test_gdal_sieve.tif")
+    tmp_filename = str(tmp_vsimem / "tmp.grd")
+
+    gdal.FileFromMemBuffer(tmp_filename, open("../alg/data/sieve_src.grd", "rb").read())
+
+    alg = get_alg()
+    alg["input"] = tmp_filename
+    alg["output"] = result_tif
+    alg["size-threshold"] = 2
+    alg.Run()
+
+    with pytest.raises(Exception, match="already exists"):
+        alg.Run()
+
+    alg["overwrite"] = True
+    alg.Run()

--- a/autotest/utilities/test_gdalalg_raster_sieve.py
+++ b/autotest/utilities/test_gdalalg_raster_sieve.py
@@ -128,7 +128,7 @@ def test_gdalalg_raster_sieve_overwrite(tmp_path, tmp_vsimem):
     alg["output"] = result_tif
     alg["size-threshold"] = 2
     alg.Run()
-
+    alg.Finalize()  # ensure output file is closed, to be later overwritten
     with pytest.raises(Exception, match="already exists"):
         alg.Run()
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -393,6 +393,13 @@ man_pages = [
         1,
     ),
     (
+        "programs/gdal_raster_sieve",
+        "gdal-raster-sieve",
+        "Remove small raster polygons",
+        [author_elpaso],
+        1,
+    ),
+    (
         "programs/gdal_raster_select",
         "gdal-raster-select",
         "Select a subset of bands from a raster dataset",

--- a/doc/source/programs/gdal_raster.rst
+++ b/doc/source/programs/gdal_raster.rst
@@ -40,6 +40,7 @@ Available sub-commands
 - :ref:`gdal_raster_roughness`
 - :ref:`gdal_raster_scale`
 - :ref:`gdal_raster_select`
+- :ref:`gdal_raster_sieve`
 - :ref:`gdal_raster_slope`
 - :ref:`gdal_raster_stack`
 - :ref:`gdal_raster_tpi`

--- a/doc/source/programs/gdal_raster_sieve.rst
+++ b/doc/source/programs/gdal_raster_sieve.rst
@@ -21,11 +21,11 @@ Description
 -----------
 
 :program:`gdal raster sieve` removes raster polygons smaller than a provided threshold size (in pixels)
-    and replaces them with the pixel value of the largest neighbour polygon.
+and replaces them with the pixel value of the largest neighbour polygon.
 
-    The input dataset is read as integer data which means that floating point
-    values are rounded to integers. Re-scaling source data may be necessary in
-    some cases (e.g. 32-bit floating point data with min=0 and max=1).
+The input dataset is read as integer data which means that floating point
+values are rounded to integers. Re-scaling source data may be necessary in
+some cases (e.g. 32-bit floating point data with min=0 and max=1).
 
 Standard options
 ++++++++++++++++
@@ -50,7 +50,9 @@ Standard options
 
 .. option:: --mask <MASK>
 
-    Use the first band of the specified file as a validity mask (zero is invalid, non-zero is valid).
+    Use the first band of the specified file as a validity mask:
+    all pixels in the mask band with a value other than zero
+    will be considered suitable for inclusion in polygons.
 
 
 Examples

--- a/doc/source/programs/gdal_raster_sieve.rst
+++ b/doc/source/programs/gdal_raster_sieve.rst
@@ -47,7 +47,7 @@ Standard options
 .. option:: -c, --connect-diagonal-pixels
 
     Consider diagonal pixels (pixels at the corners) as connected.
-    The default behaviour is to only consider pixels that are touching the edges
+    The default behavior is to only consider pixels that are touching the edges
     as connected, which is the same as 4-connectivity. When this option is
     selected, the algorithm will also consider pixels at the corners as connected,
     which is the same as 8-connectivity.

--- a/doc/source/programs/gdal_raster_sieve.rst
+++ b/doc/source/programs/gdal_raster_sieve.rst
@@ -44,9 +44,13 @@ Standard options
 
     Minimum size of polygons to keep (default: 2)
 
-.. option:: -c, --connectedness
+.. option:: -c, --connect-diagonal-pixels
 
-    Consider diagonal neighbour pixels as connected.
+    Consider diagonal pixels (pixels at the corners) as connected.
+    The default behaviour is to only consider pixels that are touching the edges
+    as connected, which is the same as 4-connectivity. When this option is
+    selected, the algorithm will also consider pixels at the corners as connected,
+    which is the same as 8-connectivity.
 
 .. option:: --mask <MASK>
 

--- a/doc/source/programs/gdal_raster_sieve.rst
+++ b/doc/source/programs/gdal_raster_sieve.rst
@@ -1,0 +1,64 @@
+.. _gdal_raster_sieve:
+
+================================================================================
+``gdal raster sieve``
+================================================================================
+
+.. versionadded:: 3.11
+
+.. only:: html
+
+    Remove small raster polygons
+
+.. Index:: gdal raster sieve
+
+Synopsis
+--------
+
+.. program-output:: gdal raster sieve --help-doc
+
+Description
+-----------
+
+:program:`gdal raster sieve` removes raster polygons smaller than a provided threshold size (in pixels)
+    and replaces them with the pixel value of the largest neighbour polygon.
+
+    The input dataset is read as integer data which means that floating point
+    values are rounded to integers. Re-scaling source data may be necessary in
+    some cases (e.g. 32-bit floating point data with min=0 and max=1).
+
+Standard options
+++++++++++++++++
+
+.. include:: gdal_options/of_raster_create_copy.rst
+
+.. include:: gdal_options/co.rst
+
+.. include:: gdal_options/overwrite.rst
+
+.. option:: -b, --band <BAND>
+
+    Input band (1-based index)
+
+.. option:: -s, --size-threshold <SIZE-THRESHOLD>
+
+    Minimum size of polygons to keep (default: 2)
+
+.. option:: -c, --connectedness
+
+    Consider diagonal neighbour pixels as connected.
+
+.. option:: --mask <MASK>
+
+    Use the first band of the specified file as a validity mask (zero is invalid, non-zero is valid).
+
+
+Examples
+--------
+
+.. example::
+   :title: Remove polygons smaller than 10 pixels from the band 2 of a raster.
+
+   .. code-block:: bash
+
+        $ gdal raster sieve -b 2 -s 10 input.tif output.tif

--- a/doc/source/programs/index.rst
+++ b/doc/source/programs/index.rst
@@ -62,6 +62,7 @@ single :program:`gdal` program that accepts commands and subcommands.
    gdal_raster_scale
    gdal_raster_select
    gdal_raster_slope
+   gdal_raster_sieve
    gdal_raster_stack
    gdal_raster_tpi
    gdal_raster_tri
@@ -132,6 +133,7 @@ single :program:`gdal` program that accepts commands and subcommands.
     - :ref:`gdal_raster_roughness`: Generate a roughness map.
     - :ref:`gdal_raster_scale`: Scale the values of the bands of a raster dataset.
     - :ref:`gdal_raster_select`: Select a subset of bands from a raster dataset.
+    - :ref:`gdal_raster_sieve`: Remove small raster polygons.
     - :ref:`gdal_raster_slope`: Generate a slope map.
     - :ref:`gdal_raster_stack`: Combine together input bands into a multi-band output, either virtual (VRT) or materialized.
     - :ref:`gdal_raster_tpi`: Generate a Topographic Position Index (TPI) map.


### PR DESCRIPTION
```
Usage: gdal raster sieve [OPTIONS] <INPUT> <OUTPUT>

Remove small polygons from a raster dataset.

Positional arguments:
  -i, --input <INPUT>                                  Input raster dataset [required]
  -o, --output <OUTPUT>                                Output raster dataset (created by algorithm) [required]

Common Options:
  -h, --help                                           Display help message and exit
  --version                                            Display GDAL version and exit
  --json-usage                                         Display usage as JSON document and exit
  --drivers                                            Display driver list as JSON document and exit
  --config <KEY>=<VALUE>                               Configuration option [may be repeated]
  --progress                                           Display progress bar

Options:
  -f, --of, --format, --output-format <OUTPUT-FORMAT>  Output format
  --co, --creation-option <KEY>=<VALUE>                Creation option [may be repeated]
  --overwrite                                          Whether overwriting existing output is allowed
  --mask <MASK>                                        Use the first band of the specified file as a validity mask (all pixels with a value other than zero will be considered suitable for inclusion in polygons)
  -b, --band <BAND>                                    Input band (1-based index)
  -s, --size-threshold <SIZE-THRESHOLD>                Minimum size of polygons to keep (default: 2)
  -c, --connectedness                                  Consider diagonal pixels as connected

Advanced Options:
  --oo, --open-option <KEY=VALUE>                      Open options [may be repeated]
  --if, --input-format <INPUT-FORMAT>                  Input formats [may be repeated]

For more details, consult https://gdal.org/programs/gdal_raster_sieve.html
```