### PR TITLE
JP2Grok: let Grok handle jp2 box read/write

### DIFF
--- a/frmts/grok/grkdatasetbase.h
+++ b/frmts/grok/grkdatasetbase.h
@@ -82,6 +82,7 @@
 #include <grk_config.h>
 
 #include "gdal_thread_pool.h"
+#include "gdaljp2metadata.h"
 
 #ifdef HAVE_CURL
 #include "cpl_aws.h"
@@ -936,20 +937,10 @@ struct GRKCodecWrapper
         psImage->color_space = static_cast<GRK_COLOR_SPACE>(eColorSpace);
         psImage->numcomps = nBands;
 
-        grk_stream_params streamParams = {};
-        streamParams.seek_fn = JP2Dataset_Seek;
-        streamParams.write_fn = JP2Dataset_Write;
-        streamParams.user_data = psJP2File;
-
-        /* Always ask Grok to do codestream only. We will take care */
-        /* of JP2 boxes */
+        /* Default to J2K; setupJP2Metadata() switches to GRK_FMT_JP2
+         * when writing JP2 files.  Codec creation is deferred to
+         * initCodec() so JP2 metadata can be set first. */
         compressParams.cod_format = GRK_FMT_J2K;
-        pCodec = grk_compress_init(&streamParams, &compressParams, psImage);
-        if (pCodec == nullptr)
-        {
-            CPLError(CE_Failure, CPLE_AppDefined, "grk_compress_init() failed");
-            return false;
-        }
 
         // Store tile grid info for compressTile
         compressBlockXSize = nBlockXSize;
@@ -972,6 +963,401 @@ struct GRKCodecWrapper
                            sizeof(int32_t));
         }
 
