### PR TITLE
Doc: Update link to latest official NetCDF documentation

### DIFF
--- a/doc/source/drivers/raster/netcdf.rst
+++ b/doc/source/drivers/raster/netcdf.rst
@@ -777,5 +777,4 @@ See Also:
    convention <https://cfconventions.org/Data/cf-conventions/cf-conventions-1.5/build/cf-conventions.html>`__
 -  `NetCDF compiled
    libraries <http://www.unidata.ucar.edu/downloads/netcdf/index.jsp>`__
--  `NetCDF
-   Documentation <http://www.unidata.ucar.edu/software/netcdf/docs/>`__
+-  `NetCDF Documentation <https://www.unidata.ucar.edu/software/netcdf>`__


### PR DESCRIPTION
## What does this PR do?
Updates the link to the latest NetCDF documentation. The current one in the GDAL docs ends in a 404.
