### PR TITLE
Enhance temporary file management when warping to COG on /vsis3/

### DIFF
--- a/port/cpl_vsil_s3.cpp
+++ b/port/cpl_vsil_s3.cpp
@@ -1795,7 +1795,8 @@ VSIVirtualHandle *VSICurlFilesystemHandlerBaseWritable::Open(
             return nullptr;
         }
 
-        const std::string osTmpFilename(CPLGenerateTempFilenameSafe(nullptr));
+        const std::string osTmpFilename(
+            CPLGenerateTempFilenameSafe(CPLGetFilename(pszFilename)));
         if (strchr(pszAccess, 'r'))
         {
             auto poExistingFile =
@@ -1815,9 +1816,9 @@ VSIVirtualHandle *VSICurlFilesystemHandlerBaseWritable::Open(
 
         auto fpTemp = VSIVirtualHandleUniquePtr(
             VSIFOpenL(osTmpFilename.c_str(), pszAccess));
+        VSIUnlink(osTmpFilename.c_str());
         if (!fpTemp)
         {
-            VSIUnlink(osTmpFilename.c_str());
             return nullptr;
         }
 


### PR DESCRIPTION
- gdalwarp to format without Create() support: create temporary file with CPLGenerateTempFilenameSafe() instead in final directory (which might be /vsis3/)
- /vsis3/ with CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE=YES: unlink temporary file immediately after creation (on Unix)

Fixes https://lists.osgeo.org/pipermail/gdal-dev/2025-May/060584.html