### PR TITLE
Zarr v3: dual-write GDAL + SPATIAL_PROJ georeferencing conventions

### DIFF
--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -6151,7 +6151,13 @@ def test_zarr_write_vsizip(tmp_vsimem, format):
     )
 
     ds = gdal.Open(out_filename)
-    assert ds.GetMetadata() == {"AREA_OR_POINT": "Area"}
+    md = ds.GetMetadata()
+    assert md["AREA_OR_POINT"] == "Area"
+    if format == "ZARR_V2":
+        assert md == {"AREA_OR_POINT": "Area"}
+    else:
+        # V3 dual-writes both conventions, which adds spatial:bbox, zarr_conventions
+        assert "spatial:bbox" in md
 
 
 ###############################################################################
@@ -7815,6 +7821,107 @@ def test_zarr_write_spatial_geotransform(tmp_vsimem):
     assert ds.GetSpatialRef().IsSame(src_ds.GetSpatialRef())
     assert ds.GetGeoTransform() == src_ds.GetGeoTransform()
     assert ds.GetRasterBand(1).Checksum() == src_ds.GetRasterBand(1).Checksum()
+
+
+###############################################################################
+# Test Zarr V3 georeferencing convention matrix:
+#   None (default) -> dual-write both conventions
+#   GDAL           -> only _CRS
+#   SPATIAL_PROJ   -> only spatial:transform
+
+
+@gdaltest.enable_exceptions()
+@pytest.mark.parametrize(
+    "convention,expect_spatial,expect_crs",
+    [
+        (None, True, True),
+        ("GDAL", False, True),
+        ("SPATIAL_PROJ", True, False),
+    ],
+    ids=["dual-write", "explicit-GDAL", "explicit-SPATIAL_PROJ"],
+)
+def test_zarr_v3_georef_convention(tmp_vsimem, convention, expect_spatial, expect_crs):
+
+    src_ds = gdal.Open("data/byte.tif")
+    options = {"FORMAT": "ZARR_V3"}
+    if convention:
+        options["GEOREFERENCING_CONVENTION"] = convention
+    gdal.GetDriverByName("Zarr").CreateCopy(
+        tmp_vsimem / "out.zarr", src_ds, options=options
+    )
+
+    with gdal.VSIFile(tmp_vsimem / "out.zarr" / "zarr.json", "rb") as f:
+        j = json.loads(f.read())
+    attrs = j["consolidated_metadata"]["metadata"]["out"]["attributes"]
+    assert ("spatial:transform" in attrs) == expect_spatial
+    assert ("proj:code" in attrs) == expect_spatial
+    assert ("_CRS" in attrs) == expect_crs
+
+    ds = gdal.Open(tmp_vsimem / "out.zarr")
+    assert ds.GetSpatialRef().IsSame(src_ds.GetSpatialRef())
+    assert ds.GetGeoTransform() == src_ds.GetGeoTransform()
+
+
+###############################################################################
+# Test that Zarr V2 default convention is unchanged (GDAL only, no dual-write)
+
+
+@gdaltest.enable_exceptions()
+def test_zarr_v2_default_convention_unchanged(tmp_vsimem):
+
+    src_ds = gdal.Open("data/byte.tif")
+    gdal.GetDriverByName("Zarr").CreateCopy(
+        tmp_vsimem / "out.zarr",
+        src_ds,
+        options={"FORMAT": "ZARR_V2"},
+    )
+
+    # Verify GDAL convention only in .zattrs
+    with gdal.VSIFile(tmp_vsimem / "out.zarr" / "out" / ".zattrs", "rb") as f:
+        attrs = json.loads(f.read())
+    assert "_CRS" in attrs
+    assert "spatial:transform" not in attrs
+
+    # Verify round-trip via classic API
+    ds = gdal.Open(tmp_vsimem / "out.zarr")
+    assert ds.GetSpatialRef().IsSame(src_ds.GetSpatialRef())
+    assert ds.GetGeoTransform() == src_ds.GetGeoTransform()
+
+
+###############################################################################
+# Test dual-write with Point registration preserves AREA_OR_POINT and round-trips
+
+
+@gdaltest.enable_exceptions()
+def test_zarr_v3_dual_write_point_registration(tmp_vsimem):
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 2, 3)
+    src_ds.SetGeoTransform([10, 1, 0, 50, 0, -1])
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(4326)
+    srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
+    src_ds.SetSpatialRef(srs)
+    src_ds.SetMetadataItem("AREA_OR_POINT", "Point")
+
+    gdal.GetDriverByName("Zarr").CreateCopy(
+        tmp_vsimem / "out.zarr",
+        src_ds,
+        options={"FORMAT": "ZARR_V3"},
+    )
+
+    # Verify both conventions present and AREA_OR_POINT preserved
+    with gdal.VSIFile(tmp_vsimem / "out.zarr" / "zarr.json", "rb") as f:
+        j = json.loads(f.read())
+    array_attrs = j["consolidated_metadata"]["metadata"]["out"]["attributes"]
+    assert "spatial:transform" in array_attrs
+    assert array_attrs["spatial:registration"] == "node"
+    assert array_attrs["AREA_OR_POINT"] == "Point"
+    assert "_CRS" in array_attrs
+
+    # Verify geotransform round-trip
+    ds = gdal.Open(tmp_vsimem / "out.zarr")
+    assert ds.GetGeoTransform() == pytest.approx(src_ds.GetGeoTransform())
+    assert ds.GetSpatialRef().IsSame(src_ds.GetSpatialRef())
 
 
 ###############################################################################

