### PR TITLE
HF2: Fix incorrect clamping of negative elevation values

### DIFF
--- a/frmts/hf2/hf2dataset.cpp
+++ b/frmts/hf2/hf2dataset.cpp
@@ -207,8 +207,8 @@ CPLErr HF2RasterBand::IReadBlock(int nBlockXOff, int nLineYOff, void *pImage)
                 double dfVal = nVal * (double)fScale + fOff;
                 if (dfVal > std::numeric_limits<float>::max())
                     dfVal = std::numeric_limits<float>::max();
-                else if (dfVal < std::numeric_limits<float>::min())
-                    dfVal = std::numeric_limits<float>::min();
+                else if (dfVal < std::numeric_limits<float>::lowest())
+                    dfVal = std::numeric_limits<float>::lowest();
                 pafBlockData[nxoff * nBlockXSize + j * nRasterXSize + 0] =
                     static_cast<float>(dfVal);
                 for (int i = 1; i < nTileWidth; i++)
@@ -232,8 +232,8 @@ CPLErr HF2RasterBand::IReadBlock(int nBlockXOff, int nLineYOff, void *pImage)
                     dfVal = nVal * (double)fScale + fOff;
                     if (dfVal > std::numeric_limits<float>::max())
                         dfVal = std::numeric_limits<float>::max();
-                    else if (dfVal < std::numeric_limits<float>::min())
-                        dfVal = std::numeric_limits<float>::min();
+                    else if (dfVal < std::numeric_limits<float>::lowest())
+                        dfVal = std::numeric_limits<float>::lowest();
                     pafBlockData[nxoff * nBlockXSize + j * nRasterXSize + i] =
                         static_cast<float>(dfVal);
                 }


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

This PR corrects the useage of min() to lowest() in the HF2 driver. 

The GDAL HF2 driver contains a bug that incorrectly clamps all negative float values to std::numeric_limits<float>::min() (1.17549e-38, the smallest positive normalized float) when reading HF2/HFZ files. This should use std::numeric_limits<float>::lowest() (the most negative value) instead.



## What are related issues/pull requests?

Addresses issue [13607](https://github.com/OSGeo/gdal/issues/13607) 
