### PR TITLE
GDALRegenerateOverviewsMultiBand(): raise threshold to go to on-disk …

### DIFF
--- a/autotest/gcore/tiff_ovr.py
+++ b/autotest/gcore/tiff_ovr.py
@@ -2681,7 +2681,31 @@ def test_tiff_ovr_external_mask_update(tmp_vsimem):
 # of the default scanlines based one
 
 
-def test_tiff_ovr_fallback_to_multiband_overview_generate():
+@pytest.mark.parametrize(
+    "config_options",
+    [
+        {
+            "GDAL_OVR_CHUNK_MAX_SIZE": "1000",
+            "GDAL_OVR_CHUNK_MAX_SIZE_FOR_TEMP_FILE": "10000",
+        },
+        {
+            "GDAL_OVR_CHUNK_MAX_SIZE": "1000",
+            "GDAL_OVR_CHUNK_MAX_SIZE_FOR_TEMP_FILE": "10000",
+            "GDAL_OVR_TEMP_DRIVER": "MEM",
+        },
+        {
+            "GDAL_OVR_CHUNK_MAX_SIZE": "1000",
+            "GDAL_OVR_CHUNK_MAX_SIZE_FOR_TEMP_FILE": "10000",
+            "GDAL_OVR_TEMP_DRIVER": "GTIFF",
+        },
+        {
+            "GDAL_OVR_CHUNK_MAX_SIZE": "1000",
+            "GDAL_OVR_CHUNK_MAX_SIZE_FOR_TEMP_FILE": "1000",
+            "GDAL_OVR_TEMP_DRIVER": "GTIFF",
+        },
+    ],
+)
+def test_tiff_ovr_fallback_to_multiband_overview_generate(config_options):
 
     filename = "/vsimem/test_tiff_ovr_issue_4932_src.tif"
     ds = gdal.Translate(
@@ -2689,9 +2713,7 @@ def test_tiff_ovr_fallback_to_multiband_overview_generate():
         "data/byte.tif",
         options="-b 1 -b 1 -b 1 -co INTERLEAVE=BAND -co TILED=YES -outsize 1024 1024",
     )
-    with gdaltest.config_options(
-        {"GDAL_OVR_CHUNK_MAX_SIZE": "1000", "GDAL_OVR_TEMP_DRIVER": "MEM"}
-    ):
+    with gdaltest.config_options(config_options):
         ds.BuildOverviews("NEAR", overviewlist=[2, 4, 8])
     ds = None
 

--- a/port/cpl_known_config_options.h
+++ b/port/cpl_known_config_options.h
@@ -342,6 +342,7 @@ constexpr static const char* const apszKnownConfigOptions[] =
    "GDAL_OPENGIS_SCHEMAS", // from cpl_xml_validate.cpp
    "GDAL_OVERVIEW_OVERSAMPLING_THRESHOLD", // from rasterio.cpp, vrtwarped.cpp
    "GDAL_OVR_CHUNK_MAX_SIZE", // from overview.cpp
+   "GDAL_OVR_CHUNK_MAX_SIZE_FOR_TEMP_FILE", // from overview.cpp
    "GDAL_OVR_CHUNKYSIZE", // from overview.cpp
    "GDAL_OVR_PROPAGATE_NODATA", // from overview.cpp
    "GDAL_OVR_TEMP_DRIVER", // from overview.cpp


### PR DESCRIPTION
…temporary file

to be at least to accomodate of 1024 pixel block size and 3 bands. And also make GTiff temporary file tiled and compressed.

And flush overview bands when going through that temporary file code path.

Fixes #12303

I've verified that no temporary file is created with:
```
$ gdal_translate autotest/gdrivers/data/small_world.tif tmp.mrf -of mrf -co blocksize=1024 -outsize 11000 11000
$ gdaladdo -r average tmp.mrf 2
```
