### PR TITLE
Add bash completion for input layer name, and ...

### DIFF
--- a/apps/gdal.cpp
+++ b/apps/gdal.cpp
@@ -121,9 +121,16 @@ MAIN_START(argc, argv)
         args.push_back(argv[i]);
     CSLDestroy(argv);
 
+    alg->SetCalledFromCommandLine();
+
     if (!alg->ParseCommandLineArguments(args))
     {
-        if (strstr(CPLGetLastErrorMsg(), "Do you mean") == nullptr)
+        if (strstr(CPLGetLastErrorMsg(), "Do you mean") == nullptr &&
+            strstr(CPLGetLastErrorMsg(), "Should be one among") == nullptr &&
+            strstr(CPLGetLastErrorMsg(), "Potential values for argument") ==
+                nullptr &&
+            strstr(CPLGetLastErrorMsg(),
+                   "Single potential value for argument") == nullptr)
         {
             fprintf(stderr, "%s", alg->GetUsageForCLI(true).c_str());
         }
@@ -139,8 +146,6 @@ MAIN_START(argc, argv)
     GDALProgressFunc pfnProgress =
         alg->IsProgressBarRequested() ? GDALTermProgress : nullptr;
     void *pProgressData = nullptr;
-
-    alg->SetCalledFromCommandLine();
 
     int ret = 0;
     if (alg->Run(pfnProgress, pProgressData) && alg->Finalize())

--- a/apps/gdalalg_vector_info.cpp
+++ b/apps/gdalalg_vector_info.cpp
@@ -33,8 +33,11 @@ GDALVectorInfoAlgorithm::GDALVectorInfoAlgorithm()
     AddOpenOptionsArg(&m_openOptions);
     AddInputFormatsArg(&m_inputFormats)
         .AddMetadataItem(GAAMDI_REQUIRED_CAPABILITIES, {GDAL_DCAP_VECTOR});
-    AddInputDatasetArg(&m_dataset, GDAL_OF_VECTOR).AddAlias("dataset");
-    AddLayerNameArg(&m_layerNames).SetMutualExclusionGroup("layer-sql");
+    auto &datasetArg =
+        AddInputDatasetArg(&m_dataset, GDAL_OF_VECTOR).AddAlias("dataset");
+    auto &layerArg =
+        AddLayerNameArg(&m_layerNames).SetMutualExclusionGroup("layer-sql");
+    SetAutoCompleteFunctionForLayerName(layerArg, datasetArg);
     AddArg("features", 0,
            _("List all features (beware of RAM consumption on large layers)"),
            &m_listFeatures);

--- a/apps/gdalalg_vector_pipeline.cpp
+++ b/apps/gdalalg_vector_pipeline.cpp
@@ -64,19 +64,22 @@ void GDALVectorPipelineStepAlgorithm::AddInputArgs(bool hiddenForCLI)
         .AddMetadataItem(GAAMDI_REQUIRED_CAPABILITIES, {GDAL_DCAP_VECTOR})
         .SetHiddenForCLI(hiddenForCLI);
     AddOpenOptionsArg(&m_openOptions).SetHiddenForCLI(hiddenForCLI);
-    AddInputDatasetArg(&m_inputDataset, GDAL_OF_VECTOR,
-                       /* positionalAndRequired = */ !hiddenForCLI)
-        .SetMinCount(1)
-        .SetMaxCount((GetName() == GDALVectorPipelineAlgorithm::NAME ||
-                      GetName() == GDALVectorConcatAlgorithm::NAME)
-                         ? INT_MAX
-                         : 1)
-        .SetHiddenForCLI(hiddenForCLI);
+    auto &datasetArg =
+        AddInputDatasetArg(&m_inputDataset, GDAL_OF_VECTOR,
+                           /* positionalAndRequired = */ !hiddenForCLI)
+            .SetMinCount(1)
+            .SetMaxCount((GetName() == GDALVectorPipelineAlgorithm::NAME ||
+                          GetName() == GDALVectorConcatAlgorithm::NAME)
+                             ? INT_MAX
+                             : 1)
+            .SetHiddenForCLI(hiddenForCLI);
     if (GetName() != GDALVectorSQLAlgorithm::NAME)
     {
-        AddArg("input-layer", 'l', _("Input layer name(s)"), &m_inputLayerNames)
-            .AddAlias("layer")
-            .SetHiddenForCLI(hiddenForCLI);
+        auto &layerArg = AddArg("input-layer", 'l', _("Input layer name(s)"),
+                                &m_inputLayerNames)
+                             .AddAlias("layer")
+                             .SetHiddenForCLI(hiddenForCLI);
+        SetAutoCompleteFunctionForLayerName(layerArg, datasetArg);
     }
 }
 

