### PR TITLE
GPKG: use Spatialite EnableGpkgMode() instead of EnableAmphibiousGpkgMode() to avoid having to use AsGPB()

### DIFF
--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -7007,9 +7007,10 @@ def test_ogr_gpkg_spatial_view_computed_geom_column(tmp_vsimem, tmp_path):
     f.SetGeometry(ogr.CreateGeometryFromWkt("POINT Z (1 2 3)"))
     lyr.CreateFeature(f)
 
-    ds.ExecuteSQL(
-        "CREATE VIEW geom_view AS SELECT fid AS my_fid, AsGPB(ST_Multi(geom)) AS my_geom FROM foo"
-    )
+    with gdaltest.error_raised(gdal.CE_Warning):
+        ds.ExecuteSQL(
+            "CREATE VIEW geom_view AS SELECT fid AS my_fid, AsGPB(ST_Multi(geom)) AS my_geom FROM foo"
+        )
     ds.ExecuteSQL(
         "INSERT INTO gpkg_contents (table_name, identifier, data_type, srs_id) VALUES ( 'geom_view', 'geom_view', 'features', 4326 )"
     )

--- a/doc/source/drivers/vector/gpkg.rst
+++ b/doc/source/drivers/vector/gpkg.rst
@@ -62,16 +62,21 @@ against the database.
 
 SQL SELECT statements passed to ExecuteSQL() are also executed directly against the database.
 
-If the SQLite dialect is used with the SpatiaLite functions, an explicit cast
-operator AsGPB() is required to transform SpatiaLite geometries into GeoPackage
-geometries.
+.. warning::
 
-::
+    Before GDAL 3.13, if the SQLite dialect is used with the SpatiaLite functions, an explicit cast
+    operator AsGPB() is required to transform SpatiaLite geometries into GeoPackage
+    geometries.
 
-   ogrinfo -update points.gpkg -sql "INSERT INTO points (geom) values (AsGPB(ST_GeomFromText('POINT(3 54)', 4326)))"
+    ::
 
-The reverse conversion from GPKG geometries into SpatiaLite geometries
-is automatically done.
+       ogrinfo -update points.gpkg -sql "INSERT INTO points (geom) values (AsGPB(ST_GeomFromText('POINT(3 54)', 4326)))"
+
+    Since GDAL 3.13, the use of AsGPB() is no longer needed
+    (GDAL will automatically remove it when detecting ``AsGPB(ST_`` patterns)
+
+    The reverse conversion from GPKG geometries into SpatiaLite geometries
+    is automatically done.
 
 The "DROP TABLE layer_name" and "ALTER TABLE
 layer_name RENAME TO new_layer" statements can be used. They will update


### PR DESCRIPTION
cf [EnableGpkgMode](https://github.com/OSGeo/gdal/issues/13337#issuecomment-3495391882)