### PR TITLE
doc: update defunct Google Maps API signup link in gdal2tiles 

### DIFF
--- a/doc/source/programs/gdal2tiles.rst
+++ b/doc/source/programs/gdal2tiles.rst
@@ -225,7 +225,7 @@ Options for generated HTML viewers a la Google Maps
 
 .. option:: -g <GOOGLEKEY>, --googlekey=<GOOGLEKEY>
 
-  Google Maps API key from http://code.google.com/apis/maps/signup.html.
+  Google Maps API key from https://developers.google.com/maps/get-started.
 
 .. option:: -b <BINGKEY>, --bingkey=<BINGKEY>
 


### PR DESCRIPTION
## Summary

The `--googlekey` option description in `gdal2tiles.rst` referenced:

    http://code.google.com/apis/maps/signup.html

this link redirects to the Google Maps Platform FAQ, which
is unrelated to obtaining an API key and can be confusing for users

## Fix

replace it with the official entry for maps API:

    https://developers.google.com/maps/get-started

this closes #14076 
