### PR TITLE
Doc: Remove confusing quotation mark in ESRIC driver

### DIFF
--- a/doc/source/drivers/raster/esric.rst
+++ b/doc/source/drivers/raster/esric.rst
@@ -55,7 +55,7 @@ content into a TIF file.
 
 To convert a .tpkx file to a GeoTIFF:
 
-``gdal_translate -outsize 1024 1024 "/path/to/my.tpkx output.tif``
+``gdal_translate -outsize 1024 1024 /path/to/my.tpkx output.tif``
 
 Features and Limitations
 ________________________


### PR DESCRIPTION
The example contains a misplaced quotation mark which can be confusing.