### PR TITLE
HEIF fixes

### DIFF
--- a/autotest/gdrivers/heif.py
+++ b/autotest/gdrivers/heif.py
@@ -507,14 +507,12 @@ def test_identify_various(major_brand, compatible_brands, expect_success):
 
 
 @pytest.mark.require_curl()
-# Hangs on 24.04 CI targets since ~ May 23th 2025
-@pytest.mark.skipif(gdaltest.is_ci(), reason="hangs on CI")
 def test_heif_network_read(tmp_vsimem):
 
     if not _has_read_write_support_for("UNCOMPRESSED"):
         pytest.skip("does not support UNCOMPRESSED")
-    if get_version() < [1, 19, 0]:
-        pytest.skip("libheif >= 1.19.0 not met")
+    if get_version() < [1, 19, 8]:
+        pytest.skip("libheif >= 1.19.8 not met")
 
     filename = tmp_vsimem / "test.hic"
     gdal.Translate(
@@ -585,6 +583,8 @@ def test_heif_network_read(tmp_vsimem):
 
                 request.wfile.write(extract(start, end - start + 1))
 
+        handler.add("GET", "/test.hic", custom_method=method)
+        handler.add("GET", "/test.hic", custom_method=method)
         handler.add("GET", "/test.hic", custom_method=method)
         with webserver.install_http_handler(handler):
             ret = ds.ReadRaster()

--- a/cmake/helpers/CheckDependentLibraries.cmake
+++ b/cmake/helpers/CheckDependentLibraries.cmake
@@ -448,9 +448,12 @@ gdal_check_package(MONGOCXX "Enable MongoDBV3 driver" CAN_DISABLE)
 
 define_find_package2(HEIF libheif/heif.h heif PKGCONFIG_NAME libheif)
 gdal_check_package(HEIF "HEIF >= 1.1" CAN_DISABLE)
-
-include(CheckCXXSourceCompiles)
-check_cxx_source_compiles(
+if (HEIF_FOUND)
+  include(CMakePushCheckState)
+  include(CheckCXXSourceCompiles)
+  cmake_push_check_state(RESET)
+  set(CMAKE_REQUIRED_INCLUDES ${HEIF_INCLUDE_DIRS})
+  check_cxx_source_compiles(
     "
     #include <libheif/heif.h>
     int main()
@@ -460,10 +463,12 @@ check_cxx_source_compiles(
     }
     "
     LIBHEIF_SUPPORTS_TILES
-)
-if (LIBHEIF_SUPPORTS_TILES)
-  set_property(TARGET HEIF::HEIF APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS "LIBHEIF_SUPPORTS_TILES")
-endif ()
+  )
+  if (LIBHEIF_SUPPORTS_TILES)
+    set_property(TARGET HEIF::HEIF APPEND PROPERTY INTERFACE_COMPILE_DEFINITIONS "LIBHEIF_SUPPORTS_TILES")
+  endif ()
+  cmake_pop_check_state()
+endif()
 
 include(CheckDependentLibrariesAVIF)
 


### PR DESCRIPTION
- CMake: fix LIBHEIF_SUPPORTS_TILES check when the include directory is not a system path
- heif.py: fix network test