### PR TITLE
Doc: Add glossary terms from the user documentation

### DIFF
--- a/doc/source/glossary.rst
+++ b/doc/source/glossary.rst
@@ -16,9 +16,73 @@ The GDAL glossary contains terms and acronyms found throughout the GDAL document
 
         Application Programming Interface. A set of rules that lets different software programs communicate and share data or functions.
 
+    Arc
+
+        A curved segment of a circle or other curve, often used in geographic data to represent smooth curved lines or boundaries between points.
+
+    Band
+
+        A single layer of data values within a raster dataset. In a single-band raster, each pixel contains one value - such as elevation in a :term:`DEM`.
+        A multi-band raster contains multiple such layers; for example, satellite imagery may include three bands representing Red, Green, and Blue channels.
+
+    Band Algebra
+
+        A method for performing mathematical operations on one or more raster bands to produce a new output band or raster.
+        Band algebra involves applying expressions - such as addition, subtraction, multiplication, division,
+        or more complex functions—on pixel values across bands.
+
+        .. seealso::
+            :ref:`gdal_band_algebra`.
+
+    Block Cache
+
+        A memory cache that stores recently accessed blocks of data to reduce disk reads and improve performance.
+
+    Boolean
+
+        A data type representing one of two values: True or False, commonly used in logical operations and conditions.
+
+    Coordinate Epoch
+
+        The date tied to spatial coordinates in a dynamic reference frame, used to account for positional changes over time (e.g., due to tectonic motion).
+
+    Credentials
+
+        Information (such as a username and password or tokens) used to verify the identity of a user or system for authentication and access control.
+
+    CRS
+
+        Coordinate Reference System. A system that maps spatial data coordinates to real-world locations,
+        combining a coordinate system with a reference surface like a projection or :term:`ellipsoid`.
+
+    curl
+
+        A command-line tool and library for transferring data with URLs, supporting protocols such as HTTP, HTTPS, FTP, and more.
+        Commonly used for testing and interacting with web services.
+
     DEM
 
         Digital Elevation Model. A raster representation of the height of the earth's surface.
+
+    Driver
+
+        A software component that enables reading, writing, and processing of specific raster or vector data formats.
+
+    Ellipsoid
+
+        A model used to approximate the Earth's shape in coordinate systems.
+
+    Environment Variable
+
+        A variable in the operating system that can influence the behavior of running processes or applications.
+
+        .. seealso::
+            :ref:`configoptions`.
+
+    Escaped Character
+
+        Refers to a character or sequence modified to prevent it from being interpreted as code or control instructions,
+        allowing it to be treated as literal data.
 
     Euclidean Distance
 
@@ -30,6 +94,10 @@ The GDAL glossary contains terms and acronyms found throughout the GDAL document
         now part of IOGP (International Association of Oil & Gas Producers). Known for creating the EPSG Geodetic Parameter Dataset,
         a widely used database of coordinate systems and geodetic parameters.
 
+    File Handle
+
+        An identifier used by an operating system to manage and access an open file during a program's execution.
+
     Gridding
 
         The process of converting scattered or irregularly spaced data points into a regular, structured grid format.
@@ -40,6 +108,11 @@ The GDAL glossary contains terms and acronyms found throughout the GDAL document
     Georeference
 
         Linking data to real-world geographic coordinates so a location can be accurately mapped.
+
+
+    Georeferencing
+
+        See :term:`Georeference`.
 
     Geotransform
 
@@ -66,6 +139,21 @@ The GDAL glossary contains terms and acronyms found throughout the GDAL document
 
         The measurement and representation of land elevation (or terrain height) relative to sea level.
 
+    Library
+
+        A collection of software routines, functions, or classes that can be used by programs to perform specific tasks
+        without having to write code from scratch. Libraries help developers reuse code and simplify software development.
+
+    Linestring
+
+        A geometric object consisting of a sequence of connected points forming a continuous line, commonly used to represent
+        linear features such as roads or rivers in spatial data.
+
+    LRU Cache
+
+        Least Recently Used Cache. A memory cache that stores a limited number of items, automatically discarding the
+        least recently used entries to make space for new ones.
+
     Moving Average
 
         A method that smooths data by averaging values over a sliding window of data points.
@@ -73,14 +161,53 @@ The GDAL glossary contains terms and acronyms found throughout the GDAL document
         .. seealso::
             :ref:`gdal_grid_tut`.
 
+    Multithreading
+
+        A programming technique where multiple threads are executed concurrently within a single process,
+        allowing parallel execution of tasks to improve performance and responsiveness.
+
+    Normalizing
+
+        The process of adjusting data values to a common scale. In raster analysis, normalizing is commonly used to
+        scale pixel values to a defined range (such as 0 to 1) to facilitate comparison and visualization.
+
     Nearest Neighbor
 
         A method that finds the closest data point(s) to a given point, often used for classification or estimation based on similarity.
+
+    OSR
+
+        OGR Spatial Reference (OSR) - module that handles spatial reference systems and coordinate transformations.
+
+        .. seealso::
+            :ref:`osr_api_tut`.
+
+    PAM
+
+        Persistent Auxiliary Metadata. Metadata stored separately from the main raster data file,
+        allowing additional information to persist without modifying the original file.
 
     Raster
 
         A type of spatial data used with GIS, consisting of a regular grid of points spaced at a set distance (the resolution);
         often used to represent heights (DEM) or temperature data.
