### PR TITLE
WIP: VRT expressions / gdal raster calc: Handle NoData

### DIFF
--- a/apps/gdalalg_raster_calc.cpp
+++ b/apps/gdalalg_raster_calc.cpp
@@ -503,8 +503,10 @@ CreateDerivedBandXML(CPLXMLNode *root, int nXOut, int nYOut,
                 {
                     CPLXMLNode *srcNoDataNode =
                         CPLCreateXMLNode(source, CXT_Element, "NODATA");
+                    std::string srcNoDataText =
+                        CPLSPrintf("%.17g", srcNoData.value());
                     CPLCreateXMLNode(srcNoDataNode, CXT_Text,
-                                     std::to_string(srcNoData.value()).c_str());
+                                     srcNoDataText.c_str());
 
                     if (autoSelectNoDataValue && !dstNoData.has_value())
                     {
@@ -547,8 +549,9 @@ CreateDerivedBandXML(CPLXMLNode *root, int nXOut, int nYOut,
 
                 CPLXMLNode *noDataNode =
                     CPLCreateXMLNode(band, CXT_Element, "NoDataValue");
-                CPLCreateXMLNode(noDataNode, CXT_Text,
-                                 std::to_string(dstNoData.value()).c_str());
+                CPLString dstNoDataText =
+                    CPLSPrintf("%.17g", dstNoData.value());
+                CPLCreateXMLNode(noDataNode, CXT_Text, dstNoDataText.c_str());
             }
         }
 

--- a/apps/gdalalg_raster_calc.cpp
+++ b/apps/gdalalg_raster_calc.cpp
@@ -105,7 +105,7 @@ static bool PosIsFunctionArgument(const std::string &expression, size_t pos)
     // scan backwards for a ( and find only variable names, literals or commas.
     while (pos != 0)
     {
-        char c = expression[pos];
+        const char c = expression[pos];
         if (c == '(')
         {
             pos--;
@@ -123,7 +123,7 @@ static bool PosIsFunctionArgument(const std::string &expression, size_t pos)
     // value function name
     while (pos != 0)
     {
-        char c = expression[pos];
+        const char c = expression[pos];
         if (isalnum(c) || c == '_')
         {
             return true;
@@ -187,6 +187,7 @@ struct SourceProperties
     std::array<double, 6> gt{};
     std::unique_ptr<OGRSpatialReference, OGRSpatialReferenceReleaser> srs{
         nullptr};
+    std::vector<std::optional<double>> noData{};
     GDALDataType eDT{GDT_Unknown};
 };
 
@@ -213,6 +214,7 @@ UpdateSourceProperties(SourceProperties &out, const std::string &dsn,
         source.nBands = ds->GetRasterCount();
         source.nX = ds->GetRasterXSize();
         source.nY = ds->GetRasterYSize();
+        source.noData.resize(source.nBands);
 
         if (options.checkExtent)
         {
@@ -226,17 +228,27 @@ UpdateSourceProperties(SourceProperties &out, const std::string &dsn,
         }
 
         // Store the source data type if it is the same for all bands in the source
-        for (int i = 0; i < source.nBands; ++i)
+        bool bandsHaveSameType = true;
+        for (int i = 1; i <= source.nBands; ++i)
         {
-            if (i == 0)
+            GDALRasterBand *band = ds->GetRasterBand(i);
+
+            if (i == 1)
             {
-                source.eDT = ds->GetRasterBand(1)->GetRasterDataType();
+                source.eDT = band->GetRasterDataType();
             }
-            else if (source.eDT !=
-                     ds->GetRasterBand(i + 1)->GetRasterDataType())
+            else if (bandsHaveSameType &&
+                     source.eDT != band->GetRasterDataType())
             {
                 source.eDT = GDT_Unknown;
-                break;
+                bandsHaveSameType = false;
+            }
+
+            int success;
+            double noData = band->GetNoDataValue(&success);
+            if (success)
+            {
+                source.noData[i - 1] = noData;
             }
         }
     }
@@ -335,6 +347,7 @@ UpdateSourceProperties(SourceProperties &out, const std::string &dsn,
  * @param dialect Expression dialect
  * @param flatten Generate a single band output raster per expression, even if
  *                input datasets are multiband.
+ * @param noData nodata value to use for the created band
  * @param pixelFunctionArguments Pixel function arguments.
  * @param sources Mapping of source names to DSNs
  * @param sourceProps Mapping of source names to properties
@@ -345,6 +358,7 @@ static bool
 CreateDerivedBandXML(CPLXMLNode *root, int nXOut, int nYOut,
                      GDALDataType bandType, const std::string &expression,
                      const std::string &dialect, bool flatten,
+                     std::optional<double> noData,
                      const std::vector<std::string> &pixelFunctionArguments,
                      const std::map<std::string, std::string> &sources,
                      const std::map<std::string, SourceProperties> &sourceProps,
@@ -371,6 +385,14 @@ CreateDerivedBandXML(CPLXMLNode *root, int nXOut, int nYOut,
         }
         CPLAddXMLAttributeAndValue(band, "dataType",
                                    pszDataType ? pszDataType : "Float64");
+
+        if (noData.has_value())
+        {
+            CPLXMLNode *noDataNode =
+                CPLCreateXMLNode(band, CXT_Element, "NoDataValue");
+            CPLCreateXMLNode(noDataNode, CXT_Text,
+                             std::to_string(noData.value()).c_str());
+        }
 
         for (const auto &[source_name, dsn] : sources)
         {
@@ -437,8 +459,12 @@ CreateDerivedBandXML(CPLXMLNode *root, int nXOut, int nYOut,
                     }
                 }
 
-                CPLXMLNode *source =
-                    CPLCreateXMLNode(band, CXT_Element, "SimpleSource");
+                const std::optional<double> &srcNoData =
+                    props.noData[nInBand - 1];
+
+                CPLXMLNode *source = CPLCreateXMLNode(
+                    band, CXT_Element,
+                    srcNoData.has_value() ? "ComplexSource" : "SimpleSource");
                 if (!inBandVariable.empty())
                 {
                     CPLAddXMLAttributeAndValue(source, "name",
@@ -463,6 +489,14 @@ CreateDerivedBandXML(CPLXMLNode *root, int nXOut, int nYOut,
                     CPLCreateXMLNode(source, CXT_Element, "SourceBand");
                 CPLCreateXMLNode(sourceBand, CXT_Text,
                                  std::to_string(nInBand).c_str());
+
+                if (srcNoData.has_value())
+                {
+                    CPLXMLNode *srcNoDataNode =
+                        CPLCreateXMLNode(source, CXT_Element, "NODATA");
+                    CPLCreateXMLNode(srcNoDataNode, CXT_Text,
+                                     std::to_string(srcNoData.value()).c_str());
+                }
 
                 if (fakeSourceFilename.empty())
                 {
@@ -489,31 +523,30 @@ CreateDerivedBandXML(CPLXMLNode *root, int nXOut, int nYOut,
 
         CPLXMLNode *pixelFunctionType =
             CPLCreateXMLNode(band, CXT_Element, "PixelFunctionType");
+        CPLXMLNode *arguments =
+            CPLCreateXMLNode(band, CXT_Element, "PixelFunctionArguments");
+
         if (dialect == "builtin")
         {
             CPLCreateXMLNode(pixelFunctionType, CXT_Text, expression.c_str());
-            if (!pixelFunctionArguments.empty())
-            {
-                CPLXMLNode *arguments = CPLCreateXMLNode(
-                    band, CXT_Element, "PixelFunctionArguments");
-                const CPLStringList args(pixelFunctionArguments);
-                for (const auto &[key, value] : cpl::IterateNameValue(args))
-                {
-                    CPLAddXMLAttributeAndValue(arguments, key, value);
-                }
-            }
         }
         else
         {
             CPLCreateXMLNode(pixelFunctionType, CXT_Text, "expression");
-            CPLXMLNode *arguments =
-                CPLCreateXMLNode(band, CXT_Element, "PixelFunctionArguments");
-
+            CPLAddXMLAttributeAndValue(arguments, "dialect", "muparser");
             // Add the expression as a last step, because we may modify the
             // expression as we iterate through the bands.
             CPLAddXMLAttributeAndValue(arguments, "expression",
                                        bandExpression.c_str());
-            CPLAddXMLAttributeAndValue(arguments, "dialect", "muparser");
+        }
+
+        if (!pixelFunctionArguments.empty())
+        {
+            const CPLStringList args(pixelFunctionArguments);
+            for (const auto &[key, value] : cpl::IterateNameValue(args))
+            {
+                CPLAddXMLAttributeAndValue(arguments, key, value);
+            }
         }
     }
 
@@ -647,6 +680,7 @@ static bool ReadFileLists(const std::vector<GDALArgDatasetValue> &inputDS,
  * @param dialect Expression dialect
  * @param flatten Generate a single band output raster per expression, even if
  *                input datasets are multiband.
+ * @param noData NoData values to use for output bands
  * @param pixelFunctionArguments Pixel function arguments.
  * @param options flags controlling which checks should be performed on the inputs
  * @param[out] maxSourceBands Maximum number of bands in source dataset(s)
@@ -657,7 +691,7 @@ static bool ReadFileLists(const std::vector<GDALArgDatasetValue> &inputDS,
 static std::unique_ptr<GDALDataset> GDALCalcCreateVRTDerived(
     const std::vector<std::string> &inputs,
     const std::vector<std::string> &expressions, const std::string &dialect,
-    bool flatten,
+    bool flatten, std::optional<double> noData,
     const std::vector<std::vector<std::string>> &pixelFunctionArguments,
     const GDALCalcOptions &options, int &maxSourceBands,
     const std::string &fakeSourceFilename = std::string())
@@ -751,7 +785,7 @@ static std::unique_ptr<GDALDataset> GDALCalcCreateVRTDerived(
         }
 
         if (!CreateDerivedBandXML(root.get(), out.nX, out.nY, bandType,
-                                  origExpression, dialect, flatten,
+                                  origExpression, dialect, flatten, noData,
                                   pixelFunctionArguments[iExpr], sources,
                                   sourceProps, fakeSourceFilename))
         {
@@ -802,9 +836,14 @@ GDALRasterCalcAlgorithm::GDALRasterCalcAlgorithm(bool standaloneStep) noexcept
 
     AddArg("no-check-srs", 0,
            _("Do not check consistency of input spatial reference systems"),
-           &m_NoCheckSRS);
+           &m_noCheckSRS);
     AddArg("no-check-extent", 0, _("Do not check consistency of input extents"),
-           &m_NoCheckExtent);
+           &m_noCheckExtent);
+
+    AddArg("propagate-nodata", 0,
+           _("Whether to set pixels to the output NoData value if any of the "
+             "input pixels is NoData"),
+           &m_propagateNoData);
 
     AddArg("calc", 0, _("Expression(s) to evaluate"), &m_expr)
         .SetRequired()
@@ -830,6 +869,9 @@ GDALRasterCalcAlgorithm::GDALRasterCalcAlgorithm(bool standaloneStep) noexcept
            _("Generate a single band output raster per expression, even if "
              "input datasets are multiband"),
            &m_flatten);
+
+    AddNodataArg(&m_nodata, true)
+        .SetDefault("none");
 
     // This is a hidden option only used by test_gdalalg_raster_calc_expression_rewriting()
     // for now
@@ -869,8 +911,8 @@ bool GDALRasterCalcAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
     CPLAssert(!m_outputDataset.GetDatasetRef());
 
     GDALCalcOptions options;
-    options.checkExtent = !m_NoCheckExtent;
-    options.checkSRS = !m_NoCheckSRS;
+    options.checkExtent = !m_noCheckExtent;
+    options.checkSRS = !m_noCheckSRS;
     if (!m_type.empty())
     {
         options.dstType = GDALGetDataTypeByName(m_type.c_str());
@@ -965,9 +1007,31 @@ bool GDALRasterCalcAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
         pixelFunctionArgs.resize(m_expr.size());
     }
 
+    if (m_propagateNoData)
+    {
+        if (m_nodata == "none")
+        {
+            ReportError(CE_Failure, CPLE_AppDefined,
+                        "Output NoData value must be specified to use "
+                        "--propagate-nodata");
+            return false;
+        }
+        for (auto &args : pixelFunctionArgs)
+        {
+            args.push_back("propagateNoData=1");
+        }
+    }
+
+    // FIXME harden nodata parsing
+    std::optional<double> noData;
+    if (m_nodata != "none")
+    {
+        noData = CPLAtof(m_nodata.c_str());
+    }
+
     int maxSourceBands = 0;
     auto vrt =
-        GDALCalcCreateVRTDerived(inputFilenames, m_expr, m_dialect, m_flatten,
+        GDALCalcCreateVRTDerived(inputFilenames, m_expr, m_dialect, m_flatten, noData,
                                  pixelFunctionArgs, options, maxSourceBands);
     if (vrt == nullptr)
     {
@@ -1006,7 +1070,7 @@ bool GDALRasterCalcAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
             if (!osTmpFilename.empty())
             {
                 auto fakeVRT = GDALCalcCreateVRTDerived(
-                    inputFilenames, m_expr, m_dialect, m_flatten,
+                    inputFilenames, m_expr, m_dialect, m_flatten, noData,
                     pixelFunctionArgs, options, maxSourceBands, osTmpFilename);
                 if (fakeVRT &&
                     fakeVRT->RasterIO(GF_Read, 0, 0, 1, 1, dummyData.data(), 1,

--- a/apps/gdalalg_raster_calc.h
+++ b/apps/gdalalg_raster_calc.h
@@ -43,9 +43,11 @@ class GDALRasterCalcAlgorithm : public GDALRasterPipelineStepAlgorithm
     std::string m_dialect{"muparser"};
     bool m_flatten{false};
     std::string m_type{};
-    bool m_NoCheckSRS{false};
-    bool m_NoCheckExtent{false};
+    std::string m_nodata{};
+    bool m_noCheckSRS{false};
+    bool m_noCheckExtent{false};
     bool m_noCheckExpression{false};
+    bool m_propagateNoData{false};
 };
 
 /************************************************************************/

--- a/autotest/gdrivers/vrtderived.py
+++ b/autotest/gdrivers/vrtderived.py
@@ -1189,6 +1189,13 @@ def vrt_expression_xml(tmpdir, expression, dialect, sources):
             id="muparser nan comparison is false in conditional",
         ),
         pytest.param(
+            "isnan(B3) ? B1 : B2",
+            (5, 9, float("nan")),
+            5,
+            ["muparser"],
+            id="muparser isnan",
+        ),
+        pytest.param(
             "if (B1 > 5) B1",
             (1,),
             float("nan"),

--- a/autotest/utilities/test_gdalalg_raster_calc.py
+++ b/autotest/utilities/test_gdalalg_raster_calc.py
@@ -187,6 +187,24 @@ def test_gdalalg_raster_calc_output_type(calc, tmp_vsimem):
     assert calc.Finalize()
 
 
+def test_gdalalg_raster_calc_invalid_nodata_for_output_type(calc, tmp_vsimem):
+
+    with gdal.GetDriverByName("GTiff").Create(
+        tmp_vsimem / "src.tif", 1, 1, eType=gdal.GDT_Int16
+    ) as ds:
+        ds.GetRasterBand(1).SetNoDataValue(-9)
+        ds.GetRasterBand(1).Fill(-9)
+
+    calc["input"] = tmp_vsimem / "src.tif"
+    calc["output-format"] = "stream"
+    calc["calc"] = "X"
+    calc["output-data-type"] = "Byte"
+    calc["nodata"] = -9
+
+    with pytest.raises(Exception, match="Byte cannot represent NoData value -9"):
+        calc.Run()
+
+
 def test_gdalalg_raster_calc_overwrite(calc, tmp_vsimem):
 
     infile = "../gcore/data/byte.tif"

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1217,11 +1217,22 @@ GDAL provides a set of default pixel functions that can be used without writing 
      - ``expression``
 
        ``dialect`` (optional)
+
+       ``propagateNoData`` (GDAL >= 3.12, optional, default=false)
+
      - Evaluate a specified expression using `muparser <https://beltoforion.de/en/muparser/>`__ (default)
        or `ExprTk <https://www.partow.net/programming/exprtk/index.html>`__.
 
        The expression is specified using the "expression" argument.
        The dialect may be specified using the "dialect" argument.
+
+       If the optional ``propagateNoData`` parameter is set to ``true``, then
+
+       if a NoData pixel is found in one of the bands, if will be propagated to
+
+       the output value. Otherwise, NoData pixels will be converted to NaN before
+
+       evaluating the expression.
 
        Within the expression, band values can be accessed:
 

--- a/doc/source/drivers/raster/vrt.rst
+++ b/doc/source/drivers/raster/vrt.rst
@@ -1246,7 +1246,10 @@ GDAL provides a set of default pixel functions that can be used without writing 
          With muparser, it is expanded into a list of all input bands.
 
        Starting with GDAL 3.12, the variables ``_CENTER_X_`` and ``_CENTER_Y_`` can be
-       included in the expression to access cell center coordinates.
+
+       included in the expression to access cell center coordinates. The variable ``NODATA``
+
+       can be included in the expression if the derived band has a NoData value.
 
        ExprTk and muparser support a number of built-in functions and control structures.
 

--- a/doc/source/programs/gdal_raster_calc.rst
+++ b/doc/source/programs/gdal_raster_calc.rst
@@ -109,6 +109,16 @@ The following options are available:
     Do not check the spatial reference systems of the inputs for consistency. All inputs will be assumed to have the
     spatial reference system of the first input, and this spatial reference system will be used for the output.
 
+.. option:: --nodata
+
+    Set the NoData value for the output dataset. May be set to "none" to leave the NoData value undefined. If 
+    :option:`--nodata` is not specified, :program:`gdal raster calc` will use a NoData value from the first
+    source dataset to have one.
+
+.. option:: --propagate-nodata
+
+    If set, a NoData value in any input dataset used an in expression will cause the output value to be NoData.
+
 .. GDALG output (on-the-fly / streamed dataset)
 .. --------------------------------------------
 

--- a/frmts/vrt/pixelfunctions.cpp
+++ b/frmts/vrt/pixelfunctions.cpp
@@ -2744,6 +2744,10 @@ static CPLErr MaxPixelFunc(void **papoSources, int nSources, void *pData,
 
 static const char pszExprPixelFuncMetadata[] =
     "<PixelFunctionArgumentsList>"
+    "   <Argument type='builtin' value='NoData' optional='true' />"
+    "   <Argument name='propagateNoData' description='Whether the output value "
+    "should be NoData as as soon as one source is NoData' type='boolean' "
+    "default='false' />"
     "   <Argument name='expression' "
     "             description='Expression to be evaluated' "
     "             type='string'></Argument>"
@@ -2773,6 +2777,14 @@ static CPLErr ExprPixelFunc(void **papoSources, int nSources, void *pData,
                  "expression cannot by applied to complex data types");
         return CE_Failure;
     }
+
+    double dfNoData{0};
+    const bool bHasNoData = CSLFindName(papszArgs, "NoData") != -1;
+    if (bHasNoData && FetchDoubleArg(papszArgs, "NoData", &dfNoData) != CE_None)
+        return CE_Failure;
+
+    const bool bPropagateNoData = CPLTestBool(
+        CSLFetchNameValueDef(papszArgs, "propagateNoData", "false"));
 
     std::unique_ptr<gdal::MathExpression> poExpression;
 
@@ -2879,11 +2891,25 @@ static CPLErr ExprPixelFunc(void **papoSources, int nSources, void *pData,
     {
         for (int iCol = 0; iCol < nXSize; ++iCol, ++ii)
         {
+            bool resultIsNoData = false;
+
             for (int iSrc = 0; iSrc < nSources; iSrc++)
             {
                 // cppcheck-suppress unreadVariable
-                adfValuesForPixel[iSrc] =
-                    GetSrcVal(papoSources[iSrc], eSrcType, ii);
+                double dfVal = GetSrcVal(papoSources[iSrc], eSrcType, ii);
+
+                if (bHasNoData && IsNoData(dfVal, dfNoData))
+                {
+                    if (bPropagateNoData)
+                    {
+                        resultIsNoData = true;
+                        break;
+                    }
+
+                    dfVal = std::numeric_limits<double>::quiet_NaN();
+                }
+
+                adfValuesForPixel[iSrc] = dfVal;
             }
 
             if (includeCenterCoords)
@@ -2895,12 +2921,17 @@ static CPLErr ExprPixelFunc(void **papoSources, int nSources, void *pData,
                                       &dfCenterX, &dfCenterY);
             }
 
-            if (auto eErr = poExpression->Evaluate(); eErr != CE_None)
+            if (resultIsNoData)
             {
-                return CE_Failure;
+                padfResults.get()[iCol] = dfNoData;
             }
             else
             {
+                if (auto eErr = poExpression->Evaluate(); eErr != CE_None)
+                {
+                    return CE_Failure;
+                }
+
                 padfResults.get()[iCol] = poExpression->Results()[0];
             }
         }

--- a/frmts/vrt/pixelfunctions.cpp
+++ b/frmts/vrt/pixelfunctions.cpp
@@ -2770,7 +2770,6 @@ static CPLErr ExprPixelFunc(void **papoSources, int nSources, void *pData,
                             int nLineSpace, CSLConstList papszArgs)
 {
     /* ---- Init ---- */
-
     if (GDALDataTypeIsComplex(eSrcType))
     {
         CPLError(CE_Failure, CPLE_AppDefined,
@@ -2785,8 +2784,6 @@ static CPLErr ExprPixelFunc(void **papoSources, int nSources, void *pData,
 
     const bool bPropagateNoData = CPLTestBool(
         CSLFetchNameValueDef(papszArgs, "propagateNoData", "false"));
-
-    std::unique_ptr<gdal::MathExpression> poExpression;
 
     const char *pszExpression = CSLFetchNameValue(papszArgs, "expression");
 
@@ -2811,7 +2808,7 @@ static CPLErr ExprPixelFunc(void **papoSources, int nSources, void *pData,
         pszDialect = "muparser";
     }
 
-    poExpression = gdal::MathExpression::Create(pszExpression, pszDialect);
+    auto poExpression = gdal::MathExpression::Create(pszExpression, pszDialect);
 
     // cppcheck-suppress knownConditionTrueFalse
     if (!poExpression)
@@ -2891,6 +2888,7 @@ static CPLErr ExprPixelFunc(void **papoSources, int nSources, void *pData,
     {
         for (int iCol = 0; iCol < nXSize; ++iCol, ++ii)
         {
+            double &dfResult = padfResults.get()[iCol];
             bool resultIsNoData = false;
 
             for (int iSrc = 0; iSrc < nSources; iSrc++)
@@ -2923,7 +2921,7 @@ static CPLErr ExprPixelFunc(void **papoSources, int nSources, void *pData,
 
             if (resultIsNoData)
             {
-                padfResults.get()[iCol] = dfNoData;
+                dfResult = dfNoData;
             }
             else
             {
@@ -2932,7 +2930,12 @@ static CPLErr ExprPixelFunc(void **papoSources, int nSources, void *pData,
                     return CE_Failure;
                 }
 
-                padfResults.get()[iCol] = poExpression->Results()[0];
+                dfResult = poExpression->Results()[0];
+
+                if (std::isnan(dfResult) && GDALDataTypeIsInteger(eBufType))
+                {
+                    dfResult = dfNoData;
+                }
             }
         }
 

--- a/frmts/vrt/pixelfunctions.cpp
+++ b/frmts/vrt/pixelfunctions.cpp
@@ -2872,6 +2872,11 @@ static CPLErr ExprPixelFunc(void **papoSources, int nSources, void *pData,
         poExpression->RegisterVariable("_CENTER_Y_", &dfCenterY);
     }
 
+    if (bHasNoData)
+    {
+        poExpression->RegisterVariable("NODATA", &dfNoData);
+    }
+
     if (strstr(pszExpression, "BANDS"))
     {
         poExpression->RegisterVector("BANDS", &adfValuesForPixel);

--- a/frmts/vrt/vrtexpression_muparser.cpp
+++ b/frmts/vrt/vrtexpression_muparser.cpp
@@ -13,6 +13,7 @@
 #include "vrtexpression.h"
 #include "cpl_string.h"
 
+#include <cmath>
 #include <limits>
 #include <map>
 #include <optional>
@@ -22,6 +23,11 @@ namespace gdal
 {
 
 /*! @cond Doxygen_Suppress */
+
+static mu::value_type isnan(mu::value_type x)
+{
+    return std::isnan(x);
+}
 
 static std::optional<std::string> Sanitize(const std::string &osVariable)
 {
@@ -109,6 +115,8 @@ class MuParserExpression::Impl
 
         try
         {
+            m_oParser.DefineFun(_T("isnan"), isnan);
+
             std::string tmpExpression(m_osExpression);
 
             for (const auto &[osFrom, osTo] : m_oSubstitutions)


### PR DESCRIPTION
This PR updates the "expression" pixel function to read the `NoData` and `propagateNoData` pixel function arguments. It's not totally obvious what to do when `propagateNoData` is false. Unlike a built-in function, I can't just avoid passing a NoData pixel to `X + 3`. So I instead pass `NaN`, on the theory that if we don't want to propagate NoData values, then the expression should be expected to handle them itself (with an expression like `isnan(X) : NODATA : X + 3`). This is a breaking change. If the expression returns NaN, it will be changed to the NoData value for integer types. 

It also updates `gdal raster calc` to check sources for NoData values, bringing them as a `ComplexSource` if this is the case. The first source with a NoData value is used to set the NoData value of the raster band, unless `gdal raster calc` is called with `--nodata`.

Unresolved:

- I also added a `--propagate-nodata` to `gdal raster calc` and sets the `propagateNoData` pixel function argument, regardless of dialect. I'm not totally sure this argument is needed.

- Should all NaN results be converted to NoData ?