### PR TITLE
DOC: Fix typo in gdal_calc documentation

### DIFF
--- a/doc/source/programs/gdal_calc.rst
+++ b/doc/source/programs/gdal_calc.rst
@@ -201,7 +201,7 @@ Examples
    .. caution::
 
       If A and B inputs both have integer data types, integer division will be
-      performed.  To avoid this, you can convert of one of the operands to a
+      performed. To avoid this, you can convert one of the operands to a
       floating point type before the division operation.
 
       .. code-block:: bash


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

Just fixes a typo at https://gdal.org/en/latest/programs/gdal_calc.html: from "you can convert of one of the operands" to "you can convert one of the operands".