### PR TITLE
CPLString / CPLStringList: do not allow implicit cast to void*

### DIFF
--- a/frmts/aaigrid/aaigriddataset.cpp
+++ b/frmts/aaigrid/aaigriddataset.cpp
@@ -1466,8 +1466,8 @@ GDALDataset *AAIGDataset::CreateCopy(const char *pszFilename,
                 if ((iPixel > 0 && (iPixel % 1024) == 0) ||
                     iPixel == nXSize - 1)
                 {
-                    if (VSIFWriteL(osBuf, static_cast<int>(osBuf.size()), 1,
-                                   fpImage) != 1)
+                    if (VSIFWriteL(osBuf.c_str(), osBuf.size(), 1, fpImage) !=
+                        1)
                     {
                         eErr = CE_Failure;
                         ReportError(pszFilename, CE_Failure, CPLE_AppDefined,
@@ -1508,8 +1508,8 @@ GDALDataset *AAIGDataset::CreateCopy(const char *pszFilename,
                 if ((iPixel > 0 && (iPixel % 1024) == 0) ||
                     iPixel == nXSize - 1)
                 {
-                    if (VSIFWriteL(osBuf, static_cast<int>(osBuf.size()), 1,
-                                   fpImage) != 1)
+                    if (VSIFWriteL(osBuf.c_str(), osBuf.size(), 1, fpImage) !=
+                        1)
                     {
                         eErr = CE_Failure;
                         ReportError(pszFilename, CE_Failure, CPLE_AppDefined,

--- a/frmts/cals/calsdataset.cpp
+++ b/frmts/cals/calsdataset.cpp
@@ -524,25 +524,25 @@ GDALDataset *CALSDataset::CreateCopy(const char *pszFilename,
     CPLString osField;
     osField = "srcdocid: NONE";
     // cppcheck-suppress redundantCopy
-    memcpy(szBuffer, osField, osField.size());
+    memcpy(szBuffer, osField.c_str(), osField.size());
 
     osField = "dstdocid: NONE";
-    memcpy(szBuffer + 128, osField, osField.size());
+    memcpy(szBuffer + 128, osField.c_str(), osField.size());
 
     osField = "txtfilid: NONE";
-    memcpy(szBuffer + 128 * 2, osField, osField.size());
+    memcpy(szBuffer + 128 * 2, osField.c_str(), osField.size());
 
     osField = "figid: NONE";
-    memcpy(szBuffer + 128 * 3, osField, osField.size());
+    memcpy(szBuffer + 128 * 3, osField.c_str(), osField.size());
 
     osField = "srcgph: NONE";
-    memcpy(szBuffer + 128 * 4, osField, osField.size());
+    memcpy(szBuffer + 128 * 4, osField.c_str(), osField.size());
 
     osField = "doccls: NONE";
-    memcpy(szBuffer + 128 * 5, osField, osField.size());
+    memcpy(szBuffer + 128 * 5, osField.c_str(), osField.size());
 
     osField = "rtype: 1";
-    memcpy(szBuffer + 128 * 6, osField, osField.size());
+    memcpy(szBuffer + 128 * 6, osField.c_str(), osField.size());
 
     int nAngle1 = 0;
     int nAngle2 = 270;
@@ -555,11 +555,11 @@ GDALDataset *CALSDataset::CreateCopy(const char *pszFilename,
         nAngle2 = atoi(pszLineProgression);
     }
     osField = CPLSPrintf("rorient: %03d,%03d", nAngle1, nAngle2);
-    memcpy(szBuffer + 128 * 7, osField, osField.size());
+    memcpy(szBuffer + 128 * 7, osField.c_str(), osField.size());
 
     osField = CPLSPrintf("rpelcnt: %06d,%06d", poSrcDS->GetRasterXSize(),
                          poSrcDS->GetRasterYSize());
-    memcpy(szBuffer + 128 * 8, osField, osField.size());
+    memcpy(szBuffer + 128 * 8, osField.c_str(), osField.size());
 
     int nDensity = 200;
     const char *pszXRes = poSrcDS->GetMetadataItem("TIFFTAG_XRESOLUTION");
@@ -573,10 +573,10 @@ GDALDataset *CALSDataset::CreateCopy(const char *pszFilename,
             nDensity = 200;
     }
     osField = CPLSPrintf("rdensty: %04d", nDensity);
-    memcpy(szBuffer + 128 * 9, osField, osField.size());
+    memcpy(szBuffer + 128 * 9, osField.c_str(), osField.size());
 
     osField = "notes: NONE";
-    memcpy(szBuffer + 128 * 10, osField, osField.size());
+    memcpy(szBuffer + 128 * 10, osField.c_str(), osField.size());
     VSIFWriteL(szBuffer, 1, 2048, fp);
     VSIFCloseL(fp);
 

--- a/frmts/rcm/rcmdataset.cpp
+++ b/frmts/rcm/rcmdataset.cpp
@@ -1840,9 +1840,6 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
             const int bandPositionIndex = imageBandList.FindString(pszPole);
             if (bandPositionIndex < 0)
             {
-                CPLFree(imageBandList);
-                CPLFree(imageBandFileList);
-
                 CPLError(CE_Failure, CPLE_OpenFailed,
                          "ERROR: RCM cannot find the polarization %s. Please "
                          "contact your data provider for a corrected dataset",

--- a/frmts/vrt/vrtrawrasterband.cpp
+++ b/frmts/vrt/vrtrawrasterband.cpp
@@ -600,7 +600,7 @@ void VRTRawRasterBand::GetFileList(char ***ppapszFileList, int *pnSize,
     else
         osSourceFilename = m_pszSourceFilename;
 
-    if (CPLHashSetLookup(hSetFiles, osSourceFilename) != nullptr)
+    if (CPLHashSetLookup(hSetFiles, osSourceFilename.c_str()) != nullptr)
         return;
 
     /* -------------------------------------------------------------------- */

--- a/frmts/wms/minidriver_tiled_wms.cpp
+++ b/frmts/wms/minidriver_tiled_wms.cpp
@@ -361,7 +361,7 @@ CPLErr WMSMiniDriver_TiledWMS::Initialize(CPLXMLNode *config,
         // First process the changes from open options, if present
         changes = CSLFetchNameValueMultiple(OpenOptions, "Change");
         // Transfer them to subst list
-        for (int i = 0; changes && changes[i] != nullptr; i++)
+        for (int i = 0; i < changes.size(); i++)
         {
             char *key = nullptr;
             const char *value = CPLParseNameValue(changes[i], &key);
@@ -387,8 +387,8 @@ CPLErr WMSMiniDriver_TiledWMS::Initialize(CPLXMLNode *config,
         m_parent_dataset->SetMetadataItem("ServerURL", m_base_url, nullptr);
         m_parent_dataset->SetMetadataItem("TiledGroupName", tiledGroupName,
                                           nullptr);
-        for (int i = 0, n = CSLCount(substs); i < n && substs; i++)
-            m_parent_dataset->SetMetadataItem("Change", substs[i], nullptr);
+        for (const char *subst : substs)
+            m_parent_dataset->SetMetadataItem("Change", subst, nullptr);
 
         const char *pszConfiguration =
             CPLGetXMLValue(config, "Configuration", nullptr);
@@ -814,9 +814,9 @@ CPLErr WMSMiniDriver_TiledWMS::Initialize(CPLXMLNode *config,
                         nodechange = nodechange->psNext;
                     }
 
-                    for (int i = 0, n = substs.size(); i < n && substs; i++)
+                    for (const char *subst : substs)
                     {
-                        CPLString kv(substs[i]);
+                        CPLString kv(subst);
                         auto sep_pos =
                             kv.find_first_of("=:");  // It should find it
                         if (sep_pos == CPLString::npos)

--- a/frmts/xyz/xyzdataset.cpp
+++ b/frmts/xyz/xyzdataset.cpp
@@ -1719,8 +1719,7 @@ GDALDataset *XYZDataset::CreateCopy(const char *pszFilename,
             osBuf += szBuf;
             if ((i & 1023) == 0 || i == nXSize - 1)
             {
-                if (VSIFWriteL(osBuf, static_cast<int>(osBuf.size()), 1, fp) !=
-                    1)
+                if (VSIFWriteL(osBuf.c_str(), osBuf.size(), 1, fp) != 1)
                 {
                     eErr = CE_Failure;
                     CPLError(CE_Failure, CPLE_AppDefined,

--- a/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
@@ -163,8 +163,10 @@ static unsigned long OGRPGHashTableEntry(const void *_psTableEntry)
 {
     const PGTableEntry *psTableEntry =
         static_cast<const PGTableEntry *>(_psTableEntry);
-    return CPLHashSetHashStr(CPLString().Printf(
-        "%s.%s", psTableEntry->pszSchemaName, psTableEntry->pszTableName));
+    return CPLHashSetHashStr(CPLString()
+                                 .Printf("%s.%s", psTableEntry->pszSchemaName,
+                                         psTableEntry->pszTableName)
+                                 .c_str());
 }
 
 static int OGRPGEqualTableEntry(const void *_psTableEntry1,

--- a/port/cpl_string.h
+++ b/port/cpl_string.h
@@ -422,6 +422,9 @@ extern "C++"
         CPLSTRING_METHOD_DLL CPLString &tolower(void);
 
         CPLSTRING_METHOD_DLL bool endsWith(const std::string &osStr) const;
+
+      private:
+        operator void *(void) = delete;
     };
 
 #undef CPLSTRING_CLASS_DLL
@@ -644,6 +647,9 @@ extern "C++"
         {
             return std::vector<std::string>{begin(), end()};
         }
+
+      private:
+        operator void *(void) = delete;
     };
 
 #ifdef GDAL_COMPILATION


### PR DESCRIPTION
Avoid misuses such that the one in the RCM driver