### PR TITLE
MiraMonRaster: fixing fuzzer issue 447845743

### DIFF
--- a/frmts/miramon/miramon_rel.cpp
+++ b/frmts/miramon/miramon_rel.cpp
@@ -15,6 +15,7 @@
 #include "cpl_port.h"
 #include "gdal_priv.h"
 #include "cpl_string.h"
+#include <set>
 
 #include "miramon_rel.h"
 #include "miramon_band.h"
@@ -810,7 +811,7 @@ CPLErr MMRRel::ParseBandInfo()
 
     CPLString osBandSectionKey;
     CPLString osBandSectionValue;
-    CPLStringList aosProcessedTokens;
+    std::set<std::string> setProcessedTokens;
 
     int nNBand;
     if (m_papoSDSBands.size())
@@ -822,10 +823,12 @@ CPLErr MMRRel::ParseBandInfo()
 
     for (int nIBand = 0; nIBand < nMaxBands; nIBand++)
     {
-        if (aosProcessedTokens.FindString(aosTokens[nIBand]) >= 0)
+        const std::string lowerCaseToken =
+            CPLString(aosTokens[nIBand]).tolower();
+        if (cpl::contains(setProcessedTokens, lowerCaseToken))
             continue;  // Repeated bands are ignored.
 
-        aosProcessedTokens.AddString(aosTokens[nIBand]);
+        setProcessedTokens.insert(lowerCaseToken);
 
         osBandSectionKey = KEY_NomCamp;
         osBandSectionKey.append("_");


### PR DESCRIPTION
## What does this PR do?
Fix oss-fuzz issue 447845743 (miramon_fuzzer): avoid processing duplicate bands

When parsing band lists, duplicate bands are no longer processed multiple times.
It is not valid to have the same band twice in a dataset, so repeated bands are
skipped and only the first occurrence is considered.

## What are related issues/pull requests?
https://oss-fuzz.com/testcase-detail/6028581513003008

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] All CI builds and checks have passed
