### PR TITLE
gdal raster edit: add a --gcp option

### DIFF
--- a/apps/gdalalg_raster_edit.h
+++ b/apps/gdalalg_raster_edit.h
@@ -15,6 +15,11 @@
 
 #include "gdalalg_raster_pipeline.h"
 
+namespace gdal
+{
+class GCP;
+}
+
 //! @cond Doxygen_Suppress
 
 /************************************************************************/
@@ -30,10 +35,11 @@ class GDALRasterEditAlgorithm /* non final */
     static constexpr const char *HELP_URL = "/programs/gdal_raster_edit.html";
 
     explicit GDALRasterEditAlgorithm(bool standaloneStep = false);
+    ~GDALRasterEditAlgorithm() override;
 
   private:
-    bool RunImpl(GDALProgressFunc pfnProgress, void *pProgressData) override;
     bool RunStep(GDALRasterPipelineStepRunContext &ctxt) override;
+    std::vector<gdal::GCP> ParseGCPs() const;
 
     GDALArgDatasetValue m_dataset{};  // standalone mode only
     bool m_readOnly = false;          // standalone mode only
@@ -42,6 +48,7 @@ class GDALRasterEditAlgorithm /* non final */
     std::vector<std::string> m_metadata{};
     std::vector<std::string> m_unsetMetadata{};
     std::string m_nodata{};
+    std::vector<std::string> m_gcps{};
     bool m_stats = false;        // standalone mode only
     bool m_approxStats = false;  // standalone mode only
     bool m_hist = false;         // standalone mode only

--- a/doc/source/programs/gdal_raster_edit.rst
+++ b/doc/source/programs/gdal_raster_edit.rst
@@ -71,15 +71,32 @@ This subcommand is also available as a potential step of :ref:`gdal_raster_pipel
 
     Compute raster band statistics for all bands.
 
+.. option:: --gcp <GCP>
+
+    .. versionadded:: 3.12
+
+    Set ground control point(s), replacing any existing GCPs. Each GCP must be formatted as a string
+    "pixel,line,easting,northing" or "pixel,line,easting,northing,elevation".
+    Each GCP must be specified with a ``--gcp`` argument.
+
+    It is also possible to provide a single ``--gcp`` argument whose value is
+    the filename of a vector dataset, prefixed with `@`. This dataset must have
+    a single layer with the following required fields ``column``, ``line``, ``x``, ``y``,
+    and optionally ``id``, ``info`` and ``z``.
+
 .. option:: --approx-stats
 
     Compute raster band statistics for all bands. They may be computed
     based on overviews or a subset of all tiles. Useful if you are in a
     hurry and don't need precise stats.
 
+    .. note:: This option is not available when the command is part of a pipeline.
+
 .. option:: --hist
 
     Compute histogram information for all bands.
+
+    .. note:: This option is not available when the command is part of a pipeline.
 
 
 Examples
@@ -112,3 +129,17 @@ Examples
    .. code-block:: bash
 
         $ gdal raster edit --unset-metadata AUTHOR my.tif
+
+.. example::
+   :title: Add 2 ground control point (GCP) for (column=0,line=0,X=2,Y=49) and (column=50,line=100,X=3,Y=48)
+
+   .. code-block:: bash
+
+        $ gdal raster edit --gcp 0,0,2,49 --gcp 50,100,3,48 my.tif
+
+.. example::
+   :title: Add ground control point (GCP) from :file:`gcps.csv`, that must have fields named ``column``, ``line``, ``x`` and  ``y``.
+
+   .. code-block:: bash
+
+        $ gdal raster edit --gcp @gcps.csv my.tif

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -4732,7 +4732,7 @@ def BuildVRTOptions(options=None,
             else:
                 for opt in pixelFunctionArgs:
                     new_options += ['-pixel-function-arg', opt]
-       
+
 
     if return_option_list:
         return new_options
@@ -6010,7 +6010,14 @@ class VSIFile(BytesIO):
 
         if arg_type == GAAT_STRING_LIST:
             if isinstance(value, list):
-                return self.SetAsStringList([str(v) for v in value])
+                if self.GetName() == "gcp" and len(value) >= 1 and \
+                   isinstance(value[0], list) and len(value[0]) >= 4 and \
+                   (isinstance(value[0][0], int) or isinstance(value[0][0], float)):
+                    return self.SetAsStringList([','.join(["%.17g" % x for x in v]) for v in value])
+                elif self.GetName() == "gcp" and len(value) >= 1 and isinstance(value[0], GCP):
+                    return self.SetAsStringList(["%.17g,%.17g,%.17g,%.17g,%.17g" % (gcp.GCPPixel, gcp.GCPLine, gcp.GCPX, gcp.GCPY, gcp.GCPZ) for gcp in value])
+                else:
+                    return self.SetAsStringList([str(v) for v in value])
             elif isinstance(value, dict):
                 return self.SetAsStringList([f"{k}={str(value[k])}" for k in value])
             else:


### PR DESCRIPTION
Accepting both GCPs set by value, or pointing to a vector dataset
