### PR TITLE
MongoDB: compatibility with >=mongo-cpp-driver-4

### DIFF
--- a/.github/workflows/ubuntu_24.04/Dockerfile.ci
+++ b/.github/workflows/ubuntu_24.04/Dockerfile.ci
@@ -99,7 +99,7 @@ RUN apt-get update \
    && ACCEPT_EULA=Y apt-get install -y msodbcsql17 unixodbc-dev
 
 # Build mongo-c-driver
-ARG MONGO_C_DRIVER_VERSION=1.24.4
+ARG MONGO_C_DRIVER_VERSION=2.0.2
 RUN mkdir mongo-c-driver \
     && wget -q https://github.com/mongodb/mongo-c-driver/releases/download/${MONGO_C_DRIVER_VERSION}/mongo-c-driver-${MONGO_C_DRIVER_VERSION}.tar.gz -O - \
         | tar xz -C mongo-c-driver --strip-components=1 \
@@ -113,7 +113,7 @@ RUN mkdir mongo-c-driver \
     && rm -rf mongo-c-driver
 
 # Build mongocxx
-ARG MONGOCXX_VERSION=3.8.1
+ARG MONGOCXX_VERSION=4.1.1
 RUN mkdir mongocxx \
     && wget -q https://github.com/mongodb/mongo-cxx-driver/archive/r${MONGOCXX_VERSION}.tar.gz -O - \
         | tar xz -C mongocxx --strip-components=1 \

--- a/ogr/ogrsf_frmts/mongodbv3/mongocxxv3_headers.h
+++ b/ogr/ogrsf_frmts/mongodbv3/mongocxxv3_headers.h
@@ -21,9 +21,12 @@
 #include <bsoncxx/builder/basic/document.hpp>
 #include <bsoncxx/builder/basic/kvp.hpp>
 #include <bsoncxx/json.hpp>
-#include <bsoncxx/stdx/make_unique.hpp>
 #include <bsoncxx/string/to_string.hpp>
+
+#if BSONCXX_VERSION_MAJOR < 4
+#include <bsoncxx/stdx/make_unique.hpp>
 #include <bsoncxx/types/value.hpp>
+#endif
 
 #include <mongocxx/client.hpp>
 #include <mongocxx/instance.hpp>


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?
Fix api incompatibilities with >=mongo-cpp-driver-4.

https://www.mongodb.com/docs/languages/cpp/cpp-driver/current/upgrade/#api-breaking-changes-in-v4.0

k_string is available as far back as 3.7, but I think its simpler to just check if the version is higher than 4.

## What are related issues/pull requests?

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS: Gentoo Linux amd64
* Compiler: gcc (Gentoo 15.1.1_p20250705-r1 p2) 15.1.1 20250705

