### PR TITLE
los: remove redundant IsAboveTerrain call to halve I/O

### DIFF
--- a/alg/los.cpp
+++ b/alg/los.cpp
@@ -354,7 +354,7 @@ bool GDALIsLineOfSightVisible(const GDALRasterBandH hBand, const int xA,
         {
             SetXYIntersection(x, y);
         }
-        return IsAboveTerrain(hBand, x, y, z);
+        return isAbove;
     };
 
     return Bresenham2D(xA, yA, xB, yB, OnBresenhamPoint);


### PR DESCRIPTION
## Fix: Remove duplicate terrain check in line-of-sight

The line-of-sight logic was unnecessarily checking whether a point is above the terrain twice. The result of the first check was already computed and stored..... but instead of reusing it, the code performed the same terrain check again with identical values.

Since each check involves reading a pixel from the raster, this  doubled(well effectively) the i/o operations for every point along the line, causing avoidable overhead.

**My proposed change:**
```cpp
// Before:
return IsAboveTerrain(hBand, x, y, z);
```
to 
```cpp
// After:
return isAbove;  
```

note: this was actually already computed 6 lines above 
For the issue I raised --->#14035