### PR TITLE
Rename 'gdal raster fillnodata' as 'gdal raster fill-nodata' and 'gdal raster pixelinfo' as 'gdal raster pixel-info'

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -27,7 +27,7 @@ add_library(
   gdalalg_raster_edit.cpp
   gdalalg_raster_contour.cpp
   gdalalg_raster_footprint.cpp
-  gdalalg_raster_fillnodata.cpp
+  gdalalg_raster_fill_nodata.cpp
   gdalalg_raster_hillshade.cpp
   gdalalg_raster_index.cpp
   gdalalg_raster_mosaic.cpp

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -32,7 +32,7 @@ add_library(
   gdalalg_raster_index.cpp
   gdalalg_raster_mosaic.cpp
   gdalalg_raster_pipeline.cpp
-  gdalalg_raster_pixelinfo.cpp
+  gdalalg_raster_pixel_info.cpp
   gdalalg_raster_polygonize.cpp
   gdalalg_raster_overview_add.cpp
   gdalalg_raster_overview_delete.cpp

--- a/apps/gdalalg_raster.cpp
+++ b/apps/gdalalg_raster.cpp
@@ -24,7 +24,7 @@
 #include "gdalalg_raster_edit.h"
 #include "gdalalg_raster_contour.h"
 #include "gdalalg_raster_footprint.h"
-#include "gdalalg_raster_fillnodata.h"
+#include "gdalalg_raster_fill_nodata.h"
 #include "gdalalg_raster_hillshade.h"
 #include "gdalalg_raster_index.h"
 #include "gdalalg_raster_mosaic.h"

--- a/apps/gdalalg_raster.cpp
+++ b/apps/gdalalg_raster.cpp
@@ -30,7 +30,7 @@
 #include "gdalalg_raster_mosaic.h"
 #include "gdalalg_raster_overview.h"
 #include "gdalalg_raster_pipeline.h"
-#include "gdalalg_raster_pixelinfo.h"
+#include "gdalalg_raster_pixel_info.h"
 #include "gdalalg_raster_polygonize.h"
 #include "gdalalg_raster_reproject.h"
 #include "gdalalg_raster_resize.h"

--- a/apps/gdalalg_raster_fill_nodata.cpp
+++ b/apps/gdalalg_raster_fill_nodata.cpp
@@ -10,7 +10,7 @@
  * SPDX-License-Identifier: MIT
  ****************************************************************************/
 
-#include "gdalalg_raster_fillnodata.h"
+#include "gdalalg_raster_fill_nodata.h"
 
 #include "gdal_priv.h"
 #include "gdal_utils.h"

--- a/apps/gdalalg_raster_fill_nodata.h
+++ b/apps/gdalalg_raster_fill_nodata.h
@@ -1,7 +1,7 @@
 /******************************************************************************
  *
  * Project:  GDAL
- * Purpose:  "gdal raster fillnodata" standalone command
+ * Purpose:  "gdal raster fill-nodata" standalone command
  * Author:   Alessandro Pasotti <elpaso at itopen dot it>
  *
  ******************************************************************************
@@ -10,8 +10,8 @@
  * SPDX-License-Identifier: MIT
  ****************************************************************************/
 
-#ifndef GDALALG_RASTER_FILLNODATA_INCLUDED
-#define GDALALG_RASTER_FILLNODATA_INCLUDED
+#ifndef GDALALG_RASTER_FILL_NODATA_INCLUDED
+#define GDALALG_RASTER_FILL_NODATA_INCLUDED
 
 #include "gdalalg_raster_pipeline.h"
 
@@ -25,11 +25,11 @@ class GDALRasterFillNodataAlgorithm /* non final */
     : public GDALAlgorithm
 {
   public:
-    static constexpr const char *NAME = "fillnodata";
+    static constexpr const char *NAME = "fill-nodata";
     static constexpr const char *DESCRIPTION =
         "Fill nodata raster regions by interpolation from edges.";
     static constexpr const char *HELP_URL =
-        "/programs/gdal_raster_fillnodata.html";
+        "/programs/gdal_raster_fill_nodata.html";
 
     explicit GDALRasterFillNodataAlgorithm() noexcept;
 

--- a/apps/gdalalg_raster_pipeline.cpp
+++ b/apps/gdalalg_raster_pipeline.cpp
@@ -17,7 +17,6 @@
 #include "gdalalg_raster_clip.h"
 #include "gdalalg_raster_color_map.h"
 #include "gdalalg_raster_edit.h"
-#include "gdalalg_raster_fillnodata.h"
 #include "gdalalg_raster_hillshade.h"
 #include "gdalalg_raster_reproject.h"
 #include "gdalalg_raster_resize.h"

--- a/apps/gdalalg_raster_pixel_info.cpp
+++ b/apps/gdalalg_raster_pixel_info.cpp
@@ -10,7 +10,7 @@
  * SPDX-License-Identifier: MIT
  ****************************************************************************/
 
-#include "gdalalg_raster_pixelinfo.h"
+#include "gdalalg_raster_pixel_info.h"
 
 #include "cpl_conv.h"
 #include "cpl_json.h"

--- a/apps/gdalalg_raster_pixel_info.h
+++ b/apps/gdalalg_raster_pixel_info.h
@@ -24,11 +24,11 @@
 class GDALRasterPixelInfoAlgorithm final : public GDALAlgorithm
 {
   public:
-    static constexpr const char *NAME = "pixelinfo";
+    static constexpr const char *NAME = "pixel-info";
     static constexpr const char *DESCRIPTION =
         "Return information on a pixel of a raster dataset.";
     static constexpr const char *HELP_URL =
-        "/programs/gdal_raster_pixelinfo.html";
+        "/programs/gdal_raster_pixel_info.html";
 
     GDALRasterPixelInfoAlgorithm();
 

--- a/autotest/utilities/test_gdalalg_raster_fill_nodata.py
+++ b/autotest/utilities/test_gdalalg_raster_fill_nodata.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 ###############################################################################
 # Project:  GDAL/OGR Test Suite
-# Purpose:  'gdal raster fillnodata' testing
+# Purpose:  'gdal raster fill-nodata' testing
 # Author:   Alessandro Pasotti <elpaso at itopen dot it>
 #
 ###############################################################################
@@ -21,10 +21,10 @@ gdaltest.importorskip_gdal_array()
 
 
 def get_alg():
-    return gdal.GetGlobalAlgorithmRegistry()["raster"]["fillnodata"]
+    return gdal.GetGlobalAlgorithmRegistry()["raster"]["fill-nodata"]
 
 
-def test_gdalalg_raster_fillnodata_cannot_open_file():
+def test_gdalalg_raster_fill_nodata_cannot_open_file():
 
     alg = get_alg()
     alg["input"] = "/i_do/not/exist/in.tif"
@@ -37,7 +37,7 @@ def test_gdalalg_raster_fillnodata_cannot_open_file():
 
 
 def run_alg(alg, tmp_path, tmp_vsimem):
-    result_tif = str(tmp_path / "test_gdal_fillnodata_1.tif")
+    result_tif = str(tmp_path / "test_gdal_fill_nodata_1.tif")
     tmp_filename = str(tmp_vsimem / "tmp.tif")
     gdal.FileFromMemBuffer(
         tmp_filename, open("../gcore/data/nodata_byte.tif", "rb").read()
@@ -64,7 +64,7 @@ def run_alg(alg, tmp_path, tmp_vsimem):
 
 
 @pytest.mark.parametrize("creation_option", ({}, {"TILED": "YES"}, {"COMPRESS": "LZW"}))
-def test_gdalalg_raster_fillnodata(tmp_path, tmp_vsimem, creation_option):
+def test_gdalalg_raster_fill_nodata(tmp_path, tmp_vsimem, creation_option):
 
     alg = get_alg()
     alg["creation-option"] = creation_option
@@ -84,7 +84,7 @@ def test_gdalalg_raster_fillnodata(tmp_path, tmp_vsimem, creation_option):
     del ds
 
 
-def test_gdalalg_raster_fillnodata_overwrite(tmp_path, tmp_vsimem):
+def test_gdalalg_raster_fill_nodata_overwrite(tmp_path, tmp_vsimem):
 
     alg = get_alg()
     ds = run_alg(alg, tmp_path, tmp_vsimem)
@@ -102,7 +102,7 @@ def test_gdalalg_raster_fillnodata_overwrite(tmp_path, tmp_vsimem):
     del ds
 
 
-def test_gdalalg_raster_fillnodata_smoothing(tmp_path, tmp_vsimem):
+def test_gdalalg_raster_fill_nodata_smoothing(tmp_path, tmp_vsimem):
 
     alg = get_alg()
     alg["s"] = 2
@@ -111,7 +111,7 @@ def test_gdalalg_raster_fillnodata_smoothing(tmp_path, tmp_vsimem):
     del ds
 
 
-def test_gdalalg_raster_fillnodata_max_distance(tmp_path, tmp_vsimem):
+def test_gdalalg_raster_fill_nodata_max_distance(tmp_path, tmp_vsimem):
 
     alg = get_alg()
     alg["d"] = 1
@@ -120,7 +120,7 @@ def test_gdalalg_raster_fillnodata_max_distance(tmp_path, tmp_vsimem):
     del ds
 
 
-def test_gdalalg_raster_fillnodata_strategy(tmp_path, tmp_vsimem):
+def test_gdalalg_raster_fill_nodata_strategy(tmp_path, tmp_vsimem):
 
     alg = get_alg()
     alg["strategy"] = "invdist"
@@ -135,7 +135,7 @@ def test_gdalalg_raster_fillnodata_strategy(tmp_path, tmp_vsimem):
     del ds
 
 
-def test_gdalalg_raster_fillnodata_mask(tmp_path, tmp_vsimem):
+def test_gdalalg_raster_fill_nodata_mask(tmp_path, tmp_vsimem):
 
     # Create a mask
     mask_tif = str(tmp_vsimem / "mask.tif")

--- a/autotest/utilities/test_gdalalg_raster_pixel_info.py
+++ b/autotest/utilities/test_gdalalg_raster_pixel_info.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 ###############################################################################
 # Project:  GDAL/OGR Test Suite
-# Purpose:  'gdal raster pixelinfo' testing
+# Purpose:  'gdal raster pixel-info' testing
 # Author:   Even Rouault <even dot rouault @ spatialys.com>
 #
 ###############################################################################
@@ -25,10 +25,10 @@ pytestmark = pytest.mark.skipif(
 
 
 def get_alg():
-    return gdal.GetGlobalAlgorithmRegistry()["raster"]["pixelinfo"]
+    return gdal.GetGlobalAlgorithmRegistry()["raster"]["pixel-info"]
 
 
-def test_gdalalg_raster_pixelinfo_missing_position():
+def test_gdalalg_raster_pixel_info_missing_position():
 
     alg = get_alg()
     alg["dataset"] = "../gcore/data/byte.tif"
@@ -36,14 +36,14 @@ def test_gdalalg_raster_pixelinfo_missing_position():
         alg.Run()
 
 
-def test_gdalalg_raster_pixelinfo_invalid_position():
+def test_gdalalg_raster_pixel_info_invalid_position():
 
     alg = get_alg()
     with pytest.raises(Exception, match="even number of values must be specified"):
         alg["position"] = 5
 
 
-def test_gdalalg_raster_pixelinfo_byte_json():
+def test_gdalalg_raster_pixel_info_byte_json():
 
     alg = get_alg()
     alg["dataset"] = "../gcore/data/byte.tif"
@@ -70,7 +70,7 @@ def test_gdalalg_raster_pixelinfo_byte_json():
     }
 
 
-def test_gdalalg_raster_pixelinfo_float64_json():
+def test_gdalalg_raster_pixel_info_float64_json():
 
     alg = get_alg()
     alg["dataset"] = "../gcore/data/float64.tif"
@@ -97,7 +97,7 @@ def test_gdalalg_raster_pixelinfo_float64_json():
     }
 
 
-def test_gdalalg_raster_pixelinfo_complex_json():
+def test_gdalalg_raster_pixel_info_complex_json():
 
     alg = get_alg()
     alg["dataset"] = "../gcore/data/cfloat32.tif"
@@ -127,7 +127,7 @@ def test_gdalalg_raster_pixelinfo_complex_json():
     }
 
 
-def test_gdalalg_raster_pixelinfo_byte_csv():
+def test_gdalalg_raster_pixel_info_byte_csv():
 
     alg = get_alg()
     alg["dataset"] = "../gcore/data/byte.tif"
@@ -140,7 +140,7 @@ def test_gdalalg_raster_pixelinfo_byte_csv():
     )
 
 
-def test_gdalalg_raster_pixelinfo_out_of_raster_csv():
+def test_gdalalg_raster_pixel_info_out_of_raster_csv():
 
     alg = get_alg()
     alg["dataset"] = "../gcore/data/byte.tif"
@@ -153,7 +153,7 @@ def test_gdalalg_raster_pixelinfo_out_of_raster_csv():
     )
 
 
-def test_gdalalg_raster_pixelinfo_complex_csv():
+def test_gdalalg_raster_pixel_info_complex_csv():
 
     alg = get_alg()
     alg["dataset"] = "../gcore/data/cfloat32.tif"
@@ -166,7 +166,7 @@ def test_gdalalg_raster_pixelinfo_complex_csv():
     )
 
 
-def test_gdalalg_raster_pixelinfo_complex_out_of_raster_csv():
+def test_gdalalg_raster_pixel_info_complex_out_of_raster_csv():
 
     alg = get_alg()
     alg["dataset"] = "../gcore/data/cfloat32.tif"
@@ -179,7 +179,7 @@ def test_gdalalg_raster_pixelinfo_complex_out_of_raster_csv():
     )
 
 
-def test_gdalalg_raster_pixelinfo_invalid_overview():
+def test_gdalalg_raster_pixel_info_invalid_overview():
 
     alg = get_alg()
     alg["dataset"] = "../gcore/data/byte.tif"
@@ -191,7 +191,7 @@ def test_gdalalg_raster_pixelinfo_invalid_overview():
         alg.Run()
 
 
-def test_gdalalg_raster_pixelinfo_invalid_overview_bis():
+def test_gdalalg_raster_pixel_info_invalid_overview_bis():
 
     src_ds = gdal.Translate("", "../gcore/data/byte.tif", format="MEM")
     src_ds.BuildOverviews("NEAR", [2])
@@ -206,7 +206,7 @@ def test_gdalalg_raster_pixelinfo_invalid_overview_bis():
         alg.Run()
 
 
-def test_gdalalg_raster_pixelinfo_overview():
+def test_gdalalg_raster_pixel_info_overview():
 
     src_ds = gdal.Translate("", "../gcore/data/byte.tif", format="MEM")
     src_ds.BuildOverviews("NEAR", [2])
