### PR TITLE
Fix buffer overflow in gdal2ogr.c

### DIFF
--- a/apps/gdal2ogr.c
+++ b/apps/gdal2ogr.c
@@ -172,9 +172,8 @@ int main(int argc, char *argv[])
         }
         fprintf(fOut, "x,y,z\n");
 
-        pszDstFilenameCSVT = CPLMalloc(strlen(pszDstFilename) + 2);
-        strcpy(pszDstFilenameCSVT, pszDstFilename);
-        strcat(pszDstFilenameCSVT, "t");
+        pszDstFilenameCSVT = (char*) CPLMalloc(strlen(pszDstFilename) + 2);
+        snprintf(pszDstFilenameCSVT, strlen(pszDstFilename) + 2, "%st", pszDstFilename);
         fOutCSVT = fopen(pszDstFilenameCSVT, "wt");
         if (fOutCSVT == NULL)
         {
@@ -187,7 +186,8 @@ int main(int argc, char *argv[])
         fOutCSVT = NULL;
 
         pszDstFilenameVRT = CPLStrdup(pszDstFilename);
-        strcpy(pszDstFilenameVRT + strlen(pszDstFilename) - 3, "vrt");
+        if (strlen(pszDstFilenameVRT) >= 3)
+            snprintf(pszDstFilenameVRT + strlen(pszDstFilenameVRT) - 3, 4, "vrt");
         fOutVRT = fopen(pszDstFilenameVRT, "wt");
         if (fOutVRT == NULL)
         {


### PR DESCRIPTION
## What does this PR do?
It fixes a buffer overflow vulnerability in [apps/gdal2ogr.c](cci:7://file:///c:/Users/BIT/OneDrive/Desktop/osgeo/gdal/apps/gdal2ogr.c:0:0-0:0) caused by the usage of unsafe string manipulation functions (`strcpy` and `strcat`). 
When creating the `.csvt` and `.vrt` destination filenames, the original code performed unprotected copies and concatenation that assumed the length of `pszDstFilename` did not exceed standard buffer space bounds, creating a potential memory corruption attack vector.
The fix replaces these operations with bounded functions (`snprintf`) to strictly limit the writes to the size of the dynamically allocated buffer.
## What are related issues/pull requests?
Resolves the Buffer Overflow vulnerability reported via static analysis #13992 
## Tasklist
 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
## Environment
Provide environment details, if relevant:
* OS: Cross-platform C vulnerability 
* Compiler: GCC/Clang/MSVC