### PR TITLE
docs(gdal_contour): clarify that -inodata and -snodata are mutually exclusive

### DIFF
--- a/doc/source/programs/gdal_raster_calc.rst
+++ b/doc/source/programs/gdal_raster_calc.rst
@@ -12,18 +12,17 @@
 
 .. Index:: gdal raster calc
 
+Synopsis
+--------
+
+.. program-output:: gdal raster calc --help-doc
+
 Description
 -----------
 
 :program:`gdal raster calc` performs pixel-wise calculations on one or more input GDAL datasets. Calculations
 can be performed eagerly, writing results to a conventional raster format,
 or lazily, written as a set of derived bands in a :ref:`VRT (Virtual Dataset) <raster.vrt>`.
-
-Synopsis
---------
-
-.. program-output:: gdal raster calc --help-doc
-
 
 The list of input GDAL datasets can be specified at the end
 of the command line or put in a text file (one input per line) for very long lists.


### PR DESCRIPTION
This PR improves the documentation of `gdal_contour` by clarifying the behavior of the `-inodata` and `-snodata` options.

The documentation previously did not clearly state that these two options are mutually exclusive.
This change explicitly documents that `-inodata` cannot be used together with `-snodata`, and vice versa.

This improves clarity for users of the `gdal_contour` utility.

Fixes #11761.
