### PR TITLE
ISIS3 metadata enhancements

### DIFF
--- a/apps/gdal_translate_lib.cpp
+++ b/apps/gdal_translate_lib.cpp
@@ -89,6 +89,8 @@ struct GDALTranslateScaleParams
  */
 struct GDALTranslateOptions
 {
+    /*! Raw program arguments */
+    CPLStringList aosArgs{};
 
     /*! output format. Use the short format name. */
     std::string osFormat{};
@@ -509,21 +511,20 @@ static void ReworkArray(CPLJSONObject &container, const CPLJSONObject &obj,
     }
 }
 
-static CPLString
+static std::string
 EditISIS3MetadataForBandChange(const char *pszJSON, int nSrcBandCount,
                                const GDALTranslateOptions *psOptions)
 {
     CPLJSONDocument oJSONDocument;
-    const GByte *pabyData = reinterpret_cast<const GByte *>(pszJSON);
-    if (!oJSONDocument.LoadMemory(pabyData))
+    if (!oJSONDocument.LoadMemory(pszJSON))
     {
-        return CPLString();
+        return std::string();
     }
 
     auto oRoot = oJSONDocument.GetRoot();
     if (!oRoot.IsValid())
     {
-        return CPLString();
+        return std::string();
     }
 
     auto oBandBin = oRoot.GetObj("IsisCube/BandBin");
@@ -552,6 +553,88 @@ EditISIS3MetadataForBandChange(const char *pszJSON, int nSrcBandCount,
             }
         }
     }
+
+    return oRoot.Format(CPLJSONObject::PrettyFormat::Pretty);
+}
+
+/************************************************************************/
+/*                    EditISIS3ForMetadataChanges()                     */
+/************************************************************************/
+
+static std::string
+EditISIS3ForMetadataChanges(const char *pszJSON, bool bKeepExtent,
+                            bool bKeepResolution,
+                            const GDALTranslateOptions *psOptions)
+{
+    CPLJSONDocument oJSONDocument;
+    if (!oJSONDocument.LoadMemory(pszJSON))
+    {
+        return std::string();
+    }
+
+    auto oRoot = oJSONDocument.GetRoot();
+    if (!oRoot.IsValid())
+    {
+        return std::string();
+    }
+
+    auto oGDALHistory = oRoot.GetObj("GDALHistory");
+    if (!oGDALHistory.IsValid())
+    {
+        oGDALHistory = CPLJSONObject();
+        oRoot.Add("GDALHistory", oGDALHistory);
+    }
+    oGDALHistory["_type"] = "object";
+
+    char szFullFilename[2048] = {0};
+    if (!CPLGetExecPath(szFullFilename, sizeof(szFullFilename) - 1))
+        strcpy(szFullFilename, "unknown_program");
+    const CPLString osProgram(CPLGetBasenameSafe(szFullFilename));
+    const CPLString osPath(CPLGetPathSafe(szFullFilename));
+
+    oGDALHistory["GdalVersion"] = GDALVersionInfo("RELEASE_NAME");
+    oGDALHistory["Program"] = osProgram;
+    if (osPath != ".")
+        oGDALHistory["ProgramPath"] = osPath;
+
+    std::vector<std::string> aosOps;
+    if (!bKeepExtent)
+    {
+        aosOps.push_back("a clipping operation");
+    }
+    if (!bKeepResolution)
+    {
+        aosOps.push_back("a resolution change operation");
+    }
+    if (psOptions->bUnscale)
+    {
+        aosOps.push_back("an unscaling operation");
+    }
+    else if (!psOptions->asScaleParams.empty())
+    {
+        aosOps.push_back("a scaling operation");
+    }
+
+    std::string osArgs;
+    for (const char *pszArg : psOptions->aosArgs)
+    {
+        if (!osArgs.empty())
+            osArgs += ' ';
+        osArgs += pszArg;
+    }
+    oGDALHistory["ProgramArguments"] = osArgs;
+
+    std::string osComment = "Part of that metadata might be invalid due to ";
+    for (size_t i = 0; i < aosOps.size(); ++i)
+    {
+        if (i > 0 && i + 1 == aosOps.size())
+            osComment += " and ";
+        else if (i > 0)
+            osComment += ", ";
+        osComment += aosOps[i];
+    }
+    osComment += " having been performed by GDAL tools";
+    oGDALHistory.Add("Comment", osComment);
 
     return oRoot.Format(CPLJSONObject::PrettyFormat::Pretty);
 }