--- a/autotest/utilities/test_gdal.py
+++ b/autotest/utilities/test_gdal.py
@@ -468,6 +468,35 @@ def test_gdal_completion_gdal_vector_pipeline_read_layer(gdal_path):
     assert out == ["poly"]
 
 
+def test_gdal_question_mark(gdal_path):
+
+    _, err = gdaltest.runexternal_out_and_err(
+        f"{gdal_path} vector info ../ogr/data/poly.shp --layer=?"
+    )
+    assert "Single potential value for argument 'layer' is 'poly'" in err
+
+    _, err = gdaltest.runexternal_out_and_err(
+        f"{gdal_path} vector pipeline read ../ogr/data/poly.shp --layer=?"
+    )
+    assert "Single potential value for argument 'input-layer' is 'poly'" in err
+
+    _, err = gdaltest.runexternal_out_and_err(
+        f"{gdal_path} raster reproject --resampling=?"
+    )
+    assert (
+        "Potential values for argument 'resampling' are:\n- nearest\n- bilinear"
+        in err.replace("\r\n", "\n")
+    )
+
+    _, err = gdaltest.runexternal_out_and_err(
+        f"{gdal_path} raster pipeline read ../gcore/data/byte.tif ! reproject --resampling=?"
+    )
+    assert (
+        "Potential values for argument 'resampling' are:\n- nearest\n- bilinear"
+        in err.replace("\r\n", "\n")
+    )
+
+
 def test_gdal_algorithm_getter_setter():
 
     with pytest.raises(

--- a/autotest/utilities/test_gdal.py
+++ b/autotest/utilities/test_gdal.py
@@ -185,7 +185,7 @@ def test_gdal_completion(gdal_path):
     )
     assert (
         out
-        == "** description:\\ Target\\ resolution\\ (in\\ destination\\ CRS\\ units)"
+        == "** \xC2\xA0description:\\ Target\\ resolution\\ (in\\ destination\\ CRS\\ units)"
     )
 
     out = gdaltest.runexternal(

--- a/autotest/utilities/test_gdal.py
+++ b/autotest/utilities/test_gdal.py
@@ -437,6 +437,37 @@ def test_gdal_completion_pipeline(gdal_path, subcommand):
         assert "set-type" in out
 
 
+def test_gdal_completion_gdal_vector_info_layer(gdal_path):
+
+    out = gdaltest.runexternal(
+        f"{gdal_path} completion gdal vector info ../ogr/data/poly.shp --layer"
+    ).split(" ")
+    assert out == ["poly"]
+
+    out = gdaltest.runexternal(
+        f"{gdal_path} completion gdal vector info ../ogr/data/poly.shp --layer p"
+    ).split(" ")
+    assert out == ["poly"]
+
+    out = gdaltest.runexternal(
+        f"{gdal_path} completion gdal vector info ../ogr/data/poly.shp --layer poly"
+    ).split(" ")
+    assert out == [""]
+
+    out = gdaltest.runexternal(
+        f"{gdal_path} completion gdal vector info ../ogr/data/poly.shp --layer poly XX"
+    ).split(" ")
+    assert out == [""]
+
+
+def test_gdal_completion_gdal_vector_pipeline_read_layer(gdal_path):
+
+    out = gdaltest.runexternal(
+        f"{gdal_path} completion gdal vector pipeline read ../ogr/data/poly.shp --layer"
+    ).split(" ")
+    assert out == ["poly"]
+
+
 def test_gdal_algorithm_getter_setter():
 
     with pytest.raises(

--- a/doc/source/programs/gdal_syntax.rst
+++ b/doc/source/programs/gdal_syntax.rst
@@ -74,3 +74,53 @@ The following command lines are valid:
     gdal raster convert --input input.tif --output output.tif
     gdal raster convert --creation-option COMPRESS=LZW --creation-option TILED=YES --overwrite input.tif output.tif
     gdal raster convert input.tif output.tif--co COMPRESS=LZW,TILED=YES --overwrite
+
+
+Suggestions for argument values
++++++++++++++++++++++++++++++++
+
+As an alternative to :ref:`gdal_bash_completion`, it is possible to ask for
+potential enumerated values for an argument by appending ``=?`` to the argument name.
+
+.. example::
+   :title: Asking for the layer names of a vector dataset
+
+   .. code-block:: bash
+
+        gdal vector info my.gpkg --layer=?
+
+   can return:
+
+   .. code-block::
+
+        ERROR 1: info: Potential values for argument 'layer' are:
+        - towns
+        - countries
+
+
+.. example::
+   :title: Asking for the allowed values of the resampling argument
+
+   .. code-block:: bash
+
+        gdal raster reproject --resampling=?
+
+   returns:
+
+   .. code-block::
+
+        ERROR 1: reproject: Potential values for argument 'resampling' are:
+        - nearest
+        - bilinear
+        - cubic
+        - cubicspline
+        - lanczos
+        - average
+        - rms
+        - mode
+        - min
+        - max
+        - med
+        - q1
+        - q3
+        - sum

--- a/gcore/gdalalgorithm.cpp
+++ b/gcore/gdalalgorithm.cpp
@@ -5401,8 +5401,10 @@ GDALAlgorithm::GetAutoComplete(std::vector<std::string> &args,
             if (ret.empty())
             {
                 ret.push_back("**");
-                ret.push_back(
-                    std::string("description: ").append(arg->GetDescription()));
+                // Non printable UTF-8 space, to avoid autocompletion to pickup on 'd'
+                ret.push_back(std::string("\xC2\xA0"
+                                          "description: ")
+                                  .append(arg->GetDescription()));
             }
         }
     }

--- a/gcore/gdalalgorithm.h
+++ b/gcore/gdalalgorithm.h
@@ -2829,6 +2829,11 @@ class CPL_DLL GDALAlgorithmRegistry
     GDALInConstructionAlgorithmArg &
     AddGeometryTypeArg(std::string *pValue, const char *helpMessage = nullptr);
 
+    /** Register an auto complete function for a layer name argument */
+    static void SetAutoCompleteFunctionForLayerName(
+        GDALInConstructionAlgorithmArg &layerArg,
+        GDALInConstructionAlgorithmArg &datasetArg);
+
     /** Add (single) band argument. */
     GDALInConstructionAlgorithmArg &
     AddBandArg(int *pValue, const char *helpMessage = nullptr);

--- a/gcore/gdalalgorithm.h
+++ b/gcore/gdalalgorithm.h
@@ -1838,6 +1838,8 @@ class CPL_DLL GDALAlgorithmArg /* non-final */
     /** Autocompletion function */
     std::function<std::vector<std::string>(const std::string &)>
         m_autoCompleteFunction{};
+    /** Algorith that may own this argument. */
+    GDALAlgorithm *m_owner = nullptr;
 
   private:
     bool m_skipIfAlreadySet = false;
@@ -1858,6 +1860,8 @@ class CPL_DLL GDALAlgorithmArg /* non-final */
     std::string ValidateChoice(const std::string &value) const;
     bool ValidateIntRange(int val) const;
     bool ValidateRealRange(double val) const;
+
+    CPL_DISALLOW_COPY_ASSIGN(GDALAlgorithmArg)
 };
 
 /************************************************************************/
