### PR TITLE
WMS: add a mini-driver for International Image Interoperability Framework (IIIF) Image API 3.0

### DIFF
--- a/doc/source/drivers/raster/wms.rst
+++ b/doc/source/drivers/raster/wms.rst
@@ -293,8 +293,8 @@ band object.
    gdallocationinfo -wgs84 "<GDAL_WMS><Service name=\"AGS\"><ServerUrl>https://services.arcgisonline.com/arcgis/rest/services/World_Imagery/MapServer</ServerUrl><BBoxOrder>xyXY</BBoxOrder><SRS>3857</SRS></Service><DataWindow><UpperLeftX>-20037508.34</UpperLeftX><UpperLeftY>20037508.34</UpperLeftY><LowerRightX>20037508.34</LowerRightX><LowerRightY>-20037508.34</LowerRightY><SizeX>512</SizeX><SizeY>512</SizeY></DataWindow></GDAL_WMS>" -75.704 39.75
 
 
-Internet Imaging Protocol (IIP) (GDAL 2.1 and later)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Internet Imaging Protocol (IIP)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Access to images served through `IIP
 protocol <https://en.wikipedia.org/wiki/Internet_Imaging_Protocol>`__.
@@ -309,6 +309,24 @@ the full resolution dimension and the number of resolutions.
 
 The XML definition can then be generated with "gdal_translate
 IIP:http://foo.com/FIF=image_name out.xml -of WMS"
+
+
+International Image Interoperability Framework Image API (IIIF)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. versionadded:: 3.12
+
+Access to images served through `IIIF Image API 3.0 <https://iiif.io/api/image/3.0>`__.
+
+If using the XML syntax, the ServerURL must point to the image identifier URL,
+such that :file:`{url}/info.json` exists.
+
+Otherwise it is also possible to use "IIIF:https://path/to/image/identifier"
+syntax as connection string, to retrieve from the server information on
+the full resolution dimension and the number of resolutions.
+
+The XML definition can then be generated with "gdal_translate
+IIIF:https://path/to/image/identifier out.xml -of WMS"
 
 Caching
 -------
@@ -413,6 +431,9 @@ Examples
 
 -  IIP online sample server layer :source_file:`frmts/wms/frmt_wms_iip.xml` accessed with
    the IIP minidriver.
+
+-  IIIF online sample server layer :source_file:`frmts/wms/frmt_wms_iiif.xml` accessed with
+   the IIIF minidriver.
 
 Open syntax
 -----------

--- a/frmts/wms/CMakeLists.txt
+++ b/frmts/wms/CMakeLists.txt
@@ -2,6 +2,7 @@ add_gdal_driver(
   TARGET gdal_WMS
   SOURCES gdalhttp.cpp
           gdalwmsrasterband.cpp
+          minidriver_iiifimage.cpp
           minidriver_iip.cpp
           minidriver_tiled_wms.cpp
           minidriver_tms.cpp
@@ -10,6 +11,7 @@ add_gdal_driver(
           wmsutils.cpp
           gdalhttp.h
           minidriver.cpp
+          minidriver_iiifimage.h
           minidriver_iip.h
           minidriver_tiled_wms.h
           minidriver_tms.h

--- a/frmts/wms/frmt_wms_iiif.xml
+++ b/frmts/wms/frmt_wms_iiif.xml
@@ -1,0 +1,15 @@
+<GDAL_WMS>
+  <Service name="IIIFImage">
+    <ServerUrl>https://asge.jarvis.memooria.org/images/iiif/db/6431901e-7474-4c51-aa57-41dfddf13604</ServerUrl>
+    <ImageFormat>image/jpeg</ImageFormat>
+  </Service>
+  <DataWindow>
+    <SizeX>7236</SizeX>
+    <SizeY>5238</SizeY>
+    <TileLevel>6</TileLevel>
+  </DataWindow>
+  <BlockSizeX>256</BlockSizeX>
+  <BlockSizeY>256</BlockSizeY>
+  <BandsCount>3</BandsCount>
+  <Cache />
+</GDAL_WMS>

--- a/frmts/wms/minidriver_iiifimage.cpp
+++ b/frmts/wms/minidriver_iiifimage.cpp
@@ -1,0 +1,95 @@
+/******************************************************************************
+ *
+ * Project:  WMS Client Driver
+ * Purpose:  Mini driver for International Image Interoperability Framework
+ *           Image API (IIIFImage)
+ * Author:   Even Rouault <even.rouault at spatialys.com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2025, Even Rouault <even.rouault at spatialys.com>
+ *
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#include "wmsdriver.h"
+#include "minidriver_iiifimage.h"
+
+#include <algorithm>
+
+// Implements https://iiif.io/api/image/3.0/ "Image API 3.0"
+
+WMSMiniDriver_IIIFImage::WMSMiniDriver_IIIFImage()
+{
+}
+
+WMSMiniDriver_IIIFImage::~WMSMiniDriver_IIIFImage()
+{
+}
+
+CPLErr WMSMiniDriver_IIIFImage::Initialize(CPLXMLNode *config,
+                                           CPL_UNUSED char **papszOpenOptions)
+{
+    m_base_url = CPLGetXMLValue(config, "ServerURL", "");
+    if (m_base_url.empty())
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "GDALWMS, IIIFImage mini-driver: ServerURL missing.");
+        return CE_Failure;
+    }
+
+    const char *pszImageFormat =
+        CPLGetXMLValue(config, "ImageFormat", "image/jpeg");
+    if (EQUAL(pszImageFormat, "image/jpeg"))
+        m_imageExtension = "jpg";
+    else if (EQUAL(pszImageFormat, "image/png"))
+        m_imageExtension = "png";
+    else if (EQUAL(pszImageFormat, "image/webp"))
+        m_imageExtension = "webp";
+
+    return CE_None;
+}
+
+void WMSMiniDriver_IIIFImage::GetCapabilities(WMSMiniDriverCapabilities *caps)
+{
+    caps->m_overview_dim_computation_method = OVERVIEW_FLOOR;
+    caps->m_has_geotransform = false;
+}
+
+CPLErr WMSMiniDriver_IIIFImage::TiledImageRequest(
+    WMSHTTPRequest &request, const GDALWMSImageRequestInfo & /* iri */,
+    const GDALWMSTiledImageRequestInfo &tiri)
+{
+    CPLString &url = request.URL;
+    url = m_base_url;
+    if (!url.empty() && url.back() != '/')
+        url += '/';
+
+    int nBlockWidth = 0;
+    int nBlockHeight = 0;
+    m_parent_dataset->GetRasterBand(1)->GetBlockSize(&nBlockWidth,
+                                                     &nBlockHeight);
+
+    const int iShift =
+        m_parent_dataset->GetRasterBand(1)->GetOverviewCount() - tiri.m_level;
+
+    GDALRasterBand *poOvrBand =
+        iShift == 0
+            ? m_parent_dataset->GetRasterBand(1)
+            : m_parent_dataset->GetRasterBand(1)->GetOverview(
+                  m_parent_dataset->GetRasterBand(1)->GetOverviewCount() - 1 -
+                  tiri.m_level);
+
+    const int nXOffFullRes = (tiri.m_x * nBlockWidth) << iShift;
+    const int nYOffFullRes = (tiri.m_y * nBlockHeight) << iShift;
+    url += CPLSPrintf(
+        "%d,%d,%d,%d/%d,%d/0/default.%s", nXOffFullRes, nYOffFullRes,
+        std::min(nBlockWidth << iShift,
+                 m_parent_dataset->GetRasterXSize() - nXOffFullRes),
+        std::min(nBlockHeight << iShift,
+                 m_parent_dataset->GetRasterYSize() - nYOffFullRes),
+        std::min(nBlockWidth, poOvrBand->GetXSize() - tiri.m_x * nBlockWidth),
+        std::min(nBlockHeight, poOvrBand->GetYSize() - tiri.m_y * nBlockHeight),
+        m_imageExtension.c_str());
+
+    return CE_None;
+}

--- a/frmts/wms/minidriver_iiifimage.h
+++ b/frmts/wms/minidriver_iiifimage.h
@@ -1,0 +1,36 @@
+/******************************************************************************
+ *
+ * Project:  WMS Client Driver
+ * Purpose:  Mini driver for International Image Interoperability Framework
+ *           Image API (IIIFImage)
+ * Author:   Even Rouault <even.rouault at spatialys.com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2025, Even Rouault <even.rouault at spatialys.com>
+ *
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#ifndef MINIDRIVER_IIIFImage_H_INCLUDED
+#define MINIDRIVER_IIIFImage_H_INCLUDED
+
+class WMSMiniDriver_IIIFImage : public WMSMiniDriver
+{
+  public:
+    WMSMiniDriver_IIIFImage();
+    virtual ~WMSMiniDriver_IIIFImage();
+
+  public:
+    virtual CPLErr Initialize(CPLXMLNode *config,
+                              char **papszOpenOptions) override;
+    virtual void GetCapabilities(WMSMiniDriverCapabilities *caps) override;
+    virtual CPLErr
+    TiledImageRequest(WMSHTTPRequest &request,
+                      const GDALWMSImageRequestInfo &iri,
+                      const GDALWMSTiledImageRequestInfo &tiri) override;
+
+  private:
+    std::string m_imageExtension = "jpg";
+};
+
+#endif /* MINIDRIVER_IIIFImage_H_INCLUDED */

--- a/frmts/wms/wmsdrivercore.cpp
+++ b/frmts/wms/wmsdrivercore.cpp
@@ -93,6 +93,11 @@ int WMSDriverIdentify(GDALOpenInfo *poOpenInfo)
     {
         return TRUE;
     }
+    else if (poOpenInfo->nHeaderBytes == 0 &&
+             STARTS_WITH_CI(pszFilename, "IIIF:"))
+    {
+        return TRUE;
+    }
     else
         return FALSE;
 }


### PR DESCRIPTION
```
$ gdalinfo IIIF:https://asge.jarvis.memooria.org/images/iiif/db/6431901e-7474-4c51-aa57-41dfddf13604 
Driver: WMS/OGC Web Map Service
Files: none associated
Size is 7236, 5238
Metadata:
  CACHE_PATH=/home/even/.cache/gdalwmscache/1b6a019f0189df3f4dcfba57e2090320
Image Structure Metadata:
  INTERLEAVE=PIXEL
Corner Coordinates:
Upper Left  (    0.0,    0.0)
Lower Left  (    0.0, 5238.0)
Upper Right ( 7236.0,    0.0)
Lower Right ( 7236.0, 5238.0)
Center      ( 3618.0, 2619.0)
Band 1 Block=256x256 Type=Byte, ColorInterp=Red
  Overviews: 3618x2619, 1809x1309, 904x654, 452x327, 226x163, 113x81
Band 2 Block=256x256 Type=Byte, ColorInterp=Green
  Overviews: 3618x2619, 1809x1309, 904x654, 452x327, 226x163, 113x81
Band 3 Block=256x256 Type=Byte, ColorInterp=Blue
  Overviews: 3618x2619, 1809x1309, 904x654, 452x327, 226x163, 113x81
```