### PR TITLE
gdal CLI: make --version and --drivers only available to top 'gdal' utility

### DIFF
--- a/apps/gdalalg_main.cpp
+++ b/apps/gdalalg_main.cpp
@@ -14,6 +14,10 @@
 
 //! @cond Doxygen_Suppress
 
+#ifndef _
+#define _(x) (x)
+#endif
+
 /************************************************************************/
 /*                  GDALMainAlgorithm::GDALMainAlgorithm()              */
 /************************************************************************/
@@ -31,6 +35,12 @@ GDALMainAlgorithm::GDALMainAlgorithm()
     }
 
     SetCallPath({NAME});
+
+    AddArg("version", 0, _("Display GDAL version and exit"), &m_dummyBoolean)
+        .SetOnlyForCLI();
+    AddArg("drivers", 0, _("Display driver list as JSON document and exit"),
+           &m_dummyBoolean)
+        .SetOnlyForCLI();
 
     m_longDescription = "'gdal <FILENAME>' can also be used as a shortcut for "
                         "'gdal info <FILENAME>'.\n"
@@ -74,6 +84,12 @@ bool GDALMainAlgorithm::ParseCommandLineArguments(
 
         return GDALAlgorithm::ParseCommandLineArguments(args);
     }
+    else if (args.size() == 1 && args[0].size() >= 2 && args[0][0] == '-' &&
+             args[0][1] == '-')
+    {
+        return GDALAlgorithm::ParseCommandLineArguments(args);
+    }
+
     // Generic case: "gdal {subcommand} arguments"
     // where subcommand is a known subcommand
     else if (args.size() >= 1)

--- a/apps/gdalalg_main.h
+++ b/apps/gdalalg_main.h
@@ -40,6 +40,7 @@ class GDALMainAlgorithm final : public GDALAlgorithm
   private:
     std::unique_ptr<GDALAlgorithm> m_subAlg{};
     bool m_showUsage = true;
