### PR TITLE
[Backport release/3.12] MiraMonVector: CreateLayer(): launder layer name for filename compatibility

### DIFF
--- a/autotest/ogr/ogr_miramon_vector.py
+++ b/autotest/ogr/ogr_miramon_vector.py
@@ -1551,3 +1551,18 @@ def test_ogr_miramon_check_layer_name_with_accents(tmp_vsimem):
 
     ds = None
     lyr = None
+
+
+###############################################################################
+
+
+def test_ogr_miramon_write_launder_layer_name(tmp_path):
+
+    ds = ogr.GetDriverByName("MiramonVector").CreateVector(tmp_path)
+    srs = osr.SpatialReference()
+    srs.ImportFromEPSG(32631)
+    with gdaltest.error_raised(
+        gdal.CE_Warning,
+        match="Layer name 'not/allowed' laundered as 'not_allowed' for filename compatibility",
+    ):
+        ds.CreateLayer("not/allowed", srs=srs, geom_type=ogr.wkbUnknown)

--- a/ogr/ogrsf_frmts/miramon/ogrmiramondatasource.cpp
+++ b/ogr/ogrsf_frmts/miramon/ogrmiramondatasource.cpp
@@ -181,8 +181,18 @@ OGRMiraMonDataSource::ICreateLayer(const char *pszLayerName,
     }
     else
     {
+        const std::string osFilename =
+            CPLLaunderForFilenameSafe(pszLayerName, nullptr);
+        if (osFilename != pszLayerName)
+        {
+            CPLError(
+                CE_Warning, CPLE_AppDefined,
+                "Layer name '%s' laundered as '%s' for filename compatibility",
+                pszLayerName, osFilename.c_str());
+        }
+
         osFullMMLayerName =
-            CPLFormFilenameSafe(m_osRootName.c_str(), pszLayerName, "");
+            CPLFormFilenameSafe(m_osRootName.c_str(), osFilename.c_str(), "");
 
         /* -------------------------------------------------------------------- */
         /*      Let's create the folder if it's not already created.            */


### PR DESCRIPTION
Backport #14208
 **Authored by:** @rouault