### PR TITLE
gdal raster info: emit short form for CRS if possible

### DIFF
--- a/.github/workflows/ubuntu_26.04/reference_arg_names.txt
+++ b/.github/workflows/ubuntu_26.04/reference_arg_names.txt
@@ -55,6 +55,7 @@ copyright
 country-code
 creation-option
 crs
+crs-format
 curvature-coefficient
 curve
 dataset

--- a/apps/gdalalg_raster_info.cpp
+++ b/apps/gdalalg_raster_info.cpp
@@ -91,9 +91,27 @@ GDALRasterInfoAlgorithm::GDALRasterInfoAlgorithm(bool standaloneStep,
            &m_subDS)
         .SetCategory(GAAC_ESOTERIC)
         .SetMinValueIncluded(1);
+    AddArg("crs-format", 0, _("Which format to use to report CRS"),
+           &m_crsFormat)
+        .SetChoices("AUTO", "WKT2", "PROJJSON")
+        .SetDefault(m_crsFormat)
+        .SetCategory(GAAC_ESOTERIC);
 
     AddOutputStringArg(&m_output);
     AddStdoutArg(&m_stdout);
+
+    AddValidationAction(
+        [this]()
+        {
+            if (m_crsFormat != "AUTO" && m_format == "json")
+            {
+                ReportError(CE_Failure, CPLE_AppDefined,
+                            "'crs-format' cannot be set when 'format' is set "
+                            "to 'json'");
+                return false;
+            }
+            return true;
+        });
 }
 
 /************************************************************************/
@@ -110,6 +128,8 @@ bool GDALRasterInfoAlgorithm::RunStep(GDALPipelineStepRunContext &)
         m_format = IsCalledFromCommandLine() ? "text" : "json";
 
     CPLStringList aosOptions;
+    aosOptions.AddString("--invoked-from=gdal-raster-info");
+    aosOptions.AddString("--crs-format=" + m_crsFormat);
     if (m_format == "json")
         aosOptions.AddString("-json");
     if (m_minMax)

--- a/apps/gdalalg_raster_info.h
+++ b/apps/gdalalg_raster_info.h
@@ -55,6 +55,7 @@ class GDALRasterInfoAlgorithm /* non final */
     bool m_listMDD = false;
     std::string m_mdd{};
     int m_subDS = 0;
+    std::string m_crsFormat = "AUTO";
 };
 
 /************************************************************************/

--- a/apps/gdalinfo_lib.cpp
+++ b/apps/gdalinfo_lib.cpp
@@ -126,6 +126,12 @@ struct GDALInfoOptions
     std::string osWKTFormat = "WKT2";
 
     bool bStdoutOutput = false;
+
+    /*! May be set to "gdal-raster-info" */
+    std::string osInvokedFrom{};
+
+    /*! Only used when osInvokedFrom is set to "gdal-raster-info" */
+    std::string osCRSFormat{"AUTO"};
 };
 
 static int GDALInfoReportCorner(const GDALInfoOptions *psOptions,
@@ -222,6 +228,17 @@ GDALInfoAppOptionsGetParser(GDALInfoOptions *psOptions,
 
     argParser->add_epilog(
         _("For more details, consult https://gdal.org/programs/gdalinfo.html"));
+
+    // Hidden: only for gdal raster info
+    argParser->add_argument("--invoked-from")
+        .store_into(psOptions->osInvokedFrom)
+        .hidden();
+
+    // Hidden: only for gdal raster info
+    argParser->add_argument("--crs-format")
+        .choices("AUTO", "WKT2", "PROJJSON")
+        .store_into(psOptions->osCRSFormat)
+        .hidden();
 
     argParser->add_argument("-json")
         .flag()
@@ -553,23 +570,25 @@ char *GDALInfo(GDALDatasetH hDataset, const GDALInfoOptions *psOptions)
     auto hSRS = GDALGetSpatialRef(hDataset);
     if (hSRS != nullptr)
     {
+        const OGRSpatialReference *poSRS =
+            OGRSpatialReference::FromHandle(hSRS);
+
         json_object *poCoordinateSystem = nullptr;
 
         if (bJson)
             poCoordinateSystem = json_object_new_object();
 
-        char *pszPrettyWkt = nullptr;
+        const std::string osWkt = poSRS->exportToWkt(apszWKTOptions);
 
-        OSRExportToWktEx(hSRS, &pszPrettyWkt, apszWKTOptions);
+        const std::vector<int> anAxes = poSRS->GetDataAxisToSRSAxisMapping();
 
-        int nAxesCount = 0;
-        const int *panAxes = OSRGetDataAxisToSRSAxisMapping(hSRS, &nAxesCount);
+        const double dfCoordinateEpoch = poSRS->GetCoordinateEpoch();
 
-        const double dfCoordinateEpoch = OSRGetCoordinateEpoch(hSRS);
-
+        const char *pszAuthCode = poSRS->GetAuthorityCode(nullptr);
+        const char *pszAuthName = poSRS->GetAuthorityName(nullptr);
         if (bJson)
         {
-            json_object *poWkt = json_object_new_string(pszPrettyWkt);
+            json_object *poWkt = json_object_new_string(osWkt.c_str());
             if (psOptions->osWKTFormat == "WKT2")
             {
                 json_object *poStacWkt = nullptr;
@@ -578,8 +597,6 @@ char *GDALInfo(GDALDatasetH hDataset, const GDALInfoOptions *psOptions)
             }
             json_object_object_add(poCoordinateSystem, "wkt", poWkt);
 
-            const char *pszAuthCode = OSRGetAuthorityCode(hSRS, nullptr);
-            const char *pszAuthName = OSRGetAuthorityName(hSRS, nullptr);
             if (pszAuthCode && pszAuthName && EQUAL(pszAuthName, "EPSG"))
             {
                 json_object *poEPSG = json_object_new_int64(atoi(pszAuthCode));
@@ -593,12 +610,8 @@ char *GDALInfo(GDALDatasetH hDataset, const GDALInfoOptions *psOptions)
                 json_object_object_add(poStac, "proj:epsg", nullptr);
             }
             {
-                // PROJJSON requires PROJ >= 6.2
-                CPLErrorStateBackuper oCPLErrorHandlerPusher(
-                    CPLQuietErrorHandler);
                 char *pszProjJson = nullptr;
-                OGRErr result =
-                    OSRExportToPROJJSON(hSRS, &pszProjJson, nullptr);
+                OGRErr result = poSRS->exportToPROJJSON(&pszProjJson, nullptr);
                 if (result == OGRERR_NONE)
                 {
                     json_object *poStacProjJson =
@@ -610,10 +623,10 @@ char *GDALInfo(GDALDatasetH hDataset, const GDALInfoOptions *psOptions)
             }
 
             json_object *poAxisMapping = json_object_new_array();
-            for (int i = 0; i < nAxesCount; i++)
+            for (int nMapping : anAxes)
             {
                 json_object_array_add(poAxisMapping,
-                                      json_object_new_int(panAxes[i]));
+                                      json_object_new_int(nMapping));
             }
             json_object_object_add(poCoordinateSystem,
                                    "dataAxisToSRSAxisMapping", poAxisMapping);
@@ -627,18 +640,196 @@ char *GDALInfo(GDALDatasetH hDataset, const GDALInfoOptions *psOptions)
         }
         else
         {
-            Concat(osStr, psOptions->bStdoutOutput,
-                   "Coordinate System is:\n%s\n", pszPrettyWkt);
+            bool bCRSAlreadyEmitted = false;
+            if (psOptions->osInvokedFrom == "gdal-raster-info")
+            {
+                if (pszAuthName && pszAuthCode &&
+                    psOptions->osCRSFormat == "AUTO")
+                {
+                    OGRSpatialReference oSRSFromAuthCode;
+                    CPLErrorStateBackuper oBackuper(CPLQuietErrorHandler);
+                    const char *const apszComparisonCriteria[] = {
+                        "IGNORE_DATA_AXIS_TO_SRS_AXIS_MAPPING=YES",
+                        "CRITERION=EQUIVALENT_EXCEPT_AXIS_ORDER_GEOGCRS",
+                        "IGNORE_COORDINATE_EPOCH=YES", nullptr};
+                    if (oSRSFromAuthCode.SetFromUserInput(
+                            std::string(pszAuthName)
+                                .append(":")
+                                .append(pszAuthCode)
+                                .c_str()) == OGRERR_NONE &&
+                        oSRSFromAuthCode.IsSame(poSRS, apszComparisonCriteria))
+                    {
+                        std::string osCRSId;
+                        if (STARTS_WITH_CI(pszAuthName, "IAU_"))
+                        {
+                            osCRSId = "urn:ogc:def:crs:IAU:";
+                            osCRSId += pszAuthName + strlen("IAU_");
+                            osCRSId += ':';
+                            osCRSId += pszAuthCode;
+                        }
+                        else if (strchr(pszAuthName, '_') == nullptr)
+                        {
+                            osCRSId = pszAuthName;
+                            osCRSId += ':';
+                            osCRSId += pszAuthCode;
+                        }
+
+                        if (!osCRSId.empty())
+                        {
+                            bCRSAlreadyEmitted = true;
+                            Concat(osStr, psOptions->bStdoutOutput,
+                                   "Coordinate Reference System name: %s\n",
+                                   poSRS->GetName());
+
+                            Concat(osStr, psOptions->bStdoutOutput,
+                                   "Coordinate Reference System ID: %s\n",
+                                   osCRSId.c_str());
+
+                            const char *pszHorizType =
+                                poSRS->IsGeographic()
+                                    ? (poSRS->IsCompound() ? "Geographic"
+                                       : poSRS->GetAxesCount() == 3
+                                           ? "Geographic 3D"
+                                           : "Geographic 2D")
+                                : poSRS->IsProjected() ? "Projected"
+                                                       : "Other";
+                            Concat(osStr, psOptions->bStdoutOutput,
+                                   "Coordinate Reference System type: %s\n",
+                                   poSRS->IsCompound()
+                                       ? std::string("Compound of ")
+                                             .append(pszHorizType)
+                                             .c_str()
+                                       : pszHorizType);
+                            if (poSRS->IsProjected())
+                            {
+                                // Create a copy since we want to force the internal
+                                // WKT tree model to be WKT2 as we are going to
+                                // request CONVERSION
+                                OGRSpatialReference oSRS(*poSRS);
+                                const char *pszConversion =
+                                    oSRS.GetAttrValue("CONVERSION");
+                                const std::string osConversion =
+                                    pszConversion ? pszConversion : "";
+                                const char *pszMethod =
+                                    oSRS.GetAttrValue("CONVERSION|METHOD");
+                                const std::string osMethod =
+                                    pszMethod ? pszMethod : "";
+                                if (!osConversion.empty() && !osMethod.empty())
+                                {
+                                    if (osConversion == osMethod)
+                                    {
+                                        Concat(osStr, psOptions->bStdoutOutput,
+                                               "Coordinate Reference System "
+                                               "projection type: %s\n",
+                                               osConversion.c_str());
+                                    }
+                                    else
+                                    {
+                                        Concat(osStr, psOptions->bStdoutOutput,
+                                               "Coordinate Reference System "
+                                               "projection type: %s, %s\n",
+                                               osConversion.c_str(),
+                                               osMethod.c_str());
+                                    }
+                                }
+                                const char *pszLinearUnits = nullptr;
+                                poSRS->GetLinearUnits(&pszLinearUnits);
+                                if (pszLinearUnits)
+                                {
+                                    Concat(osStr, psOptions->bStdoutOutput,
+                                           "Coordinate Reference System units: "
+                                           "%s\n",
+                                           pszLinearUnits);
+                                }
+                            }
+                            double dfWest = 0;
+                            double dfSouth = 0;
+                            double dfEast = 0;
+                            double dfNorth = 0;
+                            const char *pszAreaName = nullptr;
+                            if (poSRS->GetAreaOfUse(&dfWest, &dfSouth, &dfEast,
+                                                    &dfNorth, &pszAreaName))
+                            {
+                                if (pszAreaName && pszAreaName[0])
+                                {
+                                    std::string osAreaOfUse(pszAreaName);
+                                    if (osAreaOfUse.back() == '.')
+                                        osAreaOfUse.pop_back();
+                                    if (osAreaOfUse.size() > 40)
+                                    {
+                                        auto nPos = osAreaOfUse.find(" - ");
+                                        if (nPos == std::string::npos)
+                                            nPos = osAreaOfUse.find(", ");
+                                        if (nPos == std::string::npos)
+                                            nPos = osAreaOfUse.find(' ');
+                                        if (nPos == std::string::npos)
+                                            nPos = 40;
+                                        osAreaOfUse.resize(nPos);
+                                        osAreaOfUse += "...";
+                                    }
+                                    Concat(osStr, psOptions->bStdoutOutput,
+                                           "Coordinate Reference System area "
+                                           "of use: %s, west %.2f, south %.2f, "
+                                           "east %.2f, north %.2f\n",
+                                           osAreaOfUse.c_str(), dfWest, dfSouth,
+                                           dfEast, dfNorth);
+                                }
+                                else
+                                {
+                                    Concat(osStr, psOptions->bStdoutOutput,
+                                           "Coordinate Reference System area "
+                                           "of use: west %.2f, south %.2f, "
+                                           "east %.2f, north %.2f\n",
+                                           dfWest, dfSouth, dfEast, dfNorth);
+                                }
+                            }
+                        }
+                    }
+                }
+                if (!bCRSAlreadyEmitted)
+                {
+                    if (psOptions->osCRSFormat == "PROJJSON")
+                    {
+                        char *pszProjJson = nullptr;
+                        OSRExportToPROJJSON(hSRS, &pszProjJson, nullptr);
+                        if (pszProjJson)
+                        {
+                            Concat(
+                                osStr, psOptions->bStdoutOutput,
+                                "Coordinate Reference System PROJJSON:\n%s\n",
+                                pszProjJson);
+                        }
+                        else
+                        {
+                            Concat(osStr, psOptions->bStdoutOutput,
+                                   "Coordinate Reference System PROJJSON: "
+                                   "ERROR while exporting it to PROJJSON!\n");
+                        }
+                        CPLFree(pszProjJson);
+                    }
+                    else
+                    {
+                        Concat(osStr, psOptions->bStdoutOutput,
+                               "Coordinate Reference System WKT:\n%s\n",
+                               osWkt.c_str());
+                    }
+                }
+            }
+            else
+            {
+                Concat(osStr, psOptions->bStdoutOutput,
+                       "Coordinate System is:\n%s\n", osWkt.c_str());
+            }
 
             Concat(osStr, psOptions->bStdoutOutput,
                    "Data axis to CRS axis mapping: ");
-            for (int i = 0; i < nAxesCount; i++)
+            for (size_t i = 0; i < anAxes.size(); i++)
             {
                 if (i > 0)
                 {
                     Concat(osStr, psOptions->bStdoutOutput, ",");
                 }
-                Concat(osStr, psOptions->bStdoutOutput, "%d", panAxes[i]);
+                Concat(osStr, psOptions->bStdoutOutput, "%d", anAxes[i]);
             }
             Concat(osStr, psOptions->bStdoutOutput, "\n");
 
@@ -657,7 +848,6 @@ char *GDALInfo(GDALDatasetH hDataset, const GDALInfoOptions *psOptions)
                        "Coordinate epoch: %s\n", osCoordinateEpoch.c_str());
             }
         }
-        CPLFree(pszPrettyWkt);
 
         if (psOptions->bReportProj4)
         {

--- a/autotest/utilities/test_gdalalg_raster_info.py
+++ b/autotest/utilities/test_gdalalg_raster_info.py
@@ -15,7 +15,7 @@ import json
 
 import pytest
 
-from osgeo import gdal
+from osgeo import gdal, osr
 
 
 def get_info_alg():
@@ -185,3 +185,114 @@ def test_gdalalg_raster_info_pipeline():
     ) as alg:
         j = alg.Output()
         assert len(j["bands"]) == 3
+
+
+@pytest.mark.require_proj(8, 2)  # For IAU testing
+def test_gdalalg_raster_info_crs():
+
+    with gdal.alg.raster.info(
+        input="../gcore/data/byte.tif", output_format="text"
+    ) as alg:
+        output_string = alg.Output()
+        assert (
+            "Coordinate Reference System name: NAD27 / UTM zone 11N\n" in output_string
+        )
+        assert "Coordinate Reference System ID: EPSG:26711\n" in output_string
+        assert "Coordinate Reference System type: Projected\n" in output_string
+        assert (
+            "Coordinate Reference System projection type: UTM zone 11N, Transverse Mercator\n"
+            in output_string
+        )
+        assert "Coordinate Reference System units: metre\n" in output_string
+        assert (
+            "Coordinate Reference System area of use: North America..., west -120.00, south 26.93, east -114.00, north 78.13\n"
+            in output_string
+        )
+
+    with gdal.alg.raster.info(input="data/utmsmall.tif", output_format="text") as alg:
+        output_string = alg.Output()
+        assert (
+            "Coordinate Reference System name: NAD27 / UTM zone 11N\n" in output_string
+        )
+        assert "Coordinate Reference System ID: EPSG:26711\n" in output_string
+        assert "Coordinate Reference System type: Projected\n" in output_string
+        assert (
+            "Coordinate Reference System projection type: Transverse Mercator\n"
+            in output_string
+        )
+        assert "Coordinate Reference System units: metre\n" in output_string
+        assert "Coordinate Reference System area of use" not in output_string
+
+    with gdal.alg.raster.info(
+        input="../gdrivers/data/small_world.tif", output_format="text"
+    ) as alg:
+        output_string = alg.Output()
+        assert "Coordinate Reference System name: WGS 84\n" in output_string
+        assert "Coordinate Reference System ID: EPSG:4326\n" in output_string
+        assert "Coordinate Reference System type: Geographic 2D\n" in output_string
+        assert "Coordinate Reference System projection type" not in output_string
+        assert "Coordinate Reference System units" not in output_string
+        assert (
+            "Coordinate Reference System area of use: World, west -180.00, south -90.00, east 180.00, north 90.00\n"
+            in output_string
+        )
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    srs = osr.SpatialReference()
+    srs.SetFromUserInput("EPSG:9518")
+    src_ds.SetSpatialRef(srs)
+    with gdal.alg.raster.info(input=src_ds, output_format="text") as alg:
+        output_string = alg.Output()
+        assert (
+            "Coordinate Reference System name: WGS 84 + EGM2008 height\n"
+            in output_string
+        )
+        assert "Coordinate Reference System ID: EPSG:9518\n" in output_string
+        assert (
+            "Coordinate Reference System type: Compound of Geographic\n"
+            in output_string
+        )
+        assert "Coordinate Reference System projection type" not in output_string
+        assert "Coordinate Reference System units" not in output_string
+        assert (
+            "Coordinate Reference System area of use: World, west -180.00, south -90.00, east 180.00, north 90.00\n"
+            in output_string
+        )
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    srs = osr.SpatialReference()
+    srs.ImportFromProj4("+proj=longlat +ellps=GRS80")
+    src_ds.SetSpatialRef(srs)
+    with gdal.alg.raster.info(input=src_ds, output_format="text") as alg:
+        output_string = alg.Output()
+        assert 'Coordinate Reference System WKT:\nGEOGCRS["unknown",' in output_string
+
+    src_ds = gdal.GetDriverByName("MEM").Create("", 1, 1)
+    srs = osr.SpatialReference()
+    srs.SetFromUserInput("IAU_2015:30100")
+    src_ds.SetSpatialRef(srs)
+    with gdal.alg.raster.info(input=src_ds, output_format="text") as alg:
+        output_string = alg.Output()
+        assert (
+            "Coordinate Reference System name: Moon (2015) - Sphere / Ocentric\n"
+            in output_string
+        )
+        assert (
+            "Coordinate Reference System ID: urn:ogc:def:crs:IAU:2015:30100\n"
+            in output_string
+        )
+
+    with gdal.alg.raster.info(
+        input="data/utmsmall.tif", output_format="text", crs_format="WKT2"
+    ) as alg:
+        output_string = alg.Output()
+        assert (
+            'Coordinate Reference System WKT:\nPROJCRS["NAD27 / UTM zone 11N"'
+            in output_string
+        )
+
+    with gdal.alg.raster.info(
+        input="data/utmsmall.tif", output_format="text", crs_format="PROJJSON"
+    ) as alg:
+        output_string = alg.Output()
+        assert 'Coordinate Reference System PROJJSON:\n{\n  "$schema":' in output_string

--- a/doc/source/programs/gdal_raster_info.rst
+++ b/doc/source/programs/gdal_raster_info.rst
@@ -27,7 +27,7 @@ The following items will be reported (when known):
 
 -  The format driver used to access the file.
 -  Raster size (in pixels and lines).
--  The coordinate system for the file (in OGC WKT).
+-  The coordinate system for the file (in short form AUTH_NAME:CODE when possible, or otherwise OGC WKT2:2019).
 -  The geotransform associated with the file (rotational coefficients
    are currently not reported).
 -  Corner coordinates in georeferenced, and if possible lat/long based
@@ -68,6 +68,20 @@ Program-Specific Options
 
     Which output format to use. Default is JSON, and starting with GDAL 3.12,
     text when invoked from command line.
+
+.. option:: --crs-format AUTO|WKT2|PROJJSON
+
+    .. versionadded:: 3.13
+
+    Which format to use to report the CRS. In AUTO default mode, if the CRS
+    can be captured with an authority name and code (known of PROJ), only
+    a summary of the CRS, including its name, ID, type and area of use will be
+    reported. Otherwise a full WKT2:2019 definition will be reported.
+
+    .. note::
+
+        :option:`--crs-format` can only be set when :option:`--output-format`
+        is set to ``text``.  The JSON text format includes both WKT2 and PROJJSON.
 
 .. option:: --hist
 

--- a/ogr/ogrspatialreference.cpp
+++ b/ogr/ogrspatialreference.cpp
@@ -141,7 +141,7 @@ struct OGRSpatialReference::Private
     void setRoot(OGR_SRSNode *poRoot);
     void refreshProjObj();
     void nodesChanged();
-    void refreshRootFromProjObj();
+    void refreshRootFromProjObj(bool bForceWKT2);
     void invalidateNodes();
 
     void setMorphToESRI(bool b);
@@ -392,7 +392,7 @@ void OGRSpatialReference::Private::refreshProjObj()
     }
 }
 
