### PR TITLE
GDALAlgorithm: re-arrange argument validation so that 'gdal raster create --bbox=' doesn't crash

### DIFF
--- a/autotest/cpp/test_gdal_algorithm.cpp
+++ b/autotest/cpp/test_gdal_algorithm.cpp
@@ -2953,8 +2953,8 @@ TEST_F(test_gdal_algorithm, min_max_count_equal)
 
     {
         MyAlgorithm alg;
-        alg.GetArg("arg")->Set(std::vector<std::string>{"foo"});
         CPLErrorStateBackuper oBackuper(CPLQuietErrorHandler);
+        EXPECT_FALSE(alg.GetArg("arg")->Set(std::vector<std::string>{"foo"}));
         EXPECT_FALSE(alg.ValidateArguments());
         EXPECT_STREQ(CPLGetLastErrorMsg(),
                      "test: 1 value has been specified for argument 'arg', "

--- a/autotest/gcore/algorithm.py
+++ b/autotest/gcore/algorithm.py
@@ -458,7 +458,10 @@ def test_algorithm_arg_set_dataset_list(tmp_path):
     alg["input"] = [tmp_path]
     alg["input"] = ["foo"]
     alg["input"] = [gdal.GetDriverByName("MEM").Create("", 1, 1)]
-    alg["input"] = []
+    with pytest.raises(
+        RuntimeError, match="Only 0 value has been specified for argument 'input'"
+    ):
+        alg["input"] = []
     alg["input"] = ["foo", "bar"]
 
     with pytest.raises(TypeError):

--- a/autotest/utilities/test_gdalalg_raster_create.py
+++ b/autotest/utilities/test_gdalalg_raster_create.py
@@ -454,7 +454,7 @@ def test_gdalalg_raster_create_driver_not_available():
     drv = gdal.GetDriverByName("MEM")
     drv.Deregister()
     try:
-        with pytest.raises(Exception, match="Cannot find driver MEM"):
+        with pytest.raises(Exception, match="Driver 'MEM' does not exist"):
             alg.Run()
     finally:
         drv.Register()
@@ -497,4 +497,22 @@ def test_gdalalg_raster_set_bbox_failed(tmp_vsimem):
     alg["size"] = [1, 1]
 
     with pytest.raises(Exception, match="Setting extent failed"):
+        alg.Run()
+
+
+def test_gdalalg_raster_create_empty_bbox():
+
+    alg = get_alg()
+    alg["output-format"] = "MEM"
+    with pytest.raises(
+        Exception,
+        match="0 value has been specified for argument 'bbox', whereas exactly 4 were expected",
+    ):
+        alg["bbox"] = []
+    alg["size"] = [1, 1]
+
+    with pytest.raises(
+        Exception,
+        match="0 value has been specified for argument 'bbox', whereas exactly 4 were expected",
+    ):
         alg.Run()

--- a/autotest/utilities/test_gdalalg_vector_layer_algebra.py
+++ b/autotest/utilities/test_gdalalg_vector_layer_algebra.py
@@ -387,7 +387,7 @@ def test_gdal_vector_layer_algebra_output_driver_not_existing(tmp_vsimem):
     drv = gdal.GetDriverByName("ESRI Shapefile")
     drv.Deregister()
     try:
-        with pytest.raises(Exception, match="Driver ESRI Shapefile does not exist"):
+        with pytest.raises(Exception, match="Driver 'ESRI Shapefile' does not exist"):
             alg.Run()
     finally:
         drv.Register()

--- a/gcore/gdalalgorithm.cpp
+++ b/gcore/gdalalgorithm.cpp
@@ -1028,13 +1028,92 @@ bool GDALAlgorithmArg::RunValidationActions()
             ret = ValidateRealRange(v) && ret;
     }
 
-    for (const auto &f : m_validationActions)
+    if (GDALAlgorithmArgTypeIsList(GetType()))
     {
-        if (!f())
+        int valueCount = 0;
+        if (GetType() == GAAT_STRING_LIST)
+        {
+            valueCount =
+                static_cast<int>(Get<std::vector<std::string>>().size());
+        }
+        else if (GetType() == GAAT_INTEGER_LIST)
+        {
+            valueCount = static_cast<int>(Get<std::vector<int>>().size());
+        }
+        else if (GetType() == GAAT_REAL_LIST)
+        {
+            valueCount = static_cast<int>(Get<std::vector<double>>().size());
+        }
+        else if (GetType() == GAAT_DATASET_LIST)
+        {
+            valueCount = static_cast<int>(
+                Get<std::vector<GDALArgDatasetValue>>().size());
+        }
+
+        if (valueCount != GetMinCount() && GetMinCount() == GetMaxCount())
+        {
+            ReportError(CE_Failure, CPLE_AppDefined,
+                        "%d value%s been specified for argument '%s', "
+                        "whereas exactly %d %s expected.",
+                        valueCount, valueCount > 1 ? "s have" : " has",
+                        GetName().c_str(), GetMinCount(),
+                        GetMinCount() > 1 ? "were" : "was");
             ret = false;
+        }
+        else if (valueCount < GetMinCount())
+        {
+            ReportError(CE_Failure, CPLE_AppDefined,
+                        "Only %d value%s been specified for argument '%s', "
+                        "whereas at least %d %s expected.",
+                        valueCount, valueCount > 1 ? "s have" : " has",
+                        GetName().c_str(), GetMinCount(),
+                        GetMinCount() > 1 ? "were" : "was");
+            ret = false;
+        }
+        else if (valueCount > GetMaxCount())
+        {
+            ReportError(CE_Failure, CPLE_AppDefined,
+                        "%d value%s been specified for argument '%s', "
+                        "whereas at most %d %s expected.",
+                        valueCount, valueCount > 1 ? "s have" : " has",
+                        GetName().c_str(), GetMaxCount(),
+                        GetMaxCount() > 1 ? "were" : "was");
+            ret = false;
+        }
+    }
+
+    if (ret)
+    {
+        for (const auto &f : m_validationActions)
+        {
+            if (!f())
+                ret = false;
+        }
     }
 
     return ret;
+}
+
+/************************************************************************/
+/*                    GDALAlgorithmArg::ReportError()                   */
+/************************************************************************/
+
+void GDALAlgorithmArg::ReportError(CPLErr eErrClass, CPLErrorNum err_no,
+                                   const char *fmt, ...) const
+{
+    va_list args;
+    va_start(args, fmt);
+    if (m_owner)
+    {
+        m_owner->ReportError(eErrClass, err_no, "%s",
+                             CPLString().vPrintf(fmt, args).c_str());
+    }
+    else
+    {
+        CPLError(eErrClass, err_no, "%s",
+                 CPLString().vPrintf(fmt, args).c_str());
+    }
+    va_end(args);
 }
 
 /************************************************************************/
