### PR TITLE
autotest: allow to run test suite without lxml to avoid crashes on mingw64

### DIFF
--- a/.github/workflows/cmake_builds.yml
+++ b/.github/workflows/cmake_builds.yml
@@ -329,7 +329,7 @@ jobs:
             mingw-w64-x86_64-geos mingw-w64-x86_64-libspatialite mingw-w64-x86_64-proj
             mingw-w64-x86_64-cgal mingw-w64-x86_64-libfreexl mingw-w64-x86_64-hdf5 mingw-w64-x86_64-muparser mingw-w64-x86_64-netcdf mingw-w64-x86_64-poppler  mingw-w64-x86_64-podofo mingw-w64-x86_64-postgresql
             mingw-w64-x86_64-libgeotiff mingw-w64-x86_64-libpng mingw-w64-x86_64-libtiff mingw-w64-x86_64-openjpeg2
-            mingw-w64-x86_64-python-pip mingw-w64-x86_64-python-numpy mingw-w64-x86_64-python-pytest mingw-w64-x86_64-python-setuptools mingw-w64-x86_64-python-lxml mingw-w64-x86_64-swig mingw-w64-x86_64-python-psutil mingw-w64-x86_64-blosc mingw-w64-x86_64-libavif
+            mingw-w64-x86_64-python-pip mingw-w64-x86_64-python-numpy mingw-w64-x86_64-python-pytest mingw-w64-x86_64-python-setuptools mingw-w64-x86_64-swig mingw-w64-x86_64-python-psutil mingw-w64-x86_64-blosc mingw-w64-x86_64-libavif
       - name: Setup cache
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         id: cache
@@ -353,7 +353,7 @@ jobs:
         run: |
           # One of the dependencies of jsonschema 4.18 is rpds_py which requires a Rust compiler
           PYTHON_CMD=python3 && $PYTHON_CMD -m pip install "jsonschema<4.18"
-          PYTHON_CMD=python3 && $PYTHON_CMD -m pip install -r autotest/requirements.txt
+          PYTHON_CMD=python3 && $PYTHON_CMD -m pip install pytest-sugar pytest-env pytest-benchmark filelock
       # Disable mySQL since C:/mysql/lib/mysqlclient.lib (unrelated to msys) is found, which causes linking issues
       # Set explicitly CMAKE_C|CXX_COMPILER otherwise C:/ProgramData/chocolatey/bin/gcc.exe would be used
       # Disable GDAL_ENABLE_DRIVER_HDF5 because of https://github.com/OSGeo/gdal/issues/11181

--- a/autotest/alg/warp.py
+++ b/autotest/alg/warp.py
@@ -28,8 +28,6 @@ pytestmark = pytest.mark.skipif(
     reason="VRT driver open missing",
 )
 
-from lxml import etree
-
 from osgeo import gdal, osr
 
 ###############################################################################
@@ -2040,60 +2038,6 @@ def test_warp_multi_threaded_errors(tmp_vsimem):
 ###############################################################################
 
 
-schema_optionlist = etree.XML(
-    r"""
-<xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
-    <xs:element name="Value">
-    <xs:complexType>
-      <xs:simpleContent>
-        <xs:extension base="xs:string">
-          <xs:attribute type="xs:string" name="alias" use="optional"/>
-        </xs:extension>
-      </xs:simpleContent>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="Option">
-    <xs:complexType mixed="true">
-      <xs:sequence>
-        <xs:element ref="Value" maxOccurs="unbounded" minOccurs="0"/>
-      </xs:sequence>
-      <xs:attribute name="name" use="required">
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:pattern value="[^\s]*"/>
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute name="type" use="required">
-        <xs:simpleType>
-          <xs:restriction base="xs:string">
-            <xs:enumeration value="int" />
-            <xs:enumeration value="float" />
-            <xs:enumeration value="boolean" />
-            <xs:enumeration value="string-select" />
-            <xs:enumeration value="string" />
-          </xs:restriction>
-        </xs:simpleType>
-      </xs:attribute>
-      <xs:attribute type="xs:string" name="description" use="optional"/>
-      <xs:attribute type="xs:string" name="default" use="optional"/>
-      <xs:attribute type="xs:string" name="alias" use="optional"/>
-      <xs:attribute type="xs:string" name="min" use="optional"/>
-      <xs:attribute type="xs:string" name="max" use="optional"/>
-    </xs:complexType>
-  </xs:element>
-  <xs:element name="OptionList">
-    <xs:complexType>
-      <xs:sequence>
-        <xs:element ref="Option" maxOccurs="unbounded" minOccurs="0"/>
-      </xs:sequence>
-    </xs:complexType>
-  </xs:element>
-</xs:schema>
-"""
-)
-
-
 def test_warp_validate_options():
 
     if (
@@ -2102,6 +2046,61 @@ def test_warp_validate_options():
         or gdaltest.is_travis_branch("build-windows-minimum")
     ):
         pytest.skip("Crashes for unknown reason")
+
+    from lxml import etree
+
+    schema_optionlist = etree.XML(
+        r"""
+    <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+        <xs:element name="Value">
+        <xs:complexType>
+          <xs:simpleContent>
+            <xs:extension base="xs:string">
+              <xs:attribute type="xs:string" name="alias" use="optional"/>
+            </xs:extension>
+          </xs:simpleContent>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="Option">
+        <xs:complexType mixed="true">
+          <xs:sequence>
+            <xs:element ref="Value" maxOccurs="unbounded" minOccurs="0"/>
+          </xs:sequence>
+          <xs:attribute name="name" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:pattern value="[^\s]*"/>
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute name="type" use="required">
+            <xs:simpleType>
+              <xs:restriction base="xs:string">
+                <xs:enumeration value="int" />
+                <xs:enumeration value="float" />
+                <xs:enumeration value="boolean" />
+                <xs:enumeration value="string-select" />
+                <xs:enumeration value="string" />
+              </xs:restriction>
+            </xs:simpleType>
+          </xs:attribute>
+          <xs:attribute type="xs:string" name="description" use="optional"/>
+          <xs:attribute type="xs:string" name="default" use="optional"/>
+          <xs:attribute type="xs:string" name="alias" use="optional"/>
+          <xs:attribute type="xs:string" name="min" use="optional"/>
+          <xs:attribute type="xs:string" name="max" use="optional"/>
+        </xs:complexType>
+      </xs:element>
+      <xs:element name="OptionList">
+        <xs:complexType>
+          <xs:sequence>
+            <xs:element ref="Option" maxOccurs="unbounded" minOccurs="0"/>
+          </xs:sequence>
+        </xs:complexType>
+      </xs:element>
+    </xs:schema>
+    """
+    )
 
     schema = etree.XMLSchema(schema_optionlist)
 

--- a/autotest/gcore/test_driver_metadata.py
+++ b/autotest/gcore/test_driver_metadata.py
@@ -14,7 +14,6 @@
 
 import gdaltest
 import pytest
-from lxml import etree
 
 from osgeo import gdal
 
@@ -52,8 +51,13 @@ multidim_driver_name = [
     == "YES"
 ]
 
