### PR TITLE
ossfuzz: suppress false positive unsigned-integer-overflow warning on std::from_chars()

### DIFF
--- a/cmake/helpers/GdalCompilationFlags.cmake
+++ b/cmake/helpers/GdalCompilationFlags.cmake
@@ -170,6 +170,11 @@ else ()
     endif ()
   endif ()
 
+  check_c_compiler_flag(-fsanitize-ignorelist=${PROJECT_SOURCE_DIR}/cmake/helpers/ubsan_ignore_list.txt HAVE_SANITIZE_IGNORE_LIST)
+  if (HAVE_SANITIZE_IGNORE_LIST)
+      add_compile_options(-fsanitize-ignorelist=${PROJECT_SOURCE_DIR}/cmake/helpers/ubsan_ignore_list.txt)
+  endif()
+
 endif ()
 
 add_compile_definitions($<$<CONFIG:DEBUG>:DEBUG>)

--- a/cmake/helpers/ubsan_ignore_list.txt
+++ b/cmake/helpers/ubsan_ignore_list.txt
@@ -1,0 +1,3 @@
+[unsigned-integer-overflow]
+# std::from_chars() with integer output generates unsigned integer overflow
+fun:*from_chars*


### PR DESCRIPTION
should fix https://issues.oss-fuzz.com/issues/448717148
