### PR TITLE
PostGIS: use full geometry intersection for SetSpatialFilter(), and not only bounding box

### DIFF
--- a/doc/source/drivers/vector/pg.rst
+++ b/doc/source/drivers/vector/pg.rst
@@ -243,6 +243,22 @@ The following open options are supported:
       :oo::`PRELUDE_STATEMENTS`, the appropriate CLOSING_STATEMENTS would be
       "COMMIT".
 
+-  .. oo:: SPATIAL_FILTER_INTERSECTION
+      :choices: LOCAL, SERVER
+      :default: LOCAL
+      :since: 3.13
+
+      Since GDAL 3.13, spatial filters are evaluated using full geometry intersection
+      rather than only bounding box intersection, as in earlier versions.
+      The ``SPATIAL_FILTER_INTERSECTION`` open option controls where this
+      intersection operation is performed. Even when the intersection is evaluated
+      locally (which is the default), the server still applies a bounding
+      box-based spatial filter to efficiently retrieve candidate features.
+
+      Note that for PostGIS geometry columns of type GEOGRAPHY, the current
+      implementation deals with geographies as if they were cartesian geometries.
+
+
 Dataset Creation Options
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/ogr/ogrsf_frmts/pg/ogr_pg.h
+++ b/ogr/ogrsf_frmts/pg/ogr_pg.h
@@ -604,6 +604,8 @@ class OGRPGDataSource final : public GDALDataset
     bool m_bHasWritePermissionsOnMetadataTableRun = false;
     bool m_bHasWritePermissionsOnMetadataTableSuccess = false;
 
+    bool m_bSpatialFilterIntersectionIsLocal = true;
+
     void LoadTables();
 
     CPLString osDebugLastTransactionCommand{};
@@ -714,6 +716,11 @@ class OGRPGDataSource final : public GDALDataset
     bool CreateMetadataTableIfNeeded();
     bool HasOgrSystemTablesMetadataTable();
     bool HasWritePermissionsOnMetadataTable();
+
+    bool IsSpatialFilterIntersectionLocal() const
+    {
+        return m_bSpatialFilterIntersectionIsLocal;
+    }
 };
 
 #endif /* ndef OGR_PG_H_INCLUDED */

--- a/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgdatasource.cpp
@@ -261,6 +261,11 @@ int OGRPGDataSource::Open(const char *pszNewName, int bUpdate, int bTestOpen,
     CPLAssert(nLayers == 0);
     papszOpenOptions = CSLDuplicate(papszOpenOptionsIn);
 
+    m_bSpatialFilterIntersectionIsLocal =
+        EQUAL(CSLFetchNameValueDef(papszOpenOptions,
+                                   "SPATIAL_FILTER_INTERSECTION", "LOCAL"),
+              "LOCAL");
+
     const char *pszPreludeStatements =
         CSLFetchNameValue(papszOpenOptions, "PRELUDE_STATEMENTS");
     if (pszPreludeStatements)

--- a/ogr/ogrsf_frmts/pg/ogrpgdrivercore.cpp
+++ b/ogr/ogrsf_frmts/pg/ogrpgdrivercore.cpp
@@ -79,6 +79,12 @@ void OGRPGDriverSetCommonMetadata(GDALDriver *poDriver)
         "  <Option name='SKIP_VIEWS' type='boolean' description='Whether "
         "views should be omitted from the list' "
         "default='NO'/>"
+        "  <Option name='SPATIAL_FILTER_INTERSECTION' type='string-select' "
+        "description='Whether geometry intersection of spatial filter is "
+        "evaluated locally or on the server' default='LOCAL'>"
+        "    <Value>LOCAL</Value>"
+        "    <Value>DATABASE</Value>"
+        "  </Option>"
         "</OpenOptionList>");
 
     poDriver->SetMetadataItem(GDAL_DMD_CREATIONOPTIONLIST,


### PR DESCRIPTION
Fixes https://lists.osgeo.org/pipermail/gdal-dev/2026-January/061350.html

Fixes #1700