### PR TITLE
GML geometry parser: recognize '<gml:Curve><gml:segments/></gml:Curve>' as LINESTRING EMPTY

### DIFF
--- a/autotest/ogr/ogr_gml_geom.py
+++ b/autotest/ogr/ogr_gml_geom.py
@@ -1511,7 +1511,7 @@ def test_gml_invalid_geoms():
         ),
         ("<gml:Curve/>", None),
         ("<gml:Curve><foo/></gml:Curve>", None),
-        ("<gml:Curve><gml:segments/></gml:Curve>", None),
+        ("<gml:Curve><gml:segments/></gml:Curve>", "LINESTRING EMPTY"),
         ("<gml:Curve><gml:segments><foo/></gml:segments></gml:Curve>", None),
         (
             "<gml:Curve><gml:segments><gml:Point><gml:pos>31 29 16</gml:pos></gml:Point></gml:segments></gml:Curve>",
@@ -1528,7 +1528,6 @@ def test_gml_invalid_geoms():
         ),
         ("<gml:Circle/>", None),
         ("<gml:Circle><gml:posList>0 0 0 1</gml:posList></gml:Circle>", None),
-        ("<gml:segments/>", None),
         ("<gml:segments><foo/></gml:segments>", None),
         ("<gml:segments><gml:LineStringSegment/></gml:segments>", None),
         (

--- a/ogr/gml2ogrgeometry.cpp
+++ b/ogr/gml2ogrgeometry.cpp
@@ -2711,7 +2711,7 @@ GML2OGRGeometry_XMLNode_Internal(const CPLXMLNode *psNode, const char *pszId,
         if (poCurve != nullptr)
             return poCurve;
         if (poCC == nullptr)
-            return nullptr;
+            return std::make_unique<OGRLineString>();
 
         if (/* bCastToLinearTypeIfPossible && */ bChildrenAreAllLineString)
         {


### PR DESCRIPTION
Fix #12349