+        return true;
+    }
+
+    /**
+     * @brief Extract cdef and palette info from Grok's parsed JP2 boxes.
+     */
+    void extractJP2BoxInfo(int nBands, int &nRedIndex, int &nGreenIndex,
+                           int &nBlueIndex, int &nAlphaIndex,
+                           GDALColorTable **ppoCT)
+    {
+        if (!psImage || !psImage->meta)
+            return;
+
+        auto *cdef = psImage->meta->color.channel_definition;
+        if (cdef &&
+            cdef->num_channel_descriptions == static_cast<uint16_t>(nBands))
+        {
+            nRedIndex = nGreenIndex = nBlueIndex = -1;
+            for (int i = 0; i < nBands; i++)
+            {
+                int CNi = cdef->descriptions[i].channel;
+                int Typi = cdef->descriptions[i].typ;
+                int Asoci = cdef->descriptions[i].asoc;
+                if (CNi < 0 || CNi >= nBands)
+                {
+                    CPLError(CE_Failure, CPLE_AppDefined,
+                             "Wrong value of CN%d=%d", i, CNi);
+                    break;
+                }
+                if (Typi == 0)
+                {
+                    if (Asoci == 1)
+                        nRedIndex = CNi;
+                    else if (Asoci == 2)
+                        nGreenIndex = CNi;
+                    else if (Asoci == 3)
+                        nBlueIndex = CNi;
+                    else if (Asoci < 0 || (Asoci > nBands && Asoci != 65535))
+                    {
+                        CPLError(CE_Failure, CPLE_AppDefined,
+                                 "Wrong value of Asoc%d=%d", i, Asoci);
+                        break;
+                    }
+                }
+                else if (Typi == 1)
+                    nAlphaIndex = CNi;
+            }
+        }
+        else if (cdef)
+            CPLDebug(debugId(), "Unsupported cdef content");
+
+        auto *pal = psImage->meta->color.palette;
+        if (pal && pal->num_entries <= 256 &&
+            (pal->num_channels == 3 || pal->num_channels == 4))
+        {
+            bool allPrec7 = true;
+            for (int c = 0; c < pal->num_channels; c++)
+                if (pal->channel_prec[c] != 7)
+                {
+                    allPrec7 = false;
+                    break;
+                }
+            if (allPrec7)
+            {
+                *ppoCT = new GDALColorTable();
+                for (int i = 0; i < pal->num_entries; i++)
+                {
+                    GDALColorEntry e;
+                    int off = i * pal->num_channels;
+                    e.c1 = static_cast<short>(pal->lut[off]);
+                    e.c2 = static_cast<short>(pal->lut[off + 1]);
+                    e.c3 = static_cast<short>(pal->lut[off + 2]);
+                    e.c4 = (pal->num_channels == 4)
+                               ? static_cast<short>(pal->lut[off + 3])
+                               : 255;
+                    (*ppoCT)->SetColorEntry(i, &e);
+                }
+            }
+        }
+    }
+
+    /**
+     * @brief Set JP2 metadata on the image for Grok-native JP2 writing.
+     *
+     * Called between initCompress() and initCodec().
+     */
+    void setupJP2Metadata(bool bInspireTG, int bProfile1, bool bGeoBoxesAfter,
+                          GDALJP2Metadata *poJP2MD, GDALJP2Box *poGMLJP2Box,
+                          int nAlphaBandIndex, int nRedBandIndex,
+                          int nGreenBandIndex, int nBlueBandIndex,
+                          JP2_COLOR_SPACE eColorSpace, int nBands,
+                          GDALColorTable *poCT, GDALDataset *poSrcDS,
+                          CSLConstList papszOptions)
+    {
+        compressParams.cod_format = GRK_FMT_JP2;
+
+        if (!psImage->meta)
+            psImage->meta = grk_image_meta_new();
+
+        /* JPX branding + reader requirements */
+        const bool bJPXBranding =
+            CPLFetchBool(papszOptions, "JPX", true) && poGMLJP2Box != nullptr;
+        if (bJPXBranding)
+        {
+            compressParams.jpx_branding = true;
+            compressParams.write_rreq = true;
+            compressParams.num_rreq_standard_features = 0;
+            compressParams.rreq_standard_features
+                [compressParams.num_rreq_standard_features++] =
+                bProfile1 ? 4 : 5;
+            compressParams.rreq_standard_features
+                [compressParams.num_rreq_standard_features++] = 67;
+        }
+        if (bInspireTG && poGMLJP2Box != nullptr &&
+            !CPLFetchBool(papszOptions, "JPX", true))
+        {
+            CPLError(CE_Warning, CPLE_AppDefined,
+                     "INSPIRE_TG=YES implies GMLJP2 which recommends "
+                     "JPX capability");
+        }
+
+        compressParams.geoboxes_after_jp2c = bGeoBoxesAfter;
+
+        const bool bWriteMetadata =
+            CPLFetchBool(papszOptions, "WRITE_METADATA", false);
+        const bool bMainMDOnly =
+            CPLFetchBool(papszOptions, "MAIN_MD_DOMAIN_ONLY", false);
+        const bool bIPR =
+            poSrcDS->GetMetadata("xml:IPR") != nullptr && bWriteMetadata;
+
+        if (bIPR)
+        {
+            compressParams.rreq_standard_features
+                [compressParams.num_rreq_standard_features++] = 35;
+        }
+
+        /* GeoTIFF UUID */
+        if (poJP2MD)
+        {
+            std::unique_ptr<GDALJP2Box> poGeoBox(poJP2MD->CreateJP2GeoTIFF());
+            if (poGeoBox)
+            {
+                const GByte *p = poGeoBox->GetWritableData();
+                GIntBig n = poGeoBox->GetDataLength();
+                if (n > 16) /* skip 16-byte UUID prefix */
+                    grk_image_meta_set_field(psImage->meta, "geotiff", p + 16,
+                                             static_cast<size_t>(n - 16));
+            }
+        }
+
+        /* IPR box */
+        if (bIPR)
+        {
+            std::unique_ptr<GDALJP2Box> poIPRBox(
+                GDALJP2Metadata::CreateIPRBox(poSrcDS));
+            if (poIPRBox)
+            {
+                const GByte *p = poIPRBox->GetWritableData();
+                GIntBig n = poIPRBox->GetDataLength();
+                if (n > 0)
+                    grk_image_meta_set_field(psImage->meta, "ipr", p,
+                                             static_cast<size_t>(n));
+            }
+        }
+
+        /* GMLJP2 asoc boxes */
+        if (poGMLJP2Box)
+        {
+            const GByte *asocData = poGMLJP2Box->GetWritableData();
+            int asocLen = static_cast<int>(poGMLJP2Box->GetDataLength());
+            flattenAndSetAsocBoxes(asocData, asocLen);
+        }
+
+        /* XMP UUID */
+        if (bWriteMetadata && !bMainMDOnly)
+        {
+            std::unique_ptr<GDALJP2Box> poXMPBox(
+                GDALJP2Metadata::CreateXMPBox(poSrcDS));
+            if (poXMPBox)
+            {
+                const GByte *p = poXMPBox->GetWritableData();
+                GIntBig n = poXMPBox->GetDataLength();
+                if (n > 16)
+                    grk_image_meta_set_field(psImage->meta, "xmp", p + 16,
+                                             static_cast<size_t>(n - 16));
+            }
+        }
+
+        /* GDAL metadata XML box */
+        if (bWriteMetadata)
+        {
+            std::unique_ptr<GDALJP2Box> poMDBox(
+                GDALJP2Metadata::CreateGDALMultiDomainMetadataXMLBox(
+                    poSrcDS, bMainMDOnly));
+            if (poMDBox)
+            {
+                const GByte *p = poMDBox->GetWritableData();
+                GIntBig n = poMDBox->GetDataLength();
+                if (n > 0)
+                {
+                    psImage->meta->xml_len = static_cast<size_t>(n);
+                    psImage->meta->xml_buf =
+                        static_cast<uint8_t *>(malloc(psImage->meta->xml_len));
+                    memcpy(psImage->meta->xml_buf, p, psImage->meta->xml_len);
+                }
+            }
+        }
+
+        /* cdef: component type/association */
+        setupCdef(nAlphaBandIndex, nRedBandIndex, nGreenBandIndex,
+                  nBlueBandIndex, eColorSpace, nBands, poCT, papszOptions);
+
+        /* Display resolution */
+        setupResolution(poSrcDS);
+    }
+
+  private:
+    void setupCdef(int nAlphaBandIndex, int nRedBandIndex, int nGreenBandIndex,
+                   int nBlueBandIndex, JP2_COLOR_SPACE eColorSpace, int nBands,
+                   GDALColorTable *poCT, CSLConstList papszOptions)
+    {
+        bool needCdef =
+            (((nBands == 3 || nBands == 4) &&
+              (eColorSpace == static_cast<JP2_COLOR_SPACE>(GRK_CLRSPC_SRGB) ||
+               eColorSpace == static_cast<JP2_COLOR_SPACE>(GRK_CLRSPC_SYCC)) &&
+              (nRedBandIndex != 0 || nGreenBandIndex != 1 ||
+               nBlueBandIndex != 2)) ||
+             nAlphaBandIndex >= 0);
+        if (!needCdef)
+            return;
+
+        int nComponents = nBands;
+        if (poCT != nullptr)
+        {
+            int nCTComp =
+                atoi(CSLFetchNameValueDef(papszOptions, "CT_COMPONENTS", "0"));
+            if (nCTComp == 4)
+                nComponents = 4;
+        }
+        for (int i = 0; i < nComponents; i++)
+        {
+            if (i != nAlphaBandIndex)
+            {
+                psImage->comps[i].type = GRK_CHANNEL_TYPE_COLOUR;
+                if (eColorSpace ==
+                        static_cast<JP2_COLOR_SPACE>(GRK_CLRSPC_GRAY) &&
+                    i == 0)
+                    psImage->comps[i].association = GRK_CHANNEL_ASSOC_COLOUR_1;
+                else if (i == nRedBandIndex)
+                    psImage->comps[i].association = GRK_CHANNEL_ASSOC_COLOUR_1;
+                else if (i == nGreenBandIndex)
+                    psImage->comps[i].association = GRK_CHANNEL_ASSOC_COLOUR_2;
+                else if (i == nBlueBandIndex)
+                    psImage->comps[i].association = GRK_CHANNEL_ASSOC_COLOUR_3;
+            }
+            else
+            {
+                psImage->comps[i].type = GRK_CHANNEL_TYPE_OPACITY;
+                psImage->comps[i].association = GRK_CHANNEL_ASSOC_WHOLE_IMAGE;
+            }
+        }
+    }
+
+    void setupResolution(GDALDataset *poSrcDS)
+    {
+        if (poSrcDS->GetMetadataItem("TIFFTAG_XRESOLUTION") == nullptr ||
+            poSrcDS->GetMetadataItem("TIFFTAG_YRESOLUTION") == nullptr ||
+            poSrcDS->GetMetadataItem("TIFFTAG_RESOLUTIONUNIT") == nullptr)
+            return;
+
+        double dfXRes =
+            CPLAtof(poSrcDS->GetMetadataItem("TIFFTAG_XRESOLUTION"));
+        double dfYRes =
+            CPLAtof(poSrcDS->GetMetadataItem("TIFFTAG_YRESOLUTION"));
+        int nResUnit = atoi(poSrcDS->GetMetadataItem("TIFFTAG_RESOLUTIONUNIT"));
+        if (nResUnit == 2)
+        {
+            dfXRes = dfXRes * 39.37 / 100.0;
+            dfYRes = dfYRes * 39.37 / 100.0;
+        }
+        if ((nResUnit == 2 || nResUnit == 3) && dfXRes > 0 && dfYRes > 0 &&
+            dfXRes < 65535 && dfYRes < 65535)
+        {
+            compressParams.write_display_resolution = true;
+            compressParams.display_resolution[0] = dfXRes * 100.0;
+            compressParams.display_resolution[1] = dfYRes * 100.0;
+        }
+    }
+
+    void flattenAndSetAsocBoxes(const GByte *asocData, int asocDataLen)
+    {
+        struct AsocEntry
+        {
+            uint32_t level;
+            std::string label;
+            std::vector<uint8_t> xml;
+        };
+
+        std::vector<AsocEntry> entries;
+
+        std::function<void(const GByte *, int, uint32_t)> flattenAsoc;
+        flattenAsoc = [&](const GByte *data, int dataLen, uint32_t level)
+        {
+            int offset = 0;
+            AsocEntry thisEntry;
+            thisEntry.level = level;
+            std::vector<std::pair<const GByte *, int>> childAsocs;
+
+            while (offset + 8 <= dataLen)
+            {
+                uint32_t sz = static_cast<uint32_t>(
+                    (static_cast<uint32_t>(data[offset]) << 24) |
+                    (data[offset + 1] << 16) | (data[offset + 2] << 8) |
+                    data[offset + 3]);
+                if (sz < 8 || offset + static_cast<int>(sz) > dataLen)
+                    break;
+                const GByte *boxContent = data + offset + 8;
+                uint32_t boxContentLen = sz - 8;
+
+                if (memcmp(data + offset + 4, "lbl ", 4) == 0)
+                    thisEntry.label.assign(
+                        reinterpret_cast<const char *>(boxContent),
+                        boxContentLen);
+                else if (memcmp(data + offset + 4, "xml ", 4) == 0)
+                    thisEntry.xml.assign(boxContent,
+                                         boxContent + boxContentLen);
+                else if (memcmp(data + offset + 4, "asoc", 4) == 0)
+                    childAsocs.push_back(
+                        {boxContent, static_cast<int>(boxContentLen)});
+                offset += static_cast<int>(sz);
+            }
+            entries.push_back(std::move(thisEntry));
+            for (auto &child : childAsocs)
+                flattenAsoc(child.first, child.second, level + 1);
+        };
+        flattenAsoc(asocData, asocDataLen, 0);
+
+        if (!entries.empty())
+        {
+            std::vector<grk_asoc> asocs(entries.size());
+            for (size_t i = 0; i < entries.size(); i++)
+            {
+                asocs[i].level = entries[i].level;
+                asocs[i].label = entries[i].label.c_str();
+                asocs[i].xml =
+                    entries[i].xml.empty() ? nullptr : entries[i].xml.data();
+                asocs[i].xml_len = static_cast<uint32_t>(entries[i].xml.size());
+            }
+            grk_image_meta_set_asocs(psImage->meta, asocs.data(),
+                                     static_cast<uint32_t>(asocs.size()));
+        }
+    }
+
+  public:
+    /**
+     * @brief Returns true if the codec uses native file I/O for writing.
+     *
+     * When true, the VSILFILE passed to open() was closed and should
+     * not be used or closed by the caller.
+     */
+    bool ownsFile() const
+    {
+        return psJP2File && psJP2File->fp_ == nullptr;
+    }
+
+    /**
+     * @brief Create the Grok codec after metadata has been set.
+     *
+     * For local files and /vsis3/, uses native file I/O (closing the
+     * VSILFILE).  For other VSI paths, uses VSILFILE callbacks.
+     */
+    bool initCodec(const char *pszFilename, VSIVirtualHandleUniquePtr &fpOwner)
+    {
+        grk_stream_params streamParams = {};
+        if (pszFilename && GrokCanRead(pszFilename))
+        {
+            CPLDebug("GROK", "Native file write for: %s", pszFilename);
+            safe_strcpy(streamParams.file, pszFilename);
+            fpOwner.reset();  // close before Grok opens natively
+            if (psJP2File)
+                psJP2File->fp_ = nullptr;
+        }
+        else
+        {
+            streamParams.seek_fn = JP2Dataset_Seek;
+            streamParams.write_fn = JP2Dataset_Write;
+            streamParams.user_data = psJP2File;
+        }
+
+        pCodec = grk_compress_init(&streamParams, &compressParams, psImage);
+        if (pCodec == nullptr)
+        {
+            CPLError(CE_Failure, CPLE_AppDefined, "grk_compress_init() failed");
+            return false;
+        }
         return true;
     }
 

