### PR TITLE
Doc: Add note about updating conda master builds

### DIFF
--- a/doc/source/download.rst
+++ b/doc/source/download.rst
@@ -235,8 +235,21 @@ build can be installed with the following command:
 
     conda install -c gdal-master -c conda-forge gdal-master::gdal
 
-As with released versions of GDAL, additional drivers can be installed using `gdal-master::libgdal-{driver_name}`.
+As with released versions of GDAL, additional drivers can be installed using ``gdal-master::libgdal-{driver_name}``.
 
+If you already have a GDAL master build installed in an environment, you can update it to the latest master version using the commands below.
+GDAL subpackages may need to be updated individually, because the master version numbers (e.g. ``3.12.99``) do not change with every nightly build.
+
+::
+
+    # check currently installed GDAL components and versions
+    conda list gdal
+    gdal --version
+    # update GDAL
+    conda install -c gdal-master gdal --force-reinstall --yes
+    # update libgdal-core to the latest master build
+    conda install -c gdal-master libgdal-core --force-reinstall --yes
+    gdal --version
 
 .. _pixi:
 


### PR DESCRIPTION
This PR adds a note about updating to the latest GDAL conda master builds (without having to remove and recreate a new environment). This has been a source of confusion for me for the last 6 months (see #12805)!

Without ` conda install -c gdal-master libgdal-core --force-reinstall --yes` the GDAL cli tools never updated (`gdal --version` was always an older version). As I understand it, as the version number met dependency requirements (e.g. `3.12.99`) `libgdal-core` was never updated when running `conda install -c gdal-master gdal --force-reinstall --yes` (even with an additional `--update-deps`). 