### PR TITLE
Update gdal_raster_materialize.rst: add note that VRT cannot be used and add example on how to use materialize for cloud optimized geotiff

### DIFF
--- a/doc/source/programs/gdal_raster_materialize.rst
+++ b/doc/source/programs/gdal_raster_materialize.rst
@@ -60,7 +60,7 @@ Examples
 
 
 .. example::
-   :title: How to use materialize for Cloud Optimzed GeoTIFF (COG)
+   :title: How to use materialize for Cloud Optimized GeoTIFF (COG)
 
     Usually when you want load COG data, you are not loading the whole data but instead on certain region and using lower resolution for fast analysis.
     Therefore, after using command `read`, it is not supposed to be materialize right away because it mean it will download the whole thing into the memory/disk.


### PR DESCRIPTION
Add example of command where materialize in the format of VRT is not possible

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

## What are related issues/pull requests?

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
