### PR TITLE
gdal raster create: enable use in pipelines

### DIFF
--- a/apps/gdalalg_abstract_pipeline.h
+++ b/apps/gdalalg_abstract_pipeline.h
@@ -139,6 +139,7 @@ class GDALPipelineStepAlgorithm /* non final */ : public GDALAlgorithm
         bool standaloneStep = false;
         bool addDefaultArguments = true;
         bool autoOpenInputDatasets = true;
+        bool inputDatasetRequired = true;
         bool outputDatasetRequired = true;
         bool addInputLayerNameArgument = true;   // only for vector input
         bool addUpdateArgument = true;           // only for vector output
@@ -169,6 +170,12 @@ class GDALPipelineStepAlgorithm /* non final */ : public GDALAlgorithm
         inline ConstructorOptions &SetAddInputLayerNameArgument(bool b)
         {
             addInputLayerNameArgument = b;
+            return *this;
+        }
+
+        inline ConstructorOptions &SetInputDatasetRequired(bool b)
+        {
+            inputDatasetRequired = b;
             return *this;
         }
 

--- a/apps/gdalalg_pipeline.cpp
+++ b/apps/gdalalg_pipeline.cpp
@@ -88,12 +88,12 @@ void GDALPipelineStepAlgorithm::AddRasterInputArgs(
         .SetHiddenForCLI(hiddenForCLI);
     AddOpenOptionsArg(&m_openOptions).SetHiddenForCLI(hiddenForCLI);
     auto &arg =
-        AddInputDatasetArg(&m_inputDataset,
-                           openForMixedRasterVector
-                               ? (GDAL_OF_RASTER | GDAL_OF_VECTOR)
-                               : GDAL_OF_RASTER,
-                           /* positionalAndRequired = */ !hiddenForCLI,
-                           m_constructorOptions.inputDatasetHelpMsg.c_str())
+        AddInputDatasetArg(
+            &m_inputDataset,
+            openForMixedRasterVector ? (GDAL_OF_RASTER | GDAL_OF_VECTOR)
+                                     : GDAL_OF_RASTER,
+            m_constructorOptions.inputDatasetRequired && !hiddenForCLI,
+            m_constructorOptions.inputDatasetHelpMsg.c_str())
             .SetMinCount(1)
             .SetMaxCount(m_constructorOptions.inputDatasetMaxCount)
             .SetAutoOpenDataset(m_constructorOptions.autoOpenInputDatasets)
@@ -585,6 +585,7 @@ GDALPipelineAlgorithm::GDALPipelineAlgorithm()
 
     GDALRasterPipelineAlgorithm::RegisterAlgorithms(m_stepRegistry, true);
     GDALVectorPipelineAlgorithm::RegisterAlgorithms(m_stepRegistry, true);
+    m_stepRegistry.Register<GDALRasterAsFeaturesAlgorithm>();
     m_stepRegistry.Register<GDALRasterContourAlgorithm>();
     m_stepRegistry.Register<GDALRasterFootprintAlgorithm>();
     m_stepRegistry.Register<GDALRasterPolygonizeAlgorithm>();
@@ -632,7 +633,7 @@ GDALPipelineAlgorithm::GetUsageForCLI(bool shortUsage,
         return ret;
 
     ret +=
-        "\n<PIPELINE> is of the form: read|calc|concat|mosaic|stack "
+        "\n<PIPELINE> is of the form: read|calc|concat|create|mosaic|stack "
         "[READ-OPTIONS] "
         "( ! <STEP-NAME> [STEP-OPTIONS] )* ! write!info!tile [WRITE-OPTIONS]\n";
 

--- a/apps/gdalalg_raster.cpp
+++ b/apps/gdalalg_raster.cpp
@@ -91,7 +91,7 @@ class GDALRasterAlgorithm final : public GDALAlgorithm
         RegisterSubAlgorithm<GDALRasterColorMapAlgorithmStandalone>();
         RegisterSubAlgorithm<GDALRasterCompareAlgorithmStandalone>();
         RegisterSubAlgorithm<GDALRasterConvertAlgorithm>();
-        RegisterSubAlgorithm<GDALRasterCreateAlgorithm>();
+        RegisterSubAlgorithm<GDALRasterCreateAlgorithmStandalone>();
         RegisterSubAlgorithm<GDALRasterEditAlgorithmStandalone>();
         RegisterSubAlgorithm<GDALRasterFootprintAlgorithmStandalone>();
         RegisterSubAlgorithm<GDALRasterHillshadeAlgorithmStandalone>();

--- a/apps/gdalalg_raster_create.h
+++ b/apps/gdalalg_raster_create.h
@@ -13,7 +13,7 @@
 #ifndef GDALALG_RASTER_CREATE_INCLUDED
 #define GDALALG_RASTER_CREATE_INCLUDED
 
-#include "gdalalgorithm.h"
+#include "gdalalg_raster_pipeline.h"
 
 //! @cond Doxygen_Suppress
 
@@ -21,26 +21,29 @@
 /*                     GDALRasterCreateAlgorithm                        */
 /************************************************************************/
 
-class GDALRasterCreateAlgorithm final : public GDALAlgorithm
+class GDALRasterCreateAlgorithm : public GDALRasterPipelineStepAlgorithm
 {
   public:
     static constexpr const char *NAME = "create";
     static constexpr const char *DESCRIPTION = "Create a new raster dataset.";
     static constexpr const char *HELP_URL = "/programs/gdal_raster_create.html";
 
-    GDALRasterCreateAlgorithm();
+    explicit GDALRasterCreateAlgorithm(bool standaloneStep = false) noexcept;
+
+    bool CanBeMiddleStep() const override
+    {
+        return true;
+    }
+
+    bool CanBeFirstStep() const override
+    {
+        return true;
+    }
 
   private:
+    bool RunStep(GDALPipelineStepRunContext &ctxt) override;
     bool RunImpl(GDALProgressFunc pfnProgress, void *pProgressData) override;
 
-    std::string m_outputFormat{};
-    GDALArgDatasetValue m_inputDataset{};
-    std::vector<std::string> m_openOptions{};
-    std::vector<std::string> m_inputFormats{};
-    GDALArgDatasetValue m_outputDataset{};
-    std::vector<std::string> m_creationOptions{};
-    bool m_overwrite = false;
-    bool m_append = false;
     std::vector<int> m_size{};
     int m_bandCount = 1;
     std::string m_type = "Byte";
@@ -51,6 +54,22 @@ class GDALRasterCreateAlgorithm final : public GDALAlgorithm
     std::vector<double> m_burnValues{};
     bool m_copyOverviews = false;
     bool m_copyMetadata = false;
+};
+
+/************************************************************************/
+/*                  GDALRasterCreateAlgorithmStandalone                 */
+/************************************************************************/
+
+class GDALRasterCreateAlgorithmStandalone final
+    : public GDALRasterCreateAlgorithm
+{
+  public:
+    GDALRasterCreateAlgorithmStandalone()
+        : GDALRasterCreateAlgorithm(/* standaloneStep = */ true)
+    {
+    }
+
+    ~GDALRasterCreateAlgorithmStandalone() override;
 };
 
 //! @endcond

--- a/apps/gdalalg_raster_pipeline.cpp
+++ b/apps/gdalalg_raster_pipeline.cpp
@@ -19,6 +19,7 @@
 #include "gdalalg_raster_clip.h"
 #include "gdalalg_raster_color_map.h"
 #include "gdalalg_raster_compare.h"
+#include "gdalalg_raster_create.h"
 #include "gdalalg_raster_edit.h"
 #include "gdalalg_raster_fill_nodata.h"
 #include "gdalalg_raster_hillshade.h"
@@ -170,6 +171,7 @@ void GDALRasterPipelineAlgorithm::RegisterAlgorithms(
         addSuffixIfNeeded(GDALRasterReadAlgorithm::NAME));
 
     registry.Register<GDALRasterCalcAlgorithm>();
+    registry.Register<GDALRasterCreateAlgorithm>();
 
     registry.Register<GDALRasterNeighborsAlgorithm>();
 

--- a/autotest/utilities/test_gdalalg_raster_create.py
+++ b/autotest/utilities/test_gdalalg_raster_create.py
@@ -524,3 +524,26 @@ def test_gdalalg_raster_create_empty_bbox():
         match="0 value has been specified for argument 'bbox', whereas exactly 4 were expected",
     ):
         alg.Run()
+
+
+def test_gdalalg_raster_create_pipeline_first_step():
+
+    with gdal.Run(
+        "raster pipeline",
+        output_format="MEM",
+        pipeline="create --bbox -10,-10,10,10 --size 2,2 ! write",
+    ) as alg:
+        assert alg.Output().GetGeoTransform() == (-10, 10, 0, 10, 0, -10)
+
+
+def test_gdalalg_raster_create_pipeline_middle_step():
+
+    with gdal.Run(
+        "raster pipeline",
+        output_format="MEM",
+        pipeline="read ../gcore/data/byte.tif ! create --burn 7 ! write",
+    ) as alg:
+        ds = alg.Output()
+        assert ds.RasterXSize == 20
+        assert ds.RasterYSize == 20
+        assert ds.GetRasterBand(1).ComputeRasterMinMax() == (7, 7)

--- a/autotest/utilities/test_gdalalg_raster_pipeline.py
+++ b/autotest/utilities/test_gdalalg_raster_pipeline.py
@@ -304,7 +304,7 @@ def test_gdalalg_raster_pipeline_write_write():
     pipeline = get_pipeline_alg()
     with pytest.raises(
         Exception,
-        match="pipeline: First step should be 'read', 'calc', 'mosaic' or 'stack'",
+        match="pipeline: First step should be 'read'",
     ):
         pipeline.ParseRunAndFinalize(
             ["write", "/vsimem/out.tif", "!", "write", "/vsimem/out.tif"]

--- a/doc/source/programs/gdal_raster_as_features.rst
+++ b/doc/source/programs/gdal_raster_as_features.rst
@@ -67,3 +67,13 @@ Examples
                 reclassify -m "[-inf, 150)=1; DEFAULT=NO_DATA" !
                 as-features --geometry-type point --skip-nodata ! 
                 write out.shp
+
+
+.. example::
+   :title: Create a polygon grid dividing the globe into 1-degree chunks
+   
+   .. code-block:: bash
+
+       gdal pipeline create --bbox -180,-90,180,90 --size 360,180 ! 
+                as-features --geometry-type polygon !
+                write grid.shp

--- a/doc/source/programs/gdal_raster_create.rst
+++ b/doc/source/programs/gdal_raster_create.rst
@@ -38,6 +38,8 @@ can be useful to create a file of minimum size.`
 :program:`gdal raster create` can be used also in special cases, like creating
 a PDF file from a XML composition file.
 
+Since GDAL 3.13, ``create`` can also be used as a step of :ref:`gdal_raster_pipeline`.
+
 Options
 +++++++
 

--- a/doc/source/programs/gdal_raster_pipeline.rst
+++ b/doc/source/programs/gdal_raster_pipeline.rst
@@ -32,7 +32,7 @@ Synopsis
 .. program-output:: gdal raster pipeline --help-doc=main
 
 A pipeline chains several steps, separated with the `!` (exclamation mark) character.
-The first step must be ``read``, ``calc``, ``mosaic`` or ``stack``,
+The first step must be ``read``, ``calc``, ``create``, ``mosaic`` or ``stack``,
 and the last one ``write``, ``info`` or ``tile``.
 Each step has its own positional or non-positional arguments.
 Apart from ``read``, ``calc``, ``mosaic``, ``stack``, ``compare``, ``info``, ``tile`` and ``write``,
@@ -49,6 +49,12 @@ Potential steps are:
 .. program-output:: gdal raster pipeline --help-doc=calc
 
 Details for options can be found in :ref:`gdal_raster_calc`.
+
+* create
+
+.. program-output:: gdal raster pipeline --help-doc=create
+
+Details for options can be found in :ref:`gdal_raster_create`.
 
 * mosaic
 


### PR DESCRIPTION
Example added to `gdal raster as-features` showing one (the only?) application of this.

```
.. example::
   :title: Create a polygon grid dividing the globe into 1-degree chunks

   .. code-block:: bash
       gdal pipeline create --bbox -180,-90,180,90 --size 360,180 ! 
                as-features --geometry-type polygon !
                write grid.shp
```