### PR TITLE
DXF: Fix links to external resources in docs

### DIFF
--- a/doc/source/drivers/vector/dxf.rst
+++ b/doc/source/drivers/vector/dxf.rst
@@ -418,7 +418,7 @@ The driver supports the following dataset creation options:
       :since: 3.11
 
       Drawing units for the model space
-      (`$INSUNITS <https://knowledge.autodesk.com/support/autocad/learn-explore/caas/CloudHelp/cloudhelp/2018/ENU/AutoCAD-Core/files/GUID-A58A87BB-482B-4042-A00A-EEF55A2B4FD8-htm.html>`__ system variable).
+      (`$INSUNITS <https://help.autodesk.com/view/ACD/2018/ENU/?guid=GUID-A58A87BB-482B-4042-A00A-EEF55A2B4FD8>`__ system variable).
       The default ``AUTO`` mode first check if the written layer has a projected
       CRS, and if so uses is linear units to determine the value of ``$INSUNITS``.
       Otherwise it fallbacks to the value of the header template (``HEADER_VALUE`` mode),
@@ -430,7 +430,7 @@ The driver supports the following dataset creation options:
       :since: 3.11
 
       Whether the current drawing uses imperial or metric hatch pattern and linetype
-      (`$MEASUREMENT <https://knowledge.autodesk.com/support/autocad/learn-explore/caas/CloudHelp/cloudhelp/2018/ENU/AutoCAD-Core/files/GUID-1D074C55-0B63-482E-8A37-A52AC0C7C8FE-htm.html>`__ system variable).
+      (`$MEASUREMENT <https://help.autodesk.com/view/ACD/2018/ENU/?guid=GUID-1D074C55-0B63-482E-8A37-A52AC0C7C8FE>`__ system variable).
       Defaults to the value of the header template, which is ``IMPERIAL``.
 
 
@@ -512,7 +512,7 @@ See also
 List of known issues :source_file:`ogr/ogrsf_frmts/dxf/KNOWN_ISSUES.md`
 
 `AutoCAD 2000 DXF
-Reference <http://www.autodesk.com/techpubs/autocad/acad2000/dxf/>`__
+Reference <https://web.archive.org/web/20150923180435/http://www.autodesk.com/techpubs/autocad/acad2000/dxf/>`__
 
 `AutoCAD 2014 DXF
 Reference <http://images.autodesk.com/adsk/files/autocad_2014_pdf_dxf_reference_enu.pdf>`__


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

Fixes links to external web pages about $INSUNITS, $MEASUREMENT and AutoCAD 2000 DXF Reference in https://gdal.org/en/latest/drivers/vector/dxf.html

## What are related issues/pull requests?

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS:
* Compiler: