### PR TITLE
[Backport release/3.12] Add CPLLexicallyNormalize() to normalize file paths

### DIFF
--- a/autotest/cpp/test_cpl.cpp
+++ b/autotest/cpp/test_cpl.cpp
@@ -1119,11 +1119,30 @@ TEST_F(test_cpl, CPLGetDirname)
         "2Fgdal%2Fmaster%2Fautotest%2Fogr%2Fdata");
 }
 
-TEST_F(test_cpl, VSIGetDiskFreeSpace)
+TEST_F(test_cpl, CPLLexicallyNormalize)
 {
-    ASSERT_TRUE(VSIGetDiskFreeSpace("/vsimem/") > 0);
-    ASSERT_TRUE(VSIGetDiskFreeSpace(".") == -1 ||
-                VSIGetDiskFreeSpace(".") >= 0);
+    EXPECT_STREQ(CPLLexicallyNormalize("", '/').c_str(), "");
+    EXPECT_STREQ(CPLLexicallyNormalize("x", '/').c_str(), "x");
+    EXPECT_STREQ(CPLLexicallyNormalize("xy", '/').c_str(), "xy");
+    EXPECT_STREQ(CPLLexicallyNormalize("x/", '/').c_str(), "x/");
+    EXPECT_STREQ(CPLLexicallyNormalize("x/.", '/').c_str(), "x/");
+    EXPECT_STREQ(CPLLexicallyNormalize("x/./", '/').c_str(), "x/");
+    EXPECT_STREQ(CPLLexicallyNormalize("x/y", '/').c_str(), "x/y");
+    EXPECT_STREQ(CPLLexicallyNormalize("x/yz", '/').c_str(), "x/yz");
+    EXPECT_STREQ(CPLLexicallyNormalize("xy/z", '/').c_str(), "xy/z");
+    EXPECT_STREQ(CPLLexicallyNormalize("x//y", '/').c_str(), "x/y");
+    EXPECT_STREQ(CPLLexicallyNormalize("/", '/').c_str(), "/");
+    EXPECT_STREQ(CPLLexicallyNormalize("/x", '/').c_str(), "/x");
+    EXPECT_STREQ(CPLLexicallyNormalize("../x", '/').c_str(), "../x");
+    EXPECT_STREQ(CPLLexicallyNormalize("x/../y", '/').c_str(), "y");
+    EXPECT_STREQ(CPLLexicallyNormalize("x/..", '/').c_str(), "");
+    EXPECT_STREQ(CPLLexicallyNormalize("x/../", '/').c_str(), "");
+    EXPECT_STREQ(CPLLexicallyNormalize("xy/../z", '/').c_str(), "z");
+    EXPECT_STREQ(CPLLexicallyNormalize("x/../yz", '/').c_str(), "yz");
+    EXPECT_STREQ(CPLLexicallyNormalize("x/../../yz", '/').c_str(), "../yz");
+    EXPECT_STREQ(CPLLexicallyNormalize("a/x/y/../../t", '/').c_str(), "a/t");
+    EXPECT_STREQ(CPLLexicallyNormalize("a\\x\\y\\..\\..\\t", '/', '\\').c_str(),
+                 "a\\t");
 }
 
 TEST_F(test_cpl, CPLsscanf)

--- a/port/cpl_conv.h
+++ b/port/cpl_conv.h
@@ -238,6 +238,12 @@ extern "C++"
         CPL_WARN_UNUSED_RESULT;
     std::string CPL_DLL CPLLaunderForFilenameSafe(
         const char *pszName, const char *pszOutputPath) CPL_WARN_UNUSED_RESULT;
+
+#if defined(GDAL_COMPILATION) || __cplusplus >= 201703L
+    std::string CPL_DLL CPLLexicallyNormalize(std::string_view svPath,
+                                              char sep1, char sep2 = 0)
+        CPL_WARN_UNUSED_RESULT;
+#endif
 }
 
 #endif  // defined(__cplusplus) && !defined(CPL_SUPRESS_CPLUSPLUS)

