### PR TITLE
gdal raster convert: avoid error message when outputing to /vsistdout/

### DIFF
--- a/autotest/utilities/test_gdalalg_raster_convert.py
+++ b/autotest/utilities/test_gdalalg_raster_convert.py
@@ -102,3 +102,19 @@ def test_gdalalg_raster_convert_comma_in_filename(tmp_vsimem):
 
     convert = get_convert_alg()
     assert convert.ParseRunAndFinalize([tmp_vsimem / "a,b.tif", out_filename])
+
+
+@pytest.mark.require_driver("XYZ")
+def test_gdalalg_raster_convert_to_vsistdout(tmp_vsimem):
+    import gdaltest
+    import test_cli_utilities
+
+    gdal_path = test_cli_utilities.get_gdal_path()
+    if gdal_path is None:
+        pytest.skip("gdal binary missing")
+    out, err = gdaltest.runexternal_out_and_err(
+        f"{gdal_path} raster convert --of XYZ ../gcore/data/byte.tif /vsistdout/"
+    )
+    gdal.FileFromMemBuffer(tmp_vsimem / "test.xyz", out)
+    assert gdal.Open(tmp_vsimem / "test.xyz")
+    assert err == ""


### PR DESCRIPTION
Fixes #13400
