### PR TITLE
GTiff: accept Float16 with PREDICTOR=3

### DIFF
--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -12166,6 +12166,31 @@ def test_tiff_write_multi_band_interleaved_predictor_3(tmp_vsimem):
 #
 
 
+def test_tiff_write_float16_predictor_3(tmp_vsimem):
+
+    ref_values = (1.5, -3.5, 4.5, -2.5)
+    ref_content = struct.pack("e" * len(ref_values), *ref_values)
+    with gdal.GetDriverByName("GTiff").Create(
+        tmp_vsimem / "test.tif",
+        len(ref_values),
+        1,
+        1,
+        gdal.GDT_Float16,
+        options=["PREDICTOR=3", "COMPRESS=LZW"],
+    ) as ds:
+        ds.WriteRaster(0, 0, len(ref_values), 1, ref_content, buf_type=gdal.GDT_Float16)
+    with gdal.Open(tmp_vsimem / "test.tif") as ds:
+        assert ds.GetMetadataItem("PREDICTOR", "IMAGE_STRUCTURE") == "3"
+        content = struct.unpack(
+            "e" * len(ref_values), ds.ReadRaster(buf_type=gdal.GDT_Float16)
+        )
+        assert content == pytest.approx(ref_values, abs=1e-6)
+
+
+###############################################################################
+#
+
+
 def test_tiff_write_5_bands_interleaved_predictor_2(tmp_vsimem):
 
     ref_content = struct.pack("B" * 10, 1, 5, 3, 2, 4, 9, 6, 8, 0, 7)

--- a/frmts/gtiff/gtiffdataset_write.cpp
+++ b/frmts/gtiff/gtiffdataset_write.cpp
@@ -5729,11 +5729,12 @@ TIFF *GTiffDataset::CreateLL(const char *pszFilename, int nXSize, int nYSize,
         }
         else if (nPredictor == 3)
         {
-            if (eType != GDT_Float32 && eType != GDT_Float64)
+            if (eType != GDT_Float16 && eType != GDT_Float32 &&
+                eType != GDT_Float64)
             {
-                ReportError(
-                    pszFilename, CE_Failure, CPLE_AppDefined,
-                    "PREDICTOR=3 is only supported with Float32 or Float64.");
+                ReportError(pszFilename, CE_Failure, CPLE_AppDefined,
+                            "PREDICTOR=3 is only supported with Float16, "
+                            "Float32 or Float64.");
                 return nullptr;
             }
         }


### PR DESCRIPTION
GTiff now supports Float16, and PREDICTOR=3 supports f16, but PREDICTOR=3 was incorrectly gated to only work with Float32+NBITS=16.
It was already documented to work, now it actually does work.

## Tasklist

 - [X] AI (Copilot or something similar) supported my development of this PR
 - [X] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [X] Add test case(s)
 - [X] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant:

* OS: MacOS 15
* Compiler: clang 17
