### PR TITLE
DTED/dted_api.c: Change to the dted_api DTEDReadPoint to include a configuration optio…

### DIFF
--- a/doc/source/drivers/raster/dted.rst
+++ b/doc/source/drivers/raster/dted.rst
@@ -60,6 +60,17 @@ the default behavior of the DTED driver.
       If ``TRUE``, apply a pixel-is-point interpretation to the data when
       reading the geotransform.
 
+-  .. config:: DTED_ASSUME_CONFORMANT
+      :choices: TRUE, FALSE
+      :default: FALSE
+      :since: 3.11
+
+      If ``TRUE``, assume that the DTED file is conformant to the DTED
+      standard and not in two's complement form. This will cause the DTED
+      driver to skip the check for values less than -16000 and not change
+      them to signed magnitude - assuming they are two's complement before
+      the conversion.
+
 
 Read Issues
 -----------

--- a/doc/source/drivers/raster/dted.rst
+++ b/doc/source/drivers/raster/dted.rst
@@ -63,7 +63,7 @@ the default behavior of the DTED driver.
 -  .. config:: DTED_ASSUME_CONFORMANT
       :choices: TRUE, FALSE
       :default: FALSE
-      :since: 3.11
+      :since: 3.12
 
       If ``TRUE``, assume that the DTED file is conformant to the DTED
       standard and not in two's complement form. This will cause the DTED

--- a/frmts/dted/dted_api.c
+++ b/frmts/dted/dted_api.c
@@ -525,13 +525,15 @@ int DTEDReadPoint(DTEDInfo *psDInfo, int nXOff, int nYOff, GInt16 *panVal)
     if (pabyData[0] & 0x80)
     {
         *panVal *= -1;
+        const char* pszAssume = CPLGetConfigOption("DTED_ASSUME_CONFORMANT", "NO");
+        const bool bAssumeConformant = CPLTestBool(pszAssume);
 
         /*
         ** It seems that some files are improperly generated in twos
         ** complement form for negatives.  For these, redo the job
         ** in twos complement.  eg. w_069_s50.dt0
         */
-        if ((*panVal < -16000) && (*panVal != DTED_NODATA_VALUE))
+        if (!bAssumeConformant && (*panVal < -16000) && (*panVal != DTED_NODATA_VALUE))
         {
             *panVal = (pabyData[0] << 8) | pabyData[1];
 
@@ -547,9 +549,13 @@ int DTEDReadPoint(DTEDInfo *psDInfo, int nXOff, int nYOff, GInt16 *panVal)
 #endif
                     "The DTED driver found values less than -16000, and has "
                     "adjusted\n"
-                    "them assuming they are improperly two-complemented.  No "
-                    "more warnings\n"
-                    "will be issued in this session about this operation.");
+                    "them assuming they are improperly two-complemented.  If "
+                    "you wish to\n"
+                    "disable this behavior, set the DTED_ASSUME_CONFORMANT "
+                    "configuration\n"
+                    "option to YES. No more warnings will be issued in this "
+                    "session\n"
+                    "about this operation.");
             }
         }
     }

--- a/frmts/dted/dted_api.c
+++ b/frmts/dted/dted_api.c
@@ -323,6 +323,8 @@ DTEDInfo *DTEDOpenEx(VSILFILE *fp, const char *pszFilename,
 
     DTEDDetectVariantWithMissingColumns(psDInfo);
 
+    psDInfo->bAssumeConformant = CPLTestBool(CPLGetConfigOption("DTED_ASSUME_CONFORMANT", "NO"));
+
     return psDInfo;
 }
 
@@ -525,15 +527,13 @@ int DTEDReadPoint(DTEDInfo *psDInfo, int nXOff, int nYOff, GInt16 *panVal)
     if (pabyData[0] & 0x80)
     {
         *panVal *= -1;
-        const char* pszAssume = CPLGetConfigOption("DTED_ASSUME_CONFORMANT", "NO");
-        const bool bAssumeConformant = CPLTestBool(pszAssume);
 
         /*
         ** It seems that some files are improperly generated in twos
         ** complement form for negatives.  For these, redo the job
         ** in twos complement.  eg. w_069_s50.dt0
         */
-        if (!bAssumeConformant && (*panVal < -16000) && (*panVal != DTED_NODATA_VALUE))
+        if (!psDInfo->bAssumeConformant && (*panVal < -16000) && (*panVal != DTED_NODATA_VALUE))
         {
             *panVal = (pabyData[0] << 8) | pabyData[1];
 

--- a/frmts/dted/dted_api.h
+++ b/frmts/dted/dted_api.h
@@ -111,6 +111,8 @@ typedef struct
     int *
         panMapLogicalColsToOffsets; /* size of nXSize elements. Might be NULL */
 
+    bool bAssumeConformant;
+
 } DTEDInfo;
 
 /* -------------------------------------------------------------------- */

--- a/port/cpl_known_config_options.h
+++ b/port/cpl_known_config_options.h
@@ -163,6 +163,7 @@ constexpr static const char* const apszKnownConfigOptions[] =
    "DISABLE_OPEN_REAL_NETCDF_FILES", // from netcdfdataset.cpp, netcdfdrivercore.cpp
    "DRIVER_WISHED", // from test_ogrsf.cpp
    "DTED_APPLY_PIXEL_IS_POINT", // from dteddataset.cpp
+   "DTED_ASSUME_CONFORMANT", // from dted_api.c
    "DTED_VERIFY_CHECKSUM", // from dteddataset.cpp
    "DUMP_JP2_BOXES", // from gdaljp2metadata.cpp
    "DWG_ALL_ATTRIBUTES", // from ogrdwgdatasource.cpp


### PR DESCRIPTION
…n DTED_ASSUME_COMPLIANT for the user to opt out of DTED 2's compliment conversion if the values are less than -16000

Fixes issue #12299 
