### PR TITLE
VRTDerivedBand expressions: Add _CENTER_X_ and _CENTER_Y_ built-in variables

### DIFF
--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1234,6 +1234,9 @@ GDAL provides a set of default pixel functions that can be used without writing 
 
          With muparser, it is expanded into a list of all input bands.
 
+       Starting with GDAL 3.12, the variables ``_CENTER_X_`` and ``_CENTER_Y_`` can be
+       included in the expression to access cell center coordinates.
+
        ExprTk and muparser support a number of built-in functions and control structures.
 
        Refer to the documentation of those libraries for details.

--- a/frmts/vrt/pixelfunctions.cpp
+++ b/frmts/vrt/pixelfunctions.cpp
@@ -11,6 +11,7 @@
  * SPDX-License-Identifier: MIT
  *****************************************************************************/
 
+#include <array>
 #include <cmath>
 #include "gdal.h"
 #include "vrtdataset.h"
@@ -2736,6 +2737,9 @@ static const char pszExprPixelFuncMetadata[] =
     "       <Value>muparser</Value>"
     "   </Argument>"
     "   <Argument type='builtin' value='source_names' />"
+    "   <Argument type='builtin' value='xoff' />"
+    "   <Argument type='builtin' value='yoff' />"
+    "   <Argument type='builtin' value='geotransform' />"
     "</PixelFunctionArgumentsList>";
 
 static CPLErr ExprPixelFunc(void **papoSources, int nSources, void *pData,
@@ -2785,6 +2789,47 @@ static CPLErr ExprPixelFunc(void **papoSources, int nSources, void *pData,
         return CE_Failure;
     }
 
+    int nXOff = 0;
+    int nYOff = 0;
+    std::array<double, 6> gt;
+    double dfCenterX = 0;
+    double dfCenterY = 0;
+
+    bool includeCenterCoords = false;
+    if (strstr(pszExpression, "_CENTER_X_") ||
+        strstr(pszExpression, "_CENTER_Y_"))
+    {
+        includeCenterCoords = true;
+
+        const char *pszXOff = CSLFetchNameValue(papszArgs, "xoff");
+        nXOff = std::atoi(pszXOff);
+
+        const char *pszYOff = CSLFetchNameValue(papszArgs, "yoff");
+        nYOff = std::atoi(pszYOff);
+
+        const char *pszGT = CSLFetchNameValue(papszArgs, "geotransform");
+        if (pszGT == nullptr)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "To use _CENTER_X_ or _CENTER_Y_ in an expression, "
+                     "VRTDataset must have a <GeoTransform> element.");
+            return CE_Failure;
+        }
+
+        CPLStringList aosGeoTransform(
+            CSLTokenizeString2(pszGT, ",", CSLT_HONOURSTRINGS));
+        if (aosGeoTransform.size() != 6)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Invalid GeoTransform argument");
+            return CE_Failure;
+        }
+        for (int i = 0; i < 6; i++)
+        {
+            gt[i] = CPLAtof(aosGeoTransform[i]);
+        }
+    }
+
     {
         int iSource = 0;
         for (const auto &osName : aosSourceNames)
@@ -2792,6 +2837,12 @@ static CPLErr ExprPixelFunc(void **papoSources, int nSources, void *pData,
             poExpression->RegisterVariable(osName,
                                            &adfValuesForPixel[iSource++]);
         }
+    }
+
+    if (includeCenterCoords)
+    {
+        poExpression->RegisterVariable("_CENTER_X_", &dfCenterX);
+        poExpression->RegisterVariable("_CENTER_Y_", &dfCenterY);
     }
 
     if (strstr(pszExpression, "BANDS"))
@@ -2815,6 +2866,15 @@ static CPLErr ExprPixelFunc(void **papoSources, int nSources, void *pData,
                 // cppcheck-suppress unreadVariable
                 adfValuesForPixel[iSrc] =
                     GetSrcVal(papoSources[iSrc], eSrcType, ii);
+            }
+
+            if (includeCenterCoords)
+            {
+                // Add 0.5 to pixel / line to move from pixel corner to cell center
+                GDALApplyGeoTransform(gt.data(),
+                                      static_cast<double>(iCol + nXOff) + 0.5,
+                                      static_cast<double>(iLine + nYOff) + 0.5,
+                                      &dfCenterX, &dfCenterY);
             }
 
             if (auto eErr = poExpression->Evaluate(); eErr != CE_None)

--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -1181,10 +1181,9 @@ class CPL_DLL VRTDerivedRasterBand CPL_NON_FINAL : public VRTSourcedRasterBand
 {
     VRTDerivedRasterBandPrivateData *m_poPrivate;
     bool InitializePython();
-    CPLErr
-    GetPixelFunctionArguments(const CPLString &,
-                              const std::vector<int> &anMapBufferIdxToSourceIdx,
-                              std::vector<std::pair<CPLString, CPLString>> &);
+    CPLErr GetPixelFunctionArguments(
+        const CPLString &, const std::vector<int> &anMapBufferIdxToSourceIdx,
+        int nXOff, int nYOff, std::vector<std::pair<CPLString, CPLString>> &);
 
     CPL_DISALLOW_COPY_ASSIGN(VRTDerivedRasterBand)
 

--- a/frmts/vrt/vrtderivedrasterband.cpp
+++ b/frmts/vrt/vrtderivedrasterband.cpp
@@ -19,6 +19,7 @@
 #include "gdalpython.h"
 
 #include <algorithm>
+#include <array>
 #include <map>
 #include <vector>
 #include <utility>
@@ -832,7 +833,7 @@ bool VRTDerivedRasterBand::InitializePython()
 
 CPLErr VRTDerivedRasterBand::GetPixelFunctionArguments(
     const CPLString &osMetadata,
-    const std::vector<int> &anMapBufferIdxToSourceIdx,
+    const std::vector<int> &anMapBufferIdxToSourceIdx, int nXOff, int nYOff,
     std::vector<std::pair<CPLString, CPLString>> &oAdditionalArgs)
 {
 
@@ -865,13 +866,38 @@ CPLErr VRTDerivedRasterBand::GetPixelFunctionArguments(
                     CPLString osVal;
                     double dfVal = 0;
 
-                    int success;
+                    int success(FALSE);
                     if (osArgName == "NoData")
                         dfVal = this->GetNoDataValue(&success);
                     else if (osArgName == "scale")
                         dfVal = this->GetScale(&success);
                     else if (osArgName == "offset")
                         dfVal = this->GetOffset(&success);
+                    else if (osArgName == "xoff")
+                    {
+                        dfVal = static_cast<double>(nXOff);
+                        success = true;
+                    }
+                    else if (osArgName == "yoff")
+                    {
+                        dfVal = static_cast<double>(nYOff);
+                        success = true;
+                    }
+                    else if (osArgName == "geotransform")
+                    {
+                        std::array<double, 6> gt;
+                        if (GetDataset()->GetGeoTransform(gt.data()) != CE_None)
+                        {
+                            // Do not fail here because the argument is most
+                            // likely not needed by the pixel function. If it
+                            // is needed, the pixel function can emit the error.
+                            continue;
+                        }
+                        osVal = CPLSPrintf(
+                            "%.17g,%.17g,%.17g,%.17g,%.17g,%.17g", gt[0], gt[1],
+                            gt[2], gt[3], gt[4], gt[5]);
+                        success = true;
+                    }
                     else if (osArgName == "source_names")
                     {
                         for (size_t iBuffer = 0;
@@ -1406,7 +1432,7 @@ CPLErr VRTDerivedRasterBand::IRasterIO(
     if (poPixelFunc != nullptr && !poPixelFunc->second.empty())
     {
         if (GetPixelFunctionArguments(poPixelFunc->second,
-                                      anMapBufferIdxToSourceIdx,
+                                      anMapBufferIdxToSourceIdx, nXOff, nYOff,
                                       oAdditionalArgs) != CE_None)
         {
             eErr = CE_Failure;


### PR DESCRIPTION
Enables expressions such as the one shown in the example here: https://usdaforestservice.github.io/gdalraster/reference/calc.html#ref-examples