--- a/doc/source/drivers/raster/zarr.rst
+++ b/doc/source/drivers/raster/zarr.rst
@@ -560,6 +560,10 @@ with ``ARRAY:`` using :program:`gdalmdimtranslate`):
       uses the Zarr `spatial <https://github.com/zarr-conventions/spatial>`__
       and `geo-proj <https://github.com/zarr-conventions/geo-proj>`__ conventions.
 
+      .. versionchanged:: 3.14
+         When writing Zarr V3 without an explicit convention, both ``GDAL`` and
+         ``SPATIAL_PROJ`` attributes are written for maximum interoperability.
+
 -  .. co:: COMPRESS
       :choices: NONE, BLOSC, ZLIB, GZIP, LZMA, ZSTD, LZ4
       :default: NONE

--- a/frmts/zarr/zarr_array.cpp
+++ b/frmts/zarr/zarr_array.cpp
@@ -255,10 +255,16 @@ CPLJSONObject ZarrArray::SerializeSpecialAttributes()
 
     auto oAttrs = m_oAttrGroup.Serialize();
 
-    const bool bUseSpatialProjConventions =
-        EQUAL(m_aosCreationOptions.FetchNameValueDef(
-                  "GEOREFERENCING_CONVENTION", "GDAL"),
-              "SPATIAL_PROJ");
+    // For v3 without an explicit GEOREFERENCING_CONVENTION, dual-write both
+    // conventions so older GDAL reads _CRS and newer GeoZarr tools read
+    // spatial:transform. Explicit GDAL or SPATIAL_PROJ writes only one.
+    const char *pszConvention =
+        m_aosCreationOptions.FetchNameValue("GEOREFERENCING_CONVENTION");
+    const bool bIsV3 = dynamic_cast<const ZarrV3Array *>(this) != nullptr;
+    const bool bWriteSpatialProj =
+        pszConvention ? EQUAL(pszConvention, "SPATIAL_PROJ") : bIsV3;
+    const bool bWriteGDALCRS =
+        pszConvention ? !EQUAL(pszConvention, "SPATIAL_PROJ") : true;
 
     const auto ExportToWkt2AndPROJJSON = [this](CPLJSONObject &oContainer,
                                                 const char *pszWKT2AttrName,
@@ -289,7 +295,7 @@ CPLJSONObject ZarrArray::SerializeSpecialAttributes()
     };
 
     CPLJSONArray oZarrConventionsArray;
