### PR TITLE
Document 2 more Multi-dimensional array API Python Functions

### DIFF
--- a/doc/source/api/python/mdim_api.rst
+++ b/doc/source/api/python/mdim_api.rst
@@ -5,6 +5,8 @@
 
 .. _python_mdim_api:
 
+.. py:currentmodule:: osgeo.gdal
+
 Multi-dimensional array API
 ===========================
 
@@ -20,7 +22,7 @@ examples of working with the Multi-dimensional array API.
 Group
 -----------------------------
 
-.. autoclass:: osgeo.gdal.Group
+.. autoclass:: Group
     :members:
     :undoc-members:
     :exclude-members: thisown
@@ -29,7 +31,7 @@ Group
 Dimension
 -----------------------------
 
-.. autoclass:: osgeo.gdal.Dimension
+.. autoclass:: Dimension
     :members:
     :undoc-members:
     :exclude-members: thisown
@@ -38,7 +40,7 @@ Dimension
 MDArray
 -----------------------------
 
-.. autoclass:: osgeo.gdal.MDArray
+.. autoclass:: MDArray
     :members:
     :undoc-members:
     :exclude-members: thisown
@@ -47,7 +49,7 @@ MDArray
 Attribute
 -----------------------------
 
-.. autoclass:: osgeo.gdal.Attribute
+.. autoclass:: Attribute
     :members:
     :undoc-members:
     :exclude-members: thisown
@@ -56,7 +58,7 @@ Attribute
 ExtendedDataType
 -----------------------------
 
-.. autoclass:: osgeo.gdal.ExtendedDataType
+.. autoclass:: ExtendedDataType
     :members:
     :undoc-members:
     :exclude-members: thisown

--- a/doc/source/api/python/mdim_api.rst
+++ b/doc/source/api/python/mdim_api.rst
@@ -8,25 +8,53 @@
 Multi-dimensional array API
 ===========================
 
+See :ref:`multidim_raster_data_model` and :ref:`multidimensional_api_tut` for
+examples of working with the Multi-dimensional array API.
+
+
+.. contents:: API Classes
+   :local:
+   :depth: 2
+
+-----------------------------
+Group
+-----------------------------
+
 .. autoclass:: osgeo.gdal.Group
     :members:
     :undoc-members:
     :exclude-members: thisown
+
+-----------------------------
+Dimension
+-----------------------------
 
 .. autoclass:: osgeo.gdal.Dimension
     :members:
     :undoc-members:
     :exclude-members: thisown
 
+-----------------------------
+MDArray
+-----------------------------
+
 .. autoclass:: osgeo.gdal.MDArray
     :members:
     :undoc-members:
     :exclude-members: thisown
 
+-----------------------------
+Attribute
+-----------------------------
+
 .. autoclass:: osgeo.gdal.Attribute
     :members:
     :undoc-members:
     :exclude-members: thisown
+
+-----------------------------
+ExtendedDataType
+-----------------------------
 
 .. autoclass:: osgeo.gdal.ExtendedDataType
     :members:

--- a/swig/include/MultiDimensional.i
+++ b/swig/include/MultiDimensional.i
@@ -179,6 +179,7 @@ public:
 %clear char **;
 
 %newobject CreateGroup;
+%feature ("kwargs") CreateGroup;
   GDALGroupHS *CreateGroup( const char *name,
                             char **options = 0 ) {
     return GDALGroupCreateGroup(self, name, options);
@@ -190,12 +191,13 @@ public:
   }
 
 %newobject CreateDimension;
+%feature ("kwargs") CreateDimension;
   GDALDimensionHS *CreateDimension( const char *name,
-                                    const char* type,
+                                    const char* dim_type,
                                     const char* direction,
                                     GUIntBig size,
                                     char **options = 0 ) {
-    return GDALGroupCreateDimension(self, name, type, direction, size, options);
+    return GDALGroupCreateDimension(self, name, dim_type, direction, size, options);
   }
 
 #if defined(SWIGPYTHON) || defined(SWIGJAVA)

