### PR TITLE
gdal pipeline: fix nullptr deref on 'read -h' pipeline in non-command line mode

### DIFF
--- a/autotest/cpp/test_gdal_algorithm.cpp
+++ b/autotest/cpp/test_gdal_algorithm.cpp
@@ -3440,12 +3440,14 @@ TEST_F(test_gdal_algorithm, various)
 
     {
         MyAlgorithm alg;
+        alg.SetCalledFromCommandLine();
         EXPECT_TRUE(alg.ParseCommandLineArguments({"-h"}));
         EXPECT_TRUE(alg.IsHelpRequested());
     }
 
     {
         MyAlgorithm alg;
+        alg.SetCalledFromCommandLine();
         EXPECT_TRUE(alg.ParseCommandLineArguments({"--help"}));
         EXPECT_TRUE(alg.IsHelpRequested());
     }
@@ -3458,6 +3460,7 @@ TEST_F(test_gdal_algorithm, various)
 
     {
         MyAlgorithm alg;
+        alg.SetCalledFromCommandLine();
         EXPECT_TRUE(alg.ParseCommandLineArguments({"--json-usage"}));
         EXPECT_TRUE(alg.IsJSONUsageRequested());
     }
@@ -4078,6 +4081,7 @@ TEST_F(test_gdal_algorithm, subalgorithms)
 
     {
         MyAlgorithm alg(hasRun);
+        alg.SetCalledFromCommandLine();
         EXPECT_TRUE(alg.ParseCommandLineArguments({"subalg", "-h"}));
         EXPECT_TRUE(alg.IsHelpRequested());
         EXPECT_TRUE(alg.ValidateArguments());

--- a/autotest/utilities/test_gdalalg_pipeline.py
+++ b/autotest/utilities/test_gdalalg_pipeline.py
@@ -1102,3 +1102,10 @@ def test_gdalalg_pipeline_tee_output_to_stdout(tmp_vsimem):
 
     with gdal.Open(tmp_vsimem / "test.xyz") as ds:
         assert ds.GetRasterBand(1).Checksum() == 4672
+
+
+def test_gdalalg_pipeline_ossfuzz_485952614():
+
+    # Used to segfault
+    with pytest.raises(Exception):
+        gdal.alg.pipeline(pipeline="read -h")

--- a/gcore/gdalalgorithm.cpp
+++ b/gcore/gdalalgorithm.cpp
@@ -1727,19 +1727,27 @@ GDALAlgorithm::GDALAlgorithm(const std::string &name,
                         ? "https://gdal.org" + m_helpURL
                         : m_helpURL)
 {
-    AddArg("help", 'h', _("Display help message and exit"), &m_helpRequested)
-        .SetHiddenForAPI()
-        .SetCategory(GAAC_COMMON)
-        .AddAction([this]() { m_specialActionRequested = true; });
-    AddArg("help-doc", 0, _("Display help message for use by documentation"),
-           &m_helpDocRequested)
-        .SetHidden()
-        .AddAction([this]() { m_specialActionRequested = true; });
-    AddArg("json-usage", 0, _("Display usage as JSON document and exit"),
-           &m_JSONUsageRequested)
-        .SetHiddenForAPI()
-        .SetCategory(GAAC_COMMON)
-        .AddAction([this]() { m_specialActionRequested = true; });
+    auto &helpArg =
+        AddArg("help", 'h', _("Display help message and exit"),
+               &m_helpRequested)
+            .SetHiddenForAPI()
+            .SetCategory(GAAC_COMMON)
+            .AddAction([this]()
+                       { m_specialActionRequested = m_calledFromCommandLine; });
+    auto &helpDocArg =
+        AddArg("help-doc", 0,
+               _("Display help message for use by documentation"),
+               &m_helpDocRequested)
+            .SetHidden()
+            .AddAction([this]()
+                       { m_specialActionRequested = m_calledFromCommandLine; });
+    auto &jsonUsageArg =
+        AddArg("json-usage", 0, _("Display usage as JSON document and exit"),
+               &m_JSONUsageRequested)
+            .SetHiddenForAPI()
+            .SetCategory(GAAC_COMMON)
+            .AddAction([this]()
+                       { m_specialActionRequested = m_calledFromCommandLine; });
     AddArg("config", 0, _("Configuration option"), &m_dummyConfigOptions)
         .SetMetaVar("<KEY>=<VALUE>")
         .SetHiddenForAPI()
@@ -1752,6 +1760,26 @@ GDALAlgorithm::GDALAlgorithm(const std::string &name,
                     "Configuration options passed with the 'config' argument "
                     "are ignored");
             });
+
+    AddValidationAction(
+        [this, &helpArg, &helpDocArg, &jsonUsageArg]()
+        {
+            if (!m_calledFromCommandLine && m_specialActionRequested)
+            {
+                for (auto &arg : {&helpArg, &helpDocArg, &jsonUsageArg})
+                {
+                    if (arg->IsExplicitlySet())
+                    {
+                        ReportError(CE_Failure, CPLE_AppDefined,
+                                    "'%s' argument only available when called "
+                                    "from command line",
+                                    arg->GetName().c_str());
+                        return false;
+                    }
+                }
+            }
+            return true;
+        });
 }
 
 /************************************************************************/


### PR DESCRIPTION
Fixes https://issues.oss-fuzz.com/issues/485952614
