### PR TITLE
[Backport release/3.12] Doc: Fix parameter types in Python Band.InterpolateAt* docs

### DIFF
--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -6038,13 +6038,13 @@ def InterpolateAtPoint(self, *args, **kwargs):
        ----------
        pixel : float
        line : float
-       interpolation : str
+       interpolation : int
            Resampling algorithm to use. One of:
 
-           - ``nearest``
-           - ``bilinear``
-           - ``cubic``
-           - ``cubicspline``
+           - :py:const:`GRIORA_NearestNeighbour`
+           - :py:const:`GRIORA_Bilinear`
+           - :py:const:`GRIORA_Cubic`
+           - :py:const:`GRIORA_CubicSpline`
 
        Returns
        -------
@@ -6100,13 +6100,13 @@ def InterpolateAtGeolocation(self, *args, **kwargs):
            taking into account the data-axis-to-crs-axis mapping
        srs : object
            :py:class:`osr.SpatialReference`. If set, override the natural CRS in which geolocX, geolocY are expressed
-       interpolation : str
+       interpolation : int
            Resampling algorithm to use. One of:
 
-           - ``nearest``
-           - ``bilinear``
-           - ``cubic``
-           - ``cubicspline``
+           - :py:const:`GRIORA_NearestNeighbour`
+           - :py:const:`GRIORA_Bilinear`
+           - :py:const:`GRIORA_Cubic`
+           - :py:const:`GRIORA_CubicSpline`
 
        Returns
        -------
@@ -6121,10 +6121,7 @@ def InterpolateAtGeolocation(self, *args, **kwargs):
        >>> with gdal.Open("byte.tif") as ds:
        ...    wgs84_srs = osr.SpatialReference("WGS84")
        ...    wgs84_srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
-       ...    ds.GetRasterBand(1).InterpolateAtGeolocation(longitude_degree, \
-                                                           latitude_degree, \
-                                                           wgs84_srs, \
-                                                           gdal.GRIORA_Bilinear)
+       ...    ds.GetRasterBand(1).InterpolateAtGeolocation(longitude_degree, latitude_degree, wgs84_srs, gdal.GRIORA_Bilinear)
        135.62  # interpolated value, rtol: 1e-3
     """
 


### PR DESCRIPTION
Backport #13852
 **Authored by:** @dbaston