### PR TITLE
[Backport release/3.11] /vsizip/: fix memory leak when opening a SOZip-enabled file

### DIFF
--- a/autotest/gcore/vsizip.py
+++ b/autotest/gcore/vsizip.py
@@ -12,7 +12,9 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
+import os
 import random
+import sys
 
 import gdaltest
 import pytest
@@ -207,30 +209,37 @@ def test_vsizip_2():
 # Test opening in write mode a file inside a zip archive whose content has been listed before (testcase for fix of r22625)
 
 
-def test_vsizip_3():
+def test_vsizip_3(tmp_path):
 
-    fmain = gdal.VSIFOpenL("/vsizip/vsimem/test3.zip", "wb")
+    fds_open = 0
+    if sys.platform == "linux":
+        fds_open = len(os.listdir("/proc/self/fd"))
 
-    f = gdal.VSIFOpenL("/vsizip/vsimem/test3.zip/foo", "wb")
+    filename_base = f"/vsizip/{tmp_path}/test3.zip"
+
+    fmain = gdal.VSIFOpenL(filename_base, "wb")
+
+    f = gdal.VSIFOpenL(filename_base + "/foo", "wb")
     gdal.VSIFWriteL("foo", 1, 3, f)
     gdal.VSIFCloseL(f)
-    f = gdal.VSIFOpenL("/vsizip/vsimem/test3.zip/bar", "wb")
+    f = gdal.VSIFOpenL(filename_base + "/bar", "wb")
     gdal.VSIFWriteL("bar", 1, 3, f)
     gdal.VSIFCloseL(f)
 
     gdal.VSIFCloseL(fmain)
 
-    gdal.ReadDir("/vsizip/vsimem/test3.zip")
+    gdal.ReadDir(filename_base)
 
-    f = gdal.VSIFOpenL("/vsizip/vsimem/test3.zip/baz", "wb")
+    f = gdal.VSIFOpenL(filename_base + "/baz", "wb")
     gdal.VSIFWriteL("baz", 1, 3, f)
     gdal.VSIFCloseL(f)
 
-    res = gdal.ReadDir("/vsizip/vsimem/test3.zip")
-
-    gdal.Unlink("/vsimem/test3.zip")
+    res = gdal.ReadDir(filename_base)
 
     assert res == ["foo", "bar", "baz"]
+
+    if sys.platform == "linux":
+        assert len(os.listdir("/proc/self/fd")) == fds_open
 
 
 ###############################################################################
@@ -910,11 +919,10 @@ def test_vsizip_byte_copyfile_file_already_open():
 ###############################################################################
 
 
-def test_vsizip_byte_sozip():
-
-    zipfilename = "/vsimem/test_vsizip_byte_sozip.zip"
-    dstfilename = f"/vsizip/{zipfilename}/test.tif"
-    try:
+def test_vsizip_byte_sozip(tmp_path):
+    def do():
+        zipfilename = f"{tmp_path}/test_vsizip_byte_sozip.zip"
+        dstfilename = f"/vsizip/{zipfilename}/test.tif"
         options = ["SOZIP_ENABLED=YES", "SOZIP_CHUNK_SIZE=128"]
         assert gdal.CopyFile("data/byte.tif", dstfilename, options=options) == 0
         assert gdal.VSIStatL(dstfilename).size == gdal.VSIStatL("data/byte.tif").size
@@ -927,9 +935,16 @@ def test_vsizip_byte_sozip():
 
         ds = gdal.Open(dstfilename)
         assert ds.GetRasterBand(1).Checksum() == 4672
+        del ds
 
-    finally:
-        gdal.Unlink(zipfilename)
+    fds_open = 0
+    if sys.platform == "linux":
+        fds_open = len(os.listdir("/proc/self/fd"))
+
+    do()
+
+    if sys.platform == "linux":
+        assert len(os.listdir("/proc/self/fd")) == fds_open
 
 
 ###############################################################################

--- a/autotest/gcore/vsizip.py
+++ b/autotest/gcore/vsizip.py
@@ -935,7 +935,7 @@ def test_vsizip_byte_sozip(tmp_path):
 
         ds = gdal.Open(dstfilename)
         assert ds.GetRasterBand(1).Checksum() == 4672
-        del ds
+        ds.Close()
 
     fds_open = 0
     if sys.platform == "linux":

--- a/frmts/georaster/cpl_vsil_ocilob.cpp
+++ b/frmts/georaster/cpl_vsil_ocilob.cpp
@@ -508,6 +508,7 @@ int VSIOCILobHandle::Close()
     if (bUpdate)
     {
         poConnection->Commit();
+        bUpdate = false;
     }
 
     return 0;

--- a/port/cpl_vsil_gzip.cpp
+++ b/port/cpl_vsil_gzip.cpp
@@ -148,7 +148,7 @@ typedef struct
 
 class VSIGZipHandle final : public VSIVirtualHandle
 {
-    VSIVirtualHandle *m_poBaseHandle = nullptr;
+    VSIVirtualHandleUniquePtr m_poBaseHandle{};
 #ifdef DEBUG
     vsi_l_offset m_offset = 0;
 #endif
@@ -189,8 +189,9 @@ class VSIGZipHandle final : public VSIVirtualHandle
     CPL_DISALLOW_COPY_ASSIGN(VSIGZipHandle)
 
   public:
-    VSIGZipHandle(VSIVirtualHandle *poBaseHandle, const char *pszBaseFileName,
-                  vsi_l_offset offset = 0, vsi_l_offset compressed_size = 0,
+    VSIGZipHandle(VSIVirtualHandleUniquePtr poBaseHandleIn,
+                  const char *pszBaseFileName, vsi_l_offset offset = 0,
+                  vsi_l_offset compressed_size = 0,
                   vsi_l_offset uncompressed_size = 0, uLong expected_crc = 0,
                   int transparent = 0);
     ~VSIGZipHandle() override;
@@ -262,7 +263,7 @@ struct VSIDeflate64Snapshot
 
 class VSIDeflate64Handle final : public VSIVirtualHandle
 {
-    VSIVirtualHandle *m_poBaseHandle = nullptr;
+    VSIVirtualHandleUniquePtr m_poBaseHandle{};
 #ifdef DEBUG
     vsi_l_offset m_offset = 0;
 #endif
@@ -298,7 +299,7 @@ class VSIDeflate64Handle final : public VSIVirtualHandle
     CPL_DISALLOW_COPY_ASSIGN(VSIDeflate64Handle)
 
   public:
-    VSIDeflate64Handle(VSIVirtualHandle *poBaseHandle,
+    VSIDeflate64Handle(VSIVirtualHandleUniquePtr poBaseHandleIn,
                        const char *pszBaseFileName, vsi_l_offset offset = 0,
                        vsi_l_offset compressed_size = 0,
                        vsi_l_offset uncompressed_size = 0,
@@ -345,7 +346,7 @@ class VSIGZipFilesystemHandler final : public VSIFilesystemHandler
     CPL_DISALLOW_COPY_ASSIGN(VSIGZipFilesystemHandler)
 
     CPLMutex *hMutex = nullptr;
-    VSIGZipHandle *poHandleLastGZipFile = nullptr;
+    std::unique_ptr<VSIGZipHandle> poHandleLastGZipFile{};
     bool m_bInSaveInfo = false;
 
   public:
@@ -389,18 +390,17 @@ VSIGZipHandle *VSIGZipHandle::Duplicate()
     VSIFilesystemHandler *poFSHandler =
         VSIFileManager::GetHandler(m_pszBaseFileName);
 
-    VSIVirtualHandle *poNewBaseHandle =
-        poFSHandler->Open(m_pszBaseFileName, "rb");
+    VSIVirtualHandleUniquePtr poNewBaseHandle;
+    poNewBaseHandle.reset(poFSHandler->Open(m_pszBaseFileName, "rb"));
 
     if (poNewBaseHandle == nullptr)
         return nullptr;
 
-    VSIGZipHandle *poHandle =
-        new VSIGZipHandle(poNewBaseHandle, m_pszBaseFileName, 0,
-                          m_compressed_size, m_uncompressed_size);
+    auto poHandle = std::make_unique<VSIGZipHandle>(
+        std::move(poNewBaseHandle), m_pszBaseFileName, 0, m_compressed_size,
+        m_uncompressed_size);
     if (!(poHandle->IsInitOK()))
     {
-        delete poHandle;
         return nullptr;
     }
 
@@ -422,7 +422,7 @@ VSIGZipHandle *VSIGZipHandle::Duplicate()
         poHandle->snapshots[i].out = snapshots[i].out;
     }
 
-    return poHandle;
+    return poHandle.release();
 }
 
 /************************************************************************/
@@ -435,9 +435,8 @@ bool VSIGZipHandle::CloseBaseHandle()
     if (m_poBaseHandle)
     {
         bRet = m_poBaseHandle->Close() == 0;
-        delete m_poBaseHandle;
+        m_poBaseHandle.reset();
     }
-    m_poBaseHandle = nullptr;
     return bRet;
 }
 
@@ -445,12 +444,12 @@ bool VSIGZipHandle::CloseBaseHandle()
 /*                       VSIGZipHandle()                                */
 /************************************************************************/
 
-VSIGZipHandle::VSIGZipHandle(VSIVirtualHandle *poBaseHandle,
+VSIGZipHandle::VSIGZipHandle(VSIVirtualHandleUniquePtr poBaseHandleIn,
                              const char *pszBaseFileName, vsi_l_offset offset,
                              vsi_l_offset compressed_size,
                              vsi_l_offset uncompressed_size, uLong expected_crc,
                              int transparent)
-    : m_poBaseHandle(poBaseHandle),
+    : m_poBaseHandle(std::move(poBaseHandleIn)),
 #ifdef DEBUG
       m_offset(offset),
 #endif
@@ -468,14 +467,14 @@ VSIGZipHandle::VSIGZipHandle(VSIVirtualHandle *poBaseHandle,
     }
     else
     {
-        if (poBaseHandle->Seek(0, SEEK_END) != 0)
+        if (m_poBaseHandle->Seek(0, SEEK_END) != 0)
             CPLError(CE_Failure, CPLE_FileIO, "Seek() failed");
-        m_compressed_size = poBaseHandle->Tell() - offset;
+        m_compressed_size = m_poBaseHandle->Tell() - offset;
         compressed_size = m_compressed_size;
     }
     offsetEndCompressedData = offset + compressed_size;
 
-    if (poBaseHandle->Seek(offset, SEEK_SET) != 0)
+    if (m_poBaseHandle->Seek(offset, SEEK_SET) != 0)
         CPLError(CE_Failure, CPLE_FileIO, "Seek() failed");
 
     stream.zalloc = nullptr;
@@ -505,7 +504,7 @@ VSIGZipHandle::VSIGZipHandle(VSIVirtualHandle *poBaseHandle,
 
     if (offset == 0)
         check_header();  // Skip the .gz header.
-    startOff = poBaseHandle->Tell() - stream.avail_in;
+    startOff = m_poBaseHandle->Tell() - stream.avail_in;
 
     if (transparent == 0)
     {
@@ -1324,18 +1323,17 @@ VSIDeflate64Handle *VSIDeflate64Handle::Duplicate()
     VSIFilesystemHandler *poFSHandler =
         VSIFileManager::GetHandler(m_pszBaseFileName);
 
-    VSIVirtualHandle *poNewBaseHandle =
-        poFSHandler->Open(m_pszBaseFileName, "rb");
+    VSIVirtualHandleUniquePtr poNewBaseHandle(
+        poFSHandler->Open(m_pszBaseFileName, "rb"));
 
     if (poNewBaseHandle == nullptr)
         return nullptr;
 
-    VSIDeflate64Handle *poHandle =
-        new VSIDeflate64Handle(poNewBaseHandle, m_pszBaseFileName, 0,
-                               m_compressed_size, m_uncompressed_size);
+    auto poHandle = std::make_unique<VSIDeflate64Handle>(
+        std::move(poNewBaseHandle), m_pszBaseFileName, 0, m_compressed_size,
+        m_uncompressed_size);
     if (!(poHandle->IsInitOK()))
     {
-        delete poHandle;
         return nullptr;
     }
 
@@ -1359,7 +1357,7 @@ VSIDeflate64Handle *VSIDeflate64Handle::Duplicate()
             snapshots[i].m_bStreamEndReached;
     }
 
-    return poHandle;
+    return poHandle.release();
 }
 
 /************************************************************************/
@@ -1372,23 +1370,22 @@ bool VSIDeflate64Handle::CloseBaseHandle()
     if (m_poBaseHandle)
     {
         bRet = m_poBaseHandle->Close() == 0;
-        delete m_poBaseHandle;
+        m_poBaseHandle.reset();
     }
-    m_poBaseHandle = nullptr;
     return bRet;
 }
 
 /************************************************************************/
-/*                       VSIDeflate64Handle()                                */
+/*                       VSIDeflate64Handle()                           */
 /************************************************************************/
 
-VSIDeflate64Handle::VSIDeflate64Handle(VSIVirtualHandle *poBaseHandle,
+VSIDeflate64Handle::VSIDeflate64Handle(VSIVirtualHandleUniquePtr poBaseHandleIn,
                                        const char *pszBaseFileName,
                                        vsi_l_offset offset,
                                        vsi_l_offset compressed_size,
                                        vsi_l_offset uncompressed_size,
                                        uLong expected_crc)
-    : m_poBaseHandle(poBaseHandle),
+    : m_poBaseHandle(std::move(poBaseHandleIn)),
 #ifdef DEBUG
       m_offset(offset),
 #endif
@@ -1402,14 +1399,14 @@ VSIDeflate64Handle::VSIDeflate64Handle(VSIVirtualHandle *poBaseHandle,
     }
     else
     {
-        if (poBaseHandle->Seek(0, SEEK_END) != 0)
+        if (m_poBaseHandle->Seek(0, SEEK_END) != 0)
             CPLError(CE_Failure, CPLE_FileIO, "Seek() failed");
-        m_compressed_size = poBaseHandle->Tell() - offset;
+        m_compressed_size = m_poBaseHandle->Tell() - offset;
         compressed_size = m_compressed_size;
     }
     offsetEndCompressedData = offset + compressed_size;
 
-    if (poBaseHandle->Seek(offset, SEEK_SET) != 0)
+    if (m_poBaseHandle->Seek(offset, SEEK_SET) != 0)
         CPLError(CE_Failure, CPLE_FileIO, "Seek() failed");
 
     stream.zalloc = nullptr;
@@ -1434,7 +1431,7 @@ VSIDeflate64Handle::VSIDeflate64Handle(VSIVirtualHandle *poBaseHandle,
         inbuf = nullptr;
         return;
     }
-    startOff = poBaseHandle->Tell() - stream.avail_in;
+    startOff = m_poBaseHandle->Tell() - stream.avail_in;
 
     snapshot_byte_interval =
         std::max(static_cast<vsi_l_offset>(Z_BUFSIZE), compressed_size / 100);
@@ -2974,7 +2971,7 @@ VSIGZipFilesystemHandler::~VSIGZipFilesystemHandler()
     if (poHandleLastGZipFile)
     {
         poHandleLastGZipFile->UnsetCanSaveInfo();
-        delete poHandleLastGZipFile;
+        poHandleLastGZipFile.reset();
     }
 
     if (hMutex != nullptr)
@@ -2998,7 +2995,7 @@ void VSIGZipFilesystemHandler::SaveInfo_unlocked(VSIGZipHandle *poHandle)
         return;
     m_bInSaveInfo = true;
 
-    CPLAssert(poHandle != poHandleLastGZipFile);
+    CPLAssert(poHandle != poHandleLastGZipFile.get());
     CPLAssert(poHandle->GetBaseFileName() != nullptr);
 
     if (poHandleLastGZipFile == nullptr ||
@@ -3007,15 +3004,14 @@ void VSIGZipFilesystemHandler::SaveInfo_unlocked(VSIGZipHandle *poHandle)
         poHandle->GetLastReadOffset() >
             poHandleLastGZipFile->GetLastReadOffset())
     {
-        VSIGZipHandle *poTmp = poHandleLastGZipFile;
-        poHandleLastGZipFile = nullptr;
+        std::unique_ptr<VSIGZipHandle> poTmp;
+        std::swap(poTmp, poHandleLastGZipFile);
         if (poTmp)
         {
             poTmp->UnsetCanSaveInfo();
-            delete poTmp;
+            poTmp.reset();
         }
-        CPLAssert(poHandleLastGZipFile == nullptr);
-        poHandleLastGZipFile = poHandle->Duplicate();
+        poHandleLastGZipFile.reset(poHandle->Duplicate());
         if (poHandleLastGZipFile)
             poHandleLastGZipFile->CloseBaseHandle();
     }
@@ -3122,8 +3118,8 @@ VSIGZipFilesystemHandler::OpenGZipReadOnly(const char *pszFilename,
     CPL_IGNORE_RET_VAL(pszAccess);
 #endif
 
-    VSIVirtualHandle *poVirtualHandle =
-        poFSHandler->Open(pszFilename + strlen("/vsigzip/"), "rb");
+    VSIVirtualHandleUniquePtr poVirtualHandle(
+        poFSHandler->Open(pszFilename + strlen("/vsigzip/"), "rb"));
 
     if (poVirtualHandle == nullptr)
         return nullptr;
@@ -3132,26 +3128,22 @@ VSIGZipFilesystemHandler::OpenGZipReadOnly(const char *pszFilename,
     if (poVirtualHandle->Read(signature, 1, 2) != 2 ||
         signature[0] != gz_magic[0] || signature[1] != gz_magic[1])
     {
-        poVirtualHandle->Close();
-        delete poVirtualHandle;
         return nullptr;
     }
 
     if (poHandleLastGZipFile)
     {
         poHandleLastGZipFile->UnsetCanSaveInfo();
-        delete poHandleLastGZipFile;
-        poHandleLastGZipFile = nullptr;
+        poHandleLastGZipFile.reset();
     }
 
-    VSIGZipHandle *poHandle =
-        new VSIGZipHandle(poVirtualHandle, pszFilename + strlen("/vsigzip/"));
+    auto poHandle = std::make_unique<VSIGZipHandle>(
+        std::move(poVirtualHandle), pszFilename + strlen("/vsigzip/"));
     if (!(poHandle->IsInitOK()))
     {
-        delete poHandle;
         return nullptr;
     }
-    return poHandle;
+    return poHandle.release();
 }
 
 /************************************************************************/
@@ -3495,7 +3487,7 @@ int VSIZipReader::GotoFileOffset(VSIArchiveEntryFileOffset *pOffset)
 
 /************************************************************************/
 /* ==================================================================== */
-/*                       VSIZipFilesystemHandler                  */
+/*                       VSIZipFilesystemHandler                        */
 /* ==================================================================== */
 /************************************************************************/
 
@@ -3709,7 +3701,7 @@ VSIZipFilesystemHandler::CreateReader(const char *pszZipFileName)
 
 class VSISOZipHandle final : public VSIVirtualHandle
 {
-    VSIVirtualHandle *poBaseHandle_;
+    VSIVirtualHandleUniquePtr poBaseHandle_{};
     vsi_l_offset nPosCompressedStream_;
     uint64_t compressed_size_;
     uint64_t uncompressed_size_;
@@ -3730,7 +3722,7 @@ class VSISOZipHandle final : public VSIVirtualHandle
     VSISOZipHandle &operator=(const VSISOZipHandle &) = delete;
 
   public:
-    VSISOZipHandle(VSIVirtualHandle *poVirtualHandle,
+    VSISOZipHandle(VSIVirtualHandleUniquePtr poVirtualHandleIn,
                    vsi_l_offset nPosCompressedStream, uint64_t compressed_size,
                    uint64_t uncompressed_size, vsi_l_offset indexPos,
                    uint32_t nToSkip, uint32_t nChunkSize);
@@ -3778,13 +3770,13 @@ class VSISOZipHandle final : public VSIVirtualHandle
 /*                         VSISOZipHandle()                             */
 /************************************************************************/
 
-VSISOZipHandle::VSISOZipHandle(VSIVirtualHandle *poVirtualHandle,
+VSISOZipHandle::VSISOZipHandle(VSIVirtualHandleUniquePtr poVirtualHandleIn,
                                vsi_l_offset nPosCompressedStream,
                                uint64_t compressed_size,
                                uint64_t uncompressed_size,
                                vsi_l_offset indexPos, uint32_t nToSkip,
                                uint32_t nChunkSize)
-    : poBaseHandle_(poVirtualHandle),
+    : poBaseHandle_(std::move(poVirtualHandleIn)),
       nPosCompressedStream_(nPosCompressedStream),
       compressed_size_(compressed_size), uncompressed_size_(uncompressed_size),
       indexPos_(indexPos), nToSkip_(nToSkip), nChunkSize_(nChunkSize)
@@ -3824,9 +3816,13 @@ VSISOZipHandle::~VSISOZipHandle()
 
 int VSISOZipHandle::Close()
 {
-    delete poBaseHandle_;
-    poBaseHandle_ = nullptr;
-    return 0;
+    int ret = 0;
+    if (poBaseHandle_)
+    {
+        ret = poBaseHandle_->Close();
+        poBaseHandle_.reset();
+    }
+    return ret;
 }
 
 /************************************************************************/
@@ -4328,51 +4324,49 @@ VSIVirtualHandle *VSIZipFilesystemHandler::Open(const char *pszFilename,
 #ifdef ENABLE_DEFLATE64
     if (info.nCompressionMethod == 9)
     {
-        auto poGZIPHandle = new VSIDeflate64Handle(
-            info.poVirtualHandle.release(), nullptr, info.nStartDataStream,
+        auto poGZIPHandle = std::make_unique<VSIDeflate64Handle>(
+            std::move(info.poVirtualHandle), nullptr, info.nStartDataStream,
             info.nCompressedSize, info.nUncompressedSize, info.nCRC);
         if (!(poGZIPHandle->IsInitOK()))
         {
-            delete poGZIPHandle;
             return nullptr;
         }
 
         // Wrap the VSIGZipHandle inside a buffered reader that will
         // improve dramatically performance when doing small backward
         // seeks.
-        return VSICreateBufferedReaderHandle(poGZIPHandle);
+        return VSICreateBufferedReaderHandle(poGZIPHandle.release());
     }
     else
 #endif
     {
         if (info.bSOZipIndexValid)
         {
-            auto poSOZIPHandle = new VSISOZipHandle(
-                info.poVirtualHandle.release(), info.nStartDataStream,
+            auto poSOZIPHandle = std::make_unique<VSISOZipHandle>(
+                std::move(info.poVirtualHandle), info.nStartDataStream,
                 info.nCompressedSize, info.nUncompressedSize,
                 info.nSOZIPStartData, info.nSOZIPToSkip, info.nSOZIPChunkSize);
             if (!poSOZIPHandle->IsOK())
             {
-                delete poSOZIPHandle;
                 return nullptr;
             }
-            return VSICreateCachedFile(poSOZIPHandle, info.nSOZIPChunkSize, 0);
+            return VSICreateCachedFile(poSOZIPHandle.release(),
+                                       info.nSOZIPChunkSize, 0);
         }
 
-        VSIGZipHandle *poGZIPHandle = new VSIGZipHandle(
-            info.poVirtualHandle.release(), nullptr, info.nStartDataStream,
+        auto poGZIPHandle = std::make_unique<VSIGZipHandle>(
+            std::move(info.poVirtualHandle), nullptr, info.nStartDataStream,
             info.nCompressedSize, info.nUncompressedSize, info.nCRC,
             info.nCompressionMethod == 0);
         if (!(poGZIPHandle->IsInitOK()))
         {
-            delete poGZIPHandle;
             return nullptr;
         }
 
         // Wrap the VSIGZipHandle inside a buffered reader that will
         // improve dramatically performance when doing small backward
         // seeks.
-        return VSICreateBufferedReaderHandle(poGZIPHandle);
+        return VSICreateBufferedReaderHandle(poGZIPHandle.release());
     }
 }
 

--- a/port/cpl_vsil_libarchive.cpp
+++ b/port/cpl_vsil_libarchive.cpp
@@ -398,6 +398,7 @@ class VSILibArchiveHandler final : public VSIVirtualHandle
 
     virtual int Close() override
     {
+        m_poReader.reset();
         return 0;
     }
 };

--- a/port/cpl_vsil_sparsefile.cpp
+++ b/port/cpl_vsil_sparsefile.cpp
@@ -55,7 +55,7 @@ class SFRegion
 
 class VSISparseFileFilesystemHandler;
 
-class VSISparseFileHandle : public VSIVirtualHandle
+class VSISparseFileHandle final : public VSIVirtualHandle
 {
     CPL_DISALLOW_COPY_ASSIGN(VSISparseFileHandle)
 
@@ -68,6 +68,8 @@ class VSISparseFileHandle : public VSIVirtualHandle
         : m_poFS(poFS)
     {
     }
+
+    ~VSISparseFileHandle() override;
 
     GUIntBig nOverallLength = 0;
     GUIntBig nCurOffset = 0;
@@ -140,6 +142,15 @@ class VSISparseFileFilesystemHandler : public VSIFilesystemHandler
 /************************************************************************/
 
 /************************************************************************/
+/*                        ~VSISparseFileHandle()                        */
+/************************************************************************/
+
+VSISparseFileHandle::~VSISparseFileHandle()
+{
+    VSISparseFileHandle::Close();
+}
+
+/************************************************************************/
 /*                               Close()                                */
 /************************************************************************/
 
@@ -151,6 +162,7 @@ int VSISparseFileHandle::Close()
         if (aoRegions[i].fp != nullptr)
             CPL_IGNORE_RET_VAL(VSIFCloseL(aoRegions[i].fp));
     }
+    aoRegions.clear();
 
     return 0;
 }

--- a/port/cpl_vsil_unix_stdio_64.cpp
+++ b/port/cpl_vsil_unix_stdio_64.cpp
@@ -222,6 +222,7 @@ class VSIUnixStdioHandle final : public VSIVirtualHandle
   public:
     VSIUnixStdioHandle(VSIUnixStdioFilesystemHandler *poFSIn, FILE *fpIn,
                        bool bReadOnlyIn, bool bModeAppendReadWriteIn);
+    ~VSIUnixStdioHandle() override;
 
     int Seek(vsi_l_offset nOffsetIn, int nWhence) override;
     vsi_l_offset Tell() override;
@@ -265,6 +266,15 @@ VSIUnixStdioHandle::VSIUnixStdioHandle(
       poFS(poFSIn)
 #endif
 {
+}
+
+/************************************************************************/
+/*                         ~VSIUnixStdioHandle()                        */
+/************************************************************************/
+
+VSIUnixStdioHandle::~VSIUnixStdioHandle()
+{
+    VSIUnixStdioHandle::Close();
 }
 
 /************************************************************************/

--- a/port/cpl_vsil_win32.cpp
+++ b/port/cpl_vsil_win32.cpp
@@ -97,6 +97,7 @@ class VSIWin32Handle final : public VSIVirtualHandle
     bool m_bWriteThrough = false;
 
     VSIWin32Handle() = default;
+    ~VSIWin32Handle() override;
 
     int Seek(vsi_l_offset nOffset, int nWhence) override;
     vsi_l_offset Tell() override;
@@ -217,6 +218,15 @@ static int ErrnoFromGetLastError(DWORD dwError = 0)
     CPLAssert(0 <= err);
 
     return err;
+}
+
+/************************************************************************/
+/*                          ~VSIWin32Handle()                           */
+/************************************************************************/
+
+VSIWin32Handle::~VSIWin32Handle()
+{
+    VSIWin32Handle::Close();
 }
 
 /************************************************************************/


### PR DESCRIPTION
Backport #12687
 **Authored by:** @rouault