### PR TITLE
ogr: document why IsFieldNull always returns false for special fields

### DIFF
--- a/ogr/ogrfeature.cpp
+++ b/ogr/ogrfeature.cpp
@@ -1670,20 +1670,8 @@ bool OGRFeature::IsFieldNull(int iField) const
     if (iSpecialField >= 0)
     {
         // Special fields (FID, geometry, style, area) are virtual/derived
-        // values that have no nullable state. They can only be set or unset,
-        // but cannot be explicitly assigned a null value as regular fields
-        // can. IsFieldSet() should be used to test whether a special field
-        // has a value.
-        switch (iSpecialField)
-        {
-            case SPF_FID:
-            case SPF_OGR_GEOMETRY:
-            case SPF_OGR_STYLE:
-            case SPF_OGR_GEOM_WKT:
-            case SPF_OGR_GEOM_AREA:
-            default:
-                return false;
-        }
+        // values that have no nullable state.
+        return false;
     }
     else
     {


### PR DESCRIPTION
## description 

the change has no different after effect compared with the existing piece of code
it has a structure that has already been followed in places like `IsFieldSet()`

closes #14092 


for ref in ogrfeature.cpp

<img width="1141" height="695" alt="image" src="https://github.com/user-attachments/assets/cce8673a-b786-4551-bef7-1c0cdd03aead" />