--- a/frmts/openjpeg/opjdatasetbase.h
+++ b/frmts/openjpeg/opjdatasetbase.h
@@ -687,6 +687,30 @@ struct OPJCodecWrapper
         return opj_start_compress(pCodec, psImage, pStream);
     }
 
+    /* No-ops: OpenJPEG JP2 boxes are handled by GDAL's GDALJP2Box I/O */
+    static bool ownsFile()
+    {
+        return false;
+    }
+
+    static bool initCodec([[maybe_unused]] const char *pszFilename,
+                          [[maybe_unused]] VSIVirtualHandleUniquePtr &fpOwner)
+    {
+        return true;
+    }
+
+    static void setupJP2Metadata(bool, int, bool, GDALJP2Metadata *,
+                                 GDALJP2Box *, int, int, int, int,
+                                 JP2_COLOR_SPACE, int, GDALColorTable *,
+                                 GDALDataset *, CSLConstList)
+    {
+    }
+
+    static void extractJP2BoxInfo(int, int &, int &, int &, int &,
+                                  GDALColorTable **)
+    {
+    }
+
     bool compressTile(int tileIndex, GByte *buff, uint32_t buffLen)
     {
         if (!pCodec || !pStream)

--- a/frmts/opjlike/jp2opjlikedataset.cpp
+++ b/frmts/opjlike/jp2opjlikedataset.cpp
@@ -19,6 +19,7 @@
 #include "cpl_atomic_ops.h"
 #include "cpl_multiproc.h"
 #include "cpl_string.h"
+#include "cpl_vsi_virtual.h"
 #include "cpl_worker_thread_pool.h"
 #include "gdal_frmts.h"
 #include "gdaljp2abstractdataset.h"
@@ -1533,7 +1534,15 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::Open(GDALOpenInfo *poOpenInfo)
     /* -------------------------------------------------------------------- */
     /*      Look for color table or cdef box                                */
     /* -------------------------------------------------------------------- */
-    if (eCodecFormat == CODEC::cvtenum(JP2_CODEC_JP2))
+    if (eCodecFormat == CODEC::cvtenum(JP2_CODEC_JP2) &&
+        BASE::canPerformDirectIO())
+    {
+        /* Grok parses JP2 boxes natively; extract cdef/pclr from codec */
+        localctx.extractJP2BoxInfo(poDS->nBands, poDS->nRedIndex,
+                                   poDS->nGreenIndex, poDS->nBlueIndex,
+                                   poDS->nAlphaIndex, &poCT);
+    }
+    else if (eCodecFormat == CODEC::cvtenum(JP2_CODEC_JP2))
     {
         vsi_l_offset nCurOffset = VSIFTellL(poDS->fp_);
 
@@ -1746,19 +1755,20 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::Open(GDALOpenInfo *poOpenInfo)
         }
 
         VSIFSeekL(poDS->fp_, nCurOffset, SEEK_SET);
+    }
 
