### PR TITLE
gdal raster neighbor: default to method=sum when a user defined kernel with coefficients whose sum is zero is provided

### DIFF
--- a/apps/gdalalg_raster_neighbors.cpp
+++ b/apps/gdalalg_raster_neighbors.cpp
@@ -416,78 +416,105 @@ bool GDALRasterNeighborsAlgorithm::RunStep(GDALPipelineStepRunContext &)
     {
         eType = GDT_Float64;
     }
-
-    if (m_method.size() <= 1)
+    std::vector<KernelDef> aKernelDefs(m_kernel.size());
+    std::vector<bool> abNullCoefficientSum(m_kernel.size());
+    for (size_t i = 0; i < m_kernel.size(); ++i)
     {
-        while (m_method.size() < m_kernel.size())
+        const std::string &kernel = m_kernel[i];
+        if (!kernel.empty() && kernel[0] == '[')
         {
-            m_method.push_back(
-                m_method.empty()
-                    ? ((m_kernel[0] == "u" || m_kernel[0] == "v" ||
-                        m_kernel[0] == "edge1" || m_kernel[0] == "edge2")
-                           ? "sum"
-                           : "mean")
-                    : m_method.back());
+            const CPLStringList aosValues(
+                CSLTokenizeString2(kernel.c_str(), "[] ,",
+                                   CSLT_STRIPLEADSPACES | CSLT_STRIPENDSPACES));
+            const double dfSize = static_cast<double>(aosValues.size());
+            KernelDef def;
+            def.size = static_cast<int>(std::floor(sqrt(dfSize) + 0.5));
+            double dfSum = 0;
+            for (const char *pszC : cpl::Iterate(aosValues))
+            {
+                const double dfV = CPLAtof(pszC);
+                dfSum += dfV;
+                // Already validated to be numeric by the validation action
+                def.adfCoefficients.push_back(dfV);
+            }
+            abNullCoefficientSum[i] = std::fabs(dfSum) < 1e-10;
+            if (abNullCoefficientSum[i] && m_method.size() == m_kernel.size() &&
+                m_method[i] == "mean")
+            {
+                ReportError(
+                    CE_Failure, CPLE_AppDefined,
+                    "Specifying method = 'mean' for a kernel whose sum of "
+                    "coeffients is zero is not allowed. Use 'sum' instead");
+                return false;
+            }
+            aKernelDefs[i] = std::move(def);
         }
+    }
+
+    if (m_method.empty())
+    {
+        for (size_t i = 0; i < m_kernel.size(); ++i)
+        {
+            const bool bIsZeroSumKernel =
+                m_kernel[i] == "u" || m_kernel[i] == "v" ||
+                m_kernel[i] == "edge1" || m_kernel[i] == "edge2" ||
+                abNullCoefficientSum[i];
+            m_method.push_back(bIsZeroSumKernel ? "sum" : "mean");
+        }
+    }
+    else if (m_method.size() == 1)
+    {
+        const std::string lastValue(m_method.back());
+        m_method.resize(m_kernel.size(), lastValue);
     }
 
     if (m_size == 0 && m_kernel[0][0] != '[')
         m_size = m_kernel[0] == "unsharp-masking" ? 5 : 3;
 
-    std::vector<KernelDef> aKernelDefs;
-    size_t i = 0;
-    for (std::string &kernel : m_kernel)
+    for (size_t i = 0; i < m_kernel.size(); ++i)
     {
-        KernelDef def;
-        if (kernel == "edge1" || kernel == "edge2" || kernel == "sharpen")
+        const std::string &kernel = m_kernel[i];
+        if (aKernelDefs[i].adfCoefficients.empty())
         {
-            CPLAssert(m_size == 3);
-            def = GetKernelDef(kernel, false, 1.0);
-        }
-        else if (kernel == "u" || kernel == "v")
-        {
-            CPLAssert(m_size == 3);
-            def = GetKernelDef(kernel, false, 0.5);
-        }
-        else if (kernel == "equal")
-        {
-            def.size = m_size;
-            const double dfWeight =
-                m_method[i] == "mean"
-                    ? 1.0 / (static_cast<double>(m_size) * m_size +
-                             std::numeric_limits<double>::min())
-                    : 1.0;
-            def.adfCoefficients.resize(static_cast<size_t>(m_size) * m_size,
-                                       dfWeight);
-        }
-        else if (kernel == "gaussian")
-        {
-            CPLAssert(m_size == 3 || m_size == 5);
-            def = GetKernelDef(m_size == 3 ? "gaussian-3x3" : "gaussian-5x5",
-                               true, 0.0);
-        }
-        else if (kernel == "unsharp-masking")
-        {
-            CPLAssert(m_size == 5);
-            def = GetKernelDef("unsharp-masking-5x5", true, 0.0);
-        }
-        else
-        {
-            CPLAssert(kernel.front() == '[');
-            const CPLStringList aosValues(
-                CSLTokenizeString2(kernel.c_str(), "[] ,",
-                                   CSLT_STRIPLEADSPACES | CSLT_STRIPENDSPACES));
-            const double dfSize = static_cast<double>(aosValues.size());
-            def.size = static_cast<int>(std::floor(sqrt(dfSize) + 0.5));
-            for (const char *pszC : cpl::Iterate(aosValues))
+            KernelDef def;
+            if (kernel == "edge1" || kernel == "edge2" || kernel == "sharpen")
             {
-                // Already validated to be numeric by the validation action
-                def.adfCoefficients.push_back(CPLAtof(pszC));
+                CPLAssert(m_size == 3);
+                def = GetKernelDef(kernel, false, 1.0);
             }
+            else if (kernel == "u" || kernel == "v")
+            {
+                CPLAssert(m_size == 3);
+                def = GetKernelDef(kernel, false, 0.5);
+            }
+            else if (kernel == "equal")
+            {
+                def.size = m_size;
+                const double dfWeight =
+                    m_method[i] == "mean"
+                        ? 1.0 / (static_cast<double>(m_size) * m_size +
+                                 std::numeric_limits<double>::min())
+                        : 1.0;
+                def.adfCoefficients.resize(static_cast<size_t>(m_size) * m_size,
+                                           dfWeight);
+            }
+            else if (kernel == "gaussian")
+            {
+                CPLAssert(m_size == 3 || m_size == 5);
+                def = GetKernelDef(
+                    m_size == 3 ? "gaussian-3x3" : "gaussian-5x5", true, 0.0);
+            }
+            else if (kernel == "unsharp-masking")
+            {
+                CPLAssert(m_size == 5);
+                def = GetKernelDef("unsharp-masking-5x5", true, 0.0);
+            }
+            else
+            {
+                CPLAssert(false);
+            }
+            aKernelDefs[i] = std::move(def);
         }
-        aKernelDefs.push_back(std::move(def));
-
-        ++i;
     }
 
     auto vrt = GDALNeighborsCreateVRTDerived(poSrcDS, m_band, eType, m_nodata,

--- a/autotest/utilities/test_gdalalg_raster_neighbors.py
+++ b/autotest/utilities/test_gdalalg_raster_neighbors.py
@@ -514,3 +514,29 @@ def test_gdalalg_raster_neighbors_complete():
         f"{gdal_path} completion gdal raster neighbors --kernel ["
     ).split(" ")
     assert "sharpen" not in out
