### PR TITLE
Implement a minimal loading function for DuckDB

### DIFF
--- a/autotest/ogr/ogr_adbc.py
+++ b/autotest/ogr/ogr_adbc.py
@@ -24,13 +24,7 @@ def _has_adbc_driver_manager():
     return drv and drv.GetMetadataItem("HAS_ADBC_DRIVER_MANAGER")
 
 
-pytestmark = [
-    pytest.mark.require_driver("ADBC"),
-    pytest.mark.skipif(
-        not _has_adbc_driver_manager(),
-        reason="ADBC driver built without AdbcDriverManager",
-    ),
-]
+pytestmark = pytest.mark.require_driver("ADBC")
 
 ###############################################################################
 
@@ -47,6 +41,25 @@ def _has_sqlite_driver():
 ###############################################################################
 
 
+def _has_duckdb_driver():
+    import ctypes
+
+    for libname in ["libduckdb.so", "libduckdb.dylib", "duckdb.dll"]:
+        try:
+            if ctypes.cdll.LoadLibrary(libname):
+                return True
+        except Exception:
+            pass
+    return False
+
+
+###############################################################################
+
+
+@pytest.mark.skipif(
+    not _has_adbc_driver_manager(),
+    reason="ADBC driver built without AdbcDriverManager",
+)
 def test_ogr_adbc_driver_open_option():
 
     if not _has_sqlite_driver():
@@ -76,10 +89,11 @@ def test_ogr_adbc_invalid_driver():
 ###############################################################################
 
 
+@pytest.mark.skipif(
+    not _has_sqlite_driver(),
+    reason="adbc_driver_sqlite missing",
+)
 def test_ogr_adbc_invalid_dataset():
-
-    if not _has_sqlite_driver():
-        pytest.skip("adbc_driver_sqlite missing")
 
     with pytest.raises(Exception):
         gdal.OpenEx(
@@ -92,10 +106,15 @@ def test_ogr_adbc_invalid_dataset():
 ###############################################################################
 
 
+@pytest.mark.skipif(
+    not _has_adbc_driver_manager(),
+    reason="ADBC driver built without AdbcDriverManager",
+)
+@pytest.mark.skipif(
+    not _has_sqlite_driver(),
+    reason="adbc_driver_sqlite missing",
+)
 def test_ogr_adbc_sqlite3():
-
-    if not _has_sqlite_driver():
-        pytest.skip("adbc_driver_sqlite missing")
 
     with gdal.OpenEx(
         "data/sqlite/poly_spatialite.sqlite", gdal.OF_VECTOR, allowed_drivers=["ADBC"]
@@ -110,11 +129,16 @@ def test_ogr_adbc_sqlite3():
 ###############################################################################
 
 
+@pytest.mark.skipif(
+    not _has_adbc_driver_manager(),
+    reason="ADBC driver built without AdbcDriverManager",
+)
+@pytest.mark.skipif(
+    not _has_sqlite_driver(),
+    reason="adbc_driver_sqlite missing",
+)
 @pytest.mark.require_driver("GPKG")
 def test_ogr_adbc_create_empty_gpkg_and_open(tmp_path):
-
-    if not _has_sqlite_driver():
-        pytest.skip("adbc_driver_sqlite missing")
 
     filename = tmp_path / "out.gpkg"
     ogr.GetDriverByName("GPKG").CreateDataSource(filename)
@@ -131,10 +155,15 @@ def test_ogr_adbc_create_empty_gpkg_and_open(tmp_path):
 ###############################################################################
 
 
+@pytest.mark.skipif(
+    not _has_adbc_driver_manager(),
+    reason="ADBC driver built without AdbcDriverManager",
+)
+@pytest.mark.skipif(
+    not _has_sqlite_driver(),
+    reason="adbc_driver_sqlite missing",
+)
 def test_ogr_adbc_sql_open_option():
-
-    if not _has_sqlite_driver():
-        pytest.skip("adbc_driver_sqlite missing")
 
     with gdal.OpenEx(
         "ADBC:data/sqlite/poly_spatialite.sqlite",
@@ -149,10 +178,11 @@ def test_ogr_adbc_sql_open_option():
 ###############################################################################
 
 
+@pytest.mark.skipif(
+    not _has_sqlite_driver(),
+    reason="adbc_driver_sqlite missing",
+)
 def test_ogr_adbc_invalid_sql():
-
-    if not _has_sqlite_driver():
-        pytest.skip("adbc_driver_sqlite missing")
 
     with pytest.raises(Exception):
         gdal.OpenEx(
@@ -165,10 +195,15 @@ def test_ogr_adbc_invalid_sql():
 ###############################################################################
 
 
+@pytest.mark.skipif(
+    not _has_adbc_driver_manager(),
+    reason="ADBC driver built without AdbcDriverManager",
+)
+@pytest.mark.skipif(
+    not _has_sqlite_driver(),
+    reason="adbc_driver_sqlite missing",
+)
 def test_ogr_adbc_generic_open_option():
-
-    if not _has_sqlite_driver():
-        pytest.skip("adbc_driver_sqlite missing")
 
     with gdal.OpenEx(
         "ADBC:",
@@ -184,10 +219,15 @@ def test_ogr_adbc_generic_open_option():
 ###############################################################################
 
 
+@pytest.mark.skipif(
+    not _has_adbc_driver_manager(),
+    reason="ADBC driver built without AdbcDriverManager",
+)
+@pytest.mark.skipif(
+    not _has_sqlite_driver(),
+    reason="adbc_driver_sqlite missing",
+)
 def test_ogr_adbc_execute_sql():
-
-    if not _has_sqlite_driver():
-        pytest.skip("adbc_driver_sqlite missing")
 
     with gdal.OpenEx(
         "data/sqlite/poly_spatialite.sqlite",
@@ -203,22 +243,11 @@ def test_ogr_adbc_execute_sql():
 ###############################################################################
 
 
-def _has_libduckdb():
-    import ctypes
-
-    try:
-        return ctypes.cdll.LoadLibrary("libduckdb.so") is not None
-    except Exception:
-        return False
-
-
-###############################################################################
-
-
+@pytest.mark.skipif(
+    not _has_duckdb_driver(),
+    reason="duckdb driver missing",
+)
 def test_ogr_adbc_duckdb_parquet():
-
-    if not _has_libduckdb():
-        pytest.skip("libduckdb.so missing")
 
     with gdal.OpenEx(
         "data/parquet/partitioned_flat/part.0.parquet",
@@ -234,10 +263,11 @@ def test_ogr_adbc_duckdb_parquet():
 ###############################################################################
 
 
+@pytest.mark.skipif(
+    not _has_duckdb_driver(),
+    reason="duckdb driver missing",
+)
 def test_ogr_adbc_duckdb_parquet_with_sql_open_option():
-
-    if not _has_libduckdb():
-        pytest.skip("libduckdb.so missing")
 
     with gdal.OpenEx(
         "data/parquet/partitioned_flat/part.0.parquet",
@@ -254,11 +284,12 @@ def test_ogr_adbc_duckdb_parquet_with_sql_open_option():
 ###############################################################################
 
 
+@pytest.mark.skipif(
+    not _has_duckdb_driver(),
+    reason="duckdb driver missing",
+)
 @pytest.mark.parametrize("OGR_ADBC_AUTO_LOAD_DUCKDB_SPATIAL", ["ON", "OFF"])
 def test_ogr_adbc_duckdb_parquet_with_spatial(OGR_ADBC_AUTO_LOAD_DUCKDB_SPATIAL):
-
-    if not _has_libduckdb():
-        pytest.skip("libduckdb.so missing")
 
     with gdal.config_option(
         "OGR_ADBC_AUTO_LOAD_DUCKDB_SPATIAL", OGR_ADBC_AUTO_LOAD_DUCKDB_SPATIAL
@@ -329,13 +360,14 @@ def test_ogr_adbc_duckdb_parquet_with_spatial(OGR_ADBC_AUTO_LOAD_DUCKDB_SPATIAL)
 ###############################################################################
 
 
+@pytest.mark.skipif(
+    not _has_duckdb_driver(),
+    reason="duckdb driver missing",
+)
 @pytest.mark.parametrize("OGR_ADBC_AUTO_LOAD_DUCKDB_SPATIAL", ["ON", "OFF"])
 def test_ogr_adbc_duckdb_parquet_with_spatial_and_SQL_open_optoin(
     OGR_ADBC_AUTO_LOAD_DUCKDB_SPATIAL,
 ):
-
-    if not _has_libduckdb():
-        pytest.skip("libduckdb.so missing")
 
     with gdal.config_option(
         "OGR_ADBC_AUTO_LOAD_DUCKDB_SPATIAL", OGR_ADBC_AUTO_LOAD_DUCKDB_SPATIAL
@@ -352,11 +384,12 @@ def test_ogr_adbc_duckdb_parquet_with_spatial_and_SQL_open_optoin(
 ###############################################################################
 
 
+@pytest.mark.skipif(
+    not _has_duckdb_driver(),
+    reason="duckdb driver missing",
+)
 @pytest.mark.parametrize("OGR_ADBC_AUTO_LOAD_DUCKDB_SPATIAL", ["ON", "OFF"])
 def test_ogr_adbc_duckdb_with_spatial_index(OGR_ADBC_AUTO_LOAD_DUCKDB_SPATIAL):
-
-    if not _has_libduckdb():
-        pytest.skip("libduckdb.so missing")
 
     with gdal.config_option(
         "OGR_ADBC_AUTO_LOAD_DUCKDB_SPATIAL", OGR_ADBC_AUTO_LOAD_DUCKDB_SPATIAL
@@ -373,10 +406,15 @@ def test_ogr_adbc_duckdb_with_spatial_index(OGR_ADBC_AUTO_LOAD_DUCKDB_SPATIAL):
 ###############################################################################
 
 
+@pytest.mark.skipif(
+    not _has_duckdb_driver(),
+    reason="duckdb driver missing",
+)
+@pytest.mark.skipif(
+    not _has_adbc_driver_manager(),
+    reason="ADBC driver built without AdbcDriverManager",
+)
 def test_ogr_adbc_duckdb_sql(tmp_path):
-
-    if not _has_libduckdb():
-        pytest.skip("libduckdb.so missing")
 
     tmp_filename = str(tmp_path / "test.parquet")
     shutil.copy("data/parquet/poly.parquet", tmp_filename)
@@ -396,11 +434,15 @@ def test_ogr_adbc_duckdb_sql(tmp_path):
 # Run test_ogrsf on a SQLite3 database
 
 
+@pytest.mark.skipif(
+    not _has_sqlite_driver(),
+    reason="adbc_driver_sqlite driver missing",
+)
+@pytest.mark.skipif(
+    not _has_adbc_driver_manager(),
+    reason="ADBC driver built without AdbcDriverManager",
+)
 def test_ogr_adbc_test_ogrsf_sqlite3():
-
-    if not _has_sqlite_driver():
-        pytest.skip("adbc_driver_sqlite missing")
-
     import test_cli_utilities
 
     if test_cli_utilities.get_test_ogrsf_path() is None:
@@ -419,10 +461,11 @@ def test_ogr_adbc_test_ogrsf_sqlite3():
 # Run test_ogrsf on a single Parquet file
 
 
+@pytest.mark.skipif(
+    not _has_duckdb_driver(),
+    reason="duckdb driver missing",
+)
 def test_ogr_adbc_test_ogrsf_parquet():
-
-    if not _has_libduckdb():
-        pytest.skip("libduckdb.so missing")
 
     import test_cli_utilities
 
@@ -442,10 +485,11 @@ def test_ogr_adbc_test_ogrsf_parquet():
 # Run test_ogrsf on a partitioned Parquet dataset
 
 
+@pytest.mark.skipif(
+    not _has_duckdb_driver(),
+    reason="duckdb driver missing",
+)
 def test_ogr_adbc_test_ogrsf_parquet_filename_with_glob():
-
-    if not _has_libduckdb():
-        pytest.skip("libduckdb.so missing")
 
     import test_cli_utilities
 
@@ -465,11 +509,12 @@ def test_ogr_adbc_test_ogrsf_parquet_filename_with_glob():
 # Run test_ogrsf on a GeoParquet file
 
 
+@pytest.mark.skipif(
+    not _has_duckdb_driver(),
+    reason="duckdb driver missing",
+)
 @pytest.mark.parametrize("OGR_ADBC_AUTO_LOAD_DUCKDB_SPATIAL", ["ON", "OFF"])
 def test_ogr_adbc_test_ogrsf_geoparquet(OGR_ADBC_AUTO_LOAD_DUCKDB_SPATIAL):
-
-    if not _has_libduckdb():
-        pytest.skip("libduckdb.so missing")
 
     import test_cli_utilities
 
@@ -489,12 +534,13 @@ def test_ogr_adbc_test_ogrsf_geoparquet(OGR_ADBC_AUTO_LOAD_DUCKDB_SPATIAL):
 # Test DATETIME_AS_STRING=YES GetArrowStream() option
 
 
+@pytest.mark.skipif(
+    not _has_duckdb_driver(),
+    reason="duckdb driver missing",
+)
 def test_ogr_adbc_arrow_stream_numpy_datetime_as_string(tmp_vsimem):
     gdaltest.importorskip_gdal_array()
     pytest.importorskip("numpy")
-
-    if not _has_libduckdb():
-        pytest.skip("libduckdb.so missing")
 
     with gdal.OpenEx(
         "data/parquet/test.parquet", gdal.OF_VECTOR, allowed_drivers=["ADBC"]
@@ -519,11 +565,12 @@ def test_ogr_adbc_arrow_stream_numpy_datetime_as_string(tmp_vsimem):
 # Run test_ogrsf on a DuckDB dataset
 
 
+@pytest.mark.skipif(
+    not _has_duckdb_driver(),
+    reason="duckdb driver missing",
+)
 @pytest.mark.parametrize("OGR_ADBC_AUTO_LOAD_DUCKDB_SPATIAL", ["ON", "OFF"])
 def test_ogr_adbc_test_ogrsf_duckdb(OGR_ADBC_AUTO_LOAD_DUCKDB_SPATIAL):
-
-    if not _has_libduckdb():
-        pytest.skip("libduckdb.so missing")
 
     import test_cli_utilities
 
@@ -543,13 +590,14 @@ def test_ogr_adbc_test_ogrsf_duckdb(OGR_ADBC_AUTO_LOAD_DUCKDB_SPATIAL):
 # Run test_ogrsf on a DuckDB dataset
 
 
+@pytest.mark.skipif(
+    not _has_duckdb_driver(),
+    reason="duckdb driver missing",
+)
 @pytest.mark.parametrize("OGR_ADBC_AUTO_LOAD_DUCKDB_SPATIAL", ["ON", "OFF"])
 def test_ogr_adbc_test_ogrsf_duckdb_with_spatial_index(
     OGR_ADBC_AUTO_LOAD_DUCKDB_SPATIAL,
 ):
-
-    if not _has_libduckdb():
-        pytest.skip("libduckdb.so missing")
 
     import test_cli_utilities
 
@@ -568,10 +616,15 @@ def test_ogr_adbc_test_ogrsf_duckdb_with_spatial_index(
 ###############################################################################
 
 
+@pytest.mark.skipif(
+    not _has_sqlite_driver(),
+    reason="adbc_driver_sqlite missing",
+)
+@pytest.mark.skipif(
+    not _has_adbc_driver_manager(),
+    reason="ADBC driver built without AdbcDriverManager",
+)
 def test_ogr_adbc_layer_list():
-
-    if not _has_sqlite_driver():
-        pytest.skip("adbc_driver_sqlite missing")
 
     with gdal.OpenEx(
         "data/sqlite/poly_spatialite.sqlite", gdal.OF_VECTOR, allowed_drivers=["ADBC"]

--- a/ogr/ogrsf_frmts/adbc/ogradbcdataset.cpp
+++ b/ogr/ogrsf_frmts/adbc/ogradbcdataset.cpp
@@ -21,13 +21,6 @@
 
 #if defined(OGR_ADBC_HAS_DRIVER_MANAGER)
 #include <arrow-adbc/adbc_driver_manager.h>
-#else
-#if defined(_WIN32)
-#include <windows.h>
-#include <libloaderapi.h>
-#else
-#include <dlfcn.h>
-#endif  // defined(_WIN32)
 #endif
 
 #define OGR_ADBC_VERSION ADBC_VERSION_1_1_0
@@ -40,22 +33,7 @@ namespace
 AdbcStatusCode OGRDuckDBLoadDriver(const char *driver_name, void *driver,
                                    struct AdbcError *error)
 {
-#if defined(_WIN32)
-    HMODULE handle = LoadLibraryExA(library, NULL, 0);
-#else
-    void *handle = dlopen(driver_name, RTLD_NOW | RTLD_LOCAL);
-#endif
-    if (!handle)
-    {
-        return ADBC_STATUS_INTERNAL;
-    }
-
-#if defined(_WIN32)
-    void *load_handle =
-        reinterpret_cast<void *>(GetProcAddress(handle, "duckdb_adbc_init"));
-#else
-    void *load_handle = dlsym(handle, "duckdb_adbc_init");
-#endif
+    void *load_handle = CPLGetSymbol(driver_name, "duckdb_adbc_init");
     if (!load_handle)
     {
         return ADBC_STATUS_INTERNAL;

--- a/ogr/ogrsf_frmts/adbc/ogradbcdataset.cpp
+++ b/ogr/ogrsf_frmts/adbc/ogradbcdataset.cpp
@@ -22,7 +22,12 @@
 #if defined(OGR_ADBC_HAS_DRIVER_MANAGER)
 #include <arrow-adbc/adbc_driver_manager.h>
 #else
+#if defined(_WIN32)
+#include <windows.h>
+#include <libloaderapi.h>
+#else
 #include <dlfcn.h>
+#endif  // defined(_WIN32)
 #endif
 
 #define OGR_ADBC_VERSION ADBC_VERSION_1_1_0


### PR DESCRIPTION
## What does this PR do?

Implement a minimal loading function for DuckDB when ADBC driver manager is not available.

The implementation is based on ADBC's code; call `dlopen()` and `dlsym()` (on non-Windows platforms).

- https://github.com/apache/arrow-adbc/blob/bbf3389e0616fe51105001d4ad06f9a360c86da7/c/driver_manager/adbc_driver_manager.cc#L1661-L1717
- https://github.com/apache/arrow-adbc/blob/bbf3389e0616fe51105001d4ad06f9a360c86da7/c/driver_manager/adbc_driver_manager.cc#L174
- https://github.com/apache/arrow-adbc/blob/bbf3389e0616fe51105001d4ad06f9a360c86da7/c/driver_manager/adbc_driver_manager.cc#L225

## What are related issues/pull requests?

Close #12631 

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: macOS 15.5
* Compiler: Apple clang 17.0.0
