### PR TITLE
GDALIsLineOfSightVisible(): treat points exactly on the DEM surface as visible

### DIFF
--- a/alg/los.cpp
+++ b/alg/los.cpp
@@ -15,9 +15,10 @@
 #include "cpl_port.h"
 #include "gdal_alg.h"
 
-// There's a plethora of bresenham implementations, all questionable production quality.
-// Bresenham optimizes for integer math, which makes sense for raster datasets in 2D.
-// For 3D, a 3D bresenham could be used if the altitude is also integer resolution.
+// There's a plethora of bresenham implementations, all questionable production
+// quality. Bresenham optimizes for integer math, which makes sense for raster
+// datasets in 2D. For 3D, a 3D bresenham could be used if the altitude is also
+// integer resolution.
 // 2D:
 // https://codereview.stackexchange.com/questions/77460/bresenhams-line-algorithm-optimization
 // https://gist.github.com/ssavi-ict/092501c69e2ffec65e96a8865470ad2f
@@ -30,9 +31,9 @@
 // https://gist.github.com/yamamushi/5823518
 
 // Run bresenham terrain checking from (x1, y1) to (x2, y2).
-// The callback is run at every point along the line,
-// which should return True if the point is above terrain.
-// Bresenham2D will return true if all points have LOS between the start and end.
+// The callback is run at every point along the line, which should return True
+// if the point is above terrain. Bresenham2D will return true if all points
+// have LOS between the start and end.
 static bool
 Bresenham2D(const int x1, const int y1, const int x2, const int y2,
             std::function<auto(const int, const int)->bool> OnBresenhamPoint)
@@ -117,14 +118,14 @@ static bool GetElevation(const GDALRasterBandH hBand, const int x, const int y,
                         0) == CE_None;
 }
 
