### PR TITLE
Remove previous Conda builds with the same version number

### DIFF
--- a/ci/travis/conda/upload.sh
+++ b/ci/travis/conda/upload.sh
@@ -12,9 +12,9 @@ ls
 pwd
 find .
 
-if [[ -n $(find . -name "*gdal*.conda") ]]; then
-  echo "Found packages to upload"
-else
+files=$(find . -name "*gdal*.conda")
+
+if [ -z "$files" ]; then
   echo "No packages matching *gdal*.conda to upload found"
   exit 1
 fi
@@ -22,5 +22,18 @@ fi
 echo "Anaconda token is available, attempting to upload"
 conda install -c conda-forge python=3.12 anaconda-client -y
 
-find . -name "*gdal*.conda" -exec anaconda -t "$ANACONDA_TOKEN" upload --force --no-progress --user gdal-master  {} \;
+for f in $files; do
+  filename=$(basename "$f")
 
+  # extract package name
+  pkg=$(echo "$filename" | sed -E 's/-[0-9].*//')
+
+  # extract version number (e.g. 3.12.99)
+  version=$(echo "$filename" | sed -E 's/^.+-([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
+
+  echo "Removing gdal-master/$pkg/$version"
+  anaconda -t "$ANACONDA_TOKEN" remove -f "gdal-master/$pkg/$version" || true
+
+  echo "Uploading $filename"
+  anaconda -t "$ANACONDA_TOKEN" upload --force --no-progress --user gdal-master "$f"
+done


### PR DESCRIPTION
## What does this PR do?

Removes gdal-master Conda packages of the same version, when uploading a new one. 

## What are related issues/pull requests?

#14190


I have tested the sed parsing locally on a folder of various Conda packages. However without setting up a full Conda repository I'm unable to test fully.

```bash
for f in $files; do
  filename=$(basename "$f")

  # extract package name
  pkg=$(echo "$filename" | sed -E 's/-[0-9].*//')

  # extract version number (e.g. 3.12.99)
  version=$(echo "$filename" | sed -E 's/^.+-([0-9]+\.[0-9]+\.[0-9]+).*/\1/')

  echo "Removing gdal-master/$pkg/$version"


  echo "Uploading $filename"

done

Removing gdal-master/gdal/3.11.99
Uploading gdal-3.11.99-py314h589ebb0_2112.conda
Removing gdal-master/gdal/3.12.99
Uploading gdal-3.12.99-py314h589ebb0_2112.conda
Removing gdal-master/libgdal/3.12.99
Uploading libgdal-3.12.99-py314h589ebb0_2112.conda
```