### PR TITLE
NITF: Prevent missing creation option metadata if JPEG not supported

### DIFF
--- a/frmts/nitf/nitfdataset.cpp
+++ b/frmts/nitf/nitfdataset.cpp
@@ -7489,8 +7489,9 @@ void NITFDriver::InitCreationOptionList()
         "progressive mode'/>"
         "   <Option name='RESTART_INTERVAL' type='int' description='Restart "
         "interval (in MCUs). -1 for auto, 0 for none, > 0 for user specified' "
-        "default='-1'/>"
+        "default='-1'/>";
 #endif
+    osCreationOptions +=
         "   <Option name='NUMI' type='int' default='1' description='Number of "
         "images to create (1-999). Only works with IC=NC if "
         "WRITE_ONLY_FIRST_IMAGE=NO'/>"


### PR DESCRIPTION
Should fix

```
/__w/gdal/gdal/frmts/nitf/nitfdataset.cpp: In member function 'void NITFDriver::InitCreationOptionList()':
/__w/gdal/gdal/frmts/nitf/nitfdataset.cpp:7494:9: warning: statement has no effect [-Wunused-value]
 7494 |         "   <Option name='NUMI' type='int' default='1' description='Number of "
      |         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 7495 |         "images to create (1-999). Only works with IC=NC if "
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 7496 |         "WRITE_ONLY_FIRST_IMAGE=NO'/>"
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 7497 |         "   <Option name='WRITE_ONLY_FIRST_IMAGE' type='boolean' default='NO' "
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 7498 |         "description='To be used with NUMI. If YES, only write first image. "
      |         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 7499 |         "Subsequent one must be written with APPEND_SUBDATASET=YES'/>";
```

https://github.com/OSGeo/gdal/actions/runs/22415709210/job/64900666465?pr=14007#step:5:1145