### PR TITLE
/vsicurl/: handle HTTP 302 response to HEAD requests

### DIFF
--- a/autotest/gcore/vsicurl.py
+++ b/autotest/gcore/vsicurl.py
@@ -617,6 +617,9 @@ def test_vsicurl_test_redirect_x_amz(server):
     current_time = 1500
 
     def method(request):
+
+        assert request.headers["Authorization"] == "Bearer xxx"
+
         response = "HTTP/1.1 302 Found\r\n"
         response += "Server: foo\r\n"
         response += (
@@ -625,7 +628,7 @@ def test_vsicurl_test_redirect_x_amz(server):
             + "\r\n"
         )
         response += "Location: %s\r\n" % (
-            "http://localhost:%d/foo.s3.amazonaws.com/test_redirected/test.bin?X-Amz-Signature=foo&X-Amz-Expires=30&X-Amz-Date=%s"
+            "http://127.0.0.1:%d/foo.s3.amazonaws.com/test_redirected/test.bin?X-Amz-Signature=foo&X-Amz-Expires=30&X-Amz-Date=%s"
             % (
                 server.port,
                 time.strftime("%Y%m%dT%H%M%SZ", time.gmtime(current_time)),
@@ -642,9 +645,13 @@ def test_vsicurl_test_redirect_x_amz(server):
         403,
         {"Server": "foo"},
         "",
+        unexpected_headers=["Authorization"],
     )
 
     def method(request):
+
+        assert "Authorization" not in request.headers
+
         if "Range" in request.headers:
             if request.headers["Range"] == "bytes=0-16383":
                 request.protocol_version = "HTTP/1.1"
@@ -687,10 +694,25 @@ def test_vsicurl_test_redirect_x_amz(server):
         custom_method=method,
     )
 
-    with webserver.install_http_handler(handler):
-        f = gdal.VSIFOpenL(
-            "/vsicurl/http://localhost:%d/test_redirect/test.bin" % server.port,
-            "rb",
+    gdal.SetPathSpecificOption(
+        "/vsicurl/http://localhost:%d/test_redirect" % server.port,
+        "GDAL_HTTP_AUTH",
+        "BEARER",
+    )
+    gdal.SetPathSpecificOption(
+        "/vsicurl/http://localhost:%d/test_redirect" % server.port,
+        "GDAL_HTTP_BEARER",
+        "xxx",
+    )
+    try:
+        with webserver.install_http_handler(handler):
+            f = gdal.VSIFOpenL(
+                "/vsicurl/http://localhost:%d/test_redirect/test.bin" % server.port,
+                "rb",
+            )
+    finally:
+        gdal.ClearPathSpecificOptions(
+            "/vsicurl/http://localhost:%d/test_redirect" % server.port
         )
     assert f is not None
 


### PR DESCRIPTION
Until now only HTTP 301 was correctly handled. This PR handles 302 responses but does not cache the redirected URL. The original URL will be used first for every new requests.