-// Check a single location is above terrain.
+// Check a single location is above (or equal) to terrain height.
 static bool IsAboveTerrain(const GDALRasterBandH hBand, const int x,
                            const int y, const double z)
 {
     double terrainHeight;
     if (GetElevation(hBand, x, y, terrainHeight))
     {
-        return z > terrainHeight;
+        return z >= terrainHeight;
     }
     else
     {
@@ -142,32 +143,37 @@ static bool IsAboveTerrain(const GDALRasterBandH hBand, const int x,
  *
  * This algorithm will check line of sight using a Bresenham algorithm.
  * https://www.researchgate.net/publication/2411280_Efficient_Line-of-Sight_Algorithms_for_Real_Terrain_Data
- * Line of sight is computed in raster coordinate space, and thus may not be appropriate.
- * For example, datasets referenced against geographic coordinate at high latitudes may have issues.
+ * Line of sight is computed in raster coordinate space, and thus may not be
+ * appropriate. For example, datasets referenced against geographic coordinate
+ * at high latitudes may have issues. A point exactly at the height of the DEM
+ * is treated as visible from above.
  *
  * @param hBand The band to read the DEM data from. This must NOT be null.
  *
- * @param xA The X location (raster column) of the first point to check on the raster.
+ * @param xA The X location (raster column) of the first point to check on the
+ * raster.
  *
- * @param yA The Y location (raster row) of the first point to check on the raster.
+ * @param yA The Y location (raster row) of the first point to check on the
+ * raster.
  *
  * @param zA The Z location (height) of the first point to check.
  *
- * @param xB The X location (raster column) of the second point to check on the raster.
+ * @param xB The X location (raster column) of the second point to check on the
+ * raster.
  *
- * @param yB The Y location (raster row) of the second point to check on the raster.
+ * @param yB The Y location (raster row) of the second point to check on the
+ * raster.
  *
  * @param zB The Z location (height) of the second point to check.
  *
  * @param[out] pnxTerrainIntersection The X location where the LOS line
- *             intersects with terrain, or nullptr if it does not intersect
- *             terrain.
+ * intersects with terrain, or nullptr if it does not intersect terrain.
  *
  * @param[out] pnyTerrainIntersection The Y location where the LOS line
- *             intersects with terrain, or nullptr if it does not intersect
- *             terrain.
+ * intersects with terrain, or nullptr if it does not intersect terrain.
  *
- * @param papszOptions Options for the line of sight algorithm (currently ignored).
+ * @param papszOptions Options for the line of sight algorithm (currently
+ * ignored).
  *
  * @return True if the two points are within Line of Sight.
  *
@@ -314,7 +320,8 @@ bool GDALIsLineOfSightVisible(const GDALRasterBandH hBand, const int xA,
         }
     };
 
-    // Handle special cases if it's a vertical or horizontal line (don't use bresenham).
+    // Handle special cases if it's a vertical or horizontal line
+    // (don't use bresenham).
     if (xA == xB)
     {
         return CheckVerticalLine();
@@ -329,23 +336,23 @@ bool GDALIsLineOfSightVisible(const GDALRasterBandH hBand, const int xA,
     // Lambda for computing the square of a number
     auto SQUARE = [](const double d) -> double { return d * d; };
 
-    // Lambda for getting Z test height given x-y input along the bresenham line.
+    // Lambda for getting Z test height given x-y input along bresenham line.
     auto GetZValueFromXY = [&](const int x, const int y) -> double
     {
         const auto rNum = SQUARE(static_cast<double>(x - xA)) +
                           SQUARE(static_cast<double>(y - yA));
         const auto rDenom = SQUARE(static_cast<double>(xB - xA)) +
                             SQUARE(static_cast<double>(yB - yA));
-        /// @todo In order to reduce CPU cost and avoid a sqrt operation, consider
-        /// the approach to just the ratio along x or y depending on whether
-        /// the line is steep or shallow.
+        /// @todo In order to reduce CPU cost and avoid a sqrt operation,
+        /// consider the approach to just the ratio along x or y depending on
+        /// whether the line is steep or shallow.
         /// See https://github.com/OSGeo/gdal/pull/9506#discussion_r1532459689.
         const double ratio =
             sqrt(static_cast<double>(rNum) / static_cast<double>(rDenom));
         return lerp(zA, zB, ratio);
     };
 
-    // Lambda to get elevation at a bresenham-computed location.
+    // Lambda to get if above terrain at a bresenham-computed location.
     auto OnBresenhamPoint = [&](const int x, const int y) -> bool
     {
         const auto z = GetZValueFromXY(x, y);

--- a/autotest/cpp/test_alg.cpp
+++ b/autotest/cpp/test_alg.cpp
@@ -13,6 +13,7 @@
 #include <array>
 #include <cmath>
 #include <limits>
+#include <string>
 
 #include "gdal_unit_test.h"
 
@@ -325,18 +326,19 @@ TEST_F(test_alg, GDALIsLineOfSightVisible_single_point_dataset)
     // One point below terrain
     EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 0, 0, 0.0, 0, 0, 43.0, nullptr,
                                           nullptr, nullptr));
-    int xIntersection, yIntersection;
-    int *pXIntersection = &xIntersection;
-    int *pYIntersection = &yIntersection;
+    int xIntersection = -1;
+    int yIntersection = -1;
+
     EXPECT_FALSE(GDALIsLineOfSightVisible(
-        pBand, 0, 0, 0.0, 0, 0, 43.0, pXIntersection, pYIntersection, nullptr));
-    EXPECT_EQ(*pXIntersection, 0);
-    EXPECT_EQ(*pYIntersection, 0);
+        pBand, 0, 0, 0.0, 0, 0, 43.0, &xIntersection, &yIntersection, nullptr));
+    EXPECT_EQ(xIntersection, 0);
+    EXPECT_EQ(yIntersection, 0);
+
     // Both points above terrain
     EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, 0, 0, 44.0, 0, 0, 43.0, nullptr,
                                          nullptr, nullptr));
     EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, 0, 0, 44.0, 0, 0, 43.0,
-                                         pXIntersection, pYIntersection,
+                                         &xIntersection, &yIntersection,
                                          nullptr));
 }
 
@@ -362,8 +364,11 @@ TEST_F(test_alg, GDALIsLineOfSightVisible_default_square_dataset)
     // Both points are above terrain.
     EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, x1, y1, 1.0, x2, y2, 1.0,
                                          nullptr, nullptr, nullptr));
+
     // Both points are above terrain, supply intersection.
-    int xIntersection, yIntersection;
+    int xIntersection = -1;
+    int yIntersection = -1;
+
     EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, x1, y1, 1.0, x2, y2, 1.0,
                                          &xIntersection, &yIntersection,
                                          nullptr));
@@ -374,19 +379,23 @@ TEST_F(test_alg, GDALIsLineOfSightVisible_default_square_dataset)
     // One point is below terrain.
     EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, x1, y1, -1.0, x2, y2, 1.0,
                                           nullptr, nullptr, nullptr));
-    int *pXIntersection = &xIntersection;
-    int *pYIntersection = &yIntersection;
+
+    // One point exactly on terrain.
+    EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, x1, y1, 0.0, x2, y2, 1.0,
+                                         nullptr, nullptr, nullptr));
+
     EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, x1, y1, -1.0, x2, y2, 1.0,
-                                          pXIntersection, pYIntersection,
+                                          &xIntersection, &yIntersection,
                                           nullptr));
-    EXPECT_EQ(*pXIntersection, 1);
-    EXPECT_EQ(*pYIntersection, 1);
-    // Flip the order, same result.
+    EXPECT_EQ(xIntersection, 1);
+    EXPECT_EQ(yIntersection, 1);
+
+    // Flip the order.
     EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, x2, y2, -1.0, x1, y1, 1.0,
-                                          pXIntersection, pYIntersection,
+                                          &xIntersection, &yIntersection,
                                           nullptr));
-    EXPECT_EQ(*pXIntersection, 2);
-    EXPECT_EQ(*pYIntersection, 2);
+    EXPECT_EQ(xIntersection, 2);
+    EXPECT_EQ(yIntersection, 2);
 
     // Both points are below terrain.
     EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, x1, y1, -1.0, x2, y2, -1.0,
@@ -396,7 +405,7 @@ TEST_F(test_alg, GDALIsLineOfSightVisible_default_square_dataset)
                                           nullptr, nullptr, nullptr));
 }
 
-// Test GDALIsLineOfSightVisible() through a mountain (not a unit test)
+// Test GDALIsLineOfSightVisible() through a mountain
 TEST_F(test_alg, GDALIsLineOfSightVisible_through_mountain)
 {
     GDALAllRegister();
@@ -426,7 +435,7 @@ TEST_F(test_alg, GDALIsLineOfSightVisible_through_mountain)
     const double mesaLatBottom = 43.4645;
     const double mesaLngBottom = -79.8985;
 
-    // In between the two locations, the mesa reaches a local max altiude of 321.
+    // Between the two locations, the mesa reaches local max altitude of 321.
 
     double dMesaTopX, dMesaTopY, dMesaBottomX, dMesaBottomY;
     GDALApplyGeoTransform(geoInvTransform.data(), mesaLngTop, mesaLatTop,
@@ -461,32 +470,34 @@ TEST_F(test_alg, GDALIsLineOfSightVisible_through_mountain)
     // Both high above terrain.
     EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, 0, 0, 460, 120, 120, 460,
                                          nullptr, nullptr, nullptr));
-    // Both heights are 1m above in the corners, but middle terrain violates LOS.
+
+    // Both heights are 1m above in the corners, but middle terrain breaks LOS.
     EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 0, 0, 295, 120, 120, 183,
                                           nullptr, nullptr, nullptr));
 
-    int xIntersection, yIntersection;
-    int *pXIntersection = &xIntersection;
-    int *pYIntersection = &yIntersection;
+    int xIntersection = -1;
+    int yIntersection = -1;
+
     EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 0, 0, 295, 120, 120, 183,
-                                          pXIntersection, pYIntersection,
+                                          &xIntersection, &yIntersection,
                                           nullptr));
-    EXPECT_EQ(*pXIntersection, 2);
-    EXPECT_EQ(*pYIntersection, 2);
+    EXPECT_EQ(xIntersection, 2);
+    EXPECT_EQ(yIntersection, 2);
 
     // Test positive slope bresenham diagonals across the whole raster.
     // Both high above terrain.
     EXPECT_TRUE(GDALIsLineOfSightVisible(pBand, 0, 120, 460, 120, 0, 460,
                                          nullptr, nullptr, nullptr));
-    // Both heights are 1m above in the corners, but middle terrain violates LOS.
-    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 0, 120, 203, 120, 0, 247,
+    // Both heights are 1m above in the corners, but middle terrain breaks LOS.
+    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 0, 120, 203, 120, 0, 248,
                                           nullptr, nullptr, nullptr));
-    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 0, 120, 203, 120, 0, 247,
-                                          pXIntersection, pYIntersection,
+
+    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 0, 120, 203, 120, 0, 248,
+                                          &xIntersection, &yIntersection,
                                           nullptr));
 
-    EXPECT_EQ(*pXIntersection, 120);
-    EXPECT_EQ(*pYIntersection, 0);
+    EXPECT_EQ(xIntersection, 16);
+    EXPECT_EQ(yIntersection, 104);
 
     // Vertical line tests with hill between two points, in both directions.
     EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 83, 111, 154, 83, 117, 198,

--- a/swig/include/python/docs/gdal_operations_docs.i
+++ b/swig/include/python/docs/gdal_operations_docs.i
@@ -108,9 +108,7 @@ tuple
 
     - ``is_visible`` (bool): True if the two points are within Line of Sight.
     - ``col_intersection`` (int): Raster column index where the LOS line intersects terrain.
-      Will be set in the future; currently -1.
     - ``row_intersection`` (int): Raster row index where the LOS line intersects terrain.
-      Will be set in the future; currently -1.
 ";
 
 // gdal.ReprojectImage


### PR DESCRIPTION
Attempts to revive the stale/closed PR #12460, fixing issue #12458.

The only code change in this new PR is the same change that was made in closed PR #12460. This new PR attempts to resolve the code formatting issues, and mainly, fixes the test issue that prevented that original PR from completion.

Note that the test issue in the original PR was not due to the code change, but rather was a flaw in the original test.

original PR, autotest/cpp/test_alg.cpp lines 481-486, testing LoS across the diagonal of n43.dt0:
```cpp
    // Both heights are 1m above in the corners, but middle terrain violates LOS.
    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 0, 120, 203, 120, 0, 247,
                                          nullptr, nullptr, nullptr));
    EXPECT_FALSE(GDALIsLineOfSightVisible(pBand, 0, 120, 203, 120, 0, 247,
                                          pXIntersection, pYIntersection,
                                          nullptr));

    // These fail with new changes.
    EXPECT_EQ(*pXIntersection, 120);
    EXPECT_EQ(*pYIntersection, 0);
```

Z = 203 for the lower left corner pixel (0, 120) is 1 m above terrain.

However, Z = 247 for the upper right corner is exactly on the DEM surface, not 1 m above. The intersection coordinate 120, 0 returned by the algorithm and considered correct in that original test is the coordinate of the upper right pixel itself, not a coordinate in the middle terrain.

If a Z value 1 m above terrain is given instead for the upper right corner coordinate (i.e., Z = 248), then line-of-sight is broken in the middle terrain as expected:
```py
from osgeo import gdal

ds = gdal.Open('n43.dt0')
res = gdal.IsLineOfSightVisible(ds.GetRasterBand(1), 0, 120, 203, 120, 0, 248)
res.is_visible
# False
res.col_intersection
# 16
res.row_intersection
# 104
```

This PR sets the Z value to 248 to be consistent with the original intent in the comment

>// Both heights are 1m above in the corners, but middle terrain violates LOS.

and updates the expected intersection values to 16, 104 as above. (Note that the test would also succeed with Z = 247 for the upper right corner,  i.e., exactly on the surface, following the code change in this PR.)

I also noticed that latest API doc for Python is out of date for `osgeo.gdal.IsLineOfSightVisible()`. It currently has "Will be set in the future; currently -1":

> Returns:
> 
>     A named tuple with the following fields:
> 
>         is_visible (bool): True if the two points are within Line of Sight.
> 
>         col_intersection (int): Raster column index where the LOS line intersects terrain. Will be set in the future; currently -1.
> 
>         row_intersection (int): Raster row index where the LOS line intersects terrain. Will be set in the future; currently -1.

but the intersection values are set by that function since at least GDAL 3.11.4. This PR removes "Will be set in the future; currently -1".


 - [ ] AI (Copilot or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [x] Add test case(s)
 - [x] Add documentation
 - [x] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed
 - [ ] ADD YOUR TASKS HERE
