### PR TITLE
TopoJSON: read a top level 'crs' member, and other fixes in GeoJSON and ESRIJSON drivers

### DIFF
--- a/autotest/ogr/data/topojson/topojson_with_crs.topojson
+++ b/autotest/ogr/data/topojson/topojson_with_crs.topojson
@@ -1,0 +1,14 @@
+{
+"type":"Topology",
+"crs": { "type": "name", "properties": { "name": "urn:ogc:def:crs:OGC:1.3:CRS84" } },
+"arcs": [
+[[0.0, 0.0], [10, 0], [0, 10]],
+],
+"transform": {
+"scale": [1.0,10.0],"translate": [100.0,1000.0]
+},
+"objects": {
+"a_layer" : {"type": "GeometryCollection", "geometries" : [ {"type": "LineString", "arcs": [0], "properties": { "name": "line", "id": "foo"} } ] },
+"foo" : {"type": "LineString", "arcs": [0], "id" : "1" }
+}
+}

--- a/autotest/ogr/ogr_topojson.py
+++ b/autotest/ogr/ogr_topojson.py
@@ -135,11 +135,13 @@ def test_ogr_topojson_no_transform():
     ds = ogr.Open("data/topojson/topojson3.topojson")
     lyr = ds.GetLayer(0)
     assert lyr.GetName() == "a_layer"
+    assert lyr.GetSpatialRef() is None
     feat = lyr.GetNextFeature()
     ogrtest.check_feature_geometry(feat, "LINESTRING (0 0,10 0,0 10,10 0,0 0)")
 
     lyr = ds.GetLayer(1)
     assert lyr.GetName() == "TopoJSON"
+    assert lyr.GetSpatialRef() is None
     feat = lyr.GetNextFeature()
     ogrtest.check_feature_geometry(feat, "LINESTRING (0 0,10 0,0 10,10 0,0 0)")
     ds = None
@@ -174,3 +176,17 @@ def test_ogr_topojson_force_opening_url():
 
     drv = gdal.IdentifyDriverEx("http://example.com", allowed_drivers=["TopoJSON"])
     assert drv.GetDescription() == "TopoJSON"
+
+
+###############################################################################
+# Test CRS support
+
+
+def test_ogr_topojson_crs():
+
+    ds = ogr.Open("data/topojson/topojson_with_crs.topojson")
+    lyr = ds.GetLayer(0)
+    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4326"
+
+    lyr = ds.GetLayer(1)
+    assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4326"

--- a/ogr/ogrsf_frmts/geojson/ogr_geojson.h
+++ b/ogr/ogrsf_frmts/geojson/ogr_geojson.h
@@ -127,6 +127,11 @@ class OGRGeoJSONLayer final : public OGRMemLayer
         oWriteOptions_ = options;
     }
 
+    void SetSupportsMGeometries(bool bSupportsMGeometries)
+    {
+        m_bSupportsMGeometries = bSupportsMGeometries;
+    }
+
   private:
     OGRGeoJSONDataSource *poDS_;
     OGRGeoJSONReader *poReader_;
@@ -135,6 +140,7 @@ class OGRGeoJSONLayer final : public OGRMemLayer
     bool bOriginalIdModified_;
     GIntBig nTotalFeatureCount_;
     GIntBig nFeatureReadSinceReset_ = 0;
+    bool m_bSupportsMGeometries = false;
 
     //! Write options used by ICreateFeature() in append scenarios
     OGRGeoJSONWriteOptions oWriteOptions_;
@@ -292,6 +298,11 @@ class OGRGeoJSONDataSource final : public GDALDataset
         return osJSonFlavor_;
     }
 
+    void SetSupportsMGeometries(bool bSupportsMGeometries)
+    {
+        m_bSupportsMGeometries = bSupportsMGeometries;
+    }
+
     virtual CPLErr FlushCache(bool bAtClosing) override;
 
     CPLErr Close() override;
@@ -327,6 +338,7 @@ class OGRGeoJSONDataSource final : public GDALDataset
 
     CPLString osJSonFlavor_;
 
