### PR TITLE
ESRIJSON: add a HTTP_METHOD=AUTO/GET/POST open option

### DIFF
--- a/autotest/ogr/ogr_esrijson.py
+++ b/autotest/ogr/ogr_esrijson.py
@@ -755,3 +755,72 @@ def test_ogr_esrijson_force_opening_url():
 
     drv = gdal.IdentifyDriverEx("http://example.com", allowed_drivers=["ESRIJSON"])
     assert drv.GetDescription() == "ESRIJSON"
+
+
+###############################################################################
+# Test reading http:// resource
+
+
+@pytest.mark.require_curl()
+def test_ogr_esrijson_read_from_http_POST():
+
+    import webserver
+
+    webserver_process, webserver_port = webserver.launch(
+        handler=webserver.DispatcherHttpHandler
+    )
+    if webserver_port == 0:
+        pytest.skip()
+
+    response = b"""
+        {
+        "objectIdFieldName" : "objectid",
+        "geometryType" : "esriGeometryPoint",
+        "fields" : [
+            {
+            "name" : "objectid",
+            "alias" : "Object ID",
+            "type" : "esriFieldTypeOID"
+            },
+
+        ],
+        "features" : [
+            {
+            "geometry" : {
+                "x" : 2,
+                "y" : 49,
+                "z" : 1
+            },
+            "attributes" : {
+                "objectid" : 1
+            }
+            }
+        ]
+        }
+        """
+
+    handler = webserver.SequentialHandler()
+    handler.add(
+        "POST",
+        "/foo",
+        200,
+        {"Content-Length": len(response)},
+        response,
+        expected_headers={
+            "Accept": "text/plain, application/json",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
+        expected_body=b"f=json&where=1%3D1&bla=" + b"x" * 256,
+    )
+
+    try:
+        with webserver.install_http_handler(handler):
+            ds = ogr.Open(
+                f"ESRIJSON:http://localhost:{webserver_port}/foo?f=json&where=1%3D1&bla="
+                + "x" * 256
+            )
+        assert ds is not None
+        lyr = ds.GetLayer(0)
+        assert lyr.GetFeatureCount() == 1
+    finally:
+        webserver.server_stop(webserver_process, webserver_port)

--- a/autotest/pymod/webserver.py
+++ b/autotest/pymod/webserver.py
@@ -236,7 +236,9 @@ class BaseMockedHttpHandler:
             if req_resp.expected_body:
                 content = request.rfile.read(int(request.headers["Content-Length"]))
                 if content != req_resp.expected_body:
-                    sys.stderr.write("Did not get expected content: %s\n" % content)
+                    sys.stderr.write(
+                        f"Did not get expected content: got '{content}', instead of '{req_resp.expected_body}'\n"
+                    )
                     request.send_response(400)
                     request.send_header("Content-Length", 0)
                     request.end_headers()

--- a/doc/source/drivers/vector/esrijson.rst
+++ b/doc/source/drivers/vector/esrijson.rst
@@ -66,12 +66,22 @@ The following open options are supported:
       through results with a ArcGIS Feature Service endpoint. Has only effect
       for ArcGIS servers >= 10.3 and layers with supportsPagination=true capability.
 
+-  .. oo:: HTTP_METHOD
+      :choices: AUTO, GET, POST
+      :default: AUTO
+      :since: 3.13
+
+      Which HTTP request method to use to send requests to the server. In AUTO
+      mode (the default), GET will be used, unless the URL exceeds 256 characters.
+      When it does, the query parameters (the part of the URL after '?') will
+      be sent in the body of a POST request.
+
 Examples
 --------
 
 .. example::
-   :title: Read the result of a FeatureService request against a GeoServices REST server 
-   
+   :title: Read the result of a FeatureService request against a GeoServices REST server
+
    Note that this server does not support paging.
 
    .. code-block:: bash

--- a/ogr/ogrsf_frmts/geojson/ogresrijsondriver.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogresrijsondriver.cpp
@@ -85,6 +85,13 @@ void RegisterOGRESRIJSON()
         "  <Option name='FEATURE_SERVER_PAGING' type='boolean' "
         "description='Whether to automatically scroll through results with a "
         "ArcGIS Feature Service endpoint'/>"
+        "  <Option name='HTTP_METHOD' type='string-select' default='AUTO' "
+        "description='Which HTTP request method to use to send requests to "
+        "the server'>"
+        "    <Value>AUTO</Value>"
+        "    <Value>GET</Value>"
+        "    <Value>POST</Value>"
+        "  </Option>"
         "</OpenOptionList>");
 
     poDriver->SetMetadataItem(GDAL_DMD_CREATIONOPTIONLIST,

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsondatasource.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsondatasource.cpp
@@ -861,7 +861,8 @@ int OGRGeoJSONDataSource::ReadFromService(GDALOpenInfo *poOpenInfo,
     /* -------------------------------------------------------------------- */
     /*      Fetch the GeoJSON result.                                        */
     /* -------------------------------------------------------------------- */
-    CPLHTTPResult *pResult = GeoJSONHTTPFetchWithContentTypeHeader(pszSource);
+    CPLHTTPResult *pResult = GeoJSONHTTPFetchWithContentTypeHeader(
+        pszSource, /* bCanUsePOST = */ osJSonFlavor_ == "ESRIJSON", poOpenInfo);
     if (!pResult)
     {
         return FALSE;

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonseqdriver.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonseqdriver.cpp
@@ -843,8 +843,8 @@ bool OGRGeoJSONSeqDataSource::Open(GDALOpenInfo *poOpenInfo,
         }
         else
         {
-            CPLHTTPResult *pResult =
-                GeoJSONHTTPFetchWithContentTypeHeader(pszUnprefixedFilename);
+            CPLHTTPResult *pResult = GeoJSONHTTPFetchWithContentTypeHeader(
+                pszUnprefixedFilename, false, nullptr);
             if (!pResult)
             {
                 return FALSE;

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonutils.cpp
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonutils.cpp
@@ -1070,7 +1070,9 @@ OGRFieldType GeoJSONStringPropertyToFieldType(json_object *poObject,
 /*               GeoJSONHTTPFetchWithContentTypeHeader()                */
 /************************************************************************/
 
-CPLHTTPResult *GeoJSONHTTPFetchWithContentTypeHeader(const char *pszURL)
+CPLHTTPResult *
+GeoJSONHTTPFetchWithContentTypeHeader(const char *pszURL, bool bCanUsePOST,
+                                      const GDALOpenInfo *poOpenInfo)
 {
     std::string osHeaders;
     const char *pszGDAL_HTTP_HEADERS =
@@ -1120,7 +1122,29 @@ CPLHTTPResult *GeoJSONHTTPFetchWithContentTypeHeader(const char *pszURL)
 
     CPLStringList aosOptions;
     aosOptions.SetNameValue("HEADERS", osHeaders.c_str());
-    CPLHTTPResult *pResult = CPLHTTPFetch(pszURL, aosOptions.List());
+
+    std::string osURL(pszURL);
+    if (bCanUsePOST && poOpenInfo)
+    {
+        const char *pszHTTPMethod = CSLFetchNameValueDef(
+            poOpenInfo->papszOpenOptions, "HTTP_METHOD", "AUTO");
+        constexpr size_t MAX_URL_LEN_FOR_GET = 256;  // arbitrary
+        if (EQUAL(pszHTTPMethod, "AUTO"))
+            pszHTTPMethod =
+                (strlen(pszURL) < MAX_URL_LEN_FOR_GET) ? "GET" : "POST";
+        if (EQUAL(pszHTTPMethod, "POST"))
+        {
+            const auto nQuestionMarkPos = osURL.find('?');
+            if (nQuestionMarkPos != std::string::npos)
+            {
+                aosOptions.SetNameValue(
+                    "POSTFIELDS", osURL.substr(nQuestionMarkPos + 1).c_str());
+                osURL.resize(nQuestionMarkPos);
+            }
+        }
+    }
+
+    CPLHTTPResult *pResult = CPLHTTPFetch(osURL.c_str(), aosOptions.List());
 
     if (nullptr == pResult || 0 == pResult->nDataLen ||
         0 != CPLGetLastErrorNo())

--- a/ogr/ogrsf_frmts/geojson/ogrgeojsonutils.h
+++ b/ogr/ogrsf_frmts/geojson/ogrgeojsonutils.h
@@ -60,6 +60,8 @@ OGRFieldType GeoJSONStringPropertyToFieldType(json_object *poObject,
 /*                GeoJSONHTTPFetchWithContentTypeHeader                 */
 /************************************************************************/
 
-CPLHTTPResult *GeoJSONHTTPFetchWithContentTypeHeader(const char *pszURL);
+CPLHTTPResult *
+GeoJSONHTTPFetchWithContentTypeHeader(const char *pszURL, bool bCanUsePOST,
+                                      const GDALOpenInfo *poOpenInfo);
 
 #endif  // OGR_GEOJSONUTILS_H_INCLUDED


### PR DESCRIPTION
Being able to switch to POST overcomes server limitations on the maximum size of a URL