@@ -237,7 +237,7 @@ def test_gdalalg_raster_pixelinfo_overview():
     }
 
 
-def test_gdalalg_raster_pixelinfo_unscaled():
+def test_gdalalg_raster_pixel_info_unscaled():
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
     src_ds.GetRasterBand(1).Fill(1)
@@ -268,7 +268,7 @@ def test_gdalalg_raster_pixelinfo_unscaled():
     }
 
 
-def test_gdalalg_raster_pixelinfo_unscaled_csv():
+def test_gdalalg_raster_pixel_info_unscaled_csv():
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1, 1, gdal.GDT_Float32)
     src_ds.GetRasterBand(1).Fill(1.5)
@@ -286,7 +286,7 @@ def test_gdalalg_raster_pixelinfo_unscaled_csv():
     )
 
 
-def test_gdalalg_raster_pixelinfo_missing_crs():
+def test_gdalalg_raster_pixel_info_missing_crs():
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
 
@@ -302,7 +302,7 @@ def test_gdalalg_raster_pixelinfo_missing_crs():
         alg.Run()
 
 
-def test_gdalalg_raster_pixelinfo_missing_gt():
+def test_gdalalg_raster_pixel_info_missing_gt():
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
     srs = osr.SpatialReference("WGS84")
@@ -317,7 +317,7 @@ def test_gdalalg_raster_pixelinfo_missing_gt():
         alg.Run()
 
 
