### PR TITLE
Doc: Add link to Python API docs

### DIFF
--- a/doc/source/api/python/python_bindings.rst
+++ b/doc/source/api/python/python_bindings.rst
@@ -8,8 +8,8 @@ This Python package and extensions are a number of tools for programming and man
 
 The GDAL project maintains SWIG generated Python
 bindings for GDAL/OGR. Generally speaking the classes and methods mostly
-match those of the GDAL and OGR C++ classes. There is no Python specific
-reference documentation, but the :ref:`tutorials <tutorials>` includes Python examples.
+match those of the GDAL and OGR C++ classes. API documentation is available at :ref:`python_osgeo`,
+and the :ref:`tutorials <tutorials>` include Python examples.
 
 Dependencies
 ------------
@@ -168,7 +168,7 @@ Examples
   are implemented in Python and can be useful examples.
 * The majority of GDAL regression tests are written in Python. They are available at
   `https://github.com/OSGeo/gdal/tree/master/autotest <https://github.com/OSGeo/gdal/tree/master/autotest>`__
-* Some examples of GDAL/numpy integration can be found is found in the following scripts:
+* Some examples of GDAL/numpy integration can be found in the following scripts:
 
   - `gdal_calc.py`
   - `val_repl.py`


### PR DESCRIPTION
Add link to API docs and fix a typo. 

I noticed the two pages `gdal/swig/python/README.rst` and `gdal/doc/source/api/python/python_bindings.rst` are very similar. I guess they were based on the same text originally but have since diverged. 

Updating `python_bindings.rst` to the following works without having duplicated text:

```
.. _python:

.. include:: ../../../../swig/python/README.rst
```

@dbaston do you see any issues with consolidating the Python bindings text and using the above approach?

I know conda is the recommended approach for installing the Python bindings, especially on Windows. I also know there are many tickets opened and closed about trying to install using pip on Windows and wondering why they don't work. 
I have notes I use on setting up the GDAL wheels available at https://github.com/cgohlke/geospatial-wheels/releases in a Python Virtual Environment (to avoid clashing with other libraries as much as possible). 
@rouault would it be useful to add these steps to the README.rst, or would you rather avoid any mention of non-official wheels?

Actual install steps would be along the lines of:

```ps1
 # create a virtual environment to install GDAL
 C:\Python312\python -m venv C:\VirtualEnvs\gdal
 # activate the virtual environment (in PowerShell)
 C:\VirtualEnvs\gdal\Scripts\activate.ps1
 # install the GDAL wheel file downloaded above
 pip install C:\Temp\gdal-3.10.2-cp312-cp312-win_amd64.whl
 # also install numpy
 pip install numpy
 # check the installation was successful
 python -c "from osgeo import gdal; print(gdal.__version__)"
 # 3.10.2
```
I also have examples of using the GDAL bindings with the GDAL installed as part of ArcGIS Pro. Would it also be useful to add these steps / details?





