### PR TITLE
GDALRasterBand: define +, -, *, /, AsType(), gdal::min()/max() to perform band lazy-evaluated arithmetics from C++, C and SWIG (Python)

### DIFF
--- a/autotest/cpp/CMakeLists.txt
+++ b/autotest/cpp/CMakeLists.txt
@@ -132,6 +132,10 @@ endif ()
 if (GDAL_USE_CURL)
   target_compile_definitions(gdal_unit_test PRIVATE -DHAVE_CURL)
 endif ()
+if (GDAL_USE_MUPARSER)
+  target_compile_definitions(gdal_unit_test PRIVATE -DHAVE_MUPARSER)
+endif()
+
 target_compile_definitions(gdal_unit_test PRIVATE "-DPROJ_DB_TMPDIR=\"${CMAKE_CURRENT_BINARY_DIR}/proj_db_tmpdir\"" "-DPROJ_GRIDS_PATH=\"${CMAKE_CURRENT_SOURCE_DIR}/../proj_grids\"")
 
 # gtest with lots of assertion can be very slow to build in optimized mode.

--- a/autotest/cpp/test_gdal.cpp
+++ b/autotest/cpp/test_gdal.cpp
@@ -5582,6 +5582,26 @@ TEST_F(test_gdal, GDALRasterBand_arithmetic_operators)
         EXPECT_THROW(CPL_IGNORE_RET_VAL(gdal::mean(
                          firstBand, firstBand, (*poOtherDS->GetRasterBand(1)))),
                      std::runtime_error);
+#ifdef HAVE_MUPARSER
+        EXPECT_THROW(
+            CPL_IGNORE_RET_VAL(firstBand > (*poOtherDS->GetRasterBand(1))),
+            std::runtime_error);
+        EXPECT_THROW(
+            CPL_IGNORE_RET_VAL(firstBand >= (*poOtherDS->GetRasterBand(1))),
+            std::runtime_error);
+        EXPECT_THROW(
+            CPL_IGNORE_RET_VAL(firstBand < (*poOtherDS->GetRasterBand(1))),
+            std::runtime_error);
+        EXPECT_THROW(
+            CPL_IGNORE_RET_VAL(firstBand <= (*poOtherDS->GetRasterBand(1))),
+            std::runtime_error);
+        EXPECT_THROW(
+            CPL_IGNORE_RET_VAL(firstBand == (*poOtherDS->GetRasterBand(1))),
+            std::runtime_error);
+        EXPECT_THROW(
+            CPL_IGNORE_RET_VAL(firstBand != (*poOtherDS->GetRasterBand(1))),
+            std::runtime_error);
+#endif
     }
 
     {
@@ -5662,6 +5682,146 @@ TEST_F(test_gdal, GDALRasterBand_arithmetic_operators)
                       .ComputeRasterMinMax(false, adfMinMax),
                   CE_None);
         EXPECT_NEAR(adfMinMax[0], (FIRST + SECOND + THIRD) / 3, 1e-14);
+
+#ifdef HAVE_MUPARSER
+        EXPECT_EQ((firstBand > 1.4).GetRasterDataType(), GDT_Byte);
+        EXPECT_EQ((firstBand > 1.4).ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], 1);
+        EXPECT_EQ((firstBand > 1.5).ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], 0);
+        EXPECT_EQ((1.5 > firstBand).ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], 0);
+        EXPECT_EQ((1.6 > firstBand).ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], 1);
+        EXPECT_EQ((firstBand > firstBand).ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], 0);
+        EXPECT_EQ(
+            (secondBand > firstBand).ComputeRasterMinMax(false, adfMinMax),
+            CE_None);
+        EXPECT_EQ(adfMinMax[0], 1);
+
+        EXPECT_EQ((firstBand >= 1.5).GetRasterDataType(), GDT_Byte);
+        EXPECT_EQ((firstBand >= 1.5).ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], 1);
+        EXPECT_EQ((firstBand >= 1.6).ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], 0);
+        EXPECT_EQ((1.4 >= firstBand).ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], 0);
+        EXPECT_EQ((1.5 >= firstBand).ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], 1);
+        EXPECT_EQ(
+            (firstBand >= firstBand).ComputeRasterMinMax(false, adfMinMax),
+            CE_None);
+        EXPECT_EQ(adfMinMax[0], 1);
+        EXPECT_EQ(
+            (secondBand >= firstBand).ComputeRasterMinMax(false, adfMinMax),
+            CE_None);
+        EXPECT_EQ(adfMinMax[0], 1);
+        EXPECT_EQ(
+            (firstBand >= secondBand).ComputeRasterMinMax(false, adfMinMax),
+            CE_None);
+        EXPECT_EQ(adfMinMax[0], 0);
+
+        EXPECT_EQ((firstBand < 1.5).GetRasterDataType(), GDT_Byte);
+        EXPECT_EQ((firstBand < 1.5).ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], 0);
+        EXPECT_EQ((firstBand < 1.6).ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], 1);
+        EXPECT_EQ((1.5 < firstBand).ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], 0);
+        EXPECT_EQ((1.4 < firstBand).ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], 1);
+        EXPECT_EQ((firstBand < firstBand).ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], 0);
+        EXPECT_EQ(
+            (firstBand < secondBand).ComputeRasterMinMax(false, adfMinMax),
+            CE_None);
+        EXPECT_EQ(adfMinMax[0], 1);
+
+        EXPECT_EQ((firstBand <= 1.5).GetRasterDataType(), GDT_Byte);
+        EXPECT_EQ((firstBand <= 1.5).ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], 1);
+        EXPECT_EQ((firstBand <= 1.4).ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], 0);
+        EXPECT_EQ((1.5 <= firstBand).ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], 1);
+        EXPECT_EQ((1.6 <= firstBand).ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], 0);
+        EXPECT_EQ(
+            (firstBand <= firstBand).ComputeRasterMinMax(false, adfMinMax),
+            CE_None);
+        EXPECT_EQ(adfMinMax[0], 1);
+        EXPECT_EQ(
+            (secondBand <= firstBand).ComputeRasterMinMax(false, adfMinMax),
+            CE_None);
+        EXPECT_EQ(adfMinMax[0], 0);
+        EXPECT_EQ(
+            (firstBand <= secondBand).ComputeRasterMinMax(false, adfMinMax),
+            CE_None);
+        EXPECT_EQ(adfMinMax[0], 1);
+
+        EXPECT_EQ((firstBand == 1.5).GetRasterDataType(), GDT_Byte);
+        EXPECT_EQ((firstBand == 1.5).ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], 1);
+        EXPECT_EQ((firstBand == 1.6).ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], 0);
+        EXPECT_EQ((1.5 == firstBand).ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], 1);
+        EXPECT_EQ((1.4 == firstBand).ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], 0);
+        EXPECT_EQ(
+            (firstBand == firstBand).ComputeRasterMinMax(false, adfMinMax),
+            CE_None);
+        EXPECT_EQ(adfMinMax[0], 1);
+        EXPECT_EQ(
+            (firstBand == secondBand).ComputeRasterMinMax(false, adfMinMax),
+            CE_None);
+        EXPECT_EQ(adfMinMax[0], 0);
+
+        EXPECT_EQ((firstBand != 1.5).GetRasterDataType(), GDT_Byte);
+        EXPECT_EQ((firstBand != 1.5).ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], 0);
+        EXPECT_EQ((firstBand != 1.6).ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], 1);
+        EXPECT_EQ((1.5 != firstBand).ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], 0);
+        EXPECT_EQ((1.4 != firstBand).ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], 1);
+        EXPECT_EQ(
+            (firstBand != firstBand).ComputeRasterMinMax(false, adfMinMax),
+            CE_None);
+        EXPECT_EQ(adfMinMax[0], 0);
+        EXPECT_EQ(
+            (firstBand != secondBand).ComputeRasterMinMax(false, adfMinMax),
+            CE_None);
+        EXPECT_EQ(adfMinMax[0], 1);
+#endif
     }
 
     EXPECT_EQ(firstBand.AsType(GDT_Byte).GetRasterDataType(), GDT_Byte);

--- a/autotest/cpp/test_gdal.cpp
+++ b/autotest/cpp/test_gdal.cpp
@@ -5587,7 +5587,15 @@ TEST_F(test_gdal, GDALRasterBand_arithmetic_operators)
 
         const OGRSpatialReference *poGotSRS =
             formula.GetDataset()->GetSpatialRef();
-        EXPECT_EQ(poGotSRS, poDS->GetSpatialRef());
+        EXPECT_NE(poGotSRS, nullptr);
+        EXPECT_TRUE(poGotSRS->IsSame(poDS->GetSpatialRef()));
+
+        EXPECT_NE(formula.GetDataset()->GetInternalHandle("VRT_DATASET"),
+                  nullptr);
+        EXPECT_EQ(formula.GetDataset()->GetInternalHandle("invalid"), nullptr);
+
+        EXPECT_EQ(formula.GetDataset()->GetMetadataItem("foo"), nullptr);
+        EXPECT_NE(formula.GetDataset()->GetMetadata("xml:VRT"), nullptr);
 
         std::vector<double> adfResults(WIDTH);
         EXPECT_EQ(formula.ReadBlock(0, 0, adfResults.data()), CE_None);

--- a/autotest/cpp/test_gdal.cpp
+++ b/autotest/cpp/test_gdal.cpp
@@ -5576,6 +5576,12 @@ TEST_F(test_gdal, GDALRasterBand_arithmetic_operators)
         EXPECT_THROW(CPL_IGNORE_RET_VAL(gdal::max(
                          firstBand, firstBand, (*poOtherDS->GetRasterBand(1)))),
                      std::runtime_error);
+        EXPECT_THROW(CPL_IGNORE_RET_VAL(
+                         gdal::mean(firstBand, (*poOtherDS->GetRasterBand(1)))),
+                     std::runtime_error);
+        EXPECT_THROW(CPL_IGNORE_RET_VAL(gdal::mean(
+                         firstBand, firstBand, (*poOtherDS->GetRasterBand(1)))),
+                     std::runtime_error);
     }
 
     {
@@ -5629,6 +5635,11 @@ TEST_F(test_gdal, GDALRasterBand_arithmetic_operators)
                   CE_None);
         EXPECT_NEAR(adfMinMax[0], std::max(FIRST, std::max(SECOND, THIRD)),
                     1e-14);
+
+        EXPECT_EQ(gdal::mean(firstBand, thirdBand, secondBand)
+                      .ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_NEAR(adfMinMax[0], (FIRST + SECOND + THIRD) / 3, 1e-14);
     }
 
     EXPECT_EQ(firstBand.AsType(GDT_Byte).GetRasterDataType(), GDT_Byte);

--- a/autotest/cpp/test_gdal.cpp
+++ b/autotest/cpp/test_gdal.cpp
@@ -5564,6 +5564,18 @@ TEST_F(test_gdal, GDALRasterBand_arithmetic_operators)
         EXPECT_THROW(
             CPL_IGNORE_RET_VAL(firstBand + (*poOtherDS->GetRasterBand(1))),
             std::runtime_error);
+        EXPECT_THROW(CPL_IGNORE_RET_VAL(
+                         gdal::min(firstBand, (*poOtherDS->GetRasterBand(1)))),
+                     std::runtime_error);
+        EXPECT_THROW(CPL_IGNORE_RET_VAL(gdal::min(
+                         firstBand, firstBand, (*poOtherDS->GetRasterBand(1)))),
+                     std::runtime_error);
+        EXPECT_THROW(CPL_IGNORE_RET_VAL(
+                         gdal::max(firstBand, (*poOtherDS->GetRasterBand(1)))),
+                     std::runtime_error);
+        EXPECT_THROW(CPL_IGNORE_RET_VAL(gdal::max(
+                         firstBand, firstBand, (*poOtherDS->GetRasterBand(1)))),
+                     std::runtime_error);
     }
 
     {
@@ -5605,6 +5617,18 @@ TEST_F(test_gdal, GDALRasterBand_arithmetic_operators)
         EXPECT_EQ(formula.ComputeRasterMinMax(false, adfMinMax), CE_None);
         EXPECT_NEAR(adfMinMax[0], expectedVal, 1e-14);
         EXPECT_NEAR(adfMinMax[1], expectedVal, 1e-14);
+
+        EXPECT_EQ(gdal::min(thirdBand, firstBand, secondBand)
+                      .ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_NEAR(adfMinMax[0], std::min(FIRST, std::min(SECOND, THIRD)),
+                    1e-14);
+
+        EXPECT_EQ(gdal::max(firstBand, thirdBand, secondBand)
+                      .ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_NEAR(adfMinMax[0], std::max(FIRST, std::max(SECOND, THIRD)),
+                    1e-14);
     }
 
     EXPECT_EQ(firstBand.AsType(GDT_Byte).GetRasterDataType(), GDT_Byte);

--- a/autotest/cpp/test_gdal.cpp
+++ b/autotest/cpp/test_gdal.cpp
@@ -5601,6 +5601,12 @@ TEST_F(test_gdal, GDALRasterBand_arithmetic_operators)
         EXPECT_THROW(
             CPL_IGNORE_RET_VAL(firstBand != (*poOtherDS->GetRasterBand(1))),
             std::runtime_error);
+        EXPECT_THROW(CPL_IGNORE_RET_VAL(gdal::IfThenElse(
+                         firstBand, firstBand, (*poOtherDS->GetRasterBand(1)))),
+                     std::runtime_error);
+        EXPECT_THROW(CPL_IGNORE_RET_VAL(gdal::IfThenElse(
+                         firstBand, (*poOtherDS->GetRasterBand(1)), firstBand)),
+                     std::runtime_error);
 #endif
     }
 
@@ -5821,6 +5827,43 @@ TEST_F(test_gdal, GDALRasterBand_arithmetic_operators)
             (firstBand != secondBand).ComputeRasterMinMax(false, adfMinMax),
             CE_None);
         EXPECT_EQ(adfMinMax[0], 1);
+
+        EXPECT_EQ(gdal::IfThenElse(firstBand == 1.5, secondBand, thirdBand)
+                      .ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], SECOND);
+        EXPECT_EQ(gdal::IfThenElse(firstBand == 1.5, secondBand, thirdBand)
+                      .GetRasterDataType(),
+                  GDALDataTypeUnion(secondBand.GetRasterDataType(),
+                                    thirdBand.GetRasterDataType()));
+
+        EXPECT_EQ(gdal::IfThenElse(firstBand == 1.5, SECOND, THIRD)
+                      .ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], SECOND);
+        EXPECT_EQ(gdal::IfThenElse(firstBand == 1.5, SECOND, THIRD)
+                      .GetRasterDataType(),
+                  GDT_Float32);
+
+        EXPECT_EQ(gdal::IfThenElse(firstBand == 1.5, SECOND, thirdBand)
+                      .ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], SECOND);
+
+        EXPECT_EQ(gdal::IfThenElse(firstBand != 1.5, secondBand, thirdBand)
+                      .ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], THIRD);
+
+        EXPECT_EQ(gdal::IfThenElse(firstBand != 1.5, secondBand, THIRD)
+                      .ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], THIRD);
+
+        EXPECT_EQ(gdal::IfThenElse(firstBand != 1.5, SECOND, THIRD)
+                      .ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], THIRD);
 #endif
     }
 

--- a/autotest/cpp/test_gdal.cpp
+++ b/autotest/cpp/test_gdal.cpp
@@ -5630,11 +5630,33 @@ TEST_F(test_gdal, GDALRasterBand_arithmetic_operators)
         EXPECT_NEAR(adfMinMax[0], std::min(FIRST, std::min(SECOND, THIRD)),
                     1e-14);
 
+        EXPECT_EQ(gdal::min(thirdBand, firstBand, 2, secondBand)
+                      .ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_NEAR(adfMinMax[0], std::min(FIRST, std::min(SECOND, THIRD)),
+                    1e-14);
+
+        EXPECT_EQ(gdal::min(thirdBand, firstBand, -1, secondBand)
+                      .ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], -1);
+
         EXPECT_EQ(gdal::max(firstBand, thirdBand, secondBand)
                       .ComputeRasterMinMax(false, adfMinMax),
                   CE_None);
         EXPECT_NEAR(adfMinMax[0], std::max(FIRST, std::max(SECOND, THIRD)),
                     1e-14);
+
+        EXPECT_EQ(gdal::max(firstBand, thirdBand, -1, secondBand)
+                      .ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_NEAR(adfMinMax[0], std::max(FIRST, std::max(SECOND, THIRD)),
+                    1e-14);
+
+        EXPECT_EQ(gdal::max(thirdBand, firstBand, 100, secondBand)
+                      .ComputeRasterMinMax(false, adfMinMax),
+                  CE_None);
+        EXPECT_EQ(adfMinMax[0], 100);
 
         EXPECT_EQ(gdal::mean(firstBand, thirdBand, secondBand)
                       .ComputeRasterMinMax(false, adfMinMax),

--- a/autotest/gcore/band_arithmetic.py
+++ b/autotest/gcore/band_arithmetic.py
@@ -55,7 +55,7 @@ def test_band_arithmetic_add_constant_to_band():
 def test_band_arithmetic_add_error():
     ds1 = gdal.GetDriverByName("MEM").Create("", 1, 1)
     ds2 = gdal.GetDriverByName("MEM").Create("", 2, 1)
-    with pytest.raises(Exception, match="Both bands do not have the same dimensions"):
+    with pytest.raises(Exception, match="Bands do not have the same dimensions"):
         ds1.GetRasterBand(1) + ds2.GetRasterBand(1)
 
 
@@ -97,7 +97,7 @@ def test_band_arithmetic_sub_constant_to_band():
 def test_band_arithmetic_sub_error():
     ds1 = gdal.GetDriverByName("MEM").Create("", 1, 1)
     ds2 = gdal.GetDriverByName("MEM").Create("", 2, 1)
-    with pytest.raises(Exception, match="Both bands do not have the same dimensions"):
+    with pytest.raises(Exception, match="Bands do not have the same dimensions"):
         ds1.GetRasterBand(1) - ds2.GetRasterBand(1)
 
 
@@ -139,7 +139,7 @@ def test_band_arithmetic_mul_constant_to_band():
 def test_band_arithmetic_mul_error():
     ds1 = gdal.GetDriverByName("MEM").Create("", 1, 1)
     ds2 = gdal.GetDriverByName("MEM").Create("", 2, 1)
-    with pytest.raises(Exception, match="Both bands do not have the same dimensions"):
+    with pytest.raises(Exception, match="Bands do not have the same dimensions"):
         ds1.GetRasterBand(1) * ds2.GetRasterBand(1)
 
 
@@ -181,7 +181,7 @@ def test_band_arithmetic_div_constant_to_band():
 def test_band_arithmetic_div_error():
     ds1 = gdal.GetDriverByName("MEM").Create("", 1, 1)
     ds2 = gdal.GetDriverByName("MEM").Create("", 2, 1)
-    with pytest.raises(Exception, match="Both bands do not have the same dimensions"):
+    with pytest.raises(Exception, match="Bands do not have the same dimensions"):
         ds1.GetRasterBand(1) / ds2.GetRasterBand(1)
 
 
@@ -276,7 +276,7 @@ def test_band_arithmetic_minimum():
 def test_band_arithmetic_minimum_error():
     ds1 = gdal.GetDriverByName("MEM").Create("", 1, 1)
     ds2 = gdal.GetDriverByName("MEM").Create("", 2, 1)
-    with pytest.raises(Exception, match="Both bands do not have the same dimensions"):
+    with pytest.raises(Exception, match="Bands do not have the same dimensions"):
         gdal.Band.minimum(ds1.GetRasterBand(1), ds2.GetRasterBand(1))
 
 
@@ -296,7 +296,7 @@ def test_band_arithmetic_maximum():
 def test_band_arithmetic_maximum_error():
     ds1 = gdal.GetDriverByName("MEM").Create("", 1, 1)
     ds2 = gdal.GetDriverByName("MEM").Create("", 2, 1)
-    with pytest.raises(Exception, match="Both bands do not have the same dimensions"):
+    with pytest.raises(Exception, match="Bands do not have the same dimensions"):
         gdal.Band.maximum(ds1.GetRasterBand(1), ds2.GetRasterBand(1))
 
 

--- a/autotest/gcore/band_arithmetic.py
+++ b/autotest/gcore/band_arithmetic.py
@@ -270,7 +270,7 @@ def test_band_arithmetic_minimum():
         R.Fill(2)
         G = ds.GetRasterBand(2)
         G.Fill(4)
-        return gdal.Band.minimum(R, G)
+        return gdal.minimum(R, G)
 
     res = get()
     assert res.DataType == gdal.GDT_Byte
@@ -284,7 +284,7 @@ def test_band_arithmetic_minimum_with_constant():
         R.Fill(2)
         G = ds.GetRasterBand(2)
         G.Fill(4)
-        return gdal.Band.minimum(R, 3, G)
+        return gdal.minimum(R, 3, G)
 
     res = get()
     assert res.DataType == gdal.GDT_Byte
@@ -298,7 +298,7 @@ def test_band_arithmetic_minimum_with_constant_bis():
         R.Fill(2)
         G = ds.GetRasterBand(2)
         G.Fill(4)
-        return gdal.Band.minimum(R, 1.5, G)
+        return gdal.minimum(R, 1.5, G)
 
     res = get()
     assert res.DataType == gdal.GDT_Float32
@@ -309,13 +309,13 @@ def test_band_arithmetic_minimum_error():
     ds1 = gdal.GetDriverByName("MEM").Create("", 1, 1)
     ds2 = gdal.GetDriverByName("MEM").Create("", 2, 1)
     with pytest.raises(Exception, match="Bands do not have the same dimensions"):
-        gdal.Band.minimum(ds1.GetRasterBand(1), ds2.GetRasterBand(1))
+        gdal.minimum(ds1.GetRasterBand(1), ds2.GetRasterBand(1))
 
     with pytest.raises(
         Exception,
         match=r"At least one argument should be a band \(or convertible to a band\)",
     ):
-        gdal.Band.minimum()
+        gdal.minimum()
 
 
 def test_band_arithmetic_maximum():
@@ -325,7 +325,7 @@ def test_band_arithmetic_maximum():
         R.Fill(2)
         G = ds.GetRasterBand(2)
         G.Fill(4)
-        return gdal.Band.maximum(R, G)
+        return gdal.maximum(R, G)
 
     res = get()
     assert res.DataType == gdal.GDT_Byte
@@ -339,7 +339,7 @@ def test_band_arithmetic_maximum_with_constant():
         R.Fill(2)
         G = ds.GetRasterBand(2)
         G.Fill(4)
-        return gdal.Band.maximum(R, 3, G)
+        return gdal.maximum(R, 3, G)
 
     res = get()
     assert res.DataType == gdal.GDT_Byte
@@ -353,7 +353,7 @@ def test_band_arithmetic_maximum_with_constant_bis():
         R.Fill(2)
         G = ds.GetRasterBand(2)
         G.Fill(4)
-        return gdal.Band.maximum(R, 4.56789012345, G)
+        return gdal.maximum(R, 4.56789012345, G)
 
     res = get()
     assert res.DataType == gdal.GDT_Float64
@@ -364,13 +364,13 @@ def test_band_arithmetic_maximum_error():
     ds1 = gdal.GetDriverByName("MEM").Create("", 1, 1)
     ds2 = gdal.GetDriverByName("MEM").Create("", 2, 1)
     with pytest.raises(Exception, match="Bands do not have the same dimensions"):
-        gdal.Band.maximum(ds1.GetRasterBand(1), ds2.GetRasterBand(1))
+        gdal.maximum(ds1.GetRasterBand(1), ds2.GetRasterBand(1))
 
     with pytest.raises(
         Exception,
         match=r"At least one argument should be a band \(or convertible to a band\)",
     ):
-        gdal.Band.maximum()
+        gdal.maximum()
 
 
 def test_band_arithmetic_rgb_to_greylevel_vrt(tmp_vsimem):
@@ -393,7 +393,7 @@ def test_band_arithmetic_mean():
         R.Fill(2)
         G = ds.GetRasterBand(2)
         G.Fill(4)
-        return gdal.Band.mean(R, G)
+        return gdal.mean(R, G)
 
     res = get()
     assert res.ComputeRasterMinMax(False) == (3, 3)
@@ -403,13 +403,13 @@ def test_band_arithmetic_mean_error():
     ds1 = gdal.GetDriverByName("MEM").Create("", 1, 1)
     ds2 = gdal.GetDriverByName("MEM").Create("", 2, 1)
     with pytest.raises(Exception, match="Bands do not have the same dimensions"):
-        gdal.Band.mean(ds1.GetRasterBand(1), ds2.GetRasterBand(1))
+        gdal.mean(ds1.GetRasterBand(1), ds2.GetRasterBand(1))
 
     with pytest.raises(
         Exception,
         match="At least one band should be passed",
     ):
-        gdal.Band.mean()
+        gdal.mean()
 
 
 def test_band_arithmetic_add_nodata():
@@ -686,22 +686,22 @@ def test_band_arithmetic_ternary():
     elseBand = ds.GetRasterBand(3)
     elseBand.Fill(3)
 
-    assert gdal.Band.where(cond, then, elseBand).DataType == gdal.GDT_Byte
-    assert gdal.Band.where(cond, then, elseBand).ComputeRasterMinMax(False)[0] == 2
+    assert gdal.where(cond, then, elseBand).DataType == gdal.GDT_Byte
+    assert gdal.where(cond, then, elseBand).ComputeRasterMinMax(False)[0] == 2
 
-    assert gdal.Band.where(cond, 10, elseBand).DataType == gdal.GDT_Byte
-    assert gdal.Band.where(cond, 10, elseBand).ComputeRasterMinMax(False)[0] == 10
+    assert gdal.where(cond, 10, elseBand).DataType == gdal.GDT_Byte
+    assert gdal.where(cond, 10, elseBand).ComputeRasterMinMax(False)[0] == 10
 
-    assert gdal.Band.where(cond, 10, 11).ComputeRasterMinMax(False)[0] == 10
+    assert gdal.where(cond, 10, 11).ComputeRasterMinMax(False)[0] == 10
 
     cond.Fill(0)
-    assert gdal.Band.where(cond, then, elseBand).DataType == gdal.GDT_Byte
-    assert gdal.Band.where(cond, then, elseBand).ComputeRasterMinMax(False)[0] == 3
+    assert gdal.where(cond, then, elseBand).DataType == gdal.GDT_Byte
+    assert gdal.where(cond, then, elseBand).ComputeRasterMinMax(False)[0] == 3
 
-    assert gdal.Band.where(cond, then, 11).DataType == gdal.GDT_Byte
-    assert gdal.Band.where(cond, then, 11).ComputeRasterMinMax(False)[0] == 11
+    assert gdal.where(cond, then, 11).DataType == gdal.GDT_Byte
+    assert gdal.where(cond, then, 11).ComputeRasterMinMax(False)[0] == 11
 
-    assert gdal.Band.where(cond, 10, 11).ComputeRasterMinMax(False)[0] == 11
+    assert gdal.where(cond, 10, 11).ComputeRasterMinMax(False)[0] == 11
 
 
 def test_band_arithmetic_ternary_error():
@@ -712,10 +712,6 @@ def test_band_arithmetic_ternary_error():
     ds1 = gdal.GetDriverByName("MEM").Create("", 1, 1)
     ds2 = gdal.GetDriverByName("MEM").Create("", 2, 1)
     with pytest.raises(Exception, match="Bands do not have the same dimensions"):
-        gdal.Band.where(
-            ds1.GetRasterBand(1), ds1.GetRasterBand(1), ds2.GetRasterBand(1)
-        )
+        gdal.where(ds1.GetRasterBand(1), ds1.GetRasterBand(1), ds2.GetRasterBand(1))
     with pytest.raises(Exception, match="Bands do not have the same dimensions"):
-        gdal.Band.where(
-            ds1.GetRasterBand(1), ds2.GetRasterBand(1), ds1.GetRasterBand(1)
-        )
+        gdal.where(ds1.GetRasterBand(1), ds2.GetRasterBand(1), ds1.GetRasterBand(1))

--- a/autotest/gcore/band_arithmetic.py
+++ b/autotest/gcore/band_arithmetic.py
@@ -489,3 +489,119 @@ def test_band_arithmetic_add_nodata_not_same_value_nan():
 
     res = get()
     assert res.GetNoDataValue() is None
+
+
+def test_band_arithmetic_greater():
+
+    if not gdaltest.gdal_has_vrt_expression_dialect("muparser"):
+        pytest.skip("Expression dialect muparser is not available")
+
+    ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 2)
+    R = ds.GetRasterBand(1)
+    R.Fill(1)
+    G = ds.GetRasterBand(2)
+    G.Fill(2)
+
+    assert (R > G).ComputeRasterMinMax(False)[0] == 0
+    assert (R > R).ComputeRasterMinMax(False)[0] == 0
+    assert (G > R).ComputeRasterMinMax(False)[0] == 1
+    assert (1 > G).ComputeRasterMinMax(False)[0] == 0
+    assert (R > 1).ComputeRasterMinMax(False)[0] == 0
+    assert (R > 0).ComputeRasterMinMax(False)[0] == 1
+
+
+def test_band_arithmetic_greater_or_equal():
+
+    if not gdaltest.gdal_has_vrt_expression_dialect("muparser"):
+        pytest.skip("Expression dialect muparser is not available")
+
+    ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 2)
+    R = ds.GetRasterBand(1)
+    R.Fill(1)
+    G = ds.GetRasterBand(2)
+    G.Fill(2)
+
+    assert (R >= G).ComputeRasterMinMax(False)[0] == 0
+    assert (R >= R).ComputeRasterMinMax(False)[0] == 1
+    assert (G >= R).ComputeRasterMinMax(False)[0] == 1
+    assert (1 >= R).ComputeRasterMinMax(False)[0] == 1
+    assert (0 >= R).ComputeRasterMinMax(False)[0] == 0
+    assert (R >= 1).ComputeRasterMinMax(False)[0] == 1
+    assert (R >= 2).ComputeRasterMinMax(False)[0] == 0
+
+
+def test_band_arithmetic_lesser():
+
+    if not gdaltest.gdal_has_vrt_expression_dialect("muparser"):
+        pytest.skip("Expression dialect muparser is not available")
+
+    ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 2)
+    R = ds.GetRasterBand(1)
+    R.Fill(1)
+    G = ds.GetRasterBand(2)
+    G.Fill(2)
+
+    assert (R < G).ComputeRasterMinMax(False)[0] == 1
+    assert (R < R).ComputeRasterMinMax(False)[0] == 0
+    assert (G < R).ComputeRasterMinMax(False)[0] == 0
+    assert (1 < G).ComputeRasterMinMax(False)[0] == 1
+    assert (R < 1).ComputeRasterMinMax(False)[0] == 0
+    assert (R < 2).ComputeRasterMinMax(False)[0] == 1
+
+
+def test_band_arithmetic_lesser_or_equal():
+
+    if not gdaltest.gdal_has_vrt_expression_dialect("muparser"):
+        pytest.skip("Expression dialect muparser is not available")
+
+    ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 2)
+    R = ds.GetRasterBand(1)
+    R.Fill(1)
+    G = ds.GetRasterBand(2)
+    G.Fill(2)
+
+    assert (R <= G).ComputeRasterMinMax(False)[0] == 1
+    assert (R >= R).ComputeRasterMinMax(False)[0] == 1
+    assert (G <= R).ComputeRasterMinMax(False)[0] == 0
+    assert (1 <= R).ComputeRasterMinMax(False)[0] == 1
+    assert (2 <= R).ComputeRasterMinMax(False)[0] == 0
+    assert (R <= 1).ComputeRasterMinMax(False)[0] == 1
+    assert (R <= 0).ComputeRasterMinMax(False)[0] == 0
+
+
+def test_band_arithmetic_equal():
+
+    if not gdaltest.gdal_has_vrt_expression_dialect("muparser"):
+        pytest.skip("Expression dialect muparser is not available")
+
+    ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 2)
+    R = ds.GetRasterBand(1)
+    R.Fill(1)
+    G = ds.GetRasterBand(2)
+    G.Fill(2)
+
+    assert (R == G).ComputeRasterMinMax(False)[0] == 0
+    assert (R == R).ComputeRasterMinMax(False)[0] == 1
+    assert (1 == R).ComputeRasterMinMax(False)[0] == 1
+    assert (0 == R).ComputeRasterMinMax(False)[0] == 0
+    assert (R == 1).ComputeRasterMinMax(False)[0] == 1
+    assert (R == 0).ComputeRasterMinMax(False)[0] == 0
+
+
+def test_band_arithmetic_not_equal():
+
+    if not gdaltest.gdal_has_vrt_expression_dialect("muparser"):
+        pytest.skip("Expression dialect muparser is not available")
+
+    ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 2)
+    R = ds.GetRasterBand(1)
+    R.Fill(1)
+    G = ds.GetRasterBand(2)
+    G.Fill(2)
+
+    assert (R != G).ComputeRasterMinMax(False)[0] == 1
+    assert (R != R).ComputeRasterMinMax(False)[0] == 0
+    assert (1 != R).ComputeRasterMinMax(False)[0] == 0
+    assert (0 != R).ComputeRasterMinMax(False)[0] == 1
+    assert (R != 1).ComputeRasterMinMax(False)[0] == 0
+    assert (R != 0).ComputeRasterMinMax(False)[0] == 1

