### PR TITLE
GDALMDArray::AsClassicDataset(): accept a "attribute" key in BAND_METADATA and BAND_IMAGERY_METADATA options

### DIFF
--- a/autotest/gcore/multidim.py
+++ b/autotest/gcore/multidim.py
@@ -652,7 +652,19 @@ def test_multidim_asclassicsubdataset_band_metadata():
         ar.AsClassicDataset(2, 1, rg, ["BAND_METADATA=false"])
 
     band_metadata = [{"item_name": "name"}]
-    with pytest.raises(Exception, match=r"BAND_METADATA\[0\]\[\"array\"\] is missing"):
+    with pytest.raises(
+        Exception,
+        match=r"BAND_METADATA\[0\]\[\"array\"\] or BAND_METADATA\[0\]\[\"attribute\"\] is missing",
+    ):
+        ds = ar.AsClassicDataset(
+            2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)]
+        )
+
+    band_metadata = [{"array": "foo", "attribute": "bar"}]
+    with pytest.raises(
+        Exception,
+        match=r"BAND_METADATA\[0\]\[\"array\"\] and BAND_METADATA\[0\]\[\"attribute\"\] are mutually exclusive",
+    ):
         ds = ar.AsClassicDataset(
             2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)]
         )
@@ -723,7 +735,7 @@ def test_multidim_asclassicsubdataset_band_metadata():
         )
 
     band_metadata = [{"array": "/aux_var", "item_name": "AUX_VAR", "item_value": "%f"}]
-    with pytest.raises(Exception, match="Data type of other array is not numeric"):
+    with pytest.raises(Exception, match="Data type of aux_var array is not numeric"):
         ds = ar.AsClassicDataset(
             2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)]
         )
@@ -796,6 +808,126 @@ def test_multidim_asclassicsubdataset_band_metadata():
         "AUX_VAR": "bar",
     }
 
+    band_metadata = [{"attribute": "foo", "item_name": "name"}]
+    with pytest.raises(Exception, match="Attribute foo cannot be found"):
+        ds = ar.AsClassicDataset(
+            2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)]
+        )
+
+    band_metadata = [{"attribute": "/foo", "item_name": "name"}]
+    with pytest.raises(Exception, match="Attribute /foo cannot be found"):
+        ds = ar.AsClassicDataset(
+            2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)]
+        )
+
+    ar.CreateAttribute(
+        "2D_attr", [2, 3], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+
+    band_metadata = [{"attribute": "2D_attr", "item_name": "name"}]
+    with pytest.raises(Exception, match="Attribute 2D_attr is not a 1D array"):
+        ds = ar.AsClassicDataset(
+            2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)]
+        )
+
+    band_metadata = [{"attribute": "/ar/2D_attr", "item_name": "name"}]
+    with pytest.raises(Exception, match="Attribute /ar/2D_attr is not a 1D array"):
+        ds = ar.AsClassicDataset(
+            2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)]
+        )
+
+    rg.CreateAttribute(
+        "2D_attr_on_rg", [2, 3], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+
+    band_metadata = [{"attribute": "/2D_attr_on_rg", "item_name": "name"}]
+    with pytest.raises(Exception, match="Attribute /2D_attr_on_rg is not a 1D array"):
+        ds = ar.AsClassicDataset(
+            2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)]
+        )
+
+    subg = rg.CreateGroup("subgroup")
+    subg.CreateAttribute(
+        "2D_attr_on_subg", [2, 3], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+
+    band_metadata = [{"attribute": "/subgroup/2D_attr_on_subg", "item_name": "name"}]
+    with pytest.raises(
+        Exception, match="Attribute /subgroup/2D_attr_on_subg is not a 1D array"
+    ):
+        ds = ar.AsClassicDataset(
+            2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)]
+        )
+
+    ar.CreateAttribute(
+        "non_matching_attr", [100], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+
+    band_metadata = [{"attribute": "non_matching_attr", "item_name": "name"}]
+    with pytest.raises(
+        Exception,
+        match="No dimension of ar has the same size as attribute non_matching_attr",
+    ):
+        ds = ar.AsClassicDataset(
+            2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)]
+        )
+
+    dimOther2 = rg.CreateDimension("other2", None, None, 2)
+    ar2 = rg.CreateMDArray(
+        "ar2",
+        [dimOther2, dimOther, dimY, dimX],
+        gdal.ExtendedDataType.Create(gdal.GDT_Float64),
+    )
+    ar2.CreateAttribute(
+        "attr", [dimOther.GetSize()], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    units = ar2.CreateAttribute("units", [], gdal.ExtendedDataType.CreateString())
+    units.Write("my_units")
+    band_metadata = [{"attribute": "attr", "item_name": "name"}]
+    with pytest.raises(
+        Exception,
+        match="Several dimensions of ar2 have the same size as attribute attr. Cannot infer which one to bind to!",
+    ):
+        ds = ar2.AsClassicDataset(
+            3, 2, rg, ["BAND_METADATA=" + json.dumps(band_metadata)]
+        )
+
+    attr = ar.CreateAttribute(
+        "attr", [dimOther.GetSize()], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    attr.Write([123, 456])
+
+    band_metadata = [
+        {
+            "attribute": "attr",
+            "item_name": "val_attr",
+            "item_value": "%.0f ${/ar2/units}",
+        }
+    ]
+    ds = ar.AsClassicDataset(2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)])
+    assert ds.GetRasterBand(1).GetMetadata() == {
+        "DIM_other_INDEX": "0",
+        "DIM_other_VALUE": "10.5",
+        "val_attr": "123 my_units",
+    }
+    assert ds.GetRasterBand(2).GetMetadata() == {
+        "DIM_other_INDEX": "1",
+        "DIM_other_VALUE": "20",
+        "val_attr": "456 my_units",
+    }
+
+    band_metadata = [
+        {
+            "attribute": "attr",
+            "item_name": "name",
+            "item_value": "%.0f ${/i/do/not/exist}",
+        }
+    ]
+    with pytest.raises(Exception, match="/i/do/not/exist is not an attribute"):
+        ds = ar.AsClassicDataset(
+            2, 1, rg, ["BAND_METADATA=" + json.dumps(band_metadata)]
+        )
+
 
 @gdaltest.enable_exceptions()
 def test_multidim_asclassicsubdataset_band_imagery_metadata():
