### PR TITLE
gdal raster pixel-info: add --promote-pixel-value-to-z

### DIFF
--- a/.github/workflows/ubuntu_24.04/reference_arg_names.txt
+++ b/.github/workflows/ubuntu_24.04/reference_arg_names.txt
@@ -233,6 +233,7 @@ position-crs
 power
 preserve-boundary
 profile
+promote-pixel-value-to-z
 propagate-nodata
 quadrant-segments
 radius

--- a/apps/gdalalg_raster_pixel_info.h
+++ b/apps/gdalalg_raster_pixel_info.h
@@ -45,6 +45,7 @@ class GDALRasterPixelInfoAlgorithm final : public GDALAlgorithm
     std::vector<double> m_pos{};
     std::string m_posCrs{};
     std::string m_resampling = "nearest";
+    bool m_promotePixelValueToZ = false;
 
     void PrintLine(const std::string &str);
 };

--- a/autotest/utilities/test_gdalalg_raster_pixel_info.py
+++ b/autotest/utilities/test_gdalalg_raster_pixel_info.py
@@ -469,6 +469,20 @@ def test_gdalalg_raster_pixel_info_files():
     }
 
 
+def test_gdalalg_raster_pixel_info_promote_pixel_value_to_z():
+
+    alg = get_alg()
+    alg["dataset"] = "../gcore/data/byte.vrt"
+    alg["position"] = [5, 10]
+    alg["promote-pixel-value-to-z"] = True
+    assert alg.Run()
+    j = json.loads(alg["output-string"])
+    assert j["features"][0]["geometry"] == {
+        "type": "Point",
+        "coordinates": [441020.0, 3750720.0, 132.0],
+    }
+
+
 @pytest.fixture()
 def gdal_path():
     return test_cli_utilities.get_gdal_path()

--- a/doc/source/programs/gdal_raster_pixel_info.rst
+++ b/doc/source/programs/gdal_raster_pixel_info.rst
@@ -79,6 +79,13 @@ Program-Specific Options
     - ``dataset`` means that the position is a georeferenced
       coordinate expressed in the CRS of the dataset.
 
+.. option:: --promote-pixel-value-to-z
+
+    .. versionadded:: 3.13
+
+    Whether to set the pixel value as Z component of GeoJSON geometry.
+    Only applies if a single band is selected, and for GeoJSON output format.
+
 .. option:: -r, --resampling nearest|bilinear|cubic|cubicspline
 
     Select a sampling algorithm. The default is ``nearest``.


### PR DESCRIPTION
Whether to set the pixel value as Z component of GeoJSON geometry. Only applies if a single band is selected, and for GeoJSON output format.
