### PR TITLE
[Backport release/3.12] LIBKML: if a simple field has the same name as a core attribute, add a 2 suffix to its name

### DIFF
--- a/autotest/ogr/data/kml/ID_simple_field.kml
+++ b/autotest/ogr/data/kml/ID_simple_field.kml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<kml xmlns="http://www.opengis.net/kml/2.2">
+<Document id="root_doc">
+<Schema name="test" id="test">
+    <SimpleField name="ID" type="int"></SimpleField>
+</Schema>
+<Folder><name>test</name>
+  <Placemark id="test.1">
+      <ExtendedData><SchemaData schemaUrl="#test">
+         <SimpleData name="ID">32</SimpleData>
+      </SchemaData></ExtendedData>
+      <Point><coordinates>2,49,0</coordinates></Point>
+  </Placemark>
+</Folder>
+</Document></kml>

--- a/autotest/ogr/ogr_libkml.py
+++ b/autotest/ogr/ogr_libkml.py
@@ -2362,7 +2362,7 @@ def test_ogr_libkml_create_field_id_integer(tmp_vsimem):
     with gdal.OpenEx(filename, gdal.OF_VECTOR | gdal.OF_UPDATE) as ds:
         lyr = ds.GetLayer(0)
         f = lyr.GetNextFeature()
-        assert f["id"] == "1"
+        assert f["id"] == "test.1"
 
 
 ###############################################################################
@@ -2406,3 +2406,16 @@ def test_ogr_libkml_creation_illegal_layer_name(tmp_vsimem):
     ds = ogr.GetDriverByName("LIBKML").CreateDataSource(tmp_vsimem / "out")
     with pytest.raises(Exception, match="Illegal character"):
         ds.CreateLayer("illegal/with/slash")
+
+
+###############################################################################
+# Test bugfix for https://github.com/OSGeo/gdal/issues/13590
+
+
+def test_ogr_libkml_read_simple_field_ID():
+
+    ds = ogr.Open("data/kml/ID_simple_field.kml")
+    lyr = ds.GetLayer(0)
+    f = lyr.GetNextFeature()
+    assert f["id"] == "test.1"
+    assert f["ID2"] == 32

--- a/ogr/ogrsf_frmts/libkml/ogr_libkml.h
+++ b/ogr/ogrsf_frmts/libkml/ogr_libkml.h
@@ -75,6 +75,7 @@ class OGRLIBKMLLayer final : public OGRLayer,
     bool m_bAllReadAtLeastOnce = false;
     std::map<GIntBig, std::string> m_oMapOGRIdToKmlId{};
     std::map<std::string, GIntBig> m_oMapKmlIdToOGRId{};
+    std::map<std::string, int> m_oMapSimpleFieldNameToOgrFieldIx{};
 
     void ScanAllFeatures();
     OGRFeature *GetNextRawFeature();

--- a/ogr/ogrsf_frmts/libkml/ogrlibkmlfeature.cpp
+++ b/ogr/ogrsf_frmts/libkml/ogrlibkmlfeature.cpp
@@ -827,9 +827,11 @@ FeaturePtr feat2kml(OGRLIBKMLDataSource *poOgrDS, OGRLIBKMLLayer *poOgrLayer,
     return poKmlFeature;
 }
 
-OGRFeature *kml2feat(PlacemarkPtr poKmlPlacemark, OGRLIBKMLDataSource *poOgrDS,
-                     OGRLIBKMLLayer *poOgrLayer, OGRFeatureDefn *poOgrFeatDefn,
-                     OGRSpatialReference *poOgrSRS)
+OGRFeature *
+kml2feat(PlacemarkPtr poKmlPlacemark, OGRLIBKMLDataSource *poOgrDS,
+         OGRLIBKMLLayer *poOgrLayer, OGRFeatureDefn *poOgrFeatDefn,
+         OGRSpatialReference *poOgrSRS,
+         const std::map<std::string, int> &mapSimpleFieldNameToOgrFieldIx)
 {
     OGRFeature *poOgrFeat = new OGRFeature(poOgrFeatDefn);
 
@@ -862,16 +864,16 @@ OGRFeature *kml2feat(PlacemarkPtr poKmlPlacemark, OGRLIBKMLDataSource *poOgrDS,
 
     /***** fields *****/
     kml2field(poOgrFeat, AsFeature(poKmlPlacemark),
-              poOgrLayer->GetFieldConfig());
+              poOgrLayer->GetFieldConfig(), mapSimpleFieldNameToOgrFieldIx);
 
     return poOgrFeat;
 }
 
