### PR TITLE
Use GDALGeoTransform member variables names instead of [idx]

### DIFF
--- a/apps/gdal_create.cpp
+++ b/apps/gdal_create.cpp
@@ -286,12 +286,12 @@ MAIN_START(argc, argv)
     GDALGeoTransform gt;
     if (sOptions.bGeoTransform && sOptions.nPixels > 0 && sOptions.nLines > 0)
     {
-        gt[0] = sOptions.dfULX;
-        gt[1] = (sOptions.dfLRX - sOptions.dfULX) / sOptions.nPixels;
-        gt[2] = 0;
-        gt[3] = sOptions.dfULY;
-        gt[4] = 0;
-        gt[5] = (sOptions.dfLRY - sOptions.dfULY) / sOptions.nLines;
+        gt.xorig = sOptions.dfULX;
+        gt.xscale = (sOptions.dfLRX - sOptions.dfULX) / sOptions.nPixels;
+        gt.xrot = 0;
+        gt.yorig = sOptions.dfULY;
+        gt.yrot = 0;
+        gt.yscale = (sOptions.dfLRY - sOptions.dfULY) / sOptions.nLines;
     }
 
     std::unique_ptr<GDALDataset> poInputDS;

--- a/apps/gdal_footprint_lib.cpp
+++ b/apps/gdal_footprint_lib.cpp
@@ -730,8 +730,8 @@ class GeoTransformCoordinateTransformation final
     {
         for (size_t i = 0; i < nCount; ++i)
         {
-            const double X = m_gt[0] + x[i] * m_gt[1] + y[i] * m_gt[2];
-            const double Y = m_gt[3] + x[i] * m_gt[4] + y[i] * m_gt[5];
+            const double X = m_gt.xorig + x[i] * m_gt.xscale + y[i] * m_gt.xrot;
+            const double Y = m_gt.yorig + x[i] * m_gt.yrot + y[i] * m_gt.yscale;
             x[i] = X;
             y[i] = Y;
             if (pabSuccess)
@@ -997,10 +997,10 @@ static bool GDALFootprintProcess(GDALDataset *poSrcDS, OGRLayer *poDstLayer,
         // Transform from overview pixel coordinates to full resolution
         // pixel coordinates
         auto poMaskBand = apoSrcMaskBands[0];
-        gt[1] = double(poSrcDS->GetRasterXSize()) / poMaskBand->GetXSize();
-        gt[2] = 0;
-        gt[4] = 0;
-        gt[5] = double(poSrcDS->GetRasterYSize()) / poMaskBand->GetYSize();
+        gt.xscale = double(poSrcDS->GetRasterXSize()) / poMaskBand->GetXSize();
+        gt.xrot = 0;
+        gt.yrot = 0;
+        gt.yscale = double(poSrcDS->GetRasterYSize()) / poMaskBand->GetYSize();
         poCT_GT = std::make_unique<GeoTransformCoordinateTransformation>(gt);
     }
 

--- a/apps/gdalalg_clip_common.cpp
+++ b/apps/gdalalg_clip_common.cpp
@@ -191,8 +191,8 @@ GDALClipCommon::GetClipGeometry()
                         poLikeDS->GetDescription())};
             }
             auto poLikeSRS = poLikeDS->GetSpatialRef();
-            const double dfTLX = gt[0];
-            const double dfTLY = gt[3];
+            const double dfTLX = gt.xorig;
+            const double dfTLY = gt.yorig;
 
             double dfTRX = 0;
             double dfTRY = 0;

--- a/apps/gdalalg_raster_calc.cpp
+++ b/apps/gdalalg_raster_calc.cpp
@@ -258,27 +258,30 @@ UpdateSourceProperties(SourceProperties &out, const std::string &dsn,
         dimensionMismatch = true;
     }
 
-    if (source.gt[0] != out.gt[0] || source.gt[2] != out.gt[2] ||
-        source.gt[3] != out.gt[3] || source.gt[4] != out.gt[4])
+    if (source.gt.xorig != out.gt.xorig || source.gt.xrot != out.gt.xrot ||
+        source.gt.yorig != out.gt.yorig || source.gt.yrot != out.gt.yrot)
     {
         extentMismatch = true;
     }
-    if (source.gt[1] != out.gt[1] || source.gt[5] != out.gt[5])
+    if (source.gt.xscale != out.gt.xscale || source.gt.yscale != out.gt.yscale)
     {
         // Resolutions are different. Are the extents the same?
-        double xmaxOut = out.gt[0] + out.nX * out.gt[1] + out.nY * out.gt[2];
-        double yminOut = out.gt[3] + out.nX * out.gt[4] + out.nY * out.gt[5];
+        double xmaxOut =
+            out.gt.xorig + out.nX * out.gt.xscale + out.nY * out.gt.xrot;
+        double yminOut =
+            out.gt.yorig + out.nX * out.gt.yrot + out.nY * out.gt.yscale;
 
-        double xmax =
-            source.gt[0] + source.nX * source.gt[1] + source.nY * source.gt[2];
-        double ymin =
-            source.gt[3] + source.nX * source.gt[4] + source.nY * source.gt[5];
+        double xmax = source.gt.xorig + source.nX * source.gt.xscale +
+                      source.nY * source.gt.xrot;
+        double ymin = source.gt.yorig + source.nX * source.gt.yrot +
+                      source.nY * source.gt.yscale;
 
         // Max allowable extent misalignment, expressed as fraction of a pixel
         constexpr double EXTENT_RTOL = 1e-3;
 
-        if (std::abs(xmax - xmaxOut) > EXTENT_RTOL * std::abs(source.gt[1]) ||
-            std::abs(ymin - yminOut) > EXTENT_RTOL * std::abs(source.gt[5]))
+        if (std::abs(xmax - xmaxOut) >
+                EXTENT_RTOL * std::abs(source.gt.xscale) ||
+            std::abs(ymin - yminOut) > EXTENT_RTOL * std::abs(source.gt.yscale))
         {
             extentMismatch = true;
         }
@@ -301,7 +304,7 @@ UpdateSourceProperties(SourceProperties &out, const std::string &dsn,
     // Find a common resolution
     if (source.nX > out.nX)
     {
-        auto dx = CPLGreatestCommonDivisor(out.gt[1], source.gt[1]);
+        auto dx = CPLGreatestCommonDivisor(out.gt.xscale, source.gt.xscale);
         if (dx == 0)
         {
             CPLError(CE_Failure, CPLE_AppDefined,
@@ -309,12 +312,12 @@ UpdateSourceProperties(SourceProperties &out, const std::string &dsn,
             return std::nullopt;
         }
         out.nX = static_cast<int>(
-            std::round(static_cast<double>(out.nX) * out.gt[1] / dx));
-        out.gt[1] = dx;
+            std::round(static_cast<double>(out.nX) * out.gt.xscale / dx));
+        out.gt.xscale = dx;
     }
     if (source.nY > out.nY)
     {
-        auto dy = CPLGreatestCommonDivisor(out.gt[5], source.gt[5]);
+        auto dy = CPLGreatestCommonDivisor(out.gt.yscale, source.gt.yscale);
         if (dy == 0)
         {
             CPLError(CE_Failure, CPLE_AppDefined,
@@ -322,8 +325,8 @@ UpdateSourceProperties(SourceProperties &out, const std::string &dsn,
             return std::nullopt;
         }
         out.nY = static_cast<int>(
-            std::round(static_cast<double>(out.nY) * out.gt[5] / dy));
-        out.gt[5] = dy;
+            std::round(static_cast<double>(out.nY) * out.gt.yscale / dy));
+        out.gt.yscale = dy;
     }
 
     if (srsMismatch)

--- a/apps/gdalalg_raster_create.cpp
+++ b/apps/gdalalg_raster_create.cpp
@@ -257,12 +257,12 @@ bool GDALRasterCreateAlgorithm::RunStep(GDALPipelineStepRunContext &)
             return false;
         }
         bGTValid = true;
-        gt[0] = m_bbox[0];
-        gt[1] = (m_bbox[2] - m_bbox[0]) / poRetDS->GetRasterXSize();
-        gt[2] = 0;
-        gt[3] = m_bbox[3];
-        gt[4] = 0;
-        gt[5] = -(m_bbox[3] - m_bbox[1]) / poRetDS->GetRasterYSize();
+        gt.xorig = m_bbox[0];
+        gt.xscale = (m_bbox[2] - m_bbox[0]) / poRetDS->GetRasterXSize();
+        gt.xrot = 0;
+        gt.yorig = m_bbox[3];
+        gt.yrot = 0;
+        gt.yscale = -(m_bbox[3] - m_bbox[1]) / poRetDS->GetRasterYSize();
     }
     if (bGTValid)
     {

--- a/apps/gdalalg_raster_edit.cpp
+++ b/apps/gdalalg_raster_edit.cpp
@@ -298,12 +298,12 @@ bool GDALRasterEditAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
                 return false;
             }
             GDALGeoTransform gt;
-            gt[0] = m_bbox[0];
-            gt[1] = (m_bbox[2] - m_bbox[0]) / poDS->GetRasterXSize();
-            gt[2] = 0;
-            gt[3] = m_bbox[3];
-            gt[4] = 0;
-            gt[5] = -(m_bbox[3] - m_bbox[1]) / poDS->GetRasterYSize();
+            gt.xorig = m_bbox[0];
+            gt.xscale = (m_bbox[2] - m_bbox[0]) / poDS->GetRasterXSize();
+            gt.xrot = 0;
+            gt.yorig = m_bbox[3];
+            gt.yrot = 0;
+            gt.yscale = -(m_bbox[3] - m_bbox[1]) / poDS->GetRasterYSize();
             if (poDS->SetGeoTransform(gt) != CE_None)
             {
                 ReportError(CE_Failure, CPLE_AppDefined,

--- a/apps/gdalalg_raster_tile.cpp
+++ b/apps/gdalalg_raster_tile.cpp
@@ -1404,14 +1404,14 @@ static bool GenerateTile(
     }
 
     GDALGeoTransform gt;
-    gt[0] =
+    gt.xorig =
         tileMatrix.mTopLeftX + iX * tileMatrix.mResX * tileMatrix.mTileWidth;
-    gt[1] = tileMatrix.mResX;
-    gt[2] = 0;
-    gt[3] =
+    gt.xscale = tileMatrix.mResX;
+    gt.xrot = 0;
+    gt.yorig =
         tileMatrix.mTopLeftY - iY * tileMatrix.mResY * tileMatrix.mTileHeight;
-    gt[4] = 0;
-    gt[5] = -tileMatrix.mResY;
+    gt.yrot = 0;
+    gt.yscale = -tileMatrix.mResY;
     memDS->SetGeoTransform(gt);
 
     memDS->SetSpatialRef(&oSRS_TMS);
@@ -2026,12 +2026,12 @@ class MosaicDataset : public GDALDataset
     {
         nRasterXSize = (nTileMaxX - nTileMinX + 1) * oTM.mTileWidth;
         nRasterYSize = (nTileMaxY - nTileMinY + 1) * oTM.mTileHeight;
-        m_gt[0] = oTM.mTopLeftX + nTileMinX * oTM.mResX * oTM.mTileWidth;
-        m_gt[1] = oTM.mResX;
-        m_gt[2] = 0;
-        m_gt[3] = oTM.mTopLeftY - nTileMinY * oTM.mResY * oTM.mTileHeight;
-        m_gt[4] = 0;
-        m_gt[5] = -oTM.mResY;
+        m_gt.xorig = oTM.mTopLeftX + nTileMinX * oTM.mResX * oTM.mTileWidth;
+        m_gt.xscale = oTM.mResX;
+        m_gt.xrot = 0;
+        m_gt.yorig = oTM.mTopLeftY - nTileMinY * oTM.mResY * oTM.mTileHeight;
+        m_gt.yrot = 0;
+        m_gt.yscale = -oTM.mResY;
         for (int i = 1; i <= nBandsIn; ++i)
         {
             const GDALColorInterp eColorInterp =

--- a/apps/gdalalg_raster_update.cpp
+++ b/apps/gdalalg_raster_update.cpp
@@ -159,8 +159,8 @@ bool GDALRasterUpdateAlgorithm::RunStep(GDALPipelineStepRunContext &stepCtxt)
                          : nullptr);
             if (bBothNoCRS || poCT)
             {
-                const double dfTLX = gt[0];
-                const double dfTLY = gt[3];
+                const double dfTLX = gt.xorig;
+                const double dfTLY = gt.yorig;
 
                 double dfTRX = 0;
                 double dfTRY = 0;

--- a/apps/gdalbuildvrt_lib.cpp
+++ b/apps/gdalbuildvrt_lib.cpp
@@ -1431,9 +1431,9 @@ void VRTBuilder::CreateVRTNonSeparate(VRTDataset *poVRTDS)
 
         if (bCanCollectOverviewFactors)
         {
-            if (std::abs(psDatasetProperties->gt[1] - we_res) >
+            if (std::abs(psDatasetProperties->gt.xscale - we_res) >
                     1e-8 * std::abs(we_res) ||
-                std::abs(psDatasetProperties->gt[5] - ns_res) >
+                std::abs(psDatasetProperties->gt.yscale - ns_res) >
                     1e-8 * std::abs(ns_res))
             {
                 bCanCollectOverviewFactors = false;

--- a/apps/gdaldem_lib.cpp
+++ b/apps/gdaldem_lib.cpp
@@ -3689,7 +3689,7 @@ GDALDatasetH GDALDEMProcessing(const char *pszDest, GDALDatasetH hSrcDataset,
                     dfAngUnits * poSrcSRS->GetSemiMajor() / zunit;
                 // Take the center latitude to compute the xscale.
                 const double dfMeanLat =
-                    (gt[3] + nYSize * gt[5] / 2) * dfAngUnits;
+                    (gt.yorig + nYSize * gt.yscale / 2) * dfAngUnits;
                 if (std::fabs(dfMeanLat) / M_PI * 180 > 80)
                 {
                     CPLError(

--- a/apps/gdalmdimtranslate_lib.cpp
+++ b/apps/gdalmdimtranslate_lib.cpp
@@ -1198,7 +1198,7 @@ static bool TranslateArray(
                 {
                     GDALGeoTransform gt;
                     if (poSrcDS->GetGeoTransform(gt) == CE_None &&
-                        gt[2] == 0.0 && gt[4] == 0.0)
+                        gt.IsAxisAligned())
                     {
                         auto var = poDstGroup->CreateVRTMDArray(
                             newDimName, {dstDim},
@@ -1207,11 +1207,13 @@ static bool TranslateArray(
                         {
                             const double dfStart =
                                 srcIndexVar->GetName() == "X"
-                                    ? gt[0] + (range.m_nStartIdx + 0.5) * gt[1]
-                                    : gt[3] + (range.m_nStartIdx + 0.5) * gt[5];
+                                    ? gt.xorig +
+                                          (range.m_nStartIdx + 0.5) * gt.xscale
+                                    : gt.yorig +
+                                          (range.m_nStartIdx + 0.5) * gt.yscale;
                             const double dfIncr =
-                                (srcIndexVar->GetName() == "X" ? gt[1]
-                                                               : gt[5]) *
+                                (srcIndexVar->GetName() == "X" ? gt.xscale
+                                                               : gt.yscale) *
                                 range.m_nIncr;
                             auto poSource = std::make_unique<
                                 VRTMDArraySourceRegularlySpaced>(dfStart,

--- a/apps/gdaltindex_lib.cpp
+++ b/apps/gdaltindex_lib.cpp
@@ -1912,20 +1912,20 @@ GDALDatasetH GDALTileIndexInternal(const char *pszDest,
 
         double adfX[5] = {0.0, 0.0, 0.0, 0.0, 0.0};
         double adfY[5] = {0.0, 0.0, 0.0, 0.0, 0.0};
-        adfX[0] = gt[0] + 0 * gt[1] + 0 * gt[2];
-        adfY[0] = gt[3] + 0 * gt[4] + 0 * gt[5];
+        adfX[0] = gt.xorig + 0 * gt.xscale + 0 * gt.xrot;
+        adfY[0] = gt.yorig + 0 * gt.yrot + 0 * gt.yscale;
 
-        adfX[1] = gt[0] + nXSize * gt[1] + 0 * gt[2];
-        adfY[1] = gt[3] + nXSize * gt[4] + 0 * gt[5];
+        adfX[1] = gt.xorig + nXSize * gt.xscale + 0 * gt.xrot;
+        adfY[1] = gt.yorig + nXSize * gt.yrot + 0 * gt.yscale;
 
-        adfX[2] = gt[0] + nXSize * gt[1] + nYSize * gt[2];
-        adfY[2] = gt[3] + nXSize * gt[4] + nYSize * gt[5];
+        adfX[2] = gt.xorig + nXSize * gt.xscale + nYSize * gt.xrot;
+        adfY[2] = gt.yorig + nXSize * gt.yrot + nYSize * gt.yscale;
 
-        adfX[3] = gt[0] + 0 * gt[1] + nYSize * gt[2];
-        adfY[3] = gt[3] + 0 * gt[4] + nYSize * gt[5];
+        adfX[3] = gt.xorig + 0 * gt.xscale + nYSize * gt.xrot;
+        adfY[3] = gt.yorig + 0 * gt.yrot + nYSize * gt.yscale;
 
-        adfX[4] = gt[0] + 0 * gt[1] + 0 * gt[2];
-        adfY[4] = gt[3] + 0 * gt[4] + 0 * gt[5];
+        adfX[4] = gt.xorig + 0 * gt.xscale + 0 * gt.xrot;
+        adfY[4] = gt.yorig + 0 * gt.yrot + 0 * gt.yscale;
 
         const double dfMinXBeforeReproj =
             std::min(std::min(adfX[0], adfX[1]), std::min(adfX[2], adfX[3]));
@@ -2635,12 +2635,12 @@ GDALDatasetH GDALTileIndexInternal(const char *pszDest,
                 double *values = static_cast<double *>(const_cast<void *>(
                     projTransformItems->buffers[ARROW_BUF_DATA]));
                 auto ptr = values + nBatchSize * NUM_ITEMS_PROJ_TRANSFORM;
-                ptr[0] = gt[1];
-                ptr[1] = gt[2];
-                ptr[2] = gt[0];
-                ptr[3] = gt[4];
-                ptr[4] = gt[5];
-                ptr[5] = gt[3];
+                ptr[0] = gt.xscale;
+                ptr[1] = gt.xrot;
+                ptr[2] = gt.xorig;
+                ptr[3] = gt.yrot;
+                ptr[4] = gt.yscale;
+                ptr[5] = gt.yorig;
                 ptr[6] = 0;
                 ptr[7] = 0;
                 ptr[8] = 1;

--- a/doc/source/api/gdaldataset_cpp.rst
+++ b/doc/source/api/gdaldataset_cpp.rst
@@ -54,4 +54,7 @@ GDALRelationship class
      CREATIONOPTIONLIST
      nDeltaDegreeOfFreedom
      padfCovMatrix
-
+     xscale
+     xorig
+     yscale
+     yorig

--- a/frmts/adrg/adrgdataset.cpp
+++ b/frmts/adrg/adrgdataset.cpp
@@ -762,13 +762,14 @@ ADRGDataset *ADRGDataset::OpenDataset(const char *pszGENFileName,
     if (ZNA == 9)
     {
         // North Polar Case
-        poDS->m_gt[0] = 111319.4907933 * (90.0 - PSO) * sin(LSO * M_PI / 180.0);
-        poDS->m_gt[1] = 40075016.68558 / ARV;
-        poDS->m_gt[2] = 0.0;
-        poDS->m_gt[3] =
+        poDS->m_gt.xorig =
+            111319.4907933 * (90.0 - PSO) * sin(LSO * M_PI / 180.0);
+        poDS->m_gt.xscale = 40075016.68558 / ARV;
+        poDS->m_gt.xrot = 0.0;
+        poDS->m_gt.yorig =
             -111319.4907933 * (90.0 - PSO) * cos(LSO * M_PI / 180.0);
-        poDS->m_gt[4] = 0.0;
-        poDS->m_gt[5] = -40075016.68558 / ARV;
+        poDS->m_gt.yrot = 0.0;
+        poDS->m_gt.yscale = -40075016.68558 / ARV;
         poDS->m_oSRS.importFromWkt(
             "PROJCS[\"ARC_System_Zone_09\",GEOGCS[\"GCS_Sphere\","
             "DATUM[\"D_Sphere\",SPHEROID[\"Sphere\",6378137.0,0.0]],"
@@ -783,12 +784,14 @@ ADRGDataset *ADRGDataset::OpenDataset(const char *pszGENFileName,
     else if (ZNA == 18)
     {
         // South Polar Case
-        poDS->m_gt[0] = 111319.4907933 * (90.0 + PSO) * sin(LSO * M_PI / 180.0);
-        poDS->m_gt[1] = 40075016.68558 / ARV;
-        poDS->m_gt[2] = 0.0;
-        poDS->m_gt[3] = 111319.4907933 * (90.0 + PSO) * cos(LSO * M_PI / 180.0);
-        poDS->m_gt[4] = 0.0;
-        poDS->m_gt[5] = -40075016.68558 / ARV;
+        poDS->m_gt.xorig =
+            111319.4907933 * (90.0 + PSO) * sin(LSO * M_PI / 180.0);
+        poDS->m_gt.xscale = 40075016.68558 / ARV;
+        poDS->m_gt.xrot = 0.0;
+        poDS->m_gt.yorig =
+            111319.4907933 * (90.0 + PSO) * cos(LSO * M_PI / 180.0);
+        poDS->m_gt.yrot = 0.0;
+        poDS->m_gt.yscale = -40075016.68558 / ARV;
         poDS->m_oSRS.importFromWkt(
             "PROJCS[\"ARC_System_Zone_18\",GEOGCS[\"GCS_Sphere\","
             "DATUM[\"D_Sphere\",SPHEROID[\"Sphere\",6378137.0,0.0]],"
@@ -802,12 +805,12 @@ ADRGDataset *ADRGDataset::OpenDataset(const char *pszGENFileName,
     }
     else
     {
-        poDS->m_gt[0] = LSO;
-        poDS->m_gt[1] = 360. / ARV;
-        poDS->m_gt[2] = 0.0;
-        poDS->m_gt[3] = PSO;
-        poDS->m_gt[4] = 0.0;
-        poDS->m_gt[5] = -360. / BRV;
+        poDS->m_gt.xorig = LSO;
+        poDS->m_gt.xscale = 360. / ARV;
+        poDS->m_gt.xrot = 0.0;
+        poDS->m_gt.yorig = PSO;
+        poDS->m_gt.yrot = 0.0;
+        poDS->m_gt.yscale = -360. / BRV;
         poDS->m_oSRS.importFromWkt(SRS_WKT_WGS84_LAT_LONG);
     }
 

--- a/frmts/adrg/srpdataset.cpp
+++ b/frmts/adrg/srpdataset.cpp
@@ -390,49 +390,49 @@ CPLErr SRPDataset::GetGeoTransform(GDALGeoTransform &gt) const
         if (ZNA == 9)
         {
             // North Polar Case
-            gt[0] = 111319.4907933 * (90.0 - PSO / 3600.0) *
-                    sin(LSO * M_PI / 648000.0);
-            gt[1] = 40075016.68558 / ARV;
-            gt[2] = 0.0;
-            gt[3] = -111319.4907933 * (90.0 - PSO / 3600.0) *
-                    cos(LSO * M_PI / 648000.0);
-            gt[4] = 0.0;
-            gt[5] = -40075016.68558 / ARV;
+            gt.xorig = 111319.4907933 * (90.0 - PSO / 3600.0) *
+                       sin(LSO * M_PI / 648000.0);
+            gt.xscale = 40075016.68558 / ARV;
+            gt.xrot = 0.0;
+            gt.yorig = -111319.4907933 * (90.0 - PSO / 3600.0) *
+                       cos(LSO * M_PI / 648000.0);
+            gt.yrot = 0.0;
+            gt.yscale = -40075016.68558 / ARV;
         }
         else if (ZNA == 18)
         {
             // South Polar Case
-            gt[0] = 111319.4907933 * (90.0 + PSO / 3600.0) *
-                    sin(LSO * M_PI / 648000.0);
-            gt[1] = 40075016.68558 / ARV;
-            gt[2] = 0.0;
-            gt[3] = 111319.4907933 * (90.0 + PSO / 3600.0) *
-                    cos(LSO * M_PI / 648000.0);
-            gt[4] = 0.0;
-            gt[5] = -40075016.68558 / ARV;
+            gt.xorig = 111319.4907933 * (90.0 + PSO / 3600.0) *
+                       sin(LSO * M_PI / 648000.0);
+            gt.xscale = 40075016.68558 / ARV;
+            gt.xrot = 0.0;
+            gt.yorig = 111319.4907933 * (90.0 + PSO / 3600.0) *
+                       cos(LSO * M_PI / 648000.0);
+            gt.yrot = 0.0;
+            gt.yscale = -40075016.68558 / ARV;
         }
         else
         {
             if (BRV == 0)
                 return CE_Failure;
-            gt[0] = LSO / 3600.0;
-            gt[1] = 360. / ARV;
-            gt[2] = 0.0;
-            gt[3] = PSO / 3600.0;
-            gt[4] = 0.0;
-            gt[5] = -360. / BRV;
+            gt.xorig = LSO / 3600.0;
+            gt.xscale = 360. / ARV;
+            gt.xrot = 0.0;
+            gt.yorig = PSO / 3600.0;
+            gt.yrot = 0.0;
+            gt.yscale = -360. / BRV;
         }
 
         return CE_None;
     }
     else if (EQUAL(osProduct, "USRP"))
     {
-        gt[0] = LSO;
-        gt[1] = LOD;
-        gt[2] = 0.0;
-        gt[3] = PSO;
-        gt[4] = 0.0;
-        gt[5] = -LAD;
+        gt.xorig = LSO;
+        gt.xscale = LOD;
+        gt.xrot = 0.0;
+        gt.yorig = PSO;
+        gt.yrot = 0.0;
+        gt.yscale = -LAD;
         return CE_None;
     }
 

--- a/frmts/aigrid/aigdataset.cpp
+++ b/frmts/aigrid/aigdataset.cpp
@@ -759,13 +759,13 @@ GDALDataset *AIGDataset::Open(GDALOpenInfo *poOpenInfo)
 CPLErr AIGDataset::GetGeoTransform(GDALGeoTransform &gt) const
 
 {
-    gt[0] = psInfo->dfLLX;
-    gt[1] = psInfo->dfCellSizeX;
-    gt[2] = 0;
+    gt.xorig = psInfo->dfLLX;
+    gt.xscale = psInfo->dfCellSizeX;
+    gt.xrot = 0;
 
-    gt[3] = psInfo->dfURY;
-    gt[4] = 0;
-    gt[5] = -psInfo->dfCellSizeY;
+    gt.yorig = psInfo->dfURY;
+    gt.yrot = 0;
+    gt.yscale = -psInfo->dfCellSizeY;
 
     return CE_None;
 }

--- a/frmts/bmp/bmpdataset.cpp
+++ b/frmts/bmp/bmpdataset.cpp
@@ -1012,10 +1012,10 @@ CPLErr BMPDataset::GetGeoTransform(GDALGeoTransform &gt) const
     // See http://trac.osgeo.org/gdal/ticket/3578
     if (sInfoHeader.iXPelsPerMeter > 0 && sInfoHeader.iYPelsPerMeter > 0)
     {
-        gt[1] = sInfoHeader.iXPelsPerMeter;
-        gt[5] = -sInfoHeader.iYPelsPerMeter;
-        gt[0] = -0.5 * gt[1];
-        gt[3] = -0.5 * gt[5];
+        gt.xscale = sInfoHeader.iXPelsPerMeter;
+        gt.yscale = -sInfoHeader.iYPelsPerMeter;
+        gt.xorig = -0.5 * gt.xscale;
+        gt.yorig = -0.5 * gt.yscale;
         return CE_None;
     }
 #endif

--- a/frmts/bsb/bsbdataset.cpp
+++ b/frmts/bsb/bsbdataset.cpp
@@ -1138,17 +1138,17 @@ static GDALDataset *BSBCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
         if (BSBIsSRSOK(pszProjection))
         {
             VSIFPrintfL(psBSB->fp, "REF/%d,%d,%d,%f,%f\n", 1, 0, 0,
-                        gt[3] + 0 * gt[4] + 0 * gt[5],
-                        gt[0] + 0 * gt[1] + 0 * gt[2]);
+                        gt.yorig + 0 * gt.yrot + 0 * gt.yscale,
+                        gt.xorig + 0 * gt.xscale + 0 * gt.xrot);
             VSIFPrintfL(psBSB->fp, "REF/%d,%d,%d,%f,%f\n", 2, nXSize, 0,
-                        gt[3] + nXSize * gt[4] + 0 * gt[5],
-                        gt[0] + nXSize * gt[1] + 0 * gt[2]);
+                        gt.yorig + nXSize * gt.yrot + 0 * gt.yscale,
+                        gt.xorig + nXSize * gt.xscale + 0 * gt.xrot);
             VSIFPrintfL(psBSB->fp, "REF/%d,%d,%d,%f,%f\n", 3, nXSize, nYSize,
-                        gt[3] + nXSize * gt[4] + nYSize * gt[5],
-                        gt[0] + nXSize * gt[1] + nYSize * gt[2]);
+                        gt.yorig + nXSize * gt.yrot + nYSize * gt.yscale,
+                        gt.xorig + nXSize * gt.xscale + nYSize * gt.xrot);
             VSIFPrintfL(psBSB->fp, "REF/%d,%d,%d,%f,%f\n", 4, 0, nYSize,
-                        gt[3] + 0 * gt[4] + nYSize * gt[5],
-                        gt[0] + 0 * gt[1] + nYSize * gt[2]);
+                        gt.yorig + 0 * gt.yrot + nYSize * gt.yscale,
+                        gt.xorig + 0 * gt.xscale + nYSize * gt.xrot);
         }
     }
 

--- a/frmts/ctg/ctgdataset.cpp
+++ b/frmts/ctg/ctgdataset.cpp
@@ -528,12 +528,12 @@ GDALDataset *CTGDataset::Open(GDALOpenInfo *poOpenInfo)
 CPLErr CTGDataset::GetGeoTransform(GDALGeoTransform &gt) const
 
 {
-    gt[0] = static_cast<double>(nNWEasting) - nCellSize / 2;
-    gt[1] = nCellSize;
-    gt[2] = 0;
-    gt[3] = static_cast<double>(nNWNorthing) + nCellSize / 2;
-    gt[4] = 0.;
-    gt[5] = -nCellSize;
+    gt.xorig = static_cast<double>(nNWEasting) - nCellSize / 2;
+    gt.xscale = nCellSize;
+    gt.xrot = 0;
+    gt.yorig = static_cast<double>(nNWNorthing) + nCellSize / 2;
+    gt.yrot = 0.;
+    gt.yscale = -nCellSize;
 
     return CE_None;
 }

--- a/frmts/daas/daasdataset.cpp
+++ b/frmts/daas/daasdataset.cpp
@@ -2106,8 +2106,8 @@ CPLErr GDALDAASRasterBand::GetBlocks(int nBlockXOff, int nBlockYOff,
     CPLJSONObject oStepTargetModel;
     if (poGDS->m_bRequestInGeoreferencedCoordinates)
     {
-        oStepTargetModel.Add("x", poGDS->m_gt[1]);
-        oStepTargetModel.Add("y", fabs(poGDS->m_gt[5]));
+        oStepTargetModel.Add("x", poGDS->m_gt.xscale);
+        oStepTargetModel.Add("y", fabs(poGDS->m_gt.yscale));
     }
     else
     {

--- a/frmts/dimap/dimapdataset.cpp
+++ b/frmts/dimap/dimapdataset.cpp
@@ -886,12 +886,12 @@ int DIMAPDataset::ReadImageInformation()
     if (psGeoLoc != nullptr)
     {
         bHaveGeoTransform = TRUE;
-        m_gt[0] = CPLAtof(CPLGetXMLValue(psGeoLoc, "ULXMAP", "0"));
-        m_gt[1] = CPLAtof(CPLGetXMLValue(psGeoLoc, "XDIM", "0"));
-        m_gt[2] = 0.0;
-        m_gt[3] = CPLAtof(CPLGetXMLValue(psGeoLoc, "ULYMAP", "0"));
-        m_gt[4] = 0.0;
-        m_gt[5] = -CPLAtof(CPLGetXMLValue(psGeoLoc, "YDIM", "0"));
+        m_gt.xorig = CPLAtof(CPLGetXMLValue(psGeoLoc, "ULXMAP", "0"));
+        m_gt.xscale = CPLAtof(CPLGetXMLValue(psGeoLoc, "XDIM", "0"));
+        m_gt.xrot = 0.0;
+        m_gt.yorig = CPLAtof(CPLGetXMLValue(psGeoLoc, "ULYMAP", "0"));
+        m_gt.yrot = 0.0;
+        m_gt.yscale = -CPLAtof(CPLGetXMLValue(psGeoLoc, "YDIM", "0"));
     }
     else
     {
@@ -1468,27 +1468,27 @@ int DIMAPDataset::ReadImageInformation2()
     if (psGeoLoc != nullptr)
     {
         bHaveGeoTransform = TRUE;
-        m_gt[0] = CPLAtof(CPLGetXMLValue(psGeoLoc, "ULXMAP", "0"));
-        m_gt[1] = CPLAtof(CPLGetXMLValue(psGeoLoc, "XDIM", "0"));
-        m_gt[2] = 0.0;
-        m_gt[3] = CPLAtof(CPLGetXMLValue(psGeoLoc, "ULYMAP", "0"));
-        m_gt[4] = 0.0;
-        m_gt[5] = -CPLAtof(CPLGetXMLValue(psGeoLoc, "YDIM", "0"));
+        m_gt.xorig = CPLAtof(CPLGetXMLValue(psGeoLoc, "ULXMAP", "0"));
+        m_gt.xscale = CPLAtof(CPLGetXMLValue(psGeoLoc, "XDIM", "0"));
+        m_gt.xrot = 0.0;
+        m_gt.yorig = CPLAtof(CPLGetXMLValue(psGeoLoc, "ULYMAP", "0"));
+        m_gt.yrot = 0.0;
+        m_gt.yscale = -CPLAtof(CPLGetXMLValue(psGeoLoc, "YDIM", "0"));
     }
     else
     {
         // Try to get geotransform from underlying raster,
         // but make sure it is a real geotransform.
         if (poImageDS->GetGeoTransform(m_gt) == CE_None &&
-            !(m_gt[0] <= 1.5 && fabs(m_gt[3]) <= 1.5))
+            !(m_gt.xorig <= 1.5 && fabs(m_gt.yorig) <= 1.5))
         {
             bHaveGeoTransform = TRUE;
             // fix up the origin if we did not get the geotransform from the
             // top-left tile
-            m_gt[0] -= (nImageDSCol - 1) * m_gt[1] * nTileWidth +
-                       (nImageDSRow - 1) * m_gt[2] * nTileHeight;
-            m_gt[3] -= (nImageDSCol - 1) * m_gt[4] * nTileWidth +
-                       (nImageDSRow - 1) * m_gt[5] * nTileHeight;
+            m_gt.xorig -= (nImageDSCol - 1) * m_gt.xscale * nTileWidth +
+                          (nImageDSRow - 1) * m_gt.xrot * nTileHeight;
+            m_gt.yorig -= (nImageDSCol - 1) * m_gt.yrot * nTileWidth +
+                          (nImageDSRow - 1) * m_gt.yscale * nTileHeight;
         }
     }
 

--- a/frmts/dted/dteddataset.cpp
+++ b/frmts/dted/dteddataset.cpp
@@ -519,23 +519,23 @@ CPLErr DTEDDataset::GetGeoTransform(GDALGeoTransform &gt) const
         CPLTestBool(CPLGetConfigOption("DTED_APPLY_PIXEL_IS_POINT", "FALSE"));
     if (!bApplyPixelIsPoint)
     {
-        gt[0] = psDTED->dfULCornerX;
-        gt[1] = psDTED->dfPixelSizeX;
-        gt[2] = 0.0;
-        gt[3] = psDTED->dfULCornerY;
-        gt[4] = 0.0;
-        gt[5] = psDTED->dfPixelSizeY * -1;
+        gt.xorig = psDTED->dfULCornerX;
+        gt.xscale = psDTED->dfPixelSizeX;
+        gt.xrot = 0.0;
+        gt.yorig = psDTED->dfULCornerY;
+        gt.yrot = 0.0;
+        gt.yscale = psDTED->dfPixelSizeY * -1;
 
         return CE_None;
     }
     else
     {
-        gt[0] = psDTED->dfULCornerX + (0.5 * psDTED->dfPixelSizeX);
-        gt[1] = psDTED->dfPixelSizeX;
-        gt[2] = 0.0;
-        gt[3] = psDTED->dfULCornerY - (0.5 * psDTED->dfPixelSizeY);
-        gt[4] = 0.0;
-        gt[5] = psDTED->dfPixelSizeY * -1;
+        gt.xorig = psDTED->dfULCornerX + (0.5 * psDTED->dfPixelSizeX);
+        gt.xscale = psDTED->dfPixelSizeX;
+        gt.xrot = 0.0;
+        gt.yorig = psDTED->dfULCornerY - (0.5 * psDTED->dfPixelSizeY);
+        gt.yrot = 0.0;
+        gt.yscale = psDTED->dfPixelSizeY * -1;
 
         return CE_None;
     }
@@ -729,13 +729,13 @@ static GDALDataset *DTEDCreateCopy(const char *pszFilename,
     poSrcDS->GetGeoTransform(gt);
 
     int nLLOriginLat =
-        (int)floor(gt[3] + poSrcDS->GetRasterYSize() * gt[5] + 0.5);
+        (int)floor(gt.yorig + poSrcDS->GetRasterYSize() * gt.yscale + 0.5);
 
-    int nLLOriginLong = (int)floor(gt[0] + 0.5);
+    int nLLOriginLong = (int)floor(gt.xorig + 0.5);
 
-    if (fabs(nLLOriginLat -
-             (gt[3] + (poSrcDS->GetRasterYSize() - 0.5) * gt[5])) > 1e-10 ||
-        fabs(nLLOriginLong - (gt[0] + 0.5 * gt[1])) > 1e-10)
+    if (fabs(nLLOriginLat - (gt.yorig + (poSrcDS->GetRasterYSize() - 0.5) *
+                                            gt.yscale)) > 1e-10 ||
+        fabs(nLLOriginLong - (gt.xorig + 0.5 * gt.xscale)) > 1e-10)
     {
         CPLError(CE_Warning, CPLE_AppDefined,
                  "The corner coordinates of the source are not properly "

--- a/frmts/ecw/ecwcreatecopy.cpp
+++ b/frmts/ecw/ecwcreatecopy.cpp
@@ -719,16 +719,16 @@ CPLErr GDALECWCompressor::Initialize(
     psClient->fCellIncrementY = -1.0;
     psClient->fCWRotationDegrees = 0.0;
 
-    if (gt[2] != 0.0 || gt[4] != 0.0)
+    if (gt.xrot != 0.0 || gt.yrot != 0.0)
         CPLError(CE_Warning, CPLE_NotSupported,
                  "Rotational coefficients ignored, georeferencing of\n"
                  "output ECW file will be incorrect.\n");
     else
     {
-        psClient->fOriginX = gt[0];
-        psClient->fOriginY = gt[3];
-        psClient->fCellIncrementX = gt[1];
-        psClient->fCellIncrementY = gt[5];
+        psClient->fOriginX = gt.xorig;
+        psClient->fOriginY = gt.yorig;
+        psClient->fCellIncrementX = gt.xscale;
+        psClient->fCellIncrementY = gt.yscale;
     }
 
     /* -------------------------------------------------------------------- */

--- a/frmts/ecw/ecwdataset.cpp
+++ b/frmts/ecw/ecwdataset.cpp
@@ -1642,10 +1642,10 @@ void ECWDataset::WriteHeader()
 
     if (bGeoTransformChanged)
     {
-        psEditInfo->fOriginX = m_gt[0];
-        psEditInfo->fCellIncrementX = m_gt[1];
-        psEditInfo->fOriginY = m_gt[3];
-        psEditInfo->fCellIncrementY = m_gt[5];
+        psEditInfo->fOriginX = m_gt.xorig;
+        psEditInfo->fCellIncrementX = m_gt.xscale;
+        psEditInfo->fOriginY = m_gt.yorig;
+        psEditInfo->fCellIncrementY = m_gt.yscale;
         CPLDebug("ECW", "Rewrite Geotransform");
     }
 
@@ -3414,12 +3414,12 @@ void ECWDataset::ECW2WKTProjection()
     {
         bGeoTransformValid = TRUE;
 
-        m_gt[0] = psFileInfo->fOriginX;
-        m_gt[1] = psFileInfo->fCellIncrementX;
-        m_gt[2] = 0.0;
+        m_gt.xorig = psFileInfo->fOriginX;
+        m_gt.xscale = psFileInfo->fCellIncrementX;
+        m_gt.xrot = 0.0;
 
-        m_gt[3] = psFileInfo->fOriginY;
-        m_gt[4] = 0.0;
+        m_gt.yorig = psFileInfo->fOriginY;
+        m_gt.yrot = 0.0;
 
         /* By default, set Y-resolution negative assuming images always */
         /* have "Upward" orientation (Y coordinates increase "Upward"). */
@@ -3429,9 +3429,9 @@ void ECWDataset::ECW2WKTProjection()
         /* rare images with "Downward" orientation, where Y coordinates */
         /* increase "Downward" and Y-resolution is positive.            */
         if (CPLTestBool(CPLGetConfigOption("ECW_ALWAYS_UPWARD", "TRUE")))
-            m_gt[5] = -fabs(psFileInfo->fCellIncrementY);
+            m_gt.yscale = -fabs(psFileInfo->fCellIncrementY);
         else
-            m_gt[5] = psFileInfo->fCellIncrementY;
+            m_gt.yscale = psFileInfo->fCellIncrementY;
     }
 
     /* -------------------------------------------------------------------- */

--- a/frmts/eeda/eedadataset.cpp
+++ b/frmts/eeda/eedadataset.cpp
@@ -521,21 +521,22 @@ OGRFeature *GDALEEDALayer::GetNextRawFeature()
             int nWidth = 0, nHeight = 0;
             double dfMinPixelSize = std::numeric_limits<double>::max();
             CPLString osSRS(aoBands[0].osWKT);
-            double dfULX = aoBands[0].gt[0];
-            double dfULY = aoBands[0].gt[3];
+            double dfULX = aoBands[0].gt.xorig;
+            double dfULY = aoBands[0].gt.yorig;
             bool bULValid = true;
             for (size_t i = 0; i < aoBands.size(); i++)
             {
                 nWidth = std::max(nWidth, aoBands[i].nWidth);
                 nHeight = std::max(nHeight, aoBands[i].nHeight);
-                dfMinPixelSize =
-                    std::min(dfMinPixelSize, std::min(aoBands[i].gt[1],
-                                                      fabs(aoBands[i].gt[5])));
+                dfMinPixelSize = std::min(
+                    dfMinPixelSize,
+                    std::min(aoBands[i].gt.xscale, fabs(aoBands[i].gt.yscale)));
                 if (osSRS != aoBands[i].osWKT)
                 {
                     osSRS.clear();
                 }
-                if (dfULX != aoBands[i].gt[0] || dfULY != aoBands[i].gt[3])
+                if (dfULX != aoBands[i].gt.xorig ||
+                    dfULY != aoBands[i].gt.yorig)
                 {
                     bULValid = false;
                 }

--- a/frmts/esric/esric_dataset.cpp
+++ b/frmts/esric/esric_dataset.cpp
@@ -321,10 +321,10 @@ CPLErr ECDataset::Initialize(CPLXMLNode *CacheInfo, bool ignoreOversizedLods)
         // resolution is the smallest figure
         res = resolutions[0];
         m_gt = GDALGeoTransform();
-        m_gt[0] = minx;
-        m_gt[3] = maxy;
-        m_gt[1] = res;
-        m_gt[5] = -res;
+        m_gt.xorig = minx;
+        m_gt.yorig = maxy;
+        m_gt.xscale = res;
+        m_gt.yscale = -res;
 
         double dxsz = (maxx - minx) / res;
         double dysz = (maxy - miny) / res;
@@ -490,10 +490,10 @@ CPLErr ECDataset::InitializeFromJSON(const CPLJSONObject &oRoot,
         // resolution is the smallest figure
         res = resolutions[0];
         m_gt = GDALGeoTransform();
-        m_gt[0] = minx;
-        m_gt[3] = maxy;
-        m_gt[1] = res;
-        m_gt[5] = -res;
+        m_gt.xorig = minx;
+        m_gt.yorig = maxy;
+        m_gt.xscale = res;
+        m_gt.yscale = -res;
 
         double dxsz = (maxx - minx) / res;
         double dysz = (maxy - miny) / res;

--- a/frmts/exr/exrdataset.cpp
+++ b/frmts/exr/exrdataset.cpp
@@ -764,12 +764,12 @@ GDALDataset *GDALEXRDataset::Open(GDALOpenInfo *poOpenInfo)
                          strcmp(iter.name(), "gdal:geoTransform") == 0)
                 {
                     poDS->m_bHasGT = true;
-                    poDS->m_gt[0] = m33DAttr->value()[0][2];
-                    poDS->m_gt[1] = m33DAttr->value()[0][0];
-                    poDS->m_gt[2] = m33DAttr->value()[0][1];
-                    poDS->m_gt[3] = m33DAttr->value()[1][2];
-                    poDS->m_gt[4] = m33DAttr->value()[1][0];
-                    poDS->m_gt[5] = m33DAttr->value()[1][1];
+                    poDS->m_gt.xorig = m33DAttr->value()[0][2];
+                    poDS->m_gt.xscale = m33DAttr->value()[0][0];
+                    poDS->m_gt.xrot = m33DAttr->value()[0][1];
+                    poDS->m_gt.yorig = m33DAttr->value()[1][2];
+                    poDS->m_gt.yrot = m33DAttr->value()[1][0];
+                    poDS->m_gt.yscale = m33DAttr->value()[1][1];
                 }
                 else if (stringAttr && STARTS_WITH(iter.name(), "gdal:"))
                 {
@@ -876,17 +876,17 @@ static void WriteSRSInHeader(Header &header, const OGRSpatialReference *poSRS)
 static void WriteGeoTransformInHeader(Header &header,
                                       const GDALGeoTransform &gtIn)
 {
-    M33d gt;
-    gt[0][0] = gtIn[1];
-    gt[0][1] = gtIn[2];
-    gt[0][2] = gtIn[0];
-    gt[1][0] = gtIn[4];
-    gt[1][1] = gtIn[5];
-    gt[1][2] = gtIn[3];
-    gt[2][0] = 0;
-    gt[2][1] = 0;
-    gt[2][2] = 1;
-    header.insert("gdal:geoTransform", M33dAttribute(gt));
+    M33d gt_33;
+    gt_33[0][0] = gtIn.xscale;
+    gt_33[0][1] = gtIn.xrot;
+    gt_33[0][2] = gtIn.xorig;
+    gt_33[1][0] = gtIn.yrot;
+    gt_33[1][1] = gtIn.yscale;
+    gt_33[1][2] = gtIn.yorig;
+    gt_33[2][0] = 0;
+    gt_33[2][1] = 0;
+    gt_33[2][2] = 1;
+    header.insert("gdal:geoTransform", M33dAttribute(gt_33));
 }
 
 static void WriteMetadataInHeader(Header &header, CSLConstList papszMD)

--- a/frmts/fits/fitsdataset.cpp
+++ b/frmts/fits/fitsdataset.cpp
@@ -3029,8 +3029,8 @@ void FITSDataset::WriteFITSInfo()
             }
         }
 
-        UpperLeftCornerX = m_gt[0] - falseEast;
-        UpperLeftCornerY = m_gt[3] - falseNorth;
+        UpperLeftCornerX = m_gt.xorig - falseEast;
+        UpperLeftCornerY = m_gt.yorig - falseNorth;
 
         if (centlon > 180.)
         {
@@ -3039,8 +3039,8 @@ void FITSDataset::WriteFITSInfo()
         if (strstr(unit, "metre"))
         {
             // convert degrees/pixel to m/pixel
-            mapres = 1. / m_gt[1];     // mapres is pixel/meters
-            mres = m_gt[1] / cfactor;  // mres is deg/pixel
+            mapres = 1. / m_gt.xscale;     // mapres is pixel/meters
+            mres = m_gt.xscale / cfactor;  // mres is deg/pixel
             crpix1 = -(UpperLeftCornerX * mapres) + centlon / mres + 0.5;
             // assuming that center latitude is also the origin of the
             // coordinate system: this is not always true. More generic
@@ -3050,8 +3050,8 @@ void FITSDataset::WriteFITSInfo()
         else if (strstr(unit, "degree"))
         {
             // convert m/pixel to pixel/degree
-            mapres = 1. / m_gt[1] / cfactor;  // mapres is pixel/deg
-            mres = m_gt[1];                   // mres is meters/pixel
+            mapres = 1. / m_gt.xscale / cfactor;  // mapres is pixel/deg
+            mres = m_gt.xscale;                   // mres is meters/pixel
             crpix1 = -(UpperLeftCornerX * mres) + centlon / mapres + 0.5;
             // assuming that center latitude is also the origin of the
             // coordinate system: this is not always true. More generic
@@ -3119,10 +3119,10 @@ void FITSDataset::WriteFITSInfo()
             /// Write WCS CDELTia and PCi_ja here
 
             double cd[4];
-            cd[0] = m_gt[1] / cfactor;
-            cd[1] = m_gt[2] / cfactor;
-            cd[2] = m_gt[4] / cfactor;
-            cd[3] = m_gt[5] / cfactor;
+            cd[0] = m_gt.xscale / cfactor;
+            cd[1] = m_gt.xrot / cfactor;
+            cd[2] = m_gt.yrot / cfactor;
+            cd[3] = m_gt.yscale / cfactor;
 
             double pc[4];
             pc[0] = 1.;
@@ -3508,10 +3508,10 @@ void FITSDataset::LoadGeoreferencing()
 
                 double radfac = DEG2RAD * aRadius;
 
-                m_gt[1] = cd[0] * radfac;
-                m_gt[2] = cd[1] * radfac;
-                m_gt[4] = cd[2] * radfac;
-                m_gt[5] = -cd[3] * radfac;
+                m_gt.xscale = cd[0] * radfac;
+                m_gt.xrot = cd[1] * radfac;
+                m_gt.yrot = cd[2] * radfac;
+                m_gt.yscale = -cd[3] * radfac;
                 if (crval1 > 180.)
                 {
                     crval1 = crval1 - 180.;
@@ -3520,11 +3520,11 @@ void FITSDataset::LoadGeoreferencing()
                 /* NOTA BENE: FITS standard define pixel integers at the center
                    of the pixel, 0.5 must be subtract to have UpperLeft corner
                  */
-                m_gt[0] = crval1 * radfac - m_gt[1] * (crpix1 - 0.5);
+                m_gt.xorig = crval1 * radfac - m_gt.xscale * (crpix1 - 0.5);
                 // assuming that center latitude is also the origin of the
                 // coordinate system: this is not always true. More generic
                 // implementation coming soon
-                m_gt[3] = -m_gt[5] * (crpix2 - 0.5);
+                m_gt.yorig = -m_gt.yscale * (crpix2 - 0.5);
                 //+ crval2 * radfac;
                 m_bGeoTransformValid = true;
             }

--- a/frmts/georaster/georaster_dataset.cpp
+++ b/frmts/georaster/georaster_dataset.cpp
@@ -220,12 +220,12 @@ GeoRasterDataset::OpenDataset(const char *pszFilenameIn, GDALAccess eAccessIn,
 
     if (poGRW->bIsReferenced)
     {
-        poGRD->m_gt[1] = poGRW->dfXCoefficient[0];
-        poGRD->m_gt[2] = poGRW->dfXCoefficient[1];
-        poGRD->m_gt[0] = poGRW->dfXCoefficient[2];
-        poGRD->m_gt[4] = poGRW->dfYCoefficient[0];
-        poGRD->m_gt[5] = poGRW->dfYCoefficient[1];
-        poGRD->m_gt[3] = poGRW->dfYCoefficient[2];
+        poGRD->m_gt.xscale = poGRW->dfXCoefficient[0];
+        poGRD->m_gt.xrot = poGRW->dfXCoefficient[1];
+        poGRD->m_gt.xorig = poGRW->dfXCoefficient[2];
+        poGRD->m_gt.yrot = poGRW->dfYCoefficient[0];
+        poGRD->m_gt.yscale = poGRW->dfYCoefficient[1];
+        poGRD->m_gt.yorig = poGRW->dfYCoefficient[2];
     }
 
     //  -------------------------------------------------------------------
@@ -2160,12 +2160,12 @@ CPLErr GeoRasterDataset::SetGeoTransform(const GDALGeoTransform &gt)
 {
     m_gt = gt;
 
-    poGeoRaster->dfXCoefficient[0] = m_gt[1];
-    poGeoRaster->dfXCoefficient[1] = m_gt[2];
-    poGeoRaster->dfXCoefficient[2] = m_gt[0];
-    poGeoRaster->dfYCoefficient[0] = m_gt[4];
-    poGeoRaster->dfYCoefficient[1] = m_gt[5];
-    poGeoRaster->dfYCoefficient[2] = m_gt[3];
+    poGeoRaster->dfXCoefficient[0] = m_gt.xscale;
+    poGeoRaster->dfXCoefficient[1] = m_gt.xrot;
+    poGeoRaster->dfXCoefficient[2] = m_gt.xorig;
+    poGeoRaster->dfYCoefficient[0] = m_gt.yrot;
+    poGeoRaster->dfYCoefficient[1] = m_gt.yscale;
+    poGeoRaster->dfYCoefficient[2] = m_gt.yorig;
 
     bGeoTransform = true;
 

--- a/frmts/grib/gribdataset.cpp
+++ b/frmts/grib/gribdataset.cpp
@@ -1842,7 +1842,7 @@ void GRIBArray::Init(GRIBGroup *poGroup, GRIBDataset *poDS,
                 size_t nCount = 1;
                 double dfVal = 0;
                 poVar->Read(&nStart, &nCount, nullptr, nullptr, m_dt, &dfVal);
-                if (std::fabs(dfVal - (gt[0] + 0.5 * gt[1])) >
+                if (std::fabs(dfVal - (gt.xorig + 0.5 * gt.xscale)) >
                     EPSILON * std::fabs(dfVal))
                 {
                     bOK = false;
@@ -1858,8 +1858,9 @@ void GRIBArray::Init(GRIBGroup *poGroup, GRIBDataset *poDS,
                     double dfVal = 0;
                     poVar->Read(&nStart, &nCount, nullptr, nullptr, m_dt,
                                 &dfVal);
-                    if (std::fabs(dfVal - (gt[3] + poDS->nRasterYSize * gt[5] -
-                                           0.5 * gt[5])) >
+                    if (std::fabs(dfVal -
+                                  (gt.yorig + poDS->nRasterYSize * gt.yscale -
+                                   0.5 * gt.yscale)) >
                         EPSILON * std::fabs(dfVal))
                     {
                         bOK = false;
@@ -1893,7 +1894,7 @@ void GRIBArray::Init(GRIBGroup *poGroup, GRIBDataset *poDS,
 
             auto var = GDALMDArrayRegularlySpaced::Create(
                 "/", poDimY->GetName(), poDimY,
-                gt[3] + poDS->GetRasterYSize() * gt[5], -gt[5], 0.5);
+                gt.yorig + poDS->GetRasterYSize() * gt.yscale, -gt.yscale, 0.5);
             poDimY->SetIndexingVariable(var);
             poGroup->AddArray(var);
         }
@@ -1912,7 +1913,7 @@ void GRIBArray::Init(GRIBGroup *poGroup, GRIBDataset *poDS,
             poGroup->m_dims.emplace_back(poDimX);
 
             auto var = GDALMDArrayRegularlySpaced::Create(
-                "/", poDimX->GetName(), poDimX, gt[0], gt[1], 0.5);
+                "/", poDimX->GetName(), poDimX, gt.xorig, gt.xscale, 0.5);
             poDimX->SetIndexingVariable(var);
             poGroup->AddArray(var);
         }
@@ -2852,10 +2853,10 @@ void GRIBDataset::SetGribMetaData(grib_MetaData *meta)
     rMinX -= rPixelSizeX / 2;
     rMaxY += rPixelSizeY / 2;
 
-    m_gt[0] = rMinX;
-    m_gt[3] = rMaxY;
-    m_gt[1] = rPixelSizeX;
-    m_gt[5] = -rPixelSizeY;
+    m_gt.xorig = rMinX;
+    m_gt.yorig = rMaxY;
+    m_gt.xscale = rPixelSizeX;
+    m_gt.yscale = -rPixelSizeY;
 
     if (bError)
         m_poSRS.reset();

--- a/frmts/gsg/gs7bgdataset.cpp
+++ b/frmts/gsg/gs7bgdataset.cpp
@@ -798,16 +798,16 @@ CPLErr GS7BGDataset::GetGeoTransform(GDALGeoTransform &gt) const
         return CE_Failure;
 
     /* calculate pixel size first */
-    gt[1] = (poGRB->dfMaxX - poGRB->dfMinX) / (nRasterXSize - 1);
-    gt[5] = (poGRB->dfMinY - poGRB->dfMaxY) / (nRasterYSize - 1);
+    gt.xscale = (poGRB->dfMaxX - poGRB->dfMinX) / (nRasterXSize - 1);
+    gt.yscale = (poGRB->dfMinY - poGRB->dfMaxY) / (nRasterYSize - 1);
 
     /* then calculate image origin */
-    gt[0] = poGRB->dfMinX - gt[1] / 2;
-    gt[3] = poGRB->dfMaxY - gt[5] / 2;
+    gt.xorig = poGRB->dfMinX - gt.xscale / 2;
+    gt.yorig = poGRB->dfMaxY - gt.yscale / 2;
 
     /* tilt/rotation does not supported by the GS grids */
-    gt[4] = 0.0;
-    gt[2] = 0.0;
+    gt.yrot = 0.0;
+    gt.xrot = 0.0;
 
     return CE_None;
 }
@@ -829,17 +829,17 @@ CPLErr GS7BGDataset::SetGeoTransform(const GDALGeoTransform &gt)
         cpl::down_cast<GS7BGRasterBand *>(GetRasterBand(1));
 
     /* non-zero transform 2 or 4 or negative 1 or 5 not supported natively */
-    /*if( gt[2] != 0.0 || gt[4] != 0.0
-    || gt[1] < 0.0 || gt[5] < 0.0 )
+    /*if( gt.xrot != 0.0 || gt.yrot != 0.0
+    || gt.xscale < 0.0 || gt.yscale < 0.0 )
     eErr = GDALPamDataset::SetGeoTransform( gt );
 
     if( eErr != CE_None )
     return eErr;*/
 
-    double dfMinX = gt[0] + gt[1] / 2;
-    double dfMaxX = gt[1] * (nRasterXSize - 0.5) + gt[0];
-    double dfMinY = gt[5] * (nRasterYSize - 0.5) + gt[3];
-    double dfMaxY = gt[3] + gt[5] / 2;
+    double dfMinX = gt.xorig + gt.xscale / 2;
+    double dfMaxX = gt.xscale * (nRasterXSize - 0.5) + gt.xorig;
+    double dfMinY = gt.yscale * (nRasterYSize - 0.5) + gt.yorig;
+    double dfMaxY = gt.yorig + gt.yscale / 2;
 
     CPLErr eErr =
         WriteHeader(fp, poGRB->nRasterXSize, poGRB->nRasterYSize, dfMinX,
@@ -1179,10 +1179,10 @@ GDALDataset *GS7BGDataset::CreateCopy(const char *pszFilename,
     GDALGeoTransform gt;
     poSrcDS->GetGeoTransform(gt);
 
-    double dfMinX = gt[0] + gt[1] / 2;
-    double dfMaxX = gt[1] * (nXSize - 0.5) + gt[0];
-    double dfMinY = gt[5] * (nYSize - 0.5) + gt[3];
-    double dfMaxY = gt[3] + gt[5] / 2;
+    double dfMinX = gt.xorig + gt.xscale / 2;
+    double dfMaxX = gt.xscale * (nXSize - 0.5) + gt.xorig;
+    double dfMinY = gt.yscale * (nYSize - 0.5) + gt.yorig;
+    double dfMaxY = gt.yorig + gt.yscale / 2;
     CPLErr eErr = WriteHeader(fp, nXSize, nYSize, dfMinX, dfMaxX, dfMinY,
                               dfMaxY, 0.0, 0.0);
 

--- a/frmts/gsg/gsbgdataset.cpp
+++ b/frmts/gsg/gsbgdataset.cpp
@@ -621,16 +621,16 @@ CPLErr GSBGDataset::GetGeoTransform(GDALGeoTransform &gt) const
         return CE_Failure;
 
     /* calculate pixel size first */
-    gt[1] = (poGRB->dfMaxX - poGRB->dfMinX) / (nRasterXSize - 1);
-    gt[5] = (poGRB->dfMinY - poGRB->dfMaxY) / (nRasterYSize - 1);
+    gt.xscale = (poGRB->dfMaxX - poGRB->dfMinX) / (nRasterXSize - 1);
+    gt.yscale = (poGRB->dfMinY - poGRB->dfMaxY) / (nRasterYSize - 1);
 
     /* then calculate image origin */
-    gt[0] = poGRB->dfMinX - gt[1] / 2;
-    gt[3] = poGRB->dfMaxY - gt[5] / 2;
+    gt.xorig = poGRB->dfMinX - gt.xscale / 2;
+    gt.yorig = poGRB->dfMaxY - gt.yscale / 2;
 
     /* tilt/rotation does not supported by the GS grids */
-    gt[4] = 0.0;
-    gt[2] = 0.0;
+    gt.yrot = 0.0;
+    gt.xrot = 0.0;
 
     return CE_None;
 }
@@ -652,17 +652,17 @@ CPLErr GSBGDataset::SetGeoTransform(const GDALGeoTransform &gt)
 
     /* non-zero transform 2 or 4 or negative 1 or 5 not supported natively */
     // CPLErr eErr = CE_None;
-    /*if( gt[2] != 0.0 || gt[4] != 0.0
-        || gt[1] < 0.0 || gt[5] < 0.0 )
+    /*if( gt.xrot != 0.0 || gt.yrot != 0.0
+        || gt.xscale < 0.0 || gt.yscale < 0.0 )
         eErr = GDALPamDataset::SetGeoTransform( gt );
 
     if( eErr != CE_None )
         return eErr;*/
 
-    double dfMinX = gt[0] + gt[1] / 2;
-    double dfMaxX = gt[1] * (nRasterXSize - 0.5) + gt[0];
-    double dfMinY = gt[5] * (nRasterYSize - 0.5) + gt[3];
-    double dfMaxY = gt[3] + gt[5] / 2;
+    double dfMinX = gt.xorig + gt.xscale / 2;
+    double dfMaxX = gt.xscale * (nRasterXSize - 0.5) + gt.xorig;
+    double dfMinY = gt.yscale * (nRasterYSize - 0.5) + gt.yorig;
+    double dfMaxY = gt.yorig + gt.yscale / 2;
 
     CPLErr eErr =
         WriteHeader(fp, poGRB->nRasterXSize, poGRB->nRasterYSize, dfMinX,
@@ -928,10 +928,10 @@ GDALDataset *GSBGDataset::CreateCopy(const char *pszFilename,
     GDALGeoTransform gt;
     poSrcDS->GetGeoTransform(gt);
 
-    double dfMinX = gt[0] + gt[1] / 2;
-    double dfMaxX = gt[1] * (nXSize - 0.5) + gt[0];
-    double dfMinY = gt[5] * (nYSize - 0.5) + gt[3];
-    double dfMaxY = gt[3] + gt[5] / 2;
+    double dfMinX = gt.xorig + gt.xscale / 2;
+    double dfMaxX = gt.xscale * (nXSize - 0.5) + gt.xorig;
+    double dfMinY = gt.yscale * (nYSize - 0.5) + gt.yorig;
+    double dfMaxY = gt.yorig + gt.yscale / 2;
     CPLErr eErr = WriteHeader(fp, nXSize, nYSize, dfMinX, dfMaxX, dfMinY,
                               dfMaxY, 0.0, 0.0);
 

--- a/frmts/gtiff/cogdriver.cpp
+++ b/frmts/gtiff/cogdriver.cpp
@@ -289,13 +289,12 @@ static bool COGGetWarpingCharacteristics(
 
     GDALTransformerInfo *psInfo =
         static_cast<GDALTransformerInfo *>(hTransformArg);
-    double adfGeoTransform[6];
+    GDALGeoTransform gt;
     double adfExtent[4];
 
     if (GDALSuggestedWarpOutput2(poTmpDS ? poTmpDS.get() : poSrcDS,
-                                 psInfo->pfnTransform, hTransformArg,
-                                 adfGeoTransform, &nXSize, &nYSize, adfExtent,
-                                 0) != CE_None)
+                                 psInfo->pfnTransform, hTransformArg, gt.data(),
+                                 &nXSize, &nYSize, adfExtent, 0) != CE_None)
     {
         GDALDestroyGenImgProjTransformer(hTransformArg);
         return false;
@@ -309,7 +308,7 @@ static bool COGGetWarpingCharacteristics(
     dfMinY = adfExtent[1];
     dfMaxX = adfExtent[2];
     dfMaxY = adfExtent[3];
-    dfRes = adfGeoTransform[1];
+    dfRes = gt.xscale;
 
     const CPLString osExtent(CSLFetchNameValueDef(papszOptions, "EXTENT", ""));
     const CPLString osRes(CSLFetchNameValueDef(papszOptions, "RES", ""));
@@ -366,7 +365,7 @@ static bool COGGetWarpingCharacteristics(
         }
         else
         {
-            double dfComputedRes = adfGeoTransform[1];
+            double dfComputedRes = gt.xscale;
             double dfPrevRes = 0.0;
             for (; nZoomLevel < static_cast<int>(tmList.size()); nZoomLevel++)
             {

--- a/frmts/gxf/gxfdataset.cpp
+++ b/frmts/gxf/gxfdataset.cpp
@@ -180,14 +180,14 @@ CPLErr GXFDataset::GetGeoTransform(GDALGeoTransform &gt) const
     // Transform to radians.
     dfRotation = (dfRotation / 360.0) * 2.0 * M_PI;
 
-    gt[1] = dfXSize * cos(dfRotation);
-    gt[2] = dfYSize * sin(dfRotation);
-    gt[4] = dfXSize * sin(dfRotation);
-    gt[5] = -1 * dfYSize * cos(dfRotation);
+    gt.xscale = dfXSize * cos(dfRotation);
+    gt.xrot = dfYSize * sin(dfRotation);
+    gt.yrot = dfXSize * sin(dfRotation);
+    gt.yscale = -1 * dfYSize * cos(dfRotation);
 
     // take into account that GXF is point or center of pixel oriented.
-    gt[0] = dfXOrigin - 0.5 * gt[1] - 0.5 * gt[2];
-    gt[3] = dfYOrigin - 0.5 * gt[4] - 0.5 * gt[5];
+    gt.xorig = dfXOrigin - 0.5 * gt.xscale - 0.5 * gt.xrot;
+    gt.yorig = dfYOrigin - 0.5 * gt.yrot - 0.5 * gt.yscale;
 
     return CE_None;
 }

--- a/frmts/hdf5/hdf5eosparser.cpp
+++ b/frmts/hdf5/hdf5eosparser.cpp
@@ -742,27 +742,29 @@ bool HDF5EOSParser::GridMetadata::GetGeoTransform(GDALGeoTransform &gt) const
             return false;
         if (nProjCode == 0)  // GEO
         {
-            gt[0] = CPLPackedDMSToDec(adfUpperLeftPointMeters[0]);
-            gt[1] = (CPLPackedDMSToDec(adfLowerRightPointMeters[0]) -
-                     CPLPackedDMSToDec(adfUpperLeftPointMeters[0])) /
-                    nRasterXSize;
-            gt[2] = 0;
-            gt[3] = CPLPackedDMSToDec(adfUpperLeftPointMeters[1]);
-            gt[4] = 0;
-            gt[5] = (CPLPackedDMSToDec(adfLowerRightPointMeters[1]) -
-                     CPLPackedDMSToDec(adfUpperLeftPointMeters[1])) /
-                    nRasterYSize;
+            gt.xorig = CPLPackedDMSToDec(adfUpperLeftPointMeters[0]);
+            gt.xscale = (CPLPackedDMSToDec(adfLowerRightPointMeters[0]) -
+                         CPLPackedDMSToDec(adfUpperLeftPointMeters[0])) /
+                        nRasterXSize;
+            gt.xrot = 0;
+            gt.yorig = CPLPackedDMSToDec(adfUpperLeftPointMeters[1]);
+            gt.yrot = 0;
+            gt.yscale = (CPLPackedDMSToDec(adfLowerRightPointMeters[1]) -
+                         CPLPackedDMSToDec(adfUpperLeftPointMeters[1])) /
+                        nRasterYSize;
         }
         else
         {
-            gt[0] = adfUpperLeftPointMeters[0];
-            gt[1] = (adfLowerRightPointMeters[0] - adfUpperLeftPointMeters[0]) /
-                    nRasterXSize;
-            gt[2] = 0;
-            gt[3] = adfUpperLeftPointMeters[1];
-            gt[4] = 0;
-            gt[5] = (adfLowerRightPointMeters[1] - adfUpperLeftPointMeters[1]) /
-                    nRasterYSize;
+            gt.xorig = adfUpperLeftPointMeters[0];
+            gt.xscale =
+                (adfLowerRightPointMeters[0] - adfUpperLeftPointMeters[0]) /
+                nRasterXSize;
+            gt.xrot = 0;
+            gt.yorig = adfUpperLeftPointMeters[1];
+            gt.yrot = 0;
+            gt.yscale =
+                (adfLowerRightPointMeters[1] - adfUpperLeftPointMeters[1]) /
+                nRasterYSize;
         }
         return true;
     }

--- a/frmts/hdf5/hdf5imagedataset.cpp
+++ b/frmts/hdf5/hdf5imagedataset.cpp
@@ -1473,12 +1473,12 @@ CPLErr HDF5ImageDataset::CreateODIMH5Projection()
     const double dfPixelY = (dfURY - dfLLY) / nRasterYSize;
 
     bHasGeoTransform = true;
-    m_gt[0] = dfLLX;
-    m_gt[1] = dfPixelX;
-    m_gt[2] = 0;
-    m_gt[3] = dfURY;
-    m_gt[4] = 0;
-    m_gt[5] = -dfPixelY;
+    m_gt.xorig = dfLLX;
+    m_gt.xscale = dfPixelX;
+    m_gt.xrot = 0;
+    m_gt.yorig = dfURY;
+    m_gt.yrot = 0;
+    m_gt.yscale = -dfPixelY;
 
     return CE_None;
 }
@@ -1962,12 +1962,12 @@ void HDF5ImageDataset::CaptureCSKGeoTransform(int iProductType)
                 // images.
                 // geotransform[5] : height of pixel (but negative)
 
-                m_gt[0] = pdOutUL[0];
-                m_gt[1] = pdLineSpacing[0];
-                m_gt[2] = 0;
-                m_gt[3] = pdOutUL[1];
-                m_gt[4] = 0;
-                m_gt[5] = -pdColumnSpacing[0];
+                m_gt.xorig = pdOutUL[0];
+                m_gt.xscale = pdLineSpacing[0];
+                m_gt.xrot = 0;
+                m_gt.yorig = pdOutUL[1];
+                m_gt.yrot = 0;
+                m_gt.yscale = -pdColumnSpacing[0];
 
                 CPLFree(pdOutUL);
                 CPLFree(pdLineSpacing);

--- a/frmts/hdf5/hdf5multidim.cpp
+++ b/frmts/hdf5/hdf5multidim.cpp
@@ -670,8 +670,8 @@ HDF5Group::GetDimensions(CSLConstList) const
             poHDF5EOSParser->GetGridMetadata(GetName(), oGridMetadata))
         {
             GDALGeoTransform gt;
-            const bool bHasGT =
-                oGridMetadata.GetGeoTransform(gt) && gt[2] == 0 && gt[4] == 0;
+            const bool bHasGT = oGridMetadata.GetGeoTransform(gt) &&
+                                gt.xrot == 0 && gt.yrot == 0;
             for (auto &oDim : oGridMetadata.aoDimensions)
             {
                 auto iterInDimMap = data.oDimMap.find(oDim.osName);
@@ -699,7 +699,7 @@ HDF5Group::GetDimensions(CSLConstList) const
                                     "HDF5",
                                     "XDim FirstX: (from XDim array:%.17g,) "
                                     "from HDF5EOS metadata:%.17g",
-                                    dfFirstVal, gt[0]);
+                                    dfFirstVal, gt.xorig);
                             }
 
                             const GUInt64 anArrayStartIdx1[] = {
@@ -714,7 +714,8 @@ HDF5Group::GetDimensions(CSLConstList) const
                                 CPLDebug("HDF5",
                                          "XDim LastX: (from XDim array:%.17g,) "
                                          "from HDF5EOS metadata:%.17g",
-                                         dfLastVal, gt[0] + oDim.nSize * gt[1]);
+                                         dfLastVal,
+                                         gt.xorig + oDim.nSize * gt.xscale);
                             }
                         }
                         else if (oDim.osName == "YDim" && bHasGT &&
@@ -735,7 +736,7 @@ HDF5Group::GetDimensions(CSLConstList) const
                                     "HDF5",
                                     "YDim FirstY: (from YDim array:%.17g,) "
                                     "from HDF5EOS metadata:%.17g",
-                                    dfFirstVal, gt[3]);
+                                    dfFirstVal, gt.yorig);
                             }
 
                             const GUInt64 anArrayStartIdx1[] = {
@@ -750,7 +751,8 @@ HDF5Group::GetDimensions(CSLConstList) const
                                 CPLDebug("HDF5",
                                          "YDim LastY: (from YDim array:%.17g,) "
                                          "from HDF5EOS metadata:%.17g",
-                                         dfLastVal, gt[3] + oDim.nSize * gt[5]);
+                                         dfLastVal,
+                                         gt.yorig + oDim.nSize * gt.yscale);
                             }
                         }
                     }
@@ -764,8 +766,8 @@ HDF5Group::GetDimensions(CSLConstList) const
                         GetFullName(), oDim.osName, GDAL_DIM_TYPE_HORIZONTAL_X,
                         std::string(), oDim.nSize);
                     auto poIndexingVar = GDALMDArrayRegularlySpaced::Create(
-                        GetFullName(), oDim.osName, poDim, gt[0] + gt[1] / 2,
-                        gt[1], 0);
+                        GetFullName(), oDim.osName, poDim,
+                        gt.xorig + gt.xscale / 2, gt.xscale, 0);
                     poDim->SetIndexingVariable(poIndexingVar);
                     m_poXIndexingArray = poIndexingVar;
                     m_poShared->KeepRef(poIndexingVar);
@@ -779,8 +781,8 @@ HDF5Group::GetDimensions(CSLConstList) const
                         GetFullName(), oDim.osName, GDAL_DIM_TYPE_HORIZONTAL_Y,
                         std::string(), oDim.nSize);
                     auto poIndexingVar = GDALMDArrayRegularlySpaced::Create(
-                        GetFullName(), oDim.osName, poDim, gt[3] + gt[5] / 2,
-                        gt[5], 0);
+                        GetFullName(), oDim.osName, poDim,
+                        gt.yorig + gt.yscale / 2, gt.yscale, 0);
                     poDim->SetIndexingVariable(poIndexingVar);
                     m_poYIndexingArray = poIndexingVar;
                     m_poShared->KeepRef(poIndexingVar);

--- a/frmts/hdf5/s102dataset.cpp
+++ b/frmts/hdf5/s102dataset.cpp
@@ -1651,7 +1651,7 @@ bool S102Creator::CopyValues(GDALProgressFunc pfnProgress, void *pProgressData)
     const int nXBlocks = static_cast<int>(DIV_ROUND_UP(nXSize, nBlockXSize));
     std::vector<float> afValues(static_cast<size_t>(nBlockYSize) * nBlockXSize *
                                 nComponents);
-    const bool bReverseY = m_gt[5] < 0;
+    const bool bReverseY = m_gt.yscale < 0;
 
     float fMinDepth = std::numeric_limits<float>::infinity();
     float fMaxDepth = -std::numeric_limits<float>::infinity();
@@ -1854,7 +1854,7 @@ bool S102Creator::CopyQualityValues(GDALDataset *poQualityDS,
     const int nXBlocks = static_cast<int>(DIV_ROUND_UP(nXSize, nBlockXSize));
     std::vector<uint32_t> anValues(static_cast<size_t>(nBlockYSize) *
                                    nBlockXSize);
-    const bool bReverseY = m_gt[5] < 0;
+    const bool bReverseY = m_gt.yscale < 0;
 
     int bHasSrcNoData = FALSE;
     const double dfSrcNoData =

--- a/frmts/hdf5/s104dataset.cpp
+++ b/frmts/hdf5/s104dataset.cpp
@@ -1556,7 +1556,7 @@ bool S104Creator::CopyValues(GDALDataset *poSrcDS, GDALProgressFunc pfnProgress,
     std::vector<GByte> abyValues(
         static_cast<size_t>(nBlockYSize) * nBlockXSize *
         (sizeof(float) + sizeof(GByte) + sizeof(float)));
-    const bool bReverseY = m_gt[5] < 0;
+    const bool bReverseY = m_gt.yscale < 0;
 
     float fMinHeight = std::numeric_limits<float>::infinity();
     float fMaxHeight = -std::numeric_limits<float>::infinity();

--- a/frmts/hdf5/s111dataset.cpp
+++ b/frmts/hdf5/s111dataset.cpp
@@ -1739,7 +1739,7 @@ bool S111Creator::CopyValues(GDALDataset *poSrcDS, GDALProgressFunc pfnProgress,
     const int nXBlocks = static_cast<int>(DIV_ROUND_UP(nXSize, nBlockXSize));
     std::vector<float> afValues(static_cast<size_t>(nBlockYSize) * nBlockXSize *
                                 nComponents);
-    const bool bReverseY = m_gt[5] < 0;
+    const bool bReverseY = m_gt.yscale < 0;
 
     constexpr std::array<float, 4> afNoDataValue{NODATA_SPEED, NODATA_DIR,
                                                  NODATA_UNCT, NODATA_UNCT};

--- a/frmts/hf2/hf2dataset.cpp
+++ b/frmts/hf2/hf2dataset.cpp
@@ -596,15 +596,15 @@ GDALDataset *HF2Dataset::Open(GDALOpenInfo *poOpenInfo)
              nTileSize);
     if (bHasExtent)
     {
-        poDS->m_gt[0] = dfMinX;
-        poDS->m_gt[3] = dfMaxY;
-        poDS->m_gt[1] = (dfMaxX - dfMinX) / nXSize;
-        poDS->m_gt[5] = -(dfMaxY - dfMinY) / nYSize;
+        poDS->m_gt.xorig = dfMinX;
+        poDS->m_gt.yorig = dfMaxY;
+        poDS->m_gt.xscale = (dfMaxX - dfMinX) / nXSize;
+        poDS->m_gt.yscale = -(dfMaxY - dfMinY) / nYSize;
     }
     else
     {
-        poDS->m_gt[1] = fHorizScale;
-        poDS->m_gt[5] = fHorizScale;
+        poDS->m_gt.xscale = fHorizScale;
+        poDS->m_gt.yscale = fHorizScale;
     }
 
     if (bHasEPSGCode)
@@ -751,10 +751,11 @@ GDALDataset *HF2Dataset::CreateCopy(const char *pszFilename,
     const int nXSize = poSrcDS->GetRasterXSize();
     const int nYSize = poSrcDS->GetRasterYSize();
     GDALGeoTransform gt;
-    const bool bHasGeoTransform = poSrcDS->GetGeoTransform(gt) == CE_None &&
-                                  !(gt[0] == 0 && gt[1] == 1 && gt[2] == 0 &&
-                                    gt[3] == 0 && gt[4] == 0 && gt[5] == 1);
-    if (gt[2] != 0 || gt[4] != 0)
+    const bool bHasGeoTransform =
+        poSrcDS->GetGeoTransform(gt) == CE_None &&
+        !(gt.xorig == 0 && gt.xscale == 1 && gt.xrot == 0 && gt.yorig == 0 &&
+          gt.yrot == 0 && gt.yscale == 1);
+    if (gt.xrot != 0 || gt.yrot != 0)
     {
         CPLError(CE_Failure, CPLE_NotSupported,
                  "HF2 driver does not support CreateCopy() from skewed or "
@@ -897,7 +898,7 @@ GDALDataset *HF2Dataset::CreateCopy(const char *pszFilename,
     WriteInt(fp, nYSize);
     WriteShort(fp, (GInt16)nTileSize);
     WriteFloat(fp, fVertPres);
-    const float fHorizScale = (float)((fabs(gt[1]) + fabs(gt[5])) / 2);
+    const float fHorizScale = (float)((fabs(gt.xscale) + fabs(gt.yscale)) / 2);
     WriteFloat(fp, fHorizScale);
     WriteInt(fp, nExtendedHeaderLen);
 
@@ -914,10 +915,10 @@ GDALDataset *HF2Dataset::CreateCopy(const char *pszFilename,
         VSIFWriteL(szBlockName, 16, 1, fp);
         WriteInt(fp, 34);
         WriteShort(fp, (GInt16)nExtentUnits);
-        WriteDouble(fp, gt[0]);
-        WriteDouble(fp, gt[0] + nXSize * gt[1]);
-        WriteDouble(fp, gt[3] + nYSize * gt[5]);
-        WriteDouble(fp, gt[3]);
+        WriteDouble(fp, gt.xorig);
+        WriteDouble(fp, gt.xorig + nXSize * gt.xscale);
+        WriteDouble(fp, gt.yorig + nYSize * gt.yscale);
+        WriteDouble(fp, gt.yorig);
     }
     if (nUTMZone != 0)
     {

--- a/frmts/hfa/hfadataset.cpp
+++ b/frmts/hfa/hfadataset.cpp
@@ -4153,14 +4153,16 @@ CPLErr HFADataset::WriteProjection()
     else
         sMapInfo.proName = const_cast<char *>("Unknown");
 
-    sMapInfo.upperLeftCenter.x = m_gt[0] + m_gt[1] * 0.5;
-    sMapInfo.upperLeftCenter.y = m_gt[3] + m_gt[5] * 0.5;
+    sMapInfo.upperLeftCenter.x = m_gt.xorig + m_gt.xscale * 0.5;
+    sMapInfo.upperLeftCenter.y = m_gt.yorig + m_gt.yscale * 0.5;
 
-    sMapInfo.lowerRightCenter.x = m_gt[0] + m_gt[1] * (GetRasterXSize() - 0.5);
-    sMapInfo.lowerRightCenter.y = m_gt[3] + m_gt[5] * (GetRasterYSize() - 0.5);
+    sMapInfo.lowerRightCenter.x =
+        m_gt.xorig + m_gt.xscale * (GetRasterXSize() - 0.5);
+    sMapInfo.lowerRightCenter.y =
+        m_gt.yorig + m_gt.yscale * (GetRasterYSize() - 0.5);
 
-    sMapInfo.pixelSize.width = std::abs(m_gt[1]);
-    sMapInfo.pixelSize.height = std::abs(m_gt[5]);
+    sMapInfo.pixelSize.width = std::abs(m_gt.xscale);
+    sMapInfo.pixelSize.height = std::abs(m_gt.yscale);
 
     // Handle units.  Try to match up with a known name.
     sMapInfo.units = const_cast<char *>("meters");
@@ -4204,7 +4206,7 @@ CPLErr HFADataset::WriteProjection()
     }
 
     // Write out definitions.
-    if (m_gt[2] == 0.0 && m_gt[4] == 0.0)
+    if (m_gt.xrot == 0.0 && m_gt.yrot == 0.0)
     {
         HFASetMapInfo(hHFA, &sMapInfo);
     }
@@ -4794,8 +4796,8 @@ CPLErr HFADataset::SetMetadataItem(const char *pszTag, const char *pszValue,
 CPLErr HFADataset::GetGeoTransform(GDALGeoTransform &gt) const
 
 {
-    if (m_gt[0] != 0.0 || m_gt[1] != 1.0 || m_gt[2] != 0.0 || m_gt[3] != 0.0 ||
-        m_gt[4] != 0.0 || m_gt[5] != 1.0)
+    if (m_gt.xorig != 0.0 || m_gt.xscale != 1.0 || m_gt.xrot != 0.0 ||
+        m_gt.yorig != 0.0 || m_gt.yrot != 0.0 || m_gt.yscale != 1.0)
     {
         gt = m_gt;
         return CE_None;

--- a/frmts/idrisi/IdrisiDataset.cpp
+++ b/frmts/idrisi/IdrisiDataset.cpp
@@ -692,12 +692,12 @@ GDALDataset *IdrisiDataset::Open(GDALOpenInfo *poOpenInfo)
         dfYPixSz = (dfMinY - dfMaxY) / poDS->nRasterYSize;
         dfXPixSz = (dfMaxX - dfMinX) / poDS->nRasterXSize;
 
-        poDS->m_gt[0] = dfMinX;
-        poDS->m_gt[1] = dfXPixSz;
-        poDS->m_gt[2] = 0.0;
-        poDS->m_gt[3] = dfMaxY;
-        poDS->m_gt[4] = 0.0;
-        poDS->m_gt[5] = dfYPixSz;
+        poDS->m_gt.xorig = dfMinX;
+        poDS->m_gt.xscale = dfXPixSz;
+        poDS->m_gt.xrot = 0.0;
+        poDS->m_gt.yorig = dfMaxY;
+        poDS->m_gt.yrot = 0.0;
+        poDS->m_gt.yscale = dfYPixSz;
     }
 
     // --------------------------------------------------------------------
@@ -1278,7 +1278,7 @@ CPLErr IdrisiDataset::GetGeoTransform(GDALGeoTransform &gt) const
 
 CPLErr IdrisiDataset::SetGeoTransform(const GDALGeoTransform &gt)
 {
-    if (gt[2] != 0.0 || gt[4] != 0.0)
+    if (gt.xrot != 0.0 || gt.yrot != 0.0)
     {
         CPLError(CE_Failure, CPLE_AppDefined,
                  "Attempt to set rotated geotransform on Idrisi Raster file.\n"
@@ -1290,21 +1290,21 @@ CPLErr IdrisiDataset::SetGeoTransform(const GDALGeoTransform &gt)
     // Update the .rdc file
     // --------------------------------------------------------------------
 
-    double dfXPixSz = gt[1];
-    double dfYPixSz = gt[5];
-    double dfMinX = gt[0];
+    double dfXPixSz = gt.xscale;
+    double dfYPixSz = gt.yscale;
+    double dfMinX = gt.xorig;
     double dfMaxX = (dfXPixSz * nRasterXSize) + dfMinX;
 
     double dfMinY, dfMaxY;
     if (dfYPixSz < 0)
     {
-        dfMaxY = gt[3];
-        dfMinY = (dfYPixSz * nRasterYSize) + gt[3];
+        dfMaxY = gt.yorig;
+        dfMinY = (dfYPixSz * nRasterYSize) + gt.yorig;
     }
     else
     {
-        dfMaxY = (dfYPixSz * nRasterYSize) + gt[3];
-        dfMinY = gt[3];
+        dfMaxY = (dfYPixSz * nRasterYSize) + gt.yorig;
+        dfMinY = gt.yorig;
     }
 
     papszRDC = CSLSetNameValue(papszRDC, rdcMIN_X, CPLSPrintf("%.7f", dfMinX));

--- a/frmts/ilwis/ilwiscoordinatesystem.cpp
+++ b/frmts/ilwis/ilwiscoordinatesystem.cpp
@@ -1051,8 +1051,8 @@ CPLErr ILWISDataset::WriteProjection()
     /* -------------------------------------------------------------------- */
     /*  Determine to write a geo-referencing file for the dataset to create */
     /* -------------------------------------------------------------------- */
-    if (m_gt[0] != 0.0 || m_gt[1] != 1.0 || m_gt[2] != 0.0 || m_gt[3] != 0.0 ||
-        m_gt[4] != 0.0 || fabs(m_gt[5]) != 1.0)
+    if (m_gt.xorig != 0.0 || m_gt.xscale != 1.0 || m_gt.xrot != 0.0 ||
+        m_gt.yorig != 0.0 || m_gt.yrot != 0.0 || fabs(m_gt.yscale) != 1.0)
         WriteElement("GeoRef", "CoordSystem", grFileName, csy);
 
     /* -------------------------------------------------------------------- */

--- a/frmts/ilwis/ilwisdataset.cpp
+++ b/frmts/ilwis/ilwisdataset.cpp
@@ -522,19 +522,19 @@ void ILWISDataset::CollectTransformCoef(std::string &osRefname)
 
             if (EQUAL(IsCorner.c_str(), "Yes"))
             {
-                m_gt[0] = CPLAtof(sMinX.c_str());
-                m_gt[3] = CPLAtof(sMaxY.c_str());
+                m_gt.xorig = CPLAtof(sMinX.c_str());
+                m_gt.yorig = CPLAtof(sMaxY.c_str());
             }
             else
             {
-                m_gt[0] = CPLAtof(sMinX.c_str()) - PixelSizeX / 2.0;
-                m_gt[3] = CPLAtof(sMaxY.c_str()) + PixelSizeY / 2.0;
+                m_gt.xorig = CPLAtof(sMinX.c_str()) - PixelSizeX / 2.0;
+                m_gt.yorig = CPLAtof(sMaxY.c_str()) + PixelSizeY / 2.0;
             }
 
-            m_gt[1] = PixelSizeX;
-            m_gt[2] = 0.0;
-            m_gt[4] = 0.0;
-            m_gt[5] = -PixelSizeY;
+            m_gt.xscale = PixelSizeX;
+            m_gt.xrot = 0.0;
+            m_gt.yrot = 0.0;
+            m_gt.yscale = -PixelSizeY;
         }
     }
 }
@@ -549,18 +549,18 @@ void ILWISDataset::WriteGeoReference()
 {
     // Check whether we should write out a georeference file.
     // Dataset must be north up.
-    if (m_gt[0] != 0.0 || m_gt[1] != 1.0 || m_gt[2] != 0.0 || m_gt[3] != 0.0 ||
-        m_gt[4] != 0.0 || fabs(m_gt[5]) != 1.0)
+    if (m_gt.xorig != 0.0 || m_gt.xscale != 1.0 || m_gt.xrot != 0.0 ||
+        m_gt.yorig != 0.0 || m_gt.yrot != 0.0 || fabs(m_gt.yscale) != 1.0)
     {
         SetGeoTransform(m_gt);  // is this needed?
-        if (m_gt[2] == 0.0 && m_gt[4] == 0.0)
+        if (m_gt.xrot == 0.0 && m_gt.yrot == 0.0)
         {
             int nXSize = GetRasterXSize();
             int nYSize = GetRasterYSize();
-            double dLLLat = (m_gt[3] + nYSize * m_gt[5]);
-            double dLLLong = (m_gt[0]);
-            double dURLat = (m_gt[3]);
-            double dURLong = (m_gt[0] + nXSize * m_gt[1]);
+            double dLLLat = (m_gt.yorig + nYSize * m_gt.yscale);
+            double dLLLong = (m_gt.xorig);
+            double dURLat = (m_gt.yorig);
+            double dURLong = (m_gt.xorig + nXSize * m_gt.xscale);
 
             std::string grFileName = CPLResetExtensionSafe(osFileName, "grf");
             WriteElement("Ilwis", "Type", grFileName, "GeoRef");
@@ -647,7 +647,7 @@ CPLErr ILWISDataset::SetGeoTransform(const GDALGeoTransform &gt)
 {
     m_gt = gt;
 
-    if (m_gt[2] == 0.0 && m_gt[4] == 0.0)
+    if (m_gt.xrot == 0.0 && m_gt.yrot == 0.0)
         bGeoDirty = TRUE;
 
     return CE_None;
@@ -1100,11 +1100,11 @@ GDALDataset *ILWISDataset::CreateCopy(const char *pszFilename,
     // Check whether we should create georeference file.
     // Source dataset must be north up.
     if (poSrcDS->GetGeoTransform(gt) == CE_None &&
-        (gt[0] != 0.0 || gt[1] != 1.0 || gt[2] != 0.0 || gt[3] != 0.0 ||
-         gt[4] != 0.0 || fabs(gt[5]) != 1.0))
+        (gt.xorig != 0.0 || gt.xscale != 1.0 || gt.xrot != 0.0 ||
+         gt.yorig != 0.0 || gt.yrot != 0.0 || fabs(gt.yscale) != 1.0))
     {
         poDS->SetGeoTransform(gt);
-        if (gt[2] == 0.0 && gt[4] == 0.0)
+        if (gt.xrot == 0.0 && gt.yrot == 0.0)
             georef = osBaseName + ".grf";
     }
 

--- a/frmts/iris/irisdataset.cpp
+++ b/frmts/iris/irisdataset.cpp
@@ -560,12 +560,12 @@ void IRISDataset::LoadProjection() const
         if (poTransform == nullptr || !poTransform->Transform(1, &dfX2, &dfY2))
             CPLError(CE_Failure, CPLE_None, "Transformation Failed");
 
-        m_gt[0] = dfX - (dfRadarLocX * (dfX2 - dfX));
-        m_gt[1] = dfX2 - dfX;
-        m_gt[2] = 0.0;
-        m_gt[3] = dfY + (dfRadarLocY * (dfY2 - dfY));
-        m_gt[4] = 0.0;
-        m_gt[5] = -1 * (dfY2 - dfY);
+        m_gt.xorig = dfX - (dfRadarLocX * (dfX2 - dfX));
+        m_gt.xscale = dfX2 - dfX;
+        m_gt.xrot = 0.0;
+        m_gt.yorig = dfY + (dfRadarLocY * (dfY2 - dfY));
+        m_gt.yrot = 0.0;
+        m_gt.yscale = -1 * (dfY2 - dfY);
 
         delete poTransform;
     }
@@ -576,23 +576,23 @@ void IRISDataset::LoadProjection() const
                          "degree", 0.0174532925199433);
         m_oSRS.SetAE(dfProjRefLat, dfProjRefLon, 0.0, 0.0);
 
-        m_gt[0] = -1 * (dfRadarLocX * dfScaleX);
-        m_gt[1] = dfScaleX;
-        m_gt[2] = 0.0;
-        m_gt[3] = dfRadarLocY * dfScaleY;
-        m_gt[4] = 0.0;
-        m_gt[5] = -1 * dfScaleY;
+        m_gt.xorig = -1 * (dfRadarLocX * dfScaleX);
+        m_gt.xscale = dfScaleX;
+        m_gt.xrot = 0.0;
+        m_gt.yorig = dfRadarLocY * dfScaleY;
+        m_gt.yrot = 0.0;
+        m_gt.yscale = -1 * dfScaleY;
         // When the projection is different from Mercator or Azimutal
         // equidistant, we set a standard geotransform.
     }
     else
     {
-        m_gt[0] = -1 * (dfRadarLocX * dfScaleX);
-        m_gt[1] = dfScaleX;
-        m_gt[2] = 0.0;
-        m_gt[3] = dfRadarLocY * dfScaleY;
-        m_gt[4] = 0.0;
-        m_gt[5] = -1 * dfScaleY;
+        m_gt.xorig = -1 * (dfRadarLocX * dfScaleX);
+        m_gt.xscale = dfScaleX;
+        m_gt.xrot = 0.0;
+        m_gt.yorig = dfRadarLocY * dfScaleY;
+        m_gt.yrot = 0.0;
+        m_gt.yscale = -1 * dfScaleY;
     }
 }
 

--- a/frmts/jdem/jdemdataset.cpp
+++ b/frmts/jdem/jdemdataset.cpp
@@ -232,13 +232,13 @@ CPLErr JDEMDataset::GetGeoTransform(GDALGeoTransform &gt) const
     const double dfURLat = JDEMGetAngle(psHeader + 43);
     const double dfURLong = JDEMGetAngle(psHeader + 50);
 
-    gt[0] = dfLLLong;
-    gt[3] = dfURLat;
-    gt[1] = (dfURLong - dfLLLong) / GetRasterXSize();
-    gt[2] = 0.0;
+    gt.xorig = dfLLLong;
+    gt.yorig = dfURLat;
+    gt.xscale = (dfURLong - dfLLLong) / GetRasterXSize();
+    gt.xrot = 0.0;
 
-    gt[4] = 0.0;
-    gt[5] = -1 * (dfURLat - dfLLLat) / GetRasterYSize();
+    gt.yrot = 0.0;
+    gt.yscale = -1 * (dfURLat - dfLLLat) / GetRasterYSize();
 
     return CE_None;
 }

--- a/frmts/jp2kak/jp2kakdataset.cpp
+++ b/frmts/jp2kak/jp2kakdataset.cpp
@@ -2687,8 +2687,8 @@ static GDALDataset *JP2KAKCreateCopy(const char *pszFilename,
     // cppcheck-suppress knownConditionTrueFalse
     if (bIsJP2 &&
         ((poSrcDS->GetGeoTransform(gt) == CE_None &&
-          (gt[0] != 0.0 || gt[1] != 1.0 || gt[2] != 0.0 || gt[3] != 0.0 ||
-           gt[4] != 0.0 || std::abs(gt[5]) != 1.0)) ||
+          (gt.xorig != 0.0 || gt.xscale != 1.0 || gt.xrot != 0.0 ||
+           gt.yorig != 0.0 || gt.yrot != 0.0 || std::abs(gt.yscale) != 1.0)) ||
          poSrcDS->GetGCPCount() > 0 || poSrcDS->GetMetadata("RPC") != nullptr))
     {
         GDALJP2Metadata oJP2MD;

--- a/frmts/kea/keacopy.cpp
+++ b/frmts/kea/keacopy.cpp
@@ -452,12 +452,12 @@ static void KEACopySpatialInfo(GDALDataset *pDataset,
     if (pDataset->GetGeoTransform(gt) == CE_None)
     {
         // convert back from GDAL's array format
-        pSpatialInfo->tlX = gt[0];
-        pSpatialInfo->xRes = gt[1];
-        pSpatialInfo->xRot = gt[2];
-        pSpatialInfo->tlY = gt[3];
-        pSpatialInfo->yRot = gt[4];
-        pSpatialInfo->yRes = gt[5];
+        pSpatialInfo->tlX = gt.xorig;
+        pSpatialInfo->xRes = gt.xscale;
+        pSpatialInfo->xRot = gt.xrot;
+        pSpatialInfo->tlY = gt.yorig;
+        pSpatialInfo->yRot = gt.yrot;
+        pSpatialInfo->yRes = gt.yscale;
     }
 
     const char *pszProjection = pDataset->GetProjectionRef();

--- a/frmts/kea/keadataset.cpp
+++ b/frmts/kea/keadataset.cpp
@@ -535,12 +535,12 @@ CPLErr KEADataset::GetGeoTransform(GDALGeoTransform &gt) const
         kealib::KEAImageSpatialInfo *pSpatialInfo =
             m_pImageIO->getSpatialInfo();
         // GDAL uses an array format
-        gt[0] = pSpatialInfo->tlX;
-        gt[1] = pSpatialInfo->xRes;
-        gt[2] = pSpatialInfo->xRot;
-        gt[3] = pSpatialInfo->tlY;
-        gt[4] = pSpatialInfo->yRot;
-        gt[5] = pSpatialInfo->yRes;
+        gt.xorig = pSpatialInfo->tlX;
+        gt.xscale = pSpatialInfo->xRes;
+        gt.xrot = pSpatialInfo->xRot;
+        gt.yorig = pSpatialInfo->tlY;
+        gt.yrot = pSpatialInfo->yRot;
+        gt.yscale = pSpatialInfo->yRes;
 
         return CE_None;
     }
@@ -581,12 +581,12 @@ CPLErr KEADataset::SetGeoTransform(const GDALGeoTransform &gt)
         kealib::KEAImageSpatialInfo *pSpatialInfo =
             m_pImageIO->getSpatialInfo();
         // convert back from GDAL's array format
-        pSpatialInfo->tlX = gt[0];
-        pSpatialInfo->xRes = gt[1];
-        pSpatialInfo->xRot = gt[2];
-        pSpatialInfo->tlY = gt[3];
-        pSpatialInfo->yRot = gt[4];
-        pSpatialInfo->yRes = gt[5];
+        pSpatialInfo->tlX = gt.xorig;
+        pSpatialInfo->xRes = gt.xscale;
+        pSpatialInfo->xRot = gt.xrot;
+        pSpatialInfo->tlY = gt.yorig;
+        pSpatialInfo->yRot = gt.yrot;
+        pSpatialInfo->yRes = gt.yscale;
 
         m_pImageIO->setSpatialInfo(pSpatialInfo);
         return CE_None;

--- a/frmts/kmlsuperoverlay/kmlsuperoverlaydataset.cpp
+++ b/frmts/kmlsuperoverlay/kmlsuperoverlaydataset.cpp
@@ -663,10 +663,10 @@ KmlSuperOverlayCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
 
     if (poSrcDS->GetGeoTransform(gt) == CE_None)
     {
-        north = gt[3];
-        south = gt[3] + gt[5] * ysize;
-        east = gt[0] + gt[1] * xsize;
-        west = gt[0];
+        north = gt.yorig;
+        south = gt.yorig + gt.yscale * ysize;
+        east = gt.xorig + gt.xscale * xsize;
+        west = gt.xorig;
     }
 
     std::unique_ptr<OGRCoordinateTransformation> poTransform;
@@ -726,10 +726,10 @@ KmlSuperOverlayCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
     std::vector<double> zoomypixels;
     for (int zoom = 0; zoom < maxzoom + 1; zoom++)
     {
-        zoomxpixels.push_back(gt[1] * pow(2.0, (maxzoom - zoom)));
-        // zoomypixels.push_back(abs(gt[5]) * pow(2.0, (maxzoom -
+        zoomxpixels.push_back(gt.xscale * pow(2.0, (maxzoom - zoom)));
+        // zoomypixels.push_back(abs(gt.yscale) * pow(2.0, (maxzoom -
         // zoom)));
-        zoomypixels.push_back(fabs(gt[5]) * pow(2.0, (maxzoom - zoom)));
+        zoomypixels.push_back(fabs(gt.yscale) * pow(2.0, (maxzoom - zoom)));
     }
 
     std::vector<std::string> fileVector;
@@ -922,7 +922,7 @@ KmlSuperOverlayCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
                     fileVector.push_back(childKmlfile);
                 }
 
-                double tmpSouth = gt[3] + gt[5] * ysize;
+                double tmpSouth = gt.yorig + gt.yscale * ysize;
                 double zoomxpix = zoomxpixels[zoom];
                 double zoomypix = zoomypixels[zoom];
                 if (zoomxpix == 0)
@@ -948,8 +948,8 @@ KmlSuperOverlayCreateCopy(const char *pszFilename, GDALDataset *poSrcDS,
                 currentTiles[parentXYKey].push_back(
                     std::make_pair(std::make_pair(ix, iy), hasChildKML));
                 GenerateChildKml(childKmlfile, zoom, ix, iy, zoomxpix, zoomypix,
-                                 dxsize, dysize, tmpSouth, gt[0], xsize, ysize,
-                                 maxzoom, poTransform.get(), fileExt,
+                                 dxsize, dysize, tmpSouth, gt.xorig, xsize,
+                                 ysize, maxzoom, poTransform.get(), fileExt,
                                  fixAntiMeridian, pszAltitude, pszAltitudeMode,
                                  childTiles[childXYKey]);
 
@@ -1279,15 +1279,17 @@ CPLErr KmlSuperOverlayReadDataset::IRasterIO(
 
     if (nBufXSize > dfXSize || nBufYSize > dfYSize)
     {
-        const double dfRequestXMin = m_gt[0] + nXOff * m_gt[1];
-        const double dfRequestXMax = m_gt[0] + (nXOff + nXSize) * m_gt[1];
-        const double dfRequestYMin = m_gt[3] + (nYOff + nYSize) * m_gt[5];
-        const double dfRequestYMax = m_gt[3] + nYOff * m_gt[5];
+        const double dfRequestXMin = m_gt.xorig + nXOff * m_gt.xscale;
+        const double dfRequestXMax =
+            m_gt.xorig + (nXOff + nXSize) * m_gt.xscale;
+        const double dfRequestYMin =
+            m_gt.yorig + (nYOff + nYSize) * m_gt.yscale;
+        const double dfRequestYMax = m_gt.yorig + nYOff * m_gt.yscale;
 
         const CPLXMLNode *psIter = psDocument->psChild;
         std::vector<SubImageDesc> aoImages;
-        const double dfXRes = m_gt[1] * nFactor;
-        const double dfYRes = -m_gt[5] * nFactor;
+        const double dfXRes = m_gt.xscale * nFactor;
+        const double dfYRes = -m_gt.yscale * nFactor;
         double dfNewXRes = dfXRes;
         double dfNewYRes = dfYRes;
 
@@ -1427,12 +1429,14 @@ CPLErr KmlSuperOverlayReadDataset::IRasterIO(
                     {
                         int nSubImageXSize = poSubImageDS->GetRasterXSize();
                         int nSubImageYSize = poSubImageDS->GetRasterYSize();
-                        adfExtents[0] = poSubImageDS->m_gt[0];
-                        adfExtents[1] = poSubImageDS->m_gt[3] +
-                                        nSubImageYSize * poSubImageDS->m_gt[5];
-                        adfExtents[2] = poSubImageDS->m_gt[0] +
-                                        nSubImageXSize * poSubImageDS->m_gt[1];
-                        adfExtents[3] = poSubImageDS->m_gt[3];
+                        adfExtents[0] = poSubImageDS->m_gt.xorig;
+                        adfExtents[1] =
+                            poSubImageDS->m_gt.yorig +
+                            nSubImageYSize * poSubImageDS->m_gt.yscale;
+                        adfExtents[2] =
+                            poSubImageDS->m_gt.xorig +
+                            nSubImageXSize * poSubImageDS->m_gt.xscale;
+                        adfExtents[3] = poSubImageDS->m_gt.yorig;
 
                         double dfSubXRes =
                             (adfExtents[2] - adfExtents[0]) / nSubImageXSize;
@@ -1492,9 +1496,9 @@ CPLErr KmlSuperOverlayReadDataset::IRasterIO(
             for (const auto &oImage : aoImages)
             {
                 const int nDstXOff = static_cast<int>(
-                    (oImage.adfExtents[0] - m_gt[0]) / dfNewXRes + 0.5);
+                    (oImage.adfExtents[0] - m_gt.xorig) / dfNewXRes + 0.5);
                 const int nDstYOff = static_cast<int>(
-                    (m_gt[3] - oImage.adfExtents[3]) / dfNewYRes + 0.5);
+                    (m_gt.yorig - oImage.adfExtents[3]) / dfNewYRes + 0.5);
                 const int nDstXSize = static_cast<int>(
                     (oImage.adfExtents[2] - oImage.adfExtents[0]) / dfNewXRes +
                     0.5);
@@ -2099,14 +2103,14 @@ void KmlSingleDocRasterDataset::BuildOverviews()
         poOvrDS->nTileSize = nTileSize;
         poOvrDS->osDirname = osDirname;
         poOvrDS->osNominalExt = oDesc.szExtI;
-        poOvrDS->m_gt[0] = adfGlobalExtents[0];
-        poOvrDS->m_gt[1] =
+        poOvrDS->m_gt.xorig = adfGlobalExtents[0];
+        poOvrDS->m_gt.xscale =
             (adfGlobalExtents[2] - adfGlobalExtents[0]) / poOvrDS->nRasterXSize;
-        poOvrDS->m_gt[2] = 0.0;
-        poOvrDS->m_gt[3] = adfGlobalExtents[3];
-        poOvrDS->m_gt[4] = 0.0;
-        poOvrDS->m_gt[5] = -(adfGlobalExtents[3] - adfGlobalExtents[1]) /
-                           poOvrDS->nRasterXSize;
+        poOvrDS->m_gt.xrot = 0.0;
+        poOvrDS->m_gt.yorig = adfGlobalExtents[3];
+        poOvrDS->m_gt.yrot = 0.0;
+        poOvrDS->m_gt.yscale = -(adfGlobalExtents[3] - adfGlobalExtents[1]) /
+                               poOvrDS->nRasterXSize;
         for (int iBand = 1; iBand <= nBands; iBand++)
             poOvrDS->SetBand(iBand,
                              std::make_unique<KmlSingleDocRasterRasterBand>(
@@ -2452,13 +2456,13 @@ GDALDataset *KmlSingleDocRasterDataset::Open(const char *pszFilename,
     poDS->osDirname = std::move(osDirname);
     poDS->osNominalExt = oDesc.szExtI;
     poDS->adfGlobalExtents = adfGlobalExtents;
-    poDS->m_gt[0] = adfGlobalExtents[0];
-    poDS->m_gt[1] =
+    poDS->m_gt.xorig = adfGlobalExtents[0];
+    poDS->m_gt.xscale =
         (adfGlobalExtents[2] - adfGlobalExtents[0]) / poDS->nRasterXSize;
-    poDS->m_gt[2] = 0.0;
-    poDS->m_gt[3] = adfGlobalExtents[3];
-    poDS->m_gt[4] = 0.0;
-    poDS->m_gt[5] =
+    poDS->m_gt.xrot = 0.0;
+    poDS->m_gt.yorig = adfGlobalExtents[3];
+    poDS->m_gt.yrot = 0.0;
+    poDS->m_gt.yscale =
         -(adfGlobalExtents[3] - adfGlobalExtents[1]) / poDS->nRasterYSize;
     if (nBands == 1 && bHasCT)
         nBands = 4;
@@ -2797,10 +2801,10 @@ KmlSuperOverlayReadDataset::Open(const char *pszFilename,
     poDS->nFactor = nFactor;
     poDS->nRasterXSize = nFactor * poDSIcon->GetRasterXSize();
     poDS->nRasterYSize = nFactor * poDSIcon->GetRasterYSize();
-    poDS->m_gt[0] = adfExtents[0];
-    poDS->m_gt[1] = (adfExtents[2] - adfExtents[0]) / poDS->nRasterXSize;
-    poDS->m_gt[3] = adfExtents[3];
-    poDS->m_gt[5] = -(adfExtents[3] - adfExtents[1]) / poDS->nRasterYSize;
+    poDS->m_gt.xorig = adfExtents[0];
+    poDS->m_gt.xscale = (adfExtents[2] - adfExtents[0]) / poDS->nRasterXSize;
+    poDS->m_gt.yorig = adfExtents[3];
+    poDS->m_gt.yscale = -(adfExtents[3] - adfExtents[1]) / poDS->nRasterYSize;
     poDS->nBands = 4;
     for (int i = 0; i < 4; i++)
         poDS->SetBand(i + 1, std::make_unique<KmlSuperOverlayRasterBand>(
@@ -2822,11 +2826,11 @@ KmlSuperOverlayReadDataset::Open(const char *pszFilename,
         poOvrDS->nFactor = nFactor;
         poOvrDS->nRasterXSize = nFactor * poDSIcon->GetRasterXSize();
         poOvrDS->nRasterYSize = nFactor * poDSIcon->GetRasterYSize();
-        poOvrDS->m_gt[0] = adfExtents[0];
-        poOvrDS->m_gt[1] =
+        poOvrDS->m_gt.xorig = adfExtents[0];
+        poOvrDS->m_gt.xscale =
             (adfExtents[2] - adfExtents[0]) / poOvrDS->nRasterXSize;
-        poOvrDS->m_gt[3] = adfExtents[3];
-        poOvrDS->m_gt[5] =
+        poOvrDS->m_gt.yorig = adfExtents[3];
+        poOvrDS->m_gt.yscale =
             -(adfExtents[3] - adfExtents[1]) / poOvrDS->nRasterYSize;
         poOvrDS->nBands = 4;
         for (int i = 0; i < 4; i++)

--- a/frmts/libertiff/libertiffdataset.cpp
+++ b/frmts/libertiff/libertiffdataset.cpp
@@ -3222,10 +3222,10 @@ void LIBERTIFFDataset::ReadGeoTransform()
             return;
 
         m_geotransformValid = true;
-        m_gt[1] = pixelScale[GCP_PIXEL];
-        m_gt[5] = -pixelScale[GCP_LINE];
-        m_gt[0] = tiepoints[GCP_X] - tiepoints[GCP_PIXEL] * m_gt[1];
-        m_gt[3] = tiepoints[GCP_Y] - tiepoints[GCP_LINE] * m_gt[5];
+        m_gt.xscale = pixelScale[GCP_PIXEL];
+        m_gt.yscale = -pixelScale[GCP_LINE];
+        m_gt.xorig = tiepoints[GCP_X] - tiepoints[GCP_PIXEL] * m_gt.xscale;
+        m_gt.yorig = tiepoints[GCP_Y] - tiepoints[GCP_LINE] * m_gt.yscale;
     }
     else if (psTagGeoTransMatrix &&
              psTagGeoTransMatrix->type == LIBERTIFF_NS::TagType::Double &&
@@ -3238,12 +3238,12 @@ void LIBERTIFFDataset::ReadGeoTransform()
         if (ok)
         {
             m_geotransformValid = true;
-            m_gt[0] = matrix[3];
-            m_gt[1] = matrix[0];
-            m_gt[2] = matrix[1];
-            m_gt[3] = matrix[7];
-            m_gt[4] = matrix[4];
-            m_gt[5] = matrix[5];
+            m_gt.xorig = matrix[3];
+            m_gt.xscale = matrix[0];
+            m_gt.xrot = matrix[1];
+            m_gt.yorig = matrix[7];
+            m_gt.yrot = matrix[4];
+            m_gt.yscale = matrix[5];
         }
     }
     else if (psTagTiePoints &&
@@ -3291,8 +3291,8 @@ void LIBERTIFFDataset::ReadGeoTransform()
         {
             if (EQUAL(pszAreaOrPoint, GDALMD_AOP_POINT))
             {
-                m_gt[0] -= (m_gt[1] * 0.5 + m_gt[2] * 0.5);
-                m_gt[3] -= (m_gt[4] * 0.5 + m_gt[5] * 0.5);
+                m_gt.xorig -= (m_gt.xscale * 0.5 + m_gt.xrot * 0.5);
+                m_gt.yorig -= (m_gt.yrot * 0.5 + m_gt.yscale * 0.5);
             }
         }
     }

--- a/frmts/map/mapdataset.cpp
+++ b/frmts/map/mapdataset.cpp
@@ -323,10 +323,10 @@ GDALDataset *MAPDataset::Open(GDALOpenInfo *poOpenInfo)
 
                     const double x = CPLAtofM(aosTokens[2]);
                     const double y = CPLAtofM(aosTokens[3]);
-                    const double X =
-                        poDS->m_gt[0] + x * poDS->m_gt[1] + y * poDS->m_gt[2];
-                    const double Y =
-                        poDS->m_gt[3] + x * poDS->m_gt[4] + y * poDS->m_gt[5];
+                    const double X = poDS->m_gt.xorig + x * poDS->m_gt.xscale +
+                                     y * poDS->m_gt.xrot;
+                    const double Y = poDS->m_gt.yorig + x * poDS->m_gt.yrot +
+                                     y * poDS->m_gt.yscale;
                     poRing->addPoint(X, Y);
                     CPLDebug("CORNER MMPXY", "%f, %f, %f, %f", x, y, X, Y);
                 }

--- a/frmts/mem/memdataset.cpp
+++ b/frmts/mem/memdataset.cpp
@@ -559,7 +559,7 @@ bool MEMRasterBand::IsMaskBand() const
 MEMDataset::MEMDataset()
     : GDALDataset(FALSE), bGeoTransformSet(FALSE), m_poPrivate(new Private())
 {
-    m_gt[5] = -1;
+    m_gt.yscale = -1;
     DisableReadWriteMutex();
 }
 

--- a/frmts/miramon/miramon_band.cpp
+++ b/frmts/miramon/miramon_band.cpp
@@ -270,12 +270,12 @@ CPLErr MMRBand::GetRasterBlock(int /*nXBlock*/, int nYBlock, void *pData,
 
 void MMRBand::UpdateGeoTransform()
 {
-    m_gt[0] = GetBoundingBoxMinX();
-    m_gt[1] = (GetBoundingBoxMaxX() - m_gt[0]) / GetWidth();
-    m_gt[2] = 0.0;  // No rotation in MiraMon rasters
-    m_gt[3] = GetBoundingBoxMaxY();
-    m_gt[4] = 0.0;
-    m_gt[5] = (GetBoundingBoxMinY() - m_gt[3]) / GetHeight();
+    m_gt.xorig = GetBoundingBoxMinX();
+    m_gt.xscale = (GetBoundingBoxMaxX() - m_gt.xorig) / GetWidth();
+    m_gt.xrot = 0.0;  // No rotation in MiraMon rasters
+    m_gt.yorig = GetBoundingBoxMaxY();
+    m_gt.yrot = 0.0;
+    m_gt.yscale = (GetBoundingBoxMinY() - m_gt.yorig) / GetHeight();
 }
 
 /************************************************************************/

--- a/frmts/miramon/miramon_dataset.cpp
+++ b/frmts/miramon/miramon_dataset.cpp
@@ -425,8 +425,8 @@ int MMRDataset::UpdateGeoTransform()
         osMinX.empty())
         return 1;
 
-    if (1 != CPLsscanf(osMinX, "%lf", &(m_gt[0])))
-        m_gt[0] = 0.0;
+    if (1 != CPLsscanf(osMinX, "%lf", &(m_gt.xorig)))
+        m_gt.xorig = 0.0;
 
     int nNCols = m_pMMRRel->GetColumnsNumberFromREL();
     if (nNCols <= 0)
@@ -441,8 +441,8 @@ int MMRDataset::UpdateGeoTransform()
     if (1 != CPLsscanf(osMaxX, "%lf", &dfMaxX))
         dfMaxX = 1.0;
 
-    m_gt[1] = (dfMaxX - m_gt[0]) / nNCols;
-    m_gt[2] = 0.0;  // No rotation in MiraMon rasters
+    m_gt.xscale = (dfMaxX - m_gt.xorig) / nNCols;
+    m_gt.xrot = 0.0;  // No rotation in MiraMon rasters
 
     CPLString osMinY;
     if (!m_pMMRRel->GetMetadataValue(SECTION_EXTENT, "MinY", osMinY) ||
@@ -462,13 +462,13 @@ int MMRDataset::UpdateGeoTransform()
     if (1 != CPLsscanf(osMaxY, "%lf", &dfMaxY))
         dfMaxY = 1.0;
 
-    m_gt[3] = dfMaxY;
-    m_gt[4] = 0.0;
+    m_gt.yorig = dfMaxY;
+    m_gt.yrot = 0.0;
 
     double dfMinY;
     if (1 != CPLsscanf(osMinY, "%lf", &dfMinY))
         dfMinY = 0.0;
-    m_gt[5] = (dfMinY - m_gt[3]) / nNRows;
+    m_gt.yscale = (dfMinY - m_gt.yorig) / nNRows;
 
     return 0;
 }
@@ -480,8 +480,8 @@ const OGRSpatialReference *MMRDataset::GetSpatialRef() const
 
 CPLErr MMRDataset::GetGeoTransform(GDALGeoTransform &gt) const
 {
-    if (m_gt[0] != 0.0 || m_gt[1] != 1.0 || m_gt[2] != 0.0 || m_gt[3] != 0.0 ||
-        m_gt[4] != 0.0 || m_gt[5] != 1.0)
+    if (m_gt.xorig != 0.0 || m_gt.xscale != 1.0 || m_gt.xrot != 0.0 ||
+        m_gt.yorig != 0.0 || m_gt.yrot != 0.0 || m_gt.yscale != 1.0)
     {
         gt = m_gt;
         return CE_None;

--- a/frmts/mrf/marfa_dataset.cpp
+++ b/frmts/mrf/marfa_dataset.cpp
@@ -770,8 +770,8 @@ CPLErr MRFDataset::LevelInit(const int l)
     bGeoTransformValid = (CE_None == cds->GetGeoTransform(m_gt));
     for (int i = 0; i < l + 1; i++)
     {
-        m_gt[1] *= scale;
-        m_gt[5] *= scale;
+        m_gt.xscale *= scale;
+        m_gt.yscale *= scale;
     }
 
     nRasterXSize = current.size.x;
@@ -1366,13 +1366,13 @@ CPLXMLNode *MRFDataset::BuildConfig()
     // Do we have an affine transform different from identity?
     GDALGeoTransform gt;
     if ((MRFDataset::GetGeoTransform(gt) == CE_None) &&
-        (gt[0] != 0 || gt[1] != 1 || gt[2] != 0 || gt[3] != 0 || gt[4] != 0 ||
-         gt[5] != 1))
+        (gt.xorig != 0 || gt.xscale != 1 || gt.xrot != 0 || gt.yorig != 0 ||
+         gt.yrot != 0 || gt.yscale != 1))
     {
-        double minx = gt[0];
-        double maxx = gt[1] * full.size.x + minx;
-        double maxy = gt[3];
-        double miny = gt[5] * full.size.y + maxy;
+        double minx = gt.xorig;
+        double maxx = gt.xscale * full.size.x + minx;
+        double maxy = gt.yorig;
+        double miny = gt.yscale * full.size.y + maxy;
         CPLXMLNode *bbox = CPLCreateXMLNode(gtags, CXT_Element, "BoundingBox");
         XMLSetAttributeVal(bbox, "minx", minx);
         XMLSetAttributeVal(bbox, "miny", miny);
@@ -1438,12 +1438,12 @@ CPLErr MRFDataset::Initialize(CPLXMLNode *config)
         y1 = atof(CPLGetXMLValue(bbox, "maxy", "1"));
         y0 = atof(CPLGetXMLValue(bbox, "miny", "0"));
 
-        m_gt[0] = x0;
-        m_gt[1] = (x1 - x0) / full.size.x;
-        m_gt[2] = 0;
-        m_gt[3] = y1;
-        m_gt[4] = 0;
-        m_gt[5] = (y0 - y1) / full.size.y;
+        m_gt.xorig = x0;
+        m_gt.xscale = (x1 - x0) / full.size.x;
+        m_gt.xrot = 0;
+        m_gt.yorig = y1;
+        m_gt.yrot = 0;
+        m_gt.yscale = (y0 - y1) / full.size.y;
         bGeoTransformValid = TRUE;
     }
 

--- a/frmts/mrsid/mrsiddataset.cpp
+++ b/frmts/mrsid/mrsiddataset.cpp
@@ -1267,10 +1267,11 @@ CPLErr MrSIDDataset::OpenZoomLevel(lt_int32 iZoom)
     if (!poImageReader->isGeoCoordImplicit())
     {
         const LTIGeoCoord &oGeo = poImageReader->getGeoCoord();
-        oGeo.get(m_gt[0], m_gt[3], m_gt[1], m_gt[5], m_gt[2], m_gt[4]);
+        oGeo.get(m_gt.xorig, m_gt.yorig, m_gt.xscale, m_gt.yscale, m_gt.xrot,
+                 m_gt.yrot);
 
-        m_gt[0] = m_gt[0] - m_gt[1] / 2;
-        m_gt[3] = m_gt[3] - m_gt[5] / 2;
+        m_gt.xorig = m_gt.xorig - m_gt.xscale / 2;
+        m_gt.yorig = m_gt.yorig - m_gt.yscale / 2;
         bGeoTransformValid = TRUE;
     }
     else if (iZoom == 0)
@@ -3095,12 +3096,14 @@ LT_STATUS MrSIDDummyImageReader::initialize()
     if (poDS->GetGeoTransform(m_gt) == CE_None)
     {
 #ifdef MRSID_SDK_40
-        LTIGeoCoord oGeo(m_gt[0] + m_gt[1] / 2, m_gt[3] + m_gt[5] / 2, m_gt[1],
-                         m_gt[5], m_gt[2], m_gt[4], nullptr,
+        LTIGeoCoord oGeo(m_gt.xorig + m_gt.xscale / 2,
+                         m_gt.yorig + m_gt.yscale / 2, m_gt.xscale, m_gt.yscale,
+                         m_gt.xrot, m_gt.yrot, nullptr,
                          poDS->GetProjectionRef());
 #else
-        LTIGeoCoord oGeo(m_gt[0] + m_gt[1] / 2, m_gt[3] + m_gt[5] / 2, m_gt[1],
-                         m_gt[5], m_gt[2], m_gt[4], poDS->GetProjectionRef());
+        LTIGeoCoord oGeo(m_gt.xorig + m_gt.xscale / 2,
+                         m_gt.yorig + m_gt.yscale / 2, m_gt.xscale, m_gt.yscale,
+                         m_gt.xrot, m_gt.yrot, poDS->GetProjectionRef());
 #endif
         if (!LT_SUCCESS(setGeoCoord(oGeo)))
             return LT_STS_Failure;

--- a/frmts/msg/msgdataset.cpp
+++ b/frmts/msg/msgdataset.cpp
@@ -226,12 +226,12 @@ GDALDataset *MSGDataset::Open(GDALOpenInfo *poOpenInfo)
                  iCentralPixelVIS_IR +
                  0.5);  // The y scan direction is always south -> north
     }
-    poDS->m_gt[0] = rMinX;
-    poDS->m_gt[3] = rMaxY;
-    poDS->m_gt[1] = rPixelSizeX;
-    poDS->m_gt[5] = -rPixelSizeY;
-    poDS->m_gt[2] = 0.0;
-    poDS->m_gt[4] = 0.0;
+    poDS->m_gt.xorig = rMinX;
+    poDS->m_gt.yorig = rMaxY;
+    poDS->m_gt.xscale = rPixelSizeX;
+    poDS->m_gt.yscale = -rPixelSizeY;
+    poDS->m_gt.xrot = 0.0;
+    poDS->m_gt.yrot = 0.0;
 
     /* -------------------------------------------------------------------- */
     /*      Set Projection Information                                      */
@@ -823,10 +823,10 @@ double MSGRasterBand::rRadiometricCorrection(unsigned int iDN, int iChannel,
         }
         else  // Channels 1,2,3 and 12 (visual): Reflectance
         {
-            double rLon =
-                poGDS->m_gt[0] + iCol * poGDS->m_gt[1];  // X, in "geos" meters
-            double rLat =
-                poGDS->m_gt[3] + iRow * poGDS->m_gt[5];  // Y, in "geos" meters
+            double rLon = poGDS->m_gt.xorig +
+                          iCol * poGDS->m_gt.xscale;  // X, in "geos" meters
+            double rLat = poGDS->m_gt.yorig +
+                          iRow * poGDS->m_gt.yscale;  // Y, in "geos" meters
             if ((poGDS->poTransform != nullptr) &&
                 poGDS->poTransform->Transform(1, &rLon,
                                               &rLat))  // transform it to latlon

--- a/frmts/msgn/msgndataset.cpp
+++ b/frmts/msgn/msgndataset.cpp
@@ -723,13 +723,13 @@ GDALDataset *MSGNDataset::Open(GDALOpenInfo *poOpenInfo)
            CGMS/DOC/12/0017 section 4.4.2
         */
 
-        poDS->m_gt[0] = -origin_x;
-        poDS->m_gt[1] = pixel_gsd_x;
-        poDS->m_gt[2] = 0.0;
+        poDS->m_gt.xorig = -origin_x;
+        poDS->m_gt.xscale = pixel_gsd_x;
+        poDS->m_gt.xrot = 0.0;
 
-        poDS->m_gt[3] = -origin_y;
-        poDS->m_gt[4] = 0.0;
-        poDS->m_gt[5] = -pixel_gsd_y;
+        poDS->m_gt.yorig = -origin_y;
+        poDS->m_gt.yrot = 0.0;
+        poDS->m_gt.yscale = -pixel_gsd_y;
 
         poDS->m_oSRS.SetProjCS("Geostationary projection (MSG)");
 

--- a/frmts/netcdf/netcdfdataset.cpp
+++ b/frmts/netcdf/netcdfdataset.cpp
@@ -5069,8 +5069,8 @@ CPLErr netCDFDataset::SetGeoTransform(const GDALGeoTransform &gt)
         return CE_Failure;
     }
 
-    CPLDebug("GDAL_netCDF", "SetGeoTransform(%f,%f,%f,%f,%f,%f)", gt[0], gt[1],
-             gt[2], gt[3], gt[4], gt[5]);
+    CPLDebug("GDAL_netCDF", "SetGeoTransform(%f,%f,%f,%f,%f,%f)", gt.xorig,
+             gt.xscale, gt.xrot, gt.yorig, gt.yrot, gt.yscale);
 
     SetGeoTransformNoUpdate(gt);
 
@@ -5838,10 +5838,10 @@ CPLErr netCDFDataset::AddProjectionVars(bool bDefsOnly,
             }
 
             // Get Y values.
-            const double dfY0 = (!bBottomUp) ? m_gt[3] :
+            const double dfY0 = (!bBottomUp) ? m_gt.yorig :
                                              // Invert latitude values.
-                                    m_gt[3] + (m_gt[5] * nRasterYSize);
-            const double dfDY = m_gt[5];
+                                    m_gt.yorig + (m_gt.yscale * nRasterYSize);
+            const double dfDY = m_gt.yscale;
 
             for (int j = 0; j < nRasterYSize; j++)
             {
@@ -5855,8 +5855,8 @@ CPLErr netCDFDataset::AddProjectionVars(bool bDefsOnly,
             countX[0] = nRasterXSize;
 
             // Get X values.
-            const double dfX0 = m_gt[0];
-            const double dfDX = m_gt[1];
+            const double dfX0 = m_gt.xorig;
+            const double dfDX = m_gt.xscale;
 
             for (int i = 0; i < nRasterXSize; i++)
             {
@@ -6126,10 +6126,10 @@ CPLErr netCDFDataset::AddProjectionVars(bool bDefsOnly,
         else if (bWriteLonLat)
         {
             // Get latitude values.
-            const double dfY0 = (!bBottomUp) ? m_gt[3] :
+            const double dfY0 = (!bBottomUp) ? m_gt.yorig :
                                              // Invert latitude values.
-                                    m_gt[3] + (m_gt[5] * nRasterYSize);
-            const double dfDY = m_gt[5];
+                                    m_gt.yorig + (m_gt.yscale * nRasterYSize);
+            const double dfDY = m_gt.yscale;
 
             std::unique_ptr<double, decltype(&VSIFree)> adLatValKeeper(nullptr,
                                                                        VSIFree);
@@ -6182,8 +6182,8 @@ CPLErr netCDFDataset::AddProjectionVars(bool bDefsOnly,
             size_t countLat[1] = {static_cast<size_t>(nRasterYSize)};
 
             // Get longitude values.
-            const double dfX0 = m_gt[0];
-            const double dfDX = m_gt[1];
+            const double dfX0 = m_gt.xorig;
+            const double dfDX = m_gt.xscale;
 
             std::unique_ptr<double, decltype(&VSIFree)> adLonValKeeper(
                 static_cast<double *>(

--- a/frmts/ngsgeoid/ngsgeoiddataset.cpp
+++ b/frmts/ngsgeoid/ngsgeoiddataset.cpp
@@ -269,12 +269,12 @@ int NGSGEOIDDataset::GetHeaderInfo(const GByte *pBuffer, GDALGeoTransform &gt,
           dfWLON >= -180.0 && dfWLON + nNLON * dfDLON <= 360.0))
         return FALSE;
 
-    gt[0] = dfWLON - dfDLON / 2;
-    gt[1] = dfDLON;
-    gt[2] = 0.0;
-    gt[3] = dfSLAT + nNLAT * dfDLAT - dfDLAT / 2;
-    gt[4] = 0.0;
-    gt[5] = -dfDLAT;
+    gt.xorig = dfWLON - dfDLON / 2;
+    gt.xscale = dfDLON;
+    gt.xrot = 0.0;
+    gt.yorig = dfSLAT + nNLAT * dfDLAT - dfDLAT / 2;
+    gt.yrot = 0.0;
+    gt.yscale = -dfDLAT;
 
     *pnRows = nNLAT;
     *pnCols = nNLON;

--- a/frmts/nitf/ecrgtocdataset.cpp
+++ b/frmts/nitf/ecrgtocdataset.cpp
@@ -447,11 +447,11 @@ bool ECRGTOCSource::ValidateOpenedBand(GDALRasterBand *poBand) const
 
     GDALGeoTransform l_gt;
     poSourceDS->GetGeoTransform(l_gt);
-    WARN_CHECK_DS(fabs(l_gt[0] - m_dfMinX) < 1e-10);
-    WARN_CHECK_DS(fabs(l_gt[3] - m_dfMaxY) < 1e-10);
-    WARN_CHECK_DS(fabs(l_gt[1] - m_dfPixelXSize) < 1e-10);
-    WARN_CHECK_DS(fabs(l_gt[5] - (-m_dfPixelYSize)) < 1e-10);
-    WARN_CHECK_DS(l_gt[2] == 0 && l_gt[4] == 0);  // No rotation.
+    WARN_CHECK_DS(fabs(l_gt.xorig - m_dfMinX) < 1e-10);
+    WARN_CHECK_DS(fabs(l_gt.yorig - m_dfMaxY) < 1e-10);
+    WARN_CHECK_DS(fabs(l_gt.xscale - m_dfPixelXSize) < 1e-10);
+    WARN_CHECK_DS(fabs(l_gt.yscale - (-m_dfPixelYSize)) < 1e-10);
+    WARN_CHECK_DS(l_gt.xrot == 0 && l_gt.yrot == 0);  // No rotation.
     WARN_CHECK_DS(poSourceDS->GetRasterCount() == 3);
     WARN_CHECK_DS(poSourceDS->GetRasterXSize() == m_nRasterXSize);
     WARN_CHECK_DS(poSourceDS->GetRasterYSize() == m_nRasterYSize);
@@ -939,12 +939,12 @@ GDALDataset *ECRGTOCDataset::Build(const char *pszTOCFilename,
         return poRetDS;
     }
 
-    poDS->m_gt[0] = dfGlobalMinX;
-    poDS->m_gt[1] = dfGlobalPixelXSize;
-    poDS->m_gt[2] = 0.0;
-    poDS->m_gt[3] = dfGlobalMaxY;
-    poDS->m_gt[4] = 0.0;
-    poDS->m_gt[5] = -dfGlobalPixelYSize;
+    poDS->m_gt.xorig = dfGlobalMinX;
+    poDS->m_gt.xscale = dfGlobalPixelXSize;
+    poDS->m_gt.xrot = 0.0;
+    poDS->m_gt.yorig = dfGlobalMaxY;
+    poDS->m_gt.yrot = 0.0;
+    poDS->m_gt.yscale = -dfGlobalPixelYSize;
 
     poDS->nRasterXSize = static_cast<int>(0.5 + (dfGlobalMaxX - dfGlobalMinX) /
                                                     dfGlobalPixelXSize);

--- a/frmts/nitf/rpftocdataset.cpp
+++ b/frmts/nitf/rpftocdataset.cpp
@@ -634,8 +634,8 @@ int RPFTOCProxyRasterDataSet::SanityCheckOK(GDALDataset *sourceDS)
     checkDone = TRUE;
 
     sourceDS->GetGeoTransform(l_gt);
-    WARN_ON_FAIL(fabs(l_gt[GEOTRSFRM_TOPLEFT_X] - nwLong) < l_gt[1]);
-    WARN_ON_FAIL(fabs(l_gt[GEOTRSFRM_TOPLEFT_Y] - nwLat) < fabs(l_gt[5]));
+    WARN_ON_FAIL(fabs(l_gt[GEOTRSFRM_TOPLEFT_X] - nwLong) < l_gt.xscale);
+    WARN_ON_FAIL(fabs(l_gt[GEOTRSFRM_TOPLEFT_Y] - nwLat) < fabs(l_gt.yscale));
     WARN_ON_FAIL(l_gt[GEOTRSFRM_ROTATION_PARAM1] == 0 &&
                  l_gt[GEOTRSFRM_ROTATION_PARAM2] == 0); /* No rotation */
     ERROR_ON_FAIL(sourceDS->GetRasterCount() == 1);     /* Just 1 band */

--- a/frmts/northwood/grcdataset.cpp
+++ b/frmts/northwood/grcdataset.cpp
@@ -261,13 +261,13 @@ NWT_GRCDataset::~NWT_GRCDataset()
 /************************************************************************/
 CPLErr NWT_GRCDataset::GetGeoTransform(GDALGeoTransform &gt) const
 {
-    gt[0] = pGrd->dfMinX - (pGrd->dfStepSize * 0.5);
-    gt[3] = pGrd->dfMaxY + (pGrd->dfStepSize * 0.5);
-    gt[1] = pGrd->dfStepSize;
-    gt[2] = 0.0;
+    gt.xorig = pGrd->dfMinX - (pGrd->dfStepSize * 0.5);
+    gt.yorig = pGrd->dfMaxY + (pGrd->dfStepSize * 0.5);
+    gt.xscale = pGrd->dfStepSize;
+    gt.xrot = 0.0;
 
-    gt[4] = 0.0;
-    gt[5] = -1 * pGrd->dfStepSize;
+    gt.yrot = 0.0;
+    gt.yscale = -1 * pGrd->dfStepSize;
 
     return CE_None;
 }

--- a/frmts/northwood/grddataset.cpp
+++ b/frmts/northwood/grddataset.cpp
@@ -485,13 +485,13 @@ CPLErr NWT_GRDDataset::FlushCache(bool bAtClosing)
 
 CPLErr NWT_GRDDataset::GetGeoTransform(GDALGeoTransform &gt) const
 {
-    gt[0] = pGrd->dfMinX - (pGrd->dfStepSize * 0.5);
-    gt[3] = pGrd->dfMaxY + (pGrd->dfStepSize * 0.5);
-    gt[1] = pGrd->dfStepSize;
-    gt[2] = 0.0;
+    gt.xorig = pGrd->dfMinX - (pGrd->dfStepSize * 0.5);
+    gt.yorig = pGrd->dfMaxY + (pGrd->dfStepSize * 0.5);
+    gt.xscale = pGrd->dfStepSize;
+    gt.xrot = 0.0;
 
-    gt[4] = 0.0;
-    gt[5] = -1 * pGrd->dfStepSize;
+    gt.yrot = 0.0;
+    gt.yscale = -1 * pGrd->dfStepSize;
 
     return CE_None;
 }
@@ -502,20 +502,20 @@ CPLErr NWT_GRDDataset::GetGeoTransform(GDALGeoTransform &gt) const
 
 CPLErr NWT_GRDDataset::SetGeoTransform(const GDALGeoTransform &gt)
 {
-    if (gt[2] != 0.0 || gt[4] != 0.0)
+    if (gt.xrot != 0.0 || gt.yrot != 0.0)
     {
 
         CPLError(CE_Failure, CPLE_NotSupported,
                  "GRD datasets do not support skew/rotation");
         return CE_Failure;
     }
-    pGrd->dfStepSize = gt[1];
+    pGrd->dfStepSize = gt.xscale;
 
     // GRD format sets the min/max coordinates to the centre of the
     // cell; We must account for this when copying the GDAL geotransform
     // which references the top left corner
-    pGrd->dfMinX = gt[0] + (pGrd->dfStepSize * 0.5);
-    pGrd->dfMaxY = gt[3] - (pGrd->dfStepSize * 0.5);
+    pGrd->dfMinX = gt.xorig + (pGrd->dfStepSize * 0.5);
+    pGrd->dfMaxY = gt.yorig - (pGrd->dfStepSize * 0.5);
 
     // Now set the miny and maxx
     pGrd->dfMaxX = pGrd->dfMinX + (pGrd->dfStepSize * (nRasterXSize - 1));

--- a/frmts/ogcapi/gdalogcapidataset.cpp
+++ b/frmts/ogcapi/gdalogcapidataset.cpp
@@ -755,10 +755,10 @@ bool OGCAPIDataset::ProcessScale(const CPLJSONObject &oScaleDenominator,
 
     nRasterXSize = std::max(1, static_cast<int>(0.5 + dfXSize));
     nRasterYSize = std::max(1, static_cast<int>(0.5 + dfYSize));
-    m_gt[0] = dfXMin;
-    m_gt[1] = (dfXMax - dfXMin) / nRasterXSize;
-    m_gt[3] = dfYMax;
-    m_gt[5] = -(dfYMax - dfYMin) / nRasterYSize;
+    m_gt.xorig = dfXMin;
+    m_gt.xscale = (dfXMax - dfXMin) / nRasterXSize;
+    m_gt.yorig = dfYMax;
+    m_gt.yscale = -(dfYMax - dfYMin) / nRasterYSize;
 
     return true;
 }
@@ -1405,10 +1405,10 @@ bool OGCAPIDataset::InitWithCoverageAPI(GDALOpenInfo *poOpenInfo,
 
             nRasterXSize = std::max(1, static_cast<int>(0.5 + dfXSize));
             nRasterYSize = std::max(1, static_cast<int>(0.5 + dfYSize));
-            m_gt[0] = dfXMin;
-            m_gt[1] = (dfXMax - dfXMin) / nRasterXSize;
-            m_gt[3] = dfYMax;
-            m_gt[5] = -(dfYMax - dfYMin) / nRasterYSize;
+            m_gt.xorig = dfXMin;
+            m_gt.xscale = (dfXMax - dfXMin) / nRasterXSize;
+            m_gt.yorig = dfYMax;
+            m_gt.yscale = -(dfYMax - dfYMin) / nRasterYSize;
         }
 
         OGRSpatialReference oSRS;
@@ -2229,7 +2229,7 @@ bool OGCAPIDataset::InitWithTilesAPI(GDALOpenInfo *poOpenInfo,
             m_apoDatasetsCropped.emplace_back(
                 GDALDataset::FromHandle(hCroppedDS));
 
-            if (tileMatrix.mResX <= m_gt[1])
+            if (tileMatrix.mResX <= m_gt.xscale)
                 break;
         }
         if (!m_apoDatasetsCropped.empty())

--- a/frmts/pcidsk/pcidskdataset2.cpp
+++ b/frmts/pcidsk/pcidskdataset2.cpp
@@ -1247,8 +1247,8 @@ CPLErr PCIDSK2Dataset::SetGeoTransform(const GDALGeoTransform &gt)
 
     try
     {
-        poGeoref->WriteSimple(poGeoref->GetGeosys(), gt[0], gt[1], gt[2], gt[3],
-                              gt[4], gt[5]);
+        poGeoref->WriteSimple(poGeoref->GetGeosys(), gt.xorig, gt.xscale,
+                              gt.xrot, gt.yorig, gt.yrot, gt.yscale);
     }
     catch (const PCIDSKException &ex)
     {
@@ -1280,7 +1280,8 @@ CPLErr PCIDSK2Dataset::GetGeoTransform(GDALGeoTransform &gt) const
     {
         try
         {
-            poGeoref->GetTransform(gt[0], gt[1], gt[2], gt[3], gt[4], gt[5]);
+            poGeoref->GetTransform(gt.xorig, gt.xscale, gt.xrot, gt.yorig,
+                                   gt.yrot, gt.yscale);
         }
         catch (const PCIDSKException &ex)
         {
@@ -1348,12 +1349,12 @@ CPLErr PCIDSK2Dataset::SetSpatialRef(const OGRSpatialReference *poSRS)
 
     try
     {
-        double adfGT[6];
-        poGeoref->GetTransform(adfGT[0], adfGT[1], adfGT[2], adfGT[3], adfGT[4],
-                               adfGT[5]);
+        GDALGeoTransform gt;
+        poGeoref->GetTransform(gt.xorig, gt.xscale, gt.xrot, gt.yorig, gt.yrot,
+                               gt.yscale);
 
-        poGeoref->WriteSimple(pszGeosys, adfGT[0], adfGT[1], adfGT[2], adfGT[3],
-                              adfGT[4], adfGT[5]);
+        poGeoref->WriteSimple(pszGeosys, gt.xorig, gt.xscale, gt.xrot, gt.yorig,
+                              gt.yrot, gt.yscale);
 
         std::vector<double> adfPCIParameters;
         for (unsigned int i = 0; i < 17; i++)

--- a/frmts/pcraster/pcrasterdataset.cpp
+++ b/frmts/pcraster/pcrasterdataset.cpp
@@ -143,11 +143,11 @@ GDALDataset *PCRasterDataset::createCopy(char const *filename,
     GDALGeoTransform gt;
     if (source->GetGeoTransform(gt) == CE_None)
     {
-        if (gt[2] == 0.0 && gt[4] == 0.0)
+        if (gt.xrot == 0.0 && gt.yrot == 0.0)
         {
-            west = static_cast<REAL8>(gt[0]);
-            north = static_cast<REAL8>(gt[3]);
-            cellSize = static_cast<REAL8>(gt[1]);
+            west = static_cast<REAL8>(gt.xorig);
+            north = static_cast<REAL8>(gt.yorig);
+            cellSize = static_cast<REAL8>(gt.xscale);
         }
     }
 
@@ -345,14 +345,14 @@ PCRasterDataset::~PCRasterDataset()
 CPLErr PCRasterDataset::GetGeoTransform(GDALGeoTransform &gt) const
 {
     // x = west + nrCols * cellsize
-    gt[0] = d_west;
-    gt[1] = d_cellSize;
-    gt[2] = 0.0;
+    gt.xorig = d_west;
+    gt.xscale = d_cellSize;
+    gt.xrot = 0.0;
 
     // y = north + nrRows * -cellsize
-    gt[3] = d_north;
-    gt[4] = 0.0;
-    gt[5] = -1.0 * d_cellSize;
+    gt.yorig = d_north;
+    gt.yrot = 0.0;
+    gt.yscale = -1.0 * d_cellSize;
 
     return CE_None;
 }
@@ -498,7 +498,7 @@ GDALDataset *PCRasterDataset::create(const char *filename, int nr_cols,
 
 CPLErr PCRasterDataset::SetGeoTransform(const GDALGeoTransform &gt)
 {
-    if ((gt[2] != 0.0) || (gt[4] != 0.0))
+    if ((gt.xrot != 0.0) || (gt.yrot != 0.0))
     {
         CPLError(CE_Failure, CPLE_NotSupported,
                  "PCRaster driver: "
@@ -506,7 +506,7 @@ CPLErr PCRasterDataset::SetGeoTransform(const GDALGeoTransform &gt)
         return CE_Failure;
     }
 
-    if (gt[1] != gt[5] * -1.0)
+    if (gt.xscale != gt.yscale * -1.0)
     {
         CPLError(CE_Failure, CPLE_NotSupported,
                  "PCRaster driver: "
@@ -514,9 +514,9 @@ CPLErr PCRasterDataset::SetGeoTransform(const GDALGeoTransform &gt)
         return CE_Failure;
     }
 
-    d_west = gt[0];
-    d_north = gt[3];
-    d_cellSize = gt[1];
+    d_west = gt.xorig;
+    d_north = gt.yorig;
+    d_cellSize = gt.xscale;
     d_location_changed = true;
 
     return CE_None;

--- a/frmts/pcraster/pcrasterrasterband.cpp
+++ b/frmts/pcraster/pcrasterrasterband.cpp
@@ -285,11 +285,11 @@ CPLErr PCRasterRasterBand::IWriteBlock(CPL_UNUSED int nBlockXoff,
         GDALGeoTransform gt;
         if (this->poDS->GetGeoTransform(gt) == CE_None)
         {
-            if (gt[2] == 0.0 && gt[4] == 0.0)
+            if (gt.xrot == 0.0 && gt.yrot == 0.0)
             {
-                west = static_cast<REAL8>(gt[0]);
-                north = static_cast<REAL8>(gt[3]);
-                cellSize = static_cast<REAL8>(gt[1]);
+                west = static_cast<REAL8>(gt.xorig);
+                north = static_cast<REAL8>(gt.yorig);
+                cellSize = static_cast<REAL8>(gt.xscale);
             }
         }
         (void)RputXUL(d_dataset->map(), west);

--- a/frmts/pdf/pdfcreatefromcomposition.cpp
+++ b/frmts/pdf/pdfcreatefromcomposition.cpp
@@ -759,13 +759,13 @@ bool GDALPDFComposerWriter::GenerateGeoreferencing(
                      "Could not compute geotransform with approximate match.");
             return false;
         }
-        if (std::fabs(georeferencing.m_gt[2]) <
-                1e-5 * std::fabs(georeferencing.m_gt[1]) &&
-            std::fabs(georeferencing.m_gt[4]) <
-                1e-5 * std::fabs(georeferencing.m_gt[5]))
+        if (std::fabs(georeferencing.m_gt.xrot) <
+                1e-5 * std::fabs(georeferencing.m_gt.xscale) &&
+            std::fabs(georeferencing.m_gt.yrot) <
+                1e-5 * std::fabs(georeferencing.m_gt.yscale))
         {
-            georeferencing.m_gt[2] = 0;
-            georeferencing.m_gt[4] = 0;
+            georeferencing.m_gt.xrot = 0;
+            georeferencing.m_gt.yrot = 0;
         }
 
         georeferencing.m_osID = pszId;

--- a/frmts/pdf/pdfdataset.cpp
+++ b/frmts/pdf/pdfdataset.cpp
@@ -5310,38 +5310,40 @@ PDFDataset *PDFDataset::Open(GDALOpenInfo *poOpenInfo)
             {
                 if (dfRotation == 90)
                 {
-                    poDS->m_gt[0] = poDS->m_adfCTM[4];
-                    poDS->m_gt[1] = poDS->m_adfCTM[2] / dfUserUnit;
-                    poDS->m_gt[2] = poDS->m_adfCTM[0] / dfUserUnit;
-                    poDS->m_gt[3] = poDS->m_adfCTM[5];
-                    poDS->m_gt[4] = poDS->m_adfCTM[3] / dfUserUnit;
-                    poDS->m_gt[5] = poDS->m_adfCTM[1] / dfUserUnit;
+                    poDS->m_gt.xorig = poDS->m_adfCTM[4];
+                    poDS->m_gt.xscale = poDS->m_adfCTM[2] / dfUserUnit;
+                    poDS->m_gt.xrot = poDS->m_adfCTM[0] / dfUserUnit;
+                    poDS->m_gt.yorig = poDS->m_adfCTM[5];
+                    poDS->m_gt.yrot = poDS->m_adfCTM[3] / dfUserUnit;
+                    poDS->m_gt.yscale = poDS->m_adfCTM[1] / dfUserUnit;
                 }
                 else if (dfRotation == -90 || dfRotation == 270)
                 {
-                    poDS->m_gt[0] = poDS->m_adfCTM[4] +
-                                    poDS->m_adfCTM[2] * poDS->m_dfPageHeight +
-                                    poDS->m_adfCTM[0] * poDS->m_dfPageWidth;
-                    poDS->m_gt[1] = -poDS->m_adfCTM[2] / dfUserUnit;
-                    poDS->m_gt[2] = -poDS->m_adfCTM[0] / dfUserUnit;
-                    poDS->m_gt[3] = poDS->m_adfCTM[5] +
-                                    poDS->m_adfCTM[3] * poDS->m_dfPageHeight +
-                                    poDS->m_adfCTM[1] * poDS->m_dfPageWidth;
-                    poDS->m_gt[4] = -poDS->m_adfCTM[3] / dfUserUnit;
-                    poDS->m_gt[5] = -poDS->m_adfCTM[1] / dfUserUnit;
+                    poDS->m_gt.xorig =
+                        poDS->m_adfCTM[4] +
+                        poDS->m_adfCTM[2] * poDS->m_dfPageHeight +
+                        poDS->m_adfCTM[0] * poDS->m_dfPageWidth;
+                    poDS->m_gt.xscale = -poDS->m_adfCTM[2] / dfUserUnit;
+                    poDS->m_gt.xrot = -poDS->m_adfCTM[0] / dfUserUnit;
+                    poDS->m_gt.yorig =
+                        poDS->m_adfCTM[5] +
+                        poDS->m_adfCTM[3] * poDS->m_dfPageHeight +
+                        poDS->m_adfCTM[1] * poDS->m_dfPageWidth;
+                    poDS->m_gt.yrot = -poDS->m_adfCTM[3] / dfUserUnit;
+                    poDS->m_gt.yscale = -poDS->m_adfCTM[1] / dfUserUnit;
                 }
                 else
                 {
-                    poDS->m_gt[0] = poDS->m_adfCTM[4] +
-                                    poDS->m_adfCTM[2] * dfY2 +
-                                    poDS->m_adfCTM[0] * dfX1;
-                    poDS->m_gt[1] = poDS->m_adfCTM[0] / dfUserUnit;
-                    poDS->m_gt[2] = -poDS->m_adfCTM[2] / dfUserUnit;
-                    poDS->m_gt[3] = poDS->m_adfCTM[5] +
-                                    poDS->m_adfCTM[3] * dfY2 +
-                                    poDS->m_adfCTM[1] * dfX1;
-                    poDS->m_gt[4] = poDS->m_adfCTM[1] / dfUserUnit;
-                    poDS->m_gt[5] = -poDS->m_adfCTM[3] / dfUserUnit;
+                    poDS->m_gt.xorig = poDS->m_adfCTM[4] +
+                                       poDS->m_adfCTM[2] * dfY2 +
+                                       poDS->m_adfCTM[0] * dfX1;
+                    poDS->m_gt.xscale = poDS->m_adfCTM[0] / dfUserUnit;
+                    poDS->m_gt.xrot = -poDS->m_adfCTM[2] / dfUserUnit;
+                    poDS->m_gt.yorig = poDS->m_adfCTM[5] +
+                                       poDS->m_adfCTM[3] * dfY2 +
+                                       poDS->m_adfCTM[1] * dfX1;
+                    poDS->m_gt.yrot = poDS->m_adfCTM[1] / dfUserUnit;
+                    poDS->m_gt.yscale = -poDS->m_adfCTM[3] / dfUserUnit;
                 }
 
                 poDS->m_bGeoTransformValid = true;
@@ -5498,25 +5500,26 @@ PDFDataset *PDFDataset::Open(GDALOpenInfo *poOpenInfo)
     /* If pixel size or top left coordinates are very close to an int, round
      * them to the int */
     double dfEps =
-        (fabs(poDS->m_gt[0]) > 1e5 && fabs(poDS->m_gt[3]) > 1e5) ? 1e-5 : 1e-8;
-    poDS->m_gt[0] = ROUND_IF_CLOSE(poDS->m_gt[0], dfEps);
-    poDS->m_gt[1] = ROUND_IF_CLOSE(poDS->m_gt[1]);
-    poDS->m_gt[3] = ROUND_IF_CLOSE(poDS->m_gt[3], dfEps);
-    poDS->m_gt[5] = ROUND_IF_CLOSE(poDS->m_gt[5]);
+        (fabs(poDS->m_gt.xorig) > 1e5 && fabs(poDS->m_gt.yorig) > 1e5) ? 1e-5
+                                                                       : 1e-8;
+    poDS->m_gt.xorig = ROUND_IF_CLOSE(poDS->m_gt.xorig, dfEps);
+    poDS->m_gt.xscale = ROUND_IF_CLOSE(poDS->m_gt.xscale);
+    poDS->m_gt.yorig = ROUND_IF_CLOSE(poDS->m_gt.yorig, dfEps);
+    poDS->m_gt.yscale = ROUND_IF_CLOSE(poDS->m_gt.yscale);
 
     if (bUseLib.test(PDFLIB_PDFIUM))
     {
         // Attempt to "fix" the loss of precision due to the use of float32 for
         // numbers by pdfium
-        if ((fabs(poDS->m_gt[0]) > 1e5 || fabs(poDS->m_gt[3]) > 1e5) &&
-            fabs(poDS->m_gt[0] - std::round(poDS->m_gt[0])) <
-                1e-6 * fabs(poDS->m_gt[0]) &&
-            fabs(poDS->m_gt[1] - std::round(poDS->m_gt[1])) <
-                1e-3 * fabs(poDS->m_gt[1]) &&
-            fabs(poDS->m_gt[3] - std::round(poDS->m_gt[3])) <
-                1e-6 * fabs(poDS->m_gt[3]) &&
-            fabs(poDS->m_gt[5] - std::round(poDS->m_gt[5])) <
-                1e-3 * fabs(poDS->m_gt[5]))
+        if ((fabs(poDS->m_gt.xorig) > 1e5 || fabs(poDS->m_gt.yorig) > 1e5) &&
+            fabs(poDS->m_gt.xorig - std::round(poDS->m_gt.xorig)) <
+                1e-6 * fabs(poDS->m_gt.xorig) &&
+            fabs(poDS->m_gt.xscale - std::round(poDS->m_gt.xscale)) <
+                1e-3 * fabs(poDS->m_gt.xscale) &&
+            fabs(poDS->m_gt.yorig - std::round(poDS->m_gt.yorig)) <
+                1e-6 * fabs(poDS->m_gt.yorig) &&
+            fabs(poDS->m_gt.yscale - std::round(poDS->m_gt.yscale)) <
+                1e-3 * fabs(poDS->m_gt.yscale))
         {
             for (int i = 0; i < 6; i++)
             {
@@ -5553,10 +5556,10 @@ PDFDataset *PDFDataset::Open(GDALOpenInfo *poOpenInfo)
                     x = (-dfX1 + poRing->getX(i)) * dfUserUnit;
                     y = (dfY2 - poRing->getY(i)) * dfUserUnit;
                 }
-                double X =
-                    poDS->m_gt[0] + x * poDS->m_gt[1] + y * poDS->m_gt[2];
-                double Y =
-                    poDS->m_gt[3] + x * poDS->m_gt[4] + y * poDS->m_gt[5];
+                double X = poDS->m_gt.xorig + x * poDS->m_gt.xscale +
+                           y * poDS->m_gt.xrot;
+                double Y = poDS->m_gt.yorig + x * poDS->m_gt.yrot +
+                           y * poDS->m_gt.yscale;
                 poRing->setPoint(i, X, Y);
             }
         }
@@ -7283,17 +7286,20 @@ int PDFDataset::ParseMeasure(GDALPDFObject *poMeasure, double dfMediaBoxWidth,
     // If the non scaling terms of the geotransform are significantly smaller
     // than the pixel size, then nullify them as being just artifacts of
     //  reprojection and GDALGCPsToGeoTransform() numerical imprecisions.
-    const double dfPixelSize = std::min(fabs(m_gt[1]), fabs(m_gt[5]));
-    const double dfRotationShearTerm = std::max(fabs(m_gt[2]), fabs(m_gt[4]));
+    const double dfPixelSize = std::min(fabs(m_gt.xscale), fabs(m_gt.yscale));
+    const double dfRotationShearTerm =
+        std::max(fabs(m_gt.xrot), fabs(m_gt.yrot));
     if (dfRotationShearTerm < 1e-5 * dfPixelSize ||
         (m_bUseLib.test(PDFLIB_PDFIUM) &&
-         std::min(fabs(m_gt[2]), fabs(m_gt[4])) < 1e-5 * dfPixelSize))
+         std::min(fabs(m_gt.xrot), fabs(m_gt.yrot)) < 1e-5 * dfPixelSize))
     {
-        dfLRX = m_gt[0] + nRasterXSize * m_gt[1] + nRasterYSize * m_gt[2];
-        dfLRY = m_gt[3] + nRasterXSize * m_gt[4] + nRasterYSize * m_gt[5];
-        m_gt[1] = (dfLRX - m_gt[0]) / nRasterXSize;
-        m_gt[5] = (dfLRY - m_gt[3]) / nRasterYSize;
-        m_gt[2] = m_gt[4] = 0;
+        dfLRX =
+            m_gt.xorig + nRasterXSize * m_gt.xscale + nRasterYSize * m_gt.xrot;
+        dfLRY =
+            m_gt.yorig + nRasterXSize * m_gt.yrot + nRasterYSize * m_gt.yscale;
+        m_gt.xscale = (dfLRX - m_gt.xorig) / nRasterXSize;
+        m_gt.yscale = (dfLRY - m_gt.yorig) / nRasterYSize;
+        m_gt.xrot = m_gt.yrot = 0;
     }
 
     return TRUE;

--- a/frmts/pdf/pdfreadvectors.cpp
+++ b/frmts/pdf/pdfreadvectors.cpp
@@ -439,8 +439,8 @@ void PDFDataset::PDFCoordsToSRSCoords(double x, double y, double &X, double &Y)
     else
         y = (y / m_dfPageHeight) * nRasterYSize;
 
-    X = m_gt[0] + x * m_gt[1] + y * m_gt[2];
-    Y = m_gt[3] + x * m_gt[4] + y * m_gt[5];
+    X = m_gt.xorig + x * m_gt.xscale + y * m_gt.xrot;
+    Y = m_gt.yorig + x * m_gt.yrot + y * m_gt.yscale;
 
     if (fabs(X - std::round(X)) < 1e-8)
         X = std::round(X);

--- a/frmts/pdf/pdfwritabledataset.cpp
+++ b/frmts/pdf/pdfwritabledataset.cpp
@@ -218,16 +218,16 @@ CPLErr PDFWritableVectorDataset::FlushCache(bool /* bAtClosing*/)
     }
 
     GDALGeoTransform gt;
-    gt[0] = sGlobalExtent.MinX;
-    gt[1] = (sGlobalExtent.MaxX - sGlobalExtent.MinX) / nWidth;
-    gt[2] = 0;
-    gt[3] = sGlobalExtent.MaxY;
-    gt[4] = 0;
-    gt[5] = -(sGlobalExtent.MaxY - sGlobalExtent.MinY) / nHeight;
+    gt.xorig = sGlobalExtent.MinX;
+    gt.xscale = (sGlobalExtent.MaxX - sGlobalExtent.MinX) / nWidth;
+    gt.xrot = 0;
+    gt.yorig = sGlobalExtent.MaxY;
+    gt.yrot = 0;
+    gt.yscale = -(sGlobalExtent.MaxY - sGlobalExtent.MinY) / nHeight;
 
     // Do again a check against 0, because the above divisions might
     // transform a difference close to 0, to plain 0.
-    if (gt[1] == 0 || gt[5] == 0)
+    if (gt.xscale == 0 || gt.yscale == 0)
     {
         CPLError(CE_Failure, CPLE_AppDefined,
                  "Cannot compute spatial extent of features");

--- a/frmts/pds/isis2dataset.cpp
+++ b/frmts/pds/isis2dataset.cpp
@@ -710,12 +710,12 @@ GDALDataset *ISIS2Dataset::Open(GDALOpenInfo *poOpenInfo)
     if (dfULXMap != 0.5 || dfULYMap != 0.5 || dfXDim != 1.0 || dfYDim != 1.0)
     {
         poDS->bGotTransform = TRUE;
-        poDS->m_gt[0] = dfULXMap;
-        poDS->m_gt[1] = dfXDim;
-        poDS->m_gt[2] = 0.0;
-        poDS->m_gt[3] = dfULYMap;
-        poDS->m_gt[4] = 0.0;
-        poDS->m_gt[5] = dfYDim;
+        poDS->m_gt.xorig = dfULXMap;
+        poDS->m_gt.xscale = dfXDim;
+        poDS->m_gt.xrot = 0.0;
+        poDS->m_gt.yorig = dfULYMap;
+        poDS->m_gt.yrot = 0.0;
+        poDS->m_gt.yscale = dfYDim;
     }
 
     if (!poDS->bGotTransform)

--- a/frmts/pds/pdsdataset.cpp
+++ b/frmts/pds/pdsdataset.cpp
@@ -695,12 +695,12 @@ void PDSDataset::ParseSRS()
     if (dfULXMap != 0.5 || dfULYMap != 0.5 || dfXDim != 1.0 || dfYDim != 1.0)
     {
         bGotTransform = TRUE;
-        m_gt[0] = dfULXMap;
-        m_gt[1] = dfXDim;
-        m_gt[2] = 0.0;
-        m_gt[3] = dfULYMap;
-        m_gt[4] = 0.0;
-        m_gt[5] = dfYDim;
+        m_gt.xorig = dfULXMap;
+        m_gt.xscale = dfXDim;
+        m_gt.xrot = 0.0;
+        m_gt.yorig = dfULYMap;
+        m_gt.yrot = 0.0;
+        m_gt.yscale = dfYDim;
 
         const double rotation = CPLAtof(GetKeyword(
             osPrefix + "IMAGE_MAP_PROJECTION.MAP_PROJECTION_ROTATION"));
@@ -710,18 +710,18 @@ void PDSDataset::ParseSRS()
                 rotation == 90 ? 1.0 : sin(rotation / 180 * M_PI);
             const double cos_rot =
                 rotation == 90 ? 0.0 : cos(rotation / 180 * M_PI);
-            const double gt_1 = cos_rot * m_gt[1] - sin_rot * m_gt[4];
-            const double gt_2 = cos_rot * m_gt[2] - sin_rot * m_gt[5];
-            const double gt_0 = cos_rot * m_gt[0] - sin_rot * m_gt[3];
-            const double gt_4 = sin_rot * m_gt[1] + cos_rot * m_gt[4];
-            const double gt_5 = sin_rot * m_gt[2] + cos_rot * m_gt[5];
-            const double gt_3 = sin_rot * m_gt[0] + cos_rot * m_gt[3];
-            m_gt[1] = gt_1;
-            m_gt[2] = gt_2;
-            m_gt[0] = gt_0;
-            m_gt[4] = gt_4;
-            m_gt[5] = gt_5;
-            m_gt[3] = gt_3;
+            const double gt_1 = cos_rot * m_gt.xscale - sin_rot * m_gt.yrot;
+            const double gt_2 = cos_rot * m_gt.xrot - sin_rot * m_gt.yscale;
+            const double gt_0 = cos_rot * m_gt.xorig - sin_rot * m_gt.yorig;
+            const double gt_4 = sin_rot * m_gt.xscale + cos_rot * m_gt.yrot;
+            const double gt_5 = sin_rot * m_gt.xrot + cos_rot * m_gt.yscale;
+            const double gt_3 = sin_rot * m_gt.xorig + cos_rot * m_gt.yorig;
+            m_gt.xscale = gt_1;
+            m_gt.xrot = gt_2;
+            m_gt.xorig = gt_0;
+            m_gt.yrot = gt_4;
+            m_gt.yscale = gt_5;
+            m_gt.yorig = gt_3;
         }
     }
 

--- a/frmts/pds/vicardataset.cpp
+++ b/frmts/pds/vicardataset.cpp
@@ -1247,7 +1247,8 @@ CPLErr VICARDataset::SetGeoTransform(const GDALGeoTransform &gt)
 {
     if (eAccess == GA_ReadOnly)
         return GDALPamDataset::SetGeoTransform(gt);
-    if (gt[1] <= 0.0 || gt[1] != -gt[5] || gt[2] != 0.0 || gt[4] != 0.0)
+    if (gt.xscale <= 0.0 || gt.xscale != -gt.yscale || gt.xrot != 0.0 ||
+        gt.yrot != 0.0)
     {
         CPLError(CE_Failure, CPLE_NotSupported,
                  "Only north-up geotransform with square pixels supported");
@@ -1860,20 +1861,20 @@ void VICARDataset::BuildLabelPropertyMap(CPLJSONObject &oLabel)
                 if (m_oSRS.IsProjected())
                 {
                     const double dfLinearUnits = m_oSRS.GetLinearUnits();
-                    const double dfScale = m_gt[1] * dfLinearUnits;
+                    const double dfScale = m_gt.xscale * dfLinearUnits;
                     oMap.Add("SAMPLE_PROJECTION_OFFSET",
-                             -m_gt[0] * dfLinearUnits / dfScale - 0.5);
+                             -m_gt.xorig * dfLinearUnits / dfScale - 0.5);
                     oMap.Add("LINE_PROJECTION_OFFSET",
-                             m_gt[3] * dfLinearUnits / dfScale - 0.5);
+                             m_gt.yorig * dfLinearUnits / dfScale - 0.5);
                     oMap.Add("MAP_SCALE", dfScale / 1000.0);
                 }
                 else if (m_oSRS.IsGeographic())
                 {
-                    const double dfScale = m_gt[1] * dfDegToMeter;
+                    const double dfScale = m_gt.xscale * dfDegToMeter;
                     oMap.Add("SAMPLE_PROJECTION_OFFSET",
-                             -m_gt[0] * dfDegToMeter / dfScale - 0.5);
+                             -m_gt.xorig * dfDegToMeter / dfScale - 0.5);
                     oMap.Add("LINE_PROJECTION_OFFSET",
-                             m_gt[3] * dfDegToMeter / dfScale - 0.5);
+                             m_gt.yorig * dfDegToMeter / dfScale - 0.5);
                     oMap.Add("MAP_SCALE", dfScale / 1000.0);
                 }
             }
@@ -2291,12 +2292,12 @@ void VICARDataset::ReadProjectionFromMapGroup()
     if (bProjectionSet)
     {
         m_bGotTransform = true;
-        m_gt[0] = dfULXMap;
-        m_gt[1] = dfXDim;
-        m_gt[2] = 0.0;
-        m_gt[3] = dfULYMap;
-        m_gt[4] = 0.0;
-        m_gt[5] = dfYDim;
+        m_gt.xorig = dfULXMap;
+        m_gt.xscale = dfXDim;
+        m_gt.xrot = 0.0;
+        m_gt.yorig = dfULYMap;
+        m_gt.yrot = 0.0;
+        m_gt.yscale = dfYDim;
     }
 }
 

--- a/frmts/plmosaic/plmosaicdataset.cpp
+++ b/frmts/plmosaic/plmosaicdataset.cpp
@@ -858,12 +858,12 @@ int PLMosaicDataset::OpenMosaic()
         }
 
         bHasGeoTransform = TRUE;
-        m_gt[0] = GM_ORIGIN;
-        m_gt[1] = dfResolution;
-        m_gt[2] = 0;
-        m_gt[3] = -GM_ORIGIN;
-        m_gt[4] = 0;
-        m_gt[5] = -dfResolution;
+        m_gt.xorig = GM_ORIGIN;
+        m_gt.xscale = dfResolution;
+        m_gt.xrot = 0;
+        m_gt.yorig = -GM_ORIGIN;
+        m_gt.yrot = 0;
+        m_gt.yscale = -dfResolution;
         nRasterXSize = static_cast<int>(2 * -GM_ORIGIN / dfResolution + 0.5);
         nRasterYSize = nRasterXSize;
 
@@ -891,8 +891,8 @@ int PLMosaicDataset::OpenMosaic()
             ymin = floor(ymin / dfTileSize) * dfTileSize;
             xmax = ceil(xmax / dfTileSize) * dfTileSize;
             ymax = ceil(ymax / dfTileSize) * dfTileSize;
-            m_gt[0] = xmin;
-            m_gt[3] = ymax;
+            m_gt.xorig = xmin;
+            m_gt.yorig = ymax;
             nRasterXSize = static_cast<int>((xmax - xmin) / dfResolution + 0.5);
             nRasterYSize = static_cast<int>((ymax - ymin) / dfResolution + 0.5);
             nMetaTileXShift =
@@ -984,12 +984,12 @@ int PLMosaicDataset::OpenMosaic()
 
                     int nSrcXOff, nSrcYOff, nDstXOff, nDstYOff;
 
-                    nSrcXOff = static_cast<int>(0.5 + (m_gt[0] - GM_ORIGIN) /
+                    nSrcXOff = static_cast<int>(0.5 + (m_gt.xorig - GM_ORIGIN) /
                                                           dfThisResolution);
                     nDstXOff = 0;
 
-                    nSrcYOff = static_cast<int>(0.5 + (-GM_ORIGIN - m_gt[3]) /
-                                                          dfThisResolution);
+                    nSrcYOff = static_cast<int>(
+                        0.5 + (-GM_ORIGIN - m_gt.yorig) / dfThisResolution);
                     nDstYOff = 0;
 
                     for (int iBand = 1; iBand <= 4; iBand++)

--- a/frmts/postgisraster/postgisrasterdataset.cpp
+++ b/frmts/postgisraster/postgisrasterdataset.cpp
@@ -1087,13 +1087,13 @@ bool PostGISRasterDataset::LoadOutdbRaster(int &nCurOffset, GDALDataType eDT,
     GDALGeoTransform gt;
     poDS->GetGeoTransform(gt);
     int nXOff =
-        static_cast<int>(std::round((dfTileUpperLeftX - gt[0]) / gt[1]));
+        static_cast<int>(std::round((dfTileUpperLeftX - gt.xorig) / gt.xscale));
     int nYOff =
-        static_cast<int>(std::round((dfTileUpperLeftY - gt[3]) / gt[5]));
+        static_cast<int>(std::round((dfTileUpperLeftY - gt.yorig) / gt.yscale));
     int nXOff2 = static_cast<int>(std::round(
-        (dfTileUpperLeftX + nTileXSize * dfTileResX - gt[0]) / gt[1]));
+        (dfTileUpperLeftX + nTileXSize * dfTileResX - gt.xorig) / gt.xscale));
     int nYOff2 = static_cast<int>(std::round(
-        (dfTileUpperLeftY + nTileYSize * dfTileResY - gt[3]) / gt[5]));
+        (dfTileUpperLeftY + nTileYSize * dfTileResY - gt.yorig) / gt.yscale));
     int nSrcXSize = nXOff2 - nXOff;
     int nSrcYSize = nYOff2 - nYOff;
     if (nXOff < 0 || nYOff < 0 || nXOff2 > poDS->GetRasterXSize() ||

--- a/frmts/postgisraster/postgisrastertilerasterband.cpp
+++ b/frmts/postgisraster/postgisrastertilerasterband.cpp
@@ -81,8 +81,8 @@ CPLErr PostGISRasterTileRasterBand::IReadBlock(int /*nBlockXOff*/,
 
     const double dfTileUpperLeftX = poRTDS->m_gt[GEOTRSFRM_TOPLEFT_X];
     const double dfTileUpperLeftY = poRTDS->m_gt[GEOTRSFRM_TOPLEFT_Y];
-    const double dfTileResX = poRTDS->m_gt[1];
-    const double dfTileResY = poRTDS->m_gt[5];
+    const double dfTileResX = poRTDS->m_gt.xscale;
+    const double dfTileResY = poRTDS->m_gt.yscale;
     const int nTileXSize = nBlockXSize;
     const int nTileYSize = nBlockYSize;
 

--- a/frmts/prf/phprfdataset.cpp
+++ b/frmts/prf/phprfdataset.cpp
@@ -255,8 +255,8 @@ static bool ParseGeoref(const CPLXMLNode *psGeorefElt, GDALGeoTransform &gt)
         }
         if (k == 5)
         {
-            gt[3] -= PH_GEOREF_SHIFT_Y * gt[4];
-            gt[3] -= PH_GEOREF_SHIFT_Y * gt[5];
+            gt.yorig -= PH_GEOREF_SHIFT_Y * gt.yrot;
+            gt.yorig -= PH_GEOREF_SHIFT_Y * gt.yscale;
             return true;
         }
     }
@@ -571,20 +571,20 @@ GDALDataset *PhPrfDataset::Open(GDALOpenInfo *poOpenInfo)
         if (abDemMetadataOk[0] && abDemMetadataOk[1] && abDemMetadataOk[2] &&
             abDemMetadataOk[3] && nSizeX > 1 && nSizeY > 1)
         {
-            gt[0] = adfDemMetadata[0];
-            gt[1] = (adfDemMetadata[1] - adfDemMetadata[0]) / (nSizeX - 1);
-            gt[2] = 0;
-            gt[3] = adfDemMetadata[3];
-            gt[4] = 0;
-            gt[5] = (adfDemMetadata[2] - adfDemMetadata[3]) / (nSizeY - 1);
+            gt.xorig = adfDemMetadata[0];
+            gt.xscale = (adfDemMetadata[1] - adfDemMetadata[0]) / (nSizeX - 1);
+            gt.xrot = 0;
+            gt.yorig = adfDemMetadata[3];
+            gt.yrot = 0;
+            gt.yscale = (adfDemMetadata[2] - adfDemMetadata[3]) / (nSizeY - 1);
 
-            gt[0] -= 0.5 * gt[1];
-            gt[3] -= 0.5 * gt[5];
+            gt.xorig -= 0.5 * gt.xscale;
+            gt.yorig -= 0.5 * gt.yscale;
 
             if (bDemShiftOk)
             {
-                gt[0] += adfDemShift[0];
-                gt[3] += adfDemShift[1];
+                gt.xorig += adfDemShift[0];
+                gt.yorig += adfDemShift[1];
             }
 
             poDataset->SetGeoTransform(gt);

--- a/frmts/raw/ace2dataset.cpp
+++ b/frmts/raw/ace2dataset.cpp
@@ -316,12 +316,12 @@ GDALDataset *ACE2Dataset::Open(GDALOpenInfo *poOpenInfo)
     poDS->nRasterXSize = nXSize;
     poDS->nRasterYSize = nYSize;
 
-    poDS->m_gt[0] = southWestLon;
-    poDS->m_gt[1] = dfPixelSize;
-    poDS->m_gt[2] = 0.0;
-    poDS->m_gt[3] = southWestLat + nYSize * dfPixelSize;
-    poDS->m_gt[4] = 0.0;
-    poDS->m_gt[5] = -dfPixelSize;
+    poDS->m_gt.xorig = southWestLon;
+    poDS->m_gt.xscale = dfPixelSize;
+    poDS->m_gt.xrot = 0.0;
+    poDS->m_gt.yorig = southWestLat + nYSize * dfPixelSize;
+    poDS->m_gt.yrot = 0.0;
+    poDS->m_gt.yscale = -dfPixelSize;
 
     /* -------------------------------------------------------------------- */
     /*      Create band information objects                                 */

--- a/frmts/raw/btdataset.cpp
+++ b/frmts/raw/btdataset.cpp
@@ -420,7 +420,7 @@ CPLErr BTDataset::SetGeoTransform(const GDALGeoTransform &gt)
     CPLErr eErr = CE_None;
 
     m_gt = gt;
-    if (gt[2] != 0.0 || gt[4] != 0.0)
+    if (gt.xrot != 0.0 || gt.yrot != 0.0)
     {
         CPLError(CE_Failure, CPLE_AppDefined,
                  ".bt format does not support rotational coefficients "
@@ -431,10 +431,10 @@ CPLErr BTDataset::SetGeoTransform(const GDALGeoTransform &gt)
     /* -------------------------------------------------------------------- */
     /*      Compute bounds, and update header info.                         */
     /* -------------------------------------------------------------------- */
-    const double dfLeft = m_gt[0];
-    const double dfRight = dfLeft + m_gt[1] * nRasterXSize;
-    const double dfTop = m_gt[3];
-    const double dfBottom = dfTop + m_gt[5] * nRasterYSize;
+    const double dfLeft = m_gt.xorig;
+    const double dfRight = dfLeft + m_gt.xscale * nRasterXSize;
+    const double dfTop = m_gt.yorig;
+    const double dfBottom = dfTop + m_gt.yscale * nRasterYSize;
 
     memcpy(abyHeader + 28, &dfLeft, 8);
     memcpy(abyHeader + 36, &dfRight, 8);
@@ -759,12 +759,12 @@ GDALDataset *BTDataset::Open(GDALOpenInfo *poOpenInfo)
         memcpy(&dfTop, poDS->abyHeader + 52, 8);
         CPL_LSBPTR64(&dfTop);
 
-        poDS->m_gt[0] = dfLeft;
-        poDS->m_gt[1] = (dfRight - dfLeft) / poDS->nRasterXSize;
-        poDS->m_gt[2] = 0.0;
-        poDS->m_gt[3] = dfTop;
-        poDS->m_gt[4] = 0.0;
-        poDS->m_gt[5] = (dfBottom - dfTop) / poDS->nRasterYSize;
+        poDS->m_gt.xorig = dfLeft;
+        poDS->m_gt.xscale = (dfRight - dfLeft) / poDS->nRasterXSize;
+        poDS->m_gt.xrot = 0.0;
+        poDS->m_gt.yorig = dfTop;
+        poDS->m_gt.yrot = 0.0;
+        poDS->m_gt.yscale = (dfBottom - dfTop) / poDS->nRasterYSize;
 
         poDS->bGeoTransformValid = TRUE;
     }

--- a/frmts/raw/byndataset.cpp
+++ b/frmts/raw/byndataset.cpp
@@ -306,12 +306,12 @@ GDALDataset *BYNDataset::Open(GDALOpenInfo *poOpenInfo)
     /* Build GeoTransform matrix */
     /*****************************/
 
-    poDS->m_gt[0] = (dfWest - (dfDLon / 2.0)) / 3600.0;
-    poDS->m_gt[1] = dfDLon / 3600.0;
-    poDS->m_gt[2] = 0.0;
-    poDS->m_gt[3] = (dfNorth + (dfDLat / 2.0)) / 3600.0;
-    poDS->m_gt[4] = 0.0;
-    poDS->m_gt[5] = -1 * dfDLat / 3600.0;
+    poDS->m_gt.xorig = (dfWest - (dfDLon / 2.0)) / 3600.0;
+    poDS->m_gt.xscale = dfDLon / 3600.0;
+    poDS->m_gt.xrot = 0.0;
+    poDS->m_gt.yorig = (dfNorth + (dfDLat / 2.0)) / 3600.0;
+    poDS->m_gt.yrot = 0.0;
+    poDS->m_gt.yscale = -1 * dfDLat / 3600.0;
 
     /*********************/
     /* Set data type     */

--- a/frmts/raw/cpgdataset.cpp
+++ b/frmts/raw/cpgdataset.cpp
@@ -705,10 +705,10 @@ GDALDataset *CPGDataset::InitializeType1Or2Dataset(const char *pszFilename)
      */
     if (iUTMParamsFound == 7)
     {
-        poDS->m_gt[1] = 0.0;
-        poDS->m_gt[2] = 0.0;
-        poDS->m_gt[4] = 0.0;
-        poDS->m_gt[5] = 0.0;
+        poDS->m_gt.xscale = 0.0;
+        poDS->m_gt.xrot = 0.0;
+        poDS->m_gt.yrot = 0.0;
+        poDS->m_gt.yscale = 0.0;
 
         double dfnorth_center;
         if (itransposed == 1)
@@ -718,18 +718,18 @@ GDALDataset *CPGDataset::InitializeType1Or2Dataset(const char *pszFilename)
                      "with transposed=1 for testing.  Georeferencing may be "
                      "wrong.\n");
             dfnorth_center = dfnorth - nSamples * dfsample_size / 2.0;
-            poDS->m_gt[0] = dfeast;
-            poDS->m_gt[2] = dfsample_size_az;
-            poDS->m_gt[3] = dfnorth;
-            poDS->m_gt[4] = -1 * dfsample_size;
+            poDS->m_gt.xorig = dfeast;
+            poDS->m_gt.xrot = dfsample_size_az;
+            poDS->m_gt.yorig = dfnorth;
+            poDS->m_gt.yrot = -1 * dfsample_size;
         }
         else
         {
             dfnorth_center = dfnorth - nLines * dfsample_size / 2.0;
-            poDS->m_gt[0] = dfeast;
-            poDS->m_gt[1] = dfsample_size_az;
-            poDS->m_gt[3] = dfnorth;
-            poDS->m_gt[5] = -1 * dfsample_size;
+            poDS->m_gt.xorig = dfeast;
+            poDS->m_gt.xscale = dfsample_size_az;
+            poDS->m_gt.yorig = dfnorth;
+            poDS->m_gt.yscale = -1 * dfsample_size;
         }
 
         if (dfnorth_center < 0)
@@ -1050,12 +1050,12 @@ GDALDataset *CPGDataset::InitializeType3Dataset(const char *pszFilename)
     if (iUTMParamsFound == 8)
     {
         double dfnorth_center = dfnorth - nLines * dfysize / 2.0;
-        poDS->m_gt[0] = dfeast + dfOffsetX;
-        poDS->m_gt[1] = dfxsize;
-        poDS->m_gt[2] = 0.0;
-        poDS->m_gt[3] = dfnorth + dfOffsetY;
-        poDS->m_gt[4] = 0.0;
-        poDS->m_gt[5] = -1 * dfysize;
+        poDS->m_gt.xorig = dfeast + dfOffsetX;
+        poDS->m_gt.xscale = dfxsize;
+        poDS->m_gt.xrot = 0.0;
+        poDS->m_gt.yorig = dfnorth + dfOffsetY;
+        poDS->m_gt.yrot = 0.0;
+        poDS->m_gt.yscale = -1 * dfysize;
 
         OGRSpatialReference oUTM;
         if (dfnorth_center < 0)

--- a/frmts/raw/doq1dataset.cpp
+++ b/frmts/raw/doq1dataset.cpp
@@ -182,12 +182,12 @@ CPLErr DOQ1Dataset::Close(GDALProgressFunc, void *)
 CPLErr DOQ1Dataset::GetGeoTransform(GDALGeoTransform &gt) const
 
 {
-    gt[0] = dfULX;
-    gt[1] = dfXPixelSize;
-    gt[2] = 0.0;
-    gt[3] = dfULY;
-    gt[4] = 0.0;
-    gt[5] = -1 * dfYPixelSize;
+    gt.xorig = dfULX;
+    gt.xscale = dfXPixelSize;
+    gt.xrot = 0.0;
+    gt.yorig = dfULY;
+    gt.yrot = 0.0;
+    gt.yscale = -1 * dfYPixelSize;
 
     return CE_None;
 }

--- a/frmts/raw/doq2dataset.cpp
+++ b/frmts/raw/doq2dataset.cpp
@@ -130,12 +130,12 @@ CPLErr DOQ2Dataset::Close(GDALProgressFunc, void *)
 CPLErr DOQ2Dataset::GetGeoTransform(GDALGeoTransform &gt) const
 
 {
-    gt[0] = dfULX;
-    gt[1] = dfXPixelSize;
-    gt[2] = 0.0;
-    gt[3] = dfULY;
-    gt[4] = 0.0;
-    gt[5] = -1 * dfYPixelSize;
+    gt.xorig = dfULX;
+    gt.xscale = dfXPixelSize;
+    gt.xrot = 0.0;
+    gt.yorig = dfULY;
+    gt.yrot = 0.0;
+    gt.yscale = -1 * dfYPixelSize;
 
     return CE_None;
 }

--- a/frmts/raw/ehdrdataset.cpp
+++ b/frmts/raw/ehdrdataset.cpp
@@ -605,7 +605,7 @@ CPLErr EHdrDataset::SetGeoTransform(const GDALGeoTransform &gt)
 
 {
     // We only support non-rotated images with info in the .HDR file.
-    if (gt[2] != 0.0 || gt[4] != 0.0)
+    if (gt.xrot != 0.0 || gt.yrot != 0.0)
     {
         return GDALPamDataset::SetGeoTransform(gt);
     }
@@ -629,16 +629,16 @@ CPLErr EHdrDataset::SetGeoTransform(const GDALGeoTransform &gt)
     // Set the transformation information.
     CPLString oValue;
 
-    oValue.Printf("%.15g", m_gt[0] + m_gt[1] * 0.5);
+    oValue.Printf("%.15g", m_gt.xorig + m_gt.xscale * 0.5);
     ResetKeyValue("ULXMAP", oValue);
 
-    oValue.Printf("%.15g", m_gt[3] + m_gt[5] * 0.5);
+    oValue.Printf("%.15g", m_gt.yorig + m_gt.yscale * 0.5);
     ResetKeyValue("ULYMAP", oValue);
 
-    oValue.Printf("%.15g", m_gt[1]);
+    oValue.Printf("%.15g", m_gt.xscale);
     ResetKeyValue("XDIM", oValue);
 
-    oValue.Printf("%.15g", fabs(m_gt[5]));
+    oValue.Printf("%.15g", fabs(m_gt.yscale));
     ResetKeyValue("YDIM", oValue);
 
     return CE_None;
@@ -1332,21 +1332,21 @@ GDALDataset *EHdrDataset::Open(GDALOpenInfo *poOpenInfo, bool bFileSizeCheck)
 
         if (bCenter)
         {
-            poDS->m_gt[0] = dfULXMap - dfXDim * 0.5;
-            poDS->m_gt[1] = dfXDim;
-            poDS->m_gt[2] = 0.0;
-            poDS->m_gt[3] = dfULYMap + dfYDim * 0.5;
-            poDS->m_gt[4] = 0.0;
-            poDS->m_gt[5] = -dfYDim;
+            poDS->m_gt.xorig = dfULXMap - dfXDim * 0.5;
+            poDS->m_gt.xscale = dfXDim;
+            poDS->m_gt.xrot = 0.0;
+            poDS->m_gt.yorig = dfULYMap + dfYDim * 0.5;
+            poDS->m_gt.yrot = 0.0;
+            poDS->m_gt.yscale = -dfYDim;
         }
         else
         {
-            poDS->m_gt[0] = dfULXMap;
-            poDS->m_gt[1] = dfXDim;
-            poDS->m_gt[2] = 0.0;
-            poDS->m_gt[3] = dfULYMap;
-            poDS->m_gt[4] = 0.0;
-            poDS->m_gt[5] = -dfYDim;
+            poDS->m_gt.xorig = dfULXMap;
+            poDS->m_gt.xscale = dfXDim;
+            poDS->m_gt.xrot = 0.0;
+            poDS->m_gt.yorig = dfULYMap;
+            poDS->m_gt.yrot = 0.0;
+            poDS->m_gt.yscale = -dfYDim;
         }
     }
 
@@ -1388,12 +1388,12 @@ GDALDataset *EHdrDataset::Open(GDALOpenInfo *poOpenInfo, bool bFileSizeCheck)
                               ""),
                       "DS"))
             {
-                poDS->m_gt[0] /= 3600.0;
-                poDS->m_gt[1] /= 3600.0;
-                poDS->m_gt[2] /= 3600.0;
-                poDS->m_gt[3] /= 3600.0;
-                poDS->m_gt[4] /= 3600.0;
-                poDS->m_gt[5] /= 3600.0;
+                poDS->m_gt.xorig /= 3600.0;
+                poDS->m_gt.xscale /= 3600.0;
+                poDS->m_gt.xrot /= 3600.0;
+                poDS->m_gt.yorig /= 3600.0;
+                poDS->m_gt.yrot /= 3600.0;
+                poDS->m_gt.yscale /= 3600.0;
             }
         }
         else

--- a/frmts/raw/genbindataset.cpp
+++ b/frmts/raw/genbindataset.cpp
@@ -700,13 +700,13 @@ GDALDataset *GenBinDataset::Open(GDALOpenInfo *poOpenInfo)
         const double dfLRY =
             CPLAtofM(CSLFetchNameValue(papszHdr, "LR_Y_COORDINATE"));
 
-        poDS->m_gt[1] = (dfLRX - dfULX) / (poDS->nRasterXSize - 1);
-        poDS->m_gt[2] = 0.0;
-        poDS->m_gt[4] = 0.0;
-        poDS->m_gt[5] = (dfLRY - dfULY) / (poDS->nRasterYSize - 1);
+        poDS->m_gt.xscale = (dfLRX - dfULX) / (poDS->nRasterXSize - 1);
+        poDS->m_gt.xrot = 0.0;
+        poDS->m_gt.yrot = 0.0;
+        poDS->m_gt.yscale = (dfLRY - dfULY) / (poDS->nRasterYSize - 1);
 
-        poDS->m_gt[0] = dfULX - poDS->m_gt[1] * 0.5;
-        poDS->m_gt[3] = dfULY - poDS->m_gt[5] * 0.5;
+        poDS->m_gt.xorig = dfULX - poDS->m_gt.xscale * 0.5;
+        poDS->m_gt.yorig = dfULY - poDS->m_gt.yscale * 0.5;
 
         poDS->bGotTransform = true;
     }

--- a/frmts/raw/gscdataset.cpp
+++ b/frmts/raw/gscdataset.cpp
@@ -165,12 +165,12 @@ GDALDataset *GSCDataset::Open(GDALOpenInfo *poOpenInfo)
         CPL_LSBPTR32(afHeaderInfo + i);
     }
 
-    poDS->m_gt[0] = afHeaderInfo[2];
-    poDS->m_gt[1] = afHeaderInfo[0];
-    poDS->m_gt[2] = 0.0;
-    poDS->m_gt[3] = afHeaderInfo[5];
-    poDS->m_gt[4] = 0.0;
-    poDS->m_gt[5] = -afHeaderInfo[1];
+    poDS->m_gt.xorig = afHeaderInfo[2];
+    poDS->m_gt.xscale = afHeaderInfo[0];
+    poDS->m_gt.xrot = 0.0;
+    poDS->m_gt.yorig = afHeaderInfo[5];
+    poDS->m_gt.yrot = 0.0;
+    poDS->m_gt.yscale = -afHeaderInfo[1];
 
     /* -------------------------------------------------------------------- */
     /*      Create band information objects.                                */

--- a/frmts/raw/iscedataset.cpp
+++ b/frmts/raw/iscedataset.cpp
@@ -340,7 +340,7 @@ CPLErr ISCEDataset::FlushCache(bool bAtClosing)
     GDALGeoTransform gt;
     if (GetGeoTransform(gt) == CE_None)
     {
-        if (gt[2] != 0 || gt[4] != 0)
+        if (gt.xrot != 0 || gt.yrot != 0)
         {
             CPLError(CE_Warning, CPLE_AppDefined,
                      "ISCE format do not support geotransform with "
@@ -348,25 +348,25 @@ CPLErr ISCEDataset::FlushCache(bool bAtClosing)
         }
         else
         {
-            CPLsnprintf(sBuf, sizeof(sBuf), "%g", gt[0]);
+            CPLsnprintf(sBuf, sizeof(sBuf), "%g", gt.xorig);
             psTmpNode =
                 CPLCreateXMLNode(psCoordinate1Node, CXT_Element, "property");
             CPLAddXMLAttributeAndValue(psTmpNode, "name", "startingValue");
             CPLCreateXMLElementAndValue(psTmpNode, "value", sBuf);
 
-            CPLsnprintf(sBuf, sizeof(sBuf), "%g", gt[1]);
+            CPLsnprintf(sBuf, sizeof(sBuf), "%g", gt.xscale);
             psTmpNode =
                 CPLCreateXMLNode(psCoordinate1Node, CXT_Element, "property");
             CPLAddXMLAttributeAndValue(psTmpNode, "name", "delta");
             CPLCreateXMLElementAndValue(psTmpNode, "value", sBuf);
 
-            CPLsnprintf(sBuf, sizeof(sBuf), "%g", gt[3]);
+            CPLsnprintf(sBuf, sizeof(sBuf), "%g", gt.yorig);
             psTmpNode =
                 CPLCreateXMLNode(psCoordinate2Node, CXT_Element, "property");
             CPLAddXMLAttributeAndValue(psTmpNode, "name", "startingValue");
             CPLCreateXMLElementAndValue(psTmpNode, "value", sBuf);
 
-            CPLsnprintf(sBuf, sizeof(sBuf), "%g", gt[5]);
+            CPLsnprintf(sBuf, sizeof(sBuf), "%g", gt.yscale);
             psTmpNode =
                 CPLCreateXMLNode(psCoordinate2Node, CXT_Element, "property");
             CPLAddXMLAttributeAndValue(psTmpNode, "name", "delta");
@@ -695,12 +695,14 @@ GDALDataset *ISCEDataset::Open(GDALOpenInfo *poOpenInfo, bool bFileSizeCheck)
         aosXmlProps.FetchNameValue("Coordinate2delta") != nullptr)
     {
         GDALGeoTransform gt;
-        gt[0] = CPLAtof(aosXmlProps.FetchNameValue("Coordinate1startingValue"));
-        gt[1] = CPLAtof(aosXmlProps.FetchNameValue("Coordinate1delta"));
-        gt[2] = 0.0;
-        gt[3] = CPLAtof(aosXmlProps.FetchNameValue("Coordinate2startingValue"));
-        gt[4] = 0.0;
-        gt[5] = CPLAtof(aosXmlProps.FetchNameValue("Coordinate2delta"));
+        gt.xorig =
+            CPLAtof(aosXmlProps.FetchNameValue("Coordinate1startingValue"));
+        gt.xscale = CPLAtof(aosXmlProps.FetchNameValue("Coordinate1delta"));
+        gt.xrot = 0.0;
+        gt.yorig =
+            CPLAtof(aosXmlProps.FetchNameValue("Coordinate2startingValue"));
+        gt.yrot = 0.0;
+        gt.yscale = CPLAtof(aosXmlProps.FetchNameValue("Coordinate2delta"));
         poDS->SetGeoTransform(gt);
 
         /* ISCE format seems not to have a projection field, but uses   */

--- a/frmts/raw/landataset.cpp
+++ b/frmts/raw/landataset.cpp
@@ -509,24 +509,24 @@ GDALDataset *LANDataset::Open(GDALOpenInfo *poOpenInfo)
     float fTmp = 0.0;
 
     memcpy(&fTmp, poDS->pachHeader + 112, 4);
-    poDS->m_gt[0] = fTmp;
+    poDS->m_gt.xorig = fTmp;
     memcpy(&fTmp, poDS->pachHeader + 120, 4);
-    poDS->m_gt[1] = fTmp;
-    poDS->m_gt[2] = 0.0;
+    poDS->m_gt.xscale = fTmp;
+    poDS->m_gt.xrot = 0.0;
     memcpy(&fTmp, poDS->pachHeader + 116, 4);
-    poDS->m_gt[3] = fTmp;
-    poDS->m_gt[4] = 0.0;
+    poDS->m_gt.yorig = fTmp;
+    poDS->m_gt.yrot = 0.0;
     memcpy(&fTmp, poDS->pachHeader + 124, 4);
-    poDS->m_gt[5] = -fTmp;
+    poDS->m_gt.yscale = -fTmp;
 
     // adjust for center of pixel vs. top left corner of pixel.
-    poDS->m_gt[0] -= poDS->m_gt[1] * 0.5;
-    poDS->m_gt[3] -= poDS->m_gt[5] * 0.5;
+    poDS->m_gt.xorig -= poDS->m_gt.xscale * 0.5;
+    poDS->m_gt.yorig -= poDS->m_gt.yscale * 0.5;
 
     /* -------------------------------------------------------------------- */
     /*      If we didn't get any georeferencing, try for a worldfile.       */
     /* -------------------------------------------------------------------- */
-    if (poDS->m_gt[1] == 0.0 || poDS->m_gt[5] == 0.0)
+    if (poDS->m_gt.xscale == 0.0 || poDS->m_gt.yscale == 0.0)
     {
         if (!GDALReadWorldFile(poOpenInfo->pszFilename, nullptr,
                                poDS->m_gt.data()))
@@ -614,7 +614,7 @@ GDALDataset *LANDataset::Open(GDALOpenInfo *poOpenInfo)
 CPLErr LANDataset::GetGeoTransform(GDALGeoTransform &gt) const
 
 {
-    if (m_gt[1] != 0.0 && m_gt[5] != 0.0)
+    if (m_gt.xscale != 0.0 && m_gt.yscale != 0.0)
     {
         gt = m_gt;
         return CE_None;

--- a/frmts/raw/lcpdataset.cpp
+++ b/frmts/raw/lcpdataset.cpp
@@ -143,13 +143,13 @@ CPLErr LCPDataset::GetGeoTransform(GDALGeoTransform &gt) const
     CPL_LSBPTR64(&dfCellX);
     CPL_LSBPTR64(&dfCellY);
 
-    gt[0] = dfWest;
-    gt[3] = dfNorth;
-    gt[1] = dfCellX;
-    gt[2] = 0.0;
+    gt.xorig = dfWest;
+    gt.yorig = dfNorth;
+    gt.xscale = dfCellX;
+    gt.xrot = 0.0;
 
-    gt[4] = 0.0;
-    gt[5] = -1 * dfCellY;
+    gt.yrot = 0.0;
+    gt.yscale = -1 * dfCellY;
 
     return CE_None;
 }

--- a/frmts/raw/loslasdataset.cpp
+++ b/frmts/raw/loslasdataset.cpp
@@ -261,12 +261,12 @@ GDALDataset *LOSLASDataset::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Setup georeferencing.                                           */
     /* -------------------------------------------------------------------- */
-    poDS->m_gt[0] = min_lon - delta_lon * 0.5;
-    poDS->m_gt[1] = delta_lon;
-    poDS->m_gt[2] = 0.0;
-    poDS->m_gt[3] = min_lat + (poDS->nRasterYSize - 0.5) * delta_lat;
-    poDS->m_gt[4] = 0.0;
-    poDS->m_gt[5] = -1.0 * delta_lat;
+    poDS->m_gt.xorig = min_lon - delta_lon * 0.5;
+    poDS->m_gt.xscale = delta_lon;
+    poDS->m_gt.xrot = 0.0;
+    poDS->m_gt.yorig = min_lat + (poDS->nRasterYSize - 0.5) * delta_lat;
+    poDS->m_gt.yrot = 0.0;
+    poDS->m_gt.yscale = -1.0 * delta_lat;
 
     /* -------------------------------------------------------------------- */
     /*      Initialize any PAM information.                                 */

--- a/frmts/raw/ndfdataset.cpp
+++ b/frmts/raw/ndfdataset.cpp
@@ -382,23 +382,23 @@ GDALDataset *NDFDataset::Open(GDALOpenInfo *poOpenInfo)
     if (CSLCount(papszUL) == 4 && CSLCount(papszUR) == 4 &&
         CSLCount(papszLL) == 4)
     {
-        poDS->m_gt[0] = CPLAtof(papszUL[2]);
-        poDS->m_gt[1] = (CPLAtof(papszUR[2]) - CPLAtof(papszUL[2])) /
-                        (poDS->nRasterXSize - 1);
-        poDS->m_gt[2] = (CPLAtof(papszUR[3]) - CPLAtof(papszUL[3])) /
-                        (poDS->nRasterXSize - 1);
+        poDS->m_gt.xorig = CPLAtof(papszUL[2]);
+        poDS->m_gt.xscale = (CPLAtof(papszUR[2]) - CPLAtof(papszUL[2])) /
+                            (poDS->nRasterXSize - 1);
+        poDS->m_gt.xrot = (CPLAtof(papszUR[3]) - CPLAtof(papszUL[3])) /
+                          (poDS->nRasterXSize - 1);
 
-        poDS->m_gt[3] = CPLAtof(papszUL[3]);
-        poDS->m_gt[4] = (CPLAtof(papszLL[2]) - CPLAtof(papszUL[2])) /
-                        (poDS->nRasterYSize - 1);
-        poDS->m_gt[5] = (CPLAtof(papszLL[3]) - CPLAtof(papszUL[3])) /
-                        (poDS->nRasterYSize - 1);
+        poDS->m_gt.yorig = CPLAtof(papszUL[3]);
+        poDS->m_gt.yrot = (CPLAtof(papszLL[2]) - CPLAtof(papszUL[2])) /
+                          (poDS->nRasterYSize - 1);
+        poDS->m_gt.yscale = (CPLAtof(papszLL[3]) - CPLAtof(papszUL[3])) /
+                            (poDS->nRasterYSize - 1);
 
         // Move origin up-left half a pixel.
-        poDS->m_gt[0] -= poDS->m_gt[1] * 0.5;
-        poDS->m_gt[0] -= poDS->m_gt[4] * 0.5;
-        poDS->m_gt[3] -= poDS->m_gt[2] * 0.5;
-        poDS->m_gt[3] -= poDS->m_gt[5] * 0.5;
+        poDS->m_gt.xorig -= poDS->m_gt.xscale * 0.5;
+        poDS->m_gt.xorig -= poDS->m_gt.yrot * 0.5;
+        poDS->m_gt.yorig -= poDS->m_gt.xrot * 0.5;
+        poDS->m_gt.yorig -= poDS->m_gt.yscale * 0.5;
     }
 
     CSLDestroy(papszUL);

--- a/frmts/raw/noaabdataset.cpp
+++ b/frmts/raw/noaabdataset.cpp
@@ -258,12 +258,12 @@ GDALDataset *NOAA_B_Dataset::Open(GDALOpenInfo *poOpenInfo)
 
     // Convert from south-west center-of-pixel convention to
     // north-east pixel-corner convention
-    poDS->m_gt[0] = dfSWLon - dfDeltaLon / 2;
-    poDS->m_gt[1] = dfDeltaLon;
-    poDS->m_gt[2] = 0.0;
-    poDS->m_gt[3] = dfSWLat + (nRows - 1) * dfDeltaLat + dfDeltaLat / 2;
-    poDS->m_gt[4] = 0.0;
-    poDS->m_gt[5] = -dfDeltaLat;
+    poDS->m_gt.xorig = dfSWLon - dfDeltaLon / 2;
+    poDS->m_gt.xscale = dfDeltaLon;
+    poDS->m_gt.xrot = 0.0;
+    poDS->m_gt.yorig = dfSWLat + (nRows - 1) * dfDeltaLat + dfDeltaLat / 2;
+    poDS->m_gt.yrot = 0.0;
+    poDS->m_gt.yscale = -dfDeltaLat;
 
     /* -------------------------------------------------------------------- */
     /*      Create band information object.                                 */

--- a/frmts/raw/nsidcbindataset.cpp
+++ b/frmts/raw/nsidcbindataset.cpp
@@ -325,23 +325,23 @@ GDALDataset *NSIDCbinDataset::Open(GDALOpenInfo *poOpenInfo)
     int epsg = -1;
     if (south)
     {
-        poDS->m_gt[0] = -3950000.0;
-        poDS->m_gt[1] = 25000;
-        poDS->m_gt[2] = 0.0;
-        poDS->m_gt[3] = 4350000.0;
-        poDS->m_gt[4] = 0.0;
-        poDS->m_gt[5] = -25000;
+        poDS->m_gt.xorig = -3950000.0;
+        poDS->m_gt.xscale = 25000;
+        poDS->m_gt.xrot = 0.0;
+        poDS->m_gt.yorig = 4350000.0;
+        poDS->m_gt.yrot = 0.0;
+        poDS->m_gt.yscale = -25000;
 
         epsg = 3976;
     }
     else
     {
-        poDS->m_gt[0] = -3837500;
-        poDS->m_gt[1] = 25000;
-        poDS->m_gt[2] = 0.0;
-        poDS->m_gt[3] = 5837500;
-        poDS->m_gt[4] = 0.0;
-        poDS->m_gt[5] = -25000;
+        poDS->m_gt.xorig = -3837500;
+        poDS->m_gt.xscale = 25000;
+        poDS->m_gt.xrot = 0.0;
+        poDS->m_gt.yorig = 5837500;
+        poDS->m_gt.yrot = 0.0;
+        poDS->m_gt.yscale = -25000;
 
         epsg = 3413;
     }

--- a/frmts/raw/ntv2dataset.cpp
+++ b/frmts/raw/ntv2dataset.cpp
@@ -508,12 +508,12 @@ bool NTv2Dataset::OpenGrid(const char *pachHeader, vsi_l_offset nGridOffsetIn)
     /* -------------------------------------------------------------------- */
     /*      Setup georeferencing.                                           */
     /* -------------------------------------------------------------------- */
-    m_gt[0] = (w_long - long_inc * 0.5) / 3600.0;
-    m_gt[1] = long_inc / 3600.0;
-    m_gt[2] = 0.0;
-    m_gt[3] = (n_lat + lat_inc * 0.5) / 3600.0;
-    m_gt[4] = 0.0;
-    m_gt[5] = (-1 * lat_inc) / 3600.0;
+    m_gt.xorig = (w_long - long_inc * 0.5) / 3600.0;
+    m_gt.xscale = long_inc / 3600.0;
+    m_gt.xrot = 0.0;
+    m_gt.yorig = (n_lat + lat_inc * 0.5) / 3600.0;
+    m_gt.yrot = 0.0;
+    m_gt.yscale = (-1 * lat_inc) / 3600.0;
 
     return true;
 }

--- a/frmts/raw/pauxdataset.cpp
+++ b/frmts/raw/pauxdataset.cpp
@@ -450,12 +450,12 @@ CPLErr PAuxDataset::GetGeoTransform(GDALGeoTransform &gt) const
     const double dfLoRightY =
         CPLAtof(CSLFetchNameValue(papszAuxLines, "LoRightY"));
 
-    gt[0] = dfUpLeftX;
-    gt[1] = (dfLoRightX - dfUpLeftX) / GetRasterXSize();
-    gt[2] = 0.0;
-    gt[3] = dfUpLeftY;
-    gt[4] = 0.0;
-    gt[5] = (dfLoRightY - dfUpLeftY) / GetRasterYSize();
+    gt.xorig = dfUpLeftX;
+    gt.xscale = (dfLoRightX - dfUpLeftX) / GetRasterXSize();
+    gt.xrot = 0.0;
+    gt.yorig = dfUpLeftY;
+    gt.yrot = 0.0;
+    gt.yscale = (dfLoRightY - dfUpLeftY) / GetRasterYSize();
 
     return CE_None;
 }

--- a/frmts/raw/roipacdataset.cpp
+++ b/frmts/raw/roipacdataset.cpp
@@ -388,12 +388,12 @@ GDALDataset *ROIPACDataset::Open(GDALOpenInfo *poOpenInfo)
         aosRSC.FetchNameValue("Y_FIRST") != nullptr &&
         aosRSC.FetchNameValue("Y_STEP") != nullptr)
     {
-        poDS->m_gt[0] = CPLAtof(aosRSC.FetchNameValue("X_FIRST"));
-        poDS->m_gt[1] = CPLAtof(aosRSC.FetchNameValue("X_STEP"));
-        poDS->m_gt[2] = 0.0;
-        poDS->m_gt[3] = CPLAtof(aosRSC.FetchNameValue("Y_FIRST"));
-        poDS->m_gt[4] = 0.0;
-        poDS->m_gt[5] = CPLAtof(aosRSC.FetchNameValue("Y_STEP"));
+        poDS->m_gt.xorig = CPLAtof(aosRSC.FetchNameValue("X_FIRST"));
+        poDS->m_gt.xscale = CPLAtof(aosRSC.FetchNameValue("X_STEP"));
+        poDS->m_gt.xrot = 0.0;
+        poDS->m_gt.yorig = CPLAtof(aosRSC.FetchNameValue("Y_FIRST"));
+        poDS->m_gt.yrot = 0.0;
+        poDS->m_gt.yscale = CPLAtof(aosRSC.FetchNameValue("Y_STEP"));
         poDS->bValidGeoTransform = true;
     }
     if (aosRSC.FetchNameValue("PROJECTION") != nullptr)
@@ -730,7 +730,7 @@ CPLErr ROIPACDataset::FlushCache(bool bAtClosing)
     }
     if (bValidGeoTransform)
     {
-        if (m_gt[2] != 0 || m_gt[4] != 0)
+        if (m_gt.xrot != 0 || m_gt.yrot != 0)
         {
             CPLError(CE_Warning, CPLE_AppDefined,
                      "ROI_PAC format do not support geotransform with "
@@ -738,10 +738,14 @@ CPLErr ROIPACDataset::FlushCache(bool bAtClosing)
         }
         else
         {
-            bOK &= VSIFPrintfL(fpRsc, "%-40s %.16g\n", "X_FIRST", m_gt[0]) > 0;
-            bOK &= VSIFPrintfL(fpRsc, "%-40s %.16g\n", "X_STEP", m_gt[1]) > 0;
-            bOK &= VSIFPrintfL(fpRsc, "%-40s %.16g\n", "Y_FIRST", m_gt[3]) > 0;
-            bOK &= VSIFPrintfL(fpRsc, "%-40s %.16g\n", "Y_STEP", m_gt[5]) > 0;
+            bOK &=
+                VSIFPrintfL(fpRsc, "%-40s %.16g\n", "X_FIRST", m_gt.xorig) > 0;
+            bOK &=
+                VSIFPrintfL(fpRsc, "%-40s %.16g\n", "X_STEP", m_gt.xscale) > 0;
+            bOK &=
+                VSIFPrintfL(fpRsc, "%-40s %.16g\n", "Y_FIRST", m_gt.yorig) > 0;
+            bOK &=
+                VSIFPrintfL(fpRsc, "%-40s %.16g\n", "Y_STEP", m_gt.yscale) > 0;
             bOK &= VSIFPrintfL(fpRsc, "%-40s %.16g\n", "Z_OFFSET",
                                band->GetOffset(nullptr)) > 0;
             bOK &= VSIFPrintfL(fpRsc, "%-40s %.16g\n", "Z_SCALE",

--- a/frmts/raw/rrasterdataset.cpp
+++ b/frmts/raw/rrasterdataset.cpp
@@ -751,10 +751,10 @@ void RRASTERDataset::RewriteHeader()
     VSIFPrintfL(fp, "nrows=%d\n", nRasterYSize);
     VSIFPrintfL(fp, "ncols=%d\n", nRasterXSize);
 
-    VSIFPrintfL(fp, "xmin=%.17g\n", m_gt[0]);
-    VSIFPrintfL(fp, "ymin=%.17g\n", m_gt[3] + nRasterYSize * m_gt[5]);
-    VSIFPrintfL(fp, "xmax=%.17g\n", m_gt[0] + nRasterXSize * m_gt[1]);
-    VSIFPrintfL(fp, "ymax=%.17g\n", m_gt[3]);
+    VSIFPrintfL(fp, "xmin=%.17g\n", m_gt.xorig);
+    VSIFPrintfL(fp, "ymin=%.17g\n", m_gt.yorig + nRasterYSize * m_gt.yscale);
+    VSIFPrintfL(fp, "xmax=%.17g\n", m_gt.xorig + nRasterXSize * m_gt.xscale);
+    VSIFPrintfL(fp, "ymax=%.17g\n", m_gt.yorig);
 
     if (!m_oSRS.IsEmpty())
     {
@@ -821,7 +821,7 @@ CPLErr RRASTERDataset::SetGeoTransform(const GDALGeoTransform &gt)
     }
 
     // We only support non-rotated images with info in the .HDR file.
-    if (gt[2] != 0.0 || gt[4] != 0.0)
+    if (gt.xrot != 0.0 || gt.yrot != 0.0)
     {
         CPLError(CE_Warning, CPLE_NotSupported,
                  "Rotated / skewed images not supported");
@@ -1215,12 +1215,12 @@ GDALDataset *RRASTERDataset::Open(GDALOpenInfo *poOpenInfo)
     poDS->nRasterXSize = nCols;
     poDS->nRasterYSize = nRows;
     poDS->m_bGeoTransformValid = true;
-    poDS->m_gt[0] = dfXMin;
-    poDS->m_gt[1] = (dfXMax - dfXMin) / nCols;
-    poDS->m_gt[2] = 0.0;
-    poDS->m_gt[3] = dfYMax;
-    poDS->m_gt[4] = 0.0;
-    poDS->m_gt[5] = -(dfYMax - dfYMin) / nRows;
+    poDS->m_gt.xorig = dfXMin;
+    poDS->m_gt.xscale = (dfXMax - dfXMin) / nCols;
+    poDS->m_gt.xrot = 0.0;
+    poDS->m_gt.yorig = dfYMax;
+    poDS->m_gt.yrot = 0.0;
+    poDS->m_gt.yscale = -(dfYMax - dfYMin) / nRows;
     poDS->m_fpImage = fpImage;
     poDS->m_bNativeOrder = bNativeOrder;
 

--- a/frmts/raw/snodasdataset.cpp
+++ b/frmts/raw/snodasdataset.cpp
@@ -454,12 +454,12 @@ GDALDataset *SNODASDataset::Open(GDALOpenInfo *poOpenInfo)
     if (bHasMinX && bHasMinY && bHasMaxX && bHasMaxY)
     {
         poDS->bGotTransform = true;
-        poDS->m_gt[0] = dfMinX;
-        poDS->m_gt[1] = (dfMaxX - dfMinX) / nCols;
-        poDS->m_gt[2] = 0.0;
-        poDS->m_gt[3] = dfMaxY;
-        poDS->m_gt[4] = 0.0;
-        poDS->m_gt[5] = -(dfMaxY - dfMinY) / nRows;
+        poDS->m_gt.xorig = dfMinX;
+        poDS->m_gt.xscale = (dfMaxX - dfMinX) / nCols;
+        poDS->m_gt.xrot = 0.0;
+        poDS->m_gt.yorig = dfMaxY;
+        poDS->m_gt.yrot = 0.0;
+        poDS->m_gt.yscale = -(dfMaxY - dfMinY) / nRows;
     }
 
     if (!osDescription.empty())

--- a/frmts/rcm/rcmdataset.cpp
+++ b/frmts/rcm/rcmdataset.cpp
@@ -2113,12 +2113,14 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
                 CPLGetXMLValue(psPos, "upperRightCorner.mapCoordinate.northing",
                                "0.0"),
                 nullptr);
-            poDS->m_gt[1] = (tr_x - tl_x) / (poDS->nRasterXSize - 1);
-            poDS->m_gt[4] = (tr_y - tl_y) / (poDS->nRasterXSize - 1);
-            poDS->m_gt[2] = (bl_x - tl_x) / (poDS->nRasterYSize - 1);
-            poDS->m_gt[5] = (bl_y - tl_y) / (poDS->nRasterYSize - 1);
-            poDS->m_gt[0] = (tl_x - 0.5 * poDS->m_gt[1] - 0.5 * poDS->m_gt[2]);
-            poDS->m_gt[3] = (tl_y - 0.5 * poDS->m_gt[4] - 0.5 * poDS->m_gt[5]);
+            poDS->m_gt.xscale = (tr_x - tl_x) / (poDS->nRasterXSize - 1);
+            poDS->m_gt.yrot = (tr_y - tl_y) / (poDS->nRasterXSize - 1);
+            poDS->m_gt.xrot = (bl_x - tl_x) / (poDS->nRasterYSize - 1);
+            poDS->m_gt.yscale = (bl_y - tl_y) / (poDS->nRasterYSize - 1);
+            poDS->m_gt.xorig =
+                (tl_x - 0.5 * poDS->m_gt.xscale - 0.5 * poDS->m_gt.xrot);
+            poDS->m_gt.yorig =
+                (tl_y - 0.5 * poDS->m_gt.yrot - 0.5 * poDS->m_gt.yscale);
 
             /* Use bottom right pixel to test geotransform */
             const double br_x = CPLStrtod(
@@ -2129,19 +2131,20 @@ GDALDataset *RCMDataset::Open(GDALOpenInfo *poOpenInfo)
                 CPLGetXMLValue(psPos, "lowerRightCorner.mapCoordinate.northing",
                                "0.0"),
                 nullptr);
-            const double testx = poDS->m_gt[0] +
-                                 poDS->m_gt[1] * (poDS->nRasterXSize - 0.5) +
-                                 poDS->m_gt[2] * (poDS->nRasterYSize - 0.5);
-            const double testy = poDS->m_gt[3] +
-                                 poDS->m_gt[4] * (poDS->nRasterXSize - 0.5) +
-                                 poDS->m_gt[5] * (poDS->nRasterYSize - 0.5);
+            const double testx =
+                poDS->m_gt.xorig +
+                poDS->m_gt.xscale * (poDS->nRasterXSize - 0.5) +
+                poDS->m_gt.xrot * (poDS->nRasterYSize - 0.5);
+            const double testy = poDS->m_gt.yorig +
+                                 poDS->m_gt.yrot * (poDS->nRasterXSize - 0.5) +
+                                 poDS->m_gt.yscale * (poDS->nRasterYSize - 0.5);
 
             /* Give 1/4 pixel numerical error leeway in calculating location
             based on affine transform */
             if ((fabs(testx - br_x) >
-                 fabs(0.25 * (poDS->m_gt[1] + poDS->m_gt[2]))) ||
+                 fabs(0.25 * (poDS->m_gt.xscale + poDS->m_gt.xrot))) ||
                 (fabs(testy - br_y) >
-                 fabs(0.25 * (poDS->m_gt[4] + poDS->m_gt[5]))))
+                 fabs(0.25 * (poDS->m_gt.yrot + poDS->m_gt.yscale))))
             {
                 CPLError(CE_Warning, CPLE_AppDefined,
                          "WARNING: Unexpected error in calculating affine "

--- a/frmts/rik/rikdataset.cpp
+++ b/frmts/rik/rikdataset.cpp
@@ -1210,12 +1210,12 @@ GDALDataset *RIKDataset::Open(GDALOpenInfo *poOpenInfo)
     poDS->fp = poOpenInfo->fpL;
     poOpenInfo->fpL = nullptr;
 
-    poDS->m_gt[0] = header.fWest - metersPerPixel / 2.0;
-    poDS->m_gt[1] = metersPerPixel;
-    poDS->m_gt[2] = 0.0;
-    poDS->m_gt[3] = header.fNorth + metersPerPixel / 2.0;
-    poDS->m_gt[4] = 0.0;
-    poDS->m_gt[5] = -metersPerPixel;
+    poDS->m_gt.xorig = header.fWest - metersPerPixel / 2.0;
+    poDS->m_gt.xscale = metersPerPixel;
+    poDS->m_gt.xrot = 0.0;
+    poDS->m_gt.yorig = header.fNorth + metersPerPixel / 2.0;
+    poDS->m_gt.yrot = 0.0;
+    poDS->m_gt.yscale = -metersPerPixel;
 
     poDS->nBlockXSize = header.iBlockWidth;
     poDS->nBlockYSize = header.iBlockHeight;

--- a/frmts/saga/sagadataset.cpp
+++ b/frmts/saga/sagadataset.cpp
@@ -717,15 +717,15 @@ CPLErr SAGADataset::GetGeoTransform(GDALGeoTransform &gt) const
     if (eErr == CE_None)
         return CE_None;
 
-    gt[1] = poGRB->m_Cellsize;
-    gt[5] = poGRB->m_Cellsize * -1.0;
-    gt[0] = poGRB->m_Xmin - poGRB->m_Cellsize / 2;
-    gt[3] = poGRB->m_Ymin + (nRasterYSize - 1) * poGRB->m_Cellsize +
-            poGRB->m_Cellsize / 2;
+    gt.xscale = poGRB->m_Cellsize;
+    gt.yscale = poGRB->m_Cellsize * -1.0;
+    gt.xorig = poGRB->m_Xmin - poGRB->m_Cellsize / 2;
+    gt.yorig = poGRB->m_Ymin + (nRasterYSize - 1) * poGRB->m_Cellsize +
+               poGRB->m_Cellsize / 2;
 
     /* tilt/rotation is not supported by SAGA grids */
-    gt[4] = 0.0;
-    gt[2] = 0.0;
+    gt.yrot = 0.0;
+    gt.xrot = 0.0;
 
     return CE_None;
 }
@@ -749,7 +749,7 @@ CPLErr SAGADataset::SetGeoTransform(const GDALGeoTransform &gt)
     if (poGRB == nullptr)
         return CE_Failure;
 
-    if (gt[1] != gt[5] * -1.0)
+    if (gt.xscale != gt.yscale * -1.0)
     {
         CPLError(CE_Failure, CPLE_NotSupported,
                  "Unable to set GeoTransform, SAGA binary grids only support "
@@ -757,12 +757,12 @@ CPLErr SAGADataset::SetGeoTransform(const GDALGeoTransform &gt)
         return CE_Failure;
     }
 
-    const double dfMinX = gt[0] + gt[1] / 2;
-    const double dfMinY = gt[5] * (nRasterYSize - 0.5) + gt[3];
+    const double dfMinX = gt.xorig + gt.xscale / 2;
+    const double dfMinY = gt.yscale * (nRasterYSize - 0.5) + gt.yorig;
 
     poGRB->m_Xmin = dfMinX;
     poGRB->m_Ymin = dfMinY;
-    poGRB->m_Cellsize = gt[1];
+    poGRB->m_Cellsize = gt.xscale;
     headerDirty = true;
 
     return CE_None;

--- a/frmts/sigdem/sigdemdataset.cpp
+++ b/frmts/sigdem/sigdemdataset.cpp
@@ -135,12 +135,12 @@ SIGDEMDataset::SIGDEMDataset(const SIGDEMHeader &sHeaderIn)
     this->nRasterXSize = sHeader.nCols;
     this->nRasterYSize = sHeader.nRows;
 
-    m_gt[0] = sHeader.dfMinX;
-    m_gt[1] = sHeader.dfXDim;
-    m_gt[2] = 0.0;
-    m_gt[3] = sHeader.dfMaxY;
-    m_gt[4] = 0.0;
-    m_gt[5] = -sHeader.dfYDim;
+    m_gt.xorig = sHeader.dfMinX;
+    m_gt.xscale = sHeader.dfXDim;
+    m_gt.xrot = 0.0;
+    m_gt.yorig = sHeader.dfMaxY;
+    m_gt.yrot = 0.0;
+    m_gt.yscale = -sHeader.dfYDim;
 }
 
 SIGDEMDataset::~SIGDEMDataset()
@@ -196,7 +196,7 @@ GDALDataset *SIGDEMDataset::CreateCopy(const char *pszFilename,
 
     SIGDEMHeader sHeader;
     sHeader.nCoordinateSystemId = nCoordinateSystemId;
-    sHeader.dfMinX = gt[0];
+    sHeader.dfMinX = gt.xorig;
     const char *pszMin = band->GetMetadataItem("STATISTICS_MINIMUM");
     if (pszMin == nullptr)
     {
@@ -206,7 +206,7 @@ GDALDataset *SIGDEMDataset::CreateCopy(const char *pszFilename,
     {
         sHeader.dfMinZ = CPLAtof(pszMin);
     }
-    sHeader.dfMaxY = gt[3];
+    sHeader.dfMaxY = gt.yorig;
     const char *pszMax = band->GetMetadataItem("STATISTICS_MAXIMUM");
     if (pszMax == nullptr)
     {
@@ -218,8 +218,8 @@ GDALDataset *SIGDEMDataset::CreateCopy(const char *pszFilename,
     }
     sHeader.nCols = poSrcDS->GetRasterXSize();
     sHeader.nRows = poSrcDS->GetRasterYSize();
-    sHeader.dfXDim = gt[1];
-    sHeader.dfYDim = -gt[5];
+    sHeader.dfXDim = gt.xscale;
+    sHeader.dfYDim = -gt.yscale;
     sHeader.dfMaxX = sHeader.dfMinX + sHeader.nCols * sHeader.dfXDim;
     sHeader.dfMinY = sHeader.dfMaxY - sHeader.nRows * sHeader.dfYDim;
     sHeader.dfOffsetX = sHeader.dfMinX;

--- a/frmts/srtmhgt/srtmhgtdataset.cpp
+++ b/frmts/srtmhgt/srtmhgtdataset.cpp
@@ -479,12 +479,12 @@ GDALPamDataset *SRTMHGTDataset::OpenPAM(GDALOpenInfo *poOpenInfo)
     poDS->nRasterYSize = numPixels_y;
     poDS->nBands = 1;
 
-    poDS->m_gt[0] = southWestLon - 0.5 / (numPixels_x - 1);
-    poDS->m_gt[1] = 1.0 / (numPixels_x - 1);
-    poDS->m_gt[2] = 0.0;
-    poDS->m_gt[3] = southWestLat + 1 + 0.5 / (numPixels_y - 1);
-    poDS->m_gt[4] = 0.0;
-    poDS->m_gt[5] = -1.0 / (numPixels_y - 1);
+    poDS->m_gt.xorig = southWestLon - 0.5 / (numPixels_x - 1);
+    poDS->m_gt.xscale = 1.0 / (numPixels_x - 1);
+    poDS->m_gt.xrot = 0.0;
+    poDS->m_gt.yorig = southWestLat + 1 + 0.5 / (numPixels_y - 1);
+    poDS->m_gt.yrot = 0.0;
+    poDS->m_gt.yscale = -1.0 / (numPixels_y - 1);
 
     poDS->SetMetadataItem(GDALMD_AREA_OR_POINT, GDALMD_AOP_POINT);
 
@@ -567,13 +567,13 @@ GDALDataset *SRTMHGTDataset::CreateCopy(const char *pszFilename,
     }
 
     const int nLLOriginLat = static_cast<int>(
-        std::floor(gt[3] + poSrcDS->GetRasterYSize() * gt[5] + 0.5));
+        std::floor(gt.yorig + poSrcDS->GetRasterYSize() * gt.yscale + 0.5));
 
-    int nLLOriginLong = static_cast<int>(std::floor(gt[0] + 0.5));
+    int nLLOriginLong = static_cast<int>(std::floor(gt.xorig + 0.5));
 
-    if (std::abs(nLLOriginLat -
-                 (gt[3] + (poSrcDS->GetRasterYSize() - 0.5) * gt[5])) > 1e-10 ||
-        std::abs(nLLOriginLong - (gt[0] + 0.5 * gt[1])) > 1e-10)
+    if (std::abs(nLLOriginLat - (gt.yorig + (poSrcDS->GetRasterYSize() - 0.5) *
+                                                gt.yscale)) > 1e-10 ||
+        std::abs(nLLOriginLong - (gt.xorig + 0.5 * gt.xscale)) > 1e-10)
     {
         CPLError(CE_Warning, CPLE_AppDefined,
                  "The corner coordinates of the source are not properly "

--- a/frmts/stacta/stactadataset.cpp
+++ b/frmts/stacta/stactadataset.cpp
@@ -1300,17 +1300,19 @@ bool STACTADataset::Open(GDALOpenInfo *poOpenInfo)
         }
         else
         {
-            const double dfMinX = m_gt[0];
-            const double dfMaxX = m_gt[0] + GetRasterXSize() * m_gt[1];
-            const double dfMaxY = m_gt[3];
-            const double dfMinY = m_gt[3] + GetRasterYSize() * m_gt[5];
+            const double dfMinX = m_gt.xorig;
+            const double dfMaxX = m_gt.xorig + GetRasterXSize() * m_gt.xscale;
+            const double dfMaxY = m_gt.yorig;
+            const double dfMinY = m_gt.yorig + GetRasterYSize() * m_gt.yscale;
 
-            const double dfOvrMinX = poRawDS->m_gt[0];
+            const double dfOvrMinX = poRawDS->m_gt.xorig;
             const double dfOvrMaxX =
-                poRawDS->m_gt[0] + poRawDS->GetRasterXSize() * poRawDS->m_gt[1];
-            const double dfOvrMaxY = poRawDS->m_gt[3];
+                poRawDS->m_gt.xorig +
+                poRawDS->GetRasterXSize() * poRawDS->m_gt.xscale;
+            const double dfOvrMaxY = poRawDS->m_gt.yorig;
             const double dfOvrMinY =
-                poRawDS->m_gt[3] + poRawDS->GetRasterYSize() * poRawDS->m_gt[5];
+                poRawDS->m_gt.yorig +
+                poRawDS->GetRasterYSize() * poRawDS->m_gt.yscale;
 
             if (fabs(dfMinX - dfOvrMinX) < 1e-10 * fabs(dfMinX) &&
                 fabs(dfMinY - dfOvrMinY) < 1e-10 * fabs(dfMinY) &&
@@ -1529,10 +1531,12 @@ bool STACTARawDataset::InitRaster(GDALDataset *poProtoDS,
         return false;
     }
     m_oSRS.SetAxisMappingStrategy(OAMS_TRADITIONAL_GIS_ORDER);
-    m_gt[0] = oTM.mTopLeftX + m_nMinMetaTileCol * m_nMetaTileWidth * oTM.mResX;
-    m_gt[1] = oTM.mResX;
-    m_gt[3] = oTM.mTopLeftY - m_nMinMetaTileRow * m_nMetaTileHeight * oTM.mResY;
-    m_gt[5] = -oTM.mResY;
+    m_gt.xorig =
+        oTM.mTopLeftX + m_nMinMetaTileCol * m_nMetaTileWidth * oTM.mResX;
+    m_gt.xscale = oTM.mResX;
+    m_gt.yorig =
+        oTM.mTopLeftY - m_nMinMetaTileRow * m_nMetaTileHeight * oTM.mResY;
+    m_gt.yscale = -oTM.mResY;
     SetMetadataItem("INTERLEAVE", "PIXEL", "IMAGE_STRUCTURE");
 
     return true;

--- a/frmts/terragen/terragendataset.cpp
+++ b/frmts/terragen/terragendataset.cpp
@@ -418,12 +418,12 @@ TerragenDataset::TerragenDataset()
     m_dLogSpan[0] = 0.0;
     m_dLogSpan[1] = 0.0;
 
-    m_gt[0] = 0.0;
-    m_gt[1] = m_dSCAL;
-    m_gt[2] = 0.0;
-    m_gt[3] = 0.0;
-    m_gt[4] = 0.0;
-    m_gt[5] = m_dSCAL;
+    m_gt.xorig = 0.0;
+    m_gt.xscale = m_dSCAL;
+    m_gt.xrot = 0.0;
+    m_gt.yorig = 0.0;
+    m_gt.yrot = 0.0;
+    m_gt.yscale = m_dSCAL;
     m_span_m[0] = 0.0;
     m_span_m[1] = 0.0;
     m_span_px[0] = 0.0;
@@ -503,16 +503,16 @@ bool TerragenDataset::write_header()
         */
 
         /* const double m_dDegLongPerPixel =
-              fabs(m_gt[1]); */
+              fabs(m_gt.xscale); */
 
-        const double m_dDegLatPerPixel = std::abs(m_gt[5]);
+        const double m_dDegLatPerPixel = std::abs(m_gt.yscale);
 
         /* const double m_dCenterLongitude =
-              m_gt[0] +
+              m_gt.xorig +
               (0.5 * m_dDegLongPerPixel * (nXSize-1)); */
 
         const double m_dCenterLatitude =
-            m_gt[3] + (0.5 * m_dDegLatPerPixel * (nYSize - 1));
+            m_gt.yorig + (0.5 * m_dDegLatPerPixel * (nYSize - 1));
 
         const double dLatCircum =
             kdEarthCircumEquat *
@@ -792,12 +792,12 @@ int TerragenDataset::LoadFromFile()
     // Make our projection to have origin at the
     // NW corner, and groundscale to match elev scale
     // (i.e., uniform voxels).
-    m_gt[0] = 0.0;
-    m_gt[1] = m_dSCAL;
-    m_gt[2] = 0.0;
-    m_gt[3] = 0.0;
-    m_gt[4] = 0.0;
-    m_gt[5] = m_dSCAL;
+    m_gt.xorig = 0.0;
+    m_gt.xscale = m_dSCAL;
+    m_gt.xrot = 0.0;
+    m_gt.yorig = 0.0;
+    m_gt.yrot = 0.0;
+    m_gt.yscale = m_dSCAL;
 
     /* -------------------------------------------------------------------- */
     /*      Set projection.                                                 */
@@ -870,7 +870,7 @@ CPLErr TerragenDataset::SetGeoTransform(const GDALGeoTransform &gt)
     m_gt = gt;
 
     // Average the projection scales.
-    m_dGroundScale = average(fabs(m_gt[1]), fabs(m_gt[5]));
+    m_dGroundScale = average(fabs(m_gt.xscale), fabs(m_gt.yscale));
     return CE_None;
 }
 

--- a/frmts/til/tildataset.cpp
+++ b/frmts/til/tildataset.cpp
@@ -314,12 +314,12 @@ GDALDataset *TILDataset::Open(GDALOpenInfo *poOpenInfo)
         // https://www.digitalglobe.com/sites/default/files/ISD_External.pdf,
         // ulx=originX and is "Easting of the center of the upper left pixel of
         // the image."
-        gt[0] = CPLAtof(CSLFetchNameValueDef(
-                    papszIMD, "MAP_PROJECTED_PRODUCT.ULX", "0")) -
-                gt[1] / 2;
-        gt[3] = CPLAtof(CSLFetchNameValueDef(
-                    papszIMD, "MAP_PROJECTED_PRODUCT.ULY", "0")) -
-                gt[5] / 2;
+        gt.xorig = CPLAtof(CSLFetchNameValueDef(
+                       papszIMD, "MAP_PROJECTED_PRODUCT.ULX", "0")) -
+                   gt.xscale / 2;
+        gt.yorig = CPLAtof(CSLFetchNameValueDef(
+                       papszIMD, "MAP_PROJECTED_PRODUCT.ULY", "0")) -
+                   gt.yscale / 2;
         poDS->SetGeoTransform(gt);
     }
 

--- a/frmts/usgsdem/usgsdemdataset.cpp
+++ b/frmts/usgsdem/usgsdemdataset.cpp
@@ -366,7 +366,7 @@ CPLErr USGSDEMRasterBand::IReadBlock(CPL_UNUSED int nBlockXOff,
     /* -------------------------------------------------------------------- */
     CPL_IGNORE_RET_VAL(VSIFSeekL(poGDS->fp, poGDS->nDataStartOffset, 0));
 
-    double dfYMin = poGDS->m_gt[3] + (GetYSize() - 0.5) * poGDS->m_gt[5];
+    double dfYMin = poGDS->m_gt.yorig + (GetYSize() - 0.5) * poGDS->m_gt.yscale;
 
     /* -------------------------------------------------------------------- */
     /*      Read all the profiles into the image buffer.                    */
@@ -439,7 +439,7 @@ CPLErr USGSDEMRasterBand::IReadBlock(CPL_UNUSED int nBlockXOff,
         if (poGDS->m_oSRS.IsGeographic())
             dyStart = dyStart / 3600.0;
 
-        double dygap = (dfYMin - dyStart) / poGDS->m_gt[5] + 0.5;
+        double dygap = (dfYMin - dyStart) / poGDS->m_gt.yscale + 0.5;
         if (dygap <= INT_MIN || dygap >= INT_MAX || !std::isfinite(dygap))
         {
             CPLFree(sBuffer.buffer);
@@ -808,12 +808,12 @@ int USGSDEMDataset::LoadFromFile(VSILFILE *InDem)
             static_cast<int>((extent_max.y - extent_min.y) / dydelta + 1.5);
         nRasterXSize = nProfiles;
 
-        m_gt[0] = dxStart - dxdelta / 2.0;
-        m_gt[1] = dxdelta;
-        m_gt[2] = 0.0;
-        m_gt[3] = extent_max.y + dydelta / 2.0;
-        m_gt[4] = 0.0;
-        m_gt[5] = -dydelta;
+        m_gt.xorig = dxStart - dxdelta / 2.0;
+        m_gt.xscale = dxdelta;
+        m_gt.xrot = 0.0;
+        m_gt.yorig = extent_max.y + dydelta / 2.0;
+        m_gt.yrot = 0.0;
+        m_gt.yscale = -dydelta;
     }
     /* -------------------------------------------------------------------- */
     /*      Geographic -- use corners directly.                             */
@@ -825,12 +825,12 @@ int USGSDEMDataset::LoadFromFile(VSILFILE *InDem)
         nRasterXSize = nProfiles;
 
         // Translate extents from arc-seconds to decimal degrees.
-        m_gt[0] = (extent_min.x - dxdelta / 2.0) / 3600.0;
-        m_gt[1] = dxdelta / 3600.0;
-        m_gt[2] = 0.0;
-        m_gt[3] = (extent_max.y + dydelta / 2.0) / 3600.0;
-        m_gt[4] = 0.0;
-        m_gt[5] = (-dydelta) / 3600.0;
+        m_gt.xorig = (extent_min.x - dxdelta / 2.0) / 3600.0;
+        m_gt.xscale = dxdelta / 3600.0;
+        m_gt.xrot = 0.0;
+        m_gt.yorig = (extent_max.y + dydelta / 2.0) / 3600.0;
+        m_gt.yrot = 0.0;
+        m_gt.yscale = (-dydelta) / 3600.0;
     }
 
     // IReadBlock() not ready for more than INT_MAX pixels, and that

--- a/frmts/vrt/vrtdataset.cpp
+++ b/frmts/vrt/vrtdataset.cpp
@@ -314,7 +314,8 @@ CPLXMLNode *VRTDataset::SerializeToXML(const char *pszVRTPathIn)
         CPLSetXMLValue(
             psDSTree, "GeoTransform",
             CPLSPrintf("%24.16e,%24.16e,%24.16e,%24.16e,%24.16e,%24.16e",
-                       m_gt[0], m_gt[1], m_gt[2], m_gt[3], m_gt[4], m_gt[5]));
+                       m_gt.xorig, m_gt.xscale, m_gt.xrot, m_gt.yorig,
+                       m_gt.yrot, m_gt.yscale));
     }
 
     /* -------------------------------------------------------------------- */

--- a/frmts/vrt/vrtprocesseddataset.cpp
+++ b/frmts/vrt/vrtprocesseddataset.cpp
@@ -407,13 +407,13 @@ CPLErr VRTProcessedDataset::Init(const CPLXMLNode *psTree,
     {
         m_bGeoTransformSet = true;
         m_gt = poParentDS->m_gt;
-        m_gt[1] *=
+        m_gt.xscale *=
             static_cast<double>(poParentDS->GetRasterXSize()) / nRasterXSize;
-        m_gt[2] *=
+        m_gt.xrot *=
             static_cast<double>(poParentDS->GetRasterYSize()) / nRasterYSize;
-        m_gt[4] *=
+        m_gt.yrot *=
             static_cast<double>(poParentDS->GetRasterXSize()) / nRasterXSize;
-        m_gt[5] *=
+        m_gt.yscale *=
             static_cast<double>(poParentDS->GetRasterYSize()) / nRasterYSize;
     }
 

--- a/frmts/wcs/gmlcoverage.cpp
+++ b/frmts/wcs/gmlcoverage.cpp
@@ -143,18 +143,18 @@ CPLErr WCSParseGMLCoverage(CPLXMLNode *psXML, int *pnXSize, int *pnYSize,
     if (CSLCount(papszOffset1Tokens) >= 2 &&
         CSLCount(papszOffset2Tokens) >= 2 && poOriginGeometry != nullptr)
     {
-        gt[0] = poOriginGeometry->getX();
-        gt[1] = CPLAtof(papszOffset1Tokens[0]);
-        gt[2] = CPLAtof(papszOffset1Tokens[1]);
-        gt[3] = poOriginGeometry->getY();
-        gt[4] = CPLAtof(papszOffset2Tokens[0]);
-        gt[5] = CPLAtof(papszOffset2Tokens[1]);
+        gt.xorig = poOriginGeometry->getX();
+        gt.xscale = CPLAtof(papszOffset1Tokens[0]);
+        gt.xrot = CPLAtof(papszOffset1Tokens[1]);
+        gt.yorig = poOriginGeometry->getY();
+        gt.yrot = CPLAtof(papszOffset2Tokens[0]);
+        gt.yscale = CPLAtof(papszOffset2Tokens[1]);
 
         // offset from center of pixel.
-        gt[0] -= gt[1] * 0.5;
-        gt[0] -= gt[2] * 0.5;
-        gt[3] -= gt[4] * 0.5;
-        gt[3] -= gt[5] * 0.5;
+        gt.xorig -= gt.xscale * 0.5;
+        gt.xorig -= gt.xrot * 0.5;
+        gt.yorig -= gt.yrot * 0.5;
+        gt.yorig -= gt.yscale * 0.5;
 
         bSuccess = true;
     }

--- a/frmts/wcs/wcsdataset.cpp
+++ b/frmts/wcs/wcsdataset.cpp
@@ -106,19 +106,19 @@ void WCSDataset::SetGeometry(const std::vector<int> &size,
     nRasterXSize = size[0];
     nRasterYSize = size[1];
 
-    m_gt[0] = origin[0];
-    m_gt[1] = offsets[0][0];
-    m_gt[2] = offsets[0].size() == 1 ? 0.0 : offsets[0][1];
-    m_gt[3] = origin[1];
-    m_gt[4] = offsets[1].size() == 1 ? 0.0 : offsets[1][0];
-    m_gt[5] = offsets[1].size() == 1 ? offsets[1][0] : offsets[1][1];
+    m_gt.xorig = origin[0];
+    m_gt.xscale = offsets[0][0];
+    m_gt.xrot = offsets[0].size() == 1 ? 0.0 : offsets[0][1];
+    m_gt.yorig = origin[1];
+    m_gt.yrot = offsets[1].size() == 1 ? 0.0 : offsets[1][0];
+    m_gt.yscale = offsets[1].size() == 1 ? offsets[1][0] : offsets[1][1];
 
     if (!CPLGetXMLBoolean(psService, "OriginAtBoundary"))
     {
-        m_gt[0] -= m_gt[1] * 0.5;
-        m_gt[0] -= m_gt[2] * 0.5;
-        m_gt[3] -= m_gt[4] * 0.5;
-        m_gt[3] -= m_gt[5] * 0.5;
+        m_gt.xorig -= m_gt.xscale * 0.5;
+        m_gt.xorig -= m_gt.xrot * 0.5;
+        m_gt.yorig -= m_gt.yrot * 0.5;
+        m_gt.yorig -= m_gt.yscale * 0.5;
     }
 }
 

--- a/frmts/wcs/wcsdataset100.cpp
+++ b/frmts/wcs/wcsdataset100.cpp
@@ -41,10 +41,10 @@ std::vector<double> WCSDataset100::GetNativeExtent(int nXOff, int nYOff,
 {
     std::vector<double> extent;
     // WCS 1.0 extents are the outer edges of outer pixels.
-    extent.push_back(m_gt[0] + (nXOff)*m_gt[1]);
-    extent.push_back(m_gt[3] + (nYOff + nYSize) * m_gt[5]);
-    extent.push_back(m_gt[0] + (nXOff + nXSize) * m_gt[1]);
-    extent.push_back(m_gt[3] + (nYOff)*m_gt[5]);
+    extent.push_back(m_gt.xorig + (nXOff)*m_gt.xscale);
+    extent.push_back(m_gt.yorig + (nYOff + nYSize) * m_gt.yscale);
+    extent.push_back(m_gt.xorig + (nXOff + nXSize) * m_gt.xscale);
+    extent.push_back(m_gt.yorig + (nYOff)*m_gt.yscale);
     return extent;
 }
 
@@ -247,10 +247,10 @@ bool WCSDataset100::ExtractGridInfo()
     // MapServer have origin at pixel boundary
     if (CPLGetXMLBoolean(psService, "OriginAtBoundary"))
     {
-        m_gt[0] += m_gt[1] * 0.5;
-        m_gt[0] += m_gt[2] * 0.5;
-        m_gt[3] += m_gt[4] * 0.5;
-        m_gt[3] += m_gt[5] * 0.5;
+        m_gt.xorig += m_gt.xscale * 0.5;
+        m_gt.xorig += m_gt.xrot * 0.5;
+        m_gt.yorig += m_gt.yrot * 0.5;
+        m_gt.yorig += m_gt.yscale * 0.5;
     }
 
     /* -------------------------------------------------------------------- */

--- a/frmts/wcs/wcsdataset110.cpp
+++ b/frmts/wcs/wcsdataset110.cpp
@@ -42,36 +42,36 @@ std::vector<double> WCSDataset110::GetNativeExtent(int nXOff, int nYOff,
     std::vector<double> extent;
 
     // outer edges of outer pixels.
-    extent.push_back(m_gt[0] + (nXOff)*m_gt[1]);
-    extent.push_back(m_gt[3] + (nYOff + nYSize) * m_gt[5]);
-    extent.push_back(m_gt[0] + (nXOff + nXSize) * m_gt[1]);
-    extent.push_back(m_gt[3] + (nYOff)*m_gt[5]);
+    extent.push_back(m_gt.xorig + (nXOff)*m_gt.xscale);
+    extent.push_back(m_gt.yorig + (nYOff + nYSize) * m_gt.yscale);
+    extent.push_back(m_gt.xorig + (nXOff + nXSize) * m_gt.xscale);
+    extent.push_back(m_gt.yorig + (nYOff)*m_gt.yscale);
 
     bool no_shrink = CPLGetXMLBoolean(psService, "OuterExtents");
 
     // WCS 1.1 extents are centers of outer pixels.
     if (!no_shrink)
     {
-        extent[2] -= m_gt[1] * 0.5;
-        extent[0] += m_gt[1] * 0.5;
-        extent[1] -= m_gt[5] * 0.5;
-        extent[3] += m_gt[5] * 0.5;
+        extent[2] -= m_gt.xscale * 0.5;
+        extent[0] += m_gt.xscale * 0.5;
+        extent[1] -= m_gt.yscale * 0.5;
+        extent[3] += m_gt.yscale * 0.5;
     }
 
     double dfXStep, dfYStep;
 
     if (!no_shrink)
     {
-        dfXStep = (nXSize / (double)nBufXSize) * m_gt[1];
-        dfYStep = (nYSize / (double)nBufYSize) * m_gt[5];
+        dfXStep = (nXSize / (double)nBufXSize) * m_gt.xscale;
+        dfYStep = (nYSize / (double)nBufYSize) * m_gt.yscale;
         // Carefully adjust bounds for pixel centered values at new
         // sampling density.
         if (nBufXSize != nXSize || nBufYSize != nYSize)
         {
-            extent[0] = nXOff * m_gt[1] + m_gt[0] + dfXStep * 0.5;
+            extent[0] = nXOff * m_gt.xscale + m_gt.xorig + dfXStep * 0.5;
             extent[2] = extent[0] + (nBufXSize - 1) * dfXStep;
 
-            extent[3] = nYOff * m_gt[5] + m_gt[3] + dfYStep * 0.5;
+            extent[3] = nYOff * m_gt.yscale + m_gt.yorig + dfYStep * 0.5;
             extent[1] = extent[3] + (nBufYSize - 1) * dfYStep;
         }
     }
@@ -79,8 +79,8 @@ std::vector<double> WCSDataset110::GetNativeExtent(int nXOff, int nYOff,
     {
         double adjust =
             CPLAtof(CPLGetXMLValue(psService, "BufSizeAdjust", "0.0"));
-        dfXStep = (nXSize / ((double)nBufXSize + adjust)) * m_gt[1];
-        dfYStep = (nYSize / ((double)nBufYSize + adjust)) * m_gt[5];
+        dfXStep = (nXSize / ((double)nBufXSize + adjust)) * m_gt.xscale;
+        dfYStep = (nYSize / ((double)nBufYSize + adjust)) * m_gt.yscale;
     }
 
     extent.push_back(dfXStep);

--- a/frmts/wcs/wcsdataset201.cpp
+++ b/frmts/wcs/wcsdataset201.cpp
@@ -133,10 +133,10 @@ std::vector<double> WCSDataset201::GetNativeExtent(int nXOff, int nYOff,
 {
     std::vector<double> extent;
     // WCS 2.0 extents are the outer edges of outer pixels.
-    extent.push_back(m_gt[0] + (nXOff)*m_gt[1]);
-    extent.push_back(m_gt[3] + (nYOff + nYSize) * m_gt[5]);
-    extent.push_back(m_gt[0] + (nXOff + nXSize) * m_gt[1]);
-    extent.push_back(m_gt[3] + (nYOff)*m_gt[5]);
+    extent.push_back(m_gt.xorig + (nXOff)*m_gt.xscale);
+    extent.push_back(m_gt.yorig + (nYOff + nYSize) * m_gt.yscale);
+    extent.push_back(m_gt.xorig + (nXOff + nXSize) * m_gt.xscale);
+    extent.push_back(m_gt.yorig + (nYOff)*m_gt.yscale);
     return extent;
 }
 
@@ -199,9 +199,9 @@ WCSDataset201::GetCoverageRequest(bool scaled, int nBufXSize, int nBufYSize,
     }
     /*
     std::string a = CPLString().Printf(
-        "%.17g", MAX(m_gt[0], extent[0]));
+        "%.17g", MAX(m_gt.xorig, extent[0]));
     std::string b = CPLString().Printf(
-        "%.17g", MIN(m_gt[0] + nRasterXSize * m_gt[1],
+        "%.17g", MIN(m_gt.xorig + nRasterXSize * m_gt.xscale,
     extent[2]));
     */
 
@@ -223,9 +223,9 @@ WCSDataset201::GetCoverageRequest(bool scaled, int nBufXSize, int nBufYSize,
     }
     /*
     a = CPLString().Printf(
-        "%.17g", MAX(m_gt[3] + nRasterYSize * m_gt[5],
+        "%.17g", MAX(m_gt.yorig + nRasterYSize * m_gt.yscale,
     extent[1])); b = CPLString().Printf(
-        "%.17g", MIN(m_gt[3], extent[3]));
+        "%.17g", MIN(m_gt.yorig, extent[3]));
     */
 
     request +=
@@ -264,9 +264,9 @@ WCSDataset201::GetCoverageRequest(bool scaled, int nBufXSize, int nBufYSize,
         // scaling is expressed in grid axes
         if (CPLGetXMLBoolean(psService, "UseScaleFactor"))
         {
-            double fx = fabs((extent[2] - extent[0]) / m_gt[1] /
+            double fx = fabs((extent[2] - extent[0]) / m_gt.xscale /
                              ((double)nBufXSize + 0.5));
-            double fy = fabs((extent[3] - extent[1]) / m_gt[5] /
+            double fy = fabs((extent[3] - extent[1]) / m_gt.yscale /
                              ((double)nBufYSize + 0.5));
             tmp.Printf("&SCALEFACTOR=%.15g", MIN(fx, fy));
         }

--- a/frmts/wms/gdalwmsdataset.cpp
+++ b/frmts/wms/gdalwmsdataset.cpp
@@ -780,14 +780,14 @@ CPLErr GDALWMSDataset::GetGeoTransform(GDALGeoTransform &gt) const
         gt = GDALGeoTransform();
         return CE_Failure;
     }
-    gt[0] = m_data_window.m_x0;
-    gt[1] = (m_data_window.m_x1 - m_data_window.m_x0) /
-            static_cast<double>(m_data_window.m_sx);
-    gt[2] = 0.0;
-    gt[3] = m_data_window.m_y0;
-    gt[4] = 0.0;
-    gt[5] = (m_data_window.m_y1 - m_data_window.m_y0) /
-            static_cast<double>(m_data_window.m_sy);
+    gt.xorig = m_data_window.m_x0;
+    gt.xscale = (m_data_window.m_x1 - m_data_window.m_x0) /
+                static_cast<double>(m_data_window.m_sx);
+    gt.xrot = 0.0;
+    gt.yorig = m_data_window.m_y0;
+    gt.yrot = 0.0;
+    gt.yscale = (m_data_window.m_y1 - m_data_window.m_y0) /
+                static_cast<double>(m_data_window.m_sy);
     return CE_None;
 }
 

--- a/frmts/zarr/zarr_array.cpp
+++ b/frmts/zarr/zarr_array.cpp
@@ -382,12 +382,12 @@ CPLJSONObject ZarrArray::SerializeSpecialAttributes()
                 else if (!std::isnan(dfXOff) && !std::isnan(dfXRes) &&
                          !std::isnan(dfYOff) && !std::isnan(dfYRes))
                 {
-                    gt[0] = dfXOff;
-                    gt[1] = dfXRes;
-                    gt[2] = 0;  // xrot
-                    gt[3] = dfYOff;
-                    gt[4] = 0;  // yrot
-                    gt[5] = dfYRes;
+                    gt.xorig = dfXOff;
+                    gt.xscale = dfXRes;
+                    gt.xrot = 0;  // xrot
+                    gt.yorig = dfYOff;
+                    gt.yrot = 0;  // yrot
+                    gt.yscale = dfYRes;
                     bAddSpatialProjConvention = true;
                 }
             }
@@ -407,19 +407,19 @@ CPLJSONObject ZarrArray::SerializeSpecialAttributes()
                     oAttrs.Delete(GDALMD_AREA_OR_POINT);
 
                     // Going from GDAL's corner convention to pixel center
-                    gt[0] += 0.5 * gt[1] + 0.5 * gt[2];
-                    gt[3] += 0.5 * gt[4] + 0.5 * gt[5];
+                    gt.xorig += 0.5 * gt.xscale + 0.5 * gt.xrot;
+                    gt.yorig += 0.5 * gt.yrot + 0.5 * gt.yscale;
                     dfWidth -= 1.0;
                     dfHeight -= 1.0;
                 }
 
                 CPLJSONArray oAttrSpatialTransform;
-                oAttrSpatialTransform.Add(gt[1]);  // xres
-                oAttrSpatialTransform.Add(gt[2]);  // xrot
-                oAttrSpatialTransform.Add(gt[0]);  // xoff
-                oAttrSpatialTransform.Add(gt[4]);  // yrot
-                oAttrSpatialTransform.Add(gt[5]);  // yres
-                oAttrSpatialTransform.Add(gt[3]);  // yoff
+                oAttrSpatialTransform.Add(gt.xscale);  // xres
+                oAttrSpatialTransform.Add(gt.xrot);    // xrot
+                oAttrSpatialTransform.Add(gt.xorig);   // xoff
+                oAttrSpatialTransform.Add(gt.yrot);    // yrot
+                oAttrSpatialTransform.Add(gt.yscale);  // yres
+                oAttrSpatialTransform.Add(gt.yorig);   // yoff
 
                 oAttrs.Add("spatial:transform_type", "affine");
                 oAttrs.Add("spatial:transform", oAttrSpatialTransform);

--- a/frmts/zarr/zarrdriver.cpp
+++ b/frmts/zarr/zarrdriver.cpp
@@ -1560,7 +1560,7 @@ CPLErr ZarrDataset::GetGeoTransform(GDALGeoTransform &gt) const
 
 CPLErr ZarrDataset::SetGeoTransform(const GDALGeoTransform &gt)
 {
-    const bool bHasRotatedTerms = (gt[2] != 0 || gt[4] != 0);
+    const bool bHasRotatedTerms = (gt.xrot != 0 || gt.yrot != 0);
 
     if (bHasRotatedTerms)
     {
@@ -1627,7 +1627,7 @@ CPLErr ZarrDataset::SetGeoTransform(const GDALGeoTransform &gt)
             {
                 adfX.reserve(nRasterXSize);
                 for (int i = 0; i < nRasterXSize; ++i)
-                    adfX.emplace_back(m_gt[0] + m_gt[1] * (i + 0.5));
+                    adfX.emplace_back(m_gt.xorig + m_gt.xscale * (i + 0.5));
             }
             catch (const std::exception &)
             {
@@ -1658,7 +1658,7 @@ CPLErr ZarrDataset::SetGeoTransform(const GDALGeoTransform &gt)
         {
             adfY.reserve(nRasterYSize);
             for (int i = 0; i < nRasterYSize; ++i)
-                adfY.emplace_back(m_gt[3] + m_gt[5] * (i + 0.5));
+                adfY.emplace_back(m_gt.yorig + m_gt.yscale * (i + 0.5));
         }
         catch (const std::exception &)
         {

--- a/frmts/zmap/zmapdataset.cpp
+++ b/frmts/zmap/zmapdataset.cpp
@@ -452,20 +452,20 @@ GDALDataset *ZMapDataset::Open(GDALOpenInfo *poOpenInfo)
         const double dfStepX = (dfMaxX - dfMinX) / (nCols - 1);
         const double dfStepY = (dfMaxY - dfMinY) / (nRows - 1);
 
-        poDS->m_gt[0] = dfMinX - dfStepX / 2;
-        poDS->m_gt[1] = dfStepX;
-        poDS->m_gt[3] = dfMaxY + dfStepY / 2;
-        poDS->m_gt[5] = -dfStepY;
+        poDS->m_gt.xorig = dfMinX - dfStepX / 2;
+        poDS->m_gt.xscale = dfStepX;
+        poDS->m_gt.yorig = dfMaxY + dfStepY / 2;
+        poDS->m_gt.yscale = -dfStepY;
     }
     else
     {
         const double dfStepX = (dfMaxX - dfMinX) / nCols;
         const double dfStepY = (dfMaxY - dfMinY) / nRows;
 
-        poDS->m_gt[0] = dfMinX;
-        poDS->m_gt[1] = dfStepX;
-        poDS->m_gt[3] = dfMaxY;
-        poDS->m_gt[5] = -dfStepY;
+        poDS->m_gt.xorig = dfMinX;
+        poDS->m_gt.xscale = dfStepX;
+        poDS->m_gt.yorig = dfMaxY;
+        poDS->m_gt.yscale = -dfStepY;
     }
 
     /* -------------------------------------------------------------------- */
@@ -581,7 +581,7 @@ GDALDataset *ZMapDataset::CreateCopy(const char *pszFilename,
 
     GDALGeoTransform gt;
     poSrcDS->GetGeoTransform(gt);
-    if (gt[2] != 0 || gt[4] != 0)
+    if (gt.xrot != 0 || gt.yrot != 0)
     {
         CPLError(CE_Failure, CPLE_NotSupported,
                  "ZMap driver does not support CreateCopy() from skewed or "
@@ -633,23 +633,25 @@ GDALDataset *ZMapDataset::CreateCopy(const char *pszFilename,
 
     if (CPLTestBool(CPLGetConfigOption("ZMAP_PIXEL_IS_POINT", "FALSE")))
     {
-        WriteRightJustified(fp, gt[0] + gt[1] / 2, 14, 7);
+        WriteRightJustified(fp, gt.xorig + gt.xscale / 2, 14, 7);
         fp->Printf(",");
-        WriteRightJustified(fp, gt[0] + gt[1] * nXSize - gt[1] / 2, 14, 7);
+        WriteRightJustified(fp, gt.xorig + gt.xscale * nXSize - gt.xscale / 2,
+                            14, 7);
         fp->Printf(",");
-        WriteRightJustified(fp, gt[3] + gt[5] * nYSize - gt[5] / 2, 14, 7);
+        WriteRightJustified(fp, gt.yorig + gt.yscale * nYSize - gt.yscale / 2,
+                            14, 7);
         fp->Printf(",");
-        WriteRightJustified(fp, gt[3] + gt[5] / 2, 14, 7);
+        WriteRightJustified(fp, gt.yorig + gt.yscale / 2, 14, 7);
     }
     else
     {
-        WriteRightJustified(fp, gt[0], 14, 7);
+        WriteRightJustified(fp, gt.xorig, 14, 7);
         fp->Printf(",");
-        WriteRightJustified(fp, gt[0] + gt[1] * nXSize, 14, 7);
+        WriteRightJustified(fp, gt.xorig + gt.xscale * nXSize, 14, 7);
         fp->Printf(",");
-        WriteRightJustified(fp, gt[3] + gt[5] * nYSize, 14, 7);
+        WriteRightJustified(fp, gt.yorig + gt.yscale * nYSize, 14, 7);
         fp->Printf(",");
-        WriteRightJustified(fp, gt[3], 14, 7);
+        WriteRightJustified(fp, gt.yorig, 14, 7);
     }
 
     fp->Printf("\n");

--- a/gcore/gdal_misc.cpp
+++ b/gcore/gdal_misc.cpp
@@ -3453,11 +3453,11 @@ void GDALComposeGeoTransforms(const double *padfGT1, const double *padfGT2,
     // We need to think of the geotransform in a more normal form to do
     // the matrix multiple:
     //
-    //  __                     __
-    //  | gt[1]   gt[2]   gt[0] |
-    //  | gt[4]   gt[5]   gt[3] |
-    //  |  0.0     0.0     1.0  |
-    //  --                     --
+    //  __                                __
+    //  | gt.xscale   gt.xrot     gt.xorig |
+    //  | gt.yrot     gt.yscale   gt.yorig |
+    //  |  0.0        0.0         1.0      |
+    //  --                                --
     //
     // Then we can use normal matrix multiplication to produce the
     // composed transformation.  I don't actually reform the matrix

--- a/gcore/gdaldataset.cpp
+++ b/gcore/gdaldataset.cpp
@@ -1602,13 +1602,13 @@ CPLErr CPL_STDCALL GDALSetProjection(GDALDatasetH hDS,
  * space, and projection coordinates (Xp,Yp) space.
  *
  * \code
- *   Xp = gt[0] + P*gt[1] + L*gt[2];
- *   Yp = gt[3] + P*padfTransform[4] + L*gt[5];
+ *   Xp = gt.xorig + P*gt.xscale + L*gt.xrot;
+ *   Yp = gt.yorig + P*padfTransform[4] + L*gt.yscale;
  * \endcode
  *
- * In a north up image, gt[1] is the pixel width, and
- * gt[5] is the pixel height.  The upper left corner of the
- * upper left pixel is at position (gt[0],gt[3]).
+ * In a north up image, gt.xscale is the pixel width, and
+ * gt.yscale is the pixel height.  The upper left corner of the
+ * upper left pixel is at position (gt.xorig,gt.yorig).
  *
  * The default transform is (0,1,0,0,0,1) and should be returned even when
  * a CE_Failure error is returned, such as for formats that don't support
@@ -11415,8 +11415,8 @@ CPLErr GDALDataset::GetExtent(OGREnvelope *psExtent,
         }
 
         constexpr int DENSIFY_POINT_COUNT = 21;
-        double dfULX = gt[0];
-        double dfULY = gt[3];
+        double dfULX = gt.xorig;
+        double dfULY = gt.yorig;
         double dfURX = 0, dfURY = 0;
         gt.Apply(nRasterXSize, 0, &dfURX, &dfURY);
         double dfLLX = 0, dfLLY = 0;
@@ -12014,14 +12014,14 @@ class GDALMDArrayFromDataset final : public GDALMDArray
         }
 
         GDALGeoTransform gt;
-        if (m_poDS->GetGeoTransform(gt) == CE_None && gt[2] == 0 && gt[4] == 0)
+        if (m_poDS->GetGeoTransform(gt) == CE_None && gt.IsAxisAligned())
         {
             m_varX = GDALMDArrayRegularlySpaced::Create(
-                "/", poBandDim->GetName(), poXDim, gt[0], gt[1], 0.5);
+                "/", poBandDim->GetName(), poXDim, gt.xorig, gt.xscale, 0.5);
             poXDim->SetIndexingVariable(m_varX);
 
             m_varY = GDALMDArrayRegularlySpaced::Create(
-                "/", poYDim->GetName(), poYDim, gt[3], gt[5], 0.5);
+                "/", poYDim->GetName(), poYDim, gt.yorig, gt.yscale, 0.5);
             poYDim->SetIndexingVariable(m_varY);
         }
         if (bBandYX)

--- a/gcore/gdaljp2metadata.cpp
+++ b/gcore/gdaljp2metadata.cpp
@@ -631,8 +631,7 @@ int GDALJP2Metadata::ParseJP2GeoTIFF()
         bPixelIsPoint = CPL_TO_BOOL(abPixelIsPoint[iBestIndex]);
         papszRPCMD = apapszRPCMD[iBestIndex];
 
-        if (m_gt[0] != 0 || m_gt[1] != 1 || m_gt[2] != 0 || m_gt[3] != 0 ||
-            m_gt[4] != 0 || m_gt[5] != 1)
+        if (m_gt != GDALGeoTransform())
             m_bHaveGeoTransform = true;
 
         if (ahSRS[iBestIndex])
@@ -948,18 +947,18 @@ int GDALJP2Metadata::ParseGMLCoverageDesc()
     if (CSLCount(papszOffset1Tokens) >= 2 &&
         CSLCount(papszOffset2Tokens) >= 2 && poOriginGeometry != nullptr)
     {
-        m_gt[0] = poOriginGeometry->getX();
-        m_gt[1] = CPLAtof(papszOffset1Tokens[0]);
-        m_gt[2] = CPLAtof(papszOffset2Tokens[0]);
-        m_gt[3] = poOriginGeometry->getY();
-        m_gt[4] = CPLAtof(papszOffset1Tokens[1]);
-        m_gt[5] = CPLAtof(papszOffset2Tokens[1]);
+        m_gt.xorig = poOriginGeometry->getX();
+        m_gt.xscale = CPLAtof(papszOffset1Tokens[0]);
+        m_gt.xrot = CPLAtof(papszOffset2Tokens[0]);
+        m_gt.yorig = poOriginGeometry->getY();
+        m_gt.yrot = CPLAtof(papszOffset1Tokens[1]);
+        m_gt.yscale = CPLAtof(papszOffset2Tokens[1]);
 
         // offset from center of pixel.
-        m_gt[0] -= m_gt[1] * 0.5;
-        m_gt[0] -= m_gt[2] * 0.5;
-        m_gt[3] -= m_gt[4] * 0.5;
-        m_gt[3] -= m_gt[5] * 0.5;
+        m_gt.xorig -= m_gt.xscale * 0.5;
+        m_gt.xorig -= m_gt.xrot * 0.5;
+        m_gt.yorig -= m_gt.yrot * 0.5;
+        m_gt.yorig -= m_gt.yscale * 0.5;
 
         bSuccess = true;
         m_bHaveGeoTransform = true;
@@ -1101,7 +1100,7 @@ int GDALJP2Metadata::ParseGMLCoverageDesc()
         CPLDebug("GMLJP2",
                  "Flipping axis orientation in GMLJP2 coverage description.");
 
-        std::swap(m_gt[0], m_gt[3]);
+        std::swap(m_gt.xorig, m_gt.yorig);
 
         int swapWith1Index = 4;
         int swapWith2Index = 5;
@@ -1123,11 +1122,12 @@ int GDALJP2Metadata::ParseGMLCoverageDesc()
                      "GDAL_JP2K_ALT_OFFSETVECTOR_ORDER.");
         }
 
-        std::swap(m_gt[1], m_gt[swapWith1Index]);
-        std::swap(m_gt[2], m_gt[swapWith2Index]);
+        std::swap(m_gt.xscale, m_gt[swapWith1Index]);
+        std::swap(m_gt.xrot, m_gt[swapWith2Index]);
 
         /* Found in autotest/gdrivers/data/ll.jp2 */
-        if (m_gt[1] == 0.0 && m_gt[2] < 0.0 && m_gt[4] > 0.0 && m_gt[5] == 0.0)
+        if (m_gt.xscale == 0.0 && m_gt.xrot < 0.0 && m_gt.yrot > 0.0 &&
+            m_gt.yscale == 0.0)
         {
             CPLError(
                 CE_Warning, CPLE_AppDefined,
@@ -1299,13 +1299,13 @@ void GDALJP2Metadata::GetGMLJP2GeoreferencingInfo(
     /*      Prepare coverage origin and offset vectors.  Take axis          */
     /*      order into account if needed.                                   */
     /* -------------------------------------------------------------------- */
-    adfOrigin[0] = m_gt[0] + m_gt[1] * 0.5 + m_gt[4] * 0.5;
-    adfOrigin[1] = m_gt[3] + m_gt[2] * 0.5 + m_gt[5] * 0.5;
-    adfXVector[0] = m_gt[1];
-    adfXVector[1] = m_gt[2];
+    adfOrigin[0] = m_gt.xorig + m_gt.xscale * 0.5 + m_gt.yrot * 0.5;
+    adfOrigin[1] = m_gt.yorig + m_gt.xrot * 0.5 + m_gt.yscale * 0.5;
+    adfXVector[0] = m_gt.xscale;
+    adfXVector[1] = m_gt.xrot;
 
-    adfYVector[0] = m_gt[4];
-    adfYVector[1] = m_gt[5];
+    adfYVector[0] = m_gt.yrot;
+    adfYVector[1] = m_gt.yscale;
 
     if (bNeedAxisFlip && CPLTestBool(CPLGetConfigOption(
                              "GDAL_IGNORE_AXIS_ORIENTATION", "FALSE")))
@@ -1451,14 +1451,14 @@ GDALJP2Box *GDALJP2Metadata::CreateGMLJP2(int nXSize, int nYSize)
                  "gmljp2://xml/CRSDictionary.gml#ogrcrs1");
 
     // Compute bounding box
-    double dfX1 = m_gt[0];
-    double dfX2 = m_gt[0] + nXSize * m_gt[1];
-    double dfX3 = m_gt[0] + nYSize * m_gt[2];
-    double dfX4 = m_gt[0] + nXSize * m_gt[1] + nYSize * m_gt[2];
-    double dfY1 = m_gt[3];
-    double dfY2 = m_gt[3] + nXSize * m_gt[4];
-    double dfY3 = m_gt[3] + nYSize * m_gt[5];
-    double dfY4 = m_gt[3] + nXSize * m_gt[4] + nYSize * m_gt[5];
+    double dfX1 = m_gt.xorig;
+    double dfX2 = m_gt.xorig + nXSize * m_gt.xscale;
+    double dfX3 = m_gt.xorig + nYSize * m_gt.xrot;
+    double dfX4 = m_gt.xorig + nXSize * m_gt.xscale + nYSize * m_gt.xrot;
+    double dfY1 = m_gt.yorig;
+    double dfY2 = m_gt.yorig + nXSize * m_gt.yrot;
+    double dfY3 = m_gt.yorig + nYSize * m_gt.yscale;
+    double dfY4 = m_gt.yorig + nXSize * m_gt.yrot + nYSize * m_gt.yscale;
     double dfLCX = std::min({dfX1, dfX2, dfX3, dfX4});
     double dfLCY = std::min({dfY1, dfY2, dfY3, dfY4});
     double dfUCX = std::max({dfX1, dfX2, dfX3, dfX4});
@@ -2467,14 +2467,14 @@ GDALJP2Box *GDALJP2Metadata::CreateGMLJP2V2(int nXSize, int nYSize,
                      "gmljp2://xml/CRSDictionary.gml#ogrcrs1");
 
         // Compute bounding box
-        double dfX1 = m_gt[0];
-        double dfX2 = m_gt[0] + nXSize * m_gt[1];
-        double dfX3 = m_gt[0] + nYSize * m_gt[2];
-        double dfX4 = m_gt[0] + nXSize * m_gt[1] + nYSize * m_gt[2];
-        double dfY1 = m_gt[3];
-        double dfY2 = m_gt[3] + nXSize * m_gt[4];
-        double dfY3 = m_gt[3] + nYSize * m_gt[5];
-        double dfY4 = m_gt[3] + nXSize * m_gt[4] + nYSize * m_gt[5];
+        double dfX1 = m_gt.xorig;
+        double dfX2 = m_gt.xorig + nXSize * m_gt.xscale;
+        double dfX3 = m_gt.xorig + nYSize * m_gt.xrot;
+        double dfX4 = m_gt.xorig + nXSize * m_gt.xscale + nYSize * m_gt.xrot;
+        double dfY1 = m_gt.yorig;
+        double dfY2 = m_gt.yorig + nXSize * m_gt.yrot;
+        double dfY3 = m_gt.yorig + nYSize * m_gt.yscale;
+        double dfY4 = m_gt.yorig + nXSize * m_gt.yrot + nYSize * m_gt.yscale;
         double dfLCX = std::min({dfX1, dfX2, dfX3, dfX4});
         double dfLCY = std::min({dfY1, dfY2, dfY3, dfY4});
         double dfUCX = std::max({dfX1, dfX2, dfX3, dfX4});

--- a/gcore/gdalmultidim.cpp
+++ b/gcore/gdalmultidim.cpp
@@ -7683,12 +7683,12 @@ bool GDALMDArray::GuessGeoTransform(size_t nDimX, size_t nDimY,
         poVarX->IsRegularlySpaced(dfXStart, dfXSpacing) &&
         poVarY->IsRegularlySpaced(dfYStart, dfYSpacing))
     {
-        gt[0] = dfXStart - (bPixelIsPoint ? 0 : dfXSpacing / 2);
-        gt[1] = dfXSpacing;
-        gt[2] = 0;
-        gt[3] = dfYStart - (bPixelIsPoint ? 0 : dfYSpacing / 2);
-        gt[4] = 0;
-        gt[5] = dfYSpacing;
+        gt.xorig = dfXStart - (bPixelIsPoint ? 0 : dfXSpacing / 2);
+        gt.xscale = dfXSpacing;
+        gt.xrot = 0;
+        gt.yorig = dfYStart - (bPixelIsPoint ? 0 : dfYSpacing / 2);
+        gt.yrot = 0;
+        gt.yscale = dfYSpacing;
         return true;
     }
     return false;
@@ -8434,14 +8434,16 @@ std::shared_ptr<GDALMDArray> GDALMDArrayResampled::Create(
         std::string(), "dimY", GDAL_DIM_TYPE_HORIZONTAL_Y, "NORTH",
         poReprojectedDS->GetRasterYSize());
     auto varY = GDALMDArrayRegularlySpaced::Create(
-        std::string(), poDimY->GetName(), poDimY, gt[3] + gt[5] / 2, gt[5], 0);
+        std::string(), poDimY->GetName(), poDimY, gt.yorig + gt.yscale / 2,
+        gt.yscale, 0);
     poDimY->SetIndexingVariable(varY);
 
     auto poDimX = std::make_shared<GDALDimensionWeakIndexingVar>(
         std::string(), "dimX", GDAL_DIM_TYPE_HORIZONTAL_X, "EAST",
         poReprojectedDS->GetRasterXSize());
     auto varX = GDALMDArrayRegularlySpaced::Create(
-        std::string(), poDimX->GetName(), poDimX, gt[0] + gt[1] / 2, gt[1], 0);
+        std::string(), poDimX->GetName(), poDimX, gt.xorig + gt.xscale / 2,
+        gt.xscale, 0);
     poDimX->SetIndexingVariable(varX);
 
     apoNewDims.emplace_back(poDimY);

--- a/gcore/gdalpamdataset.cpp
+++ b/gcore/gdalpamdataset.cpp
@@ -278,8 +278,8 @@ CPLXMLNode *GDALPamDataset::SerializeToXML(const char *pszUnused)
     {
         CPLString oFmt;
         oFmt.Printf("%24.16e,%24.16e,%24.16e,%24.16e,%24.16e,%24.16e",
-                    psPam->gt[0], psPam->gt[1], psPam->gt[2], psPam->gt[3],
-                    psPam->gt[4], psPam->gt[5]);
+                    psPam->gt.xorig, psPam->gt.xscale, psPam->gt.xrot,
+                    psPam->gt.yorig, psPam->gt.yrot, psPam->gt.yscale);
         CPLSetXMLValue(psDSTree, "GeoTransform", oFmt);
     }
 
@@ -637,27 +637,27 @@ CPLErr GDALPamDataset::XMLInit(const CPLXMLNode *psTree, const char *pszUnused)
                 }
                 if (adfCoeffX.size() == 3 && adfCoeffY.size() == 3)
                 {
-                    psPam->gt[0] = adfCoeffX[0];
-                    psPam->gt[1] = adfCoeffX[1];
+                    psPam->gt.xorig = adfCoeffX[0];
+                    psPam->gt.xscale = adfCoeffX[1];
                     // Looking at the example of https://github.com/qgis/QGIS/issues/53125#issuecomment-1567650082
                     // when comparing the .pgwx world file and .png.aux.xml file,
                     // it appears that the sign of the coefficients for the line
                     // terms must be negated (which is a bit in line with the
                     // negation of dfGCPLine in the above GCP case)
-                    psPam->gt[2] = -adfCoeffX[2];
-                    psPam->gt[3] = adfCoeffY[0];
-                    psPam->gt[4] = adfCoeffY[1];
-                    psPam->gt[5] = -adfCoeffY[2];
+                    psPam->gt.xrot = -adfCoeffX[2];
+                    psPam->gt.yorig = adfCoeffY[0];
+                    psPam->gt.yrot = adfCoeffY[1];
+                    psPam->gt.yscale = -adfCoeffY[2];
 
                     // Looking at the example of https://github.com/qgis/QGIS/issues/53125#issuecomment-1567650082
                     // when comparing the .pgwx world file and .png.aux.xml file,
                     // one can see that they have the same origin, so knowing
                     // that world file uses a center-of-pixel convention,
                     // correct from center of pixel to top left of pixel
-                    psPam->gt[0] -= 0.5 * psPam->gt[1];
-                    psPam->gt[0] -= 0.5 * psPam->gt[2];
-                    psPam->gt[3] -= 0.5 * psPam->gt[4];
-                    psPam->gt[3] -= 0.5 * psPam->gt[5];
+                    psPam->gt.xorig -= 0.5 * psPam->gt.xscale;
+                    psPam->gt.xorig -= 0.5 * psPam->gt.xrot;
+                    psPam->gt.yorig -= 0.5 * psPam->gt.yrot;
+                    psPam->gt.yorig -= 0.5 * psPam->gt.yscale;
 
                     psPam->bHaveGeoTransform = TRUE;
                 }

--- a/gcore/gdalrasterband.cpp
+++ b/gcore/gdalrasterband.cpp
@@ -11119,14 +11119,14 @@ class GDALMDArrayFromRasterBand final : public GDALMDArray
                       "/", "X", osTypeX, osDirectionX, nXSize)};
 
         GDALGeoTransform gt;
-        if (m_poDS->GetGeoTransform(gt) == CE_None && gt[2] == 0 && gt[4] == 0)
+        if (m_poDS->GetGeoTransform(gt) == CE_None && gt.IsAxisAligned())
         {
-            m_varX = GDALMDArrayRegularlySpaced::Create("/", "X", m_dims[1],
-                                                        gt[0], gt[1], 0.5);
+            m_varX = GDALMDArrayRegularlySpaced::Create(
+                "/", "X", m_dims[1], gt.xorig, gt.xscale, 0.5);
             m_dims[1]->SetIndexingVariable(m_varX);
 
-            m_varY = GDALMDArrayRegularlySpaced::Create("/", "Y", m_dims[0],
-                                                        gt[3], gt[5], 0.5);
+            m_varY = GDALMDArrayRegularlySpaced::Create(
+                "/", "Y", m_dims[0], gt.yorig, gt.yscale, 0.5);
             m_dims[0]->SetIndexingVariable(m_varY);
         }
     }

--- a/gcore/geoheif.cpp
+++ b/gcore/geoheif.cpp
@@ -91,21 +91,21 @@ CPLErr GeoHEIF::GetGeoTransform(GDALGeoTransform &gt) const
 
     if (axes.size() && axes[0] != 1)
     {
-        gt[1] = modelTransform[4];
-        gt[2] = modelTransform[5];
-        gt[0] = modelTransform[3];
-        gt[4] = modelTransform[1];
-        gt[5] = modelTransform[2];
-        gt[3] = modelTransform[0];
+        gt.xscale = modelTransform[4];
+        gt.xrot = modelTransform[5];
+        gt.xorig = modelTransform[3];
+        gt.yrot = modelTransform[1];
+        gt.yscale = modelTransform[2];
+        gt.yorig = modelTransform[0];
     }
     else
     {
-        gt[1] = modelTransform[1];
-        gt[2] = modelTransform[2];
-        gt[0] = modelTransform[0];
-        gt[4] = modelTransform[4];
-        gt[5] = modelTransform[5];
-        gt[3] = modelTransform[3];
+        gt.xscale = modelTransform[1];
+        gt.xrot = modelTransform[2];
+        gt.xorig = modelTransform[0];
+        gt.yrot = modelTransform[4];
+        gt.yscale = modelTransform[5];
+        gt.yorig = modelTransform[3];
     }
     return CE_None;
 }


### PR DESCRIPTION
Mostly generated with
```
find ../apps ../gcore ../frmts -name "*.cpp" -exec sed -i "s/gt\[0\]/gt.xorig/g" {} \;
find ../apps ../gcore ../frmts -name "*.cpp" -exec sed -i "s/gt\[1\]/gt.xscale/g" {} \;
find ../apps ../gcore ../frmts -name "*.cpp" -exec sed -i "s/gt\[2\]/gt.xrot/g" {} \;
find ../apps ../gcore ../frmts -name "*.cpp" -exec sed -i "s/gt\[3\]/gt.yorig/g" {} \;
find ../apps ../gcore ../frmts -name "*.cpp" -exec sed -i "s/gt\[4\]/gt.yrot/g" {} \;
find ../apps ../gcore ../frmts -name "*.cpp" -exec sed -i "s/gt\[5\]/gt.yscale/g" {} \;
```