### PR TITLE
Revert c# Utf8 marshalling changes 

### DIFF
--- a/swig/include/csharp/typemaps_csharp.i
+++ b/swig/include/csharp/typemaps_csharp.i
@@ -479,10 +479,16 @@ CSHARP_OBJECT_ARRAYS_PINNED(GDALRasterBandShadow, Band)
 /*
  * Typemap for const char *utf8_path and utf8_or_null.
  */
-%typemap(imtype,
-  inattributes="[MarshalAs(UnmanagedType.LPUTF8Str)]",
-  outattributes="[return: MarshalAs(UnmanagedType.LPUTF8Str)]")
-    (const char *utf8_path), (const char *utf8_or_null = NULL) "string"
+%typemap(csin) (const char *utf8_path), (const char *utf8_or_null) "$module.StringToUtf8Bytes($csinput)"
+%typemap(imtype, out="IntPtr") (const char *utf8_path), (const char *utf8_or_null) "byte[]"
+%typemap(out) (const char *utf8_path) %{ $result = $1; %}
+%typemap(csout, excode=SWIGEXCODE) (const char *utf8_path) {
+        /* %typemap(csout) (const char *utf8_path) */
+        IntPtr cPtr = $imcall;
+        string ret = $module.Utf8BytesToString(cPtr);
+        $excode
+        return ret;
+}
 
 %apply ( const char *utf8_path ) {
     const char* GetFieldAsString,


### PR DESCRIPTION
## What does this PR do?
#14075 changed the `utf8_path` P/Invoke signatures to use the built-in .NET marshaller to marshal UTF-8 strings. However, GisInternals targets netstandard2.0, but `UnmanagedType.LPUTF8Str` was added in netstandard2.1. This PR reverts that change, using the `Utf8BytesToString` and `StringToUtf8Bytes` methods instead.

Add `utf8_or_null` type pattern to allow passing null values, because gdal.i applies a `NONNULL` constraint to `utf8_path`

## What are related issues/pull requests?
[This comment](https://github.com/OSGeo/gdal/pull/14075#issuecomment-4106628039) in #14075

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
