### PR TITLE
JP2OpenJPEG writer: fix duplicate type/association pairs in CDEF box for 3 grey band+alpha JP2 files

### DIFF
--- a/autotest/gdrivers/jp2openjpeg.py
+++ b/autotest/gdrivers/jp2openjpeg.py
@@ -3941,3 +3941,31 @@ def test_jp2openjpeg_write_check_golden_file(tmp_path, src_filename, creation_op
         )
     assert os.stat(src_filename).st_size == os.stat(out_filename).st_size
     assert open(src_filename, "rb").read() == open(out_filename, "rb").read()
+
+
+###############################################################################
+
+
+def test_jp2openjpeg_write_grey_undefined_undefined_alpha(tmp_path):
+
+    drv = gdal.GetDriverByName("JP2OpenJPEG")
+    src = gdal.GetDriverByName("MEM").Create("", 1, 1, 4)
+    drv.CreateCopy(tmp_path / "out.jp2", src, options=["ALPHA=YES"])
+
+    ret = gdal.GetJPEG2000StructureAsString(str(tmp_path / "out.jp2"), ["ALL=YES"])
+    assert (
+        """<Field name="N" type="uint16">4</Field>
+        <Field name="Cn0" type="uint16">0</Field>
+        <Field name="Typ0" type="uint16" description="Colour channel">0</Field>
+        <Field name="Asoc0" type="uint16" description="Associated with a particular colour">1</Field>
+        <Field name="Cn1" type="uint16">1</Field>
+        <Field name="Typ1" type="uint16" description="Not specified">65535</Field>
+        <Field name="Asoc1" type="uint16" description="Not associated with a particular colour">65535</Field>
+        <Field name="Cn2" type="uint16">2</Field>
+        <Field name="Typ2" type="uint16" description="Not specified">65535</Field>
+        <Field name="Asoc2" type="uint16" description="Not associated with a particular colour">65535</Field>
+        <Field name="Cn3" type="uint16">3</Field>
+        <Field name="Typ3" type="uint16" description="Opacity channel">1</Field>
+        <Field name="Asoc3" type="uint16" description="Associated to the whole image">0</Field>"""
+        in ret
+    )

--- a/frmts/opjlike/jp2opjlikedataset.cpp
+++ b/frmts/opjlike/jp2opjlikedataset.cpp
@@ -2979,50 +2979,48 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
             cdefBox.AppendUInt16(static_cast<GUInt16>(nComponents));
             for (int i = 0; i < nComponents; i++)
             {
-                cdefBox.AppendUInt16(
-                    static_cast<GUInt16>(i)); /* Component number */
+                uint16_t nTyp = 65535;   // Unspecified
+                uint16_t nAsoc = 65535;  // Unassociated
                 if (i != nAlphaBandIndex)
                 {
-                    cdefBox.AppendUInt16(
-                        0); /* Signification: This channel is the colour image
-                               data for the associated colour */
                     if (eColorSpace == CODEC::cvtenum(JP2_CLRSPC_GRAY) &&
-                        nComponents == 2)
-                        cdefBox.AppendUInt16(
-                            1); /* Colour of the component: associated with a
-                                   particular colour */
+                        i == 0)
+                    {
+                        nTyp =
+                            0;  // colour image data for the associated colour
+                        nAsoc = 1;  // associated with a particular colour
+                    }
                     else if ((eColorSpace == CODEC::cvtenum(JP2_CLRSPC_SRGB) ||
                               eColorSpace == CODEC::cvtenum(JP2_CLRSPC_SYCC)) &&
                              (nComponents == 3 || nComponents == 4))
                     {
+                        nTyp =
+                            0;  // colour image data for the associated colour
                         if (i == nRedBandIndex)
-                            cdefBox.AppendUInt16(1);
+                            nAsoc = 1;
                         else if (i == nGreenBandIndex)
-                            cdefBox.AppendUInt16(2);
+                            nAsoc = 2;
                         else if (i == nBlueBandIndex)
-                            cdefBox.AppendUInt16(3);
+                            nAsoc = 3;
                         else
                         {
                             CPLError(CE_Warning, CPLE_AppDefined,
                                      "Could not associate band %d with a "
                                      "red/green/blue channel",
                                      i + 1);
-                            cdefBox.AppendUInt16(65535);
                         }
                     }
-                    else
-                        cdefBox.AppendUInt16(
-                            65535); /* Colour of the component: not associated
-                                       with any particular colour */
                 }
                 else
                 {
-                    cdefBox.AppendUInt16(
-                        1); /* Signification: Non pre-multiplied alpha */
-                    cdefBox.AppendUInt16(
-                        0); /* Colour of the component: This channel is
-                               associated as the image as a whole */
+                    nTyp = 1;   // Non pre-multiplied alpha
+                    nAsoc = 0;  // Associated to the image as a whole
                 }
+
+                // Component number
+                cdefBox.AppendUInt16(static_cast<GUInt16>(i));
+                cdefBox.AppendUInt16(nTyp);
+                cdefBox.AppendUInt16(nAsoc);
             }
         }
 


### PR DESCRIPTION
Fixes #14185
