### PR TITLE
Doc: added missing .prj to CREATE_CSVT

### DIFF
--- a/doc/source/drivers/vector/csv.rst
+++ b/doc/source/drivers/vector/csv.rst
@@ -469,6 +469,7 @@ The following layer creation options are supported:
       Create the
       associated .csvt file (see above paragraph) to describe the type of
       each column of the layer and its optional width and precision.
+      This option also creates .prj file which stores coordinate system information.
 
 -  .. lco:: SEPARATOR
       :choices: COMMA, SEMICOLON, TAB, SPACE


### PR DESCRIPTION
Driver also creates PRJ side-car file when this option is used. This wasn't documented, and there is no separate LCO to create PRJ file only.