### PR TITLE
Multidim: skip .gmac cache stat for non-local filesystems

### DIFF
--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -6249,7 +6249,6 @@ def test_zarr_read_simple_sharding_network():
             handler.add("HEAD", "/test.zarr/zarr.AUX", 404)
             handler.add("HEAD", "/test.zarr/zarr.json.aux", 404)
             handler.add("HEAD", "/test.zarr/zarr.json.AUX", 404)
-            handler.add("HEAD", "/test.zarr/zarr.json.gmac", 404)
             handler.add("HEAD", "/test.zarr/c/0/0", 200, {"Content-Length": "65536"})
             handler.add(
                 "GET",

--- a/gcore/gdalmultidim.cpp
+++ b/gcore/gdalmultidim.cpp
@@ -4362,6 +4362,13 @@ GDALMDArray::GetCacheRootGroup(bool bCanCreate,
     if (pszProxy != nullptr)
         osCacheFilenameOut = pszProxy;
 
+    // .gmac sidecars are local-only; skip stat for non-local filesystems.
+    if (!bCanCreate && pszProxy == nullptr &&
+        !VSIIsLocal(osCacheFilenameOut.c_str()))
+    {
+        return nullptr;
+    }
+
     std::unique_ptr<GDALDataset> poDS;
     VSIStatBufL sStat;
     if (VSIStatL(osCacheFilenameOut.c_str(), &sStat) == 0)


### PR DESCRIPTION
## What does this PR do?

`GetCacheRootGroup()` checks for a `.gmac` sidecar on every `GDALMDArray::Read()`. This is a local cache artifact created by the `Cache()` method, yet over `/vsicurl/` the check fires a HEAD that 404s - 1 per band, per render.

This PR adds an early return when the path is non-local (`VSIIsLocal()`), no cache creation was requested, and no PAM proxy is configured. The explicit `Cache()` code path is unaffected.

Applies to all multidim array implementations over network filesystems, not only Zarr.

## What are related issues/pull requests?

- https://github.com/OSGeo/gdal/pull/13893

## Tasklist

- [x] AI (Claude) supported my development of this PR
- [x] Code is correctly formatted (pre-commit)
- [x] Add test case(s)
- [x] All CI builds and checks have passed