### PR TITLE
gdal_footprint: fail if there is a simplification error and there is a single input feature

### DIFF
--- a/apps/gdal_footprint_lib.cpp
+++ b/apps/gdal_footprint_lib.cpp
@@ -1131,9 +1131,38 @@ static bool GDALFootprintProcess(GDALDataset *poSrcDS, OGRLayer *poDstLayer,
                 continue;
         }
 
+        const auto DoSimplification = [&poMemLayer, &poGeom](double dfTolerance)
+        {
+            std::string osLastErrorMsg;
+            {
+                CPLErrorStateBackuper oBackuper(CPLQuietErrorHandler);
+                CPLErrorReset();
+                poGeom.reset(poGeom->Simplify(dfTolerance));
+                osLastErrorMsg = CPLGetLastErrorMsg();
+            }
+            if (!poGeom || poGeom->IsEmpty())
+            {
+                if (poMemLayer->GetFeatureCount(false) == 1)
+                {
+                    if (!osLastErrorMsg.empty())
+                        CPLError(CE_Failure, CPLE_AppDefined, "%s",
+                                 osLastErrorMsg.c_str());
+                    else
+                        CPLError(CE_Failure, CPLE_AppDefined,
+                                 "Simplification resulted in empty geometry");
+                    return false;
+                }
+                if (!osLastErrorMsg.empty())
+                    CPLError(CE_Warning, CPLE_AppDefined, "%s",
+                             osLastErrorMsg.c_str());
+            }
+            return true;
+        };
+
         if (psOptions->dfSimplifyTolerance != 0)
         {
-            poGeom.reset(poGeom->Simplify(psOptions->dfSimplifyTolerance));
+            if (!DoSimplification(psOptions->dfSimplifyTolerance))
+                return false;
             if (!poGeom || poGeom->IsEmpty())
                 continue;
         }
@@ -1172,7 +1201,9 @@ static bool GDALFootprintProcess(GDALDataset *poSrcDS, OGRLayer *poDstLayer,
                     tolMin = tol;
                 }
             }
-            poGeom.reset(poGeom->Simplify(tolMax));
+
+            if (!DoSimplification(tolMax))
+                return false;
             if (!poGeom || poGeom->IsEmpty())
                 continue;
         }


### PR DESCRIPTION
Fixes #12724

(I couldn't come up with a test case to reproduce the situation of the initial issue)