--- a/swig/include/python/docs/gdal_mdm_docs.i
+++ b/swig/include/python/docs/gdal_mdm_docs.i
@@ -1,3 +1,71 @@
+%feature("docstring")  CreateAttribute "
+
+Create an attribute within a :py:class:`osgeo.gdal.MDArray` or :py:class:`osgeo.gdal.Group`.
+
+See :cpp:func:`GDALIHasAttribute::CreateAttribute`.
+
+Parameters
+----------
+name : str
+    name
+dimensions : list
+    List of dimensions, ordered from the slowest varying
+    dimension first to the fastest varying dimension last.
+    Might be empty for a scalar array (if supported by driver)
+data_type: :py:class:`osgeo.gdal.ExtendedDataType`
+    Attribute data type
+options: dict/list
+    an optional dict or list of driver specific ``NAME=VALUE`` option strings.
+
+Returns
+-------
+
+Attribute:
+    the new :py:class:`osgeo.gdal.Attribute` or ``None`` on failure.
+
+Examples
+--------
+>>> numeric_attr = ar.CreateAttribute('numeric_attr', [], gdal.ExtendedDataType.Create(gdal.GDT_Float64))
+>>> string_attr = ar.CreateAttribute('string_attr', [], gdal.ExtendedDataType.CreateString())
+
+";
+
+%feature("docstring")  CreateDimension "
+
+Create a dimension within a :py:class:`osgeo.gdal.Group`.
+
+See :cpp:func:`GDALGroup::CreateDimension`.
+
+Parameters
+----------
+name : str
+    Dimension name
+dim_type : str
+    Dimension type (might be empty, and ignored by drivers)
+direction: str
+    Dimension direction (might be empty, and ignored by drivers)
+size : int
+    Number of values indexed by this dimension. Should be > 0
+options: dict/list
+    an optional dict or list of driver specific ``NAME=VALUE`` option strings.
+
+Returns
+-------
+
+Dimension:
+    the new :py:class:`osgeo.gdal.Dimension` or ``None`` on failure.
+
+Examples
+--------
+>>> dim_band = rg.CreateDimension('band', None, None, 3)
+>>> dim_x = rg.CreateDimension('X', None, None, 2)
+>>> dim_x.GetFullName()
+'/X'
+>>> lat = rg.CreateDimension('latitude', gdal.DIM_TYPE_HORIZONTAL_X, None, 2)
+>>> lat.GetType()
+'HORIZONTAL_X'
+";
+
 %feature("docstring")  CreateMDArray "
 
 Create a multidimensional array within a group.
@@ -17,6 +85,7 @@ dimensions : list
     dimension first to the fastest varying dimension last.
     Might be empty for a scalar array (if supported by driver)
 data_type: :py:class:`osgeo.gdal.ExtendedDataType`
+    Array data type
 options: dict/list
     an optional dict or list of driver specific ``NAME=VALUE`` option strings.
 

--- a/swig/include/python/docs/gdal_mdm_docs.i
+++ b/swig/include/python/docs/gdal_mdm_docs.i
@@ -1,6 +1,6 @@
 %feature("docstring")  CreateAttribute "
 
-Create an attribute within a :py:class:`osgeo.gdal.MDArray` or :py:class:`osgeo.gdal.Group`.
+Create an attribute within a :py:class:`MDArray` or :py:class:`Group`.
 
 See :cpp:func:`GDALIHasAttribute::CreateAttribute`.
 
@@ -12,7 +12,7 @@ dimensions : list
     List of dimensions, ordered from the slowest varying
     dimension first to the fastest varying dimension last.
     Might be empty for a scalar array (if supported by driver)
-data_type: :py:class:`osgeo.gdal.ExtendedDataType`
+data_type: :py:class:`ExtendedDataType`
     Attribute data type
 options: dict/list
     an optional dict or list of driver specific ``NAME=VALUE`` option strings.
@@ -21,10 +21,16 @@ Returns
 -------
 
 Attribute:
-    the new :py:class:`osgeo.gdal.Attribute` or ``None`` on failure.
+    the new :py:class:`Attribute` or ``None`` on failure.
 
 Examples
 --------
