### PR TITLE
/vsis3/, /vsigs/, /vsioss/: switch to using ListObjectsV2, since ListObjects is now deprecated

### DIFF
--- a/autotest/gcore/vsigs.py
+++ b/autotest/gcore/vsigs.py
@@ -414,7 +414,9 @@ def test_vsigs_open_after_config_option_change(gs_test_config, webserver_port):
     ):
         handler = webserver.SequentialHandler()
         handler.add(
-            "GET", "/test_vsigs_open_after_config_option_change/?delimiter=%2F", 403
+            "GET",
+            "/test_vsigs_open_after_config_option_change/?delimiter=%2F&list-type=2",
+            403,
         )
         handler.add("GET", "/test_vsigs_open_after_config_option_change/test.bin", 403)
         with webserver.install_http_handler(handler):
@@ -439,7 +441,7 @@ def test_vsigs_open_after_config_option_change(gs_test_config, webserver_port):
         handler = webserver.SequentialHandler()
         handler.add(
             "GET",
-            "/test_vsigs_open_after_config_option_change/?delimiter=%2F",
+            "/test_vsigs_open_after_config_option_change/?delimiter=%2F&list-type=2",
             200,
             {"Content-type": "application/xml"},
             """<?xml version="1.0" encoding="UTF-8"?>
@@ -478,13 +480,13 @@ def test_vsigs_readdir(gs_test_config, webserver_port):
         handler = webserver.SequentialHandler()
         handler.add(
             "GET",
-            "/gs_fake_bucket2/?delimiter=%2F&prefix=a_dir%2F",
+            "/gs_fake_bucket2/?delimiter=%2F&list-type=2&prefix=a_dir%2F",
             200,
             {"Content-type": "application/xml"},
             """<?xml version="1.0" encoding="UTF-8"?>
                         <ListBucketResult>
                             <Prefix>a_dir/</Prefix>
-                            <NextMarker>bla</NextMarker>
+                            <NextContinuationToken>bla</NextContinuationToken>
                             <Contents>
                                 <Key>a_dir/resource3.bin</Key>
                                 <LastModified>1970-01-01T00:00:01.000Z</LastModified>
@@ -495,7 +497,7 @@ def test_vsigs_readdir(gs_test_config, webserver_port):
         )
         handler.add(
             "GET",
-            "/gs_fake_bucket2/?delimiter=%2F&marker=bla&prefix=a_dir%2F",
+            "/gs_fake_bucket2/?continuation-token=bla&delimiter=%2F&list-type=2&prefix=a_dir%2F",
             200,
             {"Content-type": "application/xml"},
             """<?xml version="1.0" encoding="UTF-8"?>
@@ -656,7 +658,9 @@ def test_vsigs_fake_rename(gs_test_config, webserver_port):
         )
         handler.add("GET", "/test/target.txt", 404)
         handler.add(
-            "GET", "/test/?delimiter=%2F&max-keys=100&prefix=target.txt%2F", 200
+            "GET",
+            "/test/?delimiter=%2F&list-type=2&max-keys=100&prefix=target.txt%2F",
+            200,
         )
 
         def method(request):
@@ -1889,7 +1893,7 @@ def test_vsigs_rmdirrecursive_empty_dir(gs_test_config, webserver_port):
     handler = webserver.SequentialHandler()
     handler.add(
         "GET",
-        "/test_vsigs_rmdirrecursive_empty_dir/?prefix=empty_dir%2F",
+        "/test_vsigs_rmdirrecursive_empty_dir/?list-type=2&prefix=empty_dir%2F",
         200,
         {"Content-type": "application/xml"},
         """<?xml version="1.0" encoding="UTF-8"?>

--- a/autotest/gcore/vsioss.py
+++ b/autotest/gcore/vsioss.py
@@ -445,7 +445,7 @@ def test_vsioss_3(server):
         response = """<?xml version="1.0" encoding="UTF-8"?>
             <ListBucketResult>
                 <Prefix>a_dir/</Prefix>
-                <NextMarker>bla</NextMarker>
+                <NextContinuationToken>bla</NextContinuationToken>
                 <Contents>
                     <Key>a_dir/resource3.bin</Key>
                     <LastModified>1970-01-01T00:00:01.000Z</LastModified>
@@ -458,7 +458,9 @@ def test_vsioss_3(server):
         request.wfile.write(response.encode("ascii"))
 
     handler.add(
-        "GET", "/oss_fake_bucket2/?delimiter=%2F&prefix=a_dir%2F", custom_method=method
+        "GET",
+        "/oss_fake_bucket2/?delimiter=%2F&list-type=2&prefix=a_dir%2F",
+        custom_method=method,
     )
 
     def method(request):
@@ -484,7 +486,7 @@ def test_vsioss_3(server):
 
     handler.add(
         "GET",
-        "/oss_fake_bucket2/?delimiter=%2F&marker=bla&prefix=a_dir%2F",
+        "/oss_fake_bucket2/?continuation-token=bla&delimiter=%2F&list-type=2&prefix=a_dir%2F",
         custom_method=method,
     )
 
@@ -564,7 +566,7 @@ def test_vsioss_3(server):
             if config_option_value is None:
                 handler.add(
                     "GET",
-                    "/oss_non_cached/?delimiter=%2F",
+                    "/oss_non_cached/?delimiter=%2F&list-type=2",
                     200,
                     {"Content-type": "application/xml"},
                     """<?xml version="1.0" encoding="UTF-8"?>
@@ -803,7 +805,7 @@ def test_vsioss_5(server):
     )
     handler.add(
         "GET",
-        "/oss_delete_bucket/?delimiter=%2F&max-keys=100&prefix=delete_file%2F",
+        "/oss_delete_bucket/?delimiter=%2F&list-type=2&max-keys=100&prefix=delete_file%2F",
         404,
         {"Connection": "close"},
         "foo",
@@ -1130,7 +1132,7 @@ def test_vsioss_7(server):
     handler.add("GET", "/oss_bucket_test_mkdir/dir/", 404, {"Connection": "close"})
     handler.add(
         "GET",
-        "/oss_bucket_test_mkdir/?delimiter=%2F&max-keys=100&prefix=dir%2F",
+        "/oss_bucket_test_mkdir/?delimiter=%2F&list-type=2&max-keys=100&prefix=dir%2F",
         404,
         {"Connection": "close"},
     )
@@ -1157,7 +1159,7 @@ def test_vsioss_7(server):
     handler.add("GET", "/oss_bucket_test_mkdir/dir/", 404)
     handler.add(
         "GET",
-        "/oss_bucket_test_mkdir/?delimiter=%2F&max-keys=100&prefix=dir%2F",
+        "/oss_bucket_test_mkdir/?delimiter=%2F&list-type=2&max-keys=100&prefix=dir%2F",
         404,
         {"Connection": "close"},
     )
@@ -1170,7 +1172,7 @@ def test_vsioss_7(server):
     handler.add("GET", "/oss_bucket_test_mkdir/dir_nonempty/", 416)
     handler.add(
         "GET",
-        "/oss_bucket_test_mkdir/?delimiter=%2F&max-keys=100&prefix=dir_nonempty%2F",
+        "/oss_bucket_test_mkdir/?delimiter=%2F&list-type=2&max-keys=100&prefix=dir_nonempty%2F",
         200,
         {"Content-type": "application/xml"},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -1198,7 +1200,7 @@ def test_vsioss_8(server):
     handler = webserver.SequentialHandler()
     handler.add(
         "GET",
-        "/vsioss_8/?delimiter=%2F",
+        "/vsioss_8/?delimiter=%2F&list-type=2",
         200,
         {"Content-type": "application/xml"},
         """<?xml version="1.0" encoding="UTF-8"?>

--- a/autotest/gcore/vsis3.py
+++ b/autotest/gcore/vsis3.py
@@ -985,7 +985,9 @@ def test_vsis3_open_after_config_option_change(aws_test_config, webserver_port):
     gdal.VSICurlClearCache()
 
     handler = webserver.SequentialHandler()
-    handler.add("GET", "/test_vsis3_change_config_options/?delimiter=%2F", 403)
+    handler.add(
+        "GET", "/test_vsis3_change_config_options/?delimiter=%2F&list-type=2", 403
+    )
     handler.add("GET", "/test_vsis3_change_config_options/test.bin", 403)
     with webserver.install_http_handler(handler):
         with gdal.quiet_errors():
@@ -1003,7 +1005,7 @@ def test_vsis3_open_after_config_option_change(aws_test_config, webserver_port):
         handler = webserver.SequentialHandler()
         handler.add(
             "GET",
-            "/test_vsis3_change_config_options/?delimiter=%2F",
+            "/test_vsis3_change_config_options/?delimiter=%2F&list-type=2",
             200,
             {"Content-type": "application/xml"},
             """<?xml version="1.0" encoding="UTF-8"?>
@@ -1068,7 +1070,7 @@ def test_vsis3_readdir(aws_test_config, webserver_port):
                 response = """<?xml version="1.0" encoding="UTF-8"?>
                 <ListBucketResult>
                     <Prefix>a_dir with_space/</Prefix>
-                    <NextMarker>bla</NextMarker>
+                    <NextContinuationToken>bla</NextContinuationToken>
                     <Contents>
                         <Key>a_dir with_space/resource3 with_space.bin</Key>
                         <LastModified>1970-01-01T00:00:01.000Z</LastModified>
@@ -1088,17 +1090,17 @@ def test_vsis3_readdir(aws_test_config, webserver_port):
 
     handler.add(
         "GET",
-        "/s3_fake_bucket2/?delimiter=%2F&prefix=a_dir%20with_space%2F",
+        "/s3_fake_bucket2/?delimiter=%2F&list-type=2&prefix=a_dir%20with_space%2F",
         custom_method=method,
     )
     handler.add(
         "GET",
-        "/s3_fake_bucket2/?delimiter=%2F&prefix=a_dir%20with_space%2F",
+        "/s3_fake_bucket2/?delimiter=%2F&list-type=2&prefix=a_dir%20with_space%2F",
         custom_method=method,
     )
     handler.add(
         "GET",
-        "/s3_fake_bucket2/?delimiter=%2F&prefix=a_dir%20with_space%2F",
+        "/s3_fake_bucket2/?delimiter=%2F&list-type=2&prefix=a_dir%20with_space%2F",
         custom_method=method,
     )
 
@@ -1155,7 +1157,10 @@ def test_vsis3_readdir(aws_test_config, webserver_port):
 
     handler.add(
         "GET",
-        ("/s3_fake_bucket2/" "?delimiter=%2F&marker=bla&prefix=a_dir%20with_space%2F"),
+        (
+            "/s3_fake_bucket2/"
+            "?continuation-token=bla&delimiter=%2F&list-type=2&prefix=a_dir%20with_space%2F"
+        ),
         custom_method=method,
     )
 
@@ -1228,7 +1233,7 @@ def test_vsis3_readdir(aws_test_config, webserver_port):
     handler.add(
         "GET",
         (
-            "/s3_fake_bucket2/?delimiter=%2F&max-keys=100"
+            "/s3_fake_bucket2/?delimiter=%2F&list-type=2&max-keys=100"
             "&prefix=a_dir%20with_space%2Fresource3%20with_space.bin%2F"
         ),
         400,
@@ -1241,7 +1246,7 @@ def test_vsis3_readdir(aws_test_config, webserver_port):
     handler = webserver.SequentialHandler()
     handler.add(
         "GET",
-        "/s3_fake_bucket2/?delimiter=%2F&prefix=a_dir%2F",
+        "/s3_fake_bucket2/?delimiter=%2F&list-type=2&prefix=a_dir%2F",
         200,
         {"Content-type": "application/xml"},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -1271,7 +1276,7 @@ def test_vsis3_readdir(aws_test_config, webserver_port):
     handler = webserver.SequentialHandler()
     handler.add(
         "GET",
-        "/s3_fake_bucket2/?delimiter=%2F&prefix=a_dir%2F",
+        "/s3_fake_bucket2/?delimiter=%2F&list-type=2&prefix=a_dir%2F",
         200,
         {},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -1317,7 +1322,7 @@ def test_vsis3_readdir(aws_test_config, webserver_port):
     handler = webserver.SequentialHandler()
     handler.add(
         "GET",
-        "/s3_fake_bucket2/?delimiter=%2F&prefix=a_dir%2F",
+        "/s3_fake_bucket2/?delimiter=%2F&list-type=2&prefix=a_dir%2F",
         200,
         {},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -1418,7 +1423,7 @@ def test_vsis3_readdir(aws_test_config, webserver_port):
             if config_option_value is None:
                 handler.add(
                     "GET",
-                    "/s3_non_cached/?delimiter=%2F",
+                    "/s3_non_cached/?delimiter=%2F&list-type=2",
                     200,
                     {"Content-type": "application/xml"},
                     """<?xml version="1.0" encoding="UTF-8"?>
@@ -1577,12 +1582,12 @@ def test_vsis3_readdir(aws_test_config, webserver_port):
     )
     handler.add(
         "GET",
-        "/s3_test_temporary_redirect_read_dir/?delimiter=%2F",
+        "/s3_test_temporary_redirect_read_dir/?delimiter=%2F&list-type=2",
         custom_method=h.method_req_1,
     )
     handler.add(
         "GET",
-        "/s3_test_temporary_redirect_read_dir/?delimiter=%2F",
+        "/s3_test_temporary_redirect_read_dir/?delimiter=%2F&list-type=2",
         custom_method=h.method_req_2,
     )
 
@@ -1606,12 +1611,12 @@ def test_vsis3_readdir(aws_test_config, webserver_port):
     )
     handler.add(
         "GET",
-        "/s3_test_temporary_redirect_read_dir/?delimiter=%2F&prefix=test%2F",
+        "/s3_test_temporary_redirect_read_dir/?delimiter=%2F&list-type=2&prefix=test%2F",
         custom_method=h.method_req_1,
     )
     handler.add(
         "GET",
-        "/s3_test_temporary_redirect_read_dir/?delimiter=%2F&prefix=test%2F",
+        "/s3_test_temporary_redirect_read_dir/?delimiter=%2F&list-type=2&prefix=test%2F",
         custom_method=h.method_req_2,
     )
 
@@ -1629,7 +1634,7 @@ def test_vsis3_opendir(aws_test_config, webserver_port):
     handler = webserver.SequentialHandler()
     handler.add(
         "GET",
-        "/vsis3_opendir/",
+        "/vsis3_opendir/?list-type=2",
         200,
         {"Content-type": "application/xml"},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -1680,7 +1685,7 @@ def test_vsis3_opendir(aws_test_config, webserver_port):
     handler = webserver.SequentialHandler()
     handler.add(
         "GET",
-        "/vsis3_opendir/?delimiter=%2F",
+        "/vsis3_opendir/?delimiter=%2F&list-type=2",
         200,
         {"Content-type": "application/xml"},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -1721,7 +1726,7 @@ def test_vsis3_opendir(aws_test_config, webserver_port):
     handler = webserver.SequentialHandler()
     handler.add(
         "GET",
-        "/vsis3_opendir/?delimiter=%2F",
+        "/vsis3_opendir/?delimiter=%2F&list-type=2",
         200,
         {"Content-type": "application/xml"},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -1756,7 +1761,7 @@ def test_vsis3_opendir(aws_test_config, webserver_port):
     handler = webserver.SequentialHandler()
     handler.add(
         "GET",
-        "/vsis3_opendir/?delimiter=%2F&prefix=subdir%2F",
+        "/vsis3_opendir/?delimiter=%2F&list-type=2&prefix=subdir%2F",
         200,
         {"Content-type": "application/xml"},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -1784,7 +1789,7 @@ def test_vsis3_opendir(aws_test_config, webserver_port):
     handler = webserver.SequentialHandler()
     handler.add(
         "GET",
-        "/vsis3_opendir/?prefix=my_prefix",
+        "/vsis3_opendir/?list-type=2&prefix=my_prefix",
         200,
         {"Content-type": "application/xml"},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -1818,7 +1823,7 @@ def test_vsis3_opendir(aws_test_config, webserver_port):
     handler = webserver.SequentialHandler()
     handler.add(
         "GET",
-        "/vsis3_opendir/?prefix=some_dir%2Fmy_prefix",
+        "/vsis3_opendir/?list-type=2&prefix=some_dir%2Fmy_prefix",
         200,
         {"Content-type": "application/xml"},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -1887,7 +1892,7 @@ def test_vsis3_opendir_synthetize_missing_directory(aws_test_config, webserver_p
     handler = webserver.SequentialHandler()
     handler.add(
         "GET",
-        "/vsis3_opendir/?prefix=maindir%2F",
+        "/vsis3_opendir/?list-type=2&prefix=maindir%2F",
         200,
         {"Content-type": "application/xml"},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -2012,7 +2017,7 @@ def test_vsis3_opendir_from_prefix(aws_test_config, webserver_port):
     )
     handler.add(
         "GET",
-        "/bucket1/",
+        "/bucket1/?list-type=2",
         200,
         {"Content-type": "application/xml"},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -2034,7 +2039,7 @@ def test_vsis3_opendir_from_prefix(aws_test_config, webserver_port):
     )
     handler.add(
         "GET",
-        "/bucket2/",
+        "/bucket2/?list-type=2",
         200,
         {"Content-type": "application/xml"},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -2322,7 +2327,7 @@ def test_vsis3_put_invalidate(aws_test_config, webserver_port):
     gdal.VSICurlClearCache()
 
     handler = webserver.SequentialHandler()
-    handler.add("GET", "/s3_fake_bucket3/?delimiter=%2F", 200)
+    handler.add("GET", "/s3_fake_bucket3/?delimiter=%2F&list-type=2", 200)
     handler.add("GET", "/s3_fake_bucket3/test_put_invalidate.bin", 200, {}, b"foo")
     handler.add("GET", "/s3_fake_bucket3/test_put_invalidate.bin", 200, {}, b"foo")
 
@@ -2354,7 +2359,7 @@ def test_vsis3_put_invalidate(aws_test_config, webserver_port):
             gdal.VSIFCloseL(f)
 
     handler = webserver.SequentialHandler()
-    handler.add("GET", "/s3_fake_bucket3/?delimiter=%2F", 200)
+    handler.add("GET", "/s3_fake_bucket3/?delimiter=%2F&list-type=2", 200)
     handler.add("GET", "/s3_fake_bucket3/test_put_invalidate.bin", 200, {}, b"barbaw")
     handler.add("GET", "/s3_fake_bucket3/test_put_invalidate.bin", 200, {}, b"barbaw")
 
@@ -2376,7 +2381,7 @@ def test_vsis3_copy_invalidate(aws_test_config, webserver_port, tmp_vsimem):
     gdal.VSICurlClearCache()
 
     handler = webserver.SequentialHandler()
-    handler.add("GET", "/s3_fake_bucket3/?delimiter=%2F", 200)
+    handler.add("GET", "/s3_fake_bucket3/?delimiter=%2F&list-type=2", 200)
     handler.add("GET", "/s3_fake_bucket3/test_put_invalidate.bin", 200, {}, b"foo")
     handler.add("GET", "/s3_fake_bucket3/test_put_invalidate.bin", 200, {}, b"foo")
 
@@ -2406,7 +2411,7 @@ def test_vsis3_copy_invalidate(aws_test_config, webserver_port, tmp_vsimem):
         gdal.CopyFile(memfilename, "/vsis3/s3_fake_bucket3/test_put_invalidate.bin")
 
     handler = webserver.SequentialHandler()
-    handler.add("GET", "/s3_fake_bucket3/?delimiter=%2F", 200)
+    handler.add("GET", "/s3_fake_bucket3/?delimiter=%2F&list-type=2", 200)
     handler.add("GET", "/s3_fake_bucket3/test_put_invalidate.bin", 200, {}, b"barbaw")
     handler.add("GET", "/s3_fake_bucket3/test_put_invalidate.bin", 200, {}, b"barbaw")
 
@@ -2499,7 +2504,7 @@ def test_vsis3_5(aws_test_config, webserver_port):
     handler.add("GET", "/s3_delete_bucket/delete_file", 404, {"Connection": "close"})
     handler.add(
         "GET",
-        "/s3_delete_bucket/?delimiter=%2F&max-keys=100&prefix=delete_file%2F",
+        "/s3_delete_bucket/?delimiter=%2F&list-type=2&max-keys=100&prefix=delete_file%2F",
         404,
         {"Connection": "close"},
     )
@@ -2635,7 +2640,7 @@ def test_vsis3_rmdir_recursive(aws_test_config, webserver_port):
     handler = webserver.SequentialHandler()
     handler.add(
         "GET",
-        "/test_rmdir_recursive/?prefix=somedir%2F",
+        "/test_rmdir_recursive/?list-type=2&prefix=somedir%2F",
         200,
         {"Content-type": "application/xml"},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -2727,7 +2732,7 @@ def test_vsis3_rmdir_recursive_no_batch_deletion(aws_test_config, webserver_port
     handler = webserver.SequentialHandler()
     handler.add(
         "GET",
-        "/test_vsis3_rmdir_recursive_no_batch_deletion/?prefix=somedir%2F",
+        "/test_vsis3_rmdir_recursive_no_batch_deletion/?list-type=2&prefix=somedir%2F",
         200,
         {"Content-type": "application/xml"},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -2760,7 +2765,7 @@ def test_vsis3_rmdir_recursive_no_batch_deletion(aws_test_config, webserver_port
     handler.add("GET", "/test_vsis3_rmdir_recursive_no_batch_deletion/somedir/", 404)
     handler.add(
         "GET",
-        "/test_vsis3_rmdir_recursive_no_batch_deletion/?delimiter=%2F&max-keys=100&prefix=somedir%2F",
+        "/test_vsis3_rmdir_recursive_no_batch_deletion/?delimiter=%2F&list-type=2&max-keys=100&prefix=somedir%2F",
         200,
         {"Content-type": "application/xml"},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -3233,7 +3238,7 @@ def test_vsis3_7(aws_test_config, webserver_port):
     handler.add("GET", "/s3_bucket_test_mkdir/dir/", 404, {"Connection": "close"})
     handler.add(
         "GET",
-        "/s3_bucket_test_mkdir/?delimiter=%2F&max-keys=100&prefix=dir%2F",
+        "/s3_bucket_test_mkdir/?delimiter=%2F&list-type=2&max-keys=100&prefix=dir%2F",
         404,
         {"Connection": "close"},
     )
@@ -3265,7 +3270,7 @@ def test_vsis3_7(aws_test_config, webserver_port):
     handler.add("GET", "/s3_bucket_test_mkdir/dir/", 404)
     handler.add(
         "GET",
-        "/s3_bucket_test_mkdir/?delimiter=%2F&max-keys=100&prefix=dir%2F",
+        "/s3_bucket_test_mkdir/?delimiter=%2F&list-type=2&max-keys=100&prefix=dir%2F",
         404,
         {"Connection": "close"},
     )
@@ -3278,7 +3283,10 @@ def test_vsis3_7(aws_test_config, webserver_port):
     handler.add("GET", "/s3_bucket_test_mkdir/dir_nonempty/", 416)
     handler.add(
         "GET",
-        ("/s3_bucket_test_mkdir/?delimiter=%2F&max-keys=100" "&prefix=dir_nonempty%2F"),
+        (
+            "/s3_bucket_test_mkdir/?delimiter=%2F&list-type=2&max-keys=100"
+            "&prefix=dir_nonempty%2F"
+        ),
         200,
         {"Content-type": "application/xml"},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -3302,7 +3310,7 @@ def test_vsis3_7(aws_test_config, webserver_port):
     handler.add(
         "GET",
         (
-            "/s3_bucket_test_dir_stat/?delimiter=%2F&max-keys=100"
+            "/s3_bucket_test_dir_stat/?delimiter=%2F&list-type=2&max-keys=100"
             "&prefix=test_dir_stat%2F"
         ),
         200,
@@ -3327,7 +3335,7 @@ def test_vsis3_7(aws_test_config, webserver_port):
     handler = webserver.SequentialHandler()
     handler.add(
         "GET",
-        "/s3_bucket_test_readdir/?delimiter=%2F&prefix=test_dirread%2F",
+        "/s3_bucket_test_readdir/?delimiter=%2F&list-type=2&prefix=test_dirread%2F",
         200,
         {"Content-type": "application/xml"},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -3350,7 +3358,7 @@ def test_vsis3_7(aws_test_config, webserver_port):
     handler.add(
         "GET",
         (
-            "/s3_bucket_test_dir_stat_2/?delimiter=%2F&max-keys=100"
+            "/s3_bucket_test_dir_stat_2/?delimiter=%2F&list-type=2&max-keys=100"
             "&prefix=test_dir_stat%2F"
         ),
         200,
@@ -3375,7 +3383,7 @@ def test_vsis3_7(aws_test_config, webserver_port):
     handler = webserver.SequentialHandler()
     handler.add(
         "GET",
-        "/s3_bucket_test_readdir2/?delimiter=%2F&prefix=test_dirread%2F",
+        "/s3_bucket_test_readdir2/?delimiter=%2F&list-type=2&prefix=test_dirread%2F",
         200,
         {"Content-type": "application/xml"},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -3402,7 +3410,7 @@ def test_vsis3_8(aws_test_config, webserver_port):
     handler = webserver.SequentialHandler()
     handler.add(
         "GET",
-        "/vsis3_8/?delimiter=%2F",
+        "/vsis3_8/?delimiter=%2F&list-type=2",
         200,
         {"Content-type": "application/xml"},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -3451,7 +3459,11 @@ def test_vsis3_sync_etag(tmp_vsimem, aws_test_config, webserver_port):
     with gdal.quiet_errors():
         handler = webserver.SequentialHandler()
         handler.add("GET", "/do_not/exist", 404)
-        handler.add("GET", "/do_not/?delimiter=%2F&max-keys=100&prefix=exist%2F", 404)
+        handler.add(
+            "GET",
+            "/do_not/?delimiter=%2F&list-type=2&max-keys=100&prefix=exist%2F",
+            404,
+        )
         handler.add("PUT", "/do_not/exist", 404)
         with webserver.install_http_handler(handler):
             assert not gdal.Sync("vsifile.py", "/vsis3/do_not/exist", options=options)
@@ -3459,7 +3471,11 @@ def test_vsis3_sync_etag(tmp_vsimem, aws_test_config, webserver_port):
     handler = webserver.SequentialHandler()
     handler.add("GET", "/out/", 200)
     handler.add("GET", "/out/testsync.txt", 404)
-    handler.add("GET", "/out/?delimiter=%2F&max-keys=100&prefix=testsync.txt%2F", 404)
+    handler.add(
+        "GET",
+        "/out/?delimiter=%2F&list-type=2&max-keys=100&prefix=testsync.txt%2F",
+        404,
+    )
 
     handler.add(
         "PUT",
@@ -3569,7 +3585,7 @@ def test_vsis3_sync_etag(tmp_vsimem, aws_test_config, webserver_port):
     handler = webserver.SequentialHandler()
     handler.add(
         "GET",
-        "/out/",
+        "/out/?list-type=2",
         200,
         {},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -3707,7 +3723,7 @@ def test_vsis3_sync_failed(tmp_vsimem, aws_test_config, webserver_port):
     )
     handler.add(
         "GET",
-        "/out/?delimiter=%2F",
+        "/out/?delimiter=%2F&list-type=2",
         200,
         {"Content-type": "application/xml"},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -3801,7 +3817,7 @@ def test_vsis3_sync_implicit_directories(tmp_path, aws_test_config, webserver_po
     handler = webserver.SequentialHandler()
     handler.add(
         "GET",
-        "/mybucket/?prefix=subdir%2F",
+        "/mybucket/?list-type=2&prefix=subdir%2F",
         200,
         {},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -3821,7 +3837,7 @@ def test_vsis3_sync_implicit_directories(tmp_path, aws_test_config, webserver_po
     handler.add("GET", "/mybucket/subdir", 404)
     handler.add(
         "GET",
-        "/mybucket/?delimiter=%2F&max-keys=100&prefix=subdir%2F",
+        "/mybucket/?delimiter=%2F&list-type=2&max-keys=100&prefix=subdir%2F",
         200,
         {},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -3916,7 +3932,7 @@ def test_vsis3_sync_win32_special_filenames(aws_test_config, webserver_port, tmp
     handler = webserver.SequentialHandler()
     handler.add(
         "GET",
-        "/bucket/",
+        "/bucket/?list-type=2",
         200,
         {},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -3973,7 +3989,7 @@ def test_vsis3_sync_win32_special_filenames(aws_test_config, webserver_port, tmp
     )
     handler.add(
         "GET",
-        "/bucket/?delimiter=%2F&prefix=subdir%2F",
+        "/bucket/?delimiter=%2F&list-type=2&prefix=subdir%2F",
         200,
         {},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -4004,11 +4020,11 @@ def test_vsis3_sync_win32_special_filenames(aws_test_config, webserver_port, tmp
     # Local to S3
     gdal.VSICurlClearCache()
     handler = webserver.SequentialHandler()
-    handler.add("GET", "/out/", 404)
+    handler.add("GET", "/out/?list-type=2", 404)
     handler.add("GET", "/out/", 404)
     handler.add(
         "GET",
-        "/out/?delimiter=%2F&max-keys=100",
+        "/out/?delimiter=%2F&list-type=2&max-keys=100",
         200,
         {},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -4043,7 +4059,9 @@ def test_vsis3_fake_rename(aws_test_config, webserver_port):
         "foo",
     )
     handler.add("GET", "/test/target.txt", 404)
-    handler.add("GET", "/test/?delimiter=%2F&max-keys=100&prefix=target.txt%2F", 200)
+    handler.add(
+        "GET", "/test/?delimiter=%2F&list-type=2&max-keys=100&prefix=target.txt%2F", 200
+    )
     handler.add(
         "PUT",
         "/test/target.txt",
@@ -4072,7 +4090,7 @@ def test_vsis3_fake_rename_dir(aws_test_config, webserver_port):
     handler.add("GET", "/test/source_dir", 404)
     handler.add(
         "GET",
-        "/test/?delimiter=%2F&max-keys=100&prefix=source_dir%2F",
+        "/test/?delimiter=%2F&list-type=2&max-keys=100&prefix=source_dir%2F",
         200,
         {"Content-type": "application/xml"},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -4087,7 +4105,9 @@ def test_vsis3_fake_rename_dir(aws_test_config, webserver_port):
         """,
     )
     handler.add("GET", "/test/target_dir/", 404)
-    handler.add("GET", "/test/?delimiter=%2F&max-keys=100&prefix=target_dir%2F", 404)
+    handler.add(
+        "GET", "/test/?delimiter=%2F&list-type=2&max-keys=100&prefix=target_dir%2F", 404
+    )
 
     def method(request):
         if request.headers["Content-Length"] != "0":
@@ -4121,7 +4141,9 @@ def test_vsis3_fake_rename_dir(aws_test_config, webserver_port):
     handler.add("DELETE", "/test/source_dir/test.txt", 204)
 
     handler.add("GET", "/test/source_dir/", 404)
-    handler.add("GET", "/test/?delimiter=%2F&max-keys=100&prefix=source_dir%2F", 404)
+    handler.add(
+        "GET", "/test/?delimiter=%2F&list-type=2&max-keys=100&prefix=source_dir%2F", 404
+    )
 
     with webserver.install_http_handler(handler):
         assert gdal.Rename("/vsis3/test/source_dir", "/vsis3/test/target_dir") == 0
@@ -4168,9 +4190,13 @@ def test_vsis3_fake_sync_multithreaded_upload_chunk_size(
 
     tab = [-1]
     handler = webserver.SequentialHandler()
-    handler.add("GET", "/test_bucket/?prefix=test%2F", 200)
+    handler.add("GET", "/test_bucket/?list-type=2&prefix=test%2F", 200)
     handler.add("GET", "/test_bucket/test", 404)
-    handler.add("GET", "/test_bucket/?delimiter=%2F&max-keys=100&prefix=test%2F", 200)
+    handler.add(
+        "GET",
+        "/test_bucket/?delimiter=%2F&list-type=2&max-keys=100&prefix=test%2F",
+        200,
+    )
     handler.add("GET", "/test_bucket/", 200)
     handler.add("GET", "/test_bucket/test/", 404)
     handler.add("PUT", "/test_bucket/test/", 200)
@@ -4247,9 +4273,13 @@ def test_vsis3_fake_sync_multithreaded_upload_chunk_size_failure(
     gdal.FileFromMemBuffer(tmp_vsimem / "test/foo", "foo\n")
 
     handler = webserver.SequentialHandler()
-    handler.add("GET", "/test_bucket/?prefix=test%2F", 200)
+    handler.add("GET", "/test_bucket/?list-type=2&prefix=test%2F", 200)
     handler.add("GET", "/test_bucket/test", 404)
-    handler.add("GET", "/test_bucket/?delimiter=%2F&max-keys=100&prefix=test%2F", 200)
+    handler.add(
+        "GET",
+        "/test_bucket/?delimiter=%2F&list-type=2&max-keys=100&prefix=test%2F",
+        200,
+    )
     handler.add("GET", "/test_bucket/", 200)
     handler.add("GET", "/test_bucket/test/", 404)
     handler.add("PUT", "/test_bucket/test/", 200)
@@ -4770,7 +4800,7 @@ def test_vsis3_no_useless_requests(aws_test_config, webserver_port):
     handler = webserver.SequentialHandler()
     handler.add(
         "GET",
-        "/no_useless_requests/?delimiter=%2F",
+        "/no_useless_requests/?delimiter=%2F&list-type=2",
         200,
         {"Content-type": "application/xml"},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -4870,7 +4900,10 @@ def test_vsis3_random_write_gtiff_create_copy(aws_test_config, webserver_port):
     handler = webserver.SequentialHandler()
     handler.add("GET", "/random_write/test.tif", 404, {})
     handler.add(
-        "GET", "/random_write/?delimiter=%2F&max-keys=100&prefix=test.tif%2F", 404, {}
+        "GET",
+        "/random_write/?delimiter=%2F&list-type=2&max-keys=100&prefix=test.tif%2F",
+        404,
+        {},
     )
 
     src_ds = gdal.Open("data/byte.tif")
@@ -4904,7 +4937,7 @@ def test_vsis3_random_write_on_existing_file(aws_test_config, webserver_port):
     handler = webserver.SequentialHandler()
     handler.add(
         "GET",
-        "/random_write/?delimiter=%2F",
+        "/random_write/?delimiter=%2F&list-type=2",
         200,
         {"Content-type": "application/xml"},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -4943,7 +4976,7 @@ def test_vsis3_random_write_on_existing_file_that_does_not_exist(
     handler = webserver.SequentialHandler()
     handler.add(
         "GET",
-        "/random_write/?delimiter=%2F",
+        "/random_write/?delimiter=%2F&list-type=2",
         200,
         {"Content-type": "application/xml"},
         """<?xml version="1.0" encoding="UTF-8"?>
@@ -6398,7 +6431,7 @@ def test_vsis3_non_existing_file_GDAL_DISABLE_READDIR_ON_OPEN(
     handler.add("GET", "/test_bucket/non_existing.tif", 404)
     handler.add(
         "GET",
-        "/test_bucket/?delimiter=%2F&max-keys=100&prefix=non_existing.tif%2F",
+        "/test_bucket/?delimiter=%2F&list-type=2&max-keys=100&prefix=non_existing.tif%2F",
         200,
     )
     gdal.ErrorReset()

--- a/port/cpl_known_config_options.h
+++ b/port/cpl_known_config_options.h
@@ -156,6 +156,7 @@ constexpr static const char* const apszKnownConfigOptions[] =
    "CPL_VSIL_USE_TEMP_FILE_FOR_RANDOM_WRITE", // from cpl_vsil_s3.cpp, ogrgeopackagedatasource.cpp, ogrlibkmldatasource.cpp, ogrsqlitedatasource.cpp
    "CPL_VSIL_ZIP_ALLOWED_EXTENSIONS", // from cpl_vsil_gzip.cpp
    "CPL_VSIS3_CREATE_DIR_OBJECT", // from cpl_vsil_s3.cpp
+   "CPL_VSIS3_LIST_OBJECTS_VERSION", // from cpl_vsil_s3.cpp
    "CPL_VSIS3_LIST_UPLOADS_MAX", // from cpl_vsil_s3.cpp
    "CPL_VSIS3_UNLINK_BATCH_SIZE", // from cpl_vsil_s3.cpp
    "CPL_VSIS3_USE_BASE_RMDIR_RECURSIVE", // from cpl_vsil_s3.cpp

--- a/port/cpl_vsil_s3.cpp
+++ b/port/cpl_vsil_s3.cpp
@@ -527,11 +527,13 @@ bool VSIDIRS3::IssueListDir()
 
     IVSIS3LikeHandleHelper *l_poHandlerHelper = poHandleHelper.get();
 
-    bool bUseV2 = false;
     auto poS3HandleHelper =
         dynamic_cast<VSIS3HandleHelper *>(poHandleHelper.get());
-    if (poS3HandleHelper)
-        bUseV2 = poS3HandleHelper->IsDirectoryBucket();
+    const bool bUseListObjectsV2 =
+        ((!osBucket.empty() || !m_osFilterPrefix.empty()) &&
+         EQUAL(CPLGetConfigOption("CPL_VSIS3_LIST_OBJECTS_VERSION", "2"),
+               "2")) ||
+        (poS3HandleHelper && poS3HandleHelper->IsDirectoryBucket());
 
     std::unique_ptr<VSIS3HandleHelper> poTmpHandleHelper;
     if (m_bRegularListingDone && m_bListBucket)
@@ -550,7 +552,7 @@ bool VSIDIRS3::IssueListDir()
     {
         l_poHandlerHelper->ResetQueryParameters();
         const std::string osBaseURL(l_poHandlerHelper->GetURL());
-        if (bUseV2)
+        if (bUseListObjectsV2)
             l_poHandlerHelper->AddQueryParameter("list-type", "2");
 
         CURL *hCurlHandle = curl_easy_init();
@@ -561,7 +563,8 @@ bool VSIDIRS3::IssueListDir()
                 l_poHandlerHelper->AddQueryParameter("delimiter", "/");
             if (!l_osNextMarker.empty())
                 l_poHandlerHelper->AddQueryParameter(
-                    bUseV2 ? "continuation-token" : "marker", l_osNextMarker);
+                    bUseListObjectsV2 ? "continuation-token" : "marker",
+                    l_osNextMarker);
             if (!osMaxKeys.empty())
                 l_poHandlerHelper->AddQueryParameter("max-keys", osMaxKeys);
             if (!osObjectKey.empty())
@@ -623,7 +626,8 @@ bool VSIDIRS3::IssueListDir()
         {
             bool bIsTruncated;
             bool ret = AnalyseS3FileList(
-                bUseV2, osBaseURL, requestHelper.sWriteFuncData.pBuffer,
+                bUseListObjectsV2, osBaseURL,
+                requestHelper.sWriteFuncData.pBuffer,
                 VSICurlFilesystemHandlerBase::GetS3IgnoredStorageClasses(),
                 bIsTruncated);
 
@@ -737,8 +741,9 @@ bool VSICurlFilesystemHandlerBase::AnalyseS3FileList(
 {
     VSIDIRS3 oDir(std::string(), this);
     oDir.nMaxFiles = nMaxFiles;
-    bool ret = oDir.AnalyseS3FileList(/* bUseV2 = */ false, osBaseURL, pszXML,
-                                      oSetIgnoredStorageClasses, bIsTruncated);
+    bool ret =
+        oDir.AnalyseS3FileList(/* bUseListObjectsV2 = */ false, osBaseURL,
+                               pszXML, oSetIgnoredStorageClasses, bIsTruncated);
     for (const auto &entry : oDir.aoEntries)
     {
         osFileList.AddString(entry->pszName);


### PR DESCRIPTION
and /vsis3/: use NextContinuationToken for paged ListObjectsV2 responses, and ignore NextMarker if present
