### PR TITLE
BuildVRT: Support pixel functions

### DIFF
--- a/apps/gdalalg_raster_mosaic.cpp
+++ b/apps/gdalalg_raster_mosaic.cpp
@@ -111,6 +111,11 @@ GDALRasterMosaicAlgorithm::GDALRasterMosaicAlgorithm()
            _("Specify a pixel function to calculate output value from "
              "overlapping inputs"),
            &m_pixelFunction);
+    AddArg("pixel-function-arg", 0,
+           _("Specify argument(s) to pass to the pixel function"),
+           &m_pixelFunctionArgs)
+        .SetMetaVar("<NAME>=<VALUE>")
+        .SetRepeatedArgAllowed(true);
 }
 
 /************************************************************************/
@@ -274,6 +279,12 @@ bool GDALRasterMosaicAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
     {
         aosOptions.push_back("-pixel-function");
         aosOptions.push_back(m_pixelFunction);
+    }
+
+    for (const auto &arg : m_pixelFunctionArgs)
+    {
+        aosOptions.push_back("-pixel-function-arg");
+        aosOptions.push_back(arg);
     }
 
     GDALBuildVRTOptions *psOptions =

--- a/apps/gdalalg_raster_mosaic.cpp
+++ b/apps/gdalalg_raster_mosaic.cpp
@@ -107,6 +107,10 @@ GDALRasterMosaicAlgorithm::GDALRasterMosaicAlgorithm()
              "raster have "
              "none."),
            &m_addAlpha);
+    AddArg("pixel-function", 0,
+           _("Specify a pixel function to calculate output value from "
+             "overlapping inputs"),
+           &m_pixelFunction);
 }
 
 /************************************************************************/
@@ -266,8 +270,19 @@ bool GDALRasterMosaicAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
         aosOptions.push_back("-write_absolute_path");
     }
 
+    if (!m_pixelFunction.empty())
+    {
+        aosOptions.push_back("-pixel-function");
+        aosOptions.push_back(m_pixelFunction);
+    }
+
     GDALBuildVRTOptions *psOptions =
         GDALBuildVRTOptionsNew(aosOptions.List(), nullptr);
+    if (!psOptions)
+    {
+        return false;
+    }
+
     if (bVRTOutput)
     {
         GDALBuildVRTOptionsSetProgress(psOptions, pfnProgress, pProgressData);

--- a/apps/gdalalg_raster_mosaic.h
+++ b/apps/gdalalg_raster_mosaic.h
@@ -49,6 +49,7 @@ class GDALRasterMosaicAlgorithm final : public GDALAlgorithm
     bool m_addAlpha = false;
     bool m_writeAbsolutePaths = false;
     std::string m_pixelFunction{};
+    std::vector<std::string> m_pixelFunctionArgs{};
 };
 
 //! @endcond

--- a/apps/gdalalg_raster_mosaic.h
+++ b/apps/gdalalg_raster_mosaic.h
@@ -48,6 +48,7 @@ class GDALRasterMosaicAlgorithm final : public GDALAlgorithm
     bool m_hideNoData = false;
     bool m_addAlpha = false;
     bool m_writeAbsolutePaths = false;
+    std::string m_pixelFunction{};
 };
 
 //! @endcond

--- a/apps/gdalbuildvrt_lib.cpp
+++ b/apps/gdalbuildvrt_lib.cpp
@@ -2507,6 +2507,13 @@ GDALBuildVRTOptionsNew(char **papszArgv,
             psOptions->ymax = (*oTE)[3];
         }
 
+        if (psOptions->osPixelFunction.empty() &&
+            !psOptions->aosPixelFunctionArgs.empty())
+        {
+            throw std::runtime_error(
+                "Pixel function arguments provided without a pixel function");
+        }
+
         return psOptions.release();
     }
     catch (const std::exception &err)

--- a/apps/gdalbuildvrt_lib.cpp
+++ b/apps/gdalbuildvrt_lib.cpp
@@ -248,6 +248,8 @@ class VRTBuilder
     bool bNoDataFromMask = false;
     double dfMaskValueThreshold = 0;
     const CPLStringList aosCreateOptions;
+    std::string osPixelFunction{};
+    const CPLStringList aosPixelFunctionArgs;
     const bool bWriteAbsolutePath;
 
     /* Internal variables */
@@ -288,6 +290,8 @@ class VRTBuilder
                const char *pszVRTNoData, bool bUseSrcMaskBand,
                bool bNoDataFromMask, double dfMaskValueThreshold,
                const char *pszOutputSRS, const char *pszResampling,
+               const char *pszPixelFunctionName,
+               const CPLStringList &aosPixelFunctionArgs,
                const char *const *papszOpenOptionsIn,
                const CPLStringList &aosCreateOptionsIn,
                bool bWriteAbsolutePathIn);
@@ -315,14 +319,22 @@ VRTBuilder::VRTBuilder(
     const char *pszSrcNoDataIn, const char *pszVRTNoDataIn,
     bool bUseSrcMaskBandIn, bool bNoDataFromMaskIn,
     double dfMaskValueThresholdIn, const char *pszOutputSRSIn,
-    const char *pszResamplingIn, const char *const *papszOpenOptionsIn,
+    const char *pszResamplingIn, const char *pszPixelFunctionIn,
+    const CPLStringList &aosPixelFunctionArgsIn,
+    const char *const *papszOpenOptionsIn,
     const CPLStringList &aosCreateOptionsIn, bool bWriteAbsolutePathIn)
     : bStrict(bStrictIn), aosCreateOptions(aosCreateOptionsIn),
