### PR TITLE
Zarr: expose GDAL_BLOSC_NUM_THREADS for multi-threaded blosc decompression

### DIFF
--- a/frmts/zarr/zarr_v3_codec.h
+++ b/frmts/zarr/zarr_v3_codec.h
@@ -121,6 +121,7 @@ class ZarrV3CodecAbstractCompressor CPL_NON_FINAL : public ZarrV3Codec
 {
   protected:
     CPLStringList m_aosCompressorOptions{};
+    CPLStringList m_aosDecompressorOptions{};
     const CPLCompressor *m_pDecompressor = nullptr;
     const CPLCompressor *m_pCompressor = nullptr;
 

--- a/frmts/zarr/zarr_v3_codec_abstract_compressor.cpp
+++ b/frmts/zarr/zarr_v3_codec_abstract_compressor.cpp
@@ -62,9 +62,9 @@ bool ZarrV3CodecAbstractCompressor::Decode(
     abyDst.resize(abyDst.capacity());
     void *pOutputData = abyDst.data();
     size_t nOutputSize = abyDst.size();
-    bool bRet = m_pDecompressor->pfnFunc(abySrc.data(), abySrc.size(),
-                                         &pOutputData, &nOutputSize, nullptr,
-                                         m_pDecompressor->user_data);
+    bool bRet = m_pDecompressor->pfnFunc(
+        abySrc.data(), abySrc.size(), &pOutputData, &nOutputSize,
+        m_aosDecompressorOptions.List(), m_pDecompressor->user_data);
     if (bRet)
     {
         abyDst.resize(nOutputSize);

--- a/frmts/zarr/zarr_v3_codec_blosc.cpp
+++ b/frmts/zarr/zarr_v3_codec_blosc.cpp
@@ -163,6 +163,17 @@ bool ZarrV3CodecBlosc::InitFromConfiguration(
                                             CPLSPrintf("%d", nBlocksize));
     }
 
+    // Allow multi-threaded blosc decompression via config option.
+    // blosc_decompress_ctx() supports a nthreads parameter; by default
+    // GDAL passes 1.  GDAL_BLOSC_NUM_THREADS overrides this.
+    const char *pszNumThreads =
+        CPLGetConfigOption("GDAL_BLOSC_NUM_THREADS", nullptr);
+    if (pszNumThreads)
+    {
+        m_aosDecompressorOptions.SetNameValue("NUM_THREADS", pszNumThreads);
+        m_aosCompressorOptions.SetNameValue("NUM_THREADS", pszNumThreads);
+    }
+
     return true;
 }
 


### PR DESCRIPTION
## What does this PR do?

`blosc_decompress_ctx()` supports an `nthreads` parameter but the Zarr v3 codec always passes 1. This adds `GDAL_BLOSC_NUM_THREADS` config option (integer or `ALL_CPUS`) forwarded via decompressor options.

## Changes (3 files)

- `frmts/zarr/zarr_v3_codec.h` - add `m_aosDecompressorOptions` member
- `frmts/zarr/zarr_v3_codec_abstract_compressor.cpp` - pass decompressor options to `pfnFunc` in `Decode()` instead of `nullptr`
- `frmts/zarr/zarr_v3_codec_blosc.cpp` - read `GDAL_BLOSC_NUM_THREADS` in `InitFromConfiguration()`, set `NUM_THREADS` on both compressor and decompressor options

## Tasklist

- [x] AI (Claude) supported my development of this PR
- [x] Code is correctly formatted (pre-commit)