### PR TITLE
[Backport release/3.12] NITF: fix reading extended header TREs

### DIFF
--- a/frmts/nitf/nitffile.cpp
+++ b/frmts/nitf/nitffile.cpp
@@ -439,7 +439,8 @@ retry_read_header:
                 return nullptr;
             }
             psFile->pachTRE = pachNewTRE;
-            memcpy(psFile->pachTRE + psFile->nTREBytes, pachHeader + nOffset, nXHDL);
+            memcpy(psFile->pachTRE + psFile->nTREBytes, pachHeader + nOffset,
+                   nXHDL);
             psFile->nTREBytes += nXHDL;
         }
     }


### PR DESCRIPTION
Backport #13508
 **Authored by:** @jdbren