### PR TITLE
[Backport release/3.12] Python bindings: avoid gdal.alg.X public symbols to have non relevant suggestions

### DIFF
--- a/autotest/gcore/algorithm.py
+++ b/autotest/gcore/algorithm.py
@@ -479,6 +479,9 @@ def test_gdal_alg_module(tmp_vsimem):
     assert set(["dataset", "mdim", "raster", "vector", "vsi"]).issubset(
         set(gdal.alg.__dict__.keys())
     )
+    assert "gdal" not in gdal.alg.__dict__.keys()
+    assert "os" not in gdal.alg.__dict__.keys()
+    assert "Optional" not in gdal.alg.__dict__.keys()
 
     gdal.FileFromMemBuffer(tmp_vsimem / "a", "a")
 

--- a/swig/include/python/generate_gdal_alg_methods.i
+++ b/swig/include/python/generate_gdal_alg_methods.i
@@ -5,6 +5,7 @@
 def _generate_gdal_alg_methods():
     """Dynamically generates gdal.alg.{X}.{Y}.{func} methods from GDAL algorithms"""
 
+    import copy
     import os
     import types
     import typing
@@ -147,14 +148,16 @@ def {name_sanitized}({args}):
     kwargs = {{k: v for k, v in kwargs.items() if v is not None}}
     return gdal.Run({new_path}, **kwargs)
 """
-            g = parent_module.__dict__
+            func_globals = copy.copy(parent_module.__dict__)
             extra = {"gdal": gdal_module, "os": os, "List": List, "Union": Union, "Optional": Optional, "Callable": Callable}
             for k,v in extra.items():
-                g[k] = v
-            exec(func_code, g)
+                func_globals[k] = v
+            exec(func_code, func_globals)
+
+            parent_module.__dict__[name_sanitized] = func_globals[name_sanitized]
 
             # Register doc string
-            g[name_sanitized].__doc__ = f"""{alg.GetDescription()}
+            parent_module.__dict__[name_sanitized].__doc__ = f"""{alg.GetDescription()}
 
        Consult {alg.GetHelpFullURL()} for more details.
 


### PR DESCRIPTION
Backport #13444
 **Authored by:** @rouault