### PR TITLE
gdal pipeline: allow to run an existing pipeline and override/add parameters

### DIFF
--- a/apps/data/gdal_algorithm.schema.json
+++ b/apps/data/gdal_algorithm.schema.json
@@ -44,6 +44,10 @@
           },
           "$comment": "Names of the immediate sub-algorithm of this algorithm. For example, or 'gdal raster', this will be [\"info\", \"convert\", ...]"
         },
+        "user_provided_arguments_allowed": {
+          "type": "boolean",
+          "$comment": "Whether user-provided arguments are allowed"
+        },
         "input_arguments": {
           "type": "array",
           "items": {

--- a/apps/gdalalg_raster.cpp
+++ b/apps/gdalalg_raster.cpp
@@ -111,7 +111,7 @@ class GDALRasterAlgorithm final : public GDALAlgorithm
         RegisterSubAlgorithm<GDALRasterSieveAlgorithmStandalone>();
         RegisterSubAlgorithm<GDALRasterSlopeAlgorithmStandalone>();
         RegisterSubAlgorithm<GDALRasterStackAlgorithmStandalone>();
-        RegisterSubAlgorithm<GDALRasterTileAlgorithm>();
+        RegisterSubAlgorithm<GDALRasterTileAlgorithmStandalone>();
         RegisterSubAlgorithm<GDALRasterTPIAlgorithmStandalone>();
         RegisterSubAlgorithm<GDALRasterTRIAlgorithmStandalone>();
         RegisterSubAlgorithm<GDALRasterUnscaleAlgorithmStandalone>();

--- a/apps/gdalalg_raster_footprint.cpp
+++ b/apps/gdalalg_raster_footprint.cpp
@@ -58,7 +58,8 @@ GDALRasterFootprintAlgorithm::GDALRasterFootprintAlgorithm(bool standaloneStep)
     }
 
     m_outputLayerName = "footprint";
-    AddArg("output-layer", 0, _("Output layer name"), &m_outputLayerName)
+    AddArg(GDAL_ARG_NAME_OUTPUT_LAYER, 0, _("Output layer name"),
+           &m_outputLayerName)
         .SetDefault(m_outputLayerName);
 
     AddBandArg(&m_bands);
@@ -282,7 +283,7 @@ bool GDALRasterFootprintAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
         aosOptions.push_back(m_dstCrs);
     }
 