+
+    Raster Algebra
+
+        See :term:`Band Algebra`.
+
+    Resampling
+
+        The process of changing the resolution or grid alignment of raster data by interpolating pixel values,
+        used when scaling, reprojecting, or transforming images to maintain data quality.
+
+    RGB
+
+        An acronym for Red, Green, and Blue - the three primary colors of light used in digital imaging.
+
+    Runtime
+
+        The period during which a program or process is actively executing. It refers to the time from the start of a program's execution to its termination.
 
     Search Ellipse
 
@@ -96,6 +223,60 @@ The GDAL glossary contains terms and acronyms found throughout the GDAL document
         .. seealso::
             :ref:`gdal_grid_tut`.
 
+    Shell
+
+        A command-line interface used to interact with an operating system by typing commands.
+
+    Side-car Files
+
+        Auxiliary files stored alongside a primary data file that contain metadata or additional information without
+        altering the original file.
+
+    SRS
+
+        Spatial Reference System. A system that defines how spatial coordinates map to real-world locations.
+        Often used interchangeably with :term:`CRS`, though CRS is the more precise term in modern geospatial standards.
+
+    SSL
+
+        Secure Sockets Layer. A security protocol that encrypts data transmitted over the Internet
+        to ensure privacy and data integrity between a client and a server.
+
+    stdout
+
+        Standard output stream used by programs to display output data, typically shown on the console or terminal.
+
+    Swath
+
+        A contiguous block or strip of raster data processed or read at one time.
+
+    Thread
+
+        A sequence of executable instructions within a program that can run independently, often used to perform tasks concurrently for better performance.
+
+    Topology
+
+        The study and representation of spatial relationships between geometric features, such as adjacency, connectivity, and containment,
+        ensuring data integrity in GIS by defining how points, lines, and polygons share boundaries and connect.
+
+    User-Agent
+
+        A string sent by a web browser or client identifying itself to a web server, often including information
+        about the software, version, and operating system.
+
+    UTF8
+
+        A character encoding that represents text using one to four bytes per character, and capable of encoding all Unicode characters. Also
+        referred to a UTF-8. 
+
+    VRT
+
+        Virtual Raster Tile: A lightweight XML-based GDAL format that references multiple rasters to create a
+        virtual mosaic without duplicating data.
+
+        .. seealso::
+            :ref:`raster.vrt`.
+
     VSI
 
         Virtual System Interface. An interface for accessing files and datasets in non-filesystem locations, such as
@@ -103,6 +284,14 @@ The GDAL glossary contains terms and acronyms found throughout the GDAL document
 
         .. seealso::
             :ref:`virtual_file_systems`.
+
+    Warping
+
+        The process of geometrically transforming raster data to align with a different coordinate system, projection,
+        or spatial reference, often involving :term:`resampling` of pixel values.
+
+        .. seealso::
+            :ref:`gdalwarp`.
 
     WKT
 

--- a/doc/source/user/configoptions.rst
+++ b/doc/source/user/configoptions.rst
@@ -4,7 +4,7 @@
 Configuration options
 ================================================================================
 
-This page discusses runtime configuration options for GDAL. These are distinct from
+This page discusses :term:`runtime` configuration options for GDAL. These are distinct from
 options to the build-time configure script. Runtime configuration options apply
 on all platforms, and are evaluated at runtime. They can be set programmatically,
 by commandline switches or in the environment by the user.
@@ -18,7 +18,7 @@ How to set configuration options?
 
 One example of a configuration option is the :config:`GDAL_CACHEMAX`
 option. It controls the size
-of the GDAL block cache, in megabytes. It can be set in the environment on Unix
+of the GDAL :term:`block cache`, in megabytes. It can be set in the environment on Unix
 (bash/bourne) shell like this:
 
 ::
@@ -292,7 +292,7 @@ Performance and caching
 
       Used by :source_file:`gcore/rasterio.cpp`
 
-      Size of the swath when copying raster data from one dataset to another one (in
+      Size of the :term:`swath` when copying raster data from one dataset to another one (in
       bytes). Should not be smaller than :config:`GDAL_CACHEMAX`.
 
 -  .. config:: GDAL_DISABLE_READDIR_ON_OPEN
@@ -301,7 +301,7 @@ Performance and caching
 
       By default (FALSE), GDAL establishes a list of all the files in the
       directory of the file passed to :cpp:func:`GDALOpen`. This can result in
-      speed-ups in some use cases, but also to major slow downswhen the
+      speed-ups in some use cases, but also to major slow-downs when the
       directory contains thousands of other files. When set to TRUE, GDAL will
       not try to establish the list of files. The number of files read can
       also be limited by :config:`GDAL_READDIR_LIMIT_ON_OPEN`.
@@ -949,7 +949,7 @@ Networking options
 -  .. config:: GDAL_PROXY_AUTH
       :choices: BASIC, NTLM, NEGOTIATE, DIGEST, ANY, ANYSAFE
 
-      Set value to  to tell libcurl which authentication method(s) you want it to use
+      Set value to tell libcurl which authentication method(s) you want it to use
       for your proxy authentication. See
       http://curl.haxx.se/libcurl/c/curl_easy_setopt.html#CURLOPTPROXYAUTH for more
       information.


### PR DESCRIPTION
Adds terms to the glossary from https://gdal.org/en/latest/user/band_algebra.html and https://gdal.org/en/latest/user/configoptions.html. 
Fix a couple of typos while reading through, and added some `:term:` references. 