### PR TITLE
Doc: Update examples that use text output by default

### DIFF
--- a/doc/source/programs/gdal_dataset_identify.rst
+++ b/doc/source/programs/gdal_dataset_identify.rst
@@ -52,7 +52,7 @@ Examples
 
    .. code-block:: console
 
-       $ gdal dataset identify --of=text NE1_50M_SR_W.tif
+       $ gdal dataset identify NE1_50M_SR_W.tif
 
        NE1_50M_SR_W.tif: GTiff
 
@@ -61,7 +61,7 @@ Examples
 
    .. code-block:: console
 
-       $ gdal dataset identify NE1_50M_SR_W.tif
+       $ gdal dataset identify --of=JSON NE1_50M_SR_W.tif
 
    .. code-block:: json
 
@@ -77,7 +77,7 @@ Examples
 
     .. code-block::
 
-        $ gdal dataset identify --of=text -r 50m_raster/
+        $ gdal dataset identify -r 50m_raster/
 
         NE1_50M_SR_W/ne1_50m.jpg: JPEG
         NE1_50M_SR_W/ne1_50m.png: PNG

--- a/doc/source/programs/gdal_info.rst
+++ b/doc/source/programs/gdal_info.rst
@@ -24,15 +24,15 @@ Examples
 --------
 
 .. example::
-   :title: Getting information on the file :file:`utmsmall.tif` (with JSON output)
+   :title: Getting information on the file :file:`utmsmall.tif` (with text output)
 
    .. command-output:: gdal info utmsmall.tif
       :cwd: ../../data
 
 .. example::
-   :title: Getting information on the file :file:`poly.gpkg` (with text output), listing all features
+   :title: Getting information on the file :file:`poly.gpkg` (with JSON output), listing all features
 
-   .. command-output:: gdal vector info --format=text --features poly.gpkg
+   .. command-output:: gdal vector info --format=JSON --features poly.gpkg
       :cwd: ../../data
 
 .. example::

--- a/doc/source/programs/gdal_raster.rst
+++ b/doc/source/programs/gdal_raster.rst
@@ -62,7 +62,7 @@ Examples
 --------
 
 .. example::
-   :title: Getting information on the file :file:`utm.tif` (with JSON output)
+   :title: Getting information on the file :file:`utm.tif` (with text output)
 
    .. code-block:: console
 

--- a/doc/source/programs/gdal_raster_info.rst
+++ b/doc/source/programs/gdal_raster_info.rst
@@ -145,13 +145,13 @@ Examples
 --------
 
 .. example::
-   :title: Getting information on the file :file:`utmsmall.tif` as JSON output
+   :title: Getting information on the file :file:`utmsmall.tif` as text output
 
    .. command-output:: gdal raster info utmsmall.tif
       :cwd: ../../data
 
 .. example::
-   :title: Getting information on the file :file:`utmsmall.tif` as text output, including statistics
+   :title: Getting information on the file :file:`utmsmall.tif` as JSON output, including statistics
 
-   .. command-output:: gdal raster info --format=text --stats utmsmall.tif
+   .. command-output:: gdal raster info --format=JSON --stats utmsmall.tif
       :cwd: ../../data/with_stats

--- a/doc/source/programs/gdal_vector.rst
+++ b/doc/source/programs/gdal_vector.rst
@@ -42,7 +42,7 @@ Examples
 --------
 
 .. example::
-   :title: Getting information on the file :file:`poly.gpkg` (with JSON output)
+   :title: Getting information on the file :file:`poly.gpkg` (with text output)
 
    .. code-block:: console
 

--- a/doc/source/programs/gdal_vector_info.rst
+++ b/doc/source/programs/gdal_vector_info.rst
@@ -107,11 +107,11 @@ Examples
 .. example::
    :title: Getting information on the file :file:`poly.gpkg` (with text output), listing all features
 
-   .. command-output:: gdal vector info --format=text --features poly.gpkg
+   .. command-output:: gdal vector info --features poly.gpkg
       :cwd: ../../data
 
 .. example::
    :title: Getting information on the file :file:`poly.gpkg` (with JSON output)
 
-   .. command-output:: gdal vector info poly.gpkg
+   .. command-output:: gdal vector info --format=JSON poly.gpkg
       :cwd: ../../data

--- a/doc/source/programs/gdal_vsi.rst
+++ b/doc/source/programs/gdal_vsi.rst
@@ -38,4 +38,4 @@ Examples
 
    .. code-block:: console
 
-       $ gdal vsi list -lR --of=text /vsis3/bucket
+       $ gdal vsi list -lR /vsis3/bucket

--- a/doc/source/programs/gdal_vsi_list.rst
+++ b/doc/source/programs/gdal_vsi_list.rst
@@ -74,4 +74,4 @@ Examples
 
    .. code-block:: console
 
-       $ gdal vsi list -lR --of=text /vsis3/bucket
+       $ gdal vsi list -lR /vsis3/bucket

--- a/doc/source/programs/migration_guide_to_gdal_cli.rst
+++ b/doc/source/programs/migration_guide_to_gdal_cli.rst
@@ -19,7 +19,7 @@ Raster commands
 
     ==>
 
-    gdal raster info --format=text my.tif
+    gdal raster info my.tif
 
 
 * Converting a georeferenced netCDF file to cloud-optimized GeoTIFF
@@ -192,7 +192,7 @@ Vector commands
 
     ==>
 
-    gdal vector info --format=text my.gpkg
+    gdal vector info my.gpkg
 
 
 * Converting a shapefile to a GeoPackage


### PR DESCRIPTION
Since https://github.com/OSGeo/gdal/pull/12737 the GDAL cli uses text mode for gdal raster/vector info and gdal vsi list by default. This PR updates the docs to reflect this.

Currently, there is a mismatch between the docs and the output e.g. https://gdal.org/en/latest/programs/gdal_info.html#programs/gdal_info-1

<img width="1101" height="439" alt="image" src="https://github.com/user-attachments/assets/e6cf1d0e-8185-4800-8419-969f94b9f3fd" />


Note `gdal mdim info` still uses JSON by default. 