### PR TITLE
VRTDerivedRasterBand: Add reclassify pixel function

### DIFF
--- a/autotest/gdrivers/vrtderived.py
+++ b/autotest/gdrivers/vrtderived.py
@@ -1292,3 +1292,150 @@ def test_vrt_pixelfn_constant_factor(tmp_vsimem, fn):
         np.testing.assert_array_equal(dst, src + k)
     elif fn == "mul":
         np.testing.assert_array_equal(dst, src * k)
+
+
+###############################################################################
+# Test reclassification
+
+
+@pytest.mark.parametrize("default", (7, "NO_DATA"))
+def test_vrt_pixelfn_reclassify(tmp_vsimem, default):
+    np = pytest.importorskip("numpy")
+    gdaltest.importorskip_gdal_array()
+
+    nx = 2
+    ny = 3
+
+    data = np.arange(nx * ny).reshape(ny, nx)
+
+    with gdal.GetDriverByName("GTiff").Create(tmp_vsimem / "src.tif", nx, ny, 1) as src:
+        src.WriteArray(data)
+
+    xml = f"""
+    <VRTDataset rasterXSize="{nx}" rasterYSize="{ny}">
+      <VRTRasterBand dataType="Float32" band="1" subclass="VRTDerivedRasterBand">
+        <PixelFunctionType>reclassify</PixelFunctionType>
+        <PixelFunctionArguments mapping="1=2,3=4" default="{default}"/>
+        <SimpleSource>
+          <SourceFilename>{tmp_vsimem / "src.tif"}</SourceFilename>
+          <SourceBand>1</SourceBand>j
+        </SimpleSource>
+        <NoDataValue>7</NoDataValue>
+      </VRTRasterBand>
+    </VRTDataset>"""
+
+    dst = gdal.Open(xml).ReadAsArray()
+
+    assert np.all(dst[np.where(data == 1)] == 2)
+    assert np.all(dst[np.where(data == 3)] == 4)
+    assert np.all(dst[np.where((data != 1) & (data != 3))] == 7)
+
+
+@gdaltest.enable_exceptions()
+def test_vrt_pixelfn_reclassify_no_default(tmp_vsimem):
+
+    np = pytest.importorskip("numpy")
+    gdaltest.importorskip_gdal_array()
+
+    nx = 2
+    ny = 3
+
+    data = np.arange(nx * ny).reshape(ny, nx)
+
+    with gdal.GetDriverByName("GTiff").Create(tmp_vsimem / "src.tif", nx, ny, 1) as src:
+        src.WriteArray(data)
+
+    xml = f"""
+    <VRTDataset rasterXSize="{nx}" rasterYSize="{ny}">
+      <VRTRasterBand dataType="Float32" band="1" subclass="VRTDerivedRasterBand">
+        <PixelFunctionType>reclassify</PixelFunctionType>
+        <PixelFunctionArguments mapping="1=2,3=4"/>
+        <SimpleSource>
+          <SourceFilename>{tmp_vsimem / "src.tif"}</SourceFilename>
+          <SourceBand>1</SourceBand>j
+        </SimpleSource>
+      </VRTRasterBand>
+    </VRTDataset>"""
+
+    with pytest.raises(
+        Exception, match="Encountered value .* with no specified mapping"
+    ):
+        gdal.Open(xml).ReadAsArray()
+
+
+@gdaltest.enable_exceptions()
+@pytest.mark.parametrize(
+    "default,error",
+    [
+        ("32k", "Failed to parse"),
+        ("", "Failed to parse"),
+        ("256", "cannot be represented"),
+        ("NO_DATA", "NoData value is not set"),
+    ],
+)
+def test_vrt_pixelfn_reclassify_bad_default(tmp_vsimem, default, error):
+
+    np = pytest.importorskip("numpy")
+    gdaltest.importorskip_gdal_array()
+
+    nx = 2
+    ny = 3
+
+    data = np.arange(nx * ny).reshape(ny, nx)
+
+    with gdal.GetDriverByName("GTiff").Create(tmp_vsimem / "src.tif", nx, ny, 1) as src:
+        src.WriteArray(data)
+
+    xml = f"""
+    <VRTDataset rasterXSize="{nx}" rasterYSize="{ny}">
+      <VRTRasterBand dataType="Byte" band="1" subclass="VRTDerivedRasterBand">
+        <PixelFunctionType>reclassify</PixelFunctionType>
+        <PixelFunctionArguments mapping="1=2,3=4" default="{default}" />
+        <SimpleSource>
+          <SourceFilename>{tmp_vsimem / "src.tif"}</SourceFilename>
+          <SourceBand>1</SourceBand>j
+        </SimpleSource>
+      </VRTRasterBand>
+    </VRTDataset>"""
+
+    with pytest.raises(Exception, match=error):
+        gdal.Open(xml).ReadAsArray()
+
+
+@gdaltest.enable_exceptions()
+@pytest.mark.parametrize(
+    "mapping,error",
+    [
+        ("1=2,3", "expected '='"),
+        ("1=2,3=4g", "expected ',' or end"),
+        ("1=2,", "expected number"),
+        ("1=3,3=256,", "cannot be represented"),
+    ],
+)
+def test_vrt_pixelfn_reclassify_invalid_mapping(tmp_vsimem, mapping, error):
+
+    np = pytest.importorskip("numpy")
+    gdaltest.importorskip_gdal_array()
+
+    nx = 2
+    ny = 3
+
+    data = np.arange(nx * ny).reshape(ny, nx)
+
+    with gdal.GetDriverByName("GTiff").Create(tmp_vsimem / "src.tif", nx, ny, 1) as src:
+        src.WriteArray(data)
+
+    xml = f"""
+    <VRTDataset rasterXSize="{nx}" rasterYSize="{ny}">
+      <VRTRasterBand dataType="Byte" band="1" subclass="VRTDerivedRasterBand">
+        <PixelFunctionType>reclassify</PixelFunctionType>
+        <PixelFunctionArguments mapping="{mapping}" default="7" />
+        <SimpleSource>
+          <SourceFilename>{tmp_vsimem / "src.tif"}</SourceFilename>
+          <SourceBand>1</SourceBand>j
+        </SimpleSource>
+      </VRTRasterBand>
+    </VRTDataset>"""
+
+    with pytest.raises(Exception, match=error):
+        gdal.Open(xml).ReadAsArray()

