### PR TITLE
tests: add pytest.mark.network marker

### DIFF
--- a/autotest/gdrivers/wms.py
+++ b/autotest/gdrivers/wms.py
@@ -56,7 +56,8 @@ def gpwv3_wms():
 ###############################################################################
 # Check various things about the configuration.
 
-
+@pytest.mark.network
+@pytest.mark.require_curl
 def test_wms_3(gpwv3_wms):
 
     assert (

--- a/cmake/template/pytest.ini.in
+++ b/cmake/template/pytest.ini.in
@@ -28,6 +28,7 @@ markers =
     require_run_on_demand: Skip test(s) if RUN_ON_DEMAND environment variable is not set
     slow: Skip test(s) if GDAL_RUN_SLOW_TESTS environment variable is not set
     xdist_group: Associated test with a named group that will be sent to a single parallel worker
+    network: tests requiring external network access
 
 # Make sure that all markers are declared above
 # --strict-markers causes an error if a test has a marker that is not handled


### PR DESCRIPTION
This PR introduces a new pytest.mark.network marker to identify tests that require external network access.

The marker is declared in pytest.ini.in and applied conservatively to a WMS test that clearly depends on an external service, following a case-by-case approach as discussed in #10886.