### PR TITLE
GTI: update path to example gti schema

### DIFF
--- a/doc/source/drivers/raster/gti.rst
+++ b/doc/source/drivers/raster/gti.rst
@@ -298,7 +298,7 @@ metadata domains such as GeoPackage)
 GTI XML format
 ----------------
 
-A `XML schema of the GDAL GTI format <https://raw.githubusercontent.com/OSGeo/gdal/master/frmts/gti/data/gdaltileindex.xsd>`_
+A XML schema of the GDAL GTI format (:source_file:`frmts/gti/data/gdaltileindex.xsd`)
 is available.
 
 The following artificial example contains all potential elements and attributes.


### PR DESCRIPTION
## What does this PR do?
Updates the path to the example gti xml schema as the link in this section is broken: https://gdal.org/en/latest/drivers/raster/gti.html#gti-xml-format

## What are related issues/pull requests?

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
