### PR TITLE
gdaldem/gdal raster hillshade/slope/aspect/roughness/tpi/tri streaming: expose overviews if source has overviews

### DIFF
--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -1566,12 +1566,9 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
             psOptions->srcWin.dfXOff * adfDstGeoTransform[4] +
             psOptions->srcWin.dfYOff * adfDstGeoTransform[5];
 
-        const double dfX = static_cast<double>(nOXSize);
-        const double dfY = static_cast<double>(nOYSize);
-        adfDstGeoTransform[1] *= psOptions->srcWin.dfXSize / dfX;
-        adfDstGeoTransform[2] *= psOptions->srcWin.dfYSize / dfY;
-        adfDstGeoTransform[4] *= psOptions->srcWin.dfXSize / dfX;
-        adfDstGeoTransform[5] *= psOptions->srcWin.dfYSize / dfY;
+        const double dfXRatio = psOptions->srcWin.dfXSize / nOXSize;
+        const double dfYRatio = psOptions->srcWin.dfYSize / nOYSize;
+        GDALRescaleGeoTransform(adfDstGeoTransform, dfXRatio, dfYRatio);
 
         if (psOptions->dfXRes != 0.0)
         {

--- a/autotest/utilities/test_gdalalg_raster_aspect.py
+++ b/autotest/utilities/test_gdalalg_raster_aspect.py
@@ -123,3 +123,48 @@ def test_gdalalg_raster_aspect_vrt_output_pipeline_from_filename():
         match=r"aspect: VRT output is not supported. Consider using the GDALG driver instead \(files with \.gdalg\.json extension\)",
     ):
         alg.Run()
+
+
+def test_gdalalg_raster_aspect_overview():
+
+    src_ds = gdal.Translate(
+        "",
+        "../gdrivers/data/n43.tif",
+        format="MEM",
+        width=61,
+        resampleAlg=gdal.GRIORA_Bilinear,
+    )
+
+    with gdal.Run(
+        "raster",
+        "aspect",
+        input=src_ds,
+        output="",
+        output_format="stream",
+    ) as alg:
+        out_ds = alg.Output()
+        cs = out_ds.GetRasterBand(1).Checksum()
+        stats = out_ds.GetRasterBand(1).ComputeStatistics(False)
+
+    src_ds = gdal.Translate("", "../gdrivers/data/n43.tif", format="MEM")
+    src_ds.BuildOverviews("BILINEAR", [2, 4])
+
+    with gdal.Run(
+        "raster",
+        "aspect",
+        input=src_ds,
+        output="",
+        output_format="stream",
+    ) as alg:
+        out_ds = alg.Output()
+    del src_ds
+
+    assert out_ds.GetRasterBand(1).GetOverviewCount() == 2
+    assert out_ds.GetRasterBand(1).GetOverview(-1) is None
+    assert out_ds.GetRasterBand(1).GetOverview(2) is None
+    assert out_ds.GetRasterBand(1).GetOverview(0).XSize == 61
+    assert out_ds.GetRasterBand(1).GetOverview(0).YSize == 61
+    assert out_ds.GetRasterBand(1).GetOverview(1).XSize == 31
+    assert out_ds.GetRasterBand(1).GetOverview(1).YSize == 31
+    assert out_ds.GetRasterBand(1).GetOverview(0).Checksum() == cs
+    assert out_ds.GetRasterBand(1).GetOverview(0).ComputeStatistics(False) == stats

--- a/autotest/utilities/test_gdalalg_raster_hillshade.py
+++ b/autotest/utilities/test_gdalalg_raster_hillshade.py
@@ -154,3 +154,40 @@ def test_gdalalg_raster_hillshade_vrt_output_pipeline_from_filename():
         match=r"hillshade: VRT output is not supported. Consider using the GDALG driver instead \(files with \.gdalg\.json extension\)",
     ):
         alg.Run()
