### PR TITLE
Add gdal vector clean-coverage

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -68,6 +68,7 @@ add_library(
   gdalalg_vector.cpp
   gdalalg_vector_info.cpp
   gdalalg_vector_clip.cpp
+  gdalalg_vector_clean_coverage.cpp
   gdalalg_vector_concat.cpp
   gdalalg_vector_convert.cpp
   gdalalg_vector_edit.cpp

--- a/apps/gdalalg_vector.cpp
+++ b/apps/gdalalg_vector.cpp
@@ -14,6 +14,7 @@
 
 #include "gdalalg_vector_info.h"
 #include "gdalalg_vector_buffer.h"
+#include "gdalalg_vector_clean_coverage.h"
 #include "gdalalg_vector_clip.h"
 #include "gdalalg_vector_concat.h"
 #include "gdalalg_vector_convert.h"
@@ -63,6 +64,7 @@ class GDALVectorAlgorithm final : public GDALAlgorithm
 
         RegisterSubAlgorithm<GDALVectorInfoAlgorithm>();
         RegisterSubAlgorithm<GDALVectorBufferAlgorithmStandalone>();
+        RegisterSubAlgorithm<GDALVectorCleanCoverageAlgorithmStandalone>();
         RegisterSubAlgorithm<GDALVectorClipAlgorithmStandalone>();
         RegisterSubAlgorithm<GDALVectorConcatAlgorithmStandalone>();
         RegisterSubAlgorithm<GDALVectorConvertAlgorithm>();

--- a/apps/gdalalg_vector_clean_coverage.h
+++ b/apps/gdalalg_vector_clean_coverage.h
@@ -1,0 +1,72 @@
+/******************************************************************************
+*
+ * Project:  GDAL
+ * Purpose:  "gdal vector clean-coverage"
+ * Author:   Daniel Baston
+ *
+ ******************************************************************************
+ * Copyright (c) 2025, ISciences LLC
+ *
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#ifndef GDALALG_VECTOR_CLEAN_COVERAGE_INCLUDED
+#define GDALALG_VECTOR_CLEAN_COVERAGE_INCLUDED
+
+#include "gdalalg_vector_pipeline.h"
+#include "cpl_progress.h"
+
+#include <string>
+
+//! @cond Doxygen_Suppress
+
+/************************************************************************/
+/*                     GDALVectorCleanCoverageAlgorithm                 */
+/************************************************************************/
+
+class GDALVectorCleanCoverageAlgorithm : public GDALVectorPipelineStepAlgorithm
+{
+  public:
+    static constexpr const char *NAME = "clean-coverage";
+    static constexpr const char *DESCRIPTION =
+        "Alter polygon boundaries to make shared edges identical, removing "
+        "gaps and overlaps";
+    static constexpr const char *HELP_URL =
+        "/programs/gdal_vector_clean_coverage.html";
+
+    explicit GDALVectorCleanCoverageAlgorithm(bool standaloneStep = false);
+
+    struct Options
+    {
+        double snappingTolerance = -1;
+        double maximumGapWidth = 0;
+        std::string mergeStrategy = "longest-border";
+    };
+
+  private:
+    bool RunStep(GDALPipelineStepRunContext &ctxt) override;
+
+    std::string m_activeLayer{};
+
+    Options m_opts{};
+};
+
+/************************************************************************/
+/*                 GDALVectorCleanCoverageAlgorithmStandalone           */
+/************************************************************************/
+
+class GDALVectorCleanCoverageAlgorithmStandalone final
+    : public GDALVectorCleanCoverageAlgorithm
+{
+  public:
+    GDALVectorCleanCoverageAlgorithmStandalone()
+        : GDALVectorCleanCoverageAlgorithm(/* standaloneStep = */ true)
+    {
+    }
+
+    ~GDALVectorCleanCoverageAlgorithmStandalone() override;
+};
+
+//! @endcond
+
+#endif /* GDALALG_VECTOR_CLEAN_COVERAGE_INCLUDED */

--- a/apps/gdalalg_vector_pipeline.cpp
+++ b/apps/gdalalg_vector_pipeline.cpp
@@ -13,6 +13,7 @@
 #include "gdalalg_vector_pipeline.h"
 #include "gdalalg_vector_read.h"
 #include "gdalalg_vector_buffer.h"
+#include "gdalalg_vector_clean_coverage.h"
 #include "gdalalg_vector_clip.h"
 #include "gdalalg_vector_concat.h"
 #include "gdalalg_vector_edit.h"
@@ -129,6 +130,7 @@ void GDALVectorPipelineAlgorithm::RegisterAlgorithms(
 
     registry.Register<GDALVectorBufferAlgorithm>();
     registry.Register<GDALVectorConcatAlgorithm>();
+    registry.Register<GDALVectorCleanCoverageAlgorithm>();
 
     algInfo.m_name = addSuffixIfNeeded(GDALVectorClipAlgorithm::NAME);
     algInfo.m_creationFunc = []() -> std::unique_ptr<GDALAlgorithm>

--- a/autotest/utilities/test_gdalalg_vector_clean_coverage.py
+++ b/autotest/utilities/test_gdalalg_vector_clean_coverage.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env pytest
+# -*- coding: utf-8 -*-
+###############################################################################
+# Project:  GDAL/OGR Test Suite
+# Purpose:  'gdal vector clean-coverage' testing
+# Author:   Daniel Baston
+#
+###############################################################################
+# Copyright (c) 2025, ISciences LLC
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+
+import gdaltest
+import pytest
+
+from osgeo import gdal, ogr, osr
+
+pytestmark = pytest.mark.require_geos(3, 14)
+
+
+@pytest.fixture()
+def alg():
+    return gdal.GetGlobalAlgorithmRegistry()["vector"]["clean-coverage"]
+
+
+@pytest.fixture()
+def circles():
+
+    ds = gdal.GetDriverByName("MEM").CreateVector("")
+    lyr = ds.CreateLayer(
+        "circles", osr.SpatialReference(epsg=32145), geom_type=ogr.wkbPolygon
+    )
+
+    geoms = []
+
+    g = ogr.Geometry(ogr.wkbPoint)
+    g.AddPoint(5, 5)
+    geoms.append(g.Buffer(5))
+
+    g = ogr.Geometry(ogr.wkbPoint)
+    g.AddPoint(10, 15)
+    geoms.append(g.Buffer(6.5))
+
+    g = ogr.Geometry(ogr.wkbPoint)
+    g.AddPoint(15, 5)
+    geoms.append(g.Buffer(5.1))
+
+    for geom in geoms:
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f.SetGeometry(geom)
+        lyr.CreateFeature(f)
+
+    return ds
+
+
+def test_gdalalg_vector_clean_coverage(alg, circles):
+
+    src_lyr = circles.GetLayer(0)
+
+    alg["input"] = circles
+    alg["output"] = ""
+    alg["output-format"] = "stream"
+
+    assert alg.Run()
+
+    dst_ds = alg["output"].GetDataset()
+    dst_lyr = dst_ds.GetLayer(0)
+
+    assert dst_lyr.GetFeatureCount() == src_lyr.GetFeatureCount()
+    assert dst_lyr.GetSpatialRef().IsSame(src_lyr.GetSpatialRef())
+
+    areas = [f.GetGeometryRef().GetArea() for f in dst_lyr]
+    assert areas == pytest.approx([77.85, 132.67, 80.82], abs=0.01)
+
+    assert alg.Finalize()
+
+
+@pytest.mark.parametrize(
+    "strategy", (None, "longest-border", "min-index", "max-area", "min-area")
+)
+def test_gdalalg_vector_clean_coverage_merge_strategy(alg, circles, strategy):
+
+    alg["input"] = circles
+    alg["output"] = ""
+    alg["output-format"] = "stream"
+
+    if strategy is not None:
+        alg["merge-strategy"] = strategy
+
+    assert alg.Run()
+
+    dst_ds = alg["output"].GetDataset()
+    dst_lyr = dst_ds.GetLayer(0)
+
+    areas = [f.GetGeometryRef().GetArea() for f in dst_lyr]
+
+    if strategy in {"max-area", None, "longest-border"}:
+        assert areas == pytest.approx([77.85, 132.67, 80.82], abs=0.01)
+    elif strategy == "min-area":
+        assert areas == pytest.approx([78.50, 131.26, 81.58], abs=0.01)
+    elif strategy == "min-index":
+        assert areas == pytest.approx([78.50, 132.11, 80.73], abs=0.01)
+    else:
+        pytest.fail("Unhandled strategy")
+
+    assert alg.Finalize()
+
+
+def test_gdalalg_vector_clean_coverage_maximum_gap_width(alg, circles):
+
+    alg["input"] = circles
+    alg["output"] = ""
+    alg["output-format"] = "stream"
+    alg["maximum-gap-width"] = 2
+
+    assert alg.Run()
+
+    dst_ds = alg["output"].GetDataset()
+    dst_lyr = dst_ds.GetLayer(0)
+
+    areas = [f.GetGeometryRef().GetArea() for f in dst_lyr]
+
+    assert areas == pytest.approx([80.80, 132.67, 80.82], abs=0.01)
+
+
+@pytest.mark.parametrize("tol", (-5, float("nan")))
+def test_gdalalg_vector_clean_coverage_bad_maximum_gap_width(alg, tol):
+
+    with pytest.raises(RuntimeError, match="should be >= 0"):
+        alg["maximum-gap-width"] = tol
+
+
+@pytest.mark.parametrize("tol", (-5, float("nan")))
+def test_gdalalg_vector_clean_coverage_bad_snapping_distance(alg, tol):
+
+    with pytest.raises(RuntimeError, match="should be >= 0"):
+        alg["snapping-distance"] = tol
+
+
+def test_gdalalg_vector_clean_coverage_active_layer(alg, circles):
+
+    src_ds = gdal.GetDriverByName("MEM").CreateVector("")
+
+    src_ds.CopyLayer(circles.GetLayer(0), "poly1")
+    src_ds.CopyLayer(circles.GetLayer(0), "poly2")
+
+    alg["input"] = src_ds
+    alg["output"] = ""
+    alg["output-format"] = "stream"
+    alg["active-layer"] = "bad"
+
+    with pytest.raises(RuntimeError, match="layer .* was not found"):
+        alg.Run()
+
+    alg["active-layer"] = "poly2"
+    assert alg.Run()
+
+    dst_ds = alg["output"].GetDataset()
+
+    assert dst_ds.GetLayerCount() == 2
+
+    dst_lyr1 = dst_ds.GetLayer(0)
+    dst_lyr2 = dst_ds.GetLayer(1)
+    areas1 = [f.GetGeometryRef().GetArea() for f in dst_lyr1]
+    areas2 = [f.GetGeometryRef().GetArea() for f in dst_lyr2]
+
+    # overlaps removed in layer 2, so total area is less
+    assert sum(areas1) > sum(areas2)
+
+    assert alg.Finalize()
+
+
+@pytest.mark.parametrize(
+    "geom",
+    (
+        ogr.CreateGeometryFromWkt("POINT (3 8)"),
+        ogr.CreateGeometryFromWkt("TIN (((0 0,0 1,1 1,0 0)))"),
+        None,
+    ),
+)
+def test_gdalalg_vector_clean_coverage_non_polygonal_inputs(alg, geom, tmp_vsimem):
+
+    src_ds = gdal.GetDriverByName("MEM").CreateVector("")
+    src_lyr = src_ds.CreateLayer("layer")
+    src_lyr.CreateField(ogr.FieldDefn("a"))
+
+    f = ogr.Feature(src_lyr.GetLayerDefn())
+    f["a"] = 1
+    f.SetGeometryDirectly(ogr.CreateGeometryFromWkt("POINT (3 8)"))
+    src_lyr.CreateFeature(f)
+
+    alg["input"] = src_ds
+    alg["output"] = tmp_vsimem / "out.shp"
+
+    with pytest.raises(RuntimeError, match="can only be performed on polygonal"):
+        assert alg.Run()
+
+
+@pytest.mark.require_driver("GDALG")
+def test_gdalalg_vector_clean_coverage_test_ogrsf(tmp_path):
+
+    import test_cli_utilities
+
+    if test_cli_utilities.get_test_ogrsf_path() is None:
+        pytest.skip()
+
+    gdalg_filename = tmp_path / "tmp.gdalg.json"
+    open(gdalg_filename, "wb").write(
+        b'{"type": "gdal_streamed_alg","command_line": "gdal vector clean-coverage ../ogr/data/poly.shp --output-format=stream dummy_dataset_name","relative_paths_relative_to_this_file":false}'
+    )
+
+    ret = gdaltest.runexternal(
+        test_cli_utilities.get_test_ogrsf_path() + f" -ro {gdalg_filename}"
+    )
+
+    assert "INFO" in ret
+    assert "ERROR" not in ret
+    assert "FAILURE" not in ret

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -783,6 +783,13 @@ man_pages = [
         1,
     ),
     (
+        "programs/gdal_vector_clean_cverage",
+        "gdal-vector-clean-coverage",
+        "Remove gaps and overlaps from a polygon dataset",
+        [author_dbaston],
+        1,
+    ),
+    (
         "programs/gdal_vector_clip",
         "gdal-vector-clip",
         "Clip a vector dataset",

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -783,7 +783,7 @@ man_pages = [
         1,
     ),
     (
-        "programs/gdal_vector_clean_cverage",
+        "programs/gdal_vector_clean_coverage",
         "gdal-vector-clean-coverage",
         "Remove gaps and overlaps from a polygon dataset",
         [author_dbaston],

--- a/doc/source/programs/gdal_vector_clean_coverage.rst
+++ b/doc/source/programs/gdal_vector_clean_coverage.rst
@@ -1,0 +1,92 @@
+.. _gdal_vector_clean_coverage:
+
+================================================================================
+``gdal vector clean-coverage``
+================================================================================
+
+.. versionadded:: 3.12
+
+.. only:: html
+
+    Adjust the boundaries of a polygonal dataset, removing gaps and overlaps.
+
+.. Index:: gdal vector clean-coverage
+
+
+
+Synopsis
+--------
+
+.. program-output:: gdal vector clean-coverage --help-doc
+
+Description
+-----------
+
+:program:`gdal vector clean-coverage` modifies boundaries of a
+polygonal dataset, such that gaps and overlaps between features are removed and
+shared edges are defined using the same vertices. The resulting dataset will
+form a polygonal coverage that can be used with :ref:`gdal_vector_simplify_coverage`.
+
+This command can also be used as a step of :ref:`gdal_vector_pipeline`, although it
+requires loading the entire dataset into memory at once.
+
+.. note:: This command requires a GDAL build against the GEOS library (version 3.14 or greater).
+
+Standard options
+++++++++++++++++
+
+.. option:: --maximum-gap-width <MAXIMUM-GAP-WIDTH>
+
+    Defines the largest area that should be considered a "gap" and merged into
+    an adjacent polygon. Gaps will be merged unless a circle with radius larger 
+    than the specified tolerance can be inscribed within the gap.
+
+.. option:: --merge-strategy <MERGE-STRATEGY>
+
+    Method by which overlaps or gaps should be added to adjacent polygons. Options include:
+    - longest-border (default): add areas to the polygon with which the longest border is shared
+    - max-area: add areas to the largest adjacent polygon
+    - min-area: add areas to the smallest adjacent polygon
+    - min-index: add areas to the adjacent polygon that was read first
+
+.. option:: --snapping-distance <SNAPPING-DISTANCE>
+
+    Controls the node snapping step, when nearby vertices are snapped together.
+    By default, an automatic snapping distance is determined based on an
+    analysis of the input. Set to zero to turn off all snapping.
+
+.. include:: gdal_options/active_layer.rst
+
+.. include:: gdal_options/of_vector.rst
+
+.. include:: gdal_options/co_vector.rst
+
+.. include:: options/lco.rst
+
+.. include:: gdal_options/overwrite.rst
+
+Advanced options
+++++++++++++++++
+
+.. include:: gdal_options/oo.rst
+
+.. include:: gdal_options/if.rst
+
+.. GDALG output (on-the-fly / streamed dataset)
+.. --------------------------------------------
+
+.. include:: gdal_cli_include/gdalg_vector_compatible_non_natively_streamable.rst
+
+Examples
+--------
+
+.. example::
+   :title: Create and then simplify a polygonal coverage
+
+   .. code-block:: bash
+
+        $ gdal vector pipeline read ne_10m_admin_0_countries.shp ! \
+                               make-valid ! \
+                               clean-coverage ! \
+                               simplify-coverage --tolerance 1 ! \
+                               write countries.shp

--- a/doc/source/programs/index.rst
+++ b/doc/source/programs/index.rst
@@ -175,6 +175,7 @@ Vector commands
 
    gdal_vector
    gdal_vector_buffer
+   gdal_vector_clean_coverage
    gdal_vector_clip
    gdal_vector_concat
    gdal_vector_convert
@@ -201,6 +202,7 @@ Vector commands
 
     - :ref:`gdal_vector`: Entry point for vector commands
     - :ref:`gdal_vector_buffer`: Compute a buffer around geometries of a vector dataset
+    - :ref:`gdal_vector_clean_coverage`: Remove gaps and overlaps in a polygon dataset
     - :ref:`gdal_vector_clip`: Clip a vector dataset
     - :ref:`gdal_vector_concat`: Concatenate vector datasets
     - :ref:`gdal_vector_convert`: Convert a vector dataset


### PR DESCRIPTION
Adds a pipeline step to clean a polygonal coverage. Could also see an argument for combining with with `gdal vector make-valid`.