### PR TITLE
MiraMonRaster: Fix Fuzz issue: 484932882

### DIFF
--- a/frmts/miramon/miramon_rasterband.cpp
+++ b/frmts/miramon/miramon_rasterband.cpp
@@ -727,7 +727,13 @@ CPLErr MMRRasterBand::FromPaletteToColorTableCategoricalMode()
         {
             // In that case (byte, uint) we can limit the number
             // of colours at the maximum value that the band has.
+            if (static_cast<int>(poBand->GetMax()) == INT_MAX)
+                return CE_Failure;
             nNPossibleValues = static_cast<int>(poBand->GetMax()) + 1;
+
+            // Oss-fuzz issue: 484932882
+            if (nNPossibleValues <= 0 || nNPossibleValues >= 65536)
+                return CE_Failure;
         }
         else
         {


### PR DESCRIPTION
## What does this PR do?
Fixes Oss-fuzz issue 484932882 verifiying that a variable is not negative. If it is, then the program aborts.


## What are related issues/pull requests?
https://oss-fuzz.com/testcase-detail/5433397555298304

## Tasklist
 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Review
 - [ ] All CI builds and checks have passed