### PR TITLE
gdal raster color-map/gdaldem color-relief: fix crash when color map …

### DIFF
--- a/apps/gdaldem_lib.cpp
+++ b/apps/gdaldem_lib.cpp
@@ -1866,7 +1866,8 @@ class GDALColorReliefDataset final : public GDALDataset
 
     bool InitOK() const
     {
-        return pafSourceBuf != nullptr || panSourceBuf != nullptr;
+        return !asColorAssociation.empty() &&
+               (pafSourceBuf != nullptr || panSourceBuf != nullptr);
     }
 
     CPLErr GetGeoTransform(GDALGeoTransform &gt) const override;

--- a/autotest/utilities/test_gdalalg_raster_color_map.py
+++ b/autotest/utilities/test_gdalalg_raster_color_map.py
@@ -121,3 +121,20 @@ def test_gdalalg_raster_color_map_from_color_table(options, checksum, output_for
     assert [
         out_ds.GetRasterBand(i + 1).Checksum() for i in range(out_ds.RasterCount)
     ] == checksum
+
+
+@pytest.mark.parametrize("output_format", ["MEM", "PNG"])
+def test_gdalalg_raster_empty_color_map(tmp_vsimem, output_format):
+
+    if gdal.GetDriverByName(output_format) is None:
+        pytest.skip(f"{output_format} not available")
+
+    gdal.FileFromMemBuffer(tmp_vsimem / "empty.txt", "")
+
+    alg = get_alg()
+    alg["input"] = "../gdrivers/data/n43.tif"
+    alg["color-map"] = tmp_vsimem / "empty.txt"
+    alg["output"] = tmp_vsimem / "out"
+    alg["output-format"] = output_format
+    with pytest.raises(Exception, match="No color association found"):
+        alg.Run()


### PR DESCRIPTION
…is invalid and outputing to a format without CreateCopy capability

Fixes https://lists.osgeo.org/pipermail/gdal-dev/2025-November/061178.html
