### PR TITLE
SetNextByIndex(invalid_index): return OGRERR_NON_EXISTING_FEATURE and…

### DIFF
--- a/apps/test_ogrsf.cpp
+++ b/apps/test_ogrsf.cpp
@@ -1384,7 +1384,7 @@ static int TestBasic(GDALDataset *poDS, OGRLayer *poLayer)
 static int TestLayerErrorConditions(OGRLayer *poLyr)
 {
     int bRet = TRUE;
-    OGRFeature *poFeat = nullptr;
+    std::unique_ptr<OGRFeature> poFeat;
 
     CPLPushErrorHandler(CPLQuietErrorHandler);
 
@@ -1422,18 +1422,16 @@ static int TestLayerErrorConditions(OGRLayer *poLyr)
     }
 
     poLyr->ResetReading();
-    poFeat = poLyr->GetNextFeature();
+    poFeat.reset(poLyr->GetNextFeature());
     if (poFeat)
     {
         poFeat->SetFID(-10);
-        if (poLyr->SetFeature(poFeat) == OGRERR_NONE)
+        if (poLyr->SetFeature(poFeat.get()) == OGRERR_NONE)
         {
             printf("ERROR: SetFeature(-10) should have returned an error\n");
-            delete poFeat;
             bRet = FALSE;
             goto bye;
         }
-        delete poFeat;
     }
 
     if (poLyr->DeleteFeature(-10) == OGRERR_NONE)
@@ -1451,18 +1449,40 @@ static int TestLayerErrorConditions(OGRLayer *poLyr)
         goto bye;
     }
 
-    if (LOG_ACTION(poLyr->SetNextByIndex(-10)) != OGRERR_FAILURE)
+    if (LOG_ACTION(poLyr->SetNextByIndex(-1)) != OGRERR_NON_EXISTING_FEATURE)
     {
-        printf("ERROR: SetNextByIndex(-10) should have "
-               "returned OGRERR_FAILURE\n");
+        printf("ERROR: SetNextByIndex(-1) should have "
+               "returned OGRERR_NON_EXISTING_FEATURE\n");
+        bRet = FALSE;
+        goto bye;
+    }
+    if (LOG_ACTION(std::unique_ptr<OGRFeature>(poLyr->GetNextFeature())) !=
+        nullptr)
+    {
+        printf("ERROR: GetNextFeature() after SetNextByIndex(-1) "
+               "should have returned NULL\n");
         bRet = FALSE;
         goto bye;
     }
 
-    if (LOG_ACTION(poLyr->SetNextByIndex(2000000000)) == OGRERR_NONE &&
-        LOG_ACTION(poLyr->GetNextFeature()) != nullptr)
+    if (poFeat)
     {
-        printf("ERROR: SetNextByIndex(2000000000) and then GetNextFeature() "
+        poLyr->ResetReading();
+        poFeat.reset(poLyr->GetNextFeature());
+        if (!poFeat)
+        {
+            printf("ERROR: GetNextFeature() after SetNextByIndex(-1) and "
+                   "ResetReading() should have returned a non-NULL feature\n");
+            bRet = FALSE;
+            goto bye;
+        }
+    }
+
+    CPL_IGNORE_RET_VAL(LOG_ACTION(poLyr->SetNextByIndex(2000000000)));
+    if (LOG_ACTION(std::unique_ptr<OGRFeature>(poLyr->GetNextFeature())) !=
+        nullptr)
+    {
+        printf("ERROR: GetNextFeature() after SetNextByIndex(2000000000) "
                "should have returned NULL\n");
         bRet = FALSE;
         goto bye;

--- a/autotest/ogr/ogr_sql_rfc28.py
+++ b/autotest/ogr/ogr_sql_rfc28.py
@@ -1265,11 +1265,11 @@ def test_ogr_rfc28_47(data_ds):
         ogrtest.check_features_against_list(lyr, "EAS_ID", [171, 170])
 
     with data_ds.ExecuteSQL("SELECT * FROM POLY LIMIT 1") as lyr:
-        assert lyr.SetNextByIndex(1) == ogr.OGRERR_FAILURE
+        assert lyr.SetNextByIndex(1) == ogr.OGRERR_NON_EXISTING_FEATURE
         assert lyr.GetNextFeature() is None
 
     with data_ds.ExecuteSQL("SELECT * FROM POLY LIMIT 1 OFFSET 1") as lyr:
-        assert lyr.SetNextByIndex(1) == ogr.OGRERR_FAILURE
+        assert lyr.SetNextByIndex(1) == ogr.OGRERR_NON_EXISTING_FEATURE
         assert lyr.GetNextFeature() is None
 
     with data_ds.ExecuteSQL("SELECT * FROM POLY LIMIT 2 OFFSET 1") as lyr:
@@ -1286,15 +1286,15 @@ def test_ogr_rfc28_47(data_ds):
         assert lyr.GetNextFeature() is None
 
     with data_ds.ExecuteSQL("SELECT * FROM POLY LIMIT 1 OFFSET 1") as lyr:
-        assert lyr.SetNextByIndex((1 << 63) - 1) == ogr.OGRERR_FAILURE
+        assert lyr.SetNextByIndex((1 << 63) - 1) == ogr.OGRERR_NON_EXISTING_FEATURE
         assert lyr.GetNextFeature() is None
 
     with data_ds.ExecuteSQL("SELECT * FROM POLY OFFSET 1") as lyr:
-        assert lyr.SetNextByIndex((1 << 63) - 1) == ogr.OGRERR_FAILURE
+        assert lyr.SetNextByIndex((1 << 63) - 1) == ogr.OGRERR_NON_EXISTING_FEATURE
         assert lyr.GetNextFeature() is None
 
     with data_ds.ExecuteSQL("SELECT * FROM POLY") as lyr:
-        assert lyr.SetNextByIndex((1 << 63) - 1) == ogr.OGRERR_FAILURE
+        assert lyr.SetNextByIndex((1 << 63) - 1) == ogr.OGRERR_NON_EXISTING_FEATURE
         assert lyr.GetNextFeature() is None
 
 

--- a/frmts/mem/ogrmemlayer.cpp
+++ b/frmts/mem/ogrmemlayer.cpp
@@ -127,6 +127,9 @@ void OGRMemLayer::ResetReading()
 OGRFeature *OGRMemLayer::GetNextFeature()
 
 {
+    if (m_iNextReadFID < 0)
+        return nullptr;
+
     while (true)
     {
         OGRFeature *poFeature = nullptr;
@@ -172,7 +175,10 @@ OGRErr OGRMemLayer::SetNextByIndex(GIntBig nIndex)
         return OGRLayer::SetNextByIndex(nIndex);
 
     if (nIndex < 0 || nIndex >= m_nMaxFeatureCount)
-        return OGRERR_FAILURE;
+    {
+        m_iNextReadFID = -1;
+        return OGRERR_NON_EXISTING_FEATURE;
+    }
 
     m_iNextReadFID = nIndex;
 

--- a/ogr/ogrsf_frmts/generic/ogr_gensql.cpp
+++ b/ogr/ogrsf_frmts/generic/ogr_gensql.cpp
@@ -617,8 +617,13 @@ void OGRGenSQLResultsLayer::ResetReading()
 OGRErr OGRGenSQLResultsLayer::SetNextByIndex(GIntBig nIndex)
 
 {
+    m_bEOF = false;
+
     if (nIndex < 0)
-        return OGRERR_FAILURE;
+    {
+        m_bEOF = true;
+        return OGRERR_NON_EXISTING_FEATURE;
+    }
 
     swq_select *psSelectInfo = m_pSelectInfo.get();
 
@@ -627,7 +632,7 @@ OGRErr OGRGenSQLResultsLayer::SetNextByIndex(GIntBig nIndex)
         m_nIteratedFeatures = nIndex;
         if (m_nIteratedFeatures >= psSelectInfo->limit)
         {
-            return OGRERR_FAILURE;
+            return OGRERR_NON_EXISTING_FEATURE;
         }
     }
 
@@ -636,7 +641,7 @@ OGRErr OGRGenSQLResultsLayer::SetNextByIndex(GIntBig nIndex)
     if (nIndex > std::numeric_limits<GIntBig>::max() - psSelectInfo->offset)
     {
         m_bEOF = true;
-        return OGRERR_FAILURE;
+        return OGRERR_NON_EXISTING_FEATURE;
     }
     if (psSelectInfo->query_mode == SWQM_SUMMARY_RECORD ||
         psSelectInfo->query_mode == SWQM_DISTINCT_LIST || !m_anFIDIndex.empty())

--- a/ogr/ogrsf_frmts/generic/ogrlayer.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrlayer.cpp
@@ -814,18 +814,15 @@ OGRErr OGRLayer::SetNextByIndex(GIntBig nIndex)
 
 {
     if (nIndex < 0)
-        return OGRERR_FAILURE;
+        nIndex = GINTBIG_MAX;
 
     ResetReading();
 
-    OGRFeature *poFeature = nullptr;
     while (nIndex-- > 0)
     {
-        poFeature = GetNextFeature();
+        auto poFeature = std::unique_ptr<OGRFeature>(GetNextFeature());
         if (poFeature == nullptr)
-            return OGRERR_FAILURE;
-
-        delete poFeature;
+            return OGRERR_NON_EXISTING_FEATURE;
     }
 
     return OGRERR_NONE;

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -3481,6 +3481,7 @@ OGRErr OGRGeoPackageTableLayer::SetAttributeFilter(const char *pszQuery)
 
 void OGRGeoPackageTableLayer::ResetReading()
 {
+    m_bEOF = false;
     if (m_bDeferredCreation && RunDeferredCreationIfNecessary() != OGRERR_NONE)
         return;
 
@@ -3519,7 +3520,10 @@ void OGRGeoPackageTableLayer::ResetReading()
 OGRErr OGRGeoPackageTableLayer::SetNextByIndex(GIntBig nIndex)
 {
     if (nIndex < 0)
-        return OGRERR_FAILURE;
+    {
+        m_bEOF = true;
+        return OGRERR_NON_EXISTING_FEATURE;
+    }
     if (m_soColumns.empty())
         BuildColumns();
     return ResetStatementInternal(nIndex);
@@ -3620,6 +3624,8 @@ OGRErr OGRGeoPackageTableLayer::ResetStatementInternal(GIntBig nStartIndex)
 
 OGRFeature *OGRGeoPackageTableLayer::GetNextFeature()
 {
+    if (m_bEOF)
+        return nullptr;
     if (!m_bFeatureDefnCompleted)
         GetLayerDefn();
     if (m_bDeferredCreation && RunDeferredCreationIfNecessary() != OGRERR_NONE)

--- a/ogr/ogrsf_frmts/ngw/ogr_ngw.h
+++ b/ogr/ogrsf_frmts/ngw/ogr_ngw.h
@@ -177,6 +177,7 @@ class OGRNGWLayer final : public OGRLayer
     std::string osWhere;
     std::string osSpatialFilter;
     bool bClientSideAttributeFilter;
+    bool m_bEOF = false;
 
     explicit OGRNGWLayer(const std::string &osResourceIdIn,
                          OGRNGWDataset *poDSIn,

--- a/ogr/ogrsf_frmts/ngw/ogrngwlayer.cpp
+++ b/ogr/ogrsf_frmts/ngw/ogrngwlayer.cpp
@@ -591,6 +591,7 @@ OGRErr OGRNGWLayer::Rename(const char *pszNewName)
  */
 void OGRNGWLayer::ResetReading()
 {
+    m_bEOF = false;
     SyncToDisk();
     FreeFeaturesCache();
     if (poDS->GetPageSize() > 0)
@@ -653,7 +654,7 @@ OGRErr OGRNGWLayer::SetNextByIndex(GIntBig nIndex)
         CPLError(CE_Failure, CPLE_AppDefined,
                  "Feature index must be greater or equal 0. Got " CPL_FRMT_GIB,
                  nIndex);
-        return OGRERR_FAILURE;
+        return OGRERR_NON_EXISTING_FEATURE;
     }
     if (poDS->GetPageSize() > 0)
     {
@@ -719,6 +720,8 @@ OGRErr OGRNGWLayer::SetNextByIndex(GIntBig nIndex)
  */
 OGRFeature *OGRNGWLayer::GetNextFeature()
 {
+    if (m_bEOF)
+        return nullptr;
     std::string osUrl;
 
     if (poDS->GetPageSize() > 0)

--- a/ogr/ogrsf_frmts/ogrsf_frmts.dox
+++ b/ogr/ogrsf_frmts/ogrsf_frmts.dox
@@ -1881,6 +1881,12 @@ error code.
  fast seeking is available on the current layer use the TestCapability()
  method with a value of OLCFastSetNextByIndex.
 
+ Starting with GDAL 3.12, when implementations can detect that nIndex is
+ invalid (at the minimum all should detect negative indices), they should
+ return OGRERR_NON_EXISTING_FEATURE, and following calls to GetNextFeature()
+ should return nullptr, until ResetReading() or a valid call to
+ SetNextByIndex() is done.
+
  This method is the same as the C function OGR_L_SetNextByIndex().
 
  @param nIndex the index indicating how many steps into the result set
@@ -1908,6 +1914,12 @@ error code.
  and then calls GetNextFeature() nIndex times is used.  To determine if
  fast seeking is available on the current layer use the TestCapability()
  method with a value of OLCFastSetNextByIndex.
+
+ Starting with GDAL 3.12, when implementations can detect that nIndex is
+ invalid (at the minimum all should detect negative indices), they should
+ return OGRERR_NON_EXISTING_FEATURE, and following calls to GetNextFeature()
+ should return nullptr, until ResetReading() or a valid call to
+ SetNextByIndex() is done.
 
  This method is the same as the C++ method OGRLayer::SetNextByIndex()
 

--- a/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdblayer.cpp
@@ -2022,13 +2022,18 @@ OGRErr OGROpenFileGDBLayer::SetNextByIndex(GIntBig nIndex)
     if (!BuildLayerDefinition())
         return OGRERR_FAILURE;
 
+    m_bEOF = false;
+
     if (m_eSpatialIndexState == SPI_IN_BUILDING)
         m_eSpatialIndexState = SPI_INVALID;
 
     if (m_nFilteredFeatureCount >= 0)
     {
         if (nIndex < 0 || nIndex >= m_nFilteredFeatureCount)
-            return OGRERR_FAILURE;
+        {
+            m_bEOF = true;
+            return OGRERR_NON_EXISTING_FEATURE;
+        }
         m_iCurFeat = nIndex;
         return OGRERR_NONE;
     }
@@ -2036,7 +2041,10 @@ OGRErr OGROpenFileGDBLayer::SetNextByIndex(GIntBig nIndex)
              m_poLyrTable->GetTotalRecordCount())
     {
         if (nIndex < 0 || nIndex >= m_poLyrTable->GetValidRecordCount())
-            return OGRERR_FAILURE;
+        {
+            m_bEOF = true;
+            return OGRERR_NON_EXISTING_FEATURE;
+        }
         m_iCurFeat = nIndex;
         return OGRERR_NONE;
     }

--- a/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetlayer.cpp
@@ -2779,11 +2779,19 @@ bool OGRParquetLayer::GetArrowStream(struct ArrowArrayStream *out_stream,
 OGRErr OGRParquetLayer::SetNextByIndex(GIntBig nIndex)
 {
     if (nIndex < 0)
-        return OGRERR_FAILURE;
+    {
+        m_bEOF = true;
+        return OGRERR_NON_EXISTING_FEATURE;
+    }
 
     const auto metadata = m_poArrowReader->parquet_reader()->metadata();
     if (nIndex >= metadata->num_rows())
-        return OGRERR_FAILURE;
+    {
+        m_bEOF = true;
+        return OGRERR_NON_EXISTING_FEATURE;
+    }
+
+    m_bEOF = false;
 
     if (m_bSingleBatch)
     {

--- a/ogr/ogrsf_frmts/pds/ogrpdslayer.cpp
+++ b/ogr/ogrsf_frmts/pds/ogrpdslayer.cpp
@@ -799,7 +799,10 @@ OGRErr OGRPDSLayer::SetNextByIndex(GIntBig nIndex)
         return OGRLayer::SetNextByIndex(nIndex);
 
     if (nIndex < 0 || nIndex >= nRecords)
-        return OGRERR_FAILURE;
+    {
+        nNextFID = nRecords;
+        return OGRERR_NON_EXISTING_FEATURE;
+    }
 
     nNextFID = (int)nIndex;
     VSIFSeekL(fpPDS, nStartBytes + nNextFID * nRecordSize, SEEK_SET);

--- a/ogr/ogrsf_frmts/pg/ogrpglayer.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpglayer.cpp
@@ -1508,6 +1508,9 @@ void OGRPGLayer::SetInitialQueryCursor()
 OGRFeature *OGRPGLayer::GetNextRawFeature()
 
 {
+    if (iNextShapeId < 0)
+        return nullptr;
+
     PGconn *hPGConn = poDS->GetPGConn();
     CPLString osCommand;
 
@@ -1604,8 +1607,9 @@ OGRErr OGRPGLayer::SetNextByIndex(GIntBig nIndex)
 
     if (nIndex < 0)
     {
+        iNextShapeId = -1;
         CPLError(CE_Failure, CPLE_AppDefined, "Invalid index");
-        return OGRERR_FAILURE;
+        return OGRERR_NON_EXISTING_FEATURE;
     }
 
     if (nIndex == 0)
@@ -1637,9 +1641,9 @@ OGRErr OGRPGLayer::SetNextByIndex(GIntBig nIndex)
 
         CloseCursor();
 
-        iNextShapeId = 0;
+        iNextShapeId = -1;
 
-        return OGRERR_FAILURE;
+        return OGRERR_NON_EXISTING_FEATURE;
     }
 
     nResultOffset = 0;

--- a/ogr/ogrsf_frmts/shape/ogrshapelayer.cpp
+++ b/ogr/ogrsf_frmts/shape/ogrshapelayer.cpp
@@ -862,8 +862,11 @@ OGRErr OGRShapeLayer::SetNextByIndex(GIntBig nIndex)
     if (!TouchLayer())
         return OGRERR_FAILURE;
 
-    if (nIndex < 0 || nIndex > INT_MAX)
-        return OGRERR_FAILURE;
+    if (nIndex < 0 || nIndex >= m_nTotalShapeCount)
+    {
+        m_iNextShapeId = m_nTotalShapeCount;
+        return OGRERR_NON_EXISTING_FEATURE;
+    }
 
     // Eventually we should try to use m_panMatchingFIDs list
     // if available and appropriate.

--- a/ogr/ogrsf_frmts/sxf/ogr_sxf.h
+++ b/ogr/ogrsf_frmts/sxf/ogr_sxf.h
@@ -44,6 +44,7 @@ class OGRSXFLayer final : public OGRLayer
     CPLString sFIDColumn_{};
     CPLMutex **m_hIOMutex;
     double m_dfCoeff;
+    bool m_bEOF = false;
     OGRFeature *GetNextRawFeature(long nFID);
 
     GUInt32 TranslateXYH(const SXFRecordDescription &certifInfo,

--- a/ogr/ogrsf_frmts/sxf/ogrsxflayer.cpp
+++ b/ogr/ogrsf_frmts/sxf/ogrsxflayer.cpp
@@ -261,8 +261,12 @@ bool OGRSXFLayer::AddRecord(long nFID, unsigned nClassCode,
 
 OGRErr OGRSXFLayer::SetNextByIndex(GIntBig nIndex)
 {
+    m_bEOF = false;
     if (nIndex < 0 || nIndex > (long)mnRecordDesc.size())
-        return OGRERR_FAILURE;
+    {
+        m_bEOF = true;
+        return OGRERR_NON_EXISTING_FEATURE;
+    }
 
     oNextIt = mnRecordDesc.begin();
     std::advance(oNextIt, static_cast<size_t>(nIndex));
@@ -343,6 +347,7 @@ GIntBig OGRSXFLayer::GetFeatureCount(int bForce)
 void OGRSXFLayer::ResetReading()
 
 {
+    m_bEOF = false;
     oNextIt = mnRecordDesc.begin();
 }
 
@@ -352,6 +357,8 @@ void OGRSXFLayer::ResetReading()
 
 OGRFeature *OGRSXFLayer::GetNextFeature()
 {
+    if (m_bEOF)
+        return nullptr;
     CPLMutexHolderD(m_hIOMutex);
     while (oNextIt != mnRecordDesc.end())
     {


### PR DESCRIPTION
… make sure following calls to GetNextFeature() return nullptr

Fixes #12832
