### PR TITLE
Parquet: add update support using OGREditableLayer mechanism

### DIFF
--- a/.github/workflows/ubuntu_24.04/expected_ogrinfo_formats.txt
+++ b/.github/workflows/ubuntu_24.04/expected_ogrinfo_formats.txt
@@ -73,7 +73,7 @@ Supported Formats: (ro:read-only, rw:read-write, +:write from scratch, u:update,
   MVT -vector- (rw+v): Mapbox Vector Tiles (*.mvt, *.mvt.gz, *.pbf)
   NGW -raster,vector- (rw+s): NextGIS Web
   MapML -vector- (rw+v): MapML
-  Parquet -vector- (rw+v): (Geo)Parquet (*.parquet)
+  Parquet -vector- (rw+uv): (Geo)Parquet (*.parquet)
   Arrow -vector- (rw+v): (Geo)Arrow IPC File Format / Stream (*.arrow, *.feather, *.arrows, *.ipc)
   GTFS -vector- (rov): General Transit Feed Specification (*.zip)
   PMTiles -vector- (rw+v): ProtoMap Tiles (*.pmtiles)

--- a/.github/workflows/windows_conda_expected_ogrinfo_formats.txt
+++ b/.github/workflows/windows_conda_expected_ogrinfo_formats.txt
@@ -68,7 +68,7 @@ Supported Formats: (ro:read-only, rw:read-write, +:write from scratch, u:update,
   MVT -vector- (rw+v): Mapbox Vector Tiles (*.mvt, *.mvt.gz, *.pbf)
   NGW -raster,vector- (rw+s): NextGIS Web
   MapML -vector- (rw+v): MapML
-  Parquet -vector- (rw+v): (Geo)Parquet (*.parquet)
+  Parquet -vector- (rw+uv): (Geo)Parquet (*.parquet)
   Arrow -vector- (rw+v): (Geo)Arrow IPC File Format / Stream (*.arrow, *.feather, *.arrows, *.ipc)
   GTFS -vector- (rov): General Transit Feed Specification (*.zip)
   PMTiles -vector- (rw+v): ProtoMap Tiles (*.pmtiles)

--- a/autotest/ogr/ogr_parquet.py
+++ b/autotest/ogr/ogr_parquet.py
@@ -4440,3 +4440,179 @@ def test_ogr_parquet_test_ogrsf_parquet_geometry():
 
     assert "INFO" in ret
     assert "ERROR" not in ret
+
+
+###############################################################################
+
+
+def test_ogr_parquet_update(tmp_path):
+
+    with gdal.GetDriverByName("PARQUET").CreateVector(tmp_path / "test.parquet") as ds:
+        lyr = ds.CreateLayer(
+            "test", geom_type=ogr.wkbPoint, srs=osr.SpatialReference(epsg=32631)
+        )
+        lyr.CreateField(ogr.FieldDefn("str", ogr.OFTString))
+        lyr.CreateField(ogr.FieldDefn("int", ogr.OFTInteger))
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f["str"] = "foo"
+        f["int"] = 123
+        f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (1 2)"))
+        lyr.CreateFeature(f)
+
+    with ogr.Open(tmp_path / "test.parquet", gdal.GA_Update) as ds:
+        lyr = ds.GetLayer(0)
+        assert lyr.GetMetadata("_GDAL_CREATION_OPTIONS_") == {}
+        assert lyr.GetFIDColumn() == ""
+        assert lyr.GetGeometryColumn() == "geometry"
+        assert lyr.GetGeomType() == ogr.wkbPoint
+        assert lyr.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        assert lyr.TestCapability(ogr.OLCSequentialWrite)
+        assert lyr.TestCapability(ogr.OLCRandomWrite)
+        assert lyr.TestCapability(ogr.OLCCreateField)
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f["str"] = "bar"
+        f["int"] = 456
+        f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (3 4)"))
+        lyr.CreateFeature(f)
+        assert lyr.GetFeatureCount() == 2
+
+    with ogr.Open(tmp_path / "test.parquet") as ds:
+        lyr = ds.GetLayer(0)
+        assert lyr.GetMetadata("_GDAL_CREATION_OPTIONS_") == {}
+        assert lyr.GetFIDColumn() == ""
+        assert lyr.GetGeometryColumn() == "geometry"
+        assert lyr.GetGeomType() == ogr.wkbPoint
+        assert lyr.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        assert lyr.GetFeatureCount() == 2
+        f = lyr.GetNextFeature()
+        assert f["str"] == "foo"
+        assert f["int"] == 123
+        assert f.GetGeometryRef().ExportToWkt() == "POINT (1 2)"
+        f = lyr.GetNextFeature()
+        assert f["str"] == "bar"
+        assert f["int"] == 456
+        assert f.GetGeometryRef().ExportToWkt() == "POINT (3 4)"
+
+    with ogr.Open(tmp_path / "test.parquet", gdal.GA_Update) as ds:
+        lyr = ds.GetLayer(0)
+        lyr.CreateField(ogr.FieldDefn("real", ogr.OFTReal))
+        f = lyr.GetNextFeature()
+        f["real"] = 1.5
+        lyr.SetFeature(f)
+
+    with ogr.Open(tmp_path / "test.parquet") as ds:
+        lyr = ds.GetLayer(0)
+        assert lyr.GetFeatureCount() == 2
+        f = lyr.GetNextFeature()
+        assert f["str"] == "foo"
+        assert f["int"] == 123
+        assert f["real"] == 1.5
+        assert f.GetGeometryRef().ExportToWkt() == "POINT (1 2)"
+
+    if test_cli_utilities.get_test_ogrsf_path() is not None:
+        ret = gdaltest.runexternal(
+            test_cli_utilities.get_test_ogrsf_path() + f" {tmp_path}/test.parquet"
+        )
+
+        assert "INFO" in ret
+        assert "ERROR" not in ret
+
+
+###############################################################################
+
+
+def test_ogr_parquet_update_with_creation_options_implicit(tmp_path):
+
+    with gdal.GetDriverByName("PARQUET").CreateVector(tmp_path / "test.parquet") as ds:
+        lyr = ds.CreateLayer(
+            "test",
+            geom_type=ogr.wkbPoint,
+            srs=osr.SpatialReference(epsg=32631),
+            options=["FID=my_fid", "GEOMETRY_NAME=my_geom", "EDGES=SPHERICAL"],
+        )
+        lyr.CreateField(ogr.FieldDefn("str", ogr.OFTString))
+        lyr.CreateField(ogr.FieldDefn("int", ogr.OFTInteger))
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f["str"] = "foo"
+        f["int"] = 123
+        f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (1 2)"))
+        lyr.CreateFeature(f)
+
+    with ogr.Open(tmp_path / "test.parquet", gdal.GA_Update) as ds:
+        lyr = ds.GetLayer(0)
+        assert lyr.GetMetadata("_GDAL_CREATION_OPTIONS_") == {}
+        assert lyr.GetMetadataItem("EDGES") == "SPHERICAL"
+        assert lyr.GetFIDColumn() == "my_fid"
+        assert lyr.GetGeometryColumn() == "my_geom"
+        assert lyr.GetGeomType() == ogr.wkbPoint
+        assert lyr.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f["str"] = "bar"
+        f["int"] = 456
+        f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (3 4)"))
+        lyr.CreateFeature(f)
+        assert lyr.GetFeatureCount() == 2
+
+    with ogr.Open(tmp_path / "test.parquet") as ds:
+        lyr = ds.GetLayer(0)
+        assert lyr.GetMetadata("_GDAL_CREATION_OPTIONS_") == {}
+        assert lyr.GetMetadataItem("EDGES") == "SPHERICAL"
+        assert lyr.GetFIDColumn() == "my_fid"
+        assert lyr.GetGeometryColumn() == "my_geom"
+        assert lyr.GetGeomType() == ogr.wkbPoint
+        assert lyr.GetSpatialRef().GetAuthorityCode(None) == "32631"
+        assert lyr.GetFeatureCount() == 2
+        f = lyr.GetNextFeature()
+        assert f["str"] == "foo"
+        assert f["int"] == 123
+        assert f.GetGeometryRef().ExportToWkt() == "POINT (1 2)"
+        f = lyr.GetNextFeature()
+        assert f["str"] == "bar"
+        assert f["int"] == 456
+        assert f.GetGeometryRef().ExportToWkt() == "POINT (3 4)"
+
+
+###############################################################################
+
+
+def test_ogr_parquet_update_with_creation_options_explicit(tmp_path):
+
+    with gdal.GetDriverByName("PARQUET").CreateVector(tmp_path / "test.parquet") as ds:
+        lyr = ds.CreateLayer(
+            "test",
+            geom_type=ogr.wkbPoint,
+            srs=osr.SpatialReference(epsg=32631),
+            options=["ROW_GROUP_SIZE=1"],
+        )
+        lyr.CreateField(ogr.FieldDefn("str", ogr.OFTString))
+        lyr.CreateField(ogr.FieldDefn("int", ogr.OFTInteger))
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f["str"] = "foo"
+        f["int"] = 123
+        f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (1 2)"))
+        lyr.CreateFeature(f)
+
+    with ogr.Open(tmp_path / "test.parquet", gdal.GA_Update) as ds:
+        lyr = ds.GetLayer(0)
+        assert lyr.GetMetadata("_GDAL_CREATION_OPTIONS_") == {"ROW_GROUP_SIZE": "1"}
+        assert lyr.GetMetadataItem("NUM_ROW_GROUPS", "_PARQUET_") == "1"
+        f = ogr.Feature(lyr.GetLayerDefn())
+        f["str"] = "bar"
+        f["int"] = 456
+        f.SetGeometry(ogr.CreateGeometryFromWkt("POINT (3 4)"))
+        lyr.CreateFeature(f)
+        assert lyr.GetFeatureCount() == 2
+
+    with ogr.Open(tmp_path / "test.parquet") as ds:
+        lyr = ds.GetLayer(0)
+        assert lyr.GetMetadata("_GDAL_CREATION_OPTIONS_") == {"ROW_GROUP_SIZE": "1"}
+        assert lyr.GetMetadataItem("NUM_ROW_GROUPS", "_PARQUET_") == "2"
+        assert lyr.GetFeatureCount() == 2
+        f = lyr.GetNextFeature()
+        assert f["str"] == "foo"
+        assert f["int"] == 123
+        assert f.GetGeometryRef().ExportToWkt() == "POINT (1 2)"
+        f = lyr.GetNextFeature()
+        assert f["str"] == "bar"
+        assert f["int"] == 456
+        assert f.GetGeometryRef().ExportToWkt() == "POINT (3 4)"

--- a/doc/source/drivers/vector/parquet.rst
+++ b/doc/source/drivers/vector/parquet.rst
@@ -244,6 +244,25 @@ it is lower by 4). This number can be configured with the configuration option
 :config:`GDAL_NUM_THREADS`, which can be set to an integer value or
 ``ALL_CPUS``.
 
+Update support
+--------------
+
+.. versionadded:: 3.12.0
+
+The driver supports adding, updating, removing features and fields. Note that
+this is accomplished by rewriting the whole file during :cpp:func:`GDALDataset::FlushCache`
+or when closing the dataset, and keeping into memory all modifications between
+two flushes.
+
+If the file to be updated has been created by GDAL >= 3.12, the creation options
+to create the original file will be re-applied when creating the updated file.
+Stability of feature ids is only guaranteed if the original file has been
+created with an explicit ``FID`` creation option.
+
+If the file to be updated has been created outside of GDAL, the original
+non-scalar/nested field types will not always be preserved, but a JSON
+representation may be used instead.
+
 Validation script
 -----------------
 

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowdataset.hpp
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowdataset.hpp
@@ -29,7 +29,7 @@ inline OGRArrowDataset::OGRArrowDataset(
 /*                            SetLayer()                                */
 /************************************************************************/
 
-inline void OGRArrowDataset::SetLayer(std::unique_ptr<OGRArrowLayer> &&poLayer)
+inline void OGRArrowDataset::SetLayer(std::unique_ptr<IOGRArrowLayer> &&poLayer)
 {
     m_poLayer = std::move(poLayer);
 }
@@ -71,7 +71,9 @@ OGRArrowDataset::GetFieldDomain(const std::string &name) const
     if (iter == m_oMapDomainNameToCol.end())
         return nullptr;
     return m_oMapFieldDomains
-        .insert(std::pair(name, m_poLayer->BuildDomain(name, iter->second)))
+        .insert(
+            std::pair(name, m_poLayer->GetUnderlyingArrowLayer()->BuildDomain(
+                                name, iter->second)))
         .first->second.get();
 }
 
@@ -90,7 +92,7 @@ inline int OGRArrowDataset::GetLayerCount() const
 
 inline const OGRLayer *OGRArrowDataset::GetLayer(int idx) const
 {
-    return idx == 0 ? m_poLayer.get() : nullptr;
+    return idx == 0 ? m_poLayer->GetLayer() : nullptr;
 }
 
 #endif /* OGARROWDATASET_HPP_INCLUDED */

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
@@ -36,6 +36,8 @@
 #pragma clang diagnostic ignored "-Wweak-vtables"
 #endif
 
+inline IOGRArrowLayer::~IOGRArrowLayer() = default;
+
 /************************************************************************/
 /*                         OGRArrowLayer()                              */
 /************************************************************************/

--- a/ogr/ogrsf_frmts/generic/ogreditablelayer.cpp
+++ b/ogr/ogrsf_frmts/generic/ogreditablelayer.cpp
@@ -634,8 +634,7 @@ int OGREditableLayer::TestCapability(const char *pszCap) const
         EQUAL(pszCap, OLCReorderFields) || EQUAL(pszCap, OLCAlterFieldDefn) ||
         EQUAL(pszCap, OLCAlterGeomFieldDefn) || EQUAL(pszCap, OLCDeleteFeature))
     {
-        return m_poDecoratedLayer->TestCapability(OLCCreateField) == TRUE ||
-               m_poDecoratedLayer->TestCapability(OLCSequentialWrite) == TRUE;
+        return TRUE;
     }
     if (EQUAL(pszCap, OLCCreateGeomField))
         return m_bSupportsCreateGeomField;

--- a/ogr/ogrsf_frmts/parquet/ogrparquetdataset.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetdataset.cpp
@@ -22,9 +22,8 @@
 /*                         OGRParquetDataset()                          */
 /************************************************************************/
 
-OGRParquetDataset::OGRParquetDataset(
-    const std::shared_ptr<arrow::MemoryPool> &poMemoryPool)
-    : OGRArrowDataset(poMemoryPool)
+OGRParquetDataset::OGRParquetDataset()
+    : OGRArrowDataset(arrow::MemoryPool::CreateDefault())
 {
 }
 
@@ -61,6 +60,132 @@ CPLErr OGRParquetDataset::Close()
     }
 
     return eErr;
+}
+
+/***********************************************************************/
+/*                          CreateReaderLayer()                        */
+/***********************************************************************/
+
+std::unique_ptr<OGRParquetLayer>
+OGRParquetDataset::CreateReaderLayer(const std::string &osFilename,
+                                     VSILFILE *&fpIn,
+                                     CSLConstList papszOpenOptionsIn)
+{
+    try
+    {
+        std::shared_ptr<arrow::io::RandomAccessFile> infile;
+        if (STARTS_WITH(osFilename.c_str(), "/vsi") ||
+            CPLTestBool(CPLGetConfigOption("OGR_PARQUET_USE_VSI", "NO")))
+        {
+            VSIVirtualHandleUniquePtr fp(fpIn);
+            fpIn = nullptr;
+            if (fp == nullptr)
+            {
+                fp.reset(VSIFOpenL(osFilename.c_str(), "rb"));
+                if (fp == nullptr)
+                    return nullptr;
+            }
+            infile = std::make_shared<OGRArrowRandomAccessFile>(osFilename,
+                                                                std::move(fp));
+        }
+        else
+        {
+            PARQUET_ASSIGN_OR_THROW(infile,
+                                    arrow::io::ReadableFile::Open(osFilename));
+        }
+
+        // Open Parquet file reader
+        std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
+
+        const int nNumCPUs = OGRParquetLayerBase::GetNumCPUs();
+        const char *pszUseThreads =
+            CPLGetConfigOption("OGR_PARQUET_USE_THREADS", nullptr);
+        if (!pszUseThreads && nNumCPUs > 1)
+        {
+            pszUseThreads = "YES";
+        }
+        const bool bUseThreads = pszUseThreads && CPLTestBool(pszUseThreads);
+
+        const char *pszParquetBatchSize =
+            CPLGetConfigOption("OGR_PARQUET_BATCH_SIZE", nullptr);
+
+        auto poMemoryPool = GetMemoryPool();
+#if ARROW_VERSION_MAJOR >= 21
+        parquet::arrow::FileReaderBuilder fileReaderBuilder;
+        {
+            auto st = fileReaderBuilder.Open(std::move(infile));
+            if (!st.ok())
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "parquet::arrow::FileReaderBuilder::Open() failed: %s",
+                         st.message().c_str());
+                return nullptr;
+            }
+        }
+        fileReaderBuilder.memory_pool(poMemoryPool);
+        parquet::ArrowReaderProperties fileReaderProperties;
+        fileReaderProperties.set_arrow_extensions_enabled(CPLTestBool(
+            CPLGetConfigOption("OGR_PARQUET_ENABLE_ARROW_EXTENSIONS", "YES")));
+        if (pszParquetBatchSize)
+        {
+            fileReaderProperties.set_batch_size(
+                CPLAtoGIntBig(pszParquetBatchSize));
+        }
+        if (bUseThreads)
+        {
+            fileReaderProperties.set_use_threads(true);
+        }
+        fileReaderBuilder.properties(fileReaderProperties);
+        {
+            auto res = fileReaderBuilder.Build();
+            if (!res.ok())
+            {
+                CPLError(
+                    CE_Failure, CPLE_AppDefined,
+                    "parquet::arrow::FileReaderBuilder::Build() failed: %s",
+                    res.status().message().c_str());
+                return nullptr;
+            }
+            arrow_reader = std::move(*res);
+        }
+#elif ARROW_VERSION_MAJOR >= 19
+        PARQUET_ASSIGN_OR_THROW(
+            arrow_reader,
+            parquet::arrow::OpenFile(std::move(infile), poMemoryPool));
+#else
+        auto st = parquet::arrow::OpenFile(std::move(infile), poMemoryPool,
+                                           &arrow_reader);
+        if (!st.ok())
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "parquet::arrow::OpenFile() failed: %s",
+                     st.message().c_str());
+            return nullptr;
+        }
+#endif
+
+#if ARROW_VERSION_MAJOR < 21
+        if (pszParquetBatchSize)
+        {
+            arrow_reader->set_batch_size(CPLAtoGIntBig(pszParquetBatchSize));
+        }
+
+        if (bUseThreads)
+        {
+            arrow_reader->set_use_threads(true);
+        }
+#endif
+
+        return std::make_unique<OGRParquetLayer>(
+            this, CPLGetBasenameSafe(osFilename.c_str()).c_str(),
+            std::move(arrow_reader), papszOpenOptionsIn);
+    }
+    catch (const std::exception &e)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Parquet exception: %s",
+                 e.what());
+        return nullptr;
+    }
 }
 
 /***********************************************************************/

--- a/ogr/ogrsf_frmts/parquet/ogrparquetdriver.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetdriver.cpp
@@ -21,6 +21,7 @@
 #include "ogr_parquet.h"
 #include "ogrparquetdrivercore.h"
 #include "memdataset.h"
+#include "ogreditablelayer.h"
 
 #include "../arrow_common/ograrrowrandomaccessfile.h"
 #include "../arrow_common/vsiarrowfilesystem.hpp"
@@ -43,11 +44,8 @@ static GDALDataset *OpenFromDatasetFactory(
     std::shared_ptr<arrow::dataset::Dataset> dataset;
     PARQUET_ASSIGN_OR_THROW(dataset, factory->Finish());
 
-    auto poMemoryPool = std::shared_ptr<arrow::MemoryPool>(
-        arrow::MemoryPool::CreateDefault().release());
-
     const bool bIsVSI = STARTS_WITH(osBasePath.c_str(), "/vsi");
-    auto poDS = std::make_unique<OGRParquetDataset>(poMemoryPool);
+    auto poDS = std::make_unique<OGRParquetDataset>();
     auto poLayer = std::make_unique<OGRParquetDatasetLayer>(
         poDS.get(), CPLGetBasenameSafe(osBasePath.c_str()).c_str(), bIsVSI,
         dataset, papszOpenOptions);
@@ -306,14 +304,230 @@ static GDALDataset *BuildMemDatasetWithRowGroupExtents(OGRParquetLayer *poLayer)
 }
 
 /************************************************************************/
