### PR TITLE
[Backport release/3.11] doc: fix default value for DXF_MERGE_BLOCK_GEOMETRIES

### DIFF
--- a/doc/source/drivers/vector/dxf.rst
+++ b/doc/source/drivers/vector/dxf.rst
@@ -104,7 +104,7 @@ The following entity types are supported:
 
    -  .. config:: DXF_MERGE_BLOCK_GEOMETRIES
          :choices: TRUE, FALSE
-         :default: FALSE
+         :default: TRUE
 
          To avoid merging blocks into a
          compound geometry the :config:`DXF_MERGE_BLOCK_GEOMETRIES` config option may


### PR DESCRIPTION
Backport #13124
 **Authored by:** @netthier