### PR TITLE
OGRParseDate(): do not round second=59.999999 to 60.0 but 59.999

### DIFF
--- a/autotest/cpp/test_ogr.cpp
+++ b/autotest/cpp/test_ogr.cpp
@@ -602,6 +602,11 @@ TEST_F(test_ogr, OGRParseDate)
     EXPECT_EQ(sField.Date.Second, 56.789f);
     EXPECT_EQ(sField.Date.TZFlag, 100);
 
+    EXPECT_EQ(OGRParseDate("2017-11-31T23:59:59.999999Z", &sField, 0), TRUE);
+    EXPECT_EQ(sField.Date.Hour, 23);
+    EXPECT_EQ(sField.Date.Minute, 59);
+    EXPECT_EQ(sField.Date.Second, 59.999f);
+
     EXPECT_EQ(OGRParseDate("2017-11-31", &sField, 0), TRUE);
     EXPECT_EQ(sField.Date.Year, 2017);
     EXPECT_EQ(sField.Date.Month, 11);

--- a/ogr/ogrutils.cpp
+++ b/ogr/ogrutils.cpp
@@ -1265,6 +1265,16 @@ int OGRParseDate(const char *pszInput, OGRField *psField, int nOptions)
                 return FALSE;
             psField->Date.Second = static_cast<float>(dfSeconds);
 
+            // Avoid rounding 59.999xxx to 60.0f (or set second to zero and
+            // increment the minute value) where x is 9, but round to 59.999 as
+            // the maximum value representable on a float.
+            if (pszInput[0] == '5' && pszInput[1] == '9' &&
+                pszInput[2] == '.' && pszInput[3] == '9' &&
+                psField->Date.Second == 60.000f)
+            {
+                psField->Date.Second = 59.999f;
+            }
+
             pszInput += 2;
             if (*pszInput == '.')
             {


### PR DESCRIPTION
Fixes https://lists.osgeo.org/pipermail/gdal-dev/2025-June/060685.html
