### PR TITLE
CI: Fix quotes for Conda gdal-master

### DIFF
--- a/ci/travis/conda/compile.sh
+++ b/ci/travis/conda/compile.sh
@@ -25,7 +25,7 @@ elif grep -q "macos-15-intel" <<< "$GHA_CI_PLATFORM"; then
     ARCH="64"
 fi
 
-echo "CONDA_SUBDIR=\"${CONDA_PLAT}-${ARCH}\"" >> $GITHUB_ENV
+echo "CONDA_SUBDIR=${CONDA_PLAT}-${ARCH}" >> $GITHUB_ENV
 
 conda build recipe --clobber-file recipe/recipe_clobber.yaml --output-folder packages -m ".ci_support/${CONDA_PLAT}_${ARCH}_.yaml"
 conda create -y -n test -c ./packages/${CONDA_PLAT}-${ARCH} python libgdal gdal


### PR DESCRIPTION
Fixes error at https://github.com/OSGeo/gdal/actions/runs/23356860911/job/67952410726#step:10:189
`CondaValueError: Invalid platform '"win-64"'. `

Relates to #14190