### PR TITLE
gdal2tiles.py: make it use 'gdal raster tile' underneath

### DIFF
--- a/apps/gdalalg_raster_tile.cpp
+++ b/apps/gdalalg_raster_tile.cpp
@@ -188,7 +188,7 @@ GDALRasterTileAlgorithm::GDALRasterTileAlgorithm(bool standaloneStep)
 
     std::vector<std::string> tilingSchemes{"raster"};
     for (const std::string &scheme :
-         gdal::TileMatrixSet::listPredefinedTileMatrixSets())
+         gdal::TileMatrixSet::listPredefinedTileMatrixSets(/* hidden = */ true))
     {
         auto poTMS = gdal::TileMatrixSet::parse(scheme.c_str());
         OGRSpatialReference oSRS_TMS;
@@ -208,7 +208,7 @@ GDALRasterTileAlgorithm::GDALRasterTileAlgorithm(bool standaloneStep)
         .SetHiddenChoices(
             "GoogleMapsCompatible",  // equivalent of WebMercatorQuad
             "mercator",              // gdal2tiles equivalent of WebMercatorQuad
-            "geodetic"  // gdal2tiles (not totally) equivalent of WorldCRS84Quad
+            "GlobalGeodeticOriginLat270"  // gdal2tiles geodetic without --tmscompatible
         );
 
     AddArg("min-zoom", 0, _("Minimum zoom level"), &m_minZoomLevel)
@@ -2239,7 +2239,7 @@ GenerateMapML(const std::string &osDirectory, const std::string &mapmlTemplate,
         else
             substs["TILING_SCHEME"] = tms.identifier();
 
-        substs["URL"] = osURL.empty() ? "./" : osURL;
+        substs["URL"] = osURL.empty() ? "./" : osURL + "/";
         substs["MINTILEX"] = CPLSPrintf("%d", nMinTileX);
         substs["MINTILEY"] = CPLSPrintf("%d", nMinTileY);
         substs["MAXTILEX"] = CPLSPrintf("%d", nMaxTileX);
@@ -4597,8 +4597,6 @@ bool GDALRasterTileAlgorithm::RunStep(GDALPipelineStepRunContext &ctxt)
 
     if (m_tilingScheme == "mercator")
         m_tilingScheme = "WebMercatorQuad";
-    else if (m_tilingScheme == "geodetic")
-        m_tilingScheme = "WorldCRS84Quad";
     else if (m_tilingScheme == "raster")
     {
         if (m_tileSize == 0)

--- a/autotest/pyscripts/gdal2tiles/test_logger.py
+++ b/autotest/pyscripts/gdal2tiles/test_logger.py
@@ -33,6 +33,7 @@ def test_gdal2tiles_logger():
         argv=[
             "gdal2tiles",
             "--verbose",
+            "--legacy",
             "-z",
             "13-14",
             "../../gcore/data/byte.tif",

--- a/autotest/pyscripts/gdal2tiles/test_vsimem.py
+++ b/autotest/pyscripts/gdal2tiles/test_vsimem.py
@@ -30,7 +30,13 @@ def test_gdal2tiles_vsimem():
         pytest.skip("PNG driver is missing")
 
     gdal2tiles.main(
-        argv=["gdal2tiles", "-q", "../../gcore/data/byte.tif", "/vsimem/gdal2tiles"]
+        argv=[
+            "gdal2tiles",
+            "--legacy",
+            "-q",
+            "../../gcore/data/byte.tif",
+            "/vsimem/gdal2tiles",
+        ]
     )
 
     assert set(gdal.ReadDirRecursive("/vsimem/gdal2tiles")) == set(

--- a/autotest/pyscripts/test_gdal2tiles.py
+++ b/autotest/pyscripts/test_gdal2tiles.py
@@ -97,7 +97,8 @@ def _verify_raster_band_checksums(filename, expected_cs=[]):
 
 
 @pytest.mark.require_driver("PNG")
-def test_gdal2tiles_py_simple(script_path, tmp_path):
+@pytest.mark.parametrize("legacy", [True, False])
+def test_gdal2tiles_py_simple(script_path, tmp_path, legacy):
 
     input_tif = str(tmp_path / "out_gdal2tiles_smallworld.tif")
 
@@ -111,7 +112,10 @@ def test_gdal2tiles_py_simple(script_path, tmp_path):
     try:
         os.chdir(tmp_path)
         _, err = test_py_scripts.run_py_script(
-            script_path, "gdal2tiles", f"-q {input_tif}", return_stderr=True
+            script_path,
+            "gdal2tiles",
+            f"-q {input_tif}" + (" --legacy" if legacy else ""),
+            return_stderr=True,
         )
     finally:
         os.chdir(prev_wd)
@@ -120,22 +124,28 @@ def test_gdal2tiles_py_simple(script_path, tmp_path):
 
     _verify_raster_band_checksums(
         f"{tmp_path}/out_gdal2tiles_smallworld/0/0/0.png",
-        expected_cs=[31420, 32522, 16314, 17849],
+        expected_cs=[31420, 32522, 16314, 17849] if legacy else [32115, 33298, 17674],
     )
 
-    for filename in [
-        "googlemaps.html",
-        "leaflet.html",
-        "openlayers.html",
-        "tilemapresource.xml",
-    ]:
+    if legacy:
+        expected_files = [
+            "googlemaps.html",
+            "leaflet.html",
+            "openlayers.html",
+            "tilemapresource.xml",
+        ]
+    else:
+        expected_files = ["leaflet.html", "openlayers.html"]
+
+    for filename in expected_files:
         assert os.path.exists(f"{tmp_path}/out_gdal2tiles_smallworld/" + filename), (
             "%s missing" % filename
         )
 
 
 @pytest.mark.require_driver("PNG")
-def test_gdal2tiles_py_zoom_option(script_path, tmp_path):
+@pytest.mark.parametrize("legacy", [True, False])
+def test_gdal2tiles_py_zoom_option(script_path, tmp_path, legacy):
 
     tiles_dir = str(tmp_path / "out_gdal2tiles_smallworld")
 
@@ -148,12 +158,13 @@ def test_gdal2tiles_py_zoom_option(script_path, tmp_path):
         "-q --force-kml --processes=2 -z 0-1 "
         + "vrt://"
         + test_py_scripts.get_data_path("gdrivers")
-        + f"small_world.tif {tiles_dir}",
+        + f"small_world.tif {tiles_dir}"
+        + (" --legacy" if legacy else ""),
     )
 
     _verify_raster_band_checksums(
         f"{tiles_dir}/1/0/0.png",
-        expected_cs=[24063, 23632, 14707, 17849],
+        expected_cs=[24063, 23632, 14707, 17849] if legacy else [24302, 23636, 14857],
     )
 
     assert not os.path.exists(f"{tiles_dir}/0/0/0.png.aux.xml")
@@ -209,7 +220,8 @@ def test_gdal2tiles_py_resampling_option(script_path, tmp_path, resample):
 
 
 @pytest.mark.require_driver("PNG")
-def test_gdal2tiles_py_xyz(script_path, tmp_path):
+@pytest.mark.parametrize("legacy", [True, False])
+def test_gdal2tiles_py_xyz(script_path, tmp_path, legacy):
 
     if gdaltest.is_travis_branch("sanitize"):
         pytest.skip("fails on sanitize for unknown reason")
@@ -225,21 +237,30 @@ def test_gdal2tiles_py_xyz(script_path, tmp_path):
     ret = test_py_scripts.run_py_script(
         script_path,
         "gdal2tiles",
-        f"-q --xyz --zoom=0-1 {input_tif} {out_dir}",
+        f"-q --xyz --zoom=0-1 {input_tif} {out_dir}" + (" --legacy" if legacy else ""),
     )
 
     assert "ERROR ret code" not in ret
 
     _verify_raster_band_checksums(
         f"{out_dir}/0/0/0.png",
-        expected_cs=[31747, 33381, 18447, 17849],
+        expected_cs=[31747, 33381, 18447, 17849] if legacy else [32874, 33678, 17458],
     )
     _verify_raster_band_checksums(
         f"{out_dir}/1/0/0.png",
-        expected_cs=[15445, 16942, 13681, 17849],
+        expected_cs=[15445, 16942, 13681, 17849] if legacy else [15844, 16904, 14254],
     )
 
-    for filename in ["googlemaps.html", "leaflet.html", "openlayers.html"]:
+    if legacy:
+        expected_files = [
+            "googlemaps.html",
+            "leaflet.html",
+            "openlayers.html",
+        ]
+    else:
+        expected_files = ["leaflet.html", "openlayers.html"]
+
+    for filename in expected_files:
         assert os.path.exists(f"{out_dir}/{filename}"), "%s missing" % filename
     assert not os.path.exists(f"{out_dir}/tilemapresource.xml")
 
@@ -269,7 +290,7 @@ def test_gdal2tiles_py_invalid_srs(script_path, tmp_path):
         script_path, "gdal2tiles", f"-q --zoom=0-1 {input_vrt} {output_dir}"
     )
 
-    assert "ERROR ret code = 2" in ret
+    assert "ERROR ret code = 1" in ret
 
     # this time pass the spatial reference system via cli options
     ret2 = test_py_scripts.run_py_script(
@@ -373,7 +394,8 @@ def test_exclude_transparent_tiles(script_path, tmp_path):
 
 
 @pytest.mark.require_driver("PNG")
-def test_gdal2tiles_py_profile_raster(script_path, tmp_path):
+@pytest.mark.parametrize("legacy", [True, False])
+def test_gdal2tiles_py_profile_raster(script_path, tmp_path, legacy):
 
     out_folder = str(tmp_path / "out_gdal2tiles_smallworld")
 
@@ -382,16 +404,21 @@ def test_gdal2tiles_py_profile_raster(script_path, tmp_path):
         "gdal2tiles",
         "-q -p raster -z 0-1 "
         + test_py_scripts.get_data_path("gdrivers")
-        + f"small_world.tif {out_folder}",
+        + f"small_world.tif {out_folder}"
+        + (" --legacy" if legacy else ""),
     )
 
     _verify_raster_band_checksums(
         f"{out_folder}/0/0/0.png",
-        expected_cs=[10125, 10802, 27343, 48852],
+        expected_cs=(
+            [10125, 10802, 27343, 48852] if legacy else [1614, 1448, 24219, 52014]
+        ),
     )
     _verify_raster_band_checksums(
         f"{out_folder}/1/0/0.png",
-        expected_cs=[62125, 59756, 43894, 38539],
+        expected_cs=(
+            [62125, 59756, 43894, 38539] if legacy else [60550, 62572, 46338, 38489]
+        ),
     )
 
     if gdal.GetDriverByName("KMLSuperOverlay") is None:
@@ -401,7 +428,9 @@ def test_gdal2tiles_py_profile_raster(script_path, tmp_path):
         # For some reason, the checksums on the kml file on Windows are the ones of the below png
         _verify_raster_band_checksums(
             f"{out_folder}/0/0/0.kml",
-            expected_cs=[29839, 34244, 42706, 64319],
+            expected_cs=(
+                [29839, 34244, 42706, 64319] if legacy else [51397, 57304, 23305, 11534]
+            ),
         )
 
 
@@ -413,7 +442,7 @@ def test_gdal2tiles_py_profile_raster_oversample(script_path, tmp_path):
     test_py_scripts.run_py_script_as_external_script(
         script_path,
         "gdal2tiles",
-        "-q -p raster -z 0-2 "
+        "-q -p raster -z 0-2 --legacy "
         + test_py_scripts.get_data_path("gdrivers")
         + f"small_world.tif {out_folder}",
     )
@@ -431,7 +460,8 @@ def test_gdal2tiles_py_profile_raster_oversample(script_path, tmp_path):
 
 
 @pytest.mark.require_driver("PNG")
-def test_gdal2tiles_py_profile_raster_xyz(script_path, tmp_path):
+@pytest.mark.parametrize("legacy", [True, False])
+def test_gdal2tiles_py_profile_raster_xyz(script_path, tmp_path, legacy):
 
     out_folder = str(tmp_path / "out_gdal2tiles_smallworld")
 
@@ -440,12 +470,15 @@ def test_gdal2tiles_py_profile_raster_xyz(script_path, tmp_path):
         "gdal2tiles",
         "-q -p raster --xyz -z 0-1 "
         + test_py_scripts.get_data_path("gdrivers")
-        + f"small_world.tif {out_folder}",
+        + f"small_world.tif {out_folder}"
+        + (" --legacy" if legacy else ""),
     )
 
     _verify_raster_band_checksums(
         f"{out_folder}/0/0/0.png",
-        expected_cs=[11468, 10719, 27582, 48827],
+        expected_cs=(
+            [11468, 10719, 27582, 48827] if legacy else [1614, 1448, 24219, 52014]
+        ),
     )
     _verify_raster_band_checksums(
         f"{out_folder}/1/0/0.png",
@@ -459,12 +492,17 @@ def test_gdal2tiles_py_profile_raster_xyz(script_path, tmp_path):
         # For some reason, the checksums on the kml file on Windows are the ones of the below png
         _verify_raster_band_checksums(
             f"{out_folder}/0/0/0.kml",
-            expected_cs=[27644, 31968, 38564, 64301],
+            expected_cs=(
+                [27644, 31968, 38564, 64301] if legacy else [51397, 57304, 23305, 11534]
+            ),
         )
 
 
 @pytest.mark.require_driver("PNG")
-def test_gdal2tiles_py_profile_geodetic_tmscompatible_xyz(script_path, tmp_path):
+@pytest.mark.parametrize("legacy", [True, False])
+def test_gdal2tiles_py_profile_geodetic_tmscompatible_xyz(
+    script_path, tmp_path, legacy
+):
 
     out_folder = str(tmp_path / "out_gdal2tiles_smallworld")
 
@@ -473,16 +511,17 @@ def test_gdal2tiles_py_profile_geodetic_tmscompatible_xyz(script_path, tmp_path)
         "gdal2tiles",
         "-q -p geodetic --tmscompatible --xyz -z 0-1 "
         + test_py_scripts.get_data_path("gdrivers")
-        + f"small_world.tif {out_folder}",
+        + f"small_world.tif {out_folder}"
+        + (" --legacy" if legacy else ""),
     )
 
     _verify_raster_band_checksums(
         f"{out_folder}/0/0/0.png",
-        expected_cs=[8560, 8031, 7209, 17849],
+        expected_cs=[8560, 8031, 7209, 17849] if legacy else [8682, 7870, 6354],
     )
     _verify_raster_band_checksums(
         f"{out_folder}/1/0/0.png",
-        expected_cs=[2799, 3468, 8686, 17849],
+        expected_cs=[2799, 3468, 8686, 17849] if legacy else [3041, 4203, 8996],
     )
 
     if gdal.GetDriverByName("KMLSuperOverlay") is None:
@@ -492,7 +531,9 @@ def test_gdal2tiles_py_profile_geodetic_tmscompatible_xyz(script_path, tmp_path)
         # For some reason, the checksums on the kml file on Windows are the ones of the below png
         _verify_raster_band_checksums(
             f"{out_folder}/0/0/0.kml",
-            expected_cs=[12361, 18212, 21827, 5934],
+            expected_cs=(
+                [12361, 18212, 21827, 5934] if legacy else [14917, 18500, 22006, 5934]
+            ),
         )
 
 
@@ -530,7 +571,7 @@ def test_gdal2tiles_py_mapml(script_path, tmp_path):
         in mapml
     )
     assert (
-        '<map-link tref="https://foo/out_gdal2tiles_mapml/{z}/{x}/{y}.png" rel="tile" ></map-link>'
+        '<map-link tref="https://foo/out_gdal2tiles_mapml/out_gdal2tiles_mapml/{z}/{x}/{y}.png" rel="tile" ></map-link>'
         in mapml
     )
 
@@ -666,11 +707,10 @@ def test_gdal2tiles_nodata_values_pct_threshold(script_path, tmp_path):
         f"-q -z 0-1 {input_tif} {output_folder}",
     )
 
