### PR TITLE
workflow: Use python 3.10 rather than 3.8 and 3.9

### DIFF
--- a/.github/workflows/cmake_builds.yml
+++ b/.github/workflows/cmake_builds.yml
@@ -703,7 +703,7 @@ jobs:
     - uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
       with:
         activate-environment: gdalenv
-        python-version: 3.10
+        python-version: "3.10"
         channels: conda-forge
     - name: Install dependency
       shell: bash -l {0}

--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -198,7 +198,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Install lint tool
       run: |
         PYTHON_CMD=python3 && $PYTHON_CMD -m pip --upgrade pip
@@ -231,7 +231,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Check cmakelist
       run: |
         python scripts/collect_config_options.py
@@ -246,7 +246,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
       with:
-        python-version: 3.10
+        python-version: "3.10"
     - name: Check cmakelist
       run: |
         python scripts/collect_driver_connection_prefix.py


### PR DESCRIPTION
3.8 has been end-of-life for a year and 3.9 is end-of-life this month.

https://devguide.python.org/versions/

I have not tested this outside of the default github CI action runs that come with making a PR.