--- a/autotest/gcore/band_arithmetic.py
+++ b/autotest/gcore/band_arithmetic.py
@@ -298,3 +298,16 @@ def test_band_arithmetic_maximum_error():
     ds2 = gdal.GetDriverByName("MEM").Create("", 2, 1)
     with pytest.raises(Exception, match="Both bands do not have the same dimensions"):
         gdal.Band.maximum(ds1.GetRasterBand(1), ds2.GetRasterBand(1))
+
+
+def test_band_arithmetic_rgb_to_greylevel_vrt(tmp_vsimem):
+
+    with gdal.Open("data/rgbsmall.tif") as ds:
+        R = ds.GetRasterBand(1)
+        G = ds.GetRasterBand(2)
+        B = ds.GetRasterBand(3)
+        greylevel = (0.299 * R + 0.587 * G + 0.114 * B).astype(gdal.GDT_Byte)
+        gdal.GetDriverByName("VRT").CreateCopy(tmp_vsimem / "out.vrt", greylevel)
+
+    ds = gdal.Open(tmp_vsimem / "out.vrt")
+    assert ds.GetRasterBand(1).Checksum() == 21466

--- a/autotest/gcore/band_arithmetic.py
+++ b/autotest/gcore/band_arithmetic.py
@@ -510,6 +510,17 @@ def test_band_arithmetic_greater():
     assert (R > 0).ComputeRasterMinMax(False)[0] == 1
 
 
+def test_band_arithmetic_greater_error():
+
+    if not gdaltest.gdal_has_vrt_expression_dialect("muparser"):
+        pytest.skip("Expression dialect muparser is not available")
+
+    ds1 = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    ds2 = gdal.GetDriverByName("MEM").Create("", 2, 1)
+    with pytest.raises(Exception, match="Bands do not have the same dimensions"):
+        ds1.GetRasterBand(1) > ds2.GetRasterBand(1)
+
+
 def test_band_arithmetic_greater_or_equal():
 
     if not gdaltest.gdal_has_vrt_expression_dialect("muparser"):
@@ -530,6 +541,17 @@ def test_band_arithmetic_greater_or_equal():
     assert (R >= 2).ComputeRasterMinMax(False)[0] == 0
 
 
+def test_band_arithmetic_greater_or_equal_error():
+
+    if not gdaltest.gdal_has_vrt_expression_dialect("muparser"):
+        pytest.skip("Expression dialect muparser is not available")
+
+    ds1 = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    ds2 = gdal.GetDriverByName("MEM").Create("", 2, 1)
+    with pytest.raises(Exception, match="Bands do not have the same dimensions"):
+        ds1.GetRasterBand(1) >= ds2.GetRasterBand(1)
+
+
 def test_band_arithmetic_lesser():
 
     if not gdaltest.gdal_has_vrt_expression_dialect("muparser"):
@@ -547,6 +569,17 @@ def test_band_arithmetic_lesser():
     assert (1 < G).ComputeRasterMinMax(False)[0] == 1
     assert (R < 1).ComputeRasterMinMax(False)[0] == 0
     assert (R < 2).ComputeRasterMinMax(False)[0] == 1
+
+
+def test_band_arithmetic_lesser_error():
+
+    if not gdaltest.gdal_has_vrt_expression_dialect("muparser"):
+        pytest.skip("Expression dialect muparser is not available")
+
+    ds1 = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    ds2 = gdal.GetDriverByName("MEM").Create("", 2, 1)
+    with pytest.raises(Exception, match="Bands do not have the same dimensions"):
+        ds1.GetRasterBand(1) < ds2.GetRasterBand(1)
 
 
 def test_band_arithmetic_lesser_or_equal():
@@ -569,6 +602,17 @@ def test_band_arithmetic_lesser_or_equal():
     assert (R <= 0).ComputeRasterMinMax(False)[0] == 0
 
 
+def test_band_arithmetic_lesser_or_equal_error():
+
+    if not gdaltest.gdal_has_vrt_expression_dialect("muparser"):
+        pytest.skip("Expression dialect muparser is not available")
+
+    ds1 = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    ds2 = gdal.GetDriverByName("MEM").Create("", 2, 1)
+    with pytest.raises(Exception, match="Bands do not have the same dimensions"):
+        ds1.GetRasterBand(1) <= ds2.GetRasterBand(1)
+
+
 def test_band_arithmetic_equal():
 
     if not gdaltest.gdal_has_vrt_expression_dialect("muparser"):
@@ -588,6 +632,17 @@ def test_band_arithmetic_equal():
     assert (R == 0).ComputeRasterMinMax(False)[0] == 0
 
 
+def test_band_arithmetic_equal_error():
+
+    if not gdaltest.gdal_has_vrt_expression_dialect("muparser"):
+        pytest.skip("Expression dialect muparser is not available")
+
+    ds1 = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    ds2 = gdal.GetDriverByName("MEM").Create("", 2, 1)
+    with pytest.raises(Exception, match="Bands do not have the same dimensions"):
+        ds1.GetRasterBand(1) == ds2.GetRasterBand(1)
+
+
 def test_band_arithmetic_not_equal():
 
     if not gdaltest.gdal_has_vrt_expression_dialect("muparser"):
@@ -605,3 +660,62 @@ def test_band_arithmetic_not_equal():
     assert (0 != R).ComputeRasterMinMax(False)[0] == 1
     assert (R != 1).ComputeRasterMinMax(False)[0] == 0
     assert (R != 0).ComputeRasterMinMax(False)[0] == 1
+
+
+def test_band_arithmetic_not_equal_error():
+
+    if not gdaltest.gdal_has_vrt_expression_dialect("muparser"):
+        pytest.skip("Expression dialect muparser is not available")
+
+    ds1 = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    ds2 = gdal.GetDriverByName("MEM").Create("", 2, 1)
+    with pytest.raises(Exception, match="Bands do not have the same dimensions"):
+        ds1.GetRasterBand(1) != ds2.GetRasterBand(1)
+
+
+def test_band_arithmetic_ternary():
+
+    if not gdaltest.gdal_has_vrt_expression_dialect("muparser"):
+        pytest.skip("Expression dialect muparser is not available")
+
+    ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 3)
+    cond = ds.GetRasterBand(1)
+    cond.Fill(1)
+    then = ds.GetRasterBand(2)
+    then.Fill(2)
+    elseBand = ds.GetRasterBand(3)
+    elseBand.Fill(3)
+
+    assert gdal.Band.where(cond, then, elseBand).DataType == gdal.GDT_Byte
+    assert gdal.Band.where(cond, then, elseBand).ComputeRasterMinMax(False)[0] == 2
+
+    assert gdal.Band.where(cond, 10, elseBand).DataType == gdal.GDT_Byte
+    assert gdal.Band.where(cond, 10, elseBand).ComputeRasterMinMax(False)[0] == 10
+
+    assert gdal.Band.where(cond, 10, 11).ComputeRasterMinMax(False)[0] == 10
+
+    cond.Fill(0)
+    assert gdal.Band.where(cond, then, elseBand).DataType == gdal.GDT_Byte
+    assert gdal.Band.where(cond, then, elseBand).ComputeRasterMinMax(False)[0] == 3
+
+    assert gdal.Band.where(cond, then, 11).DataType == gdal.GDT_Byte
+    assert gdal.Band.where(cond, then, 11).ComputeRasterMinMax(False)[0] == 11
+
+    assert gdal.Band.where(cond, 10, 11).ComputeRasterMinMax(False)[0] == 11
+
+
+def test_band_arithmetic_ternary_error():
+
+    if not gdaltest.gdal_has_vrt_expression_dialect("muparser"):
+        pytest.skip("Expression dialect muparser is not available")
+
+    ds1 = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    ds2 = gdal.GetDriverByName("MEM").Create("", 2, 1)
+    with pytest.raises(Exception, match="Bands do not have the same dimensions"):
+        gdal.Band.where(
+            ds1.GetRasterBand(1), ds1.GetRasterBand(1), ds2.GetRasterBand(1)
+        )
+    with pytest.raises(Exception, match="Bands do not have the same dimensions"):
+        gdal.Band.where(
+            ds1.GetRasterBand(1), ds2.GetRasterBand(1), ds1.GetRasterBand(1)
+        )

--- a/autotest/gcore/band_arithmetic.py
+++ b/autotest/gcore/band_arithmetic.py
@@ -270,7 +270,36 @@ def test_band_arithmetic_minimum():
         return gdal.Band.minimum(R, G)
 
     res = get()
+    assert res.DataType == gdal.GDT_Byte
     assert res.ComputeRasterMinMax(False) == (2, 2)
+
+
+def test_band_arithmetic_minimum_with_constant():
+    def get():
+        ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 3)
+        R = ds.GetRasterBand(1)
+        R.Fill(2)
+        G = ds.GetRasterBand(2)
+        G.Fill(4)
+        return gdal.Band.minimum(R, 3, G)
+
+    res = get()
+    assert res.DataType == gdal.GDT_Byte
+    assert res.ComputeRasterMinMax(False) == (2, 2)
+
+
+def test_band_arithmetic_minimum_with_constant_bis():
+    def get():
+        ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 3)
+        R = ds.GetRasterBand(1)
+        R.Fill(2)
+        G = ds.GetRasterBand(2)
+        G.Fill(4)
+        return gdal.Band.minimum(R, 1.5, G)
+
+    res = get()
+    assert res.DataType == gdal.GDT_Float32
+    assert res.ComputeRasterMinMax(False) == (1.5, 1.5)
 
 
 def test_band_arithmetic_minimum_error():
@@ -278,6 +307,12 @@ def test_band_arithmetic_minimum_error():
     ds2 = gdal.GetDriverByName("MEM").Create("", 2, 1)
     with pytest.raises(Exception, match="Bands do not have the same dimensions"):
         gdal.Band.minimum(ds1.GetRasterBand(1), ds2.GetRasterBand(1))
+
+    with pytest.raises(
+        Exception,
+        match=r"At least one argument should be a band \(or convertible to a band\)",
+    ):
+        gdal.Band.minimum()
 
 
 def test_band_arithmetic_maximum():
@@ -290,7 +325,36 @@ def test_band_arithmetic_maximum():
         return gdal.Band.maximum(R, G)
 
     res = get()
+    assert res.DataType == gdal.GDT_Byte
     assert res.ComputeRasterMinMax(False) == (4, 4)
+
+
+def test_band_arithmetic_maximum_with_constant():
+    def get():
+        ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 3)
+        R = ds.GetRasterBand(1)
+        R.Fill(2)
+        G = ds.GetRasterBand(2)
+        G.Fill(4)
+        return gdal.Band.maximum(R, 3, G)
+
+    res = get()
+    assert res.DataType == gdal.GDT_Byte
+    assert res.ComputeRasterMinMax(False) == (4, 4)
+
+
+def test_band_arithmetic_maximum_with_constant_bis():
+    def get():
+        ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 3)
+        R = ds.GetRasterBand(1)
+        R.Fill(2)
+        G = ds.GetRasterBand(2)
+        G.Fill(4)
+        return gdal.Band.maximum(R, 4.56789012345, G)
+
+    res = get()
+    assert res.DataType == gdal.GDT_Float64
+    assert res.ComputeRasterMinMax(False) == (4.56789012345, 4.56789012345)
 
 
 def test_band_arithmetic_maximum_error():
@@ -298,6 +362,12 @@ def test_band_arithmetic_maximum_error():
     ds2 = gdal.GetDriverByName("MEM").Create("", 2, 1)
     with pytest.raises(Exception, match="Bands do not have the same dimensions"):
         gdal.Band.maximum(ds1.GetRasterBand(1), ds2.GetRasterBand(1))
+
+    with pytest.raises(
+        Exception,
+        match=r"At least one argument should be a band \(or convertible to a band\)",
+    ):
+        gdal.Band.maximum()
 
 
 def test_band_arithmetic_rgb_to_greylevel_vrt(tmp_vsimem):

--- a/autotest/gcore/band_arithmetic.py
+++ b/autotest/gcore/band_arithmetic.py
@@ -311,3 +311,29 @@ def test_band_arithmetic_rgb_to_greylevel_vrt(tmp_vsimem):
 
     ds = gdal.Open(tmp_vsimem / "out.vrt")
     assert ds.GetRasterBand(1).Checksum() == 21466
+
+
+def test_band_arithmetic_mean():
+    def get():
+        ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 3)
+        R = ds.GetRasterBand(1)
+        R.Fill(2)
+        G = ds.GetRasterBand(2)
+        G.Fill(4)
+        return gdal.Band.mean(R, G)
+
+    res = get()
+    assert res.ComputeRasterMinMax(False) == (3, 3)
+
+
+def test_band_arithmetic_mean_error():
+    ds1 = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    ds2 = gdal.GetDriverByName("MEM").Create("", 2, 1)
+    with pytest.raises(Exception, match="Bands do not have the same dimensions"):
+        gdal.Band.mean(ds1.GetRasterBand(1), ds2.GetRasterBand(1))
+
+    with pytest.raises(
+        Exception,
+        match="At least one band should be passed",
+    ):
+        gdal.Band.mean()

--- a/autotest/gcore/band_arithmetic.py
+++ b/autotest/gcore/band_arithmetic.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env pytest
+###############################################################################
+#
+# Project:  GDAL/OGR Test Suite
+# Purpose:  Test Band arithmetic
+# Author:   Even Rouault <even.rouault@spatialys.com>
+#
+###############################################################################
+# Copyright (c) 2025, Even Rouault <even.rouault@spatialys.com>
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+
+import gdaltest
+import pytest
+
+from osgeo import gdal
+
+
+def test_band_arithmetic_add():
+    def get():
+        ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 3)
+        R = ds.GetRasterBand(1)
+        R.Fill(1)
+        G = ds.GetRasterBand(2)
+        G.Fill(2)
+        return R + G
+
+    res = get()
+    assert res.ComputeRasterMinMax(False) == (3, 3)
+
+
+def test_band_arithmetic_add_constant():
+    def get():
+        ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 1)
+        R = ds.GetRasterBand(1)
+        R.Fill(1)
+        return R + 2
+
+    res = get()
+    assert res.ComputeRasterMinMax(False) == (3, 3)
+
+
+def test_band_arithmetic_add_constant_to_band():
+    def get():
+        ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 1)
+        R = ds.GetRasterBand(1)
+        R.Fill(1)
+        return 2 + R
+
+    res = get()
+    assert res.ComputeRasterMinMax(False) == (3, 3)
+
+
+def test_band_arithmetic_add_error():
+    ds1 = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    ds2 = gdal.GetDriverByName("MEM").Create("", 2, 1)
+    with pytest.raises(Exception, match="Both bands do not have the same dimensions"):
+        ds1.GetRasterBand(1) + ds2.GetRasterBand(1)
+
+
+def test_band_arithmetic_sub():
+    def get():
+        ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 3)
+        R = ds.GetRasterBand(1)
+        R.Fill(1)
+        G = ds.GetRasterBand(2)
+        G.Fill(2)
+        return R - G
+
+    res = get()
+    assert res.ComputeRasterMinMax(False) == (-1, -1)
+
+
+def test_band_arithmetic_sub_constant():
+    def get():
+        ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 1)
+        R = ds.GetRasterBand(1)
+        R.Fill(1)
+        return R - 2
+
+    res = get()
+    assert res.ComputeRasterMinMax(False) == (-1, -1)
+
+
+def test_band_arithmetic_sub_constant_to_band():
+    def get():
+        ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 1)
+        R = ds.GetRasterBand(1)
+        R.Fill(1)
+        return 3 - R
+
+    res = get()
+    assert res.ComputeRasterMinMax(False) == (2, 2)
+
+
+def test_band_arithmetic_sub_error():
+    ds1 = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    ds2 = gdal.GetDriverByName("MEM").Create("", 2, 1)
+    with pytest.raises(Exception, match="Both bands do not have the same dimensions"):
+        ds1.GetRasterBand(1) - ds2.GetRasterBand(1)
+
+
+def test_band_arithmetic_mul():
+    def get():
+        ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 3)
+        R = ds.GetRasterBand(1)
+        R.Fill(2)
+        G = ds.GetRasterBand(2)
+        G.Fill(3)
+        return R * G
+
+    res = get()
+    assert res.ComputeRasterMinMax(False) == (6, 6)
+
+
+def test_band_arithmetic_mul_constant():
+    def get():
+        ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 1)
+        R = ds.GetRasterBand(1)
+        R.Fill(2)
+        return R * 3
+
+    res = get()
+    assert res.ComputeRasterMinMax(False) == (6, 6)
+
+
+def test_band_arithmetic_mul_constant_to_band():
+    def get():
+        ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 1)
+        R = ds.GetRasterBand(1)
+        R.Fill(2)
+        return 3 * R
+
+    res = get()
+    assert res.ComputeRasterMinMax(False) == (6, 6)
+
+
+def test_band_arithmetic_mul_error():
+    ds1 = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    ds2 = gdal.GetDriverByName("MEM").Create("", 2, 1)
+    with pytest.raises(Exception, match="Both bands do not have the same dimensions"):
+        ds1.GetRasterBand(1) * ds2.GetRasterBand(1)
+
+
+def test_band_arithmetic_div():
+    def get():
+        ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 3)
+        R = ds.GetRasterBand(1)
+        R.Fill(2)
+        G = ds.GetRasterBand(2)
+        G.Fill(4)
+        return R / G
+
+    res = get()
+    assert res.ComputeRasterMinMax(False) == (0.5, 0.5)
+
+
+def test_band_arithmetic_div_constant():
+    def get():
+        ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 1)
+        R = ds.GetRasterBand(1)
+        R.Fill(4)
+        return R / 2
+
+    res = get()
+    assert res.ComputeRasterMinMax(False) == (2, 2)
+
+
+def test_band_arithmetic_div_constant_to_band():
+    def get():
+        ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 1)
+        R = ds.GetRasterBand(1)
+        R.Fill(4)
+        return 2 / R
+
+    res = get()
+    assert res.ComputeRasterMinMax(False) == (0.5, 0.5)
+
+
+def test_band_arithmetic_div_error():
+    ds1 = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    ds2 = gdal.GetDriverByName("MEM").Create("", 2, 1)
+    with pytest.raises(Exception, match="Both bands do not have the same dimensions"):
+        ds1.GetRasterBand(1) / ds2.GetRasterBand(1)
+
+
+def test_band_arithmetic_astype():
+
+    ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    assert ds.GetRasterBand(1).astype(gdal.GDT_Float64).DataType == gdal.GDT_Float64
+
+    with pytest.raises(
+        Exception, match=r"GDALRasterBandAsDataType\(GDT_Unknown\) not supported"
+    ):
+        ds.GetRasterBand(1).astype(gdal.GDT_Unknown)
+
+    with pytest.raises(Exception, match=r"Invalid dt value"):
+        assert ds.GetRasterBand(1).astype("wrong")
+
+
+def test_band_arithmetic_astype_numpy():
+
+    np = pytest.importorskip("numpy")
+    gdaltest.importorskip_gdal_array()
+
+    ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    assert ds.GetRasterBand(1).astype(np.float64).DataType == gdal.GDT_Float64
+
+
+def test_band_arithmetic_rgb_to_greylevel_subfunc():
+    def greylevel():
+        ds = gdal.Open("data/rgbsmall.tif")
+        R = ds.GetRasterBand(1)
+        G = ds.GetRasterBand(2)
+        B = ds.GetRasterBand(3)
+        return (0.299 * R + 0.587 * G + 0.114 * B).astype(gdal.GDT_Byte)
+
+    assert greylevel().Checksum() == 21466
+
+
+def test_band_arithmetic_rgb_to_greylevel_with():
+
+    with gdal.Open("data/rgbsmall.tif") as ds:
+        R = ds.GetRasterBand(1)
+        G = ds.GetRasterBand(2)
+        B = ds.GetRasterBand(3)
+        greylevel = (0.299 * R + 0.587 * G + 0.114 * B).astype(gdal.GDT_Byte)
+        assert greylevel.Checksum() == 21466
+
+
+def test_band_arithmetic_rgb_to_greylevel_with_error():
+
+    with gdal.Open("data/rgbsmall.tif") as ds:
+        R = ds.GetRasterBand(1)
+        G = ds.GetRasterBand(2)
+        B = ds.GetRasterBand(3)
+        greylevel = (0.299 * R + 0.587 * G + 0.114 * B).astype(gdal.GDT_Byte)
+
+    with pytest.raises(Exception):
+        greylevel.Checksum()
+
+
+def test_band_arithmetic_rgb_to_greylevel_using_numpy_array():
+
+    pytest.importorskip("numpy")
+    gdaltest.importorskip_gdal_array()
+
+    def greylevel():
+        ds = gdal.Open("data/rgbsmall.tif")
+        R = ds.GetRasterBand(1)
+        G = ds.GetRasterBand(2).ReadAsArray()
+        B = ds.GetRasterBand(3).ReadAsArray()
+        return (0.299 * R + 0.587 * G + 0.114 * B).astype(gdal.GDT_Byte)
+
+    assert greylevel().Checksum() == 21466
+
+    ds = gdal.Open("data/rgbsmall.tif")
+    with pytest.raises(Exception, match="numpy array must hold a single band"):
+        ds.GetRasterBand(1) + ds.ReadAsArray()
+
+
+def test_band_arithmetic_minimum():
+    def get():
+        ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 3)
+        R = ds.GetRasterBand(1)
+        R.Fill(2)
+        G = ds.GetRasterBand(2)
+        G.Fill(4)
+        return gdal.Band.minimum(R, G)
+
+    res = get()
+    assert res.ComputeRasterMinMax(False) == (2, 2)
+
+
+def test_band_arithmetic_minimum_error():
+    ds1 = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    ds2 = gdal.GetDriverByName("MEM").Create("", 2, 1)
+    with pytest.raises(Exception, match="Both bands do not have the same dimensions"):
+        gdal.Band.minimum(ds1.GetRasterBand(1), ds2.GetRasterBand(1))
+
+
+def test_band_arithmetic_maximum():
+    def get():
+        ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 3)
+        R = ds.GetRasterBand(1)
+        R.Fill(2)
+        G = ds.GetRasterBand(2)
+        G.Fill(4)
+        return gdal.Band.maximum(R, G)
+
+    res = get()
+    assert res.ComputeRasterMinMax(False) == (4, 4)
+
+
+def test_band_arithmetic_maximum_error():
+    ds1 = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    ds2 = gdal.GetDriverByName("MEM").Create("", 2, 1)
+    with pytest.raises(Exception, match="Both bands do not have the same dimensions"):
+        gdal.Band.maximum(ds1.GetRasterBand(1), ds2.GetRasterBand(1))

--- a/autotest/gcore/basic_test.py
+++ b/autotest/gcore/basic_test.py
@@ -1033,3 +1033,12 @@ def test_gdal_open_non_accessible_object_on_cloud_storage():
     with gdal.config_option("OSS_SECRET_ACCESS_KEY", ""):
         with pytest.raises(Exception, match="InvalidCredentials"):
             gdal.Open("/vsioss/i_do_not/exist.bin")
