### PR TITLE
Pipeline: in non-command line use cases, allow last step not to be a write step

### DIFF
--- a/apps/gdal.cpp
+++ b/apps/gdal.cpp
@@ -143,6 +143,8 @@ MAIN_START(argc, argv)
     // Register GDAL drivers
     GDALAllRegister();
 
+    alg->SetCalledFromCommandLine();
+
     if (bIsCompletion)
     {
         const bool bLastWordIsComplete =
@@ -218,8 +220,6 @@ MAIN_START(argc, argv)
         args.push_back(strcmp(argv[i], pszFormatReplaced) == 0 ? "--format"
                                                                : argv[i]);
     CSLDestroy(argv);
-
-    alg->SetCalledFromCommandLine();
 
     if (!alg->ParseCommandLineArguments(args))
     {

--- a/apps/gdalalg_abstract_pipeline.cpp
+++ b/apps/gdalalg_abstract_pipeline.cpp
@@ -129,7 +129,7 @@ bool GDALAbstractPipelineAlgorithm::CheckFirstAndLastStep(
     if (forAutoComplete)
         return true;
 
-    if (!m_bExpectWriteStep)
+    if (m_eLastStepAsWrite == StepConstraint::CAN_NOT_BE)
     {
         if (steps.back()->CanBeLastStep() && !steps.back()->CanBeMiddleStep())
         {
@@ -142,32 +142,42 @@ bool GDALAbstractPipelineAlgorithm::CheckFirstAndLastStep(
 
     for (size_t i = 1; i < steps.size() - 1; ++i)
     {
-        if (m_bExpectReadStep && steps[i]->CanBeFirstStep() &&
-            !steps[i]->CanBeMiddleStep())
+        if (!steps[i]->CanBeMiddleStep())
         {
-            ReportError(CE_Failure, CPLE_AppDefined,
-                        "Only first step can be '%s'",
-                        steps[i]->GetName().c_str());
-            return false;
-        }
-        else if (m_bExpectWriteStep && steps[i]->CanBeLastStep() &&
-                 !steps[i]->CanBeMiddleStep())
-        {
-            ReportError(CE_Failure, CPLE_AppDefined,
-                        "Only last step can be '%s'",
-                        steps[i]->GetName().c_str());
-            return false;
-        }
-        else if (!steps[i]->CanBeMiddleStep())
-        {
-            ReportError(CE_Failure, CPLE_AppDefined,
-                        "'%s' is not allowed as an intermediate step",
-                        steps[i]->GetName().c_str());
-            return false;
+            if (steps[i]->CanBeFirstStep() && m_bExpectReadStep)
+            {
+                ReportError(CE_Failure, CPLE_AppDefined,
+                            "Only first step can be '%s'",
+                            steps[i]->GetName().c_str());
+            }
+            else if (steps[i]->CanBeLastStep() &&
+                     m_eLastStepAsWrite != StepConstraint::CAN_NOT_BE)
+            {
+                ReportError(CE_Failure, CPLE_AppDefined,
+                            "Only last step can be '%s'",
+                            steps[i]->GetName().c_str());
+            }
+            else
+            {
+                ReportError(CE_Failure, CPLE_AppDefined,
+                            "'%s' is not allowed as an intermediate step",
+                            steps[i]->GetName().c_str());
+                return false;
+            }
         }
     }
 
-    if (m_bExpectWriteStep && !steps.back()->CanBeLastStep())
+    if (steps.size() >= 2 && steps.back()->CanBeFirstStep() &&
+        !steps.back()->CanBeLastStep())
+    {
+        ReportError(CE_Failure, CPLE_AppDefined,
+                    "'%s' is only allowed as a first step",
+                    steps.back()->GetName().c_str());
+        return false;
+    }
+
+    if (m_eLastStepAsWrite == StepConstraint::MUST_BE &&
+        !steps.back()->CanBeLastStep())
     {
         std::set<CPLString> setLastStepNames;
         for (const auto &stepName : GetStepRegistry().GetNames())
@@ -229,6 +239,11 @@ bool GDALAbstractPipelineAlgorithm::ParseCommandLineArguments(
     const std::vector<std::string> &argsIn, bool forAutoComplete)
 {
     std::vector<std::string> args = argsIn;
+
+    if (IsCalledFromCommandLine())
+    {
+        m_eLastStepAsWrite = StepConstraint::MUST_BE;
+    }
 
     if (args.size() == 1 && (args[0] == "-h" || args[0] == "--help" ||
                              args[0] == "help" || args[0] == "--json-usage"))
@@ -576,24 +591,7 @@ bool GDALAbstractPipelineAlgorithm::ParseCommandLineArguments(
     if (!steps.back().alg)
         steps.pop_back();
 
-    // Automatically add a final write step if none in m_executionForStreamOutput
-    // mode
-    if (m_executionForStreamOutput && m_bExpectWriteStep && !steps.empty() &&
-        steps.back().alg->GetName() !=
-            std::string(GDALRasterWriteAlgorithm::NAME)
-                .append(bIsGenericPipeline ? RASTER_SUFFIX : ""))
-    {
-        steps.resize(steps.size() + 1);
-        steps.back().alg =
-            GetStepAlg(std::string(GDALRasterWriteAlgorithm::NAME)
-                           .append(bIsGenericPipeline ? RASTER_SUFFIX : ""));
-        steps.back().args.push_back(
-            std::string("--").append(GDAL_ARG_NAME_OUTPUT_FORMAT));
-        steps.back().args.push_back("stream");
-        steps.back().args.push_back("streamed_dataset");
-    }
-
-    else if (runExistingPipeline)
+    if (runExistingPipeline)
     {
         // Add a final "write" step if there is no explicit allowed last step
         if (!steps.empty() && !steps.back().alg->CanBeLastStep())
@@ -641,7 +639,7 @@ bool GDALAbstractPipelineAlgorithm::ParseCommandLineArguments(
         }
     }
 
-    if (m_bExpectWriteStep)
+    if (m_eLastStepAsWrite == StepConstraint::MUST_BE)
     {
         if (!m_bExpectReadStep)
         {
@@ -649,7 +647,8 @@ bool GDALAbstractPipelineAlgorithm::ParseCommandLineArguments(
             {
                 ReportError(
                     CE_Failure, CPLE_AppDefined,
-                    "At least one step must be provided in an inner pipeline.");
+                    "At least one step must be provided in %s pipeline.",
+                    m_bInnerPipeline ? "an inner" : "a");
                 return false;
             }
         }
@@ -679,18 +678,20 @@ bool GDALAbstractPipelineAlgorithm::ParseCommandLineArguments(
     {
         if (steps.empty())
         {
-            ReportError(
-                CE_Failure, CPLE_AppDefined,
-                "At least one step must be provided in an inner pipeline.");
+            ReportError(CE_Failure, CPLE_AppDefined,
+                        "At least one step must be provided in %s pipeline.",
+                        m_bInnerPipeline ? "an inner" : "a");
             return false;
         }
 
-        if (steps.back().alg->CanBeLastStep() &&
+        if (m_eLastStepAsWrite == StepConstraint::CAN_NOT_BE &&
+            steps.back().alg->CanBeLastStep() &&
             !steps.back().alg->CanBeMiddleStep())
         {
             ReportError(CE_Failure, CPLE_AppDefined,
-                        "Last step in an inner pipeline must not be a "
-                        "write-like step.");
+                        "Last step in %s pipeline must not be a "
+                        "write-like step.",
+                        m_bInnerPipeline ? "an inner" : "a");
             return false;
         }
     }
@@ -750,7 +751,8 @@ bool GDALAbstractPipelineAlgorithm::ParseCommandLineArguments(
         }
     };
 
-    if (m_bExpectWriteStep && steps.back().alg->CanBeLastStep())
+    if (m_eLastStepAsWrite != StepConstraint::CAN_NOT_BE &&
+        steps.back().alg->CanBeLastStep())
     {
         SetWriteArgFromPipeline();
     }
@@ -1139,7 +1141,8 @@ bool GDALAbstractPipelineAlgorithm::ParseCommandLineArguments(
 
                 steps[i].alg = std::move(newAlg);
 
-                if (i == steps.size() - 1 && m_bExpectWriteStep)
+                if (i == steps.size() - 1 &&
+                    m_eLastStepAsWrite != StepConstraint::CAN_NOT_BE)
                 {
                     SetWriteArgFromPipeline();
                 }
@@ -1204,7 +1207,7 @@ std::string GDALAbstractPipelineAlgorithm::BuildNestedPipeline(
     if (curAlg->GetName() == GDALTeeStepAlgorithmAbstract::NAME)
         nestedPipeline->m_bExpectReadStep = false;
     else
-        nestedPipeline->m_bExpectWriteStep = false;
+        nestedPipeline->m_eLastStepAsWrite = StepConstraint::CAN_NOT_BE;
     nestedPipeline->m_executionForStreamOutput = m_executionForStreamOutput;
     nestedPipeline->SetReferencePathForRelativePaths(
         GetReferencePathForRelativePaths());

--- a/apps/gdalalg_abstract_pipeline.h
+++ b/apps/gdalalg_abstract_pipeline.h
@@ -347,12 +347,25 @@ class GDALAbstractPipelineAlgorithm CPL_NON_FINAL
     static constexpr const char *VECTOR_SUFFIX = "-vector";
 
   private:
+    friend class GDALPipelineAlgorithm;
+    friend class GDALRasterPipelineAlgorithm;
+    friend class GDALVectorPipelineAlgorithm;
+
     std::vector<std::unique_ptr<GDALPipelineStepAlgorithm>> m_steps{};
 
     std::unique_ptr<GDALPipelineStepAlgorithm> m_stepOnWhichHelpIsRequested{};
 
+    bool m_bInnerPipeline = false;
     bool m_bExpectReadStep = true;
-    bool m_bExpectWriteStep = true;
+
+    enum class StepConstraint
+    {
+        MUST_BE,
+        CAN_BE,
+        CAN_NOT_BE
+    };
+
+    StepConstraint m_eLastStepAsWrite = StepConstraint::CAN_BE;
 
     std::vector<std::unique_ptr<GDALAbstractPipelineAlgorithm>>
         m_apoNestedPipelines{};

--- a/apps/gdalalg_pipeline.cpp
+++ b/apps/gdalalg_pipeline.cpp
@@ -535,7 +535,9 @@ class GDALPipelineAlgorithm final : public GDALAbstractPipelineAlgorithm
     std::unique_ptr<GDALAbstractPipelineAlgorithm>
     CreateNestedPipeline() const override
     {
-        return std::make_unique<GDALPipelineAlgorithm>();
+        auto pipeline = std::make_unique<GDALPipelineAlgorithm>();
+        pipeline->m_bInnerPipeline = true;
+        return pipeline;
     }
 };
 

--- a/apps/gdalalg_raster_pipeline.h
+++ b/apps/gdalalg_raster_pipeline.h
@@ -169,7 +169,9 @@ class GDALRasterPipelineAlgorithm final : public GDALAbstractPipelineAlgorithm
     std::unique_ptr<GDALAbstractPipelineAlgorithm>
     CreateNestedPipeline() const override
     {
-        return std::make_unique<GDALRasterPipelineAlgorithm>();
+        auto pipeline = std::make_unique<GDALRasterPipelineAlgorithm>();
+        pipeline->m_bInnerPipeline = true;
+        return pipeline;
     }
 };
 

--- a/apps/gdalalg_vector_pipeline.h
+++ b/apps/gdalalg_vector_pipeline.h
@@ -148,7 +148,9 @@ class GDALVectorPipelineAlgorithm final : public GDALAbstractPipelineAlgorithm
     std::unique_ptr<GDALAbstractPipelineAlgorithm>
     CreateNestedPipeline() const override
     {
-        return std::make_unique<GDALVectorPipelineAlgorithm>();
+        auto pipeline = std::make_unique<GDALVectorPipelineAlgorithm>();
+        pipeline->m_bInnerPipeline = true;
+        return pipeline;
     }
 };
 

--- a/autotest/utilities/test_gdalalg_pipeline.py
+++ b/autotest/utilities/test_gdalalg_pipeline.py
@@ -108,7 +108,7 @@ def test_gdalalg_pipeline_read_and_write_raster_from_object():
         input=src_ds,
         output_format="MEM",
         output="",
-        pipeline="read ! write",
+        pipeline="read",
     ) as alg:
         assert alg.Output().GetRasterBand(1).Checksum() == 4672
 
@@ -159,12 +159,6 @@ def test_gdalalg_pipeline_errors():
 
     with pytest.raises(Exception, match="pipeline: unknown step name: foo"):
         gdal.Run("pipeline", pipeline="foo")
-
-    with pytest.raises(Exception, match="pipeline: At least 2 steps must be provided"):
-        gdal.Run("pipeline", pipeline="read ../gcore/data/byte.tif")
-
-    with pytest.raises(Exception, match="pipeline: Last step should be 'write'"):
-        gdal.Run("pipeline", pipeline="read ../gcore/data/byte.tif ! reproject")
 
     with pytest.raises(Exception, match="read: Option '--bar' is unknown"):
         gdal.Run("pipeline", pipeline="read ../gcore/data/byte.tif --bar ! write")
@@ -229,6 +223,11 @@ def gdal_path():
 
 
 def test_gdalalg_pipeline_command_line(gdal_path, tmp_path):
+
+    _, err = gdaltest.runexternal_out_and_err(
+        f"{gdal_path} pipeline read ../gcore/data/byte.tif"
+    )
+    assert "pipeline: At least 2 steps must be provided" in err
 
     out = gdaltest.runexternal(
         f"{gdal_path} pipeline --progress read ../gcore/data/byte.tif ! write {tmp_path}/out.tif"

--- a/autotest/utilities/test_gdalalg_raster_pipeline.py
+++ b/autotest/utilities/test_gdalalg_raster_pipeline.py
@@ -124,9 +124,10 @@ def test_gdalalg_raster_pipeline_output_through_api(tmp_vsimem):
 def test_gdalalg_raster_pipeline_as_api_error():
 
     pipeline = get_pipeline_alg()
-    pipeline["pipeline"] = "read"
-    with pytest.raises(Exception, match="pipeline: At least 2 steps must be provided"):
-        pipeline.Run()
+    pipeline["pipeline"] = "read ../gcore/data/byte.tif"
+    pipeline.Run()
+    ds = pipeline.Output()
+    assert ds.GetRasterBand(1).Checksum() == 4672
 
 
 def test_gdalalg_raster_pipeline_mutually_exclusive_args():
@@ -264,7 +265,9 @@ def test_gdalalg_raster_pipeline_missing_at_run():
 def test_gdalalg_raster_pipeline_empty_args():
 
     pipeline = get_pipeline_alg()
-    with pytest.raises(Exception, match="pipeline: At least 2 steps must be provided"):
+    with pytest.raises(
+        Exception, match="At least one step must be provided in a pipeline"
+    ):
         pipeline.ParseRunAndFinalize([])
 
 
@@ -288,7 +291,9 @@ def test_gdalalg_raster_pipeline_unknow_step():
 def test_gdalalg_raster_pipeline_read_read():
 
     pipeline = get_pipeline_alg()
-    with pytest.raises(Exception, match="pipeline: Last step should be 'write'"):
+    with pytest.raises(
+        Exception, match="pipeline: 'read' is only allowed as a first step"
+    ):
         pipeline.ParseRunAndFinalize(
             ["read", "../gcore/data/byte.tif", "!", "read", "../gcore/data/byte.tif"]
         )
@@ -297,7 +302,10 @@ def test_gdalalg_raster_pipeline_read_read():
 def test_gdalalg_raster_pipeline_write_write():
 
     pipeline = get_pipeline_alg()
-    with pytest.raises(Exception, match="pipeline: First step should be 'read'"):
+    with pytest.raises(
+        Exception,
+        match="pipeline: First step should be 'read', 'calc', 'mosaic' or 'stack'",
+    ):
         pipeline.ParseRunAndFinalize(
             ["write", "/vsimem/out.tif", "!", "write", "/vsimem/out.tif"]
         )

--- a/autotest/utilities/test_gdalalg_vector_pipeline.py
+++ b/autotest/utilities/test_gdalalg_vector_pipeline.py
@@ -200,14 +200,6 @@ def test_gdalalg_vector_pipeline_output_through_api(tmp_vsimem):
         assert ds.GetLayer(0).GetFeatureCount() == 10
 
 
-def test_gdalalg_vector_pipeline_as_api_error():
-
-    pipeline = get_pipeline_alg()
-    pipeline["pipeline"] = "read"
-    with pytest.raises(Exception, match="pipeline: At least 2 steps must be provided"):
-        pipeline.Run()
-
-
 def test_gdalalg_vector_pipeline_mutually_exclusive_args():
 
     with pytest.raises(
@@ -343,7 +335,9 @@ def test_gdalalg_vector_pipeline_missing_at_run():
 def test_gdalalg_vector_pipeline_empty_args():
 
     pipeline = get_pipeline_alg()
-    with pytest.raises(Exception, match="pipeline: At least 2 steps must be provided"):
+    with pytest.raises(
+        Exception, match="pipeline: At least one step must be provided in a pipeline"
+    ):
         pipeline.ParseRunAndFinalize([])
 
 
@@ -367,7 +361,9 @@ def test_gdalalg_vector_pipeline_unknow_step():
 def test_gdalalg_vector_pipeline_read_read():
 
     pipeline = get_pipeline_alg()
-    with pytest.raises(Exception, match="pipeline: Last step should be 'write'"):
+    with pytest.raises(
+        Exception, match="pipeline: 'read' is only allowed as a first step"
+    ):
         pipeline.ParseRunAndFinalize(
             ["read", "../ogr/data/poly.shp", "!", "read", "../ogr/data/poly.shp"]
         )

--- a/doc/source/programs/gdal_cli_from_python.rst
+++ b/doc/source/programs/gdal_cli_from_python.rst
@@ -153,3 +153,19 @@ Vector commands examples
 
         gdal.UseExceptions()
         gdal.Run("vector", "convert", input="in.shp", output="out.gpkg", overwrite=True)
+
+
+Pipeline examples
+-----------------
+
+.. example::
+   :title: Perform raster reprojection and gets the result as a streamed dataset.
+
+   .. code-block:: python
+
+        from osgeo import gdal
+
+        gdal.UseExceptions()
+        with gdal.Run("pipeline", pipeline="read byte.tif ! reproject --dst-crs EPSG:4326 --resampling cubic") as alg:
+            ds = alg.Output()
+            # do something with the dataset

--- a/gcore/gdalalgorithm.cpp
+++ b/gcore/gdalalgorithm.cpp
@@ -6514,6 +6514,7 @@ GDALAlgorithm::GetAutoComplete(std::vector<std::string> &args,
     }
     if (curAlg != this)
     {
+        curAlg->m_calledFromCommandLine = m_calledFromCommandLine;
         return curAlg->GetAutoComplete(args, lastWordIsComplete,
                                        /* showAllOptions = */ false);
     }


### PR DESCRIPTION
Previously one had to insert a "! write --format=streamed streamed_dataset" final step to get a non-materialized dataset. Now it is no longer required, unless the pipeline is invoked from the 'gdal' binary itself.
