### PR TITLE
Add path traversal detection in drivers

### DIFF
--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -5984,4 +5984,17 @@ TEST_F(test_cpl, CPLGetCurrentThreadCount)
 #endif
 }
 
+TEST_F(test_cpl, CPLHasPathTraversal)
+{
+    EXPECT_TRUE(CPLHasPathTraversal("a/../b"));
+    EXPECT_TRUE(CPLHasPathTraversal("a\\..\\b"));
+    EXPECT_FALSE(CPLHasPathTraversal("a/b"));
+    {
+        CPLConfigOptionSetter oSetter("CPL_ENABLE_PATH_TRAVERSAL_DETECTION",
+                                      "NO", true);
+        EXPECT_FALSE(CPLHasPathTraversal("a/../b"));
+        EXPECT_FALSE(CPLHasPathTraversal("a\\..\\b"));
+    }
+}
+
 }  // namespace

--- a/autotest/gdrivers/netcdf.py
+++ b/autotest/gdrivers/netcdf.py
@@ -2428,6 +2428,21 @@ def test_netcdf_57(tmp_path):
 
 
 ###############################################################################
+# Test one layer per file creation
+
+
+@gdaltest.enable_exceptions()
+def test_netcdf_one_layer_per_file_failure(tmp_path):
+
+    ds = ogr.GetDriverByName("netCDF").CreateDataSource(
+        tmp_path / "my_subdir",
+        options=["MULTIPLE_LAYERS=SEPARATE_FILES", "GEOMETRY_ENCODING=WKT"],
+    )
+    with pytest.raises(Exception, match="Illegal characters"):
+        ds.CreateLayer("slash/not_allowed")
+
+
+###############################################################################
 # Test one layer per group (NC4)
 
 

--- a/autotest/ogr/ogr_csv.py
+++ b/autotest/ogr/ogr_csv.py
@@ -3598,6 +3598,17 @@ def test_ogr_csv_open_dir(tmp_vsimem):
 ###############################################################################
 
 
+@gdaltest.enable_exceptions()
+def test_ogr_csv_creation_illegal_layer_name(tmp_vsimem):
+
+    ds = ogr.GetDriverByName("CSV").CreateDataSource(tmp_vsimem / "out")
+    with pytest.raises(Exception, match="Illegal character"):
+        ds.CreateLayer("illegal/with/slash")
+
+
+###############################################################################
+
+
 if __name__ == "__main__":
     gdal.UseExceptions()
     if len(sys.argv) != 2:

--- a/autotest/ogr/ogr_libkml.py
+++ b/autotest/ogr/ogr_libkml.py
@@ -2396,3 +2396,13 @@ def test_ogr_libkml_create_field_bool(tmp_vsimem):
         assert f["b"]
         f = lyr.GetNextFeature()
         assert not f["b"]
+
+
+###############################################################################
+
+
+def test_ogr_libkml_creation_illegal_layer_name(tmp_vsimem):
+
+    ds = ogr.GetDriverByName("LIBKML").CreateDataSource(tmp_vsimem / "out")
+    with pytest.raises(Exception, match="Illegal character"):
+        ds.CreateLayer("illegal/with/slash")

--- a/autotest/ogr/ogr_mitab.py
+++ b/autotest/ogr/ogr_mitab.py
@@ -3010,3 +3010,14 @@ def test_ogr_mitab_read_dbf_with_delete_column():
         f = lyr.GetNextFeature()
         assert f["id"] == 1
         assert f["str"] == "foo"
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_ogr_mitab_creation_illegal_layer_name(tmp_vsimem):
+
+    ds = ogr.GetDriverByName("MapInfo File").CreateDataSource(tmp_vsimem / "out")
+    with pytest.raises(Exception, match="Illegal character"):
+        ds.CreateLayer("illegal/with/slash")

--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -5545,6 +5545,7 @@ def test_ogr_shape_write_multipolygon_parts_non_constant_z(tmp_vsimem):
 # Test renaming a layer
 
 
+@gdaltest.enable_exceptions()
 def test_ogr_shape_rename_layer(tmp_path):
 
     outfilename = tmp_path / "test_rename.shp"
@@ -5554,15 +5555,18 @@ def test_ogr_shape_rename_layer(tmp_path):
     lyr = ds.GetLayer(0)
     assert lyr.TestCapability(ogr.OLCRename) == 1
 
-    with gdal.quiet_errors():
-        assert lyr.Rename("test_rename") != ogr.OGRERR_NONE
+    with pytest.raises(Exception, match="Illegal character"):
+        lyr.Rename("illegal/slash")
+
+    with pytest.raises(Exception):
+        lyr.Rename("test_rename")
 
     f = gdal.VSIFOpenL(tmp_path / "test_rename_foo.dbf", "wb")
     assert f
     gdal.VSIFCloseL(f)
 
-    with gdal.quiet_errors():
-        assert lyr.Rename("test_rename_foo") != ogr.OGRERR_NONE
+    with pytest.raises(Exception):
+        lyr.Rename("test_rename_foo")
 
     gdal.Unlink(tmp_path / "test_rename_foo.dbf")
 

--- a/doc/source/user/configoptions.rst
+++ b/doc/source/user/configoptions.rst
@@ -511,6 +511,15 @@ General options
 
       Location of Python shared library file, e.g. ``pythonX.Y[...].so/.dll``.
 
+-  .. config:: CPL_ENABLE_PATH_TRAVERSAL_DETECTION
+      :choices: YES, NO
+      :default: YES
+      :since: 3.12
+
+      Whether :cpp:func:`CPLHasPathTraversal` must detect ``../`` or ``..\\``
+      patterns in file paths that could cause
+      `path traversal vulnerabilities <https://en.wikipedia.org/wiki/Directory_traversal_attack>`__.
+
 
 .. _configoptions_vector:
 

--- a/frmts/ers/ersdataset.cpp
+++ b/frmts/ers/ersdataset.cpp
@@ -987,12 +987,17 @@ GDALDataset *ERSDataset::Open(GDALOpenInfo *poOpenInfo)
     CPLString osPath = CPLGetPathSafe(poOpenInfo->pszFilename);
     CPLString osDataFile = poHeader->Find("DataFile", "");
 
-    if (osDataFile.length() == 0)  // just strip off extension.
+    if (osDataFile.empty())  // just strip off extension.
     {
         osDataFile = CPLGetFilename(poOpenInfo->pszFilename);
         osDataFile = osDataFile.substr(0, osDataFile.find_last_of('.'));
     }
-
+    if (CPLHasPathTraversal(osDataFile.c_str()))
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Path traversal detected in %s",
+                 osDataFile.c_str());
+        return nullptr;
+    }
     CPLString osDataFilePath = CPLFormFilenameSafe(osPath, osDataFile, nullptr);
 
     /* -------------------------------------------------------------------- */

