### PR TITLE
Support remote zarr without directory listing.

### DIFF
--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -5850,3 +5850,22 @@ def test_zarr_read_zarr_with_stac_proj_wkt2():
 
     ds = gdal.Open("data/zarr/zarr_with_stac_proj_wkt2.zarr")
     assert ds.GetSpatialRef().GetAuthorityCode(None) == "26711"
+
+
+###############################################################################
+#
+
+
+@pytest.mark.parametrize(
+    "file_path",
+    [
+        ("data/zarr/array_attrs.zarr/.zarray"),
+        ("data/zarr/group.zarr/.zgroup"),
+        ("data/zarr/group_with_zmetadata.zarr/.zmetadata"),
+        ("data/zarr/v3/test.zr3/zarr.json"),
+    ],
+)
+@gdaltest.enable_exceptions()
+def test_zarr_identify_file_extensions(file_path):
+    ds = gdal.Open(file_path)
+    ds.GetRasterBand(1).Checksum()

--- a/doc/source/drivers/raster/zarr.rst
+++ b/doc/source/drivers/raster/zarr.rst
@@ -73,6 +73,19 @@ with single-quote characters:
 
     gdalmdiminfo 'ZARR:"/vsicurl/https://example.org/foo.zarr"'
 
+Zarr stores without directory listing
+-------------------------------------
+
+.. versionadded:: 3.12
+
+Sometimes remote Zarr stores don't have a reliable directory listing. In such
+cases, one can point to one of the following metadata files for GDAL to detect
+the correct driver to open the Zarr store:
+
+- :file:`zarr.json`
+- :file:`.zmetadata`
+- :file:`.zgroup`
+- :file:`.zarray`
 
 Kerchunk reference stores
 -------------------------
@@ -615,6 +628,14 @@ Get information on the dataset using the multidimensional tools:
 ::
 
     gdalmdiminfo my.zarr
+
+
+Get information on the dataset using the multidimensional tools when there is no
+directory listing available or reliable:
+
+::
+
+    gdalmdiminfo /vsicurl/https://example.com/my.zarr/.zmetadata
 
 
 Convert a netCDF file to ZARR using the multidimensional tools:

--- a/frmts/zarr/zarrdriver.cpp
+++ b/frmts/zarr/zarrdriver.cpp
@@ -304,6 +304,10 @@ GDALDataset *ZarrDataset::Open(GDALOpenInfo *poOpenInfo)
     }
 
     CPLString osFilename(poOpenInfo->pszFilename);
+    if (!poOpenInfo->bIsDirectory)
+    {
+        osFilename = CPLGetPathSafe(osFilename);
+    }
     CPLString osArrayOfInterest;
     std::vector<uint64_t> anExtraDimIndices;
     if (STARTS_WITH(poOpenInfo->pszFilename, "ZARR:"))

--- a/frmts/zarr/zarrdrivercore.cpp
+++ b/frmts/zarr/zarrdrivercore.cpp
@@ -14,6 +14,7 @@
 #include "gdal_frmts.h"
 #include "gdalplugindriverproxy.h"
 
+#include "cpl_string.h"
 #include "vsikerchunk.h"
 #include "vsikerchunk_inline.hpp"
 
@@ -72,8 +73,9 @@ bool ZARRIsLikelyKerchunkJSONRef(const GDALOpenInfo *poOpenInfo)
 int ZARRDriverIdentify(GDALOpenInfo *poOpenInfo)
 
 {
-    if (STARTS_WITH(poOpenInfo->pszFilename, "ZARR:") ||
-        STARTS_WITH(poOpenInfo->pszFilename, "ZARR_DUMMY:"))
+    const std::string_view osvFilename(poOpenInfo->pszFilename);
+    if (cpl::starts_with(osvFilename, "ZARR:") ||
+        cpl::starts_with(osvFilename, "ZARR_DUMMY:"))
     {
         return TRUE;
     }
@@ -82,11 +84,18 @@ int ZARRDriverIdentify(GDALOpenInfo *poOpenInfo)
     {
         return TRUE;
     }
-    if (STARTS_WITH(poOpenInfo->pszFilename, JSON_REF_FS_PREFIX))
+    if (cpl::starts_with(osvFilename, JSON_REF_FS_PREFIX))
     {
         return -1;
     }
-
+    for (const char *pszFile :
+         {".zarray", ".zgroup", ".zmetadata", "zarr.json"})
+    {
+        if (cpl::ends_with(osvFilename, pszFile))
+        {
+            return TRUE;
+        }
+    }
     if (!poOpenInfo->bIsDirectory)
     {
         return FALSE;


### PR DESCRIPTION
Sometimes remote online Zarr stores won't have a reliable directory listing. In such cases, one can point to one of the following metadata files for GDAL to detect the correct driver to open the Zarr store:

- zarr.json
- .zmetadata
- .zgroup
- .zarray


Real life example with ESA's EOPF Zarr: `gdalmdiminfo /vsicurl/https://objectstore.eodc.eu:2222/e05ab01a9d56408d82ac32d69a5aae2a:202504-s02msil2a/15/products/cpm_v256/S2A_MSIL2A_20250415T094041_N0511_R036_T35VLC_20250415T155631.zarr/.zmetadata `

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [x] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
