### PR TITLE
jp2kakdataset.h: Remove JP2KAKDataset::Identify

### DIFF
--- a/frmts/jp2kak/jp2kakdataset.h
+++ b/frmts/jp2kak/jp2kakdataset.h
@@ -94,7 +94,6 @@ class JP2KAKDataset final : public GDALJP2AbstractDataset
 
     static void KakaduInitialize();
     static GDALDataset *Open(GDALOpenInfo *);
-    static int Identify(GDALOpenInfo *);
 };
 
 /************************************************************************/


### PR DESCRIPTION
This static method was removed in 443ad2010bcb4639c324958fc2db16a8ed639341