### PR TITLE
S57: fix nullptr dereference on invalid dataset when GDAL_DATA not set

### DIFF
--- a/ogr/ogrsf_frmts/s57/s57.h
+++ b/ogr/ogrsf_frmts/s57/s57.h
@@ -314,7 +314,7 @@ class CPL_DLL S57Reader
     void AssembleSoundingGeometry(DDFRecord *, OGRFeature *);
     // cppcheck-suppress functionStatic
     void AssemblePointGeometry(DDFRecord *, OGRFeature *);
-    void AssembleLineGeometry(DDFRecord *, OGRFeature *);
+    bool AssembleLineGeometry(DDFRecord *, OGRFeature *);
     void AssembleAreaGeometry(const DDFRecord *, OGRFeature *);
 
     bool FetchPoint(int, int, double *, double *, double * = nullptr);


### PR DESCRIPTION
Fixes https://issues.oss-fuzz.com/issues/428506175
