### PR TITLE
Python bindings: make gdal.config_option[s] error out on GDAL_CACHEMAX…

### DIFF
--- a/autotest/gcore/basic_test.py
+++ b/autotest/gcore/basic_test.py
@@ -1210,3 +1210,26 @@ def test_basic_exclude_driver_at_open_time():
             gdal.OF_RASTER | gdal.OF_VERBOSE_ERROR,
             allowed_drivers=["-GTiff", "-LIBERTIFF"],
         )
+
+
+@gdaltest.enable_exceptions()
+def test_basic_config_option_GDAL_CACHEMAX():
+
+    with pytest.raises(
+        Exception,
+        match="Setting GDAL_CACHEMAX has process-wide visibility, and is thus incompatible of the thread_local=True argument of gdal.config_option",
+    ):
+        with gdal.config_option("GDAL_CACHEMAX", 1):
+            pass
+
+    old_val = gdal.GetCacheMax()
+    with gdal.config_option("GDAL_CACHEMAX", 1, thread_local=False):
+        assert gdal.GetCacheMax() == 1
+    assert gdal.GetCacheMax() == old_val
+
+    with pytest.raises(
+        Exception,
+        match="Setting GDAL_CACHEMAX has process-wide visibility, and is thus incompatible of the thread_local=True argument of gdal.config_options",
+    ):
+        with gdal.config_options({"GDAL_CACHEMAX": 1}):
+            pass

--- a/port/cpl_conv.cpp
+++ b/port/cpl_conv.cpp
@@ -2060,6 +2060,10 @@ static void CPLSetConfigOptionDetectUnknownConfigOption(const char *pszKey,
  * value (note: passing NULL will not unset an existing environment variable;
  * it will just unset a value previously set by CPLSetConfigOption()).
  *
+ * Note that setting the GDAL_CACHEMAX configuration option after at least one
+ * raster has been read will be without effect. Use GDALSetCacheMax64()
+ * instead.
+ *
  * Starting with GDAL 3.11, if CPL_DEBUG is enabled prior to this call, and
  * CPLSetConfigOption() is called with a key that is neither a known
  * configuration option of GDAL itself, or one that has been declared with
@@ -2121,6 +2125,10 @@ static void CPLSetThreadLocalTLSFreeFunc(void *pData)
  * a value set through CPLSetConfigOption();
  * it will just unset a value previously set by
  * CPLSetThreadLocalConfigOption()).
+ *
+ * Note that setting the GDAL_CACHEMAX configuration option after at least one
+ * raster has been read will be without effect. Use GDALSetCacheMax64()
+ * instead.
  *
  * @param pszKey the key of the option
  * @param pszValue the value of the option, or NULL to clear a setting.

--- a/swig/include/python/gdal_python.i
+++ b/swig/include/python/gdal_python.i
@@ -6034,7 +6034,7 @@ def config_options(options, thread_local=True):
             Dictionary of configuration options passed as key, value
        thread_local : bool, default=True
             Whether the configuration options should be only set on the current
-            thread.
+            thread. Note that GDAL_CACHEMAX cannot be set with thread_local=True.
 
        Returns
        -------
@@ -6051,15 +6051,25 @@ def config_options(options, thread_local=True):
     get_config_option = GetThreadLocalConfigOption if thread_local else GetGlobalConfigOption
     set_config_option = SetThreadLocalConfigOption if thread_local else SetConfigOption
 
+    if thread_local and "GDAL_CACHEMAX" in options:
+        raise ValueError("Setting GDAL_CACHEMAX has process-wide visibility, and is thus incompatible of the thread_local=True argument of gdal.config_options()")
+
     oldvals = {key: get_config_option(key) for key in options}
+    old_gdal_cache_max = GetCacheMax() if "GDAL_CACHEMAX" in options else None
 
     for key in options:
-        set_config_option(key, options[key])
+        if key == "GDAL_CACHEMAX":
+            SetCacheMax(int(options[key]))
+        else:
+            set_config_option(key, options[key])
     try:
         yield
     finally:
         for key in options:
-            set_config_option(key, oldvals[key])
+            if key == "GDAL_CACHEMAX":
+                SetCacheMax(int(old_gdal_cache_max))
+            else:
+                set_config_option(key, oldvals[key])
 
 
 def config_option(key, value, thread_local=True):
@@ -6073,7 +6083,7 @@ def config_option(key, value, thread_local=True):
             Value of the configuration option
        thread_local : bool, default=True
             Whether the configuration option should be only set on the current
-            thread.
+            thread. Note that GDAL_CACHEMAX cannot be set with thread_local=True.
 
        Returns
        -------
@@ -6087,6 +6097,10 @@ def config_option(key, value, thread_local=True):
        ...     gdal.Warp("out.tif", "in.tif", dstSRS="EPSG:4326")
        <osgeo.gdal.Dataset; proxy of <Swig Object of type 'GDALDatasetShadow *' at 0x...> >
     """
+
+    if thread_local and key == "GDAL_CACHEMAX":
+        raise ValueError("Setting GDAL_CACHEMAX has process-wide visibility, and is thus incompatible of the thread_local=True argument of gdal.config_option()")
+
     return config_options({key: value}, thread_local=thread_local)
 
 


### PR DESCRIPTION
… if thread_local=True, and otherwise use gdal.SetCacheMax()

Fixes #14004
