### PR TITLE
[cli] vector change-field-type

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -90,6 +90,7 @@ target_sources(appslib PRIVATE
   gdalalg_raster_write.cpp
   gdalalg_vector.cpp
   gdalalg_vector_info.cpp
+  gdalalg_vector_change_field_type.cpp
   gdalalg_vector_check_coverage.cpp
   gdalalg_vector_check_geometry.cpp
   gdalalg_vector_clip.cpp

--- a/apps/gdalalg_vector.cpp
+++ b/apps/gdalalg_vector.cpp
@@ -14,6 +14,7 @@
 
 #include "gdalalg_vector_info.h"
 #include "gdalalg_vector_buffer.h"
+#include "gdalalg_vector_change_field_type.h"
 #include "gdalalg_vector_check_geometry.h"
 #include "gdalalg_vector_check_coverage.h"
 #include "gdalalg_vector_clean_coverage.h"
@@ -67,6 +68,7 @@ class GDALVectorAlgorithm final : public GDALAlgorithm
 
         RegisterSubAlgorithm<GDALVectorInfoAlgorithmStandalone>();
         RegisterSubAlgorithm<GDALVectorBufferAlgorithmStandalone>();
+        RegisterSubAlgorithm<GDALVectorChangeFieldTypeAlgorithmStandalone>();
         RegisterSubAlgorithm<GDALVectorCheckCoverageAlgorithmStandalone>();
         RegisterSubAlgorithm<GDALVectorCheckGeometryAlgorithmStandalone>();
         RegisterSubAlgorithm<GDALVectorCleanCoverageAlgorithmStandalone>();

--- a/apps/gdalalg_vector_change_field_type.cpp
+++ b/apps/gdalalg_vector_change_field_type.cpp
@@ -1,0 +1,188 @@
+/******************************************************************************
+ *
+ * Project:  GDAL
+ * Purpose:  "change-field-type" step of "vector pipeline"
+ * Author:   Alessandro Pasotti <elpaso at itopen dot it>
+ *
+ ******************************************************************************
+ * Copyright (c) 2025, Alessandro Pasotti <elpaso at itopen dot it>
+ *
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#include "gdalalg_vector_change_field_type.h"
+#include "gdal_priv.h"
+#include "gdal_utils.h"
+
+//! @cond Doxygen_Suppress
+
+#ifndef _
+#define _(x) (x)
+#endif
+
+/************************************************************************/
+/*          GDALVectorChangeFieldTypeAlgorithm::GDALVectorChangeFieldTypeAlgorithm()          */
+/************************************************************************/
+
+GDALVectorChangeFieldTypeAlgorithm::GDALVectorChangeFieldTypeAlgorithm(
+    bool standaloneStep)
+    : GDALVectorPipelineStepAlgorithm(NAME, DESCRIPTION, HELP_URL,
+                                      standaloneStep)
+{
+    AddActiveLayerArg(&m_activeLayer);
+    AddFieldNameArg(&m_fieldName).SetRequired();
+    AddFieldTypeSubtypeArg(&m_newFieldType, &m_newFieldSubType,
+                           &m_newFieldTypeSubTypeStr)
+        .SetRequired();
+}
+
+/************************************************************************/
+/*                   GDALVectorChangeFieldTypeAlgorithmLayer                       */
+/************************************************************************/
+
+namespace
+{
+class GDALVectorChangeFieldTypeAlgorithmLayer final
+    : public GDALVectorPipelineOutputLayer
+{
+  public:
+    GDALVectorChangeFieldTypeAlgorithmLayer(
+        OGRLayer &oSrcLayer, const std::string &activeLayer,
+        const std::string &fieldName, const OGRFieldType &newFieldType,
+        const OGRFieldSubType &newFieldSubType)
+        : GDALVectorPipelineOutputLayer(oSrcLayer)
+    {
+
+        m_poFeatureDefn = oSrcLayer.GetLayerDefn()->Clone();
+        m_poFeatureDefn->Reference();
+
+        if (activeLayer.empty() || activeLayer == GetDescription())
+        {
+            m_fieldIndex = m_poFeatureDefn->GetFieldIndex(fieldName.c_str());
+            CPLAssert(-1 != m_fieldIndex);
+            auto poFieldDefn = m_poFeatureDefn->GetFieldDefn(m_fieldIndex);
+            m_sourceFieldType = poFieldDefn->GetType();
+
+            // Set to OFSTNone to bypass the check that prevents changing the type
+            poFieldDefn->SetSubType(OFSTNone);
+            poFieldDefn->SetType(newFieldType);
+            poFieldDefn->SetSubType(newFieldSubType);
+        }
+    }
+
+    ~GDALVectorChangeFieldTypeAlgorithmLayer() override
+    {
+        m_poFeatureDefn->Release();
+    }
+
+    const OGRFeatureDefn *GetLayerDefn() const override
+    {
+        return m_poFeatureDefn;
+    }
+
+    void TranslateFeature(
+        std::unique_ptr<OGRFeature> poSrcFeature,
+        std::vector<std::unique_ptr<OGRFeature>> &apoOutFeatures) override
+    {
+        if (m_poFeatureDefn->GetFieldDefn(m_fieldIndex)->GetType() !=
+            m_sourceFieldType)
+        {
+            // Store the old value and type in a temporary feature
+            std::unique_ptr<OGRFeatureDefn> poFeatureDefTemp =
+                std::make_unique<OGRFeatureDefn>(m_poFeatureDefn->GetName());
+            poFeatureDefTemp->AddFieldDefn(
+                std::make_unique<OGRFieldDefn>("__dummy__", m_sourceFieldType));
+            OGRFeature oFeatureTemp{poFeatureDefTemp.release()};
+            const int tempMap[1] = {m_fieldIndex};
+            oFeatureTemp.SetFieldsFrom(poSrcFeature.get(), tempMap, false,
+                                       true);
+
+            // Remove the old field value
+            poSrcFeature->UnsetField(m_fieldIndex);
+
+            // Change the type
+            poSrcFeature->SetFDefnUnsafe(m_poFeatureDefn);
+
+            // Convert the value
+            std::vector<int> fieldsMap(m_poFeatureDefn->GetFieldCount());
+            for (int i = 0; i < m_poFeatureDefn->GetFieldCount(); i++)
+            {
+                fieldsMap[i] = i == m_fieldIndex ? 0 : -1;
+            }
+            const auto result{poSrcFeature->SetFieldsFrom(
+                &oFeatureTemp, fieldsMap.data(), false, true)};
+            if (result != OGRERR_NONE)
+            {
+                CPLError(
+                    CE_Warning, CPLE_AppDefined,
+                    "Cannot convert field '%s' to new type, setting it to NULL",
+                    m_poFeatureDefn->GetFieldDefn(m_fieldIndex)->GetNameRef());
+            }
+        }
+
+        apoOutFeatures.push_back(std::move(poSrcFeature));
+    }
+
+    int TestCapability(const char *pszCap) const override
+    {
+        if (EQUAL(pszCap, OLCStringsAsUTF8) ||
+            EQUAL(pszCap, OLCCurveGeometries) || EQUAL(pszCap, OLCZGeometries))
+            return m_srcLayer.TestCapability(pszCap);
+        return false;
+    }
+
+  private:
+    OGRFeatureDefn *m_poFeatureDefn = nullptr;
+    /*
+     Stores the original type in order to detect if a change is needed
+     (the change might only affect the subtype)
+    */
+    OGRFieldType m_sourceFieldType = OFTString;
+    int m_fieldIndex{-1};
+
+    CPL_DISALLOW_COPY_ASSIGN(GDALVectorChangeFieldTypeAlgorithmLayer)
+};
+
+}  // namespace
+
+/************************************************************************/
+/*                GDALVectorChangeFieldTypeAlgorithm::RunStep()                    */
+/************************************************************************/
+
+bool GDALVectorChangeFieldTypeAlgorithm::RunStep(GDALPipelineStepRunContext &)
+{
+    auto poSrcDS = m_inputDataset[0].GetDatasetRef();
+    CPLAssert(poSrcDS);
+
+    CPLAssert(m_outputDataset.GetName().empty());
+    CPLAssert(!m_outputDataset.GetDatasetRef());
+
+    const int nLayerCount = poSrcDS->GetLayerCount();
+
+    auto outDS = std::make_unique<GDALVectorPipelineOutputDataset>(*poSrcDS);
+
+    bool ret = true;
+    for (int i = 0; ret && i < nLayerCount; ++i)
+    {
+        auto poSrcLayer = poSrcDS->GetLayer(i);
+        ret = (poSrcLayer != nullptr);
+        if (ret)
+        {
+            outDS->AddLayer(
+                *poSrcLayer,
+                std::make_unique<GDALVectorChangeFieldTypeAlgorithmLayer>(
+                    *poSrcLayer, m_activeLayer, m_fieldName, m_newFieldType,
+                    m_newFieldSubType));
+        }
+    }
+
+    if (ret)
+        m_outputDataset.Set(std::move(outDS));
+
+    return ret;
+}
+
+GDALVectorChangeFieldTypeAlgorithmStandalone::
+    ~GDALVectorChangeFieldTypeAlgorithmStandalone() = default;
+
+//! @endcond

--- a/apps/gdalalg_vector_change_field_type.h
+++ b/apps/gdalalg_vector_change_field_type.h
@@ -1,0 +1,64 @@
+/******************************************************************************
+ *
+ * Project:  GDAL
+ * Purpose:  "change-field-type" step of "vector pipeline"
+ * Author:   Alessandro Pasotti <elpaso at itopen dot it>
+ *
+ ******************************************************************************
+ * Copyright (c) 2025, Alessandro Pasotti <elpaso at itopen dot it>
+ *
+ * SPDX-License-Identifier: MIT
+ ****************************************************************************/
+
+#ifndef GDALALG_VECTOR_CHANGE_FIELD_TYPE_INCLUDED
+#define GDALALG_VECTOR_CHANGE_FIELD_TYPE_INCLUDED
+
+#include "gdalalg_vector_pipeline.h"
+
+//! @cond Doxygen_Suppress
+
+/************************************************************************/
+/*                       GDALVectorChangeFieldTypeAlgorithm                        */
+/************************************************************************/
+
+class GDALVectorChangeFieldTypeAlgorithm /* non final */
+    : public GDALVectorPipelineStepAlgorithm
+{
+  public:
+    static constexpr const char *NAME = "change-field-type";
+    static constexpr const char *DESCRIPTION =
+        "Change the type of a field of a vector dataset.";
+    static constexpr const char *HELP_URL =
+        "/programs/gdal_vector_change_field_type.html";
+
+    explicit GDALVectorChangeFieldTypeAlgorithm(bool standaloneStep = false);
+
+  private:
+    bool RunStep(GDALPipelineStepRunContext &ctxt) override;
+
+    std::string m_activeLayer{};
+    std::string m_fieldName{};
+    OGRFieldType m_newFieldType{OGRFieldType::OFTString};
+    OGRFieldSubType m_newFieldSubType{OGRFieldSubType::OFSTNone};
+    std::string m_newFieldTypeSubTypeStr{};
+};
+
+/************************************************************************/
+/*                   GDALVectorChangeFieldTypeAlgorithmStandalone                  */
+/************************************************************************/
+
+class GDALVectorChangeFieldTypeAlgorithmStandalone final
+    : public GDALVectorChangeFieldTypeAlgorithm
+{
+  public:
+    GDALVectorChangeFieldTypeAlgorithmStandalone()
+        : GDALVectorChangeFieldTypeAlgorithm(/* standaloneStep = */ true)
+    {
+    }
+
+    ~GDALVectorChangeFieldTypeAlgorithmStandalone() override;
+};
+
+//! @endcond
+
+#endif /* GDALALG_VECTOR_CHANGE_FIELD_TYPE_INCLUDED */

--- a/apps/gdalalg_vector_pipeline.cpp
+++ b/apps/gdalalg_vector_pipeline.cpp
@@ -13,6 +13,7 @@
 #include "gdalalg_vector_pipeline.h"
 #include "gdalalg_vector_read.h"
 #include "gdalalg_vector_buffer.h"
+#include "gdalalg_vector_change_field_type.h"
 #include "gdalalg_vector_check_coverage.h"
 #include "gdalalg_vector_check_geometry.h"
 #include "gdalalg_vector_clean_coverage.h"
@@ -151,6 +152,9 @@ void GDALVectorPipelineAlgorithm::RegisterAlgorithms(
 
     registry.Register<GDALVectorEditAlgorithm>(
         addSuffixIfNeeded(GDALVectorEditAlgorithm::NAME));
+
+    registry.Register<GDALVectorChangeFieldTypeAlgorithm>(
+        addSuffixIfNeeded(GDALVectorChangeFieldTypeAlgorithm::NAME));
 
     registry.Register<GDALVectorExplodeCollectionsAlgorithm>();
 

--- a/autotest/utilities/test_gdalalg_vector_change_field_type.py
+++ b/autotest/utilities/test_gdalalg_vector_change_field_type.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env pytest
+# -*- coding: utf-8 -*-
+###############################################################################
+# Project:  GDAL/OGR Test Suite
+# Purpose:  'gdal vector change-field-type' testing
+# Author:   Alessandro Pasotti, <elpaso at itopen dot it>
+#
+###############################################################################
+# Copyright (c) 2025, Alessandro Pasotti <elpaso at itopen dot it>
+#
+# SPDX-License-Identifier: MIT
+###############################################################################
+
+
+import pytest
+
+from osgeo import gdal, ogr
+
+
+def get_change_field_type_alg():
+    return gdal.GetGlobalAlgorithmRegistry()["vector"]["change-field-type"]
+
+
+@pytest.mark.parametrize(
+    "src_type,src_subtype,dest_type_str,src_value,expected_value",
+    [
+        (ogr.OFTString, ogr.OFSTNone, "Integer", "123", 123),
+        (ogr.OFTString, ogr.OFSTNone, "Real", "123.456", 123.456),
+        (ogr.OFTString, ogr.OFSTNone, "String", "foo", "foo"),
+        (ogr.OFTInteger, ogr.OFSTNone, "String", 123, "123"),
+        (ogr.OFTInteger, ogr.OFSTNone, "Real", 123, 123.0),
+        (ogr.OFTInteger, ogr.OFSTNone, "Integer", 123, 123),
+        (ogr.OFTReal, ogr.OFSTNone, "String", 123.456, "123.456"),
+        (ogr.OFTReal, ogr.OFSTNone, "Integer", 123.456, 123),
+        (ogr.OFTReal, ogr.OFSTNone, "Real", 123.456, 123.456),
+        (ogr.OFTString, ogr.OFSTNone, "Date", "2024/06/01", "2024/06/01"),
+        (
+            ogr.OFTString,
+            ogr.OFSTNone,
+            "DateTime",
+            "2024/06/01 12:34:56",
+            "2024/06/01 12:34:56",
+        ),
+        (ogr.OFTString, ogr.OFSTNone, "Time", "12:34:56", "12:34:56"),
+        (ogr.OFTString, ogr.OFSTNone, "Integer64", "1234567890123", 1234567890123),
+        # Test JSON
+        (
+            ogr.OFTString,
+            ogr.OFSTJSON,
+            "StringList",
+            '["foo","bar","baz"]',
+            ["foo", "bar", "baz"],
+        ),
+        (ogr.OFTString, ogr.OFSTJSON, "IntegerList", "[1,2,3]", [1, 2, 3]),
+        (ogr.OFTString, ogr.OFSTJSON, "RealList", "[1.1,2.2,3.3]", [1.1, 2.2, 3.3]),
+        # Failing: (ogr.OFTString, ogr.OFSTJSON, "Integer64List", "[1234567890123,2345678901234]", [1234567890123, 2345678901234]),
+        # Test list types
+        (
+            ogr.OFTStringList,
+            ogr.OFSTNone,
+            "String",
+            '["foo","bar","baz"]',
+            '["foo","bar","baz"]',
+        ),
+        (ogr.OFTIntegerList, ogr.OFSTNone, "String", "[1,2,3]", "[1,2,3]"),
+        (ogr.OFTRealList, ogr.OFSTNone, "String", "[1.1,2.2,3.3]", "[1.1,2.2,3.3]"),
+        # Test destination subtype
+        (
+            ogr.OFTStringList,
+            ogr.OFSTNone,
+            "JSON",
+            '["foo","bar","baz"]',
+            '[ "foo", "bar", "baz" ]',
+        ),
+        (
+            ogr.OFTString,
+            ogr.OFSTNone,
+            "UUID",
+            "550e8400-e29b-41d4-a716-446655440000",
+            "550e8400-e29b-41d4-a716-446655440000",
+        ),
+        (ogr.OFTString, ogr.OFSTNone, "boolean", "true", True),
+        (ogr.OFTString, ogr.OFSTNone, "float32", "1.5", 1.5),
+        (ogr.OFTString, ogr.OFSTNone, "int16", "123", 123),
+    ],
+)
+def test_gdalalg_vector_change_field_type(
+    src_type, src_subtype, dest_type_str, src_value, expected_value
+):
+
+    src_ds = gdal.GetDriverByName("MEM").CreateDataSource("")
+    lyr = src_ds.CreateLayer("layer", geom_type=ogr.wkbNone)
+    fld_defn = ogr.FieldDefn("value", src_type)
+    fld_defn.SetSubType(src_subtype)
+    lyr.CreateField(fld_defn)
+
+    f = ogr.Feature(lyr.GetLayerDefn())
+    f["value"] = src_value
+    lyr.CreateFeature(f)
+
+    alg = get_change_field_type_alg()
+    alg["input"] = src_ds
+
+    assert alg.ParseCommandLineArguments(
+        [
+            "--field-name",
+            "value",
+            "--field-type",
+            dest_type_str,
+            "--of",
+            "MEM",
+            "--output",
+            "memory_ds",
+        ]
+    )
+    assert alg.Run()
+
+    out_ds = alg["output"].GetDataset()
+    out_lyr = out_ds.GetLayer(0)
+    out_f = out_lyr.GetNextFeature()
+    # Check field type and subtype
+    out_field_defn = out_lyr.GetLayerDefn().GetFieldDefn(0)
+    expected_type = ogr.GetFieldTypeByName(dest_type_str)
+
+    if expected_type == ogr.OFTString and dest_type_str.lower() != "string":
+        # It must be a subtype
+        expected_subtype = ogr.GetFieldSubtypeByName(dest_type_str)
+        assert out_field_defn.GetSubType() == expected_subtype
+    else:
+        # It must be a type
+        assert out_field_defn.GetType() == expected_type
+
+    assert out_f["value"] == expected_value

--- a/autotest/utilities/test_gdalalg_vector_change_field_type.py
+++ b/autotest/utilities/test_gdalalg_vector_change_field_type.py
@@ -25,6 +25,7 @@ def get_change_field_type_alg():
     "src_type,src_subtype,dest_type_str,src_value,expected_value",
     [
         (ogr.OFTString, ogr.OFSTNone, "Integer", "123", 123),
+        (ogr.OFTBinary, ogr.OFSTNone, "String", b"foo", "666F6F"),
         (ogr.OFTString, ogr.OFSTNone, "Real", "123.456", 123.456),
         (ogr.OFTString, ogr.OFSTNone, "String", "foo", "foo"),
         (ogr.OFTInteger, ogr.OFSTNone, "String", 123, "123"),
@@ -53,17 +54,23 @@ def get_change_field_type_alg():
         ),
         (ogr.OFTString, ogr.OFSTJSON, "IntegerList", "[1,2,3]", [1, 2, 3]),
         (ogr.OFTString, ogr.OFSTJSON, "RealList", "[1.1,2.2,3.3]", [1.1, 2.2, 3.3]),
-        # Failing: (ogr.OFTString, ogr.OFSTJSON, "Integer64List", "[1234567890123,2345678901234]", [1234567890123, 2345678901234]),
+        (
+            ogr.OFTString,
+            ogr.OFSTJSON,
+            "Integer64List",
+            "[1234567890123,2345678901234]",
+            [1234567890123, 2345678901234],
+        ),
         # Test list types
         (
             ogr.OFTStringList,
             ogr.OFSTNone,
             "String",
             '["foo","bar","baz"]',
-            '["foo","bar","baz"]',
+            "(3:foo,bar,baz)",
         ),
-        (ogr.OFTIntegerList, ogr.OFSTNone, "String", "[1,2,3]", "[1,2,3]"),
-        (ogr.OFTRealList, ogr.OFSTNone, "String", "[1.1,2.2,3.3]", "[1.1,2.2,3.3]"),
+        (ogr.OFTIntegerList, ogr.OFSTNone, "String", "[1,2,3]", "(3:1,2,3)"),
+        (ogr.OFTRealList, ogr.OFSTNone, "String", "[1.1,2.2,3.3]", "(3:1.1,2.2,3.3)"),
         # Test destination subtype
         (
             ogr.OFTStringList,
@@ -82,6 +89,10 @@ def get_change_field_type_alg():
         (ogr.OFTString, ogr.OFSTNone, "boolean", "true", True),
         (ogr.OFTString, ogr.OFSTNone, "float32", "1.5", 1.5),
         (ogr.OFTString, ogr.OFSTNone, "int16", "123", 123),
+        # Test source subtype
+        (ogr.OFTInteger, ogr.OFSTInt16, "integer", -32768, -32768),
+        (ogr.OFTInteger, ogr.OFSTBoolean, "integer", True, 1),
+        (ogr.OFTInteger, ogr.OFSTBoolean, "integer", False, 0),
     ],
 )
 def test_gdalalg_vector_change_field_type(
@@ -129,5 +140,57 @@ def test_gdalalg_vector_change_field_type(
     else:
         # It must be a type
         assert out_field_defn.GetType() == expected_type
+        assert out_field_defn.GetSubType() == ogr.OFSTNone
 
     assert out_f["value"] == expected_value
+
+
+def test_gdalalg_vector_change_field_type_errors():
+    src_ds = gdal.GetDriverByName("MEM").CreateDataSource("")
+    lyr = src_ds.CreateLayer("layer", geom_type=ogr.wkbNone)
+    fld_defn = ogr.FieldDefn("value", ogr.OFTString)
+    lyr.CreateField(fld_defn)
+
+    f = ogr.Feature(lyr.GetLayerDefn())
+    f["value"] = "foo"
+    lyr.CreateFeature(f)
+
+    # Wrong field name
+    alg = get_change_field_type_alg()
+    alg["input"] = src_ds
+
+    with pytest.raises(
+        Exception, match="Cannot find field 'non_existing_field' in layer 'layer'"
+    ):
+        alg.ParseCommandLineArguments(
+            [
+                "--field-name",
+                "non_existing_field",
+                "--field-type",
+                "Integer",
+                "--of",
+                "MEM",
+                "--output",
+                "memory_ds",
+            ]
+        )
+
+    # Wrong field type
+    alg = get_change_field_type_alg()
+    alg["input"] = src_ds
+    with pytest.raises(
+        Exception,
+        match="change-field-type: Invalid value for argument 'field-type': 'NonExistingType'",
+    ):
+        alg.ParseCommandLineArguments(
+            [
+                "--field-name",
+                "value",
+                "--field-type",
+                "NonExistingType",
+                "--of",
+                "MEM",
+                "--output",
+                "memory_ds",
+            ]
+        )

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -849,6 +849,13 @@ man_pages = [
         1,
     ),
     (
+        "programs/gdal_vector_change_field_type",
+        "gdal-vector-change-field-type",
+        "Change the type of a field of a vector dataset",
+        [author_elpaso],
+        1,
+    ),
+    (
         "programs/gdal_vector_filter",
         "gdal-vector-filter",
         "Filter a vector dataset",

--- a/doc/source/programs/gdal_vector.rst
+++ b/doc/source/programs/gdal_vector.rst
@@ -23,6 +23,7 @@ Available sub-commands
 - :ref:`gdal_vector_clip`
 - :ref:`gdal_vector_concat`
 - :ref:`gdal_vector_convert`
+- :ref:`gdal_vector_change_field_type`
 - :ref:`gdal_vector_edit`
 - :ref:`gdal_vector_filter`
 - :ref:`gdal_vector_index`

--- a/doc/source/programs/gdal_vector_change_field_type.rst
+++ b/doc/source/programs/gdal_vector_change_field_type.rst
@@ -1,0 +1,75 @@
+.. _gdal_vector_change_field_type:
+
+================================================================================
+``gdal vector change-field-type``
+================================================================================
+
+.. versionadded:: 3.11
+
+.. only:: html
+
+    Change the type of a field of a vector layer.
+
+.. Index:: gdal vector change-field-type
+
+Synopsis
+--------
+
+.. program-output:: gdal vector change-field-type --help-doc
+
+Description
+-----------
+
+:program:`gdal vector change-field-type` can be used to change the field type of a vector dataset:
+
+``edit`` can also be used as a step of :ref:`gdal_vector_pipeline`.
+
+
+Standard options
+++++++++++++++++
+
+.. include:: gdal_options/of_vector.rst
+
+.. include:: gdal_options/co_vector.rst
+
+.. include:: gdal_options/lco.rst
+
+.. include:: gdal_options/overwrite.rst
+
+.. include:: gdal_options/active_layer.rst
+
+
+.. option:: --field-name <FIELD-NAME>
+
+    The name of the field to modify. Required.
+
+.. option:: --field-type <FIELD-TYPE>
+
+    The new field type. Valid values are: ``Integer``, ``IntegerList``, ``Real``, ``RealList``, ``String``, ``StringList``, ``Binary``,  ` ``Date``, ``Time``, ``DateTime``, ``Integer64``, ``Integer64List``.
+    A field subtype can be specified instead of a field type. Valid values are: ``Boolean``, ``Int16``, ``Float32``, ``JSON``, ``UUID``. The field type will be derived from the subtype.
+
+
+Advanced options
+++++++++++++++++
+
+.. include:: gdal_options/if.rst
+
+.. include:: gdal_options/oo.rst
+
+.. include:: gdal_options/output-oo.rst
+
+
+.. GDALG output (on-the-fly / streamed dataset)
+.. --------------------------------------------
+
+.. include:: gdal_cli_include/gdalg_vector_compatible.rst
+
+Examples
+--------
+
+.. example::
+   :title: Change the type of a field from String to Integer
+
+   .. code-block:: bash
+
+        $ gdal vector change-field-type input.gpkg output.gpkg --field-name myfield --field-type Integer

--- a/doc/source/programs/gdal_vector_pipeline.rst
+++ b/doc/source/programs/gdal_vector_pipeline.rst
@@ -49,6 +49,13 @@ Details for options can be found in :ref:`gdal_vector_buffer`.
 
 Details for options can be found in :ref:`gdal_vector_concat`.
 
+* change-field-type
+
+.. program-output:: gdal vector pipeline --help-doc=change-field-type
+
+Details for options can be found in :ref:`gdal_vector_change_field_type`.
+
+
 * clip
 
 .. program-output:: gdal vector pipeline --help-doc=clip

--- a/doc/source/programs/index.rst
+++ b/doc/source/programs/index.rst
@@ -188,6 +188,7 @@ Vector commands
    gdal_vector_check_geometry
    gdal_vector_clean_coverage
    gdal_vector_clip
+   gdal_vector_change_field_type
    gdal_vector_concat
    gdal_vector_convert
    gdal_vector_edit
@@ -220,6 +221,7 @@ Vector commands
     - :ref:`gdal_vector_check_geometry`: Check a dataset for invalid or non-simple geometries
     - :ref:`gdal_vector_clean_coverage`: Remove gaps and overlaps in a polygon dataset
     - :ref:`gdal_vector_clip`: Clip a vector dataset
+    - :ref:`gdal_vector_change_field_type`: Change the type of a field of a vector dataset
     - :ref:`gdal_vector_concat`: Concatenate vector datasets
     - :ref:`gdal_vector_convert`: Convert a vector dataset
     - :ref:`gdal_vector_edit`: Edit metadata of a vector dataset

--- a/gcore/gdalalgorithm.cpp
+++ b/gcore/gdalalgorithm.cpp
@@ -4515,7 +4515,7 @@ GDALInConstructionAlgorithmArg &GDALAlgorithm::AddFieldTypeSubtypeArg(
                 [](const std::string &currentValue)
                 {
                     std::vector<std::string> oRet;
-                    for (int i = 0; i <= OGRFieldSubType::OFSTMaxSubType; i++)
+                    for (int i = 1; i <= OGRFieldSubType::OFSTMaxSubType; i++)
                     {
                         const char *pszSubType =
                             OGRFieldDefn::GetFieldSubTypeName(
@@ -4532,6 +4532,12 @@ GDALInConstructionAlgorithmArg &GDALAlgorithm::AddFieldTypeSubtypeArg(
 
                     for (int i = 0; i <= OGRFieldType::OFTMaxType; i++)
                     {
+                        // Skip deprecated
+                        if (static_cast<OGRFieldType>(i) ==
+                                OGRFieldType::OFTWideString ||
+                            static_cast<OGRFieldType>(i) ==
+                                OGRFieldType::OFTWideStringList)
+                            continue;
                         const char *pszType = OGRFieldDefn::GetFieldTypeName(
                             static_cast<OGRFieldType>(i));
                         if (pszType != nullptr)

--- a/gcore/gdalalgorithm.h
+++ b/gcore/gdalalgorithm.h
@@ -3020,6 +3020,11 @@ class CPL_DLL GDALAlgorithmRegistry
         GDALInConstructionAlgorithmArg &layerArg,
         GDALInConstructionAlgorithmArg &datasetArg);
 
+    /** Register an auto complete function for a field name argument */
+    static void SetAutoCompleteFunctionForFieldName(
+        GDALInConstructionAlgorithmArg &fieldArg,
+        GDALInConstructionAlgorithmArg &layerArg);
+
     /** Add a field name argument */
     GDALInConstructionAlgorithmArg &
     AddFieldNameArg(std::string *pValue, const char *helpMessage = nullptr);

--- a/gcore/gdalalgorithm.h
+++ b/gcore/gdalalgorithm.h
@@ -3020,6 +3020,15 @@ class CPL_DLL GDALAlgorithmRegistry
         GDALInConstructionAlgorithmArg &layerArg,
         GDALInConstructionAlgorithmArg &datasetArg);
 
+    /** Add a field name argument */
+    GDALInConstructionAlgorithmArg &
+    AddFieldNameArg(std::string *pValue, const char *helpMessage = nullptr);
+
+    /** Add a field type (or subtipe) argument */
+    GDALInConstructionAlgorithmArg &AddFieldTypeSubtypeArg(
+        OGRFieldType *pTypeValue, OGRFieldSubType *pSubtypeValue,
+        std::string *pStrValue, const char *helpMessage = nullptr);
+
     /** Add (single) band argument. */
     GDALInConstructionAlgorithmArg &
     AddBandArg(int *pValue, const char *helpMessage = nullptr);

--- a/swig/include/ogr.i
+++ b/swig/include/ogr.i
@@ -636,6 +636,27 @@ typedef int CPLErr;
 #endif /* defined(SWIGPYTHON) */
 #endif /* FROM_GDAL_I */
 
+
+
+%inline %{
+/************************************************************************/
+/*                          OGRGetFieldTypeByName                       */
+/************************************************************************/
+OGRFieldType GetFieldTypeByName(const char* typeName )
+{
+    return OGR_GetFieldTypeByName(typeName);
+}
+
+/************************************************************************/
+/*                        OGRGetFieldSubTypeByName                      */
+/************************************************************************/
+OGRFieldSubType GetFieldSubtypeByName (const char* subTypeName )
+{
+    return OGR_GetFieldSubTypeByName(subTypeName);
+}
+%}
+
+
 /************************************************************************/
 /*                               OGRGetGEOSVersion                      */
 /************************************************************************/


### PR DESCRIPTION
Fix https://github.com/OSGeo/gdal/issues/13046

```
Usage: gdal vector change-field-type [OPTIONS] <INPUT> <OUTPUT>

Change the type of a field of a vector dataset.

Positional arguments:
  -i, --input <INPUT>                                  Input vector datasets [required]
  -o, --output <OUTPUT>                                Output vector dataset [required]

Common Options:
  -h, --help                                           Display help message and exit
  --json-usage                                         Display usage as JSON document and exit
  --config <KEY>=<VALUE>                               Configuration option [may be repeated]
  -q, --quiet                                          Quiet mode (no progress bar)

Options:
  -l, --layer, --input-layer <INPUT-LAYER>             Input layer name(s) [may be repeated]
  -f, --of, --format, --output-format <OUTPUT-FORMAT>  Output format ("GDALG" allowed)
  --co, --creation-option <KEY>=<VALUE>                Creation option [may be repeated]
  --lco, --layer-creation-option <KEY>=<VALUE>         Layer creation option [may be repeated]
  --overwrite                                          Whether overwriting existing output is allowed
  --update                                             Whether to open existing dataset in update mode
  --overwrite-layer                                    Whether overwriting existing output is allowed
  --append                                             Whether appending to existing layer is allowed
  --output-layer <OUTPUT-LAYER>                        Output layer name
  --active-layer <ACTIVE-LAYER>                        Set active layer (if not specified, all)
  --field-name <FIELD-NAME>                            Field name [required]
  --field-type <FIELD-TYPE>                            Field type or subtype [required]

Advanced Options:
  --if, --input-format <INPUT-FORMAT>                  Input formats [may be repeated]
  --oo, --open-option <KEY>=<VALUE>                    Open options [may be repeated]
  --output-oo, --output-open-option <KEY>=<VALUE>      Output open options [may be repeated]

For more details, consult https://gdal.org/programs/gdal_vector_change_field_type.html
```