@@ -1102,11 +1185,13 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
         psOptions->nOXSizePixel == 0 && psOptions->dfOXSizePct == 0.0 &&
         psOptions->nOYSizePixel == 0 && psOptions->dfOYSizePct == 0.0 &&
         psOptions->dfXRes == 0.0;
-    const bool bSpatialArrangementPreserved =
+    const bool bKeepExtent =
         psOptions->srcWin.dfXOff == 0 && psOptions->srcWin.dfYOff == 0 &&
         psOptions->srcWin.dfXSize == poSrcDS->GetRasterXSize() &&
-        psOptions->srcWin.dfYSize == poSrcDS->GetRasterYSize() &&
-        bKeepResolution;
+        psOptions->srcWin.dfYSize == poSrcDS->GetRasterYSize();
+    const bool bSpatialArrangementPreserved = bKeepExtent && bKeepResolution;
+    const bool bValuesChanged =
+        psOptions->bUnscale || !psOptions->asScaleParams.empty();
 
     if (psOptions->eOutputType == GDT_Unknown &&
         psOptions->asScaleParams.empty() && psOptions->adfExponent.empty() &&
@@ -1675,21 +1760,23 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
 
     /* ISIS3 metadata preservation */
     char **papszMD_ISIS3 = poSrcDS->GetMetadata("json:ISIS3");
-    if (papszMD_ISIS3 != nullptr)
+    if (papszMD_ISIS3 != nullptr && papszMD_ISIS3[0])
     {
+        std::string osJSON = papszMD_ISIS3[0];
         if (!bAllBandsInOrder)
         {
-            CPLString osJSON = EditISIS3MetadataForBandChange(
-                papszMD_ISIS3[0], poSrcDS->GetRasterCount(), psOptions.get());
-            if (!osJSON.empty())
-            {
-                char *apszMD[] = {&osJSON[0], nullptr};
-                poVDS->SetMetadata(apszMD, "json:ISIS3");
-            }
+            osJSON = EditISIS3MetadataForBandChange(
+                osJSON.c_str(), poSrcDS->GetRasterCount(), psOptions.get());
         }
-        else
+        if (!bSpatialArrangementPreserved || bValuesChanged)
         {
-            poVDS->SetMetadata(papszMD_ISIS3, "json:ISIS3");
+            osJSON = EditISIS3ForMetadataChanges(
+                osJSON.c_str(), bKeepExtent, bKeepResolution, psOptions.get());
+        }
+        if (!osJSON.empty())
+        {
+            char *apszMD[] = {osJSON.data(), nullptr};
+            poVDS->SetMetadata(apszMD, "json:ISIS3");
         }
     }
 
@@ -1847,9 +1934,9 @@ GDALDatasetH GDALTranslate(const char *pszDest, GDALDatasetH hSrcDataset,
     }
 
     // Can be set to TRUE in the band loop too
-    bool bFilterOutStatsMetadata =
-        !psOptions->asScaleParams.empty() || psOptions->bUnscale ||
-        !bSpatialArrangementPreserved || psOptions->nRGBExpand != 0;
+    bool bFilterOutStatsMetadata = bValuesChanged ||
+                                   !bSpatialArrangementPreserved ||
+                                   psOptions->nRGBExpand != 0;
 
     if (static_cast<int>(psOptions->anColorInterp.size()) >
         psOptions->nBandCount)
@@ -3151,6 +3238,8 @@ GDALTranslateOptionsNew(char **papszArgv,
                         GDALTranslateOptionsForBinary *psOptionsForBinary)
 {
     auto psOptions = std::make_unique<GDALTranslateOptions>();
+
+    psOptions->aosArgs.Assign(CSLDuplicate(papszArgv), true);
 
     /* -------------------------------------------------------------------- */
     /*      Pre-processing for custom syntax that ArgumentParser does not   */

--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -5984,4 +5984,17 @@ TEST_F(test_cpl, CPLGetCurrentThreadCount)
 #endif
 }
 
+TEST_F(test_cpl, CPLHasPathTraversal)
+{
+    EXPECT_TRUE(CPLHasPathTraversal("a/../b"));
+    EXPECT_TRUE(CPLHasPathTraversal("a\\..\\b"));
+    EXPECT_FALSE(CPLHasPathTraversal("a/b"));
+    {
+        CPLConfigOptionSetter oSetter("CPL_ENABLE_PATH_TRAVERSAL_DETECTION",
+                                      "NO", true);
+        EXPECT_FALSE(CPLHasPathTraversal("a/../b"));
+        EXPECT_FALSE(CPLHasPathTraversal("a\\..\\b"));
+    }
+}
+
 }  // namespace

