### PR TITLE
[Backport release/3.11] ESRIJSON: recognize esriFieldTypeDateOnly, esriFieldTypeTimeOnly, esriFieldTypeBigInteger, esriFieldTypeGUID and esriFieldTypeGlobalID data types

### DIFF
--- a/autotest/ogr/data/esrijson/esripoint.json
+++ b/autotest/ogr/data/esrijson/esripoint.json
@@ -44,6 +44,31 @@
       "alias": "fooDate",
       "type": "esriFieldTypeDate",
       "length": 8
+    },
+    {
+      "name": "fooDateOnly",
+      "alias": "fooDateOnly",
+      "type": "esriFieldTypeDateOnly",
+    },
+    {
+      "name": "fooTimeOnly",
+      "alias": "fooTimeOnly",
+      "type": "esriFieldTypeTimeOnly",
+    },
+    {
+      "name": "fooBigInteger",
+      "alias": "fooBigInteger",
+      "type": "esriFieldTypeBigInteger",
+    },
+    {
+      "name": "fooGUID",
+      "alias": "fooGUID",
+      "type": "esriFieldTypeGUID",
+    },
+    {
+      "name": "fooGlobalID",
+      "alias": "fooGlobalID",
+      "type": "esriFieldTypeGlobalID",
     }
   ],
   "features" : [
@@ -59,7 +84,12 @@
         "fooSingle" : 1.5,
         "fooDouble" : 3.4,
         "fooString" : "56",
-        "fooDate": 1640908800000
+        "fooDate": 1640908800000,
+        "fooDateOnly": "2025-09-20",
+        "fooTimeOnly": "12:34:56",
+        "fooBigInteger": 1234567890123456,
+        "fooGlobalID": "{FD04C39C-69C6-4DCC-88D6-7E3E673DD0CB}",
+        "fooGUID": "{3BFE6840-A9E6-432A-AD34-B2067C8A276F}"
       }
     }
   ]

--- a/autotest/ogr/ogr_esrijson.py
+++ b/autotest/ogr/ogr_esrijson.py
@@ -81,7 +81,7 @@ def test_ogr_esrijson_read_point():
 
     extent = (2, 2, 49, 49)
 
-    rc = validate_layer(lyr, "esripoint", 1, ogr.wkbPoint, 7, extent)
+    rc = validate_layer(lyr, "esripoint", 1, ogr.wkbPoint, 12, extent)
     assert rc
 
     layer_defn = lyr.GetLayerDefn()
@@ -102,12 +102,47 @@ def test_ogr_esrijson_read_point():
     ogrtest.check_feature_geometry(feature, "POINT(2 49)")
 
     assert feature.GetFID() == 1
+    assert (
+        lyr.GetLayerDefn()
+        .GetFieldDefn(lyr.GetLayerDefn().GetFieldIndex("fooSmallInt"))
+        .GetSubType()
+        == ogr.OFSTInt16
+    )
     assert feature["fooSmallInt"] == 2
     assert feature["fooInt"] == 1234567890
+    assert (
+        lyr.GetLayerDefn()
+        .GetFieldDefn(lyr.GetLayerDefn().GetFieldIndex("fooSingle"))
+        .GetSubType()
+        == ogr.OFSTFloat32
+    )
     assert feature["fooSingle"] == 1.5
     assert feature["fooDouble"] == 3.4
     assert feature["fooString"] == "56"
     assert feature["fooDate"] == "2021/12/31 00:00:00+00"
+    assert feature["fooDateOnly"] == "2025/09/20"
+    assert (
+        lyr.GetLayerDefn()
+        .GetFieldDefn(lyr.GetLayerDefn().GetFieldIndex("fooTimeOnly"))
+        .GetType()
+        == ogr.OFTTime
+    )
+    assert feature["fooTimeOnly"] == "12:34:56"
+    assert feature["fooBigInteger"] == 1234567890123456
+    assert (
+        lyr.GetLayerDefn()
+        .GetFieldDefn(lyr.GetLayerDefn().GetFieldIndex("fooGlobalID"))
+        .GetSubType()
+        == ogr.OFSTUUID
+    )
+    assert feature["fooGlobalID"] == "{FD04C39C-69C6-4DCC-88D6-7E3E673DD0CB}"
+    assert (
+        lyr.GetLayerDefn()
+        .GetFieldDefn(lyr.GetLayerDefn().GetFieldIndex("fooGUID"))
+        .GetSubType()
+        == ogr.OFSTUUID
+    )
+    assert feature["fooGUID"] == "{3BFE6840-A9E6-432A-AD34-B2067C8A276F}"
 
     lyr = None
     ds = None

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonutils.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonutils.cpp
@@ -22,11 +22,12 @@
 #include <algorithm>
 #include <memory>
 
-const char szESRIJSonFeaturesGeometryRings[] =
-    "{\"features\":[{\"geometry\":{\"rings\":[";
+constexpr const char szESRIJSonFeaturesGeometryRings[] =
+    "\"features\":[{\"geometry\":{\"rings\":[";
 
 // Cf https://github.com/OSGeo/gdal/issues/9996#issuecomment-2129845692
-const char szESRIJSonFeaturesAttributes[] = "{\"features\":[{\"attributes\":{";
+constexpr const char szESRIJSonFeaturesAttributes[] =
+    "\"features\":[{\"attributes\":{";
 
 /************************************************************************/
 /*                           SkipUTF8BOM()                              */
@@ -227,8 +228,9 @@ static bool IsGeoJSONLikeObject(const char *pszText, bool &bMightBeSequence,
 
     const std::string osWithoutSpace = GetCompactJSon(pszText, strlen(pszText));
     if (osWithoutSpace.find("{\"features\":[") == 0 &&
-        osWithoutSpace.find(szESRIJSonFeaturesGeometryRings) != 0 &&
-        osWithoutSpace.find(szESRIJSonFeaturesAttributes) != 0)
+        osWithoutSpace.find(szESRIJSonFeaturesGeometryRings) ==
+            std::string::npos &&
+        osWithoutSpace.find(szESRIJSonFeaturesAttributes) == std::string::npos)
     {
         return true;
     }
@@ -329,8 +331,10 @@ bool ESRIJSONIsObject(const char *pszText, GDALOpenInfo *poOpenInfo)
     }
 
     const std::string osWithoutSpace = GetCompactJSon(pszText, strlen(pszText));
-    if (osWithoutSpace.find(szESRIJSonFeaturesGeometryRings) == 0 ||
-        osWithoutSpace.find(szESRIJSonFeaturesAttributes) == 0 ||
+    if (osWithoutSpace.find(szESRIJSonFeaturesGeometryRings) !=
+            std::string::npos ||
+        osWithoutSpace.find(szESRIJSonFeaturesAttributes) !=
+            std::string::npos ||
         osWithoutSpace.find("\"spatialReference\":{\"wkid\":") !=
             std::string::npos)
     {


### PR DESCRIPTION
Backport #13102
 **Authored by:** @rouault