### PR TITLE
Zarr: auto-parallel chunk decompression in IRead

### DIFF
--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -4193,6 +4193,89 @@ def test_zarr_advise_read(tmp_path, compression, format):
     read()
 
 
+###############################################################################
+# Test auto-parallel IRead: GDAL_NUM_THREADS triggers IAdviseRead() internally
+
+
+@pytest.mark.parametrize("format", ["ZARR_V2", "ZARR_V3"])
+@gdaltest.enable_exceptions()
+def test_zarr_iread_auto_parallel(tmp_path, format):
+
+    filename = str(tmp_path / "test.zarr")
+    dim0_size = 100
+    dim1_size = 120
+    blocksize = 20
+    data_ar = [(i % 256) for i in range(dim0_size * dim1_size)]
+    data = array.array("B", data_ar)
+
+    ds = gdal.GetDriverByName("ZARR").CreateMultiDimensional(
+        filename, options=["FORMAT=" + format]
+    )
+    rg = ds.GetRootGroup()
+    dim0 = rg.CreateDimension("dim0", None, None, dim0_size)
+    dim1 = rg.CreateDimension("dim1", None, None, dim1_size)
+    ar = rg.CreateMDArray(
+        "test",
+        [dim0, dim1],
+        gdal.ExtendedDataType.Create(gdal.GDT_UInt8),
+        ["BLOCKSIZE=%d,%d" % (blocksize, blocksize)],
+    )
+    assert ar.Write(data) == gdal.CE_None
+    ds = None
+
+    # Reference: sequential read
+    ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
+    ar = ds.GetRootGroup().OpenMDArray("test")
+    expected_full = ar.Read()
+    expected_strided = ar.Read(
+        array_start_idx=[0, 0],
+        count=[dim0_size // 2, dim1_size // 2],
+        array_step=[2, 2],
+    )
+    expected_sub1 = ar.Read(
+        array_start_idx=[0, 0], count=[dim0_size // 2, dim1_size // 2]
+    )
+    expected_sub2 = ar.Read(
+        array_start_idx=[dim0_size // 2, dim1_size // 2],
+        count=[dim0_size // 2, dim1_size // 2],
+    )
+    ds = None
+
+    with gdal.config_option("GDAL_NUM_THREADS", "ALL_CPUS"):
+        ds = gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER)
+        ar = ds.GetRootGroup().OpenMDArray("test")
+
+        # Full read
+        assert ar.Read() == expected_full
+
+        # Strided read (step > 1): verifies adjusted count passed to
+        # IAdviseRead covers the full element range, not just count elements.
+        assert (
+            ar.Read(
+                array_start_idx=[0, 0],
+                count=[dim0_size // 2, dim1_size // 2],
+                array_step=[2, 2],
+            )
+            == expected_strided
+        )
+
+        # Two sequential sub-region reads on the same array: verifies stale
+        # cache from the first read does not block auto-parallel on the second.
+        assert (
+            ar.Read(array_start_idx=[0, 0], count=[dim0_size // 2, dim1_size // 2])
+            == expected_sub1
+        )
+        assert (
+            ar.Read(
+                array_start_idx=[dim0_size // 2, dim1_size // 2],
+                count=[dim0_size // 2, dim1_size // 2],
+            )
+            == expected_sub2
+        )
+
+        ds = None
+
+
 def test_zarr_read_invalid_nczarr_dim(tmp_vsimem):
 
     gdal.Mkdir(tmp_vsimem / "test.zarr", 0)

--- a/doc/source/drivers/raster/zarr.rst
+++ b/doc/source/drivers/raster/zarr.rst
@@ -510,8 +510,13 @@ The following dataset open options are available:
 Multi-threaded caching
 ----------------------
 
-The driver implements the :cpp:func:`GDALMDArray::AdviseRead` method. This
-proceed to multi-threaded decoding of the tiles that intersect the area of
+Starting with GDAL 3.13, when the :config:`GDAL_NUM_THREADS` configuration
+option is set and a read request spans multiple chunks, the driver automatically
+decodes chunks in parallel, similar to the GeoTIFF driver behavior
+(since GDAL 3.6). No application changes are needed.
+
+The driver also implements the :cpp:func:`GDALMDArray::AdviseRead` method for
+explicit multi-threaded pre-fetching of tiles that intersect the area of
 interest specified. A sufficient cache size must be specified. The call is
 blocking.
 

--- a/frmts/zarr/zarr_array.cpp
+++ b/frmts/zarr/zarr_array.cpp
@@ -1157,6 +1157,44 @@ bool ZarrArray::IRead(const GUInt64 *arrayStartIdx, const size_t *count,
         bufferStride = bufferStrideMod.data();
     }
 
+    // Auto-parallel: prefetch multi-chunk reads via IAdviseRead().
+    // arrayStep[i] guaranteed positive after negative-step normalization above.
+    if (nDims >= 2 && m_oChunkCache.empty())
+    {
+        const char *pszNumThreads =
+            CPLGetConfigOption("GDAL_NUM_THREADS", nullptr);
+        if (pszNumThreads != nullptr)
+        {
+            size_t nReqChunks = 1;
+            for (size_t i = 0; i < nDims; ++i)
+            {
+                const uint64_t startBlock =
+                    arrayStartIdx[i] / m_anInnerBlockSize[i];
+                const uint64_t endBlock =
+                    (arrayStartIdx[i] +
+                     (count[i] - 1) * static_cast<uint64_t>(arrayStep[i])) /
+                    m_anInnerBlockSize[i];
+                nReqChunks *= static_cast<size_t>(endBlock - startBlock + 1);
+            }
+            if (nReqChunks > 1)
+            {
+                // IAdviseRead expects the contiguous element count per
+                // dimension, not the strided output count.  When step > 1,
+                // expand count to cover the full element range.
+                std::vector<size_t> anAdjustedCount(nDims);
+                for (size_t i = 0; i < nDims; ++i)
+                {
+                    anAdjustedCount[i] =
+                        1 + (count[i] - 1) * static_cast<size_t>(arrayStep[i]);
+                }
+                CPLStringList aosOptions;
+                aosOptions.SetNameValue("NUM_THREADS", pszNumThreads);
+                CPL_IGNORE_RET_VAL(IAdviseRead(
+                    arrayStartIdx, anAdjustedCount.data(), aosOptions.List()));
+            }
+        }
+    }
+
     std::vector<uint64_t> indicesOuterLoop(nDims + 1);
     std::vector<GByte *> dstPtrStackOuterLoop(nDims + 1);
 

--- a/port/cpl_known_config_options.h
+++ b/port/cpl_known_config_options.h
@@ -349,7 +349,7 @@ constexpr static const char* const apszKnownConfigOptions[] =
    "GDAL_NETCDF_REPORT_EXTRA_DIM_VALUES", // from netcdfdataset.cpp
    "GDAL_NETCDF_VERIFY_DIMS", // from netcdfdataset.cpp
    "GDAL_NO_COSTLY_OVERVIEW", // from rasterio.cpp
-   "GDAL_NUM_THREADS", // from gdal_thread_pool.cpp, gdalalgorithm.cpp
+   "GDAL_NUM_THREADS", // from gdal_thread_pool.cpp, gdalalgorithm.cpp, zarr_array.cpp
    "GDAL_OGCAPI_TILEMATRIXSET_LIMITS", // from gdalogcapidataset.cpp
    "GDAL_ONE_BIG_READ", // from jp2kakdataset.cpp, jpipkakdataset.cpp, mrsiddataset.cpp, rawdataset.cpp, wcsdataset.cpp
    "GDAL_OPEN_AFTER_COPY", // from jpgdataset.cpp, pngdataset.cpp


### PR DESCRIPTION
## What does this PR do?

`GDAL_NUM_THREADS` auto-parallelizes GeoTIFF tile decompression since 3.6, but Zarr only parallelizes on explicit `AdviseRead()` calls - which `gdal_translate`, `gdalwarp`, and rasterio never make. This brings Zarr to parity: when `GDAL_NUM_THREADS` is set and a read spans multiple chunks, `ZarrArray::IRead()` now calls `IAdviseRead()` automatically.

Reuses the existing thread pool and chunk cache infrastructure unchanged. Falls back to sequential if chunks don't fit in half the GDAL block cache. Covers v2 and v3 (logic is in the shared `ZarrArray` base class).

### Benchmark

Sentinel-2 10980x10980, Zarr v3 ZSTD, 1830x1830 chunks, 8-core M2, median of 7.

| Scenario | Sequential | Parallel | Speedup |
|----------|-----------|----------|---------|
| single_band | 270 ms | 149 ms | 1.8x |
| rgb 3-band | 807 ms | 374 ms | 2.2x |

For reference, COG (ZSTD) on the same data achieves 3.6x (352 -> 97 ms). The higher ratio is expected: GeoTIFF decompresses directly into the output buffer while Zarr routes through the chunk cache.

<details>
<summary>Reproducible benchmark script</summary>

```python
import numpy as np, time, os, shutil
from osgeo import gdal
gdal.UseExceptions()

zarr_path, cog_path = "/tmp/bench_zarr", "/tmp/bench_cog.tif"
N, CHUNK, COG_TILE = 10980, 1830, 1824

data = np.random.RandomState(42).randint(0, 10000, (N, N), dtype=np.uint16)

ds = gdal.GetDriverByName("ZARR").Create(
    zarr_path, N, N, 1, gdal.GDT_UInt16,
    options=["FORMAT=ZARR_V3", f"BLOCKSIZE={CHUNK},{CHUNK}", "COMPRESS=ZSTD"])
ds.GetRasterBand(1).WriteArray(data); ds.FlushCache(); ds = None

gdal.Translate(cog_path, zarr_path,
    creationOptions=["COMPRESS=ZSTD", f"BLOCKXSIZE={COG_TILE}",
                     f"BLOCKYSIZE={COG_TILE}", "TILED=YES"])

def bench(path, label, n=7):
    t = []
    for _ in range(n):
        gdal.SetCacheMax(512 << 20)
        t0 = time.perf_counter()
        ds = gdal.Open(path); ds.GetRasterBand(1).ReadAsArray(); ds = None
        t.append((time.perf_counter() - t0) * 1e3)
    print(f"{label}: {sorted(t)[n//2]:.0f} ms")

for threads in [None, "ALL_CPUS"]:
    gdal.SetConfigOption("GDAL_NUM_THREADS", threads)
    tag = "parallel" if threads else "sequential"
    bench(zarr_path, f"Zarr {tag}"); bench(cog_path, f"COG  {tag}")

shutil.rmtree(zarr_path, True); os.path.exists(cog_path) and os.remove(cog_path)
```

</details>

## What are related issues/pull requests?

- #13901 - parallel inner chunk decode in BatchDecodePartial
- #13909 - parallel shard I/O in PreloadShardedBlocks
- #11824 - Zarr v3 / GeoZarr tracking issue

## Tasklist

- [x] AI (Claude) supported my development of this PR
- [x] Code is correctly formatted (pre-commit)
- [x] Add test case(s)
- [x] Add documentation
- [x] All CI builds and checks have passed