### PR TITLE
fix typo in clean-collar docs

### DIFF
--- a/doc/source/programs/gdal_raster_clean_collar.rst
+++ b/doc/source/programs/gdal_raster_clean_collar.rst
@@ -62,17 +62,17 @@ Standard options
     this number of pixels.
     Defaults to 2.
 
-.. option:: --addalpha
+.. option:: --add-alpha
 
     Adds an alpha band to the output file.
     The alpha band is set to 0 in the image collar and to 255 elsewhere.
-    This option is mutually exclusive with :option:`--addmask`.
+    This option is mutually exclusive with :option:`--add-mask`.
 
-.. option:: --addmask
+.. option:: --add-mask
 
     Adds a mask band to the output file,
     The mask band is set to 0 in the image collar and to 255 elsewhere.
-    This option is mutually exclusive with :option:`--addalpha`.
+    This option is mutually exclusive with :option:`--add-alpha`.
 
 .. option:: --algorithm floodfill|twopasses
 
@@ -108,4 +108,4 @@ Examples
 
    .. code-block:: bash
 
-        $ gdal raster clean-collar --addalpha --color=black --color=white --color-threshold=5 in.tif out.tif
+        $ gdal raster clean-collar --add-alpha --color=black --color=white --color-threshold=5 in.tif out.tif


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

fix some typos in gdal raster clean-collar docs.
it should be **--add-alpha** and **--add-mask** instead of **--addalpha** and **--addmask**

<img width="1548" height="495" alt="image" src="https://github.com/user-attachments/assets/870f3592-c979-48ed-9ac4-0026f6e7bdf6" />