-void OGRSpatialReference::Private::refreshRootFromProjObj()
+void OGRSpatialReference::Private::refreshRootFromProjObj(bool bForceWKT2)
 {
     CPLAssert(m_poRoot == nullptr);
 
@@ -406,7 +406,8 @@ void OGRSpatialReference::Private::refreshRootFromProjObj()
         }
         aosOptions.SetNameValue("STRICT", "NO");
 
-        const char *pszWKT;
+        const char *pszWKT = nullptr;
+        if (!bForceWKT2)
         {
             CPLErrorStateBackuper oErrorStateBackuper(CPLQuietErrorHandler);
             pszWKT = proj_as_wkt(getPROJContext(), m_pj_crs,
@@ -1181,7 +1182,7 @@ OGR_SRSNode *OGRSpatialReference::GetRoot()
 
     if (!d->m_poRoot)
     {
-        d->refreshRootFromProjObj();
+        d->refreshRootFromProjObj(false);
     }
     return d->m_poRoot;
 }
@@ -1192,7 +1193,7 @@ const OGR_SRSNode *OGRSpatialReference::GetRoot() const
 
     if (!d->m_poRoot)
     {
-        d->refreshRootFromProjObj();
+        d->refreshRootFromProjObj(false);
     }
     return d->m_poRoot;
 }
