### PR TITLE
gdal raster create: make sure the like argument is not positional

### DIFF
--- a/apps/gdalalg_raster_create.cpp
+++ b/apps/gdalalg_raster_create.cpp
@@ -36,6 +36,7 @@ GDALRasterCreateAlgorithm::GDALRasterCreateAlgorithm(
                                           .SetAutoOpenInputDatasets(true)
                                           .SetInputDatasetAlias("like")
                                           .SetInputDatasetRequired(false)
+                                          .SetInputDatasetPositional(false)
                                           .SetInputDatasetMaxCount(1))
 {
     AddRasterInputArgs(false, false);

--- a/autotest/utilities/test_gdalalg_raster_create.py
+++ b/autotest/utilities/test_gdalalg_raster_create.py
@@ -547,3 +547,20 @@ def test_gdalalg_raster_create_pipeline_middle_step():
         assert ds.RasterXSize == 20
         assert ds.RasterYSize == 20
         assert ds.GetRasterBand(1).ComputeRasterMinMax() == (7, 7)
+
+
+def test_gdalalg_raster_create_like_not_positional(tmp_vsimem):
+
+    import gdaltest
+    import test_cli_utilities
+
+    gdal_path = test_cli_utilities.get_gdal_path()
+    if gdal_path is None:
+        pytest.skip("gdal binary missing")
+    _, err = gdaltest.runexternal_out_and_err(
+        f"{gdal_path} raster create ../gcore/data/byte.tif {tmp_vsimem}/out.tif"
+    )
+    assert (
+        "Positional values starting at '/vsimem/test_gdalalg_raster_create_like_not_positional/out.tif' are not expected"
+        in err
+    )


### PR DESCRIPTION
to limit confusion with other utilities like 'gdal raster convert'

Refs #14056
