### PR TITLE
Set the varchar2 type length to be "CHAR" instead of the default "BYTE"

### DIFF
--- a/ogr/ogrsf_frmts/oci/ogrociwritablelayer.cpp
+++ b/ogr/ogrsf_frmts/oci/ogrociwritablelayer.cpp
@@ -282,7 +282,7 @@ OGRErr OGROCIWritableLayer::CreateField(const OGRFieldDefn *poFieldIn,
             snprintf(szFieldType, sizeof(szFieldType), "VARCHAR2(%d)",
                      nDefaultStringSize);
         else
-            snprintf(szFieldType, sizeof(szFieldType), "VARCHAR2(%d)",
+            snprintf(szFieldType, sizeof(szFieldType), "VARCHAR2(%d CHAR)",
                      oField.GetWidth());
     }
     else if (oField.GetType() == OFTDate)


### PR DESCRIPTION
## What does this PR do?

To fix the error  "ORA-12899: value too large for column ..." when loading vector data to DB.

## What are related issues/pull requests?

N/A

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
