### PR TITLE
Fix copy-paste typo in SSE RMS overview resampling

### DIFF
--- a/gcore/overview.cpp
+++ b/gcore/overview.cpp
@@ -1073,7 +1073,7 @@ static int
 
         // Compute the maximum of each DEST_ELTS value to RMS-average
         const auto maxV = max_ps(max_ps(firstLineEven, firstLineOdd),
-                                 max_ps(secondLineEven, secondLineEven));
+                                 max_ps(secondLineEven, secondLineOdd));
 
         // Normalize each value by the maximum of the DEST_ELTS ones.
         // This step is important to avoid that the square evaluates to infinity


### PR DESCRIPTION
## What's the issue?

There's a typo in the RMS overview code where `secondLineEven` is used twice instead of using `secondLineOdd`:

```cpp
// Before:
max_ps(secondLineEven, secondLineEven)

// After I edited it:
max_ps(secondLineEven, secondLineOdd)
```

This delivers the change that was proposed in the issue  #14033