### PR TITLE
Touchup Docker Image Generation

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -87,6 +87,7 @@ jobs:
               ./build.sh --platform linux/${{ matrix.platform }} --with-multi-arch --push
             else
               ./build.sh --platform linux/${{ matrix.platform }} --with-multi-arch
+            fi
           fi
           docker run --rm ghcr.io/osgeo/gdal:${{ matrix.base }}-latest-${{ matrix.platform }} gdalinfo --formats
           docker run --rm ghcr.io/osgeo/gdal:${{ matrix.base }}-latest-${{ matrix.platform }} ogrinfo --formats

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,7 +31,7 @@ jobs:
             base: ubuntu-full
             proprietary_sdks: 'true'
     name: ${{ matrix.base }}-${{ matrix.platform }} Proprietary-SDKs=${{ matrix.proprietary_sdks }}
-    runs-on: ${{ matrix.platform == 'amd64' && 'ubuntu-latest' || 'ubuntu-24.04-arm64' }}
+    runs-on: ${{ matrix.platform == 'amd64' && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
     permissions:
       contents: read
       attestations: write

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,7 +39,7 @@ jobs:
       id-token: write
 
     steps:
-      - name: Set PUSH_PACKAGE due to schedule
+      - name: Set PUSH_PACKAGES due to schedule
         if: github.event_name == 'schedule'
         run: |
           echo "PUSH_PACKAGES=true" >> $GITHUB_ENV
@@ -83,9 +83,11 @@ jobs:
             echo "PUSH_PACKAGES=false" >> $GITHUB_ENV
             ./build.sh --platform linux/${{ matrix.platform }} --with-multi-arch --with-oracle --with-mrsid --with-ecw
           else
-            ./build.sh --platform linux/${{ matrix.platform }} --with-multi-arch
+            if test "${{ env.PUSH_PACKAGES }}" == "true"; then
+              ./build.sh --platform linux/${{ matrix.platform }} --with-multi-arch --push
+            else
+              ./build.sh --platform linux/${{ matrix.platform }} --with-multi-arch
           fi
-          docker image tag ghcr.io/osgeo/gdal:${{ matrix.base }}-latest ${{ matrix.base }}-latest-${{ matrix.platform }}
           docker run --rm ghcr.io/osgeo/gdal:${{ matrix.base }}-latest-${{ matrix.platform }} gdalinfo --formats
           docker run --rm ghcr.io/osgeo/gdal:${{ matrix.base }}-latest-${{ matrix.platform }} ogrinfo --formats
   create-manifest:
@@ -101,7 +103,7 @@ jobs:
       matrix:
         tag: ["ubuntu-full", "ubuntu-small", "alpine-small", "alpine-normal"]
     steps:
-      - name: Set PUSH_PACKAGE due to schedule
+      - name: Set PUSH_PACKAGES due to schedule
         if: github.event_name == 'schedule'
         run: |
           echo "PUSH_PACKAGES=true" >> $GITHUB_ENV
@@ -118,5 +120,9 @@ jobs:
         run: |
           docker buildx imagetools create \
           -t ghcr.io/osgeo/gdal:${{ matrix.tag }}-latest \
-          ghcr.io/osgeo/osgeo:${{ matrix.tag }}-latest-amd64 \
-          ghcr.io/osgeo/osgeo:${{ matrix.tag }}-latest-arm64
+          ghcr.io/osgeo/gdal:${{ matrix.tag }}-latest-amd64 \
+          ghcr.io/osgeo/gdal:${{ matrix.tag }}-latest-arm64
+      - name: Alias ubuntu-full-latest to latest
+        if: matrix.tag == 'ubuntu-full'
+        run: |
+          docker buildx imagetools create ghcr.io/osgeo/gdal:ubuntu-full-latest --tag ghcr.io/osgeo/gdal:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -30,7 +30,7 @@ jobs:
           - platform: amd64
             base: ubuntu-full
             proprietary_sdks: 'true'
-    name: ${{ matrix.base }}-${{ matrix.platform }} Proprietary-SDKs=${{ matrix.proprietary_sdks }}
+    name: ${{ matrix.base }}-${{ matrix.platform }} proprietary-sdks=${{ matrix.proprietary_sdks }}
     runs-on: ${{ matrix.platform == 'amd64' && 'ubuntu-latest' || 'ubuntu-24.04-arm' }}
     permissions:
       contents: read
@@ -85,9 +85,9 @@ jobs:
           else
             ./build.sh --platform linux/${{ matrix.platform }} --with-multi-arch
           fi
+          docker image tag ghcr.io/osgeo/gdal:${{ matrix.base }}-latest ${{ matrix.base }}-latest-${{ matrix.platform }}
           docker run --rm ghcr.io/osgeo/gdal:${{ matrix.base }}-latest-${{ matrix.platform }} gdalinfo --formats
           docker run --rm ghcr.io/osgeo/gdal:${{ matrix.base }}-latest-${{ matrix.platform }} ogrinfo --formats
-
   create-manifest:
     permissions:
       contents: read

--- a/docker/README.md
+++ b/docker/README.md
@@ -118,6 +118,8 @@ that the user invoking the build happens to run, but for others as well.
 
 There is a small setup process depending on your operating system. Refer to [Preparation toward running Docker on ARM Mac: Building multi-arch images with Docker BuildX](https://medium.com/nttlabs/buildx-multiarch-2c6c2df00ca2).
 
+Also, your docker daemon must be set to use the containerd image store.
+
 #### Example Scenario
 
 If you're running Docker for MacOS with an Intel CPU

--- a/docker/alpine-normal/build.sh
+++ b/docker/alpine-normal/build.sh
@@ -41,7 +41,7 @@ fi
 if test "${HAS_PLATFORM}" = "0" && test "${HAS_RELEASE}" = "0" && test "${TARGET_IMAGE}" = "osgeo/gdal:alpine-normal"; then
  "${SCRIPT_DIR}/../util.sh" --platform linux/arm64 "$@" --test-python
 
- if test "$HAS_PUSH" = "1" && test -z "$CI"; then
+ if test "${HAS_PUSH}" = "1" && test -z "${CI}"; then
    DOCKER_REPO=$(cat /tmp/gdal_docker_repo.txt)
 
    docker manifest rm ${DOCKER_REPO}/${TARGET_IMAGE}-latest || /bin/true

--- a/docker/alpine-small/build.sh
+++ b/docker/alpine-small/build.sh
@@ -41,7 +41,7 @@ fi
 if test "${HAS_PLATFORM}" = "0" && test "${HAS_RELEASE}" = "0" && test "${TARGET_IMAGE}" = "osgeo/gdal:alpine-small"; then
  "${SCRIPT_DIR}/../util.sh" --platform linux/arm64 "$@"
 
-  if test "$HAS_PUSH" = "1" && test -z "$CI"; then
+  if test "${HAS_PUSH}" = "1" && test -z "${CI}"; then
    DOCKER_REPO=$(cat /tmp/gdal_docker_repo.txt)
 
    docker manifest rm ${DOCKER_REPO}/${TARGET_IMAGE}-latest || /bin/true

--- a/docker/ubuntu-full/Dockerfile
+++ b/docker/ubuntu-full/Dockerfile
@@ -347,7 +347,7 @@ RUN . /buildscripts/bh-set-envvars.sh \
 # Build libqb3
 RUN --mount=type=cache,id=ubuntu-full-libqb3,target=$HOME/.cache \
     . /buildscripts/bh-set-envvars.sh \
-    && git clone https://github.com/lucianpls/QB3.git \
+    && git clone --depth 1 https://github.com/lucianpls/QB3.git \
     && if [ -n "${RSYNC_REMOTE:-}" ]; then \
         echo "Downloading cache..."; \
         rsync -ra "${RSYNC_REMOTE}/libqb3/${GCC_ARCH}/" "$HOME/.cache/"; \
@@ -396,7 +396,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     && apt-get install -y --fix-missing --no-install-recommends libgflags-dev${APT_ARCH_SUFFIX}
 RUN --mount=type=cache,id=ubuntu-full-libjxl,target=$HOME/.cache \
     . /buildscripts/bh-set-envvars.sh \
-    && git clone https://github.com/libjxl/libjxl.git --recursive \
+    && git clone --depth 1 --shallow-submodules https://github.com/libjxl/libjxl.git --recursive \
     && if [ -n "${RSYNC_REMOTE:-}" ]; then \
         echo "Downloading cache..."; \
         rsync -ra "${RSYNC_REMOTE}/libjxl/${GCC_ARCH}/" "$HOME/.cache/"; \

--- a/docker/ubuntu-full/build.sh
+++ b/docker/ubuntu-full/build.sh
@@ -41,7 +41,7 @@ fi
 if test "${HAS_PLATFORM}" = "0" && test "${HAS_RELEASE}" = "0" && test "${TARGET_IMAGE}" = "osgeo/gdal:ubuntu-full"; then
  "${SCRIPT_DIR}/../util.sh" --platform linux/arm64 "$@" --test-python
 
- if test "$HAS_PUSH" = "1" && test -z "$CI"; then
+ if test "${HAS_PUSH}" = "1" && test -z "${CI}"; then
    DOCKER_REPO=$(cat /tmp/gdal_docker_repo.txt)
 
    docker manifest rm ${DOCKER_REPO}/${TARGET_IMAGE}-latest || /bin/true

--- a/docker/ubuntu-small/build.sh
+++ b/docker/ubuntu-small/build.sh
@@ -41,7 +41,7 @@ fi
 if test "${HAS_PLATFORM}" = "0" && test "${HAS_RELEASE}" = "0" && test "${TARGET_IMAGE}" = "osgeo/gdal:ubuntu-small"; then
  "${SCRIPT_DIR}/../util.sh" --platform linux/arm64 "$@" --test-python
 
-  if test "$HAS_PUSH" = "1" && test -z "$CI"; then
+  if test "${HAS_PUSH}" = "1" && test -z "${CI}"; then
    DOCKER_REPO=$(cat /tmp/gdal_docker_repo.txt)
 
    docker manifest rm ${DOCKER_REPO}/${TARGET_IMAGE}-latest || /bin/true

--- a/docker/util.sh
+++ b/docker/util.sh
@@ -157,7 +157,10 @@ echo "${DOCKER_REPO}" > /tmp/gdal_docker_repo.txt
 
 if test "${DOCKER_BUILDKIT}" = "1" && test "${DOCKER_CLI_EXPERIMENTAL}" = "enabled"; then
   DOCKER_BUILDX="buildx"
-  DOCKER_BUILDX_ARGS=("--platform" "${ARCH_PLATFORMS}"  "--sbom" "true" "--provenance" "true")
+  DOCKER_BUILDX_ARGS=("--platform" "${ARCH_PLATFORMS}")
+  if [ -n "${CI}" ]; then
+     DOCKER_BUILDX_ARGS+=("--sbom" "true" "--provenance" "true")
+  fi
 fi
 
 if test "${RELEASE}" = "yes"; then
@@ -179,7 +182,7 @@ if test "${RELEASE}" = "yes"; then
     if test "${WITH_DEBUG_SYMBOLS}" = ""; then
         WITH_DEBUG_SYMBOLS=no
     fi
-    [ -v DOCKER_CACHE_PARAM ] || DOCKER_CACHE_PARAM="--no-cache"
+    [[ -n "${DOCKER_CACHE_PARAM}" ]] || [[ DOCKER_CACHE_PARAM="--no-cache" ]]
 else
     if test "${TAG_NAME}" = ""; then
         TAG_NAME=latest
@@ -187,7 +190,7 @@ else
     if test "${WITH_DEBUG_SYMBOLS}" = ""; then
         WITH_DEBUG_SYMBOLS=yes
     fi
-    [ -v DOCKER_CACHE_PARAM ] || DOCKER_CACHE_PARAM=""
+    [[ -n "${DOCKER_CACHE_PARAM}" ]] || [[ DOCKER_CACHE_PARAM="" ]]
 fi
 
 check_image()
@@ -237,7 +240,7 @@ BUILD_ARGS=(
     "--build-arg" "GDAL_REPOSITORY=${GDAL_REPOSITORY}" \
     "--build-arg" "WITH_DEBUG_SYMBOLS=${WITH_DEBUG_SYMBOLS}" \
 )
-[ -z "${DOCKER_CACHE_PARAM}" ] || BUILD_ARGS+=("${DOCKER_CACHE_PARAM}")
+[[ -z "${DOCKER_CACHE_PARAM}" ]] || BUILD_ARGS+=("${DOCKER_CACHE_PARAM}")
 
 if test "${WITH_ORACLE}" != ""; then
       BUILD_ARGS+=("--build-arg" "WITH_ORACLE=${WITH_ORACLE}")
@@ -258,7 +261,7 @@ fi
 if test "${RELEASE}" = "yes"; then
     BUILD_ARGS+=("--build-arg" "GDAL_BUILD_IS_RELEASE=YES")
 
-    if [ -z "${SOURCE_DATE_EPOCH}" ]; then
+    if [[ -z "${SOURCE_DATE_EPOCH}" ]]; then
         # Try to set SOURCE_DATE_EPOCH to the timestamp of the tar.gz for
         # the release, so repeated builds give similar output.
         # https://github.com/moby/buildkit/blob/master/docs/build-repro.md#source_date_epoch
@@ -266,7 +269,7 @@ if test "${RELEASE}" = "yes"; then
         # the timestamp, so "build.sh --gdal HEAD" works.
         LAST_MODIFIED=$(curl -L -sI "https://github.com/OSGeo/gdal/releases/download/${GDAL_VERSION}/gdal-${GDAL_VERSION#v}.tar.gz" \
                             | grep -i last-modified | awk -F: '{print $2}')
-        if [ -n "${LAST_MODIFIED}" ]; then
+        if [ ! -z "${LAST_MODIFIED}" ]; then
             MODIFIED_SINCE_EPOCH=$(date -d "${LAST_MODIFIED}" +%s)
             if [ -n "${MODIFIED_SINCE_EPOCH}" ]; then
                 export SOURCE_DATE_EPOCH="${MODIFIED_SINCE_EPOCH}"
@@ -315,7 +318,7 @@ else
         test "${IMAGE_NAME}" = "osgeo/gdal:alpine-small-latest" || \
         test "${IMAGE_NAME}" = "osgeo/gdal:alpine-normal-latest"; then
         if test "${DOCKER_BUILDX}" != "buildx"; then
-          ARCH_PLATFORM_ARCH=$(echo ${ARCH_PLATFORMS} | sed "s/linux\///")
+          ARCH_PLATFORM_ARCH=$(echo "${ARCH_PLATFORMS}" | sed "s/linux\///")
           IMAGE_NAME_WITH_ARCH="${REPO_IMAGE_NAME}-${ARCH_PLATFORM_ARCH}"
         fi
     fi
@@ -328,7 +331,7 @@ else
     echo "Using GDAL_RELEASE_DATE=${GDAL_RELEASE_DATE}"
     BUILD_ARGS+=("--build-arg" "GDAL_RELEASE_DATE=${GDAL_RELEASE_DATE}")
 
-    if [ ! -v NO_RSYNC_DAEMON ]; then
+    if [[ -z NO_RSYNC_DAEMON ]]; then
         RSYNC_DAEMON_CONTAINER=gdal_rsync_daemon
         HOST_CACHE_DIR="$HOME/gdal-docker-cache"
 
@@ -386,24 +389,24 @@ EOF
           BUILD_ARGS+=("--build-arg" "TARGET_BASE_IMAGE=${BASE_IMAGE}")
         fi
     else
-      if test "${DOCKER_BUILDX}" != "buildx" && test \( "${IMAGE_NAME}" = "osgeo/gdal:ubuntu-full-latest" || test "${IMAGE_NAME}" = "osgeo/gdal:ubuntu-small-latest" \); then
+      if test "${DOCKER_BUILDX}" != "buildx" && [[ "${IMAGE_NAME}" = "osgeo/gdal:ubuntu-full-latest" || "${IMAGE_NAME}" = "osgeo/gdal:ubuntu-small-latest" ]]; then
         if test "${ARCH_PLATFORMS}" = "linux/arm64"; then
-          BASE_IMAGE=$(grep "ARG BASE_IMAGE=" ${SCRIPT_DIR}/Dockerfile | sed "s/ARG BASE_IMAGE=//")
+          BASE_IMAGE=$(grep "ARG BASE_IMAGE=" "${SCRIPT_DIR}/Dockerfile" | sed "s/ARG BASE_IMAGE=//")
           echo "Fetching digest for ${BASE_IMAGE} ${ARCH_PLATFORMS}..."
-          ARCH_PLATFORM_ARCH=$(echo ${ARCH_PLATFORMS} | sed "s/linux\///")
-          TARGET_BASE_IMAGE_DIGEST=$(docker manifest inspect ${BASE_IMAGE} | jq --raw-output '.manifests[] | (if .platform.architecture == "'${ARCH_PLATFORM_ARCH}'" then .digest else empty end)')
+          ARCH_PLATFORM_ARCH=$(echo "${ARCH_PLATFORMS}" | sed "s/linux\///")
+          TARGET_BASE_IMAGE_DIGEST=$(docker manifest inspect "${BASE_IMAGE}" | jq --raw-output '.manifests[] | (if .platform.architecture == "'${ARCH_PLATFORM_ARCH}'" then .digest else empty end)')
           docker pull "${BASE_IMAGE}@${TARGET_BASE_IMAGE_DIGEST}"
           BUILD_ARGS+=("--build-arg" "TARGET_ARCH=${ARCH_PLATFORM_ARCH}")
           BUILD_ARGS+=("--build-arg" "TARGET_BASE_IMAGE=${BASE_IMAGE}@${TARGET_BASE_IMAGE_DIGEST}")
           # echo "${BUILD_ARGS[@]}"
         fi
-      elif test "${DOCKER_BUILDX}" != "buildx" && test \( "${IMAGE_NAME}" = "osgeo/gdal:alpine-small-latest" || test "${IMAGE_NAME}" = "osgeo/gdal:alpine-normal-latest" \); then
+      elif test "${DOCKER_BUILDX}" != "buildx" && [[ "${IMAGE_NAME}" = "osgeo/gdal:alpine-small-latest" || "${IMAGE_NAME}" = "osgeo/gdal:alpine-normal-latest" ]]; then
         if test "${ARCH_PLATFORMS}" = "linux/arm64"; then
-          ALPINE_VERSION=$(grep "ARG ALPINE_VERSION=" ${SCRIPT_DIR}/Dockerfile | sed "s/ARG ALPINE_VERSION=//")
+          ALPINE_VERSION=$(grep "ARG ALPINE_VERSION=" "${SCRIPT_DIR}/Dockerfile" | sed "s/ARG ALPINE_VERSION=//")
           BASE_IMAGE="alpine:${ALPINE_VERSION}"
           echo "Fetching digest for ${BASE_IMAGE} ${ARCH_PLATFORMS}..."
-          ARCH_PLATFORM_ARCH=$(echo ${ARCH_PLATFORMS} | sed "s/linux\///")
-          TARGET_BASE_IMAGE_DIGEST=$(docker manifest inspect ${BASE_IMAGE} | jq --raw-output '.manifests[] | (if .platform.architecture == "'${ARCH_PLATFORM_ARCH}'" then .digest else empty end)')
+          ARCH_PLATFORM_ARCH=$(echo "${ARCH_PLATFORMS}" | sed "s/linux\///")
+          TARGET_BASE_IMAGE_DIGEST=$(docker manifest inspect "${BASE_IMAGE}" | jq --raw-output '.manifests[] | (if .platform.architecture == "'${ARCH_PLATFORM_ARCH}'" then .digest else empty end)')
           echo "${TARGET_BASE_IMAGE_DIGEST}"
           BUILD_ARGS+=("--build-arg" "ALPINE_VERSION=${ALPINE_VERSION}@${TARGET_BASE_IMAGE_DIGEST}")
           # echo "${BUILD_ARGS[@]}"
@@ -439,7 +442,7 @@ EOF
     # Cleanup previous images
     NEW_IMAGE_ID=$(docker image ls "${IMAGE_NAME_WITH_ARCH}" -q)
     if test "${OLD_IMAGE_ID}" != "" && test "${OLD_IMAGE_ID}" != "${NEW_IMAGE_ID}"; then
-        docker rmi "${OLD_IMAGE_ID}"
+        docker rmi "${OLD_IMAGE_ID}" --force
     fi
 
     if test "${IMAGE_NAME}" = "osgeo/gdal:ubuntu-full-latest" || \

--- a/docker/util.sh
+++ b/docker/util.sh
@@ -182,7 +182,7 @@ if test "${RELEASE}" = "yes"; then
     if test "${WITH_DEBUG_SYMBOLS}" = ""; then
         WITH_DEBUG_SYMBOLS=no
     fi
-    [[ -n "${DOCKER_CACHE_PARAM}" ]] || [[ DOCKER_CACHE_PARAM="--no-cache" ]]
+    [[ -n "${DOCKER_CACHE_PARAM}" ]] || [[ ${DOCKER_CACHE_PARAM} = "--no-cache" ]]
 else
     if test "${TAG_NAME}" = ""; then
         TAG_NAME=latest
@@ -190,7 +190,7 @@ else
     if test "${WITH_DEBUG_SYMBOLS}" = ""; then
         WITH_DEBUG_SYMBOLS=yes
     fi
-    [[ -n "${DOCKER_CACHE_PARAM}" ]] || [[ DOCKER_CACHE_PARAM="" ]]
+    [[ -n "${DOCKER_CACHE_PARAM}" ]] || [[ -z ${DOCKER_CACHE_PARAM} ]]
 fi
 
 check_image()
@@ -332,7 +332,7 @@ else
     echo "Using GDAL_RELEASE_DATE=${GDAL_RELEASE_DATE}"
     BUILD_ARGS+=("--build-arg" "GDAL_RELEASE_DATE=${GDAL_RELEASE_DATE}")
 
-    if [[ -z NO_RSYNC_DAEMON ]]; then
+    if [[ -z ${NO_RSYNC_DAEMON} ]]; then
         RSYNC_DAEMON_CONTAINER=gdal_rsync_daemon
         HOST_CACHE_DIR="$HOME/gdal-docker-cache"
 


### PR DESCRIPTION
## What does this PR do?

PR makes some changes so that `latest` docker images which make use of multi-platform capability are pushed to ghcr.io/osgeo/gdal.

This PR makes an attempt to have it such that the `Docker/build-all.sh` script can still be used both locally and in CI, but when used in CI, the multi-process builds would make use of attestation and the multi-node runners; but when used locally, it will use emulation to generate the builds.

Fixes some issues left-over from #13066

If merged, the commits should be squashed.

## What are related issues/pull requests?

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
