### PR TITLE
ogr: add two pci datums to ogr_srs_pci.cpp

### DIFF
--- a/ogr/ogr_srs_pci.cpp
+++ b/ogr/ogr_srs_pci.cpp
@@ -43,6 +43,7 @@ static const PCIDatums asDatums[] = {
     {"D-03", 4267},  // NAD27 (Canada, NTv1)
     {"D-02", 4269},  // NAD83 (USA, NADCON)
     {"D-04", 4269},  // NAD83 (Canada, NTv1)
+    {"D-25", 7844},  // GDA2020 (Australia)
     {"D000", 4326},  // WGS 1984
     {"D001", 4322},  // WGS 1972
     {"D008", 4296},  // Sudan
@@ -85,6 +86,7 @@ static const PCIDatums asDatums[] = {
     {"D188", 4311},  // Zanderij (Suriname)
     {"D401", 4124},  // RT90 (Sweden)
     {"D501", 4312},  // MGI (Hermannskogel, Austria)
+    {"D536", 4283},  // GDA94 (Australia)
     {nullptr, 0}};
 
 static const PCIDatums asEllips[] = {


### PR DESCRIPTION
I am an employee of pci geomatics, We have a customer having issues due to these missing datums.

<!--
IMPORTANT: Do NOT use GitHub to post any questions or support requests!
           They will be closed immediately and ignored.

Make sure that the title of your commit(s) is descriptive. Typically, they
should be formatted as "component/filename: Describe what the commit does (fixes #ticket)",
so that anyone that parses 'git log' immediately knows what a commit is about.
Do not hesitate to provide more context in the longer part of the commit message.

For example:

"GTiff: fix wrong color interpretation with -co ALPHA=YES (fixes #1234)

When -co ALPHA=YES was used, but PHOTOMETRIC was not specified, the ExtraSample
tag was wrongly set to unspecified.
"

The GDAL project requires specific code formatting for C/C++ and Python code.
This is largely automated with the pre-commit tool.
Consult how to [install and set it up](https://gdal.org/development/dev_practices.html#commit-hooks)

More generally, consult [development practices](https://gdal.org/development/dev_practices.html)
-->

## What does this PR do?

This PR adds 2 datums to ogr_srs_pci.cpp
