### PR TITLE
docs: fix the 'of' option for vector grid

### DIFF
--- a/doc/source/programs/gdal_vector_grid.rst
+++ b/doc/source/programs/gdal_vector_grid.rst
@@ -37,7 +37,7 @@ Options common to all algorithms
 Standard options
 ++++++++++++++++
 
-.. include:: gdal_options/of_vector.rst
+.. include:: gdal_options/of_raster_create.rst
 
 .. include:: gdal_options/co_vector.rst
 


### PR DESCRIPTION
## What does this PR do?

Fixes the `-of` option for `gdal vector grid`. The command outputs a raster but the vector docs (https://gdal.org/en/stable/programs/gdal_vector_grid.html) were used:

<img width="944" height="130" alt="image" src="https://github.com/user-attachments/assets/4f3469f5-dabb-4ec0-bd99-309534f533f0" />

## AI tool usage

 - [ ] AI (Copilot or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [ ] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [x] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [x] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed

