### PR TITLE
gdal vector filter: add --update-extent

### DIFF
--- a/.github/workflows/ubuntu_24.04/reference_arg_names.txt
+++ b/.github/workflows/ubuntu_24.04/reference_arg_names.txt
@@ -312,6 +312,7 @@ unset-layer-metadata
 unset-metadata
 unset-metadata-domain
 update
+update-extent
 upsert
 url
 use-source-timestamp

--- a/apps/gdalalg_vector_filter.cpp
+++ b/apps/gdalalg_vector_filter.cpp
@@ -41,13 +41,74 @@ GDALVectorFilterAlgorithm::GDALVectorFilterAlgorithm(bool standaloneStep)
         .SetReadFromFileAtSyntaxAllowed()
         .SetMetaVar("<WHERE>|@<filename>")
         .SetRemoveSQLCommentsEnabled();
+    AddArg("update-extent", 0,
+           _("Update layer extent to take into account the filter"),
+           &m_updateExtent);
 }
+
+/************************************************************************/
+/*                GDALVectorFilterAlgorithmLayerChangeExtent            */
+/************************************************************************/
+
+namespace
+{
+class GDALVectorFilterAlgorithmLayerChangeExtent final
+    : public GDALVectorPipelinePassthroughLayer
+{
+  public:
+    GDALVectorFilterAlgorithmLayerChangeExtent(
+        OGRLayer &oSrcLayer, const OGREnvelope3D &sLayerEnvelope)
+        : GDALVectorPipelinePassthroughLayer(oSrcLayer),
+          m_sLayerEnvelope(sLayerEnvelope)
+    {
+    }
+
+    OGRErr IGetExtent(int /*iGeomField*/, OGREnvelope *psExtent,
+                      bool /* bForce */) override
+    {
+        if (m_sLayerEnvelope.IsInit())
+        {
+            *psExtent = m_sLayerEnvelope;
+            return OGRERR_NONE;
+        }
+        else
+        {
+            return OGRERR_FAILURE;
+        }
+    }
+
+    OGRErr IGetExtent3D(int /*iGeomField*/, OGREnvelope3D *psExtent,
+                        bool /* bForce */) override
+    {
+        if (m_sLayerEnvelope.IsInit())
+        {
+            *psExtent = m_sLayerEnvelope;
+            return OGRERR_NONE;
+        }
+        else
+        {
+            return OGRERR_FAILURE;
+        }
+    }
+
+    int TestCapability(const char *pszCap) const override
+    {
+        if (EQUAL(pszCap, OLCFastGetExtent))
+            return true;
+        return m_srcLayer.TestCapability(pszCap);
+    }
+
+  private:
+    const OGREnvelope3D m_sLayerEnvelope;
+};
+
+}  // namespace
 
 /************************************************************************/
 /*               GDALVectorFilterAlgorithm::RunStep()                   */
 /************************************************************************/
 
-bool GDALVectorFilterAlgorithm::RunStep(GDALPipelineStepRunContext &)
+bool GDALVectorFilterAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
 {
     auto poSrcDS = m_inputDataset[0].GetDatasetRef();
     CPLAssert(poSrcDS);
@@ -89,7 +150,90 @@ bool GDALVectorFilterAlgorithm::RunStep(GDALPipelineStepRunContext &)
         }
     }
 
-    if (ret)
+    if (ret && m_updateExtent)
+    {
+        auto outDS =
+            std::make_unique<GDALVectorPipelineOutputDataset>(*poSrcDS);
+
+        int64_t nTotalFeatures = 0;
+        if (ctxt.m_pfnProgress)
+        {
+            for (int i = 0; ret && i < nLayerCount; ++i)
+            {
+                auto poSrcLayer = poSrcDS->GetLayer(i);
+                ret = (poSrcLayer != nullptr);
+                if (ret)
+                {
+                    if (m_activeLayer.empty() ||
+                        m_activeLayer == poSrcLayer->GetDescription())
+                    {
+                        if (poSrcLayer->TestCapability(OLCFastFeatureCount))
+                        {
+                            const auto nFC = poSrcLayer->GetFeatureCount(false);
+                            if (nFC < 0)
+                            {
+                                nTotalFeatures = 0;
+                                break;
+                            }
+                            nTotalFeatures += nFC;
+                        }
+                    }
+                }
+            }
+        }
+
+        int64_t nFeatureCounter = 0;
+        for (int i = 0; ret && i < nLayerCount; ++i)
+        {
+            auto poSrcLayer = poSrcDS->GetLayer(i);
+            ret = (poSrcLayer != nullptr);
+            if (ret)
+            {
+                if (m_activeLayer.empty() ||
+                    m_activeLayer == poSrcLayer->GetDescription())
+                {
+                    OGREnvelope3D sLayerEnvelope, sFeatureEnvelope;
+                    for (auto &&poFeature : poSrcLayer)
+                    {
+                        const auto poGeom = poFeature->GetGeometryRef();
+                        if (poGeom && !poGeom->IsEmpty())
+                        {
+                            poGeom->getEnvelope(&sFeatureEnvelope);
+                            sLayerEnvelope.Merge(sFeatureEnvelope);
+                        }
+
+                        ++nFeatureCounter;
+                        if (nTotalFeatures > 0 && ctxt.m_pfnProgress &&
+                            !ctxt.m_pfnProgress(
+                                static_cast<double>(nFeatureCounter) /
+                                    static_cast<double>(nTotalFeatures),
+                                "", ctxt.m_pProgressData))
+                        {
+                            ReportError(CE_Failure, CPLE_UserInterrupt,
+                                        "Interrupted by user");
+                            return false;
+                        }
+                    }
+                    outDS->AddLayer(
+                        *poSrcLayer,
+                        std::make_unique<
+                            GDALVectorFilterAlgorithmLayerChangeExtent>(
+                            *poSrcLayer, sLayerEnvelope));
+                }
+                else
+                {
+                    outDS->AddLayer(
+                        *poSrcLayer,
+                        std::make_unique<GDALVectorPipelinePassthroughLayer>(
+                            *poSrcLayer));
+                }
+            }
+        }
+
+        if (ret)
+            m_outputDataset.Set(std::move(outDS));
+    }
+    else if (ret)
     {
         m_outputDataset.Set(poSrcDS);
     }

