### PR TITLE
Add -isysroot when building py bindings (macos)

### DIFF
--- a/swig/python/setup.py.in
+++ b/swig/python/setup.py.in
@@ -346,6 +346,12 @@ class gdal_ext(build_ext):
         else:
             ext.extra_compile_args.append("-DSWIG_PYTHON_SILENT_MEMLEAK")
 
+        # Add -isysroot on osx if used in cmake
+        if '@CMAKE_OSX_SYSROOT@':
+            ext.extra_compile_args.extend(['-isysroot', '@CMAKE_OSX_SYSROOT@'])
+            ext.extra_link_args.extend(['-isysroot', '@CMAKE_OSX_SYSROOT@'])
+
+
         return build_ext.build_extension(self, ext)
 
 


### PR DESCRIPTION
Build error:

```
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/c++ -DNDEBUG -g -fwrapv -O3 -Wall -fPIC -O3 -fPIC -O3 -I/Users/mkuhn/dev/vcpkg/vcpkg/buildtrees/gdal/arm64-osx-dynamic-rel/port -I/Users/mkuhn/dev/vcpkg/vcpkg/buildtrees/gdal/src/v3.11.0-0688d3c8f1.clean/port -I/Users/mkuhn/dev/vcpkg/vcpkg/buildtrees/gdal/arm64-osx-dynamic-rel/gcore -I/Users/mkuhn/dev/vcpkg/vcpkg/buildtrees/gdal/src/v3.11.0-0688d3c8f1.clean/gcore -I/Users/mkuhn/dev/vcpkg/vcpkg/buildtrees/gdal/src/v3.11.0-0688d3c8f1.clean/alg -I/Users/mkuhn/dev/vcpkg/vcpkg/buildtrees/gdal/src/v3.11.0-0688d3c8f1.clean/ogr/ -I/Users/mkuhn/dev/vcpkg/vcpkg/buildtrees/gdal/src/v3.11.0-0688d3c8f1.clean/ogr/ogrsf_frmts -I/Users/mkuhn/dev/vcpkg/vcpkg/buildtrees/gdal/src/v3.11.0-0688d3c8f1.clean/gnm -I/Users/mkuhn/dev/vcpkg/vcpkg/buildtrees/gdal/src/v3.11.0-0688d3c8f1.clean/apps -I/Users/mkuhn/dev/vcpkg/vcpkg/installed/arm64-osx-dynamic/include/python3.11 -I/Users/mkuhn/dev/vcpkg/vcpkg/installed/arm64-osx-dynamic/lib/python3.11/site-packages/numpy/core/include -c extensions/osr_wrap.cpp -o build/temp.macosx-15.3-arm64-cpython-311/extensions/osr_wrap.o -std=c++11 -Wno-error=unused-command-line-argument-hard-error-in-future -DSWIG_PYTHON_SILENT_MEMLEAK
warning: unknown warning option '-Werror=unused-command-line-argument-hard-error-in-future'; did you mean '-Werror=unused-command-line-argument'? [-Wunknown-warning-option]
warning: unknown warning option '-Werror=unused-command-line-argument-hard-error-in-future'; did you mean '-Werror=unused-command-line-argument'? [-Wunknown-warning-option]
warning: unknown warning option '-Werror=unused-command-line-argument-hard-error-in-future'; did you mean '-Werror=unused-command-line-argument'? [-Wunknown-warning-option]
warning: unknown warning option '-Werror=unused-command-line-argument-hard-error-in-future'; did you mean '-Werror=unused-command-line-argument'? [-Wunknown-warning-option]
warning: unknown warning option '-Werror=unused-command-line-argument-hard-error-in-future'; did you mean '-Werror=unused-command-line-argument'? [-Wunknown-warning-option]
warning: unknown warning option '-Werror=unused-command-line-argument-hard-error-in-future'; did you mean '-Werror=unused-command-line-argument'? [-Wunknown-warning-option]
In file included from extensions/gnm_wrap.cpp:200:
/Users/mkuhn/dev/vcpkg/vcpkg/installed/arm64-osx-dynamic/include/python3.11/Python.h:23:12: fatal error: 'stdlib.h' file not found
   23 | #  include <stdlib.h>
      |            ^~~~~~~~~~
In file included from extensions/osr_wrap.cpp:200:
/Users/mkuhn/dev/vcpkg/vcpkg/installed/arm64-osx-dynamic/include/python3.11/Python.h:23:12: fatal error: 'stdlib.h' file not found
   23 | #  include <stdlib.h>
      |            ^~~~~~~~~~
In file included from extensions/ogr_wrap.cpp:200:
/Users/mkuhn/dev/vcpkg/vcpkg/installed/arm64-osx-dynamic/include/python3.11/Python.h:23:12: fatal error: 'stdlib.h' file not found
   23 | #  include <stdlib.h>
      |            ^~~~~~~~~~
In file included from extensions/gdal_wrap.cpp:200:
/Users/mkuhn/dev/vcpkg/vcpkg/installed/arm64-osx-dynamic/include/python3.11/Python.h:23:12: fatal error: 'stdlib.h' file not found
   23 | #  include <stdlib.h>
      |            ^~~~~~~~~~
1 warning and 1 error generated.
1 warning and 1 error generated.
1 warning and 1 error generated.
1 warning and 1 error generated.
1 warning generated.
```

This is a missing system include, stdlib.h comes from the SDK which somehow doesn't end up in -isysroot if not done explicitly.