### PR TITLE
gdal raster mosaic: add completion/choices for --pixel-function and --pixel-function--arg

### DIFF
--- a/apps/gdalalg_raster_mosaic.cpp
+++ b/apps/gdalalg_raster_mosaic.cpp
@@ -17,6 +17,7 @@
 
 #include "gdal_priv.h"
 #include "gdal_utils.h"
+#include "vrtdataset.h"
 
 //! @cond Doxygen_Suppress
 
@@ -107,15 +108,62 @@ GDALRasterMosaicAlgorithm::GDALRasterMosaicAlgorithm()
              "raster have "
              "none."),
            &m_addAlpha);
+
+    const auto pixelFunctionNames =
+        VRTDerivedRasterBand::GetPixelFunctionNames();
     AddArg("pixel-function", 0,
            _("Specify a pixel function to calculate output value from "
              "overlapping inputs"),
-           &m_pixelFunction);
-    AddArg("pixel-function-arg", 0,
-           _("Specify argument(s) to pass to the pixel function"),
-           &m_pixelFunctionArgs)
-        .SetMetaVar("<NAME>=<VALUE>")
-        .SetRepeatedArgAllowed(true);
+           &m_pixelFunction)
+        .SetChoices(pixelFunctionNames);
+
+    auto &pixelFunctionArgArg =
+        AddArg("pixel-function-arg", 0,
+               _("Specify argument(s) to pass to the pixel function"),
+               &m_pixelFunctionArgs)
+            .SetMetaVar("<NAME>=<VALUE>")
+            .SetRepeatedArgAllowed(true);
+    pixelFunctionArgArg.AddValidationAction(
+        [this, &pixelFunctionArgArg]()
+        { return ParseAndValidateKeyValue(pixelFunctionArgArg); });
+
+    pixelFunctionArgArg.SetAutoCompleteFunction(
+        [this](const std::string &currentValue)
+        {
+            std::vector<std::string> ret;
+
+            if (!m_pixelFunction.empty())
+            {
+                const auto *pair = VRTDerivedRasterBand::GetPixelFunction(
+                    m_pixelFunction.c_str());
+                if (!pair)
+                {
+                    ret.push_back("**");
+                    // Non printable UTF-8 space, to avoid autocompletion to pickup on 'd'
+                    ret.push_back(std::string("\xC2\xA0"
+                                              "Invalid pixel function name"));
+                }
+                else if (pair->second.find("Argument name=") ==
+                         std::string::npos)
+                {
+                    ret.push_back("**");
+                    // Non printable UTF-8 space, to avoid autocompletion to pickup on 'd'
+                    ret.push_back(
+                        std::string(
+                            "\xC2\xA0"
+                            "No pixel function arguments for pixel function '")
+                            .append(m_pixelFunction)
+                            .append("'"));
+                }
+                else
+                {
+                    AddOptionsSuggestions(pair->second.c_str(), 0, currentValue,
+                                          ret);
+                }
+            }
+
+            return ret;
+        });
 }
 
 /************************************************************************/

--- a/autotest/utilities/test_gdalalg_raster_mosaic.py
+++ b/autotest/utilities/test_gdalalg_raster_mosaic.py
@@ -512,3 +512,13 @@ def test_gdalalg_raster_mosaic_pixel_function_arg_complete():
         f"{gdal_path} completion gdal raster mosaic --pixel-function=mean --pixel-function-arg"
     )
     assert out == "propagateNoData="
+
+    out = gdaltest.runexternal(
+        f"{gdal_path} completion gdal raster mosaic --pixel-function=mean --pixel-function-arg propagateNoData="
+    ).split(" ")
+    assert out == ["NO", "YES"]
+
+    out = gdaltest.runexternal(
+        f"{gdal_path} completion gdal raster mosaic --pixel-function=mean --pixel-function-arg propagateNoData=YES"
+    )
+    assert out == ""

--- a/autotest/utilities/test_gdalalg_raster_mosaic.py
+++ b/autotest/utilities/test_gdalalg_raster_mosaic.py
@@ -465,13 +465,50 @@ def test_gdalalg_raster_mosaic_pixel_function(pixfn, args):
 
 def test_gdalalg_raster_mosaic_pixel_function_invalid():
 
-    src_ds = gdal.GetDriverByName("MEM").Create("", 3, 1)
-    src_ds.SetGeoTransform([0, 1, 0, 1, 0, -1])
+    alg = get_mosaic_alg()
+    with pytest.raises(
+        RuntimeError,
+        match="Invalid value 'does_not_exist' for string argument 'pixel-function'",
+    ):
+        alg["pixel-function"] = "does_not_exist"
+
+
+def test_gdalalg_raster_mosaic_pixel_function_arg_invalid():
 
     alg = get_mosaic_alg()
-    alg["input"] = src_ds
-    alg["output"] = ""
-    alg["pixel-function"] = "does_not_exist"
+    with pytest.raises(
+        RuntimeError,
+        match="Invalid value for argument 'pixel-function-arg'. <KEY>=<VALUE> expected",
+    ):
+        alg["pixel-function-arg"] = "key_without_value"
 
-    with pytest.raises(RuntimeError, match="not a registered pixel function"):
-        alg.Run()
+
+def test_gdalalg_raster_mosaic_pixel_function_arg_complete():
+    import gdaltest
+    import test_cli_utilities
+
+    gdal_path = test_cli_utilities.get_gdal_path()
+    if gdal_path is None:
+        pytest.skip("gdal binary missing")
+
+    out = gdaltest.runexternal(
+        f"{gdal_path} completion gdal raster mosaic --pixel-function-arg"
+    )
+    assert (
+        "Specify argument(s) to pass to the pixel function".replace(" ", "\\ ") in out
+    )
+
+    out = gdaltest.runexternal(
+        f"{gdal_path} completion gdal raster mosaic --pixel-function=invalid --pixel-function-arg"
+    )
+    assert "Invalid pixel function name".replace(" ", "\\ ") in out
+
+    out = gdaltest.runexternal(
+        f"{gdal_path} completion gdal raster mosaic --pixel-function=scale --pixel-function-arg"
+    )
+    assert "No pixel function arguments for pixel function".replace(" ", "\\ ") in out
+
+    out = gdaltest.runexternal(
+        f"{gdal_path} completion gdal raster mosaic --pixel-function=mean --pixel-function-arg"
+    )
+    assert out == "propagateNoData="

--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -1213,6 +1213,8 @@ class CPL_DLL VRTDerivedRasterBand CPL_NON_FINAL : public VRTSourcedRasterBand
     static const std::pair<PixelFunc, std::string> *
     GetPixelFunction(const char *pszFuncNameIn);
 
+    static std::vector<std::string> GetPixelFunctionNames();
+
     void SetPixelFunctionName(const char *pszFuncNameIn);
     void AddPixelFunctionArgument(const char *pszArg, const char *pszValue);
     void SetSkipNonContributingSources(bool bSkip);

