### PR TITLE
Doc: Formatting fixes for pixel function table

### DIFF
--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1215,6 +1215,7 @@ GDAL provides a set of default pixel functions that can be used without writing 
    * - **expression**
      - 1
      - ``expression``
+       
        ``dialect`` (optional)
      - Evaluate a specified expression using `muparser <https://beltoforion.de/en/muparser/>`__ (default)
        or `ExprTk <https://www.partow.net/programming/exprtk/index.html>`__.

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1175,15 +1175,21 @@ GDAL provides a set of default pixel functions that can be used without writing 
      - 2
      - -
      - Computes the difference between 2 raster bands (``b1 - b2``).
+
        Starting with GDAL 3.12, if either ``b1`` or ``b2`` is equal to the
+
        derived band's NoData value (set with ``<NoDataValue>``), the result
+
        will be the NoData value.
    * - **div**
      - 2
      - -
      - Divide one raster band by another (``b1 / b2``).
+
        Starting with GDAL 3.12, if either ``b1`` or ``b2`` is equal to the
+
        derived band's NoData value (set with ``<NoDataValue>``), the result
+
        will be the NoData value.
    * - **exp**
      - 1
@@ -1203,16 +1209,19 @@ GDAL provides a set of default pixel functions that can be used without writing 
        ``base = 10.`` and ``fact = 0.05`` i.e. ``1. / 20``
 
        Starting with GDAL 3.12, if ``x`` is equal to the derived band's NoData value
+
        (set with ``<NoDataValue>``), the result will be the NoData value.
 
    * - **expression**
      - 1
      - ``expression``
+       ``dialect`` (optional)
      - Evaluate a specified expression using `muparser <https://beltoforion.de/en/muparser/>`__ (default)
        or `ExprTk <https://www.partow.net/programming/exprtk/index.html>`__.
 
        The expression is specified using the "expression" argument.
        The dialect may be specified using the "dialect" argument.
+
        Within the expression, band values can be accessed:
 
        - through the variables ``B1``, ``B2``, etc.
@@ -1221,6 +1230,7 @@ GDAL provides a set of default pixel functions that can be used without writing 
 
        - or through the ``BANDS`` vector.
          With ExprTk, ``BANDS`` is exposed as a standard (0-indexed) vector.
+
          With muparser, it is expanded into a list of all input bands.
 
        ExprTk and muparser support a number of built-in functions and control structures.
@@ -1238,45 +1248,65 @@ GDAL provides a set of default pixel functions that can be used without writing 
      - >= 2
      - ``t0``, ``dt``, ``t``
      - Interpolate a value at time (or position) ``t`` given input sources
+
        beginning at position ``t0`` with spacing ``dt`` using exponential interpolation.
+
        Starting with GDAL 3.12, if either input source bounding ``t`` is equal to the NoData
+
        value of the derived band (set with ``<NoDataValue>``), the result will be the 
+
        NoData value.
    * - **interpolate_linear**
      - >= 2
      - ``t0``, ``dt``, ``t``
      - Interpolate a value at time (or position) ``t`` given input sources
+
        beginning at ``t0`` with spacing ``dt`` using linear interpolation.
+
        Starting with GDAL 3.12, if either input source bounding ``t`` is equal to the NoData
+
        value of the derived band (set with ``<NoDataValue>``), the result will be the 
+
        NoData value.
    * - **inv**
      - 1
      - ``k`` (optional)
      - Inverse (``1./x``). If the optional ``k`` parameter is set,
+
        then the result is multiplied by ``k`` (``k / x``).
+
        Starting with GDAL 3.12, if ``x`` is equal to the derived band's NoData value
+
        (set with ``<NoDataValue>``), the result will be the NoData value.
    * - **log10**
      - 1
      - -
      - Compute the logarithm (base 10) of the abs of a single raster band
+
        (real or complex): ``log10( abs( x ) )``
+
        Starting with GDAL 3.12, if ``x`` is equal to the derived band's NoData value
+
        (set with ``<NoDataValue>``), the result will be the NoData value.
    * - **max**
      - >= 2
-     - ``propagateNoData`` (optional, default=``false``)
+     - ``propagateNoData`` (optional, default=false)
      - (GDAL >= 3.8) Maximum of 2 or more raster bands.
+
        If the optional ``propagateNoData`` parameter is set to ``true``, then
+
        if a NoData pixel is found in one of the bands, if will be propagated to
+
        the output value. Otherwise, NoData pixels will be ignored.
    * - **min**
      - >= 2
-     - ``propagateNoData`` (optional, default=``false``)
+     - ``propagateNoData`` (optional, default=false)
      - (GDAL >= 3.8) Minimum of 2 or more raster bands.
+
        If the optional ``propagateNoData`` parameter is set to ``true``, then
+
        if a NoData pixel is found in one of the bands, if will be propagated to
+
        the output value. Otherwise, NoData pixels will be ignored.
    * - **mod**
      - 1
@@ -1286,20 +1316,29 @@ GDAL provides a set of default pixel functions that can be used without writing 
      - >= 1
      - ``k`` (optional)
 
-       ``propagatenodata`` (optional)
+       ``propagateNoData`` (optional, default=false)
      - Multiply 1 or more raster bands.
+
        If the optional ``k`` parameter is provided then the result is
-       multiplied by the scalar ``k``.  Starting with GDAL 3.12, if
-       ``propagateNoData`` is true, any input pixel equal to the derived band's
-       NoData value (set with ``<NoDataValue>``) will cause the result to be
-       the NoData value. If ``propagateNoData`` is false, input NoData values
-       will be ignored.
+
+       multiplied by the scalar ``k``.
+       
+       Starting with GDAL 3.12, if ``propagateNoData`` is true, any input pixel
+
+       equal to the derived band's NoData value (set with ``<NoDataValue>``)
+
+       will cause the result to be the NoData value. If ``propagateNoData`` is
+
+       false, input NoData values will be ignored.
    * - **norm_diff**
      - 2
      - -
      - Computes the normalized difference between two raster bands: ``(b1 - b2)/(b1 + b2)``
+
        Starting with GDAL 3.12, if either ``b1`` or ``b2`` is equal to the
+
        derived band's NoData value (set with ``<NoDataValue>``), the result
+
        will be the NoData value.
    * - **phase**
      - 1
@@ -1323,7 +1362,9 @@ GDAL provides a set of default pixel functions that can be used without writing 
      - 1
      - ``power``
      - Raise a single raster band to a constant power, specified with argument ``power`` (real only)
+
        Starting with GDAL 3.12, if the input is equal to the derived band's NoData value
+
        (set with ``<NoDataValue>``), the result will be the NoData value.
    * - **real**
      - 1
@@ -1362,13 +1403,17 @@ GDAL provides a set of default pixel functions that can be used without writing 
      - = 1
      - -
      - Perform scaling according to the ``offset`` and ``scale`` values of the raster band
+
        Starting with GDAL 3.12, if the input is equal to the derived band's NoData value
+
        (set with ``<NoDataValue>``), the result will be the NoData value.
    * - **sqrt**
      - 1
      - -
      - Perform the square root of a single raster band (real only).
+
        Starting with GDAL 3.12, if the input is equal to the derived band's NoData value
+
        (set with ``<NoDataValue>``), the result will be the NoData value.
    * - **sum**
      - >= 1
@@ -1376,10 +1421,15 @@ GDAL provides a set of default pixel functions that can be used without writing 
 
        ``propagateNoData`` (optional, default=``false``)
      - Sum 1 or more raster bands. If the optional ``k`` parameter is provided
+
        then it is added to each element of the result.
+
        Starting with GDAL 3.12, if ``propagateNoData`` is true, any input pixel
+
        equal to the derived band's NoData value (set with ``<NoDataValue>``)
+
        will cause the result to be the NoData value. If ``propagateNoData`` is
+
        false, input NoData values will be ignored.
 
 .. example::


### PR DESCRIPTION
Manually wrap text to avoid horizontal scrolling.
Remove backticks that are not interpreted by the parser.
