### PR TITLE
Update ogrinfo.rst to clarify -dialect usage

### DIFF
--- a/doc/source/programs/ogrinfo.rst
+++ b/doc/source/programs/ogrinfo.rst
@@ -121,6 +121,7 @@ edit data.
     of the native SQL of an RDBMS by passing the ``OGRSQL`` dialect value.
     The :ref:`sql_sqlite_dialect` can be selected with the ``SQLITE``
     and ``INDIRECT_SQLITE`` dialect values, and this can be used with any datasource.
+    Note: -dialect is ignored with -where. Use -sql instead of -where if you want to use -dialect.
 
 .. option:: -spat <xmin> <ymin> <xmax> <ymax>
 


### PR DESCRIPTION
Make sure users know this, no matter which spot of the two in the man page they look at. They might have learned -where last year, and only this year learned -dialect, and thus didn't remember the notice. This will avoid runtime error messages.