### PR TITLE
Zarr: cache shard index in DecodePartial()

### DIFF
--- a/frmts/zarr/zarr_v3_array.cpp
+++ b/frmts/zarr/zarr_v3_array.cpp
@@ -487,6 +487,7 @@ bool ZarrV3Array::LoadBlockData(const uint64_t *blockIndices, bool bUseMutex,
                                     m_anOuterBlockSize[i]));
             anCount.push_back(static_cast<size_t>(m_anInnerBlockSize[i]));
         }
+        poCodecs->SetCurrentShardFilename(osFilename);
         if (!poCodecs->DecodePartial(fp.get(), abyRawBlockData, anStartIdx,
                                      anCount))
             return false;

--- a/frmts/zarr/zarr_v3_codec_sequence.cpp
+++ b/frmts/zarr/zarr_v3_codec_sequence.cpp
@@ -284,6 +284,21 @@ bool ZarrV3CodecSequence::DecodePartial(VSIVirtualHandle *poFile,
 }
 
 /************************************************************************/
+/*            ZarrV3CodecSequence::SetCurrentShardFilename()            */
+/************************************************************************/
+
+void ZarrV3CodecSequence::SetCurrentShardFilename(const std::string &osFilename)
+{
+    if (!m_apoCodecs.empty())
+    {
+        auto *poSharding = dynamic_cast<ZarrV3CodecShardingIndexed *>(
+            m_apoCodecs.back().get());
+        if (poSharding)
+            poSharding->SetCurrentShardFilename(osFilename);
+    }
+}
+
+/************************************************************************/
 /*             ZarrV3CodecSequence::GetInnerMostBlockSize()             */
 /************************************************************************/
 


### PR DESCRIPTION
## What does this PR do?

When reading inner chunks from a sharded Zarr v3 array, each `DecodePartial()` call re-reads and re-decodes the shard index to locate the requested chunk. The index is small (~32 KB for a 45x45 grid of inner chunks), so `/vsicurl/`'s 16 KB region cache already prevents redundant HTTP requests. However, the index is re-decoded from raw bytes on every call.

This PR reads and decodes the full shard index on the first access and caches the decoded result in memory. Subsequent reads from the same shard look up offsets directly. When a different shard is accessed, the cache is replaced. `Clone()` (used by `IAdviseRead` thread pool) creates an independent codec with its own empty cache, so there is no shared mutable state.

The primary value is enabling #13871: batch reads need all index entries available upfront to collect byte ranges for `ReadMultiRange()`. Without this cache, each `DecodePartial()` operates in isolation with no opportunity to batch.

## What are related issues/pull requests?

- #13708 -- `sharding_indexed` codec
- #13835 -- streaming filename fix
- #13871 -- batch reads (stacked on this PR, where the HTTP reduction happens)

## Tasklist

- [x] AI (Claude) supported my development of this PR
- [x] Code is correctly formatted (pre-commit)
- [x] Add test case(s)
- [ ] All CI builds and checks have passed