-        if (poDS->eColorSpace == CODEC::cvtenum(JP2_CLRSPC_GRAY) &&
-            poDS->nBands == 4 && poDS->nRedIndex == 0 &&
-            poDS->nGreenIndex == 1 && poDS->nBlueIndex == 2 &&
-            poDS->m_osFilename.find("dop10rgbi") != std::string::npos)
-        {
-            CPLDebug(CODEC::debugId(),
-                     "Autofix wrong colorspace from Greyscale to sRGB");
-            // Workaround https://github.com/uclouvain/openjpeg/issues/1464
-            // dop10rgbi products from https://www.opengeodata.nrw.de/produkte/geobasis/lusat/dop/dop_jp2_f10/
-            // have a wrong color space.
-            poDS->eColorSpace = CODEC::cvtenum(JP2_CLRSPC_SRGB);
-        }
+    if (eCodecFormat == CODEC::cvtenum(JP2_CODEC_JP2) &&
+        poDS->eColorSpace == CODEC::cvtenum(JP2_CLRSPC_GRAY) &&
+        poDS->nBands == 4 && poDS->nRedIndex == 0 && poDS->nGreenIndex == 1 &&
+        poDS->nBlueIndex == 2 &&
+        poDS->m_osFilename.find("dop10rgbi") != std::string::npos)
+    {
+        CPLDebug(CODEC::debugId(),
+                 "Autofix wrong colorspace from Greyscale to sRGB");
+        // Workaround https://github.com/uclouvain/openjpeg/issues/1464
+        // dop10rgbi products from https://www.opengeodata.nrw.de/produkte/geobasis/lusat/dop/dop_jp2_f10/
+        // have a wrong color space.
+        poDS->eColorSpace = CODEC::cvtenum(JP2_CLRSPC_SRGB);
     }
 
     /* -------------------------------------------------------------------- */
