### PR TITLE
[Backport release/3.11] Python bindings: fix issues with None bounds for ogr.CreateRangeFieldDomain() and ogr.CreateRangeFieldDomainDateTime()

### DIFF
--- a/autotest/ogr/ogr_fielddomain.py
+++ b/autotest/ogr/ogr_fielddomain.py
@@ -52,6 +52,22 @@ def test_ogr_fielddomain_range():
     assert domain.GetMergePolicy() == ogr.OFDMP_SUM
 
     domain = ogr.CreateRangeFieldDomain(
+        "name", "desc", ogr.OFTInteger, ogr.OFSTNone, None, False, 2, True
+    )
+    assert domain.GetDomainType() == ogr.OFDT_RANGE
+    assert domain.GetFieldType() == ogr.OFTInteger
+    assert domain.GetMinAsDouble() == float("-inf")
+    assert domain.GetMaxAsDouble() == 2.0
+
+    domain = ogr.CreateRangeFieldDomain(
+        "name", "desc", ogr.OFTInteger, ogr.OFSTNone, 1, True, None, False
+    )
+    assert domain.GetDomainType() == ogr.OFDT_RANGE
+    assert domain.GetFieldType() == ogr.OFTInteger
+    assert domain.GetMinAsDouble() == 1
+    assert domain.GetMaxAsDouble() == float("inf")
+
+    domain = ogr.CreateRangeFieldDomain(
         "name",
         None,
         ogr.OFTInteger64,
@@ -115,6 +131,28 @@ def test_ogr_fielddomain_range():
 
     with pytest.raises(Exception, match="should be called with a glob field domain"):
         domain.GetGlob()
+
+    domain = ogr.CreateRangeFieldDomainDateTime(
+        "datetime_range",
+        "datetime_range_desc",
+        None,
+        False,
+        "2023-07-03T12:13:15",
+        True,
+    )
+    assert domain.GetMinAsString() is None
+    assert domain.GetMaxAsString() == "2023-07-03T12:13:15"
+
+    domain = ogr.CreateRangeFieldDomainDateTime(
+        "datetime_range",
+        "datetime_range_desc",
+        "2023-07-03T12:13:14",
+        True,
+        None,
+        False,
+    )
+    assert domain.GetMinAsString() == "2023-07-03T12:13:14"
+    assert domain.GetMaxAsString() is None
 
 
 def test_ogr_fielddomain_coded():

--- a/autotest/ogr/ogr_fielddomain.py
+++ b/autotest/ogr/ogr_fielddomain.py
@@ -224,9 +224,10 @@ def test_ogr_fielddomain_mem_driver():
         ds.AddFieldDomain(None)
 
     # Duplicate domain
-    assert not ds.AddFieldDomain(
-        ogr.CreateGlobFieldDomain("name", "desc", ogr.OFTString, ogr.OFSTNone, "*")
-    )
+    with pytest.raises(Exception, match="A domain of identical name already exists"):
+        ds.AddFieldDomain(
+            ogr.CreateGlobFieldDomain("name", "desc", ogr.OFTString, ogr.OFSTNone, "*")
+        )
 
     assert ds.GetFieldDomainNames() == ["name"]
 

--- a/autotest/ogr/ogr_parquet.py
+++ b/autotest/ogr/ogr_parquet.py
@@ -710,7 +710,8 @@ def test_ogr_parquet_write_edge_cases():
     domain = ogr.CreateCodedFieldDomain(
         "name", "desc", ogr.OFTInteger, ogr.OFSTNone, {1: "one", "2": None}
     )
-    assert ds.AddFieldDomain(domain) == False
+    with pytest.raises(Exception, match="Layer must be created"):
+        ds.AddFieldDomain(domain)
     assert ds.GetFieldDomainNames() is None
     assert ds.GetFieldDomain("foo") is None
     ds = None

--- a/ogr/ogrsf_frmts/openfilegdb/filegdb_fielddomain.h
+++ b/ogr/ogrsf_frmts/openfilegdb/filegdb_fielddomain.h
@@ -419,45 +419,43 @@ inline std::string BuildXMLFieldDomainDef(const OGRFieldDomain *poDomain,
                 [&AddFieldTypeAsXSIType, &poDomain,
                  psRoot](const char *pszElementName, const OGRField &oValue)
             {
-                if (!OGR_RawField_IsUnset(&oValue))
+                auto psValue =
+                    CPLCreateXMLNode(psRoot, CXT_Element, pszElementName);
+                AddFieldTypeAsXSIType(psValue);
+                if (poDomain->GetFieldType() == OFTInteger)
                 {
-                    auto psValue =
-                        CPLCreateXMLNode(psRoot, CXT_Element, pszElementName);
-                    AddFieldTypeAsXSIType(psValue);
-                    if (poDomain->GetFieldType() == OFTInteger)
-                    {
-                        CPLCreateXMLNode(psValue, CXT_Text,
-                                         CPLSPrintf("%d", oValue.Integer));
-                    }
-                    else if (poDomain->GetFieldType() == OFTReal)
-                    {
-                        CPLCreateXMLNode(psValue, CXT_Text,
-                                         CPLSPrintf("%.18g", oValue.Real));
-                    }
-                    else if (poDomain->GetFieldType() == OFTString)
-                    {
-                        CPLCreateXMLNode(psValue, CXT_Text, oValue.String);
-                    }
-                    else if (poDomain->GetFieldType() == OFTDateTime)
-                    {
-                        CPLCreateXMLNode(
-                            psValue, CXT_Text,
-                            CPLSPrintf(
-                                "%04d-%02d-%02dT%02d:%02d:%02d",
-                                oValue.Date.Year, oValue.Date.Month,
-                                oValue.Date.Day, oValue.Date.Hour,
-                                oValue.Date.Minute,
-                                static_cast<int>(oValue.Date.Second + 0.5)));
-                    }
+                    CPLCreateXMLNode(psValue, CXT_Text,
+                                     CPLSPrintf("%d", oValue.Integer));
+                }
+                else if (poDomain->GetFieldType() == OFTReal)
+                {
+                    CPLCreateXMLNode(psValue, CXT_Text,
+                                     CPLSPrintf("%.18g", oValue.Real));
+                }
+                else if (poDomain->GetFieldType() == OFTDateTime)
+                {
+                    CPLCreateXMLNode(
+                        psValue, CXT_Text,
+                        CPLSPrintf("%04d-%02d-%02dT%02d:%02d:%02d",
+                                   oValue.Date.Year, oValue.Date.Month,
+                                   oValue.Date.Day, oValue.Date.Hour,
+                                   oValue.Date.Minute,
+                                   static_cast<int>(oValue.Date.Second + 0.5)));
                 }
             };
 
             bool bIsInclusiveOut = false;
-            const OGRField &oMax = poRangeDomain->GetMax(bIsInclusiveOut);
-            SerializeMinOrMax("MaxValue", oMax);
-
-            bIsInclusiveOut = false;
             const OGRField &oMin = poRangeDomain->GetMin(bIsInclusiveOut);
+            const OGRField &oMax = poRangeDomain->GetMax(bIsInclusiveOut);
+            if (OGR_RawField_IsUnset(&oMin) || OGR_RawField_IsUnset(&oMax))
+            {
+                failureReason =
+                    "FileGeoDatabase requires that both minimum and maximum "
+                    "values of a range field domain are set.";
+                return std::string();
+            }
+
+            SerializeMinOrMax("MaxValue", oMax);
             SerializeMinOrMax("MinValue", oMin);
 
             break;

--- a/swig/include/Dataset.i
+++ b/swig/include/Dataset.i
@@ -982,7 +982,14 @@ OGRErr AbortSQL() {
   %apply Pointer NONNULL {OGRFieldDomainShadow* fieldDomain};
   bool AddFieldDomain(OGRFieldDomainShadow* fieldDomain)
   {
-      return GDALDatasetAddFieldDomain(self, (OGRFieldDomainH)fieldDomain, NULL);
+      char* pszReason = NULL;
+      if( !GDALDatasetAddFieldDomain(self, (OGRFieldDomainH)fieldDomain, &pszReason) )
+      {
+          CPLError(CE_Failure, CPLE_AppDefined, "%s", pszReason);
+          CPLFree(pszReason);
+          return false;
+      }
+      return true;
   }
   %clear OGRFieldDomainShadow* fieldDomain;
 

--- a/swig/include/ogr.i
+++ b/swig/include/ogr.i
@@ -4331,6 +4331,58 @@ OGRFieldDomainShadow* CreateCodedFieldDomain( const char *name,
 
 %newobject CreateRangeFieldDomain;
 %apply Pointer NONNULL {const char* name};
+
+#ifdef SWIGPYTHON
+%apply (double *optional_double) {(double*)};
+
+%inline %{
+static
+OGRFieldDomainShadow* CreateRangeFieldDomain( const char *name,
+                                              const char* description,
+                                              OGRFieldType type,
+                                              OGRFieldSubType subtype,
+                                              double* min,
+                                              bool minIsInclusive,
+                                              double* max,
+                                              bool maxIsInclusive) {
+  OGRField sMin;
+  if (min )
+  {
+      if( type == OFTInteger )
+          sMin.Integer = static_cast<int>(*min);
+      else if( type == OFTInteger64 )
+          sMin.Integer64 = static_cast<GIntBig>(*min);
+      else if( type == OFTReal )
+          sMin.Real = *min;
+      else
+          return NULL;
+  }
+
+  OGRField sMax;
+  if( max )
+  {
+      if( type == OFTInteger )
+          sMax.Integer = static_cast<int>(*max);
+      else if( type == OFTInteger64 )
+          sMax.Integer64 = static_cast<GIntBig>(*max);
+      else if( type == OFTReal )
+          sMax.Real = *max;
+      else
+          return NULL;
+  }
+  return (OGRFieldDomainShadow*) OGR_RangeFldDomain_Create( name,
+                                                            description,
+                                                            type,
+                                                            subtype,
+                                                            min ? &sMin : NULL,
+                                                            minIsInclusive,
+                                                            max ? &sMax : NULL,
+                                                            maxIsInclusive );
+}
+%}
+
+#else
+
 %inline %{
 static
 OGRFieldDomainShadow* CreateRangeFieldDomain( const char *name,
@@ -4340,7 +4392,7 @@ OGRFieldDomainShadow* CreateRangeFieldDomain( const char *name,
                                               double min,
                                               bool minIsInclusive,
                                               double max,
-                                              double maxIsInclusive) {
+                                              bool maxIsInclusive) {
   OGRField sMin;
   if( type == OFTInteger )
       sMin.Integer = static_cast<int>(min);
@@ -4370,6 +4422,8 @@ OGRFieldDomainShadow* CreateRangeFieldDomain( const char *name,
 }
 %}
 
+#endif
+
 %inline %{
 static
 OGRFieldDomainShadow* CreateRangeFieldDomainDateTime( const char *name,
@@ -4380,14 +4434,14 @@ OGRFieldDomainShadow* CreateRangeFieldDomainDateTime( const char *name,
                                               double maxIsInclusive) {
   OGRField sMin;
   OGRField sMax;
-  if( !OGRParseXMLDateTime(min, &sMin))
+  if( min && !OGRParseXMLDateTime(min, &sMin))
   {
     CPLError(CE_Failure, CPLE_AppDefined,
              "Invalid min: %s",
              min);
     return NULL;
   }
-  if( !OGRParseXMLDateTime(max, &sMax))
+  if( max && !OGRParseXMLDateTime(max, &sMax))
   {
     CPLError(CE_Failure, CPLE_AppDefined,
              "Invalid max: %s",
@@ -4398,9 +4452,9 @@ OGRFieldDomainShadow* CreateRangeFieldDomainDateTime( const char *name,
                                                             description,
                                                             OFTDateTime,
                                                             OFSTNone,
-                                                            &sMin,
+                                                            min ? &sMin : NULL,
                                                             minIsInclusive,
-                                                            &sMax,
+                                                            max ? &sMax : NULL,
                                                             maxIsInclusive );
 }
 %}

--- a/swig/include/python/typemaps_python.i
+++ b/swig/include/python/typemaps_python.i
@@ -1543,6 +1543,7 @@ static PyObject* CSLToList( char** stringarray, bool *pbErr )
 
 OPTIONAL_POD(int,i);
 OPTIONAL_POD(GIntBig,L);
+OPTIONAL_POD(double, d);
 
 /*
  * Typedef const char * <- Any object.


### PR DESCRIPTION
Backport #12571
 **Authored by:** @rouault