### PR TITLE
Add tip to warning messages for Z and M geometry types

### DIFF
--- a/autotest/ogr/ogr_gpkg.py
+++ b/autotest/ogr/ogr_gpkg.py
@@ -5778,21 +5778,13 @@ def test_ogr_gpkg_z_or_m_geometry_in_non_zm_layer(tmp_vsimem):
 
     feat = ogr.Feature(lyr.GetLayerDefn())
     feat.SetGeometryDirectly(ogr.CreateGeometryFromWkt("POINT Z (1 2 3)"))
-    with gdal.quiet_errors():
+    with gdaltest.error_raised(gdal.CE_Warning, match="Setting the Z=2 hint"):
         lyr.CreateFeature(feat)
-        assert (
-            gdal.GetLastErrorMsg()
-            == "Layer 'foo' has been declared with non-Z geometry type Point, but it does contain geometries with Z. Setting the Z=2 hint into gpkg_geometry_columns"
-        )
 
     feat = ogr.Feature(lyr.GetLayerDefn())
     feat.SetGeometryDirectly(ogr.CreateGeometryFromWkt("POINT M (1 2 3)"))
-    with gdal.quiet_errors():
+    with gdaltest.error_raised(gdal.CE_Warning, match="Setting the M=2 hint"):
         lyr.CreateFeature(feat)
-        assert (
-            gdal.GetLastErrorMsg()
-            == "Layer 'foo' has been declared with non-M geometry type Point, but it does contain geometries with M. Setting the M=2 hint into gpkg_geometry_columns"
-        )
 
     ds = None
 

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagetablelayer.cpp
@@ -2201,7 +2201,9 @@ void OGRGeoPackageTableLayer::CheckGeometryType(const OGRFeature *poFeature)
                         CE_Warning, CPLE_AppDefined,
                         "Layer '%s' has been declared with non-Z geometry type "
                         "%s, but it does contain geometries with Z. Setting "
-                        "the Z=2 hint into gpkg_geometry_columns",
+                        "the Z=2 hint into gpkg_geometry_columns. "
+                        "If using ogr2ogr, specify the -nlt option to avoid "
+                        "ambiguity.",
                         GetName(),
                         OGRToOGCGeomType(eLayerGeomType, true, true, true));
                 }
@@ -2216,7 +2218,9 @@ void OGRGeoPackageTableLayer::CheckGeometryType(const OGRFeature *poFeature)
                         CE_Warning, CPLE_AppDefined,
                         "Layer '%s' has been declared with non-M geometry type "
                         "%s, but it does contain geometries with M. Setting "
-                        "the M=2 hint into gpkg_geometry_columns",
+                        "the M=2 hint into gpkg_geometry_columns. "
+                        "If using ogr2ogr, specify the -nlt option to avoid "
+                        "ambiguity.",
                         GetName(),
                         OGRToOGCGeomType(eLayerGeomType, true, true, true));
                 }


### PR DESCRIPTION
Else users will get the warning over and over, not knowing how to fix it.

By the way, are you sure you want to say
> Setting the M=2 hint into gpkg_geometry_columns

Seems like an internal detail to me.

All I know about is ogr2ogr. I don't know how to phrase this for after retirement of ogr2ogr.

Also I would put the message in one spot, not two, in the code, and call it with either a "Z" or an "M".

For the record, I triggered the M warning with
```
$ ogr2ogr -explodecollections segA.gpkg side1.gpkg \
  -dialect SQLite -sql \
'SELECT ST_DissolveSegments(geom) AS geom FROM side1'
```
but that doesn't matter.