### PR TITLE
[Backport release/3.11] gdal raster tile: port --excluded-values, --excluded-values-pct-threshold, --nodata-values-pct-threshold from gdal2tiles

### DIFF
--- a/apps/gdalalg_raster_tile.h
+++ b/apps/gdalalg_raster_tile.h
@@ -65,6 +65,10 @@ class GDALRasterTileAlgorithm final : public GDALAlgorithm
     int m_numThreads = 0;
     bool m_kml = false;
 
+    std::string m_excludedValues{};
+    double m_excludedValuesPctThreshold = 50;
+    double m_nodataValuesPctThreshold = 100;
+
     std::vector<std::string> m_webviewers{};
     std::string m_url{};
     std::string m_title{};

--- a/doc/source/programs/gdal2tiles.rst
+++ b/doc/source/programs/gdal2tiles.rst
@@ -153,7 +153,7 @@ can publish a picture without proper georeferencing too.
 .. option:: --excluded-values=<EXCLUDED_VALUES>
 
   Comma-separated tuple of values (thus typically "R,G,B"), that are ignored
-  as contributing source * pixels during resampling. The number of values in
+  as contributing source pixels during resampling. The number of values in
   the tuple must be the same as the number of bands, excluding the alpha band.
   Several tuples of excluded values may be specified using the "(R1,G1,B2),(R2,G2,B2)" syntax.
   Only taken into account by Average currently.

--- a/doc/source/programs/gdal_raster_tile.rst
+++ b/doc/source/programs/gdal_raster_tile.rst
@@ -191,6 +191,40 @@ Standard options
    Default: number of CPUs detected.
 
 
+Advanced Resampling Options
++++++++++++++++++++++++++++
+
+.. option:: --excluded-values=<EXCLUDED-VALUES>
+
+  Comma-separated tuple of values (thus typically "R,G,B"), that are ignored
+  as contributing source pixels during resampling. The number of values in
+  the tuple must be the same as the number of bands, excluding the alpha band.
+  Several tuples of excluded values may be specified using the "(R1,G1,B2),(R2,G2,B2)" syntax.
+  Only taken into account for average resampling.
+  This concept is a bit similar to nodata/alpha, but the main difference is
+  that pixels matching one of the excluded value tuples are still considered
+  as valid, when determining the target pixel validity/density.
+
+.. versionadded:: 3.11.1
+
+.. option:: --excluded-values-pct-threshold=<EXCLUDED-VALUES-PCT-THRESHOLD>
+
+  Minimum percentage of source pixels that must be set at one of the --excluded-values to cause the excluded
+  value, that is in majority among source pixels, to be used as the target pixel value. Default value is 50(%)
+
+.. versionadded:: 3.11.1
+
+.. option:: --nodata-values-pct-threshold=<NODATA-VALUES-PCT-THRESHOLD>
+
+  Minimum percentage of source pixels that must be at nodata (or alpha=0 or any
+  other way to express transparent pixel) to cause the target pixel value to
+  be transparent. Default value is 100 (%), which means that a target pixel is
+  transparent only if all contributing source pixels are transparent.
+  Only taken into account for average resampling.
+
+.. versionadded:: 3.11.1
+
+
 Publication Options
 +++++++++++++++++++
 


### PR DESCRIPTION
Backport #12325
 **Authored by:** @rouault