### PR TITLE
Doc: Fix various typos found in spelling_wordlist.txt

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8278,7 +8278,7 @@ GTiff driver:
  * early checks for PREDICTOR settings, and update internal libtiff to support PREDICTOR=2 for 64-bit samples (rasterio/rasterio#2384)
  * remove limitation to 32,000 bytes when writing the GDAL metadata tag (#4116)
  * Create(): better detection of threshold when to switch to BigTIFF for tiled images (#5479)
- * unset geotransform from non-PAM source if PAM defines GCPs, and PAM is the prioritary source
+ * unset geotransform from non-PAM source if PAM defines GCPs, and PAM is the priority source
  * fix crash when building overviews and computing approx stats (#5580)
 
 HDF5 driver:

--- a/alg/gdal_alg.h
+++ b/alg/gdal_alg.h
@@ -670,7 +670,7 @@ typedef struct
     int nFacets;             /**< number of facets */
     GDALTriFacet *pasFacets; /**< array of nFacets facets */
     GDALTriBarycentricCoefficients
-        *pasFacetCoefficients; /**< arra of nFacets barycentric coefficients */
+        *pasFacetCoefficients; /**< array of nFacets barycentric coefficients */
 } GDALTriangulation;
 
 int CPL_DLL GDALHasTriangulation(void);

--- a/alg/gdaltransformer.cpp
+++ b/alg/gdaltransformer.cpp
@@ -2052,7 +2052,7 @@ const char *GDALGetGenImgProjTranformerOptionList(void)
  * operations that are not the "best" if resources (typically grids) needed
  * to use them are missing. It will then fallback to other coordinate operations
  * that have a lesser accuracy, for example using Helmert transformations,
- * or in the absence of such operations, to ones with potential very rought
+ * or in the absence of such operations, to ones with potential very rough
  * accuracy, using "ballpark" transformations
  * (see https://proj.org/glossary.html).
  * When calling this method with YES, PROJ will only consider the
@@ -3533,7 +3533,7 @@ void *GDALCreateReprojectionTransformer(const char *pszSrcWKT,
  * operations that are not the "best" if resources (typically grids) needed
  * to use them are missing. It will then fallback to other coordinate operations
  * that have a lesser accuracy, for example using Helmert transformations,
- * or in the absence of such operations, to ones with potential very rought
+ * or in the absence of such operations, to ones with potential very rough
  * accuracy, using "ballpark" transformations
  * (see https://proj.org/glossary.html).
  * When calling this method with YES, PROJ will only consider the

--- a/doc/source/api/csharp/csharp_compile_cmake.rst
+++ b/doc/source/api/csharp/csharp_compile_cmake.rst
@@ -85,7 +85,7 @@ Using the .NET Bindings
 
 The easiest way to use the bindings in development would be use the NuGET packages created.
 
-To do this you need to add a local repistory pointing to the GDAL install directory. `This is explained here <https://docs.microsoft.com/en-us/nuget/hosting-packages/local-feeds>`__ .
+To do this you need to add a local repository pointing to the GDAL install directory. `This is explained here <https://docs.microsoft.com/en-us/nuget/hosting-packages/local-feeds>`__ .
 
 Once this is done, you add the GDAL packages into your project as normal.
 
@@ -163,7 +163,7 @@ As an example:
     cmake -DGDAL_CSHARP_ONLY=ON -B ../build -S .
     cmake --build ../build --config Release --target csharp_samples
 
-The output from this build is axactly the same as documented as above, except that the outputs will be in `../build/swig/csharp` and some of the sub folders.
+The output from this build is exactly the same as documented as above, except that the outputs will be in `../build/swig/csharp` and some of the sub folders.
 
 Signing of build artifacts
 ++++++++++++++++++++++++++

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -942,7 +942,7 @@ man_pages = [
     (
         "programs/gdal_vector_swap_xy",
         "gdal-vector-swap-xy",
-        "Swap X and Y coordinates of geometries of a vector datasett",
+        "Swap X and Y coordinates of geometries of a vector dataset",
         [author_evenr],
         1,
     ),

--- a/doc/source/development/rfc/rfc12_filemanagement.rst
+++ b/doc/source/development/rfc/rfc12_filemanagement.rst
@@ -180,7 +180,7 @@ Additional Notes
    rename/delete operations on open files. Things could easily be left
    in an inconsistent state.
 -  Datasets without associated files in the file system will return an
-   empty file list. This essentially identifies them as "unmanagable".
+   empty file list. This essentially identifies them as "unmanageable".
 
 Implementation Plan
 -------------------

--- a/doc/source/development/rfc/rfc14_imagestructure.rst
+++ b/doc/source/development/rfc/rfc14_imagestructure.rst
@@ -50,7 +50,7 @@ values between 128 and 255 should be interpreted as being values between
 Compatibility Issues
 --------------------
 
-This RFC has two changes from existing practise that may cause
+This RFC has two changes from existing practice that may cause
 compatibility issues:
 
 1. Traditionally the NBITS metadata appeared in the default metadata

--- a/doc/source/development/rfc/rfc20_srs_axes.rst
+++ b/doc/source/development/rfc/rfc20_srs_axes.rst
@@ -193,7 +193,7 @@ Drivers Affected
    gcore/gdaljp2metadata.cpp).
 -  WCS (based on interpretation of urns).
 -  WMS (maybe? actually, I suspect we don't actually get the coordinate
-   system from the capabalities)
+   system from the capabilities)
 -  OGR GML (maybe? only GML3 affected?)
 -  BSB, SAR_CEOS, ENVISAT, HDF4, JDEM, L1B, LAN, SRTMHGT: Like
    SetWellKnownGeogCS() these all include lat/long AXIS specifications

--- a/doc/source/development/rfc/rfc30_utf8_filenames.rst
+++ b/doc/source/development/rfc/rfc30_utf8_filenames.rst
@@ -137,7 +137,7 @@ C# Changes
 Tamas notes that in C# we normally convert the unicode C# strings into C
 string with the PtrToStringAnsi marshaller. Presumably we will need to
 use a utf-8 converter for all interface strings considered to be
-filenames. I would note this should also apploy to OGR string attribute
+filenames. I would note this should also apply to OGR string attribute
 values which are also intended to be treated as utf-8.
 
 (It is unclear who will take care of this aspect since the primary

--- a/doc/source/development/rfc/rfc31_ogr_64.rst
+++ b/doc/source/development/rfc/rfc31_ogr_64.rst
@@ -248,7 +248,7 @@ list of changes is :
    advertized as soon as MAX(fid_column) is 64 bit. GetFeatureCount()
    modified to return 64 bit values.
 -  SQLite: Integer64 and 64 bit FID supported in read/write. On write,
-   Integer64 are createad as "BIGINT" and on read BIGINT or INT8 are
+   Integer64 are created as "BIGINT" and on read BIGINT or INT8 are
    considered as Integer64. However it might be possible that databases
    produced by other tools are created with "INTEGER" and hold 64 bit
    values, in which case OGR will not be able to detect it. The

--- a/doc/source/development/rfc/rfc34_license_policy.rst
+++ b/doc/source/development/rfc/rfc34_license_policy.rst
@@ -197,7 +197,7 @@ Unresolved:
 
 -  The OGR SOSI driver should probably be marked as proprietary
    currently as it relies on linking with binary objects with unknown
-   licencing terms, even if apparently the ultimate goal seems to open
+   licensing terms, even if apparently the ultimate goal seems to open
    source them.
 -  I'm a bit confused by :ref:`raster.msg`.
    Seems that it relies on third party stuff with both proprietary and

--- a/doc/source/development/rfc/rfc41_multiple_geometry_fields.rst
+++ b/doc/source/development/rfc/rfc41_multiple_geometry_fields.rst
@@ -241,7 +241,7 @@ Impact on OGRLayer class :
    GetGeomField(0)->GetSpatialRef() returning NULL. The test_ogrsf
    utility will check and warn about this. Update of existing drivers
    will be made progressively. In the mean time, using
-   OGRLayer::GetSpatialRef() will be advized to get the SRS of the first
+   OGRLayer::GetSpatialRef() will be advised to get the SRS of the first
    geometry field in a reliable way.
 
 -  add :
@@ -337,7 +337,7 @@ returned by GetNextFeature()) :
 
 This would lead, for legacy code, to geometry being handled as regular
 field. We could imagine that GetFieldAsString() converts the geometry as
-WKT, but it is doubtfull that this would really be desired.
+WKT, but it is doubtful that this would really be desired.
 Fundamentally, the handling of attribute and geometry fields is
 different in most use cases.
 

--- a/doc/source/development/rfc/rfc45_virtualmem.rst
+++ b/doc/source/development/rfc/rfc45_virtualmem.rst
@@ -1053,7 +1053,7 @@ execution after a segmentation fault.
 Porting to other POSIX operating systems such as MacOSX should be doable
 with moderate effort. Windows has API that offer similar capabilities as
 POSIX API with VirtualAlloc(), VirtualProtect() and
-SetUnhandledExceptionFilter(), although the porting would undoubtly
+SetUnhandledExceptionFilter(), although the porting would undoubtedly
 require more effort.
 
 The existence of `libsigsegv <http://www.gnu.org/software/libsigsegv>`__

--- a/doc/source/development/rfc/rfc46_gdal_ogr_unification.rst
+++ b/doc/source/development/rfc/rfc46_gdal_ogr_unification.rst
@@ -93,7 +93,7 @@ Drivers and driver registration
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 -  The OGRSFDriver now extends GDALDriver and is meant as being a legacy
-   way of implementing a vector driver. It is kept mainbly because, in
+   way of implementing a vector driver. It is kept mainly because, in
    the current implementation, not all drivers have been migrated to
    being "pure" GDALDriver. The CopyDataSource() virtual method has been
    removed since no in-tree drivers implement it. The inheritance to
@@ -613,7 +613,7 @@ Changes in SWIG bindings
       MajorObject
 
 -  Perl and CSharp: make sure that it still compiles but some work would
-   have to be done by their mainteners to be able to use the new
+   have to be done by their maintainers to be able to use the new
    capabilities
 
 Potential changes that are *NOT* included in this RFC

--- a/doc/source/development/rfc/rfc54_dataset_transactions.rst
+++ b/doc/source/development/rfc/rfc54_dataset_transactions.rst
@@ -35,7 +35,7 @@ to do bulk insertion. This is for example the case of WFS, CartoDB, GFT,
 GME. For some of them, it could rather be at dataset level too since
 potentially multiple layer modifications could be stacked together.
 
-Furthermode some use cases require updating several layers consistently,
+Furthermore some use cases require updating several layers consistently,
 hence the need for a real database level transaction abstraction.
 
 The current situation of various drivers is the following (some of the

--- a/doc/source/development/rfc/rfc55_refined_setfeature_deletefeature_semantics.rst
+++ b/doc/source/development/rfc/rfc55_refined_setfeature_deletefeature_semantics.rst
@@ -48,7 +48,7 @@ The behavior of the shapefile driver is a bit particular, in that, its
 SetFeature() implementation accepts to recreate a feature that had been
 deleted (and its CreateFeature() implementation ignores any set FID on
 the passed feature to append a new feature). So
-OGRERR_NON_EXISTING_FEATURE will effictively been returned only if the
+OGRERR_NON_EXISTING_FEATURE will effectively been returned only if the
 FID is negative or greater or equal to the maximum feature count.
 
 SWIG bindings (Python / Java / C# / Perl) changes

--- a/doc/source/development/rfc/rfc59.1_utilities_as_a_library.rst
+++ b/doc/source/development/rfc/rfc59.1_utilities_as_a_library.rst
@@ -305,7 +305,7 @@ specifying options in a more user friendly way.
 
 gdal.Info() can be used either with setting the attributes of
 gdal.InfoOptions() or inlined arguments of gdal.Info(). Arguments can be
-specified as array of strings, command line syntax or dedeicated
+specified as array of strings, command line syntax or dedicated
 keywords. So various combinations are possible :
 
 ::

--- a/doc/source/development/rfc/rfc64_triangle_polyhedralsurface_tin.rst
+++ b/doc/source/development/rfc/rfc64_triangle_polyhedralsurface_tin.rst
@@ -53,7 +53,7 @@ SQL/MM Part 3
 
 .. image:: ../../../images/rfc64/classOGRGeometry_RFC64.png
 
-Some prelimenary work had already been done prior to this proposal, such
+Some preliminary work had already been done prior to this proposal, such
 as including the necessary WKB codes in <ogr_core.h>.
 
 Additionally, the `SFCGAL <http://www.sfcgal.org/>`__ library is a new

--- a/doc/source/development/rfc/rfc6_sqlgeom.rst
+++ b/doc/source/development/rfc/rfc6_sqlgeom.rst
@@ -417,7 +417,7 @@ Backward Compatibility
 In most cases the backward compatibility of the OGR library will be
 retained. However the special fields will potentially conflict with
 regard fields with the given names. When accessing the field values the
-special fields will take pecedence over the other fields with the same
+special fields will take precedence over the other fields with the same
 names.
 
 When using OGRFeature::GetFieldAsString the returned value will be

--- a/doc/source/development/rfc/rfc71_github_migration.rst
+++ b/doc/source/development/rfc/rfc71_github_migration.rst
@@ -31,7 +31,7 @@ Motivations
    mirror has existed since 2012 and has over time become the preferred
    way for contributors without direct SVN access (or even those with
    SVN access) to submit their contributions, in particular because of
-   the coupling with the continuous integratations services of Travis-CI
+   the coupling with the continuous integration services of Travis-CI
    and !AppVeyor that enable maintainers to check that the contribution
    doesn't introduce known regressions + the friendly way of commenting
    a pull request. However the manual porting of !GitHub pull requests

--- a/doc/source/development/rfc/rfc78_gdal_utils_package.rst
+++ b/doc/source/development/rfc/rfc78_gdal_utils_package.rst
@@ -15,7 +15,7 @@ Status:        Adopted, implemented in GDAL 3.3
 Summary
 -------
 
-This RFC suggests to put all the GDAL python modules (formly scripts), except from the GDAL core SWIG bindings,
+This RFC suggests to put all the GDAL python modules (formerly scripts), except from the GDAL core SWIG bindings,
 into their own distribution on pypi.
 The GDAL python sub-package `osgeo.utils` (introduced in GDAL 3.2) would be renamed into a package named `osgeo_utils`.
 

--- a/doc/source/development/rfc/rfc83_use_of_project_sponsorship.rst
+++ b/doc/source/development/rfc/rfc83_use_of_project_sponsorship.rst
@@ -50,7 +50,7 @@ Scope
   contribution and guide the proponent through the steps to make it accepted:
   identifying issues reported by Continuous Integration, asking for new tests
   to be developed whenever possible, etc. When the contributor is not in capacity
-  to polish his/her contribution, the co-maintainer may do it themself.
+  to polish his/her contribution, the co-maintainer may do it themselves.
 - Ensuring that fixes that are appropriate for backporting in stable branch /
   branches are backported.
 - Monitoring of project communication channels (mailing list, IRC, Slack

--- a/doc/source/development/rfc/rfc86_column_oriented_api.rst
+++ b/doc/source/development/rfc/rfc86_column_oriented_api.rst
@@ -518,7 +518,7 @@ bench_fiona.py
 ++++++++++++++
 
 Use of the Fiona Python library which uses the OGR C GetNextFeature() underneath to
-expose them as GeoJSON features holded by a Python dictionary.
+expose them as GeoJSON features stored in a Python dictionary.
 
 .. code-block:: python
 

--- a/doc/source/development/rfc/rfc89_sql_logging_callback.rst
+++ b/doc/source/development/rfc/rfc89_sql_logging_callback.rst
@@ -88,7 +88,7 @@ Efficiency considerations
 
 Drivers that support the query logger callback function would need to
 check if the function pointer is `nullptr` and call the function if it is
-not. The cost of thish check is probably negligible on most architectures.
+not. The cost of this check is probably negligible on most architectures.
 
 In order to catch SQLite prepare errors, a prepare function wrapper will be 
 called instead of the sqlite3 API C function, this implies the cost of

--- a/doc/source/development/rfc/rfc97_feature_and_fielddefn_sealing.rst
+++ b/doc/source/development/rfc/rfc97_feature_and_fielddefn_sealing.rst
@@ -101,7 +101,7 @@ no way to advertise the error through an error code. However, when using the
 Python bindings with exceptions enabled, a Python exception will be thrown.
 
 A convenience method is also offered to use the Resource Acquisition Is Initialization (RAII)
-paradygm to temporary unseal an instance, which is an operation that drivers
+paradigm to temporary unseal an instance, which is an operation that drivers
 implementing AlterFieldDefn() / AlterGeomFieldDefn() will need to do on fields
 they have priorly sealed.
 
@@ -164,7 +164,7 @@ fields owned by the OGRFeatureDefn to be sealed/unsealed at the same time.
      * This method should only be called by driver implementations.
      *
      * @param bSealFields Whether fields and geometry fields should be sealed.
-     *                    This is generally desirabled, but in case of deferred
+     *                    This is generally desirable, but in case of deferred
      *                    resolution of them, this parameter should be set to false.
      * @since GDAL 3.9
      */
@@ -183,7 +183,7 @@ fields owned by the OGRFeatureDefn to be sealed/unsealed at the same time.
      * This method should only be called by driver implementations.
      *
      * @param bUnsealFields Whether fields and geometry fields should be unsealed.
-     *                      This is generally desirabled, but in case of deferred
+     *                      This is generally desirable, but in case of deferred
      *                      resolution of them, this parameter should be set to
      * false.
      * @since GDAL 3.9
@@ -204,7 +204,7 @@ fields owned by the OGRFeatureDefn to be sealed/unsealed at the same time.
      *
      * @param bSealFields Whether fields and geometry fields should be unsealed and
      *                    resealed.
-     *                    This is generally desirabled, but in case of deferred
+     *                    This is generally desirable, but in case of deferred
      *                    resolution of them, this parameter should be set to false.
      * @since GDAL 3.9
      */

--- a/doc/source/development/rfc/rfc99_geometry_coordinate_precision.rst
+++ b/doc/source/development/rfc/rfc99_geometry_coordinate_precision.rst
@@ -49,7 +49,7 @@ remembered when data is edited/appended to an existing layer
 (see https://github.com/qgis/QGIS/issues/56335).
 
 For binary formats using IEEE-754 double-precision encoding of real numbers,
-one can show that at least the last 16 least-significants bits (ie the last
+one can show that at least the last 16 least-significant bits (ie the last
 2 bytes of 8) of a coordinate can be set to zero while keeping a 1 mm precision
 (which corresponds to about 8.9e-9 degree).
 On a test dataset, setting a 1 mm precision reduced the size of the .zip of the
@@ -421,7 +421,7 @@ And for the C API:
 
 A new ``GDAL_DCAP_HONOR_GEOM_COORDINATE_PRECISION`` driver capability will be added
 to advertise that a driver honours OGRGeomFieldDefn::GetCoordinatePrecision()
-when writing geometries. This may be useul for user interfaces that could offer
+when writing geometries. This may be useful for user interfaces that could offer
 an option to the user to specify the coordinate precision. Note however that
 the driver may not be able to store that precision in the dataset metadata.
 

--- a/doc/source/drivers/raster/jp2kak.rst
+++ b/doc/source/drivers/raster/jp2kak.rst
@@ -237,7 +237,7 @@ better understand their meaning.
 -  **Corder**: Progression order. Defaults to "PRCL".
 -  **Cprecincts**: Precincts settings. Defaults to
    "{512,512},{256,512},{128,512},{64,512},{32,512},{16,512},{8,512},{4,512},{2,512}".
--  **ORGgen_plt**: Whether to generate PLT markers (Paquet Length). Defaults to "yes".
+-  **ORGgen_plt**: Whether to generate PLT markers (Packet Length). Defaults to "yes".
 -  **ORGgen_tlm**: Whether to generate TLM markers (Tile Length). Kakadu SDK defaults used.
 -  **ORGtparts**: Kakadu SDK defaults used.
 -  **Cmodes**: Kakadu SDK defaults used.

--- a/doc/source/drivers/raster/ngw.rst
+++ b/doc/source/drivers/raster/ngw.rst
@@ -244,7 +244,7 @@ read-only metadata items *creation_date*, *resource_type* and
 Examples
 --------
 
-Read datasource contensts (1730 is resource group identifier):
+Read datasource contents (1730 is resource group identifier):
 
 ::
 

--- a/doc/source/drivers/raster/tiledb.rst
+++ b/doc/source/drivers/raster/tiledb.rst
@@ -176,7 +176,7 @@ The following array creation options are available:
 
 -  **COMPRESSION_LEVEL=int_value**: compression level
 
--  **IN_MEMORY=YES/NO**: hether the array should be only in-memory. Useful to
+-  **IN_MEMORY=YES/NO**: whether the array should be only in-memory. Useful to
    create an indexing variable that is serialized as a dimension label
 
 -  **TILEDB_TIMESTAMP=val**: Create array at this timestamp. Should be strictly greater than zero when set.

--- a/doc/source/drivers/vector/gmlas.rst
+++ b/doc/source/drivers/vector/gmlas.rst
@@ -169,7 +169,7 @@ field with the XML definition of the GML geometry.
 Performance issues with large multi-layer GML files.
 ----------------------------------------------------
 
-Traditionnaly to read a OGR datasource, one iterate over layers with
+Traditionally to read a OGR datasource, one iterate over layers with
 GDALDataset::GetLayer(), and for each layer one iterate over features
 with OGRLayer::GetNextFeature(). While this approach still works for the
 GMLAS driver, it may result in very poor performance on big documents or
@@ -197,7 +197,7 @@ The following open options are supported:
 -  .. oo:: CONFIG_FILE
       :choices: <filename>, <xml>
 
-      finition: filename of a
+      filename of a
       XML configuration file conforming to the
       :source_file:`ogr/ogrsf_frmts/gmlas/data/gmlasconf.xsd`
       schema. It is also possible to provide the XML content directly

--- a/doc/source/drivers/vector/libkml.rst
+++ b/doc/source/drivers/vector/libkml.rst
@@ -80,16 +80,16 @@ element at the top Document level.
 
 - .. dsco:: AUTHOR_NAME
 
-     Specifieds the value of the ``<atom:name>`` element.
+     Specifies the value of the ``<atom:name>`` element.
 
 - .. dsco:: AUTHOR_URI
 
-     Specifieds the value of the ``<atom:uri>`` element.
+     Specifies the value of the ``<atom:uri>`` element.
      It should start with ``http://`` or ``https://``
 
 - .. dsco:: AUTHOR_EMAIL
 
-     Specifieds the value of the ``<atom:email>`` element.
+     Specifies the value of the ``<atom:email>`` element.
      It should include a ``@`` character.
 
 Additional dataset creation options affecting the top Document level:

--- a/doc/source/drivers/vector/mitab.rst
+++ b/doc/source/drivers/vector/mitab.rst
@@ -137,7 +137,7 @@ The following dataset creation options are supported:
       :since: 3.10
 
       Replaces all non alphanumeric characters in dataset's field names by
-      `_` (underscope). For recent MapInfo can be set to `NO`.
+      `_` (underscore). For recent MapInfo can be set to `NO`.
 
 Layer Creation Options
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -180,7 +180,7 @@ The following layer creation options are supported:
       :since: 3.10
 
       Replaces all non alphanumeric characters in layer's field names by
-      `_` (underscope). For recent MapInfo can be set to `NO`.
+      `_` (underscore). For recent MapInfo can be set to `NO`.
 
 Configuration options
 ~~~~~~~~~~~~~~~~~~~~~

--- a/doc/source/drivers/vector/ngw.rst
+++ b/doc/source/drivers/vector/ngw.rst
@@ -443,7 +443,7 @@ Read datasource contents (1730 is resource group identifier):
 
        ogrinfo -ro NGW:https://demo.nextgis.com/resource/1730
 
-Read layer details (`1730` is resource group identifier, `Parks` is vecror layer
+Read layer details (`1730` is resource group identifier, `Parks` is vector layer
 name):
 
 ::

--- a/doc/source/faq.rst
+++ b/doc/source/faq.rst
@@ -19,7 +19,7 @@ GDAL - Geospatial Data Abstraction Library
 
 It is sometimes pronounced "goo-doll" (a bit like goo-gle), while others pronounce it "gee-doll," and others pronounce it "gee-dall."
 
-`Listen <https://soundcloud.com/danabauer/how-do-you-pronounce-gdal#t=00:02:58>`__ how Frank Warmerdam prounounces it and the history behind the acronym.
+`Listen <https://soundcloud.com/danabauer/how-do-you-pronounce-gdal#t=00:02:58>`__ how Frank Warmerdam pronounces it and the history behind the acronym.
 
 What is this OGR stuff?
 +++++++++++++++++++++++++

--- a/doc/source/spelling_wordlist.txt
+++ b/doc/source/spelling_wordlist.txt
@@ -32,7 +32,6 @@ adfMinMax
 advertized
 advertizing
 AdviseRead
-advized
 AES
 affine
 Affine
@@ -53,7 +52,6 @@ allCountries
 allocator
 alphanumerics
 Alpina
-altername
 alternance
 altitudemode
 altitudeMode
@@ -68,7 +66,6 @@ Analysing
 analytics
 Andrey
 AndreyK
-andsize
 anMapNewAxisToOldAxis
 Antalya
 antialias
@@ -79,7 +76,6 @@ aoDims
 api
 Api
 apoNewDims
-apploy
 approximator
 AppVeyor
 APSTILE
@@ -93,7 +89,6 @@ argc
 args
 argv
 ari
-arra
 Arrayname
 arrayStartIdx
 ASC
@@ -101,7 +96,6 @@ ascii
 aspatial
 Aspatial
 assumerolewithwebidentity
-asterix
 Astrogeology
 Astun
 AStyle
@@ -115,7 +109,6 @@ Athlon
 atof
 atoi
 atomicity
-atrix
 attr
 Attrbute
 attrib
@@ -148,7 +141,6 @@ Avenza
 Avyav
 avyavkumar
 aws
-axactly
 axisLabels
 axisOrder
 axisswap
@@ -257,7 +249,6 @@ Bonne
 Bool
 boolean
 booleans
-Bootstraping
 boto
 Boto
 bottomfov
@@ -305,7 +296,6 @@ BUnits
 bUnlinkAndSeize
 bUpdate
 burnValues
-butsetting
 bValueIsNull
 byn
 bytecode
@@ -314,12 +304,9 @@ cadastral
 Cadastral
 Cadastre
 Cadcorp
-Cadorp
 calc
 Calc
-calclulated
 calloc
-capabalities
 capi
 cardinality
 Cardinality
@@ -460,11 +447,9 @@ conformities
 connectedness
 const
 constexpr
-contensts
 contextlib
 contextmanager
 ContourOptions
-Contrarty
 conv
 Convair
 conveniency
@@ -494,7 +479,6 @@ CPUs
 CPython
 Cracknell
 creatable
-createad
 CreateCopy
 CreateFieldFromArrowSchema
 createGeometry
@@ -551,12 +535,10 @@ dataset
 Dataset
 datasets
 Datasets
-datasett
 datasource
 Datasource
 datasources
 Datasources
-datasset
 datastore
 Datastores
 datastream
@@ -586,7 +568,6 @@ DCMAKE
 de
 De
 deaccess
-deails
 deallocate
 Deallocate
 deallocated
@@ -599,7 +580,6 @@ Decompressor
 decompressors
 decrementing
 decrypted
-dedeicated
 Deegree
 defacto
 define'ed
@@ -627,13 +607,11 @@ derogations
 des
 DES
 desc
-descendent
 describedby
 deserialization
 deserialize
 deserialized
 deserializing
-desirabled
 dest
 destructor
 Destructor
@@ -694,7 +672,6 @@ dimensioned
 dimN
 DINSTALL
 dir
-directies
 Discoe
 discretization
 discretizing
@@ -721,18 +698,16 @@ domainSet
 domainuser
 doo
 doq
-doubtfull
+doubtful
 downcasting
 downsampled
 downsampling
 downscaling
-downswhen
 dox
 doxing
 Doxyfiles
 Doxygen
 dp
-dpecified
 drawOrder
 drv
 ds
@@ -772,12 +747,10 @@ ecw
 ecwp
 eDataType
 EDE
-editings
 eDstType
 eDT
 eedaconf
 eErrClass
-effictively
 eFieldType
 eg
 eGeomType
@@ -856,7 +829,6 @@ ExportToWKB
 exportToWkt
 ExportToWKT
 expr
-Exte
 extendbeyonddateline
 ExtendBeyondDateLine
 Extensibility
@@ -913,7 +885,6 @@ filesystems
 fillnodata
 FillValue
 FindFile
-finition
 fiona
 fipszone
 fixedLevels
@@ -938,7 +909,6 @@ forecolor
 Foris
 formatter
 formatters
-formly
 Fortran
 fp
 fpInput
@@ -976,8 +946,6 @@ fullExtent
 func
 funnyline
 Furieri
-furtherbelow
-Furthermode
 fusiontables
 fwhm
 fwrite
@@ -1304,7 +1272,6 @@ heightfields
 Helmert
 hElseBand
 Helvetica
-hether
 hFeat
 hGeom
 hGeomCoordPrec
@@ -1334,7 +1301,6 @@ hNewSubGeom
 hObject
 hobu
 hoc
-holded
 Homebrew
 homographies
 Homographies
@@ -1452,12 +1418,10 @@ ini
 init
 Init
 initialExtent
-initiali
 initializer
 inlined
 instantiable
 instantiation
-integratations
 integrations
 integrators
 intentionally
@@ -1668,7 +1632,6 @@ libwebp
 libXML
 libxz
 libzstd
-licencing
 Lichun
 lifonly
 linearities
@@ -1711,7 +1674,6 @@ loheight
 lon
 LongitudeDirection
 longjmp
-longtiudinal
 lonorth
 los
 Loskot
@@ -1742,8 +1704,6 @@ MacOS
 magellan
 magnetics
 Mahamood
-mainbly
-mainteners
 makefile
 Makefile
 makefiles
@@ -2390,8 +2350,6 @@ papszStrList
 papszURL
 papszVectorTranslateArguments
 papszWarpOptions
-Paquet
-paradygm
 parallelisation
 parallelising
 Parallelization
@@ -2439,7 +2397,6 @@ pds
 PDS
 pDstBuffer
 pDstBufferAllocStart
-pecedence
 pel
 perefix
 performant
@@ -2609,7 +2566,6 @@ ppszRawXML
 ppszResult
 ppszUnits
 ppWorkingData
-practise
 pre
 Pre
 pread
@@ -2621,7 +2577,6 @@ precompute
 predefine
 predelete
 preinstalled
-prelimenary
 preload
 premultiplication
 Prepar
@@ -2635,7 +2590,6 @@ pRet
 prf
 printf
 Printf
-prioritary
 priorly
 Priorly
 priv
@@ -2656,12 +2610,10 @@ projjson
 projwin
 projWin
 PropertyDefn
-prounounces
 Provincie
 proximities
 proxyauth
 proxyuserpwd
-prsence
 ps
 psBlockInfo
 psChild
@@ -2860,7 +2812,6 @@ relaxedFieldNameMatch
 relink
 RemoveM
 renderer
-repistory
 repo
 reportings
 reportSrcColumn
@@ -2900,7 +2851,6 @@ resy
 retile
 retiling
 RetrieveNumericColumnsAsDouble
-Retrurns
 rewrap
 rewrapped
 rfc
@@ -2928,7 +2878,6 @@ RollbackTransaction
 Ronnen
 rorient
 rouault
-rought
 roundCoordinates
 roundoff
 roundtrip
@@ -3041,7 +2990,6 @@ si
 sig
 Sightlines
 signedness
-significants
 Simmon
 sinc
 sizeBytes
@@ -3089,9 +3037,7 @@ spatio
 Spatio
 spc
 specialised
-speciffed
 specificities
-Specifieds
 SpectralBand
 spf
 sprintf
@@ -3285,12 +3231,10 @@ tgt
 tgz
 th
 thebuffer
-themself
 thenBand
 thescale
 thf
 THH
-thish
 Thorne
 thorougful
 threadsafe
@@ -3372,12 +3316,9 @@ tpkx
 tps
 trac
 Trac
-Traditionnaly
 Traditonal
-trailaing
 transactional
 Transactional
-transcations
 transcode
 transcoded
 transcoding
@@ -3427,10 +3368,8 @@ uncoded
 uncomment
 Uncompress
 uncompressing
-underscope
 undirected
 Undirected
-undoubtly
 unencrypted
 unescape
 Unescape
@@ -3439,7 +3378,6 @@ ungeoreference
 ungeoreferenced
 ungridded
 unicode
-unintentionnaly
 uninvertable
 unioned
 unistd
@@ -3448,12 +3386,10 @@ unix
 unixodbc
 unixODBC
 unlabelled
-unlikeley
 unlink
 Unlink
 unlogged
 Unlogged
-unmanagable
 unmanaged
 unmapped
 unoptimized
@@ -3496,7 +3432,6 @@ Userid
 userNote
 USERPROFILE
 UserPwd
-useul
 usgsdemdataset
 ushort
 usr
@@ -3525,7 +3460,6 @@ vct
 vcvars
 vdc
 vdv
-vecror
 VectorInfo
 VectorInfoOptions
 vectorization

--- a/doc/source/tutorials/gnm_api_tut.rst
+++ b/doc/source/tutorials/gnm_api_tut.rst
@@ -55,7 +55,7 @@ For now we have a void network consisted of only "system layers". We need to pop
 
     GDALClose(poSrcDS);
 
-After the successful copying we have the network full of features, but with no topology. The features were added and registered in the network but they are still not connected with each other. Now it is time to build the network topology. There are two ways of doing this in GNM: manually or automatically. In the most cases automatic building is more convenient, while manual is useful for small editings. Automatic building requires some parameters: we must specify which "class layers" will participate in topology building (we select our two layers), a snap tolerance, direct and inverse cost, direction, which is equal 0.00005 in our case. If the building will be successful the network's graph will be filled with the according connections.
+After the successful copying we have the network full of features, but with no topology. The features were added and registered in the network but they are still not connected with each other. Now it is time to build the network topology. There are two ways of doing this in GNM: manually or automatically. In the most cases automatic building is more convenient, while manual is useful for small edits. Automatic building requires some parameters: we must specify which "class layers" will participate in topology building (we select our two layers), a snap tolerance, direct and inverse cost, direction, which is equal 0.00005 in our case. If the building will be successful the network's graph will be filled with the according connections.
 
 
 .. code-block::

--- a/doc/source/tutorials/vector_python_driver.rst
+++ b/doc/source/tutorials/vector_python_driver.rst
@@ -39,7 +39,7 @@ Driver location
 ---------------
 
 Driver filenames must start with `gdal_` or `ogr_` and have the `.py` extension.
-They will be searched in the following directies:
+They will be searched in the following directories:
 
 * the directory pointed by the ``GDAL_PYTHON_DRIVER_PATH`` configuration option
   (there may be several paths separated by `:` on Unix or `;` on Windows)

--- a/doc/source/tutorials/wktproblems.rst
+++ b/doc/source/tutorials/wktproblems.rst
@@ -269,7 +269,7 @@ Martin wrote back that he was uncertain on the correct signage and that
 the Adam had programmed the Cadcorp implementation empirically,
 according to what seemed to work for the test data available.
 
-I am prepared to adhere to the Cadorp sign usage (as per EPSG 9607) if
+I am prepared to adhere to the Cadcorp sign usage (as per EPSG 9607) if
 this can be clarified in the specification.
 
 Current state of OGR implementation
@@ -285,7 +285,7 @@ the appropriate conversion (negating the sign of the rotation terms).
 Longitudes Relative to PRIMEM?
 ------------------------------
 
-Another related question is whether longtiudinal projection parameters
+Another related question is whether longitudinal projection parameters
 (ie. central meridian) are relative to the GEOGCS prime meridian or
 relative to greenwich. While the simplest approach is to treat all
 longitudes as relative to Greenwich, I somehow convinced myself at one

--- a/doc/source/user/ogr_feature_style.rst
+++ b/doc/source/user/ogr_feature_style.rst
@@ -393,7 +393,7 @@ optional:
   ids. The names in the comma-delimited list of ids are scanned until one is
   recognized by the target system.
 
-  Brush Ids can be either system-specific ids (see furtherbelow) or be one of
+  Brush Ids can be either system-specific ids (see further below) or be one of
   the pre-defined OGR brush ids for well known brush patterns. The id parameter
   should always include one of the OGR ids at the end of the comma-delimited
   list of ids so that an application never has to rely on understanding
@@ -548,7 +548,7 @@ optional:
 
   * ``ds`` is the step to use when  placing symbols along the line.
     By default, symbols applied to a feature with a line geometry are placed at
-    each vertex, butsetting "ds" triggers the placement of symbols at an equal
+    each vertex, but setting "ds" triggers the placement of symbols at an equal
     distance along the line. "ds" has no effect for a feature with a point
     geometry.
 

--- a/doc/source/user/ogr_sql_dialect.rst
+++ b/doc/source/user/ogr_sql_dialect.rst
@@ -437,7 +437,7 @@ Wildcards are also somewhat more involved.  All fields from the primary table
 (**city** in this case) and the secondary table (**nation** in this
 case) may be selected using the usual ``*`` wildcard.  But the fields of
 just one of the primary or secondary table may be selected by prefixing the
-asterix with the table name.
+asterisk with the table name.
 
 The field names in the resulting query layer will be qualified by the table
 name, if the table name is given as a qualifier in the field list.  In addition

--- a/frmts/gti/gdaltileindexdataset.cpp
+++ b/frmts/gti/gdaltileindexdataset.cpp
@@ -3922,7 +3922,7 @@ bool GDALTileIndexDataset::CollectSources(double dfXOff, double dfYOff,
         SortSourceDesc();
     }
 
-    // Try to find the last (most prioritary) fully opaque source covering
+    // Try to find the last (most priority) fully opaque source covering
     // the whole AOI. We only need to start rendering from it.
     size_t i = m_aoSourceDesc.size();
     while (i > 0)
@@ -4219,7 +4219,7 @@ bool GDALTileIndexDataset::NeedInitBuffer(int nBandCount,
                                           const int *panBandMap) const
 {
     bool bNeedInitBuffer = true;
-    // If the last source (that is the most prioritary one) covers at least
+    // If the last source (that is the most priority one) covers at least
     // the window of interest and is fully opaque, then we don't need to
     // initialize the buffer, and can directly render that source.
     int bHasNoData = false;

--- a/frmts/gtiff/gtiffdataset_read.cpp
+++ b/frmts/gtiff/gtiffdataset_read.cpp
@@ -4386,7 +4386,7 @@ void GTiffDataset::ApplyPamInfo()
     {
         m_aoGCPs = gdal::GCP::fromC(GDALPamDataset::GetGCPs(), nPamGCPCount);
 
-        // Invalidate Geotransorm got from less prioritary sources
+        // Invalidate Geotransorm got from less priority sources
         if (!m_aoGCPs.empty() && m_bGeoTransformValid && !bGotGTFromPAM &&
             m_nPAMGeorefSrcIndex == 0)
         {
@@ -4484,7 +4484,7 @@ void GTiffDataset::ApplyPamInfo()
                             /* Y = */ adfTargetGCPs[2 * i + 1]);
                     }
 
-                    // Invalidate Geotransform got from less prioritary sources
+                    // Invalidate Geotransform got from less priority sources
                     if (!m_aoGCPs.empty() && m_bGeoTransformValid &&
                         !bGotGTFromPAM && m_nPAMGeorefSrcIndex == 0)
                     {

--- a/gcore/gdalgeorefpamdataset.cpp
+++ b/gcore/gdalgeorefpamdataset.cpp
@@ -298,7 +298,7 @@ CPLErr GDALGeorefPamDataset::GetGeoTransform(GDALGeoTransform &gt) const
 /************************************************************************/
 /*                     GetPAMGeorefSrcIndex()                           */
 /*                                                                      */
-/*      Get priority index of PAM (the lower, the more prioritary)      */
+/*      Get priority index of PAM (the lower, the more priority)      */
 /************************************************************************/
 int GDALGeorefPamDataset::GetPAMGeorefSrcIndex() const
 {

--- a/gcore/gdalmultidim.cpp
+++ b/gcore/gdalmultidim.cpp
@@ -1347,7 +1347,7 @@ GDALGroup::OpenAttributeFromFullname(const std::string &osFullName,
  * Otherwise the search will start from the group identified by osStartingPath,
  * and an array whose name is osName will be looked for in this group (if
  * osStartingPath is empty or "/", then the current group is used). If there
- * is no match, then a recursive descendent search will be made in its
+ * is no match, then a recursive descendant search will be made in its
  * subgroups. If there is no match in the subgroups, then the parent (if
  * existing) of the group pointed by osStartingPath will be used as the new
  * starting point for the search.
@@ -2420,7 +2420,7 @@ GUInt64 GDALAbstractMDArray::GetTotalElementsCount() const
  *
  * This method is used by GetProcessingChunkSize().
  *
- * Pedantic note: the returned type is GUInt64, so in the highly unlikeley
+ * Pedantic note: the returned type is GUInt64, so in the highly unlikely
  * theoretical case of a 32-bit platform, this might exceed its size_t
  * allocation capabilities.
  *
@@ -12937,7 +12937,7 @@ double GDALMDArrayGetOffsetEx(GDALMDArrayH hArray, int *pbHasValue,
  *
  * This method is used by GetProcessingChunkSize().
  *
- * Pedantic note: the returned type is GUInt64, so in the highly unlikeley
+ * Pedantic note: the returned type is GUInt64, so in the highly unlikely
  * theoretical case of a 32-bit platform, this might exceed its size_t
  * allocation capabilities.
  *

--- a/ogr/ogr_feature.h
+++ b/ogr/ogr_feature.h
@@ -911,7 +911,7 @@ class CPL_DLL OGRFeatureDefn
  *
  * @param bSealFields Whether fields and geometry fields should be unsealed and
  *                    resealed.
- *                    This is generally desirabled, but in case of deferred
+ *                    This is generally desirable, but in case of deferred
  *                    resolution of them, this parameter should be set to false.
  * @since GDAL 3.9
  */

--- a/ogr/ogrfeaturedefn.cpp
+++ b/ogr/ogrfeaturedefn.cpp
@@ -1694,7 +1694,7 @@ OGRFeatureDefn::ComputeMapForSetFrom(const OGRFeatureDefn *poSrcFDefn,
  * This method should only be called by driver implementations.
  *
  * @param bSealFields Whether fields and geometry fields should be sealed.
- *                    This is generally desirabled, but in case of deferred
+ *                    This is generally desirable, but in case of deferred
  *                    resolution of them, this parameter should be set to false.
  * @since GDAL 3.9
  */
@@ -1734,7 +1734,7 @@ void OGRFeatureDefn::Seal(bool bSealFields)
  * This method should only be called by driver implementations.
  *
  * @param bUnsealFields Whether fields and geometry fields should be unsealed.
- *                      This is generally desirabled, but in case of deferred
+ *                      This is generally desirable, but in case of deferred
  *                      resolution of them, this parameter should be set to
  * false.
  * @since GDAL 3.9
@@ -1780,7 +1780,7 @@ void OGRFeatureDefn::Unseal(bool bUnsealFields)
  *
  * @param bSealFields Whether fields and geometry fields should be unsealed and
  *                    resealed.
- *                    This is generally desirabled, but in case of deferred
+ *                    This is generally desirable, but in case of deferred
  *                    resolution of them, this parameter should be set to false.
  * @since GDAL 3.9
  */

--- a/ogr/ogrsf_frmts/generic/ogrlayer.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrlayer.cpp
@@ -535,7 +535,7 @@ OGRErr OGR_L_GetExtentEx(OGRLayerH hLayer, int iGeomField,
  TRUE then some implementations will actually scan the entire layer once
  to compute the MBR of all the features in the layer.
 
- (Contrarty to GetExtent() 2D), the returned extent will always take into
+ (Contrary to GetExtent() 2D), the returned extent will always take into
  account the attribute and spatial filters that may be installed.
 
  Layers without any geometry may return OGRERR_FAILURE just indicating that
@@ -677,7 +677,7 @@ OGRErr OGRLayer::IGetExtent3D(int iGeomField, OGREnvelope3D *psExtent3D,
  TRUE then some implementations will actually scan the entire layer once
  to compute the MBR of all the features in the layer.
 
- (Contrarty to GetExtent() 2D), the returned extent will always take into
+ (Contrary to GetExtent() 2D), the returned extent will always take into
  account the attribute and spatial filters that may be installed.
 
  Layers without any geometry may return OGRERR_FAILURE just indicating that

--- a/ogr/ogrsf_frmts/generic/ogrlayerarrow.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrlayerarrow.cpp
@@ -6393,7 +6393,7 @@ bool OGRLayer::CreateFieldFromArrowSchemaInternal(
  * struct (format=+s) (unless writing a set of fields grouped together in the
  * same structure).
  *
- * Additional field metadata can be speciffed through the ArrowSchema::metadata
+ * Additional field metadata can be specified through the ArrowSchema::metadata
  * field with the potential following items:
  * <ul>
  * <li>"GDAL:OGR:alternative_name": value of
@@ -6439,7 +6439,7 @@ bool OGRLayer::CreateFieldFromArrowSchema(const struct ArrowSchema *schema,
  * struct (format=+s) (unless writing a set of fields grouped together in the
  * same structure).
  *
- * Additional field metadata can be speciffed through the ArrowSchema::metadata
+ * Additional field metadata can be specified through the ArrowSchema::metadata
  * field with the potential following items:
  * <ul>
  * <li>"GDAL:OGR:alternative_name": value of

--- a/ogr/ogrspatialreference.cpp
+++ b/ogr/ogrspatialreference.cpp
@@ -7314,7 +7314,7 @@ OGRErr OSRSetHOM2PNO(OGRSpatialReferenceH hSRS, double dfCenterLat,
  * @param dfCenterLong Longitude of the projection origin.
  * @param dfAzimuth Azimuth, measured clockwise from North, of the projection
  * centerline.
- * @param dfScale Scale factor on the initiali line
+ * @param dfScale Scale factor on the initial line
  * @param dfFalseEasting False easting.
  * @param dfFalseNorthing False northing.
  *

--- a/port/cpl_odbc.cpp
+++ b/port/cpl_odbc.cpp
@@ -1123,7 +1123,7 @@ short CPLODBCStatement::GetColNullable(int iCol)
  *
  * @param iCol the zero based column index.
  *
- * @return NULL if the default value is not dpecified
+ * @return NULL if the default value is not specified
  * or the internal copy of the default value.
  */
 

--- a/port/cpl_string.h
+++ b/port/cpl_string.h
@@ -76,7 +76,7 @@ char CPL_DLL **CSLTokenizeString2(const char *pszString,
 #define CSLT_PRESERVEESCAPES 0x0008
 /** Flag for CSLTokenizeString2() to strip leading spaces */
 #define CSLT_STRIPLEADSPACES 0x0010
-/** Flag for CSLTokenizeString2() to strip trailaing spaces */
+/** Flag for CSLTokenizeString2() to strip trailing spaces */
 #define CSLT_STRIPENDSPACES 0x0020
 
 int CPL_DLL CSLPrint(CSLConstList papszStrList, FILE *fpOut);

--- a/port/cpl_vsil.cpp
+++ b/port/cpl_vsil.cpp
@@ -1291,7 +1291,7 @@ char *VSIMultipartUploadAddPart(const char *pszFilename,
  *                    Should be the same as the one used for
  *                    VSIMultipartUploadStart()
  * @param pszUploadId Value returned by VSIMultipartUploadStart()
- * @param nPartIdsCount Number of parts,  andsize of apszPartIds
+ * @param nPartIdsCount Number of parts, and size of apszPartIds
  * @param apszPartIds Array of part identifiers (as returned by
  *                    VSIMultipartUploadAddPart()), that must be ordered in
  *                    the sequential order of parts, and of size nPartIdsCount.

--- a/swig/include/python/docs/gdal_dataset_docs.i
+++ b/swig/include/python/docs/gdal_dataset_docs.i
@@ -772,7 +772,7 @@ Update an existing field domain by replacing its definition.
 
 The existing field domain with matching name will be replaced.
 
-Requires the :py:const:`ogr.ODsCUpdateFieldDomain` datasset capability.
+Requires the :py:const:`ogr.ODsCUpdateFieldDomain` dataset capability.
 
 Parameters
 ----------


### PR DESCRIPTION
Fixes various typos in the docs that had been added to spelling_wordlist.txt (and remove them from spelling_wordlist.txt). 