### PR TITLE
[Backport 3.11] AVIF, GRIB, COG, JPEG, netCDF, NITF, VRT, ZARR, GPKG, ARROW, PARQUET: fix multithreading race in getting driver metadata

### DIFF
--- a/autotest/cpp/CMakeLists.txt
+++ b/autotest/cpp/CMakeLists.txt
@@ -389,6 +389,9 @@ gdal_gtest_target(testlog test-log
 gdal_gtest_target(test_deferred_plugin test-deferred-plugin
     FILES
         test_deferred_plugin.cpp)
+gdal_gtest_target(test_driver_metadata_multithread test-driver-metadata-multithread.cpp
+    FILES
+        test_driver_metadata_multithread.cpp)
 
 if (GDAL_ENABLE_DRIVER_JPEG_PLUGIN)
     target_compile_definitions(test_deferred_plugin PRIVATE -DJPEG_PLUGIN)

--- a/autotest/cpp/test_driver_metadata_multithread.cpp
+++ b/autotest/cpp/test_driver_metadata_multithread.cpp
@@ -1,0 +1,83 @@
+/******************************************************************************
+ * Project:  GDAL Core
+ * Purpose:  Test getting driver metadata concurrently from multiple threads.
+ * Author:   Even Rouault <even dot rouault at spatialys.com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2025, Even Rouault <even dot rouault at spatialys.com>
+ *
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#include "gdal_priv.h"
+
+#include "gtest_include.h"
+
+#include <thread>
+
+namespace
+{
+
+static bool test(int mainIter)
+{
+    bool ret = true;
+    GDALAllRegister();
+
+    const char *pszItem = (mainIter % 2) == 0
+                              ? GDAL_DMD_CREATIONOPTIONLIST
+                              : GDAL_DS_LAYER_CREATIONOPTIONLIST;
+
+    auto poDM = GetGDALDriverManager();
+    const int nDriverCount = poDM->GetDriverCount();
+    for (int iDrv = 0; iDrv < nDriverCount; ++iDrv)
+    {
+        auto poDriver = poDM->GetDriver(iDrv);
+        if (poDriver->pfnCreate || poDriver->pfnCreateCopy)
+        {
+            std::vector<std::thread> threads;
+            std::vector<std::string> tabretval(4);
+            for (size_t i = 0; i < tabretval.size(); ++i)
+            {
+                std::string &retval = tabretval[i];
+                threads.emplace_back(
+                    [pszItem, i, poDriver, &retval]()
+                    {
+                        const char *pszStr;
+                        if ((i % 2) == 0)
+                        {
+                            pszStr = poDriver->GetMetadataItem(pszItem);
+                        }
+                        else
+                        {
+                            pszStr = CSLFetchNameValue(poDriver->GetMetadata(),
+                                                       pszItem);
+                        }
+                        if (pszStr)
+                            retval = pszStr;
+                    });
+            }
+            for (size_t i = 0; i < tabretval.size(); ++i)
+            {
+                threads[i].join();
+                if (i > 0 && tabretval[i] != tabretval[0])
+                {
+                    fprintf(stderr, "%s\n", poDriver->GetDescription());
+                    ret = false;
+                }
+            }
+        }
+    }
+
+    GDALDestroyDriverManager();
+    return ret;
+}
+
+TEST(Test, test)
+{
+    for (int i = 0; i < 200; ++i)
+    {
+        ASSERT_TRUE(test(i));
+    }
+}
+
+}  // namespace

--- a/frmts/avif/avifdataset.cpp
+++ b/frmts/avif/avifdataset.cpp
@@ -21,6 +21,7 @@
 
 #include <algorithm>
 #include <cinttypes>
+#include <mutex>
 #include <vector>
 #include <iostream>
 #include <geoheif.h>
@@ -1064,6 +1065,7 @@ GDALDataset *GDALAVIFDataset::CreateCopy(const char *pszFilename,
 
 class GDALAVIFDriver final : public GDALDriver
 {
+    std::mutex m_oMutex{};
     bool m_bMetadataInitialized = false;
     void InitMetadata();
 
@@ -1071,6 +1073,7 @@ class GDALAVIFDriver final : public GDALDriver
     const char *GetMetadataItem(const char *pszName,
                                 const char *pszDomain = "") override
     {
+        std::lock_guard oLock(m_oMutex);
         if (EQUAL(pszName, GDAL_DMD_CREATIONOPTIONLIST))
         {
             InitMetadata();
@@ -1080,6 +1083,7 @@ class GDALAVIFDriver final : public GDALDriver
 
     char **GetMetadata(const char *pszDomain) override
     {
+        std::lock_guard oLock(m_oMutex);
         InitMetadata();
         return GDALDriver::GetMetadata(pszDomain);
     }

--- a/frmts/grib/gribdataset.cpp
+++ b/frmts/grib/gribdataset.cpp
@@ -28,6 +28,7 @@
 #endif
 
 #include <algorithm>
+#include <mutex>
 #include <set>
 #include <string>
 #include <vector>
@@ -2880,7 +2881,9 @@ static void GDALDeregister_GRIB(GDALDriver *)
 
 class GDALGRIBDriver : public GDALDriver
 {
+    std::mutex m_oMutex{};
     bool m_bHasFullInitMetadata = false;
+    void InitializeMetadata();
 
   public:
     GDALGRIBDriver() = default;
@@ -2891,12 +2894,11 @@ class GDALGRIBDriver : public GDALDriver
 };
 
 /************************************************************************/
-/*                            GetMetadata()                             */
+/*                         InitializeMetadata()                         */
 /************************************************************************/
 
-char **GDALGRIBDriver::GetMetadata(const char *pszDomain)
+void GDALGRIBDriver::InitializeMetadata()
 {
-    if (pszDomain == nullptr || EQUAL(pszDomain, ""))
     {
         // Defer until necessary the setting of the CreationOptionList
         // to let a chance to JPEG2000 drivers to have been loaded.
@@ -2987,6 +2989,19 @@ char **GDALGRIBDriver::GetMetadata(const char *pszDomain)
             SetMetadataItem(GDAL_DMD_CREATIONOPTIONLIST, osCreationOptionList);
         }
     }
+}
+
+/************************************************************************/
+/*                            GetMetadata()                             */
+/************************************************************************/
+
+char **GDALGRIBDriver::GetMetadata(const char *pszDomain)
+{
+    std::lock_guard oLock(m_oMutex);
+    if (pszDomain == nullptr || EQUAL(pszDomain, ""))
+    {
+        InitializeMetadata();
+    }
     return GDALDriver::GetMetadata(pszDomain);
 }
 