-def test_gdalalg_raster_pixelinfo_wrong_gt():
+def test_gdalalg_raster_pixel_info_wrong_gt():
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
     srs = osr.SpatialReference("WGS84")
@@ -333,7 +333,7 @@ def test_gdalalg_raster_pixelinfo_wrong_gt():
         alg.Run()
 
 
-def test_gdalalg_raster_pixelinfo_position_crs_dataset():
+def test_gdalalg_raster_pixel_info_position_crs_dataset():
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
     srs = osr.SpatialReference("WGS84")
@@ -368,7 +368,7 @@ def test_gdalalg_raster_pixelinfo_position_crs_dataset():
     }
 
 
-def test_gdalalg_raster_pixelinfo_position_crs():
+def test_gdalalg_raster_pixel_info_position_crs():
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
     srs = osr.SpatialReference("WGS84")
@@ -403,7 +403,7 @@ def test_gdalalg_raster_pixelinfo_position_crs():
     }
 
 
-def test_gdalalg_raster_pixelinfo_non_epsg_crs():
+def test_gdalalg_raster_pixel_info_non_epsg_crs():
 
     src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
     srs = osr.SpatialReference("+proj=utm +zone=17")
@@ -437,7 +437,7 @@ def test_gdalalg_raster_pixelinfo_non_epsg_crs():
     }
 
 
