### PR TITLE
CI: Only remove gdal-master Conda builds for the same platform

### DIFF
--- a/ci/travis/conda/compile.sh
+++ b/ci/travis/conda/compile.sh
@@ -25,6 +25,8 @@ elif grep -q "macos-15-intel" <<< "$GHA_CI_PLATFORM"; then
     ARCH="64"
 fi
 
+echo "CONDA_SUBDIR=\"${CONDA_PLAT}-${ARCH}\"" >> $GITHUB_ENV
+
 conda build recipe --clobber-file recipe/recipe_clobber.yaml --output-folder packages -m ".ci_support/${CONDA_PLAT}_${ARCH}_.yaml"
 conda create -y -n test -c ./packages/${CONDA_PLAT}-${ARCH} python libgdal gdal
 conda deactivate

--- a/ci/travis/conda/upload.sh
+++ b/ci/travis/conda/upload.sh
@@ -8,6 +8,11 @@ then
     exit 1
 fi
 
+if [ -z "${CONDA_SUBDIR+x}" ]; then
+    echo "CONDA_SUBDIR is not set!"
+    exit 1
+fi
+
 ls
 pwd
 find .
@@ -31,8 +36,8 @@ for f in $files; do
   # extract version number (e.g. 3.12.99)
   version=$(echo "$filename" | sed -E 's/^.+-([0-9]+\.[0-9]+\.[0-9]+).*/\1/')
 
-  echo "Removing gdal-master/$pkg/$version"
-  anaconda -t "$ANACONDA_TOKEN" remove -f "gdal-master/$pkg/$version" || true
+  echo "Removing gdal-master/$pkg/$version/$CONDA_SUBDIR"
+  anaconda -t "$ANACONDA_TOKEN" remove -f "gdal-master/$pkg/$version/$CONDA_SUBDIR" || true
 
   echo "Uploading $filename"
   anaconda -t "$ANACONDA_TOKEN" upload --force --no-progress --user gdal-master "$f"


### PR DESCRIPTION
Follow-up to #14191.

Sorry @rouault - the first PR removes the Conda packages of the same version for *all* platforms. See https://anaconda.org/channels/gdal-master/packages/gdal/files?file_q=3.12.99 - only the osx-arm64 package remains. 

This PR takes the logic about the platform and saves it as an environment variable, and then uses it later to only delete files of the same platform. 