### PR TITLE
ubuntu-*/Dockerfile: hide internal libproj

### DIFF
--- a/docker/ubuntu-full/Dockerfile
+++ b/docker/ubuntu-full/Dockerfile
@@ -483,7 +483,7 @@ ARG WITH_DEBUG_SYMBOLS=no
 
 # Refresh grids
 ARG PROJ_DATUMGRID_LATEST_LAST_MODIFIED
-ARG PROJ_INSTALL_PREFIX=/usr/local
+ARG PROJ_INSTALL_PREFIX=/usr/local/gdal-internal
 COPY ./bh-proj.sh /buildscripts/bh-proj.sh
 # We build PROJ a first time, just to build the projsync utility if grids need
 # to be refreshed. We will rebuild just afterwards, but depending on the
@@ -499,7 +499,7 @@ RUN --mount=type=cache,id=ubuntu-full-proj,target=$HOME/.cache \
       . /buildscripts/bh-set-envvars.sh \
       && rm -f /tmp/proj_grids/proj_grids_not_included \
       && DESTDIR=/build_tmp_proj /buildscripts/bh-proj.sh \
-      && LD_LIBRARY_PATH=/build_tmp_proj/usr/local/lib /build_tmp_proj/usr/local/bin/projsync --target-dir /tmp/proj_grids --all \
+      && LD_LIBRARY_PATH=/build_tmp_proj/${PROJ_INSTALL_PREFIX}/lib /build_tmp_proj/${PROJ_INSTALL_PREFIX}/bin/projsync --target-dir /tmp/proj_grids --all \
       && rm -rf /build_tmp_proj \
     ); fi
 
@@ -618,7 +618,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 COPY --from=builder  /build_thirdparty/usr/ /usr/
 COPY --from=builder  /build_thirdparty/opt/ /opt/
 