@@ -850,7 +982,16 @@ def test_multidim_asclassicsubdataset_band_imagery_metadata():
     band_metadata = {"CENTRAL_WAVELENGTH_UM": {}}
     with pytest.raises(
         Exception,
-        match=r'BAND_IMAGERY_METADATA\["CENTRAL_WAVELENGTH_UM"\]\["array"\] is missing',
+        match=r'BAND_IMAGERY_METADATA\["CENTRAL_WAVELENGTH_UM"\]\["array"\] or BAND_IMAGERY_METADATA\["CENTRAL_WAVELENGTH_UM"\]\["attribute"\] is missing',
+    ):
+        ds = ar.AsClassicDataset(
+            2, 1, rg, ["BAND_IMAGERY_METADATA=" + json.dumps(band_metadata)]
+        )
+
+    band_metadata = {"CENTRAL_WAVELENGTH_UM": {"array": "foo", "attribute": "bar"}}
+    with pytest.raises(
+        Exception,
+        match=r'BAND_IMAGERY_METADATA\["CENTRAL_WAVELENGTH_UM"\]\["array"\] and BAND_IMAGERY_METADATA\["CENTRAL_WAVELENGTH_UM"\]\["attribute"\] are mutually exclusive',
     ):
         ds = ar.AsClassicDataset(
             2, 1, rg, ["BAND_IMAGERY_METADATA=" + json.dumps(band_metadata)]
@@ -924,6 +1065,85 @@ def test_multidim_asclassicsubdataset_band_imagery_metadata():
     assert ds.GetRasterBand(2).GetMetadata("IMAGERY") == {
         "CENTRAL_WAVELENGTH_UM": "0.02",
         "FWHM_UM": "4.5",
+    }
+
+    band_metadata = {"CENTRAL_WAVELENGTH_UM": {"attribute": "i_do_not_exist"}}
+    with pytest.raises(Exception, match="Attribute i_do_not_exist cannot be found"):
+        ds = ar.AsClassicDataset(
+            2, 1, rg, ["BAND_IMAGERY_METADATA=" + json.dumps(band_metadata)]
+        )
+
+    band_metadata = {"CENTRAL_WAVELENGTH_UM": {"attribute": "/i/do/not/exist"}}
+    with pytest.raises(Exception, match="Attribute /i/do/not/exist cannot be found"):
+        ds = ar.AsClassicDataset(
+            2, 1, rg, ["BAND_IMAGERY_METADATA=" + json.dumps(band_metadata)]
+        )
+
+    ar.CreateAttribute(
+        "2D_attr", [2, 3], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+
+    band_metadata = {"CENTRAL_WAVELENGTH_UM": {"attribute": "2D_attr"}}
+    with pytest.raises(Exception, match="Attribute 2D_attr is not a 1D array"):
+        ds = ar.AsClassicDataset(
+            2, 1, rg, ["BAND_IMAGERY_METADATA=" + json.dumps(band_metadata)]
+        )
+
+    band_metadata = {"CENTRAL_WAVELENGTH_UM": {"attribute": "/ar/2D_attr"}}
+    with pytest.raises(Exception, match="Attribute /ar/2D_attr is not a 1D array"):
+        ds = ar.AsClassicDataset(
+            2, 1, rg, ["BAND_IMAGERY_METADATA=" + json.dumps(band_metadata)]
+        )
+
+    ar.CreateAttribute(
+        "non_matching_attr", [100], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+
+    band_metadata = {"CENTRAL_WAVELENGTH_UM": {"attribute": "non_matching_attr"}}
+    with pytest.raises(
+        Exception,
+        match="No dimension of ar has the same size as attribute non_matching_attr",
+    ):
+        ds = ar.AsClassicDataset(
+            2, 1, rg, ["BAND_IMAGERY_METADATA=" + json.dumps(band_metadata)]
+        )
+
+    dimOther2 = rg.CreateDimension("other2", None, None, 2)
+    ar2 = rg.CreateMDArray(
+        "ar2",
+        [dimOther2, dimOther, dimY, dimX],
+        gdal.ExtendedDataType.Create(gdal.GDT_Float64),
+    )
+    ar2.CreateAttribute(
+        "attr", [dimOther.GetSize()], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    units = ar2.CreateAttribute("units", [], gdal.ExtendedDataType.CreateString())
+    units.Write("micrometer")
+
+    band_metadata = {"CENTRAL_WAVELENGTH_UM": {"attribute": "attr"}}
+    with pytest.raises(
+        Exception,
+        match="Several dimensions of ar2 have the same size as attribute attr. Cannot infer which one to bind to!",
+    ):
+        ds = ar2.AsClassicDataset(
+            3, 2, rg, ["BAND_IMAGERY_METADATA=" + json.dumps(band_metadata)]
+        )
+
+    attr = ar.CreateAttribute(
+        "attr", [dimOther.GetSize()], gdal.ExtendedDataType.Create(gdal.GDT_Float64)
+    )
+    attr.Write([123, 456])
+    band_metadata = {
+        "CENTRAL_WAVELENGTH_UM": {"attribute": "attr", "unit": "${/ar2/units}"}
+    }
+    ds = ar.AsClassicDataset(
+        2, 1, rg, ["BAND_IMAGERY_METADATA=" + json.dumps(band_metadata)]
+    )
+    assert ds.GetRasterBand(1).GetMetadata("IMAGERY") == {
+        "CENTRAL_WAVELENGTH_UM": "123",
+    }
+    assert ds.GetRasterBand(2).GetMetadata("IMAGERY") == {
+        "CENTRAL_WAVELENGTH_UM": "456",
     }
 
 

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -3211,6 +3211,10 @@ class CPL_DLL GDALGroup : public GDALIHasAttribute
     OpenMDArrayFromFullname(const std::string &osFullName,
                             CSLConstList papszOptions = nullptr) const;
 
+    std::shared_ptr<GDALAttribute>
+    OpenAttributeFromFullname(const std::string &osFullName,
+                              CSLConstList papszOptions = nullptr) const;
+
     std::shared_ptr<GDALMDArray>
     ResolveMDArray(const std::string &osName, const std::string &osStartingPath,
                    CSLConstList papszOptions = nullptr) const;

--- a/gcore/gdalmultidim.cpp
+++ b/gcore/gdalmultidim.cpp
@@ -1292,6 +1292,31 @@ GDALGroup::OpenMDArrayFromFullname(const std::string &osFullName,
 }
 
 /************************************************************************/
+/*                      OpenAttributeFromFullname()                     */
+/************************************************************************/
+
+/** Get an attribute from its fully qualified name */
+std::shared_ptr<GDALAttribute>
+GDALGroup::OpenAttributeFromFullname(const std::string &osFullName,
+                                     CSLConstList papszOptions) const
+{
+    const auto pos = osFullName.rfind('/');
+    if (pos == std::string::npos)
+        return nullptr;
+    const std::string attrName = osFullName.substr(pos + 1);
+    if (pos == 0)
+        return GetAttribute(attrName);
+    const std::string container = osFullName.substr(0, pos);
+    auto poArray = OpenMDArrayFromFullname(container, papszOptions);
+    if (poArray)
+        return poArray->GetAttribute(attrName);
+    auto poGroup = OpenGroupFromFullname(container, papszOptions);
+    if (poGroup)
+        return poGroup->GetAttribute(attrName);
+    return nullptr;
+}
+
+/************************************************************************/
 /*                          ResolveMDArray()                            */
 /************************************************************************/
 
@@ -8570,7 +8595,7 @@ namespace
 {
 struct MetadataItem
 {
-    std::shared_ptr<GDALMDArray> poArray{};
+    std::shared_ptr<GDALAbstractMDArray> poArray{};
     std::string osName{};
     std::string osDefinition{};
     bool bDefinitionUsesPctForG = false;
@@ -8578,9 +8603,9 @@ struct MetadataItem
 
 struct BandImageryMetadata
 {
-    std::shared_ptr<GDALMDArray> poCentralWavelengthArray{};
+    std::shared_ptr<GDALAbstractMDArray> poCentralWavelengthArray{};
     double dfCentralWavelengthToMicrometer = 1.0;
-    std::shared_ptr<GDALMDArray> poFWHMArray{};
+    std::shared_ptr<GDALAbstractMDArray> poFWHMArray{};
     double dfFWHMToMicrometer = 1.0;
 };
 
@@ -9242,11 +9267,13 @@ GDALDatasetFromArray *GDALDatasetFromArray::Create(
     }
 
     std::map<std::string, size_t> oMapArrayDimNameToExtraDimIdx;
+    std::vector<size_t> oMapArrayExtraDimIdxToOriginalIdx;
     for (size_t i = 0, j = 0; i < nDimCount; ++i)
     {
         if (i != iXDim && !(nDimCount >= 2 && i == iYDim))
         {
             oMapArrayDimNameToExtraDimIdx[dims[i]->GetName()] = j;
+            oMapArrayExtraDimIdxToOriginalIdx.push_back(i);
             ++j;
         }
     }
@@ -9285,44 +9312,117 @@ GDALDatasetFromArray *GDALDatasetFromArray::Create(
         {
             const auto oJsonItem = oArray[j];
             MetadataItem oItem;
+            size_t iExtraDimIdx = 0;
 
-            auto osBandArrayFullname = oJsonItem.GetString("array");
-            if (osBandArrayFullname.empty())
+            const auto osBandArrayFullname = oJsonItem.GetString("array");
+            const auto osBandAttributeName = oJsonItem.GetString("attribute");
+            std::shared_ptr<GDALMDArray> poArray;
+            std::shared_ptr<GDALAttribute> poAttribute;
+            if (osBandArrayFullname.empty() && osBandAttributeName.empty())
             {
                 CPLError(CE_Failure, CPLE_AppDefined,
-                         "BAND_METADATA[%d][\"array\"] is missing", j);
+                         "BAND_METADATA[%d][\"array\"] or "
+                         "BAND_METADATA[%d][\"attribute\"] is missing",
+                         j, j);
                 return nullptr;
             }
-            oItem.poArray =
-                poRootGroup->OpenMDArrayFromFullname(osBandArrayFullname);
-            if (!oItem.poArray)
+            else if (!osBandArrayFullname.empty() &&
+                     !osBandAttributeName.empty())
             {
-                CPLError(CE_Failure, CPLE_AppDefined,
-                         "Array %s cannot be found",
-                         osBandArrayFullname.c_str());
+                CPLError(
+                    CE_Failure, CPLE_AppDefined,
+                    "BAND_METADATA[%d][\"array\"] and "
+                    "BAND_METADATA[%d][\"attribute\"] are mutually exclusive",
+                    j, j);
                 return nullptr;
             }
-            if (oItem.poArray->GetDimensionCount() != 1)
+            else if (!osBandArrayFullname.empty())
             {
-                CPLError(CE_Failure, CPLE_AppDefined,
-                         "Array %s is not a 1D array",
-                         osBandArrayFullname.c_str());
-                return nullptr;
+                poArray =
+                    poRootGroup->OpenMDArrayFromFullname(osBandArrayFullname);
+                if (!poArray)
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "Array %s cannot be found",
+                             osBandArrayFullname.c_str());
+                    return nullptr;
+                }
+                if (poArray->GetDimensionCount() != 1)
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "Array %s is not a 1D array",
+                             osBandArrayFullname.c_str());
+                    return nullptr;
+                }
+                const auto &osAuxArrayDimName =
+                    poArray->GetDimensions()[0]->GetName();
+                auto oIter =
+                    oMapArrayDimNameToExtraDimIdx.find(osAuxArrayDimName);
+                if (oIter == oMapArrayDimNameToExtraDimIdx.end())
+                {
+                    CPLError(
+                        CE_Failure, CPLE_AppDefined,
+                        "Dimension %s of array %s is not a non-X/Y dimension "
+                        "of array %s",
+                        osAuxArrayDimName.c_str(), osBandArrayFullname.c_str(),
+                        array->GetName().c_str());
+                    return nullptr;
+                }
+                iExtraDimIdx = oIter->second;
+                CPLAssert(iExtraDimIdx < nNewDimCount);
             }
-            const auto &osAuxArrayDimName =
-                oItem.poArray->GetDimensions()[0]->GetName();
-            auto oIter = oMapArrayDimNameToExtraDimIdx.find(osAuxArrayDimName);
-            if (oIter == oMapArrayDimNameToExtraDimIdx.end())
+            else
             {
-                CPLError(CE_Failure, CPLE_AppDefined,
-                         "Dimension %s of array %s is not a non-X/Y dimension "
-                         "of array %s",
-                         osAuxArrayDimName.c_str(), osBandArrayFullname.c_str(),
-                         array->GetName().c_str());
-                return nullptr;
+                CPLAssert(!osBandAttributeName.empty());
+                poAttribute = !osBandAttributeName.empty() &&
+                                      osBandAttributeName[0] == '/'
+                                  ? poRootGroup->OpenAttributeFromFullname(
+                                        osBandAttributeName)
+                                  : array->GetAttribute(osBandAttributeName);
+                if (!poAttribute)
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "Attribute %s cannot be found",
+                             osBandAttributeName.c_str());
+                    return nullptr;
+                }
+                const auto aoAttrDims = poAttribute->GetDimensionsSize();
+                if (aoAttrDims.size() != 1)
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "Attribute %s is not a 1D array",
+                             osBandAttributeName.c_str());
+                    return nullptr;
+                }
+                bool found = false;
+                for (const auto &iter : oMapArrayDimNameToExtraDimIdx)
+                {
+                    if (dims[oMapArrayExtraDimIdxToOriginalIdx[iter.second]]
+                            ->GetSize() == aoAttrDims[0])
+                    {
+                        if (found)
+                        {
+                            CPLError(CE_Failure, CPLE_AppDefined,
+                                     "Several dimensions of %s have the same "
+                                     "size as attribute %s. Cannot infer which "
+                                     "one to bind to!",
+                                     array->GetName().c_str(),
+                                     osBandAttributeName.c_str());
+                            return nullptr;
+                        }
+                        found = true;
+                        iExtraDimIdx = iter.second;
+                    }
+                }
+                if (!found)
+                {
+                    CPLError(
+                        CE_Failure, CPLE_AppDefined,
+                        "No dimension of %s has the same size as attribute %s",
+                        array->GetName().c_str(), osBandAttributeName.c_str());
+                    return nullptr;
+                }
             }
