### PR TITLE
Simplify header file inclusion

### DIFF
--- a/frmts/snap_tiff/snaptiffdriver.cpp
+++ b/frmts/snap_tiff/snaptiffdriver.cpp
@@ -8,7 +8,7 @@
 #include "rawdataset.h"
 
 #define LIBERTIFF_NS GDAL_libertiff
-#include "../../third_party/libertiff/libertiff.hpp"
+#include "libertiff.hpp"
 
 #include <algorithm>
 #include <cmath>


### PR DESCRIPTION
It is the same as [frmts/libertiff/libertiffdataset.cpp](https://github.com/OSGeo/gdal/blob/master/frmts/libertiff/libertiffdataset.cpp#L35).