### PR TITLE
Doc: Remove C types from Python docstrings

### DIFF
--- a/swig/include/python/gnm_python.i
+++ b/swig/include/python/gnm_python.i
@@ -3,7 +3,8 @@
  * python specific code for ogr bindings.
  */
 
-%feature("autodoc");
+// Disable C-style signatures in Python docstrings (see #12177)
+%feature("autodoc", "0");
 
 #ifndef FROM_GDAL_I
 %init %{

--- a/swig/include/python/ogr_python.i
+++ b/swig/include/python/ogr_python.i
@@ -3,7 +3,8 @@
  * python specific code for ogr bindings.
  */
 
-%feature("autodoc");
+// Disable C-style signatures in Python docstrings (see #12177)
+%feature("autodoc", "0");
 
 #ifndef FROM_GDAL_I
 %init %{

--- a/swig/include/python/osr_python.i
+++ b/swig/include/python/osr_python.i
@@ -3,7 +3,8 @@
  * python specific code for ogr bindings.
  */
 
-%feature("autodoc");
+// Disable C-style signatures in Python docstrings (see #12177)
+%feature("autodoc", "0");
 
 %init %{
   // Will be turned on for GDAL 4.0


### PR DESCRIPTION
Continues #13625, resolves #12177