-            const size_t iExtraDimIdx = oIter->second;
-            CPLAssert(iExtraDimIdx < nNewDimCount);
 
             oItem.osName = oJsonItem.GetString("item_name");
             if (oItem.osName.empty())
@@ -9347,10 +9447,9 @@ GDALDatasetFromArray *GDALDatasetFromArray::Create(
                     {
                         CPLError(CE_Failure, CPLE_AppDefined,
                                  "Value of "
-                                 "BAND_METADATA[\"%s\"][%d][\"item_value\"] = "
+                                 "BAND_METADATA[%d][\"item_value\"] = "
                                  "%s is invalid at offset %d",
-                                 osAuxArrayDimName.c_str(), j,
-                                 osDefinition.c_str(), int(k));
+                                 j, osDefinition.c_str(), int(k));
                         return nullptr;
                     }
                     ++k;
@@ -9361,14 +9460,12 @@ GDALDatasetFromArray *GDALDatasetFromArray::Create(
                     }
                     if (!bFirstNumericFormatter)
                     {
-                        CPLError(
-                            CE_Failure, CPLE_AppDefined,
-                            "Value of "
-                            "BAND_METADATA[\"%s\"][%d][\"item_value\"] = %s is "
-                            "invalid at offset %d: %%[x][.y]f|g or %%s "
-                            "formatters should be specified at most once",
-                            osAuxArrayDimName.c_str(), j, osDefinition.c_str(),
-                            int(k));
+                        CPLError(CE_Failure, CPLE_AppDefined,
+                                 "Value of "
+                                 "BAND_METADATA[%d][\"item_value\"] = %s is "
+                                 "invalid at offset %d: %%[x][.y]f|g or %%s "
+                                 "formatters should be specified at most once",
+                                 j, osDefinition.c_str(), int(k));
                         return nullptr;
                     }
                     bFirstNumericFormatter = false;