+
+
+def test_basic_test_create_copy_band():
+    mem_driver = gdal.GetDriverByName("MEM")
+    src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    src_ds.GetRasterBand(1).Fill(1)
+
+    out_ds = mem_driver.CreateCopy("", src_ds.GetRasterBand(1))
+    assert out_ds.GetRasterBand(1).Checksum() == 1

--- a/autotest/gdrivers/vrtderived.py
+++ b/autotest/gdrivers/vrtderived.py
@@ -1516,6 +1516,8 @@ def test_vrt_pixelfn_reclassify_nan(tmp_vsimem):
         ("inv", [float("nan")], float("nan"), {}, float("nan")),
         ("log10", [7], 7, {}, 7),
         ("max", [3, 7, 9], 7, {}, 9),
+        ("max", [3, 7, 9], 7, {"k": 10}, 10),
+        ("max", [3, 7, 9], 7, {"k": 5}, 9),
         ("max", [3, 7, 9], 7, {"propagateNoData": True}, 7),
         ("mean", [3, 7, 9], 7, {}, (3 + 9) / 2),
         ("mean", [7, 7, 7], 7, {}, 7),
@@ -1525,6 +1527,8 @@ def test_vrt_pixelfn_reclassify_nan(tmp_vsimem):
         ("median", [7, 7, 7], 7, {}, 7),
         ("median", [3, 7, 9], 7, {"propagateNoData": True}, 7),
         ("min", [3, 7, 9], 7, {}, 3),
+        ("min", [3, 7, 9], 7, {"k": 5}, 3),
+        ("min", [3, 7, 9], 7, {"k": 2}, 2),
         ("min", [3, float("nan"), 9], 7, {}, 3),
         ("min", [3, float("nan"), 9], 7, {"propagateNoData": True}, 7),  # should be 3?
         ("min", [3, 7, 9], 7, {"propagateNoData": True}, 7),

--- a/doc/source/api/gdalrasterband_cpp.rst
+++ b/doc/source/api/gdalrasterband_cpp.rst
@@ -21,3 +21,18 @@ GDALRasterBand class
    :project: api
    :members:
    :protected-members:
+
+GDALRasterBand related functions
+--------------------------------
+
+.. doxygenfunction:: gdal::min
+   :project: api
+
+.. doxygenfunction:: gdal::max
+   :project: api
+
+.. doxygenfunction:: gdal::mean
+   :project: api
+
+.. doxygenfunction:: gdal::IfThenElse
+   :project: api

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1215,7 +1215,7 @@ GDAL provides a set of default pixel functions that can be used without writing 
    * - **expression**
      - 1
      - ``expression``
-       
+
        ``dialect`` (optional)
      - Evaluate a specified expression using `muparser <https://beltoforion.de/en/muparser/>`__ (default)
        or `ExprTk <https://www.partow.net/programming/exprtk/index.html>`__.
@@ -1281,7 +1281,7 @@ GDAL provides a set of default pixel functions that can be used without writing 
 
        Starting with GDAL 3.12, if either input source bounding ``t`` is equal to the NoData
 
-       value of the derived band (set with ``<NoDataValue>``), the result will be the 
+       value of the derived band (set with ``<NoDataValue>``), the result will be the
 
        NoData value.
    * - **interpolate_linear**
@@ -1293,7 +1293,7 @@ GDAL provides a set of default pixel functions that can be used without writing 
 
        Starting with GDAL 3.12, if either input source bounding ``t`` is equal to the NoData
 
-       value of the derived band (set with ``<NoDataValue>``), the result will be the 
+       value of the derived band (set with ``<NoDataValue>``), the result will be the
 
        NoData value.
    * - **inv**
@@ -1317,9 +1317,11 @@ GDAL provides a set of default pixel functions that can be used without writing 
 
        (set with ``<NoDataValue>``), the result will be the NoData value.
    * - **max**
-     - >= 2
+     - >= 1
      - ``propagateNoData`` (optional, default=false)
-     - (GDAL >= 3.8) Maximum of 2 or more raster bands.
+
+       ``k``: constant (optional)
+     - (GDAL >= 3.8) Maximum of raster band(s) and an optional constant
 
        If the optional ``propagateNoData`` parameter is set to ``true``, then
 
@@ -1347,9 +1349,11 @@ GDAL provides a set of default pixel functions that can be used without writing 
 
        the output value. Otherwise, NoData pixels will be ignored.
    * - **min**
-     - >= 2
+     - >= 1
      - ``propagateNoData`` (optional, default=false)
-     - (GDAL >= 3.8) Minimum of 2 or more raster bands.
+
+       ``k``: constant (optional)
+     - (GDAL >= 3.8) Minimum of raster band(s) and an optional constant
 
        If the optional ``propagateNoData`` parameter is set to ``true``, then
 
@@ -1380,7 +1384,7 @@ GDAL provides a set of default pixel functions that can be used without writing 
        If the optional ``k`` parameter is provided then the result is
 
        multiplied by the scalar ``k``.
-       
+
        Starting with GDAL 3.12, if ``propagateNoData`` is true, any input pixel
 
        equal to the derived band's NoData value (set with ``<NoDataValue>``)

--- a/doc/source/spelling_wordlist.txt
+++ b/doc/source/spelling_wordlist.txt
@@ -1269,6 +1269,7 @@ hashtable
 hAttr
 Hayford
 hComp
+hCondBand
 hCT
 hCutline
 hdbuserstore
@@ -1287,6 +1288,7 @@ heightfield
 Heightfield
 heightfields
 Helmert
+hElseBand
 Helvetica
 hether
 hFeat
@@ -1351,6 +1353,7 @@ hSrcDS
 hST
 hTarget
 hTargetEDT
+hThenBand
 hThis
 html
 hTransformArg

--- a/doc/source/spelling_wordlist.txt
+++ b/doc/source/spelling_wordlist.txt
@@ -448,6 +448,7 @@ conceptualhelp
 cond
 conda
 Conda
+condBand
 conf
 config
 Config
@@ -783,6 +784,7 @@ Elbor
 ElementPath
 ellps
 elpaso
+elseBand
 emptor
 Enablement
 Encodings
@@ -1391,6 +1393,7 @@ ieee
 ifdef
 ifit
 ifndef
+IfThenElse
 ifv
 igc
 IGeometry
@@ -3236,6 +3239,7 @@ tgz
 th
 thebuffer
 themself
+thenBand
 thescale
 thf
 THH

--- a/doc/source/user/band_algebra.rst
+++ b/doc/source/user/band_algebra.rst
@@ -35,15 +35,15 @@ evaluated, that is pixel values are computed only when they are requested.
 Other operations are available:
 
 - ternary / if-then-else, with :cpp:func:`gdal::IfThenElse` in C++ and
-  :py:meth:`osgeo.gdal.Band.where` in Python (similar to `NumPy where <https://numpy.org/doc/stable/reference/generated/numpy.where.html>`__)
+  :py:meth:`osgeo.gdal.where` in Python (similar to `NumPy where <https://numpy.org/doc/stable/reference/generated/numpy.where.html>`__)
 - cast to a data type, with :cpp:func:`GDALRasterBand::AsType` in C++ and
   :py:meth:`osgeo.gdal.Band.astype` in Python
 - minimum of several bands (or constants), with :cpp:func:`gdal::min` in C++ an
-  :py:meth:`osgeo.gdal.Band.minimum` in Python
+  :py:meth:`osgeo.gdal.minimum` in Python
 - maximum of several bands (or constants), with :cpp:func:`gdal::max` in C++ and
-  :py:meth:`osgeo.gdal.Band.maximum` in Python
+  :py:meth:`osgeo.gdal.maximum` in Python
 - arithmetic mean of several bands, with :cpp:func:`gdal::mean` in C++ and
-  :py:meth:`osgeo.gdal.Band.mean` in Python
+  :py:meth:`osgeo.gdal.mean` in Python
 
 It is possible to serialize the operation to a :ref:`raster.vrt` file by using
 :cpp:func:`GDALDriver::CreateCopy` on the dataset owing the result band.
@@ -170,6 +170,6 @@ Examples
                A = ds.GetRasterBand(1)
                B = ds.GetRasterBand(2)
                C = ds.GetRasterBand(3)
-               max_minus_min = gdal.Band.maximum(A,B,C) - gdal.Band.minimum(A,B,C)
-               A_normalized = gdal.Band.where(max_minus_min == 0, 1.0, (A - gdal.Band.min(A,B,C)) / max_minus_min)
+               max_minus_min = gdal.maximum(A,B,C) - gdal.minimum(A,B,C)
+               A_normalized = gdal.where(max_minus_min == 0, 1.0, (A - gdal.min(A,B,C)) / max_minus_min)
                gdal.GetDriverByName("VRT").CreateCopy("A_normalized.vrt", A_normalized)

--- a/doc/source/user/band_algebra.rst
+++ b/doc/source/user/band_algebra.rst
@@ -1,0 +1,175 @@
+.. _gdal_band_algebra:
+
+================================================================================
+GDAL Band Algebra
+================================================================================
+
+.. versionadded:: 3.12
+
+Description
+-----------
+
+Common algebraic operations can be on :cpp:class:`GDALRasterBand` instances
+from C++ and Python:
+
+- addition, with ``+`` operator
+- subtraction, with ``*`` operator
+- multiplication, with ``-`` operator
+- division, with ``/`` operator
+- strictly greater than comparison, with ``>`` operator
+- greater or equal to comparison, with ``>=`` operator
+- strictly lesser than comparison, with ``<`` operator
+- lesser of equal to comparison, with ``<=`` operator
+- equal to comparison, with ``==`` operator
+- not equal to comparison, with ``!=`` operator
+
+Left and right operands can be a Band object or a numeric value (at least
+one of them must be a Band object). If two bands are provided they must have
+the same dimension.
+
+The result of those operations is a band of the same dimension as the input
+one(s), and whose each pixel is evaluated by applying the operator on the
+corresponding pixel in the input band(s). The resulting Band object is lazy
+evaluated, that is pixel values are computed only when they are requested.
+
+Other operations are available:
+
+- ternary / if-then-else, with :cpp:func:`gdal::IfThenElse` in C++ and
+  :py:meth:`osgeo.gdal.Band.where` in Python (similar to `NumPy where <https://numpy.org/doc/stable/reference/generated/numpy.where.html>`__)
+- cast to a data type, with :cpp:func:`GDALRasterBand::AsType` in C++ and
+  :py:meth:`osgeo.gdal.Band.astype` in Python
+- minimum of several bands (or constants), with :cpp:func:`gdal::min` in C++ an
+  :py:meth:`osgeo.gdal.Band.minimum` in Python
+- maximum of several bands (or constants), with :cpp:func:`gdal::max` in C++ and
+  :py:meth:`osgeo.gdal.Band.maximum` in Python
+- arithmetic mean of several bands, with :cpp:func:`gdal::mean` in C++ and
+  :py:meth:`osgeo.gdal.Band.mean` in Python
+
+It is possible to serialize the operation to a :ref:`raster.vrt` file by using
+:cpp:func:`GDALDriver::CreateCopy` on the dataset owing the result band.
+
+The capability is similar to the one offered by the :ref:`gdal_raster_calc` program.
+
+.. note:: The comparison operators, including the ternary one, require a GDAL build against the muparser library.
+
+.. note:: The operations are also available in the C API, for potential bindings
+          to other languages. Cf :cpp:func:`GDALRasterBandAddBand`, :cpp:func:`GDALRasterBandAddDouble`, etc.
+
+Examples
+--------
+
+.. example::
+    :title: Convert a RGB dataset to a graylevel one.
+
+    .. tabs::
+
+       .. code-tab:: c++
+
+            #include <gdal_priv.h>
+
+            int main()
+            {
+                GDALAllRegister();
+
+                auto poDS = std::unique_ptr<GDALDataset>(GDALDataset::Open("rgb.tif"));
+                auto& R = *(poDS->GetRasterBand(1));
+                auto& G = *(poDS->GetRasterBand(2));
+                auto& B = *(poDS->GetRasterBand(3));
+                auto graylevel = (0.299 * R + 0.587 * G + 0.114 * B).AsType(GDT_Byte);
+
+                auto poGTiffDrv = GetGDALDriverManager()->GetDriverByName("GTiff");
+                std::unique_ptr<GDALDataset>(
+                    poGTiffDrv->CreateCopy("graylevel.tif", graylevel.GetDataset(), false, nullptr, nullptr, nullptr)).reset();
+
+                return 0;
+            }
+
+       .. code-tab:: python
+
+            from osgeo import gdal
+            gdal.UseExceptions()
+
+            with gdal.Open("rgb.tif") as ds:
+               R = ds.GetRasterBand(1)
+               G = ds.GetRasterBand(2)
+               B = ds.GetRasterBand(3)
+               graylevel = (0.299 * R + 0.587 * G + 0.114 * B).astype(gdal.GDT_Byte)
+               gdal.GetDriverByName("GTiff").CreateCopy("graylevel.tif", graylevel)
+
+
+.. example::
+    :title: Compute normalized difference vegetation index (NDVI)
+
+    .. tabs::
+
+       .. code-tab:: c++
+
+            #include <gdal_priv.h>
+
+            int main()
+            {
+                GDALAllRegister();
+
+                auto poDS = std::unique_ptr<GDALDataset>(GDALDataset::Open("rgbnir.tif"));
+                auto& R = *(poDS->GetRasterBand(1));
+                auto& NIR = *(poDS->GetRasterBand(4));
+                auto NDVI = (NIR - R) / (NIR + R);
+
+                auto poGTiffDrv = GetGDALDriverManager()->GetDriverByName("GTiff");
+                std::unique_ptr<GDALDataset>(
+                    poGTiffDrv->CreateCopy("NDVI.tif", NDVI.GetDataset(), false, nullptr, nullptr, nullptr)).reset();
+
+                return 0;
+            }
+
+       .. code-tab:: python
+
+            from osgeo import gdal
+            gdal.UseExceptions()
+
+            with gdal.Open("rgbnir.tif") as ds:
+               R = ds.GetRasterBand(1)
+               NIR = ds.GetRasterBand(4)
+               NDVI = (NIR - R) / (NIR + R)
+               gdal.GetDriverByName("GTiff").CreateCopy("NDVI.tif", NDVI)
+
+
+.. example::
+    :title: Normalizing the values of a band to the [0, 1] range using the minimum and maximum of all bands
+
+    .. tabs::
+
+       .. code-tab:: c++
+
+            #include <gdal_priv.h>
+
+            int main()
+            {
+                GDALAllRegister();
+
+                auto poDS = std::unique_ptr<GDALDataset>(GDALDataset::Open("input.tif"));
+                auto& A = *(poDS->GetRasterBand(1));
+                auto& B = *(poDS->GetRasterBand(2));
+                auto& C = *(poDS->GetRasterBand(3));
+                auto max_minus_min = gdal::max(A,B,C) - gdal::min(A,B,C);
+                auto A_normalized = gdal::IfThenElse(max_minus_min == 0, 1.0, (A - gdal::min(A,B,C)) / max_minus_min);
+
+                auto poVRTDrv = GetGDALDriverManager()->GetDriverByName("VRT");
+                std::unique_ptr<GDALDataset>(
+                    poVRTDrv->CreateCopy("A_normalized.vrt", A_normalized.GetDataset(), false, nullptr, nullptr, nullptr)).reset();
+
+                return 0;
+            }
+
+       .. code-tab:: python
+
+            from osgeo import gdal
+            gdal.UseExceptions()
+
+            with gdal.Open("input.tif") as ds:
+               A = ds.GetRasterBand(1)
+               B = ds.GetRasterBand(2)
+               C = ds.GetRasterBand(3)
+               max_minus_min = gdal.Band.maximum(A,B,C) - gdal.Band.minimum(A,B,C)
+               A_normalized = gdal.Band.where(max_minus_min == 0, 1.0, (A - gdal.Band.min(A,B,C)) / max_minus_min)
+               gdal.GetDriverByName("VRT").CreateCopy("A_normalized.vrt", A_normalized)

--- a/doc/source/user/band_algebra.rst
+++ b/doc/source/user/band_algebra.rst
@@ -48,6 +48,10 @@ Other operations are available:
 It is possible to serialize the operation to a :ref:`raster.vrt` file by using
 :cpp:func:`GDALDriver::CreateCopy` on the dataset owing the result band.
 
+When several bands are combined together, that at least one of them has a nodata
+value but they do not share the same nodata value, not-a-number will be used as
+the nodata value for the result band.
+
 The capability is similar to the one offered by the :ref:`gdal_raster_calc` program.
 
 .. note:: The comparison operators, including the ternary one, require a GDAL build against the muparser library.

--- a/doc/source/user/index.rst
+++ b/doc/source/user/index.rst
@@ -8,6 +8,7 @@ User oriented documentation
    :maxdepth: 1
 
    raster_data_model
+   band_algebra
    multidim_raster_data_model
    vector_data_model
    gnm_data_model