--- a/port/cpl_path.cpp
+++ b/port/cpl_path.cpp
@@ -1737,3 +1737,102 @@ bool CPLHasUnbalancedPathTraversal(const char *pszFilename)
 
     return false;
 }
+
+/************************************************************************/
+/*                       CPLLexicallyNormalize()                        */
+/************************************************************************/
+
+/**
+ * Return a path where "/./" or "/../" sequences are removed.
+ *
+ * No filesystem access is done.
+ *
+ * @param svPath Input path
+ * @param sep1 Path separator (typically slash or backslash)
+ * @param sep2 Secondary path separator (typically slash or backslash), or NUL
+ * @return compacted path
+ *
+ * @since GDAL 3.13
+ */
+std::string CPLLexicallyNormalize(std::string_view svPath, char sep1, char sep2)
+{
+    struct Token
+    {
+        size_t iStart = 0;  // index of start of token with svPath
+        size_t nLen = 0;    // length of token (excluding ending separator)
+        char chSep = 0;     // separator at end of token, or 0 if there is none
+    };
+
+    std::vector<Token> tokens;
+
+    const auto CompactTokens = [&tokens, &svPath]()
+    {
+        Token &t = tokens.back();
+        if (t.nLen == 1 && svPath[t.iStart] == '.')
+        {
+            tokens.pop_back();
+        }
+        else if (t.nLen == 2 && svPath[t.iStart] == '.' &&
+                 svPath[t.iStart + 1] == '.')
+        {
+            if (tokens.size() >= 2)
+                tokens.resize(tokens.size() - 2);
+        }
+    };
+
+    bool lastCharIsSep = false;
+    for (size_t i = 0; i < svPath.size(); ++i)
+    {
+        const char c = svPath[i];
+        if (c == sep1 || c == sep2)
+        {
+            if (!lastCharIsSep)
+            {
+                if (tokens.empty())
+                {
+                    Token t;
+                    t.chSep = c;
+                    tokens.push_back(t);
+                }
+                else
+                {
+                    Token &t = tokens.back();
+                    t.chSep = c;
+                    CompactTokens();
+                }
+                lastCharIsSep = true;
+            }
+        }
+        else
+        {
+            if (tokens.empty() || lastCharIsSep)
+            {
+                Token t;
+                t.iStart = i;
+                t.nLen = 1;
+                tokens.push_back(t);
+            }
+            else
+            {
+                Token &t = tokens.back();
+                ++t.nLen;
+            }
+            lastCharIsSep = false;
+        }
+    }
+    if (!tokens.empty())
+    {
+        CompactTokens();
+    }
+
+    std::string s;
+    s.reserve(svPath.size());
+    for (const auto &t : tokens)
+    {
+        if (t.nLen)
+            s.append(svPath.substr(t.iStart, t.nLen));
+        if (t.chSep)
+            s.push_back(t.chSep);
+    }
+    return s;
+}

--- a/port/cpl_vsil_s3.cpp
+++ b/port/cpl_vsil_s3.cpp
@@ -1890,38 +1890,15 @@ VSIS3FSHandler::CreateWriteHandle(const char *pszFilename,
 /*                        NormalizeFilenameIfNeeded()                   */
 /************************************************************************/
 
-static void NormalizeFilenameIfNeeded(CPLString &osFilename,
-                                      const char *&pszFilename)
+static void NormalizeFilenameIfNeeded(CPLString &osFilename)
 {
     // Transform '/vsis3/./foo' to '/vsis3/foo' by default
     //
     // Cf https://curl.se/libcurl/c/CURLOPT_PATH_AS_IS.html
-    if (!CPLTestBool(VSIGetPathSpecificOption(pszFilename,
+    if (!CPLTestBool(VSIGetPathSpecificOption(osFilename,
                                               "GDAL_HTTP_PATH_VERBATIM", "NO")))
     {
-        osFilename.replaceAll("/./", '/');
-
-        // Remove "/.." or /../" sequences..
-        while (true)
-        {
-            const auto nSlashDotDotSlashPos = osFilename.find("/../");
-            if (nSlashDotDotSlashPos != std::string::npos &&
-                nSlashDotDotSlashPos > 0)
-            {
-                const auto nLastSlashPos =
-                    osFilename.rfind('/', nSlashDotDotSlashPos - 1);
-                if (nLastSlashPos != std::string::npos)
-                {
-                    osFilename = osFilename.substr(0, nLastSlashPos + 1) +
-                                 osFilename.substr(nSlashDotDotSlashPos +
-                                                   strlen("/../"));
-                    continue;
-                }
-            }
-            break;
-        }
-
-        pszFilename = osFilename.c_str();
+        osFilename = CPLLexicallyNormalize(osFilename, '/');
     }
 }
 
@@ -1937,11 +1914,11 @@ VSIVirtualHandleUniquePtr VSICurlFilesystemHandlerBaseWritable::Open(
         return nullptr;
 
     CPLString osFilename(pszFilename);
-    NormalizeFilenameIfNeeded(osFilename, pszFilename);
+    NormalizeFilenameIfNeeded(osFilename);
 
     if (strchr(pszAccess, '+'))
     {
-        if (!SupportsRandomWrite(pszFilename, true))
+        if (!SupportsRandomWrite(osFilename, true))
         {
             if (bSetError)
             {
@@ -1956,16 +1933,16 @@ VSIVirtualHandleUniquePtr VSICurlFilesystemHandlerBaseWritable::Open(
         }
 
         const std::string osTmpFilename(
-            CPLGenerateTempFilenameSafe(CPLGetFilename(pszFilename)));
+            CPLGenerateTempFilenameSafe(CPLGetFilename(osFilename)));
         if (strchr(pszAccess, 'r'))
         {
             auto poExistingFile =
-                VSIFilesystemHandler::OpenStatic(pszFilename, "rb");
+                VSIFilesystemHandler::OpenStatic(osFilename, "rb");
             if (!poExistingFile)
             {
                 return nullptr;
             }
-            if (VSICopyFile(pszFilename, osTmpFilename.c_str(),
+            if (VSICopyFile(osFilename, osTmpFilename.c_str(),
                             poExistingFile.get(), static_cast<vsi_l_offset>(-1),
                             nullptr, nullptr, nullptr) != 0)
             {
@@ -1982,7 +1959,7 @@ VSIVirtualHandleUniquePtr VSICurlFilesystemHandlerBaseWritable::Open(
             return nullptr;
         }
 
-        auto poWriteHandle = CreateWriteHandle(pszFilename, papszOptions);
+        auto poWriteHandle = CreateWriteHandle(osFilename, papszOptions);
         if (!poWriteHandle)
         {
             return nullptr;
@@ -1994,20 +1971,20 @@ VSIVirtualHandleUniquePtr VSICurlFilesystemHandlerBaseWritable::Open(
     else if (strchr(pszAccess, 'w') || strchr(pszAccess, 'a'))
     {
         return VSIVirtualHandleUniquePtr(
-            CreateWriteHandle(pszFilename, papszOptions).release());
+            CreateWriteHandle(osFilename, papszOptions).release());
     }
 
-    if (std::string(pszFilename).back() != '/')
+    if (osFilename.back() != '/')
     {
         // If there's directory content for the directory where this file
         // belongs to, use it to detect if the object does not exist
         CachedDirList cachedDirList;
-        const std::string osDirname(CPLGetDirnameSafe(pszFilename));
+        const std::string osDirname(CPLGetDirnameSafe(osFilename));
         if (STARTS_WITH_CI(osDirname.c_str(), GetFSPrefix().c_str()) &&
             GetCachedDirList(osDirname.c_str(), cachedDirList) &&
             cachedDirList.bGotFileList)
         {
-            const std::string osFilenameOnly(CPLGetFilename(pszFilename));
+            const std::string osFilenameOnly(CPLGetFilename(osFilename));
             bool bFound = false;
             for (int i = 0; i < cachedDirList.oFileList.size(); i++)
             {
@@ -2024,7 +2001,7 @@ VSIVirtualHandleUniquePtr VSICurlFilesystemHandlerBaseWritable::Open(
         }
     }
 
-    return VSICurlFilesystemHandlerBase::Open(pszFilename, pszAccess, bSetError,
+    return VSICurlFilesystemHandlerBase::Open(osFilename, pszAccess, bSetError,
                                               papszOptions);
 }
 
@@ -2467,17 +2444,18 @@ char **VSIS3FSHandler::GetFileMetadata(const char *pszFilename,
         return nullptr;
 
     CPLString osFilename(pszFilename);
-    NormalizeFilenameIfNeeded(osFilename, pszFilename);
+    NormalizeFilenameIfNeeded(osFilename);
 
     if (pszDomain == nullptr || !EQUAL(pszDomain, "TAGS"))
     {
         return VSICurlFilesystemHandlerBase::GetFileMetadata(
-            pszFilename, pszDomain, papszOptions);
+            osFilename, pszDomain, papszOptions);
     }
 
     auto poS3HandleHelper =
         std::unique_ptr<VSIS3HandleHelper>(VSIS3HandleHelper::BuildFromURI(
-            pszFilename + GetFSPrefix().size(), GetFSPrefix().c_str(), false));
+            osFilename.c_str() + GetFSPrefix().size(), GetFSPrefix().c_str(),
+            false));
     if (!poS3HandleHelper)
         return nullptr;
 
@@ -2486,7 +2464,7 @@ char **VSIS3FSHandler::GetFileMetadata(const char *pszFilename,
 
     bool bRetry;
 
-    const CPLStringList aosHTTPOptions(CPLHTTPGetOptionsFromEnv(pszFilename));
+    const CPLStringList aosHTTPOptions(CPLHTTPGetOptionsFromEnv(osFilename));
     const CPLHTTPRetryParameters oRetryParameters(aosHTTPOptions);
     CPLHTTPRetryContext oRetryContext(oRetryParameters);
 
@@ -2588,7 +2566,7 @@ bool VSIS3FSHandler::SetFileMetadata(const char *pszFilename,
         return false;
 
     CPLString osFilename(pszFilename);
-    NormalizeFilenameIfNeeded(osFilename, pszFilename);
+    NormalizeFilenameIfNeeded(osFilename);
 
     if (pszDomain == nullptr ||
         !(EQUAL(pszDomain, "HEADERS") || EQUAL(pszDomain, "TAGS")))
@@ -2600,12 +2578,13 @@ bool VSIS3FSHandler::SetFileMetadata(const char *pszFilename,
 
     if (EQUAL(pszDomain, "HEADERS"))
     {
-        return CopyObject(pszFilename, pszFilename, papszMetadata) == 0;
+        return CopyObject(osFilename, osFilename, papszMetadata) == 0;
     }
 
     auto poS3HandleHelper =
         std::unique_ptr<VSIS3HandleHelper>(VSIS3HandleHelper::BuildFromURI(
-            pszFilename + GetFSPrefix().size(), GetFSPrefix().c_str(), false));
+            osFilename.c_str() + GetFSPrefix().size(), GetFSPrefix().c_str(),
+            false));
     if (!poS3HandleHelper)
         return false;
 
@@ -2662,7 +2641,7 @@ bool VSIS3FSHandler::SetFileMetadata(const char *pszFilename,
 
     bool bRetry;
 
-    const CPLStringList aosHTTPOptions(CPLHTTPGetOptionsFromEnv(pszFilename));
+    const CPLStringList aosHTTPOptions(CPLHTTPGetOptionsFromEnv(osFilename));
     const CPLHTTPRetryParameters oRetryParameters(aosHTTPOptions);
     CPLHTTPRetryContext oRetryContext(oRetryParameters);
 
@@ -2774,7 +2753,7 @@ int IVSIS3LikeFSHandler::MkdirInternal(const char *pszDirname, long /*nMode*/,
     NetworkStatisticsAction oContextAction("Mkdir");
 
     CPLString osDirname(pszDirname);
-    NormalizeFilenameIfNeeded(osDirname, pszDirname);
+    NormalizeFilenameIfNeeded(osDirname);
     if (!osDirname.empty() && osDirname.back() != '/')
         osDirname += "/";
 
@@ -2848,7 +2827,7 @@ int IVSIS3LikeFSHandler::Rmdir(const char *pszDirname)
     NetworkStatisticsAction oContextAction("Rmdir");
 
     CPLString osDirname(pszDirname);
-    NormalizeFilenameIfNeeded(osDirname, pszDirname);
+    NormalizeFilenameIfNeeded(osDirname);
     if (!osDirname.empty() && osDirname.back() != '/')
         osDirname += "/";
 
@@ -2907,14 +2886,13 @@ int IVSIS3LikeFSHandler::Stat(const char *pszFilename, VSIStatBufL *pStatBuf,
         return -1;
 
     CPLString osFilename(pszFilename);
-    NormalizeFilenameIfNeeded(osFilename, pszFilename);
+    NormalizeFilenameIfNeeded(osFilename);
 
     if ((nFlags & VSI_STAT_CACHE_ONLY) != 0)
-        return VSICurlFilesystemHandlerBase::Stat(pszFilename, pStatBuf,
-                                                  nFlags);
+        return VSICurlFilesystemHandlerBase::Stat(osFilename, pStatBuf, nFlags);
 
     memset(pStatBuf, 0, sizeof(VSIStatBufL));
-    if (!IsAllowedFilename(pszFilename))
+    if (!IsAllowedFilename(osFilename))
         return -1;
 
     NetworkStatisticsFileSystem oContextFS(GetFSPrefix().c_str());
@@ -3057,9 +3035,9 @@ int IVSIS3LikeFSHandler::Unlink(const char *pszFilename)
         return -1;
 
     CPLString osFilename(pszFilename);
-    NormalizeFilenameIfNeeded(osFilename, pszFilename);
+    NormalizeFilenameIfNeeded(osFilename);
 
-    std::string osNameWithoutPrefix = pszFilename + GetFSPrefix().size();
+    std::string osNameWithoutPrefix = osFilename.c_str() + GetFSPrefix().size();
     if (osNameWithoutPrefix.find('/') == std::string::npos)
     {
         CPLDebug(GetDebugKey(), "%s is not a file", pszFilename);
@@ -3071,7 +3049,7 @@ int IVSIS3LikeFSHandler::Unlink(const char *pszFilename)
     NetworkStatisticsAction oContextAction("Unlink");
 
     VSIStatBufL sStat;
-    if (VSIStatL(pszFilename, &sStat) != 0)
+    if (VSIStatL(osFilename, &sStat) != 0)
     {
         CPLDebug(GetDebugKey(), "%s is not a object", pszFilename);
         errno = ENOENT;
@@ -3084,7 +3062,7 @@ int IVSIS3LikeFSHandler::Unlink(const char *pszFilename)
         return -1;
     }
 
-    return DeleteObject(pszFilename);
+    return DeleteObject(osFilename);
 }
 
 /************************************************************************/
@@ -3101,16 +3079,16 @@ int IVSIS3LikeFSHandler::Rename(const char *oldpath, const char *newpath,
         return -1;
 
     CPLString osOldPath(oldpath);
-    NormalizeFilenameIfNeeded(osOldPath, oldpath);
+    NormalizeFilenameIfNeeded(osOldPath);
 
     CPLString osNewPath(newpath);
-    NormalizeFilenameIfNeeded(osNewPath, newpath);
+    NormalizeFilenameIfNeeded(osNewPath);
 
     NetworkStatisticsFileSystem oContextFS(GetFSPrefix().c_str());
     NetworkStatisticsAction oContextAction("Rename");
 
     VSIStatBufL sStat;
-    if (VSIStatL(oldpath, &sStat) != 0)
+    if (VSIStatL(osOldPath, &sStat) != 0)
     {
         CPLDebug(GetDebugKey(), "%s is not a object", oldpath);
         errno = ENOENT;
@@ -3120,21 +3098,21 @@ int IVSIS3LikeFSHandler::Rename(const char *oldpath, const char *newpath,
     // AWS doesn't like renaming to the same name, and errors out
     // But GCS does like it, and so we might end up killing ourselves !
     // POSIX says renaming on the same file is OK
-    if (strcmp(oldpath, newpath) == 0)
+    if (strcmp(osOldPath, osNewPath) == 0)
         return 0;
 
     if (VSI_ISDIR(sStat.st_mode))
     {
         int ret = 0;
-        const CPLStringList aosList(VSIReadDir(oldpath));
-        Mkdir(newpath, 0755);
+        const CPLStringList aosList(VSIReadDir(osOldPath));
+        Mkdir(osNewPath, 0755);
         const int nListSize = aosList.size();
         for (int i = 0; ret == 0 && i < nListSize; i++)
         {
             const std::string osSrc =
-                CPLFormFilenameSafe(oldpath, aosList[i], nullptr);
+                CPLFormFilenameSafe(osOldPath, aosList[i], nullptr);
             const std::string osTarget =
-                CPLFormFilenameSafe(newpath, aosList[i], nullptr);
+                CPLFormFilenameSafe(osNewPath, aosList[i], nullptr);
             void *pScaledProgress =
                 GDALCreateScaledProgress(static_cast<double>(i) / nListSize,
                                          static_cast<double>(i + 1) / nListSize,
@@ -3145,23 +3123,23 @@ int IVSIS3LikeFSHandler::Rename(const char *oldpath, const char *newpath,
             GDALDestroyScaledProgress(pScaledProgress);
         }
         if (ret == 0)
-            Rmdir(oldpath);
+            Rmdir(osOldPath);
         return ret;
     }
     else
     {
-        if (VSIStatL(newpath, &sStat) == 0 && VSI_ISDIR(sStat.st_mode))
+        if (VSIStatL(osNewPath, &sStat) == 0 && VSI_ISDIR(sStat.st_mode))
         {
             CPLDebug(GetDebugKey(), "%s already exists and is a directory",
                      newpath);
             errno = ENOTEMPTY;
             return -1;
         }
-        if (CopyObject(oldpath, newpath, nullptr) != 0)
+        if (CopyObject(osOldPath, osNewPath, nullptr) != 0)
         {
             return -1;
         }
-        return DeleteObject(oldpath);
+        return DeleteObject(osOldPath);
     }
 }
 
@@ -3471,12 +3449,12 @@ VSIDIR *IVSIS3LikeFSHandler::OpenDir(const char *pszPath, int nRecurseDepth,
         return nullptr;
 
     CPLString osPath(pszPath);
-    NormalizeFilenameIfNeeded(osPath, pszPath);
+    NormalizeFilenameIfNeeded(osPath);
 
     NetworkStatisticsFileSystem oContextFS(GetFSPrefix().c_str());
     NetworkStatisticsAction oContextAction("OpenDir");
 
-    std::string osDirnameWithoutPrefix = pszPath + GetFSPrefix().size();
+    std::string osDirnameWithoutPrefix = osPath.c_str() + GetFSPrefix().size();
     if (!osDirnameWithoutPrefix.empty() && osDirnameWithoutPrefix.back() == '/')
     {
         osDirnameWithoutPrefix.pop_back();
@@ -3498,7 +3476,7 @@ VSIDIR *IVSIS3LikeFSHandler::OpenDir(const char *pszPath, int nRecurseDepth,
         return nullptr;
     }
 
-    VSIDIRS3 *dir = new VSIDIRS3(pszPath, this);
+    VSIDIRS3 *dir = new VSIDIRS3(osPath, this);
     dir->nRecurseDepth = nRecurseDepth;
     dir->poHandleHelper = std::move(poS3HandleHelper);
     dir->osBucket = std::move(osBucket);


### PR DESCRIPTION
Backport #14131
 **Authored by:** @rouault