### PR TITLE
docs: remove htmlzip format to avoid single-page zipped HTML documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -30,7 +30,6 @@ build:
     - unzip
 
 formats:
-  - htmlzip
   - pdf
 
 python:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -129,7 +129,9 @@ if doc_version_known:
 else:
     offline_download_text = "Documentation for the latest version of GDAL is "
     url_root = "https://gdal.org"
-offline_download_text += f"available as a `PDF <{url_root}{pdf_url}>`__ or a `ZIP of individual HTML pages <{url_root}{zip_url}>`__ for offline browsing."
+offline_download_text += (
+    f"available as a `PDF <{url_root}{pdf_url}>`__ for offline browsing."
+)
 rst_prolog += f"""
 .. |offline-download| replace:: {offline_download_text}
 """


### PR DESCRIPTION
Refs #12123

The zipped HTML documentation generated by ReadTheDocs produced a
single-page HTML version of the documentation.

This change removes the htmlzip format from the ReadTheDocs
configuration so that only the PDF download format is provided.