### PR TITLE
Doc: Add --quiet parameter when running docstub

### DIFF
--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -217,7 +217,7 @@ if (BUILD_DOCS)
     add_test(NAME docstub-annotations
              COMMAND ${CMAKE_COMMAND} -E env ${BUILD_RUN_ENV}
              ${Python_EXECUTABLE} -m docstub run ${CMAKE_BINARY_DIR}/swig/python/osgeo
-             --config ${CMAKE_BINARY_DIR}/swig/python/pyproject.toml
+             --config ${CMAKE_BINARY_DIR}/swig/python/pyproject.toml --quiet
              WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
 
 endif ()

--- a/swig/python/CMakeLists.txt
+++ b/swig/python/CMakeLists.txt
@@ -387,7 +387,7 @@ if __name__ == '__main__':
         ALL
         COMMAND ${Python_EXECUTABLE_CMAKE} -m docstub run
                 ${CMAKE_CURRENT_BINARY_DIR}/osgeo
-                --config ${CMAKE_CURRENT_BINARY_DIR}/pyproject.toml
+                --config ${CMAKE_CURRENT_BINARY_DIR}/pyproject.toml --quiet
         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
         DEPENDS ${GDAL_PYTHON_PYSOURCES}
     )


### PR DESCRIPTION
Fixes #13356.

If there are errors, they will still be reported and the docstub task will fail:

```
E Unknown name in doctype: 'strx'
    strx
    ^^^^^^
    osgeo\gdal.py:5601
E Total errors: 1
```

If there are no errors, it appears no output is logged. Logged an issue about this at https://github.com/scientific-python/docstub/issues/116. 