### PR TITLE
CPL AWS: Fix sso cache file location and region parameter (Fixes #12064)

### DIFF
--- a/port/cpl_aws.cpp
+++ b/port/cpl_aws.cpp
@@ -1185,7 +1185,8 @@ bool VSIS3HandleHelper::GetConfigurationFromAWSConfigFiles(
     std::string &osSourceProfile, std::string &osExternalId,
     std::string &osMFASerial, std::string &osRoleSessionName,
     std::string &osWebIdentityTokenFile, std::string &osSSOStartURL,
-    std::string &osSSOAccountID, std::string &osSSORoleName)
+    std::string &osSSOAccountID, std::string &osSSORoleName,
+    std::string &osSSOSession)
 {
     // See http://docs.aws.amazon.com/cli/latest/userguide/cli-config-files.html
     // If AWS_DEFAULT_PROFILE is set (obsolete, no longer documented), use it in
@@ -1245,7 +1246,6 @@ bool VSIS3HandleHelper::GetConfigurationFromAWSConfigFiles(
         const char *pszLine;
         std::map<std::string, std::map<std::string, std::string>>
             oMapSSOSessions;
-        std::string osSSOSession;
         while ((pszLine = CPLReadLineL(fp)) != nullptr)
         {
             if (STARTS_WITH(pszLine, "[sso-session ") &&
@@ -1510,6 +1510,7 @@ static bool GetTemporaryCredentialsForRole(
 
 // Issue a GetRoleCredentials request
 static bool GetTemporaryCredentialsForSSO(const std::string &osSSOStartURL,
+                                          const std::string &osSSOSession,
                                           const std::string &osSSOAccountID,
                                           const std::string &osSSORoleName,
                                           std::string &osTempSecretAccessKey,
@@ -1524,8 +1525,14 @@ static bool GetTemporaryCredentialsForSSO(const std::string &osSSOStartURL,
     osSSOFilename += "cache";
     osSSOFilename += GetDirSeparator();
 
+    std::string hashValue = osSSOStartURL;
+    if (!osSSOSession.empty())
+    {
+        hashValue = osSSOSession;
+    }
+
     GByte hash[CPL_SHA1_HASH_SIZE];
-    CPL_SHA1(osSSOStartURL.data(), osSSOStartURL.size(), hash);
+    CPL_SHA1(hashValue.data(), hashValue.size(), hash);
     osSSOFilename += CPLGetLowerCaseHex(hash, sizeof(hash));
     osSSOFilename += ".json";
 
@@ -1580,9 +1587,13 @@ static bool GetTemporaryCredentialsForSSO(const std::string &osSSOStartURL,
     headers += "x-amz-sso_bearer_token: " + osAccessToken;
     aosOptions.AddNameValue("HEADERS", headers.c_str());
 
+    const std::string osRegion = oRoot.GetString("region", "us-east-1");
+    const std::string osDefaultHost("portal.sso." + osRegion +
+        ".amazonaws.com");
+
     const bool bUseHTTPS = CPLTestBool(CPLGetConfigOption("AWS_HTTPS", "YES"));
     const std::string osHost(CPLGetConfigOption(
-        "CPL_AWS_SSO_ENDPOINT", "portal.sso.us-east-1.amazonaws.com"));
+        "CPL_AWS_SSO_ENDPOINT", osDefaultHost.c_str()));
 
     const std::string osURL = (bUseHTTPS ? "https://" : "http://") + osHost +
                               osResourceAndQueryString;
@@ -1714,7 +1725,7 @@ bool VSIS3HandleHelper::GetOrRefreshTemporaryCredentialsForSSO(
         gosGlobalAccessKeyId.clear();
         gosGlobalSessionToken.clear();
         if (GetTemporaryCredentialsForSSO(
-                gosSSOStartURL, gosSSOAccountID, gosSSORoleName,
+                gosSSOStartURL, "", gosSSOAccountID, gosSSORoleName,
                 gosGlobalSecretAccessKey, gosGlobalAccessKeyId,
                 gosGlobalSessionToken, osExpirationEpochInMS))
         {
@@ -1817,6 +1828,7 @@ bool VSIS3HandleHelper::GetConfiguration(
     std::string osSSOStartURL;
     std::string osSSOAccountID;
     std::string osSSORoleName;
+    std::string osSSOSession;
     // coverity[tainted_data]
     if (GetConfigurationFromAWSConfigFiles(
             osPathForOption,
@@ -1824,7 +1836,7 @@ bool VSIS3HandleHelper::GetConfiguration(
             osSessionToken, osRegion, osCredentials, osRoleArn, osSourceProfile,
             osExternalId, osMFASerial, osRoleSessionName,
             osWebIdentityTokenFile, osSSOStartURL, osSSOAccountID,
-            osSSORoleName))
+            osSSORoleName, osSSOSession))
     {
         if (osSecretAccessKey.empty() && !osRoleArn.empty())
         {
@@ -1851,7 +1863,8 @@ bool VSIS3HandleHelper::GetConfiguration(
                         osRegionSP, osCredentialsSP, osRoleArnSP,
                         osSourceProfileSP, osExternalIdSP, osMFASerialSP,
                         osRoleSessionNameSP, osWebIdentityTokenFile,
-                        osSSOStartURLSP, osSSOAccountIDSP, osSSORoleNameSP))
+                        osSSOStartURLSP, osSSOAccountIDSP, osSSORoleNameSP, 
+                        osSSOSession))
                 {
                     if (GetConfigurationFromAssumeRoleWithWebIdentity(
                             /* bForceRefresh = */ false, osPathForOption,
@@ -1922,14 +1935,14 @@ bool VSIS3HandleHelper::GetConfiguration(
             return false;
         }
 
-        if (!osSSOStartURL.empty())
+        if (!osSSOStartURL.empty() || !osSSOSession.empty())
         {
             std::string osTempSecretAccessKey;
             std::string osTempAccessKeyId;
             std::string osTempSessionToken;
             std::string osExpirationEpochInMS;
             if (GetTemporaryCredentialsForSSO(
-                    osSSOStartURL, osSSOAccountID, osSSORoleName,
+                    osSSOStartURL, osSSOSession, osSSOAccountID, osSSORoleName,
                     osTempSecretAccessKey, osTempAccessKeyId,
                     osTempSessionToken, osExpirationEpochInMS))
             {

--- a/port/cpl_aws.h
+++ b/port/cpl_aws.h
@@ -183,7 +183,8 @@ class VSIS3HandleHelper final : public IVSIS3LikeHandleHelper
         std::string &osSourceProfile, std::string &osExternalId,
         std::string &osMFASerial, std::string &osRoleSessionName,
         std::string &osWebIdentityTokenFile, std::string &osSSOStartURL,
-        std::string &osSSOAccountID, std::string &osSSORoleName);
+        std::string &osSSOAccountID, std::string &osSSORoleName,
+        std::string &osSSOSession);
 
     static bool GetConfiguration(const std::string &osPathForOption,
                                  CSLConstList papszOptions,


### PR DESCRIPTION
Needed to wire through the profile name from the config, then use that for the file name hash rather than the start url if it exists. This makes it match the way boto3 (the aws python library) does it.

Also pulled the region out of the cache file and used that when building the token url as the old way only worked if your AWS account was based in US-east-1

## What does this PR do?

Make the code that finds the AWS SSO Cache locate the correct file when using profile names. The code now should match the way boto3 works. https://github.com/boto/botocore/blob/master/botocore/utils.py#L3356 

It also uses the region parameter from the cache file to make sure it goes to the correct region when asking for the token.

## What are related issues/pull requests?

https://github.com/OSGeo/gdal/issues/12064



## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

I couldn't find any tests around this functionality already so wasn't sure where to create them. If someone can point me at the right location for the tests then I'll be happy to add some.