### PR TITLE
Only run cron CI job on OSGeo repo

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -114,7 +114,7 @@ jobs:
           ghcr.io/osgeo/gdal:${{ matrix.tag }}-latest-amd64 \
           ghcr.io/osgeo/gdal:${{ matrix.tag }}-latest-arm64
       - name: Alias ubuntu-full-latest to latest
-        if: matrix.tag == 'ubuntu-full'
+        if: matrix.tag == 'ubuntu-full' && env.PUSH_PACKAGES == 'true'
         run: |
           docker buildx imagetools create ghcr.io/osgeo/gdal:ubuntu-full-latest --tag ghcr.io/osgeo/gdal:latest
 


### PR DESCRIPTION
## What does this PR do?

Also refactor job matrix to remove the proprietary SDKs build.  This cleans up the logic a bit, also since we do not push the proprietary SDK image to remote, no need to wait for that job to finish before creating the manifests for the other images.

I noticed the cron job for the docker images was running in my fork and getting a notification email about it failing overnight each night.


## What are related issues/pull requests?

#13166
#13171 
#13154

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed



