### PR TITLE
Fix CMake compilation with -Wp,-D_FORTIFY_SOURCE=2 flags

### DIFF
--- a/autotest/cpp/CMakeLists.txt
+++ b/autotest/cpp/CMakeLists.txt
@@ -142,7 +142,7 @@ target_compile_definitions(gdal_unit_test PRIVATE "-DPROJ_DB_TMPDIR=\"${CMAKE_CU
 # As we don't need optimizations for that unit test, override it with -O0 for gcc-style compilers
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # -D_FORTIFY_SOURCE can't be used with -O0
-    string(REPLACE "-D_FORTIFY_SOURCE=2" " " CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ")
+    string(REGEX REPLACE "(-Wp,)?-D_FORTIFY_SOURCE=2" " " CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ")
     target_compile_options(gdal_unit_test PRIVATE -O0)
 endif()
 


### PR DESCRIPTION
Handle both -D_FORTIFY_SOURCE=2 and -Wp,-D_FORTIFY_SOURCE=2 variants when removing FORTIFY_SOURCE flags for unit test compilation with -O0.

## What does this PR do?

Fixes a CMake compilation error that occurs when building GDAL unit tests on systems using hardened compiler flags with the `-Wp,-D_FORTIFY_SOURCE=2` format.

The existing code in `autotest/cpp/CMakeLists.txt` only removes the `-D_FORTIFY_SOURCE=2` variant when compiling unit tests with `-O0` optimization, but doesn't handle the `-Wp,-D_FORTIFY_SOURCE=2` variant used by modern hardened build environments. This leaves dangling `-Wp,` prefixes that cause compilation to fail with "too many filenames" errors.

The fix adds string replacement for both variants to ensure clean flag removal.

## What are related issues/pull requests?

Fixes #12840

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: Amazon Linux 2023
* Compiler: GCC with hardened flags (-Wp,-D_FORTIFY_SOURCE=2)


## Testing
```
cmake .. -DCMAKE_CXX_FLAGS="-Wp,-D_FORTIFY_SOURCE=2 -O2"
cmake --build . --target gdal_unit_test --verbose
```
[gdal-fixed-with-Wp.log](https://github.com/user-attachments/files/21544267/gdal-fixed-with-Wp.log)

```
cmake .. -DCMAKE_CXX_FLAGS="-D_FORTIFY_SOURCE=2 -O2"
-D_FORTIFY_SOURCE=2 -O2"
cmake --build . --target gdal_unit_test --verbose
```
[gdal-fixed-without-Wp.log](https://github.com/user-attachments/files/21544268/gdal-fixed-without-Wp.log)

```
cmake .. 
-D_FORTIFY_SOURCE=2 -O2"
cmake --build . --target gdal_unit_test --verbose
```
[gdal-fixed-no-flags.log](https://github.com/user-attachments/files/21544400/gdal-fixed-no-flags.log)

