### PR TITLE
GTI: only rewrite URLs (like gs:// --> /vsigs/) for a STAC collection catalog

### DIFF
--- a/autotest/gdrivers/gti.py
+++ b/autotest/gdrivers/gti.py
@@ -19,6 +19,7 @@ import struct
 import gdaltest
 import ogrtest
 import pytest
+import webserver
 
 from osgeo import gdal, ogr
 
@@ -3213,3 +3214,58 @@ def test_gti_sql(tmp_vsimem):
         )
     with pytest.raises(Exception, match="syntax error"):
         gti_ds.GetRasterBand(1).ComputeRasterMinMax()
+
+
+###############################################################################
+
+
+@pytest.fixture(scope="module")
+def server():
+
+    process, port = webserver.launch(handler=webserver.DispatcherHttpHandler)
+    if port == 0:
+        pytest.skip()
+
+    import collections
+
+    WebServer = collections.namedtuple("WebServer", "process port")
+
+    yield WebServer(process, port)
+
+    # Clearcache needed to close all connections, since the Python server
+    # can only handle one connection at a time
+    gdal.VSICurlClearCache()
+
+    webserver.server_stop(process, port)
+
+
+###############################################################################
+
+
+@pytest.mark.require_curl()
+@pytest.mark.require_driver("HTTP")
+@pytest.mark.require_driver("CSV")
+def test_gti_non_rewriting_of_url(server, tmp_vsimem):
+    """Check fix for https://github.com/OSGeo/gdal/issues/12900#issuecomment-3637663699"""
+
+    gdal.FileFromMemBuffer(
+        tmp_vsimem / "test.csv",
+        f'location,WKT\n"http://localhost:{server.port}/test.tif","POLYGON((0 0,0 1,1 1,1 0))"',
+    )
+
+    with gdal.GetDriverByName("GTiff").Create(tmp_vsimem / "test.tif", 1, 1) as ds:
+        ds.SetGeoTransform([0, 1, 0, 1, 0, -1])
+        ds.GetRasterBand(1).Fill(1)
+
+    with gdal.VSIFile(tmp_vsimem / "test.tif", "rb") as f:
+        content = f.read()
+
+    handler = webserver.SequentialHandler()
+    # Check that we get a GET request for the full file (ie using the HTTP driver)
+    # and not a /vsicurl/ range request
+    handler.add("GET", "/test.tif", 200, {}, content, unexpected_headers=["Range"])
+    handler.add("GET", "/test.tif", 200, {}, content, unexpected_headers=["Range"])
+
+    with webserver.install_http_handler(handler), gdal.quiet_errors():
+        ds = gdal.Open(f"GTI:{tmp_vsimem}/test.csv")
+        assert ds.GetRasterBand(1).Checksum() == 1


### PR DESCRIPTION
For 'pure' GTI indexes, this is not desirable, since users could install their own I/O layer.

Fixes https://github.com/OSGeo/gdal/issues/12900#issuecomment-3637663699
