### PR TITLE
GTiff: dataset creation: do not trigger output directory listing if GDAL_DISABLE_READDIR_ON_OPEN=TRUE

### DIFF
--- a/autotest/gcore/tiff_write.py
+++ b/autotest/gcore/tiff_write.py
@@ -12536,6 +12536,11 @@ def test_tiff_write_rat(tmp_vsimem, GTIFF_WRITE_RAT_TO_PAM):
         else:
             assert gdal.VSIStatL(str(filename2) + ".aux.xml") is None
 
+        # Test that RAT gets re-written when modifying another compoonent of
+        # the GDAL_METADATA tag without re-requesting the RAT.
+        with gdal.Open(filename2, gdal.GA_Update) as ds:
+            ds.SetMetadataItem("foo", "bar")
+
         with gdal.Open(filename2) as ds:
             got_rat = ds.GetRasterBand(1).GetDefaultRAT()
             assert ds.GetRasterBand(1).GetDefaultRAT()  # do it again
@@ -12627,3 +12632,47 @@ def test_tiff_cog_layout(tmp_vsimem):
         )
     with gdal.Open(tmp_vsimem / "out.tif") as ds:
         assert ds.GetMetadataItem("LAYOUT", "IMAGE_STRUCTURE") == "COG"
+
+
+###############################################################################
+
+
+def test_tiff_no_get_sibling_files(tmp_vsimem):
+
+    if "DEBUG=YES" not in gdal.VersionInfo("BUILD_INFO"):
+        pytest.skip("Only compatible of a GDAL build with -DDEBUG")
+
+    res = [False]
+
+    def handler(lvl, no, msg):
+        if "file listing" in msg:
+            res[0] = True
+
+    with gdal.config_option("CPL_DEBUG", "GTiff"):
+        with gdaltest.error_handler(handler):
+            gdal.GetDriverByName("GTiff").Create(tmp_vsimem / "foo.tif", 1, 1)
+    assert not res[0]
+
+    with gdal.config_options(
+        {"CPL_DEBUG": "GTiff", "GDAL_DISABLE_READDIR_ON_OPEN": "YES"}
+    ):
+        with gdaltest.error_handler(handler):
+            with gdal.Open(tmp_vsimem / "foo.tif") as ds:
+                ds.GetRasterBand(1).GetDefaultRAT()
+    assert not res[0]
+
+    with gdal.config_options(
+        {"CPL_DEBUG": "GTiff", "GDAL_DISABLE_READDIR_ON_OPEN": "EMPTY_DIR"}
+    ):
+        with gdaltest.error_handler(handler):
+            with gdal.Open(tmp_vsimem / "foo.tif") as ds:
+                ds.GetRasterBand(1).GetDefaultRAT()
+    assert not res[0]
+
+    with gdal.config_options(
+        {"CPL_DEBUG": "GTiff", "GDAL_DISABLE_READDIR_ON_OPEN": "NO"}
+    ):
+        with gdaltest.error_handler(handler):
+            with gdal.Open(tmp_vsimem / "foo.tif") as ds:
+                ds.GetRasterBand(1).GetDefaultRAT()
+    assert res[0]

--- a/frmts/gtiff/gtiffdataset_read.cpp
+++ b/frmts/gtiff/gtiffdataset_read.cpp
@@ -3942,8 +3942,7 @@ GDALDataset *GTiffDataset::Open(GDALOpenInfo *poOpenInfo)
     }
 
     // In the case of GDAL_DISABLE_READDIR_ON_OPEN = NO / EMPTY_DIR
-    if (poOpenInfo->AreSiblingFilesLoaded() &&
-        CSLCount(poOpenInfo->GetSiblingFiles()) <= 1)
+    if (poOpenInfo->AreSiblingFilesLoaded())
     {
         poDS->oOvManager.TransferSiblingFiles(
             CSLDuplicate(poOpenInfo->GetSiblingFiles()));
@@ -5831,6 +5830,7 @@ CSLConstList GTiffDataset::GetSiblingFiles()
     const int nMaxFiles =
         atoi(CPLGetConfigOption("GDAL_READDIR_LIMIT_ON_OPEN", "1000"));
     const std::string osDirname = CPLGetDirnameSafe(m_osFilename.c_str());
+    CPLDebugOnly("GTiff", "Doing '%s' file listing", osDirname.c_str());
     CPLStringList aosSiblingFiles(VSIReadDirEx(osDirname.c_str(), nMaxFiles));
     if (nMaxFiles > 0 && aosSiblingFiles.size() > nMaxFiles)
     {

--- a/frmts/gtiff/gtiffdataset_write.cpp
+++ b/frmts/gtiff/gtiffdataset_write.cpp
@@ -4701,8 +4701,21 @@ bool GTiffDataset::WriteMetadata(GDALDataset *poSrcDS, TIFF *l_hTIFF,
     {
         for (int nBand = 1; nBand <= poSrcDS->GetRasterCount(); ++nBand)
         {
-            GDALRasterBand *poBand = poSrcDS->GetRasterBand(nBand);
-            const auto poRAT = poBand->GetDefaultRAT();
+            GDALRasterAttributeTable *poRAT = nullptr;
+            if (poSrcDSGTiff)
+            {
+                auto poBand = cpl::down_cast<GTiffRasterBand *>(
+                    poSrcDSGTiff->GetRasterBand(nBand));
+                // Scenario of https://github.com/OSGeo/gdal/issues/13930
+                // Do not try to fetch the RAT from auxiliary files if creating
+                // a new GeoTIFF file
+                if (poBand->m_bRATSet)
+                    poRAT = poBand->GetDefaultRAT();
+            }
+            else
+            {
+                poRAT = poSrcDS->GetRasterBand(nBand)->GetDefaultRAT();
+            }
             if (poRAT)
             {
                 auto psSerializedRAT = poRAT->Serialize();
@@ -6798,6 +6811,12 @@ GDALDataset *GTiffDataset::Create(const char *pszFilename, int nXSize,
     poDS->nRasterXSize = nXSize;
     poDS->nRasterYSize = nYSize;
     poDS->eAccess = GA_Update;
+
+    // This will avoid GTiffDataset::GetSiblingFiles() to trigger a directory
+    // listing, which is potentially costly and only makes sense when opening
+    // new files, not creating new ones. Helps for scenario like
+    // https://github.com/OSGeo/gdal/issues/13930
+    poDS->m_bHasGotSiblingFiles = true;
 
     poDS->m_nColorTableMultiplier = nColorTableMultiplier;
 

--- a/gcore/gdal_misc.cpp
+++ b/gcore/gdal_misc.cpp
@@ -2911,7 +2911,9 @@ const char *CPL_STDCALL GDALVersionInfo(const char *pszRequest)
 #ifdef USE_ONLY_EMBEDDED_RESOURCE_FILES
         osBuildInfo += "USE_ONLY_EMBEDDED_RESOURCE_FILES=YES\n";
 #endif
-
+#ifdef DEBUG
+        osBuildInfo += "DEBUG=YES\n";
+#endif
 #undef STRINGIFY_HELPER
 #undef STRINGIFY
 


### PR DESCRIPTION
Fixes a 3.12.0 regression caused by https://github.com/OSGeo/gdal/commit/7868b1c08f6c500e8b34885cc822452922966df4

Fixes #13930
