### PR TITLE
[Backport release/3.11] GDALNoDataMaskBand::IRasterIO(): fix corruption when reading from Byte band and nLineSpace > nBufXSize (3.10.0 regression)

### DIFF
--- a/autotest/gcore/nodatamaskband.py
+++ b/autotest/gcore/nodatamaskband.py
@@ -14,109 +14,133 @@
 
 import struct
 
+import pytest
+
 from osgeo import gdal
 
 
-def test_nodatamaskband_1():
-
-    for (dt, struct_type, v) in [
+@pytest.mark.parametrize(
+    "dt,struct_type,v",
+    [
         (gdal.GDT_Byte, "B", 255),
+        (gdal.GDT_Int8, "b", 127),
         (gdal.GDT_Int16, "h", 32767),
         (gdal.GDT_UInt16, "H", 65535),
         (gdal.GDT_Int32, "i", 0x7FFFFFFF),
         (gdal.GDT_UInt32, "I", 0xFFFFFFFF),
+        (gdal.GDT_Int64, "q", 0x7FFFFFFFFFFFFFFF),
+        (gdal.GDT_UInt64, "Q", 0xFFFFFFFFFFFFFFFF),
+        (gdal.GDT_Float16, "e", 1.25),
         (gdal.GDT_Float32, "f", 1.25),
         (gdal.GDT_Float32, "f", float("nan")),
         (gdal.GDT_Float64, "d", 1.2345678),
         (gdal.GDT_Float64, "d", float("nan")),
-    ]:
+    ],
+)
+def test_nodatamaskband_1(dt, struct_type, v):
 
-        ds = gdal.GetDriverByName("MEM").Create("", 6, 4, 1, dt)
-        ds.GetRasterBand(1).SetNoDataValue(v)
-        ds.GetRasterBand(1).WriteRaster(
+    ds = gdal.GetDriverByName("MEM").Create("", 6, 4, 1, dt)
+    ds.GetRasterBand(1).SetNoDataValue(v)
+    ds.GetRasterBand(1).WriteRaster(
+        0,
+        0,
+        6,
+        4,
+        struct.pack(
+            struct_type * 6 * 4,
+            v,
+            1,
+            1,
+            v,
+            v,
+            0,
+            v,
+            1,
+            1,
+            v,
+            v,
+            0,
+            v,
+            1,
+            1,
+            v,
+            v,
             0,
             0,
-            6,
-            4,
-            struct.pack(
-                struct_type * 6 * 4,
-                v,
-                1,
-                1,
-                v,
-                v,
-                0,
-                v,
-                1,
-                1,
-                v,
-                v,
-                0,
-                v,
-                1,
-                1,
-                v,
-                v,
-                0,
-                0,
-                v,
-                v,
-                0,
-                0,
-                0,
-            ),
-        )
+            v,
+            v,
+            0,
+            0,
+            0,
+        ),
+    )
 
-        data = ds.GetRasterBand(1).GetMaskBand().ReadRaster()
-        data_ar = struct.unpack("B" * 6 * 4, data)
-        expected_ar = (
-            0,
-            255,
-            255,
-            0,
-            0,
-            255,
-            0,
-            255,
-            255,
-            0,
-            0,
-            255,
-            0,
-            255,
-            255,
-            0,
-            0,
-            255,
-            255,
-            0,
-            0,
-            255,
-            255,
-            255,
-        )
-        assert data_ar == expected_ar, dt
+    data = ds.GetRasterBand(1).GetMaskBand().ReadRaster()
+    data_ar = struct.unpack("B" * 6 * 4, data)
+    expected_ar = (
+        0,
+        255,
+        255,
+        0,
+        0,
+        255,
+        0,
+        255,
+        255,
+        0,
+        0,
+        255,
+        0,
+        255,
+        255,
+        0,
+        0,
+        255,
+        255,
+        0,
+        0,
+        255,
+        255,
+        255,
+    )
+    assert data_ar == expected_ar, dt
 
-        data = ds.GetRasterBand(1).GetMaskBand().ReadBlock(0, 0)
-        data_ar = struct.unpack("B" * 6 * 1, data)
-        expected_ar = (0, 255, 255, 0, 0, 255)
-        assert data_ar == expected_ar, dt
+    data = ds.GetRasterBand(1).GetMaskBand().ReadRaster(buf_line_space=8)
+    data_ar = struct.unpack("B" * (8 * 3 + 6), data)
+    for y in range(4):
+        for x in range(6):
+            assert data_ar[y * 8 + x] == expected_ar[y * 6 + x]
 
-        data = ds.GetRasterBand(1).GetMaskBand().ReadBlock(0, 3)
-        data_ar = struct.unpack("B" * 6 * 1, data)
-        expected_ar = (255, 0, 0, 255, 255, 255)
-        assert data_ar == expected_ar, dt
+    data = (
+        ds.GetRasterBand(1)
+        .GetMaskBand()
+        .ReadRaster(buf_pixel_space=2, buf_line_space=2 * 6)
+    )
+    data_ar = struct.unpack("B" * ((6 * 3 + 5) * 2 + 1), data)
+    for y in range(4):
+        for x in range(6):
+            assert data_ar[(y * 6 + x) * 2] == expected_ar[y * 6 + x]
 
-        data = ds.GetRasterBand(1).GetMaskBand().ReadRaster(buf_xsize=3, buf_ysize=2)
-        data_ar = struct.unpack("B" * 3 * 2, data)
-        expected_ar = (255, 0, 255, 0, 255, 255)
-        assert data_ar == expected_ar, dt
+    data = ds.GetRasterBand(1).GetMaskBand().ReadBlock(0, 0)
+    data_ar = struct.unpack("B" * 6 * 1, data)
+    expected_ar = (0, 255, 255, 0, 0, 255)
+    assert data_ar == expected_ar, dt
 
-        data = (
-            ds.GetRasterBand(1)
-            .GetMaskBand()
-            .ReadRaster(buf_type=gdal.GDT_UInt16, buf_xsize=3, buf_ysize=2)
-        )
-        data_ar = struct.unpack("H" * 3 * 2, data)
-        expected_ar = (255, 0, 255, 0, 255, 255)
-        assert data_ar == expected_ar, dt
+    data = ds.GetRasterBand(1).GetMaskBand().ReadBlock(0, 3)
+    data_ar = struct.unpack("B" * 6 * 1, data)
+    expected_ar = (255, 0, 0, 255, 255, 255)
+    assert data_ar == expected_ar, dt
+
+    data = ds.GetRasterBand(1).GetMaskBand().ReadRaster(buf_xsize=3, buf_ysize=2)
+    data_ar = struct.unpack("B" * 3 * 2, data)
+    expected_ar = (255, 0, 255, 0, 255, 255)
+    assert data_ar == expected_ar, dt
+
+    data = (
+        ds.GetRasterBand(1)
+        .GetMaskBand()
+        .ReadRaster(buf_type=gdal.GDT_UInt16, buf_xsize=3, buf_ysize=2)
+    )
+    data_ar = struct.unpack("H" * 3 * 2, data)
+    expected_ar = (255, 0, 255, 0, 255, 255)
+    assert data_ar == expected_ar, dt

--- a/gcore/gdalnodatamaskband.cpp
+++ b/gcore/gdalnodatamaskband.cpp
@@ -16,6 +16,7 @@
 #include "gdal_priv.h"
 
 #include <algorithm>
+#include <cassert>
 #include <cmath>
 #include <cstring>
 #include <utility>
@@ -157,6 +158,11 @@ bool GDALNoDataMaskBand::IsNoDataInRange(double dfNoDataValue,
             return GDALIsValueInRange<GByte>(dfNoDataValue);
         }
 