-schema_openoptionslist = etree.XML(
-    r"""
+
+def get_schema_openoptionslist():
+
+    from lxml import etree
+
+    return etree.XML(
+        r"""
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:element name="Value">
     <xs:complexType>
@@ -119,10 +123,15 @@ schema_openoptionslist = etree.XML(
   </xs:element>
 </xs:schema>
 """
-)
+    )
 
-schema_creationoptionslist_xml = etree.XML(
-    r"""
+
+def get_schema_creationoptionslist_xml():
+
+    from lxml import etree
+
+    return etree.XML(
+        r"""
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:element name="Value">
     <xs:complexType>
@@ -189,10 +198,15 @@ schema_creationoptionslist_xml = etree.XML(
   </xs:element>
 </xs:schema>
 """
-)
+    )
 
-schema_layer_creationoptionslist_xml = etree.XML(
-    r"""
+
+def get_schema_layer_creationoptionslist_xml():
+
+    from lxml import etree
+
+    return etree.XML(
+        r"""
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:element name="Value">
     <xs:complexType>
@@ -258,11 +272,15 @@ schema_layer_creationoptionslist_xml = etree.XML(
   </xs:element>
 </xs:schema>
 """
-)
+    )
 
 
-schema_multidim_array_creationoptionslist_xml = etree.XML(
-    r"""
+def get_schema_multidim_array_creationoptionslist_xml():
+
+    from lxml import etree
+
+    return etree.XML(
+        r"""
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:element name="Value">
     <xs:complexType>
@@ -296,11 +314,15 @@ schema_multidim_array_creationoptionslist_xml = etree.XML(
   </xs:element>
 </xs:schema>
 """
-)
+    )
 
 
-schema_multidim_attribute_creationoptionslist_xml = etree.XML(
-    r"""
+def get_schema_multidim_attribute_creationoptionslist_xml():
+
+    from lxml import etree
+
+    return etree.XML(
+        r"""
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="Value" type="xs:string"/>
   <xs:element name="Option">
@@ -321,11 +343,15 @@ schema_multidim_attribute_creationoptionslist_xml = etree.XML(
     </xs:complexType>
   </xs:element>
 </xs:schema>"""
-)
+    )
 
 
-schema_multidim_dataset_creationoptionslist_xml = etree.XML(
-    r"""
+def get_schema_multidim_dataset_creationoptionslist_xml():
+
+    from lxml import etree
+
+    return etree.XML(
+        r"""
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="Value" type="xs:string"/>
   <xs:element name="Option">
@@ -347,11 +373,15 @@ schema_multidim_dataset_creationoptionslist_xml = etree.XML(
     </xs:complexType>
   </xs:element>
 </xs:schema>"""
-)
+    )
 
 
-schema_multidim_dimension_creationoptionslist_xml = etree.XML(
-    r"""
+def get_schema_multidim_dimension_creationoptionslist_xml():
+
+    from lxml import etree
+
+    return etree.XML(
+        r"""
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
   <xs:element name="Option">
     <xs:complexType>
@@ -373,7 +403,7 @@ schema_multidim_dimension_creationoptionslist_xml = etree.XML(
     </xs:complexType>
   </xs:element>
 </xs:schema>"""
-)
+    )
 
 
 @pytest.mark.parametrize("driver_name", all_driver_names)
@@ -399,7 +429,9 @@ def test_metadata_dcap_yes(driver_name):
 def test_metadata_openoptionlist(driver_name):
     """Test if DMD_OPENOPTIONLIST metadataitem is present and can be parsed"""
 
-    schema = etree.XMLSchema(schema_openoptionslist)
+    from lxml import etree
+
+    schema = etree.XMLSchema(get_schema_openoptionslist())
 
     driver = gdal.GetDriverByName(driver_name)
     openoptionlist_xml = driver.GetMetadataItem("DMD_OPENOPTIONLIST")
@@ -418,7 +450,9 @@ def test_metadata_openoptionlist(driver_name):
 def test_metadata_creationoptionslist(driver_name):
     """Test if DMD_CREATIONOPTIONLIST metadataitem is present and can be parsed"""
 
-    schema = etree.XMLSchema(schema_creationoptionslist_xml)
+    from lxml import etree
+
+    schema = etree.XMLSchema(get_schema_creationoptionslist_xml())
 
     driver = gdal.GetDriverByName(driver_name)
     creationoptionslist_xml = driver.GetMetadataItem("DMD_CREATIONOPTIONLIST")
@@ -437,7 +471,9 @@ def test_metadata_creationoptionslist(driver_name):
 def test_metadata_layer_creationoptionslist(driver_name):
     """Test if DS_LAYER_CREATIONOPTIONLIST metadataitem is present and can be parsed"""
 
-    schema = etree.XMLSchema(schema_layer_creationoptionslist_xml)
+    from lxml import etree
+
+    schema = etree.XMLSchema(get_schema_layer_creationoptionslist_xml())
 
     driver = gdal.GetDriverByName(driver_name)
     creationoptionslist_xml = driver.GetMetadataItem("DS_LAYER_CREATIONOPTIONLIST")
@@ -456,7 +492,9 @@ def test_metadata_layer_creationoptionslist(driver_name):
 def test_metadata_multidim_array_creationoptionslist(driver_name):
     """Test if DMD_MULTIDIM_ARRAY_CREATIONOPTIONLIST metadataitem is present and can be parsed"""
 
-    schema = etree.XMLSchema(schema_multidim_array_creationoptionslist_xml)
+    from lxml import etree
+
+    schema = etree.XMLSchema(get_schema_multidim_array_creationoptionslist_xml())
 
     driver = gdal.GetDriverByName(driver_name)
     xml = driver.GetMetadataItem("DMD_MULTIDIM_ARRAY_CREATIONOPTIONLIST")
@@ -475,7 +513,9 @@ def test_metadata_multidim_array_creationoptionslist(driver_name):
 def test_metadata_multidim_attribute_creationoptionslist(driver_name):
     """Test if DMD_MULTIDIM_ATTRIBUTE_CREATIONOPTIONLIST metadataitem is present and can be parsed"""
 
-    schema = etree.XMLSchema(schema_multidim_attribute_creationoptionslist_xml)
+    from lxml import etree
+
+    schema = etree.XMLSchema(get_schema_multidim_attribute_creationoptionslist_xml())
 
     driver = gdal.GetDriverByName(driver_name)
     xml = driver.GetMetadataItem("DMD_MULTIDIM_ATTRIBUTE_CREATIONOPTIONLIST")
@@ -494,7 +534,9 @@ def test_metadata_multidim_attribute_creationoptionslist(driver_name):
 def test_metadata_multidim_dataset_creationoptionslist(driver_name):
     """Test if DMD_MULTIDIM_DATASET_CREATIONOPTIONLIST metadataitem is present and can be parsed"""
 
-    schema = etree.XMLSchema(schema_multidim_dataset_creationoptionslist_xml)
+    from lxml import etree
+
+    schema = etree.XMLSchema(get_schema_multidim_dataset_creationoptionslist_xml())
 
     driver = gdal.GetDriverByName(driver_name)
     xml = driver.GetMetadataItem("DMD_MULTIDIM_DATASET_CREATIONOPTIONLIST")
@@ -513,7 +555,9 @@ def test_metadata_multidim_dataset_creationoptionslist(driver_name):
 def test_metadata_multidim_dimension_creationoptionslist(driver_name):
     """Test if DMD_MULTIDIM_DIMENSION_CREATIONOPTIONLIST metadataitem is present and can be parsed"""
 
-    schema = etree.XMLSchema(schema_multidim_dimension_creationoptionslist_xml)
+    from lxml import etree
+
+    schema = etree.XMLSchema(get_schema_multidim_dimension_creationoptionslist_xml())
 
     driver = gdal.GetDriverByName(driver_name)
     xml = driver.GetMetadataItem("DMD_MULTIDIM_DIMENSION_CREATIONOPTIONLIST")
@@ -531,6 +575,8 @@ def test_metadata_multidim_dimension_creationoptionslist(driver_name):
 @pytest.mark.parametrize("driver_name", multidim_driver_name)
 def test_metadata_multidim_group_creationoptionslist(driver_name):
     """Test if DMD_MULTIDIM_GROUP_CREATIONOPTIONLIST metadataitem is present and can be parsed"""
+
+    from lxml import etree
 
     # TODO: create schema if xml is available
     # schema = etree.XMLSchema(schema_multidim_group_creationoptionslist_xml)

--- a/autotest/gcore/transformer.py
+++ b/autotest/gcore/transformer.py
@@ -18,7 +18,6 @@ import math
 
 import gdaltest
 import pytest
-from lxml import etree
 
 from osgeo import gdal, osr
 
@@ -1337,8 +1336,19 @@ def test_transformer_unknown_option():
 ###############################################################################
 
 
-schema_optionlist = etree.XML(
-    r"""
+def test_transformer_validate_options():
+
+    if (
+        gdaltest.is_travis_branch("mingw64")
+        or gdaltest.is_travis_branch("build-windows-conda")
+        or gdaltest.is_travis_branch("build-windows-minimum")
+    ):
+        pytest.skip("Crashes for unknown reason")
+
+    from lxml import etree
+
+    schema_optionlist = etree.XML(
+        r"""
 <xs:schema attributeFormDefault="unqualified" elementFormDefault="qualified" xmlns:xs="http://www.w3.org/2001/XMLSchema">
     <xs:element name="Value">
     <xs:complexType>
@@ -1388,17 +1398,7 @@ schema_optionlist = etree.XML(
   </xs:element>
 </xs:schema>
 """
-)
-
-
-def test_transformer_validate_options():
-
-    if (
-        gdaltest.is_travis_branch("mingw64")
-        or gdaltest.is_travis_branch("build-windows-conda")
-        or gdaltest.is_travis_branch("build-windows-minimum")
-    ):
-        pytest.skip("Crashes for unknown reason")
+    )
 
     schema = etree.XMLSchema(schema_optionlist)
 

--- a/autotest/gcore/vsifile.py
+++ b/autotest/gcore/vsifile.py
@@ -18,7 +18,6 @@ import time
 
 import gdaltest
 import pytest
-from lxml import etree
 
 from osgeo import gdal, ogr
 
@@ -800,6 +799,8 @@ def test_vsifile_18():
     reason="Crashes for unknown reason",
 )
 def test_vsifile_19():
+
+    from lxml import etree
 
     for prefix in gdal.GetFileSystemsPrefixes():
         options = gdal.GetFileSystemOptions(prefix)

--- a/autotest/pymod/xmlvalidate.py
+++ b/autotest/pymod/xmlvalidate.py
@@ -18,7 +18,7 @@ import os
 import sys
 
 import gdaltest
-from lxml import etree
+import pytest
 
 ###############################################################################
 # Remove mime header if found
@@ -80,6 +80,11 @@ def validate(
     ogc_schemas_location=None,
     inspire_schemas_location=None,
 ):
+
+    try:
+        from lxml import etree
+    except ImportError:
+        pytest.skip("lxml not available")
 
     try:
         if xml_filename_or_content.startswith("<"):


### PR DESCRIPTION

otherwise when running pytest autotest/gcore, a segmentation fault within libxml2 occurs when python exits:
```
Results (533.34s (0:08:53)):
    2825 passed
       5 xfailed
    1977 skipped

Thread 1 received signal SIGSEGV, Segmentation fault.
0x00007ffdd7a749e6 in ntdll!RtlWaitOnAddress () from C:\WINDOWS\SYSTEM32\ntdll.dll
(gdb) bt
#0  0x00007ffdd7a749e6 in ntdll!RtlWaitOnAddress () from C:\WINDOWS\SYSTEM32\ntdll.dll
#1  0x00007ffdd7a3fcb4 in ntdll!RtlEnterCriticalSection () from C:\WINDOWS\SYSTEM32\ntdll.dll
#2  0x00007ffdd7a3fae2 in ntdll!RtlEnterCriticalSection () from C:\WINDOWS\SYSTEM32\ntdll.dll
#3  0x00007ffda5703a1f in ?? () from C:\dev\msys64\mingw64\bin\libxml2-16.dll
#4  0x00007ffda570b038 in ?? () from C:\dev\msys64\mingw64\bin\libxml2-16.dll
#5  0x00007ffda5731586 in ?? () from C:\dev\msys64\mingw64\bin\libxml2-16.dll
#6  0x00007ffd9d258b7b in ?? ()
   from C:\dev\msys64\mingw64\lib\python3.12\site-packages\lxml\etree.cp312-mingw_x86_64_msvcrt_gnu.
pyd
#7  0x00007ffd9d28f155 in ?? ()
   from C:\dev\msys64\mingw64\lib\python3.12\site-packages\lxml\etree.cp312-mingw_x86_64_msvcrt_gnu.
pyd
#8  0x00007ffda94a03f5 in ?? () from C:\dev\msys64\mingw64\bin\libpython3.12.dll
#9  0x00007ffda949fbb2 in ?? () from C:\dev\msys64\mingw64\bin\libpython3.12.dll
#10 0x00007ffda93937f9 in ?? () from C:\dev\msys64\mingw64\bin\libpython3.12.dll
#11 0x00007ffda93e725c in ?? () from C:\dev\msys64\mingw64\bin\libpython3.12.dll
#12 0x00007ffda93e66bd in ?? () from C:\dev\msys64\mingw64\bin\libpython3.12.dll
#13 0x00007ffda9577dcb in ?? () from C:\dev\msys64\mingw64\bin\libpython3.12.dll
#14 0x00007ffda93f1a41 in ?? () from C:\dev\msys64\mingw64\bin\libpython3.12.dll
#15 0x00007ff67fcb1319 in ?? ()
#16 0x00007ff67fcb1426 in ?? ()
#17 0x00007ffdd7917374 in KERNEL32!BaseThreadInitThunk () from C:\WINDOWS\System32\kernel32.dll
#18 0x00007ffdd7a5cc91 in ntdll!RtlUserThreadStart () from C:\WINDOWS\SYSTEM32\ntdll.dll
#19 0x0000000000000000 in ?? ()
(gdb)

```
