### PR TITLE
[cli] gdal vector info do not implicitly set -al with -json

### DIFF
--- a/apps/data/ogrinfo_output.schema.json
+++ b/apps/data/ogrinfo_output.schema.json
@@ -55,6 +55,13 @@
         "name": {
           "type": "string"
         },
+        "geometryType": {
+          "$comment": "Geometry type(s) as a string, e.g. 'Point', 'Line String', 'Polygon', etc. If the layer has multiple geometry types, they are separated by commas. This property is optional and is only present in summary mode when the 'geometryFields' property is omitted.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
         "metadata": {
           "$ref": "#/definitions/metadata"
         },

--- a/apps/data/ogrinfo_output.schema.json
+++ b/apps/data/ogrinfo_output.schema.json
@@ -91,10 +91,7 @@
         }
       },
       "required": [
-        "name",
-        "metadata",
-        "geometryFields",
-        "fields"
+        "name"
       ],
       "additionalProperties": false
     },

--- a/apps/gdalalg_vector_info.cpp
+++ b/apps/gdalalg_vector_info.cpp
@@ -42,7 +42,8 @@ GDALVectorInfoAlgorithm::GDALVectorInfoAlgorithm()
            _("List all features (beware of RAM consumption on large layers)"),
            &m_listFeatures)
         .SetMutualExclusionGroup("summary-features");
