### PR TITLE
Fetch and set band names from TileDB schema attributes

### DIFF
--- a/frmts/tiledb/tiledbdense.cpp
+++ b/frmts/tiledb/tiledbdense.cpp
@@ -1735,11 +1735,15 @@ GDALDataset *TileDBRasterDataset::OpenInternal(GDALOpenInfo *poOpenInfo,
                 // Create band information objects.
                 for (int i = 1; i <= poDS->nBands; ++i)
                 {
-                    tiledb::Attribute const& attr = schema.attribute(i-1);
-                    std::string const& attr_name = attr.name();
+                    tiledb::Attribute const &attr = schema.attribute(i - 1);
+                    std::string const &attr_name = attr.name();
 
-                    CPLDebug("TileDB", "Set attribute '%s' from TileDB schema", attr_name.c_str());
-                    GDALRasterBand* band = new TileDBRasterBand(poDS.get(), i, attr_name.c_str());
+                    CPLDebug("TileDB", "Set attribute '%s' from TileDB schema",
+                             attr_name.c_str());
+
+                    GDALRasterBand *band =
+                        new TileDBRasterBand(poDS.get(), i, attr_name.c_str());
+
                     poDS->SetBand(i, band);
                 }
             }


### PR DESCRIPTION
## What does this PR do?

TileDB uses `TILEDB_ATTRIBUTE` as a config option, which I think was meant to support setting a series of subdataset band names. The scheme doesn't work so well when each attribute has its own name. I have included a zip file of a TileDB instance demonstrating such a scenario.

Existing issues:

* fill_value for the attribute is not set on the RasterBands. It seems the first band is defaulted (or fetched) to `0`, but subsequent ones are not captured
* ColorInterp is not configured. The first three bands default to RGB, and then the subsequent ones are all `Alpha`