+
+
+def test_gdalalg_raster_hillshade_overview():
+
+    src_ds = gdal.Translate(
+        "",
+        "../gdrivers/data/n43.tif",
+        format="MEM",
+        width=61,
+        resampleAlg=gdal.GRIORA_Bilinear,
+    )
+
+    with gdal.Run(
+        "raster", "hillshade", input=src_ds, output="", output_format="stream", z=30
+    ) as alg:
+        out_ds = alg.Output()
+        cs = out_ds.GetRasterBand(1).Checksum()
+        stats = out_ds.GetRasterBand(1).ComputeStatistics(False)
+
+    src_ds = gdal.Translate("", "../gdrivers/data/n43.tif", format="MEM")
+    src_ds.BuildOverviews("BILINEAR", [2, 4])
+
+    with gdal.Run(
+        "raster", "hillshade", input=src_ds, output="", output_format="stream", z=30
+    ) as alg:
+        out_ds = alg.Output()
+    del src_ds
+
+    assert out_ds.GetRasterBand(1).GetOverviewCount() == 2
+    assert out_ds.GetRasterBand(1).GetOverview(-1) is None
+    assert out_ds.GetRasterBand(1).GetOverview(2) is None
+    assert out_ds.GetRasterBand(1).GetOverview(0).XSize == 61
+    assert out_ds.GetRasterBand(1).GetOverview(0).YSize == 61
+    assert out_ds.GetRasterBand(1).GetOverview(1).XSize == 31
+    assert out_ds.GetRasterBand(1).GetOverview(1).YSize == 31
+    assert out_ds.GetRasterBand(1).GetOverview(0).Checksum() == cs
+    assert out_ds.GetRasterBand(1).GetOverview(0).ComputeStatistics(False) == stats

--- a/autotest/utilities/test_gdalalg_raster_roughness.py
+++ b/autotest/utilities/test_gdalalg_raster_roughness.py
@@ -119,3 +119,48 @@ def test_gdalalg_raster_roughness_vrt_output_pipeline_from_filename():
         match=r"roughness: VRT output is not supported. Consider using the GDALG driver instead \(files with \.gdalg\.json extension\)",
     ):
         alg.Run()
+
+
+def test_gdalalg_raster_roughness_overview():
+
+    src_ds = gdal.Translate(
+        "",
+        "../gdrivers/data/n43.tif",
+        format="MEM",
+        width=61,
+        resampleAlg=gdal.GRIORA_Bilinear,
+    )
+
+    with gdal.Run(
+        "raster",
+        "roughness",
+        input=src_ds,
+        output="",
+        output_format="stream",
+    ) as alg:
+        out_ds = alg.Output()
+        cs = out_ds.GetRasterBand(1).Checksum()
+        stats = out_ds.GetRasterBand(1).ComputeStatistics(False)
+
+    src_ds = gdal.Translate("", "../gdrivers/data/n43.tif", format="MEM")
+    src_ds.BuildOverviews("BILINEAR", [2, 4])
+
+    with gdal.Run(
+        "raster",
+        "roughness",
+        input=src_ds,
+        output="",
+        output_format="stream",
+    ) as alg:
+        out_ds = alg.Output()
+    del src_ds
+
+    assert out_ds.GetRasterBand(1).GetOverviewCount() == 2
+    assert out_ds.GetRasterBand(1).GetOverview(-1) is None
+    assert out_ds.GetRasterBand(1).GetOverview(2) is None
+    assert out_ds.GetRasterBand(1).GetOverview(0).XSize == 61
+    assert out_ds.GetRasterBand(1).GetOverview(0).YSize == 61
+    assert out_ds.GetRasterBand(1).GetOverview(1).XSize == 31
+    assert out_ds.GetRasterBand(1).GetOverview(1).YSize == 31
+    assert out_ds.GetRasterBand(1).GetOverview(0).Checksum() == cs
+    assert out_ds.GetRasterBand(1).GetOverview(0).ComputeStatistics(False) == stats

