### PR TITLE
Add STACIT driver examples

### DIFF
--- a/doc/source/drivers/raster/examples/drivers/raster/stacit.py
+++ b/doc/source/drivers/raster/examples/drivers/raster/stacit.py
@@ -1,3 +1,4 @@
+# Example 1
 from osgeo import gdal
 
 gdal.UseExceptions()
@@ -14,7 +15,7 @@ ds = gdal.OpenEx(
 
 print(gdal.Info(ds, format="json"))
 
-# subdatasets
+# Example 2
 
 subdatasets = ds.GetSubDatasets()
 # get the first subdataset properties

--- a/doc/source/drivers/raster/examples/stacit.py
+++ b/doc/source/drivers/raster/examples/stacit.py
@@ -1,0 +1,25 @@
+from osgeo import gdal
+
+gdal.UseExceptions()
+
+stac_url = "https://planetarycomputer.microsoft.com/api/stac/v1/search"
+bbox = "-100,40,-99,41"
+datetime = "2019-01-01T00:00:00Z%2F.."
+collections = "naip"
+url = f"{stac_url}?collections={collections}&bbox={bbox}&datetime={datetime}"
+
+ds = gdal.OpenEx(
+    url, allowed_drivers=["STACIT"]
+)  # force the STACIT driver or it opens as GeoJSON
+
+print(gdal.Info(ds, format="json"))
+
+# subdatasets
+
+subdatasets = ds.GetSubDatasets()
+# get the first subdataset properties
+sds_properties = subdatasets[0]
+subdataset_url = sds_properties[0]  # a tuple of URL and description
+subdataset = gdal.OpenEx(subdataset_url, allowed_drivers=["STACIT"])
+
+print(gdal.Info(subdataset, format="json"))

--- a/doc/source/drivers/raster/stacit.rst
+++ b/doc/source/drivers/raster/stacit.rst
@@ -141,6 +141,7 @@ Open a subdataset returned by the above request:
    .. code-tab:: bash
 
     gdalinfo "STACIT:\"https://planetarycomputer.microsoft.com/api/stac/v1/search?collections=naip&bbox=-100,40,-99,41&datetime=2019-01-01T00:00:00Z%2F..\":asset=image"
+    # from GDAL 3.11+
     gdal raster info "STACIT:\"https://planetarycomputer.microsoft.com/api/stac/v1/search?collections=naip&bbox=-100,40,-99,41&datetime=2019-01-01T00:00:00Z%2F..\":asset=image"
 
    .. code-tab:: ps1

--- a/doc/source/drivers/raster/stacit.rst
+++ b/doc/source/drivers/raster/stacit.rst
@@ -10,13 +10,17 @@ STACIT - Spatio-Temporal Asset Catalog Items
 
 .. built_in_by_default::
 
-This driver supports opening STAC API ItemCollections, with the input usually being a `STAC API search query <https://github.com/radiantearth/stac-api-spec/tree/main/item-search>`_ or the results saved as a JSON file. Items in the response must include projection information following the `Projection Extension Specification <https://github.com/stac-extensions/projection/>`_.
+This driver supports opening STAC API ItemCollections, with the input usually being a `STAC API search query <https://github.com/radiantearth/stac-api-spec/tree/main/item-search>`_
+or the results saved as a JSON file. Items in the response must include projection information following the
+`Projection Extension Specification <https://github.com/stac-extensions/projection/>`_.
 It builds a virtual mosaic from the items.
 
 A STACIT dataset which has no subdatasets is actually a :ref:`raster.vrt` dataset.
 Thus, translating it into VRT will result in a VRT file that directly references the items.
 
-Note that `STAC API ItemCollections <https://github.com/radiantearth/stac-api-spec/blob/main/fragments/itemcollection/README.md>`_ are not the same as  `STAC Collections <https://github.com/radiantearth/stac-spec/tree/master/collection-spec>`_. STAC API ItemCollections are GeoJSON FeatureCollections enhanced with STAC entities.
+Note that `STAC API ItemCollections <https://github.com/radiantearth/stac-api-spec/blob/main/fragments/itemcollection/README.md>`_
+are not the same as  `STAC Collections <https://github.com/radiantearth/stac-spec/tree/master/collection-spec>`_.
+STAC API ItemCollections are GeoJSON FeatureCollections enhanced with STAC entities.
 
 Open syntax
 -----------
@@ -108,17 +112,47 @@ Examples
 List the subdatasets associated to a `STAC search <https://github.com/radiantearth/stac-api-spec/tree/master/item-search>`_
 on a given collection, bbox and starting from a datetime:
 
-::
+.. tabs::
+
+   .. code-tab:: bash
 
     gdalinfo "STACIT:\"https://planetarycomputer.microsoft.com/api/stac/v1/search?collections=naip&bbox=-100,40,-99,41&datetime=2019-01-01T00:00:00Z%2F..\""
+    # from GDAL 3.11+
+    gdal raster info "STACIT:\"https://planetarycomputer.microsoft.com/api/stac/v1/search?collections=naip&bbox=-100,40,-99,41&datetime=2019-01-01T00:00:00Z%2F..\""
 
+
+   .. code-tab:: ps1
+
+    gdalinfo 'STACIT:\"https://planetarycomputer.microsoft.com/api/stac/v1/search?collections=naip&bbox=-100,40,-99,41&datetime=2019-01-01T00:00:00Z%2F..\"'
+    # from GDAL 3.11+
+    gdal raster info 'STACIT:\"https://planetarycomputer.microsoft.com/api/stac/v1/search?collections=naip&bbox=-100,40,-99,41&datetime=2019-01-01T00:00:00Z%2F..\"'
+
+   .. tab:: Python
+
+      .. literalinclude :: examples/stacit.py
+         :language: python
+         :end-before: # subdatasets
 
 Open a subdataset returned by the above request:
 
-::
+.. tabs::
+
+   .. code-tab:: bash
 
     gdalinfo "STACIT:\"https://planetarycomputer.microsoft.com/api/stac/v1/search?collections=naip&bbox=-100,40,-99,41&datetime=2019-01-01T00:00:00Z%2F..\":asset=image"
+    gdal raster info "STACIT:\"https://planetarycomputer.microsoft.com/api/stac/v1/search?collections=naip&bbox=-100,40,-99,41&datetime=2019-01-01T00:00:00Z%2F..\":asset=image"
 
+   .. code-tab:: ps1
+
+    gdalinfo 'STACIT:\"https://planetarycomputer.microsoft.com/api/stac/v1/search?collections=naip&bbox=-100,40,-99,41&datetime=2019-01-01T00:00:00Z%2F..\":asset=image'
+    # from GDAL 3.11+
+    gdal raster info 'STACIT:\"https://planetarycomputer.microsoft.com/api/stac/v1/search?collections=naip&bbox=-100,40,-99,41&datetime=2019-01-01T00:00:00Z%2F..\":asset=image'
+
+   .. tab:: Python
+
+      .. literalinclude :: examples/stacit.py
+         :language: python
+         :start-after: # subdatasets
 
 See Also
 --------

--- a/doc/source/drivers/raster/stacit.rst
+++ b/doc/source/drivers/raster/stacit.rst
@@ -127,11 +127,12 @@ on a given collection, bbox and starting from a datetime:
     # from GDAL 3.11+
     gdal raster info 'STACIT:\"https://planetarycomputer.microsoft.com/api/stac/v1/search?collections=naip&bbox=-100,40,-99,41&datetime=2019-01-01T00:00:00Z%2F..\"'
 
-   .. tab:: Python
+   .. group-tab:: Python
 
-      .. literalinclude :: examples/stacit.py
+      .. literalinclude :: examples/drivers/raster/stacit.py
          :language: python
-         :end-before: # subdatasets
+         :start-after: # Example 1
+         :end-before: # Example 2
 
 Open a subdataset returned by the above request:
 
@@ -148,11 +149,12 @@ Open a subdataset returned by the above request:
     # from GDAL 3.11+
     gdal raster info 'STACIT:\"https://planetarycomputer.microsoft.com/api/stac/v1/search?collections=naip&bbox=-100,40,-99,41&datetime=2019-01-01T00:00:00Z%2F..\":asset=image'
 
-   .. tab:: Python
+   .. group-tab:: Python
 
-      .. literalinclude :: examples/stacit.py
+      .. literalinclude :: examples/drivers/raster/stacit.py
          :language: python
-         :start-after: # subdatasets
+         :start-after: # Example 2
+
 
 See Also
 --------


### PR DESCRIPTION
## What does this PR do?

Adds command-line and Python examples to the STACIT driver page, using the tabs Sphinx plugin. 

![image](https://github.com/user-attachments/assets/e4e52a3e-3707-4b5c-affa-15fd5afd6235)

This is a sample pull request to get feedback on if this is a good approach to use for other drivers. 

## Questions

cc @dbaston @rouault

- What is the best approach for handling the old and new command-line interfaces? Include both with a ` # from GDAL 3.11+` note? Only use the new approach for the latest docs?
- I have added `bash` (Linux) examples, and `PowerShell` (Windows) examples - as quoting can differ between the two operating systems (I ran into issues with the current examples). My personal preference is to not also include `cmd` Windows examples, but maybe these should also be added?
- I added the Python examples as separate scripts, and parts can then be included in the docs. This allows them to be linted (and possibly automate testing them as a CI task). Is this a good approach?

Questions specific to these examples:

- When should `Open` be used in Python, and when `OpenEx`? Here I needed to force the driver in Python as noted in https://lists.osgeo.org/pipermail/gdal-dev/2024-March/058667.html or I got `RuntimeError: `https://planetarycomputer.microsoft.com/api/stac/v1/search?collections=naip&bbox=-100,40,-99,41&datetime=2019-01-01T00:00:00Z%2F..' does not exist in the file system, and is not recognized as a supported dataset name.`
