### PR TITLE
COG: write OVERVIEW_RESAMPLING in IMAGE_STRUCTURE metadata domain, and expose it when present

### DIFF
--- a/frmts/gtiff/cogdriver.cpp
+++ b/frmts/gtiff/cogdriver.cpp
@@ -1150,6 +1150,7 @@ GDALDataset *GDALCOGCreator::Create(const char *pszFilename,
         }
     }
 
+    std::string osOverviewResampling;
     if (bGenerateOvr)
     {
         CPLDebug("COG", "Generating overviews of the imagery: start");
@@ -1157,7 +1158,7 @@ GDALDataset *GDALCOGCreator::Create(const char *pszFilename,
         std::vector<GDALRasterBand *> apoSrcBands;
         for (int i = 0; i < nBands; i++)
             apoSrcBands.push_back(poCurDS->GetRasterBand(i + 1));
-        const char *pszResampling = CSLFetchNameValueDef(
+        osOverviewResampling = CSLFetchNameValueDef(
             papszOptions, "OVERVIEW_RESAMPLING",
             CSLFetchNameValueDef(papszOptions, "RESAMPLING",
                                  GetResampling(poSrcDS)));
@@ -1181,8 +1182,8 @@ GDALDataset *GDALCOGCreator::Create(const char *pszFilename,
         CPLErr eErr = GTIFFBuildOverviewsEx(
             m_osTmpOverviewFilename, nBands, &apoSrcBands[0],
             static_cast<int>(asOverviewDims.size()), nullptr,
-            asOverviewDims.data(), pszResampling, aosOverviewOptions.List(),
-            GDALScaledProgress, pScaledProgress);
+            asOverviewDims.data(), osOverviewResampling.c_str(),
+            aosOverviewOptions.List(), GDALScaledProgress, pScaledProgress);
         CPLDebug("COG", "Generating overviews of the imagery: end");
 
         GDALDestroyScaledProgress(pScaledProgress);
@@ -1190,6 +1191,14 @@ GDALDataset *GDALCOGCreator::Create(const char *pszFilename,
         {
             return nullptr;
         }
+    }
+    else if (poSrcDS->GetRasterBand(1)->GetOverviewCount() > 0)
+    {
+        const char *pszResampling =
+            poSrcDS->GetRasterBand(1)->GetOverview(0)->GetMetadataItem(
+                "RESAMPLING");
+        if (pszResampling)
+            osOverviewResampling = pszResampling;
     }
 
     CPLStringList aosOptions;
@@ -1271,6 +1280,11 @@ GDALDataset *GDALCOGCreator::Create(const char *pszFilename,
     }
     else
     {
+        if (!osOverviewResampling.empty())
+        {
+            aosOptions.SetNameValue("@OVERVIEW_RESAMPLING",
+                                    osOverviewResampling.c_str());
+        }
         if (!m_osTmpOverviewFilename.empty())
         {
             aosOptions.SetNameValue("@OVERVIEW_DATASET",

--- a/frmts/gtiff/gtiffdataset.cpp
+++ b/frmts/gtiff/gtiffdataset.cpp
@@ -1170,6 +1170,24 @@ void GTiffDataset::ScanDirectories()
                     // poODS->m_nZLevel = m_nZLevel;
                     // poODS->m_nLZMAPreset = m_nLZMAPreset;
                     // poODS->m_nZSTDLevel = m_nZSTDLevel;
+
+                    if (const char *pszOverviewResampling =
+                            m_oGTiffMDMD.GetMetadataItem("OVERVIEW_RESAMPLING",
+                                                         "IMAGE_STRUCTURE"))
+                    {
+                        for (int iBand = 1; iBand <= poODS->GetRasterCount();
+                             ++iBand)
+                        {
+                            auto poOBand = cpl::down_cast<GTiffRasterBand *>(
+                                poODS->GetRasterBand(iBand));
+                            if (poOBand->GetMetadataItem("RESAMPLING") ==
+                                nullptr)
+                            {
+                                poOBand->m_oGTiffMDMD.SetMetadataItem(
+                                    "RESAMPLING", pszOverviewResampling);
+                            }
+                        }
+                    }
                 }
             }
             // Embedded mask of the main image.

--- a/frmts/gtiff/gtiffdataset_read.cpp
+++ b/frmts/gtiff/gtiffdataset_read.cpp
@@ -5464,7 +5464,12 @@ CPLErr GTiffDataset::OpenOffset(TIFF *hTIFFIn, toff_t nDirOffsetIn,
                 continue;
             if (EQUAL(pszDomain, "IMAGE_STRUCTURE"))
             {
-                if (EQUAL(pszKey, "INTERLEAVE"))
+                if (EQUAL(pszKey, "OVERVIEW_RESAMPLING"))
+                {
+                    m_oGTiffMDMD.SetMetadataItem(pszKey, pszValue,
+                                                 "IMAGE_STRUCTURE");
+                }
+                else if (EQUAL(pszKey, "INTERLEAVE"))
                 {
                     if (EQUAL(pszValue, "TILE"))
                     {

--- a/frmts/gtiff/gtiffdataset_write.cpp
+++ b/frmts/gtiff/gtiffdataset_write.cpp
@@ -4538,6 +4538,14 @@ bool GTiffDataset::WriteMetadata(GDALDataset *poSrcDS, TIFF *l_hTIFF,
         }
     }
 
+    if (const char *pszOverviewResampling =
+            CSLFetchNameValue(papszCreationOptions, "@OVERVIEW_RESAMPLING"))
+    {
+        AppendMetadataItem(&psRoot, &psTail, "OVERVIEW_RESAMPLING",
+                           pszOverviewResampling, 0, nullptr,
+                           "IMAGE_STRUCTURE");
+    }
+
     /* -------------------------------------------------------------------- */
     /*      Write information about some codecs.                            */
     /* -------------------------------------------------------------------- */


### PR DESCRIPTION
Fixes #13014

```
$ gdal_translate byte.tif cog.tif -outsize 1024 0 -of COG -co OVERVIEW_RESAMPLING=AVERAGE

$ gdalinfo cog.tif
[...]
Image Structure Metadata:
  LAYOUT=COG
  COMPRESSION=LZW
  INTERLEAVE=BAND
  OVERVIEW_RESAMPLING=AVERAGE
[...]

$ exiftool -j cog.tif | jq '.[0].GDALMetadata'
"<GDALMetadata>\n  <Item name=\"OVERVIEW_RESAMPLING\" domain=\"IMAGE_STRUCTURE\">AVERAGE</Item>\n</GDALMetadata>\n"
```
