### PR TITLE
CMake: Avoid Permission Denied errors on Windows SWIG builds

### DIFF
--- a/swig/python/modify_cpp_files.cmake
+++ b/swig/python/modify_cpp_files.cmake
@@ -69,4 +69,13 @@ string(REPLACE "# define SWIG_HEAPTYPES" "// Below is disabled because of https:
 string(REPLACE "#define SWIG_HEAPTYPES" "// Below is disabled because of https://github.com/swig/swig/issues/3061\n// # define SWIG_HEAPTYPES"
        _CONTENTS "${_CONTENTS}")
 
-file(WRITE ${FILE} "${_CONTENTS}")
+set(_TMP "${FILE}.tmp")
+
+# Write to a temporary file first (avoids "Permission denied" on Windows)
+file(WRITE ${_TMP} "${_CONTENTS}")
+
+# Remove the original file before rename
+file(REMOVE ${FILE})
+
+# Rename temp file back to the original name
+file(RENAME ${_TMP} ${FILE})


### PR DESCRIPTION
## What does this PR do?

Instead of replacing SWIG generated file content directly in the file, it writes the replaced content to a temp file, and then renames this back to the original file. This resolves an issue when building on Windows where "Permission denied" errors were raised, presumably due to reading and writing the same file at the same time:

```
  CMake Error at C:/docs/gdal/swig/python/modify_cpp_files.cmake:72 (file):
    file failed to open for writing (Permission denied):
```

## What are related issues/pull requests?

#13033

## Tasklist

 - [X] AI (Copilot or something similar) supported my development of this PR

ChatGPT was used to help with the REMOVE/RENAME CMake syntax.  

## Environment

- Windows 11
- conda 24.3.0
- Python 3.13.2
- gdal master (5/9/25)

