### PR TITLE
validate_geoparquet: resolve projjson schema from local PROJ data

### DIFF
--- a/swig/python/gdal-utils/osgeo_utils/samples/validate_geoparquet.py
+++ b/swig/python/gdal-utils/osgeo_utils/samples/validate_geoparquet.py
@@ -13,6 +13,7 @@
 ###############################################################################
 
 import json
+import os
 import sys
 
 from osgeo import gdal, ogr, osr
@@ -37,6 +38,23 @@ map_ogr_geom_type_to_geoparquet = {
 }
 
 map_remote_resources = {}
+
+
+def _try_local_proj_schema(uri):
+    """Try to resolve a proj.org schema URI from local PROJ data directory."""
+    prefix = "https://proj.org/schemas/"
+    if not uri.startswith(prefix):
+        return None
+    relative = uri[len(prefix) :]
+    try:
+        for search_path in osr.GetPROJSearchPaths():
+            local_path = os.path.join(search_path, os.path.basename(relative))
+            if os.path.isfile(local_path):
+                with open(local_path, "rb") as f:
+                    return f.read()
+    except OSError:
+        pass
+    return None
 
 
 class GeoParquetValidator:
@@ -99,16 +117,20 @@ class GeoParquetValidator:
             def retrieve_remote_file(uri: str):
                 if not uri.startswith("http://") and not uri.startswith("https://"):
                     raise Exception(f"Cannot retrieve {uri}")
-                import urllib.request
 
                 if uri not in map_remote_resources:
-                    response = urllib.request.urlopen(
-                        urllib.request.Request(uri, headers={"User-Agent": "GDAL"})
-                    ).read()
-                    map_remote_resources[uri] = response
-                else:
-                    response = map_remote_resources[uri]
-                return Resource.from_contents(json.loads(response))
+                    local_content = _try_local_proj_schema(uri)
+                    if local_content is not None:
+                        map_remote_resources[uri] = local_content
+                    else:
+                        import urllib.request
+
+                        response = urllib.request.urlopen(
+                            urllib.request.Request(uri, headers={"User-Agent": "GDAL"})
+                        ).read()
+                        map_remote_resources[uri] = response
+
+                return Resource.from_contents(json.loads(map_remote_resources[uri]))
 
             registry = Registry(retrieve=retrieve_remote_file)
             validator_cls = jsonschema.validators.validator_for(schema)


### PR DESCRIPTION
## What does this PR do?

GeoParquet validation resolves `$ref` to `proj.org/schemas/v0.7/projjson.schema.json` at runtime via network fetch. When `proj.org` is unreachable, 13 parquet validation tests fail with `Expecting value: line 1 column 1` (e.g. [this CI failure](https://github.com/OSGeo/gdal/actions/runs/22686015271/job/65789840017?pr=14064)).

PROJ already ships this schema locally in its data directory. This adds `_try_local_proj_schema()` which checks `osr.GetPROJSearchPaths()` for the schema file before falling back to network. Zero new dependencies.

## What are related issues/pull requests?

Observed on unrelated PRs when proj.org has intermittent outages.

## AI tool usage

 - [x] AI (Claude) supported my development of this PR.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed