### PR TITLE
ComputeMinMax(): speed-up computation in the non-mask case for all non-complex types (but Byte and UInt16 that were already optimized)

### DIFF
--- a/autotest/gcore/gdal_stats.py
+++ b/autotest/gcore/gdal_stats.py
@@ -1150,3 +1150,83 @@ def test_stats_float64_nan_with_nodata(tmp_vsimem, GDAL_STATS_USE_FLOAT64_OPTIM)
         assert got_stats == expected_stats
     else:
         assert got_stats == pytest.approx(expected_stats, rel=1e-15)
+
+
+###############################################################################
+
+
+@pytest.mark.parametrize(
+    "datatype",
+    [
+        gdal.GDT_Byte,
+        gdal.GDT_Int8,
+        gdal.GDT_UInt16,
+        gdal.GDT_Int16,
+        gdal.GDT_UInt32,
+        gdal.GDT_Int32,
+        gdal.GDT_UInt64,
+        gdal.GDT_Int64,
+        gdal.GDT_Float16,
+        gdal.GDT_Float32,
+        gdal.GDT_Float64,
+    ],
+)
+def test_stats_minmax_one_two(datatype):
+
+    ds = gdal.GetDriverByName("MEM").Create("", 2, 1, 1, datatype)
+    ds.GetRasterBand(1).WriteRaster(0, 0, 2, 1, b"\x01\x02", buf_type=gdal.GDT_Byte)
+    assert ds.GetRasterBand(1).ComputeRasterMinMax() == (1.0, 2.0)
+
+
+###############################################################################
+
+
+@pytest.mark.parametrize(
+    "datatype",
+    [
+        gdal.GDT_Byte,
+        gdal.GDT_Int8,
+        gdal.GDT_UInt16,
+        gdal.GDT_Int16,
+        gdal.GDT_UInt32,
+        gdal.GDT_Int32,
+        gdal.GDT_UInt64,
+        gdal.GDT_Int64,
+        gdal.GDT_Float16,
+        gdal.GDT_Float32,
+        gdal.GDT_Float64,
+    ],
+)
+def test_stats_minmax_all_invalid_nodata(datatype):
+
+    ds = gdal.GetDriverByName("MEM").Create("", 1, 1, 1, datatype)
+    ds.GetRasterBand(1).SetNoDataValue(0)
+    with pytest.raises(Exception, match="Failed to compute min/max"):
+        ds.GetRasterBand(1).ComputeRasterMinMax()
+
+
+###############################################################################
+
+
+@pytest.mark.parametrize(
+    "datatype",
+    [
+        gdal.GDT_Byte,
+        gdal.GDT_Int8,
+        gdal.GDT_UInt16,
+        gdal.GDT_Int16,
+        gdal.GDT_UInt32,
+        gdal.GDT_Int32,
+        gdal.GDT_UInt64,
+        gdal.GDT_Int64,
+        gdal.GDT_Float16,
+        gdal.GDT_Float32,
+        gdal.GDT_Float64,
+    ],
+)
+def test_stats_minmax_all_invalid_mask(datatype):
+
+    ds = gdal.GetDriverByName("MEM").Create("", 1, 1, 1, datatype)
+    ds.CreateMaskBand(gdal.GMF_PER_DATASET)
+    with pytest.raises(Exception, match="Failed to compute min/max"):
+        ds.GetRasterBand(1).ComputeRasterMinMax()

--- a/gcore/gdalrasterband.cpp
+++ b/gcore/gdalrasterband.cpp
@@ -8260,6 +8260,26 @@ CPLErr GDALRasterBand::ComputeRasterMinMax(int bApproxOK, double *adfMinMax)
         }
     }
 
+    if (!bApproxOK &&
+        (eDataType == GDT_Int8 || eDataType == GDT_Int16 ||
+         eDataType == GDT_UInt32 || eDataType == GDT_Int32 ||
+         eDataType == GDT_UInt64 || eDataType == GDT_Int64 ||
+         eDataType == GDT_Float16 || eDataType == GDT_Float32 ||
+         eDataType == GDT_Float64) &&
+        !poMaskBand)
+    {
+        CPLErr eErr = ComputeRasterMinMaxLocation(
+            &adfMinMax[0], &adfMinMax[1], nullptr, nullptr, nullptr, nullptr);
+        if (eErr == CE_Warning)
+        {
+            ReportError(CE_Failure, CPLE_AppDefined,
+                        "Failed to compute min/max, no valid pixels found in "
+                        "sampling.");
+            eErr = CE_Failure;
+        }
+        return eErr;
+    }
+
     bool bSignedByte = false;
     if (eDataType == GDT_Byte)
     {

--- a/perftests/computeminmax.py
+++ b/perftests/computeminmax.py
@@ -8,8 +8,14 @@ from osgeo import gdal
 tab_ds = {}
 for dt in (
     gdal.GDT_Byte,
+    gdal.GDT_Int8,
     gdal.GDT_UInt16,
     gdal.GDT_Int16,
+    gdal.GDT_UInt32,
+    gdal.GDT_Int32,
+    gdal.GDT_UInt64,
+    gdal.GDT_Int64,
+    gdal.GDT_Float16,
     gdal.GDT_Float32,
     gdal.GDT_Float64,
 ):
@@ -28,12 +34,36 @@ print(
     % timeit.timeit("test(gdal.GDT_Byte)", setup=setup, number=NITERS)
 )
 print(
+    "testInt8(): %.3f"
+    % timeit.timeit("test(gdal.GDT_Int8)", setup=setup, number=NITERS)
+)
+print(
     "testUInt16(): %.3f"
     % timeit.timeit("test(gdal.GDT_UInt16)", setup=setup, number=NITERS)
 )
 print(
     "testInt16(): %.3f"
     % timeit.timeit("test(gdal.GDT_Int16)", setup=setup, number=NITERS)
+)
+print(
+    "testUInt32(): %.3f"
+    % timeit.timeit("test(gdal.GDT_UInt32)", setup=setup, number=NITERS)
+)
+print(
+    "testInt32(): %.3f"
+    % timeit.timeit("test(gdal.GDT_Int32)", setup=setup, number=NITERS)
+)
+print(
+    "testUInt64(): %.3f"
+    % timeit.timeit("test(gdal.GDT_UInt64)", setup=setup, number=NITERS)
+)
+print(
+    "testInt64(): %.3f"
+    % timeit.timeit("test(gdal.GDT_Int64)", setup=setup, number=NITERS)
+)
+print(
+    "testFloat16(): %.3f"
+    % timeit.timeit("test(gdal.GDT_Float16)", setup=setup, number=NITERS)
 )
 print(
     "testFloat32(): %.3f"


### PR DESCRIPTION
timings wih a SSE2 optimized build:

- before:
testByte(): 0.306
testInt8(): 5.779
testUInt16(): 0.726
testInt16(): 2.519
testUInt32(): 6.933
testInt32(): 7.537
testUInt64(): 8.140
testInt64(): 7.807
testFloat16(): 12.953
testFloat32(): 6.105
testFloat64(): 6.525

- after
testByte(): 0.308
testInt8(): 0.440
testUInt16(): 0.710
testInt16(): 0.897
testUInt32(): 1.986
testInt32(): 1.826
testUInt64(): 6.004
testInt64(): 5.641
testFloat16(): 2.120
testFloat32(): 1.811
testFloat64(): 3.571