### PR TITLE
Doc: add CLI example for ogr2ogr shapefile to GeoJSON conversion

### DIFF
--- a/doc/source/programs/ogr2ogr.rst
+++ b/doc/source/programs/ogr2ogr.rst
@@ -746,6 +746,15 @@ Examples
       ogr2ogr -where "\"POP_EST\" < 1000000" \
         output.gpkg natural_earth_vector.gpkg ne_10m_admin_0_countries
 
+.. example::
+   :title: Convert a Shapefile to GeoJSON
+
+   .. code-block:: console
+
+      ogr2ogr -f GeoJSON output.json input.shp
+
+This command converts the input Shapefile dataset into GeoJSON format.
+
 
 More examples are given in the individual format pages.
 


### PR DESCRIPTION
Adds a CLI example demonstrating how to convert a Shapefile dataset
to GeoJSON format using ogr2ogr.

Related to #12098