--- a/frmts/gtiff/gt_jpeg_copy.cpp
+++ b/frmts/gtiff/gt_jpeg_copy.cpp
@@ -199,7 +199,7 @@ CPLErr GTIFF_DirectCopyFromJPEG(GDALDataset *poDS, GDALDataset *poSrcDS,
     {
         bShouldFallbackToNormalCopyIfFail = false;
 
-        TIFF *hTIFF = (TIFF *)poDS->GetInternalHandle(NULL);
+        TIFF *hTIFF = (TIFF *)poDS->GetInternalHandle("TIFF_HANDLE");
         if (TIFFWriteRawStrip(hTIFF, 0, pabyJPEGData, nSize) != nSize)
             eErr = CE_Failure;
 
@@ -860,7 +860,7 @@ CPLErr GTIFF_CopyFromJPEG(GDALDataset *poDS, GDALDataset *poSrcDS,
     // mechanism that can expose a pseudo one-line-strip whereas the
     // real layout is a single big strip.
 
-    TIFF *hTIFF = static_cast<TIFF *>(poDS->GetInternalHandle(nullptr));
+    TIFF *hTIFF = static_cast<TIFF *>(poDS->GetInternalHandle("TIFF_HANDLE"));
     if (TIFFIsTiled(hTIFF))
     {
         TIFFGetField(hTIFF, TIFFTAG_TILEWIDTH, &(nBlockXSize));

--- a/frmts/gtiff/gt_overview.cpp
+++ b/frmts/gtiff/gt_overview.cpp
@@ -968,7 +968,7 @@ CPLErr GTIFFBuildOverviewsEx(const char *pszFilename, int nBands,
     /* -------------------------------------------------------------------- */
     /*      Do we need to set the jpeg quality?                             */
     /* -------------------------------------------------------------------- */
-    TIFF *hTIFF = static_cast<TIFF *>(hODS->GetInternalHandle(nullptr));
+    TIFF *hTIFF = static_cast<TIFF *>(hODS->GetInternalHandle("TIFF_HANDLE"));
 
     const char *pszJPEGQuality =
         GetOptionValue("JPEG_QUALITY", "JPEG_QUALITY_OVERVIEW");

--- a/frmts/gtiff/gtiffdataset.cpp
+++ b/frmts/gtiff/gtiffdataset.cpp
@@ -1400,10 +1400,12 @@ void GTiffDataset::ScanDirectories()
 /*                         GetInternalHandle()                          */
 /************************************************************************/
 
-void *GTiffDataset::GetInternalHandle(const char * /* pszHandleName */)
+void *GTiffDataset::GetInternalHandle(const char *pszHandleName)
 
 {
-    return m_hTIFF;
+    if (pszHandleName && EQUAL(pszHandleName, "TIFF_HANDLE"))
+        return m_hTIFF;
+    return nullptr;
 }
 
 /************************************************************************/

--- a/frmts/gtiff/gtiffdataset_write.cpp
+++ b/frmts/gtiff/gtiffdataset_write.cpp
@@ -7968,7 +7968,7 @@ GDALDataset *GTiffDataset::CreateCopy(const char *pszFilename,
             poDstBand->SetCategoryNames(papszCatNames);
     }
 
-    l_hTIFF = static_cast<TIFF *>(poDS->GetInternalHandle(nullptr));
+    l_hTIFF = static_cast<TIFF *>(poDS->GetInternalHandle("TIFF_HANDLE"));
 
     /* -------------------------------------------------------------------- */
     /*      Handle forcing xml:ESRI data to be written to PAM.              */

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -1798,6 +1798,16 @@ CPLErr VRTDataset::AddBand(GDALDataType eType, char **papszOptions)
     {
         VRTSourcedRasterBand *poBand = nullptr;
 
+        int nBlockXSizeIn =
+            atoi(CSLFetchNameValueDef(papszOptions, "BLOCKXSIZE", "0"));
+        int nBlockYSizeIn =
+            atoi(CSLFetchNameValueDef(papszOptions, "BLOCKYSIZE", "0"));
+        if (nBlockXSizeIn == 0 && nBlockYSizeIn == 0)
+        {
+            nBlockXSizeIn = m_nBlockXSize;
+            nBlockYSizeIn = m_nBlockYSize;
+        }
+
         /* ---- Check for our sourced band 'derived' subclass ---- */
         if (pszSubClass != nullptr &&
             EQUAL(pszSubClass, "VRTDerivedRasterBand"))
@@ -1805,9 +1815,9 @@ CPLErr VRTDataset::AddBand(GDALDataType eType, char **papszOptions)
 
             /* We'll need a pointer to the subclass in case we need */
             /* to set the new band's pixel function below. */
-            VRTDerivedRasterBand *poDerivedBand =
-                new VRTDerivedRasterBand(this, GetRasterCount() + 1, eType,
-                                         GetRasterXSize(), GetRasterYSize());
+            VRTDerivedRasterBand *poDerivedBand = new VRTDerivedRasterBand(
+                this, GetRasterCount() + 1, eType, GetRasterXSize(),
+                GetRasterYSize(), nBlockXSizeIn, nBlockYSizeIn);
 
             /* Set the pixel function options it provided. */
             const char *pszFuncName =
@@ -1860,15 +1870,6 @@ CPLErr VRTDataset::AddBand(GDALDataType eType, char **papszOptions)
         }
         else
         {
-            int nBlockXSizeIn =
-                atoi(CSLFetchNameValueDef(papszOptions, "BLOCKXSIZE", "0"));
-            int nBlockYSizeIn =
-                atoi(CSLFetchNameValueDef(papszOptions, "BLOCKYSIZE", "0"));
-            if (nBlockXSizeIn == 0 && nBlockYSizeIn == 0)
-            {
-                nBlockXSizeIn = m_nBlockXSize;
-                nBlockYSizeIn = m_nBlockYSize;
-            }
             /* ---- Standard sourced band ---- */
             poBand = new VRTSourcedRasterBand(
                 this, GetRasterCount() + 1, eType, GetRasterXSize(),

--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -193,9 +193,14 @@ class CPL_DLL VRTSource
         return false;
     }
 
-    virtual const CPLString &GetName() const
+    const std::string &GetName() const
     {
         return m_osName;
+    }
+
+    void SetName(const std::string &s)
+    {
+        m_osName = s;
     }
 
     /** Returns a string with the VRTSource class type.
@@ -209,7 +214,7 @@ class CPL_DLL VRTSource
     }
 
   protected:
-    CPLString m_osName{};
+    std::string m_osName{};
 };
 
 typedef VRTSource *(*VRTSourceParser)(const CPLXMLNode *, const char *,

--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -1198,7 +1198,8 @@ class CPL_DLL VRTDerivedRasterBand CPL_NON_FINAL : public VRTSourcedRasterBand
 
     VRTDerivedRasterBand(GDALDataset *poDS, int nBand);
     VRTDerivedRasterBand(GDALDataset *poDS, int nBand, GDALDataType eType,
-                         int nXSize, int nYSize);
+                         int nXSize, int nYSize, int nBlockXSizeIn = 0,
+                         int nBlockYSizeIn = 0);
     virtual ~VRTDerivedRasterBand();
 
     virtual CPLErr IRasterIO(GDALRWFlag, int, int, int, int, void *, int, int,

--- a/frmts/vrt/vrtderivedrasterband.cpp
+++ b/frmts/vrt/vrtderivedrasterband.cpp
@@ -205,8 +205,10 @@ VRTDerivedRasterBand::VRTDerivedRasterBand(GDALDataset *poDSIn, int nBandIn)
 
 VRTDerivedRasterBand::VRTDerivedRasterBand(GDALDataset *poDSIn, int nBandIn,
                                            GDALDataType eType, int nXSize,
-                                           int nYSize)
-    : VRTSourcedRasterBand(poDSIn, nBandIn, eType, nXSize, nYSize),
+                                           int nYSize, int nBlockXSizeIn,
+                                           int nBlockYSizeIn)
+    : VRTSourcedRasterBand(poDSIn, nBandIn, eType, nXSize, nYSize,
+                           nBlockXSizeIn, nBlockYSizeIn),
       m_poPrivate(nullptr), eSourceTransferType(GDT_Unknown)
 {
     m_poPrivate = new VRTDerivedRasterBandPrivateData;

--- a/frmts/vrt/vrtdriver.cpp
+++ b/frmts/vrt/vrtdriver.cpp
@@ -176,12 +176,24 @@ static GDALDataset *VRTCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
 {
     CPLAssert(nullptr != poSrcDS);
 
+    VRTDataset *poSrcVRTDS = nullptr;
+
+    void *pHandle = poSrcDS->GetInternalHandle("VRT_DATASET");
+    if (pHandle && poSrcDS->GetInternalHandle(nullptr) == nullptr)
+    {
+        poSrcVRTDS = static_cast<VRTDataset *>(pHandle);
+    }
+    else
+    {
+        poSrcVRTDS = dynamic_cast<VRTDataset *>(poSrcDS);
+    }
+
     /* -------------------------------------------------------------------- */
     /*      If the source dataset is a virtual dataset then just write      */
     /*      it to disk as a special case to avoid extra layers of           */
     /*      indirection.                                                    */
     /* -------------------------------------------------------------------- */
-    if (auto poSrcVRTDS = dynamic_cast<VRTDataset *>(poSrcDS))
+    if (poSrcVRTDS)
     {
 
         /* --------------------------------------------------------------------

--- a/frmts/vrt/vrtsources.cpp
+++ b/frmts/vrt/vrtsources.cpp
@@ -497,7 +497,7 @@ CPLXMLNode *VRTSimpleSource::SerializeToXML(const char *pszVRTPath)
 
     if (!m_osName.empty())
     {
-        CPLAddXMLAttributeAndValue(psSrc, "name", m_osName);
+        CPLAddXMLAttributeAndValue(psSrc, "name", m_osName.c_str());
     }
 
     if (m_bSrcDSNameFromVRT)

--- a/gcore/CMakeLists.txt
+++ b/gcore/CMakeLists.txt
@@ -154,6 +154,10 @@ if (ENABLE_PAM)
   target_compile_definitions(gcore PRIVATE -DPAM_ENABLED)
 endif ()
 
+if (GDAL_USE_MUPARSER)
+  target_compile_definitions(gcore PRIVATE -DHAVE_MUPARSER)
+endif()
+
 if (NOT GDAL_ENABLE_DRIVER_DERIVED)
   target_compile_definitions(gcore PRIVATE -DWITHOUT_DERIVED)
 endif ()

--- a/gcore/CMakeLists.txt
+++ b/gcore/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(
   gdal_adbc.cpp
   gdalalgorithm.cpp
   gdalalgorithmregistry.cpp
+  gdalcomputedrasterband.cpp
   gdalopeninfo.cpp
   gdaldriver.cpp
   gdaldrivermanager.cpp

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -1932,6 +1932,40 @@ int CPL_DLL CPL_STDCALL GDALGetDataCoverageStatus(GDALRasterBandH hBand,
                                                   int nMaskFlagStop,
                                                   double *pdfDataPct);
 
+void CPL_DLL GDALComputedRasterBandRelease(GDALComputedRasterBandH hBand);
+
+GDALComputedRasterBandH CPL_DLL GDALRasterBandAddBand(
+    GDALRasterBandH hBand, GDALRasterBandH hOtherBand) CPL_WARN_UNUSED_RESULT;
+GDALComputedRasterBandH CPL_DLL GDALRasterBandAddDouble(
+    GDALRasterBandH hBand, double constant) CPL_WARN_UNUSED_RESULT;
+
+GDALComputedRasterBandH CPL_DLL GDALRasterBandSubBand(
+    GDALRasterBandH hBand, GDALRasterBandH hOtherBand) CPL_WARN_UNUSED_RESULT;
+GDALComputedRasterBandH CPL_DLL GDALRasterBandSubDouble(
+    GDALRasterBandH hBand, double constant) CPL_WARN_UNUSED_RESULT;
+GDALComputedRasterBandH CPL_DLL GDALRasterBandSubDoubleToBand(
+    double constant, GDALRasterBandH hBand) CPL_WARN_UNUSED_RESULT;
+
+GDALComputedRasterBandH CPL_DLL GDALRasterBandMulBand(
+    GDALRasterBandH hBand, GDALRasterBandH hOtherBand) CPL_WARN_UNUSED_RESULT;
+GDALComputedRasterBandH CPL_DLL GDALRasterBandMulDouble(
+    GDALRasterBandH hBand, double constant) CPL_WARN_UNUSED_RESULT;
+
+GDALComputedRasterBandH CPL_DLL GDALRasterBandDivBand(
+    GDALRasterBandH hBand, GDALRasterBandH hOtherBand) CPL_WARN_UNUSED_RESULT;
+GDALComputedRasterBandH CPL_DLL GDALRasterBandDivDouble(
+    GDALRasterBandH hBand, double constant) CPL_WARN_UNUSED_RESULT;
+GDALComputedRasterBandH CPL_DLL GDALRasterBandDivDoubleByBand(
+    double constant, GDALRasterBandH hBand) CPL_WARN_UNUSED_RESULT;
+
+GDALComputedRasterBandH CPL_DLL GDALRasterBandAsDataType(
+    GDALRasterBandH hBand, GDALDataType eDT) CPL_WARN_UNUSED_RESULT;
+
+GDALComputedRasterBandH CPL_DLL GDALMaximumOfTwoBands(
+    GDALRasterBandH hBand1, GDALRasterBandH hBand2) CPL_WARN_UNUSED_RESULT;
+GDALComputedRasterBandH CPL_DLL GDALMinimumOfTwoBands(
+    GDALRasterBandH hBand1, GDALRasterBandH hBand2) CPL_WARN_UNUSED_RESULT;
+
 /* ==================================================================== */
 /*     GDALAsyncReader                                                  */
 /* ==================================================================== */

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -1958,6 +1958,36 @@ GDALComputedRasterBandH CPL_DLL GDALRasterBandDivDouble(
 GDALComputedRasterBandH CPL_DLL GDALRasterBandDivDoubleByBand(
     double constant, GDALRasterBandH hBand) CPL_WARN_UNUSED_RESULT;
 
+GDALComputedRasterBandH CPL_DLL GDALRasterBandGreaterThanBand(
+    GDALRasterBandH hBand, GDALRasterBandH hOtherBand) CPL_WARN_UNUSED_RESULT;
+GDALComputedRasterBandH CPL_DLL GDALRasterBandGreaterThanDouble(
+    GDALRasterBandH hBand, double constant) CPL_WARN_UNUSED_RESULT;
+
+GDALComputedRasterBandH CPL_DLL GDALRasterBandGreaterOrEqualToBand(
+    GDALRasterBandH hBand, GDALRasterBandH hOtherBand) CPL_WARN_UNUSED_RESULT;
+GDALComputedRasterBandH CPL_DLL GDALRasterBandGreaterOrEqualToDouble(
+    GDALRasterBandH hBand, double constant) CPL_WARN_UNUSED_RESULT;
+
+GDALComputedRasterBandH CPL_DLL GDALRasterBandLesserThanBand(
+    GDALRasterBandH hBand, GDALRasterBandH hOtherBand) CPL_WARN_UNUSED_RESULT;
+GDALComputedRasterBandH CPL_DLL GDALRasterBandLesserThanDouble(
+    GDALRasterBandH hBand, double constant) CPL_WARN_UNUSED_RESULT;
+
+GDALComputedRasterBandH CPL_DLL GDALRasterBandLesserOrEqualToBand(
+    GDALRasterBandH hBand, GDALRasterBandH hOtherBand) CPL_WARN_UNUSED_RESULT;
+GDALComputedRasterBandH CPL_DLL GDALRasterBandLesserOrEqualToDouble(
+    GDALRasterBandH hBand, double constant) CPL_WARN_UNUSED_RESULT;
+
+GDALComputedRasterBandH CPL_DLL GDALRasterBandEqualToBand(
+    GDALRasterBandH hBand, GDALRasterBandH hOtherBand) CPL_WARN_UNUSED_RESULT;
+GDALComputedRasterBandH CPL_DLL GDALRasterBandEqualToDouble(
+    GDALRasterBandH hBand, double constant) CPL_WARN_UNUSED_RESULT;
+
+GDALComputedRasterBandH CPL_DLL GDALRasterBandNotEqualToBand(
+    GDALRasterBandH hBand, GDALRasterBandH hOtherBand) CPL_WARN_UNUSED_RESULT;
+GDALComputedRasterBandH CPL_DLL GDALRasterBandNotEqualToDouble(
+    GDALRasterBandH hBand, double constant) CPL_WARN_UNUSED_RESULT;
+
 GDALComputedRasterBandH CPL_DLL GDALRasterBandAsDataType(
     GDALRasterBandH hBand, GDALDataType eDT) CPL_WARN_UNUSED_RESULT;
 

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -1963,8 +1963,12 @@ GDALComputedRasterBandH CPL_DLL GDALRasterBandAsDataType(
 
 GDALComputedRasterBandH CPL_DLL GDALMaximumOfNBands(
     size_t nBandCount, GDALRasterBandH *pahBands) CPL_WARN_UNUSED_RESULT;
+GDALComputedRasterBandH CPL_DLL GDALRasterBandMaxConstant(
+    GDALRasterBandH hBand, double dfConstant) CPL_WARN_UNUSED_RESULT;
 GDALComputedRasterBandH CPL_DLL GDALMinimumOfNBands(
     size_t nBandCount, GDALRasterBandH *pahBands) CPL_WARN_UNUSED_RESULT;
+GDALComputedRasterBandH CPL_DLL GDALRasterBandMinConstant(
+    GDALRasterBandH hBand, double dfConstant) CPL_WARN_UNUSED_RESULT;
 GDALComputedRasterBandH CPL_DLL GDALMeanOfNBands(
     size_t nBandCount, GDALRasterBandH *pahBands) CPL_WARN_UNUSED_RESULT;
 

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -1988,6 +1988,10 @@ GDALComputedRasterBandH CPL_DLL GDALRasterBandNotEqualToBand(
 GDALComputedRasterBandH CPL_DLL GDALRasterBandNotEqualToDouble(
     GDALRasterBandH hBand, double constant) CPL_WARN_UNUSED_RESULT;
 
+GDALComputedRasterBandH CPL_DLL
+GDALRasterBandIfThenElse(GDALRasterBandH hCondBand, GDALRasterBandH hThenBand,
+                         GDALRasterBandH hElseBand) CPL_WARN_UNUSED_RESULT;
+
 GDALComputedRasterBandH CPL_DLL GDALRasterBandAsDataType(
     GDALRasterBandH hBand, GDALDataType eDT) CPL_WARN_UNUSED_RESULT;
 

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -1961,10 +1961,10 @@ GDALComputedRasterBandH CPL_DLL GDALRasterBandDivDoubleByBand(
 GDALComputedRasterBandH CPL_DLL GDALRasterBandAsDataType(
     GDALRasterBandH hBand, GDALDataType eDT) CPL_WARN_UNUSED_RESULT;
 
-GDALComputedRasterBandH CPL_DLL GDALMaximumOfTwoBands(
-    GDALRasterBandH hBand1, GDALRasterBandH hBand2) CPL_WARN_UNUSED_RESULT;
-GDALComputedRasterBandH CPL_DLL GDALMinimumOfTwoBands(
-    GDALRasterBandH hBand1, GDALRasterBandH hBand2) CPL_WARN_UNUSED_RESULT;
+GDALComputedRasterBandH CPL_DLL GDALMaximumOfNBands(
+    size_t nBandCount, GDALRasterBandH *pahBands) CPL_WARN_UNUSED_RESULT;
+GDALComputedRasterBandH CPL_DLL GDALMinimumOfNBands(
+    size_t nBandCount, GDALRasterBandH *pahBands) CPL_WARN_UNUSED_RESULT;
 
 /* ==================================================================== */
 /*     GDALAsyncReader                                                  */

--- a/gcore/gdal.h
+++ b/gcore/gdal.h
@@ -1965,6 +1965,8 @@ GDALComputedRasterBandH CPL_DLL GDALMaximumOfNBands(
     size_t nBandCount, GDALRasterBandH *pahBands) CPL_WARN_UNUSED_RESULT;
 GDALComputedRasterBandH CPL_DLL GDALMinimumOfNBands(
     size_t nBandCount, GDALRasterBandH *pahBands) CPL_WARN_UNUSED_RESULT;
+GDALComputedRasterBandH CPL_DLL GDALMeanOfNBands(
+    size_t nBandCount, GDALRasterBandH *pahBands) CPL_WARN_UNUSED_RESULT;
 
 /* ==================================================================== */
 /*     GDALAsyncReader                                                  */

--- a/gcore/gdal_fwd.h
+++ b/gcore/gdal_fwd.h
@@ -44,6 +44,9 @@ typedef void *GDALDatasetH;
 /** Opaque type used for the C bindings of the C++ GDALRasterBand class */
 typedef void *GDALRasterBandH;
 
+/** Opaque type used for the C bindings of the C++ GDALComputedRasterBand class */
+typedef void *GDALComputedRasterBandH;
+
 /** Opaque type used for the C bindings of the C++ GDALDriver class */
 typedef void *GDALDriverH;
 

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -2134,23 +2134,37 @@ class CPL_DLL GDALComputedRasterBand final : public GDALRasterBand
         OP_CAST,
     };
 
-    // Semi-public for gdal::min(), gdal::max()
-    GDALComputedRasterBand(Operation op, const GDALRasterBand &firstBand,
-                           const GDALRasterBand &secondBand);
-
-    GDALComputedRasterBand(GDALComputedRasterBand &&) = default;
-    //! @endcond
-
-  protected:
-    friend class GDALRasterBand;
-
-    //! @cond Doxygen_Suppress
     GDALComputedRasterBand(Operation op, const GDALRasterBand &firstBand,
                            double constant);
     GDALComputedRasterBand(Operation op, const GDALRasterBand &firstBand,
                            GDALDataType dt);
 
+    // Semi-public for gdal::min(), gdal::max()
+    GDALComputedRasterBand(Operation op, const GDALRasterBand &firstBand,
+                           const GDALRasterBand &secondBand);
+
+    GDALComputedRasterBand(GDALComputedRasterBand &&) = default;
+
     //! @endcond
+
+    /** Convert a GDALComputedRasterBand* to a GDALComputedRasterBandH.
+     */
+    static inline GDALComputedRasterBandH
+    ToHandle(GDALComputedRasterBand *poBand)
+    {
+        return static_cast<GDALComputedRasterBandH>(poBand);
+    }
+
+    /** Convert a GDALComputedRasterBandH to a GDALComputedRasterBand*.
+     */
+    static inline GDALComputedRasterBand *
+    FromHandle(GDALComputedRasterBandH hBand)
+    {
+        return static_cast<GDALComputedRasterBand *>(hBand);
+    }
+
+  protected:
+    friend class GDALRasterBand;
 
     CPLErr IReadBlock(int, int, void *) override;
 

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -2176,6 +2176,7 @@ class CPL_DLL GDALComputedRasterBand final : public GDALRasterBand
         OP_EQ,
         OP_NE,
         OP_CAST,
+        OP_TERNARY,
     };
 
     GDALComputedRasterBand(
@@ -2241,6 +2242,21 @@ namespace gdal
 {
 using std::max;
 using std::min;
+
+GDALComputedRasterBand CPL_DLL IfThenElse(const GDALRasterBand &condBand,
+                                          const GDALRasterBand &thenBand,
+                                          const GDALRasterBand &elseBand);
+
+GDALComputedRasterBand CPL_DLL IfThenElse(const GDALRasterBand &condBand,
+                                          double thenValue,
+                                          const GDALRasterBand &elseBand);
+
+GDALComputedRasterBand CPL_DLL IfThenElse(const GDALRasterBand &condBand,
+                                          const GDALRasterBand &thenBand,
+                                          double elseValue);
+
+GDALComputedRasterBand CPL_DLL IfThenElse(const GDALRasterBand &condBand,
+                                          double thenValue, double elseValue);
 
 /** Return a band whose each pixel value is the minimum of the corresponding
  * pixel values in the inputs (bands or constants)

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -2154,6 +2154,8 @@ class CPL_DLL GDALComputedRasterBand final : public GDALRasterBand
 
     //! @endcond
 
+    double GetNoDataValue(int *pbSuccess = nullptr) override;
+
     /** Convert a GDALComputedRasterBand* to a GDALComputedRasterBandH.
      */
     static inline GDALComputedRasterBandH
@@ -2184,6 +2186,8 @@ class CPL_DLL GDALComputedRasterBand final : public GDALRasterBand
   private:
     friend class GDALComputedDataset;
     std::unique_ptr<GDALDataset, GDALDatasetUniquePtrReleaser> m_poOwningDS{};
+    bool m_bHasNoData{false};
+    double m_dfNoDataValue{0};
 
     GDALComputedRasterBand(const GDALComputedRasterBand &, bool);
     GDALComputedRasterBand(const GDALComputedRasterBand &) = delete;

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -2134,9 +2134,11 @@ class CPL_DLL GDALComputedRasterBand final : public GDALRasterBand
         OP_CAST,
     };
 
-    GDALComputedRasterBand(Operation op, const GDALRasterBand &firstBand,
+    GDALComputedRasterBand(Operation op, double constant,
+                           const GDALRasterBand &band);
+    GDALComputedRasterBand(Operation op, const GDALRasterBand &band,
                            double constant);
-    GDALComputedRasterBand(Operation op, const GDALRasterBand &firstBand,
+    GDALComputedRasterBand(Operation op, const GDALRasterBand &band,
                            GDALDataType dt);
 
     // Semi-public for gdal::min(), gdal::max()

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -2240,12 +2240,12 @@ class CPL_DLL GDALComputedRasterBand final : public GDALRasterBand
 
 namespace gdal
 {
-using std::max;
-using std::min;
 
 GDALComputedRasterBand CPL_DLL IfThenElse(const GDALRasterBand &condBand,
                                           const GDALRasterBand &thenBand,
                                           const GDALRasterBand &elseBand);
+
+//! @cond Doxygen_Suppress
 
 GDALComputedRasterBand CPL_DLL IfThenElse(const GDALRasterBand &condBand,
                                           double thenValue,
@@ -2258,24 +2258,13 @@ GDALComputedRasterBand CPL_DLL IfThenElse(const GDALRasterBand &condBand,
 GDALComputedRasterBand CPL_DLL IfThenElse(const GDALRasterBand &condBand,
                                           double thenValue, double elseValue);
 
-/** Return a band whose each pixel value is the minimum of the corresponding
- * pixel values in the inputs (bands or constants)
- *
- * The resulting band is lazy evaluated. A reference is taken on input
- * datasets.
- *
- * Two or more bands can be passed.
- *
- * @since 3.12
- * @throw std::runtime_error if bands do not have the same dimensions.
- */
-inline GDALComputedRasterBand min(const GDALRasterBand &first,
-                                  const GDALRasterBand &second)
-{
-    GDALRasterBand::ThrowIfNotSameDimensions(first, second);
-    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_MIN,
-                                  first, second);
-}
+//! @endcond
+
+using std::max;
+using std::min;
+
+GDALComputedRasterBand CPL_DLL min(const GDALRasterBand &first,
+                                   const GDALRasterBand &second);
 
 //! @cond Doxygen_Suppress
 
@@ -2336,24 +2325,8 @@ inline GDALComputedRasterBand min(const U &first, V &&...rest)
 
 //! @endcond
 
-/** Return a band whose each pixel value is the maximum of the corresponding
- * pixel values in the inputs (bands or constants)
- *
- * The resulting band is lazy evaluated. A reference is taken on input
- * datasets.
- *
- * Two or more bands can be passed.
- *
- * @since 3.12
- * @throw std::runtime_error if bands do not have the same dimensions.
- */
-inline GDALComputedRasterBand max(const GDALRasterBand &first,
-                                  const GDALRasterBand &second)
-{
-    GDALRasterBand::ThrowIfNotSameDimensions(first, second);
-    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_MAX,
-                                  first, second);
-}
+GDALComputedRasterBand CPL_DLL max(const GDALRasterBand &first,
+                                   const GDALRasterBand &second);
 
 //! @cond Doxygen_Suppress
 
@@ -2414,24 +2387,8 @@ inline GDALComputedRasterBand max(const U &first, V &&...rest)
 
 //! @endcond
 
-/** Return a band whose each pixel value is the arithmetic mean of the
- * corresponding pixel values in the input bands.
- *
- * The resulting band is lazy evaluated. A reference is taken on input
- * datasets.
- *
- * Two or more bands can be passed.
- *
- * @since 3.12
- * @throw std::runtime_error if bands do not have the same dimensions.
- */
-inline GDALComputedRasterBand mean(const GDALRasterBand &first,
-                                   const GDALRasterBand &second)
-{
-    GDALRasterBand::ThrowIfNotSameDimensions(first, second);
-    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_MEAN,
-                                  first, second);
-}
+GDALComputedRasterBand CPL_DLL mean(const GDALRasterBand &first,
+                                    const GDALRasterBand &second);
 
 //! @cond Doxygen_Suppress
 inline GDALComputedRasterBand

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -1872,6 +1872,42 @@ class CPL_DLL GDALRasterBand : public GDALMajorObject
     friend GDALComputedRasterBand CPL_DLL
     operator/(double cst, const GDALRasterBand &other) CPL_WARN_UNUSED_RESULT;
 
+    GDALComputedRasterBand
+    operator>(const GDALRasterBand &other) const CPL_WARN_UNUSED_RESULT;
+    GDALComputedRasterBand operator>(double cst) const CPL_WARN_UNUSED_RESULT;
+    friend GDALComputedRasterBand CPL_DLL
+    operator>(double cst, const GDALRasterBand &other) CPL_WARN_UNUSED_RESULT;
+
+    GDALComputedRasterBand
+    operator>=(const GDALRasterBand &other) const CPL_WARN_UNUSED_RESULT;
+    GDALComputedRasterBand operator>=(double cst) const CPL_WARN_UNUSED_RESULT;
+    friend GDALComputedRasterBand CPL_DLL
+    operator>=(double cst, const GDALRasterBand &other) CPL_WARN_UNUSED_RESULT;
+
+    GDALComputedRasterBand
+    operator<(const GDALRasterBand &other) const CPL_WARN_UNUSED_RESULT;
+    GDALComputedRasterBand operator<(double cst) const CPL_WARN_UNUSED_RESULT;
+    friend GDALComputedRasterBand CPL_DLL
+    operator<(double cst, const GDALRasterBand &other) CPL_WARN_UNUSED_RESULT;
+
+    GDALComputedRasterBand
+    operator<=(const GDALRasterBand &other) const CPL_WARN_UNUSED_RESULT;
+    GDALComputedRasterBand operator<=(double cst) const CPL_WARN_UNUSED_RESULT;
+    friend GDALComputedRasterBand CPL_DLL
+    operator<=(double cst, const GDALRasterBand &other) CPL_WARN_UNUSED_RESULT;
+
+    GDALComputedRasterBand
+    operator==(const GDALRasterBand &other) const CPL_WARN_UNUSED_RESULT;
+    GDALComputedRasterBand operator==(double cst) const CPL_WARN_UNUSED_RESULT;
+    friend GDALComputedRasterBand CPL_DLL
+    operator==(double cst, const GDALRasterBand &other) CPL_WARN_UNUSED_RESULT;
+
+    GDALComputedRasterBand
+    operator!=(const GDALRasterBand &other) const CPL_WARN_UNUSED_RESULT;
+    GDALComputedRasterBand operator!=(double cst) const CPL_WARN_UNUSED_RESULT;
+    friend GDALComputedRasterBand CPL_DLL
+    operator!=(double cst, const GDALRasterBand &other) CPL_WARN_UNUSED_RESULT;
+
     GDALComputedRasterBand AsType(GDALDataType) const CPL_WARN_UNUSED_RESULT;
 
     CPLErr ReadBlock(int nXBlockOff, int nYBlockOff,
@@ -2133,6 +2169,12 @@ class CPL_DLL GDALComputedRasterBand final : public GDALRasterBand
         OP_MIN,
         OP_MAX,
         OP_MEAN,
+        OP_GT,
+        OP_GE,
+        OP_LT,
+        OP_LE,
+        OP_EQ,
+        OP_NE,
         OP_CAST,
     };
 

--- a/gcore/gdalcomputedrasterband.cpp
+++ b/gcore/gdalcomputedrasterband.cpp
@@ -308,6 +308,9 @@ void GDALComputedDataset::AddSources()
         case GDALComputedRasterBand::Operation::OP_MAX:
             ret = "max";
             break;
+        case GDALComputedRasterBand::Operation::OP_MEAN:
+            ret = "mean";
+            break;
         case GDALComputedRasterBand::Operation::OP_CAST:
             break;
     }

--- a/gcore/gdalcomputedrasterband.cpp
+++ b/gcore/gdalcomputedrasterband.cpp
@@ -1,0 +1,354 @@
+/******************************************************************************
+ *
+ * Project:  GDAL
+ * Purpose:  GDALComputedDataset and GDALComputedRasterBand
+ * Author:   Even Rouault <even dot rouault at spatialys.com>
+ *
+ ******************************************************************************
+ * Copyright (c) 2025, Even Rouault <even dot rouault at spatialys.com>
+ *
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#include "gdal_priv.h"
+#include "vrtdataset.h"
+
+/************************************************************************/
+/*                        GDALComputedDataset                           */
+/************************************************************************/
+
+class GDALComputedDataset final : public GDALDataset
+{
+    friend class GDALComputedRasterBand;
+
+    const GDALComputedRasterBand::Operation m_op;
+    CPLStringList m_aosOptions{};
+    std::unique_ptr<GDALDataset, GDALDatasetUniquePtrReleaser> m_firstBandDS{};
+    std::unique_ptr<GDALDataset, GDALDatasetUniquePtrReleaser> m_secondBandDS{};
+    GDALRasterBand *m_poFirstBand = nullptr;
+    GDALRasterBand *m_poSecondBand = nullptr;
+    VRTDataset m_oVRTDS;
+
+    void AddSources();
+
+    static const char *
+    OperationToFunctionName(GDALComputedRasterBand::Operation op);
+
+    GDALComputedDataset &operator=(const GDALComputedDataset &) = delete;
+    GDALComputedDataset(GDALComputedDataset &&) = delete;
+    GDALComputedDataset &operator=(GDALComputedDataset &&) = delete;
+
+  public:
+    GDALComputedDataset(const GDALComputedDataset &other);
+
+    GDALComputedDataset(int nXSize, int nYSize, GDALDataType eDT,
+                        int nBlockXSize, int nBlockYSize,
+                        GDALComputedRasterBand::Operation op,
+                        const GDALRasterBand &firstBand,
+                        const GDALRasterBand *secondBand, double *pConstant);
+
+    ~GDALComputedDataset() override;
+
+    CPLErr GetGeoTransform(double *padfGeoTransform) override
+    {
+        auto poRefDS = m_poFirstBand->GetDataset();
+        return poRefDS ? poRefDS->GetGeoTransform(padfGeoTransform)
+                       : CE_Failure;
+    }
+
+    const OGRSpatialReference *GetSpatialRef() const override
+    {
+        auto poRefDS = m_poFirstBand->GetDataset();
+        return poRefDS ? poRefDS->GetSpatialRef() : nullptr;
+    }
+};
+
+/************************************************************************/
+/*                        GDALComputedDataset()                         */
+/************************************************************************/
+
+GDALComputedDataset::GDALComputedDataset(const GDALComputedDataset &other)
+    : GDALDataset(), m_op(other.m_op), m_aosOptions(other.m_aosOptions),
+      m_firstBandDS(nullptr), m_secondBandDS(nullptr),
+      m_poFirstBand(other.m_poFirstBand), m_poSecondBand(other.m_poSecondBand),
+      m_oVRTDS(other.GetRasterXSize(), other.GetRasterYSize(),
+               other.m_oVRTDS.GetBlockXSize(), other.m_oVRTDS.GetBlockYSize())
+{
+    nRasterXSize = other.nRasterXSize;
+    nRasterYSize = other.nRasterYSize;
+
+    SetBand(
+        1,
+        new GDALComputedRasterBand(
+            const_cast<const GDALComputedRasterBand &>(
+                *cpl::down_cast<GDALComputedRasterBand *>(
+                    const_cast<GDALComputedDataset &>(other).GetRasterBand(1))),
+            true));
+
+    m_oVRTDS.AddBand(other.m_oVRTDS.GetRasterBand(1)->GetRasterDataType(),
+                     m_aosOptions.List());
+
+    AddSources();
+}
+
+/************************************************************************/
+/*                        GDALComputedDataset()                         */
+/************************************************************************/
+
+GDALComputedDataset::GDALComputedDataset(
+    int nXSize, int nYSize, GDALDataType eDT, int nBlockXSize, int nBlockYSize,
+    GDALComputedRasterBand::Operation op, const GDALRasterBand &firstBand,
+    const GDALRasterBand *secondBand, double *pConstant)
+    : m_op(op), m_poFirstBand(const_cast<GDALRasterBand *>(&firstBand)),
+      m_poSecondBand(const_cast<GDALRasterBand *>(secondBand)),
+      m_oVRTDS(nXSize, nYSize, nBlockXSize, nBlockYSize)
+{
+    nRasterXSize = nXSize;
+    nRasterYSize = nYSize;
+    if (op == GDALComputedRasterBand::Operation::OP_CAST)
+    {
+#ifdef DEBUG
+        // Just for code coverage...
+        CPL_IGNORE_RET_VAL(GDALComputedDataset::OperationToFunctionName(op));
+#endif
+        m_aosOptions.SetNameValue("subclass", "VRTSourcedRasterBand");
+    }
+    else
+    {
+        m_aosOptions.SetNameValue("subclass", "VRTDerivedRasterBand");
+        if (op == GDALComputedRasterBand::Operation::OP_SUBTRACT && pConstant)
+        {
+            m_aosOptions.SetNameValue("PixelFunctionType", "sum");
+            m_aosOptions.SetNameValue("_PIXELFN_ARG_k",
+                                      CPLSPrintf("%.17g", -(*pConstant)));
+        }
+        else if (op == GDALComputedRasterBand::Operation::OP_DIVIDE &&
+                 pConstant)
+        {
+            m_aosOptions.SetNameValue("PixelFunctionType", "mul");
+            m_aosOptions.SetNameValue("_PIXELFN_ARG_k",
+                                      CPLSPrintf("%.17g", 1.0 / (*pConstant)));
+        }
+        else
+        {
+            m_aosOptions.SetNameValue("PixelFunctionType",
+                                      OperationToFunctionName(op));
+            if (pConstant)
+                m_aosOptions.SetNameValue("_PIXELFN_ARG_k",
+                                          CPLSPrintf("%.17g", *pConstant));
+        }
+    }
+    m_oVRTDS.AddBand(eDT, m_aosOptions.List());
+
+    AddSources();
+}
+
+/************************************************************************/
+/*                       ~GDALComputedDataset()                         */
+/************************************************************************/
+
+GDALComputedDataset::~GDALComputedDataset() = default;
+
+/************************************************************************/
+/*                  GDALComputedDataset::AddSources()                   */
+/************************************************************************/
+
+void GDALComputedDataset::AddSources()
+{
+    auto poSourcedRasterBand =
+        cpl::down_cast<VRTSourcedRasterBand *>(m_oVRTDS.GetRasterBand(1));
+
+    // For inputs that are instances of GDALComputedDataset, clone them
+    // to make sure we do not depend on temporary instances,
+    // such as "a + b + c", which is evaluated as "(a + b) + c", and the
+    // temporary band/dataset corresponding to a + b will go out of scope
+    // quickly.
+    if (auto poComputedDS =
+            dynamic_cast<GDALComputedDataset *>(m_poFirstBand->GetDataset()))
+    {
+        auto poComputedDSNew =
+            std::make_unique<GDALComputedDataset>(*poComputedDS);
+        m_poFirstBand = poComputedDSNew->GetRasterBand(1);
+        m_firstBandDS.reset(poComputedDSNew.release());
+    }
+    poSourcedRasterBand->AddSimpleSource(m_poFirstBand);
+
+    if (m_poSecondBand)
+    {
+        auto poDS = m_poSecondBand->GetDataset();
+        if (auto poComputedDS = dynamic_cast<GDALComputedDataset *>(poDS))
+        {
+            auto poComputedDSNew =
+                std::make_unique<GDALComputedDataset>(*poComputedDS);
+            m_poSecondBand = poComputedDSNew->GetRasterBand(1);
+            m_secondBandDS.reset(poComputedDSNew.release());
+        }
+        poSourcedRasterBand->AddSimpleSource(m_poSecondBand);
+    }
+}
+
+/************************************************************************/
+/*                       OperationToFunctionName()                      */
+/************************************************************************/
+
+/* static */ const char *GDALComputedDataset::OperationToFunctionName(
+    GDALComputedRasterBand::Operation op)
+{
+    const char *ret = "";
+    switch (op)
+    {
+        case GDALComputedRasterBand::Operation::OP_ADD:
+            ret = "sum";
+            break;
+        case GDALComputedRasterBand::Operation::OP_SUBTRACT:
+            ret = "diff";
+            break;
+        case GDALComputedRasterBand::Operation::OP_MULTIPLY:
+            ret = "mul";
+            break;
+        case GDALComputedRasterBand::Operation::OP_DIVIDE:
+            ret = "div";
+            break;
+        case GDALComputedRasterBand::Operation::OP_MIN:
+            ret = "min";
+            break;
+        case GDALComputedRasterBand::Operation::OP_MAX:
+            ret = "max";
+            break;
+        case GDALComputedRasterBand::Operation::OP_CAST:
+            break;
+    }
+    return ret;
+}
+
+/************************************************************************/
+/*                       GDALComputedRasterBand()                       */
+/************************************************************************/
+
+GDALComputedRasterBand::GDALComputedRasterBand(
+    const GDALComputedRasterBand &other, bool)
+    : GDALRasterBand()
+{
+    nRasterXSize = other.nRasterXSize;
+    nRasterYSize = other.nRasterYSize;
+    eDataType = other.eDataType;
+    nBlockXSize = other.nBlockXSize;
+    nBlockYSize = other.nBlockYSize;
+}
+
+//! @cond Doxygen_Suppress
+
+/************************************************************************/
+/*                       GDALComputedRasterBand()                       */
+/************************************************************************/
+
+GDALComputedRasterBand::GDALComputedRasterBand(Operation op,
+                                               const GDALRasterBand &firstBand,
+                                               const GDALRasterBand &secondBand)
+{
+    nRasterXSize = firstBand.GetXSize();
+    nRasterYSize = firstBand.GetYSize();
+    const auto firstDT = firstBand.GetRasterDataType();
+    const auto secondDT = secondBand.GetRasterDataType();
+    if (op == Operation::OP_ADD && firstDT == GDT_Byte && secondDT == GDT_Byte)
+        eDataType = GDT_UInt16;
+    else if (firstDT == GDT_Float32 && secondDT == GDT_Float32)
+        eDataType = GDT_Float32;
+    else if ((op == Operation::OP_MIN || op == Operation::OP_MAX) &&
+             firstDT == secondDT)
+        eDataType = firstDT;
+    else
+        eDataType = GDT_Float64;
+    firstBand.GetBlockSize(&nBlockXSize, &nBlockYSize);
+    auto l_poDS = std::make_unique<GDALComputedDataset>(
+        nRasterXSize, nRasterYSize, eDataType, nBlockXSize, nBlockYSize, op,
+        firstBand, &secondBand, nullptr);
+    l_poDS->SetBand(1, this);
+    m_poOwningDS.reset(l_poDS.release());
+}
+
+/************************************************************************/
+/*                       GDALComputedRasterBand()                       */
+/************************************************************************/
+
+GDALComputedRasterBand::GDALComputedRasterBand(Operation op,
+                                               const GDALRasterBand &firstBand,
+                                               double constant)
+{
+    nRasterXSize = firstBand.GetXSize();
+    nRasterYSize = firstBand.GetYSize();
+    const auto firstDT = firstBand.GetRasterDataType();
+    if (op == Operation::OP_ADD && firstDT == GDT_Byte && constant >= -128 &&
+        constant <= 127 && std::floor(constant) == constant)
+        eDataType = GDT_Byte;
+    else if (firstDT == GDT_Float32 && static_cast<float>(constant) == constant)
+        eDataType = GDT_Float32;
+    else
+        eDataType = GDT_Float64;
+    firstBand.GetBlockSize(&nBlockXSize, &nBlockYSize);
+    auto l_poDS = std::make_unique<GDALComputedDataset>(
+        nRasterXSize, nRasterYSize, eDataType, nBlockXSize, nBlockYSize, op,
+        firstBand, nullptr, &constant);
+    l_poDS->SetBand(1, this);
+    m_poOwningDS.reset(l_poDS.release());
+}
+
+/************************************************************************/
+/*                       GDALComputedRasterBand()                       */
+/************************************************************************/
+
+GDALComputedRasterBand::GDALComputedRasterBand(Operation op,
+                                               const GDALRasterBand &firstBand,
+                                               GDALDataType dt)
+{
+    CPLAssert(op == Operation::OP_CAST);
+    nRasterXSize = firstBand.GetXSize();
+    nRasterYSize = firstBand.GetYSize();
+    eDataType = dt;
+    firstBand.GetBlockSize(&nBlockXSize, &nBlockYSize);
+    auto l_poDS = std::make_unique<GDALComputedDataset>(
+        nRasterXSize, nRasterYSize, eDataType, nBlockXSize, nBlockYSize, op,
+        firstBand, nullptr, nullptr);
+    l_poDS->SetBand(1, this);
+    m_poOwningDS.reset(l_poDS.release());
+}
+
+//! @endcond
+
+/************************************************************************/
+/*                      ~GDALComputedRasterBand()                       */
+/************************************************************************/
+
+GDALComputedRasterBand::~GDALComputedRasterBand()
+{
+    if (m_poOwningDS)
+        cpl::down_cast<GDALComputedDataset *>(m_poOwningDS.get())->nBands = 0;
+    poDS = nullptr;
+}
+
+/************************************************************************/
+/*                           IReadBlock()                               */
+/************************************************************************/
+
+CPLErr GDALComputedRasterBand::IReadBlock(int nBlockXOff, int nBlockYOff,
+                                          void *pData)
+{
+    auto l_poDS = cpl::down_cast<GDALComputedDataset *>(poDS);
+    return l_poDS->m_oVRTDS.GetRasterBand(1)->ReadBlock(nBlockXOff, nBlockYOff,
+                                                        pData);
+}
+
+/************************************************************************/
+/*                           IRasterIO()                                */
+/************************************************************************/
+
+CPLErr GDALComputedRasterBand::IRasterIO(
+    GDALRWFlag eRWFlag, int nXOff, int nYOff, int nXSize, int nYSize,
+    void *pData, int nBufXSize, int nBufYSize, GDALDataType eBufType,
+    GSpacing nPixelSpace, GSpacing nLineSpace, GDALRasterIOExtraArg *psExtraArg)
+{
+    auto l_poDS = cpl::down_cast<GDALComputedDataset *>(poDS);
+    return l_poDS->m_oVRTDS.GetRasterBand(1)->RasterIO(
+        eRWFlag, nXOff, nYOff, nXSize, nYSize, pData, nBufXSize, nBufYSize,
+        eBufType, nPixelSpace, nLineSpace, psExtraArg);
+}

--- a/gcore/gdalcomputedrasterband.cpp
+++ b/gcore/gdalcomputedrasterband.cpp
@@ -327,6 +327,19 @@ GDALComputedRasterBand::~GDALComputedRasterBand()
 }
 
 /************************************************************************/
+/*                    GDALComputedRasterBandRelease()                   */
+/************************************************************************/
+
+/** Release a GDALComputedRasterBandH
+ *
+ * @since 3.12
+ */
+void GDALComputedRasterBandRelease(GDALComputedRasterBandH hBand)
+{
+    delete GDALComputedRasterBand::FromHandle(hBand);
+}
+
+/************************************************************************/
 /*                           IReadBlock()                               */
 /************************************************************************/
 

--- a/gcore/gdalrasterband.cpp
+++ b/gcore/gdalrasterband.cpp
@@ -10242,7 +10242,7 @@ GDALRasterBand::operator+(const GDALRasterBand &other) const
  * datasets.
  *
  * @since 3.12
- * @return a handle to free with  GDALComputedRasterBandRelease(), or nullptr if error.
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
  */
 GDALComputedRasterBandH GDALRasterBandAddBand(GDALRasterBandH hBand,
                                               GDALRasterBandH hOtherBand)
@@ -10291,7 +10291,7 @@ GDALComputedRasterBand GDALRasterBand::operator+(double constant) const
  * datasets.
  *
  * @since 3.12
- * @return a handle to free with  GDALComputedRasterBandRelease(), or nullptr if error.
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
  */
 GDALComputedRasterBandH GDALRasterBandAddDouble(GDALRasterBandH hBand,
                                                 double constant)
@@ -10348,7 +10348,7 @@ GDALRasterBand::operator-(const GDALRasterBand &other) const
  * datasets.
  *
  * @since 3.12
- * @return a handle to free with  GDALComputedRasterBandRelease(), or nullptr if error.
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
  */
 GDALComputedRasterBandH GDALRasterBandSubBand(GDALRasterBandH hBand,
                                               GDALRasterBandH hOtherBand)
@@ -10397,7 +10397,7 @@ GDALComputedRasterBand GDALRasterBand::operator-(double constant) const
  * datasets.
  *
  * @since 3.12
- * @return a handle to free with  GDALComputedRasterBandRelease(), or nullptr if error.
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
  */
 GDALComputedRasterBandH GDALRasterBandSubDouble(GDALRasterBandH hBand,
                                                 double constant)
@@ -10434,7 +10434,7 @@ GDALComputedRasterBand operator-(double constant, const GDALRasterBand &other)
  * datasets.
  *
  * @since 3.12
- * @return a handle to free with  GDALComputedRasterBandRelease(), or nullptr if error.
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
  */
 GDALComputedRasterBandH GDALRasterBandSubDoubleToBand(double constant,
                                                       GDALRasterBandH hBand)
@@ -10477,7 +10477,7 @@ GDALRasterBand::operator*(const GDALRasterBand &other) const
  * datasets.
  *
  * @since 3.12
- * @return a handle to free with  GDALComputedRasterBandRelease(), or nullptr if error.
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
  */
 GDALComputedRasterBandH GDALRasterBandMulBand(GDALRasterBandH hBand,
                                               GDALRasterBandH hOtherBand)
@@ -10542,7 +10542,7 @@ GDALComputedRasterBand operator*(double constant, const GDALRasterBand &other)
  * datasets.
  *
  * @since 3.12
- * @return a handle to free with  GDALComputedRasterBandRelease(), or nullptr if error.
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
  */
 GDALComputedRasterBandH GDALRasterBandMulDouble(GDALRasterBandH hBand,
                                                 double constant)
@@ -10583,7 +10583,7 @@ GDALRasterBand::operator/(const GDALRasterBand &other) const
  * datasets.
  *
  * @since 3.12
- * @return a handle to free with  GDALComputedRasterBandRelease(), or nullptr if error.
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
  */
 GDALComputedRasterBandH GDALRasterBandDivBand(GDALRasterBandH hBand,
                                               GDALRasterBandH hOtherBand)
@@ -10632,7 +10632,7 @@ GDALComputedRasterBand GDALRasterBand::operator/(double constant) const
  * datasets.
  *
  * @since 3.12
- * @return a handle to free with  GDALComputedRasterBandRelease(), or nullptr if error.
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
  */
 GDALComputedRasterBandH GDALRasterBandDivDouble(GDALRasterBandH hBand,
                                                 double constant)
@@ -10670,7 +10670,7 @@ GDALComputedRasterBand operator/(double constant, const GDALRasterBand &other)
  * datasets.
  *
  * @since 3.12
- * @return a handle to free with  GDALComputedRasterBandRelease(), or nullptr if error.
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
  */
 GDALComputedRasterBandH GDALRasterBandDivDoubleByBand(double constant,
                                                       GDALRasterBandH hBand)
@@ -10679,6 +10679,873 @@ GDALComputedRasterBandH GDALRasterBandDivDoubleByBand(double constant,
     return new GDALComputedRasterBand(
         GDALComputedRasterBand::Operation::OP_DIVIDE, constant,
         *(GDALRasterBand::FromHandle(hBand)));
+}
+
+/************************************************************************/
+/*                          ThrowIfNotMuparser()                        */
+/************************************************************************/
+
+#ifndef HAVE_MUPARSER
+static GDALComputedRasterBand ThrowIfNotMuparser()
+{
+    throw std::runtime_error("Band comparison operators not available on a "
+                             "GDAL build without muparser");
+}
+#endif
+
+/************************************************************************/
+/*                           operator>()                                */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the pixel value of the left operand
+ * is greater than the pixel value of the right operand.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand
+GDALRasterBand::operator>(const GDALRasterBand &other) const
+{
+#ifndef HAVE_MUPARSER
+    (void)other;
+    return ThrowIfNotMuparser();
+#else
+    ThrowIfNotSameDimensions(*this, other);
+    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_GT,
+                                  *this, other);
+#endif
+}
+
+/************************************************************************/
+/*                  GDALRasterBandGreaterThanBand()                     */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the pixel value of the left operand
+ * is greater than the pixel value of the right operand.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on both input
+ * datasets.
+ *
+ * @since 3.12
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
+ */
+GDALComputedRasterBandH
+GDALRasterBandGreaterThanBand(GDALRasterBandH hBand, GDALRasterBandH hOtherBand)
+{
+    VALIDATE_POINTER1(hBand, __func__, nullptr);
+    VALIDATE_POINTER1(hOtherBand, __func__, nullptr);
+#ifndef HAVE_MUPARSER
+    CPLError(CE_Failure, CPLE_NotSupported,
+             "Band comparison operators not available on a GDAL build without "
+             "muparser");
+    return nullptr;
+#else
+    auto &firstBand = *(GDALRasterBand::FromHandle(hBand));
+    auto &secondBand = *(GDALRasterBand::FromHandle(hOtherBand));
+    try
+    {
+        GDALRasterBand::ThrowIfNotSameDimensions(firstBand, secondBand);
+    }
+    catch (const std::exception &e)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "%s", e.what());
+        return nullptr;
+    }
+    return new GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_GT,
+                                      firstBand, secondBand);
+#endif
+}
+
+/************************************************************************/
+/*                           operator>()                                */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the pixel value of the left operand
+ * is greater than the constant.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand GDALRasterBand::operator>(double constant) const
+{
+#ifndef HAVE_MUPARSER
+    (void)constant;
+    return ThrowIfNotMuparser();
+#else
+    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_GT,
+                                  *this, constant);
+#endif
+}
+
+/************************************************************************/
+/*                  GDALRasterBandGreaterThanDouble()                   */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the pixel value of the left operand
+ * is greater than the constant.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
+ */
+GDALComputedRasterBandH GDALRasterBandGreaterThanDouble(GDALRasterBandH hBand,
+                                                        double constant)
+{
+    VALIDATE_POINTER1(hBand, __func__, nullptr);
+#ifndef HAVE_MUPARSER
+    (void)constant;
+    CPLError(CE_Failure, CPLE_NotSupported,
+             "Band comparison operators not available on a GDAL build without "
+             "muparser");
+    return nullptr;
+#else
+    auto &band = *(GDALRasterBand::FromHandle(hBand));
+    return new GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_GT,
+                                      band, constant);
+#endif
+}
+
+/************************************************************************/
+/*                           operator>()                                */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the constant is greater than the pixel
+ * value of the right operand.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand operator>(double constant, const GDALRasterBand &other)
+{
+#ifndef HAVE_MUPARSER
+    (void)constant;
+    (void)other;
+    return ThrowIfNotMuparser();
+#else
+    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_GT,
+                                  constant, other);
+#endif
+}
+
+/************************************************************************/
+/*                           operator>=()                               */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the pixel value of the left operand
+ * is greater or equal to the pixel value of the right operand.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand
+GDALRasterBand::operator>=(const GDALRasterBand &other) const
+{
+#ifndef HAVE_MUPARSER
+    (void)other;
+    return ThrowIfNotMuparser();
+#else
+    ThrowIfNotSameDimensions(*this, other);
+    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_GE,
+                                  *this, other);
+#endif
+}
+
+/************************************************************************/
+/*                  GDALRasterBandGreaterOrEqualToBand()                */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the pixel value of the left operand
+ * is greater or equal to the pixel value of the right operand.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on both input
+ * datasets.
+ *
+ * @since 3.12
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
+ */
+GDALComputedRasterBandH
+GDALRasterBandGreaterOrEqualToBand(GDALRasterBandH hBand,
+                                   GDALRasterBandH hOtherBand)
+{
+    VALIDATE_POINTER1(hBand, __func__, nullptr);
+    VALIDATE_POINTER1(hOtherBand, __func__, nullptr);
+#ifndef HAVE_MUPARSER
+    CPLError(CE_Failure, CPLE_NotSupported,
+             "Band comparison operators not available on a GDAL build without "
+             "muparser");
+    return nullptr;
+#else
+    auto &firstBand = *(GDALRasterBand::FromHandle(hBand));
+    auto &secondBand = *(GDALRasterBand::FromHandle(hOtherBand));
+    try
+    {
+        GDALRasterBand::ThrowIfNotSameDimensions(firstBand, secondBand);
+    }
+    catch (const std::exception &e)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "%s", e.what());
+        return nullptr;
+    }
+    return new GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_GE,
+                                      firstBand, secondBand);
+#endif
+}
+
+/************************************************************************/
+/*                           operator>=()                               */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the pixel value of the left operand
+ * is greater or equal to the constant.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand GDALRasterBand::operator>=(double constant) const
+{
+#ifndef HAVE_MUPARSER
+    (void)constant;
+    return ThrowIfNotMuparser();
+#else
+    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_GE,
+                                  *this, constant);
+#endif
+}
+
+/************************************************************************/
+/*                 GDALRasterBandGreaterOrEqualToDouble()               */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the pixel value of the left operand
+ * is greater or equal to the constant.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
+ */
+GDALComputedRasterBandH
+GDALRasterBandGreaterOrEqualToDouble(GDALRasterBandH hBand, double constant)
+{
+    VALIDATE_POINTER1(hBand, __func__, nullptr);
+#ifndef HAVE_MUPARSER
+    (void)constant;
+    CPLError(CE_Failure, CPLE_NotSupported,
+             "Band comparison operators not available on a GDAL build without "
+             "muparser");
+    return nullptr;
+#else
+    auto &band = *(GDALRasterBand::FromHandle(hBand));
+    return new GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_GE,
+                                      band, constant);
+#endif
+}
+
+/************************************************************************/
+/*                           operator>=()                               */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the constant is greater or equal to
+ * the pixel value of the right operand.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand operator>=(double constant, const GDALRasterBand &other)
+{
+#ifndef HAVE_MUPARSER
+    (void)constant;
+    (void)other;
+    return ThrowIfNotMuparser();
+#else
+    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_GE,
+                                  constant, other);
+#endif
+}
+
+/************************************************************************/
+/*                           operator<()                                */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the pixel value of the left operand
+ * is lesser than the pixel value of the right operand.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand
+GDALRasterBand::operator<(const GDALRasterBand &other) const
+{
+#ifndef HAVE_MUPARSER
+    (void)other;
+    return ThrowIfNotMuparser();
+#else
+    ThrowIfNotSameDimensions(*this, other);
+    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_LT,
+                                  *this, other);
+#endif
+}
+
+/************************************************************************/
+/*                    GDALRasterBandLesserThanBand()                    */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the pixel value of the left operand
+ * is lesser than the pixel value of the right operand.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on both input
+ * datasets.
+ *
+ * @since 3.12
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
+ */
+GDALComputedRasterBandH GDALRasterBandLesserThanBand(GDALRasterBandH hBand,
+                                                     GDALRasterBandH hOtherBand)
+{
+    VALIDATE_POINTER1(hBand, __func__, nullptr);
+    VALIDATE_POINTER1(hOtherBand, __func__, nullptr);
+#ifndef HAVE_MUPARSER
+    CPLError(CE_Failure, CPLE_NotSupported,
+             "Band comparison operators not available on a GDAL build without "
+             "muparser");
+    return nullptr;
+#else
+    auto &firstBand = *(GDALRasterBand::FromHandle(hBand));
+    auto &secondBand = *(GDALRasterBand::FromHandle(hOtherBand));
+    try
+    {
+        GDALRasterBand::ThrowIfNotSameDimensions(firstBand, secondBand);
+    }
+    catch (const std::exception &e)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "%s", e.what());
+        return nullptr;
+    }
+    return new GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_LT,
+                                      firstBand, secondBand);
+#endif
+}
+
+/************************************************************************/
+/*                           operator<()                                */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the pixel value of the left operand
+ * is lesser than the constant.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand GDALRasterBand::operator<(double constant) const
+{
+#ifndef HAVE_MUPARSER
+    (void)constant;
+    return ThrowIfNotMuparser();
+#else
+    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_LT,
+                                  *this, constant);
+#endif
+}
+
+/************************************************************************/
+/*                    GDALRasterBandLesserThanDouble()                  */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the pixel value of the left operand
+ * is lesser than the constant.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
+ */
+GDALComputedRasterBandH GDALRasterBandLesserThanDouble(GDALRasterBandH hBand,
+                                                       double constant)
+{
+    VALIDATE_POINTER1(hBand, __func__, nullptr);
+#ifndef HAVE_MUPARSER
+    (void)constant;
+    CPLError(CE_Failure, CPLE_NotSupported,
+             "Band comparison operators not available on a GDAL build without "
+             "muparser");
+    return nullptr;
+#else
+    auto &band = *(GDALRasterBand::FromHandle(hBand));
+    return new GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_LT,
+                                      band, constant);
+#endif
+}
+
+/************************************************************************/
+/*                           operator<()                                */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the constant is lesser than the pixel
+ * value of the right operand.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand operator<(double constant, const GDALRasterBand &other)
+{
+#ifndef HAVE_MUPARSER
+    (void)constant;
+    (void)other;
+    return ThrowIfNotMuparser();
+#else
+    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_LT,
+                                  constant, other);
+#endif
+}
+
+/************************************************************************/
+/*                           operator<=()                               */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the pixel value of the left operand
+ * is lesser or equal to the pixel value of the right operand.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand
+GDALRasterBand::operator<=(const GDALRasterBand &other) const
+{
+#ifndef HAVE_MUPARSER
+    (void)other;
+    return ThrowIfNotMuparser();
+#else
+    ThrowIfNotSameDimensions(*this, other);
+    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_LE,
+                                  *this, other);
+#endif
+}
+
+/************************************************************************/
+/*                  GDALRasterBandLesserOrEqualToBand()                 */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the pixel value of the left operand
+ * is lesser or equal to the pixel value of the right operand.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on both input
+ * datasets.
+ *
+ * @since 3.12
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
+ */
+GDALComputedRasterBandH
+GDALRasterBandLesserOrEqualToBand(GDALRasterBandH hBand,
+                                  GDALRasterBandH hOtherBand)
+{
+    VALIDATE_POINTER1(hBand, __func__, nullptr);
+    VALIDATE_POINTER1(hOtherBand, __func__, nullptr);
+#ifndef HAVE_MUPARSER
+    CPLError(CE_Failure, CPLE_NotSupported,
+             "Band comparison operators not available on a GDAL build without "
+             "muparser");
+    return nullptr;
+#else
+    auto &firstBand = *(GDALRasterBand::FromHandle(hBand));
+    auto &secondBand = *(GDALRasterBand::FromHandle(hOtherBand));
+    try
+    {
+        GDALRasterBand::ThrowIfNotSameDimensions(firstBand, secondBand);
+    }
+    catch (const std::exception &e)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "%s", e.what());
+        return nullptr;
+    }
+    return new GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_LE,
+                                      firstBand, secondBand);
+#endif
+}
+
+/************************************************************************/
+/*                           operator<=()                               */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the pixel value of the left operand
+ * is lesser or equal to the constant.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand GDALRasterBand::operator<=(double constant) const
+{
+#ifndef HAVE_MUPARSER
+    (void)constant;
+    return ThrowIfNotMuparser();
+#else
+    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_LE,
+                                  *this, constant);
+#endif
+}
+
+/************************************************************************/
+/*                   GDALRasterBandLesserOrEqualToDouble()              */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the pixel value of the left operand
+ * is lesser or equal to the constant.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
+ */
+GDALComputedRasterBandH
+GDALRasterBandLesserOrEqualToDouble(GDALRasterBandH hBand, double constant)
+{
+    VALIDATE_POINTER1(hBand, __func__, nullptr);
+#ifndef HAVE_MUPARSER
+    (void)constant, CPLError(CE_Failure, CPLE_NotSupported,
+                             "Band comparison operators not available on a "
+                             "GDAL build without muparser");
+    return nullptr;
+#else
+    auto &band = *(GDALRasterBand::FromHandle(hBand));
+    return new GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_LE,
+                                      band, constant);
+#endif
+}
+
+/************************************************************************/
+/*                           operator<=()                               */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the constant is lesser or equal to
+ * the pixel value of the right operand.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand operator<=(double constant, const GDALRasterBand &other)
+{
+#ifndef HAVE_MUPARSER
+    (void)constant;
+    (void)other;
+    return ThrowIfNotMuparser();
+#else
+    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_LE,
+                                  constant, other);
+#endif
+}
+
+/************************************************************************/
+/*                           operator==()                               */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the pixel value of the left operand
+ * is equal to the pixel value of the right operand.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand
+GDALRasterBand::operator==(const GDALRasterBand &other) const
+{
+#ifndef HAVE_MUPARSER
+    (void)other;
+    return ThrowIfNotMuparser();
+#else
+    ThrowIfNotSameDimensions(*this, other);
+    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_EQ,
+                                  *this, other);
+#endif
+}
+
+/************************************************************************/
+/*                     GDALRasterBandEqualToBand()                      */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the pixel value of the left operand
+ * is equal to the pixel value of the right operand.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on both input
+ * datasets.
+ *
+ * @since 3.12
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
+ */
+GDALComputedRasterBandH GDALRasterBandEqualToBand(GDALRasterBandH hBand,
+                                                  GDALRasterBandH hOtherBand)
+{
+    VALIDATE_POINTER1(hBand, __func__, nullptr);
+    VALIDATE_POINTER1(hOtherBand, __func__, nullptr);
+#ifndef HAVE_MUPARSER
+    CPLError(CE_Failure, CPLE_NotSupported,
+             "Band comparison operators not available on a GDAL build without "
+             "muparser");
+    return nullptr;
+#else
+
+    auto &firstBand = *(GDALRasterBand::FromHandle(hBand));
+    auto &secondBand = *(GDALRasterBand::FromHandle(hOtherBand));
+    try
+    {
+        GDALRasterBand::ThrowIfNotSameDimensions(firstBand, secondBand);
+    }
+    catch (const std::exception &e)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "%s", e.what());
+        return nullptr;
+    }
+    return new GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_EQ,
+                                      firstBand, secondBand);
+#endif
+}
+
+/************************************************************************/
+/*                           operator==()                               */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the pixel value of the left operand
+ * is equal to the constant.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand GDALRasterBand::operator==(double constant) const
+{
+#ifndef HAVE_MUPARSER
+    (void)constant;
+    return ThrowIfNotMuparser();
+#else
+    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_EQ,
+                                  *this, constant);
+#endif
+}
+
+/************************************************************************/
+/*                       GDALRasterBandEqualToDouble()                  */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the pixel value of the left operand
+ * is equal to the constant.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
+ */
+GDALComputedRasterBandH GDALRasterBandEqualToDouble(GDALRasterBandH hBand,
+                                                    double constant)
+{
+    VALIDATE_POINTER1(hBand, __func__, nullptr);
+#ifndef HAVE_MUPARSER
+    (void)constant, CPLError(CE_Failure, CPLE_NotSupported,
+                             "Band comparison operators not available on a "
+                             "GDAL build without muparser");
+    return nullptr;
+#else
+
+    auto &band = *(GDALRasterBand::FromHandle(hBand));
+    return new GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_EQ,
+                                      band, constant);
+#endif
+}
+
+/************************************************************************/
+/*                           operator==()                               */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the constant is equal to
+ * the pixel value of the right operand.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand operator==(double constant, const GDALRasterBand &other)
+{
+#ifndef HAVE_MUPARSER
+    (void)constant;
+    (void)other;
+    return ThrowIfNotMuparser();
+#else
+    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_EQ,
+                                  constant, other);
+#endif
+}
+
+/************************************************************************/
+/*                           operator!=()                               */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the pixel value of the left operand
+ * is different from the pixel value of the right operand.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand
+GDALRasterBand::operator!=(const GDALRasterBand &other) const
+{
+#ifndef HAVE_MUPARSER
+    (void)other;
+    return ThrowIfNotMuparser();
+#else
+    ThrowIfNotSameDimensions(*this, other);
+    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_NE,
+                                  *this, other);
+#endif
+}
+
+/************************************************************************/
+/*                    GDALRasterBandNotEqualToBand()                    */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the pixel value of the left operand
+ * is different from the pixel value of the right operand.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on both input
+ * datasets.
+ *
+ * @since 3.12
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
+ */
+GDALComputedRasterBandH GDALRasterBandNotEqualToBand(GDALRasterBandH hBand,
+                                                     GDALRasterBandH hOtherBand)
+{
+    VALIDATE_POINTER1(hBand, __func__, nullptr);
+    VALIDATE_POINTER1(hOtherBand, __func__, nullptr);
+#ifndef HAVE_MUPARSER
+    CPLError(CE_Failure, CPLE_NotSupported,
+             "Band comparison operators not available on a GDAL build without "
+             "muparser");
+    return nullptr;
+#else
+
+    auto &firstBand = *(GDALRasterBand::FromHandle(hBand));
+    auto &secondBand = *(GDALRasterBand::FromHandle(hOtherBand));
+    try
+    {
+        GDALRasterBand::ThrowIfNotSameDimensions(firstBand, secondBand);
+    }
+    catch (const std::exception &e)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "%s", e.what());
+        return nullptr;
+    }
+    return new GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_NE,
+                                      firstBand, secondBand);
+#endif
+}
+
+/************************************************************************/
+/*                           operator!=()                               */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the pixel value of the left operand
+ * is different from the constant.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand GDALRasterBand::operator!=(double constant) const
+{
+#ifndef HAVE_MUPARSER
+    (void)constant;
+    return ThrowIfNotMuparser();
+#else
+    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_NE,
+                                  *this, constant);
+#endif
+}
+
+/************************************************************************/
+/*                     GDALRasterBandNotEqualToDouble()                 */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the pixel value of the left operand
+ * is different from the constant.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
+ */
+GDALComputedRasterBandH GDALRasterBandNotEqualToDouble(GDALRasterBandH hBand,
+                                                       double constant)
+{
+    VALIDATE_POINTER1(hBand, __func__, nullptr);
+#ifndef HAVE_MUPARSER
+    (void)constant, CPLError(CE_Failure, CPLE_NotSupported,
+                             "Band comparison operators not available on a "
+                             "GDAL build without muparser");
+    return nullptr;
+#else
+
+    auto &band = *(GDALRasterBand::FromHandle(hBand));
+    return new GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_NE,
+                                      band, constant);
+#endif
+}
+
+/************************************************************************/
+/*                           operator!=()                               */
+/************************************************************************/
+
+/** Return a band whose value is 1 if the constant is different from
+ * the pixel value of the right operand.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand operator!=(double constant, const GDALRasterBand &other)
+{
+#ifndef HAVE_MUPARSER
+    (void)constant;
+    (void)other;
+    return ThrowIfNotMuparser();
+#else
+    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_NE,
+                                  constant, other);
+#endif
 }
 
 /************************************************************************/
