### PR TITLE
MDIM translate: ensure valid axis values in transpose

### DIFF
--- a/apps/gdalmdimtranslate_lib.cpp
+++ b/apps/gdalmdimtranslate_lib.cpp
@@ -798,7 +798,20 @@ static bool ParseArraySpec(const std::string &arraySpec, std::string &srcName,
                 CSLTokenizeString2(transposeExpr.c_str(), ",", 0));
             for (int i = 0; i < aosAxis.size(); ++i)
             {
-                anTransposedAxis.push_back(atoi(aosAxis[i]));
+                int iAxis = atoi(aosAxis[i]);
+                // check for non-integer characters
+                if (iAxis == 0)
+                {
+                    if (!EQUAL(aosAxis[i], "0"))
+                    {
+                        CPLError(CE_Failure, CPLE_AppDefined,
+                                 "Invalid value for axis in transpose: %s",
+                                 aosAxis[i]);
+                        return false;
+                    }
+                }
+
+                anTransposedAxis.push_back(iAxis);
             }
         }
         else if (STARTS_WITH(token.c_str(), "view="))

--- a/autotest/utilities/test_gdalalg_mdim_convert.py
+++ b/autotest/utilities/test_gdalalg_mdim_convert.py
@@ -420,3 +420,20 @@ def test_gdalalg_mdim_convert_completion_array_option(gdal_path):
         f"{gdal_path} completion gdal mdim convert ../gdrivers/data/netcdf/byte.nc --array-option"
     ).split(" ")
     assert "USE_DEFAULT_FILL_AS_NODATA=" in out
+
+
+###############################################################################
+@pytest.mark.require_driver("ZARR")
+def test_gdalalg_mdim_convert_valid_transpose_axis(tmp_path):
+
+    tmpfile = tmp_path / "out.zarr"
+    alg = get_mdim_convert_alg()
+    alg["input"] = "../gdrivers/data/zarr/array_dimensions.zarr"
+    alg["output"] = tmpfile
+    alg["output-format"] = "ZARR"
+    alg["array"] = "name=var,transpose=[a,1]"
+    with pytest.raises(
+        Exception,
+        match=r"Invalid value for axis in transpose: a",
+    ):
+        alg.Run()


### PR DESCRIPTION
gdal mdim translate doesn't validate bad `transpose` values that evaluate to 0

```
gdalmdimtranslate \
/vsicurl/https://github.com/OSGeo/gdal/raw/refs/heads/master/autotest/gdrivers/data/zarr/array_dimensions.zarr/ \
/vsimem/out.zarr -array "name=var,transpose=[a,1]"
```
## What does this PR do?

Applies a check that zero values for transpose are equal to "0". 



 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments



