### PR TITLE
MITAB .mif reader: accepts linestring and multilinestring of 1 point (even zero)

### DIFF
--- a/ogr/ogrsf_frmts/mitab/mitab_feature_mif.cpp
+++ b/ogr/ogrsf_frmts/mitab/mitab_feature_mif.cpp
@@ -706,7 +706,7 @@ int TABPolyline::ReadGeometryFromMIFFile(MIDDATAFile *fp)
                     }
                     nNumPoints = atoi(pszLine);
                 }
-                if (nNumPoints < 2)
+                if (nNumPoints < 0)
                 {
                     CPLError(CE_Failure, CPLE_FileIO,
                              "Invalid number of vertices (%d) in PLINE "
@@ -771,7 +771,7 @@ int TABPolyline::ReadGeometryFromMIFFile(MIDDATAFile *fp)
         }
         else
         {
-            if (nNumPoints < 2)
+            if (nNumPoints < 0)
             {
                 CPLError(CE_Failure, CPLE_FileIO,
                          "Invalid number of vertices (%d) in PLINE "


### PR DESCRIPTION
Fixes #13796
