### PR TITLE
Doc: Persist current page when switching versions

### DIFF
--- a/doc/source/_static/js/versions.js
+++ b/doc/source/_static/js/versions.js
@@ -64,7 +64,7 @@ if (themeFlyoutDisplay === "attached") {
                 .map(
                     (version) => `
         <dd ${version.slug === config.versions.current.slug ? 'class="rtd-current-item"' : ""}>
-          <a href="${version.urls.documentation}">${version.slug}</a>
+          <a href="${window.location.pathname.replace(config.versions.current.slug, version.slug)}">${version.slug}</a>
         </dd>
         `,
                 )


### PR DESCRIPTION
Follow-up to #13480 based on comment at https://github.com/OSGeo/gdal/issues/11812#issuecomment-3592691165

Update `renderVersions` function to persist current page when selecting versions at the bottom of the TOC. 
Tested on https://geographika-gdal.readthedocs.io/ (it can only be tested on a RTD deployment, not locally). 

<img width="316" height="125" alt="520500463-5843ad6e-3e5e-4725-8178-e113292e829a" src="https://github.com/user-attachments/assets/aa68b84f-14da-4201-ad09-ceaea2df16cd" />

I've also opened a PR upstream with these changes: https://github.com/readthedocs/sphinx_rtd_theme/pull/1663

cc @dbaston 