### PR TITLE
Docs: add initial cookbook section with raster examples

### DIFF
--- a/doc/source/cookbook/index.rst
+++ b/doc/source/cookbook/index.rst
@@ -1,0 +1,17 @@
+Cookbook
+========
+
+This section provides practical, task-oriented examples for common GDAL workflows.
+
+The goal is to answer questions like:
+
+* How do I clip a raster?
+* How do I reproject data?
+* How do I filter vector layers?
+
+Each recipe provides CLI and Python examples where applicable.
+
+.. toctree::
+   :maxdepth: 1
+
+   raster

--- a/doc/source/cookbook/raster.rst
+++ b/doc/source/cookbook/raster.rst
@@ -1,0 +1,24 @@
+Raster recipes
+==============
+
+Clip a raster using a vector cutline
+------------------------------------
+
+**Using GDAL CLI**
+
+.. code-block:: console
+
+   gdalwarp -cutline boundary.geojson -crop_to_cutline input.tif output.tif
+
+**Using Python**
+
+.. code-block:: python
+
+   from osgeo import gdal
+
+   gdal.Warp(
+       "output.tif",
+       "input.tif",
+       cutlineDSName="boundary.geojson",
+       cropToCutline=True
+   )

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -16,6 +16,7 @@ GDAL
     User <user/index>
     api/index
     tutorials/index
+    cookbook/index
     development/index
     community/index
     sponsors/index


### PR DESCRIPTION
This PR introduces an initial **Cookbook** section to the GDAL documentation.

### What’s included
- New `cookbook/` section under `doc/source`
- Initial structure with:
  - `index.rst`
  - `raster.rst`
- Practical, task-oriented examples (CLI + Python style)
- First recipe: raster clipping example

### Motivation
This addresses the need for task-based documentation discussed in #12089, 
making common GDAL workflows easier to discover and understand.

### Scope
- Documentation only
- No code or behavior changes
 Closes #12089

