### PR TITLE
gdalwarp: change INIT_DEST=NO_DATA warning to failure

### DIFF
--- a/alg/gdalwarpoperation.cpp
+++ b/alg/gdalwarpoperation.cpp
@@ -846,7 +846,8 @@ CPLErr GDALWarpOperation::InitializeDestinationBuffer(void *pDstBuffer,
             if (psOptions->padfDstNoDataReal == nullptr)
             {
                 CPLError(CE_Failure, CPLE_AppDefined,
-                         "INIT_DEST was set to NO_DATA, but a NoData value was not defined.");                        
+                         "INIT_DEST was set to NO_DATA, but a NoData value was "
+                         "not defined.");
             }
             else
             {

--- a/autotest/utilities/test_gdalwarp_lib.py
+++ b/autotest/utilities/test_gdalwarp_lib.py
@@ -4553,9 +4553,7 @@ def test_gdalwarp_lib_init_dest_invalid(tmp_vsimem, init_dest):
 
 def test_gdalwarp_lib_init_dest_nodata_invalid(tmp_vsimem):
 
-    # TODO: switch from warning to failure in GDAL 3.12
-    # with pytest.raises(Exception, match="NoData value was not defined"):
-    with gdaltest.error_raised(gdal.CE_Warning, "NoData value was not defined"):
+    with gdaltest.error_raised(gdal.CE_Failure, "NoData value was not defined"):
         gdal.Warp(
             tmp_vsimem / "out.tif",
             "../gcore/data/byte.tif",


### PR DESCRIPTION
Fixes #12210

Promote the warning emitted when `INIT_DEST=NO_DATA` is used without a destination nodata value to a failure, so the warp operation aborts when the configuration is invalid.
