### PR TITLE
[Backport release/3.11] SWIG: Guard against null input to SuggestedWarpOutput

### DIFF
--- a/autotest/alg/warp.py
+++ b/autotest/alg/warp.py
@@ -1292,6 +1292,11 @@ def test_warp_41():
         assert src_gt[i] == pytest.approx(vrt_gt[i], abs=1e-5)
 
 
+def test_warp_suggestedwarp_output_invalid_input():
+    with pytest.raises(ValueError):
+        gdal.SuggestedWarpOutput(None, {"DST_SRS": "EPSG:4326"})
+
+
 ###############################################################################
 
 # Maximum

--- a/autotest/alg/warp.py
+++ b/autotest/alg/warp.py
@@ -1293,7 +1293,7 @@ def test_warp_41():
 
 
 def test_warp_suggestedwarp_output_invalid_input():
-    with pytest.raises(ValueError):
+    with pytest.raises(Exception):
         gdal.SuggestedWarpOutput(None, {"DST_SRS": "EPSG:4326"})
 
 

--- a/swig/include/Operations.i
+++ b/swig/include/Operations.i
@@ -909,6 +909,7 @@ struct SuggestedWarpOutputRes
 #else
 %newobject SuggestedWarpOutput;
 #endif
+%apply Pointer NONNULL {GDALDatasetShadow *src};
 %inline %{
 #ifdef SWIGPYTHON
   SuggestedWarpOutputRes* SuggestedWarpOutputFromOptions( GDALDatasetShadow *src,
@@ -937,6 +938,7 @@ struct SuggestedWarpOutputRes
     return res;
   }
 %}
+%clear GDALDatasetShadow *src;
 
 #ifdef SWIGPYTHON
 


### PR DESCRIPTION
Backport #13052
 **Authored by:** @dbaston