### PR TITLE
Make GDALDataset::AddBand/AdviseRead/BeginAsyncReader/CopyLayer/pfnCreate/pfnCreateCopy...

### DIFF
--- a/autotest/cpp/test_gdal.cpp
+++ b/autotest/cpp/test_gdal.cpp
@@ -587,14 +587,14 @@ class DatasetWithErrorInFlushCache final : public GDALDataset
         return CE_None;
     }
 
-    static GDALDataset *CreateCopy(const char *, GDALDataset *, int, char **,
-                                   GDALProgressFunc, void *)
+    static GDALDataset *CreateCopy(const char *, GDALDataset *, int,
+                                   CSLConstList, GDALProgressFunc, void *)
     {
         return new DatasetWithErrorInFlushCache();
     }
 
     static GDALDataset *Create(const char *, int nXSize, int nYSize, int,
-                               GDALDataType, char **)
+                               GDALDataType, CSLConstList)
     {
         DatasetWithErrorInFlushCache *poDS = new DatasetWithErrorInFlushCache();
         poDS->eAccess = GA_Update;

--- a/doc/source/user/migration_guide.rst
+++ b/doc/source/user/migration_guide.rst
@@ -11,6 +11,11 @@ From GDAL 3.12 to GDAL 3.13
 
   * :cpp:func:`GDALDataset::Close` takes now 2 input parameters ``(GDALProgressFunc pfnProgress, void *pProgressData)``,
     which may be nullptr.
+  * :cpp:func:`GDALDataset::AddBand`, :cpp:func:`GDALDataset::AdviseRead`,
+    :cpp:func:`GDALDataset::BeginAsyncReader`, :cpp:func:`GDALDataset::CopyLayer`,
+    ``GDALDriver::pfnCreate``, ``GDALDriver::pfnCreateCopy``,
+    :cpp:func:`GDALRasterBand::AdviseRead` and :cpp:func:`GDALRasterBand::GetVirtualMemAuto`
+    now take a ``CSLConstList papszOptions`` parameter instead of ``char **``.
 
 - Changes impacting C++ users:
 

--- a/frmts/aaigrid/aaigriddataset.cpp
+++ b/frmts/aaigrid/aaigriddataset.cpp
@@ -1298,7 +1298,7 @@ const OGRSpatialReference *AAIGDataset::GetSpatialRef() const
 
 GDALDataset *AAIGDataset::CreateCopy(const char *pszFilename,
                                      GDALDataset *poSrcDS, int /* bStrict */,
-                                     char **papszOptions,
+                                     CSLConstList papszOptions,
                                      GDALProgressFunc pfnProgress,
                                      void *pProgressData)
 {

--- a/frmts/aaigrid/aaigriddataset.h
+++ b/frmts/aaigrid/aaigriddataset.h
@@ -102,7 +102,7 @@ class AAIGDataset CPL_NON_FINAL : public GDALPamDataset
     static CPLErr Remove(const char *pszFilename, int bRepError);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 

--- a/frmts/avif/avifdataset.cpp
+++ b/frmts/avif/avifdataset.cpp
@@ -80,7 +80,7 @@ class GDALAVIFDataset final : public GDALPamDataset
     }
 
     static GDALDataset *CreateCopy(const char *, GDALDataset *, int,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 
@@ -699,11 +699,10 @@ GDALPamDataset *GDALAVIFDataset::OpenStaticPAM(GDALOpenInfo *poOpenInfo)
 /************************************************************************/
 
 /* static */
-GDALDataset *GDALAVIFDataset::CreateCopy(const char *pszFilename,
-                                         GDALDataset *poSrcDS,
-                                         int /* bStrict */, char **papszOptions,
-                                         GDALProgressFunc pfnProgress,
-                                         void *pProgressData)
+GDALDataset *
+GDALAVIFDataset::CreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
+                            int /* bStrict */, CSLConstList papszOptions,
+                            GDALProgressFunc pfnProgress, void *pProgressData)
 {
     auto poDrv = GetGDALDriverManager()->GetDriverByName(DRIVER_NAME);
     if (poDrv && poDrv->GetMetadataItem(GDAL_DMD_CREATIONOPTIONLIST) == nullptr)

--- a/frmts/basisu_ktx2/basisudataset.cpp
+++ b/frmts/basisu_ktx2/basisudataset.cpp
@@ -53,7 +53,7 @@ class BASISUDataset final : public GDALPamDataset
     static GDALDataset *Open(GDALOpenInfo *poOpenInfo);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 };
@@ -360,7 +360,7 @@ GDALDataset *BASISUDataset::Open(GDALOpenInfo *poOpenInfo)
 
 GDALDataset *BASISUDataset::CreateCopy(const char *pszFilename,
                                        GDALDataset *poSrcDS, int /*bStrict*/,
-                                       char **papszOptions,
+                                       CSLConstList papszOptions,
                                        GDALProgressFunc pfnProgress,
                                        void *pProgressData)
 {

--- a/frmts/basisu_ktx2/ktx2dataset.cpp
+++ b/frmts/basisu_ktx2/ktx2dataset.cpp
@@ -51,7 +51,7 @@ class KTX2Dataset final : public GDALPamDataset
     static GDALDataset *Open(GDALOpenInfo *poOpenInfo);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 };
@@ -402,7 +402,7 @@ GDALDataset *KTX2Dataset::Open(GDALOpenInfo *poOpenInfo)
 
 GDALDataset *KTX2Dataset::CreateCopy(const char *pszFilename,
                                      GDALDataset *poSrcDS, int /*bStrict*/,
-                                     char **papszOptions,
+                                     CSLConstList papszOptions,
                                      GDALProgressFunc pfnProgress,
                                      void *pProgressData)
 {

--- a/frmts/bmp/bmpdataset.cpp
+++ b/frmts/bmp/bmpdataset.cpp
@@ -247,7 +247,7 @@ class BMPDataset final : public GDALPamDataset
     static GDALDataset *Open(GDALOpenInfo *);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBandsIn, GDALDataType eType,
-                               char **papszParamList);
+                               CSLConstList papszParamList);
 
     CPLErr GetGeoTransform(GDALGeoTransform &gt) const override;
     CPLErr SetGeoTransform(const GDALGeoTransform &gt) override;
@@ -1430,7 +1430,7 @@ GDALDataset *BMPDataset::Open(GDALOpenInfo *poOpenInfo)
 
 GDALDataset *BMPDataset::Create(const char *pszFilename, int nXSize, int nYSize,
                                 int nBandsIn, GDALDataType eType,
-                                char **papszOptions)
+                                CSLConstList papszOptions)
 
 {
     if (eType != GDT_UInt8)

--- a/frmts/cals/calsdataset.cpp
+++ b/frmts/cals/calsdataset.cpp
@@ -46,7 +46,7 @@ class CALSDataset final : public GDALPamDataset
     static GDALDataset *Open(GDALOpenInfo *);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 };
@@ -427,7 +427,7 @@ GDALDataset *CALSDataset::Open(GDALOpenInfo *poOpenInfo)
 
 GDALDataset *CALSDataset::CreateCopy(const char *pszFilename,
                                      GDALDataset *poSrcDS, int bStrict,
-                                     char ** /* papszOptionsUnused */,
+                                     CSLConstList /* papszOptionsUnused */,
                                      GDALProgressFunc pfnProgress,
                                      void *pProgressData)
 {

--- a/frmts/daas/daasdataset.cpp
+++ b/frmts/daas/daasdataset.cpp
@@ -149,7 +149,8 @@ class GDALDAASDataset final : public GDALDataset
     CPLErr AdviseRead(int nXOff, int nYOff, int nXSize, int nYSize,
                       int /* nBufXSize */, int /* nBufYSize */,
                       GDALDataType /* eBufType */, int /*nBands*/,
-                      int * /*panBands*/, char ** /* papszOptions */) override;
+                      int * /*panBands*/,
+                      CSLConstList /* papszOptions */) override;
     CPLErr FlushCache(bool bAtClosing) override;
 };
 
@@ -183,7 +184,7 @@ class GDALDAASRasterBand final : public GDALRasterBand
     CPLErr AdviseRead(int nXOff, int nYOff, int nXSize, int nYSize,
                       int /* nBufXSize */, int /* nBufYSize */,
                       GDALDataType /* eBufType */,
-                      char ** /* papszOptions */) override;
+                      CSLConstList /* papszOptions */) override;
     double GetNoDataValue(int *pbHasNoData) override;
     GDALColorInterp GetColorInterpretation() override;
     GDALRasterBand *GetMaskBand() override;
@@ -396,7 +397,8 @@ static double DAASBackoffFactor(double base)
 /*                          DAAS_CPLHTTPFetch()                         */
 /************************************************************************/
 
-static CPLHTTPResult *DAAS_CPLHTTPFetch(const char *pszURL, char **papszOptions)
+static CPLHTTPResult *DAAS_CPLHTTPFetch(const char *pszURL,
+                                        CSLConstList papszOptions)
 {
     CPLHTTPResult *psResult;
     const int RETRY_COUNT = 4;
@@ -1597,7 +1599,7 @@ CPLErr GDALDAASDataset::AdviseRead(int nXOff, int nYOff, int nXSize, int nYSize,
                                    int nBufXSize, int nBufYSize,
                                    GDALDataType /* eBufType */, int /*nBands*/,
                                    int * /*panBands*/,
-                                   char ** /* papszOptions */)
+                                   CSLConstList /* papszOptions */)
 {
     if (nXSize == nBufXSize && nYSize == nBufYSize)
     {
@@ -1752,7 +1754,7 @@ CPLErr GDALDAASRasterBand::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
 CPLErr GDALDAASRasterBand::AdviseRead(int nXOff, int nYOff, int nXSize,
                                       int nYSize, int nBufXSize, int nBufYSize,
                                       GDALDataType /* eBufType */,
-                                      char ** /* papszOptions */)
+                                      CSLConstList /* papszOptions */)
 {
     GDALDAASDataset *poGDS = cpl::down_cast<GDALDAASDataset *>(poDS);
     if (nXSize == nBufXSize && nYSize == nBufYSize)

--- a/frmts/dds/ddsdataset.cpp
+++ b/frmts/dds/ddsdataset.cpp
@@ -53,7 +53,7 @@ class DDSDataset final : public GDALPamDataset
     static GDALDataset *Open(GDALOpenInfo *poOpenInfo);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 };
@@ -450,7 +450,7 @@ GDALDataset *DDSDatasetAllDecoded::Open(GDALOpenInfo *poOpenInfo)
 
 GDALDataset *DDSDataset::CreateCopy(const char *pszFilename,
                                     GDALDataset *poSrcDS, int bStrict,
-                                    char **papszOptions,
+                                    CSLConstList papszOptions,
                                     GDALProgressFunc pfnProgress,
                                     void *pProgressData)
 

--- a/frmts/dted/dteddataset.cpp
+++ b/frmts/dted/dteddataset.cpp
@@ -659,7 +659,7 @@ const OGRSpatialReference *DTEDDataset::GetSpatialRef() const
 
 static GDALDataset *DTEDCreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char ** /* papszOptions */,
+                                   CSLConstList /* papszOptions */,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData)
 