+        case GDT_Int8:
+        {
+            return GDALIsValueInRange<signed char>(dfNoDataValue);
+        }
+
         case GDT_Int16:
         {
             return GDALIsValueInRange<GInt16>(dfNoDataValue);
@@ -203,10 +209,18 @@ bool GDALNoDataMaskBand::IsNoDataInRange(double dfNoDataValue,
             return true;
         }
 
-        default:
-            CPLAssert(false);
-            return false;
+        case GDT_CFloat16:
+        case GDT_CFloat32:
+        case GDT_CFloat64:
+        case GDT_CInt16:
+        case GDT_CInt32:
+        case GDT_Unknown:
+        case GDT_TypeCount:
+            break;
     }
+
+    CPLAssert(false);
+    return false;
 }
 
 /************************************************************************/
@@ -268,12 +282,7 @@ static void SetZeroOr255(GByte *pabyDest, const T *panSrc, int nBufXSize,
                          int nBufYSize, GSpacing nPixelSpace,
                          GSpacing nLineSpace, T nNoData)
 {
-    if (nPixelSpace == 1 && nLineSpace == nBufXSize)
-    {
-        const size_t nBufSize = static_cast<size_t>(nBufXSize) * nBufYSize;
-        SetZeroOr255(pabyDest, panSrc, nBufSize, nNoData);
-    }
-    else if (nPixelSpace == 1)
+    if (nPixelSpace == 1)
     {
         for (int iY = 0; iY < nBufYSize; iY++)
         {
@@ -319,7 +328,8 @@ CPLErr GDALNoDataMaskBand::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
     // Optimization in common use case (#4488).
     // This avoids triggering the block cache on this band, which helps
     // reducing the global block cache consumption.
-    if (eBufType == GDT_Byte && eWrkDT == GDT_Byte)
+    if (eBufType == GDT_Byte && eWrkDT == GDT_Byte && nPixelSpace == 1 &&
+        nLineSpace >= nBufXSize)
     {
         const CPLErr eErr = m_poParent->RasterIO(
             GF_Read, nXOff, nYOff, nXSize, nYSize, pData, nBufXSize, nBufYSize,
@@ -330,15 +340,19 @@ CPLErr GDALNoDataMaskBand::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
         GByte *pabyData = static_cast<GByte *>(pData);
         const GByte byNoData = static_cast<GByte>(m_dfNoDataValue);
 
-        if (nPixelSpace == 1 && nLineSpace == nBufXSize)
+        if (nLineSpace == nBufXSize)
         {
             const size_t nBufSize = static_cast<size_t>(nBufXSize) * nBufYSize;
             SetZeroOr255(pabyData, nBufSize, byNoData);
         }
         else
         {
-            SetZeroOr255(pabyData, pabyData, nBufXSize, nBufYSize, nPixelSpace,
-                         nLineSpace, byNoData);
+            assert(nLineSpace > nBufXSize);
+            for (int iY = 0; iY < nBufYSize; iY++)
+            {
+                SetZeroOr255(pabyData, nBufXSize, byNoData);
+                pabyData += nLineSpace;
+            }
         }
         return CE_None;
     }
@@ -421,6 +435,15 @@ CPLErr GDALNoDataMaskBand::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
          */
         switch (eWrkDT)
         {
+            case GDT_Byte:
+            {
+                const auto nNoData = static_cast<GByte>(m_dfNoDataValue);
+                const auto *panSrc = static_cast<const GByte *>(pTemp);
+                SetZeroOr255(pabyDest, panSrc, nBufXSize, nBufYSize,
+                             nPixelSpace, nLineSpace, nNoData);
+            }
+            break;
+
             case GDT_Int16:
             {
                 const auto nNoData = static_cast<int16_t>(m_dfNoDataValue);


### PR DESCRIPTION
Backport #12818
 **Authored by:** @rouault