### PR TITLE
[Backport release/3.11] gdalwarp: for TPS warping, use -wo SOURCE_EXTRA=5 by default

### DIFF
--- a/alg/gdalwarpoperation.cpp
+++ b/alg/gdalwarpoperation.cpp
@@ -3227,11 +3227,10 @@ CPLErr GDALWarpOperation::ComputeSourceWindow(
     /*      fallback to adding a bit to the window if any points failed     */
     /*      to transform.                                                   */
     /* -------------------------------------------------------------------- */
-    if (CSLFetchNameValue(psOptions->papszWarpOptions, "SOURCE_EXTRA") !=
-        nullptr)
+    if (const char *pszSoureExtra =
+            CSLFetchNameValue(psOptions->papszWarpOptions, "SOURCE_EXTRA"))
     {
-        const int nSrcExtra = atoi(
-            CSLFetchNameValue(psOptions->papszWarpOptions, "SOURCE_EXTRA"));
+        const int nSrcExtra = atoi(pszSoureExtra);
         nXRadius += nSrcExtra;
         nYRadius += nSrcExtra;
     }

--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -2698,13 +2698,8 @@ static GDALDatasetH GDALWarpDirect(const char *pszDest, GDALDatasetH hDstDS,
                     GDALGetDescription(hSrcDS));
         }
 
-        /* --------------------------------------------------------------------
-         */
-        /*      For RPC warping add a few extra source pixels by default */
-        /*      (probably mostly needed in the RPC DEM case) */
-        /* --------------------------------------------------------------------
-         */
-
+        // For RPC warping add a few extra source pixels by default
+        // (probably mostly needed in the RPC DEM case)
         if (iSrc == 0 && (GDALGetMetadata(hSrcDS, "RPC") != nullptr &&
                           (pszMethod == nullptr || EQUAL(pszMethod, "RPC"))))
         {
@@ -2723,6 +2718,19 @@ static GDALDatasetH GDALWarpDirect(const char *pszDest, GDALDatasetH hDstDS,
                 CPLDebug("WARP", "Set SAMPLE_STEPS=ALL warping options due to "
                                  "RPC DEM warping");
                 psOptions->aosWarpOptions.SetNameValue("SAMPLE_STEPS", "ALL");
+            }
+        }
+        // Also do the same for GCP TPS warping, e.g. to solve use case of
+        // https://github.com/OSGeo/gdal/issues/12736
+        else if (iSrc == 0 &&
+                 (GDALGetGCPCount(hSrcDS) > 0 &&
+                  (pszMethod == nullptr || EQUAL(pszMethod, "TPS"))))
+        {
+            if (!psOptions->aosWarpOptions.FetchNameValue("SOURCE_EXTRA"))
+            {
+                CPLDebug(
+                    "WARP",
+                    "Set SOURCE_EXTRA=5 warping options due to TPS warping");
             }
         }
 


### PR DESCRIPTION
Backport #12739
 **Authored by:** @rouault