-def test_gdalalg_raster_pixelinfo_files():
+def test_gdalalg_raster_pixel_info_files():
 
     alg = get_alg()
     alg["dataset"] = "../gcore/data/byte.vrt"
@@ -474,10 +474,11 @@ def gdal_path():
     return test_cli_utilities.get_gdal_path()
 
 
-def test_gdalalg_raster_pixelinfo_from_command_line(gdal_path):
+def test_gdalalg_raster_pixel_info_from_command_line(gdal_path):
 
     ret = gdaltest.runexternal(
-        f"{gdal_path} raster pixelinfo ../gcore/data/byte.tif", strin="5.5 10.5 foo bar"
+        f"{gdal_path} raster pixel-info ../gcore/data/byte.tif",
+        strin="5.5 10.5 foo bar",
     )
     assert json.loads(ret) == {
         "type": "FeatureCollection",
@@ -500,10 +501,10 @@ def test_gdalalg_raster_pixelinfo_from_command_line(gdal_path):
     }
 
 
-def test_gdalalg_raster_pixelinfo_from_command_line_csv(gdal_path):
+def test_gdalalg_raster_pixel_info_from_command_line_csv(gdal_path):
 
     ret = gdaltest.runexternal(
-        f"{gdal_path} raster pixelinfo --of=csv ../gcore/data/byte.tif",
+        f"{gdal_path} raster pixel-info --of=csv ../gcore/data/byte.tif",
         strin="5.5 10.5 foo bar",
     ).replace("\r\n", "\n")
     assert (

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -316,8 +316,8 @@ man_pages = [
         1,
     ),
     (
-        "programs/gdal_raster_fillnodata",
-        "gdal-raster-fillnodata",
+        "programs/gdal_raster_fill_nodata",
+        "gdal-raster-fill-nodata",
         "Fill nodata values in a raster dataset",
         [author_elpaso],
         1,

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -372,8 +372,8 @@ man_pages = [
         1,
     ),
     (
-        "programs/gdal_raster_pixelinfo",
-        "gdal-raster-pixelinfo",
+        "programs/gdal_raster_pixel_info",
+        "gdal-raster-pixel-info",
         "Return information on a pixel of a raster dataset",
         [author_evenr],
         1,

--- a/doc/source/programs/gdal_raster.rst
+++ b/doc/source/programs/gdal_raster.rst
@@ -29,7 +29,7 @@ Available sub-commands
 - :ref:`gdal_raster_convert`
 - :ref:`gdal_raster_create`
 - :ref:`gdal_raster_footprint`
-- :ref:`gdal_raster_fillnodata`
+- :ref:`gdal_raster_fill_nodata`
 - :ref:`gdal_raster_hillshade`
 - :ref:`gdal_raster_index`
 - :ref:`gdal_raster_mosaic`

--- a/doc/source/programs/gdal_raster.rst
+++ b/doc/source/programs/gdal_raster.rst
@@ -35,7 +35,7 @@ Available sub-commands
 - :ref:`gdal_raster_mosaic`
 - :ref:`gdal_raster_overview`
 - :ref:`gdal_raster_pipeline`
-- :ref:`gdal_raster_pixelinfo`
+- :ref:`gdal_raster_pixel_info`
 - :ref:`gdal_raster_polygonize`
 - :ref:`gdal_raster_reproject`
 - :ref:`gdal_raster_resize`

--- a/doc/source/programs/gdal_raster_fill_nodata.rst
+++ b/doc/source/programs/gdal_raster_fill_nodata.rst
@@ -1,7 +1,7 @@
-.. _gdal_raster_fillnodata:
+.. _gdal_raster_fill_nodata:
 
 ================================================================================
-``gdal raster fillnodata``
+``gdal raster fill-nodata``
 ================================================================================
 
 .. versionadded:: 3.11
@@ -10,17 +10,17 @@
 
     Fill nodata raster regions by interpolation from edges
 
-.. Index:: gdal raster fillnodata
+.. Index:: gdal raster fill-nodata
 
 Synopsis
 --------
 
-.. program-output:: gdal raster fillnodata --help-doc
+.. program-output:: gdal raster fill-nodata --help-doc
 
 Description
 -----------
 
-:program:`gdal raster fillnodata` fills nodata areas by interpolating
+:program:`gdal raster fill-nodata` fills nodata areas by interpolating
 from valid pixels around the edges of the area.
 
 The following options are available:
@@ -73,6 +73,6 @@ Examples
 
    .. code-block:: bash
 
-    gdal raster fillnodata -b 2 --max-distance 50 --smoothing-iterations 3 \
+    gdal raster fill-nodata -b 2 --max-distance 50 --smoothing-iterations 3 \
         --strategy nearest --mask mask.tif \
         input.tif output.tif

--- a/doc/source/programs/gdal_raster_pixel_info.rst
+++ b/doc/source/programs/gdal_raster_pixel_info.rst
@@ -1,7 +1,7 @@
-.. _gdal_raster_pixelinfo:
+.. _gdal_raster_pixel_info:
 
 ================================================================================
-``gdal raster pixelinfo``
+``gdal raster pixel-info``
 ================================================================================
 
 .. versionadded:: 3.11
@@ -10,17 +10,17 @@
 
     Return information on a pixel of a raster dataset
 
-.. Index:: gdal raster pixelinfo
+.. Index:: gdal raster pixel-info
 
 Synopsis
 --------
 
-.. program-output:: gdal raster pixelinfo --help-doc
+.. program-output:: gdal raster pixel-info --help-doc
 
 Description
 -----------
 
-:program:`gdal raster pixelinfo` provide a mechanism to query information about
+:program:`gdal raster pixel-info` provide a mechanism to query information about
 a pixel given its location in one of a variety of coordinate systems.
 
 It supports outputting either as GeoJSON or CSV.
@@ -103,23 +103,23 @@ Examples
 .. example::
    :title: Reporting on pixel column=5, line=10 on the file :file:`byte.tif`
 
-   .. command-output:: gdal raster pixelinfo byte.tif 5 10
+   .. command-output:: gdal raster pixel-info byte.tif 5 10
       :cwd: ../../../autotest/gcore/data
 
 .. example::
    :title: Reporting on point at UTM 11N coordinates easting=441320 and northing=3750720 on the file :file:`byte.tif`
 
-   .. command-output:: gdal raster pixelinfo --position-crs=dataset byte.tif 441320 3750720
+   .. command-output:: gdal raster pixel-info --position-crs=dataset byte.tif 441320 3750720
       :cwd: ../../../autotest/gcore/data
 
 .. example::
    :title: Reporting on point at WGS84 coordinates longitude=-117.6355 and latitude=33.8970 on the file :file:`byte.tif`, with CSV output format
 
-   .. command-output:: gdal raster pixelinfo --of=csv --position-crs=WGS84 byte.tif -117.6355 33.8970
+   .. command-output:: gdal raster pixel-info --of=csv --position-crs=WGS84 byte.tif -117.6355 33.8970
       :cwd: ../../../autotest/gcore/data
 
 .. example::
    :title: Reporting on point at WGS84 coordinates provided on the standard input with longitude, latitude order.
 
-   .. command-output:: echo -117.6355 33.8970 | gdal raster pixelinfo --of=csv --position-crs=WGS84 byte.tif
+   .. command-output:: echo -117.6355 33.8970 | gdal raster pixel-info --of=csv --position-crs=WGS84 byte.tif
       :cwd: ../../../autotest/gcore/data

--- a/doc/source/programs/index.rst
+++ b/doc/source/programs/index.rst
@@ -48,7 +48,7 @@ single :program:`gdal` program that accepts commands and subcommands.
    gdal_raster_create
    gdal_raster_edit
    gdal_raster_footprint
-   gdal_raster_fillnodata
+   gdal_raster_fill_nodata
    gdal_raster_hillshade
    gdal_raster_index
    gdal_raster_mosaic
@@ -122,7 +122,7 @@ single :program:`gdal` program that accepts commands and subcommands.
     - :ref:`gdal_raster_create`: Create a new raster dataset
     - :ref:`gdal_raster_edit`: Edit in place a raster dataset
     - :ref:`gdal_raster_footprint`: Compute the footprint of a raster dataset.
-    - :ref:`gdal_raster_fillnodata`: Fill raster regions by interpolation from edges.
+    - :ref:`gdal_raster_fill_nodata`: Fill raster regions by interpolation from edges.
     - :ref:`gdal_raster_hillshade`: Generate a shaded relief map
     - :ref:`gdal_raster_index`: Create a vector index of raster datasets
     - :ref:`gdal_raster_mosaic`: Build a mosaic, either virtual (VRT) or materialized.

--- a/doc/source/programs/index.rst
+++ b/doc/source/programs/index.rst
@@ -56,7 +56,7 @@ single :program:`gdal` program that accepts commands and subcommands.
    gdal_raster_overview_add
    gdal_raster_overview_delete
    gdal_raster_pipeline
-   gdal_raster_pixelinfo
+   gdal_raster_pixel_info
    gdal_raster_polygonize
    gdal_raster_reproject
    gdal_raster_resize
@@ -131,7 +131,7 @@ single :program:`gdal` program that accepts commands and subcommands.
     - :ref:`gdal_raster_overview_delete`: Remove overviews of a raster dataset
     - :ref:`gdal_raster_pipeline`: Process a raster dataset
     - :ref:`gdal_raster_polygonize`: Create a polygon feature dataset from a raster band
-    - :ref:`gdal_raster_pixelinfo`: Return information on a pixel of a raster dataset
+    - :ref:`gdal_raster_pixel_info`: Return information on a pixel of a raster dataset
     - :ref:`gdal_raster_reproject`: Reproject a raster dataset
     - :ref:`gdal_raster_resize`: Resize a raster dataset without changing the georeferenced extents
     - :ref:`gdal_raster_roughness`: Generate a roughness map.


### PR DESCRIPTION
suggested by @dbaston to be consistent with 'gdal raster clean-collar' and 'gdal raster color-map'