### PR TITLE
Zarr: update geo-proj CMO URLs from zarr-experimental to zarr-conventions

### DIFF
--- a/autotest/gdrivers/data/zarr/v3/spatial_proj_at_array_level.zarr/zarr.json
+++ b/autotest/gdrivers/data/zarr/v3/spatial_proj_at_array_level.zarr/zarr.json
@@ -2,8 +2,8 @@
   "attributes": {
     "zarr_conventions": [
       {
-          "schema_url": "https://raw.githubusercontent.com/zarr-experimental/geo-proj/refs/tags/v1/schema.json",
-          "spec_url": "https://github.com/zarr-experimental/geo-proj/blob/v1/README.md",
+          "schema_url": "https://raw.githubusercontent.com/zarr-conventions/geo-proj/refs/tags/v1/schema.json",
+          "spec_url": "https://github.com/zarr-conventions/geo-proj/blob/v1/README.md",
           "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
           "name": "proj:",
           "description": "Coordinate reference system information for geospatial data"

--- a/autotest/gdrivers/data/zarr/v3/spatial_proj_at_parent_level.zarr/zarr.json
+++ b/autotest/gdrivers/data/zarr/v3/spatial_proj_at_parent_level.zarr/zarr.json
@@ -2,8 +2,8 @@
   "attributes": {
     "zarr_conventions": [
       {
-          "schema_url": "https://raw.githubusercontent.com/zarr-experimental/geo-proj/refs/tags/v1/schema.json",
-          "spec_url": "https://github.com/zarr-experimental/geo-proj/blob/v1/README.md",
+          "schema_url": "https://raw.githubusercontent.com/zarr-conventions/geo-proj/refs/tags/v1/schema.json",
+          "spec_url": "https://github.com/zarr-conventions/geo-proj/blob/v1/README.md",
           "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
           "name": "proj:",
           "description": "Coordinate reference system information for geospatial data"

--- a/autotest/gdrivers/data/zarr/v3/spatial_proj_convention_at_root_level.zarr/zarr.json
+++ b/autotest/gdrivers/data/zarr/v3/spatial_proj_convention_at_root_level.zarr/zarr.json
@@ -2,8 +2,8 @@
   "attributes": {
     "zarr_conventions": [
       {
-          "schema_url": "https://raw.githubusercontent.com/zarr-experimental/geo-proj/refs/tags/v1/schema.json",
-          "spec_url": "https://github.com/zarr-experimental/geo-proj/blob/v1/README.md",
+          "schema_url": "https://raw.githubusercontent.com/zarr-conventions/geo-proj/refs/tags/v1/schema.json",
+          "spec_url": "https://github.com/zarr-conventions/geo-proj/blob/v1/README.md",
           "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
           "name": "proj:",
           "description": "Coordinate reference system information for geospatial data"

--- a/autotest/gdrivers/zarr_driver.py
+++ b/autotest/gdrivers/zarr_driver.py
@@ -7782,8 +7782,8 @@ def test_zarr_write_spatial_geotransform(tmp_vsimem):
                         "spatial:dimensions": ["Y", "X"],
                         "zarr_conventions": [
                             {
-                                "schema_url": "https://raw.githubusercontent.com/zarr-experimental/geo-proj/refs/tags/v1/schema.json",
-                                "spec_url": "https://github.com/zarr-experimental/geo-proj/blob/v1/README.md",
+                                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/geo-proj/refs/tags/v1/schema.json",
+                                "spec_url": "https://github.com/zarr-conventions/geo-proj/blob/v1/README.md",
                                 "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
                                 "name": "proj:",
                                 "description": "Coordinate reference system information for geospatial data",
@@ -7892,8 +7892,8 @@ def test_zarr_write_spatial_geotransform_no_epsg_code_rotated_gt_and_pixel_cente
                         "spatial:registration": "node",
                         "zarr_conventions": [
                             {
-                                "schema_url": "https://raw.githubusercontent.com/zarr-experimental/geo-proj/refs/tags/v1/schema.json",
-                                "spec_url": "https://github.com/zarr-experimental/geo-proj/blob/v1/README.md",
+                                "schema_url": "https://raw.githubusercontent.com/zarr-conventions/geo-proj/refs/tags/v1/schema.json",
+                                "spec_url": "https://github.com/zarr-conventions/geo-proj/blob/v1/README.md",
                                 "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
                                 "name": "proj:",
                                 "description": "Coordinate reference system information for geospatial data",

--- a/doc/source/drivers/raster/zarr.rst
+++ b/doc/source/drivers/raster/zarr.rst
@@ -401,8 +401,8 @@ Example:
             "spatial:dimensions": ["Y", "X"],
             "zarr_conventions": [
                 {
-                    "schema_url": "https://raw.githubusercontent.com/zarr-experimental/geo-proj/refs/tags/v1/schema.json",
-                    "spec_url": "https://github.com/zarr-experimental/geo-proj/blob/v1/README.md",
+                    "schema_url": "https://raw.githubusercontent.com/zarr-conventions/geo-proj/refs/tags/v1/schema.json",
+                    "spec_url": "https://github.com/zarr-conventions/geo-proj/blob/v1/README.md",
                     "uuid": "f17cb550-5864-4468-aeb7-f3180cfb622f",
                     "name": "proj:",
                     "description": "Coordinate reference system information for geospatial data",

--- a/frmts/zarr/zarr_array.cpp
+++ b/frmts/zarr/zarr_array.cpp
@@ -296,10 +296,10 @@ CPLJSONObject ZarrArray::SerializeSpecialAttributes()
             CPLJSONObject oConventionProj;
             oConventionProj.Set(
                 "schema_url",
-                "https://raw.githubusercontent.com/zarr-experimental/geo-proj/"
+                "https://raw.githubusercontent.com/zarr-conventions/geo-proj/"
                 "refs/tags/v1/schema.json");
             oConventionProj.Set("spec_url",
-                                "https://github.com/zarr-experimental/geo-proj/"
+                                "https://github.com/zarr-conventions/geo-proj/"
                                 "blob/v1/README.md");
             oConventionProj.Set("uuid", "f17cb550-5864-4468-aeb7-f3180cfb622f");
             oConventionProj.Set("name", "proj:");  // ending colon intended


### PR DESCRIPTION
**Note:** Parked until [zarr-developers/geozarr-spec#126](https://github.com/zarr-developers/geozarr-spec/issues/126) settles on a final hosting location. The target URLs in this PR may change.

## What does this PR do?

The geo-proj convention repo moved from `zarr-experimental/geo-proj` to `zarr-conventions/geo-proj`. This updates `schema_url` and `spec_url` references in the Zarr write path, test data, test assertions, and docs.

The `spatial:` and `multiscales:` CMOs already reference `zarr-conventions` - only `proj:` still pointed to the old org. While `github.com` redirects the old org name, `raw.githubusercontent.com` does not - so schema URLs embedded in written Zarr files currently 404.

Note: all three convention repos (`geo-proj`, `spatial`, `multiscales`) lack a `v1` tag, so the `refs/tags/v1` path segment in schema URLs also 404s. That affects all conventions equally and is out of scope here.

## What are related issues/pull requests?

https://github.com/zarr-developers/geozarr-spec/issues/110

## AI tool usage

- [x] AI (Claude) supported my development of this PR.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Update test fixtures
 - [x] Update documentation
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed