### PR TITLE
Arrow/Parquet/generic arrow: support Timestamp With Offset extension field

### DIFF
--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -4671,8 +4671,8 @@ def test_ogr_geojson_arrow_stream_pyarrow_mixed_timezone(tmp_vsimem):
     ds = ogr.Open(filename)
     lyr = ds.GetLayer(0)
 
-    stream = lyr.GetArrowStreamAsPyArrow()
-    assert stream.schema.field("datetime").type.tz == "UTC"
+    stream = lyr.GetArrowStreamAsPyArrow(["TIMEZONE=unknown"])
+    assert stream.schema.field("datetime").type.tz is None
     values = []
     for batch in stream:
         for x in batch.field("datetime"):

--- a/doc/source/drivers/vector/arrow.rst
+++ b/doc/source/drivers/vector/arrow.rst
@@ -124,6 +124,21 @@ The following layer creation options are supported:
      layer creation option of the Arrow driver (unless ``-lco FID=`` is used to
      set an empty name)
 
+- .. lco:: TIMESTAMP_WITH_OFFSET
+     :choices: AUTO, YES, NO
+     :default: AUTO
+     :since: 3.13
+
+     Whether OGR datetime fields should be written as Arrow timestamp with offset fields, following the
+     `Timestamp With Offset extension <https://github.com/apache/arrow/blob/main/docs/source/format/CanonicalExtensions.rst#timestamp-with-offset>`__ specification.
+     Such fields store both the datetime as a timestamp expressed in the UTC timezone and the
+     offset to UTC of the timezone in which the datetime is defined.
+     In AUTO mode, they are used as soon as a DateTime field reports a mixed
+     time zone flag (i.e. :cpp:func:`OGRFieldDefn::GetTZFlag` returns ``OGR_TZFLAG_MIXED_TZ``).
+     As few drivers are able to automatically set this flag, it may be useful
+     to override the flag by setting this option to YES. Setting it to NO forces the use
+     of a DateTime field with the UTC timezone.
+
 Conda-forge package
 -------------------
 

--- a/doc/source/drivers/vector/parquet.rst
+++ b/doc/source/drivers/vector/parquet.rst
@@ -223,6 +223,21 @@ The following layer creation options are supported:
      fallbacks to the generic implementation, which does not support advanced
      Arrow types (lists, maps, etc.).
 
+- .. lco:: TIMESTAMP_WITH_OFFSET
+     :choices: AUTO, YES, NO
+     :default: AUTO
+     :since: 3.13
+
+     Whether OGR datetime fields should be written as Arrow timestamp with offset fields, following the
+     `Timestamp With Offset extension <https://github.com/apache/arrow/blob/main/docs/source/format/CanonicalExtensions.rst#timestamp-with-offset>`__ specification.
+     Such fields store both the datetime as a timestamp expressed in the UTC timezone and the
+     offset to UTC of the timezone in which the datetime is defined.
+     In AUTO mode, they are used as soon as a DateTime field reports a mixed
+     time zone flag (i.e. :cpp:func:`OGRFieldDefn::GetTZFlag` returns ``OGR_TZFLAG_MIXED_TZ``).
+     As few drivers are able to automatically set this flag, it may be useful
+     to override the flag by setting this option to YES. Setting it to NO forces the use
+     of a DateTime field with the UTC timezone.
+
 SQL support
 -----------
 

--- a/ogr/ogrsf_frmts/arrow/ogrfeatherdriver.cpp
+++ b/ogr/ogrsf_frmts/arrow/ogrfeatherdriver.cpp
@@ -449,6 +449,19 @@ void OGRFeatherDriver::InitMetadata()
                                    "Name of the FID column to create");
     }
 
+    {
+        auto psOption = CPLCreateXMLNode(oTree.get(), CXT_Element, "Option");
+        CPLAddXMLAttributeAndValue(psOption, "name", "TIMESTAMP_WITH_OFFSET");
+        CPLAddXMLAttributeAndValue(psOption, "type", "string-select");
+        CPLAddXMLAttributeAndValue(psOption, "default", "AUTO");
+        CPLAddXMLAttributeAndValue(
+            psOption, "description",
+            "Whether timestamp with offset fields should be used");
+        CPLCreateXMLElementAndValue(psOption, "Value", "AUTO");
+        CPLCreateXMLElementAndValue(psOption, "Value", "YES");
+        CPLCreateXMLElementAndValue(psOption, "Value", "NO");
+    }
+
     char *pszXML = CPLSerializeXMLTree(oTree.get());
     GDALDriver::SetMetadataItem(GDAL_DS_LAYER_CREATIONOPTIONLIST, pszXML);
     CPLFree(pszXML);

