### PR TITLE
fix: restrict --fid to supported SQL dialects

### DIFF
--- a/apps/gdalalg_vector_info.h
+++ b/apps/gdalalg_vector_info.h
@@ -46,6 +46,7 @@ class GDALVectorInfoAlgorithm /* non final */
     std::string m_sql{};
     std::string m_where{};
     std::string m_dialect{};
+    std::string m_fid{};   
     int m_limit = 0;
 };
 


### PR DESCRIPTION
This PR restricts the --fid option to supported SQL dialects and drivers.

--fid is now accepted with the OGR SQL dialect, and with the SQLite dialect
only for GeoPackage and SpatiaLite datasources, avoiding invalid SQL for
other drivers (e.g. CSV).
