### PR TITLE
/vsizip/ / /vsitar/: make it respect bSetError / VSI_STAT_SET_ERROR_FLAG flag, in particular when used with /vsicurl/

### DIFF
--- a/port/cpl_vsi_virtual.h
+++ b/port/cpl_vsi_virtual.h
@@ -504,7 +504,7 @@ class VSIArchiveFilesystemHandler : public VSIFilesystemHandler
                         VSIArchiveReader *poReader = nullptr);
     virtual char *SplitFilename(const char *pszFilename,
                                 CPLString &osFileInArchive,
-                                int bCheckMainFileExists);
+                                bool bCheckMainFileExists, bool bSetError);
     virtual VSIArchiveReader *OpenArchiveFile(const char *archiveFilename,
                                               const char *fileInArchiveName);
     virtual int FindFileInArchive(const char *archiveFilename,

--- a/port/cpl_vsil_libarchive.cpp
+++ b/port/cpl_vsil_libarchive.cpp
@@ -529,7 +529,8 @@ class VSILibArchiveFilesystemHandler final : public VSIArchiveFilesystemHandler
 
 VSIVirtualHandle *VSILibArchiveFilesystemHandler::Open(const char *pszFilename,
                                                        const char *pszAccess,
-                                                       bool, CSLConstList)
+                                                       bool bSetError,
+                                                       CSLConstList)
 {
     if (strchr(pszAccess, 'w') != nullptr || strchr(pszAccess, '+') != nullptr)
     {
@@ -540,7 +541,7 @@ VSIVirtualHandle *VSILibArchiveFilesystemHandler::Open(const char *pszFilename,
 
     CPLString osFileInArchive;
     char *pszArchiveFileName =
-        SplitFilename(pszFilename, osFileInArchive, TRUE);
+        SplitFilename(pszFilename, osFileInArchive, true, bSetError);
     if (pszArchiveFileName == nullptr)
         return nullptr;
 

--- a/port/cpl_vsil_tar.cpp
+++ b/port/cpl_vsil_tar.cpp
@@ -555,7 +555,7 @@ VSITarFilesystemHandler::CreateReader(const char *pszTarFileName)
 
 VSIVirtualHandle *VSITarFilesystemHandler::Open(const char *pszFilename,
                                                 const char *pszAccess,
-                                                bool /* bSetError */,
+                                                bool bSetError,
                                                 CSLConstList /* papszOptions */)
 {
 
@@ -567,7 +567,8 @@ VSIVirtualHandle *VSITarFilesystemHandler::Open(const char *pszFilename,
     }
 
     CPLString osTarInFileName;
-    char *tarFilename = SplitFilename(pszFilename, osTarInFileName, TRUE);
+    char *tarFilename =
+        SplitFilename(pszFilename, osTarInFileName, true, bSetError);
     if (tarFilename == nullptr)
         return nullptr;
 


### PR DESCRIPTION
Fixes #12572
