### PR TITLE
[Backport release/3.11] ENVI: warn/error out if samples/lines/bands are greater than INT_MAX

### DIFF
--- a/doc/source/user/raster_data_model.rst
+++ b/doc/source/user/raster_data_model.rst
@@ -11,6 +11,8 @@ Dataset
 
 A dataset (represented by the :cpp:class:`GDALDataset` class) is an assembly of related raster bands and some information common to them all. In particular the dataset has a concept of the raster size (in pixels and lines) that applies to all the bands. The dataset is also responsible for the georeferencing transform and coordinate system definition of all bands. The dataset itself can also have associated metadata, a list of name/value pairs in string form.
 
+The number of pixels and lines for a raster band is limited to 2,147,483,647 each. The number of bands is also limited to 2,147,483,647, although by default a limitation to 65,536 is applied to avoid excessive RAM consumption.
+
 Note that the GDAL dataset, and raster band data model is loosely based on the OpenGIS Grid Coverages specification.
 
 Coordinate System

--- a/frmts/raw/envidataset.cpp
+++ b/frmts/raw/envidataset.cpp
@@ -2112,11 +2112,42 @@ ENVIDataset *ENVIDataset::Open(GDALOpenInfo *poOpenInfo, bool bFileSizeCheck)
     }
 
     // Extract required values from the .hdr.
-    int nLines = atoi(poDS->m_aosHeader.FetchNameValueDef("lines", "0"));
+    const char *pszLines = poDS->m_aosHeader.FetchNameValueDef("lines", "0");
+    const auto nLines64 = std::strtoll(pszLines, nullptr, 10);
+    const int nLines = static_cast<int>(std::min<int64_t>(nLines64, INT_MAX));
+    if (nLines < nLines64)
+    {
+        CPLError(CE_Warning, CPLE_AppDefined,
+                 "Limiting number of lines from %s to %d due to GDAL raster "
+                 "data model limitation",
+                 pszLines, nLines);
+    }
 
-    int nSamples = atoi(poDS->m_aosHeader.FetchNameValueDef("samples", "0"));
+    const char *pszSamples =
+        poDS->m_aosHeader.FetchNameValueDef("samples", "0");
+    const auto nSamples64 = std::strtoll(pszSamples, nullptr, 10);
+    const int nSamples =
+        static_cast<int>(std::min<int64_t>(nSamples64, INT_MAX));
+    if (nSamples < nSamples64)
+    {
+        CPLError(
+            CE_Failure, CPLE_AppDefined,
+            "Cannot handle samples=%s due to GDAL raster data model limitation",
+            pszSamples);
+        return nullptr;
+    }
 
-    int nBands = atoi(poDS->m_aosHeader.FetchNameValueDef("bands", "0"));
+    const char *pszBands = poDS->m_aosHeader.FetchNameValueDef("bands", "0");
+    const auto nBands64 = std::strtoll(pszBands, nullptr, 10);
+    const int nBands = static_cast<int>(std::min<int64_t>(nBands64, INT_MAX));
+    if (nBands < nBands64)
+    {
+        CPLError(
+            CE_Failure, CPLE_AppDefined,
+            "Cannot handle bands=%s due to GDAL raster data model limitation",
+            pszBands);
+        return nullptr;
+    }
 
     // In case, there is no interleave keyword, we try to derive it from the
     // file extension.
@@ -2328,7 +2359,7 @@ ENVIDataset *ENVIDataset::Open(GDALOpenInfo *poOpenInfo, bool bFileSizeCheck)
         }
         nLineOffset = nDataSize * nSamples;
         nPixelOffset = nDataSize;
-        nBandOffset = static_cast<vsi_l_offset>(nLineOffset) * nLines;
+        nBandOffset = static_cast<vsi_l_offset>(nLineOffset) * nLines64;
     }
 
     const char *pszMajorFrameOffset = poDS->m_aosHeader["major_frame_offsets"];


### PR DESCRIPTION
Backport #12783
 **Authored by:** @rouault