### PR TITLE
Add a glossary and example link

### DIFF
--- a/doc/source/glossary.rst
+++ b/doc/source/glossary.rst
@@ -108,6 +108,12 @@ The GDAL glossary contains terms and acronyms found throughout the GDAL document
 
         Well-Known Text. Text representation of geometries described in the Simple Features for SQL (SFSQL) specification.
 
+    WKT-CRS
+
+        Well-Known Text for Coordinate Reference Systems. A text format that defines how to describe coordinate reference
+        systems and transformations between them in a standardized way.
+        See the `OGC WKT-CRS standard <https://www.ogc.org/standards/wkt-crs/>__.
+
     WKB
 
         Well-Known Binary. Binary representation of geometries described in the Simple Features for SQL (SFSQL) specification.

--- a/doc/source/glossary.rst
+++ b/doc/source/glossary.rst
@@ -1,0 +1,128 @@
+.. _glossary:
+
+================================================================================
+Glossary
+================================================================================
+
+The GDAL glossary contains terms and acronyms found throughout the GDAL documentation
+
+.. glossary::
+
+    Affine Transformation
+
+        A geometric change that preserves points, straight lines, and ratios, including scaling, rotating, or translating.
+
+    API
+
+        Application Programming Interface. A set of rules that lets different software programs communicate and share data or functions.
+
+    DEM
+
+        Digital Elevation Model. A raster representation of the height of the earth's surface.
+
+    Euclidean Distance
+
+        A measure of the straight-line distance between two points in space.
+
+    EPSG
+
+        European Petroleum Survey Group. A group of geospatial experts for the petroleum industry (1986–2005),
+        now part of IOGP (International Association of Oil & Gas Producers). Known for creating the EPSG Geodetic Parameter Dataset,
+        a widely used database of coordinate systems and geodetic parameters.
+
+    Gridding
+
+        The process of converting scattered or irregularly spaced data points into a regular, structured grid format.
+
+        .. seealso::
+            :ref:`gdal_grid_tut`.
+
+    Georeference
+
+        Linking data to real-world geographic coordinates so a location can be accurately mapped.
+
+    Geotransform
+
+        A set of parameters that defines how to convert pixel locations in an image to real-world geographic coordinates.
+
+        .. seealso::
+            :ref:`geotransforms_tut`.
+
+    GNM
+
+        Geographic Network Model. A GDAL abstraction for different existed network formats.
+
+        .. seealso::
+            :ref:`gnm_data_model`.
+
+    Interpolation
+
+        A mathematical and statistical technique used to estimate unknown values between known values.
+
+        .. seealso::
+            :ref:`gdal_grid_tut`.
+
+    Hypsometric
+
+        The measurement and representation of land elevation (or terrain height) relative to sea level.
+
+    Moving Average
+
+        A method that smooths data by averaging values over a sliding window of data points.
+
+        .. seealso::
+            :ref:`gdal_grid_tut`.
+
+    Nearest Neighbor
+
+        A method that finds the closest data point(s) to a given point, often used for classification or estimation based on similarity.
+
+    Raster
+
+        A type of spatial data used with GIS, consisting of a regular grid of points spaced at a set distance (the resolution);
+        often used to represent heights (DEM) or temperature data.
+
+    Search Ellipse
+
+        :term:`Search window` in :term:`gridding` algorithms specified in the form of rotated ellipse.
+
+        .. seealso::
+            :ref:`gdal_grid_tut`.
+
+    Search Window
+
+        A defined area within which data is analyzed or searched, often used in spatial analysis or image processing.
+
+        .. seealso::
+            :ref:`gdal_grid_tut`.
+
+    VSI
+
+        Virtual System Interface. An interface for accessing files and datasets in non-filesystem locations, such as
+        in-memory files, zip files, and over network protocols.
+
+        .. seealso::
+            :ref:`virtual_file_systems`.
+
+    WKT
+
+        Well-Known Text. Text representation of geometries described in the Simple Features for SQL (SFSQL) specification.
+
+    WKB
+
+        Well-Known Binary. Binary representation of geometries described in the Simple Features for SQL (SFSQL) specification.
+
+
+Credits and Acknowledgments
+---------------------------
+
+Some definitions have been created with the help of the following resources.
+
++ `Introduction to Spatial Data and Using R as a GIS <https://github.com/nickbearman/intro-r-spatial-analysis/blob/main/glossary.tex>`__ by Nick Bearman,
+  licensed under the `Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International <http://creativecommons.org/licenses/by-nc-sa/4.0/>`__
++ `The Good Docs Project Glossary Initiative <https://drive.google.com/drive/folders/1v5ir_VrR71RFxR8ipf9xmpIIH8muEvEK>`__,
+  by various contributors to the project, used under the following `Terms of Use <https://www.thegooddocsproject.dev/terms-of-use>`__.
++ The `MapServer Glossary <https://mapserver.org/glossary.html>`__ covered by the `MapServer Licensing <https://mapserver.org/copyright.html>`__.
+
+.. spelling:word-list::
+    Bearman

