### PR TITLE
DOC: clarify CENTER_X / CENTER_Y in gdal raster calc

### DIFF
--- a/doc/source/programs/gdal_raster_calc.rst
+++ b/doc/source/programs/gdal_raster_calc.rst
@@ -226,7 +226,7 @@ Examples
 
 
 .. example::
-   :title: Latitude-based calculation using CENTER_Y
+   :title: Latitude-based calculation using ``_CENTER_Y_``
    :id: raster-calc-center-y
 
    .. code-block:: bash


### PR DESCRIPTION
Clarifies the availability and meaning of the _CENTER_X_ and _CENTER_Y_
built-in variables in gdal raster calc, as discussed in #13462.