### PR TITLE
ZArr V3: on creation with CHUNK_MEMORY_LAYOUT=F, no longer write "order":"F", but the permutation array instead

### DIFF
--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -2279,21 +2279,21 @@ def test_zarr_create_array_compressor_v3(
         [
             ["@ENDIAN=little", "CHUNK_MEMORY_LAYOUT=F"],
             [
-                {"name": "transpose", "configuration": {"order": "F"}},
+                {"name": "transpose", "configuration": {"order": [1, 0]}},
                 {"configuration": {"endian": "little"}, "name": "bytes"},
             ],
         ],
         [
             ["@ENDIAN=big", "CHUNK_MEMORY_LAYOUT=F"],
             [
-                {"name": "transpose", "configuration": {"order": "F"}},
+                {"name": "transpose", "configuration": {"order": [1, 0]}},
                 {"configuration": {"endian": "big"}, "name": "bytes"},
             ],
         ],
         [
             ["@ENDIAN=big", "CHUNK_MEMORY_LAYOUT=F", "COMPRESS=GZIP"],
             [
-                {"name": "transpose", "configuration": {"order": "F"}},
+                {"name": "transpose", "configuration": {"order": [1, 0]}},
                 {"name": "bytes", "configuration": {"endian": "big"}},
                 {"name": "gzip", "configuration": {"level": 6}},
             ],
@@ -2331,8 +2331,9 @@ def test_zarr_create_array_endian_v3(
         rg = ds.GetRootGroup()
         assert rg
         dim0 = rg.CreateDimension("dim0", None, None, 2)
+        dim1 = rg.CreateDimension("dim1", None, None, 1)
         ar = rg.CreateMDArray(
-            "test", [dim0], gdal.ExtendedDataType.Create(gdal_data_type), options
+            "test", [dim0, dim1], gdal.ExtendedDataType.Create(gdal_data_type), options
         )
         assert ar.Write(array.array(array_type, [1, 2])) == gdal.CE_None
 
@@ -3346,7 +3347,7 @@ def test_zarr_create_fortran_order_3d_and_compression_and_dim_separator(
     else:
         assert "codecs" in j
         assert j["codecs"] == [
-            {"name": "transpose", "configuration": {"order": "F"}},
+            {"name": "transpose", "configuration": {"order": [2, 1, 0]}},
             {"name": "bytes", "configuration": {"endian": "little"}},
             {"name": "gzip", "configuration": {"level": 6}},
         ]

--- a/frmts/zarr/zarr.h
+++ b/frmts/zarr/zarr.h
@@ -1419,7 +1419,6 @@ class ZarrV3CodecTranspose final : public ZarrV3Codec
     }
 
     static CPLJSONObject GetConfiguration(const std::vector<int> &anOrder);
-    static CPLJSONObject GetConfiguration(const std::string &osOrder);
 
     bool
     InitFromConfiguration(const CPLJSONObject &configuration,

--- a/frmts/zarr/zarr_v3_codec.cpp
+++ b/frmts/zarr/zarr_v3_codec.cpp
@@ -580,7 +580,7 @@ bool ZarrV3CodecBytes::Encode(const ZarrByteVectorQuickResize &abySrc,
     if (abySrc.size() < nEltCount * nNativeSize)
     {
         CPLError(CE_Failure, CPLE_AppDefined,
-                 "ZarrV3CodecTranspose::Encode(): input buffer too small");
+                 "ZarrV3CodecBytes::Encode(): input buffer too small");
         return false;
     }
     CPLAssert(abySrc.size() >= nEltCount * nNativeSize);
@@ -677,19 +677,6 @@ ZarrV3CodecTranspose::GetConfiguration(const std::vector<int> &anOrder)
 }
 
 /************************************************************************/
-/*                           GetConfiguration()                         */
-/************************************************************************/
-
-/* static */ CPLJSONObject
-ZarrV3CodecTranspose::GetConfiguration(const std::string &osOrder)
-{
-    CPLJSONObject oConfig;
-    CPLJSONArray oOrder;
-    oConfig.Add("order", osOrder);
-    return oConfig;
-}
-
-/************************************************************************/
 /*                ZarrV3CodecTranspose::InitFromConfiguration()         */
 /************************************************************************/
 
@@ -726,6 +713,7 @@ bool ZarrV3CodecTranspose::InitFromConfiguration(
     const int nDims = static_cast<int>(oInputArrayMetadata.anBlockSizes.size());
     if (oOrder.GetType() == CPLJSONObject::Type::String)
     {
+        // Deprecated
         const auto osOrder = oOrder.ToString();
         if (osOrder == "C")
         {

--- a/frmts/zarr/zarr_v3_group.cpp
+++ b/frmts/zarr/zarr_v3_group.cpp
@@ -593,12 +593,18 @@ std::shared_ptr<GDALMDArray> ZarrV3Group::CreateMDArray(
 
     const bool bFortranOrder = EQUAL(
         CSLFetchNameValueDef(papszOptions, "CHUNK_MEMORY_LAYOUT", "C"), "F");
-    if (bFortranOrder)
+    if (bFortranOrder && aoDimensions.size() > 1)
     {
         CPLJSONObject oCodec;
         oCodec.Add("name", "transpose");
+        std::vector<int> anOrder;
+        const int nDims = static_cast<int>(aoDimensions.size());
+        for (int i = 0; i < nDims; ++i)
+        {
+            anOrder.push_back(nDims - 1 - i);
+        }
         oCodec.Add("configuration",
-                   ZarrV3CodecTranspose::GetConfiguration("F"));
+                   ZarrV3CodecTranspose::GetConfiguration(anOrder));
         oCodecs.Add(oCodec);
     }
 


### PR DESCRIPTION
Cf https://zarr-specs.readthedocs.io/en/latest/v3/codecs/transpose/index.html#changes-after-acceptance-of-zep-1
