### PR TITLE
Doc: bring back Erdas Imagine (.ige) format description

### DIFF
--- a/doc/source/drivers/raster/hfa.rst
+++ b/doc/source/drivers/raster/hfa.rst
@@ -199,3 +199,13 @@ See Also
    Reader <http://web.archive.org/web/20130730133056/http://home.gdal.org/projects/imagine/hfa_index.html>`__
    page as saved by archive.org.
 -  `Erdas.com <http://www.erdas.com/>`__
+
+Erdas Imagine (.ige) format
+----------------------------
+
+The Erdas Imagine .ige format is related to the HFA (Hierarchical File
+Architecture) format used by Erdas Imagine software.
+
+More details about the historical format specification can be found at:
+
+https://web.archive.org/web/20110205035551/http://home.gdal.org/projects/imagine/ige_format.html


### PR DESCRIPTION
Restore documentation about the Erdas Imagine (.ige) format in the HFA driver docs.

The original documentation page is no longer available on the GDAL website,
so an archived version from the Internet Archive is referenced.