### PR TITLE
MiraMonVector: deactivating NO_CXX_WFLAGS_EFFCXX and NO_WFLAG_OLD_STYLE

### DIFF
--- a/ogr/ogrsf_frmts/miramon/CMakeLists.txt
+++ b/ogr/ogrsf_frmts/miramon/CMakeLists.txt
@@ -3,8 +3,6 @@ add_gdal_driver(
   SOURCES ogrmiramondatasource.cpp ogrmiramondriver.cpp ogrmiramonlayer.cpp mm_wrlayr.c mm_rdlayr.c
   PLUGIN_CAPABLE 
   NO_DEPS
-  NO_CXX_WFLAGS_EFFCXX
-  NO_WFLAG_OLD_STYLE_CAST
 )
 gdal_standard_includes(ogr_MiraMon)
 target_include_directories(ogr_MiraMon PRIVATE $<TARGET_PROPERTY:ogrsf_generic,SOURCE_DIR>)

--- a/ogr/ogrsf_frmts/miramon/ogrmiramon.h
+++ b/ogr/ogrsf_frmts/miramon/ogrmiramon.h
@@ -25,6 +25,9 @@ class OGRMiraMonLayer final
     : public OGRLayer,
       public OGRGetNextFeatureThroughRaw<OGRMiraMonLayer>
 {
+    OGRMiraMonLayer(const OGRMiraMonLayer &) = delete;
+    OGRMiraMonLayer &operator=(const OGRMiraMonLayer &) = delete;
+
     GDALDataset *m_poDS;
     OGRSpatialReference *m_poSRS;
     OGRFeatureDefn *m_poFeatureDefn;
@@ -51,8 +54,8 @@ class OGRMiraMonLayer final
     VSILFILE *m_fp = nullptr;
 
     // Array of doubles used in the field features processing
-    double *padfValues;
-    GInt64 *pnInt64Values;
+    double *padfValues = nullptr;
+    GInt64 *pnInt64Values = nullptr;
 
     OGRFeature *GetNextRawFeature();
     OGRFeature *GetFeature(GIntBig nFeatureId) override;
@@ -111,13 +114,16 @@ class OGRMiraMonLayer final
 
 class OGRMiraMonDataSource final : public GDALDataset
 {
-    std::vector<std::unique_ptr<OGRMiraMonLayer>> m_apoLayers;
+    std::vector<std::unique_ptr<OGRMiraMonLayer>> m_apoLayers = {};
     std::string m_osRootName{};
     bool m_bUpdate = false;
-    struct MiraMonVectMapInfo m_MMMap;
+    struct MiraMonVectMapInfo m_MMMap = {};
 
   public:
     OGRMiraMonDataSource();
+    OGRMiraMonDataSource(const OGRMiraMonDataSource &) = delete;
+    OGRMiraMonDataSource &operator=(const OGRMiraMonDataSource &) = delete;
+
     ~OGRMiraMonDataSource() override;
 
     bool Open(const char *pszFilename, VSILFILE *fp,


### PR DESCRIPTION
## What does this PR do?
This change addresses a task that had been pending for some time. I have now deactivated the NO_CXX_WFLAGS_EFFCXX and NO_WFLAG_OLD_STYLE_CAST flags, enabling the corresponding C++ warnings to improve code quality and adherence to best practices in MiraMonVector driver.

## What are related issues/pull requests?
https://github.com/OSGeo/gdal/pull/12563

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Review
 - [x] All CI builds and checks have passed
