### PR TITLE
Doc: Add another level to Download table of contents

### DIFF
--- a/doc/source/download.rst
+++ b/doc/source/download.rst
@@ -7,7 +7,7 @@ Download
 .. only:: html
 
     .. contents::
-       :depth: 3
+       :depth: 4
        :backlinks: none
 
 The GDAL project distributes GDAL as source code and :ref:`Containers` only. :ref:`Binaries` produced by others are available for a variety of platforms and package managers.


### PR DESCRIPTION
Minor change to make the details on various package managers, such as Conda, more visible:

<img width="515" height="800" alt="image" src="https://github.com/user-attachments/assets/4c21684d-b4d8-445c-9663-5b8c959c2bef" />
