### PR TITLE
[Backport release/3.12] Add explicit include for std::strtoull

### DIFF
--- a/apps/gdalalg_vsi_sozip.cpp
+++ b/apps/gdalalg_vsi_sozip.cpp
@@ -16,6 +16,7 @@
 #include "cpl_string.h"
 #include "cpl_time.h"
 
+#include <cstdlib>
 #include <limits>
 
 //! @cond Doxygen_Suppress


### PR DESCRIPTION
Backport #13729
 **Authored by:** @4JustMe4