### PR TITLE
[Backport release/3.11] gdalmdiminfo: fix crash on a null string attribute

### DIFF
--- a/apps/gdalmdiminfo_lib.cpp
+++ b/apps/gdalmdiminfo_lib.cpp
@@ -353,6 +353,10 @@ static void DumpAttrValue(const std::shared_ptr<GDALAttribute> &attr,
                         serializer.Add(pszStr);
                     }
                 }
+                else
+                {
+                    serializer.AddNull();
+                }
             }
             else
             {

--- a/autotest/utilities/test_gdalmdiminfo_lib.py
+++ b/autotest/utilities/test_gdalmdiminfo_lib.py
@@ -288,3 +288,22 @@ def test_gdalmdiminfo_lib_uint64():
 
     ret = gdal.MultiDimInfo(ds, detailed=True)
     assert ret["arrays"]["ar"]["values"] == [10000000000]
+
+
+###############################################################################
+
+
+def test_gdalmdiminfo_lib_null_string():
+
+    drv = gdal.GetDriverByName("MEM")
+    ds = drv.CreateMultiDimensional("")
+    rg = ds.GetRootGroup()
+    rg.CreateAttribute("null_string", [], gdal.ExtendedDataType.CreateString())
+
+    ret = gdal.MultiDimInfo(ds)
+    assert ret == {
+        "type": "group",
+        "driver": "MEM",
+        "name": "/",
+        "attributes": {"null_string": None},
+    }


### PR DESCRIPTION
Backport #12791
 **Authored by:** @rouault