### PR TITLE
SWIG/c#: Update string marshaling code to use utf-8 native strings

### DIFF
--- a/swig/include/csharp/typemaps_csharp.i
+++ b/swig/include/csharp/typemaps_csharp.i
@@ -238,10 +238,17 @@ CSHARP_OBJECT_ARRAYS_PINNED(GDALRasterBandShadow, Band)
 
         int byteCount = System.Text.Encoding.UTF8.GetByteCount(str);
         IntPtr unmanagedString = Marshal.AllocHGlobal(byteCount + 1);
-        byte[] utf8Bytes = System.Text.Encoding.UTF8.GetBytes(str);
-        Marshal.Copy(utf8Bytes, 0, unmanagedString, byteCount);
-        // null-terminate the string
-        Marshal.WriteByte(unmanagedString, byteCount, 0);
+
+        unsafe
+        {
+            byte* ptr = (byte*)unmanagedString.ToPointer();
+            fixed (char *pStr = str)
+            {
+                System.Text.Encoding.UTF8.GetBytes(pStr, str.Length, ptr, byteCount);
+                // null-terminate
+                ptr[byteCount] = 0;
+            }
+        }
 
         return unmanagedString;
     }


### PR DESCRIPTION
Update C# SWIG typemap to marshal array of strings as an array of utf-8 strings, as RFC 5 suggests.

This fixes generated c# bindings and makes .net code to work with the datasets containing non-ascii characters in the text data.

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?
Fix SWIG/.net typemaps to treat strings in string arrays as utf-8 strings. This makes the datasets containing non-ascii characters in the text data usable by the .NET applications.

The use of UTF-8 in character data is mandated by RFC 5 (https://gdal.org/en/stable/development/rfc/rfc5_unicode.html).

## What are related issues/pull requests?

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

