### PR TITLE
gdal_raster_zonal_stats.rst: Fix typo of :opt: typo 

### DIFF
--- a/doc/source/programs/gdal_raster_zonal_stats.rst
+++ b/doc/source/programs/gdal_raster_zonal_stats.rst
@@ -144,7 +144,7 @@ The following options are available:
 .. option:: --strategy <STRATEGY>
 
    Specifies the the processing strategy (``raster`` or ``feature``), when vector zones are used.
-   In the default strategy (``--strategy feature``), GDAL will iterate over the features in the zone dataset, read the corresponding pixels from the raster, and write the statistics for that feature. This avoids the need to read the entire feature dataset into memory at once, but may cause the same pixels to be read multiple times if the polygon features are large or not ordered spatially. If ``--strategy raster`` is used, GDAL will iterate over chunks of the raster dataset, find corresponding polygon zones, and update the statistics for those features. (The size of the raster chunks can be controlled using :option:``memory``.) This ensures that raster pixels are only read once, but may cause the same features to be processed multiple times.
+   In the default strategy (``--strategy feature``), GDAL will iterate over the features in the zone dataset, read the corresponding pixels from the raster, and write the statistics for that feature. This avoids the need to read the entire feature dataset into memory at once, but may cause the same pixels to be read multiple times if the polygon features are large or not ordered spatially. If ``--strategy raster`` is used, GDAL will iterate over chunks of the raster dataset, find corresponding polygon zones, and update the statistics for those features. (The size of the raster chunks can be controlled using :option:``--chunk-size``.) This ensures that raster pixels are only read once, but may cause the same features to be processed multiple times.
    
 .. option:: --include-field <INCLUDE-FIELD>
 


### PR DESCRIPTION
Fixed a very minor mistake of :opt:``memory`` when it should be :option:``memory``.