@@ -1884,8 +1888,9 @@ class CPL_DLL GDALInConstructionAlgorithmArg final : public GDALAlgorithmArg
     template <class T>
     GDALInConstructionAlgorithmArg(GDALAlgorithm *owner,
                                    const GDALAlgorithmArgDecl &decl, T *pValue)
-        : GDALAlgorithmArg(decl, pValue), m_owner(owner)
+        : GDALAlgorithmArg(decl, pValue)
     {
+        m_owner = owner;
     }
 
     /** Add a documented alias for the argument */
@@ -2217,14 +2222,6 @@ class CPL_DLL GDALInConstructionAlgorithmArg final : public GDALAlgorithmArg
     SetIsCRSArg(bool noneAllowed = false,
                 const std::vector<std::string> &specialValues =
                     std::vector<std::string>());
-
-  private:
-    GDALAlgorithm *const m_owner;
-
-    GDALInConstructionAlgorithmArg(const GDALInConstructionAlgorithmArg &) =
-        delete;
-    GDALInConstructionAlgorithmArg &
-    operator=(const GDALInConstructionAlgorithmArg &) = delete;
 };
 
 /************************************************************************/


### PR DESCRIPTION
make 'gdal raster reproject --resampling=?' or 'gdal vector info my.gpkg --layer=?' output possible values

```
As an alternative to :ref:`gdal_bash_completion`, it is possible to ask for
potential enumerated values for an argument by appending ``=?`` to the argument name.

.. example::
   :title: Asking for the layer names of a vector dataset

   .. code-block:: bash

        gdal vector info my.gpkg --layer=?

   can return:

   .. code-block::

        ERROR 1: info: Potential values for argument 'layer' are:
        - towns
        - countries


.. example::
   :title: Asking for the allowed values of the resampling argument

   .. code-block:: bash

        gdal raster reproject --resampling=?

   returns:

   .. code-block::

        ERROR 1: reproject: Potential values for argument 'resampling' are:
        - nearest
        - bilinear
        - cubic
        - cubicspline
        - lanczos
        - average
        - rms
        - mode
        - min
        - max
        - med
        - q1
        - q3
        - sum
```