### PR TITLE
MapInfo .tab: fix support of px vs pt for pen width, including fractional point width

### DIFF
--- a/autotest/ogr/ogr_mitab.py
+++ b/autotest/ogr/ogr_mitab.py
@@ -2210,11 +2210,11 @@ def test_ogr_mitab_style(tmp_vsimem):
     lyr.CreateFeature(f)
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometryDirectly(ogr.CreateGeometryFromWkt("POLYGON((0 0,0 1,1 1,0 0))"))
-    f.SetStyleString('BRUSH(fc:#AABBCC,id:"mapinfo-brush-1")')
+    f.SetStyleString('BRUSH(fc:#AABBCC,id:"mapinfo-brush-1");PEN(w:2px)')
     lyr.CreateFeature(f)
     f = ogr.Feature(lyr.GetLayerDefn())
     f.SetGeometryDirectly(ogr.CreateGeometryFromWkt("POLYGON((0 0,0 1,1 1,0 0))"))
-    f.SetStyleString("BRUSH(fc:#AABBCC00,bc:#ddeeff00)")
+    f.SetStyleString("BRUSH(fc:#AABBCC00,bc:#ddeeff00);PEN(w:2.5pt)")
     lyr.CreateFeature(f)
     ds = None
 
@@ -2230,14 +2230,14 @@ def test_ogr_mitab_style(tmp_vsimem):
     f = lyr.GetNextFeature()
     if (
         f.GetStyleString()
-        != 'BRUSH(fc:#aabbcc,id:"mapinfo-brush-1,ogr-brush-1");PEN(w:1px,c:#000000,id:"mapinfo-pen-2,ogr-pen-0",cap:r,j:r)'
+        != 'BRUSH(fc:#aabbcc,id:"mapinfo-brush-1,ogr-brush-1");PEN(w:2px,c:#000000,id:"mapinfo-pen-2,ogr-pen-0",cap:r,j:r)'
     ):
         f.DumpReadable()
         pytest.fail()
     f = lyr.GetNextFeature()
     if (
         f.GetStyleString()
-        != 'BRUSH(fc:#aabbcc,id:"mapinfo-brush-1,ogr-brush-1");PEN(w:1px,c:#000000,id:"mapinfo-pen-2,ogr-pen-0",cap:r,j:r)'
+        != 'BRUSH(fc:#aabbcc,id:"mapinfo-brush-1,ogr-brush-1");PEN(w:2.5pt,c:#000000,id:"mapinfo-pen-2,ogr-pen-0",cap:r,j:r)'
     ):
         f.DumpReadable()
         pytest.fail()

--- a/ogr/ogr_featurestyle.h
+++ b/ogr/ogr_featurestyle.h
@@ -244,6 +244,10 @@ class CPL_DLL OGRStyleTool
     double GetParamDbl(const OGRStyleParamId &sStyleParam,
                        const OGRStyleValue &sStyleValue, GBool &bValueIsNull);
 
+    double GetRawParamDbl(const OGRStyleParamId &sStyleParam,
+                          const OGRStyleValue &sStyleValue,
+                          OGRSTUnitId &eRawUnit, GBool &bValueIsNull);
+
     void SetParamStr(const OGRStyleParamId &sStyleParam,
                      OGRStyleValue &sStyleValue, const char *pszParamString);
 
@@ -293,6 +297,11 @@ class CPL_DLL OGRStylePen : public OGRStyleTool
     double Width(GBool &bDefault)
     {
         return GetParamDbl(OGRSTPenWidth, bDefault);
+    }
+
+    double RawWidth(OGRSTUnitId &eRawUnit, GBool &bDefault)
+    {
+        return GetRawParamDbl(OGRSTPenWidth, eRawUnit, bDefault);
     }
 
     void SetWidth(double dfWidth)
@@ -365,6 +374,8 @@ class CPL_DLL OGRStylePen : public OGRStyleTool
     const char *GetParamStr(OGRSTPenParam eParam, GBool &bValueIsNull);
     int GetParamNum(OGRSTPenParam eParam, GBool &bValueIsNull);
     double GetParamDbl(OGRSTPenParam eParam, GBool &bValueIsNull);
+    double GetRawParamDbl(OGRSTPenParam eParam, OGRSTUnitId &eRawUnit,
+                          GBool &bValueIsNull);
     void SetParamStr(OGRSTPenParam eParam, const char *pszParamString);
     void SetParamNum(OGRSTPenParam eParam, int nParam);
     void SetParamDbl(OGRSTPenParam eParam, double dfParam);

--- a/ogr/ogrfeaturestyle.cpp
+++ b/ogr/ogrfeaturestyle.cpp
@@ -2116,6 +2116,46 @@ double OGRStyleTool::GetParamDbl(const OGRStyleParamId &sStyleParam,
 }
 
 /****************************************************************************/
+/*                           GetRawParamDbl()                               */
+/****************************************************************************/
+
+/** Return the raw value of a parameter of type double.
+ *
+ * @param sStyleParam Identifier of the parameter.
+ * @param sStyleValue Value of the parameter.
+ * @param[out] eRawUnit Raw unit
+ * @param[out] bValueIsNull if the value is null
+ * @return the raw value.
+ */
+double OGRStyleTool::GetRawParamDbl(const OGRStyleParamId &sStyleParam,
+                                    const OGRStyleValue &sStyleValue,
+                                    OGRSTUnitId &eRawUnit, GBool &bValueIsNull)
+{
+    eRawUnit = OGRSTUGround;
+    if (!Parse())
+    {
+        bValueIsNull = TRUE;
+        return 0.0;
+    }
+
+    bValueIsNull = !sStyleValue.bValid;
+
+    if (bValueIsNull == TRUE)
+        return 0.0;
+
+    switch (sStyleParam.eType)
+    {
+        case OGRSTypeDouble:
+            eRawUnit = sStyleValue.eUnit;
+            return sStyleValue.dfValue;
+
+        default:
+            bValueIsNull = TRUE;
+            return 0.0;
+    }
+}
+
+/****************************************************************************/
 /*      void OGRStyleTool::SetParamStr(OGRStyleParamId &sStyleParam ,       */
 /*                             OGRStyleValue &sStyleValue,                  */
 /*                             const char *pszParamString)                  */
@@ -2678,6 +2718,16 @@ double OGRStylePen::GetParamDbl(OGRSTPenParam eParam, GBool &bValueIsNull)
 {
     return OGRStyleTool::GetParamDbl(asStylePen[eParam],
                                      m_pasStyleValue[eParam], bValueIsNull);
+}
+
+/************************************************************************/
+/*                           GetRawParamDbl()                           */
+/************************************************************************/
+double OGRStylePen::GetRawParamDbl(OGRSTPenParam eParam, OGRSTUnitId &eRawUnit,
+                                   GBool &bValueIsNull)
+{
+    return OGRStyleTool::GetRawParamDbl(
+        asStylePen[eParam], m_pasStyleValue[eParam], eRawUnit, bValueIsNull);
 }
 
 /************************************************************************/


### PR DESCRIPTION
Fixes #13064
