### PR TITLE
Dataset RasterIO non-nearest interpolation: for consistency with overall design, do the interpolation in the input data type, not the output one

### DIFF
--- a/autotest/gcore/rasterio.py
+++ b/autotest/gcore/rasterio.py
@@ -12,6 +12,7 @@
 # SPDX-License-Identifier: MIT
 ###############################################################################
 
+import array
 import math
 import struct
 import sys
@@ -3898,3 +3899,50 @@ def test_rasterio_gdt_unknown():
         # Caught at the SWIG level
         with pytest.raises(Exception, match="Illegal value for data type"):
             ds.GetRasterBand(1).ReadRaster(buf_type=gdal.GDT_Unknown)
+
+
+###############################################################################
+
+
+def test_rasterio_resampling_output_type_not_native_type():
+
+    ds = gdal.GetDriverByName("MEM").Create("", 4, 4, eType=gdal.GDT_UInt8, bands=2)
+    ds.GetRasterBand(1).WriteRaster(
+        0, 0, 4, 4, array.array("B", [i for i in range(16)])
+    )
+    ds.GetRasterBand(2).WriteRaster(
+        0, 0, 4, 4, array.array("B", [i + 16 for i in range(16)])
+    )
+
+    got = struct.unpack(
+        "d" * 8,
+        ds.ReadRaster(
+            buf_xsize=2,
+            buf_ysize=2,
+            buf_type=gdal.GDT_Float64,
+            resample_alg=gdal.GRIORA_CubicSpline,
+        ),
+    )
+    assert got == (5.0, 6.0, 9.0, 10.0, 21.0, 22.0, 25.0, 26.0)
+
+    got = struct.unpack(
+        "d" * 4,
+        ds.GetRasterBand(1).ReadRaster(
+            buf_xsize=2,
+            buf_ysize=2,
+            buf_type=gdal.GDT_Float64,
+            resample_alg=gdal.GRIORA_CubicSpline,
+        ),
+    )
+    assert got == (5.0, 6.0, 9.0, 10.0)
+
+    got = struct.unpack(
+        "d" * 4,
+        ds.GetRasterBand(2).ReadRaster(
+            buf_xsize=2,
+            buf_ysize=2,
+            buf_type=gdal.GDT_Float64,
+            resample_alg=gdal.GRIORA_CubicSpline,
+        ),
+    )
+    assert got == (21.0, 22.0, 25.0, 26.0)

--- a/gcore/gdal_misc.cpp
+++ b/gcore/gdal_misc.cpp
@@ -5048,10 +5048,12 @@ GDALRIOResampleAlg GDALRasterIOGetResampleAlg(const char *pszResampling)
 
 const char *GDALRasterIOGetResampleAlg(GDALRIOResampleAlg eResampleAlg)
 {
+    const char *pszRet = "Unknown";
     switch (eResampleAlg)
     {
         case GRIORA_NearestNeighbour:
-            return "NearestNeighbour";
+            pszRet = "NearestNeighbour";
+            break;
         case GRIORA_Bilinear:
             return "Bilinear";
         case GRIORA_Cubic:
@@ -5068,10 +5070,11 @@ const char *GDALRasterIOGetResampleAlg(GDALRIOResampleAlg eResampleAlg)
             return "Mode";
         case GRIORA_Gauss:
             return "Gauss";
-        default:
-            CPLAssert(false);
-            return "Unknown";
+        case GRIORA_RESERVED_START:
+        case GRIORA_RESERVED_END:
+            break;
     }
+    return pszRet;
 }
 
 /************************************************************************/

--- a/gcore/gdaldataset.cpp
+++ b/gcore/gdaldataset.cpp
@@ -2949,6 +2949,11 @@ CPLErr GDALDataset::ValidateRasterIOOrAdviseReadParameters(
     int nYOff, int nXSize, int nYSize, int nBufXSize, int nBufYSize,
     int nBandCount, const int *panBandMap)
 {
+    if (nBands == 0)
+    {
+        *pbStopProcessingOnCENone = TRUE;
+        return CE_None;
+    }
 
     /* -------------------------------------------------------------------- */
     /*      Some size values are "noop".  Lets just return to avoid         */

--- a/gcore/rasterio.cpp
+++ b/gcore/rasterio.cpp
@@ -1232,16 +1232,7 @@ CPLErr GDALRasterBand::RasterIOResampled(
     else
     {
         const char *pszResampling =
-            (psExtraArg->eResampleAlg == GRIORA_Bilinear)      ? "BILINEAR"
-            : (psExtraArg->eResampleAlg == GRIORA_Cubic)       ? "CUBIC"
-            : (psExtraArg->eResampleAlg == GRIORA_CubicSpline) ? "CUBICSPLINE"
-            : (psExtraArg->eResampleAlg == GRIORA_Lanczos)     ? "LANCZOS"
-            : (psExtraArg->eResampleAlg == GRIORA_Average)     ? "AVERAGE"
-            : (psExtraArg->eResampleAlg == GRIORA_RMS)         ? "RMS"
-            : (psExtraArg->eResampleAlg == GRIORA_Mode)        ? "MODE"
-            : (psExtraArg->eResampleAlg == GRIORA_Gauss)       ? "GAUSS"
-                                                               : "UNKNOWN";
-
+            GDALRasterIOGetResampleAlg(psExtraArg->eResampleAlg);
         int nKernelRadius = 0;
         GDALResampleFunction pfnResampleFunc =
             GDALGetResampleFunction(pszResampling, &nKernelRadius);
@@ -1577,39 +1568,47 @@ CPLErr GDALDataset::RasterIOResampled(
     }
 
     // Create a MEM dataset that wraps the output buffer.
-    GDALDataset *poMEMDS =
+    std::unique_ptr<void, VSIFreeReleaser> pTempBuffer;
+    GSpacing nPSMem = nPixelSpace;
+    GSpacing nLSMem = nLineSpace;
+    GSpacing nBandSpaceMEM = nBandSpace;
+    void *pDataMem = pData;
+    GDALDataType eDTMem = eBufType;
+    GDALRasterBand *poFirstSrcBand = GetRasterBand(panBandMap[0]);
+    const GDALDataType eDataType = poFirstSrcBand->GetRasterDataType();
+    if (eBufType != eDataType)
+    {
+        nPSMem = GDALGetDataTypeSizeBytes(eDataType);
+        nLSMem = nPSMem * nBufXSize;
+        nBandSpaceMEM = nLSMem * nBandCount;
+        pTempBuffer.reset(VSI_MALLOC3_VERBOSE(nBandCount, nBufYSize,
+                                              static_cast<size_t>(nLSMem)));
+        if (pTempBuffer == nullptr)
+            return CE_Failure;
+        pDataMem = pTempBuffer.get();
+        eDTMem = eDataType;
+    }
+
+    auto poMEMDS = std::unique_ptr<GDALDataset>(
         MEMDataset::Create("", nDestXOffVirtual + nBufXSize,
-                           nDestYOffVirtual + nBufYSize, 0, eBufType, nullptr);
-    GDALRasterBand **papoDstBands = static_cast<GDALRasterBand **>(
-        CPLMalloc(nBandCount * sizeof(GDALRasterBand *)));
+                           nDestYOffVirtual + nBufYSize, 0, eDTMem, nullptr));
+#ifdef GDAL_ENABLE_RESAMPLING_MULTIBAND
+    std::vector<GDALRasterBand *> apoDstBands(nBandCount);
+#endif
     int nNBITS = 0;
     for (int i = 0; i < nBandCount; i++)
     {
-        char szBuffer[32] = {'\0'};
-        int nRet = CPLPrintPointer(
-            szBuffer,
-            static_cast<GByte *>(pData) - nPixelSpace * nDestXOffVirtual -
-                nLineSpace * nDestYOffVirtual + nBandSpace * i,
-            sizeof(szBuffer));
-        szBuffer[nRet] = 0;
-
-        char szBuffer0[64] = {'\0'};
-        snprintf(szBuffer0, sizeof(szBuffer0), "DATAPOINTER=%s", szBuffer);
-
-        char szBuffer1[64] = {'\0'};
-        snprintf(szBuffer1, sizeof(szBuffer1), "PIXELOFFSET=" CPL_FRMT_GIB,
-                 static_cast<GIntBig>(nPixelSpace));
-
-        char szBuffer2[64] = {'\0'};
-        snprintf(szBuffer2, sizeof(szBuffer2), "LINEOFFSET=" CPL_FRMT_GIB,
-                 static_cast<GIntBig>(nLineSpace));
-
-        char *apszOptions[4] = {szBuffer0, szBuffer1, szBuffer2, nullptr};
-
-        poMEMDS->AddBand(eBufType, apszOptions);
+        GByte *const pBandData = static_cast<GByte *>(pDataMem) -
+                                 nPSMem * nDestXOffVirtual -
+                                 nLSMem * nDestYOffVirtual + nBandSpaceMEM * i;
+        auto poMEMBand = GDALRasterBand::FromHandle(MEMCreateRasterBandEx(
+            poMEMDS.get(), 1, pBandData, eDTMem, nPSMem, nLSMem, false));
+        poMEMDS->SetBand(i + 1, poMEMBand);
 
         GDALRasterBand *poSrcBand = GetRasterBand(panBandMap[i]);
-        papoDstBands[i] = poMEMDS->GetRasterBand(i + 1);
+#ifdef GDAL_ENABLE_RESAMPLING_MULTIBAND
+        apoDstBands[i] = poMEMBand;
+#endif
         const char *pszNBITS =
             poSrcBand->GetMetadataItem("NBITS", "IMAGE_STRUCTURE");
         if (pszNBITS)
@@ -1698,18 +1697,8 @@ CPLErr GDALDataset::RasterIOResampled(
 #endif
     {
         const char *pszResampling =
-            (psExtraArg->eResampleAlg == GRIORA_Bilinear)      ? "BILINEAR"
-            : (psExtraArg->eResampleAlg == GRIORA_Cubic)       ? "CUBIC"
-            : (psExtraArg->eResampleAlg == GRIORA_CubicSpline) ? "CUBICSPLINE"
-            : (psExtraArg->eResampleAlg == GRIORA_Lanczos)     ? "LANCZOS"
-            : (psExtraArg->eResampleAlg == GRIORA_Average)     ? "AVERAGE"
-            : (psExtraArg->eResampleAlg == GRIORA_RMS)         ? "RMS"
-            : (psExtraArg->eResampleAlg == GRIORA_Mode)        ? "MODE"
-            : (psExtraArg->eResampleAlg == GRIORA_Gauss)       ? "GAUSS"
-                                                               : "UNKNOWN";
+            GDALRasterIOGetResampleAlg(psExtraArg->eResampleAlg);
 
-        GDALRasterBand *poFirstSrcBand = GetRasterBand(panBandMap[0]);
-        GDALDataType eDataType = poFirstSrcBand->GetRasterDataType();
         int nBlockXSize, nBlockYSize;
         poFirstSrcBand->GetBlockSize(&nBlockXSize, &nBlockYSize);
 
@@ -1786,10 +1775,8 @@ CPLErr GDALDataset::RasterIOResampled(
         if (pChunk == nullptr ||
             (bUseNoDataMask && pabyChunkNoDataMask == nullptr))
         {
-            GDALClose(poMEMDS);
             CPLFree(pChunk);
             CPLFree(pabyChunkNoDataMask);
-            CPLFree(papoDstBands);
             return CE_Failure;
         }
 
@@ -1891,11 +1878,11 @@ CPLErr GDALDataset::RasterIOResampled(
                                 {
                                     GDALCopyWords64(
                                         abyZero, GDT_UInt8, 0,
-                                        static_cast<GByte *>(pData) +
-                                            iBand * nBandSpace +
-                                            nLineSpace * (j + nDstYOff) +
-                                            nDstXOff * nPixelSpace,
-                                        eBufType, static_cast<int>(nPixelSpace),
+                                        static_cast<GByte *>(pDataMem) +
+                                            iBand * nBandSpaceMEM +
+                                            nLSMem * (j + nDstYOff) +
+                                            nDstXOff * nPSMem,
+                                        eBufType, static_cast<int>(nPSMem),
                                         nDstXCount);
                                 }
                             }
@@ -1934,8 +1921,8 @@ CPLErr GDALDataset::RasterIOResampled(
                         nChunkYSizeQueried, nDstXOff + nDestXOffVirtual,
                         nDstXOff + nDestXOffVirtual + nDstXCount,
                         nDstYOff + nDestYOffVirtual,
-                        nDstYOff + nDestYOffVirtual + nDstYCount, papoDstBands,
-                        pszResampling, FALSE /*bHasNoData*/,
+                        nDstYOff + nDestYOffVirtual + nDstYCount,
+                        apoDstBands.data(), pszResampling, FALSE /*bHasNoData*/,
                         0.0 /* dfNoDataValue */, nullptr /* color table*/,
                         eDataType);
                 }
@@ -2020,8 +2007,13 @@ CPLErr GDALDataset::RasterIOResampled(
         CPLFree(pabyChunkNoDataMask);
     }
 
-    CPLFree(papoDstBands);
-    GDALClose(poMEMDS);
+    if (eBufType != eDataType)
+    {
+        CPL_IGNORE_RET_VAL(poMEMDS->RasterIO(
+            GF_Read, nDestXOffVirtual, nDestYOffVirtual, nBufXSize, nBufYSize,
+            pData, nBufXSize, nBufYSize, eBufType, nBandCount, nullptr,
+            nPixelSpace, nLineSpace, nBandSpace, nullptr));
+    }
 
     return eErr;
 }


### PR DESCRIPTION
Fixes #14221
