### PR TITLE
Zarr v3: cache shard indices in BatchDecodePartial

### DIFF
--- a/frmts/zarr/zarr.h
+++ b/frmts/zarr/zarr.h
@@ -1498,5 +1498,7 @@ class ZarrV3Array final : public ZarrArray
 };
 
 void ZarrClearCoordinateCache();
+void ZarrClearShardIndexCache();
+void ZarrEraseShardIndexFromCache(const std::string &osFilename);
 
 #endif  // ZARR_H

--- a/frmts/zarr/zarr_v3_array.cpp
+++ b/frmts/zarr/zarr_v3_array.cpp
@@ -743,7 +743,8 @@ lbl_next:
             anRequests.push_back({info.anStartIdx, info.anCount});
 
         std::vector<ZarrByteVectorQuickResize> aResults;
-        if (!poCodecs->BatchDecodePartial(fp.get(), anRequests, aResults))
+        if (!poCodecs->BatchDecodePartial(fp.get(), work.posFilename->c_str(),
+                                          anRequests, aResults))
             return;
 
         // Type-convert outside mutex (CPU-bound, thread-local data)
@@ -1395,6 +1396,8 @@ bool ZarrV3Array::FlushSingleShard(const std::string &osFilename,
         bRet = false;
     }
     VSIFCloseL(fp);
+    if (bRet)
+        ZarrEraseShardIndexFromCache(osFilename);
     return bRet;
 }
 

--- a/frmts/zarr/zarr_v3_codec.h
+++ b/frmts/zarr/zarr_v3_codec.h
@@ -456,11 +456,11 @@ class ZarrV3CodecShardingIndexed final : public ZarrV3Codec
 
     /** Batch-read multiple inner chunks from the same shard via two
      *  ReadMultiRange() passes (index entries, then data), then decode.
-     *  No persistent state is kept — each call reads the needed index
-     *  entries on demand.
+     *  pszFilename is used as a cache key for the shard index; pass nullptr
+     *  to bypass the cache.
      */
     bool BatchDecodePartial(
-        VSIVirtualHandle *poFile,
+        VSIVirtualHandle *poFile, const char *pszFilename,
         const std::vector<std::pair<std::vector<size_t>, std::vector<size_t>>>
             &anRequests,
         std::vector<ZarrByteVectorQuickResize> &aResults);
@@ -526,9 +526,10 @@ class ZarrV3CodecSequence
     /** Batch-read multiple inner chunks via ReadMultiRange().
      *  Delegates to the sharding codec if present, otherwise falls back
      *  to sequential DecodePartial() calls.
+     *  pszFilename is forwarded to the sharding codec for index caching.
      */
     bool BatchDecodePartial(
-        VSIVirtualHandle *poFile,
+        VSIVirtualHandle *poFile, const char *pszFilename,
         const std::vector<std::pair<std::vector<size_t>, std::vector<size_t>>>
             &anRequests,
         std::vector<ZarrByteVectorQuickResize> &aResults);

--- a/frmts/zarr/zarr_v3_codec_sequence.cpp
+++ b/frmts/zarr/zarr_v3_codec_sequence.cpp
@@ -288,7 +288,7 @@ bool ZarrV3CodecSequence::DecodePartial(VSIVirtualHandle *poFile,
 /************************************************************************/
 
 bool ZarrV3CodecSequence::BatchDecodePartial(
-    VSIVirtualHandle *poFile,
+    VSIVirtualHandle *poFile, const char *pszFilename,
     const std::vector<std::pair<std::vector<size_t>, std::vector<size_t>>>
         &anRequests,
     std::vector<ZarrByteVectorQuickResize> &aResults)
@@ -302,7 +302,8 @@ bool ZarrV3CodecSequence::BatchDecodePartial(
             m_apoCodecs.back().get());
         if (poSharding)
         {
-            return poSharding->BatchDecodePartial(poFile, anRequests, aResults);
+            return poSharding->BatchDecodePartial(poFile, pszFilename,
+                                                  anRequests, aResults);
         }
     }
 

