### PR TITLE
autotest/requirements.txt: remove mentions of python < 3.7.

### DIFF
--- a/autotest/requirements.txt
+++ b/autotest/requirements.txt
@@ -1,6 +1,5 @@
 pytest>=6.0.0
-pytest-sugar<=0.9.6; python_version < '3.7'
-pytest-sugar; python_version >= '3.7'
+pytest-sugar
 pytest-env
 pytest-benchmark
 lxml


### PR DESCRIPTION
Our baseline since GDAL 3.9 is Python >= 3.8
