### PR TITLE
CMake Java: restore -fno-strict-aliasing

### DIFF
--- a/swig/java/CMakeLists.txt
+++ b/swig/java/CMakeLists.txt
@@ -5,6 +5,14 @@ if (CMAKE_CXX_FLAGS)
   string(REPLACE "/WX " " " CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ")
 endif ()
 
+# Do not remove -fno-strict-aliasing while SWIG generates weird code in upcast methods
+# http://trac.osgeo.org/gdal/changeset/16006
+#
+# https://swig.org//Doc4.3/Java.html#Java_compiling_dynamic
+if (NOT MSVC)
+  add_compile_options("-fno-strict-aliasing")
+endif()
+
 list(APPEND GDAL_SWIG_COMMON_INTERFACE_FILES
    ${PROJECT_SOURCE_DIR}/swig/include/java/callback.i
    ${PROJECT_SOURCE_DIR}/swig/include/java/gdalconst_java.i


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?
Restore -fno-strict-aliasing to the java swig bindings, it was dropped again at some time point in the cmake transition. It's still recommended by swig documentation to have this flag.

https://swig.org//Doc4.3/Java.html#Java_compiling_dynamic

## What are related issues/pull requests?
https://bugs.gentoo.org/948810

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS: Gentoo Linux amd64
* Compiler: gcc (Gentoo 15.1.1_p20250705-r1 p2) 15.1.1 20250705

