### PR TITLE
/vsis3/ (and /vsigs/, /vsiaz/, etc.): by default squash '/./' and '/../' sequences in path, unless the GDAL_HTTP_PATH_VERBATIM config option is set

### DIFF
--- a/autotest/gcore/vsis3.py
+++ b/autotest/gcore/vsis3.py
@@ -6588,6 +6588,48 @@ def test_vsis3_AWS_S3SESSION_TOKEN(aws_test_config, webserver_port):
 
 
 ###############################################################################
+# Test PATH_VERBATIM
+
+
+def test_vsis3_PATH_VERBATIM(aws_test_config, webserver_port):
+
+    gdal.VSICurlClearCache()
+
+    handler = webserver.SequentialHandler()
+    handler.add(
+        "GET", "/test_vsis3_PATH_VERBATIM/test.bin", 200, {"Connection": "close"}, "a"
+    )
+    with webserver.install_http_handler(handler):
+        assert gdal.VSIStatL("/vsis3/test_vsis3_PATH_VERBATIM/./test.bin").size == 1
+
+    handler = webserver.SequentialHandler()
+    handler.add(
+        "GET", "/test_vsis3_PATH_VERBATIM/test2.bin", 200, {"Connection": "close"}, "ab"
+    )
+    with webserver.install_http_handler(handler):
+        assert (
+            gdal.VSIStatL(
+                "/vsis3/test_vsis3_PATH_VERBATIM/a/b/../../c/../test2.bin"
+            ).size
+            == 2
+        )
+
+    with gdal.config_option("GDAL_HTTP_PATH_VERBATIM", "YES"):
+        handler = webserver.SequentialHandler()
+        handler.add(
+            "GET",
+            "/test_vsis3_PATH_VERBATIM/./test3.bin",
+            200,
+            {"Connection": "close"},
+            "abc",
+        )
+        with webserver.install_http_handler(handler):
+            assert (
+                gdal.VSIStatL("/vsis3/test_vsis3_PATH_VERBATIM/./test3.bin").size == 3
+            )
+
+
+###############################################################################
 # Nominal cases (require valid credentials)
 
 

--- a/doc/source/user/configoptions.rst
+++ b/doc/source/user/configoptions.rst
@@ -709,6 +709,15 @@ Networking options
       no longer cached. This can help when dealing with resources that can be
       modified during execution of GDAL-related code.
 
+-  .. config:: GDAL_HTTP_PATH_VERBATIM
+      :choices: YES, NO
+      :default: NO
+      :since: 3.12
+
+      When set to YES, sequences of ``/../`` or ``/./`` that may exist in the
+      URL's path part are kept unchanged. Otherwise, by default, they are squashed,
+      according to RFC 3986 section 5.2.4.
+
 -  .. config:: GDAL_HTTP_HEADER_FILE
       :choices: <filename>
       :since: 2.3

--- a/doc/source/user/virtual_file_systems.rst
+++ b/doc/source/user/virtual_file_systems.rst
@@ -457,6 +457,8 @@ Starting with GDAL 2.3, the :config:`CPL_VSIL_CURL_NON_CACHED` configuration opt
 
 Starting with GDAL 2.1, ``/vsicurl/`` will try to query directly redirected URLs to Amazon S3 signed URLs during their validity period, so as to minimize round-trips. This behavior can be disabled by setting the configuration option :config:`CPL_VSIL_CURL_USE_S3_REDIRECT` to ``NO``.
 
+Starting with GDAL 3.12,  the :config:`GDAL_HTTP_PATH_VERBATIM` configuration option can be set to ``YES`` so that sequences of ``/../`` or ``/./`` that may exist in the URL's path part are kept unchanged. Otherwise, by default, they are squashed, according to RFC 3986 section 5.2.4.
+
 :cpp:func:`VSIStatL` will return the size in st_size member and file nature- file or directory - in st_mode member (the later only reliable with FTP resources for now).
 
 :cpp:func:`VSIReadDir` should be able to parse the HTML directory listing returned by the most popular web servers, such as Apache and Microsoft IIS.

--- a/port/cpl_http.cpp
+++ b/port/cpl_http.cpp
@@ -533,6 +533,7 @@ constexpr TupleEnvVarOptionName asAssocEnvVarOptionName[] = {
     {"GDAL_HTTP_TCP_KEEPALIVE", "TCP_KEEPALIVE"},
     {"GDAL_HTTP_TCP_KEEPIDLE", "TCP_KEEPIDLE"},
     {"GDAL_HTTP_TCP_KEEPINTVL", "TCP_KEEPINTVL"},
+    {"GDAL_HTTP_PATH_VERBATIM", "PATH_VERBATIM"},
 };
 
 char **CPLHTTPGetOptionsFromEnv(const char *pszFilename)
@@ -1223,6 +1224,12 @@ int CPLHTTPPopFetchCallback(void)
  * <li>KEYPASSWD=string (GDAL >= 3.7): Passphrase to private key.
  * Cf https://curl.se/libcurl/c/CURLOPT_KEYPASSWD.html.
  * Corresponding configuration option: GDAL_HTTP_KEYPASSWD.
+ * <li>PATH_VERBATIM=[YES/NO] Can be set to YES so that sequences of "/../" or "/./"
+ * that may exist in the URL's path part are kept as it. Otherwise, by default,
+ * they are squashed, according to RFC 3986 section 5.2.4
+ * Cf https://curl.se/libcurl/c/CURLOPT_PATH_AS_IS.html
+ * Corresponding configuration option: GDAL_HTTP_PATH_VERBATIM.
+ * </li>
  * </ul>
  *
  * If an option is specified through papszOptions and as a configuration option,
@@ -2132,6 +2139,14 @@ void *CPLHTTPSetOptions(void *pcurl, const char *pszURL,
             unchecked_curl_easy_setopt(http_handle, CURLOPT_DEBUGFUNCTION,
                                        CPLHTTPCurlDebugFunction);
         }
+    }
+
+    const char *pszPathAsIt = CSLFetchNameValue(papszOptions, "PATH_VERBATIM");
+    if (pszPathAsIt == nullptr)
+        pszPathAsIt = CPLGetConfigOption("GDAL_HTTP_PATH_VERBATIM", nullptr);
+    if (pszPathAsIt && CPLTestBool(pszPathAsIt))
+    {
+        unchecked_curl_easy_setopt(http_handle, CURLOPT_PATH_AS_IS, 1L);
     }
 
     const char *pszHttpVersion =

--- a/port/cpl_known_config_options.h
+++ b/port/cpl_known_config_options.h
@@ -303,6 +303,7 @@ constexpr static const char* const apszKnownConfigOptions[] =
    "GDAL_HTTP_MULTIRANGE", // from cpl_vsil_curl.cpp
    "GDAL_HTTP_NETRC", // from cpl_http.cpp
    "GDAL_HTTP_NETRC_FILE", // from cpl_http.cpp
+   "GDAL_HTTP_PATH_VERBATIM", // from cpl_http.cpp, cpl_vsil_s3.cpp
    "GDAL_HTTP_PROXY", // from cpl_http.cpp
    "GDAL_HTTP_PROXYUSERPWD", // from cpl_http.cpp
    "GDAL_HTTP_RETRY_CODES", // from cpl_http.cpp


### PR DESCRIPTION
Fixes #13040
