### PR TITLE
[Backport release/3.11] GDALAlgorithm: Refuse NaN for arguments with specified valid ranges

### DIFF
--- a/autotest/utilities/test_gdalalg_vector_geom_simplify.py
+++ b/autotest/utilities/test_gdalalg_vector_geom_simplify.py
@@ -64,10 +64,11 @@ def test_gdalalg_vector_geom_simplify():
     assert out_lyr.GetFeature(-1) is None
 
 
-def test_gdalalg_vector_geom_simplify_error():
+@pytest.mark.parametrize("tol", (-1, float("nan")))
+def test_gdalalg_vector_geom_simplify_error(tol):
 
     alg = get_alg()
     with pytest.raises(
-        Exception, match="Value of argument 'tolerance' is -1, but should be >= 0"
+        Exception, match="Value of argument 'tolerance' is .*, but should be >= 0"
     ):
-        alg["tolerance"] = -1
+        alg["tolerance"] = tol

--- a/gcore/gdalalgorithm.cpp
+++ b/gcore/gdalalgorithm.cpp
@@ -889,14 +889,14 @@ bool GDALAlgorithmArg::ValidateRealRange(double val) const
     const auto [minVal, minValIsIncluded] = GetMinValue();
     if (!std::isnan(minVal))
     {
-        if (minValIsIncluded && val < minVal)
+        if (minValIsIncluded && !(val >= minVal))
         {
             CPLError(CE_Failure, CPLE_IllegalArg,
                      "Value of argument '%s' is %g, but should be >= %g",
                      GetName().c_str(), val, minVal);
             ret = false;
         }
-        else if (!minValIsIncluded && val <= minVal)
+        else if (!minValIsIncluded && !(val > minVal))
         {
             CPLError(CE_Failure, CPLE_IllegalArg,
                      "Value of argument '%s' is %g, but should be > %g",
@@ -909,14 +909,14 @@ bool GDALAlgorithmArg::ValidateRealRange(double val) const
     if (!std::isnan(maxVal))
     {
 
-        if (maxValIsIncluded && val > maxVal)
+        if (maxValIsIncluded && !(val <= maxVal))
         {
             CPLError(CE_Failure, CPLE_IllegalArg,
                      "Value of argument '%s' is %g, but should be <= %g",
                      GetName().c_str(), val, maxVal);
             ret = false;
         }
-        else if (!maxValIsIncluded && val >= maxVal)
+        else if (!maxValIsIncluded && !(val < maxVal))
         {
             CPLError(CE_Failure, CPLE_IllegalArg,
                      "Value of argument '%s' is %g, but should be < %g",


### PR DESCRIPTION
Backport #12310
 **Authored by:** @dbaston