### PR TITLE
Zarr: enable IAdviseRead for all bands in multi-band reads

### DIFF
--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -4302,6 +4302,108 @@ def test_zarr_iread_auto_parallel(tmp_path, format):
         ds = None
 
 
+@pytest.mark.parametrize("format", ["ZARR_V2", "ZARR_V3"])
+def test_zarr_multiband_advise_read(tmp_path, format):
+    """Classic API ds.ReadRaster() should get parallel prefetch on all bands."""
+
+    filename = str(tmp_path / "test.zarr")
+    ny, nx, nbands = 60, 80, 3
+    blocksize = 20
+
+    # Create 3-band dataset via multidimensional API (band, y, x)
+    ds = gdal.GetDriverByName("ZARR").CreateMultiDimensional(
+        filename, options=["FORMAT=" + format]
+    )
+    rg = ds.GetRootGroup()
+    dim_band = rg.CreateDimension("band", None, None, nbands)
+    dim_y = rg.CreateDimension("Y", None, None, ny)
+    dim_x = rg.CreateDimension("X", None, None, nx)
+    ar = rg.CreateMDArray(
+        "test",
+        [dim_band, dim_y, dim_x],
+        gdal.ExtendedDataType.Create(gdal.GDT_UInt8),
+        [
+            "BLOCKSIZE=1,%d,%d" % (blocksize, blocksize),
+            "MULTIBAND=YES",
+            "DIM_X=X",
+            "DIM_Y=Y",
+        ],
+    )
+    data_ar = [(i % 256) for i in range(nbands * ny * nx)]
+    data = array.array("B", data_ar)
+    assert ar.Write(data) == gdal.CE_None
+    ds = None
+
+    # Reference: read via classic API without threads
+    ds = gdal.Open(filename)
+    assert ds.RasterCount == nbands
+    expected = ds.ReadRaster()
+    assert expected is not None
+    ds = None
+
+    # Read with GDAL_NUM_THREADS: exercises IAdviseRead on every band
+    with gdal.config_option("GDAL_NUM_THREADS", "ALL_CPUS"):
+        ds = gdal.Open(filename)
+        got = ds.ReadRaster()
+        ds = None
+
+    assert got == expected
+
+
+@pytest.mark.parametrize("format", ["ZARR_V2", "ZARR_V3"])
+def test_zarr_advise_read_cache_preserved(tmp_path, format):
+    """Explicit IAdviseRead cache survives auto-IAdviseRead in IRead.
+
+    After AdviseRead populates the cache, chunk files are deleted.
+    ReadRaster must still return correct data from cache, proving
+    auto-IAdviseRead did not clear it.
+    """
+
+    filename = str(tmp_path / "test.zarr")
+    ny, nx = 60, 80
+    blocksize = 20
+
+    ds = gdal.GetDriverByName("ZARR").CreateMultiDimensional(
+        filename, options=["FORMAT=" + format]
+    )
+    rg = ds.GetRootGroup()
+    dim_y = rg.CreateDimension("Y", None, None, ny)
+    dim_x = rg.CreateDimension("X", None, None, nx)
+    ar = rg.CreateMDArray(
+        "test",
+        [dim_y, dim_x],
+        gdal.ExtendedDataType.Create(gdal.GDT_UInt8),
+        ["BLOCKSIZE=%d,%d" % (blocksize, blocksize)],
+    )
+    data = array.array("B", [(i % 256) for i in range(ny * nx)])
+    ar.Write(data)
+    ds = None
+
+    # Reference read without threads
+    ds = gdal.Open(filename)
+    expected = ds.ReadRaster()
+    ds = None
+
+    with gdal.config_option("GDAL_NUM_THREADS", "ALL_CPUS"):
+        ds = gdal.Open(filename)
+        band = ds.GetRasterBand(1)
+        band.AdviseRead(0, 0, nx, ny)
+
+        # Delete chunk files - Read must succeed from cache
+        for p in tmp_path.rglob("*"):
+            if (
+                p.is_file()
+                and p.suffix not in (".json",)
+                and not p.name.startswith(".z")
+            ):
+                p.unlink()
+
+        got = ds.ReadRaster()
+        ds = None
+
+    assert got == expected
+
+
 def test_zarr_read_invalid_nczarr_dim(tmp_vsimem):
 
     gdal.Mkdir(tmp_vsimem / "test.zarr", 0)

--- a/frmts/zarr/zarr.h
+++ b/frmts/zarr/zarr.h
@@ -978,6 +978,10 @@ class ZarrArray CPL_NON_FINAL : public GDALPamMDArray
 
     mutable std::map<std::vector<uint64_t>, CachedBlock> m_oChunkCache{};
 
+    //! Region covered by the last IAdviseRead (for subset check in IRead)
+    mutable std::vector<GUInt64> m_anCachedAdviseReadStart{};
+    mutable std::vector<size_t> m_anCachedAdviseReadCount{};
+
     static uint64_t
     ComputeBlockCount(const std::string &osName,
                       const std::vector<std::shared_ptr<GDALDimension>> &aoDims,

--- a/frmts/zarr/zarr_array.cpp
+++ b/frmts/zarr/zarr_array.cpp
@@ -1039,6 +1039,8 @@ bool ZarrArray::IAdviseReadCommon(const GUInt64 *arrayStartIdx,
              nThreadsMax);
 
     m_oChunkCache.clear();
+    m_anCachedAdviseReadStart.assign(arrayStartIdx, arrayStartIdx + nDims);
+    m_anCachedAdviseReadCount.assign(count, count + nDims);
 
     // Overflow checked above
     try
@@ -1172,38 +1174,65 @@ bool ZarrArray::IRead(const GUInt64 *arrayStartIdx, const size_t *count,
 
     // Auto-parallel: prefetch multi-chunk reads via IAdviseRead().
     // arrayStep[i] guaranteed positive after negative-step normalization above.
-    if (nDims >= 2 && m_oChunkCache.empty())
+    // Skip if the current read region is already covered by a previous
+    // IAdviseRead (explicit or auto), so we don't blow away a useful cache.
+    if (nDims >= 2)
     {
-        const char *pszNumThreads =
-            CPLGetConfigOption("GDAL_NUM_THREADS", nullptr);
-        if (pszNumThreads != nullptr)
+        bool bAlreadyCached = false;
+        if (!m_oChunkCache.empty() && m_anCachedAdviseReadStart.size() == nDims)
         {
-            size_t nReqChunks = 1;
-            for (size_t i = 0; i < nDims; ++i)
+            bAlreadyCached = true;
+            for (size_t i = 0; i < nDims && bAlreadyCached; ++i)
             {
-                const uint64_t startBlock =
-                    arrayStartIdx[i] / m_anInnerBlockSize[i];
-                const uint64_t endBlock =
-                    (arrayStartIdx[i] +
-                     (count[i] - 1) * static_cast<uint64_t>(arrayStep[i])) /
-                    m_anInnerBlockSize[i];
-                nReqChunks *= static_cast<size_t>(endBlock - startBlock + 1);
+                const GUInt64 reqEnd =
+                    arrayStartIdx[i] +
+                    (count[i] - 1) * static_cast<uint64_t>(arrayStep[i]);
+                const GUInt64 cachedEnd = m_anCachedAdviseReadStart[i] +
+                                          m_anCachedAdviseReadCount[i] - 1;
+                if (arrayStartIdx[i] < m_anCachedAdviseReadStart[i] ||
+                    reqEnd > cachedEnd)
+                {
+                    bAlreadyCached = false;
+                }
             }
-            if (nReqChunks > 1)
+        }
+
+        if (!bAlreadyCached)
+        {
+            const char *pszNumThreads =
+                CPLGetConfigOption("GDAL_NUM_THREADS", nullptr);
+            if (pszNumThreads != nullptr)
             {
-                // IAdviseRead expects the contiguous element count per
-                // dimension, not the strided output count.  When step > 1,
-                // expand count to cover the full element range.
-                std::vector<size_t> anAdjustedCount(nDims);
+                size_t nReqChunks = 1;
                 for (size_t i = 0; i < nDims; ++i)
                 {
-                    anAdjustedCount[i] =
-                        1 + (count[i] - 1) * static_cast<size_t>(arrayStep[i]);
+                    const uint64_t startBlock =
+                        arrayStartIdx[i] / m_anInnerBlockSize[i];
+                    const uint64_t endBlock =
+                        (arrayStartIdx[i] +
+                         (count[i] - 1) * static_cast<uint64_t>(arrayStep[i])) /
+                        m_anInnerBlockSize[i];
+                    nReqChunks *=
+                        static_cast<size_t>(endBlock - startBlock + 1);
                 }
-                CPLStringList aosOptions;
-                aosOptions.SetNameValue("NUM_THREADS", pszNumThreads);
-                CPL_IGNORE_RET_VAL(IAdviseRead(
-                    arrayStartIdx, anAdjustedCount.data(), aosOptions.List()));
+                if (nReqChunks > 1)
+                {
+                    // IAdviseRead expects the contiguous element count per
+                    // dimension, not the strided output count.  When step > 1,
+                    // expand count to cover the full element range.
+                    std::vector<size_t> anAdjustedCount(nDims);
+                    for (size_t i = 0; i < nDims; ++i)
+                    {
+                        anAdjustedCount[i] =
+                            1 +
+                            (count[i] - 1) * static_cast<size_t>(arrayStep[i]);
+                    }
+                    CPLStringList aosOptions;
+                    aosOptions.SetNameValue("NUM_THREADS", pszNumThreads);
+                    CPL_IGNORE_RET_VAL(IAdviseRead(arrayStartIdx,
+                                                   anAdjustedCount.data(),
+                                                   aosOptions.List()));
+                }
             }
         }
     }


### PR DESCRIPTION
## What does this PR do?

Fixes a regression I introduced in #13972. The `m_oChunkCache.empty()` guard was meant to skip redundant prefetches, but it breaks multi-band reads: `ds.ReadRaster()` reads bands one at a time, each at a different offset in the 3D array. Band 1 fills the cache, so bands 2+ see it's not empty, skip `IAdviseRead`, and decode serially.

The fix replaces the `empty()` check with a region-based subset check. `IAdviseReadCommon()` now stores the last prefetched region (start + count). Auto-IAdviseRead in `IRead()` skips only when the current read falls within that region. This preserves the `IAdviseRead()` + `Read()` API path while fixing multi-band reads - each band has a different `arrayStartIdx[0]`, so it's never a subset of the previous band's cached region.

<details><summary>Benchmark</summary>

Synthetic 3-band UInt16, 10980x10980, ZSTD level 3, 8 threads:

| | Master | With fix |
|---|---|---|
| Zarr v3 ZSTD | 1.015s / 713 MB/s | 0.519s / 1394 MB/s |

On master only band 1 gets parallel prefetch (~1.2x scaling). With this fix all bands do (~2.2x scaling).

~~~python
from osgeo import gdal
import numpy as np
import time, shutil

gdal.UseExceptions()
nx, ny = 8192, 8192
mem = gdal.GetDriverByName("MEM").Create("", nx, ny, 3, gdal.GDT_UInt16)
for b in range(3):
    mem.GetRasterBand(b + 1).WriteArray(
        np.random.default_rng(b).integers(0, 10000, (ny, nx), dtype=np.uint16))

out = "/tmp/test_advise.zarr"
shutil.rmtree(out, ignore_errors=True)
gdal.Translate(out, mem, format="Zarr",
               creationOptions=["FORMAT=ZARR_V3", "COMPRESS=ZSTD", "ZSTD_LEVEL=3"])
mem = None

for label, opts in [("no threads", {}), ("8 threads", {"GDAL_NUM_THREADS": "8"})]:
    with gdal.config_options(opts):
        ds = gdal.Open(out)
        ds.ReadRaster()  # warmup
        ds = None
        ds = gdal.Open(out)
        t0 = time.perf_counter()
        ds.ReadRaster()
        print(f"  {label}: {time.perf_counter()-t0:.3f}s")
        ds = None
shutil.rmtree(out)
~~~

</details>

## What are related issues/pull requests?

- #13972 - Auto-parallel IAdviseRead (original feature)

## AI tool usage

- [x] AI (Claude) supported my development of this PR.

## Tasklist

- [x] Make sure code is correctly formatted (cf pre-commit configuration)
- [x] Add test case(s) (`test_zarr_multiband_advise_read`, `test_zarr_advise_read_cache_preserved` in `zarr_driver.py`)
- [x] All CI builds and checks have passed