### PR TITLE
[Backport release/3.12] GDALFPolygonize(): make it handle 64-bit float rasters on their native precision, and not Float32

### DIFF
--- a/alg/gdal_alg_priv.h
+++ b/alg/gdal_alg_priv.h
@@ -377,13 +377,25 @@ int GDALDitherRGB2PCTInternal(GDALRasterBandH hRed, GDALRasterBandH hGreen,
  */
 #define MAX_ULPS 10
 
-GBool GDALFloatEquals(float A, float B);
+bool CPL_DLL GDALFloatAlmostEquals(float A, float B,
+                                   unsigned maxUlps = MAX_ULPS);
 
 struct FloatEqualityTest
 {
     bool operator()(float a, float b)
     {
-        return GDALFloatEquals(a, b) == TRUE;
+        return GDALFloatAlmostEquals(a, b);
+    }
+};
+
+bool CPL_DLL GDALDoubleAlmostEquals(double A, double B,
+                                    unsigned maxUlps = MAX_ULPS);
+
+struct DoubleEqualityTest
+{
+    bool operator()(double a, double b)
+    {
+        return GDALDoubleAlmostEquals(a, b);
     }
 };
 

--- a/alg/gdalrasterpolygonenumerator.cpp
+++ b/alg/gdalrasterpolygonenumerator.cpp
@@ -320,4 +320,6 @@ template class GDALRasterPolygonEnumeratorT<std::int64_t, IntEqualityTest>;
 
 template class GDALRasterPolygonEnumeratorT<float, FloatEqualityTest>;
 
+template class GDALRasterPolygonEnumeratorT<double, DoubleEqualityTest>;
+
 /*! @endcond */

--- a/alg/polygonize_polygonizer_impl.cpp
+++ b/alg/polygonize_polygonizer_impl.cpp
@@ -9,9 +9,13 @@ template class Polygonizer<GInt32, std::int64_t>;
 
 template class Polygonizer<GInt32, float>;
 
+template class Polygonizer<GInt32, double>;
+
 template class OGRPolygonWriter<std::int64_t>;
 
 template class OGRPolygonWriter<float>;
+
+template class OGRPolygonWriter<double>;
 
 }  // namespace polygonizer
 }  // namespace gdal

--- a/autotest/alg/polygonize.py
+++ b/autotest/alg/polygonize.py
@@ -427,3 +427,24 @@ def test_polygonize_8():
         wkt
         == "POLYGON ((1 4,1 3,0 3,0 1,1 1,1 0,3 0,3 1,4 1,4 3,3 3,3 4,1 4),(1 3,3 3,3 1,1 1,1 3))"
     )
+
+
+###############################################################################
+# Test 64-bit float raster
+
+
+def test_polygonize_64bit_float():
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 3, 3, 1, gdal.GDT_Float64)
+    src_ds.WriteRaster(1, 1, 1, 1, struct.pack("d", 1.234567890123))
+
+    mem_layer = src_ds.CreateLayer("res", None, ogr.wkbPolygon)
+    fd = ogr.FieldDefn("DN", ogr.OFTReal)
+    mem_layer.CreateField(fd)
+
+    # run the algorithm.
+    result = gdal.FPolygonize(src_ds.GetRasterBand(1), None, mem_layer, 0, [])
+    assert result == 0, "Polygonize failed"
+
+    feature = mem_layer.GetNextFeature()
+    assert feature.GetField("DN") == 1.234567890123

--- a/autotest/cpp/test_alg.cpp
+++ b/autotest/cpp/test_alg.cpp
@@ -11,12 +11,15 @@
  ****************************************************************************/
 
 #include <array>
+#include <cmath>
+#include <limits>
 
 #include "gdal_unit_test.h"
 
 #include "cpl_conv.h"
 
 #include "gdal_alg.h"
+#include "gdal_alg_priv.h"
 #include "gdalwarper.h"
 #include "gdal_priv.h"
 
@@ -504,6 +507,48 @@ TEST_F(test_alg, GDALIsLineOfSightVisible_through_mountain)
                                          nullptr, nullptr, nullptr));
     EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, 89, 115, 460, 75, 115, 460,
                                          nullptr, nullptr, nullptr));
+}
+
+TEST_F(test_alg, GDALFloatAlmostEquals)
+{
+    float f = 1.23f;
+    EXPECT_TRUE(GDALFloatAlmostEquals(f, f));
+    EXPECT_TRUE(GDALFloatAlmostEquals(-f, -f));
+    EXPECT_FALSE(GDALFloatAlmostEquals(f, -f));
+    EXPECT_FALSE(GDALFloatAlmostEquals(f, 0.0f));
+    float f2 = std::nextafter(f, std::numeric_limits<float>::max());
+    EXPECT_TRUE(GDALFloatAlmostEquals(f, f2, 1));
+    EXPECT_TRUE(GDALFloatAlmostEquals(f2, f, 1));
+    EXPECT_TRUE(GDALFloatAlmostEquals(-f, -f2, 1));
+    EXPECT_TRUE(GDALFloatAlmostEquals(-f2, -f, 1));
+    float f3 = std::nextafter(f2, std::numeric_limits<float>::max());
+    EXPECT_FALSE(GDALFloatAlmostEquals(f, f3, 1));
+    EXPECT_FALSE(GDALFloatAlmostEquals(f3, f, 1));
+
+    EXPECT_TRUE(GDALFloatAlmostEquals(
+        std::nextafter(0.0f, std::numeric_limits<float>::max()),
+        std::nextafter(0.0f, -std::numeric_limits<float>::max())));
+}
+
+TEST_F(test_alg, GDALDoubleAlmostEquals)
+{
+    double f = 1.23;
+    EXPECT_TRUE(GDALDoubleAlmostEquals(f, f));
+    EXPECT_TRUE(GDALDoubleAlmostEquals(-f, -f));
+    EXPECT_FALSE(GDALDoubleAlmostEquals(f, -f));
+    EXPECT_FALSE(GDALDoubleAlmostEquals(f, 0));
+    double f2 = std::nextafter(f, std::numeric_limits<double>::max());
+    EXPECT_TRUE(GDALDoubleAlmostEquals(f, f2, 1));
+    EXPECT_TRUE(GDALDoubleAlmostEquals(f2, f, 1));
+    EXPECT_TRUE(GDALDoubleAlmostEquals(-f, -f2, 1));
+    EXPECT_TRUE(GDALDoubleAlmostEquals(-f2, -f, 1));
+    double f3 = std::nextafter(f2, std::numeric_limits<double>::max());
+    EXPECT_FALSE(GDALDoubleAlmostEquals(f, f3, 1));
+    EXPECT_FALSE(GDALDoubleAlmostEquals(f3, f, 1));
+
+    EXPECT_TRUE(GDALDoubleAlmostEquals(
+        std::nextafter(0, std::numeric_limits<double>::max()),
+        std::nextafter(0, -std::numeric_limits<double>::max())));
 }
 
 }  // namespace


### PR DESCRIPTION
Backport #13548
 **Authored by:** @rouault