### PR TITLE
[Backport release/3.11] ADBC: error out on non-existing database with DuckDB

### DIFF
--- a/autotest/ogr/ogr_adbc.py
+++ b/autotest/ogr/ogr_adbc.py
@@ -393,6 +393,25 @@ def test_ogr_adbc_duckdb_sql(tmp_path):
 
 
 ###############################################################################
+
+
+@pytest.mark.skipif(
+    not _has_adbc_driver_manager(),
+    reason="ADBC driver built without AdbcDriverManager",
+)
+def test_ogr_adbc_duckdb_not_existing_file(tmp_path):
+
+    if not _has_libduckdb():
+        pytest.skip("libduckdb.so missing")
+
+    with pytest.raises(Exception, match="/i/do_not/exist does not exist"):
+        gdal.OpenEx(
+            "ADBC:/i/do_not/exist",
+            open_options=["ADBC_DRIVER=libduckdb"],
+        )
+
+
+###############################################################################
 # Run test_ogrsf on a SQLite3 database
 
 

--- a/ogr/ogrsf_frmts/adbc/ogradbcdataset.cpp
+++ b/ogr/ogrsf_frmts/adbc/ogradbcdataset.cpp
@@ -322,8 +322,15 @@ bool OGRADBCDataset::Open(const GDALOpenInfo *poOpenInfo)
     }
 
     // Set options
-    if (m_bIsDuckDBDriver)
+    if (m_bIsDuckDBDriver && pszFilename[0])
     {
+        VSIStatBuf sStatBuf;
+        if (!bIsParquet && VSIStat(pszFilename, &sStatBuf) != 0)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined, "%s does not exist",
+                     pszFilename);
+            return false;
+        }
         if (ADBC_CALL(DatabaseSetOption, &m_database, "path",
                       bIsParquet ? ":memory:" : pszFilename,
                       error) != ADBC_STATUS_OK)


### PR DESCRIPTION
Backport #13177
 **Authored by:** @rouault