### PR TITLE
gdal raster edit: add missing --oo option in standalone mode

### DIFF
--- a/apps/gdalalg_raster_edit.cpp
+++ b/apps/gdalalg_raster_edit.cpp
@@ -53,6 +53,7 @@ GDALRasterEditAlgorithm::GDALRasterEditAlgorithm(bool standaloneStep)
                &m_dataset, GDAL_OF_RASTER | GDAL_OF_UPDATE)
             .SetPositional()
             .SetRequired();
+        AddOpenOptionsArg(&m_openOptions);
         AddArg("auxiliary", 0,
                _("Ask for an auxiliary .aux.xml file to be edited"),
                &m_readOnly)

--- a/autotest/utilities/test_gdalalg_raster_edit.py
+++ b/autotest/utilities/test_gdalalg_raster_edit.py
@@ -539,3 +539,23 @@ def test_gdalalg_raster_edit_gcp_output_fromat_does_not_support(tmp_vsimem):
 
     with pytest.raises(Exception, match="Setting GCPs failed"):
         gdal.Run("raster", "edit", dataset=ds, gcp=[[1.5, 2.5, 3.5, 4.5]])
+
+
+@pytest.mark.require_driver("COG")
+def test_gdalalg_raster_edit_cog(tmp_vsimem):
+
+    gdal.alg.raster.convert(
+        input="../gcore/data/byte.tif",
+        output=tmp_vsimem / "out.tif",
+        output_format="COG",
+    )
+    with pytest.raises(
+        Exception, match=r"has C\(loud\) O\(ptimized\) G\(eoTIFF\) layout"
+    ):
+        gdal.alg.raster.edit(dataset=tmp_vsimem / "out.tif", crs="EPSG:32611")
+    with gdal.quiet_errors():
+        gdal.alg.raster.edit(
+            dataset=tmp_vsimem / "out.tif",
+            crs="EPSG:32611",
+            open_option={"IGNORE_COG_LAYOUT_BREAK": "YES"},
+        )

--- a/doc/source/programs/gdal_raster_edit.rst
+++ b/doc/source/programs/gdal_raster_edit.rst
@@ -108,6 +108,13 @@ Program-Specific Options
 
     Remove metadata domain, at the dataset level. May be repeated.
 
+Standard Options
+----------------
+
+.. collapse:: Details
+
+    .. include:: gdal_options/oo.rst
+
 .. Return status code
 .. ------------------
 


### PR DESCRIPTION
Fixes #14107