--- a/doc/source/glossary.rst
+++ b/doc/source/glossary.rst
@@ -112,7 +112,7 @@ The GDAL glossary contains terms and acronyms found throughout the GDAL document
 
         Well-Known Text for Coordinate Reference Systems. A text format that defines how to describe coordinate reference
         systems and transformations between them in a standardized way.
-        See the `OGC WKT-CRS standard <https://www.ogc.org/standards/wkt-crs/>__.
+        See the `OGC WKT-CRS standard <https://www.ogc.org/standards/wkt-crs/>`__.
 
     WKB
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -21,6 +21,7 @@ GDAL
     sponsors/index
     contributing/index
     faq
+    glossary
     license
     thanks
 

--- a/doc/source/programs/gdal_raster_color_map.rst
+++ b/doc/source/programs/gdal_raster_color_map.rst
@@ -22,7 +22,7 @@ Description
 
 :program:`gdal raster color-map` generates a RGB or RGBA dataset from a
 single band, using a color map, either attached directly to a raster band,
-or from an external text file. It is typically used to create hypsometric maps
+or from an external text file. It is typically used to create :term:`hypsometric` maps
 from a DEM.
 
 This subcommand is also available as a potential step of :ref:`gdal_raster_pipeline`

--- a/doc/source/programs/gdal_raster_color_merge.rst
+++ b/doc/source/programs/gdal_raster_color_merge.rst
@@ -84,8 +84,6 @@ Examples
 .. below is an allow-list for spelling checker.
 
 .. spelling:word-list::
-    Hypsometric
-    hypsometric
     RGB
     RGBA
     HSV

--- a/doc/source/spelling_wordlist.txt
+++ b/doc/source/spelling_wordlist.txt
@@ -1367,6 +1367,8 @@ Hydrologic
 Hydrological
 hypercubes
 hyperspectral
+hypsometric
+Hypsometric
 iAxis
 iBand
 iChild

--- a/doc/source/tutorials/gdal_grid_tut.rst
+++ b/doc/source/tutorials/gdal_grid_tut.rst
@@ -22,7 +22,7 @@ regular grid for further processing and combining with other grids.
     .. image:: ../../images/grid/gridding.png
         :alt:   Scattered data gridding
 
-This problem can be solved using data interpolation or approximation
+This problem can be solved using data :term:`interpolation` or approximation
 algorithms. But you are not limited by interpolation here. Sometimes you don't
 need to interpolate your data but rather compute some statistics or data
 metrics over the region. Statistics are valuable themselves or could be used for
@@ -64,7 +64,7 @@ where:
 - :math:`p` is a weighting power,
 - :math:`n` is a number of points in `Search Ellipse`_.
 
-The smoothing parameter :math:`s` is used as an additive term in the Euclidean distance calculation:
+The smoothing parameter :math:`s` is used as an additive term in the :term:`Euclidean distance` calculation:
 
 .. math::
 

--- a/doc/source/tutorials/geotransforms_tut.rst
+++ b/doc/source/tutorials/geotransforms_tut.rst
@@ -6,7 +6,7 @@ Geotransform Tutorial
 
 Introduction to Geotransforms:
 -------------------------------
-A geotransform is an affine transformation from the image coordinate space (row, column),
+A geotransform is an :term:`affine transformation` from the image coordinate space (row, column),
 also known as (pixel, line)
 to the georeferenced coordinate space (projected or geographic coordinates).
 

--- a/doc/source/user/raster_data_model.rst
+++ b/doc/source/user/raster_data_model.rst
@@ -26,7 +26,7 @@ Dataset coordinate systems are represented as OpenGIS Well Known Text strings. T
 - A list of projection parameters (e.g., central_meridian).
 - A units name, and conversion factor to meters or radians.
 - Names and ordering for the axes.
-- Codes for most of the above in terms of predefined coordinate systems from authorities such as EPSG.
+- Codes for most of the above in terms of predefined coordinate systems from authorities such as :term:`EPSG`.
 
 For more information on OpenGIS WKT coordinate system definitions, and mechanisms to manipulate them, refer to the osr_tutorial document and/or the OGRSpatialReference class documentation.
 


### PR DESCRIPTION
The GDAL docs contain a lot of abbreviations and technical terms. A glossary defining these terms and abbreviations could be of use to a reader. 

This PR adds a glossary page to the GDAL docs, with an example link, as a starting point for discussions to see if this would be a good idea to include and expand upon. 

The glossary uses the standard Sphinx glossary approach, similar to MapServer https://mapserver.org/glossary.html

![image](https://github.com/user-attachments/assets/a41de080-1473-481e-b403-2453c9804770)

Terms can link to the glossary using the following syntax. An example is included in this PR. 

```
:term:`EPSG`
```

![image](https://github.com/user-attachments/assets/d5bb72e6-d7ba-4697-8db7-85c59a83084e)

There is an OSGeo Lexicon mailing list that was looking to "Coordinate definitions for terminology used within the OSGeo context" - https://lists.osgeo.org/mailman/listinfo/lexicon. I've emailed the list to see if there are any definition datasets that could be used as a starting point. 