--- a/frmts/zarr/zarrdriver.cpp
+++ b/frmts/zarr/zarrdriver.cpp
@@ -763,6 +763,7 @@ static CPLErr ZarrDatasetCopyFiles(const char *pszNewName,
 static void ZarrDriverClearCaches(GDALDriver *)
 {
     ZarrClearCoordinateCache();
+    ZarrClearShardIndexCache();
 }
 
 /************************************************************************/

--- a/port/cpl_known_config_options.h
+++ b/port/cpl_known_config_options.h
@@ -437,6 +437,7 @@ constexpr static const char* const apszKnownConfigOptions[] =
    "GDAL_WARP_USE_TRANSLATION_OPTIM", // from gdalwarpoperation.cpp
    "GDAL_WMS_MAX_CONNECTIONS", // from gdalogcapidataset.cpp
    "GDAL_XML_VALIDATION", // from ogrgmlasconf.cpp, ogrvrtdriver.cpp, pdfcreatefromcomposition.cpp
+   "GDAL_ZARR_SHARD_INDEX_CACHE_MAX_BYTES", // from zarr_v3_codec_sharding.cpp
    "GDAL_ZARR_USE_OPTIMIZED_CODE_PATHS", // from zarr_array.cpp
    "GDALCUTLINE_SKIP_CONTAINMENT_TEST", // from gdalcutline.cpp
    "GDALWARP_DENSIFY_CUTLINE", // from gdalwarp_lib.cpp


### PR DESCRIPTION
## What does this PR do?

### Problem

Each `BatchDecodePartial` call reads shard index entries individually via `ReadMultiRange` - each 16-byte entry becomes a separate HTTP GET. A 9x9 chunk window generates 81 index GETs. Panning in QGIS fires repeated `BatchDecodePartial` calls on the same 1-2 shards, re-fetching the same index every time.

### Solution

Two changes to Pass 1 (index read) in `BatchDecodePartial()`:

1. **Contiguous index read**: instead of 81 individual 16-byte range requests, read the full shard index in a single `Read()` call. For the 9x9 case this is one 5.9 KB read instead of 81 separate GETs.

2. **LRU cache**: store the index in a process-wide LRU cache (64 entries, keyed by shard filename, mutex-protected). On the first read the index is fetched and cached. Every subsequent read on the same shard pays 0 index GETs - a `memcpy` from the cache replaces the network request.

Shards whose index exceeds `GDAL_ZARR_SHARD_INDEX_CACHE_MAX_BYTES` (default 1 MiB) skip the cache and fall back to per-entry `ReadMultiRange`.

Cache invalidation:
- `ZarrDriverClearCaches()` clears all cached indices (via `ZarrClearShardIndexCache()`)
- `FlushSingleShard()` erases the specific shard entry after a successful write (via `ZarrEraseShardIndexFromCache()`)

Pass 2 (data chunk read) is unchanged. Data chunk sort/merge is in #14020.

## What are related issues/pull requests?

- #14018 - Zarr v3: reduce HTTP GETs for sharded reads
- #11824 - Zarr v3 / GeoZarr tracking issue

<details><summary>Benchmark</summary>

EOPF Sentinel-2 r10m, shape [10980,10980], 1 shard, 244x244 inner chunks, blosc/zstd. Chunk-aligned read: `ReadRaster(3904, 3904, 2196, 2196)` (3904=16x244, 2196=9x244). Measured Feb 2026, GDAL 3.13.0dev.

```bash
CPL_DEBUG=VSICURL \
  python3 -c "
from osgeo import gdal; gdal.UseExceptions()
uri = 'ZARR:\"/vsicurl/https://s3.explorer.eopf.copernicus.eu/esa-zarr-sentinel-explorer-fra/tests-output/sentinel-2-l2a/S2C_MSIL2A_20260223T114351_N0512_R123_T30VVM_20260223T143408.zarr/measurements/reflectance/r10m/b04\"'
ds = gdal.Open(uri)
ds.ReadRaster(3904, 3904, 2196, 2196)
" 2>&1 | grep -c 'VSICURL: Downloading'
```

| | master | this PR | delta |
|---|---|---|---|
| total GETs | 93 | 15 | -84% |
| index GETs | 81 | 1 | -99% |
| data GETs | 9 | 11 | (merged by VSICURL) |
| metadata | 3 | 3 | zarr.json reads |

On warm reads (2nd+ pan/zoom on same shard): 0 index GETs.

</details>

## AI tool usage

- [x] AI (Claude) supported my development of this PR.

## Tasklist

- [x] Make sure code is correctly formatted (cf pre-commit configuration)
- [x] Add test case(s) (`test_zarr_read_sharding_index_cache` in `zarr_driver.py`)
- [x] Add documentation (`GDAL_ZARR_SHARD_INDEX_CACHE_MAX_BYTES` added to `cpl_known_config_options.h`)
- [x] All CI builds and checks have passed