### PR TITLE
GDALOverviews: Limit external file size in GDALRegenerateOverviewsMultiBand

### DIFF
--- a/autotest/gcore/tiff_ovr.py
+++ b/autotest/gcore/tiff_ovr.py
@@ -2719,7 +2719,7 @@ def test_tiff_ovr_fallback_to_multiband_overview_generate(config_options):
 
     ds = gdal.Open(filename)
     cs = ds.GetRasterBand(1).GetOverview(0).Checksum()
-    assert cs == 37308
+    assert cs == 36766
     ds = None
 
     gdal.GetDriverByName("GTiff").Delete(filename)

--- a/autotest/gcore/tiff_ovr.py
+++ b/autotest/gcore/tiff_ovr.py
@@ -3069,3 +3069,56 @@ def test_tiff_ovr_huge_raster_with_ovr_huge_block(tmp_vsimem):
     with pytest.raises(Exception):
         with gdal.Open(tmp_vsimem / "tmp.tif", gdal.GA_Update) as ds:
             ds.BuildOverviews("AVERAGE", [2])
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_tiff_ovr_huge_reduction_factor_nodata(tmp_vsimem):
+
+    ds = gdal.GetDriverByName("GTIFF").Create(
+        tmp_vsimem / "test.tif",
+        1024,
+        1024,
+        3,
+        options=["BLOCKYSIZE=1024", "COMPRESS=LZW"],
+    )
+    ds.GetRasterBand(1).SetNoDataValue(0)
+    ds.GetRasterBand(2).SetNoDataValue(0)
+    ds.GetRasterBand(3).SetNoDataValue(0)
+    ds.WriteRaster(511, 511, 1, 1, b"\xFF" * 3)
+    with gdaltest.config_options(
+        {
+            "GDAL_OVR_CHUNK_MAX_SIZE": "1000",
+            "GDAL_OVR_CHUNK_MAX_SIZE_FOR_TEMP_FILE": "1000",
+        }
+    ):
+        ds.BuildOverviews("AVERAGE", [1024])
+    assert ds.GetRasterBand(1).GetOverview(0).ReadRaster() == b"\xFF"
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_tiff_ovr_huge_reduction_factor_mask(tmp_vsimem):
+
+    ds = gdal.GetDriverByName("GTIFF").Create(
+        tmp_vsimem / "test.tif",
+        1024,
+        1024,
+        3,
+        options=["BLOCKYSIZE=1024", "COMPRESS=LZW"],
+    )
+    ds.WriteRaster(511, 511, 1, 1, b"\xFF" * 3)
+    ds.CreateMaskBand(gdal.GMF_PER_DATASET)
+    ds.GetRasterBand(1).GetMaskBand().WriteRaster(511, 511, 1, 1, b"\xFF")
+    with gdaltest.config_options(
+        {
+            "GDAL_OVR_CHUNK_MAX_SIZE": "1000",
+            "GDAL_OVR_CHUNK_MAX_SIZE_FOR_TEMP_FILE": "1000",
+        }
+    ):
+        ds.BuildOverviews("AVERAGE", [1024])
+    assert ds.GetRasterBand(1).GetOverview(0).ReadRaster() == b"\xFF"