--- a/doc/source/drivers/raster/isis3.rst
+++ b/doc/source/drivers/raster/isis3.rst
@@ -130,14 +130,20 @@ For example:
        "Name":"IsisCube",
        "StartByte":1,
        "Bytes":957,
-       "^History":"r0200357_10m_Jul20_o_i3_detatched.History.IsisCube"
+       "^History":"r0200357_10m_Jul20_o_i3_detatched.History.IsisCube",
+       "_data": {
+          "ASCII" : "[...snip...]"
+       },
      },
      "OriginalLabel":{
        "_type":"object",
        "Name":"IsisCube",
        "StartByte":1,
        "Bytes":2482,
-       "^OriginalLabel":"r0200357_10m_Jul20_o_i3_detatched.OriginalLabel.IsisCube"
+       "^OriginalLabel":"r0200357_10m_Jul20_o_i3_detatched.OriginalLabel.IsisCube",
+       "_data": {
+          "HEX" : "0102[...snip...]"
+       },
      }
    }
 
@@ -304,6 +310,29 @@ The available creation options are:
       Manually defined GDAL history. Must be
       formatted as ISIS3 PDL. If not specified, it is automatically
       composed. Only used if :co:`ADD_GDAL_HISTORY=YES` (or unspecified).
+
+Open options
+------------
+
+.. versionadded:: 3.12
+
+|about-open-options|
+The available open options are:
+
+-  .. oo:: INCLUDE_OFFLINE_CONTENT
+      :choices: YES, NO
+      :default: YES
+
+      Whether to include a ``_data`` member in ``json:ISIS3`` metadata with offline
+      content of label objects. Defaults to YES
+
+-  .. oo:: MAX_SIZE_OFFLINE_CONTENT
+      :choices: <integer>
+      :default: 1000000000
+
+      Maximum size of offline content to include in ``_data`` member, in bytes.
+
+
 
 Examples
 --------

--- a/doc/source/drivers/raster/pds4.rst
+++ b/doc/source/drivers/raster/pds4.rst
@@ -224,6 +224,15 @@ The following dataset creation options are available:
 
          Manually set bounding box
 
+   -  .. co:: PROPAGATE_SRC_METADATA
+         :choices: YES, NO
+         :default: YES
+         :since: 3.12
+
+         Whether to propagate particular metadata domains, such as json:ISIS3.
+         When YES (the default), if IMAGE_FORMAT=GEOTIFF, that metadata is also
+         written into the GeoTIFF file.
+
 Layer creation options (vector/table datasets)
 ----------------------------------------------
 

--- a/doc/source/user/configoptions.rst
+++ b/doc/source/user/configoptions.rst
@@ -511,6 +511,15 @@ General options
 
       Location of Python shared library file, e.g. ``pythonX.Y[...].so/.dll``.
 
+-  .. config:: CPL_ENABLE_PATH_TRAVERSAL_DETECTION
+      :choices: YES, NO
+      :default: YES
+      :since: 3.12
+
+      Whether :cpp:func:`CPLHasPathTraversal` must detect ``../`` or ``..\\``
+      patterns in file paths that could cause
+      `path traversal vulnerabilities <https://en.wikipedia.org/wiki/Directory_traversal_attack>`__.
+
 
 .. _configoptions_vector:
 

--- a/frmts/pds/pds4dataset.cpp
+++ b/frmts/pds/pds4dataset.cpp
@@ -4818,10 +4818,17 @@ GDALDataset *PDS4Dataset::CreateCopy(const char *pszFilename,
             return nullptr;
         }
 
