### PR TITLE
gdal raster overview add: add a --overview-src option

### DIFF
--- a/apps/gdalalg_raster_overview_add.h
+++ b/apps/gdalalg_raster_overview_add.h
@@ -35,6 +35,7 @@ class GDALRasterOverviewAlgorithmAdd final : public GDALAlgorithm
     bool RunImpl(GDALProgressFunc, void *) override;
 
     GDALArgDatasetValue m_dataset{};
+    std::vector<GDALArgDatasetValue> m_overviewSources{};
     std::vector<std::string> m_openOptions{};
     std::vector<std::string> m_inputFormats{};
     std::string m_resampling{};

--- a/doc/source/programs/gdal_raster_overview_add.rst
+++ b/doc/source/programs/gdal_raster_overview_add.rst
@@ -31,6 +31,20 @@ most supported file formats with one of several downsampling algorithms.
 
     Create external ``.ovr`` overviews as GeoTIFF files.
 
+.. option::  --overview-src <INPUT>
+
+    .. versionadded:: 3.12
+
+    Add specified input raster datasets as overviews of the target dataset.
+    Source overviews may come from any GDAL supported format, provided they
+    have the same number of bands and geospatial extent than the target
+    dataset.
+
+    That mode is currently only implemented when the target dataset is in
+    GeoTIFF format, or when using :option:`--external`.
+
+    Mutually exclusive with :option:`--levels`
+
 .. option:: --resampling {nearest|average|cubic|cubicspline|lanczos|bilinear|gauss|average_magphase|rms|mode}
 
     Select a resampling algorithm. The default is ``nearest``, which is generally not
@@ -78,6 +92,8 @@ most supported file formats with one of several downsampling algorithms.
     - Otherwise, appropriate overview power-of-two factors will be selected
       until the smallest overview is smaller than the value of the
       :option:`--min-size` switch.
+
+    Mutually exclusive with :option:`--overview-src`
 
 .. option:: --min-size <val>
 
@@ -128,3 +144,10 @@ Examples
    .. code-block:: bash
 
        gdal raster overview add GPKG:file.gpkg:layer
+
+.. example::
+   :title: Add 3 existing datasets at scale 1:25K, 1:50K and 1:100K as overviews of :file:`my.tif`.
+
+   .. code-block:: bash
+
+       gdal raster overview add --overview-src ovr_25k.tif --overview-src ovr_50k.tif --overview-src ovr_100k.tif --dataset my.tif

--- a/frmts/gtiff/gt_overview.cpp
+++ b/frmts/gtiff/gt_overview.cpp
@@ -947,6 +947,11 @@ CPLErr GTIFFBuildOverviewsEx(const char *pszFilename, int nBands,
         return CE_Failure;
     fpL = nullptr;
 
+    if (EQUAL(pszResampling, "NONE"))
+    {
+        return CE_None;
+    }
+
     /* -------------------------------------------------------------------- */
     /*      Open the overview dataset so that we can get at the overview    */
     /*      bands.                                                          */

--- a/frmts/gtiff/gt_overview.h
+++ b/frmts/gtiff/gt_overview.h
@@ -39,12 +39,4 @@ void GTIFFBuildOverviewMetadata(const char *pszResampling,
                                 GDALDataset *poBaseDS, bool bIsForMaskBand,
                                 CPLString &osMetadata);
 
-CPLErr GTIFFBuildOverviewsEx(const char *pszFilename, int nBands,
-                             GDALRasterBand *const *papoBandList,
-                             int nOverviews, const int *panOverviewList,
-                             const std::pair<int, int> *pasOverviewSize,
-                             const char *pszResampling,
-                             const char *const *papszOptions,
-                             GDALProgressFunc pfnProgress, void *pProgressData);
-
 #endif

--- a/frmts/gtiff/gtiffdataset.h
+++ b/frmts/gtiff/gtiffdataset.h
@@ -498,6 +498,11 @@ class GTiffDataset final : public GDALPamDataset
                                    const int *, GDALProgressFunc, void *,
                                    CSLConstList papszOptions) override;
 
+    virtual CPLErr AddOverviews(const std::vector<GDALDataset *> &apoSrcOvrDS,
+                                GDALProgressFunc pfnProgress,
+                                void *pProgressData,
+                                CSLConstList papszOptions) override;
+
     bool ComputeBlocksPerColRowAndBand(int l_nBands);
 
     CPLErr OpenOffset(TIFF *, toff_t nDirOffset, GDALAccess,

--- a/frmts/mrf/marfa.h
+++ b/frmts/mrf/marfa.h
@@ -488,6 +488,8 @@ class MRFDataset final : public GDALPamDataset
     bool IsSingleTile();
 
     // Add uniform scale overlays, returns the new size of the index file
+    using GDALDataset::AddOverviews;
+
     GIntBig AddOverviews(int scale);
 
     // Late allocation buffer

--- a/gcore/gdal_priv.h
+++ b/gcore/gdal_priv.h
@@ -67,6 +67,7 @@ class GDALAlgorithm;
 #include <span>
 #endif
 #include <type_traits>
+#include <utility>
 #include <vector>
 
 #include "ogr_core.h"
@@ -290,6 +291,15 @@ class CPL_DLL GDALDefaultOverviews
                               GDALProgressFunc pfnProgress, void *pProgressData,
                               CSLConstList papszOptions);
 
