### PR TITLE
GPKG/SQL/SQL SQLite: error out when trying to execute multiple statements

### DIFF
--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -11447,3 +11447,37 @@ def test_ogr_gpkg_ST_Hilbert(tmp_vsimem):
         with pytest.raises(Exception, match="Invalid argument type for 2nd argument"):
             with ds.ExecuteSQL("SELECT ST_Hilbert(geom, NULL) FROM test") as sql_lyr:
                 pass
+
+
+###############################################################################
+# Check that we detect multiple statements and error out
+
+
+@gdaltest.enable_exceptions()
+@pytest.mark.parametrize(
+    "sql,error_expected",
+    [
+        ("SELECT 1", False),
+        ("SELECT 1 ", False),
+        ("SELECT 1\t", False),
+        ("SELECT 1\n", False),
+        ("SELECT 1\r", False),
+        ("SELECT 1 -- ok SELECT 2", False),
+        ("SELECT 1 -- ok\n-- disabled", False),
+        ("SELECT 1 /* ok SELECT 2 */ ", False),
+        ("SELECT 1 /* ok\nSELECT 2 */", False),
+        # Error cases
+        ("SELECT 1;SELECT 2", True),
+        ("SELECT 1;\nSELECT 2", True),
+        ("SELECT 1; -- \nSELECT 2", True),
+    ],
+)
+def test_ogr_gpkg_detect_multiple_statements(sql, error_expected):
+    ds = ogr.Open("data/gpkg/poly_golden.gpkg")
+    if error_expected:
+        with pytest.raises(Exception, match="Multiple statements are not supported"):
+            with ds.ExecuteSQL(sql):
+                pass
+    else:
+        with ds.ExecuteSQL(sql):
+            pass

--- a/autotest/ogr/ogr_sql_sqlite.py
+++ b/autotest/ogr/ogr_sql_sqlite.py
@@ -2467,3 +2467,37 @@ def test_ogr_sql_sqlite_execute_sql_error_on_spatial_filter_shp_layer(tmp_vsimem
         Exception, match="Cannot set spatial filter: no geometry field present in layer"
     ):
         ds.ExecuteSQL("SELECT 1 FROM test", spatialFilter=geom, dialect="SQLITE")
+
+
+###############################################################################
+# Check that we detect multiple statements and error out
+
+
+@gdaltest.enable_exceptions()
+@pytest.mark.parametrize(
+    "sql,error_expected",
+    [
+        ("SELECT 1", False),
+        ("SELECT 1 ", False),
+        ("SELECT 1\t", False),
+        ("SELECT 1\n", False),
+        ("SELECT 1\r", False),
+        ("SELECT 1 -- ok SELECT 2", False),
+        ("SELECT 1 -- ok\n-- disabled", False),
+        ("SELECT 1 /* ok SELECT 2 */ ", False),
+        ("SELECT 1 /* ok\nSELECT 2 */", False),
+        # Error cases
+        ("SELECT 1;SELECT 2", True),
+        ("SELECT 1;\nSELECT 2", True),
+        ("SELECT 1; -- \nSELECT 2", True),
+    ],
+)
+def test_ogr_sql_sqlite_detect_multiple_statements(sql, error_expected):
+    ds = ogr.Open("data/poly.shp")
+    if error_expected:
+        with pytest.raises(Exception, match="Multiple statements are not supported"):
+            with ds.ExecuteSQL(sql, dialect="SQLite"):
+                pass
+    else:
+        with ds.ExecuteSQL(sql, dialect="SQLite"):
+            pass

--- a/autotest/ogr/ogr_sqlite.py
+++ b/autotest/ogr/ogr_sqlite.py
@@ -4757,3 +4757,37 @@ def test_ogr_sqlite_ST_Hilbert(tmp_vsimem, require_spatialite):
                 "SELECT ST_Hilbert(geometry, NULL) FROM test"
             ) as sql_lyr:
                 pass