--- a/autotest/gdrivers/vrtderived.py
+++ b/autotest/gdrivers/vrtderived.py
@@ -1318,7 +1318,7 @@ def test_vrt_pixelfn_reclassify(tmp_vsimem, default):
         <PixelFunctionArguments mapping=" (-inf, 1)=8; 2=9 ; (3,5]=4; [11, Inf] = 11 " default="{default}"/>
         <SimpleSource>
           <SourceFilename>{tmp_vsimem / "src.tif"}</SourceFilename>
-          <SourceBand>1</SourceBand>j
+          <SourceBand>1</SourceBand>
         </SimpleSource>
         <NoDataValue>7</NoDataValue>
       </VRTRasterBand>
@@ -1352,7 +1352,7 @@ def test_vrt_pixelfn_reclassify_no_default(tmp_vsimem):
         <PixelFunctionArguments mapping="1=2;3=4"/>
         <SimpleSource>
           <SourceFilename>{tmp_vsimem / "src.tif"}</SourceFilename>
-          <SourceBand>1</SourceBand>j
+          <SourceBand>1</SourceBand>
         </SimpleSource>
       </VRTRasterBand>
     </VRTDataset>"""
@@ -1393,7 +1393,7 @@ def test_vrt_pixelfn_reclassify_bad_default(tmp_vsimem, default, error):
         <PixelFunctionArguments mapping="1=2;3=4" default="{default}" />
         <SimpleSource>
           <SourceFilename>{tmp_vsimem / "src.tif"}</SourceFilename>
-          <SourceBand>1</SourceBand>j
+          <SourceBand>1</SourceBand>
         </SimpleSource>
       </VRTRasterBand>
     </VRTDataset>"""

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1221,6 +1221,10 @@ GDAL provides a set of default pixel functions that can be used without writing 
      - 1
      - -
      - extract real part from a single raster band (just a copy if the input is non-complex)
+   * - **reclassify**
+     - = 1
+     - ``mapping``, ``default``
+     - reclassify values according to a mapping provided by ``mapping``. The format of the mapping is ``SOURCE=DEST;SOURCE=DEST;..`` where each ``SOURCE`` element is either a single value or an interval (e.g., ``(-inf,30]``). An error will be raised if a pixel value is not covered by any interval, unless the ```default`` argument has been specified. ``default`` may also be set any constant or ``NO_DATA``.
    * - **replace_nodata**
      - = 1
      - ``to`` (optional)

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -457,6 +457,7 @@ Clamping is performed for input pixel values outside of the range specified by t
 input pixel value is lower than the minimum source value, then the destination
 value corresponding to that minimum source value is used as the output pixel value.
 And similarly for an input pixel value that is greater than the maximum source value.
+To remap values without interpolation, the "reclassify" pixel function can be used. See :ref:`vrt_derived_bands`.
 
 The ComplexSource supports fetching a color component from a source raster
 band that has a color table. The ColorTableComponent value is the index of the
@@ -1224,7 +1225,7 @@ GDAL provides a set of default pixel functions that can be used without writing 
    * - **reclassify**
      - = 1
      - ``mapping``, ``default``
-     - reclassify values according to a mapping provided by ``mapping``. The format of the mapping is ``SOURCE=DEST;SOURCE=DEST;..`` where each ``SOURCE`` element is either a single value or an interval (e.g., ``(-inf,30]``). An error will be raised if a pixel value is not covered by any interval, unless the ```default`` argument has been specified. ``default`` may also be set any constant or ``NO_DATA``.
+     - reclassify values according to a mapping provided by ``mapping``. The format of the mapping is ``SOURCE=DEST;SOURCE=DEST;..`` where each ``SOURCE`` element is either a single value or an interval (e.g., ``(-inf,30]``). An error will be raised if a pixel value is not covered by any interval, unless the ```default`` argument has been specified. ``default`` may also be set any constant or ``NO_DATA``. A similar functionality, but with interpolation, is offered by the ``ComplexSource``.
    * - **replace_nodata**
      - = 1
      - ``to`` (optional)


### PR DESCRIPTION
## What does this PR do?

Adds a "reclassify" pixel function. Can map values from individual values or specified ranges.

Doesn't currently check the ranges to make sure they are non-overlapping. Range checking is via O(n) lookup, could be improved by binary search later.

## What are related issues/pull requests?

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed