### PR TITLE
Docs: Revert dynamic exclude_patterns

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1177,10 +1177,6 @@ def builder_inited(app):
     if app.builder.name == "html":
         check_python_bindings()
 
-    # exclude the PDF toctree from HTML builds
-    if app.builder.name != "latex":
-        app.config.exclude_patterns.append("index_pdf.rst")
-
 
 def setup(app):
     app.connect("builder-inited", builder_inited)


### PR DESCRIPTION
This PR rolls back the change added in https://github.com/OSGeo/gdal/pull/12315 as this broke incremental builds. 

I closed #12419 which attempted to exclude one of the indexes based on the build type. It was beoming overly complex with little benefit. 

The messages `index.rst: document is referenced in multiple toctrees: ['index', 'index_pdf'], selecting: index_pdf <- api/index` are `INFO` so not warnings. If they had been warnings, they could be silenced in `conf.py` using:

```
suppress_warnings = [
    "toc.multiple_toc_parents",  # Suppresses "document is referenced in multiple toctrees"
]
```

cc @dbaston 