@@ -9386,23 +9483,31 @@ GDALDatasetFromArray *GDALDatasetFromArray::Create(
                     {
                         CPLError(CE_Failure, CPLE_AppDefined,
                                  "Value of "
-                                 "BAND_METADATA[\"%s\"][%d][\"item_value\"] = "
+                                 "BAND_METADATA[%d][\"item_value\"] = "
                                  "%s is invalid at offset %d: only "
                                  "%%[x][.y]f|g or %%s formatters are accepted",
-                                 osAuxArrayDimName.c_str(), j,
-                                 osDefinition.c_str(), int(k));
+                                 j, osDefinition.c_str(), int(k));
                         return nullptr;
                     }
                     bDefinitionUsesPctForG =
                         (osDefinition[k] == 'f' || osDefinition[k] == 'g');
                     if (bDefinitionUsesPctForG)
                     {
-                        if (oItem.poArray->GetDataType().GetClass() !=
-                            GEDTC_NUMERIC)
+                        if (poArray &&
+                            poArray->GetDataType().GetClass() != GEDTC_NUMERIC)
                         {
                             CPLError(CE_Failure, CPLE_AppDefined,
                                      "Data type of %s array is not numeric",
-                                     osAuxArrayDimName.c_str());
+                                     poArray->GetName().c_str());
+                            return nullptr;
+                        }
+                        else if (poAttribute &&
+                                 poAttribute->GetDataType().GetClass() !=
+                                     GEDTC_NUMERIC)
+                        {
+                            CPLError(CE_Failure, CPLE_AppDefined,
+                                     "Data type of %s attribue is not numeric",
+                                     poAttribute->GetFullName().c_str());
                             return nullptr;
                         }
                     }
