### PR TITLE
Fix subdomain of FLIR metadata

### DIFF
--- a/autotest/gdrivers/jpeg.py
+++ b/autotest/gdrivers/jpeg.py
@@ -1275,7 +1275,6 @@ def test_jpeg_flir_png():
     assert ds.GetMetadataDomainList() == [
         "IMAGE_STRUCTURE",
         "FLIR",
-        "",
         "SUBDATASETS",
         "DERIVED_SUBDATASETS",
     ]
@@ -1330,6 +1329,7 @@ def test_jpeg_flir_png():
         "RawValueRangeMax": "61986",
         "RawValueRangeMin": "7630",
         "ReflectedApparentTemperature": "20.000000 C",
+        "RelativeHumidity": "50.000000 %",
         "UnderflowColor": "41 110 240",
     }
     subds = ds.GetSubDatasets()

--- a/frmts/jpeg/jpgdataset.cpp
+++ b/frmts/jpeg/jpgdataset.cpp
@@ -688,7 +688,8 @@ void JPGDatasetCommon::ReadFLIRMetadata()
         if (fRelativeHumidity > 2)
             fRelativeHumidity /= 100.0f;  // Sometimes expressed in percentage
         SetMetadataItem("RelativeHumidity",
-                        CPLSPrintf("%f %%", 100.0f * fRelativeHumidity));
+                        CPLSPrintf("%f %%", 100.0f * fRelativeHumidity),
+                        "FLIR");
         SetMetadataItem("PlanckR1",
                         CPLSPrintf("%.8g", ReadFloat32(nRecOffset + 88)),
                         "FLIR");


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

Fix missing `FLIR` subdomain when reading the relative humidity of the FLIR metadata.

## What are related issues/pull requests?

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
