### PR TITLE
[Backport release/3.12] viewshed: allow values outside of Byte range for DEM and GROUND modes

### DIFF
--- a/alg/viewshed/viewshed.cpp
+++ b/alg/viewshed/viewshed.cpp
@@ -178,11 +178,14 @@ GDALDatasetH GDALViewshedGenerate(
                  "dfInvisibleVal out of range. Must be [0, 255].");
         return nullptr;
     }
-    if (!GDALIsValueInRange<uint8_t>(dfOutOfRangeVal))
+    if (oOpts.outputMode == viewshed::OutputMode::Normal)
     {
-        CPLError(CE_Failure, CPLE_AppDefined,
-                 "dfOutOfRangeVal out of range. Must be [0, 255].");
-        return nullptr;
+        if (!GDALIsValueInRange<uint8_t>(dfOutOfRangeVal))
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "dfOutOfRangeVal out of range. Must be [0, 255].");
+            return nullptr;
+        }
     }
     oOpts.visibleVal = dfVisibleVal;
     oOpts.invisibleVal = dfInvisibleVal;

--- a/apps/gdalalg_raster_viewshed.cpp
+++ b/apps/gdalalg_raster_viewshed.cpp
@@ -121,9 +121,7 @@ GDALRasterViewshedAlgorithm::GDALRasterViewshedAlgorithm(bool standaloneStep)
            _("Pixel value to set for the cells that fall outside of the range "
              "specified by the observer location and the maximum distance"),
            &m_opts.outOfRangeVal)
-        .SetDefault(m_opts.outOfRangeVal)
-        .SetMinValueIncluded(0)
-        .SetMaxValueIncluded(255);
+        .SetDefault(m_opts.outOfRangeVal);
     AddArg("dst-nodata", 0,
            _("The value to be set for the cells in the output raster that have "
              "no data."),

--- a/autotest/utilities/test_gdalalg_raster_viewshed.py
+++ b/autotest/utilities/test_gdalalg_raster_viewshed.py
@@ -130,6 +130,18 @@ def test_gdalalg_raster_viewshed_max_distance_and_out_of_range_value(viewshed_in
     ds = alg["output"].GetDataset()
     assert ds.GetRasterBand(1).Checksum() not in (-1, 0, VIEWSHED_NOMINAL_CHECKSUM, cs)
 
+    alg = get_alg()
+    alg["input"] = viewshed_input
+    alg["output"] = ""
+    alg["output-format"] = "MEM"
+    alg["position"] = [621528, 4817617, 100]
+    alg["max-distance"] = 2000
+    alg["mode"] = "ground"
+    alg["out-of-range-value"] = -9999
+    assert alg.Run()
+    ds = alg["output"].GetDataset()
+    assert ds.GetRasterBand(1).Checksum() not in (-1, 0, VIEWSHED_NOMINAL_CHECKSUM, cs)
+
 
 def test_gdalalg_raster_viewshed_curvature_coefficient(viewshed_input):
 


### PR DESCRIPTION
Backport #13964
 **Authored by:** @lnicola