+
+>>> drv = gdal.GetDriverByName('MEM')
+>>> mem_ds = drv.CreateMultiDimensional('myds')
+>>> rg = mem_ds.GetRootGroup()
+>>> dim = rg.CreateDimension('dim', None, None, 2)
+>>> ar = rg.CreateMDArray('ar_double', [dim], gdal.ExtendedDataType.Create(gdal.GDT_Float64))
 >>> numeric_attr = ar.CreateAttribute('numeric_attr', [], gdal.ExtendedDataType.Create(gdal.GDT_Float64))
 >>> string_attr = ar.CreateAttribute('string_attr', [], gdal.ExtendedDataType.CreateString())
 
@@ -32,7 +38,7 @@ Examples
 
 %feature("docstring")  CreateDimension "
 
-Create a dimension within a :py:class:`osgeo.gdal.Group`.
+Create a dimension within a :py:class:`Group`.
 
 See :cpp:func:`GDALGroup::CreateDimension`.
 
@@ -53,10 +59,14 @@ Returns
 -------
 
 Dimension:
-    the new :py:class:`osgeo.gdal.Dimension` or ``None`` on failure.
+    the new :py:class:`Dimension` or ``None`` on failure.
 
 Examples
 --------
+
+>>> drv = gdal.GetDriverByName('MEM')
+>>> mem_ds = drv.CreateMultiDimensional('myds')
+>>> rg = mem_ds.GetRootGroup()
 >>> dim_band = rg.CreateDimension('band', None, None, 3)
 >>> dim_x = rg.CreateDimension('X', None, None, 2)
 >>> dim_x.GetFullName()
@@ -84,7 +94,7 @@ dimensions : list
     List of dimensions, ordered from the slowest varying
     dimension first to the fastest varying dimension last.
     Might be empty for a scalar array (if supported by driver)
-data_type: :py:class:`osgeo.gdal.ExtendedDataType`
+data_type: :py:class:`ExtendedDataType`
     Array data type
 options: dict/list
     an optional dict or list of driver specific ``NAME=VALUE`` option strings.
@@ -93,7 +103,7 @@ Returns
 -------
 
 MDArray:
-    the new :py:class:`osgeo.gdal.MDArray` or ``None`` on failure.
+    the new :py:class:`MDArray` or ``None`` on failure.
 
 Examples
 --------


### PR DESCRIPTION
I added in titles to allow an automatic TOC for the page as it was easy to become lost on the page, and this allows users to quickly jump to a class. 

One question on the SWIG Python bindings - nearly all functions in `gdal.py` have the arguments `(self, *args)`, this is unlike the MapServer bindings which have arguments that mirror their C functions, e.g. `(self, postData, url)`. 

With the example of `CreateDimension` the function is fully documented in `gdalmultidim.cpp`:

```c++
std::shared_ptr<GDALDimension> GDALGroup::CreateDimension(
    CPL_UNUSED const std::string &osName, CPL_UNUSED const std::string &osType,
    CPL_UNUSED const std::string &osDirection, CPL_UNUSED GUInt64 nSize,
    CPL_UNUSED CSLConstList papszOptions)
{
    CPLError(CE_Failure, CPLE_NotSupported,
             "CreateDimension() not implemented");
    return nullptr;
}
```

Then each of the drivers that supports MultiDimensions has its own implementation, e.g. in `memdataset.cpp`. 
Then in the SWIG bindings interface file `MultiDimensional.i` we create a wrapper function:

```c++
%newobject CreateDimension;
  GDALDimensionHS *CreateDimension( const char *name,
                                    const char* type,
                                    const char* direction,
                                    GUIntBig size,
                                    char **options = 0 ) {
    return GDALGroupCreateDimension(self, name, type, direction, size, options);
  }
```

I would have expected SWIG to generate a Python function similar to:

```python
def CreateDimension(name: str, type: str, direction: str, size: int, options=None) -> 'GDALDimension':
    # Python types would be a bonus, but even named parameters would be useful
```

However, in `gdal.py` it outputs:

```python
    def CreateDimension(self, *args):
        r"""
        CreateDimension(Group self, char const * name, char const * type, char const * direction, GUIntBig size, char ** options=None) -> Dimension
```

One final question. The `MultiDimensional.i` file uses the parameter name `const char* type`, however in Python `type` is a reserved word, so I used `dim_type`. Should these parameter names always match? Does it make any difference to the Python bindings what they are called (apart from for clarity in the help/docstrings)?
