### PR TITLE
CI: do not write to cache on pull_request events to prevent cache poisoning

### DIFF
--- a/.github/workflows/linux_build.yml
+++ b/.github/workflows/linux_build.yml
@@ -320,6 +320,11 @@ jobs:
 
       - name: Save build cache
         uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        # Do not write to cache on pull_request events to prevent cache poisoning.
+        # Fork PRs can otherwise overwrite shared cache keys used by main branch runs
+        # and as we have "packages: write" that could potentially lead to compromising
+        # our gdal-deps Docker images.
+        if: github.event_name != 'pull_request'
         with:
           path: ${{ github.workspace }}/.ccache
           key: ${{ steps.restore-cache.outputs.cache-primary-key }}


### PR DESCRIPTION
Inspired by https://github.com/OSGeo/grass/pull/7238
