### PR TITLE
CI: macOS build caching parity with conda/cmake workflows

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -29,20 +29,49 @@ jobs:
 
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
+      - name: Setup ccache cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/.ccache
+          key: ${{ runner.os }}-ccache-${{ github.ref_name }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-${{ github.ref_name }}-
+            ${{ runner.os }}-ccache-
+
+      - name: Cache Conda packages
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          path: ~/conda_pkgs_dir
+          key: ${{ runner.os }}-conda-${{ hashFiles('ci/travis/osx/before_install.sh') }}
+          restore-keys: |
+            ${{ runner.os }}-conda-
+
       - uses: conda-incubator/setup-miniconda@835234971496cad1653abb28a638a281cf32541f # v3.2.0
         with:
             channels: conda-forge
             auto-update-conda: true
+            use-mamba: true
 
       - name: Install Requirements
         shell: bash -l {0}
         run: |
           source ./ci/travis/osx/before_install.sh
 
+      - name: Configure ccache
+        shell: bash -l {0}
+        run: |
+          echo "CCACHE_DIR=$HOME/.ccache" >> $GITHUB_ENV
+          echo "CCACHE_MAXSIZE=1G" >> $GITHUB_ENV
+          ccache -z
+
       - name: Build
         shell: bash -l {0}
         run: |
           source ./ci/travis/osx/install.sh
+
+      - name: Show ccache stats
+        shell: bash -l {0}
+        run: ccache -sv
 
       - name: Run tests
         shell: bash -l {0}

--- a/ci/travis/osx/before_install.sh
+++ b/ci/travis/osx/before_install.sh
@@ -3,7 +3,7 @@
 set -e
 
 conda update -n base -c defaults conda
-conda install -y compilers automake pkgconfig cmake
+conda install -y compilers automake pkgconfig cmake ccache
 
 conda config --set channel_priority strict
 conda install --yes --quiet proj python=3.12 swig lxml jsonschema numpy setuptools

--- a/ci/travis/osx/install.sh
+++ b/ci/travis/osx/install.sh
@@ -20,6 +20,7 @@ CFLAGS="-Wextra -Werror" CXXFLAGS="-Wextra -Werror" cmake .. \
          -DCMAKE_INSTALL_PREFIX=${CONDA_PREFIX} \
          -DCMAKE_PREFIX_PATH=${CONDA_PREFIX} \
          -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+         -DUSE_CCACHE=ON \
          -DGDAL_USE_GEOTIFF_INTERNAL=ON \
          -DGDAL_USE_PNG_INTERNAL=ON \
          -DGDAL_USE_POSTGRESQL=OFF \


### PR DESCRIPTION
## What does this PR do?

Bring the macOS build in line with the other conda-based workflows (`conda.yml`, `cmake_builds.yml`) which already have ccache, conda package caching, and mamba. The macOS workflow had none of these.

1. **ccache** + build cache - reuse compiled objects across pushes
2. **Conda package cache** - avoid re-downloading packages
3. **mamba** - faster conda solving (already used by `conda.yml` and `cmake_builds.yml`)

Cache key was missing `ref_name`, so restore-keys couldn't prefix-match across runs on the same branch. Fixed in b9b792b.

### Measured results (fork, all three changes combined, ~1h apart)

| Run | Build time | Links |
|-----|------------|-------|
| Cold (no cache) | 8m 53s | [run](https://github.com/wietzesuijker/gdal/actions/runs/21912768814) |
| Warm (cache hit) | 4m 40s (1.9x) | [run](https://github.com/wietzesuijker/gdal/actions/runs/21914867193) |

## Tasklist

- [x] AI (Claude) supported my development of this PR
- [x] All CI builds and checks have passed