### PR TITLE
GDALAlgorithm: move common code dealing with overwriting in GDALAlgorithm::ProcessDatasetArg()

### DIFF
--- a/apps/gdalalg_raster_calc.cpp
+++ b/apps/gdalalg_raster_calc.cpp
@@ -580,24 +580,6 @@ bool GDALRasterCalcAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
 {
     CPLAssert(!m_outputDataset.GetDatasetRef());
 
-    const char *pszType = "";
-    if (!m_outputDataset.GetName().empty() &&
-        GDALDoesFileOrDatasetExist(m_outputDataset.GetName().c_str(), &pszType))
-    {
-        if (!m_overwrite)
-        {
-            ReportError(CE_Failure, CPLE_AppDefined,
-                        "%s '%s' already exists. Specify the --overwrite "
-                        "option to overwrite it.",
-                        pszType, m_outputDataset.GetName().c_str());
-            return false;
-        }
-        else
-        {
-            VSIUnlink(m_outputDataset.GetName().c_str());
-        }
-    }
-
     GDALCalcOptions options;
     options.checkExtent = !m_NoCheckExtent;
     options.checkSRS = !m_NoCheckSRS;

--- a/apps/gdalalg_raster_contour.cpp
+++ b/apps/gdalalg_raster_contour.cpp
@@ -171,24 +171,6 @@ bool GDALRasterContourAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
         aosOptions.AddString(m_outputLayerName);
     }
 
-    const char *pszType = "";
-    if (!m_outputDataset.GetName().empty() &&
-        GDALDoesFileOrDatasetExist(m_outputDataset.GetName().c_str(), &pszType))
-    {
-        if (!m_overwrite)
-        {
-            ReportError(CE_Failure, CPLE_AppDefined,
-                        "%s '%s' already exists. Specify the --overwrite "
-                        "option to overwrite it.",
-                        pszType, m_outputDataset.GetName().c_str());
-            return false;
-        }
-        else
-        {
-            VSIUnlink(m_outputDataset.GetName().c_str());
-        }
-    }
-
     // Check that one of --interval, --levels, --exp-base is specified
     if (m_levels.size() == 0 && std::isnan(m_interval) && m_expBase == 0)
     {

--- a/apps/gdalalg_raster_convert.cpp
+++ b/apps/gdalalg_raster_convert.cpp
@@ -44,8 +44,8 @@ GDALRasterConvertAlgorithm::GDALRasterConvertAlgorithm(
     AddCreationOptionsArg(&m_creationOptions);
     const char *exclusionGroup = "overwrite-append";
     AddOverwriteArg(&m_overwrite).SetMutualExclusionGroup(exclusionGroup);
-    AddArg("append", 0, _("Append as a subdataset to existing output"),
-           &m_append)
+    AddArg(GDAL_ARG_NAME_APPEND, 0,
+           _("Append as a subdataset to existing output"), &m_append)
         .SetDefault(false)
         .SetMutualExclusionGroup(exclusionGroup);
 }

--- a/apps/gdalalg_raster_create.cpp
+++ b/apps/gdalalg_raster_create.cpp
@@ -42,8 +42,8 @@ GDALRasterCreateAlgorithm::GDALRasterCreateAlgorithm()
     AddCreationOptionsArg(&m_creationOptions);
     const char *exclusionGroup = "overwrite-append";
     AddOverwriteArg(&m_overwrite).SetMutualExclusionGroup(exclusionGroup);
-    AddArg("append", 0, _("Append as a subdataset to existing output"),
-           &m_append)
+    AddArg(GDAL_ARG_NAME_APPEND, 0,
+           _("Append as a subdataset to existing output"), &m_append)
         .SetDefault(false)
         .SetMutualExclusionGroup(exclusionGroup);
     AddArg("size", 0, _("Output size in pixels"), &m_size)
@@ -88,24 +88,6 @@ bool GDALRasterCreateAlgorithm::RunImpl(GDALProgressFunc /* pfnProgress */,
                                         void * /*pProgressData */)
 {
     CPLAssert(!m_outputDataset.GetDatasetRef());
-
-    const char *pszType = "";
-    if (!m_append && !m_outputDataset.GetName().empty() &&
-        GDALDoesFileOrDatasetExist(m_outputDataset.GetName().c_str(), &pszType))
-    {
-        if (!m_overwrite)
-        {
-            ReportError(CE_Failure, CPLE_AppDefined,
-                        "%s '%s' already exists. Specify the --overwrite "
-                        "option to overwrite it, or --append to append to it.",
-                        pszType, m_outputDataset.GetName().c_str());
-            return false;
-        }
-        else
-        {
-            VSIUnlink(m_outputDataset.GetName().c_str());
-        }
-    }
 
     if (m_outputFormat.empty())
     {

--- a/apps/gdalalg_raster_fill_nodata.cpp
+++ b/apps/gdalalg_raster_fill_nodata.cpp
@@ -87,25 +87,6 @@ GDALRasterFillNodataAlgorithm::GDALRasterFillNodataAlgorithm() noexcept
 bool GDALRasterFillNodataAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
                                             void *pProgressData)
 {
-
-    const char *pszType = "";
-    if (!m_outputDataset.GetName().empty() &&
-        GDALDoesFileOrDatasetExist(m_outputDataset.GetName().c_str(), &pszType))
-    {
-        if (!m_overwrite)
-        {
-            ReportError(CE_Failure, CPLE_AppDefined,
-                        "%s '%s' already exists. Specify the --overwrite "
-                        "option to overwrite it.",
-                        pszType, m_outputDataset.GetName().c_str());
-            return false;
-        }
-        else
-        {
-            VSIUnlink(m_outputDataset.GetName().c_str());
-        }
-    }
-
     const CPLStringList creationOptions{m_creationOptions};
     const std::string destinationFormat{
         m_format.empty()

--- a/apps/gdalalg_raster_mosaic.cpp
+++ b/apps/gdalalg_raster_mosaic.cpp
@@ -174,24 +174,6 @@ bool GDALRasterMosaicAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
         return false;
     }
 
-    const char *pszType = "";
-    if (!m_outputDataset.GetName().empty() &&
-        GDALDoesFileOrDatasetExist(m_outputDataset.GetName().c_str(), &pszType))
-    {
-        if (!m_overwrite)
-        {
-            ReportError(CE_Failure, CPLE_AppDefined,
-                        "%s '%s' already exists. Specify the --overwrite "
-                        "option to overwrite it.",
-                        pszType, m_outputDataset.GetName().c_str());
-            return false;
-        }
-        else
-        {
-            VSIUnlink(m_outputDataset.GetName().c_str());
-        }
-    }
-
     const bool bVRTOutput =
         m_outputDataset.GetName().empty() || EQUAL(m_format.c_str(), "VRT") ||
         EQUAL(m_format.c_str(), "stream") ||

--- a/apps/gdalalg_raster_polygonize.cpp
+++ b/apps/gdalalg_raster_polygonize.cpp
@@ -44,26 +44,19 @@ GDALRasterPolygonizeAlgorithm::GDALRasterPolygonizeAlgorithm()
     AddCreationOptionsArg(&m_creationOptions);
     AddLayerCreationOptionsArg(&m_layerCreationOptions);
     AddOverwriteArg(&m_overwrite);
-    AddUpdateArg(&m_update);
+    auto &updateArg = AddUpdateArg(&m_update);
     AddArg("overwrite-layer", 0,
            _("Whether overwriting existing layer is allowed"),
            &m_overwriteLayer)
         .SetDefault(false)
         .AddValidationAction(
-            [this]
+            [&updateArg]
             {
-                GetArg(GDAL_ARG_NAME_UPDATE)->Set(true);
+                updateArg.Set(true);
                 return true;
             });
-    AddArg("append", 0, _("Whether appending to existing layer is allowed"),
-           &m_appendLayer)
-        .SetDefault(false)
-        .AddValidationAction(
-            [this]
-            {
-                GetArg(GDAL_ARG_NAME_UPDATE)->Set(true);
-                return true;
-            });
+    AddAppendUpdateArg(&m_appendLayer,
+                       _("Whether appending to existing layer is allowed"));
 
     // gdal_polygonize specific options
     AddBandArg(&m_band).SetDefault(m_band);
@@ -88,24 +81,6 @@ bool GDALRasterPolygonizeAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
 {
     auto poSrcDS = m_inputDataset.GetDatasetRef();
     CPLAssert(poSrcDS);
-
-    const char *pszType = "";
-    if (!m_update && !m_outputDataset.GetName().empty() &&
-        GDALDoesFileOrDatasetExist(m_outputDataset.GetName().c_str(), &pszType))
-    {
-        if (!m_overwrite)
-        {
-            ReportError(CE_Failure, CPLE_AppDefined,
-                        "%s '%s' already exists. Specify the --overwrite "
-                        "option to overwrite it, or --update to update it.",
-                        pszType, m_outputDataset.GetName().c_str());
-            return false;
-        }
-        else
-        {
-            VSIUnlink(m_outputDataset.GetName().c_str());
-        }
-    }
 
     GDALDataset *poDstDS = m_outputDataset.GetDatasetRef();
     std::unique_ptr<GDALDataset> poRetDS;
@@ -185,7 +160,7 @@ bool GDALRasterPolygonizeAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
             ReportError(CE_Failure, CPLE_AppDefined,
                         "Layer '%s' already exists. Specify the "
                         "--overwrite-layer option to overwrite it, or --append "
-                        "to append it.",
+                        "to append to it.",
                         m_outputLayerName.c_str());
             return false;
         }

--- a/apps/gdalalg_raster_stack.cpp
+++ b/apps/gdalalg_raster_stack.cpp
@@ -169,24 +169,6 @@ bool GDALRasterStackAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
         return false;
     }
 
-    const char *pszType = "";
-    if (!m_outputDataset.GetName().empty() &&
-        GDALDoesFileOrDatasetExist(m_outputDataset.GetName().c_str(), &pszType))
-    {
-        if (!m_overwrite)
-        {
-            ReportError(CE_Failure, CPLE_AppDefined,
-                        "%s '%s' already exists. Specify the --overwrite "
-                        "option to overwrite it.",
-                        pszType, m_outputDataset.GetName().c_str());
-            return false;
-        }
-        else
-        {
-            VSIUnlink(m_outputDataset.GetName().c_str());
-        }
-    }
-
     const bool bVRTOutput =
         m_outputDataset.GetName().empty() || EQUAL(m_format.c_str(), "VRT") ||
         EQUAL(m_format.c_str(), "stream") ||

--- a/apps/gdalalg_raster_viewshed.cpp
+++ b/apps/gdalalg_raster_viewshed.cpp
@@ -121,24 +121,6 @@ bool GDALRasterViewshedAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
 {
     CPLAssert(!m_outputDataset.GetDatasetRef());
 
-    const char *pszType = "";
-    if (!m_outputDataset.GetName().empty() &&
-        GDALDoesFileOrDatasetExist(m_outputDataset.GetName().c_str(), &pszType))
-    {
-        if (!m_overwrite)
-        {
-            ReportError(CE_Failure, CPLE_AppDefined,
-                        "%s '%s' already exists. Specify the --overwrite "
-                        "option to overwrite it.",
-                        pszType, m_outputDataset.GetName().c_str());
-            return false;
-        }
-        else
-        {
-            VSIUnlink(m_outputDataset.GetName().c_str());
-        }
-    }
-
     gdal::viewshed::Options opts;
 
     opts.observer.x = m_observerPos[0];

--- a/apps/gdalalg_vector_convert.cpp
+++ b/apps/gdalalg_vector_convert.cpp
@@ -42,14 +42,19 @@ GDALVectorConvertAlgorithm::GDALVectorConvertAlgorithm()
     AddCreationOptionsArg(&m_creationOptions);
     AddLayerCreationOptionsArg(&m_layerCreationOptions);
     AddOverwriteArg(&m_overwrite);
-    AddUpdateArg(&m_update);
+    auto &updateArg = AddUpdateArg(&m_update);
     AddArg("overwrite-layer", 0,
            _("Whether overwriting existing layer is allowed"),
            &m_overwriteLayer)
-        .SetDefault(false);
-    AddArg("append", 0, _("Whether appending to existing layer is allowed"),
-           &m_appendLayer)
-        .SetDefault(false);
+        .SetDefault(false)
+        .AddValidationAction(
+            [&updateArg]()
+            {
+                updateArg.Set(true);
+                return true;
+            });
+    AddAppendUpdateArg(&m_appendLayer,
+                       _("Whether appending to existing layer is allowed"));
     AddArg("input-layer", 'l', _("Input layer name(s)"), &m_inputLayerNames)
         .AddAlias("layer");
     AddArg("output-layer", 0, _("Output layer name"), &m_outputLayerName)
@@ -110,28 +115,30 @@ bool GDALVectorConvertAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
         aosOptions.AddString(name.c_str());
     }
 
-    GDALVectorTranslateOptions *psOptions =
-        GDALVectorTranslateOptionsNew(aosOptions.List(), nullptr);
-
-    GDALVectorTranslateOptionsSetProgress(psOptions, pfnProgress,
-                                          pProgressData);
-
-    GDALDatasetH hOutDS =
-        GDALDataset::ToHandle(m_outputDataset.GetDatasetRef());
-    GDALDatasetH hSrcDS = GDALDataset::ToHandle(m_inputDataset.GetDatasetRef());
-    auto poRetDS = GDALDataset::FromHandle(
-        GDALVectorTranslate(m_outputDataset.GetName().c_str(), hOutDS, 1,
-                            &hSrcDS, psOptions, nullptr));
-    GDALVectorTranslateOptionsFree(psOptions);
-    if (!poRetDS)
-        return false;
-
-    if (!hOutDS)
+    std::unique_ptr<GDALVectorTranslateOptions,
+                    decltype(&GDALVectorTranslateOptionsFree)>
+        psOptions(GDALVectorTranslateOptionsNew(aosOptions.List(), nullptr),
+                  GDALVectorTranslateOptionsFree);
+    bool bOK = false;
+    if (psOptions)
     {
-        m_outputDataset.Set(std::unique_ptr<GDALDataset>(poRetDS));
+        GDALVectorTranslateOptionsSetProgress(psOptions.get(), pfnProgress,
+                                              pProgressData);
+        GDALDatasetH hOutDS =
+            GDALDataset::ToHandle(m_outputDataset.GetDatasetRef());
+        GDALDatasetH hSrcDS =
+            GDALDataset::ToHandle(m_inputDataset.GetDatasetRef());
+        auto poRetDS = GDALDataset::FromHandle(
+            GDALVectorTranslate(m_outputDataset.GetName().c_str(), hOutDS, 1,
+                                &hSrcDS, psOptions.get(), nullptr));
+        bOK = poRetDS != nullptr;
+        if (!hOutDS)
+        {
+            m_outputDataset.Set(std::unique_ptr<GDALDataset>(poRetDS));
+        }
     }
 
-    return true;
+    return bOK;
 }
 
 //! @endcond

--- a/apps/gdalalg_vector_grid.cpp
+++ b/apps/gdalalg_vector_grid.cpp
@@ -301,24 +301,6 @@ bool GDALVectorGridAbstractAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
 
     GDALGridOptionsSetProgress(psOptions.get(), pfnProgress, pProgressData);
 
-    const char *pszType = "";
-    if (!m_outputDataset.GetName().empty() &&
-        GDALDoesFileOrDatasetExist(m_outputDataset.GetName().c_str(), &pszType))
-    {
-        if (!m_overwrite)
-        {
-            ReportError(CE_Failure, CPLE_AppDefined,
-                        "%s '%s' already exists. Specify the --overwrite "
-                        "option to overwrite it, or --update to update it.",
-                        pszType, m_outputDataset.GetName().c_str());
-            return false;
-        }
-        else
-        {
-            VSIUnlink(m_outputDataset.GetName().c_str());
-        }
-    }
-
     auto poRetDS = std::unique_ptr<GDALDataset>(GDALDataset::FromHandle(
         GDALGrid(m_outputDataset.GetName().c_str(),
                  GDALDataset::ToHandle(poSrcDS), psOptions.get(), nullptr)));

--- a/apps/gdalalg_vector_output_abstract.cpp
+++ b/apps/gdalalg_vector_output_abstract.cpp
@@ -73,24 +73,6 @@ GDALVectorOutputAbstractAlgorithm::SetupOutputDataset()
 {
     SetupOutputDatasetRet ret;
 
-    const char *pszType = "";
-    if (!m_update && !m_outputDataset.GetName().empty() &&
-        GDALDoesFileOrDatasetExist(m_outputDataset.GetName().c_str(), &pszType))
-    {
-        if (!m_overwrite)
-        {
-            ReportError(CE_Failure, CPLE_AppDefined,
-                        "%s '%s' already exists. Specify the --overwrite "
-                        "option to overwrite it, or --update to update it.",
-                        pszType, m_outputDataset.GetName().c_str());
-            return ret;
-        }
-        else
-        {
-            VSIUnlink(m_outputDataset.GetName().c_str());
-        }
-    }
-
     GDALDataset *poDstDS = m_outputDataset.GetDatasetRef();
     std::unique_ptr<GDALDataset> poRetDS;
     if (!poDstDS)
@@ -171,7 +153,7 @@ GDALVectorOutputAbstractAlgorithm::SetupOutputDataset()
             ReportError(CE_Failure, CPLE_AppDefined,
                         "Layer '%s' already exists. Specify the "
                         "--overwrite-layer option to overwrite it, or --append "
-                        "to append it.",
+                        "to append to it.",
                         m_outputLayerName.c_str());
             return ret;
         }

--- a/apps/gdalalg_vector_pipeline.cpp
+++ b/apps/gdalalg_vector_pipeline.cpp
@@ -100,14 +100,20 @@ void GDALVectorPipelineStepAlgorithm::AddOutputArgs(
     AddLayerCreationOptionsArg(&m_layerCreationOptions)
         .SetHiddenForCLI(hiddenForCLI);
     AddOverwriteArg(&m_overwrite).SetHiddenForCLI(hiddenForCLI);
-    AddUpdateArg(&m_update).SetHiddenForCLI(hiddenForCLI);
+    auto &updateArg = AddUpdateArg(&m_update).SetHiddenForCLI(hiddenForCLI);
     AddArg("overwrite-layer", 0,
            _("Whether overwriting existing layer is allowed"),
            &m_overwriteLayer)
         .SetDefault(false)
-        .SetHiddenForCLI(hiddenForCLI);
-    AddArg("append", 0, _("Whether appending to existing layer is allowed"),
-           &m_appendLayer)
+        .SetHiddenForCLI(hiddenForCLI)
+        .AddValidationAction(
+            [&updateArg]()
+            {
+                updateArg.Set(true);
+                return true;
+            });
+    AddAppendUpdateArg(&m_appendLayer,
+                       _("Whether appending to existing layer is allowed"))
         .SetDefault(false)
         .SetHiddenForCLI(hiddenForCLI);
     if (GetName() != GDALVectorSQLAlgorithm::NAME &&

--- a/autotest/utilities/test_gdalalg_raster_create.py
+++ b/autotest/utilities/test_gdalalg_raster_create.py
@@ -122,7 +122,7 @@ def test_gdalalg_raster_create_overwrite(tmp_vsimem):
     alg["size"] = [1, 1]
     with pytest.raises(
         Exception,
-        match="already exists. Specify the --overwrite option to overwrite it, or --append to append to it.",
+        match="already exists. Specify the --overwrite option to overwrite it or the --append option to append to it.",
     ):
         alg.Run()
 
@@ -426,3 +426,19 @@ def test_gdalalg_raster_create_creation_option(tmp_vsimem):
     assert alg.Finalize()
     with gdal.Open(tmp_vsimem / "out.tif") as ds:
         assert ds.GetMetadataItem("COMPRESSION", "IMAGE_STRUCTURE") == "LZW"
+
+
+def test_gdalalg_raster_create_overwrite_mem_file_with_real_file_same_name(tmp_vsimem):
+
+    out_filename = tmp_vsimem / "out.tif"
+
+    gdal.FileFromMemBuffer(out_filename, "")
+
+    alg = get_alg()
+    alg["output"] = out_filename
+    alg["output-format"] = "MEM"
+    alg["size"] = [1, 1]
+    alg["overwrite"] = True
+    assert alg.Run()
+
+    assert gdal.VSIStatL(out_filename) is not None

--- a/autotest/utilities/test_gdalalg_raster_index.py
+++ b/autotest/utilities/test_gdalalg_raster_index.py
@@ -94,7 +94,7 @@ def test_gdalalg_raster_index_overwrite(tmp_vsimem):
     alg["output"] = out_filename
     with pytest.raises(
         Exception,
-        match="already exists. Specify the --overwrite option to overwrite it, or --update to update it.",
+        match="already exists. Specify the --overwrite option to overwrite it or the --append option to append to it.",
     ):
         alg.Run()
 
@@ -104,7 +104,7 @@ def test_gdalalg_raster_index_overwrite(tmp_vsimem):
     alg["update"] = True
     with pytest.raises(
         Exception,
-        match="Layer 'out' already exists. Specify the --overwrite-layer option to overwrite it, or --append to append it.",
+        match="Layer 'out' already exists. Specify the --overwrite-layer option to overwrite it, or --append to append to it.",
     ):
         alg.Run()
 

--- a/autotest/utilities/test_gdalalg_raster_polygonize.py
+++ b/autotest/utilities/test_gdalalg_raster_polygonize.py
@@ -113,7 +113,7 @@ def test_gdalalg_raster_polygonize_overwrite(tmp_vsimem):
     alg["output"] = out_filename
     with pytest.raises(
         Exception,
-        match="already exists. Specify the --overwrite option to overwrite it, or --update to update it",
+        match="already exists. Specify the --overwrite option to overwrite it or the --append option to append to it",
     ):
         alg.Run()
     with ogr.Open(out_filename) as ds:
@@ -126,7 +126,7 @@ def test_gdalalg_raster_polygonize_overwrite(tmp_vsimem):
     alg["update"] = True
     with pytest.raises(
         Exception,
-        match="Layer 'out' already exists. Specify the --overwrite-layer option to overwrite it, or --append to append it",
+        match="Layer 'out' already exists. Specify the --overwrite-layer option to overwrite it, or --append to append to it",
     ):
         alg.Run()
     with ogr.Open(out_filename) as ds:

--- a/autotest/utilities/test_gdalalg_vector_convert.py
+++ b/autotest/utilities/test_gdalalg_vector_convert.py
@@ -175,3 +175,63 @@ def test_gdalalg_vector_convert_vsistdout(tmp_vsimem):
     assert convert.Run()
     assert convert.Finalize()
     assert gdal.OpenEx(f"{tmp_vsimem}/tmp.json") is not None
+
+
+@pytest.mark.require_driver("OpenFileGDB")
+def test_gdalalg_vector_convert_overwrite_fgdb(tmp_vsimem):
+
+    convert = get_convert_alg()
+    convert["input"] = "../ogr/data/poly.shp"
+    convert["output"] = tmp_vsimem / "out.gdb"
+    convert["output-format"] = "OpenFileGDB"
+    convert["layer-creation-option"] = {
+        "TARGET_ARCGIS_VERSION": "ARCGIS_PRO_3_2_OR_LATER"
+    }
+    assert convert.Run()
+    assert convert.Finalize()
+
+    gdal.FileFromMemBuffer(tmp_vsimem / "out.gdb" / "new_file.txt", "foo")
+    assert gdal.VSIStatL(tmp_vsimem / "out.gdb" / "new_file.txt") is not None
+
+    convert = get_convert_alg()
+    convert["input"] = "../ogr/data/poly.shp"
+    convert["output"] = tmp_vsimem / "out.gdb"
+    convert["output-format"] = "OpenFileGDB"
+    convert["overwrite"] = True
+    convert["layer-creation-option"] = {
+        "TARGET_ARCGIS_VERSION": "ARCGIS_PRO_3_2_OR_LATER"
+    }
+    assert convert.Run()
+    assert convert.Finalize()
+
+    assert gdal.VSIStatL(tmp_vsimem / "out.gdb" / "new_file.txt") is None
+
+
+@pytest.mark.require_driver("OpenFileGDB")
+def test_gdalalg_vector_convert_overwrite_non_dataset_directory(tmp_vsimem):
+
+    gdal.FileFromMemBuffer(tmp_vsimem / "out" / "foo", "bar")
+
+    convert = get_convert_alg()
+    convert["input"] = "../ogr/data/poly.shp"
+    convert["output"] = tmp_vsimem / "out"
+    convert["output-format"] = "OpenFileGDB"
+    convert["overwrite"] = True
+    with pytest.raises(
+        Exception,
+        match="already exists, but is not recognized as a valid GDAL dataset. Please manually delete it before retrying",
+    ):
+        convert.Run()
+
+
+@pytest.mark.require_driver("GPKG")
+def test_gdalalg_vector_convert_overwrite_non_dataset_file(tmp_vsimem):
+
+    gdal.FileFromMemBuffer(tmp_vsimem / "out.gpkg", "bar")
+
+    convert = get_convert_alg()
+    convert["input"] = "../ogr/data/poly.shp"
+    convert["output"] = tmp_vsimem / "out.gpkg"
+    convert["output-format"] = "GPKG"
+    convert["overwrite"] = True
+    assert convert.Run()

--- a/autotest/utilities/test_gdalalg_vector_rasterize.py
+++ b/autotest/utilities/test_gdalalg_vector_rasterize.py
@@ -520,8 +520,8 @@ def test_gdalalg_vector_rasterize_add_option(tmp_vsimem):
         )
         assert last_pct[0] == 1.0
 
-        target_ds = gdal.Open(output_tif)
-        checksum = target_ds.GetRasterBand(2).Checksum()
+        with gdal.Open(output_tif) as target_ds:
+            checksum = target_ds.GetRasterBand(2).Checksum()
 
         assert checksum == 121
 

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -4720,7 +4720,8 @@ GDALGetSTACCommonNameFromColorInterp(GDALColorInterp eInterp);
 std::string CPL_DLL GDALGetCacheDirectory();
 
 bool GDALDoesFileOrDatasetExist(const char *pszName,
-                                const char **ppszType = nullptr);
+                                const char **ppszType = nullptr,
+                                GDALDriver **ppDriver = nullptr);
 
 std::string CPL_DLL
 GDALGetMessageAboutMissingPluginDriver(GDALDriver *poMissingPluginDriver);

--- a/gcore/gdalalgorithm.h
+++ b/gcore/gdalalgorithm.h
@@ -311,6 +311,9 @@ constexpr const char *GDAL_ARG_NAME_UPDATE = "update";
 /** Name of the argument for overwrite. */
 constexpr const char *GDAL_ARG_NAME_OVERWRITE = "overwrite";
 
+/** Name of the argument for append. */
+constexpr const char *GDAL_ARG_NAME_APPEND = "append";
+
 /** Name of the argument for read-only. */
 constexpr const char *GDAL_ARG_NAME_READ_ONLY = "read-only";
 


### PR DESCRIPTION
and avoid overwriting a real file when outputting to MEM
