### PR TITLE
VRT: 'transpose' for vrt:// connection

### DIFF
--- a/autotest/gcore/vrt_read.py
+++ b/autotest/gcore/vrt_read.py
@@ -1765,6 +1765,32 @@ def test_vrt_protocol_expand_option():
     assert ds.GetRasterBand(1).GetRasterColorInterpretation() == gdal.GCI_RedBand
 
 
+@gdaltest.enable_exceptions()
+@pytest.mark.require_driver("HDF5")
+def test_vrt_protocol_transpose_option():
+
+    ds = gdal.Open("vrt://../gdrivers/data/hdf5/fwhm.h5?transpose=/MyDataField:0,1")
+    assert ds.RasterXSize == 2
+
+    ds = gdal.Open("vrt://../gdrivers/data/hdf5/fwhm.h5?transpose=/MyDataField:2,1")
+    assert ds.RasterXSize == 4
+
+    ## check exclusivity with sd_name/sd (transpose gets priority)
+    with pytest.raises(
+        Exception,
+        match=r"'sd_name' is mutually exclusive with option 'transpose'",
+    ):
+        gdal.Open(
+            "vrt://../gdrivers/data/hdf5/fwhm.h5?sd_name=MyDataField&transpose=/MyDataField:1,0"
+        )
+
+    with pytest.raises(
+        Exception,
+        match=r"'sd' is mutually exclusive with option 'transpose'",
+    ):
+        gdal.Open("vrt://../gdrivers/data/hdf5/fwhm.h5?sd=1&transpose=/MyDataField:1,0")
+
+
 def test_vrt_source_no_dstrect():
 
     vrt_text = """<VRTDataset rasterXSize="20" rasterYSize="20">

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -2178,8 +2178,8 @@ an interface to the function :cpp:func:`GDALMDArray::AsClassicDataset` in the mu
 This can be valuable for reorienting an array that presents X and Y in YX or some other order. (There's a
 possible added advantage that a valid geotransform may be provided that the classic 2D model doesn't yet infer,
 because the multidimensional model can derive one from coordinates referenced in that form).
-The usage syntax is "vrt://somefile.extension?transpose=varname:iXDim,iYDim" with a no-op case
-"vrt://somefile.extension?transpose=varname:0,1" and "vrt://somefile.extension?transpose=varname:1,0" would be a
+The usage syntax is ``vrt://somefile.extension?transpose=varname:iXDim,iYDim`` with a no-op case
+``vrt://somefile.extension?transpose=varname:0,1`` and ``vrt://somefile.extension?transpose=varname:1,0`` would be a
 transpose on the first two axes. There must be two unique axis indexes with values between 0 and the maximum available.
 This option is mutually exclusive with ``sd_name`` and ``sd``.
 

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -2162,7 +2162,7 @@ The effect of the ``eco`` option (added in GDAL 3.8) is that ``srcwin`` or ``pro
 The effect of the ``sd_name`` option (added in GDAL 3.9) is to choose an individual subdataset by
 name for sources that have multiple subdatasets. This means that rather than a fully-qualified description
 such as "NETCDF:myfile.nc:somearray" we may use "vrt://myfile.nc?sd_name=somearray". This option
-is mutually exclusive with ``sd``.
+is mutually exclusive with ``sd``, and with ``transpose``.
 
 The effect of the ``sd`` option (added in GDAL 3.9) is to choose an individual subdataset by
 number for sources that have multiple subdatasets. This means that rather than a fully-qualified
@@ -2170,8 +2170,18 @@ description such as "NETCDF:myfile.nc:somearray" we may use "vrt://myfile.nc?sd=
 is between 1 and the number of subdatasets. Note that there is no guarantee of the order of the
 subdatasets within a source between GDAL versions (or in some cases between file series in datasets). This
 mode is for convenience only, please use ``sd_name`` to choose a subdataset by name explicitly.
-This option is mutually exclusive with ``sd_name``.
+This option is mutually exclusive with ``sd_name``, and with ``transpose``.
 
+The effect of the ``transpose`` option (added in GDAL 3.12) is to specify just one array by name from a
+multidimensional dataset and nominate the indexes for the two axes that define the 2D dataset. This is
+an interface to the function :cpp:func:`GDALMDArray::AsClassicDataset` in the multidimensional raster model.
+This can be valuable for reorienting an array that presents X and Y in YX or some other order. (There's a
+possible added advantage that a valid geotransform may be provided that the classic 2D model doesn't yet infer,
+because the multidimensional model can derive one from coordinates referenced in that form).
+The usage syntax is "vrt://somefile.extension?transpose=varname:iXDim,iYDim" with a no-op case
+"vrt://somefile.extension?transpose=varname:0,1" and "vrt://somefile.extension?transpose=varname:1,0" would be a
+transpose on the first two axes. There must be two unique axis indexes with values between 0 and the maximum available.
+This option is mutually exclusive with ``sd_name`` and ``sd``.
 
 The options may be chained together separated by '&'. (Beware the need for quoting to protect
 the ampersand).


### PR DESCRIPTION
Implements 'transpose' for the vrt connection options. This allows nomination of a variable by name and the `iXDim` and `iYDim` index positions for passing to `AsClassicDataset`. 


## What are related issues/pull requests?

Discussion and summary of related PRs: https://github.com/OSGeo/gdal/issues/7477

## Further examples 

```bash
"vrt://autotest/gdrivers/data/netcdf/foo_5dimensional.nc?transpose=/temperature:3,4"

"vrt://autotest/gdrivers/data/zarr/array_dimensions.zarr?transpose=/var:1,0"

```

The original motivation was this HDF5, which doesn't have georeferencing in 2D form, but by using multidim cast to classic we get the transform that derives, and can add further augmentation like 'a_srs'. 


 (needs earthdata auth). 

```bash
## export GDAL_HTTP_HEADER_FILE=...
gdalinfo "vrt:///vsicurl/https://gpm1.gesdisc.eosdis.nasa.gov/data/GPM_L3/GPM_3IMERGHHE.07/1998/001/3B-HHR-E.MS.MRG.3IMERG.19980101-S000000-E002959.0000.V07B.HDF5?transpose=//Grid/Intermediate/IRinfluence:1,2"

Driver: VRT/Virtual Raster
Files: none associated
Size is 3600, 1800
Origin = (-179.999996947394237,-89.999996946545821)
Pixel Size = (0.099999998304108,0.099999996607273)
Metadata:
  CodeMissingValue=-9999
  coordinates=time lon lat
  DimensionNames=time,lon,lat
  LongName=
Relative influence of infrared precipitation in the merged
                        microwave-infrared precipitation estimate

Corner Coordinates:
Upper Left  (-179.9999969, -89.9999969)
Lower Left  (-179.9999969,  89.9999969)
Upper Right ( 179.9999969, -89.9999969)
Lower Right ( 179.9999969,  89.9999969)
Center      (   0.0000000,   0.0000000)
Band 1 Block=291x1800 Type=Int16, ColorInterp=Undefined
  NoData Value=-9999
  Metadata:
    DIM_time_INDEX=0
    DIM_time_UNIT=seconds since 1980-01-06 00:00:00 UTC
    DIM_time_VALUE=567648000

```
## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE


