### PR TITLE
[Backport release/3.11] Set the varchar2 type length to be "CHAR" instead of the default "BYTE"

### DIFF
--- a/ogr/ogrsf_frmts/oci/ogrociwritablelayer.cpp
+++ b/ogr/ogrsf_frmts/oci/ogrociwritablelayer.cpp
@@ -282,7 +282,7 @@ OGRErr OGROCIWritableLayer::CreateField(const OGRFieldDefn *poFieldIn,
             snprintf(szFieldType, sizeof(szFieldType), "VARCHAR2(%d)",
                      nDefaultStringSize);
         else
-            snprintf(szFieldType, sizeof(szFieldType), "VARCHAR2(%d)",
+            snprintf(szFieldType, sizeof(szFieldType), "VARCHAR2(%d CHAR)",
                      oField.GetWidth());
     }
     else if (oField.GetType() == OFTDate)


### PR DESCRIPTION
Backport #12848
 **Authored by:** @fechen123