### PR TITLE
RAT: Avoid invalid memory access in ValuesIO

### DIFF
--- a/autotest/gcore/rat.py
+++ b/autotest/gcore/rat.py
@@ -65,78 +65,68 @@ def test_rat_1(test_rat):
 
 
 @pytest.mark.require_driver("PNM")
-def test_rat_2(test_rat):
+def test_rat_2(test_rat, tmp_vsimem):
 
-    ds = gdal.GetDriverByName("PNM").Create("tmp/rat_2.pnm", 100, 90, 1, gdal.GDT_Byte)
-    ds.GetRasterBand(1).SetDefaultRAT(test_rat)
+    with gdal.GetDriverByName("PNM").Create(
+        tmp_vsimem / "rat_2.pnm", 100, 90, 1, gdal.GDT_Byte
+    ) as ds:
+        ds.GetRasterBand(1).SetDefaultRAT(test_rat)
 
-    ds = None
+    with gdal.Open(tmp_vsimem / "rat_2.pnm", gdal.GA_Update) as ds:
+        rat2 = ds.GetRasterBand(1).GetDefaultRAT()
 
-    ds = gdal.Open("tmp/rat_2.pnm", gdal.GA_Update)
-    rat2 = ds.GetRasterBand(1).GetDefaultRAT()
+        assert rat2.GetColumnCount() == 2, "wrong column count"
 
-    assert rat2.GetColumnCount() == 2, "wrong column count"
+        assert rat2.GetRowCount() == 3, "wrong row count"
 
-    assert rat2.GetRowCount() == 3, "wrong row count"
+        assert rat2.GetNameOfCol(1) == "Count", "wrong column name"
 
-    assert rat2.GetNameOfCol(1) == "Count", "wrong column name"
+        assert rat2.GetUsageOfCol(1) == gdal.GFU_PixelCount, "wrong column usage"
 
-    assert rat2.GetUsageOfCol(1) == gdal.GFU_PixelCount, "wrong column usage"
+        assert rat2.GetTypeOfCol(1) == gdal.GFT_Integer, "wrong column type"
 
-    assert rat2.GetTypeOfCol(1) == gdal.GFT_Integer, "wrong column type"
+        assert rat2.GetRowOfValue(11.0) == 1, "wrong row for value"
 
-    assert rat2.GetRowOfValue(11.0) == 1, "wrong row for value"
+        assert rat2.GetValueAsInt(1, 1) == 200, "wrong field value."
 
-    assert rat2.GetValueAsInt(1, 1) == 200, "wrong field value."
+        # unset the RAT
+        ds.GetRasterBand(1).SetDefaultRAT(None)
 
-    # unset the RAT
-    ds.GetRasterBand(1).SetDefaultRAT(None)
-
-    ds = None
-
-    ds = gdal.Open("tmp/rat_2.pnm")
-    rat = ds.GetRasterBand(1).GetDefaultRAT()
-    ds = None
-    assert rat is None, "expected a NULL RAT."
-
-    gdal.GetDriverByName("PNM").Delete("tmp/rat_2.pnm")
+    with gdal.Open(tmp_vsimem / "rat_2.pnm") as ds:
+        rat = ds.GetRasterBand(1).GetDefaultRAT()
+        assert rat is None, "expected a NULL RAT."
 
 
 ###############################################################################
 # Save an empty RAT (#5451)
 
 
-def test_rat_3():
+def test_rat_3(tmp_vsimem):
 
-    ds = gdal.GetDriverByName("GTiff").Create("/vsimem/rat_3.tif", 1, 1)
-    ds.GetRasterBand(1).SetDefaultRAT(gdal.RasterAttributeTable())
-    ds = None
-
-    gdal.GetDriverByName("GTiff").Delete("/vsimem/rat_3.tif")
+    with gdal.GetDriverByName("GTiff").Create(tmp_vsimem / "rat_3.tif", 1, 1) as ds:
+        ds.GetRasterBand(1).SetDefaultRAT(gdal.RasterAttributeTable())
 
 
 ###############################################################################
 # Edit an existing RAT (#3783)
 
 
