### PR TITLE
gdalwarp/gdal raster reproject: add a RESET_DEST_PIXELS=YES/NO warping…

### DIFF
--- a/alg/gdalwarper.cpp
+++ b/alg/gdalwarper.cpp
@@ -1081,8 +1081,14 @@ const char *GDALWarpGetOptionList(void)
            "Numeric value or NO_DATA. This option forces the destination image "
            "to be initialized to the indicated value (for all bands) "
            "or indicates that it should be initialized to the NO_DATA value in "
-           "padfDstNoDataReal/padfDstNoDataImag. If this value is not set the "
+           "padfDstNoDataReal/padfDstNoDataImag. If this value is not set, the "
            "destination image will be read and overlaid.'/>"
+           "<Option name='RESET_DEST_PIXELS' type='boolean' description='"
+           "Whether the whole destination image must be re-initialized to the "
+           "destination nodata value of padfDstNoDataReal/padfDstNoDataImag "
+           "if set, or 0 otherwise. The main difference with INIT_DEST is that "
+           "it also affects regions not related to the source dataset.' "
+           "default='NO'/>"
            "<Option name='WRITE_FLUSH' type='boolean' description='"
            "This option forces a flush to disk of data after "
            "each chunk is processed. In some cases this helps ensure a serial "
@@ -1291,6 +1297,14 @@ const char *GDALWarpGetOptionList(void)
  * or indicates that it should be initialized to the NO_DATA value in
  * padfDstNoDataReal/padfDstNoDataImag. If this value isn't set the
  * destination image will be read and overlaid.</li>
+ *
+ * <li>RESET_DEST_PIXELS=YES/NO (since GDAL 3.13): Defaults to NO.
+ * Whether the whole destination image must be re-initialized to the
+ * destination nodata value of padfDstNoDataReal/padfDstNoDataImag if set,
+ * or 0 otherwise.
+ * The main difference with INIT_DEST is that it also affects regions
+ * not related to the source dataset.
+ * </li>
  *
  * <li>WRITE_FLUSH=YES/NO: This option forces a flush to disk of data after
  * each chunk is processed. In some cases this helps ensure a serial

--- a/alg/gdalwarpoperation.cpp
+++ b/alg/gdalwarpoperation.cpp
@@ -723,6 +723,21 @@ GDALWarpOperation::Initialize(const GDALWarpOptions *psNewOptions,
         }
     }
 
+    if (eErr == CE_None && psOptions->hDstDS &&
+        CPLTestBool(CSLFetchNameValueDef(psOptions->papszWarpOptions,
+                                         "RESET_DEST_PIXELS", "NO")))
+    {
+        for (int i = 0; eErr == CE_None && i < psOptions->nBandCount; ++i)
+        {
+            eErr = GDALFillRaster(
+                GDALGetRasterBand(psOptions->hDstDS, psOptions->panDstBands[i]),
+                psOptions->padfDstNoDataReal ? psOptions->padfDstNoDataReal[i]
+                                             : 0.0,
+                psOptions->padfDstNoDataImag ? psOptions->padfDstNoDataImag[i]
+                                             : 0.0);
+        }
+    }
+
     return eErr;
 }
 

--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -2812,6 +2812,10 @@ GDALWarpDirect(const char *pszDest, GDALDatasetH hDstDS, int nSrcCount,
             }
         }
 
+        if (iSrc > 0)
+            psOptions->aosWarpOptions.SetNameValue("RESET_DEST_PIXELS",
+                                                   nullptr);
+
         /* --------------------------------------------------------------------
          */
         /*      Create a transformation object from the source to */


### PR DESCRIPTION
…option to reset the existing output dataset completely to dstnodata/0

CC @GlenRice-NOAA 