### PR TITLE
PNG: fix caching of other bands that only worked if reading band 1

### DIFF
--- a/frmts/png/pngdataset.h
+++ b/frmts/png/pngdataset.h
@@ -115,6 +115,7 @@ class PNGDataset final : public GDALPamDataset
     void LoadICCProfile();
 
     bool m_bByteOrderIsLittleEndian = false;
+    bool m_bHasRewind = false;
 
     static void WriteMetadataAsText(jmp_buf sSetJmpContext, png_structp hPNG,
                                     png_infop psPNGInfo, const char *pszKey,


### PR DESCRIPTION
But when resampling we read alpha band first, and thus that would cause decompression to restart for resampling kernels such as Lanczos.

Fixes #12713
