### PR TITLE
gdal raster pixel-info: make it possible to use --position in pipeline mode too (master only)

### DIFF
--- a/apps/gdalalg_raster_pixel_info.cpp
+++ b/apps/gdalalg_raster_pixel_info.cpp
@@ -71,7 +71,7 @@ GDALRasterPixelInfoAlgorithm::GDALRasterPixelInfoAlgorithm(bool standaloneStep)
                    GDAL_OF_VECTOR)
                 .SetMutualExclusionGroup("position-dataset-pos");
         if (!standaloneStep)
-            coordinateDatasetArg.SetPositional().SetRequired();
+            coordinateDatasetArg.SetPositional();
 
         SetAutoCompleteFunctionForFilename(coordinateDatasetArg,
                                            GDAL_OF_VECTOR);
@@ -99,12 +99,10 @@ GDALRasterPixelInfoAlgorithm::GDALRasterPixelInfoAlgorithm(bool standaloneStep)
            &m_overview)
         .SetMinValueIncluded(0);
 
-    if (standaloneStep)
-    {
+    auto &positionArg =
         AddArg("position", 'p', _("Pixel position"), &m_pos)
             .AddAlias("pos")
             .SetMetaVar("<column,line> or <X,Y>")
-            .SetPositional()
             .SetMutualExclusionGroup("position-dataset-pos")
             .AddValidationAction(
                 [this]
@@ -119,7 +117,8 @@ GDALRasterPixelInfoAlgorithm::GDALRasterPixelInfoAlgorithm(bool standaloneStep)
                     }
                     return true;
                 });
-    }
+    if (standaloneStep)
+        positionArg.SetPositional();
 
     AddArg("position-crs", 0,
            _("CRS of position (default is 'pixel' if 'position-dataset' not "

--- a/autotest/utilities/test_gdalalg_raster_pixel_info.py
+++ b/autotest/utilities/test_gdalalg_raster_pixel_info.py
@@ -924,6 +924,13 @@ def test_gdalalg_raster_pixel_info_in_pipeline(tmp_vsimem):
         assert out_lyr.GetFeatureCount() == 1
 
     with gdal.alg.pipeline(
+        pipeline="read ../gcore/data/byte.tif ! pixel-info --position 1,2"
+    ) as alg:
+        out_ds = alg.Output()
+        out_lyr = out_ds.GetLayer(0)
+        assert out_lyr.GetFeatureCount() == 1
+
+    with gdal.alg.pipeline(
         pipeline=f"read ../gcore/data/byte.tif ! pixel-info --input _PIPE_ --position-dataset {tmp_vsimem}/coords.shp"
     ) as alg:
         out_ds = alg.Output()
@@ -939,7 +946,7 @@ def test_gdalalg_raster_pixel_info_in_pipeline(tmp_vsimem):
 
     with pytest.raises(
         Exception,
-        match="Positional arguments starting at 'POSITION-DATASET' have not been specified",
+        match="Argument 'position' or 'position-dataset' must be specified",
     ):
         gdal.alg.pipeline(pipeline="read ../gcore/data/byte.tif ! pixel-info")
 


### PR DESCRIPTION
Fixes #14179
