### PR TITLE
gdal raster reproject: fix performance issue when outputing to COG

### DIFF
--- a/apps/gdalalg_abstract_pipeline.h
+++ b/apps/gdalalg_abstract_pipeline.h
@@ -401,7 +401,7 @@ bool GDALAbstractPipelineAlgorithm<StepAlgorithm>::RunStep(
         }
         if (bCanHandleNextStep)
         {
-            stepCtxt.m_poNextStep = m_steps[i + 1].get();
+            stepCtxt.m_poNextUsableStep = m_steps[i + 1].get();
         }
         if (!step->ValidateArguments() || !step->RunStep(stepCtxt))
         {

--- a/apps/gdalalg_raster_aspect.cpp
+++ b/apps/gdalalg_raster_aspect.cpp
@@ -53,7 +53,7 @@ GDALRasterAspectAlgorithm::GDALRasterAspectAlgorithm(bool standaloneStep)
 /*                GDALRasterAspectAlgorithm::RunStep()                  */
 /************************************************************************/
 
-bool GDALRasterAspectAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALRasterAspectAlgorithm::RunStep(GDALRasterPipelineStepRunContext &)
 {
     CPLAssert(m_inputDataset.GetDatasetRef());
     CPLAssert(m_outputDataset.GetName().empty());

--- a/apps/gdalalg_raster_aspect.h
+++ b/apps/gdalalg_raster_aspect.h
@@ -34,7 +34,7 @@ class GDALRasterAspectAlgorithm /* non final */
     explicit GDALRasterAspectAlgorithm(bool standaloneStep = false);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALRasterPipelineStepRunContext &ctxt) override;
 
     int m_band = 1;
     std::string m_convention = "azimuth";

--- a/apps/gdalalg_raster_clip.cpp
+++ b/apps/gdalalg_raster_clip.cpp
@@ -73,7 +73,7 @@ GDALRasterClipAlgorithm::GDALRasterClipAlgorithm(bool standaloneStep)
 /*                 GDALRasterClipAlgorithm::RunStep()                   */
 /************************************************************************/
 
-bool GDALRasterClipAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALRasterClipAlgorithm::RunStep(GDALRasterPipelineStepRunContext &)
 {
     auto poSrcDS = m_inputDataset.GetDatasetRef();
     CPLAssert(poSrcDS);

--- a/apps/gdalalg_raster_clip.h
+++ b/apps/gdalalg_raster_clip.h
@@ -35,7 +35,7 @@ class GDALRasterClipAlgorithm /* non final */
     explicit GDALRasterClipAlgorithm(bool standaloneStep = false);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALRasterPipelineStepRunContext &ctxt) override;
 
     bool m_onlyBBOX{false};
     bool m_allowExtentOutsideSource{false};

--- a/apps/gdalalg_raster_color_map.cpp
+++ b/apps/gdalalg_raster_color_map.cpp
@@ -46,7 +46,7 @@ GDALRasterColorMapAlgorithm::GDALRasterColorMapAlgorithm(bool standaloneStep)
 /*               GDALRasterColorMapAlgorithm::RunStep()                 */
 /************************************************************************/
 
-bool GDALRasterColorMapAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALRasterColorMapAlgorithm::RunStep(GDALRasterPipelineStepRunContext &)
 {
     auto poSrcDS = m_inputDataset.GetDatasetRef();
     CPLAssert(poSrcDS);

--- a/apps/gdalalg_raster_color_map.h
+++ b/apps/gdalalg_raster_color_map.h
@@ -37,7 +37,7 @@ class GDALRasterColorMapAlgorithm /* non final */
     explicit GDALRasterColorMapAlgorithm(bool standaloneStep = false);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALRasterPipelineStepRunContext &ctxt) override;
 
     int m_band = 1;
     std::string m_colorMap{};

--- a/apps/gdalalg_raster_contour.h
+++ b/apps/gdalalg_raster_contour.h
@@ -34,18 +34,6 @@ class GDALRasterContourAlgorithm final : public GDALAlgorithm
 
     explicit GDALRasterContourAlgorithm();
 
-    GDALDataset *GetDatasetRef()
-    {
-        return m_inputDataset.GetDatasetRef();
-    }
-
-    void SetDataset(GDALDataset *poDS)
-    {
-        auto arg = GetArg(GDAL_ARG_NAME_INPUT);
-        arg->Set(poDS);
-        arg->SetSkipIfAlreadySet();
-    }
-
   private:
     bool RunImpl(GDALProgressFunc pfnProgress, void *pProgressData) override;
 

--- a/apps/gdalalg_raster_edit.cpp
+++ b/apps/gdalalg_raster_edit.cpp
@@ -236,7 +236,10 @@ bool GDALRasterEditAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
     }
     else
     {
-        return RunStep(pfnProgress, pProgressData);
+        GDALRasterPipelineStepRunContext ctxt;
+        ctxt.m_pfnProgress = pfnProgress;
+        ctxt.m_pProgressData = pProgressData;
+        return RunStep(ctxt);
     }
 }
 
@@ -244,7 +247,7 @@ bool GDALRasterEditAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
 /*                GDALRasterEditAlgorithm::RunStep()                    */
 /************************************************************************/
 
-bool GDALRasterEditAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALRasterEditAlgorithm::RunStep(GDALRasterPipelineStepRunContext &)
 {
     CPLAssert(m_inputDataset.GetDatasetRef());
     CPLAssert(m_outputDataset.GetName().empty());

--- a/apps/gdalalg_raster_edit.h
+++ b/apps/gdalalg_raster_edit.h
@@ -33,7 +33,7 @@ class GDALRasterEditAlgorithm /* non final */
 
   private:
     bool RunImpl(GDALProgressFunc pfnProgress, void *pProgressData) override;
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALRasterPipelineStepRunContext &ctxt) override;
 
     GDALArgDatasetValue m_dataset{};  // standalone mode only
     bool m_readOnly = false;          // standalone mode only

