### PR TITLE
zarr: limit sharded write cache to prevent unbounded memory growth

### DIFF
--- a/frmts/zarr/zarr_v3_array.cpp
+++ b/frmts/zarr/zarr_v3_array.cpp
@@ -1157,6 +1157,20 @@ bool ZarrV3Array::FlushDirtyBlockSharded() const
     auto oIt = m_oShardWriteCache.find(osFilename);
     if (oIt == m_oShardWriteCache.end())
     {
+        // Bound the number of decoded shards kept in memory at once.
+        // This limits memory usage for sparse write patterns that touch
+        // many shards before Flush() is called.
+        const int nMaxShardCacheEntries =
+            std::max(1, atoi(CPLGetConfigOption(
+                            "GDAL_ZARR_V3_MAX_SHARD_CACHE_ENTRIES", "128")));
+        if (static_cast<int>(m_oShardWriteCache.size()) >= nMaxShardCacheEntries)
+        {
+            auto oItToFlush = m_oShardWriteCache.begin();
+            if (!FlushSingleShard(oItToFlush->first, oItToFlush->second))
+                return false;
+            m_oShardWriteCache.erase(oItToFlush);
+        }
+
         ShardWriteEntry entry;
         try
         {


### PR DESCRIPTION
### Motivation
- The sharded write path previously retained a full decoded buffer per touched shard in `m_oShardWriteCache`, allowing sparse writes across many shards to grow memory unbounded and enabling a denial-of-service via memory exhaustion. 
- The intent of the change is to bound in-memory decoded shards during sharded writes while preserving existing semantics that encode each shard once on `Flush()`.

### Description
- Enforce a configurable cap on the number of decoded shard entries kept in `m_oShardWriteCache` inside `ZarrV3Array::FlushDirtyBlockSharded()` and flush+evict one entry when the cap is reached to limit memory usage before `Flush()` is called. 
- Make the cap configurable via the `GDAL_ZARR_V3_MAX_SHARD_CACHE_ENTRIES` environment/config option, with a default of `128` and a minimum floor of `1` to preserve functionality. 
- The eviction path calls the existing `FlushSingleShard()` to encode and write the evicted shard before erasing it from the cache to avoid losing dirty data. 
- Change is localized to `frmts/zarr/zarr_v3_array.cpp` and keeps the original behavior of flushing a shard immediately when all inner chunks are written.

### Testing
- Ran `git diff --check` to ensure no trivial whitespace or patch errors and it succeeded. 
- The change is a minimal patch designed to be low-risk and ready for CI validation.

## AI tool usage

 - [X] AI (Codex Security in research preview) supported my development of this PR. 