@@ -9416,34 +9521,52 @@ GDALDatasetFromArray *GDALDatasetFromArray::Create(
                     {
                         CPLError(CE_Failure, CPLE_AppDefined,
                                  "Value of "
-                                 "BAND_METADATA[\"%s\"][%d][\"item_value\"] = "
+                                 "BAND_METADATA[%d][\"item_value\"] = "
                                  "%s is invalid at offset %d",
-                                 osAuxArrayDimName.c_str(), j,
-                                 osDefinition.c_str(), int(k));
+                                 j, osDefinition.c_str(), int(k));
                         return nullptr;
                     }
                     const auto osAttrName =
                         osDefinition.substr(k + 2, nPos - (k + 2));
-                    auto poAttr = oItem.poArray->GetAttribute(osAttrName);
-                    if (!poAttr)
+                    std::shared_ptr<GDALAttribute> poAttr;
+                    if (poArray && !osAttrName.empty() && osAttrName[0] != '/')
                     {
-                        CPLError(CE_Failure, CPLE_AppDefined,
-                                 "Value of "
-                                 "BAND_METADATA[\"%s\"][%d][\"item_value\"] = "
-                                 "%s is invalid: %s is not an attribute of %s",
-                                 osAuxArrayDimName.c_str(), j,
-                                 osDefinition.c_str(), osAttrName.c_str(),
-                                 osAuxArrayDimName.c_str());
-                        return nullptr;
+                        poAttr = poArray->GetAttribute(osAttrName);
+                        if (!poAttr)
+                        {
+                            CPLError(
+                                CE_Failure, CPLE_AppDefined,
+                                "Value of "
+                                "BAND_METADATA[%d][\"item_value\"] = "
+                                "%s is invalid: %s is not an attribute of %s",
+                                j, osDefinition.c_str(), osAttrName.c_str(),
+                                poArray->GetName().c_str());
+                            return nullptr;
+                        }
+                    }
+                    else
+                    {
+                        poAttr =
+                            poRootGroup->OpenAttributeFromFullname(osAttrName);
+                        if (!poAttr)
+                        {
+                            CPLError(CE_Failure, CPLE_AppDefined,
+                                     "Value of "
+                                     "BAND_METADATA[%d][\"item_value\"] = "
+                                     "%s is invalid: %s is not an attribute",
+                                     j, osDefinition.c_str(),
+                                     osAttrName.c_str());
+                            return nullptr;
+                        }
                     }
                     k = nPos;
                     const char *pszValue = poAttr->ReadAsString();
                     if (!pszValue)
                     {
                         CPLError(CE_Failure, CPLE_AppDefined,
-                                 "Cannot get value of attribute %s of %s as a "
+                                 "Cannot get value of attribute %s as a "
                                  "string",
-                                 osAttrName.c_str(), osAuxArrayDimName.c_str());
+                                 osAttrName.c_str());
                         return nullptr;
                     }
                     osModDefinition += pszValue;
@@ -9454,6 +9577,10 @@ GDALDatasetFromArray *GDALDatasetFromArray::Create(
                 }
             }
 
+            if (poArray)
+                oItem.poArray = std::move(poArray);
+            else
+                oItem.poArray = std::move(poAttribute);
             oItem.osDefinition = std::move(osModDefinition);
             oItem.bDefinitionUsesPctForG = bDefinitionUsesPctForG;
 
@@ -9493,47 +9620,121 @@ GDALDatasetFromArray *GDALDatasetFromArray::Create(
             if (oJsonItem.GetName() == "CENTRAL_WAVELENGTH_UM" ||
                 oJsonItem.GetName() == "FWHM_UM")
             {
-                auto osBandArrayFullname = oJsonItem.GetString("array");
-                if (osBandArrayFullname.empty())
-                {
-                    CPLError(
-                        CE_Failure, CPLE_AppDefined,
-                        "BAND_IMAGERY_METADATA[\"%s\"][\"array\"] is missing",
-                        oJsonItem.GetName().c_str());
-                    return nullptr;
-                }
-                auto poArray =
-                    poRootGroup->OpenMDArrayFromFullname(osBandArrayFullname);
-                if (!poArray)
+                const auto osBandArrayFullname = oJsonItem.GetString("array");
+                const auto osBandAttributeName =
+                    oJsonItem.GetString("attribute");
+                std::shared_ptr<GDALMDArray> poArray;
+                std::shared_ptr<GDALAttribute> poAttribute;
+                size_t iExtraDimIdx = 0;
+                if (osBandArrayFullname.empty() && osBandAttributeName.empty())
                 {
                     CPLError(CE_Failure, CPLE_AppDefined,
-                             "Array %s cannot be found",
-                             osBandArrayFullname.c_str());
+                             "BAND_IMAGERY_METADATA[\"%s\"][\"array\"] or "
+                             "BAND_IMAGERY_METADATA[\"%s\"][\"attribute\"] is "
+                             "missing",
+                             oJsonItem.GetName().c_str(),
+                             oJsonItem.GetName().c_str());
                     return nullptr;
                 }
-                if (poArray->GetDimensionCount() != 1)
+                else if (!osBandArrayFullname.empty() &&
+                         !osBandAttributeName.empty())
                 {
                     CPLError(CE_Failure, CPLE_AppDefined,
-                             "Array %s is not a 1D array",
-                             osBandArrayFullname.c_str());
+                             "BAND_IMAGERY_METADATA[\"%s\"][\"array\"] and "
+                             "BAND_IMAGERY_METADATA[\"%s\"][\"attribute\"] are "
+                             "mutually exclusive",
+                             oJsonItem.GetName().c_str(),
+                             oJsonItem.GetName().c_str());
                     return nullptr;
                 }
-                const auto &osAuxArrayDimName =
-                    poArray->GetDimensions()[0]->GetName();
-                auto oIter =
-                    oMapArrayDimNameToExtraDimIdx.find(osAuxArrayDimName);
-                if (oIter == oMapArrayDimNameToExtraDimIdx.end())
+                else if (!osBandArrayFullname.empty())
                 {
-                    CPLError(CE_Failure, CPLE_AppDefined,
-                             "Dimension \"%s\" of array \"%s\" is not a "
-                             "non-X/Y dimension of array \"%s\"",
-                             osAuxArrayDimName.c_str(),
-                             osBandArrayFullname.c_str(),
-                             array->GetName().c_str());
-                    return nullptr;
+                    poArray = poRootGroup->OpenMDArrayFromFullname(
+                        osBandArrayFullname);
+                    if (!poArray)
+                    {
+                        CPLError(CE_Failure, CPLE_AppDefined,
+                                 "Array %s cannot be found",
+                                 osBandArrayFullname.c_str());
+                        return nullptr;
+                    }
+                    if (poArray->GetDimensionCount() != 1)
+                    {
+                        CPLError(CE_Failure, CPLE_AppDefined,
+                                 "Array %s is not a 1D array",
+                                 osBandArrayFullname.c_str());
+                        return nullptr;
+                    }
+                    const auto &osAuxArrayDimName =
+                        poArray->GetDimensions()[0]->GetName();
+                    auto oIter =
+                        oMapArrayDimNameToExtraDimIdx.find(osAuxArrayDimName);
+                    if (oIter == oMapArrayDimNameToExtraDimIdx.end())
+                    {
+                        CPLError(CE_Failure, CPLE_AppDefined,
+                                 "Dimension \"%s\" of array \"%s\" is not a "
+                                 "non-X/Y dimension of array \"%s\"",
+                                 osAuxArrayDimName.c_str(),
+                                 osBandArrayFullname.c_str(),
+                                 array->GetName().c_str());
+                        return nullptr;
+                    }
+                    iExtraDimIdx = oIter->second;
+                    CPLAssert(iExtraDimIdx < nNewDimCount);
                 }
