### PR TITLE
sqlite_rtree_bulk_load.c: include <stdlib.h>

### DIFF
--- a/ogr/ogrsf_frmts/sqlite/sqlite_rtree_bulk_load/sqlite_rtree_bulk_load.c
+++ b/ogr/ogrsf_frmts/sqlite/sqlite_rtree_bulk_load/sqlite_rtree_bulk_load.c
@@ -19,6 +19,7 @@
 #include <assert.h>
 #include <inttypes.h>
 #include <math.h>
+#include <stdlib.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
`<math.h>` doesn't transitively include `<stdlib.h>` anymore in llvm near upstream head.

Caused by this commit:

https://github.com/llvm/llvm-project/commit/584cc376870505821b5ff0b0e80be85ee563ff0c

> [libc++] Move std::abs into __math/abs.h (https://github.com/llvm/llvm-project/pull/139586)
>
> `template <class = int>` is also added to our implementations to avoid an ambiguity between the libc's version and our version when both are visible.
> 
> This avoids including `<stdlib.h>` in `<math.h>`.