### PR TITLE
VRT reclassification improvements

### DIFF
--- a/autotest/gdrivers/vrtderived.py
+++ b/autotest/gdrivers/vrtderived.py
@@ -1315,7 +1315,7 @@ def test_vrt_pixelfn_reclassify(tmp_vsimem, default):
     <VRTDataset rasterXSize="{nx}" rasterYSize="{ny}">
       <VRTRasterBand dataType="Float32" band="1" subclass="VRTDerivedRasterBand">
         <PixelFunctionType>reclassify</PixelFunctionType>
-        <PixelFunctionArguments mapping=" (-inf, 1)=8; 2=9 ; (3,5]=4; 10=NO_DATA; [11, Inf] = 11 " default="{default}"/>
+        <PixelFunctionArguments mapping=" (-inf, 1)=8; 2=9 ; (3,5]=4; 10=NO_DATA; [11, Inf] = 11; default={default}"/>
         <SimpleSource>
           <SourceFilename>{tmp_vsimem / "src.tif"}</SourceFilename>
           <SourceBand>1</SourceBand>
@@ -1370,45 +1370,6 @@ def test_vrt_pixelfn_reclassify_no_default(tmp_vsimem):
     with pytest.raises(
         Exception, match="Encountered value .* with no specified mapping"
     ):
-        gdal.Open(xml).ReadAsArray()
-
-
-@gdaltest.enable_exceptions()
-@pytest.mark.parametrize(
-    "default,error",
-    [
-        ("32k", "Failed to parse"),
-        ("", "Failed to parse"),
-        ("256", "cannot be represented"),
-        ("NO_DATA", "NoData value is not set"),
-    ],
-)
-def test_vrt_pixelfn_reclassify_bad_default(tmp_vsimem, default, error):
-
-    np = pytest.importorskip("numpy")
-    gdaltest.importorskip_gdal_array()
-
-    nx = 2
-    ny = 3
-
-    data = np.arange(nx * ny).reshape(ny, nx)
-
-    with gdal.GetDriverByName("GTiff").Create(tmp_vsimem / "src.tif", nx, ny, 1) as src:
-        src.WriteArray(data)
-
-    xml = f"""
-    <VRTDataset rasterXSize="{nx}" rasterYSize="{ny}">
-      <VRTRasterBand dataType="Byte" band="1" subclass="VRTDerivedRasterBand">
-        <PixelFunctionType>reclassify</PixelFunctionType>
-        <PixelFunctionArguments mapping="1=2;3=4" default="{default}" />
-        <SimpleSource>
-          <SourceFilename>{tmp_vsimem / "src.tif"}</SourceFilename>
-          <SourceBand>1</SourceBand>
-        </SimpleSource>
-      </VRTRasterBand>
-    </VRTDataset>"""
-
-    with pytest.raises(Exception, match=error):
         gdal.Open(xml).ReadAsArray()
 
 

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1225,7 +1225,7 @@ GDAL provides a set of default pixel functions that can be used without writing 
    * - **reclassify**
      - = 1
      - ``mapping``, ``default``
-     - reclassify values according to a mapping provided by ``mapping``. The format of the mapping is ``SOURCE=DEST;SOURCE=DEST;...`` where each ``SOURCE`` element is either a single value, an interval (e.g., ``(-inf,30]``), ``NO_DATA``, or ``DEFAULT``. ``DEST`` may be any constant or ``NO_DATA``. An error will be raised if a pixel value is not covered by any interval. A similar functionality, but with interpolation, is offered by the ``ComplexSource``.
+     - reclassify values according to a mapping provided by ``mapping``. The format of the mapping is ``SOURCE=DEST;SOURCE=DEST;...`` where each ``SOURCE`` element is either a single value, an interval (e.g., ``(-inf,30]``), ``NO_DATA``, or ``DEFAULT``. ``DEST`` may be any constant, ``PASS_THROUGH`` (to skip reclassification for certain values), or ``NO_DATA``. An error will be raised if a pixel value is not covered by any interval. A similar functionality, but with interpolation, is offered by the ``ComplexSource``.
    * - **replace_nodata**
      - = 1
      - ``to`` (optional)

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1225,7 +1225,7 @@ GDAL provides a set of default pixel functions that can be used without writing 
    * - **reclassify**
      - = 1
      - ``mapping``, ``default``
-     - reclassify values according to a mapping provided by ``mapping``. The format of the mapping is ``SOURCE=DEST;SOURCE=DEST;..`` where each ``SOURCE`` element is either a single value or an interval (e.g., ``(-inf,30]``). An error will be raised if a pixel value is not covered by any interval, unless the ```default`` argument has been specified. ``default`` may also be set any constant or ``NO_DATA``. A similar functionality, but with interpolation, is offered by the ``ComplexSource``.
+     - reclassify values according to a mapping provided by ``mapping``. The format of the mapping is ``SOURCE=DEST;SOURCE=DEST;...`` where each ``SOURCE`` element is either a single value, an interval (e.g., ``(-inf,30]``), or ``DEFAULT``. ``DEST`` may be any constant or ``NO_DATA``. An error will be raised if a pixel value is not covered by any interval. A similar functionality, but with interpolation, is offered by the ``ComplexSource``.
    * - **replace_nodata**
      - = 1
      - ``to`` (optional)

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1225,7 +1225,7 @@ GDAL provides a set of default pixel functions that can be used without writing 
    * - **reclassify**
      - = 1
      - ``mapping``, ``default``
-     - reclassify values according to a mapping provided by ``mapping``. The format of the mapping is ``SOURCE=DEST;SOURCE=DEST;...`` where each ``SOURCE`` element is either a single value, an interval (e.g., ``(-inf,30]``), or ``DEFAULT``. ``DEST`` may be any constant or ``NO_DATA``. An error will be raised if a pixel value is not covered by any interval. A similar functionality, but with interpolation, is offered by the ``ComplexSource``.
+     - reclassify values according to a mapping provided by ``mapping``. The format of the mapping is ``SOURCE=DEST;SOURCE=DEST;...`` where each ``SOURCE`` element is either a single value, an interval (e.g., ``(-inf,30]``), ``NO_DATA``, or ``DEFAULT``. ``DEST`` may be any constant or ``NO_DATA``. An error will be raised if a pixel value is not covered by any interval. A similar functionality, but with interpolation, is offered by the ``ComplexSource``.
    * - **replace_nodata**
      - = 1
      - ``to`` (optional)

--- a/frmts/vrt/CMakeLists.txt
+++ b/frmts/vrt/CMakeLists.txt
@@ -19,6 +19,8 @@ add_gdal_driver(
           vrtprocesseddataset.cpp
           vrtprocesseddatasetfunctions.cpp
           vrtmultidim.cpp
+          vrtreclassifier.h
+          vrtreclassifier.cpp
           STRONG_CXX_WFLAGS)
 gdal_standard_includes(gdal_vrt)
 target_include_directories(gdal_vrt PRIVATE ${GDAL_RASTER_FORMAT_SOURCE_DIR}/raw

--- a/frmts/vrt/pixelfunctions.cpp
+++ b/frmts/vrt/pixelfunctions.cpp
@@ -15,6 +15,7 @@
 #include "gdal.h"
 #include "vrtdataset.h"
 #include "vrtexpression.h"
+#include "vrtreclassifier.h"
 
 #include <limits>
 
@@ -1731,134 +1732,6 @@ static CPLErr ExprPixelFunc(void **papoSources, int nSources, void *pData,
     return CE_None;
 }  // ExprPixelFunc
 
-struct Interval
-{
-    double dfMin;
-    double dfMax;
-    bool bMinIncluded;
-    bool bMaxIncluded;
-
-    void SetToConstant(double dfVal)
-    {
-        dfMin = dfVal;
-        dfMax = dfVal;
-        bMinIncluded = true;
-        bMaxIncluded = true;
-    }
-
-    CPLErr Parse(const char *s, char **rest)
-    {
-        const char *start = s;
-
-        while (isspace(*start))
-        {
-            start++;
-        }
-
-        char *end;
-
-        if (*start == '(')
-        {
-            bMinIncluded = false;
-        }
-        else if (*start == '[')
-        {
-            bMinIncluded = true;
-        }
-        else
-        {
-            double dfVal = CPLStrtod(start, &end);
-
-            if (end == start)
-            {
-                CPLError(CE_Failure, CPLE_AppDefined,
-                         "Interval must start with '(' or ']'");
-                return CE_Failure;
-            }
-
-            SetToConstant(dfVal);
-
-            if (rest != nullptr)
-            {
-                *rest = end;
-            }
-
-            return CE_None;
-        }
-        start++;
-
-        while (isspace(*start))
-        {
-            start++;
-        }
-
-        if (STARTS_WITH_CI(start, "-inf"))
-        {
-            dfMin = -std::numeric_limits<double>::infinity();
-            end = const_cast<char *>(start + 4);
-        }
-        else
-        {
-            dfMin = CPLStrtod(start, &end);
-        }
-
-        if (end == start || *end != ',')
-        {
-            CPLError(CE_Failure, CPLE_AppDefined, "Expected a number");
-            return CE_Failure;
-        }
-        start = end + 1;
-
-        while (isspace(*start))
-        {
-            start++;
-        }
-
-        if (STARTS_WITH_CI(start, "inf"))
-        {
-            dfMax = std::numeric_limits<double>::infinity();
-            end = const_cast<char *>(start + 3);
-        }
-        else
-        {
-            dfMax = CPLStrtod(start, &end);
-        }
-
-        if (end == start || (*end != ')' && *end != ']'))
-        {
-            CPLError(CE_Failure, CPLE_AppDefined,
-                     "Interval must end with ')' or ']");
-            return CE_Failure;
-        }
-        if (*end == ')')
-        {
-            bMaxIncluded = false;
-        }
-        else
-        {
-            bMaxIncluded = true;
-        }
-
-        if (rest != nullptr)
-        {
-            *rest = end + 1;
-        }
-
-        return CE_None;
-    }
-
-    bool IsConstant() const
-    {
-        return dfMin == dfMax;
-    }
-
-    bool Contains(double x) const
-    {
-        return (x > dfMin || (bMinIncluded && x == dfMin)) &&
-               (x < dfMax || (bMaxIncluded && x == dfMax));
-    }
-};
-
 static const char pszReclassifyPixelFuncMetadata[] =
     "<PixelFunctionArgumentsList>"
     "   <Argument name='mapping' "
@@ -1886,25 +1759,13 @@ static CPLErr ReclassifyPixelFunc(void **papoSources, int nSources, void *pData,
                  "reclassify only be applied to a single source at a time");
         return CE_Failure;
     }
-
-    bool bHasNoDataValue = false;
-    double dfNoDataValue{};
+    std::optional<double> noDataValue{};
 
     const char *pszNoData = CSLFetchNameValue(papszArgs, "NoData");
     if (pszNoData != nullptr)
     {
-        bHasNoDataValue = true;
-        dfNoDataValue = CPLAtof(pszNoData);
+        noDataValue = CPLAtof(pszNoData);
     }
-
-    bool bHasDefaultValue = false;
-    double dfDefaultValue{};
-
-    std::map<double, double> oConstantMappings;
-    std::vector<std::pair<Interval, double>> aoIntervalMappings;
-
-    constexpr char MAPPING_INTERVAL_SEP_CHAR = ';';
-    constexpr char MAPPING_FROMTO_SEP_CHAR = '=';
 
     const char *pszMappings = CSLFetchNameValue(papszArgs, "mapping");
     if (pszMappings == nullptr)
@@ -1914,126 +1775,11 @@ static CPLErr ReclassifyPixelFunc(void **papoSources, int nSources, void *pData,
         return CE_Failure;
     }
 
-    const char *start = pszMappings;
-    char *end = const_cast<char *>(start);
-    while (*end != '\0')
+    gdal::Reclassifier oReclassifier;
+    if (auto eErr = oReclassifier.Init(pszMappings, noDataValue, eBufType);
+        eErr != CE_None)
     {
-        while (isspace(*start))
-        {
-            start++;
-        }
-
-        Interval sInt{};
-        bool bFromIsDefault = false;
-
-        if (STARTS_WITH_CI(start, "DEFAULT"))
-        {
-            bHasDefaultValue = true;
-            bFromIsDefault = true;
-            end = const_cast<char *>(start + 7);
-        }
-        else if (STARTS_WITH_CI(start, "NO_DATA"))
-        {
-            if (!bHasNoDataValue)
-            {
-                CPLError(
-                    CE_Failure, CPLE_AppDefined,
-                    "Value mapped from NO_DATA, but NoData value is not set");
-                return CE_Failure;
-            }
-
-            sInt.SetToConstant(dfNoDataValue);
-            end = const_cast<char *>(start + 7);
-        }
-        else
-        {
-            if (auto eErr = sInt.Parse(start, &end); eErr != CE_None)
-            {
-                return eErr;
-            }
-        }
-
-        while (isspace(*end))
-        {
-            end++;
-        }
-
-        if (*end != MAPPING_FROMTO_SEP_CHAR)
-        {
-            CPLError(CE_Failure, CPLE_AppDefined,
-                     "Failed to parse mapping (expected '%c', got '%c')",
-                     MAPPING_FROMTO_SEP_CHAR, *end);
-            return CE_Failure;
-        }
-
-        start = end + 1;
-
-        while (isspace(*start))
-        {
-            start++;
-        }
-
-        double dfDstVal{};
-        if (STARTS_WITH(start, "NO_DATA"))
-        {
-            if (!bHasNoDataValue)
-            {
-                CPLError(
-                    CE_Failure, CPLE_AppDefined,
-                    "Value mapped to NO_DATA, but NoData value is not set");
-                return CE_Failure;
-            }
-            dfDstVal = dfNoDataValue;
-            end = const_cast<char *>(start) + 7;
-        }
-        else
-        {
-            dfDstVal = CPLStrtod(start, &end);
-            if (start == end)
-            {
-                CPLError(CE_Failure, CPLE_AppDefined,
-                         "Failed to parse output value (expected number or "
-                         "NO_DATA)");
-                return CE_Failure;
-            }
-        }
-
-        while (isspace(*end))
-        {
-            end++;
-        }
-
-        if (*end != '\0' && *end != MAPPING_INTERVAL_SEP_CHAR)
-        {
-            CPLError(CE_Failure, CPLE_AppDefined,
-                     "Failed to parse mapping (expected '%c' or end of string, "
-                     "got '%c')",
-                     MAPPING_INTERVAL_SEP_CHAR, *end);
-            return CE_Failure;
-        }
-
-        if (!GDALIsValueExactAs(dfDstVal, eBufType))
-        {
-            CPLError(CE_Failure, CPLE_AppDefined,
-                     "Value %g cannot be represented as data type %s", dfDstVal,
-                     GDALGetDataTypeName(eBufType));
-            return CE_Failure;
-        }
-
-        if (bFromIsDefault)
-        {
-            dfDefaultValue = dfDstVal;
-        }
-        else if (sInt.IsConstant())
-        {
-            oConstantMappings[sInt.dfMin] = dfDstVal;
-        }
-        else
-        {
-            aoIntervalMappings.emplace_back(sInt, dfDstVal);
-        }
-
-        start = end + 1;
+        return eErr;
     }
 
     std::unique_ptr<double, VSIFreeReleaser> padfResults(
@@ -2042,42 +1788,20 @@ static CPLErr ReclassifyPixelFunc(void **papoSources, int nSources, void *pData,
         return CE_Failure;
 
     size_t ii = 0;
+    bool bSuccess = false;
     for (int iLine = 0; iLine < nYSize; ++iLine)
     {
         for (int iCol = 0; iCol < nXSize; ++iCol, ++ii)
         {
             double srcVal = GetSrcVal(papoSources[0], eSrcType, ii);
-            auto oDstValIt = oConstantMappings.find(srcVal);
-            if (oDstValIt == oConstantMappings.end())
+            padfResults.get()[iCol] =
+                oReclassifier.Reclassify(srcVal, bSuccess);
+            if (!bSuccess)
             {
-                bool bFoundInterval = false;
-                for (const auto &[sInt, dstVal] : aoIntervalMappings)
-                {
-                    if (sInt.Contains(srcVal))
-                    {
-                        padfResults.get()[iCol] = dstVal;
-                        bFoundInterval = true;
-                        break;
-                    }
-                }
-
-                if (!bFoundInterval)
-                {
-                    if (!bHasDefaultValue)
-                    {
-                        CPLError(
-                            CE_Failure, CPLE_AppDefined,
-                            "Encountered value %g with no specified mapping",
-                            srcVal);
-                        return CE_Failure;
-                    }
-
-                    padfResults.get()[iCol] = dfDefaultValue;
-                }
-            }
-            else
-            {
-                padfResults.get()[iCol] = oDstValIt->second;
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Encountered value %g with no specified mapping",
+                         srcVal);
+                return CE_Failure;
             }
         }
 

--- a/frmts/vrt/vrtreclassifier.cpp
+++ b/frmts/vrt/vrtreclassifier.cpp
@@ -1,0 +1,294 @@
+/******************************************************************************
+*
+ * Project:  Virtual GDAL Datasets
+ * Purpose:  Implementation of Reclassifier
+ * Author:   Daniel Baston
+ *
+ ******************************************************************************
+ * Copyright (c) 2025, ISciences LLC
+ *
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#include "cpl_conv.h"
+#include "vrtreclassifier.h"
+
+#include <limits>
+
+namespace gdal
+{
+
+CPLErr Reclassifier::Interval::Parse(const char *s, char **rest)
+{
+    const char *start = s;
+
+    while (isspace(*start))
+    {
+        start++;
+    }
+
+    char *end;
+
+    if (*start == '(')
+    {
+        bMinIncluded = false;
+    }
+    else if (*start == '[')
+    {
+        bMinIncluded = true;
+    }
+    else
+    {
+        double dfVal = CPLStrtod(start, &end);
+
+        if (end == start)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Interval must start with '(' or ']'");
+            return CE_Failure;
+        }
+
+        SetToConstant(dfVal);
+
+        if (rest != nullptr)
+        {
+            *rest = end;
+        }
+
+        return CE_None;
+    }
+    start++;
+
+    while (isspace(*start))
+    {
+        start++;
+    }
+
+    if (STARTS_WITH_CI(start, "-inf"))
+    {
+        dfMin = -std::numeric_limits<double>::infinity();
+        end = const_cast<char *>(start + 4);
+    }
+    else
+    {
+        dfMin = CPLStrtod(start, &end);
+    }
+
+    if (end == start || *end != ',')
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Expected a number");
+        return CE_Failure;
+    }
+    start = end + 1;
+
+    while (isspace(*start))
+    {
+        start++;
+    }
+
+    if (STARTS_WITH_CI(start, "inf"))
+    {
+        dfMax = std::numeric_limits<double>::infinity();
+        end = const_cast<char *>(start + 3);
+    }
+    else
+    {
+        dfMax = CPLStrtod(start, &end);
+    }
+
+    if (end == start || (*end != ')' && *end != ']'))
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Interval must end with ')' or ']");
+        return CE_Failure;
+    }
+    if (*end == ')')
+    {
+        bMaxIncluded = false;
+    }
+    else
+    {
+        bMaxIncluded = true;
+    }
+
+    if (rest != nullptr)
+    {
+        *rest = end + 1;
+    }
+
+    return CE_None;
+}
+
+void Reclassifier::Interval::SetToConstant(double dfVal)
+{
+    dfMin = dfVal;
+    dfMax = dfVal;
+    bMinIncluded = true;
+    bMaxIncluded = true;
+}
+
+void Reclassifier::AddMapping(const Interval &interval, double dfDstVal)
+{
+    if (interval.IsConstant())
+    {
+        m_oConstantMappings[interval.dfMin] = dfDstVal;
+    }
+    else
+    {
+        m_aoIntervalMappings.emplace_back(interval, dfDstVal);
+    }
+}
+
+CPLErr Reclassifier::Init(const char *pszText,
+                          std::optional<double> noDataValue,
+                          GDALDataType eBufType)
+{
+    const char *start = pszText;
+    char *end = const_cast<char *>(start);
+
+    while (*end != '\0')
+    {
+        while (isspace(*start))
+        {
+            start++;
+        }
+
+        Interval sInt{};
+        bool bFromIsDefault = false;
+
+        if (STARTS_WITH_CI(start, "DEFAULT"))
+        {
+            bFromIsDefault = true;
+            end = const_cast<char *>(start + 7);
+        }
+        else if (STARTS_WITH_CI(start, "NO_DATA"))
+        {
+            if (!noDataValue.has_value())
+            {
+                CPLError(
+                    CE_Failure, CPLE_AppDefined,
+                    "Value mapped from NO_DATA, but NoData value is not set");
+                return CE_Failure;
+            }
+
+            sInt.SetToConstant(noDataValue.value());
+            end = const_cast<char *>(start + 7);
+        }
+        else
+        {
+            if (auto eErr = sInt.Parse(start, &end); eErr != CE_None)
+            {
+                return eErr;
+            }
+        }
+
+        while (isspace(*end))
+        {
+            end++;
+        }
+
+        if (*end != MAPPING_FROMTO_SEP_CHAR)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Failed to parse mapping (expected '%c', got '%c')",
+                     MAPPING_FROMTO_SEP_CHAR, *end);
+            return CE_Failure;
+        }
+
+        start = end + 1;
+
+        while (isspace(*start))
+        {
+            start++;
+        }
+
+        double dfDstVal{};
+        if (STARTS_WITH(start, "NO_DATA"))
+        {
+            if (!noDataValue.has_value())
+            {
+                CPLError(
+                    CE_Failure, CPLE_AppDefined,
+                    "Value mapped to NO_DATA, but NoData value is not set");
+                return CE_Failure;
+            }
+            dfDstVal = noDataValue.value();
+            end = const_cast<char *>(start) + 7;
+        }
+        else
+        {
+            dfDstVal = CPLStrtod(start, &end);
+            if (start == end)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Failed to parse output value (expected number or "
+                         "NO_DATA)");
+                return CE_Failure;
+            }
+        }
+
+        while (isspace(*end))
+        {
+            end++;
+        }
+
+        if (*end != '\0' && *end != MAPPING_INTERVAL_SEP_CHAR)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Failed to parse mapping (expected '%c' or end of string, "
+                     "got '%c')",
+                     MAPPING_INTERVAL_SEP_CHAR, *end);
+            return CE_Failure;
+        }
+
+        if (!GDALIsValueExactAs(dfDstVal, eBufType))
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Value %g cannot be represented as data type %s", dfDstVal,
+                     GDALGetDataTypeName(eBufType));
+            return CE_Failure;
+        }
+
+        if (bFromIsDefault)
+        {
+            SetDefaultValue(dfDstVal);
+        }
+        else
+        {
+            AddMapping(sInt, dfDstVal);
+        }
+
+        start = end + 1;
+    }
+
+    return CE_None;
+}
+
+double Reclassifier::Reclassify(double srcVal, bool &bFoundInterval) const
+{
+    bFoundInterval = false;
+    auto oDstValIt = m_oConstantMappings.find(srcVal);
+    if (oDstValIt != m_oConstantMappings.end())
+    {
+        bFoundInterval = true;
+        return oDstValIt->second;
+    }
+
+    for (const auto &[sInt, dstVal] : m_aoIntervalMappings)
+    {
+        if (sInt.Contains(srcVal))
+        {
+            bFoundInterval = true;
+            return dstVal;
+        }
+    }
+
+    if (m_defaultValue.has_value())
+    {
+        bFoundInterval = true;
+        return m_defaultValue.value();
+    }
+
+    return CE_None;
+}
+}  // namespace gdal

--- a/frmts/vrt/vrtreclassifier.cpp
+++ b/frmts/vrt/vrtreclassifier.cpp
@@ -312,4 +312,5 @@ double Reclassifier::Reclassify(double srcVal, bool &bFoundInterval) const
 
     return CE_None;
 }
+
 }  // namespace gdal

--- a/frmts/vrt/vrtreclassifier.h
+++ b/frmts/vrt/vrtreclassifier.h
@@ -90,12 +90,12 @@ class Reclassifier
     CPLErr Init(const char *pszText, std::optional<double> noDataValue,
                 GDALDataType eBufType);
 
-    void SetDefaultValue(double value)
-    {
-        m_defaultValue = value;
-    }
-
-    void AddMapping(const Interval &interval, double dfDstVal);
+    /** Set a mapping between an interval and (optionally) a destination value.
+     *  If no destination value is provided, values matching the interval
+     *  will be passed through unmodified. It will not be verified that these values
+     *  fit within the destination data type.
+     */
+    void AddMapping(const Interval &interval, std::optional<double> dfDstVal);
 
     /** Reclassify a value
      *
@@ -105,10 +105,27 @@ class Reclassifier
      */
     double Reclassify(double srcVal, bool &bFoundInterval) const;
 
-  private:
+    /** If true, values not matched by any interval will be
+     *  returned unmodified. It will not be verified that these values
+     *  fit within the destination data type.
+     */
+    void SetDefaultPassThrough(bool value)
+    {
+        m_defaultPassThrough = value;
+    }
+
+    /** Sets a default value for any value not matched by any interval.
+     */
+    void SetDefaultValue(double value)
+    {
+        m_defaultValue = value;
+    }
+
     std::map<double, double> m_oConstantMappings{};
-    std::vector<std::pair<Interval, double>> m_aoIntervalMappings{};
+    std::vector<std::pair<Interval, std::optional<double>>>
+        m_aoIntervalMappings{};
     std::optional<double> m_defaultValue{};
+    bool m_defaultPassThrough{false};
 };
 
 /*! @endcond */

--- a/frmts/vrt/vrtreclassifier.h
+++ b/frmts/vrt/vrtreclassifier.h
@@ -23,21 +23,36 @@
 namespace gdal
 {
 
-/*! @cond Doxygen_Suppress */
-
+/**
+ * Class to manage reclassification of pixel values
+ */
 class Reclassifier
 {
   public:
+    /// Character separating elements in a list of mapping
     static constexpr char MAPPING_INTERVAL_SEP_CHAR = ';';
+
+    /// Character separating source interval from target value
     static constexpr char MAPPING_FROMTO_SEP_CHAR = '=';
 
+    /**
+     * Internal struct to hold an interval of values to be reclassified
+     */
     struct Interval
     {
+        /// minimum value of range
         double dfMin;
+
+        /// maximum value of range
         double dfMax;
+
+        /// whether the minimum value is included (closed interval)
         bool bMinIncluded;
+
+        /// whether the maximum value is included (closed interval)
         bool bMaxIncluded;
 
+        /// Set the interval to represent a single value [x,x]
         void SetToConstant(double dfVal);
 
         /** Parse an interval. The interval may be either a single constant value,
@@ -50,11 +65,13 @@ class Reclassifier
          */
         CPLErr Parse(const char *pszText, char **end);
 
+        /// Returns true of the interval represents a single value [x,x]
         bool IsConstant() const
         {
             return dfMin == dfMax;
         }
 
+        /// Returns true if the interval contains a value
         bool Contains(double x) const
         {
             return (x > dfMin || (bMinIncluded && x == dfMin)) &&
@@ -121,13 +138,18 @@ class Reclassifier
         m_defaultValue = value;
     }
 
+    /// mapping of constant inputs to outputs
     std::map<double, double> m_oConstantMappings{};
+
+    /// mapping of ranges to outputs
     std::vector<std::pair<Interval, std::optional<double>>>
         m_aoIntervalMappings{};
+
+    /// output value for inputs not matching any Interval
     std::optional<double> m_defaultValue{};
+
+    /// whether to pass unmatched inputs through unmodified
     bool m_defaultPassThrough{false};
 };
-
-/*! @endcond */
 
 }  // namespace gdal

--- a/frmts/vrt/vrtreclassifier.h
+++ b/frmts/vrt/vrtreclassifier.h
@@ -1,0 +1,116 @@
+/******************************************************************************
+*
+ * Project:  Virtual GDAL Datasets
+ * Purpose:  Implementation of Reclassifier
+ * Author:   Daniel Baston
+ *
+ ******************************************************************************
+ * Copyright (c) 2025, ISciences LLC
+ *
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#pragma once
+
+#include "gdal.h"
+#include "cpl_error.h"
+
+#include <map>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace gdal
+{
+
+/*! @cond Doxygen_Suppress */
+
+class Reclassifier
+{
+  public:
+    static constexpr char MAPPING_INTERVAL_SEP_CHAR = ';';
+    static constexpr char MAPPING_FROMTO_SEP_CHAR = '=';
+
+    struct Interval
+    {
+        double dfMin;
+        double dfMax;
+        bool bMinIncluded;
+        bool bMaxIncluded;
+
+        void SetToConstant(double dfVal);
+
+        /** Parse an interval. The interval may be either a single constant value,
+         *  or two comma-separated values enclosed by parentheses/brackets to
+         *  represent open/closed intervals.
+         *
+         * @param pszText string from which to parse an interval
+         * @param end pointer to first non-consumed character
+         * @return CE_None on success, CE_Failure otherwise
+         */
+        CPLErr Parse(const char *pszText, char **end);
+
+        bool IsConstant() const
+        {
+            return dfMin == dfMax;
+        }
+
+        bool Contains(double x) const
+        {
+            return (x > dfMin || (bMinIncluded && x == dfMin)) &&
+                   (x < dfMax || (bMaxIncluded && x == dfMax));
+        }
+    };
+
+    /** Initialize a Reclassifier from text. The text consists of a series of
+     *  SOURCE=DEST mappings, separated by a semicolon.
+     *
+     *  Each SOURCE element much be one of:
+     *  - a constant value
+     *  - a range of values, such as (3, 4] or [7, inf]
+     *  - the value NO_DATA, for which the provided NoData value will be
+     *    substituted
+     *  - the value DEFAULT, to define a DEST for any value that does not
+     *    match another SOURCE mapping
+     *
+     *  Each DEST element must be one of:
+     *  - a constant value
+     *  - the value NO_DATA, for which the provided NoData value will be
+     *    substituted
+     *
+     *  An error will be returned if:
+     *  - NO_DATA is used by a NoData value is not defined.
+     *  - a DEST value does not fit into the destination data type
+     *
+     * @param pszText text to parse
+     * @param noDataValue NoData value
+     * @param eBufType Destination data type
+     * @return CE_None if no errors occurred, CE_Failure otherwise
+     */
+    CPLErr Init(const char *pszText, std::optional<double> noDataValue,
+                GDALDataType eBufType);
+
+    void SetDefaultValue(double value)
+    {
+        m_defaultValue = value;
+    }
+
+    void AddMapping(const Interval &interval, double dfDstVal);
+
+    /** Reclassify a value
+     *
+     * @param srcVal the value to reclassify
+     * @param bFoundInterval set to True if the value could be reclassified
+     * @return the reclassified value
+     */
+    double Reclassify(double srcVal, bool &bFoundInterval) const;
+
+  private:
+    std::map<double, double> m_oConstantMappings{};
+    std::vector<std::pair<Interval, double>> m_aoIntervalMappings{};
+    std::optional<double> m_defaultValue{};
+};
+
+/*! @endcond */
+
+}  // namespace gdal


### PR DESCRIPTION
Made a few changes after reviewing comparable interfaces in 
SAGA: https://saga-gis.sourceforge.io/saga_tool_doc/2.2.5/grid_tools_15.html
GRASS: https://grass.osgeo.org/grass-stable/manuals/r.reclass.html
QGIS: https://docs.qgis.org/3.40/en/docs/user_manual/processing_algs/qgis/rasteranalysis.html#reclassify-by-table
ArcGIS: https://pro.arcgis.com/en/pro-app/latest/tool-reference/spatial-analyst/reclassify.htm
gdal_reclassify: https://github.com/chiatt/gdal_reclassify
GDAL reclassify CLI: https://github.com/sacridini/reclassify_cli/tree/master
terra reclassify: https://search.r-project.org/CRAN/refmans/terra/html/classify.html

Simplifies the code somewhat by removing the "default" argument and moving it into the mapping table. Allows `NO_DATA` to appear on either side of an entry in the mapping table, and `PASS_THROUGH` to appear on the right hand side.