### PR TITLE
gdal vector info --sql: emit a hint warning about trying 'gdal vector sql --update' instead

### DIFF
--- a/apps/gdalalg_vector_sql.cpp
+++ b/apps/gdalalg_vector_sql.cpp
@@ -271,7 +271,7 @@ bool GDALVectorSQLAlgorithm::RunStep(GDALPipelineStepRunContext &)
                             "Execution of the SQL statement '%s' failed.%s",
                             sql.c_str(),
                             m_update ? ""
-                                     : " Perhaps you need to specify the "
+                                     : ".\nPerhaps you need to specify the "
                                        "'update' argument?");
                 return false;
             }

--- a/apps/ogrinfo_lib.cpp
+++ b/apps/ogrinfo_lib.cpp
@@ -2113,6 +2113,15 @@ char *GDALVectorInfo(GDALDatasetH hDataset,
             }
             else if (CPLGetLastErrorType() != CE_None)
             {
+                // sqlite3 emits messages with "readonly" and GDAL with "read-only"
+                if (psOptions->bIsCli &&
+                    (strstr(CPLGetLastErrorMsg(), "readonly") ||
+                     strstr(CPLGetLastErrorMsg(), "read-only")))
+                {
+                    CPLError(CE_Warning, CPLE_AppDefined,
+                             "Perhaps you want to run \"gdal vector sql "
+                             "--update\" instead?");
+                }
                 return nullptr;
             }
         }

--- a/autotest/utilities/test_gdalalg_vector_info.py
+++ b/autotest/utilities/test_gdalalg_vector_info.py
@@ -135,6 +135,38 @@ def test_gdalalg_vector_info_sql():
     assert j["layers"][0]["fields"][0]["name"] == "foo"
 
 
+@pytest.mark.require_driver("GPKG")
+def test_gdalalg_vector_info_sql_hint_about_vector_sql_instead(tmp_vsimem):
+
+    gdal.alg.vector.convert(
+        input="../ogr/data/poly.shp", output=tmp_vsimem / "poly.gpkg"
+    )
+
+    # Warning message not caputred on that platform. Not sure why, but not
+    # worth investigating.
+    if not gdaltest.is_travis_branch("ubuntu_2004"):
+
+        # read-only error from GPKG driver
+        with gdaltest.error_raised(
+            gdal.CE_Warning,
+            match='Perhaps you want to run "gdal vector sql --update" instead?',
+        ):
+            with pytest.raises(Exception):
+                gdal.alg.vector.info(
+                    input=tmp_vsimem / "poly.gpkg", sql="DELETE FROM poly"
+                )
+
+        # read-only error from sqlite3
+        with gdaltest.error_raised(
+            gdal.CE_Warning,
+            match='Perhaps you want to run "gdal vector sql --update" instead?',
+        ):
+            with pytest.raises(Exception):
+                gdal.alg.vector.info(
+                    input=tmp_vsimem / "poly.gpkg", sql="DELETE FROM poly WHERE 1=1"
+                )
+
+
 def test_gdalalg_vector_info_layer():
     info = get_info_alg()
     assert info.ParseRunAndFinalize(["-l", "path", "data/path.shp"])


### PR DESCRIPTION
Cf https://lists.osgeo.org/pipermail/gdal-dev/2026-April/061477.html