+
+
+###############################################################################
+# Check that we detect multiple statements and error out
+
+
+@gdaltest.enable_exceptions()
+@pytest.mark.parametrize(
+    "sql,error_expected",
+    [
+        ("SELECT 1", False),
+        ("SELECT 1 ", False),
+        ("SELECT 1\t", False),
+        ("SELECT 1\n", False),
+        ("SELECT 1\r", False),
+        ("SELECT 1 -- ok SELECT 2", False),
+        ("SELECT 1 -- ok\n-- disabled", False),
+        ("SELECT 1 /* ok SELECT 2 */ ", False),
+        ("SELECT 1 /* ok\nSELECT 2 */", False),
+        # Error cases
+        ("SELECT 1;SELECT 2", True),
+        ("SELECT 1;\nSELECT 2", True),
+        ("SELECT 1; -- \nSELECT 2", True),
+    ],
+)
+def test_ogr_sqlite_detect_multiple_statements(sql, error_expected):
+    ds = ogr.Open(":memory:")
+    if error_expected:
+        with pytest.raises(Exception, match="Multiple statements are not supported"):
+            with ds.ExecuteSQL(sql):
+                pass
+    else:
+        with ds.ExecuteSQL(sql):
+            pass

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -7644,8 +7644,6 @@ OGRLayer *GDALGeoPackageDataset::ExecuteSQL(const char *pszSQLCommand,
     /* -------------------------------------------------------------------- */
     /*      Prepare statement.                                              */
     /* -------------------------------------------------------------------- */
-    sqlite3_stmt *hSQLStmt = nullptr;
-
     /* This will speed-up layer creation */
     /* ORDER BY are costly to evaluate and are not necessary to establish */
     /* the layer definition. */
@@ -7668,32 +7666,30 @@ OGRLayer *GDALGeoPackageDataset::ExecuteSQL(const char *pszSQLCommand,
         }
     }
 
-    int rc = prepareSql(hDB, osSQLCommandTruncated.c_str(),
-                        static_cast<int>(osSQLCommandTruncated.size()),
-                        &hSQLStmt, nullptr);
-
-    if (rc != SQLITE_OK)
+    const auto nErrorCount = CPLGetErrorCounter();
+    sqlite3_stmt *hSQLStmt =
+        prepareSql(hDB, osSQLCommandTruncated.c_str(),
+                   static_cast<int>(osSQLCommandTruncated.size()));
+    if (!hSQLStmt)
     {
-        CPLError(CE_Failure, CPLE_AppDefined,
-                 "In ExecuteSQL(): sqlite3_prepare_v2(%s): %s",
-                 osSQLCommandTruncated.c_str(), sqlite3_errmsg(hDB));
-
-        if (hSQLStmt != nullptr)
+        if (nErrorCount == CPLGetErrorCounter())
         {
-            sqlite3_finalize(hSQLStmt);
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "In ExecuteSQL(): sqlite3_prepare_v2(%s): %s",
+                     osSQLCommandTruncated.c_str(), sqlite3_errmsg(hDB));
         }
-
         return nullptr;
     }
 
     /* -------------------------------------------------------------------- */
     /*      Do we get a resultset?                                          */
     /* -------------------------------------------------------------------- */
-    rc = sqlite3_step(hSQLStmt);
+    int rc = sqlite3_step(hSQLStmt);
 
     for (auto &poLayer : m_apoLayers)
     {
-        poLayer->RunDeferredDropRTreeTableIfNecessary();
+        if (!poLayer->RunDeferredDropRTreeTableIfNecessary())
+            return nullptr;
     }
 
     if (rc != SQLITE_ROW)

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitebase.h
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitebase.h
@@ -257,12 +257,10 @@ class OGRSQLiteBaseDataSource CPL_NON_FINAL : public GDALPamDataset
     bool AreSpatialiteTriggersSafe();
 
     // sqlite3_prepare_v2 error logging wrapper
-    int
-    prepareSql(sqlite3 *db,           /* Database handle */
-               const char *zSql,      /* SQL statement, UTF-8 encoded */
-               int nByte,             /* Maximum length of zSql in bytes. */
-               sqlite3_stmt **ppStmt, /* OUT: Statement handle */
-               const char **pzTail /* OUT: Pointer to unused portion of zSql */
+    sqlite3_stmt *
+    prepareSql(sqlite3 *db,      /* Database handle */
+               const char *zSql, /* SQL statement, UTF-8 encoded */
+               int nByte = -1    /* Maximum length of zSql in bytes. */
     );
 
     GDALQueryLoggerFunc pfnQueryLoggerFunc = nullptr;

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
@@ -874,18 +874,24 @@ OGRSQLiteBaseDataSource::GetRelationship(const std::string &name) const
 /*                             prepareSql()                             */
 /************************************************************************/
 
-int OGRSQLiteBaseDataSource::prepareSql(sqlite3 *db, const char *zSql,
-                                        int nByte, sqlite3_stmt **ppStmt,
-                                        const char **pzTail)
+sqlite3_stmt *OGRSQLiteBaseDataSource::prepareSql(sqlite3 *db, const char *zSql,
+                                                  int nByte)
 {
-    const int rc{sqlite3_prepare_v2(db, zSql, nByte, ppStmt, pzTail)};
+    sqlite3_stmt *stmt = nullptr;
+    const char *pszTail = nullptr;
+    const int rc = sqlite3_prepare_v2(db, zSql, nByte, &stmt, &pszTail);
     if (rc != SQLITE_OK && pfnQueryLoggerFunc)
     {
         std::string error{"Error preparing query: "};
         error.append(sqlite3_errmsg(db));
         pfnQueryLoggerFunc(zSql, error.c_str(), -1, -1, poQueryLoggerArg);
     }
-    return rc;
+    else if (pszTail && SQLHasRemainingContent(pszTail))
+    {
+        sqlite3_finalize(stmt);
+        stmt = nullptr;
+    }
+    return stmt;
 }
 
 /************************************************************************/
@@ -2054,8 +2060,7 @@ bool OGRSQLiteDataSource::InitWithEPSG()
                                 nSRSId, nSRSId);
                     }
 
-                    sqlite3_stmt *hInsertStmt = nullptr;
-                    rc = prepareSql(hDB, osCommand, -1, &hInsertStmt, nullptr);
+                    sqlite3_stmt *hInsertStmt = prepareSql(hDB, osCommand, -1);
 
                     if (pszProjCS)
                     {
@@ -2124,12 +2129,14 @@ bool OGRSQLiteDataSource::InitWithEPSG()
                                      "VALUES (%d, 'EPSG', '%d', ?)",
                                      nSRSId, nSRSId);
 
-                    sqlite3_stmt *hInsertStmt = nullptr;
-                    rc = prepareSql(hDB, osCommand, -1, &hInsertStmt, nullptr);
+                    sqlite3_stmt *hInsertStmt =
+                        prepareSql(hDB, osCommand.c_str());
 
-                    if (rc == SQLITE_OK)
+                    if (hInsertStmt)
                         rc = sqlite3_bind_text(hInsertStmt, 1, pszWKT, -1,
                                                SQLITE_STATIC);
+                    else
+                        rc = SQLITE_ERROR;
 
                     if (rc == SQLITE_OK)
                         rc = sqlite3_step(hInsertStmt);
@@ -3300,8 +3307,6 @@ OGRLayer *OGRSQLiteDataSource::ExecuteSQL(const char *pszSQLCommand,
     /* -------------------------------------------------------------------- */
     /*      Prepare statement.                                              */
     /* -------------------------------------------------------------------- */
-    sqlite3_stmt *hSQLStmt = nullptr;
-
     CPLString osSQLCommand = pszSQLCommand;
 
     /* This will speed-up layer creation */
@@ -3325,28 +3330,25 @@ OGRLayer *OGRSQLiteDataSource::ExecuteSQL(const char *pszSQLCommand,
         }
     }
 
-    int rc =
-        prepareSql(GetDB(), osSQLCommand.c_str(),
-                   static_cast<int>(osSQLCommand.size()), &hSQLStmt, nullptr);
+    const auto nErrorCount = CPLGetErrorCounter();
+    sqlite3_stmt *hSQLStmt = prepareSql(GetDB(), osSQLCommand.c_str(),
+                                        static_cast<int>(osSQLCommand.size()));
 
-    if (rc != SQLITE_OK)
+    if (!hSQLStmt)
     {
-        CPLError(CE_Failure, CPLE_AppDefined,
-                 "In ExecuteSQL(): sqlite3_prepare_v2(%s):\n  %s",
-                 osSQLCommand.c_str(), sqlite3_errmsg(GetDB()));
-
-        if (hSQLStmt != nullptr)
+        if (nErrorCount == CPLGetErrorCounter())
         {
-            sqlite3_finalize(hSQLStmt);
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "In ExecuteSQL(): sqlite3_prepare_v2(%s):\n  %s",
+                     osSQLCommand.c_str(), sqlite3_errmsg(GetDB()));
         }
-
         return nullptr;
     }
 
     /* -------------------------------------------------------------------- */
     /*      Do we get a resultset?                                          */
     /* -------------------------------------------------------------------- */
-    rc = sqlite3_step(hSQLStmt);
+    int rc = sqlite3_step(hSQLStmt);
     if (rc != SQLITE_ROW)
     {
         if (rc != SQLITE_DONE)
@@ -4558,14 +4560,16 @@ int OGRSQLiteDataSource::FetchSRSId(const OGRSpatialReference *poSRS)
             "SELECT srid FROM spatial_ref_sys WHERE proj4text = ? LIMIT 2");
     }
 
-    sqlite3_stmt *hSelectStmt = nullptr;
-    int rc = prepareSql(hDB, osCommand, -1, &hSelectStmt, nullptr);
+    sqlite3_stmt *hSelectStmt = prepareSql(hDB, osCommand.c_str());
 
-    if (rc == SQLITE_OK)
+    int rc = SQLITE_OK;
+    if (hSelectStmt)
         rc = sqlite3_bind_text(hSelectStmt, 1,
                                (pszSRTEXTColName != nullptr) ? osWKT.c_str()
                                                              : osProj4.c_str(),
                                -1, SQLITE_STATIC);
