### PR TITLE
ogr/osm: fix startic_cast typo in OSM_DEBUG block

### DIFF
--- a/ogr/ogrsf_frmts/osm/ogrosmdatasource.cpp
+++ b/ogr/ogrsf_frmts/osm/ogrosmdatasource.cpp
@@ -269,7 +269,7 @@ OGROSMDataSource::~OGROSMDataSource()
 
 #ifdef OSM_DEBUG
     FILE *f = fopen("keys.txt", "wt");
-    for (int i = 1; i < startic_cast<int>(asKeys.size()); i++)
+    for (int i = 1; i < static_cast<int>(asKeys.size()); i++)
     {
         KeyDesc *psKD = asKeys[i];
         if (psKD)


### PR DESCRIPTION
## description

fixes a typo `startic_cast` → `static_cast` in the destructor
`OGROSMDataSource::~OGROSMDataSource()` inside an `#ifdef OSM_DEBUG` guard


## note
the typo is invisible in normal builds but causes an immediate compile error
when the `OSM_DEBUG` preprocessor macro is defined
breaking the OSM driver's debug code path entirely