### PR TITLE
[Backport release/3.11] GML: takes into account JGD2024 CRS from recent Japan's Fundamental Geospatial Data (FGD)

### DIFF
--- a/autotest/ogr/data/gml_jpfgd/ElevPt_JGD2024.xml
+++ b/autotest/ogr/data/gml_jpfgd/ElevPt_JGD2024.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Dataset xsi:schemaLocation="http://fgd.gsi.go.jp/spec/2008/FGD_GMLSchema FGD_GMLSchema.xsd"
+	xmlns:gml="http://www.opengis.net/gml/3.2"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:xlink="http://www.w3.org/1999/xlink"
+	xmlns="http://fgd.gsi.go.jp/spec/2008/FGD_GMLSchema"
+	gml:id="Dataset1">
+  <gml:description>GMLドライバテスト用データ. FG-GML-523336-ElevPt-20150101-0001.xmlの一部をもとに作成. 基盤地図情報メタデータ ID=fmdid:15-0101</gml:description>
+  <gml:name>基盤地図情報ダウンロードデータ（GML版）</gml:name>
+<ElevPt gml:id="K2_9999999999_1">
+<fid>99999-99999-i-1</fid>
+<lfSpanFr gml:id="K2_9999999999_1-1">
+<gml:timePosition>2013-12-10</gml:timePosition>
+</lfSpanFr>
+<devDate gml:id="K2_9999999999_1-2">
+<gml:timePosition>2015-01-07</gml:timePosition>
+</devDate>
+<orgGILvl>25000</orgGILvl>
+<vis>表示</vis>
+<pos>
+<gml:Point gml:id="K2_9999999999_1-g" srsName="fguuid:jgd2024.bl">
+<gml:pos>34.123456789 133.123456789</gml:pos>
+</gml:Point>
+</pos>
+<type>標高点（測点）</type>
+<alti>123</alti>
+</ElevPt>
+</Dataset>

--- a/autotest/ogr/ogr_gml_fgd_read.py
+++ b/autotest/ogr/ogr_gml_fgd_read.py
@@ -95,3 +95,25 @@ def test_ogr_gml_fgd_2():
     ogrtest.check_feature_geometry(feat, wkt)
 
     assert feat.GetField("devDate") == "2017-03-07", "Wrong attribute value"
+
+
+###############################################################################
+# Test reading Japanese FGD GML (v4) with JGD2024
+
+
+def test_ogr_gml_fgd_jgd2024():
+
+    # open FGD GML file
+    ds = ogr.Open(_fgd_dir + "ElevPt_JGD2024.xml")
+
+    # check number of layers
+    assert ds.GetLayerCount() == 1, "Wrong layer count"
+
+    lyr = ds.GetLayer(0)
+
+    assert lyr.GetSpatialRef().IsGeographic()
+    assert lyr.GetSpatialRef().GetName() == "JGD2024"
+
+    # check the first feature
+    feat = lyr.GetNextFeature()
+    ogrtest.check_feature_geometry(feat, "POINT (133.123456789 34.123456789)")

--- a/ogr/ogrsf_frmts/gml/ogrgmldatasource.cpp
+++ b/ogr/ogrsf_frmts/gml/ogrgmldatasource.cpp
@@ -1301,6 +1301,27 @@ bool OGRGMLDataSource::Open(GDALOpenInfo *poOpenInfo)
         CSLDestroy(papszTypeNames);
     }
 
+    // Japan Fundamental Geospatial Data (FGD)
+    if (strstr(szPtr, "http://fgd.gsi.go.jp/spec/2008/FGD_GMLSchema"))
+    {
+        if (ExtractSRSName(szPtr, szSRSName, sizeof(szSRSName)))
+        {
+            CPLErrorStateBackuper oBackuper(CPLQuietErrorHandler);
+            OGRSpatialReference oSRS;
+            if (oSRS.SetFromUserInput(
+                    szSRSName,
+                    OGRSpatialReference::
+                        SET_FROM_USER_INPUT_LIMITATIONS_get()) == OGRERR_NONE)
+            {
+                bUseGlobalSRSName = true;
+                for (int i = 0; i < poReader->GetClassCount(); ++i)
+                {
+                    poReader->GetClass(i)->SetSRSName(szSRSName);
+                }
+            }
+        }
+    }
+
     // Force a first pass to establish the schema.  Eventually we will have
     // mechanisms for remembering the schema and related information.
     const char *pszForceSRSDetection =

--- a/ogr/ogrsf_frmts/gmlutils/gmlutils.cpp
+++ b/ogr/ogrsf_frmts/gmlutils/gmlutils.cpp
@@ -82,12 +82,6 @@ bool GML_IsSRSLatLongOrder(const char *pszSRSName)
         // Shortcut.
         return true;
     }
-    /* fguuid:jgd20??.bl (Japanese FGD GML v4) */
-    else if (EQUALN(pszSRSName, "fguuid:jgd2011.bl", 17) ||
-             EQUALN(pszSRSName, "fguuid:jgd2001.bl", 17))
-    {
-        return true;
-    }
     else if (!EQUALN(pszSRSName, "EPSG:", 5))
     {
         OGRSpatialReference oSRS;

--- a/ogr/ogrspatialreference.cpp
+++ b/ogr/ogrspatialreference.cpp
@@ -4184,6 +4184,34 @@ OGRErr OGRSpatialReference::SetFromUserInput(const char *pszDefinition,
         return SetFromUserInput("EPSG:25832+7837");
     }
 
+    // Used by  Japan's Fundamental Geospatial Data (FGD) GML
+    if (EQUAL(pszDefinition, "fguuid:jgd2001.bl"))
+        return importFromEPSG(4612);  // JGD2000 (slight difference in years)
+    else if (EQUAL(pszDefinition, "fguuid:jgd2011.bl"))
+        return importFromEPSG(6668);  // JGD2011
+    else if (EQUAL(pszDefinition, "fguuid:jgd2024.bl"))
+    {
+        // FIXME when EPSG attributes a CRS code
+        return importFromWkt(
+            "GEOGCRS[\"JGD2024\",\n"
+            "    DATUM[\"Japanese Geodetic Datum 2024\",\n"
+            "        ELLIPSOID[\"GRS 1980\",6378137,298.257222101,\n"
+            "            LENGTHUNIT[\"metre\",1]]],\n"
+            "    PRIMEM[\"Greenwich\",0,\n"
+            "        ANGLEUNIT[\"degree\",0.0174532925199433]],\n"
+            "    CS[ellipsoidal,2],\n"
+            "        AXIS[\"geodetic latitude (Lat)\",north,\n"
+            "            ORDER[1],\n"
+            "            ANGLEUNIT[\"degree\",0.0174532925199433]],\n"
+            "        AXIS[\"geodetic longitude (Lon)\",east,\n"
+            "            ORDER[2],\n"
+            "            ANGLEUNIT[\"degree\",0.0174532925199433]],\n"
+            "    USAGE[\n"
+            "        SCOPE[\"Horizontal component of 3D system.\"],\n"
+            "        AREA[\"Japan - onshore and offshore.\"],\n"
+            "        BBOX[17.09,122.38,46.05,157.65]]]");
+    }
+
     // Deal with IGNF:xxx, ESRI:xxx, etc from the PROJ database
     const char *pszDot = strrchr(pszDefinition, ':');
     if (pszDot)


### PR DESCRIPTION
Backport #12918
 **Authored by:** @rouault