### PR TITLE
gdal raster reclassify: validate mappings in case VRT or GDALG output is used

### DIFF
--- a/apps/gdalalg_raster_reclassify.cpp
+++ b/apps/gdalalg_raster_reclassify.cpp
@@ -16,6 +16,7 @@
 #include "gdal_priv.h"
 #include "gdal_utils.h"
 #include "../frmts/vrt/vrtdataset.h"
+#include "../frmts/vrt/vrtreclassifier.h"
 
 #include <array>
 
@@ -43,7 +44,27 @@ GDALRasterReclassifyAlgorithm::GDALRasterReclassifyAlgorithm(
 }
 
 /************************************************************************/
-/*              GDALRasterReclassifyCreateVRTDerived)                   */
+/*              GDALRasterReclassifyValidateMappings                    */
+/************************************************************************/
+
+static bool GDALReclassifyValidateMappings(GDALDataset &input,
+                                           const std::string &mappings,
+                                           GDALDataType eDstType)
+{
+    int hasNoData;
+    std::optional<double> noData =
+        input.GetRasterBand(1)->GetNoDataValue(&hasNoData);
+    if (!hasNoData)
+    {
+        noData.reset();
+    }
+
+    gdal::Reclassifier reclassifier;
+    return reclassifier.Init(mappings.c_str(), noData, eDstType) == CE_None;
+}
+
+/************************************************************************/
+/*              GDALRasterReclassifyCreateVRTDerived                    */
 /************************************************************************/
 
 static std::unique_ptr<GDALDataset>
@@ -179,6 +200,11 @@ bool GDALRasterReclassifyAlgorithm::RunStep(GDALPipelineStepRunContext &)
     }
     if (nErrorCount == CPLGetErrorCounter())
     {
+        if (!GDALReclassifyValidateMappings(*poSrcDS, m_mapping, eDstType))
+        {
+            return false;
+        }
+
         m_outputDataset.Set(
             GDALReclassifyCreateVRTDerived(*poSrcDS, m_mapping, eDstType));
     }

--- a/autotest/utilities/test_gdalalg_raster_reclassify.py
+++ b/autotest/utilities/test_gdalalg_raster_reclassify.py
@@ -239,6 +239,19 @@ def test_gdalalg_raster_reclassify_empty_mapping(reclassify, tmp_vsimem):
         reclassify.Run()
 
 
+def test_gdalalg_raster_reclassify_invalid_mapping_vrt_output(reclassify, tmp_vsimem):
+
+    infile = "../gcore/data/byte.tif"
+    outfile = tmp_vsimem / "out.vrt"
+
+    reclassify["input"] = infile
+    reclassify["output"] = outfile
+    reclassify["mapping"] = "invalid"
+
+    with pytest.raises(RuntimeError, match="Interval must start with"):
+        reclassify.Run()
+
+
 def test_gdalalg_raster_reclassify_mapping_not_found(reclassify, tmp_vsimem):
 
     infile = "../gcore/data/byte.tif"


### PR DESCRIPTION
I struggled to find a way to enable this check only for cases the mappings will not be parsed as part of the pipeline.