### PR TITLE
[Backport release/3.11] netCDF: make LIST_ALL_ARRAYS=YES work on datasets that have no 2D array

### DIFF
--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -6746,6 +6746,20 @@ def test_netcdf_LIST_ALL_ARRAYS():
     )
 
 
+def test_netcdf_LIST_ALL_ARRAYS_on_dataset_without_2D_arrays(tmp_path):
+
+    gdal.Run(
+        "mdim",
+        "convert",
+        input="data/netcdf/byte.nc",
+        output=tmp_path / "out.nc",
+        array="x",
+    )
+
+    ds = gdal.OpenEx(tmp_path / "out.nc", open_options=["LIST_ALL_ARRAYS=YES"])
+    assert len(ds.GetSubDatasets()) == 1
+
+
 ###############################################################################
 # Test use of GeoTransform attribute to avoid precision loss
 # https://github.com/OSGeo/gdal/issues/11993

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -8494,8 +8494,11 @@ GDALDataset *netCDFDataset::Open(GDALOpenInfo *poOpenInfo)
     }
     CSLDestroy(papszIgnoreVars);
 
+    const bool bListAllArrays = CPLTestBool(
+        CSLFetchNameValueDef(poDS->papszOpenOptions, "LIST_ALL_ARRAYS", "NO"));
+
     // Case where there is no raster variable
-    if (nRasterVars == 0 && !bTreatAsSubdataset)
+    if (!bListAllArrays && nRasterVars == 0 && !bTreatAsSubdataset)
     {
         poDS->GDALPamDataset::SetMetadata(poDS->papszMetadata);
         CPLReleaseMutex(hNCMutex);  // Release mutex otherwise we'll deadlock
@@ -8524,8 +8527,6 @@ GDALDataset *netCDFDataset::Open(GDALOpenInfo *poOpenInfo)
     // We have more than one variable with 2 dimensions in the
     // file, then treat this as a subdataset container dataset.
     bool bSeveralVariablesAsBands = false;
-    const bool bListAllArrays = CPLTestBool(
-        CSLFetchNameValueDef(poDS->papszOpenOptions, "LIST_ALL_ARRAYS", "NO"));
     if (bListAllArrays || ((nRasterVars > 1) && !bTreatAsSubdataset))
     {
         if (CPLFetchBool(poOpenInfo->papszOpenOptions, "VARIABLES_AS_BANDS",


### PR DESCRIPTION
Backport #12804
 **Authored by:** @rouault