### PR TITLE
Pipeline: merge change-field-type steps immediately following open to create a OGR_SCHEMA

### DIFF
--- a/apps/gdalalg_abstract_pipeline.h
+++ b/apps/gdalalg_abstract_pipeline.h
@@ -15,6 +15,8 @@
 
 //! @cond Doxygen_Suppress
 
+#include "cpl_json.h"
+
 #include "gdalalgorithm.h"
 #include "gdal_priv.h"
 
@@ -251,6 +253,13 @@ class GDALPipelineStepAlgorithm /* non final */ : public GDALAlgorithm
         return false;
     }
 
+    virtual CPLJSONObject Get_OGR_SCHEMA_OpenOption_Layer() const
+    {
+        CPLJSONObject obj;
+        obj.Deinit();
+        return obj;
+    }
+
     virtual bool RunStep(GDALPipelineStepRunContext &ctxt) = 0;
 
     bool m_standaloneStep = false;
@@ -323,8 +332,10 @@ class GDALAbstractPipelineAlgorithm CPL_NON_FINAL
     GDALAbstractPipelineAlgorithm(
         const std::string &name, const std::string &description,
         const std::string &helpURL,
-        const typename GDALPipelineStepAlgorithm::ConstructorOptions &options)
-        : GDALPipelineStepAlgorithm(name, description, helpURL, options)
+        const GDALPipelineStepAlgorithm::ConstructorOptions &options)
+        : GDALPipelineStepAlgorithm(
+              name, description, helpURL,
+              ConstructorOptions(options).SetAutoOpenInputDatasets(false))
     {
     }
 

--- a/apps/gdalalg_vector_change_field_type.cpp
+++ b/apps/gdalalg_vector_change_field_type.cpp
@@ -48,6 +48,39 @@ GDALVectorChangeFieldTypeAlgorithm::GDALVectorChangeFieldTypeAlgorithm(
 }
 
 /************************************************************************/
+/*                     Get_OGR_SCHEMA_OpenOption_Layer()                */
+/************************************************************************/
+
+CPLJSONObject
+GDALVectorChangeFieldTypeAlgorithm::Get_OGR_SCHEMA_OpenOption_Layer() const
+{
+    CPLJSONObject oLayer;
+    oLayer.Set("name", m_activeLayer.empty() ? "*" : m_activeLayer);
+    oLayer.Set("schemaType", "Patch");
+    CPLJSONArray oFields;
+    CPLJSONObject oField;
+    if (m_fieldName.empty())
+    {
+        oField.Set("srcType", OGRFieldDefn::GetFieldTypeName(m_srcFieldType));
+        oField.Set("srcSubType",
+                   OGRFieldDefn::GetFieldSubTypeName(m_srcFieldSubType));
+    }
+    else
+    {
+        oField.Set("name", m_fieldName);
+    }
+    if (!m_newFieldTypeSubTypeStr.empty())
+    {
+        oField.Set("type", OGRFieldDefn::GetFieldTypeName(m_newFieldType));
+        oField.Set("subType",
+                   OGRFieldDefn::GetFieldSubTypeName(m_newFieldSubType));
+    }
+    oFields.Add(oField);
+    oLayer.Set("fields", oFields);
+    return oLayer;
+}
+
+/************************************************************************/
 /*                            GlobalValidation()                        */
 /************************************************************************/
 

--- a/apps/gdalalg_vector_change_field_type.h
+++ b/apps/gdalalg_vector_change_field_type.h
@@ -33,10 +33,13 @@ class GDALVectorChangeFieldTypeAlgorithm /* non final */
 
     explicit GDALVectorChangeFieldTypeAlgorithm(bool standaloneStep = false);
 
+    CPLJSONObject Get_OGR_SCHEMA_OpenOption_Layer() const override;
+
   private:
     bool RunStep(GDALPipelineStepRunContext &ctxt) override;
     bool GlobalValidation() const;
 
+    // NOTE: if adding any option, please update Get_OGR_SCHEMA_OpenOption_Layer() */
     std::string m_activeLayer{};
     std::string m_fieldName{};
     OGRFieldType m_srcFieldType{OGRFieldType::OFTString};
@@ -45,6 +48,7 @@ class GDALVectorChangeFieldTypeAlgorithm /* non final */
     OGRFieldType m_newFieldType{OGRFieldType::OFTString};
     OGRFieldSubType m_newFieldSubType{OGRFieldSubType::OFSTNone};
     std::string m_newFieldTypeSubTypeStr{};
+    // NOTE: if adding any option, please update Get_OGR_SCHEMA_OpenOption_Layer() */
 };
 
 /************************************************************************/

--- a/autotest/ogr/ogr_csv.py
+++ b/autotest/ogr/ogr_csv.py
@@ -3245,12 +3245,12 @@ def test_ogr_csv_invalid_wkt(tmp_vsimem):
         # Override full schema and JSON subtype
         (
             [
-                r'OGR_SCHEMA={ "layers": [{"name": "test_point", "schemaType": "Full", "fields": [{ "name": "json_str", "subType": "JSON", "new_name": "json_str" }]}]}'
+                r'OGR_SCHEMA={ "layers": [{"name": "test_point", "schemaType": "Full", "fields": [{ "name": "json_str", "subType": "JSON", "newName": "renamed_json_str" }]}]}'
             ],
             [
                 (ogr.OFTString, ogr.OFSTJSON),  # json subType
             ],
-            ["json_str"],
+            ["renamed_json_str"],
             None,
         ),
         # Test width and precision override
@@ -3285,6 +3285,24 @@ def test_ogr_csv_invalid_wkt(tmp_vsimem):
                 ogr.OFTString,  # real string
                 ogr.OFTString,  # json subType
                 ogr.OFTString,  # uuid subType
