### PR TITLE
[Backport release/3.11] InitializeDestinationBuffer(): do not return CE_Failure when emitting…

### DIFF
--- a/alg/gdalwarpoperation.cpp
+++ b/alg/gdalwarpoperation.cpp
@@ -801,19 +801,20 @@ CPLErr GDALWarpOperation::InitializeDestinationBuffer(void *pDstBuffer,
         {
             if (psOptions->padfDstNoDataReal == nullptr)
             {
-                // TODO: Change to CE_Failure for GDAL 3.12
+                // TODO: Change to CE_Failure and error out for GDAL 3.13
                 // See https://github.com/OSGeo/gdal/pull/12189
                 CPLError(CE_Warning, CPLE_AppDefined,
                          "INIT_DEST was set to NO_DATA, but a NoData value was "
                          "not defined. This warning will become a failure in a "
                          "future GDAL release.");
-                return CE_Failure;
             }
-
-            adfInitRealImag[0] = psOptions->padfDstNoDataReal[iBand];
-            if (psOptions->padfDstNoDataImag != nullptr)
+            else
             {
-                adfInitRealImag[1] = psOptions->padfDstNoDataImag[iBand];
+                adfInitRealImag[0] = psOptions->padfDstNoDataReal[iBand];
+                if (psOptions->padfDstNoDataImag != nullptr)
+                {
+                    adfInitRealImag[1] = psOptions->padfDstNoDataImag[iBand];
+                }
             }
         }
         else


### PR DESCRIPTION
Backport #13028
 **Authored by:** @rouault