### PR TITLE
gdal raster reclassify: allow it to accept a MEM input dataset

### DIFF
--- a/apps/gdalalg_raster_reclassify.cpp
+++ b/apps/gdalalg_raster_reclassify.cpp
@@ -17,8 +17,6 @@
 #include "gdal_utils.h"
 #include "../frmts/vrt/vrtdataset.h"
 
-#include <optional>
-
 //! @cond Doxygen_Suppress
 
 #ifndef _
@@ -40,41 +38,6 @@ GDALRasterReclassifyAlgorithm::GDALRasterReclassifyAlgorithm(
            &m_mapping)
         .SetRequired();
     AddOutputDataTypeArg(&m_type);
-}
-
-/************************************************************************/
-/*                      GetNoDataValueAsString                          */
-/************************************************************************/
-
-static std::optional<std::string> GetNoDataValueAsString(GDALRasterBand &band)
-{
-    int hasNoData;
-    if (band.GetRasterDataType() == GDT_UInt64)
-    {
-        std::uint64_t noData = band.GetNoDataValueAsUInt64(&hasNoData);
-        if (hasNoData)
-        {
-            return std::to_string(noData);
-        }
-    }
-    else if (band.GetRasterDataType() == GDT_Int64)
-    {
-        std::int64_t noData = band.GetNoDataValueAsInt64(&hasNoData);
-        if (hasNoData)
-        {
-            return std::to_string(noData);
-        }
-    }
-    else
-    {
-        double noData = band.GetNoDataValue(&hasNoData);
-        if (hasNoData)
-        {
-            return std::to_string(noData);
-        }
-    }
-
-    return std::nullopt;
 }
 
 /************************************************************************/
@@ -109,42 +72,6 @@ GDALReclassifyCreateVRTDerived(GDALDataset &input, const std::string &mappings,
         CPLXMLNode *arguments =
             CPLCreateXMLNode(band, CXT_Element, "PixelFunctionArguments");
         CPLAddXMLAttributeAndValue(arguments, "mapping", mappings.c_str());
-
-        CPLXMLNode *source =
-            CPLCreateXMLNode(band, CXT_Element, "SimpleSource");
-
-        CPLXMLNode *sourceFilename =
-            CPLCreateXMLNode(source, CXT_Element, "SourceFilename");
-        CPLAddXMLAttributeAndValue(sourceFilename, "relativeToVRT", "0");
-        CPLCreateXMLNode(sourceFilename, CXT_Text, input.GetDescription());
-
-        CPLXMLNode *sourceBand =
-            CPLCreateXMLNode(source, CXT_Element, "SourceBand");
-        CPLCreateXMLNode(sourceBand, CXT_Text, std::to_string(iBand).c_str());
-
-        CPLXMLNode *srcRect = CPLCreateXMLNode(source, CXT_Element, "SrcRect");
-        CPLAddXMLAttributeAndValue(srcRect, "xOff", "0");
-        CPLAddXMLAttributeAndValue(srcRect, "yOff", "0");
-        CPLAddXMLAttributeAndValue(srcRect, "xSize",
-                                   std::to_string(nX).c_str());
-        CPLAddXMLAttributeAndValue(srcRect, "ySize",
-                                   std::to_string(nY).c_str());
-
-        CPLXMLNode *dstRect = CPLCreateXMLNode(source, CXT_Element, "DstRect");
-        CPLAddXMLAttributeAndValue(dstRect, "xOff", "0");
-        CPLAddXMLAttributeAndValue(dstRect, "yOff", "0");
-        CPLAddXMLAttributeAndValue(dstRect, "xSize",
-                                   std::to_string(nX).c_str());
-        CPLAddXMLAttributeAndValue(dstRect, "ySize",
-                                   std::to_string(nY).c_str());
-
-        auto noData = GetNoDataValueAsString(*input.GetRasterBand(iBand));
-        if (noData.has_value())
-        {
-            CPLXMLNode *noDataNode =
-                CPLCreateXMLNode(band, CXT_Element, "NoDataValue");
-            CPLCreateXMLNode(noDataNode, CXT_Text, noData.value().c_str());
-        }
     }
 
     auto ds = std::make_unique<VRTDataset>(nX, nY);
@@ -153,9 +80,18 @@ GDALReclassifyCreateVRTDerived(GDALDataset &input, const std::string &mappings,
         return nullptr;
     };
 
+    for (int iBand = 1; iBand <= input.GetRasterCount(); ++iBand)
+    {
+        auto poSrcBand = input.GetRasterBand(iBand);
+        auto poDstBand =
+            cpl::down_cast<VRTDerivedRasterBand *>(ds->GetRasterBand(iBand));
+        GDALCopyNoDataValue(poDstBand, poSrcBand);
+        poDstBand->AddSimpleSource(poSrcBand);
+    }
+
     std::array<double, 6> gt;
-    input.GetGeoTransform(gt.data());
-    ds->SetGeoTransform(gt.data());
+    if (input.GetGeoTransform(gt.data()) == CE_None)
+        ds->SetGeoTransform(gt.data());
     ds->SetSpatialRef(input.GetSpatialRef());
 
     return ds;


### PR DESCRIPTION
FYI @dbaston : using ``VRTDerivedRasterBand::AddSimpleSource(GDALRasterBand*)`` allows it to work with a unnamed / MEM source dataset