### PR TITLE
Python bindings: Add Band.BlockWindows()

### DIFF
--- a/doc/source/spelling_wordlist.txt
+++ b/doc/source/spelling_wordlist.txt
@@ -237,6 +237,7 @@ blockings
 blocksize
 BlockSizeX
 BlockSizeY
+BlockWindows
 blocky
 bLookForCircular
 bLookForNonLinear


### PR DESCRIPTION
Add block window iterator to Python `Band` object. I couldn't decide between returning a tuple (which can be unpacked directly into `ReadAsArray`) or a custom type with members for `xoff`, `xsize`, etc. Ended up returning a type that behaves both ways. Maybe this is inadvisable for some reason.