### PR TITLE
ESRIC: Remove record count header check

### DIFF
--- a/frmts/esric/esric_dataset.cpp
+++ b/frmts/esric/esric_dataset.cpp
@@ -127,8 +127,6 @@ struct Bundle
         index.resize(BSZ * BSZ);
         if (3 != u32lat(header) || 5 != u32lat(header + 12) ||
             40 != u32lat(header + 32) || 0 != u32lat(header + 36) ||
-            (!isTpkx &&
-             BSZ * BSZ != u32lat(header + 4)) || /* skip this check for tpkx */
             BSZ * BSZ * 8 != u32lat(header + 60) ||
             index.size() != fh->Read(index.data(), 8, index.size()))
         {
@@ -145,7 +143,6 @@ struct Bundle
     std::vector<GUInt64> index{};
     VSIVirtualHandleUniquePtr fh{};
     bool isV2 = false;
-    bool isTpkx = false;
     CPLString name{};
     const size_t BSZ = 128;
 };
@@ -515,11 +512,6 @@ CPLErr ECDataset::InitializeFromJSON(const CPLJSONObject &oRoot)
         }
         // Keep 4 bundle files open
         bundles.resize(4);
-        // Set the tile package flag in the bundles
-        for (auto &bundle : bundles)
-        {
-            bundle.isTpkx = true;
-        }
     }
     catch (CPLString &err)
     {


### PR DESCRIPTION
## What does this PR do?

Certain bundle files created don't follow the bundle file header definition. This check is already skipped when working with tpkx files even though there is no specific relation between the tpkx file and bundle file

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [x] Add documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

This issue has been encountered on Windows builds (custom build) as well as Docker images (alpine-normal-latest).
