### PR TITLE
Replace CPLAssert with runtime validation in WKB polygon parsing

### DIFF
--- a/ogr/ogrpolygon.cpp
+++ b/ogr/ogrpolygon.cpp
@@ -420,10 +420,27 @@ OGRErr OGRPolygon::importFromWkb(const unsigned char *pabyData, size_t nSize,
             return eErr;
         }
 
-        CPLAssert(nBytesConsumedRing > 0);
+        if (nBytesConsumedRing == 0)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "Invalid WKB: ring parsing consumed 0 bytes");
+            delete oCC.papoCurves[iRing];
+            oCC.nCurveCount = iRing;
+            return OGRERR_CORRUPT_DATA;
+        }
+
         if (nSize != static_cast<size_t>(-1))
         {
-            CPLAssert(nSize >= nBytesConsumedRing);
+            if (nSize < nBytesConsumedRing)
+            {
+                CPLError(CE_Failure, CPLE_AppDefined,
+                         "Invalid WKB: ring size %lu exceeds remaining buffer %lu",
+                         static_cast<unsigned long>(nBytesConsumedRing),
+                         static_cast<unsigned long>(nSize));
+                delete oCC.papoCurves[iRing];
+                oCC.nCurveCount = iRing;
+                return OGRERR_CORRUPT_DATA;
+            }
             nSize -= nBytesConsumedRing;
         }
 


### PR DESCRIPTION
# Replace CPLAssert with runtime validation in WKB polygon parsing

## Problem

`CPLAssert` is disabled in release builds but was used to validate untrusted WKB input in `ogrpolygon.cpp`. Malformed WKB data can cause:
- **Infinite loop** if parsing consumes 0 bytes
- **Integer underflow** if bytes consumed exceeds buffer size

Both are DoS vulnerabilities per GDAL security policy.

## Solution

Replace asserts with runtime checks that return `OGRERR_CORRUPT_DATA` with error messages.

## Testing

Verified CPLAssert behavior in debug/release builds and confirmed the fix prevents both DoS scenarios.

## Closes

#14039 

## Checklist

- [x] Bug fix (non-breaking)
- [x] AI-assisted
---

I found this with AI assistance scanning for assert usage on untrusted input, then manually verified the code, tested debug/release builds, and confirmed the vulnerability. 

I cross referenced this bug against [GDAL's security policy](https://gdal.org/user/security.html) and confirmed it matches their documented DoS vulnerability category: "infinite, or very long, loops in code" when "processing untrusted data." The policy explicitly lists these patterns as security concerns 

