### PR TITLE
alg: Add directional constraints (angle/pitch) to GDALViewshedGenerate

### DIFF
--- a/alg/viewshed/viewshed.cpp
+++ b/alg/viewshed/viewshed.cpp
@@ -114,7 +114,7 @@
  * <li><b>LOW_PITCH</b>: Bound observable height to be no lower than the 'low-pitch' angle from the observer. Degrees from horizontal - positive is up. Must be less than 'high-pitch'.</li>
  * <li><b>HIGH_PITCH</b>: Mark all cells out-of-range where the observable height would be higher than the 'high-pitch' angle from the observer. Degrees from horizontal - positive is up. Must be greater than 'low-pitch'.</li>
  * </ul>
- * If NULL, a 360-degree omni-directional viewshed is calculated.
+ * If NULL, a 360-degree viewshed is calculated.
  *
  * @return not NULL output dataset on success (to be closed with GDALClose()) or
  * NULL if an error occurs.


### PR DESCRIPTION
## What does this PR do?

This PR enhances the `GDALViewshedGenerate` function (and its SWIG bindings) by adding support for directional visibility analysis.

Previously, viewshed analysis was omni-directional. With this change, users can now constrain the visibility analysis using horizontal angles (azimuth) and vertical pitch. This is particularly useful for use cases such as simulating camera field-of-view, radar sectors, or human vision.

**Specific changes:**
* **alg/gdal_alg.h**: Updated the C API signature of `GDALViewshedGenerate` to include `startAngle`, `endAngle`, `lowPitch`, and `highPitch`.
* **alg/viewshed/viewshed.cpp**: Passed these new parameters into the internal `gdal::Viewshed::Options` structure.
* **swig/include/Operations.i**: Updated the SWIG interface file to expose these parameters to Python (and other bindings) with default values that preserve the original behavior (full 360-degree coverage).

## What are related issues/pull requests?

[Issue/#13451](https://github.com/OSGeo/gdal/issues/13451)

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [x] Add documentation
 - [x] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

* OS: Windows 11
* Compiler: MSVC