--- a/frmts/vrt/vrtderivedrasterband.cpp
+++ b/frmts/vrt/vrtderivedrasterband.cpp
@@ -353,6 +353,7 @@ CPLErr VRTDerivedRasterBand::AddPixelFunction(
  *         metadata string. If no pixel function has been registered
  *         for pszFuncNameIn, nullptr will be returned.
  */
+/* static */
 const std::pair<VRTDerivedRasterBand::PixelFunc, std::string> *
 VRTDerivedRasterBand::GetPixelFunction(const char *pszFuncNameIn)
 {
@@ -368,6 +369,24 @@ VRTDerivedRasterBand::GetPixelFunction(const char *pszFuncNameIn)
         return nullptr;
 
     return &(oIter->second);
+}
+
+/************************************************************************/
+/*                        GetPixelFunctionNames()                       */
+/************************************************************************/
+
+/**
+ * Return the list of available pixel function names.
+ */
+/* static */
+std::vector<std::string> VRTDerivedRasterBand::GetPixelFunctionNames()
+{
+    std::vector<std::string> res;
+    for (const auto &iter : GetGlobalMapPixelFunction())
+    {
+        res.push_back(iter.first);
+    }
+    return res;
 }
 
 /************************************************************************/

--- a/gcore/gdalalgorithm.cpp
+++ b/gcore/gdalalgorithm.cpp
@@ -3429,11 +3429,21 @@ bool GDALAlgorithm::AddOptionsSuggestions(const char *pszXML, int datasetType,
     CPLXMLTreeCloser poTree(CPLParseXMLString(pszXML));
     if (!poTree)
         return false;
+
+    std::string typedOptionName = currentValue;
+    const auto posEqual = typedOptionName.find('=');
+    std::string typedValue;
+    if (posEqual != 0 && posEqual != std::string::npos)
+    {
+        typedValue = currentValue.substr(posEqual + 1);
+        typedOptionName.resize(posEqual);
+    }
+
     for (const CPLXMLNode *psChild = poTree.get()->psChild; psChild;
          psChild = psChild->psNext)
     {
         const char *pszName = CPLGetXMLValue(psChild, "name", nullptr);
-        if (pszName && currentValue == pszName &&
+        if (pszName && typedOptionName == pszName &&
             (strcmp(psChild->pszValue, "Option") == 0 ||
              strcmp(psChild->pszValue, "Argument") == 0))
         {
@@ -3453,6 +3463,11 @@ bool GDALAlgorithm::AddOptionsSuggestions(const char *pszXML, int datasetType,
             }
             else if (EQUAL(pszType, "boolean"))
             {
+                if (typedValue == "YES" || typedValue == "NO")
+                {
+                    oRet.push_back(currentValue);
+                    return true;
+                }
                 oRet.push_back("NO");
                 oRet.push_back("YES");
             }

--- a/gcore/gdalalgorithm.cpp
+++ b/gcore/gdalalgorithm.cpp
@@ -3434,7 +3434,8 @@ bool GDALAlgorithm::AddOptionsSuggestions(const char *pszXML, int datasetType,
     {
         const char *pszName = CPLGetXMLValue(psChild, "name", nullptr);
         if (pszName && currentValue == pszName &&
-            EQUAL(psChild->pszValue, "Option"))
+            (strcmp(psChild->pszValue, "Option") == 0 ||
+             strcmp(psChild->pszValue, "Argument") == 0))
         {
             const char *pszType = CPLGetXMLValue(psChild, "type", "");
             const char *pszMin = CPLGetXMLValue(psChild, "min", nullptr);
@@ -3508,7 +3509,8 @@ bool GDALAlgorithm::AddOptionsSuggestions(const char *pszXML, int datasetType,
          psChild = psChild->psNext)
     {
         const char *pszName = CPLGetXMLValue(psChild, "name", nullptr);
-        if (pszName && EQUAL(psChild->pszValue, "Option"))
+        if (pszName && (strcmp(psChild->pszValue, "Option") == 0 ||
+                        strcmp(psChild->pszValue, "Argument") == 0))
         {
             const char *pszScope = CPLGetXMLValue(psChild, "scope", nullptr);
             if (!pszScope ||


### PR DESCRIPTION
CC @dbaston 

```
$ gdal raster mosaic --pixel-function=<TAB<>TAB>
cmul                dB2amp              exp                 imag                inv                 median              mul                 pow                 scale
complex             dB2pow              expression          intensity           log10               min                 norm_diff           real                sqrt
conj                diff                geometric_mean      interpolate_exp     max                 mod                 phase               reclassify          sum
dB                  div                 harmonic_mean       interpolate_linear  mean                mode                polar               replace_nodata

$ gdal raster mosaic --pixel-function=median --pixel-function-arg=<TAB>
==>
$ gdal raster mosaic --pixel-function=median --pixel-function-arg=propagateNoData=

$ gdal raster mosaic --pixel-function=real --pixel-function-arg=<TAB><TAB>
**                                                     No pixel function arguments for pixel function real
```
