### PR TITLE
[Backport release/3.11] GTIFF: fix creating a R,G,B,Nir file without explicit PHOTOMETRIC creation option

### DIFF
--- a/frmts/gtiff/gtiffrasterband_write.cpp
+++ b/frmts/gtiff/gtiffrasterband_write.cpp
@@ -465,12 +465,14 @@ CPLErr GTiffRasterBand::SetColorInterpretation(GDALColorInterp eInterp)
         }
     }
 
-    // Mark alpha band / undefined in extrasamples.
-    if (eInterp == GCI_AlphaBand || eInterp == GCI_Undefined)
+    // Mark non-RGB in extrasamples.
+    if (eInterp != GCI_RedBand && eInterp != GCI_GreenBand &&
+        eInterp != GCI_BlueBand)
     {
         uint16_t *v = nullptr;
         uint16_t count = 0;
-        if (TIFFGetField(m_poGDS->m_hTIFF, TIFFTAG_EXTRASAMPLES, &count, &v))
+        if (TIFFGetField(m_poGDS->m_hTIFF, TIFFTAG_EXTRASAMPLES, &count, &v) &&
+            count > 0)
         {
             const int nBaseSamples = m_poGDS->m_nSamplesPerPixel - count;
 


### PR DESCRIPTION
Backport #12778
 **Authored by:** @rouault