### PR TITLE
SQLite/GPKG: more user-friendly error message

### DIFF
--- a/autotest/ogr/ogr_sqlite.py
+++ b/autotest/ogr/ogr_sqlite.py
@@ -1203,14 +1203,14 @@ def test_ogr_sqlite_24(tmp_path):
 
 
 def get_sqlite_version():
-    ds = ogr.Open(":memory:")
-    sql_lyr = ds.ExecuteSQL("SELECT sqlite_version()")
-    feat = sql_lyr.GetNextFeature()
-    sqlite_version = feat.GetFieldAsString(0)
-    print("SQLite version : %s" % sqlite_version)
-    feat = None
-    ds.ReleaseResultSet(sql_lyr)
-    return sqlite_version
+    with gdaltest.disable_exceptions():
+        ds = ogr.Open(":memory:")
+    if ds is None:
+        return (0, 0, 0)
+    with ds.ExecuteSQL("SELECT sqlite_version()") as sql_lyr:
+        f = sql_lyr.GetNextFeature()
+        version = f.GetField(0)
+    return tuple([int(x) for x in version.split(".")[0:3]])
 
 
 ###############################################################################
@@ -3107,14 +3107,6 @@ def test_ogr_sqlite_42(sqlite_test_db):
 
 def test_ogr_sqlite_43():
 
-    # Only available since sqlite 3.8.0
-    version = get_sqlite_version().split(".")
-    if not (
-        len(version) >= 3
-        and int(version[0]) * 10000 + int(version[1]) * 100 + int(version[2]) >= 30800
-    ):
-        pytest.skip()
-
     ds = ogr.Open("file:foo?mode=memory&cache=shared")
     assert ds is not None
 
@@ -3172,14 +3164,6 @@ def test_ogr_sqlite_44(tmp_vsimem):
 
 
 def test_ogr_sqlite_45(tmp_path):
-
-    # Only available since sqlite 3.7.0
-    version = get_sqlite_version().split(".")
-    if not (
-        len(version) >= 3
-        and int(version[0]) * 10000 + int(version[1]) * 100 + int(version[2]) >= 30700
-    ):
-        pytest.skip()
 
     ds = ogr.GetDriverByName("SQLite").CreateDataSource(tmp_path / "ogr_sqlite_45.db")
     sql_lyr = ds.ExecuteSQL("PRAGMA journal_mode = WAL")
@@ -4791,3 +4775,28 @@ def test_ogr_sqlite_detect_multiple_statements(sql, error_expected):
     else:
         with ds.ExecuteSQL(sql):
             pass
+
+
+###############################################################################
+
+
+def test_ogr_sqlite_error_msg():
+
+    ds = ogr.Open(":memory:")
+
+    version_3_38_or_later = get_sqlite_version() >= (3, 38, 0)
+    with gdal.quiet_errors():
+        ds.ExecuteSQL("SELECT (1 FROM x)")
+    if version_3_38_or_later:
+        assert (
+            gdal.GetLastErrorMsg()
+            == """In ExecuteSQL(): sqlite3_prepare_v2(): near "FROM": syntax error
+  SELECT (1 FROM x)
+            ^--- error here"""
+        )
+    else:
+        assert (
+            gdal.GetLastErrorMsg()
+            == """In ExecuteSQL(): sqlite3_prepare_v2(): near "FROM": syntax error
+  SELECT (1 FROM x)"""
+        )

