### PR TITLE
gdalinfo JSON output: attach 'rat' object to 'band', and add missing elements in gdalinfo_output.schema.json

### DIFF
--- a/apps/data/gdalinfo_output.schema.json
+++ b/apps/data/gdalinfo_output.schema.json
@@ -34,6 +34,9 @@
         "band": {
           "type": "integer"
         },
+        "description": {
+          "type": "string"
+        },
         "block": {
           "$ref": "#/definitions/arrayOfTwoIntegers"
         },
@@ -118,6 +121,31 @@
         },
         "metadata": {
           "$ref": "#/definitions/metadata"
+        },
+        "colorTable": {
+          "type": "object",
+          "properties": {
+            "entries": {
+              "type": "array",
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "integer",
+                  "minItems": 4,
+                  "maxItems": 4
+                }
+              }
+            },
+            "count": {
+              "type": "integer"
+            },
+            "palette": {
+              "type": "string"
+            }
+          }
+        },
+        "rat": {
+          "type": "object"
         }
       },
       "required": [

--- a/apps/gdalinfo_lib.cpp
+++ b/apps/gdalinfo_lib.cpp
@@ -1886,7 +1886,7 @@ char *GDALInfo(GDALDatasetH hDataset, const GDALInfoOptions *psOptions)
             {
                 json_object *poRAT =
                     static_cast<json_object *>(GDALRATSerializeJSON(hRAT));
-                json_object_object_add(poJsonObject, "rat", poRAT);
+                json_object_object_add(poBand, "rat", poRAT);
             }
             else
             {

--- a/autotest/gdrivers/rraster.py
+++ b/autotest/gdrivers/rraster.py
@@ -251,26 +251,26 @@ def test_rraster_rat(filename="data/rraster/byte_rraster_rat.grd"):
                 "colorInterpretation": "Undefined",
                 "metadata": {},
                 "type": "Byte",
+                "rat": {
+                    "fieldDefn": [
+                        {"index": 0, "name": "ID", "type": 0, "usage": 0},
+                        {"index": 1, "name": "int_field", "type": 0, "usage": 0},
+                        {"index": 2, "name": "numeric_field", "type": 1, "usage": 0},
+                        {"index": 3, "name": "string_field", "type": 2, "usage": 0},
+                        {"index": 4, "name": "red", "type": 0, "usage": 6},
+                        {"index": 5, "name": "green", "type": 0, "usage": 7},
+                        {"index": 6, "name": "blue", "type": 0, "usage": 8},
+                        {"index": 7, "name": "alpha", "type": 0, "usage": 9},
+                        {"index": 8, "name": "pixelcount", "type": 0, "usage": 1},
+                        {"index": 9, "name": "name", "type": 2, "usage": 2},
+                    ],
+                    "row": [
+                        {"f": [0, 10, 1.2, "foo", 0, 2, 4, 6, 8, "baz"], "index": 0},
+                        {"f": [1, 11, 2.3, "bar", 1, 3, 5, 7, 9, "baw"], "index": 1},
+                    ],
+                },
             }
-        ],
-        "rat": {
-            "fieldDefn": [
-                {"index": 0, "name": "ID", "type": 0, "usage": 0},
-                {"index": 1, "name": "int_field", "type": 0, "usage": 0},
-                {"index": 2, "name": "numeric_field", "type": 1, "usage": 0},
-                {"index": 3, "name": "string_field", "type": 2, "usage": 0},
-                {"index": 4, "name": "red", "type": 0, "usage": 6},
-                {"index": 5, "name": "green", "type": 0, "usage": 7},
-                {"index": 6, "name": "blue", "type": 0, "usage": 8},
-                {"index": 7, "name": "alpha", "type": 0, "usage": 9},
-                {"index": 8, "name": "pixelcount", "type": 0, "usage": 1},
-                {"index": 9, "name": "name", "type": 2, "usage": 2},
-            ],
-            "row": [
-                {"f": [0, 10, 1.2, "foo", 0, 2, 4, 6, 8, "baz"], "index": 0},
-                {"f": [1, 11, 2.3, "bar", 1, 3, 5, 7, 9, "baw"], "index": 1},
-            ],
-        },
+        ]
     }
     assert _is_dict_included_in_dict(info, expected_info)
 

--- a/autotest/utilities/test_gdalinfo.py
+++ b/autotest/utilities/test_gdalinfo.py
@@ -550,7 +550,7 @@ def test_gdalinfo_33(gdalinfo_path):
     ret = gdaltest.runexternal(gdalinfo_path + " -json ../gdrivers/data/hfa/int.img")
     ret = json.loads(ret)
     assert "overviews" in ret["bands"][0]
-    assert "rat" in ret
+    assert "rat" in ret["bands"][0]
 
 
 ###############################################################################

--- a/autotest/utilities/test_gdalinfo_lib.py
+++ b/autotest/utilities/test_gdalinfo_lib.py
@@ -335,3 +335,18 @@ def test_gdalinfo_lib_json_stac_common_name():
     ds.GetRasterBand(1).SetColorInterpretation(gdal.GCI_PanBand)
     ret = gdal.Info(ds, options="-json")
     assert ret["stac"]["eo:bands"][0]["common_name"] == "pan"
+
+
+###############################################################################
+
+
+@pytest.mark.require_driver("HFA")
+def test_gdalinfo_lib_json_color_table_and_rat():
+
+    ds = gdal.Open("../gcore/data/rat.img")
+
+    ret = gdal.Info(ds, format="json")
+    assert "colorTable" in ret["bands"][0]
+    assert "rat" in ret["bands"][0]
+
+    gdaltest.validate_json(ret, "gdalinfo_output.schema.json")


### PR DESCRIPTION
Fixes https://lists.osgeo.org/pipermail/gdal-dev/2025-June/060666.html
