### PR TITLE
Fix #7830 utf8 handling in some csharp field defn bindings

### DIFF
--- a/swig/include/ogr.i
+++ b/swig/include/ogr.i
@@ -2855,9 +2855,15 @@ public:
   %clear (const char* name_null_ok );
 #endif
 
+#ifdef SWIGCSHARP
+  %apply ( const char *utf8_path ) { const char * GetName };
+#endif
   const char * GetName() {
     return OGR_Fld_GetNameRef(self);
   }
+#ifdef SWIGCSHARP
+  %clear (const char * GetName );
+#endif
 
 #ifdef SWIGJAVA
   StringAsByteArray* GetNameAsByteArray() {

--- a/swig/include/ogr.i
+++ b/swig/include/ogr.i
@@ -2869,9 +2869,17 @@ public:
     return OGR_Fld_GetNameRef(self);
   }
 
+#ifdef SWIGCSHARP
+  %apply ( const char *utf8_path ) { (const char* name) };
+#endif
+
   void SetName( const char* name) {
     OGR_Fld_SetName(self, name);
   }
+
+#ifdef SWIGCSHARP
+  %clear (const char* name );
+#endif
 
   const char * GetAlternativeName() {
     return OGR_Fld_GetAlternativeNameRef(self);

--- a/swig/include/ogr.i
+++ b/swig/include/ogr.i
@@ -2841,6 +2841,9 @@ public:
 #ifndef SWIGJAVA
   %feature("kwargs") OGRFieldDefnShadow;
 #endif
+#ifdef SWIGCSHARP
+  %apply ( const char *utf8_path ) { (const char* name_null_ok) };
+#endif
   OGRFieldDefnShadow( const char* name_null_ok="unnamed",
                       OGRFieldType field_type=OFTString) {
     if (ValidateOGRFieldType(field_type))
@@ -2848,6 +2851,9 @@ public:
     else
         return NULL;
   }
+#ifdef SWIGCSHARP
+  %clear (const char* name_null_ok );
+#endif
 
   const char * GetName() {
     return OGR_Fld_GetNameRef(self);


### PR DESCRIPTION
## What does this PR do?

adds missing UTF8 conversion from C# string to UTF8 character bytes in :
 - OGR FieldDefn Create
 - OGR FieldDefn SetName
 - OGR FieldDefn GetName

## What are related issues/pull requests?

#7830 

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [X] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

* OS: Windows 10
* Compiler: