### PR TITLE
WMTS: Speedup Curl downloads by reusing handles

### DIFF
--- a/frmts/wms/gdalhttp.cpp
+++ b/frmts/wms/gdalhttp.cpp
@@ -15,6 +15,7 @@
 
 #include "wmsdriver.h"
 #include <algorithm>
+#include <vector>
 
 static size_t WriteFunc(void *buffer, size_t count, size_t nmemb, void *req)
 {
@@ -53,8 +54,7 @@ static size_t WriteFunc(void *buffer, size_t count, size_t nmemb, void *req)
 }
 
 // Process curl errors
-static void ProcessCurlErrors(CURLMsg *msg, WMSHTTPRequest *pasRequest,
-                              int nRequestCount)
+static void ProcessCurlErrors(CURLMsg *msg, WMSHTTPRequest *psRequest)
 {
     CPLAssert(msg != nullptr);
     CPLAssert(msg->msg == CURLMSG_DONE);
@@ -62,39 +62,24 @@ static void ProcessCurlErrors(CURLMsg *msg, WMSHTTPRequest *pasRequest,
     // in case of local file error: update status code
     if (msg->data.result == CURLE_FILE_COULDNT_READ_FILE)
     {
-        // identify current request
-        for (int current_req_i = 0; current_req_i < nRequestCount;
-             ++current_req_i)
+        // sanity check for local files
+        if (STARTS_WITH(psRequest->URL.c_str(), "file://"))
         {
-            WMSHTTPRequest *const psRequest = &pasRequest[current_req_i];
-            if (psRequest->m_curl_handle != msg->easy_handle)
-                continue;
-
-            // sanity check for local files
-            if (STARTS_WITH(psRequest->URL.c_str(), "file://"))
-            {
-                psRequest->nStatus = 404;
-                break;
-            }
+            psRequest->nStatus = 404;
         }
     }
 }
 
 // Builds a curl request
-void WMSHTTPInitializeRequest(WMSHTTPRequest *psRequest)
+static void WMSHTTPInitializeRequest(WMSHTTPRequest *psRequest, CURL *curl)
 {
     psRequest->nStatus = 0;
     psRequest->pabyData = nullptr;
     psRequest->nDataLen = 0;
     psRequest->nDataAlloc = 0;
+    psRequest->retry = 3;
 
-    psRequest->m_curl_handle = curl_easy_init();
-    if (psRequest->m_curl_handle == nullptr)
-    {
-        CPLError(CE_Failure, CPLE_AppDefined,
-                 "CPLHTTPInitializeRequest(): Unable to create CURL handle.");
-        return;
-    }
+    psRequest->m_curl_handle = curl;
 
     if (!psRequest->Range.empty())
     {
@@ -115,22 +100,70 @@ void WMSHTTPInitializeRequest(WMSHTTPRequest *psRequest)
     psRequest->m_headers = static_cast<struct curl_slist *>(CPLHTTPSetOptions(
         psRequest->m_curl_handle, psRequest->URL.URLEncode().c_str(),
         psRequest->options));
-    if (psRequest->m_headers != nullptr)
-    {
-        CPL_IGNORE_RET_VAL(curl_easy_setopt(psRequest->m_curl_handle,
-                                            CURLOPT_HTTPHEADER,
-                                            psRequest->m_headers));
-    }
+    CPL_IGNORE_RET_VAL(curl_easy_setopt(
+        psRequest->m_curl_handle, CURLOPT_HTTPHEADER, psRequest->m_headers));
+    curl_easy_setopt(curl, CURLOPT_PRIVATE, psRequest);
 }
 
 WMSHTTPRequest::~WMSHTTPRequest()
 {
-    if (m_curl_handle != nullptr)
-        curl_easy_cleanup(m_curl_handle);
     if (m_headers != nullptr)
         curl_slist_free_all(m_headers);
     if (pabyData != nullptr)
         CPLFree(pabyData);
+}
+
+static CURL *new_curl_handle(void)
+{
+    CURL *curl = curl_easy_init();
+    if (curl == nullptr)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined,
+                 "CPLHTTPInitializeRequest(): Unable to create CURL handle.");
+        return curl;
+    }
+    curl_easy_setopt(curl, CURLOPT_BUFFERSIZE, CURL_MAX_READ_SIZE);
+    return curl;
+}
+
+static void process(WMSHTTPRequest *psRequest)
+{
+    long response_code;
+    curl_easy_getinfo(psRequest->m_curl_handle, CURLINFO_RESPONSE_CODE,
+                      &response_code);
+    // for local files, don't update the status code if one is already set
+    if (!(psRequest->nStatus != 0 &&
+          STARTS_WITH(psRequest->URL.c_str(), "file://")))
+        psRequest->nStatus = static_cast<int>(response_code);
+
+    char *content_type = nullptr;
+    curl_easy_getinfo(psRequest->m_curl_handle, CURLINFO_CONTENT_TYPE,
+                      &content_type);
+    psRequest->ContentType = content_type ? content_type : "";
+
+    if (psRequest->Error.empty())
+        psRequest->Error = &psRequest->m_curl_error[0];
+
+    /* In the case of a file:// URL, curl will return a status == 0, so if
+        * there's no */
+    /* error returned, patch the status code to be 200, as it would be for
+        * http:// */
+    if (psRequest->nStatus == 0 && psRequest->Error.empty() &&
+        STARTS_WITH(psRequest->URL.c_str(), "file://"))
+        psRequest->nStatus = 200;
+
+    // If there is an error with no error message, use the content if it is
+    // text
+    if (psRequest->Error.empty() && psRequest->nStatus != 0 &&
+        psRequest->nStatus != 200 && strstr(psRequest->ContentType, "text") &&
+        psRequest->pabyData != nullptr)
+        psRequest->Error = reinterpret_cast<const char *>(psRequest->pabyData);
+
+    CPLDebug("HTTP", "Request %s : status = %d, type = %s, error = %s",
+             psRequest->URL.c_str(), psRequest->nStatus,
+             !psRequest->ContentType.empty() ? psRequest->ContentType.c_str()
+                                             : "(null)",
+             !psRequest->Error.empty() ? psRequest->Error.c_str() : "(null)");
 }
 
 //
