### PR TITLE
MRF: flush overviews on close

### DIFF
--- a/frmts/mrf/marfa_dataset.cpp
+++ b/frmts/mrf/marfa_dataset.cpp
@@ -158,9 +158,9 @@ MRFDataset::~MRFDataset()
             CPLError(CE_Failure, CPLE_FileIO, "Error creating files");
         }
 
+    MRFDataset::FlushCache(true);
     if (eAccess != GA_ReadOnly)
     {
-        MRFDataset::FlushCache(true);
         // There could be data in the overviews that needs to be flushed
         for (int i = 0; i < nBands; i++)
         {


### PR DESCRIPTION
## What does this PR do?

Before closing the MRF dataset, the overview bands block caches might need to be flushed.

## What are related issues/pull requests?
This problem that surfaced because of recent changes in GDALRegenerateOverviewsMultiBand(), related to issue #12303

## Environment