### PR TITLE
Doc: Add `check-coverage` examples

### DIFF
--- a/doc/source/programs/gdal_vector_check_coverage.rst
+++ b/doc/source/programs/gdal_vector_check_coverage.rst
@@ -117,9 +117,9 @@ Examples
 
       .. code-tab:: bash
 
-        gdal vector pipeline !
-            ! read "https://cdn.jsdelivr.net/npm/us-atlas@3/counties-albers-10m.json" --layer counties !
-            ! check-coverage !
+        gdal vector pipeline \
+            ! read "https://cdn.jsdelivr.net/npm/us-atlas@3/counties-albers-10m.json" --layer counties \
+            ! check-coverage \
             ! info --features
 
       .. code-tab:: powershell


### PR DESCRIPTION
Added a couple of examples, and a note that valid features will return empty geometries when using `--include-valid` (this is what I observed in testing).

@dbaston looking at the GDAL history and tests I think the `--include-field` parameter may have been incorrectly added to this page, and only applies to `check-geometry`? I was testing with last night's conda build. 

```bash
gdal vector check-coverage "https://cdn.jsdelivr.net/npm/us-atlas@3/counties-albers-10m.json" --layer counties counties-errors.geojson --include-field "name"
ERROR 5: check-coverage: Option '--include-field' is unknown.
```
I removed the `--include-field` parameter (It would be a useful option though). Let me know if this should be left. 