-    ds = gdal.Open(f"{output_folder}/0/0/0.png")
-    assert struct.unpack("B" * 2, ds.ReadRaster(0, 0, 1, 1, band_list=[1, 4])) == (
-        round((10 + 30 + 40) / 3),
-        255,
-    )
+    with gdal.Open(f"{output_folder}/0/0/0.png") as ds:
+        assert struct.unpack("B", ds.GetRasterBand(1).ReadRaster(0, 0, 1, 1))[
+            0
+        ] == round((10 + 30 + 40) / 3)
 
     test_py_scripts.run_py_script_as_external_script(
         script_path,
@@ -678,11 +718,10 @@ def test_gdal2tiles_nodata_values_pct_threshold(script_path, tmp_path):
         f"-q -z 0-1 --nodata-values-pct-threshold=50 {input_tif} {output_folder}",
     )
 
-    ds = gdal.Open(f"{output_folder}/0/0/0.png")
-    assert struct.unpack("B" * 2, ds.ReadRaster(0, 0, 1, 1, band_list=[1, 4])) == (
-        round((10 + 30 + 40) / 3),
-        255,
-    )
+    with gdal.Open(f"{output_folder}/0/0/0.png") as ds:
+        assert struct.unpack("B", ds.GetRasterBand(1).ReadRaster(0, 0, 1, 1))[
+            0
+        ] == round((10 + 30 + 40) / 3)
 
     test_py_scripts.run_py_script_as_external_script(
         script_path,
@@ -690,8 +729,7 @@ def test_gdal2tiles_nodata_values_pct_threshold(script_path, tmp_path):
         f"-q -z 0-1 --nodata-values-pct-threshold=25 {input_tif} {output_folder}",
     )
 
