### PR TITLE
doc: add @since for a couple of functions [ci skip]

### DIFF
--- a/alg/contour.cpp
+++ b/alg/contour.cpp
@@ -564,6 +564,7 @@ mode.
  * issuing the starting transaction and committing the final one.
  *
  * @return CE_None on success or CE_Failure if an error occurs.
+ * @since GDAL 2.4
  */
 CPLErr GDALContourGenerateEx(GDALRasterBandH hBand, void *hLayer,
                              CSLConstList options, GDALProgressFunc pfnProgress,

--- a/gcore/gdal_misc.cpp
+++ b/gcore/gdal_misc.cpp
@@ -372,6 +372,7 @@ GDALDataType CPL_STDCALL GDALFindDataTypeForValue(double dValue, int bComplex)
  *
  * @param eDataType type, such as GDT_Byte.
  * @return the number of bytes or zero if it is not recognised.
+ * @since GDAL 2.1
  */
 
 int CPL_STDCALL GDALGetDataTypeSizeBytes(GDALDataType eDataType)
@@ -424,6 +425,7 @@ int CPL_STDCALL GDALGetDataTypeSizeBytes(GDALDataType eDataType)
  *
  * @param eDataType type, such as GDT_Byte.
  * @return the number of bits or zero if it is not recognised.
+ * @since GDAL 2.1
  */
 
 int CPL_STDCALL GDALGetDataTypeSizeBits(GDALDataType eDataType)


### PR DESCRIPTION
## What does this PR do?
Add Doxygen `@since` annotations for `GDALGetDataTypeSizeBytes`, `GDALGetDataTypeSizeBits` and `GDALContourGenerateEx`. The first two are useful with the new deprecation warning.

https://github.com/OSGeo/gdal/commit/b44b7b92000
https://github.com/OSGeo/gdal/pull/834