### PR TITLE
[Backport release/3.11] multidim: Fix GetView(["::-1"]) on a dimension of size 1

### DIFF
--- a/autotest/gdrivers/memmultidim.py
+++ b/autotest/gdrivers/memmultidim.py
@@ -963,10 +963,25 @@ def test_mem_md_array_slice():
     with gdal.quiet_errors():
         assert not ar[:]
 
+    dim_1 = rg.CreateDimension("dim_1", None, None, 1)
+    ar = rg.CreateMDArray(
+        "array_1", [dim_1], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
+    )
+    data = b"\xFE"
+    assert ar.Write(data) == gdal.CE_None
+    assert ar[:].Read() == data
+    assert ar[0:1].Read() == data
+    assert ar[0].Read() == data
+    assert ar[::-1].Read() == data
+    with gdaltest.error_raised(
+        gdal.CE_Failure, "Output dimension of size 0 is not allowed"
+    ):
+        ar[0:0]
+
     ar = rg.CreateMDArray(
         "array", [dim_2, dim_3, dim_4], gdal.ExtendedDataType.Create(gdal.GDT_Byte)
     )
-    data = array.array("B", list(range(24))).tobytes()
+    data = array.array("B", list(range(2 * 3 * 4))).tobytes()
     assert ar.Write(data) == gdal.CE_None
 
     with pytest.raises(Exception):

--- a/gcore/gdalmultidim.cpp
+++ b/gcore/gdalmultidim.cpp
@@ -5413,17 +5413,23 @@ CreateSlicedArray(const std::shared_ptr<GDALMDArray> &self,
             }
             GUInt64 nEndIdx = endIdx;
             nEndIdx = EQUAL(pszEnd, "") ? (!bPosIncr ? 0 : nDimSize) : nEndIdx;
-            if ((bPosIncr && range.m_nStartIdx >= nEndIdx) ||
-                (!bPosIncr && range.m_nStartIdx <= nEndIdx))
+            if (pszStart[0] || pszEnd[0])
             {
-                CPLError(CE_Failure, CPLE_AppDefined,
-                         "Output dimension of size 0 is not allowed");
-                return nullptr;
+                if ((bPosIncr && range.m_nStartIdx >= nEndIdx) ||
+                    (!bPosIncr && range.m_nStartIdx <= nEndIdx))
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "Output dimension of size 0 is not allowed");
+                    return nullptr;
+                }
             }
             int inc = (EQUAL(pszEnd, "") && !bPosIncr) ? 1 : 0;
             const auto nAbsIncr = std::abs(range.m_nIncr);
             const GUInt64 newSize =
-                bPosIncr
+                (pszStart[0] == 0 && pszEnd[0] == 0 &&
+                 range.m_nStartIdx == nEndIdx)
+                    ? 1
+                : bPosIncr
                     ? DIV_ROUND_UP(nEndIdx - range.m_nStartIdx, nAbsIncr)
                     : DIV_ROUND_UP(inc + range.m_nStartIdx - nEndIdx, nAbsIncr);
             const auto &poSrcDim = srcDims[nCurSrcDim];


### PR DESCRIPTION
Backport #13283
 **Authored by:** @rouault