### PR TITLE
Zarr: batch inner chunk reads via ReadMultiRange

### DIFF
--- a/frmts/zarr/zarr.h
+++ b/frmts/zarr/zarr.h
@@ -1366,6 +1366,14 @@ class ZarrV3Array final : public ZarrArray
                        ZarrByteVectorQuickResize &abyDecodedBlockData,
                        bool &bMissingBlockOut) const;
 
+    bool IRead(const GUInt64 *arrayStartIdx, const size_t *count,
+               const GInt64 *arrayStep, const GPtrDiff_t *bufferStride,
+               const GDALExtendedDataType &bufferDataType,
+               void *pDstBuffer) const override;
+
+    void PreloadShardedBlocks(const GUInt64 *arrayStartIdx,
+                              const size_t *count) const;
+
     bool IWrite(const GUInt64 *arrayStartIdx, const size_t *count,
                 const GInt64 *arrayStep, const GPtrDiff_t *bufferStride,
                 const GDALExtendedDataType &bufferDataType,

--- a/frmts/zarr/zarr_v3_codec.h
+++ b/frmts/zarr/zarr_v3_codec.h
@@ -450,6 +450,17 @@ class ZarrV3CodecShardingIndexed final : public ZarrV3Codec
                        std::vector<size_t> &anStartIdx,
                        std::vector<size_t> &anCount) override;
 
+    /** Batch-read multiple inner chunks from the same shard via two
+     *  ReadMultiRange() passes (index entries, then data), then decode.
+     *  No persistent state is kept — each call reads the needed index
+     *  entries on demand.
+     */
+    bool BatchDecodePartial(
+        VSIVirtualHandle *poFile,
+        const std::vector<std::pair<std::vector<size_t>, std::vector<size_t>>>
+            &anRequests,
+        std::vector<ZarrByteVectorQuickResize> &aResults);
+
     std::vector<size_t>
     GetInnerMostBlockSize(const std::vector<size_t> &input) const override;
 };
@@ -507,6 +518,16 @@ class ZarrV3CodecSequence
                        ZarrByteVectorQuickResize &abyBuffer,
                        const std::vector<size_t> &anStartIdx,
                        const std::vector<size_t> &anCount);
+
+    /** Batch-read multiple inner chunks via ReadMultiRange().
+     *  Delegates to the sharding codec if present, otherwise falls back
+     *  to sequential DecodePartial() calls.
+     */
+    bool BatchDecodePartial(
+        VSIVirtualHandle *poFile,
+        const std::vector<std::pair<std::vector<size_t>, std::vector<size_t>>>
+            &anRequests,
+        std::vector<ZarrByteVectorQuickResize> &aResults);
 
     std::vector<size_t>
     GetInnerMostBlockSize(const std::vector<size_t> &anOuterBlockSize) const;

--- a/frmts/zarr/zarr_v3_codec_sequence.cpp
+++ b/frmts/zarr/zarr_v3_codec_sequence.cpp
@@ -284,6 +284,40 @@ bool ZarrV3CodecSequence::DecodePartial(VSIVirtualHandle *poFile,
 }
 
 /************************************************************************/
+/*              ZarrV3CodecSequence::BatchDecodePartial()               */
+/************************************************************************/
+
+bool ZarrV3CodecSequence::BatchDecodePartial(
+    VSIVirtualHandle *poFile,
+    const std::vector<std::pair<std::vector<size_t>, std::vector<size_t>>>
+        &anRequests,
+    std::vector<ZarrByteVectorQuickResize> &aResults)
+{
+    // Only batch-decode when sharding is the sole codec. If other codecs
+    // (e.g. transpose) precede it, indices and output need codec-specific
+    // transformations that BatchDecodePartial does not handle.
+    if (m_apoCodecs.size() == 1)
+    {
+        auto *poSharding = dynamic_cast<ZarrV3CodecShardingIndexed *>(
+            m_apoCodecs.back().get());
+        if (poSharding)
+        {
+            return poSharding->BatchDecodePartial(poFile, anRequests, aResults);
+        }
+    }
+
+    // Fallback: sequential DecodePartial for non-sharding codec chains
+    aResults.resize(anRequests.size());
+    for (size_t i = 0; i < anRequests.size(); ++i)
+    {
+        if (!DecodePartial(poFile, aResults[i], anRequests[i].first,
+                           anRequests[i].second))
+            return false;
+    }
+    return true;
+}
+
+/************************************************************************/
 /*             ZarrV3CodecSequence::GetInnerMostBlockSize()             */
 /************************************************************************/
 


### PR DESCRIPTION
## What does this PR do?

When a read spans multiple inner chunks in the same shard, GDAL currently fetches each chunk with its own HTTP range request. With the shard index cached in memory (#13870), all byte ranges are known upfront. This PR collects them and fetches everything in one `ReadMultiRange()` call.

A new `IRead()` override on `ZarrV3Array` groups uncached blocks by shard, batch-decodes them via `BatchDecodePartial()`, and populates the chunk cache before the base-class read runs. Single-block reads skip batching entirely to avoid overhead for the common case.

Measured on an EOPF Sentinel-2 land scene (sharding_indexed, blosc+zstd, 244x244 inner chunks):

| Window | Inner chunks | Master GETs | PR GETs |
|--------|-------------|-------------|---------|
| 244x244  | 1   | 4  | 4 |
| 732x732  | 9   | 12 | 4 |
| 1220x1220 | 25  | 28 | 4 |
| 2196x2196 | 81  | 84 | 4 |

Constant 4 GETs regardless of chunk count (metadata + index + one batched data read). Same pattern as GeoTIFF's `ReadMultiRange()` for batched byte-range reads.

## What are related issues/pull requests?

- Depends on shard index cache #13870 (stacked)
- #13708 -- `sharding_indexed` codec

## Tasklist

- [x] AI (Claude) supported my development of this PR
- [x] Code is correctly formatted (pre-commit)
- [x] Add test case(s)
- [x] All CI builds and checks have passed