### PR TITLE
DOC: Remove C types from Python docstrings (gdal)

### DIFF
--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -3,8 +3,9 @@
  * python specific code for gdal bindings.
  */
 
+// Disable C-style signatures in Python docstrings (see #12177)
+%feature("autodoc", "0");
 
-%feature("autodoc");
 
 %include "gdal_docs.i"
 %include "gdal_algorithm_docs.i"


### PR DESCRIPTION
This PR updates the SWIG autodoc configuration for the Python GDAL module to suppress the auto-generated C-style signature line in docstrings by using %feature("autodoc", "0"). This removes confusing C/C++ types from Python docstrings while preserving the existing documentation text. Scope is intentionally limited to the GDAL Python module.

Fixes #12177.