### PR TITLE
ZIP filename warning suppression, and LIBKML warning suppression

### DIFF
--- a/autotest/gcore/vsifile.py
+++ b/autotest/gcore/vsifile.py
@@ -1226,6 +1226,27 @@ def test_vsifile_vsizip_stored():
 
 
 ###############################################################################
+# Test creating a file in a ZIP with non-Latin1 character
+
+
+def test_vsifile_vsizip_non_latin1_char(tmp_vsimem):
+
+    gdal.ErrorReset()
+    with gdal.VSIFile(
+        f"/vsizip/{tmp_vsimem}/test.zip/" + b"\xE5\xAE\x89.txt".decode("UTF-8"), "wb"
+    ) as f:
+        f.close()
+        assert gdal.GetLastErrorMsg() == ""
+
+    assert gdal.ReadDir(f"/vsizip/{tmp_vsimem}/test.zip") == [
+        b"\xE5\xAE\x89.txt".decode("UTF-8")
+    ]
+
+    with gdal.VSIFile(f"{tmp_vsimem}/test.zip", "rb") as f:
+        assert b"0xE50xAE0x89" in f.read()
+
+
+###############################################################################
 # Test that VSIFTruncateL() zeroize beyond the truncated area
 
 

--- a/ogr/ogrsf_frmts/libkml/ogrlibkmldrivercore.cpp
+++ b/ogr/ogrsf_frmts/libkml/ogrlibkmldrivercore.cpp
@@ -292,8 +292,10 @@ void OGRLIBKMLDriverSetCommonMetadata(GDALDriver *poDriver)
         "</LayerCreationOptionList>");
 
     poDriver->SetMetadataItem(GDAL_DCAP_VIRTUALIO, "YES");
-    poDriver->SetMetadataItem(GDAL_DMD_CREATIONFIELDDATATYPES,
-                              "Integer Real String");
+    poDriver->SetMetadataItem(
+        GDAL_DMD_CREATIONFIELDDATATYPES,
+        "Integer Integer64 Real String Date DateTime Time");
+    poDriver->SetMetadataItem(GDAL_DMD_CREATIONFIELDDATASUBTYPES, "Boolean");
     poDriver->SetMetadataItem(GDAL_DCAP_FEATURE_STYLES, "YES");
     poDriver->SetMetadataItem(GDAL_DCAP_FEATURE_STYLES_READ, "YES");
     poDriver->SetMetadataItem(GDAL_DCAP_FEATURE_STYLES_WRITE, "YES");

--- a/port/cpl_minizip_zip.cpp
+++ b/port/cpl_minizip_zip.cpp
@@ -2104,7 +2104,36 @@ CPLErr CPLCreateFileInZip(void *hZip, const char *pszFilename,
 #endif
         );
 
-        pszCPFilename = CPLRecode(pszFilename, CPL_ENC_UTF8, pszDestEncoding);
+        {
+            CPLErrorStateBackuper oBackuper(CPLQuietErrorHandler);
+            pszCPFilename =
+                CPLRecode(pszFilename, CPL_ENC_UTF8, pszDestEncoding);
+
+            char *pszBackToUTF8 =
+                CPLRecode(pszCPFilename, pszDestEncoding, CPL_ENC_UTF8);
+            if (strcmp(pszBackToUTF8, pszFilename) != 0)
+            {
+                // If the UTF-8 name cannot be properly encoded to CPL_ZIP_ENCODING,
+                // then generate an ASCII name for it where non-ASCII characters
+                // are replaced by an hexadecimal representation
+                std::string s;
+                for (int i = 0; pszFilename[i]; ++i)
+                {
+                    if (static_cast<unsigned char>(pszFilename[i]) <= 127)
+                    {
+                        s += pszFilename[i];
+                    }
+                    else
+                    {
+                        s += CPLSPrintf("0x%02X", static_cast<unsigned char>(
+                                                      pszFilename[i]));
+                    }
+                }
+                CPLFree(pszCPFilename);
+                pszCPFilename = CPLStrdup(s.c_str());
+            }
+            CPLFree(pszBackToUTF8);
+        }
 
         /* Create a Info-ZIP Unicode Path Extra Field (0x7075) */
         const size_t nDataLength =


### PR DESCRIPTION
- ZIP creation: do not warn on filenames within ZIP that are non-Latin1
- LIBKML: advertize Date/Time/DateTime/Integer64 (mapped as string) as types on creations; do proper mapping of bool
    
Fixes #12292