@@ -2997,12 +3012,13 @@ char **GDALGRIBDriver::GetMetadata(const char *pszDomain)
 const char *GDALGRIBDriver::GetMetadataItem(const char *pszName,
                                             const char *pszDomain)
 {
+    std::lock_guard oLock(m_oMutex);
     if (pszDomain == nullptr || EQUAL(pszDomain, ""))
     {
         // Defer until necessary the setting of the CreationOptionList
         // to let a chance to JPEG2000 drivers to have been loaded.
         if (EQUAL(pszName, GDAL_DMD_CREATIONOPTIONLIST))
-            GetMetadata();
+            InitializeMetadata();
     }
     return GDALDriver::GetMetadataItem(pszName, pszDomain);
 }

--- a/frmts/gtiff/cogdriver.cpp
+++ b/frmts/gtiff/cogdriver.cpp
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <mutex>
 #include <vector>
 
 static bool gbHasLZW = false;
@@ -1405,6 +1406,7 @@ static GDALDataset *COGCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
 
 class GDALCOGDriver final : public GDALDriver
 {
+    std::mutex m_oMutex{};
     bool m_bInitialized = false;
 
     bool bHasLZW = false;
@@ -1424,6 +1426,7 @@ class GDALCOGDriver final : public GDALDriver
     const char *GetMetadataItem(const char *pszName,
                                 const char *pszDomain) override
     {
+        std::lock_guard oLock(m_oMutex);
         if (EQUAL(pszName, GDAL_DMD_CREATIONOPTIONLIST))
         {
             InitializeCreationOptionList();
@@ -1433,6 +1436,7 @@ class GDALCOGDriver final : public GDALDriver
 
     char **GetMetadata(const char *pszDomain) override
     {
+        std::lock_guard oLock(m_oMutex);
         InitializeCreationOptionList();
         return GDALDriver::GetMetadata(pszDomain);
     }

--- a/frmts/jpeg/jpgdataset.h
+++ b/frmts/jpeg/jpgdataset.h
@@ -30,6 +30,7 @@
 #include <setjmp.h>
 
 #include <algorithm>
+#include <mutex>
 #include <string>
 
 #include "cpl_conv.h"
@@ -408,13 +409,16 @@ class JPGMaskBand final : public GDALRasterBand
 class GDALJPGDriver final : public GDALDriver
 {
   public:
-    GDALJPGDriver()
-    {
-    }
+    GDALJPGDriver() = default;
 
     char **GetMetadata(const char *pszDomain = "") override;
     const char *GetMetadataItem(const char *pszName,
                                 const char *pszDomain = "") override;
+
+  private:
+    std::mutex m_oMutex{};
+    bool m_bMetadataInitialized = false;
+    void InitializeMetadata();
 };
 
 #endif  // !defined(JPGDataset)

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -29,6 +29,7 @@
 #include <algorithm>
 #include <limits>
 #include <map>
+#include <mutex>
 #include <set>
 #include <queue>
 #include <string>
@@ -10208,6 +10209,7 @@ class GDALnetCDFDriver final : public GDALDriver
     const char *GetMetadataItem(const char *pszName,
                                 const char *pszDomain) override
     {
+        std::lock_guard oLock(m_oMutex);
         if (EQUAL(pszName, GDAL_DCAP_VIRTUALIO))
         {
             InitializeDCAPVirtualIO();
@@ -10217,11 +10219,13 @@ class GDALnetCDFDriver final : public GDALDriver
 
     char **GetMetadata(const char *pszDomain) override
     {
+        std::lock_guard oLock(m_oMutex);
         InitializeDCAPVirtualIO();
         return GDALDriver::GetMetadata(pszDomain);
     }
 
   private:
+    std::mutex m_oMutex{};
     bool m_bInitialized = false;
 
     void InitializeDCAPVirtualIO()

--- a/frmts/nitf/nitfdataset.cpp
+++ b/frmts/nitf/nitfdataset.cpp
@@ -29,6 +29,7 @@
 #endif
 #include <algorithm>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -7174,6 +7175,7 @@ static const char *const apszFieldsBLOCKA[] = {
 
 class NITFDriver final : public GDALDriver
 {
+    std::mutex m_oMutex{};
     bool m_bCreationOptionListInitialized = false;
     void InitCreationOptionList();
 
@@ -7181,6 +7183,7 @@ class NITFDriver final : public GDALDriver
     const char *GetMetadataItem(const char *pszName,
                                 const char *pszDomain) override
     {
+        std::lock_guard oLock(m_oMutex);
         if (EQUAL(pszName, GDAL_DMD_CREATIONOPTIONLIST))
         {
             InitCreationOptionList();
@@ -7190,6 +7193,7 @@ class NITFDriver final : public GDALDriver
 
     char **GetMetadata(const char *pszDomain) override
     {
+        std::lock_guard oLock(m_oMutex);
         InitCreationOptionList();
         return GDALDriver::GetMetadata(pszDomain);
     }

--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -1290,6 +1290,7 @@ class VRTDriver final : public GDALDriver
 {
     CPL_DISALLOW_COPY_ASSIGN(VRTDriver)
 
+    std::mutex m_oMutex{};
     std::map<std::string, VRTSourceParser> m_oMapSourceParser{};
 
   public:

--- a/frmts/vrt/vrtdriver.cpp
+++ b/frmts/vrt/vrtdriver.cpp
@@ -70,6 +70,7 @@ char **VRTDriver::GetMetadataDomainList()
 char **VRTDriver::GetMetadata(const char *pszDomain)
 
 {
+    std::lock_guard oLock(m_oMutex);
     if (pszDomain && EQUAL(pszDomain, "SourceParsers"))
         return papszSourceParsers;
 
@@ -83,6 +84,7 @@ char **VRTDriver::GetMetadata(const char *pszDomain)
 CPLErr VRTDriver::SetMetadata(char **papszMetadata, const char *pszDomain)
 
 {
+    std::lock_guard oLock(m_oMutex);
     if (pszDomain && EQUAL(pszDomain, "SourceParsers"))
     {
         m_oMapSourceParser.clear();

--- a/frmts/zarr/zarrdriver.cpp
+++ b/frmts/zarr/zarrdriver.cpp
@@ -20,6 +20,7 @@
 #include <cassert>
 #include <cinttypes>
 #include <limits>
+#include <mutex>
 
 #ifdef HAVE_BLOSC
 #include <blosc.h>
@@ -749,6 +750,7 @@ static CPLErr ZarrDatasetCopyFiles(const char *pszNewName,
 
 class ZarrDriver final : public GDALDriver
 {
+    std::mutex m_oMutex{};
     bool m_bMetadataInitialized = false;
     void InitMetadata();
 
@@ -756,6 +758,7 @@ class ZarrDriver final : public GDALDriver
     const char *GetMetadataItem(const char *pszName,
                                 const char *pszDomain) override
     {
+        std::lock_guard oLock(m_oMutex);
         if (EQUAL(pszName, "COMPRESSORS") ||
             EQUAL(pszName, "BLOSC_COMPRESSORS") ||
             EQUAL(pszName, GDAL_DMD_CREATIONOPTIONLIST) ||
@@ -768,6 +771,7 @@ class ZarrDriver final : public GDALDriver
 
     char **GetMetadata(const char *pszDomain) override
     {
+        std::lock_guard oLock(m_oMutex);
         InitMetadata();
         return GDALDriver::GetMetadata(pszDomain);
     }

--- a/ogr/ogrsf_frmts/arrow/ogrfeatherdriver.cpp
+++ b/ogr/ogrsf_frmts/arrow/ogrfeatherdriver.cpp
@@ -14,6 +14,7 @@
 #include "ogrsf_frmts.h"
 
 #include <map>
+#include <mutex>
 
 #include "ogr_feather.h"
 #include "../arrow_common/ograrrowrandomaccessfile.h"
@@ -308,6 +309,7 @@ static GDALDataset *OGRFeatherDriverCreate(const char *pszName, int nXSize,
 
 class OGRFeatherDriver final : public GDALDriver
 {
+    std::mutex m_oMutex{};
     bool m_bMetadataInitialized = false;
     void InitMetadata();
 
@@ -315,6 +317,7 @@ class OGRFeatherDriver final : public GDALDriver
     const char *GetMetadataItem(const char *pszName,
                                 const char *pszDomain) override
     {
+        std::lock_guard oLock(m_oMutex);
         if (EQUAL(pszName, GDAL_DS_LAYER_CREATIONOPTIONLIST))
         {
             InitMetadata();
@@ -324,6 +327,7 @@ class OGRFeatherDriver final : public GDALDriver
 
     char **GetMetadata(const char *pszDomain) override
     {
+        std::lock_guard oLock(m_oMutex);
         InitMetadata();
         return GDALDriver::GetMetadata(pszDomain);
     }


### PR DESCRIPTION
Backport of PR #12390