### PR TITLE
NITF: fix reading extended header TREs

### DIFF
--- a/frmts/nitf/nitffile.cpp
+++ b/frmts/nitf/nitffile.cpp
@@ -439,7 +439,8 @@ retry_read_header:
                 return nullptr;
             }
             psFile->pachTRE = pachNewTRE;
-            memcpy(psFile->pachTRE + psFile->nTREBytes, pachHeader + nOffset, nXHDL);
+            memcpy(psFile->pachTRE + psFile->nTREBytes, pachHeader + nOffset,
+                   nXHDL);
             psFile->nTREBytes += nXHDL;
         }
     }


### PR DESCRIPTION
Was not found by me but think extended header TREs overwriting old after the realloc