-    AddArg("summary", 0, _("List the layer names"), &m_summaryOnly)
+    AddArg("summary", 0, _("List the layer names and the geometry type"),
+           &m_summaryOnly)
         .SetMutualExclusionGroup("summary-features");
     AddArg("sql", 0,
            _("Execute the indicated SQL statement and return the result"),
@@ -89,6 +90,9 @@ bool GDALVectorInfoAlgorithm::RunImpl(GDALProgressFunc, void *)
     CPLAssert(m_dataset.GetDatasetRef());
 
     CPLStringList aosOptions;
+
+    aosOptions.AddString("--cli");
+
     if (m_format == "json")
     {
         aosOptions.AddString("-json");
@@ -97,7 +101,6 @@ bool GDALVectorInfoAlgorithm::RunImpl(GDALProgressFunc, void *)
     if (m_summaryOnly)
     {
         aosOptions.AddString("-summary");
-        aosOptions.AddString("--quiet");
     }
     else if (m_listFeatures)
     {
@@ -136,6 +139,7 @@ bool GDALVectorInfoAlgorithm::RunImpl(GDALProgressFunc, void *)
 
     GDALVectorInfoOptions *psInfo =
         GDALVectorInfoOptionsNew(aosOptions.List(), nullptr);
+
     char *ret = GDALVectorInfo(GDALDataset::ToHandle(m_dataset.GetDatasetRef()),
                                psInfo);
     GDALVectorInfoOptionsFree(psInfo);

--- a/apps/gdalalg_vector_info.cpp
+++ b/apps/gdalalg_vector_info.cpp
@@ -42,10 +42,7 @@ GDALVectorInfoAlgorithm::GDALVectorInfoAlgorithm()
            _("List all features (beware of RAM consumption on large layers)"),
            &m_listFeatures)
         .SetMutualExclusionGroup("summary-features");
-    AddArg("summary", 0,
-           _("List the layer names and the geometry type (when possibile "
-             "without scanning the whole dataset)"),
-           &m_summaryOnly)
+    AddArg("summary", 0, _("List the layer names"), &m_summaryOnly)
         .SetMutualExclusionGroup("summary-features");
     AddArg("sql", 0,
            _("Execute the indicated SQL statement and return the result"),

--- a/apps/gdalalg_vector_info.h
+++ b/apps/gdalalg_vector_info.h
@@ -51,6 +51,7 @@ class GDALVectorInfoAlgorithm final : public GDALAlgorithm
     bool m_update = false;
     std::vector<std::string> m_layerNames{};
     bool m_listFeatures = false;
+    bool m_summaryOnly = false;
     bool m_stdout = false;
     std::string m_sql{};
     std::string m_where{};

--- a/apps/ogrinfo_lib.cpp
+++ b/apps/ogrinfo_lib.cpp
@@ -68,6 +68,9 @@ struct GDALVectorInfoOptions
     // Only used during argument parsing
     bool bSummaryParser = false;
     bool bFeaturesParser = false;
+
+    // Set by gdal vector info
+    bool bIsCli = false;
 };
 
 /************************************************************************/
@@ -801,9 +804,53 @@ static void ReportOnLayer(CPLString &osRet, CPLJSONObject &oLayer,
                           bool bTakeIntoAccountGeomField)
 {
     const bool bJson = psOptions->eFormat == FORMAT_JSON;
+    const bool bIsSummaryCli = psOptions->bIsCli && psOptions->bSummaryParser;
     OGRFeatureDefn *poDefn = poLayer->GetLayerDefn();
 
     oLayer.Set("name", poLayer->GetName());
+    const int nGeomFieldCount =
+        psOptions->bGeomType ? poLayer->GetLayerDefn()->GetGeomFieldCount() : 0;
+
+    if (bIsSummaryCli)
+    {
+        // Collect geometry types
+        std::set<std::string> geomFieldTypes;
+        for (int iGeom = 0; iGeom < nGeomFieldCount; iGeom++)
+        {
+            const OGRGeomFieldDefn *poGFldDefn =
+                poLayer->GetLayerDefn()->GetGeomFieldDefn(iGeom);
+            geomFieldTypes.emplace(OGRToOGCGeomType(poGFldDefn->GetType(),
+                                                    /*bCamelCase=*/true,
+                                                    /*bAddZm=*/true,
+                                                    /*bSpaceBeforeZM=*/false));
+        }
+
+        if (bJson)
+        {
+            CPLJSONArray oGeometryFields;
+            oLayer.Add("geometryType", oGeometryFields);
+            for (const auto &geomType : geomFieldTypes)
+            {
+                oGeometryFields.Add(geomType);
+            }
+        }
+        else
+        {
+            Concat(osRet, psOptions->bStdoutOutput, "\n");
+            // Join with comma and space
+            std::string osGeomTypes;
+            for (auto it = geomFieldTypes.begin(); it != geomFieldTypes.end();
+                 ++it)
+            {
+                if (it != geomFieldTypes.begin())
+                    osGeomTypes += ", ";
+                osGeomTypes += *it;
+            }
+            Concat(osRet, psOptions->bStdoutOutput, "%s (%s)\n",
+                   poLayer->GetName(), osGeomTypes.c_str());
+        }
+        return;
+    }
 
     /* -------------------------------------------------------------------- */
     /*      Set filters if provided.                                        */
@@ -851,14 +898,12 @@ static void ReportOnLayer(CPLString &osRet, CPLJSONObject &oLayer,
     }
 
     GDALVectorInfoReportMetadata(osRet, oLayer, psOptions, poLayer,
-                                 psOptions->bListMDD, psOptions->bShowMetadata,
+                                 !bIsSummaryCli && psOptions->bListMDD,
+                                 !bIsSummaryCli && psOptions->bShowMetadata,
                                  psOptions->aosExtraMDDomains.List());
 
     if (psOptions->bVerbose)
     {
-        const int nGeomFieldCount =
-            psOptions->bGeomType ? poLayer->GetLayerDefn()->GetGeomFieldCount()
-                                 : 0;
 
         CPLString osWKTFormat("FORMAT=");
         osWKTFormat += psOptions->osWKTFormat;
@@ -1683,6 +1728,7 @@ static void PrintLayerSummary(CPLString &osRet, CPLJSONObject &oLayer,
                               OGRLayer *poLayer, bool bIsPrivate)
 {
     const bool bJson = psOptions->eFormat == FORMAT_JSON;
+    const bool bIsSummaryCli = psOptions->bIsCli && psOptions->bSummaryOnly;
     if (bJson)
         oLayer.Set("name", poLayer->GetName());
     else
@@ -1699,6 +1745,20 @@ static void PrintLayerSummary(CPLString &osRet, CPLJSONObject &oLayer,
 
     const int nGeomFieldCount =
         psOptions->bGeomType ? poLayer->GetLayerDefn()->GetGeomFieldCount() : 0;
+
+    if (bIsSummaryCli && bJson)
+    {
+        CPLJSONArray oGeometryTypes;
+        for (int iGeom = 0; iGeom < nGeomFieldCount; iGeom++)
+        {
+            OGRGeomFieldDefn *poGFldDefn =
+                poLayer->GetLayerDefn()->GetGeomFieldDefn(iGeom);
+            oGeometryTypes.Add(OGRGeometryTypeToName(poGFldDefn->GetType()));
+        }
+        oLayer.Add("geometryType", oGeometryTypes);
+        return;
+    }
+
     if (bJson || nGeomFieldCount > 1)
     {
         if (!bJson)
@@ -1841,6 +1901,8 @@ char *GDALVectorInfo(GDALDatasetH hDataset,
     const std::string osFilename(poDS->GetDescription());
 
     const bool bJson = psOptions->eFormat == FORMAT_JSON;
+    const bool bIsSummaryCli = psOptions->bIsCli && psOptions->bSummaryParser;
+
     CPLJSONArray oLayerArray;
     if (bJson)
     {
@@ -1875,185 +1937,193 @@ char *GDALVectorInfo(GDALDatasetH hDataset,
                poDS->GetDescription(), osFilename.c_str());
     }
 
-    GDALVectorInfoReportMetadata(osRet, oRoot, psOptions, poDS,
-                                 psOptions->bListMDD, psOptions->bShowMetadata,
-                                 psOptions->aosExtraMDDomains.List());
+    int nRepeatCount = psOptions->nRepeatCount;
 
-    CPLJSONObject oDomains;
-    oRoot.Add("domains", oDomains);
-    if (!psOptions->osFieldDomain.empty())
+    if (!bIsSummaryCli)
     {
-        auto poDomain = poDS->GetFieldDomain(psOptions->osFieldDomain);
-        if (poDomain == nullptr)
+        GDALVectorInfoReportMetadata(
+            osRet, oRoot, psOptions, poDS, psOptions->bListMDD,
+            psOptions->bShowMetadata, psOptions->aosExtraMDDomains.List());
+
+        CPLJSONObject oDomains;
+        oRoot.Add("domains", oDomains);
+        if (!psOptions->osFieldDomain.empty())
         {
-            CPLError(CE_Failure, CPLE_AppDefined, "Domain %s cannot be found.",
-                     psOptions->osFieldDomain.c_str());
-            return nullptr;
-        }
-        if (!bJson)
-            Concat(osRet, psOptions->bStdoutOutput, "\n");
-        ReportFieldDomain(osRet, oDomains, psOptions, poDomain);
-        if (!bJson)
-            Concat(osRet, psOptions->bStdoutOutput, "\n");
-    }
-    else if (bJson)
-    {
-        for (const auto &osDomainName : poDS->GetFieldDomainNames())
-        {
-            auto poDomain = poDS->GetFieldDomain(osDomainName);
-            if (poDomain)
+            auto poDomain = poDS->GetFieldDomain(psOptions->osFieldDomain);
+            if (poDomain == nullptr)
             {
-                ReportFieldDomain(osRet, oDomains, psOptions, poDomain);
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Domain %s cannot be found.",
+                         psOptions->osFieldDomain.c_str());
+                return nullptr;
+            }
+            if (!bJson)
+                Concat(osRet, psOptions->bStdoutOutput, "\n");
+            ReportFieldDomain(osRet, oDomains, psOptions, poDomain);
+            if (!bJson)
+                Concat(osRet, psOptions->bStdoutOutput, "\n");
+        }
+        else if (bJson)
+        {
+            for (const auto &osDomainName : poDS->GetFieldDomainNames())
+            {
+                auto poDomain = poDS->GetFieldDomain(osDomainName);
+                if (poDomain)
+                {
+                    ReportFieldDomain(osRet, oDomains, psOptions, poDomain);
+                }
             }
         }
-    }
 
-    int nRepeatCount = psOptions->nRepeatCount;
-    if (psOptions->bDatasetGetNextFeature)
-    {
-        nRepeatCount = 0;  // skip layer reporting.
-
-        /* --------------------------------------------------------------------
-         */
-        /*      Set filters if provided. */
-        /* --------------------------------------------------------------------
-         */
-        if (!psOptions->osWHERE.empty() ||
-            psOptions->poSpatialFilter != nullptr)
+        if (psOptions->bDatasetGetNextFeature)
         {
-            for (int iLayer = 0; iLayer < poDS->GetLayerCount(); iLayer++)
+            nRepeatCount = 0;  // skip layer reporting.
+
+            /* --------------------------------------------------------------------
+             */
+            /*      Set filters if provided. */
+            /* --------------------------------------------------------------------
+             */
+            if (!psOptions->osWHERE.empty() ||
+                psOptions->poSpatialFilter != nullptr)
             {
-                OGRLayer *poLayer = poDS->GetLayer(iLayer);
-
-                if (poLayer == nullptr)
+                for (int iLayer = 0; iLayer < poDS->GetLayerCount(); iLayer++)
                 {
-                    CPLError(CE_Failure, CPLE_AppDefined,
-                             "Couldn't fetch advertised layer %d.", iLayer);
-                    return nullptr;
-                }
+                    OGRLayer *poLayer = poDS->GetLayer(iLayer);
 
+                    if (poLayer == nullptr)
+                    {
+                        CPLError(CE_Failure, CPLE_AppDefined,
+                                 "Couldn't fetch advertised layer %d.", iLayer);
+                        return nullptr;
+                    }
+
+                    if (!psOptions->osWHERE.empty())
+                    {
+                        if (poLayer->SetAttributeFilter(
+                                psOptions->osWHERE.c_str()) != OGRERR_NONE)
+                        {
+                            CPLError(
+                                CE_Warning, CPLE_AppDefined,
+                                "SetAttributeFilter(%s) failed on layer %s.",
+                                psOptions->osWHERE.c_str(), poLayer->GetName());
+                        }
+                    }
+
+                    if (psOptions->poSpatialFilter != nullptr)
+                    {
+                        if (!psOptions->osGeomField.empty())
+                        {
+                            OGRFeatureDefn *poDefn = poLayer->GetLayerDefn();
+                            const int iGeomField = poDefn->GetGeomFieldIndex(
+                                psOptions->osGeomField.c_str());
+                            if (iGeomField >= 0)
+                                poLayer->SetSpatialFilter(
+                                    iGeomField,
+                                    psOptions->poSpatialFilter.get());
+                            else
+                                CPLError(CE_Warning, CPLE_AppDefined,
+                                         "Cannot find geometry field %s.",
+                                         psOptions->osGeomField.c_str());
+                        }
+                        else
+                        {
+                            poLayer->SetSpatialFilter(
+                                psOptions->poSpatialFilter.get());
+                        }
+                    }
+                }
+            }
+
+            std::set<OGRLayer *> oSetLayers;
+            while (true)
+            {
+                OGRLayer *poLayer = nullptr;
+                OGRFeature *poFeature =
+                    poDS->GetNextFeature(&poLayer, nullptr, nullptr, nullptr);
+                if (poFeature == nullptr)
+                    break;
+                if (psOptions->aosLayers.empty() || poLayer == nullptr ||
+                    CSLFindString(psOptions->aosLayers.List(),
+                                  poLayer->GetName()) >= 0)
+                {
+                    if (psOptions->bVerbose && poLayer != nullptr &&
+                        oSetLayers.find(poLayer) == oSetLayers.end())
+                    {
+                        oSetLayers.insert(poLayer);
+                        CPLJSONObject oLayer;
+                        oLayerArray.Add(oLayer);
+                        ReportOnLayer(
+                            osRet, oLayer, psOptions, poLayer,
+                            /*bForceSummary = */ true,
+                            /*bTakeIntoAccountWHERE = */ false,
+                            /*bTakeIntoAccountSpatialFilter = */ false,
+                            /*bTakeIntoAccountGeomField = */ false);
+                    }
+                    if (!psOptions->bSuperQuiet && !psOptions->bSummaryOnly)
+                        poFeature->DumpReadable(
+                            nullptr,
+                            const_cast<char **>(psOptions->aosOptions.List()));
+                }
+                OGRFeature::DestroyFeature(poFeature);
+            }
+        }
+
+        /* -------------------------------------------------------------------- */
+        /*      Special case for -sql clause.  No source layers required.       */
+        /* -------------------------------------------------------------------- */
+        else if (!psOptions->osSQLStatement.empty())
+        {
+            nRepeatCount = 0;  // skip layer reporting.
+
+            if (!bJson && !psOptions->aosLayers.empty())
+                Concat(osRet, psOptions->bStdoutOutput,
+                       "layer names ignored in combination with -sql.\n");
+
+            CPLErrorReset();
+            OGRLayer *poResultSet = poDS->ExecuteSQL(
+                psOptions->osSQLStatement.c_str(),
+                psOptions->osGeomField.empty()
+                    ? psOptions->poSpatialFilter.get()
+                    : nullptr,
+                psOptions->osDialect.empty() ? nullptr
+                                             : psOptions->osDialect.c_str());
+
+            if (poResultSet != nullptr)
+            {
                 if (!psOptions->osWHERE.empty())
                 {
-                    if (poLayer->SetAttributeFilter(
+                    if (poResultSet->SetAttributeFilter(
                             psOptions->osWHERE.c_str()) != OGRERR_NONE)
                     {
-                        CPLError(CE_Warning, CPLE_AppDefined,
-                                 "SetAttributeFilter(%s) failed on layer %s.",
-                                 psOptions->osWHERE.c_str(),
-                                 poLayer->GetName());
+                        CPLError(CE_Failure, CPLE_AppDefined,
+                                 "SetAttributeFilter(%s) failed.",
+                                 psOptions->osWHERE.c_str());
+                        return nullptr;
                     }
                 }
 
-                if (psOptions->poSpatialFilter != nullptr)
-                {
-                    if (!psOptions->osGeomField.empty())
-                    {
-                        OGRFeatureDefn *poDefn = poLayer->GetLayerDefn();
-                        const int iGeomField = poDefn->GetGeomFieldIndex(
-                            psOptions->osGeomField.c_str());
-                        if (iGeomField >= 0)
-                            poLayer->SetSpatialFilter(
-                                iGeomField, psOptions->poSpatialFilter.get());
-                        else
-                            CPLError(CE_Warning, CPLE_AppDefined,
-                                     "Cannot find geometry field %s.",
-                                     psOptions->osGeomField.c_str());
-                    }
-                    else
-                    {
-                        poLayer->SetSpatialFilter(
-                            psOptions->poSpatialFilter.get());
-                    }
-                }
-            }
-        }
-
-        std::set<OGRLayer *> oSetLayers;
-        while (true)
-        {
-            OGRLayer *poLayer = nullptr;
-            OGRFeature *poFeature =
-                poDS->GetNextFeature(&poLayer, nullptr, nullptr, nullptr);
-            if (poFeature == nullptr)
-                break;
-            if (psOptions->aosLayers.empty() || poLayer == nullptr ||
-                CSLFindString(psOptions->aosLayers.List(),
-                              poLayer->GetName()) >= 0)
-            {
-                if (psOptions->bVerbose && poLayer != nullptr &&
-                    oSetLayers.find(poLayer) == oSetLayers.end())
-                {
-                    oSetLayers.insert(poLayer);
-                    CPLJSONObject oLayer;
-                    oLayerArray.Add(oLayer);
-                    ReportOnLayer(osRet, oLayer, psOptions, poLayer,
-                                  /*bForceSummary = */ true,
+                CPLJSONObject oLayer;
+                oLayerArray.Add(oLayer);
+                if (!psOptions->osGeomField.empty())
+                    ReportOnLayer(osRet, oLayer, psOptions, poResultSet,
+                                  /*bForceSummary = */ false,
+                                  /*bTakeIntoAccountWHERE = */ false,
+                                  /*bTakeIntoAccountSpatialFilter = */ true,
+                                  /*bTakeIntoAccountGeomField = */ true);
+                else
+                    ReportOnLayer(osRet, oLayer, psOptions, poResultSet,
+                                  /*bForceSummary = */ false,
                                   /*bTakeIntoAccountWHERE = */ false,
                                   /*bTakeIntoAccountSpatialFilter = */ false,
                                   /*bTakeIntoAccountGeomField = */ false);
-                }
-                if (!psOptions->bSuperQuiet && !psOptions->bSummaryOnly)
-                    poFeature->DumpReadable(
-                        nullptr,
-                        const_cast<char **>(psOptions->aosOptions.List()));
+
+                poDS->ReleaseResultSet(poResultSet);
             }
-            OGRFeature::DestroyFeature(poFeature);
-        }
-    }
-
-    /* -------------------------------------------------------------------- */
-    /*      Special case for -sql clause.  No source layers required.       */
-    /* -------------------------------------------------------------------- */
-    else if (!psOptions->osSQLStatement.empty())
-    {
-        nRepeatCount = 0;  // skip layer reporting.
-
-        if (!bJson && !psOptions->aosLayers.empty())
-            Concat(osRet, psOptions->bStdoutOutput,
-                   "layer names ignored in combination with -sql.\n");
-
-        CPLErrorReset();
-        OGRLayer *poResultSet = poDS->ExecuteSQL(
-            psOptions->osSQLStatement.c_str(),
-            psOptions->osGeomField.empty() ? psOptions->poSpatialFilter.get()
-                                           : nullptr,
-            psOptions->osDialect.empty() ? nullptr
-                                         : psOptions->osDialect.c_str());
-
-        if (poResultSet != nullptr)
-        {
-            if (!psOptions->osWHERE.empty())
+            else if (CPLGetLastErrorType() != CE_None)
             {
-                if (poResultSet->SetAttributeFilter(
-                        psOptions->osWHERE.c_str()) != OGRERR_NONE)
-                {
-                    CPLError(CE_Failure, CPLE_AppDefined,
-                             "SetAttributeFilter(%s) failed.",
-                             psOptions->osWHERE.c_str());
-                    return nullptr;
-                }
+                return nullptr;
             }
-
-            CPLJSONObject oLayer;
-            oLayerArray.Add(oLayer);
-            if (!psOptions->osGeomField.empty())
-                ReportOnLayer(osRet, oLayer, psOptions, poResultSet,
-                              /*bForceSummary = */ false,
-                              /*bTakeIntoAccountWHERE = */ false,
-                              /*bTakeIntoAccountSpatialFilter = */ true,
-                              /*bTakeIntoAccountGeomField = */ true);
-            else
-                ReportOnLayer(osRet, oLayer, psOptions, poResultSet,
-                              /*bForceSummary = */ false,
-                              /*bTakeIntoAccountWHERE = */ false,
-                              /*bTakeIntoAccountSpatialFilter = */ false,
-                              /*bTakeIntoAccountGeomField = */ false);
-
-            poDS->ReleaseResultSet(poResultSet);
-        }
-        else if (CPLGetLastErrorType() != CE_None)
-        {
-            return nullptr;
         }
     }
 
@@ -2100,7 +2170,7 @@ char *GDALVectorInfo(GDALDatasetH hDataset,
 
                 CPLJSONObject oLayer;
                 oLayerArray.Add(oLayer);
-                if (!psOptions->bAllLayers)
+                if (!psOptions->bAllLayers || bIsSummaryCli)
                 {
                     if (!bJson)
                         Concat(osRet, psOptions->bStdoutOutput,
@@ -2154,7 +2224,7 @@ char *GDALVectorInfo(GDALDatasetH hDataset,
         }
     }
 
-    if (!papszLayers)
+    if (!papszLayers && !bIsSummaryCli)
     {
         ReportRelationships(osRet, oRoot, psOptions, poDS);
     }
@@ -2197,11 +2267,10 @@ static std::unique_ptr<GDALArgumentParser> GDALVectorInfoOptionsGetParser(
     argParser->add_argument("-json")
         .flag()
         .action(
-            [psOptions, psOptionsForBinary](const std::string &)
+            [psOptions](const std::string &)
             {
                 psOptions->eFormat = FORMAT_JSON;
-                if (psOptionsForBinary)
-                    psOptions->bAllLayers = true;
+                psOptions->bAllLayers = true;
                 psOptions->bSummaryOnly = true;
             })
         .help(_("Display the output in json format."));
@@ -2429,6 +2498,12 @@ static std::unique_ptr<GDALArgumentParser> GDALVectorInfoOptionsGetParser(
         .store_into(psOptions->bStdoutOutput)
         .hidden()
         .help(_("Directly output on stdout (format=text mode only)"));
+
+    argParser->add_argument("--cli")
+        .hidden()
+        .store_into(psOptions->bIsCli)
+        .help(_("Indicates that this is called from the gdal vector info CLI "
+                "utility."));
 
     auto &argFilename = argParser->add_argument("filename")
                             .action(

--- a/apps/ogrinfo_lib.cpp
+++ b/apps/ogrinfo_lib.cpp
@@ -811,47 +811,6 @@ static void ReportOnLayer(CPLString &osRet, CPLJSONObject &oLayer,
     const int nGeomFieldCount =
         psOptions->bGeomType ? poLayer->GetLayerDefn()->GetGeomFieldCount() : 0;
 
-    if (bIsSummaryCli)
-    {
-        // Collect geometry types
-        std::set<std::string> geomFieldTypes;
-        for (int iGeom = 0; iGeom < nGeomFieldCount; iGeom++)
-        {
-            const OGRGeomFieldDefn *poGFldDefn =
-                poLayer->GetLayerDefn()->GetGeomFieldDefn(iGeom);
-            geomFieldTypes.emplace(OGRToOGCGeomType(poGFldDefn->GetType(),
-                                                    /*bCamelCase=*/true,
-                                                    /*bAddZm=*/true,
-                                                    /*bSpaceBeforeZM=*/false));
-        }
-
-        if (bJson)
-        {
-            CPLJSONArray oGeometryFields;
-            oLayer.Add("geometryType", oGeometryFields);
-            for (const auto &geomType : geomFieldTypes)
-            {
-                oGeometryFields.Add(geomType);
-            }
-        }
-        else
-        {
-            Concat(osRet, psOptions->bStdoutOutput, "\n");
-            // Join with comma and space
-            std::string osGeomTypes;
-            for (auto it = geomFieldTypes.begin(); it != geomFieldTypes.end();
-                 ++it)
-            {
-                if (it != geomFieldTypes.begin())
-                    osGeomTypes += ", ";
-                osGeomTypes += *it;
-            }
-            Concat(osRet, psOptions->bStdoutOutput, "%s (%s)\n",
-                   poLayer->GetName(), osGeomTypes.c_str());
-        }
-        return;
-    }
-
     /* -------------------------------------------------------------------- */
     /*      Set filters if provided.                                        */
     /* -------------------------------------------------------------------- */

--- a/apps/ogrinfo_lib.cpp
+++ b/apps/ogrinfo_lib.cpp
@@ -2197,10 +2197,11 @@ static std::unique_ptr<GDALArgumentParser> GDALVectorInfoOptionsGetParser(
     argParser->add_argument("-json")
         .flag()
         .action(
-            [psOptions](const std::string &)
+            [psOptions, psOptionsForBinary](const std::string &)
             {
                 psOptions->eFormat = FORMAT_JSON;
-                psOptions->bAllLayers = true;
+                if (psOptionsForBinary)
+                    psOptions->bAllLayers = true;
                 psOptions->bSummaryOnly = true;
             })
         .help(_("Display the output in json format."));

--- a/autotest/utilities/test_gdalalg_vector_info.py
+++ b/autotest/utilities/test_gdalalg_vector_info.py
@@ -134,20 +134,14 @@ def test_gdalalg_vector_info_summary_multi_geometry(tmp_vsimem):
     sqlite_multi = tmp_vsimem / "multi_geometry.db"
     sqlite_multi = "/tmp/multi_geometry.db"
     # Create a temporary gpkg with multiple geometry types
-    ds = gdal.VectorTranslate(
+    gdal.VectorTranslate(
         sqlite_multi,
         "data/path.shp",
         format="SQLite",
         SQLStatement="select geometry as geom, st_centroid(geometry) as center, geometry as geom3, st_buffer(geometry,1) as geom4 from path",
         SQLDialect="SQLite",
     )
-    # Exec sql to alter center and geom4
-    ds.ExecuteSQL(
-        "UPDATE geometry_columns SET geometry_type = 1 where f_geometry_column = 'center'"
-    )
-    ds.ExecuteSQL(
-        "UPDATE geometry_columns SET geometry_type = 3 where f_geometry_column = 'geom4'"
-    )
+
     # Check that the layer has multiple geometry types
     info = get_info_alg()
     assert info.ParseRunAndFinalize(["--summary", sqlite_multi])

--- a/autotest/utilities/test_gdalalg_vector_info.py
+++ b/autotest/utilities/test_gdalalg_vector_info.py
@@ -129,6 +129,45 @@ def test_gdalalg_vector_info_summary():
 
 
 @pytest.mark.require_driver("SQLite")
+def test_gdalalg_vector_info_summary_multi_geometry(tmp_vsimem):
+
+    sqlite_multi = tmp_vsimem / "multi_geometry.db"
+    sqlite_multi = "/tmp/multi_geometry.db"
+    # Create a temporary gpkg with multiple geometry types
+    ds = gdal.VectorTranslate(
+        sqlite_multi,
+        "data/path.shp",
+        format="SQLite",
+        SQLStatement="select geometry as geom, st_centroid(geometry) as center, geometry as geom3, st_buffer(geometry,1) as geom4 from path",
+        SQLDialect="SQLite",
+    )
+    # Exec sql to alter center and geom4
+    ds.ExecuteSQL(
+        "UPDATE geometry_columns SET geometry_type = 1 where f_geometry_column = 'center'"
+    )
+    ds.ExecuteSQL(
+        "UPDATE geometry_columns SET geometry_type = 3 where f_geometry_column = 'geom4'"
+    )
+    # Check that the layer has multiple geometry types
+    info = get_info_alg()
+    assert info.ParseRunAndFinalize(["--summary", sqlite_multi])
+    output_string = info["output-string"]
+    j = json.loads(output_string)
+    assert j["layers"][0]["geometryType"] == [
+        "Line String",
+        "Point",
+        "Line String",
+        "Polygon",
+    ]
+
+    # Check text format
+    info = get_info_alg()
+    assert info.ParseRunAndFinalize(["--summary", "--format=text", sqlite_multi])
+    output_string = info["output-string"]
+    assert "(Line String, Point, Line String, Polygon)" in output_string
+
+
+@pytest.mark.require_driver("SQLite")
 def test_gdalalg_vector_info_dialect():
     info = get_info_alg()
     assert info.ParseRunAndFinalize(

--- a/autotest/utilities/test_gdalalg_vector_info.py
+++ b/autotest/utilities/test_gdalalg_vector_info.py
@@ -24,7 +24,7 @@ def spatialite_version():
 
     version = None
 
-    with gdal.quiet_errors():
+    with gdaltest.disable_exceptions(), gdal.quiet_errors():
         ds = gdal.GetDriverByName("SQLite").CreateDataSource(
             "/vsimem/foo.db", options=["SPATIALITE=YES"]
         )

--- a/autotest/utilities/test_gdalalg_vector_info.py
+++ b/autotest/utilities/test_gdalalg_vector_info.py
@@ -103,6 +103,7 @@ def test_gdalalg_vector_info_summary():
     j = json.loads(output_string)
     assert "features" not in j["layers"][0]
     assert "featureCount" not in j["layers"][0]
+    assert "geometryFields" not in j["layers"][0]
 
     with pytest.raises(RuntimeError, match="mutually exclusive with"):
         info = get_info_alg()
@@ -114,7 +115,17 @@ def test_gdalalg_vector_info_summary():
     output_string = info["output-string"]
     j = json.loads(output_string)
     assert "features" not in j["layers"][0]
-    assert "featureCount" in j["layers"][0]
+    assert "features" not in j["layers"][0]
+    assert "geometryFields" in j["layers"][0]
+
+    # Test text output
+    info = get_info_alg()
+    assert info.ParseRunAndFinalize(["--summary", "--format=text", "data/path.shp"])
+    output_string = info["output-string"]
+    assert (
+        output_string
+        == "INFO: Open of `data/path.shp'\n      using driver `ESRI Shapefile' successful.\n1: path (Line String)\n"
+    )
 
 
 @pytest.mark.require_driver("SQLite")

--- a/autotest/utilities/test_gdalalg_vector_info.py
+++ b/autotest/utilities/test_gdalalg_vector_info.py
@@ -96,6 +96,27 @@ def test_gdalalg_vector_info_where(cond, featureCount):
     assert j["layers"][0]["featureCount"] == featureCount
 
 
+def test_gdalalg_vector_info_summary():
+    info = get_info_alg()
+    assert info.ParseRunAndFinalize(["--summary", "data/path.shp"])
+    output_string = info["output-string"]
+    j = json.loads(output_string)
+    assert "features" not in j["layers"][0]
+    assert "featureCount" not in j["layers"][0]
+
+    with pytest.raises(RuntimeError, match="mutually exclusive with"):
+        info = get_info_alg()
+        info.ParseRunAndFinalize(["--summary", "--features", "data/poly.shp"])
+
+    # To check that featureCount is normally present unless --summary is used
+    info = get_info_alg()
+    assert info.ParseRunAndFinalize(["data/path.shp"])
+    output_string = info["output-string"]
+    j = json.loads(output_string)
+    assert "features" not in j["layers"][0]
+    assert "featureCount" in j["layers"][0]
+
+
 @pytest.mark.require_driver("SQLite")
 def test_gdalalg_vector_info_dialect():
     info = get_info_alg()

--- a/autotest/utilities/test_gdalalg_vector_info.py
+++ b/autotest/utilities/test_gdalalg_vector_info.py
@@ -132,7 +132,6 @@ def test_gdalalg_vector_info_summary():
 def test_gdalalg_vector_info_summary_multi_geometry(tmp_vsimem):
 
     sqlite_multi = tmp_vsimem / "multi_geometry.db"
-    sqlite_multi = "/tmp/multi_geometry.db"
     # Create a temporary gpkg with multiple geometry types
     ds = gdal.VectorTranslate(
         sqlite_multi,

--- a/doc/source/programs/gdal_vector_info.rst
+++ b/doc/source/programs/gdal_vector_info.rst
@@ -37,10 +37,16 @@ Standard options
     Name of one or more layers to inspect.  If no layer names are passed and
     :option:`--sql` is not specified, then all layers will be selected.
 
+.. option:: --summary
+
+    Print a summary with the list of layers.
+    This option is mutually exclusive with the :option:`--features` option.
+
 .. option:: --features
 
     List all features. Beware of RAM consumption on large layers when using
     JSON output.
+    This option is mutually exclusive with the :option:`--summary` option.
 
 .. option:: --sql <statement>|@<filename>
 

--- a/doc/source/programs/gdal_vector_info.rst
+++ b/doc/source/programs/gdal_vector_info.rst
@@ -34,12 +34,12 @@ Standard options
 
 .. option:: -l, --layer <LAYER>
 
-    Name of one or more layers to inspect.  If no layer names are passed and
+    Name of one or more layers to inspect. If no layer names are passed and
     :option:`--sql` is not specified, then all layers will be selected.
 
 .. option:: --summary
 
-    Print a summary with the list of layers.
+    Print a summary with the list of layers and the geometry type of each layer.
     This option is mutually exclusive with the :option:`--features` option.
 
 .. option:: --features


### PR DESCRIPTION
The default format with cli is json, this was implicitly setting -al.

The old behavior is kept for ogrinfo while gdal vector info requires -al.

Fix #12510
