### PR TITLE
SPELLING: fixed spelling of Celcius to Celsius

### DIFF
--- a/autotest/gdrivers/grib.py
+++ b/autotest/gdrivers/grib.py
@@ -259,7 +259,7 @@ def test_grib_grib2_read_template_4_32():
     assert cs == 48230, "Could not open file"
     assert ds.GetRasterBand(1).ComputeRasterMinMax() == pytest.approx(
         (-9.765, 2.415), 1e-3
-    )  # Reasonable range for Celcius
+    )  # Reasonable range for Celsius
     md = ds.GetRasterBand(1).GetMetadata()
     expected_md = {
         "GRIB_REF_TIME": "1508479200",

--- a/frmts/grib/degrib/README.TXT
+++ b/frmts/grib/degrib/README.TXT
@@ -70,7 +70,7 @@ The following tables can be found:
   - unit_conv: Unit conversion rule, whose values can be one of:
       + UC_NONE: No conversion allowed
       + UC_K2F: Kelvin degrees are converted to Fahrenheit (if English unit system)
-                or Celcius (metric system)
+                or Celsius (metric system)
       + UC_M2Feet: Meters are converted to Feet if English unit system
       + UC_M2Inch: Meters are converted to Inch if English unit system
       + UC_MS2Knots: m/s are converted to Knots if English unit system

--- a/frmts/jpeg/jpgdataset.cpp
+++ b/frmts/jpeg/jpgdataset.cpp
@@ -933,8 +933,8 @@ void JPGDatasetCommon::ReadFLIRMetadata()
 
         const auto ReadFloat32FromKelvin = [=](std::uint32_t nOffset)
         {
-            constexpr float ZERO_CELCIUS_IN_KELVIN = 273.15f;
-            return ReadFloat32(nOffset) - ZERO_CELCIUS_IN_KELVIN;
+            constexpr float ZERO_CELSIUS_IN_KELVIN = 273.15f;
+            return ReadFloat32(nOffset) - ZERO_CELSIUS_IN_KELVIN;
         };
         SetMetadataItem("Emissivity",
                         CPLSPrintf("%f", ReadFloat32(nRecOffset + 32)), "FLIR");


### PR DESCRIPTION
## What does this PR do?
Fixes the spelling mistake of the word Celcius with a C to Celsius with a S.

## What are related issues/pull requests?
N/A