+    else
+        rc = SQLITE_ERROR;
 
     if (rc == SQLITE_OK)
         rc = sqlite3_step(hSelectStmt);
@@ -4791,14 +4795,14 @@ int OGRSQLiteDataSource::FetchSRSId(const OGRSpatialReference *poSRS)
         }
     }
 
-    sqlite3_stmt *hInsertStmt = nullptr;
-    rc = prepareSql(hDB, osCommand, -1, &hInsertStmt, nullptr);
+    sqlite3_stmt *hInsertStmt = prepareSql(hDB, osCommand.c_str());
+    if (!hInsertStmt)
+        rc = SQLITE_ERROR;
 
-    for (int i = 0; apszToInsert[i] != nullptr; i++)
+    for (int i = 0; rc == SQLITE_OK && apszToInsert[i] != nullptr; i++)
     {
-        if (rc == SQLITE_OK)
-            rc = sqlite3_bind_text(hInsertStmt, i + 1, apszToInsert[i], -1,
-                                   SQLITE_STATIC);
+        rc = sqlite3_bind_text(hInsertStmt, i + 1, apszToInsert[i], -1,
+                               SQLITE_STATIC);
     }
 
     if (rc == SQLITE_OK)

--- a/ogr/ogrsf_frmts/sqlite/ogrsqliteexecutesql.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqliteexecutesql.cpp
@@ -1095,7 +1095,8 @@ OGRLayer *OGRSQLiteExecuteSQL(GDALDataset *poDS, const char *pszStatement,
     bool bEmptyLayer = false;
 
     sqlite3_stmt *hSQLStmt = nullptr;
-    int rc = sqlite3_prepare_v2(hDB, pszStatement, -1, &hSQLStmt, nullptr);
+    const char *pszTail = nullptr;
+    int rc = sqlite3_prepare_v2(hDB, pszStatement, -1, &hSQLStmt, &pszTail);
 
     if (rc != SQLITE_OK)
     {
@@ -1106,8 +1107,16 @@ OGRLayer *OGRSQLiteExecuteSQL(GDALDataset *poDS, const char *pszStatement,
         if (hSQLStmt != nullptr)
         {
             sqlite3_finalize(hSQLStmt);
+            hSQLStmt = nullptr;
         }
-
+    }
+    else if (pszTail && SQLHasRemainingContent(pszTail))
+    {
+        sqlite3_finalize(hSQLStmt);
+        hSQLStmt = nullptr;
+    }
+    if (!hSQLStmt)
+    {
         delete poSQLiteDS;
         VSIUnlink(pszTmpDBName);
         CPLFree(pszTmpDBName);

--- a/ogr/ogrsf_frmts/sqlite/ogrsqliteutility.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqliteutility.cpp
@@ -1061,3 +1061,44 @@ int SQLPrepareWithError(sqlite3 *db, const char *sql, int nByte,
     }
     return ret;
 }
+
+/** Returns true if pszTail (has set by sqlite3_prepare_v2) has still
+ * remaining non-blank / non-comment content.
+ */
+bool SQLHasRemainingContent(const char *pszTail)
+{
+    bool bInCComment = false;
+    bool bInSingleLineComment = false;
+    for (; *pszTail; ++pszTail)
+    {
+        const char c = *pszTail;
+        const char cNext = pszTail[1];
+        if (c == ' ' || c == '\t')
+        {
+            continue;
+        }
+        else if (c == '\n' || c == '\r')
+        {
+            bInSingleLineComment = false;
+        }
+        else if (c == '-' && cNext == '-')
+        {
+            bInSingleLineComment = true;
+        }
+        else if (c == '/' && cNext == '*')
+        {
+            bInCComment = true;
+        }
+        else if (bInCComment && c == '*' && cNext == '/')
+        {
+            bInCComment = false;
+        }
+        else if (!bInCComment && !bInSingleLineComment)
+        {
+            CPLError(CE_Failure, CPLE_NotSupported,
+                     "Multiple statements are not supported");
+            return true;
+        }
+    }
+    return false;
+}

--- a/ogr/ogrsf_frmts/sqlite/ogrsqliteutility.h
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqliteutility.h
@@ -104,4 +104,6 @@ void OGRSQLite_gdal_get_pixel_value_common(const char *pszFunctionName,
 bool SQLCheckLineIsSafe(const char *pszLine);
 #endif
 
+bool SQLHasRemainingContent(const char *pszTail);
+
 #endif  // OGR_SQLITEUTILITY_H_INCLUDED


### PR DESCRIPTION
sqlite3_prepare_v2() only parses the first statement, and sets in ``*ppszTail`` the rest of the unparsed string. Check if it contains other content, but skip white space, single line comments (--) and C-like comments (/* */). This is similar to what python's sqlite3 module does.

Fixes #14016
