### PR TITLE
[Backport release/3.11] GetDefaultHistogram(): avoid error (on non Byte data type) when min=max

### DIFF
--- a/autotest/gcore/histogram.py
+++ b/autotest/gcore/histogram.py
@@ -743,3 +743,27 @@ def test_histogram_invalid_min_max(min, max):
         else:
             ret == [0, 0]
             assert gdal.GetLastErrorMsg() != ""
+
+
+###############################################################################
+
+
+def test_histogram_int8():
+
+    ds = gdal.GetDriverByName("MEM").Create("", 1, 1, 1, gdal.GDT_Int8)
+    ds.GetRasterBand(1).Fill(-128)
+    assert ds.GetRasterBand(1).GetDefaultHistogram() == (
+        -128.5,
+        127.5,
+        256,
+        [1] + [0] * 255,
+    )
+
+
+###############################################################################
+
+
+def test_histogram_min_equal_max():
+
+    ds = gdal.GetDriverByName("MEM").Create("", 1, 1, 1, gdal.GDT_Int16)
+    assert ds.GetRasterBand(1).GetDefaultHistogram() == (-0.5, 0.5, 1, [1])

--- a/gcore/gdalrasterband.cpp
+++ b/gcore/gdalrasterband.cpp
@@ -4914,7 +4914,7 @@ CPLErr GDALRasterBand::GetDefaultHistogram(double *pdfMin, double *pdfMax,
     if (!bForce)
         return CE_Warning;
 
-    const int nBuckets = 256;
+    int nBuckets = 256;
 
     bool bSignedByte = false;
     if (eDataType == GDT_Byte)
@@ -4932,17 +4932,31 @@ CPLErr GDALRasterBand::GetDefaultHistogram(double *pdfMin, double *pdfMax,
         *pdfMin = -0.5;
         *pdfMax = 255.5;
     }
+    else if (GetRasterDataType() == GDT_Int8)
+    {
+        *pdfMin = -128 - 0.5;
+        *pdfMax = 127 + 0.5;
+    }
     else
     {
 
         const CPLErr eErr =
             GetStatistics(TRUE, TRUE, pdfMin, pdfMax, nullptr, nullptr);
-        const double dfHalfBucket = (*pdfMax - *pdfMin) / (2 * (nBuckets - 1));
-        *pdfMin -= dfHalfBucket;
-        *pdfMax += dfHalfBucket;
-
         if (eErr != CE_None)
             return eErr;
+        if (*pdfMin == *pdfMax)
+        {
+            nBuckets = 1;
+            *pdfMin -= 0.5;
+            *pdfMax += 0.5;
+        }
+        else
+        {
+            const double dfHalfBucket =
+                (*pdfMax - *pdfMin) / (2 * (nBuckets - 1));
+            *pdfMin -= dfHalfBucket;
+            *pdfMax += dfHalfBucket;
+        }
     }
 
     *ppanHistogram =


### PR DESCRIPTION
Backport #12859
 **Authored by:** @rouault