@@ -2843,8 +2853,8 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
 
     const char *pszAccess =
         STARTS_WITH_CI(pszFilename, "/vsisubfile/") ? "r+b" : "w+b";
-    VSILFILE *fp = VSIFOpenL(pszFilename, pszAccess);
-    if (fp == nullptr)
+    VSIVirtualHandleUniquePtr fpOwner(VSIFOpenL(pszFilename, pszAccess));
+    if (!fpOwner)
     {
         CPLError(CE_Failure, CPLE_AppDefined, "Cannot create file");
         CPLFree(localctx.pasBandParams);
@@ -2852,6 +2862,7 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
         delete poGMLJP2Box;
         return nullptr;
     }
+    VSILFILE *fp = fpOwner.get();
 
     /* -------------------------------------------------------------------- */
     /*      Add JP2 boxes.                                                  */
@@ -2859,7 +2870,8 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
     vsi_l_offset nStartJP2C = 0;
     int bUseXLBoxes = FALSE;
 
-    if (eCodecFormat == CODEC::cvtenum(JP2_CODEC_JP2))
+    if (eCodecFormat == CODEC::cvtenum(JP2_CODEC_JP2) &&
+        !BASE::canPerformDirectIO())
     {
         GDALJP2Box jPBox(fp);
         jPBox.SetType("jP  ");
@@ -3241,7 +3253,8 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
         }
     }
 