--- a/frmts/ecw/ecwasyncreader.cpp
+++ b/frmts/ecw/ecwasyncreader.cpp
@@ -25,7 +25,7 @@
 GDALAsyncReader *ECWDataset::BeginAsyncReader(
     int nXOff, int nYOff, int nXSize, int nYSize, void *pBuf, int nBufXSize,
     int nBufYSize, GDALDataType eBufType, int nBandCount, int *panBandMap,
-    int nPixelSpace, int nLineSpace, int nBandSpace, char **papszOptions)
+    int nPixelSpace, int nLineSpace, int nBandSpace, CSLConstList papszOptions)
 
 {
     int i;

--- a/frmts/ecw/ecwcreatecopy.cpp
+++ b/frmts/ecw/ecwcreatecopy.cpp
@@ -74,8 +74,8 @@ class GDALECWCompressor final : public CNCSFile
 
     bool WriteCancel() override;
 
-    CPLErr Initialize(const char *pszFilename, char **papszOptions, int nXSize,
-                      int nYSize, int nBands,
+    CPLErr Initialize(const char *pszFilename, CSLConstList papszOptions,
+                      int nXSize, int nYSize, int nBands,
                       const char *const *papszBandDescriptions,
                       int bRGBColorSpace, GDALDataType eType,
                       const OGRSpatialReference *poSRS,
@@ -379,7 +379,7 @@ CPLErr GDALECWCompressor::ourWriteLineBIL(UINT16 nBands, void **ppOutputLine,
 /************************************************************************/
 
 CPLErr GDALECWCompressor::Initialize(
-    const char *pszFilename, char **papszOptions, int nXSize, int nYSize,
+    const char *pszFilename, CSLConstList papszOptions, int nXSize, int nYSize,
     int nBands, const char *const *papszBandDescriptions, int bRGBColorSpace,
     GDALDataType eType, const OGRSpatialReference *poSRS,
     const GDALGeoTransform &gt, int nGCPCount, const GDAL_GCP *pasGCPList,
@@ -1084,7 +1084,7 @@ static int ECWIsInputRGBColorSpace(GDALDataset *poSrcDS)
 /************************************************************************/
 
 static GDALDataset *ECWCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
-                                  int bStrict, char **papszOptions,
+                                  int bStrict, CSLConstList papszOptions,
                                   GDALProgressFunc pfnProgress,
                                   void *pProgressData, int bIsJPEG2000)
 
@@ -1290,7 +1290,7 @@ static GDALDataset *ECWCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
 /************************************************************************/
 
 GDALDataset *ECWCreateCopyECW(const char *pszFilename, GDALDataset *poSrcDS,
-                              int bStrict, char **papszOptions,
+                              int bStrict, CSLConstList papszOptions,
                               GDALProgressFunc pfnProgress, void *pProgressData)
 
 {
@@ -1384,7 +1384,7 @@ GDALDataset *ECWCreateCopyECW(const char *pszFilename, GDALDataset *poSrcDS,
 
 GDALDataset *ECWCreateCopyJPEG2000(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData)
 
@@ -1536,7 +1536,7 @@ class ECWWriteDataset final : public GDALDataset
 
   public:
     ECWWriteDataset(const char *, int, int, int, GDALDataType,
-                    char **papszOptions, int);
+                    CSLConstList papszOptions, int);
     ~ECWWriteDataset() override;
 
     CPLErr FlushCache(bool bAtClosing) override;
@@ -1610,7 +1610,7 @@ class ECWWriteRasterBand final : public GDALRasterBand
 
 ECWWriteDataset::ECWWriteDataset(const char *pszFilenameIn, int nXSize,
                                  int nYSize, int nBandCount, GDALDataType eType,
-                                 char **papszOptionsIn, int bIsJPEG2000In)
+                                 CSLConstList papszOptionsIn, int bIsJPEG2000In)
 
 {
     bCrystalized = FALSE;
@@ -2033,7 +2033,7 @@ CPLErr ECWWriteRasterBand::IWriteBlock(CPL_UNUSED int nBlockX, int nBlockY,
 
 GDALDataset *ECWCreateJPEG2000(const char *pszFilename, int nXSize, int nYSize,
                                int nBands, GDALDataType eType,
-                               char **papszOptions)
+                               CSLConstList papszOptions)
 
 {
     if (nBands == 0)
@@ -2052,7 +2052,8 @@ GDALDataset *ECWCreateJPEG2000(const char *pszFilename, int nXSize, int nYSize,
 /************************************************************************/
 
 GDALDataset *ECWCreateECW(const char *pszFilename, int nXSize, int nYSize,
-                          int nBands, GDALDataType eType, char **papszOptions)
+                          int nBands, GDALDataType eType,
+                          CSLConstList papszOptions)
 
 {
     if (nBands == 0)

--- a/frmts/ecw/ecwdataset.cpp
+++ b/frmts/ecw/ecwdataset.cpp
@@ -287,7 +287,7 @@ CPLErr ECWRasterBand::SetColorInterpretation(GDALColorInterp eNewInterp)
 
 CPLErr ECWRasterBand::AdviseRead(int nXOff, int nYOff, int nXSize, int nYSize,
                                  int nBufXSize, int nBufYSize, GDALDataType eDT,
-                                 char **papszOptions)
+                                 CSLConstList papszOptions)
 {
     const int nResFactor = 1 << (iOverview + 1);
 
@@ -1680,7 +1680,8 @@ void ECWDataset::WriteHeader()
 CPLErr ECWDataset::AdviseRead(int nXOff, int nYOff, int nXSize, int nYSize,
                               int nBufXSize, int nBufYSize,
                               CPL_UNUSED GDALDataType eDT, int nBandCount,
-                              int *panBandList, CPL_UNUSED char **papszOptions)
+                              int *panBandList,
+                              CPL_UNUSED CSLConstList papszOptions)
 {
     CPLDebug("ECW", "ECWDataset::AdviseRead(%d,%d,%d,%d->%d,%d)", nXOff, nYOff,
              nXSize, nYSize, nBufXSize, nBufYSize);

--- a/frmts/ecw/gdal_ecw.h
+++ b/frmts/ecw/gdal_ecw.h
@@ -38,20 +38,21 @@ GDALColorInterp ECWGetColorInterpretationByName(const char *pszName);
 const char *ECWGetColorSpaceName(NCSFileColorSpace colorSpace);
 #ifdef HAVE_COMPRESS
 GDALDataset *ECWCreateCopyECW(const char *pszFilename, GDALDataset *poSrcDS,
-                              int bStrict, char **papszOptions,
+                              int bStrict, CSLConstList papszOptions,
                               GDALProgressFunc pfnProgress,
                               void *pProgressData);
 GDALDataset *ECWCreateCopyJPEG2000(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 
 GDALDataset *ECWCreateECW(const char *pszFilename, int nXSize, int nYSize,
-                          int nBands, GDALDataType eType, char **papszOptions);
+                          int nBands, GDALDataType eType,
+                          CSLConstList papszOptions);
 GDALDataset *ECWCreateJPEG2000(const char *pszFilename, int nXSize, int nYSize,
                                int nBands, GDALDataType eType,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
 #endif
 
 void ECWReportError(CNCSError &oErr, const char *pszMsg = "");
@@ -611,7 +612,7 @@ class CPL_DLL ECWDataset final : public GDALJP2AbstractDataset
     CPLErr AdviseRead(int nXOff, int nYOff, int nXSize, int nYSize,
                       int nBufXSize, int nBufYSize, GDALDataType eDT,
                       int nBandCount, int *panBandList,
-                      char **papszOptions) override;
+                      CSLConstList papszOptions) override;
 
     // progressive methods
 #if ECWSDK_VERSION >= 40
@@ -620,7 +621,7 @@ class CPL_DLL ECWDataset final : public GDALJP2AbstractDataset
                      int nBufXSize, int nBufYSize, GDALDataType eBufType,
                      int nBandCount, int *panBandMap, int nPixelSpace,
                      int nLineSpace, int nBandSpace,
-                     char **papszOptions) override;
+                     CSLConstList papszOptions) override;
 
     void EndAsyncReader(GDALAsyncReader *) override;
 #endif /* ECWSDK_VERSION > 40 */
@@ -693,7 +694,7 @@ class ECWRasterBand final : public GDALPamRasterBand
 
     CPLErr AdviseRead(int nXOff, int nYOff, int nXSize, int nYSize,
                       int nBufXSize, int nBufYSize, GDALDataType eDT,
-                      char **papszOptions) override;
+                      CSLConstList papszOptions) override;
 #if ECWSDK_VERSION >= 50
     void GetBandIndexAndCountForStatistics(int &bandIndex,
                                            int &bandCount) const;

--- a/frmts/eeda/eeda.h
+++ b/frmts/eeda/eeda.h
@@ -25,7 +25,7 @@
 #include <vector>
 #include <map>
 
-CPLHTTPResult *EEDAHTTPFetch(const char *pszURL, char **papszOptions);
+CPLHTTPResult *EEDAHTTPFetch(const char *pszURL, CSLConstList papszOptions);
 
 /************************************************************************/
 /*                             EEDAIBandDesc                            */

--- a/frmts/eeda/eedacommon.cpp
+++ b/frmts/eeda/eedacommon.cpp
@@ -464,7 +464,7 @@ static double EEDABackoffFactor(double base)
 /*                           EEDAHTTPFetch()                            */
 /************************************************************************/
 
-CPLHTTPResult *EEDAHTTPFetch(const char *pszURL, char **papszOptions)
+CPLHTTPResult *EEDAHTTPFetch(const char *pszURL, CSLConstList papszOptions)
 {
     CPLHTTPResult *psResult;
     const int RETRY_COUNT = 4;

--- a/frmts/ers/ersdataset.cpp
+++ b/frmts/ers/ersdataset.cpp
@@ -96,7 +96,7 @@ class ERSDataset final : public RawDataset
     static int Identify(GDALOpenInfo *);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBandsIn, GDALDataType eType,
-                               char **papszParamList);
+                               CSLConstList papszOptions);
 };
 
 /************************************************************************/
@@ -1319,7 +1319,7 @@ GDALDataset *ERSDataset::Open(GDALOpenInfo *poOpenInfo)
 
 GDALDataset *ERSDataset::Create(const char *pszFilename, int nXSize, int nYSize,
                                 int nBandsIn, GDALDataType eType,
-                                char **papszOptions)
+                                CSLConstList papszOptions)
 
 {
     /* -------------------------------------------------------------------- */

--- a/frmts/exr/exrdataset.cpp
+++ b/frmts/exr/exrdataset.cpp
@@ -77,10 +77,10 @@ class GDALEXRDataset final : public GDALPamDataset
     static GDALDataset *Open(GDALOpenInfo *poOpenInfo);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBandsIn, GDALDataType eType,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 };
@@ -843,7 +843,7 @@ GDALDataset *GDALEXRDataset::Open(GDALOpenInfo *poOpenInfo)
 /*                          getPixelType()                              */
 /************************************************************************/
 
-static PixelType getPixelType(GDALDataType eSrcDT, char **papszOptions)
+static PixelType getPixelType(GDALDataType eSrcDT, CSLConstList papszOptions)
 {
     PixelType pixelType =
         (eSrcDT == GDT_UInt8) ? HALF
@@ -939,7 +939,7 @@ static void FillHeaderFromOptions(Header &header, CSLConstList papszOptions)
 
 GDALDataset *GDALEXRDataset::CreateCopy(const char *pszFilename,
                                         GDALDataset *poSrcDS, int,
-                                        char **papszOptions,
+                                        CSLConstList papszOptions,
                                         GDALProgressFunc pfnProgress,
                                         void *pProgressData)
 {
@@ -1919,7 +1919,8 @@ CPLErr GDALEXRWritableRasterBand::IWriteBlock(int nBlockXOff, int nBlockYOff,
 
 GDALDataset *GDALEXRDataset::Create(const char *pszFilename, int nXSize,
                                     int nYSize, int nBandsIn,
-                                    GDALDataType eType, char **papszOptions)
+                                    GDALDataType eType,
+                                    CSLConstList papszOptions)
 {
     if (nBandsIn == 0)
         return nullptr;

--- a/frmts/fits/fitsdataset.cpp
+++ b/frmts/fits/fitsdataset.cpp
@@ -88,7 +88,7 @@ class FITSDataset final : public GDALPamDataset
     static GDALDataset *Open(GDALOpenInfo *);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBandsIn, GDALDataType eType,
-                               char **papszParamList);
+                               CSLConstList papszParamList);
     static CPLErr Delete(const char *pszFilename);
 
     const OGRSpatialReference *GetSpatialRef() const override;
@@ -2673,7 +2673,7 @@ GDALDataset *FITSDataset::Open(GDALOpenInfo *poOpenInfo)
 
 GDALDataset *FITSDataset::Create(const char *pszFilename, int nXSize,
                                  int nYSize, int nBandsIn, GDALDataType eType,
-                                 CPL_UNUSED char **papszParamList)
+                                 CPL_UNUSED CSLConstList papszParamList)
 {
     int status = 0;
 

--- a/frmts/georaster/georaster_dataset.cpp
+++ b/frmts/georaster/georaster_dataset.cpp
@@ -469,7 +469,8 @@ void GeoRasterDataset::JP2_Open(GDALAccess /* eAccess */)
 //                                                              JP2CreateCopy()
 //  ---------------------------------------------------------------------------
 
-void GeoRasterDataset::JP2_CreateCopy(GDALDataset *poJP2DS, char **papszOptions,
+void GeoRasterDataset::JP2_CreateCopy(GDALDataset *poJP2DS,
+                                      CSLConstList papszOptions,
                                       int *pnResolutions,
                                       GDALProgressFunc pfnProgress,
                                       void *pProgressData)
@@ -860,7 +861,8 @@ static bool ParseCommaSeparatedString(const char *str, double pfValues[],
 
 GDALDataset *GeoRasterDataset::Create(const char *pszFilename, int nXSize,
                                       int nYSize, int nBandsIn,
-                                      GDALDataType eType, char **papszOptions)
+                                      GDALDataType eType,
+                                      CSLConstList papszOptions)
 {
     //  -------------------------------------------------------------------
     //  Verify georaster prefix
@@ -1478,7 +1480,7 @@ GDALDataset *GeoRasterDataset::Create(const char *pszFilename, int nXSize,
 
 GDALDataset *GeoRasterDataset::CreateCopy(const char *pszFilename,
                                           GDALDataset *poSrcDS, int bStrict,
-                                          char **papszOptions,
+                                          CSLConstList papszOptions,
                                           GDALProgressFunc pfnProgress,
                                           void *pProgressData)
 {

--- a/frmts/georaster/georaster_priv.h
+++ b/frmts/georaster/georaster_priv.h
@@ -163,7 +163,7 @@ class GeoRasterDataset final : public GDALDataset
     GeoRasterRasterBand *poMaskBand;
     bool bApplyNoDataArray;
     void JP2_Open(GDALAccess eAccess);
-    void JP2_CreateCopy(GDALDataset *poJP2DS, char **papszOptions,
+    void JP2_CreateCopy(GDALDataset *poJP2DS, CSLConstList papszOptions,
                         int *pnResolutions, GDALProgressFunc pfnProgress,
                         void *pProgressData);
     boolean JP2_CopyDirect(const char *pszJP2Filename, int *pnResolutions,
@@ -186,10 +186,10 @@ class GeoRasterDataset final : public GDALDataset
     static CPLErr Delete(const char *pszFilename);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBands, GDALDataType eType,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
     CPLErr GetGeoTransform(GDALGeoTransform &gt) const override;

--- a/frmts/gif/gifdataset.cpp
+++ b/frmts/gif/gifdataset.cpp
@@ -85,7 +85,7 @@ class GIFDataset final : public GIFAbstractDataset
 
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 };
@@ -360,7 +360,7 @@ static void GDALPrintGifError(CPL_UNUSED GifFileType *hGifFile,
 
 GDALDataset *GIFDataset::CreateCopy(const char *pszFilename,
                                     GDALDataset *poSrcDS, int bStrict,
-                                    char **papszOptions,
+                                    CSLConstList papszOptions,
                                     GDALProgressFunc pfnProgress,
                                     void *pProgressData)
 

--- a/frmts/grib/gribcreatecopy.cpp
+++ b/frmts/grib/gribcreatecopy.cpp
@@ -812,9 +812,9 @@ bool GRIB2Section3Writer::Write()
 /*                         GetBandOption()                              */
 /************************************************************************/
 
-static const char *GetBandOption(char **papszOptions, GDALDataset *poSrcDS,
-                                 int nBand, const char *pszKey,
-                                 const char *pszDefault)
+static const char *GetBandOption(CSLConstList papszOptions,
+                                 GDALDataset *poSrcDS, int nBand,
+                                 const char *pszKey, const char *pszDefault)
 {
     const char *pszVal = CSLFetchNameValue(
         papszOptions, CPLSPrintf("BAND_%d_%s", nBand, pszKey));
@@ -865,13 +865,13 @@ class GRIB2Section567Writer
     bool WriteComplexPacking(int nSpatialDifferencingOrder);
     bool WriteIEEE(GDALProgressFunc pfnProgress, void *pProgressData);
     bool WritePNG();
-    bool WriteJPEG2000(char **papszOptions);
+    bool WriteJPEG2000(CSLConstList papszOptions);
 
   public:
     GRIB2Section567Writer(VSILFILE *fp, GDALDataset *poSrcDS, int nBand,
                           int nSplitAndSwap);
 
-    bool Write(float fValOffset, char **papszOptions,
+    bool Write(float fValOffset, CSLConstList papszOptions,
                GDALProgressFunc pfnProgress, void *pProgressData);
     void WriteComplexPackingNoData();
 };
@@ -1693,7 +1693,7 @@ bool GRIB2Section567Writer::WritePNG()
 /************************************************************************/
 
 // See http://www.nco.ncep.noaa.gov/pmb/docs/grib2/grib2_temp5-40.shtml
-bool GRIB2Section567Writer::WriteJPEG2000(char **papszOptions)
+bool GRIB2Section567Writer::WriteJPEG2000(CSLConstList papszOptions)
 {
     float *pafData = GetFloatData();
     if (pafData == nullptr)
@@ -1882,7 +1882,7 @@ bool GRIB2Section567Writer::WriteJPEG2000(char **papszOptions)
 /*                               Write()                                */
 /************************************************************************/
 
-bool GRIB2Section567Writer::Write(float fValOffset, char **papszOptions,
+bool GRIB2Section567Writer::Write(float fValOffset, CSLConstList papszOptions,
                                   GDALProgressFunc pfnProgress,
                                   void *pProgressData)
 {
@@ -2106,7 +2106,7 @@ bool GRIB2Section567Writer::Write(float fValOffset, char **papszOptions,
 /*                           GetIDSOption()                             */
 /************************************************************************/
 
-static const char *GetIDSOption(char **papszOptions, GDALDataset *poSrcDS,
+static const char *GetIDSOption(CSLConstList papszOptions, GDALDataset *poSrcDS,
                                 int nBand, const char *pszKey,
                                 const char *pszDefault)
 {
@@ -2136,7 +2136,7 @@ static const char *GetIDSOption(char **papszOptions, GDALDataset *poSrcDS,
 /************************************************************************/
 
 static void WriteSection1(VSILFILE *fp, GDALDataset *poSrcDS, int nBand,
-                          char **papszOptions)
+                          CSLConstList papszOptions)
 {
     // Section 1: Identification Section
     WriteUInt32(fp, 21);  // section size
@@ -2318,7 +2318,7 @@ static float ComputeValOffset(int nTokens, char **papszTokens,
 /************************************************************************/
 
 static bool WriteSection4(VSILFILE *fp, GDALDataset *poSrcDS, int nBand,
-                          char **papszOptions, float &fValOffset)
+                          CSLConstList papszOptions, float &fValOffset)
 {
     // Section 4: Product Definition Section
     vsi_l_offset nStartSection4 = VSIFTellL(fp);
@@ -2562,7 +2562,7 @@ static bool WriteSection4(VSILFILE *fp, GDALDataset *poSrcDS, int nBand,
 
 GDALDataset *GRIBDataset::CreateCopy(const char *pszFilename,
                                      GDALDataset *poSrcDS, int /* bStrict */,
-                                     char **papszOptions,
+                                     CSLConstList papszOptions,
                                      GDALProgressFunc pfnProgress,
                                      void *pProgressData)
 

--- a/frmts/grib/gribdataset.h
+++ b/frmts/grib/gribdataset.h
@@ -76,7 +76,7 @@ class GRIBDataset final : public GDALPamDataset
     static int Identify(GDALOpenInfo *);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 

--- a/frmts/gsg/gs7bgdataset.cpp
+++ b/frmts/gsg/gs7bgdataset.cpp
@@ -64,11 +64,10 @@ class GS7BGDataset final : public GDALPamDataset
     static int Identify(GDALOpenInfo *);
     static GDALDataset *Open(GDALOpenInfo *);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
-                               int nBandsIn, GDALDataType eType,
-                               char **papszParamList);
+                               int nBandsIn, GDALDataType eType, CSLConstList);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 
@@ -1051,7 +1050,7 @@ static bool GS7BGCreateCheckDims(int nXSize, int nYSize)
 
 GDALDataset *GS7BGDataset::Create(const char *pszFilename, int nXSize,
                                   int nYSize, int nBandsIn, GDALDataType eType,
-                                  char ** /* papszParamList*/)
+                                  CSLConstList /* papszParamList*/)
 
 {
     if (!GS7BGCreateCheckDims(nXSize, nYSize))
@@ -1124,7 +1123,7 @@ GDALDataset *GS7BGDataset::Create(const char *pszFilename, int nXSize,
 
 GDALDataset *GS7BGDataset::CreateCopy(const char *pszFilename,
                                       GDALDataset *poSrcDS, int bStrict,
-                                      char ** /*papszOptions*/,
+                                      CSLConstList /*papszOptions*/,
                                       GDALProgressFunc pfnProgress,
                                       void *pProgressData)
 {

--- a/frmts/gsg/gsagdataset.cpp
+++ b/frmts/gsg/gsagdataset.cpp
@@ -60,7 +60,7 @@ class GSAGDataset final : public GDALPamDataset
     static GDALDataset *Open(GDALOpenInfo *);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 
@@ -1440,7 +1440,7 @@ CPLErr GSAGDataset::UpdateHeader()
 
 GDALDataset *GSAGDataset::CreateCopy(const char *pszFilename,
                                      GDALDataset *poSrcDS, int bStrict,
-                                     CPL_UNUSED char **papszOptions,
+                                     CPL_UNUSED CSLConstList papszOptions,
                                      GDALProgressFunc pfnProgress,
                                      void *pProgressData)
 {

--- a/frmts/gsg/gsbgdataset.cpp
+++ b/frmts/gsg/gsbgdataset.cpp
@@ -55,11 +55,10 @@ class GSBGDataset final : public GDALPamDataset
     static int Identify(GDALOpenInfo *);
     static GDALDataset *Open(GDALOpenInfo *);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
-                               int nBands, GDALDataType eType,
-                               char **papszParamList);
+                               int nBands, GDALDataType eType, CSLConstList);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 
@@ -810,8 +809,7 @@ static bool GSBGCreateCheckDims(int nXSize, int nYSize)
 
 GDALDataset *GSBGDataset::Create(const char *pszFilename, int nXSize,
                                  int nYSize, int /* nBands */,
-                                 GDALDataType eType,
-                                 CPL_UNUSED char **papszParamList)
+                                 GDALDataType eType, CSLConstList)
 {
     if (!GSBGCreateCheckDims(nXSize, nYSize))
     {
@@ -874,7 +872,7 @@ GDALDataset *GSBGDataset::Create(const char *pszFilename, int nXSize,
 
 GDALDataset *GSBGDataset::CreateCopy(const char *pszFilename,
                                      GDALDataset *poSrcDS, int bStrict,
-                                     CPL_UNUSED char **papszOptions,
+                                     CPL_UNUSED CSLConstList papszOptions,
                                      GDALProgressFunc pfnProgress,
                                      void *pProgressData)
 {

--- a/frmts/gta/gtadataset.cpp
+++ b/frmts/gta/gtadataset.cpp
@@ -1282,7 +1282,7 @@ GDALDataset *GTADataset::Open(GDALOpenInfo *poOpenInfo)
 /************************************************************************/
 
 static GDALDataset *GTACreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
-                                  int bStrict, char **papszOptions,
+                                  int bStrict, CSLConstList papszOptions,
                                   GDALProgressFunc pfnProgress,
                                   void *pProgressData)
 

--- a/frmts/gtiff/cogdriver.cpp
+++ b/frmts/gtiff/cogdriver.cpp
@@ -1406,7 +1406,7 @@ GDALCOGCreator::Create(const char *pszFilename, GDALDataset *const poSrcDS,
 /************************************************************************/
 
 static GDALDataset *COGCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
-                                  int /*bStrict*/, char **papszOptions,
+                                  int /*bStrict*/, CSLConstList papszOptions,
                                   GDALProgressFunc pfnProgress,
                                   void *pProgressData)
 {
@@ -1516,7 +1516,7 @@ CPLErr COGProxyDataset::Close(GDALProgressFunc pfnProgress, void *pProgressData)
 
 static GDALDataset *COGCreate(const char *pszFilename, int nXSize, int nYSize,
                               int nBands, GDALDataType eType,
-                              char **papszOptions)
+                              CSLConstList papszOptions)
 {
     const std::string osTmpFile(GetTmpFilename(pszFilename, "create.tif"));
     CPLStringList aosOptions;

--- a/frmts/gtiff/gtiffdataset.h
+++ b/frmts/gtiff/gtiffdataset.h
@@ -389,7 +389,7 @@ class GTiffDataset final : public GDALPamDataset
     std::tuple<CPLErr, bool> Finalize();
 
     void DiscardLsb(GByte *pabyBuffer, GPtrDiff_t nBytes, int iBand) const;
-    void GetDiscardLsbOption(char **papszOptions);
+    void GetDiscardLsbOption(CSLConstList papszOptions);
     void InitCompressionThreads(bool bUpdateMode, CSLConstList papszOptions);
     void InitCreationOrOpenOptions(bool bUpdateMode, CSLConstList papszOptions);
     static void ThreadCompressionFunc(void *pData);
@@ -547,10 +547,10 @@ class GTiffDataset final : public GDALPamDataset
     static int Identify(GDALOpenInfo *);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBands, GDALDataType eType,
-                               char **papszParamList);
+                               CSLConstList papszParamList);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
     CPLErr FlushCache(bool bAtClosing) override;
@@ -583,15 +583,17 @@ class GTiffDataset final : public GDALPamDataset
     static TIFF *CreateLL(const char *pszFilename, int nXSize, int nYSize,
                           int nBands, GDALDataType eType,
                           double dfExtraSpaceForOverviews,
-                          int nColorTableMultiplier, char **papszParamList,
-                          VSILFILE **pfpL, CPLString &osTmpFilename,
-                          bool bCreateCopy, bool &bTileInterleavingOut);
+                          int nColorTableMultiplier,
+                          CSLConstList papszParamList, VSILFILE **pfpL,
+                          CPLString &osTmpFilename, bool bCreateCopy,
+                          bool &bTileInterleavingOut);
 
     CPLErr WriteEncodedTileOrStrip(uint32_t tile_or_strip, void *data,
                                    int bPreserveDataBuffer);
 
     static void SaveICCProfile(GTiffDataset *pDS, TIFF *hTIFF,
-                               char **papszParamList, uint32_t nBitsPerSample);
+                               CSLConstList papszParamList,
+                               uint32_t nBitsPerSample);
 
     static const GTIFFTag *GetTIFFTags();
 

--- a/frmts/gtiff/gtiffdataset_write.cpp
+++ b/frmts/gtiff/gtiffdataset_write.cpp
@@ -4910,7 +4910,7 @@ void GTiffDataset::UnsetNoDataValue(TIFF *l_hTIFF)
 /************************************************************************/
 
 void GTiffDataset::SaveICCProfile(GTiffDataset *pDS, TIFF *l_hTIFF,
-                                  char **papszParamList,
+                                  CSLConstList papszParamList,
                                   uint32_t l_nBitsPerSample)
 {
     if ((pDS != nullptr) && (pDS->eAccess != GA_Update))
@@ -5160,7 +5160,7 @@ void GTiffDataset::SaveICCProfile(GTiffDataset *pDS, TIFF *l_hTIFF,
     }
 }
 
-static signed char GTiffGetLZMAPreset(char **papszOptions)
+static signed char GTiffGetLZMAPreset(CSLConstList papszOptions)
 {
     int nLZMAPreset = -1;
     const char *pszValue = CSLFetchNameValue(papszOptions, "LZMA_PRESET");
@@ -5178,7 +5178,7 @@ static signed char GTiffGetLZMAPreset(char **papszOptions)
     return static_cast<signed char>(nLZMAPreset);
 }
 
-static signed char GTiffGetZSTDPreset(char **papszOptions)
+static signed char GTiffGetZSTDPreset(CSLConstList papszOptions)
 {
     int nZSTDLevel = -1;
     const char *pszValue = CSLFetchNameValue(papszOptions, "ZSTD_LEVEL");
@@ -5195,7 +5195,7 @@ static signed char GTiffGetZSTDPreset(char **papszOptions)
     return static_cast<signed char>(nZSTDLevel);
 }
 
-static signed char GTiffGetZLevel(char **papszOptions)
+static signed char GTiffGetZLevel(CSLConstList papszOptions)
 {
     int nZLevel = -1;
     const char *pszValue = CSLFetchNameValue(papszOptions, "ZLEVEL");
@@ -5227,7 +5227,7 @@ static signed char GTiffGetZLevel(char **papszOptions)
     return static_cast<signed char>(nZLevel);
 }
 
-static signed char GTiffGetJpegQuality(char **papszOptions)
+static signed char GTiffGetJpegQuality(CSLConstList papszOptions)
 {
     int nJpegQuality = -1;
     const char *pszValue = CSLFetchNameValue(papszOptions, "JPEG_QUALITY");
@@ -5245,7 +5245,7 @@ static signed char GTiffGetJpegQuality(char **papszOptions)
     return static_cast<signed char>(nJpegQuality);
 }
 
-static signed char GTiffGetJpegTablesMode(char **papszOptions)
+static signed char GTiffGetJpegTablesMode(CSLConstList papszOptions)
 {
     return static_cast<signed char>(atoi(
         CSLFetchNameValueDef(papszOptions, "JPEGTABLESMODE",
@@ -5257,7 +5257,7 @@ static signed char GTiffGetJpegTablesMode(char **papszOptions)
 /************************************************************************/
 
 static GTiffDataset::MaskOffset *GetDiscardLsbOption(TIFF *hTIFF,
-                                                     char **papszOptions)
+                                                     CSLConstList papszOptions)
 {
     const char *pszBits = CSLFetchNameValue(papszOptions, "DISCARD_LSB");
     if (pszBits == nullptr)
@@ -5337,7 +5337,7 @@ static GTiffDataset::MaskOffset *GetDiscardLsbOption(TIFF *hTIFF,
     return panMaskOffsetLsb;
 }
 
-void GTiffDataset::GetDiscardLsbOption(char **papszOptions)
+void GTiffDataset::GetDiscardLsbOption(CSLConstList papszOptions)
 {
     m_panMaskOffsetLsb = ::GetDiscardLsbOption(m_hTIFF, papszOptions);
 }
@@ -5375,9 +5375,10 @@ static GTiffProfile GetProfile(const char *pszProfile)
 TIFF *GTiffDataset::CreateLL(const char *pszFilename, int nXSize, int nYSize,
                              int l_nBands, GDALDataType eType,
                              double dfExtraSpaceForOverviews,
-                             int nColorTableMultiplier, char **papszParamList,
-                             VSILFILE **pfpL, CPLString &l_osTmpFilename,
-                             bool bCreateCopy, bool &bTileInterleavingOut)
+                             int nColorTableMultiplier,
+                             CSLConstList papszParamList, VSILFILE **pfpL,
+                             CPLString &l_osTmpFilename, bool bCreateCopy,
+                             bool &bTileInterleavingOut)
 
 {
     bTileInterleavingOut = false;
@@ -6753,7 +6754,7 @@ void GTiffDataset::SetJPEGQualityAndTablesModeFromFile(
 
 GDALDataset *GTiffDataset::Create(const char *pszFilename, int nXSize,
                                   int nYSize, int l_nBands, GDALDataType eType,
-                                  char **papszParamList)
+                                  CSLConstList papszParamList)
 
 {
     VSILFILE *l_fpL = nullptr;
@@ -7312,7 +7313,7 @@ CPLErr GTiffDataset::CopyImageryAndMask(GTiffDataset *poDstDS,
 
 GDALDataset *GTiffDataset::CreateCopy(const char *pszFilename,
                                       GDALDataset *poSrcDS, int bStrict,
-                                      char **papszOptions,
+                                      CSLConstList papszOptions,
                                       GDALProgressFunc pfnProgress,
                                       void *pProgressData)
 

--- a/frmts/gtiff/gtiffrasterband.h
+++ b/frmts/gtiff/gtiffrasterband.h
@@ -55,7 +55,7 @@ class GTiffRasterBand CPL_NON_FINAL : public GDALPamRasterBand
     CPLVirtualMem *GetVirtualMemAutoInternal(GDALRWFlag eRWFlag,
                                              int *pnPixelSpace,
                                              GIntBig *pnLineSpace,
-                                             char **papszOptions);
+                                             CSLConstList papszOptions);
 
   protected:
     GTiffDataset *m_poGDS = nullptr;
@@ -147,7 +147,8 @@ class GTiffRasterBand CPL_NON_FINAL : public GDALPamRasterBand
 
     virtual CPLVirtualMem *
     GetVirtualMemAuto(GDALRWFlag eRWFlag, int *pnPixelSpace,
-                      GIntBig *pnLineSpace, char **papszOptions) override final;
+                      GIntBig *pnLineSpace,
+                      CSLConstList papszOptions) override final;
 
     GDALRasterAttributeTable *GetDefaultRAT() override final;
     virtual CPLErr

--- a/frmts/gtiff/gtiffrasterband_read.cpp
+++ b/frmts/gtiff/gtiffrasterband_read.cpp
@@ -351,7 +351,7 @@ int GTiffRasterBand::DirectIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
 CPLVirtualMem *GTiffRasterBand::GetVirtualMemAuto(GDALRWFlag eRWFlag,
                                                   int *pnPixelSpace,
                                                   GIntBig *pnLineSpace,
-                                                  char **papszOptions)
+                                                  CSLConstList papszOptions)
 {
     const char *pszImpl = CSLFetchNameValueDef(
         papszOptions, "USE_DEFAULT_IMPLEMENTATION", "AUTO");
@@ -410,10 +410,9 @@ void GTiffRasterBand::DropReferenceVirtualMem(void *pUserData)
 /*                     GetVirtualMemAutoInternal()                      */
 /************************************************************************/
 
-CPLVirtualMem *GTiffRasterBand::GetVirtualMemAutoInternal(GDALRWFlag eRWFlag,
-                                                          int *pnPixelSpace,
-                                                          GIntBig *pnLineSpace,
-                                                          char **papszOptions)
+CPLVirtualMem *GTiffRasterBand::GetVirtualMemAutoInternal(
+    GDALRWFlag eRWFlag, int *pnPixelSpace, GIntBig *pnLineSpace,
+    CSLConstList papszOptions)
 {
     int nLineSize = nBlockXSize * GDALGetDataTypeSizeBytes(eDataType);
     if (m_poGDS->m_nPlanarConfig == PLANARCONFIG_CONTIG)

--- a/frmts/hdf4/hdf4imagedataset.cpp
+++ b/frmts/hdf4/hdf4imagedataset.cpp
@@ -146,7 +146,7 @@ class HDF4ImageDataset final : public HDF4Dataset
     static GDALDataset *Open(GDALOpenInfo *);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBandsIn, GDALDataType eType,
-                               char **papszParamList);
+                               CSLConstList papszParamList);
     CPLErr FlushCache(bool bAtClosing) override;
     CPLErr GetGeoTransform(GDALGeoTransform &gt) const override;
     CPLErr SetGeoTransform(const GDALGeoTransform &gt) override;
@@ -3775,7 +3775,8 @@ GDALDataset *HDF4ImageDataset::Open(GDALOpenInfo *poOpenInfo)
 
 GDALDataset *HDF4ImageDataset::Create(const char *pszFilename, int nXSize,
                                       int nYSize, int nBandsIn,
-                                      GDALDataType eType, char **papszOptions)
+                                      GDALDataType eType,
+                                      CSLConstList papszOptions)
 
 {
     /* -------------------------------------------------------------------- */

--- a/frmts/hdf5/s102dataset.cpp
+++ b/frmts/hdf5/s102dataset.cpp
@@ -52,7 +52,7 @@ class S102Dataset final : public S100BaseDataset
     static GDALDataset *Open(GDALOpenInfo *);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 };
@@ -1936,7 +1936,7 @@ bool S102Creator::CopyQualityValues(GDALDataset *poQualityDS,
 /* static */
 GDALDataset *S102Dataset::CreateCopy(const char *pszFilename,
                                      GDALDataset *poSrcDS, int /* bStrict*/,
-                                     char **papszOptions,
+                                     CSLConstList papszOptions,
                                      GDALProgressFunc pfnProgress,
                                      void *pProgressData)
 {

--- a/frmts/hdf5/s104dataset.cpp
+++ b/frmts/hdf5/s104dataset.cpp
@@ -48,7 +48,7 @@ class S104Dataset final : public S100BaseDataset
     static GDALDataset *Open(GDALOpenInfo *);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 };
@@ -1756,7 +1756,7 @@ static void S104DatasetDriverUnload(GDALDriver *)
 /* static */
 GDALDataset *S104Dataset::CreateCopy(const char *pszFilename,
                                      GDALDataset *poSrcDS, int /* bStrict*/,
-                                     char **papszOptions,
+                                     CSLConstList papszOptions,
                                      GDALProgressFunc pfnProgress,
                                      void *pProgressData)
 {

--- a/frmts/hdf5/s111dataset.cpp
+++ b/frmts/hdf5/s111dataset.cpp
@@ -49,7 +49,7 @@ class S111Dataset final : public S100BaseDataset
     static GDALDataset *Open(GDALOpenInfo *);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 };
@@ -1913,7 +1913,7 @@ bool S111Creator::CopyValues(GDALDataset *poSrcDS, GDALProgressFunc pfnProgress,
 /* static */
 GDALDataset *S111Dataset::CreateCopy(const char *pszFilename,
                                      GDALDataset *poSrcDS, int /* bStrict*/,
-                                     char **papszOptions,
+                                     CSLConstList papszOptions,
                                      GDALProgressFunc pfnProgress,
                                      void *pProgressData)
 {

--- a/frmts/heif/heifdataset.h
+++ b/frmts/heif/heifdataset.h
@@ -101,7 +101,7 @@ class GDALHEIFDataset final : public GDALPamDataset
 #ifdef HAS_CUSTOM_FILE_WRITER
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 #endif

--- a/frmts/heif/heifdatasetcreatecopy.cpp
+++ b/frmts/heif/heifdatasetcreatecopy.cpp
@@ -143,7 +143,7 @@ heif_error GDALHEIFDataset::VFS_WriterCallback(struct heif_context *,
 /************************************************************************/
 GDALDataset *
 GDALHEIFDataset::CreateCopy(const char *pszFilename, GDALDataset *poSrcDS, int,
-                            CPL_UNUSED char **papszOptions,
+                            CPL_UNUSED CSLConstList papszOptions,
                             CPL_UNUSED GDALProgressFunc pfnProgress,
                             CPL_UNUSED void *pProgressData)
 {

--- a/frmts/hf2/hf2dataset.cpp
+++ b/frmts/hf2/hf2dataset.cpp
@@ -57,7 +57,7 @@ class HF2Dataset final : public GDALPamDataset
     static int Identify(GDALOpenInfo *);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 };
@@ -717,7 +717,7 @@ static void WriteDouble(VSILFILE *fp, double val)
 
 GDALDataset *HF2Dataset::CreateCopy(const char *pszFilename,
                                     GDALDataset *poSrcDS, int bStrict,
-                                    char **papszOptions,
+                                    CSLConstList papszOptions,
                                     GDALProgressFunc pfnProgress,
                                     void *pProgressData)
 {

--- a/frmts/hfa/hfa.h
+++ b/frmts/hfa/hfa.h
@@ -147,7 +147,8 @@ CPLErr HFARenameReferences(HFAHandle, const char *, const char *);
 
 HFAHandle CPL_DLL HFACreateLL(const char *pszFilename);
 HFAHandle CPL_DLL HFACreate(const char *pszFilename, int nXSize, int nYSize,
-                            int nBands, EPTType eDataType, char **papszOptions);
+                            int nBands, EPTType eDataType,
+                            CSLConstList papszOptions);
 CPLErr CPL_DLL HFAFlush(HFAHandle);
 int CPL_DLL HFACreateOverview(HFAHandle hHFA, int nBand, int nOverviewLevel,
                               const char *pszResampling);

--- a/frmts/hfa/hfa_p.h
+++ b/frmts/hfa/hfa_p.h
@@ -113,7 +113,7 @@ int CPL_DLL HFACreateLayer(HFAHandle psInfo, HFAEntry *poParent,
                            int nBlockSize, int bCreateCompressed,
                            int bCreateLargeRaster, int bDependentLayer,
                            int nXSize, int nYSize, EPTType eDataType,
-                           char **papszOptions,
+                           CSLConstList papszOptions,
 
                            // These are only related to external (large) files.
                            GIntBig nStackValidFlagsOffset,

--- a/frmts/hfa/hfadataset.cpp
+++ b/frmts/hfa/hfadataset.cpp
@@ -5016,7 +5016,7 @@ char **HFADataset::GetFileList()
 
 GDALDataset *HFADataset::Create(const char *pszFilenameIn, int nXSize,
                                 int nYSize, int nBandsIn, GDALDataType eType,
-                                char **papszParamList)
+                                CSLConstList papszParamList)
 
 {
     const int nBits = CSLFetchNameValue(papszParamList, "NBITS") != nullptr
@@ -5223,7 +5223,7 @@ CPLErr HFADataset::CopyFiles(const char *pszNewName, const char *pszOldName)
 
 GDALDataset *HFADataset::CreateCopy(const char *pszFilename,
                                     GDALDataset *poSrcDS, int /* bStrict */,
-                                    char **papszOptions,
+                                    CSLConstList papszOptions,
                                     GDALProgressFunc pfnProgress,
                                     void *pProgressData)
 {

--- a/frmts/hfa/hfadataset.h
+++ b/frmts/hfa/hfadataset.h
@@ -73,10 +73,10 @@ class HFADataset final : public GDALPamDataset
     static GDALDataset *Open(GDALOpenInfo *);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBands, GDALDataType eType,
-                               char **papszParamList);
+                               CSLConstList papszParamList);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
     static CPLErr Delete(const char *pszFilename);

--- a/frmts/hfa/hfaopen.cpp
+++ b/frmts/hfa/hfaopen.cpp
@@ -2000,7 +2000,7 @@ int HFACreateLayer(HFAHandle psInfo, HFAEntry *poParent,
                    const char *pszLayerName, int bOverview, int nBlockSize,
                    int bCreateCompressed, int bCreateLargeRaster,
                    int bDependentLayer, int nXSize, int nYSize,
-                   EPTType eDataType, char ** /* papszOptions */,
+                   EPTType eDataType, CSLConstList /* papszOptions */,
                    // These are only related to external (large) files.
                    GIntBig nStackValidFlagsOffset, GIntBig nStackDataOffset,
                    int nStackCount, int nStackIndex)
@@ -2237,7 +2237,7 @@ int HFACreateLayer(HFAHandle psInfo, HFAEntry *poParent,
 /************************************************************************/
 
 HFAHandle HFACreate(const char *pszFilename, int nXSize, int nYSize, int nBands,
-                    EPTType eDataType, char **papszOptions)
+                    EPTType eDataType, CSLConstList papszOptions)
 
 {
     if (nXSize == 0 || nYSize == 0)

--- a/frmts/idrisi/IdrisiDataset.cpp
+++ b/frmts/idrisi/IdrisiDataset.cpp
@@ -400,10 +400,10 @@ class IdrisiDataset final : public GDALPamDataset
     static GDALDataset *Open(GDALOpenInfo *poOpenInfo);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBands, GDALDataType eType,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
     char **GetFileList(void) override;
@@ -848,7 +848,7 @@ GDALDataset *IdrisiDataset::Open(GDALOpenInfo *poOpenInfo)
 
 GDALDataset *IdrisiDataset::Create(const char *pszFilename, int nXSize,
                                    int nYSize, int nBandsIn, GDALDataType eType,
-                                   char ** /* papszOptions */)
+                                   CSLConstList /* papszOptions */)
 {
     // --------------------------------------------------------------------
     //      Check input options
@@ -1001,7 +1001,7 @@ GDALDataset *IdrisiDataset::Create(const char *pszFilename, int nXSize,
 
 GDALDataset *IdrisiDataset::CreateCopy(const char *pszFilename,
                                        GDALDataset *poSrcDS, int bStrict,
-                                       char **papszOptions,
+                                       CSLConstList papszOptions,
                                        GDALProgressFunc pfnProgress,
                                        void *pProgressData)
 {

--- a/frmts/ilwis/ilwisdataset.cpp
+++ b/frmts/ilwis/ilwisdataset.cpp
@@ -886,7 +886,7 @@ CPLErr ILWISDataset::FlushCache(bool bAtClosing)
 
 GDALDataset *ILWISDataset::Create(const char *pszFilename, int nXSize,
                                   int nYSize, int nBandsIn, GDALDataType eType,
-                                  CPL_UNUSED char **papszParamList)
+                                  CSLConstList)
 {
     /* -------------------------------------------------------------------- */
     /*      Verify input options.                                           */
@@ -1057,7 +1057,7 @@ GDALDataset *ILWISDataset::Create(const char *pszFilename, int nXSize,
 
 GDALDataset *ILWISDataset::CreateCopy(const char *pszFilename,
                                       GDALDataset *poSrcDS, int /* bStrict */,
-                                      char **papszOptions,
+                                      CSLConstList papszOptions,
                                       GDALProgressFunc pfnProgress,
                                       void *pProgressData)
 

--- a/frmts/ilwis/ilwisdataset.h
+++ b/frmts/ilwis/ilwisdataset.h
@@ -166,13 +166,12 @@ class ILWISDataset final : public GDALPamDataset
 
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
-                               int nBands, GDALDataType eType,
-                               char **papszParamList);
+                               int nBands, GDALDataType eType, CSLConstList);
 
     CPLErr GetGeoTransform(GDALGeoTransform &gt) const override;
     CPLErr SetGeoTransform(const GDALGeoTransform &gt) override;

--- a/frmts/jp2kak/jp2kakdataset.cpp
+++ b/frmts/jp2kak/jp2kakdataset.cpp
@@ -2030,7 +2030,7 @@ static bool JP2KAKCreateCopy_WriteTile(
 
 static GDALDataset *JP2KAKCreateCopy(const char *pszFilename,
                                      GDALDataset *poSrcDS, int bStrict,
-                                     char **papszOptions,
+                                     CSLConstList papszOptions,
                                      GDALProgressFunc pfnProgress,
                                      void *pProgressData)
 

--- a/frmts/jpeg/jpgdataset.cpp
+++ b/frmts/jpeg/jpgdataset.cpp
@@ -4342,11 +4342,12 @@ CPLErr JPGAppendMask(const char *pszJPGFilename, GDALRasterBand *poMask,
 /*                             JPGAddEXIF()                             */
 /************************************************************************/
 
-void JPGAddEXIF(GDALDataType eWorkDT, GDALDataset *poSrcDS, char **papszOptions,
-                void *cinfo, my_jpeg_write_m_header p_jpeg_write_m_header,
+void JPGAddEXIF(GDALDataType eWorkDT, GDALDataset *poSrcDS,
+                CSLConstList papszOptions, void *cinfo,
+                my_jpeg_write_m_header p_jpeg_write_m_header,
                 my_jpeg_write_m_byte p_jpeg_write_m_byte,
                 GDALDataset *(pCreateCopy)(const char *, GDALDataset *, int,
-                                           char **,
+                                           CSLConstList,
                                            GDALProgressFunc pfnProgress,
                                            void *pProgressData))
 {
@@ -4487,7 +4488,7 @@ void JPGAddEXIF(GDALDataType eWorkDT, GDALDataset *poSrcDS, char **papszOptions,
 
 GDALDataset *JPGDataset::CreateCopy(const char *pszFilename,
                                     GDALDataset *poSrcDS, int bStrict,
-                                    char **papszOptions,
+                                    CSLConstList papszOptions,
                                     GDALProgressFunc pfnProgress,
                                     void *pProgressData)
 
@@ -4922,7 +4923,7 @@ GDALDataset *JPGDataset::CreateCopy(const char *pszFilename,
 }
 
 GDALDataset *JPGDataset::CreateCopyStage2(
-    const char *pszFilename, GDALDataset *poSrcDS, char **papszOptions,
+    const char *pszFilename, GDALDataset *poSrcDS, CSLConstList papszOptions,
     GDALProgressFunc pfnProgress, void *pProgressData,
     VSIVirtualHandleUniquePtr fpImage, GDALDataType eDT, int nQuality,
     bool bAppendMask, GDALJPEGUserData &sUserData,

--- a/frmts/jpeg/jpgdataset.h
+++ b/frmts/jpeg/jpgdataset.h
@@ -96,7 +96,7 @@ class JPGDatasetCommon;
 JPGDatasetCommon *JPEGDataset12Open(JPGDatasetOpenArgs *psArgs);
 GDALDataset *JPEGDataset12CreateCopy(const char *pszFilename,
                                      GDALDataset *poSrcDS, int bStrict,
-                                     char **papszOptions,
+                                     CSLConstList papszOptions,
                                      GDALProgressFunc pfnProgress,
                                      void *pProgressData);
 #endif
@@ -109,11 +109,12 @@ typedef void (*my_jpeg_write_m_byte)(void *cinfo, int val);
 
 CPLErr JPGAppendMask(const char *pszJPGFilename, GDALRasterBand *poMask,
                      GDALProgressFunc pfnProgress, void *pProgressData);
-void JPGAddEXIF(GDALDataType eWorkDT, GDALDataset *poSrcDS, char **papszOptions,
-                void *cinfo, my_jpeg_write_m_header p_jpeg_write_m_header,
+void JPGAddEXIF(GDALDataType eWorkDT, GDALDataset *poSrcDS,
+                CSLConstList papszOptions, void *cinfo,
+                my_jpeg_write_m_header p_jpeg_write_m_header,
                 my_jpeg_write_m_byte p_jpeg_write_m_byte,
                 GDALDataset *(pCreateCopy)(const char *, GDALDataset *, int,
-                                           char **,
+                                           CSLConstList,
                                            GDALProgressFunc pfnProgress,
                                            void *pProgressData));
 void JPGAddICCProfile(void *pInfo, const char *pszICCProfile,
@@ -353,12 +354,12 @@ class JPGDataset final : public JPGDatasetCommon
     static JPGDatasetCommon *Open(JPGDatasetOpenArgs *psArgs);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
     static GDALDataset *
     CreateCopyStage2(const char *pszFilename, GDALDataset *poSrcDS,
-                     char **papszOptions, GDALProgressFunc pfnProgress,
+                     CSLConstList papszOptions, GDALProgressFunc pfnProgress,
                      void *pProgressData, VSIVirtualHandleUniquePtr fpImage,
                      GDALDataType eDT, int nQuality, bool bAppendMask,
                      GDALJPEGUserData &sUserData,

--- a/frmts/jpeg/jpgdataset_12.cpp
+++ b/frmts/jpeg/jpgdataset_12.cpp
@@ -26,7 +26,7 @@
 JPGDatasetCommon *JPEGDataset12Open(JPGDatasetOpenArgs *psArgs);
 GDALDataset *JPEGDataset12CreateCopy(const char *pszFilename,
                                      GDALDataset *poSrcDS, int bStrict,
-                                     char **papszOptions,
+                                     CSLConstList papszOptions,
                                      GDALProgressFunc pfnProgress,
                                      void *pProgressData);
 
@@ -37,7 +37,7 @@ JPGDatasetCommon *JPEGDataset12Open(JPGDatasetOpenArgs *psArgs)
 
 GDALDataset *JPEGDataset12CreateCopy(const char *pszFilename,
                                      GDALDataset *poSrcDS, int bStrict,
-                                     char **papszOptions,
+                                     CSLConstList papszOptions,
                                      GDALProgressFunc pfnProgress,
                                      void *pProgressData)
 {

--- a/frmts/jpegxl/jpegxl.cpp
+++ b/frmts/jpegxl/jpegxl.cpp
@@ -104,7 +104,7 @@ class JPEGXLDataset final : public GDALJP2AbstractDataset
     static GDALDataset *OpenStatic(GDALOpenInfo *poOpenInfo);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 };
@@ -1744,7 +1744,7 @@ GDALDataset *JPEGXLDataset::OpenStatic(GDALOpenInfo *poOpenInfo)
 
 GDALDataset *JPEGXLDataset::CreateCopy(const char *pszFilename,
                                        GDALDataset *poSrcDS, int /*bStrict*/,
-                                       char **papszOptions,
+                                       CSLConstList papszOptions,
                                        GDALProgressFunc pfnProgress,
                                        void *pProgressData)
 

--- a/frmts/jpipkak/jpipkakdataset.cpp
+++ b/frmts/jpipkak/jpipkakdataset.cpp
@@ -1215,7 +1215,7 @@ int JPIPKAKDataset::TestUseBlockIO(CPL_UNUSED int nXOff, CPL_UNUSED int nYOff,
 GDALAsyncReader *JPIPKAKDataset::BeginAsyncReader(
     int xOff, int yOff, int xSize, int ySize, void *pBuf, int bufXSize,
     int bufYSize, GDALDataType bufType, int nBandCount, int *pBandMap,
-    int nPixelSpace, int nLineSpace, int nBandSpace, char **papszOptions)
+    int nPixelSpace, int nLineSpace, int nBandSpace, CSLConstList papszOptions)
 {
     CPLDebug("JPIP", "BeginAsyncReadeR(%d,%d,%d,%d -> %dx%d)", xOff, yOff,
              xSize, ySize, bufXSize, bufYSize);

--- a/frmts/jpipkak/jpipkakdataset.h
+++ b/frmts/jpipkak/jpipkakdataset.h
@@ -218,7 +218,7 @@ class JPIPKAKDataset final : public GDALPamDataset
                      int bufXSize, int bufYSize, GDALDataType bufType,
                      int nBandCount, int *bandMap, int nPixelSpace,
                      int nLineSpace, int nBandSpace,
-                     char **papszOptions) override;
+                     CSLConstList papszOptions) override;
 
     void EndAsyncReader(GDALAsyncReader *) override;
 

--- a/frmts/kea/keadataset.cpp
+++ b/frmts/kea/keadataset.cpp
@@ -183,7 +183,7 @@ GDALDataset *KEADataset::Open(GDALOpenInfo *poOpenInfo)
 // static function
 H5::H5File *KEADataset::CreateLL(const char *pszFilename, int nXSize,
                                  int nYSize, int nBandsIn, GDALDataType eType,
-                                 char **papszParamList)
+                                 CSLConstList papszParamList)
 {
     GDALDriverH hDriver = GDALGetDriverByName("KEA");
     if ((hDriver == nullptr) ||
@@ -294,7 +294,7 @@ H5::H5File *KEADataset::CreateLL(const char *pszFilename, int nXSize,
 // static function- pointer set in driver
 GDALDataset *KEADataset::Create(const char *pszFilename, int nXSize, int nYSize,
                                 int nBandsIn, GDALDataType eType,
-                                char **papszParamList)
+                                CSLConstList papszParamList)
 {
     H5::H5File *keaImgH5File =
         CreateLL(pszFilename, nXSize, nYSize, nBandsIn, eType, papszParamList);
@@ -334,7 +334,7 @@ GDALDataset *KEADataset::Create(const char *pszFilename, int nXSize, int nYSize,
 
 GDALDataset *KEADataset::CreateCopy(const char *pszFilename,
                                     GDALDataset *pSrcDs, CPL_UNUSED int bStrict,
-                                    char **papszParamList,
+                                    CSLConstList papszParamList,
                                     GDALProgressFunc pfnProgress,
                                     void *pProgressData)
 {
@@ -770,7 +770,7 @@ CPLErr KEADataset::SetMetadata(CSLConstList papszMetadata,
     return CE_None;
 }
 
-CPLErr KEADataset::AddBand(GDALDataType eType, char **papszOptions)
+CPLErr KEADataset::AddBand(GDALDataType eType, CSLConstList papszOptions)
 {
     // process any creation options in papszOptions
     unsigned int nimageBlockSize = kealib::KEA_IMAGE_CHUNK_SIZE;

--- a/frmts/kea/keadataset.h
+++ b/frmts/kea/keadataset.h
@@ -24,7 +24,7 @@ class KEADataset final : public GDALDataset
 {
     static H5::H5File *CreateLL(const char *pszFilename, int nXSize, int nYSize,
                                 int nBands, GDALDataType eType,
-                                char **papszParamList);
+                                CSLConstList papszParamList);
 
   public:
     // constructor/destructor
@@ -37,9 +37,9 @@ class KEADataset final : public GDALDataset
     static int Identify(GDALOpenInfo *poOpenInfo);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBands, GDALDataType eType,
-                               char **papszParamList);
+                               CSLConstList papszParamList);
     static GDALDataset *CreateCopy(const char *pszFilename, GDALDataset *pSrcDs,
-                                   int bStrict, char **papszParamList,
+                                   int bStrict, CSLConstList papszParamList,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 
@@ -64,7 +64,8 @@ class KEADataset final : public GDALDataset
                        const char *pszDomain = "") override;
 
     // virtual method for adding new image bands
-    CPLErr AddBand(GDALDataType eType, char **papszOptions = nullptr) override;
+    CPLErr AddBand(GDALDataType eType,
+                   CSLConstList papszOptions = nullptr) override;
 
     // GCPs
     int GetGCPCount() override;

--- a/frmts/kmlsuperoverlay/kmlsuperoverlaydataset.cpp
+++ b/frmts/kmlsuperoverlay/kmlsuperoverlaydataset.cpp
@@ -551,7 +551,7 @@ KmlSuperOverlayDummyDataset::~KmlSuperOverlayDummyDataset() = default;
 
 static GDALDataset *
 KmlSuperOverlayCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
-                          CPL_UNUSED int bStrict, char **papszOptions,
+                          CPL_UNUSED int bStrict, CSLConstList papszOptions,
                           GDALProgressFunc pfnProgress, void *pProgressData)
 {
     bool isKmz = false;

--- a/frmts/leveller/levellerdataset.cpp
+++ b/frmts/leveller/levellerdataset.cpp
@@ -286,7 +286,7 @@ class LevellerDataset final : public GDALPamDataset
     static int Identify(GDALOpenInfo *);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBandsIn, GDALDataType eType,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
 
     CPLErr GetGeoTransform(GDALGeoTransform &gt) const override;
 
@@ -827,7 +827,8 @@ CPLErr LevellerDataset::SetSpatialRef(const OGRSpatialReference *poSRS)
 /************************************************************************/
 GDALDataset *LevellerDataset::Create(const char *pszFilename, int nXSize,
                                      int nYSize, int nBandsIn,
-                                     GDALDataType eType, char **papszOptions)
+                                     GDALDataType eType,
+                                     CSLConstList papszOptions)
 {
     if (nBandsIn != 1)
     {

--- a/frmts/mbtiles/mbtilesdataset.cpp
+++ b/frmts/mbtiles/mbtilesdataset.cpp
@@ -129,10 +129,10 @@ class MBTilesDataset final : public GDALPamDataset,
     static int Identify(GDALOpenInfo *);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBandsIn, GDALDataType eDT,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 
@@ -170,7 +170,7 @@ class MBTilesDataset final : public GDALPamDataset,
     CPLString m_osClip;
     std::vector<std::unique_ptr<OGRLayer>> m_apoLayers;
 
-    void ParseCompressionOptions(char **papszOptions);
+    void ParseCompressionOptions(CSLConstList papszOptions);
     CPLErr FinalizeRasterRegistration();
     void ComputeTileAndPixelShifts();
     bool InitRaster(MBTilesDataset *poParentDS, int nZoomLevel, int nBandCount,
@@ -178,7 +178,8 @@ class MBTilesDataset final : public GDALPamDataset,
                     double dfGDALMaxX, double dfGDALMaxY);
 
     bool CreateInternal(const char *pszFilename, int nXSize, int nYSize,
-                        int nBandsIn, GDALDataType eDT, char **papszOptions);
+                        int nBandsIn, GDALDataType eDT,
+                        CSLConstList papszOptions);
     void InitVector(double dfMinX, double dfMinY, double dfMaxX, double dfMaxY,
                     bool bZoomLevelFromSpatialFilter, bool bJsonField);
 
@@ -2932,7 +2933,7 @@ end:
 
 GDALDataset *MBTilesDataset::Create(const char *pszFilename, int nXSize,
                                     int nYSize, int nBandsIn, GDALDataType eDT,
-                                    char **papszOptions)
+                                    CSLConstList papszOptions)
 {
 #ifdef HAVE_MVT_WRITE_SUPPORT
     if (nXSize == 0 && nYSize == 0 && nBandsIn == 0 && eDT == GDT_Unknown)
@@ -2962,7 +2963,7 @@ GDALDataset *MBTilesDataset::Create(const char *pszFilename, int nXSize,
 
 bool MBTilesDataset::CreateInternal(const char *pszFilename, int nXSize,
                                     int nYSize, int nBandsIn, GDALDataType eDT,
-                                    char **papszOptions)
+                                    CSLConstList papszOptions)
 {
     if (eDT != GDT_UInt8)
     {
@@ -3125,7 +3126,7 @@ static const WarpResamplingAlg asResamplingAlg[] = {
 
 GDALDataset *MBTilesDataset::CreateCopy(const char *pszFilename,
                                         GDALDataset *poSrcDS, int /*bStrict*/,
-                                        char **papszOptions,
+                                        CSLConstList papszOptions,
                                         GDALProgressFunc pfnProgress,
                                         void *pProgressData)
 {
@@ -3454,7 +3455,7 @@ GDALDataset *MBTilesDataset::CreateCopy(const char *pszFilename,
 /*                        ParseCompressionOptions()                     */
 /************************************************************************/
 
-void MBTilesDataset::ParseCompressionOptions(char **papszOptions)
+void MBTilesDataset::ParseCompressionOptions(CSLConstList papszOptions)
 {
     const char *pszZLevel = CSLFetchNameValue(papszOptions, "ZLEVEL");
     if (pszZLevel)

--- a/frmts/mem/memdataset.h
+++ b/frmts/mem/memdataset.h
@@ -76,7 +76,7 @@ class CPL_DLL MEMDataset CPL_NON_FINAL : public GDALDataset
     // cppcheck-suppress unusedPrivateFunction
     static GDALDataset *CreateBase(const char *pszFilename, int nXSize,
                                    int nYSize, int nBands, GDALDataType eType,
-                                   char **papszParamList);
+                                   CSLConstList papszParamList);
 
   protected:
     bool CanBeCloned(int nScopeFlags, bool bCanShareState) const override;
@@ -105,7 +105,7 @@ class CPL_DLL MEMDataset CPL_NON_FINAL : public GDALDataset
     CPLErr SetGCPs(int nGCPCount, const GDAL_GCP *pasGCPList,
                    const OGRSpatialReference *poSRS) override;
     virtual CPLErr AddBand(GDALDataType eType,
-                           char **papszOptions = nullptr) override;
+                           CSLConstList papszOptions = nullptr) override;
     CPLErr IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff, int nXSize,
                      int nYSize, void *pData, int nBufXSize, int nBufYSize,
                      GDALDataType eBufType, int nBandCount,
@@ -127,7 +127,7 @@ class CPL_DLL MEMDataset CPL_NON_FINAL : public GDALDataset
     static GDALDataset *Open(GDALOpenInfo *);
     static MEMDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                               int nBands, GDALDataType eType,
-                              char **papszParamList);
+                              CSLConstList papszParamList);
     static GDALDataset *
     CreateMultiDimensional(const char *pszFilename,
                            CSLConstList papszRootGroupOptions,

--- a/frmts/mrf/Tif_band.cpp
+++ b/frmts/mrf/Tif_band.cpp
@@ -72,7 +72,7 @@ static CPLString uniq_memfname(const char *prefix)
 // copies the content to the destination buffer then erases the temp TIF
 //
 static CPLErr CompressTIF(buf_mgr &dst, const buf_mgr &src, const ILImage &img,
-                          char **papszOptions)
+                          CSLConstList papszOptions)
 {
     CPLErr ret;
     GDALDriver *poTiffDriver = GetGDALDriverManager()->GetDriverByName("GTiff");

--- a/frmts/mrf/marfa.h
+++ b/frmts/mrf/marfa.h
@@ -377,13 +377,13 @@ class MRFDataset final : public GDALPamDataset
 
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 
     static GDALDataset *Create(const char *pszName, int nXSize, int nYSize,
                                int nBands, GDALDataType eType,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
 
     // Stub for delete, GDAL should only overwrite the XML
     static CPLErr Delete(const char *)
@@ -470,11 +470,11 @@ class MRFDataset final : public GDALPamDataset
     CPLXMLNode *ReadConfig() const;
 
     // Apply create options to the current dataset
-    void ProcessCreateOptions(char **papszOptions);
+    void ProcessCreateOptions(CSLConstList papszOptions);
 
     // Called once before the parsing of the XML, should just capture the
     // options in dataset variables
-    void ProcessOpenOptions(char **papszOptions);
+    void ProcessOpenOptions(CSLConstList papszOptions);
 
     // Writes the XML tree as MRF.  It does not check the content
     int WriteConfig(CPLXMLNode *);

--- a/frmts/mrf/marfa_dataset.cpp
+++ b/frmts/mrf/marfa_dataset.cpp
@@ -1731,7 +1731,7 @@ static char **CSLAddIfMissing(char **papszList, const char *pszName,
 // CreateCopy implemented based on Create
 GDALDataset *MRFDataset::CreateCopy(const char *pszFilename,
                                     GDALDataset *poSrcDS, int /*bStrict*/,
-                                    char **papszOptions,
+                                    CSLConstList papszOptions,
                                     GDALProgressFunc pfnProgress,
                                     void *pProgressData)
 {
@@ -2103,20 +2103,19 @@ CPLErr MRFDataset::ZenCopy(GDALDataset *poSrc, GDALProgressFunc pfnProgress,
 
 // Apply open options to the current dataset
 // Called before the configuration is read
-void MRFDataset::ProcessOpenOptions(char **papszOptions)
+void MRFDataset::ProcessOpenOptions(CSLConstList papszOptions)
 {
-    CPLStringList opt(papszOptions, FALSE);
-    no_errors = opt.FetchBoolean("NOERRORS", FALSE);
-    const char *val = opt.FetchNameValue("ZSLICE");
+    no_errors = CSLFetchBoolean(papszOptions, "NOERRORS", FALSE);
+    const char *val = CSLFetchNameValue(papszOptions, "ZSLICE");
     if (val)
         zslice = atoi(val);
 }
 
 // Apply create options to the current dataset, only valid during creation
-void MRFDataset::ProcessCreateOptions(char **papszOptions)
+void MRFDataset::ProcessCreateOptions(CSLConstList papszOptions)
 {
     assert(!bCrystalized);
-    CPLStringList opt(papszOptions, FALSE);
+    const CPLStringList opt(papszOptions);
     ILImage &img(full);
 
     const char *val = opt.FetchNameValue("COMPRESS");
@@ -2196,7 +2195,7 @@ void MRFDataset::ProcessCreateOptions(char **papszOptions)
 
 GDALDataset *MRFDataset::Create(const char *pszName, int nXSize, int nYSize,
                                 int nBandsIn, GDALDataType eType,
-                                char **papszOptions)
+                                CSLConstList papszOptions)
 {
     if (nBandsIn == 0)
     {

--- a/frmts/mrsid/mrsiddataset.cpp
+++ b/frmts/mrsid/mrsiddataset.cpp
@@ -263,7 +263,7 @@ class MrSIDDataset final : public GDALJP2AbstractDataset
 #ifdef MRSID_ESDK
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBands, GDALDataType eType,
-                               char **papszParamList);
+                               CSLConstList papszParamList);
 #endif
 };
 
@@ -3168,7 +3168,7 @@ LT_STATUS MrSIDDummyImageReader::decodeStrip(LTISceneBuffer &stripData,
 
 static GDALDataset *MrSIDCreateCopy(const char *pszFilename,
                                     GDALDataset *poSrcDS, int bStrict,
-                                    char **papszOptions,
+                                    CSLConstList papszOptions,
                                     GDALProgressFunc pfnProgress,
                                     void *pProgressData)
 
@@ -3421,7 +3421,7 @@ static GDALDataset *MrSIDCreateCopy(const char *pszFilename,
 /************************************************************************/
 
 static GDALDataset *JP2CreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
-                                  int bStrict, char **papszOptions,
+                                  int bStrict, CSLConstList papszOptions,
                                   GDALProgressFunc pfnProgress,
                                   void *pProgressData)
 

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -9260,7 +9260,7 @@ static void CopyMetadata(GDALDataset *poSrcDS, GDALRasterBand *poSrcBand,
 
 netCDFDataset *netCDFDataset::CreateLL(const char *pszFilename, int nXSize,
                                        int nYSize, int nBandsIn,
-                                       char **papszOptions)
+                                       CSLConstList papszOptions)
 {
     if (!((nXSize == 0 && nYSize == 0 && nBandsIn == 0) ||
           (nXSize > 0 && nYSize > 0 && nBandsIn > 0)))
@@ -9401,7 +9401,7 @@ netCDFDataset *netCDFDataset::CreateLL(const char *pszFilename, int nXSize,
 
 GDALDataset *netCDFDataset::Create(const char *pszFilename, int nXSize,
                                    int nYSize, int nBandsIn, GDALDataType eType,
-                                   char **papszOptions)
+                                   CSLConstList papszOptions)
 {
     CPLDebug("GDAL_netCDF", "\n=====\nnetCDFDataset::Create(%s, ...)",
              pszFilename);
@@ -9580,7 +9580,7 @@ static CPLErr NCDFCopyBand(GDALRasterBand *poSrcBand, GDALRasterBand *poDstBand,
 
 GDALDataset *
 netCDFDataset::CreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
-                          CPL_UNUSED int bStrict, char **papszOptions,
+                          CPL_UNUSED int bStrict, CSLConstList papszOptions,
                           GDALProgressFunc pfnProgress, void *pProgressData)
 {
     CPLMutexHolderD(&hNCMutex);

--- a/frmts/netcdf/netcdfdataset.h
+++ b/frmts/netcdf/netcdfdataset.h
@@ -597,13 +597,14 @@ class netCDFDataset final : public GDALPamDataset
     static GDALDataset *Open(GDALOpenInfo *);
 
     static netCDFDataset *CreateLL(const char *pszFilename, int nXSize,
-                                   int nYSize, int nBands, char **papszOptions);
+                                   int nYSize, int nBands,
+                                   CSLConstList papszOptions);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBands, GDALDataType eType,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 
@@ -714,7 +715,7 @@ class netCDFLayer final : public OGRLayer
                 OGRwkbGeometryType eGeomType, OGRSpatialReference *poSRS);
     ~netCDFLayer() override;
 
-    bool Create(char **papszOptions,
+    bool Create(CSLConstList papszOptions,
                 const netCDFWriterConfigLayer *poLayerConfig);
     void SetRecordDimID(int nRecordDimID);
     void SetXYZVars(int nXVarId, int nYVarId, int nZVarId);

--- a/frmts/netcdf/netcdflayer.cpp
+++ b/frmts/netcdf/netcdflayer.cpp
@@ -114,7 +114,7 @@ void netCDFLayer::netCDFWriteAttributesFromConf(
 /*                               Create()                               */
 /************************************************************************/
 
-bool netCDFLayer::Create(char **papszOptions,
+bool netCDFLayer::Create(CSLConstList papszOptions,
                          const netCDFWriterConfigLayer *poLayerConfig)
 {
     m_poDS->SetDefineMode(true);

--- a/frmts/nitf/nitfdataset.cpp
+++ b/frmts/nitf/nitfdataset.cpp
@@ -58,8 +58,8 @@ static bool NITFWriteExtraSegments(const char *pszFilename,
                                    CSLConstList papszOptions);
 
 #ifdef JPEG_SUPPORTED
-static bool NITFWriteJPEGImage(GDALDataset *, VSILFILE *, vsi_l_offset, char **,
-                               GDALProgressFunc pfnProgress,
+static bool NITFWriteJPEGImage(GDALDataset *, VSILFILE *, vsi_l_offset,
+                               CSLConstList, GDALProgressFunc pfnProgress,
                                void *pProgressData);
 #endif
 
@@ -2222,7 +2222,7 @@ void NITFDataset::CheckGeoSDEInfo()
 CPLErr NITFDataset::AdviseRead(int nXOff, int nYOff, int nXSize, int nYSize,
                                int nBufXSize, int nBufYSize, GDALDataType eDT,
                                int nBandCount, int *panBandList,
-                               char **papszOptions)
+                               CSLConstList papszOptions)
 
 {
     //go through GDALDataset::AdviseRead for the complex SAR
@@ -4126,7 +4126,7 @@ static const char *GDALToNITFDataType(GDALDataType eType)
 /*      NITF creation options.                                          */
 /************************************************************************/
 
-static char **NITFJP2ECWOptions(char **papszOptions)
+static char **NITFJP2ECWOptions(CSLConstList papszOptions)
 
 {
     char **papszJP2Options = CSLAddString(nullptr, "PROFILE=NPJE");
@@ -4153,7 +4153,7 @@ static char **NITFJP2ECWOptions(char **papszOptions)
 /*      NITF creation options.                                          */
 /************************************************************************/
 
-static char **NITFJP2KAKOptions(char **papszOptions, int nABPP)
+static char **NITFJP2KAKOptions(CSLConstList papszOptions, int nABPP)
 
 {
     char **papszJP2Options = CSLAddString(nullptr, "CODEC=J2K");
@@ -4324,7 +4324,7 @@ static char **NITFJP2OPENJPEGOptions(GDALDriver *poJ2KDriver,
 /************************************************************************/
 
 static char **NITFExtractTEXTAndCGMCreationOption(GDALDataset *poSrcDS,
-                                                  char **papszOptions,
+                                                  CSLConstList papszOptions,
                                                   char ***ppapszTextMD,
                                                   char ***ppapszCgmMD)
 {
@@ -4406,7 +4406,7 @@ static char **NITFExtractTEXTAndCGMCreationOption(GDALDataset *poSrcDS,
 GDALDataset *NITFDataset::NITFDatasetCreate(const char *pszFilename, int nXSize,
                                             int nYSize, int nBandsIn,
                                             GDALDataType eType,
-                                            char **papszOptions)
+                                            CSLConstList papszOptions)
 
 {
     const char *pszPVType = GDALToNITFDataType(eType);
@@ -4568,7 +4568,7 @@ GDALDataset *NITFDataset::NITFDatasetCreate(const char *pszFilename, int nXSize,
 
 GDALDataset *NITFDataset::NITFCreateCopy(const char *pszFilename,
                                          GDALDataset *poSrcDS, int bStrict,
-                                         char **papszOptions,
+                                         CSLConstList papszOptions,
                                          GDALProgressFunc pfnProgress,
                                          void *pProgressData)
 
@@ -6819,7 +6819,8 @@ int NITFWriteJPEGBlock(GDALDataset *poSrcDS, VSILFILE *fp, int nBlockXOff,
                        void *pProgressData);
 
 static bool NITFWriteJPEGImage(GDALDataset *poSrcDS, VSILFILE *fp,
-                               vsi_l_offset nStartOffset, char **papszOptions,
+                               vsi_l_offset nStartOffset,
+                               CSLConstList papszOptions,
                                GDALProgressFunc pfnProgress,
                                void *pProgressData)
 {

--- a/frmts/nitf/nitfdataset.h
+++ b/frmts/nitf/nitfdataset.h
@@ -140,7 +140,7 @@ class NITFDataset final : public GDALPamDataset
     CPLErr AdviseRead(int nXOff, int nYOff, int nXSize, int nYSize,
                       int nBufXSize, int nBufYSize, GDALDataType eDT,
                       int nBandCount, int *panBandList,
-                      char **papszOptions) override;
+                      CSLConstList papszOptions) override;
 
     CPLErr IRasterIO(GDALRWFlag, int, int, int, int, void *, int, int,
                      GDALDataType, int, BANDMAP_TYPE, GSpacing nPixelSpace,
@@ -175,13 +175,13 @@ class NITFDataset final : public GDALPamDataset
     static GDALDataset *Open(GDALOpenInfo *);
     static GDALDataset *NITFCreateCopy(const char *pszFilename,
                                        GDALDataset *poSrcDS, int bStrict,
-                                       char **papszOptions,
+                                       CSLConstList papszOptions,
                                        GDALProgressFunc pfnProgress,
                                        void *pProgressData);
     static GDALDataset *NITFDatasetCreate(const char *pszFilename, int nXSize,
                                           int nYSize, int nBands,
                                           GDALDataType eType,
-                                          char **papszOptions);
+                                          CSLConstList papszOptions);
 };
 
 /************************************************************************/
@@ -304,7 +304,7 @@ class NITFProxyPamRasterBand CPL_NON_FINAL : public GDALPamRasterBand
 
     CPLErr AdviseRead(int nXOff, int nYOff, int nXSize, int nYSize,
                       int nBufXSize, int nBufYSize, GDALDataType eDT,
-                      char **papszOptions) override;
+                      CSLConstList papszOptions) override;
 
     /*virtual CPLErr  GetHistogram( double dfMin, double dfMax,
                         int nBuckets, GUIntBig * panHistogram,

--- a/frmts/nitf/nitffile.cpp
+++ b/frmts/nitf/nitffile.cpp
@@ -25,9 +25,9 @@
 #endif
 
 static bool NITFWriteBLOCKA(VSILFILE *fp, vsi_l_offset nOffsetUDIDL,
-                            int *pnOffset, char **papszOptions);
+                            int *pnOffset, CSLConstList papszOptions);
 static bool NITFWriteTREsFromOptions(VSILFILE *fp, vsi_l_offset nOffsetUDIDL,
-                                     int *pnOffset, char **papszOptions,
+                                     int *pnOffset, CSLConstList papszOptions,
                                      const char *pszTREPrefix);
 
 static int NITFCollectSegmentInfo(NITFFile *psFile, int nFileHeaderLenSize,
@@ -40,9 +40,9 @@ static void NITFExtractAndRecodeMetadata(char ***ppapszMetadata,
                                          int nLength, const char *pszName,
                                          const char *pszSrcEncoding);
 
-static bool NITFWriteOption(VSILFILE *fp, char **papszOptions, size_t nWidth,
-                            GUIntBig nLocation, const char *pszName,
-                            const char *pszText);
+static bool NITFWriteOption(VSILFILE *fp, CSLConstList papszOptions,
+                            size_t nWidth, GUIntBig nLocation,
+                            const char *pszName, const char *pszText);
 
 /************************************************************************/
 /*                              NITFOpen()                              */
@@ -527,7 +527,8 @@ static bool NITFGotoOffset(VSILFILE *fp, GUIntBig nLocation)
 /************************************************************************/
 
 int NITFCreate(const char *pszFilename, int nPixels, int nLines, int nBands,
-               int nBitsPerSample, const char *pszPVType, char **papszOptions)
+               int nBitsPerSample, const char *pszPVType,
+               CSLConstList papszOptions)
 
 {
     return NITFCreateEx(pszFilename, nPixels, nLines, nBands, nBitsPerSample,
@@ -536,9 +537,9 @@ int NITFCreate(const char *pszFilename, int nPixels, int nLines, int nBands,
 }
 
 int NITFCreateEx(const char *pszFilename, int nPixels, int nLines, int nBands,
-                 int nBitsPerSample, const char *pszPVType, char **papszOptions,
-                 int *pnIndex, int *pnImageCount, vsi_l_offset *pnImageOffset,
-                 vsi_l_offset *pnICOffset)
+                 int nBitsPerSample, const char *pszPVType,
+                 CSLConstList papszOptions, int *pnIndex, int *pnImageCount,
+                 vsi_l_offset *pnImageOffset, vsi_l_offset *pnICOffset)
 
 {
     VSILFILE *fp;
@@ -1395,7 +1396,7 @@ int NITFCreateEx(const char *pszFilename, int nPixels, int nLines, int nBands,
     return bOK;
 }
 
-static bool NITFWriteOption(VSILFILE *psFile, char **papszOptions,
+static bool NITFWriteOption(VSILFILE *psFile, CSLConstList papszOptions,
                             size_t nWidth, GUIntBig nLocation,
                             const char *pszName, const char *pszText)
 {
@@ -1482,7 +1483,7 @@ static bool NITFWriteTRE(VSILFILE *fp, vsi_l_offset nOffsetUDIDL, int *pnOffset,
 /************************************************************************/
 
 static bool NITFWriteTREsFromOptions(VSILFILE *fp, vsi_l_offset nOffsetUDIDL,
-                                     int *pnOffset, char **papszOptions,
+                                     int *pnOffset, CSLConstList papszOptions,
                                      const char *pszTREPrefix)
 
 {
@@ -1610,7 +1611,7 @@ static bool NITFWriteTREsFromOptions(VSILFILE *fp, vsi_l_offset nOffsetUDIDL,
 /************************************************************************/
 
 static bool NITFWriteBLOCKA(VSILFILE *fp, vsi_l_offset nOffsetUDIDL,
-                            int *pnOffset, char **papszOptions)
+                            int *pnOffset, CSLConstList papszOptions)
 
 {
     static const char *const apszFields[] = {

--- a/frmts/nitf/nitflib.h
+++ b/frmts/nitf/nitflib.h
@@ -78,12 +78,12 @@ bool CPL_DLL NITFClose(NITFFile *);
 
 int CPL_DLL NITFCreate(const char *pszFilename, int nPixels, int nLines,
                        int nBands, int nBitsPerSample, const char *pszPVType,
-                       char **papszOptions);
+                       CSLConstList papszOptions);
 
 int NITFCreateEx(const char *pszFilename, int nPixels, int nLines, int nBands,
-                 int nBitsPerSample, const char *pszPVType, char **papszOptions,
-                 int *pnIndex, int *pnImageCount, vsi_l_offset *pnImageOffset,
-                 vsi_l_offset *pnICOffset);
+                 int nBitsPerSample, const char *pszPVType,
+                 CSLConstList papszOptions, int *pnIndex, int *pnImageCount,
+                 vsi_l_offset *pnImageOffset, vsi_l_offset *pnICOffset);
 
 const char CPL_DLL *NITFFindTRE(const char *pszTREData, int nTREBytes,
                                 const char *pszTag, int *pnFoundTRESize);

--- a/frmts/nitf/nitfrasterband.cpp
+++ b/frmts/nitf/nitfrasterband.cpp
@@ -335,7 +335,7 @@ RB_PROXY_METHOD_WITH_RET(CPLErr, CE_Failure, BuildOverviews,
 RB_PROXY_METHOD_WITH_RET(CPLErr, CE_Failure, AdviseRead,
                          (int nXOff, int nYOff, int nXSize, int nYSize,
                           int nBufXSize, int nBufYSize, GDALDataType eDT,
-                          char **papszOptions),
+                          CSLConstList papszOptions),
                          (nXOff, nYOff, nXSize, nYSize, nBufXSize, nBufYSize,
                           eDT, papszOptions))
 

--- a/frmts/northwood/grddataset.cpp
+++ b/frmts/northwood/grddataset.cpp
@@ -89,10 +89,10 @@ class NWT_GRDDataset final : public GDALPamDataset
 #ifndef NO_MITAB_SUPPORT
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBandsIn, GDALDataType eType,
-                               char **papszParamList);
+                               CSLConstList papszParamList);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 #endif
@@ -897,7 +897,8 @@ int NWT_GRDDataset::WriteTab()
 /************************************************************************/
 GDALDataset *NWT_GRDDataset::Create(const char *pszFilename, int nXSize,
                                     int nYSize, int nBandsIn,
-                                    GDALDataType eType, char **papszParamList)
+                                    GDALDataType eType,
+                                    CSLConstList papszParamList)
 {
     if (nBandsIn != 1)
     {
@@ -1090,7 +1091,7 @@ GDALDataset *NWT_GRDDataset::Create(const char *pszFilename, int nXSize,
 /************************************************************************/
 GDALDataset *NWT_GRDDataset::CreateCopy(const char *pszFilename,
                                         GDALDataset *poSrcDS, int bStrict,
-                                        char **papszOptions,
+                                        CSLConstList papszOptions,
                                         GDALProgressFunc pfnProgress,
                                         void *pProgressData)
 {

--- a/frmts/null/nulldataset.cpp
+++ b/frmts/null/nulldataset.cpp
@@ -50,7 +50,7 @@ class GDALNullDataset final : public GDALDataset
     static GDALDataset *Open(GDALOpenInfo *poOpenInfo);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBands, GDALDataType eType,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
 };
 
 /************************************************************************/
@@ -365,7 +365,8 @@ GDALDataset *GDALNullDataset::Open(GDALOpenInfo *poOpenInfo)
 /************************************************************************/
 
 GDALDataset *GDALNullDataset::Create(const char *, int nXSize, int nYSize,
-                                     int nBandsIn, GDALDataType eType, char **)
+                                     int nBandsIn, GDALDataType eType,
+                                     CSLConstList)
 {
     GDALNullDataset *poDS = new GDALNullDataset();
     poDS->nRasterXSize = nXSize;

--- a/frmts/openjpeg/opjdatasetbase.h
+++ b/frmts/openjpeg/opjdatasetbase.h
@@ -437,8 +437,9 @@ struct OPJCodecWrapper
         return true;
     }
 
-    bool initCompress(char **papszOptions, const std::vector<double> &adfRates,
-                      int nBlockXSize, int nBlockYSize, bool bIsIrreversible,
+    bool initCompress(CSLConstList papszOptions,
+                      const std::vector<double> &adfRates, int nBlockXSize,
+                      int nBlockYSize, bool bIsIrreversible,
                       int nNumResolutions, JP2_PROG_ORDER eProgOrder, int bYCC,
                       int nCblockW, int nCblockH, int bYCBCR420, int bProfile1,
                       int nBands, int nXSize, int nYSize,

--- a/frmts/opjlike/jp2opjlikedataset.cpp
+++ b/frmts/opjlike/jp2opjlikedataset.cpp
@@ -1912,9 +1912,8 @@ bool JP2OPJLikeDataset<CODEC, BASE>::WriteBox(VSILFILE *fp, GDALJP2Box *poBox)
 /************************************************************************/
 
 template <typename CODEC, typename BASE>
-bool JP2OPJLikeDataset<CODEC, BASE>::WriteGDALMetadataBox(VSILFILE *fp,
-                                                          GDALDataset *poSrcDS,
-                                                          char **papszOptions)
+bool JP2OPJLikeDataset<CODEC, BASE>::WriteGDALMetadataBox(
+    VSILFILE *fp, GDALDataset *poSrcDS, CSLConstList papszOptions)
 {
     bool bRet = true;
     GDALJP2Box *poBox = GDALJP2Metadata::CreateGDALMultiDomainMetadataXMLBox(
@@ -2000,7 +1999,8 @@ static int FloorPowerOfTwo(int nVal)
 template <typename CODEC, typename BASE>
 GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
     const char *pszFilename, GDALDataset *poSrcDS, CPL_UNUSED int bStrict,
-    char **papszOptions, GDALProgressFunc pfnProgress, void *pProgressData)
+    CSLConstList papszOptions, GDALProgressFunc pfnProgress,
+    void *pProgressData)
 
 {
     int nBands = poSrcDS->GetRasterCount();

--- a/frmts/opjlike/jp2opjlikedataset.h
+++ b/frmts/opjlike/jp2opjlikedataset.h
@@ -135,7 +135,7 @@ class JP2OPJLikeDataset final : public GDALJP2AbstractDataset, public BASE
     static GDALDataset *Open(GDALOpenInfo *);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 
@@ -168,7 +168,7 @@ class JP2OPJLikeDataset final : public GDALJP2AbstractDataset, public BASE
 
     static bool WriteBox(VSILFILE *fp, GDALJP2Box *poBox);
     static bool WriteGDALMetadataBox(VSILFILE *fp, GDALDataset *poSrcDS,
-                                     char **papszOptions);
+                                     CSLConstList papszOptions);
     static bool WriteXMLBoxes(VSILFILE *fp, GDALDataset *poSrcDS);
     static bool WriteXMPBox(VSILFILE *fp, GDALDataset *poSrcDS);
     static bool WriteIPRBox(VSILFILE *fp, GDALDataset *poSrcDS);

--- a/frmts/pcidsk/pcidskdataset2.cpp
+++ b/frmts/pcidsk/pcidskdataset2.cpp
@@ -1957,7 +1957,8 @@ GDALDataset *PCIDSK2Dataset::LLOpen(const char *pszFilename,
 
 GDALDataset *PCIDSK2Dataset::Create(const char *pszFilename, int nXSize,
                                     int nYSize, int nBandsIn,
-                                    GDALDataType eType, char **papszParamList)
+                                    GDALDataType eType,
+                                    CSLConstList papszParamList)
 
 {
     /* -------------------------------------------------------------------- */

--- a/frmts/pcidsk/pcidskdataset2.h
+++ b/frmts/pcidsk/pcidskdataset2.h
@@ -63,7 +63,7 @@ class PCIDSK2Dataset final : public GDALPamDataset
                                char **papszSiblingFiles = nullptr);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBands, GDALDataType eType,
-                               char **papszParamList);
+                               CSLConstList papszParamList);
 
     char **GetFileList() override;
     CPLErr GetGeoTransform(GDALGeoTransform &gt) const override;

--- a/frmts/pcraster/pcrasterdataset.cpp
+++ b/frmts/pcraster/pcrasterdataset.cpp
@@ -83,10 +83,11 @@ GDALDataset *PCRasterDataset::open(GDALOpenInfo *info)
   This function always writes rasters using CR_UINT1, CR_INT4 or CR_REAL4
   cell representations.
 */
-GDALDataset *
-PCRasterDataset::createCopy(char const *filename, GDALDataset *source,
-                            CPL_UNUSED int strict, CPL_UNUSED char **options,
-                            GDALProgressFunc progress, void *progressData)
+GDALDataset *PCRasterDataset::createCopy(char const *filename,
+                                         GDALDataset *source,
+                                         CPL_UNUSED int strict, CSLConstList,
+                                         GDALProgressFunc progress,
+                                         void *progressData)
 {
     // Checks.
     const int nrBands = source->GetRasterCount();
@@ -398,7 +399,7 @@ double PCRasterDataset::defaultNoDataValue() const
 GDALDataset *PCRasterDataset::create(const char *filename, int nr_cols,
                                      int nr_rows, int nrBands,
                                      GDALDataType gdalType,
-                                     char **papszParamList)
+                                     CSLConstList papszParamList)
 {
     // Checks
     if (nrBands != 1)

--- a/frmts/pcraster/pcrasterdataset.h
+++ b/frmts/pcraster/pcrasterdataset.h
@@ -47,10 +47,10 @@ class PCRasterDataset final : public GDALPamDataset
 
     static GDALDataset *create(const char *filename, int nr_cols, int nr_rows,
                                int nrBands, GDALDataType gdalType,
-                               char **papszParamList);
+                               CSLConstList papszParamList);
 
     static GDALDataset *createCopy(char const *filename, GDALDataset *source,
-                                   int strict, char **options,
+                                   int strict, CSLConstList options,
                                    GDALProgressFunc progress,
                                    void *progressData);
 

--- a/frmts/pdf/gdal_pdf.h
+++ b/frmts/pdf/gdal_pdf.h
@@ -561,7 +561,7 @@ class PDFWritableVectorDataset final : public GDALDataset
 
     static GDALDataset *Create(const char *pszName, int nXSize, int nYSize,
                                int nBands, GDALDataType eType,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
 
     void SetModified()
     {

--- a/frmts/pdf/pdfcreatecopy.cpp
+++ b/frmts/pdf/pdfcreatecopy.cpp
@@ -948,7 +948,7 @@ GDALPDFObjectNum GDALPDFBaseWriter::WriteSRS_ISO32000(GDALDataset *poSrcDS,
 /************************************************************************/
 
 static const char *GDALPDFGetValueFromDSOrOption(GDALDataset *poSrcDS,
-                                                 char **papszOptions,
+                                                 CSLConstList papszOptions,
                                                  const char *pszKey)
 {
     const char *pszValue = CSLFetchNameValue(papszOptions, pszKey);
@@ -965,7 +965,7 @@ static const char *GDALPDFGetValueFromDSOrOption(GDALDataset *poSrcDS,
 /************************************************************************/
 
 GDALPDFObjectNum GDALPDFBaseWriter::SetInfo(GDALDataset *poSrcDS,
-                                            char **papszOptions)
+                                            CSLConstList papszOptions)
 {
     const char *pszAUTHOR =
         GDALPDFGetValueFromDSOrOption(poSrcDS, papszOptions, "AUTHOR");
@@ -4057,7 +4057,7 @@ void GDALPDFWriter::WritePages()
 /*                        GDALPDFGetJPEGQuality()                       */
 /************************************************************************/
 
-static int GDALPDFGetJPEGQuality(char **papszOptions)
+static int GDALPDFGetJPEGQuality(CSLConstList papszOptions)
 {
     int nJpegQuality = -1;
     const char *pszValue = CSLFetchNameValue(papszOptions, "JPEG_QUALITY");
@@ -4123,7 +4123,7 @@ const OGRSpatialReference *GDALPDFClippingDataset::GetSpatialRef() const
 /************************************************************************/
 
 GDALDataset *GDALPDFCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
-                               int bStrict, char **papszOptions,
+                               int bStrict, CSLConstList papszOptions,
                                GDALProgressFunc pfnProgress,
                                void *pProgressData)
 {

--- a/frmts/pdf/pdfcreatecopy.h
+++ b/frmts/pdf/pdfcreatecopy.h
@@ -276,7 +276,7 @@ class GDALPDFBaseWriter
     GDALPDFObjectNum WriteJavascript(const char *pszJavascript, bool bDeflate);
 
   public:
-    GDALPDFObjectNum SetInfo(GDALDataset *poSrcDS, char **papszOptions);
+    GDALPDFObjectNum SetInfo(GDALDataset *poSrcDS, CSLConstList papszOptions);
     GDALPDFObjectNum SetInfo(const char *pszAUTHOR, const char *pszPRODUCER,
                              const char *pszCREATOR,
                              const char *pszCREATION_DATE,
@@ -379,7 +379,7 @@ class GDALPDFWriter final : public GDALPDFBaseWriter
                 const char *pszExclusiveLayers);
 };
 
-GDALDataset *GDALPDFCreateCopy(const char *, GDALDataset *, int, char **,
+GDALDataset *GDALPDFCreateCopy(const char *, GDALDataset *, int, CSLConstList,
                                GDALProgressFunc pfnProgress,
                                void *pProgressData);
 

--- a/frmts/pdf/pdfwritabledataset.cpp
+++ b/frmts/pdf/pdfwritabledataset.cpp
@@ -47,7 +47,7 @@ PDFWritableVectorDataset::~PDFWritableVectorDataset()
 GDALDataset *PDFWritableVectorDataset::Create(const char *pszName, int nXSize,
                                               int nYSize, int nBandsIn,
                                               GDALDataType eType,
-                                              char **papszOptions)
+                                              CSLConstList papszOptions)
 {
     if (nBandsIn == 0 && nXSize == 0 && nYSize == 0 && eType == GDT_Unknown)
     {

--- a/frmts/pds/isis3dataset.cpp
+++ b/frmts/pds/isis3dataset.cpp
@@ -209,10 +209,10 @@ class ISIS3Dataset final : public RawDataset
     static GDALDataset *Open(GDALOpenInfo *);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBandsIn, GDALDataType eType,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 };
@@ -4175,7 +4175,7 @@ void ISIS3Dataset::SerializeAsPDL(VSILFILE *fp, const CPLJSONObject &oObj,
 
 GDALDataset *ISIS3Dataset::Create(const char *pszFilename, int nXSize,
                                   int nYSize, int nBandsIn, GDALDataType eType,
-                                  char **papszOptions)
+                                  CSLConstList papszOptions)
 {
     if (eType != GDT_UInt8 && eType != GDT_UInt16 && eType != GDT_Int16 &&
         eType != GDT_Float32)
@@ -4410,7 +4410,7 @@ static GDALDataset *GetUnderlyingDataset(GDALDataset *poSrcDS)
 
 GDALDataset *ISIS3Dataset::CreateCopy(const char *pszFilename,
                                       GDALDataset *poSrcDS, int /*bStrict*/,
-                                      char **papszOptions,
+                                      CSLConstList papszOptions,
                                       GDALProgressFunc pfnProgress,
                                       void *pProgressData)
 {

--- a/frmts/pds/pds4dataset.cpp
+++ b/frmts/pds/pds4dataset.cpp
@@ -4725,7 +4725,7 @@ int PDS4Dataset::TestCapability(const char *pszCap) const
 
 GDALDataset *PDS4Dataset::Create(const char *pszFilename, int nXSize,
                                  int nYSize, int nBandsIn, GDALDataType eType,
-                                 char **papszOptions)
+                                 CSLConstList papszOptions)
 {
     return CreateInternal(pszFilename, nullptr, nXSize, nYSize, nBandsIn, eType,
                           papszOptions)
@@ -5131,7 +5131,7 @@ static GDALDataset *PDS4GetUnderlyingDataset(GDALDataset *poSrcDS)
 
 GDALDataset *PDS4Dataset::CreateCopy(const char *pszFilename,
                                      GDALDataset *poSrcDS, int bStrict,
-                                     char **papszOptions,
+                                     CSLConstList papszOptions,
                                      GDALProgressFunc pfnProgress,
                                      void *pProgressData)
 {

--- a/frmts/pds/pds4dataset.h
+++ b/frmts/pds/pds4dataset.h
@@ -419,10 +419,10 @@ class PDS4Dataset final : public RawDataset
 
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBands, GDALDataType eType,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
     static CPLErr Delete(const char *pszName);

--- a/frmts/pds/pdsdataset.cpp
+++ b/frmts/pds/pdsdataset.cpp
@@ -114,7 +114,7 @@ class PDSDataset final : public RawDataset
     static GDALDataset *Open(GDALOpenInfo *);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBands, GDALDataType eType,
-                               char **papszParamList);
+                               CSLConstList papszParamList);
 };
 
 /************************************************************************/

--- a/frmts/pds/vicardataset.cpp
+++ b/frmts/pds/vicardataset.cpp
@@ -3147,7 +3147,7 @@ bool VICARDataset::GetSpacings(const VICARKeywordHandler &keywords,
 
 GDALDataset *VICARDataset::Create(const char *pszFilename, int nXSize,
                                   int nYSize, int nBandsIn, GDALDataType eType,
-                                  char **papszOptions)
+                                  CSLConstList papszOptions)
 {
     return CreateInternal(pszFilename, nXSize, nYSize, nBandsIn, eType,
                           papszOptions);
@@ -3156,7 +3156,7 @@ GDALDataset *VICARDataset::Create(const char *pszFilename, int nXSize,
 VICARDataset *VICARDataset::CreateInternal(const char *pszFilename, int nXSize,
                                            int nYSize, int nBandsIn,
                                            GDALDataType eType,
-                                           char **papszOptions)
+                                           CSLConstList papszOptions)
 {
     if (eType != GDT_UInt8 && eType != GDT_Int16 && eType != GDT_Int32 &&
         eType != GDT_Float32 && eType != GDT_Float64 && eType != GDT_CFloat32)
@@ -3332,7 +3332,7 @@ VICARDataset *VICARDataset::CreateInternal(const char *pszFilename, int nXSize,
 
 GDALDataset *VICARDataset::CreateCopy(const char *pszFilename,
                                       GDALDataset *poSrcDS, int /*bStrict*/,
-                                      char **papszOptions,
+                                      CSLConstList papszOptions,
                                       GDALProgressFunc pfnProgress,
                                       void *pProgressData)
 {

--- a/frmts/pds/vicardataset.h
+++ b/frmts/pds/vicardataset.h
@@ -83,7 +83,7 @@ class VICARDataset final : public RawDataset
     static VICARDataset *CreateInternal(const char *pszFilename, int nXSize,
                                         int nYSize, int nBands,
                                         GDALDataType eType,
-                                        char **papszOptions);
+                                        CSLConstList papszOptions);
 
     void ReadProjectionFromMapGroup();
     void BuildLabelPropertyMap(CPLJSONObject &oLabel);
@@ -126,10 +126,10 @@ class VICARDataset final : public RawDataset
     static GDALDataset *Open(GDALOpenInfo *);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBands, GDALDataType eType,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 

--- a/frmts/plmosaic/plmosaicdataset.cpp
+++ b/frmts/plmosaic/plmosaicdataset.cpp
@@ -528,7 +528,8 @@ json_object *PLMosaicDataset::RunRequest(const char *pszURL, int bQuiet404Error)
 /************************************************************************/
 
 static CPLString PLMosaicGetParameter(GDALOpenInfo *poOpenInfo,
-                                      char **papszOptions, const char *pszName,
+                                      CSLConstList papszOptions,
+                                      const char *pszName,
                                       const char *pszDefaultVal)
 {
     return CSLFetchNameValueDef(

--- a/frmts/png/pngdataset.cpp
+++ b/frmts/png/pngdataset.cpp
@@ -2292,7 +2292,7 @@ static bool safe_png_write_end(jmp_buf sSetJmpContext, png_structp png_ptr,
 
 GDALDataset *PNGDataset::CreateCopy(const char *pszFilename,
                                     GDALDataset *poSrcDS, int bStrict,
-                                    char **papszOptions,
+                                    CSLConstList papszOptions,
                                     GDALProgressFunc pfnProgress,
                                     void *pProgressData)
 
@@ -3296,7 +3296,7 @@ CPLErr PNGDataset::write_png_header()
 
 GDALDataset *PNGDataset::Create(const char *pszFilename, int nXSize, int nYSize,
                                 int nBands, GDALDataType eType,
-                                char **papszOptions)
+                                CSLConstList papszOptions)
 {
     if (eType != GDT_UInt8 && eType != GDT_UInt16)
     {

--- a/frmts/png/pngdataset.h
+++ b/frmts/png/pngdataset.h
@@ -133,7 +133,7 @@ class PNGDataset final : public GDALPamDataset
     static GDALDataset *Open(GDALOpenInfo *);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 
@@ -177,7 +177,8 @@ class PNGDataset final : public GDALPamDataset
 
     virtual CPLErr SetGeoTransform(double *);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
-                               int nBands, GDALDataType, char **papszParamList);
+                               int nBands, GDALDataType,
+                               CSLConstList papszParamList);
 
   protected:
     CPLErr write_png_header();

--- a/frmts/postgisraster/postgisraster.h
+++ b/frmts/postgisraster/postgisraster.h
@@ -295,8 +295,8 @@ class PostGISRasterDataset final : public VRTDataset
     PostGISRasterDataset();
     ~PostGISRasterDataset() override;
     static GDALDataset *Open(GDALOpenInfo *);
-    static GDALDataset *CreateCopy(const char *, GDALDataset *, int, char **,
-                                   GDALProgressFunc, void *);
+    static GDALDataset *CreateCopy(const char *, GDALDataset *, int,
+                                   CSLConstList, GDALProgressFunc, void *);
     static GBool InsertRaster(PGconn *, PostGISRasterDataset *, const char *,
                               const char *, const char *);
     static CPLErr Delete(const char *);

--- a/frmts/postgisraster/postgisrasterdataset.cpp
+++ b/frmts/postgisraster/postgisrasterdataset.cpp
@@ -3474,7 +3474,7 @@ char **PostGISRasterDataset::GetFileList()
  ********************************************************/
 GDALDataset *PostGISRasterDataset::CreateCopy(
     CPL_UNUSED const char *pszFilename, GDALDataset *poGSrcDS,
-    CPL_UNUSED int bStrict, CPL_UNUSED char **papszOptions,
+    CPL_UNUSED int bStrict, CSLConstList,
     CPL_UNUSED GDALProgressFunc pfnProgress, CPL_UNUSED void *pProgressData)
 {
     char *pszSchema = nullptr;

--- a/frmts/raw/btdataset.cpp
+++ b/frmts/raw/btdataset.cpp
@@ -63,7 +63,7 @@ class BTDataset final : public GDALPamDataset
     static GDALDataset *Open(GDALOpenInfo *);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBandsIn, GDALDataType eType,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
 };
 
 /************************************************************************/
@@ -803,7 +803,7 @@ GDALDataset *BTDataset::Open(GDALOpenInfo *poOpenInfo)
 
 GDALDataset *BTDataset::Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBandsIn, GDALDataType eType,
-                               CPL_UNUSED char **papszOptions)
+                               CPL_UNUSED CSLConstList papszOptions)
 {
 
     /* -------------------------------------------------------------------- */

--- a/frmts/raw/ehdrdataset.cpp
+++ b/frmts/raw/ehdrdataset.cpp
@@ -1637,7 +1637,7 @@ GDALDataset *EHdrDataset::Open(GDALOpenInfo *poOpenInfo, bool bFileSizeCheck)
 
 GDALDataset *EHdrDataset::Create(const char *pszFilename, int nXSize,
                                  int nYSize, int nBandsIn, GDALDataType eType,
-                                 char **papszParamList)
+                                 CSLConstList papszParamList)
 
 {
     // Verify input options.
@@ -1754,7 +1754,7 @@ GDALDataset *EHdrDataset::Create(const char *pszFilename, int nXSize,
 
 GDALDataset *EHdrDataset::CreateCopy(const char *pszFilename,
                                      GDALDataset *poSrcDS, int bStrict,
-                                     char **papszOptions,
+                                     CSLConstList papszOptions,
                                      GDALProgressFunc pfnProgress,
                                      void *pProgressData)
 

--- a/frmts/raw/ehdrdataset.h
+++ b/frmts/raw/ehdrdataset.h
@@ -100,10 +100,10 @@ class EHdrDataset final : public RawDataset
     static GDALDataset *Open(GDALOpenInfo *, bool bFileSizeCheck);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBands, GDALDataType eType,
-                               char **papszParamList);
+                               CSLConstList papszParamList);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
     static CPLString GetImageRepFilename(const char *pszFilename);

--- a/frmts/raw/envidataset.cpp
+++ b/frmts/raw/envidataset.cpp
@@ -2351,7 +2351,7 @@ int ENVIDataset::GetEnviType(GDALDataType eType)
 
 GDALDataset *ENVIDataset::Create(const char *pszFilename, int nXSize,
                                  int nYSize, int nBandsIn, GDALDataType eType,
-                                 char **papszOptions)
+                                 CSLConstList papszOptions)
 
 {
     // Verify input options.

--- a/frmts/raw/envidataset.h
+++ b/frmts/raw/envidataset.h
@@ -122,7 +122,7 @@ class ENVIDataset final : public RawDataset
     static ENVIDataset *Open(GDALOpenInfo *, bool bFileSizeCheck);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBands, GDALDataType eType,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
 };
 
 /************************************************************************/

--- a/frmts/raw/gtxdataset.cpp
+++ b/frmts/raw/gtxdataset.cpp
@@ -83,7 +83,7 @@ class GTXDataset final : public RawDataset
     static int Identify(GDALOpenInfo *);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBands, GDALDataType eType,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
 };
 
 /************************************************************************/
@@ -373,7 +373,7 @@ CPLErr GTXDataset::SetGeoTransform(const GDALGeoTransform &gt)
 
 GDALDataset *GTXDataset::Create(const char *pszFilename, int nXSize, int nYSize,
                                 int /* nBands */, GDALDataType eType,
-                                char ** /* papszOptions */)
+                                CSLConstList /* papszOptions */)
 {
     if (eType != GDT_Float32)
     {

--- a/frmts/raw/iscedataset.cpp
+++ b/frmts/raw/iscedataset.cpp
@@ -71,7 +71,7 @@ class ISCEDataset final : public RawDataset
     static GDALDataset *Open(GDALOpenInfo *poOpenInfo, bool bFileSizeCheck);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBandsIn, GDALDataType eType,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
 };
 
 /************************************************************************/
@@ -750,7 +750,7 @@ GDALDataset *ISCEDataset::Open(GDALOpenInfo *poOpenInfo, bool bFileSizeCheck)
 
 GDALDataset *ISCEDataset::Create(const char *pszFilename, int nXSize,
                                  int nYSize, int nBandsIn, GDALDataType eType,
-                                 char **papszOptions)
+                                 CSLConstList papszOptions)
 {
     const char *sType = GDALGetDataTypeName(eType);
     const char *pszScheme = CSLFetchNameValueDef(papszOptions, "SCHEME", "BIP");

--- a/frmts/raw/krodataset.cpp
+++ b/frmts/raw/krodataset.cpp
@@ -41,7 +41,7 @@ class KRODataset final : public RawDataset
     static GDALDataset *Open(GDALOpenInfo *);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBandsIn, GDALDataType eType,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
     static int Identify(GDALOpenInfo *);
 };
 
@@ -236,7 +236,7 @@ GDALDataset *KRODataset::Open(GDALOpenInfo *poOpenInfo)
 
 GDALDataset *KRODataset::Create(const char *pszFilename, int nXSize, int nYSize,
                                 int nBandsIn, GDALDataType eType,
-                                char ** /* papszOptions */)
+                                CSLConstList /* papszOptions */)
 {
     if (eType != GDT_UInt8 && eType != GDT_UInt16 && eType != GDT_Float32)
     {

--- a/frmts/raw/lcpdataset.cpp
+++ b/frmts/raw/lcpdataset.cpp
@@ -61,7 +61,7 @@ class LCPDataset final : public RawDataset
     static GDALDataset *Open(GDALOpenInfo *);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 
@@ -876,7 +876,7 @@ CPLErr LCPDataset::ClassifyBandData(GDALRasterBand *poBand, GInt32 &nNumClasses,
 
 GDALDataset *LCPDataset::CreateCopy(const char *pszFilename,
                                     GDALDataset *poSrcDS, int bStrict,
-                                    char **papszOptions,
+                                    CSLConstList papszOptions,
                                     GDALProgressFunc pfnProgress,
                                     void *pProgressData)
 

--- a/frmts/raw/pnmdataset.cpp
+++ b/frmts/raw/pnmdataset.cpp
@@ -47,7 +47,7 @@ class PNMDataset final : public RawDataset
     static GDALDataset *OpenInternal(GDALOpenInfo *, bool bInCreation);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBandsIn, GDALDataType eType,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
 };
 
 /************************************************************************/
@@ -303,7 +303,7 @@ GDALDataset *PNMDataset::OpenInternal(GDALOpenInfo *poOpenInfo,
 
 GDALDataset *PNMDataset::Create(const char *pszFilename, int nXSize, int nYSize,
                                 int nBandsIn, GDALDataType eType,
-                                char **papszOptions)
+                                CSLConstList papszOptions)
 
 {
     /* -------------------------------------------------------------------- */

--- a/frmts/raw/roipacdataset.cpp
+++ b/frmts/raw/roipacdataset.cpp
@@ -47,7 +47,7 @@ class ROIPACDataset final : public RawDataset
     static int Identify(GDALOpenInfo *poOpenInfo);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBandsIn, GDALDataType eType,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
 
     CPLErr FlushCache(bool bAtClosing) override;
     CPLErr GetGeoTransform(GDALGeoTransform &gt) const override;
@@ -538,7 +538,7 @@ int ROIPACDataset::Identify(GDALOpenInfo *poOpenInfo)
 
 GDALDataset *ROIPACDataset::Create(const char *pszFilename, int nXSize,
                                    int nYSize, int nBandsIn, GDALDataType eType,
-                                   char ** /* papszOptions */)
+                                   CSLConstList /* papszOptions */)
 {
     /* -------------------------------------------------------------------- */
     /*      Verify input options.                                           */

--- a/frmts/raw/rrasterdataset.cpp
+++ b/frmts/raw/rrasterdataset.cpp
@@ -68,10 +68,10 @@ class RRASTERDataset final : public RawDataset
     static int Identify(GDALOpenInfo *);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBandsIn, GDALDataType eType,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 
@@ -1396,7 +1396,8 @@ GDALDataset *RRASTERDataset::Open(GDALOpenInfo *poOpenInfo)
 
 GDALDataset *RRASTERDataset::Create(const char *pszFilename, int nXSize,
                                     int nYSize, int nBandsIn,
-                                    GDALDataType eType, char **papszOptions)
+                                    GDALDataType eType,
+                                    CSLConstList papszOptions)
 
 {
     // Verify input options.
@@ -1484,7 +1485,7 @@ GDALDataset *RRASTERDataset::Create(const char *pszFilename, int nXSize,
 
 GDALDataset *RRASTERDataset::CreateCopy(const char *pszFilename,
                                         GDALDataset *poSrcDS, int bStrict,
-                                        char **papszOptions,
+                                        CSLConstList papszOptions,
                                         GDALProgressFunc pfnProgress,
                                         void *pProgressData)
 

--- a/frmts/rmf/rmfdataset.cpp
+++ b/frmts/rmf/rmfdataset.cpp
@@ -2035,7 +2035,7 @@ RMFDataset *RMFDataset::Open(GDALOpenInfo *poOpenInfo, RMFDataset *poParentDS,
 /************************************************************************/
 GDALDataset *RMFDataset::Create(const char *pszFilename, int nXSize, int nYSize,
                                 int nBandsIn, GDALDataType eType,
-                                char **papszParamList)
+                                CSLConstList papszParamList)
 {
     return Create(pszFilename, nXSize, nYSize, nBandsIn, eType, papszParamList,
                   nullptr, 1.0);
@@ -2043,8 +2043,8 @@ GDALDataset *RMFDataset::Create(const char *pszFilename, int nXSize, int nYSize,
 
 GDALDataset *RMFDataset::Create(const char *pszFilename, int nXSize, int nYSize,
                                 int nBandsIn, GDALDataType eType,
-                                char **papszParamList, RMFDataset *poParentDS,
-                                double dfOvFactor)
+                                CSLConstList papszParamList,
+                                RMFDataset *poParentDS, double dfOvFactor)
 
 {
     if (nBandsIn != 1 && nBandsIn != 3)
@@ -2889,7 +2889,7 @@ void RMFDataset::WriteTileJobFunc(void *pData)
     }
 }
 
-CPLErr RMFDataset::InitCompressorData(char **papszParamList)
+CPLErr RMFDataset::InitCompressorData(CSLConstList papszParamList)
 {
     const char *pszNumThreads =
         CSLFetchNameValue(papszParamList, "NUM_THREADS");

--- a/frmts/rmf/rmfdataset.h
+++ b/frmts/rmf/rmfdataset.h
@@ -299,9 +299,9 @@ class RMFDataset final : public GDALDataset
     static RMFDataset *Open(GDALOpenInfo *, RMFDataset *poParentDS,
                             vsi_l_offset nNextHeaderOffset);
     static GDALDataset *Create(const char *, int, int, int, GDALDataType,
-                               char **);
+                               CSLConstList);
     static GDALDataset *Create(const char *, int, int, int, GDALDataType,
-                               char **, RMFDataset *poParentDS,
+                               CSLConstList, RMFDataset *poParentDS,
                                double dfOvFactor);
     CPLErr FlushCache(bool bAtClosing) override;
 
@@ -335,7 +335,7 @@ class RMFDataset final : public GDALDataset
     static GByte GetCompressionType(const char *pszCompressName);
     int SetupCompression(GDALDataType eType, const char *pszFilename);
     static void WriteTileJobFunc(void *pData);
-    CPLErr InitCompressorData(char **papszParamList);
+    CPLErr InitCompressorData(CSLConstList papszParamList);
     CPLErr WriteTile(int nBlockXOff, int nBlockYOff, GByte *pabyData,
                      size_t nBytes, GUInt32 nRawXSize, GUInt32 nRawYSize);
     CPLErr WriteRawTile(int nBlockXOff, int nBlockYOff, GByte *pabyData,

--- a/frmts/saga/sagadataset.cpp
+++ b/frmts/saga/sagadataset.cpp
@@ -67,10 +67,10 @@ class SAGADataset final : public GDALPamDataset
     static GDALDataset *Open(GDALOpenInfo *);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBandsIn, GDALDataType eType,
-                               char **papszParamList);
+                               CSLConstList papszParamList);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 
@@ -836,7 +836,7 @@ CPLErr SAGADataset::WriteHeader(const CPLString &osHDRFilename,
 
 GDALDataset *SAGADataset::Create(const char *pszFilename, int nXSize,
                                  int nYSize, int nBandsIn, GDALDataType eType,
-                                 char **papszParamList)
+                                 CSLConstList papszParamList)
 
 {
     if (nXSize <= 0 || nYSize <= 0)
@@ -986,7 +986,7 @@ GDALDataset *SAGADataset::Create(const char *pszFilename, int nXSize,
 
 GDALDataset *SAGADataset::CreateCopy(const char *pszFilename,
                                      GDALDataset *poSrcDS, int bStrict,
-                                     CPL_UNUSED char **papszOptions,
+                                     CPL_UNUSED CSLConstList papszOptions,
                                      GDALProgressFunc pfnProgress,
                                      void *pProgressData)
 {

--- a/frmts/sigdem/sigdemdataset.cpp
+++ b/frmts/sigdem/sigdemdataset.cpp
@@ -158,7 +158,7 @@ SIGDEMDataset::~SIGDEMDataset()
 
 GDALDataset *SIGDEMDataset::CreateCopy(const char *pszFilename,
                                        GDALDataset *poSrcDS, int /*bStrict*/,
-                                       char ** /*papszOptions*/,
+                                       CSLConstList /*papszOptions*/,
                                        GDALProgressFunc pfnProgress,
                                        void *pProgressData)
 {

--- a/frmts/sigdem/sigdemdataset.h
+++ b/frmts/sigdem/sigdemdataset.h
@@ -81,7 +81,7 @@ class SIGDEMDataset final : public GDALPamDataset
 
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
     static int Identify(GDALOpenInfo *);

--- a/frmts/srtmhgt/srtmhgtdataset.cpp
+++ b/frmts/srtmhgt/srtmhgtdataset.cpp
@@ -58,7 +58,7 @@ class SRTMHGTDataset final : public GDALPamDataset
     static GDALDataset *Open(GDALOpenInfo *);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 };
@@ -514,7 +514,7 @@ GDALPamDataset *SRTMHGTDataset::OpenPAM(GDALOpenInfo *poOpenInfo)
 
 GDALDataset *SRTMHGTDataset::CreateCopy(const char *pszFilename,
                                         GDALDataset *poSrcDS, int bStrict,
-                                        char ** /* papszOptions*/,
+                                        CSLConstList /* papszOptions*/,
                                         GDALProgressFunc pfnProgress,
                                         void *pProgressData)
 {

--- a/frmts/terragen/terragendataset.cpp
+++ b/frmts/terragen/terragendataset.cpp
@@ -157,7 +157,7 @@ class TerragenDataset final : public GDALPamDataset
     static GDALDataset *Open(GDALOpenInfo *);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBandsIn, GDALDataType eType,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
 
     CPLErr GetGeoTransform(GDALGeoTransform &gt) const override;
     CPLErr SetGeoTransform(const GDALGeoTransform &gt) override;
@@ -889,7 +889,8 @@ CPLErr TerragenDataset::GetGeoTransform(GDALGeoTransform &gt) const
 /************************************************************************/
 GDALDataset *TerragenDataset::Create(const char *pszFilename, int nXSize,
                                      int nYSize, int nBandsIn,
-                                     GDALDataType eType, char **papszOptions)
+                                     GDALDataType eType,
+                                     CSLConstList papszOptions)
 {
     TerragenDataset *poDS = new TerragenDataset();
 

--- a/frmts/tiledb/tiledbcommon.cpp
+++ b/frmts/tiledb/tiledbcommon.cpp
@@ -339,7 +339,7 @@ GDALDataset *TileDBDataset::Open(GDALOpenInfo *poOpenInfo)
 
 GDALDataset *TileDBDataset::Create(const char *pszFilename, int nXSize,
                                    int nYSize, int nBandsIn, GDALDataType eType,
-                                   char **papszOptions)
+                                   CSLConstList papszOptions)
 
 {
     try
@@ -364,7 +364,7 @@ GDALDataset *TileDBDataset::Create(const char *pszFilename, int nXSize,
 
 GDALDataset *TileDBDataset::CreateCopy(const char *pszFilename,
                                        GDALDataset *poSrcDS, int bStrict,
-                                       char **papszOptions,
+                                       CSLConstList papszOptions,
                                        GDALProgressFunc pfnProgress,
                                        void *pProgressData)
 

--- a/frmts/tiledb/tiledbdense.cpp
+++ b/frmts/tiledb/tiledbdense.cpp
@@ -2580,7 +2580,7 @@ TileDBRasterDataset *TileDBRasterDataset::Create(const char *pszFilename,
                                                  int nXSize, int nYSize,
                                                  int nBandsIn,
                                                  GDALDataType eType,
-                                                 char **papszOptions)
+                                                 CSLConstList papszOptions)
 
 {
     CPLString osArrayPath = TileDBDataset::VSI_to_tiledb_uri(pszFilename);
@@ -2645,7 +2645,7 @@ TileDBRasterDataset *TileDBRasterDataset::Create(const char *pszFilename,
 
 GDALDataset *TileDBRasterDataset::CreateCopy(const char *pszFilename,
                                              GDALDataset *poSrcDS, int bStrict,
-                                             char **papszOptions,
+                                             CSLConstList papszOptions,
                                              GDALProgressFunc pfnProgress,
                                              void *pProgressData)
 

--- a/frmts/tiledb/tiledbheaders.h
+++ b/frmts/tiledb/tiledbheaders.h
@@ -176,10 +176,10 @@ class TileDBDataset /* non final */ : public GDALPamDataset
     static GDALDataset *Open(GDALOpenInfo *);
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBands, GDALDataType eType,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 
@@ -292,10 +292,11 @@ class TileDBRasterDataset final : public TileDBDataset
     static GDALDataset *Open(GDALOpenInfo *, tiledb::Object::Type objectType);
     static TileDBRasterDataset *Create(const char *pszFilename, int nXSize,
                                        int nYSize, int nBands,
-                                       GDALDataType eType, char **papszOptions);
+                                       GDALDataType eType,
+                                       CSLConstList papszOptions);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 };

--- a/frmts/vrt/gdal_vrt.h
+++ b/frmts/vrt/gdal_vrt.h
@@ -65,7 +65,7 @@ typedef void *VRTSourcedRasterBandH;
 VRTDatasetH CPL_DLL CPL_STDCALL VRTCreate(int, int);
 void CPL_DLL CPL_STDCALL VRTFlushCache(VRTDatasetH);
 CPLXMLNode CPL_DLL *CPL_STDCALL VRTSerializeToXML(VRTDatasetH, const char *);
-int CPL_DLL CPL_STDCALL VRTAddBand(VRTDatasetH, GDALDataType, char **);
+int CPL_DLL CPL_STDCALL VRTAddBand(VRTDatasetH, GDALDataType, CSLConstList);
 
 /* ==================================================================== */
 /*      VRTSourcedRasterBand class.                                     */

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -1728,7 +1728,7 @@ std::unique_ptr<VRTDataset> VRTDataset::OpenXML(const char *pszXML,
 /*                              AddBand()                               */
 /************************************************************************/
 
-CPLErr VRTDataset::AddBand(GDALDataType eType, char **papszOptions)
+CPLErr VRTDataset::AddBand(GDALDataType eType, CSLConstList papszOptions)
 
 {
     if (eType == GDT_Unknown || eType == GDT_TypeCount)
@@ -1959,7 +1959,7 @@ CPLErr VRTDataset::AddBand(GDALDataType eType, char **papszOptions)
  */
 
 int CPL_STDCALL VRTAddBand(VRTDatasetH hDataset, GDALDataType eType,
-                           char **papszOptions)
+                           CSLConstList papszOptions)
 
 {
     VALIDATE_POINTER1(hDataset, "VRTAddBand", 0);
@@ -1976,7 +1976,7 @@ int CPL_STDCALL VRTAddBand(VRTDatasetH hDataset, GDALDataType eType,
 
 GDALDataset *VRTDataset::Create(const char *pszName, int nXSize, int nYSize,
                                 int nBandsIn, GDALDataType eType,
-                                char **papszOptions)
+                                CSLConstList papszOptions)
 
 {
     return CreateVRTDataset(pszName, nXSize, nYSize, nBandsIn, eType,
@@ -2361,7 +2361,7 @@ GDALDataset *VRTDataset::GetSingleSimpleSource()
 CPLErr VRTDataset::AdviseRead(int nXOff, int nYOff, int nXSize, int nYSize,
                               int nBufXSize, int nBufYSize, GDALDataType eDT,
                               int nBandCount, int *panBandList,
-                              char **papszOptions)
+                              CSLConstList papszOptions)
 {
     if (!CheckCompatibleForDatasetIO())
         return CE_None;

--- a/frmts/vrt/vrtdataset.h
+++ b/frmts/vrt/vrtdataset.h
@@ -378,7 +378,7 @@ class CPL_DLL VRTDataset CPL_NON_FINAL : public GDALDataset
                    const OGRSpatialReference *poSRS) override;
 
     virtual CPLErr AddBand(GDALDataType eType,
-                           char **papszOptions = nullptr) override;
+                           CSLConstList papszOptions = nullptr) override;
 
     char **GetFileList() override;
 
@@ -401,7 +401,7 @@ class CPL_DLL VRTDataset CPL_NON_FINAL : public GDALDataset
     CPLErr AdviseRead(int nXOff, int nYOff, int nXSize, int nYSize,
                       int nBufXSize, int nBufYSize, GDALDataType eDT,
                       int nBandCount, int *panBandList,
-                      char **papszOptions) override;
+                      CSLConstList papszOptions) override;
 
     virtual CPLXMLNode *SerializeToXML(const char *pszVRTPath);
     virtual CPLErr XMLInit(const CPLXMLNode *, const char *);
@@ -453,7 +453,7 @@ class CPL_DLL VRTDataset CPL_NON_FINAL : public GDALDataset
             GDALAccess eAccess = GA_ReadOnly);
     static GDALDataset *Create(const char *pszName, int nXSize, int nYSize,
                                int nBands, GDALDataType eType,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
     static std::unique_ptr<VRTDataset>
     CreateVRTDataset(const char *pszName, int nXSize, int nYSize, int nBands,
                      GDALDataType eType, CSLConstList papszOptions);
@@ -522,7 +522,7 @@ class CPL_DLL VRTWarpedDataset final : public VRTDataset
     CPLErr XMLInit(const CPLXMLNode *, const char *) override;
 
     virtual CPLErr AddBand(GDALDataType eType,
-                           char **papszOptions = nullptr) override;
+                           CSLConstList papszOptions = nullptr) override;
 
     char **GetFileList() override;
 
@@ -598,7 +598,7 @@ class VRTPansharpenedDataset final : public VRTDataset
                    GDALRasterBandH *pahInputSpectralBandsIn);
 
     virtual CPLErr AddBand(GDALDataType eType,
-                           char **papszOptions = nullptr) override;
+                           CSLConstList papszOptions = nullptr) override;
 
     char **GetFileList() override;
 
@@ -1309,7 +1309,7 @@ class CPL_DLL VRTRawRasterBand CPL_NON_FINAL : public VRTRasterBand
 
     CPLVirtualMem *GetVirtualMemAuto(GDALRWFlag eRWFlag, int *pnPixelSpace,
                                      GIntBig *pnLineSpace,
-                                     char **papszOptions) override;
+                                     CSLConstList papszOptions) override;
 
     virtual void GetFileList(char ***ppapszFileList, int *pnSize,
                              int *pnMaxSize, CPLHashSet *hSetFiles) override;

--- a/frmts/vrt/vrtdriver.cpp
+++ b/frmts/vrt/vrtdriver.cpp
@@ -172,7 +172,7 @@ VRTSource *VRTDriver::ParseSource(const CPLXMLNode *psSrc,
 /************************************************************************/
 
 static GDALDataset *VRTCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
-                                  int /* bStrict */, char **papszOptions,
+                                  int /* bStrict */, CSLConstList papszOptions,
                                   GDALProgressFunc pfnProgress,
                                   void *pProgressData)
 {

--- a/frmts/vrt/vrtpansharpened.cpp
+++ b/frmts/vrt/vrtpansharpened.cpp
@@ -1378,7 +1378,7 @@ void VRTPansharpenedDataset::GetBlockSize(int *pnBlockXSize,
 /************************************************************************/
 
 CPLErr VRTPansharpenedDataset::AddBand(CPL_UNUSED GDALDataType eType,
-                                       CPL_UNUSED char **papszOptions)
+                                       CPL_UNUSED CSLConstList papszOptions)
 
 {
     CPLError(CE_Failure, CPLE_NotSupported, "AddBand() not supported");

--- a/frmts/vrt/vrtrawrasterband.cpp
+++ b/frmts/vrt/vrtrawrasterband.cpp
@@ -408,7 +408,7 @@ void VRTRawRasterBand::ClearRawLink()
 CPLVirtualMem *VRTRawRasterBand::GetVirtualMemAuto(GDALRWFlag eRWFlag,
                                                    int *pnPixelSpace,
                                                    GIntBig *pnLineSpace,
-                                                   char **papszOptions)
+                                                   CSLConstList papszOptions)
 
 {
     // check the pointer to RawRasterBand

--- a/frmts/vrt/vrtwarped.cpp
+++ b/frmts/vrt/vrtwarped.cpp
@@ -2167,7 +2167,8 @@ CPLErr VRTWarpedDataset::IRasterIO(
 /*                              AddBand()                               */
 /************************************************************************/
 
-CPLErr VRTWarpedDataset::AddBand(GDALDataType eType, char ** /* papszOptions */)
+CPLErr VRTWarpedDataset::AddBand(GDALDataType eType,
+                                 CSLConstList /* papszOptions */)
 
 {
     if (eType == GDT_Unknown || eType == GDT_TypeCount)

--- a/frmts/webp/webpdataset.cpp
+++ b/frmts/webp/webpdataset.cpp
@@ -75,7 +75,7 @@ class WEBPDataset final : public GDALPamDataset
     static GDALDataset *Open(GDALOpenInfo *);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 };
@@ -715,7 +715,7 @@ static int WEBPDatasetProgressHook(int percent,
 
 GDALDataset *WEBPDataset::CreateCopy(const char *pszFilename,
                                      GDALDataset *poSrcDS, int bStrict,
-                                     char **papszOptions,
+                                     CSLConstList papszOptions,
                                      GDALProgressFunc pfnProgress,
                                      void *pProgressData)
 

--- a/frmts/wms/gdalwmsdataset.cpp
+++ b/frmts/wms/gdalwmsdataset.cpp
@@ -805,7 +805,8 @@ CPLErr GDALWMSDataset::SetGeoTransform(const GDALGeoTransform &)
 CPLErr GDALWMSDataset::AdviseRead(int x0, int y0, int sx, int sy, int bsx,
                                   int bsy, GDALDataType bdt,
                                   CPL_UNUSED int band_count,
-                                  CPL_UNUSED int *band_map, char **options)
+                                  CPL_UNUSED int *band_map,
+                                  CSLConstList options)
 {
     //    printf("AdviseRead(%d, %d, %d, %d)\n", x0, y0, sx, sy);
     if (m_offline_mode || !m_use_advise_read)

--- a/frmts/wms/gdalwmsrasterband.cpp
+++ b/frmts/wms/gdalwmsrasterband.cpp
@@ -603,7 +603,7 @@ const char *GDALWMSRasterBand::GetMetadataItem(const char *pszName,
     osMetadataItemURL = url;
 
     // This is OK, CPLHTTPFetch does not touch the options
-    char **papszOptions =
+    CSLConstList papszOptions =
         const_cast<char **>(m_parent_dataset->GetHTTPRequestOpts());
     CPLHTTPResult *psResult = CPLHTTPFetch(url, papszOptions);
 
@@ -1104,7 +1104,8 @@ CPLErr GDALWMSRasterBand::ReportWMSException(const char *file_name)
 
 CPLErr GDALWMSRasterBand::AdviseRead(int nXOff, int nYOff, int nXSize,
                                      int nYSize, int nBufXSize, int nBufYSize,
-                                     GDALDataType eDT, char **papszOptions)
+                                     GDALDataType eDT,
+                                     CSLConstList papszOptions)
 {
     //    printf("AdviseRead(%d, %d, %d, %d)\n", nXOff, nYOff, nXSize, nYSize);
     if (m_parent_dataset->m_offline_mode ||

--- a/frmts/wms/wmsdriver.cpp
+++ b/frmts/wms/wmsdriver.cpp
@@ -1085,7 +1085,7 @@ void GDALWMSDataset::DestroyCfgMutex()
 GDALDataset *GDALWMSDataset::CreateCopy(const char *pszFilename,
                                         GDALDataset *poSrcDS,
                                         CPL_UNUSED int bStrict,
-                                        CPL_UNUSED char **papszOptions,
+                                        CPL_UNUSED CSLConstList papszOptions,
                                         CPL_UNUSED GDALProgressFunc pfnProgress,
                                         CPL_UNUSED void *pProgressData)
 {

--- a/frmts/wms/wmsdriver.h
+++ b/frmts/wms/wmsdriver.h
@@ -312,7 +312,7 @@ class GDALWMSDataset final : public GDALPamDataset
     CPLErr SetGeoTransform(const GDALGeoTransform &gt) override;
     CPLErr AdviseRead(int x0, int y0, int sx, int sy, int bsx, int bsy,
                       GDALDataType bdt, int band_count, int *band_map,
-                      char **options) override;
+                      CSLConstList options) override;
 
     char **GetMetadataDomainList() override;
     virtual const char *GetMetadataItem(const char *pszName,
@@ -448,7 +448,7 @@ class GDALWMSDataset final : public GDALPamDataset
     static GDALDataset *Open(GDALOpenInfo *poOpenInfo);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 
@@ -539,7 +539,7 @@ class GDALWMSRasterBand final : public GDALPamRasterBand
     double GetMaximum(int *) override;
     GDALColorTable *GetColorTable() override;
     CPLErr AdviseRead(int x0, int y0, int sx, int sy, int bsx, int bsy,
-                      GDALDataType bdt, char **options) override;
+                      GDALDataType bdt, CSLConstList options) override;
 
     GDALColorInterp GetColorInterpretation() override;
     CPLErr SetColorInterpretation(GDALColorInterp) override;

--- a/frmts/wmts/wmtsdataset.cpp
+++ b/frmts/wmts/wmtsdataset.cpp
@@ -175,7 +175,7 @@ class WMTSDataset final : public GDALPamDataset
     static GDALDataset *Open(GDALOpenInfo *);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, CPL_UNUSED int bStrict,
-                                   CPL_UNUSED char **papszOptions,
+                                   CPL_UNUSED CSLConstList papszOptions,
                                    CPL_UNUSED GDALProgressFunc pfnProgress,
                                    CPL_UNUSED void *pProgressData);
 
@@ -2490,7 +2490,7 @@ GDALDataset *WMTSDataset::Open(GDALOpenInfo *poOpenInfo)
 GDALDataset *WMTSDataset::CreateCopy(const char *pszFilename,
                                      GDALDataset *poSrcDS,
                                      CPL_UNUSED int bStrict,
-                                     CPL_UNUSED char **papszOptions,
+                                     CPL_UNUSED CSLConstList papszOptions,
                                      CPL_UNUSED GDALProgressFunc pfnProgress,
                                      CPL_UNUSED void *pProgressData)
 {

--- a/frmts/xyz/xyzdataset.cpp
+++ b/frmts/xyz/xyzdataset.cpp
@@ -79,7 +79,7 @@ class XYZDataset final : public GDALPamDataset
     static int Identify(GDALOpenInfo *);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 };
@@ -1564,7 +1564,7 @@ GDALDataset *XYZDataset::Open(GDALOpenInfo *poOpenInfo)
 
 GDALDataset *XYZDataset::CreateCopy(const char *pszFilename,
                                     GDALDataset *poSrcDS, int bStrict,
-                                    char **papszOptions,
+                                    CSLConstList papszOptions,
                                     GDALProgressFunc pfnProgress,
                                     void *pProgressData)
 {

--- a/frmts/zarr/zarr.h
+++ b/frmts/zarr/zarr.h
@@ -84,10 +84,10 @@ class ZarrDataset final : public GDALDataset
 
     static GDALDataset *Create(const char *pszName, int nXSize, int nYSize,
                                int nBands, GDALDataType eType,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
 
     static GDALDataset *CreateCopy(const char *, GDALDataset *, int,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 

--- a/frmts/zarr/zarrdriver.cpp
+++ b/frmts/zarr/zarrdriver.cpp
@@ -1160,7 +1160,7 @@ ZarrDataset::CreateMultiDimensional(const char *pszFilename,
 
 GDALDataset *ZarrDataset::Create(const char *pszName, int nXSize, int nYSize,
                                  int nBandsIn, GDALDataType eType,
-                                 char **papszOptions)
+                                 CSLConstList papszOptions)
 {
     // To avoid any issue with short-lived string that would be passed to us
     const std::string osName = pszName;
@@ -1922,7 +1922,7 @@ CPLErr ZarrRasterBand::IRasterIO(GDALRWFlag eRWFlag, int nXOff, int nYOff,
 /* static */
 GDALDataset *ZarrDataset::CreateCopy(const char *pszFilename,
                                      GDALDataset *poSrcDS, int bStrict,
-                                     char **papszOptions,
+                                     CSLConstList papszOptions,
                                      GDALProgressFunc pfnProgress,
                                      void *pProgressData)
 {

--- a/frmts/zmap/zmapdataset.cpp
+++ b/frmts/zmap/zmapdataset.cpp
@@ -57,7 +57,7 @@ class ZMapDataset final : public GDALPamDataset
     static int Identify(GDALOpenInfo *);
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 };
@@ -541,7 +541,7 @@ static void WriteRightJustified(VSIVirtualHandleUniquePtr &fp, double dfValue,
 
 GDALDataset *ZMapDataset::CreateCopy(const char *pszFilename,
                                      GDALDataset *poSrcDS, int bStrict,
-                                     CPL_UNUSED char **papszOptions,
+                                     CPL_UNUSED CSLConstList papszOptions,
                                      GDALProgressFunc pfnProgress,
                                      void *pProgressData)
 {

--- a/gcore/gdal_cpp_functions.h
+++ b/gcore/gdal_cpp_functions.h
@@ -396,6 +396,14 @@ void CPL_DLL GDALApplyENVIHeaders(GDALDataset *poDS,
                                   const CPLStringList &aosHeaders,
                                   CSLConstList papszOptions);
 
+class GDALAsyncReader;
+
+GDALAsyncReader *
+GDALGetDefaultAsyncReader(GDALDataset *poDS, int nXOff, int nYOff, int nXSize,
+                          int nYSize, void *pBuf, int nBufXSize, int nBufYSize,
+                          GDALDataType eBufType, int nBandCount,
+                          int *panBandMap, int nPixelSpace, int nLineSpace,
+                          int nBandSpace, CSLConstList papszOptions);
 //! @endcond
 
 #endif

--- a/gcore/gdal_dataset.h
+++ b/gcore/gdal_dataset.h
@@ -367,7 +367,8 @@ class CPL_DLL GDALDataset : public GDALMajorObject
         double *pdfPixel, double *pdfLine,
         CSLConstList papszTransformerOptions = nullptr) const;
 
-    virtual CPLErr AddBand(GDALDataType eType, char **papszOptions = nullptr);
+    virtual CPLErr AddBand(GDALDataType eType,
+                           CSLConstList papszOptions = nullptr);
 
     virtual void *GetInternalHandle(const char *pszHandleName);
     virtual GDALDriver *GetDriver(void);
@@ -389,7 +390,7 @@ class CPL_DLL GDALDataset : public GDALMajorObject
     virtual CPLErr AdviseRead(int nXOff, int nYOff, int nXSize, int nYSize,
                               int nBufXSize, int nBufYSize, GDALDataType eDT,
                               int nBandCount, int *panBandList,
-                              char **papszOptions);
+                              CSLConstList papszOptions);
 
     virtual CPLErr CreateMaskBand(int nFlagsIn);
 
@@ -397,7 +398,7 @@ class CPL_DLL GDALDataset : public GDALMajorObject
     BeginAsyncReader(int nXOff, int nYOff, int nXSize, int nYSize, void *pBuf,
                      int nBufXSize, int nBufYSize, GDALDataType eBufType,
                      int nBandCount, int *panBandMap, int nPixelSpace,
-                     int nLineSpace, int nBandSpace, char **papszOptions);
+                     int nLineSpace, int nBandSpace, CSLConstList papszOptions);
     virtual void EndAsyncReader(GDALAsyncReader *poARIO);
 
     //! @cond Doxygen_Suppress
@@ -856,7 +857,7 @@ class CPL_DLL GDALDataset : public GDALMajorObject
                           CSLConstList papszOptions = nullptr);
 
     virtual OGRLayer *CopyLayer(OGRLayer *poSrcLayer, const char *pszNewName,
-                                char **papszOptions = nullptr);
+                                CSLConstList papszOptions = nullptr);
 
     virtual OGRStyleTable *GetStyleTable();
     virtual void SetStyleTableDirectly(OGRStyleTable *poStyleTable);

--- a/gcore/gdal_driver.h
+++ b/gcore/gdal_driver.h
@@ -134,7 +134,7 @@ class CPL_DLL GDALDriver : public GDALMajorObject
     typedef GDALDataset *(*CreateCallback)(const char *pszName, int nXSize,
                                            int nYSize, int nBands,
                                            GDALDataType eType,
-                                           char **papszOptions);
+                                           CSLConstList papszOptions);
 
     CreateCallback pfnCreate = nullptr;
 
@@ -145,7 +145,7 @@ class CPL_DLL GDALDriver : public GDALMajorObject
 
     GDALDataset *(*pfnCreateEx)(GDALDriver *, const char *pszName, int nXSize,
                                 int nYSize, int nBands, GDALDataType eType,
-                                char **papszOptions) = nullptr;
+                                CSLConstList papszOptions) = nullptr;
 
     typedef GDALDataset *(*CreateMultiDimensionalCallback)(
         const char *pszName, CSLConstList papszRootGroupOptions,
@@ -167,7 +167,7 @@ class CPL_DLL GDALDriver : public GDALMajorObject
     }
 
     typedef GDALDataset *(*CreateCopyCallback)(const char *, GDALDataset *, int,
-                                               char **,
+                                               CSLConstList,
                                                GDALProgressFunc pfnProgress,
                                                void *pProgressData);
 
@@ -217,7 +217,7 @@ class CPL_DLL GDALDriver : public GDALMajorObject
 
     /* For legacy OGR drivers */
     GDALDataset *(*pfnCreateVectorOnly)(GDALDriver *, const char *pszName,
-                                        char **papszOptions) = nullptr;
+                                        CSLConstList papszOptions) = nullptr;
     CPLErr (*pfnDeleteDataSource)(GDALDriver *, const char *pszName) = nullptr;
 
     /** Whether pfnVectorTranslateFrom() can be run given the source dataset

--- a/gcore/gdal_proxy.h
+++ b/gcore/gdal_proxy.h
@@ -84,7 +84,7 @@ class CPL_DLL GDALProxyDataset : public GDALDataset
     CPLErr AdviseRead(int nXOff, int nYOff, int nXSize, int nYSize,
                       int nBufXSize, int nBufYSize, GDALDataType eDT,
                       int nBandCount, int *panBandList,
-                      char **papszOptions) override;
+                      CSLConstList papszOptions) override;
 
     CPLErr CreateMaskBand(int nFlags) override;
 
@@ -185,7 +185,7 @@ class CPL_DLL GDALProxyRasterBand : public GDALRasterBand
 
     CPLErr AdviseRead(int nXOff, int nYOff, int nXSize, int nYSize,
                       int nBufXSize, int nBufYSize, GDALDataType eDT,
-                      char **papszOptions) override;
+                      CSLConstList papszOptions) override;
 
     CPLErr GetHistogram(double dfMin, double dfMax, int nBuckets,
                         GUIntBig *panHistogram, int bIncludeOutOfRange,
@@ -209,7 +209,7 @@ class CPL_DLL GDALProxyRasterBand : public GDALRasterBand
 
     CPLVirtualMem *GetVirtualMemAuto(GDALRWFlag eRWFlag, int *pnPixelSpace,
                                      GIntBig *pnLineSpace,
-                                     char **papszOptions) override;
+                                     CSLConstList papszOptions) override;
 
     CPLErr InterpolateAtPoint(double dfPixel, double dfLine,
                               GDALRIOResampleAlg eInterpolation,

--- a/gcore/gdal_rasterband.h
+++ b/gcore/gdal_rasterband.h
@@ -532,7 +532,7 @@ class CPL_DLL GDALRasterBand : public GDALMajorObject
 
     virtual CPLErr AdviseRead(int nXOff, int nYOff, int nXSize, int nYSize,
                               int nBufXSize, int nBufYSize,
-                              GDALDataType eBufType, char **papszOptions);
+                              GDALDataType eBufType, CSLConstList papszOptions);
 
     virtual CPLErr GetHistogram(double dfMin, double dfMax, int nBuckets,
                                 GUIntBig *panHistogram, int bIncludeOutOfRange,
@@ -560,7 +560,7 @@ class CPL_DLL GDALRasterBand : public GDALMajorObject
     virtual CPLVirtualMem *
     GetVirtualMemAuto(GDALRWFlag eRWFlag, int *pnPixelSpace,
                       GIntBig *pnLineSpace,
-                      char **papszOptions) CPL_WARN_UNUSED_RESULT;
+                      CSLConstList papszOptions) CPL_WARN_UNUSED_RESULT;
 
     int GetDataCoverageStatus(int nXOff, int nYOff, int nXSize, int nYSize,
                               int nMaskFlagStop = 0,

--- a/gcore/gdaldataset.cpp
+++ b/gcore/gdaldataset.cpp
@@ -84,16 +84,6 @@
 
 extern const swq_field_type SpecialFieldTypes[SPECIAL_FIELD_COUNT];
 
-CPL_C_START
-GDALAsyncReader *GDALGetDefaultAsyncReader(GDALDataset *poDS, int nXOff,
-                                           int nYOff, int nXSize, int nYSize,
-                                           void *pBuf, int nBufXSize,
-                                           int nBufYSize, GDALDataType eBufType,
-                                           int nBandCount, int *panBandMap,
-                                           int nPixelSpace, int nLineSpace,
-                                           int nBandSpace, char **papszOptions);
-CPL_C_END
-
 enum class GDALAllowReadWriteMutexState
 {
     RW_MUTEX_STATE_UNKNOWN,
@@ -970,7 +960,7 @@ void GDALDataset::RasterInitialize(int nXSize, int nYSize)
  */
 
 CPLErr GDALDataset::AddBand(CPL_UNUSED GDALDataType eType,
-                            CPL_UNUSED char **papszOptions)
+                            CPL_UNUSED CSLConstList papszOptions)
 
 {
     ReportError(CE_Failure, CPLE_NotSupported,
@@ -3490,7 +3480,7 @@ int CPL_STDCALL GDALGetAccess(GDALDatasetH hDS)
 CPLErr GDALDataset::AdviseRead(int nXOff, int nYOff, int nXSize, int nYSize,
                                int nBufXSize, int nBufYSize,
                                GDALDataType eBufType, int nBandCount,
-                               int *panBandMap, char **papszOptions)
+                               int *panBandMap, CSLConstList papszOptions)
 
 {
     /* -------------------------------------------------------------------- */
@@ -4908,7 +4898,7 @@ int CPL_STDCALL GDALDumpOpenDatasets(FILE *fp)
 GDALAsyncReader *GDALDataset::BeginAsyncReader(
     int nXOff, int nYOff, int nXSize, int nYSize, void *pBuf, int nBufXSize,
     int nBufYSize, GDALDataType eBufType, int nBandCount, int *panBandMap,
-    int nPixelSpace, int nLineSpace, int nBandSpace, char **papszOptions)
+    int nPixelSpace, int nLineSpace, int nBandSpace, CSLConstList papszOptions)
 {
     // See gdaldefaultasync.cpp
 
@@ -5905,8 +5895,7 @@ OGRLayerH GDALDatasetCopyLayer(GDALDatasetH hDS, OGRLayerH hSrcLayer,
     VALIDATE_POINTER1(pszNewName, "GDALDatasetCopyLayer", nullptr);
 
     return OGRLayer::ToHandle(GDALDataset::FromHandle(hDS)->CopyLayer(
-        OGRLayer::FromHandle(hSrcLayer), pszNewName,
-        const_cast<char **>(papszOptions)));
+        OGRLayer::FromHandle(hSrcLayer), pszNewName, papszOptions));
 }
 
 /************************************************************************/
@@ -6237,7 +6226,7 @@ GDALDataset::ICreateLayer(CPL_UNUSED const char *pszName,
 */
 
 OGRLayer *GDALDataset::CopyLayer(OGRLayer *poSrcLayer, const char *pszNewName,
-                                 char **papszOptions)
+                                 CSLConstList papszOptions)
 
 {
     /* -------------------------------------------------------------------- */

--- a/gcore/gdaldefaultasync.cpp
+++ b/gcore/gdaldefaultasync.cpp
@@ -21,16 +21,6 @@
 #include "cpl_string.h"
 #include "gdal.h"
 
-CPL_C_START
-GDALAsyncReader *GDALGetDefaultAsyncReader(GDALDataset *poDS, int nXOff,
-                                           int nYOff, int nXSize, int nYSize,
-                                           void *pBuf, int nBufXSize,
-                                           int nBufYSize, GDALDataType eBufType,
-                                           int nBandCount, int *panBandMap,
-                                           int nPixelSpace, int nLineSpace,
-                                           int nBandSpace, char **papszOptions);
-CPL_C_END
-
 /************************************************************************/
 /* ==================================================================== */
 /*                         GDALAsyncReader                              */
@@ -260,7 +250,7 @@ class GDALDefaultAsyncReader : public GDALAsyncReader
                            int nYSize, void *pBuf, int nBufXSize, int nBufYSize,
                            GDALDataType eBufType, int nBandCount,
                            int *panBandMap, int nPixelSpace, int nLineSpace,
-                           int nBandSpace, char **papszOptions);
+                           int nBandSpace, CSLConstList papszOptions);
     ~GDALDefaultAsyncReader() override;
 
     GDALAsyncStatusType GetNextUpdatedRegion(double dfTimeout, int *pnBufXOff,
@@ -272,13 +262,12 @@ class GDALDefaultAsyncReader : public GDALAsyncReader
 /*                     GDALGetDefaultAsyncReader()                      */
 /************************************************************************/
 
-GDALAsyncReader *GDALGetDefaultAsyncReader(GDALDataset *poDS, int nXOff,
-                                           int nYOff, int nXSize, int nYSize,
-                                           void *pBuf, int nBufXSize,
-                                           int nBufYSize, GDALDataType eBufType,
-                                           int nBandCount, int *panBandMap,
-                                           int nPixelSpace, int nLineSpace,
-                                           int nBandSpace, char **papszOptions)
+GDALAsyncReader *
+GDALGetDefaultAsyncReader(GDALDataset *poDS, int nXOff, int nYOff, int nXSize,
+                          int nYSize, void *pBuf, int nBufXSize, int nBufYSize,
+                          GDALDataType eBufType, int nBandCount,
+                          int *panBandMap, int nPixelSpace, int nLineSpace,
+                          int nBandSpace, CSLConstList papszOptions)
 
 {
     return new GDALDefaultAsyncReader(poDS, nXOff, nYOff, nXSize, nYSize, pBuf,
@@ -295,7 +284,7 @@ GDALDefaultAsyncReader::GDALDefaultAsyncReader(
     GDALDataset *poDSIn, int nXOffIn, int nYOffIn, int nXSizeIn, int nYSizeIn,
     void *pBufIn, int nBufXSizeIn, int nBufYSizeIn, GDALDataType eBufTypeIn,
     int nBandCountIn, int *panBandMapIn, int nPixelSpaceIn, int nLineSpaceIn,
-    int nBandSpaceIn, char **papszOptionsIn)
+    int nBandSpaceIn, CSLConstList papszOptionsIn)
 
 {
     poDS = poDSIn;

--- a/gcore/gdalproxydataset.cpp
+++ b/gcore/gdalproxydataset.cpp
@@ -201,7 +201,8 @@ D_PROXY_METHOD_WITH_RET(CPLErr, CE_Failure, SetGCPs,
 D_PROXY_METHOD_WITH_RET(CPLErr, CE_Failure, AdviseRead,
                         (int nXOff, int nYOff, int nXSize, int nYSize,
                          int nBufXSize, int nBufYSize, GDALDataType eDT,
-                         int nBandCount, int *panBandList, char **papszOptions),
+                         int nBandCount, int *panBandList,
+                         CSLConstList papszOptions),
                         (nXOff, nYOff, nXSize, nYSize, nBufXSize, nBufYSize,
                          eDT, nBandCount, panBandList, papszOptions))
 D_PROXY_METHOD_WITH_RET(CPLErr, CE_Failure, CreateMaskBand, (int nFlagsIn),
@@ -474,7 +475,7 @@ RB_PROXY_METHOD_WITH_RET(CPLErr, CE_Failure, BuildOverviews,
 RB_PROXY_METHOD_WITH_RET(CPLErr, CE_Failure, AdviseRead,
                          (int nXOff, int nYOff, int nXSize, int nYSize,
                           int nBufXSize, int nBufYSize, GDALDataType eDT,
-                          char **papszOptions),
+                          CSLConstList papszOptions),
                          (nXOff, nYOff, nXSize, nYSize, nBufXSize, nBufYSize,
                           eDT, papszOptions))
 
@@ -513,7 +514,7 @@ RB_PROXY_METHOD_WITH_RET(GDALMaskValueRange, GMVR_UNKNOWN, GetMaskValueRange,
 
 RB_PROXY_METHOD_WITH_RET(CPLVirtualMem *, nullptr, GetVirtualMemAuto,
                          (GDALRWFlag eRWFlag, int *pnPixelSpace,
-                          GIntBig *pnLineSpace, char **papszOptions),
+                          GIntBig *pnLineSpace, CSLConstList papszOptions),
                          (eRWFlag, pnPixelSpace, pnLineSpace, papszOptions))
 
 RB_PROXY_METHOD_WITH_RET(

--- a/gcore/gdalrasterband.cpp
+++ b/gcore/gdalrasterband.cpp
@@ -5153,7 +5153,7 @@ GDALGetDefaultHistogramEx(GDALRasterBandH hBand, double *pdfMin, double *pdfMax,
 CPLErr GDALRasterBand::AdviseRead(int /*nXOff*/, int /*nYOff*/, int /*nXSize*/,
                                   int /*nYSize*/, int /*nBufXSize*/,
                                   int /*nBufYSize*/, GDALDataType /*eBufType*/,
-                                  char ** /*papszOptions*/)
+                                  CSLConstList /*papszOptions*/)
 {
     return CE_None;
 }
@@ -10259,7 +10259,7 @@ void GDALRasterBand::ReportError(CPLErr eErrClass, CPLErrorNum err_no,
 CPLVirtualMem *GDALRasterBand::GetVirtualMemAuto(GDALRWFlag eRWFlag,
                                                  int *pnPixelSpace,
                                                  GIntBig *pnLineSpace,
-                                                 char **papszOptions)
+                                                 CSLConstList papszOptions)
 {
     const char *pszImpl = CSLFetchNameValueDef(
         papszOptions, "USE_DEFAULT_IMPLEMENTATION", "AUTO");

--- a/gcore/gdalthreadsafedataset.cpp
+++ b/gcore/gdalthreadsafedataset.cpp
@@ -231,7 +231,7 @@ class GDALThreadSafeDataset final : public GDALProxyDataset
 
     GDALAsyncReader *BeginAsyncReader(int, int, int, int, void *, int, int,
                                       GDALDataType, int, int *, int, int, int,
-                                      char **) override
+                                      CSLConstList) override
     {
         CPLError(CE_Failure, CPLE_AppDefined,
                  "GDALThreadSafeDataset::BeginAsyncReader() not supported");
@@ -377,7 +377,7 @@ class GDALThreadSafeRasterBand final : public GDALProxyRasterBand
     /* End of methods that forward on the prototype band */
 
     CPLVirtualMem *GetVirtualMemAuto(GDALRWFlag, int *, GIntBig *,
-                                     char **) override
+                                     CSLConstList) override
     {
         CPLError(CE_Failure, CPLE_AppDefined,
                  "GDALThreadSafeRasterBand::GetVirtualMemAuto() not supported");

--- a/gcore/rawdataset.cpp
+++ b/gcore/rawdataset.cpp
@@ -1515,7 +1515,7 @@ GDALColorInterp RawRasterBand::GetColorInterpretation()
 CPLVirtualMem *RawRasterBand::GetVirtualMemAuto(GDALRWFlag eRWFlag,
                                                 int *pnPixelSpace,
                                                 GIntBig *pnLineSpace,
-                                                char **papszOptions)
+                                                CSLConstList papszOptions)
 {
     CPLAssert(pnPixelSpace);
     CPLAssert(pnLineSpace);

--- a/gcore/rawdataset.h
+++ b/gcore/rawdataset.h
@@ -198,7 +198,7 @@ class CPL_DLL RawRasterBand : public GDALPamRasterBand
 
     CPLVirtualMem *GetVirtualMemAuto(GDALRWFlag eRWFlag, int *pnPixelSpace,
                                      GIntBig *pnLineSpace,
-                                     char **papszOptions) override;
+                                     CSLConstList papszOptions) override;
 
     CPLErr AccessLine(int iLine);
 

--- a/gnm/gnm.h
+++ b/gnm/gnm.h
@@ -102,7 +102,8 @@ class CPL_DLL GNMNetwork : public GDALDataset
      *                       specific for gnm driver.
      * @return CE_None on success
      */
-    virtual CPLErr Create(const char *pszFilename, char **papszOptions) = 0;
+    virtual CPLErr Create(const char *pszFilename,
+                          CSLConstList papszOptions) = 0;
 
     /**
      * @brief Open a network
@@ -161,7 +162,7 @@ class CPL_DLL GNMNetwork : public GDALDataset
      */
     virtual OGRLayer *GetPath(GNMGFID nStartFID, GNMGFID nEndFID,
                               GNMGraphAlgorithmType eAlgorithm,
-                              char **papszOptions) = 0;
+                              CSLConstList papszOptions) = 0;
 
     /** Casts a handle to a pointer */
     static inline GNMNetwork *FromHandle(GNMGenericNetworkH hNet)
@@ -183,7 +184,7 @@ class CPL_DLL GNMNetwork : public GDALDataset
      * @return TRUE if exist and not overwrite or FALSE
      */
     virtual int CheckNetworkExist(const char *pszFilename,
-                                  char **papszOptions) = 0;
+                                  CSLConstList papszOptions) = 0;
 
   protected:
     //! @cond Doxygen_Suppress
@@ -216,7 +217,7 @@ class CPL_DLL GNMGenericNetwork : public GNMNetwork
     int TestCapability(const char *) const override;
 
     virtual OGRLayer *CopyLayer(OGRLayer *poSrcLayer, const char *pszNewName,
-                                char **papszOptions = nullptr) override;
+                                CSLConstList papszOptions = nullptr) override;
 
     int CloseDependentDatasets() override;
     CPLErr FlushCache(bool bAtClosing) override;
@@ -224,7 +225,7 @@ class CPL_DLL GNMGenericNetwork : public GNMNetwork
     // GNMNetwork Interface
 
     virtual CPLErr Create(const char *pszFilename,
-                          char **papszOptions) override = 0;
+                          CSLConstList papszOptions) override = 0;
     CPLErr Delete() override;
 
     int GetVersion() const override;
@@ -414,7 +415,7 @@ class CPL_DLL GNMGenericNetwork : public GNMNetwork
 
     virtual OGRLayer *GetPath(GNMGFID nStartFID, GNMGFID nEndFID,
                               GNMGraphAlgorithmType eAlgorithm,
-                              char **papszOptions) override;
+                              CSLConstList papszOptions) override;
 
     /** Casts a handle to a pointer */
     static inline GNMGenericNetwork *FromHandle(GNMGenericNetworkH hNet)
@@ -436,7 +437,7 @@ class CPL_DLL GNMGenericNetwork : public GNMNetwork
      * @return CE_None if driver is exist or CE_Failure
      */
     virtual CPLErr CheckLayerDriver(const char *pszDefaultDriverName,
-                                    char **papszOptions);
+                                    CSLConstList papszOptions);
     /**
      * @brief Check if provided OGR driver accepted as storage for network data
      * @param pszDriverName The driver name
@@ -576,36 +577,36 @@ class GNMGenericLayer final : public OGRLayer
 
     /** Intersection */
     OGRErr Intersection(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
-                        char **papszOptions = nullptr,
+                        CSLConstList papszOptions = nullptr,
                         GDALProgressFunc pfnProgress = nullptr,
                         void *pProgressArg = nullptr);
     /** Union */
     OGRErr Union(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
-                 char **papszOptions = nullptr,
+                 CSLConstList papszOptions = nullptr,
                  GDALProgressFunc pfnProgress = nullptr,
                  void *pProgressArg = nullptr);
     /** SymDifference */
     OGRErr SymDifference(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
-                         char **papszOptions, GDALProgressFunc pfnProgress,
-                         void *pProgressArg);
+                         CSLConstList papszOptions,
+                         GDALProgressFunc pfnProgress, void *pProgressArg);
     /** Identity */
     OGRErr Identity(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
-                    char **papszOptions = nullptr,
+                    CSLConstList papszOptions = nullptr,
                     GDALProgressFunc pfnProgress = nullptr,
                     void *pProgressArg = nullptr);
     /** Update */
     OGRErr Update(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
-                  char **papszOptions = nullptr,
+                  CSLConstList papszOptions = nullptr,
                   GDALProgressFunc pfnProgress = nullptr,
                   void *pProgressArg = nullptr);
     /** Clip */
     OGRErr Clip(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
-                char **papszOptions = nullptr,
+                CSLConstList papszOptions = nullptr,
                 GDALProgressFunc pfnProgress = nullptr,
                 void *pProgressArg = nullptr);
     /** Erase */
     OGRErr Erase(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
-                 char **papszOptions = nullptr,
+                 CSLConstList papszOptions = nullptr,
                  GDALProgressFunc pfnProgress = nullptr,
                  void *pProgressArg = nullptr);
 

--- a/gnm/gnm_api.h
+++ b/gnm/gnm_api.h
@@ -49,7 +49,7 @@ OGRFeatureH CPL_DLL CPL_STDCALL GNMGetFeatureByGlobalFID(GNMNetworkH hNet,
 OGRLayerH CPL_DLL CPL_STDCALL GNMGetPath(GNMNetworkH hNet, GNMGFID nStartFID,
                                          GNMGFID nEndFID,
                                          GNMGraphAlgorithmType eAlgorithm,
-                                         char **papszOptions);
+                                         CSLConstList papszOptions);
 
 CPLErr CPL_DLL CPL_STDCALL GNMConnectFeatures(GNMGenericNetworkH hNet,
                                               GNMGFID nSrcFID, GNMGFID nTgtFID,

--- a/gnm/gnm_frmts/db/gnmdb.h
+++ b/gnm/gnm_frmts/db/gnmdb.h
@@ -41,7 +41,7 @@ class GNMDatabaseNetwork final : public GNMGenericNetwork
     CPLErr Open(GDALOpenInfo *poOpenInfo) override;
     OGRErr DeleteLayer(int) override;
     virtual CPLErr Create(const char *pszFilename,
-                          char **papszOptions) override;
+                          CSLConstList papszOptions) override;
 
   protected:
     OGRLayer *ICreateLayer(const char *pszName,
@@ -49,7 +49,7 @@ class GNMDatabaseNetwork final : public GNMGenericNetwork
                            CSLConstList papszOptions) override;
 
     virtual int CheckNetworkExist(const char *pszFilename,
-                                  char **papszOptions) override;
+                                  CSLConstList papszOptions) override;
 
   protected:
     CPLErr DeleteMetadataLayer() override;
@@ -60,7 +60,7 @@ class GNMDatabaseNetwork final : public GNMGenericNetwork
     bool CheckStorageDriverSupport(const char *pszDriverName) override;
 
   protected:
-    CPLErr FormName(const char *pszFilename, char **papszOptions);
+    CPLErr FormName(const char *pszFilename, CSLConstList papszOptions);
     CPLErr DeleteLayerByName(const char *pszLayerName);
 
   protected:

--- a/gnm/gnm_frmts/db/gnmdbdriver.cpp
+++ b/gnm/gnm_frmts/db/gnmdbdriver.cpp
@@ -67,7 +67,7 @@ static GDALDataset *GNMDBDriverOpen(GDALOpenInfo *poOpenInfo)
 static GDALDataset *
 GNMDBDriverCreate(const char *pszName, CPL_UNUSED int nBands,
                   CPL_UNUSED int nXSize, CPL_UNUSED int nYSize,
-                  CPL_UNUSED GDALDataType eDT, char **papszOptions)
+                  CPL_UNUSED GDALDataType eDT, CSLConstList papszOptions)
 {
     CPLAssert(nullptr != pszName);
     CPLDebug("GNM", "Attempt to create network at: %s", pszName);

--- a/gnm/gnm_frmts/db/gnmdbnetwork.cpp
+++ b/gnm/gnm_frmts/db/gnmdbnetwork.cpp
@@ -81,7 +81,8 @@ CPLErr GNMDatabaseNetwork::Open(GDALOpenInfo *poOpenInfo)
     return CE_None;
 }
 
-CPLErr GNMDatabaseNetwork::Create(const char *pszFilename, char **papszOptions)
+CPLErr GNMDatabaseNetwork::Create(const char *pszFilename,
+                                  CSLConstList papszOptions)
 {
     FormName(pszFilename, papszOptions);
 
@@ -192,7 +193,7 @@ CPLErr GNMDatabaseNetwork::Create(const char *pszFilename, char **papszOptions)
 }
 
 int GNMDatabaseNetwork::CheckNetworkExist(const char *pszFilename,
-                                          char **papszOptions)
+                                          CSLConstList papszOptions)
 {
     // check if path exist
     // if path exist check if network already present and OVERWRITE option
@@ -327,7 +328,7 @@ bool GNMDatabaseNetwork::CheckStorageDriverSupport(const char *pszDriverName)
 }
 
 CPLErr GNMDatabaseNetwork::FormName(const char *pszFilename,
-                                    char **papszOptions)
+                                    CSLConstList papszOptions)
 {
     if (m_soNetworkFullName.empty())
         m_soNetworkFullName = pszFilename;

--- a/gnm/gnm_frmts/file/gnmfile.h
+++ b/gnm/gnm_frmts/file/gnmfile.h
@@ -45,7 +45,7 @@ class GNMFileNetwork : public GNMGenericNetwork
     int CloseDependentDatasets() override;
     OGRErr DeleteLayer(int) override;
     virtual CPLErr Create(const char *pszFilename,
-                          char **papszOptions) override;
+                          CSLConstList papszOptions) override;
 
   protected:
     OGRLayer *ICreateLayer(const char *pszName,
@@ -53,27 +53,27 @@ class GNMFileNetwork : public GNMGenericNetwork
                            CSLConstList papszOptions) override;
 
     virtual int CheckNetworkExist(const char *pszFilename,
-                                  char **papszOptions) override;
+                                  CSLConstList papszOptions) override;
 
   protected:
     virtual CPLErr CreateMetadataLayerFromFile(const char *pszFilename,
                                                int nVersion,
-                                               char **papszOptions);
+                                               CSLConstList papszOptions);
     CPLErr StoreNetworkSrs() override;
     CPLErr LoadNetworkSrs() override;
     CPLErr DeleteMetadataLayer() override;
     virtual CPLErr CreateGraphLayerFromFile(const char *pszFilename,
-                                            char **papszOptions);
+                                            CSLConstList papszOptions);
     CPLErr DeleteGraphLayer() override;
     virtual CPLErr CreateFeaturesLayerFromFile(const char *pszFilename,
-                                               char **papszOptions);
+                                               CSLConstList papszOptions);
     CPLErr DeleteFeaturesLayer() override;
     CPLErr DeleteNetworkLayers() override;
     CPLErr LoadNetworkLayer(const char *pszLayername) override;
     bool CheckStorageDriverSupport(const char *pszDriverName) override;
 
   protected:
-    CPLErr FormPath(const char *pszFilename, char **papszOptions);
+    CPLErr FormPath(const char *pszFilename, CSLConstList papszOptions);
 
   protected:
     CPLString m_soNetworkFullName;

--- a/gnm/gnm_frmts/file/gnmfiledriver.cpp
+++ b/gnm/gnm_frmts/file/gnmfiledriver.cpp
@@ -91,7 +91,7 @@ static GDALDataset *GNMFileDriverOpen(GDALOpenInfo *poOpenInfo)
 static GDALDataset *
 GNMFileDriverCreate(const char *pszName, CPL_UNUSED int nBands,
                     CPL_UNUSED int nXSize, CPL_UNUSED int nYSize,
-                    CPL_UNUSED GDALDataType eDT, char **papszOptions)
+                    CPL_UNUSED GDALDataType eDT, CSLConstList papszOptions)
 {
     CPLAssert(nullptr != pszName);
     CPLDebug("GNM", "Attempt to create network at: %s", pszName);

--- a/gnm/gnm_frmts/file/gnmfilenetwork.cpp
+++ b/gnm/gnm_frmts/file/gnmfilenetwork.cpp
@@ -140,7 +140,7 @@ CPLErr GNMFileNetwork::Open(GDALOpenInfo *poOpenInfo)
 }
 
 int GNMFileNetwork::CheckNetworkExist(const char *pszFilename,
-                                      char **papszOptions)
+                                      CSLConstList papszOptions)
 {
     // check if path exist
     // if path exist check if network already present and OVERWRITE option
@@ -242,7 +242,7 @@ CPLErr GNMFileNetwork::Delete()
 
 CPLErr GNMFileNetwork::CreateMetadataLayerFromFile(const char *pszFilename,
                                                    int nVersion,
-                                                   char **papszOptions)
+                                                   CSLConstList papszOptions)
 {
     CPLErr eResult = CheckLayerDriver(GNM_MD_DEFAULT_FILE_FORMAT, papszOptions);
     if (CE_None != eResult)
@@ -329,7 +329,7 @@ CPLErr GNMFileNetwork::DeleteMetadataLayer()
 }
 
 CPLErr GNMFileNetwork::CreateGraphLayerFromFile(const char *pszFilename,
-                                                char **papszOptions)
+                                                CSLConstList papszOptions)
 {
     CPLErr eResult = CheckLayerDriver(GNM_MD_DEFAULT_FILE_FORMAT, papszOptions);
     if (CE_None != eResult)
@@ -366,7 +366,7 @@ CPLErr GNMFileNetwork::DeleteGraphLayer()
 }
 
 CPLErr GNMFileNetwork::CreateFeaturesLayerFromFile(const char *pszFilename,
-                                                   char **papszOptions)
+                                                   CSLConstList papszOptions)
 {
     CPLErr eResult = CheckLayerDriver(GNM_MD_DEFAULT_FILE_FORMAT, papszOptions);
     if (CE_None != eResult)
@@ -461,7 +461,8 @@ bool GNMFileNetwork::CheckStorageDriverSupport(const char *pszDriverName)
     return false;
 }
 
-CPLErr GNMFileNetwork::FormPath(const char *pszFilename, char **papszOptions)
+CPLErr GNMFileNetwork::FormPath(const char *pszFilename,
+                                CSLConstList papszOptions)
 {
     if (m_soNetworkFullName.empty())
     {
@@ -597,7 +598,8 @@ OGRLayer *GNMFileNetwork::ICreateLayer(const char *pszName,
     return pGNMLayer;
 }
 
-CPLErr GNMFileNetwork::Create(const char *pszFilename, char **papszOptions)
+CPLErr GNMFileNetwork::Create(const char *pszFilename,
+                              CSLConstList papszOptions)
 {
     // check required options
 

--- a/gnm/gnmgenericnetwork.cpp
+++ b/gnm/gnmgenericnetwork.cpp
@@ -768,7 +768,7 @@ CPLErr GNMGenericNetwork::ChangeAllBlockState(bool bIsBlock)
 
 OGRLayer *GNMGenericNetwork::GetPath(GNMGFID nStartFID, GNMGFID nEndFID,
                                      GNMGraphAlgorithmType eAlgorithm,
-                                     char **papszOptions)
+                                     CSLConstList papszOptions)
 {
 
     if (!m_bIsGraphLoaded && LoadGraph() != CE_None)
@@ -1026,7 +1026,7 @@ void GNMGenericNetwork::FillResultLayer(OGRGNMWrappedResultLayer *poResLayer,
 }
 
 CPLErr GNMGenericNetwork::CheckLayerDriver(const char *pszDefaultDriverName,
-                                           char **papszOptions)
+                                           CSLConstList papszOptions)
 {
     if (nullptr == m_poLayerDriver)
     {
@@ -1402,7 +1402,7 @@ int GNMGenericNetwork::TestCapability(const char *pszCap) const
 
 OGRLayer *GNMGenericNetwork::CopyLayer(OGRLayer *poSrcLayer,
                                        const char *pszNewName,
-                                       char **papszOptions)
+                                       CSLConstList papszOptions)
 {
     CPLStringList aosOptions(CSLDuplicate(papszOptions));
     aosOptions.SetNameValue("DST_SRSWKT", GetProjectionRef());

--- a/gnm/gnmlayer.cpp
+++ b/gnm/gnmlayer.cpp
@@ -62,7 +62,7 @@ OGRErr GNMGenericLayer::SetIgnoredFields(CSLConstList papszFields)
 
 OGRErr GNMGenericLayer::Intersection(OGRLayer *pLayerMethod,
                                      OGRLayer *pLayerResult,
-                                     char **papszOptions,
+                                     CSLConstList papszOptions,
                                      GDALProgressFunc pfnProgress,
                                      void *pProgressArg)
 {
@@ -71,8 +71,8 @@ OGRErr GNMGenericLayer::Intersection(OGRLayer *pLayerMethod,
 }
 
 OGRErr GNMGenericLayer::Union(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
-                              char **papszOptions, GDALProgressFunc pfnProgress,
-                              void *pProgressArg)
+                              CSLConstList papszOptions,
+                              GDALProgressFunc pfnProgress, void *pProgressArg)
 {
     return m_poLayer->Union(pLayerMethod, pLayerResult, papszOptions,
                             pfnProgress, pProgressArg);
@@ -80,7 +80,7 @@ OGRErr GNMGenericLayer::Union(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
 
 OGRErr GNMGenericLayer::SymDifference(OGRLayer *pLayerMethod,
                                       OGRLayer *pLayerResult,
-                                      char **papszOptions,
+                                      CSLConstList papszOptions,
                                       GDALProgressFunc pfnProgress,
                                       void *pProgressArg)
 {
@@ -89,7 +89,7 @@ OGRErr GNMGenericLayer::SymDifference(OGRLayer *pLayerMethod,
 }
 
 OGRErr GNMGenericLayer::Identity(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
-                                 char **papszOptions,
+                                 CSLConstList papszOptions,
                                  GDALProgressFunc pfnProgress,
                                  void *pProgressArg)
 {
@@ -98,7 +98,7 @@ OGRErr GNMGenericLayer::Identity(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
 }
 
 OGRErr GNMGenericLayer::Update(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
-                               char **papszOptions,
+                               CSLConstList papszOptions,
                                GDALProgressFunc pfnProgress, void *pProgressArg)
 {
     return m_poLayer->Update(pLayerMethod, pLayerResult, papszOptions,
@@ -106,16 +106,16 @@ OGRErr GNMGenericLayer::Update(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
 }
 
 OGRErr GNMGenericLayer::Clip(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
-                             char **papszOptions, GDALProgressFunc pfnProgress,
-                             void *pProgressArg)
+                             CSLConstList papszOptions,
+                             GDALProgressFunc pfnProgress, void *pProgressArg)
 {
     return m_poLayer->Clip(pLayerMethod, pLayerResult, papszOptions,
                            pfnProgress, pProgressArg);
 }
 
 OGRErr GNMGenericLayer::Erase(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
-                              char **papszOptions, GDALProgressFunc pfnProgress,
-                              void *pProgressArg)
+                              CSLConstList papszOptions,
+                              GDALProgressFunc pfnProgress, void *pProgressArg)
 {
     return m_poLayer->Erase(pLayerMethod, pLayerResult, papszOptions,
                             pfnProgress, pProgressArg);

--- a/gnm/gnmnetwork.cpp
+++ b/gnm/gnmnetwork.cpp
@@ -89,7 +89,7 @@ OGRFeatureH CPL_STDCALL GNMGetFeatureByGlobalFID(GNMNetworkH hNet,
 OGRLayerH CPL_STDCALL GNMGetPath(GNMNetworkH hNet, GNMGFID nStartFID,
                                  GNMGFID nEndFID,
                                  GNMGraphAlgorithmType eAlgorithm,
-                                 char **papszOptions)
+                                 CSLConstList papszOptions)
 {
     VALIDATE_POINTER1(hNet, "GNMGetPath", nullptr);
 

--- a/ogr/ogr2gmlgeometry.cpp
+++ b/ogr/ogr2gmlgeometry.cpp
@@ -1264,7 +1264,7 @@ char *OGR_G_ExportToGML(OGRGeometryH hGeometry)
  *
  */
 
-char *OGR_G_ExportToGMLEx(OGRGeometryH hGeometry, char **papszOptions)
+char *OGR_G_ExportToGMLEx(OGRGeometryH hGeometry, CSLConstList papszOptions)
 
 {
     if (hGeometry == nullptr)

--- a/ogr/ogr_api.cpp
+++ b/ogr/ogr_api.cpp
@@ -1955,7 +1955,7 @@ int OGR_G_HasCurveGeometry(OGRGeometryH hGeom, int bLookForNonLinear)
 
 OGRGeometryH CPL_DLL OGR_G_GetLinearGeometry(OGRGeometryH hGeom,
                                              double dfMaxAngleStepSizeDegrees,
-                                             char **papszOptions)
+                                             CSLConstList papszOptions)
 {
     VALIDATE_POINTER1(hGeom, "OGR_G_GetLinearGeometry", nullptr);
     return ToHandle(ToPointer(hGeom)->getLinearGeometry(
@@ -1991,7 +1991,7 @@ OGRGeometryH CPL_DLL OGR_G_GetLinearGeometry(OGRGeometryH hGeom,
  */
 
 OGRGeometryH CPL_DLL OGR_G_GetCurveGeometry(OGRGeometryH hGeom,
-                                            char **papszOptions)
+                                            CSLConstList papszOptions)
 {
     VALIDATE_POINTER1(hGeom, "OGR_G_GetCurveGeometry", nullptr);
 

--- a/ogr/ogr_api.h
+++ b/ogr/ogr_api.h
@@ -101,9 +101,9 @@ OGRGeometryH
     CPL_DLL OGR_G_ForceToMultiPoint(OGRGeometryH) CPL_WARN_UNUSED_RESULT;
 OGRGeometryH
     CPL_DLL OGR_G_ForceToMultiLineString(OGRGeometryH) CPL_WARN_UNUSED_RESULT;
-OGRGeometryH CPL_DLL OGR_G_ForceTo(OGRGeometryH hGeom,
-                                   OGRwkbGeometryType eTargetType,
-                                   char **papszOptions) CPL_WARN_UNUSED_RESULT;
+OGRGeometryH CPL_DLL
+OGR_G_ForceTo(OGRGeometryH hGeom, OGRwkbGeometryType eTargetType,
+              CSLConstList papszOptions) CPL_WARN_UNUSED_RESULT;
 OGRGeometryH CPL_DLL OGR_G_RemoveLowerDimensionSubGeoms(
     const OGRGeometryH hGeom) CPL_WARN_UNUSED_RESULT;
 
@@ -148,8 +148,8 @@ void CPL_DLL OGR_G_CloseRings(OGRGeometryH);
 
 OGRGeometryH CPL_DLL OGR_G_CreateFromGML(const char *) CPL_WARN_UNUSED_RESULT;
 char CPL_DLL *OGR_G_ExportToGML(OGRGeometryH) CPL_WARN_UNUSED_RESULT;
-char CPL_DLL *OGR_G_ExportToGMLEx(OGRGeometryH,
-                                  char **papszOptions) CPL_WARN_UNUSED_RESULT;
+char CPL_DLL *OGR_G_ExportToGMLEx(OGRGeometryH, CSLConstList papszOptions)
+    CPL_WARN_UNUSED_RESULT;
 
 OGRGeometryH CPL_DLL OGR_G_CreateFromGMLTree(const CPLXMLNode *)
     CPL_WARN_UNUSED_RESULT;
@@ -161,8 +161,8 @@ char CPL_DLL *OGR_G_ExportToKML(OGRGeometryH, const char *pszAltitudeMode)
     CPL_WARN_UNUSED_RESULT;
 
 char CPL_DLL *OGR_G_ExportToJson(OGRGeometryH) CPL_WARN_UNUSED_RESULT;
-char CPL_DLL *OGR_G_ExportToJsonEx(OGRGeometryH,
-                                   char **papszOptions) CPL_WARN_UNUSED_RESULT;
+char CPL_DLL *OGR_G_ExportToJsonEx(OGRGeometryH, CSLConstList papszOptions)
+    CPL_WARN_UNUSED_RESULT;
 /** Create a OGR geometry from a GeoJSON geometry object */
 OGRGeometryH CPL_DLL OGR_G_CreateGeometryFromJson(const char *)
     CPL_WARN_UNUSED_RESULT;
@@ -326,9 +326,9 @@ OGRErr CPL_DLL OGR_G_RemoveGeometry(OGRGeometryH, int, int);
 int CPL_DLL OGR_G_HasCurveGeometry(OGRGeometryH, int bLookForNonLinear);
 OGRGeometryH CPL_DLL
 OGR_G_GetLinearGeometry(OGRGeometryH hGeom, double dfMaxAngleStepSizeDegrees,
-                        char **papszOptions) CPL_WARN_UNUSED_RESULT;
+                        CSLConstList papszOptions) CPL_WARN_UNUSED_RESULT;
 OGRGeometryH CPL_DLL OGR_G_GetCurveGeometry(
-    OGRGeometryH hGeom, char **papszOptions) CPL_WARN_UNUSED_RESULT;
+    OGRGeometryH hGeom, CSLConstList papszOptions) CPL_WARN_UNUSED_RESULT;
 
 OGRGeometryH CPL_DLL OGRBuildPolygonFromEdges(
     OGRGeometryH hLinesAsCollection, int bBestEffort, int bAutoClose,
@@ -566,7 +566,7 @@ const char CPL_DLL *OGR_F_GetNativeMediaType(OGRFeatureH);
 void CPL_DLL OGR_F_SetNativeMediaType(OGRFeatureH, const char *);
 
 void CPL_DLL OGR_F_FillUnsetWithDefault(OGRFeatureH hFeat, int bNotNullableOnly,
-                                        char **papszOptions);
+                                        CSLConstList papszOptions);
 int CPL_DLL OGR_F_Validate(OGRFeatureH, int nValidateFlags, int bEmitError);
 
 /* OGRFieldDomain */
@@ -702,7 +702,7 @@ struct ArrowArrayStream;
 
 bool CPL_DLL OGR_L_GetArrowStream(OGRLayerH hLayer,
                                   struct ArrowArrayStream *out_stream,
-                                  char **papszOptions);
+                                  CSLConstList papszOptions);
 
 /** Data type for a Arrow C schema. Include ogr_recordbatch.h to get the
  * definition. */
@@ -710,11 +710,11 @@ struct ArrowSchema;
 
 bool CPL_DLL OGR_L_IsArrowSchemaSupported(OGRLayerH hLayer,
                                           const struct ArrowSchema *schema,
-                                          char **papszOptions,
+                                          CSLConstList papszOptions,
                                           char **ppszErrorMsg);
 bool CPL_DLL OGR_L_CreateFieldFromArrowSchema(OGRLayerH hLayer,
                                               const struct ArrowSchema *schema,
-                                              char **papszOptions);
+                                              CSLConstList papszOptions);
 
 /** Data type for a Arrow C array. Include ogr_recordbatch.h to get the
  * definition. */
@@ -723,7 +723,7 @@ struct ArrowArray;
 bool CPL_DLL OGR_L_WriteArrowBatch(OGRLayerH hLayer,
                                    const struct ArrowSchema *schema,
                                    struct ArrowArray *array,
-                                   char **papszOptions);
+                                   CSLConstList papszOptions);
 
 OGRErr CPL_DLL OGR_L_SetNextByIndex(OGRLayerH, GIntBig);
 OGRFeatureH CPL_DLL OGR_L_GetFeature(OGRLayerH, GIntBig) CPL_WARN_UNUSED_RESULT;
@@ -787,19 +787,19 @@ void CPL_DLL OGR_L_SetStyleTableDirectly(OGRLayerH, OGRStyleTableH);
 /** Set style table */
 void CPL_DLL OGR_L_SetStyleTable(OGRLayerH, OGRStyleTableH);
 OGRErr CPL_DLL OGR_L_SetIgnoredFields(OGRLayerH, const char **);
-OGRErr CPL_DLL OGR_L_Intersection(OGRLayerH, OGRLayerH, OGRLayerH, char **,
+OGRErr CPL_DLL OGR_L_Intersection(OGRLayerH, OGRLayerH, OGRLayerH, CSLConstList,
                                   GDALProgressFunc, void *);
-OGRErr CPL_DLL OGR_L_Union(OGRLayerH, OGRLayerH, OGRLayerH, char **,
+OGRErr CPL_DLL OGR_L_Union(OGRLayerH, OGRLayerH, OGRLayerH, CSLConstList,
                            GDALProgressFunc, void *);
-OGRErr CPL_DLL OGR_L_SymDifference(OGRLayerH, OGRLayerH, OGRLayerH, char **,
-                                   GDALProgressFunc, void *);
-OGRErr CPL_DLL OGR_L_Identity(OGRLayerH, OGRLayerH, OGRLayerH, char **,
+OGRErr CPL_DLL OGR_L_SymDifference(OGRLayerH, OGRLayerH, OGRLayerH,
+                                   CSLConstList, GDALProgressFunc, void *);
+OGRErr CPL_DLL OGR_L_Identity(OGRLayerH, OGRLayerH, OGRLayerH, CSLConstList,
                               GDALProgressFunc, void *);
-OGRErr CPL_DLL OGR_L_Update(OGRLayerH, OGRLayerH, OGRLayerH, char **,
+OGRErr CPL_DLL OGR_L_Update(OGRLayerH, OGRLayerH, OGRLayerH, CSLConstList,
                             GDALProgressFunc, void *);
-OGRErr CPL_DLL OGR_L_Clip(OGRLayerH, OGRLayerH, OGRLayerH, char **,
+OGRErr CPL_DLL OGR_L_Clip(OGRLayerH, OGRLayerH, OGRLayerH, CSLConstList,
                           GDALProgressFunc, void *);
-OGRErr CPL_DLL OGR_L_Erase(OGRLayerH, OGRLayerH, OGRLayerH, char **,
+OGRErr CPL_DLL OGR_L_Erase(OGRLayerH, OGRLayerH, OGRLayerH, CSLConstList,
                            GDALProgressFunc, void *);
 
 /* OGRDataSource */

--- a/ogr/ogr_feature.h
+++ b/ogr/ogr_feature.h
@@ -1542,7 +1542,7 @@ class CPL_DLL OGRFeature
     //! @endcond
 
     int Validate(int nValidateFlags, int bEmitError) const;
-    void FillUnsetWithDefault(int bNotNullableOnly, char **papszOptions);
+    void FillUnsetWithDefault(int bNotNullableOnly, CSLConstList papszOptions);
 
     bool SerializeToBinary(std::vector<GByte> &abyBuffer) const;
     bool DeserializeFromBinary(const GByte *pabyBuffer, size_t nSize);

--- a/ogr/ogr_geocoding.cpp
+++ b/ogr/ogr_geocoding.cpp
@@ -126,7 +126,7 @@ static const char FIELD_BLOB[] = "blob";
 /*                       OGRGeocodeGetParameter()                       */
 /************************************************************************/
 
-static const char *OGRGeocodeGetParameter(char **papszOptions,
+static const char *OGRGeocodeGetParameter(CSLConstList papszOptions,
                                           const char *pszKey,
                                           const char *pszDefaultValue)
 {
@@ -233,7 +233,7 @@ static bool OGRGeocodeHasStringValidFormat(const char *pszQueryTemplate)
  */
 /* clang-format on */
 
-OGRGeocodingSessionH OGRGeocodeCreateSession(char **papszOptions)
+OGRGeocodingSessionH OGRGeocodeCreateSession(CSLConstList papszOptions)
 {
     OGRGeocodingSessionH hSession = static_cast<OGRGeocodingSessionH>(
         CPLCalloc(1, sizeof(_OGRGeocodingSessionHS)));
@@ -1219,7 +1219,7 @@ static OGRLayerH OGRGeocodeBuildLayer(const char *pszContent,
 
 static OGRLayerH OGRGeocodeCommon(OGRGeocodingSessionH hSession,
                                   const std::string &osURLIn,
-                                  char **papszOptions)
+                                  CSLConstList papszOptions)
 {
     std::string osURL(osURLIn);
 
@@ -1402,7 +1402,7 @@ static OGRLayerH OGRGeocodeCommon(OGRGeocodingSessionH hSession,
 /* clang-format on */
 
 OGRLayerH OGRGeocode(OGRGeocodingSessionH hSession, const char *pszQuery,
-                     char **papszStructuredQuery, char **papszOptions)
+                     char **papszStructuredQuery, CSLConstList papszOptions)
 {
     VALIDATE_POINTER1(hSession, "OGRGeocode", nullptr);
     if ((pszQuery == nullptr && papszStructuredQuery == nullptr) ||
@@ -1548,7 +1548,7 @@ static CPLString OGRGeocodeReverseSubstitute(CPLString osURL, double dfLon,
 /* clang-format on */
 
 OGRLayerH OGRGeocodeReverse(OGRGeocodingSessionH hSession, double dfLon,
-                            double dfLat, char **papszOptions)
+                            double dfLat, CSLConstList papszOptions)
 {
     VALIDATE_POINTER1(hSession, "OGRGeocodeReverse", nullptr);
 

--- a/ogr/ogr_geocoding.h
+++ b/ogr/ogr_geocoding.h
@@ -27,16 +27,16 @@ CPL_C_START
 /** Opaque type for a geocoding session */
 typedef struct _OGRGeocodingSessionHS *OGRGeocodingSessionH;
 
-OGRGeocodingSessionH CPL_DLL OGRGeocodeCreateSession(char **papszOptions);
+OGRGeocodingSessionH CPL_DLL OGRGeocodeCreateSession(CSLConstList papszOptions);
 
 void CPL_DLL OGRGeocodeDestroySession(OGRGeocodingSessionH hSession);
 
 OGRLayerH CPL_DLL OGRGeocode(OGRGeocodingSessionH hSession,
                              const char *pszQuery, char **papszStructuredQuery,
-                             char **papszOptions);
+                             CSLConstList papszOptions);
 
 OGRLayerH CPL_DLL OGRGeocodeReverse(OGRGeocodingSessionH hSession, double dfLon,
-                                    double dfLat, char **papszOptions);
+                                    double dfLat, CSLConstList papszOptions);
 
 void CPL_DLL OGRGeocodeFreeResult(OGRLayerH hLayer);
 

--- a/ogr/ogr_geometry.h
+++ b/ogr/ogr_geometry.h
@@ -4308,7 +4308,7 @@ class CPL_DLL OGRGeometryFactory
 
     static OGRGeometry *transformWithOptions(
         const OGRGeometry *poSrcGeom, OGRCoordinateTransformation *poCT,
-        char **papszOptions,
+        CSLConstList papszOptions,
         const TransformWithOptionsCache &cache = TransformWithOptionsCache());
 
     static double GetDefaultArcStepSize();

--- a/ogr/ogr_spatialref.h
+++ b/ogr/ogr_spatialref.h
@@ -440,7 +440,7 @@ class CPL_DLL OGRSpatialReference
                         int nCode);
 
     OGRErr AutoIdentifyEPSG();
-    OGRSpatialReferenceH *FindMatches(char **papszOptions, int *pnEntries,
+    OGRSpatialReferenceH *FindMatches(CSLConstList papszOptions, int *pnEntries,
                                       int **ppanMatchConfidence) const;
     OGRSpatialReference *
     FindBestMatch(int nMinimumMatchConfidence = 90,

--- a/ogr/ogr_srs_api.h
+++ b/ogr/ogr_srs_api.h
@@ -615,7 +615,7 @@ OGRErr CPL_DLL OSRSetStatePlaneWithUnits(OGRSpatialReferenceH hSRS, int nZone,
 OGRErr CPL_DLL OSRAutoIdentifyEPSG(OGRSpatialReferenceH hSRS);
 
 OGRSpatialReferenceH CPL_DLL *OSRFindMatches(OGRSpatialReferenceH hSRS,
-                                             char **papszOptions,
+                                             CSLConstList papszOptions,
                                              int *pnEntries,
                                              int **ppanMatchConfidence);
 void CPL_DLL OSRFreeSRSArray(OGRSpatialReferenceH *pahSRS);

--- a/ogr/ograpispy.cpp
+++ b/ogr/ograpispy.cpp
@@ -216,7 +216,7 @@ static bool OGRAPISpyEnabled()
     return true;
 }
 
-static CPLString OGRAPISpyGetOptions(char **papszOptions)
+static CPLString OGRAPISpyGetOptions(CSLConstList papszOptions)
 {
     if (papszOptions == nullptr)
     {
@@ -224,7 +224,8 @@ static CPLString OGRAPISpyGetOptions(char **papszOptions)
     }
 
     CPLString options = "[";
-    for (char **papszIter = papszOptions; *papszIter != nullptr; papszIter++)
+    for (CSLConstList papszIter = papszOptions; *papszIter != nullptr;
+         papszIter++)
     {
         if (papszIter != papszOptions)
             options += ", ";
@@ -600,7 +601,7 @@ void OGRAPISpyPostClose()
 }
 
 void OGRAPISpyCreateDataSource(GDALDriverH hDriver, const char *pszName,
-                               char **papszOptions, GDALDatasetH hDS)
+                               CSLConstList papszOptions, GDALDatasetH hDS)
 {
     if (!OGRAPISpyEnabled())
         return;
@@ -701,8 +702,8 @@ void OGRAPISpy_DS_ReleaseResultSet(GDALDatasetH hDS, OGRLayerH hLayer)
 
 void OGRAPISpy_DS_CreateLayer(GDALDatasetH hDS, const char *pszName,
                               OGRSpatialReferenceH hSpatialRef,
-                              OGRwkbGeometryType eType, char **papszOptions,
-                              OGRLayerH hLayer)
+                              OGRwkbGeometryType eType,
+                              CSLConstList papszOptions, OGRLayerH hLayer)
 {
     CPLMutexHolderD(&hOGRAPISpyMutex);
     OGRAPISpyFlushDefered();

--- a/ogr/ograpispy.h
+++ b/ogr/ograpispy.h
@@ -61,7 +61,7 @@ void OGRAPISpyOpen(const char *pszName, int bUpdate, int iSnapshot,
 void OGRAPISpyPreClose(GDALDatasetH hDS);
 void OGRAPISpyPostClose();
 void OGRAPISpyCreateDataSource(GDALDriverH hDriver, const char *pszName,
-                               char **papszOptions, GDALDatasetH hDS);
+                               CSLConstList papszOptions, GDALDatasetH hDS);
 void OGRAPISpyDeleteDataSource(GDALDriverH hDriver, const char *pszName);
 
 void OGRAPISpy_DS_GetLayerCount(GDALDatasetH hDS);
@@ -75,8 +75,8 @@ void OGRAPISpy_DS_ReleaseResultSet(GDALDatasetH hDS, OGRLayerH hLayer);
 
 void OGRAPISpy_DS_CreateLayer(GDALDatasetH hDS, const char *pszName,
                               OGRSpatialReferenceH hSpatialRef,
-                              OGRwkbGeometryType eType, char **papszOptions,
-                              OGRLayerH hLayer);
+                              OGRwkbGeometryType eType,
+                              CSLConstList papszOptions, OGRLayerH hLayer);
 void OGRAPISpy_DS_DeleteLayer(GDALDatasetH hDS, int iLayer);
 
 void OGRAPISpy_Dataset_StartTransaction(GDALDatasetH hDS, int bForce);

--- a/ogr/ogrfeature.cpp
+++ b/ogr/ogrfeature.cpp
@@ -6969,7 +6969,7 @@ void OGR_F_SetStyleTable(OGRFeatureH hFeat, OGRStyleTableH hStyleTable)
  */
 
 void OGRFeature::FillUnsetWithDefault(int bNotNullableOnly,
-                                      CPL_UNUSED char **papszOptions)
+                                      CPL_UNUSED CSLConstList papszOptions)
 {
     const int nFieldCount = poDefn->GetFieldCount();
     for (int i = 0; i < nFieldCount; i++)
@@ -7043,7 +7043,7 @@ void OGRFeature::FillUnsetWithDefault(int bNotNullableOnly,
  */
 
 void OGR_F_FillUnsetWithDefault(OGRFeatureH hFeat, int bNotNullableOnly,
-                                char **papszOptions)
+                                CSLConstList papszOptions)
 
 {
     VALIDATE_POINTER0(hFeat, "OGR_F_FillUnsetWithDefault");

--- a/ogr/ogrgeojsonwriter.cpp
+++ b/ogr/ogrgeojsonwriter.cpp
@@ -1815,7 +1815,7 @@ char *OGR_G_ExportToJson(OGRGeometryH hGeometry)
  *
  */
 
-char *OGR_G_ExportToJsonEx(OGRGeometryH hGeometry, char **papszOptions)
+char *OGR_G_ExportToJsonEx(OGRGeometryH hGeometry, CSLConstList papszOptions)
 {
     VALIDATE_POINTER1(hGeometry, "OGR_G_ExportToJson", nullptr);
 

--- a/ogr/ogrgeometryfactory.cpp
+++ b/ogr/ogrgeometryfactory.cpp
@@ -4215,7 +4215,8 @@ bool OGRGeometryFactory::isTransformWithOptionsRegularTransform(
  */
 OGRGeometry *OGRGeometryFactory::transformWithOptions(
     const OGRGeometry *poSrcGeom, OGRCoordinateTransformation *poCT,
-    char **papszOptions, CPL_UNUSED const TransformWithOptionsCache &cache)
+    CSLConstList papszOptions,
+    CPL_UNUSED const TransformWithOptionsCache &cache)
 {
     auto poDstGeom = std::unique_ptr<OGRGeometry>(poSrcGeom->clone());
     if (poCT)
@@ -5398,7 +5399,7 @@ OGRGeometry *OGRGeometryFactory::forceTo(OGRGeometry *poGeom,
  */
 
 OGRGeometryH OGR_G_ForceTo(OGRGeometryH hGeom, OGRwkbGeometryType eTargetType,
-                           char **papszOptions)
+                           CSLConstList papszOptions)
 
 {
     return OGRGeometry::ToHandle(OGRGeometryFactory::forceTo(

--- a/ogr/ogrsf_frmts/amigocloud/ogramigoclouddriver.cpp
+++ b/ogr/ogrsf_frmts/amigocloud/ogramigoclouddriver.cpp
@@ -50,12 +50,11 @@ static GDALDataset *OGRAmigoCloudDriverOpen(GDALOpenInfo *poOpenInfo)
 /*                      OGRAmigoCloudDriverCreate()                        */
 /************************************************************************/
 
-static GDALDataset *OGRAmigoCloudDriverCreate(const char *pszName,
-                                              CPL_UNUSED int nBands,
-                                              CPL_UNUSED int nXSize,
-                                              CPL_UNUSED int nYSize,
-                                              CPL_UNUSED GDALDataType eDT,
-                                              CPL_UNUSED char **papszOptions)
+static GDALDataset *
+OGRAmigoCloudDriverCreate(const char *pszName, CPL_UNUSED int nBands,
+                          CPL_UNUSED int nXSize, CPL_UNUSED int nYSize,
+                          CPL_UNUSED GDALDataType eDT,
+                          CPL_UNUSED CSLConstList papszOptions)
 
 {
     OGRAmigoCloudDataSource *poDS = new OGRAmigoCloudDataSource();

--- a/ogr/ogrsf_frmts/arrow/ogrfeatherdriver.cpp
+++ b/ogr/ogrsf_frmts/arrow/ogrfeatherdriver.cpp
@@ -283,7 +283,7 @@ static GDALDataset *OGRFeatherDriverOpen(GDALOpenInfo *poOpenInfo)
 static GDALDataset *OGRFeatherDriverCreate(const char *pszName, int nXSize,
                                            int nYSize, int nBands,
                                            GDALDataType eType,
-                                           char ** /* papszOptions */)
+                                           CSLConstList /* papszOptions */)
 {
     if (!(nXSize == 0 && nYSize == 0 && nBands == 0 && eType == GDT_Unknown))
         return nullptr;

--- a/ogr/ogrsf_frmts/carto/ogrcartodriver.cpp
+++ b/ogr/ogrsf_frmts/carto/ogrcartodriver.cpp
@@ -50,7 +50,7 @@ static GDALDataset *OGRCartoDriverCreate(const char *pszName,
                                          CPL_UNUSED int nXSize,
                                          CPL_UNUSED int nYSize,
                                          CPL_UNUSED GDALDataType eDT,
-                                         CPL_UNUSED char **papszOptions)
+                                         CPL_UNUSED CSLConstList papszOptions)
 
 {
     OGRCARTODataSource *poDS = new OGRCARTODataSource();

--- a/ogr/ogrsf_frmts/csv/ogrcsvdriver.cpp
+++ b/ogr/ogrsf_frmts/csv/ogrcsvdriver.cpp
@@ -183,7 +183,7 @@ static GDALDataset *OGRCSVDriverOpen(GDALOpenInfo *poOpenInfo)
 static GDALDataset *
 OGRCSVDriverCreate(const char *pszName, CPL_UNUSED int nBands,
                    CPL_UNUSED int nXSize, CPL_UNUSED int nYSize,
-                   CPL_UNUSED GDALDataType eDT, char **papszOptions)
+                   CPL_UNUSED GDALDataType eDT, CSLConstList papszOptions)
 {
     // First, ensure there isn't any such file yet.
     VSIStatBufL sStatBuf;

--- a/ogr/ogrsf_frmts/dgn/ogrdgndriver.cpp
+++ b/ogr/ogrsf_frmts/dgn/ogrdgndriver.cpp
@@ -76,7 +76,7 @@ static GDALDataset *OGRDGNDriverOpen(GDALOpenInfo *poOpenInfo)
 static GDALDataset *OGRDGNDriverCreate(const char *, int /* nBands */,
                                        int /* nXSize */, int /* nYSize */,
                                        GDALDataType /* eDT */,
-                                       char **papszOptions)
+                                       CSLConstList papszOptions)
 {
     OGRDGNDataSource *poDS = new OGRDGNDataSource();
     poDS->PreCreate(papszOptions);

--- a/ogr/ogrsf_frmts/dwg/ogr_dgnv8.h
+++ b/ogr/ogrsf_frmts/dwg/ogr_dgnv8.h
@@ -125,7 +125,7 @@ class OGRDGNV8DataSource final : public GDALDataset
     ~OGRDGNV8DataSource() override;
 
     int Open(const char *, bool bUpdate);
-    bool PreCreate(const char *, char **);
+    bool PreCreate(const char *, CSLConstList);
 
     OGRLayer *ICreateLayer(const char *pszName,
                            const OGRGeomFieldDefn *poGeomFieldDefn,

--- a/ogr/ogrsf_frmts/dwg/ogrdgnv8datasource.cpp
+++ b/ogr/ogrsf_frmts/dwg/ogrdgnv8datasource.cpp
@@ -362,7 +362,7 @@ const char *OGRDGNV8DataSource::GetMetadataItem(const char *pszName,
 /************************************************************************/
 
 bool OGRDGNV8DataSource::PreCreate(const char *pszFilename,
-                                   char **papszOptionsIn)
+                                   CSLConstList papszOptionsIn)
 
 {
     m_bUpdate = true;

--- a/ogr/ogrsf_frmts/dwg/ogrdgnv8driver.cpp
+++ b/ogr/ogrsf_frmts/dwg/ogrdgnv8driver.cpp
@@ -55,7 +55,7 @@ static GDALDataset *OGRDGNV8DriverOpen(GDALOpenInfo *poOpenInfo)
 static GDALDataset *OGRDGNV8DriverCreate(const char *pszName, int /* nBands */,
                                          int /* nXSize */, int /* nYSize */,
                                          GDALDataType /* eDT */,
-                                         char **papszOptions)
+                                         CSLConstList papszOptions)
 {
     if (!OGRTEIGHAInitialize())
         return nullptr;

--- a/ogr/ogrsf_frmts/dxf/ogr_dxf.h
+++ b/ogr/ogrsf_frmts/dxf/ogr_dxf.h
@@ -1012,7 +1012,7 @@ class OGRDXFWriterDS final : public GDALDataset
     OGRDXFWriterDS();
     ~OGRDXFWriterDS() override;
 
-    int Open(const char *pszFilename, char **papszOptions);
+    int Open(const char *pszFilename, CSLConstList papszOptions);
 
     int GetLayerCount() const override;
     const OGRLayer *GetLayer(int) const override;

--- a/ogr/ogrsf_frmts/dxf/ogrdxfdriver.cpp
+++ b/ogr/ogrsf_frmts/dxf/ogrdxfdriver.cpp
@@ -96,7 +96,7 @@ static GDALDataset *OGRDXFDriverOpen(GDALOpenInfo *poOpenInfo)
 static GDALDataset *
 OGRDXFDriverCreate(const char *pszName, CPL_UNUSED int nBands,
                    CPL_UNUSED int nXSize, CPL_UNUSED int nYSize,
-                   CPL_UNUSED GDALDataType eDT, char **papszOptions)
+                   CPL_UNUSED GDALDataType eDT, CSLConstList papszOptions)
 {
     OGRDXFWriterDS *poDS = new OGRDXFWriterDS();
 

--- a/ogr/ogrsf_frmts/dxf/ogrdxfwriterds.cpp
+++ b/ogr/ogrsf_frmts/dxf/ogrdxfwriterds.cpp
@@ -175,7 +175,7 @@ int OGRDXFWriterDS::GetLayerCount() const
 /*                                Open()                                */
 /************************************************************************/
 
-int OGRDXFWriterDS::Open(const char *pszFilename, char **papszOptions)
+int OGRDXFWriterDS::Open(const char *pszFilename, CSLConstList papszOptions)
 
 {
     /* -------------------------------------------------------------------- */

--- a/ogr/ogrsf_frmts/elastic/ogr_elastic.h
+++ b/ogr/ogrsf_frmts/elastic/ogr_elastic.h
@@ -351,7 +351,7 @@ class OGRElasticDataSource final : public GDALDataset
 
     bool Open(GDALOpenInfo *poOpenInfo);
 
-    int Create(const char *pszFilename, char **papszOptions);
+    int Create(const char *pszFilename, CSLConstList papszOptions);
 
     CPLHTTPResult *HTTPFetch(const char *pszURL, CSLConstList papszOptions);
 

--- a/ogr/ogrsf_frmts/elastic/ogrelasticdatasource.cpp
+++ b/ogr/ogrsf_frmts/elastic/ogrelasticdatasource.cpp
@@ -963,7 +963,7 @@ bool OGRElasticDataSource::UploadFile(const CPLString &url,
 /************************************************************************/
 
 int OGRElasticDataSource::Create(const char *pszFilename,
-                                 CPL_UNUSED char **papszOptions)
+                                 CPL_UNUSED CSLConstList papszOptions)
 {
     eAccess = GA_Update;
     m_pszName = CPLStrdup(pszFilename);

--- a/ogr/ogrsf_frmts/elastic/ogrelasticdriver.cpp
+++ b/ogr/ogrsf_frmts/elastic/ogrelasticdriver.cpp
@@ -37,10 +37,12 @@ static GDALDataset *OGRElasticsearchDriverOpen(GDALOpenInfo *poOpenInfo)
 /************************************************************************/
 /*                     OGRElasticsearchDriverCreate()                   */
 /************************************************************************/
-static GDALDataset *
-OGRElasticsearchDriverCreate(const char *pszName, CPL_UNUSED int nXSize,
-                             CPL_UNUSED int nYSize, CPL_UNUSED int nBands,
-                             CPL_UNUSED GDALDataType eDT, char **papszOptions)
+static GDALDataset *OGRElasticsearchDriverCreate(const char *pszName,
+                                                 CPL_UNUSED int nXSize,
+                                                 CPL_UNUSED int nYSize,
+                                                 CPL_UNUSED int nBands,
+                                                 CPL_UNUSED GDALDataType eDT,
+                                                 CSLConstList papszOptions)
 {
     OGRElasticDataSource *poDS = new OGRElasticDataSource();
 

--- a/ogr/ogrsf_frmts/filegdb/FGdbDriver.cpp
+++ b/ogr/ogrsf_frmts/filegdb/FGdbDriver.cpp
@@ -159,7 +159,7 @@ static GDALDataset *OGRFileGDBDriverOpen(GDALOpenInfo *poOpenInfo)
 static GDALDataset *
 OGRFileGDBDriverCreate(const char *pszName, CPL_UNUSED int nBands,
                        CPL_UNUSED int nXSize, CPL_UNUSED int nYSize,
-                       CPL_UNUSED GDALDataType eDT, char **papszOptions)
+                       CPL_UNUSED GDALDataType eDT, CSLConstList papszOptions)
 {
     auto poOpenFileGDBDriver =
         GetGDALDriverManager()->GetDriverByName("OpenFileGDB");

--- a/ogr/ogrsf_frmts/flatgeobuf/ogr_flatgeobuf.h
+++ b/ogr/ogrsf_frmts/flatgeobuf/ogr_flatgeobuf.h
@@ -263,7 +263,7 @@ class OGRFlatGeobufDataset final : public GDALDataset
     static GDALDataset *Create(const char *pszName, CPL_UNUSED int nBands,
                                CPL_UNUSED int nXSize, CPL_UNUSED int nYSize,
                                CPL_UNUSED GDALDataType eDT,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
     using GDALDataset::GetLayer;
     const OGRLayer *GetLayer(int) const override;
     int TestCapability(const char *pszCap) const override;

--- a/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobufdataset.cpp
+++ b/ogr/ogrsf_frmts/flatgeobuf/ogrflatgeobufdataset.cpp
@@ -324,7 +324,7 @@ GDALDataset *OGRFlatGeobufDataset::Create(const char *pszName, int /* nBands */,
                                           CPL_UNUSED int nXSize,
                                           CPL_UNUSED int nYSize,
                                           CPL_UNUSED GDALDataType eDT,
-                                          char ** /* papszOptions */)
+                                          CSLConstList /* papszOptions */)
 {
     // First, ensure there isn't any such file yet.
     VSIStatBufL sStatBuf;

--- a/ogr/ogrsf_frmts/generic/ogrlayer.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrlayer.cpp
@@ -5357,8 +5357,8 @@ static OGRGeometry *promote_to_multi(OGRGeometry *poGeom)
  */
 
 OGRErr OGRLayer::Intersection(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
-                              char **papszOptions, GDALProgressFunc pfnProgress,
-                              void *pProgressArg)
+                              CSLConstList papszOptions,
+                              GDALProgressFunc pfnProgress, void *pProgressArg)
 {
     OGRErr ret = OGRERR_NONE;
     OGRFeatureDefn *poDefnInput = GetLayerDefn();
@@ -5681,7 +5681,7 @@ done:
  */
 
 OGRErr OGR_L_Intersection(OGRLayerH pLayerInput, OGRLayerH pLayerMethod,
-                          OGRLayerH pLayerResult, char **papszOptions,
+                          OGRLayerH pLayerResult, CSLConstList papszOptions,
                           GDALProgressFunc pfnProgress, void *pProgressArg)
 
 {
@@ -5775,7 +5775,7 @@ OGRErr OGR_L_Intersection(OGRLayerH pLayerInput, OGRLayerH pLayerMethod,
  */
 
 OGRErr OGRLayer::Union(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
-                       char **papszOptions, GDALProgressFunc pfnProgress,
+                       CSLConstList papszOptions, GDALProgressFunc pfnProgress,
                        void *pProgressArg)
 {
     OGRErr ret = OGRERR_NONE;
@@ -6231,7 +6231,7 @@ done:
  */
 
 OGRErr OGR_L_Union(OGRLayerH pLayerInput, OGRLayerH pLayerMethod,
-                   OGRLayerH pLayerResult, char **papszOptions,
+                   OGRLayerH pLayerResult, CSLConstList papszOptions,
                    GDALProgressFunc pfnProgress, void *pProgressArg)
 
 {
@@ -6312,7 +6312,7 @@ OGRErr OGR_L_Union(OGRLayerH pLayerInput, OGRLayerH pLayerMethod,
  */
 
 OGRErr OGRLayer::SymDifference(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
-                               char **papszOptions,
+                               CSLConstList papszOptions,
                                GDALProgressFunc pfnProgress, void *pProgressArg)
 {
     OGRErr ret = OGRERR_NONE;
@@ -6649,7 +6649,7 @@ done:
  */
 
 OGRErr OGR_L_SymDifference(OGRLayerH pLayerInput, OGRLayerH pLayerMethod,
-                           OGRLayerH pLayerResult, char **papszOptions,
+                           OGRLayerH pLayerResult, CSLConstList papszOptions,
                            GDALProgressFunc pfnProgress, void *pProgressArg)
 
 {
@@ -6742,8 +6742,8 @@ OGRErr OGR_L_SymDifference(OGRLayerH pLayerInput, OGRLayerH pLayerMethod,
  */
 
 OGRErr OGRLayer::Identity(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
-                          char **papszOptions, GDALProgressFunc pfnProgress,
-                          void *pProgressArg)
+                          CSLConstList papszOptions,
+                          GDALProgressFunc pfnProgress, void *pProgressArg)
 {
     OGRErr ret = OGRERR_NONE;
     OGRFeatureDefn *poDefnInput = GetLayerDefn();
@@ -7078,7 +7078,7 @@ done:
  */
 
 OGRErr OGR_L_Identity(OGRLayerH pLayerInput, OGRLayerH pLayerMethod,
-                      OGRLayerH pLayerResult, char **papszOptions,
+                      OGRLayerH pLayerResult, CSLConstList papszOptions,
                       GDALProgressFunc pfnProgress, void *pProgressArg)
 
 {
@@ -7160,7 +7160,7 @@ OGRErr OGR_L_Identity(OGRLayerH pLayerInput, OGRLayerH pLayerMethod,
  */
 
 OGRErr OGRLayer::Update(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
-                        char **papszOptions, GDALProgressFunc pfnProgress,
+                        CSLConstList papszOptions, GDALProgressFunc pfnProgress,
                         void *pProgressArg)
 {
     OGRErr ret = OGRERR_NONE;
@@ -7434,7 +7434,7 @@ done:
  */
 
 OGRErr OGR_L_Update(OGRLayerH pLayerInput, OGRLayerH pLayerMethod,
-                    OGRLayerH pLayerResult, char **papszOptions,
+                    OGRLayerH pLayerResult, CSLConstList papszOptions,
                     GDALProgressFunc pfnProgress, void *pProgressArg)
 
 {
@@ -7509,7 +7509,7 @@ OGRErr OGR_L_Update(OGRLayerH pLayerInput, OGRLayerH pLayerMethod,
  */
 
 OGRErr OGRLayer::Clip(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
-                      char **papszOptions, GDALProgressFunc pfnProgress,
+                      CSLConstList papszOptions, GDALProgressFunc pfnProgress,
                       void *pProgressArg)
 {
     OGRErr ret = OGRERR_NONE;
@@ -7743,7 +7743,7 @@ done:
  */
 
 OGRErr OGR_L_Clip(OGRLayerH pLayerInput, OGRLayerH pLayerMethod,
-                  OGRLayerH pLayerResult, char **papszOptions,
+                  OGRLayerH pLayerResult, CSLConstList papszOptions,
                   GDALProgressFunc pfnProgress, void *pProgressArg)
 
 {
@@ -7818,7 +7818,7 @@ OGRErr OGR_L_Clip(OGRLayerH pLayerInput, OGRLayerH pLayerMethod,
  */
 
 OGRErr OGRLayer::Erase(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
-                       char **papszOptions, GDALProgressFunc pfnProgress,
+                       CSLConstList papszOptions, GDALProgressFunc pfnProgress,
                        void *pProgressArg)
 {
     OGRErr ret = OGRERR_NONE;
@@ -8031,7 +8031,7 @@ done:
  */
 
 OGRErr OGR_L_Erase(OGRLayerH pLayerInput, OGRLayerH pLayerMethod,
-                   OGRLayerH pLayerResult, char **papszOptions,
+                   OGRLayerH pLayerResult, CSLConstList papszOptions,
                    GDALProgressFunc pfnProgress, void *pProgressArg)
 
 {

--- a/ogr/ogrsf_frmts/generic/ogrlayerarrow.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrlayerarrow.cpp
@@ -2946,7 +2946,7 @@ YES.</li>
  * @since GDAL 3.6
  */
 bool OGR_L_GetArrowStream(OGRLayerH hLayer, struct ArrowArrayStream *out_stream,
-                          char **papszOptions)
+                          CSLConstList papszOptions)
 {
     VALIDATE_POINTER1(hLayer, "OGR_L_GetArrowStream", false);
     VALIDATE_POINTER1(out_stream, "OGR_L_GetArrowStream", false);
@@ -6230,7 +6230,8 @@ bool OGRLayer::IsArrowSchemaSupported(const struct ArrowSchema *schema,
  */
 bool OGR_L_IsArrowSchemaSupported(OGRLayerH hLayer,
                                   const struct ArrowSchema *schema,
-                                  char **papszOptions, char **ppszErrorMsg)
+                                  CSLConstList papszOptions,
+                                  char **ppszErrorMsg)
 {
     VALIDATE_POINTER1(hLayer, __func__, false);
     VALIDATE_POINTER1(schema, __func__, false);
@@ -6667,7 +6668,7 @@ bool OGRLayer::CreateFieldFromArrowSchema(const struct ArrowSchema *schema,
  */
 bool OGR_L_CreateFieldFromArrowSchema(OGRLayerH hLayer,
                                       const struct ArrowSchema *schema,
-                                      char **papszOptions)
+                                      CSLConstList papszOptions)
 {
     VALIDATE_POINTER1(hLayer, __func__, false);
     VALIDATE_POINTER1(schema, __func__, false);
@@ -8478,7 +8479,7 @@ bool OGRLayer::WriteArrowBatch(const struct ArrowSchema *schema,
 // clang-format on
 
 bool OGR_L_WriteArrowBatch(OGRLayerH hLayer, const struct ArrowSchema *schema,
-                           struct ArrowArray *array, char **papszOptions)
+                           struct ArrowArray *array, CSLConstList papszOptions)
 {
     VALIDATE_POINTER1(hLayer, __func__, false);
     VALIDATE_POINTER1(schema, __func__, false);

--- a/ogr/ogrsf_frmts/generic/ogrmutexeddatasource.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrmutexeddatasource.cpp
@@ -120,7 +120,7 @@ OGRMutexedDataSource::ICreateLayer(const char *pszName,
 
 OGRLayer *OGRMutexedDataSource::CopyLayer(OGRLayer *poSrcLayer,
                                           const char *pszNewName,
-                                          char **papszOptions)
+                                          CSLConstList papszOptions)
 {
     CPLMutexHolderOptionalLockD(m_hGlobalMutex);
     return WrapLayerIfNecessary(

--- a/ogr/ogrsf_frmts/generic/ogrmutexeddatasource.h
+++ b/ogr/ogrsf_frmts/generic/ogrmutexeddatasource.h
@@ -67,7 +67,7 @@ class CPL_DLL OGRMutexedDataSource final : public GDALDataset
                                    const OGRGeomFieldDefn *poGeomFieldDefn,
                                    CSLConstList papszOptions) override;
     virtual OGRLayer *CopyLayer(OGRLayer *poSrcLayer, const char *pszNewName,
-                                char **papszOptions = nullptr) override;
+                                CSLConstList papszOptions = nullptr) override;
 
     OGRStyleTable *GetStyleTable() override;
     void SetStyleTableDirectly(OGRStyleTable *poStyleTable) override;

--- a/ogr/ogrsf_frmts/generic/ogrsfdriverregistrar.cpp
+++ b/ogr/ogrsf_frmts/generic/ogrsfdriverregistrar.cpp
@@ -294,11 +294,11 @@ GDALDataset *OGRSFDriverRegistrar::OpenWithDriverArg(GDALDriver *poDriver,
 
 GDALDataset *OGRSFDriverRegistrar::CreateVectorOnly(GDALDriver *poDriver,
                                                     const char *pszName,
-                                                    char **papszOptions)
+                                                    CSLConstList papszOptions)
 {
     OGRDataSource *poDS = reinterpret_cast<OGRDataSource *>(
         reinterpret_cast<OGRSFDriver *>(poDriver)->CreateDataSource(
-            pszName, papszOptions));
+            pszName, const_cast<char **>(papszOptions)));
     if (poDS != nullptr && poDS->GetName() != nullptr)
         poDS->SetDescription(poDS->GetName());
     return poDS;

--- a/ogr/ogrsf_frmts/geojson/ogr_geojson.h
+++ b/ogr/ogrsf_frmts/geojson/ogr_geojson.h
@@ -260,7 +260,7 @@ class OGRGeoJSONDataSource final : public GDALDataset
     //
     // OGRGeoJSONDataSource Interface
     //
-    int Create(const char *pszName, char **papszOptions);
+    int Create(const char *pszName, CSLConstList papszOptions);
 
     VSILFILE *GetOutputFile() const
     {

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsondatasource.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsondatasource.cpp
@@ -687,7 +687,7 @@ int OGRGeoJSONDataSource::TestCapability(const char *pszCap) const
 /************************************************************************/
 
 int OGRGeoJSONDataSource::Create(const char *pszName,
-                                 char ** /* papszOptions */)
+                                 CSLConstList /* papszOptions */)
 {
     CPLAssert(nullptr == fpOut_);
 

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsondriver.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsondriver.cpp
@@ -582,7 +582,7 @@ static GDALDataset *OGRGeoJSONDriverCreate(const char *pszName,
                                            int /* nBands */, int /* nXSize */,
                                            int /* nYSize */,
                                            GDALDataType /* eDT */,
-                                           char **papszOptions)
+                                           CSLConstList papszOptions)
 {
     OGRGeoJSONDataSource *poDS = new OGRGeoJSONDataSource();
 

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonseqdriver.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonseqdriver.cpp
@@ -57,7 +57,7 @@ class OGRGeoJSONSeqDataSource final : public GDALDataset
     int TestCapability(const char *pszCap) const override;
 
     bool Open(GDALOpenInfo *poOpenInfo, GeoJSONSourceType nSrcType);
-    bool Create(const char *pszName, char **papszOptions);
+    bool Create(const char *pszName, CSLConstList papszOptions);
 };
 
 /************************************************************************/
@@ -893,7 +893,7 @@ bool OGRGeoJSONSeqDataSource::Open(GDALOpenInfo *poOpenInfo,
 /************************************************************************/
 
 bool OGRGeoJSONSeqDataSource::Create(const char *pszName,
-                                     char ** /* papszOptions */)
+                                     CSLConstList /* papszOptions */)
 {
     CPLAssert(nullptr == m_fp);
 
@@ -985,7 +985,7 @@ static GDALDataset *OGRGeoJSONSeqDriverOpen(GDALOpenInfo *poOpenInfo)
 static GDALDataset *
 OGRGeoJSONSeqDriverCreate(const char *pszName, int /* nBands */,
                           int /* nXSize */, int /* nYSize */,
-                          GDALDataType /* eDT */, char **papszOptions)
+                          GDALDataType /* eDT */, CSLConstList papszOptions)
 {
     OGRGeoJSONSeqDataSource *poDS = new OGRGeoJSONSeqDataSource();
 

--- a/ogr/ogrsf_frmts/georss/ogr_georss.h
+++ b/ogr/ogrsf_frmts/georss/ogr_georss.h
@@ -181,7 +181,7 @@ class OGRGeoRSSDataSource final : public GDALDataset
 
     int Open(const char *pszFilename, int bUpdate);
 
-    int Create(const char *pszFilename, char **papszOptions);
+    int Create(const char *pszFilename, CSLConstList papszOptions);
 
     int GetLayerCount() const override
     {

--- a/ogr/ogrsf_frmts/georss/ogrgeorssdatasource.cpp
+++ b/ogr/ogrsf_frmts/georss/ogrgeorssdatasource.cpp
@@ -350,7 +350,8 @@ int OGRGeoRSSDataSource::Open(const char *pszFilename, int bUpdateIn)
 /*                               Create()                               */
 /************************************************************************/
 
-int OGRGeoRSSDataSource::Create(const char *pszFilename, char **papszOptions)
+int OGRGeoRSSDataSource::Create(const char *pszFilename,
+                                CSLConstList papszOptions)
 {
     if (fpOutput != nullptr)
     {

--- a/ogr/ogrsf_frmts/georss/ogrgeorssdriver.cpp
+++ b/ogr/ogrsf_frmts/georss/ogrgeorssdriver.cpp
@@ -55,7 +55,7 @@ static GDALDataset *OGRGeoRSSDriverOpen(GDALOpenInfo *poOpenInfo)
 static GDALDataset *
 OGRGeoRSSDriverCreate(const char *pszName, CPL_UNUSED int nBands,
                       CPL_UNUSED int nXSize, CPL_UNUSED int nYSize,
-                      CPL_UNUSED GDALDataType eDT, char **papszOptions)
+                      CPL_UNUSED GDALDataType eDT, CSLConstList papszOptions)
 {
     OGRGeoRSSDataSource *poDS = new OGRGeoRSSDataSource();
 

--- a/ogr/ogrsf_frmts/gml/ogr_gml.h
+++ b/ogr/ogrsf_frmts/gml/ogr_gml.h
@@ -178,7 +178,7 @@ class OGRGMLDataSource final : public GDALDataset
 
     bool Open(GDALOpenInfo *poOpenInfo);
     CPLErr Close(GDALProgressFunc = nullptr, void * = nullptr) override;
-    bool Create(const char *pszFile, char **papszOptions);
+    bool Create(const char *pszFile, CSLConstList papszOptions);
 
     int GetLayerCount() const override
     {

--- a/ogr/ogrsf_frmts/gml/ogrgmldatasource.cpp
+++ b/ogr/ogrsf_frmts/gml/ogrgmldatasource.cpp
@@ -1857,7 +1857,8 @@ const char *OGRGMLDataSource::GetGlobalSRSName()
 /*                               Create()                               */
 /************************************************************************/
 
-bool OGRGMLDataSource::Create(const char *pszFilename, char **papszOptions)
+bool OGRGMLDataSource::Create(const char *pszFilename,
+                              CSLConstList papszOptions)
 
 {
     if (fpOutput != nullptr || poReader != nullptr)

--- a/ogr/ogrsf_frmts/gml/ogrgmldriver.cpp
+++ b/ogr/ogrsf_frmts/gml/ogrgmldriver.cpp
@@ -98,7 +98,7 @@ static GDALDataset *OGRGMLDriverOpen(GDALOpenInfo *poOpenInfo)
 static GDALDataset *
 OGRGMLDriverCreate(const char *pszName, CPL_UNUSED int nBands,
                    CPL_UNUSED int nXSize, CPL_UNUSED int nYSize,
-                   CPL_UNUSED GDALDataType eDT, char **papszOptions)
+                   CPL_UNUSED GDALDataType eDT, CSLConstList papszOptions)
 {
     OGRGMLDataSource *poDS = new OGRGMLDataSource();
 

--- a/ogr/ogrsf_frmts/gmlas/ogr_gmlas.h
+++ b/ogr/ogrsf_frmts/gmlas/ogr_gmlas.h
@@ -40,7 +40,7 @@ typedef enum
 
 GDALDataset *OGRGMLASDriverCreateCopy(const char *pszFilename,
                                       GDALDataset *poSrcDS, int /*bStrict*/,
-                                      char **papszOptions,
+                                      CSLConstList papszOptions,
                                       GDALProgressFunc pfnProgress,
                                       void *pProgressData);
 

--- a/ogr/ogrsf_frmts/gmlas/ogrgmlaswriter.cpp
+++ b/ogr/ogrsf_frmts/gmlas/ogrgmlaswriter.cpp
@@ -2819,7 +2819,7 @@ GMLASFakeDataset::~GMLASFakeDataset() = default;
 
 GDALDataset *OGRGMLASDriverCreateCopy(const char *pszFilename,
                                       GDALDataset *poSrcDS, int /*bStrict*/,
-                                      char **papszOptions,
+                                      CSLConstList papszOptions,
                                       GDALProgressFunc pfnProgress,
                                       void *pProgressData)
 {

--- a/ogr/ogrsf_frmts/gmt/ogrgmtdriver.cpp
+++ b/ogr/ogrsf_frmts/gmt/ogrgmtdriver.cpp
@@ -61,7 +61,8 @@ static GDALDataset *OGRGMTDriverOpen(GDALOpenInfo *poOpenInfo)
 static GDALDataset *OGRGMTDriverCreate(const char *, CPL_UNUSED int nBands,
                                        CPL_UNUSED int nXSize,
                                        CPL_UNUSED int nYSize,
-                                       CPL_UNUSED GDALDataType eDT, char **)
+                                       CPL_UNUSED GDALDataType eDT,
+                                       CSLConstList)
 {
     return new OGRGmtDataSource();
 }

--- a/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
+++ b/ogr/ogrsf_frmts/gpkg/ogr_geopackage.h
@@ -206,7 +206,7 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource,
                     double dfMinX, double dfMinY, double dfMaxX, double dfMaxY,
                     const char *pszContentsMinX, const char *pszContentsMinY,
                     const char *pszContentsMaxX, const char *pszContentsMaxY,
-                    char **papszOpenOptions, const SQLResult &oResult,
+                    CSLConstList papszOpenOptions, const SQLResult &oResult,
                     int nIdxInResult);
     bool InitRaster(GDALGeoPackageDataset *poParentDS, const char *pszTableName,
                     int nZoomLevel, int nBandCount, double dfTMSMinX,
@@ -220,12 +220,12 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource,
                     double dfMinY, double dfMaxX, double dfMaxY,
                     const char *pszContentsMinX, const char *pszContentsMinY,
                     const char *pszContentsMaxX, const char *pszContentsMaxY,
-                    bool bIsTiles, char **papszOptions);
+                    bool bIsTiles, CSLConstList papszOptions);
     CPLErr FinalizeRasterRegistration();
 
     bool RegisterWebPExtension();
     bool RegisterZoomOtherExtension();
-    void ParseCompressionOptions(char **papszOptions);
+    void ParseCompressionOptions(CSLConstList papszOptions);
 
     bool HasMetadataTables() const;
     bool CreateMetadataTables();
@@ -238,7 +238,7 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource,
     int FindLayerIndex(const char *pszLayerName);
 
     bool HasGriddedCoverageAncillaryTable();
-    bool CreateTileGriddedTable(char **papszOptions);
+    bool CreateTileGriddedTable(CSLConstList papszOptions);
 
     void RemoveOGREmptyTable();
 
@@ -325,7 +325,7 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource,
 
     int Open(GDALOpenInfo *poOpenInfo, const std::string &osFilenameInZip);
     int Create(const char *pszFilename, int nXSize, int nYSize, int nBands,
-               GDALDataType eDT, char **papszOptions);
+               GDALDataType eDT, CSLConstList papszOptions);
     const OGRLayer *GetLayer(int iLayer) const override;
     OGRErr DeleteLayer(int iLayer) override;
     OGRLayer *ICreateLayer(const char *pszName,
@@ -409,7 +409,7 @@ class GDALGeoPackageDataset final : public OGRSQLiteBaseDataSource,
 
     static GDALDataset *CreateCopy(const char *pszFilename,
                                    GDALDataset *poSrcDS, int bStrict,
-                                   char **papszOptions,
+                                   CSLConstList papszOptions,
                                    GDALProgressFunc pfnProgress,
                                    void *pProgressData);
 

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -2285,7 +2285,7 @@ bool GDALGeoPackageDataset::InitRaster(
     GDALGeoPackageDataset *poParentDS, const char *pszTableName, double dfMinX,
     double dfMinY, double dfMaxX, double dfMaxY, const char *pszContentsMinX,
     const char *pszContentsMinY, const char *pszContentsMaxX,
-    const char *pszContentsMaxY, char **papszOpenOptionsIn,
+    const char *pszContentsMaxY, CSLConstList papszOpenOptionsIn,
     const SQLResult &oResult, int nIdxInResult)
 {
     m_osRasterTable = pszTableName;
@@ -2632,7 +2632,7 @@ bool GDALGeoPackageDataset::OpenRaster(
     const char *pszDescription, int nSRSId, double dfMinX, double dfMinY,
     double dfMaxX, double dfMaxY, const char *pszContentsMinX,
     const char *pszContentsMinY, const char *pszContentsMaxX,
-    const char *pszContentsMaxY, bool bIsTiles, char **papszOpenOptionsIn)
+    const char *pszContentsMaxY, bool bIsTiles, CSLConstList papszOpenOptionsIn)
 {
     if (dfMinX >= dfMaxX || dfMinY >= dfMaxY)
         return false;
@@ -4945,7 +4945,7 @@ CPLErr GDALGeoPackageDataset::SetMetadataItem(const char *pszName,
 
 int GDALGeoPackageDataset::Create(const char *pszFilename, int nXSize,
                                   int nYSize, int nBandsIn, GDALDataType eDT,
-                                  char **papszOptions)
+                                  CSLConstList papszOptions)
 {
     CPLString osCommand;
 
@@ -5702,7 +5702,7 @@ void GDALGeoPackageDataset::RemoveOGREmptyTable()
 /*                        CreateTileGriddedTable()                      */
 /************************************************************************/
 
-bool GDALGeoPackageDataset::CreateTileGriddedTable(char **papszOptions)
+bool GDALGeoPackageDataset::CreateTileGriddedTable(CSLConstList papszOptions)
 {
     CPLString osSQL;
     if (!HasGriddedCoverageAncillaryTable())
@@ -5897,7 +5897,8 @@ static const WarpResamplingAlg asResamplingAlg[] = {
 
 GDALDataset *GDALGeoPackageDataset::CreateCopy(const char *pszFilename,
                                                GDALDataset *poSrcDS,
-                                               int bStrict, char **papszOptions,
+                                               int bStrict,
+                                               CSLConstList papszOptions,
                                                GDALProgressFunc pfnProgress,
                                                void *pProgressData)
 {
@@ -6382,7 +6383,7 @@ GDALDataset *GDALGeoPackageDataset::CreateCopy(const char *pszFilename,
 /*                        ParseCompressionOptions()                     */
 /************************************************************************/
 
-void GDALGeoPackageDataset::ParseCompressionOptions(char **papszOptions)
+void GDALGeoPackageDataset::ParseCompressionOptions(CSLConstList papszOptions)
 {
     const char *pszZLevel = CSLFetchNameValue(papszOptions, "ZLEVEL");
     if (pszZLevel)

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedriver.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedriver.cpp
@@ -355,7 +355,7 @@ static GDALDataset *OGRGeoPackageDriverOpen(GDALOpenInfo *poOpenInfo)
 static GDALDataset *OGRGeoPackageDriverCreate(const char *pszFilename,
                                               int nXSize, int nYSize,
                                               int nBands, GDALDataType eDT,
-                                              char **papszOptions)
+                                              CSLConstList papszOptions)
 {
     if (strcmp(pszFilename, ":memory:") != 0)
     {

--- a/ogr/ogrsf_frmts/gpsbabel/ogr_gpsbabel.h
+++ b/ogr/ogrsf_frmts/gpsbabel/ogr_gpsbabel.h
@@ -81,7 +81,7 @@ class OGRGPSBabelWriteDataSource final : public GDALDataset
                            const OGRGeomFieldDefn *poGeomFieldDefn,
                            CSLConstList papszOptions) override;
 
-    int Create(const char *pszFilename, char **papszOptions);
+    int Create(const char *pszFilename, CSLConstList papszOptions);
 };
 
 #endif /* ndef OGR_GPSBABEL_H_INCLUDED */

--- a/ogr/ogrsf_frmts/gpsbabel/ogrgpsbabeldriver.cpp
+++ b/ogr/ogrsf_frmts/gpsbabel/ogrgpsbabeldriver.cpp
@@ -162,7 +162,7 @@ static GDALDataset *OGRGPSBabelDriverCreate(const char *pszName,
                                             int /* nBands */, int /* nXSize */,
                                             int /* nYSize */,
                                             GDALDataType /* eDT */,
-                                            char **papszOptions)
+                                            CSLConstList papszOptions)
 {
     OGRGPSBabelWriteDataSource *poDS = new OGRGPSBabelWriteDataSource();
 

--- a/ogr/ogrsf_frmts/gpsbabel/ogrgpsbabelwritedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpsbabel/ogrgpsbabelwritedatasource.cpp
@@ -118,7 +118,7 @@ bool OGRGPSBabelWriteDataSource::Convert()
 /************************************************************************/
 
 int OGRGPSBabelWriteDataSource::Create(const char *pszNameIn,
-                                       char **papszOptions)
+                                       CSLConstList papszOptions)
 {
     GDALDriver *poGPXDriver =
         OGRSFDriverRegistrar::GetRegistrar()->GetDriverByName("GPX");

--- a/ogr/ogrsf_frmts/gpx/ogr_gpx.h
+++ b/ogr/ogrsf_frmts/gpx/ogr_gpx.h
@@ -212,7 +212,7 @@ class OGRGPXDataSource final : public GDALDataset
 
     int Open(GDALOpenInfo *poOpenInfo);
 
-    int Create(const char *pszFilename, char **papszOptions);
+    int Create(const char *pszFilename, CSLConstList papszOptions);
 
     int GetLayerCount() const override
     {

--- a/ogr/ogrsf_frmts/gpx/ogrgpxdatasource.cpp
+++ b/ogr/ogrsf_frmts/gpx/ogrgpxdatasource.cpp
@@ -594,7 +594,7 @@ int OGRGPXDataSource::Open(GDALOpenInfo *poOpenInfo)
 /*                               Create()                               */
 /************************************************************************/
 
-int OGRGPXDataSource::Create(const char *pszFilename, char **papszOptions)
+int OGRGPXDataSource::Create(const char *pszFilename, CSLConstList papszOptions)
 {
     if (strcmp(pszFilename, "/dev/stdout") == 0)
         pszFilename = "/vsistdout/";

--- a/ogr/ogrsf_frmts/gpx/ogrgpxdriver.cpp
+++ b/ogr/ogrsf_frmts/gpx/ogrgpxdriver.cpp
@@ -61,10 +61,12 @@ static GDALDataset *OGRGPXDriverOpen(GDALOpenInfo *poOpenInfo)
 /*                               Create()                               */
 /************************************************************************/
 
-static GDALDataset *
-OGRGPXDriverCreate(const char *pszName, CPL_UNUSED int nBands,
-                   CPL_UNUSED int nXSize, CPL_UNUSED int nYSize,
-                   CPL_UNUSED GDALDataType eDT, CPL_UNUSED char **papszOptions)
+static GDALDataset *OGRGPXDriverCreate(const char *pszName,
+                                       CPL_UNUSED int nBands,
+                                       CPL_UNUSED int nXSize,
+                                       CPL_UNUSED int nYSize,
+                                       CPL_UNUSED GDALDataType eDT,
+                                       CPL_UNUSED CSLConstList papszOptions)
 {
     OGRGPXDataSource *poDS = new OGRGPXDataSource();
 

--- a/ogr/ogrsf_frmts/hana/ogr_hana.h
+++ b/ogr/ogrsf_frmts/hana/ogr_hana.h
@@ -443,7 +443,7 @@ class OGRHanaDataSource final : public GDALDataset
     OGRHanaDataSource();
     ~OGRHanaDataSource() override;
 
-    int Open(const char *newName, char **options, int update);
+    int Open(const char *newName, CSLConstList options, int update);
 
     OGRHANA::HanaVersion GetHanaVersion() const
     {

--- a/ogr/ogrsf_frmts/hana/ogrhanadatasource.cpp
+++ b/ogr/ogrsf_frmts/hana/ogrhanadatasource.cpp
@@ -553,7 +553,8 @@ OGRHanaDataSource::~OGRHanaDataSource()
 /*                                 Open()                               */
 /************************************************************************/
 
-int OGRHanaDataSource::Open(const char *newName, char **openOptions, int update)
+int OGRHanaDataSource::Open(const char *newName, CSLConstList openOptions,
+                            int update)
 {
     CPLAssert(layers_.size() == 0);
 

--- a/ogr/ogrsf_frmts/hana/ogrhanadriver.cpp
+++ b/ogr/ogrsf_frmts/hana/ogrhanadriver.cpp
@@ -40,7 +40,7 @@ static GDALDataset *OGRHanaDriverCreate(const char *name, CPL_UNUSED int nBands,
                                         CPL_UNUSED int nXSize,
                                         CPL_UNUSED int nYSize,
                                         CPL_UNUSED GDALDataType eDT,
-                                        CPL_UNUSED char **options)
+                                        CSLConstList options)
 {
     auto ds = std::make_unique<OGRHanaDataSource>();
     if (!ds->Open(name, options, TRUE))

--- a/ogr/ogrsf_frmts/jml/ogr_jml.h
+++ b/ogr/ogrsf_frmts/jml/ogr_jml.h
@@ -211,7 +211,7 @@ class OGRJMLDataset final : public GDALDataset
     static GDALDataset *Open(GDALOpenInfo *poOpenInfo);
     static GDALDataset *Create(const char *pszFilename, int nBands, int nXSize,
                                int nYSize, GDALDataType eDT,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
 };
 
 #endif /* ndef OGR_JML_H_INCLUDED */

--- a/ogr/ogrsf_frmts/jml/ogrjmldataset.cpp
+++ b/ogr/ogrsf_frmts/jml/ogrjmldataset.cpp
@@ -117,7 +117,7 @@ GDALDataset *OGRJMLDataset::Open(GDALOpenInfo *poOpenInfo)
 GDALDataset *OGRJMLDataset::Create(const char *pszFilename, int /* nXSize */,
                                    int /* nYSize */, int /* nBands */,
                                    GDALDataType /* eDT */,
-                                   char ** /* papszOptions */)
+                                   CSLConstList /* papszOptions */)
 {
     if (strcmp(pszFilename, "/dev/stdout") == 0)
         pszFilename = "/vsistdout/";

--- a/ogr/ogrsf_frmts/jsonfg/ogrjsonfgdriver.cpp
+++ b/ogr/ogrsf_frmts/jsonfg/ogrjsonfgdriver.cpp
@@ -59,7 +59,7 @@ static GDALDataset *OGRJSONFGDriverOpen(GDALOpenInfo *poOpenInfo)
 static GDALDataset *OGRJSONFGDriverCreate(const char *pszName, int /* nBands */,
                                           int /* nXSize */, int /* nYSize */,
                                           GDALDataType /* eDT */,
-                                          char **papszOptions)
+                                          CSLConstList papszOptions)
 {
     auto poDS = std::make_unique<OGRJSONFGDataset>();
     if (!poDS->Create(pszName, papszOptions))

--- a/ogr/ogrsf_frmts/kml/ogr_kml.h
+++ b/ogr/ogrsf_frmts/kml/ogr_kml.h
@@ -110,7 +110,7 @@ class OGRKMLDataSource final : public GDALDataset
     //
     // OGRKMLDataSource Interface
     //
-    int Create(const char *pszName, char **papszOptions);
+    int Create(const char *pszName, CSLConstList papszOptions);
 
     const char *GetNameField() const
     {

--- a/ogr/ogrsf_frmts/kml/ogrkmldatasource.cpp
+++ b/ogr/ogrsf_frmts/kml/ogrkmldatasource.cpp
@@ -253,7 +253,7 @@ int OGRKMLDataSource::Open(const char *pszNewName, int bTestOpen)
 /*                               Create()                               */
 /************************************************************************/
 
-int OGRKMLDataSource::Create(const char *pszName, char **papszOptions)
+int OGRKMLDataSource::Create(const char *pszName, CSLConstList papszOptions)
 {
     CPLAssert(nullptr != pszName);
 

--- a/ogr/ogrsf_frmts/kml/ogrkmldriver.cpp
+++ b/ogr/ogrsf_frmts/kml/ogrkmldriver.cpp
@@ -86,7 +86,7 @@ static GDALDataset *OGRKMLDriverOpen(GDALOpenInfo *poOpenInfo)
 static GDALDataset *OGRKMLDriverCreate(const char *pszName, int /* nBands */,
                                        int /* nXSize */, int /* nYSize */,
                                        GDALDataType /* eDT */,
-                                       char **papszOptions)
+                                       CSLConstList papszOptions)
 {
     CPLAssert(nullptr != pszName);
     CPLDebug("KML", "Attempt to create: %s", pszName);

--- a/ogr/ogrsf_frmts/libkml/ogr_libkml.h
+++ b/ogr/ogrsf_frmts/libkml/ogr_libkml.h
@@ -263,7 +263,7 @@ class OGRLIBKMLDataSource final : public GDALDataset
     void SetStyleTable(OGRStyleTable *poStyleTable) override;
 
     int Open(const char *pszFilename, bool bUpdate);
-    int Create(const char *pszFilename, char **papszOptions);
+    int Create(const char *pszFilename, CSLConstList papszOptions);
 
     CPLErr FlushCache(bool bAtClosing) override;
     int TestCapability(const char *) const override;
@@ -328,9 +328,9 @@ class OGRLIBKMLDataSource final : public GDALDataset
     int OpenDir(const char *pszFilename, int bUpdate);
 
     /***** methods to create various datasource types *****/
-    int CreateKml(const char *pszFilename, char **papszOptions);
-    int CreateKmz(const char *pszFilename, char **papszOptions);
-    int CreateDir(const char *pszFilename, char **papszOptions);
+    int CreateKml(const char *pszFilename, CSLConstList papszOptions);
+    int CreateKmz(const char *pszFilename, CSLConstList papszOptions);
+    int CreateDir(const char *pszFilename, CSLConstList papszOptions);
 
     /***** methods to create layers on various datasource types *****/
     OGRLIBKMLLayer *CreateLayerKml(const char *pszLayerName,

--- a/ogr/ogrsf_frmts/libkml/ogrlibkmldatasource.cpp
+++ b/ogr/ogrsf_frmts/libkml/ogrlibkmldatasource.cpp
@@ -358,7 +358,7 @@ bool OGRLIBKMLDataSource::WriteKml()
 /******************************************************************************/
 
 static KmlPtr OGRLIBKMLCreateOGCKml22(KmlFactory *poFactory,
-                                      char **papszOptions = nullptr)
+                                      CSLConstList papszOptions = nullptr)
 {
     const char *pszAuthorName = CSLFetchNameValue(papszOptions, "AUTHOR_NAME");
     const char *pszAuthorURI = CSLFetchNameValue(papszOptions, "AUTHOR_URI");
@@ -1824,7 +1824,7 @@ void OGRLIBKMLDataSource::ParseDocumentOptions(KmlPtr poKml,
 ******************************************************************************/
 
 int OGRLIBKMLDataSource::CreateKml(const char * /* pszFilename */,
-                                   char **papszOptions)
+                                   CSLConstList papszOptions)
 {
     m_poKmlDSKml = OGRLIBKMLCreateOGCKml22(m_poKmlFactory, papszOptions);
     if (osUpdateTargetHref.empty())
@@ -1851,7 +1851,7 @@ int OGRLIBKMLDataSource::CreateKml(const char * /* pszFilename */,
 ******************************************************************************/
 
 int OGRLIBKMLDataSource::CreateKmz(const char * /* pszFilename */,
-                                   char ** /* papszOptions */)
+                                   CSLConstList /* papszOptions */)
 {
     /***** create the doc.kml  *****/
     if (osUpdateTargetHref.empty())
@@ -1886,7 +1886,7 @@ int OGRLIBKMLDataSource::CreateKmz(const char * /* pszFilename */,
 ******************************************************************************/
 
 int OGRLIBKMLDataSource::CreateDir(const char *pszFilename,
-                                   char ** /* papszOptions */)
+                                   CSLConstList /* papszOptions */)
 {
     if (VSIMkdir(pszFilename, 0755))
     {
@@ -1927,7 +1927,8 @@ int OGRLIBKMLDataSource::CreateDir(const char *pszFilename,
 
 ******************************************************************************/
 
-int OGRLIBKMLDataSource::Create(const char *pszFilename, char **papszOptions)
+int OGRLIBKMLDataSource::Create(const char *pszFilename,
+                                CSLConstList papszOptions)
 {
     if (strcmp(pszFilename, "/dev/stdout") == 0)
         pszFilename = "/vsistdout/";

--- a/ogr/ogrsf_frmts/libkml/ogrlibkmldriver.cpp
+++ b/ogr/ogrsf_frmts/libkml/ogrlibkmldriver.cpp
@@ -69,7 +69,7 @@ static GDALDataset *OGRLIBKMLDriverOpen(GDALOpenInfo *poOpenInfo)
 static GDALDataset *OGRLIBKMLDriverCreate(const char *pszName, int /* nBands */,
                                           int /* nXSize */, int /* nYSize */,
                                           GDALDataType /* eDT */,
-                                          char **papszOptions)
+                                          CSLConstList papszOptions)
 {
     CPLAssert(nullptr != pszName);
     CPLDebug("LIBKML", "Attempt to create: %s", pszName);

--- a/ogr/ogrsf_frmts/libkml/ogrlibkmlstyle.cpp
+++ b/ogr/ogrsf_frmts/libkml/ogrlibkmlstyle.cpp
@@ -987,7 +987,7 @@ void ParseStyles(DocumentPtr poKmlDocument, OGRStyleTable **poStyleTable)
 ******************************************************************************/
 
 void styletable2kml(OGRStyleTable *poOgrStyleTable, KmlFactory *poKmlFactory,
-                    ContainerPtr poKmlContainer, char **papszOptions)
+                    ContainerPtr poKmlContainer, CSLConstList papszOptions)
 {
     /***** just return if the styletable is null *****/
     if (!poOgrStyleTable)

--- a/ogr/ogrsf_frmts/libkml/ogrlibkmlstyle.h
+++ b/ogr/ogrsf_frmts/libkml/ogrlibkmlstyle.h
@@ -54,7 +54,7 @@ void ParseStyles(kmldom::DocumentPtr poKmlDocument,
 void styletable2kml(OGRStyleTable *poOgrStyleTable,
                     kmldom::KmlFactory *poKmlFactory,
                     kmldom::ContainerPtr poKmlContainer,
-                    char **papszOptions = nullptr);
+                    CSLConstList papszOptions = nullptr);
 
 /******************************************************************************
  Function to add a ListStyle and select it to a container.

--- a/ogr/ogrsf_frmts/mapml/ogrmapmldataset.cpp
+++ b/ogr/ogrsf_frmts/mapml/ogrmapmldataset.cpp
@@ -150,7 +150,7 @@ class OGRMapMLWriterDataset final : public GDALPamDataset
 
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBandsIn, GDALDataType eDT,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
 };
 
 /************************************************************************/
@@ -880,7 +880,7 @@ OGRMapMLWriterDataset::~OGRMapMLWriterDataset()
 GDALDataset *OGRMapMLWriterDataset::Create(const char *pszFilename, int nXSize,
                                            int nYSize, int nBandsIn,
                                            GDALDataType eDT,
-                                           char **papszOptions)
+                                           CSLConstList papszOptions)
 {
     if (nXSize != 0 || nYSize != 0 || nBandsIn != 0 || eDT != GDT_Unknown)
     {

--- a/ogr/ogrsf_frmts/miramon/ogrmiramondriver.cpp
+++ b/ogr/ogrsf_frmts/miramon/ogrmiramondriver.cpp
@@ -95,10 +95,12 @@ static GDALDataset *OGRMiraMonDriverOpen(GDALOpenInfo *poOpenInfo)
 /*                         OGRMiraMonDriverCreate()                              */
 /****************************************************************************/
 
-static GDALDataset *
-OGRMiraMonDriverCreate(const char *pszName, CPL_UNUSED int /*nBands*/,
-                       CPL_UNUSED int /*nXSize*/, CPL_UNUSED int /*nYSize*/,
-                       CPL_UNUSED GDALDataType /*eDT*/, char **papszOptions)
+static GDALDataset *OGRMiraMonDriverCreate(const char *pszName,
+                                           CPL_UNUSED int /*nBands*/,
+                                           CPL_UNUSED int /*nXSize*/,
+                                           CPL_UNUSED int /*nYSize*/,
+                                           CPL_UNUSED GDALDataType /*eDT*/,
+                                           CSLConstList papszOptions)
 {
     auto poDS = std::make_unique<OGRMiraMonDataSource>();
 

--- a/ogr/ogrsf_frmts/mitab/mitab_ogr_datasource.cpp
+++ b/ogr/ogrsf_frmts/mitab/mitab_ogr_datasource.cpp
@@ -58,7 +58,7 @@ OGRTABDataSource::~OGRTABDataSource()
 /*      Create a new dataset (directory or file).                       */
 /************************************************************************/
 
-int OGRTABDataSource::Create(const char *pszName, char **papszOptions)
+int OGRTABDataSource::Create(const char *pszName, CSLConstList papszOptions)
 
 {
     SetDescription(pszName);

--- a/ogr/ogrsf_frmts/mitab/mitab_ogr_driver.cpp
+++ b/ogr/ogrsf_frmts/mitab/mitab_ogr_driver.cpp
@@ -110,7 +110,7 @@ static GDALDataset *OGRTABDriverOpen(GDALOpenInfo *poOpenInfo)
 static GDALDataset *
 OGRTABDriverCreate(const char *pszName, CPL_UNUSED int nBands,
                    CPL_UNUSED int nXSize, CPL_UNUSED int nYSize,
-                   CPL_UNUSED GDALDataType eDT, char **papszOptions)
+                   CPL_UNUSED GDALDataType eDT, CSLConstList papszOptions)
 {
     // Try to create the data source.
     OGRTABDataSource *poDS = new OGRTABDataSource();

--- a/ogr/ogrsf_frmts/mitab/mitab_ogr_driver.h
+++ b/ogr/ogrsf_frmts/mitab/mitab_ogr_driver.h
@@ -53,7 +53,7 @@ class OGRTABDataSource final : public GDALDataset
     ~OGRTABDataSource() override;
 
     int Open(GDALOpenInfo *poOpenInfo, int bTestOpen);
-    int Create(const char *pszName, char **papszOptions);
+    int Create(const char *pszName, CSLConstList papszOptions);
 
     int GetLayerCount() const override;
     const OGRLayer *GetLayer(int) const override;

--- a/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdriver.cpp
+++ b/ogr/ogrsf_frmts/mssqlspatial/ogrmssqlspatialdriver.cpp
@@ -46,7 +46,7 @@ static GDALDataset *OGRMSSQLSpatialDriverOpen(GDALOpenInfo *poOpenInfo)
 static GDALDataset *OGRMSSQLSpatialDriverCreateDataSource(
     const char *pszName, CPL_UNUSED int nBands, CPL_UNUSED int nXSize,
     CPL_UNUSED int nYSize, CPL_UNUSED GDALDataType eDT,
-    CPL_UNUSED char **papszOptions)
+    CPL_UNUSED CSLConstList papszOptions)
 {
     if (!STARTS_WITH_CI(pszName, "MSSQL:"))
         return nullptr;

--- a/ogr/ogrsf_frmts/mvt/mvtutils.h
+++ b/ogr/ogrsf_frmts/mvt/mvtutils.h
@@ -77,7 +77,8 @@ OGRFeature *OGRMVTCreateFeatureFrom(OGRFeature *poSrcFeature,
 // #ifdef HAVE_MVT_WRITE_SUPPORT
 GDALDataset *OGRMVTWriterDatasetCreate(const char *pszFilename, int nXSize,
                                        int nYSize, int nBandsIn,
-                                       GDALDataType eDT, char **papszOptions);
+                                       GDALDataType eDT,
+                                       CSLConstList papszOptions);
 // #endif
 
 #endif  // MVTUTILS_H

--- a/ogr/ogrsf_frmts/mvt/ogrmvtdataset.cpp
+++ b/ogr/ogrsf_frmts/mvt/ogrmvtdataset.cpp
@@ -3527,7 +3527,7 @@ class OGRMVTWriterDataset final : public GDALDataset
 
     static GDALDataset *Create(const char *pszFilename, int nXSize, int nYSize,
                                int nBandsIn, GDALDataType eDT,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
 
     OGRSpatialReference *GetSRS()
     {
@@ -6130,7 +6130,8 @@ OGRMVTWriterDataset::ICreateLayer(const char *pszLayerName,
 
 GDALDataset *OGRMVTWriterDataset::Create(const char *pszFilename, int nXSize,
                                          int nYSize, int nBandsIn,
-                                         GDALDataType eDT, char **papszOptions)
+                                         GDALDataType eDT,
+                                         CSLConstList papszOptions)
 {
     if (nXSize != 0 || nYSize != 0 || nBandsIn != 0 || eDT != GDT_Unknown)
     {
@@ -6422,7 +6423,8 @@ GDALDataset *OGRMVTWriterDataset::Create(const char *pszFilename, int nXSize,
 
 GDALDataset *OGRMVTWriterDatasetCreate(const char *pszFilename, int nXSize,
                                        int nYSize, int nBandsIn,
-                                       GDALDataType eDT, char **papszOptions)
+                                       GDALDataType eDT,
+                                       CSLConstList papszOptions)
 {
     return OGRMVTWriterDataset::Create(pszFilename, nXSize, nYSize, nBandsIn,
                                        eDT, papszOptions);

--- a/ogr/ogrsf_frmts/mysql/ogrmysqldriver.cpp
+++ b/ogr/ogrsf_frmts/mysql/ogrmysqldriver.cpp
@@ -84,7 +84,7 @@ static GDALDataset *OGRMySQLDriverCreate(const char *pszName,
                                          CPL_UNUSED int nXSize,
                                          CPL_UNUSED int nYSize,
                                          CPL_UNUSED GDALDataType eDT,
-                                         CPL_UNUSED char **papszOptions)
+                                         CPL_UNUSED CSLConstList papszOptions)
 {
     OGRMySQLDataSource *poDS;
 

--- a/ogr/ogrsf_frmts/nas/ogr_nas.h
+++ b/ogr/ogrsf_frmts/nas/ogr_nas.h
@@ -78,7 +78,7 @@ class OGRNASDataSource final : public GDALDataset
     ~OGRNASDataSource() override;
 
     int Open(const char *);
-    int Create(const char *pszFile, char **papszOptions);
+    int Create(const char *pszFile, CSLConstList papszOptions);
 
     int GetLayerCount() const override
     {

--- a/ogr/ogrsf_frmts/ngw/gdalngwdataset.cpp
+++ b/ogr/ogrsf_frmts/ngw/gdalngwdataset.cpp
@@ -243,7 +243,7 @@ const OGRLayer *OGRNGWDataset::GetLayer(int iLayer) const
  */
 bool OGRNGWDataset::Open(const std::string &osUrlIn,
                          const std::string &osResourceIdIn,
-                         char **papszOpenOptionsIn, bool bUpdateIn,
+                         CSLConstList papszOpenOptionsIn, bool bUpdateIn,
                          int nOpenFlagsIn)
 {
     osUrl = osUrlIn;
@@ -330,8 +330,9 @@ bool OGRNGWDataset::Open(const std::string &osUrlIn,
  *      - NGW:http://some.nextgis.com/resource/0
  *      - NGW:http://some.nextgis.com:8000/test/resource/0
  */
-bool OGRNGWDataset::Open(const char *pszFilename, char **papszOpenOptionsIn,
-                         bool bUpdateIn, int nOpenFlagsIn)
+bool OGRNGWDataset::Open(const char *pszFilename,
+                         CSLConstList papszOpenOptionsIn, bool bUpdateIn,
+                         int nOpenFlagsIn)
 {
     NGWAPI::Uri stUri = NGWAPI::ParseUri(pszFilename);
 

--- a/ogr/ogrsf_frmts/ngw/ogr_ngw.h
+++ b/ogr/ogrsf_frmts/ngw/ogr_ngw.h
@@ -302,10 +302,11 @@ class OGRNGWDataset final : public GDALDataset
     OGRNGWDataset();
     ~OGRNGWDataset() override;
 
-    bool Open(const char *pszFilename, char **papszOpenOptionsIn,
+    bool Open(const char *pszFilename, CSLConstList papszOpenOptionsIn,
               bool bUpdateIn, int nOpenFlagsIn);
     bool Open(const std::string &osUrlIn, const std::string &osResourceIdIn,
-              char **papszOpenOptionsIn, bool bUpdateIn, int nOpenFlagsIn);
+              CSLConstList papszOpenOptionsIn, bool bUpdateIn,
+              int nOpenFlagsIn);
     std::string Extensions() const;
 
     /* GDALDataset */

--- a/ogr/ogrsf_frmts/ngw/ogrngwdriver.cpp
+++ b/ogr/ogrsf_frmts/ngw/ogrngwdriver.cpp
@@ -97,7 +97,7 @@ static GDALDataset *OGRNGWDriverOpen(GDALOpenInfo *poOpenInfo)
 static GDALDataset *
 OGRNGWDriverCreate(const char *pszName, CPL_UNUSED int nBands,
                    CPL_UNUSED int nXSize, CPL_UNUSED int nYSize,
-                   CPL_UNUSED GDALDataType eDT, char **papszOptions)
+                   CPL_UNUSED GDALDataType eDT, CSLConstList papszOptions)
 
 {
     NGWAPI::Uri stUri = NGWAPI::ParseUri(pszName);
@@ -238,7 +238,7 @@ static CPLErr OGRNGWDriverRename(const char *pszNewName, const char *pszOldName)
  */
 static GDALDataset *OGRNGWDriverCreateCopy(const char *pszFilename,
                                            GDALDataset *poSrcDS, int bStrict,
-                                           char **papszOptions,
+                                           CSLConstList papszOptions,
                                            GDALProgressFunc pfnProgress,
                                            void *pProgressData)
 {

--- a/ogr/ogrsf_frmts/oci/ogrocidriver.cpp
+++ b/ogr/ogrsf_frmts/oci/ogrocidriver.cpp
@@ -41,10 +41,12 @@ static GDALDataset *OGROCIDriverOpen(GDALOpenInfo *poOpenInfo)
 /*                         OGROCIDriverCreate()                         */
 /************************************************************************/
 
-static GDALDataset *
-OGROCIDriverCreate(const char *pszName, CPL_UNUSED int nBands,
-                   CPL_UNUSED int nXSize, CPL_UNUSED int nYSize,
-                   CPL_UNUSED GDALDataType eDT, CPL_UNUSED char **papszOptions)
+static GDALDataset *OGROCIDriverCreate(const char *pszName,
+                                       CPL_UNUSED int nBands,
+                                       CPL_UNUSED int nXSize,
+                                       CPL_UNUSED int nYSize,
+                                       CPL_UNUSED GDALDataType eDT,
+                                       CPL_UNUSED CSLConstList papszOptions)
 
 {
     OGROCIDataSource *poDS;

--- a/ogr/ogrsf_frmts/ods/ogr_ods.h
+++ b/ogr/ogrsf_frmts/ods/ogr_ods.h
@@ -236,7 +236,7 @@ class OGRODSDataSource final : public GDALDataset
 
     int Open(const char *pszFilename, VSILFILE *fpContentIn,
              VSILFILE *fpSettingsIn, int bUpdatableIn);
-    int Create(const char *pszName, char **papszOptions);
+    int Create(const char *pszName, CSLConstList papszOptions);
 
     int GetLayerCount() const override;
     const OGRLayer *GetLayer(int) const override;

--- a/ogr/ogrsf_frmts/ods/ogrodsdatasource.cpp
+++ b/ogr/ogrsf_frmts/ods/ogrodsdatasource.cpp
@@ -468,7 +468,7 @@ int OGRODSDataSource::Open(const char *pszFilename, VSILFILE *fpContentIn,
 /************************************************************************/
 
 int OGRODSDataSource::Create(const char *pszFilename,
-                             char ** /* papszOptions */)
+                             CSLConstList /* papszOptions */)
 {
     bUpdated = true;
     bUpdatable = true;

--- a/ogr/ogrsf_frmts/ods/ogrodsdriver.cpp
+++ b/ogr/ogrsf_frmts/ods/ogrodsdriver.cpp
@@ -167,7 +167,7 @@ static GDALDataset *OGRODSDriverOpen(GDALOpenInfo *poOpenInfo)
 static GDALDataset *OGRODSDriverCreate(const char *pszName, int /* nXSize */,
                                        int /* nYSize */, int /* nBands */,
                                        GDALDataType /* eDT */,
-                                       char **papszOptions)
+                                       CSLConstList papszOptions)
 
 {
     if (!EQUAL(CPLGetExtensionSafe(pszName).c_str(), "ODS"))

--- a/ogr/ogrsf_frmts/ogrsf_frmts.h
+++ b/ogr/ogrsf_frmts/ogrsf_frmts.h
@@ -326,30 +326,30 @@ class CPL_DLL OGRLayer : public GDALMajorObject
                      GDALProgressFunc pfnProgress, void *pProgressData);
 
     OGRErr Intersection(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
-                        char **papszOptions = nullptr,
+                        CSLConstList papszOptions = nullptr,
                         GDALProgressFunc pfnProgress = nullptr,
                         void *pProgressArg = nullptr);
     OGRErr Union(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
-                 char **papszOptions = nullptr,
+                 CSLConstList papszOptions = nullptr,
                  GDALProgressFunc pfnProgress = nullptr,
                  void *pProgressArg = nullptr);
     OGRErr SymDifference(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
-                         char **papszOptions, GDALProgressFunc pfnProgress,
-                         void *pProgressArg);
+                         CSLConstList papszOptions,
+                         GDALProgressFunc pfnProgress, void *pProgressArg);
     OGRErr Identity(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
-                    char **papszOptions = nullptr,
+                    CSLConstList papszOptions = nullptr,
                     GDALProgressFunc pfnProgress = nullptr,
                     void *pProgressArg = nullptr);
     OGRErr Update(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
-                  char **papszOptions = nullptr,
+                  CSLConstList papszOptions = nullptr,
                   GDALProgressFunc pfnProgress = nullptr,
                   void *pProgressArg = nullptr);
     OGRErr Clip(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
-                char **papszOptions = nullptr,
+                CSLConstList papszOptions = nullptr,
                 GDALProgressFunc pfnProgress = nullptr,
                 void *pProgressArg = nullptr);
     OGRErr Erase(OGRLayer *pLayerMethod, OGRLayer *pLayerResult,
-                 char **papszOptions = nullptr,
+                 CSLConstList papszOptions = nullptr,
                  GDALProgressFunc pfnProgress = nullptr,
                  void *pProgressArg = nullptr);
 
@@ -657,7 +657,7 @@ class CPL_DLL OGRSFDriverRegistrar
                                           GDALOpenInfo *poOpenInfo);
     static GDALDataset *CreateVectorOnly(GDALDriver *poDriver,
                                          const char *pszName,
-                                         char **papszOptions);
+                                         CSLConstList papszOptions);
     static CPLErr DeleteDataSource(GDALDriver *poDriver, const char *pszName);
 
   public:

--- a/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdbdriver.cpp
+++ b/ogr/ogrsf_frmts/openfilegdb/ogropenfilegdbdriver.cpp
@@ -101,7 +101,7 @@ static GDALDataset *OGROpenFileGDBDriverOpen(GDALOpenInfo *poOpenInfo)
 static GDALDataset *OGROpenFileGDBDriverCreate(const char *pszName, int nXSize,
                                                int nYSize, int nBands,
                                                GDALDataType eType,
-                                               char ** /* papszOptions*/)
+                                               CSLConstList /* papszOptions*/)
 
 {
     if (!(nXSize == 0 && nYSize == 0 && nBands == 0 && eType == GDT_Unknown))

--- a/ogr/ogrsf_frmts/parquet/ogrparquetdriver.cpp
+++ b/ogr/ogrsf_frmts/parquet/ogrparquetdriver.cpp
@@ -699,7 +699,7 @@ static GDALDataset *OGRParquetDriverOpen(GDALOpenInfo *poOpenInfo)
 static GDALDataset *OGRParquetDriverCreate(const char *pszName, int nXSize,
                                            int nYSize, int nBands,
                                            GDALDataType eType,
-                                           char ** /* papszOptions */)
+                                           CSLConstList /* papszOptions */)
 {
     if (!(nXSize == 0 && nYSize == 0 && nBands == 0 && eType == GDT_Unknown))
         return nullptr;

--- a/ogr/ogrsf_frmts/pg/ogr_pg.h
+++ b/ogr/ogrsf_frmts/pg/ogr_pg.h
@@ -656,7 +656,8 @@ class OGRPGDataSource final : public GDALDataset
     const OGRSpatialReference *FetchSRS(int nSRSId);
     static OGRErr InitializeMetadataTables();
 
-    int Open(const char *, int bUpdate, int bTestOpen, char **papszOpenOptions);
+    int Open(const char *, int bUpdate, int bTestOpen,
+             CSLConstList papszOpenOptions);
     OGRPGTableLayer *
     OpenTable(CPLString &osCurrentSchema, const char *pszTableName,
               const char *pszSchemaName, const char *pszDescription,

--- a/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
@@ -255,7 +255,7 @@ static PGTableEntry *OGRPGAddTableEntry(CPLHashSet *hSetTables,
 /************************************************************************/
 
 int OGRPGDataSource::Open(const char *pszNewName, int bUpdate, int bTestOpen,
-                          char **papszOpenOptionsIn)
+                          CSLConstList papszOpenOptionsIn)
 
 {
     CPLAssert(nLayers == 0);

--- a/ogr/ogrsf_frmts/pg/ogrpgdriver.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgdriver.cpp
@@ -44,7 +44,7 @@ static GDALDataset *OGRPGDriverOpen(GDALOpenInfo *poOpenInfo)
 static GDALDataset *
 OGRPGDriverCreate(const char *pszName, CPL_UNUSED int nBands,
                   CPL_UNUSED int nXSize, CPL_UNUSED int nYSize,
-                  CPL_UNUSED GDALDataType eDT, char **papszOptions)
+                  CPL_UNUSED GDALDataType eDT, CSLConstList papszOptions)
 
 {
     OGRPGDataSource *poDS = new OGRPGDataSource();

--- a/ogr/ogrsf_frmts/pgdump/ogr_pgdump.h
+++ b/ogr/ogrsf_frmts/pgdump/ogr_pgdump.h
@@ -269,7 +269,7 @@ class OGRPGDumpDataSource final : public GDALDataset
     const char *m_pszEOL = "\n";
 
   public:
-    OGRPGDumpDataSource(const char *pszName, char **papszOptions);
+    OGRPGDumpDataSource(const char *pszName, CSLConstList papszOptions);
     ~OGRPGDumpDataSource() override;
 
     bool Log(const char *pszStr, bool bAddSemiColumn = true);

--- a/ogr/ogrsf_frmts/pgdump/ogrpgdumpdatasource.cpp
+++ b/ogr/ogrsf_frmts/pgdump/ogrpgdumpdatasource.cpp
@@ -22,7 +22,7 @@
 /************************************************************************/
 
 OGRPGDumpDataSource::OGRPGDumpDataSource(const char *pszNameIn,
-                                         char **papszOptions)
+                                         CSLConstList papszOptions)
 {
     SetDescription(pszNameIn);
 

--- a/ogr/ogrsf_frmts/pgdump/ogrpgdumpdriver.cpp
+++ b/ogr/ogrsf_frmts/pgdump/ogrpgdumpdriver.cpp
@@ -20,7 +20,7 @@
 static GDALDataset *
 OGRPGDumpDriverCreate(const char *pszName, CPL_UNUSED int nXSize,
                       CPL_UNUSED int nYSize, CPL_UNUSED int nBands,
-                      CPL_UNUSED GDALDataType eDT, char **papszOptions)
+                      CPL_UNUSED GDALDataType eDT, CSLConstList papszOptions)
 {
     if (strcmp(pszName, "/dev/stdout") == 0)
         pszName = "/vsistdout/";

--- a/ogr/ogrsf_frmts/plscenes/ogr_plscenes.h
+++ b/ogr/ogrsf_frmts/plscenes/ogr_plscenes.h
@@ -44,7 +44,7 @@ class OGRPLScenesDataV1Dataset final : public GDALDataset
     bool ParseItemTypes(json_object *poObj, CPLString &osNext);
     void EstablishLayerList();
     GDALDataset *OpenRasterScene(GDALOpenInfo *poOpenInfo, CPLString osScene,
-                                 char **papszOptions);
+                                 CSLConstList papszOptions);
     CPLString InsertAPIKeyInURL(CPLString osURL);
 
   public:

--- a/ogr/ogrsf_frmts/plscenes/ogrplscenesdatav1dataset.cpp
+++ b/ogr/ogrsf_frmts/plscenes/ogrplscenesdatav1dataset.cpp
@@ -370,9 +370,8 @@ CPLString OGRPLScenesDataV1Dataset::InsertAPIKeyInURL(CPLString osURL)
 /*                            OpenRasterScene()                         */
 /************************************************************************/
 
-GDALDataset *OGRPLScenesDataV1Dataset::OpenRasterScene(GDALOpenInfo *poOpenInfo,
-                                                       CPLString osScene,
-                                                       char **papszOptions)
+GDALDataset *OGRPLScenesDataV1Dataset::OpenRasterScene(
+    GDALOpenInfo *poOpenInfo, CPLString osScene, CSLConstList papszOptions)
 {
     if (!(poOpenInfo->nOpenFlags & GDAL_OF_RASTER))
     {
@@ -384,24 +383,17 @@ GDALDataset *OGRPLScenesDataV1Dataset::OpenRasterScene(GDALOpenInfo *poOpenInfo,
     int nActivationTimeout = atoi(CSLFetchNameValueDef(
         poOpenInfo->papszOpenOptions, "ACTIVATION_TIMEOUT", "3600"));
 
-    for (char **papszIter = papszOptions; papszIter && *papszIter; papszIter++)
+    for (const auto &[pszKey, pszValue] : cpl::IterateNameValue(papszOptions))
     {
-        char *pszKey = nullptr;
-        const char *pszValue = CPLParseNameValue(*papszIter, &pszKey);
-        if (pszValue != nullptr)
+        if (!EQUAL(pszKey, "api_key") && !EQUAL(pszKey, "scene") &&
+            !EQUAL(pszKey, "product_type") && !EQUAL(pszKey, "asset") &&
+            !EQUAL(pszKey, "catalog") && !EQUAL(pszKey, "itemtypes") &&
+            !EQUAL(pszKey, "version") && !EQUAL(pszKey, "follow_links") &&
+            !EQUAL(pszKey, "metadata"))
         {
-            if (!EQUAL(pszKey, "api_key") && !EQUAL(pszKey, "scene") &&
-                !EQUAL(pszKey, "product_type") && !EQUAL(pszKey, "asset") &&
-                !EQUAL(pszKey, "catalog") && !EQUAL(pszKey, "itemtypes") &&
-                !EQUAL(pszKey, "version") && !EQUAL(pszKey, "follow_links") &&
-                !EQUAL(pszKey, "metadata"))
-            {
-                CPLError(CE_Failure, CPLE_NotSupported, "Unsupported option %s",
-                         pszKey);
-                CPLFree(pszKey);
-                return nullptr;
-            }
-            CPLFree(pszKey);
+            CPLError(CE_Failure, CPLE_NotSupported, "Unsupported option %s",
+                     pszKey);
+            return nullptr;
         }
     }
 

--- a/ogr/ogrsf_frmts/pmtiles/ogrpmtilesdriver.cpp
+++ b/ogr/ogrsf_frmts/pmtiles/ogrpmtilesdriver.cpp
@@ -121,7 +121,7 @@ static GDALDataset *OGRPMTilesDriverVectorTranslateFrom(
 static GDALDataset *OGRPMTilesDriverCreate(const char *pszFilename, int nXSize,
                                            int nYSize, int nBandsIn,
                                            GDALDataType eDT,
-                                           char **papszOptions)
+                                           CSLConstList papszOptions)
 {
     if (nXSize == 0 && nYSize == 0 && nBandsIn == 0 && eDT == GDT_Unknown)
     {

--- a/ogr/ogrsf_frmts/s57/ogr_s57.h
+++ b/ogr/ogrsf_frmts/s57/ogr_s57.h
@@ -86,14 +86,14 @@ class OGRS57DataSource final : public GDALDataset
     CPL_DISALLOW_COPY_ASSIGN(OGRS57DataSource)
 
   public:
-    explicit OGRS57DataSource(char **papszOpenOptions = nullptr);
+    explicit OGRS57DataSource(CSLConstList papszOpenOptions = nullptr);
     ~OGRS57DataSource() override;
 
     void SetOptionList(char **);
     const char *GetOption(const char *);
 
     int Open(const char *pszName);
-    int Create(const char *pszName, char **papszOptions);
+    int Create(const char *pszName, CSLConstList papszOptions);
 
     int GetLayerCount() const override
     {
@@ -140,7 +140,7 @@ class OGRS57Driver final : public GDALDriver
     static GDALDataset *Open(GDALOpenInfo *poOpenInfo);
     static GDALDataset *Create(const char *pszName, int nBands, int nXSize,
                                int nYSize, GDALDataType eDT,
-                               char **papszOptions);
+                               CSLConstList papszOptions);
 
     static S57ClassRegistrar *GetS57Registrar();
 };

--- a/ogr/ogrsf_frmts/s57/ogrs57datasource.cpp
+++ b/ogr/ogrsf_frmts/s57/ogrs57datasource.cpp
@@ -22,7 +22,7 @@
 /*                          OGRS57DataSource()                          */
 /************************************************************************/
 
-OGRS57DataSource::OGRS57DataSource(char **papszOpenOptionsIn)
+OGRS57DataSource::OGRS57DataSource(CSLConstList papszOpenOptionsIn)
     : nLayers(0), papoLayers(nullptr), poSpatialRef(new OGRSpatialReference()),
       papszOptions(nullptr), nModules(0), papoModules(nullptr),
       poWriter(nullptr), poClassContentExplorer(nullptr), bExtentsSet(false)
@@ -43,7 +43,7 @@ OGRS57DataSource::OGRS57DataSource(char **papszOpenOptionsIn)
         if (papszOptions && *papszOptions)
         {
             CPLDebug("S57", "The following S57 options are being set:");
-            char **papszCurOption = papszOptions;
+            CSLConstList papszCurOption = papszOptions;
             while (*papszCurOption)
                 CPLDebug("S57", "    %s", *papszCurOption++);
         }
@@ -52,7 +52,7 @@ OGRS57DataSource::OGRS57DataSource(char **papszOpenOptionsIn)
     /* -------------------------------------------------------------------- */
     /*      And from open options.                                          */
     /* -------------------------------------------------------------------- */
-    for (char **papszIter = papszOpenOptionsIn; papszIter && *papszIter;
+    for (CSLConstList papszIter = papszOpenOptionsIn; papszIter && *papszIter;
          ++papszIter)
     {
         char *pszKey = nullptr;
@@ -431,7 +431,8 @@ OGRErr OGRS57DataSource::GetDSExtent(OGREnvelope *psExtent, int bForce)
 /*      Create a new S57 file, and represent it as a datasource.        */
 /************************************************************************/
 
-int OGRS57DataSource::Create(const char *pszFilename, char **papszOptionsIn)
+int OGRS57DataSource::Create(const char *pszFilename,
+                             CSLConstList papszOptionsIn)
 {
     /* -------------------------------------------------------------------- */
     /*      Instantiate the class registrar if possible.                    */

--- a/ogr/ogrsf_frmts/s57/ogrs57driver.cpp
+++ b/ogr/ogrsf_frmts/s57/ogrs57driver.cpp
@@ -105,7 +105,8 @@ GDALDataset *OGRS57Driver::Open(GDALOpenInfo *poOpenInfo)
 
 GDALDataset *OGRS57Driver::Create(const char *pszName, int /* nBands */,
                                   int /* nXSize */, int /* nYSize */,
-                                  GDALDataType /* eDT */, char **papszOptions)
+                                  GDALDataType /* eDT */,
+                                  CSLConstList papszOptions)
 {
     OGRS57DataSource *poDS = new OGRS57DataSource();
 

--- a/ogr/ogrsf_frmts/s57/s57.h
+++ b/ogr/ogrsf_frmts/s57/s57.h
@@ -334,7 +334,7 @@ class CPL_DLL S57Reader
     ~S57Reader();
 
     void SetClassBased(S57ClassRegistrar *, S57ClassContentExplorer *);
-    bool SetOptions(char **);
+    bool SetOptions(CSLConstList);
 
     int GetOptionFlags()
     {

--- a/ogr/ogrsf_frmts/s57/s57dump.cpp
+++ b/ogr/ogrsf_frmts/s57/s57dump.cpp
@@ -32,7 +32,7 @@ int main(int nArgc, char **papszArgv)
     /* -------------------------------------------------------------------- */
     /*      Process commandline arguments.                                  */
     /* -------------------------------------------------------------------- */
-    char **papszOptions = nullptr;
+    CSLConstList papszOptions = nullptr;
     bool bReturnPrimitives = false;
     char *pszDataPath = nullptr;
 

--- a/ogr/ogrsf_frmts/s57/s57reader.cpp
+++ b/ogr/ogrsf_frmts/s57/s57reader.cpp
@@ -312,7 +312,7 @@ OGRFeature *S57Reader::NextPendingMultiPoint()
 /*                             SetOptions()                             */
 /************************************************************************/
 
-bool S57Reader::SetOptions(char **papszOptionsIn)
+bool S57Reader::SetOptions(CSLConstList papszOptionsIn)
 
 {
     CSLDestroy(papszOptions);

--- a/ogr/ogrsf_frmts/selafin/ogrselafindriver.cpp
+++ b/ogr/ogrsf_frmts/selafin/ogrselafindriver.cpp
@@ -76,7 +76,7 @@ static GDALDataset *OGRSelafinDriverOpen(GDALOpenInfo *poOpenInfo)
 static GDALDataset *
 OGRSelafinDriverCreate(const char *pszName, CPL_UNUSED int nXSize,
                        CPL_UNUSED int nYSize, CPL_UNUSED int nBands,
-                       CPL_UNUSED GDALDataType eDT, char **papszOptions)
+                       CPL_UNUSED GDALDataType eDT, CSLConstList papszOptions)
 {
     // First, ensure there isn't any such file yet.
     VSIStatBufL sStatBuf;

--- a/ogr/ogrsf_frmts/shape/ogrshapedriver.cpp
+++ b/ogr/ogrsf_frmts/shape/ogrshapedriver.cpp
@@ -158,7 +158,7 @@ static GDALDataset *OGRShapeDriverOpen(GDALOpenInfo *poOpenInfo)
 static GDALDataset *OGRShapeDriverCreate(const char *pszName, int /* nBands */,
                                          int /* nXSize */, int /* nYSize */,
                                          GDALDataType /* eDT */,
-                                         char ** /* papszOptions */)
+                                         CSLConstList /* papszOptions */)
 {
     bool bSingleNewFile = false;
     const CPLString osExt(CPLGetExtensionSafe(pszName));

--- a/ogr/ogrsf_frmts/sosi/ogr_sosi.h
+++ b/ogr/ogrsf_frmts/sosi/ogr_sosi.h
@@ -119,7 +119,7 @@ class OGRSOSIDataSource final : public GDALDataset
     OGRLayer *ICreateLayer(const char *pszName,
                            const OGRSpatialReference *poSpatialRef = NULL,
                            OGRwkbGeometryType eGType = wkbUnknown,
-                           char **papszOptions = NULL) override;
+                           CSLConstList papszOptions = NULL) override;
 #endif
 };
 

--- a/ogr/ogrsf_frmts/sosi/ogrsosidatasource.cpp
+++ b/ogr/ogrsf_frmts/sosi/ogrsosidatasource.cpp
@@ -640,7 +640,7 @@ int OGRSOSIDataSource::Create(const char *pszFilename)
 
 OGRLayer *OGRSOSIDataSource::ICreateLayer(
     const char *pszNameIn, const OGRSpatialReference *poSpatialRef,
-    OGRwkbGeometryType eGType, CPL_UNUSED char **papszOptions)
+    OGRwkbGeometryType eGType, CPL_UNUSED CSLConstList papszOptions)
 {
     /* SOSI does not really support layers - so let's first see that the global
      * settings are consistent */

--- a/ogr/ogrsf_frmts/sosi/ogrsosidriver.cpp
+++ b/ogr/ogrsf_frmts/sosi/ogrsosidriver.cpp
@@ -76,10 +76,12 @@ static GDALDataset *OGRSOSIDriverOpen(GDALOpenInfo *poOpenInfo)
 /*                              Create()                                */
 /************************************************************************/
 
-static GDALDataset *
-OGRSOSIDriverCreate(const char *pszName, CPL_UNUSED int nBands,
-                    CPL_UNUSED int nXSize, CPL_UNUSED int nYSize,
-                    CPL_UNUSED GDALDataType eDT, CPL_UNUSED char **papszOptions)
+static GDALDataset *OGRSOSIDriverCreate(const char *pszName,
+                                        CPL_UNUSED int nBands,
+                                        CPL_UNUSED int nXSize,
+                                        CPL_UNUSED int nYSize,
+                                        CPL_UNUSED GDALDataType eDT,
+                                        CPL_UNUSED CSLConstList papszOptions)
 {
     OGRSOSIInit();
     OGRSOSIDataSource *poDS = new OGRSOSIDataSource();

--- a/ogr/ogrsf_frmts/sqlite/ogr_sqlite.h
+++ b/ogr/ogrsf_frmts/sqlite/ogr_sqlite.h
@@ -733,7 +733,7 @@ class OGRSQLiteDataSource final : public OGRSQLiteBaseDataSource
     ~OGRSQLiteDataSource() override;
 
     bool Open(GDALOpenInfo *poOpenInfo);
-    bool Create(const char *, char **papszOptions);
+    bool Create(const char *, CSLConstList papszOptions);
 
     bool OpenTable(const char *pszTableName, bool IsTable, bool bIsVirtualShape,
                    bool bMayEmitError);
@@ -919,7 +919,8 @@ void OGRSQLiteDriverUnload(GDALDriver *);
 
 #ifdef HAVE_RASTERLITE2
 GDALDataset *OGRSQLiteDriverCreateCopy(const char *, GDALDataset *, int,
-                                       char **, GDALProgressFunc pfnProgress,
+                                       CSLConstList,
+                                       GDALProgressFunc pfnProgress,
                                        void *pProgressData);
 #endif
 

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
@@ -1811,7 +1811,8 @@ void *OGRSQLiteBaseDataSource::GetInternalHandle(const char *pszKey)
 /*                               Create()                               */
 /************************************************************************/
 
-bool OGRSQLiteDataSource::Create(const char *pszNameIn, char **papszOptions)
+bool OGRSQLiteDataSource::Create(const char *pszNameIn,
+                                 CSLConstList papszOptions)
 {
     CPLString osCommand;
 

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitedriver.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitedriver.cpp
@@ -214,7 +214,7 @@ static GDALDataset *OGRSQLiteDriverCreate(const char *pszName, int nBands,
                                           CPL_UNUSED int nXSize,
                                           CPL_UNUSED int nYSize,
                                           CPL_UNUSED GDALDataType eDT,
-                                          char **papszOptions)
+                                          CSLConstList papszOptions)
 {
     if (nBands != 0)
     {

--- a/ogr/ogrsf_frmts/sqlite/ogrsqliteexecutesql.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqliteexecutesql.cpp
@@ -921,7 +921,7 @@ OGRLayer *OGRSQLiteExecuteSQL(GDALDataset *poDS, const char *pszStatement,
 #else
     /* No caching version */
     poSQLiteDS = new OGRSQLiteDataSource();
-    char **papszOptions = CSLAddString(NULL, "SPATIALITE=YES");
+    CSLConstList papszOptions = CSLAddString(NULL, "SPATIALITE=YES");
     {
         CPLConfigOptionSetter oSetter("OGR_SQLITE_STATIC_VIRTUAL_OGR", "NO",
                                       false);

--- a/ogr/ogrsf_frmts/sqlite/rasterlite2.cpp
+++ b/ogr/ogrsf_frmts/sqlite/rasterlite2.cpp
@@ -1460,7 +1460,7 @@ static int RasterLite2Callback(void *data, double dfTileMinX, double dfTileMinY,
 
 GDALDataset *OGRSQLiteDriverCreateCopy(const char *pszName,
                                        GDALDataset *poSrcDS, int /* bStrict */,
-                                       char **papszOptions,
+                                       CSLConstList papszOptions,
                                        GDALProgressFunc pfnProgress,
                                        void *pProgressData)
 {

--- a/ogr/ogrsf_frmts/vdv/ogr_vdv.h
+++ b/ogr/ogrsf_frmts/vdv/ogr_vdv.h
@@ -220,7 +220,8 @@ class OGRVDVDataSource final : public GDALDataset
     static GDALDataset *Open(GDALOpenInfo *poOpenInfo);
     static GDALDataset *Create(const char *pszName, int /*nXSize*/,
                                int /*nYSize*/, int /*nBands*/,
-                               GDALDataType /*eType*/, char **papszOptions);
+                               GDALDataType /*eType*/,
+                               CSLConstList papszOptions);
 };
 
 #endif /* ndef OGR_VDV_H_INCLUDED */

--- a/ogr/ogrsf_frmts/vdv/ogrvdvdatasource.cpp
+++ b/ogr/ogrsf_frmts/vdv/ogrvdvdatasource.cpp
@@ -2052,7 +2052,7 @@ int OGRVDVDataSource::TestCapability(const char *pszCap) const
 GDALDataset *OGRVDVDataSource::Create(const char *pszName, int /*nXSize*/,
                                       int /*nYSize*/, int /*nBands*/,
                                       GDALDataType /*eType*/,
-                                      char **papszOptions)
+                                      CSLConstList papszOptions)
 
 {
     /* -------------------------------------------------------------------- */

--- a/ogr/ogrsf_frmts/wasp/ogrwaspdriver.cpp
+++ b/ogr/ogrsf_frmts/wasp/ogrwaspdriver.cpp
@@ -53,7 +53,7 @@ static GDALDataset *OGRWAsPDriverOpen(GDALOpenInfo *poOpenInfo)
 /************************************************************************/
 
 static GDALDataset *OGRWAsPDriverCreate(const char *pszName, int, int, int,
-                                        GDALDataType, char **)
+                                        GDALDataType, CSLConstList)
 
 {
     VSILFILE *fh = VSIFOpenL(pszName, "w");

--- a/ogr/ogrsf_frmts/wfs/ogr_wfs.h
+++ b/ogr/ogrsf_frmts/wfs/ogr_wfs.h
@@ -474,7 +474,7 @@ class OGRWFSDataSource final : public GDALDataset
 
     void SaveLayerSchema(const char *pszLayerName, const CPLXMLNode *psSchema);
 
-    CPLHTTPResult *HTTPFetch(const char *pszURL, char **papszOptions);
+    CPLHTTPResult *HTTPFetch(const char *pszURL, CSLConstList papszOptions);
 
     bool IsPagingAllowed() const
     {

--- a/ogr/ogrsf_frmts/wfs/ogrwfsdatasource.cpp
+++ b/ogr/ogrsf_frmts/wfs/ogrwfsdatasource.cpp
@@ -1879,7 +1879,7 @@ void OGRWFSDataSource::LoadMultipleLayerDefn(const char *pszLayerName,
 
     // CPLDebug("WFS", "%s", osPost.c_str());
 
-    char **papszOptions = NULL;
+    CSLConstList papszOptions = NULL;
     papszOptions = CSLAddNameValue(papszOptions, "POSTFIELDS", osPost.c_str());
     papszOptions =
         CSLAddNameValue(papszOptions, "HEADERS",
@@ -2201,7 +2201,7 @@ CPLString WFS_DecodeURL(const CPLString &osSrc)
 /************************************************************************/
 
 CPLHTTPResult *OGRWFSDataSource::HTTPFetch(const char *pszURL,
-                                           char **papszOptions)
+                                           CSLConstList papszOptions)
 {
     char **papszNewOptions = CSLDuplicate(papszOptions);
     if (bUseHttp10)

--- a/ogr/ogrsf_frmts/xlsx/ogr_xlsx.h
+++ b/ogr/ogrsf_frmts/xlsx/ogr_xlsx.h
@@ -285,7 +285,7 @@ class OGRXLSXDataSource final : public GDALDataset
     int Open(const char *pszFilename, const char *pszPrefixedFilename,
              VSILFILE *fpWorkbook, VSILFILE *fpWorkbookRels,
              VSILFILE *fpSharedStrings, VSILFILE *fpStyles, int bUpdate);
-    int Create(const char *pszName, char **papszOptions);
+    int Create(const char *pszName, CSLConstList papszOptions);
 
     int GetLayerCount() const override;
     const OGRLayer *GetLayer(int) const override;

--- a/ogr/ogrsf_frmts/xlsx/ogrxlsxdatasource.cpp
+++ b/ogr/ogrsf_frmts/xlsx/ogrxlsxdatasource.cpp
@@ -458,7 +458,7 @@ int OGRXLSXDataSource::Open(const char *pszFilename,
 /************************************************************************/
 
 int OGRXLSXDataSource::Create(const char *pszFilename,
-                              CPL_UNUSED char **papszOptions)
+                              CPL_UNUSED CSLConstList papszOptions)
 {
     bUpdated = true;
     bUpdatable = true;

--- a/ogr/ogrsf_frmts/xlsx/ogrxlsxdriver.cpp
+++ b/ogr/ogrsf_frmts/xlsx/ogrxlsxdriver.cpp
@@ -173,7 +173,7 @@ static GDALDataset *OGRXLSXDriverOpen(GDALOpenInfo *poOpenInfo)
 static GDALDataset *OGRXLSXDriverCreate(const char *pszName, int /* nXSize */,
                                         int /* nYSize */, int /* nBands */,
                                         GDALDataType /* eDT */,
-                                        char **papszOptions)
+                                        CSLConstList papszOptions)
 
 {
     if (!EQUAL(CPLGetExtensionSafe(pszName).c_str(), "XLSX"))

--- a/ogr/ogrspatialreference.cpp
+++ b/ogr/ogrspatialreference.cpp
@@ -10257,7 +10257,7 @@ OSRConvertToOtherProjection(OGRSpatialReferenceH hSRS,
  *
  */
 OGRSpatialReferenceH *OSRFindMatches(OGRSpatialReferenceH hSRS,
-                                     char **papszOptions, int *pnEntries,
+                                     CSLConstList papszOptions, int *pnEntries,
                                      int **ppanMatchConfidence)
 {
     if (pnEntries)
@@ -11888,7 +11888,7 @@ OGRErr OSRMorphFromESRI(OGRSpatialReferenceH hSRS)
  * @see OGRSpatialReference::FindBestMatch()
  */
 OGRSpatialReferenceH *
-OGRSpatialReference::FindMatches(char **papszOptions, int *pnEntries,
+OGRSpatialReference::FindMatches(CSLConstList papszOptions, int *pnEntries,
                                  int **ppanMatchConfidence) const
 {
     TAKE_OPTIONAL_LOCK();


### PR DESCRIPTION
…, GDALRasterBand::AdviseRead/GetVirtualMemAuto virtual method take a a CSLConstList papszOptions parameter instead of char **

Impacts out-of-tree drivers

Fixes #13746
