### PR TITLE
MiraMonRaster: searching NomFitxer in the appropiate place

### DIFF
--- a/frmts/miramon/miramon_band.cpp
+++ b/frmts/miramon/miramon_band.cpp
@@ -28,8 +28,12 @@ MMRBand::MMRBand(MMRRel &fRel, const CPLString &osBandSectionIn)
 
 {
     // Getting band and band file name from metadata.
-    if (!m_pfRel->GetMetadataValue(SECTION_ATTRIBUTE_DATA, osBandSectionIn,
-                                   KEY_NomFitxer, m_osRawBandFileName) ||
+    CPLString osNomFitxer;
+    osNomFitxer = SECTION_ATTRIBUTE_DATA;
+    osNomFitxer.append(":");
+    osNomFitxer.append(osBandSectionIn);
+    if (!m_pfRel->GetMetadataValue(osNomFitxer, KEY_NomFitxer,
+                                   m_osRawBandFileName) ||
         m_osRawBandFileName.empty())
     {
         // A band name may be empty only if it is the only band present


### PR DESCRIPTION
## What does this PR do?
Fixes the issue 445248683 from fuzzer where the name of the band was searched in the particular section [ATTRIBUTE_DATA:name] **or** in [ATTRIBUTE_DATA] section. This name has not to be found in [ATTRIBUTE_DATA] section. 

Note: Ignore the name of the fork where this PR comes, it's because I am improving palette stuff. I only commit the appropiated file.

## What are related issues/pull requests?
https://issues.oss-fuzz.com/issues/445248683

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Review
 - [ ] All CI builds and checks have passed