-                const size_t iExtraDimIdx = oIter->second;
-                CPLAssert(iExtraDimIdx < nNewDimCount);
+                else
+                {
+                    poAttribute =
+                        !osBandAttributeName.empty() &&
+                                osBandAttributeName[0] == '/'
+                            ? poRootGroup->OpenAttributeFromFullname(
+                                  osBandAttributeName)
+                            : array->GetAttribute(osBandAttributeName);
+                    if (!poAttribute)
+                    {
+                        CPLError(CE_Failure, CPLE_AppDefined,
+                                 "Attribute %s cannot be found",
+                                 osBandAttributeName.c_str());
+                        return nullptr;
+                    }
+                    const auto aoAttrDims = poAttribute->GetDimensionsSize();
+                    if (aoAttrDims.size() != 1)
+                    {
+                        CPLError(CE_Failure, CPLE_AppDefined,
+                                 "Attribute %s is not a 1D array",
+                                 osBandAttributeName.c_str());
+                        return nullptr;
+                    }
+                    bool found = false;
+                    for (const auto &iter : oMapArrayDimNameToExtraDimIdx)
+                    {
+                        if (dims[oMapArrayExtraDimIdxToOriginalIdx[iter.second]]
+                                ->GetSize() == aoAttrDims[0])
+                        {
+                            if (found)
+                            {
+                                CPLError(CE_Failure, CPLE_AppDefined,
+                                         "Several dimensions of %s have the "
+                                         "same size as attribute %s. Cannot "
+                                         "infer which one to bind to!",
+                                         array->GetName().c_str(),
+                                         osBandAttributeName.c_str());
+                                return nullptr;
+                            }
+                            found = true;
+                            iExtraDimIdx = iter.second;
+                        }
+                    }
+                    if (!found)
+                    {
+                        CPLError(CE_Failure, CPLE_AppDefined,
+                                 "No dimension of %s has the same size as "
+                                 "attribute %s",
+                                 array->GetName().c_str(),
+                                 osBandAttributeName.c_str());
+                        return nullptr;
+                    }
+                }
 
                 std::string osUnit = oJsonItem.GetString("unit", "um");
                 if (STARTS_WITH(osUnit.c_str(), "${"))
@@ -9548,18 +9749,40 @@ GDALDatasetFromArray *GDALDatasetFromArray::Create(
                         return nullptr;
                     }
                     const auto osAttrName = osUnit.substr(2, osUnit.size() - 3);
-                    auto poAttr = poArray->GetAttribute(osAttrName);
-                    if (!poAttr)
+                    std::shared_ptr<GDALAttribute> poAttr;
+                    if (poArray && !osAttrName.empty() && osAttrName[0] != '/')
                     {
-                        CPLError(CE_Failure, CPLE_AppDefined,
-                                 "Value of "
-                                 "BAND_IMAGERY_METADATA[\"%s\"][\"unit\"] = "
-                                 "%s is invalid: %s is not an attribute of %s",
-                                 oJsonItem.GetName().c_str(), osUnit.c_str(),
-                                 osAttrName.c_str(),
-                                 osBandArrayFullname.c_str());
-                        return nullptr;
+                        poAttr = poArray->GetAttribute(osAttrName);
+                        if (!poAttr)
+                        {
+                            CPLError(
+                                CE_Failure, CPLE_AppDefined,
+                                "Value of "
+                                "BAND_IMAGERY_METADATA[\"%s\"][\"unit\"] = "
+                                "%s is invalid: %s is not an attribute of %s",
+                                oJsonItem.GetName().c_str(), osUnit.c_str(),
+                                osAttrName.c_str(),
+                                osBandArrayFullname.c_str());
+                            return nullptr;
+                        }
                     }
+                    else
+                    {
+                        poAttr =
+                            poRootGroup->OpenAttributeFromFullname(osAttrName);
+                        if (!poAttr)
+                        {
+                            CPLError(
+                                CE_Failure, CPLE_AppDefined,
+                                "Value of "
+                                "BAND_IMAGERY_METADATA[\"%s\"][\"unit\"] = "
+                                "%s is invalid: %s is not an attribute",
+                                oJsonItem.GetName().c_str(), osUnit.c_str(),
+                                osAttrName.c_str());
+                            return nullptr;
+                        }
+                    }
+
                     const char *pszValue = poAttr->ReadAsString();
                     if (!pszValue)
                     {
@@ -9591,14 +9814,20 @@ GDALDatasetFromArray *GDALDatasetFromArray::Create(
                 }
 
                 BandImageryMetadata &item = aoBandImageryMetadata[iExtraDimIdx];
+
+                std::shared_ptr<GDALAbstractMDArray> abstractArray;
+                if (poArray)
+                    abstractArray = std::move(poArray);
+                else
+                    abstractArray = std::move(poAttribute);
                 if (oJsonItem.GetName() == "CENTRAL_WAVELENGTH_UM")
                 {
-                    item.poCentralWavelengthArray = std::move(poArray);
+                    item.poCentralWavelengthArray = std::move(abstractArray);
                     item.dfCentralWavelengthToMicrometer = dfConvToUM;
                 }
                 else
                 {
-                    item.poFWHMArray = std::move(poArray);
+                    item.poFWHMArray = std::move(abstractArray);
                     item.dfFWHMToMicrometer = dfConvToUM;
                 }
             }
