### PR TITLE
Doc: add CLI example for gdal_translate

### DIFF
--- a/doc/source/programs/gdal_translate.rst
+++ b/doc/source/programs/gdal_translate.rst
@@ -499,3 +499,10 @@ Examples
        $ gdal_translate -strict test.tif test.webp
        ERROR 6: WEBP driver doesn't support data type Int16.
        Only UInt8 bands supported.
+
+.. example::
+   :title: Convert a raster to GeoTIFF format
+
+   .. code-block:: console
+
+      gdal_translate -of GTiff input.vrt output.tif


### PR DESCRIPTION
Adds an additional CLI usage example for the gdal_translate command
to improve the documentation.

Related to #12098