### PR TITLE
cpl_vsil_abstract_archive.cpp: Cleanup includes.

### DIFF
--- a/port/cpl_vsil_abstract_archive.cpp
+++ b/port/cpl_vsil_abstract_archive.cpp
@@ -13,10 +13,9 @@
 #include "cpl_port.h"
 #include "cpl_vsi_virtual.h"
 
-#include <algorithm>
 #include <cstring>
-#include <fcntl.h>
 #include <ctime>
+#include <fcntl.h>
 #include <map>
 #include <set>
 #include <string>


### PR DESCRIPTION
Remove `algorithm` and sort `ctime` & `fcntl.h`

- https://clang.llvm.org/extra/clang-tidy/checks/llvm/include-order.html
- https://clang.llvm.org/extra/clang-tidy/checks/misc/include-cleaner.html

Ran into these with https://github.com/OSGeo/gdal/commit/e572148ba4a7220649bdb497b1d5ecc38b7196ba

Used clang-tidy like this:

```
/usr/bin/clang-tidy-19 -checks='llvm-include-order' cpl_vsil_abstract_archive.cpp -- -std=c++17 -I. -I../build-ninja/port/
```