### PR TITLE
Fix to prevent negative size values in gdal2tiles.py

### DIFF
--- a/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
@@ -1328,7 +1328,7 @@ def create_base_tile(
     # Query is in 'nearest neighbour' but can be bigger in then the tile_size
     # We scale down the query to the tile_size by supplied algorithm.
 
-    if rxsize != 0 and rysize != 0 and wxsize != 0 and wysize != 0:
+    if rxsize > 0 and rysize > 0 and wxsize > 0 and wysize > 0:
         alpha = alphaband.ReadRaster(rx, ry, rxsize, rysize, wxsize, wysize)
 
         # Detect totally transparent tile and skip its creation


### PR DESCRIPTION
Problem:
Gdal2tiles crashes with the message "Illegal values for buffer size". The problem was reported in multiple source and exists already for years. Examples:
https://gis.stackexchange.com/questions/249809/gdal2tiles-error-5-illegal-values-for-buffer-size-error-for-a-single-zoom-lev

Solution:
We just skip the tile with negative extent values.
