### PR TITLE
Docs: Fix figure sizes in vector rasterization

### DIFF
--- a/doc/source/programs/gdal_vector_rasterize.rst
+++ b/doc/source/programs/gdal_vector_rasterize.rst
@@ -34,16 +34,18 @@ Since GDAL 3.12, this algorithm can be part of a :ref:`gdal_pipeline`.
       * - .. figure:: ../../images/programs/gdal_vector_rasterize.png
              :width: 100%
 
-             Rasterization of a vector polygon input.
-
-             The figure shows the default behavior, where only pixels on the line render path are burnt into the raster.
+             Rasterization result using default settings.
 
         - .. figure:: ../../images/programs/gdal_vector_rasterize_all_touching.png
              :width: 100%
 
-             Rasterization of a vector polygon input, using the ``--all-touched`` option.
+             Rasterization result using :option:`--all-touched`.
 
-             All cells touching the input polygons are burnt into the raster.
+The left figure illustrates the default rasterization behavior, where only pixels on the line render
+path are included.
+
+The right figure shows the effect of :option:`--all-touched`, where every pixel that touches the input polygons is
+included.
 
 The following options are available:
 


### PR DESCRIPTION
Minor updates to https://github.com/OSGeo/gdal/pull/13355 based on review comments (cc @dbaston). 

Sphinx seems to resize figures based on the length of the associated caption, and it does not seem possible to force line breaks (without various HTML tricks). I've moved the longer text underneath. 