### PR TITLE
[Backport release/3.11] VRT reclassify: Avoid crash with empty mapping

### DIFF
--- a/autotest/utilities/test_gdalalg_raster_reclassify.py
+++ b/autotest/utilities/test_gdalalg_raster_reclassify.py
@@ -224,6 +224,21 @@ def test_gdalalg_raster_reclassify_multiple_bands(reclassify, tmp_vsimem):
             assert np.all(dst_val[np.where(src_val >= 128)] == 1)
 
 
+def test_gdalalg_raster_reclassify_empty_mapping(reclassify, tmp_vsimem):
+
+    infile = "../gcore/data/byte.tif"
+    outfile = tmp_vsimem / "out.tif"
+
+    reclassify["input"] = infile
+    reclassify["output"] = outfile
+    reclassify["mapping"] = ""
+
+    with pytest.raises(
+        RuntimeError, match="Encountered value .* with no specified mapping"
+    ):
+        reclassify.Run()
+
+
 def test_gdalalg_raster_reclassify_mapping_not_found(reclassify, tmp_vsimem):
 
     infile = "../gcore/data/byte.tif"

--- a/frmts/vrt/vrtreclassifier.cpp
+++ b/frmts/vrt/vrtreclassifier.cpp
@@ -354,6 +354,11 @@ static std::optional<size_t> FindInterval(
         &arr,
     double srcVal)
 {
+    if (arr.empty())
+    {
+        return std::nullopt;
+    }
+
     size_t low = 0;
     size_t high = arr.size() - 1;
 


### PR DESCRIPTION
Backport #12470
 **Authored by:** @dbaston