### PR TITLE
[Backport release/3.11] OGRGeometry::OGRexportToSFCGAL(): fix for 3D geometries for SFCGAL >= 1.5.2

### DIFF
--- a/autotest/ogr/ogr_geom.py
+++ b/autotest/ogr/ogr_geom.py
@@ -239,7 +239,7 @@ def test_ogr_geom_polyhedral_surface():
     #        print(wkt_geom)
     #        return 'fail'
 
-    if ogrtest.have_geos() or ogrtest.have_sfcgal():
+    if ogrtest.have_geos():
         geom = ogr.CreateGeometryFromWkb(wkb_string)
         assert ps.Contains(geom), "Failure in Contains() of PolyhedralSurface"
 
@@ -349,7 +349,7 @@ def test_ogr_geom_tin():
         tin.GetGeometryCount() == geom_count
     ), "Added wrong geometry in TIN, error has code " + str(x)
 
-    if ogrtest.have_geos() or ogrtest.have_sfcgal():
+    if ogrtest.have_geos():
         point = tin.PointOnSurface()
         point_wkt = point.ExportToWkt()
         point_correct_wkt = "POINT EMPTY"

--- a/ogr/ogrgeometry.cpp
+++ b/ogr/ogrgeometry.cpp
@@ -8114,6 +8114,8 @@ OGRGeometry::OGRexportToSFCGAL(UNUSED_IF_NO_SFCGAL const OGRGeometry *poGeom)
         // Set export options with NDR byte order
         OGRwkbExportOptions oOptions;
         oOptions.eByteOrder = wkbNDR;
+        // and ISO to avoid wkb25DBit for Z geometries
+        oOptions.eWkbVariant = wkbVariantIso;
 
         // Export to WKB
         sfcgal_geometry_t *sfcgalGeom = nullptr;


### PR DESCRIPTION
Backport #12291
 **Authored by:** @rouault