### PR TITLE
AAIGrid: guard‐rail against oversized grids to prevent OOMFix aaigrid oom

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,6 @@ gdal/share
 /build
 CMakeSettings.json
 out/
+build-*/
+install-asan/
+venv/


### PR DESCRIPTION
Fixes issue-number 12648 --> Rationale Reading an .asc header that advertises enormous grid dimensions (e.g. 1 000 000 001 × 2) causes GDAL to allocate huge internal structures and can be killed by the OOM-killer. This patch adds an explicit upper-bound check (10 million cells per side, consistent with other drivers) and returns an error early. 