-ARG PROJ_INSTALL_PREFIX=/usr/local
+ARG PROJ_INSTALL_PREFIX=/usr/local/gdal-internal
 COPY --from=builder  /tmp/proj_grids/* ${PROJ_INSTALL_PREFIX}/share/proj/
 
 COPY --from=builder  /build${PROJ_INSTALL_PREFIX}/share/proj/ ${PROJ_INSTALL_PREFIX}/share/proj/
@@ -641,6 +641,7 @@ RUN ogrinfo ADBC::memory: -oo ADBC_DRIVER=libduckdb.so -oo PRELUDE_STATEMENTS="I
 RUN echo "source /usr/share/bash-completion/bash_completion" >> /root/.bashrc
 
 # Set tcmalloc as the allocator to improve multi-threaded performance
-ENV LD_PRELOAD=libtcmalloc_minimal.so.4
+ENV LD_PRELOAD=libtcmalloc_minimal.so.4 \
+    PATH="${PATH}:/usr/local/gdal-internal/bin"
 
 CMD ["/bin/bash", "-l"]

--- a/docker/ubuntu-full/bh-gdal.sh
+++ b/docker/ubuntu-full/bh-gdal.sh
@@ -41,6 +41,7 @@ curl -Lo - -fsS "https://github.com/${GDAL_REPOSITORY}/archive/${GDAL_VERSION}.t
     export CFLAGS="-DPROJ_RENAME_SYMBOLS -O2 -g"
     # -Wno-psabi avoid 'note: parameter passing for argument of type 'std::pair<double, double>' when C++17 is enabled changed to match C++14 in GCC 10.1' on arm64
     export CXXFLAGS="-DPROJ_RENAME_SYMBOLS -DPROJ_INTERNAL_CPP_NAMESPACE -O2 -g -Wno-psabi"
+    export LDFLAGS="-Wl,-rpath=${PROJ_INSTALL_PREFIX}/lib"
 
     mkdir build
     cd build
@@ -82,8 +83,8 @@ curl -Lo - -fsS "https://github.com/${GDAL_REPOSITORY}/archive/${GDAL_VERSION}.t
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DGDAL_FIND_PACKAGE_PROJ_MODE=MODULE \
         -DBUILD_TESTING=OFF \
-        -DPROJ_INCLUDE_DIR="/build${PROJ_INSTALL_PREFIX-/usr/local}/include" \
-        -DPROJ_LIBRARY="/build${PROJ_INSTALL_PREFIX-/usr/local}/lib/libinternalproj.so" \
+        -DPROJ_INCLUDE_DIR="/build${PROJ_INSTALL_PREFIX}/include" \
+        -DPROJ_LIBRARY="/build${PROJ_INSTALL_PREFIX}/lib/libinternalproj.so" \
         -DGDAL_ENABLE_PLUGINS=ON \
         -DGDAL_USE_TIFF_INTERNAL=ON \
         -DBUILD_PYTHON_BINDINGS=ON \
@@ -94,7 +95,6 @@ curl -Lo - -fsS "https://github.com/${GDAL_REPOSITORY}/archive/${GDAL_VERSION}.t
 
     ninja
     DESTDIR="/build" ninja install
-    rm /build${PROJ_INSTALL_PREFIX}/lib/pkgconfig/proj.pc
 
     cd ..
 

--- a/docker/ubuntu-full/bh-proj.sh
+++ b/docker/ubuntu-full/bh-proj.sh
@@ -39,7 +39,7 @@ curl -Lo - -fsS "https://github.com/OSGeo/PROJ/archive/${PROJ_VERSION}.tar.gz" \
     cmake . \
         -G Ninja \
         -DBUILD_SHARED_LIBS=ON \
-        -DCMAKE_INSTALL_PREFIX=${PROJ_INSTALL_PREFIX:-/usr/local} \
+        -DCMAKE_INSTALL_PREFIX=${PROJ_INSTALL_PREFIX} \
         -DBUILD_TESTING=OFF \
         $PROJ_DB_CACHE_PARAM
 

--- a/docker/ubuntu-small/Dockerfile
+++ b/docker/ubuntu-small/Dockerfile
@@ -7,7 +7,7 @@
 # Public domain
 # or licensed under MIT (LICENSE.TXT) Copyright 2019 Even Rouault <even.rouault@spatialys.com>
 
-ARG PROJ_INSTALL_PREFIX=/usr/local
+ARG PROJ_INSTALL_PREFIX=/usr/local/gdal-internal
 ARG BASE_IMAGE=ubuntu:24.04
 ARG TARGET_BASE_IMAGE=ubuntu:24.04
 
@@ -181,13 +181,13 @@ RUN --mount=type=cache,id=ubuntu-small-gdal,target=$HOME/.cache \
     && mkdir build \
     && cd build \
     # -Wno-psabi avoid 'note: parameter passing for argument of type 'std::pair<double, double>' when C++17 is enabled changed to match C++14 in GCC 10.1' on arm64
-    && CFLAGS='-DPROJ_RENAME_SYMBOLS -O2' CXXFLAGS='-DPROJ_RENAME_SYMBOLS -DPROJ_INTERNAL_CPP_NAMESPACE -O2 -Wno-psabi' \
+    && CFLAGS='-DPROJ_RENAME_SYMBOLS -O2' CXXFLAGS='-DPROJ_RENAME_SYMBOLS -DPROJ_INTERNAL_CPP_NAMESPACE -O2 -Wno-psabi' LDFLAGS="-Wl,-rpath=${PROJ_INSTALL_PREFIX}/lib" \
        cmake .. \
         -G Ninja \
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DGDAL_FIND_PACKAGE_PROJ_MODE=MODULE \
-        -DPROJ_INCLUDE_DIR="/build${PROJ_INSTALL_PREFIX-/usr/local}/include" \
-        -DPROJ_LIBRARY="/build${PROJ_INSTALL_PREFIX-/usr/local}/lib/libinternalproj.so" \
+        -DPROJ_INCLUDE_DIR="/build${PROJ_INSTALL_PREFIX}/include" \
+        -DPROJ_LIBRARY="/build${PROJ_INSTALL_PREFIX}/lib/libinternalproj.so" \
         -DGDAL_USE_TIFF_INTERNAL=ON \
         -DGDAL_USE_GEOTIFF_INTERNAL=ON ${GDAL_CMAKE_EXTRA_OPTS} \
         -DBUILD_TESTING=OFF \
@@ -216,8 +216,7 @@ RUN --mount=type=cache,id=ubuntu-small-gdal,target=$HOME/.cache \
     && mv /build/usr/bin                    /build_gdal_version_changing/usr \
     && for i in /build_gdal_version_changing/usr/lib/${GCC_ARCH}-linux-gnu/*; do ${GCC_ARCH}-linux-gnu-strip -s $i 2>/dev/null || /bin/true; done \
     && for i in /build_gdal_python/usr/lib/python3/dist-packages/osgeo/*.so; do ${GCC_ARCH}-linux-gnu-strip -s $i 2>/dev/null || /bin/true; done \
-    && for i in /build_gdal_version_changing/usr/bin/*; do ${GCC_ARCH}-linux-gnu-strip -s $i 2>/dev/null || /bin/true; done \
-    && rm /build${PROJ_INSTALL_PREFIX}/lib/pkgconfig/proj.pc
+    && for i in /build_gdal_version_changing/usr/bin/*; do ${GCC_ARCH}-linux-gnu-strip -s $i 2>/dev/null || /bin/true; done
 
 # Build final image
 FROM $TARGET_BASE_IMAGE AS runner
@@ -271,6 +270,7 @@ RUN ldconfig
 RUN echo "source /usr/share/bash-completion/bash_completion" >> /root/.bashrc
 
 # Set tcmalloc as the allocator to improve multi-threaded performance
-ENV LD_PRELOAD=libtcmalloc_minimal.so.4
+ENV LD_PRELOAD=libtcmalloc_minimal.so.4 \
+    PATH="${PATH}:/usr/local/gdal-internal/bin"
 
 CMD ["/bin/bash", "-l"]


### PR DESCRIPTION
<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

Set the installation prefix for the internal
libproj to /usr/local/gdal-internal, so
third-party configure scripts don't accidentally
decide to use the internal libproj.

## What are related issues/pull requests?

#13699

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE

## Environment

Provide environment details, if relevant:

* OS:
* Compiler:
