### PR TITLE
Zarr v3: multiscales read docs + UUID dedup

### DIFF
--- a/doc/source/drivers/raster/zarr.rst
+++ b/doc/source/drivers/raster/zarr.rst
@@ -86,6 +86,22 @@ Sharding support
 `Zarr v3 sharding <https://zarr-specs.readthedocs.io/en/latest/v3/codecs/sharding-indexed/index.html>`__
 is supported in read-only since GDAL 3.13.
 
+Multiscales (overviews / pyramids)
+----------------------------------
+
+.. versionadded:: 3.13
+
+The driver supports reading the Zarr
+`multiscales convention <https://github.com/zarr-conventions/multiscales>`__
+for Zarr V3 datasets. This convention describes a pyramid of arrays at
+decreasing resolutions within a group hierarchy.
+
+When a Zarr V3 array has a parent (or grandparent) group whose
+attributes contain a ``zarr_conventions`` entry with the multiscales UUID and
+a ``multiscales`` attribute with a ``layout`` array, the driver exposes
+lower-resolution levels as overviews via :cpp:func:`GDALMDArray::GetOverview`
+and the classic raster band overview API.
+
 Kerchunk reference stores
 -------------------------
 
@@ -758,3 +774,5 @@ See Also:
 .. spelling:word-list::
     Kerchunk
     Sharding
+    multiscales
+    Multiscales

--- a/frmts/zarr/zarr.h
+++ b/frmts/zarr/zarr.h
@@ -31,6 +31,11 @@
 
 #define CRS_ATTRIBUTE_NAME "_CRS"
 
+// UUID identifying the multiscales zarr convention
+// (https://github.com/zarr-conventions/multiscales)
+constexpr const char *ZARR_MULTISCALES_UUID =
+    "d35379db-88df-4056-af3a-620245f8e347";
+
 const CPLCompressor *ZarrGetShuffleCompressor();
 const CPLCompressor *ZarrGetShuffleDecompressor();
 const CPLCompressor *ZarrGetQuantizeDecompressor();

--- a/frmts/zarr/zarr_v3_array.cpp
+++ b/frmts/zarr/zarr_v3_array.cpp
@@ -2237,11 +2237,7 @@ void ZarrV3Array::LoadOverviews() const
 
     const auto oZarrConventionsArray = oZarrConventions.ToArray();
     const auto hasMultiscalesUUIDLambda = [](const CPLJSONObject &obj)
-    {
-        constexpr const char *MULTISCALES_UUID =
-            "d35379db-88df-4056-af3a-620245f8e347";
-        return obj.GetString("uuid") == MULTISCALES_UUID;
-    };
+    { return obj.GetString("uuid") == ZARR_MULTISCALES_UUID; };
     const bool bFoundMultiScalesUUID =
         std::find_if(oZarrConventionsArray.begin(), oZarrConventionsArray.end(),
                      hasMultiscalesUUIDLambda) != oZarrConventionsArray.end();


### PR DESCRIPTION
## Summary

Document [multiscales convention](https://github.com/zarr-conventions/multiscales)
read support for Zarr v3 (merged in #13736). Deduplicates the multiscales UUID
constant into `zarr.h` for shared use between read and future write paths.

## Tasklist

- [x] AI (Claude) supported my development of this PR
- [x] Docs: multiscales read support section
- [x] Deduplicate `ZARR_MULTISCALES_UUID` into `zarr.h`