--- a/frmts/vrt/vrtsources.cpp
+++ b/frmts/vrt/vrtsources.cpp
@@ -1365,6 +1365,7 @@ CPLErr VRTSimpleSource::RasterIO(GDALDataType eVRTBandDataType, int nXOff,
     {
         psExtraArg->pfnProgress = psExtraArgIn->pfnProgress;
         psExtraArg->pProgressData = psExtraArgIn->pProgressData;
+        psExtraArg->bDoNotUseOverviews = psExtraArgIn->bDoNotUseOverviews;
     }
 
     GByte *pabyOut = static_cast<unsigned char *>(pData) +

--- a/frmts/vrt/vrtsources.cpp
+++ b/frmts/vrt/vrtsources.cpp
@@ -1365,7 +1365,7 @@ CPLErr VRTSimpleSource::RasterIO(GDALDataType eVRTBandDataType, int nXOff,
     {
         psExtraArg->pfnProgress = psExtraArgIn->pfnProgress;
         psExtraArg->pProgressData = psExtraArgIn->pProgressData;
-        psExtraArg->bDoNotUseOverviews = psExtraArgIn->bDoNotUseOverviews;
+        psExtraArg->bUseOnlyThisScale = psExtraArgIn->bUseOnlyThisScale;
     }
 
     GByte *pabyOut = static_cast<unsigned char *>(pData) +

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -213,7 +213,7 @@ typedef struct
         (s).pfnProgress = CPL_NULLPTR;                                         \
         (s).pProgressData = CPL_NULLPTR;                                       \
         (s).bFloatingPointWindowValidity = FALSE;                              \
-        (s).bUseOnlyThisScale = FALSE;                                            \
+        (s).bUseOnlyThisScale = FALSE;                                         \
     } while (0)
 
 /** Value indicating the start of the range for color interpretations belonging

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -191,8 +191,11 @@ typedef struct
     /*! Height in pixels of the area of interest. Only valid if
      * bFloatingPointWindowValidity = TRUE */
     double dfYSize;
-    /*! Do not use overviews even if it would be possible */
-    int bDoNotUseOverviews;
+    /*! Indicate if overviews should be considered. Tested in
+        GDALBandGetBestOverviewLevel(), mostly reserved for use by
+        GDALRegenerateOverviewsMultiBand()
+    */
+    int bUseOnlyThisScale;
 } GDALRasterIOExtraArg;
 
 #ifndef DOXYGEN_SKIP
@@ -210,7 +213,7 @@ typedef struct
         (s).pfnProgress = CPL_NULLPTR;                                         \
         (s).pProgressData = CPL_NULLPTR;                                       \
         (s).bFloatingPointWindowValidity = FALSE;                              \
-        (s).bDoNotUseOverviews = FALSE;                                        \
+        (s).bUseOnlyThisScale = FALSE;                                            \
     } while (0)
 
 /** Value indicating the start of the range for color interpretations belonging

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -191,6 +191,8 @@ typedef struct
     /*! Height in pixels of the area of interest. Only valid if
      * bFloatingPointWindowValidity = TRUE */
     double dfYSize;
+    /*! Do not use overviews even if it would be possible */
+    int bDoNotUseOverviews;
 } GDALRasterIOExtraArg;
 
 #ifndef DOXYGEN_SKIP
@@ -208,6 +210,7 @@ typedef struct
         (s).pfnProgress = CPL_NULLPTR;                                         \
         (s).pProgressData = CPL_NULLPTR;                                       \
         (s).bFloatingPointWindowValidity = FALSE;                              \
+        (s).bDoNotUseOverviews = FALSE;                                        \
     } while (0)
 
 /** Value indicating the start of the range for color interpretations belonging

--- a/gcore/overview.cpp
+++ b/gcore/overview.cpp
@@ -5545,7 +5545,7 @@ CPLErr GDALRegenerateOverviewsMultiBand(
                     }  // width
 
                     if (!pfnProgress(dfCurPixelCount / dfTotalPixelCount,
-                        nullptr, pProgressData))
+                                     nullptr, pProgressData))
                     {
                         CPLError(CE_Failure, CPLE_UserInterrupt,
                                  "User terminated");
@@ -5565,8 +5565,8 @@ CPLErr GDALRegenerateOverviewsMultiBand(
                 for (int iBand = 0; iBand < nBands; ++iBand)
                     apoDstBand[iBand]->FlushCache(false);
 
-                continue; // Next overview
-            } // chunking via temporary dataset
+                continue;  // Next overview
+            }              // chunking via temporary dataset
 
             // Too much memory needed and no chunking possible?
             const auto nDTSize = GDALGetDataTypeSizeBytes(eDataType);
@@ -5585,20 +5585,19 @@ CPLErr GDALRegenerateOverviewsMultiBand(
             const char *pszGDAL_OVR_TEMP_DRIVER =
                 CPLGetConfigOption("GDAL_OVR_TEMP_DRIVER", "");
             if ((!bTmpDSMemRequirementOverflow &&
-                    nTmpDSMemRequirement <= nChunkMaxSizeForTempFile &&
-                    !EQUAL(pszGDAL_OVR_TEMP_DRIVER, "GTIFF")) ||
+                 nTmpDSMemRequirement <= nChunkMaxSizeForTempFile &&
+                 !EQUAL(pszGDAL_OVR_TEMP_DRIVER, "GTIFF")) ||
                 EQUAL(pszGDAL_OVR_TEMP_DRIVER, "MEM"))
             {
-                auto poTmpDrv =
-                    GetGDALDriverManager()->GetDriverByName("MEM");
+                auto poTmpDrv = GetGDALDriverManager()->GetDriverByName("MEM");
                 if (!poTmpDrv)
                 {
                     eErr = CE_Failure;
                     break;
                 }
                 poTmpDS.reset(poTmpDrv->Create("", nDstTotalWidth,
-                                                nDstTotalHeight, nBands,
-                                                eDataType, nullptr));
+                                               nDstTotalHeight, nBands,
+                                               eDataType, nullptr));
             }
             else
             {
@@ -5632,12 +5631,10 @@ CPLErr GDALRegenerateOverviewsMultiBand(
                           (nReducedDstChunkYSize % GTIFF_BLOCK_SIZE_MULTIPLE)))
                 {
                     aosCO.SetNameValue("TILED", "YES");
-                    aosCO.SetNameValue(
-                        "BLOCKXSIZE",
-                        CPLSPrintf("%d", nReducedDstChunkXSize));
-                    aosCO.SetNameValue(
-                        "BLOCKYSIZE",
-                        CPLSPrintf("%d", nReducedDstChunkYSize));
+                    aosCO.SetNameValue("BLOCKXSIZE",
+                                       CPLSPrintf("%d", nReducedDstChunkXSize));
+                    aosCO.SetNameValue("BLOCKYSIZE",
+                                       CPLSPrintf("%d", nReducedDstChunkYSize));
                 }
                 if (const char *pszCOList = poTmpDrv->GetMetadataItem(
                         GDAL_DMD_CREATIONOPTIONLIST))
@@ -5729,8 +5726,8 @@ CPLErr GDALRegenerateOverviewsMultiBand(
                         auto poSrcBand = poVRTDS->GetRasterBand(iBand + 1);
                         eErr = poSrcBand->RasterIO(
                             GF_Read, nDstXOff, nDstYOff, nDstXCount, nDstYCount,
-                            pDstBuffer, nDstXCount, nDstYCount, eWrkDataType,
-                            0, 0, &sExtraArg);
+                            pDstBuffer, nDstXCount, nDstYCount, eWrkDataType, 0,
+                            0, &sExtraArg);
                         if (eErr != CE_None)
                             break;
                         // Write to the temporary dataset, shifted
@@ -5755,7 +5752,7 @@ CPLErr GDALRegenerateOverviewsMultiBand(
                     nDstYCount = nDstYOffEnd - nDstYOff;
 
                 for (int nDstXOff = nDstXOffStart; nDstXOff < nDstXOffEnd;
-                    nDstXOff += nDstChunkXSize)
+                     nDstXOff += nDstChunkXSize)
                 {
                     if (eErr != CE_None)
                         break;
@@ -5778,9 +5775,9 @@ CPLErr GDALRegenerateOverviewsMultiBand(
                         // Write to the destination overview bands
                         auto poOvrBand = papapoOverviewBands[iBand][iOverview];
                         eErr = poOvrBand->RasterIO(
-                            GF_Write, nDstXOff, nDstYOff, nDstXCount, nDstYCount,
-                            pDstBuffer, nDstXCount, nDstYCount, eWrkDataType, 0,
-                            0, nullptr);
+                            GF_Write, nDstXOff, nDstYOff, nDstXCount,
+                            nDstYCount, pDstBuffer, nDstXCount, nDstYCount,
+                            eWrkDataType, 0, 0, nullptr);
                     }
                 }
             }

--- a/gcore/overview.cpp
+++ b/gcore/overview.cpp
@@ -5545,8 +5545,7 @@ CPLErr GDALRegenerateOverviewsMultiBand(
                             eErr = apoVRTBand[iBand]->RasterIO(
                                 GF_Read, nDstXOff, nDstYOff, nDstXCount,
                                 nDstYCount, abyChunk.data(), nDstXCount,
-                                nDstYCount, eDataType, 0, 0,
-                                &sExtraArg);
+                                nDstYCount, eDataType, 0, 0, &sExtraArg);
                             if (eErr != CE_None)
                                 break;
                             eErr = apoDstBand[iBand]->RasterIO(

--- a/gcore/overview.cpp
+++ b/gcore/overview.cpp
@@ -5502,7 +5502,7 @@ CPLErr GDALRegenerateOverviewsMultiBand(
                 GDALRasterIOExtraArg sExtraArg;
                 INIT_RASTERIO_EXTRA_ARG(sExtraArg);
                 if (iSrcOverview == -1)
-                    sExtraArg.bDoNotUseOverviews = true;
+                    sExtraArg.bUseOnlyThisScale = true;
 
                 // A single band buffer for data transfer to the overview
                 std::vector<GByte> abyChunk(GUInt64(nMaxDataTypeSize) *
@@ -5697,7 +5697,7 @@ CPLErr GDALRegenerateOverviewsMultiBand(
             GDALRasterIOExtraArg sExtraArg;
             INIT_RASTERIO_EXTRA_ARG(sExtraArg);
             if (iSrcOverview == -1)
-                sExtraArg.bDoNotUseOverviews = true;
+                sExtraArg.bUseOnlyThisScale = true;
 
             // Scale and copy data from the VRT to the temp file
             for (int nDstYOff = nDstYOffStart; nDstYOff < nDstYOffEnd;

--- a/gcore/overview.cpp
+++ b/gcore/overview.cpp
@@ -5348,13 +5348,13 @@ CPLErr GDALRegenerateOverviewsMultiBand(
                      nDstTotalHeight);
         const int nDstHeight = nDstYOffEnd - nDstYOffStart;
 
-        CPLDebug("GDAL",
-                 "Generating overview %d/%d (%dx%d -> %dx%d) from %dx%d",
-                 iOverview + 1, nOverviews, nDstWidth, nDstHeight,
-                 nToplevelSrcWidth, nToplevelSrcHeight, nSrcXSize, nSrcYSize);
-        // Also print the bounds of the source region to read
-        CPLDebug("GDAL", "Source region to read: %d,%d,%d,%d", nSrcXOff,
-                 nSrcYOff, nSrcXOff + nSrcXSize, nSrcYOff + nSrcYSize);
+        //CPLDebug("GDAL",
+        //         "Generating overview %d/%d (%dx%d -> %dx%d) from %dx%d",
+        //         iOverview + 1, nOverviews, nDstWidth, nDstHeight,
+        //         nToplevelSrcWidth, nToplevelSrcHeight, nSrcXSize, nSrcYSize);
+        //// Also print the bounds of the source region to read
+        //CPLDebug("GDAL", "Source region to read: %d,%d,%d,%d", nSrcXOff,
+        //         nSrcYOff, nSrcXOff + nSrcXSize, nSrcYOff + nSrcYSize);
 
         // Try to use previous level of overview as the source to compute
         // the next level.

--- a/gcore/overview.cpp
+++ b/gcore/overview.cpp
@@ -5469,12 +5469,11 @@ CPLErr GDALRegenerateOverviewsMultiBand(
                     : static_cast<GIntBig>(nDstWidth) * nDstHeight * nBands *
                           nDTSize;
 
-            // One band buffer might overflow size_t
+            // make sure that one band buffer doesn't overflow size_t
             const bool bChunkSizeOverflow =
                 nDstHeight > INT_MAX / nDTSize ||
-                nDstWidth >
+                size_t(nDstWidth) >
                     std::numeric_limits<size_t>::max() / (nDstHeight * nDTSize);
-
             const size_t nChunkSize =
                 bChunkSizeOverflow
                     ? 0

--- a/gcore/overview.cpp
+++ b/gcore/overview.cpp
@@ -5636,12 +5636,11 @@ CPLErr GDALRegenerateOverviewsMultiBand(
                     aosCO.SetNameValue("BLOCKYSIZE",
                                        CPLSPrintf("%d", nReducedDstChunkYSize));
                 }
-                if (const char *pszCOList = poTmpDrv->GetMetadataItem(
-                        GDAL_DMD_CREATIONOPTIONLIST))
+                if (const char *pszCOList =
+                        poTmpDrv->GetMetadataItem(GDAL_DMD_CREATIONOPTIONLIST))
                 {
-                    aosCO.SetNameValue("COMPRESS", strstr(pszCOList, "ZSTD")
-                                                        ? "ZSTD"
-                                                        : "LZW");
+                    aosCO.SetNameValue(
+                        "COMPRESS", strstr(pszCOList, "ZSTD") ? "ZSTD" : "LZW");
                 }
                 poTmpDS.reset(poTmpDrv->Create(osTmpFilename.c_str(), nDstWidth,
                                                nDstHeight, nBands, eDataType,

--- a/gcore/overview.cpp
+++ b/gcore/overview.cpp
@@ -5460,7 +5460,8 @@ CPLErr GDALRegenerateOverviewsMultiBand(
         {
             // If the overview accomodates chunking, do so and recurse
             // to avoid generating full size temporary files
-            if (nDstChunkXSize < nDstWidth || nDstChunkYSize < nDstHeight)
+            if (!bOverflowFullResXChunkYChunkQueried &&
+                (nDstChunkXSize < nDstWidth || nDstChunkYSize < nDstHeight))
             {
                 // Create a VRT with the smaller chunk to do the scaling
                 auto poVRTDS = std::unique_ptr<VRTDataset>(new VRTDataset(

--- a/gcore/rasterio.cpp
+++ b/gcore/rasterio.cpp
@@ -367,7 +367,7 @@ CPLErr GDALRasterBand::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
     /*      this request?                                                   */
     /* ==================================================================== */
     if ((nBufXSize < nXSize || nBufYSize < nYSize) && GetOverviewCount() > 0 &&
-        eRWFlag == GF_Read && !psExtraArg->bDoNotUseOverviews)
+        eRWFlag == GF_Read)
     {
         GDALRasterIOExtraArg sExtraArg;
         GDALCopyRasterIOExtraArg(&sExtraArg, psExtraArg);
@@ -3666,6 +3666,8 @@ int GDALBandGetBestOverviewLevel2(GDALRasterBand *poBand, int &nXOff,
                                   int nBufXSize, int nBufYSize,
                                   GDALRasterIOExtraArg *psExtraArg)
 {
+    if (psExtraArg != nullptr && psExtraArg->bDoNotUseOverviews)
+        return -1;
     /* -------------------------------------------------------------------- */
     /*      Compute the desired downsampling factor.  It is                 */
     /*      based on the least reduced axis, and represents the number      */
@@ -5140,6 +5142,7 @@ void GDALCopyRasterIOExtraArg(GDALRasterIOExtraArg *psDestArg,
         psDestArg->eResampleAlg = psSrcArg->eResampleAlg;
         psDestArg->pfnProgress = psSrcArg->pfnProgress;
         psDestArg->pProgressData = psSrcArg->pProgressData;
+        psDestArg->bDoNotUseOverviews = psSrcArg->bDoNotUseOverviews;
         psDestArg->bFloatingPointWindowValidity =
             psSrcArg->bFloatingPointWindowValidity;
         if (psSrcArg->bFloatingPointWindowValidity)

--- a/gcore/rasterio.cpp
+++ b/gcore/rasterio.cpp
@@ -367,7 +367,7 @@ CPLErr GDALRasterBand::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
     /*      this request?                                                   */
     /* ==================================================================== */
     if ((nBufXSize < nXSize || nBufYSize < nYSize) && GetOverviewCount() > 0 &&
-        eRWFlag == GF_Read)
+        eRWFlag == GF_Read && !psExtraArg->bDoNotUseOverviews)
     {
         GDALRasterIOExtraArg sExtraArg;
         GDALCopyRasterIOExtraArg(&sExtraArg, psExtraArg);

--- a/gcore/rasterio.cpp
+++ b/gcore/rasterio.cpp
@@ -3666,7 +3666,7 @@ int GDALBandGetBestOverviewLevel2(GDALRasterBand *poBand, int &nXOff,
                                   int nBufXSize, int nBufYSize,
                                   GDALRasterIOExtraArg *psExtraArg)
 {
-    if (psExtraArg != nullptr && psExtraArg->bDoNotUseOverviews)
+    if (psExtraArg != nullptr && psExtraArg->bUseOnlyThisScale)
         return -1;
     /* -------------------------------------------------------------------- */
     /*      Compute the desired downsampling factor.  It is                 */
@@ -5142,7 +5142,7 @@ void GDALCopyRasterIOExtraArg(GDALRasterIOExtraArg *psDestArg,
         psDestArg->eResampleAlg = psSrcArg->eResampleAlg;
         psDestArg->pfnProgress = psSrcArg->pfnProgress;
         psDestArg->pProgressData = psSrcArg->pProgressData;
-        psDestArg->bDoNotUseOverviews = psSrcArg->bDoNotUseOverviews;
+        psDestArg->bUseOnlyThisScale = psSrcArg->bUseOnlyThisScale;
         psDestArg->bFloatingPointWindowValidity =
             psSrcArg->bFloatingPointWindowValidity;
         if (psSrcArg->bFloatingPointWindowValidity)


### PR DESCRIPTION
## What does this PR do?
In GDALRegenerateOverviewsMultiBand() (ROMB), when too much memory would be needed for generating an overview block, the overviews are generated in a temporary file and then copied to the actual overview dataset. The size of this temporary file is not limited, and it has extra problems with pixel interleaved output, since the bands are copied one at a time for the full overview.
This issue was reported in issue #12303 and was partially addressed in #12307, which raised the allowable memory limit which triggers the problem code path, but did not limit the size of the temporary file or the pixel interleaved problems.

This PR addresses the remaining problems by chunking the output overview when possible, and using the temporary file path for a single chunk at a time.

## What are related issues/pull requests?
#12303, #12307

## Test case
To trigger the code path in question, set GDAL_OVER_CHUNK_MAX_SIZE_FOR_TEMP_FILE to 10485760 and build power of 2 overviews for a 11000 by 11000 8bit, pixel interleaved RGB MRF with a blocksize of 1024

```
gdal_translate -outsize 11000 11000  -co BLOCKSIZE=1024 any_small_rgb.jpg test_file.mrf
gdaladdo -r average test_file.mrf
```

## Changes

The "chunking" code triggers when a temporary file would be used, but an output chunk (tile) smaller than the whole overview does exist. The chunk would still exceed the memory usage limit. It then calls ROMB() for every chunk, with extra parameters that limit the processing extent.
On the next pass through ROMB, the external file will be created, this time limited to the chunk extent. This part was also modified, using a VRT to effect the scaling, with the correct resampling, before writing the chunk data in the external file.
Finally, the chunk data is transferred from the temporary output to the destination overview.

In addtion, an extra flag had to be added to the RasterIO ExtraArguments structure, to indicate that the source overviews should not be used for the respective operation, to avoid having the input data read from the same overview that is being generated.

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
