### PR TITLE
Add OGR_G_ConstrainedDelaunayTriangulation(), using GEOS >=3.10 GEOSConstrainedDelaunayTriangulation_r()

### DIFF
--- a/autotest/ogr/ogr_geos.py
+++ b/autotest/ogr/ogr_geos.py
@@ -607,6 +607,45 @@ def test_ogr_geos_DelaunayTriangulation():
 ###############################################################################
 
 
+def test_ogr_geos_ConstrainedDelaunayTriangulation():
+
+    # polygon input
+    in_wkt = "POLYGON ((10 10, 20 40, 90 90, 90 10, 10 10))"
+    g = ogr.CreateGeometryFromWkt(in_wkt)
+
+    gdal.ErrorReset()
+    tri = g.ConstrainedDelaunayTriangulation()
+    if tri is None:
+        assert "GEOS" in gdal.GetLastErrorMsg()
+        pytest.skip()
+
+    assert (
+        tri.ExportToWkt()
+        == "GEOMETRYCOLLECTION (POLYGON ((90 10,20 40,90 90,90 10)),POLYGON ((20 40,90 10,10 10,20 40)))"
+    ), ("Got: %s" % tri.ExportToWkt())
+
+    # multipolygon input
+    in_wkt = "MULTIPOLYGON (((10 10, 20 50, 50 50, 40 20, 10 10)), ((20 60, 60 60, 90 20, 90 90, 20 60)), ((10 90, 10 70, 40 70, 50 90, 10 90)))"
+    g = ogr.CreateGeometryFromWkt(in_wkt)
+    tri = g.ConstrainedDelaunayTriangulation()
+
+    assert tri is not None
+    assert tri.GetGeometryType() == ogr.wkbGeometryCollection
+    assert tri.GetGeometryCount() == 6
+
+    # non-polygon input
+    in_wkt = "MULTIPOINT(0 0,0 1,1 1,1 0)"
+    g = ogr.CreateGeometryFromWkt(in_wkt)
+    tri = g.ConstrainedDelaunayTriangulation()
+
+    assert tri.ExportToWkt() == "GEOMETRYCOLLECTION EMPTY", (
+        "Got: %s" % tri.ExportToWkt()
+    )
+
+
+###############################################################################
+
+
 def test_ogr_geos_polygonize():
 
     g = ogr.CreateGeometryFromWkt("MULTILINESTRING((0 0,0 1,1 1),(1 1,0 0))")

--- a/ogr/ogr_api.h
+++ b/ogr/ogr_api.h
@@ -190,6 +190,8 @@ OGRGeometryH CPL_DLL OGR_G_SimplifyPreserveTopology(
 OGRGeometryH CPL_DLL
 OGR_G_DelaunayTriangulation(OGRGeometryH hThis, double dfTolerance,
                             int bOnlyEdges) CPL_WARN_UNUSED_RESULT;
+OGRGeometryH CPL_DLL OGR_G_ConstrainedDelaunayTriangulation(OGRGeometryH hThis)
+    CPL_WARN_UNUSED_RESULT;
 
 void CPL_DLL OGR_G_Segmentize(OGRGeometryH hGeom, double dfMaxLength);
 int CPL_DLL OGR_G_Intersects(OGRGeometryH, OGRGeometryH);

--- a/ogr/ogr_geometry.h
+++ b/ogr/ogr_geometry.h
@@ -588,6 +588,8 @@ class CPL_DLL OGRGeometry
     virtual OGRGeometry *
     DelaunayTriangulation(double dfTolerance,
                           int bOnlyEdges) const CPL_WARN_UNUSED_RESULT;
+    virtual OGRGeometry *
+    ConstrainedDelaunayTriangulation() const CPL_WARN_UNUSED_RESULT;
 
     virtual OGRGeometry *Polygonize() const CPL_WARN_UNUSED_RESULT;
     virtual OGRGeometry *BuildArea() const CPL_WARN_UNUSED_RESULT;

--- a/swig/include/ogr.i
+++ b/swig/include/ogr.i
@@ -3266,8 +3266,8 @@ OGRGeometryShadow* CreateGeometryFromWkb(int nLen, unsigned char *pBuf,
 #ifndef SWIGCSHARP
 %newobject CreateGeometryFromEnvelope;
 %inline %{
-  OGRGeometryShadow *CreateGeometryFromEnvelope(double xmin, 
-                                                double ymin, 
+  OGRGeometryShadow *CreateGeometryFromEnvelope(double xmin,
+                                                double ymin,
                                                 double xmax,
                                                 double ymax,
                                                 OSRSpatialReferenceShadow *reference = nullptr) {
@@ -3804,6 +3804,12 @@ public:
 #endif
   OGRGeometryShadow* DelaunayTriangulation(double dfTolerance = 0.0, int bOnlyEdges = FALSE) {
     return (OGRGeometryShadow*) OGR_G_DelaunayTriangulation(self, dfTolerance, bOnlyEdges);
+  }
+
+  /* OGR >= 3.12 */
+  %newobject ConstrainedDelaunayTriangulation;
+  OGRGeometryShadow* ConstrainedDelaunayTriangulation() {
+    return (OGRGeometryShadow*) OGR_G_ConstrainedDelaunayTriangulation(self);
   }
 
   %newobject Polygonize;

--- a/swig/include/python/docs/ogr_geometry_docs.i
+++ b/swig/include/python/docs/ogr_geometry_docs.i
@@ -864,6 +864,22 @@ Geometry:
     error occurs.
 ";
 
+%feature("docstring")  ConstrainedDelaunayTriangulation "
+Return a constrained Delaunay triangulation of the vertices of the given
+polygon(s). For non-polygonal inputs, silently returns an empty geometry
+collection.
+
+For more details: :cpp:func:`OGR_G_ConstrainedDelaunayTriangulation`
+
+.. versionadded:: 3.12
+
+Returns
+--------
+Geometry:
+    The geometry collection resulting from the constrained Delaunay
+    triangulation or None if an error occurs.
+";
+
 %feature("docstring")  Polygonize "
 Polygonizes a set of sparse edges.
 


### PR DESCRIPTION
Adds `OGRGeometry::ConstrainedDelaunayTriangulation()` / `OGR_G_ConstrainedDelaunayTriangulation()` and maps it to SWIG.

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
