### PR TITLE
Add v18 of Microsoft ODBC Driver for SQL Server to CMake module

### DIFF
--- a/cmake/modules/packages/FindMSSQL_ODBC.cmake
+++ b/cmake/modules/packages/FindMSSQL_ODBC.cmake
@@ -28,7 +28,7 @@ This module defines the following variables:
   MSSQL_ODBC_INCLUDE_DIRS   - where to find msodbcsql.h, etc.
   MSSQL_ODBC_LIBRARIES      - List of libraries when using MSSQL_ODBC.
   MSSQL_ODBC_FOUND          - True if MSSQL_ODBC found.
-  MSSQL_ODBC_VERSION        - Major Version (17, 13, ...). Can be a input variable too
+  MSSQL_ODBC_VERSION        - Major Version (18, 17, 13, ...). Can be a input variable too
 
 #]=======================================================================]
 
@@ -38,7 +38,7 @@ endif()
 
 if(WIN32)
     if(NOT DEFINED MSSQL_ODBC_VERSION)
-        set(MSSQL_ODBC_VERSION_CANDIDATES 17 13)
+        set(MSSQL_ODBC_VERSION_CANDIDATES 18 17 13)
         foreach(_vers IN LISTS MSSQL_ODBC_VERSION_CANDIDATES)
           set(_dir "C:/Program Files/Microsoft SQL Server/Client SDK/ODBC/${_vers}0/SDK")
           if(EXISTS "${_dir}")
@@ -67,7 +67,7 @@ if(WIN32)
     mark_as_advanced(MSSQL_ODBC_LIBRARY)
 else()
     if(NOT DEFINED MSSQL_ODBC_VERSION)
-        set(MSSQL_ODBC_VERSION_CANDIDATES 17 13)
+        set(MSSQL_ODBC_VERSION_CANDIDATES 18 17 13)
         foreach(_vers IN LISTS MSSQL_ODBC_VERSION_CANDIDATES)
           set(_dir "/opt/microsoft/msodbcsql${_vers}")
           if(EXISTS "${_dir}")

--- a/doc/source/development/building_from_source.rst
+++ b/doc/source/development/building_from_source.rst
@@ -1392,11 +1392,11 @@ MSSQL_ODBC
 The Microsoft SQL Native ODBC driver Library (closed source/proprietary) is required
 to enable bulk copy in the :ref:`vector.mssqlspatial` driver.
 If both MSSQL_NCLI and MSSQL_ODBC are found and enabled, MSSQL_ODBC will be used.
-The library is normally found if installed in standard location, and at version 17.
+The library is normally found if installed in standard location, and at version 17+.
 
 .. option:: MSSQL_ODBC_VERSION
 
-  Major version of the Native Client, typically 17
+  Major version of the Native Client, typically 17 or 18
 
 .. option:: MSSQL_ODBC_INCLUDE_DIR
 


### PR DESCRIPTION
## What does this PR do?

Adds version 18 of the [Microsoft ODBC Driver 18 for SQL Server](https://go.microsoft.com/fwlink/?linkid=2307162) to the CMake module, which searches for libraries in common locations such as `C:\Program Files\Microsoft SQL Server\Client SDK\ODBC\180` 

Related build docs also updated. 
