### PR TITLE
Exclude index_pdf.rst for non-latex builds

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1102,8 +1102,15 @@ shutil.copy(
 )
 
 
+def builder_inited(app):
+
+    if app.builder.name == "html":
+        check_python_bindings()
+
+    # exclude the PDF toctree from HTML builds
+    if app.builder.name != "latex":
+        app.config.exclude_patterns.append("index_pdf.rst")
+
+
 def setup(app):
-    app.connect(
-        "builder-inited",
-        lambda app: check_python_bindings() if app.builder.name == "html" else None,
-    )
+    app.connect("builder-inited", builder_inited)


### PR DESCRIPTION
Currently, when building the docs several warnings are output:

```
checking consistency... C:\docs\gdal\doc\source\api\index.rst: document is referenced in multiple toctrees: ['index_pdf
  ', 'index'], selecting: index_pdf <- api/index
  C:\docs\gdal\doc\source\community\index.rst: document is referenced in multiple toctrees: ['index_pdf', 'index'], selecting: index_pdf
  <- community/index
  C:\docs\gdal\doc\source\contributing\index.rst: document is referenced in multiple toctrees: ['index_pdf', 'index'], selecting: index_p
  df <- contributing/index
  C:\docs\gdal\doc\source\download.rst: document is referenced in multiple toctrees: ['index_pdf', 'index'], selecting: index_pdf <- down
  load
...
```

This PR excludes the index_pdf.pdf for non-latex builds to stop the warnings. The original `builder-inited` lambda function was moved to a standard function with the additional logic. 