### PR TITLE
[Backport release/3.12] ai_tool_policy.rst: Fix link to AI tool policy in documentation

### DIFF
--- a/doc/source/community/ai_tool_policy.rst
+++ b/doc/source/community/ai_tool_policy.rst
@@ -125,7 +125,7 @@ they should paste the following response to request changes:
     and requires additional justification for why it is valuable enough to the
     project for us to review it. Please see our developer policy on
     AI-generated contributions:
-    https://gdal.org/community/_ai_tool_policy.html
+    https://gdal.org/community/ai_tool_policy.html
 
 The best ways to make a change less extractive and more valuable are to reduce
 its size or complexity or to increase its usefulness to the community. These


### PR DESCRIPTION
Backport #14116
 **Authored by:** @schwehr