### PR TITLE
Fix typo in driver error message

### DIFF
--- a/gcore/gdalalgorithm.cpp
+++ b/gcore/gdalalgorithm.cpp
@@ -4151,7 +4151,7 @@ bool GDALAlgorithm::ValidateFormat(const GDALAlgorithmArg &arg,
                         GDALGetMessageAboutMissingPluginDriver(poMissingDriver);
                     ReportError(CE_Failure, CPLE_AppDefined,
                                 "Invalid value for argument '%s'. Driver '%s' "
-                                "not found but it known. However plugin %s",
+                                "not found but is known. However plugin %s",
                                 arg.GetName().c_str(), val.c_str(),
                                 msg.c_str());
                 }


### PR DESCRIPTION
"It" should be "is".
Noticed in error message:

```
ERROR 1: convert: Invalid value for argument 'output-format'. Driver 'parquet' not found but it known. However plugin ogr_Parquet.dll is not available in your installation. You may install it with 'conda install -c conda-forge libgdal-arrow-parquet'. The GDAL_DRIVER_PATH configuration option is not set.
```