--- a/autotest/utilities/test_gdalalg_raster_slope.py
+++ b/autotest/utilities/test_gdalalg_raster_slope.py
@@ -124,3 +124,48 @@ def test_gdalalg_raster_slope_vrt_output_pipeline_from_filename():
         match=r"slope: VRT output is not supported. Consider using the GDALG driver instead \(files with \.gdalg\.json extension\)",
     ):
         alg.Run()
+
+
+def test_gdalalg_raster_slope_overview():
+
+    src_ds = gdal.Translate(
+        "",
+        "../gdrivers/data/n43.tif",
+        format="MEM",
+        width=61,
+        resampleAlg=gdal.GRIORA_Bilinear,
+    )
+
+    with gdal.Run(
+        "raster",
+        "slope",
+        input=src_ds,
+        output="",
+        output_format="stream",
+    ) as alg:
+        out_ds = alg.Output()
+        cs = out_ds.GetRasterBand(1).Checksum()
+        stats = out_ds.GetRasterBand(1).ComputeStatistics(False)
+
+    src_ds = gdal.Translate("", "../gdrivers/data/n43.tif", format="MEM")
+    src_ds.BuildOverviews("BILINEAR", [2, 4])
+
+    with gdal.Run(
+        "raster",
+        "slope",
+        input=src_ds,
+        output="",
+        output_format="stream",
+    ) as alg:
+        out_ds = alg.Output()
+    del src_ds
+
+    assert out_ds.GetRasterBand(1).GetOverviewCount() == 2
+    assert out_ds.GetRasterBand(1).GetOverview(-1) is None
+    assert out_ds.GetRasterBand(1).GetOverview(2) is None
+    assert out_ds.GetRasterBand(1).GetOverview(0).XSize == 61
+    assert out_ds.GetRasterBand(1).GetOverview(0).YSize == 61
+    assert out_ds.GetRasterBand(1).GetOverview(1).XSize == 31
+    assert out_ds.GetRasterBand(1).GetOverview(1).YSize == 31
+    assert out_ds.GetRasterBand(1).GetOverview(0).Checksum() == cs
+    assert out_ds.GetRasterBand(1).GetOverview(0).ComputeStatistics(False) == stats

--- a/frmts/mem/memdataset.cpp
+++ b/frmts/mem/memdataset.cpp
@@ -888,6 +888,16 @@ CPLErr MEMDataset::IBuildOverviews(const char *pszResampling, int nOverviews,
                 (nRasterXSize + panOverviewList[i] - 1) / panOverviewList[i];
             poOvrDS->nRasterYSize =
                 (nRasterYSize + panOverviewList[i] - 1) / panOverviewList[i];
+            poOvrDS->bGeoTransformSet = bGeoTransformSet;
+            memcpy(poOvrDS->adfGeoTransform, adfGeoTransform,
+                   6 * sizeof(double));
+            const double dfOvrXRatio =
+                static_cast<double>(nRasterXSize) / poOvrDS->nRasterXSize;
+            const double dfOvrYRatio =
+                static_cast<double>(nRasterYSize) / poOvrDS->nRasterYSize;
+            GDALRescaleGeoTransform(poOvrDS->adfGeoTransform, dfOvrXRatio,
+                                    dfOvrYRatio);
+            poOvrDS->m_oSRS = m_oSRS;
             for (int iBand = 0; iBand < nBands; iBand++)
             {
                 const GDALDataType eDT =

--- a/frmts/mem/memdataset.cpp
+++ b/frmts/mem/memdataset.cpp
@@ -907,7 +907,7 @@ CPLErr MEMDataset::IBuildOverviews(const char *pszResampling, int nOverviews,
                     return CE_Failure;
                 }
             }
-            m_apoOverviewDS.emplace_back(std::move(poOvrDS));
+            m_apoOverviewDS.emplace_back(poOvrDS.release());
         }
     }
 
