### PR TITLE
[Backport release/3.12] DOC: disable dummy Python Module Index in PDF output

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1425,6 +1425,12 @@ latex_documents = [
 latex_toplevel_sectioning = "chapter"
 
 latex_logo = "../images/gdalicon_big.png"
+# Disable module and domain indices in PDF output.
+# Python API documentation is not included in the PDF, so keeping them
+# results in a dummy and confusing "Python Module Index" section.
+latex_use_modindex = False
+latex_domain_indices = False
+
 
 # If true, show URL addresses after external links.
 # man_show_urls = False


### PR DESCRIPTION
Backport #13725
 **Authored by:** @Sionigdha