### PR TITLE
DOC: Cross-reference gdalwarp -te with gdal.WarpOptions outputBounds

### DIFF
--- a/apps/gdalwarp_lib.cpp
+++ b/apps/gdalwarp_lib.cpp
@@ -5876,8 +5876,9 @@ GDALWarpAppOptionsGetParser(GDALWarpAppOptions *psOptions,
         .metavar("<xmin> <ymin> <xmax> <ymax>")
         .nargs(4)
         .scan<'g', double>()
-        .help(_("Set georeferenced extents of output file to be created."));
-
+        .help(_("Set georeferenced extents of output file to be created "
+            "(corresponds to outputBounds in gdal.WarpOptions)."));
+            
     argParser->add_argument("-te_srs")
         .metavar("<srs_def>")
         .action(


### PR DESCRIPTION
This PR improves documentation clarity by explicitly cross-referencing the `-te` option of `gdalwarp` with the corresponding Python API parameter `outputBounds` in `gdal.WarpOptions`.This helps users map CLI usage to the Python utilities API. 
No functional changes.