### PR TITLE
Shapefile: read .shp.xml to set field names >= 10 chars, and field aliases

### DIFF
--- a/autotest/ogr/ogr_shape.py
+++ b/autotest/ogr/ogr_shape.py
@@ -6250,3 +6250,82 @@ def test_ogr_shape_read_huge_multipolygon():
     assert end - start < 20
     g = f.GetGeometryRef()
     assert g.GetGeometryCount() == 161782
+
+
+###############################################################################
+
+
+@gdaltest.enable_exceptions()
+def test_ogr_shape_read_shp_xml(tmp_vsimem):
+
+    with gdal.GetDriverByName("ESRI Shapefile").CreateVector(
+        tmp_vsimem / "test.shp"
+    ) as ds:
+        lyr = ds.CreateLayer("test")
+        lyr.CreateField(ogr.FieldDefn("id", ogr.OFTInteger))
+        lyr.CreateField(ogr.FieldDefn("0123456789", ogr.OFTString))
+
+    gdal.FileFromMemBuffer(
+        tmp_vsimem / "test.shp.xml",
+        """<metadata>
+<eainfo>
+    <detailed Name="test">
+      <enttyp>
+        <enttypl Sync="TRUE">test</enttypl>
+        <enttypt Sync="TRUE">Feature Class</enttypt>
+        <enttypc Sync="TRUE">0</enttypc>
+      </enttyp>
+      <attr>
+        <attrlabl Sync="TRUE">OBJECTID</attrlabl>
+        <attalias Sync="TRUE">OBJECTID</attalias>
+        <attrtype Sync="TRUE">OID</attrtype>
+        <attwidth Sync="TRUE">4</attwidth>
+        <atprecis Sync="TRUE">0</atprecis>
+        <attscale Sync="TRUE">0</attscale>
+      </attr>
+      <attr>
+        <attrlabl Sync="TRUE">Shape</attrlabl>
+        <attalias Sync="TRUE">Shape</attalias>
+        <attrtype Sync="TRUE">Geometry</attrtype>
+        <attwidth Sync="TRUE">0</attwidth>
+        <atprecis Sync="TRUE">0</atprecis>
+        <attscale Sync="TRUE">0</attscale>
+      </attr>
+      <attr>
+        <attrlabl Sync="TRUE">id</attrlabl>
+        <attalias Sync="TRUE">id</attalias>
+        <attrtype Sync="TRUE">Integer</attrtype>
+        <attwidth Sync="TRUE">4</attwidth>
+        <atprecis Sync="TRUE">0</atprecis>
+        <attscale Sync="TRUE">0</attscale>
+      </attr>
+      <attr>
+        <attrlabl Sync="TRUE">0123456789abcdef</attrlabl>
+        <attalias Sync="TRUE">my_alias</attalias>
+        <attrtype Sync="TRUE">String</attrtype>
+        <attwidth Sync="TRUE">8000</attwidth>
+        <atprecis Sync="TRUE">0</atprecis>
+        <attscale Sync="TRUE">0</attscale>
+      </attr>
+    </detailed>
+</eainfo>
+</metadata>""",
+    )
+
+    ds = ogr.Open(tmp_vsimem / "test.shp")
+    lyr = ds.GetLayer(0)
+    lyr_defn = lyr.GetLayerDefn()
+    assert lyr_defn.GetFieldCount() == 2
+    assert lyr_defn.GetFieldDefn(0).GetName() == "id"
+    assert lyr_defn.GetFieldDefn(0).GetAlternativeName() == ""
+    assert lyr_defn.GetFieldDefn(0).GetType() == ogr.OFTInteger
+    assert lyr_defn.GetFieldDefn(1).GetName() == "0123456789abcdef"
+    assert lyr_defn.GetFieldDefn(1).GetAlternativeName() == "my_alias"
+    assert lyr_defn.GetFieldDefn(1).GetType() == ogr.OFTString
+
+    assert ds.GetFileList() == [
+        "/vsimem/test_ogr_shape_read_shp_xml/test.shp",
+        "/vsimem/test_ogr_shape_read_shp_xml/test.shx",
+        "/vsimem/test_ogr_shape_read_shp_xml/test.dbf",
+        "/vsimem/test_ogr_shape_read_shp_xml/test.shp.xml",
+    ]

--- a/doc/source/drivers/vector/shapefile.rst
+++ b/doc/source/drivers/vector/shapefile.rst
@@ -53,6 +53,9 @@ a full analysis based on topological relationships of the parts of the
 polygons so that the resulting polygons are correctly defined in the
 OGC Simple Feature convention.
 
+Starting with GDAL 3.13, ``.shp.xml`` side-car files are used to set field
+names potentially longer than 10 characters, and field aliases.
+
 Driver capabilities
 -------------------
 

--- a/frmts/hdf5/hdf5imagedataset.cpp
+++ b/frmts/hdf5/hdf5imagedataset.cpp
@@ -1288,6 +1288,10 @@ GDALDataset *HDF5ImageDataset::Open(GDALOpenInfo *poOpenInfo)
                 poDS->m_nBandChunkSize =
                     static_cast<int>(panChunkDims[poDS->m_nOtherDimIndex]);
 
+                if (poDS->m_nBandChunkSize > 1)
+                    poDS->SetMetadataItem("INTERLEAVE", "PIXEL",
+                                          "IMAGE_STRUCTURE");
+
                 poDS->SetMetadataItem("BAND_CHUNK_SIZE",
                                       CPLSPrintf("%d", poDS->m_nBandChunkSize),
                                       "IMAGE_STRUCTURE");

--- a/ogr/ogrsf_frmts/shape/ogrshape.h
+++ b/ogr/ogrsf_frmts/shape/ogrshape.h
@@ -43,7 +43,7 @@ OGRFeature *SHPReadOGRFeature(SHPHandle hSHP, DBFHandle hDBF,
 OGRGeometry *SHPReadOGRObject(SHPHandle hSHP, int iShape, SHPObject *psShape,
                               bool &bHasWarnedWrongWindingOrder);
 OGRFeatureDefn *SHPReadOGRFeatureDefn(const char *pszName, SHPHandle hSHP,
-                                      DBFHandle hDBF,
+                                      DBFHandle hDBF, VSILFILE *fpSHPXML,
                                       const char *pszSHPEncoding,
                                       int bAdjustType);
 OGRErr SHPWriteOGRFeature(SHPHandle hSHP, DBFHandle hDBF,
@@ -112,6 +112,7 @@ class OGRShapeLayer final : public OGRAbstractProxiedLayer
     DBFHandle m_hDBF = nullptr;
 
     bool m_bUpdateAccess = false;
+    bool m_bHasShpXML = false;
 
     OGRwkbGeometryType m_eRequestedGeomType = wkbUnknown;
     int ResetGeomType(int nNewType);

--- a/ogr/ogrsf_frmts/shape/ogrshapedatasource.cpp
+++ b/ogr/ogrsf_frmts/shape/ogrshapedatasource.cpp
@@ -1255,7 +1255,8 @@ OGRLayer *OGRShapeDataSource::ExecuteSQL(const char *pszStatement,
 const char *const *OGRShapeDataSource::GetExtensionsForDeletion()
 {
     static const char *const apszExtensions[] = {
-        "shp",  "shx", "dbf", "sbn", "sbx", "prj", "idm", "ind", "qix", "cpg",
+        "shp",  "shx", "dbf", "sbn", "sbx",     "prj",
+        "idm",  "ind", "qix", "cpg", "shp.xml",
         "qpj",  // QGIS projection file
         nullptr};
     return apszExtensions;

--- a/ogr/ogrsf_frmts/shape/ogrshapelayer.cpp
+++ b/ogr/ogrsf_frmts/shape/ogrshapelayer.cpp
@@ -31,6 +31,7 @@
 #include "cpl_string.h"
 #include "cpl_time.h"
 #include "cpl_vsi.h"
+#include "cpl_vsi_virtual.h"
 #include "ogr_core.h"
 #include "ogr_feature.h"
 #include "ogr_geometry.h"
@@ -133,9 +134,13 @@ OGRShapeLayer::OGRShapeLayer(OGRShapeDataSource *poDSIn,
     }
     SetMetadataItem("SOURCE_ENCODING", m_osEncoding, "SHAPEFILE");
 
+    auto fpShpXML = VSIFilesystemHandler::OpenStatic(
+        CPLResetExtensionSafe(m_osFullName.c_str(), "shp.xml").c_str(), "rb");
+    m_bHasShpXML = fpShpXML != nullptr;
+
     m_poFeatureDefn = SHPReadOGRFeatureDefn(
         CPLGetBasenameSafe(m_osFullName.c_str()).c_str(), m_hSHP, m_hDBF,
-        m_osEncoding,
+        fpShpXML.get(), m_osEncoding,
         CPLFetchBool(m_poDS->GetOpenOptions(), "ADJUST_TYPE", false));
 
     // To make sure that
@@ -3743,6 +3748,14 @@ void OGRShapeLayer::AddToFileList(CPLStringList &oFileList)
             oFileList.AddStringDirectly(
                 VSIGetCanonicalFilename(osSBXFilename.c_str()));
         }
+    }
+
+    if (m_bHasShpXML)
+    {
+        const std::string osSBXFilename =
+            CPLResetExtensionSafe(m_osFullName.c_str(), "shp.xml");
+        oFileList.AddStringDirectly(
+            VSIGetCanonicalFilename(osSBXFilename.c_str()));
     }
 }
 

--- a/ogr/ogrsf_frmts/shape/shape2ogr.cpp
+++ b/ogr/ogrsf_frmts/shape/shape2ogr.cpp
@@ -27,6 +27,8 @@
 #include "cpl_conv.h"
 #include "cpl_error.h"
 #include "cpl_string.h"
+#include "cpl_minixml.h"
+#include "cpl_vsi_virtual.h"
 #include "ogr_core.h"
 #include "ogr_feature.h"
 #include "ogr_geometry.h"
@@ -1089,7 +1091,7 @@ static OGRErr SHPWriteOGRObject(SHPHandle hSHP, int iShape,
 /************************************************************************/
 
 OGRFeatureDefn *SHPReadOGRFeatureDefn(const char *pszName, SHPHandle hSHP,
-                                      DBFHandle hDBF,
+                                      DBFHandle hDBF, VSILFILE *fpSHPXML,
                                       const char *pszSHPEncoding,
                                       int bAdjustType)
 
@@ -1099,6 +1101,102 @@ OGRFeatureDefn *SHPReadOGRFeatureDefn(const char *pszName, SHPHandle hSHP,
 
     OGRFeatureDefn *const poDefn = new OGRFeatureDefn(pszName);
     poDefn->Reference();
+
+    // Parse .shp.xml side car if available, to get long field names and aliases
+    // but only if they are consistent with the number of DBF fields and their
+    // content.
+    std::vector<OGRFieldDefn> aFieldsFromSHPXML;
+    if (fpSHPXML)
+    {
+        fpSHPXML->Seek(0, SEEK_END);
+        const auto nSize = fpSHPXML->Tell();
+        if (nSize < 10 * 1024 * 1024)
+        {
+            fpSHPXML->Seek(0, SEEK_SET);
+            GByte *pabyOut = nullptr;
+            if (VSIIngestFile(fpSHPXML, nullptr, &pabyOut, nullptr, -1))
+            {
+                const char *pszXML = reinterpret_cast<char *>(pabyOut);
+                CPLXMLTreeCloser oTree(CPLParseXMLString(pszXML));
+                if (oTree)
+                {
+                    const CPLXMLNode *psFields =
+                        CPLGetXMLNode(oTree.get(), "=metadata.eainfo.detailed");
+                    int iField = 0;
+                    for (const CPLXMLNode *psIter = psFields ? psFields->psChild
+                                                             : nullptr;
+                         psIter; psIter = psIter->psNext)
+                    {
+                        if (psIter->eType != CXT_Element ||
+                            strcmp(psIter->pszValue, "attr") != 0)
+                            continue;
+                        const char *pszType =
+                            CPLGetXMLValue(psIter, "attrtype", "");
+                        if (strcmp(pszType, "OID") == 0 ||
+                            strcmp(pszType, "Geometry") == 0)
+                            continue;
+                        const char *pszLabel =
+                            CPLGetXMLValue(psIter, "attrlabl", "");
+                        if (iField == nFieldCount)
+                        {
+                            CPLDebug("Shape",
+                                     "More fields in .shp.xml than in .dbf");
+                            aFieldsFromSHPXML.clear();
+                            break;
+                        }
+
+                        char szFieldNameFromDBF[XBASE_FLDNAME_LEN_READ + 1] =
+                            {};
+                        int nWidth = 0;
+                        int nPrecision = 0;
+                        CPL_IGNORE_RET_VAL(
+                            DBFGetFieldInfo(hDBF, iField, szFieldNameFromDBF,
+                                            &nWidth, &nPrecision));
+                        std::string osFieldNameFromDBF(szFieldNameFromDBF);
+                        if (strlen(pszSHPEncoding) > 0)
+                        {
+                            char *pszUTF8Field =
+                                CPLRecode(szFieldNameFromDBF, pszSHPEncoding,
+                                          CPL_ENC_UTF8);
+                            osFieldNameFromDBF = pszUTF8Field;
+                            CPLFree(pszUTF8Field);
+                        }
+                        // Check that field names are consistent
+                        if ((strlen(pszLabel) < 10 &&
+                             pszLabel != osFieldNameFromDBF) ||
+                            (strlen(pszLabel) >= 10 &&
+                             osFieldNameFromDBF.size() >= 10 &&
+                             strncmp(pszLabel, osFieldNameFromDBF.c_str(), 5) !=
+                                 0))
+                        {
+                            CPLDebug("Shape",
+                                     "For field at index %d, mismatch between "
+                                     ".shp.xml name (%s) vs .dbf name (%s)",
+                                     iField, pszLabel, szFieldNameFromDBF);
+                            aFieldsFromSHPXML.clear();
+                            break;
+                        }
+
+                        OGRFieldDefn oField(pszLabel, OFTMaxType);
+                        const char *pszAlias =
+                            CPLGetXMLValue(psIter, "attalias", "");
+                        if (pszAlias[0] && strcmp(pszLabel, pszAlias) != 0)
+                            oField.SetAlternativeName(pszAlias);
+                        const char *pszWidth =
+                            CPLGetXMLValue(psIter, "attwidth", "");
+                        if (strcmp(pszType, "Integer") == 0 &&
+                            strcmp(pszWidth, "4") == 0)
+                            oField.SetType(OFTInteger);
+                        aFieldsFromSHPXML.push_back(std::move(oField));
+                        ++iField;
+                    }
+                    if (iField != nFieldCount)
+                        aFieldsFromSHPXML.clear();
+                }
+            }
+            CPLFree(pabyOut);
+        }
+    }
 
     for (int iField = 0; iField < nFieldCount; iField++)
     {
@@ -1110,7 +1208,11 @@ OGRFeatureDefn *SHPReadOGRFeatureDefn(const char *pszName, SHPHandle hSHP,
             DBFGetFieldInfo(hDBF, iField, szFieldName, &nWidth, &nPrecision);
 
         OGRFieldDefn oField("", OFTInteger);
-        if (strlen(pszSHPEncoding) > 0)
+        if (!aFieldsFromSHPXML.empty())
+        {
+            oField = aFieldsFromSHPXML[iField];
+        }
+        else if (strlen(pszSHPEncoding) > 0)
         {
             char *const pszUTF8Field =
                 CPLRecode(szFieldName, pszSHPEncoding, CPL_ENC_UTF8);
@@ -1139,7 +1241,13 @@ OGRFeatureDefn *SHPReadOGRFeatureDefn(const char *pszName, SHPHandle hSHP,
         {
             nAdjustableFields += (nPrecision == 0);
             if (nPrecision == 0 && nWidth < 19)
-                oField.SetType(OFTInteger64);
+            {
+                if (!aFieldsFromSHPXML.empty() &&
+                    aFieldsFromSHPXML[iField].GetType() == OFTInteger)
+                    oField.SetType(OFTInteger);
+                else
+                    oField.SetType(OFTInteger64);
+            }
             else
                 oField.SetType(OFTReal);
         }


### PR DESCRIPTION
Fixes #13472
