### PR TITLE
Remove compiler flags as defined in #12563

### DIFF
--- a/ogr/ogrsf_frmts/lvbag/CMakeLists.txt
+++ b/ogr/ogrsf_frmts/lvbag/CMakeLists.txt
@@ -1,7 +1,5 @@
 add_gdal_driver(TARGET ogr_LVBAG SOURCES ogrlvbagdatasource.cpp ogrlvbagdriver.cpp ogrlvbaglayer.cpp PLUGIN_CAPABLE
   NO_DEPS
-  NO_CXX_WFLAGS_EFFCXX
-  NO_WFLAG_OLD_STYLE_CAST
 )
 gdal_standard_includes(ogr_LVBAG)
 target_include_directories(ogr_LVBAG PRIVATE $<TARGET_PROPERTY:ogrsf_generic,SOURCE_DIR>)

--- a/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
+++ b/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
@@ -5,7 +5,7 @@
  * Author:   Laixer B.V., info at laixer dot com
  *
  ******************************************************************************
- * Copyright (c) 2021, Laixer B.V. <info at laixer dot com>
+ * Copyright (c) 2020, Laixer B.V. <info at laixer dot com>
  *
  * SPDX-License-Identifier: MIT
  ****************************************************************************/
@@ -27,11 +27,12 @@ constexpr const size_t nDefaultIdentifierSize = 16;
 
 OGRLVBAGLayer::OGRLVBAGLayer(const char *pszFilename, OGRLayerPool *poPoolIn,
                              char **papszOpenOptions)
-    : OGRAbstractProxiedLayer{poPoolIn}, poFeatureDefn{new OGRFeatureDefn{}},
-      fp{nullptr}, osFilename{pszFilename}, eFileDescriptorsState{FD_CLOSED},
-      oParser{nullptr}, bSchemaOnly{false}, bHasReadSchema{false},
-      bFixInvalidData{
-          CPLFetchBool(papszOpenOptions, "AUTOCORRECT_INVALID_DATA", false)},
+    : OGRAbstractProxiedLayer{poPoolIn},
+      poFeatureDefn{new OGRFeatureDefn{}}, fp{nullptr}, osFilename{pszFilename},
+      eFileDescriptorsState{FD_CLOSED}, oParser{nullptr}, bSchemaOnly{false},
+      bHasReadSchema{false}, bFixInvalidData{CPLFetchBool(
+                                 papszOpenOptions, "AUTOCORRECT_INVALID_DATA",
+                                 false)},
       bLegacyId{CPLFetchBool(papszOpenOptions, "LEGACY_ID", false)},
       nNextFID{0}, nCurrentDepth{0}, nGeometryElementDepth{0},
       nFeatureCollectionDepth{0}, nFeatureElementDepth{0},

--- a/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
+++ b/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
@@ -27,17 +27,17 @@ constexpr const size_t nDefaultIdentifierSize = 16;
 
 OGRLVBAGLayer::OGRLVBAGLayer(const char *pszFilename, OGRLayerPool *poPoolIn,
                              char **papszOpenOptions)
-    : OGRAbstractProxiedLayer{poPoolIn},
-      poFeatureDefn{new OGRFeatureDefn{}}, fp{nullptr}, osFilename{pszFilename},
-      eFileDescriptorsState{FD_CLOSED}, oParser{nullptr}, bSchemaOnly{false},
-      bHasReadSchema{false}, bFixInvalidData{CPLFetchBool(
-                                 papszOpenOptions, "AUTOCORRECT_INVALID_DATA",
-                                 false)},
+    : OGRAbstractProxiedLayer{poPoolIn}, poFeatureDefn{new OGRFeatureDefn{}},
+      fp{nullptr}, osFilename{pszFilename}, eFileDescriptorsState{FD_CLOSED},
+      oParser{nullptr}, bSchemaOnly{false}, bHasReadSchema{false},
+      bFixInvalidData{
+          CPLFetchBool(papszOpenOptions, "AUTOCORRECT_INVALID_DATA", false)},
       bLegacyId{CPLFetchBool(papszOpenOptions, "LEGACY_ID", false)},
       nNextFID{0}, nCurrentDepth{0}, nGeometryElementDepth{0},
       nFeatureCollectionDepth{0}, nFeatureElementDepth{0},
       nAttributeElementDepth{0},
