### PR TITLE
VRT Reclassify: Fix typo in VRT reclassify error message

### DIFF
--- a/frmts/vrt/vrtreclassifier.cpp
+++ b/frmts/vrt/vrtreclassifier.cpp
@@ -58,7 +58,7 @@ CPLErr Reclassifier::Interval::Parse(const char *s, char **rest)
         if (end == start)
         {
             CPLError(CE_Failure, CPLE_AppDefined,
-                     "Interval must start with '(' or ']'");
+                     "Interval must start with '(' or '['");
             return CE_Failure;
         }
 
@@ -139,9 +139,9 @@ CPLErr Reclassifier::Interval::Parse(const char *s, char **rest)
 
     if (dfMin > dfMax)
     {
-        CPLError(
-            CE_Failure, CPLE_AppDefined,
-            "Lower bound of interval must be lower or equal to upper bound");
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "Lower bound of interval must be lower or equal to upper "
+                 "bound");
         return CE_Failure;
     }
 
@@ -227,9 +227,9 @@ CPLErr Reclassifier::Init(const char *pszText,
         {
             if (!noDataValue.has_value())
             {
-                CPLError(
-                    CE_Failure, CPLE_AppDefined,
-                    "Value mapped from NO_DATA, but NoData value is not set");
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Value mapped from NO_DATA, but NoData value is "
+                         "not set");
                 return CE_Failure;
             }
 


### PR DESCRIPTION
## What does this PR do?
Fix a minor typo in the error message for intervals in the raster reclassification code

## What are related issues/pull requests?
N/A - spotted in recent mailing list support query

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