--- a/apps/gdalalg_raster_fill_nodata.cpp
+++ b/apps/gdalalg_raster_fill_nodata.cpp
@@ -71,9 +71,12 @@ GDALRasterFillNodataAlgorithm::GDALRasterFillNodataAlgorithm(
 /*                 GDALRasterFillNodataAlgorithm::RunStep()             */
 /************************************************************************/
 
-bool GDALRasterFillNodataAlgorithm::RunStep(GDALProgressFunc pfnProgress,
-                                            void *pProgressData)
+bool GDALRasterFillNodataAlgorithm::RunStep(
+    GDALRasterPipelineStepRunContext &ctxt)
 {
+    auto pfnProgress = ctxt.m_pfnProgress;
+    auto pProgressData = ctxt.m_pProgressData;
+
     auto poSrcDS = m_inputDataset.GetDatasetRef();
     std::unique_ptr<void, decltype(&GDALDestroyScaledProgress)> pScaledData(
         GDALCreateScaledProgress(0.0, 0.5, pfnProgress, pProgressData),

--- a/apps/gdalalg_raster_fill_nodata.h
+++ b/apps/gdalalg_raster_fill_nodata.h
@@ -35,7 +35,7 @@ class GDALRasterFillNodataAlgorithm /* non final */
         bool standaloneStep = false) noexcept;
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALRasterPipelineStepRunContext &ctxt) override;
 
     // The maximum distance (in pixels) that the algorithm will search out for values to interpolate. The default is 100 pixels.
     int m_maxDistance = 100;

--- a/apps/gdalalg_raster_hillshade.cpp
+++ b/apps/gdalalg_raster_hillshade.cpp
@@ -67,7 +67,7 @@ GDALRasterHillshadeAlgorithm::GDALRasterHillshadeAlgorithm(bool standaloneStep)
 /*              GDALRasterHillshadeAlgorithm::RunStep()                 */
 /************************************************************************/
 
-bool GDALRasterHillshadeAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALRasterHillshadeAlgorithm::RunStep(GDALRasterPipelineStepRunContext &)
 {
     CPLAssert(m_inputDataset.GetDatasetRef());
     CPLAssert(m_outputDataset.GetName().empty());

--- a/apps/gdalalg_raster_hillshade.h
+++ b/apps/gdalalg_raster_hillshade.h
@@ -35,7 +35,7 @@ class GDALRasterHillshadeAlgorithm /* non final */
     explicit GDALRasterHillshadeAlgorithm(bool standaloneStep = false);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALRasterPipelineStepRunContext &ctxt) override;
 
     int m_band = 1;
     double m_zfactor = 1;

--- a/apps/gdalalg_raster_pipeline.cpp
+++ b/apps/gdalalg_raster_pipeline.cpp
@@ -207,7 +207,7 @@ bool GDALRasterPipelineStepAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
             stepCtxt.m_pfnProgress = pScaledData ? GDALScaledProgress : nullptr;
             stepCtxt.m_pProgressData = pScaledData.get();
             if (bCanHandleNextStep)
-                stepCtxt.m_poNextStep = &writeAlg;
+                stepCtxt.m_poNextUsableStep = &writeAlg;
             if (RunPreStepPipelineValidations() && RunStep(stepCtxt))
             {
                 if (bIsStreaming || bCanHandleNextStep)

--- a/apps/gdalalg_raster_pipeline.h
+++ b/apps/gdalalg_raster_pipeline.h
@@ -29,9 +29,15 @@ class GDALRasterPipelineStepRunContext
   public:
     GDALRasterPipelineStepRunContext() = default;
 
+    // Progress callback to use during execution of the step
     GDALProgressFunc m_pfnProgress = nullptr;
     void *m_pProgressData = nullptr;
-    GDALRasterPipelineStepAlgorithm *m_poNextStep = nullptr;
+
+    // If there is a step in the pipeline immediately following step to which
+    // this instance of GDALRasterPipelineStepRunContext is passed, and that
+    // this next step is usable by the current step (as determined by
+    // CanHandleNextStep()), then this member will point to this next step.
+    GDALRasterPipelineStepAlgorithm *m_poNextUsableStep = nullptr;
 
   private:
     CPL_DISALLOW_COPY_ASSIGN(GDALRasterPipelineStepRunContext)

--- a/apps/gdalalg_raster_pipeline.h
+++ b/apps/gdalalg_raster_pipeline.h
@@ -22,6 +22,8 @@
 /*                  GDALRasterPipelineStepRunContext                    */
 /************************************************************************/
 
+class GDALRasterPipelineStepAlgorithm;
+
 class GDALRasterPipelineStepRunContext
 {
   public:
@@ -29,6 +31,7 @@ class GDALRasterPipelineStepRunContext
 
     GDALProgressFunc m_pfnProgress = nullptr;
     void *m_pProgressData = nullptr;
+    GDALRasterPipelineStepAlgorithm *m_poNextStep = nullptr;
 
   private:
     CPL_DISALLOW_COPY_ASSIGN(GDALRasterPipelineStepRunContext)
@@ -40,6 +43,22 @@ class GDALRasterPipelineStepRunContext
 
 class GDALRasterPipelineStepAlgorithm /* non final */ : public GDALAlgorithm
 {
+  public:
+    const GDALArgDatasetValue &GetOutputDataset() const
+    {
+        return m_outputDataset;
+    }
+
+    const std::string &GetOutputFormat() const
+    {
+        return m_format;
+    }
+
+    const std::vector<std::string> &GetCreationOptions() const
+    {
+        return m_creationOptions;
+    }
+
   protected:
     using StepRunContext = GDALRasterPipelineStepRunContext;
 
@@ -54,6 +73,11 @@ class GDALRasterPipelineStepAlgorithm /* non final */ : public GDALAlgorithm
     virtual bool IsNativelyStreamingCompatible() const
     {
         return true;
+    }
+
+    virtual bool CanHandleNextStep(GDALRasterPipelineStepAlgorithm *) const
+    {
+        return false;
     }
 
     virtual bool RunStep(GDALRasterPipelineStepRunContext &ctxt) = 0;

--- a/apps/gdalalg_raster_pipeline.h
+++ b/apps/gdalalg_raster_pipeline.h
@@ -19,12 +19,30 @@
 //! @cond Doxygen_Suppress
 
 /************************************************************************/
+/*                  GDALRasterPipelineStepRunContext                    */
+/************************************************************************/
+
+class GDALRasterPipelineStepRunContext
+{
+  public:
+    GDALRasterPipelineStepRunContext() = default;
+
+    GDALProgressFunc m_pfnProgress = nullptr;
+    void *m_pProgressData = nullptr;
+
+  private:
+    CPL_DISALLOW_COPY_ASSIGN(GDALRasterPipelineStepRunContext)
+};
+
+/************************************************************************/
 /*                GDALRasterPipelineStepAlgorithm                       */
 /************************************************************************/
 
 class GDALRasterPipelineStepAlgorithm /* non final */ : public GDALAlgorithm
 {
   protected:
+    using StepRunContext = GDALRasterPipelineStepRunContext;
+
     GDALRasterPipelineStepAlgorithm(const std::string &name,
                                     const std::string &description,
                                     const std::string &helpURL,
@@ -38,7 +56,7 @@ class GDALRasterPipelineStepAlgorithm /* non final */ : public GDALAlgorithm
         return true;
     }
 
-    virtual bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) = 0;
+    virtual bool RunStep(GDALRasterPipelineStepRunContext &ctxt) = 0;
 
     void AddInputArgs(bool openForMixedRasterVector, bool hiddenForCLI);
     void AddOutputArgs(bool hiddenForCLI);

--- a/apps/gdalalg_raster_proximity.cpp
+++ b/apps/gdalalg_raster_proximity.cpp
@@ -61,9 +61,12 @@ GDALRasterProximityAlgorithm::GDALRasterProximityAlgorithm(bool standaloneStep)
 /*                 GDALRasterProximityAlgorithm::RunStep()              */
 /************************************************************************/
 
-bool GDALRasterProximityAlgorithm::RunStep(GDALProgressFunc pfnProgress,
-                                           void *pProgressData)
+bool GDALRasterProximityAlgorithm::RunStep(
+    GDALRasterPipelineStepRunContext &ctxt)
 {
+    auto pfnProgress = ctxt.m_pfnProgress;
+    auto pProgressData = ctxt.m_pProgressData;
+
     auto poSrcDS = m_inputDataset.GetDatasetRef();
     CPLAssert(poSrcDS);
 

--- a/apps/gdalalg_raster_proximity.h
+++ b/apps/gdalalg_raster_proximity.h
@@ -34,7 +34,7 @@ class GDALRasterProximityAlgorithm /* non final */
     explicit GDALRasterProximityAlgorithm(bool standaloneStep = false);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALRasterPipelineStepRunContext &ctxt) override;
 
     double m_noDataValue = 0.0;
     int m_inputBand = 1;

--- a/apps/gdalalg_raster_read.cpp
+++ b/apps/gdalalg_raster_read.cpp
@@ -33,7 +33,7 @@ GDALRasterReadAlgorithm::GDALRasterReadAlgorithm()
 /*                  GDALRasterReadAlgorithm::RunStep()                  */
 /************************************************************************/
 
-bool GDALRasterReadAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALRasterReadAlgorithm::RunStep(GDALRasterPipelineStepRunContext &)
 {
     CPLAssert(m_inputDataset.GetDatasetRef());
     CPLAssert(m_outputDataset.GetName().empty());

--- a/apps/gdalalg_raster_read.h
+++ b/apps/gdalalg_raster_read.h
@@ -32,7 +32,7 @@ class GDALRasterReadAlgorithm final : public GDALRasterPipelineStepAlgorithm
     GDALRasterReadAlgorithm();
 
   private:
-    bool RunStep(GDALProgressFunc, void *) override;
+    bool RunStep(GDALRasterPipelineStepRunContext &ctxt) override;
 };
 
 //! @endcond

--- a/apps/gdalalg_raster_reclassify.cpp
+++ b/apps/gdalalg_raster_reclassify.cpp
@@ -109,7 +109,7 @@ GDALReclassifyCreateVRTDerived(GDALDataset &input, const std::string &mappings,
 /*           GDALRasterReclassifyAlgorithm::RunStep()                   */
 /************************************************************************/
 
-bool GDALRasterReclassifyAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALRasterReclassifyAlgorithm::RunStep(GDALRasterPipelineStepRunContext &)
 {
     const auto poSrcDS = m_inputDataset.GetDatasetRef();
     CPLAssert(poSrcDS);

--- a/apps/gdalalg_raster_reclassify.h
+++ b/apps/gdalalg_raster_reclassify.h
@@ -33,7 +33,7 @@ class GDALRasterReclassifyAlgorithm : public GDALRasterPipelineStepAlgorithm
     explicit GDALRasterReclassifyAlgorithm(bool standaloneStep = false);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALRasterPipelineStepRunContext &ctxt) override;
 
     std::string m_mapping{};
     std::string m_type{};

--- a/apps/gdalalg_raster_reproject.cpp
+++ b/apps/gdalalg_raster_reproject.cpp
@@ -188,11 +188,11 @@ bool GDALRasterReprojectAlgorithm::RunStep(
 
     CPLStringList aosOptions;
     std::string outputFilename;
-    if (ctxt.m_poNextStep)
+    if (ctxt.m_poNextUsableStep)
     {
-        CPLAssert(CanHandleNextStep(ctxt.m_poNextStep));
-        outputFilename = ctxt.m_poNextStep->GetOutputDataset().GetName();
-        const auto &format = ctxt.m_poNextStep->GetOutputFormat();
+        CPLAssert(CanHandleNextStep(ctxt.m_poNextUsableStep));
+        outputFilename = ctxt.m_poNextUsableStep->GetOutputDataset().GetName();
+        const auto &format = ctxt.m_poNextUsableStep->GetOutputFormat();
         if (!format.empty())
         {
             aosOptions.AddString("-of");
@@ -200,7 +200,8 @@ bool GDALRasterReprojectAlgorithm::RunStep(
         }
 
         bool bFoundNumThreads = false;
-        for (const std::string &co : ctxt.m_poNextStep->GetCreationOptions())
+        for (const std::string &co :
+             ctxt.m_poNextUsableStep->GetCreationOptions())
         {
             aosOptions.AddString("-co");
             if (STARTS_WITH_CI(co.c_str(), "NUM_THREADS="))
@@ -338,7 +339,7 @@ bool GDALRasterReprojectAlgorithm::RunStep(
         GDALWarpAppOptionsNew(aosOptions.List(), nullptr);
     if (psOptions)
     {
-        if (ctxt.m_poNextStep)
+        if (ctxt.m_poNextUsableStep)
         {
             GDALWarpAppOptionsSetProgress(psOptions, ctxt.m_pfnProgress,
                                           ctxt.m_pProgressData);

--- a/apps/gdalalg_raster_reproject.cpp
+++ b/apps/gdalalg_raster_reproject.cpp
@@ -165,7 +165,7 @@ void GDALRasterReprojectUtils::AddWarpOptTransformOptErrorThresholdArg(
 /*            GDALRasterReprojectAlgorithm::RunStep()                   */
 /************************************************************************/
 
-bool GDALRasterReprojectAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALRasterReprojectAlgorithm::RunStep(GDALRasterPipelineStepRunContext &)
 {
     CPLAssert(m_inputDataset.GetDatasetRef());
     CPLAssert(m_outputDataset.GetName().empty());

--- a/apps/gdalalg_raster_reproject.h
+++ b/apps/gdalalg_raster_reproject.h
@@ -35,7 +35,7 @@ class GDALRasterReprojectAlgorithm /* non final */
     explicit GDALRasterReprojectAlgorithm(bool standaloneStep = false);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALRasterPipelineStepRunContext &ctxt) override;
 
     std::string m_srsCrs{};
     std::string m_dstCrs{};

--- a/apps/gdalalg_raster_reproject.h
+++ b/apps/gdalalg_raster_reproject.h
@@ -53,6 +53,10 @@ class GDALRasterReprojectAlgorithm /* non final */
     std::vector<std::string> m_warpOptions{};
     std::vector<std::string> m_transformOptions{};
     double m_errorThreshold = std::numeric_limits<double>::quiet_NaN();
+    int m_numThreads = 0;
+
+    // Work variables
+    std::string m_numThreadsStr{"ALL_CPUS"};
 };
 
 /************************************************************************/

--- a/apps/gdalalg_raster_reproject.h
+++ b/apps/gdalalg_raster_reproject.h
@@ -34,6 +34,8 @@ class GDALRasterReprojectAlgorithm /* non final */
 
     explicit GDALRasterReprojectAlgorithm(bool standaloneStep = false);
 
+    bool CanHandleNextStep(GDALRasterPipelineStepAlgorithm *) const override;
+
   private:
     bool RunStep(GDALRasterPipelineStepRunContext &ctxt) override;
 

--- a/apps/gdalalg_raster_resize.cpp
+++ b/apps/gdalalg_raster_resize.cpp
@@ -84,7 +84,7 @@ GDALRasterResizeAlgorithm::GDALRasterResizeAlgorithm(bool standaloneStep)
 /*              GDALRasterResizeAlgorithm::RunStep()                    */
 /************************************************************************/
 
-bool GDALRasterResizeAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALRasterResizeAlgorithm::RunStep(GDALRasterPipelineStepRunContext &)
 {
     CPLAssert(m_inputDataset.GetDatasetRef());
     CPLAssert(m_outputDataset.GetName().empty());

--- a/apps/gdalalg_raster_resize.h
+++ b/apps/gdalalg_raster_resize.h
@@ -33,7 +33,7 @@ class GDALRasterResizeAlgorithm /* non final */
     explicit GDALRasterResizeAlgorithm(bool standaloneStep = false);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALRasterPipelineStepRunContext &ctxt) override;
 
     std::vector<std::string> m_size{};
     std::string m_resampling{};

--- a/apps/gdalalg_raster_rgb_to_palette.cpp
+++ b/apps/gdalalg_raster_rgb_to_palette.cpp
@@ -44,9 +44,11 @@ GDALRasterRGBToPaletteAlgorithm::GDALRasterRGBToPaletteAlgorithm(
 /*                GDALRasterRGBToPaletteAlgorithm::RunStep()            */
 /************************************************************************/
 
-bool GDALRasterRGBToPaletteAlgorithm::RunStep(GDALProgressFunc pfnProgress,
-                                              void *pProgressData)
+bool GDALRasterRGBToPaletteAlgorithm::RunStep(
+    GDALRasterPipelineStepRunContext &ctxt)
 {
+    auto pfnProgress = ctxt.m_pfnProgress;
+    auto pProgressData = ctxt.m_pProgressData;
     auto poSrcDS = m_inputDataset.GetDatasetRef();
     CPLAssert(poSrcDS);
 

--- a/apps/gdalalg_raster_rgb_to_palette.h
+++ b/apps/gdalalg_raster_rgb_to_palette.h
@@ -34,7 +34,7 @@ class GDALRasterRGBToPaletteAlgorithm /* non final */
     explicit GDALRasterRGBToPaletteAlgorithm(bool standaloneStep = false);
 
   private:
-    bool RunStep(GDALProgressFunc, void *) override;
+    bool RunStep(GDALRasterPipelineStepRunContext &ctxt) override;
 
     int m_colorCount = 256;
     std::string m_colorMap{};

--- a/apps/gdalalg_raster_roughness.cpp
+++ b/apps/gdalalg_raster_roughness.cpp
@@ -44,7 +44,7 @@ GDALRasterRoughnessAlgorithm::GDALRasterRoughnessAlgorithm(bool standaloneStep)
 /*                GDALRasterRoughnessAlgorithm::RunStep()               */
 /************************************************************************/
 
-bool GDALRasterRoughnessAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALRasterRoughnessAlgorithm::RunStep(GDALRasterPipelineStepRunContext &)
 {
     CPLAssert(m_inputDataset.GetDatasetRef());
     CPLAssert(m_outputDataset.GetName().empty());

--- a/apps/gdalalg_raster_roughness.h
+++ b/apps/gdalalg_raster_roughness.h
@@ -35,7 +35,7 @@ class GDALRasterRoughnessAlgorithm /* non final */
     explicit GDALRasterRoughnessAlgorithm(bool standaloneStep = false);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALRasterPipelineStepRunContext &ctxt) override;
 
     int m_band = 1;
     bool m_noEdges = false;

--- a/apps/gdalalg_raster_scale.cpp
+++ b/apps/gdalalg_raster_scale.cpp
@@ -51,7 +51,7 @@ GDALRasterScaleAlgorithm::GDALRasterScaleAlgorithm(bool standaloneStep)
 /*               GDALRasterScaleAlgorithm::RunStep()                    */
 /************************************************************************/
 
-bool GDALRasterScaleAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALRasterScaleAlgorithm::RunStep(GDALRasterPipelineStepRunContext &)
 {
     CPLAssert(m_inputDataset.GetDatasetRef());
     CPLAssert(m_outputDataset.GetName().empty());

--- a/apps/gdalalg_raster_scale.h
+++ b/apps/gdalalg_raster_scale.h
@@ -35,7 +35,7 @@ class GDALRasterScaleAlgorithm /* non final */
     explicit GDALRasterScaleAlgorithm(bool standaloneStep = false);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALRasterPipelineStepRunContext &ctxt) override;
 
     std::string m_type{};
     int m_band = 0;

--- a/apps/gdalalg_raster_select.cpp
+++ b/apps/gdalalg_raster_select.cpp
@@ -82,7 +82,7 @@ GDALRasterSelectAlgorithm::GDALRasterSelectAlgorithm(bool standaloneStep)
 /*              GDALRasterSelectAlgorithm::RunStep()                    */
 /************************************************************************/
 
-bool GDALRasterSelectAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALRasterSelectAlgorithm::RunStep(GDALRasterPipelineStepRunContext &)
 {
     CPLAssert(m_inputDataset.GetDatasetRef());
     CPLAssert(m_outputDataset.GetName().empty());

--- a/apps/gdalalg_raster_select.h
+++ b/apps/gdalalg_raster_select.h
@@ -33,7 +33,7 @@ class GDALRasterSelectAlgorithm /* non final */
     explicit GDALRasterSelectAlgorithm(bool standaloneStep = false);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALRasterPipelineStepRunContext &ctxt) override;
 
     std::vector<std::string> m_bands{};
     std::string m_mask{};

--- a/apps/gdalalg_raster_set_type.cpp
+++ b/apps/gdalalg_raster_set_type.cpp
@@ -36,7 +36,7 @@ GDALRasterSetTypeAlgorithm::GDALRasterSetTypeAlgorithm(bool standaloneStep)
 /*             GDALRasterSetTypeAlgorithm::RunStep()                    */
 /************************************************************************/
 
-bool GDALRasterSetTypeAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALRasterSetTypeAlgorithm::RunStep(GDALRasterPipelineStepRunContext &)
 {
     CPLAssert(m_inputDataset.GetDatasetRef());
     CPLAssert(m_outputDataset.GetName().empty());

--- a/apps/gdalalg_raster_set_type.h
+++ b/apps/gdalalg_raster_set_type.h
@@ -34,7 +34,7 @@ class GDALRasterSetTypeAlgorithm /* non final */
     explicit GDALRasterSetTypeAlgorithm(bool standaloneStep = false);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALRasterPipelineStepRunContext &ctxt) override;
 
     std::string m_type{};
 };

--- a/apps/gdalalg_raster_sieve.cpp
+++ b/apps/gdalalg_raster_sieve.cpp
@@ -57,9 +57,10 @@ GDALRasterSieveAlgorithm::GDALRasterSieveAlgorithm(bool standaloneStep)
 /*                 GDALRasterSieveAlgorithm::RunStep()                  */
 /************************************************************************/
 
-bool GDALRasterSieveAlgorithm::RunStep(GDALProgressFunc pfnProgress,
-                                       void *pProgressData)
+bool GDALRasterSieveAlgorithm::RunStep(GDALRasterPipelineStepRunContext &ctxt)
 {
+    auto pfnProgress = ctxt.m_pfnProgress;
+    auto pProgressData = ctxt.m_pProgressData;
     auto poSrcDS = m_inputDataset.GetDatasetRef();
     std::unique_ptr<void, decltype(&GDALDestroyScaledProgress)> pScaledData(
         GDALCreateScaledProgress(0.0, 0.5, pfnProgress, pProgressData),

--- a/apps/gdalalg_raster_sieve.h
+++ b/apps/gdalalg_raster_sieve.h
@@ -33,7 +33,7 @@ class GDALRasterSieveAlgorithm /* non final */
     explicit GDALRasterSieveAlgorithm(bool standaloneStep = false);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALRasterPipelineStepRunContext &ctxt) override;
 
     int m_band = 1;
     int m_sizeThreshold = 2;

--- a/apps/gdalalg_raster_slope.cpp
+++ b/apps/gdalalg_raster_slope.cpp
@@ -54,10 +54,10 @@ GDALRasterSlopeAlgorithm::GDALRasterSlopeAlgorithm(bool standaloneStep)
 }
 
 /************************************************************************/
-/*              GDALRasterSlopeAlgorithm::RunStep()                 */
+/*                GDALRasterSlopeAlgorithm::RunStep()                   */
 /************************************************************************/
 
-bool GDALRasterSlopeAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALRasterSlopeAlgorithm::RunStep(GDALRasterPipelineStepRunContext &)
 {
     CPLAssert(m_inputDataset.GetDatasetRef());
     CPLAssert(m_outputDataset.GetName().empty());

--- a/apps/gdalalg_raster_slope.h
+++ b/apps/gdalalg_raster_slope.h
@@ -34,7 +34,7 @@ class GDALRasterSlopeAlgorithm /* non final */
     explicit GDALRasterSlopeAlgorithm(bool standaloneStep = false);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALRasterPipelineStepRunContext &ctxt) override;
 
     int m_band = 1;
     std::string m_unit = "degree";

--- a/apps/gdalalg_raster_stack.cpp
+++ b/apps/gdalalg_raster_stack.cpp
@@ -25,7 +25,7 @@
 #endif
 
 /************************************************************************/
-/*        GDALRasterStackAlgorithm::GDALRasterStackAlgorithm()    */
+/*          GDALRasterStackAlgorithm::GDALRasterStackAlgorithm()        */
 /************************************************************************/
 
 GDALRasterStackAlgorithm::GDALRasterStackAlgorithm()
@@ -101,7 +101,7 @@ GDALRasterStackAlgorithm::GDALRasterStackAlgorithm()
 }
 
 /************************************************************************/
-/*                   GDALRasterStackAlgorithm::RunImpl()               */
+/*                   GDALRasterStackAlgorithm::RunImpl()                */
 /************************************************************************/
 
 bool GDALRasterStackAlgorithm::RunImpl(GDALProgressFunc pfnProgress,

--- a/apps/gdalalg_raster_tpi.cpp
+++ b/apps/gdalalg_raster_tpi.cpp
@@ -44,7 +44,7 @@ GDALRasterTPIAlgorithm::GDALRasterTPIAlgorithm(bool standaloneStep)
 /*                  GDALRasterTPIAlgorithm::RunStep()                   */
 /************************************************************************/
 
-bool GDALRasterTPIAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALRasterTPIAlgorithm::RunStep(GDALRasterPipelineStepRunContext &)
 {
     CPLAssert(m_inputDataset.GetDatasetRef());
     CPLAssert(m_outputDataset.GetName().empty());

--- a/apps/gdalalg_raster_tpi.h
+++ b/apps/gdalalg_raster_tpi.h
@@ -35,7 +35,7 @@ class GDALRasterTPIAlgorithm /* non final */
     explicit GDALRasterTPIAlgorithm(bool standaloneStep = false);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALRasterPipelineStepRunContext &ctxt) override;
 
     int m_band = 1;
     bool m_noEdges = false;

--- a/apps/gdalalg_raster_tri.cpp
+++ b/apps/gdalalg_raster_tri.cpp
@@ -47,7 +47,7 @@ GDALRasterTRIAlgorithm::GDALRasterTRIAlgorithm(bool standaloneStep)
 /*                  GDALRasterTRIAlgorithm::RunStep()                   */
 /************************************************************************/
 
-bool GDALRasterTRIAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALRasterTRIAlgorithm::RunStep(GDALRasterPipelineStepRunContext &)
 {
     CPLAssert(m_inputDataset.GetDatasetRef());
     CPLAssert(m_outputDataset.GetName().empty());

--- a/apps/gdalalg_raster_tri.h
+++ b/apps/gdalalg_raster_tri.h
@@ -35,7 +35,7 @@ class GDALRasterTRIAlgorithm /* non final */
     explicit GDALRasterTRIAlgorithm(bool standaloneStep = false);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALRasterPipelineStepRunContext &ctxt) override;
 
     int m_band = 1;
     std::string m_algorithm = "Riley";

--- a/apps/gdalalg_raster_unscale.cpp
+++ b/apps/gdalalg_raster_unscale.cpp
@@ -36,7 +36,7 @@ GDALRasterUnscaleAlgorithm::GDALRasterUnscaleAlgorithm(bool standaloneStep)
 /*               GDALRasterUnscaleAlgorithm::RunStep()                  */
 /************************************************************************/
 
-bool GDALRasterUnscaleAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALRasterUnscaleAlgorithm::RunStep(GDALRasterPipelineStepRunContext &)
 {
     auto poSrcDS = m_inputDataset.GetDatasetRef();
     CPLAssert(poSrcDS);

--- a/apps/gdalalg_raster_unscale.h
+++ b/apps/gdalalg_raster_unscale.h
@@ -34,7 +34,7 @@ class GDALRasterUnscaleAlgorithm /* non final */
     explicit GDALRasterUnscaleAlgorithm(bool standaloneStep = false);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALRasterPipelineStepRunContext &ctxt) override;
 
     std::string m_type{};
 };

--- a/apps/gdalalg_raster_viewshed.cpp
+++ b/apps/gdalalg_raster_viewshed.cpp
@@ -102,9 +102,11 @@ GDALRasterViewshedAlgorithm::GDALRasterViewshedAlgorithm(bool standaloneStep)
 /*                 GDALRasterViewshedAlgorithm::RunStep()               */
 /************************************************************************/
 
-bool GDALRasterViewshedAlgorithm::RunStep(GDALProgressFunc pfnProgress,
-                                          void *pProgressData)
+bool GDALRasterViewshedAlgorithm::RunStep(
+    GDALRasterPipelineStepRunContext &ctxt)
 {
+    auto pfnProgress = ctxt.m_pfnProgress;
+    auto pProgressData = ctxt.m_pProgressData;
     auto poSrcDS = m_inputDataset.GetDatasetRef();
     CPLAssert(poSrcDS);
     CPLAssert(!m_outputDataset.GetDatasetRef());

--- a/apps/gdalalg_raster_viewshed.h
+++ b/apps/gdalalg_raster_viewshed.h
@@ -34,7 +34,7 @@ class GDALRasterViewshedAlgorithm /* non final */
     explicit GDALRasterViewshedAlgorithm(bool standaloneStep = false);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALRasterPipelineStepRunContext &ctxt) override;
 
     std::vector<double> m_observerPos{};
     double m_targetHeight = 0;

--- a/apps/gdalalg_raster_write.cpp
+++ b/apps/gdalalg_raster_write.cpp
@@ -33,9 +33,10 @@ GDALRasterWriteAlgorithm::GDALRasterWriteAlgorithm()
 /*                  GDALRasterWriteAlgorithm::RunStep()                 */
 /************************************************************************/
 
-bool GDALRasterWriteAlgorithm::RunStep(GDALProgressFunc pfnProgress,
-                                       void *pProgressData)
+bool GDALRasterWriteAlgorithm::RunStep(GDALRasterPipelineStepRunContext &ctxt)
 {
+    auto pfnProgress = ctxt.m_pfnProgress;
+    auto pProgressData = ctxt.m_pProgressData;
     CPLAssert(m_inputDataset.GetDatasetRef());
     CPLAssert(!m_outputDataset.GetDatasetRef());
 

--- a/apps/gdalalg_raster_write.h
+++ b/apps/gdalalg_raster_write.h
@@ -31,6 +31,11 @@ class GDALRasterWriteAlgorithm final : public GDALRasterPipelineStepAlgorithm
 
     GDALRasterWriteAlgorithm();
 
+    bool IsNativelyStreamingCompatible() const override
+    {
+        return false;
+    }
+
   private:
     friend class GDALRasterPipelineStepAlgorithm;
     bool RunStep(GDALRasterPipelineStepRunContext &ctxt) override;

--- a/apps/gdalalg_raster_write.h
+++ b/apps/gdalalg_raster_write.h
@@ -32,7 +32,8 @@ class GDALRasterWriteAlgorithm final : public GDALRasterPipelineStepAlgorithm
     GDALRasterWriteAlgorithm();
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    friend class GDALRasterPipelineStepAlgorithm;
+    bool RunStep(GDALRasterPipelineStepRunContext &ctxt) override;
 };
 
 //! @endcond

--- a/apps/gdalalg_vector_clip.cpp
+++ b/apps/gdalalg_vector_clip.cpp
@@ -182,7 +182,7 @@ class GDALVectorClipAlgorithmLayer final : public GDALVectorPipelineOutputLayer
 /*                 GDALVectorClipAlgorithm::RunStep()                   */
 /************************************************************************/
 
-bool GDALVectorClipAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALVectorClipAlgorithm::RunStep(GDALVectorPipelineStepRunContext &)
 {
     auto poSrcDS = m_inputDataset[0].GetDatasetRef();
     CPLAssert(poSrcDS);

--- a/apps/gdalalg_vector_clip.h
+++ b/apps/gdalalg_vector_clip.h
@@ -34,7 +34,7 @@ class GDALVectorClipAlgorithm /* non final */
     explicit GDALVectorClipAlgorithm(bool standaloneStep = false);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALVectorPipelineStepRunContext &ctxt) override;
 
     std::string m_activeLayer{};
 };

--- a/apps/gdalalg_vector_concat.cpp
+++ b/apps/gdalalg_vector_concat.cpp
@@ -176,7 +176,7 @@ static std::string BuildLayerName(const std::string &layerNameTemplate,
 /*                   GDALVectorConcatAlgorithm::RunStep()               */
 /************************************************************************/
 
-bool GDALVectorConcatAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALVectorConcatAlgorithm::RunStep(GDALVectorPipelineStepRunContext &)
 {
     std::unique_ptr<OGRSpatialReference> poSrcCRS;
     if (!m_srsCrs.empty())
@@ -420,7 +420,10 @@ bool GDALVectorConcatAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
     }
     else
     {
-        return RunStep(pfnProgress, pProgressData);
+        GDALVectorPipelineStepRunContext stepCtxt;
+        stepCtxt.m_pfnProgress = pfnProgress;
+        stepCtxt.m_pProgressData = pProgressData;
+        return RunStep(stepCtxt);
     }
 }
 

--- a/apps/gdalalg_vector_concat.h
+++ b/apps/gdalalg_vector_concat.h
@@ -34,7 +34,7 @@ class GDALVectorConcatAlgorithm /* non final */
     explicit GDALVectorConcatAlgorithm(bool bStandalone = false);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALVectorPipelineStepRunContext &ctxt) override;
     bool RunImpl(GDALProgressFunc pfnProgress, void *pProgressData) override;
 
     std::string m_layerNameTemplate{};

--- a/apps/gdalalg_vector_edit.cpp
+++ b/apps/gdalalg_vector_edit.cpp
@@ -187,7 +187,7 @@ class GDALVectorEditAlgorithmLayer final : public GDALVectorPipelineOutputLayer
 /*                GDALVectorEditAlgorithm::RunStep()                    */
 /************************************************************************/
 
-bool GDALVectorEditAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALVectorEditAlgorithm::RunStep(GDALVectorPipelineStepRunContext &)
 {
     auto poSrcDS = m_inputDataset[0].GetDatasetRef();
     CPLAssert(poSrcDS);

--- a/apps/gdalalg_vector_edit.h
+++ b/apps/gdalalg_vector_edit.h
@@ -33,7 +33,7 @@ class GDALVectorEditAlgorithm /* non final */
     explicit GDALVectorEditAlgorithm(bool standaloneStep = false);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALVectorPipelineStepRunContext &ctxt) override;
 
     std::string m_activeLayer{};
     std::string m_overrideCrs{};

--- a/apps/gdalalg_vector_filter.cpp
+++ b/apps/gdalalg_vector_filter.cpp
@@ -47,7 +47,7 @@ GDALVectorFilterAlgorithm::GDALVectorFilterAlgorithm(bool standaloneStep)
 /*               GDALVectorFilterAlgorithm::RunStep()                   */
 /************************************************************************/
 
-bool GDALVectorFilterAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALVectorFilterAlgorithm::RunStep(GDALVectorPipelineStepRunContext &)
 {
     auto poSrcDS = m_inputDataset[0].GetDatasetRef();
     CPLAssert(poSrcDS);

--- a/apps/gdalalg_vector_filter.h
+++ b/apps/gdalalg_vector_filter.h
@@ -32,7 +32,7 @@ class GDALVectorFilterAlgorithm /* non final */
     explicit GDALVectorFilterAlgorithm(bool standaloneStep = false);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALVectorPipelineStepRunContext &ctxt) override;
 
     std::string m_activeLayer{};
     std::vector<double> m_bbox{};

--- a/apps/gdalalg_vector_geom.cpp
+++ b/apps/gdalalg_vector_geom.cpp
@@ -47,7 +47,7 @@ GDALVectorGeomAlgorithm::GDALVectorGeomAlgorithm(bool standaloneStep)
 /*                GDALVectorGeomAlgorithm::RunStep()                    */
 /************************************************************************/
 
-bool GDALVectorGeomAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALVectorGeomAlgorithm::RunStep(GDALVectorPipelineStepRunContext &)
 {
     CPLError(CE_Failure, CPLE_AppDefined,
              "The Run() method should not be called directly on the \"gdal "
@@ -77,7 +77,8 @@ GDALVectorGeomAbstractAlgorithm::GDALVectorGeomAbstractAlgorithm(
 /*               GDALVectorGeomAbstractAlgorithm::RunStep()             */
 /************************************************************************/
 
-bool GDALVectorGeomAbstractAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALVectorGeomAbstractAlgorithm::RunStep(
+    GDALVectorPipelineStepRunContext &)
 {
     auto poSrcDS = m_inputDataset[0].GetDatasetRef();
     CPLAssert(poSrcDS);

--- a/apps/gdalalg_vector_geom.h
+++ b/apps/gdalalg_vector_geom.h
@@ -33,7 +33,7 @@ class GDALVectorGeomAlgorithm /* non final */
     explicit GDALVectorGeomAlgorithm(bool standaloneStep = false);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALVectorPipelineStepRunContext &ctxt) override;
 
     /** Register the sub-algorithm of type MyAlgorithm.
      */
@@ -83,7 +83,7 @@ class GDALVectorGeomAbstractAlgorithm /* non final */
                                     const std::string &helpURL,
                                     bool standaloneStep, OptionsBase &opts);
 
-    bool RunStep(GDALProgressFunc, void *) override;
+    bool RunStep(GDALVectorPipelineStepRunContext &ctxt) override;
 
   private:
     std::string &m_activeLayer;

--- a/apps/gdalalg_vector_geom_buffer.cpp
+++ b/apps/gdalalg_vector_geom_buffer.cpp
@@ -153,14 +153,16 @@ GDALVectorGeomBufferAlgorithm::CreateAlgLayer(
 /*                GDALVectorGeomBufferAlgorithm::RunStep()              */
 /************************************************************************/
 
-bool GDALVectorGeomBufferAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALVectorGeomBufferAlgorithm::RunStep(
+    GDALVectorPipelineStepRunContext &ctxt)
 {
 #ifdef HAVE_GEOS
     if (m_opts.m_side == "right")
         m_opts.m_distance = -m_opts.m_distance;
 
-    return GDALVectorGeomAbstractAlgorithm::RunStep(nullptr, nullptr);
+    return GDALVectorGeomAbstractAlgorithm::RunStep(ctxt);
 #else
+    (void)ctxt;
     ReportError(CE_Failure, CPLE_NotSupported,
                 "This algorithm is only supported for builds against GEOS");
     return false;

--- a/apps/gdalalg_vector_geom_buffer.h
+++ b/apps/gdalalg_vector_geom_buffer.h
@@ -47,7 +47,7 @@ class GDALVectorGeomBufferAlgorithm final
     explicit GDALVectorGeomBufferAlgorithm(bool standaloneStep);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALVectorPipelineStepRunContext &ctxt) override;
 
     Options m_opts{};
 };

--- a/apps/gdalalg_vector_geom_explode_collections.cpp
+++ b/apps/gdalalg_vector_geom_explode_collections.cpp
@@ -280,8 +280,8 @@ GDALVectorGeomExplodeCollectionsAlgorithm::CreateAlgLayer(OGRLayer &srcLayer)
 /*          GDALVectorGeomExplodeCollectionsAlgorithm::RunStep()        */
 /************************************************************************/
 
-bool GDALVectorGeomExplodeCollectionsAlgorithm::RunStep(GDALProgressFunc,
-                                                        void *)
+bool GDALVectorGeomExplodeCollectionsAlgorithm::RunStep(
+    GDALVectorPipelineStepRunContext &ctxt)
 {
     if (!m_opts.m_type.empty())
     {
@@ -295,7 +295,7 @@ bool GDALVectorGeomExplodeCollectionsAlgorithm::RunStep(GDALProgressFunc,
         }
     }
 
-    return GDALVectorGeomAbstractAlgorithm::RunStep(nullptr, nullptr);
+    return GDALVectorGeomAbstractAlgorithm::RunStep(ctxt);
 }
 
 //! @endcond

--- a/apps/gdalalg_vector_geom_explode_collections.h
+++ b/apps/gdalalg_vector_geom_explode_collections.h
@@ -46,7 +46,7 @@ class GDALVectorGeomExplodeCollectionsAlgorithm final
     explicit GDALVectorGeomExplodeCollectionsAlgorithm(bool standaloneStep);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALVectorPipelineStepRunContext &ctxt) override;
 
     Options m_opts{};
 };

--- a/apps/gdalalg_vector_geom_make_valid.cpp
+++ b/apps/gdalalg_vector_geom_make_valid.cpp
@@ -160,7 +160,8 @@ GDALVectorGeomMakeValidAlgorithm::CreateAlgLayer(
 /*                GDALVectorGeomMakeValidAlgorithm::RunStep()           */
 /************************************************************************/
 
-bool GDALVectorGeomMakeValidAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALVectorGeomMakeValidAlgorithm::RunStep(
+    GDALVectorPipelineStepRunContext &ctxt)
 {
 #ifdef HAVE_GEOS
 
@@ -175,8 +176,9 @@ bool GDALVectorGeomMakeValidAlgorithm::RunStep(GDALProgressFunc, void *)
     }
 #endif
 
-    return GDALVectorGeomAbstractAlgorithm::RunStep(nullptr, nullptr);
+    return GDALVectorGeomAbstractAlgorithm::RunStep(ctxt);
 #else
+    (void)ctxt;
     ReportError(CE_Failure, CPLE_NotSupported,
                 "This algorithm is only supported for builds against GEOS");
     return false;

--- a/apps/gdalalg_vector_geom_make_valid.h
+++ b/apps/gdalalg_vector_geom_make_valid.h
@@ -43,7 +43,7 @@ class GDALVectorGeomMakeValidAlgorithm final
     explicit GDALVectorGeomMakeValidAlgorithm(bool standaloneStep);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALVectorPipelineStepRunContext &ctxt) override;
 
     Options m_opts{};
 };

--- a/apps/gdalalg_vector_geom_set_type.cpp
+++ b/apps/gdalalg_vector_geom_set_type.cpp
@@ -266,7 +266,8 @@ GDALVectorGeomSetTypeAlgorithm::CreateAlgLayer(OGRLayer &srcLayer)
 /*            GDALVectorGeomSetTypeAlgorithm::RunStep()                 */
 /************************************************************************/
 
-bool GDALVectorGeomSetTypeAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALVectorGeomSetTypeAlgorithm::RunStep(
+    GDALVectorPipelineStepRunContext &ctxt)
 {
     if (!m_opts.m_type.empty())
     {
@@ -282,7 +283,7 @@ bool GDALVectorGeomSetTypeAlgorithm::RunStep(GDALProgressFunc, void *)
         m_opts.m_eType = OGRFromOGCGeomType(m_opts.m_type.c_str());
     }
 
-    return GDALVectorGeomAbstractAlgorithm::RunStep(nullptr, nullptr);
+    return GDALVectorGeomAbstractAlgorithm::RunStep(ctxt);
 }
 
 //! @endcond

--- a/apps/gdalalg_vector_geom_set_type.h
+++ b/apps/gdalalg_vector_geom_set_type.h
@@ -53,7 +53,7 @@ class GDALVectorGeomSetTypeAlgorithm final
     CreateAlgLayer(OGRLayer &srcLayer) override;
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALVectorPipelineStepRunContext &ctxt) override;
 
     Options m_opts{};
 };

--- a/apps/gdalalg_vector_geom_simplify.cpp
+++ b/apps/gdalalg_vector_geom_simplify.cpp
@@ -123,11 +123,13 @@ GDALVectorGeomSimplifyAlgorithm::CreateAlgLayer(
 /*                GDALVectorGeomSimplifyAlgorithm::RunStep()            */
 /************************************************************************/
 
-bool GDALVectorGeomSimplifyAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALVectorGeomSimplifyAlgorithm::RunStep(
+    GDALVectorPipelineStepRunContext &ctxt)
 {
 #ifdef HAVE_GEOS
-    return GDALVectorGeomAbstractAlgorithm::RunStep(nullptr, nullptr);
+    return GDALVectorGeomAbstractAlgorithm::RunStep(ctxt);
 #else
+    (void)ctxt;
     ReportError(CE_Failure, CPLE_NotSupported,
                 "This algorithm is only supported for builds against GEOS");
     return false;

--- a/apps/gdalalg_vector_geom_simplify.h
+++ b/apps/gdalalg_vector_geom_simplify.h
@@ -42,7 +42,7 @@ class GDALVectorGeomSimplifyAlgorithm final
     explicit GDALVectorGeomSimplifyAlgorithm(bool standaloneStep);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALVectorPipelineStepRunContext &ctxt) override;
 
     Options m_opts{};
 };

--- a/apps/gdalalg_vector_pipeline.cpp
+++ b/apps/gdalalg_vector_pipeline.cpp
@@ -157,9 +157,10 @@ bool GDALVectorPipelineStepAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
             }
         }
 
+        const bool bIsStreaming = m_format == "stream";
+
         // Already checked by GDALAlgorithm::Run()
-        CPLAssert(!m_executionForStreamOutput ||
-                  EQUAL(m_format.c_str(), "stream"));
+        CPLAssert(!m_executionForStreamOutput || bIsStreaming);
 
         bool ret = false;
         if (readAlg.Run())
@@ -168,9 +169,22 @@ bool GDALVectorPipelineStepAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
             m_inputDataset.resize(1);
             m_inputDataset[0].Set(readAlg.m_outputDataset.GetDatasetRef());
             m_outputDataset.Set(nullptr);
-            if (RunPreStepPipelineValidations() && RunStep(nullptr, nullptr))
+
+            std::unique_ptr<void, decltype(&GDALDestroyScaledProgress)>
+                pScaledData(nullptr, GDALDestroyScaledProgress);
+            if (pfnProgress && !IsNativelyStreamingCompatible())
             {
-                if (m_format == "stream")
+                pScaledData.reset(GDALCreateScaledProgress(
+                    0.0, bIsStreaming ? 1.0 : 0.5, pfnProgress, pProgressData));
+            }
+
+            GDALVectorPipelineStepRunContext stepCtxt;
+            stepCtxt.m_pfnProgress = pScaledData ? GDALScaledProgress : nullptr;
+            stepCtxt.m_pProgressData = pScaledData.get();
+
+            if (RunPreStepPipelineValidations() && RunStep(stepCtxt))
+            {
+                if (bIsStreaming)
                 {
                     ret = true;
                 }
@@ -180,7 +194,17 @@ bool GDALVectorPipelineStepAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
                     writeAlg.m_inputDataset.resize(1);
                     writeAlg.m_inputDataset[0].Set(
                         m_outputDataset.GetDatasetRef());
-                    if (writeAlg.Run(pfnProgress, pProgressData))
+                    if (pfnProgress)
+                    {
+                        pScaledData.reset(GDALCreateScaledProgress(
+                            IsNativelyStreamingCompatible() ? 0.0 : 0.5, 1.0,
+                            pfnProgress, pProgressData));
+                    }
+                    stepCtxt.m_pfnProgress =
+                        pScaledData ? GDALScaledProgress : nullptr;
+                    stepCtxt.m_pProgressData = pScaledData.get();
+                    if (writeAlg.ValidateArguments() &&
+                        writeAlg.RunStep(stepCtxt))
                     {
                         m_outputDataset.Set(
                             writeAlg.m_outputDataset.GetDatasetRef());
@@ -194,8 +218,10 @@ bool GDALVectorPipelineStepAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
     }
     else
     {
-        return RunPreStepPipelineValidations() &&
-               RunStep(pfnProgress, pProgressData);
+        GDALVectorPipelineStepRunContext stepCtxt;
+        stepCtxt.m_pfnProgress = pfnProgress;
+        stepCtxt.m_pProgressData = pProgressData;
+        return RunPreStepPipelineValidations() && RunStep(stepCtxt);
     }
 }
 

--- a/apps/gdalalg_vector_pipeline.cpp
+++ b/apps/gdalalg_vector_pipeline.cpp
@@ -188,7 +188,7 @@ bool GDALVectorPipelineStepAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
             stepCtxt.m_pfnProgress = pScaledData ? GDALScaledProgress : nullptr;
             stepCtxt.m_pProgressData = pScaledData.get();
             if (bCanHandleNextStep)
-                stepCtxt.m_poNextStep = &writeAlg;
+                stepCtxt.m_poNextUsableStep = &writeAlg;
             if (RunPreStepPipelineValidations() && RunStep(stepCtxt))
             {
                 if (bIsStreaming || bCanHandleNextStep)

--- a/apps/gdalalg_vector_pipeline.h
+++ b/apps/gdalalg_vector_pipeline.h
@@ -28,6 +28,8 @@
 /*                  GDALVectorPipelineStepRunContext                    */
 /************************************************************************/
 
+class GDALVectorPipelineStepAlgorithm;
+
 class GDALVectorPipelineStepRunContext
 {
   public:
@@ -35,6 +37,7 @@ class GDALVectorPipelineStepRunContext
 
     GDALProgressFunc m_pfnProgress = nullptr;
     void *m_pProgressData = nullptr;
+    GDALVectorPipelineStepAlgorithm *m_poNextStep = nullptr;
 
   private:
     CPL_DISALLOW_COPY_ASSIGN(GDALVectorPipelineStepRunContext)
@@ -61,6 +64,11 @@ class GDALVectorPipelineStepAlgorithm /* non final */ : public GDALAlgorithm
     virtual bool IsNativelyStreamingCompatible() const
     {
         return true;
+    }
+
+    virtual bool CanHandleNextStep(GDALVectorPipelineStepAlgorithm *) const
+    {
+        return false;
     }
 
     virtual bool RunStep(GDALVectorPipelineStepRunContext &ctxt) = 0;

--- a/apps/gdalalg_vector_pipeline.h
+++ b/apps/gdalalg_vector_pipeline.h
@@ -35,9 +35,15 @@ class GDALVectorPipelineStepRunContext
   public:
     GDALVectorPipelineStepRunContext() = default;
 
+    // Progress callback to use during execution of the step
     GDALProgressFunc m_pfnProgress = nullptr;
     void *m_pProgressData = nullptr;
-    GDALVectorPipelineStepAlgorithm *m_poNextStep = nullptr;
+
+    // If there is a step in the pipeline immediately following step to which
+    // this instance of GDALRasterPipelineStepRunContext is passed, and that
+    // this next step is usable by the current step (as determined by
+    // CanHandleNextStep()), then this member will point to this next step.
+    GDALVectorPipelineStepAlgorithm *m_poNextUsableStep = nullptr;
 
   private:
     CPL_DISALLOW_COPY_ASSIGN(GDALVectorPipelineStepRunContext)

--- a/apps/gdalalg_vector_pipeline.h
+++ b/apps/gdalalg_vector_pipeline.h
@@ -25,6 +25,22 @@
 //! @cond Doxygen_Suppress
 
 /************************************************************************/
+/*                  GDALVectorPipelineStepRunContext                    */
+/************************************************************************/
+
+class GDALVectorPipelineStepRunContext
+{
+  public:
+    GDALVectorPipelineStepRunContext() = default;
+
+    GDALProgressFunc m_pfnProgress = nullptr;
+    void *m_pProgressData = nullptr;
+
+  private:
+    CPL_DISALLOW_COPY_ASSIGN(GDALVectorPipelineStepRunContext)
+};
+
+/************************************************************************/
 /*                GDALVectorPipelineStepAlgorithm                       */
 /************************************************************************/
 
@@ -36,6 +52,8 @@ class GDALVectorPipelineStepAlgorithm /* non final */ : public GDALAlgorithm
                                     const std::string &helpURL,
                                     bool standaloneStep);
 
+    using StepRunContext = GDALVectorPipelineStepRunContext;
+
     friend class GDALVectorPipelineAlgorithm;
     friend class GDALAbstractPipelineAlgorithm<GDALVectorPipelineStepAlgorithm>;
     friend class GDALVectorConcatAlgorithm;
@@ -45,7 +63,7 @@ class GDALVectorPipelineStepAlgorithm /* non final */ : public GDALAlgorithm
         return true;
     }
 
-    virtual bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) = 0;
+    virtual bool RunStep(GDALVectorPipelineStepRunContext &ctxt) = 0;
 
     void AddInputArgs(bool hiddenForCLI);
     void AddOutputArgs(bool hiddenForCLI, bool shortNameOutputLayerAllowed);

--- a/apps/gdalalg_vector_read.cpp
+++ b/apps/gdalalg_vector_read.cpp
@@ -151,7 +151,7 @@ OGRFeature *GDALVectorPipelineReadOutputDataset::GetNextFeature(
 /*                  GDALVectorReadAlgorithm::RunStep()                  */
 /************************************************************************/
 
-bool GDALVectorReadAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALVectorReadAlgorithm::RunStep(GDALVectorPipelineStepRunContext &)
 {
     auto poSrcDS = m_inputDataset[0].GetDatasetRef();
     CPLAssert(poSrcDS);

--- a/apps/gdalalg_vector_read.h
+++ b/apps/gdalalg_vector_read.h
@@ -32,7 +32,7 @@ class GDALVectorReadAlgorithm final : public GDALVectorPipelineStepAlgorithm
     GDALVectorReadAlgorithm();
 
   private:
-    bool RunStep(GDALProgressFunc, void *) override;
+    bool RunStep(GDALVectorPipelineStepRunContext &ctxt) override;
 };
 
 //! @endcond

--- a/apps/gdalalg_vector_reproject.cpp
+++ b/apps/gdalalg_vector_reproject.cpp
@@ -45,7 +45,7 @@ GDALVectorReprojectAlgorithm::GDALVectorReprojectAlgorithm(bool standaloneStep)
 /*            GDALVectorReprojectAlgorithm::RunStep()                   */
 /************************************************************************/
 
-bool GDALVectorReprojectAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALVectorReprojectAlgorithm::RunStep(GDALVectorPipelineStepRunContext &)
 {
     auto poSrcDS = m_inputDataset[0].GetDatasetRef();
     CPLAssert(poSrcDS);

--- a/apps/gdalalg_vector_reproject.h
+++ b/apps/gdalalg_vector_reproject.h
@@ -33,7 +33,7 @@ class GDALVectorReprojectAlgorithm /* non final */
     explicit GDALVectorReprojectAlgorithm(bool standaloneStep = false);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALVectorPipelineStepRunContext &ctxt) override;
 
     std::string m_activeLayer{};
     std::string m_srsCrs{};

--- a/apps/gdalalg_vector_select.cpp
+++ b/apps/gdalalg_vector_select.cpp
@@ -286,7 +286,7 @@ class GDALVectorSelectAlgorithmLayer final
 /*               GDALVectorSelectAlgorithm::RunStep()                   */
 /************************************************************************/
 
-bool GDALVectorSelectAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALVectorSelectAlgorithm::RunStep(GDALVectorPipelineStepRunContext &)
 {
     auto poSrcDS = m_inputDataset[0].GetDatasetRef();
     CPLAssert(poSrcDS);

--- a/apps/gdalalg_vector_select.h
+++ b/apps/gdalalg_vector_select.h
@@ -33,7 +33,7 @@ class GDALVectorSelectAlgorithm /* non final */
     explicit GDALVectorSelectAlgorithm(bool standaloneStep = false);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALVectorPipelineStepRunContext &ctxt) override;
 
     std::string m_activeLayer{};
     std::vector<std::string> m_fields{};

--- a/apps/gdalalg_vector_sql.cpp
+++ b/apps/gdalalg_vector_sql.cpp
@@ -211,7 +211,7 @@ class GDALVectorSQLAlgorithmDatasetMultiLayer final : public GDALDataset
 /*                 GDALVectorSQLAlgorithm::RunStep()                    */
 /************************************************************************/
 
-bool GDALVectorSQLAlgorithm::RunStep(GDALProgressFunc, void *)
+bool GDALVectorSQLAlgorithm::RunStep(GDALVectorPipelineStepRunContext &)
 {
     auto poSrcDS = m_inputDataset[0].GetDatasetRef();
     CPLAssert(poSrcDS);

--- a/apps/gdalalg_vector_sql.h
+++ b/apps/gdalalg_vector_sql.h
@@ -33,7 +33,7 @@ class GDALVectorSQLAlgorithm /* non final */
     explicit GDALVectorSQLAlgorithm(bool standaloneStep = false);
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    bool RunStep(GDALVectorPipelineStepRunContext &ctxt) override;
 
     std::vector<std::string> m_sql{};
     std::vector<std::string> m_outputLayer{};

--- a/apps/gdalalg_vector_write.cpp
+++ b/apps/gdalalg_vector_write.cpp
@@ -38,9 +38,10 @@ GDALVectorWriteAlgorithm::GDALVectorWriteAlgorithm()
 /*                  GDALVectorWriteAlgorithm::RunStep()                 */
 /************************************************************************/
 
-bool GDALVectorWriteAlgorithm::RunStep(GDALProgressFunc pfnProgress,
-                                       void *pProgressData)
+bool GDALVectorWriteAlgorithm::RunStep(GDALVectorPipelineStepRunContext &ctxt)
 {
+    auto pfnProgress = ctxt.m_pfnProgress;
+    auto pProgressData = ctxt.m_pProgressData;
     auto poSrcDS = m_inputDataset[0].GetDatasetRef();
     CPLAssert(poSrcDS);
 

--- a/apps/gdalalg_vector_write.h
+++ b/apps/gdalalg_vector_write.h
@@ -32,7 +32,8 @@ class GDALVectorWriteAlgorithm final : public GDALVectorPipelineStepAlgorithm
     GDALVectorWriteAlgorithm();
 
   private:
-    bool RunStep(GDALProgressFunc pfnProgress, void *pProgressData) override;
+    friend class GDALVectorPipelineStepAlgorithm;
+    bool RunStep(GDALVectorPipelineStepRunContext &ctxt) override;
 };
 
 //! @endcond

--- a/apps/gdalalg_vector_write.h
+++ b/apps/gdalalg_vector_write.h
@@ -31,6 +31,11 @@ class GDALVectorWriteAlgorithm final : public GDALVectorPipelineStepAlgorithm
 
     GDALVectorWriteAlgorithm();
 
+    bool IsNativelyStreamingCompatible() const override
+    {
+        return false;
+    }
+
   private:
     friend class GDALVectorPipelineStepAlgorithm;
     bool RunStep(GDALVectorPipelineStepRunContext &ctxt) override;

--- a/autotest/gdrivers/gdalg.py
+++ b/autotest/gdrivers/gdalg.py
@@ -14,6 +14,7 @@
 
 import json
 
+import gdaltest
 import pytest
 
 from osgeo import gdal, ogr
@@ -62,7 +63,10 @@ def test_gdalg_raster_pipeline_explicit_write_step():
 
 
 def test_gdalg_raster_pipeline_warn_about_config():
-    with gdal.quiet_errors():
+    with gdaltest.error_raised(
+        gdal.CE_Warning,
+        match="Configuration options passed with the 'config' argument are ignored",
+    ):
         ds = gdal.Open(
             json.dumps(
                 {
@@ -70,10 +74,6 @@ def test_gdalg_raster_pipeline_warn_about_config():
                     "command_line": "gdal raster pipeline ! read --config FOO=BAR data/byte.tif",
                 }
             )
-        )
-        assert (
-            gdal.GetLastErrorMsg()
-            == "read: Configuration options passed with the 'config' argument are ignored"
         )
     assert ds.GetRasterBand(1).Checksum() == 4672
 

--- a/autotest/utilities/test_gdalalg_raster_reproject.py
+++ b/autotest/utilities/test_gdalalg_raster_reproject.py
@@ -29,6 +29,7 @@ def test_gdalalg_raster_reproject(tmp_vsimem):
     last_pct = [0]
 
     def my_progress(pct, msg, user_data):
+        assert pct >= last_pct[0]
         last_pct[0] = pct
         return True
 
@@ -39,11 +40,61 @@ def test_gdalalg_raster_reproject(tmp_vsimem):
     alg["dst-crs"] = srs
     alg["input"] = "../gcore/data/byte.tif"
     alg["output"] = out_filename
+    alg["creation-option"] = {"COMPRESS": "LZW"}
     assert alg.Run(my_progress) and alg.Finalize()
     assert last_pct[0] == 1.0
 
     with gdal.OpenEx(out_filename) as ds:
         assert ds.GetRasterBand(1).Checksum() == 4727
+        assert ds.GetMetadataItem("COMPRESSION", "IMAGE_STRUCTURE") == "LZW"
+
+
+def test_gdalalg_raster_reproject_through_pipeline(tmp_vsimem):
+
+    out_filename = str(tmp_vsimem / "out.tif")
+
+    last_pct = [0]
+
+    def my_progress(pct, msg, user_data):
+        assert pct >= last_pct[0]
+        last_pct[0] = pct
+        return True
+
+    assert gdal.Run(
+        "raster",
+        "pipeline",
+        pipeline=f"read ../gcore/data/byte.tif ! reproject --src-crs=EPSG:32611 --dst-crs=EPSG:4326 ! write {out_filename} --co COMPRESS=LZW",
+        progress=my_progress,
+    )
+    assert last_pct[0] == 1.0
+
+    with gdal.OpenEx(out_filename) as ds:
+        assert ds.GetRasterBand(1).Checksum() == 4727
+        assert ds.GetMetadataItem("COMPRESSION", "IMAGE_STRUCTURE") == "LZW"
+
+
+def test_gdalalg_raster_reproject_through_pipeline_non_optimized_path(tmp_vsimem):
+
+    out_filename = str(tmp_vsimem / "out.tif")
+
+    last_pct = [0]
+
+    def my_progress(pct, msg, user_data):
+        assert pct >= last_pct[0]
+        last_pct[0] = pct
+        return True
+
+    assert gdal.Run(
+        "raster",
+        "pipeline",
+        pipeline=f"read ../gcore/data/byte.tif ! reproject --src-crs=EPSG:32611 --dst-crs=EPSG:4326 ! edit ! write {out_filename} --co COMPRESS=LZW",
+        progress=my_progress,
+    )
+    assert last_pct[0] == 1.0
+
+    with gdal.OpenEx(out_filename) as ds:
+        assert ds.GetRasterBand(1).Checksum() == 4727
+        assert ds.GetMetadataItem("COMPRESSION", "IMAGE_STRUCTURE") == "LZW"
 
 
 def test_gdalalg_raster_reproject_failure(tmp_vsimem):

--- a/autotest/utilities/test_gdalalg_raster_reproject.py
+++ b/autotest/utilities/test_gdalalg_raster_reproject.py
@@ -227,3 +227,40 @@ def test_gdalalg_raster_reproject_error_threshold(tmp_vsimem):
         Exception, match="Value of argument 'error-threshold' is -1, but should be >= 0"
     ):
         alg["error-threshold"] = -1
+
+
+def test_gdalalg_raster_reproject_num_threads_warp_option(tmp_vsimem):
+
+    out_filename = str(tmp_vsimem / "out.tif")
+
+    alg = get_reproject_alg()
+    assert alg.ParseRunAndFinalize(
+        [
+            "--src-crs=EPSG:32611",
+            "--dst-crs=EPSG:4326",
+            "../gcore/data/byte.tif",
+            "--wo=NUM_THREADS=2",
+            out_filename,
+        ],
+    )
+
+
+def test_gdalalg_raster_reproject_both_num_threads_and_warp_option(tmp_vsimem):
+
+    out_filename = str(tmp_vsimem / "out.tif")
+
+    alg = get_reproject_alg()
+    with pytest.raises(
+        Exception,
+        match="--num-threads argument and NUM_THREADS warp options are mutually exclusive",
+    ):
+        alg.ParseRunAndFinalize(
+            [
+                "--src-crs=EPSG:32611",
+                "--dst-crs=EPSG:4326",
+                "../gcore/data/byte.tif",
+                "--wo=NUM_THREADS=1",
+                "--num-threads=2",
+                out_filename,
+            ],
+        )

--- a/doc/source/programs/gdal_raster_reproject.rst
+++ b/doc/source/programs/gdal_raster_reproject.rst
@@ -125,6 +125,13 @@ Standard options
     Alignment means that xmin / resx, ymin / resy,
     xmax / resx and ymax / resy are integer values.
 
+.. option:: -j, --num-threads <value>
+
+    .. versionadded:: 3.12
+
+    Number of jobs to run at once.
+    Default: number of CPUs detected.
+
 Advanced options
 ++++++++++++++++
 

--- a/gcore/gdalalgorithm.cpp
+++ b/gcore/gdalalgorithm.cpp
@@ -1453,7 +1453,15 @@ GDALAlgorithm::GDALAlgorithm(const std::string &name,
     AddArg("config", 0, _("Configuration option"), &m_dummyConfigOptions)
         .SetMetaVar("<KEY>=<VALUE>")
         .SetOnlyForCLI()
-        .SetCategory(GAAC_COMMON);
+        .SetCategory(GAAC_COMMON)
+        .AddAction(
+            [this]()
+            {
+                ReportError(
+                    CE_Warning, CPLE_AppDefined,
+                    "Configuration options passed with the 'config' argument "
+                    "are ignored");
+            });
 }
 
 /************************************************************************/
@@ -4468,13 +4476,6 @@ bool GDALAlgorithm::Run(GDALProgressFunc pfnProgress, void *pProgressData)
 
     if (!ValidateArguments())
         return false;
-
-    if (!m_dummyConfigOptions.empty())
-    {
-        ReportError(CE_Warning, CPLE_AppDefined,
-                    "Configuration options passed with the 'config' argument "
-                    "are ignored");
-    }
 
     switch (ProcessGDALGOutput())
     {


### PR DESCRIPTION
We recover performance by allowing a step to do the job of the following step, if it declares to be able to do so. This enables us to replace warp to VRT + translate  with warp to final format, which is very beneficial for COG output given that there is a co-operation between the COG driver and the warping code.

With this PR:
```
$ time gdal raster pipeline read byte.tif ! reproject --size 10000,10000 -r cubic --t_srs EPSG:4326 -j 0 ! write out.tif --overwrite --of=cog --co compress=zstd

real    0m5,748s
user    0m5,595s
sys     0m0,152s

$ time gdalwarp byte.tif out.tif -ts 10000 10000 -r cubic -wo NUM_THREADS=0 -co NUM_THREADS=0 -of COG -co COMPRESS=ZSTD -overwrite

real    0m5,280s
user    0m5,110s
sys     0m0,168s

$ time gdal raster pipeline read byte.tif ! reproject --size 10000,10000 -r cubic --t_srs EPSG:4326 -j 8 ! write out.tif --overwrite --of=cog --co compress=zstd

real    0m2,599s
user    0m11,262s
sys     0m0,527s

$ time gdal raster reproject --size 10000,10000 -r cubic --t_srs EPSG:4326 -j 8 --overwrite --of=cog --co compress=zstd byte.tif out.tif

real	0m2,594s
user	0m11,633s
sys	0m0,464s

$ time gdalwarp byte.tif out.tif -ts 10000 10000 -r cubic -wo NUM_THREADS=8 -co NUM_THREADS=8 -of COG -co COMPRESS=ZSTD -overwrite
Creating output file that is 10000P x 10000L.

real    0m2,258s
user    0m10,186s
sys     0m0,344s
```

Compared to master + https://github.com/OSGeo/gdal/pull/12383:
```
$ time gdal raster pipeline read byte.tif ! reproject --size 10000,10000 -r cubic --t_srs EPSG:4326 -j 0 ! write out.tif --overwrite --of=cog --co compress=zstd

real    0m8,631s
user    0m8,558s
sys     0m0,072s

$ time gdal raster pipeline read byte.tif ! reproject --size 10000,10000 -r cubic --t_srs EPSG:4326 -j 8 ! write out.tif --overwrite --of=cog --co compress=zstd --co num_threads=8

real    0m6,256s
user    0m17,601s
sys     0m0,388s
```
