### PR TITLE
Fix osgeo4w gdal-dev

### DIFF
--- a/frmts/ecw/ecwdataset.cpp
+++ b/frmts/ecw/ecwdataset.cpp
@@ -73,6 +73,10 @@ ECWRasterBand::ECWRasterBand(ECWDataset *poDSIn, int nBandIn, int iOverviewIn,
     nRasterYSize = poDS->GetRasterYSize() / (1 << (iOverview + 1));
 
 #if ECWSDK_VERSION >= 51
+// undefine min macro if any
+#ifdef min
+#undef min
+#endif
     if (poDSIn->bIsJPEG2000 && poDSIn->poFileView)
     {
         UINT32 nTileWidth = 0;

--- a/gcore/gdal_priv_templates.hpp
+++ b/gcore/gdal_priv_templates.hpp
@@ -31,7 +31,7 @@
 #ifdef USE_NEON_OPTIMIZATIONS
 #include "include_sse2neon.h"
 #else
-#include <emmintrin.h>
+#include <immintrin.h>
 #endif
 
 static inline void GDALCopyXMMToInt32(const __m128i xmm, void *pDest)


### PR DESCRIPTION
Fix for https://trac.osgeo.org/osgeo4w/ticket/883

Fixes build errors:
```
FAILED: alg/CMakeFiles/alg.dir/gdalrasterize.cpp.obj
C:\src\osgeo4w\scripts\vs2022\VC\Tools\MSVC\14.38.33130\bin\Hostx64\x64\cl.exe  /nologo /TP -DGDAL_COMPILATION -DHAVE_AVX_AT_COMPILE_TIME -DHAVE_GEOS=1 -DHAVE_SSE_AT_COMPILE_TIME -DHAVE_SSSE3_AT_COMPILE_TIME -DINTERNAL_QHULL -DNOMINMAX -D_CRT_NONSTDC_NO_DEPRECATE -D_CRT_SECURE_NO_DEPRECATE -IC:\src\osgeo4w\src\gdal-dev\gdal\apps -IC:\src\osgeo4w\src\gdal-dev\gdal\alg -IC:\src\osgeo4w\src\gdal-dev\gdal\gcore -IC:\src\osgeo4w\src\gdal-dev\osgeo4w\build\gcore -IC:\src\osgeo4w\src\gdal-dev\gdal\port -IC:\src\osgeo4w\src\gdal-dev\osgeo4w\build\port -IC:\src\osgeo4w\src\gdal-dev\gdal\ogr -IC:\src\osgeo4w\src\gdal-dev\gdal\ogr\ogrsf_frmts -IC:\src\osgeo4w\src\gdal-dev\gdal\frmts -IC:\src\osgeo4w\src\gdal-dev\gdal\frmts\mem -IC:\src\osgeo4w\src\gdal-dev\gdal\alg\marching_squares -IC:\src\osgeo4w\src\gdal-dev\gdal\frmts\vrt -IC:\src\osgeo4w\src\gdal-dev\osgeo4w\osgeo4w\include\geos -IC:\src\osgeo4w\src\gdal-dev\osgeo4w\osgeo4w\include -IC:\src\osgeo4w\src\gdal-dev\gdal\alg\internal_libqhull /D_DISABLE_CONSTEXPR_MUTEX_CONSTRUCTOR  /DWIN32 /D_WINDOWS /EHsc /O2 /Ob1 /DNDEBUG -std:c++17 -MD -Zi /EHsc /MP /W4 /wd4127 /wd4251 /wd4275 /wd4786 /wd4100 /wd4245 /wd4206 /wd4351 /wd4611 /showIncludes /Foalg\CMakeFiles\alg.dir\gdalrasterize.cpp.obj /Fdalg\CMakeFiles\alg.dir\ /FS -c C:\src\osgeo4w\src\gdal-dev\gdal\alg\gdalrasterize.cpp
C:\src\osgeo4w\src\gdal-dev\gdal\gcore\gdal_priv_templates.hpp(401): error C3861: '_mm_undefined_ps': identifier not found
C:\src\osgeo4w\src\gdal-dev\gdal\gcore\gdal_priv_templates.hpp(400): error C2660: '_mm_store_ss': function does not take 1 arguments
C:\src\osgeo4w\scripts\vs2022\VC\Tools\MSVC\14.38.33130\include\xmmintrin.h(352): note: see declaration of '_mm_store_ss'
C:\src\osgeo4w\src\gdal-dev\gdal\gcore\gdal_priv_templates.hpp(400): note: while trying to match the argument list '(float *)'
``