### PR TITLE
[Backport release/3.11] gdalwarp -te + -te_srs: better compute target extent in target CRS …

### DIFF
--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -1621,12 +1621,13 @@ static bool CheckOptions(const char *pszDest, GDALDatasetH hDstDS,
                     psOptions->aosTransformerOptions.FetchNameValue("SRC_SRS"));
                 bOK = true;
             }
-            else
+            else if (nSrcCount)
             {
-                if (nSrcCount && GDALGetProjectionRef(pahSrcDS[0]) &&
-                    GDALGetProjectionRef(pahSrcDS[0])[0])
+                const auto poSrcSRS =
+                    GDALDataset::FromHandle(pahSrcDS[0])->GetSpatialRef();
+                if (poSrcSRS)
                 {
-                    oSRSDS.SetFromUserInput(GDALGetProjectionRef(pahSrcDS[0]));
+                    oSRSDS = *poSrcSRS;
                     bOK = true;
                 }
             }
@@ -1655,23 +1656,22 @@ static bool CheckOptions(const char *pszDest, GDALDatasetH hDstDS,
                         dfWestLongitudeDeg, dfSouthLatitudeDeg,
                         dfEastLongitudeDeg, dfNorthLatitudeDeg);
                 }
-                OGRCoordinateTransformation *poCT =
+                auto poCT = std::unique_ptr<OGRCoordinateTransformation>(
                     OGRCreateCoordinateTransformation(&oSRSIn, &oSRSDS,
-                                                      options);
-                if (!(poCT &&
-                      poCT->Transform(1, &psOptions->dfMinX,
-                                      &psOptions->dfMinY) &&
-                      poCT->Transform(1, &psOptions->dfMaxX,
-                                      &psOptions->dfMaxY)))
+                                                      options));
+                constexpr int DENSIFY_PTS = 21;
+                if (!(poCT && poCT->TransformBounds(
+                                  psOptions->dfMinX, psOptions->dfMinY,
+                                  psOptions->dfMaxX, psOptions->dfMaxY,
+                                  &(psOptions->dfMinX), &(psOptions->dfMinY),
+                                  &(psOptions->dfMaxX), &(psOptions->dfMaxY),
+                                  DENSIFY_PTS)))
                 {
-                    OGRCoordinateTransformation::DestroyCT(poCT);
-
                     CPLError(CE_Failure, CPLE_AppDefined,
                              "-te_srs ignored since coordinate transformation "
                              "failed.");
                     return false;
                 }
-                delete poCT;
             }
         }
     }

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -4569,3 +4569,21 @@ def test_gdalwarp_lib_int_max_sized_raster(tmp_vsimem):
             transformerOptions=["SRC_METHOD=NO_GEOTRANSFORM"],
             height=2147483647,
         )
+
+
+###############################################################################
+# Check fix for https://github.com/OSGeo/gdal/issues/12583
+
+
+def test_gdalwarp_te_srs_check_extent():
+
+    out_ds = gdal.Warp(
+        "",
+        "../gdrivers/data/small_world.tif",
+        options="-te 0 -90 6 0 -te_srs EPSG:4326 -t_srs EPSG:32631 -f MEM",
+    )
+    assert out_ds.RasterXSize == 18
+    assert out_ds.RasterYSize == 273
+    assert out_ds.GetGeoTransform() == pytest.approx(
+        (166021, 37108, 0.0, 0.0, 0.0, -36622), abs=1000
+    )


### PR DESCRIPTION
Backport #12597
 **Authored by:** @rouault