### PR TITLE
FileGDB Docs: fixed dead link for ESRI download

### DIFF
--- a/doc/source/drivers/vector/filegdb.rst
+++ b/doc/source/drivers/vector/filegdb.rst
@@ -28,7 +28,7 @@ Driver capabilities
 Requirements
 ------------
 
-`FileGDB API SDK <http://www.esri.com/apps/products/download/#File_Geodatabase_API_1.3>`__
+`ESRI File Geodatabase API <https://github.com/Esri/file-geodatabase-api>`__
 
 Curve in geometries are supported on reading with GDAL >= 2.2.
 


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

Updates a dead link in the documentation for the ESRI File Geodatabase driver.

The docs previously directed individuals to an old ESRI download page, however according to an [ESRI Blog](https://www.esri.com/arcgis-blog/products/developers/data-management/guide-to-the-file-geodatabase-api) the official place to download it from now is directly from their GitHub repo.

## What are related issues/pull requests?

N/A

## Tasklist

N/A

## Environment

Provide environment details, if relevant:

* OS: N/A
* Compiler: N/A