-OGRFeature *kmlgroundoverlay2feat(GroundOverlayPtr poKmlOverlay,
-                                  OGRLIBKMLDataSource * /* poOgrDS */,
-                                  OGRLIBKMLLayer *poOgrLayer,
-                                  OGRFeatureDefn *poOgrFeatDefn,
-                                  OGRSpatialReference *poOgrSRS)
+OGRFeature *kmlgroundoverlay2feat(
+    GroundOverlayPtr poKmlOverlay, OGRLIBKMLDataSource * /* poOgrDS */,
+    OGRLIBKMLLayer *poOgrLayer, OGRFeatureDefn *poOgrFeatDefn,
+    OGRSpatialReference *poOgrSRS,
+    const std::map<std::string, int> &mapSimpleFieldNameToOgrFieldIx)
 {
     OGRFeature *poOgrFeat = new OGRFeature(poOgrFeatDefn);
 
@@ -890,7 +892,8 @@ OGRFeature *kmlgroundoverlay2feat(GroundOverlayPtr poKmlOverlay,
     }
 
     /***** fields *****/
-    kml2field(poOgrFeat, AsFeature(poKmlOverlay), poOgrLayer->GetFieldConfig());
+    kml2field(poOgrFeat, AsFeature(poKmlOverlay), poOgrLayer->GetFieldConfig(),
+              mapSimpleFieldNameToOgrFieldIx);
 
     return poOgrFeat;
 }

--- a/ogr/ogrsf_frmts/libkml/ogrlibkmlfeature.h
+++ b/ogr/ogrsf_frmts/libkml/ogrlibkmlfeature.h
@@ -28,15 +28,16 @@ kmldom::FeaturePtr feat2kml(OGRLIBKMLDataSource *poOgrDS,
  Function to read a kml placemark into a ogr feature.
 ******************************************************************************/
 
-OGRFeature *kml2feat(kmldom::PlacemarkPtr poKmlPlacemark,
-                     OGRLIBKMLDataSource *poOgrDS, OGRLIBKMLLayer *poOgrLayer,
-                     OGRFeatureDefn *poOgrFeatDefn,
-                     OGRSpatialReference *poOgrSRS);
+OGRFeature *
+kml2feat(kmldom::PlacemarkPtr poKmlPlacemark, OGRLIBKMLDataSource *poOgrDS,
+         OGRLIBKMLLayer *poOgrLayer, OGRFeatureDefn *poOgrFeatDefn,
+         OGRSpatialReference *poOgrSRS,
+         const std::map<std::string, int> &mapSimpleFieldNameToOgrFieldIx);
 
-OGRFeature *kmlgroundoverlay2feat(kmldom::GroundOverlayPtr poKmlOverlay,
-                                  OGRLIBKMLDataSource *poOgrDS,
-                                  OGRLIBKMLLayer *poOgrLayer,
-                                  OGRFeatureDefn *poOgrFeatDefn,
-                                  OGRSpatialReference *poOgrSRS);
+OGRFeature *kmlgroundoverlay2feat(
+    kmldom::GroundOverlayPtr poKmlOverlay, OGRLIBKMLDataSource *poOgrDS,
+    OGRLIBKMLLayer *poOgrLayer, OGRFeatureDefn *poOgrFeatDefn,
+    OGRSpatialReference *poOgrSRS,
+    const std::map<std::string, int> &mapSimpleFieldNameToOgrFieldIx);
 
 #endif /*  OGR_LIBKML_FEATURE_H */

--- a/ogr/ogrsf_frmts/libkml/ogrlibkmlfield.h
+++ b/ogr/ogrsf_frmts/libkml/ogrlibkmlfield.h
@@ -39,6 +39,8 @@
 
 #include "ogr_libkml.h"
 
+#include <set>
+
 void field2kml(OGRFeature *poOgrFeat, OGRLIBKMLLayer *poOgrLayer,
                kmldom::KmlFactory *poKmlFactory,
                kmldom::FeaturePtr poKmlPlacemark, int bUseSimpleField,
@@ -48,8 +50,10 @@ void field2kml(OGRFeature *poOgrFeat, OGRLIBKMLLayer *poOgrLayer,
  Function to read kml into ogr fields.
 ******************************************************************************/
 
-void kml2field(OGRFeature *poOgrFeat, kmldom::FeaturePtr poKmlFeature,
-               const fieldconfig &oFC);
+void kml2field(
+    OGRFeature *poOgrFeat, kmldom::FeaturePtr poKmlFeature,
+    const fieldconfig &oFC,
+    const std::map<std::string, int> &mapSimpleFieldNameToOgrFieldIx);
 
 /******************************************************************************
  Function create a simplefield from a FieldDefn.
@@ -64,7 +68,9 @@ kmldom::SimpleFieldPtr FieldDef2kml(const OGRFieldDefn *poOgrFieldDef,
 ******************************************************************************/
 
 void kml2FeatureDef(kmldom::SchemaPtr poKmlSchema,
-                    OGRFeatureDefn *poOgrFeatureDefn);
+                    OGRFeatureDefn *poOgrFeatureDefn,
+                    std::map<std::string, int> &mapSimpleFieldNameToOgrFieldIx,
+                    std::set<std::string> &oSetSimpleFields);
 
 int kmlAltitudeModeFromString(const char *pszAltitudeMode, int &isGX);
 


### PR DESCRIPTION
Backport #13591
 **Authored by:** @rouault