### PR TITLE
[Backport release/3.12] gdal raster calc / VRTDerivedRasterBand: fix computation/transfer data type with ComplexSource

### DIFF
--- a/autotest/utilities/test_gdalalg_raster_calc.py
+++ b/autotest/utilities/test_gdalalg_raster_calc.py
@@ -1007,3 +1007,21 @@ def test_gdalalg_raster_calc_sum_builtin_two_bands_three_bands_fail(calc, tmp_vs
         match=r"Expression cannot operate on all bands of rasters with incompatible numbers of bands \(source B has 3 bands but expected to have 1 or 2 bands\)",
     ):
         calc.Run()
+
+
+def test_gdalalg_raster_calc_sum_float_input_with_nodata(calc, tmp_vsimem):
+
+    input = tmp_vsimem / "in.tif"
+
+    with gdal.GetDriverByName("GTiff").Create(input, 1, 1, 1, gdal.GDT_Float32) as ds:
+        ds.GetRasterBand(1).SetNoDataValue(0)
+        ds.GetRasterBand(1).Fill(0.1)
+
+    calc["input"] = [f"A={input}"]
+    calc["output-format"] = "MEM"
+    calc["calc"] = "A * 10"
+    calc["output-data-type"] = "Byte"
+    calc.Run()
+
+    out_ds = calc["output"].GetDataset()
+    assert out_ds.GetRasterBand(1).Checksum() == 1

--- a/frmts/vrt/vrtderivedrasterband.cpp
+++ b/frmts/vrt/vrtderivedrasterband.cpp
@@ -1098,7 +1098,7 @@ CPLErr VRTDerivedRasterBand::IRasterIO(
         GDALDataType eAllSrcType = GDT_Unknown;
         for (auto &poSource : m_papoSources)
         {
-            if (poSource->GetType() == VRTSimpleSource::GetTypeStatic())
+            if (poSource->IsSimpleSource())
             {
                 const auto poSS =
                     static_cast<VRTSimpleSource *>(poSource.get());
@@ -1122,9 +1122,9 @@ CPLErr VRTDerivedRasterBand::IRasterIO(
         }
 
         if (eAllSrcType != GDT_Unknown)
-            eSrcType = eAllSrcType;
+            eSrcType = GDALDataTypeUnion(eAllSrcType, eDataType);
         else
-            eSrcType = eBufType;
+            eSrcType = GDALDataTypeUnion(GDT_Float64, eDataType);
     }
     const int nSrcTypeSize = GDALGetDataTypeSizeBytes(eSrcType);
 


### PR DESCRIPTION
Backport #13413
 **Authored by:** @rouault