-    ds = gdal.Open(f"{output_folder}/0/0/0.png")
-    assert struct.unpack("B" * 2, ds.ReadRaster(0, 0, 1, 1, band_list=[1, 4])) == (0, 0)
+    assert not os.path.exists(f"{output_folder}/0/0/0.png")
 
 
 @pytest.mark.require_driver("JPEG")

--- a/autotest/utilities/data/gdal_raster_tile_expected_mapml.mapml
+++ b/autotest/utilities/data/gdal_raster_tile_expected_mapml.mapml
@@ -14,7 +14,7 @@
             <map-input name="z" type="zoom" value="11" min="11" max="11" ></map-input>
             <map-input name="x" type="location" axis="column" units="tilematrix" min="354" max="354" ></map-input>
             <map-input name="y" type="location" axis="row" units="tilematrix" min="818" max="818" ></map-input>
-            <map-link tref="http://example.com/test_gdalalg_raster_tile_basic_None_None_{z}/{x}/{y}.png" rel="tile" ></map-link>
+            <map-link tref="http://example.com/test_gdalalg_raster_tile_basic_None_None_/{z}/{x}/{y}.png" rel="tile" ></map-link>
             <!--<map-link tref="http://localhost:8080/myservice/wmts?layer=MYLAYER&amp;style=&amp;tilematrixset=OSMTILE&amp;service=WMTS&amp;request=GetTile&amp;version=1.0.0&amp;tilematrix={z}&amp;TileCol={x}&amp;TileRow={y}&amp;format=image/png" rel="tile" ></map-link>-->
             <!--
             <map-input name="i" type="location" axis="i" units="tile" ></map-input>

--- a/autotest/utilities/test_gdalalg_raster_tile.py
+++ b/autotest/utilities/test_gdalalg_raster_tile.py
@@ -146,7 +146,7 @@ def test_gdalalg_raster_tile_basic(tmp_vsimem, tiling_scheme, tilesize):
 
 @pytest.mark.parametrize(
     "tiling_scheme,xyz,addalpha",
-    [("WorldCRS84Quad", True, True), ("geodetic", False, False)],
+    [("WorldCRS84Quad", True, True), ("WorldCRS84Quad", False, False)],
 )
 def test_gdalalg_raster_tile_small_world_geodetic(
     tmp_vsimem, tiling_scheme, xyz, addalpha

--- a/doc/source/programs/gdal2tiles.rst
+++ b/doc/source/programs/gdal2tiles.rst
@@ -17,6 +17,7 @@ Synopsis
 
 
     gdal2tiles [--help] [--help-general]
+                  [--legacy]
                   [-p <profile>] [-r resampling] [-s <srs>] [-z <zoom>]
                   [-e] [-a nodata] [-v] [-q] [-h] [-k] [-n] [-u <url>]
                   [-w <webviewer>] [-t <title>] [-c <copyright>]
@@ -29,6 +30,16 @@ Synopsis
 
 Description
 -----------
+
+.. warning::
+
+    Starting with GDAL 3.13, :program:`gdal2tiles` is deprecated, and by default
+    is remapped to :ref:`gdal_raster_tile`. For now, you may force the use of
+    the legacy code by specifying `--legacy`, but legacy mode will be
+    removed in GDAL 3.15. If you find yourself to need legacy mode
+    and cannot find workarounds using gdal raster tile, please file a ticket at
+    https://github.com/OSGeo/GDAL
+
 
 This utility generates a directory with small tiles and metadata, following
 the OSGeo Tile Map Service Specification. Simple web pages with viewers based on
@@ -64,6 +75,13 @@ can publish a picture without proper georeferencing too.
 .. program:: gdal2tiles
 
 .. include:: options/help_and_help_general.rst
+
+.. option:: --legacy
+
+  .. versionadded:: 3.13
+
+  Force the use of the legacy code base. Since GDAL 3.13, by default, gdal2tiles
+  is implemented using :ref:`gdal_raster_tile`.
 
 .. option:: -p <PROFILE>, --profile=<PROFILE>
 
@@ -128,18 +146,24 @@ can publish a picture without proper georeferencing too.
 
 .. option:: --mpi
 
+  .. versionadded:: 3.5
+
   Assume launched by mpiexec, enable MPI parallelism and ignore --processes.
   Requires working MPI environment and the MPI for Python (mpi4py) package.
   User should set GDAL_CACHEMAX to an appropriate cache size per process
   based on memory per node and the number of processes launched per node.
 
-  .. versionadded:: 3.5
+  .. warning::
+
+     --mpi mode is not supported in :ref:`gdal_raster_tile` non-legacy mode.
+     You may specify :option:`--legacy` to go on, but this legacy mode is going
+     to be removed in GDAL 3.15.
 
 .. option:: --tilesize=<PIXELS>
 
-  Width and height in pixel of a tile. Default is 256.
-
   .. versionadded:: 3.1
+
+  Width and height in pixel of a tile. Default is 256.
 
 .. option:: --tiledriver=<DRIVER>
 

--- a/frmts/jpeg/jpgdataset.cpp
+++ b/frmts/jpeg/jpgdataset.cpp
@@ -5060,12 +5060,22 @@ GDALDataset *JPGDataset::CreateCopyStage2(
     sCInfo.image_height = nYSize;
     sCInfo.input_components = nBands;
 
+    int eGDALColorSpace;
     if (nBands == 3)
+    {
+        eGDALColorSpace = JCS_RGB;
         sCInfo.in_color_space = JCS_RGB;
+    }
     else if (nBands == 1)
+    {
+        eGDALColorSpace = JCS_GRAYSCALE;
         sCInfo.in_color_space = JCS_GRAYSCALE;
+    }
     else
+    {
+        eGDALColorSpace = JCS_CMYK;
         sCInfo.in_color_space = JCS_UNKNOWN;
+    }
 
     jpeg_set_defaults(&sCInfo);
 
@@ -5353,6 +5363,7 @@ GDALDataset *JPGDataset::CreateCopyStage2(
     }
 
     JPGDataset *poJPG_DS = new JPGDataset();
+    poJPG_DS->eGDALColorSpace = eGDALColorSpace;
     poJPG_DS->nRasterXSize = nXSize;
     poJPG_DS->nRasterYSize = nYSize;
     for (int i = 0; i < nBands; i++)

--- a/gcore/tilematrixset.cpp
+++ b/gcore/tilematrixset.cpp
@@ -30,11 +30,14 @@ namespace gdal
 /*                    listPredefinedTileMatrixSets()                    */
 /************************************************************************/
 
-std::vector<std::string> TileMatrixSet::listPredefinedTileMatrixSets()
+std::vector<std::string>
+TileMatrixSet::listPredefinedTileMatrixSets(bool includeHidden)
 {
     std::vector<std::string> l{"GoogleMapsCompatible", "WorldCRS84Quad",
                                "WorldMercatorWGS84Quad", "GoogleCRS84Quad",
                                "PseudoTMS_GlobalMercator"};
+    if (includeHidden)
+        l.push_back("GlobalGeodeticOriginLat270");
     const char *pszSomeFile = CPLFindFile("gdal", "tms_NZTM2000.json");
     if (pszSomeFile)
     {
@@ -241,6 +244,36 @@ std::unique_ptr<TileMatrixSet> TileMatrixSet::parse(const char *fileOrDef)
                 tm.mResX * (HALF_CIRCUMFERENCE / 180) / 0.28e-3;
             tm.mTopLeftX = -180;
             tm.mTopLeftY = 180;
+            tm.mTileWidth = 256;
+            tm.mTileHeight = 256;
+            tm.mMatrixWidth = 1 << i;
+            tm.mMatrixHeight = 1 << i;
+            poTMS->mTileMatrixList.emplace_back(std::move(tm));
+        }
+        return poTMS;
+    }
+
+    if (EQUAL(fileOrDef, "GlobalGeodeticOriginLat270"))
+    {
+        // gdal2tiles --profile=geodetic *without* --tmscompatible
+        poTMS->mTitle = "GlobalGeodeticOriginLat270";
+        poTMS->mIdentifier = "GlobalGeodeticOriginLat270";
+        poTMS->mCrs = "http://www.opengis.net/def/crs/OGC/1.3/CRS84";
+        poTMS->mBbox.mCrs = poTMS->mCrs;
+        poTMS->mBbox.mLowerCornerX = -180;
+        poTMS->mBbox.mLowerCornerY = -90;
+        poTMS->mBbox.mUpperCornerX = 180;
+        poTMS->mBbox.mUpperCornerY = 270;
+        for (int i = 0; i <= 30; i++)
+        {
+            TileMatrix tm;
+            tm.mId = CPLSPrintf("%d", i);
+            tm.mResX = 360. / 256 / (1 << i);
+            tm.mResY = tm.mResX;
+            tm.mScaleDenominator =
+                tm.mResX * (HALF_CIRCUMFERENCE / 180) / 0.28e-3;
+            tm.mTopLeftX = -180;
+            tm.mTopLeftY = 270;
             tm.mTileWidth = 256;
             tm.mTileHeight = 256;
             tm.mMatrixWidth = 1 << i;

--- a/gcore/tilematrixset.hpp
+++ b/gcore/tilematrixset.hpp
@@ -121,7 +121,8 @@ class CPL_DLL TileMatrixSet
 
     /** Return hardcoded tile matrix set names (such as GoogleMapsCompatible),
      * as well as XXX for each tms_XXXX.json in GDAL data directory */
-    static std::vector<std::string> listPredefinedTileMatrixSets();
+    static std::vector<std::string>
+    listPredefinedTileMatrixSets(bool includeHidden = false);
 
     bool haveAllLevelsSameTopLeft() const;
 

--- a/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
+++ b/swig/python/gdal-utils/osgeo_utils/gdal2tiles.py
@@ -31,6 +31,7 @@ import stat
 import sys
 import tempfile
 import threading
+import warnings
 from functools import partial
 from typing import Any, Dict, List, NoReturn, Optional, Tuple
 from uuid import uuid4
@@ -1702,6 +1703,15 @@ def optparse_init() -> Tuple[optparse.OptionParser, Dict[Any, Any]]:
     p = optparse.OptionParser(usage, version="%prog " + __version__)
 
     profile_list, tmsMap = get_profile_list_and_tmsMap()
+
+    p.add_option(
+        "--legacy",
+        dest="legacy",
+        action="store_true",
+        help=(
+            "Whether to use legacy gdal2tiles mode. Otherwise by default 'gdal raster tile' is used underneath. If you find yourself to need legacy mode and cannot find workarounds using gdal raster tile, please file a ticket at https://github.com/OSGeo/GDAL since legacy mode will be removed in GDAL 3.15."
+        ),
+    )
 
     p.add_option(
         "-p",
@@ -4584,6 +4594,12 @@ def main(argv: List[str] = sys.argv, called_from_main=False) -> int:
             os.environ[argv[i + 1]] = argv[i + 2]
 
     if "--mpi" in argv:
+
+        if "--legacy" not in argv:
+            raise Exception(
+                "--mpi mode is not supported in 'gdal raster tile' non-legacy mode. You may specify --legacy to go on, but this legacy mode is going to be removed in GDAL 3.15."
+            )
+
         from mpi4py import MPI
         from mpi4py.futures import MPICommExecutor
 
@@ -4608,6 +4624,133 @@ def submain(argv: List[str], pool=None, pool_size=0, called_from_main=False) -> 
     input_file, output_folder, options, tmsMap = process_args(
         argv[1:], called_from_main=called_from_main
     )
+
+    if not options.legacy:
+
+        kwargs = {
+            "input": input_file,
+            "output": output_folder,
+        }
+        if not options.quiet:
+            kwargs["progress"] = gdal.TermProgress_nocb
+
+        if options.profile == "raster":
+            kwargs["tiling_scheme"] = "raster"
+        elif options.profile == "geodetic":
+            if options.tmscompatible:
+                kwargs["tiling_scheme"] = "WorldCRS84Quad"
+            else:
+                kwargs["tiling_scheme"] = "GlobalGeodeticOriginLat270"
+        else:
+            kwargs["tiling_scheme"] = options.profile
+
+        if options.resampling:
+            kwargs["resampling"] = options.resampling
+
+        if options.zoom[0] is not None:
+            kwargs["min_zoom"] = options.zoom[0]
+        if options.zoom[1] is not None:
+            kwargs["max_zoom"] = options.zoom[1]
+
+        if options.resume:
+            kwargs["resume"] = True
+
+        if options.s_srs or options.srcnodata is not None:
+            tmp_dir = tempfile.mkdtemp()
+            tmp_file = os.path.join(tmp_dir, "tmp.vrt")
+            gdal.Translate(
+                tmp_file, input_file, outputSRS=options.s_srs, noData=options.srcnodata
+            )
+            kwargs["input"] = str(tmp_file)
+
+        if not options.xyz:
+            kwargs["convention"] = "tms"
+
+        if options.processes:
+            kwargs["num_threads"] = options.processes
+
+        if options.tilesize:
+            kwargs["tile_size"] = options.tilesize
+
+        if options.tiledriver:
+            kwargs["output_format"] = options.tiledriver
+
+        if options.excluded_values:
+            kwargs["excluded_values"] = options.excluded_values
+
+            if options.excluded_values_pct_threshold:
+                kwargs["excluded_values_pct_threshold"] = (
+                    options.excluded_values_pct_threshold
+                )
+
+        if options.nodata_values_pct_threshold != 100:
+            kwargs["nodata_values_pct_threshold"] = options.nodata_values_pct_threshold
+
+        def is_4326_raster(kwargs):
+            ds = gdal.Open(kwargs["input"])
+            srs = ds.GetSpatialRef()
+            return srs is not None and srs.GetAuthorityCode(None) == "4326"
+
+        if options.kml is True or (
+            (
+                options.profile == "geodetic"
+                or (options.profile == "raster" and is_4326_raster(kwargs))
+            )
+            and options.kml is None
+        ):
+            kwargs["kml"] = True
+
+        if options.url:
+            kwargs["url"] = options.url
+
+        if options.webviewer:
+            kwargs["webviewer"] = options.webviewer
+
+        if options.title:
+            kwargs["title"] = options.title
+
+        if options.copyright:
+            kwargs["copyright"] = options.copyright
+
+        if options.mapml_template:
+            kwargs["mapml_template"] = options.mapml_template
+
+        kwargs["skip_blank"] = True
+
+        creation_options = {}
+
+        if options.tiledriver == "WEBP":
+            if options.webp_quality:
+                creation_options["QUALITY"] = options.webp_quality
+            if options.webp_lossless:
+                creation_options["LOSSLESS"] = True
+        elif options.tiledriver == "JPEG":
+            if options.jpeg_quality:
+                creation_options["QUALITY"] = options.jpeg_quality
+
+        if creation_options:
+            kwargs["creation_option"] = creation_options
+
+        if options.googlekey != "INSERT_YOUR_KEY_HERE":
+            raise Exception(
+                "--googlekey is no longer supported in new 'gdal raster tile' non-legacy mode."
+            )
+
+        if options.bingkey != "INSERT_YOUR_KEY_HERE":
+            raise Exception(
+                "--bingkey is no longer supported in new 'gdal raster tile' non-legacy mode."
+            )
+
+        if gdal.alg.raster.tile(**kwargs):
+            return 0
+        else:
+            return 1
+
+    warnings.warn(
+        "--legacy mode is deprecated and will be removed in GDAL 3.15. If you find yourself to need legacy mode and cannot find workarounds using 'gdal raster tile', please file a ticket at https://github.com/OSGeo/GDAL",
+        DeprecationWarning,
+    )
+
     if pool_size:
         options.nb_processes = pool_size
     nb_processes = options.nb_processes or 1


### PR DESCRIPTION
gdal2tiles has always been a bit hard to maintain and is now mostly a sub-par version of gdal raster tile.

So:

- Remap by default gdal2tiles command line arguments to 'gdal raster tile' and make it do the job

- unless the user specifies "--legacy". Emit a deprecation warning when legacy mode is specified, indicating it will be removed in GDAL 3.15. Then gdal2tiles will only be a compatibility shim.

- the only significant option of gdal2tiles not available in 'gdal raster tile' is --mpi. Emit explicit error when users try it to ask them to set --legacy and warn them some action will be needed if they want to keep that functionality

Note that even when options can be mapped, the end result can be different:
- default zoom level logic computation is different
- pixel values are different (gdal raster tile output should be better)
- some auxiliary files like googlemaps.html and tilemapresource.xml are not generated by gdal raster tile
