### PR TITLE
TileDB: fix cppcheck false positive in FillTimeOrDateArray

### DIFF
--- a/frmts/tiledb/tiledbsparse.cpp
+++ b/frmts/tiledb/tiledbsparse.cpp
@@ -4960,7 +4960,7 @@ void OGRTileDBLayer::FillTimeOrDateArray(
             }
         }
     }
-    psChild->buffers[1] = newValuesPtr->data();
+    psChild->buffers[1] = newValues.data();
 
     SetNullBuffer(psChild, iField, abyValidityFromFilters);
 }


### PR DESCRIPTION
cppcheck flags `autoVariables` at `tiledbsparse.cpp:4963` where `newValuesPtr->data()` (a local `shared_ptr`) is assigned to `psChild->buffers[1]`. The `shared_ptr` is kept alive via `psPrivateData->valueHolder`, but cppcheck can't trace ownership through `std::variant`.

Fix: use the existing `newValues` reference (`auto &newValues = *newValuesPtr`) instead. Same pointer, no suppress comment.

Breaks `cppcheck_master` on current master ([run](https://github.com/OSGeo/gdal/actions/runs/22024767830)).

## Tasklist

- [x] AI (Claude) supported my development of this PR
- [x] Make sure code is correctly formatted
- [x] All CI builds and checks have passed