### PR TITLE
MiraMonVector: Fixing decimal figures error (2)

### DIFF
--- a/ogr/ogrsf_frmts/miramon/ogrmiramonlayer.cpp
+++ b/ogr/ogrsf_frmts/miramon/ogrmiramonlayer.cpp
@@ -2510,10 +2510,24 @@ OGRErr OGRMiraMonLayer::TranslateFieldsValuesToMM(OGRFeature *poFeature)
                 }
 
                 char szChain[MAX_SIZE_OF_FIELD_NUMBER_WITH_MINUS];
-                MM_SprintfDoubleSignifFigures(
-                    szChain, sizeof(szChain),
-                    phMiraMonLayer->pLayerDB->pFields[iField].nNumberOfDecimals,
-                    padfRLValues[nIRecord]);
+                if (phMiraMonLayer->pLayerDB->pFields[iField]
+                            .nNumberOfDecimals > 0 &&
+                    phMiraMonLayer->pLayerDB->pFields[iField]
+                            .nNumberOfDecimals < MAX_RELIABLE_SF_DOUBLE)
+                {
+                    CPLsnprintf(szChain, sizeof(szChain), "%.*f",
+                                phMiraMonLayer->pLayerDB->pFields[iField]
+                                    .nNumberOfDecimals,
+                                padfRLValues[nIRecord]);
+                }
+                else
+                {
+                    MM_SprintfDoubleSignifFigures(
+                        szChain, sizeof(szChain),
+                        phMiraMonLayer->pLayerDB->pFields[iField]
+                            .nNumberOfDecimals,
+                        padfRLValues[nIRecord]);
+                }
 
                 if (MM_SecureCopyStringFieldValue(
                         &hMMFeature.pRecords[nIRecord].pField[iField].pDinValue,


### PR DESCRIPTION
## What does this PR do?
This fixes the OFTRealList case of a fixed problem ocurred in https://github.com/OSGeo/gdal/pull/12508 with the OFTReal case.
I forgot to add this case. It's an adaptation of the same.
As OftRealList cases are not as usual as OFTReal ones I no add test. No danger in that code as it's more or less the same than the other.

## What are related issues/pull requests?
https://github.com/OSGeo/gdal/pull/12508

## Tasklist
 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Review
 - [ ] All CI builds and checks have passed
