### PR TITLE
gdal vector check-geometry: add include-field option

### DIFF
--- a/apps/gdalalg_vector_check_geometry.h
+++ b/apps/gdalalg_vector_check_geometry.h
@@ -38,6 +38,7 @@ class GDALVectorCheckGeometryAlgorithm : public GDALVectorPipelineStepAlgorithm
   private:
     bool RunStep(GDALPipelineStepRunContext &ctxt) override;
 
+    std::vector<std::string> m_includeFields{};
     std::string m_geomField{};
     bool m_includeValid{false};
 };

--- a/autotest/utilities/test_gdalalg_vector_check_geometry.py
+++ b/autotest/utilities/test_gdalalg_vector_check_geometry.py
@@ -495,3 +495,32 @@ def test_gdalalg_vector_check_geometry_no_geometry_field(alg):
         Exception, match="Specified layer 'source' has no geometry field"
     ):
         alg.Run()
+
+
+def test_gdalalg_vector_check_geometry_include_field(alg):
+
+    alg["input"] = "../ogr/data/poly.shp"
+    alg["include-field"] = ["EAS_ID", "AREA"]
+    alg["output-format"] = "stream"
+    alg["include-valid"] = True
+
+    assert alg.Run()
+    dst_ds = alg["output"].GetDataset()
+    dst_lyr = dst_ds.GetLayer(0)
+    dst_defn = dst_lyr.GetLayerDefn()
+    assert dst_defn.GetFieldDefn(0).GetName() == "EAS_ID"
+    assert dst_defn.GetFieldDefn(1).GetName() == "AREA"
+
+    f = dst_lyr.GetNextFeature()
+    assert f["EAS_ID"] == 168
+    assert f["AREA"] == 215229.266
+
+
+def test_gdalalg_vector_check_geometry_include_field_error(alg):
+
+    alg["input"] = "../ogr/data/poly.shp"
+    alg["include-field"] = "does_not_exist"
+    alg["output-format"] = "stream"
+
+    with pytest.raises(Exception, match="Specified field .* does not exist"):
+        alg.Run()

--- a/doc/source/programs/gdal_vector_check_coverage.rst
+++ b/doc/source/programs/gdal_vector_check_coverage.rst
@@ -51,6 +51,12 @@ Standard options
 
    Include features for valid geometries in the output, maintaining 1:1 correspondence between input and output features.
 
+.. option:: --include-field
+
+   .. versionadded:: 3.12.1
+
+   Optional field(s) to copy from the input features to the output.
+
 .. option:: --maximum-gap-width <MAXIMUM-GAP-WIDTH>
 
    Defines the largest area that should be considered a gap.


### PR DESCRIPTION
Allows copying fields from input layer to output. I had been relying on FID but didn't appreciate how difficult that it is to use.

I'm thinking it should go in 3.12 since it really affects the usability.