### PR TITLE
Information about PG_USE_COPY on pg.rst docs

### DIFF
--- a/doc/source/drivers/vector/pg.rst
+++ b/doc/source/drivers/vector/pg.rst
@@ -417,6 +417,12 @@ The following configuration options are available:
                    mode as used by the OGR PostgreSQL driver. Thus you should
                    force PG_USE_COPY=NO when using PgPoolII.
 
+      .. warning:: It is not always possible to use COPY. In particular if
+                   the input layer has columns with a DEFAULT value specified
+                   and that the feature has no value set for that given field,
+                   the driver will default to INSERT even if instructed to use
+                   COPY via this option.
+
 -  .. config:: PGSQL_OGR_FID
 
       Set name of primary key instead of 'ogc_fid'. Only


### PR DESCRIPTION
## What does this PR do?

Simple change at documentation which adds valuable knowledge about the `PG_USE_COPY` option

## What are related issues/pull requests?

Valuable knowledge about the option behavior was found at https://github.com/OSGeo/gdal/issues/1039#issuecomment-431696843

## Tasklist

 - No AI was used to contribute this piece
 - [x] Added documentation

> Cleaned-up noise as this is a doc-only change

## Environment

Not relevant

## Additional information

I'm not used to the .rst docs, please tell me if the formatting isn't correct.
The intent is the change being reflected at https://gdal.org/en/stable/drivers/vector/pgdump.html#environment-variables,
I've supposed this file was the SSoT for the knowledge about that option, please tell me if I'm wrong.