@@ -1246,6 +1247,12 @@ void OGRSpatialReference::SetRoot(OGR_SRSNode *poNewRoot)
 OGR_SRSNode *OGRSpatialReference::GetAttrNode(const char *pszNodePath)
 
 {
+    if (strstr(pszNodePath, "CONVERSION") && !d->m_bNodesWKT2)
+    {
+        d->invalidateNodes();
+        d->refreshRootFromProjObj(/* bForceWKT2 = */ true);
+    }
+
     if (strchr(pszNodePath, '|') == nullptr)
     {
         // Fast path


### PR DESCRIPTION
and add a --crs-format=AUTO|WKT2|PROJJSON, only for --format=text

Triggered by remark in https://github.com/OSGeo/gdal/pull/14285 . @geographika @dbaston @jratike80 Good / bad idea ?

Demo:
```
$ gdal raster info byte.tif
Driver: GTiff/GeoTIFF
Files: byte.tif
Size is 20, 20
Coordinate Reference System name: NAD27 / UTM zone 11N
Coordinate Reference System ID: EPSG:26711
Coordinate Reference System type: Projected
Coordinate Reference System projection type: UTM zone 11N, Transverse Mercator
Coordinate Reference System units: metre
Coordinate Reference System area of use: North America..., west -120.00, south 26.93, east -114.00, north 78.13
Data axis to CRS axis mapping: 1,2
Origin = (440720.000000000000000,3751320.000000000000000)
Pixel Size = (60.000000000000000,-60.000000000000000)
Metadata:
  AREA_OR_POINT=Area
Image Structure Metadata:
  INTERLEAVE=BAND
Corner Coordinates:
Upper Left  (  440720.000, 3751320.000) (117d38'28.21"W, 33d54' 8.47"N)
Lower Left  (  440720.000, 3750120.000) (117d38'27.92"W, 33d53'29.51"N)
Upper Right (  441920.000, 3751320.000) (117d37'41.48"W, 33d54' 8.71"N)
Lower Right (  441920.000, 3750120.000) (117d37'41.20"W, 33d53'29.75"N)
Center      (  441320.000, 3750720.000) (117d38' 4.70"W, 33d53'49.11"N)
Band 1 Block=20x20 Type=Byte, ColorInterp=Gray
```

```
$ gdal raster info byte.tif --crs-format=WKT2
Driver: GTiff/GeoTIFF
Files: byte.tif
Size is 20, 20
Coordinate Reference System WKT:
PROJCRS["NAD27 / UTM zone 11N",
    BASEGEOGCRS["NAD27",
        DATUM["North American Datum 1927",
            ELLIPSOID["Clarke 1866",6378206.4,294.978698213898,
                LENGTHUNIT["metre",1]]],
        PRIMEM["Greenwich",0,
            ANGLEUNIT["degree",0.0174532925199433]],
        ID["EPSG",4267]],
    CONVERSION["UTM zone 11N",
        METHOD["Transverse Mercator",
            ID["EPSG",9807]],
        PARAMETER["Latitude of natural origin",0,
            ANGLEUNIT["degree",0.0174532925199433],
            ID["EPSG",8801]],
        PARAMETER["Longitude of natural origin",-117,
            ANGLEUNIT["degree",0.0174532925199433],
            ID["EPSG",8802]],
        PARAMETER["Scale factor at natural origin",0.9996,
            SCALEUNIT["unity",1],
            ID["EPSG",8805]],
        PARAMETER["False easting",500000,
            LENGTHUNIT["metre",1],
            ID["EPSG",8806]],
        PARAMETER["False northing",0,
            LENGTHUNIT["metre",1],
            ID["EPSG",8807]]],
    CS[Cartesian,2],
        AXIS["(E)",east,
            ORDER[1],
            LENGTHUNIT["metre",1]],
        AXIS["(N)",north,
            ORDER[2],
            LENGTHUNIT["metre",1]],
    USAGE[
        SCOPE["Engineering survey, topographic mapping."],
        AREA["North America - between 120°W and 114°W - onshore. Canada - Alberta; British Columbia; Northwest Territories; Nunavut. Mexico. United States (USA) - California; Idaho; Nevada; Oregon; Washington."],
        BBOX[26.93,-120,78.13,-114]],
    ID["EPSG",26711]]
Data axis to CRS axis mapping: 1,2
Origin = (440720.000000000000000,3751320.000000000000000)
Pixel Size = (60.000000000000000,-60.000000000000000)
Metadata:
  AREA_OR_POINT=Area
Image Structure Metadata:
  INTERLEAVE=BAND
Corner Coordinates:
Upper Left  (  440720.000, 3751320.000) (117d38'28.21"W, 33d54' 8.47"N)
Lower Left  (  440720.000, 3750120.000) (117d38'27.92"W, 33d53'29.51"N)
Upper Right (  441920.000, 3751320.000) (117d37'41.48"W, 33d54' 8.71"N)
Lower Right (  441920.000, 3750120.000) (117d37'41.20"W, 33d53'29.75"N)
Center      (  441320.000, 3750720.000) (117d38' 4.70"W, 33d53'49.11"N)
Band 1 Block=20x20 Type=Byte, ColorInterp=Gray
```

 - <s>[ ] AI (Copilot or something similar) supported my development of this PR. See our [policy about AI tool use](https://gdal.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.</s>
