### PR TITLE
VRT: Add "name" attribute to source types in xml schema

### DIFF
--- a/frmts/vrt/data/gdalvrt.xsd
+++ b/frmts/vrt/data/gdalvrt.xsd
@@ -515,6 +515,7 @@
     <xs:complexType name="SimpleSourceType">
         <xs:group ref="SimpleSourceElementsGroup"/>
         <xs:attribute name="resampling" type="xs:string"/>
+        <xs:attribute name="name" type="xs:string"/>
     </xs:complexType>
 
     <xs:group name="ComplexSourceElementsGroup">
@@ -540,6 +541,7 @@
     <xs:complexType name="ComplexSourceType">
         <xs:group ref="ComplexSourceElementsGroup"/>
         <xs:attribute name="resampling" type="xs:string"/>
+        <xs:attribute name="name" type="xs:string"/>
     </xs:complexType>
 
     <xs:group name="NoDataFromMaskSourceElementsGroup">
@@ -566,6 +568,7 @@
             </xs:choice>
         </xs:sequence>
         <xs:attribute name="resampling" type="xs:string"/>
+        <xs:attribute name="name" type="xs:string" />
     </xs:complexType>
 
     <xs:complexType name="KernelType">
@@ -594,6 +597,7 @@
             <xs:element name="SrcRect" type="RectType" minOccurs="0"/>
             <xs:element name="DstRect" type="RectType" minOccurs="0"/>
         </xs:sequence>
+        <xs:attribute name="name" type="xs:string"/>
     </xs:complexType>
 
     <xs:element name="AbstractArray" type="AbstractArrayType" abstract="true"/>


### PR DESCRIPTION
VRT pixel function expressions accept a source band name for access with muparser and ExprTk. This commit adds the name attribute to the schema.

## What does this PR do?

Adds the "name" attribute to SimpleSourceType, ComplexSourceType, KernelFilteredSourceType and ArraySourceType complexTypes. Making VRT files that use the source band name attribute for VRT expression pixel functions valid. 

## What are related issues/pull requests?
NA

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