@@ -10712,7 +11579,7 @@ GDALComputedRasterBand GDALRasterBand::AsType(GDALDataType dt) const
  * dataset.
  *
  * @since 3.12
- * @return a handle to free with  GDALComputedRasterBandRelease(), or nullptr if error.
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
  */
 GDALComputedRasterBandH GDALRasterBandAsDataType(GDALRasterBandH hBand,
                                                  GDALDataType eDT)
@@ -10790,7 +11657,7 @@ GDALOperationOnNBands(GDALComputedRasterBand::Operation op, size_t nBandCount,
  * datasets.
  *
  * @since 3.12
- * @return a handle to free with  GDALComputedRasterBandRelease(), or nullptr if error.
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
  */
 GDALComputedRasterBandH GDALMaximumOfNBands(size_t nBandCount,
                                             GDALRasterBandH *pahBands)
@@ -10810,7 +11677,7 @@ GDALComputedRasterBandH GDALMaximumOfNBands(size_t nBandCount,
  * dataset.
  *
  * @since 3.12
- * @return a handle to free with  GDALComputedRasterBandRelease(), or nullptr if error.
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
  */
 GDALComputedRasterBandH GDALRasterBandMaxConstant(GDALRasterBandH hBand,
                                                   double dfConstant)
@@ -10832,7 +11699,7 @@ GDALComputedRasterBandH GDALRasterBandMaxConstant(GDALRasterBandH hBand,
  * datasets.
  *
  * @since 3.12
- * @return a handle to free with  GDALComputedRasterBandRelease(), or nullptr if error.
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
  */
 GDALComputedRasterBandH GDALMinimumOfNBands(size_t nBandCount,
                                             GDALRasterBandH *pahBands)
@@ -10852,7 +11719,7 @@ GDALComputedRasterBandH GDALMinimumOfNBands(size_t nBandCount,
  * dataset.
  *
  * @since 3.12
- * @return a handle to free with  GDALComputedRasterBandRelease(), or nullptr if error.
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
  */
 GDALComputedRasterBandH GDALRasterBandMinConstant(GDALRasterBandH hBand,
                                                   double dfConstant)
@@ -10874,7 +11741,7 @@ GDALComputedRasterBandH GDALRasterBandMinConstant(GDALRasterBandH hBand,
  * datasets.
  *
  * @since 3.12
- * @return a handle to free with  GDALComputedRasterBandRelease(), or nullptr if error.
+ * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
  */
 GDALComputedRasterBandH GDALMeanOfNBands(size_t nBandCount,
                                          GDALRasterBandH *pahBands)

--- a/gcore/gdalrasterband.cpp
+++ b/gcore/gdalrasterband.cpp
@@ -10221,6 +10221,8 @@ void GDALRasterBand::ThrowIfNotSameDimensions(const GDALRasterBand &first,
  * The resulting band is lazy evaluated. A reference is taken on both input
  * datasets.
  *
+ * This method is the same as the C function GDALRasterBandAddBand()
+ *
  * @since 3.12
  * @throw std::runtime_error if both bands do not have the same dimensions.
  */
@@ -10240,6 +10242,9 @@ GDALRasterBand::operator+(const GDALRasterBand &other) const
  *
  * The resulting band is lazy evaluated. A reference is taken on both input
  * datasets.
+ *
+ * This function is the same as the C++ method
+ * GDALRasterBand::operator+(const GDALRasterBand&)
  *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
@@ -10273,6 +10278,8 @@ GDALComputedRasterBandH GDALRasterBandAddBand(GDALRasterBandH hBand,
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
  *
+ * This method is the same as the C function GDALRasterBandAddDouble()
+ *
  * @since 3.12
  */
 GDALComputedRasterBand GDALRasterBand::operator+(double constant) const
@@ -10289,6 +10296,9 @@ GDALComputedRasterBand GDALRasterBand::operator+(double constant) const
  *
  * The resulting band is lazy evaluated. A reference is taken on both input
  * datasets.
+ *
+ * This function is the same as the C++ method
+ * GDALRasterBand::operator+(double)
  *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
@@ -10311,6 +10321,9 @@ GDALComputedRasterBandH GDALRasterBandAddDouble(GDALRasterBandH hBand,
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
  *
+ * This method is the same as the C function GDALRasterBandAddDouble()
+ * (with constant and band parameters reversed)
+ *
  * @since 3.12
  */
 GDALComputedRasterBand operator+(double constant, const GDALRasterBand &other)
@@ -10326,6 +10339,8 @@ GDALComputedRasterBand operator+(double constant, const GDALRasterBand &other)
  *
  * The resulting band is lazy evaluated. A reference is taken on both input
  * datasets.
+ *
+ * This method is the same as the C function GDALRasterBandSubBand()
  *
  * @since 3.12
  * @throw std::runtime_error if both bands do not have the same dimensions.
@@ -10346,6 +10361,9 @@ GDALRasterBand::operator-(const GDALRasterBand &other) const
  *
  * The resulting band is lazy evaluated. A reference is taken on both input
  * datasets.
+ *
+ * This function is the same as the C++ method
+ * GDALRasterBand::operator-(const GDALRasterBand&)
  *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
@@ -10379,6 +10397,8 @@ GDALComputedRasterBandH GDALRasterBandSubBand(GDALRasterBandH hBand,
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
  *
+ * This method is the same as the C function GDALRasterBandSubDouble()
+ *
  * @since 3.12
  */
 GDALComputedRasterBand GDALRasterBand::operator-(double constant) const
@@ -10395,6 +10415,9 @@ GDALComputedRasterBand GDALRasterBand::operator-(double constant) const
  *
  * The resulting band is lazy evaluated. A reference is taken on both input
  * datasets.
+ *
+ * This function is the same as the C++ method
+ * GDALRasterBand::operator-(double)
  *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
@@ -10417,6 +10440,8 @@ GDALComputedRasterBandH GDALRasterBandSubDouble(GDALRasterBandH hBand,
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
  *
+ * This method is the same as the C function GDALRasterBandSubDoubleToBand()
+ *
  * @since 3.12
  */
 GDALComputedRasterBand operator-(double constant, const GDALRasterBand &other)
@@ -10432,6 +10457,9 @@ GDALComputedRasterBand operator-(double constant, const GDALRasterBand &other)
  *
  * The resulting band is lazy evaluated. A reference is taken on both input
  * datasets.
+ *
+ * This function is the same as the C++ method
+ * operator-(double, const GDALRasterBand&)
  *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
@@ -10456,6 +10484,8 @@ GDALComputedRasterBandH GDALRasterBandSubDoubleToBand(double constant,
  * The resulting band is lazy evaluated. A reference is taken on both input
  * datasets.
  *
+ * This method is the same as the C function GDALRasterBandMulBand()
+ *
  * @since 3.12
  * @throw std::runtime_error if both bands do not have the same dimensions.
  */
@@ -10475,6 +10505,9 @@ GDALRasterBand::operator*(const GDALRasterBand &other) const
  *
  * The resulting band is lazy evaluated. A reference is taken on both input
  * datasets.
+ *
+ * This function is the same as the C++ method
+ * GDALRasterBand::operator*(const GDALRasterBand&)
  *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
@@ -10508,6 +10541,8 @@ GDALComputedRasterBandH GDALRasterBandMulBand(GDALRasterBandH hBand,
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
  *
+ * This method is the same as the C function GDALRasterBandMulDouble()
+ *
  * @since 3.12
  */
 GDALComputedRasterBand GDALRasterBand::operator*(double constant) const
@@ -10525,6 +10560,9 @@ GDALComputedRasterBand GDALRasterBand::operator*(double constant) const
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
  *
+ * This method is the same as the C function GDALRasterBandMulDouble()
+ * (with constant and band parameters reversed)
+ *
  * @since 3.12
  */
 GDALComputedRasterBand operator*(double constant, const GDALRasterBand &other)
@@ -10540,6 +10578,9 @@ GDALComputedRasterBand operator*(double constant, const GDALRasterBand &other)
  *
  * The resulting band is lazy evaluated. A reference is taken on both input
  * datasets.
+ *
+ * This function is the same as the C++ method
+ * GDALRasterBand::operator*(double)
  *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
@@ -10562,6 +10603,8 @@ GDALComputedRasterBandH GDALRasterBandMulDouble(GDALRasterBandH hBand,
  * The resulting band is lazy evaluated. A reference is taken on both input
  * datasets.
  *
+ * This method is the same as the C function GDALRasterBandDivBand()
+ *
  * @since 3.12
  * @throw std::runtime_error if both bands do not have the same dimensions.
  */
@@ -10581,6 +10624,9 @@ GDALRasterBand::operator/(const GDALRasterBand &other) const
  *
  * The resulting band is lazy evaluated. A reference is taken on both input
  * datasets.
+ *
+ * This function is the same as the C++ method
+ * GDALRasterBand::operator/(const GDALRasterBand&)
  *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
@@ -10614,6 +10660,8 @@ GDALComputedRasterBandH GDALRasterBandDivBand(GDALRasterBandH hBand,
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
  *
+ * This method is the same as the C function GDALRasterBandDivDouble()
+ *
  * @since 3.12
  */
 GDALComputedRasterBand GDALRasterBand::operator/(double constant) const
@@ -10630,6 +10678,9 @@ GDALComputedRasterBand GDALRasterBand::operator/(double constant) const
  *
  * The resulting band is lazy evaluated. A reference is taken on both input
  * datasets.
+ *
+ * This function is the same as the C++ method
+ * GDALRasterBand::operator/(double)
  *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
@@ -10652,6 +10703,8 @@ GDALComputedRasterBandH GDALRasterBandDivDouble(GDALRasterBandH hBand,
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
  *
+ * This method is the same as the C function GDALRasterBandDivDoubleByBand()
+ *
  * @since 3.12
  */
 GDALComputedRasterBand operator/(double constant, const GDALRasterBand &other)
@@ -10668,6 +10721,9 @@ GDALComputedRasterBand operator/(double constant, const GDALRasterBand &other)
  *
  * The resulting band is lazy evaluated. A reference is taken on both input
  * datasets.
+ *
+ * This function is the same as the C++ method
+ * operator/(double, const GDALRasterBand&)
  *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
@@ -10703,6 +10759,8 @@ static GDALComputedRasterBand ThrowIfNotMuparser()
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
  *
+ * This method is the same as the C function GDALRasterBandGreaterThanBand()
+ *
  * @since 3.12
  */
 GDALComputedRasterBand
@@ -10727,6 +10785,9 @@ GDALRasterBand::operator>(const GDALRasterBand &other) const
  *
  * The resulting band is lazy evaluated. A reference is taken on both input
  * datasets.
+ *
+ * This function is the same as the C++ method
+ * GDALRasterBand::operator>(const GDALRasterBand&)
  *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
@@ -10768,6 +10829,8 @@ GDALRasterBandGreaterThanBand(GDALRasterBandH hBand, GDALRasterBandH hOtherBand)
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
  *
+ * This method is the same as the C function GDALRasterBandGreaterThanDouble()
+ *
  * @since 3.12
  */
 GDALComputedRasterBand GDALRasterBand::operator>(double constant) const
@@ -10790,6 +10853,9 @@ GDALComputedRasterBand GDALRasterBand::operator>(double constant) const
  *
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
+ *
+ * This function is the same as the C++ method
+ * GDALRasterBand::operator>(double)
  *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
@@ -10821,6 +10887,9 @@ GDALComputedRasterBandH GDALRasterBandGreaterThanDouble(GDALRasterBandH hBand,
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
  *
+ * This method is the same as the C function GDALRasterBandLesserThanDouble()
+ * (with constant and band parameters reversed)
+ *
  * @since 3.12
  */
 GDALComputedRasterBand operator>(double constant, const GDALRasterBand &other)
@@ -10844,6 +10913,8 @@ GDALComputedRasterBand operator>(double constant, const GDALRasterBand &other)
  *
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
+ *
+ * This method is the same as the C function GDALRasterBandGreaterOrEqualToBand()
  *
  * @since 3.12
  */
@@ -10869,6 +10940,9 @@ GDALRasterBand::operator>=(const GDALRasterBand &other) const
  *
  * The resulting band is lazy evaluated. A reference is taken on both input
  * datasets.
+ *
+ * This function is the same as the C++ method
+ * GDALRasterBand::operator>=(const GDALRasterBand&)
  *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
@@ -10911,6 +10985,8 @@ GDALRasterBandGreaterOrEqualToBand(GDALRasterBandH hBand,
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
  *
+ * This method is the same as the C function GDALRasterBandGreaterOrEqualToDouble()
+ *
  * @since 3.12
  */
 GDALComputedRasterBand GDALRasterBand::operator>=(double constant) const
@@ -10933,6 +11009,9 @@ GDALComputedRasterBand GDALRasterBand::operator>=(double constant) const
  *
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
+ *
+ * This function is the same as the C++ method
+ * GDALRasterBand::operator>=(double)
  *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
@@ -10964,6 +11043,9 @@ GDALRasterBandGreaterOrEqualToDouble(GDALRasterBandH hBand, double constant)
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
  *
+ * This method is the same as the C function GDALRasterBandLesserOrEqualToDouble()
+ * (with constant and band parameters reversed)
+ *
  * @since 3.12
  */
 GDALComputedRasterBand operator>=(double constant, const GDALRasterBand &other)
@@ -10987,6 +11069,8 @@ GDALComputedRasterBand operator>=(double constant, const GDALRasterBand &other)
  *
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
+ *
+ * This method is the same as the C function GDALRasterBandLesserThanBand()
  *
  * @since 3.12
  */
@@ -11012,6 +11096,9 @@ GDALRasterBand::operator<(const GDALRasterBand &other) const
  *
  * The resulting band is lazy evaluated. A reference is taken on both input
  * datasets.
+ *
+ * This function is the same as the C++ method
+ * GDALRasterBand::operator<(const GDALRasterBand&)
  *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
@@ -11053,6 +11140,8 @@ GDALComputedRasterBandH GDALRasterBandLesserThanBand(GDALRasterBandH hBand,
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
  *
+ * This method is the same as the C function GDALRasterBandLesserThanDouble()
+ *
  * @since 3.12
  */
 GDALComputedRasterBand GDALRasterBand::operator<(double constant) const
@@ -11075,6 +11164,9 @@ GDALComputedRasterBand GDALRasterBand::operator<(double constant) const
  *
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
+ *
+ * This function is the same as the C++ method
+ * GDALRasterBand::operator<=(double)
  *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
@@ -11106,6 +11198,9 @@ GDALComputedRasterBandH GDALRasterBandLesserThanDouble(GDALRasterBandH hBand,
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
  *
+ * This method is the same as the C function GDALRasterBandGreaterThanDouble()
+ * (with constant and band parameters reversed)
+ *
  * @since 3.12
  */
 GDALComputedRasterBand operator<(double constant, const GDALRasterBand &other)
@@ -11129,6 +11224,8 @@ GDALComputedRasterBand operator<(double constant, const GDALRasterBand &other)
  *
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
+ *
+ * This method is the same as the C function GDALRasterBandLesserOrEqualToBand()
  *
  * @since 3.12
  */
@@ -11154,6 +11251,9 @@ GDALRasterBand::operator<=(const GDALRasterBand &other) const
  *
  * The resulting band is lazy evaluated. A reference is taken on both input
  * datasets.
+ *
+ * This function is the same as the C++ method
+ * GDALRasterBand::operator<=(const GDALRasterBand&)
  *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
@@ -11196,6 +11296,8 @@ GDALRasterBandLesserOrEqualToBand(GDALRasterBandH hBand,
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
  *
+ * This method is the same as the C function GDALRasterBandLesserOrEqualToDouble()
+ *
  * @since 3.12
  */
 GDALComputedRasterBand GDALRasterBand::operator<=(double constant) const
@@ -11218,6 +11320,9 @@ GDALComputedRasterBand GDALRasterBand::operator<=(double constant) const
  *
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
+ *
+ * This function is the same as the C++ method
+ * GDALRasterBand::operator<=(double)
  *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
@@ -11248,6 +11353,9 @@ GDALRasterBandLesserOrEqualToDouble(GDALRasterBandH hBand, double constant)
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
  *
+ * This method is the same as the C function GDALRasterBandGreaterOrEqualToDouble()
+ * (with constant and band parameters reversed)
+ *
  * @since 3.12
  */
 GDALComputedRasterBand operator<=(double constant, const GDALRasterBand &other)
@@ -11271,6 +11379,8 @@ GDALComputedRasterBand operator<=(double constant, const GDALRasterBand &other)
  *
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
+ *
+ * This method is the same as the C function GDALRasterBandEqualToBand()
  *
  * @since 3.12
  */
@@ -11296,6 +11406,9 @@ GDALRasterBand::operator==(const GDALRasterBand &other) const
  *
  * The resulting band is lazy evaluated. A reference is taken on both input
  * datasets.
+ *
+ * This function is the same as the C++ method
+ * GDALRasterBand::operator==(const GDALRasterBand&)
  *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
@@ -11338,6 +11451,8 @@ GDALComputedRasterBandH GDALRasterBandEqualToBand(GDALRasterBandH hBand,
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
  *
+ * This method is the same as the C function GDALRasterBandEqualToDouble()
+ *
  * @since 3.12
  */
 GDALComputedRasterBand GDALRasterBand::operator==(double constant) const
@@ -11360,6 +11475,9 @@ GDALComputedRasterBand GDALRasterBand::operator==(double constant) const
  *
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
+ *
+ * This function is the same as the C++ method
+ * GDALRasterBand::operator==(double)
  *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
@@ -11391,6 +11509,9 @@ GDALComputedRasterBandH GDALRasterBandEqualToDouble(GDALRasterBandH hBand,
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
  *
+ * This method is the same as the C function GDALRasterBandEqualToDouble()
+ * (with constant and band parameters reversed)
+ *
  * @since 3.12
  */
 GDALComputedRasterBand operator==(double constant, const GDALRasterBand &other)
@@ -11414,6 +11535,8 @@ GDALComputedRasterBand operator==(double constant, const GDALRasterBand &other)
  *
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
+ *
+ * This method is the same as the C function GDALRasterBandNotEqualToBand()
  *
  * @since 3.12
  */
@@ -11439,6 +11562,9 @@ GDALRasterBand::operator!=(const GDALRasterBand &other) const
  *
  * The resulting band is lazy evaluated. A reference is taken on both input
  * datasets.
+ *
+ * This function is the same as the C++ method
+ * GDALRasterBand::operator!=(const GDALRasterBand&)
  *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
@@ -11481,6 +11607,8 @@ GDALComputedRasterBandH GDALRasterBandNotEqualToBand(GDALRasterBandH hBand,
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
  *
+ * This method is the same as the C function GDALRasterBandNotEqualToDouble()
+ *
  * @since 3.12
  */
 GDALComputedRasterBand GDALRasterBand::operator!=(double constant) const
@@ -11503,6 +11631,9 @@ GDALComputedRasterBand GDALRasterBand::operator!=(double constant) const
  *
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
+ *
+ * This function is the same as the C++ method
+ * GDALRasterBand::operator!=(double)
  *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
@@ -11534,6 +11665,9 @@ GDALComputedRasterBandH GDALRasterBandNotEqualToDouble(GDALRasterBandH hBand,
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
  *
+ * This method is the same as the C function GDALRasterBandNotEqualToDouble()
+ * (with constant and band parameters reversed)
+ *
  * @since 3.12
  */
 GDALComputedRasterBand operator!=(double constant, const GDALRasterBand &other)
@@ -11563,6 +11697,8 @@ namespace gdal
  *
  * The resulting band is lazy evaluated. A reference is taken on the input
  * datasets.
+ *
+ * This method is the same as the C function GDALRasterBandIfThenElse()
  *
  * @since 3.12
  */
@@ -11595,6 +11731,9 @@ GDALComputedRasterBand IfThenElse(const GDALRasterBand &condBand,
  *
  * The resulting band is lazy evaluated. A reference is taken on the input
  * datasets.
+ *
+ * This method is the same as the C function GDALRasterBandIfThenElse(),
+ * with thenBand = (condBand * 0) + thenValue
  *
  * @since 3.12
  */
@@ -11629,6 +11768,9 @@ GDALComputedRasterBand IfThenElse(const GDALRasterBand &condBand,
  * The resulting band is lazy evaluated. A reference is taken on the input
  * datasets.
  *
+ * This method is the same as the C function GDALRasterBandIfThenElse(),
+ * with elseBand = (condBand * 0) + elseValue
+
  * @since 3.12
  */
 GDALComputedRasterBand IfThenElse(const GDALRasterBand &condBand,
@@ -11661,6 +11803,9 @@ GDALComputedRasterBand IfThenElse(const GDALRasterBand &condBand,
  *
  * The resulting band is lazy evaluated. A reference is taken on the input
  * datasets.
+ *
+ * This method is the same as the C function GDALRasterBandIfThenElse(),
+ * with thenBand = (condBand * 0) + thenValue and elseBand = (condBand * 0) + elseValue
  *
  * @since 3.12
  */
@@ -11700,6 +11845,8 @@ GDALComputedRasterBand IfThenElse(const GDALRasterBand &condBand,
  *
  * The resulting band is lazy evaluated. A reference is taken on the input
  * datasets.
+ *
+ * This function is the same as the C++ method gdal::IfThenElse()
  *
  * @since 3.12
  */
@@ -11745,6 +11892,8 @@ GDALComputedRasterBandH GDALRasterBandIfThenElse(GDALRasterBandH hCondBand,
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
  *
+ * This method is the same as the C function GDALRasterBandAsDataType()
+ *
  * @since 3.12
  */
 GDALComputedRasterBand GDALRasterBand::AsType(GDALDataType dt) const
@@ -11765,6 +11914,8 @@ GDALComputedRasterBand GDALRasterBand::AsType(GDALDataType dt) const
  *
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
+ *
+ * This function is the same as the C++ method GDALRasterBand::AsType()
  *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
@@ -11844,6 +11995,8 @@ GDALOperationOnNBands(GDALComputedRasterBand::Operation op, size_t nBandCount,
  * The resulting band is lazy evaluated. A reference is taken on input
  * datasets.
  *
+ * This function is the same as the C ++ method gdal::max()
+ *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
  */
@@ -11868,6 +12021,8 @@ namespace gdal
  *
  * Two or more bands can be passed.
  *
+ * This method is the same as the C function GDALMaximumOfNBands()
+ *
  * @since 3.12
  * @throw std::runtime_error if bands do not have the same dimensions.
  */
@@ -11890,6 +12045,8 @@ GDALComputedRasterBand max(const GDALRasterBand &first,
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
  *
+ * This function is the same as the C ++ method gdal::max()
+ *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
  */
@@ -11911,6 +12068,8 @@ GDALComputedRasterBandH GDALRasterBandMaxConstant(GDALRasterBandH hBand,
  *
  * The resulting band is lazy evaluated. A reference is taken on input
  * datasets.
+ *
+ * This function is the same as the C ++ method gdal::min()
  *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
@@ -11936,6 +12095,8 @@ namespace gdal
  *
  * Two or more bands can be passed.
  *
+ * This method is the same as the C function GDALMinimumOfNBands()
+ *
  * @since 3.12
  * @throw std::runtime_error if bands do not have the same dimensions.
  */
@@ -11958,6 +12119,8 @@ GDALComputedRasterBand min(const GDALRasterBand &first,
  * The resulting band is lazy evaluated. A reference is taken on the input
  * dataset.
  *
+ * This function is the same as the C ++ method gdal::min()
+ *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
  */
@@ -11979,6 +12142,8 @@ GDALComputedRasterBandH GDALRasterBandMinConstant(GDALRasterBandH hBand,
  *
  * The resulting band is lazy evaluated. A reference is taken on input
  * datasets.
+ *
+ * This function is the same as the C ++ method gdal::mean()
  *
  * @since 3.12
  * @return a handle to free with GDALComputedRasterBandRelease(), or nullptr if error.
@@ -12004,6 +12169,8 @@ namespace gdal
  * datasets.
  *
  * Two or more bands can be passed.
+ *
+ * This method is the same as the C function GDALMeanOfNBands()
  *
  * @since 3.12
  * @throw std::runtime_error if bands do not have the same dimensions.

--- a/gcore/gdalrasterband.cpp
+++ b/gcore/gdalrasterband.cpp
@@ -10760,7 +10760,11 @@ GDALOperationOnNBands(GDALComputedRasterBand::Operation op, size_t nBandCount,
 {
     VALIDATE_POINTER1(pahBands, __func__, nullptr);
     if (nBandCount == 0)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "At least one band should be passed");
         return nullptr;
+    }
 
     std::vector<const GDALRasterBand *> bands;
     try
@@ -10812,5 +10816,25 @@ GDALComputedRasterBandH GDALMinimumOfNBands(size_t nBandCount,
                                             GDALRasterBandH *pahBands)
 {
     return GDALOperationOnNBands(GDALComputedRasterBand::Operation::OP_MIN,
+                                 nBandCount, pahBands);
+}
+
+/************************************************************************/
+/*                         GDALMeanOfNBands()                           */
+/************************************************************************/
+
+/** Return a band whose each pixel value is the arithmetic mean of the
+ * corresponding pixel values in the input bands.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on input
+ * datasets.
+ *
+ * @since 3.12
+ * @return a handle to free with  GDALComputedRasterBandRelease(), or nullptr if error.
+ */
+GDALComputedRasterBandH GDALMeanOfNBands(size_t nBandCount,
+                                         GDALRasterBandH *pahBands)
+{
+    return GDALOperationOnNBands(GDALComputedRasterBand::Operation::OP_MEAN,
                                  nBandCount, pahBands);
 }

--- a/gcore/gdalrasterband.cpp
+++ b/gcore/gdalrasterband.cpp
@@ -11558,6 +11558,9 @@ namespace gdal
 /** Return a band whose value is thenBand if the corresponding pixel in condBand
  * is not zero, or the one from elseBand otherwise.
  *
+ * Variants of this method exits where thenBand and/or elseBand can be double
+ * values.
+ *
  * The resulting band is lazy evaluated. A reference is taken on the input
  * datasets.
  *
@@ -11580,6 +11583,8 @@ GDALComputedRasterBand IfThenElse(const GDALRasterBand &condBand,
         std::vector<const GDALRasterBand *>{&condBand, &thenBand, &elseBand});
 #endif
 }
+
+//! @cond Doxygen_Suppress
 
 /************************************************************************/
 /*                           IfThenElse()                               */
@@ -11681,6 +11686,8 @@ GDALComputedRasterBand IfThenElse(const GDALRasterBand &condBand,
         std::vector<const GDALRasterBand *>{&condBand, &thenBand, &elseBand});
 #endif
 }
+
+//! @endcond
 
 }  // namespace gdal
 
@@ -11848,6 +11855,32 @@ GDALComputedRasterBandH GDALMaximumOfNBands(size_t nBandCount,
 }
 
 /************************************************************************/
+/*                               gdal::max()                            */
+/************************************************************************/
+
+namespace gdal
+{
+/** Return a band whose each pixel value is the maximum of the corresponding
+ * pixel values in the inputs (bands or constants)
+ *
+ * The resulting band is lazy evaluated. A reference is taken on input
+ * datasets.
+ *
+ * Two or more bands can be passed.
+ *
+ * @since 3.12
+ * @throw std::runtime_error if bands do not have the same dimensions.
+ */
+GDALComputedRasterBand max(const GDALRasterBand &first,
+                           const GDALRasterBand &second)
+{
+    GDALRasterBand::ThrowIfNotSameDimensions(first, second);
+    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_MAX,
+                                  first, second);
+}
+}  // namespace gdal
+
+/************************************************************************/
 /*                     GDALRasterBandMaxConstant()                      */
 /************************************************************************/
 
@@ -11890,6 +11923,32 @@ GDALComputedRasterBandH GDALMinimumOfNBands(size_t nBandCount,
 }
 
 /************************************************************************/
+/*                               gdal::min()                            */
+/************************************************************************/
+
+namespace gdal
+{
+/** Return a band whose each pixel value is the minimum of the corresponding
+ * pixel values in the inputs (bands or constants)
+ *
+ * The resulting band is lazy evaluated. A reference is taken on input
+ * datasets.
+ *
+ * Two or more bands can be passed.
+ *
+ * @since 3.12
+ * @throw std::runtime_error if bands do not have the same dimensions.
+ */
+GDALComputedRasterBand min(const GDALRasterBand &first,
+                           const GDALRasterBand &second)
+{
+    GDALRasterBand::ThrowIfNotSameDimensions(first, second);
+    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_MIN,
+                                  first, second);
+}
+}  // namespace gdal
+
+/************************************************************************/
 /*                     GDALRasterBandMinConstant()                      */
 /************************************************************************/
 
@@ -11930,3 +11989,30 @@ GDALComputedRasterBandH GDALMeanOfNBands(size_t nBandCount,
     return GDALOperationOnNBands(GDALComputedRasterBand::Operation::OP_MEAN,
                                  nBandCount, pahBands);
 }
+
+/************************************************************************/
+/*                              gdal::mean()                            */
+/************************************************************************/
+
+namespace gdal
+{
+
+/** Return a band whose each pixel value is the arithmetic mean of the
+ * corresponding pixel values in the input bands.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on input
+ * datasets.
+ *
+ * Two or more bands can be passed.
+ *
+ * @since 3.12
+ * @throw std::runtime_error if bands do not have the same dimensions.
+ */
+GDALComputedRasterBand mean(const GDALRasterBand &first,
+                            const GDALRasterBand &second)
+{
+    GDALRasterBand::ThrowIfNotSameDimensions(first, second);
+    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_MEAN,
+                                  first, second);
+}
+}  // namespace gdal

--- a/gcore/gdalrasterband.cpp
+++ b/gcore/gdalrasterband.cpp
@@ -11548,6 +11548,187 @@ GDALComputedRasterBand operator!=(double constant, const GDALRasterBand &other)
 #endif
 }
 
+namespace gdal
+{
+
+/************************************************************************/
+/*                           IfThenElse()                               */
+/************************************************************************/
+
+/** Return a band whose value is thenBand if the corresponding pixel in condBand
+ * is not zero, or the one from elseBand otherwise.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * datasets.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand IfThenElse(const GDALRasterBand &condBand,
+                                  const GDALRasterBand &thenBand,
+                                  const GDALRasterBand &elseBand)
+{
+#ifndef HAVE_MUPARSER
+    (void)condBand;
+    (void)thenBand;
+    (void)elseBand;
+    return ThrowIfNotMuparser();
+#else
+    GDALRasterBand::ThrowIfNotSameDimensions(condBand, thenBand);
+    GDALRasterBand::ThrowIfNotSameDimensions(condBand, elseBand);
+    return GDALComputedRasterBand(
+        GDALComputedRasterBand::Operation::OP_TERNARY,
+        std::vector<const GDALRasterBand *>{&condBand, &thenBand, &elseBand});
+#endif
+}
+
+/************************************************************************/
+/*                           IfThenElse()                               */
+/************************************************************************/
+
+/** Return a band whose value is thenValue if the corresponding pixel in condBand
+ * is not zero, or the one from elseBand otherwise.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * datasets.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand IfThenElse(const GDALRasterBand &condBand,
+                                  double thenValue,
+                                  const GDALRasterBand &elseBand)
+{
+#ifndef HAVE_MUPARSER
+    (void)condBand;
+    (void)thenValue;
+    (void)elseBand;
+    return ThrowIfNotMuparser();
+#else
+    GDALRasterBand::ThrowIfNotSameDimensions(condBand, elseBand);
+    auto thenBand =
+        (condBand * 0)
+            .AsType(GDALDataTypeUnionWithValue(GDT_Unknown, thenValue, false)) +
+        thenValue;
+    return GDALComputedRasterBand(
+        GDALComputedRasterBand::Operation::OP_TERNARY,
+        std::vector<const GDALRasterBand *>{&condBand, &thenBand, &elseBand});
+#endif
+}
+
+/************************************************************************/
+/*                           IfThenElse()                               */
+/************************************************************************/
+
+/** Return a band whose value is thenBand if the corresponding pixel in condBand
+ * is not zero, or the one from elseValue otherwise.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * datasets.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand IfThenElse(const GDALRasterBand &condBand,
+                                  const GDALRasterBand &thenBand,
+                                  double elseValue)
+{
+#ifndef HAVE_MUPARSER
+    (void)condBand;
+    (void)thenBand;
+    (void)elseValue;
+    return ThrowIfNotMuparser();
+#else
+    GDALRasterBand::ThrowIfNotSameDimensions(condBand, thenBand);
+    auto elseBand =
+        (condBand * 0)
+            .AsType(GDALDataTypeUnionWithValue(GDT_Unknown, elseValue, false)) +
+        elseValue;
+    return GDALComputedRasterBand(
+        GDALComputedRasterBand::Operation::OP_TERNARY,
+        std::vector<const GDALRasterBand *>{&condBand, &thenBand, &elseBand});
+#endif
+}
+
+/************************************************************************/
+/*                           IfThenElse()                               */
+/************************************************************************/
+
+/** Return a band whose value is thenValue if the corresponding pixel in condBand
+ * is not zero, or the one from elseValue otherwise.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * datasets.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand IfThenElse(const GDALRasterBand &condBand,
+                                  double thenValue, double elseValue)
+{
+#ifndef HAVE_MUPARSER
+    (void)condBand;
+    (void)thenValue;
+    (void)elseValue;
+    return ThrowIfNotMuparser();
+#else
+    auto thenBand =
+        (condBand * 0)
+            .AsType(GDALDataTypeUnionWithValue(GDT_Unknown, thenValue, false)) +
+        thenValue;
+    auto elseBand =
+        (condBand * 0)
+            .AsType(GDALDataTypeUnionWithValue(GDT_Unknown, elseValue, false)) +
+        elseValue;
+    return GDALComputedRasterBand(
+        GDALComputedRasterBand::Operation::OP_TERNARY,
+        std::vector<const GDALRasterBand *>{&condBand, &thenBand, &elseBand});
+#endif
+}
+
+}  // namespace gdal
+
+/************************************************************************/
+/*                     GDALRasterBandIfThenElse()                       */
+/************************************************************************/
+
+/** Return a band whose value is hThenBand if the corresponding pixel in hCondBand
+ * is not zero, or the one from hElseBand otherwise.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * datasets.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBandH GDALRasterBandIfThenElse(GDALRasterBandH hCondBand,
+                                                 GDALRasterBandH hThenBand,
+                                                 GDALRasterBandH hElseBand)
+{
+    VALIDATE_POINTER1(hCondBand, __func__, nullptr);
+    VALIDATE_POINTER1(hThenBand, __func__, nullptr);
+    VALIDATE_POINTER1(hElseBand, __func__, nullptr);
+#ifndef HAVE_MUPARSER
+    CPLError(CE_Failure, CPLE_NotSupported,
+             "Band comparison operators not available on a GDAL build without "
+             "muparser");
+    return nullptr;
+#else
+
+    auto &condBand = *(GDALRasterBand::FromHandle(hCondBand));
+    auto &thenBand = *(GDALRasterBand::FromHandle(hThenBand));
+    auto &elseBand = *(GDALRasterBand::FromHandle(hElseBand));
+    try
+    {
+        GDALRasterBand::ThrowIfNotSameDimensions(condBand, thenBand);
+        GDALRasterBand::ThrowIfNotSameDimensions(condBand, elseBand);
+    }
+    catch (const std::exception &e)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "%s", e.what());
+        return nullptr;
+    }
+    return new GDALComputedRasterBand(
+        GDALComputedRasterBand::Operation::OP_TERNARY,
+        std::vector<const GDALRasterBand *>{&condBand, &thenBand, &elseBand});
+#endif
+}
+
 /************************************************************************/
 /*                       GDALRasterBand::AsType()                       */
 /************************************************************************/

--- a/gcore/gdalrasterband.cpp
+++ b/gcore/gdalrasterband.cpp
@@ -10800,6 +10800,28 @@ GDALComputedRasterBandH GDALMaximumOfNBands(size_t nBandCount,
 }
 
 /************************************************************************/
+/*                     GDALRasterBandMaxConstant()                      */
+/************************************************************************/
+
+/** Return a band whose each pixel value is the maximum of the corresponding
+ * pixel values in the input band and the constant.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ * @return a handle to free with  GDALComputedRasterBandRelease(), or nullptr if error.
+ */
+GDALComputedRasterBandH GDALRasterBandMaxConstant(GDALRasterBandH hBand,
+                                                  double dfConstant)
+{
+    return GDALRasterBand::ToHandle(new GDALComputedRasterBand(
+        GDALComputedRasterBand::Operation::OP_MAX,
+        std::vector<const GDALRasterBand *>{GDALRasterBand::FromHandle(hBand)},
+        dfConstant));
+}
+
+/************************************************************************/
 /*                       GDALMinimumOfNBands()                          */
 /************************************************************************/
 
@@ -10817,6 +10839,28 @@ GDALComputedRasterBandH GDALMinimumOfNBands(size_t nBandCount,
 {
     return GDALOperationOnNBands(GDALComputedRasterBand::Operation::OP_MIN,
                                  nBandCount, pahBands);
+}
+
+/************************************************************************/
+/*                     GDALRasterBandMinConstant()                      */
+/************************************************************************/
+
+/** Return a band whose each pixel value is the minimum of the corresponding
+ * pixel values in the input band and the constant.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ * @return a handle to free with  GDALComputedRasterBandRelease(), or nullptr if error.
+ */
+GDALComputedRasterBandH GDALRasterBandMinConstant(GDALRasterBandH hBand,
+                                                  double dfConstant)
+{
+    return GDALRasterBand::ToHandle(new GDALComputedRasterBand(
+        GDALComputedRasterBand::Operation::OP_MIN,
+        std::vector<const GDALRasterBand *>{GDALRasterBand::FromHandle(hBand)},
+        dfConstant));
 }
 
 /************************************************************************/

--- a/gcore/gdalrasterband.cpp
+++ b/gcore/gdalrasterband.cpp
@@ -10656,9 +10656,8 @@ GDALComputedRasterBandH GDALRasterBandDivDouble(GDALRasterBandH hBand,
  */
 GDALComputedRasterBand operator/(double constant, const GDALRasterBand &other)
 {
-    // FIXME Horrible workaround !
-    // cppcheck-suppress duplicateExpression
-    return ((other / other) / other) * constant;
+    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_DIVIDE,
+                                  constant, other);
 }
 
 /************************************************************************/
@@ -10677,14 +10676,9 @@ GDALComputedRasterBandH GDALRasterBandDivDoubleByBand(double constant,
                                                       GDALRasterBandH hBand)
 {
     VALIDATE_POINTER1(hBand, __func__, nullptr);
-
-    // FIXME Horrible workaround !
-    auto hBandOne = GDALRasterBandDivBand(hBand, hBand);
-    auto hBandOneDivBand = GDALRasterBandDivBand(hBandOne, hBand);
-    GDALComputedRasterBandRelease(hBandOne);
-    auto hRet = GDALRasterBandMulDouble(hBandOneDivBand, constant);
-    GDALComputedRasterBandRelease(hBandOneDivBand);
-    return hRet;
+    return new GDALComputedRasterBand(
+        GDALComputedRasterBand::Operation::OP_DIVIDE, constant,
+        *(GDALRasterBand::FromHandle(hBand)));
 }
 
 /************************************************************************/

--- a/gcore/gdalrasterband.cpp
+++ b/gcore/gdalrasterband.cpp
@@ -10193,3 +10193,256 @@ CPLErr GDALRasterBand::SplitRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
 }
 
 //! @endcond
+
+/************************************************************************/
+/*                         ThrowIfNotSameDimensions()                   */
+/************************************************************************/
+
+//! @cond Doxygen_Suppress
+/* static */
+void GDALRasterBand::ThrowIfNotSameDimensions(const GDALRasterBand &first,
+                                              const GDALRasterBand &second)
+{
+    if (first.GetXSize() != second.GetXSize() ||
+        first.GetYSize() != second.GetYSize())
+    {
+        throw std::runtime_error("Both bands do not have the same dimensions");
+    }
+}
+
+//! @endcond
+
+/************************************************************************/
+/*                           operator+()                                */
+/************************************************************************/
+
+/** Add this band with another one.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on both input
+ * datasets.
+ *
+ * @since 3.12
+ * @throw std::runtime_error if both bands do not have the same dimensions.
+ */
+GDALComputedRasterBand
+GDALRasterBand::operator+(const GDALRasterBand &other) const
+{
+    ThrowIfNotSameDimensions(*this, other);
+    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_ADD,
+                                  *this, other);
+}
+
+/************************************************************************/
+/*                           operator+()                                */
+/************************************************************************/
+
+/** Add this band with a constant.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand GDALRasterBand::operator+(double constant) const
+{
+    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_ADD,
+                                  *this, constant);
+}
+
+/************************************************************************/
+/*                           operator+()                                */
+/************************************************************************/
+
+/** Add a band with a constant.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand operator+(double constant, const GDALRasterBand &other)
+{
+    return other + constant;
+}
+
+/************************************************************************/
+/*                           operator-()                                */
+/************************************************************************/
+
+/** Subtract this band with another one.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on both input
+ * datasets.
+ *
+ * @since 3.12
+ * @throw std::runtime_error if both bands do not have the same dimensions.
+ */
+GDALComputedRasterBand
+GDALRasterBand::operator-(const GDALRasterBand &other) const
+{
+    ThrowIfNotSameDimensions(*this, other);
+    return GDALComputedRasterBand(
+        GDALComputedRasterBand::Operation::OP_SUBTRACT, *this, other);
+}
+
+/************************************************************************/
+/*                           operator-()                                */
+/************************************************************************/
+
+/** Subtract this band with a constant.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand GDALRasterBand::operator-(double constant) const
+{
+    return GDALComputedRasterBand(
+        GDALComputedRasterBand::Operation::OP_SUBTRACT, *this, constant);
+}
+
+/************************************************************************/
+/*                           operator-()                                */
+/************************************************************************/
+
+/** Subtract a constant with a band.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand operator-(double constant, const GDALRasterBand &other)
+{
+    return other * (-1.0) + constant;
+}
+
+/************************************************************************/
+/*                           operator*()                                */
+/************************************************************************/
+
+/** Multiply this band with another one.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on both input
+ * datasets.
+ *
+ * @since 3.12
+ * @throw std::runtime_error if both bands do not have the same dimensions.
+ */
+GDALComputedRasterBand
+GDALRasterBand::operator*(const GDALRasterBand &other) const
+{
+    ThrowIfNotSameDimensions(*this, other);
+    return GDALComputedRasterBand(
+        GDALComputedRasterBand::Operation::OP_MULTIPLY, *this, other);
+}
+
+/************************************************************************/
+/*                           operator*()                                */
+/************************************************************************/
+
+/** Multiply this band by a constant.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand GDALRasterBand::operator*(double constant) const
+{
+    return GDALComputedRasterBand(
+        GDALComputedRasterBand::Operation::OP_MULTIPLY, *this, constant);
+}
+
+/************************************************************************/
+/*                           operator*()                                */
+/************************************************************************/
+
+/** Multiply a band with a constant.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand operator*(double constant, const GDALRasterBand &other)
+{
+    return other * constant;
+}
+
+/************************************************************************/
+/*                           operator/()                                */
+/************************************************************************/
+
+/** Divide this band with another one.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on both input
+ * datasets.
+ *
+ * @since 3.12
+ * @throw std::runtime_error if both bands do not have the same dimensions.
+ */
+GDALComputedRasterBand
+GDALRasterBand::operator/(const GDALRasterBand &other) const
+{
+    ThrowIfNotSameDimensions(*this, other);
+    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_DIVIDE,
+                                  *this, other);
+}
+
+/************************************************************************/
+/*                           operator/()                                */
+/************************************************************************/
+
+/** Divide this band by a constant.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand GDALRasterBand::operator/(double constant) const
+{
+    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_DIVIDE,
+                                  *this, constant);
+}
+
+/************************************************************************/
+/*                           operator/()                                */
+/************************************************************************/
+
+/** Divide a constant by a band.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand operator/(double constant, const GDALRasterBand &other)
+{
+    // FIXME Horrible workaround !
+    // cppcheck-suppress duplicateExpression
+    return ((other / other) / other) * constant;
+}
+
+/************************************************************************/
+/*                       GDALRasterBand::AsType()                       */
+/************************************************************************/
+
+/** Cast this band to another type.
+ *
+ * The resulting band is lazy evaluated. A reference is taken on the input
+ * dataset.
+ *
+ * @since 3.12
+ */
+GDALComputedRasterBand GDALRasterBand::AsType(GDALDataType dt) const
+{
+    if (dt == GDT_Unknown)
+    {
+        throw std::runtime_error("AsType(GDT_Unknown) is not supported");
+    }
+    return GDALComputedRasterBand(GDALComputedRasterBand::Operation::OP_CAST,
+                                  *this, dt);
+}

--- a/swig/include/Band.i
+++ b/swig/include/Band.i
@@ -720,6 +720,96 @@ CPLErr AdviseRead(  int xoff, int yoff, int xsize, int ysize,
       GDALEnablePixelTypeSignedByteWarning(self, b);
   }
 
+  %apply Pointer NONNULL {GDALRasterBandShadow* other};
+  %newobject Add;
+  GDALComputedRasterBandShadow* Add(GDALRasterBandShadow* other)
+  {
+      return GDALRasterBandAddBand(self, other);
+  }
+  %clear GDALRasterBandShadow* other;
+
+  %newobject AddDouble;
+  GDALComputedRasterBandShadow* AddDouble(double constant)
+  {
+      return GDALRasterBandAddDouble(self, constant);
+  }
+
+  %apply Pointer NONNULL {GDALRasterBandShadow* other};
+  %newobject Sub;
+  GDALComputedRasterBandShadow* Sub(GDALRasterBandShadow* other)
+  {
+      return GDALRasterBandSubBand(self, other);
+  }
+  %clear GDALRasterBandShadow* other;
+
+  %newobject SubDouble;
+  GDALComputedRasterBandShadow* SubDouble(double constant)
+  {
+      return GDALRasterBandSubDouble(self, constant);
+  }
+
+  %newobject SubDoubleToBand;
+  GDALComputedRasterBandShadow* SubDoubleToBand(double constant)
+  {
+      return GDALRasterBandSubDoubleToBand(constant, self);
+  }
+
+  %apply Pointer NONNULL {GDALRasterBandShadow* other};
+  %newobject Mul;
+  GDALComputedRasterBandShadow* Mul(GDALRasterBandShadow* other)
+  {
+      return GDALRasterBandMulBand(self, other);
+  }
+  %clear GDALRasterBandShadow* other;
+
+  %newobject MulDouble;
+  GDALComputedRasterBandShadow* MulDouble(double constant)
+  {
+      return GDALRasterBandMulDouble(self, constant);
+  }
+
+  %apply Pointer NONNULL {GDALRasterBandShadow* other};
+  %newobject Div;
+  GDALComputedRasterBandShadow* Div(GDALRasterBandShadow* other)
+  {
+      return GDALRasterBandDivBand(self, other);
+  }
+  %clear GDALRasterBandShadow* other;
+
+  %newobject DivDouble;
+  GDALComputedRasterBandShadow* DivDouble(double constant)
+  {
+      return GDALRasterBandDivDouble(self, constant);
+  }
+
+  %newobject DivDoubleByBand;
+  GDALComputedRasterBandShadow* DivDoubleByBand(double constant)
+  {
+      return GDALRasterBandDivDoubleByBand(constant, self);
+  }
+
+  %newobject AsType;
+  GDALComputedRasterBandShadow* AsType(GDALDataType dt)
+  {
+      return GDALRasterBandAsDataType(self, dt);
+  }
+
+  %apply Pointer NONNULL {GDALRasterBandShadow* other};
+  %newobject MaximumOfTwoBands;
+  GDALComputedRasterBandShadow* MaximumOfTwoBands(GDALRasterBandShadow* other)
+  {
+     return GDALMaximumOfTwoBands(self, other);
+  }
+  %clear GDALRasterBandShadow* other;
+
+  %apply Pointer NONNULL {GDALRasterBandShadow* other};
+  %newobject MinimumOfTwoBands;
+  GDALComputedRasterBandShadow* MinimumOfTwoBands(GDALRasterBandShadow* other)
+  {
+     return GDALMinimumOfTwoBands(self, other);
+  }
+  %clear GDALRasterBandShadow* other;
+
 } /* %extend */
 
 };
@@ -735,3 +825,25 @@ int GDALRasterBandShadow_YSize_get( GDALRasterBandShadow *h ) {
   return GDALGetRasterBandYSize( h );
 }
 %}
+
+/************************************************************************
+ *
+ * Define the extensions for ComputedBand (GDALComputedRasterBandShadow)
+ *
+*************************************************************************/
+
+%rename (ComputedBand) GDALComputedRasterBandShadow;
+
+class GDALComputedRasterBandShadow : public GDALRasterBandShadow {
+private:
+  GDALComputedRasterBandShadow();
+public:
+%extend {
+
+  ~GDALComputedRasterBandShadow() {
+      GDALComputedRasterBandRelease(self);
+  }
+
+} /* %extend */
+
+};

--- a/swig/include/Band.i
+++ b/swig/include/Band.i
@@ -788,6 +788,96 @@ CPLErr AdviseRead(  int xoff, int yoff, int xsize, int ysize,
       return GDALRasterBandDivDoubleByBand(constant, self);
   }
 
+
+  %apply Pointer NONNULL {GDALRasterBandShadow* other};
+  %newobject GreaterThan;
+  GDALComputedRasterBandShadow* GreaterThan(GDALRasterBandShadow* other)
+  {
+      return GDALRasterBandGreaterThanBand(self, other);
+  }
+  %clear GDALRasterBandShadow* other;
+
+  %newobject GreaterThanDouble;
+  GDALComputedRasterBandShadow* GreaterThanDouble(double constant)
+  {
+      return GDALRasterBandGreaterThanDouble(self, constant);
+  }
+
+
+  %apply Pointer NONNULL {GDALRasterBandShadow* other};
+  %newobject GreaterOrEqualTo;
+  GDALComputedRasterBandShadow* GreaterOrEqualTo(GDALRasterBandShadow* other)
+  {
+      return GDALRasterBandGreaterOrEqualToBand(self, other);
+  }
+  %clear GDALRasterBandShadow* other;
+
+  %newobject GreaterOrEqualToDouble;
+  GDALComputedRasterBandShadow* GreaterOrEqualToDouble(double constant)
+  {
+      return GDALRasterBandGreaterOrEqualToDouble(self, constant);
+  }
+
+
+  %apply Pointer NONNULL {GDALRasterBandShadow* other};
+  %newobject LesserThan;
+  GDALComputedRasterBandShadow* LesserThan(GDALRasterBandShadow* other)
+  {
+      return GDALRasterBandLesserThanBand(self, other);
+  }
+  %clear GDALRasterBandShadow* other;
+
+  %newobject LesserThanDouble;
+  GDALComputedRasterBandShadow* LesserThanDouble(double constant)
+  {
+      return GDALRasterBandLesserThanDouble(self, constant);
+  }
+
+  %apply Pointer NONNULL {GDALRasterBandShadow* other};
+  %newobject LesserOrEqualTo;
+  GDALComputedRasterBandShadow* LesserOrEqualTo(GDALRasterBandShadow* other)
+  {
+      return GDALRasterBandLesserOrEqualToBand(self, other);
+  }
+  %clear GDALRasterBandShadow* other;
+
+  %newobject LesserOrEqualToDouble;
+  GDALComputedRasterBandShadow* LesserOrEqualToDouble(double constant)
+  {
+      return GDALRasterBandLesserOrEqualToDouble(self, constant);
+  }
+
+
+  %apply Pointer NONNULL {GDALRasterBandShadow* other};
+  %newobject EqualTo;
+  GDALComputedRasterBandShadow* EqualTo(GDALRasterBandShadow* other)
+  {
+      return GDALRasterBandEqualToBand(self, other);
+  }
+  %clear GDALRasterBandShadow* other;
+
+  %newobject EqualToDouble;
+  GDALComputedRasterBandShadow* EqualToDouble(double constant)
+  {
+      return GDALRasterBandEqualToDouble(self, constant);
+  }
+
+
+  %apply Pointer NONNULL {GDALRasterBandShadow* other};
+  %newobject NotEqualTo;
+  GDALComputedRasterBandShadow* NotEqualTo(GDALRasterBandShadow* other)
+  {
+      return GDALRasterBandNotEqualToBand(self, other);
+  }
+  %clear GDALRasterBandShadow* other;
+
+  %newobject NotEqualToDouble;
+  GDALComputedRasterBandShadow* NotEqualToDouble(double constant)
+  {
+      return GDALRasterBandNotEqualToDouble(self, constant);
+  }
+
+
   %newobject AsType;
   GDALComputedRasterBandShadow* AsType(GDALDataType dt)
   {

--- a/swig/include/Band.i
+++ b/swig/include/Band.i
@@ -810,6 +810,14 @@ CPLErr AdviseRead(  int xoff, int yoff, int xsize, int ysize,
   }
   %clear (int band_count, GDALRasterBandShadow **bands);
 
+  %newobject MeanOfNBands;
+  %apply (int object_list_count, GDALRasterBandShadow **poObjects) {(int band_count, GDALRasterBandShadow **bands)};
+  static GDALComputedRasterBandShadow* MeanOfNBands(int band_count, GDALRasterBandShadow** bands)
+  {
+     return GDALMeanOfNBands(band_count, bands);
+  }
+  %clear (int band_count, GDALRasterBandShadow **bands);
+
 
 } /* %extend */
 

--- a/swig/include/Band.i
+++ b/swig/include/Band.i
@@ -802,6 +802,12 @@ CPLErr AdviseRead(  int xoff, int yoff, int xsize, int ysize,
   }
   %clear (int band_count, GDALRasterBandShadow **bands);
 
+  %newobject MaxConstant;
+  GDALComputedRasterBandShadow* MaxConstant(double constant)
+  {
+      return GDALRasterBandMaxConstant(self, constant);
+  }
+
   %newobject MinimumOfNBands;
   %apply (int object_list_count, GDALRasterBandShadow **poObjects) {(int band_count, GDALRasterBandShadow **bands)};
   static GDALComputedRasterBandShadow* MinimumOfNBands(int band_count, GDALRasterBandShadow** bands)
@@ -809,6 +815,12 @@ CPLErr AdviseRead(  int xoff, int yoff, int xsize, int ysize,
      return GDALMinimumOfNBands(band_count, bands);
   }
   %clear (int band_count, GDALRasterBandShadow **bands);
+
+  %newobject MinConstant;
+  GDALComputedRasterBandShadow* MinConstant(double constant)
+  {
+      return GDALRasterBandMinConstant(self, constant);
+  }
 
   %newobject MeanOfNBands;
   %apply (int object_list_count, GDALRasterBandShadow **poObjects) {(int band_count, GDALRasterBandShadow **bands)};

--- a/swig/include/Band.i
+++ b/swig/include/Band.i
@@ -877,6 +877,20 @@ CPLErr AdviseRead(  int xoff, int yoff, int xsize, int ysize,
       return GDALRasterBandNotEqualToDouble(self, constant);
   }
 
+  %apply Pointer NONNULL {GDALRasterBandShadow* condBand};
+  %apply Pointer NONNULL {GDALRasterBandShadow* thenBand};
+  %apply Pointer NONNULL {GDALRasterBandShadow* elseBand};
+  %newobject IfThenElse;
+  static GDALComputedRasterBandShadow* IfThenElse(GDALRasterBandShadow* condBand,
+                                                  GDALRasterBandShadow* thenBand,
+                                                  GDALRasterBandShadow* elseBand)
+  {
+      return GDALRasterBandIfThenElse(condBand, thenBand, elseBand);
+  }
+  %clear GDALRasterBandShadow* condBand;
+  %clear GDALRasterBandShadow* thenBand;
+  %clear GDALRasterBandShadow* elseBand;
+
 
   %newobject AsType;
   GDALComputedRasterBandShadow* AsType(GDALDataType dt)

--- a/swig/include/Band.i
+++ b/swig/include/Band.i
@@ -794,21 +794,22 @@ CPLErr AdviseRead(  int xoff, int yoff, int xsize, int ysize,
       return GDALRasterBandAsDataType(self, dt);
   }
 
-  %apply Pointer NONNULL {GDALRasterBandShadow* other};
-  %newobject MaximumOfTwoBands;
-  GDALComputedRasterBandShadow* MaximumOfTwoBands(GDALRasterBandShadow* other)
+  %newobject MaximumOfNBands;
+  %apply (int object_list_count, GDALRasterBandShadow **poObjects) {(int band_count, GDALRasterBandShadow **bands)};
+  static GDALComputedRasterBandShadow* MaximumOfNBands(int band_count, GDALRasterBandShadow** bands)
   {
-     return GDALMaximumOfTwoBands(self, other);
+     return GDALMaximumOfNBands(band_count, bands);
   }
-  %clear GDALRasterBandShadow* other;
+  %clear (int band_count, GDALRasterBandShadow **bands);
 
-  %apply Pointer NONNULL {GDALRasterBandShadow* other};
-  %newobject MinimumOfTwoBands;
-  GDALComputedRasterBandShadow* MinimumOfTwoBands(GDALRasterBandShadow* other)
+  %newobject MinimumOfNBands;
+  %apply (int object_list_count, GDALRasterBandShadow **poObjects) {(int band_count, GDALRasterBandShadow **bands)};
+  static GDALComputedRasterBandShadow* MinimumOfNBands(int band_count, GDALRasterBandShadow** bands)
   {
-     return GDALMinimumOfTwoBands(self, other);
+     return GDALMinimumOfNBands(band_count, bands);
   }
-  %clear GDALRasterBandShadow* other;
+  %clear (int band_count, GDALRasterBandShadow **bands);
+
 
 } /* %extend */
 

--- a/swig/include/Band.i
+++ b/swig/include/Band.i
@@ -951,6 +951,40 @@ int GDALRasterBandShadow_YSize_get( GDALRasterBandShadow *h ) {
 }
 %}
 
+#if defined(SWIGPYTHON)
+%pythoncode %{
+del Band.Add
+del Band.AddDouble
+del Band.Sub
+del Band.SubDouble
+del Band.SubDoubleToBand
+del Band.Mul
+del Band.MulDouble
+del Band.Div
+del Band.DivDouble
+del Band.DivDoubleByBand
+del Band.GreaterThan
+del Band.GreaterThanDouble
+del Band.LesserThan
+del Band.LesserThanDouble
+del Band.GreaterOrEqualTo
+del Band.GreaterOrEqualToDouble
+del Band.LesserOrEqualTo
+del Band.LesserOrEqualToDouble
+del Band.EqualTo
+del Band.EqualToDouble
+del Band.NotEqualTo
+del Band.NotEqualToDouble
+del Band.AsType
+del Band.MinimumOfNBands
+del Band.MinConstant
+del Band.MaximumOfNBands
+del Band.MaxConstant
+del Band.MeanOfNBands
+del Band.IfThenElse
+%}
+#endif
+
 /************************************************************************
  *
  * Define the extensions for ComputedBand (GDALComputedRasterBandShadow)

--- a/swig/include/gdal.i
+++ b/swig/include/gdal.i
@@ -62,6 +62,7 @@ typedef void GDALMajorObjectShadow;
 typedef void GDALDriverShadow;
 typedef void GDALDatasetShadow;
 typedef void GDALRasterBandShadow;
+typedef void GDALComputedRasterBandShadow;
 typedef void GDALColorTableShadow;
 typedef void GDALRasterAttributeTableShadow;
 typedef void GDALSubdatasetInfoShadow;

--- a/swig/include/gdal.i
+++ b/swig/include/gdal.i
@@ -358,6 +358,7 @@ $1;
 %rename (GetDataTypeName) GDALGetDataTypeName;
 %rename (GetDataTypeByName) GDALGetDataTypeByName;
 %rename (DataTypeUnion) GDALDataTypeUnion;
+%rename (DataTypeUnionWithValue) GDALDataTypeUnionWithValue;
 %rename (GetColorInterpretationName) GDALGetColorInterpretationName;
 %rename (GetColorInterpretationByName) GDALGetColorInterpretationByName;
 %rename (GetPaletteInterpretationName) GDALGetPaletteInterpretationName;
@@ -755,6 +756,8 @@ const char *GDALGetDataTypeName( GDALDataType eDataType );
 GDALDataType GDALGetDataTypeByName( const char * pszDataTypeName );
 
 GDALDataType GDALDataTypeUnion( GDALDataType a, GDALDataType b );
+
+GDALDataType GDALDataTypeUnionWithValue( GDALDataType a, double val, bool isComplex);
 
 const char *GDALGetColorInterpretationName( GDALColorInterp eColorInterp );
 

--- a/swig/include/gdal_array.i
+++ b/swig/include/gdal_array.i
@@ -64,6 +64,7 @@ typedef void GDALRasterBandShadow;
 typedef void GDALDatasetShadow;
 typedef void GDALRasterAttributeTableShadow;
 #endif
+typedef void GDALComputedRasterBandShadow;
 
 // Declaration from memmultidim.h
 std::shared_ptr<GDALMDArray> CPL_DLL MEMGroupCreateMDArray(GDALGroup* poGroup,

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -578,6 +578,12 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
         else:
             return o
 
+  def __key(self):
+      return str(self)
+
+  def __hash__(self):
+      return hash(self.__key())
+
   def __add__(self, other):
       """Add this raster band to a raster band, a numpy array or a constant
 
@@ -651,6 +657,78 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
       """
       other = Band._get_as_band_if_possible(other)
       return self.DivDoubleByBand(other)._add_parent_references([self])
+
+  def __gt__(self, other):
+      """Return a band whose value is 1 if the pixel value of the left operand
+         is greater than the pixel value of the right operand.
+
+         The resulting band is lazily evaluated.
+      """
+      other = Band._get_as_band_if_possible(other)
+      if isinstance(other, Band):
+          return self.GreaterThan(other)._add_parent_references([self, other])
+      else:
+          return self.GreaterThanDouble(other)._add_parent_references([self])
+
+  def __ge__(self, other):
+      """Return a band whose value is 1 if the pixel value of the left operand
+         is greater or equal to the pixel value of the right operand.
+
+         The resulting band is lazily evaluated.
+      """
+      other = Band._get_as_band_if_possible(other)
+      if isinstance(other, Band):
+          return self.GreaterOrEqualTo(other)._add_parent_references([self, other])
+      else:
+          return self.GreaterOrEqualToDouble(other)._add_parent_references([self])
+
+  def __lt__(self, other):
+      """Return a band whose value is 1 if the pixel value of the left operand
+         is lesser than the pixel value of the right operand.
+
+         The resulting band is lazily evaluated.
+      """
+      other = Band._get_as_band_if_possible(other)
+      if isinstance(other, Band):
+          return self.LesserThan(other)._add_parent_references([self, other])
+      else:
+          return self.LesserThanDouble(other)._add_parent_references([self])
+
+  def __le__(self, other):
+      """Return a band whose value is 1 if the pixel value of the left operand
+         is lesser or equal to the pixel value of the right operand.
+
+         The resulting band is lazily evaluated.
+      """
+      other = Band._get_as_band_if_possible(other)
+      if isinstance(other, Band):
+          return self.LesserOrEqualTo(other)._add_parent_references([self, other])
+      else:
+          return self.LesserOrEqualToDouble(other)._add_parent_references([self])
+
+  def __eq__(self, other):
+      """Return a band whose value is 1 if the pixel value of the left operand
+         is equal to the pixel value of the right operand.
+
+         The resulting band is lazily evaluated.
+      """
+      other = Band._get_as_band_if_possible(other)
+      if isinstance(other, Band):
+          return self.EqualTo(other)._add_parent_references([self, other])
+      else:
+          return self.EqualToDouble(other)._add_parent_references([self])
+
+  def __ne__(self, other):
+      """Return a band whose value is 1 if the pixel value of the left operand
+         is not equal to the pixel value of the right operand.
+
+         The resulting band is lazily evaluated.
+      """
+      other = Band._get_as_band_if_possible(other)
+      if isinstance(other, Band):
+          return self.NotEqualTo(other)._add_parent_references([self, other])
+      else:
+          return self.NotEqualToDouble(other)._add_parent_references([self])
 
   def astype(self, dt):
       """Cast this band to the specified data type

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -271,6 +271,8 @@ static void readraster_releasebuffer(CPLErr eErr,
 
       return _gdal.Band_IfThenElse(cond_band, then_band, else_band)._add_parent_references([cond_band, then_band, else_band])
 
+  Where = where
+
   def minimum(*args):
       """Return a band whose each pixel value is the minimum of the corresponding
          pixel values in the input arguments which may be gdal.Band or a numeric constant.
@@ -295,6 +297,8 @@ static void readraster_releasebuffer(CPLErr eErr,
       if constant is not None:
           res = _gdal.Band_MinConstant(res, constant)._add_parent_references([res])
       return res
+
+  Minimum = minimum
 
   def maximum(*args):
       """Return a band whose each pixel value is the maximum of the corresponding
@@ -321,6 +325,8 @@ static void readraster_releasebuffer(CPLErr eErr,
           res = _gdal.Band_MaxConstant(res, constant)._add_parent_references([res])
       return res
 
+  Maximum = maximum
+
   def mean(*args):
       """Return a band whose each pixel value is the arithmetic mean of the corresponding
          pixel values in the input bands.
@@ -333,6 +339,7 @@ static void readraster_releasebuffer(CPLErr eErr,
       band_refs = [band for band in args]
       return _gdal.Band_MeanOfNBands(bands)._add_parent_references(band_refs)
 
+  Mean = mean
 %}
 
 %{

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -691,6 +691,17 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
       band_refs = [band for band in args]
       return Band.MaximumOfNBands(bands)._add_parent_references(band_refs)
 
+  @staticmethod
+  def mean(*args):
+      """Return a band whose each pixel value is the arithmetic mean of the corresponding
+         pixel values in the input bands.
+
+         The resulting band is lazily evaluated.
+      """
+      bands = [Band._get_as_band_if_possible(band) for band in args]
+      band_refs = [band for band in args]
+      return Band.MeanOfNBands(bands)._add_parent_references(band_refs)
+
   def ReadRaster(self, xoff=0, yoff=0, xsize=None, ysize=None,
                  buf_xsize=None, buf_ysize=None, buf_type=None,
                  buf_pixel_space=None, buf_line_space=None,

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -670,26 +670,26 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
       return self.AsType(dt)._add_parent_references([self])
 
   @staticmethod
-  def minimum(band1, band2):
+  def minimum(*args):
       """Return a band whose each pixel value is the minimum of the corresponding
          pixel values in the input bands.
 
          The resulting band is lazily evaluated.
       """
-      band1 = Band._get_as_band_if_possible(band1)
-      band2 = Band._get_as_band_if_possible(band2)
-      return band1.MinimumOfTwoBands(band2)._add_parent_references([band1, band2])
+      bands = [Band._get_as_band_if_possible(band) for band in args]
+      band_refs = [band for band in args]
+      return Band.MinimumOfNBands(bands)._add_parent_references(band_refs)
 
   @staticmethod
-  def maximum(band1, band2):
+  def maximum(*args):
       """Return a band whose each pixel value is the maximum of the corresponding
          pixel values in the input bands.
 
          The resulting band is lazily evaluated.
       """
-      band1 = Band._get_as_band_if_possible(band1)
-      band2 = Band._get_as_band_if_possible(band2)
-      return band1.MaximumOfTwoBands(band2)._add_parent_references([band1, band2])
+      bands = [Band._get_as_band_if_possible(band) for band in args]
+      band_refs = [band for band in args]
+      return Band.MaximumOfNBands(bands)._add_parent_references(band_refs)
 
   def ReadRaster(self, xoff=0, yoff=0, xsize=None, ysize=None,
                  buf_xsize=None, buf_ysize=None, buf_type=None,

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -591,9 +591,9 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
       """
       other = Band._get_as_band_if_possible(other)
       if isinstance(other, Band):
-          return self.Add(other)._add_parent_references([self, other])
+          return _gdal.Band_Add(self, other)._add_parent_references([self, other])
       else:
-          return self.AddDouble(other)._add_parent_references([self])
+          return _gdal.Band_AddDouble(self, other)._add_parent_references([self])
 
   def __radd__(self, other):
       """Add a constant to this raster band
@@ -609,9 +609,9 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
       """
       other = Band._get_as_band_if_possible(other)
       if isinstance(other, Band):
-          return self.Sub(other)._add_parent_references([self, other])
+          return _gdal.Band_Sub(self, other)._add_parent_references([self, other])
       else:
-          return self.SubDouble(other)._add_parent_references([self])
+          return _gdal.Band_SubDouble(self, other)._add_parent_references([self])
 
   def __rsub__(self, other):
       """Subtract a constant with a raster band
@@ -619,7 +619,7 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
          The resulting band is lazily evaluated.
       """
       other = Band._get_as_band_if_possible(other)
-      return self.SubDoubleToBand(other)._add_parent_references([self])
+      return _gdal.Band_SubDoubleToBand(self, other)._add_parent_references([self])
 
   def __mul__(self, other):
       """Multiply this raster band with a raster band, a numpy array or a constant
@@ -628,9 +628,9 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
       """
       other = Band._get_as_band_if_possible(other)
       if isinstance(other, Band):
-          return self.Mul(other)._add_parent_references([self, other])
+          return _gdal.Band_Mul(self, other)._add_parent_references([self, other])
       else:
-          return self.MulDouble(other)._add_parent_references([self])
+          return _gdal.Band_MulDouble(self, other)._add_parent_references([self])
 
   def __rmul__(self, other):
       """Multiply a constant with this raster band
@@ -646,9 +646,9 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
       """
       other = Band._get_as_band_if_possible(other)
       if isinstance(other, Band):
-          return self.Div(other)._add_parent_references([self, other])
+          return _gdal.Band_Div(self, other)._add_parent_references([self, other])
       else:
-          return self.DivDouble(other)._add_parent_references([self])
+          return _gdal.Band_DivDouble(self, other)._add_parent_references([self])
 
   def __rtruediv__(self, other):
       """Divide a constant by a raster band
@@ -656,7 +656,7 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
          The resulting band is lazily evaluated.
       """
       other = Band._get_as_band_if_possible(other)
-      return self.DivDoubleByBand(other)._add_parent_references([self])
+      return _gdal.Band_DivDoubleByBand(self, other)._add_parent_references([self])
 
   def __gt__(self, other):
       """Return a band whose value is 1 if the pixel value of the left operand
@@ -666,9 +666,9 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
       """
       other = Band._get_as_band_if_possible(other)
       if isinstance(other, Band):
-          return self.GreaterThan(other)._add_parent_references([self, other])
+          return _gdal.Band_GreaterThan(self, other)._add_parent_references([self, other])
       else:
-          return self.GreaterThanDouble(other)._add_parent_references([self])
+          return _gdal.Band_GreaterThanDouble(self, other)._add_parent_references([self])
 
   def __ge__(self, other):
       """Return a band whose value is 1 if the pixel value of the left operand
@@ -678,9 +678,9 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
       """
       other = Band._get_as_band_if_possible(other)
       if isinstance(other, Band):
-          return self.GreaterOrEqualTo(other)._add_parent_references([self, other])
+          return _gdal.Band_GreaterOrEqualTo(self, other)._add_parent_references([self, other])
       else:
-          return self.GreaterOrEqualToDouble(other)._add_parent_references([self])
+          return _gdal.Band_GreaterOrEqualToDouble(self, other)._add_parent_references([self])
 
   def __lt__(self, other):
       """Return a band whose value is 1 if the pixel value of the left operand
@@ -690,9 +690,9 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
       """
       other = Band._get_as_band_if_possible(other)
       if isinstance(other, Band):
-          return self.LesserThan(other)._add_parent_references([self, other])
+          return _gdal.Band_LesserThan(self, other)._add_parent_references([self, other])
       else:
-          return self.LesserThanDouble(other)._add_parent_references([self])
+          return _gdal.Band_LesserThanDouble(self, other)._add_parent_references([self])
 
   def __le__(self, other):
       """Return a band whose value is 1 if the pixel value of the left operand
@@ -702,9 +702,9 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
       """
       other = Band._get_as_band_if_possible(other)
       if isinstance(other, Band):
-          return self.LesserOrEqualTo(other)._add_parent_references([self, other])
+          return _gdal.Band_LesserOrEqualTo(self, other)._add_parent_references([self, other])
       else:
-          return self.LesserOrEqualToDouble(other)._add_parent_references([self])
+          return _gdal.Band_LesserOrEqualToDouble(self, other)._add_parent_references([self])
 
   def __eq__(self, other):
       """Return a band whose value is 1 if the pixel value of the left operand
@@ -714,9 +714,9 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
       """
       other = Band._get_as_band_if_possible(other)
       if isinstance(other, Band):
-          return self.EqualTo(other)._add_parent_references([self, other])
+          return _gdal.Band_EqualTo(self, other)._add_parent_references([self, other])
       else:
-          return self.EqualToDouble(other)._add_parent_references([self])
+          return _gdal.Band_EqualToDouble(self, other)._add_parent_references([self])
 
   def __ne__(self, other):
       """Return a band whose value is 1 if the pixel value of the left operand
@@ -726,9 +726,9 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
       """
       other = Band._get_as_band_if_possible(other)
       if isinstance(other, Band):
-          return self.NotEqualTo(other)._add_parent_references([self, other])
+          return _gdal.Band_NotEqualTo(self, other)._add_parent_references([self, other])
       else:
-          return self.NotEqualToDouble(other)._add_parent_references([self])
+          return _gdal.Band_NotEqualToDouble(self, other)._add_parent_references([self])
 
   def astype(self, dt):
       """Cast this band to the specified data type
@@ -745,7 +745,7 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
           except Exception:
               raise ValueError( "Invalid dt value")
 
-      return self.AsType(dt)._add_parent_references([self])
+      return _gdal.Band_AsType(self, dt)._add_parent_references([self])
 
   @staticmethod
   def where(cond_band, then_band, else_band):
@@ -768,7 +768,7 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
       if not isinstance(else_band, Band):
           else_band = (cond_band * 0).astype(DataTypeUnionWithValue(gdalconst.GDT_Unknown, else_band, False)) + else_band
 
-      return Band.IfThenElse(cond_band, then_band, else_band)._add_parent_references([cond_band, then_band, else_band])
+      return _gdal.Band_IfThenElse(cond_band, then_band, else_band)._add_parent_references([cond_band, then_band, else_band])
 
   @staticmethod
   def minimum(*args):
@@ -789,9 +789,9 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
               constant = arg
       if not band_args:
           raise RuntimeError("At least one argument should be a band (or convertible to a band)")
-      res = Band.MinimumOfNBands(band_args)._add_parent_references(band_refs)
+      res = _gdal.Band_MinimumOfNBands(band_args)._add_parent_references(band_refs)
       if constant is not None:
-          res = res.MinConstant(constant)._add_parent_references([res])
+          res = _gdal.Band_MinConstant(res, constant)._add_parent_references([res])
       return res
 
   @staticmethod
@@ -813,9 +813,9 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
               constant = arg
       if not band_args:
           raise RuntimeError("At least one argument should be a band (or convertible to a band)")
-      res = Band.MaximumOfNBands(band_args)._add_parent_references(band_refs)
+      res = _gdal.Band_MaximumOfNBands(band_args)._add_parent_references(band_refs)
       if constant is not None:
-          res = res.MaxConstant(constant)._add_parent_references([res])
+          res = _gdal.Band_MaxConstant(res, constant)._add_parent_references([res])
       return res
 
   @staticmethod
@@ -827,7 +827,7 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
       """
       bands = [Band._get_as_band_if_possible(band) for band in args]
       band_refs = [band for band in args]
-      return Band.MeanOfNBands(bands)._add_parent_references(band_refs)
+      return _gdal.Band_MeanOfNBands(bands)._add_parent_references(band_refs)
 
   def ReadRaster(self, xoff=0, yoff=0, xsize=None, ysize=None,
                  buf_xsize=None, buf_ysize=None, buf_type=None,

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -2280,6 +2280,14 @@ def _WarnIfUserHasNotSpecifiedIfUsingOgrExceptions():
 
 %pythonprepend CreateCopy %{
     _WarnIfUserHasNotSpecifiedIfUsingExceptions()
+
+    if len(args) >= 2 and isinstance(args[1], Band):
+        ds = args[1].GetDataset()
+        if ds:
+            args = [arg for arg in args]
+            args[1] = ds
+            args = tuple(args)
+
 %}
 
 %pythonprepend Delete %{

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -748,6 +748,29 @@ void wrapper_VSIGetMemFileBuffer(const char *utf8_path, GByte **out, vsi_l_offse
       return self.AsType(dt)._add_parent_references([self])
 
   @staticmethod
+  def where(cond_band, then_band, else_band):
+      """Ternary operator. Return a band whose value is then_band if the
+         corresponding pixel in cond_band is not zero, or the one from else_band
+         otherwise.
+
+         cond_band must be a band or convertible to a band. then_band or else_band
+         can be band, convertible to band or numeric constants.
+
+         The resulting band is lazily evaluated.
+      """
+      cond_band = Band._get_as_band_if_possible(cond_band)
+      then_band = Band._get_as_band_if_possible(then_band)
+      else_band = Band._get_as_band_if_possible(else_band)
+
+      if not isinstance(then_band, Band):
+          then_band = (cond_band * 0).astype(DataTypeUnionWithValue(gdalconst.GDT_Unknown, then_band, False)) + then_band
+
+      if not isinstance(else_band, Band):
+          else_band = (cond_band * 0).astype(DataTypeUnionWithValue(gdalconst.GDT_Unknown, else_band, False)) + else_band
+
+      return Band.IfThenElse(cond_band, then_band, else_band)._add_parent_references([cond_band, then_band, else_band])
+
+  @staticmethod
   def minimum(*args):
       """Return a band whose each pixel value is the minimum of the corresponding
          pixel values in the input arguments which may be gdal.Band or a numeric constant.


### PR DESCRIPTION
Documentation in https://gdal--12507.org.readthedocs.build/en/12507/user/band_algebra.html

Uses VRTDerivedRasterBand and pixel functions underneath.

Demo program converting a RGB image to grey level:

- Python:

 ```python
from osgeo import gdal
gdal.UseExceptions()
    
with gdal.Open("rgbsmall.tif") as ds:
    R = ds.GetRasterBand(1)
    G = ds.GetRasterBand(2)
    B = ds.GetRasterBand(3)
    greylevel = (0.299 * R + 0.587 * G + 0.114 * B).astype(gdal.GDT_Byte)
    gdal.GetDriverByName("GTiff").CreateCopy("greylevel.tif", greylevel)
```

- C++:

```cpp
#include <gdal_priv.h>

int main()
{
    GDALAllRegister();

    auto poDS = std::unique_ptr<GDALDataset>(GDALDataset::Open("rgbsmall.tif"));
    auto& R = *(poDS->GetRasterBand(1));
    auto& G = *(poDS->GetRasterBand(2));
    auto& B = *(poDS->GetRasterBand(3));
    auto greylevel = (0.299 * R + 0.587 * G + 0.114 * B).AsType(GDT_Byte);

    auto poGTiffDrv = GetGDALDriverManager()->GetDriverByName("GTiff");
    std::unique_ptr<GDALDataset>(
        poGTiffDrv->CreateCopy("greylevel.tif", greylevel.GetDataset(), false, nullptr, nullptr, nullptr)).reset();

    return 0;
}
```

CC @dbaston I've experimented with the above as a potentially alternative/complement to gdal raster calc for C++ & Python users. Thoughts?