### PR TITLE
HDF5: do not report GCPs on swath geolocation fields

### DIFF
--- a/autotest/gdrivers/hdf5.py
+++ b/autotest/gdrivers/hdf5.py
@@ -1274,6 +1274,12 @@ END
     assert gdal.Open(ds.GetMetadataItem("Y_DATASET", "GEOLOCATION")) is not None
     ds = None
 
+    ds = gdal.Open(
+        'HDF5:"data/hdf5/dummy_HDFEOS_swath.h5"://HDFEOS/SWATHS/MySwath/Geolocation_Fields/Longitude'
+    )
+    assert len(ds.GetGCPs()) == 0
+    assert ds.GetMetadata("GEOLOCATION") is not None
+
 
 ###############################################################################
 # Test opening a HDF5EOS swath file with a .aux.xml

--- a/frmts/hdf5/hdf5dataset.cpp
+++ b/frmts/hdf5/hdf5dataset.cpp
@@ -1460,7 +1460,7 @@ CPLErr HDF5Dataset::HDF5ListGroupObjects(HDF5GroupObjects *poRootGroup,
         }
 
         HDF5EOSParser::GridMetadata oGridMetadata;
-        HDF5EOSParser::SwathDataFieldMetadata oSwathDataFieldMetadata;
+        HDF5EOSParser::SwathFieldMetadata oSwathFieldMetadata;
         if (m_oHDFEOSParser.GetDataModel() == HDF5EOSParser::DataModel::GRID &&
             m_oHDFEOSParser.GetGridMetadata(poRootGroup->pszUnderscorePath,
                                             oGridMetadata) &&
@@ -1506,29 +1506,24 @@ CPLErr HDF5Dataset::HDF5ListGroupObjects(HDF5GroupObjects *poRootGroup,
         }
         else if (m_oHDFEOSParser.GetDataModel() ==
                      HDF5EOSParser::DataModel::SWATH &&
-                 m_oHDFEOSParser.GetSwathDataFieldMetadata(
-                     poRootGroup->pszUnderscorePath, oSwathDataFieldMetadata) &&
-                 static_cast<int>(
-                     oSwathDataFieldMetadata.aoDimensions.size()) ==
+                 m_oHDFEOSParser.GetSwathFieldMetadata(
+                     poRootGroup->pszUnderscorePath, oSwathFieldMetadata) &&
+                 static_cast<int>(oSwathFieldMetadata.aoDimensions.size()) ==
                      poRootGroup->nRank &&
-                 oSwathDataFieldMetadata.iXDim >= 0 &&
-                 oSwathDataFieldMetadata.iYDim >= 0)
+                 oSwathFieldMetadata.iXDim >= 0 &&
+                 oSwathFieldMetadata.iYDim >= 0)
         {
             const std::string &osXDimName =
-                oSwathDataFieldMetadata
-                    .aoDimensions[oSwathDataFieldMetadata.iXDim]
+                oSwathFieldMetadata.aoDimensions[oSwathFieldMetadata.iXDim]
                     .osName;
             const int nXDimSize =
-                oSwathDataFieldMetadata
-                    .aoDimensions[oSwathDataFieldMetadata.iXDim]
+                oSwathFieldMetadata.aoDimensions[oSwathFieldMetadata.iXDim]
                     .nSize;
             const std::string &osYDimName =
-                oSwathDataFieldMetadata
-                    .aoDimensions[oSwathDataFieldMetadata.iYDim]
+                oSwathFieldMetadata.aoDimensions[oSwathFieldMetadata.iYDim]
                     .osName;
             const int nYDimSize =
-                oSwathDataFieldMetadata
-                    .aoDimensions[oSwathDataFieldMetadata.iYDim]
+                oSwathFieldMetadata.aoDimensions[oSwathFieldMetadata.iYDim]
                     .nSize;
             switch (poRootGroup->nRank)
             {
@@ -1539,14 +1534,14 @@ CPLErr HDF5Dataset::HDF5ListGroupObjects(HDF5GroupObjects *poRootGroup,
                 case 3:
                 {
                     const std::string &osOtherDimName =
-                        oSwathDataFieldMetadata
-                            .aoDimensions[oSwathDataFieldMetadata.iOtherDim]
+                        oSwathFieldMetadata
+                            .aoDimensions[oSwathFieldMetadata.iOtherDim]
                             .osName;
                     const int nOtherDimSize =
-                        oSwathDataFieldMetadata
-                            .aoDimensions[oSwathDataFieldMetadata.iOtherDim]
+                        oSwathFieldMetadata
+                            .aoDimensions[oSwathFieldMetadata.iOtherDim]
                             .nSize;
-                    if (oSwathDataFieldMetadata.iOtherDim == 0)
+                    if (oSwathFieldMetadata.iOtherDim == 0)
                     {
                         osStr.Printf("(%s=%d)x(%s=%d)x(%s=%d)",
                                      osOtherDimName.c_str(), nOtherDimSize,

--- a/frmts/hdf5/hdf5eosparser.cpp
+++ b/frmts/hdf5/hdf5eosparser.cpp
@@ -434,6 +434,8 @@ void HDF5EOSParser::ParseSwathStructure(const CPLJSONObject &oSwathStructure)
             const auto oGeoFields = oSwath.GetObj("GeoField");
             std::vector<Dimension> aoLongitudeDimensions;
             std::vector<Dimension> aoLatitudeDimensions;
+
+            // First pass to create dimensions
             for (const auto &oGeoField : oGeoFields.GetChildren())
             {
                 if (oGeoField.GetType() == CPLJSONObject::Type::Object)
@@ -473,20 +475,110 @@ void HDF5EOSParser::ParseSwathStructure(const CPLJSONObject &oSwathStructure)
                     }
                     if (bValid)
                     {
-                        SwathGeolocationFieldMetadata oMetadata;
-                        oMetadata.poSwathMetadata = poSwathMetadataRef;
-
                         if (osGeoFieldName == "Longitude")
                             aoLongitudeDimensions = aoDimensions;
                         else if (osGeoFieldName == "Latitude")
                             aoLatitudeDimensions = aoDimensions;
+                    }
+                }
+            }
 
-                        oMetadata.aoDimensions = std::move(aoDimensions);
+            // Second pass to register field
+            for (const auto &oGeoField : oGeoFields.GetChildren())
+            {
+                if (oGeoField.GetType() == CPLJSONObject::Type::Object)
+                {
+                    const auto osGeoFieldName =
+                        oGeoField.GetString("GeoFieldName");
+                    const auto oDimList = oGeoField.GetArray("DimList");
+                    bool bValid = true;
+                    SwathFieldMetadata oMetadata;
+                    oMetadata.poSwathMetadata = poSwathMetadataRef;
+                    for (int j = 0; j < oDimList.Size(); ++j)
+                    {
+                        const auto osDimensionName = oDimList[j].ToString();
+                        const auto oIter = oMapDimensionNameToSize.find(
+                            osDimensionName.c_str());
+                        if (oIter == oMapDimensionNameToSize.end())
+                        {
+                            bValid = false;
+                            break;
+                        }
+                        Dimension oDim;
+                        oDim.osName = std::move(osDimensionName);
+                        oDim.nSize = oIter->second;
+                        oMetadata.aoDimensions.push_back(std::move(oDim));
+                    }
+                    if (bValid)
+                    {
+                        if (oMetadata.aoDimensions.size() >= 2 &&
+                            aoLongitudeDimensions.size() == 2 &&
+                            aoLongitudeDimensions == aoLatitudeDimensions)
+                        {
+                            int i = 0;
+                            std::string osDataXDimName;
+                            std::string osDataYDimName;
+                            for (const auto &oDimSwath : oMetadata.aoDimensions)
+                            {
+                                auto oIter =
+                                    oMapDataDimensionToGeoDimension.find(
+                                        oDimSwath.osName);
+                                if (oIter !=
+                                    oMapDataDimensionToGeoDimension.end())
+                                {
+                                    const auto &osGeoDimName = oIter->second;
+                                    if (osGeoDimName ==
+                                        aoLongitudeDimensions[0].osName)
+                                    {
+                                        osDataYDimName = oDimSwath.osName;
+                                        oMetadata.iYDim = i;
+                                    }
+                                    else if (osGeoDimName ==
+                                             aoLongitudeDimensions[1].osName)
+                                    {
+                                        osDataXDimName = oDimSwath.osName;
+                                        oMetadata.iXDim = i;
+                                    }
+                                }
+                                else
+                                {
+                                    oMetadata.iOtherDim = i;
+                                }
+                                ++i;
+                            }
+                            if (oMetadata.iXDim >= 0 && oMetadata.iYDim >= 0)
+                            {
+                                oMetadata.osLongitudeSubdataset =
+                                    "//HDFEOS/SWATHS/" + osSwathName +
+                                    "/Geolocation_Fields/Longitude";
+                                oMetadata.osLatitudeSubdataset =
+                                    "//HDFEOS/SWATHS/" + osSwathName +
+                                    "/Geolocation_Fields/Latitude";
+
+                                for (const auto &oDimMap : aoDimensionMaps)
+                                {
+                                    if (oDimMap.osDataDimName == osDataYDimName)
+                                    {
+                                        oMetadata.nLineOffset = oDimMap.nOffset;
+                                        oMetadata.nLineStep =
+                                            oDimMap.nIncrement;
+                                    }
+                                    else if (oDimMap.osDataDimName ==
+                                             osDataXDimName)
+                                    {
+                                        oMetadata.nPixelOffset =
+                                            oDimMap.nOffset;
+                                        oMetadata.nPixelStep =
+                                            oDimMap.nIncrement;
+                                    }
+                                }
+                            }
+                        }
 
                         const std::string osSubdatasetName =
                             "//HDFEOS/SWATHS/" + osSwathName +
                             "/Geolocation_Fields/" + osGeoFieldName;
-                        m_oMapSubdatasetNameToSwathGeolocationFieldMetadata
+                        m_oMapSubdatasetNameToSwathFieldMetadata
                             [osSubdatasetName] = std::move(oMetadata);
                     }
                 }
@@ -500,7 +592,7 @@ void HDF5EOSParser::ParseSwathStructure(const CPLJSONObject &oSwathStructure)
                     const auto osDataFieldName =
                         oDataField.GetString("DataFieldName");
                     const auto oDimList = oDataField.GetArray("DimList");
-                    SwathDataFieldMetadata oMetadata;
+                    SwathFieldMetadata oMetadata;
                     oMetadata.poSwathMetadata = poSwathMetadataRef;
                     bool bValid = oDimList.Size() > 0;
                     for (int j = 0; j < oDimList.Size(); ++j)
@@ -584,7 +676,7 @@ void HDF5EOSParser::ParseSwathStructure(const CPLJSONObject &oSwathStructure)
                             }
                         }
 
-                        m_oMapSubdatasetNameToSwathDataFieldMetadata
+                        m_oMapSubdatasetNameToSwathFieldMetadata
                             ["//HDFEOS/SWATHS/" + osSwathName +
                              "/Data_Fields/" + osDataFieldName] =
                                 std::move(oMetadata);
@@ -610,34 +702,18 @@ bool HDF5EOSParser::GetSwathMetadata(const std::string &osSwathName,
 }
 
 /************************************************************************/
-/*                      GetSwathDataFieldMetadata()                     */
+/*                        GetSwathFieldMetadata()                       */
 /************************************************************************/
 
-bool HDF5EOSParser::GetSwathDataFieldMetadata(
+bool HDF5EOSParser::GetSwathFieldMetadata(
     const char *pszSubdatasetName,
-    SwathDataFieldMetadata &swathDataFieldMetadataOut) const
+    SwathFieldMetadata &swathFieldMetadataOut) const
 {
     const auto oIter =
-        m_oMapSubdatasetNameToSwathDataFieldMetadata.find(pszSubdatasetName);
-    if (oIter == m_oMapSubdatasetNameToSwathDataFieldMetadata.end())
+        m_oMapSubdatasetNameToSwathFieldMetadata.find(pszSubdatasetName);
+    if (oIter == m_oMapSubdatasetNameToSwathFieldMetadata.end())
         return false;
-    swathDataFieldMetadataOut = oIter->second;
-    return true;
-}
-
-/************************************************************************/
-/*                    GetSwathGeolocationFieldMetadata()                */
-/************************************************************************/
-
-bool HDF5EOSParser::GetSwathGeolocationFieldMetadata(
-    const char *pszSubdatasetName,
-    SwathGeolocationFieldMetadata &swathGeolocationFieldMetadataOut) const
-{
-    const auto oIter = m_oMapSubdatasetNameToSwathGeolocationFieldMetadata.find(
-        pszSubdatasetName);
-    if (oIter == m_oMapSubdatasetNameToSwathGeolocationFieldMetadata.end())
-        return false;
-    swathGeolocationFieldMetadataOut = oIter->second;
+    swathFieldMetadataOut = oIter->second;
     return true;
 }
 

--- a/frmts/hdf5/hdf5eosparser.h
+++ b/frmts/hdf5/hdf5eosparser.h
@@ -82,16 +82,10 @@ class HDF5EOSParser
         std::vector<Dimension> aoDimensions{};  // all dimensions of the swath
     };
 
-    struct SwathGeolocationFieldMetadata
+    struct SwathFieldMetadata
     {
         std::vector<Dimension>
-            aoDimensions{};  // dimensions of the geolocation field
-        const SwathMetadata *poSwathMetadata = nullptr;
-    };
-
-    struct SwathDataFieldMetadata
-    {
-        std::vector<Dimension> aoDimensions{};  // dimensions of the data field
+            aoDimensions{};  // dimensions of the geolocation/data field
         const SwathMetadata *poSwathMetadata = nullptr;
 
         int iXDim = -1;
@@ -121,12 +115,8 @@ class HDF5EOSParser
         GridDataFieldMetadata &gridDataFieldMetadataOut) const;
     bool GetSwathMetadata(const std::string &osSwathName,
                           SwathMetadata &swathMetadataOut) const;
-    bool GetSwathDataFieldMetadata(
-        const char *pszSubdatasetName,
-        SwathDataFieldMetadata &swathDataFieldMetadataOut) const;
-    bool GetSwathGeolocationFieldMetadata(
-        const char *pszSubdatasetName,
-        SwathGeolocationFieldMetadata &swathGeolocationFieldMetadataOut) const;
+    bool GetSwathFieldMetadata(const char *pszSubdatasetName,
+                               SwathFieldMetadata &swathFieldMetadataOut) const;
 
   private:
     DataModel m_eDataModel = DataModel::INVALID;
@@ -136,10 +126,8 @@ class HDF5EOSParser
         m_oMapSubdatasetNameToGridDataFieldMetadata{};
     std::map<std::string, std::unique_ptr<SwathMetadata>>
         m_oMapSwathNameToSwathMetadata{};
-    std::map<std::string, SwathDataFieldMetadata>
-        m_oMapSubdatasetNameToSwathDataFieldMetadata{};
-    std::map<std::string, SwathGeolocationFieldMetadata>
-        m_oMapSubdatasetNameToSwathGeolocationFieldMetadata{};
+    std::map<std::string, SwathFieldMetadata>
+        m_oMapSubdatasetNameToSwathFieldMetadata{};
 
     void ParseGridStructure(const CPLJSONObject &oGridStructure);
     void ParseSwathStructure(const CPLJSONObject &oSwathStructure);

--- a/frmts/hdf5/hdf5imagedataset.cpp
+++ b/frmts/hdf5/hdf5imagedataset.cpp
@@ -1114,7 +1114,7 @@ GDALDataset *HDF5ImageDataset::Open(GDALOpenInfo *poOpenInfo)
         {
             CPLDebug("HDF5", "Successfully parsed HDFEOS metadata");
             HDF5EOSParser::GridDataFieldMetadata oGridDataFieldMetadata;
-            HDF5EOSParser::SwathDataFieldMetadata oSwathDataFieldMetadata;
+            HDF5EOSParser::SwathFieldMetadata oSwathFieldMetadata;
             if (oHDFEOSParser.GetDataModel() ==
                     HDF5EOSParser::DataModel::GRID &&
                 oHDFEOSParser.GetGridDataFieldMetadata(
@@ -1144,47 +1144,45 @@ GDALDataset *HDF5ImageDataset::Open(GDALOpenInfo *poOpenInfo)
             }
             else if (oHDFEOSParser.GetDataModel() ==
                          HDF5EOSParser::DataModel::SWATH &&
-                     oHDFEOSParser.GetSwathDataFieldMetadata(
-                         osSubdatasetName.c_str(), oSwathDataFieldMetadata) &&
+                     oHDFEOSParser.GetSwathFieldMetadata(
+                         osSubdatasetName.c_str(), oSwathFieldMetadata) &&
                      static_cast<int>(
-                         oSwathDataFieldMetadata.aoDimensions.size()) ==
+                         oSwathFieldMetadata.aoDimensions.size()) ==
                          poDS->ndims &&
-                     oSwathDataFieldMetadata.iXDim >= 0 &&
-                     oSwathDataFieldMetadata.iYDim >= 0)
+                     oSwathFieldMetadata.iXDim >= 0 &&
+                     oSwathFieldMetadata.iYDim >= 0)
             {
-                poDS->m_nXIndex = oSwathDataFieldMetadata.iXDim;
-                poDS->m_nYIndex = oSwathDataFieldMetadata.iYDim;
-                poDS->m_nOtherDimIndex = oSwathDataFieldMetadata.iOtherDim;
-                if (!oSwathDataFieldMetadata.osLongitudeSubdataset.empty())
+                poDS->m_nXIndex = oSwathFieldMetadata.iXDim;
+                poDS->m_nYIndex = oSwathFieldMetadata.iYDim;
+                poDS->m_nOtherDimIndex = oSwathFieldMetadata.iOtherDim;
+                if (!oSwathFieldMetadata.osLongitudeSubdataset.empty())
                 {
                     CPLStringList aosGeolocation;
 
                     // Arbitrary
                     aosGeolocation.AddNameValue("SRS", SRS_WKT_WGS84_LAT_LONG);
                     aosGeolocation.AddNameValue(
-                        "X_DATASET",
-                        ("HDF5:\"" + osFilename +
-                         "\":" + oSwathDataFieldMetadata.osLongitudeSubdataset)
-                            .c_str());
+                        "X_DATASET", ("HDF5:\"" + osFilename + "\":" +
+                                      oSwathFieldMetadata.osLongitudeSubdataset)
+                                         .c_str());
                     aosGeolocation.AddNameValue("X_BAND", "1");
                     aosGeolocation.AddNameValue(
-                        "Y_DATASET",
-                        ("HDF5:\"" + osFilename +
-                         "\":" + oSwathDataFieldMetadata.osLatitudeSubdataset)
-                            .c_str());
+                        "Y_DATASET", ("HDF5:\"" + osFilename + "\":" +
+                                      oSwathFieldMetadata.osLatitudeSubdataset)
+                                         .c_str());
                     aosGeolocation.AddNameValue("Y_BAND", "1");
                     aosGeolocation.AddNameValue(
                         "PIXEL_OFFSET",
-                        CPLSPrintf("%d", oSwathDataFieldMetadata.nPixelOffset));
+                        CPLSPrintf("%d", oSwathFieldMetadata.nPixelOffset));
                     aosGeolocation.AddNameValue(
                         "PIXEL_STEP",
-                        CPLSPrintf("%d", oSwathDataFieldMetadata.nPixelStep));
+                        CPLSPrintf("%d", oSwathFieldMetadata.nPixelStep));
                     aosGeolocation.AddNameValue(
                         "LINE_OFFSET",
-                        CPLSPrintf("%d", oSwathDataFieldMetadata.nLineOffset));
+                        CPLSPrintf("%d", oSwathFieldMetadata.nLineOffset));
                     aosGeolocation.AddNameValue(
                         "LINE_STEP",
-                        CPLSPrintf("%d", oSwathDataFieldMetadata.nLineStep));
+                        CPLSPrintf("%d", oSwathFieldMetadata.nLineStep));
                     // Not totally sure about that
                     aosGeolocation.AddNameValue("GEOREFERENCING_CONVENTION",
                                                 "PIXEL_CENTER");


### PR DESCRIPTION
but report geolocation array instead.

Reporting GCPs involves reading the longitude and latitute arrays, which has a performance implication, especially when reading from cloud storage.