-      eAddressRefState{AddressRefState::ADDRESS_PRIMARY}, bCollectData{false}
+      eAddressRefState{AddressRefState::ADDRESS_PRIMARY}, osElementString{},
+      osAttributeString{}, bCollectData{false}
 {
     SetDescription(CPLGetBasenameSafe(pszFilename).c_str());
 

--- a/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
+++ b/ogr/ogrsf_frmts/lvbag/ogrlvbaglayer.cpp
@@ -62,7 +62,9 @@ OGRLVBAGLayer::~OGRLVBAGLayer()
 void OGRLVBAGLayer::ResetReading()
 {
     if (!TouchLayer())
+    {
         return;
+    }
 
     VSIRewindL(fp);
 
@@ -83,7 +85,9 @@ void OGRLVBAGLayer::ResetReading()
 OGRFeatureDefn *OGRLVBAGLayer::GetLayerDefn()
 {
     if (!TouchLayer())
+    {
         return nullptr;
+    }
 
     if (!bHasReadSchema)
     {
@@ -105,7 +109,9 @@ static inline const char *XMLTagSplit(const char *pszName)
     const char *pszTag = pszName;
     const char *pszSep = strchr(pszTag, ':');
     if (pszSep)
+    {
         pszTag = pszSep + 1;
+    }
 
     return pszTag;
 }
@@ -320,8 +326,10 @@ void OGRLVBAGLayer::CreateFeatureDefn(const char *pszDataset)
         AddSpatialRef(wkbMultiPolygon);
     }
     else
+    {
         CPLError(CE_Failure, CPLE_AppDefined,
                  "Parsing LV BAG extract failed : invalid layer definition");
+    }
 }
 
 /************************************************************************/
@@ -353,7 +361,9 @@ void OGRLVBAGLayer::StopDataCollect()
 void OGRLVBAGLayer::DataHandlerCbk(const char *data, int nLen)
 {
     if (nLen && bCollectData)
+    {
         osElementString.append(data, nLen);
+    }
 }
 
 /************************************************************************/
@@ -395,7 +405,9 @@ bool OGRLVBAGLayer::TouchLayer()
 void OGRLVBAGLayer::CloseUnderlyingLayer()
 {
     if (fp)
+    {
         VSIFCloseL(fp);
+    }
     fp = nullptr;
 
     eFileDescriptorsState = FD_CLOSED;
@@ -755,13 +767,17 @@ void OGRLVBAGLayer::EndElementCbk(const char *pszName)
         }
 
         if (!bHasReadSchema)
+        {
             CreateFeatureDefn(osElementString.c_str());
+        }
         bHasReadSchema = true;
 
         // The parser is suspended but never resumed. Stop
         // without resume indicated an error.
         if (bSchemaOnly)
+        {
             XML_StopParser(oParser.get(), XML_TRUE);
+        }
     }
 }
 
@@ -872,7 +888,9 @@ void OGRLVBAGLayer::ParseDocument()
 OGRFeature *OGRLVBAGLayer::GetNextFeature()
 {
     if (!TouchLayer())
+    {
         return nullptr;
+    }
 
     if (!bHasReadSchema)
     {
@@ -898,7 +916,9 @@ OGRFeature *OGRLVBAGLayer::GetNextRawFeature()
     bSchemaOnly = false;
 
     if (nNextFID == 0)
+    {
         ConfigureParser();
+    }
 
     if (m_poFeature)
     {
@@ -919,10 +939,14 @@ OGRFeature *OGRLVBAGLayer::GetNextRawFeature()
 int OGRLVBAGLayer::TestCapability(const char *pszCap)
 {
     if (!TouchLayer())
+    {
         return FALSE;
+    }
 
     if (EQUAL(pszCap, OLCStringsAsUTF8))
+    {
         return TRUE;
+    }
 
     return FALSE;
 }


### PR DESCRIPTION
This removes the warning compiler flags set in #12563. It also improves code style by using brackets for all statement blocks.