-        char **papszISIS3MD = poSrcDS->GetMetadata("json:ISIS3");
-        if (papszISIS3MD)
+        if (CPLFetchBool(papszOptions, "PROPAGATE_SRC_METADATA", true))
         {
-            poDS->SetMetadata(papszISIS3MD, "json:ISIS3");
+            char **papszISIS3MD = poSrcDS->GetMetadata("json:ISIS3");
+            if (papszISIS3MD)
+            {
+                poDS->SetMetadata(papszISIS3MD, "json:ISIS3");
+
+                if (poDS->m_poExternalDS)
+                    poDS->m_poExternalDS->SetMetadata(papszISIS3MD,
+                                                      "json:ISIS3");
+            }
         }
     }
 

--- a/frmts/pds/pds4dataset.h
+++ b/frmts/pds/pds4dataset.h
@@ -368,11 +368,10 @@ class PDS4Dataset final : public RawDataset
 
     bool OpenTableDelimited(const char *pszFilename, const CPLXMLNode *psTable);
 
-    static PDS4Dataset *CreateInternal(const char *pszFilename,
-                                       GDALDataset *poSrcDS, int nXSize,
-                                       int nYSize, int nBands,
-                                       GDALDataType eType,
-                                       const char *const *papszOptions);
+    static std::unique_ptr<PDS4Dataset>
+    CreateInternal(const char *pszFilename, GDALDataset *poSrcDS, int nXSize,
+                   int nYSize, int nBands, GDALDataType eType,
+                   const char *const *papszOptions);
 
     CPLErr Close() override;
 
@@ -407,11 +406,11 @@ class PDS4Dataset final : public RawDataset
 
     bool GetRawBinaryLayout(GDALDataset::RawBinaryLayout &) override;
 
-    static PDS4Dataset *OpenInternal(GDALOpenInfo *);
+    static std::unique_ptr<PDS4Dataset> OpenInternal(GDALOpenInfo *);
 
     static GDALDataset *Open(GDALOpenInfo *poOpenInfo)
     {
-        return OpenInternal(poOpenInfo);
+        return OpenInternal(poOpenInfo).release();
     }
 
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,

--- a/frmts/pds/pdsdrivercore.cpp
+++ b/frmts/pds/pdsdrivercore.cpp
@@ -387,6 +387,18 @@ void ISIS3DriverSetCommonMetadata(GDALDriver *poDriver)
     poDriver->SetMetadataItem(GDAL_DMD_CREATIONDATATYPES,
                               "Byte UInt16 Int16 Float32");
     poDriver->SetMetadataItem(GDAL_DMD_OPENOPTIONLIST, "<OpenOptionList/>");
+
+    poDriver->SetMetadataItem(
+        GDAL_DMD_OPENOPTIONLIST,
+        "<OpenOptionList>"
+        "  <Option name='INCLUDE_OFFLINE_CONTENT' type='boolean' default='YES' "
+        "description='Whether to include a _data member in "
+        "json:ISIS3 metadata with offline content of label objects'/>"
+        "  <Option name='MAX_SIZE_OFFLINE_CONTENT' type='string' "
+        "default='100000000' description='Maximum size of offline content to "
+        "include in _data member, in bytes' min='0'/>"
+        "</OpenOptionList>");
+
     poDriver->SetMetadataItem(
         GDAL_DMD_CREATIONOPTIONLIST,
         "<CreationOptionList>"

--- a/frmts/pds/pdsdrivercore.cpp
+++ b/frmts/pds/pdsdrivercore.cpp
@@ -270,6 +270,9 @@ void PDS4DriverSetCommonMetadata(GDALDriver *poDriver)
         "  <Option name='BOUNDING_DEGREES' type='string' scope='raster,vector' "
         "description='Manually set bounding box with the syntax "
         "west_lon,south_lat,east_lon,north_lat'/>"
+        "  <Option name='PROPAGATE_SRC_METADATA' type='boolean' scope='raster' "
+        "description='Whether to propagate particular metadata domains, such "
+        "as json:ISIS3' default='YES'/>"
         "</CreationOptionList>");
 
     poDriver->SetMetadataItem(

--- a/port/cpl_conv.h
+++ b/port/cpl_conv.h
@@ -242,6 +242,8 @@ extern "C++"
 
 #endif  // defined(__cplusplus) && !defined(CPL_SUPRESS_CPLUSPLUS)
 
+bool CPL_DLL CPLHasPathTraversal(const char *pszFilename);
+
 /* -------------------------------------------------------------------- */
 /*      Find File Function                                              */
 /* -------------------------------------------------------------------- */

--- a/port/cpl_known_config_options.h
+++ b/port/cpl_known_config_options.h
@@ -100,6 +100,7 @@ constexpr static const char* const apszKnownConfigOptions[] =
    "CPL_CURL_VERBOSE_DATA_IN", // from cpl_http.cpp
    "CPL_CURL_VSIMEM_PRINT_HEADERS", // from cpl_http.cpp
    "CPL_DEBUG", // from cpl_conv.cpp, cpl_error.cpp, gdalinfo_bin.cpp, gdalsrsinfo.cpp, gdalwarp_bin.cpp, gmlutils.cpp
+   "CPL_ENABLE_PATH_TRAVERSAL_DETECTION", // from cpl_path.cpp
    "CPL_ENABLE_USERFAULTFD", // from cpl_userfaultfd.cpp
    "CPL_ERROR_SEPARATOR", // from cpl_error.cpp
    "CPL_GCE_CHECK_LOCAL_FILES", // from cpl_google_cloud.cpp

--- a/port/cpl_path.cpp
+++ b/port/cpl_path.cpp
@@ -1608,3 +1608,44 @@ const char *CPLLaunderForFilename(const char *pszName,
     return CPLPathReturnTLSString(
         CPLLaunderForFilenameSafe(pszName, pszOutputPath), __FUNCTION__);
 }
+
+/************************************************************************/
+/*                        CPLHasPathTraversal()                        */
+/************************************************************************/
+
+/**
+ * Return whether the filename contains a path traversal pattern.
+ *
+ * i.e. if it contains "../" or "..\\".
+ *
+ * The CPL_ENABLE_PATH_TRAVERSAL_DETECTION configuration option can be set
+ * to NO to disable this check, although this is not recommended when dealing
+ * with un-trusted input.
+ *
+ * @param pszFilename The input string to check.
+ * @return true if a path traversal pattern is detected.
+ *
+ * @since GDAL 3.12
+ */
+
+bool CPLHasPathTraversal(const char *pszFilename)
+{
+    if (strstr(pszFilename, "../") != nullptr ||
+        strstr(pszFilename, "..\\") != nullptr)
+    {
+        if (CPLTestBool(CPLGetConfigOption(
+                "CPL_ENABLE_PATH_TRAVERSAL_DETECTION", "YES")))
+        {
+            CPLDebug("CPL", "Path traversal detected for %s", pszFilename);
+            return true;
+        }
+        else
+        {
+            CPLDebug("CPL",
+                     "Path traversal detected for %s but ignored given that "
+                     "CPL_ENABLE_PATH_TRAVERSAL_DETECTION is disabled",
+                     pszFilename);
+        }
+    }
+    return false;
+}


### PR DESCRIPTION
*  ISIS3: adds a _data member in json:ISIS3 metadata
   
   that contains the offline content as hexadecimal encoded.
    
    ```
            "Table_SecondTable": {
                "Bytes": 5,
                "Name": "SecondTable",
                "StartByte": 1,
                "_container_name": "Table",
                "^Table": "in.bin",
                "_data": "0102030405",
                "_type": "object",
            }
    ```
    

    Adds two open options:
    
    - INCLUDE_OFFLINE_CONTENT=YES/NO: Whether to include a _data member in
      json:ISIS3 metadata with offline content of label objects. Defaults to
      YES
    
    - MAX_SIZE_OFFLINE_CONTENT=<int>: Maximum size of offline content to
      include in _data member, in bytes. Defaults to 100,000,000
      
*   ISIS3 -> PDS4 GeoTIFF: propagate json:ISIS3 metadata
    
    Add a PROPAGATE_SRC_METADATA=YES/NO (default YES) creation option to the
    PDS4 driver to control this.

*   gdal_translate/gdalwarp: add a GDALHistory section to json:ISIS3 metadata if it might be invalidated
