### PR TITLE
VSIMkdirRecursive(): fix perf issue on very long /vsimem/ filenames

### DIFF
--- a/autotest/gcore/vsifile.py
+++ b/autotest/gcore/vsifile.py
@@ -1908,3 +1908,12 @@ def test_vsifile_buffering(tmp_path):
         assert f.tell() == BUFFER_SIZE - 2 + 3 + 3 + BUFFER_SIZE + 3
         f.seek(-5, os.SEEK_CUR)
         assert f.read() == b"xxghi"
+
+
+###############################################################################
+def test_vsifile_mkdir_recursive_huge_filename(tmp_vsimem):
+
+    filename = str(tmp_vsimem)
+    filename += "a/" * ((4096 - len(filename)) // len("a/"))
+    assert gdal.MkdirRecursive(filename, 0o755) == 0
+    assert gdal.MkdirRecursive(filename + "a/", 0o755) < 0

--- a/port/cpl_vsi_mem.cpp
+++ b/port/cpl_vsi_mem.cpp
@@ -216,6 +216,12 @@ class VSIMemFilesystemHandler final : public VSIFilesystemHandler
 
     static CPLString NormalizePath(const std::string &in);
 
+    std::string
+    GetCanonicalFilename(const std::string &osFilename) const override
+    {
+        return NormalizePath(osFilename);
+    }
+
     int Unlink_unlocked(const char *pszFilename);
 
     VSIFilesystemHandler *Duplicate(const char *pszPrefix) override

--- a/port/cpl_vsil.cpp
+++ b/port/cpl_vsil.cpp
@@ -647,8 +647,13 @@ int VSIMkdirRecursive(const char *pszPathname, long mode)
     if (!pszPathname)
         return -1;
 
-    const std::string osPathnameOri(pszPathname);
-    if (osPathnameOri.empty() || osPathnameOri == "/")
+    const std::string osPathnameOri(VSIFileManager::GetHandler(pszPathname)
+                                        ->GetCanonicalFilename(pszPathname));
+    // Limit to avoid performance issues such as in
+    // https://issues.oss-fuzz.com/issues/471096341
+    constexpr size_t CPL_MAX_PATH = 4096;
+    if (osPathnameOri.empty() || osPathnameOri == "/" ||
+        osPathnameOri.size() > CPL_MAX_PATH)
         return -1;
 
     VSIStatBufL sStat;


### PR DESCRIPTION
Fixes https://issues.oss-fuzz.com/issues/471096341
