### PR TITLE
gdal cli: add hyphens to separate composite-word argument names

### DIFF
--- a/apps/gdalalg_raster_clean_collar.cpp
+++ b/apps/gdalalg_raster_clean_collar.cpp
@@ -91,10 +91,10 @@ GDALRasterCleanCollarAlgorithm::GDALRasterCleanCollarAlgorithm()
            &m_pixelDistance)
         .SetDefault(m_pixelDistance)
         .SetMinValueIncluded(0);
-    AddArg("addalpha", 0, _("Adds an alpha band to the output dataset."),
+    AddArg("add-alpha", 0, _("Adds an alpha band to the output dataset."),
            &m_addAlpha)
         .SetMutualExclusionGroup("addalpha-addmask");
-    AddArg("addmask", 0, _("Adds a mask band to the output dataset."),
+    AddArg("add-mask", 0, _("Adds a mask band to the output dataset."),
            &m_addMask)
         .SetMutualExclusionGroup("addalpha-addmask");
     AddArg("algorithm", 0, _("Algorithm to apply"), &m_algorithm)

--- a/apps/gdalalg_raster_clip.cpp
+++ b/apps/gdalalg_raster_clip.cpp
@@ -63,7 +63,7 @@ GDALRasterClipAlgorithm::GDALRasterClipAlgorithm(bool standaloneStep)
     AddArg("allow-bbox-outside-source", 0,
            _("Allow clipping box to include pixels outside input dataset"),
            &m_allowExtentOutsideSource);
-    AddArg("addalpha", 0,
+    AddArg("add-alpha", 0,
            _("Adds an alpha mask band to the destination when the source "
              "raster have none."),
            &m_addAlpha);

--- a/apps/gdalalg_raster_color_map.cpp
+++ b/apps/gdalalg_raster_color_map.cpp
@@ -33,7 +33,7 @@ GDALRasterColorMapAlgorithm::GDALRasterColorMapAlgorithm(bool standaloneStep)
 {
     AddBandArg(&m_band).SetDefault(m_band);
     AddArg("color-map", 0, _("Color map filename"), &m_colorMap);
-    AddArg("addalpha", 0, _("Adds an alpha mask band to the destination."),
+    AddArg("add-alpha", 0, _("Adds an alpha mask band to the destination."),
            &m_addAlpha);
     AddArg("color-selection", 0,
            _("How to compute output colors from input values"),

--- a/apps/gdalalg_raster_contour.cpp
+++ b/apps/gdalalg_raster_contour.cpp
@@ -56,7 +56,7 @@ GDALRasterContourAlgorithm::GDALRasterContourAlgorithm()
     AddArg("max-name", 0, _("Name of the maximum elevation field"), &m_amax);
     AddArg("3d", 0, _("Force production of 3D vectors instead of 2D"), &m_3d);
 
-    AddArg("srcnodata", 0, _("Input pixel value to treat as 'nodata'"),
+    AddArg("src-nodata", 0, _("Input pixel value to treat as 'nodata'"),
            &m_sNodata);
     AddArg("interval", 0, _("Elevation interval between contours"), &m_interval)
         .SetMutualExclusionGroup("levels")

--- a/apps/gdalalg_raster_footprint.cpp
+++ b/apps/gdalalg_raster_footprint.cpp
@@ -61,7 +61,7 @@ GDALRasterFootprintAlgorithm::GDALRasterFootprintAlgorithm()
            &m_overview)
         .SetMutualExclusionGroup("overview-srcnodata")
         .SetMinValueIncluded(0);
-    AddArg("srcnodata", 0, _("Set nodata values for input bands."),
+    AddArg("src-nodata", 0, _("Set nodata values for input bands."),
            &m_srcNoData)
         .SetMinCount(1)
         .SetRepeatedArgAllowed(false)

--- a/apps/gdalalg_raster_mosaic.cpp
+++ b/apps/gdalalg_raster_mosaic.cpp
@@ -87,18 +87,18 @@ GDALRasterMosaicAlgorithm::GDALRasterMosaicAlgorithm()
            _("Round target extent to target resolution"),
            &m_targetAlignedPixels)
         .AddHiddenAlias("tap");
-    AddArg("srcnodata", 0, _("Set nodata values for input bands."),
+    AddArg("src-nodata", 0, _("Set nodata values for input bands."),
            &m_srcNoData)
         .SetMinCount(1)
         .SetRepeatedArgAllowed(false);
-    AddArg("dstnodata", 0,
+    AddArg("dst-nodata", 0,
            _("Set nodata values at the destination band level."), &m_dstNoData)
         .SetMinCount(1)
         .SetRepeatedArgAllowed(false);
-    AddArg("hidenodata", 0,
+    AddArg("hide-nodata", 0,
            _("Makes the destination band not report the NoData."),
            &m_hideNoData);
-    AddArg("addalpha", 0,
+    AddArg("add-alpha", 0,
            _("Adds an alpha mask band to the destination when the source "
              "raster have "
              "none."),

--- a/apps/gdalalg_raster_reproject.cpp
+++ b/apps/gdalalg_raster_reproject.cpp
@@ -75,19 +75,19 @@ GDALRasterReprojectAlgorithm::GDALRasterReprojectAlgorithm(bool standaloneStep)
            &m_targetAlignedPixels)
         .AddHiddenAlias("tap")
         .SetCategory(GAAC_ADVANCED);
-    AddArg("srcnodata", 0,
+    AddArg("src-nodata", 0,
            _("Set nodata values for input bands ('None' to unset)."),
            &m_srcNoData)
         .SetMinCount(1)
         .SetRepeatedArgAllowed(false)
         .SetCategory(GAAC_ADVANCED);
-    AddArg("dstnodata", 0,
+    AddArg("dst-nodata", 0,
            _("Set nodata values for output bands ('None' to unset)."),
            &m_dstNoData)
         .SetMinCount(1)
         .SetRepeatedArgAllowed(false)
         .SetCategory(GAAC_ADVANCED);
-    AddArg("addalpha", 0,
+    AddArg("add-alpha", 0,
            _("Adds an alpha mask band to the destination when the source "
              "raster have none."),
            &m_addAlpha)

--- a/apps/gdalalg_raster_scale.cpp
+++ b/apps/gdalalg_raster_scale.cpp
@@ -34,10 +34,12 @@ GDALRasterScaleAlgorithm::GDALRasterScaleAlgorithm(bool standaloneStep)
     AddOutputDataTypeArg(&m_type);
     AddBandArg(&m_band,
                _("Select band to restrict the scaling (1-based index)"));
-    AddArg("srcmin", 0, _("Minimum value of the source range"), &m_srcMin);
-    AddArg("srcmax", 0, _("Maximum value of the source range"), &m_srcMax);
-    AddArg("dstmin", 0, _("Minimum value of the destination range"), &m_dstMin);
-    AddArg("dstmax", 0, _("Maximum value of the destination range"), &m_dstMax);
+    AddArg("src-min", 0, _("Minimum value of the source range"), &m_srcMin);
+    AddArg("src-max", 0, _("Maximum value of the source range"), &m_srcMax);
+    AddArg("dst-min", 0, _("Minimum value of the destination range"),
+           &m_dstMin);
+    AddArg("dst-max", 0, _("Maximum value of the destination range"),
+           &m_dstMax);
     AddArg("exponent", 0,
            _("Exponent to apply non-linear scaling with a power function"),
            &m_exponent);
@@ -70,7 +72,7 @@ bool GDALRasterScaleAlgorithm::RunStep(GDALProgressFunc, void *)
         if (std::isnan(m_srcMax))
         {
             ReportError(CE_Failure, CPLE_AppDefined,
-                        "srcmax must be specified when srcmin is specified");
+                        "src-max must be specified when src-min is specified");
             return false;
         }
         aosOptions.AddString(CPLSPrintf("%.17g", m_srcMin));
@@ -79,7 +81,7 @@ bool GDALRasterScaleAlgorithm::RunStep(GDALProgressFunc, void *)
     else if (!std::isnan(m_srcMax))
     {
         ReportError(CE_Failure, CPLE_AppDefined,
-                    "srcmin must be specified when srcmax is specified");
+                    "src-min must be specified when src-max is specified");
         return false;
     }
 
@@ -88,7 +90,7 @@ bool GDALRasterScaleAlgorithm::RunStep(GDALProgressFunc, void *)
         if (std::isnan(m_dstMax))
         {
             ReportError(CE_Failure, CPLE_AppDefined,
-                        "dstmax must be specified when dstmin is specified");
+                        "dst-max must be specified when dst-min is specified");
             return false;
         }
         if (std::isnan(m_srcMin))
@@ -102,7 +104,7 @@ bool GDALRasterScaleAlgorithm::RunStep(GDALProgressFunc, void *)
     else if (!std::isnan(m_dstMax))
     {
         ReportError(CE_Failure, CPLE_AppDefined,
-                    "dstmin must be specified when dstmax is specified");
+                    "dst-min must be specified when dst-max is specified");
         return false;
     }
 

--- a/apps/gdalalg_raster_stack.cpp
+++ b/apps/gdalalg_raster_stack.cpp
@@ -87,15 +87,15 @@ GDALRasterStackAlgorithm::GDALRasterStackAlgorithm()
            _("Round target extent to target resolution"),
            &m_targetAlignedPixels)
         .AddHiddenAlias("tap");
-    AddArg("srcnodata", 0, _("Set nodata values for input bands."),
+    AddArg("src-nodata", 0, _("Set nodata values for input bands."),
            &m_srcNoData)
         .SetMinCount(1)
         .SetRepeatedArgAllowed(false);
-    AddArg("dstnodata", 0,
+    AddArg("dst-nodata", 0,
            _("Set nodata values at the destination band level."), &m_dstNoData)
         .SetMinCount(1)
         .SetRepeatedArgAllowed(false);
-    AddArg("hidenodata", 0,
+    AddArg("hide-nodata", 0,
            _("Makes the destination band not report the NoData."),
            &m_hideNoData);
 }

--- a/apps/gdalalg_raster_viewshed.cpp
+++ b/apps/gdalalg_raster_viewshed.cpp
@@ -95,7 +95,7 @@ GDALRasterViewshedAlgorithm::GDALRasterViewshedAlgorithm()
         .SetDefault(m_outOfRangeVal)
         .SetMinValueIncluded(0)
         .SetMaxValueIncluded(255);
-    AddArg("dstnodata", 0,
+    AddArg("dst-nodata", 0,
            _("The value to be set for the cells in the output raster that have "
              "no data."),
            &m_dstNoData)

--- a/autotest/gcore/algorithm.py
+++ b/autotest/gcore/algorithm.py
@@ -382,29 +382,29 @@ def test_algorithm_arg_set_double_list():
     reg = gdal.GetGlobalAlgorithmRegistry()
     alg = reg["raster"]["footprint"]
 
-    alg["srcnodata"] = 2
-    assert alg["srcnodata"] == [2]
+    alg["src-nodata"] = 2
+    assert alg["src-nodata"] == [2]
 
-    alg["srcnodata"] = "2"
-    assert alg["srcnodata"] == [2]
+    alg["src-nodata"] = "2"
+    assert alg["src-nodata"] == [2]
 
-    alg["srcnodata"] = 2.5
-    assert alg["srcnodata"] == [2.5]
+    alg["src-nodata"] = 2.5
+    assert alg["src-nodata"] == [2.5]
 
-    alg["srcnodata"] = [2, 4]
-    assert alg["srcnodata"] == [2, 4]
+    alg["src-nodata"] = [2, 4]
+    assert alg["src-nodata"] == [2, 4]
 
-    alg["srcnodata"] = ["2", "4"]
-    assert alg["srcnodata"] == [2, 4]
+    alg["src-nodata"] = ["2", "4"]
+    assert alg["src-nodata"] == [2, 4]
 
-    alg["srcnodata"] = [2.5, 4.5]
-    assert alg["srcnodata"] == [2.5, 4.5]
-
-    with pytest.raises(TypeError):
-        alg["srcnodata"] = None
+    alg["src-nodata"] = [2.5, 4.5]
+    assert alg["src-nodata"] == [2.5, 4.5]
 
     with pytest.raises(TypeError):
-        alg["srcnodata"] = [None]
+        alg["src-nodata"] = None
+
+    with pytest.raises(TypeError):
+        alg["src-nodata"] = [None]
 
 
 ###############################################################################

--- a/autotest/utilities/test_gdalalg_raster_clean_collar.py
+++ b/autotest/utilities/test_gdalalg_raster_clean_collar.py
@@ -184,7 +184,7 @@ def test_gdalalg_raster_clean_collar_add_alpha():
     alg["input"] = ds
     alg["output"] = "my_name"
     alg["output-format"] = "MEM"
-    alg["addalpha"] = True
+    alg["add-alpha"] = True
     assert alg.Run()
     out_ds = alg["output"].GetDataset()
     assert out_ds.RasterCount == 2
@@ -212,7 +212,7 @@ def test_gdalalg_raster_clean_collar_add_mask():
     alg["input"] = ds
     alg["output"] = "my_name"
     alg["output-format"] = "MEM"
-    alg["addmask"] = True
+    alg["add-mask"] = True
     assert alg.Run()
     out_ds = alg["output"].GetDataset()
     assert out_ds.RasterCount == 1
@@ -241,7 +241,7 @@ def test_gdalalg_raster_clean_collar_add_mask_from_alpha():
     alg["input"] = ds
     alg["output"] = "my_name"
     alg["output-format"] = "MEM"
-    alg["addmask"] = True
+    alg["add-mask"] = True
     assert alg.Run()
     out_ds = alg["output"].GetDataset()
     assert out_ds.RasterCount == 1

--- a/autotest/utilities/test_gdalalg_raster_clip.py
+++ b/autotest/utilities/test_gdalalg_raster_clip.py
@@ -179,7 +179,7 @@ def test_gdalalg_raster_clip_geometry_add_alpha():
     alg[
         "geometry"
     ] = "POLYGON ((440720 3750120,441920 3751320,441920 3750120,440720 3750120))"
-    alg["addalpha"] = True
+    alg["add-alpha"] = True
     with gdaltest.error_raised(gdal.CE_Warning):
         assert alg.Run()
     ds = alg["output"].GetDataset()
@@ -280,7 +280,7 @@ def test_gdalalg_raster_clip_geometry_srs():
     alg["output-format"] = "MEM"
     alg["geometry"] = f"POLYGON (({x1} {y1},{x1} {y2},{x2} {y2},{x2} {y1},{x1} {y1}))"
     alg["geometry-crs"] = "EPSG:4267"
-    alg["addalpha"] = True
+    alg["add-alpha"] = True
     alg["allow-bbox-outside-source"] = True
     assert alg.Run()
     ds = alg["output"].GetDataset()

--- a/autotest/utilities/test_gdalalg_raster_color_map.py
+++ b/autotest/utilities/test_gdalalg_raster_color_map.py
@@ -27,7 +27,7 @@ def get_alg():
     "options,checksum",
     [
         ({}, [55066, 37594, 47768]),
-        ({"addalpha": True}, [55066, 37594, 47768, 48613]),
+        ({"add-alpha": True}, [55066, 37594, 47768, 48613]),
         ({"color-selection": "exact"}, [8073, 53707, 59536]),
         ({"color-selection": "nearest"}, [57296, 42926, 47181]),
     ],
@@ -98,7 +98,7 @@ def test_gdalalg_raster_color_map_gdalg(tmp_vsimem):
     [
         ({}, [4672, 4672, 4672]),
         ({"color-selection": "nearest"}, [4672, 4672, 4672]),
-        ({"addalpha": True}, [4672, 4672, 4672, 4873]),
+        ({"add-alpha": True}, [4672, 4672, 4672, 4873]),
     ],
 )
 @pytest.mark.parametrize("output_format", ["MEM", "VRT"])

--- a/autotest/utilities/test_gdalalg_raster_contour.py
+++ b/autotest/utilities/test_gdalalg_raster_contour.py
@@ -38,7 +38,7 @@ def get_contour_alg():
             [5.0, 15.0, 25.0, 35.0],
         ),
         (
-            ["--interval", "10", "--elevation-name", "ELEV", "--srcnodata", "4"],
+            ["--interval", "10", "--elevation-name", "ELEV", "--src-nodata", "4"],
             False,
             [20.0, 30.0],
         ),

--- a/autotest/utilities/test_gdalalg_raster_footprint.py
+++ b/autotest/utilities/test_gdalalg_raster_footprint.py
@@ -228,7 +228,7 @@ def test_gdalalg_raster_footprint_srcnodata():
     alg["input"] = src_ds
     alg["output"] = ""
     alg["output-format"] = "MEM"
-    alg["srcnodata"] = 255
+    alg["src-nodata"] = 255
     assert alg.Run()
     ds = alg["output"].GetDataset()
     lyr = ds.GetLayer(0)
@@ -252,7 +252,7 @@ def test_gdalalg_raster_footprint_srcnodata_several(use_setnodatavalue):
     alg["output"] = ""
     alg["output-format"] = "MEM"
     if not use_setnodatavalue:
-        alg["srcnodata"] = [0, 1]
+        alg["src-nodata"] = [0, 1]
     assert alg.Run()
     ds = alg["output"].GetDataset()
     lyr = ds.GetLayer(0)

--- a/autotest/utilities/test_gdalalg_raster_mosaic.py
+++ b/autotest/utilities/test_gdalalg_raster_mosaic.py
@@ -263,8 +263,8 @@ def test_gdalalg_raster_mosaic_srcnodata_dstnodata():
     alg = get_mosaic_alg()
     alg["input"] = [src1_ds]
     alg["output"] = ""
-    alg["srcnodata"] = [1]
-    alg["dstnodata"] = [2]
+    alg["src-nodata"] = [1]
+    alg["dst-nodata"] = [2]
     assert alg.Run()
     ds = alg["output"].GetDataset()
     assert ds.GetRasterBand(1).Checksum() == 2
@@ -280,9 +280,9 @@ def test_gdalalg_raster_mosaic_hidenodata():
     alg = get_mosaic_alg()
     alg["input"] = [src1_ds]
     alg["output"] = ""
-    alg["srcnodata"] = [1]
-    alg["dstnodata"] = [2]
-    alg["hidenodata"] = True
+    alg["src-nodata"] = [1]
+    alg["dst-nodata"] = [2]
+    alg["hide-nodata"] = True
     assert alg.Run()
     ds = alg["output"].GetDataset()
     assert ds.GetRasterBand(1).Checksum() == 2

--- a/autotest/utilities/test_gdalalg_raster_reproject.py
+++ b/autotest/utilities/test_gdalalg_raster_reproject.py
@@ -109,8 +109,8 @@ def test_gdalalg_raster_reproject_srcnodata_dst_nodata(tmp_vsimem):
     alg["input"] = src_ds
     alg["output"] = ""
     alg["output-format"] = "MEM"
-    alg["srcnodata"] = [1]
-    alg["dstnodata"] = [2]
+    alg["src-nodata"] = [1]
+    alg["dst-nodata"] = [2]
     assert alg.Run()
     out_ds = alg["output"].GetDataset()
     assert out_ds.GetRasterBand(1).GetNoDataValue() == 2
@@ -126,7 +126,7 @@ def test_gdalalg_raster_reproject_addalpha(tmp_vsimem):
     alg["input"] = src_ds
     alg["output"] = ""
     alg["output-format"] = "MEM"
-    alg["addalpha"] = True
+    alg["add-alpha"] = True
     assert alg.Run()
     out_ds = alg["output"].GetDataset()
     assert out_ds.RasterCount == 2
@@ -146,7 +146,7 @@ def test_gdalalg_raster_reproject_warp_option(tmp_vsimem):
     alg["output"] = ""
     alg["output-format"] = "MEM"
     alg["warp-option"] = ["UNIFIED_SRC_NODATA=YES"]
-    alg["dstnodata"] = [3, 4]
+    alg["dst-nodata"] = [3, 4]
     assert alg.Run()
     out_ds = alg["output"].GetDataset()
     assert out_ds.GetRasterBand(1).ReadRaster() == b"\x00"

--- a/autotest/utilities/test_gdalalg_raster_scale.py
+++ b/autotest/utilities/test_gdalalg_raster_scale.py
@@ -60,8 +60,8 @@ def test_gdalalg_raster_scale_srcmin_srcmax_only():
     alg["input"] = src_ds
     alg["output"] = ""
     alg["output-format"] = "MEM"
-    alg["srcmin"] = 0
-    alg["srcmax"] = 3
+    alg["src-min"] = 0
+    alg["src-max"] = 3
     assert alg.Run()
     out_ds = alg["output"].GetDataset()
     assert out_ds.GetRasterBand(1).ComputeRasterMinMax() == (85, 170)
@@ -76,8 +76,8 @@ def test_gdalalg_raster_scale_dstcmin_dstmax_only():
     alg["input"] = src_ds
     alg["output"] = ""
     alg["output-format"] = "MEM"
-    alg["dstmin"] = 0
-    alg["dstmax"] = 3
+    alg["dst-min"] = 0
+    alg["dst-max"] = 3
     assert alg.Run()
     out_ds = alg["output"].GetDataset()
     assert out_ds.GetRasterBand(1).ComputeRasterMinMax() == (0, 3)
@@ -92,8 +92,8 @@ def test_gdalalg_raster_scale_missing_srcmin():
     alg["input"] = src_ds
     alg["output"] = ""
     alg["output-format"] = "MEM"
-    alg["srcmax"] = 0
-    with pytest.raises(Exception, match="scale: srcmin must be specified"):
+    alg["src-max"] = 0
+    with pytest.raises(Exception, match="scale: src-min must be specified"):
         alg.Run()
 
 
@@ -106,8 +106,8 @@ def test_gdalalg_raster_scale_missing_srcmax():
     alg["input"] = src_ds
     alg["output"] = ""
     alg["output-format"] = "MEM"
-    alg["srcmin"] = 0
-    with pytest.raises(Exception, match="scale: srcmax must be specified"):
+    alg["src-min"] = 0
+    with pytest.raises(Exception, match="scale: src-max must be specified"):
         alg.Run()
 
 
@@ -120,8 +120,8 @@ def test_gdalalg_raster_scale_missing_dstmin():
     alg["input"] = src_ds
     alg["output"] = ""
     alg["output-format"] = "MEM"
-    alg["dstmax"] = 0
-    with pytest.raises(Exception, match="scale: dstmin must be specified"):
+    alg["dst-max"] = 0
+    with pytest.raises(Exception, match="scale: dst-min must be specified"):
         alg.Run()
 
 
@@ -134,8 +134,8 @@ def test_gdalalg_raster_scale_missing_dstmax():
     alg["input"] = src_ds
     alg["output"] = ""
     alg["output-format"] = "MEM"
-    alg["dstmin"] = 0
-    with pytest.raises(Exception, match="scale: dstmax must be specified"):
+    alg["dst-min"] = 0
+    with pytest.raises(Exception, match="scale: dst-max must be specified"):
         alg.Run()
 
 
@@ -149,10 +149,10 @@ def test_gdalalg_raster_scale_srcmin_srcmax_destmin_dstmax():
     alg["input"] = src_ds
     alg["output"] = ""
     alg["output-format"] = "MEM"
-    alg["srcmin"] = 10
-    alg["srcmax"] = 20
-    alg["dstmin"] = 100
-    alg["dstmax"] = 200
+    alg["src-min"] = 10
+    alg["src-max"] = 20
+    alg["dst-min"] = 100
+    alg["dst-max"] = 200
     assert alg.Run()
     out_ds = alg["output"].GetDataset()
     assert out_ds.GetRasterBand(1).ComputeRasterMinMax() == (150, 150)
@@ -170,10 +170,10 @@ def test_gdalalg_raster_scale_band():
     alg["output"] = ""
     alg["output-format"] = "MEM"
     alg["band"] = 1
-    alg["srcmin"] = 10
-    alg["srcmax"] = 20
-    alg["dstmin"] = 100
-    alg["dstmax"] = 200
+    alg["src-min"] = 10
+    alg["src-max"] = 20
+    alg["dst-min"] = 100
+    alg["dst-max"] = 200
     assert alg.Run()
     out_ds = alg["output"].GetDataset()
     assert out_ds.GetRasterBand(1).ComputeRasterMinMax() == (150, 150)
@@ -190,10 +190,10 @@ def test_gdalalg_raster_exponent():
     alg["input"] = src_ds
     alg["output"] = ""
     alg["output-format"] = "MEM"
-    alg["srcmin"] = 10
-    alg["srcmax"] = 20
-    alg["dstmin"] = 100
-    alg["dstmax"] = 200
+    alg["src-min"] = 10
+    alg["src-max"] = 20
+    alg["dst-min"] = 100
+    alg["dst-max"] = 200
     alg["exponent"] = 1.5
     assert alg.Run()
     out_ds = alg["output"].GetDataset()
@@ -213,10 +213,10 @@ def test_gdalalg_raster_band_exponent_datatype():
     alg["output-format"] = "MEM"
     alg["output-data-type"] = "UInt16"
     alg["band"] = 2
-    alg["srcmin"] = 10
-    alg["srcmax"] = 20
-    alg["dstmin"] = 100
-    alg["dstmax"] = 200
+    alg["src-min"] = 10
+    alg["src-max"] = 20
+    alg["dst-min"] = 100
+    alg["dst-max"] = 200
     alg["exponent"] = 1.5
     assert alg.Run()
     out_ds = alg["output"].GetDataset()
@@ -234,10 +234,10 @@ def test_gdalalg_raster_scale_clip():
     alg["input"] = src_ds
     alg["output"] = ""
     alg["output-format"] = "MEM"
-    alg["srcmin"] = 1
-    alg["srcmax"] = 3
-    alg["dstmin"] = 100
-    alg["dstmax"] = 200
+    alg["src-min"] = 1
+    alg["src-max"] = 3
+    alg["dst-min"] = 100
+    alg["dst-max"] = 200
     assert alg.Run()
     out_ds = alg["output"].GetDataset()
     assert struct.unpack("B" * 5, out_ds.GetRasterBand(1).ReadRaster()) == (
@@ -258,10 +258,10 @@ def test_gdalalg_raster_scale_no_clip():
     alg["input"] = src_ds
     alg["output"] = ""
     alg["output-format"] = "MEM"
-    alg["srcmin"] = 1
-    alg["srcmax"] = 3
-    alg["dstmin"] = 100
-    alg["dstmax"] = 200
+    alg["src-min"] = 1
+    alg["src-max"] = 3
+    alg["dst-min"] = 100
+    alg["dst-max"] = 200
     alg["no-clip"] = True
     assert alg.Run()
     out_ds = alg["output"].GetDataset()
@@ -283,10 +283,10 @@ def test_gdalalg_raster_scale_no_clip_exponent():
     alg["input"] = src_ds
     alg["output"] = ""
     alg["output-format"] = "MEM"
-    alg["srcmin"] = 1
-    alg["srcmax"] = 3
-    alg["dstmin"] = 100
-    alg["dstmax"] = 200
+    alg["src-min"] = 1
+    alg["src-max"] = 3
+    alg["dst-min"] = 100
+    alg["dst-max"] = 200
     alg["exponent"] = 1.1
     alg["no-clip"] = True
     assert alg.Run()

--- a/autotest/utilities/test_gdalalg_raster_viewshed.py
+++ b/autotest/utilities/test_gdalalg_raster_viewshed.py
@@ -217,7 +217,7 @@ def test_gdalalg_raster_viewshed_nodata(viewshed_input):
     alg["output"] = ""
     alg["output-format"] = "MEM"
     alg["position"] = [621528, 4817617, 100]
-    alg["dstnodata"] = 0
+    alg["dst-nodata"] = 0
     assert alg.Run()
     ds = alg["output"].GetDataset()
     assert ds.GetRasterBand(1).Checksum() == VIEWSHED_NOMINAL_CHECKSUM

--- a/doc/source/programs/gdal_raster_contour.rst
+++ b/doc/source/programs/gdal_raster_contour.rst
@@ -60,7 +60,7 @@ Standard options
 
     Forces the production of 3D vectors instead of 2D. Includes elevation at every vertex.
 
-.. option:: --srcnodata <SRCNODATA>
+.. option:: --src-nodata <SRCNODATA>
 
     Input pixel value to treat as 'nodata'.
 

--- a/doc/source/programs/gdal_raster_footprint.rst
+++ b/doc/source/programs/gdal_raster_footprint.rst
@@ -68,9 +68,9 @@ The following options are available:
    To specify which overview level of source file must be used, when overviews
    are available on the source raster. By default the full resolution level is
    used. The index is 0-based, that is 0 means the first overview level.
-   This option is mutually exclusive with :option:`--srcnodata`.
+   This option is mutually exclusive with :option:`--src-nodata`.
 
-.. option:: --srcnodata <value>
+.. option:: --src-nodata <value>
 
     Set nodata values for input bands (different values can be supplied for each band).
     If a single value is specified, it applies to all selected bands.

--- a/doc/source/programs/gdal_raster_mosaic.rst
+++ b/doc/source/programs/gdal_raster_mosaic.rst
@@ -79,8 +79,8 @@ The following options are available:
     Set georeferenced extents of output file. The values must be expressed in georeferenced units.
     If not specified, the extent of the output is the minimum bounding box of the set of source rasters.
     Pixels within the extent of the output but not covered by a source raster will be read as valid
-    pixels with a value of zero unless a NODATA value is specified using :option:`--dstnodata`
-    or an alpha mask band is added with :option:`--addalpha`.
+    pixels with a value of zero unless a NODATA value is specified using :option:`--dst-nodata`
+    or an alpha mask band is added with :option:`--add-alpha`.
 
 .. option:: --target-aligned-pixels
 
@@ -89,14 +89,14 @@ The following options are available:
     such that the aligned extent includes the minimum extent.
     Alignment means that xmin / resx, ymin / resy, xmax / resx and ymax / resy are integer values.
 
-.. option:: --srcnodata <value>[,<value>]...
+.. option:: --src-nodata <value>[,<value>]...
 
     Set nodata values for input bands (different values can be supplied for each band).
     If the option is not specified, the intrinsic nodata settings on the source datasets
     will be used (if they exist). The value set by this option is written in the NODATA element
     of each ``ComplexSource`` element.
 
-.. option:: --dstnodata <value>[,<value>]...
+.. option:: --dst-nodata <value>[,<value>]...
 
     Set nodata values at the output band level (different values can be supplied for each band).  If more
     than one value is supplied, all values should be quoted to keep them together
@@ -105,18 +105,18 @@ The following options are available:
     is written in the ``NoDataValue`` element of each ``VRTRasterBand element``. Use a value of
     `None` to ignore intrinsic nodata settings on the source datasets.
 
-.. option:: --addalpha
+.. option:: --add-alpha
 
     Adds an alpha mask band to the output when the source raster have none. Mainly useful for RGB sources (or grey-level sources).
     The alpha band is filled on-the-fly with the value 0 in areas without any source raster, and with value
     255 in areas with source raster. The effect is that a RGBA viewer will render
     the areas without source rasters as transparent and areas with source rasters as opaque.
 
-.. option:: --hidenodata
+.. option:: --hide-nodata
 
     Even if any band contains nodata value, giving this option makes the output band
     not report the NoData. Useful when you want to control the background color of
-    the dataset. By using along with the -addalpha option, you can prepare a
+    the dataset. By using along with the :option:`--add-alpha` option, you can prepare a
     dataset which doesn't report nodata value but is transparent in areas with no
     data.
 
@@ -137,7 +137,7 @@ Examples
 
    .. code-block:: bash
 
-       gdal raster mosaic --hidenodata --dstnodata=0,0,255 doq/*.tif doq_index.vrt
+       gdal raster mosaic --hide-nodata --dst-nodata=0,0,255 doq/*.tif doq_index.vrt
 
 
 .. below is an allow-list for spelling checker.

--- a/doc/source/programs/gdal_raster_reproject.rst
+++ b/doc/source/programs/gdal_raster_reproject.rst
@@ -167,7 +167,7 @@ Standard options
 Advanced options
 ++++++++++++++++
 
-.. option:: --srcnodata <SRCNODATA>
+.. option:: --src-nodata <SRCNODATA>
 
     Set nodata masking values for input bands (different values can be supplied
     for each band). If more than one value is supplied all values should be quoted
@@ -180,11 +180,11 @@ Advanced options
     warping option (see :cpp:member:`GDALWarpOptions::papszWarpOptions`) to be
     set to ``YES``, if it is not explicitly set.
 
-    If ``--srcnodata`` is not explicitly set, but the source dataset has nodata values,
+    If ``--src-nodata`` is not explicitly set, but the source dataset has nodata values,
     they will be taken into account, with ``UNIFIED_SRC_NODATA`` at ``PARTIAL``
     by default.
 
-.. option:: --dstnodata <DSTNODATA>
+.. option:: --dst-nodata <DSTNODATA>
 
     Set nodata values for output bands (different values can be supplied for each band).
     If more than one value is supplied all values should be quoted to keep them together
@@ -228,7 +228,7 @@ Nodata / source validity mask handling
 Invalid values in source pixels, either identified through a nodata value
 metadata set on the source band, a mask band, an alpha band (for an alpha band,
 a value of 0 means invalid. Other values are used for blending values) or the use of
-:option:`--srcnodata` will not be used in interpolation.
+:option:`--src-nodata` will not be used in interpolation.
 The details of how it is taken into account depends on the resampling kernel:
 
 - for nearest resampling, for each target pixel, the coordinate of its center

--- a/doc/source/programs/gdal_raster_scale.rst
+++ b/doc/source/programs/gdal_raster_scale.rst
@@ -21,8 +21,8 @@ Description
 -----------
 
 :program:`gdal raster scale` can be used to rescale the input pixels values
-from the range :option:`--srcmin` to :option:`--srcmax` to the range
-:option:`--dstmin` to :option:`--dstmax`.
+from the range :option:`--src-min` to :option:`--src-max` to the range
+:option:`--dst-min` to :option:`--dst-max`.
 It is also often necessary to reset the output datatype with the :option:`--ot` switch.
 If omitted the output range is from the minimum value to the maximum value allowed
 for integer data types (for example from 0 to 255 for Byte output) or from 0 to 1
@@ -61,29 +61,29 @@ Standard options
 
     Index (starting at 1) of the band to which the scaling must be only applied.
 
-.. option:: --srcmin <SRCMIN>
+.. option:: --src-min <SRCMIN>
 
     Minimum value of the source range. If not specified, it will be calculated from the input dataset.
-    This option must be used together with :option:`--srcmax`.
+    This option must be used together with :option:`--src-max`.
 
-.. option:: --srcmax <SRCMAX>
+.. option:: --src-max <SRCMAX>
 
     Maximum value of the source range. If not specified, it will be calculated from the source dataset.
-    This option must be used together with :option:`--srcmin`.
+    This option must be used together with :option:`--src-min`.
 
-.. option:: --dstmin <DSTMIN>
+.. option:: --dst-min <DSTMIN>
 
-    Minimum value of the output range. This option must be used together with :option:`--dstmax`.
+    Minimum value of the output range. This option must be used together with :option:`--dst-max`.
 
-.. option:: --dstmax <DSTMAX>
+.. option:: --dst-max <DSTMAX>
 
-    Maximum value of the output range. This option must be used together with :option:`--dstmin`.
+    Maximum value of the output range. This option must be used together with :option:`--dst-min`.
 
 .. option:: --exponent <EXPONENT>
 
     Apply non-linear scaling with a power function. ``exp_val`` is the exponent
     of the power function (must be positive). This option must be used with the
-    :option:`--srcmin` / :option:`--srcmax` / :option:`--dstmin` / :option:`--dstmax` options.
+    :option:`--src-min` / :option:`--src-max` / :option:`--dst-min` / :option:`--dst-max` options.
 
     The scaled value ``Dst`` is calculated from the source value ``Src`` with the following
     formula:
@@ -116,4 +116,4 @@ Examples
 
    .. code-block:: bash
 
-        $ gdal raster scale --datatype Byte --srcmin 0 --srcmax 4095 uint16.tif byte.tif --overwrite
+        $ gdal raster scale --datatype Byte --src-min 0 --src-max 4095 uint16.tif byte.tif --overwrite

--- a/doc/source/programs/gdal_raster_stack.rst
+++ b/doc/source/programs/gdal_raster_stack.rst
@@ -71,8 +71,8 @@ The following options are available:
     Set georeferenced extents of output file. The values must be expressed in georeferenced units.
     If not specified, the extent of the output is the minimum bounding box of the set of source rasters.
     Pixels within the extent of the output but not covered by a source raster will be read as valid
-    pixels with a value of zero unless a NODATA value is specified using :option:`--dstnodata`
-    or an alpha mask band is added with :option:`--addalpha`.
+    pixels with a value of zero unless a NODATA value is specified using :option:`--dst-nodata`
+    or an alpha mask band is added with :option:`--add-alpha`.
 
 .. option:: --target-aligned-pixels
 
@@ -81,14 +81,14 @@ The following options are available:
     such that the aligned extent includes the minimum extent.
     Alignment means that xmin / resx, ymin / resy, xmax / resx and ymax / resy are integer values.
 
-.. option:: --srcnodata <value>[,<value>]...
+.. option:: --src-nodata <value>[,<value>]...
 
     Set nodata values for input bands (different values can be supplied for each band).
     If the option is not specified, the intrinsic nodata settings on the source datasets
     will be used (if they exist). The value set by this option is written in the NODATA element
     of each ``ComplexSource`` element.
 
-.. option:: --dstnodata <value>[,<value>]...
+.. option:: --dst-nodata <value>[,<value>]...
 
     Set nodata values at the output band level (different values can be supplied for each band).  If more
     than one value is supplied, all values should be quoted to keep them together
@@ -97,11 +97,11 @@ The following options are available:
     is written in the ``NoDataValue`` element of each ``VRTRasterBand element``. Use a value of
     `None` to ignore intrinsic nodata settings on the source datasets.
 
-.. option:: --hidenodata
+.. option:: --hide-nodata
 
     Even if any band contains nodata value, giving this option makes the output band
     not report the NoData. Useful when you want to control the background color of
-    the dataset. By using along with the -addalpha option, you can prepare a
+    the dataset. By using along with the :option:`--add-alpha` option, you can prepare a
     dataset which doesn't report nodata value but is transparent in areas with no
     data.
 

--- a/doc/source/programs/gdal_raster_viewshed.rst
+++ b/doc/source/programs/gdal_raster_viewshed.rst
@@ -42,7 +42,7 @@ Standard options
    Only a single band can be used. Only the part of the raster within the specified
    maximum distance around the observer point is processed.
 
-.. option:: --dstnodata <value>
+.. option:: --dst-nodata <value>
 
    The value to be set for the cells in the output raster that have no data.
 
@@ -170,4 +170,4 @@ Examples
 
    .. code-block:: bash
 
-       gdal raster viewshed --max-distance=500 --pos=-10147017,5108065s source.tif destination.tif
+       gdal raster viewshed --max-distance=500 --pos=-10147017,5108065 source.tif destination.tif


### PR DESCRIPTION
Fixes #12255
