### PR TITLE
gcore: Use initializer list for min or max of more than 2 numbers.

### DIFF
--- a/gcore/gdaldataset.cpp
+++ b/gcore/gdaldataset.cpp
@@ -10648,14 +10648,10 @@ CPLErr GDALDataset::GetExtent(OGREnvelope *psExtent,
         gt.Apply(0, nRasterYSize, &dfLLX, &dfLLY);
         double dfLRX = 0, dfLRY = 0;
         gt.Apply(nRasterXSize, nRasterYSize, &dfLRX, &dfLRY);
-        const double xmin =
-            std::min({dfULX, dfURX, dfLLX, dfLRX});
-        const double ymin =
-            std::min({dfULY, dfURY, dfLLY, dfLRY});
-        const double xmax =
-            std::max({dfULX, dfURX, dfLLX, dfLRX});
-        const double ymax =
-            std::max({dfULY, dfURY, dfLLY, dfLRY});
+        const double xmin = std::min({dfULX, dfURX, dfLLX, dfLRX});
+        const double ymin = std::min({dfULY, dfURY, dfLLY, dfLRY});
+        const double xmax = std::max({dfULX, dfURX, dfLLX, dfLRX});
+        const double ymax = std::max({dfULY, dfURY, dfLLY, dfLRY});
         if (poCT)
         {
             OGREnvelope sEnvTmp;

--- a/gcore/gdaldataset.cpp
+++ b/gcore/gdaldataset.cpp
@@ -10649,13 +10649,13 @@ CPLErr GDALDataset::GetExtent(OGREnvelope *psExtent,
         double dfLRX = 0, dfLRY = 0;
         gt.Apply(nRasterXSize, nRasterYSize, &dfLRX, &dfLRY);
         const double xmin =
-            std::min(std::min(dfULX, dfURX), std::min(dfLLX, dfLRX));
+            std::min({dfULX, dfURX, dfLLX, dfLRX});
         const double ymin =
-            std::min(std::min(dfULY, dfURY), std::min(dfLLY, dfLRY));
+            std::min({dfULY, dfURY, dfLLY, dfLRY});
         const double xmax =
-            std::max(std::max(dfULX, dfURX), std::max(dfLLX, dfLRX));
+            std::max({dfULX, dfURX, dfLLX, dfLRX});
         const double ymax =
-            std::max(std::max(dfULY, dfURY), std::max(dfLLY, dfLRY));
+            std::max({dfULY, dfURY, dfLLY, dfLRY});
         if (poCT)
         {
             OGREnvelope sEnvTmp;

--- a/gcore/gdaljp2metadata.cpp
+++ b/gcore/gdaljp2metadata.cpp
@@ -1462,10 +1462,10 @@ GDALJP2Box *GDALJP2Metadata::CreateGMLJP2(int nXSize, int nYSize)
     double dfY2 = m_gt[3] + nXSize * m_gt[4];
     double dfY3 = m_gt[3] + nYSize * m_gt[5];
     double dfY4 = m_gt[3] + nXSize * m_gt[4] + nYSize * m_gt[5];
-    double dfLCX = std::min(std::min(dfX1, dfX2), std::min(dfX3, dfX4));
-    double dfLCY = std::min(std::min(dfY1, dfY2), std::min(dfY3, dfY4));
-    double dfUCX = std::max(std::max(dfX1, dfX2), std::max(dfX3, dfX4));
-    double dfUCY = std::max(std::max(dfY1, dfY2), std::max(dfY3, dfY4));
+    double dfLCX = std::min({dfX1, dfX2, dfX3, dfX4});
+    double dfLCY = std::min({dfY1, dfY2, dfY3, dfY4});
+    double dfUCX = std::max({dfX1, dfX2, dfX3, dfX4});
+    double dfUCY = std::max({dfY1, dfY2, dfY3, dfY4});
     if (bNeedAxisFlip)
     {
         std::swap(dfLCX, dfLCY);
@@ -2478,10 +2478,10 @@ GDALJP2Box *GDALJP2Metadata::CreateGMLJP2V2(int nXSize, int nYSize,
         double dfY2 = m_gt[3] + nXSize * m_gt[4];
         double dfY3 = m_gt[3] + nYSize * m_gt[5];
         double dfY4 = m_gt[3] + nXSize * m_gt[4] + nYSize * m_gt[5];
-        double dfLCX = std::min(std::min(dfX1, dfX2), std::min(dfX3, dfX4));
-        double dfLCY = std::min(std::min(dfY1, dfY2), std::min(dfY3, dfY4));
-        double dfUCX = std::max(std::max(dfX1, dfX2), std::max(dfX3, dfX4));
-        double dfUCY = std::max(std::max(dfY1, dfY2), std::max(dfY3, dfY4));
+        double dfLCX = std::min({dfX1, dfX2, dfX3, dfX4});
+        double dfLCY = std::min({dfY1, dfY2, dfY3, dfY4});
+        double dfUCX = std::max({dfX1, dfX2, dfX3, dfX4});
+        double dfUCY = std::max({dfY1, dfY2, dfY3, dfY4});
         if (bNeedAxisFlip)
         {
             std::swap(dfLCX, dfLCY);


### PR DESCRIPTION
Why?

- Slightly more readable with the form `std::min({a, b, c, ...}`
- Slightly better performance for non-optimized builds

An example to play with: https://godbolt.org/z/sKfTMz6GE

Spotted reviewing https://github.com/OSGeo/gdal/commit/ac95cad0fc09b71b39756fd85b7791523b284a6e / https://github.com/OSGeo/gdal/pull/12814

It's a C++11 feature, so safe to do: https://en.cppreference.com/w/cpp/algorithm/min.html