--- a/frmts/hdf5/s100.cpp
+++ b/frmts/hdf5/s100.cpp
@@ -416,6 +416,12 @@ std::string S100ReadMetadata(GDALDataset *poDS, const std::string &osFilename,
             const char *pszVal = poAttr->ReadAsString();
             if (pszVal && pszVal[0])
             {
+                if (CPLHasPathTraversal(pszVal))
+                {
+                    CPLError(CE_Warning, CPLE_AppDefined,
+                             "Path traversal detected in %s", pszVal);
+                    continue;
+                }
                 osMetadataFile = CPLFormFilenameSafe(
                     CPLGetPathSafe(osFilename.c_str()).c_str(), pszVal,
                     nullptr);

--- a/frmts/map/mapdataset.cpp
+++ b/frmts/map/mapdataset.cpp
@@ -183,7 +183,7 @@ GDALDataset *MAPDataset::Open(GDALOpenInfo *poOpenInfo)
     /*      Create a corresponding GDALDataset.                             */
     /* -------------------------------------------------------------------- */
 
-    MAPDataset *poDS = new MAPDataset();
+    auto poDS = std::make_unique<MAPDataset>();
 
     /* -------------------------------------------------------------------- */
     /*      Try to load and parse the .MAP file.                            */
@@ -206,19 +206,16 @@ GDALDataset *MAPDataset::Open(GDALOpenInfo *poOpenInfo)
        function does not returns all required data . An API change is necessary
        : maybe in GDAL 2.0 ? */
 
-    char **papszLines = CSLLoad2(poOpenInfo->pszFilename, 200, 200, nullptr);
-
-    if (!papszLines)
+    const CPLStringList aosLines(
+        CSLLoad2(poOpenInfo->pszFilename, 200, 200, nullptr));
+    if (aosLines.empty())
     {
-        delete poDS;
         return nullptr;
     }
 
-    const int nLines = CSLCount(papszLines);
+    const int nLines = aosLines.size();
     if (nLines < 3)
     {
-        delete poDS;
-        CSLDestroy(papszLines);
         return nullptr;
     }
 
@@ -226,7 +223,13 @@ GDALDataset *MAPDataset::Open(GDALOpenInfo *poOpenInfo)
     /*      We need to open the image in order to establish                 */
     /*      details like the band count and types.                          */
     /* -------------------------------------------------------------------- */
-    poDS->osImgFilename = papszLines[2];
+    poDS->osImgFilename = aosLines[2];
+    if (CPLHasPathTraversal(poDS->osImgFilename.c_str()))
+    {
+        CPLError(CE_Failure, CPLE_NotSupported, "Path traversal detected in %s",
+                 poDS->osImgFilename.c_str());
+        return nullptr;
+    }
 
     const CPLString osPath = CPLGetPathSafe(poOpenInfo->pszFilename);
     if (CPLIsFilenameRelative(poDS->osImgFilename))
@@ -248,12 +251,10 @@ GDALDataset *MAPDataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Try and open the file.                                          */
     /* -------------------------------------------------------------------- */
-    poDS->poImageDS =
-        GDALDataset::FromHandle(GDALOpen(poDS->osImgFilename, GA_ReadOnly));
+    poDS->poImageDS = GDALDataset::Open(poDS->osImgFilename,
+                                        GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR);
     if (poDS->poImageDS == nullptr || poDS->poImageDS->GetRasterCount() == 0)
     {
-        CSLDestroy(papszLines);
-        delete poDS;
         return nullptr;
     }
 
@@ -264,14 +265,11 @@ GDALDataset *MAPDataset::Open(GDALOpenInfo *poOpenInfo)
     poDS->nRasterYSize = poDS->poImageDS->GetRasterYSize();
     if (!GDALCheckDatasetDimensions(poDS->nRasterXSize, poDS->nRasterYSize))
     {
-        CSLDestroy(papszLines);
-        GDALClose(poDS->poImageDS);
-        delete poDS;
         return nullptr;
     }
 
     for (int iBand = 1; iBand <= poDS->poImageDS->GetRasterCount(); iBand++)
-        poDS->SetBand(iBand, new MAPWrapperRasterBand(
+        poDS->SetBand(iBand, std::make_unique<MAPWrapperRasterBand>(
                                  poDS->poImageDS->GetRasterBand(iBand)));
 
     /* -------------------------------------------------------------------- */
@@ -282,28 +280,25 @@ GDALDataset *MAPDataset::Open(GDALOpenInfo *poOpenInfo)
     bool bNeatLine = false;
     for (int iLine = 10; iLine < nLines; iLine++)
     {
-        if (STARTS_WITH_CI(papszLines[iLine], "MMPXY,"))
+        if (STARTS_WITH_CI(aosLines[iLine], "MMPXY,"))
         {
-            char **papszTok =
-                CSLTokenizeString2(papszLines[iLine], ",",
-                                   CSLT_STRIPLEADSPACES | CSLT_STRIPENDSPACES);
+            const CPLStringList aosTokens(
+                CSLTokenizeString2(aosLines[iLine], ",",
+                                   CSLT_STRIPLEADSPACES | CSLT_STRIPENDSPACES));
 
-            if (CSLCount(papszTok) != 4)
+            if (aosTokens.size() != 4)
             {
-                CSLDestroy(papszTok);
                 continue;
             }
 
-            const int x = atoi(papszTok[2]);
-            const int y = atoi(papszTok[3]);
+            const int x = atoi(aosTokens[2]);
+            const int y = atoi(aosTokens[3]);
             if ((x != 0 && x != poDS->nRasterXSize) ||
                 (y != 0 && y != poDS->nRasterYSize))
             {
                 bNeatLine = true;
-                CSLDestroy(papszTok);
                 break;
             }
-            CSLDestroy(papszTok);
         }
     }
 
@@ -319,33 +314,31 @@ GDALDataset *MAPDataset::Open(GDALOpenInfo *poOpenInfo)
         {
             for (int iLine = 10; iLine < nLines; iLine++)
             {
-                if (STARTS_WITH_CI(papszLines[iLine], "MMPXY,"))
+                if (STARTS_WITH_CI(aosLines[iLine], "MMPXY,"))
                 {
-                    char **papszTok = CSLTokenizeString2(
-                        papszLines[iLine], ",",
-                        CSLT_STRIPLEADSPACES | CSLT_STRIPENDSPACES);
+                    const CPLStringList aosTokens(CSLTokenizeString2(
+                        aosLines[iLine], ",",
+                        CSLT_STRIPLEADSPACES | CSLT_STRIPENDSPACES));
 
-                    if (CSLCount(papszTok) != 4)
+                    if (aosTokens.size() != 4)
                     {
-                        CSLDestroy(papszTok);
                         continue;
                     }
 
-                    const double x = CPLAtofM(papszTok[2]);
-                    const double y = CPLAtofM(papszTok[3]);
+                    const double x = CPLAtofM(aosTokens[2]);
+                    const double y = CPLAtofM(aosTokens[3]);
                     const double X =
                         poDS->m_gt[0] + x * poDS->m_gt[1] + y * poDS->m_gt[2];
                     const double Y =
                         poDS->m_gt[3] + x * poDS->m_gt[4] + y * poDS->m_gt[5];
                     poRing->addPoint(X, Y);
                     CPLDebug("CORNER MMPXY", "%f, %f, %f, %f", x, y, X, Y);
-                    CSLDestroy(papszTok);
                 }
             }
         }
         else /* Convert the geographic coordinates to projected coordinates */
         {
-            OGRCoordinateTransformation *poTransform = nullptr;
+            std::unique_ptr<OGRCoordinateTransformation> poTransform;
             if (!poDS->m_oSRS.IsEmpty())
             {
                 OGRSpatialReference *poLongLat = poDS->m_oSRS.CloneGeogCS();
@@ -353,40 +346,36 @@ GDALDataset *MAPDataset::Open(GDALOpenInfo *poOpenInfo)
                 {
                     poLongLat->SetAxisMappingStrategy(
                         OAMS_TRADITIONAL_GIS_ORDER);
-                    poTransform = OGRCreateCoordinateTransformation(
-                        poLongLat, &poDS->m_oSRS);
-                    delete poLongLat;
+                    poTransform.reset(OGRCreateCoordinateTransformation(
+                        poLongLat, &poDS->m_oSRS));
+                    poLongLat->Release();
                 }
             }
 
             for (int iLine = 10; iLine < nLines; iLine++)
             {
-                if (STARTS_WITH_CI(papszLines[iLine], "MMPLL,"))
+                if (STARTS_WITH_CI(aosLines[iLine], "MMPLL,"))
                 {
-                    CPLDebug("MMPLL", "%s", papszLines[iLine]);
+                    CPLDebug("MMPLL", "%s", aosLines[iLine]);
 
-                    char **papszTok = CSLTokenizeString2(
-                        papszLines[iLine], ",",
-                        CSLT_STRIPLEADSPACES | CSLT_STRIPENDSPACES);
+                    const CPLStringList aosTokens(CSLTokenizeString2(
+                        aosLines[iLine], ",",
+                        CSLT_STRIPLEADSPACES | CSLT_STRIPENDSPACES));
 
-                    if (CSLCount(papszTok) != 4)
+                    if (aosTokens.size() != 4)
                     {
-                        CSLDestroy(papszTok);
                         continue;
                     }
 
-                    double dfLon = CPLAtofM(papszTok[2]);
-                    double dfLat = CPLAtofM(papszTok[3]);
+                    double dfLon = CPLAtofM(aosTokens[2]);
+                    double dfLat = CPLAtofM(aosTokens[3]);
 
                     if (poTransform)
                         poTransform->Transform(1, &dfLon, &dfLat);
                     poRing->addPoint(dfLon, dfLat);
                     CPLDebug("CORNER MMPLL", "%f, %f", dfLon, dfLat);
-                    CSLDestroy(papszTok);
                 }
             }
-            if (poTransform)
-                delete poTransform;
         }
 
         poRing->closeRings();
@@ -399,9 +388,7 @@ GDALDataset *MAPDataset::Open(GDALOpenInfo *poOpenInfo)
         CPLFree(pszNeatLineWkt);
     }
 
-    CSLDestroy(papszLines);
-
-    return poDS;
+    return poDS.release();
 }
 
 /************************************************************************/

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -6671,6 +6671,14 @@ OGRLayer *netCDFDataset::ICreateLayer(const char *pszName,
     netCDFDataset *poLayerDataset = nullptr;
     if (eMultipleLayerBehavior == SEPARATE_FILES)
     {
+        if (CPLLaunderForFilenameSafe(osNetCDFLayerName.c_str(), nullptr) !=
+            osNetCDFLayerName)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Illegal characters in '%s' to form a valid filename",
+                     osNetCDFLayerName.c_str());
+            return nullptr;
+        }
         char **papszDatasetOptions = nullptr;
         papszDatasetOptions = CSLSetNameValue(
             papszDatasetOptions, "CONFIG_FILE",

--- a/frmts/nitf/rpftocfile.cpp
+++ b/frmts/nitf/rpftocfile.cpp
@@ -573,6 +573,14 @@ RPFToc *RPFTOCReadFromBuffer(const char *pszFilename, VSILFILE *fp,
         frameEntry->filename[12] = '\0';
         bOK &= strlen(frameEntry->filename) > 0;
 
+        if (CPLHasPathTraversal(frameEntry->filename))
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Path traversal detected in %s", frameEntry->filename);
+            RPFTOCFree(toc);
+            return nullptr;
+        }
+
         // Check (case insensitive) if the filename is an overview or legend
         // some CADRG maps have legend name smaller than 8.3 then the extension
         // has blanks (0x20) at the end -> check only the first 3 letters of the
@@ -648,6 +656,14 @@ RPFToc *RPFTOCReadFromBuffer(const char *pszFilename, VSILFILE *fp,
         frameEntry->directory[pathLength] = 0;
         if (frameEntry->directory[pathLength - 1] == '/')
             frameEntry->directory[pathLength - 1] = 0;
+
+        if (CPLHasPathTraversal(frameEntry->directory))
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Path traversal detected in %s", frameEntry->directory);
+            RPFTOCFree(toc);
+            return nullptr;
+        }
 
         if (frameEntry->directory[0] == '.' && frameEntry->directory[1] == '/')
         {

--- a/frmts/pds/isis2dataset.cpp
+++ b/frmts/pds/isis2dataset.cpp
@@ -199,7 +199,13 @@ GDALDataset *ISIS2Dataset::Open(GDALOpenInfo *poOpenInfo)
     {
         const CPLString osTPath = CPLGetPathSafe(poOpenInfo->pszFilename);
         CPLString osFilename = pszQube;
-        poDS->CleanString(osFilename);
+        CleanString(osFilename);
+        if (CPLHasPathTraversal(osFilename.c_str()))
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Path traversal detected in %s", osFilename.c_str());
+            return nullptr;
+        }
         osTargetFile = CPLFormCIFilenameSafe(osTPath, osFilename, nullptr);
         poDS->osExternalCube = osTargetFile;
     }
@@ -207,7 +213,13 @@ GDALDataset *ISIS2Dataset::Open(GDALOpenInfo *poOpenInfo)
     {
         const CPLString osTPath = CPLGetPathSafe(poOpenInfo->pszFilename);
         CPLString osFilename = poDS->GetKeywordSub("^QUBE", 1, "");
-        poDS->CleanString(osFilename);
+        CleanString(osFilename);
+        if (CPLHasPathTraversal(osFilename.c_str()))
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Path traversal detected in %s", osFilename.c_str());
+            return nullptr;
+        }
         osTargetFile = CPLFormCIFilenameSafe(osTPath, osFilename, nullptr);
         poDS->osExternalCube = osTargetFile;
 
@@ -380,7 +392,7 @@ GDALDataset *ISIS2Dataset::Open(GDALOpenInfo *poOpenInfo)
     /***********   Grab MAP_PROJECTION_TYPE ************/
     CPLString map_proj_name =
         poDS->GetKeyword("QUBE.IMAGE_MAP_PROJECTION.MAP_PROJECTION_TYPE");
-    poDS->CleanString(map_proj_name);
+    CleanString(map_proj_name);
 
     /***********   Grab SEMI-MAJOR ************/
     const double semi_major =

--- a/frmts/pds/pds4dataset.cpp
+++ b/frmts/pds/pds4dataset.cpp
@@ -1421,6 +1421,13 @@ static std::string FixupTableFilename(const std::string &osFilename)
 bool PDS4Dataset::OpenTableCharacter(const char *pszFilename,
                                      const CPLXMLNode *psTable)
 {
+    if (CPLHasPathTraversal(pszFilename))
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "OpenTableCharacter(): path traversal detected: %s",
+                 pszFilename);
+        return false;
+    }
     const std::string osLayerName(CPLGetBasenameSafe(pszFilename));
     const std::string osFullFilename = FixupTableFilename(CPLFormFilenameSafe(
         CPLGetPathSafe(m_osXMLFilename.c_str()).c_str(), pszFilename, nullptr));
@@ -1443,6 +1450,12 @@ bool PDS4Dataset::OpenTableCharacter(const char *pszFilename,
 bool PDS4Dataset::OpenTableBinary(const char *pszFilename,
                                   const CPLXMLNode *psTable)
 {
+    if (CPLHasPathTraversal(pszFilename))
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "OpenTableBinary(): path traversal detected: %s", pszFilename);
+        return false;
+    }
     const std::string osLayerName(CPLGetBasenameSafe(pszFilename));
     const std::string osFullFilename = FixupTableFilename(CPLFormFilenameSafe(
         CPLGetPathSafe(m_osXMLFilename.c_str()).c_str(), pszFilename, nullptr));
@@ -1465,6 +1478,13 @@ bool PDS4Dataset::OpenTableBinary(const char *pszFilename,
 bool PDS4Dataset::OpenTableDelimited(const char *pszFilename,
                                      const CPLXMLNode *psTable)
 {
+    if (CPLHasPathTraversal(pszFilename))
+    {
+        CPLError(CE_Failure, CPLE_NotSupported,
+                 "OpenTableDelimited(): path traversal detected: %s",
+                 pszFilename);
+        return false;
+    }
     const std::string osLayerName(CPLGetBasenameSafe(pszFilename));
     const std::string osFullFilename = FixupTableFilename(CPLFormFilenameSafe(
         CPLGetPathSafe(m_osXMLFilename.c_str()).c_str(), pszFilename, nullptr));
@@ -1943,12 +1963,18 @@ PDS4Dataset *PDS4Dataset::OpenInternal(GDALOpenInfo *poOpenInfo)
             const std::string osImageFullFilename = CPLFormFilenameSafe(
                 CPLGetPathSafe(osXMLFilename.c_str()).c_str(), pszFilename,
                 nullptr);
+            if (CPLHasPathTraversal(pszFilename))
+            {
+                CPLError(CE_Failure, CPLE_NotSupported,
+                         "Path traversal detected in %s", pszFilename);
+                return nullptr;
+            }
             VSILFILE *fp = VSIFOpenExL(
                 osImageFullFilename.c_str(),
                 (poOpenInfo->eAccess == GA_Update) ? "rb+" : "rb", true);
             if (fp == nullptr)
             {
-                CPLError(CE_Warning, CPLE_FileIO, "Cannt open %s: %s",
+                CPLError(CE_Warning, CPLE_FileIO, "Cannot open %s: %s",
                          osImageFullFilename.c_str(), VSIGetLastErrorMsg());
                 continue;
             }

--- a/frmts/pds/pdsdataset.cpp
+++ b/frmts/pds/pdsdataset.cpp
@@ -832,6 +832,12 @@ int PDSDataset::ParseImage(const CPLString &osPrefix,
     if (!osQube.empty() && osQube[0] == '"')
     {
         const CPLString osFilename = CleanString(osQube);
+        if (CPLHasPathTraversal(osFilename.c_str()))
+        {
+            CPLError(CE_Failure, CPLE_NotSupported,
+                     "Path traversal detected in %s", osFilename.c_str());
+            return false;
+        }
         if (!osFilenamePrefix.empty())
         {
             m_osImageFilename = osFilenamePrefix + osFilename;
@@ -1323,6 +1329,12 @@ int PDSDataset::ParseCompressedImage()
 {
     const CPLString osFileName =
         CleanString(GetKeyword("COMPRESSED_FILE.FILE_NAME", ""));
+    if (CPLHasPathTraversal(osFileName.c_str()))
+    {
+        CPLError(CE_Failure, CPLE_NotSupported, "Path traversal detected in %s",
+                 osFileName.c_str());
+        return false;
+    }
 
     const CPLString osPath = CPLGetPathSafe(GetDescription());
     const CPLString osFullFileName =

--- a/frmts/raw/eirdataset.cpp
+++ b/frmts/raw/eirdataset.cpp
@@ -327,6 +327,12 @@ GDALDataset *EIRDataset::Open(GDALOpenInfo *poOpenInfo)
         }
         else if (EQUAL(aosTokens[0], "PIXEL_FILES"))
         {
+            if (CPLHasPathTraversal(aosTokens[1]))
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Path traversal detected in %s", aosTokens[1]);
+                return nullptr;
+            }
             osRasterFilename = CPLFormCIFilenameSafe(osPath, aosTokens[1], "");
         }
         else if (EQUAL(aosTokens[0], "FORMAT"))

--- a/frmts/raw/ndfdataset.cpp
+++ b/frmts/raw/ndfdataset.cpp
@@ -281,6 +281,12 @@ GDALDataset *NDFDataset::Open(GDALOpenInfo *poOpenInfo)
         }
         else
         {
+            if (CPLHasPathTraversal(osFilename.c_str()))
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Path traversal detected in %s", osFilename.c_str());
+                return nullptr;
+            }
             CPLString osBasePath = CPLGetPathSafe(poOpenInfo->pszFilename);
             osFilename = CPLFormFilenameSafe(osBasePath, osFilename, nullptr);
         }

--- a/frmts/raw/pauxdataset.cpp
+++ b/frmts/raw/pauxdataset.cpp
@@ -492,6 +492,12 @@ GDALDataset *PAuxDataset::Open(GDALOpenInfo *poOpenInfo)
         }
         szAuxTarget[sizeof(szAuxTarget) - 1] = '\0';
 
+        if (CPLHasPathTraversal(szAuxTarget))
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Path traversal detected in %s", szAuxTarget);
+            return nullptr;
+        }
         const std::string osPath(CPLGetPathSafe(poOpenInfo->pszFilename));
         osTarget = CPLFormFilenameSafe(osPath.c_str(), szAuxTarget, nullptr);
     }

--- a/frmts/raw/snodasdataset.cpp
+++ b/frmts/raw/snodasdataset.cpp
@@ -415,7 +415,12 @@ GDALDataset *SNODASDataset::Open(GDALOpenInfo *poOpenInfo)
 
     if (osDataFilename.empty())
         return nullptr;
-
+    if (CPLHasPathTraversal(osDataFilename.c_str()))
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Path traversal detected in %s",
+                 osDataFilename.c_str());
+        return nullptr;
+    }
     if (!GDALCheckDatasetDimensions(nCols, nRows))
         return nullptr;
 

