### PR TITLE
ogr_geojson: accept alternate bbox for PROJ >= 9.8 eqc ellipsoidal formula

### DIFF
--- a/autotest/ogr/ogr_geojson.py
+++ b/autotest/ogr/ogr_geojson.py
@@ -2472,7 +2472,18 @@ def test_ogr_geojson_57(tmp_vsimem):
 ]
 }
 """
-    assert json.loads(got) == json.loads(expected)
+    # PROJ >= 9.8 uses ellipsoidal formula for +proj=eqc (previously
+    # spherical), producing slightly different Y values
+    expected_alt = """{
+"type": "FeatureCollection",
+"bbox": [ -17.9663057, -18.0814781, 17.9663057, 18.0814781 ],
+"features": [
+{ "type": "Feature", "properties": { }, "bbox": [ -17.9663057, -18.0814781, 17.9663057, 18.0814781 ], "geometry": { "type": "Polygon", "coordinates": [ [ [ 17.9663057, 18.0814781 ], [ -17.9663057, 18.0814781 ], [ -17.9663057, -18.0814781 ], [ 17.9663057, -18.0814781 ], [ 17.9663057, 18.0814781 ] ] ] } }
+]
+}
+"""
+    j_got = json.loads(got)
+    assert j_got == json.loads(expected) or j_got == json.loads(expected_alt), got
 
     # Polar case: EPSG:3995: WGS 84 / Arctic Polar Stereographic
     src_ds = gdal.GetDriverByName("MEM").Create("", 0, 0, 0)


### PR DESCRIPTION
## What does this PR do?

`test_ogr_geojson_57` eqc sub-test fails with PROJ >= 9.8, which provides an ellipsoidal formula for `+proj=eqc` whereas previous versions use spherical only. This produces slightly different Y-bbox values in eqc-to-WGS84 reprojection.

- Expected: `[-17.9663057, -17.9663057, 17.9663057, 17.9663057]`
- PROJ 9.8: `[-17.9663057, -18.0814781, 17.9663057, 18.0814781]`

Applies the existing alternate-output pattern already used later in the same test function (line 2669).

## What are related issues/pull requests?

CI failure: [build-windows-conda](https://github.com/OSGeo/gdal/actions/runs/22686015271/job/65789840083?pr=14064)

## AI tool usage

 - [x] AI (Claude) supported my development of this PR.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed