### PR TITLE
Rename 'aliases' to 'alias' in schema

### DIFF
--- a/ogr/data/ogr_fields_override.schema.json
+++ b/ogr/data/ogr_fields_override.schema.json
@@ -103,7 +103,7 @@
             "string"
           ]
         },
-        "aliases": {
+        "alias": {
           "description": "Alias for the field",
           "type": "string"
         },


### PR DESCRIPTION
I cannot remember why I named this in the plural form, I think it was a mistake.

I will add a test case for this property in a separate PR because there isn't any.