### PR TITLE
gdalmultidim.cpp: Use `.reserve()` before a loop around emplace_back

### DIFF
--- a/gcore/gdalmultidim.cpp
+++ b/gcore/gdalmultidim.cpp
@@ -11145,6 +11145,7 @@ GDALExtendedDataTypeCreateCompound(const char *pszName, size_t nTotalSize,
                                    const GDALEDTComponentH *comps)
 {
     std::vector<std::unique_ptr<GDALEDTComponent>> compsCpp;
+    compsCpp.reserve(nComponents);
     for (size_t i = 0; i < nComponents; i++)
     {
         compsCpp.emplace_back(


### PR DESCRIPTION
Pretty minor optimization. There are likely others, but I didn't spot any right away.

https://clang.llvm.org/extra/clang-tidy/checks/performance/inefficient-vector-operation.html

But how many components are there likely to be?