### PR TITLE
[Backport release/3.12] GTiff: make GetMetadataItem(<top-level-key>, json:ISIS3) return a subset of the whole JSON

### DIFF
--- a/autotest/gcore/tiff_read.py
+++ b/autotest/gcore/tiff_read.py
@@ -5634,6 +5634,30 @@ def test_tiff_read_vat_dbf_boolean_datetime(tmp_vsimem):
 
 
 ###############################################################################
+def test_tiff_read_json_ISIS3(tmp_vsimem):
+
+    filename = str(tmp_vsimem / "test.tif")
+    with gdal.GetDriverByName("GTiff").Create(filename, 1, 1) as ds:
+        ds.SetMetadata('{"foo":{"bar":"baz"}}', "json:ISIS3")
+
+    with gdal.Open(filename) as ds:
+        assert ds.GetMetadata("json:ISIS3")[0] == '{"foo":{"bar":"baz"}}'
+
+    with gdal.Open(filename) as ds:
+        assert ds.GetMetadataItem("foo", "json:ISIS3") == '{ "bar": "baz" }'
+        # Hit cache
+        assert ds.GetMetadataItem("foo", "json:ISIS3") == '{ "bar": "baz" }'
+        assert ds.GetMetadataItem("bar", "json:ISIS3") is None
+
+        # Invalidate cached items
+        ds.SetMetadata('{"bar":{"foo":"baz"}}', "json:ISIS3")
+        assert ds.GetMetadataItem("foo", "json:ISIS3") is None
+
+        with pytest.raises(Exception):
+            ds.SetMetadataItem("foo", '{"bar":"baz"}', "json:ISIS3")
+
+
+###############################################################################
 
 
 def test_tiff_read_corrupted_lzw():

--- a/doc/source/drivers/raster/gtiff.rst
+++ b/doc/source/drivers/raster/gtiff.rst
@@ -452,6 +452,15 @@ profile information cannot be used.
 All these metadata tags can be overridden and/or used as creation
 options.
 
+json:ISIS3 Metadata
+-------------------
+
+.. versionadded:: 3.13
+
+It is possible to use :cpp:func:`GDALDataset::GetMetadataItem` to request one
+particular key in the ``json:ISIS3`` metadata domain among all the top-level
+keys that would be returned by ``GDALDataset::GetMetadata("json:ISIS3")``.
+
 Nodata value
 ------------
 

--- a/frmts/gtiff/gtiffdataset.cpp
+++ b/frmts/gtiff/gtiffdataset.cpp
@@ -113,6 +113,7 @@ GTiffDataset::GTiffDataset()
         m_eVirtualMemIOUsage = VirtualMemIOEnum::YES;
 
     m_oSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
+    m_oISIS3Metadata.Deinit();
 }
 
 /************************************************************************/

--- a/frmts/gtiff/gtiffdataset.h
+++ b/frmts/gtiff/gtiffdataset.h
@@ -19,6 +19,7 @@
 #include <mutex>
 #include <queue>
 
+#include "cpl_json.h"
 #include "cpl_mem_cache.h"
 #include "cpl_worker_thread_pool.h"  // CPLJobQueue, CPLWorkerThreadPool
 #include "fetchbufferdirectio.h"
@@ -157,6 +158,9 @@ class GTiffDataset final : public GDALPamDataset
     char *m_pszTmpFilename = nullptr;
     char *m_pszGeorefFilename = nullptr;
     char *m_pszXMLFilename = nullptr;
+
+    CPLJSONObject m_oISIS3Metadata{};
+    std::map<std::string, std::string> m_oMapISIS3MetadataItems{};
 
     GDALGeoTransform m_gt{};
     double m_dfMaxZError = 0.0;

--- a/frmts/gtiff/gtiffdataset_read.cpp
+++ b/frmts/gtiff/gtiffdataset_read.cpp
@@ -6558,6 +6558,39 @@ const char *GTiffDataset::GetMetadataItem(const char *pszName,
         }
     }
 
+    else if (pszName && pszDomain && EQUAL(pszDomain, "json:ISIS3"))
+    {
+        auto oIter = m_oMapISIS3MetadataItems.find(pszName);
+        if (oIter != m_oMapISIS3MetadataItems.end())
+        {
+            return oIter->second.c_str();
+        }
+        else
+        {
+            if (!m_oISIS3Metadata.IsValid())
+            {
+                CSLConstList papszMD = m_oGTiffMDMD.GetMetadata(pszDomain);
+                if (papszMD && papszMD[0])
+                {
+                    CPLJSONDocument oDoc;
+                    if (oDoc.LoadMemory(papszMD[0]))
+                    {
+                        m_oISIS3Metadata = oDoc.GetRoot();
+                    }
+                }
+            }
+            CPLJSONObject obj = m_oISIS3Metadata[pszName];
+            if (obj.IsValid())
+            {
+                return m_oMapISIS3MetadataItems
+                    .insert(std::pair<std::string, std::string>(pszName,
+                                                                obj.ToString()))
+                    .first->second.c_str();
+            }
+            return nullptr;
+        }
+    }
+
     return m_oGTiffMDMD.GetMetadataItem(pszName, pszDomain);
 }
 

--- a/frmts/gtiff/gtiffdataset_write.cpp
+++ b/frmts/gtiff/gtiffdataset_write.cpp
@@ -9239,6 +9239,12 @@ CPLErr GTiffDataset::SetMetadata(char **papszMD, const char *pszDomain)
         return CE_Failure;
     }
 
+    if (pszDomain && EQUAL(pszDomain, "json:ISIS3"))
+    {
+        m_oISIS3Metadata.Deinit();
+        m_oMapISIS3MetadataItems.clear();
+    }
+
     CPLErr eErr = CE_None;
     if (eAccess == GA_Update)
     {
@@ -9320,6 +9326,14 @@ CPLErr GTiffDataset::SetMetadataItem(const char *pszName, const char *pszValue,
         ReportError(
             CE_Failure, CPLE_NotSupported,
             "Cannot modify metadata at that point in a streamed output file");
+        return CE_Failure;
+    }
+
+    if (pszDomain && EQUAL(pszDomain, "json:ISIS3"))
+    {
+        ReportError(CE_Failure, CPLE_NotSupported,
+                    "Updating part of json:ISIS3 is not supported. "
+                    "Use SetMetadata() instead");
         return CE_Failure;
     }
 


### PR DESCRIPTION
Backport #13676
 **Authored by:** @rouault