@@ -142,7 +175,8 @@ CPLErr WMSHTTPFetchMulti(WMSHTTPRequest *pasRequest, int nRequestCount)
     CPLErr ret = CE_None;
     CURLM *curl_multi = nullptr;
     int max_conn;
-    int i, conn_i;
+    int conn_i;
+    std::vector<CURL *> handles;
 
     CPLAssert(nRequestCount >= 0);
     if (nRequestCount == 0)
@@ -159,7 +193,7 @@ CPLErr WMSHTTPFetchMulti(WMSHTTPRequest *pasRequest, int nRequestCount)
         /* Disabled by default for potential security issues */
         CPLTestBool(CPLGetConfigOption("CPL_CURL_ENABLE_VSIMEM", "FALSE")))
     {
-        for (i = 0; i < nRequestCount; i++)
+        for (int i = 0; i < nRequestCount; i++)
         {
             CPLHTTPResult *psResult =
                 CPLHTTPFetch(pasRequest[i].URL.c_str(),
@@ -191,11 +225,31 @@ CPLErr WMSHTTPFetchMulti(WMSHTTPRequest *pasRequest, int nRequestCount)
                  "CPLHTTPFetchMulti(): Unable to create CURL multi-handle.");
     }
 
+    curl_multi_setopt(curl_multi, CURLMOPT_MAX_HOST_CONNECTIONS,
+                      static_cast<long>(max_conn));
+    curl_multi_setopt(curl_multi, CURLMOPT_MAXCONNECTS,
+                      static_cast<long>(max_conn));
+    curl_multi_setopt(curl_multi, CURLMOPT_MAX_TOTAL_CONNECTIONS,
+                      static_cast<long>(max_conn));
+
     // add at most max_conn requests
     int torun = std::min(nRequestCount, max_conn);
+    handles.reserve(torun);
+    for (int i = 0; i < torun; i++)
+    {
+        CURL *curl = new_curl_handle();
+        if (!curl)
+        {
+            CPLError(CE_Fatal, CPLE_AppDefined,
+                     "CPLHTTPFetchMulti(): Unable to create CURL handle.");
+        }
+        handles.push_back(curl);
+    }
+
     for (conn_i = 0; conn_i < torun; ++conn_i)
     {
         WMSHTTPRequest *const psRequest = &pasRequest[conn_i];
+        WMSHTTPInitializeRequest(psRequest, handles[conn_i]);
         CPLDebug("HTTP", "Requesting [%d/%d] %s", conn_i + 1, nRequestCount,
                  pasRequest[conn_i].URL.c_str());
         curl_multi_add_handle(curl_multi, psRequest->m_curl_handle);
@@ -206,24 +260,61 @@ CPLErr WMSHTTPFetchMulti(WMSHTTPRequest *pasRequest, int nRequestCount)
     do
     {
         CURLMcode mc;
-        do
+        mc = curl_multi_perform(curl_multi, &still_running);
+        if (mc != CURLM_OK)
         {
-            mc = curl_multi_perform(curl_multi, &still_running);
-        } while (CURLM_CALL_MULTI_PERFORM == mc);
+            CPLError(CE_Fatal, CPLE_AppDefined, "curl_multi failed, code %d.\n",
+                     mc);
+        }
 
+        if (still_running)
+        {
+            mc = curl_multi_poll(curl_multi, nullptr, 0, 1000, nullptr);
+            if (mc != CURLM_OK)
+            {
+                CPLError(CE_Fatal, CPLE_AppDefined,
+                         "curl_multi_poll failed, code %d.\n", mc);
+            }
+        }
         // Pick up messages, clean up the completed ones, add more
         int msgs_in_queue = 0;
-        do
+        while (CURLMsg *m = curl_multi_info_read(curl_multi, &msgs_in_queue))
         {
-            CURLMsg *m = curl_multi_info_read(curl_multi, &msgs_in_queue);
-            if (m && (m->msg == CURLMSG_DONE))
+            if (m->msg == CURLMSG_DONE)
             {
-                ProcessCurlErrors(m, pasRequest, nRequestCount);
+                auto handle = m->easy_handle;
+                CURLcode result = m->data.result;
+                WMSHTTPRequest *psRequest;
+                curl_easy_getinfo(handle, CURLINFO_PRIVATE, &psRequest);
 
-                curl_multi_remove_handle(curl_multi, m->easy_handle);
+                curl_multi_remove_handle(curl_multi, handle);
+                ProcessCurlErrors(m, psRequest);
+
+                if (result != CURLE_OK)
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "CURL: Transfer failed: %s\n",
+                             curl_easy_strerror(result));
+                    curl_off_t wait = 0;
+                    curl_easy_getinfo(handle, CURLINFO_RETRY_AFTER, &wait);
+                    if (wait)
+                    {
+                        sleep(1);
+                    }
+                    if (--psRequest->retry > 0)
+                    {
+                        curl_multi_add_handle(curl_multi, handle);
+                        still_running = 1;  // Still have request pending
+                        continue;
+                    }
+                    ret = CE_Failure;
+                }
+                process(psRequest);
+
                 if (conn_i < nRequestCount)
                 {
-                    auto psRequest = &pasRequest[conn_i];
+                    psRequest = &pasRequest[conn_i];
+                    WMSHTTPInitializeRequest(psRequest, handle);
                     CPLDebug("HTTP", "Requesting [%d/%d] %s", conn_i + 1,
                              nRequestCount, pasRequest[conn_i].URL.c_str());
                     curl_multi_add_handle(curl_multi, psRequest->m_curl_handle);
@@ -231,29 +322,8 @@ CPLErr WMSHTTPFetchMulti(WMSHTTPRequest *pasRequest, int nRequestCount)
                     still_running = 1;  // Still have request pending
                 }
             }
-        } while (msgs_in_queue);
-
-        if (CURLM_OK == mc)
-        {
-            int numfds;
-            curl_multi_wait(curl_multi, nullptr, 0, 100, &numfds);
         }
     } while (still_running || conn_i != nRequestCount);
-
-    // process any message still in queue
-    CURLMsg *msg;
-    int msgs_in_queue;
-    do
-    {
-        msg = curl_multi_info_read(curl_multi, &msgs_in_queue);
-        if (msg != nullptr)
-        {
-            if (msg->msg == CURLMSG_DONE)
-            {
-                ProcessCurlErrors(msg, pasRequest, nRequestCount);
-            }
-        }
-    } while (msg != nullptr);
 
     CPLHTTPRestoreSigPipeHandler(old_handler);
 
@@ -267,54 +337,11 @@ CPLErr WMSHTTPFetchMulti(WMSHTTPRequest *pasRequest, int nRequestCount)
         ret = CE_Failure;
     }
 
-    for (i = 0; i < nRequestCount; ++i)
-    {
-        WMSHTTPRequest *const psRequest = &pasRequest[i];
-
-        long response_code;
-        curl_easy_getinfo(psRequest->m_curl_handle, CURLINFO_RESPONSE_CODE,
-                          &response_code);
-        // for local files, don't update the status code if one is already set
-        if (!(psRequest->nStatus != 0 &&
-              STARTS_WITH(psRequest->URL.c_str(), "file://")))
-            psRequest->nStatus = static_cast<int>(response_code);
-
-        char *content_type = nullptr;
-        curl_easy_getinfo(psRequest->m_curl_handle, CURLINFO_CONTENT_TYPE,
-                          &content_type);
-        psRequest->ContentType = content_type ? content_type : "";
-
-        if (psRequest->Error.empty())
-            psRequest->Error = &psRequest->m_curl_error[0];
-
-        /* In the case of a file:// URL, curl will return a status == 0, so if
-         * there's no */
-        /* error returned, patch the status code to be 200, as it would be for
-         * http:// */
-        if (psRequest->nStatus == 0 && psRequest->Error.empty() &&
-            STARTS_WITH(psRequest->URL.c_str(), "file://"))
-            psRequest->nStatus = 200;
-
-        // If there is an error with no error message, use the content if it is
-        // text
-        if (psRequest->Error.empty() && psRequest->nStatus != 0 &&
-            psRequest->nStatus != 200 &&
-            strstr(psRequest->ContentType, "text") &&
-            psRequest->pabyData != nullptr)
-            psRequest->Error =
-                reinterpret_cast<const char *>(psRequest->pabyData);
-
-        CPLDebug(
-            "HTTP", "Request [%d] %s : status = %d, type = %s, error = %s", i,
-            psRequest->URL.c_str(), psRequest->nStatus,
-            !psRequest->ContentType.empty() ? psRequest->ContentType.c_str()
-                                            : "(null)",
-            !psRequest->Error.empty() ? psRequest->Error.c_str() : "(null)");
-
-        curl_multi_remove_handle(curl_multi, pasRequest->m_curl_handle);
-    }
-
     curl_multi_cleanup(curl_multi);
