### PR TITLE
gdalinfo JSON output: return integer nodata value of integer bands as integer

### DIFF
--- a/apps/gdalinfo_lib.cpp
+++ b/apps/gdalinfo_lib.cpp
@@ -1485,8 +1485,12 @@ char *GDALInfo(GDALDatasetH hDataset, const GDALInfoOptions *psOptions)
                 if (bJson)
                 {
                     json_object *poNoDataValue =
-                        gdal_json_object_new_double_significant_digits(
-                            dfNoData, nSignificantDigits);
+                        (GDALDataTypeIsInteger(eDT) && dfNoData >= INT_MIN &&
+                         dfNoData <= INT_MAX &&
+                         static_cast<int>(dfNoData) == dfNoData)
+                            ? json_object_new_int(static_cast<int>(dfNoData))
+                            : gdal_json_object_new_double_significant_digits(
+                                  dfNoData, nSignificantDigits);
                     json_object *poStacNoDataValue = nullptr;
                     json_object_deep_copy(poNoDataValue, &poStacNoDataValue,
                                           nullptr);

--- a/autotest/utilities/test_gdalinfo_lib.py
+++ b/autotest/utilities/test_gdalinfo_lib.py
@@ -237,6 +237,18 @@ def test_gdalinfo_lib_nodata_full_precision_float64():
     assert ret["bands"][0]["noDataValue"] == float(nodata_str)
 
 
+def test_gdalinfo_lib_nodata_int():
+
+    ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    ds.GetRasterBand(1).SetNoDataValue(255)
+    assert "NoData Value=255\n" in gdal.Info(ds).replace("\r\n", "\n")
+
+    ret = gdal.Info(ds, format="json")
+    ndv = ret["bands"][0]["noDataValue"]
+    assert ndv == 255
+    assert isinstance(ndv, int)
+
+
 ###############################################################################
 # Test fix for https://github.com/OSGeo/gdal/issues/8137
 


### PR DESCRIPTION
Fixes https://lists.osgeo.org/pipermail/gdal-dev/2025-June/060665.html
