### PR TITLE
[cleanup] PDF driver: use Page::getPageObj() getter for Poppler >= 25.03.00

### DIFF
--- a/frmts/pdf/pdfdataset.cpp
+++ b/frmts/pdf/pdfdataset.cpp
@@ -4791,9 +4791,14 @@ PDFDataset *PDFDataset::Open(GDALOpenInfo *poOpenInfo)
             return nullptr;
         }
 
+#if POPPLER_MAJOR_VERSION > 25 ||                                              \
+    (POPPLER_MAJOR_VERSION == 25 && POPPLER_MINOR_VERSION >= 3)
+        const Object &oPageObj = poPagePoppler->getPageObj();
+#else
         /* Here's the dirty part: this is a private member */
         /* so we had to #define private public to get it ! */
-        Object &oPageObj = poPagePoppler->pageObj;
+        const Object &oPageObj = poPagePoppler->pageObj;
+#endif
         if (!oPageObj.isDict())
         {
             CPLError(CE_Failure, CPLE_AppDefined,
@@ -4802,7 +4807,7 @@ PDFDataset *PDFDataset::Open(GDALOpenInfo *poOpenInfo)
             return nullptr;
         }
 
-        poPageObj = new GDALPDFObjectPoppler(&oPageObj, FALSE);
+        poPageObj = new GDALPDFObjectPoppler(&oPageObj);
         Ref *poPageRef = poCatalogPoppler->getPageRef(iPage);
         if (poPageRef != nullptr)
         {

--- a/frmts/pdf/pdfobject.cpp
+++ b/frmts/pdf/pdfobject.cpp
@@ -1032,8 +1032,7 @@ class GDALPDFStreamPoppler : public GDALPDFStream
 
 GDALPDFObjectPoppler::~GDALPDFObjectPoppler()
 {
-    if (m_bDestroy)
-        delete m_po;
+    delete m_poToDestroy;
     delete m_poDict;
     delete m_poArray;
     delete m_poStream;
@@ -1045,7 +1044,7 @@ GDALPDFObjectPoppler::~GDALPDFObjectPoppler()
 
 GDALPDFObjectType GDALPDFObjectPoppler::GetType()
 {
-    switch (m_po->getType())
+    switch (m_poConst->getType())
     {
         case objNull:
             return PDFObjectType_Null;
@@ -1076,7 +1075,7 @@ GDALPDFObjectType GDALPDFObjectPoppler::GetType()
 
 const char *GDALPDFObjectPoppler::GetTypeNameNative()
 {
-    return m_po->getTypeName();
+    return m_poConst->getTypeName();
 }
 
 /************************************************************************/
@@ -1086,7 +1085,7 @@ const char *GDALPDFObjectPoppler::GetTypeNameNative()
 int GDALPDFObjectPoppler::GetBool()
 {
     if (GetType() == PDFObjectType_Bool)
-        return m_po->getBool();
+        return m_poConst->getBool();
     else
         return 0;
 }
@@ -1098,7 +1097,7 @@ int GDALPDFObjectPoppler::GetBool()
 int GDALPDFObjectPoppler::GetInt()
 {
     if (GetType() == PDFObjectType_Int)
-        return m_po->getInt();
+        return m_poConst->getInt();
     else
         return 0;
 }
@@ -1110,7 +1109,7 @@ int GDALPDFObjectPoppler::GetInt()
 double GDALPDFObjectPoppler::GetReal()
 {
     if (GetType() == PDFObjectType_Real)
-        return m_po->getReal();
+        return m_poConst->getReal();
     else
         return 0.0;
 }
@@ -1123,7 +1122,7 @@ const std::string &GDALPDFObjectPoppler::GetString()
 {
     if (GetType() == PDFObjectType_String)
     {
-        const GooString *gooString = m_po->getString();
+        const GooString *gooString = m_poConst->getString();
         const std::string &osStdStr = gooString->toStr();
         const bool bLEUnicodeMarker =
             osStdStr.size() >= 2 && static_cast<uint8_t>(osStdStr[0]) == 0xFE &&
@@ -1161,7 +1160,7 @@ const std::string &GDALPDFObjectPoppler::GetString()
 const std::string &GDALPDFObjectPoppler::GetName()
 {
     if (GetType() == PDFObjectType_Name)
-        return (osStr = m_po->getName());
+        return (osStr = m_poConst->getName());
     else
         return (osStr = "");
 }
@@ -1178,8 +1177,9 @@ GDALPDFDictionary *GDALPDFObjectPoppler::GetDictionary()
     if (m_poDict)
         return m_poDict;
 
-    Dict *poDict = (m_po->getType() == objStream) ? m_po->getStream()->getDict()
-                                                  : m_po->getDict();
+    Dict *poDict = (m_poConst->getType() == objStream)
+                       ? m_poConst->getStream()->getDict()
+                       : m_poConst->getDict();
     if (poDict == nullptr)
         return nullptr;
     m_poDict = new GDALPDFDictionaryPoppler(poDict);
@@ -1198,7 +1198,7 @@ GDALPDFArray *GDALPDFObjectPoppler::GetArray()
     if (m_poArray)
         return m_poArray;
 
-    Array *poArray = m_po->getArray();
+    Array *poArray = m_poConst->getArray();
     if (poArray == nullptr)
         return nullptr;
     m_poArray = new GDALPDFArrayPoppler(poArray);
@@ -1211,12 +1211,12 @@ GDALPDFArray *GDALPDFObjectPoppler::GetArray()
 
 GDALPDFStream *GDALPDFObjectPoppler::GetStream()
 {
-    if (m_po->getType() != objStream)
+    if (m_poConst->getType() != objStream)
         return nullptr;
 
     if (m_poStream)
         return m_poStream;
-    m_poStream = new GDALPDFStreamPoppler(m_po->getStream());
+    m_poStream = new GDALPDFStreamPoppler(m_poConst->getStream());
     return m_poStream;
 }
 

--- a/frmts/pdf/pdfobject.h
+++ b/frmts/pdf/pdfobject.h
@@ -367,8 +367,8 @@ class GDALPDFArrayRW : public GDALPDFArray
 class GDALPDFObjectPoppler : public GDALPDFObject
 {
   private:
-    Object *m_po;
-    const bool m_bDestroy;
+    Object *m_poToDestroy;
+    const Object *m_poConst;
     GDALPDFDictionary *m_poDict = nullptr;
     GDALPDFArray *m_poArray = nullptr;
     GDALPDFStream *m_poStream = nullptr;
@@ -383,7 +383,12 @@ class GDALPDFObjectPoppler : public GDALPDFObject
 
   public:
     GDALPDFObjectPoppler(Object *po, bool bDestroy)
-        : m_po(po), m_bDestroy(bDestroy)
+        : m_poToDestroy(bDestroy ? po : nullptr), m_poConst(po)
+    {
+    }
+
+    GDALPDFObjectPoppler(const Object *po)
+        : m_poToDestroy(nullptr), m_poConst(po)
     {
     }
 

--- a/frmts/pdf/pdfsdk_headers_poppler.h
+++ b/frmts/pdf/pdfsdk_headers_poppler.h
@@ -45,9 +45,14 @@
 #include <Object.h>
 #include <Stream.h>
 
+#if POPPLER_MAJOR_VERSION > 25 ||                                              \
+    (POPPLER_MAJOR_VERSION == 25 && POPPLER_MINOR_VERSION >= 3)
+#include <Page.h>
+#else
 #define private public /* Ugly! Page::pageObj is private but we need it... */
 #include <Page.h>
 #undef private
+#endif
 
 #include <Dict.h>
 


### PR DESCRIPTION
Fixes #11806