--- a/frmts/rcm/rcmdataset.cpp
+++ b/frmts/rcm/rcmdataset.cpp
@@ -551,25 +551,24 @@ void RCMCalibRasterBand::ReadNoiseLevels()
 
     // Load Beta Nought, Sigma Nought, Gamma noise levels
     // Loop through all nodes with spaces
-    CPLXMLNode *psReferenceNoiseLevelNode =
+    const CPLXMLNode *psReferenceNoiseLevelNode =
         CPLGetXMLNode(psNoiseLevels.get(), "=noiseLevels");
     if (!psReferenceNoiseLevelNode)
         return;
 
-    CPLXMLNode *psNodeInc;
-    for (psNodeInc = psReferenceNoiseLevelNode->psChild; psNodeInc != nullptr;
-         psNodeInc = psNodeInc->psNext)
+    for (const CPLXMLNode *psNodeInc = psReferenceNoiseLevelNode->psChild;
+         psNodeInc != nullptr; psNodeInc = psNodeInc->psNext)
     {
         if (EQUAL(psNodeInc->pszValue, "referenceNoiseLevel"))
         {
-            CPLXMLNode *psCalibType =
+            const CPLXMLNode *psCalibType =
                 CPLGetXMLNode(psNodeInc, "sarCalibrationType");
-            CPLXMLNode *psPixelFirstNoiseValue =
+            const CPLXMLNode *psPixelFirstNoiseValue =
                 CPLGetXMLNode(psNodeInc, "pixelFirstNoiseValue");
-            CPLXMLNode *psStepSize = CPLGetXMLNode(psNodeInc, "stepSize");
-            CPLXMLNode *psNumberOfValues =
+            const CPLXMLNode *psStepSize = CPLGetXMLNode(psNodeInc, "stepSize");
+            const CPLXMLNode *psNumberOfValues =
                 CPLGetXMLNode(psNodeInc, "numberOfValues");
-            CPLXMLNode *psNoiseLevelValues =
+            const CPLXMLNode *psNoiseLevelValues =
                 CPLGetXMLNode(psNodeInc, "noiseLevelValues");
 
             if (psCalibType != nullptr && psPixelFirstNoiseValue != nullptr &&
@@ -1122,7 +1121,7 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
         return nullptr;
     }
 
-    CPLXMLNode *psSceneAttributes =
+    const CPLXMLNode *psSceneAttributes =
         CPLGetXMLNode(psProduct.get(), "=product.sceneAttributes");
     if (psSceneAttributes == nullptr)
     {
@@ -1131,7 +1130,7 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
         return nullptr;
     }
 
-    CPLXMLNode *psImageAttributes = CPLGetXMLNode(
+    const CPLXMLNode *psImageAttributes = CPLGetXMLNode(
         psProduct.get(), "=product.sceneAttributes.imageAttributes");
     if (psImageAttributes == nullptr)
     {
@@ -1150,7 +1149,7 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
         return nullptr;
     }
 
-    CPLXMLNode *psImageReferenceAttributes =
+    const CPLXMLNode *psImageReferenceAttributes =
         CPLGetXMLNode(psProduct.get(), "=product.imageReferenceAttributes");
     if (psImageReferenceAttributes == nullptr)
     {
@@ -1160,7 +1159,7 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
         return nullptr;
     }
 
-    CPLXMLNode *psImageGenerationParameters =
+    const CPLXMLNode *psImageGenerationParameters =
         CPLGetXMLNode(psProduct.get(), "=product.imageGenerationParameters");
     if (psImageGenerationParameters == nullptr)
     {
@@ -1394,9 +1393,9 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Open each of the data files as a complex band.                  */
     /* -------------------------------------------------------------------- */
-    char *pszBeta0LUT = nullptr;
-    char *pszGammaLUT = nullptr;
-    char *pszSigma0LUT = nullptr;
+    std::string osBeta0LUT;
+    std::string osGammaLUT;
+    std::string osSigma0LUT;
     // Same file for all calibrations except the calibration is plit inside the
     // XML
     std::string osNoiseLevelsValues;
@@ -1404,7 +1403,7 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
     const CPLString osPath = CPLGetPathSafe(osMDFilename);
 
     /* Get a list of all polarizations */
-    CPLXMLNode *psSourceAttrs =
+    const CPLXMLNode *psSourceAttrs =
         CPLGetXMLNode(poDS->psProduct.get(), "=product.sourceAttributes");
     if (psSourceAttrs == nullptr)
     {
@@ -1415,7 +1414,7 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
         return nullptr;
     }
 
-    CPLXMLNode *psRadarParameters = CPLGetXMLNode(
+    const CPLXMLNode *psRadarParameters = CPLGetXMLNode(
         poDS->psProduct.get(), "=product.sourceAttributes.radarParameters");
     if (psRadarParameters == nullptr)
     {
@@ -1465,8 +1464,8 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
     while (iss >> pol)
         imageBandCount++;
 
-    CPLXMLNode *psNode = psImageAttributes->psChild;
-    for (; psNode != nullptr; psNode = psNode->psNext)
+    for (const CPLXMLNode *psNode = psImageAttributes->psChild;
+         psNode != nullptr; psNode = psNode->psNext)
     {
         /* Find the tif or ntf filename */
         if (psNode->eType != CXT_Element || !(EQUAL(psNode->pszValue, "ipdf")))
@@ -1533,10 +1532,16 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
 
     if (pszIncidenceAngleFileName != nullptr)
     {
-        CPLString osIncidenceAngleFilePath = CPLFormFilenameSafe(
+        if (CPLHasPathTraversal(pszIncidenceAngleFileName))
+        {
+            CPLError(CE_Failure, CPLE_NotSupported,
+                     "Path traversal detected in %s",
+                     pszIncidenceAngleFileName);
+            return nullptr;
+        }
+        const CPLString osIncidenceAngleFilePath = CPLFormFilenameSafe(
             CPLFormFilenameSafe(osPath, CALIBRATION_FOLDER, nullptr).c_str(),
             pszIncidenceAngleFileName, nullptr);
-
         /* Check if the file exist */
         if (IsValidXMLFile(osIncidenceAngleFilePath))
         {
@@ -1603,7 +1608,7 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
             CPLString(aosPolarizationsGrids[iPoleInx]).toupper();
 
         // Look if the NoiseLevel file xml exist for the
-        CPLXMLNode *psRefNode = psImageReferenceAttributes->psChild;
+        const CPLXMLNode *psRefNode = psImageReferenceAttributes->psChild;
         for (; psRefNode != nullptr; psRefNode = psRefNode->psNext)
         {
             if (EQUAL(psRefNode->pszValue, "noiseLevelFileName") && bCanCalib)
@@ -1645,6 +1650,13 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
                 /* --------------------------------------------------------------------
                  */
 
+                if (CPLHasPathTraversal(pszNoiseLevelFile))
+                {
+                    CPLError(CE_Failure, CPLE_NotSupported,
+                             "Path traversal detected in %s",
+                             pszNoiseLevelFile);
+                    return nullptr;
+                }
                 CPLString oNoiseLevelPath = CPLFormFilenameSafe(
                     CPLFormFilenameSafe(osPath, CALIBRATION_FOLDER, nullptr)
                         .c_str(),
@@ -1702,6 +1714,12 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
                 /*      called 'calibration' from the 'metadata' folder */
                 /* --------------------------------------------------------------------
                  */
+                if (CPLHasPathTraversal(pszLUTFile))
+                {
+                    CPLError(CE_Failure, CPLE_NotSupported,
+                             "Path traversal detected in %s", pszLUTFile);
+                    return nullptr;
+                }
                 const CPLString osLUTFilePath = CPLFormFilenameSafe(
                     CPLFormFilenameSafe(osPath, CALIBRATION_FOLDER, nullptr)
                         .c_str(),
@@ -1715,8 +1733,7 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
 
                     CPLString pszBuf(
                         FormatCalibration(szBETA0, osMDFilename.c_str()));
-                    CPLFree(pszBeta0LUT);
-                    pszBeta0LUT = VSIStrdup(osLUTFilePath);
+                    osBeta0LUT = osLUTFilePath;
 
                     const char *oldLut =
                         poDS->GetMetadataItem("BETA_NOUGHT_LUT");
@@ -1753,8 +1770,7 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
 
                     CPLString pszBuf(
                         FormatCalibration(szSIGMA0, osMDFilename.c_str()));
-                    CPLFree(pszSigma0LUT);
-                    pszSigma0LUT = VSIStrdup(osLUTFilePath);
+                    osSigma0LUT = osLUTFilePath;
 
                     const char *oldLut =
                         poDS->GetMetadataItem("SIGMA_NOUGHT_LUT");
@@ -1792,8 +1808,7 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
 
                     CPLString pszBuf(
                         FormatCalibration(szGAMMA, osMDFilename.c_str()));
-                    CPLFree(pszGammaLUT);
-                    pszGammaLUT = VSIStrdup(osLUTFilePath);
+                    osGammaLUT = osLUTFilePath;
 
                     const char *oldLut = poDS->GetMetadataItem("GAMMA_LUT");
                     if (oldLut == nullptr)
@@ -1858,8 +1873,22 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
         /*      Form full filename (path of product.xml + basename). */
         /* --------------------------------------------------------------------
          */
-        char *pszFullname = CPLStrdup(
-            CPLFormFilenameSafe(osPath, pszBasedFilename, nullptr).c_str());
+        std::string osPathImage = osPath;
+        std::string osBasedImage = pszBasedFilename;
+        if (STARTS_WITH(osBasedImage.c_str(), "../") ||
+            STARTS_WITH(osBasedImage.c_str(), "..\\"))
+        {
+            osPathImage = CPLGetPathSafe(osPath);
+            osBasedImage = osBasedImage.substr(strlen("../"));
+        }
+        if (CPLHasPathTraversal(osBasedImage.c_str()))
+        {
+            CPLError(CE_Failure, CPLE_NotSupported,
+                     "Path traversal detected in %s", osBasedImage.c_str());
+            return nullptr;
+        }
+        const std::string osFullname = CPLFormFilenameSafe(
+            osPathImage.c_str(), osBasedImage.c_str(), nullptr);
 
         /* --------------------------------------------------------------------
          */
@@ -1867,20 +1896,14 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
         /* --------------------------------------------------------------------
          */
         auto poBandFile = std::unique_ptr<GDALDataset>(GDALDataset::Open(
-            pszFullname, GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR));
-        if (poBandFile == nullptr)
+            osFullname.c_str(), GDAL_OF_RASTER | GDAL_OF_VERBOSE_ERROR));
+        if (poBandFile == nullptr || poBandFile->GetRasterCount() == 0)
         {
-            CPLFree(pszFullname);
-            continue;
-        }
-        if (poBandFile->GetRasterCount() == 0)
-        {
-            CPLFree(pszFullname);
             continue;
         }
 
         poDS->papszExtraFiles =
-            CSLAddString(poDS->papszExtraFiles, pszFullname);
+            CSLAddString(poDS->papszExtraFiles, osFullname.c_str());
 
         /* Some CFloat32 NITF files have nBitsPerSample incorrectly reported */
         /* as 16, and get misinterpreted as CInt16.  Check the underlying NITF
@@ -1893,7 +1916,6 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
             checkBandFileMappingRCM(eDataType, poBandFile.get(), bIsNITF);
         if (b == BANDERROR)
         {
-            CPLFree(pszFullname);
             CPLError(CE_Failure, CPLE_AppDefined,
                      "The underlying band files do not have an appropriate "
                      "data type.");
@@ -1918,25 +1940,24 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
         }
         else
         {
-            const char *pszLUT = nullptr;
+            const char *pszLUT = osSigma0LUT.c_str();
             switch (eCalib)
             {
                 case Sigma0:
-                    pszLUT = pszSigma0LUT;
+                    pszLUT = osSigma0LUT.c_str();
                     break;
                 case Beta0:
-                    pszLUT = pszBeta0LUT;
+                    pszLUT = osBeta0LUT.c_str();
                     break;
                 case Gamma:
-                    pszLUT = pszGammaLUT;
+                    pszLUT = osGammaLUT.c_str();
                     break;
                 default:
                     /* we should bomb gracefully... */
-                    pszLUT = pszSigma0LUT;
+                    break;
             }
-            if (!pszLUT)
+            if (pszLUT[0] == '\0')
             {
-                CPLFree(pszFullname);
                 CPLError(CE_Failure, CPLE_AppDefined, "LUT missing.");
                 return nullptr;
             }
@@ -1960,8 +1981,6 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
                 poDS->SetBand(poDS->GetRasterCount() + 1, poBand);
             }
         }
-
-        CPLFree(pszFullname);
     }
 
     if (poDS->papszSubDatasets != nullptr && eCalib == None)
@@ -2049,12 +2068,12 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
     /*      Collect Map projection/Geotransform information, if present.DONE */
     /*      In RCM, there is no file that indicates                         */
     /* -------------------------------------------------------------------- */
-    CPLXMLNode *psMapProjection = CPLGetXMLNode(
+    const CPLXMLNode *psMapProjection = CPLGetXMLNode(
         psImageReferenceAttributes, "geographicInformation.mapProjection");
 
     if (psMapProjection != nullptr)
     {
-        CPLXMLNode *psPos =
+        const CPLXMLNode *psPos =
             CPLGetXMLNode(psMapProjection, "positioningInformation");
 
         pszItem =
@@ -2141,7 +2160,7 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Collect Projection String Information.DONE                      */
     /* -------------------------------------------------------------------- */
-    CPLXMLNode *psEllipsoid =
+    const CPLXMLNode *psEllipsoid =
         CPLGetXMLNode(psImageReferenceAttributes,
                       "geographicInformation.ellipsoidParameters");
 
@@ -2192,10 +2211,10 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
                 CPLGetXMLValue(psMapProjection, "mapProjectionDescriptor", "");
             bool bUseProjInfo = false;
 
-            CPLXMLNode *psUtmParams =
+            const CPLXMLNode *psUtmParams =
                 CPLGetXMLNode(psMapProjection, "utmProjectionParameters");
 
-            CPLXMLNode *psNspParams =
+            const CPLXMLNode *psNspParams =
                 CPLGetXMLNode(psMapProjection, "nspProjectionParameters");
 
             if ((psUtmParams != nullptr) && poDS->bHaveGeoTransform)
@@ -2293,7 +2312,7 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Collect GCPs.DONE */
     /* -------------------------------------------------------------------- */
-    CPLXMLNode *psGeoGrid = CPLGetXMLNode(
+    const CPLXMLNode *psGeoGrid = CPLGetXMLNode(
         psImageReferenceAttributes, "geographicInformation.geolocationGrid");
 
     if (psGeoGrid != nullptr)
@@ -2301,7 +2320,7 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
         /* count GCPs */
         poDS->nGCPCount = 0;
 
-        for (psNode = psGeoGrid->psChild; psNode != nullptr;
+        for (const CPLXMLNode *psNode = psGeoGrid->psChild; psNode != nullptr;
              psNode = psNode->psNext)
         {
             if (EQUAL(psNode->pszValue, "imageTiePoint"))
@@ -2313,7 +2332,7 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
 
         poDS->nGCPCount = 0;
 
-        for (psNode = psGeoGrid->psChild; psNode != nullptr;
+        for (const CPLXMLNode *psNode = psGeoGrid->psChild; psNode != nullptr;
              psNode = psNode->psNext)
         {
             GDAL_GCP *psGCP = poDS->pasGCPList + poDS->nGCPCount;
@@ -2340,17 +2359,10 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
         }
     }
 
-    if (pszBeta0LUT)
-        CPLFree(pszBeta0LUT);
-    if (pszSigma0LUT)
-        CPLFree(pszSigma0LUT);
-    if (pszGammaLUT)
-        CPLFree(pszGammaLUT);
-
     /* -------------------------------------------------------------------- */
     /*      Collect RPC.DONE */
     /* -------------------------------------------------------------------- */
-    CPLXMLNode *psRationalFunctions = CPLGetXMLNode(
+    const CPLXMLNode *psRationalFunctions = CPLGetXMLNode(
         psImageReferenceAttributes, "geographicInformation.rationalFunctions");
     if (psRationalFunctions != nullptr)
     {

--- a/frmts/sentinel2/sentinel2dataset.cpp
+++ b/frmts/sentinel2/sentinel2dataset.cpp
@@ -1082,6 +1082,13 @@ static bool SENTINEL2GetGranuleList(
             osGranuleMTDPath += pszGranuleId;
             osGranuleMTDPath += chSeparator;
             osGranuleMTDPath += osGranuleMTD;
+            if (CPLHasPathTraversal(osGranuleMTDPath.c_str()))
+            {
+                CPLError(CE_Failure, CPLE_NotSupported,
+                         "Path traversal detected in %s",
+                         osGranuleMTDPath.c_str());
+                return false;
+            }
             osList.push_back(std::move(osGranuleMTDPath));
         }
     }
@@ -2433,6 +2440,12 @@ SENTINEL2Dataset::OpenL1BSubdatasetWithGeoloc(GDALOpenInfo *poOpenInfo)
             .append(achSeparator)
             .append(CPLString(osDatastrip).replaceAll("_MSI_", "_MTD_"))
             .append(".xml");
+    if (CPLHasPathTraversal(osXMLDatastrip.c_str()))
+    {
+        CPLError(CE_Failure, CPLE_NotSupported, "Path traversal detected in %s",
+                 osXMLDatastrip.c_str());
+        return nullptr;
+    }
     CPLXMLTreeCloser poXML(CPLParseXMLFile(osXMLDatastrip.c_str()));
     if (!poXML)
     {
@@ -2740,6 +2753,13 @@ static bool SENTINEL2GetGranuleList_L1CSafeCompact(
             }
             L1CSafeCompatGranuleDescription oDesc;
             oDesc.osBandPrefixPath = osDirname + chSeparator + pszImageFile;
+            if (CPLHasPathTraversal(oDesc.osBandPrefixPath.c_str()))
+            {
+                CPLError(CE_Failure, CPLE_NotSupported,
+                         "Path traversal detected in %s",
+                         oDesc.osBandPrefixPath.c_str());
+                return false;
+            }
             oDesc.osBandPrefixPath.resize(oDesc.osBandPrefixPath.size() -
                                           3);  // strip B12
             // GRANULE/L1C_T30TXT_A007999_20170102T111441/IMG_DATA/T30TXT_20170102T111442_B12
@@ -2841,6 +2861,13 @@ static bool SENTINEL2GetGranuleList_L2ASafeCompact(
             {
                 CPLDebug("SENTINEL2", "Band prefix path too short");
                 continue;
+            }
+            if (CPLHasPathTraversal(oDesc.osBandPrefixPath.c_str()))
+            {
+                CPLError(CE_Failure, CPLE_NotSupported,
+                         "Path traversal detected in %s",
+                         oDesc.osBandPrefixPath.c_str());
+                return false;
             }
             oDesc.osBandPrefixPath.resize(oDesc.osBandPrefixPath.size() - 36);
             // GRANULE/L1C_T30TXT_A007999_20170102T111441/IMG_DATA/T30TXT_20170102T111442_B12_60m

--- a/frmts/tsx/tsxdataset.cpp
+++ b/frmts/tsx/tsxdataset.cpp
@@ -99,7 +99,7 @@ class TSXDataset final : public GDALPamDataset
     static int Identify(GDALOpenInfo *poOpenInfo);
 
   private:
-    bool getGCPsFromGEOREF_XML(char *pszGeorefFilename);
+    bool getGCPsFromGEOREF_XML(const char *pszGeorefFilename);
 };
 
 /************************************************************************/
@@ -293,7 +293,7 @@ int TSXDataset::Identify(GDALOpenInfo *poOpenInfo)
 /*string.                                                                */
 /*Returns true on success.                                                */
 /************************************************************************/
-bool TSXDataset::getGCPsFromGEOREF_XML(char *pszGeorefFilename)
+bool TSXDataset::getGCPsFromGEOREF_XML(const char *pszGeorefFilename)
 {
     // open GEOREF.xml
     CPLXMLNode *psGeorefData = CPLParseXMLFile(pszGeorefFilename);
@@ -465,29 +465,27 @@ GDALDataset *TSXDataset::Open(GDALOpenInfo *poOpenInfo)
         osFilename = poOpenInfo->pszFilename;
 
     /* Ingest the XML */
-    CPLXMLNode *psData = CPLParseXMLFile(osFilename);
+    CPLXMLTreeCloser psData(CPLParseXMLFile(osFilename));
     if (psData == nullptr)
         return nullptr;
 
     /* find the product components */
-    CPLXMLNode *psComponents =
-        CPLGetXMLNode(psData, "=level1Product.productComponents");
+    const CPLXMLNode *psComponents =
+        CPLGetXMLNode(psData.get(), "=level1Product.productComponents");
     if (psComponents == nullptr)
     {
         CPLError(CE_Failure, CPLE_OpenFailed,
                  "Unable to find <productComponents> tag in file.\n");
-        CPLDestroyXMLNode(psData);
         return nullptr;
     }
 
     /* find the product info tag */
-    CPLXMLNode *psProductInfo =
-        CPLGetXMLNode(psData, "=level1Product.productInfo");
+    const CPLXMLNode *psProductInfo =
+        CPLGetXMLNode(psData.get(), "=level1Product.productInfo");
     if (psProductInfo == nullptr)
     {
         CPLError(CE_Failure, CPLE_OpenFailed,
                  "Unable to find <productInfo> tag in file.\n");
-        CPLDestroyXMLNode(psData);
         return nullptr;
     }
 
@@ -495,7 +493,7 @@ GDALDataset *TSXDataset::Open(GDALOpenInfo *poOpenInfo)
     /*      Create the dataset.                                             */
     /* -------------------------------------------------------------------- */
 
-    TSXDataset *poDS = new TSXDataset();
+    auto poDS = std::make_unique<TSXDataset>();
 
     /* -------------------------------------------------------------------- */
     /*      Read in product info.                                           */
@@ -526,9 +524,9 @@ GDALDataset *TSXDataset::Open(GDALOpenInfo *poOpenInfo)
                           CPLGetXMLValue(psProductInfo,
                                          "productVariantInfo.productVariant",
                                          "unknown"));
-    char *pszDataType = CPLStrdup(CPLGetXMLValue(
-        psProductInfo, "imageDataInfo.imageDataType", "unknown"));
-    poDS->SetMetadataItem("IMAGE_TYPE", pszDataType);
+    std::string osDataType =
+        CPLGetXMLValue(psProductInfo, "imageDataInfo.imageDataType", "unknown");
+    poDS->SetMetadataItem("IMAGE_TYPE", osDataType.c_str());
 
     /* Get raster information */
     int nRows = atoi(CPLGetXMLValue(
@@ -581,15 +579,21 @@ GDALDataset *TSXDataset::Open(GDALOpenInfo *poOpenInfo)
         poDS->nProduct = eUnknown;
 
     /* Start reading in the product components */
-    char *pszGeorefFile = nullptr;
+    std::string osGeorefFile;
     CPLErr geoTransformErr = CE_Failure;
     for (CPLXMLNode *psComponent = psComponents->psChild;
          psComponent != nullptr; psComponent = psComponent->psNext)
     {
         const char *pszType = nullptr;
-        const std::string osPath =
-            CPLFormFilenameSafe(CPLGetDirnameSafe(osFilename).c_str(),
-                                GetFilePath(psComponent, &pszType).c_str(), "");
+        const std::string osFilePath = GetFilePath(psComponent, &pszType);
+        if (CPLHasPathTraversal(osFilePath.c_str()))
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Path traversal detected in %s", osFilePath.c_str());
+            return nullptr;
+        }
+        std::string osPath = CPLFormFilenameSafe(
+            CPLGetDirnameSafe(osFilename).c_str(), osFilePath.c_str(), "");
         const char *pszPolLayer = CPLGetXMLValue(psComponent, "polLayer", " ");
 
         if (!STARTS_WITH_CI(pszType, " "))
@@ -602,8 +606,7 @@ GDALDataset *TSXDataset::Open(GDALOpenInfo *poOpenInfo)
             else if (STARTS_WITH_CI(pszType, "GEOREF"))
             {
                 /* save the path to the georef data for later use */
-                CPLFree(pszGeorefFile);
-                pszGeorefFile = CPLStrdup(osPath.c_str());
+                osGeorefFile = std::move(osPath);
             }
         }
         else if (!STARTS_WITH_CI(pszPolLayer, " ") &&
@@ -628,9 +631,9 @@ GDALDataset *TSXDataset::Open(GDALOpenInfo *poOpenInfo)
                 ePol = VV;
             }
 
-            GDALDataType eDataType = STARTS_WITH_CI(pszDataType, "COMPLEX")
-                                         ? GDT_CInt16
-                                         : GDT_UInt16;
+            GDALDataType eDataType =
+                STARTS_WITH_CI(osDataType.c_str(), "COMPLEX") ? GDT_CInt16
+                                                              : GDT_UInt16;
 
             /* try opening the file that represents that band */
             GDALDataset *poBandData =
@@ -638,7 +641,7 @@ GDALDataset *TSXDataset::Open(GDALOpenInfo *poOpenInfo)
             if (poBandData != nullptr)
             {
                 TSXRasterBand *poBand =
-                    new TSXRasterBand(poDS, eDataType, ePol, poBandData);
+                    new TSXRasterBand(poDS.get(), eDataType, ePol, poBandData);
                 poDS->SetBand(poDS->GetRasterCount() + 1, poBand);
 
                 // copy georeferencing info from the band
@@ -665,8 +668,6 @@ GDALDataset *TSXDataset::Open(GDALOpenInfo *poOpenInfo)
         poDS->m_gt = GDALGeoTransform();
     }
 
-    CPLFree(pszDataType);
-
     /* -------------------------------------------------------------------- */
     /*      Check and set matrix representation.                            */
     /* -------------------------------------------------------------------- */
@@ -680,14 +681,14 @@ GDALDataset *TSXDataset::Open(GDALOpenInfo *poOpenInfo)
     /*      Read the four corners and centre GCPs in                        */
     /* -------------------------------------------------------------------- */
 
-    CPLXMLNode *psSceneInfo =
-        CPLGetXMLNode(psData, "=level1Product.productInfo.sceneInfo");
+    const CPLXMLNode *psSceneInfo =
+        CPLGetXMLNode(psData.get(), "=level1Product.productInfo.sceneInfo");
     if (psSceneInfo != nullptr)
     {
         /* extract the GCPs from the provided file */
         bool success = false;
-        if (pszGeorefFile != nullptr)
-            success = poDS->getGCPsFromGEOREF_XML(pszGeorefFile);
+        if (!osGeorefFile.empty())
+            success = poDS->getGCPsFromGEOREF_XML(osGeorefFile.c_str());
 
         // if the gcp's cannot be extracted from the georef file, try to get the
         // corner coordinates for now just SSC because the others don't have
@@ -701,7 +702,7 @@ GDALDataset *TSXDataset::Open(GDALOpenInfo *poOpenInfo)
             // count and allocate gcps - there should be five - 4 corners and a
             // centre
             poDS->nGCPCount = 0;
-            CPLXMLNode *psNode = psSceneInfo->psChild;
+            const CPLXMLNode *psNode = psSceneInfo->psChild;
             for (; psNode != nullptr; psNode = psNode->psNext)
             {
                 if (!EQUAL(psNode->pszValue, "sceneCenterCoord") &&
@@ -761,8 +762,6 @@ GDALDataset *TSXDataset::Open(GDALOpenInfo *poOpenInfo)
                  "Proceeding with caution.");
     }
 
-    CPLFree(pszGeorefFile);
-
     /* -------------------------------------------------------------------- */
     /*      Initialize any PAM information.                                 */
     /* -------------------------------------------------------------------- */
@@ -772,11 +771,9 @@ GDALDataset *TSXDataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Check for overviews.                                            */
     /* -------------------------------------------------------------------- */
-    poDS->oOvManager.Initialize(poDS, poOpenInfo->pszFilename);
+    poDS->oOvManager.Initialize(poDS.get(), poOpenInfo->pszFilename);
 
-    CPLDestroyXMLNode(psData);
-
-    return poDS;
+    return poDS.release();
 }
 
 /************************************************************************/

--- a/frmts/zarr/vsikerchunk_json_ref.cpp
+++ b/frmts/zarr/vsikerchunk_json_ref.cpp
@@ -1345,6 +1345,13 @@ bool VSIKerchunkRefFile::ConvertToParquetRef(const std::string &osCacheDir,
                     }
                     poDS.reset();
                 }
+                if (CPLHasPathTraversal(osArrayName.c_str()))
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "Path traversal detected in %s",
+                             osArrayName.c_str());
+                    return false;
+                }
                 const std::string osParqFilename = CPLFormFilenameSafe(
                     CPLFormFilenameSafe(osCacheDir.c_str(), osArrayName.c_str(),
                                         nullptr)

--- a/frmts/zarr/zarr_group.cpp
+++ b/frmts/zarr/zarr_group.cpp
@@ -109,7 +109,12 @@ bool ZarrGroupBase::DeleteGroup(const std::string &osName,
                  "Dataset not open in update mode");
         return false;
     }
-
+    if (CPLHasPathTraversal(osName.c_str()))
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Path traversal detected in %s",
+                 osName.c_str());
+        return false;
+    }
     GetGroupNames();
 
     auto oIterNames = std::find(m_aosGroups.begin(), m_aosGroups.end(), osName);
@@ -254,7 +259,12 @@ bool ZarrGroupBase::DeleteMDArray(const std::string &osName,
                  "Dataset not open in update mode");
         return false;
     }
-
+    if (CPLHasPathTraversal(osName.c_str()))
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Path traversal detected in %s",
+                 osName.c_str());
+        return false;
+    }
     GetMDArrayNames();
 
     auto oIterNames = std::find(m_aosArrays.begin(), m_aosArrays.end(), osName);

--- a/frmts/zarr/zarr_v2_array.cpp
+++ b/frmts/zarr/zarr_v2_array.cpp
@@ -1474,6 +1474,13 @@ ZarrV2Group::LoadArray(const std::string &osArrayName,
             std::string osDirName = m_osDirectoryName;
             while (true)
             {
+                if (CPLHasPathTraversal(osDimName.c_str()))
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "Path traversal detected in %s",
+                             osDimName.c_str());
+                    return false;
+                }
                 const std::string osArrayFilenameDim = CPLFormFilenameSafe(
                     CPLFormFilenameSafe(osDirName.c_str(), osDimName.c_str(),
                                         nullptr)
@@ -1972,6 +1979,13 @@ ZarrV2Group::LoadArray(const std::string &osArrayName,
         const std::string gridMappingName = gridMapping.ToString();
         if (m_oMapMDArrays.find(gridMappingName) == m_oMapMDArrays.end())
         {
+            if (CPLHasPathTraversal(gridMappingName.c_str()))
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Path traversal detected in %s",
+                         gridMappingName.c_str());
+                return nullptr;
+            }
             const std::string osArrayFilenameDim = CPLFormFilenameSafe(
                 CPLFormFilenameSafe(m_osDirectoryName.c_str(),
                                     gridMappingName.c_str(), nullptr)

--- a/ogr/ogrsf_frmts/csv/ogrcsvdatasource.cpp
+++ b/ogr/ogrsf_frmts/csv/ogrcsvdatasource.cpp
@@ -1095,6 +1095,13 @@ OGRCSVDataSource::ICreateLayer(const char *pszLayerName,
     }
     else
     {
+        if (CPLLaunderForFilenameSafe(pszLayerName, nullptr) != pszLayerName)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Illegal characters in '%s' to form a valid filename",
+                     pszLayerName);
+            return nullptr;
+        }
         osFilename = CPLFormFilenameSafe(pszName, pszLayerName, "csv");
     }
 

--- a/ogr/ogrsf_frmts/libkml/ogrlibkmldatasource.cpp
+++ b/ogr/ogrsf_frmts/libkml/ogrlibkmldatasource.cpp
@@ -2270,6 +2270,14 @@ OGRLIBKMLDataSource::ICreateLayer(const char *pszLayerName,
     if (!bUpdate)
         return nullptr;
 
+    if (CPLLaunderForFilenameSafe(pszLayerName, nullptr) != pszLayerName)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Illegal characters in '%s' to form a valid filename",
+                 pszLayerName);
+        return nullptr;
+    }
+
     if ((IsKmz() || IsDir()) && EQUAL(pszLayerName, "doc"))
     {
         CPLError(CE_Failure, CPLE_AppDefined,

--- a/ogr/ogrsf_frmts/mitab/mitab_ogr_datasource.cpp
+++ b/ogr/ogrsf_frmts/mitab/mitab_ogr_datasource.cpp
@@ -328,6 +328,14 @@ OGRTABDataSource::ICreateLayer(const char *pszLayerName,
 
     else
     {
+        if (CPLLaunderForFilenameSafe(pszLayerName, nullptr) != pszLayerName)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Illegal characters in '%s' to form a valid filename",
+                     pszLayerName);
+            return nullptr;
+        }
+
         if (m_bCreateMIF)
         {
             pszFullFilename = CPLStrdup(

--- a/ogr/ogrsf_frmts/openfilegdb/filegdbindex.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/filegdbindex.cpp
@@ -1132,6 +1132,13 @@ int FileGDBIndexIterator::SetConstraint(int nFieldIdx, FileGDBSQLOp op,
         return FALSE;
     }
 
+    if (CPLHasPathTraversal(poIndex->GetIndexName().c_str()))
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Path traversal detected in %s",
+                 poIndex->GetIndexName().c_str());
+        return FALSE;
+    }
+
     const std::string osAtxName =
         CPLFormFilenameSafe(
             CPLGetPathSafe(poParent->GetFilename().c_str()).c_str(),

--- a/ogr/ogrsf_frmts/pds/ogrpdsdatasource.cpp
+++ b/ogr/ogrsf_frmts/pds/ogrpdsdatasource.cpp
@@ -148,6 +148,14 @@ bool OGRPDSDataSource::LoadTable(const char *pszFilename, int nRecordSize,
         }
         CPLString osTPath = CPLGetPathSafe(pszFilename);
         CleanString(osTableFilename);
+
+        if (CPLHasPathTraversal(osTableFilename.c_str()))
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Path traversal detected in %s", osTableFilename.c_str());
+            return false;
+        }
+
         osTableFilename =
             CPLFormCIFilenameSafe(osTPath, osTableFilename, nullptr);
     }
@@ -181,6 +189,15 @@ bool OGRPDSDataSource::LoadTable(const char *pszFilename, int nRecordSize,
         {
             CPLString osTPath = CPLGetPathSafe(pszFilename);
             CleanString(osTableFilename);
+
+            if (CPLHasPathTraversal(osTableFilename.c_str()))
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Path traversal detected in %s",
+                         osTableFilename.c_str());
+                return false;
+            }
+
             osTableFilename =
                 CPLFormCIFilenameSafe(osTPath, osTableFilename, nullptr);
             nStartBytes = 0;
@@ -232,6 +249,15 @@ bool OGRPDSDataSource::LoadTable(const char *pszFilename, int nRecordSize,
     {
         CPLString osTPath = CPLGetPathSafe(pszFilename);
         CleanString(osTableStructure);
+
+        if (CPLHasPathTraversal(osTableStructure.c_str()))
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Path traversal detected in %s", osTableStructure.c_str());
+            VSIFCloseL(fp);
+            return false;
+        }
+
         osTableStructure =
             CPLFormCIFilenameSafe(osTPath, osTableStructure, nullptr);
     }

--- a/ogr/ogrsf_frmts/shape/ogrshapelayer.cpp
+++ b/ogr/ogrsf_frmts/shape/ogrshapelayer.cpp
@@ -3770,6 +3770,14 @@ OGRErr OGRShapeLayer::Rename(const char *pszNewName)
     if (!TestCapability(OLCRename))
         return OGRERR_FAILURE;
 
+    if (CPLLaunderForFilenameSafe(pszNewName, nullptr) != pszNewName)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Illegal characters in '%s' to form a valid filename",
+                 pszNewName);
+        return OGRERR_FAILURE;
+    }
+
     if (m_poDS->GetLayerByName(pszNewName) != nullptr)
     {
         CPLError(CE_Failure, CPLE_AppDefined, "Layer %s already exists",

--- a/ogr/ogrsf_frmts/vdv/ogrvdvdatasource.cpp
+++ b/ogr/ogrsf_frmts/vdv/ogrvdvdatasource.cpp
@@ -1919,6 +1919,14 @@ OGRVDVDataSource::ICreateLayer(const char *pszLayerName,
     }
     else
     {
+        if (CPLLaunderForFilenameSafe(pszLayerName, nullptr) != pszLayerName)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Illegal characters in '%s' to form a valid filename",
+                     pszLayerName);
+            return nullptr;
+        }
+
         CPLString osExtension =
             CSLFetchNameValueDef(papszOptions, "EXTENSION", "x10");
         const CPLString osFilename =

--- a/port/cpl_conv.h
+++ b/port/cpl_conv.h
@@ -242,6 +242,8 @@ extern "C++"
 
 #endif  // defined(__cplusplus) && !defined(CPL_SUPRESS_CPLUSPLUS)
 
+bool CPL_DLL CPLHasPathTraversal(const char *pszFilename);
+
 /* -------------------------------------------------------------------- */
 /*      Find File Function                                              */
 /* -------------------------------------------------------------------- */

--- a/port/cpl_known_config_options.h
+++ b/port/cpl_known_config_options.h
@@ -100,6 +100,7 @@ constexpr static const char* const apszKnownConfigOptions[] =
    "CPL_CURL_VERBOSE_DATA_IN", // from cpl_http.cpp
    "CPL_CURL_VSIMEM_PRINT_HEADERS", // from cpl_http.cpp
    "CPL_DEBUG", // from cpl_conv.cpp, cpl_error.cpp, gdalinfo_bin.cpp, gdalsrsinfo.cpp, gdalwarp_bin.cpp, gmlutils.cpp
+   "CPL_ENABLE_PATH_TRAVERSAL_DETECTION", // from cpl_path.cpp
    "CPL_ENABLE_USERFAULTFD", // from cpl_userfaultfd.cpp
    "CPL_ERROR_SEPARATOR", // from cpl_error.cpp
    "CPL_GCE_CHECK_LOCAL_FILES", // from cpl_google_cloud.cpp

--- a/port/cpl_path.cpp
+++ b/port/cpl_path.cpp
@@ -1608,3 +1608,44 @@ const char *CPLLaunderForFilename(const char *pszName,
     return CPLPathReturnTLSString(
         CPLLaunderForFilenameSafe(pszName, pszOutputPath), __FUNCTION__);
 }
+
+/************************************************************************/
+/*                        CPLHasPathTraversal()                        */
+/************************************************************************/
+
+/**
+ * Return whether the filename contains a path traversal pattern.
+ *
+ * i.e. if it contains "../" or "..\\".
+ *
+ * The CPL_ENABLE_PATH_TRAVERSAL_DETECTION configuration option can be set
+ * to NO to disable this check, although this is not recommended when dealing
+ * with un-trusted input.
+ *
+ * @param pszFilename The input string to check.
+ * @return true if a path traversal pattern is detected.
+ *
+ * @since GDAL 3.12
+ */
+
+bool CPLHasPathTraversal(const char *pszFilename)
+{
+    if (strstr(pszFilename, "../") != nullptr ||
+        strstr(pszFilename, "..\\") != nullptr)
+    {
+        if (CPLTestBool(CPLGetConfigOption(
+                "CPL_ENABLE_PATH_TRAVERSAL_DETECTION", "YES")))
+        {
+            CPLDebug("CPL", "Path traversal detected for %s", pszFilename);
+            return true;
+        }
+        else
+        {
+            CPLDebug("CPL",
+                     "Path traversal detected for %s but ignored given that "
+                     "CPL_ENABLE_PATH_TRAVERSAL_DETECTION is disabled",
+                     pszFilename);
+        }
+    }
+    return false;
+}


### PR DESCRIPTION
Many file formats read auxiliary files whose names are given in the file that is opened. That could be abused for [path traversal attacks](https://en.wikipedia.org/wiki/Directory_traversal_attack), so this PR adds a CPLHasPathTraversal() function to detect ``../`` and ``..\`` patterns in filenames. A review of potential call sites where this check must be added has been done by looking for calls to CPLFormFilename() or CPLFormCIFilename() and assessing if they needed a prior check to CPLHasPathTraversal(). There might be misses (false negatives), and perhaps wrong detections (false positives). For that later case, a ``CPL_ENABLE_PATH_TRAVERSAL_DETECTION`` config option is introduced, which defaults to TRUE.
Related to that the CreateLayer() function of a few vector drivers has been enhanced to detect layer names that could lead to path traversal.