### PR TITLE
gdal vector geom set-type: replace dimension flags with single option

### DIFF
--- a/apps/gdalalg_vector_geom_set_type.cpp
+++ b/apps/gdalalg_vector_geom_set_type.cpp
@@ -75,14 +75,9 @@ GDALVectorGeomSetTypeAlgorithm::GDALVectorGeomSetTypeAlgorithm(
            &m_opts.m_curve)
         .SetMutualExclusionGroup("linear-curve");
 
-    AddArg("xy", 0, _("Force geometries to XY dimension"), &m_opts.m_xy)
-        .SetMutualExclusionGroup("xy");
-    AddArg("xyz", 0, _("Force geometries to XYZ dimension"), &m_opts.m_xyz)
-        .SetMutualExclusionGroup("xy");
-    AddArg("xym", 0, _("Force geometries to XYM dimension"), &m_opts.m_xym)
-        .SetMutualExclusionGroup("xy");
-    AddArg("xyzm", 0, _("Force geometries to XYZM dimension"), &m_opts.m_xyzm)
-        .SetMutualExclusionGroup("xy");
+    AddArg("dim", 0, _("Force geometries to the specified dimension"),
+           &m_opts.m_dim)
+        .SetChoices("XY", "XYZ", "XYM", "XYZM");
 
     AddArg("skip", 0,
            _("Skip feature when change of feature geometry type failed"),
@@ -214,19 +209,19 @@ GDALVectorGeomSetTypeAlgorithmLayer::ConvertType(OGRwkbGeometryType eType) const
         eRetType = OGR_GT_GetCurve(eRetType);
     }
 
-    if (m_opts.m_xy)
+    if (EQUAL(m_opts.m_dim.c_str(), "XY"))
     {
         eRetType = OGR_GT_Flatten(eRetType);
     }
-    else if (m_opts.m_xyz)
+    else if (EQUAL(m_opts.m_dim.c_str(), "XYZ"))
     {
         eRetType = OGR_GT_SetZ(OGR_GT_Flatten(eRetType));
     }
-    else if (m_opts.m_xym)
+    else if (EQUAL(m_opts.m_dim.c_str(), "XYM"))
     {
         eRetType = OGR_GT_SetM(OGR_GT_Flatten(eRetType));
     }
-    else if (m_opts.m_xyzm)
+    else if (EQUAL(m_opts.m_dim.c_str(), "XYZM"))
     {
         eRetType = OGR_GT_SetZ(OGR_GT_SetM(OGR_GT_Flatten(eRetType)));
     }
@@ -298,12 +293,11 @@ bool GDALVectorGeomSetTypeAlgorithm::RunStep(GDALProgressFunc, void *)
     if (!m_opts.m_type.empty())
     {
         if (m_opts.m_multi || m_opts.m_single || m_opts.m_linear ||
-            m_opts.m_curve || m_opts.m_xy || m_opts.m_xyz || m_opts.m_xym ||
-            m_opts.m_xyzm)
+            m_opts.m_curve || !m_opts.m_dim.empty())
         {
             ReportError(CE_Failure, CPLE_AppDefined,
                         "--geometry-type cannot be used with any of "
-                        "--multi/single/linear/multi/xy/xyz/xym/xyzm");
+                        "--multi/single/linear/multi/dim");
             return false;
         }
 

--- a/apps/gdalalg_vector_geom_set_type.h
+++ b/apps/gdalalg_vector_geom_set_type.h
@@ -42,10 +42,7 @@ class GDALVectorGeomSetTypeAlgorithm final
         bool m_single = false;
         bool m_linear = false;
         bool m_curve = false;
-        bool m_xy = false;
-        bool m_xyz = false;
-        bool m_xym = false;
-        bool m_xyzm = false;
+        std::string m_dim{};
         bool m_skip = false;
 
         // Computed value from m_type

--- a/autotest/utilities/test_gdalalg_vector_geom_set_type.py
+++ b/autotest/utilities/test_gdalalg_vector_geom_set_type.py
@@ -67,9 +67,7 @@ def test_gdalalg_vector_geom_set_type_geometry_type_invalid():
         alg.Run()
 
 
-@pytest.mark.parametrize(
-    "other_option", ["multi", "single", "linear", "curve", "xy", "xyz", "xym", "xyzm"]
-)
+@pytest.mark.parametrize("other_option", ["multi", "single", "linear", "curve", "dim"])
 def test_gdalalg_vector_geom_set_type_geometry_type_exclusive_with_other_option(
     other_option,
 ):
@@ -81,7 +79,7 @@ def test_gdalalg_vector_geom_set_type_geometry_type_exclusive_with_other_option(
     alg["output"] = ""
     alg["output-format"] = "stream"
     alg["geometry-type"] = "POINT"
-    alg[other_option] = True
+    alg[other_option] = "XY" if other_option == "dim" else True
 
     with pytest.raises(Exception, match="cannot be used with any of"):
         alg.Run()
@@ -203,11 +201,11 @@ def test_gdalalg_vector_geom_set_type_geometry_type_feature_only():
 @pytest.mark.parametrize(
     "modifier,in_wkt,out_wkt",
     [
-        ("xy", "POINT Z (1 2 3)", "POINT (1 2)"),
-        ("xyz", "POINT (1 2)", "POINT Z (1 2 0)"),
-        ("xym", "POINT (1 2 3 4)", "POINT M (1 2 4)"),
-        ("xyzm", "POINT (1 2)", "POINT ZM (1 2 0 0)"),
-        ("xyzm", "POINT ZM (1 2 3 4)", "POINT ZM (1 2 3 4)"),
+        (("dim", "xy"), "POINT Z (1 2 3)", "POINT (1 2)"),
+        (("dim", "xyz"), "POINT (1 2)", "POINT Z (1 2 0)"),
+        (("dim", "xym"), "POINT (1 2 3 4)", "POINT M (1 2 4)"),
+        (("dim", "xyzm"), "POINT (1 2)", "POINT ZM (1 2 0 0)"),
+        (("dim", "xyzm"), "POINT ZM (1 2 3 4)", "POINT ZM (1 2 3 4)"),
         ("multi", "POINT Z (1 2 3)", "MULTIPOINT Z ((1 2 3))"),
         ("single", "MULTIPOINT Z ((1 2 3))", "POINT Z (1 2 3)"),
         ("single", "MULTILINESTRING ((1 2,3 4))", "LINESTRING (1 2,3 4)"),
@@ -239,7 +237,11 @@ def test_gdalalg_vector_geom_set_type_other_modifiers(modifier, in_wkt, out_wkt)
     alg["input"] = src_ds
     alg["output"] = ""
     alg["output-format"] = "stream"
-    alg[modifier] = True
+
+    if type(modifier) is str:
+        alg[modifier] = True
+    else:
+        alg[modifier[0]] = modifier[1]
 
     assert alg.Run()
 

--- a/doc/source/programs/gdal_vector_geom_set_type.rst
+++ b/doc/source/programs/gdal_vector_geom_set_type.rst
@@ -28,7 +28,7 @@ It can also be used as a step of :ref:`gdal_vector_pipeline`.
 The following groups of options can be combined together:
 -  :option:`--multi` / :option:`--single`
 -  :option:`--linear` / :option:`--curve`
--  :option:`--xy` / :option:`--xyz` / :option:`--xym` / :option:`--xyzm`
+-  :option:`--dim`
 
 Standard options
 ++++++++++++++++
@@ -65,8 +65,7 @@ Standard options
    indicate the dimensionality.
 
    This option is mutually exclusive with :option:`--multi`, :option:`--single`,
-   :option:`--linear`, :option:`--curve`, :option:`--xy`, :option:`--xyz`,
-   :option:`--xym`, :option:`--xyzm`.
+   :option:`--linear`, :option:`--curve`, and :option:`--dim`.
 
 .. option:: --multi
 
@@ -97,28 +96,10 @@ Standard options
    or ``POLYGON`` ==> ``CURVEPOLYGON``. Points are kept unmodified.
    This option is mutually exclusive with :option:`--linear`.
 
-.. option:: --xy
+.. option:: --dim
 
-   Force geometries to XY dimension.
-   This option is mutually exclusive with :option:`--xyz`, :option:`--xym`, :option:`--xyzm`.
-
-.. option:: --xyz
-
-   Force geometries to XYZ dimension. If the input geometry lacks a Z component,
-   it will be set to 0.
-   This option is mutually exclusive with :option:`--xy`, :option:`--xym`, :option:`--xyzm`.
-
-.. option:: --xym
-
-   Force geometries to XYM dimension. If the input geometry lacks a M component,
-   it will be set to 0.
-   This option is mutually exclusive with :option:`--xy`, :option:`--xyz`, :option:`--xyzm`.
-
-.. option:: --xyzm
-
-   Force geometries to XYZM dimension. If the input geometry lacks a Z or M component,
-   it will be set to 0.
-   This option is mutually exclusive with :option:`--xy`, :option:`--xyz`, :option:`--xym`.
+   Force geometries to the specified dimension (XY, XYZ, XYM, or XYZM). If the input geometry lacks Z or M components, they will be set to 0. This option
+   is mutually exclusive with :option:`--geometry-type`.
 
 .. option:: --skip
 
@@ -128,8 +109,7 @@ Standard options
    the output layer if it does not support mix of geometry types).
    This option applies both when the target geometry type is defined with
    :option:`--geometry-type`, or with any of :option:`--multi`, :option:`--single`,
-   :option:`--linear`, :option:`--curve`, :option:`--xy`, :option:`--xyz`,
-   :option:`--xym` or :option:`--xyzm`.
+   :option:`--linear`, and :option:`--curve`.
 
 Advanced options
 ++++++++++++++++


### PR DESCRIPTION
Replaces four mutually-exclusive flags with a single option, a sort of complement to 3c0d9011ef325b0d1ef3aa3b4ef66b089f258147