### PR TITLE
Doc: fix link to 'gdal vector pipeline' on the Programs index page

### DIFF
--- a/doc/source/programs/index.rst
+++ b/doc/source/programs/index.rst
@@ -233,7 +233,7 @@ Vector commands
 
     Pipelines:
 
-    - :ref:`gdal_raster_pipeline`: Process a vector dataset applying several steps
+    - :ref:`gdal_vector_pipeline`: Process a vector dataset applying several steps
 
 Multidimensional raster commands
 ++++++++++++++++++++++++++++++++


### PR DESCRIPTION
## What does this PR do?

Fix link to 'gdal vector pipeline' (currently points to raster pipeline).

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE
