### PR TITLE
gdal raster index: automatically sets --dst-crs=EPSG:4326 for --profile=STAC-GeoParquet

### DIFF
--- a/autotest/utilities/test_gdalalg_raster_index.py
+++ b/autotest/utilities/test_gdalalg_raster_index.py
@@ -431,6 +431,7 @@ def test_gdalalg_raster_index_stac_geoparquet_base_url(tmp_vsimem):
 
     with ogr.Open(tmp_vsimem / "out.parquet") as ds:
         lyr = ds.GetLayer(0)
+        assert lyr.GetSpatialRef().GetAuthorityCode(None) == "4326"
         f = lyr.GetNextFeature()
         assert f["assets.image.href"] == "http://example.com/byte.tif"
 
@@ -477,3 +478,47 @@ def test_gdalalg_raster_index_stac_geoparquet_no_proj_code(tmp_vsimem):
         assert f["proj:code"] is None
         assert f["proj:wkt2"].startswith("GEOGCRS[")
         assert json.loads(f["proj:projjson"])["type"] == "GeographicCRS"
+
+
+@pytest.mark.require_driver("PARQUET")
+def test_gdalalg_raster_index_stac_geoparquet_error_not_parquet(tmp_vsimem):
+
+    with pytest.raises(
+        Exception,
+        match="STAC-GeoParquet profile is only compatible with Parquet output format",
+    ):
+        gdal.alg.raster.index(
+            input="../gcore/data/byte.tif",
+            output=tmp_vsimem / "out.gpkg",
+            profile="STAC-GeoParquet",
+        )
+
+
+@pytest.mark.require_driver("PARQUET")
+def test_gdalalg_raster_index_stac_geoparquet_error_not_parquet_bis(tmp_vsimem):
+
+    with pytest.raises(
+        Exception,
+        match="STAC-GeoParquet profile is only compatible with Parquet output format",
+    ):
+        gdal.alg.raster.index(
+            input="../gcore/data/byte.tif",
+            output=tmp_vsimem / "out.parquet",
+            profile="STAC-GeoParquet",
+            output_format="GPKG",
+        )
+
+
+@pytest.mark.require_driver("PARQUET")
+def test_gdalalg_raster_index_stac_geoparquet_error_not_epsg_4326(tmp_vsimem):
+
+    with pytest.raises(
+        Exception,
+        match="STAC-GeoParquet profile is only compatible with --dst-crs=EPSG:4326",
+    ):
+        gdal.alg.raster.index(
+            input="../gcore/data/byte.tif",
+            output=tmp_vsimem / "out.parquet",
+            profile="STAC-GeoParquet",
+            dst_crs="EPSG:3857",
+        )

--- a/doc/source/programs/gdal_raster_index.rst
+++ b/doc/source/programs/gdal_raster_index.rst
@@ -137,6 +137,7 @@ Standard options
     a Parquet file conforming to the `STAC-GeoParquet <https://radiantearth.github.io/stac-geoparquet-spec/latest/>`__
     specification is created (provided that the Parquet format is also selected).
     Such file can be read by the :ref:`GTI driver <raster.gti.stac_geoparquet>`.
+    Setting ``STAC-GeoParquet`` also implicitly sets the target CRS to EPSG:4326.
 
 .. option:: --base-url <BASE-URL>
 
@@ -192,4 +193,4 @@ Examples
 
    .. code-block:: bash
 
-       gdal raster index --dst-crs EPSG:4326 --profile STAC-GeoParquet  *.tif index.parquet
+       gdal raster index --profile STAC-GeoParquet  *.tif index.parquet


### PR DESCRIPTION
Fixes #13459 (master only)