+/*                     OGRParquetEditableLayerSynchronizer              */
+/************************************************************************/
+
+class OGRParquetEditableLayer;
+
+class OGRParquetEditableLayerSynchronizer final
+    : public IOGREditableLayerSynchronizer
+{
+    OGRParquetDataset *const m_poDS;
+    OGRParquetEditableLayer *const m_poEditableLayer;
+    const std::string m_osFilename;
+    const CPLStringList m_aosOpenOptions;
+
+    CPL_DISALLOW_COPY_ASSIGN(OGRParquetEditableLayerSynchronizer)
+
+  public:
+    OGRParquetEditableLayerSynchronizer(
+        OGRParquetDataset *poDS, OGRParquetEditableLayer *poEditableLayer,
+        const std::string &osFilename, CSLConstList papszOpenOptions)
+        : m_poDS(poDS), m_poEditableLayer(poEditableLayer),
+          m_osFilename(osFilename),
+          m_aosOpenOptions(CSLDuplicate(papszOpenOptions))
+    {
+    }
+
+    OGRErr EditableSyncToDisk(OGRLayer *poEditableLayer,
+                              OGRLayer **ppoDecoratedLayer) override;
+};
+
+/************************************************************************/
+/*                        OGRParquetEditableLayer                       */
+/************************************************************************/
+
+class OGRParquetEditableLayer final : public IOGRArrowLayer,
+                                      public OGREditableLayer
+{
+  public:
+    OGRParquetEditableLayer(OGRParquetDataset *poDS,
+                            const std::string &osFilename,
+                            std::unique_ptr<OGRParquetLayer> poParquetLayer,
+                            CSLConstList papszOpenOptions)
+        : OGREditableLayer(poParquetLayer.get(), false,
+                           new OGRParquetEditableLayerSynchronizer(
+                               poDS, this, osFilename, papszOpenOptions),
+                           false),
+          m_poParquetLayer(std::move(poParquetLayer))
+    {
+    }
+
+    ~OGRParquetEditableLayer() override
+    {
+        SyncToDisk();
+        delete m_poSynchronizer;
+        m_poSynchronizer = nullptr;
+    }
+
+    OGRLayer *GetLayer() override;
+
+    OGRParquetLayer *GetUnderlyingArrowLayer() override
+    {
+        return m_poParquetLayer.get();
+    }
+
+    void
+    SetUnderlyingArrowLayer(std::unique_ptr<OGRParquetLayer> poParquetLayer)
+    {
+        m_poParquetLayer = std::move(poParquetLayer);
+    }
+
+  private:
+    std::unique_ptr<OGRParquetLayer> m_poParquetLayer{};
+};
+
+/************************************************************************/
+/*                 OGRParquetEditableLayer::GetLayer()                  */
+/************************************************************************/
+
+OGRLayer *OGRParquetEditableLayer::GetLayer()
+{
+    return this;
+}
+
+/************************************************************************/
+/*      OGRParquetEditableLayerSynchronizer::EditableSyncToDisk()       */
+/************************************************************************/
+
+OGRErr OGRParquetEditableLayerSynchronizer::EditableSyncToDisk(
+    OGRLayer *poEditableLayer, OGRLayer **ppoDecoratedLayer)
+{
+    CPLAssert(*ppoDecoratedLayer ==
+              m_poEditableLayer->GetUnderlyingArrowLayer());
+
+    const std::string osTmpFilename = m_osFilename + ".tmp.parquet";
+    try
+    {
+        std::shared_ptr<arrow::io::OutputStream> out_file;
+        if (STARTS_WITH(osTmpFilename.c_str(), "/vsi") ||
+            CPLTestBool(CPLGetConfigOption("OGR_PARQUET_USE_VSI", "YES")))
+        {
+            VSIVirtualHandleUniquePtr fp =
+                VSIFilesystemHandler::OpenStatic(osTmpFilename.c_str(), "wb");
+            if (fp == nullptr)
+            {
+                CPLError(CE_Failure, CPLE_FileIO, "Cannot create %s",
+                         osTmpFilename.c_str());
+                return OGRERR_FAILURE;
+            }
+            out_file = std::make_shared<OGRArrowWritableFile>(std::move(fp));
+        }
+        else
+        {
+            PARQUET_ASSIGN_OR_THROW(
+                out_file, arrow::io::FileOutputStream::Open(osTmpFilename));
+        }
+
+        OGRParquetWriterDataset writerDS(out_file);
+
+        auto poParquetLayer = m_poEditableLayer->GetUnderlyingArrowLayer();
+        CPLStringList aosCreationOptions(poParquetLayer->GetCreationOptions());
+        const char *pszFIDColumn = poParquetLayer->GetFIDColumn();
+        if (pszFIDColumn[0])
+            aosCreationOptions.SetNameValue("FID", pszFIDColumn);
+        const char *pszEdges = poParquetLayer->GetMetadataItem("EDGES");
+        if (pszEdges)
+            aosCreationOptions.SetNameValue("EDGES", pszEdges);
+        auto poWriterLayer = writerDS.CreateLayer(
+            CPLGetBasenameSafe(m_osFilename.c_str()).c_str(),
+            poParquetLayer->GetGeomType() == wkbNone
+                ? nullptr
+                : poParquetLayer->GetLayerDefn()->GetGeomFieldDefn(0),
+            aosCreationOptions.List());
+        if (!poWriterLayer)
+            return OGRERR_FAILURE;
+
+        // Create target fields from source fields
+        for (const auto poSrcFieldDefn :
+             poEditableLayer->GetLayerDefn()->GetFields())
+        {
+            if (poWriterLayer->CreateField(poSrcFieldDefn) != OGRERR_NONE)
+                return OGRERR_FAILURE;
+        }
+
+        // Disable all filters and backup them.
+        const char *pszQueryStringConst = poEditableLayer->GetAttrQueryString();
+        const std::string osQueryString =
+            pszQueryStringConst ? pszQueryStringConst : "";
+        poEditableLayer->SetAttributeFilter(nullptr);
+
+        const int iFilterGeomIndexBak = poEditableLayer->GetGeomFieldFilter();
+        std::unique_ptr<OGRGeometry> poFilterGeomBak;
+        if (const OGRGeometry *poFilterGeomSrc =
+                poEditableLayer->GetSpatialFilter())
+            poFilterGeomBak.reset(poFilterGeomSrc->clone());
+        poEditableLayer->SetSpatialFilter(nullptr);
+
+        bool bError = false;
+
+        // Copy all features
+        for (auto &&poSrcFeature : *poEditableLayer)
+        {
+            OGRFeature oDstFeature(poWriterLayer->GetLayerDefn());
+            oDstFeature.SetFrom(poSrcFeature.get());
+            oDstFeature.SetFID(poSrcFeature->GetFID());
+            if (poWriterLayer->CreateFeature(&oDstFeature) != OGRERR_NONE)
+            {
+                bError = true;
+                break;
+            }
+        }
+
+        // Restore filters.
+        if (!osQueryString.empty())
+            poEditableLayer->SetAttributeFilter(osQueryString.c_str());
+        poEditableLayer->SetSpatialFilter(iFilterGeomIndexBak,
+                                          poFilterGeomBak.get());
+
+        // Flush and close file
+        if (bError || writerDS.Close() != CE_None)
+            return OGRERR_FAILURE;
+    }
+    catch (const std::exception &e)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Parquet exception: %s",
+                 e.what());
+        return OGRERR_FAILURE;
+    }
+
+    // Close original Parquet file
+    m_poEditableLayer->SetUnderlyingArrowLayer(nullptr);
+    *ppoDecoratedLayer = nullptr;
+
+    // Backup original file, and rename new file into it
+    const std::string osTmpOriFilename = m_osFilename + ".ogr_bak";
+    if (VSIRename(m_osFilename.c_str(), osTmpOriFilename.c_str()) != 0 ||
+        VSIRename(osTmpFilename.c_str(), m_osFilename.c_str()) != 0)
+    {
+        CPLError(CE_Failure, CPLE_AppDefined, "Cannot rename files");
+        return OGRERR_FAILURE;
+    }
+    // Remove backup file
+    VSIUnlink(osTmpOriFilename.c_str());
+
+    // Re-open parquet file
+    VSILFILE *fp = nullptr;
+    auto poParquetLayer =
+        m_poDS->CreateReaderLayer(m_osFilename, fp, m_aosOpenOptions.List());
+    if (!poParquetLayer)
+    {
+        return OGRERR_FAILURE;
+    }
+
+    // Update adapters
+    *ppoDecoratedLayer = poParquetLayer.get();
+    m_poEditableLayer->SetUnderlyingArrowLayer(std::move(poParquetLayer));
+
+    return OGRERR_NONE;
+}
+
+/************************************************************************/
 /*                                Open()                                */
 /************************************************************************/
 
 static GDALDataset *OGRParquetDriverOpen(GDALOpenInfo *poOpenInfo)
 {
-    if (poOpenInfo->eAccess == GA_Update)
-        return nullptr;
-
 #if ARROW_VERSION_MAJOR >= 21
     // Register geoarrow.wkb extension if not already done
     if (!arrow::GetExtensionType(EXTENSION_NAME_GEOARROW_WKB) &&
@@ -366,6 +580,9 @@ static GDALDataset *OGRParquetDriverOpen(GDALOpenInfo *poOpenInfo)
             // If there's a _metadata file, then use it to avoid listing files
             try
             {
+                if (poOpenInfo->eAccess == GA_Update)
+                    return nullptr;
+
                 return OpenParquetDatasetWithMetadata(
                     osBasePath, "_metadata", osQueryParameters,
                     poOpenInfo->papszOpenOptions);
@@ -414,6 +631,9 @@ static GDALDataset *OGRParquetDriverOpen(GDALOpenInfo *poOpenInfo)
             {
                 try
                 {
+                    if (poOpenInfo->eAccess == GA_Update)
+                        return nullptr;
+
                     return OpenParquetDatasetWithoutMetadata(
                         osBasePath, osQueryParameters,
                         poOpenInfo->papszOpenOptions);
@@ -448,133 +668,26 @@ static GDALDataset *OGRParquetDriverOpen(GDALOpenInfo *poOpenInfo)
         osFilename = poOpenInfo->pszFilename + strlen("PARQUET:");
     }
 
-    try
-    {
-        std::shared_ptr<arrow::io::RandomAccessFile> infile;
-        if (STARTS_WITH(osFilename.c_str(), "/vsi") ||
-            CPLTestBool(CPLGetConfigOption("OGR_PARQUET_USE_VSI", "NO")))
-        {
-            VSIVirtualHandleUniquePtr fp(poOpenInfo->fpL);
-            poOpenInfo->fpL = nullptr;
-            if (fp == nullptr)
-            {
-                fp.reset(VSIFOpenL(osFilename.c_str(), "rb"));
-                if (fp == nullptr)
-                    return nullptr;
-            }
-            infile = std::make_shared<OGRArrowRandomAccessFile>(osFilename,
-                                                                std::move(fp));
-        }
-        else
-        {
-            PARQUET_ASSIGN_OR_THROW(infile,
-                                    arrow::io::ReadableFile::Open(osFilename));
-        }
-
-        // Open Parquet file reader
-        std::unique_ptr<parquet::arrow::FileReader> arrow_reader;
-        auto poMemoryPool = std::shared_ptr<arrow::MemoryPool>(
-            arrow::MemoryPool::CreateDefault().release());
-
-        const int nNumCPUs = OGRParquetLayerBase::GetNumCPUs();
-        const char *pszUseThreads =
-            CPLGetConfigOption("OGR_PARQUET_USE_THREADS", nullptr);
-        if (!pszUseThreads && nNumCPUs > 1)
-        {
-            pszUseThreads = "YES";
-        }
-        const bool bUseThreads = pszUseThreads && CPLTestBool(pszUseThreads);
-
-        const char *pszParquetBatchSize =
-            CPLGetConfigOption("OGR_PARQUET_BATCH_SIZE", nullptr);
-
-#if ARROW_VERSION_MAJOR >= 21
-        parquet::arrow::FileReaderBuilder fileReaderBuilder;
-        {
-            auto st = fileReaderBuilder.Open(std::move(infile));
-            if (!st.ok())
-            {
-                CPLError(CE_Failure, CPLE_AppDefined,
-                         "parquet::arrow::FileReaderBuilder::Open() failed: %s",
-                         st.message().c_str());
-                return nullptr;
-            }
-        }
-        fileReaderBuilder.memory_pool(poMemoryPool.get());
-        parquet::ArrowReaderProperties fileReaderProperties;
-        fileReaderProperties.set_arrow_extensions_enabled(CPLTestBool(
-            CPLGetConfigOption("OGR_PARQUET_ENABLE_ARROW_EXTENSIONS", "YES")));
-        if (pszParquetBatchSize)
-        {
-            fileReaderProperties.set_batch_size(
-                CPLAtoGIntBig(pszParquetBatchSize));
-        }
-        if (bUseThreads)
-        {
-            fileReaderProperties.set_use_threads(true);
-        }
-        fileReaderBuilder.properties(fileReaderProperties);
-        {
-            auto res = fileReaderBuilder.Build();
-            if (!res.ok())
-            {
-                CPLError(
-                    CE_Failure, CPLE_AppDefined,
-                    "parquet::arrow::FileReaderBuilder::Build() failed: %s",
-                    res.status().message().c_str());
-                return nullptr;
-            }
-            arrow_reader = std::move(*res);
-        }
-#elif ARROW_VERSION_MAJOR >= 19
-        PARQUET_ASSIGN_OR_THROW(
-            arrow_reader,
-            parquet::arrow::OpenFile(std::move(infile), poMemoryPool.get()));
-#else
-        auto st = parquet::arrow::OpenFile(std::move(infile),
-                                           poMemoryPool.get(), &arrow_reader);
-        if (!st.ok())
-        {
-            CPLError(CE_Failure, CPLE_AppDefined,
-                     "parquet::arrow::OpenFile() failed: %s",
-                     st.message().c_str());
-            return nullptr;
-        }
-#endif
-
-#if ARROW_VERSION_MAJOR < 21
-        if (pszParquetBatchSize)
-        {
-            arrow_reader->set_batch_size(CPLAtoGIntBig(pszParquetBatchSize));
-        }
-
-        if (bUseThreads)
-        {
-            arrow_reader->set_use_threads(true);
-        }
-#endif
-
-        auto poDS = std::make_unique<OGRParquetDataset>(poMemoryPool);
-        auto poLayer = std::make_unique<OGRParquetLayer>(
-            poDS.get(), CPLGetBasenameSafe(osFilename.c_str()).c_str(),
-            std::move(arrow_reader), poOpenInfo->papszOpenOptions);
-
-        // For debug purposes: return a layer with the extent of each row group
-        if (CPLTestBool(
-                CPLGetConfigOption("OGR_PARQUET_SHOW_ROW_GROUP_EXTENT", "NO")))
-        {
-            return BuildMemDatasetWithRowGroupExtents(poLayer.get());
-        }
-
-        poDS->SetLayer(std::move(poLayer));
-        return poDS.release();
-    }
-    catch (const std::exception &e)
-    {
-        CPLError(CE_Failure, CPLE_AppDefined, "Parquet exception: %s",
-                 e.what());
+    auto poDS = std::make_unique<OGRParquetDataset>();
+    auto poLayer = poDS->CreateReaderLayer(osFilename, poOpenInfo->fpL,
+                                           poOpenInfo->papszOpenOptions);
+    if (!poLayer)
         return nullptr;
+
+    // For debug purposes: return a layer with the extent of each row group
+    if (CPLTestBool(
+            CPLGetConfigOption("OGR_PARQUET_SHOW_ROW_GROUP_EXTENT", "NO")))
+    {
+        return BuildMemDatasetWithRowGroupExtents(poLayer.get());
     }
+
+    if (poOpenInfo->eAccess == GA_Update)
+        poDS->SetLayer(std::make_unique<OGRParquetEditableLayer>(
+            poDS.get(), osFilename, std::move(poLayer),
+            poOpenInfo->papszOpenOptions));
+    else
+        poDS->SetLayer(std::move(poLayer));
+    return poDS.release();
 }
 
 /************************************************************************/

--- a/ogr/ogrsf_frmts/parquet/ogrparquetdrivercore.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetdrivercore.cpp
@@ -116,6 +116,14 @@ void OGRParquetDriverSetCommonMetadata(GDALDriver *poDriver)
     poDriver->pfnIdentify = OGRParquetDriverIdentify;
     poDriver->SetMetadataItem(GDAL_DCAP_OPEN, "YES");
     poDriver->SetMetadataItem(GDAL_DCAP_CREATE, "YES");
+
+    poDriver->SetMetadataItem(GDAL_DCAP_UPDATE, "YES");
+    poDriver->SetMetadataItem(GDAL_DMD_UPDATE_ITEMS, "Features");
+
+    poDriver->SetMetadataItem(GDAL_DCAP_DELETE_FIELD, "YES");
+    poDriver->SetMetadataItem(GDAL_DCAP_REORDER_FIELDS, "YES");
+    poDriver->SetMetadataItem(GDAL_DMD_ALTER_FIELD_DEFN_FLAGS,
+                              "Name Type WidthPrecision");
 }
 
 /************************************************************************/

--- a/ogr/ogrsf_frmts/parquet/ogrparquetwriterdataset.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetwriterdataset.cpp
@@ -104,13 +104,9 @@ OGRParquetWriterDataset::ICreateLayer(const char *pszName,
         return nullptr;
     }
 
-    const auto eGType = poGeomFieldDefn ? poGeomFieldDefn->GetType() : wkbNone;
-    const auto poSpatialRef =
-        poGeomFieldDefn ? poGeomFieldDefn->GetSpatialRef() : nullptr;
-
     m_poLayer = std::make_unique<OGRParquetWriterLayer>(
         this, m_poMemoryPool.get(), m_poOutputStream, pszName);
-    if (!m_poLayer->SetOptions(papszOptions, poSpatialRef, eGType))
+    if (!m_poLayer->SetOptions(poGeomFieldDefn, papszOptions))
     {
         m_poLayer.reset();
         return nullptr;

--- a/port/cpl_known_config_options.h
+++ b/port/cpl_known_config_options.h
@@ -771,11 +771,11 @@ constexpr static const char* const apszKnownConfigOptions[] =
    "OGR_OPENFILEGDB_WRITE_EMPTY_GEOMETRY", // from ogropenfilegdblayer_write.cpp
    "OGR_ORGANIZE_POLYGONS", // from filegdbtable.cpp, ogrgeometryfactory.cpp
    "OGR_PARQUET_BATCH_READ_AHEAD", // from ogrparquetdatasetlayer.cpp
-   "OGR_PARQUET_BATCH_SIZE", // from ogrparquetdatasetlayer.cpp, ogrparquetdriver.cpp
+   "OGR_PARQUET_BATCH_SIZE", // from ogrparquetdataset.cpp, ogrparquetdatasetlayer.cpp
    "OGR_PARQUET_COMPUTE_GEOMETRY_TYPE", // from ogrparquetlayer.cpp
    "OGR_PARQUET_CRS_ENCODING", // from ogrparquetwriterlayer.cpp
    "OGR_PARQUET_CRS_OMIT_IF_WGS84", // from ogrparquetwriterlayer.cpp
-   "OGR_PARQUET_ENABLE_ARROW_EXTENSIONS", // from ogrparquetdriver.cpp
+   "OGR_PARQUET_ENABLE_ARROW_EXTENSIONS", // from ogrparquetdataset.cpp, ogrparquetdriver.cpp
    "OGR_PARQUET_FRAGMENT_READ_AHEAD", // from ogrparquetdatasetlayer.cpp
    "OGR_PARQUET_GEO_METADATA", // from ogrparquetwriterlayer.cpp
    "OGR_PARQUET_LOAD_FILE_SYSTEM_FACTORIES", // from ogrparquetdriver.cpp
@@ -786,8 +786,8 @@ constexpr static const char* const apszKnownConfigOptions[] =
    "OGR_PARQUET_USE_BBOX", // from ogrparquetdatasetlayer.cpp, ogrparquetlayer.cpp
    "OGR_PARQUET_USE_METADATA_FILE", // from ogrparquetdriver.cpp
    "OGR_PARQUET_USE_STATISTICS", // from ogrparquetdataset.cpp
-   "OGR_PARQUET_USE_THREADS", // from ogrparquetdatasetlayer.cpp, ogrparquetdriver.cpp
-   "OGR_PARQUET_USE_VSI", // from ogrparquetdriver.cpp
+   "OGR_PARQUET_USE_THREADS", // from ogrparquetdataset.cpp, ogrparquetdatasetlayer.cpp
+   "OGR_PARQUET_USE_VSI", // from ogrparquetdataset.cpp, ogrparquetdriver.cpp
    "OGR_PARQUET_WRITE_ARROW_EXTENSION_NAME", // from ogrparquetwriterlayer.cpp
    "OGR_PARQUET_WRITE_ARROW_SCHEMA", // from ogrparquetwriterlayer.cpp
    "OGR_PARQUET_WRITE_BBOX", // from ogrparquetwriterlayer.cpp


### PR DESCRIPTION
The driver supports adding, updating, removing features and fields. Note that
this is accomplished by rewriting the whole file during :cpp:func:`GDALDataset::FlushCache`
or when closing the dataset, and keeping into memory all modifications between
two flushes.

If the file to be updated has been created by GDAL >= 3.12, the creation options
to create the original file will be re-applied when creating the updated file.
Stability of feature ids is only guaranteed if the original file has been
created with an explicit ``FID`` creation option.

If the file to be updated has been created outside of GDAL, the original
non-scalar/nested field types will not always be preserved, but a JSON
representation may be used instead.