-    if (GetArg("output-layer")->IsExplicitlySet())
+    if (GetArg(GDAL_ARG_NAME_OUTPUT_LAYER)->IsExplicitlySet())
     {
         aosOptions.push_back("-lyr_name");
         aosOptions.push_back(m_outputLayerName.c_str());

--- a/apps/gdalalg_raster_info.h
+++ b/apps/gdalalg_raster_info.h
@@ -33,6 +33,11 @@ class GDALRasterInfoAlgorithm /* non final */
     explicit GDALRasterInfoAlgorithm(bool standaloneStep = false,
                                      bool openForMixedRasterVector = false);
 
+    bool CanBeLastStep() const override
+    {
+        return true;
+    }
+
     GDALDataset *GetDatasetRef()
     {
         return m_inputDataset.empty() ? nullptr

--- a/apps/gdalalg_raster_reproject.cpp
+++ b/apps/gdalalg_raster_reproject.cpp
@@ -309,7 +309,7 @@ bool GDALRasterReprojectAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
     }
     if (bFoundNumThreads)
     {
-        if (GetArg("num-threads")->IsExplicitlySet())
+        if (GetArg(GDAL_ARG_NAME_NUM_THREADS)->IsExplicitlySet())
         {
             ReportError(CE_Failure, CPLE_AppDefined,
                         "--num-threads argument and NUM_THREADS warp options "

--- a/apps/gdalalg_raster_viewshed.cpp
+++ b/apps/gdalalg_raster_viewshed.cpp
@@ -234,8 +234,8 @@ bool GDALRasterViewshedAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
     }
     else
     {
-        static const std::vector<std::string> badArgs{"observer-spacing",
-                                                      "num-threads"};
+        static const std::vector<std::string> badArgs{
+            "observer-spacing", GDAL_ARG_NAME_NUM_THREADS};
         for (const auto &arg : badArgs)
             if (GetArg(arg)->IsExplicitlySet())
             {

--- a/apps/gdalalg_raster_write.h
+++ b/apps/gdalalg_raster_write.h
@@ -31,6 +31,11 @@ class GDALRasterWriteAlgorithm final : public GDALRasterPipelineStepAlgorithm
 
     GDALRasterWriteAlgorithm();
 
+    bool CanBeLastStep() const override
+    {
+        return true;
+    }
+
     bool IsNativelyStreamingCompatible() const override
     {
         return false;

--- a/apps/gdalalg_vector_concat.cpp
+++ b/apps/gdalalg_vector_concat.cpp
@@ -53,7 +53,7 @@ GDALVectorConcatAlgorithm::GDALVectorConcatAlgorithm(bool bStandalone)
         &m_mode)
         .SetChoices("merge-per-layer-name", "stack", "single")
         .SetDefault(m_mode);
-    AddArg("output-layer", 0,
+    AddArg(GDAL_ARG_NAME_OUTPUT_LAYER, 0,
            _("Name of the output vector layer (single mode), or template to "
              "name the output vector layers (stack mode)"),
            &m_layerNameTemplate);
@@ -493,7 +493,7 @@ bool GDALVectorConcatAlgorithm::RunImpl(GDALProgressFunc pfnProgress,
         GDALVectorWriteAlgorithm writeAlg;
         for (auto &arg : writeAlg.GetArgs())
         {
-            if (arg->GetName() != "output-layer")
+            if (arg->GetName() != GDAL_ARG_NAME_OUTPUT_LAYER)
             {
                 auto stepArg = GetArg(arg->GetName());
                 if (stepArg && stepArg->IsExplicitlySet())

--- a/apps/gdalalg_vector_convert.cpp
+++ b/apps/gdalalg_vector_convert.cpp
@@ -46,9 +46,11 @@ GDALVectorConvertAlgorithm::GDALVectorConvertAlgorithm(
     AddUpdateArg(&m_update);
     AddOverwriteLayerArg(&m_overwriteLayer);
     AddAppendLayerArg(&m_appendLayer);
-    AddArg("input-layer", 'l', _("Input layer name(s)"), &m_inputLayerNames)
+    AddArg(GDAL_ARG_NAME_INPUT_LAYER, 'l', _("Input layer name(s)"),
+           &m_inputLayerNames)
         .AddAlias("layer");
-    AddArg("output-layer", 0, _("Output layer name"), &m_outputLayerName)
+    AddArg(GDAL_ARG_NAME_OUTPUT_LAYER, 0, _("Output layer name"),
+           &m_outputLayerName)
         .AddHiddenAlias("nln");  // For ogr2ogr nostalgic people
     AddArg("skip-errors", 0, _("Skip errors when writing features"),
            &m_skipErrors)

--- a/apps/gdalalg_vector_info.h
+++ b/apps/gdalalg_vector_info.h
@@ -32,6 +32,11 @@ class GDALVectorInfoAlgorithm /* non final */
 
     explicit GDALVectorInfoAlgorithm(bool standaloneStep = false);
 
+    bool CanBeLastStep() const override
+    {
+        return true;
+    }
+
     void SetDataset(GDALDataset *poDS)
     {
         auto arg = GetArg(GDAL_ARG_NAME_INPUT);

--- a/apps/gdalalg_vector_layer_algebra.cpp
+++ b/apps/gdalalg_vector_layer_algebra.cpp
@@ -65,9 +65,11 @@ GDALVectorLayerAlgebraAlgorithm::GDALVectorLayerAlgebraAlgorithm()
     AddOverwriteLayerArg(&m_overwriteLayer);
     AddAppendLayerArg(&m_appendLayer);
 
-    AddArg("input-layer", 0, _("Input layer name"), &m_inputLayerName);
+    AddArg(GDAL_ARG_NAME_INPUT_LAYER, 0, _("Input layer name"),
+           &m_inputLayerName);
     AddArg("method-layer", 0, _("Method layer name"), &m_methodLayerName);
-    AddArg("output-layer", 0, _("Output layer name"), &m_outputLayerName)
+    AddArg(GDAL_ARG_NAME_OUTPUT_LAYER, 0, _("Output layer name"),
+           &m_outputLayerName)
         .AddHiddenAlias("nln");  // For ogr2ogr nostalgic people
 
     AddGeometryTypeArg(&m_geometryType);

--- a/apps/gdalalg_vector_sql.cpp
+++ b/apps/gdalalg_vector_sql.cpp
@@ -56,8 +56,8 @@ GDALVectorSQLAlgorithm::GDALVectorSQLAlgorithm(bool standaloneStep)
                        .SetRemoveSQLCommentsEnabled();
     if (!standaloneStep)
         sqlArg.SetPositional();
-    AddArg("output-layer", standaloneStep ? 0 : 'l', _("Output layer name(s)"),
-           &m_outputLayer);
+    AddArg(GDAL_ARG_NAME_OUTPUT_LAYER, standaloneStep ? 0 : 'l',
+           _("Output layer name(s)"), &m_outputLayer);
     AddArg("dialect", 0, _("SQL dialect (e.g. OGRSQL, SQLITE)"), &m_dialect);
 }
 

--- a/apps/gdalalg_vector_write.h
+++ b/apps/gdalalg_vector_write.h
@@ -31,6 +31,11 @@ class GDALVectorWriteAlgorithm final : public GDALVectorPipelineStepAlgorithm
 
     GDALVectorWriteAlgorithm();
 
+    bool CanBeLastStep() const override
+    {
+        return true;
+    }
+
     bool IsNativelyStreamingCompatible() const override
     {
         return false;

--- a/autotest/utilities/test_gdalalg_pipeline.py
+++ b/autotest/utilities/test_gdalalg_pipeline.py
@@ -253,10 +253,7 @@ def test_gdalalg_pipeline_help_doc(gdal_path):
     out = gdaltest.runexternal(f"{gdal_path} pipeline --help-doc=main")
 
     assert "Usage: gdal pipeline [OPTIONS] <PIPELINE>" in out
-    assert (
-        "<PIPELINE> is of the form: read|calc|concat|mosaic|stack [READ-OPTIONS] ( ! <STEP-NAME> [STEP-OPTIONS] )* ! write [WRITE-OPTIONS]"
-        in out
-    )
+    assert "<PIPELINE> is of the form:" in out
 
     out = gdaltest.runexternal(f"{gdal_path} pipeline --help-doc=edit-raster")
 

--- a/autotest/utilities/test_gdalalg_pipeline.py
+++ b/autotest/utilities/test_gdalalg_pipeline.py
@@ -422,7 +422,7 @@ def test_gdalalg_pipeline_raster_info_executable():
         pytest.skip("gdal binary missing")
 
     out = gdaltest.runexternal(
-        f"{gdal_path} pipeline read ../gcore/data/byte.tif ! info"
+        f'{gdal_path} pipeline --pipeline "read ../gcore/data/byte.tif ! info"'
     )
     assert out.startswith("Driver: GTiff/GeoTIFF")
 
@@ -436,5 +436,247 @@ def test_gdalalg_pipeline_vector_info_executable():
     if gdal_path is None:
         pytest.skip("gdal binary missing")
 
-    out = gdaltest.runexternal(f"{gdal_path} pipeline read ../ogr/data/poly.shp ! info")
+    out = gdaltest.runexternal(
+        f'{gdal_path} pipeline "--pipeline=read ../ogr/data/poly.shp ! info"'
+    )
     assert out.startswith("INFO: Open of `../ogr/data/poly.shp'")
+
+
+def test_gdalalg_pipeline_run_existing(tmp_path):
+
+    import gdaltest
+    import test_cli_utilities
+
+    gdal_path = test_cli_utilities.get_gdal_path()
+    if gdal_path is None:
+        pytest.skip("gdal binary missing")
+
+    pipeline_filename = tmp_path / "pipeline.gdalg.json"
+
+    with gdal.VSIFile(pipeline_filename, "wb") as f:
+        j = json.dumps(
+            {
+                "type": "gdal_streamed_alg",
+                "relative_paths_relative_to_this_file": False,
+                "command_line": "gdal pipeline read ../gcore/data/byte.tif ! edit --nodata=5 --metadata=KEY=VALUE",
+            }
+        )
+        f.write(j.encode("UTF-8"))
+
+    with gdal.Run(
+        "pipeline",
+        pipeline=pipeline_filename,
+        output="",
+        output_format="MEM",
+        arguments={"edit.metadata": "FOO=BAR"},
+    ) as alg:
+        ds = alg.Output()
+        assert ds.GetDriver().ShortName == "MEM"
+        assert ds.GetRasterBand(1).Checksum() == 4672
+        assert ds.GetRasterBand(1).GetNoDataValue() == 5
+        assert ds.GetMetadataItem("FOO") == "BAR"
+
+    output_filename = tmp_path / "out.tif"
+
+    out = gdaltest.runexternal(
+        f"{gdal_path} pipeline {pipeline_filename} --write.output {output_filename} --quiet"
+    )
+    assert out == ""
+
+    with gdal.Open(output_filename) as ds:
+        assert ds.GetRasterBand(1).Checksum() == 4672
+        assert ds.GetMetadataItem("KEY") == "VALUE"
+
+    _, err = gdaltest.runexternal_out_and_err(
+        f"{gdal_path} pipeline {pipeline_filename} --output {output_filename} --quiet"
+    )
+    assert "--overwrite" in err
+
+    gdal.Unlink(output_filename)
+
+    out = gdaltest.runexternal(
+        f"{gdal_path} pipeline --pipeline={pipeline_filename} --output {output_filename} --quiet"
+    )
+    assert out == ""
+    with gdal.Open(output_filename) as ds:
+        assert ds.GetRasterBand(1).Checksum() == 4672
+        assert ds.GetMetadataItem("KEY") == "VALUE"
+    gdal.Unlink(output_filename)
+
+    out = gdaltest.runexternal(
+        f"{gdal_path} pipeline --pipeline {pipeline_filename} --input ../gcore/data/rgbsmall.tif --output {output_filename} --metadata FOO=BAR --quiet"
+    )
+    assert out == ""
+    with gdal.Open(output_filename) as ds:
+        assert ds.RasterCount == 3
+        assert ds.GetMetadataItem("FOO") == "BAR"
+    gdal.Unlink(output_filename)
+
+    with gdal.VSIFile(pipeline_filename, "wb") as f:
+        j = json.dumps(
+            {
+                "type": "gdal_streamed_alg",
+                "relative_paths_relative_to_this_file": False,
+                "command_line": "gdal pipeline read ../gcore/data/byte.tif ! edit --metadata KEY=VALUE",
+            }
+        )
+        f.write(j.encode("UTF-8"))
+
+    out = gdaltest.runexternal(
+        f"{gdal_path} pipeline --pipeline {pipeline_filename} --input ../gcore/data/rgbsmall.tif --output {output_filename} --metadata=FOO=BAR --quiet"
+    )
+    assert out == ""
+    with gdal.Open(output_filename) as ds:
+        assert ds.RasterCount == 3
+        assert ds.GetMetadataItem("FOO") == "BAR"
+    gdal.Unlink(output_filename)
+
+    _, err = gdaltest.runexternal_out_and_err(
+        f"{gdal_path} pipeline {pipeline_filename}"
+    )
+    assert (
+        "write: Positional arguments starting at 'OUTPUT' have not been specified"
+        in err
+    )
+
+    _, err = gdaltest.runexternal_out_and_err(
+        f"{gdal_path} pipeline {pipeline_filename}  --output {output_filename} --foo.bar=baz"
+    )
+    assert (
+        "Argument 'foo.bar' refers to a non-existing 'foo' step in the pipeline" in err
+    )
+
+    _, err = gdaltest.runexternal_out_and_err(
+        f"{gdal_path} pipeline {pipeline_filename}  --output {output_filename} --read.bar=baz"
+    )
+    assert "read: Option '--bar' is unknown" in err
+
+    _, err = gdaltest.runexternal_out_and_err(
+        f"{gdal_path} pipeline {pipeline_filename}  --output {output_filename} --foo=bar"
+    )
+    assert "pipeline: No step in the pipeline has an argument named 'foo'" in err
+
+    _, err = gdaltest.runexternal_out_and_err(
+        f"{gdal_path} pipeline {pipeline_filename}  --output {output_filename} --foo.bar.baz=baw"
+    )
+    assert (
+        "Invalid argument name 'foo.bar.baz'. It should of the form <algorithm-name>.<argument-name>"
+        in err
+    )
+    with gdal.VSIFile(pipeline_filename, "wb") as f:
+        j = json.dumps(
+            {
+                "type": "gdal_streamed_alg",
+                "relative_paths_relative_to_this_file": False,
+                "command_line": "gdal pipeline read ../gcore/data/byte.tif ! edit --metadata=KEY=VALUE ! edit ! write --output-format=stream streamed_dataset",
+            }
+        )
+        f.write(j.encode("UTF-8"))
+
+    _, err = gdaltest.runexternal_out_and_err(
+        f"{gdal_path} pipeline {pipeline_filename}  --output {output_filename} --metadata=foo=bar"
+    )
+    assert (
+        "Ambiguous argument name 'metadata', because it is valid for several steps in the pipeline. It should be specified with the form <algorithm-name>.<argument-name>"
+        in err
+    )
+
+    _, err = gdaltest.runexternal_out_and_err(
+        f"{gdal_path} pipeline {pipeline_filename}  --output {output_filename} --edit.metadata=foo=bar"
+    )
+    assert (
+        "pipeline: Argument 'edit.metadata' is ambiguous as there are several 'edit' steps in the pipeline"
+        in err
+    )
+
+    out, err = gdaltest.runexternal_out_and_err(
+        f"{gdal_path} pipeline {pipeline_filename}  --output {output_filename} --edit[2].metadata=foo=bar"
+    )
+    assert (
+        "pipeline: Argument 'edit[2].metadata' refers to a non-existing 'edit[2]' step in the pipeline"
+        in err
+    )
+
+    out = gdaltest.runexternal(
+        f"{gdal_path} pipeline {pipeline_filename} --output {output_filename} --edit[1].metadata=foo=bar --quiet"
+    )
+    assert out == ""
+    with gdal.Open(output_filename) as ds:
+        assert ds.GetMetadataItem("KEY") == "VALUE"
+        assert ds.GetMetadataItem("foo") == "bar"
+    gdal.Unlink(output_filename)
+
+    with gdal.VSIFile(pipeline_filename, "wb") as f:
+        j = json.dumps(
+            {
+                "type": "gdal_streamed_alg",
+                "relative_paths_relative_to_this_file": False,
+                "command_line": "gdal pipeline read ../ogr/data/poly.shp ! edit --geometry-type MULTIPOLYGON --metadata=KEY=VALUE",
+            }
+        )
+        f.write(j.encode("UTF-8"))
+
+    with gdal.Run(
+        "pipeline",
+        pipeline=pipeline_filename,
+        output="",
+        output_format="MEM",
+        arguments={"edit.metadata": "FOO=BAR"},
+    ) as alg:
+        ds = alg.Output()
+        assert ds.GetDriver().ShortName == "MEM"
+        assert ds.GetLayerCount() == 1
+        assert ds.GetLayer(0).GetFeatureCount() == 10
+        assert ds.GetLayer(0).GetGeomType() == ogr.wkbMultiPolygon
+        assert ds.GetMetadataItem("FOO") == "BAR"
+
+    with gdal.VSIFile(pipeline_filename, "wb") as f:
+        f.write(b"""corrupted""")
+
+    _, err = gdaltest.runexternal_out_and_err(
+        f"{gdal_path} pipeline {pipeline_filename}  --output {output_filename} --edit[2].metadata=foo=bar"
+    )
+    assert "JSON parsing error" in err
+
+    with gdal.VSIFile(pipeline_filename, "wb") as f:
+        j = json.dumps(
+            {
+                "type": "gdal_streamed_alg",
+            }
+        )
+        f.write(j.encode("UTF-8"))
+
+    _, err = gdaltest.runexternal_out_and_err(
+        f"{gdal_path} pipeline {pipeline_filename}  --output {output_filename} --edit[2].metadata=foo=bar"
+    )
+    assert "pipeline: command_line missing in" in err
+
+    with gdal.VSIFile(pipeline_filename, "wb") as f:
+        j = json.dumps(
+            {
+                "type": "gdal_streamed_alg",
+                "relative_paths_relative_to_this_file": False,
+                "command_line": "gdal pipeline read a b c ! edit --metadata=KEY=VALUE ! edit ! write --output-format=stream streamed_dataset",
+            }
+        )
+        f.write(j.encode("UTF-8"))
+
+    _, err = gdaltest.runexternal_out_and_err(
+        f"{gdal_path} pipeline {pipeline_filename} --output {output_filename} --input=/i/do_not/exist"
+    )
+    assert "/i/do_not/exist" in err
+
+    with gdal.VSIFile(pipeline_filename, "wb") as f:
+        j = json.dumps(
+            {
+                "type": "gdal_streamed_alg",
+                "relative_paths_relative_to_this_file": False,
+                "command_line": "gdal pipeline read a b c ! edit --metadata=KEY=VALUE ! edit ! write --output-format stream --output streamed_dataset",
+            }
+        )
+        f.write(j.encode("UTF-8"))
+
+    _, err = gdaltest.runexternal_out_and_err(
+        f"{gdal_path} pipeline {pipeline_filename} --output {output_filename} --input=/i/do_not/exist"
+    )
+    assert "/i/do_not/exist" in err

--- a/autotest/utilities/test_gdalalg_raster_pipeline.py
+++ b/autotest/utilities/test_gdalalg_raster_pipeline.py
@@ -148,10 +148,7 @@ def test_gdalalg_raster_pipeline_help_doc():
     out = gdaltest.runexternal(f"{gdal_path} raster pipeline --help-doc=main")
 
     assert "Usage: gdal raster pipeline [OPTIONS] <PIPELINE>" in out
-    assert (
-        "<PIPELINE> is of the form: read|mosaic|stack [READ-OPTIONS] ( ! <STEP-NAME> [STEP-OPTIONS] )* ! write [WRITE-OPTIONS]"
-        in out
-    )
+    assert "<PIPELINE> is of the form: " in out
 
     out = gdaltest.runexternal(f"{gdal_path} raster pipeline --help-doc=edit")
 

--- a/autotest/utilities/test_gdalalg_vector_pipeline.py
+++ b/autotest/utilities/test_gdalalg_vector_pipeline.py
@@ -227,10 +227,7 @@ def test_gdalalg_vector_pipeline_help_doc():
     out = gdaltest.runexternal(f"{gdal_path} vector pipeline --help-doc=main")
 
     assert "Usage: gdal vector pipeline [OPTIONS] <PIPELINE>" in out
-    assert (
-        "<PIPELINE> is of the form: read|concat [READ-OPTIONS] ( ! <STEP-NAME> [STEP-OPTIONS] )* ! write [WRITE-OPTIONS]"
-        in out
-    )
+    assert "<PIPELINE> is of the form:" in out
 
     out = gdaltest.runexternal(f"{gdal_path} vector pipeline --help-doc=edit")
 

--- a/doc/source/programs/gdal_pipeline.rst
+++ b/doc/source/programs/gdal_pipeline.rst
@@ -96,6 +96,77 @@ The final ``write`` step can be added but if so it must explicitly specify the
         "command_line": "gdal pipeline ! read in.tif ! footprint ! buffer 20 ! write --output-format=streamed streamed_dataset"
     }
 
+.. _gdal_pipeline_substitutions:
+
+Substitutions
+-------------
+
+It is also possible to use :program:`gdal pipeline` to use a pipeline already
+serialized in a .gdal.json file, and customize its existing steps, typically
+changing input filename, specifying output filename, or adding/modifying arguments
+of steps.
+
+The syntax is:
+
+::
+
+    gdal pipeline <filename.gdalg.json> --<step-name>.<arg-name>=value
+
+
+When specifying an existing argument of a step of a pipeline, the value from the
+pipeline is overridden by the one specified on the :program:`gdal pipeline` command line.
+
+Let's imagine with have a :file:`raster_reproject.gdalg.json` with the following content:
+
+.. code-block:: json
+
+    {
+        "type": "gdal_streamed_alg",
+        "command_line": "gdal pipeline ! read in.tif ! reproject --dst-crs=EPSG:4326 ! edit --metadata=CHANGES=reprojected"
+    }
+
+It is possible to run it with the following command command line, overridden the
+``input`` argument of the ``read`` step, and implicitly adding a final ``write``
+step with an ``output`` argument.
+
+.. code-block:: bash
+
+    $ gdal pipeline raster_reproject.gdalg.json --read.input=other_input.tif --write.output=out.tif
+
+
+When there is no ambiguity, it is also possible to omit the step name, and just
+specify the argument name (if there is an ambiguity, :program:`gdal pipeline`
+will emit an error, so this is safe to do):
+
+.. code-block:: bash
+
+    $ gdal pipeline raster_reproject.gdalg.json --input=other_input.tif --output=out.tif --co COMPRESS=LZW --overwrite
+
+
+When a step appears several times in the pipeline, it must specified as
+``<step-name>[<idx>]``, where ``<idx>`` is a zero-based index.
+
+For example, given:
+
+.. code-block:: json
+
+    {
+        "type": "gdal_streamed_alg",
+        "command_line": "gdal pipeline ! read in.tif ! edit --metadata=before=value ! reproject --dst-crs=EPSG:4326 ! edit --metadata=CHANGES=reprojected"
+    }
+
+the following command line may be used:
+
+.. code-block:: bash
+
+    $ gdal pipeline raster_reproject.gdalg.json --edit[0].metadata=before=modified --output=out.tif
+
+
+Execution of pipeline and argument substitutions can also be done in Python with:
+
+.. code-block:: python
+
+    gdal.Run("pipeline", pipeline="raster_reproject.gdalg.json", output="out.tif", arguments={"edit[0].metadata": "before=modified"})
 
 Examples
 --------
@@ -113,3 +184,10 @@ Examples
    .. code-block:: bash
 
         $ gdal pipeline ! read in.gpkg ! rasterize --size 1000,1000 ! reproject --dst-crs EPSG:4326 ! write out.tif --overwrite
+
+.. example::
+   :title: Use an existing pipeline that rasterize and reproject, but change its input file and target CRS, and specify the output file
+
+   .. code-block:: bash
+
+        $ gdal pipeline raster_reproject.gdalg.json --input=my.gpkg --output=out.tif --dst-crs=EPSG:32631

--- a/doc/source/programs/gdal_pipeline.rst
+++ b/doc/source/programs/gdal_pipeline.rst
@@ -24,8 +24,10 @@ Synopsis
 .. program-output:: gdal pipeline --help-doc=main
 
 A pipeline chains several steps, separated with the `!` (exclamation mark) character.
-The first step must be ``read``, ``calc``, ``concat``, ``mosaic`` or ``stack``, and the last one ``info`` or ``write``. Each step has its
-own positional or non-positional arguments. Apart from ``read``, ``calc``, ``concat``, ``mosaic``, ``stack`` and ``write``,
+The first step must be ``read``, ``calc``, ``concat``, ``mosaic`` or ``stack``,
+and the last one ``info``, ``tile`` or ``write``.
+Each step has its own positional or non-positional arguments.
+Apart from ``read``, ``calc``, ``concat``, ``mosaic``, ``stack``, ``info``, ``tile`` and ``write``,
 all other steps can potentially be used several times in a pipeline.
 
 For steps that have both *raster* data type as input and output, consult :ref:`gdal_raster_pipeline`.

--- a/doc/source/programs/gdal_raster_pipeline.rst
+++ b/doc/source/programs/gdal_raster_pipeline.rst
@@ -26,8 +26,10 @@ Synopsis
 .. program-output:: gdal raster pipeline --help-doc=main
 
 A pipeline chains several steps, separated with the `!` (exclamation mark) character.
-The first step must be ``read``, ``calc``, ``mosaic`` or ``stack``, and the last one ``write``. Each step has its
-own positional or non-positional arguments. Apart from ``read``, ``calc``, ``mosaic``, ``stack`` and ``write``,
+The first step must be ``read``, ``calc``, ``mosaic`` or ``stack``,
+and the last one ``write``, ``info`` or ``tile``.
+Each step has its own positional or non-positional arguments.
+Apart from ``read``, ``calc``, ``mosaic``, ``stack``, ``info``, ``tile`` and ``write``,
 all other steps can potentially be used several times in a pipeline.
 
 Potential steps are:
@@ -200,6 +202,14 @@ Details for options can be found in :ref:`gdal_raster_viewshed`.
 
 Details for options can be found in :ref:`gdal_raster_info`.
 
+* tile
+
+.. versionadded:: 3.12
+
+.. program-output:: gdal raster pipeline --help-doc=tile
+
+Details for options can be found in :ref:`gdal_raster_tile`.
+
 * write
 
 .. program-output:: gdal raster pipeline --help-doc=write
@@ -251,6 +261,13 @@ Examples
 
         $ gdal raster pipeline ! read in.tif ! reproject --dst-crs=EPSG:32632 ! write in_epsg_32632.gdalg.json --overwrite
         $ gdal raster info in_epsg_32632.gdalg.json
+
+.. example::
+   :title: Mosaic on-the-fly several input files and tile that mosaic.
+
+   .. code-block:: bash
+
+      gdal raster pipeline ! mosaic input*.tif ! tile output_folder
 
 
 

--- a/doc/source/programs/gdal_raster_pipeline.rst
+++ b/doc/source/programs/gdal_raster_pipeline.rst
@@ -244,6 +244,19 @@ The final ``write`` step can be added but if so it must explicitly specify the
     }
 
 
+Substitutions
+-------------
+
+.. versionadded:: 3.12
+
+It is possible to use :program:`gdal pipeline` to use a pipeline already
+serialized in a .gdal.json file, and customize its existing steps, typically
+changing input filename, specifying output filename, or adding/modifying arguments
+of steps.
+
+See :ref:`gdal_pipeline_substitutions`
+
+
 Examples
 --------
 

--- a/doc/source/programs/gdal_raster_tile.rst
+++ b/doc/source/programs/gdal_raster_tile.rst
@@ -36,6 +36,9 @@ It can also use a tiling scheme fully adapted to the input raster, in terms of
 origin and resolution, when using the ``raster`` tiling scheme. In that scheme,
 tiles at the maximum zoom level will have the same resolution as the raster.
 
+Starting with GDAL 3.12, :program:`gdal raster tile` can be used as the last
+step of a pipeline.
+
 Standard options
 ++++++++++++++++
 
@@ -326,3 +329,10 @@ Examples
    .. code-block:: bash
 
       gdal raster tile --format COG --tile-size 4096 input.tif output_folder
+
+.. example::
+   :title: Mosaic on-the-fly several input files and tile that mosaic.
+
+   .. code-block:: bash
+
+      gdal raster pipeline ! mosaic input*.tif ! tile output_folder

--- a/doc/source/programs/gdal_vector_pipeline.rst
+++ b/doc/source/programs/gdal_vector_pipeline.rst
@@ -169,6 +169,20 @@ The final ``write`` step can be added but if so it must explicitly specify the
     }
 
 
+
+Substitutions
+-------------
+
+.. versionadded:: 3.12
+
+It is possible to use :program:`gdal pipeline` to use a pipeline already
+serialized in a .gdal.json file, and customize its existing steps, typically
+changing input filename, specifying output filename, or adding/modifying arguments
+of steps.
+
+See :ref:`gdal_pipeline_substitutions`
+
+`
 Examples
 --------
 

--- a/gcore/gdalalgorithm.cpp
+++ b/gcore/gdalalgorithm.cpp
@@ -4887,7 +4887,7 @@ GDALAlgorithm::AddLayerCreationOptionsArg(std::vector<std::string> *pValue,
                                           const char *helpMessage)
 {
     auto &arg =
-        AddArg("layer-creation-option", 0,
+        AddArg(GDAL_ARG_NAME_LAYER_CREATION_OPTION, 0,
                MsgOrDefault(helpMessage, _("Layer creation option")), pValue)
             .AddAlias("lco")
             .SetMetaVar("<KEY>=<VALUE>")

--- a/gcore/gdalalgorithm.h
+++ b/gcore/gdalalgorithm.h
@@ -347,6 +347,13 @@ constexpr const char *GDAL_ARG_NAME_APPEND = "append";
 /** Name of the argument for read-only. */
 constexpr const char *GDAL_ARG_NAME_READ_ONLY = "read-only";
 
+/** Name of the argument for number of threads (string). */
+constexpr const char *GDAL_ARG_NAME_NUM_THREADS = "num-threads";
+
+/** Name of the argument for number of threads (integer). */
+constexpr const char *GDAL_ARG_NAME_NUM_THREADS_INT_HIDDEN =
+    "num-threads-int-hidden";
+
 /** Driver must expose GDAL_DCAP_RASTER or GDAL_DCAP_MULTIDIM_RASTER.
  * This is a potential value of GetMetadataItem(GAAMDI_REQUIRED_CAPABILITIES)
  */
@@ -466,6 +473,12 @@ class CPL_DLL GDALArgDatasetValue final
      */
     void SetFrom(const GDALArgDatasetValue &other);
 
+    /** Set that the dataset has been opened by the algorithm */
+    void SetDatasetOpenedByAlgorithm()
+    {
+        m_openedByAlgorithm = true;
+    }
+
     /** Whether the dataset has been opened by the algorithm */
     bool HasDatasetBeenOpenedByAlgorithm() const
     {
@@ -480,12 +493,6 @@ class CPL_DLL GDALArgDatasetValue final
     {
         CPLAssert(!m_ownerArg);
         m_ownerArg = arg;
-    }
-
-    /** Set that the dataset has been opened by the algorithm */
-    void SetDatasetOpenedByAlgorithm()
-    {
-        m_openedByAlgorithm = true;
     }
 
   private:
@@ -1892,7 +1899,7 @@ class CPL_DLL GDALAlgorithmArg /* non-final */
      * May return false if the argument is not explicitly set or if a dataset
      * is passed by value.
      */
-    bool Serialize(std::string &serializedArg) const;
+    bool Serialize(std::string &serializedArg, bool absolutePath = false) const;
 
     //! @cond Doxygen_Suppress
     void NotifyValueSet()
@@ -2709,8 +2716,10 @@ class CPL_DLL GDALAlgorithmRegistry
         return m_calledFromCommandLine;
     }
 
-    /** Save command line in a .gdalg.json file. */
-    static bool SaveGDALG(const std::string &filename,
+    /** Save command line in a .gdalg.json file.
+     * If filename is empty, outString will contain the serialized JSON content.
+     */
+    static bool SaveGDALG(const std::string &filename, std::string &outString,
                           const std::string &commandLine);
 
     //! @cond Doxygen_Suppress

--- a/gcore/gdalalgorithm.h
+++ b/gcore/gdalalgorithm.h
@@ -327,6 +327,9 @@ constexpr const char *GDAL_ARG_NAME_INPUT = "input";
 /** Name of the argument for the input format. */
 constexpr const char *GDAL_ARG_NAME_INPUT_FORMAT = "input-format";
 
+/** Name of the argument for the input layer. */
+constexpr const char *GDAL_ARG_NAME_INPUT_LAYER = "input-layer";
+
 /** Name of the argument for an open option. */
 constexpr const char *GDAL_ARG_NAME_OPEN_OPTION = "open-option";
 
@@ -342,8 +345,15 @@ constexpr const char *GDAL_ARG_NAME_STDOUT = "stdout";
 /** Name of the argument for an output format. */
 constexpr const char *GDAL_ARG_NAME_OUTPUT_FORMAT = "output-format";
 
+/** Name of the argument for the output layer. */
+constexpr const char *GDAL_ARG_NAME_OUTPUT_LAYER = "output-layer";
+
 /** Name of the argument for a creation option. */
 constexpr const char *GDAL_ARG_NAME_CREATION_OPTION = "creation-option";
+
+/** Name of the argument for a layer creation option. */
+constexpr const char *GDAL_ARG_NAME_LAYER_CREATION_OPTION =
+    "layer-creation-option";
 
 /** Name of the argument for update. */
 constexpr const char *GDAL_ARG_NAME_UPDATE = "update";

--- a/port/cpl_spawn.cpp
+++ b/port/cpl_spawn.cpp
@@ -296,16 +296,18 @@ CPLSpawnAsync(CPL_UNUSED int (*pfnMain)(CPL_FILE_HANDLE, CPL_FILE_HANDLE),
     {
         if (i > 0)
             osCommandLine += " ";
-        // We need to quote arguments with spaces in them (if not already done).
-        if (strchr(papszArgv[i], ' ') != nullptr && papszArgv[i][0] != '"')
+        CPLString osArg(papszArgv[i]);
+        // We need to quote arguments with spaces or double quotes in them (if not already done).
+        if (osArg.find_first_of(" \"") != std::string::npos &&
+            !(osArg.size() >= 3 && osArg.front() == '"' && osArg.back() == '"'))
         {
-            osCommandLine += "\"";
-            osCommandLine += papszArgv[i];
-            osCommandLine += "\"";
+            osCommandLine += '"';
+            osCommandLine += osArg.replaceAll('"', "\\\"");
+            osCommandLine += '"';
         }
         else
         {
-            osCommandLine += papszArgv[i];
+            osCommandLine += osArg;
         }
     }
 

--- a/swig/include/Algorithm.i
+++ b/swig/include/Algorithm.i
@@ -398,6 +398,13 @@ public:
   }
 %clear const char *argName;
 
+%apply Pointer NONNULL {const char *argName};
+%newobject GetArgNonConst;
+  GDALAlgorithmArgHS* GetArgNonConst(const char *argName) {
+    return GDALAlgorithmGetArgNonConst(self, argName);
+  }
+%clear const char *argName;
+
 }
 };
 

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -2369,7 +2369,7 @@ def ReleaseResultSet(self, sql_lyr):
   def ReadAsArray(self, field, start=0, length=None):
       """
       Read a single column of a RAT into a NumPy array.
-      
+
       Parameters
       ----------
       field : int
@@ -2377,13 +2377,13 @@ def ReleaseResultSet(self, sql_lyr):
       start : int, default = 0
           The index of the first row to read (starting at 0)
       length : int, default = None
-          The number of rows to read 
-      
-      
+          The number of rows to read
+
+
       Returns
       -------
       np.ndarray
-      
+
       Examples
       --------
       >>> ds = gdal.Open('clc2018_v2020_20u1.tif')
@@ -6447,7 +6447,7 @@ class VSIFile(BytesIO):
            >>> alg["input"] = [one_ds, two_ds]
         """
 
-        arg = self.GetArg(key.replace('_', '-'))
+        arg = self.GetArgNonConst(key.replace('_', '-'))
         if not arg:
             raise RuntimeError(f"'{key}' is not a valid argument of '{self.GetName()}'")
         if not arg.Set(value):


### PR DESCRIPTION
Strongly inspired from [PDAL's "pdal pipeline" substitutions](https://pdal.io/en/stable/apps/pipeline.html#substitutions)

CC @hobu @msmitherdc 

(on top of PR #12927, only last 2 commits are specific to this PR)

Extract from doc:
```rst


It is also possible to use :program:`gdal pipeline` to use a pipeline already
serialized in a .gdal.json file, and customize its existing steps, typically
changing input filename, specifying output filename, or adding/modifying arguments
of steps.

The syntax is:

::

    gdal pipeline <filename.gdalg.json> --<step-name>.<arg-name>=value

When specifying an existing argument of a step of a pipeline, the value from the
pipeline is overridden by the one specified on the :program:`gdal pipeline` command line.

Let's imagine with have a :file:`raster_reproject.gdalg.json` with the following content:

.. code-block:: json

    {
        "type": "gdal_streamed_alg",
        "command_line": "gdal pipeline ! read in.tif ! reproject --dst-crs=EPSG:4326 ! edit --metadata=CHANGES=reprojected"
    }

It is possible to run it with the following command command line, overridden the
``input`` argument of the ``read`` step, and implicitly adding a final ``write``
step with an ``output`` argument.

.. code-block:: bash

    $ gdal pipeline raster_reproject.gdalg.json --read.input=other_input.tif --write.output=out.tif


When there is no ambiguity, it is also possible to omit the step name, and just
specify the argument name (if there is an ambiguity, :program:`gdal pipeline`
will emit an error, so this is safe to do):

.. code-block:: bash

    $ gdal pipeline raster_reproject.gdalg.json --input=other_input.tif --output=out.tif --co COMPRESS=LZW --overwrite


When a step appears several times in the pipeline, it must specified as
``<step-name>[<idx>]``, where ``<idx>`` is a zero-based index.

For example, given:

.. code-block:: json

    {
        "type": "gdal_streamed_alg",
        "command_line": "gdal pipeline ! read in.tif ! edit --metadata=before=value ! reproject --dst-crs=EPSG:4326 ! edit --metadata=CHANGES=reprojected"
    }

the following command line may be used:

.. code-block:: bash

    $ gdal pipeline raster_reproject.gdalg.json --edit[0].metadata=before=modified --output=out.tif

Execution of pipeline and argument substitutions can also be done in Python with:

.. code-block:: python

    gdal.Run("pipeline", pipeline="raster_reproject.gdalg.json", output="out.tif", arguments={"edit[0].metadata": "before=modified"})

```