### PR TITLE
Update documentation for gdalwarp

### DIFF
--- a/doc/source/programs/gdalwarp.rst
+++ b/doc/source/programs/gdalwarp.rst
@@ -280,11 +280,11 @@ with control information.
 
     Resampling method to use. Available methods are:
 
-    ``near``: nearest neighbour resampling (default, fastest algorithm, worst interpolation quality).
+    ``near``: nearest neighbour resampling (default for non-COG drivers, fastest algorithm, worst interpolation quality).
 
     ``bilinear``: bilinear resampling.
 
-    ``cubic``: cubic resampling.
+    ``cubic``: cubic resampling (default for COG driver).
 
     ``cubicspline``: cubic spline resampling.
 


### PR DESCRIPTION
## What does this PR do?

Update the documentation for gdalwarp (or, at least, a suggestive edit) to highlight the differences between default resampling methods between COG and non-COG drivers.

Specifically, gdalwarp defaults to COG-specific cubic resampling method if dealing with COG data, and otherwise it defaults to linear. This is an undocumented behaviour, even though that code seems to be over 3 years old.

## What are related issues/pull requests?

I have not opened an issue for this specifically.

## Tasklist

 - [ ] AI (Copilot or something similar) supported my development of this PR
 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