+            ],
+            [],
+            None,
+        ),
+        # Test srcType matching
+        (
+            [
+                r'OGR_SCHEMA={ "layers": [{"name": "*", "schemaType": "Patch", "fields": [{ "srcType": "String", "type": "DateTime"}]}]}'
+            ],
+            [
+                ogr.OFTDateTime,
+                ogr.OFTInteger,
+                ogr.OFTReal,
+                ogr.OFTInteger,
+                ogr.OFTDateTime,
+                ogr.OFTDateTime,
+                ogr.OFTDateTime,
+                ogr.OFTDateTime,
             ],
             [],
             None,
@@ -3408,7 +3426,13 @@ def test_ogr_csv_schema_override(
                         if int_sub_type == ogr.OFSTBoolean
                         else 2
                     )
-                if "str" in expected_field_names:
+                if (
+                    "str" in expected_field_names
+                    and feat.GetFieldDefnRef(
+                        lyr.GetLayerDefn().GetFieldIndex("str")
+                    ).GetType()
+                    == ogr.OFTString
+                ):
                     assert feat.GetFieldAsString("str") == "1"
                 if "new_str" in expected_field_names:
                     assert feat.GetFieldAsString("new_str") == "1"

--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -4388,10 +4388,10 @@ def test_ogr_geojson_ogr2ogr_nln_with_input_dataset_having_name(tmp_vsimem):
     gdal.VectorTranslate(
         filename,
         '{"type":"FeatureCollection","name":"to_be_overriden","features":[]}',
-        layerName="new_name",
+        layerName="newName",
     )
     ds = ogr.Open(filename)
-    assert ds.GetLayer(0).GetName() == "new_name"
+    assert ds.GetLayer(0).GetName() == "newName"
     ds = None
 
 
@@ -5591,7 +5591,7 @@ def test_ogr_geojson_force_opening_stacta():
         # Override full schema and JSON/UUID subtype
         (
             [
-                r'OGR_SCHEMA={ "layers": [{"name": "test_point", "schemaType": "Full", "fields": [{ "name": "json_str", "subType": "JSON", "new_name": "json_str" }, {"name": "uuid_str", "subType": "UUID" }]}]}'
+                r'OGR_SCHEMA={ "layers": [{"name": "test_point", "schemaType": "Full", "fields": [{ "name": "json_str", "subType": "JSON", "newName": "json_str" }, {"name": "uuid_str", "subType": "UUID" }]}]}'
             ],
             [
                 (ogr.OFTString, ogr.OFSTJSON),  # json subType
@@ -5666,7 +5666,7 @@ def test_ogr_geojson_force_opening_stacta():
         # Test invalid field name
         (
             [
-                r'OGR_SCHEMA={ "layers": [{"name": "test_point", "fields": [{ "name": "xxxxx", "type": "String", "new_name": "new_str" }]}]}'
+                r'OGR_SCHEMA={ "layers": [{"name": "test_point", "fields": [{ "name": "xxxxx", "type": "String", "newName": "new_str" }]}]}'
             ],
             [],
             [],

--- a/autotest/ogr/ogr_sqlite.py
+++ b/autotest/ogr/ogr_sqlite.py
@@ -4310,7 +4310,7 @@ def test_ogr_sqlite_run_deferred_actions_before_start_transaction():
         # Override full schema and JSON/UUID subtype
         (
             [
-                r'OGR_SCHEMA={ "layers": [{"name": "test_point", "schemaType": "Full", "fields": [{ "name": "json_str", "subType": "JSON", "new_name": "json_str" }, {"name": "uuid_str", "subType": "UUID" }]}]}'
+                r'OGR_SCHEMA={ "layers": [{"name": "test_point", "schemaType": "Full", "fields": [{ "name": "json_str", "subType": "JSON", "newName": "json_str" }, {"name": "uuid_str", "subType": "UUID" }]}]}'
             ],
             [
                 (ogr.OFTString, ogr.OFSTJSON),  # json subType
@@ -4385,7 +4385,7 @@ def test_ogr_sqlite_run_deferred_actions_before_start_transaction():
         # Test invalid field name
         (
             [
-                r'OGR_SCHEMA={ "layers": [{"name": "test_point", "fields": [{ "name": "xxxxx", "type": "String", "new_name": "new_str" }]}]}'
+                r'OGR_SCHEMA={ "layers": [{"name": "test_point", "fields": [{ "name": "xxxxx", "type": "String", "newName": "new_str" }]}]}'
             ],
             [],
             [],

--- a/frmts/xyz/xyzdataset.cpp
+++ b/frmts/xyz/xyzdataset.cpp
@@ -1426,7 +1426,12 @@ GDALDataset *XYZDataset::Open(GDALOpenInfo *poOpenInfo)
 
     if (adfStepX.size() != 1 || adfStepX[0] == 0)
     {
-        CPLError(CE_Failure, CPLE_AppDefined, "Couldn't determine X spacing");
+        if (!((poOpenInfo->nOpenFlags & GDAL_OF_VECTOR) != 0 &&
+              poOpenInfo->IsExtensionEqualToCI("CSV")))
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Couldn't determine X spacing");
+        }
         VSIFCloseL(fp);
         return nullptr;
     }

--- a/ogr/data/ogr_fields_override.schema.json
+++ b/ogr/data/ogr_fields_override.schema.json
@@ -33,7 +33,7 @@
       "type": "object",
       "properties": {
         "name": {
-          "description": "The name of the layer",
+          "description": "The name of the layer. Can be '*' to apply to any layer.",
           "type": "string"
         },
         "schemaType": {
@@ -56,44 +56,56 @@
     },
     "field": {
       "description": "The field definition",
-      "additionalProperties": true,
       "type": "object",
       "properties": {
         "name": {
+          "type": "string"
+        },
+        "srcType": {
+          "$ref": "#/definitions/fieldType"
+        },
+        "srcSubType": {
+          "$ref": "#/definitions/fieldSubType"
+        },
+        "type": {
+          "$ref": "#/definitions/fieldType"
+        },
+        "subType": {
+          "$ref": "#/definitions/fieldSubType"
+        },
+        "width": {
+          "type": "integer"
+        },
+        "precision": {
+          "type": "integer"
+        },
+        "newName": {
+          "description": "The new name of the field",
           "type": "string"
         }
       },
       "anyOf": [
         {
-          "type": "object",
-          "properties": {
-            "type": {
-              "$ref": "#/definitions/fieldType"
-            },
-            "subType": {
-              "$ref": "#/definitions/fieldSubType"
-            },
-            "width": {
-              "type": "integer"
-            },
-            "precision": {
-              "type": "integer"
-            }
-          }
+          "required": [
+            "name"
+          ]
         },
         {
-          "description": "The new name of the field",
-          "newName": {
-            "type": "string"
-          },
-          "required": [
-            "newName"
+          "anyOf": [
+            {
+              "required": [
+                "srcType"
+              ]
+            },
+            {
+              "required": [
+                "srcSubType"
+              ]
+            }
           ]
         }
       ],
-      "required": [
-        "name"
-      ]
+      "additionalProperties": false
     },
     "fieldType": {
       "enum": [

--- a/ogr/ogr_schema_override.cpp
+++ b/ogr/ogr_schema_override.cpp
@@ -12,6 +12,7 @@
 //! @cond Doxygen_Suppress
 
 #include "ogr_schema_override.h"
+#include "ogrsf_frmts.h"
 
 bool OGRSchemaOverride::LoadFromJSON(const std::string &osJSON)
 {
@@ -60,14 +61,14 @@ bool OGRSchemaOverride::LoadFromJSON(const std::string &osJSON)
                         for (const auto &oField : oLayerFields)
                         {
                             const auto osFieldName = oField.GetString("name");
-                            if (osFieldName.empty())
-                            {
-                                CPLError(CE_Warning, CPLE_AppDefined,
-                                         "Field name is missing");
-                                return false;
-                            }
                             OGRFieldDefnOverride oFieldOverride;
 
+                            const CPLString oSrcType(
+                                CPLString(oField.GetString("srcType"))
+                                    .tolower());
+                            const CPLString oSrcSubType(
+                                CPLString(oField.GetString("srcSubType"))
+                                    .tolower());
                             const CPLString oType(
                                 CPLString(oField.GetString("type")).tolower());
                             const CPLString oSubType(
@@ -83,6 +84,79 @@ bool OGRSchemaOverride::LoadFromJSON(const std::string &osJSON)
                             if (!osNewName.empty())
                             {
                                 oFieldOverride.SetFieldName(osNewName);
+                            }
+
+                            if (!oSrcType.empty())
+                            {
+                                if (bSchemaFullOverride)
+                                {
+                                    CPLError(CE_Failure, CPLE_AppDefined,
+                                             "Non-patch OGR_SCHEMA definition "
+                                             "is not allowed with specifying "
+                                             "source field type");
+                                    return false;
+                                }
+                                if (!osFieldName.empty() || !osNewName.empty())
+                                {
+                                    CPLError(CE_Warning, CPLE_AppDefined,
+                                             "Field name and source field type "
+                                             "are mutually exclusive");
+                                    return false;
+                                }
+                                const OGRFieldType eType =
+                                    OGRFieldDefn::GetFieldTypeByName(
+                                        oSrcType.c_str());
+                                // Check if the field type is valid
+                                if (eType == OFTString && oSrcType != "string")
+                                {
+                                    CPLError(CE_Failure, CPLE_AppDefined,
+                                             "Unsupported source field type: "
+                                             "%s",
+                                             oSrcType.c_str());
+                                    return false;
+                                }
+                                oFieldOverride.SetSrcFieldType(eType);
+                            }
+
+                            if (!oSrcSubType.empty())
+                            {
+                                if (bSchemaFullOverride)
+                                {
+                                    CPLError(CE_Failure, CPLE_AppDefined,
+                                             "Non-patch OGR_SCHEMA definition "
+                                             "is not allowed with specifying "
+                                             "source field subtype");
+                                    return false;
+                                }
+                                if (!osFieldName.empty() || !osNewName.empty())
+                                {
+                                    CPLError(CE_Warning, CPLE_AppDefined,
+                                             "Field name and source field "
+                                             "subtype are mutually exclusive");
+                                    return false;
+                                }
+                                const OGRFieldSubType eSubType =
+                                    OGRFieldDefn::GetFieldSubTypeByName(
+                                        oSubType.c_str());
+                                // Check if the field subType is valid
+                                if (eSubType == OFSTNone &&
+                                    oSrcSubType != "none")
+                                {
+                                    CPLError(CE_Failure, CPLE_AppDefined,
+                                             "Unsupported source field subType:"
+                                             " %s",
+                                             oSubType.c_str());
+                                    return false;
+                                }
+                                oFieldOverride.SetSrcFieldSubType(eSubType);
+                            }
+
+                            if (oSrcType.empty() && oSrcSubType.empty() &&
+                                osFieldName.empty())
+                            {
+                                CPLError(CE_Warning, CPLE_AppDefined,
+                                         "Field name is missing");
+                                return false;
                             }
 
                             if (!oType.empty())
@@ -133,8 +207,16 @@ bool OGRSchemaOverride::LoadFromJSON(const std::string &osJSON)
 
                             if (bSchemaFullOverride || oFieldOverride.IsValid())
                             {
-                                oLayerOverride.AddFieldOverride(osFieldName,
-                                                                oFieldOverride);
+                                if (osFieldName.empty())
+                                {
+                                    oLayerOverride.AddUnnamedFieldOverride(
+                                        oFieldOverride);
+                                }
+                                else
+                                {
+                                    oLayerOverride.AddNamedFieldOverride(
+                                        osFieldName, oFieldOverride);
+                                }
                             }
                             else
                             {
@@ -149,7 +231,7 @@ bool OGRSchemaOverride::LoadFromJSON(const std::string &osJSON)
 
                     if (oLayerOverride.IsValid())
                     {
-                        AddLayerOverride(osLayerName, oLayerOverride);
+                        AddLayerOverride(oLayerOverride);
                     }
                     else
                     {
@@ -184,25 +266,163 @@ bool OGRSchemaOverride::LoadFromJSON(const std::string &osJSON)
 
 bool OGRSchemaOverride::IsValid() const
 {
-    bool isValid = !m_moLayerOverrides.empty();
-    for (const auto &oLayerOverride : m_moLayerOverrides)
+    bool isValid = !m_aoLayerOverrides.empty();
+    for (const auto &oLayerOverride : m_aoLayerOverrides)
     {
-        isValid &= oLayerOverride.second.IsValid();
+        isValid &= oLayerOverride.IsValid();
     }
     return isValid;
 }
 
+bool OGRSchemaOverride::DefaultApply(
+    GDALDataset *poDS, const char *pszDebugKey,
+    std::function<void(OGRLayer *, int)> callbackWhenRemovingField) const
+{
+    const auto &oLayerOverrides = GetLayerOverrides();
+    for (const auto &oLayerFieldOverride : oLayerOverrides)
+    {
+        const auto &osLayerName = oLayerFieldOverride.GetLayerName();
+        const bool bIsFullOverride{oLayerFieldOverride.IsFullOverride()};
+        auto oNamedFieldOverrides =
+            oLayerFieldOverride.GetNamedFieldOverrides();
+        const auto &oUnnamedFieldOverrides =
+            oLayerFieldOverride.GetUnnamedFieldOverrides();
+
+        const auto ProcessLayer =
+            [&callbackWhenRemovingField, &osLayerName, &oNamedFieldOverrides,
+             &oUnnamedFieldOverrides, bIsFullOverride](OGRLayer *poLayer)
+        {
+            std::vector<OGRFieldDefn *> aoFields;
+            // Patch field definitions
+            auto poLayerDefn = poLayer->GetLayerDefn();
+            for (int i = 0; i < poLayerDefn->GetFieldCount(); i++)
+            {
+                auto poFieldDefn = poLayerDefn->GetFieldDefn(i);
+
+                const auto PatchFieldDefn =
+                    [poFieldDefn](const OGRFieldDefnOverride &oFieldOverride)
+                {
+                    if (oFieldOverride.GetFieldType().has_value())
+                        whileUnsealing(poFieldDefn)
+                            ->SetType(oFieldOverride.GetFieldType().value());
+                    if (oFieldOverride.GetFieldWidth().has_value())
+                        whileUnsealing(poFieldDefn)
+                            ->SetWidth(oFieldOverride.GetFieldWidth().value());
+                    if (oFieldOverride.GetFieldPrecision().has_value())
+                        whileUnsealing(poFieldDefn)
+                            ->SetPrecision(
+                                oFieldOverride.GetFieldPrecision().value());
+                    if (oFieldOverride.GetFieldSubType().has_value())
+                        whileUnsealing(poFieldDefn)
+                            ->SetSubType(
+                                oFieldOverride.GetFieldSubType().value());
+                    if (oFieldOverride.GetFieldName().has_value())
+                        whileUnsealing(poFieldDefn)
+                            ->SetName(
+                                oFieldOverride.GetFieldName().value().c_str());
+                };
+
+                auto oFieldOverrideIter =
+                    oNamedFieldOverrides.find(poFieldDefn->GetNameRef());
+                if (oFieldOverrideIter != oNamedFieldOverrides.cend())
+                {
+                    const auto &oFieldOverride = oFieldOverrideIter->second;
+                    PatchFieldDefn(oFieldOverride);
+
+                    if (bIsFullOverride)
+                    {
+                        aoFields.push_back(poFieldDefn);
+                    }
+                    oNamedFieldOverrides.erase(oFieldOverrideIter);
+                }
+                else
+                {
+                    for (const auto &oFieldOverride : oUnnamedFieldOverrides)
+                    {
+                        if ((!oFieldOverride.GetSrcFieldType().has_value() ||
+                             oFieldOverride.GetSrcFieldType().value() ==
+                                 poFieldDefn->GetType()) &&
+                            (!oFieldOverride.GetSrcFieldSubType().has_value() ||
+                             oFieldOverride.GetSrcFieldSubType().value() ==
+                                 poFieldDefn->GetSubType()))
+                        {
+                            PatchFieldDefn(oFieldOverride);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // Error if any field override is not found
+            if (!oNamedFieldOverrides.empty())
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Field %s not found in layer %s",
+                         oNamedFieldOverrides.cbegin()->first.c_str(),
+                         osLayerName.c_str());
+                return false;
+            }
+
+            // Remove fields not in the override
+            if (bIsFullOverride)
+            {
+                for (int i = poLayerDefn->GetFieldCount() - 1; i >= 0; i--)
+                {
+                    auto poFieldDefn = poLayerDefn->GetFieldDefn(i);
+                    if (std::find(aoFields.begin(), aoFields.end(),
+                                  poFieldDefn) == aoFields.end())
+                    {
+                        callbackWhenRemovingField(poLayer, i);
+                        whileUnsealing(poLayerDefn)->DeleteFieldDefn(i);
+                    }
+                }
+            }
+
+            return true;
+        };
+
+        CPLDebug(pszDebugKey, "Applying schema override for layer %s",
+                 osLayerName.c_str());
+
+        if (osLayerName == "*")
+        {
+            for (auto *poLayer : poDS->GetLayers())
+            {
+                if (!ProcessLayer(poLayer))
+                    return false;
+            }
+        }
+        else
+        {
+            // Fail if the layer name does not exist
+            auto poLayer = poDS->GetLayerByName(osLayerName.c_str());
+            if (poLayer == nullptr)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined, "Layer %s not found",
+                         osLayerName.c_str());
+                return false;
+            }
+            if (!ProcessLayer(poLayer))
+                return false;
+        }
+    }
+
+    return true;
+}
+
 bool OGRLayerSchemaOverride::IsValid() const
 {
-    bool isValid = !m_osLayerName.empty() && !m_moFieldOverrides.empty();
-    for (const auto &oFieldOverride : m_moFieldOverrides)
+    bool isValid =
+        !m_osLayerName.empty() &&
+        (!m_oNamedFieldOverrides.empty() || !m_aoUnnamedFieldOverrides.empty());
+    for (const auto &oFieldOverrideIter : m_oNamedFieldOverrides)
     {
-        isValid &= !oFieldOverride.first.empty();
+        isValid &= !oFieldOverrideIter.first.empty();
         // When schemaType is "full" override we don't need to check if the field
         // overrides are valid: a list of fields to keep is enough.
         if (!m_bIsFullOverride)
         {
-            isValid &= oFieldOverride.second.IsValid();
+            isValid &= oFieldOverrideIter.second.IsValid();
         }
     }
     return isValid;
@@ -211,7 +431,8 @@ bool OGRLayerSchemaOverride::IsValid() const
 bool OGRFieldDefnOverride::IsValid() const
 {
     return m_osName.has_value() || m_eType.has_value() ||
-           m_eSubType.has_value() || m_nWidth.has_value() ||
+           m_eSubType.has_value() || m_eSrcType.has_value() ||
+           m_eSrcSubType.has_value() || m_nWidth.has_value() ||
            m_nPrecision.has_value();
 }
 

--- a/ogr/ogrsf_frmts/csv/ogrcsvdatasource.cpp
+++ b/ogr/ogrsf_frmts/csv/ogrcsvdatasource.cpp
@@ -730,7 +730,7 @@ const std::vector<int> &OGRCSVDataSource::DeletedFieldIndexes() const
 bool OGRCSVDataSource::DealWithOgrSchemaOpenOption(
     CSLConstList papszOpenOptionsIn)
 {
-    std::string osFieldsSchemaOverrideParam =
+    const std::string osFieldsSchemaOverrideParam =
         CSLFetchNameValueDef(papszOpenOptionsIn, "OGR_SCHEMA", "");
 
     if (!osFieldsSchemaOverrideParam.empty())
@@ -742,99 +742,26 @@ bool OGRCSVDataSource::DealWithOgrSchemaOpenOption(
             return false;
         }
 
-        OGRSchemaOverride osSchemaOverride;
-        if (!osSchemaOverride.LoadFromJSON(osFieldsSchemaOverrideParam) ||
-            !osSchemaOverride.IsValid())
+        OGRSchemaOverride oSchemaOverride;
+        const auto nErrorCount = CPLGetErrorCounter();
+        if (!oSchemaOverride.LoadFromJSON(osFieldsSchemaOverrideParam) ||
+            !oSchemaOverride.IsValid())
         {
+            if (nErrorCount == CPLGetErrorCounter())
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Content of OGR_SCHEMA in %s is not valid",
+                         osFieldsSchemaOverrideParam.c_str());
+            }
             return false;
         }
 
-        const auto &oLayerOverrides = osSchemaOverride.GetLayerOverrides();
-        for (const auto &oLayer : oLayerOverrides)
+        if (!oSchemaOverride.DefaultApply(
+                this, "CSV",
+                [this](OGRLayer *, int iField)
+                { m_oDeletedFieldIndexes.push_back(iField); }))
         {
-            const auto &oLayerName = oLayer.first;
-            const auto &oLayerFieldOverride = oLayer.second;
-            const bool bIsFullOverride{oLayerFieldOverride.IsFullOverride()};
-            auto oFieldOverrides = oLayerFieldOverride.GetFieldOverrides();
-            std::vector<OGRFieldDefn *> aoFields;
-
-            CPLDebug("CSV", "Applying schema override for layer %s",
-                     oLayerName.c_str());
-
-            // Fail if the layer name does not exist
-            auto poLayer = GetLayerByName(oLayerName.c_str());
-            if (poLayer == nullptr)
-            {
-                CPLError(CE_Failure, CPLE_AppDefined,
-                         "Layer %s not found in CSV file", oLayerName.c_str());
-                return false;
-            }
-
-            // Patch field definitions
-            auto poLayerDefn = poLayer->GetLayerDefn();
-            for (int i = 0; i < poLayerDefn->GetFieldCount(); i++)
-            {
-                auto poFieldDefn = poLayerDefn->GetFieldDefn(i);
-                auto oFieldOverride =
-                    oFieldOverrides.find(poFieldDefn->GetNameRef());
-                if (oFieldOverride != oFieldOverrides.cend())
-                {
-                    if (oFieldOverride->second.GetFieldType().has_value())
-                        whileUnsealing(poFieldDefn)
-                            ->SetType(
-                                oFieldOverride->second.GetFieldType().value());
-                    if (oFieldOverride->second.GetFieldWidth().has_value())
-                        whileUnsealing(poFieldDefn)
-                            ->SetWidth(
-                                oFieldOverride->second.GetFieldWidth().value());
-                    if (oFieldOverride->second.GetFieldPrecision().has_value())
-                        whileUnsealing(poFieldDefn)
-                            ->SetPrecision(
-                                oFieldOverride->second.GetFieldPrecision()
-                                    .value());
-                    if (oFieldOverride->second.GetFieldSubType().has_value())
-                        whileUnsealing(poFieldDefn)
-                            ->SetSubType(
-                                oFieldOverride->second.GetFieldSubType()
-                                    .value());
-                    if (oFieldOverride->second.GetFieldName().has_value())
-                        whileUnsealing(poFieldDefn)
-                            ->SetName(oFieldOverride->second.GetFieldName()
-                                          .value()
-                                          .c_str());
-
-                    if (bIsFullOverride)
-                    {
-                        aoFields.push_back(poFieldDefn);
-                    }
-                    oFieldOverrides.erase(oFieldOverride);
-                }
-            }
-
-            // Error if any field override is not found
-            if (!oFieldOverrides.empty())
-            {
-                CPLError(CE_Failure, CPLE_AppDefined,
-                         "Field %s not found in layer %s",
-                         oFieldOverrides.cbegin()->first.c_str(),
-                         oLayerName.c_str());
-                return false;
-            }
-
-            // Remove fields not in the override
-            if (bIsFullOverride)
-            {
-                for (int i = poLayerDefn->GetFieldCount() - 1; i >= 0; i--)
-                {
-                    auto poFieldDefn = poLayerDefn->GetFieldDefn(i);
-                    if (std::find(aoFields.begin(), aoFields.end(),
-                                  poFieldDefn) == aoFields.end())
-                    {
-                        whileUnsealing(poLayerDefn)->DeleteFieldDefn(i);
-                        m_oDeletedFieldIndexes.push_back(i);
-                    }
-                }
-            }
+            return false;
         }
     }
     return true;

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsondatasource.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsondatasource.cpp
@@ -96,8 +96,7 @@ CPLErr OGRGeoJSONDataSource::Close()
 bool OGRGeoJSONDataSource::DealWithOgrSchemaOpenOption(
     const GDALOpenInfo *poOpenInfo)
 {
-
-    std::string osFieldsSchemaOverrideParam =
+    const std::string osFieldsSchemaOverrideParam =
         CSLFetchNameValueDef(poOpenInfo->papszOpenOptions, "OGR_SCHEMA", "");
 
     if (!osFieldsSchemaOverrideParam.empty())
@@ -110,100 +109,22 @@ bool OGRGeoJSONDataSource::DealWithOgrSchemaOpenOption(
             return false;
         }
 
-        OGRSchemaOverride osSchemaOverride;
-        if (!osSchemaOverride.LoadFromJSON(osFieldsSchemaOverrideParam) ||
-            !osSchemaOverride.IsValid())
+        OGRSchemaOverride oSchemaOverride;
+        const auto nErrorCount = CPLGetErrorCounter();
+        if (!oSchemaOverride.LoadFromJSON(osFieldsSchemaOverrideParam) ||
+            !oSchemaOverride.IsValid())
         {
+            if (nErrorCount == CPLGetErrorCounter())
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Content of OGR_SCHEMA in %s is not valid",
+                         osFieldsSchemaOverrideParam.c_str());
+            }
             return false;
         }
 
-        const auto &oLayerOverrides = osSchemaOverride.GetLayerOverrides();
-        for (const auto &oLayer : oLayerOverrides)
-        {
-            const auto &oLayerName = oLayer.first;
-            const auto &oLayerFieldOverride = oLayer.second;
-            const bool bIsFullOverride{oLayerFieldOverride.IsFullOverride()};
-            auto oFieldOverrides = oLayerFieldOverride.GetFieldOverrides();
-            std::vector<OGRFieldDefn *> aoFields;
-
-            CPLDebug("GeoJSON", "Applying schema override for layer %s",
-                     oLayerName.c_str());
-
-            // Fail if the layer name does not exist
-            auto poLayer = GetLayerByName(oLayerName.c_str());
-            if (poLayer == nullptr)
-            {
-                CPLError(CE_Failure, CPLE_AppDefined,
-                         "Layer %s not found in GeoJSON file",
-                         oLayerName.c_str());
-                return false;
-            }
-
-            // Patch field definitions
-            auto poLayerDefn = poLayer->GetLayerDefn();
-            for (int i = 0; i < poLayerDefn->GetFieldCount(); i++)
-            {
-                auto poFieldDefn = poLayerDefn->GetFieldDefn(i);
-                auto oFieldOverride =
-                    oFieldOverrides.find(poFieldDefn->GetNameRef());
-                if (oFieldOverride != oFieldOverrides.cend())
-                {
-                    if (oFieldOverride->second.GetFieldType().has_value())
-                        whileUnsealing(poFieldDefn)
-                            ->SetType(
-                                oFieldOverride->second.GetFieldType().value());
-                    if (oFieldOverride->second.GetFieldWidth().has_value())
-                        whileUnsealing(poFieldDefn)
-                            ->SetWidth(
-                                oFieldOverride->second.GetFieldWidth().value());
-                    if (oFieldOverride->second.GetFieldPrecision().has_value())
-                        whileUnsealing(poFieldDefn)
-                            ->SetPrecision(
-                                oFieldOverride->second.GetFieldPrecision()
-                                    .value());
-                    if (oFieldOverride->second.GetFieldSubType().has_value())
-                        whileUnsealing(poFieldDefn)
-                            ->SetSubType(
-                                oFieldOverride->second.GetFieldSubType()
-                                    .value());
-                    if (oFieldOverride->second.GetFieldName().has_value())
-                        whileUnsealing(poFieldDefn)
-                            ->SetName(oFieldOverride->second.GetFieldName()
-                                          .value()
-                                          .c_str());
-
-                    if (bIsFullOverride)
-                    {
-                        aoFields.push_back(poFieldDefn);
-                    }
-                    oFieldOverrides.erase(oFieldOverride);
-                }
-            }
-
-            // Error if any field override is not found
-            if (!oFieldOverrides.empty())
-            {
-                CPLError(CE_Failure, CPLE_AppDefined,
-                         "Field %s not found in layer %s",
-                         oFieldOverrides.cbegin()->first.c_str(),
-                         oLayerName.c_str());
-                return false;
-            }
-
-            // Remove fields not in the override
-            if (bIsFullOverride)
-            {
-                for (int i = poLayerDefn->GetFieldCount() - 1; i >= 0; i--)
-                {
-                    auto poFieldDefn = poLayerDefn->GetFieldDefn(i);
-                    if (std::find(aoFields.begin(), aoFields.end(),
-                                  poFieldDefn) == aoFields.end())
-                    {
-                        whileUnsealing(poLayerDefn)->DeleteFieldDefn(i);
-                    }
-                }
-            }
-        }
+        if (!oSchemaOverride.DefaultApply(this, "GeoJSON"))
+            return false;
     }
     return true;
 }

--- a/ogr/ogrsf_frmts/gml/ogrgmldatasource.cpp
+++ b/ogr/ogrsf_frmts/gml/ogrgmldatasource.cpp
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "cpl_conv.h"
+#include "cpl_error.h"
 #include "cpl_http.h"
 #include "cpl_string.h"
 #include "cpl_vsi_error.h"
@@ -2074,8 +2075,7 @@ void OGRGMLDataSource::WriteTopElements()
 bool OGRGMLDataSource::DealWithOgrSchemaOpenOption(
     const GDALOpenInfo *poOpenInfo)
 {
-
-    std::string osFieldsSchemaOverrideParam =
+    const std::string osFieldsSchemaOverrideParam =
         CSLFetchNameValueDef(poOpenInfo->papszOpenOptions, "OGR_SCHEMA", "");
 
     if (!osFieldsSchemaOverrideParam.empty())
@@ -2090,106 +2090,169 @@ bool OGRGMLDataSource::DealWithOgrSchemaOpenOption(
         }
 
         OGRSchemaOverride osSchemaOverride;
+        const auto nErrorCount = CPLGetErrorCounter();
         if (!osSchemaOverride.LoadFromJSON(osFieldsSchemaOverrideParam) ||
             !osSchemaOverride.IsValid())
         {
+            if (nErrorCount == CPLGetErrorCounter())
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Content of OGR_SCHEMA in %s is not valid",
+                         osFieldsSchemaOverrideParam.c_str());
+            }
             return false;
         }
 
         const auto &oLayerOverrides = osSchemaOverride.GetLayerOverrides();
-        for (const auto &oLayer : oLayerOverrides)
+        for (const auto &oLayerFieldOverride : oLayerOverrides)
         {
-            const auto &oLayerName = oLayer.first;
-            const auto &oLayerFieldOverride = oLayer.second;
+            const auto &osLayerName = oLayerFieldOverride.GetLayerName();
             const bool bIsFullOverride{oLayerFieldOverride.IsFullOverride()};
-            std::vector<GMLPropertyDefn *> aoProperties;
+            auto oNamedFieldOverrides =
+                oLayerFieldOverride.GetNamedFieldOverrides();
+            const auto &oUnnamedFieldOverrides =
+                oLayerFieldOverride.GetUnnamedFieldOverrides();
 
-            CPLDebug("GML", "Applying schema override for layer %s",
-                     oLayerName.c_str());
-
-            // Fail if the layer name does not exist
-            const auto oClass = poReader->GetClass(oLayerName.c_str());
-            if (oClass == nullptr)
+            const auto ProcessLayer =
+                [&osLayerName, &oNamedFieldOverrides, &oUnnamedFieldOverrides,
+                 bIsFullOverride](GMLFeatureClass *poClass)
             {
-                CPLError(CE_Failure, CPLE_AppDefined, "Layer %s not found",
-                         oLayerName.c_str());
-                return false;
-            }
-
-            const auto &oLayerFields = oLayerFieldOverride.GetFieldOverrides();
-            for (const auto &oFieldOverrideIt : oLayerFields)
-            {
-                const auto oProperty =
-                    oClass->GetProperty(oFieldOverrideIt.first.c_str());
-                if (oProperty == nullptr)
+                std::vector<GMLPropertyDefn *> aoProperties;
+                // Patch field definitions
+                for (int i = 0; i < poClass->GetPropertyCount(); i++)
                 {
-                    CPLError(CE_Failure, CPLE_AppDefined,
-                             "Field %s not found in layer %s",
-                             oFieldOverrideIt.first.c_str(),
-                             oLayerName.c_str());
-                    return false;
-                }
+                    auto poProperty = poClass->GetProperty(i);
 
-                const auto &oFieldOverride = oFieldOverrideIt.second;
-
-                const OGRFieldSubType eSubType =
-                    oFieldOverride.GetFieldSubType().value_or(OFSTNone);
-
-                if (oFieldOverride.GetFieldSubType().has_value())
-                {
-                    oProperty->SetSubType(eSubType);
-                }
-
-                if (oFieldOverride.GetFieldType().has_value())
-                {
-                    oProperty->SetType(GML_FromOGRFieldType(
-                        oFieldOverride.GetFieldType().value(), eSubType));
-                }
-
-                if (oFieldOverride.GetFieldName().has_value())
-                {
-                    oProperty->SetName(
-                        oFieldOverride.GetFieldName().value().c_str());
-                }
-
-                if (oFieldOverride.GetFieldWidth().has_value())
-                {
-                    oProperty->SetWidth(oFieldOverride.GetFieldWidth().value());
-                }
-
-                if (oFieldOverride.GetFieldPrecision().has_value())
-                {
-                    oProperty->SetPrecision(
-                        oFieldOverride.GetFieldPrecision().value());
-                }
-
-                if (bIsFullOverride)
-                {
-                    aoProperties.push_back(oProperty);
-                }
-            }
-
-            // Remove fields not in the override
-            if (bIsFullOverride &&
-                aoProperties.size() !=
-                    static_cast<size_t>(oClass->GetPropertyCount()))
-            {
-                for (int j = 0; j < oClass->GetPropertyCount(); ++j)
-                {
-                    const auto oProperty = oClass->GetProperty(j);
-                    if (std::find(aoProperties.begin(), aoProperties.end(),
-                                  oProperty) == aoProperties.end())
+                    const auto PatchProperty =
+                        [poProperty](const OGRFieldDefnOverride &oFieldOverride)
                     {
-                        delete (oProperty);
+                        const OGRFieldSubType eSubType =
+                            oFieldOverride.GetFieldSubType().value_or(OFSTNone);
+
+                        if (oFieldOverride.GetFieldSubType().has_value())
+                        {
+                            poProperty->SetSubType(eSubType);
+                        }
+
+                        if (oFieldOverride.GetFieldType().has_value())
+                        {
+                            poProperty->SetType(GML_FromOGRFieldType(
+                                oFieldOverride.GetFieldType().value(),
+                                eSubType));
+                        }
+                        if (oFieldOverride.GetFieldWidth().has_value())
+                        {
+                            poProperty->SetWidth(
+                                oFieldOverride.GetFieldWidth().value());
+                        }
+                        if (oFieldOverride.GetFieldPrecision().has_value())
+                        {
+                            poProperty->SetPrecision(
+                                oFieldOverride.GetFieldPrecision().value());
+                        }
+                        if (oFieldOverride.GetFieldName().has_value())
+                        {
+                            poProperty->SetName(
+                                oFieldOverride.GetFieldName().value().c_str());
+                        }
+                    };
+
+                    auto oFieldOverrideIter =
+                        oNamedFieldOverrides.find(poProperty->GetName());
+                    if (oFieldOverrideIter != oNamedFieldOverrides.cend())
+                    {
+                        const auto &oFieldOverride = oFieldOverrideIter->second;
+                        PatchProperty(oFieldOverride);
+
+                        if (bIsFullOverride)
+                        {
+                            aoProperties.push_back(poProperty);
+                        }
+                        oNamedFieldOverrides.erase(oFieldOverrideIter);
+                    }
+                    else
+                    {
+                        for (const auto &oFieldOverride :
+                             oUnnamedFieldOverrides)
+                        {
+                            OGRFieldSubType eSubType =
+                                oFieldOverride.GetFieldSubType().value_or(
+                                    OFSTNone);
+                            if ((!oFieldOverride.GetSrcFieldType()
+                                      .has_value() ||
+                                 GML_FromOGRFieldType(
+                                     oFieldOverride.GetSrcFieldType().value(),
+                                     eSubType) == poProperty->GetType()) &&
+                                (!oFieldOverride.GetSrcFieldSubType()
+                                      .has_value() ||
+                                 oFieldOverride.GetSrcFieldSubType().value() ==
+                                     poProperty->GetSubType()))
+                            {
+                                PatchProperty(oFieldOverride);
+                                break;
+                            }
+                        }
                     }
                 }
 
-                oClass->StealProperties();
-
-                for (const auto &oProperty : aoProperties)
+                // Error if any field override is not found
+                if (!oNamedFieldOverrides.empty())
                 {
-                    oClass->AddProperty(oProperty);
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "Field %s not found in layer %s",
+                             oNamedFieldOverrides.cbegin()->first.c_str(),
+                             osLayerName.c_str());
+                    return false;
                 }
+
+                // Remove fields not in the override
+                if (bIsFullOverride)
+                {
+                    for (int j = 0; j < poClass->GetPropertyCount(); ++j)
+                    {
+                        const auto oProperty = poClass->GetProperty(j);
+                        if (std::find(aoProperties.begin(), aoProperties.end(),
+                                      oProperty) == aoProperties.end())
+                        {
+                            delete (oProperty);
+                        }
+                    }
+
+                    poClass->StealProperties();
+
+                    for (const auto &oProperty : aoProperties)
+                    {
+                        poClass->AddProperty(oProperty);
+                    }
+                }
+
+                return true;
+            };
+
+            CPLDebug("GML", "Applying schema override for layer %s",
+                     osLayerName.c_str());
+
+            if (osLayerName == "*")
+            {
+                for (int iClass = 0; iClass < poReader->GetClassCount();
+                     ++iClass)
+                {
+                    if (!ProcessLayer(poReader->GetClass(iClass)))
+                        return false;
+                }
+            }
+            else
+            {
+                // Fail if the layer name does not exist
+                const auto oClass = poReader->GetClass(osLayerName.c_str());
+                if (oClass == nullptr)
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "Layer %s not found in", osLayerName.c_str());
+                    return false;
+                }
+                if (!ProcessLayer(oClass))
+                    return false;
             }
         }
     }

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
@@ -251,7 +251,7 @@ void OGRSQLiteDriverUnload(GDALDriver *)
 bool OGRSQLiteBaseDataSource::DealWithOgrSchemaOpenOption(
     CSLConstList papszOpenOptionsIn)
 {
-    std::string osFieldsSchemaOverrideParam =
+    const std::string osFieldsSchemaOverrideParam =
         CSLFetchNameValueDef(papszOpenOptionsIn, "OGR_SCHEMA", "");
 
     if (!osFieldsSchemaOverrideParam.empty())
@@ -263,99 +263,22 @@ bool OGRSQLiteBaseDataSource::DealWithOgrSchemaOpenOption(
             return false;
         }
 
-        OGRSchemaOverride osSchemaOverride;
-        if (!osSchemaOverride.LoadFromJSON(osFieldsSchemaOverrideParam) ||
-            !osSchemaOverride.IsValid())
+        OGRSchemaOverride oSchemaOverride;
+        const auto nErrorCount = CPLGetErrorCounter();
+        if (!oSchemaOverride.LoadFromJSON(osFieldsSchemaOverrideParam) ||
+            !oSchemaOverride.IsValid())
         {
+            if (nErrorCount == CPLGetErrorCounter())
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Content of OGR_SCHEMA in %s is not valid",
+                         osFieldsSchemaOverrideParam.c_str());
+            }
             return false;
         }
 
-        const auto &oLayerOverrides = osSchemaOverride.GetLayerOverrides();
-        for (const auto &oLayer : oLayerOverrides)
-        {
-            const auto &oLayerName = oLayer.first;
-            const auto &oLayerFieldOverride = oLayer.second;
-            const bool bIsFullOverride{oLayerFieldOverride.IsFullOverride()};
-            auto oFieldOverrides = oLayerFieldOverride.GetFieldOverrides();
-            std::vector<OGRFieldDefn *> aoFields;
-
-            CPLDebug("SQLite", "Applying schema override for layer %s",
-                     oLayerName.c_str());
-
-            // Fail if the layer name does not exist
-            auto poLayer = GetLayerByName(oLayerName.c_str());
-            if (poLayer == nullptr)
-            {
-                CPLError(CE_Failure, CPLE_AppDefined,
-                         "Layer %s not found in SQLite DB", oLayerName.c_str());
-                return false;
-            }
-
-            // Patch field definitions
-            auto poLayerDefn = poLayer->GetLayerDefn();
-            for (int i = 0; i < poLayerDefn->GetFieldCount(); i++)
-            {
-                auto poFieldDefn = poLayerDefn->GetFieldDefn(i);
-                auto oFieldOverride =
-                    oFieldOverrides.find(poFieldDefn->GetNameRef());
-                if (oFieldOverride != oFieldOverrides.cend())
-                {
-                    if (oFieldOverride->second.GetFieldType().has_value())
-                        whileUnsealing(poFieldDefn)
-                            ->SetType(
-                                oFieldOverride->second.GetFieldType().value());
-                    if (oFieldOverride->second.GetFieldWidth().has_value())
-                        whileUnsealing(poFieldDefn)
-                            ->SetWidth(
-                                oFieldOverride->second.GetFieldWidth().value());
-                    if (oFieldOverride->second.GetFieldPrecision().has_value())
-                        whileUnsealing(poFieldDefn)
-                            ->SetPrecision(
-                                oFieldOverride->second.GetFieldPrecision()
-                                    .value());
-                    if (oFieldOverride->second.GetFieldSubType().has_value())
-                        whileUnsealing(poFieldDefn)
-                            ->SetSubType(
-                                oFieldOverride->second.GetFieldSubType()
-                                    .value());
-                    if (oFieldOverride->second.GetFieldName().has_value())
-                        whileUnsealing(poFieldDefn)
-                            ->SetName(oFieldOverride->second.GetFieldName()
-                                          .value()
-                                          .c_str());
-
-                    if (bIsFullOverride)
-                    {
-                        aoFields.push_back(poFieldDefn);
-                    }
-                    oFieldOverrides.erase(oFieldOverride);
-                }
-            }
-
-            // Error if any field override is not found
-            if (!oFieldOverrides.empty())
-            {
-                CPLError(CE_Failure, CPLE_AppDefined,
-                         "Field %s not found in layer %s",
-                         oFieldOverrides.cbegin()->first.c_str(),
-                         oLayerName.c_str());
-                return false;
-            }
-
-            // Remove fields not in the override
-            if (bIsFullOverride)
-            {
-                for (int i = poLayerDefn->GetFieldCount() - 1; i >= 0; i--)
-                {
-                    auto poFieldDefn = poLayerDefn->GetFieldDefn(i);
-                    if (std::find(aoFields.begin(), aoFields.end(),
-                                  poFieldDefn) == aoFields.end())
-                    {
-                        whileUnsealing(poLayerDefn)->DeleteFieldDefn(i);
-                    }
-                }
-            }
-        }
+        if (!oSchemaOverride.DefaultApply(this, "SQLite"))
+            return false;
     }
     return true;
 }


### PR DESCRIPTION
For pipelines like ``read test.csv ! change-field-type --src-field-type String --field-type Date ! change-field-type --field-name int --field-type Integer64 ! ...`, translate the change-field-type content as a OGR_SCHEMA open option for drivers that support it

(@elpaso what we discussed recently)