+      aosPixelFunctionArgs(aosPixelFunctionArgsIn),
       bWriteAbsolutePath(bWriteAbsolutePathIn)
 {
     pszOutputFilename = CPLStrdup(pszOutputFilenameIn);
     nInputFiles = nInputFilesIn;
     papszOpenOptions = CSLDuplicate(const_cast<char **>(papszOpenOptionsIn));
+
+    if (pszPixelFunctionIn != nullptr)
+    {
+        osPixelFunction = pszPixelFunctionIn;
+    }
 
     if (ppszInputFilenamesIn)
     {
@@ -1258,9 +1270,27 @@ void VRTBuilder::CreateVRTSeparate(VRTDataset *poVRTDS)
 
 void VRTBuilder::CreateVRTNonSeparate(VRTDataset *poVRTDS)
 {
+    CPLStringList aosOptions;
+
+    if (!osPixelFunction.empty())
+    {
+        aosOptions.AddNameValue("subclass", "VRTDerivedRasterBand");
+        aosOptions.AddNameValue("PixelFunctionType", osPixelFunction.c_str());
+        aosOptions.AddNameValue("SkipNonContributingSources", "1");
+        aosOptions.AddNameValue("SourceTransferType", "Float64");
+
+        CPLString osName;
+        for (const auto &[pszKey, pszValue] :
+             cpl::IterateNameValue(aosPixelFunctionArgs))
+        {
+            osName.Printf("_PIXELFN_ARG_%s", pszKey);
+            aosOptions.AddNameValue(osName.c_str(), pszValue);
+        }
+    }
+
     for (int j = 0; j < nSelectedBands; j++)
     {
-        poVRTDS->AddBand(asBandProperties[j].dataType);
+        poVRTDS->AddBand(asBandProperties[j].dataType, aosOptions.List());
         GDALRasterBand *poBand = poVRTDS->GetRasterBand(j + 1);
         poBand->SetColorInterpretation(asBandProperties[j].colorInterpretation);
         if (asBandProperties[j].colorInterpretation == GCI_PaletteIndex)
@@ -1873,6 +1903,8 @@ struct GDALBuildVRTOptions
     bool bNoDataFromMask = false;
     double dfMaskValueThreshold = 0;
     bool bWriteAbsolutePath = false;
+    std::string osPixelFunction{};
+    CPLStringList aosPixelFunctionArgs{};
 
     /*! allow or suppress progress monitor and other non-error output */
     bool bQuiet = true;
@@ -2024,8 +2056,10 @@ GDALDatasetH GDALBuildVRT(const char *pszDest, int nSrcCount,
         sOptions.dfMaskValueThreshold,
         sOptions.osOutputSRS.empty() ? nullptr : sOptions.osOutputSRS.c_str(),
         sOptions.osResampling.empty() ? nullptr : sOptions.osResampling.c_str(),
-        sOptions.aosOpenOptions.List(), sOptions.aosCreateOptions,
-        sOptions.bWriteAbsolutePath);
+        sOptions.osPixelFunction.empty() ? nullptr
+                                         : sOptions.osPixelFunction.c_str(),
+        sOptions.aosPixelFunctionArgs, sOptions.aosOpenOptions.List(),
+        sOptions.aosCreateOptions, sOptions.bWriteAbsolutePath);
     oBuilder.m_osProgramName = sOptions.osProgramName;
 
     return GDALDataset::ToHandle(
@@ -2192,10 +2226,39 @@ GDALBuildVRTOptionsGetParser(GDALBuildVRTOptions *psOptions,
             .help(_("Text file with an input filename on each line"));
     }
 
-    argParser->add_argument("-separate")
-        .flag()
-        .store_into(psOptions->bSeparate)
-        .help(_("Place each input file into a separate band."));
+    {
+        auto &group = argParser->add_mutually_exclusive_group();
+
+        group.add_argument("-separate")
+            .flag()
+            .store_into(psOptions->bSeparate)
+            .help(_("Place each input file into a separate band."));
+
+        group.add_argument("-pixel-function")
+            .metavar("<function>")
+            .action(
+                [psOptions](const std::string &s)
+                {
+                    auto *poPixFun =
+                        VRTDerivedRasterBand::GetPixelFunction(s.c_str());
+                    if (poPixFun == nullptr)
+                    {
+                        throw std::invalid_argument(
+                            s + " is not a registered pixel function.");
+                    }
+
+                    psOptions->osPixelFunction = s;
+                })
+
+            .help("Function to calculate value from overlapping inputs");
+    }
+
+    argParser->add_argument("-pixel-function-arg")
+        .metavar("<NAME>=<VALUE>")
+        .append()
+        .action([psOptions](const std::string &s)
+                { psOptions->aosPixelFunctionArgs.AddString(s); })
+        .help(_("Pixel function argument(s)"));
 
     argParser->add_argument("-allow_projection_difference")
         .flag()

--- a/autotest/utilities/test_gdalalg_raster_mosaic.py
+++ b/autotest/utilities/test_gdalalg_raster_mosaic.py
@@ -11,6 +11,7 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
+import gdaltest
 import pytest
 
 from osgeo import gdal, osr
@@ -426,3 +427,50 @@ def test_gdalalg_raster_mosaic_abolute_path(tmp_vsimem):
         '<SourceFilename relativeToVRT="0">' + str(tmp_vsimem / "byte.tif") in content
     )
     assert '<SourceFilename relativeToVRT="1">byte.tif' not in content
+
+
+@pytest.mark.parametrize("pixfn", ("sum", "min"))
+def test_gdalalg_raster_mosaic_pixel_function(pixfn):
+
+    gdaltest.importorskip_gdal_array()
+    np = pytest.importorskip("numpy")
+
+    src1_ds = gdal.GetDriverByName("MEM").Create("", 3, 1, eType=gdal.GDT_Int16)
+    src1_ds.SetGeoTransform([0, 1, 0, 1, 0, -1])
+    src1_ds.GetRasterBand(1).Fill(1)
+
+    src2_ds = gdal.GetDriverByName("MEM").Create("", 3, 1, eType=gdal.GDT_Int16)
+    src2_ds.SetGeoTransform([1, 1, 0, 1, 0, -1])
+    src2_ds.GetRasterBand(1).Fill(2)
+
+    alg = get_mosaic_alg()
+    alg["input"] = [src1_ds, src2_ds]
+    alg["output"] = ""
+    alg["dst-nodata"] = [-999]
+    alg["pixel-function"] = pixfn
+    assert alg.Run()
+    ds = alg["output"].GetDataset()
+
+    dst_values = ds.ReadAsArray()
+    if pixfn == "sum":
+        np.testing.assert_array_equal(dst_values, np.array([[1, 3, 3, 2]]))
+    elif pixfn == "min":
+        np.testing.assert_array_equal(dst_values, np.array([[1, 1, 1, 2]]))
+    else:
+        pytest.fail("Unexpected pixel function")
+
+    assert alg.Finalize()
+
+
+def test_gdalalg_raster_mosaic_pixel_function_invalid():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 3, 1)
+    src_ds.SetGeoTransform([0, 1, 0, 1, 0, -1])
+
+    alg = get_mosaic_alg()
+    alg["input"] = src_ds
+    alg["output"] = ""
+    alg["pixel-function"] = "does_not_exist"
+
+    with pytest.raises(RuntimeError, match="not a registered pixel function"):
+        alg.Run()

--- a/autotest/utilities/test_gdalalg_raster_mosaic.py
+++ b/autotest/utilities/test_gdalalg_raster_mosaic.py
@@ -429,8 +429,8 @@ def test_gdalalg_raster_mosaic_abolute_path(tmp_vsimem):
     assert '<SourceFilename relativeToVRT="1">byte.tif' not in content
 
 
-@pytest.mark.parametrize("pixfn", ("sum", "min"))
-def test_gdalalg_raster_mosaic_pixel_function(pixfn):
+@pytest.mark.parametrize("pixfn,args", [("sum", ["k=4"]), ("min", [])])
+def test_gdalalg_raster_mosaic_pixel_function(pixfn, args):
 
     gdaltest.importorskip_gdal_array()
     np = pytest.importorskip("numpy")
@@ -448,12 +448,13 @@ def test_gdalalg_raster_mosaic_pixel_function(pixfn):
     alg["output"] = ""
     alg["dst-nodata"] = [-999]
     alg["pixel-function"] = pixfn
+    alg["pixel-function-arg"] = args
     assert alg.Run()
     ds = alg["output"].GetDataset()
 
     dst_values = ds.ReadAsArray()
     if pixfn == "sum":
-        np.testing.assert_array_equal(dst_values, np.array([[1, 3, 3, 2]]))
+        np.testing.assert_array_equal(dst_values, np.array([[1, 3, 3, 2]]) + 4)
     elif pixfn == "min":
         np.testing.assert_array_equal(dst_values, np.array([[1, 1, 1, 2]]))
     else:

--- a/autotest/utilities/test_gdalbuildvrt_lib.py
+++ b/autotest/utilities/test_gdalbuildvrt_lib.py
@@ -1077,3 +1077,11 @@ def test_gdalbuildvrt_pixel_function_invalid():
 
     with pytest.raises(RuntimeError, match="not a registered pixel function"):
         gdal.BuildVRT("", "../gcore/data/byte.tif", pixelFunction="does_not_exist")
+
+
+def test_gdalbuildvrt_pixel_function_arg_no_pixel_function():
+
+    with pytest.raises(
+        RuntimeError, match="arguments provided without a pixel function"
+    ):
+        gdal.BuildVRT("", "../gcore/data/byte.tif", pixelFunctionArgs={"k": 7})

--- a/autotest/utilities/test_gdalbuildvrt_lib.py
+++ b/autotest/utilities/test_gdalbuildvrt_lib.py
@@ -1023,3 +1023,57 @@ def test_gdalbuildvrt_write_absolute_path_from_relative_path(tmp_path, separate)
 
     finally:
         os.chdir(old_curdir)
+
+
+###############################################################################
+
+
+@pytest.mark.parametrize(
+    "pixfn,args,expected",
+    [
+        ("sum", None, [[1, 1, 3, 2, 2]]),
+        # next test is disabled - pixel function can't distinguish between
+        # "source not present" and "source present with NoData value"
+        # ("sum", "propagateNoData=True", [[1, 99, 3, 99, 2]]),
+    ],
+)
+def test_gdalbuildvrt_pixel_function(tmp_vsimem, pixfn, args, expected):
+
+    gdaltest.importorskip_gdal_array()
+    np = pytest.importorskip("numpy")
+
+    with gdal.GetDriverByName("GTiff").Create(tmp_vsimem / "src1.tif", 4, 1) as src1_ds:
+        src1_ds.SetGeoTransform([0, 1, 0, 1, 0, -1])
+        src1_ds.GetRasterBand(1).WriteArray(np.array([[1, 1, 1, 99]]))
+
+    with gdal.GetDriverByName("GTiff").Create(tmp_vsimem / "src2.tif", 4, 1) as src2_ds:
+        src2_ds.SetGeoTransform([1, 1, 0, 1, 0, -1])
+        src2_ds.GetRasterBand(1).WriteArray(np.array([[99, 2, 2, 2]]))
+
+    with gdal.BuildVRT(
+        "",
+        [tmp_vsimem / "src1.tif", tmp_vsimem / "src2.tif"],
+        pixelFunction=pixfn,
+        pixelFunctionArgs=args,
+        VRTNodata=99,
+    ) as ds:
+        dst_values = ds.ReadAsArray()
+        np.testing.assert_array_equal(dst_values, expected)
+
+
+def test_gdalbuildvrt_pixel_function_invalid_args():
+
+    # test -pixel-function exclusive with -separate
+    with pytest.raises(RuntimeError, match="Argument .* not allowed"):
+        gdal.BuildVRT(
+            "",
+            "../gcore/data/byte.tif",
+            pixelFunction="sum",
+            separate=True,
+        )
+
+
+def test_gdalbuildvrt_pixel_function_invalid():
+
+    with pytest.raises(RuntimeError, match="not a registered pixel function"):
+        gdal.BuildVRT("", "../gcore/data/byte.tif", pixelFunction="does_not_exist")

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1068,7 +1068,7 @@ A VRTRasterBand can be made a VRTDerivedRasterBand by setting attribute subClass
 Some of the common subelements for VRTRasterBand (whose subClass="VRTDerivedRasterBand") are listed here. They can be used with built-in, C++, or Python pixel functions.
 
 - **PixelFunctionType**: (required): A pixel function with this name must be defined.
-- **SkipNonContributingSources**: (optional, added in GDAL 3.7, defaults to false) = true/false: Whether sources that do not intersect the VRTRasterBand RasterIO() requested region should be omitted. By default, data for all sources, including ones that do not intersect it, are passed to the pixel function. By setting this parameter to false, only sources that intersect the requested region will be passed.
+- **SkipNonContributingSources**: (optional, added in GDAL 3.7, defaults to false) = true/false: Whether sources that do not intersect the VRTRasterBand RasterIO() requested region should be omitted. By default, data for all sources, including ones that do not intersect it, are passed to the pixel function. By setting this parameter to true, only sources that intersect the requested region will be passed.
 
 .. example::
    :title: Calculating a derived band

--- a/doc/source/programs/gdal_raster_mosaic.rst
+++ b/doc/source/programs/gdal_raster_mosaic.rst
@@ -33,7 +33,10 @@ on network file systems such as /vsis3/, /vsigs/, /vsiaz/, etc.
 in the resulting file have similar characteristics: number of bands, projection, color
 interpretation, etc. If not, files that do not match the common characteristics will be skipped.
 
-If the inputs spatially overlap, the order of the input list is used to determine priority.
+Starting with GDAL 3.12, a function (e.g., ``min``, ``mean``, ``median``) can
+be specified (:option:`--pixel-function`) to calculate pixel values from
+overlapping inputs. If no function is specified, or in earlier versions, 
+the order of the input list is used to determine priority.
 Files that are listed at the end are the ones
 from which the content will be fetched. Note that nodata will be taken into account
 to potentially fetch data from lower-priority datasets, but currently, alpha channel

--- a/doc/source/programs/gdal_raster_mosaic.rst
+++ b/doc/source/programs/gdal_raster_mosaic.rst
@@ -127,11 +127,19 @@ The following options are available:
     dataset which doesn't report nodata value but is transparent in areas with no
     data.
 
-.. option:: -pixel-function
+.. option:: --pixel-function
 
     Specify a function name to calculate a value from overlapping inputs.
     For a list of available pixel functions, see :ref:`builtin_pixel_functions`.
     If no function is specified, values will be taken from the last overlapping input.
+
+    .. versionadded:: 3.12
+
+.. option:: --pixel-function-arg
+
+    Specify an argument to be provided to a pixel function, in the format
+    ``<NAME>=<VALUE>``. Multiple arguments may be specified by repeating this
+    option.
 
     .. versionadded:: 3.12
 

--- a/doc/source/programs/gdal_raster_mosaic.rst
+++ b/doc/source/programs/gdal_raster_mosaic.rst
@@ -127,6 +127,14 @@ The following options are available:
     dataset which doesn't report nodata value but is transparent in areas with no
     data.
 
+.. option:: -pixel-function
+
+    Specify a function name to calculate a value from overlapping inputs.
+    For a list of available pixel functions, see :ref:`builtin_pixel_functions`.
+    If no function is specified, values will be taken from the last overlapping input.
+
+    .. versionadded:: 3.12
+
 GDALG output (on-the-fly / streamed dataset)
 --------------------------------------------
 

--- a/doc/source/programs/gdalbuildvrt.rst
+++ b/doc/source/programs/gdalbuildvrt.rst
@@ -15,22 +15,23 @@ Synopsis
 
 .. code-block::
 
-   gdalbuildvrt [--help] [--long-usage] [--help-general]
-                [--quiet]
-                [[-strict]|[-non_strict]]
-                [-tile_index <field_name>]
-                [-resolution user|common|average|highest|lowest|same]
-                [-tr <xres> <yes>] [-input_file_list <filename>] [-separate]
-                [-allow_projection_difference] [-sd <n>] [-tap]
-                [-te <xmin> <ymin> <xmax> <ymax>] [-addalpha] [-b <band>]...
-                [-hidenodata] [-overwrite]
-                [-srcnodata "<value>[ <value>]..."]
-                [-vrtnodata "<value>[ <value>]..."] [-a_srs <srs_def>]
-                [-r nearest|bilinear|cubic|cubicspline|lanczos|average|mode]
-                [-oo <NAME>=<VALUE>]... [-co <NAME>=<VALUE>]...
-                [-ignore_srcmaskband]
-                [-nodata_max_mask_threshold <threshold>]
-                <vrt_dataset_name> [<src_dataset_name>]...
+    gdalbuildvrt [--help] [--long-usage] [--help-general]
+                 [--quiet]
+                 [[-strict]|[-non_strict]]
+                 [-tile_index <field_name>]
+                 [-resolution user|average|common|highest|lowest|same]
+                 [-tr <xres> <yes>] [-input_file_list <filename>]
+                 [[-separate]|[-pixel-function <function>]]
+                 [-allow_projection_difference] [-sd <n>] [-tap]
+                 [-te <xmin> <ymin> <xmax> <ymax>] [-addalpha] [-b <band>]...
+                 [-hidenodata] [-overwrite]
+                 [-srcnodata "<value>[ <value>]..."]
+                 [-vrtnodata "<value>[ <value>]..."] [-a_srs <srs_def>]
+                 [-r nearest|bilinear|cubic|cubicspline|lanczos|average|mode]
+                 [-oo <NAME>=<VALUE>]... [-co <NAME>=<VALUE>]...
+                 [-ignore_srcmaskband]
+                 [-nodata_max_mask_threshold <threshold>]
+                 <vrt_dataset_name> [<src_dataset_name>]...
 
 
 Description
@@ -191,12 +192,22 @@ changed in later versions.
     Place each input file into a separate band. See :example:`separate`.
     Contrary to the default mode, it is not
     required that all bands have the same datatype.
+    This option is mutually exclusive with :option:`-pixel-function`.
 
     Starting with GDAL 3.8, all bands of each input file are added as separate
     VRT bands, unless :option:`-b` is specified to select a subset of them.
     Before GDAL 3.8, only the first band of each input file was placed into a
     new VRT band, and :option:`-b` was ignored.
 
+.. option:: -pixel-function
+
+    Specify a function name to calculate a value from overlapping inputs.
+    For a list of available pixel functions, see :ref:`builtin_pixel_functions`.
+    If no function is specified, values will be taken from the last overlapping input.
+    This option is mutually exclusive with with :option:`-separate`.
+
+    .. versionadded:: 3.12
+    
 .. option:: -allow_projection_difference
 
     When this option is specified, the utility will create a VRT even if the input datasets do not have

--- a/doc/source/programs/gdalbuildvrt.rst
+++ b/doc/source/programs/gdalbuildvrt.rst
@@ -66,7 +66,10 @@ interpretation, etc. If not, files that do not match the common characteristics 
 unless :option:`-strict` is used.
 (This is only true in the default mode, and not when using the :option:`-separate` option)
 
-If the inputs spatially overlap, the order of the input list is used to determine priority.
+Starting with GDAL 3.12, a function (e.g., ``min``, ``mean``, ``median``) can
+be specified (:option:`-pixel-function`) to calculate pixel values from
+overlapping inputs. If no function is specified, or in earlier versions, 
+the order of the input list is used to determine priority.
 Files that are listed at the end are the ones
 from which the content will be fetched. Note that nodata will be taken into account
 to potentially fetch data from lower-priority datasets, but currently, alpha channel

--- a/doc/source/programs/gdalbuildvrt.rst
+++ b/doc/source/programs/gdalbuildvrt.rst
@@ -22,6 +22,7 @@ Synopsis
                  [-resolution user|average|common|highest|lowest|same]
                  [-tr <xres> <yes>] [-input_file_list <filename>]
                  [[-separate]|[-pixel-function <function>]]
+                 [-pixel-function-arg <NAME>=<VALUE>]...
                  [-allow_projection_difference] [-sd <n>] [-tap]
                  [-te <xmin> <ymin> <xmax> <ymax>] [-addalpha] [-b <band>]...
                  [-hidenodata] [-overwrite]
@@ -205,6 +206,14 @@ changed in later versions.
     For a list of available pixel functions, see :ref:`builtin_pixel_functions`.
     If no function is specified, values will be taken from the last overlapping input.
     This option is mutually exclusive with with :option:`-separate`.
+
+    .. versionadded:: 3.12
+
+.. option:: -pixel-function-arg
+
+    Specify an argument to be provided to a pixel function, in the format
+    ``<NAME>=<VALUE>``. Multiple arguments may be specified by repeating this
+    option.
 
     .. versionadded:: 3.12
     

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -1714,11 +1714,9 @@ CPLErr VRTDataset::AddBand(GDALDataType eType, char **papszOptions)
     {
         const int nWordDataSize = GDALGetDataTypeSizeBytes(eType);
 
-        /* --------------------------------------------------------------------
-     */
-        /*      Collect required information. */
-        /* --------------------------------------------------------------------
-     */
+        /* ---------------------------------------------------------------- */
+        /*      Collect required information.                               */
+        /* ---------------------------------------------------------------- */
         const char *pszImageOffset =
             CSLFetchNameValueDef(papszOptions, "ImageOffset", "0");
         vsi_l_offset nImageOffset = CPLScanUIntBig(
@@ -1761,11 +1759,9 @@ CPLErr VRTDataset::AddBand(GDALDataType eType, char **papszOptions)
         const bool bRelativeToVRT =
             CPLFetchBool(papszOptions, "relativeToVRT", false);
 
-        /* --------------------------------------------------------------------
-     */
-        /*      Create and initialize the band. */
-        /* --------------------------------------------------------------------
-     */
+        /* --------------------------------------------------------------- */
+        /*      Create and initialize the band.                            */
+        /* --------------------------------------------------------------- */
 
         VRTRawRasterBand *poBand =
             new VRTRawRasterBand(this, GetRasterCount() + 1, eType);
@@ -1822,6 +1818,23 @@ CPLErr VRTDataset::AddBand(GDALDataType eType, char **papszOptions)
             if (pszLanguage != nullptr)
                 poDerivedBand->SetPixelFunctionLanguage(pszLanguage);
 
+            const char *pszSkipNonContributingSources =
+                CSLFetchNameValue(papszOptions, "SkipNonContributingSources");
+            if (pszSkipNonContributingSources != nullptr)
+            {
+                poDerivedBand->SetSkipNonContributingSources(
+                    CPLTestBool(pszSkipNonContributingSources));
+            }
+            for (const auto &[pszKey, pszValue] :
+                 cpl::IterateNameValue(static_cast<CSLConstList>(papszOptions)))
+            {
+                if (STARTS_WITH(pszKey, "_PIXELFN_ARG_"))
+                {
+                    poDerivedBand->AddPixelFunctionArgument(pszKey + 13,
+                                                            pszValue);
+                }
+            }
+
             const char *pszTransferTypeName =
                 CSLFetchNameValue(papszOptions, "SourceTransferType");
             if (pszTransferTypeName != nullptr)
@@ -1840,7 +1853,7 @@ CPLErr VRTDataset::AddBand(GDALDataType eType, char **papszOptions)
             }
 
             /* We're done with the derived band specific stuff, so */
-            /* we can assigned the base class pointer now. */
+            /* we can assign the base class pointer now. */
             poBand = poDerivedBand;
         }
         else

--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -1212,6 +1212,8 @@ class CPL_DLL VRTDerivedRasterBand CPL_NON_FINAL : public VRTSourcedRasterBand
     GetPixelFunction(const char *pszFuncNameIn);
 
     void SetPixelFunctionName(const char *pszFuncNameIn);
+    void AddPixelFunctionArgument(const char *pszArg, const char *pszValue);
+    void SetSkipNonContributingSources(bool bSkip);
     void SetSourceTransferType(GDALDataType eDataType);
     void SetPixelFunctionLanguage(const char *pszLanguage);
 

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -4612,6 +4612,8 @@ def BuildVRTOptions(options=None,
                     nodataMaxMaskThreshold=None,
                     strict=False,
                     writeAbsolutePath=False,
+                    pixelFunction=None,
+                    pixelFunctionArgs=None,
                     creationOptions=None,
                     callback=None, callback_data=None):
     """Create a BuildVRTOptions() object that can be passed to gdal.BuildVRT()
@@ -4653,6 +4655,12 @@ def BuildVRTOptions(options=None,
         value of the mask band of a source below which the source band values should be replaced by VRTNodata (or 0 if not specified)
     strict:
         set to True if warnings should be failures
+    pixelFunction: str
+        a pixel function to use to calculate output pixel values when multiple
+        sources overlap. For a list of available pixel functions, see
+        :ref:`builtin_pixel_functions`.
+    pixelFunctionArgs:
+        list or dict of pixel function arguments
     creationOptions:
         list or dict of creation options
     writeAbsolutePath:
@@ -4713,6 +4721,18 @@ def BuildVRTOptions(options=None,
             new_options += ['-write_absolute_path']
         if creationOptions is not None:
             _addCreationOptions(new_options, creationOptions)
+        if pixelFunction:
+            new_options += ['-pixel-function', pixelFunction]
+        if pixelFunctionArgs:
+            if isinstance(pixelFunctionArgs, str):
+                new_options += ['-pixel-function-arg', pixelFunctionArgs]
+            elif isinstance(pixelFunctionArgs, dict):
+                for k, v in pixelFunctionArgs.items():
+                    new_options += ['-pixel-function-arg', f'{k}={v}']
+            else:
+                for opt in pixelFunctionArgs:
+                    new_options += ['-pixel-function-arg', opt]
+       
 
     if return_option_list:
         return new_options


### PR DESCRIPTION
## What does this PR do?

Adds a `-pixel-function` argument to `gdalbuildvrt` and `gdal raster mosaic` to specify how overlapping inputs should be handled.

I don't think the name "pixel function" is especially descriptive, but it's been around for a while so people seem to know what it means. (Like VSI?)

Keeping this as draft for now because I want to figure out a better solution for non-contributing sources. The failing "min" test is a good illustration of the problem.

## What are related issues/pull requests?

#11952

## Tasklist

 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

