### PR TITLE
Doc: fix description of the return value for OGRGeometry::IsRing()

### DIFF
--- a/ogr/ogrgeometry.cpp
+++ b/ogr/ogrgeometry.cpp
@@ -2480,7 +2480,8 @@ int OGR_G_IsSimple(OGRGeometryH hGeom)
  * FALSE.
  *
  *
- * @return TRUE if the geometry has no points, otherwise FALSE.
+ * @return TRUE if the coordinates of the geometry form a ring, by checking
+ * length and closure (self-intersection is not checked), otherwise FALSE.
  */
 
 OGRBoolean OGRGeometry::IsRing() const
@@ -2525,7 +2526,8 @@ OGRBoolean OGRGeometry::IsRing() const
  *
  * @param hGeom The Geometry to test.
  *
- * @return TRUE if the geometry has no points, otherwise FALSE.
+ * @return TRUE if the coordinates of the geometry form a ring, by checking
+ * length and closure (self-intersection is not checked), otherwise FALSE.
  */
 
 int OGR_G_IsRing(OGRGeometryH hGeom)

--- a/swig/include/python/docs/ogr_geometry_docs.i
+++ b/swig/include/python/docs/ogr_geometry_docs.i
@@ -464,7 +464,8 @@ For more details: :cpp:func:`OGR_G_IsRing`
 Returns
 --------
 int:
-    True if the geometry has no points, otherwise False.
+    True if the coordinates of the geometry form a ring, by checking length
+    and closure (self-intersection is not checked), otherwise False.
 ";
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes the description of the return value of `OGRGeometry::IsRing()`, consistent with https://libgeos.org/doxygen/group__prop.html#gabaeb1320a591615a4907cc6929f42e15

## Tasklist

 - [X] Add documentation
 - [X] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed