### PR TITLE
test_ogrsf: do not build test program if BUILD_TESTING=OFF

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -333,19 +333,25 @@ if (BUILD_APPS)
   if(NOT MSVC AND CMAKE_THREAD_LIBS_INIT)
     target_link_libraries(multireadtest PRIVATE ${CMAKE_THREAD_LIBS_INIT})
   endif()
-  add_executable(test_ogrsf test_ogrsf.cpp)
+  if(BUILD_TESTING)
+    add_executable(test_ogrsf test_ogrsf.cpp)
+  endif()
   add_executable(testreprojmulti EXCLUDE_FROM_ALL testreprojmulti.cpp)
 
+  set(APPS_NON_DEFAULT_TARGETS
+      dumpoverviews
+      gdal2ogr
+      gdalasyncread
+      gdaltorture
+      gdalflattenmask
+      multireadtest
+      testreprojmulti)
+  if(BUILD_TESTING)
+    list(APPEND APPS_NON_DEFAULT_TARGETS test_ogrsf)
+  endif()
   foreach (
     UTILCMD IN
-    ITEMS dumpoverviews
-          gdal2ogr
-          gdalasyncread
-          gdaltorture
-          gdalflattenmask
-          multireadtest
-          test_ogrsf
-          testreprojmulti)
+    ITEMS ${APPS_NON_DEFAULT_TARGETS})
     if (WIN32)
         target_sources(${UTILCMD} PRIVATE longpathaware.manifest)
     endif()


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?
Skip building test_ogrsf program if `BUILD_TESTING` is `OFF`.
I noticed in GRASS' Docker builds where gdal is built from source, that some test targets are still being built. This non-default app is being built by default (notice the contradiction here). Either the `test_ogrsf` should be non-default, or built only when building testing tools. It seems that in OGR 3.5.0-era, `test_ogrsf` was built by default but not installed (in autotools builds), see https://github.com/OSGeo/gdal/blob/9bed24f3fcb75b6116c176053c18a23eb585613a/NEWS.md?plain=1#L8237

I chose to not build that app if `BUILD_TESTING` is not `ON`, similar to how some sample programs were not built in the issues/PRs listed below.

With feedback, I could also add more apps to not build when tests are not built, but they don't seem to be built unconditionally.

There is also `my_test_sqlite3_ext.c` that seems to be always built. Maybe a solution like the issues/PRs below should apply, but I was unsure of the implications, so I left it as is for now.

```
	[1030/1446] Building C object ogr/ogrsf_frmts/sqlite/CMakeFiles/my_test_sqlite3_ext.dir/my_test_sqlite3_ext.c.o
	[1031/1446] Linking C shared module gdalplugins/my_test_sqlite3_ext.so
```

## What are related issues/pull requests?
Similar to my older issue https://github.com/OSGeo/gdal/issues/9856, that lead to https://github.com/OSGeo/gdal/issues/9857 and https://github.com/OSGeo/gdal/pull/9864

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
