### PR TITLE
Java bindings: avoid double free with Band.GetDataset().Close()

### DIFF
--- a/swig/include/Band.i
+++ b/swig/include/Band.i
@@ -117,7 +117,11 @@ public:
 %mutable;
 
   /* Interface method added for GDAL 1.12.0 */
+#if defined(SWIGJAVA)
+  GDALDatasetShadow* GetDatasetInternal()
+#else
   GDALDatasetShadow* GetDataset()
+#endif
   {
     return (GDALDatasetShadow*) GDALGetBandDataset(self);
   }

--- a/swig/include/java/gdal_java.i
+++ b/swig/include/java/gdal_java.i
@@ -1125,8 +1125,14 @@ import org.gdal.gdalconst.gdalconstConstants;
 import org.gdal.osr.SpatialReference;
 %}
 
-
 %typemap(javacode) GDALRasterBandShadow %{
+
+  public Dataset GetDataset()
+  {
+      if (parentReference != null)
+         return (Dataset)parentReference;
+      return GetDatasetInternal();
+  }
 
   // Preferred name to match C++ API
   public int GetXSize() { return getXSize(); }
@@ -1359,7 +1365,7 @@ import org.gdal.osr.SpatialReference;
 %}
 
 %typemap(javacode) GDALMajorObjectShadow %{
-  private Object parentReference;
+  protected Object parentReference;
 
   /* Ensure that the GC doesn't collect any parent instance set from Java */
   protected void addReference(Object reference) {

--- a/swig/java/CMakeLists.txt
+++ b/swig/java/CMakeLists.txt
@@ -237,6 +237,7 @@ if (Java_Runtime_FOUND AND BUILD_TESTING)
   set_tests_properties(java_ogrtindex PROPERTIES DEPENDS java_GDALContour)
   add_test(NAME java_OSRTest COMMAND ${JAVA_RUN} OSRTest)
   add_test(NAME java_test_ogrfielddomains COMMAND ${JAVA_RUN} test_ogrfielddomains)
+  add_test(NAME java_GDALClose COMMAND ${JAVA_RUN} GDALClose)
 
   set(JAVA_TEST_LIST
           java_GDALOverviews
@@ -256,6 +257,7 @@ if (Java_Runtime_FOUND AND BUILD_TESTING)
           java_ogrtindex
           java_OSRTest
           java_test_ogrfielddomains
+          java_GDALClose
   )
   if (OGR_ENABLE_DRIVER_CSV)
       add_test(NAME java_OGRTest COMMAND ${JAVA_RUN} OGRTest)

--- a/swig/java/apps/GDALClose.java
+++ b/swig/java/apps/GDALClose.java
@@ -1,0 +1,34 @@
+import org.gdal.gdal.Band;
+import org.gdal.gdal.Dataset;
+import org.gdal.gdal.Driver;
+import org.gdal.gdal.gdal;
+
+import static org.gdal.gdalconst.gdalconstConstants.GDT_Byte;
+
+public class GDALClose {
+    public static void main(String[] args) {
+
+        gdal.AllRegister();
+
+        Driver drv = gdal.GetDriverByName("GTiff");
+        Dataset ds = drv.Create("/vsimem/test.tif", 10, 10, 1, GDT_Byte, new String[]{});
+        Band bd = ds.GetRasterBand(1);
+        System.err.println("First closing");
+        bd.GetDataset().Close();
+        ds = null;
+        System.gc();
+
+        ds = gdal.Open("/vsimem/test.tif");
+        bd = ds.GetRasterBand(1);
+        System.err.println("Second closing");
+        bd.GetDataset().Close();
+        ds = null;
+        bd = null;
+        System.gc();
+        System.gc();
+        try {
+            Thread.sleep(500);
+        } catch (Exception ignore) {
+        }
+    }
+}


### PR DESCRIPTION
Fixes #12764
