### PR TITLE
PGDUMP: Use OGR_PG_SKIP_CONFLICTS

### DIFF
--- a/doc/source/drivers/vector/pgdump.rst
+++ b/doc/source/drivers/vector/pgdump.rst
@@ -182,6 +182,13 @@ The following layer creation options are supported:
       DROP TABLE from being emitted. Set to IF_EXISTS
       in order DROP TABLE IF EXISTS to be emitted (needs PostgreSQL >= 8.2)
 
+-  .. config:: OGR_PG_SKIP_CONFLICTS
+      :choices: YES, NO
+      :default: NO
+
+      If set to "YES" (not the default), conflicts when inserting features
+      will be skipped (only applies when PG_USE_COPY is off).
+
 -  .. lco:: SRID
 
       Set the SRID of the geometry. Defaults to -1, unless a SRS

--- a/ogr/ogrsf_frmts/pgdump/ogr_pgdump.h
+++ b/ogr/ogrsf_frmts/pgdump/ogr_pgdump.h
@@ -121,6 +121,7 @@ class OGRPGDumpLayer final : public OGRLayer
     bool m_bCopyStatementWithFID = true;
     bool m_bNeedToUpdateSequence = false;
     bool m_bGeomColumnPositionImmediate = true;
+    int bSkipConflicts = false;
     std::vector<std::string> m_aosDeferredGeomFieldCreationCommands{};
     std::vector<std::string> m_aosDeferrentNonGeomFieldCreationCommands{};
     std::vector<std::string> m_aosSpatialIndexCreationCommands{};

--- a/ogr/ogrsf_frmts/pgdump/ogrpgdumplayer.cpp
+++ b/ogr/ogrsf_frmts/pgdump/ogrpgdumplayer.cpp
@@ -47,7 +47,9 @@ OGRPGDumpLayer::OGRPGDumpLayer(OGRPGDumpDataSource *poDSIn,
           OGRPGDumpEscapeColumnName(pszTableName).c_str()))),
       m_pszFIDColumn(pszFIDColumnIn ? CPLStrdup(pszFIDColumnIn) : nullptr),
       m_poFeatureDefn(new OGRFeatureDefn(pszTableName)), m_poDS(poDSIn),
-      m_bWriteAsHex(CPL_TO_BOOL(bWriteAsHexIn)), m_bCreateTable(bCreateTableIn)
+      m_bWriteAsHex(CPL_TO_BOOL(bWriteAsHexIn)), m_bCreateTable(bCreateTableIn),
+      bSkipConflicts(
+          CPLTestBool(CPLGetConfigOption("OGR_PG_SKIP_CONFLICTS", "FALSE")))
 {
     SetDescription(m_poFeatureDefn->GetName());
     m_poFeatureDefn->SetGeomType(wkbNone);
@@ -436,6 +438,9 @@ OGRErr OGRPGDumpLayer::CreateFeatureViaInsert(OGRFeature *poFeature)
     }
 
     osCommand += ")";
+
+    if (bSkipConflicts)
+        osCommand += " ON CONFLICT DO NOTHING";
 
     if (bEmptyInsert)
         osCommand.Printf("INSERT INTO %s DEFAULT VALUES", m_pszSqlTableName);


### PR DESCRIPTION
## What does this PR do?

Add support for the `OGR_PG_SKIP_CONFLICTS` config setting to the PGDump driver. The additional code and test follow the pattern in #10156, which added the option for the PostgreSQL driver.

The update adds `on conflict do nothing` to the end of each INSERT statement when the option is true. 

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