+    bool m_dummyBoolean = false;  // Used for --version
 
     bool RunImpl(GDALProgressFunc, void *) override
     {

--- a/autotest/cpp/test_gdal_algorithm.cpp
+++ b/autotest/cpp/test_gdal_algorithm.cpp
@@ -3961,7 +3961,7 @@ TEST_F(test_gdal_algorithm, algorithm_c_api)
 
     char **argNames = GDALAlgorithmGetArgNames(hAlg.get());
     ASSERT_NE(argNames, nullptr);
-    EXPECT_EQ(CSLCount(argNames), 14);
+    EXPECT_EQ(CSLCount(argNames), 12);
     CSLDestroy(argNames);
 
     EXPECT_EQ(GDALAlgorithmGetArg(hAlg.get(), "non_existing"), nullptr);

--- a/gcore/gdalalgorithm.cpp
+++ b/gcore/gdalalgorithm.cpp
@@ -1433,18 +1433,11 @@ GDALAlgorithm::GDALAlgorithm(const std::string &name,
            &m_helpDocRequested)
         .SetHidden()
         .AddAction([this]() { m_specialActionRequested = true; });
-    AddArg("version", 0, _("Display GDAL version and exit"), &m_dummyBoolean)
-        .SetOnlyForCLI()
-        .SetCategory(GAAC_COMMON);
     AddArg("json-usage", 0, _("Display usage as JSON document and exit"),
            &m_JSONUsageRequested)
         .SetOnlyForCLI()
         .SetCategory(GAAC_COMMON)
         .AddAction([this]() { m_specialActionRequested = true; });
-    AddArg("drivers", 0, _("Display driver list as JSON document and exit"),
-           &m_dummyBoolean)
-        .SetOnlyForCLI()
-        .SetCategory(GAAC_COMMON);
     AddArg("config", 0, _("Configuration option"), &m_dummyConfigOptions)
         .SetMetaVar("<KEY>=<VALUE>")
         .SetOnlyForCLI()

--- a/gcore/gdalalgorithm.h
+++ b/gcore/gdalalgorithm.h
@@ -2890,7 +2890,6 @@ class CPL_DLL GDALAlgorithmRegistry
     bool m_helpDocRequested = false;
 
     bool m_JSONUsageRequested = false;
-    bool m_dummyBoolean = false;  // Used for --version
     bool m_parseForAutoCompletion = false;
     std::string m_referencePath{};
     std::vector<std::string> m_dummyConfigOptions{};


### PR DESCRIPTION
Refs #12253

```
$ gdal --help
Usage: gdal <COMMAND> [OPTIONS]
where <COMMAND> is one of:
  - convert:  Convert a dataset (shortcut for 'gdal raster convert' or 'gdal vector convert').
  - driver:   Command for driver specific operations.
  - info:     Return information on a dataset (shortcut for 'gdal raster info' or 'gdal vector info').
  - mdim:     Multidimensional commands.
  - pipeline: Execute a pipeline (shortcut for 'gdal raster pipeline' or 'gdal vector pipeline').
  - raster:   Raster commands.
  - vector:   Vector commands.
  - vsi:      GDAL Virtual System Interface (VSI) commands.

Common Options:
  -h, --help              Display help message and exit
  --json-usage            Display usage as JSON document and exit
  --config <KEY>=<VALUE>  Configuration option [may be repeated]

Options:
  --version               Display GDAL version and exit
  --drivers               Display driver list as JSON document and exit

'gdal <FILENAME>' can also be used as a shortcut for 'gdal info <FILENAME>'.
And 'gdal read <FILENAME> ! ...' as a shortcut for 'gdal pipeline <FILENAME> ! ...'.

For more details, consult https://gdal.org/programs/index.html

WARNING: the gdal command is provisionally provided as an alternative interface to GDAL and OGR command line utilities.
The project reserves the right to modify, rename, reorganize, and change the behavior of the utility
until it is officially frozen in a future feature release of GDAL.
```

```
$ gdal raster info --help
Usage: gdal raster info [OPTIONS] <INPUT>

Return information on a raster dataset.

Positional arguments:
  -i, --dataset, --input <INPUT>                       Input raster dataset [required]

Common Options:
  -h, --help                                           Display help message and exit
  --json-usage                                         Display usage as JSON document and exit
  --config <KEY>=<VALUE>                               Configuration option [may be repeated]

Options:
  -f, --of, --format, --output-format <OUTPUT-FORMAT>  Output format. OUTPUT-FORMAT=json|text (default: json)
  --mm, --min-max                                      Compute minimum and maximum value
  --stats                                              Retrieve or compute statistics, using all pixels
                                                       Mutually exclusive with --approx-stats
  --approx-stats                                       Retrieve or compute statistics, using a subset of pixels
                                                       Mutually exclusive with --stats
  --hist                                               Retrieve or compute histogram

Advanced Options:
  --oo, --open-option <KEY>=<VALUE>                    Open options [may be repeated]
  --if, --input-format <INPUT-FORMAT>                  Input formats [may be repeated]
  --no-gcp                                             Suppress ground control points list printing
  --no-md                                              Suppress metadata printing
  --no-ct                                              Suppress color table printing
  --no-fl                                              Suppress file list printing
  --checksum                                           Compute pixel checksum
  --list-metadata-domains, --list-mdd                  List all metadata domains available for the dataset
  --mdd, --metadata-domain <METADATA-DOMAIN>           Report metadata for the specified domain. 'all' can be used to report metadata in all domains

Esoteric Options:
  --no-nodata                                          Suppress retrieving nodata value
  --no-mask                                            Suppress mask band information
  --subdataset <SUBDATASET>                            Use subdataset of specified index (starting at 1), instead of the source dataset itself

For more details, consult https://gdal.org/programs/gdal_raster_info.html

WARNING: the gdal command is provisionally provided as an alternative interface to GDAL and OGR command line utilities.
The project reserves the right to modify, rename, reorganize, and change the behavior of the utility
until it is officially frozen in a future feature release of GDAL.
```