### PR TITLE
Make GDALRasterAttributeTable::SetValue() methods return a CPLErr

### DIFF
--- a/MIGRATION_GUIDE.TXT
+++ b/MIGRATION_GUIDE.TXT
@@ -10,6 +10,9 @@ MIGRATION GUIDE FROM GDAL 3.11 to GDAL 3.12
   * Furthermore, sub-command "set-type" of "gdal vector geom" is renamed as
     "set-geom-type" and also placed under "gdal vector".
 
+- Methods GDALRasterAttributeTable::SetValue() now return a CPLErr instead of
+  void. This will impact in particular out-of-tree drivers that implement those
+  methods in a subclass of GDALRasterAttributeTable.
 
 MIGRATION GUIDE FROM GDAL 3.10 to GDAL 3.11
 -------------------------------------------

--- a/frmts/hfa/hfadataset.cpp
+++ b/frmts/hfa/hfadataset.cpp
@@ -370,7 +370,7 @@ int HFARasterAttributeTable::GetRowCount() const
 const char *HFARasterAttributeTable::GetValueAsString(int iRow,
                                                       int iField) const
 {
-    // Get ValuesIO do do the work.
+    // Let ValuesIO do the work.
     char *apszStrList[1] = {nullptr};
     if (const_cast<HFARasterAttributeTable *>(this)->ValuesIO(
             GF_Read, iField, iRow, 1, apszStrList) != CE_None)
@@ -391,7 +391,7 @@ const char *HFARasterAttributeTable::GetValueAsString(int iRow,
 
 int HFARasterAttributeTable::GetValueAsInt(int iRow, int iField) const
 {
-    // Get ValuesIO do do the work.
+    // Let ValuesIO do the work.
     int nValue = 0;
     if (const_cast<HFARasterAttributeTable *>(this)->ValuesIO(
             GF_Read, iField, iRow, 1, &nValue) != CE_None)
@@ -408,7 +408,7 @@ int HFARasterAttributeTable::GetValueAsInt(int iRow, int iField) const
 
 double HFARasterAttributeTable::GetValueAsDouble(int iRow, int iField) const
 {
-    // Get ValuesIO do do the work.
+    // Let ValuesIO do the work.
     double dfValue = 0.0;
     if (const_cast<HFARasterAttributeTable *>(this)->ValuesIO(
             GF_Read, iField, iRow, 1, &dfValue) != CE_None)
@@ -423,31 +423,32 @@ double HFARasterAttributeTable::GetValueAsDouble(int iRow, int iField) const
 /*                          SetValue()                                  */
 /************************************************************************/
 
-void HFARasterAttributeTable::SetValue(int iRow, int iField,
-                                       const char *pszValue)
+CPLErr HFARasterAttributeTable::SetValue(int iRow, int iField,
+                                         const char *pszValue)
 {
-    // Get ValuesIO do do the work.
-    ValuesIO(GF_Write, iField, iRow, 1, (char **)&pszValue);
+    // Let ValuesIO do the work.
+    char *apszValues[1] = {const_cast<char *>(pszValue)};
+    return ValuesIO(GF_Write, iField, iRow, 1, apszValues);
 }
 
 /************************************************************************/
 /*                          SetValue()                                  */
 /************************************************************************/
 
-void HFARasterAttributeTable::SetValue(int iRow, int iField, double dfValue)
+CPLErr HFARasterAttributeTable::SetValue(int iRow, int iField, double dfValue)
 {
-    // Get ValuesIO do do the work.
-    ValuesIO(GF_Write, iField, iRow, 1, &dfValue);
+    // Let ValuesIO do the work.
+    return ValuesIO(GF_Write, iField, iRow, 1, &dfValue);
 }
 
 /************************************************************************/
 /*                          SetValue()                                  */
 /************************************************************************/
 
-void HFARasterAttributeTable::SetValue(int iRow, int iField, int nValue)
+CPLErr HFARasterAttributeTable::SetValue(int iRow, int iField, int nValue)
 {
-    // Get ValuesIO do do the work.
-    ValuesIO(GF_Write, iField, iRow, 1, &nValue);
+    // Let ValuesIO do the work.
+    return ValuesIO(GF_Write, iField, iRow, 1, &nValue);
 }
 
 /************************************************************************/

--- a/frmts/hfa/hfadataset.h
+++ b/frmts/hfa/hfadataset.h
@@ -254,9 +254,10 @@ class HFARasterAttributeTable final : public GDALRasterAttributeTable
     virtual int GetValueAsInt(int iRow, int iField) const override;
     virtual double GetValueAsDouble(int iRow, int iField) const override;
 
-    virtual void SetValue(int iRow, int iField, const char *pszValue) override;
-    virtual void SetValue(int iRow, int iField, double dfValue) override;
-    virtual void SetValue(int iRow, int iField, int nValue) override;
+    virtual CPLErr SetValue(int iRow, int iField,
+                            const char *pszValue) override;
+    virtual CPLErr SetValue(int iRow, int iField, double dfValue) override;
+    virtual CPLErr SetValue(int iRow, int iField, int nValue) override;
 
     virtual CPLErr ValuesIO(GDALRWFlag eRWFlag, int iField, int iStartRow,
                             int iLength, double *pdfData) override;

--- a/frmts/kea/kearat.cpp
+++ b/frmts/kea/kearat.cpp
@@ -297,7 +297,7 @@ int KEARasterAttributeTable::GetRowCount() const
 const char *KEARasterAttributeTable::GetValueAsString(int iRow,
                                                       int iField) const
 {
-    // Get ValuesIO do do the work
+    /// Let ValuesIO do the work.
     char *apszStrList[1];
     if ((const_cast<KEARasterAttributeTable *>(this))
             ->ValuesIO(GF_Read, iField, iRow, 1, apszStrList) != CE_None)
@@ -314,7 +314,7 @@ const char *KEARasterAttributeTable::GetValueAsString(int iRow,
 
 int KEARasterAttributeTable::GetValueAsInt(int iRow, int iField) const
 {
-    // Get ValuesIO do do the work
+    // Let ValuesIO do the work.
     int nValue = 0;
     if ((const_cast<KEARasterAttributeTable *>(this))
             ->ValuesIO(GF_Read, iField, iRow, 1, &nValue) != CE_None)
@@ -327,7 +327,7 @@ int KEARasterAttributeTable::GetValueAsInt(int iRow, int iField) const
 
 double KEARasterAttributeTable::GetValueAsDouble(int iRow, int iField) const
 {
-    // Get ValuesIO do do the work
+    // Let ValuesIO do the work.
     double dfValue = 0.0;
     if ((const_cast<KEARasterAttributeTable *>(this))
             ->ValuesIO(GF_Read, iField, iRow, 1, &dfValue) != CE_None)
@@ -338,23 +338,24 @@ double KEARasterAttributeTable::GetValueAsDouble(int iRow, int iField) const
     return dfValue;
 }
 
-void KEARasterAttributeTable::SetValue(int iRow, int iField,
-                                       const char *pszValue)
+CPLErr KEARasterAttributeTable::SetValue(int iRow, int iField,
+                                         const char *pszValue)
 {
-    // Get ValuesIO do do the work
-    ValuesIO(GF_Write, iField, iRow, 1, const_cast<char **>(&pszValue));
+    // Let ValuesIO do the work.
+    char *apszValues[1] = {const_cast<char *>(pszValue)};
+    return ValuesIO(GF_Write, iField, iRow, 1, apszValues);
 }
 
-void KEARasterAttributeTable::SetValue(int iRow, int iField, double dfValue)
+CPLErr KEARasterAttributeTable::SetValue(int iRow, int iField, double dfValue)
 {
-    // Get ValuesIO do do the work
-    ValuesIO(GF_Write, iField, iRow, 1, &dfValue);
+    // Let ValuesIO do the work.
+    return ValuesIO(GF_Write, iField, iRow, 1, &dfValue);
 }
 
-void KEARasterAttributeTable::SetValue(int iRow, int iField, int nValue)
+CPLErr KEARasterAttributeTable::SetValue(int iRow, int iField, int nValue)
 {
-    // Get ValuesIO do do the work
-    ValuesIO(GF_Write, iField, iRow, 1, &nValue);
+    // Let ValuesIO do the work.
+    return ValuesIO(GF_Write, iField, iRow, 1, &nValue);
 }
 
 CPLErr KEARasterAttributeTable::ValuesIO(GDALRWFlag eRWFlag, int iField,

--- a/frmts/kea/kearat.h
+++ b/frmts/kea/kearat.h
@@ -48,9 +48,10 @@ class KEARasterAttributeTable : public GDALDefaultRasterAttributeTable
     virtual int GetValueAsInt(int iRow, int iField) const override;
     virtual double GetValueAsDouble(int iRow, int iField) const override;
 
-    virtual void SetValue(int iRow, int iField, const char *pszValue) override;
-    virtual void SetValue(int iRow, int iField, double dfValue) override;
-    virtual void SetValue(int iRow, int iField, int nValue) override;
+    virtual CPLErr SetValue(int iRow, int iField,
+                            const char *pszValue) override;
+    virtual CPLErr SetValue(int iRow, int iField, double dfValue) override;
+    virtual CPLErr SetValue(int iRow, int iField, int nValue) override;
 
     virtual CPLErr ValuesIO(GDALRWFlag eRWFlag, int iField, int iStartRow,
                             int iLength, double *pdfData) override;

--- a/gcore/gdal_rat.cpp
+++ b/gcore/gdal_rat.cpp
@@ -114,6 +114,7 @@ CPLErr GDALRasterAttributeTable::ValuesIO(GDALRWFlag eRWFlag, int iField,
         return CE_Failure;
     }
 
+    CPLErr eErr = CE_None;
     if (eRWFlag == GF_Read)
     {
         for (int iIndex = iStartRow; iIndex < (iStartRow + iLength); iIndex++)
@@ -123,12 +124,13 @@ CPLErr GDALRasterAttributeTable::ValuesIO(GDALRWFlag eRWFlag, int iField,
     }
     else
     {
-        for (int iIndex = iStartRow; iIndex < (iStartRow + iLength); iIndex++)
+        for (int iIndex = iStartRow;
+             eErr == CE_None && iIndex < (iStartRow + iLength); iIndex++)
         {
-            SetValue(iIndex, iField, pdfData[iIndex]);
+            eErr = SetValue(iIndex, iField, pdfData[iIndex]);
         }
     }
-    return CE_None;
+    return eErr;
 }
 
 /************************************************************************/
@@ -178,6 +180,7 @@ CPLErr GDALRasterAttributeTable::ValuesIO(GDALRWFlag eRWFlag, int iField,
         return CE_Failure;
     }
 
+    CPLErr eErr = CE_None;
     if (eRWFlag == GF_Read)
     {
         for (int iIndex = iStartRow; iIndex < (iStartRow + iLength); iIndex++)
@@ -187,12 +190,13 @@ CPLErr GDALRasterAttributeTable::ValuesIO(GDALRWFlag eRWFlag, int iField,
     }
     else
     {
-        for (int iIndex = iStartRow; iIndex < (iStartRow + iLength); iIndex++)
+        for (int iIndex = iStartRow;
+             eErr == CE_None && iIndex < (iStartRow + iLength); iIndex++)
         {
-            SetValue(iIndex, iField, pnData[iIndex]);
+            eErr = SetValue(iIndex, iField, pnData[iIndex]);
         }
     }
-    return CE_None;
+    return eErr;
 }
 
 /************************************************************************/
@@ -244,6 +248,7 @@ CPLErr GDALRasterAttributeTable::ValuesIO(GDALRWFlag eRWFlag, int iField,
         return CE_Failure;
     }
 
+    CPLErr eErr = CE_None;
     if (eRWFlag == GF_Read)
     {
         for (int iIndex = iStartRow; iIndex < (iStartRow + iLength); iIndex++)
@@ -253,12 +258,13 @@ CPLErr GDALRasterAttributeTable::ValuesIO(GDALRWFlag eRWFlag, int iField,
     }
     else
     {
-        for (int iIndex = iStartRow; iIndex < (iStartRow + iLength); iIndex++)
+        for (int iIndex = iStartRow;
+             eErr == CE_None && iIndex < (iStartRow + iLength); iIndex++)
         {
-            SetValue(iIndex, iField, papszStrList[iIndex]);
+            eErr = SetValue(iIndex, iField, papszStrList[iIndex]);
         }
     }
-    return CE_None;
+    return eErr;
 }
 
 /************************************************************************/
@@ -1702,8 +1708,8 @@ void GDALDefaultRasterAttributeTable::SetRowCount(int nNewCount)
  * @param iField field index.
  * @param pszValue value.
  */
-void GDALDefaultRasterAttributeTable::SetValue(int iRow, int iField,
-                                               const char *pszValue)
+CPLErr GDALDefaultRasterAttributeTable::SetValue(int iRow, int iField,
+                                                 const char *pszValue)
 
 {
     if (iField < 0 || iField >= static_cast<int>(aoFields.size()))
@@ -1711,7 +1717,7 @@ void GDALDefaultRasterAttributeTable::SetValue(int iRow, int iField,
         CPLError(CE_Failure, CPLE_AppDefined, "iField (%d) out of range.",
                  iField);
 
-        return;
+        return CE_Failure;
     }
 
     if (iRow == nRowCount)
@@ -1721,7 +1727,7 @@ void GDALDefaultRasterAttributeTable::SetValue(int iRow, int iField,
     {
         CPLError(CE_Failure, CPLE_AppDefined, "iRow (%d) out of range.", iRow);
 
-        return;
+        return CE_Failure;
     }
 
     switch (aoFields[iField].eType)
@@ -1738,6 +1744,8 @@ void GDALDefaultRasterAttributeTable::SetValue(int iRow, int iField,
             aoFields[iField].aosValues[iRow] = pszValue;
             break;
     }
+
+    return CE_None;
 }
 
 /************************************************************************/
@@ -1769,7 +1777,8 @@ void CPL_STDCALL GDALRATSetValueAsString(GDALRasterAttributeTableH hRAT,
 /*                              SetValue()                              */
 /************************************************************************/
 
-void GDALDefaultRasterAttributeTable::SetValue(int iRow, int iField, int nValue)
+CPLErr GDALDefaultRasterAttributeTable::SetValue(int iRow, int iField,
+                                                 int nValue)
 
 {
     if (iField < 0 || iField >= static_cast<int>(aoFields.size()))
@@ -1777,7 +1786,7 @@ void GDALDefaultRasterAttributeTable::SetValue(int iRow, int iField, int nValue)
         CPLError(CE_Failure, CPLE_AppDefined, "iField (%d) out of range.",
                  iField);
 
-        return;
+        return CE_Failure;
     }
 
     if (iRow == nRowCount)
@@ -1787,7 +1796,7 @@ void GDALDefaultRasterAttributeTable::SetValue(int iRow, int iField, int nValue)
     {
         CPLError(CE_Failure, CPLE_AppDefined, "iRow (%d) out of range.", iRow);
 
-        return;
+        return CE_Failure;
     }
 
     switch (aoFields[iField].eType)
@@ -1809,6 +1818,8 @@ void GDALDefaultRasterAttributeTable::SetValue(int iRow, int iField, int nValue)
         }
         break;
     }
+
+    return CE_None;
 }
 
 /************************************************************************/
@@ -1834,8 +1845,8 @@ void CPL_STDCALL GDALRATSetValueAsInt(GDALRasterAttributeTableH hRAT, int iRow,
 /*                              SetValue()                              */
 /************************************************************************/
 
-void GDALDefaultRasterAttributeTable::SetValue(int iRow, int iField,
-                                               double dfValue)
+CPLErr GDALDefaultRasterAttributeTable::SetValue(int iRow, int iField,
+                                                 double dfValue)
 
 {
     if (iField < 0 || iField >= static_cast<int>(aoFields.size()))
@@ -1843,7 +1854,7 @@ void GDALDefaultRasterAttributeTable::SetValue(int iRow, int iField,
         CPLError(CE_Failure, CPLE_AppDefined, "iField (%d) out of range.",
                  iField);
 
-        return;
+        return CE_Failure;
     }
 
     if (iRow == nRowCount)
@@ -1853,7 +1864,7 @@ void GDALDefaultRasterAttributeTable::SetValue(int iRow, int iField,
     {
         CPLError(CE_Failure, CPLE_AppDefined, "iRow (%d) out of range.", iRow);
 
-        return;
+        return CE_Failure;
     }
 
     switch (aoFields[iField].eType)
@@ -1875,6 +1886,8 @@ void GDALDefaultRasterAttributeTable::SetValue(int iRow, int iField,
         }
         break;
     }
+
+    return CE_None;
 }
 
 /************************************************************************/

--- a/gcore/gdal_rat.h
+++ b/gcore/gdal_rat.h
@@ -173,8 +173,9 @@ class CPL_DLL GDALRasterAttributeTable
      * @param iRow row to fetch (zero based).
      * @param iField column to fetch (zero based).
      * @param pszValue the value to assign.
+     * @return (since 3.12) CE_None in case of success, error code otherwise
      */
-    virtual void SetValue(int iRow, int iField, const char *pszValue) = 0;
+    virtual CPLErr SetValue(int iRow, int iField, const char *pszValue) = 0;
 
     /**
      * \brief Set field value from integer.
@@ -188,8 +189,9 @@ class CPL_DLL GDALRasterAttributeTable
      * @param iRow row to fetch (zero based).
      * @param iField column to fetch (zero based).
      * @param nValue the value to assign.
+     * @return (since 3.12) CE_None in case of success, error code otherwise
      */
-    virtual void SetValue(int iRow, int iField, int nValue) = 0;
+    virtual CPLErr SetValue(int iRow, int iField, int nValue) = 0;
 
     /**
      * \brief Set field value from double.
@@ -203,8 +205,9 @@ class CPL_DLL GDALRasterAttributeTable
      * @param iRow row to fetch (zero based).
      * @param iField column to fetch (zero based).
      * @param dfValue the value to assign.
+     * @return (since 3.12) CE_None in case of success, error code otherwise
      */
-    virtual void SetValue(int iRow, int iField, double dfValue) = 0;
+    virtual CPLErr SetValue(int iRow, int iField, double dfValue) = 0;
 
     /**
      * \brief Determine whether changes made to this RAT are reflected directly
@@ -365,9 +368,9 @@ class CPL_DLL GDALDefaultRasterAttributeTable : public GDALRasterAttributeTable
     int GetValueAsInt(int iRow, int iField) const override;
     double GetValueAsDouble(int iRow, int iField) const override;
 
-    void SetValue(int iRow, int iField, const char *pszValue) override;
-    void SetValue(int iRow, int iField, double dfValue) override;
-    void SetValue(int iRow, int iField, int nValue) override;
+    CPLErr SetValue(int iRow, int iField, const char *pszValue) override;
+    CPLErr SetValue(int iRow, int iField, double dfValue) override;
+    CPLErr SetValue(int iRow, int iField, int nValue) override;
 
     int ChangesAreWrittenToFile() override;
     void SetRowCount(int iCount) override;

--- a/gcore/gdalmultidim_rat.cpp
+++ b/gcore/gdalmultidim_rat.cpp
@@ -270,27 +270,30 @@ class GDALRasterAttributeTableFromMDArrays final
     }
 
     //
-    void SetValue(int, int, const char *) override
+    CPLErr SetValue(int, int, const char *) override
     {
         CPLError(
             CE_Failure, CPLE_NotSupported,
             "GDALRasterAttributeTableFromMDArrays::SetValue(): not supported");
+        return CE_Failure;
     }
 
     //
-    void SetValue(int, int, int) override
+    CPLErr SetValue(int, int, int) override
     {
         CPLError(
             CE_Failure, CPLE_NotSupported,
             "GDALRasterAttributeTableFromMDArrays::SetValue(): not supported");
+        return CE_Failure;
     }
 
     //
-    void SetValue(int, int, double) override
+    CPLErr SetValue(int, int, double) override
     {
         CPLError(
             CE_Failure, CPLE_NotSupported,
             "GDALRasterAttributeTableFromMDArrays::SetValue(): not supported");
+        return CE_Failure;
     }
 
     //

--- a/ogr/ogrsf_frmts/openfilegdb/ogr_openfilegdb.h
+++ b/ogr/ogrsf_frmts/openfilegdb/ogr_openfilegdb.h
@@ -814,19 +814,22 @@ class GDALOpenFileGDBRasterAttributeTable final
         return poFeat->GetFieldAsDouble(iField);
     }
 
-    void SetValue(int, int, const char *) override
+    CPLErr SetValue(int, int, const char *) override
     {
         CPLError(CE_Failure, CPLE_NotSupported, "SetValue() not supported");
+        return CE_Failure;
     }
 
-    void SetValue(int, int, int) override
+    CPLErr SetValue(int, int, int) override
     {
         CPLError(CE_Failure, CPLE_NotSupported, "SetValue() not supported");
+        return CE_Failure;
     }
 
-    void SetValue(int, int, double) override
+    CPLErr SetValue(int, int, double) override
     {
         CPLError(CE_Failure, CPLE_NotSupported, "SetValue() not supported");
+        return CE_Failure;
     }
 
     int ChangesAreWrittenToFile() override


### PR DESCRIPTION
Fixes a Coverity Scan warning in the HFA driver whose implementation of SetValue() delegates to ValuesIO(), but ignored the return code of this later function.

And MRF: fix Coverity Scan warnings about division by zero and "wrapper object use after free" (for papapoOverviewBands, false positive). CC @lucianpls 