-    if (bUseSpatialProjConventions)
+    if (bWriteSpatialProj)
     {
         if (m_poSRS)
         {
@@ -400,12 +406,14 @@ CPLJSONObject ZarrArray::SerializeSpecialAttributes()
                 if (osGDALMD_AREA_OR_POINT == GDALMD_AOP_AREA)
                 {
                     oAttrs.Add("spatial:registration", "pixel");
-                    oAttrs.Delete(GDALMD_AREA_OR_POINT);
+                    if (!bWriteGDALCRS)
+                        oAttrs.Delete(GDALMD_AREA_OR_POINT);
                 }
                 else if (osGDALMD_AREA_OR_POINT == GDALMD_AOP_POINT)
                 {
                     oAttrs.Add("spatial:registration", "node");
-                    oAttrs.Delete(GDALMD_AREA_OR_POINT);
+                    if (!bWriteGDALCRS)
+                        oAttrs.Delete(GDALMD_AREA_OR_POINT);
 
                     // Going from GDAL's corner convention to pixel center
                     gt.xorig += 0.5 * gt.xscale + 0.5 * gt.xrot;
@@ -424,7 +432,8 @@ CPLJSONObject ZarrArray::SerializeSpecialAttributes()
 
                 oAttrs.Add("spatial:transform_type", "affine");
                 oAttrs.Add("spatial:transform", oAttrSpatialTransform);
-                oAttrs.Delete("gdal:geotransform");
+                if (!bWriteGDALCRS)
+                    oAttrs.Delete("gdal:geotransform");
 
                 double dfX0, dfY0;
                 double dfX1, dfY1;
@@ -481,7 +490,7 @@ CPLJSONObject ZarrArray::SerializeSpecialAttributes()
             oAttrs.Add("zarr_conventions", oZarrConventionsArray);
         }
     }
-    else if (m_poSRS)
+    if (bWriteGDALCRS && m_poSRS)
     {
         // GDAL convention
 

--- a/frmts/zarr/zarrdriver.cpp
+++ b/frmts/zarr/zarrdriver.cpp
@@ -1033,8 +1033,10 @@ void ZarrDriver::InitMetadata()
                                    "string-select");
         CPLAddXMLAttributeAndValue(psGeoreferencingConvention, "default",
                                    "GDAL");
-        CPLAddXMLAttributeAndValue(psGeoreferencingConvention, "description",
-                                   "Georeferencing convention to use");
+        CPLAddXMLAttributeAndValue(
+            psGeoreferencingConvention, "description",
+            "Georeferencing convention to use. "
+            "Zarr V3 writes both conventions by default");
 
         {
             auto poValueNode = CPLCreateXMLNode(psGeoreferencingConvention,
@@ -1343,9 +1345,14 @@ GDALDataset *ZarrDataset::Create(const char *pszName, int nXSize, int nYSize,
         osDimXType = GDAL_DIM_TYPE_HORIZONTAL_X;
         osDimYType = GDAL_DIM_TYPE_HORIZONTAL_Y;
     }
-    poDS->m_bSpatialProjConvention = EQUAL(
-        CSLFetchNameValueDef(papszOptions, "GEOREFERENCING_CONVENTION", "GDAL"),
-        "SPATIAL_PROJ");
+    // Use SPATIAL_PROJ dimension naming for v3 by default.
+    const char *pszConvention =
+        CSLFetchNameValue(papszOptions, "GEOREFERENCING_CONVENTION");
+    poDS->m_bSpatialProjConvention =
+        pszConvention
+            ? EQUAL(pszConvention, "SPATIAL_PROJ")
+            : EQUAL(CSLFetchNameValueDef(papszOptions, "FORMAT", "ZARR_V2"),
+                    "ZARR_V3");
 
     if (bAppendSubDS)
     {


### PR DESCRIPTION
## What does this PR do?

When writing Zarr v3 without an explicit `GEOREFERENCING_CONVENTION`, GDAL now writes both `_CRS` (GDAL convention) and `spatial:transform`/`proj:code` (SPATIAL_PROJ convention). Existing GDAL versions read `_CRS`, newer GeoZarr tools read `spatial:transform`. Explicit `GEOREFERENCING_CONVENTION=GDAL` or `SPATIAL_PROJ` still writes only the requested convention. V2 default unchanged.

## What are related issues/pull requests?

- [zarr-developers/geozarr-spec#110](https://github.com/zarr-developers/geozarr-spec/issues/110)
- #11824

## AI tool usage

- [x] AI (Claude) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html).

## Tasklist

- [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
- [x] Add test case(s)
- [x] Add documentation
- [ ] Review
- [ ] Adjust for comments
- [x] All CI builds and checks have passed