### PR TITLE
 Zarr: make GDALDataset::Close() report errors when write failure occurs

### DIFF
--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -4744,10 +4744,10 @@ def test_zarr_multidim_rename_group_after_reopening(
     "format,create_z_metadata",
     [("ZARR_V2", "YES"), ("ZARR_V2", "NO"), ("ZARR_V3", "NO")],
 )
-def test_zarr_multidim_rename_array_at_creation(tmp_vsimem, format, create_z_metadata):
+def test_zarr_multidim_rename_array_at_creation(tmp_path, format, create_z_metadata):
 
     drv = gdal.GetDriverByName("ZARR")
-    filename = str(tmp_vsimem / "test.zarr")
+    filename = str(tmp_path / "test.zarr")
 
     def test():
         ds = drv.CreateMultiDimensional(
@@ -5799,3 +5799,20 @@ def test_zarr_write_error_at_close_on_array(tmp_path, format):
 
     with pytest.raises(Exception, match="cannot be opened for writing"):
         ds.Close()
+
+
+###############################################################################
+#
+
+
+@gdaltest.enable_exceptions()
+@pytest.mark.parametrize("format", ["ZARR_V2", "ZARR_V3"])
+def test_zarr_write_vsizip(tmp_vsimem, format):
+    out_filename = "/vsizip/" + str(tmp_vsimem) + "test.zarr.zip/test.zarr"
+
+    gdal.GetDriverByName("Zarr").CreateCopy(
+        out_filename, gdal.Open("data/byte.tif"), options=["FORMAT=" + format]
+    )
+
+    ds = gdal.Open(out_filename)
+    assert ds.GetMetadata() == {"AREA_OR_POINT": "Area"}

--- a/frmts/zarr/zarr_group.cpp
+++ b/frmts/zarr/zarr_group.cpp
@@ -24,13 +24,27 @@
 
 ZarrGroupBase::~ZarrGroupBase()
 {
-    // We need to explicitly flush arrays so that the _ARRAY_DIMENSIONS
-    // is properly written. As it relies on checking if the dimensions of the
-    // array have an indexing variable, then still need to be all alive.
+    ZarrGroupBase::Close();
+}
+
+/************************************************************************/
+/*                            Close()                                   */
+/************************************************************************/
+
+bool ZarrGroupBase::Close()
+{
+    bool ret = true;
+
+    for (auto &kv : m_oMapGroups)
+    {
+        ret = kv.second->Close() && ret;
+    }
+
     for (auto &kv : m_oMapMDArrays)
     {
-        kv.second->Flush();
+        ret = kv.second->Flush() && ret;
     }
+    return ret;
 }
 
 /************************************************************************/

--- a/frmts/zarr/zarr_v2_group.cpp
+++ b/frmts/zarr/zarr_v2_group.cpp
@@ -40,15 +40,28 @@ ZarrV2Group::Create(const std::shared_ptr<ZarrSharedResource> &poSharedResource,
 
 ZarrV2Group::~ZarrV2Group()
 {
+    ZarrV2Group::Close();
+}
+
+/************************************************************************/
+/*                            Close()                                   */
+/************************************************************************/
+
+bool ZarrV2Group::Close()
+{
+    bool bRet = ZarrGroupBase::Close();
+
     if (m_bValid && m_oAttrGroup.IsModified())
     {
         CPLJSONDocument oDoc;
         oDoc.SetRoot(m_oAttrGroup.Serialize());
         const std::string osAttrFilename =
             CPLFormFilenameSafe(m_osDirectoryName.c_str(), ".zattrs", nullptr);
-        oDoc.Save(osAttrFilename);
+        bRet = oDoc.Save(osAttrFilename) && bRet;
         m_poSharedResource->SetZMetadataItem(osAttrFilename, oDoc.GetRoot());
     }
+
+    return bRet;
 }
 
 /************************************************************************/
@@ -1126,7 +1139,8 @@ std::shared_ptr<GDALMDArray> ZarrV2Group::CreateMDArray(
     poArray->SetFilters(oFilters);
     poArray->SetUpdatable(true);
     poArray->SetDefinitionModified(true);
-    poArray->Flush();
+    if (!poArray->Flush())
+        return nullptr;
     RegisterArray(poArray);
 
     return poArray;

--- a/frmts/zarr/zarr_v2_group.cpp
+++ b/frmts/zarr/zarr_v2_group.cpp
@@ -1139,7 +1139,7 @@ std::shared_ptr<GDALMDArray> ZarrV2Group::CreateMDArray(
     poArray->SetFilters(oFilters);
     poArray->SetUpdatable(true);
     poArray->SetDefinitionModified(true);
-    if (!poArray->Flush())
+    if (!cpl::starts_with(osZarrayFilename, "/vsi") && !poArray->Flush())
         return nullptr;
     RegisterArray(poArray);
 

--- a/frmts/zarr/zarr_v3_array.cpp
+++ b/frmts/zarr/zarr_v3_array.cpp
@@ -74,12 +74,12 @@ ZarrV3Array::~ZarrV3Array()
 /*                                Flush()                               */
 /************************************************************************/
 
-void ZarrV3Array::Flush()
+bool ZarrV3Array::Flush()
 {
     if (!m_bValid)
-        return;
+        return true;
 
-    ZarrV3Array::FlushDirtyTile();
+    bool ret = ZarrV3Array::FlushDirtyTile();
 
     if (!m_aoDims.empty())
     {
@@ -112,16 +112,19 @@ void ZarrV3Array::Flush()
 
     if (m_bDefinitionModified)
     {
-        Serialize(oAttrs);
+        if (!Serialize(oAttrs))
+            ret = false;
         m_bDefinitionModified = false;
     }
+
+    return ret;
 }
 
 /************************************************************************/
 /*                    ZarrV3Array::Serialize()                          */
 /************************************************************************/
 
-void ZarrV3Array::Serialize(const CPLJSONObject &oAttrs)
+bool ZarrV3Array::Serialize(const CPLJSONObject &oAttrs)
 {
     CPLJSONDocument oDoc;
     CPLJSONObject oRoot = oDoc.GetRoot();
@@ -238,7 +241,7 @@ void ZarrV3Array::Serialize(const CPLJSONObject &oAttrs)
 
     // TODO: codecs
 
-    oDoc.Save(m_osFilename);
+    return oDoc.Save(m_osFilename);
 }
 
 /************************************************************************/

--- a/frmts/zarr/zarr_v3_group.cpp
+++ b/frmts/zarr/zarr_v3_group.cpp
@@ -729,7 +729,7 @@ std::shared_ptr<GDALMDArray> ZarrV3Group::CreateMDArray(
         poArray->SetCodecs(std::move(poCodecs));
     poArray->SetUpdatable(true);
     poArray->SetDefinitionModified(true);
-    if (!poArray->Flush())
+    if (!cpl::starts_with(osFilename, "/vsi") && !poArray->Flush())
         return nullptr;
     RegisterArray(poArray);
 

--- a/frmts/zarr/zarr_v3_group.cpp
+++ b/frmts/zarr/zarr_v3_group.cpp
@@ -181,6 +181,17 @@ ZarrV3Group::ZarrV3Group(
 
 ZarrV3Group::~ZarrV3Group()
 {
+    ZarrV3Group::Close();
+}
+
+/************************************************************************/
+/*                            Close()                                   */
+/************************************************************************/
+
+bool ZarrV3Group::Close()
+{
+    bool bRet = ZarrGroupBase::Close();
+
     if (m_bValid && m_oAttrGroup.IsModified())
     {
         CPLJSONDocument oDoc;
@@ -190,8 +201,10 @@ ZarrV3Group::~ZarrV3Group()
         oRoot.Add("attributes", m_oAttrGroup.Serialize());
         const std::string osZarrJsonFilename = CPLFormFilenameSafe(
             m_osDirectoryName.c_str(), "zarr.json", nullptr);
-        oDoc.Save(osZarrJsonFilename);
+        bRet = oDoc.Save(osZarrJsonFilename) && bRet;
     }
+
+    return bRet;
 }
 
 /************************************************************************/
@@ -716,7 +729,8 @@ std::shared_ptr<GDALMDArray> ZarrV3Group::CreateMDArray(
         poArray->SetCodecs(std::move(poCodecs));
     poArray->SetUpdatable(true);
     poArray->SetDefinitionModified(true);
-    poArray->Flush();
+    if (!poArray->Flush())
+        return nullptr;
     RegisterArray(poArray);
 
     return poArray;

--- a/frmts/zarr/zarrdriver.cpp
+++ b/frmts/zarr/zarrdriver.cpp
@@ -30,7 +30,7 @@
 /*                            ZarrDataset()                             */
 /************************************************************************/
 
-ZarrDataset::ZarrDataset(const std::shared_ptr<GDALGroup> &poRootGroup)
+ZarrDataset::ZarrDataset(const std::shared_ptr<ZarrGroupBase> &poRootGroup)
     : m_poRootGroup(poRootGroup)
 {
 }
@@ -1407,6 +1407,11 @@ ZarrDataset::~ZarrDataset()
 CPLErr ZarrDataset::FlushCache(bool bAtClosing)
 {
     CPLErr eErr = GDALDataset::FlushCache(bAtClosing);
+    if (m_poRootGroup)
+    {
+        if (!m_poRootGroup->Close())
+            eErr = CE_Failure;
+    }
     if (m_poSingleArray)
     {
         bool bFound = false;
@@ -1443,6 +1448,15 @@ CPLErr ZarrDataset::FlushCache(bool bAtClosing)
         }
     }
     return eErr;
+}
+
+/************************************************************************/
+/*                          GetRootGroup()                              */
+/************************************************************************/
+
+std::shared_ptr<GDALGroup> ZarrDataset::GetRootGroup() const
+{
+    return m_poRootGroup;
 }
 
 /************************************************************************/

--- a/port/cpl_json.cpp
+++ b/port/cpl_json.cpp
@@ -116,18 +116,18 @@ bool CPLJSONDocument::Save(const std::string &osPath) const
     VSILFILE *fp = VSIFOpenL(osPath.c_str(), "wt");
     if (nullptr == fp)
     {
-        CPLError(CE_Failure, CPLE_NoWriteAccess, "Open file %s to write failed",
-                 osPath.c_str());
+        CPLError(CE_Failure, CPLE_NoWriteAccess,
+                 "File %s cannot be opened for writing", osPath.c_str());
         return false;
     }
 
     const char *pabyData = json_object_to_json_string_ext(
         TO_JSONOBJ(m_poRootJsonObject), JSON_C_TO_STRING_PRETTY);
-    VSIFWriteL(pabyData, 1, strlen(pabyData), fp);
+    bool bRet = VSIFWriteL(pabyData, strlen(pabyData), 1, fp) == 1;
 
-    VSIFCloseL(fp);
+    bRet = VSIFCloseL(fp) == 0 && bRet;
 
-    return true;
+    return bRet;
 }
 
 /**


### PR DESCRIPTION
and fix creating a /vsizip/ file
    
Fixes #12790
