### PR TITLE
Doc: Add GTFS examples

### DIFF
--- a/doc/source/drivers/vector/gtfs.rst
+++ b/doc/source/drivers/vector/gtfs.rst
@@ -39,8 +39,65 @@ Driver capabilities
 
 .. supports_virtualio::
 
+Examples
+--------
+
+List the contents of a GTFS local zip file:
+
+.. tabs::
+
+   .. code-tab:: bash
+
+        ogrinfo GTFS_Realtime.zip
+
+   .. code-tab:: bash gdal CLI
+
+        gdal vector info GTFS_Realtime.zip
+
+List the contents of a GTFS local directory:
+
+.. tabs::
+
+   .. code-tab:: bash
+
+        # specifying the driver
+        ogrinfo GTFS:"/data/GTFS_Realtime"
+        # specifying the input format
+        ogrinfo /data/GTFS_Realtime -if GTFS
+
+   .. code-tab:: bash gdal CLI
+
+        # specifying the driver
+        gdal vector info GTFS:"/data/GTFS_Realtime"
+        # specifying the input format
+        gdal vector info /data/GTFS_Realtime --input-format GTFS
+
+List the contents of a GTFS file at a URL:
+
+.. tabs::
+
+   .. code-tab:: bash
+
+        ogrinfo /vsicurl/https://www.transportforireland.ie/transitData/Data/GTFS_Realtime.zip
+
+   .. code-tab:: bash gdal CLI
+
+        gdal vector info /vsicurl/https://www.transportforireland.ie/transitData/Data/GTFS_Realtime.zip
+
+Extract the stops from the GTFS file and save into a FlatGeobuf file:
+
+.. tabs::
+
+   .. code-tab:: bash
+
+        ogr2ogr -f "FlatGeobuf" stops.fgb GTFS_Realtime.zip stops
+
+   .. code-tab:: bash gdal CLI
+
+        gdal vector convert GTFS_Realtime.zip stops.fgb --input-layer stops
 
 Links
 -----
 
 -  `GTFS Wikipedia page <https://en.wikipedia.org/wiki/GTFS>`__
+-  `GTFS.org <https://gtfs.org>`__


### PR DESCRIPTION
Adds GTFS example to the driver page, for both "traditional" and CLI usage. Thoughts on using the tabs for this approach welcome. 

![image](https://github.com/user-attachments/assets/691d746d-e6ab-43aa-ac09-06b224afa394)

One difference between the traditinal and new approaches is the the CLI reports all error and warnings by default.

E.g. `ogrinfo /vsicurl/https://www.transportforireland.ie/transitData/Data/GTFS_Realtime.zip` just has output, whereas `gdal vector info /vsicurl/https://www.transportforireland.ie/transitData/Data/GTFS_Realtime.zip` lists all errors (which seem to be real errors). 

There doesn't appear to be a way to control this (either to add to the traditional ogr2ogr or to suppress in the CLI). 
