### PR TITLE
Updating CPLGetExtension to CPLGetExtensionSafe

### DIFF
--- a/fuzzers/ogr_fuzzer.cpp
+++ b/fuzzers/ogr_fuzzer.cpp
@@ -114,9 +114,9 @@ int LLVMFuzzerTestOneInput(const uint8_t *buf, size_t len)
     std::string osFileInTar;
     for (int i = 0; papszFiles && papszFiles[i]; ++i)
     {
-        if (EQUAL(CPLGetExtension(papszFiles[i]), "pol") ||
-            EQUAL(CPLGetExtension(papszFiles[i]), "arc") ||
-            EQUAL(CPLGetExtension(papszFiles[i]), "pnt"))
+        if (CPLGetExtensionSafe(papszFiles[i]) == "pol" ||
+            CPLGetExtensionSafe(papszFiles[i]) == "arc" ||
+            CPLGetExtensionSafe(papszFiles[i]) == "pnt")
         {
             osFileInTar = papszFiles[i];
             break;


### PR DESCRIPTION
## What does this PR do?
Makes that fuzzers\ogr_fuzzer.cpp file compiles using CPLGetExtensionSafe() ninstead of CPLGetExtension()

## What are related issues/pull requests?
None, i was just trying to compilate MiraMonFuzzer in ogr project.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] All CI builds and checks have passed
