### PR TITLE
Zarr: probe zarr.json before v2 files in OpenRootGroup()

### DIFF
--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -6223,62 +6223,59 @@ def test_zarr_read_simple_sharding_network():
     chunk_block = b"\x01\x02\x03\x04" + (16384 - 4) * b"\x00"
 
     try:
-        # Loop twice: second iteration proves ClearMemoryCaches() lets the
-        # driver re-fetch everything cleanly.
-        for _ in range(2):
-            handler = webserver.SequentialHandler()
-            handler.add("GET", "/test.zarr/", 404)
-            handler.add("HEAD", "/test.zarr/.zmetadata", 404)
-            handler.add("HEAD", "/test.zarr/.zarray", 404)
-            handler.add("HEAD", "/test.zarr/.zgroup", 404)
-            handler.add(
-                "HEAD",
-                "/test.zarr/zarr.json",
-                200,
-                {"Content-Length": "%d" % len(zarr_json)},
-            )
-            handler.add(
-                "GET",
-                "/test.zarr/zarr.json",
-                200,
-                {"Content-Length": "%d" % len(zarr_json)},
-                zarr_json,
-            )
-            handler.add("HEAD", "/test.zarr/zarr.json.aux.xml", 404)
-            handler.add("HEAD", "/test.zarr/zarr.aux", 404)
-            handler.add("HEAD", "/test.zarr/zarr.AUX", 404)
-            handler.add("HEAD", "/test.zarr/zarr.json.aux", 404)
-            handler.add("HEAD", "/test.zarr/zarr.json.AUX", 404)
-            handler.add("HEAD", "/test.zarr/c/0/0", 200, {"Content-Length": "65536"})
-            handler.add(
-                "GET",
-                "/test.zarr/c/0/0",
-                206,
-                {
-                    "Content-Length": "16384",
-                    "Content-Range": "bytes 49152-65535/65536",
-                },
-                shard_tail,
-                expected_headers={"Range": "bytes=49152-65535"},
-            )
-            handler.add(
-                "GET",
-                "/test.zarr/c/0/0",
-                206,
-                {
-                    "Content-Length": "16384",
-                    "Content-Range": "bytes 0-16383/65536",
-                },
-                chunk_block,
-                expected_headers={"Range": "bytes=0-16383"},
-            )
-            with webserver.install_http_handler(handler):
-                ds = gdal.Open(
-                    'ZARR:"/vsicurl/http://localhost:%d/test.zarr"' % webserver_port
+        with gdaltest.config_options({"GDAL_PAM_ENABLED": "NO"}):
+            # Loop twice: second iteration proves ClearMemoryCaches() lets the
+            # driver re-fetch everything cleanly.
+            for _ in range(2):
+                handler = webserver.SequentialHandler()
+                handler.add("GET", "/test.zarr/", 404)
+                handler.add("HEAD", "/test.zarr/.zmetadata", 404)
+                # Probe zarr.json first; v2 probes (.zarray, .zgroup) skipped.
+                handler.add(
+                    "HEAD",
+                    "/test.zarr/zarr.json",
+                    200,
+                    {"Content-Length": "%d" % len(zarr_json)},
                 )
-                assert ds.GetRasterBand(1).ReadBlock(0, 0) == b"\x01\x02\x03\x04"
-            ds = None
-            gdal.ClearMemoryCaches()
+                handler.add(
+                    "GET",
+                    "/test.zarr/zarr.json",
+                    200,
+                    {"Content-Length": "%d" % len(zarr_json)},
+                    zarr_json,
+                )
+                handler.add(
+                    "HEAD", "/test.zarr/c/0/0", 200, {"Content-Length": "65536"}
+                )
+                handler.add(
+                    "GET",
+                    "/test.zarr/c/0/0",
+                    206,
+                    {
+                        "Content-Length": "16384",
+                        "Content-Range": "bytes 49152-65535/65536",
+                    },
+                    shard_tail,
+                    expected_headers={"Range": "bytes=49152-65535"},
+                )
+                handler.add(
+                    "GET",
+                    "/test.zarr/c/0/0",
+                    206,
+                    {
+                        "Content-Length": "16384",
+                        "Content-Range": "bytes 0-16383/65536",
+                    },
+                    chunk_block,
+                    expected_headers={"Range": "bytes=0-16383"},
+                )
+                with webserver.install_http_handler(handler):
+                    ds = gdal.Open(
+                        'ZARR:"/vsicurl/http://localhost:%d/test.zarr"' % webserver_port
+                    )
+                    assert ds.GetRasterBand(1).ReadBlock(0, 0) == b"\x01\x02\x03\x04"
+                ds = None
+                gdal.ClearMemoryCaches()
 
     finally:
         webserver.server_stop(webserver_process, webserver_port)


### PR DESCRIPTION
## What does this PR do?

With Zarr v3 adoption growing, the driver's v2-first probe order in `OpenRootGroup()` wastes 2 HEAD requests (`.zarray`, `.zgroup`) that always 404 on v3 stores.

This PR checks `zarr.json` first. When present, the v2 cascade is skipped entirely. V2 datasets fall through unchanged after the `zarr.json` 404 - one extra stat that is free locally and a single HEAD remotely.

## What are related issues/pull requests?

- Companion PR: skip `.gmac` cache stat for non-local filesystems
- #13708 - `sharding_indexed` codec

## Tasklist

- [x] AI (Claude) supported my development of this PR
- [x] Code is correctly formatted (pre-commit)
- [x] Add test case(s)
- [ ] All CI builds and checks have passed