--- a/apps/gdalalg_vector_filter.h
+++ b/apps/gdalalg_vector_filter.h
@@ -31,12 +31,18 @@ class GDALVectorFilterAlgorithm /* non final */
 
     explicit GDALVectorFilterAlgorithm(bool standaloneStep = false);
 
+    bool IsNativelyStreamingCompatible() const override
+    {
+        return !m_updateExtent;
+    }
+
   private:
     bool RunStep(GDALPipelineStepRunContext &ctxt) override;
 
     std::string m_activeLayer{};
     std::vector<double> m_bbox{};
     std::string m_where{};
+    bool m_updateExtent = false;
 };
 
 /************************************************************************/

--- a/apps/gdalalg_vector_pipeline.h
+++ b/apps/gdalalg_vector_pipeline.h
@@ -241,6 +241,18 @@ class GDALVectorPipelinePassthroughLayer /* non final */
         return m_srcLayer.TestCapability(pszCap);
     }
 
+    OGRErr IGetExtent(int iGeomField, OGREnvelope *psExtent,
+                      bool bForce) override
+    {
+        return m_srcLayer.GetExtent(iGeomField, psExtent, bForce);
+    }
+
+    OGRErr IGetExtent3D(int iGeomField, OGREnvelope3D *psExtent,
+                        bool bForce) override
+    {
+        return m_srcLayer.GetExtent3D(iGeomField, psExtent, bForce);
+    }
+
     void TranslateFeature(
         std::unique_ptr<OGRFeature> poSrcFeature,
         std::vector<std::unique_ptr<OGRFeature>> &apoOutFeatures) override

--- a/doc/source/programs/gdal_vector_filter.rst
+++ b/doc/source/programs/gdal_vector_filter.rst
@@ -51,6 +51,13 @@ Standard options
 
     Attribute query (like SQL WHERE).
 
+.. option:: --update-extent
+
+    Update layer extent to take into account the filter(s). Otherwise the layer
+    extent will generally be the one of the source layer before applying the
+    filter(s). Note that using this option requires doing a full scan of the
+    filtered layers.
+
 
 Advanced options
 ++++++++++++++++

--- a/doc/source/programs/gdal_vector_rasterize.rst
+++ b/doc/source/programs/gdal_vector_rasterize.rst
@@ -199,3 +199,13 @@ Examples
     .. code-block:: bash
 
         gdal vector rasterize --burn 255,0,0 --ot Byte --size 1000,1000 -l footprints footprints.shp mask.tif
+
+.. example::
+    :title: Burn a shapefile into a raster using a specific where condition to select features, and restrict the extent to the one of selected features
+
+    .. code-block:: bash
+
+        gdal pipeline read /vsizip/vsicurl/https://www2.census.gov/geo/tiger/TIGER2025/STATE/tl_2025_us_state.zip ! \
+                        filter --where  "stusps = 'CA'" --update-extent ! \
+                        rasterize  --burn 1 --size 1500,1500 --datatype Byte ! \
+                        write out.png --overwrite


### PR DESCRIPTION
```
.. option:: --update-extent

    .. versionadded:: 3.13

    Update layer extent to take into account the filter(s). Otherwise the layer
    extent will generally be the one of the source layer before applying the
    filter(s). Note that using this option requires doing a full scan of the
```

Fixes #13519
