### PR TITLE
[Backport release/3.11] CMake: fix checks for CMAKE_SYSTEM_PROCESSOR on non Windows platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,7 @@ endif()
 include(Ccache)
 
 #
-if ("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "(x86|AMD64)")
+if ("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "(i586|i686|x86|AMD64)")
   check_compiler_machine_option(flag SSE)
   if (NOT ${flag} STREQUAL "")
     set(HAVE_SSE_AT_COMPILE_TIME 1)

--- a/cmake/helpers/CheckCompilerMachineOption.cmake
+++ b/cmake/helpers/CheckCompilerMachineOption.cmake
@@ -31,7 +31,7 @@ function(check_compiler_machine_option outvar feature)
   endmacro()
 
   set(_FLAGS)
-  if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "(x86|AMD64)")
+  if("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "(i586|i686|x86|AMD64)")
     if(MSVC AND (${feature} MATCHES "SSE"))
       # SSE2 and SSE are default on
       set(_FLAGS " ")
@@ -100,7 +100,7 @@ function(check_compiler_machine_option outvar feature)
         endif()
       endif()
     endif()
-  elseif("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "(ARM|aarch64)")
+  elseif("${CMAKE_SYSTEM_PROCESSOR}" MATCHES "(arm|ARM|aarch64)")
     if(MSVC)
       # TODO implement me
     elseif(CMAKE_CXX_COMPILER MATCHES "/(icpc|icc)$") # ICC (on Linux)


### PR DESCRIPTION
Backport #12771
 **Authored by:** @parona-source