+    for (auto handle : handles)
+    {
+        curl_easy_cleanup(handle);
+    }
 
     return ret;
 }

--- a/frmts/wms/gdalhttp.h
+++ b/frmts/wms/gdalhttp.h
@@ -42,6 +42,7 @@ struct WMSHTTPRequest
     GByte *pabyData{nullptr};
     size_t nDataLen{};
     size_t nDataAlloc{};
+    int retry{};
 
     /* curl internal stuff */
     CURL *m_curl_handle{nullptr};
@@ -54,8 +55,6 @@ struct WMSHTTPRequest
     std::vector<char> m_curl_error{};
 };
 
-// Not public, only for use within WMS
-void WMSHTTPInitializeRequest(WMSHTTPRequest *psRequest);
 CPLErr WMSHTTPFetchMulti(WMSHTTPRequest *psRequest, int nRequestCount = 1);
 
 #endif /*  GDALHTTP_H */

--- a/frmts/wms/gdalwmsrasterband.cpp
+++ b/frmts/wms/gdalwmsrasterband.cpp
@@ -172,7 +172,6 @@ CPLErr GDALWMSRasterBand::ReadBlocks(int x, int y, void *buffer, int bx0,
                 else
                 {
                     request.options = options;
-                    WMSHTTPInitializeRequest(&request);
                     count++;
                 }
             }

--- a/frmts/wms/minidriver_mrf.cpp
+++ b/frmts/wms/minidriver_mrf.cpp
@@ -84,7 +84,6 @@ static size_t pread_curl(void *user_data, void *buff, size_t count,
     request.Range.Printf(CPL_FRMT_GUIB "-" CPL_FRMT_GUIB,
                          static_cast<GUIntBig>(offset),
                          static_cast<GUIntBig>(offset + count - 1));
-    WMSHTTPInitializeRequest(&request);
     if (WMSHTTPFetchMulti(&request) != CE_None)
     {
         CPLError(CE_Failure, CPLE_AppDefined,


### PR DESCRIPTION
## What does this PR do?

Speed improvement.

Reuse Curl handles in WMSHTTPRequest so they use same connection pools and less memory.

Clean up the WMSHTTPFetchMulti() so that all operations are handled in one while-loop and split the data processing into its own function process(WMSHTTPRequest *)

Add retry capability for WMSHTTPRequest.

## What are related issues/pull requests?

None.

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS: Ubuntu 24.04.3 LTS
* Compiler: gcc (Ubuntu 13.3.0-6ubuntu2~24.04) 13.3.0


## Comparison to GDAL 3.8.4 on Ubuntu

GDAL from `apt get gdal-bin`
```
gdal_translate 'WMTS:traficom-getcap.xml,layer="Traficom:Rannikkokartat public",tilematrixset=WGS84_Pseudo-Mercator,zoom_level=10' -of png 'Traficom_Rannikkokartat public.png'
Input file size is 6656, 10240
0...10...20...30...40...50...60...70...80...90...100 - done.

real    10m47.473s
user    9m10.483s
sys     1m20.249s
```

GDAL build from this PR
```
gdal_translate 'WMTS:traficom-getcap.xml,layer="Traficom:Rannikkokartat public",tilematrixset=WGS84_Pseudo-Mercator,zoom_level=10' -of png 'Traficom_Rannikkokartat public.png'
Input file size is 6656, 10240
0...10...20...30...40...50...60...70...80...90...100 - done in 00:00:20.

real    0m20.423s
user    0m10.665s
sys     0m1.154s
```

Both started on empty cache directory.
Following configuration file is used:
```
[configoptions]
GDAL_NUM_THREADS=ALL_CPUS
GDAL_CACHEMAX=4GB
GDAL_DEFAULT_WMS_CACHE_PATH=./gdalwmscache
GDAL_MAX_CONNECTIONS=10
CPL_CURL_VERBOSE=NO
CPL_DEBUG=OFF
```
