### PR TITLE
Doc: Add an additional gdal raster mosaic example

### DIFF
--- a/doc/source/programs/gdal_raster_mosaic.rst
+++ b/doc/source/programs/gdal_raster_mosaic.rst
@@ -179,6 +179,8 @@ Examples
 .. example::
    :title: Create a Cloud Optimized GeoTIFF (COG) mosaic from all GeoTIFFs in a folder
 
+   Because the size of the resulting GeoTIFF will be more than 4 GB, the :co:`drivers/raster/cog BIGTIFF=YES` creation option is used.
+
    .. code-block:: bash
 
        gdal raster mosaic --output-format COG --creation-option BIGTIFF=YES *.tif mosaic.tif


### PR DESCRIPTION
Add a new example of a persisted GeoTIFF. 

Without the `BIGTIFF=YES` option, there are errors with the test data I used as the output is larger than 4GB. 

```
ERROR 1: TIFFAppendToStrip:Maximum TIFF file size exceeded. Use BIGTIFF=YES creation option.
Warning 1: mosaic.tif: A strile cannot be rewritten in place, which invalidates the BLOCK_ORDER optimization.
ERROR 1: TIFFAppendToStrip:Maximum TIFF file size exceeded. Use BIGTIFF=YES creation option.
ERROR 1: TIFFAppendToStrip:Maximum TIFF file size exceeded. Use BIGTIFF=YES creation option.
ERROR 1: TIFFAppendToStrip:Maximum TIFF file size exceeded. Use BIGTIFF=YES creation option.
...
```