### PR TITLE
[Backport release/3.12] JML: fix memleak when GetLayerDefn() is called after ResetReading()

### DIFF
--- a/ogr/ogrsf_frmts/jml/ogr_jml.h
+++ b/ogr/ogrsf_frmts/jml/ogr_jml.h
@@ -58,7 +58,16 @@ class OGRJMLLayer final : public OGRLayer
     VSILFILE *fp;
     bool bHasReadSchema;
 
-    XML_Parser oParser;
+    struct XMLParserDeleter
+    {
+        void operator()(XML_Parser parser)
+        {
+            if (parser)
+                XML_ParserFree(parser);
+        }
+    };
+
+    std::unique_ptr<XML_ParserStruct, XMLParserDeleter> poParser{};
 
     int currentDepth;
     bool bStopParsing;


### PR DESCRIPTION
Backport #13738
 **Authored by:** @rouault