### PR TITLE
overview: warn in case of conflicting mask sources

### DIFF
--- a/apps/gdalalg_raster_reproject.cpp
+++ b/apps/gdalalg_raster_reproject.cpp
@@ -207,6 +207,7 @@ bool GDALRasterReprojectAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
 
     CPLStringList aosOptions;
     std::string outputFilename;
+
     if (ctxt.m_poNextUsableStep)
     {
         CPLAssert(CanHandleNextStep(ctxt.m_poNextUsableStep));

--- a/doc/source/api/gdalrasterband_cpp.rst
+++ b/doc/source/api/gdalrasterband_cpp.rst
@@ -71,3 +71,9 @@ GDALRasterWindow class
 .. doxygenclass:: GDALRasterWindow
    :project: api
    :members:
+
+
+.. below is an allow-list for spelling checker.
+
+.. spelling:word-list::
+    posDetailMessage

--- a/gcore/gdal_rasterband.h
+++ b/gcore/gdal_rasterband.h
@@ -122,6 +122,8 @@ class CPL_DLL GDALRasterBand : public GDALMajorObject
         GSpacing nPixelSpace, GSpacing nLineSpace,
         GDALRasterIOExtraArg *psExtraArg) CPL_WARN_UNUSED_RESULT;
 
+    CPL_INTERNAL bool HasNoData() const;
+
   protected:
     GDALRasterBand();
     explicit GDALRasterBand(int bForceCachedIO);
@@ -552,6 +554,8 @@ class CPL_DLL GDALRasterBand : public GDALMajorObject
     virtual CPLErr CreateMaskBand(int nFlagsIn);
     virtual bool IsMaskBand() const;
     virtual GDALMaskValueRange GetMaskValueRange() const;
+    bool HasConflictingMaskSources(std::string *posDetailMessage = nullptr,
+                                   bool bMentionPrioritarySource = true) const;
 
     virtual CPLVirtualMem *
     GetVirtualMemAuto(GDALRWFlag eRWFlag, int *pnPixelSpace,


### PR DESCRIPTION
Fixes #13703

```
$ gdal raster overview add --external sample2.tif -r average
Warning 1: Raster band 1 of dataset sample2.tif has several conflicting mask sources:
- nodata value
- related to a raster band that is an alpha band
Only the nodata value will be taken into account.
0...10...20...30...40...50...60...70...80...90...100 - done.
```
