### PR TITLE
test: relax test_warp_52 timeout, skip cfchecks on network failure

### DIFF
--- a/autotest/alg/warp.py
+++ b/autotest/alg/warp.py
@@ -1485,7 +1485,7 @@ def test_warp_52():
     )
 
     end = time.time()
-    assert end - start <= 10, "processing time was way too long"
+    assert end - start <= 60, "processing time was way too long"
 
     cs = out_ds.GetRasterBand(4).Checksum()
     assert cs == 3177

--- a/autotest/gdrivers/netcdf_cf.py
+++ b/autotest/gdrivers/netcdf_cf.py
@@ -68,6 +68,8 @@ def netcdf_cf_check_file(ifile, version="auto"):
 
     # There should be a ERRORS detected summary
     if "ERRORS detected" not in ret:
+        if "urlopen error" in err:
+            pytest.skip("cfchecks network failure: " + err.strip()[:200])
         print(err)
         pytest.fail("ERROR with command - " + command)
 


### PR DESCRIPTION
Two tests fail intermittently on CI due to infrastructure, not code. This adds noise to unrelated PRs.

### `test_warp_52` - timeout 10 to 60 s

The timer guards against #2460 (RPC warp hang); correctness is the checksum. Bumped from 5 to 10 s https://github.com/OSGeo/gdal/commit/8f83a13099 in 2020. Seven master failures since Dec 2025, all on Ubuntu 20.04 coverage (12-20 s wall time):

[`20507833730`](https://github.com/OSGeo/gdal/actions/runs/20507833730), [`20640283658`](https://github.com/OSGeo/gdal/actions/runs/20640283658), [`20792110393`](https://github.com/OSGeo/gdal/actions/runs/20792110393), [`20979478889`](https://github.com/OSGeo/gdal/actions/runs/20979478889), [`21449881642`](https://github.com/OSGeo/gdal/actions/runs/21449881642), [`21501057898`](https://github.com/OSGeo/gdal/actions/runs/21501057898), [`21788575450`](https://github.com/OSGeo/gdal/actions/runs/21788575450)

### `netcdf_cf_check_file` - skip on DNS failure

`cfchecks` fetches the CF standard-names table over HTTP. DNS failure crashes it, and the helper calls `pytest.fail()` even though the check never ran. Two failures on unrelated branches (Ubuntu 24.04 gcc, the only runner with cfchecks):

[`21438432150`](https://github.com/OSGeo/gdal/actions/runs/21438432150) (`vrtcon_block`), [`21820972409`](https://github.com/OSGeo/gdal/actions/runs/21820972409) (`perf/zarr-coord-cache`)

Fix checks for `urlopen error` in stderr and converts to `pytest.skip()`.

## Tasklist

- [x] AI (Claude) supported my development of this PR
- [x] Code is correctly formatted (pre-commit)
- [x] Add test case(s) - N/A, these ARE test fixes
- [ ] All CI builds and checks have passed
