### PR TITLE
MiraMonVector: documenting create capacity in metadata

### DIFF
--- a/ogr/ogrsf_frmts/miramon/ogrmiramondriver.cpp
+++ b/ogr/ogrsf_frmts/miramon/ogrmiramondriver.cpp
@@ -125,6 +125,7 @@ void RegisterOGRMiraMon()
     GDALDriver *poDriver = new GDALDriver();
     poDriver->SetDescription("MiraMonVector");
     poDriver->SetMetadataItem(GDAL_DCAP_VECTOR, "YES");
+    poDriver->SetMetadataItem(GDAL_DCAP_CREATE, "YES");
     poDriver->SetMetadataItem(GDAL_DCAP_CREATE_LAYER, "YES");
     poDriver->SetMetadataItem(GDAL_DCAP_CREATE_FIELD, "YES");
     poDriver->SetMetadataItem(GDAL_DMD_LONGNAME,


### PR DESCRIPTION
## What does this PR do?
Adds the line "poDriver->SetMetadataItem(GDAL_DCAP_CREATE, "YES");" that documents the capacity of create

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Review
 - [ ] All CI builds and checks have passed