### PR TITLE
Cloned note about .vrt files from raster/vrt.rst

### DIFF
--- a/doc/source/drivers/vector/vrt.rst
+++ b/doc/source/drivers/vector/vrt.rst
@@ -19,8 +19,8 @@ The virtual files are currently normally prepared by hand.
 
 Note .vrt files starting with
 
-- <OGRVRTDataSource> open with :ref:`ogrinfo`, etc.
-- <VRTDataset> open with :ref:`gdalinfo`, etc.
+- ``<OGRVRTDataSource>`` are managed by this driver.
+- ``<VRTDataset>`` are managed by the :ref:`raster VRT <raster.vrt>` driver
 
 Driver capabilities
 -------------------


### PR DESCRIPTION
Added notes on the two flavors of VRT files.

In fact they are straight off of https://github.com/OSGeo/gdal/edit/master/doc/source/drivers/raster/vrt.rst so it is only fair that they say the same thing.