### PR TITLE
MSVC build: Add parallel compile option

### DIFF
--- a/cmake/helpers/GdalCompilationFlags.cmake
+++ b/cmake/helpers/GdalCompilationFlags.cmake
@@ -204,6 +204,7 @@ add_definitions(-DGDAL_COMPILATION)
 if (MSVC)
   add_definitions(-D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE)
   add_definitions(-DNOMINMAX)
+  add_compile_options(/MP)
 endif ()
 
 if (MINGW)


### PR DESCRIPTION
## What does this PR do?
Enable parallel compilation with MSVC, making the build faster on most multi-core machines.

While projects do run in parallel if there are CPUs available, some projects (alg, appslib, ogr) have a lot of files that need to be compiled and take much longer to complete than drivers. This makes the gdal build time much longer than it needs to be.
On a 16 core desktop, this makes a simple gdal compilation finish in 1m40s from 3m52s. Similar results on a 6core laptop, going from 10m20s to 7m10s.

## What are related issues/pull requests?

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS: Windows
* Compiler: MSVC
