### PR TITLE
Doc: Use svg2pdfconverter to add SVG images to Sphinx PDF output

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -14,4 +14,5 @@ sphinx-rtd-theme == 3.0.2
 # We use a slightly forked version
 # sphinxcontrib-programoutput
 sphinxcontrib-spelling
+sphinxcontrib-svg2pdfconverter[CairoSVG]
 myst_nb

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -86,6 +86,7 @@ extensions = [
     "doctestplus_gdal",
     "source_file",
     "sphinx.ext.napoleon",
+    "sphinxcontrib.cairosvgconverter",
     "sphinxcontrib.jquery",
     "sphinxcontrib_programoutput_gdal",
     "sphinxcontrib.spelling",

--- a/doc/source/programs/gdal_raster_neighbors.rst
+++ b/doc/source/programs/gdal_raster_neighbors.rst
@@ -35,11 +35,9 @@ in the neighborhood defined by the kernel, source nodata values are ignored.
 
 This algorithm can be part of a :ref:`gdal_pipeline` or :ref:`gdal_raster_pipeline`.
 
-.. only:: html
+.. figure:: ../../images/programs/gdal_raster_neighbors.svg
 
-   .. figure:: ../../images/programs/gdal_raster_neighbors.svg
-
-      Raster dataset before (left) and after (right) summation with a 3x3 equal-weight kernel. NoData values are considered zero for the purpose of the summation. Edge cells are replicated where the kernel window extends beyond the edge of the dataset.
+   Raster dataset before (left) and after (right) summation with a 3x3 equal-weight kernel. NoData values are considered zero for the purpose of the summation. Edge cells are replicated where the kernel window extends beyond the edge of the dataset.
 
 .. GDALG output (on-the-fly / streamed dataset)
 .. --------------------------------------------

--- a/doc/source/programs/gdal_raster_polygonize.rst
+++ b/doc/source/programs/gdal_raster_polygonize.rst
@@ -34,9 +34,7 @@ details on the algorithm.
 
 Since GDAL 3.12, this algorithm can be part of a :ref:`gdal_pipeline`.
 
-.. only:: html
-
-   .. figure:: ../../images/programs/gdal_raster_polygonize.svg
+.. figure:: ../../images/programs/gdal_raster_polygonize.svg
 
    Polygonization of a 3x3 raster input. The middle figure shows the default behavior,
    where separate polygons are created for pixel regions that are connected only to

--- a/doc/source/programs/gdal_raster_reclassify.rst
+++ b/doc/source/programs/gdal_raster_reclassify.rst
@@ -47,9 +47,7 @@ If this is not desired, the input range ``DEFAULT`` can be used to specify an ou
 value for pixels not covered by any other input range.
 These pixels may be converted unto NoData (``DEFAULT = NO_DATA``), some other constant value (e.g., ``DEFAULT = 50``), or left unmodified (``DEFAULT = PASS_THROUGH``).
 
-.. only:: html
-
-   .. figure:: ../../images/programs/gdal_raster_reclassify.svg
+.. figure:: ../../images/programs/gdal_raster_reclassify.svg
 
    Raster dataset before (left) and after (right) reclassification with :program:`gdal raster reclassify --mapping "[1,3]= 101; [4, 5)= 102; 7=102; NO_DATA=103; DEFAULT=NO_DATA"`.
 

--- a/doc/source/programs/gdal_vector_check_coverage.rst
+++ b/doc/source/programs/gdal_vector_check_coverage.rst
@@ -31,11 +31,9 @@ If the coverage is valid, the output dataset will be empty unless :option:`--inc
 
 It is assumed that the individual polygons are themselves valid according to the :term:`OGC` Simple Features standard. This can be checked by :ref:`gdal_vector_check_geometry`.
 
-.. only:: html
+.. figure:: ../../images/programs/gdal_vector_check_coverage.svg
 
-   .. figure:: ../../images/programs/gdal_vector_check_coverage.svg
-
-      Polygon dataset (left) and locations of invalid coverage edges (right).
+   Polygon dataset (left) and locations of invalid coverage edges (right).
 
 .. note:: This command requires a GDAL build against the GEOS library (version 3.12 or greater).
 

--- a/doc/source/programs/gdal_vector_check_geometry.rst
+++ b/doc/source/programs/gdal_vector_check_geometry.rst
@@ -32,11 +32,9 @@ The following checks are performed, depending on the input geometry type:
 
 Validity/simplicity checking is performed by the GEOS library and should be consistent with results of software such as PostGIS, QGIS, and shapely that also use that library. GEOS does not consider repeated points to be a cause of invalidity or non-simplicity.
 
-.. only:: html
+.. figure:: ../../images/programs/gdal_vector_check_geometry.svg
 
-   .. figure:: ../../images/programs/gdal_vector_check_geometry.svg
-
-      Error locations reported by :program:`gdal vector check-geometry` for Polygon, MultiPolyon, and LineString inputs.
+   Error locations reported by :program:`gdal vector check-geometry` for Polygon, MultiPolyon, and LineString inputs.
 
 .. warning::
 

--- a/doc/source/programs/gdal_vector_clean_coverage.rst
+++ b/doc/source/programs/gdal_vector_clean_coverage.rst
@@ -51,12 +51,10 @@ Program-Specific Options
     than the specified tolerance can be inscribed within the gap. The default
     maximum gap width is zero, meaning that gaps are not closed.
 
-    .. only:: html
+    .. figure:: ../../images/programs/gdal_vector_clean_coverage_close_gaps.svg
 
-       .. figure:: ../../images/programs/gdal_vector_clean_coverage_close_gaps.svg
-
-          Polygon dataset before cleaning (left), after cleaning with default parameters (center),
-          and after cleaning with ``--maximum-gap-width 1`` (right).
+       Polygon dataset before cleaning (left), after cleaning with default parameters (center),
+       and after cleaning with ``--maximum-gap-width 1`` (right).
 
 .. option:: --merge-strategy <MERGE-STRATEGY>
 
@@ -66,11 +64,9 @@ Program-Specific Options
     - min-area: add areas to the smallest adjacent polygon
     - min-index: add areas to the adjacent polygon that was read first
 
-    .. only:: html
+    .. figure:: ../../images/programs/gdal_vector_clean_coverage_merge_max_area.svg
 
-        .. figure:: ../../images/programs/gdal_vector_clean_coverage_merge_max_area.svg
-
-           Polygon dataset before cleaning (left), after cleaning with "longest-border" merge strategy (center) and ``--merge-strategy max-area`` (right).
+       Polygon dataset before cleaning (left), after cleaning with "longest-border" merge strategy (center) and ``--merge-strategy max-area`` (right).
 
 .. option:: --output-layer
 
@@ -84,12 +80,10 @@ Program-Specific Options
     By default, an automatic snapping distance is determined based on an
     analysis of the input. Set to zero to turn off all snapping.
 
-    .. only:: html
+    .. figure:: ../../images/programs/gdal_vector_clean_coverage_snap_distance.svg
 
-        .. figure:: ../../images/programs/gdal_vector_clean_coverage_snap_distance.svg
-
-           Polygon dataset before cleaning (left), after cleaning with default snapping distance (center), and a more aggressive ``--snapping-distance 0.2`` (right). Note the movement in the
-           upper-left corner of the polygon on the right.
+       Polygon dataset before cleaning (left), after cleaning with default snapping distance (center), and a more aggressive ``--snapping-distance 0.2`` (right). Note the movement in the
+       upper-left corner of the polygon on the right.
 
 Standard Options
 ----------------

--- a/doc/source/programs/gdal_vector_layer_algebra.rst
+++ b/doc/source/programs/gdal_vector_layer_algebra.rst
@@ -49,36 +49,28 @@ Program-Specific Options
         A union is a set of features, which represent areas that are in either of the operand layers.
         The operation is symmetric, and input and method layers can be interchanged.
 
-        .. only:: html
-
-           .. image:: ../../images/programs/gdal_vector_layer_algebra_union.svg
+        .. image:: ../../images/programs/gdal_vector_layer_algebra_union.svg
 
     * ``intersection``
 
         An intersection is a set of features, which represent the common areas of two layers.
         The operation is symmetric, and input and method layers can be interchanged.
 
-        .. only:: html
-
-           .. image:: ../../images/programs/gdal_vector_layer_algebra_intersection.svg
+        .. image:: ../../images/programs/gdal_vector_layer_algebra_intersection.svg
 
     * ``sym-difference``
 
         A symmetric difference is a set of features, which represent areas that are in operand layers but which do not intersect.
         The operation is symmetric, and input and method layers can be interchanged.
 
-        .. only:: html
-
-           .. image:: ../../images/programs/gdal_vector_layer_algebra_sym_difference.svg
+        .. image:: ../../images/programs/gdal_vector_layer_algebra_sym_difference.svg
 
     * ``identity``
 
         The identity method identifies features in the input layer with features in the method layer possibly splitting features into several features.
         By default the result layer has attributes from both operand layers.
 
-        .. only:: html
-
-           .. image:: ../../images/programs/gdal_vector_layer_algebra_identity.svg
+        .. image:: ../../images/programs/gdal_vector_layer_algebra_identity.svg
 
 
     * ``update``
@@ -86,18 +78,14 @@ Program-Specific Options
         The update method creates a layer, which add features into the input layer from the method layer possibly cutting features in the input layer.
         By default the result layer has attributes only from the input layer.
 
-        .. only:: html
-
-           .. image:: ../../images/programs/gdal_vector_layer_algebra_update.svg
+        .. image:: ../../images/programs/gdal_vector_layer_algebra_update.svg
 
     * ``clip``
 
         The clip method creates a layer, which has features from the input layer clipped to the areas of the features in the method layer.
         By default the result layer has attributes of the input layer.
 
-        .. only:: html
-
-           .. image:: ../../images/programs/gdal_vector_layer_algebra_clip.svg
+        .. image:: ../../images/programs/gdal_vector_layer_algebra_clip.svg
 
 
     * ``erase``
@@ -105,9 +93,7 @@ Program-Specific Options
         The erase method creates a layer, which has features from the input layer whose areas are erased by the features in the method layer.
         By default the result layer has attributes of the input layer.
 
-        .. only:: html
-
-           .. image:: ../../images/programs/gdal_vector_layer_algebra_erase.svg
+        .. image:: ../../images/programs/gdal_vector_layer_algebra_erase.svg
 
 .. option:: --method-layer <METHOD-LAYER>
 

--- a/doc/source/programs/gdal_vector_simplify.rst
+++ b/doc/source/programs/gdal_vector_simplify.rst
@@ -34,9 +34,7 @@ happen. To perform simplification that preserves shared boundaries between geome
 
 This command can also be used as a step of :ref:`gdal_vector_pipeline`.
 
-.. only:: html
-
-   .. figure:: ../../images/programs/gdal_vector_simplify.svg
+.. figure:: ../../images/programs/gdal_vector_simplify.svg
 
    Line dataset before (left) and after (right) simplification with :program:`gdal vector simplify`.
 

--- a/doc/source/programs/gdal_vector_simplify_coverage.rst
+++ b/doc/source/programs/gdal_vector_simplify_coverage.rst
@@ -35,9 +35,7 @@ Simplification is performed using the Visvalingam-Whyatt algorithm.
 
 This command can also be used as a step of :ref:`gdal_vector_pipeline`.
 
-.. only:: html
-
-   .. figure:: ../../images/programs/gdal_vector_simplify_coverage.svg
+.. figure:: ../../images/programs/gdal_vector_simplify_coverage.svg
 
    Polygon dataset before (left) and after (right) simplification with :program:`gdal vector simplify-coverage`.
 


### PR DESCRIPTION
Use https://github.com/missinglinkelectronics/sphinxcontrib-svg2pdfconverter to allow SVG images to be added to the GDAL PDF doc output. Fixes #12085. 

The ImageMagick approach in #13555 did not work for SVGs. From https://www.sphinx-doc.org/en/master/usage/extensions/imgconverter.html: 

>ImageMagick rasterizes a SVG image on conversion. As a result, the image becomes not scalable. To avoid that, please use other image converters like sphinxcontrib-svg2pdfconverter (which uses Inkscape or rsvg-convert_

I have removed `.. only:: html` and checked the created output at https://github.com/geographika/gdal/actions/runs/20877823278/artifacts/5084917229:

<img width="1298" height="720" alt="image" src="https://github.com/user-attachments/assets/758c0fd1-5c8e-4fc6-ad53-340d2249680f" />
