### PR TITLE
GDALInfo(): fix crash on datasets not linked to a driver

### DIFF
--- a/apps/gdalinfo_lib.cpp
+++ b/apps/gdalinfo_lib.cpp
@@ -428,10 +428,6 @@ char *GDALInfo(GDALDatasetH hDataset, const GDALInfoOptions *psOptions)
     {
         json_object *poDescription =
             json_object_new_string(GDALGetDescription(hDataset));
-        json_object *poDriverShortName =
-            json_object_new_string(GDALGetDriverShortName(hDriver));
-        json_object *poDriverLongName =
-            json_object_new_string(GDALGetDriverLongName(hDriver));
         poJsonObject = json_object_new_object();
         poBands = json_object_new_array();
         poMetadata = json_object_new_object();
@@ -440,12 +436,19 @@ char *GDALInfo(GDALDatasetH hDataset, const GDALInfoOptions *psOptions)
         poStacEOBands = json_object_new_array();
 
         json_object_object_add(poJsonObject, "description", poDescription);
-        json_object_object_add(poJsonObject, "driverShortName",
-                               poDriverShortName);
-        json_object_object_add(poJsonObject, "driverLongName",
-                               poDriverLongName);
+        if (hDriver)
+        {
+            json_object *poDriverShortName =
+                json_object_new_string(GDALGetDriverShortName(hDriver));
+            json_object *poDriverLongName =
+                json_object_new_string(GDALGetDriverLongName(hDriver));
+            json_object_object_add(poJsonObject, "driverShortName",
+                                   poDriverShortName);
+            json_object_object_add(poJsonObject, "driverLongName",
+                                   poDriverLongName);
+        }
     }
-    else
+    else if (hDriver)
     {
         Concat(osStr, psOptions->bStdoutOutput, "Driver: %s/%s\n",
                GDALGetDriverShortName(hDriver), GDALGetDriverLongName(hDriver));
@@ -456,7 +459,8 @@ char *GDALInfo(GDALDatasetH hDataset, const GDALInfoOptions *psOptions)
         // The list of files of a raster FileGDB is not super useful and potentially
         // super long, so omit it, unless the -json mode is enabled
         char **papszFileList =
-            (!bJson && EQUAL(GDALGetDriverShortName(hDriver), "OpenFileGDB"))
+            (!bJson && hDriver &&
+             EQUAL(GDALGetDriverShortName(hDriver), "OpenFileGDB"))
                 ? nullptr
                 : GDALGetFileList(hDataset);
 

--- a/autotest/utilities/test_gdalinfo_lib.py
+++ b/autotest/utilities/test_gdalinfo_lib.py
@@ -362,3 +362,15 @@ def test_gdalinfo_lib_json_color_table_and_rat():
     assert "rat" in ret["bands"][0]
 
     gdaltest.validate_json(ret, "gdalinfo_output.schema.json")
+
+
+###############################################################################
+
+
+def test_gdalinfo_lib_no_driver():
+
+    ds = gdal.Open("../gcore/data/byte.tif")
+    ds2 = ds.GetRasterBand(1).AsMDArray().AsClassicDataset(0, 1)
+    assert ds2.GetDriver() is None
+    gdal.Info(ds2)
+    gdal.Info(ds2, format="json")


### PR DESCRIPTION
Fixes #13106
