### PR TITLE
hdf5: Adding proper support for parallel HDF5

### DIFF
--- a/frmts/hdf5/CMakeLists.txt
+++ b/frmts/hdf5/CMakeLists.txt
@@ -93,6 +93,14 @@ elseif(NOT DEFINED GDAL_ENABLE_HDF5_GLOBAL_LOCK)
   target_compile_definitions(gdal_HDF5 PRIVATE -DENABLE_HDF5_GLOBAL_LOCK)
 endif()
 
+if (HDF5_ENABLE_PARALLEL)
+    find_package(MPI)
+    if (MPI_FOUND)
+        target_include_directories(gdal_HDF5 PRIVATE ${MPI_C_INCLUDE_DIRS})
+        target_link_libraries(gdal_HDF5 PRIVATE ${MPI_C_LIBRARIES})
+    endif ()
+endif ()
+
 # When build as plugin, initialize all drivers from Register_HDF5
 if (GDAL_ENABLE_DRIVER_HDF5_PLUGIN)
   target_compile_definitions(gdal_HDF5 PRIVATE -DHDF5_PLUGIN)


### PR DESCRIPTION
## What does this PR do?

Initially contributed by @mathstuf in https://gitlab.kitware.com/paraview/paraview-superbuild/-/merge_requests/1112, this add proper support for parallel HDF5 in the CMake logic

## What are related issues/pull requests?

None

## AI tool usage

 - [ ] AI (Copilot or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

## Environment

Provide environment details, if relevant: CMake

* OS:
* Compiler:
