### PR TITLE
[Backport release/3.11] Add linking to -latomic for std::atomic<uint64_t> on architectures where it is needed

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -112,7 +112,9 @@ gdal_standard_includes(appslib)
 target_compile_options(appslib PRIVATE ${GDAL_CXX_WARNING_FLAGS} ${WFLAG_OLD_STYLE_CAST} ${WFLAG_EFFCXX})
 target_include_directories(
   appslib PRIVATE $<TARGET_PROPERTY:gdal_vrt,SOURCE_DIR> $<TARGET_PROPERTY:ogrsf_generic,SOURCE_DIR>)
-
+if (HAVE_ATOMIC_UINT64_T_WITH_ATOMIC)
+    gdal_target_link_libraries(appslib PRIVATE atomic)
+endif()
 gdal_target_link_libraries(appslib PRIVATE PROJ::proj)
 
 set_property(TARGET appslib PROPERTY POSITION_INDEPENDENT_CODE ${GDAL_OBJECT_LIBRARIES_POSITION_INDEPENDENT_CODE})


### PR DESCRIPTION
Backport #12275
 **Authored by:** @rouault