### PR TITLE
cmake_builds.yml:  numpy>=2

### DIFF
--- a/.github/workflows/cmake_builds.yml
+++ b/.github/workflows/cmake_builds.yml
@@ -243,7 +243,7 @@ jobs:
         source myvenv/bin/activate
         # Set PATH so that gdal-config is found
         PYTHON_CMD=python3 && PATH=$GITHUB_WORKSPACE/install-gdal/bin:$PATH $PYTHON_CMD -m pip uninstall numpy
-        PYTHON_CMD=python3 && PATH=$GITHUB_WORKSPACE/install-gdal/bin:$PATH $PYTHON_CMD -m pip install numpy==1.26.4
+        PYTHON_CMD=python3 && PATH=$GITHUB_WORKSPACE/install-gdal/bin:$PATH $PYTHON_CMD -m pip install numpy>=2.0
         PYTHON_CMD=python3 && PATH=$GITHUB_WORKSPACE/install-gdal/bin:$PATH $PYTHON_CMD -m pip install gdal-python.tar.gz[numpy]
         LD_LIBRARY_PATH=$GITHUB_WORKSPACE/install-gdal/lib python -c "from osgeo import gdal_array"
         which gdal_edit


### PR DESCRIPTION
Can we bump the numpy issue in the builds? 


## What does this PR do?

Unpins the numpy version from 1.26.4 in docker builds. 

## What are related issues/pull requests?

https://lists.osgeo.org/pipermail/gdal-dev/2024-July/059198.html

A slightly cheeky PR since I'm not otherwise sure how to test this in context.   I really want to have numpy>2 when leveraging the docker image 🙏 