-def test_rat_4():
+def test_rat_4(tmp_vsimem):
 
     # Create test RAT
-    ds = gdal.GetDriverByName("GTiff").Create("/vsimem/rat_4.tif", 1, 1)
-    rat = gdal.RasterAttributeTable()
-    rat.CreateColumn("VALUE", gdal.GFT_Integer, gdal.GFU_MinMax)
-    rat.CreateColumn("CLASS", gdal.GFT_String, gdal.GFU_Name)
-    rat.SetValueAsInt(0, 0, 111)
-    rat.SetValueAsString(0, 1, "Class1")
-    ds.GetRasterBand(1).SetDefaultRAT(rat)
-    ds = None
+    with gdal.GetDriverByName("GTiff").Create(tmp_vsimem / "rat_4.tif", 1, 1) as ds:
+        rat = gdal.RasterAttributeTable()
+        rat.CreateColumn("VALUE", gdal.GFT_Integer, gdal.GFU_MinMax)
+        rat.CreateColumn("CLASS", gdal.GFT_String, gdal.GFU_Name)
+        rat.SetValueAsInt(0, 0, 111)
+        rat.SetValueAsString(0, 1, "Class1")
+        ds.GetRasterBand(1).SetDefaultRAT(rat)
 
     # Verify
-    ds = gdal.OpenEx("/vsimem/rat_4.tif")
-    gdal_band = ds.GetRasterBand(1)
-    rat = gdal_band.GetDefaultRAT()
-    assert rat.GetValueAsInt(0, 0) == 111
-    ds = None
+    with gdal.OpenEx(tmp_vsimem / "rat_4.tif") as ds:
+        gdal_band = ds.GetRasterBand(1)
+        rat = gdal_band.GetDefaultRAT()
+        assert rat.GetValueAsInt(0, 0) == 111
 
     # Replace existing RAT
     rat = gdal.RasterAttributeTable()
@@ -144,20 +134,13 @@ def test_rat_4():
     rat.CreateColumn("CLASS", gdal.GFT_String, gdal.GFU_Name)
     rat.SetValueAsInt(0, 0, 222)
     rat.SetValueAsString(0, 1, "Class1")
-    ds = gdal.OpenEx("/vsimem/rat_4.tif", gdal.OF_RASTER | gdal.OF_UPDATE)
-    gdal_band = ds.GetRasterBand(1)
-    gdal_band.SetDefaultRAT(rat)
-    ds = None
+    with gdal.OpenEx(tmp_vsimem / "rat_4.tif", gdal.OF_RASTER | gdal.OF_UPDATE) as ds:
+        gdal_band = ds.GetRasterBand(1)
+        gdal_band.SetDefaultRAT(rat)
 
     # Verify
-    ds = gdal.OpenEx("/vsimem/rat_4.tif")
-    gdal_band = ds.GetRasterBand(1)
-    rat = gdal_band.GetDefaultRAT()
-    assert rat is not None
-    assert rat.GetValueAsInt(0, 0) == 222
-    ds = None
-
-    gdal.GetDriverByName("GTiff").Delete("/vsimem/rat_4.tif")
-
-
-##############################################################################
+    with gdal.OpenEx(tmp_vsimem / "rat_4.tif") as ds:
+        gdal_band = ds.GetRasterBand(1)
+        rat = gdal_band.GetDefaultRAT()
+        assert rat is not None
+        assert rat.GetValueAsInt(0, 0) == 222

--- a/gcore/gdal_rat.cpp
+++ b/gcore/gdal_rat.cpp
@@ -66,12 +66,12 @@
  * column of usage GFU_MinMax can be used.
  *
  * In other cases all the categories are of equal size and regularly spaced
