### PR TITLE
SHPCreateLL()/DBFCreate(): make error message contains full filename …

### DIFF
--- a/ogr/ogrsf_frmts/shape/dbfopen.c
+++ b/ogr/ogrsf_frmts/shape/dbfopen.c
@@ -14,6 +14,7 @@
 #include "shapefil_private.h"
 
 #include <assert.h>
+#include <errno.h>
 #include <math.h>
 #include <stdbool.h>
 #include <stdio.h>
@@ -687,6 +688,16 @@ DBFHandle SHPAPI_CALL DBFCreateLL(const char *pszFilename,
     SAFile fp = psHooks->FOpen(pszFullname, "wb+", psHooks->pvUserData);
     if (fp == SHPLIB_NULLPTR)
     {
+        const size_t nMessageLen = strlen(pszFullname) + 256;
+        char *pszMessage = STATIC_CAST(char *, malloc(nMessageLen));
+        if (pszMessage)
+        {
+            snprintf(pszMessage, nMessageLen, "Failed to create file %s: %s",
+                     pszFullname, strerror(errno));
+            psHooks->Error(pszMessage);
+            free(pszMessage);
+        }
+
         free(pszFullname);
         return SHPLIB_NULLPTR;
     }

--- a/ogr/ogrsf_frmts/shape/shpopen.c
+++ b/ogr/ogrsf_frmts/shape/shpopen.c
@@ -1028,11 +1028,15 @@ SHPHandle SHPAPI_CALL SHPCreateLL(const char *pszLayer, int nShapeType,
     SAFile fpSHP = psHooks->FOpen(pszFullname, "w+b", psHooks->pvUserData);
     if (fpSHP == SHPLIB_NULLPTR)
     {
-        char szErrorMsg[200];
-        snprintf(szErrorMsg, sizeof(szErrorMsg), "Failed to create file %s: %s",
-                 pszFullname, strerror(errno));
-        psHooks->Error(szErrorMsg);
-
+        const size_t nMessageLen = strlen(pszFullname) + 256;
+        char *pszMessage = STATIC_CAST(char *, malloc(nMessageLen));
+        if (pszMessage)
+        {
+            snprintf(pszMessage, nMessageLen, "Failed to create file %s: %s",
+                     pszFullname, strerror(errno));
+            psHooks->Error(pszMessage);
+            free(pszMessage);
+        }
         free(pszFullname);
         free(psSHP);
         return SHPLIB_NULLPTR;
@@ -1042,10 +1046,15 @@ SHPHandle SHPAPI_CALL SHPCreateLL(const char *pszLayer, int nShapeType,
     SAFile fpSHX = psHooks->FOpen(pszFullname, "w+b", psHooks->pvUserData);
     if (fpSHX == SHPLIB_NULLPTR)
     {
-        char szErrorMsg[200];
-        snprintf(szErrorMsg, sizeof(szErrorMsg), "Failed to create file %s: %s",
-                 pszFullname, strerror(errno));
-        psHooks->Error(szErrorMsg);
+        const size_t nMessageLen = strlen(pszFullname) + 256;
+        char *pszMessage = STATIC_CAST(char *, malloc(nMessageLen));
+        if (pszMessage)
+        {
+            snprintf(pszMessage, nMessageLen, "Failed to create file %s: %s",
+                     pszFullname, strerror(errno));
+            psHooks->Error(pszMessage);
+            free(pszMessage);
+        }
 
         free(pszFullname);
         psHooks->FClose(fpSHP);


### PR DESCRIPTION
…(in case it is very long)
