### PR TITLE
Zarr: discover overviews from sibling resolution groups

### DIFF
--- a/autotest/gdrivers/data/zarr/v3/simple_multiscales_v010/zarr.json
+++ b/autotest/gdrivers/data/zarr/v3/simple_multiscales_v010/zarr.json
@@ -1,0 +1,303 @@
+{
+  "attributes": {
+    "zarr_conventions": {
+      "d35379db-88df-4056-af3a-620245f8e347": {
+        "version": "0.1.0",
+        "schema": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v0.1.0/schema.json",
+        "spec": "https://github.com/zarr-conventions/multiscales/blob/v0.1.0/README.md",
+        "name": "multiscales",
+        "description": "Multiscale layout of zarr datasets"
+      }
+    },
+    "multiscales": {
+      "layout": [
+        {
+          "asset": "level0"
+        },
+        {
+          "asset": "level1",
+          "derived_from": "level0",
+          "transform": {
+            "scale": [
+              2.0,
+              2.0
+            ],
+            "translation": [
+              0.0,
+              0.0
+            ]
+          }
+        },
+        {
+          "asset": "level2"
+        }
+      ]
+    }
+  },
+  "zarr_format": 3,
+  "consolidated_metadata": {
+    "kind": "inline",
+    "must_understand": false,
+    "metadata": {
+      "level0": {
+        "attributes": {},
+        "zarr_format": 3,
+        "consolidated_metadata": {
+          "kind": "inline",
+          "must_understand": false,
+          "metadata": {}
+        },
+        "node_type": "group"
+      },
+      "level1": {
+        "attributes": {},
+        "zarr_format": 3,
+        "consolidated_metadata": {
+          "kind": "inline",
+          "must_understand": false,
+          "metadata": {}
+        },
+        "node_type": "group"
+      },
+      "level2": {
+        "attributes": {},
+        "zarr_format": 3,
+        "consolidated_metadata": {
+          "kind": "inline",
+          "must_understand": false,
+          "metadata": {}
+        },
+        "node_type": "group"
+      },
+      "level0/ar": {
+        "shape": [
+          200,
+          100
+        ],
+        "data_type": "float32",
+        "chunk_grid": {
+          "name": "regular",
+          "configuration": {
+            "chunk_shape": [
+              200,
+              100
+            ]
+          }
+        },
+        "chunk_key_encoding": {
+          "name": "default",
+          "configuration": {
+            "separator": "/"
+          }
+        },
+        "fill_value": "NaN",
+        "codecs": [
+          {
+              "name": "bytes",
+              "configuration": {
+                "endian": "little"
+              }
+          }
+        ],
+        "attributes": {},
+        "dimension_names": [
+          "y",
+          "x"
+        ],
+        "zarr_format": 3,
+        "node_type": "array",
+        "storage_transformers": []
+      },
+      "level0/unrelated": {
+        "shape": [
+          200,
+          100
+        ],
+        "data_type": "float32",
+        "chunk_grid": {
+          "name": "regular",
+          "configuration": {
+            "chunk_shape": [
+              200,
+              100
+            ]
+          }
+        },
+        "chunk_key_encoding": {
+          "name": "default",
+          "configuration": {
+            "separator": "/"
+          }
+        },
+        "fill_value": "NaN",
+        "codecs": [
+          {
+              "name": "bytes",
+              "configuration": {
+                "endian": "little"
+              }
+          }
+        ],
+        "attributes": {},
+        "dimension_names": [
+          "y",
+          "x"
+        ],
+        "zarr_format": 3,
+        "node_type": "array",
+        "storage_transformers": []
+      },
+      "level0/y": {
+        "shape": [
+          200
+        ],
+        "data_type": "float32",
+        "chunk_grid": {
+          "name": "regular",
+          "configuration": {
+            "chunk_shape": [
+              200
+            ]
+          }
+        },
+        "chunk_key_encoding": {
+          "name": "default",
+          "configuration": {
+            "separator": "/"
+          }
+        },
+        "fill_value": "NaN",
+        "codecs": [
+          {
+              "name": "bytes",
+              "configuration": {
+                "endian": "little"
+              }
+          }
+        ],
+        "attributes": {},
+        "dimension_names": [
+          "y"
+        ],
+        "zarr_format": 3,
+        "node_type": "array",
+        "storage_transformers": []
+      },
+      "level1/ar": {
+        "shape": [
+          100,
+          50
+        ],
+        "data_type": "float32",
+        "chunk_grid": {
+          "name": "regular",
+          "configuration": {
+            "chunk_shape": [
+              100,
+              50
+            ]
+          }
+        },
+        "chunk_key_encoding": {
+          "name": "default",
+          "configuration": {
+            "separator": "/"
+          }
+        },
+        "fill_value": "NaN",
+        "codecs": [
+          {
+              "name": "bytes",
+              "configuration": {
+                "endian": "little"
+              }
+          }
+        ],
+        "attributes": {},
+        "dimension_names": [
+          "y",
+          "x"
+        ],
+        "zarr_format": 3,
+        "node_type": "array",
+        "storage_transformers": []
+      },
+      "level1/y": {
+        "shape": [
+          100
+        ],
+        "data_type": "float32",
+        "chunk_grid": {
+          "name": "regular",
+          "configuration": {
+            "chunk_shape": [
+              100
+            ]
+          }
+        },
+        "chunk_key_encoding": {
+          "name": "default",
+          "configuration": {
+            "separator": "/"
+          }
+        },
+        "fill_value": "NaN",
+        "codecs": [
+          {
+              "name": "bytes",
+              "configuration": {
+                "endian": "little"
+              }
+          }
+        ],
+        "attributes": {},
+        "dimension_names": [
+          "y"
+        ],
+        "zarr_format": 3,
+        "node_type": "array",
+        "storage_transformers": []
+      },
+      "level2/ar": {
+        "shape": [
+          50,
+          25
+        ],
+        "data_type": "float32",
+        "chunk_grid": {
+          "name": "regular",
+          "configuration": {
+            "chunk_shape": [
+              50,
+              25
+            ]
+          }
+        },
+        "chunk_key_encoding": {
+          "name": "default",
+          "configuration": {
+            "separator": "/"
+          }
+        },
+        "fill_value": "NaN",
+        "codecs": [
+          {
+              "name": "bytes",
+              "configuration": {
+                "endian": "little"
+              }
+          }
+        ],
+        "attributes": {},
+        "dimension_names": [
+          "y",
+          "x"
+        ],
+        "zarr_format": 3,
+        "node_type": "array",
+        "storage_transformers": []
+      }
+    }
+  },
+  "node_type": "group"
+}

--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -6821,6 +6821,7 @@ def test_zarr_read_nested_sharding():
     "filename",
     [
         "data/zarr/v3/simple_multiscales/zarr.json",
+        "data/zarr/v3/simple_multiscales_v010/zarr.json",
         "data/zarr/v3/simple_multiscales_ref_array/zarr.json",
         "data/zarr/v3/simple_multiscales_spatial/zarr.json",
     ],


### PR DESCRIPTION
## What does this PR do?

When the multiscales convention is absent, scan sibling groups of the parent for arrays with the same name but smaller dimensions. Register matches as overviews sorted by decreasing resolution.

Handles EOPF Sentinel-2 stores where `r10m`/`r20m`/`r60m` groups contain the same bands at different native resolutions. When consolidated metadata is loaded, discovery is purely in-memory (no extra HTTP).

## Changes (3 files)

- `frmts/zarr/zarr_v3_array.cpp` - overview discovery logic in array open path
- `frmts/zarr/zarr.h` - declare new method
- `autotest/gdrivers/zarr_driver.py` - test with synthetic multi-resolution groups

## Tasklist

- [x] AI (Claude) supported my development of this PR
- [x] Code is correctly formatted (pre-commit)
- [x] Add test case(s)