- * and the categorization information can be determine just by knowing the
+ * and the categorization information can be determined just by knowing the
  * value at which the categories start, and the size of a category.  This
  * is called "Linear Binning" and the information is kept specially on
  * the raster attribute table as a whole.
  *
- * RATs are normally associated with GDALRasterBands and be be queried
+ * RATs are normally associated with GDALRasterBands and can be queried
  * using the GDALRasterBand::GetDefaultRAT() method.
  */
 
@@ -119,7 +119,7 @@ CPLErr GDALRasterAttributeTable::ValuesIO(GDALRWFlag eRWFlag, int iField,
     {
         for (int iIndex = iStartRow; iIndex < (iStartRow + iLength); iIndex++)
         {
-            pdfData[iIndex] = GetValueAsDouble(iIndex, iField);
+            pdfData[iIndex - iStartRow] = GetValueAsDouble(iIndex, iField);
         }
     }
     else
@@ -127,7 +127,7 @@ CPLErr GDALRasterAttributeTable::ValuesIO(GDALRWFlag eRWFlag, int iField,
         for (int iIndex = iStartRow;
              eErr == CE_None && iIndex < (iStartRow + iLength); iIndex++)
         {
-            eErr = SetValue(iIndex, iField, pdfData[iIndex]);
+            eErr = SetValue(iIndex, iField, pdfData[iIndex - iStartRow]);
         }
     }
     return eErr;
@@ -185,7 +185,7 @@ CPLErr GDALRasterAttributeTable::ValuesIO(GDALRWFlag eRWFlag, int iField,
     {
         for (int iIndex = iStartRow; iIndex < (iStartRow + iLength); iIndex++)
         {
-            pnData[iIndex] = GetValueAsInt(iIndex, iField);
+            pnData[iIndex - iStartRow] = GetValueAsInt(iIndex, iField);
         }
     }
     else
@@ -193,7 +193,7 @@ CPLErr GDALRasterAttributeTable::ValuesIO(GDALRWFlag eRWFlag, int iField,
         for (int iIndex = iStartRow;
              eErr == CE_None && iIndex < (iStartRow + iLength); iIndex++)
         {
-            eErr = SetValue(iIndex, iField, pnData[iIndex]);
+            eErr = SetValue(iIndex, iField, pnData[iIndex - iStartRow]);
         }
     }
     return eErr;
@@ -253,7 +253,8 @@ CPLErr GDALRasterAttributeTable::ValuesIO(GDALRWFlag eRWFlag, int iField,
     {
         for (int iIndex = iStartRow; iIndex < (iStartRow + iLength); iIndex++)
         {
-            papszStrList[iIndex] = VSIStrdup(GetValueAsString(iIndex, iField));
+            papszStrList[iIndex - iStartRow] =
+                VSIStrdup(GetValueAsString(iIndex, iField));
         }
     }
     else
@@ -261,7 +262,7 @@ CPLErr GDALRasterAttributeTable::ValuesIO(GDALRWFlag eRWFlag, int iField,
         for (int iIndex = iStartRow;
              eErr == CE_None && iIndex < (iStartRow + iLength); iIndex++)
         {
-            eErr = SetValue(iIndex, iField, papszStrList[iIndex]);
+            eErr = SetValue(iIndex, iField, papszStrList[iIndex - iStartRow]);
         }
     }
     return eErr;

--- a/swig/include/gdal_array.i
+++ b/swig/include/gdal_array.i
@@ -2893,6 +2893,10 @@ def RATReadArray(rat, field, start=0, length=None):
     if length is None:
         length = rat.GetRowCount() - start
 
+    if length < 0:
+        gdal.Error(gdal.CE_Failure, gdal.CPLE_AppDefined, "length must be a positive integer")
+        _RaiseException()
+
     ret = RATValuesIONumPyRead(rat, field, start, length)
     if ret is None:
         _RaiseException()


### PR DESCRIPTION
Prevent `GDALRasterAttributeTable::ValuesIO` from accessing incorrect locations whenever `iStartRow` is nonzero.