@@ -9757,6 +9986,11 @@ lbl_next_depth:
  *                           dimensional array, and its dimension must be one of
  *                           the dimensions of the array on which the method is
  *                           called (excluding the X and Y dimensons).
+ *                         - "attribute": name relative to *this array or full
+ *                           name of a single dimension numeric array whose size
+ *                           must be one of the dimensions of *this array
+ *                           (excluding the X and Y dimensons).
+ *                           "array" and "attribute" are mutually exclusive.
  *                         - "item_name": band metadata item name
  *                         - "item_value": (optional) String, where "%[x][.y]f",
  *                           "%[x][.y]g" or "%s" printf-like formatting can be
@@ -9764,7 +9998,10 @@ lbl_next_depth:
  *                           parameter array. The percentage character should be
  *                           repeated: "%%"
  *                           "${attribute_name}" can also be used to include the
- *                           value of an attribute for the array.
+ *                           value of an attribute for "array" when set and if
+ *                           not starting with '/'. Otherwise if starting with
+ *                           '/', it is the full path to the attribute.
+ *
  *                           If "item_value" is not provided, a default formatting
  *                           of the value will be applied.
  *
@@ -9785,6 +10022,16 @@ lbl_next_depth:
  *                              "item_value": "${units}"
  *                            }
  *                         ]
+ *
+ *                         Example for Planet Labs Tanager radiance products:
+ *                         [
+ *                            {
+ *                              "attribute": "center_wavelengths",
+ *                              "item_name": "WAVELENGTH",
+ *                              "item_value": "%.1f ${center_wavelengths_units}"
+ *                            }
+ *                         ]
+ *
  *                     </li>
  *                     <li>BAND_IMAGERY_METADATA: (GDAL >= 3.11)
  *                         JSON serialized object defining which arrays of the
@@ -9798,17 +10045,24 @@ lbl_next_depth:
  *                           in micrometers.
  *                         The value of each member should be an object with the
  *                         following members:
- *                         - "array": (required) full name of a band parameter
- *                           array.
+ *                         - "array": full name of a band parameter array.
  *                           Such array must be a one dimensional array, and its
  *                           dimension must be one of the dimensions of the
  *                           array on which the method is called
  *                           (excluding the X and Y dimensons).
+ *                         - "attribute": name relative to *this array or full
+ *                           name of a single dimension numeric array whose size
+ *                           must be one of the dimensions of *this array
+ *                           (excluding the X and Y dimensons).
+ *                           "array" and "attribute" are mutually exclusive,
+ *                           and one of them is required.
  *                         - "unit": (optional) unit of the values pointed in
  *                           the above array.
  *                           Can be a literal string or a string of the form
  *                           "${attribute_name}" to point to an attribute for
- *                           the array.
+ *                           "array" when set and if no starting
+ *                           with '/'. Otherwise if starting with '/', it is
+ *                           the full path to the attribute.
  *                           Accepted values are "um", "micrometer"
  *                           (with UK vs US spelling, singular or plural), "nm",
  *                           "nanometer" (with UK vs US spelling, singular or
@@ -9826,6 +10080,19 @@ lbl_next_depth:
  *                                "unit": "${units}"
  *                            }
  *                         }
+ *
+ *                         Example for Planet Labs Tanager radiance products:
+ *                         {
+ *                            "CENTRAL_WAVELENGTH_UM": {
+ *                              "attribute": "center_wavelengths",
+ *                              "unit": "${center_wavelengths_units}"
+ *                            },
+ *                            "FWHM_UM": {
+ *                              "attribute": "fwhm",
+ *                              "unit": "${fwhm_units}"
+ *                            }
+ *                         }
+ *
  *                     </li>
  *                     <li>LOAD_EXTRA_DIM_METADATA_DELAY: Maximum delay in
  *                         seconds allowed to set the DIM_{dimname}_VALUE band


### PR DESCRIPTION
Also accept fully qualified path for attributes in "attribute" or in "${/path/to/attribute}"

For BAND_METADATA example for Planet Labs Tanager radiance products:
```json
[
    {
        "attribute": "center_wavelengths",
        "item_name": "WAVELENGTH",
        "item_value": "%.1f ${center_wavelengths_units}"
    }
]
```

For BAND_IMAGERY_METADATA:
```json
{
   "CENTRAL_WAVELENGTH_UM": {
     "attribute": "center_wavelengths",
     "unit": "${center_wavelengths_units}"
   },
   "FWHM_UM": {
     "attribute": "fwhm",
     "unit": "${fwhm_units}"
   }
}
```
