### PR TITLE
fix(Windows): missing import specifier

### DIFF
--- a/port/cpl_port.h
+++ b/port/cpl_port.h
@@ -297,7 +297,7 @@ typedef uintptr_t GUIntptr_t;
 #ifdef GDAL_COMPILATION
 #define CPL_DLL __declspec(dllexport)
 #else
-#define CPL_DLL
+#define CPL_DLL __declspec(dllimport)
 #endif
 #define CPL_INTERNAL
 #else


### PR DESCRIPTION
## What does this PR do?

I look at this code and do not understand why the dllexport exists and not the dllimport. Is it an intended behavior?

## What are related issues/pull requests?

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
