### PR TITLE
KMLSuperOverlay: fix creating datasets using extended-length path on Windows

### DIFF
--- a/frmts/kmlsuperoverlay/kmlsuperoverlaydataset.cpp
+++ b/frmts/kmlsuperoverlay/kmlsuperoverlaydataset.cpp
@@ -824,6 +824,9 @@ KmlSuperOverlayCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
         currentTiles;
     std::pair<int, int> childXYKey;
     std::pair<int, int> parentXYKey;
+
+    const char *pszPathSep = VSIGetDirectorySeparator(outDir.c_str());
+
     for (zoom = maxzoom; zoom >= 0; --zoom)
     {
         const int rmaxxsize = tilexsize * (1 << (maxzoom - zoom));
@@ -836,7 +839,8 @@ KmlSuperOverlayCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
         zoomStr << zoom;
 
         std::string zoomDir = outDir;
-        zoomDir += "/" + zoomStr.str();
+        zoomDir += pszPathSep;
+        zoomDir += zoomStr.str();
         VSIMkdir(zoomDir.c_str(), 0775);
 
         for (int ix = 0; ix < xloop; ix++)
@@ -849,8 +853,10 @@ KmlSuperOverlayCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
             ixStr << ix;
 
             zoomDir = outDir;
-            zoomDir += "/" + zoomStr.str();
-            zoomDir += "/" + ixStr.str();
+            zoomDir += pszPathSep;
+            zoomDir += zoomStr.str();
+            zoomDir += pszPathSep;
+            zoomDir += ixStr.str();
             VSIMkdir(zoomDir.c_str(), 0775);
 
             for (int iy = 0; iy < yloop; iy++)
@@ -895,7 +901,10 @@ KmlSuperOverlayCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
                 {
                     fileExt = ".png";
                 }
-                std::string filename = zoomDir + "/" + iyStr.str() + fileExt;
+                std::string filename = zoomDir;
+                filename += pszPathSep;
+                filename += iyStr.str();
+                filename += fileExt;
                 if (isKmz)
                 {
                     fileVector.push_back(filename);
@@ -904,7 +913,10 @@ KmlSuperOverlayCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
                 GenerateTiles(filename, zoom, rxsize, rysize, ix, iy, rx, ry,
                               dxsize, dysize, bands, poSrcDS,
                               poOutputTileDriver, isJpegDriver);
-                std::string childKmlfile = zoomDir + "/" + iyStr.str() + ".kml";
+                std::string childKmlfile = zoomDir;
+                childKmlfile += pszPathSep;
+                childKmlfile += iyStr.str();
+                childKmlfile += ".kml";
                 if (isKmz)
                 {
                     fileVector.push_back(childKmlfile);


### PR DESCRIPTION
Fixes #12601
