### PR TITLE
Docs: clarify OGRFeature::SetGeometry does not check geometry type

### DIFF
--- a/ogr/ogr_feature.h
+++ b/ogr/ogr_feature.h
@@ -1235,9 +1235,29 @@ class CPL_DLL OGRFeature
     //! @cond Doxygen_Suppress
     void SetFDefnUnsafe(OGRFeatureDefn *poNewFDefn);
     //! @endcond
-
+    /**
+ * Set feature geometry.
+ *
+ * @note This method does NOT check that the geometry type matches the
+ *       feature definition and will not return
+ *       OGRERR_UNSUPPORTED_GEOMETRY_TYPE.
+ */
     OGRErr SetGeometryDirectly(OGRGeometry *);
+    /**
+ * Set feature geometry.
+ *
+ * @note This method does NOT check that the geometry type matches the
+ *       feature definition and will not return
+ *       OGRERR_UNSUPPORTED_GEOMETRY_TYPE.
+ */
     OGRErr SetGeometry(const OGRGeometry *);
+    /**
+ * Set feature geometry.
+ *
+ * @note This method does NOT check that the geometry type matches the
+ *       feature definition and will not return
+ *       OGRERR_UNSUPPORTED_GEOMETRY_TYPE.
+ */
     OGRErr SetGeometry(std::unique_ptr<OGRGeometry>);
     OGRGeometry *GetGeometryRef();
     const OGRGeometry *GetGeometryRef() const;


### PR DESCRIPTION
This updates the documentation of OGRFeature::SetGeometry* to explicitly
state that geometry type checking is not performed and that
OGRERR_UNSUPPORTED_GEOMETRY_TYPE is not returned.

This follows the approach suggested in issue #11147.
Fixes #11147