+
+
+def test_gdalalg_raster_neighbors_custom_kernel_0_sum(neighbors):
+
+    neighbors["input"] = "../gcore/data/byte.tif"
+    neighbors["kernel"] = [[0, -0.04, 0], [-0.04, 0.16, -0.04], [0, -0.04, 0]]
+    neighbors["output-format"] = "MEM"
+    assert neighbors.Run()
+
+    out_ds = neighbors.Output()
+    assert out_ds.GetRasterBand(1).ComputeRasterMinMax() == pytest.approx(
+        (-7.56, 12.24)
+    )
+
+
+def test_gdalalg_raster_neighbors_custom_kernel_0_sum_error(neighbors):
+
+    neighbors["input"] = "../gcore/data/byte.tif"
+    neighbors["kernel"] = [[0, -0.04, 0], [-0.04, 0.16, -0.04], [0, -0.04, 0]]
+    neighbors["method"] = "mean"
+    neighbors["output-format"] = "MEM"
+    with pytest.raises(
+        Exception,
+        match="Specifying method = 'mean' for a kernel whose sum of coeffients is zero is not allowed. Use 'sum' instead",
+    ):
+        neighbors.Run()

--- a/doc/source/programs/gdal_raster_neighbors.rst
+++ b/doc/source/programs/gdal_raster_neighbors.rst
@@ -122,29 +122,22 @@ The following options are available:
 .. option:: --method sum|mean|min|max|stddev|median|mode
 
     Function to apply to the weighted source pixels in the neighborhood defined by the kernel.
-    Defaults to ``mean``, except when :option:`--kernel` is set to ``u``, ``v``, ``edge1`` or ``edge2``, in which
-    case ``sum`` is used.
+    Defaults to ``mean``, except when :option:`--kernel` is set to ``u``, ``v``, ``edge1``, ``edge2``,
+    or a user defined kernel whose sum of coefficients is zero, in which case ``sum`` is used.
 
-    - ``sum``: computes the sum of the value of contributing source pixels
-       multiplied by the corresponding weight of the kernel
+    - ``sum``: computes the sum of the value of contributing source pixels multiplied by the corresponding weight of the kernel. This corresponds to a kernel with un-normalized sum of coefficients.
 
-    - ``mean``: computes the average of the value of contributing source pixels
-       multiplied by the corresponding weight of the kernel
+    - ``mean``: computes the average of the value of contributing source pixels multiplied by the corresponding weight of the kernel. This has the effect of normalizing kernel coefficients so their sum is one.
 
-    - ``min``: computes the minimum of the value of contributing source pixels
-       multiplied by the corresponding weight of the kernel
+    - ``min``: computes the minimum of the value of contributing source pixels multiplied by the corresponding weight of the kernel
 
-    - ``max``: computes the maximum of the value of contributing source pixels
-       multiplied by the corresponding weight of the kernel
+    - ``max``: computes the maximum of the value of contributing source pixels multiplied by the corresponding weight of the kernel
 
-    - ``stddev``: computes the standard deviation of the value of contributing source pixels
-       multiplied by the corresponding weight of the kernel
+    - ``stddev``: computes the standard deviation of the value of contributing source pixels multiplied by the corresponding weight of the kernel
 
-    - ``median``: computes the median of the value of contributing source pixels
-       multiplied by the corresponding weight of the kernel
+    - ``median``: computes the median of the value of contributing source pixels multiplied by the corresponding weight of the kernel
 
-    - ``mode`` (majority): computes the most frequent of the value of contributing source pixels
-       multiplied by the corresponding weight of the kernel
+    - ``mode`` (majority): computes the most frequent of the value of contributing source pixels multiplied by the corresponding weight of the kernel
 
 .. option:: --nodata
 


### PR DESCRIPTION
Fixes #13326
