### PR TITLE
Zarr: fix GetParentGroup() for root-level arrays

### DIFF
--- a/autotest/gdrivers/data/zarr/v3/root_level_multiscales/zarr.json
+++ b/autotest/gdrivers/data/zarr/v3/root_level_multiscales/zarr.json
@@ -1,0 +1,130 @@
+{
+  "attributes": {
+    "zarr_conventions": [
+      {
+        "uuid": "d35379db-88df-4056-af3a-620245f8e347",
+        "schema_url": "https://raw.githubusercontent.com/zarr-conventions/multiscales/refs/tags/v1/schema.json",
+        "spec_url": "https://github.com/zarr-conventions/multiscales/blob/v1/README.md",
+        "name": "multiscales",
+        "description": "Multiscale layout of zarr datasets"
+      }
+    ],
+    "multiscales": {
+      "layout": [
+        {
+          "asset": "ar"
+        },
+        {
+          "asset": "ovr_2x",
+          "derived_from": "ar",
+          "transform": {
+            "scale": [
+              2.0,
+              2.0
+            ],
+            "translation": [
+              0.0,
+              0.0
+            ]
+          }
+        }
+      ]
+    }
+  },
+  "zarr_format": 3,
+  "consolidated_metadata": {
+    "kind": "inline",
+    "must_understand": false,
+    "metadata": {
+      "ar": {
+        "shape": [
+          200,
+          100
+        ],
+        "data_type": "float32",
+        "chunk_grid": {
+          "name": "regular",
+          "configuration": {
+            "chunk_shape": [
+              200,
+              100
+            ]
+          }
+        },
+        "chunk_key_encoding": {
+          "name": "default",
+          "configuration": {
+            "separator": "/"
+          }
+        },
+        "fill_value": "NaN",
+        "codecs": [
+          {
+            "name": "bytes",
+            "configuration": {
+              "endian": "little"
+            }
+          }
+        ],
+        "attributes": {},
+        "dimension_names": [
+          "y",
+          "x"
+        ],
+        "zarr_format": 3,
+        "node_type": "array",
+        "storage_transformers": []
+      },
+      "ovr_2x": {
+        "attributes": {},
+        "zarr_format": 3,
+        "consolidated_metadata": {
+          "kind": "inline",
+          "must_understand": false,
+          "metadata": {}
+        },
+        "node_type": "group"
+      },
+      "ovr_2x/ar": {
+        "shape": [
+          100,
+          50
+        ],
+        "data_type": "float32",
+        "chunk_grid": {
+          "name": "regular",
+          "configuration": {
+            "chunk_shape": [
+              100,
+              50
+            ]
+          }
+        },
+        "chunk_key_encoding": {
+          "name": "default",
+          "configuration": {
+            "separator": "/"
+          }
+        },
+        "fill_value": "NaN",
+        "codecs": [
+          {
+            "name": "bytes",
+            "configuration": {
+              "endian": "little"
+            }
+          }
+        ],
+        "attributes": {},
+        "dimension_names": [
+          "y",
+          "x"
+        ],
+        "zarr_format": 3,
+        "node_type": "array",
+        "storage_transformers": []
+      }
+    }
+  },
+  "node_type": "group"
+}

--- a/autotest/gdrivers/memmultidim.py
+++ b/autotest/gdrivers/memmultidim.py
@@ -90,6 +90,10 @@ def test_mem_md_subgroup():
     assert subsubg is not None
     assert subsubg.GetFullName() == "/subgroup/subsubgroup"
 
+    root_from_fullname = rg.OpenGroupFromFullname("/")
+    assert root_from_fullname is not None
+    assert root_from_fullname.GetFullName() == "/"
+
     subg.CreateMDArray("myarray", [], gdal.ExtendedDataType.Create(gdal.GDT_UInt8))
     array = rg.OpenMDArrayFromFullname("/subgroup/myarray")
     assert array is not None

--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -7128,6 +7128,31 @@ def test_zarr_read_simple_multiscales(filename):
 
 
 ###############################################################################
+# Test reading multiscales with a root-level array (GetParentGroup nPos==0)
+
+
+@gdaltest.enable_exceptions()
+def test_zarr_read_root_level_multiscales():
+
+    filename = "data/zarr/v3/root_level_multiscales/zarr.json"
+
+    # MDArray API: root-level array should discover overviews
+    with gdal.OpenEx(filename, gdal.OF_MULTIDIM_RASTER) as ds:
+        rg = ds.GetRootGroup()
+        ar = rg.OpenMDArray("ar")
+        assert ar.GetOverviewCount() == 1
+        assert ar.GetOverview(0).GetFullName() == "/ovr_2x/ar"
+
+    # Classic API via ZARR: URI
+    store = filename.replace("/zarr.json", "")
+    with gdal.Open(f'ZARR:"{store}":/ar') as ds:
+        band = ds.GetRasterBand(1)
+        assert band.GetOverviewCount() == 1
+        assert band.GetOverview(0).YSize == 100
+        assert band.GetOverview(0).XSize == 50
+
+
+###############################################################################
 # Test reading a dataset with errors in the "multiscales" convention
 
 

--- a/frmts/zarr/zarr_array.cpp
+++ b/frmts/zarr/zarr_array.cpp
@@ -3772,11 +3772,11 @@ std::shared_ptr<ZarrGroupBase> ZarrArray::GetParentGroup() const
         if (auto poRootGroup = m_poSharedResource->GetRootGroup())
         {
             const auto nPos = m_osFullName.rfind('/');
-            if (nPos != 0 && nPos != std::string::npos)
+            if (nPos != std::string::npos)
             {
                 poGroup = std::dynamic_pointer_cast<ZarrGroupBase>(
-                    poRootGroup->OpenGroupFromFullname(
-                        m_osFullName.substr(0, nPos)));
+                    poRootGroup->OpenGroupFromFullname(m_osFullName.substr(
+                        0, std::max(static_cast<size_t>(1), nPos))));
             }
         }
     }

--- a/frmts/zarr/zarr_group.cpp
+++ b/frmts/zarr/zarr_group.cpp
@@ -589,15 +589,11 @@ std::shared_ptr<ZarrGroupBase> ZarrGroupBase::GetParentGroup() const
         if (auto poRootGroup = m_poSharedResource->GetRootGroup())
         {
             const auto nPos = m_osFullName.rfind('/');
-            if (nPos == 0)
-            {
-                poGroup = std::move(poRootGroup);
-            }
-            else if (nPos != std::string::npos)
+            if (nPos != std::string::npos)
             {
                 poGroup = std::dynamic_pointer_cast<ZarrGroupBase>(
-                    poRootGroup->OpenGroupFromFullname(
-                        m_osFullName.substr(0, nPos)));
+                    poRootGroup->OpenGroupFromFullname(m_osFullName.substr(
+                        0, std::max(static_cast<size_t>(1), nPos))));
             }
         }
     }

--- a/gcore/gdalmultidim.cpp
+++ b/gcore/gdalmultidim.cpp
@@ -1274,7 +1274,9 @@ GDALGroup::GetInnerMostGroup(const std::string &osPathOrArrayOrDim,
         CSLTokenizeString2(osPathOrArrayOrDim.c_str(), "/", 0));
     if (aosTokens.size() == 0)
     {
-        return nullptr;
+        // "/" case: the root group itself is the innermost group
+        osLastPart.clear();
+        return poCurGroup;
     }
 
     for (int i = 0; i < aosTokens.size() - 1; i++)
@@ -1467,6 +1469,8 @@ GDALGroup::OpenGroupFromFullname(const std::string &osFullName,
     auto poGroup(GetInnerMostGroup(osFullName, curGroupHolder, osName));
     if (poGroup == nullptr)
         return nullptr;
+    if (osName.empty())
+        return m_pSelf.lock();
     return poGroup->OpenGroup(osName, papszOptions);
 }
 


### PR DESCRIPTION
## What does this PR do?

`gdal_translate -of ZARR` puts the data array directly in the root group (`/array_name`). When such a store has multiscales metadata (e.g. after `BuildOverviews()` from #13980, or hand-written), the classic API (`gdal.Open('ZARR:...')`) returns 0 overviews - they're invisible.

`GetParentGroup()` does `rfind('/')` on the full name to find the parent group path. For `/ar` that returns position 0, and the `nPos != 0` guard skipped it, returning null instead of the root group. `LoadOverviews()` then silently gave up.

Fix: handle `nPos == 0` by returning the root group directly.

## What are related issues/pull requests?

Regression in #13736 (multiscales read support).

## Tasklist

- [x] AI (Claude) supported my development of this PR
- [x] Code is correctly formatted (pre-commit)
- [x] Add test case(s)
- [x] All CI builds and checks have passed