### PR TITLE
OSM: fix reading complex multipolygons (3.11.5 regression)

### DIFF
--- a/autotest/ogr/data/osm/test_multipolygon_bugfix_gh13610.osm
+++ b/autotest/ogr/data/osm/test_multipolygon_bugfix_gh13610.osm
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="hand">
+ <bounds minlat="49" minlon="2" maxlat="50" maxlon="3"/>
+ <node id="1" lat="10" lon="0" user="some_user" uid="1" version="1" changeset="1" timestamp="2012-07-10T00:00:00Z"/>
+ <node id="2" lat="11" lon="0" user="some_user" uid="1" version="1" changeset="1" timestamp="2012-07-10T00:00:00Z"/>
+ <node id="3" lat="11" lon="1" user="some_user" uid="1" version="1" changeset="1" timestamp="2012-07-10T00:00:00Z"/>
+ <node id="4" lat="10" lon="1" user="some_user" uid="1" version="1" changeset="1" timestamp="2012-07-10T00:00:00Z"/>
+ <node id="5" lat="10.1" lon="0.1" user="some_user" uid="1" version="1" changeset="1" timestamp="2012-07-10T00:00:00Z"/>
+ <node id="6" lat="10.4" lon="0.1" user="some_user" uid="1" version="1" changeset="1" timestamp="2012-07-10T00:00:00Z"/>
+ <node id="7" lat="10.4" lon="0.9" user="some_user" uid="1" version="1" changeset="1" timestamp="2012-07-10T00:00:00Z"/>
+ <node id="8" lat="10.6" lon="0.9" user="some_user" uid="1" version="1" changeset="1" timestamp="2012-07-10T00:00:00Z"/>
+ <node id="9" lat="10.6" lon="0.1" user="some_user" uid="1" version="1" changeset="1" timestamp="2012-07-10T00:00:00Z"/>
+ <node id="10" lat="10.9" lon="0.1" user="some_user" uid="1" version="1" changeset="1" timestamp="2012-07-10T00:00:00Z"/>
+ <node id="11" lat="10.9" lon="0.9" user="some_user" uid="1" version="1" changeset="1" timestamp="2012-07-10T00:00:00Z"/>
+ <node id="12" lat="10.6" lon="0.9" user="some_user" uid="1" version="1" changeset="1" timestamp="2012-07-10T00:00:00Z"/>
+ <way id="100" user="some_user" uid="1" version="1" changeset="1" timestamp="2012-07-10T00:00:00Z">
+  <nd ref="1"/>
+  <nd ref="2"/>
+  <nd ref="3"/>
+  <nd ref="4"/>
+  <nd ref="1"/>
+ </way>
+ <way id="200" user="some_user" uid="1" version="1" changeset="1" timestamp="2012-07-10T00:00:00Z">
+  <nd ref="5"/>
+  <nd ref="6"/>
+  <nd ref="7"/>
+ </way>
+ <way id="300" user="some_user" uid="1" version="1" changeset="1" timestamp="2012-07-10T00:00:00Z">
+  <nd ref="7"/>
+  <nd ref="8"/>
+  <nd ref="5"/>
+ </way>
+ <way id="400" user="some_user" uid="1" version="1" changeset="1" timestamp="2012-07-10T00:00:00Z">
+  <nd ref="9"/>
+  <nd ref="10"/>
+  <nd ref="11"/>
+ </way>
+ <way id="500" user="some_user" uid="1" version="1" changeset="1" timestamp="2012-07-10T00:00:00Z">
+  <nd ref="11"/>
+  <nd ref="12"/>
+  <nd ref="9"/>
+ </way>
+ <relation id="1000" user="some_user" uid="1" version="1" changeset="1" timestamp="2012-07-10T00:00:00Z">
+  <member type="way" ref="100" role="outer"/>
+  <member type="way" ref="200" role="inner"/>
+  <member type="way" ref="300" role="inner"/>
+  <member type="way" ref="400" role="inner"/>
+  <member type="way" ref="500" role="inner"/>
+  <tag k="type" v="multipolygon"/>
+ </relation>
+</osm>

--- a/autotest/ogr/ogr_osm.py
+++ b/autotest/ogr/ogr_osm.py
@@ -937,3 +937,21 @@ def test_ogr_osmconf_ini():
             config.read_file(open(osmconf_ini_filename))
             assert "general" in config
             assert "closed_ways_are_polygons" in config["general"]
+
+
+###############################################################################
+# Test bugfix for https://github.com/OSGeo/gdal/issues/13610
+
+
+def test_ogr_osm_parse_complex_multipolygon():
+
+    if not ogrtest.osm_drv_parse_osm:
+        pytest.skip("Expat support missing")
+
+    ds = ogr.Open("data/osm/test_multipolygon_bugfix_gh13610.osm")
+    lyr = ds.GetLayerByName("multipolygons")
+    f = lyr.GetNextFeature()
+    ogrtest.check_feature_geometry(
+        f,
+        "MULTIPOLYGON (((0 10,0 11,1 11,1 10,0 10),(0.1 10.1,0.1 10.4,0.9 10.4,0.9 10.6,0.1 10.1),(0.1 10.6,0.1 10.9,0.9 10.9,0.9 10.6,0.1 10.6)))",
+    )

--- a/ogr/ogrsf_frmts/osm/ogrosmdatasource.cpp
+++ b/ogr/ogrsf_frmts/osm/ogrosmdatasource.cpp
@@ -2320,19 +2320,46 @@ OGRGeometry *OGROSMDataSource::BuildMultiPolygon(const OSMRelation *psRelation,
         auto poPolyFromEdges = std::unique_ptr<OGRGeometry>(
             OGRGeometry::FromHandle(OGRBuildPolygonFromEdges(
                 OGRGeometry::ToHandle(&oMLS), TRUE, FALSE, 0, nullptr)));
-        if (poPolyFromEdges && poPolyFromEdges->getGeometryType() == wkbPolygon)
+
+        const auto AddPolygonDirectlyToPolyArray =
+            [&apoPolygons, &nPolys](OGRPolygon *poPoly)
         {
-            const OGRPolygon *poSuperPoly = poPolyFromEdges->toPolygon();
-            for (const OGRLinearRing *poRing : *poSuperPoly)
+            const int nRings =
+                poPoly->IsEmpty() ? 0 : 1 + poPoly->getNumInteriorRings();
+            for (int i = nRings - 1; i >= 0; --i)
             {
+                auto poRing = std::unique_ptr<OGRLinearRing>(
+                    i > 0 ? poPoly->getInteriorRing(i - 1)
+                          : poPoly->getExteriorRing());
+                poPoly->removeRing(i, /* bDelete = */ false);
                 if (poRing != nullptr && poRing->getNumPoints() >= 4 &&
                     poRing->getX(0) ==
                         poRing->getX(poRing->getNumPoints() - 1) &&
                     poRing->getY(0) == poRing->getY(poRing->getNumPoints() - 1))
                 {
-                    OGRPolygon *poPoly = new OGRPolygon();
-                    poPoly->addRing(poRing);
-                    apoPolygons[nPolys++] = poPoly;
+                    auto poNewPoly = std::make_unique<OGRPolygon>();
+                    poNewPoly->addRing(std::move(poRing));
+                    apoPolygons[nPolys++] = poNewPoly.release();
+                }
+            }
+        };
+
+        if (poPolyFromEdges)
+        {
+            if (poPolyFromEdges->getGeometryType() == wkbPolygon)
+            {
+                AddPolygonDirectlyToPolyArray(poPolyFromEdges->toPolygon());
+            }
+            else if (OGR_GT_IsSubClassOf(poPolyFromEdges->getGeometryType(),
+                                         wkbGeometryCollection))
+            {
+                auto poGC = poPolyFromEdges->toGeometryCollection();
+                for (auto *poPart : *poGC)
+                {
+                    if (poPart->getGeometryType() == wkbPolygon)
+                    {
+                        AddPolygonDirectlyToPolyArray(poPart->toPolygon());
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixes https://github.com/OSGeo/gdal/issues/13610

This was due to a change in OGRBuildPolygonFromEdges() that made it potentially return multipolygons since
https://github.com/OSGeo/gdal/pull/13247 / https://github.com/OSGeo/gdal/pull/13247/commits/5939b2e1e4077e5c35d5a73937d7ffa0a1a3d1eb for which the OSM driver wasn't ready.
