### PR TITLE
gdal vector info: add --check-valid-geometry and --check-valid-coverage

### DIFF
--- a/apps/gdalalg_vector_info.cpp
+++ b/apps/gdalalg_vector_info.cpp
@@ -45,6 +45,11 @@ GDALVectorInfoAlgorithm::GDALVectorInfoAlgorithm()
     AddArg("summary", 0, _("List the layer names and the geometry type"),
            &m_summaryOnly)
         .SetMutualExclusionGroup("summary-features");
+    AddArg("check-valid-geometry", 0, _("Check the validity of geometries"),
+           &m_checkValidGeometry);
+    AddArg("check-valid-coverage", 0,
+           _("Check whether layer geometries form a valid polygonal coverage"),
+           &m_checkValidCoverage);
     AddArg("sql", 0,
            _("Execute the indicated SQL statement and return the result"),
            &m_sql)
@@ -125,6 +130,16 @@ bool GDALVectorInfoAlgorithm::RunImpl(GDALProgressFunc, void *)
     if (m_stdout)
     {
         aosOptions.AddString("-stdout");
+    }
+
+    if (m_checkValidGeometry)
+    {
+        aosOptions.AddString("-check-valid-geometry");
+    }
+
+    if (m_checkValidCoverage)
+    {
+        aosOptions.AddString("-check-valid-coverage");
     }
 
     // Must be last, as positional

--- a/apps/gdalalg_vector_info.h
+++ b/apps/gdalalg_vector_info.h
@@ -57,6 +57,8 @@ class GDALVectorInfoAlgorithm final : public GDALAlgorithm
     std::string m_where{};
     std::string m_dialect{};
     std::string m_output{};
+    bool m_checkValidGeometry{false};
+    bool m_checkValidCoverage{false};
 };
 
 //! @endcond

--- a/doc/source/programs/gdal_vector_info.rst
+++ b/doc/source/programs/gdal_vector_info.rst
@@ -48,6 +48,15 @@ Standard options
     JSON output.
     This option is mutually exclusive with the :option:`--summary` option.
 
+.. option:: --check-valid-geometry
+
+    Report the number of invalid geometries in each inspected layer.
+
+.. option:: --check-valid-coverage
+
+    Report whether each inspected layer forms a valid polygonal coverage.
+    Requires a GDAL build with version 3.12 or later of the GEOS library.
+
 .. option:: --sql <statement>|@<filename>
 
     Execute the indicated SQL statement and return the result. The

--- a/ogr/ogr_geometry.h
+++ b/ogr/ogr_geometry.h
@@ -3094,6 +3094,8 @@ class CPL_DLL OGRGeometryCollection : public OGRGeometry
     bool hasEmptyParts() const override;
     void removeEmptyParts() override;
 
+    bool IsValidCoverage() const;
+
     virtual void
     assignSpatialReference(const OGRSpatialReference *poSR) override;
 


### PR DESCRIPTION
Still needs some tests. Does adding this to `gdal vector info` / `ogrinfo` seem like a reasonable idea?

cc @dr-jts