@@ -1089,7 +1089,7 @@ std::unique_ptr<GDALDataset> MEMDataset::Clone(int nScopeFlags,
         for (const auto &poOvrDS : m_apoOverviewDS)
         {
             poNewDS->m_apoOverviewDS.emplace_back(
-                poOvrDS->Clone(nScopeFlags, bCanShareState));
+                poOvrDS->Clone(nScopeFlags, bCanShareState).release());
         }
 
         poNewDS->SetDescription(GetDescription());

--- a/frmts/mem/memdataset.h
+++ b/frmts/mem/memdataset.h
@@ -52,7 +52,10 @@ class CPL_DLL MEMDataset CPL_NON_FINAL : public GDALDataset
     std::vector<gdal::GCP> m_aoGCPs{};
     OGRSpatialReference m_oGCPSRS{};
 
-    std::vector<std::unique_ptr<GDALDataset>> m_apoOverviewDS{};
+    using GDALDatasetRefCountedPtr =
+        std::unique_ptr<GDALDataset, GDALDatasetUniquePtrReleaser>;
+
+    std::vector<GDALDatasetRefCountedPtr> m_apoOverviewDS{};
 
     struct Private;
     std::unique_ptr<Private> m_poPrivate;

--- a/gcore/gdal_misc.cpp
+++ b/gcore/gdal_misc.cpp
@@ -5842,3 +5842,23 @@ bool GDALDoesFileOrDatasetExist(const char *pszName, const char **ppszType,
 
     return false;
 }
+
+/************************************************************************/
+/*                        GDALRescaleGeoTransform()                     */
+/************************************************************************/
+
+/** Rescale a geotransform by multiplying its scale and rotation terms by
+ * the provided ratios.
+ *
+ * This is typically used to compute the geotransform matrix of an overview
+ * dataset from the full resolution dataset, where the ratios are the size
+ * of the full resolution dataset divided by the size of the overview.
+ */
+void GDALRescaleGeoTransform(double adfGeoTransform[6], double dfXRatio,
+                             double dfYRatio)
+{
+    adfGeoTransform[1] *= dfXRatio;
+    adfGeoTransform[2] *= dfYRatio;
+    adfGeoTransform[4] *= dfXRatio;
+    adfGeoTransform[5] *= dfYRatio;
+}

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -4774,6 +4774,9 @@ struct GDALColorAssociation
 std::vector<GDALColorAssociation> GDALLoadTextColorMap(const char *pszFilename,
                                                        GDALRasterBand *poBand);
 
+void GDALRescaleGeoTransform(double adfGeoTransform[6], double dfXRatio,
+                             double dfYRatio);
+
 // Macro used so that Identify and driver metadata methods in drivers built
 // as plugin can be duplicated in libgdal core and in the driver under different
 // names

--- a/gcore/gdaloverviewdataset.cpp
+++ b/gcore/gdaloverviewdataset.cpp
@@ -376,14 +376,11 @@ CPLErr GDALOverviewDataset::GetGeoTransform(double *padfTransform)
     if (poMainDS->GetGeoTransform(adfGeoTransform) != CE_None)
         return CE_Failure;
 
-    adfGeoTransform[1] *=
+    const double dfOvrXRatio =
         static_cast<double>(poMainDS->GetRasterXSize()) / nRasterXSize;
-    adfGeoTransform[2] *=
+    const double dfOvrYRatio =
         static_cast<double>(poMainDS->GetRasterYSize()) / nRasterYSize;
-    adfGeoTransform[4] *=
-        static_cast<double>(poMainDS->GetRasterXSize()) / nRasterXSize;
-    adfGeoTransform[5] *=
-        static_cast<double>(poMainDS->GetRasterYSize()) / nRasterYSize;
+    GDALRescaleGeoTransform(adfGeoTransform, dfOvrXRatio, dfOvrYRatio);
 
     memcpy(padfTransform, adfGeoTransform, sizeof(double) * 6);
 


### PR DESCRIPTION
and hillshade: enable to use SSE2 implementation when using streaming dataset (previously was only used when outputing directly to final raster)
