### PR TITLE
CI: Remove cppcheck 1.90 configuration

### DIFF
--- a/.github/workflows/code_checks.yml
+++ b/.github/workflows/code_checks.yml
@@ -20,29 +20,6 @@ permissions:
 
 jobs:
 
-  cppcheck_2004:
-    runs-on: ubuntu-latest
-    container: ubuntu:20.04
-    steps:
-      - name: Checkout
-        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-
-      - name: Install Requirements
-        run: |
-          apt update
-          apt install -y cppcheck libsqlite3-dev ccache sqlite3 libproj-dev cmake g++ make
-
-      - name: Run cmake
-        run: |
-          mkdir build
-          cd build
-          cmake ..
-
-      - name: Run cppcheck test
-        run: |
-          cd build
-          ../scripts/cppcheck.sh
-
   cppcheck_2404:
     runs-on: ubuntu-latest
     container: ubuntu:24.04


### PR DESCRIPTION
Removes a CI configuration using cppcheck 1.90, released in 2019. This will eliminate the need to work around C++17 features not understood by this version of cppcheck, such as https://trac.cppcheck.net/ticket/9630.