### PR TITLE
gdal raster calc: allow to specify input files as nested pipelines

### DIFF
--- a/apps/gdalalg_raster_calc.cpp
+++ b/apps/gdalalg_raster_calc.cpp
@@ -649,6 +649,17 @@ static bool ParseSourceDescriptors(const std::vector<std::string> &inputs,
 
         std::string dsn =
             (pos == std::string::npos) ? input : input.substr(pos + 1);
+
+        if (!dsn.empty() && dsn.front() == '[' && dsn.back() == ']')
+        {
+            dsn = "{\"type\":\"gdal_streamed_alg\", \"command_line\":\"gdal "
+                  "raster pipeline " +
+                  CPLString(dsn.substr(1, dsn.size() - 2))
+                      .replaceAll('\\', "\\\\")
+                      .replaceAll('"', "\\\"") +
+                  "\"}";
+        }
+
         if (datasets.find(name) != datasets.end())
         {
             CPLError(CE_Failure, CPLE_AppDefined,

--- a/autotest/utilities/test_gdalalg_raster_calc.py
+++ b/autotest/utilities/test_gdalalg_raster_calc.py
@@ -1025,3 +1025,15 @@ def test_gdalalg_raster_calc_sum_float_input_with_nodata(calc, tmp_vsimem):
 
     out_ds = calc["output"].GetDataset()
     assert out_ds.GetRasterBand(1).Checksum() == 1
+
+
+@pytest.mark.require_driver("GDALG")
+def test_gdalalg_raster_calc_input_pipeline(calc):
+
+    calc["input"] = "A=[ read ../gcore/data/byte.tif ! aspect ]"
+    calc["output-format"] = "MEM"
+    calc["calc"] = "A * 10"
+    calc.Run()
+
+    out_ds = calc["output"].GetDataset()
+    assert out_ds.GetRasterBand(1).Checksum() == 4692

--- a/doc/source/programs/gdal_raster_calc.rst
+++ b/doc/source/programs/gdal_raster_calc.rst
@@ -184,3 +184,11 @@ Examples
    .. code-block:: bash
 
        gdal raster calc -i A=input1.tif -i B=input2.tif -o result.tif --flatten --calc=mean --dialect=builtin
+
+
+.. example::
+   :title: Generate a masked aspect layer where the slope angle is greater than 2 degrees, using nested pipelines (since GDAL 3.12.1)
+
+   .. code-block:: bash
+
+       gdal raster calc -i "SLOPE=[ read dem.tif ! slope ]" -i "ASPECT=[ read dem.tif ! aspect ]" -o result.tif --calc "(SLOPE >= 2) ? ASPECT : -9999" --nodata -9999


### PR DESCRIPTION
Fixes #13493
