### PR TITLE
Show that MakePoint() and Cast() are not in fact needed

### DIFF
--- a/doc/source/drivers/vector/csv.rst
+++ b/doc/source/drivers/vector/csv.rst
@@ -247,6 +247,14 @@ AS float))) FROM test GROUP BY way_id"* will return :
      way_id (String) = 2
      LINESTRING (-2 49,-3 50)
 
+In fact we can get the same output with simply:
+
+::
+
+    ogrinfo -sql "SELECT MakeLine(geometry) FROM test GROUP BY way_id" \
+    -oo X_POSSIBLE_NAMES=x -oo Y_POSSIBLE_NAMES=y -dialect SQLite test.csv	
+
+
 VSI Virtual File System API support
 -----------------------------------
 


### PR DESCRIPTION
https://gis.stackexchange.com/a/500352/77230 alerts us that the heavy lifting is mostly done for us already.

By the way, perhaps go a little farther,
tossing in a real "real", in the input, and output,
```
  LINESTRING (2 49,3.0 50.4)
                          ^here
```
to show that non-integers are safe and won't get turned into integers too.