### PR TITLE
gdal vector simplify-coverage: make tolerance parameter positional

### DIFF
--- a/apps/gdalalg_vector_simplify_coverage.cpp
+++ b/apps/gdalalg_vector_simplify_coverage.cpp
@@ -35,6 +35,7 @@ GDALVectorSimplifyCoverageAlgorithm::GDALVectorSimplifyCoverageAlgorithm(
     AddActiveLayerArg(&m_activeLayer);
     AddArg("tolerance", 0, _("Distance tolerance for simplification."),
            &m_opts.tolerance)
+        .SetPositional()
         .SetRequired()
         .SetMinValueIncluded(0);
     AddArg("preserve-boundary", 0,


### PR DESCRIPTION
for consistency with 'gdal vector simplify'

Fixes #13288