--- a/ogr/ogrsf_frmts/arrow/ogrfeatherlayer.cpp
+++ b/ogr/ogrsf_frmts/arrow/ogrfeatherlayer.cpp
@@ -202,7 +202,10 @@ void OGRFeatherLayer::EstablishFeatureDefn()
 
         bool bRegularField = true;
         auto oIter = m_oMapGeometryColumns.find(fieldName);
-        if (oIter != m_oMapGeometryColumns.end() || !osExtensionName.empty())
+        if (oIter != m_oMapGeometryColumns.end() ||
+            (osExtensionName != EXTENSION_NAME_ARROW_JSON &&
+             osExtensionName != EXTENSION_NAME_ARROW_TIMESTAMP_WITH_OFFSET &&
+             !osExtensionName.empty()))
         {
             CPLJSONObject oJSONDef;
             if (oIter != m_oMapGeometryColumns.end())

--- a/ogr/ogrsf_frmts/arrow/ogrfeatherwriterlayer.cpp
+++ b/ogr/ogrsf_frmts/arrow/ogrfeatherwriterlayer.cpp
@@ -75,6 +75,8 @@ bool OGRFeatherWriterLayer::SetOptions(const std::string &osFilename,
                                        const OGRSpatialReference *poSpatialRef,
                                        OGRwkbGeometryType eGType)
 {
+    m_aosCreationOptions = papszOptions;
+
     const char *pszDefaultFormat =
         (EQUAL(CPLGetExtensionSafe(osFilename.c_str()).c_str(), "arrows") ||
          STARTS_WITH_CI(osFilename.c_str(), "/vsistdout"))

--- a/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
+++ b/ogr/ogrsf_frmts/arrow_common/ogr_arrow.h
@@ -480,6 +480,8 @@ class OGRArrowWriterLayer CPL_NON_FINAL : public OGRLayer
     bool m_bUseArrowWKBExtension = false;
 #endif
 
+    CPLStringList m_aosCreationOptions{};
+
     static OGRArrowGeomEncoding
     GetPreciseArrowGeomEncoding(OGRArrowGeomEncoding eEncodingType,
                                 OGRwkbGeometryType eGType);

--- a/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
+++ b/ogr/ogrsf_frmts/arrow_common/ograrrowlayer.hpp
@@ -291,21 +291,15 @@ OGRArrowLayer::IsHandledMapType(const std::shared_ptr<arrow::MapType> &mapType)
 }
 
 /************************************************************************/
-/*                        MapArrowTypeToOGR()                           */
+/*                        GetFieldExtensionName()                       */
 /************************************************************************/
 
-inline bool OGRArrowLayer::MapArrowTypeToOGR(
-    const std::shared_ptr<arrow::DataType> &typeIn,
-    const std::shared_ptr<arrow::Field> &field, OGRFieldDefn &oField,
-    OGRFieldType &eType, OGRFieldSubType &eSubType,
-    const std::vector<int> &path,
-    const std::map<std::string, std::unique_ptr<OGRFieldDefn>>
-        &oMapFieldNameToGDALSchemaFieldDefn)
+inline static std::string
+GetFieldExtensionName(const std::shared_ptr<arrow::Field> &field,
+                      std::shared_ptr<arrow::DataType> &type,
+                      const char *pszDebugKey)
 {
-    bool bTypeOK = false;
-
     std::string osExtensionName;
-    std::shared_ptr<arrow::DataType> type(typeIn);
     if (type->id() == arrow::Type::EXTENSION)
     {
         auto extensionType = cpl::down_cast<arrow::ExtensionType *>(type.get());
@@ -322,14 +316,34 @@ inline bool OGRArrowLayer::MapArrowTypeToOGR(
     }
 
     if (!osExtensionName.empty() &&
-        osExtensionName != EXTENSION_NAME_ARROW_JSON)
+        osExtensionName != EXTENSION_NAME_ARROW_JSON &&
+        osExtensionName != EXTENSION_NAME_ARROW_TIMESTAMP_WITH_OFFSET)
     {
-        CPLDebug(GetDriverUCName().c_str(),
+        CPLDebug(pszDebugKey,
                  "Dealing with field %s of extension type %s as %s",
                  field->name().c_str(), osExtensionName.c_str(),
                  type->ToString().c_str());
     }
+    return osExtensionName;
+}
 
+/************************************************************************/
+/*                        MapArrowTypeToOGR()                           */
+/************************************************************************/
+
+inline bool OGRArrowLayer::MapArrowTypeToOGR(
+    const std::shared_ptr<arrow::DataType> &typeIn,
+    const std::shared_ptr<arrow::Field> &field, OGRFieldDefn &oField,
+    OGRFieldType &eType, OGRFieldSubType &eSubType,
+    const std::vector<int> &path,
+    const std::map<std::string, std::unique_ptr<OGRFieldDefn>>
+        &oMapFieldNameToGDALSchemaFieldDefn)
+{
+    bool bTypeOK = false;
+
+    std::shared_ptr<arrow::DataType> type(typeIn);
+    const std::string osExtensionName =
+        GetFieldExtensionName(field, type, GetDriverUCName().c_str());
     switch (type->id())
     {
         case arrow::Type::NA:
@@ -677,14 +691,34 @@ inline void OGRArrowLayer::CreateFieldFromSchema(
     if (type->id() == arrow::Type::STRUCT)
     {
         const auto subfields = field->Flatten();
-        auto newpath = path;
-        newpath.push_back(0);
-        for (int j = 0; j < static_cast<int>(subfields.size()); j++)
+        const std::string osExtensionName =
+            GetFieldExtensionName(field, type, GetDriverUCName().c_str());
+        if (osExtensionName == EXTENSION_NAME_ARROW_TIMESTAMP_WITH_OFFSET &&
+            subfields.size() == 2 &&
+            subfields[0]->name() ==
+                field->name() + "." + ATSWO_TIMESTAMP_FIELD_NAME &&
+            subfields[0]->type()->id() == arrow::Type::TIMESTAMP &&
+            subfields[1]->name() ==
+                field->name() + "." + ATSWO_OFFSET_MINUTES_FIELD_NAME &&
+            subfields[1]->type()->id() == arrow::Type::INT16)
         {
-            const auto &subfield = subfields[j];
-            newpath.back() = j;
-            CreateFieldFromSchema(subfield, newpath,
-                                  oMapFieldNameToGDALSchemaFieldDefn);
+            oField.SetType(OFTDateTime);
+            oField.SetTZFlag(OGR_TZFLAG_MIXED_TZ);
+            oField.SetNullable(field->nullable());
+            m_poFeatureDefn->AddFieldDefn(&oField);
+            m_anMapFieldIndexToArrowColumn.push_back(path);
+        }
+        else
+        {
+            auto newpath = path;
+            newpath.push_back(0);
+            for (int j = 0; j < static_cast<int>(subfields.size()); j++)
+            {
+                const auto &subfield = subfields[j];
+                newpath.back() = j;
+                CreateFieldFromSchema(subfield, newpath,
+                                      oMapFieldNameToGDALSchemaFieldDefn);
+            }
         }
     }
     else if (bTypeOK)
@@ -2220,22 +2254,56 @@ inline OGRFeature *OGRArrowLayer::ReadFeature(
 
         int j = 1;
         bool bSkipToNextField = false;
-        while (array->type_id() == arrow::Type::STRUCT)
+        if (array->type_id() == arrow::Type::STRUCT &&
+            m_poFeatureDefn->GetFieldDefn(i)->GetType() == OFTDateTime &&
+            m_poFeatureDefn->GetFieldDefn(i)->GetTZFlag() ==
+                OGR_TZFLAG_MIXED_TZ)
         {
-            const auto castArray =
+            const auto structArray =
                 static_cast<const arrow::StructArray *>(array);
-            const auto &subArrays = castArray->fields();
-            CPLAssert(
-                j < static_cast<int>(m_anMapFieldIndexToArrowColumn[i].size()));
-            const int iArrowSubcol = m_anMapFieldIndexToArrowColumn[i][j];
-            j++;
-            CPLAssert(iArrowSubcol < static_cast<int>(subArrays.size()));
-            array = GetStorageArray(subArrays[iArrowSubcol].get());
-            if (array->IsNull(nIdxInBatch))
+            const auto &subArrays = structArray->fields();
+            CPLAssert(subArrays.size() == 2);
+            const auto timestampType = static_cast<arrow::TimestampType *>(
+                subArrays[0]->data()->type.get());
+            const auto timestampArray =
+                static_cast<const arrow::TimestampArray *>(subArrays[0].get());
+            const int64_t timestamp = timestampArray->Value(nIdxInBatch);
+            const auto offsetMinutesArray =
+                static_cast<const arrow::Int16Array *>(subArrays[1].get());
+            const int nOffsetMinutes = offsetMinutesArray->Value(nIdxInBatch);
+            const int MAX_TIME_ZONE_HOUR = 14;
+            const int nTZFlag =
+                nOffsetMinutes >= -MAX_TIME_ZONE_HOUR * 60 &&
+                        nOffsetMinutes <= MAX_TIME_ZONE_HOUR * 60
+                    ? OGR_TZFLAG_UTC + nOffsetMinutes / 15
+                    : OGR_TZFLAG_UTC;
+            OGRField sField;
+            sField.Set.nMarker1 = OGRUnsetMarker;
+            sField.Set.nMarker2 = OGRUnsetMarker;
+            sField.Set.nMarker3 = OGRUnsetMarker;
+            TimestampToOGR(timestamp, timestampType, nTZFlag, &sField);
+            poFeature->SetField(i, &sField);
+            continue;
+        }
+        else
+        {
+            while (array->type_id() == arrow::Type::STRUCT)
             {
-                poFeature->SetFieldNull(i);
-                bSkipToNextField = true;
-                break;
+                const auto castArray =
+                    static_cast<const arrow::StructArray *>(array);
+                const auto &subArrays = castArray->fields();
+                CPLAssert(j < static_cast<int>(
+                                  m_anMapFieldIndexToArrowColumn[i].size()));
+                const int iArrowSubcol = m_anMapFieldIndexToArrowColumn[i][j];
+                j++;
+                CPLAssert(iArrowSubcol < static_cast<int>(subArrays.size()));
+                array = GetStorageArray(subArrays[iArrowSubcol].get());
+                if (array->IsNull(nIdxInBatch))
+                {
+                    poFeature->SetFieldNull(i);
+                    bSkipToNextField = true;
+                    break;
+                }
             }
         }
         if (bSkipToNextField)

--- a/ogr/ogrsf_frmts/generic/ograrrowarrayhelper.h
+++ b/ogr/ogrsf_frmts/generic/ograrrowarrayhelper.h
@@ -200,8 +200,23 @@ class CPL_DLL OGRArrowArrayHelper
             const int TZOffsetMS = TZOffset * 60 * 1000;
             nVal -= TZOffsetMS;
         }
-        static_cast<int64_t *>(const_cast<void *>(psArray->buffers[1]))[iFeat] =
-            nVal;
+        if (psArray->n_children == 2)
+        {
+            static_cast<int64_t *>(const_cast<void *>(
+                psArray->children[0]->buffers[1]))[iFeat] = nVal;
+            const int nOffsetMinutes =
+                ogrField.Date.TZFlag > OGR_TZFLAG_MIXED_TZ
+                    ? (ogrField.Date.TZFlag - OGR_TZFLAG_UTC) * 15
+                    : 0;
+            static_cast<int16_t *>(
+                const_cast<void *>(psArray->children[1]->buffers[1]))[iFeat] =
+                static_cast<int16_t>(nOffsetMinutes);
+        }
+        else
+        {
+            static_cast<int64_t *>(
+                const_cast<void *>(psArray->buffers[1]))[iFeat] = nVal;
+        }
     }
 
     static GByte *GetPtrForStringOrBinary(struct ArrowArray *psArray, int iFeat,

--- a/ogr/ogrsf_frmts/generic/ogrlayerarrow.h
+++ b/ogr/ogrsf_frmts/generic/ogrlayerarrow.h
@@ -24,7 +24,16 @@ constexpr const char *ARROW_EXTENSION_NAME_KEY = "ARROW:extension:name";
 constexpr const char *ARROW_EXTENSION_METADATA_KEY = "ARROW:extension:metadata";
 constexpr const char *EXTENSION_NAME_OGC_WKB = "ogc.wkb";
 constexpr const char *EXTENSION_NAME_GEOARROW_WKB = "geoarrow.wkb";
+
+// Cf https://github.com/apache/arrow/blob/main/docs/source/format/CanonicalExtensions.rst#json
 constexpr const char *EXTENSION_NAME_ARROW_JSON = "arrow.json";
+
+// Cf https://github.com/apache/arrow/blob/main/docs/source/format/CanonicalExtensions.rst#timestamp-with-offset
+constexpr const char *EXTENSION_NAME_ARROW_TIMESTAMP_WITH_OFFSET =
+    "arrow.timestamp_with_offset";
+// ATSWO = Arrow TimeStamp With Offset
+constexpr const char *ATSWO_TIMESTAMP_FIELD_NAME = "timestamp";
+constexpr const char *ATSWO_OFFSET_MINUTES_FIELD_NAME = "offset_minutes";
 
 // GetArrowStream(GAS) options
 constexpr const char *GAS_OPT_DATETIME_AS_STRING = "DATETIME_AS_STRING";

--- a/ogr/ogrsf_frmts/parquet/ogr_parquet.h
+++ b/ogr/ogrsf_frmts/parquet/ogr_parquet.h
@@ -352,8 +352,6 @@ class OGRParquetWriterLayer final : public OGRArrowWriterLayer
     //! Whether to write "geo" footer metadata;
     bool m_bWriteGeoMetadata = true;
 
-    CPLStringList m_aosCreationOptions{};
-
     bool IsFileWriterCreated() const override
     {
         return m_poFileWriter != nullptr;

--- a/ogr/ogrsf_frmts/parquet/ogrparquetdriver.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetdriver.cpp
@@ -994,6 +994,19 @@ void OGRParquetDriver::InitMetadata()
                                    "the bounding box of their geometries");
     }
 
+    {
+        auto psOption = CPLCreateXMLNode(oTree.get(), CXT_Element, "Option");
+        CPLAddXMLAttributeAndValue(psOption, "name", "TIMESTAMP_WITH_OFFSET");
+        CPLAddXMLAttributeAndValue(psOption, "type", "string-select");
+        CPLAddXMLAttributeAndValue(psOption, "default", "AUTO");
+        CPLAddXMLAttributeAndValue(
+            psOption, "description",
+            "Whether timestamp with offset fields should be used");
+        CPLCreateXMLElementAndValue(psOption, "Value", "AUTO");
+        CPLCreateXMLElementAndValue(psOption, "Value", "YES");
+        CPLCreateXMLElementAndValue(psOption, "Value", "NO");
+    }
+
     char *pszXML = CPLSerializeXMLTree(oTree.get());
     GDALDriver::SetMetadataItem(GDAL_DS_LAYER_CREATIONOPTIONLIST, pszXML);
     CPLFree(pszXML);


### PR DESCRIPTION
New layer creation option for Arrow/Parquet drivers:

- .. lco:: TIMESTAMP_WITH_OFFSET
     :choices: AUTO, YES, NO
     :default: AUTO
     :since: 3.13

     Whether OGR datetime fields should be written as Arrow timestamp with offset fields, following the
     :ref:`Timestamp With Offset extension <https://github.com/apache/arrow/blob/main/docs/source/format/CanonicalExtensions.rst#timestamp-with-offset>`__ specification.
     Such fields store both the datetime as a timestamp expressed in the UTC timezone and the
     offset to UTC of the timezone in which the datetime is defined.
     In AUTO mode, they are used as soon as a DateTime field reports a mixed
     time zone flag (i.e. :cpp:func:`OGRFieldDefn::GetTZFlag()`` returns ``OGR_TZFLAG_MIXED_TZ``).
     As few drivers are able to automatically set this flag, it may be useful
     to override by setting this option to YES. Setting it to NO forces the use
     of a DateTime field with the UTC timezone.

New 'mixed' value for the 'TIMEZONE' option for OGRLayer::GetNextArrowArray():

::

     TIMEZONE="unknown", "mixed", "UTC", "(+|:)HH:MM" or any other value supported by
     Arrow. (GDAL >= 3.8)
     Override the timezone flag nominally provided by
     OGRFieldDefn::GetTZFlag(), and used for the Arrow field timezone
     declaration, with a user specified timezone.
     Note that datetime values in Arrow arrays are always stored in UTC, and
     that the time zone flag used by GDAL to convert to UTC is the one of the
     OGRField::Date::TZFlag member at the OGRFeature level. The conversion
     to UTC of a OGRField::Date is only done if both the timezone indicated by
     OGRField::Date::TZFlag and the one at the OGRFieldDefn level (or set by
     this TIMEZONE option) are not unknown.
     Since GDAL 3.13, "mixed" can be used to create an Arrow structure field,
     following the "timestamp with offset" extension (https://github.com/apache/arrow/blob/main/docs/source/format/CanonicalExtensions.rst#timestamp-with-offset)
     and storing both a UTC timestamp and the offset in minutes from the UTC
     timezone.

CC @jorisvandenbossche @theroggy