### PR TITLE
[Backport release/3.11] Fix CMake compilation with -Wp,-D_FORTIFY_SOURCE=2 flags

### DIFF
--- a/autotest/cpp/CMakeLists.txt
+++ b/autotest/cpp/CMakeLists.txt
@@ -139,7 +139,7 @@ target_compile_definitions(gdal_unit_test PRIVATE "-DPROJ_DB_TMPDIR=\"${CMAKE_CU
 # As we don't need optimizations for that unit test, override it with -O0 for gcc-style compilers
 if (CMAKE_CXX_COMPILER_ID MATCHES "Clang" OR CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # -D_FORTIFY_SOURCE can't be used with -O0
-    string(REPLACE "-D_FORTIFY_SOURCE=2" " " CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ")
+    string(REGEX REPLACE "(-Wp,)?-D_FORTIFY_SOURCE=2" " " CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ")
     target_compile_options(gdal_unit_test PRIVATE -O0)
 endif()
 


### PR DESCRIPTION
Backport #12842
 **Authored by:** @aale24