+    static bool CheckSrcOverviewsConsistencyWithBase(
+        GDALDataset *poFullResDS,
+        const std::vector<GDALDataset *> &apoSrcOvrDS);
+
+    CPLErr AddOverviews(const char *pszBasename,
+                        const std::vector<GDALDataset *> &apoSrcOvrDS,
+                        GDALProgressFunc pfnProgress, void *pProgressData,
+                        CSLConstList papszOptions);
+
     CPLErr CleanOverviews();
 
     // Mask Related
@@ -308,6 +318,9 @@ class CPL_DLL GDALDefaultOverviews
 
   private:
     CPL_DISALLOW_COPY_ASSIGN(GDALDefaultOverviews)
+
+    CPLErr CreateOrOpenOverviewFile(const char *pszBasename,
+                                    CSLConstList papszOptions);
 };
 
 //! @endcond
@@ -1086,6 +1099,10 @@ class CPL_DLL GDALDataset : public GDALMajorObject
                           const int *panBandList, GDALProgressFunc pfnProgress,
                           void *pProgressData, CSLConstList papszOptions);
 #endif
+
+    virtual CPLErr AddOverviews(const std::vector<GDALDataset *> &apoSrcOvrDS,
+                                GDALProgressFunc pfnProgress,
+                                void *pProgressData, CSLConstList papszOptions);
 
 #ifndef DOXYGEN_XML
     void ReportError(CPLErr eErrClass, CPLErrorNum err_no, const char *fmt,
@@ -5191,6 +5208,15 @@ CPLErr CPL_DLL GTIFFBuildOverviews(const char *pszFilename, int nBands,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData,
                                    CSLConstList papszOptions);
+
+CPLErr CPL_DLL GTIFFBuildOverviewsEx(const char *pszFilename, int nBands,
+                                     GDALRasterBand *const *papoBandList,
+                                     int nOverviews, const int *panOverviewList,
+                                     const std::pair<int, int> *pasOverviewSize,
+                                     const char *pszResampling,
+                                     const char *const *papszOptions,
+                                     GDALProgressFunc pfnProgress,
+                                     void *pProgressData);
 
 int CPL_DLL GDALBandGetBestOverviewLevel(GDALRasterBand *poBand, int &nXOff,
                                          int &nYOff, int &nXSize, int &nYSize,

--- a/gcore/gdaldataset.cpp
+++ b/gcore/gdaldataset.cpp
@@ -2156,7 +2156,7 @@ CPLErr GDALSetGCPs2(GDALDatasetH hDS, int nGCPCount, const GDAL_GCP *pasGCPList,
 /**
  * \brief Build raster overview(s)
  *
- * If the operation is unsupported for the indicated dataset, then
+ * If the operation is not supported for the indicated dataset, then
  * CE_Failure is returned, and CPLGetLastErrorNo() will return
  * CPLE_NotSupported.
  *
@@ -2333,6 +2333,54 @@ CPLErr GDALDataset::IBuildOverviews(const char *pszResampling, int nOverviews,
 }
 
 //! @endcond
+
+/************************************************************************/
+/*                            AddOverviews()                            */
+/*                                                                      */
+/*      Default implementation.                                         */
+/************************************************************************/
+
+/**
+ * \brief Add overview from existing dataset(s)
+ *
+ * This function creates new overview levels or refresh existing one from
+ * the list of provided overview datasets.
+ * Source overviews may come from any GDAL supported format, provided they
+ * have the same number of bands and geospatial extent than the target
+ * dataset.
+ *
+ * If the operation is not supported for the indicated dataset, then
+ * CE_Failure is returned, and CPLGetLastErrorNo() will return
+ * CPLE_NotSupported.
+ *
+ * At time of writing, this method is only implemented for internal overviews
+ * of GeoTIFF datasets and external overviews in GeoTIFF format.
+ *
+ * @param apoSrcOvrDS Vector of source overviews.
+ * @param pfnProgress a function to call to report progress, or NULL.
+ * @param pProgressData application data to pass to the progress function.
+ * @param papszOptions NULL terminated list of options as
+ *                     key=value pairs, or NULL. None currently
+ *
+ * @return CE_None on success or CE_Failure if the operation doesn't work.
+ * @since 3.12
+ */
+CPLErr GDALDataset::AddOverviews(const std::vector<GDALDataset *> &apoSrcOvrDS,
+                                 GDALProgressFunc pfnProgress,
+                                 void *pProgressData, CSLConstList papszOptions)
+{
+    if (oOvManager.IsInitialized())
+    {
+        return oOvManager.AddOverviews(nullptr, apoSrcOvrDS, pfnProgress,
+                                       pProgressData, papszOptions);
+    }
+    else
+    {
+        ReportError(CE_Failure, CPLE_NotSupported,
+                    "AddOverviews() not supported for this dataset.");
+        return CE_Failure;
+    }
+}
 
 /************************************************************************/
 /*                             IRasterIO()                              */


### PR DESCRIPTION
to add specified input raster datasets as overviews of the target dataset.
Source overviews may come from any GDAL supported format, provided they
have the same number of bands and geospatial extent than the target
dataset.

That mode is currently only implemented when the target dataset is in
GeoTIFF format, or when using :option:`--external`.

.. example::
   :title: Add 3 existing datasets at scale 1:25K, 1:50K and 1:100K as overviews of :file:`my.tif`.

   .. code-block:: bash

       gdal raster overview add --overview-src ovr_25k.tif --overview-src ovr_50k.tif --overview-src ovr_100k.tif --dataset my.tif

Fixes #12614

