### PR TITLE
[Backport release/3.11] GDALAlgorithm: fix reading a .gdalg.json dataset with 'GDALG' input format option specified

### DIFF
--- a/autotest/utilities/test_gdalalg_raster_info.py
+++ b/autotest/utilities/test_gdalalg_raster_info.py
@@ -154,3 +154,11 @@ def test_gdalalg_raster_info_list_subdataset_error_cannot_open_subdataset():
         match="i_do_not_exist",
     ):
         info.ParseRunAndFinalize(["--subdataset=1"])
+
+
+@pytest.mark.require_driver("GDALG")
+def test_gdalalg_raster_info_read_gdalg_with_input_format():
+    info = get_info_alg()
+    info["input"] = "../gdrivers/data/gdalg/read_byte.gdalg.json"
+    info["input-format"] = "GDALG"
+    assert info.Run()

--- a/gcore/gdalalgorithm.cpp
+++ b/gcore/gdalalgorithm.cpp
@@ -3434,7 +3434,7 @@ bool GDALAlgorithm::ValidateFormat(const GDALAlgorithmArg &arg,
             if (bStreamAllowed && EQUAL(val.c_str(), "stream"))
                 return true;
 
-            if (EQUAL(val.c_str(), "GDALG"))
+            if (EQUAL(val.c_str(), "GDALG") && arg.IsOutput())
             {
                 if (bGDALGAllowed)
                 {


### PR DESCRIPTION
Backport #12298
 **Authored by:** @rouault