### PR TITLE
Add np.bool to map of gdal codes

### DIFF
--- a/autotest/gcore/numpy_rw.py
+++ b/autotest/gcore/numpy_rw.py
@@ -367,7 +367,7 @@ def test_numpy_rw_13():
     ds.GetRasterBand(1).WriteArray(ar)
 
     # Try reading into unsupported array type
-    ar = numpy.empty([1, 2], dtype=numpy.dtype('S1'))
+    ar = numpy.empty([1, 2], dtype=numpy.dtype("S1"))
     with pytest.raises(
         Exception, match="array does not have " "corresponding GDAL data type"
     ):
@@ -435,7 +435,7 @@ def test_numpy_rw_13():
     for i in range(3):
         ds.GetRasterBand(i + 1).WriteArray(ar[i])
 
-    ar = numpy.empty([3, 1, 2], dtype=numpy.dtype('S1'))
+    ar = numpy.empty([3, 1, 2], dtype=numpy.dtype("S1"))
     with pytest.raises(
         Exception, match="array does not have " "corresponding GDAL data type"
     ):
@@ -659,7 +659,7 @@ def test_numpy_rw_16():
     assert ds is None
 
     # Unsupported data type
-    array = numpy.empty([1, 1], numpy.dtype('S1'))
+    array = numpy.empty([1, 1], numpy.dtype("S1"))
     with gdal.quiet_errors():
         ds = gdal_array.OpenArray(array)
     assert ds is None

--- a/autotest/gcore/numpy_rw.py
+++ b/autotest/gcore/numpy_rw.py
@@ -260,6 +260,7 @@ def test_numpy_rw_10_bis(options):
 def test_numpy_rw_11():
 
     type_tuples = [
+        ("bool", gdal.GDT_Byte, numpy.bool_, True),
         ("uint8", gdal.GDT_Byte, numpy.uint8, 255),
         ("uint16", gdal.GDT_UInt16, numpy.uint16, 65535),
         ("int16", gdal.GDT_Int16, numpy.int16, -32767),
@@ -366,7 +367,7 @@ def test_numpy_rw_13():
     ds.GetRasterBand(1).WriteArray(ar)
 
     # Try reading into unsupported array type
-    ar = numpy.empty([1, 2], dtype=numpy.bool_)
+    ar = numpy.empty([1, 2], dtype=numpy.dtype('S1'))
     with pytest.raises(
         Exception, match="array does not have " "corresponding GDAL data type"
     ):
@@ -434,7 +435,7 @@ def test_numpy_rw_13():
     for i in range(3):
         ds.GetRasterBand(i + 1).WriteArray(ar[i])
 
-    ar = numpy.empty([3, 1, 2], dtype=numpy.bool_)
+    ar = numpy.empty([3, 1, 2], dtype=numpy.dtype('S1'))
     with pytest.raises(
         Exception, match="array does not have " "corresponding GDAL data type"
     ):
@@ -658,7 +659,7 @@ def test_numpy_rw_16():
     assert ds is None
 
     # Unsupported data type
-    array = numpy.empty([1, 1], numpy.bool_)
+    array = numpy.empty([1, 1], numpy.dtype('S1'))
     with gdal.quiet_errors():
         ds = gdal_array.OpenArray(array)
     assert ds is None

--- a/swig/include/gdal_array.i
+++ b/swig/include/gdal_array.i
@@ -2390,7 +2390,7 @@ np_class_to_gdal_code = { v : k for k, v in codes.items() }
 # the opposite that is an exact match (ticket 1518)
 np_class_to_gdal_code[numpy.complex64] = gdalconst.GDT_CFloat32
 # also recognize numpy bool arrays
-np_class_to_gdal_code[numpy.bool] = gdalconst.GDT_Byte
+np_class_to_gdal_code[numpy.bool_] = gdalconst.GDT_Byte
 np_dtype_to_gdal_code = { numpy.dtype(k) : v for k, v in np_class_to_gdal_code.items() }
 
 def OpenArray(array, prototype_ds=None, interleave='band'):

--- a/swig/include/gdal_array.i
+++ b/swig/include/gdal_array.i
@@ -2389,6 +2389,8 @@ np_class_to_gdal_code = { v : k for k, v in codes.items() }
 # since several things map to complex64 we must carefully select
 # the opposite that is an exact match (ticket 1518)
 np_class_to_gdal_code[numpy.complex64] = gdalconst.GDT_CFloat32
+# also recognize numpy bool arrays
+np_class_to_gdal_code[numpy.bool] = gdalconst.GDT_Byte
 np_dtype_to_gdal_code = { numpy.dtype(k) : v for k, v in np_class_to_gdal_code.items() }
 
 def OpenArray(array, prototype_ds=None, interleave='band'):


### PR DESCRIPTION
Don't promote a boolean array to float64 when trying to write the data

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?
Fix a performance issue when writing out a numpy array of booleans. With this change, saving out a 6000x6000 array to a geotiff is now 66% faster! Memory savings is also useful.

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [x] Adjust for comments
 - [ ] All CI builds and checks have passed