### PR TITLE
CMake: when setting GDAL_SET_INSTALL_RELATIVE_RPATH, do not define global CMAKE_INSTALL_RPATH…

### DIFF
--- a/.github/workflows/cmake_builds.yml
+++ b/.github/workflows/cmake_builds.yml
@@ -222,8 +222,10 @@ jobs:
     - name: CMake with rpath
       run: |
         export PATH=$CMAKE_DIR:/usr/local/bin:/usr/bin:/bin # Avoid CMake config from brew etc.
-        (cd $GITHUB_WORKSPACE/superbuild/build; cmake .. "-DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install-gdal-with-rpath" "-DCMAKE_INSTALL_RPATH=$GITHUB_WORKSPACE/install-gdal-with-rpath/lib")
+        (cd $GITHUB_WORKSPACE/superbuild/build; cmake .. "-DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install-gdal-with-rpath" -DGDAL_SET_INSTALL_RELATIVE_RPATH=ON)
         cmake --build $GITHUB_WORKSPACE/superbuild/build --target install -- -j$(nproc)
+        readelf -d $GITHUB_WORKSPACE/install-gdal-with-rpath/lib/libgdal.so | grep RUNPATH | grep "\$ORIGIN"
+        readelf -d $GITHUB_WORKSPACE/install-gdal-with-rpath/bin/gdal | grep RUNPATH | grep "\$ORIGIN:\$ORIGIN/../lib"
         # For some reason, during the install phase of above invocation, the Python bindings are rebuilt after the build phase, and without the rpath... Can't reproduce that locally
         # PYTHONPATH=$GITHUB_WORKSPACE/install-gdal-with-rpath/lib/python3.10/site-packages python -c "from osgeo import gdal;print(gdal.VersionInfo(None))"
     - name: Rerun using Mono
@@ -231,7 +233,7 @@ jobs:
         export PATH=$CMAKE_DIR:/usr/local/bin:/usr/bin:/bin # Avoid CMake config from brew etc.
         cd $GITHUB_WORKSPACE/superbuild/build
         rm -rf swig/csharp
-        cmake  ${CMAKE_OPTIONS} -DCSHARP_MONO=ON -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install-gdal -UCMAKE_INSTALL_RPATH -DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD} -DCMAKE_C_FLAGS=-Werror -DCMAKE_CXX_FLAGS=-Werror ..
+        cmake  ${CMAKE_OPTIONS} -DCSHARP_MONO=ON -DCMAKE_INSTALL_PREFIX=$GITHUB_WORKSPACE/install-gdal -UGDAL_SET_INSTALL_RELATIVE_RPATH -DCMAKE_UNITY_BUILD=${CMAKE_UNITY_BUILD} -DCMAKE_C_FLAGS=-Werror -DCMAKE_CXX_FLAGS=-Werror ..
         cmake --build $GITHUB_WORKSPACE/superbuild/build --target install -- -j$(nproc)
         # Below fails with errors like 'System.InvalidProgramException: Invalid IL code in CreateData:Main (string[]): IL_00c4: callvirt  0x0a00000c'
         # ctest -V -R "^csharp.*"

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -319,6 +319,10 @@ if (BUILD_APPS)
     endif ()
     target_link_libraries(${UTILCMD} PRIVATE $<TARGET_NAME:${GDAL_LIB_TARGET_NAME}> utils_common)
 
+    if(GDAL_INSTALL_RPATH)
+      set_target_properties(${UTILCMD} PROPERTIES INSTALL_RPATH "${GDAL_INSTALL_RPATH};${GDAL_INSTALL_RPATH_FOR_BINARY}")
+    endif()
+
     if (NOT GDAL_ENABLE_DRIVER_GTI OR GDAL_ENABLE_DRIVER_GTI_PLUGIN)
         target_compile_definitions(${UTILCMD} PRIVATE -DGTI_DRIVER_DISABLED_OR_PLUGIN)
     endif()
@@ -379,6 +383,11 @@ if (BUILD_APPS)
     target_include_directories(
       ${UTILCMD} PRIVATE $<TARGET_PROPERTY:gdal_vrt,SOURCE_DIR> $<TARGET_PROPERTY:ogrsf_generic,SOURCE_DIR>)
     target_link_libraries(${UTILCMD} PRIVATE $<TARGET_NAME:${GDAL_LIB_TARGET_NAME}>)
+
+    if(GDAL_INSTALL_RPATH)
+      set_target_properties(${UTILCMD} PROPERTIES INSTALL_RPATH "${GDAL_INSTALL_RPATH};${GDAL_INSTALL_RPATH_FOR_BINARY}")
+    endif()
+
   endforeach ()
 endif ()
 

--- a/cmake/helpers/GdalDriverHelper.cmake
+++ b/cmake/helpers/GdalDriverHelper.cmake
@@ -332,6 +332,10 @@ function(add_gdal_driver)
         endif ()
     endif ()
 
+    if(GDAL_INSTALL_RPATH)
+      set_target_properties(${_DRIVER_TARGET} PROPERTIES INSTALL_RPATH ${GDAL_INSTALL_RPATH})
+    endif()
+
     target_compile_definitions(${_DRIVER_TARGET} PUBLIC $<$<CONFIG:DEBUG>:GDAL_DEBUG>)
 
     if (USE_PRECOMPILED_HEADERS AND NOT _DRIVER_SKIP_GDAL_PRIV_HEADER)

--- a/gdal.cmake
+++ b/gdal.cmake
@@ -307,12 +307,14 @@ else ()
         ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_BINDIR}
         ${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}
       )
-      if( NOT "${CMAKE_INSTALL_RPATH}" STREQUAL "" )
-          message(WARNING "CMAKE_INSTALL_RPATH=${CMAKE_INSTALL_RPATH} will be ignored and replaced with ${base};${base}/${relDir} due to GDAL_SET_INSTALL_RELATIVE_RPATH being set")
-      endif()
-      set(CMAKE_INSTALL_RPATH ${base} ${base}/${relDir})
+      set(GDAL_INSTALL_RPATH "${base}")
+      set(GDAL_INSTALL_RPATH_FOR_BINARY "${base}/${relDir}")
   endif()
 endif ()
+
+if(GDAL_INSTALL_RPATH)
+  set_target_properties(${GDAL_LIB_TARGET_NAME} PROPERTIES INSTALL_RPATH ${GDAL_INSTALL_RPATH})
+endif()
 
 set(INSTALL_PLUGIN_FULL_DIR "${CMAKE_INSTALL_PREFIX}/${INSTALL_PLUGIN_DIR}")
 


### PR DESCRIPTION
… but set the INSTALL_RPATH property of shared libraries and binary targets

Fixes #14015

@mwestphal does that look good to you?