@@ -2849,63 +2928,6 @@ bool GDALAlgorithm::ValidateArguments()
             if (!ProcessDatasetArg(arg.get(), this))
                 ret = false;
         }
-        else if (arg->IsExplicitlySet() &&
-                 GDALAlgorithmArgTypeIsList(arg->GetType()))
-        {
-            int valueCount = 0;
-            if (arg->GetType() == GAAT_STRING_LIST)
-            {
-                valueCount = static_cast<int>(
-                    arg->Get<std::vector<std::string>>().size());
-            }
-            else if (arg->GetType() == GAAT_INTEGER_LIST)
-            {
-                valueCount =
-                    static_cast<int>(arg->Get<std::vector<int>>().size());
-            }
-            else if (arg->GetType() == GAAT_REAL_LIST)
-            {
-                valueCount =
-                    static_cast<int>(arg->Get<std::vector<double>>().size());
-            }
-            else if (arg->GetType() == GAAT_DATASET_LIST)
-            {
-                valueCount = static_cast<int>(
-                    arg->Get<std::vector<GDALArgDatasetValue>>().size());
-            }
-
-            if (valueCount != arg->GetMinCount() &&
-                arg->GetMinCount() == arg->GetMaxCount())
-            {
-                ReportError(CE_Failure, CPLE_AppDefined,
-                            "%d value%s been specified for argument '%s', "
-                            "whereas exactly %d %s expected.",
-                            valueCount, valueCount > 1 ? "s have" : " has",
-                            arg->GetName().c_str(), arg->GetMinCount(),
-                            arg->GetMinCount() > 1 ? "were" : "was");
-                ret = false;
-            }
-            else if (valueCount < arg->GetMinCount())
-            {
-                ReportError(CE_Failure, CPLE_AppDefined,
-                            "Only %d value%s been specified for argument '%s', "
-                            "whereas at least %d %s expected.",
-                            valueCount, valueCount > 1 ? "s have" : " has",
-                            arg->GetName().c_str(), arg->GetMinCount(),
-                            arg->GetMinCount() > 1 ? "were" : "was");
-                ret = false;
-            }
-            else if (valueCount > arg->GetMaxCount())
-            {
-                ReportError(CE_Failure, CPLE_AppDefined,
-                            "%d value%s been specified for argument '%s', "
-                            "whereas at most %d %s expected.",
-                            valueCount, valueCount > 1 ? "s have" : " has",
-                            arg->GetName().c_str(), arg->GetMaxCount(),
-                            arg->GetMaxCount() > 1 ? "were" : "was");
-                ret = false;
-            }
-        }
 
         if (arg->IsExplicitlySet() && arg->GetType() == GAAT_DATASET_LIST &&
             arg->AutoOpenDataset())
@@ -2978,6 +3000,9 @@ bool GDALAlgorithm::ValidateArguments()
                 }
             }
         }
+
+        if (arg->IsExplicitlySet() && !arg->RunValidationActions())
+            ret = false;
     }
 
     for (const auto &f : m_validationActions)

--- a/gcore/gdalalgorithm.h
+++ b/gcore/gdalalgorithm.h
@@ -2003,6 +2003,9 @@ class CPL_DLL GDALAlgorithmArg /* non-final */
     bool ValidateIntRange(int val) const;
     bool ValidateRealRange(double val) const;
 
+    void ReportError(CPLErr eErrClass, CPLErrorNum err_no, const char *fmt,
+                     ...) const CPL_PRINT_FUNC_FORMAT(4, 5);
+
     CPL_DISALLOW_COPY_ASSIGN(GDALAlgorithmArg)
 };
 


### PR DESCRIPTION
Fixes #13112