-    if (eCodecFormat == CODEC::cvtenum(JP2_CODEC_JP2))
+    if (eCodecFormat == CODEC::cvtenum(JP2_CODEC_JP2) &&
+        !BASE::canPerformDirectIO())
     {
         // Start codestream box
         nStartJP2C = VSIFTellL(fp);
@@ -3308,7 +3321,6 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
                     : static_cast<size_t>(nCodeStreamLength - nRead);
             if (VSIFReadL(abyBuffer, 1, nToRead, fpSrc) != nToRead)
             {
-                VSIFCloseL(fp);
                 VSIFCloseL(fpSrc);
                 delete poGMLJP2Box;
                 return nullptr;
@@ -3333,7 +3345,6 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
                 !pfnProgress((nRead + nToRead) * 1.0 / nCodeStreamLength,
                              nullptr, pProgressData))
             {
-                VSIFCloseL(fp);
                 VSIFCloseL(fpSrc);
                 delete poGMLJP2Box;
                 return nullptr;
@@ -3354,10 +3365,34 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
         {
             CPLError(CE_Failure, CPLE_AppDefined, "init compress failed");
             localctx.free();
-            VSIFCloseL(fp);
             delete poGMLJP2Box;
             return nullptr;
         }
+
+        /* Grok JP2: let codec handle box writing natively */
+        if (BASE::canPerformDirectIO() &&
+            eCodecFormat == CODEC::cvtenum(JP2_CODEC_JP2))
+        {
+            localctx.setupJP2Metadata(
+                bInspireTG, bProfile1, bGeoBoxesAfter,
+                (bGeoJP2Option && bGeoreferencingCompatOfGeoJP2) ? &oJP2MD
+                                                                 : nullptr,
+                poGMLJP2Box, nAlphaBandIndex, nRedBandIndex, nGreenBandIndex,
+                nBlueBandIndex, eColorSpace, nBands, poCT, poSrcDS,
+                papszOptions);
+        }
+
+        if (!localctx.initCodec(pszFilename, fpOwner))
+        {
+            CPLError(CE_Failure, CPLE_AppDefined,
+                     "codec initialization failed");
+            localctx.free();
+            delete poGMLJP2Box;
+            return nullptr;
+        }
+        if (!fpOwner)
+            fp = nullptr;
+
         const int nTilesX = DIV_ROUND_UP(nXSize, nBlockXSize);
         const int nTilesY = DIV_ROUND_UP(nYSize, nBlockYSize);
 
@@ -3387,7 +3422,6 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
         if (pTempBuffer == nullptr)
         {
             localctx.free();
-            VSIFCloseL(fp);
             delete poGMLJP2Box;
             return nullptr;
         }
@@ -3402,7 +3436,6 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
             {
                 localctx.free();
                 CPLFree(pTempBuffer);
-                VSIFCloseL(fp);
                 delete poGMLJP2Box;
                 return nullptr;
             }
@@ -3632,7 +3665,6 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
         if (eErr != CE_None)
         {
             localctx.free();
-            VSIFCloseL(fp);
             delete poGMLJP2Box;
             return nullptr;
         }
@@ -3640,7 +3672,6 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
         if (!localctx.finishCompress())
         {
             localctx.free();
-            VSIFCloseL(fp);
             delete poGMLJP2Box;
             return nullptr;
         }
@@ -3652,6 +3683,7 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
     /* -------------------------------------------------------------------- */
     bool bRet = true;
     if (eCodecFormat == CODEC::cvtenum(JP2_CODEC_JP2) &&
+        !BASE::canPerformDirectIO() &&
         !CPLFetchBool(papszOptions, "JP2C_LENGTH_ZERO",
                       false) /* debug option */)
     {
@@ -3733,8 +3765,11 @@ GDALDataset *JP2OPJLikeDataset<CODEC, BASE>::CreateCopy(
         }
     }
 
-    if (VSIFCloseL(fp) != 0)
-        bRet = false;
+    if (fpOwner)
+    {
+        if (VSIFCloseL(fpOwner.release()) != 0)
+            bRet = false;
+    }
     delete poGMLJP2Box;
     if (!bRet)
         return nullptr;

--- a/swig/python/gdal-utils/osgeo_utils/samples/validate_jp2.py
+++ b/swig/python/gdal-utils/osgeo_utils/samples/validate_jp2.py
@@ -599,6 +599,14 @@ def validate(
             if expected_ftyp_branding is None:
                 if gmljp2_found and "gmljp2:GMLJP2CoverageCollection" in gmljp2:
                     expected_ftyp_branding = "jpx "
+                elif gmljp2_found:
+                    # GMLJP2 v1 uses asoc/lbl boxes from JPEG2000 Part II;
+                    # "jpx " branding is valid per section 8.1 of 05-047r3
+                    actual_br = get_field_val(ftyp, "BR")
+                    if actual_br in ("jp2 ", "jpx "):
+                        expected_ftyp_branding = actual_br
+                    else:
+                        expected_ftyp_branding = "jp2 "
                 else:
                     expected_ftyp_branding = "jp2 "
 


### PR DESCRIPTION
## What does this PR do?

The current JP2Grok driver handles read, write and rewrite of JP2 boxes. This PR allows Grok to handle read
and write (not re-write), as it is more efficient to let the codec itself manage the boxes.

No new unit tests have been added as the existing ones will test these changes.

## AI tool usage

 - [x] AI (Copilot or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.

## Tasklist

 - [x] Make sure code is correctly formatted (cf [pre-commit configuration](https://gdal.org/development/dev_practices.html#commit-hooks))
 - [ ] Add test case(s)
 - [ ] Add documentation
 - [ ] Updated Python API documentation (swig/include/python/docs/)
 - [ ] Review
 - [ ] Adjust for comments
 - [ ] All CI builds and checks have passed