### PR TITLE
[Backport release/3.11] Do not include cpl_float.h in gdal_priv.h, to avoid issues on Windows  with min/max macros

### DIFF
--- a/apps/gdalalg_raster_calc.cpp
+++ b/apps/gdalalg_raster_calc.cpp
@@ -15,6 +15,7 @@
 #include "../frmts/vrt/gdal_vrt.h"
 #include "../frmts/vrt/vrtdataset.h"
 
+#include "cpl_float.h"
 #include "gdal_priv.h"
 #include "gdal_utils.h"
 

--- a/autotest/cpp/test_gdal_algorithm.cpp
+++ b/autotest/cpp/test_gdal_algorithm.cpp
@@ -23,6 +23,7 @@
 
 #include "gtest_include.h"
 
+#include <algorithm>
 #include <limits>
 
 namespace test_gdal_algorithm

--- a/frmts/vrt/pixelfunctions.cpp
+++ b/frmts/vrt/pixelfunctions.cpp
@@ -16,6 +16,7 @@
 #include "vrtdataset.h"
 #include "vrtexpression.h"
 #include "vrtreclassifier.h"
+#include "cpl_float.h"
 
 #include <limits>
 

--- a/frmts/vrt/vrtprocesseddatasetfunctions.cpp
+++ b/frmts/vrt/vrtprocesseddatasetfunctions.cpp
@@ -10,6 +10,7 @@
  * SPDX-License-Identifier: MIT
  ****************************************************************************/
 
+#include "cpl_float.h"
 #include "cpl_minixml.h"
 #include "cpl_string.h"
 #include "vrtdataset.h"

--- a/frmts/zarr/zarr_v2_array.cpp
+++ b/frmts/zarr/zarr_v2_array.cpp
@@ -10,6 +10,7 @@
  * SPDX-License-Identifier: MIT
  ****************************************************************************/
 
+#include "cpl_float.h"
 #include "cpl_vsi_virtual.h"
 #include "gdal_thread_pool.h"
 #include "zarr.h"

--- a/frmts/zarr/zarr_v3_array.cpp
+++ b/frmts/zarr/zarr_v3_array.cpp
@@ -10,6 +10,7 @@
  * SPDX-License-Identifier: MIT
  ****************************************************************************/
 
+#include "cpl_float.h"
 #include "cpl_vsi_virtual.h"
 #include "gdal_thread_pool.h"
 #include "zarr.h"

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -47,7 +47,6 @@ class GDALAlgorithm;
 #include "gdalsubdatasetinfo.h"
 #include "cpl_vsi.h"
 #include "cpl_conv.h"
-#include "cpl_float.h"
 #include "cpl_string.h"
 #include "cpl_minixml.h"
 #include "cpl_multiproc.h"
@@ -3748,10 +3747,10 @@ class CPL_DLL GDALMDArray : virtual public GDALAbstractMDArray,
     Transpose(const std::vector<int> &anMapNewAxisToOldAxis) const;
 
     std::shared_ptr<GDALMDArray> GetUnscaled(
-        double dfOverriddenScale = cpl::NumericLimits<double>::quiet_NaN(),
-        double dfOverriddenOffset = cpl::NumericLimits<double>::quiet_NaN(),
+        double dfOverriddenScale = std::numeric_limits<double>::quiet_NaN(),
+        double dfOverriddenOffset = std::numeric_limits<double>::quiet_NaN(),
         double dfOverriddenDstNodata =
-            cpl::NumericLimits<double>::quiet_NaN()) const;
+            std::numeric_limits<double>::quiet_NaN()) const;
 
     virtual std::shared_ptr<GDALMDArray>
     GetMask(CSLConstList papszOptions) const;
@@ -4627,29 +4626,21 @@ GDALDataset *GDALCreateOverviewDataset(GDALDataset *poDS, int nOvrLevel,
 // TODO: The expression `abs(fVal1 + fVal2)` looks strange; is this a bug?
 // Should this be `abs(fVal1) + abs(fVal2)` instead?
 
-inline bool ARE_REAL_EQUAL(GFloat16 dfVal1, GFloat16 dfVal2, int ulp = 2)
-{
-    using std::abs;
-    return dfVal1 == dfVal2 || /* Should cover infinity */
-           abs(dfVal1 - dfVal2) < cpl::NumericLimits<GFloat16>::epsilon() *
-                                      abs(dfVal1 + dfVal2) * ulp;
-}
-
 inline bool ARE_REAL_EQUAL(float fVal1, float fVal2, int ulp = 2)
 {
     using std::abs;
     return fVal1 == fVal2 || /* Should cover infinity */
            abs(fVal1 - fVal2) <
-               cpl::NumericLimits<float>::epsilon() * abs(fVal1 + fVal2) * ulp;
+               std::numeric_limits<float>::epsilon() * abs(fVal1 + fVal2) * ulp;
 }
 
-// We are using `cpl::NumericLimits<float>::epsilon()` for backward
+// We are using `std::numeric_limits<float>::epsilon()` for backward
 // compatibility
 inline bool ARE_REAL_EQUAL(double dfVal1, double dfVal2, int ulp = 2)
 {
     using std::abs;
     return dfVal1 == dfVal2 || /* Should cover infinity */
-           abs(dfVal1 - dfVal2) < cpl::NumericLimits<float>::epsilon() *
+           abs(dfVal1 - dfVal2) < std::numeric_limits<float>::epsilon() *
                                       abs(dfVal1 + dfVal2) * ulp;
 }
 

--- a/gcore/gdal_typetraits.h
+++ b/gcore/gdal_typetraits.h
@@ -27,16 +27,7 @@
 #define GDAL_TYPETRAITS_H_INCLUDED
 
 #include "gdal_priv.h"
-
-// NOTE: below GDAL_ENABLE_FLOAT16 is not guaranteed to be stable and is
-// mostly for Esri internal needs for now. Might be revisited if/once RFC 100
-// (https://github.com/OSGeo/gdal/pull/10146) is adopted.
-#ifdef GDAL_ENABLE_FLOAT16
-#if defined(__GNUC__) || defined(__clang__)
-#define __STDC_WANT_IEC_60559_TYPES_EXT__
-#include <float.h>  // Also brings in GFloat16
-#endif
-#endif
+#include "cpl_float.h"
 
 #include <complex>
 

--- a/gcore/gdalcachedpixelaccessor.h
+++ b/gcore/gdalcachedpixelaccessor.h
@@ -15,6 +15,7 @@
 
 #include "gdal_priv.h"
 #include "cpl_error.h"
+#include "cpl_float.h"
 
 #include <algorithm>
 #include <array>

--- a/gcore/gdalrasterband.cpp
+++ b/gcore/gdalrasterband.cpp
@@ -4089,6 +4089,18 @@ struct GDALNoDataValues
 };
 
 /************************************************************************/
+/*                            ARE_REAL_EQUAL()                          */
+/************************************************************************/
+
+inline bool ARE_REAL_EQUAL(GFloat16 dfVal1, GFloat16 dfVal2, int ulp = 2)
+{
+    using std::abs;
+    return dfVal1 == dfVal2 || /* Should cover infinity */
+           abs(dfVal1 - dfVal2) < cpl::NumericLimits<GFloat16>::epsilon() *
+                                      abs(dfVal1 + dfVal2) * ulp;
+}
+
+/************************************************************************/
 /*                            GetHistogram()                            */
 /************************************************************************/
 


### PR DESCRIPTION
Backport #12342
 **Authored by:** @rouault