--- a/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
+++ b/ogr/ogrsf_frmts/gpkg/ogrgeopackagedatasource.cpp
@@ -7674,9 +7674,11 @@ OGRLayer *GDALGeoPackageDataset::ExecuteSQL(const char *pszSQLCommand,
     {
         if (nErrorCount == CPLGetErrorCounter())
         {
-            CPLError(CE_Failure, CPLE_AppDefined,
-                     "In ExecuteSQL(): sqlite3_prepare_v2(%s): %s",
-                     osSQLCommandTruncated.c_str(), sqlite3_errmsg(hDB));
+            CPLError(CE_Failure, CPLE_AppDefined, "%s",
+                     SQLFormatErrorMsgFailedPrepare(
+                         GetDB(), "In ExecuteSQL(): sqlite3_prepare_v2(): ",
+                         osSQLCommand.c_str())
+                         .c_str());
         }
         return nullptr;
     }

--- a/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqlitedatasource.cpp
@@ -882,9 +882,11 @@ sqlite3_stmt *OGRSQLiteBaseDataSource::prepareSql(sqlite3 *db, const char *zSql,
     const int rc = sqlite3_prepare_v2(db, zSql, nByte, &stmt, &pszTail);
     if (rc != SQLITE_OK && pfnQueryLoggerFunc)
     {
-        std::string error{"Error preparing query: "};
-        error.append(sqlite3_errmsg(db));
-        pfnQueryLoggerFunc(zSql, error.c_str(), -1, -1, poQueryLoggerArg);
+        pfnQueryLoggerFunc(
+            zSql,
+            SQLFormatErrorMsgFailedPrepare(db, "Error preparing query: ", zSql)
+                .c_str(),
+            -1, -1, poQueryLoggerArg);
     }
     else if (strchr(zSql, ';') && pszTail && SQLHasRemainingContent(pszTail))
     {
@@ -3338,9 +3340,11 @@ OGRLayer *OGRSQLiteDataSource::ExecuteSQL(const char *pszSQLCommand,
     {
         if (nErrorCount == CPLGetErrorCounter())
         {
-            CPLError(CE_Failure, CPLE_AppDefined,
-                     "In ExecuteSQL(): sqlite3_prepare_v2(%s):\n  %s",
-                     osSQLCommand.c_str(), sqlite3_errmsg(GetDB()));
+            CPLError(CE_Failure, CPLE_AppDefined, "%s",
+                     SQLFormatErrorMsgFailedPrepare(
+                         GetDB(), "In ExecuteSQL(): sqlite3_prepare_v2(): ",
+                         osSQLCommand.c_str())
+                         .c_str());
         }
         return nullptr;
     }

--- a/ogr/ogrsf_frmts/sqlite/ogrsqliteexecutesql.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqliteexecutesql.cpp
@@ -1100,10 +1100,11 @@ OGRLayer *OGRSQLiteExecuteSQL(GDALDataset *poDS, const char *pszStatement,
 
     if (rc != SQLITE_OK)
     {
-        CPLError(CE_Failure, CPLE_AppDefined,
-                 "In ExecuteSQL(): sqlite3_prepare_v2(%s):\n  %s", pszStatement,
-                 sqlite3_errmsg(hDB));
-
+        CPLError(
+            CE_Failure, CPLE_AppDefined, "%s",
+            SQLFormatErrorMsgFailedPrepare(
+                hDB, "In ExecuteSQL(): sqlite3_prepare_v2(): ", pszStatement)
+                .c_str());
         if (hSQLStmt != nullptr)
         {
             sqlite3_finalize(hSQLStmt);

--- a/ogr/ogrsf_frmts/sqlite/ogrsqliteutility.cpp
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqliteutility.cpp
@@ -1104,6 +1104,30 @@ bool SQLHasRemainingContent(const char *pszTail)
 }
 
 /************************************************************************/
+/*                   SQLFormatErrorMsgFailedPrepare()                   */
+/************************************************************************/
+
+std::string SQLFormatErrorMsgFailedPrepare(sqlite3 *hDB,
+                                           const char *pszErrMsgIntro,
+                                           const char *pszSQL)
+{
+    std::string osErrorMsg(pszErrMsgIntro);
+    osErrorMsg += sqlite3_errmsg(hDB);
+    osErrorMsg += "\n  ";
+    osErrorMsg += pszSQL;
+#if SQLITE_VERSION_NUMBER >= 3038000L
+    const int nOffset = sqlite3_error_offset(hDB);
+    if (nOffset >= 0 && static_cast<size_t>(nOffset) <= strlen(pszSQL))
+    {
+        osErrorMsg += "\n  ";
+        osErrorMsg.append(nOffset, ' ');
+        osErrorMsg += "^--- error here";
+    }
+#endif
+    return osErrorMsg;
+}
+
+/************************************************************************/
 /*                       SQLGetSQLite3DataType()                        */
 /************************************************************************/
 

--- a/ogr/ogrsf_frmts/sqlite/ogrsqliteutility.h
+++ b/ogr/ogrsf_frmts/sqlite/ogrsqliteutility.h
@@ -108,4 +108,8 @@ bool SQLCheckLineIsSafe(const char *pszLine);
 
 bool SQLHasRemainingContent(const char *pszTail);
 
+std::string SQLFormatErrorMsgFailedPrepare(sqlite3 *hDB,
+                                           const char *pszErrMsgIntro,
+                                           const char *pszSQL);
+
 #endif  // OGR_SQLITEUTILITY_H_INCLUDED


### PR DESCRIPTION
Fixes #14203

```
$ ogrinfo :memory: -sql "SELECT (1 FROM x)"
INFO: Open of `:memory:'
      using driver `SQLite' successful.
ERROR 1: In ExecuteSQL(): sqlite3_prepare_v2(): near "FROM": syntax error
  SELECT (1 FROM x)
            ^--- error here
```