+    bool m_bSupportsMGeometries = false;
     //
     // Private utility functions
     //

--- a/ogr/ogrsf_frmts/geojson/ogr_geojson.h
+++ b/ogr/ogrsf_frmts/geojson/ogr_geojson.h
@@ -132,6 +132,11 @@ class OGRGeoJSONLayer final : public OGRMemLayer
         m_bSupportsMGeometries = bSupportsMGeometries;
     }
 
+    void SetSupportsZGeometries(bool bSupportsZGeometries)
+    {
+        m_bSupportsZGeometries = bSupportsZGeometries;
+    }
+
   private:
     OGRGeoJSONDataSource *poDS_;
     OGRGeoJSONReader *poReader_;
@@ -141,6 +146,7 @@ class OGRGeoJSONLayer final : public OGRMemLayer
     GIntBig nTotalFeatureCount_;
     GIntBig nFeatureReadSinceReset_ = 0;
     bool m_bSupportsMGeometries = false;
+    bool m_bSupportsZGeometries = true;
 
     //! Write options used by ICreateFeature() in append scenarios
     OGRGeoJSONWriteOptions oWriteOptions_;
@@ -303,6 +309,11 @@ class OGRGeoJSONDataSource final : public GDALDataset
         m_bSupportsMGeometries = bSupportsMGeometries;
     }
 
+    void SetSupportsZGeometries(bool bSupportsZGeometries)
+    {
+        m_bSupportsZGeometries = bSupportsZGeometries;
+    }
+
     virtual CPLErr FlushCache(bool bAtClosing) override;
 
     CPLErr Close() override;
@@ -339,6 +350,8 @@ class OGRGeoJSONDataSource final : public GDALDataset
     CPLString osJSonFlavor_;
 
     bool m_bSupportsMGeometries = false;
+    bool m_bSupportsZGeometries = true;
+
     //
     // Private utility functions
     //

--- a/ogr/ogrsf_frmts/geojson/ogresrijsondriver.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogresrijsondriver.cpp
@@ -77,6 +77,7 @@ void RegisterOGRESRIJSON()
     poDriver->SetMetadataItem(GDAL_DMD_HELPTOPIC,
                               "drivers/vector/esrijson.html");
     poDriver->SetMetadataItem(GDAL_DCAP_Z_GEOMETRIES, "YES");
+    poDriver->SetMetadataItem(GDAL_DCAP_MEASURED_GEOMETRIES, "YES");
 
     poDriver->SetMetadataItem(
         GDAL_DMD_OPENOPTIONLIST,

--- a/ogr/ogrsf_frmts/geojson/ogresrijsonreader.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogresrijsonreader.cpp
@@ -87,6 +87,8 @@ void OGRESRIJSONReader::ReadLayers(OGRGeoJSONDataSource *poDS,
 {
     CPLAssert(nullptr == poLayer_);
 
+    poDS->SetSupportsMGeometries(true);
+
     if (nullptr == poGJObject_)
     {
         CPLDebug("ESRIJSON",
@@ -143,6 +145,7 @@ void OGRESRIJSONReader::ReadLayers(OGRGeoJSONDataSource *poDS,
 
     poLayer_ =
         new OGRGeoJSONLayer(osName.c_str(), poSRS, eGeomType, poDS, nullptr);
+    poLayer_->SetSupportsMGeometries(true);
     if (poSRS != nullptr)
         poSRS->Release();
 

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsondatasource.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsondatasource.cpp
@@ -752,8 +752,9 @@ int OGRGeoJSONDataSource::TestCapability(const char *pszCap)
 {
     if (EQUAL(pszCap, ODsCCreateLayer))
         return fpOut_ != nullptr && nLayers_ == 0;
-    else if (EQUAL(pszCap, ODsCZGeometries) ||
-             EQUAL(pszCap, ODsCMeasuredGeometries))
+    else if (EQUAL(pszCap, ODsCMeasuredGeometries))
+        return m_bSupportsMGeometries;
+    else if (EQUAL(pszCap, ODsCZGeometries))
         return TRUE;
 
     return FALSE;

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsondatasource.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsondatasource.cpp
@@ -755,7 +755,7 @@ int OGRGeoJSONDataSource::TestCapability(const char *pszCap)
     else if (EQUAL(pszCap, ODsCMeasuredGeometries))
         return m_bSupportsMGeometries;
     else if (EQUAL(pszCap, ODsCZGeometries))
-        return TRUE;
+        return m_bSupportsZGeometries;
 
     return FALSE;
 }

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsondriver.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsondriver.cpp
@@ -782,7 +782,7 @@ void RegisterOGRGeoJSON()
         "Integer64List RealList StringList Date DateTime");
     poDriver->SetMetadataItem(GDAL_DMD_CREATIONFIELDDATASUBTYPES, "Boolean");
     poDriver->SetMetadataItem(GDAL_DMD_SUPPORTED_SQL_DIALECTS, "OGRSQL SQLITE");
-    poDriver->SetMetadataItem(GDAL_DCAP_MEASURED_GEOMETRIES, "YES");
+
     poDriver->SetMetadataItem(GDAL_DCAP_FLUSHCACHE_CONSISTENT_STATE, "YES");
     poDriver->SetMetadataItem(GDAL_DCAP_HONOR_GEOM_COORDINATE_PRECISION, "YES");
 

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonlayer.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonlayer.cpp
@@ -507,7 +507,7 @@ int OGRGeoJSONLayer::TestCapability(const char *pszCap)
     else if (EQUAL(pszCap, OLCMeasuredGeometries))
         return m_bSupportsMGeometries;
     else if (EQUAL(pszCap, OLCZGeometries))
-        return TRUE;
+        return m_bSupportsZGeometries;
     else if (EQUAL(pszCap, OLCStringsAsUTF8))
         return TRUE;
     else if (EQUAL(pszCap, OLCFastGetExtent) ||

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonlayer.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonlayer.cpp
@@ -504,6 +504,8 @@ int OGRGeoJSONLayer::TestCapability(const char *pszCap)
 {
     if (EQUAL(pszCap, OLCCurveGeometries))
         return FALSE;
+    else if (EQUAL(pszCap, OLCMeasuredGeometries))
+        return m_bSupportsMGeometries;
     else if (EQUAL(pszCap, OLCZGeometries))
         return TRUE;
     else if (EQUAL(pszCap, OLCStringsAsUTF8))

--- a/ogr/ogrsf_frmts/geojson/ogrtopojsonreader.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrtopojsonreader.cpp
@@ -495,6 +495,7 @@ ParseObjectMain(const char *pszId, json_object *poObj,
                     OGRGeoJSONLayer *poLayer =
                         new OGRGeoJSONLayer(pszId ? pszId : "TopoJSON", nullptr,
                                             wkbUnknown, poDS, nullptr);
+                    poLayer->SetSupportsZGeometries(false);
                     OGRFeatureDefn *poDefn = poLayer->GetLayerDefn();
 
                     const auto nGeometries =
@@ -569,6 +570,9 @@ ParseObjectMain(const char *pszId, json_object *poObj,
                 {
                     *ppoMainLayer = new OGRGeoJSONLayer(
                         "TopoJSON", nullptr, wkbUnknown, poDS, nullptr);
+
+                    (*ppoMainLayer)->SetSupportsZGeometries(false);
+
                     apoFieldDefn.emplace_back(
                         std::make_unique<OGRFieldDefn>("id", OFTString));
                     oMapFieldNameToIdx["id"] = 0;
@@ -628,6 +632,8 @@ void OGRTopoJSONReader::ReadLayers(OGRGeoJSONDataSource *poDS)
                  "Missing parsed TopoJSON data. Forgot to call Parse()?");
         return;
     }
+
+    poDS->SetSupportsZGeometries(false);
 
     ScalingParams sParams;
     sParams.dfScale0 = 1.0;


### PR DESCRIPTION
fixes #12216