### PR TITLE
[Backport release/3.12] docs: fix the 'of' option for vector grid

### DIFF
--- a/doc/source/programs/gdal_vector_grid.rst
+++ b/doc/source/programs/gdal_vector_grid.rst
@@ -37,7 +37,7 @@ Options common to all algorithms
 Standard options
 ++++++++++++++++
 
-.. include:: gdal_options/of_vector.rst
+.. include:: gdal_options/of_raster_create.rst
 
 .. include:: gdal_options/co_vector.rst
 


### PR DESCRIPTION
Backport #14125
 **Authored by:** @gadomski