### PR TITLE
GML: fix memory leak on invalid files with invalid geometry cross-linking

### DIFF
--- a/autotest/ogr/data/gml/ossfuzz_487160964.gml
+++ b/autotest/ogr/data/gml/ossfuzz_487160964.gml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<DbTopoFeatureCollection xmlns:gml="http://www.opengis.net/gml" xmlns:xlink="http://www.w3.org/1999/xlinj" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.geografia.toscana.it/gml/dbtopo" xmlns="http://www.geografia.toscana.it/gml/dbtopo">
+<dbTopoFeatureMembers>
+<LineeElementari>
+<geometriaLineare>
+<gml:TopoCurve>
+<gml:directedEdge>
+<gml:Edge gml:id="Edge_2">
+<gml:directedNode orientation="-" xlink:href="#Node_2">
+<gml:directedNode>
+<gml:Node gml:id="Node_2"/>
+</gml:directedNode>
+<gml:curveProperty>
+<gml:LineString>
+<gml:posList srsDimension="2">-0.4 0.4 -0.3 0.4</gml:posList>
+</gml:LineString>

--- a/autotest/ogr/ogr_gml.py
+++ b/autotest/ogr/ogr_gml.py
@@ -5433,3 +5433,13 @@ def test_ogr_gml_multiple_geom_elements_different_last_element(tmp_vsimem):
     assert f.GetGeometryRef().ExportToIsoWkt() == "POINT (3 4)"
     f = lyr.GetNextFeature()
     assert f.GetGeometryRef().ExportToIsoWkt() == "POINT (7 8)"
+
+
+###############################################################################
+# Test that we don't leak memory on that invalid file
+
+
+def test_ogr_gml_ossfuzz_487160964():
+
+    with gdal.quiet_errors():
+        ogr.Open("data/gml/ossfuzz_487160964.gml")


### PR DESCRIPTION
Fixes https://issues.oss-fuzz.com/issues/487160964
